### PR TITLE
On E0277, point at type that doesn't implement bound

### DIFF
--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -275,8 +275,9 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                         *err.long_ty_path() = long_ty_file;
 
                         let mut suggested = false;
+                        let mut noted_missing_impl = false;
                         if is_try_conversion || is_question_mark {
-                            suggested = self.try_conversion_context(&obligation, main_trait_predicate, &mut err);
+                            (suggested, noted_missing_impl) = self.try_conversion_context(&obligation, main_trait_predicate, &mut err);
                         }
 
                         if let Some(ret_span) = self.return_type_span(&obligation) {
@@ -335,6 +336,11 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                             return err.emit();
                         }
 
+                        let ty_span = match leaf_trait_predicate.self_ty().skip_binder().kind() {
+                            ty::Adt(def, _) if def.did().is_local()
+                                && !self.can_suggest_derive(&obligation, leaf_trait_predicate) => self.tcx.def_span(def.did()),
+                            _ => DUMMY_SP,
+                        };
                         if let Some(s) = label {
                             // If it has a custom `#[rustc_on_unimplemented]`
                             // error message, let's display it as the label!
@@ -347,15 +353,28 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                                     // Don't say "the trait `FromResidual<Option<Infallible>>` is
                                     // not implemented for `Result<T, E>`".
                             {
-                                err.help(explanation);
+                                // We do this just so that the JSON output's `help` position is the
+                                // right one and not `file.rs:1:1`. The render is the same.
+                                if ty_span == DUMMY_SP {
+                                    err.help(explanation);
+                                } else {
+                                    err.span_help(ty_span, explanation);
+                                }
                             }
                         } else if let Some(custom_explanation) = safe_transmute_explanation {
                             err.span_label(span, custom_explanation);
-                        } else if explanation.len() > self.tcx.sess.diagnostic_width() {
+                        } else if (explanation.len() > self.tcx.sess.diagnostic_width() || ty_span != DUMMY_SP) && !noted_missing_impl {
                             // Really long types don't look good as span labels, instead move it
                             // to a `help`.
                             err.span_label(span, "unsatisfied trait bound");
-                            err.help(explanation);
+
+                            // We do this just so that the JSON output's `help` position is the
+                            // right one and not `file.rs:1:1`. The render is the same.
+                            if ty_span == DUMMY_SP {
+                                err.help(explanation);
+                            } else {
+                                err.span_help(ty_span, explanation);
+                            }
                         } else {
                             err.span_label(span, explanation);
                         }
@@ -939,7 +958,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         obligation: &PredicateObligation<'tcx>,
         trait_pred: ty::PolyTraitPredicate<'tcx>,
         err: &mut Diag<'_>,
-    ) -> bool {
+    ) -> (bool, bool) {
         let span = obligation.cause.span;
         /// Look for the (direct) sub-expr of `?`, and return it if it's a `.` method call.
         struct FindMethodSubexprOfTry {
@@ -959,21 +978,22 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             }
         }
         let hir_id = self.tcx.local_def_id_to_hir_id(obligation.cause.body_id);
-        let Some(body_id) = self.tcx.hir_node(hir_id).body_id() else { return false };
+        let Some(body_id) = self.tcx.hir_node(hir_id).body_id() else { return (false, false) };
         let ControlFlow::Break(expr) =
             (FindMethodSubexprOfTry { search_span: span }).visit_body(self.tcx.hir_body(body_id))
         else {
-            return false;
+            return (false, false);
         };
         let Some(typeck) = &self.typeck_results else {
-            return false;
+            return (false, false);
         };
         let ObligationCauseCode::QuestionMark = obligation.cause.code().peel_derives() else {
-            return false;
+            return (false, false);
         };
         let self_ty = trait_pred.skip_binder().self_ty();
         let found_ty = trait_pred.skip_binder().trait_ref.args.get(1).and_then(|a| a.as_type());
-        self.note_missing_impl_for_question_mark(err, self_ty, found_ty, trait_pred);
+        let noted_missing_impl =
+            self.note_missing_impl_for_question_mark(err, self_ty, found_ty, trait_pred);
 
         let mut prev_ty = self.resolve_vars_if_possible(
             typeck.expr_ty_adjusted_opt(expr).unwrap_or(Ty::new_misc_error(self.tcx)),
@@ -1137,7 +1157,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             }
             prev = Some(err_ty);
         }
-        suggested
+        (suggested, noted_missing_impl)
     }
 
     fn note_missing_impl_for_question_mark(
@@ -1146,7 +1166,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         self_ty: Ty<'_>,
         found_ty: Option<Ty<'_>>,
         trait_pred: ty::PolyTraitPredicate<'tcx>,
-    ) {
+    ) -> bool {
         match (self_ty.kind(), found_ty) {
             (ty::Adt(def, _), Some(ty))
                 if let ty::Adt(found, _) = ty.kind()
@@ -1187,8 +1207,9 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     format!("`{ty}` needs to implement `Into<{self_ty}>`"),
                 );
             }
-            _ => {}
+            _ => return false,
         }
+        true
     }
 
     fn report_const_param_not_wf(

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
@@ -3853,59 +3853,71 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         }
     }
 
