### PR TITLE
When suggesting trait bounds, use fully-qualified path

### DIFF
--- a/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
@@ -28,7 +28,7 @@ use rustc_middle::traits::IsConstable;
 use rustc_middle::ty::error::TypeError;
 use rustc_middle::ty::print::{
     PrintPolyTraitPredicateExt as _, PrintPolyTraitRefExt, PrintTraitPredicateExt as _,
-    with_forced_trimmed_paths, with_no_trimmed_paths, with_types_for_suggestion,
+    with_crate_prefix, with_forced_trimmed_paths, with_no_trimmed_paths, with_types_for_suggestion,
 };
 use rustc_middle::ty::{
     self, AdtKind, GenericArgs, InferTy, IsSuggestable, Ty, TyCtxt, TypeFoldable, TypeFolder,
@@ -221,15 +221,24 @@ pub fn suggest_restriction<'tcx, G: EmissionGuarantee>(
             (_, None) => predicate_constraint(hir_generics, trait_pred.upcast(tcx)),
             (None, Some((ident, []))) => (
                 ident.span.shrink_to_hi(),
-                format!(": {}", trait_pred.print_modifiers_and_trait_path()),
+                with_crate_prefix!(with_no_trimmed_paths!(format!(
+                    ": {}",
+                    trait_pred.print_modifiers_and_trait_path()
+                ))),
             ),
             (_, Some((_, [.., bounds]))) => (
                 bounds.span().shrink_to_hi(),
-                format!(" + {}", trait_pred.print_modifiers_and_trait_path()),
+                with_crate_prefix!(with_no_trimmed_paths!(format!(
+                    " + {}",
+                    trait_pred.print_modifiers_and_trait_path()
+                ))),
             ),
             (Some(_), Some((_, []))) => (
                 hir_generics.span.shrink_to_hi(),
-                format!(": {}", trait_pred.print_modifiers_and_trait_path()),
+                with_crate_prefix!(with_no_trimmed_paths!(format!(
+                    ": {}",
+                    trait_pred.print_modifiers_and_trait_path()
+                ))),
             ),
         };
 
@@ -384,9 +393,10 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     }
                     // Missing generic type parameter bound.
                     let param_name = self_ty.to_string();
