### PR TITLE
editorconfig: don't use nonexistent syntax

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,10 +8,13 @@ root = true
 end_of_line = lf
 charset = utf-8
 insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
 
 # some tests need trailing whitespace in output snapshots
-[!tests/]
-trim_trailing_whitespace = true
+[tests/**]
+trim_trailing_whitespace = false
 # for actual source code files of test, we still don't want trailing whitespace
 [tests/**.{rs,js}]
 trim_trailing_whitespace = true
@@ -19,9 +22,9 @@ trim_trailing_whitespace = true
 [tests/ui/{frontmatter/frontmatter-whitespace-3.rs,parser/shebang/shebang-space.rs}]
 trim_trailing_whitespace = false
 
-[!src/llvm-project]
-indent_style = space
-indent_size = 4
+[src/llvm-project]
+indent_style = unset
+indent_size = unset
 
 [*.rs]
 max_line_length = 100


### PR DESCRIPTION
reading through the editorconfig spec, using `!` to negate an entire glob is simply not a feature.

you can use `!` to negate a charachter class, but that's not what was going on here.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
