### PR TITLE
test(rustfmt): Verify frontmatter is preserved

### DIFF
--- a/src/tools/rustfmt/tests/source/frontmatter_compact.rs
+++ b/src/tools/rustfmt/tests/source/frontmatter_compact.rs
@@ -1,0 +1,8 @@
+#!/usr/bin/env cargo
+---identifier
+[dependencies]
+regex = "1"
+---
+#![feature(frontmatter)]
+
+fn main() {}

--- a/src/tools/rustfmt/tests/source/frontmatter_escaped.rs
+++ b/src/tools/rustfmt/tests/source/frontmatter_escaped.rs
@@ -1,0 +1,13 @@
+#!/usr/bin/env cargo
+------------
+package.description = """
+Header
+-----
+
+Body
+"""
+------------
+
+#![feature(frontmatter)]
+
+fn main() {}

--- a/src/tools/rustfmt/tests/source/frontmatter_spaced.rs
+++ b/src/tools/rustfmt/tests/source/frontmatter_spaced.rs
@@ -1,0 +1,16 @@
+#!/usr/bin/env cargo
+
+
+---   identifier
+[dependencies]
+regex = "1"
+
+---
+
+
+
+
+
+#![feature(frontmatter)]
+
+fn main() {}

--- a/src/tools/rustfmt/tests/target/frontmatter_compact.rs
+++ b/src/tools/rustfmt/tests/target/frontmatter_compact.rs
@@ -1,0 +1,8 @@
+#!/usr/bin/env cargo
+---identifier
+[dependencies]
+regex = "1"
+---
+#![feature(frontmatter)]
+
+fn main() {}

--- a/src/tools/rustfmt/tests/target/frontmatter_escaped.rs
+++ b/src/tools/rustfmt/tests/target/frontmatter_escaped.rs
@@ -1,0 +1,13 @@
+#!/usr/bin/env cargo
+------------
+package.description = """
+Header
+-----
+
+Body
+"""
+------------
+
+#![feature(frontmatter)]
+
+fn main() {}

--- a/src/tools/rustfmt/tests/target/frontmatter_spaced.rs
+++ b/src/tools/rustfmt/tests/target/frontmatter_spaced.rs
@@ -1,0 +1,16 @@
+#!/usr/bin/env cargo
+
+
+---   identifier
+[dependencies]
+regex = "1"
+
+---
+
+
+
+
+
+#![feature(frontmatter)]
+
+fn main() {}


### PR DESCRIPTION
This is to prove that the frontmatter is preserved.

The choices in tests is intended for showing the different parts of the proposed Style Guide for frontmatters (rust-lang/rust#145617).

While rustfmt is developed in a different repo, work involving upstream integration is blocked on some work that is being finished up in that repo.  I was told that it would be ok to post against this repo in the mean time.

Tracking issue: rust-lang/rust#136889