### PR TITLE
rustdoc: make attributes render consistently

### DIFF
--- a/src/librustdoc/html/templates/item_union.html
+++ b/src/librustdoc/html/templates/item_union.html
@@ -1,5 +1,4 @@
 <pre class="rust item-decl"><code>
-    {{ self.render_attributes_in_pre()|safe }}
     {{ self.render_union()|safe }}
 </code></pre>
 {% if !self.is_type_alias %}

--- a/tests/rustdoc/attribute-rendering.rs
+++ b/tests/rustdoc/attribute-rendering.rs
@@ -1,7 +1,8 @@
 #![crate_name = "foo"]
 
 //@ has 'foo/fn.f.html'
-//@ has - //*[@'class="rust item-decl"]' '#[unsafe(export_name = "f")] pub fn f()'
+//@ has - //*[@'class="code-attribute"]' '#[unsafe(export_name = "f")]'
+//@ has - //*[@'class="rust item-decl"]' 'pub fn f()'
 #[unsafe(export_name = "\
 f")]
 pub fn f() {}

--- a/tests/rustdoc/attributes.rs
+++ b/tests/rustdoc/attributes.rs
@@ -1,18 +1,77 @@
 //@ edition: 2024
 #![crate_name = "foo"]
 
-//@ has foo/fn.f.html '//pre[@class="rust item-decl"]' '#[unsafe(no_mangle)]'
+//@ has foo/fn.f.html '//*[@class="code-attribute"]' '#[unsafe(no_mangle)]'
 #[unsafe(no_mangle)]
 pub extern "C" fn f() {}
 
-//@ has foo/fn.g.html '//pre[@class="rust item-decl"]' '#[unsafe(export_name = "bar")]'
+//@ has foo/fn.g.html '//*[@class="code-attribute"]' '#[unsafe(export_name = "bar")]'
 #[unsafe(export_name = "bar")]
 pub extern "C" fn g() {}
 
-//@ has foo/fn.example.html '//pre[@class="rust item-decl"]' '#[unsafe(link_section = ".text")]'
+//@ has foo/fn.example.html '//*[@class="code-attribute"]' '#[unsafe(link_section = ".text")]'
 #[unsafe(link_section = ".text")]
 pub extern "C" fn example() {}
 
-//@ has foo/struct.Repr.html '//pre[@class="rust item-decl"]' '#[repr(C, align(8))]'
+//@ has foo/struct.Repr.html '//*[@class="code-attribute"]' '#[repr(C, align(8))]'
 #[repr(C, align(8))]
 pub struct Repr;
+
+//@ has foo/macro.macro_rule.html '//*[@class="code-attribute"]' '#[unsafe(link_section = ".text")]'
+#[unsafe(link_section = ".text")]
+#[macro_export]
+macro_rules! macro_rule {
+    () => {};
+}
+
+//@ has 'foo/enum.Enum.html' '//*[@class="code-attribute"]' '#[unsafe(link_section = "enum")]'
+#[unsafe(link_section = "enum")]
+pub enum Enum {
+    //@ has 'foo/enum.Enum.html' '//*[@class="code-attribute"]' '#[unsafe(link_section = "a")]'
+    #[unsafe(link_section = "a")]
+    A,
+    //@ has 'foo/enum.Enum.html' '//*[@class="code-attribute"]' '#[unsafe(link_section = "quz")]'
+    #[unsafe(link_section = "quz")]
+    Quz {
+        //@ has 'foo/enum.Enum.html' '//*[@class="code-attribute"]' '#[unsafe(link_section = "b")]'
+        #[unsafe(link_section = "b")]
+        b: (),
+    },
+}
+
+//@ has 'foo/trait.Trait.html' '//*[@class="code-attribute"]' '#[unsafe(link_section = "trait")]'
+#[unsafe(link_section = "trait")]
+pub trait Trait {
+    //@ has 'foo/trait.Trait.html'
+    //@ has - '//*[@id="associatedconstant.BAR"]/*[@class="code-header"]/*[@class="code-attribute"]' '#[unsafe(link_section = "bar")]'
+    //@ has - '//*[@id="associatedconstant.BAR"]/*[@class="code-header"]' 'const BAR: u32 = 0u32'
+    #[unsafe(link_section = "bar")]
+    const BAR: u32 = 0;
+
+    //@ has - '//*[@class="code-attribute"]' '#[unsafe(link_section = "foo")]'
+    #[unsafe(link_section = "foo")]
+    fn foo() {}
+}
+
+//@ has 'foo/union.Union.html' '//*[@class="code-attribute"]' '#[unsafe(link_section = "union")]'
+#[unsafe(link_section = "union")]
+pub union Union {
+    //@ has 'foo/union.Union.html' '//*[@class="code-attribute"]' '#[unsafe(link_section = "x")]'
+    #[unsafe(link_section = "x")]
+    pub x: u32,
+    y: f32,
+}
+
+//@ has 'foo/struct.Struct.html' '//*[@class="code-attribute"]' '#[unsafe(link_section = "struct")]'
+#[unsafe(link_section = "struct")]
+pub struct Struct {
+    //@ has 'foo/struct.Struct.html' '//*[@class="code-attribute"]' '#[unsafe(link_section = "x")]'
+    #[unsafe(link_section = "x")]
+    pub x: u32,
+    y: f32,
+}
+
+// Check that the attributes from the trait items show up consistently in the impl.
+//@ has 'foo/struct.Struct.html' '//*[@id="trait-implementations-list"]//*[@class="code-attribute"]' '#[unsafe(link_section = "bar")]'
+//@ has 'foo/struct.Struct.html' '//*[@id="trait-implementations-list"]//*[@class="code-attribute"]' '#[unsafe(link_section = "foo")]'
+impl Trait for Struct {}

