### PR TITLE
Add hook for overriding compiler builtin macros

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4222,6 +4222,7 @@ dependencies = [
  "rustc_data_structures",
  "rustc_error_messages",
  "rustc_errors",
+ "rustc_expand",
  "rustc_feature",
  "rustc_fluent_macro",
  "rustc_graphviz",

--- a/compiler/rustc_const_eval/src/lib.rs
+++ b/compiler/rustc_const_eval/src/lib.rs
@@ -40,6 +40,7 @@ pub fn provide(providers: &mut Providers) {
     providers.eval_to_allocation_raw = const_eval::eval_to_allocation_raw_provider;
     providers.eval_static_initializer = const_eval::eval_static_initializer_provider;
     providers.hooks.const_caller_location = util::caller_location::const_caller_location_provider;
+    providers.hooks.after_register_builtin_macros = |_, _| {};
     providers.eval_to_valtree = |tcx, ty::PseudoCanonicalInput { typing_env, value }| {
         const_eval::eval_to_valtree(tcx, typing_env, value)
     };

--- a/compiler/rustc_expand/src/base.rs
+++ b/compiler/rustc_expand/src/base.rs
@@ -1101,6 +1101,7 @@ pub trait ResolverExpand {
         fragment: &AstFragment,
     );
     fn register_builtin_macro(&mut self, name: Symbol, ext: SyntaxExtensionKind);
+    fn override_builtin_macro(&mut self, name: Symbol, ext: SyntaxExtensionKind);
 
     fn expansion_for_ast_pass(
         &mut self,

--- a/compiler/rustc_expand/src/base.rs
+++ b/compiler/rustc_expand/src/base.rs
@@ -1,5 +1,6 @@
 use std::any::Any;
 use std::default::Default;
+use std::fmt::Debug;
 use std::iter;
 use std::path::Component::Prefix;
 use std::path::{Path, PathBuf};
@@ -1090,7 +1091,7 @@ pub struct DeriveResolution {
     pub is_const: bool,
 }
 
-pub trait ResolverExpand {
+pub trait ResolverExpand: Debug {
     fn next_node_id(&mut self) -> NodeId;
     fn invocation_parent(&self, id: LocalExpnId) -> LocalDefId;
 

--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -140,6 +140,7 @@ fn configure_and_expand(
         crate_name,
     );
     rustc_builtin_macros::register_builtin_macros(resolver);
+    tcx.after_register_builtin_macros(resolver);
 
     let num_standard_library_imports = sess.time("crate_injection", || {
         rustc_builtin_macros::standard_library_imports::inject(

--- a/compiler/rustc_middle/Cargo.toml
+++ b/compiler/rustc_middle/Cargo.toml
@@ -17,6 +17,7 @@ rustc_ast_ir = { path = "../rustc_ast_ir" }
 rustc_data_structures = { path = "../rustc_data_structures" }
 rustc_error_messages = { path = "../rustc_error_messages" } # Used for intra-doc links
 rustc_errors = { path = "../rustc_errors" }
+rustc_expand = { path = "../rustc_expand" }
 rustc_feature = { path = "../rustc_feature" }
 rustc_fluent_macro = { path = "../rustc_fluent_macro" }
 rustc_graphviz = { path = "../rustc_graphviz" }

--- a/compiler/rustc_middle/src/hooks/mod.rs
+++ b/compiler/rustc_middle/src/hooks/mod.rs
@@ -88,6 +88,8 @@ declare_hooks! {
 
     hook alloc_self_profile_query_strings() -> ();
 
+    hook after_register_builtin_macros(resolver: &mut dyn rustc_expand::base::ResolverExpand) -> ();
+
     /// Saves and writes the DepGraph to the file system.
     ///
     /// This function saves both the dep-graph and the query result cache,

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -1280,6 +1280,12 @@ pub struct Resolver<'ra, 'tcx> {
     impl_trait_names: FxHashMap<NodeId, Symbol>,
 }
 
+impl std::fmt::Debug for Resolver<'_, '_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Resolver").finish_non_exhaustive()
+    }
+}
+
 /// This provides memory for the rest of the crate. The `'ra` lifetime that is
 /// used by many types in this crate is an abbreviation of `ResolverArenas`.
 #[derive(Default)]

--- a/compiler/rustc_resolve/src/macros.rs
+++ b/compiler/rustc_resolve/src/macros.rs
@@ -203,6 +203,10 @@ impl<'ra, 'tcx> ResolverExpand for Resolver<'ra, 'tcx> {
         }
     }
 
+    fn override_builtin_macro(&mut self, name: Symbol, ext: SyntaxExtensionKind) {
+        self.builtin_macros.insert(name, ext);
+    }
+
     // Create a new Expansion with a definition site of the provided module, or
     // a fake empty `#[no_implicit_prelude]` module if no module is provided.
     fn expansion_for_ast_pass(


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/145734)*
<!-- homu-ignore:end -->

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

It would be useful for compiler plugins to be able to override the functionality of builtin macros, so this PR attempts to implement that. This is my first real attempt at contributing to Rust, so I’m looking to improve my skills and am very open to feedback or criticism!

This feature would specifically be very useful for us in [Kani](https://github.com/model-checking/kani), as it would allow us to stub out the std library's `panic!()` macro when we’re doing codegen for verification and avoid having to verify the complicated string formatting from certain calls of that macro.

r? @oli-obk 