+    pub fn can_suggest_derive(
+        &self,
+        obligation: &PredicateObligation<'tcx>,
+        trait_pred: ty::PolyTraitPredicate<'tcx>,
+    ) -> bool {
+        if trait_pred.polarity() == ty::PredicatePolarity::Negative {
+            return false;
+        }
+        let Some(diagnostic_name) = self.tcx.get_diagnostic_name(trait_pred.def_id()) else {
+            return false;
+        };
+        let (adt, args) = match trait_pred.skip_binder().self_ty().kind() {
+            ty::Adt(adt, args) if adt.did().is_local() => (adt, args),
+            _ => return false,
+        };
+        let is_derivable_trait = match diagnostic_name {
+            sym::Default => !adt.is_enum(),
+            sym::PartialEq | sym::PartialOrd => {
+                let rhs_ty = trait_pred.skip_binder().trait_ref.args.type_at(1);
+                trait_pred.skip_binder().self_ty() == rhs_ty
+            }
+            sym::Eq | sym::Ord | sym::Clone | sym::Copy | sym::Hash | sym::Debug => true,
+            _ => false,
+        };
+        is_derivable_trait &&
+            // Ensure all fields impl the trait.
+            adt.all_fields().all(|field| {
+                let field_ty = ty::GenericArg::from(field.ty(self.tcx, args));
+                let trait_args = match diagnostic_name {
+                    sym::PartialEq | sym::PartialOrd => {
+                        Some(field_ty)
+                    }
+                    _ => None,
+                };
+                let trait_pred = trait_pred.map_bound_ref(|tr| ty::TraitPredicate {
+                    trait_ref: ty::TraitRef::new(self.tcx,
+                        trait_pred.def_id(),
+                        [field_ty].into_iter().chain(trait_args),
+                    ),
+                    ..*tr
+                });
+                let field_obl = Obligation::new(
+                    self.tcx,
+                    obligation.cause.clone(),
+                    obligation.param_env,
+                    trait_pred,
+                );
+                self.predicate_must_hold_modulo_regions(&field_obl)
+            })
+    }
+
     pub fn suggest_derive(
         &self,
         obligation: &PredicateObligation<'tcx>,
         err: &mut Diag<'_>,
         trait_pred: ty::PolyTraitPredicate<'tcx>,
     ) {
-        if trait_pred.polarity() == ty::PredicatePolarity::Negative {
-            return;
-        }
         let Some(diagnostic_name) = self.tcx.get_diagnostic_name(trait_pred.def_id()) else {
             return;
         };
-        let (adt, args) = match trait_pred.skip_binder().self_ty().kind() {
-            ty::Adt(adt, args) if adt.did().is_local() => (adt, args),
+        let adt = match trait_pred.skip_binder().self_ty().kind() {
+            ty::Adt(adt, _) if adt.did().is_local() => adt,
             _ => return,
         };
-        let can_derive = {
-            let is_derivable_trait = match diagnostic_name {
-                sym::Default => !adt.is_enum(),
-                sym::PartialEq | sym::PartialOrd => {
-                    let rhs_ty = trait_pred.skip_binder().trait_ref.args.type_at(1);
-                    trait_pred.skip_binder().self_ty() == rhs_ty
-                }
-                sym::Eq | sym::Ord | sym::Clone | sym::Copy | sym::Hash | sym::Debug => true,
-                _ => false,
-            };
-            is_derivable_trait &&
-                // Ensure all fields impl the trait.
-                adt.all_fields().all(|field| {
-                    let field_ty = ty::GenericArg::from(field.ty(self.tcx, args));
-                    let trait_args = match diagnostic_name {
-                        sym::PartialEq | sym::PartialOrd => {
-                            Some(field_ty)
-                        }
-                        _ => None,
-                    };
-                    let trait_pred = trait_pred.map_bound_ref(|tr| ty::TraitPredicate {
-                        trait_ref: ty::TraitRef::new(self.tcx,
-                            trait_pred.def_id(),
-                            [field_ty].into_iter().chain(trait_args),
-                        ),
-                        ..*tr
-                    });
-                    let field_obl = Obligation::new(
-                        self.tcx,
-                        obligation.cause.clone(),
-                        obligation.param_env,
-                        trait_pred,
-                    );
-                    self.predicate_must_hold_modulo_regions(&field_obl)
-                })
-        };
-        if can_derive {
+        if self.can_suggest_derive(obligation, trait_pred) {
             err.span_suggestion_verbose(
                 self.tcx.def_span(adt.did()).shrink_to_lo(),
                 format!(

--- a/tests/ui-fulldeps/rustc-dev-remap.only-remap.stderr
+++ b/tests/ui-fulldeps/rustc-dev-remap.only-remap.stderr
@@ -2,8 +2,13 @@ error[E0277]: the trait bound `NotAValidResultType: VisitorResult` is not satisf
   --> $DIR/rustc-dev-remap.rs:LL:COL
    |
 LL |     type Result = NotAValidResultType;
-   |                   ^^^^^^^^^^^^^^^^^^^ the trait `VisitorResult` is not implemented for `NotAValidResultType`
+   |                   ^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
    |
+help: the trait `VisitorResult` is not implemented for `NotAValidResultType`
+  --> $DIR/rustc-dev-remap.rs:LL:COL
+   |
+LL | struct NotAValidResultType;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: the following other types implement trait `VisitorResult`:
              ()
              ControlFlow<T>

--- a/tests/ui-fulldeps/rustc-dev-remap.remap-unremap.stderr
+++ b/tests/ui-fulldeps/rustc-dev-remap.remap-unremap.stderr
@@ -2,8 +2,13 @@ error[E0277]: the trait bound `NotAValidResultType: VisitorResult` is not satisf
   --> $DIR/rustc-dev-remap.rs:LL:COL
    |
 LL |     type Result = NotAValidResultType;
-   |                   ^^^^^^^^^^^^^^^^^^^ the trait `VisitorResult` is not implemented for `NotAValidResultType`
+   |                   ^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
    |
+help: the trait `VisitorResult` is not implemented for `NotAValidResultType`
+  --> $DIR/rustc-dev-remap.rs:LL:COL
+   |
+LL | struct NotAValidResultType;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: the following other types implement trait `VisitorResult`:
              ()
              ControlFlow<T>

--- a/tests/ui-fulldeps/session-diagnostic/diagnostic-derive-doc-comment-field.stderr
+++ b/tests/ui-fulldeps/session-diagnostic/diagnostic-derive-doc-comment-field.stderr
@@ -5,8 +5,13 @@ LL | #[derive(Diagnostic)]
    |          ---------- required by a bound introduced by this call
 ...
 LL |     arg: NotIntoDiagArg,
-   |          ^^^^^^^^^^^^^^ the trait `IntoDiagArg` is not implemented for `NotIntoDiagArg`
+   |          ^^^^^^^^^^^^^^ unsatisfied trait bound
    |
+help: the trait `IntoDiagArg` is not implemented for `NotIntoDiagArg`
+  --> $DIR/diagnostic-derive-doc-comment-field.rs:28:1
+   |
+LL | struct NotIntoDiagArg;
+   | ^^^^^^^^^^^^^^^^^^^^^
    = help: normalized in stderr
 note: required by a bound in `Diag::<'a, G>::arg`
   --> $COMPILER_DIR/rustc_errors/src/diagnostic.rs:LL:CC
@@ -19,8 +24,13 @@ LL | #[derive(Subdiagnostic)]
    |          ------------- required by a bound introduced by this call
 ...
 LL |     arg: NotIntoDiagArg,
-   |          ^^^^^^^^^^^^^^ the trait `IntoDiagArg` is not implemented for `NotIntoDiagArg`
+   |          ^^^^^^^^^^^^^^ unsatisfied trait bound
    |
+help: the trait `IntoDiagArg` is not implemented for `NotIntoDiagArg`
+  --> $DIR/diagnostic-derive-doc-comment-field.rs:28:1
+   |
+LL | struct NotIntoDiagArg;
+   | ^^^^^^^^^^^^^^^^^^^^^
    = help: normalized in stderr
 note: required by a bound in `Diag::<'a, G>::arg`
   --> $COMPILER_DIR/rustc_errors/src/diagnostic.rs:LL:CC

--- a/tests/ui-fulldeps/session-diagnostic/diagnostic-derive.stderr
+++ b/tests/ui-fulldeps/session-diagnostic/diagnostic-derive.stderr
@@ -637,8 +637,13 @@ LL | #[derive(Diagnostic)]
    |          ---------- required by a bound introduced by this call
 ...
 LL |     other: Hello,
-   |            ^^^^^ the trait `IntoDiagArg` is not implemented for `Hello`
+   |            ^^^^^ unsatisfied trait bound
    |
+help: the trait `IntoDiagArg` is not implemented for `Hello`
+  --> $DIR/diagnostic-derive.rs:40:1
+   |
+LL | struct Hello {}
+   | ^^^^^^^^^^^^
    = help: normalized in stderr
 note: required by a bound in `Diag::<'a, G>::arg`
   --> $COMPILER_DIR/rustc_errors/src/diagnostic.rs:LL:CC

--- a/tests/ui/associated-consts/issue-105330.stderr
+++ b/tests/ui/associated-consts/issue-105330.stderr
@@ -53,8 +53,13 @@ error[E0277]: the trait bound `Demo: TraitWAssocConst` is not satisfied
   --> $DIR/issue-105330.rs:12:11
    |
 LL |     foo::<Demo>()();
-   |           ^^^^ the trait `TraitWAssocConst` is not implemented for `Demo`
+   |           ^^^^ unsatisfied trait bound
    |
+help: the trait `TraitWAssocConst` is not implemented for `Demo`
+  --> $DIR/issue-105330.rs:4:1
+   |
+LL | pub struct Demo {}
+   | ^^^^^^^^^^^^^^^
 note: required by a bound in `foo`
   --> $DIR/issue-105330.rs:11:11
    |
@@ -75,8 +80,13 @@ error[E0277]: the trait bound `Demo: TraitWAssocConst` is not satisfied
   --> $DIR/issue-105330.rs:20:11
    |
 LL |     foo::<Demo>();
-   |           ^^^^ the trait `TraitWAssocConst` is not implemented for `Demo`
+   |           ^^^^ unsatisfied trait bound
    |
+help: the trait `TraitWAssocConst` is not implemented for `Demo`
+  --> $DIR/issue-105330.rs:4:1
+   |
+LL | pub struct Demo {}
+   | ^^^^^^^^^^^^^^^
 note: required by a bound in `foo`
   --> $DIR/issue-105330.rs:11:11
    |

--- a/tests/ui/associated-types/defaults-suitability.current.stderr
+++ b/tests/ui/associated-types/defaults-suitability.current.stderr
@@ -73,8 +73,13 @@ error[E0277]: the trait bound `NotClone: IsU8<NotClone>` is not satisfied
   --> $DIR/defaults-suitability.rs:59:18
    |
 LL |     type Assoc = NotClone;
-   |                  ^^^^^^^^ the trait `IsU8<NotClone>` is not implemented for `NotClone`
+   |                  ^^^^^^^^ unsatisfied trait bound
    |
+help: the trait `IsU8<NotClone>` is not implemented for `NotClone`
+  --> $DIR/defaults-suitability.rs:12:1
+   |
+LL | struct NotClone;
+   | ^^^^^^^^^^^^^^^
 note: required by a bound in `D::Assoc`
   --> $DIR/defaults-suitability.rs:56:18
    |

--- a/tests/ui/associated-types/defaults-suitability.next.stderr
+++ b/tests/ui/associated-types/defaults-suitability.next.stderr
@@ -73,8 +73,13 @@ error[E0277]: the trait bound `NotClone: IsU8<NotClone>` is not satisfied
   --> $DIR/defaults-suitability.rs:59:18
    |
 LL |     type Assoc = NotClone;
-   |                  ^^^^^^^^ the trait `IsU8<NotClone>` is not implemented for `NotClone`
+   |                  ^^^^^^^^ unsatisfied trait bound
    |
+help: the trait `IsU8<NotClone>` is not implemented for `NotClone`
+  --> $DIR/defaults-suitability.rs:12:1
+   |
+LL | struct NotClone;
+   | ^^^^^^^^^^^^^^^
 note: required by a bound in `D::Assoc`
   --> $DIR/defaults-suitability.rs:56:18
    |

--- a/tests/ui/associated-types/issue-64855.stderr
+++ b/tests/ui/associated-types/issue-64855.stderr
@@ -2,8 +2,13 @@ error[E0277]: the trait bound `Bar<T>: Foo` is not satisfied
   --> $DIR/issue-64855.rs:9:19
    |
 LL | pub struct Bar<T>(<Self as Foo>::Type) where Self: ;
-   |                   ^^^^^^^^^^^^^^^^^^^ the trait `Foo` is not implemented for `Bar<T>`
+   |                   ^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
    |
+help: the trait `Foo` is not implemented for `Bar<T>`
+  --> $DIR/issue-64855.rs:9:1
+   |
+LL | pub struct Bar<T>(<Self as Foo>::Type) where Self: ;
+   | ^^^^^^^^^^^^^^^^^
 help: this trait has no implementations, consider adding one
   --> $DIR/issue-64855.rs:5:1
    |

--- a/tests/ui/associated-types/issue-65774-1.stderr
+++ b/tests/ui/associated-types/issue-65774-1.stderr
@@ -2,8 +2,13 @@ error[E0277]: the trait bound `T: MyDisplay` is not satisfied
   --> $DIR/issue-65774-1.rs:10:33
    |
 LL |     type MpuConfig: MyDisplay = T;
-   |                                 ^ the trait `MyDisplay` is not implemented for `T`
+   |                                 ^ unsatisfied trait bound
    |
+help: the trait `MyDisplay` is not implemented for `T`
+  --> $DIR/issue-65774-1.rs:7:1
+   |
+LL | struct T;
+   | ^^^^^^^^
    = help: the trait `MyDisplay` is implemented for `&'a mut T`
 note: required by a bound in `MPU::MpuConfig`
   --> $DIR/issue-65774-1.rs:10:21
@@ -15,8 +20,13 @@ error[E0277]: the trait bound `T: MyDisplay` is not satisfied
   --> $DIR/issue-65774-1.rs:44:76
    |
 LL |         let closure = |config: &mut <S as MPU>::MpuConfig| writer.my_write(&config);
-   |                                                                            ^^^^^^^ the trait `MyDisplay` is not implemented for `T`
+   |                                                                            ^^^^^^^ unsatisfied trait bound
    |
+help: the trait `MyDisplay` is not implemented for `T`
+  --> $DIR/issue-65774-1.rs:7:1
+   |
+LL | struct T;
+   | ^^^^^^^^
    = help: the trait `MyDisplay` is implemented for `&'a mut T`
 note: required for `&mut T` to implement `MyDisplay`
   --> $DIR/issue-65774-1.rs:5:24

--- a/tests/ui/associated-types/issue-65774-2.stderr
+++ b/tests/ui/associated-types/issue-65774-2.stderr
@@ -2,8 +2,13 @@ error[E0277]: the trait bound `T: MyDisplay` is not satisfied
   --> $DIR/issue-65774-2.rs:10:33
    |
 LL |     type MpuConfig: MyDisplay = T;
-   |                                 ^ the trait `MyDisplay` is not implemented for `T`
+   |                                 ^ unsatisfied trait bound
    |
+help: the trait `MyDisplay` is not implemented for `T`
+  --> $DIR/issue-65774-2.rs:7:1
+   |
+LL | struct T;
+   | ^^^^^^^^
    = help: the trait `MyDisplay` is implemented for `&'a mut T`
 note: required by a bound in `MPU::MpuConfig`
   --> $DIR/issue-65774-2.rs:10:21
@@ -15,8 +20,13 @@ error[E0277]: the trait bound `T: MyDisplay` is not satisfied
   --> $DIR/issue-65774-2.rs:39:25
    |
 LL |         writer.my_write(valref)
-   |                         ^^^^^^ the trait `MyDisplay` is not implemented for `T`
+   |                         ^^^^^^ unsatisfied trait bound
    |
+help: the trait `MyDisplay` is not implemented for `T`
+  --> $DIR/issue-65774-2.rs:7:1
+   |
+LL | struct T;
+   | ^^^^^^^^
    = help: the trait `MyDisplay` is implemented for `&'a mut T`
    = note: required for the cast from `&mut T` to `&dyn MyDisplay`
 

--- a/tests/ui/async-await/async-fn/impl-header.stderr
+++ b/tests/ui/async-await/async-fn/impl-header.stderr
@@ -36,7 +36,11 @@ error[E0277]: expected a `FnMut()` closure, found `F`
 LL | impl async Fn<()> for F {}
    |                       ^ expected an `FnMut()` closure, found `F`
    |
-   = help: the trait `FnMut()` is not implemented for `F`
+help: the trait `FnMut()` is not implemented for `F`
+  --> $DIR/impl-header.rs:3:1
+   |
+LL | struct F;
+   | ^^^^^^^^
    = note: wrap the `F` in a closure with no arguments: `|| { /* code */ }`
 note: required by a bound in `Fn`
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL

--- a/tests/ui/async-await/issue-61076.rs
+++ b/tests/ui/async-await/issue-61076.rs
@@ -4,7 +4,7 @@ use core::future::Future;
 use core::pin::Pin;
 use core::task::{Context, Poll};
 
-struct T;
+struct T; //~ HELP the trait `Try` is not implemented for `T`
 
 struct Tuple(i32);
 
@@ -61,9 +61,7 @@ async fn baz() -> Result<(), ()> {
     let t = T;
     t?; //~ ERROR the `?` operator can only be applied to values that implement `Try`
     //~^ NOTE the `?` operator cannot be applied to type `T`
-    //~| HELP the trait `Try` is not implemented for `T`
     //~| HELP consider `await`ing on the `Future`
-    //~| NOTE in this expansion of desugaring of operator `?`
     //~| NOTE in this expansion of desugaring of operator `?`
     //~| NOTE in this expansion of desugaring of operator `?`
 

--- a/tests/ui/async-await/issue-61076.stderr
+++ b/tests/ui/async-await/issue-61076.stderr
@@ -16,14 +16,18 @@ error[E0277]: the `?` operator can only be applied to values that implement `Try
 LL |     t?;
    |     ^^ the `?` operator cannot be applied to type `T`
    |
-   = help: the trait `Try` is not implemented for `T`
+help: the trait `Try` is not implemented for `T`
+  --> $DIR/issue-61076.rs:7:1
+   |
+LL | struct T;
+   | ^^^^^^^^
 help: consider `await`ing on the `Future`
    |
 LL |     t.await?;
    |      ++++++
 
 error[E0609]: no field `0` on type `impl Future<Output = Tuple>`
-  --> $DIR/issue-61076.rs:71:26
+  --> $DIR/issue-61076.rs:69:26
    |
 LL |     let _: i32 = tuple().0;
    |                          ^ field not available in `impl Future`, but it is available in its `Output`
@@ -34,7 +38,7 @@ LL |     let _: i32 = tuple().await.0;
    |                         ++++++
 
 error[E0609]: no field `a` on type `impl Future<Output = Struct>`
-  --> $DIR/issue-61076.rs:75:28
+  --> $DIR/issue-61076.rs:73:28
    |
 LL |     let _: i32 = struct_().a;
    |                            ^ field not available in `impl Future`, but it is available in its `Output`
@@ -45,7 +49,7 @@ LL |     let _: i32 = struct_().await.a;
    |                           ++++++
 
 error[E0599]: no method named `method` found for opaque type `impl Future<Output = Struct>` in the current scope
-  --> $DIR/issue-61076.rs:79:15
+  --> $DIR/issue-61076.rs:77:15
    |
 LL |     struct_().method();
    |               ^^^^^^ method not found in `impl Future<Output = Struct>`
@@ -56,7 +60,7 @@ LL |     struct_().await.method();
    |               ++++++
 
 error[E0308]: mismatched types
-  --> $DIR/issue-61076.rs:88:9
+  --> $DIR/issue-61076.rs:86:9
    |
 LL |     match tuple() {
    |           ------- this expression has type `impl Future<Output = Tuple>`

--- a/tests/ui/async-await/issue-64130-1-sync.stderr
+++ b/tests/ui/async-await/issue-64130-1-sync.stderr
@@ -4,7 +4,11 @@ error: future cannot be shared between threads safely
 LL |     is_sync(bar());
    |             ^^^^^ future returned by `bar` is not `Sync`
    |
-   = help: within `impl Future<Output = ()>`, the trait `Sync` is not implemented for `Foo`
+help: within `impl Future<Output = ()>`, the trait `Sync` is not implemented for `Foo`
+  --> $DIR/issue-64130-1-sync.rs:7:1
+   |
+LL | struct Foo;
+   | ^^^^^^^^^^
 note: future is not `Sync` as this value is used across an await
   --> $DIR/issue-64130-1-sync.rs:15:11
    |

--- a/tests/ui/async-await/issue-64130-2-send.stderr
+++ b/tests/ui/async-await/issue-64130-2-send.stderr
@@ -4,7 +4,11 @@ error: future cannot be sent between threads safely
 LL |     is_send(bar());
    |             ^^^^^ future returned by `bar` is not `Send`
    |
-   = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `Foo`
+help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `Foo`
+  --> $DIR/issue-64130-2-send.rs:7:1
+   |
+LL | struct Foo;
+   | ^^^^^^^^^^
 note: future is not `Send` as this value is used across an await
   --> $DIR/issue-64130-2-send.rs:15:11
    |

--- a/tests/ui/async-await/issue-64130-3-other.stderr
+++ b/tests/ui/async-await/issue-64130-3-other.stderr
@@ -5,8 +5,13 @@ LL | async fn bar() {
    | -------------- within this `impl Future<Output = ()>`
 ...
 LL |     is_qux(bar());
-   |            ^^^^^ within `impl Future<Output = ()>`, the trait `Qux` is not implemented for `Foo`
+   |            ^^^^^ unsatisfied trait bound
    |
+help: within `impl Future<Output = ()>`, the trait `Qux` is not implemented for `Foo`
+  --> $DIR/issue-64130-3-other.rs:10:1
+   |
+LL | struct Foo;
+   | ^^^^^^^^^^
 note: future does not implement `Qux` as this value is used across an await
   --> $DIR/issue-64130-3-other.rs:18:11
    |

--- a/tests/ui/async-await/partial-drop-partial-reinit.stderr
+++ b/tests/ui/async-await/partial-drop-partial-reinit.stderr
@@ -9,7 +9,11 @@ LL |     gimme_send(foo());
 LL | async fn foo() {
    | -------------- within this `impl Future<Output = ()>`
    |
-   = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `NotSend`
+help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `NotSend`
+  --> $DIR/partial-drop-partial-reinit.rs:19:1
+   |
+LL | struct NotSend {}
+   | ^^^^^^^^^^^^^^
    = note: required because it appears within the type `(NotSend,)`
 note: required because it's used within this `async` fn body
   --> $DIR/partial-drop-partial-reinit.rs:27:16

--- a/tests/ui/auto-traits/issue-83857-ub.stderr
+++ b/tests/ui/auto-traits/issue-83857-ub.stderr
@@ -4,7 +4,11 @@ error[E0277]: `Foo<T, U>` cannot be sent between threads safely
 LL | fn generic<T, U>(v: Foo<T, U>, f: fn(<Foo<T, U> as WithAssoc>::Output) -> i32) {
    |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Foo<T, U>` cannot be sent between threads safely
    |
-   = help: the trait `Send` is not implemented for `Foo<T, U>`
+help: the trait `Send` is not implemented for `Foo<T, U>`
+  --> $DIR/issue-83857-ub.rs:6:1
+   |
+LL | struct Foo<T, U>(Always<T, U>);
+   | ^^^^^^^^^^^^^^^^
 note: required for `Foo<T, U>` to implement `WithAssoc`
   --> $DIR/issue-83857-ub.rs:14:15
    |
@@ -23,7 +27,11 @@ error[E0277]: `Foo<T, U>` cannot be sent between threads safely
 LL | fn generic<T, U>(v: Foo<T, U>, f: fn(<Foo<T, U> as WithAssoc>::Output) -> i32) {
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Foo<T, U>` cannot be sent between threads safely
    |
-   = help: the trait `Send` is not implemented for `Foo<T, U>`
+help: the trait `Send` is not implemented for `Foo<T, U>`
+  --> $DIR/issue-83857-ub.rs:6:1
+   |
+LL | struct Foo<T, U>(Always<T, U>);
+   | ^^^^^^^^^^^^^^^^
 note: required for `Foo<T, U>` to implement `WithAssoc`
   --> $DIR/issue-83857-ub.rs:14:15
    |
@@ -44,7 +52,11 @@ LL |     f(foo(v));
    |       |
    |       required by a bound introduced by this call
    |
-   = help: the trait `Send` is not implemented for `Foo<T, U>`
+help: the trait `Send` is not implemented for `Foo<T, U>`
+  --> $DIR/issue-83857-ub.rs:6:1
+   |
+LL | struct Foo<T, U>(Always<T, U>);
+   | ^^^^^^^^^^^^^^^^
 note: required by a bound in `foo`
   --> $DIR/issue-83857-ub.rs:28:11
    |

--- a/tests/ui/auto-traits/typeck-default-trait-impl-constituent-types-2.stderr
+++ b/tests/ui/auto-traits/typeck-default-trait-impl-constituent-types-2.stderr
@@ -2,8 +2,13 @@ error[E0277]: the trait bound `MyS2: MyTrait` is not satisfied in `(MyS2, MyS)`
   --> $DIR/typeck-default-trait-impl-constituent-types-2.rs:17:18
    |
 LL |     is_mytrait::<(MyS2, MyS)>();
-   |                  ^^^^^^^^^^^ within `(MyS2, MyS)`, the trait `MyTrait` is not implemented for `MyS2`
+   |                  ^^^^^^^^^^^ unsatisfied trait bound
    |
+help: within `(MyS2, MyS)`, the trait `MyTrait` is not implemented for `MyS2`
+  --> $DIR/typeck-default-trait-impl-constituent-types-2.rs:8:1
+   |
+LL | struct MyS2;
+   | ^^^^^^^^^^^
    = note: required because it appears within the type `(MyS2, MyS)`
 note: required by a bound in `is_mytrait`
   --> $DIR/typeck-default-trait-impl-constituent-types-2.rs:12:18

--- a/tests/ui/auto-traits/typeck-default-trait-impl-constituent-types.stderr
+++ b/tests/ui/auto-traits/typeck-default-trait-impl-constituent-types.stderr
@@ -2,8 +2,13 @@ error[E0277]: the trait bound `MyS2: MyTrait` is not satisfied
   --> $DIR/typeck-default-trait-impl-constituent-types.rs:21:18
    |
 LL |     is_mytrait::<MyS2>();
-   |                  ^^^^ the trait `MyTrait` is not implemented for `MyS2`
+   |                  ^^^^ unsatisfied trait bound
    |
+help: the trait `MyTrait` is not implemented for `MyS2`
+  --> $DIR/typeck-default-trait-impl-constituent-types.rs:10:1
+   |
+LL | struct MyS2;
+   | ^^^^^^^^^^^
 note: required by a bound in `is_mytrait`
   --> $DIR/typeck-default-trait-impl-constituent-types.rs:16:18
    |

--- a/tests/ui/auto-traits/typeck-default-trait-impl-negation.stderr
+++ b/tests/ui/auto-traits/typeck-default-trait-impl-negation.stderr
@@ -2,8 +2,13 @@ error[E0277]: the trait bound `ThisImplsUnsafeTrait: MyTrait` is not satisfied
   --> $DIR/typeck-default-trait-impl-negation.rs:22:19
    |
 LL |     is_my_trait::<ThisImplsUnsafeTrait>();
-   |                   ^^^^^^^^^^^^^^^^^^^^ the trait `MyTrait` is not implemented for `ThisImplsUnsafeTrait`
+   |                   ^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
    |
+help: the trait `MyTrait` is not implemented for `ThisImplsUnsafeTrait`
+  --> $DIR/typeck-default-trait-impl-negation.rs:13:1
+   |
+LL | struct ThisImplsUnsafeTrait;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `is_my_trait`
   --> $DIR/typeck-default-trait-impl-negation.rs:17:19
    |
@@ -14,8 +19,13 @@ error[E0277]: the trait bound `ThisImplsTrait: MyUnsafeTrait` is not satisfied
   --> $DIR/typeck-default-trait-impl-negation.rs:25:26
    |
 LL |     is_my_unsafe_trait::<ThisImplsTrait>();
-   |                          ^^^^^^^^^^^^^^ the trait `MyUnsafeTrait` is not implemented for `ThisImplsTrait`
+   |                          ^^^^^^^^^^^^^^ unsatisfied trait bound
    |
+help: the trait `MyUnsafeTrait` is not implemented for `ThisImplsTrait`
+  --> $DIR/typeck-default-trait-impl-negation.rs:8:1
+   |
+LL | struct ThisImplsTrait;
+   | ^^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `is_my_unsafe_trait`
   --> $DIR/typeck-default-trait-impl-negation.rs:18:26
    |

--- a/tests/ui/coherence/fuzzing/best-obligation-ICE.stderr
+++ b/tests/ui/coherence/fuzzing/best-obligation-ICE.stderr
@@ -11,8 +11,13 @@ error[E0277]: the trait bound `W<W<T>>: Trait` is not satisfied
   --> $DIR/best-obligation-ICE.rs:10:19
    |
 LL | impl<T> Trait for W<W<W<T>>> {}
-   |                   ^^^^^^^^^^ the trait `Trait` is not implemented for `W<W<T>>`
+   |                   ^^^^^^^^^^ unsatisfied trait bound
    |
+help: the trait `Trait` is not implemented for `W<W<T>>`
+  --> $DIR/best-obligation-ICE.rs:9:1
+   |
+LL | struct W<T: Trait>(*mut T);
+   | ^^^^^^^^^^^^^^^^^^
 note: required by a bound in `W`
   --> $DIR/best-obligation-ICE.rs:9:13
    |
@@ -27,8 +32,13 @@ error[E0277]: the trait bound `W<T>: Trait` is not satisfied
   --> $DIR/best-obligation-ICE.rs:10:19
    |
 LL | impl<T> Trait for W<W<W<T>>> {}
-   |                   ^^^^^^^^^^ the trait `Trait` is not implemented for `W<T>`
+   |                   ^^^^^^^^^^ unsatisfied trait bound
    |
+help: the trait `Trait` is not implemented for `W<T>`
+  --> $DIR/best-obligation-ICE.rs:9:1
+   |
+LL | struct W<T: Trait>(*mut T);
+   | ^^^^^^^^^^^^^^^^^^
 note: required by a bound in `W`
   --> $DIR/best-obligation-ICE.rs:9:13
    |

--- a/tests/ui/const-generics/adt_const_params/const_param_ty_bad_empty_array.stderr
+++ b/tests/ui/const-generics/adt_const_params/const_param_ty_bad_empty_array.stderr
@@ -2,8 +2,13 @@ error[E0277]: `NotParam` can't be used as a const parameter type
   --> $DIR/const_param_ty_bad_empty_array.rs:10:13
    |
 LL |     check::<[NotParam; 0]>();
-   |             ^^^^^^^^^^^^^ the trait `ConstParamTy_` is not implemented for `NotParam`
+   |             ^^^^^^^^^^^^^ unsatisfied trait bound
    |
+help: the trait `ConstParamTy_` is not implemented for `NotParam`
+  --> $DIR/const_param_ty_bad_empty_array.rs:5:1
+   |
+LL | struct NotParam;
+   | ^^^^^^^^^^^^^^^
    = note: required for `[NotParam; 0]` to implement `ConstParamTy_`
 note: required by a bound in `check`
   --> $DIR/const_param_ty_bad_empty_array.rs:7:13

--- a/tests/ui/const-generics/adt_const_params/const_param_ty_generic_bounds_do_not_hold.stderr
+++ b/tests/ui/const-generics/adt_const_params/const_param_ty_generic_bounds_do_not_hold.stderr
@@ -2,8 +2,13 @@ error[E0277]: `NotParam` can't be used as a const parameter type
   --> $DIR/const_param_ty_generic_bounds_do_not_hold.rs:10:13
    |
 LL |     check::<&NotParam>();
-   |             ^^^^^^^^^ the trait `UnsizedConstParamTy` is not implemented for `NotParam`
+   |             ^^^^^^^^^ unsatisfied trait bound
    |
+help: the trait `UnsizedConstParamTy` is not implemented for `NotParam`
+  --> $DIR/const_param_ty_generic_bounds_do_not_hold.rs:5:1
+   |
+LL | struct NotParam;
+   | ^^^^^^^^^^^^^^^
    = note: required for `&NotParam` to implement `UnsizedConstParamTy`
 note: required by a bound in `check`
   --> $DIR/const_param_ty_generic_bounds_do_not_hold.rs:7:13
@@ -15,8 +20,13 @@ error[E0277]: `NotParam` can't be used as a const parameter type
   --> $DIR/const_param_ty_generic_bounds_do_not_hold.rs:11:13
    |
 LL |     check::<[NotParam]>();
-   |             ^^^^^^^^^^ the trait `UnsizedConstParamTy` is not implemented for `NotParam`
+   |             ^^^^^^^^^^ unsatisfied trait bound
    |
+help: the trait `UnsizedConstParamTy` is not implemented for `NotParam`
+  --> $DIR/const_param_ty_generic_bounds_do_not_hold.rs:5:1
+   |
+LL | struct NotParam;
+   | ^^^^^^^^^^^^^^^
    = note: required for `[NotParam]` to implement `UnsizedConstParamTy`
 note: required by a bound in `check`
   --> $DIR/const_param_ty_generic_bounds_do_not_hold.rs:7:13
@@ -28,8 +38,13 @@ error[E0277]: `NotParam` can't be used as a const parameter type
   --> $DIR/const_param_ty_generic_bounds_do_not_hold.rs:12:13
    |
 LL |     check::<[NotParam; 17]>();
-   |             ^^^^^^^^^^^^^^ the trait `UnsizedConstParamTy` is not implemented for `NotParam`
+   |             ^^^^^^^^^^^^^^ unsatisfied trait bound
    |
+help: the trait `UnsizedConstParamTy` is not implemented for `NotParam`
+  --> $DIR/const_param_ty_generic_bounds_do_not_hold.rs:5:1
+   |
+LL | struct NotParam;
+   | ^^^^^^^^^^^^^^^
    = note: required for `[NotParam; 17]` to implement `UnsizedConstParamTy`
 note: required by a bound in `check`
   --> $DIR/const_param_ty_generic_bounds_do_not_hold.rs:7:13

--- a/tests/ui/const-generics/adt_const_params/const_param_ty_impl_no_structural_eq.stderr
+++ b/tests/ui/const-generics/adt_const_params/const_param_ty_impl_no_structural_eq.stderr
@@ -16,8 +16,13 @@ error[E0277]: the type `CantParam` does not `#[derive(PartialEq)]`
   --> $DIR/const_param_ty_impl_no_structural_eq.rs:10:43
    |
 LL | impl std::marker::UnsizedConstParamTy for CantParam {}
-   |                                           ^^^^^^^^^ the trait `StructuralPartialEq` is not implemented for `CantParam`
+   |                                           ^^^^^^^^^ unsatisfied trait bound
    |
+help: the trait `StructuralPartialEq` is not implemented for `CantParam`
+  --> $DIR/const_param_ty_impl_no_structural_eq.rs:8:1
+   |
+LL | struct CantParam(ImplementsConstParamTy);
+   | ^^^^^^^^^^^^^^^^
 note: required by a bound in `UnsizedConstParamTy`
   --> $SRC_DIR/core/src/marker.rs:LL:COL
 
@@ -39,8 +44,13 @@ error[E0277]: the type `CantParamDerive` does not `#[derive(PartialEq)]`
   --> $DIR/const_param_ty_impl_no_structural_eq.rs:14:10
    |
 LL | #[derive(std::marker::UnsizedConstParamTy)]
-   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `StructuralPartialEq` is not implemented for `CantParamDerive`
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
    |
+help: the trait `StructuralPartialEq` is not implemented for `CantParamDerive`
+  --> $DIR/const_param_ty_impl_no_structural_eq.rs:17:1
+   |
+LL | struct CantParamDerive(ImplementsConstParamTy);
+   | ^^^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `UnsizedConstParamTy`
   --> $SRC_DIR/core/src/marker.rs:LL:COL
 

--- a/tests/ui/const-generics/defaults/rp_impl_trait_fail.stderr
+++ b/tests/ui/const-generics/defaults/rp_impl_trait_fail.stderr
@@ -2,11 +2,16 @@ error[E0277]: the trait bound `Uwu<10, 12>: Trait` is not satisfied
   --> $DIR/rp_impl_trait_fail.rs:6:14
    |
 LL | fn rawr() -> impl Trait {
-   |              ^^^^^^^^^^ the trait `Trait` is not implemented for `Uwu<10, 12>`
+   |              ^^^^^^^^^^ unsatisfied trait bound
 LL |
 LL |     Uwu::<10, 12>
    |     ------------- return type was inferred to be `Uwu<10, 12>` here
    |
+help: the trait `Trait` is not implemented for `Uwu<10, 12>`
+  --> $DIR/rp_impl_trait_fail.rs:1:1
+   |
+LL | struct Uwu<const N: u32 = 1, const M: u32 = N>;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: the trait `Trait` is implemented for `Uwu<N>`
 
 error[E0277]: the trait bound `u32: Traitor<N>` is not satisfied

--- a/tests/ui/const-generics/occurs-check/unused-substs-1.stderr
+++ b/tests/ui/const-generics/occurs-check/unused-substs-1.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `A<_>: Bar<_>` is not satisfied
   --> $DIR/unused-substs-1.rs:12:13
    |
 LL |     let _ = A;
-   |             ^ the trait `Bar<_>` is not implemented for `A<_>`
+   |             ^ unsatisfied trait bound
    |
    = help: the trait `Bar<_>` is not implemented for `A<_>`
            but it is implemented for `A<{ 6 + 1 }>`

--- a/tests/ui/coroutine/drop-tracking-parent-expression.stderr
+++ b/tests/ui/coroutine/drop-tracking-parent-expression.stderr
@@ -12,7 +12,11 @@ LL | |         };
 LL | |     );
    | |_____- in this macro invocation
    |
-   = help: within `{coroutine@$DIR/drop-tracking-parent-expression.rs:19:34: 19:41}`, the trait `Send` is not implemented for `derived_drop::Client`
+help: within `{coroutine@$DIR/drop-tracking-parent-expression.rs:19:34: 19:41}`, the trait `Send` is not implemented for `derived_drop::Client`
+  --> $DIR/drop-tracking-parent-expression.rs:51:46
+   |
+LL |         derived_drop => { #[derive(Default)] pub struct Client { pub nickname: String } };
+   |                                              ^^^^^^^^^^^^^^^^^
 note: coroutine is not `Send` as this value is used across a yield
   --> $DIR/drop-tracking-parent-expression.rs:23:22
    |
@@ -50,7 +54,11 @@ LL | |         };
 LL | |     );
    | |_____- in this macro invocation
    |
-   = help: within `{coroutine@$DIR/drop-tracking-parent-expression.rs:19:34: 19:41}`, the trait `Send` is not implemented for `significant_drop::Client`
+help: within `{coroutine@$DIR/drop-tracking-parent-expression.rs:19:34: 19:41}`, the trait `Send` is not implemented for `significant_drop::Client`
+  --> $DIR/drop-tracking-parent-expression.rs:55:13
+   |
+LL |             pub struct Client;
+   |             ^^^^^^^^^^^^^^^^^
 note: coroutine is not `Send` as this value is used across a yield
   --> $DIR/drop-tracking-parent-expression.rs:23:22
    |
@@ -88,7 +96,11 @@ LL | |         };
 LL | |     );
    | |_____- in this macro invocation
    |
-   = help: within `{coroutine@$DIR/drop-tracking-parent-expression.rs:19:34: 19:41}`, the trait `Send` is not implemented for `insignificant_dtor::Client`
+help: within `{coroutine@$DIR/drop-tracking-parent-expression.rs:19:34: 19:41}`, the trait `Send` is not implemented for `insignificant_dtor::Client`
+  --> $DIR/drop-tracking-parent-expression.rs:64:13
+   |
+LL |             pub struct Client;
+   |             ^^^^^^^^^^^^^^^^^
 note: coroutine is not `Send` as this value is used across a yield
   --> $DIR/drop-tracking-parent-expression.rs:23:22
    |

--- a/tests/ui/coroutine/drop-yield-twice.stderr
+++ b/tests/ui/coroutine/drop-yield-twice.stderr
@@ -9,7 +9,11 @@ LL | |         yield;
 LL | |     })
    | |______^ coroutine is not `Send`
    |
-   = help: within `{coroutine@$DIR/drop-yield-twice.rs:7:30: 7:32}`, the trait `Send` is not implemented for `Foo`
+help: within `{coroutine@$DIR/drop-yield-twice.rs:7:30: 7:32}`, the trait `Send` is not implemented for `Foo`
+  --> $DIR/drop-yield-twice.rs:3:1
+   |
+LL | struct Foo(i32);
+   | ^^^^^^^^^^
 note: coroutine is not `Send` as this value is used across a yield
   --> $DIR/drop-yield-twice.rs:9:9
    |

--- a/tests/ui/coroutine/not-send-sync.stderr
+++ b/tests/ui/coroutine/not-send-sync.stderr
@@ -9,7 +9,11 @@ LL | |         drop(a);
 LL | |     });
    | |______^ coroutine is not `Sync`
    |
