### PR TITLE
don't apply temporary lifetime extension rules to non-extended `super let`

### DIFF
--- a/compiler/rustc_hir_analysis/src/check/region.rs
+++ b/compiler/rustc_hir_analysis/src/check/region.rs
@@ -467,8 +467,12 @@ fn resolve_local<'tcx>(
     // A, but the inner rvalues `a()` and `b()` have an extended lifetime
     // due to rule C.
 
-    if let_kind == LetKind::Super {
-        if let Some(scope) = visitor.extended_super_lets.remove(&pat.unwrap().hir_id.local_id) {
+    let extend_initializer = match let_kind {
+        LetKind::Regular => true,
+        LetKind::Super
+            if let Some(scope) =
+                visitor.extended_super_lets.remove(&pat.unwrap().hir_id.local_id) =>
+        {
             // This expression was lifetime-extended by a parent let binding. E.g.
             //
             //     let a = {
@@ -481,7 +485,10 @@ fn resolve_local<'tcx>(
             // Processing of `let a` will have already decided to extend the lifetime of this
             // `super let` to its own var_scope. We use that scope.
             visitor.cx.var_parent = scope;
-        } else {
+            // Extend temporaries to live in the same scope as the parent `let`'s bindings.
+            true
+        }
+        LetKind::Super => {
             // This `super let` is not subject to lifetime extension from a parent let binding. E.g.
             //
             //     identity({ super let x = temp(); &x }).method();
@@ -497,10 +504,17 @@ fn resolve_local<'tcx>(
                 }
                 visitor.cx.var_parent = parent;
             }
+            // Don't lifetime-extend child `super let`s or block tail expressions' temporaries in
+            // the initializer when this `super let` is not itself extended by a parent `let`
+            // (#145784). Block tail expressions are temporary drop scopes in Editions 2024 and
+            // later, their temps shouldn't outlive the block in e.g. `f(pin!({ &temp() }))`.
+            false
         }
-    }
+    };
 
