### PR TITLE
Migrate `panic_unwind` to use `cfg_select!`

### DIFF
--- a/library/Cargo.lock
+++ b/library/Cargo.lock
@@ -192,7 +192,6 @@ name = "panic_unwind"
 version = "0.0.0"
 dependencies = [
  "alloc",
- "cfg-if",
  "libc",
  "rustc-std-workspace-core",
  "unwind",

--- a/library/panic_unwind/Cargo.toml
+++ b/library/panic_unwind/Cargo.toml
@@ -13,7 +13,6 @@ doc = false
 
 [dependencies]
 alloc = { path = "../alloc" }
-cfg-if = { version = "1.0", features = ['rustc-dep-of-std'] }
 core = { path = "../rustc-std-workspace-core", package = "rustc-std-workspace-core" }
 unwind = { path = "../unwind" }
 

--- a/library/panic_unwind/src/lib.rs
+++ b/library/panic_unwind/src/lib.rs
@@ -15,6 +15,7 @@
 #![unstable(feature = "panic_unwind", issue = "32837")]
 #![doc(issue_tracker_base_url = "https://github.com/rust-lang/rust/issues/")]
 #![feature(cfg_emscripten_wasm_eh)]
+#![feature(cfg_select)]
 #![feature(core_intrinsics)]
 #![feature(lang_items)]
 #![feature(panic_unwind)]
@@ -33,18 +34,21 @@ use alloc::boxed::Box;
 use core::any::Any;
 use core::panic::PanicPayload;
 
-cfg_if::cfg_if! {
-    if #[cfg(all(target_os = "emscripten", not(emscripten_wasm_eh)))] {
+cfg_select! {
+    all(target_os = "emscripten", not(emscripten_wasm_eh)) => {
         #[path = "emcc.rs"]
         mod imp;
-    } else if #[cfg(target_os = "hermit")] {
+    }
+    target_os = "hermit" => {
         #[path = "hermit.rs"]
         mod imp;
-    } else if #[cfg(target_os = "l4re")] {
+    }
+    target_os = "l4re" => {
         // L4Re is unix family but does not yet support unwinding.
         #[path = "dummy.rs"]
         mod imp;
-    } else if #[cfg(any(
+    }
+    any(
         all(target_family = "windows", target_env = "gnu"),
         target_os = "psp",
         target_os = "xous",
@@ -52,19 +56,22 @@ cfg_if::cfg_if! {
         all(target_family = "unix", not(any(target_os = "espidf", target_os = "nuttx"))),
         all(target_vendor = "fortanix", target_env = "sgx"),
         target_family = "wasm",
-    ))] {
+    ) => {
         #[path = "gcc.rs"]
         mod imp;
-    } else if #[cfg(miri)] {
+    }
+    miri => {
         // Use the Miri runtime on Windows as miri doesn't support funclet based unwinding,
         // only landingpad based unwinding. Also use the Miri runtime on unsupported platforms.
         #[path = "miri.rs"]
         mod imp;
-    } else if #[cfg(all(target_env = "msvc", not(target_arch = "arm")))] {
+    }
+    all(target_env = "msvc", not(target_arch = "arm")) => {
         // LLVM does not support unwinding on 32 bit ARM msvc (thumbv7a-pc-windows-msvc)
         #[path = "seh.rs"]
         mod imp;
-    } else {
+    }
+    _ => {
         // Targets that don't support unwinding.
         // - os=none ("bare metal" targets)
         // - os=uefi

--- a/library/panic_unwind/src/seh.rs
+++ b/library/panic_unwind/src/seh.rs
@@ -289,10 +289,11 @@ macro_rules! define_cleanup {
         }
     }
 }
-cfg_if::cfg_if! {
-   if #[cfg(target_arch = "x86")] {
+cfg_select! {
+   target_arch = "x86" => {
        define_cleanup!("thiscall" "thiscall-unwind");
-   } else {
+   }
+   _ => {
        define_cleanup!("C" "C-unwind");
    }
 }


### PR DESCRIPTION
This follows rust-lang/rust#145489 with an additional place we can drop the `cfg-if` dependency.