-                    let mut constraint = with_no_trimmed_paths!(
-                        trait_pred.print_modifiers_and_trait_path().to_string()
-                    );
+                    let mut constraint = with_crate_prefix!(with_no_trimmed_paths!(format!(
+                        "{}",
+                        trait_pred.print_modifiers_and_trait_path()
+                    )));
 
                     if let Some((name, term)) = associated_ty {
                         // FIXME: this case overlaps with code in TyCtxt::note_and_explain_type_err.

--- a/tests/ui/associated-types/defaults-unsound-62211-1.current.stderr
+++ b/tests/ui/associated-types/defaults-unsound-62211-1.current.stderr
@@ -27,8 +27,8 @@ LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + Fro
    |                                               ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `UncheckedCopy::Output`
 help: consider further restricting `Self`
    |
-LL | trait UncheckedCopy: Sized + AddAssign<&'static str> {
-   |                            +++++++++++++++++++++++++
+LL | trait UncheckedCopy: Sized + std::ops::AddAssign<&'static str> {
+   |                            +++++++++++++++++++++++++++++++++++
 
 error[E0277]: the trait bound `Self: Deref` is not satisfied
   --> $DIR/defaults-unsound-62211-1.rs:24:96
@@ -43,8 +43,8 @@ LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + Fro
    |                         ^^^^^^^^^^^^^^^^^^^ required by this bound in `UncheckedCopy::Output`
 help: consider further restricting `Self`
    |
-LL | trait UncheckedCopy: Sized + Deref {
-   |                            +++++++
+LL | trait UncheckedCopy: Sized + std::ops::Deref {
+   |                            +++++++++++++++++
 
 error[E0277]: the trait bound `Self: Copy` is not satisfied
   --> $DIR/defaults-unsound-62211-1.rs:24:96
@@ -59,8 +59,8 @@ LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + Fro
    |                  ^^^^ required by this bound in `UncheckedCopy::Output`
 help: consider further restricting `Self`
    |
-LL | trait UncheckedCopy: Sized + Copy {
-   |                            ++++++
+LL | trait UncheckedCopy: Sized + std::marker::Copy {
+   |                            +++++++++++++++++++
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/associated-types/defaults-unsound-62211-1.next.stderr
+++ b/tests/ui/associated-types/defaults-unsound-62211-1.next.stderr
@@ -27,8 +27,8 @@ LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + Fro
    |                                               ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `UncheckedCopy::Output`
 help: consider further restricting `Self`
    |
-LL | trait UncheckedCopy: Sized + AddAssign<&'static str> {
-   |                            +++++++++++++++++++++++++
+LL | trait UncheckedCopy: Sized + std::ops::AddAssign<&'static str> {
+   |                            +++++++++++++++++++++++++++++++++++
 
 error[E0277]: the trait bound `Self: Deref` is not satisfied
   --> $DIR/defaults-unsound-62211-1.rs:24:96
@@ -43,8 +43,8 @@ LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + Fro
    |                               ^^^^^^^^^^^^ required by this bound in `UncheckedCopy::Output`
 help: consider further restricting `Self`
    |
-LL | trait UncheckedCopy: Sized + Deref {
-   |                            +++++++
+LL | trait UncheckedCopy: Sized + std::ops::Deref {
+   |                            +++++++++++++++++
 
 error[E0277]: the trait bound `Self: Copy` is not satisfied
   --> $DIR/defaults-unsound-62211-1.rs:24:96
@@ -59,8 +59,8 @@ LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + Fro
    |                  ^^^^ required by this bound in `UncheckedCopy::Output`
 help: consider further restricting `Self`
    |
-LL | trait UncheckedCopy: Sized + Copy {
-   |                            ++++++
+LL | trait UncheckedCopy: Sized + std::marker::Copy {
+   |                            +++++++++++++++++++
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/associated-types/defaults-unsound-62211-2.current.stderr
+++ b/tests/ui/associated-types/defaults-unsound-62211-2.current.stderr
@@ -27,8 +27,8 @@ LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + Fro
    |                                               ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `UncheckedCopy::Output`
 help: consider further restricting `Self`
    |
-LL | trait UncheckedCopy: Sized + AddAssign<&'static str> {
-   |                            +++++++++++++++++++++++++
+LL | trait UncheckedCopy: Sized + std::ops::AddAssign<&'static str> {
+   |                            +++++++++++++++++++++++++++++++++++
 
 error[E0277]: the trait bound `Self: Deref` is not satisfied
   --> $DIR/defaults-unsound-62211-2.rs:24:96
@@ -43,8 +43,8 @@ LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + Fro
    |                         ^^^^^^^^^^^^^^^^^^^ required by this bound in `UncheckedCopy::Output`
 help: consider further restricting `Self`
    |
-LL | trait UncheckedCopy: Sized + Deref {
-   |                            +++++++
+LL | trait UncheckedCopy: Sized + std::ops::Deref {
+   |                            +++++++++++++++++
 
 error[E0277]: the trait bound `Self: Copy` is not satisfied
   --> $DIR/defaults-unsound-62211-2.rs:24:96
@@ -59,8 +59,8 @@ LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + Fro
    |                  ^^^^ required by this bound in `UncheckedCopy::Output`
 help: consider further restricting `Self`
    |
-LL | trait UncheckedCopy: Sized + Copy {
-   |                            ++++++
+LL | trait UncheckedCopy: Sized + std::marker::Copy {
+   |                            +++++++++++++++++++
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/associated-types/defaults-unsound-62211-2.next.stderr
+++ b/tests/ui/associated-types/defaults-unsound-62211-2.next.stderr
@@ -27,8 +27,8 @@ LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + Fro
    |                                               ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `UncheckedCopy::Output`
 help: consider further restricting `Self`
    |
-LL | trait UncheckedCopy: Sized + AddAssign<&'static str> {
-   |                            +++++++++++++++++++++++++
+LL | trait UncheckedCopy: Sized + std::ops::AddAssign<&'static str> {
+   |                            +++++++++++++++++++++++++++++++++++
 
 error[E0277]: the trait bound `Self: Deref` is not satisfied
   --> $DIR/defaults-unsound-62211-2.rs:24:96
@@ -43,8 +43,8 @@ LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + Fro
    |                               ^^^^^^^^^^^^ required by this bound in `UncheckedCopy::Output`
 help: consider further restricting `Self`
    |
-LL | trait UncheckedCopy: Sized + Deref {
-   |                            +++++++
+LL | trait UncheckedCopy: Sized + std::ops::Deref {
+   |                            +++++++++++++++++
 
 error[E0277]: the trait bound `Self: Copy` is not satisfied
   --> $DIR/defaults-unsound-62211-2.rs:24:96
@@ -59,8 +59,8 @@ LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + Fro
    |                  ^^^^ required by this bound in `UncheckedCopy::Output`
 help: consider further restricting `Self`
    |
-LL | trait UncheckedCopy: Sized + Copy {
-   |                            ++++++
+LL | trait UncheckedCopy: Sized + std::marker::Copy {
+   |                            +++++++++++++++++++
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/associated-types/issue-63593.current.stderr
+++ b/tests/ui/associated-types/issue-63593.current.stderr
@@ -11,8 +11,8 @@ LL |     type This = Self;
    |     ^^^^^^^^^^^^^^^^^ required by this bound in `MyTrait::This`
 help: consider further restricting `Self`
    |
-LL | trait MyTrait: Sized {
-   |              +++++++
+LL | trait MyTrait: std::marker::Sized {
+   |              ++++++++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/associated-types/issue-63593.next.stderr
+++ b/tests/ui/associated-types/issue-63593.next.stderr
@@ -11,8 +11,8 @@ LL |     type This = Self;
    |     ^^^^^^^^^^^^^^^^^ required by this bound in `MyTrait::This`
 help: consider further restricting `Self`
    |
-LL | trait MyTrait: Sized {
-   |              +++++++
+LL | trait MyTrait: std::marker::Sized {
+   |              ++++++++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/associated-types/trait-with-supertraits-needing-sized-self.stderr
+++ b/tests/ui/associated-types/trait-with-supertraits-needing-sized-self.stderr
@@ -8,8 +8,8 @@ note: required by an implicit `Sized` bound in `Add`
   --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
 help: consider further restricting `Self`
    |
-LL | trait ArithmeticOps: Add<Output=Self> + Sub<Output=Self> + Mul<Output=Self> + Div<Output=Self> + Sized {}
-   |                                                                                                +++++++
+LL | trait ArithmeticOps: Add<Output=Self> + Sub<Output=Self> + Mul<Output=Self> + Div<Output=Self> + std::marker::Sized {}
+   |                                                                                                ++++++++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/dyn-compatibility/supertrait-mentions-Self.stderr
+++ b/tests/ui/dyn-compatibility/supertrait-mentions-Self.stderr
@@ -11,8 +11,8 @@ LL | trait Bar<T> {
    |           ^ required by the implicit `Sized` requirement on this type parameter in `Bar`
 help: consider further restricting `Self`
    |
-LL | trait Baz : Bar<Self> + Sized {
-   |                       +++++++
+LL | trait Baz : Bar<Self> + std::marker::Sized {
+   |                       ++++++++++++++++++++
 help: consider relaxing the implicit `Sized` restriction
    |
 LL | trait Bar<T: ?Sized> {

--- a/tests/ui/generic-associated-types/issue-74816.current.stderr
+++ b/tests/ui/generic-associated-types/issue-74816.current.stderr
@@ -27,8 +27,8 @@ LL |     type Associated: Trait1 = Self;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `Trait2::Associated`
 help: consider further restricting `Self`
    |
-LL | trait Trait2: Sized {
-   |             +++++++
+LL | trait Trait2: std::marker::Sized {
+   |             ++++++++++++++++++++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/generic-associated-types/issue-74816.next.stderr
+++ b/tests/ui/generic-associated-types/issue-74816.next.stderr
@@ -27,8 +27,8 @@ LL |     type Associated: Trait1 = Self;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `Trait2::Associated`
 help: consider further restricting `Self`
    |
-LL | trait Trait2: Sized {
-   |             +++++++
+LL | trait Trait2: std::marker::Sized {
+   |             ++++++++++++++++++++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/suggestions/bound-suggestions.fixed
+++ b/tests/ui/suggestions/bound-suggestions.fixed
@@ -1,73 +1,75 @@
 //@ run-rustfix
+//@ edition:2018
 
-#[allow(unused)]
+#![allow(unused)]
+
 use std::fmt::Debug;
 // Rustfix should add this, or use `std::fmt::Debug` instead.
 
-#[allow(dead_code)]
 fn test_impl(t: impl Sized + std::fmt::Debug) {
     println!("{:?}", t);
     //~^ ERROR doesn't implement
 }
 
-#[allow(dead_code)]
 fn test_no_bounds<T: std::fmt::Debug>(t: T) {
     println!("{:?}", t);
     //~^ ERROR doesn't implement
 }
 
-#[allow(dead_code)]
 fn test_one_bound<T: Sized + std::fmt::Debug>(t: T) {
     println!("{:?}", t);
     //~^ ERROR doesn't implement
 }
 
-#[allow(dead_code)]
 fn test_no_bounds_where<X, Y>(x: X, y: Y) where X: std::fmt::Debug, Y: std::fmt::Debug {
     println!("{:?} {:?}", x, y);
     //~^ ERROR doesn't implement
 }
 
-#[allow(dead_code)]
 fn test_one_bound_where<X>(x: X) where X: Sized + std::fmt::Debug {
     println!("{:?}", x);
     //~^ ERROR doesn't implement
 }
 
-#[allow(dead_code)]
 fn test_many_bounds_where<X>(x: X) where X: Sized + std::fmt::Debug, X: Sized {
     println!("{:?}", x);
     //~^ ERROR doesn't implement
 }
 
-#[allow(dead_code)]
-trait Foo<T>: Sized {
+trait Foo<T>: std::marker::Sized {
     const SIZE: usize = core::mem::size_of::<Self>();
     //~^ ERROR the size for values of type `Self` cannot be known at compilation time
 }
 
-#[allow(dead_code)]
-trait Bar: std::fmt::Display + Sized {
+trait Bar: std::fmt::Display + std::marker::Sized {
     const SIZE: usize = core::mem::size_of::<Self>();
     //~^ ERROR the size for values of type `Self` cannot be known at compilation time
 }
 
-#[allow(dead_code)]
-trait Baz: Sized where Self: std::fmt::Display {
+trait Baz: std::marker::Sized where Self: std::fmt::Display {
     const SIZE: usize = core::mem::size_of::<Self>();
     //~^ ERROR the size for values of type `Self` cannot be known at compilation time
 }
 
-#[allow(dead_code)]
-trait Qux<T>: Sized where Self: std::fmt::Display {
+trait Qux<T>: std::marker::Sized where Self: std::fmt::Display {
     const SIZE: usize = core::mem::size_of::<Self>();
     //~^ ERROR the size for values of type `Self` cannot be known at compilation time
 }
 
-#[allow(dead_code)]
-trait Bat<T>: std::fmt::Display + Sized {
+trait Bat<T>: std::fmt::Display + std::marker::Sized {
     const SIZE: usize = core::mem::size_of::<Self>();
     //~^ ERROR the size for values of type `Self` cannot be known at compilation time
+}
+
+trait MyTrait {}
+
+trait Wrapper<T: MyTrait> {}
+
+mod inner {
+    trait MyTrait {}
+    // Ensure that we suggest the fully-qualified path of `crate::MyTrait`
+    // We only do that on editions>=2018.
+    fn method<T: MyTrait + crate::MyTrait, W: super::Wrapper<T>>() {} //~ ERROR the trait bound `T: MyTrait` is not satisfied
 }
 
 fn main() { }

--- a/tests/ui/suggestions/bound-suggestions.rs
+++ b/tests/ui/suggestions/bound-suggestions.rs
@@ -1,73 +1,75 @@
 //@ run-rustfix
+//@ edition:2018
 
-#[allow(unused)]
+#![allow(unused)]
+
 use std::fmt::Debug;
 // Rustfix should add this, or use `std::fmt::Debug` instead.
 
-#[allow(dead_code)]
 fn test_impl(t: impl Sized) {
     println!("{:?}", t);
     //~^ ERROR doesn't implement
 }
 
-#[allow(dead_code)]
 fn test_no_bounds<T>(t: T) {
     println!("{:?}", t);
     //~^ ERROR doesn't implement
 }
 
-#[allow(dead_code)]
 fn test_one_bound<T: Sized>(t: T) {
     println!("{:?}", t);
     //~^ ERROR doesn't implement
 }
 
-#[allow(dead_code)]
 fn test_no_bounds_where<X, Y>(x: X, y: Y) where X: std::fmt::Debug, {
     println!("{:?} {:?}", x, y);
     //~^ ERROR doesn't implement
 }
 
-#[allow(dead_code)]
 fn test_one_bound_where<X>(x: X) where X: Sized {
     println!("{:?}", x);
     //~^ ERROR doesn't implement
 }
 
-#[allow(dead_code)]
 fn test_many_bounds_where<X>(x: X) where X: Sized, X: Sized {
     println!("{:?}", x);
     //~^ ERROR doesn't implement
 }
 
-#[allow(dead_code)]
 trait Foo<T> {
     const SIZE: usize = core::mem::size_of::<Self>();
     //~^ ERROR the size for values of type `Self` cannot be known at compilation time
 }
 
-#[allow(dead_code)]
 trait Bar: std::fmt::Display {
     const SIZE: usize = core::mem::size_of::<Self>();
     //~^ ERROR the size for values of type `Self` cannot be known at compilation time
 }
 
-#[allow(dead_code)]
 trait Baz where Self: std::fmt::Display {
     const SIZE: usize = core::mem::size_of::<Self>();
     //~^ ERROR the size for values of type `Self` cannot be known at compilation time
 }
 
-#[allow(dead_code)]
 trait Qux<T> where Self: std::fmt::Display {
     const SIZE: usize = core::mem::size_of::<Self>();
     //~^ ERROR the size for values of type `Self` cannot be known at compilation time
 }
 
-#[allow(dead_code)]
 trait Bat<T>: std::fmt::Display {
     const SIZE: usize = core::mem::size_of::<Self>();
     //~^ ERROR the size for values of type `Self` cannot be known at compilation time
+}
+
+trait MyTrait {}
+
+trait Wrapper<T: MyTrait> {}
+
+mod inner {
+    trait MyTrait {}
+    // Ensure that we suggest the fully-qualified path of `crate::MyTrait`
+    // We only do that on editions>=2018.
+    fn method<T: MyTrait, W: super::Wrapper<T>>() {} //~ ERROR the trait bound `T: MyTrait` is not satisfied
 }
 
 fn main() { }

--- a/tests/ui/suggestions/bound-suggestions.stderr
+++ b/tests/ui/suggestions/bound-suggestions.stderr
@@ -1,5 +1,21 @@
+error[E0277]: the trait bound `T: MyTrait` is not satisfied
+  --> $DIR/bound-suggestions.rs:72:30
+   |
+LL |     fn method<T: MyTrait, W: super::Wrapper<T>>() {}
+   |                              ^^^^^^^^^^^^^^^^^ the trait `MyTrait` is not implemented for `T`
+   |
+note: required by a bound in `Wrapper`
+  --> $DIR/bound-suggestions.rs:66:18
+   |
+LL | trait Wrapper<T: MyTrait> {}
+   |                  ^^^^^^^ required by this bound in `Wrapper`
+help: consider further restricting type parameter `T` with trait `MyTrait`
+   |
+LL |     fn method<T: MyTrait + crate::MyTrait, W: super::Wrapper<T>>() {}
+   |                          ++++++++++++++++
+
 error[E0277]: `impl Sized` doesn't implement `Debug`
-  --> $DIR/bound-suggestions.rs:9:22
+  --> $DIR/bound-suggestions.rs:10:22
    |
 LL |     println!("{:?}", t);
    |               ----   ^ `impl Sized` cannot be formatted using `{:?}` because it doesn't implement `Debug`
@@ -27,7 +43,7 @@ LL | fn test_no_bounds<T: std::fmt::Debug>(t: T) {
    |                    +++++++++++++++++
 
 error[E0277]: `T` doesn't implement `Debug`
-  --> $DIR/bound-suggestions.rs:21:22
+  --> $DIR/bound-suggestions.rs:20:22
    |
 LL |     println!("{:?}", t);
    |               ----   ^ `T` cannot be formatted using `{:?}` because it doesn't implement `Debug`
@@ -41,7 +57,7 @@ LL | fn test_one_bound<T: Sized + std::fmt::Debug>(t: T) {
    |                            +++++++++++++++++
 
 error[E0277]: `Y` doesn't implement `Debug`
-  --> $DIR/bound-suggestions.rs:27:30
+  --> $DIR/bound-suggestions.rs:25:30
    |
 LL |     println!("{:?} {:?}", x, y);
    |                    ----      ^ `Y` cannot be formatted using `{:?}` because it doesn't implement `Debug`
@@ -55,7 +71,7 @@ LL | fn test_no_bounds_where<X, Y>(x: X, y: Y) where X: std::fmt::Debug, Y: std:
    |                                                                     ++++++++++++++++++
 
 error[E0277]: `X` doesn't implement `Debug`
-  --> $DIR/bound-suggestions.rs:33:22
+  --> $DIR/bound-suggestions.rs:30:22
    |
 LL |     println!("{:?}", x);
    |               ----   ^ `X` cannot be formatted using `{:?}` because it doesn't implement `Debug`
@@ -69,7 +85,7 @@ LL | fn test_one_bound_where<X>(x: X) where X: Sized + std::fmt::Debug {
    |                                                 +++++++++++++++++
 
 error[E0277]: `X` doesn't implement `Debug`
-  --> $DIR/bound-suggestions.rs:39:22
+  --> $DIR/bound-suggestions.rs:35:22
    |
 LL |     println!("{:?}", x);
    |               ----   ^ `X` cannot be formatted using `{:?}` because it doesn't implement `Debug`
@@ -83,6 +99,19 @@ LL | fn test_many_bounds_where<X>(x: X) where X: Sized + std::fmt::Debug, X: Siz
    |                                                   +++++++++++++++++
 
 error[E0277]: the size for values of type `Self` cannot be known at compilation time
+  --> $DIR/bound-suggestions.rs:40:46
+   |
+LL |     const SIZE: usize = core::mem::size_of::<Self>();
+   |                                              ^^^^ doesn't have a size known at compile-time
+   |
+note: required by an implicit `Sized` bound in `std::mem::size_of`
+  --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
+help: consider further restricting `Self`
+   |
+LL | trait Foo<T>: std::marker::Sized {
+   |             ++++++++++++++++++++
+
+error[E0277]: the size for values of type `Self` cannot be known at compilation time
   --> $DIR/bound-suggestions.rs:45:46
    |
 LL |     const SIZE: usize = core::mem::size_of::<Self>();
@@ -92,11 +121,11 @@ note: required by an implicit `Sized` bound in `std::mem::size_of`
   --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
 help: consider further restricting `Self`
    |
-LL | trait Foo<T>: Sized {
-   |             +++++++
+LL | trait Bar: std::fmt::Display + std::marker::Sized {
+   |                              ++++++++++++++++++++
 
 error[E0277]: the size for values of type `Self` cannot be known at compilation time
-  --> $DIR/bound-suggestions.rs:51:46
+  --> $DIR/bound-suggestions.rs:50:46
    |
 LL |     const SIZE: usize = core::mem::size_of::<Self>();
    |                                              ^^^^ doesn't have a size known at compile-time
@@ -105,11 +134,11 @@ note: required by an implicit `Sized` bound in `std::mem::size_of`
   --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
 help: consider further restricting `Self`
    |
-LL | trait Bar: std::fmt::Display + Sized {
-   |                              +++++++
+LL | trait Baz: std::marker::Sized where Self: std::fmt::Display {
+   |          ++++++++++++++++++++
 
 error[E0277]: the size for values of type `Self` cannot be known at compilation time
-  --> $DIR/bound-suggestions.rs:57:46
+  --> $DIR/bound-suggestions.rs:55:46
    |
 LL |     const SIZE: usize = core::mem::size_of::<Self>();
    |                                              ^^^^ doesn't have a size known at compile-time
@@ -118,11 +147,11 @@ note: required by an implicit `Sized` bound in `std::mem::size_of`
   --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
 help: consider further restricting `Self`
    |
-LL | trait Baz: Sized where Self: std::fmt::Display {
-   |          +++++++
+LL | trait Qux<T>: std::marker::Sized where Self: std::fmt::Display {
+   |             ++++++++++++++++++++
 
 error[E0277]: the size for values of type `Self` cannot be known at compilation time
-  --> $DIR/bound-suggestions.rs:63:46
+  --> $DIR/bound-suggestions.rs:60:46
    |
 LL |     const SIZE: usize = core::mem::size_of::<Self>();
    |                                              ^^^^ doesn't have a size known at compile-time
@@ -131,22 +160,9 @@ note: required by an implicit `Sized` bound in `std::mem::size_of`
   --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
 help: consider further restricting `Self`
    |
-LL | trait Qux<T>: Sized where Self: std::fmt::Display {
-   |             +++++++
+LL | trait Bat<T>: std::fmt::Display + std::marker::Sized {
+   |                                 ++++++++++++++++++++
 
-error[E0277]: the size for values of type `Self` cannot be known at compilation time
-  --> $DIR/bound-suggestions.rs:69:46
-   |
-LL |     const SIZE: usize = core::mem::size_of::<Self>();
-   |                                              ^^^^ doesn't have a size known at compile-time
-   |
-note: required by an implicit `Sized` bound in `std::mem::size_of`
-  --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
-help: consider further restricting `Self`
-   |
-LL | trait Bat<T>: std::fmt::Display + Sized {
-   |                                 +++++++
-
-error: aborting due to 11 previous errors
+error: aborting due to 12 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/traits/issue-28576.stderr
+++ b/tests/ui/traits/issue-28576.stderr
@@ -11,8 +11,8 @@ LL | pub trait Foo<RHS=Self> {
    |               ^^^^^^^^ required by the implicit `Sized` requirement on this type parameter in `Foo`
 help: consider further restricting `Self`
    |
-LL | pub trait Bar: Foo<Assoc=()> + Sized {
-   |                              +++++++
+LL | pub trait Bar: Foo<Assoc=()> + std::marker::Sized {
+   |                              ++++++++++++++++++++
 help: consider relaxing the implicit `Sized` restriction
    |
 LL | pub trait Foo<RHS: ?Sized=Self> {

--- a/tests/ui/type-alias-impl-trait/future.stderr
+++ b/tests/ui/type-alias-impl-trait/future.stderr
@@ -11,8 +11,8 @@ LL | fn foo<B: Bar>(bar: B) -> FooFuture<B> {
    |           ^^^ required by this bound in `foo`
 help: consider restricting type parameter `B` with trait `Bar`
    |
-LL | type FooFuture<B: Bar> = impl Future<Output = ()>;
-   |                 +++++
+LL | type FooFuture<B: crate::Bar> = impl Future<Output = ()>;
+   |                 ++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/type-alias-impl-trait/issue-89686.stderr
+++ b/tests/ui/type-alias-impl-trait/issue-89686.stderr
@@ -6,8 +6,8 @@ LL |         async move { self.f().await }
    |
 help: consider restricting type parameter `T` with trait `Trait`
    |
-LL | type G<'a, T: Trait> = impl Future<Output = ()>;
-   |             +++++++
+LL | type G<'a, T: crate::Trait> = impl Future<Output = ()>;
+   |             ++++++++++++++
 
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
This side-steps issues of name clashes with imports or traits in the current scope.

```
error[E0277]: the trait bound `T: MyTrait` is not satisfied
  --> $DIR/bound-suggestions.rs:72:27
   |
LL |     fn method<T: MyTrait, W: super::Wrapper<T>>() {}
   |                              ^^^^^^^^^^^^^^^^^ the trait `MyTrait` is not implemented for `T`
   |
note: required by a bound in `Wrapper`
  --> $DIR/bound-suggestions.rs:66:18
   |
LL | trait Wrapper<T: MyTrait> {}
   |                  ^^^^^^^ required by this bound in `Wrapper`
help: consider further restricting type parameter `T` with trait `MyTrait`
   |
LL |     fn method<T: MyTrait + crate::MyTrait, W: super::Wrapper<T>>() {}
   |                          ++++++++++++++++
```

Ideally we'd lean on resolve to have the best name for a `DefId` on a given scope, but then we'd have to ferry the scope around for pretty much every diagnostic. This is the second best thing that does address the problem of "the suggestion is broken". This PR addresses rust-lang/rust#36184 on edition>=2018. For edition 2015 we'd have to suggest `super::MyTrait`.