-   = help: within `{coroutine@$DIR/not-send-sync.rs:14:30: 14:32}`, the trait `Sync` is not implemented for `NotSync`
+help: within `{coroutine@$DIR/not-send-sync.rs:14:30: 14:32}`, the trait `Sync` is not implemented for `NotSync`
+  --> $DIR/not-send-sync.rs:5:1
+   |
+LL | struct NotSync;
+   | ^^^^^^^^^^^^^^
 note: coroutine is not `Sync` as this value is used across a yield
   --> $DIR/not-send-sync.rs:17:9
    |
@@ -34,7 +38,11 @@ LL | |         drop(a);
 LL | |     });
    | |______^ coroutine is not `Send`
    |
-   = help: within `{coroutine@$DIR/not-send-sync.rs:21:30: 21:32}`, the trait `Send` is not implemented for `NotSend`
+help: within `{coroutine@$DIR/not-send-sync.rs:21:30: 21:32}`, the trait `Send` is not implemented for `NotSend`
+  --> $DIR/not-send-sync.rs:4:1
+   |
+LL | struct NotSend;
+   | ^^^^^^^^^^^^^^
 note: coroutine is not `Send` as this value is used across a yield
   --> $DIR/not-send-sync.rs:24:9
    |

--- a/tests/ui/coroutine/parent-expression.stderr
+++ b/tests/ui/coroutine/parent-expression.stderr
@@ -12,7 +12,11 @@ LL | |         };
 LL | |     );
    | |_____- in this macro invocation
    |
-   = help: within `{coroutine@$DIR/parent-expression.rs:19:34: 19:41}`, the trait `Send` is not implemented for `derived_drop::Client`
+help: within `{coroutine@$DIR/parent-expression.rs:19:34: 19:41}`, the trait `Send` is not implemented for `derived_drop::Client`
+  --> $DIR/parent-expression.rs:51:46
+   |
+LL |         derived_drop => { #[derive(Default)] pub struct Client { pub nickname: String } };
+   |                                              ^^^^^^^^^^^^^^^^^
 note: coroutine is not `Send` as this value is used across a yield
   --> $DIR/parent-expression.rs:23:22
    |
@@ -50,7 +54,11 @@ LL | |         };
 LL | |     );
    | |_____- in this macro invocation
    |
-   = help: within `{coroutine@$DIR/parent-expression.rs:19:34: 19:41}`, the trait `Send` is not implemented for `significant_drop::Client`
+help: within `{coroutine@$DIR/parent-expression.rs:19:34: 19:41}`, the trait `Send` is not implemented for `significant_drop::Client`
+  --> $DIR/parent-expression.rs:55:13
+   |
+LL |             pub struct Client;
+   |             ^^^^^^^^^^^^^^^^^
 note: coroutine is not `Send` as this value is used across a yield
   --> $DIR/parent-expression.rs:23:22
    |
@@ -88,7 +96,11 @@ LL | |         };
 LL | |     );
    | |_____- in this macro invocation
    |
-   = help: within `{coroutine@$DIR/parent-expression.rs:19:34: 19:41}`, the trait `Send` is not implemented for `insignificant_dtor::Client`
+help: within `{coroutine@$DIR/parent-expression.rs:19:34: 19:41}`, the trait `Send` is not implemented for `insignificant_dtor::Client`
+  --> $DIR/parent-expression.rs:64:13
+   |
+LL |             pub struct Client;
+   |             ^^^^^^^^^^^^^^^^^
 note: coroutine is not `Send` as this value is used across a yield
   --> $DIR/parent-expression.rs:23:22
    |

--- a/tests/ui/coroutine/print/coroutine-print-verbose-2.stderr
+++ b/tests/ui/coroutine/print/coroutine-print-verbose-2.stderr
@@ -9,7 +9,11 @@ LL | |         drop(a);
 LL | |     });
    | |______^ coroutine is not `Sync`
    |
-   = help: within `{main::{closure#0} upvar_tys=() resume_ty=() yield_ty=() return_ty=()}`, the trait `Sync` is not implemented for `NotSync`
+help: within `{main::{closure#0} upvar_tys=() resume_ty=() yield_ty=() return_ty=()}`, the trait `Sync` is not implemented for `NotSync`
+  --> $DIR/coroutine-print-verbose-2.rs:8:1
+   |
+LL | struct NotSync;
+   | ^^^^^^^^^^^^^^
 note: coroutine is not `Sync` as this value is used across a yield
   --> $DIR/coroutine-print-verbose-2.rs:20:9
    |
@@ -34,7 +38,11 @@ LL | |         drop(a);
 LL | |     });
    | |______^ coroutine is not `Send`
    |
-   = help: within `{main::{closure#1} upvar_tys=() resume_ty=() yield_ty=() return_ty=()}`, the trait `Send` is not implemented for `NotSend`
+help: within `{main::{closure#1} upvar_tys=() resume_ty=() yield_ty=() return_ty=()}`, the trait `Send` is not implemented for `NotSend`
+  --> $DIR/coroutine-print-verbose-2.rs:7:1
+   |
+LL | struct NotSend;
+   | ^^^^^^^^^^^^^^
 note: coroutine is not `Send` as this value is used across a yield
   --> $DIR/coroutine-print-verbose-2.rs:27:9
    |

--- a/tests/ui/delegation/explicit-paths.stderr
+++ b/tests/ui/delegation/explicit-paths.stderr
@@ -89,8 +89,13 @@ error[E0277]: the trait bound `S2: Trait` is not satisfied
   --> $DIR/explicit-paths.rs:76:16
    |
 LL |         reuse <S2 as Trait>::foo1;
-   |                ^^ the trait `Trait` is not implemented for `S2`
+   |                ^^ unsatisfied trait bound
    |
+help: the trait `Trait` is not implemented for `S2`
+  --> $DIR/explicit-paths.rs:73:5
+   |
+LL |     struct S2;
+   |     ^^^^^^^^^
    = help: the following other types implement trait `Trait`:
              F
              S

--- a/tests/ui/delegation/generics/impl-to-trait-method.stderr
+++ b/tests/ui/delegation/generics/impl-to-trait-method.stderr
@@ -2,8 +2,13 @@ error[E0277]: the trait bound `bounds::S: Trait0` is not satisfied
   --> $DIR/impl-to-trait-method.rs:12:19
    |
 LL |             Self: Trait0,
-   |                   ^^^^^^ the trait `Trait0` is not implemented for `bounds::S`
+   |                   ^^^^^^ unsatisfied trait bound
    |
+help: the trait `Trait0` is not implemented for `bounds::S`
+  --> $DIR/impl-to-trait-method.rs:21:5
+   |
+LL |     struct S(F);
+   |     ^^^^^^^^
 help: this trait has no implementations, consider adding one
   --> $DIR/impl-to-trait-method.rs:5:5
    |
@@ -19,10 +24,15 @@ error[E0277]: the trait bound `bounds::F: Trait0` is not satisfied
   --> $DIR/impl-to-trait-method.rs:24:34
    |
 LL |         reuse Trait1::<T>::foo { &self.0 }
-   |                            ---   ^^^^^^^ the trait `Trait0` is not implemented for `bounds::F`
+   |                            ---   ^^^^^^^ unsatisfied trait bound
    |                            |
    |                            required by a bound introduced by this call
    |
+help: the trait `Trait0` is not implemented for `bounds::F`
+  --> $DIR/impl-to-trait-method.rs:18:5
+   |
+LL |     struct F;
+   |     ^^^^^^^^
 help: this trait has no implementations, consider adding one
   --> $DIR/impl-to-trait-method.rs:5:5
    |

--- a/tests/ui/delegation/ice-issue-122550.stderr
+++ b/tests/ui/delegation/ice-issue-122550.stderr
@@ -8,8 +8,13 @@ error[E0277]: the trait bound `S: Trait` is not satisfied
   --> $DIR/ice-issue-122550.rs:13:12
    |
 LL |     reuse <S as Trait>::description { &self.0 }
-   |            ^ the trait `Trait` is not implemented for `S`
+   |            ^ unsatisfied trait bound
    |
+help: the trait `Trait` is not implemented for `S`
+  --> $DIR/ice-issue-122550.rs:10:1
+   |
+LL | struct S(F);
+   | ^^^^^^^^
 help: this trait has no implementations, consider adding one
   --> $DIR/ice-issue-122550.rs:4:1
    |

--- a/tests/ui/did_you_mean/issue-21659-show-relevant-trait-impls-1.stderr
+++ b/tests/ui/did_you_mean/issue-21659-show-relevant-trait-impls-1.stderr
@@ -2,10 +2,15 @@ error[E0277]: the trait bound `Bar: Foo<usize>` is not satisfied
   --> $DIR/issue-21659-show-relevant-trait-impls-1.rs:24:12
    |
 LL |     f1.foo(1usize);
-   |        --- ^^^^^^ the trait `Foo<usize>` is not implemented for `Bar`
+   |        --- ^^^^^^ unsatisfied trait bound
    |        |
    |        required by a bound introduced by this call
    |
+help: the trait `Foo<usize>` is not implemented for `Bar`
+  --> $DIR/issue-21659-show-relevant-trait-impls-1.rs:13:1
+   |
+LL | struct Bar;
+   | ^^^^^^^^^^
    = help: the following other types implement trait `Foo<A>`:
              `Bar` implements `Foo<i32>`
              `Bar` implements `Foo<u8>`

--- a/tests/ui/did_you_mean/issue-21659-show-relevant-trait-impls-2.stderr
+++ b/tests/ui/did_you_mean/issue-21659-show-relevant-trait-impls-2.stderr
@@ -2,10 +2,15 @@ error[E0277]: the trait bound `Bar: Foo<usize>` is not satisfied
   --> $DIR/issue-21659-show-relevant-trait-impls-2.rs:28:12
    |
 LL |     f1.foo(1usize);
-   |        --- ^^^^^^ the trait `Foo<usize>` is not implemented for `Bar`
+   |        --- ^^^^^^ unsatisfied trait bound
    |        |
    |        required by a bound introduced by this call
    |
+help: the trait `Foo<usize>` is not implemented for `Bar`
+  --> $DIR/issue-21659-show-relevant-trait-impls-2.rs:13:1
+   |
+LL | struct Bar;
+   | ^^^^^^^^^^
    = help: the following other types implement trait `Foo<A>`:
              `Bar` implements `Foo<i16>`
              `Bar` implements `Foo<i32>`

