### PR TITLE
Handle `ReEarlyParam` in `type_name`.

### DIFF
--- a/compiler/rustc_const_eval/src/util/type_name.rs
+++ b/compiler/rustc_const_eval/src/util/type_name.rs
@@ -135,12 +135,12 @@ impl<'tcx> Printer<'tcx> for TypeNamePrinter<'tcx> {
 }
 
 impl<'tcx> PrettyPrinter<'tcx> for TypeNamePrinter<'tcx> {
-    fn should_print_optional_region(&self, _region: ty::Region<'_>) -> bool {
+    fn should_print_optional_region(&self, region: ty::Region<'_>) -> bool {
         // Bound regions are always printed (as `'_`), which gives some idea that they are special,
         // even though the `for` is omitted by the pretty printer.
         // E.g. `for<'a, 'b> fn(&'a u32, &'b u32)` is printed as "fn(&'_ u32, &'_ u32)".
-        match _region.kind() {
-            ty::ReErased => false,
+        match region.kind() {
+            ty::ReErased | ty::ReEarlyParam(_) => false,
             ty::ReBound(..) => true,
             _ => unreachable!(),
         }

--- a/tests/ui/type/type-name-basic.rs
+++ b/tests/ui/type/type-name-basic.rs
@@ -5,7 +5,7 @@
 
 #![allow(dead_code)]
 
-use std::any::type_name;
+use std::any::{Any, type_name, type_name_of_val};
 use std::borrow::Cow;
 
 struct Foo<T>(T);
@@ -26,6 +26,12 @@ trait TrLTA<'a, T> {
 macro_rules! t {
     ($ty:ty, $str:literal) => {
         assert_eq!(type_name::<$ty>(), $str);
+    }
+}
+
+macro_rules! v {
+    ($v:expr, $str:literal) => {
+        assert_eq!(type_name_of_val(&$v), $str);
     }
 }
 
@@ -91,4 +97,14 @@ pub fn main() {
         }
     }
     S::<u32>::test();
+
+    struct Wrap<T>(T);
+    impl Wrap<&()> {
+        fn get(&self) -> impl Any {
+            struct Info;
+            Info
+        }
+    }
+    let a = Wrap(&()).get();
+    v!(a, "type_name_basic::main::Wrap<&()>::get::Info");
 }


### PR DESCRIPTION
Fixes rust-lang/rust#145696.

r? @lcnr 