### PR TITLE
rustdoc: render attributes in Field and Variants sections

### DIFF
--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -1460,6 +1460,13 @@ impl<'a, 'cx: 'a> ItemUnion<'a, 'cx> {
         )
     }
 
+    fn print_field_attrs(&self, field: &'a clean::Item) -> impl Display {
+        fmt::from_fn(move |w| {
+            render_attributes_in_code(w, field, "", self.cx);
+            Ok(())
+        })
+    }
+
     fn document_field(&self, field: &'a clean::Item) -> impl Display {
         document(self.cx, field, Some(self.it), HeadingOffset::H3)
     }
@@ -1770,6 +1777,7 @@ fn item_variants(
                 )
                 .maybe_display()
             )?;
+            render_attributes_in_code(w, variant, "", cx);
             if let clean::VariantItem(ref var) = variant.kind
                 && let clean::VariantKind::CLike = var.kind
             {
@@ -1843,7 +1851,12 @@ fn item_variants(
                                 "<div class=\"sub-variant-field\">\
                                     <span id=\"{id}\" class=\"section-header\">\
                                         <a href=\"#{id}\" class=\"anchor field\">§</a>\
-                                        <code>{f}: {t}</code>\
+                                        <code>"
+                            )?;
+                            render_attributes_in_code(w, field, "", cx);
+                            write!(
+                                w,
+                                "{f}: {t}</code>\
                                     </span>\
                                     {doc}\
                                 </div>",
@@ -2079,10 +2092,15 @@ fn item_fields(
                     w,
                     "<span id=\"{id}\" class=\"{item_type} section-header\">\
                         <a href=\"#{id}\" class=\"anchor field\">§</a>\
-                        <code>{field_name}: {ty}</code>\
+                        <code>",
+                    item_type = ItemType::StructField,
+                )?;
+                render_attributes_in_code(w, field, "", cx);
+                write!(
+                    w,
+                    "{field_name}: {ty}</code>\
                     </span>\
                     {doc}",
-                    item_type = ItemType::StructField,
                     ty = ty.print(cx),
                     doc = document(cx, field, Some(it), HeadingOffset::H3),
                 )?;

--- a/src/librustdoc/html/templates/item_union.html
+++ b/src/librustdoc/html/templates/item_union.html
@@ -12,7 +12,7 @@
         {% let name = field.name.expect("union field name") %}
         <span id="structfield.{{ name }}" class="{{ ItemType::StructField +}} section-header"> {# #}
             <a href="#structfield.{{ name }}" class="anchor field">§</a> {# #}
-            <code>{{ name }}: {{+ self.print_ty(ty)|safe }}</code> {# #}
+            <code>{{+ self.print_field_attrs(field)|safe }}{{ name }}: {{+ self.print_ty(ty)|safe }}</code> {# #}
         </span>
         {% if let Some(stability_class) = self.stability_field(field) %}
             <span class="stab {{ stability_class }}"></span>

--- a/tests/rustdoc/attributes.rs
+++ b/tests/rustdoc/attributes.rs
@@ -28,12 +28,15 @@ macro_rules! macro_rule {
 #[unsafe(link_section = "enum")]
 pub enum Enum {
     //@ has 'foo/enum.Enum.html' '//*[@class="code-attribute"]' '#[unsafe(link_section = "a")]'
+    //@ has - '//*[@class="variants"]//*[@class="code-attribute"]' '#[unsafe(link_section = "a")]'
     #[unsafe(link_section = "a")]
     A,
     //@ has 'foo/enum.Enum.html' '//*[@class="code-attribute"]' '#[unsafe(link_section = "quz")]'
+    //@ has - '//*[@class="variants"]//*[@class="code-attribute"]' '#[unsafe(link_section = "quz")]'
     #[unsafe(link_section = "quz")]
     Quz {
         //@ has 'foo/enum.Enum.html' '//*[@class="code-attribute"]' '#[unsafe(link_section = "b")]'
+        //@ has - '//*[@class="variants"]//*[@class="code-attribute"]' '#[unsafe(link_section = "b")]'
         #[unsafe(link_section = "b")]
         b: (),
     },
@@ -66,6 +69,7 @@ pub union Union {
 #[unsafe(link_section = "struct")]
 pub struct Struct {
     //@ has 'foo/struct.Struct.html' '//*[@class="code-attribute"]' '#[unsafe(link_section = "x")]'
+    //@ has - '//*[@id="structfield.x"]//*[@class="code-attribute"]' '#[unsafe(link_section = "x")]'
     #[unsafe(link_section = "x")]
     pub x: u32,
     y: f32,


### PR DESCRIPTION
Follow up to  rust-lang/rust#145782.
Render attributes in Field and Variants sections.

Associated constants and methods are already rendered with attributes in their sections, so I figured out fields  and variants should too.
(no change here)
<img width="378" height="265" alt="image" src="https://github.com/user-attachments/assets/b4f45c42-0146-486e-8881-138d2a7ad1c4" />
r? @GuillaumeGomez 

---
Before (left) / after (right):

<img width="396" height="519" alt="image" src="https://github.com/user-attachments/assets/18288e13-09e7-448c-ba98-2023fa6df597" />
<img width="382" height="597" alt="image" src="https://github.com/user-attachments/assets/e624dc84-d169-41cc-bb89-7a1c2b2bb3e3" />

<img width="371" height="313" alt="image" src="https://github.com/user-attachments/assets/29833645-0b93-4900-80a8-c5a1e0b541b4" />
<img width="371" height="331" alt="image" src="https://github.com/user-attachments/assets/d5ce4b9e-f7f1-4f36-8ac0-08b0b5077e48" />

<img width="362" height="309" alt="image" src="https://github.com/user-attachments/assets/0436a51d-29a5-4403-a27c-7697524f807a" />
<img width="357" height="332" alt="image" src="https://github.com/user-attachments/assets/9a759fc5-30e7-4bbb-a88a-a3e3d1ed02aa" />
