### PR TITLE
rust-installer/install-template.sh: improve efficiency, step 1.

### DIFF
--- a/src/tools/rust-installer/install-template.sh
+++ b/src/tools/rust-installer/install-template.sh
@@ -551,54 +551,45 @@ install_components() {
         # Decide the destination of the file
         local _file_install_path="$_dest_prefix/$_file"
 
-        if echo "$_file" | grep "^etc/" > /dev/null
-        then
-        local _f="$(echo "$_file" | sed 's/^etc\///')"
-        _file_install_path="$CFG_SYSCONFDIR/$_f"
-        fi
-
-        if echo "$_file" | grep "^bin/" > /dev/null
-        then
-        local _f="$(echo "$_file" | sed 's/^bin\///')"
-        _file_install_path="$CFG_BINDIR/$_f"
-        fi
-
-        if echo "$_file" | grep "^lib/" > /dev/null
-        then
-        local _f="$(echo "$_file" | sed 's/^lib\///')"
-        _file_install_path="$CFG_LIBDIR/$_f"
-        fi
-
-        if echo "$_file" | grep "^share" > /dev/null
-        then
-        local _f="$(echo "$_file" | sed 's/^share\///')"
-        _file_install_path="$CFG_DATADIR/$_f"
-        fi
-
-        if echo "$_file" | grep "^share/man/" > /dev/null
-        then
-        local _f="$(echo "$_file" | sed 's/^share\/man\///')"
-        _file_install_path="$CFG_MANDIR/$_f"
-        fi
-
-            # HACK: Try to support overriding --docdir.  Paths with the form
-            # "share/doc/$product/" can be redirected to a single --docdir
-            # path. If the following detects that --docdir has been specified
-            # then it will replace everything preceding the "$product" path
-            # component. The problem here is that the combined rust installer
-            # contains two "products": rust and cargo; so the contents of those
-            # directories will both be dumped into the same directory; and the
-            # contents of those directories are _not_ disjoint. Since this feature
-            # is almost entirely to support 'make install' anyway I don't expect
-            # this problem to be a big deal in practice.
-            if [ "$CFG_DOCDIR" != "<default>" ]
-            then
-            if echo "$_file" | grep "^share/doc/" > /dev/null
-            then
-            local _f="$(echo "$_file" | sed 's/^share\/doc\/[^/]*\///')"
-            _file_install_path="$CFG_DOCDIR/$_f"
-            fi
-            fi
+        case "$_file" in
+            etc/*)
+                local _f="$(echo "$_file" | sed 's/^etc\///')"
+                _file_install_path="$CFG_SYSCONFDIR/$_f"
+                ;;
+            bin/*)
+                local _f="$(echo "$_file" | sed 's/^bin\///')"
+                _file_install_path="$CFG_BINDIR/$_f"
+                ;;
+            lib/*)
+                local _f="$(echo "$_file" | sed 's/^lib\///')"
+                _file_install_path="$CFG_LIBDIR/$_f"
+                ;;
+            share/man/*)
+                local _f="$(echo "$_file" | sed 's/^share\/man\///')"
+                _file_install_path="$CFG_MANDIR/$_f"
+                ;;
+            share/doc/*)
+                # HACK: Try to support overriding --docdir.  Paths with the form
+                # "share/doc/$product/" can be redirected to a single --docdir
+                # path. If the following detects that --docdir has been specified
+                # then it will replace everything preceding the "$product" path
+                # component. The problem here is that the combined rust installer
+                # contains two "products": rust and cargo; so the contents of those
+                # directories will both be dumped into the same directory; and the
+                # contents of those directories are _not_ disjoint. Since this feature
+                # is almost entirely to support 'make install' anyway I don't expect
+                # this problem to be a big deal in practice.
+                if [ "$CFG_DOCDIR" != "<default>" ]
+                then
+                    local _f="$(echo "$_file" | sed 's/^share\/doc\/[^/]*\///')"
+                    _file_install_path="$CFG_DOCDIR/$_f"
+                fi
+                ;;
+            share/*)
+                local _f="$(echo "$_file" | sed 's/^share\///')"
+                _file_install_path="$CFG_DATADIR/$_f"
+                ;;
+        esac
 
         # Make sure there's a directory for it
         make_dir_recursive "$(dirname "$_file_install_path")"
@@ -617,13 +608,20 @@ install_components() {
 
             maybe_backup_path "$_file_install_path"
 
-            if echo "$_file" | grep "^bin/" > /dev/null || test -x "$_src_dir/$_component/$_file"
-            then
-            run cp "$_src_dir/$_component/$_file" "$_file_install_path"
-            run chmod 755 "$_file_install_path"
+            if test -x "$_src_dir/$_component/$_file"; then
+                run cp "$_src_dir/$_component/$_file" "$_file_install_path"
+                run chmod 755 "$_file_install_path"
             else
-            run cp "$_src_dir/$_component/$_file" "$_file_install_path"
-            run chmod 644 "$_file_install_path"
+                case "$_file" in
+                    bin/*)
+                        run cp "$_src_dir/$_component/$_file" "$_file_install_path"
+                        run chmod 755 "$_file_install_path"
+                        ;;
+                    *)
+                        run cp "$_src_dir/$_component/$_file" "$_file_install_path"
+                        run chmod 644 "$_file_install_path"
+                        ;;
+                esac
             fi
             critical_need_ok "file creation failed"
 

--- a/src/tools/rust-installer/install-template.sh
+++ b/src/tools/rust-installer/install-template.sh
@@ -551,6 +551,7 @@ install_components() {
         # Decide the destination of the file
         local _file_install_path="$_dest_prefix/$_file"
 
+	local _is_bin=false
         case "$_file" in
             etc/*)
                 local _f="$(echo "$_file" | sed 's/^etc\///')"
@@ -558,6 +559,7 @@ install_components() {
                 ;;
             bin/*)
                 local _f="$(echo "$_file" | sed 's/^bin\///')"
+		_is_bin=true
                 _file_install_path="$CFG_BINDIR/$_f"
                 ;;
             lib/*)
@@ -608,20 +610,11 @@ install_components() {
 
             maybe_backup_path "$_file_install_path"
 
-            if test -x "$_src_dir/$_component/$_file"; then
-                run cp "$_src_dir/$_component/$_file" "$_file_install_path"
+            run cp "$_src_dir/$_component/$_file" "$_file_install_path"
+            if $_is_bin || test -x "$_src_dir/$_component/$_file"; then
                 run chmod 755 "$_file_install_path"
             else
-                case "$_file" in
-                    bin/*)
-                        run cp "$_src_dir/$_component/$_file" "$_file_install_path"
-                        run chmod 755 "$_file_install_path"
-                        ;;
-                    *)
-                        run cp "$_src_dir/$_component/$_file" "$_file_install_path"
-                        run chmod 644 "$_file_install_path"
-                        ;;
-                esac
+                run chmod 644 "$_file_install_path"
             fi
             critical_need_ok "file creation failed"
 

--- a/src/tools/rust-installer/install-template.sh
+++ b/src/tools/rust-installer/install-template.sh
@@ -551,7 +551,7 @@ install_components() {
         # Decide the destination of the file
         local _file_install_path="$_dest_prefix/$_file"
 
-	local _is_bin=false
+        local _is_bin=false
         case "$_file" in
             etc/*)
                 local _f="$(echo "$_file" | sed 's/^etc\///')"
@@ -559,7 +559,7 @@ install_components() {
                 ;;
             bin/*)
                 local _f="$(echo "$_file" | sed 's/^bin\///')"
-		_is_bin=true
+                _is_bin=true
                 _file_install_path="$CFG_BINDIR/$_f"
                 ;;
             lib/*)


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/145809)*
<!-- homu-ignore:end -->

This round replaces repetitive pattern matching in the inner loop of this script using grep (which causes a `fork()` for each test) with built-in pattern matching in the Bourne shell using the `case` / `esac` construct.

This in reference to
  https://github.com/rust-lang/rust/issues/80684
and is a separated-out request from
  https://github.com/rust-lang/rust-installer/pull/111

which apparently never got any review.

The forthcoming planned "step 2" change builds on top of this change, and replaces the inner-loops needless uses of `sed` (which again causes a `fork()` for each instance) with the suffix removal constructs from the Bourne shell.  Since this change touches lots of the same lines this change does, that pull request cannot be submitted before this one is accepted.

Hopefully this first step is less controversial than the latter change.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
