### PR TITLE
Don't evaluate the sanitizer attribute if no sanitizer is enabled

### DIFF
--- a/compiler/rustc_codegen_ssa/src/codegen_attrs.rs
+++ b/compiler/rustc_codegen_ssa/src/codegen_attrs.rs
@@ -630,6 +630,11 @@ fn parse_sanitize_attr(
 }
 
 fn disabled_sanitizers_for(tcx: TyCtxt<'_>, did: LocalDefId) -> SanitizerSet {
+    // No need to evaluate the sanitizer attribute if no sanitizer is enabled.
+    if tcx.sess.opts.unstable_opts.sanitizer.is_empty() {
+        return SanitizerSet::empty();
+    }
+
     // Backtrack to the crate root.
     let disabled = match tcx.opt_local_parent(did) {
         // Check the parent (recursively).


### PR DESCRIPTION
This is just logical as the attribute has anyways no effect in that case.

This is in reaction to some perf-metrics going up after rust-lang/rust#142681, specifically mentioned here: https://github.com/rust-lang/rust/pull/142681#issuecomment-3203951137.

r? rcvalle