### PR TITLE
[DRAFT] Add ub_checks for downcast_unchecked

### DIFF
--- a/library/alloc/src/boxed/convert.rs
+++ b/library/alloc/src/boxed/convert.rs
@@ -392,7 +392,9 @@ impl<A: Allocator> Box<dyn Any, A> {
     #[inline]
     #[unstable(feature = "downcast_unchecked", issue = "90850")]
     pub unsafe fn downcast_unchecked<T: Any>(self) -> Box<T, A> {
-        debug_assert!(self.is::<T>());
+        if core::ub_checks::check_library_ub() {
+            assert!(self.is::<T>());
+        }
         unsafe {
             let (raw, alloc): (*mut dyn Any, _) = Box::into_raw_with_allocator(self);
             Box::from_raw_in(raw as *mut T, alloc)
@@ -451,7 +453,9 @@ impl<A: Allocator> Box<dyn Any + Send, A> {
     #[inline]
     #[unstable(feature = "downcast_unchecked", issue = "90850")]
     pub unsafe fn downcast_unchecked<T: Any>(self) -> Box<T, A> {
-        debug_assert!(self.is::<T>());
+        if core::ub_checks::check_library_ub() {
+            assert!(self.is::<T>());
+        }
         unsafe {
             let (raw, alloc): (*mut (dyn Any + Send), _) = Box::into_raw_with_allocator(self);
             Box::from_raw_in(raw as *mut T, alloc)
@@ -510,7 +514,9 @@ impl<A: Allocator> Box<dyn Any + Send + Sync, A> {
     #[inline]
     #[unstable(feature = "downcast_unchecked", issue = "90850")]
     pub unsafe fn downcast_unchecked<T: Any>(self) -> Box<T, A> {
-        debug_assert!(self.is::<T>());
+        if core::ub_checks::check_library_ub() {
+            assert!(self.is::<T>());
+        }
         unsafe {
             let (raw, alloc): (*mut (dyn Any + Send + Sync), _) =
                 Box::into_raw_with_allocator(self);

--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -2042,6 +2042,9 @@ impl<A: Allocator> Rc<dyn Any, A> {
     #[inline]
     #[unstable(feature = "downcast_unchecked", issue = "90850")]
     pub unsafe fn downcast_unchecked<T: Any>(self) -> Rc<T, A> {
+        if core::ub_checks::check_library_ub() {
+            assert!((*self).is::<T>());
+        }
         unsafe {
             let (ptr, alloc) = Rc::into_inner_with_allocator(self);
             Rc::from_inner_in(ptr.cast(), alloc)

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -2754,6 +2754,9 @@ impl<A: Allocator> Arc<dyn Any + Send + Sync, A> {
     where
         T: Any + Send + Sync,
     {
+        if core::ub_checks::check_library_ub() {
+            assert!((*self).is::<T>());
+        }
         unsafe {
             let (ptr, alloc) = Arc::into_inner_with_allocator(self);
             Arc::from_inner_in(ptr.cast(), alloc)

--- a/library/core/src/any.rs
+++ b/library/core/src/any.rs
@@ -292,7 +292,9 @@ impl dyn Any {
     #[unstable(feature = "downcast_unchecked", issue = "90850")]
     #[inline]
     pub unsafe fn downcast_ref_unchecked<T: Any>(&self) -> &T {
-        debug_assert!(self.is::<T>());
+        if core::ub_checks::check_library_ub() {
+            assert!(self.is::<T>());
+        }
         // SAFETY: caller guarantees that T is the correct type
         unsafe { &*(self as *const dyn Any as *const T) }
     }
@@ -322,7 +324,9 @@ impl dyn Any {
     #[unstable(feature = "downcast_unchecked", issue = "90850")]
     #[inline]
     pub unsafe fn downcast_mut_unchecked<T: Any>(&mut self) -> &mut T {
-        debug_assert!(self.is::<T>());
+        if core::ub_checks::check_library_ub() {
+            assert!(self.is::<T>());
+        }
         // SAFETY: caller guarantees that T is the correct type
         unsafe { &mut *(self as *mut dyn Any as *mut T) }
     }


### PR DESCRIPTION
Right now `debug_assert!` is used, which will not trigger in user code.

This is likely unacceptable for performance reasons, since the optimizer cannot understand virtual `Any::type_id()` calls.

This could potentially be fixed by applying something like `#[ffi_const]` to the `Any::type_id` function (issue rust-lang/rust#58328), which would have wider reaching performance benefits. Unfortunately, `#[ffi_const]` is not possible right now because it is limited to FFI calls (as its name suggests).

Ignoring the performance issue, I wasn't quite sure how to implement the actual assertion. It cannot use the `assert_unsafe_precondition!` macro because that requires the assertion to work in a `const` context. The closest thing I could find in the stdlib seems to be `debug_assert_fd_is_open`, which uses `rtabort!`

https://github.com/rust-lang/rust/blob/040a98af70f0a7da03f3d5356531b28a2a7a77e4/library/std/src/sys/fs/unix.rs#L848-L853

However, use of `rtabort!` requires `std`. The current choice of `assert!` has the possibility of triggering unwinding, which is inconsistent with the behavior of the other UB checks. Another possibility would be to outline the check into a helper function annotated with `#[rustc_nounwind]`

I have verified the old assertion doesn't trigger in user code, but I have not tested this PR because it is a very early draft and I don't have much rust compiler experience.
 
Cross Reference rust-lang/rust#90850 and rust-lang/rust#123499


