### PR TITLE
std_detect: RISC-V: Best effort implication of target features by custom `cfg`

### DIFF
--- a/library/std_detect/src/detect/arch/aarch64.rs
+++ b/library/std_detect/src/detect/arch/aarch64.rs
@@ -110,10 +110,10 @@ features! {
     @FEATURE: #[stable(feature = "simd_aarch64", since = "1.60.0")] asimd: "neon";
     /// FEAT_AdvSIMD (Advanced SIMD/NEON)
     @FEATURE: #[stable(feature = "simd_aarch64", since = "1.60.0")] pmull: "pmull";
-    implied by target_features: ["aes"];
+    implied by cfg(target_feature = "aes");
     /// FEAT_PMULL (Polynomial Multiply) - Implied by `aes` target_feature
     @FEATURE: #[stable(feature = "simd_aarch64", since = "1.60.0")] fp: "fp";
-    implied by target_features: ["neon"];
+    implied by cfg(target_feature = "neon");
     /// FEAT_FP (Floating point support) - Implied by `neon` target_feature
     @FEATURE: #[stable(feature = "simd_aarch64", since = "1.60.0")] aes: "aes";
     /// FEAT_AES (AES SIMD instructions) & FEAT_PMULL (PMULL{2}, 64-bit operand variants)

--- a/library/std_detect/src/detect/arch/riscv.rs
+++ b/library/std_detect/src/detect/arch/riscv.rs
@@ -220,6 +220,13 @@ features! {
     /// "M" Extension for Integer Multiplication and Division
 
     @FEATURE: #[stable(feature = "riscv_ratified", since = "1.78.0")] a: "a";
+    implied by cfg(any(
+        target_feature = "a",
+        all(
+            target_feature = "zalrsc",
+            target_feature = "zaamo",
+        )
+    ));
     /// "A" Extension for Atomic Instructions
     @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zalrsc: "zalrsc";
     /// "Zalrsc" Extension for Load-Reserved/Store-Conditional Instructions
@@ -278,6 +285,14 @@ features! {
     /// "Zcmop" Extension for Compressed May-Be-Operations
 
     @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] b: "b";
+    implied by cfg(any(
+        target_feature = "b",
+        all(
+            target_feature = "zba",
+            target_feature = "zbb",
+            target_feature = "zbs",
+        )
+    ));
     /// "B" Extension for Bit Manipulation
     @FEATURE: #[stable(feature = "riscv_ratified", since = "1.78.0")] zba: "zba";
     /// "Zba" Extension for Address Generation
@@ -307,10 +322,44 @@ features! {
     @FEATURE: #[stable(feature = "riscv_ratified", since = "1.78.0")] zkr: "zkr";
     /// "Zkr" Entropy Source Extension
     @FEATURE: #[stable(feature = "riscv_ratified", since = "1.78.0")] zkn: "zkn";
+    implied by cfg(any(
+        target_feature = "zkn",
+        all(
+            target_feature = "zbkb",
+            target_feature = "zbkc",
+            target_feature = "zbkx",
+            target_feature = "zkne",
+            target_feature = "zknd",
+            target_feature = "zknh",
+        )
+    ));
     /// "Zkn" Cryptography Extension for NIST Algorithm Suite
     @FEATURE: #[stable(feature = "riscv_ratified", since = "1.78.0")] zks: "zks";
+    implied by cfg(any(
+        target_feature = "zks",
+        all(
+            target_feature = "zbkb",
+            target_feature = "zbkc",
+            target_feature = "zbkx",
+            target_feature = "zksed",
+            target_feature = "zksh",
+        )
+    ));
     /// "Zks" Cryptography Extension for ShangMi Algorithm Suite
     @FEATURE: #[stable(feature = "riscv_ratified", since = "1.78.0")] zk: "zk";
+    implied by cfg(any(
+        target_feature = "zk",
+        all(
+            target_feature = "zbkb",
+            target_feature = "zbkc",
+            target_feature = "zbkx",
+            target_feature = "zkne",
+            target_feature = "zknd",
+            target_feature = "zknh",
+            target_feature = "zkr",
+            target_feature = "zkt",
+        )
+    ));
     /// "Zk" Cryptography Extension for Standard Scalar Cryptography
     @FEATURE: #[stable(feature = "riscv_ratified", since = "1.78.0")] zkt: "zkt";
     /// "Zkt" Cryptography Extension for Data Independent Execution Latency
@@ -355,16 +404,74 @@ features! {
     @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zvksh: "zvksh";
     /// "Zvksh" Cryptography Extension for ShangMi Suite: Vector SM3 Secure Hash
     @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zvkn: "zvkn";
+    implied by cfg(any(
+        target_feature = "zvkn",
+        all(
+            target_feature = "zvkned",
+            target_feature = "zvknhb",
+            target_feature = "zvkb",
+            target_feature = "zvkt",
+        )
+    ));
     /// "Zvkn" Cryptography Extension for NIST Algorithm Suite
     @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zvknc: "zvknc";
+    implied by cfg(any(
+        target_feature = "zvknc",
+        all(
+            target_feature = "zvkned",
+            target_feature = "zvknhb",
+            target_feature = "zvkb",
+            target_feature = "zvkt",
+            target_feature = "zvbc",
+        )
+    ));
     /// "Zvknc" Cryptography Extension for NIST Algorithm Suite with Carryless Multiply
     @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zvkng: "zvkng";
+    implied by cfg(any(
+        target_feature = "zvkng",
+        all(
+            target_feature = "zvkned",
+            target_feature = "zvknhb",
+            target_feature = "zvkb",
+            target_feature = "zvkt",
+            target_feature = "zvkg",
+        )
+    ));
     /// "Zvkng" Cryptography Extension for NIST Algorithm Suite with GCM
     @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zvks: "zvks";
+    implied by cfg(any(
+        target_feature = "zvks",
+        all(
+            target_feature = "zvksed",
+            target_feature = "zvksh",
+            target_feature = "zvkb",
+            target_feature = "zvkt",
+        )
+    ));
     /// "Zvks" Cryptography Extension for ShangMi Algorithm Suite
     @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zvksc: "zvksc";
+    implied by cfg(any(
+        target_feature = "zvksc",
+        all(
+            target_feature = "zvksed",
+            target_feature = "zvksh",
+            target_feature = "zvkb",
+            target_feature = "zvkt",
+            target_feature = "zvbc",
+        )
+    ));
     /// "Zvksc" Cryptography Extension for ShangMi Algorithm Suite with Carryless Multiply
     @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zvksg: "zvksg";
+    implied by cfg(any(
+        target_feature = "zvksg",
+        all(
+            target_feature = "zvksed",
+            target_feature = "zvksh",
+            target_feature = "zvkb",
+            target_feature = "zvkt",
+            target_feature = "zvkg",
+        )
+    ));
     /// "Zvksg" Cryptography Extension for ShangMi Algorithm Suite with GCM
     @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zvkt: "zvkt";
     /// "Zvkt" Extension for Vector Data-Independent Execution Latency

--- a/library/std_detect/src/detect/arch/riscv.rs
+++ b/library/std_detect/src/detect/arch/riscv.rs
@@ -270,14 +270,22 @@ features! {
     /// "Zhinxmin" Extension for Minimal Half-Precision Floating-Point in Integer Registers
 
     @FEATURE: #[stable(feature = "riscv_ratified", since = "1.78.0")] c: "c";
+    implied by cfg(any(
+        target_feature = "c",
+        all(
+            not(target_feature = "d"),
+            any(not(target_arch = "riscv32"), not(target_feature = "f")),
+            target_feature = "zca",
+        )
+    ));
     /// "C" Extension for Compressed Instructions
     @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zca: "zca";
     /// "Zca" Compressed Instructions excluding Floating-Point Loads/Stores
     @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zcf: "zcf";
-    without cfg check: true;
+    implied by cfg(all(target_arch = "riscv32", target_feature = "c", target_feature = "f"));
     /// "Zcf" Compressed Instructions for Single-Precision Floating-Point Loads/Stores on RV32
     @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zcd: "zcd";
-    without cfg check: true;
+    implied by cfg(all(target_feature = "c", target_feature = "d"));
     /// "Zcd" Compressed Instructions for Double-Precision Floating-Point Loads/Stores
     @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zcb: "zcb";
     /// "Zcb" Simple Code-size Saving Compressed Instructions

--- a/library/std_detect/src/detect/macros.rs
+++ b/library/std_detect/src/detect/macros.rs
@@ -24,7 +24,9 @@ macro_rules! check_cfg_feature {
     };
     ($feature:tt, $feature_lit:tt, without cfg check: $feature_cfg_check:literal) => {
         #[allow(unexpected_cfgs, reason = $feature_lit)]
-        { cfg!(target_feature = $feature_lit) }
+        {
+            cfg!(target_feature = $feature_lit)
+        }
     };
 }
 
@@ -50,7 +52,12 @@ macro_rules! features {
         macro_rules! $macro_name {
             $(
                 ($feature_lit) => {
-                    $crate::detect_feature!($feature, $feature_lit $(, without cfg check: $feature_cfg_check)? $(: $($target_feature_lit),*)?)
+                    $crate::detect_feature!(
+                        $feature,
+                        $feature_lit
+                        $(, without cfg check: $feature_cfg_check)?
+                        $(: $($target_feature_lit),*)?
+                    )
                 };
             )*
             $(
@@ -135,7 +142,12 @@ macro_rules! features {
         #[deny(unfulfilled_lint_expectations)]
         const _: () = {
             $(
-                check_cfg_feature!($feature, $feature_lit $(, without cfg check: $feature_cfg_check)? $(: $($target_feature_lit),*)?);
+                check_cfg_feature!(
+                    $feature,
+                    $feature_lit
+                    $(, without cfg check: $feature_cfg_check)?
+                    $(: $($target_feature_lit),*)?
+                );
             )*
         };
 

--- a/library/std_detect/src/detect/macros.rs
+++ b/library/std_detect/src/detect/macros.rs
@@ -3,11 +3,7 @@
 #[unstable(feature = "stdarch_internal", issue = "none")]
 macro_rules! detect_feature {
     ($feature:tt, $feature_lit:tt) => {
-        $crate::detect_feature!($feature, $feature_lit : $feature_lit)
-    };
-    ($feature:tt, $feature_lit:tt : $($target_feature_lit:tt),*) => {
-        $(cfg!(target_feature = $target_feature_lit) ||)*
-            $crate::detect::__is_feature_detected::$feature()
+        cfg!(target_feature = $feature_lit) || $crate::detect::__is_feature_detected::$feature()
     };
     ($feature:tt, $feature_lit:tt : cfg($target_feature_cfg:meta)) => {
         cfg!($target_feature_cfg) || $crate::detect::__is_feature_detected::$feature()
@@ -20,10 +16,7 @@ macro_rules! detect_feature {
 #[allow(unused_macros, reason = "it's used in the features! macro below")]
 macro_rules! check_cfg_feature {
     ($feature:tt, $feature_lit:tt) => {
-        check_cfg_feature!($feature, $feature_lit : $feature_lit)
-    };
-    ($feature:tt, $feature_lit:tt : $($target_feature_lit:tt),*) => {
-        $(cfg!(target_feature = $target_feature_lit);)*
+        cfg!(target_feature = $feature_lit);
     };
     ($feature:tt, $feature_lit:tt : cfg($target_feature_cfg:meta)) => {
         cfg!($target_feature_cfg);
@@ -47,7 +40,6 @@ macro_rules! features {
       $(@NO_RUNTIME_DETECTION: $nort_feature:tt; )*
       $(@FEATURE: #[$stability_attr:meta] $feature:ident: $feature_lit:tt;
           $(without cfg check: $feature_cfg_check:tt;)?
-          $(implied by target_features: [$($target_feature_lit:tt),*];)?
           $(implied by cfg($target_feature_cfg:meta);)?
           $(#[$feature_comment:meta])*)*
     ) => {
@@ -63,7 +55,6 @@ macro_rules! features {
                         $feature,
                         $feature_lit
                         $(, without cfg check: $feature_cfg_check)?
-                        $(: $($target_feature_lit),*)?
                         $(: cfg($target_feature_cfg))?
                     )
                 };
@@ -154,7 +145,6 @@ macro_rules! features {
                     $feature,
                     $feature_lit
                     $(, without cfg check: $feature_cfg_check)?
-                    $(: $($target_feature_lit),*)?
                     $(: cfg($target_feature_cfg))?
                 );
             )*

--- a/library/std_detect/src/detect/macros.rs
+++ b/library/std_detect/src/detect/macros.rs
@@ -9,6 +9,9 @@ macro_rules! detect_feature {
         $(cfg!(target_feature = $target_feature_lit) ||)*
             $crate::detect::__is_feature_detected::$feature()
     };
+    ($feature:tt, $feature_lit:tt : cfg($target_feature_cfg:meta)) => {
+        cfg!($target_feature_cfg) || $crate::detect::__is_feature_detected::$feature()
+    };
     ($feature:tt, $feature_lit:tt, without cfg check: true) => {
         $crate::detect::__is_feature_detected::$feature()
     };
@@ -21,6 +24,9 @@ macro_rules! check_cfg_feature {
     };
     ($feature:tt, $feature_lit:tt : $($target_feature_lit:tt),*) => {
         $(cfg!(target_feature = $target_feature_lit);)*
+    };
+    ($feature:tt, $feature_lit:tt : cfg($target_feature_cfg:meta)) => {
+        cfg!($target_feature_cfg);
     };
     ($feature:tt, $feature_lit:tt, without cfg check: $feature_cfg_check:literal) => {
         #[allow(unexpected_cfgs, reason = $feature_lit)]
@@ -42,6 +48,7 @@ macro_rules! features {
       $(@FEATURE: #[$stability_attr:meta] $feature:ident: $feature_lit:tt;
           $(without cfg check: $feature_cfg_check:tt;)?
           $(implied by target_features: [$($target_feature_lit:tt),*];)?
+          $(implied by cfg($target_feature_cfg:meta);)?
           $(#[$feature_comment:meta])*)*
     ) => {
         #[macro_export]
@@ -57,6 +64,7 @@ macro_rules! features {
                         $feature_lit
                         $(, without cfg check: $feature_cfg_check)?
                         $(: $($target_feature_lit),*)?
+                        $(: cfg($target_feature_cfg))?
                     )
                 };
             )*
@@ -147,6 +155,7 @@ macro_rules! features {
                     $feature_lit
                     $(, without cfg check: $feature_cfg_check)?
                     $(: $($target_feature_lit),*)?
+                    $(: cfg($target_feature_cfg))?
                 );
             )*
         };


### PR DESCRIPTION
This PR implements new feature to `std_detect`'s `feature!` macro: implication of target features by custom `cfg` and then uses this to implement static implication logic on RISC-V where the standard target feature handling does not capture all the cases.

This PR implements implication logic for three kinds of target features:

1.  *Group* extensions where each equals aggregation of its sub-extensions (exact)
2.  Complex implications around the "C" extension (in a best effort manner)

For detailed intent of the changes, see each commit message.

It also changes some AArch64 code to use the new syntax added in this PR and removes the old custom syntax to imply a target feature.

<!-- homu-ignore:start -->

cf. [Z3-based prover for complex implications around the "C" extension](https://gist.github.com/a4lg/4c63a478d46a1886713351e2ab53f8df)

# Draft Design Consideration 1: RISC-V: How to handle ISA Bases?

Implementing custom implications to base ISA target features like `rv32i` might be an option but I have a concern (which will not happen for now but plausible in the future).

In particular, I have a concern on the following case: the program is built for an `rv32e` target but ran on an `rv32i` environment (which is a superset of `rv32e`) and reports existence of `rv32i`.  If that happens, both `rv32e` and `rv32i` would return `true` on `std::arch::is_riscv_feature_detected!`.

So, the commit implementing implication of base ISA target features (originally commit 3) was marked **DRAFT**.

My original position: Slightly Negative.

Conclusion: Remove original commit 3 and do not imply ISA bases.

# Draft Design Consideration 2: Substituting `implied by target_features:`

This PR (originally commit 2) implements implication by custom `cfg` with following syntax: `implied by cfg(CFG);`.
Unlike existing `implied by target_features: [A, B, ...];` (which will work like `cfg(any(target_feature = "A", target_feature = "B", ...))`), this syntax accepts any `cfg`s.

Interestingly, `implied by target_features:` is currently only used on AArch64 and in the simplest form (implied from one target feature).  So if there's no good reason keeping this, we have an option to remove `implied by target_features: [...];` entirely and substitute with `implied by cfg(...);`.

Commits that make such changes (originally commits 6 and 7) were marked **DRAFT**.

My original position: Positive (but leaving draft after hearing from others).

Conclusion: Substitute as the original.

r? @Amanieu
@rustbot label +O-riscv

<!-- homu-ignore:end -->
