### PR TITLE
When a trait isn't implemented, but another similar impl is found, point at it

### DIFF
--- a/compiler/rustc_errors/src/emitter.rs
+++ b/compiler/rustc_errors/src/emitter.rs
@@ -1523,16 +1523,17 @@ impl HumanEmitter {
                 label_width += 2;
             }
             let mut line = 0;
+            let mut pad = false;
             for (text, style) in msgs.iter() {
                 let text =
                     self.translator.translate_message(text, args).map_err(Report::new).unwrap();
                 // Account for newlines to align output to its label.
-                for text in normalize_whitespace(&text).lines() {
+                for text in normalize_whitespace(&text).split('\n') {
                     buffer.append(
                         line,
                         &format!(
                             "{}{}",
-                            if line == 0 { String::new() } else { " ".repeat(label_width) },
+                            if pad { " ".repeat(label_width) } else { String::new() },
                             text
                         ),
                         match style {
@@ -1541,7 +1542,9 @@ impl HumanEmitter {
                         },
                     );
                     line += 1;
+                    pad = true;
                 }
+                pad = false;
                 // We add lines above, but if the last line has no explicit newline (which would
                 // yield an empty line), then we revert one line up to continue with the next
                 // styled text chunk on the same line as the last one from the prior one. Otherwise

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -2191,7 +2191,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                         msg.extend(types.1.0);
                         msg.push(StringPart::normal("`"));
                     }
-                    err.highlighted_help(msg);
+                    err.highlighted_span_help(self.tcx.def_span(single.impl_def_id), msg);
 
                     if let [TypeError::Sorts(exp_found)] = &terrs[..] {
                         let exp_found = self.resolve_vars_if_possible(*exp_found);

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -1,3 +1,4 @@
+// ignore-tidy-filelength
 use core::ops::ControlFlow;
 use std::borrow::Cow;
 use std::path::PathBuf;

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -1906,13 +1906,13 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 // ignore `do_not_recommend` items
                 .filter(|def_id| !self.tcx.do_not_recommend_impl(*def_id))
                 // Ignore automatically derived impls and `!Trait` impls.
-                .map(|def_id| self.tcx.impl_trait_header(def_id))
-                .filter_map(|header| {
+                .map(|def_id| (self.tcx.impl_trait_header(def_id), def_id))
+                .filter_map(|(header, def_id)| {
                     (header.polarity != ty::ImplPolarity::Negative
                         || self.tcx.is_automatically_derived(def_id))
-                    .then(|| header.trait_ref.instantiate_identity())
+                    .then(|| (header.trait_ref.instantiate_identity(), def_id))
                 })
-                .filter(|trait_ref| {
+                .filter(|(trait_ref, _)| {
                     let self_ty = trait_ref.self_ty();
                     // Avoid mentioning type parameters.
                     if let ty::Param(_) = self_ty.kind() {
@@ -1944,7 +1944,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 })
                 .collect();
 
-            impl_candidates.sort_by_key(|tr| tr.to_string());
+            impl_candidates.sort_by_key(|(tr, _)| tr.to_string());
             impl_candidates.dedup();
             impl_candidates
         };
@@ -1972,7 +1972,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             let candidates = if impl_candidates.is_empty() {
                 alternative_candidates(trait_def_id)
             } else {
-                impl_candidates.into_iter().map(|cand| cand.trait_ref).collect()
+                impl_candidates.into_iter().map(|cand| (cand.trait_ref, cand.impl_def_id)).collect()
             };
             let mut span: MultiSpan = self.tcx.def_span(trait_def_id).into();
             span.push_span_label(self.tcx.def_span(trait_def_id), "this is the required trait");
@@ -2004,7 +2004,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     self.tcx.def_span(found_type),
                     "this type doesn't implement the required trait",
                 );
-                for trait_ref in candidates {
+                for (trait_ref, _) in candidates {
                     if let ty::Adt(def, _) = trait_ref.self_ty().peel_refs().kind()
                         && let candidate_def_id = def.did()
                         && let Some(name) = self.tcx.opt_item_name(candidate_def_id)
@@ -2217,12 +2217,12 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         }
 
         let other = if other { "other " } else { "" };
-        let report = |mut candidates: Vec<TraitRef<'tcx>>, err: &mut Diag<'_>| {
-            candidates.retain(|tr| !tr.references_error());
+        let report = |mut candidates: Vec<(TraitRef<'tcx>, DefId)>, err: &mut Diag<'_>| {
+            candidates.retain(|(tr, _)| !tr.references_error());
             if candidates.is_empty() {
                 return false;
             }
-            if let &[cand] = &candidates[..] {
+            if let &[(cand, def_id)] = &candidates[..] {
                 if self.tcx.is_diagnostic_item(sym::FromResidual, cand.def_id)
                     && !self.tcx.features().enabled(sym::try_trait_v2)
                 {
@@ -2238,56 +2238,87 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     };
                 let trait_ = self.tcx.short_string(cand.print_trait_sugared(), err.long_ty_path());
                 let self_ty = self.tcx.short_string(cand.self_ty(), err.long_ty_path());
-                err.highlighted_help(vec![
-                    StringPart::normal(format!("the trait `{trait_}` ",)),
-                    StringPart::highlighted("is"),
-                    StringPart::normal(desc),
-                    StringPart::highlighted(self_ty),
-                    StringPart::normal("`"),
-                    StringPart::normal(mention_castable),
-                ]);
+                err.highlighted_span_help(
+                    self.tcx.def_span(def_id),
+                    vec![
+                        StringPart::normal(format!("the trait `{trait_}` ",)),
+                        StringPart::highlighted("is"),
+                        StringPart::normal(desc),
+                        StringPart::highlighted(self_ty),
+                        StringPart::normal("`"),
+                        StringPart::normal(mention_castable),
+                    ],
+                );
                 return true;
             }
-            let trait_ref = TraitRef::identity(self.tcx, candidates[0].def_id);
+            let trait_ref = TraitRef::identity(self.tcx, candidates[0].0.def_id);
             // Check if the trait is the same in all cases. If so, we'll only show the type.
             let mut traits: Vec<_> =
-                candidates.iter().map(|c| c.print_only_trait_path().to_string()).collect();
+                candidates.iter().map(|(c, _)| c.print_only_trait_path().to_string()).collect();
             traits.sort();
             traits.dedup();
             // FIXME: this could use a better heuristic, like just checking
             // that args[1..] is the same.
             let all_traits_equal = traits.len() == 1;
 
-            let candidates: Vec<String> = candidates
-                .into_iter()
-                .map(|c| {
-                    if all_traits_equal {
-                        format!("\n  {}", self.tcx.short_string(c.self_ty(), err.long_ty_path()))
-                    } else {
-                        format!(
-                            "\n  `{}` implements `{}`",
-                            self.tcx.short_string(c.self_ty(), err.long_ty_path()),
-                            self.tcx.short_string(c.print_only_trait_path(), err.long_ty_path()),
-                        )
-                    }
-                })
-                .collect();
-
             let end = if candidates.len() <= 9 || self.tcx.sess.opts.verbose {
                 candidates.len()
             } else {
                 8
             };
-            err.help(format!(
-                "the following {other}types implement trait `{}`:{}{}",
-                trait_ref.print_trait_sugared(),
-                candidates[..end].join(""),
-                if candidates.len() > 9 && !self.tcx.sess.opts.verbose {
-                    format!("\nand {} others", candidates.len() - 8)
-                } else {
-                    String::new()
+            if candidates.len() < 5 {
+                let spans: Vec<_> =
+                    candidates.iter().map(|(_, def_id)| self.tcx.def_span(def_id)).collect();
+                let mut span: MultiSpan = spans.into();
+                for (c, def_id) in &candidates {
+                    let msg = if all_traits_equal {
+                        format!("`{}`", self.tcx.short_string(c.self_ty(), err.long_ty_path()))
+                    } else {
+                        format!(
+                            "`{}` implements `{}`",
+                            self.tcx.short_string(c.self_ty(), err.long_ty_path()),
+                            self.tcx.short_string(c.print_only_trait_path(), err.long_ty_path()),
+                        )
+                    };
+                    span.push_span_label(self.tcx.def_span(def_id), msg);
                 }
-            ));
+                err.span_help(
+                    span,
+                    format!(
+                        "the following {other}types implement trait `{}`",
+                        trait_ref.print_trait_sugared(),
+                    ),
+                );
+            } else {
+                let candidate_names: Vec<String> = candidates
+                    .iter()
+                    .map(|(c, _)| {
+                        if all_traits_equal {
+                            format!(
+                                "\n  {}",
+                                self.tcx.short_string(c.self_ty(), err.long_ty_path())
+                            )
+                        } else {
+                            format!(
+                                "\n  `{}` implements `{}`",
+                                self.tcx.short_string(c.self_ty(), err.long_ty_path()),
+                                self.tcx
+                                    .short_string(c.print_only_trait_path(), err.long_ty_path()),
+                            )
+                        }
+                    })
+                    .collect();
+                err.help(format!(
+                    "the following {other}types implement trait `{}`:{}{}",
+                    trait_ref.print_trait_sugared(),
+                    candidate_names[..end].join(""),
+                    if candidates.len() > 9 && !self.tcx.sess.opts.verbose {
+                        format!("\nand {} others", candidates.len() - 8)
+                    } else {
+                        String::new()
+                    }
+                ));
+            }
             true
         };
 
@@ -2349,7 +2380,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             (cand.similarity, len, cand.trait_ref.to_string())
         });
         let mut impl_candidates: Vec<_> =
-            impl_candidates.into_iter().map(|cand| cand.trait_ref).collect();
+            impl_candidates.into_iter().map(|cand| (cand.trait_ref, cand.impl_def_id)).collect();
         impl_candidates.dedup();
 
         report(impl_candidates, err)

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -1908,7 +1908,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 // Ignore automatically derived impls and `!Trait` impls.
                 .map(|def_id| (self.tcx.impl_trait_header(def_id), def_id))
                 .filter_map(|(header, def_id)| {
-                    (header.polarity != ty::ImplPolarity::Negative
+                    (header.polarity == ty::ImplPolarity::Positive
                         || self.tcx.is_automatically_derived(def_id))
                     .then(|| (header.trait_ref.instantiate_identity(), def_id))
                 })

--- a/tests/ui-fulldeps/rustc-dev-remap.only-remap.stderr
+++ b/tests/ui-fulldeps/rustc-dev-remap.only-remap.stderr
@@ -9,9 +9,13 @@ help: the trait `VisitorResult` is not implemented for `NotAValidResultType`
    |
 LL | struct NotAValidResultType;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: the following other types implement trait `VisitorResult`:
-             ()
-             ControlFlow<T>
+help: the following other types implement trait `VisitorResult`
+  --> /rustc-dev/xyz/compiler/rustc_ast_ir/src/visit.rs:LL:COL
+   |
+   = note: `()`
+  ::: /rustc-dev/xyz/compiler/rustc_ast_ir/src/visit.rs:LL:COL
+   |
+   = note: `ControlFlow<T>`
 note: required by a bound in `rustc_ast::visit::Visitor::Result`
   --> /rustc-dev/xyz/compiler/rustc_ast/src/visit.rs:LL:COL
    = note: this error originates in the macro `common_visitor_and_walkers` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-fulldeps/rustc-dev-remap.remap-unremap.stderr
+++ b/tests/ui-fulldeps/rustc-dev-remap.remap-unremap.stderr
@@ -9,9 +9,14 @@ help: the trait `VisitorResult` is not implemented for `NotAValidResultType`
    |
 LL | struct NotAValidResultType;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: the following other types implement trait `VisitorResult`:
-             ()
-             ControlFlow<T>
+help: the following other types implement trait `VisitorResult`
+  --> $COMPILER_DIR_REAL/rustc_ast_ir/src/visit.rs:LL:COL
+   |
+LL | impl VisitorResult for () {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^ `()`
+...
+LL | impl<T> VisitorResult for ControlFlow<T> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `ControlFlow<T>`
 note: required by a bound in `rustc_ast::visit::Visitor::Result`
   --> $COMPILER_DIR_REAL/rustc_ast/src/visit.rs:LL:COL
    |

--- a/tests/ui/allocator/not-an-allocator.rs
+++ b/tests/ui/allocator/not-an-allocator.rs
@@ -1,3 +1,6 @@
+//@ revisions: u w
+//@[u] only-unix
+//@[w] only-windows
 #[global_allocator]
 static A: usize = 0;
 //~^ ERROR E0277

--- a/tests/ui/allocator/not-an-allocator.u.stderr
+++ b/tests/ui/allocator/not-an-allocator.u.stderr
@@ -1,0 +1,50 @@
+error[E0277]: the trait bound `usize: GlobalAlloc` is not satisfied
+  --> $DIR/not-an-allocator.rs:5:11
+   |
+LL | #[global_allocator]
+   | ------------------- in this attribute macro expansion
+LL | static A: usize = 0;
+   |           ^^^^^ the trait `GlobalAlloc` is not implemented for `usize`
+   |
+help: the trait `GlobalAlloc` is implemented for `System`
+  --> $SRC_DIR/std/src/sys/alloc/unix.rs:LL:COL
+
+error[E0277]: the trait bound `usize: GlobalAlloc` is not satisfied
+  --> $DIR/not-an-allocator.rs:5:11
+   |
+LL | #[global_allocator]
+   | ------------------- in this attribute macro expansion
+LL | static A: usize = 0;
+   |           ^^^^^ the trait `GlobalAlloc` is not implemented for `usize`
+   |
+help: the trait `GlobalAlloc` is implemented for `System`
+  --> $SRC_DIR/std/src/sys/alloc/unix.rs:LL:COL
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0277]: the trait bound `usize: GlobalAlloc` is not satisfied
+  --> $DIR/not-an-allocator.rs:5:11
+   |
+LL | #[global_allocator]
+   | ------------------- in this attribute macro expansion
+LL | static A: usize = 0;
+   |           ^^^^^ the trait `GlobalAlloc` is not implemented for `usize`
+   |
+help: the trait `GlobalAlloc` is implemented for `System`
+  --> $SRC_DIR/std/src/sys/alloc/unix.rs:LL:COL
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0277]: the trait bound `usize: GlobalAlloc` is not satisfied
+  --> $DIR/not-an-allocator.rs:5:11
+   |
+LL | #[global_allocator]
+   | ------------------- in this attribute macro expansion
+LL | static A: usize = 0;
+   |           ^^^^^ the trait `GlobalAlloc` is not implemented for `usize`
+   |
+help: the trait `GlobalAlloc` is implemented for `System`
+  --> $SRC_DIR/std/src/sys/alloc/unix.rs:LL:COL
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/allocator/not-an-allocator.w.stderr
+++ b/tests/ui/allocator/not-an-allocator.w.stderr
@@ -1,44 +1,48 @@
 error[E0277]: the trait bound `usize: GlobalAlloc` is not satisfied
-  --> $DIR/not-an-allocator.rs:2:11
+  --> $DIR/not-an-allocator.rs:5:11
    |
 LL | #[global_allocator]
    | ------------------- in this attribute macro expansion
 LL | static A: usize = 0;
    |           ^^^^^ the trait `GlobalAlloc` is not implemented for `usize`
    |
-   = help: the trait `GlobalAlloc` is implemented for `System`
+help: the trait `GlobalAlloc` is implemented for `System`
+  --> $SRC_DIR/std/src/sys/alloc/windows.rs:LL:COL
 
 error[E0277]: the trait bound `usize: GlobalAlloc` is not satisfied
-  --> $DIR/not-an-allocator.rs:2:11
+  --> $DIR/not-an-allocator.rs:5:11
    |
 LL | #[global_allocator]
    | ------------------- in this attribute macro expansion
 LL | static A: usize = 0;
    |           ^^^^^ the trait `GlobalAlloc` is not implemented for `usize`
    |
-   = help: the trait `GlobalAlloc` is implemented for `System`
+help: the trait `GlobalAlloc` is implemented for `System`
+  --> $SRC_DIR/std/src/sys/alloc/windows.rs:LL:COL
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0277]: the trait bound `usize: GlobalAlloc` is not satisfied
-  --> $DIR/not-an-allocator.rs:2:11
+  --> $DIR/not-an-allocator.rs:5:11
    |
 LL | #[global_allocator]
    | ------------------- in this attribute macro expansion
 LL | static A: usize = 0;
    |           ^^^^^ the trait `GlobalAlloc` is not implemented for `usize`
    |
-   = help: the trait `GlobalAlloc` is implemented for `System`
+help: the trait `GlobalAlloc` is implemented for `System`
+  --> $SRC_DIR/std/src/sys/alloc/windows.rs:LL:COL
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0277]: the trait bound `usize: GlobalAlloc` is not satisfied
-  --> $DIR/not-an-allocator.rs:2:11
+  --> $DIR/not-an-allocator.rs:5:11
    |
 LL | #[global_allocator]
    | ------------------- in this attribute macro expansion
 LL | static A: usize = 0;
    |           ^^^^^ the trait `GlobalAlloc` is not implemented for `usize`
    |
-   = help: the trait `GlobalAlloc` is implemented for `System`
+help: the trait `GlobalAlloc` is implemented for `System`
+  --> $SRC_DIR/std/src/sys/alloc/windows.rs:LL:COL
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 4 previous errors

--- a/tests/ui/associated-types/associated-types-path-2.stderr
+++ b/tests/ui/associated-types/associated-types-path-2.stderr
@@ -25,7 +25,11 @@ LL |     f1(2u32, 4u32);
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `Foo` is implemented for `i32`
+help: the trait `Foo` is implemented for `i32`
+  --> $DIR/associated-types-path-2.rs:11:1
+   |
+LL | impl Foo for i32 {
+   | ^^^^^^^^^^^^^^^^
 note: required by a bound in `f1`
   --> $DIR/associated-types-path-2.rs:15:14
    |
@@ -38,7 +42,11 @@ error[E0277]: the trait bound `u32: Foo` is not satisfied
 LL |     f1(2u32, 4u32);
    |              ^^^^ the trait `Foo` is not implemented for `u32`
    |
-   = help: the trait `Foo` is implemented for `i32`
+help: the trait `Foo` is implemented for `i32`
+  --> $DIR/associated-types-path-2.rs:11:1
+   |
+LL | impl Foo for i32 {
+   | ^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `u32: Foo` is not satisfied
   --> $DIR/associated-types-path-2.rs:37:8
@@ -48,7 +56,11 @@ LL |     f1(2u32, 4i32);
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `Foo` is implemented for `i32`
+help: the trait `Foo` is implemented for `i32`
+  --> $DIR/associated-types-path-2.rs:11:1
+   |
+LL | impl Foo for i32 {
+   | ^^^^^^^^^^^^^^^^
 note: required by a bound in `f1`
   --> $DIR/associated-types-path-2.rs:15:14
    |
@@ -61,7 +73,11 @@ error[E0277]: the trait bound `u32: Foo` is not satisfied
 LL |     f1(2u32, 4i32);
    |              ^^^^ the trait `Foo` is not implemented for `u32`
    |
-   = help: the trait `Foo` is implemented for `i32`
+help: the trait `Foo` is implemented for `i32`
+  --> $DIR/associated-types-path-2.rs:11:1
+   |
+LL | impl Foo for i32 {
+   | ^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
   --> $DIR/associated-types-path-2.rs:43:18

--- a/tests/ui/associated-types/hr-associated-type-bound-1.stderr
+++ b/tests/ui/associated-types/hr-associated-type-bound-1.stderr
@@ -4,7 +4,8 @@ error[E0277]: the trait bound `str: Clone` is not satisfied
 LL |     type U = str;
    |              ^^^ the trait `Clone` is not implemented for `str`
    |
-   = help: the trait `Clone` is implemented for `String`
+help: the trait `Clone` is implemented for `String`
+  --> $SRC_DIR/alloc/src/string.rs:LL:COL
 note: required by a bound in `X`
   --> $DIR/hr-associated-type-bound-1.rs:3:33
    |
@@ -20,7 +21,8 @@ error[E0277]: the trait bound `str: Clone` is not satisfied
 LL |     1i32.f("abc");
    |          ^ the trait `Clone` is not implemented for `str`
    |
-   = help: the trait `Clone` is implemented for `String`
+help: the trait `Clone` is implemented for `String`
+  --> $SRC_DIR/alloc/src/string.rs:LL:COL
 note: required by a bound in `X::f`
   --> $DIR/hr-associated-type-bound-1.rs:3:33
    |

--- a/tests/ui/associated-types/hr-associated-type-bound-param-1.stderr
+++ b/tests/ui/associated-types/hr-associated-type-bound-param-1.stderr
@@ -4,7 +4,8 @@ error[E0277]: the trait bound `str: Clone` is not satisfied
 LL |     type V = str;
    |              ^^^ the trait `Clone` is not implemented for `str`
    |
-   = help: the trait `Clone` is implemented for `String`
+help: the trait `Clone` is implemented for `String`
+  --> $SRC_DIR/alloc/src/string.rs:LL:COL
 note: required by a bound in `Y`
   --> $DIR/hr-associated-type-bound-param-1.rs:4:36
    |
@@ -20,7 +21,8 @@ error[E0277]: the trait bound `str: Clone` is not satisfied
 LL |     1u8.g("abc");
    |         ^ the trait `Clone` is not implemented for `str`
    |
-   = help: the trait `Clone` is implemented for `String`
+help: the trait `Clone` is implemented for `String`
+  --> $SRC_DIR/alloc/src/string.rs:LL:COL
 note: required by a bound in `Y::g`
   --> $DIR/hr-associated-type-bound-param-1.rs:4:36
    |

--- a/tests/ui/associated-types/hr-associated-type-bound-param-2.stderr
+++ b/tests/ui/associated-types/hr-associated-type-bound-param-2.stderr
@@ -4,7 +4,8 @@ error[E0277]: the trait bound `str: Clone` is not satisfied
 LL |     T: Z<'a, u16>,
    |        ^^^^^^^^^^ the trait `Clone` is not implemented for `str`
    |
-   = help: the trait `Clone` is implemented for `String`
+help: the trait `Clone` is implemented for `String`
+  --> $SRC_DIR/alloc/src/string.rs:LL:COL
 note: required by a bound in `Z`
   --> $DIR/hr-associated-type-bound-param-2.rs:6:35
    |
@@ -20,7 +21,8 @@ error[E0277]: the trait bound `str: Clone` is not satisfied
 LL |     type W = str;
    |              ^^^ the trait `Clone` is not implemented for `str`
    |
-   = help: the trait `Clone` is implemented for `String`
+help: the trait `Clone` is implemented for `String`
+  --> $SRC_DIR/alloc/src/string.rs:LL:COL
 note: required by a bound in `Z`
   --> $DIR/hr-associated-type-bound-param-2.rs:6:35
    |
@@ -36,7 +38,8 @@ error[E0277]: the trait bound `str: Clone` is not satisfied
 LL |     T: Z<'a, u16>,
    |        ^^^^^^^^^^ the trait `Clone` is not implemented for `str`
    |
-   = help: the trait `Clone` is implemented for `String`
+help: the trait `Clone` is implemented for `String`
+  --> $SRC_DIR/alloc/src/string.rs:LL:COL
 note: required by a bound in `Z`
   --> $DIR/hr-associated-type-bound-param-2.rs:6:35
    |
@@ -53,7 +56,8 @@ error[E0277]: the trait bound `str: Clone` is not satisfied
 LL |         <T::W>::clone(x);
    |          ^^^^ the trait `Clone` is not implemented for `str`
    |
-   = help: the trait `Clone` is implemented for `String`
+help: the trait `Clone` is implemented for `String`
+  --> $SRC_DIR/alloc/src/string.rs:LL:COL
 note: required by a bound in `Z::W`
   --> $DIR/hr-associated-type-bound-param-2.rs:6:35
    |
@@ -69,7 +73,8 @@ error[E0277]: the trait bound `str: Clone` is not satisfied
 LL |         <T::W>::clone(x);
    |         ^^^^^^^^^^^^^ the trait `Clone` is not implemented for `str`
    |
-   = help: the trait `Clone` is implemented for `String`
+help: the trait `Clone` is implemented for `String`
+  --> $SRC_DIR/alloc/src/string.rs:LL:COL
 note: required by a bound in `Z`
   --> $DIR/hr-associated-type-bound-param-2.rs:6:35
    |
@@ -85,7 +90,8 @@ error[E0277]: the trait bound `str: Clone` is not satisfied
 LL |         <T::W>::clone(x);
    |         ^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `str`
    |
-   = help: the trait `Clone` is implemented for `String`
+help: the trait `Clone` is implemented for `String`
+  --> $SRC_DIR/alloc/src/string.rs:LL:COL
 note: required by a bound in `Z`
   --> $DIR/hr-associated-type-bound-param-2.rs:6:35
    |
@@ -101,7 +107,8 @@ error[E0277]: the trait bound `str: Clone` is not satisfied
 LL |     1u16.h("abc");
    |          ^ the trait `Clone` is not implemented for `str`
    |
-   = help: the trait `Clone` is implemented for `String`
+help: the trait `Clone` is implemented for `String`
+  --> $SRC_DIR/alloc/src/string.rs:LL:COL
 note: required by a bound in `Z::h`
   --> $DIR/hr-associated-type-bound-param-2.rs:6:35
    |

--- a/tests/ui/associated-types/hr-associated-type-bound-param-3.stderr
+++ b/tests/ui/associated-types/hr-associated-type-bound-param-3.stderr
@@ -4,7 +4,8 @@ error[E0277]: the trait bound `str: Clone` is not satisfied
 LL |     type U = str;
    |              ^^^ the trait `Clone` is not implemented for `str`
    |
-   = help: the trait `Clone` is implemented for `String`
+help: the trait `Clone` is implemented for `String`
+  --> $SRC_DIR/alloc/src/string.rs:LL:COL
 note: required by a bound in `X`
   --> $DIR/hr-associated-type-bound-param-3.rs:4:33
    |
@@ -20,7 +21,8 @@ error[E0277]: the trait bound `str: Clone` is not satisfied
 LL |     <(i32,) as X<(i32,)>>::f("abc");
    |                  ^^^^^^ the trait `Clone` is not implemented for `str`
    |
-   = help: the trait `Clone` is implemented for `String`
+help: the trait `Clone` is implemented for `String`
+  --> $SRC_DIR/alloc/src/string.rs:LL:COL
 note: required by a bound in `X::f`
   --> $DIR/hr-associated-type-bound-param-3.rs:4:33
    |

--- a/tests/ui/associated-types/hr-associated-type-bound-param-4.stderr
+++ b/tests/ui/associated-types/hr-associated-type-bound-param-4.stderr
@@ -4,7 +4,8 @@ error[E0277]: the trait bound `str: Clone` is not satisfied
 LL |     type U = str;
    |              ^^^ the trait `Clone` is not implemented for `str`
    |
-   = help: the trait `Clone` is implemented for `String`
+help: the trait `Clone` is implemented for `String`
+  --> $SRC_DIR/alloc/src/string.rs:LL:COL
 note: required by a bound in `X`
   --> $DIR/hr-associated-type-bound-param-4.rs:4:36
    |
@@ -20,7 +21,8 @@ error[E0277]: the trait bound `str: Clone` is not satisfied
 LL |     <(i32,) as X<i32>>::f("abc");
    |                  ^^^ the trait `Clone` is not implemented for `str`
    |
-   = help: the trait `Clone` is implemented for `String`
+help: the trait `Clone` is implemented for `String`
+  --> $SRC_DIR/alloc/src/string.rs:LL:COL
 note: required by a bound in `X::f`
   --> $DIR/hr-associated-type-bound-param-4.rs:4:36
    |

--- a/tests/ui/associated-types/hr-associated-type-bound-param-5.stderr
+++ b/tests/ui/associated-types/hr-associated-type-bound-param-5.stderr
@@ -4,7 +4,8 @@ error[E0277]: the trait bound `str: Clone` is not satisfied
 LL |     type U = str;
    |              ^^^ the trait `Clone` is not implemented for `str`
    |
-   = help: the trait `Clone` is implemented for `String`
+help: the trait `Clone` is implemented for `String`
+  --> $SRC_DIR/alloc/src/string.rs:LL:COL
 note: required by a bound in `X`
   --> $DIR/hr-associated-type-bound-param-5.rs:17:45
    |
@@ -20,7 +21,8 @@ error[E0277]: the trait bound `str: Clone` is not satisfied
 LL |     type U = str;
    |              ^^^ the trait `Clone` is not implemented for `str`
    |
-   = help: the trait `Clone` is implemented for `String`
+help: the trait `Clone` is implemented for `String`
+  --> $SRC_DIR/alloc/src/string.rs:LL:COL
 note: required by a bound in `X`
   --> $DIR/hr-associated-type-bound-param-5.rs:17:45
    |
@@ -36,7 +38,8 @@ error[E0277]: the trait bound `str: Clone` is not satisfied
 LL |     <i32 as X<Box<i32>>>::f("abc");
    |               ^^^^^^^^ the trait `Clone` is not implemented for `str`
    |
-   = help: the trait `Clone` is implemented for `String`
+help: the trait `Clone` is implemented for `String`
+  --> $SRC_DIR/alloc/src/string.rs:LL:COL
 note: required by a bound in `X::f`
   --> $DIR/hr-associated-type-bound-param-5.rs:15:33
    |

--- a/tests/ui/associated-types/hr-associated-type-bound-param-6.stderr
+++ b/tests/ui/associated-types/hr-associated-type-bound-param-6.stderr
@@ -15,7 +15,11 @@ error[E0277]: the trait bound `for<'b> i32: X<'b, i32>` is not satisfied
 LL |     <(i32,) as X<i32>>::f("abc");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `for<'b> X<'b, i32>` is not implemented for `i32`
    |
-   = help: the trait `X<'_, T>` is implemented for `(S,)`
+help: the trait `X<'_, T>` is implemented for `(S,)`
+  --> $DIR/hr-associated-type-bound-param-6.rs:12:1
+   |
+LL | impl<S, T> X<'_, T> for (S,) {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `for<'b> i32: X<'b, i32>` is not satisfied
   --> $DIR/hr-associated-type-bound-param-6.rs:18:18
@@ -23,7 +27,11 @@ error[E0277]: the trait bound `for<'b> i32: X<'b, i32>` is not satisfied
 LL |     <(i32,) as X<i32>>::f("abc");
    |                  ^^^ the trait `for<'b> X<'b, i32>` is not implemented for `i32`
    |
-   = help: the trait `X<'_, T>` is implemented for `(S,)`
+help: the trait `X<'_, T>` is implemented for `(S,)`
+  --> $DIR/hr-associated-type-bound-param-6.rs:12:1
+   |
+LL | impl<S, T> X<'_, T> for (S,) {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `X::f`
   --> $DIR/hr-associated-type-bound-param-6.rs:3:16
    |
@@ -39,7 +47,11 @@ error[E0277]: the trait bound `i32: X<'_, i32>` is not satisfied
 LL |     <(i32,) as X<i32>>::f("abc");
    |                           ^^^^^ the trait `X<'_, i32>` is not implemented for `i32`
    |
-   = help: the trait `X<'_, T>` is implemented for `(S,)`
+help: the trait `X<'_, T>` is implemented for `(S,)`
+  --> $DIR/hr-associated-type-bound-param-6.rs:12:1
+   |
+LL | impl<S, T> X<'_, T> for (S,) {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/associated-types/issue-65774-1.stderr
+++ b/tests/ui/associated-types/issue-65774-1.stderr
@@ -9,7 +9,11 @@ help: the trait `MyDisplay` is not implemented for `T`
    |
 LL | struct T;
    | ^^^^^^^^
-   = help: the trait `MyDisplay` is implemented for `&'a mut T`
+help: the trait `MyDisplay` is implemented for `&'a mut T`
+  --> $DIR/issue-65774-1.rs:5:1
+   |
+LL | impl<'a, T: MyDisplay> MyDisplay for &'a mut T { }
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `MPU::MpuConfig`
   --> $DIR/issue-65774-1.rs:10:21
    |
@@ -27,7 +31,11 @@ help: the trait `MyDisplay` is not implemented for `T`
    |
 LL | struct T;
    | ^^^^^^^^
-   = help: the trait `MyDisplay` is implemented for `&'a mut T`
+help: the trait `MyDisplay` is implemented for `&'a mut T`
+  --> $DIR/issue-65774-1.rs:5:1
+   |
+LL | impl<'a, T: MyDisplay> MyDisplay for &'a mut T { }
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required for `&mut T` to implement `MyDisplay`
   --> $DIR/issue-65774-1.rs:5:24
    |

--- a/tests/ui/associated-types/issue-65774-2.stderr
+++ b/tests/ui/associated-types/issue-65774-2.stderr
@@ -9,7 +9,11 @@ help: the trait `MyDisplay` is not implemented for `T`
    |
 LL | struct T;
    | ^^^^^^^^
-   = help: the trait `MyDisplay` is implemented for `&'a mut T`
+help: the trait `MyDisplay` is implemented for `&'a mut T`
+  --> $DIR/issue-65774-2.rs:5:1
+   |
+LL | impl<'a, T: MyDisplay> MyDisplay for &'a mut T { }
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `MPU::MpuConfig`
   --> $DIR/issue-65774-2.rs:10:21
    |
@@ -27,7 +31,11 @@ help: the trait `MyDisplay` is not implemented for `T`
    |
 LL | struct T;
    | ^^^^^^^^
-   = help: the trait `MyDisplay` is implemented for `&'a mut T`
+help: the trait `MyDisplay` is implemented for `&'a mut T`
+  --> $DIR/issue-65774-2.rs:5:1
+   |
+LL | impl<'a, T: MyDisplay> MyDisplay for &'a mut T { }
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: required for the cast from `&mut T` to `&dyn MyDisplay`
 
 error: aborting due to 2 previous errors

--- a/tests/ui/associated-types/projection-dyn-associated-type.stderr
+++ b/tests/ui/associated-types/projection-dyn-associated-type.stderr
@@ -35,7 +35,11 @@ error[E0277]: the trait bound `(dyn B + 'static): Mirror` is not satisfied
 LL | ) -> &'a <dyn B + 'static as Mirror>::Assoc {
    |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Mirror` is not implemented for `(dyn B + 'static)`
    |
-   = help: the trait `Mirror` is implemented for `dyn A`
+help: the trait `Mirror` is implemented for `dyn A`
+  --> $DIR/projection-dyn-associated-type.rs:13:1
+   |
+LL | impl<T: ?Sized> Mirror for A {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `(dyn B + 'static): Mirror` is not satisfied
   --> $DIR/projection-dyn-associated-type.rs:22:6
@@ -43,7 +47,11 @@ error[E0277]: the trait bound `(dyn B + 'static): Mirror` is not satisfied
 LL | ) -> &'a <dyn B + 'static as Mirror>::Assoc {
    |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Mirror` is not implemented for `(dyn B + 'static)`
    |
-   = help: the trait `Mirror` is implemented for `dyn A`
+help: the trait `Mirror` is implemented for `dyn A`
+  --> $DIR/projection-dyn-associated-type.rs:13:1
+   |
+LL | impl<T: ?Sized> Mirror for A {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 4 previous errors; 1 warning emitted

--- a/tests/ui/binop/binary-op-suggest-deref.stderr
+++ b/tests/ui/binop/binary-op-suggest-deref.stderr
@@ -302,11 +302,17 @@ LL |     let _ = FOO & (*"Sized".to_string().into_boxed_str());
    |                 ^ no implementation for `i32 & str`
    |
    = help: the trait `BitAnd<str>` is not implemented for `i32`
-   = help: the following other types implement trait `BitAnd<Rhs>`:
-             `&i32` implements `BitAnd<i32>`
-             `&i32` implements `BitAnd`
-             `i32` implements `BitAnd<&i32>`
-             `i32` implements `BitAnd`
+help: the following other types implement trait `BitAnd<Rhs>`
+  --> $SRC_DIR/core/src/ops/bit.rs:LL:COL
+   |
+   = note: `&i32` implements `BitAnd<i32>`
+   |
+   = note: `&i32` implements `BitAnd`
+   |
+   = note: `i32` implements `BitAnd<&i32>`
+   |
+   = note: `i32` implements `BitAnd`
+   = note: this error originates in the macro `bitand_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `str` cannot be known at compilation time
   --> $DIR/binary-op-suggest-deref.rs:78:17

--- a/tests/ui/binop/binop-mul-i32-f32.stderr
+++ b/tests/ui/binop/binop-mul-i32-f32.stderr
@@ -5,11 +5,17 @@ LL |     x * y
    |       ^ no implementation for `i32 * f32`
    |
    = help: the trait `Mul<f32>` is not implemented for `i32`
-   = help: the following other types implement trait `Mul<Rhs>`:
-             `&i32` implements `Mul<i32>`
-             `&i32` implements `Mul`
-             `i32` implements `Mul<&i32>`
-             `i32` implements `Mul`
+help: the following other types implement trait `Mul<Rhs>`
+  --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
+   |
+   = note: `&i32` implements `Mul<i32>`
+   |
+   = note: `&i32` implements `Mul`
+   |
+   = note: `i32` implements `Mul<&i32>`
+   |
+   = note: `i32` implements `Mul`
+   = note: this error originates in the macro `mul_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/block-result/issue-22645.stderr
+++ b/tests/ui/block-result/issue-22645.stderr
@@ -4,7 +4,11 @@ error[E0277]: the trait bound `{integer}: Scalar` is not satisfied
 LL |   b + 3
    |     ^ the trait `Scalar` is not implemented for `{integer}`
    |
-   = help: the trait `Scalar` is implemented for `f64`
+help: the trait `Scalar` is implemented for `f64`
+  --> $DIR/issue-22645.rs:4:1
+   |
+LL | impl Scalar for f64 {}
+   | ^^^^^^^^^^^^^^^^^^^
 note: required for `Bob` to implement `Add<{integer}>`
   --> $DIR/issue-22645.rs:8:19
    |

--- a/tests/ui/const-generics/adt_const_params/const_param_ty_bad.stderr
+++ b/tests/ui/const-generics/adt_const_params/const_param_ty_bad.stderr
@@ -82,12 +82,14 @@ LL |     check(&mut () as *mut ());
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `ConstParamTy_` is implemented for `()`
+help: the trait `ConstParamTy_` is implemented for `()`
+  --> $SRC_DIR/core/src/marker.rs:LL:COL
 note: required by a bound in `check`
   --> $DIR/const_param_ty_bad.rs:4:18
    |
 LL | fn check(_: impl std::marker::ConstParamTy_) {}
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `check`
+   = note: this error originates in the macro `marker_impls` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `*const ()` can't be used as a const parameter type
   --> $DIR/const_param_ty_bad.rs:12:11
@@ -97,12 +99,14 @@ LL |     check(&() as *const ());
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `ConstParamTy_` is implemented for `()`
+help: the trait `ConstParamTy_` is implemented for `()`
+  --> $SRC_DIR/core/src/marker.rs:LL:COL
 note: required by a bound in `check`
   --> $DIR/const_param_ty_bad.rs:4:18
    |
 LL | fn check(_: impl std::marker::ConstParamTy_) {}
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `check`
+   = note: this error originates in the macro `marker_impls` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/const-generics/adt_const_params/unsizing-wfcheck-issue-126272.stderr
+++ b/tests/ui/const-generics/adt_const_params/unsizing-wfcheck-issue-126272.stderr
@@ -53,7 +53,11 @@ LL |     nested: &'static Bar<dyn std::fmt::Debug>,
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `(dyn Debug + 'static)`
-   = help: the trait `Debug` is implemented for `Bar<T>`
+help: the trait `Debug` is implemented for `Bar<T>`
+  --> $DIR/unsizing-wfcheck-issue-126272.rs:19:10
+   |
+LL | #[derive(Debug, PartialEq, Eq, ConstParamTy)]
+   |          ^^^^^
 note: required for `Bar<(dyn Debug + 'static)>` to implement `Debug`
   --> $DIR/unsizing-wfcheck-issue-126272.rs:19:10
    |
@@ -83,7 +87,11 @@ LL | #[derive(Debug, PartialEq, Eq, ConstParamTy)]
 LL |     nested: &'static Bar<dyn std::fmt::Debug>,
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Eq` is not implemented for `dyn Debug`
    |
-   = help: the trait `Eq` is implemented for `Bar<T>`
+help: the trait `Eq` is implemented for `Bar<T>`
+  --> $DIR/unsizing-wfcheck-issue-126272.rs:19:28
+   |
+LL | #[derive(Debug, PartialEq, Eq, ConstParamTy)]
+   |                            ^^
 note: required for `Bar<dyn Debug>` to implement `Eq`
   --> $DIR/unsizing-wfcheck-issue-126272.rs:19:28
    |

--- a/tests/ui/const-generics/associated-type-bound-fail.stderr
+++ b/tests/ui/const-generics/associated-type-bound-fail.stderr
@@ -4,8 +4,12 @@ error[E0277]: the trait bound `u16: Bar<N>` is not satisfied
 LL |     type Assoc = u16;
    |                  ^^^ the trait `Bar<N>` is not implemented for `u16`
    |
-   = help: the trait `Bar<N>` is not implemented for `u16`
-           but trait `Bar<3>` is implemented for it
+help: the trait `Bar<N>` is not implemented for `u16`
+      but trait `Bar<3>` is implemented for it
+  --> $DIR/associated-type-bound-fail.rs:7:1
+   |
+LL | impl Bar<3> for u16 {}
+   | ^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `Foo::Assoc`
   --> $DIR/associated-type-bound-fail.rs:4:17
    |

--- a/tests/ui/const-generics/defaults/rp_impl_trait_fail.stderr
+++ b/tests/ui/const-generics/defaults/rp_impl_trait_fail.stderr
@@ -12,7 +12,11 @@ help: the trait `Trait` is not implemented for `Uwu<10, 12>`
    |
 LL | struct Uwu<const N: u32 = 1, const M: u32 = N>;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: the trait `Trait` is implemented for `Uwu<N>`
+help: the trait `Trait` is implemented for `Uwu<N>`
+  --> $DIR/rp_impl_trait_fail.rs:4:1
+   |
+LL | impl<const N: u32> Trait for Uwu<N> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `u32: Traitor<N>` is not satisfied
   --> $DIR/rp_impl_trait_fail.rs:16:26

--- a/tests/ui/const-generics/defaults/rp_impl_trait_fail.stderr
+++ b/tests/ui/const-generics/defaults/rp_impl_trait_fail.stderr
@@ -23,8 +23,12 @@ LL |
 LL |     1_u32
    |     ----- return type was inferred to be `u32` here
    |
-   = help: the trait `Traitor<N, N>` is not implemented for `u32`
-           but trait `Traitor<N, 2>` is implemented for it
+help: the trait `Traitor<N, N>` is not implemented for `u32`
+      but trait `Traitor<N, 2>` is implemented for it
+  --> $DIR/rp_impl_trait_fail.rs:13:1
+   |
+LL | impl<const N: u8> Traitor<N, 2> for u32 {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `u64: Traitor` is not satisfied
   --> $DIR/rp_impl_trait_fail.rs:21:13
@@ -35,8 +39,12 @@ LL |
 LL |     1_u64
    |     ----- return type was inferred to be `u64` here
    |
-   = help: the trait `Traitor<1, 1>` is not implemented for `u64`
-           but trait `Traitor<1, 2>` is implemented for it
+help: the trait `Traitor<1, 1>` is not implemented for `u64`
+      but trait `Traitor<1, 2>` is implemented for it
+  --> $DIR/rp_impl_trait_fail.rs:14:1
+   |
+LL | impl Traitor<1, 2> for u64 {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0284]: type annotations needed
   --> $DIR/rp_impl_trait_fail.rs:28:5

--- a/tests/ui/const-generics/defaults/trait_objects_fail.stderr
+++ b/tests/ui/const-generics/defaults/trait_objects_fail.stderr
@@ -4,8 +4,12 @@ error[E0277]: the trait bound `u32: Trait` is not satisfied
 LL |     foo(&10_u32);
    |         ^^^^^^^ the trait `Trait` is not implemented for `u32`
    |
-   = help: the trait `Trait<12>` is not implemented for `u32`
-           but trait `Trait<2>` is implemented for it
+help: the trait `Trait<12>` is not implemented for `u32`
+      but trait `Trait<2>` is implemented for it
+  --> $DIR/trait_objects_fail.rs:7:1
+   |
+LL | impl Trait<2> for u32 {}
+   | ^^^^^^^^^^^^^^^^^^^^^
    = note: required for the cast from `&u32` to `&dyn Trait`
 
 error[E0277]: the trait bound `bool: Traitor<_>` is not satisfied
@@ -14,8 +18,12 @@ error[E0277]: the trait bound `bool: Traitor<_>` is not satisfied
 LL |     bar(&true);
    |         ^^^^^ the trait `Traitor<_>` is not implemented for `bool`
    |
-   = help: the trait `Traitor<_, _>` is not implemented for `bool`
-           but trait `Traitor<2, 3>` is implemented for it
+help: the trait `Traitor<_, _>` is not implemented for `bool`
+      but trait `Traitor<2, 3>` is implemented for it
+  --> $DIR/trait_objects_fail.rs:19:1
+   |
+LL | impl Traitor<2, 3> for bool {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: required for the cast from `&bool` to `&dyn Traitor<_>`
 
 error: aborting due to 2 previous errors

--- a/tests/ui/const-generics/defaults/wfness.stderr
+++ b/tests/ui/const-generics/defaults/wfness.stderr
@@ -10,8 +10,12 @@ error[E0277]: the trait bound `(): Trait<2>` is not satisfied
 LL |     (): Trait<N>;
    |         ^^^^^^^^ the trait `Trait<2>` is not implemented for `()`
    |
-   = help: the trait `Trait<2>` is not implemented for `()`
-           but trait `Trait<3>` is implemented for it
+help: the trait `Trait<2>` is not implemented for `()`
+      but trait `Trait<3>` is implemented for it
+  --> $DIR/wfness.rs:5:1
+   |
+LL | impl Trait<3> for () {}
+   | ^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `WhereClause`
   --> $DIR/wfness.rs:8:9
    |
@@ -27,8 +31,12 @@ error[E0277]: the trait bound `(): Trait<1>` is not satisfied
 LL | fn foo() -> DependentDefaultWfness {
    |             ^^^^^^^^^^^^^^^^^^^^^^ the trait `Trait<1>` is not implemented for `()`
    |
-   = help: the trait `Trait<1>` is not implemented for `()`
-           but trait `Trait<3>` is implemented for it
+help: the trait `Trait<1>` is not implemented for `()`
+      but trait `Trait<3>` is implemented for it
+  --> $DIR/wfness.rs:5:1
+   |
+LL | impl Trait<3> for () {}
+   | ^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `WhereClause`
   --> $DIR/wfness.rs:8:9
    |

--- a/tests/ui/const-generics/issues/issue-67185-2.stderr
+++ b/tests/ui/const-generics/issues/issue-67185-2.stderr
@@ -4,9 +4,13 @@ error[E0277]: the trait bound `[u16; 3]: Bar` is not satisfied
 LL |     <u8 as Baz>::Quaks: Bar,
    |     ^^^^^^^^^^^^^^^^^^^^^^^ the trait `Bar` is not implemented for `[u16; 3]`
    |
-   = help: the following other types implement trait `Bar`:
-             [[u16; 3]; 3]
-             [u16; 4]
+help: the following other types implement trait `Bar`
+  --> $DIR/issue-67185-2.rs:9:1
+   |
+LL | impl Bar for [u16; 4] {}
+   | ^^^^^^^^^^^^^^^^^^^^^ `[u16; 4]`
+LL | impl Bar for [[u16; 3]; 3] {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^ `[[u16; 3]; 3]`
    = help: see issue #48214
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    |
@@ -19,9 +23,13 @@ error[E0277]: the trait bound `[[u16; 3]; 2]: Bar` is not satisfied
 LL |     [<u8 as Baz>::Quaks; 2]: Bar,
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Bar` is not implemented for `[[u16; 3]; 2]`
    |
-   = help: the following other types implement trait `Bar`:
-             [[u16; 3]; 3]
-             [u16; 4]
+help: the following other types implement trait `Bar`
+  --> $DIR/issue-67185-2.rs:9:1
+   |
+LL | impl Bar for [u16; 4] {}
+   | ^^^^^^^^^^^^^^^^^^^^^ `[u16; 4]`
+LL | impl Bar for [[u16; 3]; 3] {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^ `[[u16; 3]; 3]`
    = help: see issue #48214
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    |
@@ -34,9 +42,13 @@ error[E0277]: the trait bound `[u16; 3]: Bar` is not satisfied
 LL | impl Foo for FooImpl {}
    |      ^^^ the trait `Bar` is not implemented for `[u16; 3]`
    |
-   = help: the following other types implement trait `Bar`:
-             [[u16; 3]; 3]
-             [u16; 4]
+help: the following other types implement trait `Bar`
+  --> $DIR/issue-67185-2.rs:9:1
+   |
+LL | impl Bar for [u16; 4] {}
+   | ^^^^^^^^^^^^^^^^^^^^^ `[u16; 4]`
+LL | impl Bar for [[u16; 3]; 3] {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^ `[[u16; 3]; 3]`
 note: required by a bound in `Foo`
   --> $DIR/issue-67185-2.rs:15:25
    |
@@ -52,9 +64,13 @@ error[E0277]: the trait bound `[[u16; 3]; 2]: Bar` is not satisfied
 LL | impl Foo for FooImpl {}
    |      ^^^ the trait `Bar` is not implemented for `[[u16; 3]; 2]`
    |
-   = help: the following other types implement trait `Bar`:
-             [[u16; 3]; 3]
-             [u16; 4]
+help: the following other types implement trait `Bar`
+  --> $DIR/issue-67185-2.rs:9:1
+   |
+LL | impl Bar for [u16; 4] {}
+   | ^^^^^^^^^^^^^^^^^^^^^ `[u16; 4]`
+LL | impl Bar for [[u16; 3]; 3] {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^ `[[u16; 3]; 3]`
 note: required by a bound in `Foo`
   --> $DIR/issue-67185-2.rs:14:30
    |
@@ -70,9 +86,13 @@ error[E0277]: the trait bound `[[u16; 3]; 2]: Bar` is not satisfied
 LL | fn f(_: impl Foo) {}
    |              ^^^ the trait `Bar` is not implemented for `[[u16; 3]; 2]`
    |
-   = help: the following other types implement trait `Bar`:
-             [[u16; 3]; 3]
-             [u16; 4]
+help: the following other types implement trait `Bar`
+  --> $DIR/issue-67185-2.rs:9:1
+   |
+LL | impl Bar for [u16; 4] {}
+   | ^^^^^^^^^^^^^^^^^^^^^ `[u16; 4]`
+LL | impl Bar for [[u16; 3]; 3] {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^ `[[u16; 3]; 3]`
 note: required by a bound in `Foo`
   --> $DIR/issue-67185-2.rs:14:30
    |
@@ -88,9 +108,13 @@ error[E0277]: the trait bound `[u16; 3]: Bar` is not satisfied
 LL | fn f(_: impl Foo) {}
    |              ^^^ the trait `Bar` is not implemented for `[u16; 3]`
    |
-   = help: the following other types implement trait `Bar`:
-             [[u16; 3]; 3]
-             [u16; 4]
+help: the following other types implement trait `Bar`
+  --> $DIR/issue-67185-2.rs:9:1
+   |
+LL | impl Bar for [u16; 4] {}
+   | ^^^^^^^^^^^^^^^^^^^^^ `[u16; 4]`
+LL | impl Bar for [[u16; 3]; 3] {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^ `[[u16; 3]; 3]`
 note: required by a bound in `Foo`
   --> $DIR/issue-67185-2.rs:15:25
    |

--- a/tests/ui/const-generics/issues/issue-83249.stderr
+++ b/tests/ui/const-generics/issues/issue-83249.stderr
@@ -7,7 +7,11 @@ LL |     let _ = foo([0; 1]);
    |             required by a bound introduced by this call
    |
    = note: cannot satisfy `_: Foo`
-   = help: the trait `Foo` is implemented for `u8`
+help: the trait `Foo` is implemented for `u8`
+  --> $DIR/issue-83249.rs:8:1
+   |
+LL | impl Foo for u8 {
+   | ^^^^^^^^^^^^^^^
 note: required by a bound in `foo`
   --> $DIR/issue-83249.rs:12:11
    |

--- a/tests/ui/const-generics/occurs-check/unused-substs-1.stderr
+++ b/tests/ui/const-generics/occurs-check/unused-substs-1.stderr
@@ -4,8 +4,12 @@ error[E0277]: the trait bound `A<_>: Bar<_>` is not satisfied
 LL |     let _ = A;
    |             ^ unsatisfied trait bound
    |
-   = help: the trait `Bar<_>` is not implemented for `A<_>`
-           but it is implemented for `A<{ 6 + 1 }>`
+help: the trait `Bar<_>` is not implemented for `A<_>`
+      but it is implemented for `A<{ 6 + 1 }>`
+  --> $DIR/unused-substs-1.rs:5:1
+   |
+LL | impl<const N: usize> Bar<N> for A<{ 6 + 1 }> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `A`
   --> $DIR/unused-substs-1.rs:9:11
    |

--- a/tests/ui/consts/const-eval-array-len-in-impl.stderr
+++ b/tests/ui/consts/const-eval-array-len-in-impl.stderr
@@ -4,7 +4,11 @@ error[E0277]: the trait bound `[(); 0]: Foo` is not satisfied
 LL |     <[(); 0] as Foo>::foo()
    |      ^^^^^^^ the trait `Foo` is not implemented for `[(); 0]`
    |
-   = help: the trait `Foo` is implemented for `[(); 1]`
+help: the trait `Foo` is implemented for `[(); 1]`
+  --> $DIR/const-eval-array-len-in-impl.rs:9:1
+   |
+LL | impl Foo for [(); 1] {
+   | ^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/const-eval/const-eval-overflow-3b.stderr
+++ b/tests/ui/consts/const-eval/const-eval-overflow-3b.stderr
@@ -11,11 +11,17 @@ LL |     = [0; (i8::MAX + 1u8) as usize];
    |                    ^ no implementation for `i8 + u8`
    |
    = help: the trait `Add<u8>` is not implemented for `i8`
-   = help: the following other types implement trait `Add<Rhs>`:
-             `&i8` implements `Add<i8>`
-             `&i8` implements `Add`
-             `i8` implements `Add<&i8>`
-             `i8` implements `Add`
+help: the following other types implement trait `Add<Rhs>`
+  --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
+   |
+   = note: `&i8` implements `Add<i8>`
+   |
+   = note: `&i8` implements `Add`
+   |
+   = note: `i8` implements `Add<&i8>`
+   |
+   = note: `i8` implements `Add`
+   = note: this error originates in the macro `add_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/consts/const-eval/const-eval-overflow-4b.stderr
+++ b/tests/ui/consts/const-eval/const-eval-overflow-4b.stderr
@@ -11,11 +11,17 @@ LL |     : [u32; (i8::MAX as i8 + 1u8) as usize]
    |                            ^ no implementation for `i8 + u8`
    |
    = help: the trait `Add<u8>` is not implemented for `i8`
-   = help: the following other types implement trait `Add<Rhs>`:
-             `&i8` implements `Add<i8>`
-             `&i8` implements `Add`
-             `i8` implements `Add<&i8>`
-             `i8` implements `Add`
+help: the following other types implement trait `Add<Rhs>`
+  --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
+   |
+   = note: `&i8` implements `Add<i8>`
+   |
+   = note: `&i8` implements `Add`
+   |
+   = note: `i8` implements `Add<&i8>`
+   |
+   = note: `i8` implements `Add`
+   = note: this error originates in the macro `add_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0604]: only `u8` can be cast as `char`, not `i8`
   --> $DIR/const-eval-overflow-4b.rs:24:13

--- a/tests/ui/delegation/correct_body_owner_parent_found_in_diagnostics.stderr
+++ b/tests/ui/delegation/correct_body_owner_parent_found_in_diagnostics.stderr
@@ -58,7 +58,11 @@ error[E0277]: the trait bound `u8: Trait` is not satisfied
 LL |     reuse <u8 as Trait>::{foo, bar, meh} { &const { InvariantRef::<'a>::NEW } }
    |            ^^ the trait `Trait` is not implemented for `u8`
    |
-   = help: the trait `Trait` is implemented for `Z`
+help: the trait `Trait` is implemented for `Z`
+  --> $DIR/correct_body_owner_parent_found_in_diagnostics.rs:21:1
+   |
+LL | impl Trait for Z {
+   | ^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
   --> $DIR/correct_body_owner_parent_found_in_diagnostics.rs:22:53
@@ -75,7 +79,11 @@ error[E0277]: the trait bound `u8: Trait` is not satisfied
 LL |     reuse <u8 as Trait>::{foo, bar, meh} { &const { InvariantRef::<'a>::NEW } }
    |            ^^ the trait `Trait` is not implemented for `u8`
    |
-   = help: the trait `Trait` is implemented for `Z`
+help: the trait `Trait` is implemented for `Z`
+  --> $DIR/correct_body_owner_parent_found_in_diagnostics.rs:21:1
+   |
+LL | impl Trait for Z {
+   | ^^^^^^^^^^^^^^^^
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0308]: mismatched types
@@ -94,7 +102,11 @@ error[E0277]: the trait bound `u8: Trait` is not satisfied
 LL |     reuse <u8 as Trait>::{foo, bar, meh} { &const { InvariantRef::<'a>::NEW } }
    |            ^^ the trait `Trait` is not implemented for `u8`
    |
-   = help: the trait `Trait` is implemented for `Z`
+help: the trait `Trait` is implemented for `Z`
+  --> $DIR/correct_body_owner_parent_found_in_diagnostics.rs:21:1
+   |
+LL | impl Trait for Z {
+   | ^^^^^^^^^^^^^^^^
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0308]: mismatched types

--- a/tests/ui/delegation/explicit-paths.stderr
+++ b/tests/ui/delegation/explicit-paths.stderr
@@ -96,9 +96,17 @@ help: the trait `Trait` is not implemented for `S2`
    |
 LL |     struct S2;
    |     ^^^^^^^^^
-   = help: the following other types implement trait `Trait`:
-             F
-             S
+help: the following other types implement trait `Trait`
+  --> $DIR/explicit-paths.rs:10:1
+   |
+LL | impl Trait for F {}
+   | ^^^^^^^^^^^^^^^^ `F`
+...
+LL |     impl Trait for S {
+   |     ^^^^^^^^^^^^^^^^ `S`
+...
+LL |     impl Trait for S {
+   |     ^^^^^^^^^^^^^^^^ `S`
 
 error[E0308]: mismatched types
   --> $DIR/explicit-paths.rs:76:30

--- a/tests/ui/diagnostic_namespace/do_not_recommend/as_expression.current.stderr
+++ b/tests/ui/diagnostic_namespace/do_not_recommend/as_expression.current.stderr
@@ -4,8 +4,12 @@ error[E0277]: the trait bound `&str: AsExpression<Integer>` is not satisfied
 LL |     SelectInt.check("bar");
    |               ^^^^^ the trait `AsExpression<Integer>` is not implemented for `&str`
    |
-   = help: the trait `AsExpression<Integer>` is not implemented for `&str`
-           but trait `AsExpression<Text>` is implemented for it
+help: the trait `AsExpression<Integer>` is not implemented for `&str`
+      but trait `AsExpression<Text>` is implemented for it
+  --> $DIR/as_expression.rs:40:1
+   |
+LL | impl AsExpression<Text> for &'_ str {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: for that trait implementation, expected `Text`, found `Integer`
 
 error: aborting due to 1 previous error

--- a/tests/ui/diagnostic_namespace/do_not_recommend/as_expression.next.stderr
+++ b/tests/ui/diagnostic_namespace/do_not_recommend/as_expression.next.stderr
@@ -6,8 +6,12 @@ LL |     SelectInt.check("bar");
    |               |
    |               required by a bound introduced by this call
    |
-   = help: the trait `AsExpression<Integer>` is not implemented for `&str`
-           but trait `AsExpression<Text>` is implemented for it
+help: the trait `AsExpression<Integer>` is not implemented for `&str`
+      but trait `AsExpression<Text>` is implemented for it
+  --> $DIR/as_expression.rs:40:1
+   |
+LL | impl AsExpression<Text> for &'_ str {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: for that trait implementation, expected `Text`, found `Integer`
 note: required by a bound in `Foo::check`
   --> $DIR/as_expression.rs:47:12
@@ -24,8 +28,12 @@ error[E0277]: the trait bound `&str: AsExpression<Integer>` is not satisfied
 LL |     SelectInt.check("bar");
    |     ^^^^^^^^^^^^^^^^^^^^^^ the trait `AsExpression<Integer>` is not implemented for `&str`
    |
-   = help: the trait `AsExpression<Integer>` is not implemented for `&str`
-           but trait `AsExpression<Text>` is implemented for it
+help: the trait `AsExpression<Integer>` is not implemented for `&str`
+      but trait `AsExpression<Text>` is implemented for it
+  --> $DIR/as_expression.rs:40:1
+   |
+LL | impl AsExpression<Text> for &'_ str {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: for that trait implementation, expected `Text`, found `Integer`
 
 error: aborting due to 2 previous errors

--- a/tests/ui/diagnostic_namespace/do_not_recommend/supress_suggestions_in_help.current.stderr
+++ b/tests/ui/diagnostic_namespace/do_not_recommend/supress_suggestions_in_help.current.stderr
@@ -6,7 +6,11 @@ LL |     check(());
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `Foo` is implemented for `i32`
+help: the trait `Foo` is implemented for `i32`
+  --> $DIR/supress_suggestions_in_help.rs:17:1
+   |
+LL | impl Foo for i32 {}
+   | ^^^^^^^^^^^^^^^^
 note: required by a bound in `check`
   --> $DIR/supress_suggestions_in_help.rs:19:18
    |

--- a/tests/ui/diagnostic_namespace/do_not_recommend/supress_suggestions_in_help.next.stderr
+++ b/tests/ui/diagnostic_namespace/do_not_recommend/supress_suggestions_in_help.next.stderr
@@ -6,7 +6,11 @@ LL |     check(());
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `Foo` is implemented for `i32`
+help: the trait `Foo` is implemented for `i32`
+  --> $DIR/supress_suggestions_in_help.rs:17:1
+   |
+LL | impl Foo for i32 {}
+   | ^^^^^^^^^^^^^^^^
 note: required by a bound in `check`
   --> $DIR/supress_suggestions_in_help.rs:19:18
    |

--- a/tests/ui/diagnostic_namespace/on_unimplemented/do_not_accept_options_of_the_internal_rustc_attribute.stderr
+++ b/tests/ui/diagnostic_namespace/on_unimplemented/do_not_accept_options_of_the_internal_rustc_attribute.stderr
@@ -193,7 +193,11 @@ LL |     takes_bar(());
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `Bar` is implemented for `i32`
+help: the trait `Bar` is implemented for `i32`
+  --> $DIR/do_not_accept_options_of_the_internal_rustc_attribute.rs:28:1
+   |
+LL | impl Bar for i32 {}
+   | ^^^^^^^^^^^^^^^^
 note: required by a bound in `takes_bar`
   --> $DIR/do_not_accept_options_of_the_internal_rustc_attribute.rs:61:22
    |

--- a/tests/ui/did_you_mean/casting-fn-item-to-fn-pointer.stderr
+++ b/tests/ui/did_you_mean/casting-fn-item-to-fn-pointer.stderr
@@ -4,8 +4,9 @@ error[E0277]: a value of type `Vec<(&str, fn())>` cannot be built from an iterat
 LL |     let _: Vec<(&str, fn())> = [("foo", foo)].into_iter().collect();
    |                                                           ^^^^^^^ value of type `Vec<(&str, fn())>` cannot be built from `std::iter::Iterator<Item=(&str, fn() {foo})>`
    |
-   = help: the trait `FromIterator<(&_, fn() {foo})>` is not implemented for `Vec<(&str, fn())>`
-           but trait `FromIterator<(&_, fn())>` is implemented for it
+help: the trait `FromIterator<(&_, fn() {foo})>` is not implemented for `Vec<(&str, fn())>`
+      but trait `FromIterator<(&_, fn())>` is implemented for it
+  --> $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
    = help: for that trait implementation, expected `fn()`, found `fn() {foo}`
    = note: fn items are distinct from fn pointers
    = help: consider casting the fn item to a fn pointer: `foo as fn()`
@@ -25,8 +26,9 @@ error[E0277]: a value of type `Vec<fn()>` cannot be built from an iterator over 
 LL |     let _: Vec<fn()> = [foo].into_iter().collect();
    |                                          ^^^^^^^ value of type `Vec<fn()>` cannot be built from `std::iter::Iterator<Item=fn() {foo}>`
    |
-   = help: the trait `FromIterator<fn() {foo}>` is not implemented for `Vec<fn()>`
-           but trait `FromIterator<fn()>` is implemented for it
+help: the trait `FromIterator<fn() {foo}>` is not implemented for `Vec<fn()>`
+      but trait `FromIterator<fn()>` is implemented for it
+  --> $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
    = help: for that trait implementation, expected `fn()`, found `fn() {foo}`
    = note: fn items are distinct from fn pointers
    = help: consider casting the fn item to a fn pointer: `foo as fn()`

--- a/tests/ui/did_you_mean/issue-21659-show-relevant-trait-impls-1.stderr
+++ b/tests/ui/did_you_mean/issue-21659-show-relevant-trait-impls-1.stderr
@@ -11,9 +11,14 @@ help: the trait `Foo<usize>` is not implemented for `Bar`
    |
 LL | struct Bar;
    | ^^^^^^^^^^
-   = help: the following other types implement trait `Foo<A>`:
-             `Bar` implements `Foo<i32>`
-             `Bar` implements `Foo<u8>`
+help: the following other types implement trait `Foo<A>`
+  --> $DIR/issue-21659-show-relevant-trait-impls-1.rs:15:1
+   |
+LL | impl Foo<i32> for Bar {}
+   | ^^^^^^^^^^^^^^^^^^^^^ `Bar` implements `Foo<i32>`
+LL |
+LL | impl Foo<u8> for Bar {}
+   | ^^^^^^^^^^^^^^^^^^^^ `Bar` implements `Foo<u8>`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/did_you_mean/issue-39802-show-5-trait-impls.stderr
+++ b/tests/ui/did_you_mean/issue-39802-show-5-trait-impls.stderr
@@ -21,11 +21,17 @@ LL |     Foo::<i32>::bar(&1u8);
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the following other types implement trait `Foo<B>`:
-             `u8` implements `Foo<bool>`
-             `u8` implements `Foo<u16>`
-             `u8` implements `Foo<u32>`
-             `u8` implements `Foo<u64>`
+help: the following other types implement trait `Foo<B>`
+  --> $DIR/issue-39802-show-5-trait-impls.rs:11:1
+   |
+LL | impl Foo<u16> for u8 {}
+   | ^^^^^^^^^^^^^^^^^^^^ `u8` implements `Foo<u16>`
+LL | impl Foo<u32> for u8 {}
+   | ^^^^^^^^^^^^^^^^^^^^ `u8` implements `Foo<u32>`
+LL | impl Foo<u64> for u8 {}
+   | ^^^^^^^^^^^^^^^^^^^^ `u8` implements `Foo<u64>`
+LL | impl Foo<bool> for u8 {}
+   | ^^^^^^^^^^^^^^^^^^^^^ `u8` implements `Foo<bool>`
 
 error[E0277]: the trait bound `bool: Foo<i32>` is not satisfied
   --> $DIR/issue-39802-show-5-trait-impls.rs:26:21

--- a/tests/ui/dst/issue-90528-unsizing-not-suggestion-110063.stderr
+++ b/tests/ui/dst/issue-90528-unsizing-not-suggestion-110063.stderr
@@ -4,7 +4,11 @@ error[E0277]: the trait bound `[u8; 1]: Test` is not satisfied
 LL |     needs_test::<[u8; 1]>();
    |                  ^^^^^^^ the trait `Test` is not implemented for `[u8; 1]`
    |
-   = help: the trait `Test` is implemented for `&[u8]`
+help: the trait `Test` is implemented for `&[u8]`
+  --> $DIR/issue-90528-unsizing-not-suggestion-110063.rs:2:1
+   |
+LL | impl Test for &[u8] {}
+   | ^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `needs_test`
   --> $DIR/issue-90528-unsizing-not-suggestion-110063.rs:4:18
    |
@@ -17,7 +21,11 @@ error[E0277]: the trait bound `[u8; 1]: Test` is not satisfied
 LL |     let x: [u8; 1] = needs_test();
    |                      ^^^^^^^^^^^^ the trait `Test` is not implemented for `[u8; 1]`
    |
-   = help: the trait `Test` is implemented for `&[u8]`
+help: the trait `Test` is implemented for `&[u8]`
+  --> $DIR/issue-90528-unsizing-not-suggestion-110063.rs:2:1
+   |
+LL | impl Test for &[u8] {}
+   | ^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `needs_test`
   --> $DIR/issue-90528-unsizing-not-suggestion-110063.rs:4:18
    |

--- a/tests/ui/dst/issue-90528-unsizing-suggestion-1.stderr
+++ b/tests/ui/dst/issue-90528-unsizing-suggestion-1.stderr
@@ -6,7 +6,11 @@ LL |     wants_read([0u8]);
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `Read` is implemented for `&[u8]`
+help: the trait `Read` is implemented for `&[u8]`
+  --> $DIR/issue-90528-unsizing-suggestion-1.rs:8:1
+   |
+LL | impl Read for &[u8] {}
+   | ^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `wants_read`
   --> $DIR/issue-90528-unsizing-suggestion-1.rs:10:23
    |
@@ -25,7 +29,11 @@ LL |     wants_read(&[0u8]);
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `Read` is implemented for `&[u8]`
+help: the trait `Read` is implemented for `&[u8]`
+  --> $DIR/issue-90528-unsizing-suggestion-1.rs:8:1
+   |
+LL | impl Read for &[u8] {}
+   | ^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `wants_read`
   --> $DIR/issue-90528-unsizing-suggestion-1.rs:10:23
    |
@@ -44,7 +52,11 @@ LL |     wants_read(&mut [0u8]);
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `Read` is implemented for `&[u8]`
+help: the trait `Read` is implemented for `&[u8]`
+  --> $DIR/issue-90528-unsizing-suggestion-1.rs:8:1
+   |
+LL | impl Read for &[u8] {}
+   | ^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `wants_read`
   --> $DIR/issue-90528-unsizing-suggestion-1.rs:10:23
    |

--- a/tests/ui/dst/issue-90528-unsizing-suggestion-2.stderr
+++ b/tests/ui/dst/issue-90528-unsizing-suggestion-2.stderr
@@ -6,7 +6,11 @@ LL |     wants_read(x);
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `Read` is implemented for `&[u8]`
+help: the trait `Read` is implemented for `&[u8]`
+  --> $DIR/issue-90528-unsizing-suggestion-2.rs:8:1
+   |
+LL | impl Read for &[u8] {}
+   | ^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `wants_read`
   --> $DIR/issue-90528-unsizing-suggestion-2.rs:10:23
    |
@@ -25,7 +29,11 @@ LL |     wants_read(&x);
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `Read` is implemented for `&[u8]`
+help: the trait `Read` is implemented for `&[u8]`
+  --> $DIR/issue-90528-unsizing-suggestion-2.rs:8:1
+   |
+LL | impl Read for &[u8] {}
+   | ^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `wants_read`
   --> $DIR/issue-90528-unsizing-suggestion-2.rs:10:23
    |
@@ -44,7 +52,11 @@ LL |     wants_read(x);
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `Read` is implemented for `&[u8]`
+help: the trait `Read` is implemented for `&[u8]`
+  --> $DIR/issue-90528-unsizing-suggestion-2.rs:8:1
+   |
+LL | impl Read for &[u8] {}
+   | ^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `wants_read`
   --> $DIR/issue-90528-unsizing-suggestion-2.rs:10:23
    |
@@ -63,7 +75,11 @@ LL |     wants_read(&x);
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `Read` is implemented for `&[u8]`
+help: the trait `Read` is implemented for `&[u8]`
+  --> $DIR/issue-90528-unsizing-suggestion-2.rs:8:1
+   |
+LL | impl Read for &[u8] {}
+   | ^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `wants_read`
   --> $DIR/issue-90528-unsizing-suggestion-2.rs:10:23
    |
@@ -78,7 +94,11 @@ LL |     wants_read(*x);
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `Read` is implemented for `&[u8]`
+help: the trait `Read` is implemented for `&[u8]`
+  --> $DIR/issue-90528-unsizing-suggestion-2.rs:8:1
+   |
+LL | impl Read for &[u8] {}
+   | ^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `wants_read`
   --> $DIR/issue-90528-unsizing-suggestion-2.rs:10:23
    |

--- a/tests/ui/dst/issue-90528-unsizing-suggestion-3.stderr
+++ b/tests/ui/dst/issue-90528-unsizing-suggestion-3.stderr
@@ -6,7 +6,11 @@ LL |     wants_write([0u8]);
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `Write` is implemented for `&mut [u8]`
+help: the trait `Write` is implemented for `&mut [u8]`
+  --> $DIR/issue-90528-unsizing-suggestion-3.rs:8:1
+   |
+LL | impl Write for &mut [u8] {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `wants_write`
   --> $DIR/issue-90528-unsizing-suggestion-3.rs:10:24
    |
@@ -25,7 +29,11 @@ LL |     wants_write(&mut [0u8]);
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `Write` is implemented for `&mut [u8]`
+help: the trait `Write` is implemented for `&mut [u8]`
+  --> $DIR/issue-90528-unsizing-suggestion-3.rs:8:1
+   |
+LL | impl Write for &mut [u8] {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `wants_write`
   --> $DIR/issue-90528-unsizing-suggestion-3.rs:10:24
    |
@@ -44,7 +52,11 @@ LL |     wants_write(&[0u8]);
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `Write` is implemented for `&mut [u8]`
+help: the trait `Write` is implemented for `&mut [u8]`
+  --> $DIR/issue-90528-unsizing-suggestion-3.rs:8:1
+   |
+LL | impl Write for &mut [u8] {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `wants_write`
   --> $DIR/issue-90528-unsizing-suggestion-3.rs:10:24
    |
@@ -59,7 +71,11 @@ LL |     wants_write(&[0u8][..]);
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `Write` is implemented for `&mut [u8]`
+help: the trait `Write` is implemented for `&mut [u8]`
+  --> $DIR/issue-90528-unsizing-suggestion-3.rs:8:1
+   |
+LL | impl Write for &mut [u8] {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `wants_write`
   --> $DIR/issue-90528-unsizing-suggestion-3.rs:10:24
    |

--- a/tests/ui/dst/issue-90528-unsizing-suggestion-4.stderr
+++ b/tests/ui/dst/issue-90528-unsizing-suggestion-4.stderr
@@ -6,7 +6,11 @@ LL |     wants_write(x);
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `Write` is implemented for `&mut [u8]`
+help: the trait `Write` is implemented for `&mut [u8]`
+  --> $DIR/issue-90528-unsizing-suggestion-4.rs:8:1
+   |
+LL | impl Write for &mut [u8] {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `wants_write`
   --> $DIR/issue-90528-unsizing-suggestion-4.rs:10:24
    |
@@ -25,7 +29,11 @@ LL |     wants_write(&mut x);
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `Write` is implemented for `&mut [u8]`
+help: the trait `Write` is implemented for `&mut [u8]`
+  --> $DIR/issue-90528-unsizing-suggestion-4.rs:8:1
+   |
+LL | impl Write for &mut [u8] {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `wants_write`
   --> $DIR/issue-90528-unsizing-suggestion-4.rs:10:24
    |
@@ -44,7 +52,11 @@ LL |     wants_write(x);
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `Write` is implemented for `&mut [u8]`
+help: the trait `Write` is implemented for `&mut [u8]`
+  --> $DIR/issue-90528-unsizing-suggestion-4.rs:8:1
+   |
+LL | impl Write for &mut [u8] {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `wants_write`
   --> $DIR/issue-90528-unsizing-suggestion-4.rs:10:24
    |
@@ -63,7 +75,11 @@ LL |     wants_write(*x);
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `Write` is implemented for `&mut [u8]`
+help: the trait `Write` is implemented for `&mut [u8]`
+  --> $DIR/issue-90528-unsizing-suggestion-4.rs:8:1
+   |
+LL | impl Write for &mut [u8] {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `wants_write`
   --> $DIR/issue-90528-unsizing-suggestion-4.rs:10:24
    |

--- a/tests/ui/errors/trait-bound-error-spans/blame-trait-error.stderr
+++ b/tests/ui/errors/trait-bound-error-spans/blame-trait-error.stderr
@@ -39,7 +39,11 @@ LL |     want(Some(()));
    |     required by a bound introduced by this call
    |
    = help: the trait `Iterator` is not implemented for `()`
-   = help: the trait `T1` is implemented for `Option<It>`
+help: the trait `T1` is implemented for `Option<It>`
+  --> $DIR/blame-trait-error.rs:21:1
+   |
+LL | impl<It: Iterator> T1 for Option<It> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required for `Option<()>` to implement `T1`
   --> $DIR/blame-trait-error.rs:21:20
    |

--- a/tests/ui/feature-gates/feature-gate-trivial_bounds.stderr
+++ b/tests/ui/feature-gates/feature-gate-trivial_bounds.stderr
@@ -4,7 +4,11 @@ error[E0277]: the trait bound `i32: Foo` is not satisfied
 LL | enum E where i32: Foo { V }
    |              ^^^^^^^^ the trait `Foo` is not implemented for `i32`
    |
-   = help: the trait `Foo` is implemented for `()`
+help: the trait `Foo` is implemented for `()`
+  --> $DIR/feature-gate-trivial_bounds.rs:20:1
+   |
+LL | impl Foo for () where i32: Foo {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: see issue #48214
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    |
@@ -17,7 +21,11 @@ error[E0277]: the trait bound `i32: Foo` is not satisfied
 LL | struct S where i32: Foo;
    |                ^^^^^^^^ the trait `Foo` is not implemented for `i32`
    |
-   = help: the trait `Foo` is implemented for `()`
+help: the trait `Foo` is implemented for `()`
+  --> $DIR/feature-gate-trivial_bounds.rs:20:1
+   |
+LL | impl Foo for () where i32: Foo {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: see issue #48214
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    |
@@ -30,7 +38,11 @@ error[E0277]: the trait bound `i32: Foo` is not satisfied
 LL | trait T where i32: Foo {}
    |               ^^^^^^^^ the trait `Foo` is not implemented for `i32`
    |
-   = help: the trait `Foo` is implemented for `()`
+help: the trait `Foo` is implemented for `()`
+  --> $DIR/feature-gate-trivial_bounds.rs:20:1
+   |
+LL | impl Foo for () where i32: Foo {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: see issue #48214
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    |
@@ -43,7 +55,11 @@ error[E0277]: the trait bound `i32: Foo` is not satisfied
 LL | union U where i32: Foo { f: i32 }
    |               ^^^^^^^^ the trait `Foo` is not implemented for `i32`
    |
-   = help: the trait `Foo` is implemented for `()`
+help: the trait `Foo` is implemented for `()`
+  --> $DIR/feature-gate-trivial_bounds.rs:20:1
+   |
+LL | impl Foo for () where i32: Foo {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: see issue #48214
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    |
@@ -56,7 +72,11 @@ error[E0277]: the trait bound `i32: Foo` is not satisfied
 LL | impl Foo for () where i32: Foo {
    |                       ^^^^^^^^ the trait `Foo` is not implemented for `i32`
    |
-   = help: the trait `Foo` is implemented for `()`
+help: the trait `Foo` is implemented for `()`
+  --> $DIR/feature-gate-trivial_bounds.rs:20:1
+   |
+LL | impl Foo for () where i32: Foo {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: see issue #48214
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    |
@@ -69,7 +89,11 @@ error[E0277]: the trait bound `i32: Foo` is not satisfied
 LL | fn f() where i32: Foo
    |              ^^^^^^^^ the trait `Foo` is not implemented for `i32`
    |
-   = help: the trait `Foo` is implemented for `()`
+help: the trait `Foo` is implemented for `()`
+  --> $DIR/feature-gate-trivial_bounds.rs:20:1
+   |
+LL | impl Foo for () where i32: Foo {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: see issue #48214
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    |

--- a/tests/ui/generic-associated-types/bugs/issue-88382.stderr
+++ b/tests/ui/generic-associated-types/bugs/issue-88382.stderr
@@ -5,7 +5,11 @@ LL |     do_something(SomeImplementation(), test);
    |                                        ^^^^ cannot infer type of the type parameter `I` declared on the function `test`
    |
    = note: cannot satisfy `_: Iterable`
-   = help: the trait `Iterable` is implemented for `SomeImplementation`
+help: the trait `Iterable` is implemented for `SomeImplementation`
+  --> $DIR/issue-88382.rs:13:1
+   |
+LL | impl Iterable for SomeImplementation {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `test`
   --> $DIR/issue-88382.rs:29:16
    |

--- a/tests/ui/generic-associated-types/type-param-defaults.stderr
+++ b/tests/ui/generic-associated-types/type-param-defaults.stderr
@@ -42,7 +42,11 @@ error[E0277]: the trait bound `u64: Other` is not satisfied
 LL |     foo::<()>();
    |           ^^ the trait `Other` is not implemented for `u64`
    |
-   = help: the trait `Other` is implemented for `u32`
+help: the trait `Other` is implemented for `u32`
+  --> $DIR/type-param-defaults.rs:21:1
+   |
+LL | impl Other for u32 {}
+   | ^^^^^^^^^^^^^^^^^^
 note: required by a bound in `foo`
   --> $DIR/type-param-defaults.rs:26:15
    |

--- a/tests/ui/generic-const-items/unsatisfied-bounds.stderr
+++ b/tests/ui/generic-const-items/unsatisfied-bounds.stderr
@@ -16,8 +16,9 @@ error[E0277]: the trait bound `Infallible: From<()>` is not satisfied
 LL |     let () = K::<()>;
    |                  ^^ the trait `From<()>` is not implemented for `Infallible`
    |
-   = help: the trait `From<()>` is not implemented for `Infallible`
-           but trait `From<!>` is implemented for it
+help: the trait `From<()>` is not implemented for `Infallible`
+      but trait `From<!>` is implemented for it
+  --> $SRC_DIR/core/src/convert/mod.rs:LL:COL
    = help: for that trait implementation, expected `!`, found `()`
 note: required by a bound in `K`
   --> $DIR/unsatisfied-bounds.rs:12:17
@@ -49,8 +50,9 @@ error[E0277]: the trait bound `Infallible: From<()>` is not satisfied
 LL |     let _ = <() as Trait<&'static str>>::B::<()>;
    |                                              ^^ the trait `From<()>` is not implemented for `Infallible`
    |
-   = help: the trait `From<()>` is not implemented for `Infallible`
-           but trait `From<!>` is implemented for it
+help: the trait `From<()>` is not implemented for `Infallible`
+      but trait `From<!>` is implemented for it
+  --> $SRC_DIR/core/src/convert/mod.rs:LL:COL
    = help: for that trait implementation, expected `!`, found `()`
 note: required by a bound in `Trait::B`
   --> $DIR/unsatisfied-bounds.rs:21:21

--- a/tests/ui/impl-trait/diagnostics/highlight-difference-between-expected-trait-and-found-trait.svg
+++ b/tests/ui/impl-trait/diagnostics/highlight-difference-between-expected-trait-and-found-trait.svg
@@ -1,8 +1,9 @@
-<svg width="1096px" height="398px" xmlns="http://www.w3.org/2000/svg">
+<svg width="1188px" height="470px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
     .fg-bright-blue { fill: #5555FF }
+    .fg-bright-cyan { fill: #55FFFF }
     .fg-bright-green { fill: #55FF55 }
     .fg-bright-red { fill: #FF5555 }
     .fg-magenta { fill: #AA00AA }
@@ -37,31 +38,39 @@
 </tspan>
     <tspan x="10px" y="154px"><tspan>   </tspan><tspan class="fg-bright-blue bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>   </tspan><tspan class="fg-bright-blue bold">= </tspan><tspan class="bold">help</tspan><tspan>: the trait `Bar&lt;</tspan><tspan class="fg-magenta bold">i32</tspan><tspan>&gt;` </tspan><tspan class="fg-magenta bold">is not</tspan><tspan> implemented for `Struct`</tspan>
+    <tspan x="10px" y="172px"><tspan class="fg-bright-cyan bold">help</tspan><tspan>: the trait `Bar&lt;</tspan><tspan class="fg-magenta bold">i32</tspan><tspan>&gt;` </tspan><tspan class="fg-magenta bold">is not</tspan><tspan> implemented for `Struct`</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>           but trait `Bar&lt;</tspan><tspan class="fg-magenta bold">()</tspan><tspan>&gt;` </tspan><tspan class="fg-magenta bold">is</tspan><tspan> implemented for it</tspan>
+    <tspan x="10px" y="190px"><tspan>      but trait `Bar&lt;</tspan><tspan class="fg-magenta bold">()</tspan><tspan>&gt;` </tspan><tspan class="fg-magenta bold">is</tspan><tspan> implemented for it</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>   </tspan><tspan class="fg-bright-blue bold">= </tspan><tspan class="bold">help</tspan><tspan>: for that trait implementation, expected `</tspan><tspan class="fg-magenta bold">()</tspan><tspan>`, found `</tspan><tspan class="fg-magenta bold">i32</tspan><tspan>`</tspan>
+    <tspan x="10px" y="208px"><tspan>  </tspan><tspan class="fg-bright-blue bold">--&gt; </tspan><tspan>$DIR/highlight-difference-between-expected-trait-and-found-trait.rs:13:1</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan class="fg-bright-green bold">note</tspan><tspan>: required for `Struct` to implement `Foo&lt;i32&gt;`</tspan>
+    <tspan x="10px" y="226px"><tspan>   </tspan><tspan class="fg-bright-blue bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan>  </tspan><tspan class="fg-bright-blue bold">--&gt; </tspan><tspan>$DIR/highlight-difference-between-expected-trait-and-found-trait.rs:10:12</tspan>
+    <tspan x="10px" y="244px"><tspan class="fg-bright-blue bold">LL</tspan><tspan> </tspan><tspan class="fg-bright-blue bold">|</tspan><tspan> impl&lt;'a&gt; Bar&lt;()&gt; for Struct {}</tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>   </tspan><tspan class="fg-bright-blue bold">|</tspan>
+    <tspan x="10px" y="262px"><tspan>   </tspan><tspan class="fg-bright-blue bold">|</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">^^^^^^^^^^^^^^^^^^^^^^^^^^^</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan class="fg-bright-blue bold">LL</tspan><tspan> </tspan><tspan class="fg-bright-blue bold">|</tspan><tspan> impl&lt;T, K&gt; Foo&lt;K&gt; for T where T: Bar&lt;K&gt;</tspan>
+    <tspan x="10px" y="280px"><tspan>   </tspan><tspan class="fg-bright-blue bold">= </tspan><tspan class="bold">help</tspan><tspan>: for that trait implementation, expected `</tspan><tspan class="fg-magenta bold">()</tspan><tspan>`, found `</tspan><tspan class="fg-magenta bold">i32</tspan><tspan>`</tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan>   </tspan><tspan class="fg-bright-blue bold">|</tspan><tspan>            </tspan><tspan class="fg-bright-green bold">^^^^^^</tspan><tspan>     </tspan><tspan class="fg-bright-green bold">^</tspan><tspan>          </tspan><tspan class="fg-bright-blue bold">------</tspan><tspan> </tspan><tspan class="fg-bright-blue bold">unsatisfied trait bound introduced here</tspan>
+    <tspan x="10px" y="298px"><tspan class="fg-bright-green bold">note</tspan><tspan>: required for `Struct` to implement `Foo&lt;i32&gt;`</tspan>
 </tspan>
-    <tspan x="10px" y="316px">
+    <tspan x="10px" y="316px"><tspan>  </tspan><tspan class="fg-bright-blue bold">--&gt; </tspan><tspan>$DIR/highlight-difference-between-expected-trait-and-found-trait.rs:10:12</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">: aborting due to 1 previous error</tspan>
+    <tspan x="10px" y="334px"><tspan>   </tspan><tspan class="fg-bright-blue bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="352px">
+    <tspan x="10px" y="352px"><tspan class="fg-bright-blue bold">LL</tspan><tspan> </tspan><tspan class="fg-bright-blue bold">|</tspan><tspan> impl&lt;T, K&gt; Foo&lt;K&gt; for T where T: Bar&lt;K&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="370px"><tspan class="bold">For more information about this error, try `rustc --explain E0277`.</tspan>
+    <tspan x="10px" y="370px"><tspan>   </tspan><tspan class="fg-bright-blue bold">|</tspan><tspan>            </tspan><tspan class="fg-bright-green bold">^^^^^^</tspan><tspan>     </tspan><tspan class="fg-bright-green bold">^</tspan><tspan>          </tspan><tspan class="fg-bright-blue bold">------</tspan><tspan> </tspan><tspan class="fg-bright-blue bold">unsatisfied trait bound introduced here</tspan>
 </tspan>
     <tspan x="10px" y="388px">
+</tspan>
+    <tspan x="10px" y="406px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">: aborting due to 1 previous error</tspan>
+</tspan>
+    <tspan x="10px" y="424px">
+</tspan>
+    <tspan x="10px" y="442px"><tspan class="bold">For more information about this error, try `rustc --explain E0277`.</tspan>
+</tspan>
+    <tspan x="10px" y="460px">
 </tspan>
   </text>
 

--- a/tests/ui/impl-trait/equality.stderr
+++ b/tests/ui/impl-trait/equality.stderr
@@ -30,11 +30,17 @@ LL |         n + sum_to(n - 1)
    |           ^ no implementation for `u32 + impl Foo`
    |
    = help: the trait `Add<impl Foo>` is not implemented for `u32`
-   = help: the following other types implement trait `Add<Rhs>`:
-             `&u32` implements `Add<u32>`
-             `&u32` implements `Add`
-             `u32` implements `Add<&u32>`
-             `u32` implements `Add`
+help: the following other types implement trait `Add<Rhs>`
+  --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
+   |
+   = note: `&u32` implements `Add<u32>`
+   |
+   = note: `&u32` implements `Add`
+   |
+   = note: `u32` implements `Add<&u32>`
+   |
+   = note: `u32` implements `Add`
+   = note: this error originates in the macro `add_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors; 1 warning emitted
 

--- a/tests/ui/impl-trait/in-bindings/trait-failure.stderr
+++ b/tests/ui/impl-trait/in-bindings/trait-failure.stderr
@@ -4,7 +4,11 @@ error[E0277]: the trait bound `(): Foo` is not satisfied
 LL |     let x: impl Foo = W(());
    |                 ^^^ the trait `Foo` is not implemented for `()`
    |
-   = help: the trait `Foo` is implemented for `W<T>`
+help: the trait `Foo` is implemented for `W<T>`
+  --> $DIR/trait-failure.rs:6:1
+   |
+LL | impl<T> Foo for W<T> where T: Foo {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required for `W<()>` to implement `Foo`
   --> $DIR/trait-failure.rs:6:9
    |
@@ -17,7 +21,11 @@ error[E0277]: the trait bound `(): Foo` is not satisfied
 LL |     let x: W<impl Foo> = W(());
    |                   ^^^ the trait `Foo` is not implemented for `()`
    |
-   = help: the trait `Foo` is implemented for `W<T>`
+help: the trait `Foo` is implemented for `W<T>`
+  --> $DIR/trait-failure.rs:6:1
+   |
+LL | impl<T> Foo for W<T> where T: Foo {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/impl-trait/in-trait/cycle-effective-visibilities-during-dyn-compatibility-check.stderr
+++ b/tests/ui/impl-trait/in-trait/cycle-effective-visibilities-during-dyn-compatibility-check.stderr
@@ -6,7 +6,11 @@ LL |         MyTrait::foo(&self)
    |         |
    |         required by a bound introduced by this call
    |
-   = help: the trait `MyTrait` is implemented for `Outer`
+help: the trait `MyTrait` is implemented for `Outer`
+  --> $DIR/cycle-effective-visibilities-during-dyn-compatibility-check.rs:10:1
+   |
+LL | impl MyTrait for Outer {
+   | ^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0038]: the trait `MyTrait` is not dyn compatible
   --> $DIR/cycle-effective-visibilities-during-dyn-compatibility-check.rs:20:9
@@ -31,7 +35,11 @@ error[E0277]: the trait bound `&dyn MyTrait: MyTrait` is not satisfied
 LL |         MyTrait::foo(&self)
    |         ^^^^^^^^^^^^^^^^^^^ the trait `MyTrait` is not implemented for `&dyn MyTrait`
    |
-   = help: the trait `MyTrait` is implemented for `Outer`
+help: the trait `MyTrait` is implemented for `Outer`
+  --> $DIR/cycle-effective-visibilities-during-dyn-compatibility-check.rs:10:1
+   |
+LL | impl MyTrait for Outer {
+   | ^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0038]: the trait `MyTrait` is not dyn compatible
   --> $DIR/cycle-effective-visibilities-during-dyn-compatibility-check.rs:16:6

--- a/tests/ui/impl-trait/in-trait/issue-102140.stderr
+++ b/tests/ui/impl-trait/in-trait/issue-102140.stderr
@@ -18,7 +18,11 @@ error[E0277]: the trait bound `&dyn MyTrait: MyTrait` is not satisfied
 LL |         MyTrait::foo(&self)
    |         ^^^^^^^^^^^^^^^^^^^ the trait `MyTrait` is not implemented for `&dyn MyTrait`
    |
-   = help: the trait `MyTrait` is implemented for `Outer`
+help: the trait `MyTrait` is implemented for `Outer`
+  --> $DIR/issue-102140.rs:12:1
+   |
+LL | impl MyTrait for Outer {
+   | ^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/impl-trait/in-trait/return-dont-satisfy-bounds.stderr
+++ b/tests/ui/impl-trait/in-trait/return-dont-satisfy-bounds.stderr
@@ -13,7 +13,11 @@ error[E0277]: the trait bound `impl Foo<u8>: Foo<char>` is not satisfied
 LL |     fn foo<F2: Foo<u8>>(self) -> impl Foo<u8> {
    |                                  ^^^^^^^^^^^^ the trait `Foo<char>` is not implemented for `impl Foo<u8>`
    |
-   = help: the trait `Foo<char>` is implemented for `Bar`
+help: the trait `Foo<char>` is implemented for `Bar`
+  --> $DIR/return-dont-satisfy-bounds.rs:7:1
+   |
+LL | impl Foo<char> for Bar {
+   | ^^^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `Foo::foo::{anon_assoc#0}`
   --> $DIR/return-dont-satisfy-bounds.rs:2:30
    |

--- a/tests/ui/impl-trait/in-trait/return-dont-satisfy-bounds.stderr
+++ b/tests/ui/impl-trait/in-trait/return-dont-satisfy-bounds.stderr
@@ -29,8 +29,12 @@ LL |     fn foo<F2: Foo<u8>>(self) -> impl Foo<u8> {
 LL |         self
    |         ---- return type was inferred to be `Bar` here
    |
-   = help: the trait `Foo<u8>` is not implemented for `Bar`
-           but trait `Foo<char>` is implemented for it
+help: the trait `Foo<u8>` is not implemented for `Bar`
+      but trait `Foo<char>` is implemented for it
+  --> $DIR/return-dont-satisfy-bounds.rs:7:1
+   |
+LL | impl Foo<char> for Bar {
+   | ^^^^^^^^^^^^^^^^^^^^^^
    = help: for that trait implementation, expected `char`, found `u8`
 
 error: aborting due to 3 previous errors

--- a/tests/ui/impl-trait/issues/issue-62742.stderr
+++ b/tests/ui/impl-trait/issues/issue-62742.stderr
@@ -4,8 +4,12 @@ error[E0277]: the trait bound `RawImpl<_>: Raw<_>` is not satisfied
 LL |     WrongImpl::foo(0i32);
    |     ^^^^^^^^^ unsatisfied trait bound
    |
-   = help: the trait `Raw<_>` is not implemented for `RawImpl<_>`
-           but trait `Raw<[_]>` is implemented for it
+help: the trait `Raw<_>` is not implemented for `RawImpl<_>`
+      but trait `Raw<[_]>` is implemented for it
+  --> $DIR/issue-62742.rs:29:1
+   |
+LL | impl<T> Raw<[T]> for RawImpl<T> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `SafeImpl`
   --> $DIR/issue-62742.rs:33:35
    |
@@ -43,8 +47,12 @@ error[E0277]: the trait bound `RawImpl<()>: Raw<()>` is not satisfied
 LL |     WrongImpl::<()>::foo(0i32);
    |     ^^^^^^^^^^^^^^^ unsatisfied trait bound
    |
-   = help: the trait `Raw<()>` is not implemented for `RawImpl<()>`
-           but trait `Raw<[()]>` is implemented for it
+help: the trait `Raw<()>` is not implemented for `RawImpl<()>`
+      but trait `Raw<[()]>` is implemented for it
+  --> $DIR/issue-62742.rs:29:1
+   |
+LL | impl<T> Raw<[T]> for RawImpl<T> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: for that trait implementation, expected `[()]`, found `()`
 note: required by a bound in `SafeImpl`
   --> $DIR/issue-62742.rs:33:35

--- a/tests/ui/impl-trait/nested-rpit-hrtb.stderr
+++ b/tests/ui/impl-trait/nested-rpit-hrtb.stderr
@@ -83,8 +83,12 @@ error[E0277]: the trait bound `for<'a> &'a (): Qux<'b>` is not satisfied
 LL | fn one_hrtb_mention_fn_trait_param_uses<'b>() -> impl for<'a> Bar<'a, Assoc = impl Qux<'b>> {}
    |                                                                               ^^^^^^^^^^^^ the trait `for<'a> Qux<'b>` is not implemented for `&'a ()`
    |
-   = help: the trait `Qux<'b>` is not implemented for `&'a ()`
-           but trait `Qux<'_>` is implemented for `()`
+help: the trait `Qux<'b>` is not implemented for `&'a ()`
+      but trait `Qux<'_>` is implemented for `()`
+  --> $DIR/nested-rpit-hrtb.rs:22:1
+   |
+LL | impl Qux<'_> for () {}
+   | ^^^^^^^^^^^^^^^^^^^
    = help: for that trait implementation, expected `()`, found `&'a ()`
 
 error: implementation of `Bar` is not general enough
@@ -102,8 +106,12 @@ error[E0277]: the trait bound `for<'a, 'b> &'a (): Qux<'b>` is not satisfied
 LL | fn two_htrb_trait_param_uses() -> impl for<'a> Bar<'a, Assoc = impl for<'b> Qux<'b>> {}
    |                                                                ^^^^^^^^^^^^^^^^^^^^ the trait `for<'a, 'b> Qux<'b>` is not implemented for `&'a ()`
    |
-   = help: the trait `Qux<'b>` is not implemented for `&'a ()`
-           but trait `Qux<'_>` is implemented for `()`
+help: the trait `Qux<'b>` is not implemented for `&'a ()`
+      but trait `Qux<'_>` is implemented for `()`
+  --> $DIR/nested-rpit-hrtb.rs:22:1
+   |
+LL | impl Qux<'_> for () {}
+   | ^^^^^^^^^^^^^^^^^^^
    = help: for that trait implementation, expected `()`, found `&'a ()`
 
 error: aborting due to 9 previous errors

--- a/tests/ui/impl-trait/nested_impl_trait.stderr
+++ b/tests/ui/impl-trait/nested_impl_trait.stderr
@@ -50,7 +50,8 @@ LL | fn bad_in_ret_position(x: impl Into<u32>) -> impl Into<impl Debug> { x }
    |                                              |
    |                                              the trait `From<impl Into<u32>>` is not implemented for `impl Debug`
    |
-   = help: the trait `Into<U>` is implemented for `T`
+help: the trait `Into<U>` is implemented for `T`
+  --> $SRC_DIR/core/src/convert/mod.rs:LL:COL
    = note: required for `impl Into<u32>` to implement `Into<impl Debug>`
 
 error[E0277]: the trait bound `impl Debug: From<impl Into<u32>>` is not satisfied
@@ -61,7 +62,8 @@ LL |     fn bad(x: impl Into<u32>) -> impl Into<impl Debug> { x }
    |                                  |
    |                                  the trait `From<impl Into<u32>>` is not implemented for `impl Debug`
    |
-   = help: the trait `Into<U>` is implemented for `T`
+help: the trait `Into<U>` is implemented for `T`
+  --> $SRC_DIR/core/src/convert/mod.rs:LL:COL
    = note: required for `impl Into<u32>` to implement `Into<impl Debug>`
 
 error: aborting due to 7 previous errors

--- a/tests/ui/impl-trait/non-defining-uses/avoid-inference-constraints-from-blanket-3.stderr
+++ b/tests/ui/impl-trait/non-defining-uses/avoid-inference-constraints-from-blanket-3.stderr
@@ -4,8 +4,12 @@ error[E0277]: the trait bound `String: Trait<u32>` is not satisfied
 LL |     impls_trait(x);
    |     ^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `String`
    |
-   = help: the trait `Trait<u32>` is not implemented for `String`
-           but trait `Trait<u64>` is implemented for it
+help: the trait `Trait<u32>` is not implemented for `String`
+      but trait `Trait<u64>` is implemented for it
+  --> $DIR/avoid-inference-constraints-from-blanket-3.rs:17:1
+   |
+LL | impl Trait<u64> for String {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: for that trait implementation, expected `u64`, found `u32`
 note: required for `String` to implement `Trait<u32>`
   --> $DIR/avoid-inference-constraints-from-blanket-3.rs:16:15

--- a/tests/ui/impl-trait/recursive-type-alias-impl-trait-declaration.stderr
+++ b/tests/ui/impl-trait/recursive-type-alias-impl-trait-declaration.stderr
@@ -12,7 +12,11 @@ help: the trait `PartialEq<(Foo, i32)>` is not implemented for `Bar`
    |
 LL | struct Bar;
    | ^^^^^^^^^^
-   = help: the trait `PartialEq<(Bar, i32)>` is implemented for `Bar`
+help: the trait `PartialEq<(Bar, i32)>` is implemented for `Bar`
+  --> $DIR/recursive-type-alias-impl-trait-declaration.rs:7:1
+   |
+LL | impl PartialEq<(Bar, i32)> for Bar {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/impl-trait/unsized_coercion3.next.stderr
+++ b/tests/ui/impl-trait/unsized_coercion3.next.stderr
@@ -4,7 +4,11 @@ error[E0277]: the trait bound `dyn Send: Trait` is not satisfied
 LL |         let x = hello();
    |                 ^^^^^^^ the trait `Trait` is not implemented for `dyn Send`
    |
-   = help: the trait `Trait` is implemented for `u32`
+help: the trait `Trait` is implemented for `u32`
+  --> $DIR/unsized_coercion3.rs:9:1
+   |
+LL | impl Trait for u32 {}
+   | ^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/indexing/index-help.stderr
+++ b/tests/ui/indexing/index-help.stderr
@@ -5,9 +5,13 @@ LL |     x[0i32];
    |       ^^^^ slice indices are of type `usize` or ranges of `usize`
    |
    = help: the trait `SliceIndex<[{integer}]>` is not implemented for `i32`
-   = help: the following other types implement trait `SliceIndex<T>`:
-             `usize` implements `SliceIndex<ByteStr>`
-             `usize` implements `SliceIndex<[T]>`
+help: the following other types implement trait `SliceIndex<T>`
+  --> $SRC_DIR/core/src/slice/index.rs:LL:COL
+   |
+   = note: `usize` implements `SliceIndex<[T]>`
+  --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
+   |
+   = note: `usize` implements `SliceIndex<ByteStr>`
    = note: required for `Vec<{integer}>` to implement `Index<i32>`
 
 error: aborting due to 1 previous error

--- a/tests/ui/indexing/indexing-integral-types.stderr
+++ b/tests/ui/indexing/indexing-integral-types.stderr
@@ -5,9 +5,13 @@ LL |     v[3u8];
    |       ^^^ slice indices are of type `usize` or ranges of `usize`
    |
    = help: the trait `SliceIndex<[isize]>` is not implemented for `u8`
-   = help: the following other types implement trait `SliceIndex<T>`:
-             `usize` implements `SliceIndex<ByteStr>`
-             `usize` implements `SliceIndex<[T]>`
+help: the following other types implement trait `SliceIndex<T>`
+  --> $SRC_DIR/core/src/slice/index.rs:LL:COL
+   |
+   = note: `usize` implements `SliceIndex<[T]>`
+  --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
+   |
+   = note: `usize` implements `SliceIndex<ByteStr>`
    = note: required for `Vec<isize>` to implement `Index<u8>`
 
 error[E0277]: the type `[isize]` cannot be indexed by `i8`
@@ -17,9 +21,13 @@ LL |     v[3i8];
    |       ^^^ slice indices are of type `usize` or ranges of `usize`
    |
    = help: the trait `SliceIndex<[isize]>` is not implemented for `i8`
-   = help: the following other types implement trait `SliceIndex<T>`:
-             `usize` implements `SliceIndex<ByteStr>`
-             `usize` implements `SliceIndex<[T]>`
+help: the following other types implement trait `SliceIndex<T>`
+  --> $SRC_DIR/core/src/slice/index.rs:LL:COL
+   |
+   = note: `usize` implements `SliceIndex<[T]>`
+  --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
+   |
+   = note: `usize` implements `SliceIndex<ByteStr>`
    = note: required for `Vec<isize>` to implement `Index<i8>`
 
 error[E0277]: the type `[isize]` cannot be indexed by `u32`
@@ -29,9 +37,13 @@ LL |     v[3u32];
    |       ^^^^ slice indices are of type `usize` or ranges of `usize`
    |
    = help: the trait `SliceIndex<[isize]>` is not implemented for `u32`
-   = help: the following other types implement trait `SliceIndex<T>`:
-             `usize` implements `SliceIndex<ByteStr>`
-             `usize` implements `SliceIndex<[T]>`
+help: the following other types implement trait `SliceIndex<T>`
+  --> $SRC_DIR/core/src/slice/index.rs:LL:COL
+   |
+   = note: `usize` implements `SliceIndex<[T]>`
+  --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
+   |
+   = note: `usize` implements `SliceIndex<ByteStr>`
    = note: required for `Vec<isize>` to implement `Index<u32>`
 
 error[E0277]: the type `[isize]` cannot be indexed by `i32`
@@ -41,9 +53,13 @@ LL |     v[3i32];
    |       ^^^^ slice indices are of type `usize` or ranges of `usize`
    |
    = help: the trait `SliceIndex<[isize]>` is not implemented for `i32`
-   = help: the following other types implement trait `SliceIndex<T>`:
-             `usize` implements `SliceIndex<ByteStr>`
-             `usize` implements `SliceIndex<[T]>`
+help: the following other types implement trait `SliceIndex<T>`
+  --> $SRC_DIR/core/src/slice/index.rs:LL:COL
+   |
+   = note: `usize` implements `SliceIndex<[T]>`
+  --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
+   |
+   = note: `usize` implements `SliceIndex<ByteStr>`
    = note: required for `Vec<isize>` to implement `Index<i32>`
 
 error[E0277]: the type `[u8]` cannot be indexed by `u8`
@@ -53,9 +69,13 @@ LL |     s.as_bytes()[3u8];
    |                  ^^^ slice indices are of type `usize` or ranges of `usize`
    |
    = help: the trait `SliceIndex<[u8]>` is not implemented for `u8`
-   = help: the following other types implement trait `SliceIndex<T>`:
-             `usize` implements `SliceIndex<ByteStr>`
-             `usize` implements `SliceIndex<[T]>`
+help: the following other types implement trait `SliceIndex<T>`
+  --> $SRC_DIR/core/src/slice/index.rs:LL:COL
+   |
+   = note: `usize` implements `SliceIndex<[T]>`
+  --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
+   |
+   = note: `usize` implements `SliceIndex<ByteStr>`
    = note: required for `[u8]` to implement `Index<u8>`
 
 error[E0277]: the type `[u8]` cannot be indexed by `i8`
@@ -65,9 +85,13 @@ LL |     s.as_bytes()[3i8];
    |                  ^^^ slice indices are of type `usize` or ranges of `usize`
    |
    = help: the trait `SliceIndex<[u8]>` is not implemented for `i8`
-   = help: the following other types implement trait `SliceIndex<T>`:
-             `usize` implements `SliceIndex<ByteStr>`
-             `usize` implements `SliceIndex<[T]>`
+help: the following other types implement trait `SliceIndex<T>`
+  --> $SRC_DIR/core/src/slice/index.rs:LL:COL
+   |
+   = note: `usize` implements `SliceIndex<[T]>`
+  --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
+   |
+   = note: `usize` implements `SliceIndex<ByteStr>`
    = note: required for `[u8]` to implement `Index<i8>`
 
 error[E0277]: the type `[u8]` cannot be indexed by `u32`
@@ -77,9 +101,13 @@ LL |     s.as_bytes()[3u32];
    |                  ^^^^ slice indices are of type `usize` or ranges of `usize`
    |
    = help: the trait `SliceIndex<[u8]>` is not implemented for `u32`
-   = help: the following other types implement trait `SliceIndex<T>`:
-             `usize` implements `SliceIndex<ByteStr>`
-             `usize` implements `SliceIndex<[T]>`
+help: the following other types implement trait `SliceIndex<T>`
+  --> $SRC_DIR/core/src/slice/index.rs:LL:COL
+   |
+   = note: `usize` implements `SliceIndex<[T]>`
+  --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
+   |
+   = note: `usize` implements `SliceIndex<ByteStr>`
    = note: required for `[u8]` to implement `Index<u32>`
 
 error[E0277]: the type `[u8]` cannot be indexed by `i32`
@@ -89,9 +117,13 @@ LL |     s.as_bytes()[3i32];
    |                  ^^^^ slice indices are of type `usize` or ranges of `usize`
    |
    = help: the trait `SliceIndex<[u8]>` is not implemented for `i32`
-   = help: the following other types implement trait `SliceIndex<T>`:
-             `usize` implements `SliceIndex<ByteStr>`
-             `usize` implements `SliceIndex<[T]>`
+help: the following other types implement trait `SliceIndex<T>`
+  --> $SRC_DIR/core/src/slice/index.rs:LL:COL
+   |
+   = note: `usize` implements `SliceIndex<[T]>`
+  --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
+   |
+   = note: `usize` implements `SliceIndex<ByteStr>`
    = note: required for `[u8]` to implement `Index<i32>`
 
 error: aborting due to 8 previous errors

--- a/tests/ui/indexing/indexing-requires-a-uint.stderr
+++ b/tests/ui/indexing/indexing-requires-a-uint.stderr
@@ -5,9 +5,13 @@ LL |     [0][0u8];
    |         ^^^ slice indices are of type `usize` or ranges of `usize`
    |
    = help: the trait `SliceIndex<[{integer}]>` is not implemented for `u8`
-   = help: the following other types implement trait `SliceIndex<T>`:
-             `usize` implements `SliceIndex<ByteStr>`
-             `usize` implements `SliceIndex<[T]>`
+help: the following other types implement trait `SliceIndex<T>`
+  --> $SRC_DIR/core/src/slice/index.rs:LL:COL
+   |
+   = note: `usize` implements `SliceIndex<[T]>`
+  --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
+   |
+   = note: `usize` implements `SliceIndex<ByteStr>`
    = note: required for `[{integer}]` to implement `Index<u8>`
    = note: 1 redundant requirement hidden
    = note: required for `[{integer}; 1]` to implement `Index<u8>`

--- a/tests/ui/indexing/point-at-index-for-obligation-failure.stderr
+++ b/tests/ui/indexing/point-at-index-for-obligation-failure.stderr
@@ -4,8 +4,9 @@ error[E0277]: the trait bound `String: Borrow<&str>` is not satisfied
 LL |         &s
    |         ^^ the trait `Borrow<&str>` is not implemented for `String`
    |
-   = help: the trait `Borrow<&_>` is not implemented for `String`
-           but trait `Borrow<_>` is implemented for it
+help: the trait `Borrow<&_>` is not implemented for `String`
+      but trait `Borrow<_>` is implemented for it
+  --> $SRC_DIR/alloc/src/str.rs:LL:COL
    = help: for that trait implementation, expected `str`, found `&str`
    = note: required for `HashMap<String, String>` to implement `Index<&&str>`
 

--- a/tests/ui/issues/issue-34334.stderr
+++ b/tests/ui/issues/issue-34334.stderr
@@ -17,8 +17,9 @@ error[E0277]: a value of type `Vec<(u32, _, _)>` cannot be built from an iterato
 LL |     let sr2: Vec<(u32, _, _)> = sr.iter().map(|(faction, th_sender, th_receiver)| {}).collect();
    |                                                                                       ^^^^^^^ value of type `Vec<(u32, _, _)>` cannot be built from `std::iter::Iterator<Item=()>`
    |
-   = help: the trait `FromIterator<()>` is not implemented for `Vec<(u32, _, _)>`
-           but trait `FromIterator<(u32, _, _)>` is implemented for it
+help: the trait `FromIterator<()>` is not implemented for `Vec<(u32, _, _)>`
+      but trait `FromIterator<(u32, _, _)>` is implemented for it
+  --> $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
    = help: for that trait implementation, expected `(u32, _, _)`, found `()`
 note: the method call chain might not have had the expected associated types
   --> $DIR/issue-34334.rs:5:43

--- a/tests/ui/issues/issue-45801.stderr
+++ b/tests/ui/issues/issue-45801.stderr
@@ -4,8 +4,12 @@ error[E0277]: the trait bound `Params: Plugin<i32>` is not satisfied
 LL |     req.get_ref::<Params>();
    |         ^^^^^^^ unsatisfied trait bound
    |
-   = help: the trait `Plugin<i32>` is not implemented for `Params`
-           but trait `Plugin<Foo>` is implemented for it
+help: the trait `Plugin<i32>` is not implemented for `Params`
+      but trait `Plugin<Foo>` is implemented for it
+  --> $DIR/issue-45801.rs:14:1
+   |
+LL | impl Plugin<Foo> for Params {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: for that trait implementation, expected `Foo`, found `i32`
 
 error: aborting due to 1 previous error

--- a/tests/ui/iterators/invalid-iterator-chain-fixable.stderr
+++ b/tests/ui/iterators/invalid-iterator-chain-fixable.stderr
@@ -33,9 +33,12 @@ LL |     println!("{}", scores.sum::<i32>());
    |                           required by a bound introduced by this call
    |
    = help: the trait `Sum<()>` is not implemented for `i32`
-   = help: the following other types implement trait `Sum<A>`:
-             `i32` implements `Sum<&i32>`
-             `i32` implements `Sum`
+help: the following other types implement trait `Sum<A>`
+  --> $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
+   |
+   = note: `i32` implements `Sum<&i32>`
+   |
+   = note: `i32` implements `Sum`
 note: the method call chain might not have had the expected associated types
   --> $DIR/invalid-iterator-chain-fixable.rs:14:10
    |
@@ -51,6 +54,7 @@ LL | |         });
    | |__________^ `Iterator::Item` changed to `()` here
 note: required by a bound in `std::iter::Iterator::sum`
   --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
+   = note: this error originates in the macro `integer_sum_product` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider removing this semicolon
    |
 LL -             a + b;
@@ -66,9 +70,12 @@ LL |             .sum::<i32>(),
    |              required by a bound introduced by this call
    |
    = help: the trait `Sum<()>` is not implemented for `i32`
-   = help: the following other types implement trait `Sum<A>`:
-             `i32` implements `Sum<&i32>`
-             `i32` implements `Sum`
+help: the following other types implement trait `Sum<A>`
+  --> $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
+   |
+   = note: `i32` implements `Sum<&i32>`
+   |
+   = note: `i32` implements `Sum`
 note: the method call chain might not have had the expected associated types
   --> $DIR/invalid-iterator-chain-fixable.rs:23:14
    |
@@ -84,6 +91,7 @@ LL |             .map(|x| { x })
    |              -------------- `Iterator::Item` remains `()` here
 note: required by a bound in `std::iter::Iterator::sum`
   --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
+   = note: this error originates in the macro `integer_sum_product` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider removing this semicolon
    |
 LL -             .map(|x| { x; })
@@ -99,9 +107,12 @@ LL |     println!("{}", vec![0, 1].iter().map(|x| { x; }).sum::<i32>());
    |                                                      required by a bound introduced by this call
    |
    = help: the trait `Sum<()>` is not implemented for `i32`
-   = help: the following other types implement trait `Sum<A>`:
-             `i32` implements `Sum<&i32>`
-             `i32` implements `Sum`
+help: the following other types implement trait `Sum<A>`
+  --> $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
+   |
+   = note: `i32` implements `Sum<&i32>`
+   |
+   = note: `i32` implements `Sum`
 note: the method call chain might not have had the expected associated types
   --> $DIR/invalid-iterator-chain-fixable.rs:27:38
    |
@@ -112,6 +123,7 @@ LL |     println!("{}", vec![0, 1].iter().map(|x| { x; }).sum::<i32>());
    |                    this expression has type `Vec<{integer}>`
 note: required by a bound in `std::iter::Iterator::sum`
   --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
+   = note: this error originates in the macro `integer_sum_product` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider removing this semicolon
    |
 LL -     println!("{}", vec![0, 1].iter().map(|x| { x; }).sum::<i32>());

--- a/tests/ui/iterators/invalid-iterator-chain-fixable.stderr
+++ b/tests/ui/iterators/invalid-iterator-chain-fixable.stderr
@@ -6,8 +6,9 @@ LL |     let i = i.map(|x| x.clone());
 LL |     i.collect()
    |       ^^^^^^^ value of type `Vec<X>` cannot be built from `std::iter::Iterator<Item=&X>`
    |
-   = help: the trait `FromIterator<&_>` is not implemented for `Vec<X>`
-           but trait `FromIterator<_>` is implemented for it
+help: the trait `FromIterator<&_>` is not implemented for `Vec<X>`
+      but trait `FromIterator<_>` is implemented for it
+  --> $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
    = help: for that trait implementation, expected `X`, found `&X`
 note: the method call chain might not have had the expected associated types
   --> $DIR/invalid-iterator-chain-fixable.rs:5:26
@@ -123,8 +124,9 @@ error[E0277]: a value of type `Vec<i32>` cannot be built from an iterator over e
 LL |     let g: Vec<i32> = f.collect();
    |                         ^^^^^^^ value of type `Vec<i32>` cannot be built from `std::iter::Iterator<Item=()>`
    |
-   = help: the trait `FromIterator<()>` is not implemented for `Vec<i32>`
-           but trait `FromIterator<i32>` is implemented for it
+help: the trait `FromIterator<()>` is not implemented for `Vec<i32>`
+      but trait `FromIterator<i32>` is implemented for it
+  --> $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
    = help: for that trait implementation, expected `i32`, found `()`
 note: the method call chain might not have had the expected associated types
   --> $DIR/invalid-iterator-chain-fixable.rs:32:15

--- a/tests/ui/iterators/invalid-iterator-chain-with-int-infer.stderr
+++ b/tests/ui/iterators/invalid-iterator-chain-with-int-infer.stderr
@@ -7,9 +7,12 @@ LL |     let x = Some(()).iter().map(|()| 1).sum::<f32>();
    |                                         required by a bound introduced by this call
    |
    = help: the trait `Sum<{integer}>` is not implemented for `f32`
-   = help: the following other types implement trait `Sum<A>`:
-             `f32` implements `Sum<&f32>`
-             `f32` implements `Sum`
+help: the following other types implement trait `Sum<A>`
+  --> $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
+   |
+   = note: `f32` implements `Sum<&f32>`
+   |
+   = note: `f32` implements `Sum`
 note: the method call chain might not have had the expected associated types
   --> $DIR/invalid-iterator-chain-with-int-infer.rs:2:29
    |
@@ -20,6 +23,7 @@ LL |     let x = Some(()).iter().map(|()| 1).sum::<f32>();
    |             this expression has type `Option<()>`
 note: required by a bound in `std::iter::Iterator::sum`
   --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
+   = note: this error originates in the macro `float_sum_product` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/iterators/invalid-iterator-chain.stderr
+++ b/tests/ui/iterators/invalid-iterator-chain.stderr
@@ -6,8 +6,9 @@ LL |     let i = i.map(|x| x.clone());
 LL |     i.collect()
    |       ^^^^^^^ value of type `Vec<X>` cannot be built from `std::iter::Iterator<Item=&X>`
    |
-   = help: the trait `FromIterator<&_>` is not implemented for `Vec<X>`
-           but trait `FromIterator<_>` is implemented for it
+help: the trait `FromIterator<&_>` is not implemented for `Vec<X>`
+      but trait `FromIterator<_>` is implemented for it
+  --> $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
    = help: for that trait implementation, expected `X`, found `&X`
 note: the method call chain might not have had the expected associated types
   --> $DIR/invalid-iterator-chain.rs:4:26
@@ -180,8 +181,9 @@ error[E0277]: a value of type `Vec<i32>` cannot be built from an iterator over e
 LL |     let g: Vec<i32> = f.collect();
    |                         ^^^^^^^ value of type `Vec<i32>` cannot be built from `std::iter::Iterator<Item=()>`
    |
-   = help: the trait `FromIterator<()>` is not implemented for `Vec<i32>`
-           but trait `FromIterator<i32>` is implemented for it
+help: the trait `FromIterator<()>` is not implemented for `Vec<i32>`
+      but trait `FromIterator<i32>` is implemented for it
+  --> $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
    = help: for that trait implementation, expected `i32`, found `()`
 note: the method call chain might not have had the expected associated types
   --> $DIR/invalid-iterator-chain.rs:44:15

--- a/tests/ui/iterators/invalid-iterator-chain.stderr
+++ b/tests/ui/iterators/invalid-iterator-chain.stderr
@@ -33,9 +33,12 @@ LL |     println!("{}", scores.sum::<i32>());
    |                           required by a bound introduced by this call
    |
    = help: the trait `Sum<()>` is not implemented for `i32`
-   = help: the following other types implement trait `Sum<A>`:
-             `i32` implements `Sum<&i32>`
-             `i32` implements `Sum`
+help: the following other types implement trait `Sum<A>`
+  --> $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
+   |
+   = note: `i32` implements `Sum<&i32>`
+   |
+   = note: `i32` implements `Sum`
 note: the method call chain might not have had the expected associated types
   --> $DIR/invalid-iterator-chain.rs:12:10
    |
@@ -50,6 +53,7 @@ LL | |         });
    | |__________^ `Iterator::Item` changed to `()` here
 note: required by a bound in `std::iter::Iterator::sum`
   --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
+   = note: this error originates in the macro `integer_sum_product` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider removing this semicolon
    |
 LL -             a + b;
@@ -65,9 +69,12 @@ LL |             .sum::<i32>(),
    |              required by a bound introduced by this call
    |
    = help: the trait `Sum<()>` is not implemented for `i32`
-   = help: the following other types implement trait `Sum<A>`:
-             `i32` implements `Sum<&i32>`
-             `i32` implements `Sum`
+help: the following other types implement trait `Sum<A>`
+  --> $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
+   |
+   = note: `i32` implements `Sum<&i32>`
+   |
+   = note: `i32` implements `Sum`
 note: the method call chain might not have had the expected associated types
   --> $DIR/invalid-iterator-chain.rs:25:14
    |
@@ -89,6 +96,7 @@ LL |             .map(|x| { x; })
    |              ^^^^^^^^^^^^^^^ `Iterator::Item` changed to `()` here
 note: required by a bound in `std::iter::Iterator::sum`
   --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
+   = note: this error originates in the macro `integer_sum_product` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider removing this semicolon
    |
 LL -             .map(|x| { x; })
@@ -104,9 +112,12 @@ LL |             .sum::<i32>(),
    |              required by a bound introduced by this call
    |
    = help: the trait `Sum<f64>` is not implemented for `i32`
-   = help: the following other types implement trait `Sum<A>`:
-             `i32` implements `Sum<&i32>`
-             `i32` implements `Sum`
+help: the following other types implement trait `Sum<A>`
+  --> $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
+   |
+   = note: `i32` implements `Sum<&i32>`
+   |
+   = note: `i32` implements `Sum`
 note: the method call chain might not have had the expected associated types
   --> $DIR/invalid-iterator-chain.rs:33:14
    |
@@ -124,6 +135,7 @@ LL |             .map(|x| { x + 1.0 })
    |              -------------------- `Iterator::Item` remains `f64` here
 note: required by a bound in `std::iter::Iterator::sum`
   --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
+   = note: this error originates in the macro `integer_sum_product` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: a value of type `i32` cannot be made by summing an iterator over elements of type `()`
   --> $DIR/invalid-iterator-chain.rs:38:60
@@ -134,9 +146,12 @@ LL |     println!("{}", vec![0, 1].iter().map(|x| { x; }).sum::<i32>());
    |                                                      required by a bound introduced by this call
    |
    = help: the trait `Sum<()>` is not implemented for `i32`
-   = help: the following other types implement trait `Sum<A>`:
-             `i32` implements `Sum<&i32>`
-             `i32` implements `Sum`
+help: the following other types implement trait `Sum<A>`
+  --> $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
+   |
+   = note: `i32` implements `Sum<&i32>`
+   |
+   = note: `i32` implements `Sum`
 note: the method call chain might not have had the expected associated types
   --> $DIR/invalid-iterator-chain.rs:38:38
    |
@@ -147,6 +162,7 @@ LL |     println!("{}", vec![0, 1].iter().map(|x| { x; }).sum::<i32>());
    |                    this expression has type `Vec<{integer}>`
 note: required by a bound in `std::iter::Iterator::sum`
   --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
+   = note: this error originates in the macro `integer_sum_product` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider removing this semicolon
    |
 LL -     println!("{}", vec![0, 1].iter().map(|x| { x; }).sum::<i32>());
@@ -162,9 +178,12 @@ LL |     println!("{}", vec![(), ()].iter().sum::<i32>());
    |                                        required by a bound introduced by this call
    |
    = help: the trait `Sum<&()>` is not implemented for `i32`
-   = help: the following other types implement trait `Sum<A>`:
-             `i32` implements `Sum<&i32>`
-             `i32` implements `Sum`
+help: the following other types implement trait `Sum<A>`
+  --> $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
+   |
+   = note: `i32` implements `Sum<&i32>`
+   |
+   = note: `i32` implements `Sum`
 note: the method call chain might not have had the expected associated types
   --> $DIR/invalid-iterator-chain.rs:39:33
    |
@@ -174,6 +193,7 @@ LL |     println!("{}", vec![(), ()].iter().sum::<i32>());
    |                    this expression has type `Vec<()>`
 note: required by a bound in `std::iter::Iterator::sum`
   --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
+   = note: this error originates in the macro `integer_sum_product` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: a value of type `Vec<i32>` cannot be built from an iterator over elements of type `()`
   --> $DIR/invalid-iterator-chain.rs:48:25

--- a/tests/ui/kindck/kindck-impl-type-params.stderr
+++ b/tests/ui/kindck/kindck-impl-type-params.stderr
@@ -80,7 +80,11 @@ error[E0277]: the trait bound `String: Copy` is not satisfied
 LL |     let a = t as Box<dyn Gettable<String>>;
    |             ^ the trait `Copy` is not implemented for `String`
    |
-   = help: the trait `Gettable<T>` is implemented for `S<T>`
+help: the trait `Gettable<T>` is implemented for `S<T>`
+  --> $DIR/kindck-impl-type-params.rs:12:1
+   |
+LL | impl<T: Send + Copy + 'static> Gettable<T> for S<T> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required for `S<String>` to implement `Gettable<String>`
   --> $DIR/kindck-impl-type-params.rs:12:32
    |
@@ -96,7 +100,11 @@ error[E0277]: the trait bound `Foo: Copy` is not satisfied
 LL |     let a: Box<dyn Gettable<Foo>> = t;
    |                                     ^ the trait `Copy` is not implemented for `Foo`
    |
-   = help: the trait `Gettable<T>` is implemented for `S<T>`
+help: the trait `Gettable<T>` is implemented for `S<T>`
+  --> $DIR/kindck-impl-type-params.rs:12:1
+   |
+LL | impl<T: Send + Copy + 'static> Gettable<T> for S<T> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required for `S<Foo>` to implement `Gettable<Foo>`
   --> $DIR/kindck-impl-type-params.rs:12:32
    |

--- a/tests/ui/linkage-attr/raw-dylib/windows/dlltool-failed.stderr
+++ b/tests/ui/linkage-attr/raw-dylib/windows/dlltool-failed.stderr
@@ -1,7 +1,7 @@
 error: dlltool could not create import library with $DLLTOOL -d $DEF_FILE -D foo.dll -l $LIB_FILE $TARGET_MACHINE $ASM_FLAGS --no-leading-underscore $TEMP_PREFIX:
        
        $DLLTOOL: Syntax error in def file $DEF_FILE:1␍
-
+       
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/linkage-attr/raw-dylib/windows/dlltool-failed.stderr
+++ b/tests/ui/linkage-attr/raw-dylib/windows/dlltool-failed.stderr
@@ -2,5 +2,6 @@ error: dlltool could not create import library with $DLLTOOL -d $DEF_FILE -D foo
        
        $DLLTOOL: Syntax error in def file $DEF_FILE:1␍
 
+
 error: aborting due to 1 previous error
 

--- a/tests/ui/mismatched_types/binops.stderr
+++ b/tests/ui/mismatched_types/binops.stderr
@@ -23,11 +23,17 @@ LL |     2 as usize - Some(1);
    |                ^ no implementation for `usize - Option<{integer}>`
    |
    = help: the trait `Sub<Option<{integer}>>` is not implemented for `usize`
-   = help: the following other types implement trait `Sub<Rhs>`:
-             `&usize` implements `Sub<usize>`
-             `&usize` implements `Sub`
-             `usize` implements `Sub<&usize>`
-             `usize` implements `Sub`
+help: the following other types implement trait `Sub<Rhs>`
+  --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
+   |
+   = note: `&usize` implements `Sub<usize>`
+   |
+   = note: `&usize` implements `Sub`
+   |
+   = note: `usize` implements `Sub<&usize>`
+   |
+   = note: `usize` implements `Sub`
+   = note: this error originates in the macro `sub_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: cannot multiply `{integer}` by `()`
   --> $DIR/binops.rs:4:7

--- a/tests/ui/mismatched_types/collect-method-type-mismatch-66923.stderr
+++ b/tests/ui/mismatched_types/collect-method-type-mismatch-66923.stderr
@@ -4,8 +4,9 @@ error[E0277]: a value of type `Vec<f64>` cannot be built from an iterator over e
 LL |     let x2: Vec<f64> = x1.into_iter().collect();
    |                                       ^^^^^^^ value of type `Vec<f64>` cannot be built from `std::iter::Iterator<Item=&f64>`
    |
-   = help: the trait `FromIterator<&_>` is not implemented for `Vec<f64>`
-           but trait `FromIterator<_>` is implemented for it
+help: the trait `FromIterator<&_>` is not implemented for `Vec<f64>`
+      but trait `FromIterator<_>` is implemented for it
+  --> $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
    = help: for that trait implementation, expected `f64`, found `&f64`
 note: the method call chain might not have had the expected associated types
   --> $DIR/collect-method-type-mismatch-66923.rs:9:27
@@ -25,8 +26,9 @@ LL |     let x3 = x1.into_iter().collect::<Vec<f64>>();
    |                             |
    |                             required by a bound introduced by this call
    |
-   = help: the trait `FromIterator<&_>` is not implemented for `Vec<f64>`
-           but trait `FromIterator<_>` is implemented for it
+help: the trait `FromIterator<&_>` is not implemented for `Vec<f64>`
+      but trait `FromIterator<_>` is implemented for it
+  --> $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
    = help: for that trait implementation, expected `f64`, found `&f64`
 note: the method call chain might not have had the expected associated types
   --> $DIR/collect-method-type-mismatch-66923.rs:13:17

--- a/tests/ui/mismatched_types/float-integer-subtraction-error-24352.stderr
+++ b/tests/ui/mismatched_types/float-integer-subtraction-error-24352.stderr
@@ -5,11 +5,17 @@ LL |     1.0f64 - 1
    |            ^ no implementation for `f64 - {integer}`
    |
    = help: the trait `Sub<{integer}>` is not implemented for `f64`
-   = help: the following other types implement trait `Sub<Rhs>`:
-             `&f64` implements `Sub<f64>`
-             `&f64` implements `Sub`
-             `f64` implements `Sub<&f64>`
-             `f64` implements `Sub`
+help: the following other types implement trait `Sub<Rhs>`
+  --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
+   |
+   = note: `&f64` implements `Sub<f64>`
+   |
+   = note: `&f64` implements `Sub`
+   |
+   = note: `f64` implements `Sub<&f64>`
+   |
+   = note: `f64` implements `Sub`
+   = note: this error originates in the macro `sub_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider using a floating-point literal by writing it with `.0`
    |
 LL |     1.0f64 - 1.0

--- a/tests/ui/never_type/defaulted-never-note.fallback.stderr
+++ b/tests/ui/never_type/defaulted-never-note.fallback.stderr
@@ -6,7 +6,11 @@ LL |     foo(_x);
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `ImplementedForUnitButNotNever` is implemented for `()`
+help: the trait `ImplementedForUnitButNotNever` is implemented for `()`
+  --> $DIR/defaulted-never-note.rs:24:1
+   |
+LL | impl ImplementedForUnitButNotNever for () {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this error might have been caused by changes to Rust's type-inference algorithm (see issue #48950 <https://github.com/rust-lang/rust/issues/48950> for more information)
    = help: you might have intended to use the type `()` here instead
 note: required by a bound in `foo`

--- a/tests/ui/never_type/defaulted-never-note.rs
+++ b/tests/ui/never_type/defaulted-never-note.rs
@@ -21,7 +21,7 @@ impl Deserialize for () {
 
 trait ImplementedForUnitButNotNever {}
 
-impl ImplementedForUnitButNotNever for () {}
+impl ImplementedForUnitButNotNever for () {} //[fallback]~ HELP trait `ImplementedForUnitButNotNever` is implemented for `()`
 
 fn foo<T: ImplementedForUnitButNotNever>(_t: T) {}
 //[fallback]~^ note: required by this bound in `foo`
@@ -29,12 +29,11 @@ fn foo<T: ImplementedForUnitButNotNever>(_t: T) {}
 fn smeg() {
     let _x = return;
     foo(_x);
-    //[fallback]~^ error: the trait bound
-    //[fallback]~| note: the trait `ImplementedForUnitButNotNever` is not implemented
-    //[fallback]~| help: trait `ImplementedForUnitButNotNever` is implemented for `()`
-    //[fallback]~| note: this error might have been caused
-    //[fallback]~| note: required by a bound introduced by this call
-    //[fallback]~| help: you might have intended to use the type `()`
+    //[fallback]~^ ERROR the trait bound
+    //[fallback]~| NOTE the trait `ImplementedForUnitButNotNever` is not implemented
+    //[fallback]~| NOTE this error might have been caused
+    //[fallback]~| NOTE required by a bound introduced by this call
+    //[fallback]~| HELP you might have intended to use the type `()`
 }
 
 fn main() {

--- a/tests/ui/never_type/diverging-fallback-no-leak.fallback.stderr
+++ b/tests/ui/never_type/diverging-fallback-no-leak.fallback.stderr
@@ -6,9 +6,13 @@ LL |     unconstrained_arg(return);
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the following other types implement trait `Test`:
-             ()
-             i32
+help: the following other types implement trait `Test`
+  --> $DIR/diverging-fallback-no-leak.rs:10:1
+   |
+LL | impl Test for i32 {}
+   | ^^^^^^^^^^^^^^^^^ `i32`
+LL | impl Test for () {}
+   | ^^^^^^^^^^^^^^^^ `()`
    = note: this error might have been caused by changes to Rust's type-inference algorithm (see issue #48950 <https://github.com/rust-lang/rust/issues/48950> for more information)
    = help: you might have intended to use the type `()` here instead
 note: required by a bound in `unconstrained_arg`

--- a/tests/ui/never_type/from_infer_breaking_with_unit_fallback.unit.stderr
+++ b/tests/ui/never_type/from_infer_breaking_with_unit_fallback.unit.stderr
@@ -4,8 +4,12 @@ error[E0277]: the trait bound `E: From<()>` is not satisfied
 LL |     <E as From<_>>::from(never); // Should the inference fail?
    |      ^ unsatisfied trait bound
    |
-   = help: the trait `From<()>` is not implemented for `E`
-           but trait `From<!>` is implemented for it
+help: the trait `From<()>` is not implemented for `E`
+      but trait `From<!>` is implemented for it
+  --> $DIR/from_infer_breaking_with_unit_fallback.rs:16:1
+   |
+LL | impl From<!> for E {
+   | ^^^^^^^^^^^^^^^^^^
    = help: for that trait implementation, expected `!`, found `()`
 
 error: aborting due to 1 previous error

--- a/tests/ui/never_type/impl_trait_fallback2.stderr
+++ b/tests/ui/never_type/impl_trait_fallback2.stderr
@@ -7,7 +7,11 @@ LL |
 LL |     panic!()
    |     -------- return type was inferred to be `_` here
    |
-   = help: the trait `T` is implemented for `i32`
+help: the trait `T` is implemented for `i32`
+  --> $DIR/impl_trait_fallback2.rs:6:1
+   |
+LL | impl T for i32 {}
+   | ^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `(): T` is not satisfied
   --> $DIR/impl_trait_fallback2.rs:16:11
@@ -18,7 +22,11 @@ LL |
 LL |     panic!()
    |     -------- return type was inferred to be `_` here
    |
-   = help: the trait `T` is implemented for `i32`
+help: the trait `T` is implemented for `i32`
+  --> $DIR/impl_trait_fallback2.rs:6:1
+   |
+LL | impl T for i32 {}
+   | ^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/never_type/issue-13352.stderr
+++ b/tests/ui/never_type/issue-13352.stderr
@@ -5,11 +5,17 @@ LL |     2_usize + (loop {});
    |             ^ no implementation for `usize + ()`
    |
    = help: the trait `Add<()>` is not implemented for `usize`
-   = help: the following other types implement trait `Add<Rhs>`:
-             `&usize` implements `Add<usize>`
-             `&usize` implements `Add`
-             `usize` implements `Add<&usize>`
-             `usize` implements `Add`
+help: the following other types implement trait `Add<Rhs>`
+  --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
+   |
+   = note: `&usize` implements `Add<usize>`
+   |
+   = note: `&usize` implements `Add`
+   |
+   = note: `usize` implements `Add<&usize>`
+   |
+   = note: `usize` implements `Add`
+   = note: this error originates in the macro `add_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/never_type/never-value-fallback-issue-66757.nofallback.stderr
+++ b/tests/ui/never_type/never-value-fallback-issue-66757.nofallback.stderr
@@ -4,8 +4,12 @@ error[E0277]: the trait bound `E: From<()>` is not satisfied
 LL |     <E as From<_>>::from(never);
    |      ^ unsatisfied trait bound
    |
-   = help: the trait `From<()>` is not implemented for `E`
-           but trait `From<!>` is implemented for it
+help: the trait `From<()>` is not implemented for `E`
+      but trait `From<!>` is implemented for it
+  --> $DIR/never-value-fallback-issue-66757.rs:17:1
+   |
+LL | impl From<!> for E {
+   | ^^^^^^^^^^^^^^^^^^
    = help: for that trait implementation, expected `!`, found `()`
 
 error: aborting due to 1 previous error

--- a/tests/ui/numbers-arithmetic/not-suggest-float-literal.stderr
+++ b/tests/ui/numbers-arithmetic/not-suggest-float-literal.stderr
@@ -5,11 +5,17 @@ LL |     x + 100.0
    |       ^ no implementation for `u8 + {float}`
    |
    = help: the trait `Add<{float}>` is not implemented for `u8`
-   = help: the following other types implement trait `Add<Rhs>`:
-             `&u8` implements `Add<u8>`
-             `&u8` implements `Add`
-             `u8` implements `Add<&u8>`
-             `u8` implements `Add`
+help: the following other types implement trait `Add<Rhs>`
+  --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
+   |
+   = note: `&u8` implements `Add<u8>`
+   |
+   = note: `&u8` implements `Add`
+   |
+   = note: `u8` implements `Add<&u8>`
+   |
+   = note: `u8` implements `Add`
+   = note: this error originates in the macro `add_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: cannot add `&str` to `f64`
   --> $DIR/not-suggest-float-literal.rs:6:7
@@ -18,11 +24,17 @@ LL |     x + "foo"
    |       ^ no implementation for `f64 + &str`
    |
    = help: the trait `Add<&str>` is not implemented for `f64`
-   = help: the following other types implement trait `Add<Rhs>`:
-             `&f64` implements `Add<f64>`
-             `&f64` implements `Add`
-             `f64` implements `Add<&f64>`
-             `f64` implements `Add`
+help: the following other types implement trait `Add<Rhs>`
+  --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
+   |
+   = note: `&f64` implements `Add<f64>`
+   |
+   = note: `&f64` implements `Add`
+   |
+   = note: `f64` implements `Add<&f64>`
+   |
+   = note: `f64` implements `Add`
+   = note: this error originates in the macro `add_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: cannot add `{integer}` to `f64`
   --> $DIR/not-suggest-float-literal.rs:11:7
@@ -31,11 +43,17 @@ LL |     x + y
    |       ^ no implementation for `f64 + {integer}`
    |
    = help: the trait `Add<{integer}>` is not implemented for `f64`
-   = help: the following other types implement trait `Add<Rhs>`:
-             `&f64` implements `Add<f64>`
-             `&f64` implements `Add`
-             `f64` implements `Add<&f64>`
-             `f64` implements `Add`
+help: the following other types implement trait `Add<Rhs>`
+  --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
+   |
+   = note: `&f64` implements `Add<f64>`
+   |
+   = note: `&f64` implements `Add`
+   |
+   = note: `f64` implements `Add<&f64>`
+   |
+   = note: `f64` implements `Add`
+   = note: this error originates in the macro `add_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: cannot subtract `{float}` from `u8`
   --> $DIR/not-suggest-float-literal.rs:15:7
@@ -44,11 +62,17 @@ LL |     x - 100.0
    |       ^ no implementation for `u8 - {float}`
    |
    = help: the trait `Sub<{float}>` is not implemented for `u8`
-   = help: the following other types implement trait `Sub<Rhs>`:
-             `&u8` implements `Sub<u8>`
-             `&u8` implements `Sub`
-             `u8` implements `Sub<&u8>`
-             `u8` implements `Sub`
+help: the following other types implement trait `Sub<Rhs>`
+  --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
+   |
+   = note: `&u8` implements `Sub<u8>`
+   |
+   = note: `&u8` implements `Sub`
+   |
+   = note: `u8` implements `Sub<&u8>`
+   |
+   = note: `u8` implements `Sub`
+   = note: this error originates in the macro `sub_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: cannot subtract `&str` from `f64`
   --> $DIR/not-suggest-float-literal.rs:19:7
@@ -57,11 +81,17 @@ LL |     x - "foo"
    |       ^ no implementation for `f64 - &str`
    |
    = help: the trait `Sub<&str>` is not implemented for `f64`
-   = help: the following other types implement trait `Sub<Rhs>`:
-             `&f64` implements `Sub<f64>`
-             `&f64` implements `Sub`
-             `f64` implements `Sub<&f64>`
-             `f64` implements `Sub`
+help: the following other types implement trait `Sub<Rhs>`
+  --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
+   |
+   = note: `&f64` implements `Sub<f64>`
+   |
+   = note: `&f64` implements `Sub`
+   |
+   = note: `f64` implements `Sub<&f64>`
+   |
+   = note: `f64` implements `Sub`
+   = note: this error originates in the macro `sub_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: cannot subtract `{integer}` from `f64`
   --> $DIR/not-suggest-float-literal.rs:24:7
@@ -70,11 +100,17 @@ LL |     x - y
    |       ^ no implementation for `f64 - {integer}`
    |
    = help: the trait `Sub<{integer}>` is not implemented for `f64`
-   = help: the following other types implement trait `Sub<Rhs>`:
-             `&f64` implements `Sub<f64>`
-             `&f64` implements `Sub`
-             `f64` implements `Sub<&f64>`
-             `f64` implements `Sub`
+help: the following other types implement trait `Sub<Rhs>`
+  --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
+   |
+   = note: `&f64` implements `Sub<f64>`
+   |
+   = note: `&f64` implements `Sub`
+   |
+   = note: `f64` implements `Sub<&f64>`
+   |
+   = note: `f64` implements `Sub`
+   = note: this error originates in the macro `sub_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: cannot multiply `u8` by `{float}`
   --> $DIR/not-suggest-float-literal.rs:28:7
@@ -83,11 +119,17 @@ LL |     x * 100.0
    |       ^ no implementation for `u8 * {float}`
    |
    = help: the trait `Mul<{float}>` is not implemented for `u8`
-   = help: the following other types implement trait `Mul<Rhs>`:
-             `&u8` implements `Mul<u8>`
-             `&u8` implements `Mul`
-             `u8` implements `Mul<&u8>`
-             `u8` implements `Mul`
+help: the following other types implement trait `Mul<Rhs>`
+  --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
+   |
+   = note: `&u8` implements `Mul<u8>`
+   |
+   = note: `&u8` implements `Mul`
+   |
+   = note: `u8` implements `Mul<&u8>`
+   |
+   = note: `u8` implements `Mul`
+   = note: this error originates in the macro `mul_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: cannot multiply `f64` by `&str`
   --> $DIR/not-suggest-float-literal.rs:32:7
@@ -96,11 +138,17 @@ LL |     x * "foo"
    |       ^ no implementation for `f64 * &str`
    |
    = help: the trait `Mul<&str>` is not implemented for `f64`
-   = help: the following other types implement trait `Mul<Rhs>`:
-             `&f64` implements `Mul<f64>`
-             `&f64` implements `Mul`
-             `f64` implements `Mul<&f64>`
-             `f64` implements `Mul`
+help: the following other types implement trait `Mul<Rhs>`
+  --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
+   |
+   = note: `&f64` implements `Mul<f64>`
+   |
+   = note: `&f64` implements `Mul`
+   |
+   = note: `f64` implements `Mul<&f64>`
+   |
+   = note: `f64` implements `Mul`
+   = note: this error originates in the macro `mul_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: cannot multiply `f64` by `{integer}`
   --> $DIR/not-suggest-float-literal.rs:37:7
@@ -109,11 +157,17 @@ LL |     x * y
    |       ^ no implementation for `f64 * {integer}`
    |
    = help: the trait `Mul<{integer}>` is not implemented for `f64`
-   = help: the following other types implement trait `Mul<Rhs>`:
-             `&f64` implements `Mul<f64>`
-             `&f64` implements `Mul`
-             `f64` implements `Mul<&f64>`
-             `f64` implements `Mul`
+help: the following other types implement trait `Mul<Rhs>`
+  --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
+   |
+   = note: `&f64` implements `Mul<f64>`
+   |
+   = note: `&f64` implements `Mul`
+   |
+   = note: `f64` implements `Mul<&f64>`
+   |
+   = note: `f64` implements `Mul`
+   = note: this error originates in the macro `mul_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: cannot divide `u8` by `{float}`
   --> $DIR/not-suggest-float-literal.rs:41:7
@@ -136,11 +190,17 @@ LL |     x / "foo"
    |       ^ no implementation for `f64 / &str`
    |
    = help: the trait `Div<&str>` is not implemented for `f64`
-   = help: the following other types implement trait `Div<Rhs>`:
-             `&f64` implements `Div<f64>`
-             `&f64` implements `Div`
-             `f64` implements `Div<&f64>`
-             `f64` implements `Div`
+help: the following other types implement trait `Div<Rhs>`
+  --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
+   |
+   = note: `&f64` implements `Div<f64>`
+   |
+   = note: `&f64` implements `Div`
+   |
+   = note: `f64` implements `Div<&f64>`
+   |
+   = note: `f64` implements `Div`
+   = note: this error originates in the macro `div_impl_float` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: cannot divide `f64` by `{integer}`
   --> $DIR/not-suggest-float-literal.rs:50:7
@@ -149,11 +209,17 @@ LL |     x / y
    |       ^ no implementation for `f64 / {integer}`
    |
    = help: the trait `Div<{integer}>` is not implemented for `f64`
-   = help: the following other types implement trait `Div<Rhs>`:
-             `&f64` implements `Div<f64>`
-             `&f64` implements `Div`
-             `f64` implements `Div<&f64>`
-             `f64` implements `Div`
+help: the following other types implement trait `Div<Rhs>`
+  --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
+   |
+   = note: `&f64` implements `Div<f64>`
+   |
+   = note: `&f64` implements `Div`
+   |
+   = note: `f64` implements `Div<&f64>`
+   |
+   = note: `f64` implements `Div`
+   = note: this error originates in the macro `div_impl_float` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 12 previous errors
 

--- a/tests/ui/numbers-arithmetic/suggest-float-literal.stderr
+++ b/tests/ui/numbers-arithmetic/suggest-float-literal.stderr
@@ -5,11 +5,17 @@ LL |     x + 100
    |       ^ no implementation for `f32 + {integer}`
    |
    = help: the trait `Add<{integer}>` is not implemented for `f32`
-   = help: the following other types implement trait `Add<Rhs>`:
-             `&f32` implements `Add<f32>`
-             `&f32` implements `Add`
-             `f32` implements `Add<&f32>`
-             `f32` implements `Add`
+help: the following other types implement trait `Add<Rhs>`
+  --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
+   |
+   = note: `&f32` implements `Add<f32>`
+   |
+   = note: `&f32` implements `Add`
+   |
+   = note: `f32` implements `Add<&f32>`
+   |
+   = note: `f32` implements `Add`
+   = note: this error originates in the macro `add_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider using a floating-point literal by writing it with `.0`
    |
 LL |     x + 100.0
@@ -22,11 +28,17 @@ LL |     x + 100
    |       ^ no implementation for `f64 + {integer}`
    |
    = help: the trait `Add<{integer}>` is not implemented for `f64`
-   = help: the following other types implement trait `Add<Rhs>`:
-             `&f64` implements `Add<f64>`
-             `&f64` implements `Add`
-             `f64` implements `Add<&f64>`
-             `f64` implements `Add`
+help: the following other types implement trait `Add<Rhs>`
+  --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
+   |
+   = note: `&f64` implements `Add<f64>`
+   |
+   = note: `&f64` implements `Add`
+   |
+   = note: `f64` implements `Add<&f64>`
+   |
+   = note: `f64` implements `Add`
+   = note: this error originates in the macro `add_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider using a floating-point literal by writing it with `.0`
    |
 LL |     x + 100.0
@@ -39,11 +51,17 @@ LL |     x - 100
    |       ^ no implementation for `f32 - {integer}`
    |
    = help: the trait `Sub<{integer}>` is not implemented for `f32`
-   = help: the following other types implement trait `Sub<Rhs>`:
-             `&f32` implements `Sub<f32>`
-             `&f32` implements `Sub`
-             `f32` implements `Sub<&f32>`
-             `f32` implements `Sub`
+help: the following other types implement trait `Sub<Rhs>`
+  --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
+   |
+   = note: `&f32` implements `Sub<f32>`
+   |
+   = note: `&f32` implements `Sub`
+   |
+   = note: `f32` implements `Sub<&f32>`
+   |
+   = note: `f32` implements `Sub`
+   = note: this error originates in the macro `sub_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider using a floating-point literal by writing it with `.0`
    |
 LL |     x - 100.0
@@ -56,11 +74,17 @@ LL |     x - 100
    |       ^ no implementation for `f64 - {integer}`
    |
    = help: the trait `Sub<{integer}>` is not implemented for `f64`
-   = help: the following other types implement trait `Sub<Rhs>`:
-             `&f64` implements `Sub<f64>`
-             `&f64` implements `Sub`
-             `f64` implements `Sub<&f64>`
-             `f64` implements `Sub`
+help: the following other types implement trait `Sub<Rhs>`
+  --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
+   |
+   = note: `&f64` implements `Sub<f64>`
+   |
+   = note: `&f64` implements `Sub`
+   |
+   = note: `f64` implements `Sub<&f64>`
+   |
+   = note: `f64` implements `Sub`
+   = note: this error originates in the macro `sub_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider using a floating-point literal by writing it with `.0`
    |
 LL |     x - 100.0
@@ -73,11 +97,17 @@ LL |     x * 100
    |       ^ no implementation for `f32 * {integer}`
    |
    = help: the trait `Mul<{integer}>` is not implemented for `f32`
-   = help: the following other types implement trait `Mul<Rhs>`:
-             `&f32` implements `Mul<f32>`
-             `&f32` implements `Mul`
-             `f32` implements `Mul<&f32>`
-             `f32` implements `Mul`
+help: the following other types implement trait `Mul<Rhs>`
+  --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
+   |
+   = note: `&f32` implements `Mul<f32>`
+   |
+   = note: `&f32` implements `Mul`
+   |
+   = note: `f32` implements `Mul<&f32>`
+   |
+   = note: `f32` implements `Mul`
+   = note: this error originates in the macro `mul_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider using a floating-point literal by writing it with `.0`
    |
 LL |     x * 100.0
@@ -90,11 +120,17 @@ LL |     x * 100
    |       ^ no implementation for `f64 * {integer}`
    |
    = help: the trait `Mul<{integer}>` is not implemented for `f64`
-   = help: the following other types implement trait `Mul<Rhs>`:
-             `&f64` implements `Mul<f64>`
-             `&f64` implements `Mul`
-             `f64` implements `Mul<&f64>`
-             `f64` implements `Mul`
+help: the following other types implement trait `Mul<Rhs>`
+  --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
+   |
+   = note: `&f64` implements `Mul<f64>`
+   |
+   = note: `&f64` implements `Mul`
+   |
+   = note: `f64` implements `Mul<&f64>`
+   |
+   = note: `f64` implements `Mul`
+   = note: this error originates in the macro `mul_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider using a floating-point literal by writing it with `.0`
    |
 LL |     x * 100.0
@@ -107,11 +143,17 @@ LL |     x / 100
    |       ^ no implementation for `f32 / {integer}`
    |
    = help: the trait `Div<{integer}>` is not implemented for `f32`
-   = help: the following other types implement trait `Div<Rhs>`:
-             `&f32` implements `Div<f32>`
-             `&f32` implements `Div`
-             `f32` implements `Div<&f32>`
-             `f32` implements `Div`
+help: the following other types implement trait `Div<Rhs>`
+  --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
+   |
+   = note: `&f32` implements `Div<f32>`
+   |
+   = note: `&f32` implements `Div`
+   |
+   = note: `f32` implements `Div<&f32>`
+   |
+   = note: `f32` implements `Div`
+   = note: this error originates in the macro `div_impl_float` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider using a floating-point literal by writing it with `.0`
    |
 LL |     x / 100.0
@@ -124,11 +166,17 @@ LL |     x / 100
    |       ^ no implementation for `f64 / {integer}`
    |
    = help: the trait `Div<{integer}>` is not implemented for `f64`
-   = help: the following other types implement trait `Div<Rhs>`:
-             `&f64` implements `Div<f64>`
-             `&f64` implements `Div`
-             `f64` implements `Div<&f64>`
-             `f64` implements `Div`
+help: the following other types implement trait `Div<Rhs>`
+  --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
+   |
+   = note: `&f64` implements `Div<f64>`
+   |
+   = note: `&f64` implements `Div`
+   |
+   = note: `f64` implements `Div<&f64>`
+   |
+   = note: `f64` implements `Div`
+   = note: this error originates in the macro `div_impl_float` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider using a floating-point literal by writing it with `.0`
    |
 LL |     x / 100.0

--- a/tests/ui/on-unimplemented/slice-index.stderr
+++ b/tests/ui/on-unimplemented/slice-index.stderr
@@ -5,9 +5,13 @@ LL |     x[1i32];
    |       ^^^^ slice indices are of type `usize` or ranges of `usize`
    |
    = help: the trait `SliceIndex<[i32]>` is not implemented for `i32`
-   = help: the following other types implement trait `SliceIndex<T>`:
-             `usize` implements `SliceIndex<ByteStr>`
-             `usize` implements `SliceIndex<[T]>`
+help: the following other types implement trait `SliceIndex<T>`
+  --> $SRC_DIR/core/src/slice/index.rs:LL:COL
+   |
+   = note: `usize` implements `SliceIndex<[T]>`
+  --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
+   |
+   = note: `usize` implements `SliceIndex<ByteStr>`
    = note: required for `[i32]` to implement `Index<i32>`
 
 error[E0277]: the type `[i32]` cannot be indexed by `RangeTo<i32>`
@@ -17,11 +21,18 @@ LL |     x[..1i32];
    |       ^^^^^^ slice indices are of type `usize` or ranges of `usize`
    |
    = help: the trait `SliceIndex<[i32]>` is not implemented for `RangeTo<i32>`
-   = help: the following other types implement trait `SliceIndex<T>`:
-             `RangeTo<usize>` implements `SliceIndex<ByteStr>`
-             `RangeTo<usize>` implements `SliceIndex<[T]>`
-             `RangeTo<usize>` implements `SliceIndex<str>`
+help: the following other types implement trait `SliceIndex<T>`
+  --> $SRC_DIR/core/src/slice/index.rs:LL:COL
+   |
+   = note: `RangeTo<usize>` implements `SliceIndex<[T]>`
+  --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
+   |
+   = note: `RangeTo<usize>` implements `SliceIndex<ByteStr>`
+  --> $SRC_DIR/core/src/str/traits.rs:LL:COL
+   |
+   = note: `RangeTo<usize>` implements `SliceIndex<str>`
    = note: required for `[i32]` to implement `Index<RangeTo<i32>>`
+   = note: this error originates in the macro `impl_slice_index` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/on-unimplemented/suggest_tuple_wrap.rs
+++ b/tests/ui/on-unimplemented/suggest_tuple_wrap.rs
@@ -6,7 +6,7 @@ impl Argument for &str {}
 
 pub trait TupleArgs {}
 impl<A: Argument> TupleArgs for (A,) {}
-impl<A: Argument, B: Argument> TupleArgs for (A, B) {}
+impl<A: Argument, B: Argument> TupleArgs for (A, B) {} //~ HELP the following other types implement trait `TupleArgs`
 impl<A: Argument, B: Argument, C: Argument> TupleArgs for (A, B, C) {}
 
 fn convert_into_tuple(_x: impl TupleArgs) {}
@@ -14,6 +14,5 @@ fn convert_into_tuple(_x: impl TupleArgs) {}
 fn main() {
     convert_into_tuple(42_u8);
     //~^ ERROR E0277
-    //~| HELP the following other types implement trait `TupleArgs`
     //~| HELP use a unary tuple instead
 }

--- a/tests/ui/on-unimplemented/suggest_tuple_wrap.stderr
+++ b/tests/ui/on-unimplemented/suggest_tuple_wrap.stderr
@@ -6,10 +6,15 @@ LL |     convert_into_tuple(42_u8);
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the following other types implement trait `TupleArgs`:
-             (A, B)
-             (A, B, C)
-             (A,)
+help: the following other types implement trait `TupleArgs`
+  --> $DIR/suggest_tuple_wrap.rs:8:1
+   |
+LL | impl<A: Argument> TupleArgs for (A,) {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `(A,)`
+LL | impl<A: Argument, B: Argument> TupleArgs for (A, B) {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `(A, B)`
+LL | impl<A: Argument, B: Argument, C: Argument> TupleArgs for (A, B, C) {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `(A, B, C)`
 note: required by a bound in `convert_into_tuple`
   --> $DIR/suggest_tuple_wrap.rs:12:32
    |

--- a/tests/ui/on-unimplemented/suggest_tuple_wrap_root_obligation.rs
+++ b/tests/ui/on-unimplemented/suggest_tuple_wrap_root_obligation.rs
@@ -5,7 +5,7 @@ impl From<(u8,)> for Tuple {
         todo!()
     }
 }
-impl From<(u8, u8)> for Tuple {
+impl From<(u8, u8)> for Tuple { //~ HELP the following other types implement trait `From<T>`
     fn from(_: (u8, u8)) -> Self {
         todo!()
     }
@@ -22,5 +22,4 @@ fn main() {
     convert_into_tuple(42_u8);
     //~^ ERROR E0277
     //~| HELP use a unary tuple instead
-    //~| HELP the following other types implement trait `From<T>`
 }

--- a/tests/ui/on-unimplemented/suggest_tuple_wrap_root_obligation.stderr
+++ b/tests/ui/on-unimplemented/suggest_tuple_wrap_root_obligation.stderr
@@ -11,10 +11,17 @@ help: the trait `From<u8>` is not implemented for `Tuple`
    |
 LL | struct Tuple;
    | ^^^^^^^^^^^^
-   = help: the following other types implement trait `From<T>`:
-             `Tuple` implements `From<(u8, u8)>`
-             `Tuple` implements `From<(u8, u8, u8)>`
-             `Tuple` implements `From<(u8,)>`
+help: the following other types implement trait `From<T>`
+  --> $DIR/suggest_tuple_wrap_root_obligation.rs:3:1
+   |
+LL | impl From<(u8,)> for Tuple {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^ `Tuple` implements `From<(u8,)>`
+...
+LL | impl From<(u8, u8)> for Tuple {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Tuple` implements `From<(u8, u8)>`
+...
+LL | impl From<(u8, u8, u8)> for Tuple {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Tuple` implements `From<(u8, u8, u8)>`
    = note: required for `u8` to implement `Into<Tuple>`
 note: required by a bound in `convert_into_tuple`
   --> $DIR/suggest_tuple_wrap_root_obligation.rs:19:32

--- a/tests/ui/on-unimplemented/sum.stderr
+++ b/tests/ui/on-unimplemented/sum.stderr
@@ -7,9 +7,12 @@ LL |     vec![(), ()].iter().sum::<i32>();
    |                         required by a bound introduced by this call
    |
    = help: the trait `Sum<&()>` is not implemented for `i32`
-   = help: the following other types implement trait `Sum<A>`:
-             `i32` implements `Sum<&i32>`
-             `i32` implements `Sum`
+help: the following other types implement trait `Sum<A>`
+  --> $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
+   |
+   = note: `i32` implements `Sum<&i32>`
+   |
+   = note: `i32` implements `Sum`
 note: the method call chain might not have had the expected associated types
   --> $DIR/sum.rs:4:18
    |
@@ -19,6 +22,7 @@ LL |     vec![(), ()].iter().sum::<i32>();
    |     this expression has type `Vec<()>`
 note: required by a bound in `std::iter::Iterator::sum`
   --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
+   = note: this error originates in the macro `integer_sum_product` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: a value of type `i32` cannot be made by multiplying all elements of type `&()` from an iterator
   --> $DIR/sum.rs:7:35
@@ -29,9 +33,12 @@ LL |     vec![(), ()].iter().product::<i32>();
    |                         required by a bound introduced by this call
    |
    = help: the trait `Product<&()>` is not implemented for `i32`
-   = help: the following other types implement trait `Product<A>`:
-             `i32` implements `Product<&i32>`
-             `i32` implements `Product`
+help: the following other types implement trait `Product<A>`
+  --> $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
+   |
+   = note: `i32` implements `Product<&i32>`
+   |
+   = note: `i32` implements `Product`
 note: the method call chain might not have had the expected associated types
   --> $DIR/sum.rs:7:18
    |
@@ -41,6 +48,7 @@ LL |     vec![(), ()].iter().product::<i32>();
    |     this expression has type `Vec<()>`
 note: required by a bound in `std::iter::Iterator::product`
   --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
+   = note: this error originates in the macro `integer_sum_product` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/trait-selection-sanity.without_impl.stderr
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/trait-selection-sanity.without_impl.stderr
@@ -4,7 +4,11 @@ error[E0277]: the trait bound `&_: main::Ref` is not satisfied
 LL |     let (&_, b) = generic();
    |                   ^^^^^^^^^ the trait `main::Ref` is not implemented for `&_`
    |
-   = help: the trait `main::Ref` is implemented for `&'static mut [(); 0]`
+help: the trait `main::Ref` is implemented for `&'static mut [(); 0]`
+  --> $DIR/trait-selection-sanity.rs:22:5
+   |
+LL |     impl Ref for &'static mut [(); 0] {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `generic`
   --> $DIR/trait-selection-sanity.rs:7:19
    |

--- a/tests/ui/span/multiline-span-simple.stderr
+++ b/tests/ui/span/multiline-span-simple.stderr
@@ -5,11 +5,17 @@ LL |     foo(1 as u32 +
    |                  ^ no implementation for `u32 + ()`
    |
    = help: the trait `Add<()>` is not implemented for `u32`
-   = help: the following other types implement trait `Add<Rhs>`:
-             `&u32` implements `Add<u32>`
-             `&u32` implements `Add`
-             `u32` implements `Add<&u32>`
-             `u32` implements `Add`
+help: the following other types implement trait `Add<Rhs>`
+  --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
+   |
+   = note: `&u32` implements `Add<u32>`
+   |
+   = note: `&u32` implements `Add`
+   |
+   = note: `u32` implements `Add<&u32>`
+   |
+   = note: `u32` implements `Add`
+   = note: this error originates in the macro `add_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/specialization/coherence/default-impl-normalization-ambig-2.stderr
+++ b/tests/ui/specialization/coherence/default-impl-normalization-ambig-2.stderr
@@ -14,7 +14,11 @@ error[E0277]: the trait bound `u16: Assoc` is not satisfied
 LL | impl Foo for <u16 as Assoc>::Output {}
    |              ^^^^^^^^^^^^^^^^^^^^^^ the trait `Assoc` is not implemented for `u16`
    |
-   = help: the trait `Assoc` is implemented for `u8`
+help: the trait `Assoc` is implemented for `u8`
+  --> $DIR/default-impl-normalization-ambig-2.rs:12:1
+   |
+LL | impl Assoc for u8 {}
+   | ^^^^^^^^^^^^^^^^^
 
 error: aborting due to 1 previous error; 1 warning emitted
 

--- a/tests/ui/specialization/default-associated-type-bound-1.stderr
+++ b/tests/ui/specialization/default-associated-type-bound-1.stderr
@@ -14,7 +14,8 @@ error[E0277]: the trait bound `str: Clone` is not satisfied
 LL |     default type U = str;
    |                      ^^^ the trait `Clone` is not implemented for `str`
    |
-   = help: the trait `Clone` is implemented for `String`
+help: the trait `Clone` is implemented for `String`
+  --> $SRC_DIR/alloc/src/string.rs:LL:COL
 note: required by a bound in `X::U`
   --> $DIR/default-associated-type-bound-1.rs:8:13
    |

--- a/tests/ui/str/str-idx.stderr
+++ b/tests/ui/str/str-idx.stderr
@@ -7,9 +7,13 @@ LL |     let _: u8 = s[4];
    = help: the trait `SliceIndex<str>` is not implemented for `{integer}`
    = note: you can use `.chars().nth()` or `.bytes().nth()`
            for more information, see chapter 8 in The Book: <https://doc.rust-lang.org/book/ch08-02-strings.html#indexing-into-strings>
-   = help: the following other types implement trait `SliceIndex<T>`:
-             `usize` implements `SliceIndex<ByteStr>`
-             `usize` implements `SliceIndex<[T]>`
+help: the following other types implement trait `SliceIndex<T>`
+  --> $SRC_DIR/core/src/slice/index.rs:LL:COL
+   |
+   = note: `usize` implements `SliceIndex<[T]>`
+  --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
+   |
+   = note: `usize` implements `SliceIndex<ByteStr>`
    = note: required for `str` to implement `Index<{integer}>`
 
 error[E0277]: the type `str` cannot be indexed by `{integer}`
@@ -23,9 +27,13 @@ LL |     let _ = s.get(4);
    = help: the trait `SliceIndex<str>` is not implemented for `{integer}`
    = note: you can use `.chars().nth()` or `.bytes().nth()`
            for more information, see chapter 8 in The Book: <https://doc.rust-lang.org/book/ch08-02-strings.html#indexing-into-strings>
-   = help: the following other types implement trait `SliceIndex<T>`:
-             `usize` implements `SliceIndex<ByteStr>`
-             `usize` implements `SliceIndex<[T]>`
+help: the following other types implement trait `SliceIndex<T>`
+  --> $SRC_DIR/core/src/slice/index.rs:LL:COL
+   |
+   = note: `usize` implements `SliceIndex<[T]>`
+  --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
+   |
+   = note: `usize` implements `SliceIndex<ByteStr>`
 note: required by a bound in `core::str::<impl str>::get`
   --> $SRC_DIR/core/src/str/mod.rs:LL:COL
 
@@ -40,9 +48,13 @@ LL |     let _ = s.get_unchecked(4);
    = help: the trait `SliceIndex<str>` is not implemented for `{integer}`
    = note: you can use `.chars().nth()` or `.bytes().nth()`
            for more information, see chapter 8 in The Book: <https://doc.rust-lang.org/book/ch08-02-strings.html#indexing-into-strings>
-   = help: the following other types implement trait `SliceIndex<T>`:
-             `usize` implements `SliceIndex<ByteStr>`
-             `usize` implements `SliceIndex<[T]>`
+help: the following other types implement trait `SliceIndex<T>`
+  --> $SRC_DIR/core/src/slice/index.rs:LL:COL
+   |
+   = note: `usize` implements `SliceIndex<[T]>`
+  --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
+   |
+   = note: `usize` implements `SliceIndex<ByteStr>`
 note: required by a bound in `core::str::<impl str>::get_unchecked`
   --> $SRC_DIR/core/src/str/mod.rs:LL:COL
 

--- a/tests/ui/str/str-mut-idx.stderr
+++ b/tests/ui/str/str-mut-idx.stderr
@@ -31,9 +31,13 @@ LL |     s[1usize] = bot();
    |       ^^^^^^ string indices are ranges of `usize`
    |
    = help: the trait `SliceIndex<str>` is not implemented for `usize`
-   = help: the following other types implement trait `SliceIndex<T>`:
-             `usize` implements `SliceIndex<ByteStr>`
-             `usize` implements `SliceIndex<[T]>`
+help: the following other types implement trait `SliceIndex<T>`
+  --> $SRC_DIR/core/src/slice/index.rs:LL:COL
+   |
+   = note: `usize` implements `SliceIndex<[T]>`
+  --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
+   |
+   = note: `usize` implements `SliceIndex<ByteStr>`
    = note: required for `str` to implement `Index<usize>`
 
 error[E0277]: the type `str` cannot be indexed by `{integer}`
@@ -47,9 +51,13 @@ LL |     s.get_mut(1);
    = help: the trait `SliceIndex<str>` is not implemented for `{integer}`
    = note: you can use `.chars().nth()` or `.bytes().nth()`
            for more information, see chapter 8 in The Book: <https://doc.rust-lang.org/book/ch08-02-strings.html#indexing-into-strings>
-   = help: the following other types implement trait `SliceIndex<T>`:
-             `usize` implements `SliceIndex<ByteStr>`
-             `usize` implements `SliceIndex<[T]>`
+help: the following other types implement trait `SliceIndex<T>`
+  --> $SRC_DIR/core/src/slice/index.rs:LL:COL
+   |
+   = note: `usize` implements `SliceIndex<[T]>`
+  --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
+   |
+   = note: `usize` implements `SliceIndex<ByteStr>`
 note: required by a bound in `core::str::<impl str>::get_mut`
   --> $SRC_DIR/core/src/str/mod.rs:LL:COL
 
@@ -64,9 +72,13 @@ LL |     s.get_unchecked_mut(1);
    = help: the trait `SliceIndex<str>` is not implemented for `{integer}`
    = note: you can use `.chars().nth()` or `.bytes().nth()`
            for more information, see chapter 8 in The Book: <https://doc.rust-lang.org/book/ch08-02-strings.html#indexing-into-strings>
-   = help: the following other types implement trait `SliceIndex<T>`:
-             `usize` implements `SliceIndex<ByteStr>`
-             `usize` implements `SliceIndex<[T]>`
+help: the following other types implement trait `SliceIndex<T>`
+  --> $SRC_DIR/core/src/slice/index.rs:LL:COL
+   |
+   = note: `usize` implements `SliceIndex<[T]>`
+  --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
+   |
+   = note: `usize` implements `SliceIndex<ByteStr>`
 note: required by a bound in `core::str::<impl str>::get_unchecked_mut`
   --> $SRC_DIR/core/src/str/mod.rs:LL:COL
 

--- a/tests/ui/suggestions/dont-suggest-borrowing-existing-borrow.stderr
+++ b/tests/ui/suggestions/dont-suggest-borrowing-existing-borrow.stderr
@@ -27,7 +27,11 @@ help: the trait `Trait` is not implemented for `S`
    |
 LL | struct S;
    | ^^^^^^^^
-   = help: the trait `Trait` is implemented for `&mut S`
+help: the trait `Trait` is implemented for `&mut S`
+  --> $DIR/dont-suggest-borrowing-existing-borrow.rs:7:1
+   |
+LL | impl Trait for &mut S {}
+   | ^^^^^^^^^^^^^^^^^^^^^
 help: you likely meant to call the associated function `foo` for type `&mut S`, but the code as written calls associated function `foo` on type `S`
    |
 LL |     let _ = <&mut S>::foo();
@@ -44,7 +48,11 @@ help: the trait `Trait` is not implemented for `S`
    |
 LL | struct S;
    | ^^^^^^^^
-   = help: the trait `Trait` is implemented for `&mut S`
+help: the trait `Trait` is implemented for `&mut S`
+  --> $DIR/dont-suggest-borrowing-existing-borrow.rs:7:1
+   |
+LL | impl Trait for &mut S {}
+   | ^^^^^^^^^^^^^^^^^^^^^
 help: you likely meant to call the associated function `foo` for type `&S`, but the code as written calls associated function `foo` on type `S`
    |
 LL -     let _ = &S::foo();
@@ -73,9 +81,13 @@ help: the trait `Trait2` is not implemented for `S`
    |
 LL | struct S;
    | ^^^^^^^^
-   = help: the following other types implement trait `Trait2`:
-             &S
-             &mut S
+help: the following other types implement trait `Trait2`
+  --> $DIR/dont-suggest-borrowing-existing-borrow.rs:11:1
+   |
+LL | impl Trait2 for &S {}
+   | ^^^^^^^^^^^^^^^^^^ `&S`
+LL | impl Trait2 for &mut S {}
+   | ^^^^^^^^^^^^^^^^^^^^^^ `&mut S`
 help: you likely meant to call the associated function `bar` for type `&mut S`, but the code as written calls associated function `bar` on type `S`
    |
 LL |     let _ = <&mut S>::bar();
@@ -92,9 +104,13 @@ help: the trait `Trait2` is not implemented for `S`
    |
 LL | struct S;
    | ^^^^^^^^
-   = help: the following other types implement trait `Trait2`:
-             &S
-             &mut S
+help: the following other types implement trait `Trait2`
+  --> $DIR/dont-suggest-borrowing-existing-borrow.rs:11:1
+   |
+LL | impl Trait2 for &S {}
+   | ^^^^^^^^^^^^^^^^^^ `&S`
+LL | impl Trait2 for &mut S {}
+   | ^^^^^^^^^^^^^^^^^^^^^^ `&mut S`
 help: you likely meant to call the associated function `bar` for type `&S`, but the code as written calls associated function `bar` on type `S`
    |
 LL |     let _ = <&S>::bar();

--- a/tests/ui/suggestions/dont-suggest-foreign-doc-hidden.stderr
+++ b/tests/ui/suggestions/dont-suggest-foreign-doc-hidden.stderr
@@ -43,10 +43,16 @@ error[E0277]: the trait bound `i32: Marker` is not satisfied
 LL |     test5::<i32>();
    |             ^^^ the trait `Marker` is not implemented for `i32`
    |
-   = help: the following other types implement trait `Marker`:
-             Baz
-             Option<u32>
-             Quux
+help: the following other types implement trait `Marker`
+  --> $DIR/auxiliary/hidden-struct.rs:31:1
+   |
+LL | impl Marker for Option<u32> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Option<u32>`
+...
+LL | impl Marker for Baz {}
+   | ^^^^^^^^^^^^^^^^^^^ `Baz`
+LL | impl Marker for Quux {}
+   | ^^^^^^^^^^^^^^^^^^^^ `Quux`
 note: required by a bound in `test5`
   --> $DIR/dont-suggest-foreign-doc-hidden.rs:22:13
    |

--- a/tests/ui/suggestions/imm-ref-trait-object-literal-bound-regions.stderr
+++ b/tests/ui/suggestions/imm-ref-trait-object-literal-bound-regions.stderr
@@ -6,7 +6,11 @@ LL |     foo::<S>(s);
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `Trait` is implemented for `&mut S`
+help: the trait `Trait` is implemented for `&mut S`
+  --> $DIR/imm-ref-trait-object-literal-bound-regions.rs:7:1
+   |
+LL | impl<'a> Trait for &'a mut S {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: `for<'b> Trait` is implemented for `&'b mut S`, but not for `&'b S`
 note: required by a bound in `foo`
   --> $DIR/imm-ref-trait-object-literal-bound-regions.rs:11:20

--- a/tests/ui/suggestions/imm-ref-trait-object-literal.stderr
+++ b/tests/ui/suggestions/imm-ref-trait-object-literal.stderr
@@ -6,7 +6,11 @@ LL |   foo(&s);
    |   |
    |   required by a bound introduced by this call
    |
-   = help: the trait `Trait` is implemented for `&mut S`
+help: the trait `Trait` is implemented for `&mut S`
+  --> $DIR/imm-ref-trait-object-literal.rs:5:1
+   |
+LL | impl<'a> Trait for &'a mut S {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `foo`
   --> $DIR/imm-ref-trait-object-literal.rs:7:11
    |

--- a/tests/ui/suggestions/impl-trait-return-trailing-semicolon.rs
+++ b/tests/ui/suggestions/impl-trait-return-trailing-semicolon.rs
@@ -5,6 +5,7 @@ impl Bar for i32 {}
 struct Qux;
 
 impl Bar for Qux {}
+//~^ HELP the following other types implement trait `Bar`
 
 fn foo() -> impl Bar {
     //~^ ERROR the trait bound `(): Bar` is not satisfied
@@ -14,7 +15,6 @@ fn foo() -> impl Bar {
 
 fn bar() -> impl Bar {
     //~^ ERROR the trait bound `(): Bar` is not satisfied
-    //~| HELP the following other types implement trait `Bar`:
     "";
 }
 

--- a/tests/ui/suggestions/impl-trait-return-trailing-semicolon.stderr
+++ b/tests/ui/suggestions/impl-trait-return-trailing-semicolon.stderr
@@ -1,5 +1,5 @@
 error[E0277]: the trait bound `(): Bar` is not satisfied
-  --> $DIR/impl-trait-return-trailing-semicolon.rs:9:13
+  --> $DIR/impl-trait-return-trailing-semicolon.rs:10:13
    |
 LL | fn foo() -> impl Bar {
    |             ^^^^^^^^ the trait `Bar` is not implemented for `()`
@@ -10,14 +10,19 @@ LL |     5;
    |     this expression has type `{integer}`, which implements `Bar`
 
 error[E0277]: the trait bound `(): Bar` is not satisfied
-  --> $DIR/impl-trait-return-trailing-semicolon.rs:15:13
+  --> $DIR/impl-trait-return-trailing-semicolon.rs:16:13
    |
 LL | fn bar() -> impl Bar {
    |             ^^^^^^^^ the trait `Bar` is not implemented for `()`
    |
-   = help: the following other types implement trait `Bar`:
-             Qux
-             i32
+help: the following other types implement trait `Bar`
+  --> $DIR/impl-trait-return-trailing-semicolon.rs:3:1
+   |
+LL | impl Bar for i32 {}
+   | ^^^^^^^^^^^^^^^^ `i32`
+...
+LL | impl Bar for Qux {}
+   | ^^^^^^^^^^^^^^^^ `Qux`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/suggestions/issue-101623.stderr
+++ b/tests/ui/suggestions/issue-101623.stderr
@@ -7,8 +7,12 @@ LL |     Trait::do_stuff({ fun(&mut *inner) });
    |     |               the trait `Trait<'_>` is not implemented for `*mut ()`
    |     required by a bound introduced by this call
    |
-   = help: the trait `Trait<'_>` is not implemented for `*mut ()`
-           but it is implemented for `()`
+help: the trait `Trait<'_>` is not implemented for `*mut ()`
+      but it is implemented for `()`
+  --> $DIR/issue-101623.rs:15:1
+   |
+LL | impl<'a> Trait<'a> for () {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: for that trait implementation, expected `()`, found `*mut ()`
 
 error: aborting due to 1 previous error

--- a/tests/ui/suggestions/issue-105645.stderr
+++ b/tests/ui/suggestions/issue-105645.stderr
@@ -6,7 +6,8 @@ LL |     foo(&mut bref);
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `std::io::Write` is implemented for `&mut [u8]`
+help: the trait `std::io::Write` is implemented for `&mut [u8]`
+  --> $SRC_DIR/std/src/io/impls.rs:LL:COL
 note: required by a bound in `foo`
   --> $DIR/issue-105645.rs:8:21
    |

--- a/tests/ui/suggestions/issue-84973-negative.stderr
+++ b/tests/ui/suggestions/issue-84973-negative.stderr
@@ -6,7 +6,11 @@ LL |     bar(a);
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `Tr` is implemented for `&f32`
+help: the trait `Tr` is implemented for `&f32`
+  --> $DIR/issue-84973-negative.rs:4:1
+   |
+LL | impl Tr for &f32 {}
+   | ^^^^^^^^^^^^^^^^
 note: required by a bound in `bar`
   --> $DIR/issue-84973-negative.rs:5:11
    |

--- a/tests/ui/suggestions/issue-96223.stderr
+++ b/tests/ui/suggestions/issue-96223.stderr
@@ -11,7 +11,11 @@ help: the trait `for<'de> Foo<'_>` is not implemented for `EmptyBis<'de>`
    |
 LL | pub struct EmptyBis<'a>(&'a [u8]);
    | ^^^^^^^^^^^^^^^^^^^^^^^
-   = help: the trait `Foo<'de>` is implemented for `Baz<T>`
+help: the trait `Foo<'de>` is implemented for `Baz<T>`
+  --> $DIR/issue-96223.rs:16:1
+   |
+LL | impl<'de, T> Foo<'de> for Baz<T> where T: Foo<'de> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required for `Baz<EmptyBis<'de>>` to implement `for<'de> Foo<'de>`
   --> $DIR/issue-96223.rs:16:14
    |

--- a/tests/ui/suggestions/issue-99080.stderr
+++ b/tests/ui/suggestions/issue-99080.stderr
@@ -6,9 +6,16 @@ LL |     needs_meow(1usize);
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the following other types implement trait `Meow`:
-             GlobalMeow
-             LocalMeow
+help: the following other types implement trait `Meow`
+  --> $DIR/issue-99080.rs:16:1
+   |
+LL | impl Meow for LocalMeow {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^ `LocalMeow`
+   |
+  ::: $DIR/auxiliary/meow.rs:7:1
+   |
+LL | impl Meow for GlobalMeow {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^ `GlobalMeow`
 note: required by a bound in `needs_meow`
   --> $DIR/issue-99080.rs:7:18
    |

--- a/tests/ui/suggestions/suggest-dereferencing-index.stderr
+++ b/tests/ui/suggestions/suggest-dereferencing-index.stderr
@@ -5,9 +5,13 @@ LL |     let one_item_please: i32 = [1, 2, 3][i];
    |                                          ^ slice indices are of type `usize` or ranges of `usize`
    |
    = help: the trait `SliceIndex<[{integer}]>` is not implemented for `&usize`
-   = help: the following other types implement trait `SliceIndex<T>`:
-             `usize` implements `SliceIndex<ByteStr>`
-             `usize` implements `SliceIndex<[T]>`
+help: the following other types implement trait `SliceIndex<T>`
+  --> $SRC_DIR/core/src/slice/index.rs:LL:COL
+   |
+   = note: `usize` implements `SliceIndex<[T]>`
+  --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
+   |
+   = note: `usize` implements `SliceIndex<ByteStr>`
    = note: required for `[{integer}]` to implement `Index<&usize>`
    = note: 1 redundant requirement hidden
    = note: required for `[{integer}; 3]` to implement `Index<&usize>`

--- a/tests/ui/trait-bounds/ice-unsized-struct-arg-issue2-121424.stderr
+++ b/tests/ui/trait-bounds/ice-unsized-struct-arg-issue2-121424.stderr
@@ -4,7 +4,8 @@ error[E0277]: the trait bound `[bool]: Copy` is not satisfied
 LL | const MYSLICE_GOOD: &MySliceBool = &MySlice(true, [false]);
    |                      ^^^^^^^^^^^ the trait `Copy` is not implemented for `[bool]`
    |
-   = help: the trait `Copy` is implemented for `[T; N]`
+help: the trait `Copy` is implemented for `[T; N]`
+  --> $SRC_DIR/core/src/array/mod.rs:LL:COL
 note: required by a bound in `MySlice`
   --> $DIR/ice-unsized-struct-arg-issue2-121424.rs:3:19
    |
@@ -17,7 +18,8 @@ error[E0277]: the trait bound `[bool]: Copy` is not satisfied
 LL | const MYSLICE_GOOD: &MySliceBool = &MySlice(true, [false]);
    |                      ^^^^^^^^^^^ the trait `Copy` is not implemented for `[bool]`
    |
-   = help: the trait `Copy` is implemented for `[T; N]`
+help: the trait `Copy` is implemented for `[T; N]`
+  --> $SRC_DIR/core/src/array/mod.rs:LL:COL
 note: required by a bound in `MySlice`
   --> $DIR/ice-unsized-struct-arg-issue2-121424.rs:3:19
    |

--- a/tests/ui/traits/associated_type_bound/check-trait-object-bounds-1.stderr
+++ b/tests/ui/traits/associated_type_bound/check-trait-object-bounds-1.stderr
@@ -4,7 +4,8 @@ error[E0277]: the trait bound `str: Clone` is not satisfied
 LL |     f::<dyn X<Y = str>>();
    |         ^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `str`
    |
-   = help: the trait `Clone` is implemented for `String`
+help: the trait `Clone` is implemented for `String`
+  --> $SRC_DIR/alloc/src/string.rs:LL:COL
 note: required by a bound in `f`
   --> $DIR/check-trait-object-bounds-1.rs:7:9
    |

--- a/tests/ui/traits/associated_type_bound/check-trait-object-bounds-4.stderr
+++ b/tests/ui/traits/associated_type_bound/check-trait-object-bounds-4.stderr
@@ -4,7 +4,8 @@ error[E0277]: the trait bound `str: Clone` is not satisfied
 LL |     f::<dyn X<Y = str>>();
    |         ^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `str`
    |
-   = help: the trait `Clone` is implemented for `String`
+help: the trait `Clone` is implemented for `String`
+  --> $SRC_DIR/alloc/src/string.rs:LL:COL
 note: required by a bound in `f`
   --> $DIR/check-trait-object-bounds-4.rs:10:9
    |

--- a/tests/ui/traits/bound/same-crate-name.stderr
+++ b/tests/ui/traits/bound/same-crate-name.stderr
@@ -12,7 +12,11 @@ help: trait impl with same name found
 LL | impl Bar for Foo {}
    | ^^^^^^^^^^^^^^^^
    = note: perhaps two different versions of crate `crate_a2` are being used?
-   = help: the trait `main::a::Bar` is implemented for `ImplementsTraitForUsize<usize>`
+help: the trait `main::a::Bar` is implemented for `ImplementsTraitForUsize<usize>`
+  --> $DIR/auxiliary/crate_a1.rs:9:1
+   |
+LL | impl Bar for ImplementsTraitForUsize<usize> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `try_foo`
   --> $DIR/auxiliary/crate_a1.rs:3:24
    |
@@ -27,7 +31,11 @@ LL |         a::try_foo(implements_no_traits);
    |         |
    |         required by a bound introduced by this call
    |
-   = help: the trait `main::a::Bar` is implemented for `ImplementsTraitForUsize<usize>`
+help: the trait `main::a::Bar` is implemented for `ImplementsTraitForUsize<usize>`
+  --> $DIR/auxiliary/crate_a1.rs:9:1
+   |
+LL | impl Bar for ImplementsTraitForUsize<usize> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `try_foo`
   --> $DIR/auxiliary/crate_a1.rs:3:24
    |
@@ -48,7 +56,11 @@ help: trait impl with same name found
 LL | impl Bar for ImplementsWrongTraitConditionally<isize> {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: perhaps two different versions of crate `crate_a2` are being used?
-   = help: the trait `main::a::Bar` is implemented for `ImplementsTraitForUsize<usize>`
+help: the trait `main::a::Bar` is implemented for `ImplementsTraitForUsize<usize>`
+  --> $DIR/auxiliary/crate_a1.rs:9:1
+   |
+LL | impl Bar for ImplementsTraitForUsize<usize> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `try_foo`
   --> $DIR/auxiliary/crate_a1.rs:3:24
    |
@@ -63,7 +75,11 @@ LL |         a::try_foo(other_variant_implements_correct_trait);
    |         |
    |         required by a bound introduced by this call
    |
-   = help: the trait `main::a::Bar` is implemented for `ImplementsTraitForUsize<usize>`
+help: the trait `main::a::Bar` is implemented for `ImplementsTraitForUsize<usize>`
+  --> $DIR/auxiliary/crate_a1.rs:9:1
+   |
+LL | impl Bar for ImplementsTraitForUsize<usize> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `try_foo`
   --> $DIR/auxiliary/crate_a1.rs:3:24
    |

--- a/tests/ui/traits/coercion-generic-bad.stderr
+++ b/tests/ui/traits/coercion-generic-bad.stderr
@@ -4,8 +4,12 @@ error[E0277]: the trait bound `Struct: Trait<isize>` is not satisfied
 LL |     let s: Box<dyn Trait<isize>> = Box::new(Struct { person: "Fred" });
    |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
    |
-   = help: the trait `Trait<isize>` is not implemented for `Struct`
-           but trait `Trait<&'static str>` is implemented for it
+help: the trait `Trait<isize>` is not implemented for `Struct`
+      but trait `Trait<&'static str>` is implemented for it
+  --> $DIR/coercion-generic-bad.rs:9:1
+   |
+LL | impl Trait<&'static str> for Struct {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: for that trait implementation, expected `&'static str`, found `isize`
    = note: required for the cast from `Box<Struct>` to `Box<dyn Trait<isize>>`
 

--- a/tests/ui/traits/default_auto_traits/maybe-bounds-in-dyn-traits.stderr
+++ b/tests/ui/traits/default_auto_traits/maybe-bounds-in-dyn-traits.stderr
@@ -9,7 +9,11 @@ help: the trait `bounds_check::LeakTr` is not implemented for `NonLeakS`
    |
 LL | struct NonLeakS;
    | ^^^^^^^^^^^^^^^
-   = help: the trait `bounds_check::LeakTr` is implemented for `LeakS`
+help: the trait `bounds_check::LeakTr` is implemented for `LeakS`
+  --> $DIR/maybe-bounds-in-dyn-traits.rs:62:5
+   |
+LL |     impl LeakTr for LeakS {}
+   |     ^^^^^^^^^^^^^^^^^^^^^
    = note: required for the cast from `&NonLeakS` to `&dyn bounds_check::LeakTr + Leak`
 
 error[E0038]: the trait `DynCompatCheck2` is not dyn compatible

--- a/tests/ui/traits/fn-pointer/bare-fn-no-impl-fn-ptr-99875.stderr
+++ b/tests/ui/traits/fn-pointer/bare-fn-no-impl-fn-ptr-99875.stderr
@@ -25,7 +25,11 @@ LL |     takes(|_: Argument| -> Return { todo!() });
    |     required by a bound introduced by this call
    |
    = help: the trait `Trait` is not implemented for closure `{closure@$DIR/bare-fn-no-impl-fn-ptr-99875.rs:16:11: 16:34}`
-   = help: the trait `Trait` is implemented for fn pointer `fn(Argument) -> Return`
+help: the trait `Trait` is implemented for fn pointer `fn(Argument) -> Return`
+  --> $DIR/bare-fn-no-impl-fn-ptr-99875.rs:9:1
+   |
+LL | impl Trait for fn(Argument) -> Return {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `takes`
   --> $DIR/bare-fn-no-impl-fn-ptr-99875.rs:11:18
    |

--- a/tests/ui/traits/inheritance/repeated-supertrait-ambig.stderr
+++ b/tests/ui/traits/inheritance/repeated-supertrait-ambig.stderr
@@ -6,9 +6,14 @@ LL |     c.same_as(22)
    |       |
    |       required by a bound introduced by this call
    |
-   = help: the following other types implement trait `CompareTo<T>`:
-             `i64` implements `CompareTo<i64>`
-             `i64` implements `CompareTo<u64>`
+help: the following other types implement trait `CompareTo<T>`
+  --> $DIR/repeated-supertrait-ambig.rs:15:1
+   |
+LL | impl CompareTo<i64> for i64 {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `i64` implements `CompareTo<i64>`
+...
+LL | impl CompareTo<u64> for i64 {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `i64` implements `CompareTo<u64>`
 
 error[E0277]: the trait bound `C: CompareTo<i32>` is not satisfied
   --> $DIR/repeated-supertrait-ambig.rs:30:15
@@ -29,9 +34,14 @@ error[E0277]: the trait bound `dyn CompareToInts: CompareTo<i32>` is not satisfi
 LL |     <dyn CompareToInts>::same_as(c, 22)
    |      ^^^^^^^^^^^^^^^^^ the trait `CompareTo<i32>` is not implemented for `dyn CompareToInts`
    |
-   = help: the following other types implement trait `CompareTo<T>`:
-             `i64` implements `CompareTo<i64>`
-             `i64` implements `CompareTo<u64>`
+help: the following other types implement trait `CompareTo<T>`
+  --> $DIR/repeated-supertrait-ambig.rs:15:1
+   |
+LL | impl CompareTo<i64> for i64 {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `i64` implements `CompareTo<i64>`
+...
+LL | impl CompareTo<u64> for i64 {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `i64` implements `CompareTo<u64>`
 
 error[E0277]: the trait bound `C: CompareTo<i32>` is not satisfied
   --> $DIR/repeated-supertrait-ambig.rs:38:24
@@ -54,9 +64,14 @@ LL |     assert_eq!(22_i64.same_as(22), true);
    |                       |
    |                       required by a bound introduced by this call
    |
-   = help: the following other types implement trait `CompareTo<T>`:
-             `i64` implements `CompareTo<i64>`
-             `i64` implements `CompareTo<u64>`
+help: the following other types implement trait `CompareTo<T>`
+  --> $DIR/repeated-supertrait-ambig.rs:15:1
+   |
+LL | impl CompareTo<i64> for i64 {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `i64` implements `CompareTo<i64>`
+...
+LL | impl CompareTo<u64> for i64 {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `i64` implements `CompareTo<u64>`
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/traits/issue-79458.stderr
+++ b/tests/ui/traits/issue-79458.stderr
@@ -7,7 +7,8 @@ LL | struct Foo<'a, T> {
 LL |     bar: &'a mut T
    |     ^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `&mut T`
    |
-   = help: the trait `Clone` is implemented for `&T`
+help: the trait `Clone` is implemented for `&T`
+  --> $SRC_DIR/core/src/clone.rs:LL:COL
    = note: `Clone` is implemented for `&T`, but not for `&mut T`
 
 error: aborting due to 1 previous error

--- a/tests/ui/traits/issue-91594.stderr
+++ b/tests/ui/traits/issue-91594.stderr
@@ -9,7 +9,11 @@ help: the trait `HasComponent<()>` is not implemented for `Foo`
    |
 LL | struct Foo;
    | ^^^^^^^^^^
-   = help: the trait `HasComponent<<Foo as Component<Foo>>::Interface>` is implemented for `Foo`
+help: the trait `HasComponent<<Foo as Component<Foo>>::Interface>` is implemented for `Foo`
+  --> $DIR/issue-91594.rs:10:1
+   |
+LL | impl HasComponent<<Foo as Component<Foo>>::Interface> for Foo {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required for `Foo` to implement `Component<Foo>`
   --> $DIR/issue-91594.rs:13:27
    |

--- a/tests/ui/traits/map-types.stderr
+++ b/tests/ui/traits/map-types.stderr
@@ -4,7 +4,11 @@ error[E0277]: the trait bound `Box<dyn Map<isize, isize>>: Map<usize, isize>` is
 LL |     let y: Box<dyn Map<usize, isize>> = Box::new(x);
    |                                         ^^^^^^^^^^^ the trait `Map<usize, isize>` is not implemented for `Box<dyn Map<isize, isize>>`
    |
-   = help: the trait `Map<K, V>` is implemented for `HashMap<K, V>`
+help: the trait `Map<K, V>` is implemented for `HashMap<K, V>`
+  --> $DIR/map-types.rs:10:1
+   |
+LL | impl<K, V> Map<K, V> for HashMap<K, V> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: required for the cast from `Box<Box<dyn Map<isize, isize>>>` to `Box<dyn Map<usize, isize>>`
 
 error: aborting due to 1 previous error

--- a/tests/ui/traits/next-solver/assembly/ambiguity-due-to-uniquification-1.next.stderr
+++ b/tests/ui/traits/next-solver/assembly/ambiguity-due-to-uniquification-1.next.stderr
@@ -5,7 +5,11 @@ LL |     (&() as &dyn D<&(), &()>).f()
    |                               ^
    |
    = note: cannot satisfy `dyn D<&(), &()>: B<&()>`
-   = help: the trait `B<C>` is implemented for `()`
+help: the trait `B<C>` is implemented for `()`
+  --> $DIR/ambiguity-due-to-uniquification-1.rs:9:1
+   |
+LL | impl<C> B<C> for () {}
+   | ^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `D::f`
   --> $DIR/ambiguity-due-to-uniquification-1.rs:10:16
    |

--- a/tests/ui/traits/next-solver/assembly/ambiguity-due-to-uniquification-2.next.stderr
+++ b/tests/ui/traits/next-solver/assembly/ambiguity-due-to-uniquification-2.next.stderr
@@ -5,7 +5,11 @@ LL |     impls_trait::<'y, _>(foo::<'x, 'y>());
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: cannot satisfy `impl Trait<'_> + Trait<'_>: Trait<'_>`
-   = help: the trait `Trait<'t>` is implemented for `()`
+help: the trait `Trait<'t>` is implemented for `()`
+  --> $DIR/ambiguity-due-to-uniquification-2.rs:9:1
+   |
+LL | impl<'t> Trait<'t> for () {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `impls_trait`
   --> $DIR/ambiguity-due-to-uniquification-2.rs:13:23
    |

--- a/tests/ui/traits/next-solver/assembly/ambiguity-due-to-uniquification-3.next.stderr
+++ b/tests/ui/traits/next-solver/assembly/ambiguity-due-to-uniquification-3.next.stderr
@@ -5,7 +5,11 @@ LL |     impls_trait(obj, t);
    |     ^^^^^^^^^^^^^^^^^^^
    |
    = note: cannot satisfy `dyn Object<&(), &()>: Trait<&()>`
-   = help: the trait `Trait<T>` is implemented for `()`
+help: the trait `Trait<T>` is implemented for `()`
+  --> $DIR/ambiguity-due-to-uniquification-3.rs:17:1
+   |
+LL | impl<T> Trait<T> for () {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `impls_trait`
   --> $DIR/ambiguity-due-to-uniquification-3.rs:24:19
    |

--- a/tests/ui/traits/next-solver/const-param-placeholder.fail.stderr
+++ b/tests/ui/traits/next-solver/const-param-placeholder.fail.stderr
@@ -4,7 +4,11 @@ error[E0277]: the trait bound `[T; N]: Foo` is not satisfied
 LL |     needs_foo::<[T; N]>();
    |                 ^^^^^^ the trait `Foo` is not implemented for `[T; N]`
    |
-   = help: the trait `Foo` is implemented for `[T; 1]`
+help: the trait `Foo` is implemented for `[T; 1]`
+  --> $DIR/const-param-placeholder.rs:11:1
+   |
+LL | impl<T> Foo for [T; 1] {}
+   | ^^^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `needs_foo`
   --> $DIR/const-param-placeholder.rs:8:17
    |

--- a/tests/ui/traits/next-solver/cycles/coinduction/incompleteness-unstable-result.with.stderr
+++ b/tests/ui/traits/next-solver/cycles/coinduction/incompleteness-unstable-result.with.stderr
@@ -9,7 +9,16 @@ help: the trait `Trait<_, _, _>` is not implemented for `A<X>`
    |
 LL | struct A<T>(*const T);
    | ^^^^^^^^^^^
-   = help: the trait `Trait<U, V, D>` is implemented for `A<T>`
+help: the trait `Trait<U, V, D>` is implemented for `A<T>`
+  --> $DIR/incompleteness-unstable-result.rs:34:1
+   |
+LL | / impl<T, U, V, D> Trait<U, V, D> for A<T>
+LL | | where
+LL | |     T: IncompleteGuidance<U, V>,
+LL | |     A<T>: Trait<U, D, V>,
+LL | |     B<T>: Trait<U, V, D>,
+LL | |     (): ToU8<D>,
+   | |________________^
 note: required for `A<X>` to implement `Trait<_, _, _>`
   --> $DIR/incompleteness-unstable-result.rs:34:18
    |

--- a/tests/ui/traits/next-solver/cycles/coinduction/incompleteness-unstable-result.without.stderr
+++ b/tests/ui/traits/next-solver/cycles/coinduction/incompleteness-unstable-result.without.stderr
@@ -9,7 +9,16 @@ help: the trait `Trait<_, _, _>` is not implemented for `A<X>`
    |
 LL | struct A<T>(*const T);
    | ^^^^^^^^^^^
-   = help: the trait `Trait<U, V, D>` is implemented for `A<T>`
+help: the trait `Trait<U, V, D>` is implemented for `A<T>`
+  --> $DIR/incompleteness-unstable-result.rs:34:1
+   |
+LL | / impl<T, U, V, D> Trait<U, V, D> for A<T>
+LL | | where
+LL | |     T: IncompleteGuidance<U, V>,
+LL | |     A<T>: Trait<U, D, V>,
+LL | |     B<T>: Trait<U, V, D>,
+LL | |     (): ToU8<D>,
+   | |________________^
 note: required for `A<X>` to implement `Trait<_, _, _>`
   --> $DIR/incompleteness-unstable-result.rs:34:18
    |

--- a/tests/ui/traits/next-solver/cycles/forced_ambiguity-use-head-maybe-cause.stderr
+++ b/tests/ui/traits/next-solver/cycles/forced_ambiguity-use-head-maybe-cause.stderr
@@ -5,7 +5,20 @@ LL |     impls_trait::<Root<_>>()
    |                   ^^^^^^^ cannot infer type for struct `Head<_>`
    |
    = note: cannot satisfy `Head<_>: Trait`
-   = help: the trait `Trait` is implemented for `Head<T>`
+help: the following types implement trait `Trait`
+  --> $DIR/forced_ambiguity-use-head-maybe-cause.rs:23:1
+   |
+LL | / impl<T> Trait for Head<T>
+LL | | where
+LL | |     Root<T>: Trait,
+LL | |     T: Trait, // ambiguous
+   | |_____________^ `Head<T>`
+...
+LL | / impl<T> Trait for Head<T>
+LL | | where
+LL | |     Error<T>: Trait,
+LL | |     NotImplemented<T>: Trait,
+   | |_____________________________^ `Head<T>`
 note: required for `Root<_>` to implement `Trait`
   --> $DIR/forced_ambiguity-use-head-maybe-cause.rs:18:9
    |

--- a/tests/ui/traits/next-solver/cycles/inductive-cycle-but-err.stderr
+++ b/tests/ui/traits/next-solver/cycles/inductive-cycle-but-err.stderr
@@ -21,7 +21,18 @@ help: the trait `Trait` is not implemented for `MultipleCandidates`
    |
 LL | struct MultipleCandidates;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: the trait `Trait` is implemented for `MultipleCandidates`
+help: the following other types implement trait `Trait`
+  --> $DIR/inductive-cycle-but-err.rs:26:1
+   |
+LL | / impl Trait for MultipleCandidates
+LL | | where
+LL | |     MultipleNested: Trait
+   | |_________________________^ `MultipleCandidates`
+...
+LL | / impl Trait for MultipleCandidates
+LL | | where
+LL | |     MultipleNested: Trait,
+   | |__________________________^ `MultipleCandidates`
 note: required by a bound in `impls_trait`
   --> $DIR/inductive-cycle-but-err.rs:51:19
    |

--- a/tests/ui/traits/next-solver/cycles/normalizes-to-is-not-productive.stderr
+++ b/tests/ui/traits/next-solver/cycles/normalizes-to-is-not-productive.stderr
@@ -9,7 +9,11 @@ help: the trait `Bound` is not implemented for `Foo`
    |
 LL | struct Foo;
    | ^^^^^^^^^^
-   = help: the trait `Bound` is implemented for `u32`
+help: the trait `Bound` is implemented for `u32`
+  --> $DIR/normalizes-to-is-not-productive.rs:11:1
+   |
+LL | impl Bound for u32 {
+   | ^^^^^^^^^^^^^^^^^^
 note: required for `Foo` to implement `Trait<T>`
   --> $DIR/normalizes-to-is-not-productive.rs:23:19
    |
@@ -36,7 +40,11 @@ help: the trait `Bound` is not implemented for `Foo`
    |
 LL | struct Foo;
    | ^^^^^^^^^^
-   = help: the trait `Bound` is implemented for `u32`
+help: the trait `Bound` is implemented for `u32`
+  --> $DIR/normalizes-to-is-not-productive.rs:11:1
+   |
+LL | impl Bound for u32 {
+   | ^^^^^^^^^^^^^^^^^^
 note: required by a bound in `impls_bound`
   --> $DIR/normalizes-to-is-not-productive.rs:27:19
    |

--- a/tests/ui/traits/next-solver/unevaluated-const-impl-trait-ref.fails.stderr
+++ b/tests/ui/traits/next-solver/unevaluated-const-impl-trait-ref.fails.stderr
@@ -4,9 +4,13 @@ error[E0277]: the trait bound `(): Trait<1>` is not satisfied
 LL |     needs::<1>();
    |             ^ the trait `Trait<1>` is not implemented for `()`
    |
-   = help: the following other types implement trait `Trait<N>`:
-             `()` implements `Trait<0>`
-             `()` implements `Trait<2>`
+help: the following other types implement trait `Trait<N>`
+  --> $DIR/unevaluated-const-impl-trait-ref.rs:7:1
+   |
+LL | impl Trait<{ 1 - 1 }> for () {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `()` implements `Trait<0>`
+LL | impl Trait<{ 1 + 1 }> for () {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `()` implements `Trait<2>`
 note: required by a bound in `needs`
   --> $DIR/unevaluated-const-impl-trait-ref.rs:10:38
    |

--- a/tests/ui/traits/overflow-computing-ambiguity.stderr
+++ b/tests/ui/traits/overflow-computing-ambiguity.stderr
@@ -5,9 +5,14 @@ LL |     hello();
    |     ^^^^^ cannot infer type of the type parameter `T` declared on the function `hello`
    |
    = note: cannot satisfy `_: Hello`
-   = help: the following types implement trait `Hello`:
-             Foo<'a, &'a T>
-             Foo<'static, i32>
+help: the following types implement trait `Hello`
+  --> $DIR/overflow-computing-ambiguity.rs:8:1
+   |
+LL | impl<'a, T> Hello for Foo<'a, &'a T> where Foo<'a, T>: Hello {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Foo<'a, &'a T>`
+LL |
+LL | impl Hello for Foo<'static, i32> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Foo<'static, i32>`
 note: required by a bound in `hello`
   --> $DIR/overflow-computing-ambiguity.rs:12:13
    |

--- a/tests/ui/traits/reservation-impl/no-use.next.stderr
+++ b/tests/ui/traits/reservation-impl/no-use.next.stderr
@@ -4,7 +4,11 @@ error[E0277]: the trait bound `(): MyTrait` is not satisfied
 LL |     <() as MyTrait>::foo(&());
    |      ^^ the trait `MyTrait` is not implemented for `()`
    |
-   = help: the trait `MyTrait` is implemented for `()`
+help: the trait `MyTrait` is implemented for `()`
+  --> $DIR/no-use.rs:8:1
+   |
+LL | impl MyTrait for () { fn foo(&self) {} }
+   | ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/traits/reservation-impl/no-use.next.stderr
+++ b/tests/ui/traits/reservation-impl/no-use.next.stderr
@@ -3,12 +3,6 @@ error[E0277]: the trait bound `(): MyTrait` is not satisfied
    |
 LL |     <() as MyTrait>::foo(&());
    |      ^^ the trait `MyTrait` is not implemented for `()`
-   |
-help: the trait `MyTrait` is implemented for `()`
-  --> $DIR/no-use.rs:8:1
-   |
-LL | impl MyTrait for () { fn foo(&self) {} }
-   | ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/traits/reservation-impl/no-use.old.stderr
+++ b/tests/ui/traits/reservation-impl/no-use.old.stderr
@@ -4,7 +4,11 @@ error[E0277]: the trait bound `(): MyTrait` is not satisfied
 LL |     <() as MyTrait>::foo(&());
    |      ^^ the trait `MyTrait` is not implemented for `()`
    |
-   = help: the trait `MyTrait` is implemented for `()`
+help: the trait `MyTrait` is implemented for `()`
+  --> $DIR/no-use.rs:8:1
+   |
+LL | impl MyTrait for () { fn foo(&self) {} }
+   | ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/traits/reservation-impl/no-use.old.stderr
+++ b/tests/ui/traits/reservation-impl/no-use.old.stderr
@@ -3,12 +3,6 @@ error[E0277]: the trait bound `(): MyTrait` is not satisfied
    |
 LL |     <() as MyTrait>::foo(&());
    |      ^^ the trait `MyTrait` is not implemented for `()`
-   |
-help: the trait `MyTrait` is implemented for `()`
-  --> $DIR/no-use.rs:8:1
-   |
-LL | impl MyTrait for () { fn foo(&self) {} }
-   | ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/traits/suggest-dereferences/invalid-suggest-deref-issue-127590.stderr
+++ b/tests/ui/traits/suggest-dereferences/invalid-suggest-deref-issue-127590.stderr
@@ -23,9 +23,11 @@ LL |     for (src, dest) in std::iter::zip(fields.iter(), &variant.iter()) {
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `&std::slice::Iter<'_, {integer}>` is not an iterator
    |
    = help: the trait `Iterator` is not implemented for `&std::slice::Iter<'_, {integer}>`
-   = help: the trait `Iterator` is implemented for `std::slice::Iter<'_, T>`
+help: the trait `Iterator` is implemented for `std::slice::Iter<'_, T>`
+  --> $SRC_DIR/core/src/slice/iter.rs:LL:COL
    = note: required for `Zip<std::slice::Iter<'_, {integer}>, &std::slice::Iter<'_, {integer}>>` to implement `Iterator`
    = note: required for `Zip<std::slice::Iter<'_, {integer}>, &std::slice::Iter<'_, {integer}>>` to implement `IntoIterator`
+   = note: this error originates in the macro `iterator` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `&std::slice::Iter<'_, {integer}>` is not an iterator
   --> $DIR/invalid-suggest-deref-issue-127590.rs:13:54
@@ -52,9 +54,11 @@ LL |     for (src, dest) in std::iter::zip(fields.iter(), &variant.iter().clone(
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `&std::slice::Iter<'_, {integer}>` is not an iterator
    |
    = help: the trait `Iterator` is not implemented for `&std::slice::Iter<'_, {integer}>`
-   = help: the trait `Iterator` is implemented for `std::slice::Iter<'_, T>`
+help: the trait `Iterator` is implemented for `std::slice::Iter<'_, T>`
+  --> $SRC_DIR/core/src/slice/iter.rs:LL:COL
    = note: required for `Zip<std::slice::Iter<'_, {integer}>, &std::slice::Iter<'_, {integer}>>` to implement `Iterator`
    = note: required for `Zip<std::slice::Iter<'_, {integer}>, &std::slice::Iter<'_, {integer}>>` to implement `IntoIterator`
+   = note: this error originates in the macro `iterator` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/traits/suggest-dereferences/multiple-1.stderr
+++ b/tests/ui/traits/suggest-dereferences/multiple-1.stderr
@@ -6,7 +6,11 @@ LL |     foo(&mut baz);
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `Happy` is implemented for `&mut LDM`
+help: the trait `Happy` is implemented for `&mut LDM`
+  --> $DIR/multiple-1.rs:5:1
+   |
+LL | impl Happy for &mut LDM {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `foo`
   --> $DIR/multiple-1.rs:45:26
    |

--- a/tests/ui/traits/suggest-remove-deref-issue-140166.stderr
+++ b/tests/ui/traits/suggest-remove-deref-issue-140166.stderr
@@ -6,7 +6,11 @@ LL |     format_args!("{:?}", FlatMap(&Chars));
    |                   |
    |                   required by this formatting parameter
    |
-   = help: the trait `Trait` is implemented for `Chars`
+help: the trait `Trait` is implemented for `Chars`
+  --> $DIR/suggest-remove-deref-issue-140166.rs:4:1
+   |
+LL | impl Trait for Chars {}
+   | ^^^^^^^^^^^^^^^^^^^^
 note: required for `FlatMap<&Chars>` to implement `Debug`
   --> $DIR/suggest-remove-deref-issue-140166.rs:7:16
    |

--- a/tests/ui/try-block/try-block-bad-type.stderr
+++ b/tests/ui/try-block/try-block-bad-type.stderr
@@ -7,8 +7,9 @@ LL |         Err("")?;
    |         this can't be annotated with `?` because it has type `Result<_, &str>`
    |
    = note: the question mark operation (`?`) implicitly performs a conversion on the error value using the `From` trait
-   = help: the trait `From<&str>` is not implemented for `TryFromSliceError`
-           but trait `From<Infallible>` is implemented for it
+help: the trait `From<&str>` is not implemented for `TryFromSliceError`
+      but trait `From<Infallible>` is implemented for it
+  --> $SRC_DIR/core/src/array/mod.rs:LL:COL
    = help: for that trait implementation, expected `Infallible`, found `&str`
 
 error[E0271]: type mismatch resolving `<Result<i32, i32> as Try>::Output == &str`

--- a/tests/ui/try-trait/bad-interconversion.stderr
+++ b/tests/ui/try-trait/bad-interconversion.stderr
@@ -53,8 +53,9 @@ LL | fn result_to_control_flow() -> ControlFlow<String> {
 LL |     ControlFlow::Continue(Err("hello")?)
    |                                       ^ this `?` produces `Result<Infallible, &str>`, which is incompatible with `ControlFlow<String>`
    |
-   = help: the trait `FromResidual<Result<Infallible, &str>>` is not implemented for `ControlFlow<String>`
-           but trait `FromResidual<ControlFlow<String, Infallible>>` is implemented for it
+help: the trait `FromResidual<Result<Infallible, &str>>` is not implemented for `ControlFlow<String>`
+      but trait `FromResidual<ControlFlow<String, Infallible>>` is implemented for it
+  --> $SRC_DIR/core/src/ops/control_flow.rs:LL:COL
    = help: for that trait implementation, expected `ControlFlow<String, Infallible>`, found `Result<Infallible, &str>`
 
 error[E0277]: the `?` operator can only be used on `ControlFlow`s in a function that returns `ControlFlow`
@@ -65,8 +66,9 @@ LL | fn option_to_control_flow() -> ControlFlow<u64> {
 LL |     Some(3)?;
    |            ^ this `?` produces `Option<Infallible>`, which is incompatible with `ControlFlow<u64>`
    |
-   = help: the trait `FromResidual<Option<Infallible>>` is not implemented for `ControlFlow<u64>`
-           but trait `FromResidual<ControlFlow<u64, Infallible>>` is implemented for it
+help: the trait `FromResidual<Option<Infallible>>` is not implemented for `ControlFlow<u64>`
+      but trait `FromResidual<ControlFlow<u64, Infallible>>` is implemented for it
+  --> $SRC_DIR/core/src/ops/control_flow.rs:LL:COL
    = help: for that trait implementation, expected `ControlFlow<u64, Infallible>`, found `Option<Infallible>`
 
 error[E0277]: the `?` operator in a function that returns `ControlFlow<B, _>` can only be used on other `ControlFlow<B, _>`s (with the same Break type)
@@ -78,8 +80,9 @@ LL |     ControlFlow::Break(4_u8)?;
    |                             ^ this `?` produces `ControlFlow<u8, Infallible>`, which is incompatible with `ControlFlow<i64>`
    |
    = note: unlike `Result`, there's no `From`-conversion performed for `ControlFlow`
-   = help: the trait `FromResidual<ControlFlow<u8, _>>` is not implemented for `ControlFlow<i64>`
-           but trait `FromResidual<ControlFlow<i64, _>>` is implemented for it
+help: the trait `FromResidual<ControlFlow<u8, _>>` is not implemented for `ControlFlow<i64>`
+      but trait `FromResidual<ControlFlow<i64, _>>` is implemented for it
+  --> $SRC_DIR/core/src/ops/control_flow.rs:LL:COL
    = help: for that trait implementation, expected `i64`, found `u8`
 
 error: aborting due to 8 previous errors

--- a/tests/ui/try-trait/bad-interconversion.stderr
+++ b/tests/ui/try-trait/bad-interconversion.stderr
@@ -9,9 +9,14 @@ LL |     Ok(Err(123_i32)?)
    |        this can't be annotated with `?` because it has type `Result<_, i32>`
    |
    = note: the question mark operation (`?`) implicitly performs a conversion on the error value using the `From` trait
-   = help: the following other types implement trait `From<T>`:
-             `u8` implements `From<Char>`
-             `u8` implements `From<bool>`
+help: the following other types implement trait `From<T>`
+  --> $SRC_DIR/core/src/convert/num.rs:LL:COL
+   |
+   = note: `u8` implements `From<bool>`
+  --> $SRC_DIR/core/src/ascii/ascii_char.rs:LL:COL
+   |
+   = note: `u8` implements `From<Char>`
+   = note: this error originates in the macro `impl_from` which comes from the expansion of the macro `into_int_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the `?` operator can only be used on `Result`s, not `Option`s, in a function that returns `Result`
   --> $DIR/bad-interconversion.rs:9:12

--- a/tests/ui/type-alias-impl-trait/constrain_in_projection.current.stderr
+++ b/tests/ui/type-alias-impl-trait/constrain_in_projection.current.stderr
@@ -4,8 +4,12 @@ error[E0277]: the trait bound `Foo: Trait<Bar>` is not satisfied
 LL |     let x = <Foo as Trait<Bar>>::Assoc::default();
    |              ^^^ unsatisfied trait bound
    |
-   = help: the trait `Trait<Bar>` is not implemented for `Foo`
-           but trait `Trait<()>` is implemented for it
+help: the trait `Trait<Bar>` is not implemented for `Foo`
+      but trait `Trait<()>` is implemented for it
+  --> $DIR/constrain_in_projection.rs:19:1
+   |
+LL | impl Trait<()> for Foo {
+   | ^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `Foo: Trait<Bar>` is not satisfied
   --> $DIR/constrain_in_projection.rs:25:13
@@ -13,8 +17,12 @@ error[E0277]: the trait bound `Foo: Trait<Bar>` is not satisfied
 LL |     let x = <Foo as Trait<Bar>>::Assoc::default();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
    |
-   = help: the trait `Trait<Bar>` is not implemented for `Foo`
-           but trait `Trait<()>` is implemented for it
+help: the trait `Trait<Bar>` is not implemented for `Foo`
+      but trait `Trait<()>` is implemented for it
+  --> $DIR/constrain_in_projection.rs:19:1
+   |
+LL | impl Trait<()> for Foo {
+   | ^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/type-alias-impl-trait/constrain_in_projection2.current.stderr
+++ b/tests/ui/type-alias-impl-trait/constrain_in_projection2.current.stderr
@@ -9,9 +9,14 @@ help: the trait `Trait<Bar>` is not implemented for `Foo`
    |
 LL | struct Foo;
    | ^^^^^^^^^^
-   = help: the following other types implement trait `Trait<T>`:
-             `Foo` implements `Trait<()>`
-             `Foo` implements `Trait<u32>`
+help: the following other types implement trait `Trait<T>`
+  --> $DIR/constrain_in_projection2.rs:18:1
+   |
+LL | impl Trait<()> for Foo {
+   | ^^^^^^^^^^^^^^^^^^^^^^ `Foo` implements `Trait<()>`
+...
+LL | impl Trait<u32> for Foo {
+   | ^^^^^^^^^^^^^^^^^^^^^^^ `Foo` implements `Trait<u32>`
 
 error[E0277]: the trait bound `Foo: Trait<Bar>` is not satisfied
   --> $DIR/constrain_in_projection2.rs:28:13
@@ -24,9 +29,14 @@ help: the trait `Trait<Bar>` is not implemented for `Foo`
    |
 LL | struct Foo;
    | ^^^^^^^^^^
-   = help: the following other types implement trait `Trait<T>`:
-             `Foo` implements `Trait<()>`
-             `Foo` implements `Trait<u32>`
+help: the following other types implement trait `Trait<T>`
+  --> $DIR/constrain_in_projection2.rs:18:1
+   |
+LL | impl Trait<()> for Foo {
+   | ^^^^^^^^^^^^^^^^^^^^^^ `Foo` implements `Trait<()>`
+...
+LL | impl Trait<u32> for Foo {
+   | ^^^^^^^^^^^^^^^^^^^^^^^ `Foo` implements `Trait<u32>`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/type-alias-impl-trait/impl_trait_for_tait_bound.stderr
+++ b/tests/ui/type-alias-impl-trait/impl_trait_for_tait_bound.stderr
@@ -4,7 +4,11 @@ error[E0277]: the trait bound `u32: Yay` is not satisfied
 LL |     is_yay::<u32>();
    |              ^^^ the trait `Yay` is not implemented for `u32`
    |
-   = help: the trait `Yay` is implemented for `Foo`
+help: the trait `Yay` is implemented for `Foo`
+  --> $DIR/impl_trait_for_tait_bound.rs:7:1
+   |
+LL | impl Yay for Foo {}
+   | ^^^^^^^^^^^^^^^^
 note: required by a bound in `is_yay`
   --> $DIR/impl_trait_for_tait_bound.rs:17:14
    |

--- a/tests/ui/type-alias-impl-trait/impl_trait_for_tait_bound2.stderr
+++ b/tests/ui/type-alias-impl-trait/impl_trait_for_tait_bound2.stderr
@@ -4,7 +4,11 @@ error[E0277]: the trait bound `Foo: Yay` is not satisfied
 LL |     is_yay::<Foo>();
    |              ^^^ the trait `Yay` is not implemented for `Foo`
    |
-   = help: the trait `Yay` is implemented for `u32`
+help: the trait `Yay` is implemented for `u32`
+  --> $DIR/impl_trait_for_tait_bound2.rs:8:1
+   |
+LL | impl Yay for u32 {}
+   | ^^^^^^^^^^^^^^^^
 note: required by a bound in `is_yay`
   --> $DIR/impl_trait_for_tait_bound2.rs:15:14
    |

--- a/tests/ui/type-alias-impl-trait/issue-60371.stderr
+++ b/tests/ui/type-alias-impl-trait/issue-60371.stderr
@@ -14,7 +14,11 @@ error[E0277]: the trait bound `(): Bug` is not satisfied
 LL |     const FUN: fn() -> Self::Item = || ();
    |                                        ^^ the trait `Bug` is not implemented for `()`
    |
-   = help: the trait `Bug` is implemented for `&()`
+help: the trait `Bug` is implemented for `&()`
+  --> $DIR/issue-60371.rs:7:1
+   |
+LL | impl Bug for &() {
+   | ^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/type-alias-impl-trait/nested-tait-inference.current.stderr
+++ b/tests/ui/type-alias-impl-trait/nested-tait-inference.current.stderr
@@ -7,8 +7,12 @@ LL | fn foo() -> impl Foo<FooX> {
 LL |     ()
    |     -- return type was inferred to be `()` here
    |
-   = help: the trait `Foo<FooX>` is not implemented for `()`
-           but trait `Foo<()>` is implemented for it
+help: the trait `Foo<FooX>` is not implemented for `()`
+      but trait `Foo<()>` is implemented for it
+  --> $DIR/nested-tait-inference.rs:15:1
+   |
+LL | impl Foo<()> for () {}
+   | ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/type-alias-impl-trait/nested-tait-inference2.current.stderr
+++ b/tests/ui/type-alias-impl-trait/nested-tait-inference2.current.stderr
@@ -7,9 +7,13 @@ LL |
 LL |     ()
    |     -- return type was inferred to be `()` here
    |
-   = help: the following other types implement trait `Foo<A>`:
-             `()` implements `Foo<()>`
-             `()` implements `Foo<u32>`
+help: the following other types implement trait `Foo<A>`
+  --> $DIR/nested-tait-inference2.rs:14:1
+   |
+LL | impl Foo<()> for () {}
+   | ^^^^^^^^^^^^^^^^^^^ `()` implements `Foo<()>`
+LL | impl Foo<u32> for () {}
+   | ^^^^^^^^^^^^^^^^^^^^ `()` implements `Foo<u32>`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/type-alias-impl-trait/self-referential-2.current.stderr
+++ b/tests/ui/type-alias-impl-trait/self-referential-2.current.stderr
@@ -6,8 +6,10 @@ LL | fn bar() -> Bar {
 LL |     42_i32
    |     ------ return type was inferred to be `i32` here
    |
-   = help: the trait `PartialEq<Foo>` is not implemented for `i32`
-           but trait `PartialEq<i32>` is implemented for it
+help: the trait `PartialEq<Foo>` is not implemented for `i32`
+      but trait `PartialEq<i32>` is implemented for it
+  --> $SRC_DIR/core/src/cmp.rs:LL:COL
+   = note: this error originates in the macro `partial_eq_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/type-alias-impl-trait/self-referential-3.stderr
+++ b/tests/ui/type-alias-impl-trait/self-referential-3.stderr
@@ -8,7 +8,9 @@ LL |     i
    |     - return type was inferred to be `&i32` here
    |
    = help: the trait `PartialEq<Bar<'a, 'b>>` is not implemented for `&i32`
-   = help: the trait `PartialEq` is implemented for `i32`
+help: the trait `PartialEq` is implemented for `i32`
+  --> $SRC_DIR/core/src/cmp.rs:LL:COL
+   = note: this error originates in the macro `partial_eq_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/type-alias-impl-trait/self-referential-4.stderr
+++ b/tests/ui/type-alias-impl-trait/self-referential-4.stderr
@@ -7,7 +7,9 @@ LL |     i
    |     - return type was inferred to be `&i32` here
    |
    = help: the trait `PartialEq<Bar<'b, 'static>>` is not implemented for `&i32`
-   = help: the trait `PartialEq` is implemented for `i32`
+help: the trait `PartialEq` is implemented for `i32`
+  --> $SRC_DIR/core/src/cmp.rs:LL:COL
+   = note: this error originates in the macro `partial_eq_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: can't compare `&i32` with `Foo<'static, 'b>`
   --> $DIR/self-referential-4.rs:13:31
@@ -18,7 +20,9 @@ LL |     i
    |     - return type was inferred to be `&i32` here
    |
    = help: the trait `PartialEq<Foo<'static, 'b>>` is not implemented for `&i32`
-   = help: the trait `PartialEq` is implemented for `i32`
+help: the trait `PartialEq` is implemented for `i32`
+  --> $SRC_DIR/core/src/cmp.rs:LL:COL
+   = note: this error originates in the macro `partial_eq_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: can't compare `&i32` with `Moo<'static, 'a>`
   --> $DIR/self-referential-4.rs:20:31
@@ -29,7 +33,9 @@ LL |     i
    |     - return type was inferred to be `&i32` here
    |
    = help: the trait `PartialEq<Moo<'static, 'a>>` is not implemented for `&i32`
-   = help: the trait `PartialEq` is implemented for `i32`
+help: the trait `PartialEq` is implemented for `i32`
+  --> $SRC_DIR/core/src/cmp.rs:LL:COL
+   = note: this error originates in the macro `partial_eq_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/type-alias-impl-trait/self-referential.stderr
+++ b/tests/ui/type-alias-impl-trait/self-referential.stderr
@@ -8,7 +8,9 @@ LL |     i
    |     - return type was inferred to be `&i32` here
    |
    = help: the trait `PartialEq<Bar<'b, 'a>>` is not implemented for `&i32`
-   = help: the trait `PartialEq` is implemented for `i32`
+help: the trait `PartialEq` is implemented for `i32`
+  --> $SRC_DIR/core/src/cmp.rs:LL:COL
+   = note: this error originates in the macro `partial_eq_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: can't compare `&i32` with `(i32, Foo<'a, 'b>::{opaque#0}<'a, 'b>)`
   --> $DIR/self-referential.rs:14:31
@@ -20,7 +22,9 @@ LL |     (42, i)
    |     ------- return type was inferred to be `(i32, &i32)` here
    |
    = help: the trait `PartialEq<(i32, Foo<'a, 'b>::{opaque#0}<'a, 'b>)>` is not implemented for `&i32`
-   = help: the trait `PartialEq` is implemented for `i32`
+help: the trait `PartialEq` is implemented for `i32`
+  --> $SRC_DIR/core/src/cmp.rs:LL:COL
+   = note: this error originates in the macro `partial_eq_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: can't compare `&i32` with `(i32, Moo<'b, 'a>::{opaque#0}<'b, 'a>)`
   --> $DIR/self-referential.rs:22:31
@@ -32,7 +36,9 @@ LL |     (42, i)
    |     ------- return type was inferred to be `(i32, &i32)` here
    |
    = help: the trait `PartialEq<(i32, Moo<'b, 'a>::{opaque#0}<'b, 'a>)>` is not implemented for `&i32`
-   = help: the trait `PartialEq` is implemented for `i32`
+help: the trait `PartialEq` is implemented for `i32`
+  --> $SRC_DIR/core/src/cmp.rs:LL:COL
+   = note: this error originates in the macro `partial_eq_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/type/type-check-defaults.stderr
+++ b/tests/ui/type/type-check-defaults.stderr
@@ -83,16 +83,22 @@ LL | trait ProjectionPred<T:Iterator = IntoIter<i32>> where T::Item : Add<u8> {}
    |                                                                  ^^^^^^^ no implementation for `i32 + u8`
    |
    = help: the trait `Add<u8>` is not implemented for `i32`
-   = help: the following other types implement trait `Add<Rhs>`:
-             `&i32` implements `Add<i32>`
-             `&i32` implements `Add`
-             `i32` implements `Add<&i32>`
-             `i32` implements `Add`
+help: the following other types implement trait `Add<Rhs>`
+  --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
+   |
+   = note: `&i32` implements `Add<i32>`
+   |
+   = note: `&i32` implements `Add`
+   |
+   = note: `i32` implements `Add<&i32>`
+   |
+   = note: `i32` implements `Add`
 note: required by a bound in `ProjectionPred`
   --> $DIR/type-check-defaults.rs:24:66
    |
 LL | trait ProjectionPred<T:Iterator = IntoIter<i32>> where T::Item : Add<u8> {}
    |                                                                  ^^^^^^^ required by this bound in `ProjectionPred`
+   = note: this error originates in the macro `add_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 7 previous errors
 

--- a/tests/ui/typeck/foreign_struct_trait_unimplemented.stderr
+++ b/tests/ui/typeck/foreign_struct_trait_unimplemented.stderr
@@ -6,7 +6,11 @@ LL |     needs_test(foreign_struct_trait_unimplemented::B);
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `Test` is implemented for `A`
+help: the trait `Test` is implemented for `A`
+  --> $DIR/foreign_struct_trait_unimplemented.rs:8:1
+   |
+LL | impl Test for A {}
+   | ^^^^^^^^^^^^^^^
 note: required by a bound in `needs_test`
   --> $DIR/foreign_struct_trait_unimplemented.rs:10:23
    |

--- a/tests/ui/typeck/issue-81293.stderr
+++ b/tests/ui/typeck/issue-81293.stderr
@@ -20,11 +20,17 @@ LL |     a = c + b * 5;
    |           ^ no implementation for `usize + u16`
    |
    = help: the trait `Add<u16>` is not implemented for `usize`
-   = help: the following other types implement trait `Add<Rhs>`:
-             `&usize` implements `Add<usize>`
-             `&usize` implements `Add`
-             `usize` implements `Add<&usize>`
-             `usize` implements `Add`
+help: the following other types implement trait `Add<Rhs>`
+  --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
+   |
+   = note: `&usize` implements `Add<usize>`
+   |
+   = note: `&usize` implements `Add`
+   |
+   = note: `usize` implements `Add<&usize>`
+   |
+   = note: `usize` implements `Add`
+   = note: this error originates in the macro `add_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/typeck/suggestions/suggest-similar-impls-for-root-obligation.stderr
+++ b/tests/ui/typeck/suggestions/suggest-similar-impls-for-root-obligation.stderr
@@ -4,8 +4,12 @@ error[E0277]: the trait bound `((),): Into<Bar>` is not satisfied
 LL |     let _: Bar = ((),).into();
    |                        ^^^^ the trait `Foo<'_>` is not implemented for `((),)`
    |
-   = help: the trait `Foo<'_>` is not implemented for `((),)`
-           but it is implemented for `()`
+help: the trait `Foo<'_>` is not implemented for `((),)`
+      but it is implemented for `()`
+  --> $DIR/suggest-similar-impls-for-root-obligation.rs:3:1
+   |
+LL | impl<'s> Foo<'s> for () {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^
    = help: for that trait implementation, expected `()`, found `((),)`
 note: required for `Bar` to implement `From<((),)>`
   --> $DIR/suggest-similar-impls-for-root-obligation.rs:7:22

--- a/tests/ui/ufcs/ufcs-qpath-self-mismatch.stderr
+++ b/tests/ui/ufcs/ufcs-qpath-self-mismatch.stderr
@@ -5,11 +5,17 @@ LL |     <i32 as Add<u32>>::add(1, 2);
    |      ^^^ no implementation for `i32 + u32`
    |
    = help: the trait `Add<u32>` is not implemented for `i32`
-   = help: the following other types implement trait `Add<Rhs>`:
-             `&i32` implements `Add<i32>`
-             `&i32` implements `Add`
-             `i32` implements `Add<&i32>`
-             `i32` implements `Add`
+help: the following other types implement trait `Add<Rhs>`
+  --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
+   |
+   = note: `&i32` implements `Add<i32>`
+   |
+   = note: `&i32` implements `Add`
+   |
+   = note: `i32` implements `Add<&i32>`
+   |
+   = note: `i32` implements `Add`
+   = note: this error originates in the macro `add_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0308]: mismatched types
   --> $DIR/ufcs-qpath-self-mismatch.rs:7:28
@@ -64,11 +70,17 @@ LL |     <i32 as Add<u32>>::add(1, 2);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no implementation for `i32 + u32`
    |
    = help: the trait `Add<u32>` is not implemented for `i32`
-   = help: the following other types implement trait `Add<Rhs>`:
-             `&i32` implements `Add<i32>`
-             `&i32` implements `Add`
-             `i32` implements `Add<&i32>`
-             `i32` implements `Add`
+help: the following other types implement trait `Add<Rhs>`
+  --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
+   |
+   = note: `&i32` implements `Add<i32>`
+   |
+   = note: `&i32` implements `Add`
+   |
+   = note: `i32` implements `Add<&i32>`
+   |
+   = note: `i32` implements `Add`
+   = note: this error originates in the macro `add_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/wf/hir-wf-check-erase-regions.nll.stderr
+++ b/tests/ui/wf/hir-wf-check-erase-regions.nll.stderr
@@ -5,7 +5,8 @@ LL |     type IntoIter = std::iter::Flatten<std::slice::Iter<'a, T>>;
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `&'a T` is not an iterator
    |
    = help: the trait `Iterator` is not implemented for `&'a T`
-   = help: the trait `Iterator` is implemented for `&mut I`
+help: the trait `Iterator` is implemented for `&mut I`
+  --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
    = note: required for `Flatten<std::slice::Iter<'a, T>>` to implement `Iterator`
 note: required by a bound in `std::iter::IntoIterator::IntoIter`
   --> $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
@@ -17,7 +18,8 @@ LL |     type IntoIter = std::iter::Flatten<std::slice::Iter<'a, T>>;
    |     ^^^^^^^^^^^^^ `&'a T` is not an iterator
    |
    = help: the trait `Iterator` is not implemented for `&'a T`
-   = help: the trait `Iterator` is implemented for `&mut I`
+help: the trait `Iterator` is implemented for `&mut I`
+  --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
    = note: required for `&'a T` to implement `IntoIterator`
 note: required by a bound in `Flatten`
   --> $SRC_DIR/core/src/iter/adapters/flatten.rs:LL:COL
@@ -29,7 +31,8 @@ LL |     fn into_iter(self) -> Self::IntoIter {
    |                           ^^^^^^^^^^^^^^ `&'a T` is not an iterator
    |
    = help: the trait `Iterator` is not implemented for `&'a T`
-   = help: the trait `Iterator` is implemented for `&mut I`
+help: the trait `Iterator` is implemented for `&mut I`
+  --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
    = note: required for `&'a T` to implement `IntoIterator`
 note: required by a bound in `Flatten`
   --> $SRC_DIR/core/src/iter/adapters/flatten.rs:LL:COL
@@ -41,7 +44,8 @@ LL |     fn into_iter(self) -> Self::IntoIter {
    |                           ^^^^^^^^^^^^^^ `&T` is not an iterator
    |
    = help: the trait `Iterator` is not implemented for `&T`
-   = help: the trait `Iterator` is implemented for `&mut I`
+help: the trait `Iterator` is implemented for `&mut I`
+  --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
    = note: required for `&T` to implement `IntoIterator`
 
 error: aborting due to 4 previous errors

--- a/tests/ui/wf/hir-wf-check-erase-regions.polonius.stderr
+++ b/tests/ui/wf/hir-wf-check-erase-regions.polonius.stderr
@@ -5,7 +5,8 @@ LL |     type IntoIter = std::iter::Flatten<std::slice::Iter<'a, T>>;
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `&'a T` is not an iterator
    |
    = help: the trait `Iterator` is not implemented for `&'a T`
-   = help: the trait `Iterator` is implemented for `&mut I`
+help: the trait `Iterator` is implemented for `&mut I`
+  --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
    = note: required for `Flatten<std::slice::Iter<'a, T>>` to implement `Iterator`
 note: required by a bound in `std::iter::IntoIterator::IntoIter`
   --> $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
@@ -17,7 +18,8 @@ LL |     type IntoIter = std::iter::Flatten<std::slice::Iter<'a, T>>;
    |     ^^^^^^^^^^^^^ `&'a T` is not an iterator
    |
    = help: the trait `Iterator` is not implemented for `&'a T`
-   = help: the trait `Iterator` is implemented for `&mut I`
+help: the trait `Iterator` is implemented for `&mut I`
+  --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
    = note: required for `&'a T` to implement `IntoIterator`
 note: required by a bound in `Flatten`
   --> $SRC_DIR/core/src/iter/adapters/flatten.rs:LL:COL
@@ -29,7 +31,8 @@ LL |     fn into_iter(self) -> Self::IntoIter {
    |                           ^^^^^^^^^^^^^^ `&'a T` is not an iterator
    |
    = help: the trait `Iterator` is not implemented for `&'a T`
-   = help: the trait `Iterator` is implemented for `&mut I`
+help: the trait `Iterator` is implemented for `&mut I`
+  --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
    = note: required for `&'a T` to implement `IntoIterator`
 note: required by a bound in `Flatten`
   --> $SRC_DIR/core/src/iter/adapters/flatten.rs:LL:COL


### PR DESCRIPTION
```
error[E0277]: the trait bound `u32: Trait` is not satisfied
  --> $DIR/trait_objects_fail.rs:26:9
   |
LL |     foo(&10_u32);
   |         ^^^^^^^ the trait `Trait` is not implemented for `u32`
   |
help: the trait `Trait<12>` is not implemented for `u32`
      but trait `Trait<2>` is implemented for it
  --> $DIR/trait_objects_fail.rs:7:1
   |
LL | impl Trait<2> for u32 {}
   | ^^^^^^^^^^^^^^^^^^^^^
   = note: required for the cast from `&u32` to `&dyn Trait`
```

Pointing at the `impl` definition that *could* apply given a different self type is *particularly* useful when it has a blanket self type, as it might not be obvious and is not trivially greppable:

```
error[E0277]: the trait bound `RawImpl<_>: Raw<_>` is not satisfied
  --> $DIR/issue-62742.rs:4:5
   |
LL |     WrongImpl::foo(0i32);
   |     ^^^^^^^^^ unsatisfied trait bound
   |
help: the trait `Raw<_>` is not implemented for `RawImpl<_>`
      but trait `Raw<[_]>` is implemented for it
  --> $DIR/issue-62742.rs:29:1
   |
LL | impl<T> Raw<[T]> for RawImpl<T> {
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
note: required by a bound in `SafeImpl`
  --> $DIR/issue-62742.rs:33:35
   |
LL | pub struct SafeImpl<T: ?Sized, A: Raw<T>>(PhantomData<(A, T)>);
   |                                   ^^^^^^ required by this bound in `SafeImpl`
```

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
