### PR TITLE
Stabilize `std::panic::Location::file_as_c_str`

### DIFF
--- a/library/core/src/panic/location.rs
+++ b/library/core/src/panic/location.rs
@@ -193,8 +193,9 @@ impl<'a> Location<'a> {
     /// This is useful for interop with APIs that expect C/C++ `__FILE__` or
     /// `std::source_location::file_name`, both of which return a nul-terminated `const char*`.
     #[must_use]
-    #[unstable(feature = "file_with_nul", issue = "141727")]
     #[inline]
+    #[stable(feature = "file_with_nul", since = "CURRENT_RUSTC_VERSION")]
+    #[rustc_const_stable(feature = "file_with_nul", since = "CURRENT_RUSTC_VERSION")]
     pub const fn file_as_c_str(&self) -> &'a CStr {
         let filename = self.filename.as_ptr();
 

--- a/tests/ui/rfcs/rfc-2091-track-caller/file-is-nul-terminated.rs
+++ b/tests/ui/rfcs/rfc-2091-track-caller/file-is-nul-terminated.rs
@@ -1,5 +1,4 @@
 //@ run-pass
-#![feature(file_with_nul)]
 
 #[track_caller]
 const fn assert_file_has_trailing_zero() {


### PR DESCRIPTION
Closes: rust-lang/rust#141727

Nominating this for T-lang as per @traviscross  https://github.com/rust-lang/rust/issues/141727#issuecomment-3201318429