### PR TITLE
Wait for DPkg frontend lock when trying to remove packages

### DIFF
--- a/src/ci/scripts/free-disk-space-linux.sh
+++ b/src/ci/scripts/free-disk-space-linux.sh
@@ -221,10 +221,13 @@ cleanPackages() {
         )
     fi
 
-    sudo apt-get -qq remove -y --fix-missing "${packages[@]}"
+    WAIT_DPKG_LOCK="-o DPkg::Lock::Timeout=60"
+    sudo apt-get ${WAIT_DPKG_LOCK} -qq remove -y --fix-missing "${packages[@]}"
 
-    sudo apt-get autoremove -y || echo "::warning::The command [sudo apt-get autoremove -y] failed"
-    sudo apt-get clean || echo "::warning::The command [sudo apt-get clean] failed failed"
+    sudo apt-get ${WAIT_DPKG_LOCK} autoremove -y \
+        || echo "::warning::The command [sudo apt-get autoremove -y] failed"
+    sudo apt-get ${WAIT_DPKG_LOCK} clean \
+        || echo "::warning::The command [sudo apt-get clean] failed"
 }
 
 # Remove Docker images.


### PR DESCRIPTION
Hopefully this helps with [#t-infra > pr-check-1 fails on "free up disk space"](https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/pr-check-1.20fails.20on.20.22free.20up.20disk.20space.22/with/535794424).

As suggested by riking in [#t-infra > pr-check-1 fails on "free up disk space" @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/pr-check-1.20fails.20on.20.22free.20up.20disk.20space.22/near/535791579), thanks!

r? infra-ci