### PR TITLE
Instantiate higher-ranked binder with erased when checking `IntoIterator` predicate for query instability

### DIFF
--- a/tests/ui/lint/internal/higher-ranked-query-instability.rs
+++ b/tests/ui/lint/internal/higher-ranked-query-instability.rs
@@ -1,0 +1,11 @@
+//@ check-pass
+//@ compile-flags: -Zunstable-options
+
+// Make sure we don't try to resolve instances for trait refs that have escaping
+// bound vars when computing the query instability lint.
+
+fn foo<T>() where for<'a> &'a [T]: IntoIterator<Item = &'a T> {}
+
+fn main() {
+    foo::<()>();
+}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/145652 which was introduced by https://github.com/rust-lang/rust/pull/139345 because we were skipping a binder before calling `Instance::try_resolve`.

r? lcnr