### PR TITLE
Update outdated link in bound region comments

### DIFF
--- a/compiler/rustc_type_ir/src/region_kind.rs
+++ b/compiler/rustc_type_ir/src/region_kind.rs
@@ -154,7 +154,7 @@ pub enum RegionKind<I: Interner> {
     /// parameters via `tcx.liberate_late_bound_regions`. They are then treated
     /// the same way as `ReEarlyParam` while inside of the function.
     ///
-    /// See <https://rustc-dev-guide.rust-lang.org/early-late-bound-params/early-late-bound-summary.html> for
+    /// See <https://rustc-dev-guide.rust-lang.org/early_late_parameters.html> for
     /// more info about early and late bound lifetime parameters.
     ReLateParam(I::LateParamRegion),
 


### PR DESCRIPTION
While reading the implementation code for bound regions, I found that a link in the comments was outdated. I've updated it with a link to the corresponding documentation in the rustc dev guide that covers the same content.

prev link: https://rustc-dev-guide.rust-lang.org/early-late-bound-params/early-late-bound-summary.html (404 error)
updated: https://rustc-dev-guide.rust-lang.org/early_late_parameters.html