-    if let Some(expr) = init {
+    if let Some(expr) = init
+        && extend_initializer
+    {
         record_rvalue_scope_if_borrow_expr(visitor, expr, visitor.cx.var_parent);
 
         if let Some(pat) = pat {

--- a/tests/ui/borrowck/format-args-temporary-scopes.e2024.stderr
+++ b/tests/ui/borrowck/format-args-temporary-scopes.e2024.stderr
@@ -10,6 +10,18 @@ LL |     println!("{:?}", { &temp() });
    |
    = note: consider using a `let` binding to create a longer lived value
 
-error: aborting due to 1 previous error
+error[E0716]: temporary value dropped while borrowed
+  --> $DIR/format-args-temporary-scopes.rs:19:29
+   |
+LL |     println!("{:?}{:?}", { &temp() }, ());
+   |                          ---^^^^^---
+   |                          |  |    |
+   |                          |  |    temporary value is freed at the end of this statement
+   |                          |  creates a temporary value which is freed while still in use
+   |                          borrow later used here
+   |
+   = note: consider using a `let` binding to create a longer lived value
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0716`.

--- a/tests/ui/borrowck/format-args-temporary-scopes.e2024.stderr
+++ b/tests/ui/borrowck/format-args-temporary-scopes.e2024.stderr
@@ -1,0 +1,15 @@
+error[E0716]: temporary value dropped while borrowed
+  --> $DIR/format-args-temporary-scopes.rs:13:25
+   |
+LL |     println!("{:?}", { &temp() });
+   |                      ---^^^^^---
+   |                      |  |    |
+   |                      |  |    temporary value is freed at the end of this statement
+   |                      |  creates a temporary value which is freed while still in use
+   |                      borrow later used here
+   |
+   = note: consider using a `let` binding to create a longer lived value
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0716`.

--- a/tests/ui/borrowck/format-args-temporary-scopes.rs
+++ b/tests/ui/borrowck/format-args-temporary-scopes.rs
@@ -17,4 +17,5 @@ fn main() {
     // arguments when provided with two or more arguments. This caused the result of `temp()` to
     // outlive the result of the block, making this compile.
     println!("{:?}{:?}", { &temp() }, ());
+    //[e2024]~^ ERROR: temporary value dropped while borrowed [E0716]
 }

--- a/tests/ui/borrowck/format-args-temporary-scopes.rs
+++ b/tests/ui/borrowck/format-args-temporary-scopes.rs
@@ -1,0 +1,20 @@
+//! Test for #145784 as it relates to format arguments: arguments to macros such as `println!`
+//! should obey normal temporary scoping rules.
+//@ revisions: e2021 e2024
+//@ [e2021] check-pass
+//@ [e2021] edition: 2021
+//@ [e2024] edition: 2024
+
+fn temp() {}
+
+fn main() {
+    // In Rust 2024, block tail expressions are temporary scopes, so the result of `temp()` is
+    // dropped after evaluating `&temp()`.
+    println!("{:?}", { &temp() });
+    //[e2024]~^ ERROR: temporary value dropped while borrowed [E0716]
+
+    // In Rust 1.89, `format_args!` extended the lifetime of all extending expressions in its
+    // arguments when provided with two or more arguments. This caused the result of `temp()` to
+    // outlive the result of the block, making this compile.
+    println!("{:?}{:?}", { &temp() }, ());
+}

--- a/tests/ui/drop/super-let-tail-expr-drop-order.rs
+++ b/tests/ui/drop/super-let-tail-expr-drop-order.rs
@@ -1,0 +1,122 @@
+//! Test for #145784: the argument to `pin!` should be treated as an extending expression if and
+//! only if the whole `pin!` invocation is an extending expression. Likewise, since `pin!` is
+//! implemented in terms of `super let`, test the same for `super let` initializers. Since the
+//! argument to `pin!` and the initializer of `super let` are not temporary drop scopes, this only
+//! affects lifetimes in two cases:
+//!
+//! - Block tail expressions in Rust 2024, which are both extending expressions and temporary drop
+//! scopes; treating them as extending expressions within a non-extending `pin!` resulted in borrow
+//! expression operands living past the end of the block.
+//!
+//! - Nested `super let` statements, which can have their binding and temporary lifetimes extended
+//! when the block they're in is an extending expression.
+//!
+//! For more information on extending expressions, see
+//! https://doc.rust-lang.org/reference/destructors.html#extending-based-on-expressions
+//!
+//! For tests that `super let` initializers aren't temporary drop scopes, and tests for
+//! lifetime-extended `super let`, see tests/ui/borrowck/super-let-lifetime-and-drop.rs
+//@ run-pass
+//@ revisions: e2021 e2024
+//@ [e2021] edition: 2021
+//@ [e2024] edition: 2024
+
+#![feature(super_let)]
+
+use std::cell::RefCell;
+use std::pin::pin;
+
+fn main() {
+    // Test block arguments to `pin!` in non-extending expressions.
+    // In Rust 2021, block tail expressions aren't temporary drop scopes, so their temporaries
+    // should outlive the `pin!` invocation.
+    // In Rust 2024, block tail expressions are temporary drop scopes, so their temporaries should
+    // be dropped after evaluating the tail expression within the `pin!` invocation.
+    // By nesting two `pin!` calls, this ensures non-extended `pin!` doesn't extend an inner `pin!`.
+    assert_drop_order(1..=3, |o| {
+        #[cfg(e2021)]
+        (
+            pin!((
+                pin!({ &o.log(3) as *const LogDrop<'_> }),
+                drop(o.log(1)),
+            )),
+            drop(o.log(2)),
+        );
+        #[cfg(e2024)]
+        (
+            pin!((
+                pin!({ &o.log(3) as *const LogDrop<'_> }),
+                drop(o.log(1)),
+            )),
+            drop(o.log(2)),
+        );
+    });
+
+    // The same holds for `super let` initializers in non-extending expressions.
+    assert_drop_order(1..=4, |o| {
+        #[cfg(e2021)]
+        (
+            {
+                super let _ = {
+                    super let _ = { &o.log(4) as *const LogDrop<'_> };
+                    drop(o.log(1))
+                };
+                drop(o.log(2))
+            },
+            drop(o.log(3)),
+        );
+        #[cfg(e2024)]
+        (
+            {
+                super let _ = {
+                    super let _ = { &o.log(4) as *const LogDrop<'_> };
+                    drop(o.log(1))
+                };
+                drop(o.log(2))
+            },
+            drop(o.log(3)),
+        );
+    });
+
+    // Within an extending expression, the argument to `pin!` is also an extending expression,
+    // allowing borrow operands in block tail expressions to have extended lifetimes.
+    assert_drop_order(1..=2, |o| {
+        let _ = pin!({ &o.log(2) as *const LogDrop<'_> });
+        drop(o.log(1));
+    });
+
+    // The same holds for `super let` initializers in extending expressions.
+    assert_drop_order(1..=2, |o| {
+        let _ =  { super let _ = { &o.log(2) as *const LogDrop<'_> }; };
+        drop(o.log(1));
+    });
+}
+
+// # Test scaffolding...
+
+struct DropOrder(RefCell<Vec<u64>>);
+struct LogDrop<'o>(&'o DropOrder, u64);
+
+impl DropOrder {
+    fn log(&self, n: u64) -> LogDrop<'_> {
+        LogDrop(self, n)
+    }
+}
+
+impl<'o> Drop for LogDrop<'o> {
+    fn drop(&mut self) {
+        self.0.0.borrow_mut().push(self.1);
+    }
+}
+
+#[track_caller]
+fn assert_drop_order(
+    ex: impl IntoIterator<Item = u64>,
+    f: impl Fn(&DropOrder),
+) {
+    let order = DropOrder(RefCell::new(Vec::new()));
+    f(&order);
+    let order = order.0.into_inner();
+    let expected: Vec<u64> = ex.into_iter().collect();
+    assert_eq!(order, expected);
+}

--- a/tests/ui/drop/super-let-tail-expr-drop-order.rs
+++ b/tests/ui/drop/super-let-tail-expr-drop-order.rs
@@ -45,10 +45,10 @@ fn main() {
         #[cfg(e2024)]
         (
             pin!((
-                pin!({ &o.log(3) as *const LogDrop<'_> }),
-                drop(o.log(1)),
+                pin!({ &o.log(1) as *const LogDrop<'_> }),
+                drop(o.log(2)),
             )),
-            drop(o.log(2)),
+            drop(o.log(3)),
         );
     });
 
@@ -69,12 +69,12 @@ fn main() {
         (
             {
                 super let _ = {
-                    super let _ = { &o.log(4) as *const LogDrop<'_> };
-                    drop(o.log(1))
+                    super let _ = { &o.log(1) as *const LogDrop<'_> };
+                    drop(o.log(2))
                 };
-                drop(o.log(2))
+                drop(o.log(3))
             },
-            drop(o.log(3)),
+            drop(o.log(4)),
         );
     });
 


### PR DESCRIPTION
Reference PR: rust-lang/reference#1980

This changes the semantics for `super let` (and macros implemented in terms of it, such as `pin!`, `format_args!`, `write!`, and `println!`) as suggested by @theemathas in https://github.com/rust-lang/rust/issues/145784#issuecomment-3218658335, making `super let` initializers only count as [extending expressions](https://doc.rust-lang.org/nightly/reference/destructors.html#extending-based-on-expressions) when the `super let` itself is within an extending block. Since `super let` initializers aren't temporary drop scopes, their temporaries outside of inner temporary scopes are effectively always extended, even when not in extending positions; this only affects two cases as far as I can tell:
- Block tail expressions in Rust 2024. This PR makes `f(pin!({ &temp() }))` drop `temp()` at the end of the block in Rust 2024, whereas previously it would live until after the call to `f` because syntactically the `temp()` was in an extending position as a result of `super let` in `pin!`'s expansion.
- `super let` nested within a non-extended `super let` is no longer extended. i.e. a normal `let` is required to treat `super let`s as extending (in which case nested `super let`s will also be extending).

Closes rust-lang/rust#145784

This is a breaking change. Both static and dynamic semantics are affected. The most likely breakage is for programs to stop compiling, but it's technically possible for drop order to silently change as well (as in rust-lang/rust#145784). Since this affects stable macros, it probably would need a crater run.

Nominating for discussion alongside rust-lang/rust#145784: @rustbot label +I-lang-nominated +I-libs-api-nominated

Tracking issue for `super let`: rust-lang/rust#139076