### PR TITLE
docs: fix typo

### DIFF
--- a/src/doc/rustc-dev-guide/src/solve/candidate-preference.md
+++ b/src/doc/rustc-dev-guide/src/solve/candidate-preference.md
@@ -95,7 +95,7 @@ fn overflow<T: Trait>() {
 ```
 
 This preference causes a lot of issues. See [#24066]. Most of the
-issues are caused by prefering where-bounds over impls even if the where-bound guides type inference:
+issues are caused by preferring where-bounds over impls even if the where-bound guides type inference:
 ```rust
 trait Trait<T> {
     fn call_me(&self, x: T) {}

--- a/tests/run-make/link-under-xcode/rmake.rs
+++ b/tests/run-make/link-under-xcode/rmake.rs
@@ -17,7 +17,7 @@ fn main() {
 
     // Check that compiling and linking still works.
     //
-    // Removing `SDKROOT` is necessary for the test to excercise what we want, since bootstrap runs
+    // Removing `SDKROOT` is necessary for the test to exercise what we want, since bootstrap runs
     // under `/usr/bin/python3`, which will set SDKROOT for us.
     rustc().target(target()).env_remove("SDKROOT").env("PATH", &path).input("foo.rs").run();
 

--- a/tests/ui/README.md
+++ b/tests/ui/README.md
@@ -953,7 +953,7 @@ This directory is a small tree of `mod` dependencies, but the root, `foo.rs`, is
 
 Tests for checking missing trait bounds, and their diagnostics.
 
-**FIMXE**: Maybe a subdirectory of `ui/trait-bounds` would be more appropriate.
+**FIXME**: Maybe a subdirectory of `ui/trait-bounds` would be more appropriate.
 
 ## `tests/ui/modules/`
 


### PR DESCRIPTION
`prefering` to `preferring`
`excercise` to `exercise`
`FIMXE` to `FIXME`