### PR TITLE
Suppress suggest try wrap when found is unresolved infer

### DIFF
--- a/compiler/rustc_type_ir/src/flags.rs
+++ b/compiler/rustc_type_ir/src/flags.rs
@@ -133,6 +133,9 @@ bitflags::bitflags! {
 
         /// Does this type have any coroutines in it?
         const HAS_TY_CORO                 = 1 << 24;
+
+        /// Does this type have any Infer(TyVar(_)) in it?
+        const HAS_INFER_TY_VAR            = 1 << 25;
     }
 }
 
@@ -267,9 +270,10 @@ impl<I: Interner> FlagComputation<I> {
                 ty::FreshTy(_) | ty::FreshIntTy(_) | ty::FreshFloatTy(_) => {
                     self.add_flags(TypeFlags::HAS_TY_FRESH)
                 }
-
-                ty::TyVar(_) | ty::IntVar(_) | ty::FloatVar(_) => {
-                    self.add_flags(TypeFlags::HAS_TY_INFER)
+                ty::IntVar(_) | ty::FloatVar(_) => self.add_flags(TypeFlags::HAS_TY_INFER),
+                ty::TyVar(_) => {
+                    self.add_flags(TypeFlags::HAS_INFER_TY_VAR);
+                    self.add_flags(TypeFlags::HAS_TY_INFER);
                 }
             },
 

--- a/tests/ui/issues/issue-3680.stderr
+++ b/tests/ui/issues/issue-3680.stderr
@@ -8,10 +8,6 @@ LL |         Err(_) => ()
    |
    = note: expected enum `Option<_>`
               found enum `Result<_, _>`
-help: try wrapping the pattern in `Some`
-   |
-LL |         Some(Err(_)) => ()
-   |         +++++      +
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/issues/issue-5358-1.stderr
+++ b/tests/ui/issues/issue-5358-1.stderr
@@ -8,10 +8,6 @@ LL |         Either::Right(_) => {}
    |
    = note: expected struct `S`
                 found enum `Either<_, _>`
-help: try wrapping the pattern in `S`
-   |
-LL |         S(Either::Right(_)) => {}
-   |         ++                +
 help: you might have meant to use field `0` whose type is `Either<usize, usize>`
    |
 LL |     match S(Either::Left(5)).0 {

--- a/tests/ui/match/issue-12552.stderr
+++ b/tests/ui/match/issue-12552.stderr
@@ -8,10 +8,6 @@ LL |     Some(k) => match k {
    |
    = note: expected enum `Result<_, {integer}>`
               found enum `Option<_>`
-help: try wrapping the pattern in `Ok`
-   |
-LL |     Ok(Some(k)) => match k {
-   |     +++       +
 
 error[E0308]: mismatched types
   --> $DIR/issue-12552.rs:9:5
@@ -24,10 +20,6 @@ LL |     None => ()
    |
    = note: expected enum `Result<_, {integer}>`
               found enum `Option<_>`
-help: try wrapping the pattern in `Ok`
-   |
-LL |     Ok(None) => ()
-   |     +++    +
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/type/type-mismatch-suggest-wrap-issue-145634.rs
+++ b/tests/ui/type/type-mismatch-suggest-wrap-issue-145634.rs
@@ -1,0 +1,9 @@
+// We should not suggest wrapping rhs with `Some`
+// when the found type is an unresolved type variable
+// 
+// See https://github.com/rust-lang/rust/issues/145634
+
+fn main() {
+    let foo = Some(&(1, 2));
+    assert!(matches!(foo, &Some((1, 2)))); //~ ERROR mismatched types [E0308]
+}

--- a/tests/ui/type/type-mismatch-suggest-wrap-issue-145634.rs
+++ b/tests/ui/type/type-mismatch-suggest-wrap-issue-145634.rs
@@ -1,6 +1,6 @@
 // We should not suggest wrapping rhs with `Some`
 // when the found type is an unresolved type variable
-// 
+//
 // See https://github.com/rust-lang/rust/issues/145634
 
 fn main() {

--- a/tests/ui/type/type-mismatch-suggest-wrap-issue-145634.stderr
+++ b/tests/ui/type/type-mismatch-suggest-wrap-issue-145634.stderr
@@ -8,10 +8,6 @@ LL |     assert!(matches!(foo, &Some((1, 2))));
    |
    = note:   expected enum `Option<&({integer}, {integer})>`
            found reference `&_`
-help: try wrapping the pattern in `Some`
-   |
-LL |     assert!(matches!(foo, Some(&Some((1, 2)))));
-   |                           +++++             +
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/type/type-mismatch-suggest-wrap-issue-145634.stderr
+++ b/tests/ui/type/type-mismatch-suggest-wrap-issue-145634.stderr
@@ -1,0 +1,18 @@
+error[E0308]: mismatched types
+  --> $DIR/type-mismatch-suggest-wrap-issue-145634.rs:8:27
+   |
+LL |     assert!(matches!(foo, &Some((1, 2))));
+   |                      ---  ^^^^^^^^^^^^^ expected `Option<&({integer}, {integer})>`, found `&_`
+   |                      |
+   |                      this expression has type `Option<&({integer}, {integer})>`
+   |
+   = note:   expected enum `Option<&({integer}, {integer})>`
+           found reference `&_`
+help: try wrapping the pattern in `Some`
+   |
+LL |     assert!(matches!(foo, Some(&Some((1, 2)))));
+   |                           +++++             +
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Fixes rust-lang/rust#145634

In this example, `&Some((1, 2))` is an `&_`, and we cannot know the exact type, so I think suppressing this suggestion is the most appropriate choice here. This is similar to / inspired by rust-lang/rust#145361.

I expanded `TypeFlags` to indicate whether a type contains a type with `is_ty_var` true.

The test with regression(rust-lang/rust#3680, rust-lang/rust#5358, rust-lang/rust#12552) are all ICE, and some are even from many years ago. Therefore, this change in PR should not have a significant impact on them?

Two commits shows the diff of the newly added test.

r? compiler