--- a/tests/rustdoc/enum/enum-variant-non_exhaustive.type-alias-code.html
+++ b/tests/rustdoc/enum/enum-variant-non_exhaustive.type-alias-code.html
@@ -1,4 +1,4 @@
 <code>pub enum TypeAlias {
-    #[non_exhaustive]
+    <div class="code-attribute">#[non_exhaustive]</div>
     Variant,
 }</code>

--- a/tests/rustdoc/enum/enum-variant-non_exhaustive.type-code.html
+++ b/tests/rustdoc/enum/enum-variant-non_exhaustive.type-code.html
@@ -1,4 +1,4 @@
 <code>pub enum Type {
-    #[non_exhaustive]
+    <div class="code-attribute">#[non_exhaustive]</div>
     Variant,
 }</code>

--- a/tests/rustdoc/type-alias/repr.rs
+++ b/tests/rustdoc/type-alias/repr.rs
@@ -22,7 +22,8 @@ pub union Foo2 {
 }
 
 //@ has 'foo/type.Bar2.html'
-//@ matches - '//*[@class="rust item-decl"]' '#\[repr\(C\)\]\npub union Bar2 \{*'
+//@ matches - '//*[@class="code-attribute"]' '#\[repr\(C\)\]'
+//@ matches - '//*[@class="rust item-decl"]' 'pub union Bar2 \{*'
 // Ensures that we see the doc comment of the type alias and not of the aliased type.
 //@ has - '//*[@class="toggle top-doc"]/*[@class="docblock"]' 'bar'
 /// bar


### PR DESCRIPTION
While working on rust-lang/rust#132304, I discovered that even standard attributes aren't consistently rendered.
For some constructs/fields, attributes were missing entirely, and the attributes were only sometimes wrapped in a code-attribute divs so they appear greyed out.

In short this PR:
* makes attributes render inside code elements and inside divs with class `code-attribute`
* renders attributes for macros, associated constants, and struct/union fields

Attributes in `Fields` and `Variants` sections are still not rendered (see struct and enum screenshots), because I wasn't sure we want that.

[Compirison of tests/rustdoc/attributes.rs](https://github.com/karolzwolak/rust/blob/90aa25a1c5dbae1e94099b1a2015dfb83783dbe0/tests/rustdoc/attributes.rs)
Before (left) / after (right):

<img width="279" height="97" alt="image" src="https://github.com/user-attachments/assets/baca4b75-f809-4a76-8ac1-e3aa6389aad4" />
<img width="363" height="112" alt="image" src="https://github.com/user-attachments/assets/14970fb0-6fe5-474f-983e-5a95e16175c5" />

<img width="368" height="492" alt="image" src="https://github.com/user-attachments/assets/f9a25583-10e3-49c7-961b-34f3587b552e" />
<img width="415" height="515" alt="image" src="https://github.com/user-attachments/assets/f2fe4aa0-c731-4f2f-a3c2-04e524a858d1" />

<img width="383" height="483" alt="image" src="https://github.com/user-attachments/assets/bccc1b6e-f236-4948-8557-f9b25cad8a07" />
<img width="402" height="528" alt="image" src="https://github.com/user-attachments/assets/2cea9250-37e1-439e-8010-0603905d0f52" />

<img width="372" height="485" alt="image" src="https://github.com/user-attachments/assets/cd49bc0a-90e1-4d08-af0f-084c42af1834" />
<img width="406" height="542" alt="image" src="https://github.com/user-attachments/assets/67fb4ac7-746b-4e20-9c80-97702a71def8" />

<img width="357" height="131" alt="image" src="https://github.com/user-attachments/assets/42769532-1e4d-486d-bdca-6ecc409554b9" />
<img width="366" height="161" alt="image" src="https://github.com/user-attachments/assets/0b4d01d4-dd8e-4467-8cfc-ad58200ba0d7" />

<img width="291" height="65" alt="image" src="https://github.com/user-attachments/assets/43f61335-8eff-491b-a297-1953d17bbfc0" />
<img width="259" height="57" alt="image" src="https://github.com/user-attachments/assets/598618a3-e52f-4a4e-b790-2c8d5f1b4c77" />

r? @GuillaumeGomez