### PR TITLE
Optimize `.ilog({2,10})` to `.ilog{2,10}()`

### DIFF
--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -1491,6 +1491,20 @@ macro_rules! uint_impl {
                       without modifying the original"]
         #[inline]
         pub const fn checked_ilog(self, base: Self) -> Option<u32> {
+            // Inform compiler of optimizations when the base is known at
+            // compile time and there's a cheaper method available.
+            //
+            // Note: Like all optimizations, this is not guaranteed to be
+            // applied by the compiler. If you want those specific bases,
+            // use `.checked_ilog2()` or `.checked_ilog10()` directly.
+            if core::intrinsics::is_val_statically_known(base) {
+                if base == 2 {
+                    return self.checked_ilog2();
+                } else if base == 10 {
+                    return self.checked_ilog10();
+                }
+            }
+
             if self <= 0 || base <= 1 {
                 None
             } else if self < base {


### PR DESCRIPTION
Optimize `.ilog({2,10})` to `.ilog{2,10}()`

Inform compiler of optimizations when the base is known at compile time and there's a cheaper method available:

* `{integer}.checked_ilog(2)` -> `{integer}.checked_ilog2()`
* `{integer}.checked_ilog(10)` -> `{integer}.checked_ilog10()`
* `{integer}.ilog(2)` -> `{integer}.ilog2()`
* `{integer}.ilog(10)` -> `{integer}.ilog10()`

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->

<details><summary>Test crate <tt>aarch64</tt> assembly diffs/function aliases</summary>

## Related source code
<details><summary>Test crate source code</summary>

```rust
//use paste::paste;

macro_rules! fns {
    ($($t:ty)*) => {
        $(
            fns!($t : 2 10);

            ::paste::paste! {
                #[inline(never)]
                #[unsafe(no_mangle)]
                pub fn [<$t _checked_ilog_5>](n: $t) -> Option<u32> {
                    n.checked_ilog(5)
                }

                #[inline(never)]
                #[unsafe(no_mangle)]
                pub fn [<$t _ilog_5>](n: $t) -> u32 {
                    n.ilog(5)
                }

                #[inline(never)]
                #[unsafe(no_mangle)]
                pub fn [<$t _checked_ilog_unknown>](n: $t, base: $t) -> Option<u32> {
                    n.checked_ilog(base)
                }

                #[inline(never)]
                #[unsafe(no_mangle)]
                pub fn [<$t _ilog_unknown>](n: $t, base: $t) -> u32 {
                    n.ilog(base)
                }
            }
        )*
    };
    ($t:ty : $($base:literal)*) => {
        $(
            ::paste::paste! {
                #[inline(never)]
                #[unsafe(no_mangle)]
                pub fn [<$t _checked_ilog $base>](n: $t) -> Option<u32> {
                    n.[<checked_ilog $base>]()
                }

                #[inline(never)]
                #[unsafe(no_mangle)]
                pub fn [<$t _checked_ilog_ $base>](n: $t) -> Option<u32> {
                    n.checked_ilog($base)
                }

                #[inline(never)]
                #[unsafe(no_mangle)]
                pub fn [<$t _ilog $base>](n: $t) -> u32 {
                    n.[<ilog $base>]()
                }

                #[inline(never)]
                #[unsafe(no_mangle)]
                pub fn [<$t _ilog_ $base>](n: $t) -> u32 {
                    n.ilog($base)
                }
            }
        )*
    }
}

fns!(i8 i16 i32 i64 i128 isize u8 u16 u32 u64 u128 usize);
```
</details>
<details><summary>Assembly differences generation script (change <tt>$asmfile</tt>)</summary>

````bash
#!/usr/bin/env bash

asmfile="target/release/deps/ilog_specialization-48c144866b60ea7c.s"

reset
for base in 2 5 10 unknown; do
  echo
  if [[ $base -eq 5 ]]; then
      echo "## Base 5 (compare nightly vs new to check that assembly stays the same)"
  elif [[ $base == unknown ]]; then
      echo "## Unknown base (compare nightly vs new to check that assembly stays the same)"
  else
      echo "## Base $base (compare new vs new to check that assembly is optimized)"
  fi

  for signed in i u; do
    for bits in 8 16 32 64 128 size; do
      for checked in _checked ""; do
        if [[ $base -eq 5 || $base == unknown ]]; then
          fn="${signed}${bits}${checked}_ilog_${base}"

          echo "<details><summary><tt>${signed}${bits}</tt>${checked:+ ${checked#?}} base ${base}</summary>"
          echo

          nightlyasm=$(cargo +nightly asm "${fn}" 2>/dev/null)
          newasm=$(cargo +stage1 asm "${fn}" 2>/dev/null)

          if [[ -z $nightlyasm || -z $newasm ]]; then
            echo '```asm'
            rg "${fn}" "${asmfile}"
          else
            echo '```diff'
            diff <(echo "${nightlyasm}") <(echo "${newasm}")
          fi
        else
          fn1="${signed}${bits}${checked}_ilog${base}"
          fn2="${signed}${bits}${checked}_ilog_${base}"

          echo "<details><summary><tt>${signed}${bits}</tt>${checked:+ ${checked#?}} base ${base}</summary>"
          echo

          fn1asm=$(cargo +stage1 asm "${fn1}" 2>/dev/null)
          fn2asm=$(cargo +stage1 asm "${fn2}" 2>/dev/null)

          if [[ -z $fn1asm ]]; then
            echo '```asm'
            if [[ -z $fn2asm ]]; then
                rg "${fn1}|${fn2}" "${asmfile}"
            else
                rg "${fn1}" "${asmfile}"
            fi
          elif [[ -z $fn2asm ]]; then
            echo '```asm'
            rg "${fn2}" "${asmfile}"
          else
            echo '```diff'
            diff <(echo "${fn1asm}") <(echo "${fn2asm}")
          fi
        fi

        echo '```'
        echo "</details>"
      done
    done
  done
done
````
</details>

## Base 2 (compare new vs new to check that assembly is optimized)
<details><summary><tt>i8</tt> checked base 2</summary>

```diff
1c1
<       .globl  _i8_checked_ilog2
---
>       .globl  _i8_checked_ilog_2
3,4c3,4
< _i8_checked_ilog2:
< Lfunc_begin59:
---
> _i8_checked_ilog_2:
> Lfunc_begin63:
```
</details>
<details><summary><tt>i8</tt> base 2</summary>

```diff
1c1
<       .globl  _i8_ilog2
---
>       .globl  _i8_ilog_2
3,4c3,4
< _i8_ilog2:
< Lfunc_begin65:
---
> _i8_ilog_2:
> Lfunc_begin83:
7,8c7,8
<       cmp w8, #1
<       b.lt LBB65_2
---
>       cmp w8, #0
>       b.le LBB83_2
13c13
< LBB65_2:
---
> LBB83_2:
20c20
< Lloh78:
---
> Lloh108:
22c22
< Lloh79:
---
> Lloh109:
25c25
<       .loh AdrpAdd    Lloh78, Lloh79
---
>       .loh AdrpAdd    Lloh108, Lloh109
```
</details>
<details><summary><tt>i16</tt> checked base 2</summary>

```diff
1c1
<       .globl  _i16_checked_ilog2
---
>       .globl  _i16_checked_ilog_2
3,4c3,4
< _i16_checked_ilog2:
< Lfunc_begin13:
---
> _i16_checked_ilog_2:
> Lfunc_begin51:
```
</details>
<details><summary><tt>i16</tt> base 2</summary>

```diff
1c1
<       .globl  _i16_ilog2
---
>       .globl  _i16_ilog_2
3,4c3,4
< _i16_ilog2:
< Lfunc_begin80:
---
> _i16_ilog_2:
> Lfunc_begin54:
7,8c7,8
<       cmp w8, #1
<       b.lt LBB80_2
---
>       cmp w8, #0
>       b.le LBB54_2
13c13
< LBB80_2:
---
> LBB54_2:
20c20
< Lloh104:
---
> Lloh64:
22c22
< Lloh105:
---
> Lloh65:
25c25
<       .loh AdrpAdd    Lloh104, Lloh105
---
>       .loh AdrpAdd    Lloh64, Lloh65
```
</details>
<details><summary><tt>i32</tt> checked base 2</summary>

```diff
1c1
<       .globl  _i32_checked_ilog2
---
>       .globl  _i32_checked_ilog_2
3,4c3,4
< _i32_checked_ilog2:
< Lfunc_begin14:
---
> _i32_checked_ilog_2:
> Lfunc_begin39:
```
</details>
<details><summary><tt>i32</tt> base 2</summary>

```diff
1c1
<       .globl  _i32_ilog2
---
>       .globl  _i32_ilog_2
3,4c3,4
< _i32_ilog2:
< Lfunc_begin35:
---
> _i32_ilog_2:
> Lfunc_begin88:
6,7c6,7
<       cmp w0, #1
<       b.lt LBB35_2
---
>       cmp w0, #0
>       b.le LBB88_2
11c11
< LBB35_2:
---
> LBB88_2:
18c18
< Lloh44:
---
> Lloh118:
20c20
< Lloh45:
---
> Lloh119:
23c23
<       .loh AdrpAdd    Lloh44, Lloh45
---
>       .loh AdrpAdd    Lloh118, Lloh119
```
</details>
<details><summary><tt>i64</tt> checked base 2</summary>

```diff
1c1
<       .globl  _i64_checked_ilog2
---
>       .globl  _i64_checked_ilog_2
3,4c3,4
< _i64_checked_ilog2:
< Lfunc_begin19:
---
> _i64_checked_ilog_2:
> Lfunc_begin71:
```
</details>
<details><summary><tt>i64</tt> base 2</summary>

```diff
1c1
<       .globl  _i64_ilog2
---
>       .globl  _i64_ilog_2
3,4c3,4
< _i64_ilog2:
< Lfunc_begin36:
---
> _i64_ilog_2:
> Lfunc_begin92:
6,7c6,7
<       cmp x0, #1
<       b.lt LBB36_2
---
>       cmp x0, #0
>       b.le LBB92_2
11c11
< LBB36_2:
---
> LBB92_2:
18c18
< Lloh46:
---
> Lloh126:
20c20
< Lloh47:
---
> Lloh127:
23c23
<       .loh AdrpAdd    Lloh46, Lloh47
---
>       .loh AdrpAdd    Lloh126, Lloh127
```
</details>
<details><summary><tt>i128</tt> checked base 2</summary>

```diff
1c1
<       .globl  _i128_checked_ilog2
---
>       .globl  _i128_checked_ilog_2
3,4c3,4
< _i128_checked_ilog2:
< Lfunc_begin41:
---
> _i128_checked_ilog_2:
> Lfunc_begin11:
```
</details>
<details><summary><tt>i128</tt> base 2</summary>

```diff
1c1
<       .globl  _i128_ilog2
---
>       .globl  _i128_ilog_2
3,4c3,4
< _i128_ilog2:
< Lfunc_begin77:
---
> _i128_ilog_2:
> Lfunc_begin72:
6,8c6,8
<       cmp x0, #1
<       sbcs xzr, x1, xzr
<       b.lt LBB77_2
---
>       cmp xzr, x0
>       ngcs xzr, x1
>       b.ge LBB72_2
16c16
< LBB77_2:
---
> LBB72_2:
23c23
< Lloh102:
---
> Lloh94:
25c25
< Lloh103:
---
> Lloh95:
28c28
<       .loh AdrpAdd    Lloh102, Lloh103
---
>       .loh AdrpAdd    Lloh94, Lloh95
```
</details>
<details><summary><tt>isize</tt> checked base 2</summary>

```asm
7821: .globl  _isize_checked_ilog2
7822:_isize_checked_ilog2 = _i64_checked_ilog2
7831: .globl  _isize_checked_ilog_2
7832:_isize_checked_ilog_2 = _i64_checked_ilog_2
```
</details>
<details><summary><tt>isize</tt> base 2</summary>

```asm
7787: .globl  _isize_ilog2
7788:_isize_ilog2 = _i64_ilog2
7797: .globl  _isize_ilog_2
7798:_isize_ilog_2 = _i64_ilog_2
```
</details>
<details><summary><tt>u8</tt> checked base 2</summary>

```asm
7807: .globl  _u8_checked_ilog_2
7808:_u8_checked_ilog_2 = _u8_checked_ilog2
```
</details>
<details><summary><tt>u8</tt> base 2</summary>

```asm
7799: .globl  _u8_ilog_2
7800:_u8_ilog_2 = _u8_ilog2
```
</details>
<details><summary><tt>u16</tt> checked base 2</summary>

```asm
7809: .globl  _u16_checked_ilog_2
7810:_u16_checked_ilog_2 = _u16_checked_ilog2
```
</details>
<details><summary><tt>u16</tt> base 2</summary>

```asm
7801: .globl  _u16_ilog_2
7802:_u16_ilog_2 = _u16_ilog2
```
</details>
<details><summary><tt>u32</tt> checked base 2</summary>

```asm
7755: .globl  _u32_checked_ilog_2
7756:_u32_checked_ilog_2 = _u32_checked_ilog2
```
</details>
<details><summary><tt>u32</tt> base 2</summary>

```asm
7759: .globl  _u32_ilog_2
7760:_u32_ilog_2 = _u32_ilog2
```
</details>
<details><summary><tt>u64</tt> checked base 2</summary>

```asm
7829: .globl  _u64_checked_ilog_2
7830:_u64_checked_ilog_2 = _u64_checked_ilog2
```
</details>
<details><summary><tt>u64</tt> base 2</summary>

```asm
7793: .globl  _u64_ilog_2
7794:_u64_ilog_2 = _u64_ilog2
```
</details>
<details><summary><tt>u128</tt> checked base 2</summary>

```asm
7825: .globl  _u128_checked_ilog_2
7826:_u128_checked_ilog_2 = _u128_checked_ilog2
```
</details>
<details><summary><tt>u128</tt> base 2</summary>

```asm
7795: .globl  _u128_ilog_2
7796:_u128_ilog_2 = _u128_ilog2
```
</details>
<details><summary><tt>usize</tt> checked base 2</summary>

```asm
7823: .globl  _usize_checked_ilog2
7824:_usize_checked_ilog2 = _u64_checked_ilog2
7827: .globl  _usize_checked_ilog_2
7828:_usize_checked_ilog_2 = _u64_checked_ilog2
```
</details>
<details><summary><tt>usize</tt> base 2</summary>

```asm
7789: .globl  _usize_ilog2
7790:_usize_ilog2 = _u64_ilog2
7791: .globl  _usize_ilog_2
7792:_usize_ilog_2 = _u64_ilog2
```
</details>

## Base 5 (compare nightly vs new to check that assembly stays the same)
<details><summary><tt>i8</tt> checked base 5</summary>

```diff
4c4
< Lfunc_begin97:
---
> Lfunc_begin46:
8c8
<       b.lt LBB97_3
---
>       b.lt LBB46_3
11c11
<       b.hs LBB97_4
---
>       b.hs LBB46_4
15c15
< LBB97_3:
---
> LBB46_3:
18c18
< LBB97_4:
---
> LBB46_4:
20c20
<       b.hs LBB97_6
---
>       b.hs LBB46_6
24c24
< LBB97_6:
---
> LBB46_6:
31c31
< LBB97_7:
---
> LBB46_7:
35c35
<       b.ls LBB97_7
---
>       b.ls LBB46_7
```
</details>
<details><summary><tt>i8</tt> base 5</summary>

```diff
4c4
< Lfunc_begin85:
---
> Lfunc_begin47:
8c8
<       b.lt LBB85_8
---
>       b.lt LBB47_8
11c11
<       b.hs LBB85_3
---
>       b.hs LBB47_3
14c14
< LBB85_3:
---
> LBB47_3:
16c16
<       b.hs LBB85_5
---
>       b.hs LBB47_5
19c19
< LBB85_5:
---
> LBB47_5:
26c26
< LBB85_6:
---
> LBB47_6:
30c30
<       b.ls LBB85_6
---
>       b.ls LBB47_6
32c32
< LBB85_8:
---
> LBB47_8:
39,42c39,42
< Lloh100:
<       adrp x0, l_anon.b1a6bf9626946dc5455dc8556bf70fc4.1@PAGE
< Lloh101:
<       add x0, x0, l_anon.b1a6bf9626946dc5455dc8556bf70fc4.1@PAGEOFF
---
> Lloh60:
>       adrp x0, l_anon.5342b09e6c75d1cc3f3f5bd2e914f963.1@PAGE
> Lloh61:
>       add x0, x0, l_anon.5342b09e6c75d1cc3f3f5bd2e914f963.1@PAGEOFF
44c44
<       .loh AdrpAdd    Lloh100, Lloh101
---
>       .loh AdrpAdd    Lloh60, Lloh61
```
</details>
<details><summary><tt>i16</tt> checked base 5</summary>

```diff
4c4
< Lfunc_begin32:
---
> Lfunc_begin43:
8c8
<       b.lt LBB32_3
---
>       b.lt LBB43_3
11c11
<       b.hs LBB32_4
---
>       b.hs LBB43_4
15c15
< LBB32_3:
---
> LBB43_3:
18c18
< LBB32_4:
---
> LBB43_4:
20c20
<       b.hs LBB32_6
---
>       b.hs LBB43_6
24c24
< LBB32_6:
---
> LBB43_6:
31c31
< LBB32_7:
---
> LBB43_7:
35c35
<       b.ls LBB32_7
---
>       b.ls LBB43_7
```
</details>
<details><summary><tt>i16</tt> base 5</summary>

```diff
4c4
< Lfunc_begin12:
---
> Lfunc_begin52:
8c8
<       b.lt LBB12_8
---
>       b.lt LBB52_8
11c11
<       b.hs LBB12_3
---
>       b.hs LBB52_3
14c14
< LBB12_3:
---
> LBB52_3:
16c16
<       b.hs LBB12_5
---
>       b.hs LBB52_5
19c19
< LBB12_5:
---
> LBB52_5:
26c26
< LBB12_6:
---
> LBB52_6:
30c30
<       b.ls LBB12_6
---
>       b.ls LBB52_6
32c32
< LBB12_8:
---
> LBB52_8:
39,42c39,42
< Lloh18:
<       adrp x0, l_anon.b1a6bf9626946dc5455dc8556bf70fc4.1@PAGE
< Lloh19:
<       add x0, x0, l_anon.b1a6bf9626946dc5455dc8556bf70fc4.1@PAGEOFF
---
> Lloh62:
>       adrp x0, l_anon.5342b09e6c75d1cc3f3f5bd2e914f963.1@PAGE
> Lloh63:
>       add x0, x0, l_anon.5342b09e6c75d1cc3f3f5bd2e914f963.1@PAGEOFF
44c44
<       .loh AdrpAdd    Lloh18, Lloh19
---
>       .loh AdrpAdd    Lloh62, Lloh63
```
</details>
<details><summary><tt>i32</tt> checked base 5</summary>

```diff
4c4
< Lfunc_begin35:
---
> Lfunc_begin78:
7c7
<       b.lt LBB35_3
---
>       b.lt LBB78_3
9c9
<       b.hs LBB35_4
---
>       b.hs LBB78_4
13c13
< LBB35_3:
---
> LBB78_3:
16c16
< LBB35_4:
---
> LBB78_4:
18c18
<       b.hs LBB35_6
---
>       b.hs LBB78_6
22c22
< LBB35_6:
---
> LBB78_6:
29c29
< LBB35_7:
---
> LBB78_7:
33c33
<       b.ls LBB35_7
---
>       b.ls LBB78_7
```
</details>
<details><summary><tt>i32</tt> base 5</summary>

```diff
4c4
< Lfunc_begin114:
---
> Lfunc_begin97:
7c7
<       b.lt LBB114_8
---
>       b.lt LBB97_8
9c9
<       b.hs LBB114_3
---
>       b.hs LBB97_3
12c12
< LBB114_3:
---
> LBB97_3:
14c14
<       b.hs LBB114_5
---
>       b.hs LBB97_5
17c17
< LBB114_5:
---
> LBB97_5:
24c24
< LBB114_6:
---
> LBB97_6:
28c28
<       b.ls LBB114_6
---
>       b.ls LBB97_6
30c30
< LBB114_8:
---
> LBB97_8:
37,40c37,40
< Lloh154:
<       adrp x0, l_anon.b1a6bf9626946dc5455dc8556bf70fc4.1@PAGE
< Lloh155:
<       add x0, x0, l_anon.b1a6bf9626946dc5455dc8556bf70fc4.1@PAGEOFF
---
> Lloh136:
>       adrp x0, l_anon.5342b09e6c75d1cc3f3f5bd2e914f963.1@PAGE
> Lloh137:
>       add x0, x0, l_anon.5342b09e6c75d1cc3f3f5bd2e914f963.1@PAGEOFF
42c42
<       .loh AdrpAdd    Lloh154, Lloh155
---
>       .loh AdrpAdd    Lloh136, Lloh137
```
</details>
<details><summary><tt>i64</tt> checked base 5</summary>

```diff
4c4
< Lfunc_begin46:
---
> Lfunc_begin31:
7c7
<       b.lt LBB46_3
---
>       b.lt LBB31_3
9c9
<       b.hs LBB46_4
---
>       b.hs LBB31_4
13c13
< LBB46_3:
---
> LBB31_3:
16c16
< LBB46_4:
---
> LBB31_4:
18c18
<       b.hs LBB46_6
---
>       b.hs LBB31_6
22c22
< LBB46_6:
---
> LBB31_6:
29c29
< LBB46_7:
---
> LBB31_7:
33c33
<       b.ls LBB46_7
---
>       b.ls LBB31_7
```
</details>
<details><summary><tt>i64</tt> base 5</summary>

```diff
4c4
< Lfunc_begin90:
---
> Lfunc_begin73:
7c7
<       b.lt LBB90_8
---
>       b.lt LBB73_8
9c9
<       b.hs LBB90_3
---
>       b.hs LBB73_3
12c12
< LBB90_3:
---
> LBB73_3:
14c14
<       b.hs LBB90_5
---
>       b.hs LBB73_5
17c17
< LBB90_5:
---
> LBB73_5:
24c24
< LBB90_6:
---
> LBB73_6:
28c28
<       b.ls LBB90_6
---
>       b.ls LBB73_6
30c30
< LBB90_8:
---
> LBB73_8:
37,40c37,40
< Lloh110:
<       adrp x0, l_anon.b1a6bf9626946dc5455dc8556bf70fc4.1@PAGE
< Lloh111:
<       add x0, x0, l_anon.b1a6bf9626946dc5455dc8556bf70fc4.1@PAGEOFF
---
> Lloh96:
>       adrp x0, l_anon.5342b09e6c75d1cc3f3f5bd2e914f963.1@PAGE
> Lloh97:
>       add x0, x0, l_anon.5342b09e6c75d1cc3f3f5bd2e914f963.1@PAGEOFF
42c42
<       .loh AdrpAdd    Lloh110, Lloh111
---
>       .loh AdrpAdd    Lloh96, Lloh97
```
</details>
<details><summary><tt>i128</tt> checked base 5</summary>

```diff
4c4
< Lfunc_begin91:
---
> Lfunc_begin38:
8c8
<       b.lt LBB91_3
---
>       b.lt LBB38_3
11c11
<       b.hs LBB91_4
---
>       b.hs LBB38_4
15c15
< LBB91_3:
---
> LBB38_3:
18c18
< LBB91_4:
---
> LBB38_4:
31c31
<       b.hs LBB91_6
---
>       b.hs LBB38_6
34,35c34,35
<       b LBB91_10
< LBB91_6:
---
>       b LBB38_10
> LBB38_6:
41,42c41,42
<       b LBB91_8
< LBB91_7:
---
>       b LBB38_8
> LBB38_7:
49,50c49,50
< LBB91_8:
<       tbz w13, #0, LBB91_7
---
> LBB38_8:
>       tbz w13, #0, LBB38_7
56,57c56,57
<       b.ne LBB91_7
< LBB91_10:
---
>       b.ne LBB38_7
> LBB38_10:
75c75
<       b.lo LBB91_13
---
>       b.lo LBB38_13
77c77
< LBB91_12:
---
> LBB38_12:
85,86c85,86
<       b.hs LBB91_12
< LBB91_13:
---
>       b.hs LBB38_12
> LBB38_13:
```
</details>
<details><summary><tt>i128</tt> base 5</summary>

```diff
4c4
< Lfunc_begin77:
---
> Lfunc_begin94:
8c8
<       b.lt LBB77_13
---
>       b.lt LBB94_13
12c12
<       b.hs LBB77_3
---
>       b.hs LBB94_3
15c15
< LBB77_3:
---
> LBB94_3:
27c27
<       b.hs LBB77_5
---
>       b.hs LBB94_5
30,31c30,31
<       b LBB77_9
< LBB77_5:
---
>       b LBB94_9
> LBB94_5:
37,38c37,38
<       b LBB77_7
< LBB77_6:
---
>       b LBB94_7
> LBB94_6:
45,46c45,46
< LBB77_7:
<       tbz w13, #0, LBB77_6
---
> LBB94_7:
>       tbz w13, #0, LBB94_6
52,53c52,53
<       b.ne LBB77_6
< LBB77_9:
---
>       b.ne LBB94_6
> LBB94_9:
71c71
<       b.lo LBB77_12
---
>       b.lo LBB94_12
73c73
< LBB77_11:
---
> LBB94_11:
81,82c81,82
<       b.hs LBB77_11
< LBB77_12:
---
>       b.hs LBB94_11
> LBB94_12:
84c84
< LBB77_13:
---
> LBB94_13:
91,94c91,94
< Lloh90:
<       adrp x0, l_anon.b1a6bf9626946dc5455dc8556bf70fc4.1@PAGE
< Lloh91:
<       add x0, x0, l_anon.b1a6bf9626946dc5455dc8556bf70fc4.1@PAGEOFF
---
> Lloh128:
>       adrp x0, l_anon.5342b09e6c75d1cc3f3f5bd2e914f963.1@PAGE
> Lloh129:
>       add x0, x0, l_anon.5342b09e6c75d1cc3f3f5bd2e914f963.1@PAGEOFF
96c96
<       .loh AdrpAdd    Lloh90, Lloh91
---
>       .loh AdrpAdd    Lloh128, Lloh129
```
</details>
<details><summary><tt>isize</tt> checked base 5</summary>

```asm
7817: .globl  _isize_checked_ilog_5
7818:_isize_checked_ilog_5 = _i64_checked_ilog_5
```
</details>
<details><summary><tt>isize</tt> base 5</summary>

```asm
7765: .globl  _isize_ilog_5
7766:_isize_ilog_5 = _i64_ilog_5
```
</details>
<details><summary><tt>u8</tt> checked base 5</summary>

```diff
4c4
< Lfunc_begin68:
---
> Lfunc_begin64:
7c7
<       b.eq LBB68_3
---
>       b.eq LBB64_3
9c9
<       b.hs LBB68_4
---
>       b.hs LBB64_4
13c13
< LBB68_3:
---
> LBB64_3:
16c16
< LBB68_4:
---
> LBB64_4:
18c18
<       b.hs LBB68_6
---
>       b.hs LBB64_6
22c22
< LBB68_6:
---
> LBB64_6:
29c29
< LBB68_7:
---
> LBB64_7:
33c33
<       b.ls LBB68_7
---
>       b.ls LBB64_7
```
</details>
<details><summary><tt>u8</tt> base 5</summary>

```diff
37,40c37,40
< Lloh128:
<       adrp x0, l_anon.b1a6bf9626946dc5455dc8556bf70fc4.1@PAGE
< Lloh129:
<       add x0, x0, l_anon.b1a6bf9626946dc5455dc8556bf70fc4.1@PAGEOFF
---
> Lloh138:
>       adrp x0, l_anon.5342b09e6c75d1cc3f3f5bd2e914f963.1@PAGE
> Lloh139:
>       add x0, x0, l_anon.5342b09e6c75d1cc3f3f5bd2e914f963.1@PAGEOFF
42c42
<       .loh AdrpAdd    Lloh128, Lloh129
---
>       .loh AdrpAdd    Lloh138, Lloh139
```
</details>
<details><summary><tt>u16</tt> checked base 5</summary>

```diff
4c4
< Lfunc_begin30:
---
> Lfunc_begin4:
7c7
<       b.eq LBB30_3
---
>       b.eq LBB4_3
9c9
<       b.hs LBB30_4
---
>       b.hs LBB4_4
13c13
< LBB30_3:
---
> LBB4_3:
16c16
< LBB30_4:
---
> LBB4_4:
18c18
<       b.hs LBB30_6
---
>       b.hs LBB4_6
22c22
< LBB30_6:
---
> LBB4_6:
29c29
< LBB30_7:
---
> LBB4_7:
33c33
<       b.ls LBB30_7
---
>       b.ls LBB4_7
```
</details>
<details><summary><tt>u16</tt> base 5</summary>

```diff
4c4
< Lfunc_begin84:
---
> Lfunc_begin76:
7c7
<       b.eq LBB84_8
---
>       b.eq LBB76_8
9c9
<       b.hs LBB84_3
---
>       b.hs LBB76_3
12c12
< LBB84_3:
---
> LBB76_3:
14c14
<       b.hs LBB84_5
---
>       b.hs LBB76_5
17c17
< LBB84_5:
---
> LBB76_5:
24c24
< LBB84_6:
---
> LBB76_6:
28c28
<       b.ls LBB84_6
---
>       b.ls LBB76_6
30c30
< LBB84_8:
---
> LBB76_8:
37,40c37,40
< Lloh98:
<       adrp x0, l_anon.b1a6bf9626946dc5455dc8556bf70fc4.1@PAGE
< Lloh99:
<       add x0, x0, l_anon.b1a6bf9626946dc5455dc8556bf70fc4.1@PAGEOFF
---
> Lloh100:
>       adrp x0, l_anon.5342b09e6c75d1cc3f3f5bd2e914f963.1@PAGE
> Lloh101:
>       add x0, x0, l_anon.5342b09e6c75d1cc3f3f5bd2e914f963.1@PAGEOFF
42c42
<       .loh AdrpAdd    Lloh98, Lloh99
---
>       .loh AdrpAdd    Lloh100, Lloh101
```
</details>
<details><summary><tt>u32</tt> checked base 5</summary>

```diff
4c4
< Lfunc_begin19:
---
> Lfunc_begin34:
6c6
<       cbz w0, LBB19_3
---
>       cbz w0, LBB34_3
8c8
<       b.hs LBB19_4
---
>       b.hs LBB34_4
12c12
< LBB19_3:
---
> LBB34_3:
14c14
< LBB19_4:
---
> LBB34_4:
16c16
<       b.hs LBB19_6
---
>       b.hs LBB34_6
20c20
< LBB19_6:
---
> LBB34_6:
27c27
< LBB19_7:
---
> LBB34_7:
31c31
<       b.ls LBB19_7
---
>       b.ls LBB34_7
```
</details>
<details><summary><tt>u32</tt> base 5</summary>

```diff
4c4
< Lfunc_begin119:
---
> Lfunc_begin56:
6c6
<       cbz w0, LBB119_8
---
>       cbz w0, LBB56_8
8c8
<       b.hs LBB119_3
---
>       b.hs LBB56_3
11c11
< LBB119_3:
---
> LBB56_3:
13c13
<       b.hs LBB119_5
---
>       b.hs LBB56_5
16c16
< LBB119_5:
---
> LBB56_5:
23c23
< LBB119_6:
---
> LBB56_6:
27c27
<       b.ls LBB119_6
---
>       b.ls LBB56_6
29c29
< LBB119_8:
---
> LBB56_8:
36,39c36,39
< Lloh158:
<       adrp x0, l_anon.b1a6bf9626946dc5455dc8556bf70fc4.1@PAGE
< Lloh159:
<       add x0, x0, l_anon.b1a6bf9626946dc5455dc8556bf70fc4.1@PAGEOFF
---
> Lloh66:
>       adrp x0, l_anon.5342b09e6c75d1cc3f3f5bd2e914f963.1@PAGE
> Lloh67:
>       add x0, x0, l_anon.5342b09e6c75d1cc3f3f5bd2e914f963.1@PAGEOFF
41c41
<       .loh AdrpAdd    Lloh158, Lloh159
---
>       .loh AdrpAdd    Lloh66, Lloh67
```
</details>
<details><summary><tt>u64</tt> checked base 5</summary>

```diff
4c4
< Lfunc_begin112:
---
> Lfunc_begin50:
6c6
<       cbz x0, LBB112_3
---
>       cbz x0, LBB50_3
8c8
<       b.hs LBB112_4
---
>       b.hs LBB50_4
12c12
< LBB112_3:
---
> LBB50_3:
14c14
< LBB112_4:
---
> LBB50_4:
16c16
<       b.hs LBB112_6
---
>       b.hs LBB50_6
20c20
< LBB112_6:
---
> LBB50_6:
27c27
< LBB112_7:
---
> LBB50_7:
31c31
<       b.ls LBB112_7
---
>       b.ls LBB50_7
```
</details>
<details><summary><tt>u64</tt> base 5</summary>

```diff
4c4
< Lfunc_begin96:
---
> Lfunc_begin45:
6c6
<       cbz x0, LBB96_8
---
>       cbz x0, LBB45_8
8c8
<       b.hs LBB96_3
---
>       b.hs LBB45_3
11c11
< LBB96_3:
---
> LBB45_3:
13c13
<       b.hs LBB96_5
---
>       b.hs LBB45_5
16c16
< LBB96_5:
---
> LBB45_5:
23c23
< LBB96_6:
---
> LBB45_6:
27c27
<       b.ls LBB96_6
---
>       b.ls LBB45_6
29c29
< LBB96_8:
---
> LBB45_8:
36,39c36,39
< Lloh124:
<       adrp x0, l_anon.b1a6bf9626946dc5455dc8556bf70fc4.1@PAGE
< Lloh125:
<       add x0, x0, l_anon.b1a6bf9626946dc5455dc8556bf70fc4.1@PAGEOFF
---
> Lloh58:
>       adrp x0, l_anon.5342b09e6c75d1cc3f3f5bd2e914f963.1@PAGE
> Lloh59:
>       add x0, x0, l_anon.5342b09e6c75d1cc3f3f5bd2e914f963.1@PAGEOFF
41c41
<       .loh AdrpAdd    Lloh124, Lloh125
---
>       .loh AdrpAdd    Lloh58, Lloh59
```
</details>
<details><summary><tt>u128</tt> checked base 5</summary>

```diff
4c4
< Lfunc_begin80:
---
> Lfunc_begin69:
7c7
<       cbz x8, LBB80_3
---
>       cbz x8, LBB69_3
10c10
<       b.hs LBB80_4
---
>       b.hs LBB69_4
14c14
< LBB80_3:
---
> LBB69_3:
17c17
< LBB80_4:
---
> LBB69_4:
30c30
<       b.hs LBB80_6
---
>       b.hs LBB69_6
33,34c33,34
<       b LBB80_10
< LBB80_6:
---
>       b LBB69_10
> LBB69_6:
40,41c40,41
<       b LBB80_8
< LBB80_7:
---
>       b LBB69_8
> LBB69_7:
48,49c48,49
< LBB80_8:
<       tbz w13, #0, LBB80_7
---
> LBB69_8:
>       tbz w13, #0, LBB69_7
55,56c55,56
<       b.ne LBB80_7
< LBB80_10:
---
>       b.ne LBB69_7
> LBB69_10:
74c74
<       b.lo LBB80_13
---
>       b.lo LBB69_13
76c76
< LBB80_12:
---
> LBB69_12:
84,85c84,85
<       b.hs LBB80_12
< LBB80_13:
---
>       b.hs LBB69_12
> LBB69_13:
```
</details>
<details><summary><tt>u128</tt> base 5</summary>

```diff
4c4
< Lfunc_begin16:
---
> Lfunc_begin57:
7c7
<       cbz x9, LBB16_13
---
>       cbz x9, LBB57_13
11c11
<       b.hs LBB16_3
---
>       b.hs LBB57_3
14c14
< LBB16_3:
---
> LBB57_3:
26c26
<       b.hs LBB16_5
---
>       b.hs LBB57_5
29,30c29,30
<       b LBB16_9
< LBB16_5:
---
>       b LBB57_9
> LBB57_5:
36,37c36,37
<       b LBB16_7
< LBB16_6:
---
>       b LBB57_7
> LBB57_6:
44,45c44,45
< LBB16_7:
<       tbz w13, #0, LBB16_6
---
> LBB57_7:
>       tbz w13, #0, LBB57_6
51,52c51,52
<       b.ne LBB16_6
< LBB16_9:
---
>       b.ne LBB57_6
> LBB57_9:
70c70
<       b.lo LBB16_12
---
>       b.lo LBB57_12
72c72
< LBB16_11:
---
> LBB57_11:
80,81c80,81
<       b.hs LBB16_11
< LBB16_12:
---
>       b.hs LBB57_11
> LBB57_12:
83c83
< LBB16_13:
---
> LBB57_13:
90,93c90,93
< Lloh22:
<       adrp x0, l_anon.b1a6bf9626946dc5455dc8556bf70fc4.1@PAGE
< Lloh23:
<       add x0, x0, l_anon.b1a6bf9626946dc5455dc8556bf70fc4.1@PAGEOFF
---
> Lloh68:
>       adrp x0, l_anon.5342b09e6c75d1cc3f3f5bd2e914f963.1@PAGE
> Lloh69:
>       add x0, x0, l_anon.5342b09e6c75d1cc3f3f5bd2e914f963.1@PAGEOFF
95c95
<       .loh AdrpAdd    Lloh22, Lloh23
---
>       .loh AdrpAdd    Lloh68, Lloh69
```
</details>
<details><summary><tt>usize</tt> checked base 5</summary>

```asm
7819: .globl  _usize_checked_ilog_5
7820:_usize_checked_ilog_5 = _u64_checked_ilog_5
```
</details>
<details><summary><tt>usize</tt> base 5</summary>

```asm
7767: .globl  _usize_ilog_5
7768:_usize_ilog_5 = _u64_ilog_5
```
</details>

## Base 10 (compare new vs new to check that assembly is optimized)
<details><summary><tt>i8</tt> checked base 10</summary>

```diff
1c1
<       .globl  _i8_checked_ilog10
---
>       .globl  _i8_checked_ilog_10
3,4c3,4
< _i8_checked_ilog10:
< Lfunc_begin7:
---
> _i8_checked_ilog_10:
> Lfunc_begin95:
```
</details>
<details><summary><tt>i8</tt> base 10</summary>

```diff
1c1
<       .globl  _i8_ilog10
---
>       .globl  _i8_ilog_10
3,4c3,4
< _i8_ilog10:
< Lfunc_begin20:
---
> _i8_ilog_10:
> Lfunc_begin30:
8c8
<       b.le LBB20_2
---
>       b.le LBB30_2
15c15
< LBB20_2:
---
> LBB30_2:
22c22
< Lloh20:
---
> Lloh34:
24c24
< Lloh21:
---
> Lloh35:
27c27
<       .loh AdrpAdd    Lloh20, Lloh21
---
>       .loh AdrpAdd    Lloh34, Lloh35
```
</details>
<details><summary><tt>i16</tt> checked base 10</summary>

```diff
1c1
<       .globl  _i16_checked_ilog10
---
>       .globl  _i16_checked_ilog_10
3,4c3,4
< _i16_checked_ilog10:
< Lfunc_begin3:
---
> _i16_checked_ilog_10:
> Lfunc_begin1:
```
</details>
<details><summary><tt>i16</tt> base 10</summary>

```diff
1c1
<       .globl  _i16_ilog10
---
>       .globl  _i16_ilog_10
3,4c3,4
< _i16_ilog10:
< Lfunc_begin2:
---
> _i16_ilog_10:
> Lfunc_begin18:
8c8
<       b.le LBB2_2
---
>       b.le LBB18_2
23c23
< LBB2_2:
---
> LBB18_2:
30c30
< Lloh6:
---
> Lloh18:
32c32
< Lloh7:
---
> Lloh19:
35c35
<       .loh AdrpAdd    Lloh6, Lloh7
---
>       .loh AdrpAdd    Lloh18, Lloh19
```
</details>
<details><summary><tt>i32</tt> checked base 10</summary>

```diff
1c1
<       .globl  _i32_checked_ilog10
---
>       .globl  _i32_checked_ilog_10
3,4c3,4
< _i32_checked_ilog10:
< Lfunc_begin85:
---
> _i32_checked_ilog_10:
> Lfunc_begin70:
7c7
<       b.lt LBB85_2
---
>       b.lt LBB70_2
13d12
<       mov w10, #5
15d13
<       csel w9, w10, wzr, hi
16a15,16
>       mov w9, #5
>       csel w9, w9, wzr, hi
31c31
< LBB85_2:
---
> LBB70_2:
```
</details>
<details><summary><tt>i32</tt> base 10</summary>

```diff
1c1
<       .globl  _i32_ilog10
---
>       .globl  _i32_ilog_10
3,4c3,4
< _i32_ilog10:
< Lfunc_begin58:
---
> _i32_ilog_10:
> Lfunc_begin26:
6,7c6,7
<       cmp w0, #1
<       b.lt LBB58_2
---
>       cmp w0, #0
>       b.le LBB26_2
13d12
<       mov w10, #5
15d13
<       csel w9, w10, wzr, hi
16a15,16
>       mov w9, #5
>       csel w9, w9, wzr, hi
30c30
< LBB58_2:
---
> LBB26_2:
37c37
< Lloh70:
---
> Lloh28:
39c39
< Lloh71:
---
> Lloh29:
42c42
<       .loh AdrpAdd    Lloh70, Lloh71
---
>       .loh AdrpAdd    Lloh28, Lloh29
```
</details>
<details><summary><tt>i64</tt> checked base 10</summary>

```diff
1c1
<       .globl  _i64_checked_ilog10
---
>       .globl  _i64_checked_ilog_10
3,4c3,4
< _i64_checked_ilog10:
< Lfunc_begin60:
---
> _i64_checked_ilog_10:
> Lfunc_begin62:
7c7
<       b.lt LBB60_2
---
>       b.lt LBB62_2
47c47
< LBB60_2:
---
> LBB62_2:
```
</details>
<details><summary><tt>i64</tt> base 10</summary>

```diff
1c1
<       .globl  _i64_ilog10
---
>       .globl  _i64_ilog_10
3,4c3,4
< _i64_ilog10:
< Lfunc_begin8:
---
> _i64_ilog_10:
> Lfunc_begin5:
6,7c6,7
<       cmp x0, #0
<       b.le LBB8_2
---
>       cmp x0, #1
>       b.lt LBB5_2
20,21c20,21
<       csel w9, w10, wzr, hi
<       lsr x10, x8, #5
---
>       csel w10, w10, wzr, hi
>       lsr x9, x8, #5
26c26
<       umulh x11, x10, x11
---
>       umulh x11, x9, x11
29,33c29,33
<       orr w12, w9, w12
<       cmp x10, #3125
<       csel x8, x8, x11, lo
<       csel w9, w9, w12, lo
<       add w10, w8, #95, lsl #12
---
>       orr w12, w10, w12
>       cmp x9, #3125
>       csel x9, x8, x11, lo
>       csel w8, w10, w12, lo
>       add w10, w9, #95, lsl #12
35c35
<       add w11, w8, #127, lsl #12
---
>       add w11, w9, #127, lsl #12
38c38
<       add w11, w8, #223, lsl #12
---
>       add w11, w9, #223, lsl #12
40,44c40,44
<       add w8, w8, #125, lsl #12
<       add w8, w8, #2288
<       and w8, w11, w8
<       eor w8, w10, w8
<       add w0, w9, w8, lsr #17
---
>       add w9, w9, #125, lsl #12
>       add w9, w9, #2288
>       and w9, w11, w9
>       eor w9, w10, w9
>       add w0, w8, w9, lsr #17
46c46
< LBB8_2:
---
> LBB5_2:
53c53
< Lloh10:
---
> Lloh8:
55c55
< Lloh11:
---
> Lloh9:
58c58
<       .loh AdrpAdd    Lloh10, Lloh11
---
>       .loh AdrpAdd    Lloh8, Lloh9
```
</details>
<details><summary><tt>i128</tt> checked base 10</summary>

```diff
1c1
<       .globl  _i128_checked_ilog10
---
>       .globl  _i128_checked_ilog_10
3,4c3,4
< _i128_checked_ilog10:
< Lfunc_begin55:
---
> _i128_checked_ilog_10:
> Lfunc_begin40:
8c8
<       b.lt LBB55_3
---
>       b.lt LBB40_3
40c40
<       b.hs LBB55_4
---
>       b.hs LBB40_4
65,66c65,66
<       b LBB55_5
< LBB55_3:
---
>       b LBB40_5
> LBB40_3:
78c78
< LBB55_4:
---
> LBB40_4:
129c129
< LBB55_5:
---
> LBB40_5:
```
</details>
<details><summary><tt>i128</tt> base 10</summary>

```diff
1c1
<       .globl  _i128_ilog10
---
>       .globl  _i128_ilog_10
3,4c3,4
< _i128_ilog10:
< Lfunc_begin17:
---
> _i128_ilog_10:
> Lfunc_begin15:
22,24c22,24
<       cmp xzr, x0
<       ngcs xzr, x1
<       b.ge LBB17_5
---
>       cmp x0, #1
>       sbcs xzr, x1, xzr
>       b.lt LBB15_5
40c40
<       b.hs LBB17_3
---
>       b.hs LBB15_3
65,66c65,66
<       b LBB17_4
< LBB17_3:
---
>       b LBB15_4
> LBB15_3:
116c116
< LBB17_4:
---
> LBB15_4:
132c132
< LBB17_5:
---
> LBB15_5:
134c134
< Lloh16:
---
> Lloh14:
136c136
< Lloh17:
---
> Lloh15:
139c139
<       .loh AdrpAdd    Lloh16, Lloh17
---
>       .loh AdrpAdd    Lloh14, Lloh15
```
</details>
<details><summary><tt>isize</tt> checked base 10</summary>

```asm
7783: .globl  _isize_checked_ilog_10
7784:_isize_checked_ilog_10 = _i64_checked_ilog_10
7813: .globl  _isize_checked_ilog10
7814:_isize_checked_ilog10 = _i64_checked_ilog10
```
</details>
<details><summary><tt>isize</tt> base 10</summary>

```asm
7761: .globl  _isize_ilog10
7762:_isize_ilog10 = _i64_ilog10
7775: .globl  _isize_ilog_10
7776:_isize_ilog_10 = _i64_ilog_10
```
</details>
<details><summary><tt>u8</tt> checked base 10</summary>

```asm
7835: .globl  _u8_checked_ilog_10
7836:_u8_checked_ilog_10 = _u8_checked_ilog10
```
</details>
<details><summary><tt>u8</tt> base 10</summary>

```asm
7811: .globl  _u8_ilog_10
7812:_u8_ilog_10 = _u8_ilog10
```
</details>
<details><summary><tt>u16</tt> checked base 10</summary>

```asm
7777: .globl  _u16_checked_ilog_10
7778:_u16_checked_ilog_10 = _u16_checked_ilog10
```
</details>
<details><summary><tt>u16</tt> base 10</summary>

```asm
7757: .globl  _u16_ilog_10
7758:_u16_ilog_10 = _u16_ilog10
```
</details>
<details><summary><tt>u32</tt> checked base 10</summary>

```asm
7815: .globl  _u32_checked_ilog_10
7816:_u32_checked_ilog_10 = _u32_checked_ilog10
```
</details>
<details><summary><tt>u32</tt> base 10</summary>

```asm
7763: .globl  _u32_ilog_10
7764:_u32_ilog_10 = _u32_ilog10
```
</details>
<details><summary><tt>u64</tt> checked base 10</summary>

```asm
7779: .globl  _u64_checked_ilog_10
7780:_u64_checked_ilog_10 = _u64_checked_ilog10
```
</details>
<details><summary><tt>u64</tt> base 10</summary>

```asm
7771: .globl  _u64_ilog_10
7772:_u64_ilog_10 = _u64_ilog10
```
</details>
<details><summary><tt>u128</tt> checked base 10</summary>

```asm
7833: .globl  _u128_checked_ilog_10
7834:_u128_checked_ilog_10 = _u128_checked_ilog10
```
</details>
<details><summary><tt>u128</tt> base 10</summary>

```diff
1c1
<       .globl  _u128_ilog10
---
>       .globl  _u128_ilog_10
3,4c3,4
< _u128_ilog10:
< Lfunc_begin100:
---
> _u128_ilog_10:
> Lfunc_begin29:
23c23
<       cbz x8, LBB100_5
---
>       cbz x8, LBB29_5
39c39
<       b.hs LBB100_3
---
>       b.hs LBB29_3
64,65c64,65
<       b LBB100_4
< LBB100_3:
---
>       b LBB29_4
> LBB29_3:
115c115
< LBB100_4:
---
> LBB29_4:
131c131
< LBB100_5:
---
> LBB29_5:
133c133
< Lloh140:
---
> Lloh32:
135c135
< Lloh141:
---
> Lloh33:
138c138
<       .loh AdrpAdd    Lloh140, Lloh141
---
>       .loh AdrpAdd    Lloh32, Lloh33
```
</details>
<details><summary><tt>usize</tt> checked base 10</summary>

```asm
7781: .globl  _usize_checked_ilog10
7782:_usize_checked_ilog10 = _u64_checked_ilog10
7785: .globl  _usize_checked_ilog_10
7786:_usize_checked_ilog_10 = _u64_checked_ilog10
```
</details>
<details><summary><tt>usize</tt> base 10</summary>

```asm
7769: .globl  _usize_ilog10
7770:_usize_ilog10 = _u64_ilog10
7773: .globl  _usize_ilog_10
7774:_usize_ilog_10 = _u64_ilog10
```
</details>

## Unknown base (compare nightly vs new to check that assembly stays the same)
<details><summary><tt>i8</tt> checked base unknown</summary>

```diff
4c4
< Lfunc_begin55:
---
> Lfunc_begin48:
10c10
<       b.ge LBB55_2
---
>       b.ge LBB48_2
13c13
< LBB55_2:
---
> LBB48_2:
17c17
<       b.hs LBB55_4
---
>       b.hs LBB48_4
21c21
< LBB55_4:
---
> LBB48_4:
26c26
<       b.hi LBB55_7
---
>       b.hi LBB48_7
28c28
< LBB55_6:
---
> LBB48_6:
32,33c32,33
<       b.hs LBB55_6
< LBB55_7:
---
>       b.hs LBB48_6
> LBB48_7:
```
</details>
<details><summary><tt>i8</tt> base unknown</summary>

```diff
0a1
> .section __TEXT,__text,regular,pure_instructions
4c5
< Lfunc_begin95:
---
> Lfunc_begin0:
16c17
<       b.le LBB95_8
---
>       b.le LBB0_9
19c20
<       b.lt LBB95_9
---
>       b.lt LBB0_8
22c23
<       b.hs LBB95_4
---
>       b.hs LBB0_4
24,25c25,26
<       b LBB95_7
< LBB95_4:
---
>       b LBB0_7
> LBB0_4:
30c31
<       b.hi LBB95_7
---
>       b.hi LBB0_7
32c33
< LBB95_6:
---
> LBB0_6:
36,37c37,38
<       b.hs LBB95_6
< LBB95_7:
---
>       b.hs LBB0_6
> LBB0_7:
45c46
< LBB95_8:
---
> LBB0_8:
47,50c48,57
< Lloh118:
<       adrp x8, l_anon.b1a6bf9626946dc5455dc8556bf70fc4.3@PAGE
< Lloh119:
<       add x8, x8, l_anon.b1a6bf9626946dc5455dc8556bf70fc4.3@PAGEOFF
---
> Lloh0:
>       adrp x0, l_anon.5342b09e6c75d1cc3f3f5bd2e914f963.1@PAGE
> Lloh1:
>       add x0, x0, l_anon.5342b09e6c75d1cc3f3f5bd2e914f963.1@PAGEOFF
>       bl core::num::int_log10::panic_for_nonpositive_argument
> LBB0_9:
> Lloh2:
>       adrp x8, l_anon.5342b09e6c75d1cc3f3f5bd2e914f963.3@PAGE
> Lloh3:
>       add x8, x8, l_anon.5342b09e6c75d1cc3f3f5bd2e914f963.3@PAGEOFF
56,59c63,66
< Lloh120:
<       adrp x1, l_anon.b1a6bf9626946dc5455dc8556bf70fc4.1@PAGE
< Lloh121:
<       add x1, x1, l_anon.b1a6bf9626946dc5455dc8556bf70fc4.1@PAGEOFF
---
> Lloh4:
>       adrp x1, l_anon.5342b09e6c75d1cc3f3f5bd2e914f963.1@PAGE
> Lloh5:
>       add x1, x1, l_anon.5342b09e6c75d1cc3f3f5bd2e914f963.1@PAGEOFF
62,70c69,71
< LBB95_9:
< Lloh122:
<       adrp x0, l_anon.b1a6bf9626946dc5455dc8556bf70fc4.1@PAGE
< Lloh123:
<       add x0, x0, l_anon.b1a6bf9626946dc5455dc8556bf70fc4.1@PAGEOFF
<       bl core::num::int_log10::panic_for_nonpositive_argument
<       .loh AdrpAdd    Lloh120, Lloh121
<       .loh AdrpAdd    Lloh118, Lloh119
<       .loh AdrpAdd    Lloh122, Lloh123
---
>       .loh AdrpAdd    Lloh0, Lloh1
>       .loh AdrpAdd    Lloh4, Lloh5
>       .loh AdrpAdd    Lloh2, Lloh3
```
</details>
<details><summary><tt>i16</tt> checked base unknown</summary>

```diff
4c4
< Lfunc_begin89:
---
> Lfunc_begin53:
10c10
<       b.ge LBB89_2
---
>       b.ge LBB53_2
13c13
< LBB89_2:
---
> LBB53_2:
17c17
<       b.hs LBB89_4
---
>       b.hs LBB53_4
21c21
< LBB89_4:
---
> LBB53_4:
26c26
<       b.hi LBB89_7
---
>       b.hi LBB53_7
28c28
< LBB89_6:
---
> LBB53_6:
32,33c32,33
<       b.hs LBB89_6
< LBB89_7:
---
>       b.hs LBB53_6
> LBB53_7:
```
</details>
<details><summary><tt>i16</tt> base unknown</summary>

```diff
4c4
< Lfunc_begin113:
---
> Lfunc_begin25:
16c16
<       b.le LBB113_8
---
>       b.le LBB25_9
19c19
<       b.lt LBB113_9
---
>       b.lt LBB25_8
22c22
<       b.hs LBB113_4
---
>       b.hs LBB25_4
24,25c24,25
<       b LBB113_7
< LBB113_4:
---
>       b LBB25_7
> LBB25_4:
30c30
<       b.hi LBB113_7
---
>       b.hi LBB25_7
32c32
< LBB113_6:
---
> LBB25_6:
36,37c36,37
<       b.hs LBB113_6
< LBB113_7:
---
>       b.hs LBB25_6
> LBB25_7:
45c45
< LBB113_8:
---
> LBB25_8:
47,50c47,56
< Lloh148:
<       adrp x8, l_anon.b1a6bf9626946dc5455dc8556bf70fc4.3@PAGE
< Lloh149:
<       add x8, x8, l_anon.b1a6bf9626946dc5455dc8556bf70fc4.3@PAGEOFF
---
> Lloh22:
>       adrp x0, l_anon.5342b09e6c75d1cc3f3f5bd2e914f963.1@PAGE
> Lloh23:
>       add x0, x0, l_anon.5342b09e6c75d1cc3f3f5bd2e914f963.1@PAGEOFF
>       bl core::num::int_log10::panic_for_nonpositive_argument
> LBB25_9:
> Lloh24:
>       adrp x8, l_anon.5342b09e6c75d1cc3f3f5bd2e914f963.3@PAGE
> Lloh25:
>       add x8, x8, l_anon.5342b09e6c75d1cc3f3f5bd2e914f963.3@PAGEOFF
56,59c62,65
< Lloh150:
<       adrp x1, l_anon.b1a6bf9626946dc5455dc8556bf70fc4.1@PAGE
< Lloh151:
<       add x1, x1, l_anon.b1a6bf9626946dc5455dc8556bf70fc4.1@PAGEOFF
---
> Lloh26:
>       adrp x1, l_anon.5342b09e6c75d1cc3f3f5bd2e914f963.1@PAGE
> Lloh27:
>       add x1, x1, l_anon.5342b09e6c75d1cc3f3f5bd2e914f963.1@PAGEOFF
62,70c68,70
< LBB113_9:
< Lloh152:
<       adrp x0, l_anon.b1a6bf9626946dc5455dc8556bf70fc4.1@PAGE
< Lloh153:
<       add x0, x0, l_anon.b1a6bf9626946dc5455dc8556bf70fc4.1@PAGEOFF
<       bl core::num::int_log10::panic_for_nonpositive_argument
<       .loh AdrpAdd    Lloh150, Lloh151
<       .loh AdrpAdd    Lloh148, Lloh149
<       .loh AdrpAdd    Lloh152, Lloh153
---
>       .loh AdrpAdd    Lloh22, Lloh23
>       .loh AdrpAdd    Lloh26, Lloh27
>       .loh AdrpAdd    Lloh24, Lloh25
```
</details>
<details><summary><tt>i32</tt> checked base unknown</summary>

```diff
4c4
< Lfunc_begin25:
---
> Lfunc_begin49:
9c9
<       b.lt LBB25_4
---
>       b.lt LBB49_4
12c12
<       b.lt LBB25_9
---
>       b.lt LBB49_9
14c14
<       b.hs LBB25_5
---
>       b.hs LBB49_5
16,17c16,17
<       b LBB25_8
< LBB25_4:
---
>       b LBB49_8
> LBB49_4:
19c19
< LBB25_5:
---
> LBB49_5:
23c23
<       b.hi LBB25_8
---
>       b.hi LBB49_8
25c25
< LBB25_7:
---
> LBB49_7:
29,30c29,30
<       b.ls LBB25_7
< LBB25_8:
---
>       b.ls LBB49_7
> LBB49_8:
32c32
< LBB25_9:
---
> LBB49_9:
```
</details>
<details><summary><tt>i32</tt> base unknown</summary>

```diff
4c4
< Lfunc_begin31:
---
> Lfunc_begin37:
15c15
<       b.le LBB31_8
---
>       b.le LBB37_9
17c17
<       b.lt LBB31_9
---
>       b.lt LBB37_8
19c19
<       b.hs LBB31_4
---
>       b.hs LBB37_4
21,22c21,22
<       b LBB31_7
< LBB31_4:
---
>       b LBB37_7
> LBB37_4:
26c26
<       b.hi LBB31_7
---
>       b.hi LBB37_7
28c28
< LBB31_6:
---
> LBB37_6:
32,33c32,33
<       b.ls LBB31_6
< LBB31_7:
---
>       b.ls LBB37_6
> LBB37_7:
41c41
< LBB31_8:
---
> LBB37_8:
43,46c43,52
< Lloh38:
<       adrp x8, l_anon.b1a6bf9626946dc5455dc8556bf70fc4.3@PAGE
< Lloh39:
<       add x8, x8, l_anon.b1a6bf9626946dc5455dc8556bf70fc4.3@PAGEOFF
---
> Lloh48:
>       adrp x0, l_anon.5342b09e6c75d1cc3f3f5bd2e914f963.1@PAGE
> Lloh49:
>       add x0, x0, l_anon.5342b09e6c75d1cc3f3f5bd2e914f963.1@PAGEOFF
>       bl core::num::int_log10::panic_for_nonpositive_argument
> LBB37_9:
> Lloh50:
>       adrp x8, l_anon.5342b09e6c75d1cc3f3f5bd2e914f963.3@PAGE
> Lloh51:
>       add x8, x8, l_anon.5342b09e6c75d1cc3f3f5bd2e914f963.3@PAGEOFF
52,55c58,61
< Lloh40:
<       adrp x1, l_anon.b1a6bf9626946dc5455dc8556bf70fc4.1@PAGE
< Lloh41:
<       add x1, x1, l_anon.b1a6bf9626946dc5455dc8556bf70fc4.1@PAGEOFF
---
> Lloh52:
>       adrp x1, l_anon.5342b09e6c75d1cc3f3f5bd2e914f963.1@PAGE
> Lloh53:
>       add x1, x1, l_anon.5342b09e6c75d1cc3f3f5bd2e914f963.1@PAGEOFF
58,66c64,66
< LBB31_9:
< Lloh42:
<       adrp x0, l_anon.b1a6bf9626946dc5455dc8556bf70fc4.1@PAGE
< Lloh43:
<       add x0, x0, l_anon.b1a6bf9626946dc5455dc8556bf70fc4.1@PAGEOFF
<       bl core::num::int_log10::panic_for_nonpositive_argument
<       .loh AdrpAdd    Lloh40, Lloh41
<       .loh AdrpAdd    Lloh38, Lloh39
<       .loh AdrpAdd    Lloh42, Lloh43
---
>       .loh AdrpAdd    Lloh48, Lloh49
>       .loh AdrpAdd    Lloh52, Lloh53
>       .loh AdrpAdd    Lloh50, Lloh51
```
</details>
<details><summary><tt>i64</tt> checked base unknown</summary>

```diff
4c4
< Lfunc_begin23:
---
> Lfunc_begin28:
9c9
<       b.lt LBB23_4
---
>       b.lt LBB28_4
12c12
<       b.lt LBB23_9
---
>       b.lt LBB28_9
14c14
<       b.hs LBB23_5
---
>       b.hs LBB28_5
16,17c16,17
<       b LBB23_8
< LBB23_4:
---
>       b LBB28_8
> LBB28_4:
19c19
< LBB23_5:
---
> LBB28_5:
23c23
<       b.hi LBB23_8
---
>       b.hi LBB28_8
25c25
< LBB23_7:
---
> LBB28_7:
29,30c29,30
<       b.ls LBB23_7
< LBB23_8:
---
>       b.ls LBB28_7
> LBB28_8:
32c32
< LBB23_9:
---
> LBB28_9:
```
</details>
<details><summary><tt>i64</tt> base unknown</summary>

```diff
4c4
< Lfunc_begin71:
---
> Lfunc_begin66:
15c15
<       b.le LBB71_8
---
>       b.le LBB66_9
17c17
<       b.lt LBB71_9
---
>       b.lt LBB66_8
19c19
<       b.hs LBB71_4
---
>       b.hs LBB66_4
21,22c21,22
<       b LBB71_7
< LBB71_4:
---
>       b LBB66_7
> LBB66_4:
26c26
<       b.hi LBB71_7
---
>       b.hi LBB66_7
28c28
< LBB71_6:
---
> LBB66_6:
32,33c32,33
<       b.ls LBB71_6
< LBB71_7:
---
>       b.ls LBB66_6
> LBB66_7:
41c41
< LBB71_8:
---
> LBB66_8:
43,46c43,52
< Lloh78:
<       adrp x8, l_anon.b1a6bf9626946dc5455dc8556bf70fc4.3@PAGE
< Lloh79:
<       add x8, x8, l_anon.b1a6bf9626946dc5455dc8556bf70fc4.3@PAGEOFF
---
> Lloh80:
>       adrp x0, l_anon.5342b09e6c75d1cc3f3f5bd2e914f963.1@PAGE
> Lloh81:
>       add x0, x0, l_anon.5342b09e6c75d1cc3f3f5bd2e914f963.1@PAGEOFF
>       bl core::num::int_log10::panic_for_nonpositive_argument
> LBB66_9:
> Lloh82:
>       adrp x8, l_anon.5342b09e6c75d1cc3f3f5bd2e914f963.3@PAGE
> Lloh83:
>       add x8, x8, l_anon.5342b09e6c75d1cc3f3f5bd2e914f963.3@PAGEOFF
52,55c58,61
< Lloh80:
<       adrp x1, l_anon.b1a6bf9626946dc5455dc8556bf70fc4.1@PAGE
< Lloh81:
<       add x1, x1, l_anon.b1a6bf9626946dc5455dc8556bf70fc4.1@PAGEOFF
---
> Lloh84:
>       adrp x1, l_anon.5342b09e6c75d1cc3f3f5bd2e914f963.1@PAGE
> Lloh85:
>       add x1, x1, l_anon.5342b09e6c75d1cc3f3f5bd2e914f963.1@PAGEOFF
58,63d63
< LBB71_9:
< Lloh82:
<       adrp x0, l_anon.b1a6bf9626946dc5455dc8556bf70fc4.1@PAGE
< Lloh83:
<       add x0, x0, l_anon.b1a6bf9626946dc5455dc8556bf70fc4.1@PAGEOFF
<       bl core::num::int_log10::panic_for_nonpositive_argument
65c65
<       .loh AdrpAdd    Lloh78, Lloh79
---
>       .loh AdrpAdd    Lloh84, Lloh85
```
</details>
<details><summary><tt>i128</tt> checked base unknown</summary>

```diff
4c4
< Lfunc_begin39:
---
> Lfunc_begin23:
24c24
<       b.lt LBB39_4
---
>       b.lt LBB23_4
27c27
<       b.lt LBB39_14
---
>       b.lt LBB23_14
30c30
<       b.hs LBB39_5
---
>       b.hs LBB23_5
32,35c32,35
<       b LBB39_13
< LBB39_4:
<       b LBB39_14
< LBB39_5:
---
>       b LBB23_13
> LBB23_4:
>       b LBB23_14
> LBB23_5:
53c53
<       b.hi LBB39_10
---
>       b.hi LBB23_10
57,58c57,58
<       b LBB39_8
< LBB39_7:
---
>       b LBB23_8
> LBB23_7:
65,66c65,66
< LBB39_8:
<       tbz w9, #0, LBB39_7
---
> LBB23_8:
>       tbz w9, #0, LBB23_7
72,73c72,73
<       b.ne LBB39_7
< LBB39_10:
---
>       b.ne LBB23_7
> LBB23_10:
79c79
<       b.lo LBB39_13
---
>       b.lo LBB23_13
82c82
< LBB39_12:
---
> LBB23_12:
90,91c90,91
<       b.hs LBB39_12
< LBB39_13:
---
>       b.hs LBB23_12
> LBB23_13:
93c93
< LBB39_14:
---
> LBB23_14:
```
</details>
<details><summary><tt>i128</tt> base unknown</summary>

```diff
4c4
< Lfunc_begin38:
---
> Lfunc_begin68:
26c26
<       b.ge LBB38_14
---
>       b.ge LBB68_14
29c29
<       b.lt LBB38_13
---
>       b.lt LBB68_13
32c32
<       b.hs LBB38_4
---
>       b.hs LBB68_4
34,35c34,35
<       b LBB38_12
< LBB38_4:
---
>       b LBB68_12
> LBB68_4:
53c53
<       b.hi LBB38_9
---
>       b.hi LBB68_9
57,58c57,58
<       b LBB38_7
< LBB38_6:
---
>       b LBB68_7
> LBB68_6:
65,66c65,66
< LBB38_7:
<       tbz w9, #0, LBB38_6
---
> LBB68_7:
>       tbz w9, #0, LBB68_6
72,73c72,73
<       b.ne LBB38_6
< LBB38_9:
---
>       b.ne LBB68_6
> LBB68_9:
79c79
<       b.lo LBB38_12
---
>       b.lo LBB68_12
82c82
< LBB38_11:
---
> LBB68_11:
90,91c90,91
<       b.hs LBB38_11
< LBB38_12:
---
>       b.hs LBB68_11
> LBB68_12:
109c109
< LBB38_13:
---
> LBB68_13:
111,114c111,114
< Lloh48:
<       adrp x0, l_anon.b1a6bf9626946dc5455dc8556bf70fc4.1@PAGE
< Lloh49:
<       add x0, x0, l_anon.b1a6bf9626946dc5455dc8556bf70fc4.1@PAGEOFF
---
> Lloh88:
>       adrp x0, l_anon.5342b09e6c75d1cc3f3f5bd2e914f963.1@PAGE
> Lloh89:
>       add x0, x0, l_anon.5342b09e6c75d1cc3f3f5bd2e914f963.1@PAGEOFF
116,120c116,120
< LBB38_14:
< Lloh50:
<       adrp x8, l_anon.b1a6bf9626946dc5455dc8556bf70fc4.3@PAGE
< Lloh51:
<       add x8, x8, l_anon.b1a6bf9626946dc5455dc8556bf70fc4.3@PAGEOFF
---
> LBB68_14:
> Lloh90:
>       adrp x8, l_anon.5342b09e6c75d1cc3f3f5bd2e914f963.3@PAGE
> Lloh91:
>       add x8, x8, l_anon.5342b09e6c75d1cc3f3f5bd2e914f963.3@PAGEOFF
126,129c126,129
< Lloh52:
<       adrp x1, l_anon.b1a6bf9626946dc5455dc8556bf70fc4.1@PAGE
< Lloh53:
<       add x1, x1, l_anon.b1a6bf9626946dc5455dc8556bf70fc4.1@PAGEOFF
---
> Lloh92:
>       adrp x1, l_anon.5342b09e6c75d1cc3f3f5bd2e914f963.1@PAGE
> Lloh93:
>       add x1, x1, l_anon.5342b09e6c75d1cc3f3f5bd2e914f963.1@PAGEOFF
132,134c132,134
<       .loh AdrpAdd    Lloh48, Lloh49
<       .loh AdrpAdd    Lloh52, Lloh53
<       .loh AdrpAdd    Lloh50, Lloh51
---
>       .loh AdrpAdd    Lloh88, Lloh89
>       .loh AdrpAdd    Lloh92, Lloh93
>       .loh AdrpAdd    Lloh90, Lloh91
```
</details>
<details><summary><tt>isize</tt> checked base unknown</summary>

```asm
7837: .globl  _isize_checked_ilog_unknown
7838:_isize_checked_ilog_unknown = _i64_checked_ilog_unknown
```
</details>
<details><summary><tt>isize</tt> base unknown</summary>

```asm
7803: .globl  _isize_ilog_unknown
7804:_isize_ilog_unknown = _i64_ilog_unknown
```
</details>
<details><summary><tt>u8</tt> checked base unknown</summary>

```diff
4c4
< Lfunc_begin34:
---
> Lfunc_begin90:
9c9
<       b.eq LBB34_4
---
>       b.eq LBB90_4
13c13
<       b.lo LBB34_9
---
>       b.lo LBB90_9
16c16
<       b.hs LBB34_5
---
>       b.hs LBB90_5
18,19c18,19
<       b LBB34_8
< LBB34_4:
---
>       b LBB90_8
> LBB90_4:
21c21
< LBB34_5:
---
> LBB90_5:
26c26
<       b.hi LBB34_8
---
>       b.hi LBB90_8
28c28
< LBB34_7:
---
> LBB90_7:
32,33c32,33
<       b.hs LBB34_7
< LBB34_8:
---
>       b.hs LBB90_7
> LBB90_8:
35c35
< LBB34_9:
---
> LBB90_9:
```
</details>
<details><summary><tt>u8</tt> base unknown</summary>

```diff
4c4
< Lfunc_begin104:
---
> Lfunc_begin84:
16c16
<       b.ls LBB104_9
---
>       b.ls LBB84_8
18c18
<       b.eq LBB104_8
---
>       b.eq LBB84_9
21c21
<       b.hs LBB104_4
---
>       b.hs LBB84_4
23,24c23,24
<       b LBB104_7
< LBB104_4:
---
>       b LBB84_7
> LBB84_4:
29c29
<       b.hi LBB104_7
---
>       b.hi LBB84_7
31c31
< LBB104_6:
---
> LBB84_6:
35,36c35,36
<       b.hs LBB104_6
< LBB104_7:
---
>       b.hs LBB84_6
> LBB84_7:
44c44
< LBB104_8:
---
> LBB84_8:
46,55c46,49
< Lloh136:
<       adrp x0, l_anon.b1a6bf9626946dc5455dc8556bf70fc4.1@PAGE
< Lloh137:
<       add x0, x0, l_anon.b1a6bf9626946dc5455dc8556bf70fc4.1@PAGEOFF
<       bl core::num::int_log10::panic_for_nonpositive_argument
< LBB104_9:
< Lloh138:
<       adrp x8, l_anon.b1a6bf9626946dc5455dc8556bf70fc4.3@PAGE
< Lloh139:
<       add x8, x8, l_anon.b1a6bf9626946dc5455dc8556bf70fc4.3@PAGEOFF
---
> Lloh110:
>       adrp x8, l_anon.5342b09e6c75d1cc3f3f5bd2e914f963.3@PAGE
> Lloh111:
>       add x8, x8, l_anon.5342b09e6c75d1cc3f3f5bd2e914f963.3@PAGEOFF
61,64c55,58
< Lloh140:
<       adrp x1, l_anon.b1a6bf9626946dc5455dc8556bf70fc4.1@PAGE
< Lloh141:
<       add x1, x1, l_anon.b1a6bf9626946dc5455dc8556bf70fc4.1@PAGEOFF
---
> Lloh112:
>       adrp x1, l_anon.5342b09e6c75d1cc3f3f5bd2e914f963.1@PAGE
> Lloh113:
>       add x1, x1, l_anon.5342b09e6c75d1cc3f3f5bd2e914f963.1@PAGEOFF
67,69c61,69
<       .loh AdrpAdd    Lloh136, Lloh137
<       .loh AdrpAdd    Lloh140, Lloh141
<       .loh AdrpAdd    Lloh138, Lloh139
---
> LBB84_9:
> Lloh114:
>       adrp x0, l_anon.5342b09e6c75d1cc3f3f5bd2e914f963.1@PAGE
> Lloh115:
>       add x0, x0, l_anon.5342b09e6c75d1cc3f3f5bd2e914f963.1@PAGEOFF
>       bl core::num::int_log10::panic_for_nonpositive_argument
>       .loh AdrpAdd    Lloh112, Lloh113
>       .loh AdrpAdd    Lloh110, Lloh111
>       .loh AdrpAdd    Lloh114, Lloh115
```
</details>
<details><summary><tt>u16</tt> checked base unknown</summary>

```diff
4c4
< Lfunc_begin56:
---
> Lfunc_begin9:
9c9
<       b.eq LBB56_4
---
>       b.eq LBB9_4
13c13
<       b.lo LBB56_9
---
>       b.lo LBB9_9
16c16
<       b.hs LBB56_5
---
>       b.hs LBB9_5
18,19c18,19
<       b LBB56_8
< LBB56_4:
---
>       b LBB9_8
> LBB9_4:
21c21
< LBB56_5:
---
> LBB9_5:
26c26
<       b.hi LBB56_8
---
>       b.hi LBB9_8
28c28
< LBB56_7:
---
> LBB9_7:
32,33c32,33
<       b.hs LBB56_7
< LBB56_8:
---
>       b.hs LBB9_7
> LBB9_8:
35c35
< LBB56_9:
---
> LBB9_9:
```
</details>
<details><summary><tt>u16</tt> base unknown</summary>

```diff
4c4
< Lfunc_begin9:
---
> Lfunc_begin61:
16c16
<       b.ls LBB9_9
---
>       b.ls LBB61_8
18c18
<       b.eq LBB9_8
---
>       b.eq LBB61_9
21c21
<       b.hs LBB9_4
---
>       b.hs LBB61_4
23,24c23,24
<       b LBB9_7
< LBB9_4:
---
>       b LBB61_7
> LBB61_4:
29c29
<       b.hi LBB9_7
---
>       b.hi LBB61_7
31c31
< LBB9_6:
---
> LBB61_6:
35,36c35,36
<       b.hs LBB9_6
< LBB9_7:
---
>       b.hs LBB61_6
> LBB61_7:
44c44
< LBB9_8:
---
> LBB61_8:
46,55c46,49
< Lloh8:
<       adrp x0, l_anon.b1a6bf9626946dc5455dc8556bf70fc4.1@PAGE
< Lloh9:
<       add x0, x0, l_anon.b1a6bf9626946dc5455dc8556bf70fc4.1@PAGEOFF
<       bl core::num::int_log10::panic_for_nonpositive_argument
< LBB9_9:
< Lloh10:
<       adrp x8, l_anon.b1a6bf9626946dc5455dc8556bf70fc4.3@PAGE
< Lloh11:
<       add x8, x8, l_anon.b1a6bf9626946dc5455dc8556bf70fc4.3@PAGEOFF
---
> Lloh72:
>       adrp x8, l_anon.5342b09e6c75d1cc3f3f5bd2e914f963.3@PAGE
> Lloh73:
>       add x8, x8, l_anon.5342b09e6c75d1cc3f3f5bd2e914f963.3@PAGEOFF
61,64c55,58
< Lloh12:
<       adrp x1, l_anon.b1a6bf9626946dc5455dc8556bf70fc4.1@PAGE
< Lloh13:
<       add x1, x1, l_anon.b1a6bf9626946dc5455dc8556bf70fc4.1@PAGEOFF
---
> Lloh74:
>       adrp x1, l_anon.5342b09e6c75d1cc3f3f5bd2e914f963.1@PAGE
> Lloh75:
>       add x1, x1, l_anon.5342b09e6c75d1cc3f3f5bd2e914f963.1@PAGEOFF
67,69c61,69
<       .loh AdrpAdd    Lloh8, Lloh9
<       .loh AdrpAdd    Lloh12, Lloh13
<       .loh AdrpAdd    Lloh10, Lloh11
---
> LBB61_9:
> Lloh76:
>       adrp x0, l_anon.5342b09e6c75d1cc3f3f5bd2e914f963.1@PAGE
> Lloh77:
>       add x0, x0, l_anon.5342b09e6c75d1cc3f3f5bd2e914f963.1@PAGEOFF
>       bl core::num::int_log10::panic_for_nonpositive_argument
>       .loh AdrpAdd    Lloh74, Lloh75
>       .loh AdrpAdd    Lloh72, Lloh73
>       .loh AdrpAdd    Lloh76, Lloh77
```
</details>
<details><summary><tt>u32</tt> checked base unknown</summary>

```diff
4c4
< Lfunc_begin43:
---
> Lfunc_begin79:
8c8
<       cbz w9, LBB43_4
---
>       cbz w9, LBB79_4
11c11
<       b.lo LBB43_9
---
>       b.lo LBB79_9
13c13
<       b.hs LBB43_5
---
>       b.hs LBB79_5
15,16c15,16
<       b LBB43_8
< LBB43_4:
---
>       b LBB79_8
> LBB79_4:
18c18
< LBB43_5:
---
> LBB79_5:
22c22
<       b.hi LBB43_8
---
>       b.hi LBB79_8
24c24
< LBB43_7:
---
> LBB79_7:
28,29c28,29
<       b.ls LBB43_7
< LBB43_8:
---
>       b.ls LBB79_7
> LBB79_8:
31c31
< LBB43_9:
---
> LBB79_9:
```
</details>
<details><summary><tt>u32</tt> base unknown</summary>

```diff
4c4
< Lfunc_begin28:
---
> Lfunc_begin89:
15,16c15,16
<       b.ls LBB28_9
<       cbz w0, LBB28_8
---
>       b.ls LBB89_8
>       cbz w0, LBB89_9
18c18
<       b.hs LBB28_4
---
>       b.hs LBB89_4
20,21c20,21
<       b LBB28_7
< LBB28_4:
---
>       b LBB89_7
> LBB89_4:
25c25
<       b.hi LBB28_7
---
>       b.hi LBB89_7
27c27
< LBB28_6:
---
> LBB89_6:
31,32c31,32
<       b.ls LBB28_6
< LBB28_7:
---
>       b.ls LBB89_6
> LBB89_7:
40c40
< LBB28_8:
---
> LBB89_8:
42,51c42,45
< Lloh30:
<       adrp x0, l_anon.b1a6bf9626946dc5455dc8556bf70fc4.1@PAGE
< Lloh31:
<       add x0, x0, l_anon.b1a6bf9626946dc5455dc8556bf70fc4.1@PAGEOFF
<       bl core::num::int_log10::panic_for_nonpositive_argument
< LBB28_9:
< Lloh32:
<       adrp x8, l_anon.b1a6bf9626946dc5455dc8556bf70fc4.3@PAGE
< Lloh33:
<       add x8, x8, l_anon.b1a6bf9626946dc5455dc8556bf70fc4.3@PAGEOFF
---
> Lloh120:
>       adrp x8, l_anon.5342b09e6c75d1cc3f3f5bd2e914f963.3@PAGE
> Lloh121:
>       add x8, x8, l_anon.5342b09e6c75d1cc3f3f5bd2e914f963.3@PAGEOFF
57,60c51,54
< Lloh34:
<       adrp x1, l_anon.b1a6bf9626946dc5455dc8556bf70fc4.1@PAGE
< Lloh35:
<       add x1, x1, l_anon.b1a6bf9626946dc5455dc8556bf70fc4.1@PAGEOFF
---
> Lloh122:
>       adrp x1, l_anon.5342b09e6c75d1cc3f3f5bd2e914f963.1@PAGE
> Lloh123:
>       add x1, x1, l_anon.5342b09e6c75d1cc3f3f5bd2e914f963.1@PAGEOFF
63,65c57,65
<       .loh AdrpAdd    Lloh30, Lloh31
<       .loh AdrpAdd    Lloh34, Lloh35
<       .loh AdrpAdd    Lloh32, Lloh33
---
> LBB89_9:
> Lloh124:
>       adrp x0, l_anon.5342b09e6c75d1cc3f3f5bd2e914f963.1@PAGE
> Lloh125:
>       add x0, x0, l_anon.5342b09e6c75d1cc3f3f5bd2e914f963.1@PAGEOFF
>       bl core::num::int_log10::panic_for_nonpositive_argument
>       .loh AdrpAdd    Lloh122, Lloh123
>       .loh AdrpAdd    Lloh120, Lloh121
>       .loh AdrpAdd    Lloh124, Lloh125
```
</details>
<details><summary><tt>u64</tt> checked base unknown</summary>

```diff
4c4
< Lfunc_begin106:
---
> Lfunc_begin6:
8c8
<       cbz x9, LBB106_4
---
>       cbz x9, LBB6_4
11c11
<       b.lo LBB106_9
---
>       b.lo LBB6_9
13c13
<       b.hs LBB106_5
---
>       b.hs LBB6_5
15,16c15,16
<       b LBB106_8
< LBB106_4:
---
>       b LBB6_8
> LBB6_4:
18c18
< LBB106_5:
---
> LBB6_5:
22c22
<       b.hi LBB106_8
---
>       b.hi LBB6_8
24c24
< LBB106_7:
---
> LBB6_7:
28,29c28,29
<       b.ls LBB106_7
< LBB106_8:
---
>       b.ls LBB6_7
> LBB6_8:
31c31
< LBB106_9:
---
> LBB6_9:
```
</details>
<details><summary><tt>u64</tt> base unknown</summary>

```diff
4c4
< Lfunc_begin86:
---
> Lfunc_begin96:
15,16c15,16
<       b.ls LBB86_9
<       cbz x0, LBB86_8
---
>       b.ls LBB96_8
>       cbz x0, LBB96_9
18c18
<       b.hs LBB86_4
---
>       b.hs LBB96_4
20,21c20,21
<       b LBB86_7
< LBB86_4:
---
>       b LBB96_7
> LBB96_4:
25c25
<       b.hi LBB86_7
---
>       b.hi LBB96_7
27c27
< LBB86_6:
---
> LBB96_6:
31,32c31,32
<       b.ls LBB86_6
< LBB86_7:
---
>       b.ls LBB96_6
> LBB96_7:
40c40
< LBB86_8:
---
> LBB96_8:
42,51c42,45
< Lloh102:
<       adrp x0, l_anon.b1a6bf9626946dc5455dc8556bf70fc4.1@PAGE
< Lloh103:
<       add x0, x0, l_anon.b1a6bf9626946dc5455dc8556bf70fc4.1@PAGEOFF
<       bl core::num::int_log10::panic_for_nonpositive_argument
< LBB86_9:
< Lloh104:
<       adrp x8, l_anon.b1a6bf9626946dc5455dc8556bf70fc4.3@PAGE
< Lloh105:
<       add x8, x8, l_anon.b1a6bf9626946dc5455dc8556bf70fc4.3@PAGEOFF
---
> Lloh130:
>       adrp x8, l_anon.5342b09e6c75d1cc3f3f5bd2e914f963.3@PAGE
> Lloh131:
>       add x8, x8, l_anon.5342b09e6c75d1cc3f3f5bd2e914f963.3@PAGEOFF
57,60c51,54
< Lloh106:
<       adrp x1, l_anon.b1a6bf9626946dc5455dc8556bf70fc4.1@PAGE
< Lloh107:
<       add x1, x1, l_anon.b1a6bf9626946dc5455dc8556bf70fc4.1@PAGEOFF
---
> Lloh132:
>       adrp x1, l_anon.5342b09e6c75d1cc3f3f5bd2e914f963.1@PAGE
> Lloh133:
>       add x1, x1, l_anon.5342b09e6c75d1cc3f3f5bd2e914f963.1@PAGEOFF
63,65c57,65
<       .loh AdrpAdd    Lloh102, Lloh103
<       .loh AdrpAdd    Lloh106, Lloh107
<       .loh AdrpAdd    Lloh104, Lloh105
---
> LBB96_9:
> Lloh134:
>       adrp x0, l_anon.5342b09e6c75d1cc3f3f5bd2e914f963.1@PAGE
> Lloh135:
>       add x0, x0, l_anon.5342b09e6c75d1cc3f3f5bd2e914f963.1@PAGEOFF
>       bl core::num::int_log10::panic_for_nonpositive_argument
>       .loh AdrpAdd    Lloh132, Lloh133
>       .loh AdrpAdd    Lloh130, Lloh131
>       .loh AdrpAdd    Lloh134, Lloh135
```
</details>
<details><summary><tt>u128</tt> checked base unknown</summary>

```diff
4c4
< Lfunc_begin47:
---
> Lfunc_begin22:
23c23
<       cbz x9, LBB47_4
---
>       cbz x9, LBB22_4
26c26
<       b.lo LBB47_14
---
>       b.lo LBB22_14
29c29
<       b.hs LBB47_5
---
>       b.hs LBB22_5
31,34c31,34
<       b LBB47_13
< LBB47_4:
<       b LBB47_14
< LBB47_5:
---
>       b LBB22_13
> LBB22_4:
>       b LBB22_14
> LBB22_5:
52c52
<       b.hi LBB47_10
---
>       b.hi LBB22_10
56,57c56,57
<       b LBB47_8
< LBB47_7:
---
>       b LBB22_8
> LBB22_7:
64,65c64,65
< LBB47_8:
<       tbz w9, #0, LBB47_7
---
> LBB22_8:
>       tbz w9, #0, LBB22_7
71,72c71,72
<       b.ne LBB47_7
< LBB47_10:
---
>       b.ne LBB22_7
> LBB22_10:
78c78
<       b.lo LBB47_13
---
>       b.lo LBB22_13
81c81
< LBB47_12:
---
> LBB22_12:
89,90c89,90
<       b.hs LBB47_12
< LBB47_13:
---
>       b.hs LBB22_12
> LBB22_13:
92c92
< LBB47_14:
---
> LBB22_14:
```
</details>
<details><summary><tt>u128</tt> base unknown</summary>

```diff
4c4
< Lfunc_begin52:
---
> Lfunc_begin32:
26c26
<       b.hs LBB52_13
---
>       b.hs LBB32_13
28c28
<       cbz x8, LBB52_14
---
>       cbz x8, LBB32_14
31c31
<       b.hs LBB52_4
---
>       b.hs LBB32_4
33,34c33,34
<       b LBB52_12
< LBB52_4:
---
>       b LBB32_12
> LBB32_4:
52c52
<       b.hi LBB52_9
---
>       b.hi LBB32_9
56,57c56,57
<       b LBB52_7
< LBB52_6:
---
>       b LBB32_7
> LBB32_6:
64,65c64,65
< LBB52_7:
<       tbz w9, #0, LBB52_6
---
> LBB32_7:
>       tbz w9, #0, LBB32_6
71,72c71,72
<       b.ne LBB52_6
< LBB52_9:
---
>       b.ne LBB32_6
> LBB32_9:
78c78
<       b.lo LBB52_12
---
>       b.lo LBB32_12
81c81
< LBB52_11:
---
> LBB32_11:
89,90c89,90
<       b.hs LBB52_11
< LBB52_12:
---
>       b.hs LBB32_11
> LBB32_12:
108c108
< LBB52_13:
---
> LBB32_13:
110,113c110,113
< Lloh62:
<       adrp x8, l_anon.b1a6bf9626946dc5455dc8556bf70fc4.3@PAGE
< Lloh63:
<       add x8, x8, l_anon.b1a6bf9626946dc5455dc8556bf70fc4.3@PAGEOFF
---
> Lloh36:
>       adrp x8, l_anon.5342b09e6c75d1cc3f3f5bd2e914f963.3@PAGE
> Lloh37:
>       add x8, x8, l_anon.5342b09e6c75d1cc3f3f5bd2e914f963.3@PAGEOFF
119,122c119,122
< Lloh64:
<       adrp x1, l_anon.b1a6bf9626946dc5455dc8556bf70fc4.1@PAGE
< Lloh65:
<       add x1, x1, l_anon.b1a6bf9626946dc5455dc8556bf70fc4.1@PAGEOFF
---
> Lloh38:
>       adrp x1, l_anon.5342b09e6c75d1cc3f3f5bd2e914f963.1@PAGE
> Lloh39:
>       add x1, x1, l_anon.5342b09e6c75d1cc3f3f5bd2e914f963.1@PAGEOFF
125,129c125,129
< LBB52_14:
< Lloh66:
<       adrp x0, l_anon.b1a6bf9626946dc5455dc8556bf70fc4.1@PAGE
< Lloh67:
<       add x0, x0, l_anon.b1a6bf9626946dc5455dc8556bf70fc4.1@PAGEOFF
---
> LBB32_14:
> Lloh40:
>       adrp x0, l_anon.5342b09e6c75d1cc3f3f5bd2e914f963.1@PAGE
> Lloh41:
>       add x0, x0, l_anon.5342b09e6c75d1cc3f3f5bd2e914f963.1@PAGEOFF
131,133c131,133
<       .loh AdrpAdd    Lloh64, Lloh65
<       .loh AdrpAdd    Lloh62, Lloh63
<       .loh AdrpAdd    Lloh66, Lloh67
---
>       .loh AdrpAdd    Lloh38, Lloh39
>       .loh AdrpAdd    Lloh36, Lloh37
>       .loh AdrpAdd    Lloh40, Lloh41
```
</details>
<details><summary><tt>usize</tt> checked base unknown</summary>

```asm
7839: .globl  _usize_checked_ilog_unknown
7840:_usize_checked_ilog_unknown = _u64_checked_ilog_unknown
```
</details>
<details><summary><tt>usize</tt> base unknown</summary>

```asm
7805: .globl  _usize_ilog_unknown
7806:_usize_ilog_unknown = _u64_ilog_unknown
```
</details>
</details>

<!-- homu-ignore:end -->
