### PR TITLE
Check for bound variables when reporting type error

### DIFF
--- a/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
@@ -4870,16 +4870,23 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     })
                 } else if let Some(where_pred) = where_pred.as_projection_clause()
                     && let Some(failed_pred) = failed_pred.as_projection_clause()
-                    && let Some(found) = failed_pred.skip_binder().term.as_type()
                 {
-                    type_diffs = vec![TypeError::Sorts(ty::error::ExpectedFound {
-                        expected: where_pred
-                            .skip_binder()
-                            .projection_term
-                            .expect_ty(self.tcx)
-                            .to_ty(self.tcx),
-                        found,
-                    })];
+                    self.enter_forall(failed_pred, |failed_pred| {
+                        if let Some(found) = failed_pred.term.as_type() {
+                            let where_pred = self.instantiate_binder_with_fresh_vars(
+                                expr.span,
+                                BoundRegionConversionTime::HigherRankedType,
+                                where_pred,
+                            );
+                            type_diffs = vec![TypeError::Sorts(ty::error::ExpectedFound {
+                                expected: where_pred
+                                    .projection_term
+                                    .expect_ty(self.tcx)
+                                    .to_ty(self.tcx),
+                                found,
+                            })];
+                        }
+                    });
                 }
             }
             if let hir::ExprKind::Path(hir::QPath::Resolved(None, path)) = expr.kind

--- a/tests/ui/mismatched_types/mismatched-bound-projection-predicate.rs
+++ b/tests/ui/mismatched_types/mismatched-bound-projection-predicate.rs
@@ -1,0 +1,22 @@
+// Regression test for #144033
+
+pub struct Foo {}
+
+fn foo(foos: Vec<Foo>) {
+    let foos = foos.iter().collect::<Vec<_>>();
+    let bar = Bar {};
+    bar.bar(foos);
+    //~^ ERROR type mismatch resolving `<&Vec<&Foo> as IntoIterator>::Item == &Foo`
+}
+
+struct Bar {}
+
+impl Bar {
+    pub fn bar<I>(&self, iter: I)
+    where
+        for<'a> &'a I: IntoIterator<Item = &'a Foo>,
+    {
+    }
+}
+
+fn main() {}

--- a/tests/ui/mismatched_types/mismatched-bound-projection-predicate.stderr
+++ b/tests/ui/mismatched_types/mismatched-bound-projection-predicate.stderr
@@ -1,0 +1,31 @@
+error[E0271]: type mismatch resolving `<&Vec<&Foo> as IntoIterator>::Item == &Foo`
+  --> $DIR/mismatched-bound-projection-predicate.rs:8:13
+   |
+LL |     bar.bar(foos);
+   |         --- ^^^^ expected `&Foo`, found `&&Foo`
+   |         |
+   |         required by a bound introduced by this call
+   |
+   = note: expected reference `&Foo`
+              found reference `&&Foo`
+note: the method call chain might not have had the expected associated types
+  --> $DIR/mismatched-bound-projection-predicate.rs:6:21
+   |
+LL | fn foo(foos: Vec<Foo>) {
+   |              -------- `IntoIterator::Item` is `Foo` here
+LL |     let foos = foos.iter().collect::<Vec<_>>();
+   |                     ^^^^^^ ------------------- `IntoIterator::Item` remains `&Foo` here
+   |                     |
+   |                     `IntoIterator::Item` changed to `&Foo` here
+note: required by a bound in `Bar::bar`
+  --> $DIR/mismatched-bound-projection-predicate.rs:17:37
+   |
+LL |     pub fn bar<I>(&self, iter: I)
+   |            --- required by a bound in this associated function
+LL |     where
+LL |         for<'a> &'a I: IntoIterator<Item = &'a Foo>,
+   |                                     ^^^^^^^^^^^^^^ required by this bound in `Bar::bar`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0271`.


### PR DESCRIPTION
`can_eq` in `point_at_chain` ICEs if it's passed types with escaping bound variables, so we need to check for them, even in error reporting. Since this is just for error reporting simply skip types with escaping bound variables.

closes rust-lang/rust#145631
