### PR TITLE
Remove profile section from Clippy

### DIFF
--- a/src/tools/clippy/Cargo.toml
+++ b/src/tools/clippy/Cargo.toml
@@ -65,13 +65,6 @@ harness = false
 name = "dogfood"
 harness = false
 
-# quine-mc_cluskey makes up a significant part of the runtime in dogfood
-# due to the number of conditions in the clippy_lints crate
-# and enabling optimizations for that specific dependency helps a bit
-# without increasing total build times.
-[profile.dev.package.quine-mc_cluskey]
-opt-level = 3
-
 [lints.rust.unexpected_cfgs]
 level = "warn"
 check-cfg = ['cfg(bootstrap)']


### PR DESCRIPTION
To avoid workspace warnings.

[This](https://github.com/rust-lang/rust/pull/145749) subtree sync started causing warnings in Rust builds (https://github.com/rust-lang/rust/issues/145777) because of the `profile` section in Clippy's `Cargo.toml` file. This profile section was added in https://github.com/rust-lang/rust-clippy/pull/13408 last year, and since it also caused issues then, it was later reverted. However, this change recently reappeared in [this commit](https://github.com/rust-lang/rust-clippy/commit/90364dd178b074db391649eed504564ac26f77c1), so it is again causing issues for rust-lang/rust.

This PR removes the profile section again.

Fixes: https://github.com/rust-lang/rust/issues/145777