### PR TITLE
Move metadata generation

### DIFF
--- a/compiler/rustc_interface/src/queries.rs
+++ b/compiler/rustc_interface/src/queries.rs
@@ -28,8 +28,9 @@ impl Linker {
     pub fn codegen_and_build_linker(
         tcx: TyCtxt<'_>,
         codegen_backend: &dyn CodegenBackend,
+        metadata: EncodedMetadata,
     ) -> Linker {
-        let (ongoing_codegen, metadata) = passes::start_codegen(codegen_backend, tcx);
+        let ongoing_codegen = passes::start_codegen(codegen_backend, tcx);
 
         Linker {
             dep_graph: tcx.dep_graph.clone(),

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -2274,6 +2274,8 @@ fn prefetch_mir(tcx: TyCtxt<'_>) {
 // will allow us to slice the metadata to the precise length that we just
 // generated regardless of trailing bytes that end up in it.
 
+// The `Default` impl is for tests.
+#[derive(Default)]
 pub struct EncodedMetadata {
     // The declaration order matters because `full_metadata` should be dropped
     // before `_temp_dir`.

--- a/tests/ui-fulldeps/run-compiler-twice.rs
+++ b/tests/ui-fulldeps/run-compiler-twice.rs
@@ -12,6 +12,7 @@
 
 extern crate rustc_driver;
 extern crate rustc_interface;
+extern crate rustc_metadata;
 extern crate rustc_session;
 extern crate rustc_span;
 
@@ -81,7 +82,8 @@ fn compile(code: String, output: PathBuf, sysroot: Sysroot, linker: Option<&Path
         let krate = rustc_interface::passes::parse(&compiler.sess);
         let linker = rustc_interface::create_and_enter_global_ctxt(&compiler, krate, |tcx| {
             let _ = tcx.analysis(());
-            Linker::codegen_and_build_linker(tcx, &*compiler.codegen_backend)
+            let metadata = Default::default();
+            Linker::codegen_and_build_linker(tcx, &*compiler.codegen_backend, metadata)
         });
         linker.link(&compiler.sess, &*compiler.codegen_backend);
     });


### PR DESCRIPTION
It's currently done within `start_codegen`, which is called from `codegen_and_build_linker`, and it gets included in the codegen timing section. All this is surprising, because it's not part of codegen.

This commit moves it into `run_compiler`, just before the call to `codegen_and_build_linker`. This is a more sensible place for it. The commit also adds some extra non-obvious information about the `has_errors_or_delayed_bugs` check, which I learned when I tried moving metadata generation earlier.

Likewise, the nearby `rustc_delayed_bug_from_inside_query` code is also moved, because (a) it's not part of codegen, and (b) it needs to be nearby.

r? @bjorn3 