### PR TITLE
Fix ICE when validating transmuting ZST to inhabited enum

### DIFF
--- a/tests/ui/mir/validate/ice-zst-as-discr-145786.rs
+++ b/tests/ui/mir/validate/ice-zst-as-discr-145786.rs
@@ -1,0 +1,14 @@
+// Do not attempt to take the discriminant as the source
+// converted to a `u128`, that won't work for ZST.
+//
+//@ compile-flags: -Zvalidate-mir
+
+enum A {
+    B,
+    C,
+}
+
+fn main() {
+    let _: A = unsafe { std::mem::transmute(()) };
+    //~^ ERROR cannot transmute between types of different sizes, or dependently-sized types
+}

--- a/tests/ui/mir/validate/ice-zst-as-discr-145786.stderr
+++ b/tests/ui/mir/validate/ice-zst-as-discr-145786.stderr
@@ -1,0 +1,12 @@
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+  --> $DIR/ice-zst-as-discr-145786.rs:12:25
+   |
+LL |     let _: A = unsafe { std::mem::transmute(()) };
+   |                         ^^^^^^^^^^^^^^^^^^^
+   |
+   = note: source type: `()` (0 bits)
+   = note: target type: `A` (8 bits)
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0512`.


### PR DESCRIPTION
MIR validation attempts to determine the number of bytes needed to represent the size of the source type to compute the discriminant for the inhabited target enum. For a ZST source, there is no source data to use as a discriminant so no proper runtime check can be generated.

Since that should never be possible, insert a delayed bug to ensure the problem has been properly reported to the user by the type checker.

Fixes rust-lang/rust#145786 