### PR TITLE
std library: use execinfo library also on NetBSD.

### DIFF
--- a/library/std/src/sys/pal/unix/mod.rs
+++ b/library/std/src/sys/pal/unix/mod.rs
@@ -382,6 +382,7 @@ cfg_select! {
         unsafe extern "C" {}
     }
     target_os = "netbsd" => {
+        #[link(name = "execinfo")]
         #[link(name = "pthread")]
         #[link(name = "rt")]
         unsafe extern "C" {}


### PR DESCRIPTION
The execinfo library is also available on NetBSD.
