### PR TITLE
rustdoc-search: GUI tests check for `//` in URL

### DIFF
--- a/tests/rustdoc-gui/utils.goml
+++ b/tests/rustdoc-gui/utils.goml
@@ -39,6 +39,13 @@ define-function: (
     "perform-search",
     [query],
     block {
+        // Block requests with doubled `//`.
+        // Amazon S3 doesn't support them, but other web hosts do,
+        // and so do file:/// URLs, which means we need to block
+        // it here if we want to avoid breaking the main docs site.
+        // https://github.com/rust-lang/rust/issues/145646
+        block-network-request: "file://*//*"
+        // Perform search
         click: "#search-button"
         wait-for: ".search-input"
         write-into: (".search-input", |query|)


### PR DESCRIPTION
Follow up https://github.com/rust-lang/rust/pull/145650

When this fails, you get output that looks like:

    /home/user/rust/tests/rustdoc-gui/search-result-impl-disambiguation.goml search-result-impl-disambiguation... FAILED
    [ERROR] `tests/rustdoc-gui/utils.goml` around line 49
        from `tests/rustdoc-gui/search-result-impl-disambiguation.goml` line 25: JS errors occurred: Event: Event

Making the error message more informative requires patching browser-ui-test.