--- a/tests/ui/drop/dropck-normalize-errors.nll.stderr
+++ b/tests/ui/drop/dropck-normalize-errors.nll.stderr
@@ -2,8 +2,13 @@ error[E0277]: the trait bound `NonImplementedStruct: NonImplementedTrait` is not
   --> $DIR/dropck-normalize-errors.rs:19:28
    |
 LL | fn make_a_decoder<'a>() -> ADecoder<'a> {
-   |                            ^^^^^^^^^^^^ within `ADecoder<'a>`, the trait `NonImplementedTrait` is not implemented for `NonImplementedStruct`
+   |                            ^^^^^^^^^^^^ unsatisfied trait bound
    |
+help: within `ADecoder<'a>`, the trait `NonImplementedTrait` is not implemented for `NonImplementedStruct`
+  --> $DIR/dropck-normalize-errors.rs:14:1
+   |
+LL | struct NonImplementedStruct;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: this trait has no implementations, consider adding one
   --> $DIR/dropck-normalize-errors.rs:11:1
    |
@@ -25,8 +30,13 @@ error[E0277]: the trait bound `NonImplementedStruct: NonImplementedTrait` is not
   --> $DIR/dropck-normalize-errors.rs:27:20
    |
 LL |     type Decoder = BDecoder;
-   |                    ^^^^^^^^ within `BDecoder`, the trait `NonImplementedTrait` is not implemented for `NonImplementedStruct`
+   |                    ^^^^^^^^ unsatisfied trait bound
    |
+help: within `BDecoder`, the trait `NonImplementedTrait` is not implemented for `NonImplementedStruct`
+  --> $DIR/dropck-normalize-errors.rs:14:1
+   |
+LL | struct NonImplementedStruct;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: this trait has no implementations, consider adding one
   --> $DIR/dropck-normalize-errors.rs:11:1
    |
@@ -51,8 +61,13 @@ error[E0277]: the trait bound `NonImplementedStruct: NonImplementedTrait` is not
   --> $DIR/dropck-normalize-errors.rs:31:22
    |
 LL |     non_implemented: <NonImplementedStruct as NonImplementedTrait>::Assoc,
-   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `NonImplementedTrait` is not implemented for `NonImplementedStruct`
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
    |
+help: the trait `NonImplementedTrait` is not implemented for `NonImplementedStruct`
+  --> $DIR/dropck-normalize-errors.rs:14:1
+   |
+LL | struct NonImplementedStruct;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: this trait has no implementations, consider adding one
   --> $DIR/dropck-normalize-errors.rs:11:1
    |
@@ -63,8 +78,13 @@ error[E0277]: the trait bound `NonImplementedStruct: NonImplementedTrait` is not
   --> $DIR/dropck-normalize-errors.rs:19:28
    |
 LL | fn make_a_decoder<'a>() -> ADecoder<'a> {
-   |                            ^^^^^^^^^^^^ the trait `NonImplementedTrait` is not implemented for `NonImplementedStruct`
+   |                            ^^^^^^^^^^^^ unsatisfied trait bound
    |
+help: the trait `NonImplementedTrait` is not implemented for `NonImplementedStruct`
+  --> $DIR/dropck-normalize-errors.rs:14:1
+   |
+LL | struct NonImplementedStruct;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: this trait has no implementations, consider adding one
   --> $DIR/dropck-normalize-errors.rs:11:1
    |

--- a/tests/ui/drop/dropck-normalize-errors.polonius.stderr
+++ b/tests/ui/drop/dropck-normalize-errors.polonius.stderr
@@ -2,8 +2,13 @@ error[E0277]: the trait bound `NonImplementedStruct: NonImplementedTrait` is not
   --> $DIR/dropck-normalize-errors.rs:19:28
    |
 LL | fn make_a_decoder<'a>() -> ADecoder<'a> {
-   |                            ^^^^^^^^^^^^ within `ADecoder<'a>`, the trait `NonImplementedTrait` is not implemented for `NonImplementedStruct`
+   |                            ^^^^^^^^^^^^ unsatisfied trait bound
    |
+help: within `ADecoder<'a>`, the trait `NonImplementedTrait` is not implemented for `NonImplementedStruct`
+  --> $DIR/dropck-normalize-errors.rs:14:1
+   |
+LL | struct NonImplementedStruct;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: this trait has no implementations, consider adding one
   --> $DIR/dropck-normalize-errors.rs:11:1
    |
@@ -25,8 +30,13 @@ error[E0277]: the trait bound `NonImplementedStruct: NonImplementedTrait` is not
   --> $DIR/dropck-normalize-errors.rs:27:20
    |
 LL |     type Decoder = BDecoder;
-   |                    ^^^^^^^^ within `BDecoder`, the trait `NonImplementedTrait` is not implemented for `NonImplementedStruct`
+   |                    ^^^^^^^^ unsatisfied trait bound
    |
+help: within `BDecoder`, the trait `NonImplementedTrait` is not implemented for `NonImplementedStruct`
+  --> $DIR/dropck-normalize-errors.rs:14:1
+   |
+LL | struct NonImplementedStruct;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: this trait has no implementations, consider adding one
   --> $DIR/dropck-normalize-errors.rs:11:1
    |
@@ -51,8 +61,13 @@ error[E0277]: the trait bound `NonImplementedStruct: NonImplementedTrait` is not
   --> $DIR/dropck-normalize-errors.rs:31:22
    |
 LL |     non_implemented: <NonImplementedStruct as NonImplementedTrait>::Assoc,
-   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `NonImplementedTrait` is not implemented for `NonImplementedStruct`
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
    |
+help: the trait `NonImplementedTrait` is not implemented for `NonImplementedStruct`
+  --> $DIR/dropck-normalize-errors.rs:14:1
+   |
+LL | struct NonImplementedStruct;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: this trait has no implementations, consider adding one
   --> $DIR/dropck-normalize-errors.rs:11:1
    |

--- a/tests/ui/dst/dst-bad-coerce1.stderr
+++ b/tests/ui/dst/dst-bad-coerce1.stderr
@@ -13,8 +13,13 @@ error[E0277]: the trait bound `Foo: Bar` is not satisfied
   --> $DIR/dst-bad-coerce1.rs:20:29
    |
 LL |     let f3: &Fat<dyn Bar> = f2;
-   |                             ^^ the trait `Bar` is not implemented for `Foo`
+   |                             ^^ unsatisfied trait bound
    |
+help: the trait `Bar` is not implemented for `Foo`
+  --> $DIR/dst-bad-coerce1.rs:7:1
+   |
+LL | struct Foo;
+   | ^^^^^^^^^^
 help: this trait has no implementations, consider adding one
   --> $DIR/dst-bad-coerce1.rs:8:1
    |

--- a/tests/ui/errors/remap-path-prefix-diagnostics.not-diag-in-deps.stderr
+++ b/tests/ui/errors/remap-path-prefix-diagnostics.not-diag-in-deps.stderr
@@ -2,8 +2,13 @@ error[E0277]: `A` doesn't implement `std::fmt::Display`
   --> remapped/errors/remap-path-prefix-diagnostics.rs:LL:COL
    |
 LL | impl r#trait::Trait for A {}
-   |                         ^ the trait `std::fmt::Display` is not implemented for `A`
+   |                         ^ unsatisfied trait bound
    |
+help: the trait `std::fmt::Display` is not implemented for `A`
+  --> remapped/errors/remap-path-prefix-diagnostics.rs:LL:COL
+   |
+LL | struct A;
+   | ^^^^^^^^
 note: required by a bound in `Trait`
   --> $DIR/auxiliary/trait.rs:LL:COL
    |

--- a/tests/ui/errors/remap-path-prefix-diagnostics.only-debuginfo-in-deps.stderr
+++ b/tests/ui/errors/remap-path-prefix-diagnostics.only-debuginfo-in-deps.stderr
@@ -2,8 +2,13 @@ error[E0277]: `A` doesn't implement `std::fmt::Display`
   --> $DIR/remap-path-prefix-diagnostics.rs:LL:COL
    |
 LL | impl r#trait::Trait for A {}
-   |                         ^ the trait `std::fmt::Display` is not implemented for `A`
+   |                         ^ unsatisfied trait bound
    |
+help: the trait `std::fmt::Display` is not implemented for `A`
+  --> $DIR/remap-path-prefix-diagnostics.rs:LL:COL
+   |
+LL | struct A;
+   | ^^^^^^^^
 note: required by a bound in `Trait`
   --> $DIR/auxiliary/trait-debuginfo.rs:LL:COL
    |

--- a/tests/ui/errors/remap-path-prefix-diagnostics.only-diag-in-deps.stderr
+++ b/tests/ui/errors/remap-path-prefix-diagnostics.only-diag-in-deps.stderr
@@ -2,8 +2,13 @@ error[E0277]: `A` doesn't implement `std::fmt::Display`
   --> $DIR/remap-path-prefix-diagnostics.rs:LL:COL
    |
 LL | impl r#trait::Trait for A {}
-   |                         ^ the trait `std::fmt::Display` is not implemented for `A`
+   |                         ^ unsatisfied trait bound
    |
+help: the trait `std::fmt::Display` is not implemented for `A`
+  --> $DIR/remap-path-prefix-diagnostics.rs:LL:COL
+   |
+LL | struct A;
+   | ^^^^^^^^
 note: required by a bound in `Trait`
   --> $DIR/auxiliary/trait-diag.rs:LL:COL
    |

--- a/tests/ui/errors/remap-path-prefix-diagnostics.only-macro-in-deps.stderr
+++ b/tests/ui/errors/remap-path-prefix-diagnostics.only-macro-in-deps.stderr
@@ -2,8 +2,13 @@ error[E0277]: `A` doesn't implement `std::fmt::Display`
   --> $DIR/remap-path-prefix-diagnostics.rs:LL:COL
    |
 LL | impl r#trait::Trait for A {}
-   |                         ^ the trait `std::fmt::Display` is not implemented for `A`
+   |                         ^ unsatisfied trait bound
    |
+help: the trait `std::fmt::Display` is not implemented for `A`
+  --> $DIR/remap-path-prefix-diagnostics.rs:LL:COL
+   |
+LL | struct A;
+   | ^^^^^^^^
 note: required by a bound in `Trait`
   --> $DIR/auxiliary/trait-macro.rs:LL:COL
    |

--- a/tests/ui/errors/remap-path-prefix-diagnostics.with-debuginfo-in-deps.stderr
+++ b/tests/ui/errors/remap-path-prefix-diagnostics.with-debuginfo-in-deps.stderr
@@ -2,8 +2,13 @@ error[E0277]: `A` doesn't implement `std::fmt::Display`
   --> $DIR/remap-path-prefix-diagnostics.rs:LL:COL
    |
 LL | impl r#trait::Trait for A {}
-   |                         ^ the trait `std::fmt::Display` is not implemented for `A`
+   |                         ^ unsatisfied trait bound
    |
+help: the trait `std::fmt::Display` is not implemented for `A`
+  --> $DIR/remap-path-prefix-diagnostics.rs:LL:COL
+   |
+LL | struct A;
+   | ^^^^^^^^
 note: required by a bound in `Trait`
   --> $DIR/auxiliary/trait-debuginfo.rs:LL:COL
    |

--- a/tests/ui/errors/remap-path-prefix-diagnostics.with-diag-in-deps.stderr
+++ b/tests/ui/errors/remap-path-prefix-diagnostics.with-diag-in-deps.stderr
@@ -2,8 +2,13 @@ error[E0277]: `A` doesn't implement `std::fmt::Display`
   --> remapped/errors/remap-path-prefix-diagnostics.rs:LL:COL
    |
 LL | impl r#trait::Trait for A {}
-   |                         ^ the trait `std::fmt::Display` is not implemented for `A`
+   |                         ^ unsatisfied trait bound
    |
+help: the trait `std::fmt::Display` is not implemented for `A`
+  --> remapped/errors/remap-path-prefix-diagnostics.rs:LL:COL
+   |
+LL | struct A;
+   | ^^^^^^^^
 note: required by a bound in `Trait`
   --> remapped/errors/auxiliary/trait-diag.rs:LL:COL
    |

--- a/tests/ui/errors/remap-path-prefix-diagnostics.with-macro-in-deps.stderr
+++ b/tests/ui/errors/remap-path-prefix-diagnostics.with-macro-in-deps.stderr
@@ -2,8 +2,13 @@ error[E0277]: `A` doesn't implement `std::fmt::Display`
   --> $DIR/remap-path-prefix-diagnostics.rs:LL:COL
    |
 LL | impl r#trait::Trait for A {}
-   |                         ^ the trait `std::fmt::Display` is not implemented for `A`
+   |                         ^ unsatisfied trait bound
    |
+help: the trait `std::fmt::Display` is not implemented for `A`
+  --> $DIR/remap-path-prefix-diagnostics.rs:LL:COL
+   |
+LL | struct A;
+   | ^^^^^^^^
 note: required by a bound in `Trait`
   --> $DIR/auxiliary/trait-macro.rs:LL:COL
    |

--- a/tests/ui/feature-gates/feature-gate-unboxed-closures-manual-impls.stderr
+++ b/tests/ui/feature-gates/feature-gate-unboxed-closures-manual-impls.stderr
@@ -93,7 +93,11 @@ error[E0277]: expected a `FnMut()` closure, found `Foo`
 LL | impl Fn<()> for Foo {
    |                 ^^^ expected an `FnMut()` closure, found `Foo`
    |
-   = help: the trait `FnMut()` is not implemented for `Foo`
+help: the trait `FnMut()` is not implemented for `Foo`
+  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:8:1
+   |
+LL | struct Foo;
+   | ^^^^^^^^^^
    = note: wrap the `Foo` in a closure with no arguments: `|| { /* code */ }`
 note: required by a bound in `Fn`
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
@@ -163,7 +167,11 @@ error[E0277]: expected a `FnOnce()` closure, found `Bar`
 LL | impl FnMut<()> for Bar {
    |                    ^^^ expected an `FnOnce()` closure, found `Bar`
    |
-   = help: the trait `FnOnce()` is not implemented for `Bar`
+help: the trait `FnOnce()` is not implemented for `Bar`
+  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:25:1
+   |
+LL | struct Bar;
+   | ^^^^^^^^^^
    = note: wrap the `Bar` in a closure with no arguments: `|| { /* code */ }`
 note: required by a bound in `FnMut`
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL

--- a/tests/ui/fmt/non-source-literals.stderr
+++ b/tests/ui/fmt/non-source-literals.stderr
@@ -4,7 +4,11 @@ error[E0277]: `NonDisplay` doesn't implement `std::fmt::Display`
 LL |     let _ = format!(concat!("{", "}"), NonDisplay);
    |                                        ^^^^^^^^^^ `NonDisplay` cannot be formatted with the default formatter
    |
-   = help: the trait `std::fmt::Display` is not implemented for `NonDisplay`
+help: the trait `std::fmt::Display` is not implemented for `NonDisplay`
+  --> $DIR/non-source-literals.rs:5:1
+   |
+LL | pub struct NonDisplay;
+   | ^^^^^^^^^^^^^^^^^^^^^
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
    = note: this error originates in the macro `$crate::__export::format_args` which comes from the expansion of the macro `format` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -14,7 +18,11 @@ error[E0277]: `NonDisplay` doesn't implement `std::fmt::Display`
 LL |     let _ = format!(concat!("{", "0", "}"), NonDisplay);
    |                                             ^^^^^^^^^^ `NonDisplay` cannot be formatted with the default formatter
    |
-   = help: the trait `std::fmt::Display` is not implemented for `NonDisplay`
+help: the trait `std::fmt::Display` is not implemented for `NonDisplay`
+  --> $DIR/non-source-literals.rs:5:1
+   |
+LL | pub struct NonDisplay;
+   | ^^^^^^^^^^^^^^^^^^^^^
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
    = note: this error originates in the macro `$crate::__export::format_args` which comes from the expansion of the macro `format` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/fn/issue-39259.stderr
+++ b/tests/ui/fn/issue-39259.stderr
@@ -24,7 +24,11 @@ error[E0277]: expected a `FnMut(u32)` closure, found `S`
 LL | impl Fn(u32) -> u32 for S {
    |                         ^ expected an `FnMut(u32)` closure, found `S`
    |
-   = help: the trait `FnMut(u32)` is not implemented for `S`
+help: the trait `FnMut(u32)` is not implemented for `S`
+  --> $DIR/issue-39259.rs:4:1
+   |
+LL | struct S;
+   | ^^^^^^^^
 note: required by a bound in `Fn`
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
 

--- a/tests/ui/for/for-loop-bogosity.stderr
+++ b/tests/ui/for/for-loop-bogosity.stderr
@@ -4,7 +4,11 @@ error[E0277]: `MyStruct` is not an iterator
 LL |     for x in bogus {
    |              ^^^^^ `MyStruct` is not an iterator
    |
-   = help: the trait `Iterator` is not implemented for `MyStruct`
+help: the trait `Iterator` is not implemented for `MyStruct`
+  --> $DIR/for-loop-bogosity.rs:1:1
+   |
+LL | struct MyStruct {
+   | ^^^^^^^^^^^^^^^
    = note: required for `MyStruct` to implement `IntoIterator`
 
 error: aborting due to 1 previous error

--- a/tests/ui/impl-trait/diagnostics/highlight-difference-between-expected-trait-and-found-trait.svg
+++ b/tests/ui/impl-trait/diagnostics/highlight-difference-between-expected-trait-and-found-trait.svg
@@ -1,4 +1,4 @@
-<svg width="1028px" height="398px" xmlns="http://www.w3.org/2000/svg">
+<svg width="1188px" height="398px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -29,7 +29,7 @@
 </tspan>
     <tspan x="10px" y="82px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> fn foo() -&gt; impl Foo&lt;i32&gt; {</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>             </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^^^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">the trait `Bar&lt;i32&gt;` is not implemented for `Struct`</tspan>
+    <tspan x="10px" y="100px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>             </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^^^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">unsatisfied trait bound</tspan>
 </tspan>
     <tspan x="10px" y="118px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Struct</tspan>
 </tspan>

--- a/tests/ui/impl-trait/in-trait/return-dont-satisfy-bounds.stderr
+++ b/tests/ui/impl-trait/in-trait/return-dont-satisfy-bounds.stderr
@@ -24,7 +24,7 @@ error[E0277]: the trait bound `Bar: Foo<u8>` is not satisfied
   --> $DIR/return-dont-satisfy-bounds.rs:8:34
    |
 LL |     fn foo<F2: Foo<u8>>(self) -> impl Foo<u8> {
-   |                                  ^^^^^^^^^^^^ the trait `Foo<u8>` is not implemented for `Bar`
+   |                                  ^^^^^^^^^^^^ unsatisfied trait bound
 ...
 LL |         self
    |         ---- return type was inferred to be `Bar` here

--- a/tests/ui/impl-trait/issues/issue-62742.stderr
+++ b/tests/ui/impl-trait/issues/issue-62742.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `RawImpl<_>: Raw<_>` is not satisfied
   --> $DIR/issue-62742.rs:4:5
    |
 LL |     WrongImpl::foo(0i32);
-   |     ^^^^^^^^^ the trait `Raw<_>` is not implemented for `RawImpl<_>`
+   |     ^^^^^^^^^ unsatisfied trait bound
    |
    = help: the trait `Raw<_>` is not implemented for `RawImpl<_>`
            but trait `Raw<[_]>` is implemented for it
@@ -41,7 +41,7 @@ error[E0277]: the trait bound `RawImpl<()>: Raw<()>` is not satisfied
   --> $DIR/issue-62742.rs:10:5
    |
 LL |     WrongImpl::<()>::foo(0i32);
-   |     ^^^^^^^^^^^^^^^ the trait `Raw<()>` is not implemented for `RawImpl<()>`
+   |     ^^^^^^^^^^^^^^^ unsatisfied trait bound
    |
    = help: the trait `Raw<()>` is not implemented for `RawImpl<()>`
            but trait `Raw<[()]>` is implemented for it

--- a/tests/ui/impl-trait/recursive-type-alias-impl-trait-declaration.stderr
+++ b/tests/ui/impl-trait/recursive-type-alias-impl-trait-declaration.stderr
@@ -7,7 +7,11 @@ LL |
 LL |     Bar
    |     --- return type was inferred to be `Bar` here
    |
-   = help: the trait `PartialEq<(Foo, i32)>` is not implemented for `Bar`
+help: the trait `PartialEq<(Foo, i32)>` is not implemented for `Bar`
+  --> $DIR/recursive-type-alias-impl-trait-declaration.rs:5:1
+   |
+LL | struct Bar;
+   | ^^^^^^^^^^
    = help: the trait `PartialEq<(Bar, i32)>` is implemented for `Bar`
 
 error: aborting due to 1 previous error

--- a/tests/ui/issues/issue-45801.stderr
+++ b/tests/ui/issues/issue-45801.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `Params: Plugin<i32>` is not satisfied
   --> $DIR/issue-45801.rs:21:9
    |
 LL |     req.get_ref::<Params>();
-   |         ^^^^^^^ the trait `Plugin<i32>` is not implemented for `Params`
+   |         ^^^^^^^ unsatisfied trait bound
    |
    = help: the trait `Plugin<i32>` is not implemented for `Params`
            but trait `Plugin<Foo>` is implemented for it

--- a/tests/ui/kindck/kindck-copy.stderr
+++ b/tests/ui/kindck/kindck-copy.stderr
@@ -120,8 +120,13 @@ error[E0277]: the trait bound `MyNoncopyStruct: Copy` is not satisfied
   --> $DIR/kindck-copy.rs:64:19
    |
 LL |     assert_copy::<MyNoncopyStruct>();
-   |                   ^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `MyNoncopyStruct`
+   |                   ^^^^^^^^^^^^^^^ unsatisfied trait bound
    |
+help: the trait `Copy` is not implemented for `MyNoncopyStruct`
+  --> $DIR/kindck-copy.rs:15:1
+   |
+LL | struct MyNoncopyStruct {
+   | ^^^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `assert_copy`
   --> $DIR/kindck-copy.rs:5:18
    |

--- a/tests/ui/lifetimes/issue-95023.stderr
+++ b/tests/ui/lifetimes/issue-95023.stderr
@@ -46,7 +46,11 @@ error[E0277]: expected a `FnMut(&isize)` closure, found `Error`
 LL | impl Fn(&isize) for Error {
    |                     ^^^^^ expected an `FnMut(&isize)` closure, found `Error`
    |
-   = help: the trait `FnMut(&isize)` is not implemented for `Error`
+help: the trait `FnMut(&isize)` is not implemented for `Error`
+  --> $DIR/issue-95023.rs:2:1
+   |
+LL | struct Error(ErrorKind);
+   | ^^^^^^^^^^^^
 note: required by a bound in `Fn`
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
 

--- a/tests/ui/marker_trait_attr/overlap-marker-trait.stderr
+++ b/tests/ui/marker_trait_attr/overlap-marker-trait.stderr
@@ -2,8 +2,13 @@ error[E0277]: the trait bound `NotDebugOrDisplay: Marker` is not satisfied
   --> $DIR/overlap-marker-trait.rs:28:17
    |
 LL |     is_marker::<NotDebugOrDisplay>();
-   |                 ^^^^^^^^^^^^^^^^^ the trait `Marker` is not implemented for `NotDebugOrDisplay`
+   |                 ^^^^^^^^^^^^^^^^^ unsatisfied trait bound
    |
+help: the trait `Marker` is not implemented for `NotDebugOrDisplay`
+  --> $DIR/overlap-marker-trait.rs:18:1
+   |
+LL | struct NotDebugOrDisplay;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `is_marker`
   --> $DIR/overlap-marker-trait.rs:16:17
    |

--- a/tests/ui/methods/inherent-bound-in-probe.stderr
+++ b/tests/ui/methods/inherent-bound-in-probe.stderr
@@ -4,7 +4,11 @@ error[E0277]: `Helper<'a, T>` is not an iterator
 LL |     type IntoIter = Helper<'a, T>;
    |                     ^^^^^^^^^^^^^ `Helper<'a, T>` is not an iterator
    |
-   = help: the trait `Iterator` is not implemented for `Helper<'a, T>`
+help: the trait `Iterator` is not implemented for `Helper<'a, T>`
+  --> $DIR/inherent-bound-in-probe.rs:15:1
+   |
+LL | struct Helper<'a, T>
+   | ^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `std::iter::IntoIterator::IntoIter`
   --> $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
 

--- a/tests/ui/mut/mutable-enum-indirect.stderr
+++ b/tests/ui/mut/mutable-enum-indirect.stderr
@@ -6,7 +6,11 @@ LL |     bar(&x);
    |     |
    |     required by a bound introduced by this call
    |
-   = help: within `&Foo`, the trait `Sync` is not implemented for `NoSync`
+help: within `&Foo`, the trait `Sync` is not implemented for `NoSync`
+  --> $DIR/mutable-enum-indirect.rs:8:1
+   |
+LL | struct NoSync;
+   | ^^^^^^^^^^^^^
 note: required because it appears within the type `Foo`
   --> $DIR/mutable-enum-indirect.rs:11:6
    |

--- a/tests/ui/namespace/namespace-mix.stderr
+++ b/tests/ui/namespace/namespace-mix.stderr
@@ -106,10 +106,15 @@ error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:33:11
    |
 LL |     check(m1::S{});
-   |     ----- ^^^^^^^ the trait `Impossible` is not implemented for `c::Item`
+   |     ----- ^^^^^^^ unsatisfied trait bound
    |     |
    |     required by a bound introduced by this call
    |
+help: the trait `Impossible` is not implemented for `c::Item`
+  --> $DIR/namespace-mix.rs:16:5
+   |
+LL |     pub struct Item;
+   |     ^^^^^^^^^^^^^^^
 help: this trait has no implementations, consider adding one
   --> $DIR/namespace-mix.rs:20:1
    |
@@ -125,10 +130,15 @@ error[E0277]: the trait bound `c::S: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:35:11
    |
 LL |     check(m2::S{});
-   |     ----- ^^^^^^^ the trait `Impossible` is not implemented for `c::S`
+   |     ----- ^^^^^^^ unsatisfied trait bound
    |     |
    |     required by a bound introduced by this call
    |
+help: the trait `Impossible` is not implemented for `c::S`
+  --> $DIR/namespace-mix.rs:7:5
+   |
+LL |     pub struct S {}
+   |     ^^^^^^^^^^^^
 help: this trait has no implementations, consider adding one
   --> $DIR/namespace-mix.rs:20:1
    |
@@ -144,10 +154,15 @@ error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:36:11
    |
 LL |     check(m2::S);
-   |     ----- ^^^^^ the trait `Impossible` is not implemented for `c::Item`
+   |     ----- ^^^^^ unsatisfied trait bound
    |     |
    |     required by a bound introduced by this call
    |
+help: the trait `Impossible` is not implemented for `c::Item`
+  --> $DIR/namespace-mix.rs:16:5
+   |
+LL |     pub struct Item;
+   |     ^^^^^^^^^^^^^^^
 help: this trait has no implementations, consider adding one
   --> $DIR/namespace-mix.rs:20:1
    |
@@ -220,10 +235,15 @@ error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:55:11
    |
 LL |     check(m3::TS{});
-   |     ----- ^^^^^^^^ the trait `Impossible` is not implemented for `c::Item`
+   |     ----- ^^^^^^^^ unsatisfied trait bound
    |     |
    |     required by a bound introduced by this call
    |
+help: the trait `Impossible` is not implemented for `c::Item`
+  --> $DIR/namespace-mix.rs:16:5
+   |
+LL |     pub struct Item;
+   |     ^^^^^^^^^^^^^^^
 help: this trait has no implementations, consider adding one
   --> $DIR/namespace-mix.rs:20:1
    |
@@ -258,10 +278,15 @@ error[E0277]: the trait bound `c::TS: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:57:11
    |
 LL |     check(m4::TS{});
-   |     ----- ^^^^^^^^ the trait `Impossible` is not implemented for `c::TS`
+   |     ----- ^^^^^^^^ unsatisfied trait bound
    |     |
    |     required by a bound introduced by this call
    |
+help: the trait `Impossible` is not implemented for `c::TS`
+  --> $DIR/namespace-mix.rs:8:5
+   |
+LL |     pub struct TS();
+   |     ^^^^^^^^^^^^^
 help: this trait has no implementations, consider adding one
   --> $DIR/namespace-mix.rs:20:1
    |
@@ -277,10 +302,15 @@ error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:58:11
    |
 LL |     check(m4::TS);
-   |     ----- ^^^^^^ the trait `Impossible` is not implemented for `c::Item`
+   |     ----- ^^^^^^ unsatisfied trait bound
    |     |
    |     required by a bound introduced by this call
    |
+help: the trait `Impossible` is not implemented for `c::Item`
+  --> $DIR/namespace-mix.rs:16:5
+   |
+LL |     pub struct Item;
+   |     ^^^^^^^^^^^^^^^
 help: this trait has no implementations, consider adding one
   --> $DIR/namespace-mix.rs:20:1
    |
@@ -372,10 +402,15 @@ error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:77:11
    |
 LL |     check(m5::US{});
-   |     ----- ^^^^^^^^ the trait `Impossible` is not implemented for `c::Item`
+   |     ----- ^^^^^^^^ unsatisfied trait bound
    |     |
    |     required by a bound introduced by this call
    |
+help: the trait `Impossible` is not implemented for `c::Item`
+  --> $DIR/namespace-mix.rs:16:5
+   |
+LL |     pub struct Item;
+   |     ^^^^^^^^^^^^^^^
 help: this trait has no implementations, consider adding one
   --> $DIR/namespace-mix.rs:20:1
    |
@@ -391,10 +426,15 @@ error[E0277]: the trait bound `c::US: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:78:11
    |
 LL |     check(m5::US);
-   |     ----- ^^^^^^ the trait `Impossible` is not implemented for `c::US`
+   |     ----- ^^^^^^ unsatisfied trait bound
    |     |
    |     required by a bound introduced by this call
    |
+help: the trait `Impossible` is not implemented for `c::US`
+  --> $DIR/namespace-mix.rs:9:5
+   |
+LL |     pub struct US;
+   |     ^^^^^^^^^^^^^
 help: this trait has no implementations, consider adding one
   --> $DIR/namespace-mix.rs:20:1
    |
@@ -410,10 +450,15 @@ error[E0277]: the trait bound `c::US: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:79:11
    |
 LL |     check(m6::US{});
-   |     ----- ^^^^^^^^ the trait `Impossible` is not implemented for `c::US`
+   |     ----- ^^^^^^^^ unsatisfied trait bound
    |     |
    |     required by a bound introduced by this call
    |
+help: the trait `Impossible` is not implemented for `c::US`
+  --> $DIR/namespace-mix.rs:9:5
+   |
+LL |     pub struct US;
+   |     ^^^^^^^^^^^^^
 help: this trait has no implementations, consider adding one
   --> $DIR/namespace-mix.rs:20:1
    |
@@ -429,10 +474,15 @@ error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:80:11
    |
 LL |     check(m6::US);
-   |     ----- ^^^^^^ the trait `Impossible` is not implemented for `c::Item`
+   |     ----- ^^^^^^ unsatisfied trait bound
    |     |
    |     required by a bound introduced by this call
    |
+help: the trait `Impossible` is not implemented for `c::Item`
+  --> $DIR/namespace-mix.rs:16:5
+   |
+LL |     pub struct Item;
+   |     ^^^^^^^^^^^^^^^
 help: this trait has no implementations, consider adding one
   --> $DIR/namespace-mix.rs:20:1
    |
@@ -524,10 +574,15 @@ error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:99:11
    |
 LL |     check(m7::V{});
-   |     ----- ^^^^^^^ the trait `Impossible` is not implemented for `c::Item`
+   |     ----- ^^^^^^^ unsatisfied trait bound
    |     |
    |     required by a bound introduced by this call
    |
+help: the trait `Impossible` is not implemented for `c::Item`
+  --> $DIR/namespace-mix.rs:16:5
+   |
+LL |     pub struct Item;
+   |     ^^^^^^^^^^^^^^^
 help: this trait has no implementations, consider adding one
   --> $DIR/namespace-mix.rs:20:1
    |
@@ -543,10 +598,15 @@ error[E0277]: the trait bound `c::E: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:101:11
    |
 LL |     check(m8::V{});
-   |     ----- ^^^^^^^ the trait `Impossible` is not implemented for `c::E`
+   |     ----- ^^^^^^^ unsatisfied trait bound
    |     |
    |     required by a bound introduced by this call
    |
+help: the trait `Impossible` is not implemented for `c::E`
+  --> $DIR/namespace-mix.rs:10:5
+   |
+LL |     pub enum E {
+   |     ^^^^^^^^^^
 help: this trait has no implementations, consider adding one
   --> $DIR/namespace-mix.rs:20:1
    |
@@ -562,10 +622,15 @@ error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:102:11
    |
 LL |     check(m8::V);
-   |     ----- ^^^^^ the trait `Impossible` is not implemented for `c::Item`
+   |     ----- ^^^^^ unsatisfied trait bound
    |     |
    |     required by a bound introduced by this call
    |
+help: the trait `Impossible` is not implemented for `c::Item`
+  --> $DIR/namespace-mix.rs:16:5
+   |
+LL |     pub struct Item;
+   |     ^^^^^^^^^^^^^^^
 help: this trait has no implementations, consider adding one
   --> $DIR/namespace-mix.rs:20:1
    |
@@ -638,10 +703,15 @@ error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:121:11
    |
 LL |     check(m9::TV{});
-   |     ----- ^^^^^^^^ the trait `Impossible` is not implemented for `c::Item`
+   |     ----- ^^^^^^^^ unsatisfied trait bound
    |     |
    |     required by a bound introduced by this call
    |
+help: the trait `Impossible` is not implemented for `c::Item`
+  --> $DIR/namespace-mix.rs:16:5
+   |
+LL |     pub struct Item;
+   |     ^^^^^^^^^^^^^^^
 help: this trait has no implementations, consider adding one
   --> $DIR/namespace-mix.rs:20:1
    |
@@ -676,10 +746,15 @@ error[E0277]: the trait bound `c::E: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:123:11
    |
 LL |     check(mA::TV{});
-   |     ----- ^^^^^^^^ the trait `Impossible` is not implemented for `c::E`
+   |     ----- ^^^^^^^^ unsatisfied trait bound
    |     |
    |     required by a bound introduced by this call
    |
+help: the trait `Impossible` is not implemented for `c::E`
+  --> $DIR/namespace-mix.rs:10:5
+   |
+LL |     pub enum E {
+   |     ^^^^^^^^^^
 help: this trait has no implementations, consider adding one
   --> $DIR/namespace-mix.rs:20:1
    |
@@ -695,10 +770,15 @@ error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:124:11
    |
 LL |     check(mA::TV);
-   |     ----- ^^^^^^ the trait `Impossible` is not implemented for `c::Item`
+   |     ----- ^^^^^^ unsatisfied trait bound
    |     |
    |     required by a bound introduced by this call
    |
+help: the trait `Impossible` is not implemented for `c::Item`
+  --> $DIR/namespace-mix.rs:16:5
+   |
+LL |     pub struct Item;
+   |     ^^^^^^^^^^^^^^^
 help: this trait has no implementations, consider adding one
   --> $DIR/namespace-mix.rs:20:1
    |
@@ -790,10 +870,15 @@ error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:143:11
    |
 LL |     check(mB::UV{});
-   |     ----- ^^^^^^^^ the trait `Impossible` is not implemented for `c::Item`
+   |     ----- ^^^^^^^^ unsatisfied trait bound
    |     |
    |     required by a bound introduced by this call
    |
+help: the trait `Impossible` is not implemented for `c::Item`
+  --> $DIR/namespace-mix.rs:16:5
+   |
+LL |     pub struct Item;
+   |     ^^^^^^^^^^^^^^^
 help: this trait has no implementations, consider adding one
   --> $DIR/namespace-mix.rs:20:1
    |
@@ -809,10 +894,15 @@ error[E0277]: the trait bound `c::E: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:144:11
    |
 LL |     check(mB::UV);
-   |     ----- ^^^^^^ the trait `Impossible` is not implemented for `c::E`
+   |     ----- ^^^^^^ unsatisfied trait bound
    |     |
    |     required by a bound introduced by this call
    |
+help: the trait `Impossible` is not implemented for `c::E`
+  --> $DIR/namespace-mix.rs:10:5
+   |
+LL |     pub enum E {
+   |     ^^^^^^^^^^
 help: this trait has no implementations, consider adding one
   --> $DIR/namespace-mix.rs:20:1
    |
@@ -828,10 +918,15 @@ error[E0277]: the trait bound `c::E: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:145:11
    |
 LL |     check(mC::UV{});
-   |     ----- ^^^^^^^^ the trait `Impossible` is not implemented for `c::E`
+   |     ----- ^^^^^^^^ unsatisfied trait bound
    |     |
    |     required by a bound introduced by this call
    |
+help: the trait `Impossible` is not implemented for `c::E`
+  --> $DIR/namespace-mix.rs:10:5
+   |
+LL |     pub enum E {
+   |     ^^^^^^^^^^
 help: this trait has no implementations, consider adding one
   --> $DIR/namespace-mix.rs:20:1
    |
@@ -847,10 +942,15 @@ error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:146:11
    |
 LL |     check(mC::UV);
-   |     ----- ^^^^^^ the trait `Impossible` is not implemented for `c::Item`
+   |     ----- ^^^^^^ unsatisfied trait bound
    |     |
    |     required by a bound introduced by this call
    |
+help: the trait `Impossible` is not implemented for `c::Item`
+  --> $DIR/namespace-mix.rs:16:5
+   |
+LL |     pub struct Item;
+   |     ^^^^^^^^^^^^^^^
 help: this trait has no implementations, consider adding one
   --> $DIR/namespace-mix.rs:20:1
    |

--- a/tests/ui/never_type/from_infer_breaking_with_unit_fallback.unit.stderr
+++ b/tests/ui/never_type/from_infer_breaking_with_unit_fallback.unit.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `E: From<()>` is not satisfied
   --> $DIR/from_infer_breaking_with_unit_fallback.rs:25:6
    |
 LL |     <E as From<_>>::from(never); // Should the inference fail?
-   |      ^ the trait `From<()>` is not implemented for `E`
+   |      ^ unsatisfied trait bound
    |
    = help: the trait `From<()>` is not implemented for `E`
            but trait `From<!>` is implemented for it

--- a/tests/ui/never_type/never-value-fallback-issue-66757.nofallback.stderr
+++ b/tests/ui/never_type/never-value-fallback-issue-66757.nofallback.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `E: From<()>` is not satisfied
   --> $DIR/never-value-fallback-issue-66757.rs:28:6
    |
 LL |     <E as From<_>>::from(never);
-   |      ^ the trait `From<()>` is not implemented for `E`
+   |      ^ unsatisfied trait bound
    |
    = help: the trait `From<()>` is not implemented for `E`
            but trait `From<!>` is implemented for it

--- a/tests/ui/on-unimplemented/no-debug.stderr
+++ b/tests/ui/on-unimplemented/no-debug.stderr
@@ -34,7 +34,11 @@ LL |     println!("{} {}", Foo, Bar);
    |               |
    |               required by this formatting parameter
    |
-   = help: the trait `std::fmt::Display` is not implemented for `Foo`
+help: the trait `std::fmt::Display` is not implemented for `Foo`
+  --> $DIR/no-debug.rs:7:1
+   |
+LL | struct Foo;
+   | ^^^^^^^^^^
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
    = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/on-unimplemented/parent-label.stderr
+++ b/tests/ui/on-unimplemented/parent-label.stderr
@@ -4,10 +4,15 @@ error[E0277]: the trait bound `Foo: Trait` is not satisfied
 LL |     let x = || {
    |             -- in this scope
 LL |         f(Foo {});
-   |         - ^^^^^^ the trait `Trait` is not implemented for `Foo`
+   |         - ^^^^^^ unsatisfied trait bound
    |         |
    |         required by a bound introduced by this call
    |
+help: the trait `Trait` is not implemented for `Foo`
+  --> $DIR/parent-label.rs:8:1
+   |
+LL | struct Foo;
+   | ^^^^^^^^^^
 help: this trait has no implementations, consider adding one
   --> $DIR/parent-label.rs:6:1
    |
@@ -25,10 +30,15 @@ error[E0277]: the trait bound `Foo: Trait` is not satisfied
 LL |         let y = || {
    |                 -- in this scope
 LL |             f(Foo {});
-   |             - ^^^^^^ the trait `Trait` is not implemented for `Foo`
+   |             - ^^^^^^ unsatisfied trait bound
    |             |
    |             required by a bound introduced by this call
    |
+help: the trait `Trait` is not implemented for `Foo`
+  --> $DIR/parent-label.rs:8:1
+   |
+LL | struct Foo;
+   | ^^^^^^^^^^
 help: this trait has no implementations, consider adding one
   --> $DIR/parent-label.rs:6:1
    |
@@ -47,10 +57,15 @@ LL | fn main() {
    | --------- in this scope
 ...
 LL |             f(Foo {});
-   |             - ^^^^^^ the trait `Trait` is not implemented for `Foo`
+   |             - ^^^^^^ unsatisfied trait bound
    |             |
    |             required by a bound introduced by this call
    |
+help: the trait `Trait` is not implemented for `Foo`
+  --> $DIR/parent-label.rs:8:1
+   |
+LL | struct Foo;
+   | ^^^^^^^^^^
 help: this trait has no implementations, consider adding one
   --> $DIR/parent-label.rs:6:1
    |
@@ -69,10 +84,15 @@ LL | fn main() {
    | --------- in this scope
 ...
 LL |     f(Foo {});
-   |     - ^^^^^^ the trait `Trait` is not implemented for `Foo`
+   |     - ^^^^^^ unsatisfied trait bound
    |     |
    |     required by a bound introduced by this call
    |
+help: the trait `Trait` is not implemented for `Foo`
+  --> $DIR/parent-label.rs:8:1
+   |
+LL | struct Foo;
+   | ^^^^^^^^^^
 help: this trait has no implementations, consider adding one
   --> $DIR/parent-label.rs:6:1
    |

--- a/tests/ui/on-unimplemented/suggest_tuple_wrap_root_obligation.rs
+++ b/tests/ui/on-unimplemented/suggest_tuple_wrap_root_obligation.rs
@@ -1,4 +1,4 @@
-struct Tuple;
+struct Tuple; //~ HELP the trait `From<u8>` is not implemented for `Tuple`
 
 impl From<(u8,)> for Tuple {
     fn from(_: (u8,)) -> Self {

--- a/tests/ui/on-unimplemented/suggest_tuple_wrap_root_obligation.stderr
+++ b/tests/ui/on-unimplemented/suggest_tuple_wrap_root_obligation.stderr
@@ -2,10 +2,15 @@ error[E0277]: the trait bound `Tuple: From<u8>` is not satisfied
   --> $DIR/suggest_tuple_wrap_root_obligation.rs:22:24
    |
 LL |     convert_into_tuple(42_u8);
-   |     ------------------ ^^^^^ the trait `From<u8>` is not implemented for `Tuple`
+   |     ------------------ ^^^^^ unsatisfied trait bound
    |     |
    |     required by a bound introduced by this call
    |
+help: the trait `From<u8>` is not implemented for `Tuple`
+  --> $DIR/suggest_tuple_wrap_root_obligation.rs:1:1
+   |
+LL | struct Tuple;
+   | ^^^^^^^^^^^^
    = help: the following other types implement trait `From<T>`:
              `Tuple` implements `From<(u8, u8)>`
              `Tuple` implements `From<(u8, u8, u8)>`

--- a/tests/ui/pattern/deref-patterns/recursion-limit.stderr
+++ b/tests/ui/pattern/deref-patterns/recursion-limit.stderr
@@ -10,7 +10,13 @@ error[E0277]: the trait bound `Cyclic: DerefPure` is not satisfied
   --> $DIR/recursion-limit.rs:18:9
    |
 LL |         () => {}
-   |         ^^ the trait `DerefPure` is not implemented for `Cyclic`
+   |         ^^ unsatisfied trait bound
+   |
+help: the trait `DerefPure` is not implemented for `Cyclic`
+  --> $DIR/recursion-limit.rs:8:1
+   |
+LL | struct Cyclic;
+   | ^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/pattern/deref-patterns/unsatisfied-bounds.stderr
+++ b/tests/ui/pattern/deref-patterns/unsatisfied-bounds.stderr
@@ -2,7 +2,13 @@ error[E0277]: the trait bound `MyPointer: DerefPure` is not satisfied
   --> $DIR/unsatisfied-bounds.rs:17:9
    |
 LL |         () => {}
-   |         ^^ the trait `DerefPure` is not implemented for `MyPointer`
+   |         ^^ unsatisfied trait bound
+   |
+help: the trait `DerefPure` is not implemented for `MyPointer`
+  --> $DIR/unsatisfied-bounds.rs:4:1
+   |
+LL | struct MyPointer;
+   | ^^^^^^^^^^^^^^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/privacy/sealed-traits/false-sealed-traits-note.stderr
+++ b/tests/ui/privacy/sealed-traits/false-sealed-traits-note.stderr
@@ -2,8 +2,13 @@ error[E0277]: the trait bound `Struct: TraitA` is not satisfied
   --> $DIR/false-sealed-traits-note.rs:12:24
    |
 LL | impl inner::TraitB for Struct {}
-   |                        ^^^^^^ the trait `TraitA` is not implemented for `Struct`
+   |                        ^^^^^^ unsatisfied trait bound
    |
+help: the trait `TraitA` is not implemented for `Struct`
+  --> $DIR/false-sealed-traits-note.rs:10:1
+   |
+LL | struct Struct;
+   | ^^^^^^^^^^^^^
 help: this trait has no implementations, consider adding one
   --> $DIR/false-sealed-traits-note.rs:5:5
    |
@@ -19,8 +24,13 @@ error[E0277]: the trait bound `C: A` is not satisfied
   --> $DIR/false-sealed-traits-note.rs:20:16
    |
 LL |     impl B for C {}
-   |                ^ the trait `A` is not implemented for `C`
+   |                ^ unsatisfied trait bound
    |
+help: the trait `A` is not implemented for `C`
+  --> $DIR/false-sealed-traits-note.rs:19:5
+   |
+LL |     pub struct C;
+   |     ^^^^^^^^^^^^
 help: this trait has no implementations, consider adding one
   --> $DIR/false-sealed-traits-note.rs:16:5
    |

--- a/tests/ui/privacy/sealed-traits/sealed-trait-local.stderr
+++ b/tests/ui/privacy/sealed-traits/sealed-trait-local.stderr
@@ -2,8 +2,13 @@ error[E0277]: the trait bound `S: b::Hidden` is not satisfied
   --> $DIR/sealed-trait-local.rs:52:20
    |
 LL | impl a::Sealed for S {}
-   |                    ^ the trait `b::Hidden` is not implemented for `S`
+   |                    ^ unsatisfied trait bound
    |
+help: the trait `b::Hidden` is not implemented for `S`
+  --> $DIR/sealed-trait-local.rs:51:1
+   |
+LL | struct S;
+   | ^^^^^^^^
 note: required by a bound in `a::Sealed`
   --> $DIR/sealed-trait-local.rs:3:23
    |
@@ -17,8 +22,13 @@ error[E0277]: the trait bound `S: d::Hidden` is not satisfied
   --> $DIR/sealed-trait-local.rs:53:20
    |
 LL | impl c::Sealed for S {}
-   |                    ^ the trait `d::Hidden` is not implemented for `S`
+   |                    ^ unsatisfied trait bound
    |
+help: the trait `d::Hidden` is not implemented for `S`
+  --> $DIR/sealed-trait-local.rs:51:1
+   |
+LL | struct S;
+   | ^^^^^^^^
 note: required by a bound in `c::Sealed`
   --> $DIR/sealed-trait-local.rs:17:23
    |
@@ -33,8 +43,13 @@ error[E0277]: the trait bound `S: f::Hidden` is not satisfied
   --> $DIR/sealed-trait-local.rs:54:20
    |
 LL | impl e::Sealed for S {}
-   |                    ^ the trait `f::Hidden` is not implemented for `S`
+   |                    ^ unsatisfied trait bound
    |
+help: the trait `f::Hidden` is not implemented for `S`
+  --> $DIR/sealed-trait-local.rs:51:1
+   |
+LL | struct S;
+   | ^^^^^^^^
 note: required by a bound in `e::Sealed`
   --> $DIR/sealed-trait-local.rs:35:23
    |

--- a/tests/ui/proc-macro/issue-104884-trait-impl-sugg-err.stderr
+++ b/tests/ui/proc-macro/issue-104884-trait-impl-sugg-err.stderr
@@ -4,7 +4,11 @@ error[E0277]: can't compare `PriorityQueue<T>` with `PriorityQueue<T>`
 LL | #[derive(PartialOrd, AddImpl)]
    |          ^^^^^^^^^^ no implementation for `PriorityQueue<T> == PriorityQueue<T>`
    |
-   = help: the trait `PartialEq` is not implemented for `PriorityQueue<T>`
+help: the trait `PartialEq` is not implemented for `PriorityQueue<T>`
+  --> $DIR/issue-104884-trait-impl-sugg-err.rs:20:1
+   |
+LL | struct PriorityQueue<T>(BinaryHeap<PriorityQueueEntry<T>>);
+   | ^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `PartialOrd`
   --> $SRC_DIR/core/src/cmp.rs:LL:COL
 
@@ -12,8 +16,13 @@ error[E0277]: the trait bound `PriorityQueue<T>: Eq` is not satisfied
   --> $DIR/issue-104884-trait-impl-sugg-err.rs:13:22
    |
 LL | #[derive(PartialOrd, AddImpl)]
-   |                      ^^^^^^^ the trait `Eq` is not implemented for `PriorityQueue<T>`
+   |                      ^^^^^^^ unsatisfied trait bound
    |
+help: the trait `Eq` is not implemented for `PriorityQueue<T>`
+  --> $DIR/issue-104884-trait-impl-sugg-err.rs:20:1
+   |
+LL | struct PriorityQueue<T>(BinaryHeap<PriorityQueueEntry<T>>);
+   | ^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `Ord`
   --> $SRC_DIR/core/src/cmp.rs:LL:COL
    = note: this error originates in the derive macro `AddImpl` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/rfcs/rfc-1937-termination-trait/issue-103052-1.stderr
+++ b/tests/ui/rfcs/rfc-1937-termination-trait/issue-103052-1.stderr
@@ -2,10 +2,15 @@ error[E0277]: the trait bound `Something: Termination` is not satisfied
   --> $DIR/issue-103052-1.rs:10:13
    |
 LL |     receive(Something);
-   |     ------- ^^^^^^^^^ the trait `Termination` is not implemented for `Something`
+   |     ------- ^^^^^^^^^ unsatisfied trait bound
    |     |
    |     required by a bound introduced by this call
    |
+help: the trait `Termination` is not implemented for `Something`
+  --> $DIR/issue-103052-1.rs:7:1
+   |
+LL | struct Something;
+   | ^^^^^^^^^^^^^^^^
 note: required by a bound in `receive`
   --> $DIR/issue-103052-1.rs:5:20
    |

--- a/tests/ui/rfcs/rfc-1937-termination-trait/issue-103052-2.stderr
+++ b/tests/ui/rfcs/rfc-1937-termination-trait/issue-103052-2.stderr
@@ -2,8 +2,13 @@ error[E0277]: the trait bound `Something: Termination` is not satisfied
   --> $DIR/issue-103052-2.rs:9:22
    |
 LL |         fn main() -> Something {
-   |                      ^^^^^^^^^ the trait `Termination` is not implemented for `Something`
+   |                      ^^^^^^^^^ unsatisfied trait bound
    |
+help: the trait `Termination` is not implemented for `Something`
+  --> $DIR/issue-103052-2.rs:6:5
+   |
+LL |     struct Something;
+   |     ^^^^^^^^^^^^^^^^
 note: required by a bound in `Main::main::{anon_assoc#0}`
   --> $DIR/issue-103052-2.rs:3:27
    |

--- a/tests/ui/rfcs/rfc-1937-termination-trait/termination-trait-not-satisfied.stderr
+++ b/tests/ui/rfcs/rfc-1937-termination-trait/termination-trait-not-satisfied.stderr
@@ -4,7 +4,11 @@ error[E0277]: `main` has invalid return type `ReturnType`
 LL | fn main() -> ReturnType {
    |              ^^^^^^^^^^ `main` can only return types that implement `Termination`
    |
-   = help: consider using `()`, or a `Result`
+help: consider using `()`, or a `Result`
+  --> $DIR/termination-trait-not-satisfied.rs:1:1
+   |
+LL | struct ReturnType {}
+   | ^^^^^^^^^^^^^^^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/span/issue-71363.stderr
+++ b/tests/ui/span/issue-71363.stderr
@@ -2,8 +2,13 @@ error[E0277]: `MyError` doesn't implement `std::fmt::Display`
  --> $DIR/issue-71363.rs:4:28
   |
 4 | impl std::error::Error for MyError {}
-  |                            ^^^^^^^ the trait `std::fmt::Display` is not implemented for `MyError`
+  |                            ^^^^^^^ unsatisfied trait bound
   |
+help: the trait `std::fmt::Display` is not implemented for `MyError`
+ --> $DIR/issue-71363.rs:3:1
+  |
+3 | struct MyError;
+  | ^^^^^^^^^^^^^^
 note: required by a bound in `std::error::Error`
  --> $SRC_DIR/core/src/error.rs:LL:COL
 

--- a/tests/ui/statics/issue-17718-static-sync.stderr
+++ b/tests/ui/statics/issue-17718-static-sync.stderr
@@ -4,7 +4,11 @@ error[E0277]: `Foo` cannot be shared between threads safely
 LL | static BAR: Foo = Foo;
    |             ^^^ `Foo` cannot be shared between threads safely
    |
-   = help: the trait `Sync` is not implemented for `Foo`
+help: the trait `Sync` is not implemented for `Foo`
+  --> $DIR/issue-17718-static-sync.rs:5:1
+   |
+LL | struct Foo;
+   | ^^^^^^^^^^
    = note: shared static variables must have a type that implements `Sync`
 
 error: aborting due to 1 previous error

--- a/tests/ui/suggestions/dont-suggest-borrowing-existing-borrow.stderr
+++ b/tests/ui/suggestions/dont-suggest-borrowing-existing-borrow.stderr
@@ -20,8 +20,13 @@ error[E0277]: the trait bound `S: Trait` is not satisfied
   --> $DIR/dont-suggest-borrowing-existing-borrow.rs:17:18
    |
 LL |     let _ = &mut S::foo();
-   |                  ^ the trait `Trait` is not implemented for `S`
+   |                  ^ unsatisfied trait bound
    |
+help: the trait `Trait` is not implemented for `S`
+  --> $DIR/dont-suggest-borrowing-existing-borrow.rs:3:1
+   |
+LL | struct S;
+   | ^^^^^^^^
    = help: the trait `Trait` is implemented for `&mut S`
 help: you likely meant to call the associated function `foo` for type `&mut S`, but the code as written calls associated function `foo` on type `S`
    |
@@ -32,8 +37,13 @@ error[E0277]: the trait bound `S: Trait` is not satisfied
   --> $DIR/dont-suggest-borrowing-existing-borrow.rs:19:14
    |
 LL |     let _ = &S::foo();
-   |              ^ the trait `Trait` is not implemented for `S`
+   |              ^ unsatisfied trait bound
    |
+help: the trait `Trait` is not implemented for `S`
+  --> $DIR/dont-suggest-borrowing-existing-borrow.rs:3:1
+   |
+LL | struct S;
+   | ^^^^^^^^
    = help: the trait `Trait` is implemented for `&mut S`
 help: you likely meant to call the associated function `foo` for type `&S`, but the code as written calls associated function `foo` on type `S`
    |
@@ -56,8 +66,13 @@ error[E0277]: the trait bound `S: Trait2` is not satisfied
   --> $DIR/dont-suggest-borrowing-existing-borrow.rs:23:18
    |
 LL |     let _ = &mut S::bar();
-   |                  ^ the trait `Trait2` is not implemented for `S`
+   |                  ^ unsatisfied trait bound
    |
+help: the trait `Trait2` is not implemented for `S`
+  --> $DIR/dont-suggest-borrowing-existing-borrow.rs:3:1
+   |
+LL | struct S;
+   | ^^^^^^^^
    = help: the following other types implement trait `Trait2`:
              &S
              &mut S
@@ -70,8 +85,13 @@ error[E0277]: the trait bound `S: Trait2` is not satisfied
   --> $DIR/dont-suggest-borrowing-existing-borrow.rs:25:14
    |
 LL |     let _ = &S::bar();
-   |              ^ the trait `Trait2` is not implemented for `S`
+   |              ^ unsatisfied trait bound
    |
+help: the trait `Trait2` is not implemented for `S`
+  --> $DIR/dont-suggest-borrowing-existing-borrow.rs:3:1
+   |
+LL | struct S;
+   | ^^^^^^^^
    = help: the following other types implement trait `Trait2`:
              &S
              &mut S

--- a/tests/ui/suggestions/issue-96223.stderr
+++ b/tests/ui/suggestions/issue-96223.stderr
@@ -2,10 +2,15 @@ error[E0277]: the trait bound `for<'de> EmptyBis<'de>: Foo<'_>` is not satisfied
   --> $DIR/issue-96223.rs:49:17
    |
 LL |     icey_bounds(&p);
-   |     ----------- ^^ the trait `for<'de> Foo<'_>` is not implemented for `EmptyBis<'de>`
+   |     ----------- ^^ unsatisfied trait bound
    |     |
    |     required by a bound introduced by this call
    |
+help: the trait `for<'de> Foo<'_>` is not implemented for `EmptyBis<'de>`
+  --> $DIR/issue-96223.rs:33:1
+   |
+LL | pub struct EmptyBis<'a>(&'a [u8]);
+   | ^^^^^^^^^^^^^^^^^^^^^^^
    = help: the trait `Foo<'de>` is implemented for `Baz<T>`
 note: required for `Baz<EmptyBis<'de>>` to implement `for<'de> Foo<'de>`
   --> $DIR/issue-96223.rs:16:14

--- a/tests/ui/trait-bounds/trait-bound-adt-issue-145611.stderr
+++ b/tests/ui/trait-bounds/trait-bound-adt-issue-145611.stderr
@@ -2,8 +2,13 @@ error[E0277]: the trait bound `SomeType: LocalTrait` is not satisfied
   --> $DIR/trait-bound-adt-issue-145611.rs:8:19
    |
 LL |     impls_trait::<SomeType>();
-   |                   ^^^^^^^^ the trait `LocalTrait` is not implemented for `SomeType`
+   |                   ^^^^^^^^ unsatisfied trait bound
    |
+help: the trait `LocalTrait` is not implemented for `SomeType`
+  --> $DIR/trait-bound-adt-issue-145611.rs:5:1
+   |
+LL | struct SomeType;
+   | ^^^^^^^^^^^^^^^
 help: this trait has no implementations, consider adding one
   --> $DIR/trait-bound-adt-issue-145611.rs:4:1
    |

--- a/tests/ui/traits/coercion-generic-bad.stderr
+++ b/tests/ui/traits/coercion-generic-bad.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `Struct: Trait<isize>` is not satisfied
   --> $DIR/coercion-generic-bad.rs:16:36
    |
 LL |     let s: Box<dyn Trait<isize>> = Box::new(Struct { person: "Fred" });
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Trait<isize>` is not implemented for `Struct`
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
    |
    = help: the trait `Trait<isize>` is not implemented for `Struct`
            but trait `Trait<&'static str>` is implemented for it

--- a/tests/ui/traits/default_auto_traits/default-bounds.stderr
+++ b/tests/ui/traits/default_auto_traits/default-bounds.stderr
@@ -2,10 +2,15 @@ error[E0277]: the trait bound `Forbidden: SyncDrop` is not satisfied
   --> $DIR/default-bounds.rs:43:9
    |
 LL |     bar(Forbidden);
-   |     --- ^^^^^^^^^ the trait `SyncDrop` is not implemented for `Forbidden`
+   |     --- ^^^^^^^^^ unsatisfied trait bound
    |     |
    |     required by a bound introduced by this call
    |
+help: the trait `SyncDrop` is not implemented for `Forbidden`
+  --> $DIR/default-bounds.rs:32:1
+   |
+LL | struct Forbidden;
+   | ^^^^^^^^^^^^^^^^
 note: required by a bound in `bar`
   --> $DIR/default-bounds.rs:39:8
    |
@@ -16,10 +21,15 @@ error[E0277]: the trait bound `Forbidden: Leak` is not satisfied
   --> $DIR/default-bounds.rs:43:9
    |
 LL |     bar(Forbidden);
-   |     --- ^^^^^^^^^ the trait `Leak` is not implemented for `Forbidden`
+   |     --- ^^^^^^^^^ unsatisfied trait bound
    |     |
    |     required by a bound introduced by this call
    |
+help: the trait `Leak` is not implemented for `Forbidden`
+  --> $DIR/default-bounds.rs:32:1
+   |
+LL | struct Forbidden;
+   | ^^^^^^^^^^^^^^^^
 note: required by a bound in `bar`
   --> $DIR/default-bounds.rs:39:11
    |

--- a/tests/ui/traits/default_auto_traits/maybe-bounds-in-dyn-traits.stderr
+++ b/tests/ui/traits/default_auto_traits/maybe-bounds-in-dyn-traits.stderr
@@ -2,8 +2,13 @@ error[E0277]: the trait bound `NonLeakS: Leak` is not satisfied
   --> $DIR/maybe-bounds-in-dyn-traits.rs:59:25
    |
 LL |     let _: &dyn Trait = &NonLeakS;
-   |                         ^^^^^^^^^ the trait `Leak` is not implemented for `NonLeakS`
+   |                         ^^^^^^^^^ unsatisfied trait bound
    |
+help: the trait `Leak` is not implemented for `NonLeakS`
+  --> $DIR/maybe-bounds-in-dyn-traits.rs:46:1
+   |
+LL | struct NonLeakS;
+   | ^^^^^^^^^^^^^^^
    = note: required for the cast from `&NonLeakS` to `&dyn Trait + Leak`
 
 error[E0277]: the trait bound `dyn Trait: Leak` is not satisfied

--- a/tests/ui/traits/default_auto_traits/maybe-bounds-in-traits.stderr
+++ b/tests/ui/traits/default_auto_traits/maybe-bounds-in-traits.stderr
@@ -2,8 +2,13 @@ error[E0277]: the trait bound `NonLeakS: Leak` is not satisfied
   --> $DIR/maybe-bounds-in-traits.rs:67:22
    |
 LL |         type Leak2 = NonLeakS;
-   |                      ^^^^^^^^ the trait `Leak` is not implemented for `NonLeakS`
+   |                      ^^^^^^^^ unsatisfied trait bound
    |
+help: the trait `Leak` is not implemented for `NonLeakS`
+  --> $DIR/maybe-bounds-in-traits.rs:34:1
+   |
+LL | struct NonLeakS;
+   | ^^^^^^^^^^^^^^^
 note: required by a bound in `Test3::Leak2`
   --> $DIR/maybe-bounds-in-traits.rs:67:9
    |
@@ -57,8 +62,13 @@ error[E0277]: the trait bound `NonLeakS: Leak` is not satisfied
   --> $DIR/maybe-bounds-in-traits.rs:115:18
    |
 LL |         NonLeakS.leak_foo();
-   |                  ^^^^^^^^ the trait `Leak` is not implemented for `NonLeakS`
+   |                  ^^^^^^^^ unsatisfied trait bound
    |
+help: the trait `Leak` is not implemented for `NonLeakS`
+  --> $DIR/maybe-bounds-in-traits.rs:34:1
+   |
+LL | struct NonLeakS;
+   | ^^^^^^^^^^^^^^^
 note: required by a bound in `methods::Trait::leak_foo`
   --> $DIR/maybe-bounds-in-traits.rs:101:9
    |

--- a/tests/ui/traits/enum-negative-send-impl.stderr
+++ b/tests/ui/traits/enum-negative-send-impl.stderr
@@ -6,7 +6,11 @@ LL |     requires_send(container);
    |     |
    |     required by a bound introduced by this call
    |
-   = help: within `Container`, the trait `Send` is not implemented for `NoSend`
+help: within `Container`, the trait `Send` is not implemented for `NoSend`
+  --> $DIR/enum-negative-send-impl.rs:9:1
+   |
+LL | struct NoSend;
+   | ^^^^^^^^^^^^^
 note: required because it appears within the type `Container`
   --> $DIR/enum-negative-send-impl.rs:12:6
    |

--- a/tests/ui/traits/enum-negative-sync-impl.stderr
+++ b/tests/ui/traits/enum-negative-sync-impl.stderr
@@ -6,7 +6,11 @@ LL |     requires_sync(container);
    |     |
    |     required by a bound introduced by this call
    |
-   = help: within `Container`, the trait `Sync` is not implemented for `NoSync`
+help: within `Container`, the trait `Sync` is not implemented for `NoSync`
+  --> $DIR/enum-negative-sync-impl.rs:9:1
+   |
+LL | struct NoSync;
+   | ^^^^^^^^^^^^^
 note: required because it appears within the type `Container`
   --> $DIR/enum-negative-sync-impl.rs:12:6
    |

--- a/tests/ui/traits/issue-87558.stderr
+++ b/tests/ui/traits/issue-87558.stderr
@@ -38,7 +38,11 @@ error[E0277]: expected a `FnMut(&isize)` closure, found `Error`
 LL | impl Fn(&isize) for Error {
    |                     ^^^^^ expected an `FnMut(&isize)` closure, found `Error`
    |
-   = help: the trait `FnMut(&isize)` is not implemented for `Error`
+help: the trait `FnMut(&isize)` is not implemented for `Error`
+  --> $DIR/issue-87558.rs:2:1
+   |
+LL | struct Error(ErrorKind);
+   | ^^^^^^^^^^^^
 note: required by a bound in `Fn`
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
 

--- a/tests/ui/traits/issue-91594.stderr
+++ b/tests/ui/traits/issue-91594.stderr
@@ -2,8 +2,13 @@ error[E0277]: the trait bound `Foo: HasComponent<()>` is not satisfied
   --> $DIR/issue-91594.rs:10:19
    |
 LL | impl HasComponent<<Foo as Component<Foo>>::Interface> for Foo {}
-   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `HasComponent<()>` is not implemented for `Foo`
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
    |
+help: the trait `HasComponent<()>` is not implemented for `Foo`
+  --> $DIR/issue-91594.rs:8:1
+   |
+LL | struct Foo;
+   | ^^^^^^^^^^
    = help: the trait `HasComponent<<Foo as Component<Foo>>::Interface>` is implemented for `Foo`
 note: required for `Foo` to implement `Component<Foo>`
   --> $DIR/issue-91594.rs:13:27

--- a/tests/ui/traits/negative-bounds/on-unimplemented.stderr
+++ b/tests/ui/traits/negative-bounds/on-unimplemented.stderr
@@ -2,10 +2,16 @@ error[E0277]: the trait bound `NotFoo: !Foo` is not satisfied
   --> $DIR/on-unimplemented.rs:9:15
    |
 LL | fn hello() -> impl !Foo {
-   |               ^^^^^^^^^ the trait bound `NotFoo: !Foo` is not satisfied
+   |               ^^^^^^^^^ unsatisfied trait bound
 LL |
 LL |     NotFoo
    |     ------ return type was inferred to be `NotFoo` here
+   |
+help: the trait bound `NotFoo: !Foo` is not satisfied
+  --> $DIR/on-unimplemented.rs:7:1
+   |
+LL | struct NotFoo;
+   | ^^^^^^^^^^^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/traits/negative-bounds/simple.stderr
+++ b/tests/ui/traits/negative-bounds/simple.stderr
@@ -26,8 +26,13 @@ error[E0277]: the trait bound `Copyable: !Copy` is not satisfied
   --> $DIR/simple.rs:30:16
    |
 LL |     not_copy::<Copyable>();
-   |                ^^^^^^^^ the trait bound `Copyable: !Copy` is not satisfied
+   |                ^^^^^^^^ unsatisfied trait bound
    |
+help: the trait bound `Copyable: !Copy` is not satisfied
+  --> $DIR/simple.rs:27:1
+   |
+LL | struct Copyable;
+   | ^^^^^^^^^^^^^^^
 note: required by a bound in `not_copy`
   --> $DIR/simple.rs:3:16
    |
@@ -38,8 +43,13 @@ error[E0277]: the trait bound `NotNecessarilyCopyable: !Copy` is not satisfied
   --> $DIR/simple.rs:37:16
    |
 LL |     not_copy::<NotNecessarilyCopyable>();
-   |                ^^^^^^^^^^^^^^^^^^^^^^ the trait bound `NotNecessarilyCopyable: !Copy` is not satisfied
+   |                ^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
    |
+help: the trait bound `NotNecessarilyCopyable: !Copy` is not satisfied
+  --> $DIR/simple.rs:34:1
+   |
+LL | struct NotNecessarilyCopyable;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `not_copy`
   --> $DIR/simple.rs:3:16
    |

--- a/tests/ui/traits/negative-impls/negated-auto-traits-error.stderr
+++ b/tests/ui/traits/negative-impls/negated-auto-traits-error.stderr
@@ -6,7 +6,11 @@ LL |     Outer(TestType);
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `Send` is not implemented for `dummy::TestType`
+help: the trait `Send` is not implemented for `dummy::TestType`
+  --> $DIR/negated-auto-traits-error.rs:20:5
+   |
+LL |     struct TestType;
+   |     ^^^^^^^^^^^^^^^
 note: required by a bound in `Outer`
   --> $DIR/negated-auto-traits-error.rs:10:17
    |
@@ -19,7 +23,11 @@ error[E0277]: `dummy::TestType` cannot be sent between threads safely
 LL |     Outer(TestType);
    |     ^^^^^^^^^^^^^^^ `dummy::TestType` cannot be sent between threads safely
    |
-   = help: the trait `Send` is not implemented for `dummy::TestType`
+help: the trait `Send` is not implemented for `dummy::TestType`
+  --> $DIR/negated-auto-traits-error.rs:20:5
+   |
+LL |     struct TestType;
+   |     ^^^^^^^^^^^^^^^
 note: required by a bound in `Outer`
   --> $DIR/negated-auto-traits-error.rs:10:17
    |
@@ -34,7 +42,11 @@ LL |     is_send(TestType);
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `Send` is not implemented for `dummy1b::TestType`
+help: the trait `Send` is not implemented for `dummy1b::TestType`
+  --> $DIR/negated-auto-traits-error.rs:29:5
+   |
+LL |     struct TestType;
+   |     ^^^^^^^^^^^^^^^
 note: required by a bound in `is_send`
   --> $DIR/negated-auto-traits-error.rs:16:15
    |
@@ -49,7 +61,11 @@ LL |     is_send((8, TestType));
    |     |
    |     required by a bound introduced by this call
    |
-   = help: within `({integer}, dummy1c::TestType)`, the trait `Send` is not implemented for `dummy1c::TestType`
+help: within `({integer}, dummy1c::TestType)`, the trait `Send` is not implemented for `dummy1c::TestType`
+  --> $DIR/negated-auto-traits-error.rs:37:5
+   |
+LL |     struct TestType;
+   |     ^^^^^^^^^^^^^^^
    = note: required because it appears within the type `({integer}, dummy1c::TestType)`
 note: required by a bound in `is_send`
   --> $DIR/negated-auto-traits-error.rs:16:15
@@ -87,7 +103,11 @@ LL |     is_send(Box::new(Outer2(TestType)));
    |     |
    |     required by a bound introduced by this call
    |
-   = help: within `Outer2<dummy3::TestType>`, the trait `Send` is not implemented for `dummy3::TestType`
+help: within `Outer2<dummy3::TestType>`, the trait `Send` is not implemented for `dummy3::TestType`
+  --> $DIR/negated-auto-traits-error.rs:53:5
+   |
+LL |     struct TestType;
+   |     ^^^^^^^^^^^^^^^
 note: required because it appears within the type `Outer2<dummy3::TestType>`
   --> $DIR/negated-auto-traits-error.rs:12:8
    |
@@ -110,7 +130,11 @@ LL |     is_sync(Outer2(TestType));
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `Send` is not implemented for `main::TestType`
+help: the trait `Send` is not implemented for `main::TestType`
+  --> $DIR/negated-auto-traits-error.rs:61:5
+   |
+LL |     struct TestType;
+   |     ^^^^^^^^^^^^^^^
 note: required for `Outer2<main::TestType>` to implement `Sync`
   --> $DIR/negated-auto-traits-error.rs:14:22
    |

--- a/tests/ui/traits/next-solver/auto-with-drop_tracking_mir.fail.stderr
+++ b/tests/ui/traits/next-solver/auto-with-drop_tracking_mir.fail.stderr
@@ -4,7 +4,11 @@ error: future cannot be sent between threads safely
 LL |     is_send(foo());
    |             ^^^^^ future returned by `foo` is not `Send`
    |
-   = help: the trait `Sync` is not implemented for `NotSync`
+help: the trait `Sync` is not implemented for `NotSync`
+  --> $DIR/auto-with-drop_tracking_mir.rs:8:1
+   |
+LL | struct NotSync;
+   | ^^^^^^^^^^^^^^
 note: future is not `Send` as this value is used across an await
   --> $DIR/auto-with-drop_tracking_mir.rs:16:11
    |

--- a/tests/ui/traits/next-solver/cycles/coinduction/incompleteness-unstable-result.with.stderr
+++ b/tests/ui/traits/next-solver/cycles/coinduction/incompleteness-unstable-result.with.stderr
@@ -2,8 +2,13 @@ error[E0277]: the trait bound `A<X>: Trait<_, _, _>` is not satisfied
   --> $DIR/incompleteness-unstable-result.rs:66:19
    |
 LL |     impls_trait::<A<X>, _, _, _>();
-   |                   ^^^^ the trait `Trait<_, _, _>` is not implemented for `A<X>`
+   |                   ^^^^ unsatisfied trait bound
    |
+help: the trait `Trait<_, _, _>` is not implemented for `A<X>`
+  --> $DIR/incompleteness-unstable-result.rs:22:1
+   |
+LL | struct A<T>(*const T);
+   | ^^^^^^^^^^^
    = help: the trait `Trait<U, V, D>` is implemented for `A<T>`
 note: required for `A<X>` to implement `Trait<_, _, _>`
   --> $DIR/incompleteness-unstable-result.rs:34:18

--- a/tests/ui/traits/next-solver/cycles/coinduction/incompleteness-unstable-result.without.stderr
+++ b/tests/ui/traits/next-solver/cycles/coinduction/incompleteness-unstable-result.without.stderr
@@ -2,8 +2,13 @@ error[E0277]: the trait bound `A<X>: Trait<_, _, _>` is not satisfied
   --> $DIR/incompleteness-unstable-result.rs:66:19
    |
 LL |     impls_trait::<A<X>, _, _, _>();
-   |                   ^^^^ the trait `Trait<_, _, _>` is not implemented for `A<X>`
+   |                   ^^^^ unsatisfied trait bound
    |
+help: the trait `Trait<_, _, _>` is not implemented for `A<X>`
+  --> $DIR/incompleteness-unstable-result.rs:22:1
+   |
+LL | struct A<T>(*const T);
+   | ^^^^^^^^^^^
    = help: the trait `Trait<U, V, D>` is implemented for `A<T>`
 note: required for `A<X>` to implement `Trait<_, _, _>`
   --> $DIR/incompleteness-unstable-result.rs:34:18

--- a/tests/ui/traits/next-solver/cycles/inductive-cycle-but-err.stderr
+++ b/tests/ui/traits/next-solver/cycles/inductive-cycle-but-err.stderr
@@ -14,8 +14,13 @@ error[E0277]: the trait bound `MultipleCandidates: Trait` is not satisfied
   --> $DIR/inductive-cycle-but-err.rs:54:19
    |
 LL |     impls_trait::<MultipleCandidates>();
-   |                   ^^^^^^^^^^^^^^^^^^ the trait `Trait` is not implemented for `MultipleCandidates`
+   |                   ^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
    |
+help: the trait `Trait` is not implemented for `MultipleCandidates`
+  --> $DIR/inductive-cycle-but-err.rs:18:1
+   |
+LL | struct MultipleCandidates;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: the trait `Trait` is implemented for `MultipleCandidates`
 note: required by a bound in `impls_trait`
   --> $DIR/inductive-cycle-but-err.rs:51:19

--- a/tests/ui/traits/next-solver/cycles/normalizes-to-is-not-productive.stderr
+++ b/tests/ui/traits/next-solver/cycles/normalizes-to-is-not-productive.stderr
@@ -2,8 +2,13 @@ error[E0277]: the trait bound `Foo: Bound` is not satisfied
   --> $DIR/normalizes-to-is-not-productive.rs:42:31
    |
 LL |     <Foo as Trait<T>>::Assoc: Bound,
-   |                               ^^^^^ the trait `Bound` is not implemented for `Foo`
+   |                               ^^^^^ unsatisfied trait bound
    |
+help: the trait `Bound` is not implemented for `Foo`
+  --> $DIR/normalizes-to-is-not-productive.rs:18:1
+   |
+LL | struct Foo;
+   | ^^^^^^^^^^
    = help: the trait `Bound` is implemented for `u32`
 note: required for `Foo` to implement `Trait<T>`
   --> $DIR/normalizes-to-is-not-productive.rs:23:19
@@ -17,8 +22,13 @@ error[E0277]: the trait bound `Foo: Bound` is not satisfied
   --> $DIR/normalizes-to-is-not-productive.rs:47:19
    |
 LL |     impls_bound::<Foo>();
-   |                   ^^^ the trait `Bound` is not implemented for `Foo`
+   |                   ^^^ unsatisfied trait bound
    |
+help: the trait `Bound` is not implemented for `Foo`
+  --> $DIR/normalizes-to-is-not-productive.rs:18:1
+   |
+LL | struct Foo;
+   | ^^^^^^^^^^
    = help: the trait `Bound` is implemented for `u32`
 note: required by a bound in `impls_bound`
   --> $DIR/normalizes-to-is-not-productive.rs:27:19

--- a/tests/ui/traits/next-solver/diagnostics/dont-pick-fnptr-bound-as-leaf.current.stderr
+++ b/tests/ui/traits/next-solver/diagnostics/dont-pick-fnptr-bound-as-leaf.current.stderr
@@ -2,10 +2,15 @@ error[E0277]: the trait bound `Foo: Trait` is not satisfied
   --> $DIR/dont-pick-fnptr-bound-as-leaf.rs:24:20
    |
 LL |     requires_trait(Foo);
-   |     -------------- ^^^ the trait `Trait` is not implemented for `Foo`
+   |     -------------- ^^^ unsatisfied trait bound
    |     |
    |     required by a bound introduced by this call
    |
+help: the trait `Trait` is not implemented for `Foo`
+  --> $DIR/dont-pick-fnptr-bound-as-leaf.rs:17:1
+   |
+LL | struct Foo;
+   | ^^^^^^^^^^
 note: required by a bound in `requires_trait`
   --> $DIR/dont-pick-fnptr-bound-as-leaf.rs:19:22
    |

--- a/tests/ui/traits/next-solver/diagnostics/dont-pick-fnptr-bound-as-leaf.next.stderr
+++ b/tests/ui/traits/next-solver/diagnostics/dont-pick-fnptr-bound-as-leaf.next.stderr
@@ -2,10 +2,15 @@ error[E0277]: the trait bound `Foo: Trait` is not satisfied
   --> $DIR/dont-pick-fnptr-bound-as-leaf.rs:24:20
    |
 LL |     requires_trait(Foo);
-   |     -------------- ^^^ the trait `Trait` is not implemented for `Foo`
+   |     -------------- ^^^ unsatisfied trait bound
    |     |
    |     required by a bound introduced by this call
    |
+help: the trait `Trait` is not implemented for `Foo`
+  --> $DIR/dont-pick-fnptr-bound-as-leaf.rs:17:1
+   |
+LL | struct Foo;
+   | ^^^^^^^^^^
 note: required by a bound in `requires_trait`
   --> $DIR/dont-pick-fnptr-bound-as-leaf.rs:19:22
    |

--- a/tests/ui/traits/next-solver/diagnostics/dont-pick-fnptr-bound-as-leaf.rs
+++ b/tests/ui/traits/next-solver/diagnostics/dont-pick-fnptr-bound-as-leaf.rs
@@ -14,7 +14,7 @@ trait Trait {}
 
 impl<T: FnPtr> Trait for T {}
 
-struct Foo;
+struct Foo; //~ HELP: the trait `Trait` is not implemented for `Foo`
 
 fn requires_trait<T: Trait>(_: T) {}
 //~^ NOTE: required by a bound in `requires_trait`
@@ -23,6 +23,6 @@ fn requires_trait<T: Trait>(_: T) {}
 fn main() {
     requires_trait(Foo);
     //~^ ERROR: the trait bound `Foo: Trait` is not satisfied
-    //~| NOTE: the trait `Trait` is not implemented for `Foo`
+    //~| NOTE: unsatisfied trait bound
     //~| NOTE: required by a bound introduced by this call
 }

--- a/tests/ui/traits/no_send-struct.stderr
+++ b/tests/ui/traits/no_send-struct.stderr
@@ -6,7 +6,11 @@ LL |     bar(x);
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `Send` is not implemented for `Foo`
+help: the trait `Send` is not implemented for `Foo`
+  --> $DIR/no_send-struct.rs:5:1
+   |
+LL | struct Foo {
+   | ^^^^^^^^^^
 note: required by a bound in `bar`
   --> $DIR/no_send-struct.rs:11:11
    |

--- a/tests/ui/traits/struct-negative-sync-impl.stderr
+++ b/tests/ui/traits/struct-negative-sync-impl.stderr
@@ -6,7 +6,11 @@ LL |     requires_sync(not_sync);
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `Sync` is not implemented for `NotSync`
+help: the trait `Sync` is not implemented for `NotSync`
+  --> $DIR/struct-negative-sync-impl.rs:9:1
+   |
+LL | struct NotSync {
+   | ^^^^^^^^^^^^^^
 note: required by a bound in `requires_sync`
   --> $DIR/struct-negative-sync-impl.rs:15:21
    |

--- a/tests/ui/traits/suggest-dereferences/deref-argument.stderr
+++ b/tests/ui/traits/suggest-dereferences/deref-argument.stderr
@@ -2,10 +2,15 @@ error[E0277]: the trait bound `MyRef: Test` is not satisfied
   --> $DIR/deref-argument.rs:29:18
    |
 LL |     consume_test(my_ref);
-   |     ------------ ^^^^^^ the trait `Test` is not implemented for `MyRef`
+   |     ------------ ^^^^^^ unsatisfied trait bound
    |     |
    |     required by a bound introduced by this call
    |
+help: the trait `Test` is not implemented for `MyRef`
+  --> $DIR/deref-argument.rs:14:1
+   |
+LL | struct MyRef(u32);
+   | ^^^^^^^^^^^^
 note: required by a bound in `consume_test`
   --> $DIR/deref-argument.rs:9:25
    |

--- a/tests/ui/traits/suggest-dereferences/issue-39029.stderr
+++ b/tests/ui/traits/suggest-dereferences/issue-39029.stderr
@@ -2,10 +2,15 @@ error[E0277]: the trait bound `NoToSocketAddrs: ToSocketAddrs` is not satisfied
   --> $DIR/issue-39029.rs:16:38
    |
 LL |     let _errors = TcpListener::bind(&bad);
-   |                   -----------------  ^^^ the trait `ToSocketAddrs` is not implemented for `NoToSocketAddrs`
+   |                   -----------------  ^^^ unsatisfied trait bound
    |                   |
    |                   required by a bound introduced by this call
    |
+help: the trait `ToSocketAddrs` is not implemented for `NoToSocketAddrs`
+  --> $DIR/issue-39029.rs:4:1
+   |
+LL | struct NoToSocketAddrs(String);
+   | ^^^^^^^^^^^^^^^^^^^^^^
    = note: required for `&NoToSocketAddrs` to implement `ToSocketAddrs`
 note: required by a bound in `TcpListener::bind`
   --> $SRC_DIR/std/src/net/tcp.rs:LL:COL

--- a/tests/ui/traits/suggest-dereferences/suggest-dereferencing-receiver-argument.stderr
+++ b/tests/ui/traits/suggest-dereferences/suggest-dereferencing-receiver-argument.stderr
@@ -2,8 +2,13 @@ error[E0277]: the trait bound `TargetStruct: From<&{integer}>` is not satisfied
   --> $DIR/suggest-dereferencing-receiver-argument.rs:13:30
    |
 LL |     let _b: TargetStruct = a.into();
-   |                              ^^^^ the trait `From<&{integer}>` is not implemented for `TargetStruct`
+   |                              ^^^^ unsatisfied trait bound
    |
+help: the trait `From<&{integer}>` is not implemented for `TargetStruct`
+  --> $DIR/suggest-dereferencing-receiver-argument.rs:3:1
+   |
+LL | struct TargetStruct;
+   | ^^^^^^^^^^^^^^^^^^^
    = note: required for `&{integer}` to implement `Into<TargetStruct>`
 help: consider dereferencing here
    |

--- a/tests/ui/traits/suggest-where-clause.stderr
+++ b/tests/ui/traits/suggest-where-clause.stderr
@@ -63,7 +63,13 @@ error[E0277]: the trait bound `Misc<_>: From<T>` is not satisfied
   --> $DIR/suggest-where-clause.rs:23:6
    |
 LL |     <Misc<_> as From<T>>::from;
-   |      ^^^^^^^ the trait `From<T>` is not implemented for `Misc<_>`
+   |      ^^^^^^^ unsatisfied trait bound
+   |
+help: the trait `From<T>` is not implemented for `Misc<_>`
+  --> $DIR/suggest-where-clause.rs:3:1
+   |
+LL | struct Misc<T:?Sized>(T);
+   | ^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the size for values of type `[T]` cannot be known at compilation time
   --> $DIR/suggest-where-clause.rs:28:20

--- a/tests/ui/tuple/builtin-fail.stderr
+++ b/tests/ui/tuple/builtin-fail.stderr
@@ -42,8 +42,13 @@ error[E0277]: `TupleStruct` is not a tuple
   --> $DIR/builtin-fail.rs:17:23
    |
 LL |     assert_is_tuple::<TupleStruct>();
-   |                       ^^^^^^^^^^^ the trait `Tuple` is not implemented for `TupleStruct`
+   |                       ^^^^^^^^^^^ unsatisfied trait bound
    |
+help: the trait `Tuple` is not implemented for `TupleStruct`
+  --> $DIR/builtin-fail.rs:5:1
+   |
+LL | struct TupleStruct(i32, i32);
+   | ^^^^^^^^^^^^^^^^^^
 note: required by a bound in `assert_is_tuple`
   --> $DIR/builtin-fail.rs:3:23
    |

--- a/tests/ui/type-alias-impl-trait/constrain_in_projection.current.stderr
+++ b/tests/ui/type-alias-impl-trait/constrain_in_projection.current.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `Foo: Trait<Bar>` is not satisfied
   --> $DIR/constrain_in_projection.rs:25:14
    |
 LL |     let x = <Foo as Trait<Bar>>::Assoc::default();
-   |              ^^^ the trait `Trait<Bar>` is not implemented for `Foo`
+   |              ^^^ unsatisfied trait bound
    |
    = help: the trait `Trait<Bar>` is not implemented for `Foo`
            but trait `Trait<()>` is implemented for it
@@ -11,7 +11,7 @@ error[E0277]: the trait bound `Foo: Trait<Bar>` is not satisfied
   --> $DIR/constrain_in_projection.rs:25:13
    |
 LL |     let x = <Foo as Trait<Bar>>::Assoc::default();
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Trait<Bar>` is not implemented for `Foo`
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
    |
    = help: the trait `Trait<Bar>` is not implemented for `Foo`
            but trait `Trait<()>` is implemented for it

--- a/tests/ui/type-alias-impl-trait/constrain_in_projection2.current.stderr
+++ b/tests/ui/type-alias-impl-trait/constrain_in_projection2.current.stderr
@@ -2,8 +2,13 @@ error[E0277]: the trait bound `Foo: Trait<Bar>` is not satisfied
   --> $DIR/constrain_in_projection2.rs:28:14
    |
 LL |     let x = <Foo as Trait<Bar>>::Assoc::default();
-   |              ^^^ the trait `Trait<Bar>` is not implemented for `Foo`
+   |              ^^^ unsatisfied trait bound
    |
+help: the trait `Trait<Bar>` is not implemented for `Foo`
+  --> $DIR/constrain_in_projection2.rs:10:1
+   |
+LL | struct Foo;
+   | ^^^^^^^^^^
    = help: the following other types implement trait `Trait<T>`:
              `Foo` implements `Trait<()>`
              `Foo` implements `Trait<u32>`
@@ -12,8 +17,13 @@ error[E0277]: the trait bound `Foo: Trait<Bar>` is not satisfied
   --> $DIR/constrain_in_projection2.rs:28:13
    |
 LL |     let x = <Foo as Trait<Bar>>::Assoc::default();
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Trait<Bar>` is not implemented for `Foo`
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
    |
+help: the trait `Trait<Bar>` is not implemented for `Foo`
+  --> $DIR/constrain_in_projection2.rs:10:1
+   |
+LL | struct Foo;
+   | ^^^^^^^^^^
    = help: the following other types implement trait `Trait<T>`:
              `Foo` implements `Trait<()>`
              `Foo` implements `Trait<u32>`

--- a/tests/ui/typeck/typeck-default-trait-impl-negation-send.stderr
+++ b/tests/ui/typeck/typeck-default-trait-impl-negation-send.stderr
@@ -4,7 +4,11 @@ error[E0277]: `MyNotSendable` cannot be sent between threads safely
 LL |     is_send::<MyNotSendable>();
    |               ^^^^^^^^^^^^^ `MyNotSendable` cannot be sent between threads safely
    |
-   = help: the trait `Send` is not implemented for `MyNotSendable`
+help: the trait `Send` is not implemented for `MyNotSendable`
+  --> $DIR/typeck-default-trait-impl-negation-send.rs:9:1
+   |
+LL | struct MyNotSendable {
+   | ^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `is_send`
   --> $DIR/typeck-default-trait-impl-negation-send.rs:15:15
    |

--- a/tests/ui/typeck/typeck-default-trait-impl-negation-sync.stderr
+++ b/tests/ui/typeck/typeck-default-trait-impl-negation-sync.stderr
@@ -4,7 +4,11 @@ error[E0277]: `MyNotSync` cannot be shared between threads safely
 LL |     is_sync::<MyNotSync>();
    |               ^^^^^^^^^ `MyNotSync` cannot be shared between threads safely
    |
-   = help: the trait `Sync` is not implemented for `MyNotSync`
+help: the trait `Sync` is not implemented for `MyNotSync`
+  --> $DIR/typeck-default-trait-impl-negation-sync.rs:15:1
+   |
+LL | struct MyNotSync {
+   | ^^^^^^^^^^^^^^^^
 note: required by a bound in `is_sync`
   --> $DIR/typeck-default-trait-impl-negation-sync.rs:29:15
    |
@@ -35,7 +39,11 @@ error[E0277]: `Managed` cannot be shared between threads safely
 LL |     is_sync::<MyTypeManaged>();
    |               ^^^^^^^^^^^^^ `Managed` cannot be shared between threads safely
    |
-   = help: within `MyTypeManaged`, the trait `Sync` is not implemented for `Managed`
+help: within `MyTypeManaged`, the trait `Sync` is not implemented for `Managed`
+  --> $DIR/typeck-default-trait-impl-negation-sync.rs:3:1
+   |
+LL | struct Managed;
+   | ^^^^^^^^^^^^^^
 note: required because it appears within the type `MyTypeManaged`
   --> $DIR/typeck-default-trait-impl-negation-sync.rs:25:8
    |

--- a/tests/ui/typeck/typeck-unsafe-always-share.stderr
+++ b/tests/ui/typeck/typeck-unsafe-always-share.stderr
@@ -56,7 +56,11 @@ LL |     test(NoSync);
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `Sync` is not implemented for `NoSync`
+help: the trait `Sync` is not implemented for `NoSync`
+  --> $DIR/typeck-unsafe-always-share.rs:12:1
+   |
+LL | struct NoSync;
+   | ^^^^^^^^^^^^^
 note: required by a bound in `test`
   --> $DIR/typeck-unsafe-always-share.rs:15:12
    |

--- a/tests/ui/unboxed-closures/unboxed-closures-fnmut-as-fn.stderr
+++ b/tests/ui/unboxed-closures/unboxed-closures-fnmut-as-fn.stderr
@@ -6,7 +6,11 @@ LL |     let x = call_it(&S, 22);
    |             |
    |             required by a bound introduced by this call
    |
-   = help: the trait `Fn(isize)` is not implemented for `S`
+help: the trait `Fn(isize)` is not implemented for `S`
+  --> $DIR/unboxed-closures-fnmut-as-fn.rs:8:1
+   |
+LL | struct S;
+   | ^^^^^^^^
    = note: `S` implements `FnMut`, but it must implement `Fn`, which is more general
 note: required by a bound in `call_it`
   --> $DIR/unboxed-closures-fnmut-as-fn.rs:22:14

--- a/tests/ui/unsafe-fields/auto-traits.current.stderr
+++ b/tests/ui/unsafe-fields/auto-traits.current.stderr
@@ -2,10 +2,15 @@ error[E0277]: the trait bound `UnsafeEnum: UnsafeAuto` is not satisfied
   --> $DIR/auto-traits.rs:24:22
    |
 LL |     impl_unsafe_auto(UnsafeEnum::Safe(42));
-   |     ---------------- ^^^^^^^^^^^^^^^^^^^^ the trait `UnsafeAuto` is not implemented for `UnsafeEnum`
+   |     ---------------- ^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
    |     |
    |     required by a bound introduced by this call
    |
+help: the trait `UnsafeAuto` is not implemented for `UnsafeEnum`
+  --> $DIR/auto-traits.rs:9:1
+   |
+LL | enum UnsafeEnum {
+   | ^^^^^^^^^^^^^^^
 note: required by a bound in `impl_unsafe_auto`
   --> $DIR/auto-traits.rs:20:29
    |

--- a/tests/ui/unsafe-fields/auto-traits.next.stderr
+++ b/tests/ui/unsafe-fields/auto-traits.next.stderr
@@ -2,10 +2,15 @@ error[E0277]: the trait bound `UnsafeEnum: UnsafeAuto` is not satisfied
   --> $DIR/auto-traits.rs:24:22
    |
 LL |     impl_unsafe_auto(UnsafeEnum::Safe(42));
-   |     ---------------- ^^^^^^^^^^^^^^^^^^^^ the trait `UnsafeAuto` is not implemented for `UnsafeEnum`
+   |     ---------------- ^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
    |     |
    |     required by a bound introduced by this call
    |
+help: the trait `UnsafeAuto` is not implemented for `UnsafeEnum`
+  --> $DIR/auto-traits.rs:9:1
+   |
+LL | enum UnsafeEnum {
+   | ^^^^^^^^^^^^^^^
 note: required by a bound in `impl_unsafe_auto`
   --> $DIR/auto-traits.rs:20:29
    |

--- a/tests/ui/unsized/issue-75707.stderr
+++ b/tests/ui/unsized/issue-75707.stderr
@@ -2,8 +2,13 @@ error[E0277]: the trait bound `MyCall: Callback` is not satisfied
   --> $DIR/issue-75707.rs:15:9
    |
 LL |     f::<dyn Processing<Call = MyCall>>();
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Callback` is not implemented for `MyCall`
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
    |
+help: the trait `Callback` is not implemented for `MyCall`
+  --> $DIR/issue-75707.rs:14:5
+   |
+LL |     struct MyCall;
+   |     ^^^^^^^^^^^^^
 help: this trait has no implementations, consider adding one
   --> $DIR/issue-75707.rs:1:1
    |

--- a/tests/ui/wf/hir-wf-canonicalized.stderr
+++ b/tests/ui/wf/hir-wf-canonicalized.stderr
@@ -2,8 +2,13 @@ error[E0277]: the trait bound `Bar<'a, T>: Foo` is not satisfied
   --> $DIR/hir-wf-canonicalized.rs:10:15
    |
 LL |     callback: Box<dyn Callback<dyn Callback<Bar<'a, T>>>>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Foo` is not implemented for `Bar<'a, T>`
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
    |
+help: the trait `Foo` is not implemented for `Bar<'a, T>`
+  --> $DIR/hir-wf-canonicalized.rs:9:1
+   |
+LL | struct Bar<'a, T> {
+   | ^^^^^^^^^^^^^^^^^
 help: this trait has no implementations, consider adding one
   --> $DIR/hir-wf-canonicalized.rs:3:1
    |

--- a/tests/ui/wf/wf-packed-on-proj-of-type-as-unimpl-trait.stderr
+++ b/tests/ui/wf/wf-packed-on-proj-of-type-as-unimpl-trait.stderr
@@ -2,8 +2,13 @@ error[E0277]: the trait bound `DefaultAllocator: Allocator` is not satisfied
   --> $DIR/wf-packed-on-proj-of-type-as-unimpl-trait.rs:28:12
    |
 LL | struct Foo(Matrix<<DefaultAllocator as Allocator>::Buffer>);
-   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Allocator` is not implemented for `DefaultAllocator`
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
    |
+help: the trait `Allocator` is not implemented for `DefaultAllocator`
+  --> $DIR/wf-packed-on-proj-of-type-as-unimpl-trait.rs:21:1
+   |
+LL | pub struct DefaultAllocator;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: this trait has no implementations, consider adding one
   --> $DIR/wf-packed-on-proj-of-type-as-unimpl-trait.rs:23:1
    |

--- a/tests/ui/where-clauses/where-clause-method-substituion.stderr
+++ b/tests/ui/where-clauses/where-clause-method-substituion.stderr
@@ -2,8 +2,13 @@ error[E0277]: the trait bound `X: Foo<X>` is not satisfied
   --> $DIR/where-clause-method-substituion.rs:20:16
    |
 LL |     1.method::<X>();
-   |                ^ the trait `Foo<X>` is not implemented for `X`
+   |                ^ unsatisfied trait bound
    |
+help: the trait `Foo<X>` is not implemented for `X`
+  --> $DIR/where-clause-method-substituion.rs:10:1
+   |
+LL | struct X;
+   | ^^^^^^^^
 help: this trait has no implementations, consider adding one
   --> $DIR/where-clause-method-substituion.rs:1:1
    |


### PR DESCRIPTION
When encountering an unmet trait bound, point at local type that doesn't implement the trait:

```
error[E0277]: the trait bound `Bar<T>: Foo` is not satisfied
  --> $DIR/issue-64855.rs:9:19
   |
LL | pub struct Bar<T>(<Self as Foo>::Type) where Self: ;
   |                   ^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
   |
help: the trait `Foo` is not implemented for `Bar<T>`
  --> $DIR/issue-64855.rs:9:1
   |
LL | pub struct Bar<T>(<Self as Foo>::Type) where Self: ;
   | ^^^^^^^^^^^^^^^^^
```

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
