### PR TITLE
rustdoc: make `#[doc(hidden)]` render the same as other attrs

### DIFF
--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -1407,10 +1407,6 @@ impl clean::FnDecl {
 
 pub(crate) fn visibility_print_with_space(item: &clean::Item, cx: &Context<'_>) -> impl Display {
     fmt::from_fn(move |f| {
-        if item.is_doc_hidden() {
-            f.write_str("#[doc(hidden)] ")?;
-        }
-
         match item.visibility(cx.tcx()) {
             None => {}
             Some(ty::Visibility::Public) => f.write_str("pub ")?,

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -1865,7 +1865,6 @@ fn item_variants(
 fn item_macro(cx: &Context<'_>, it: &clean::Item, t: &clean::Macro) -> impl fmt::Display {
     fmt::from_fn(|w| {
         wrap_item(w, |w| {
-            // FIXME: Also print `#[doc(hidden)]` for `macro_rules!` if it `is_doc_hidden`.
             render_attributes_in_code(w, it, "", cx);
             if !t.macro_rules {
                 write!(w, "{}", visibility_print_with_space(it, cx))?;

--- a/tests/rustdoc/display-hidden-items.rs
+++ b/tests/rustdoc/display-hidden-items.rs
@@ -7,23 +7,27 @@
 //@ has 'foo/index.html'
 //@ has - '//dt/span[@title="Hidden item"]' '👻'
 
-//@ has - '//*[@id="reexport.hidden_reexport"]/code' '#[doc(hidden)] pub use hidden::inside_hidden as hidden_reexport;'
+//@ has - '//*[@id="reexport.hidden_reexport"]/code/*[@class="code-attribute"]' '#[doc(hidden)]'
+//@ has - '//*[@id="reexport.hidden_reexport"]/code' 'pub use hidden::inside_hidden as hidden_reexport;'
 #[doc(hidden)]
 pub use hidden::inside_hidden as hidden_reexport;
 
 //@ has - '//dt/a[@class="trait"]' 'TraitHidden'
 //@ has 'foo/trait.TraitHidden.html'
-//@ has - '//code' '#[doc(hidden)] pub trait TraitHidden'
+//@ has - '//*[@class="code-attribute"]' '#[doc(hidden)]'
+//@ has - '//code' 'pub trait TraitHidden'
 #[doc(hidden)]
 pub trait TraitHidden {}
 
 //@ has 'foo/index.html' '//dt/a[@class="trait"]' 'Trait'
 pub trait Trait {
     //@ has 'foo/trait.Trait.html'
-    //@ has - '//*[@id="associatedconstant.BAR"]/*[@class="code-header"]' '#[doc(hidden)] const BAR: u32 = 0u32'
+    //@ has - '//*[@id="associatedconstant.BAR"]/*[@class="code-header"]/*[@class="code-attribute"]' '#[doc(hidden)]'
+    //@ has - '//*[@id="associatedconstant.BAR"]/*[@class="code-header"]' 'const BAR: u32 = 0u32'
     #[doc(hidden)]
     const BAR: u32 = 0;
 
+    //@ has - '//*[@class="code-attribute"]' '#[doc(hidden)]'
     //@ has - '//*[@id="method.foo"]/*[@class="code-header"]' 'fn foo()'
     #[doc(hidden)]
     fn foo() {}
@@ -33,26 +37,31 @@ pub trait Trait {
 //@ has 'foo/struct.Struct.html'
 pub struct Struct {
     //@ has - '//*[@id="structfield.a"]/code' 'a: u32'
+    //@ has - '//*[@class="code-attribute"]' '#[doc(hidden)]'
     #[doc(hidden)]
     pub a: u32,
 }
 
 impl Struct {
+    //@ has - '//*[@class="code-attribute"]' '#[doc(hidden)]'
     //@ has - '//*[@id="method.new"]/*[@class="code-header"]' 'pub fn new() -> Self'
     #[doc(hidden)]
     pub fn new() -> Self { Self { a: 0 } }
 }
 
 impl Trait for Struct {
-    //@ has - '//*[@id="associatedconstant.BAR"]/*[@class="code-header"]' '#[doc(hidden)] const BAR: u32 = 0u32'
-    //@ has - '//*[@id="method.foo"]/*[@class="code-header"]' '#[doc(hidden)] fn foo()'
+    //@ has - '//*[@id="associatedconstant.BAR"]/*[@class="code-header"]/*[@class="code-attribute"]' '#[doc(hidden)]'
+    //@ has - '//*[@id="associatedconstant.BAR"]/*[@class="code-header"]' 'const BAR: u32 = 0u32'
+    //@ has - '//*[@id="method.foo"]/*[@class="code-header"]/*[@class="code-attribute"]' '#[doc(hidden)]'
+    //@ has - '//*[@id="method.foo"]/*[@class="code-header"]' 'fn foo()'
 }
 //@ has - '//*[@id="impl-TraitHidden-for-Struct"]/*[@class="code-header"]' 'impl TraitHidden for Struct'
 impl TraitHidden for Struct {}
 
 //@ has 'foo/index.html' '//dt/a[@class="enum"]' 'HiddenEnum'
 //@ has 'foo/enum.HiddenEnum.html'
-//@ has - '//code' '#[doc(hidden)] pub enum HiddenEnum'
+//@ has - '//*[@class="code-attribute"]' '#[doc(hidden)]'
+//@ has - '//code' 'pub enum HiddenEnum'
 #[doc(hidden)]
 pub enum HiddenEnum {
     A,
@@ -60,6 +69,7 @@ pub enum HiddenEnum {
 
 //@ has 'foo/index.html' '//dt/a[@class="enum"]' 'Enum'
 pub enum Enum {
+    //@ has - '//*[@class="code-attribute"]' '#[doc(hidden)]'
     //@ has 'foo/enum.Enum.html' '//*[@id="variant.A"]/*[@class="code-header"]' 'A'
     #[doc(hidden)]
     A,
@@ -72,4 +82,13 @@ pub mod hidden {
     //@ has - '//dt/a[@class="fn"]' 'inside_hidden'
     //@ has 'foo/hidden/fn.inside_hidden.html'
     pub fn inside_hidden() {}
+}
+
+//@ has 'foo/index.html'
+//@ has - '//*[@class="code-attribute"]' '#[doc(hidden)]'
+//@ has - '//a[@class="macro"]' 'macro_rule'
+#[doc(hidden)]
+#[macro_export]
+macro_rules! macro_rule {
+    () => {};
 }


### PR DESCRIPTION
Makes `#[doc(hidden)]` render the same as other attrs, instead of being rendered it the same line like visibility specifiers (`pub` etc.). 
This only has effect when unstable flag `document-hidden-items` is on, as otherwise items with this attr wouldn't be rendered at all.
Also makes `#[doc(hidden)]` render for `macro_rules!`.

Fixes rust-lang/rust#132304.
r? @GuillaumeGomez 

---
Before:
<img width="287" height="115" alt="image" src="https://github.com/user-attachments/assets/5799f062-0fef-4f71-a007-a1e0c9491c0b" />
After:
<img width="290" height="146" alt="image" src="https://github.com/user-attachments/assets/3d506846-11aa-4c4b-a722-44a7faf05f2d" />

Before:
<img width="523" height="112" alt="image" src="https://github.com/user-attachments/assets/3477eb3d-a3aa-4a3c-965c-e2dcf5c5db53" />
After:
<img width="371" height="134" alt="image" src="https://github.com/user-attachments/assets/0dac72a2-d9ed-4e1e-b41a-26ca9db49cbd" />

