### PR TITLE
rustc_codegen_ssa: More comprehensive RISC-V ELF flags

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/metadata.rs
+++ b/compiler/rustc_codegen_ssa/src/back/metadata.rs
@@ -329,7 +329,7 @@ pub(super) fn elf_e_flags(architecture: Architecture, sess: &Session) -> u32 {
             // Source: https://github.com/riscv-non-isa/riscv-elf-psabi-doc/blob/079772828bd10933d34121117a222b4cc0ee2200/riscv-elf.adoc
             let mut e_flags: u32 = 0x0;
 
-            // Check if compressed is enabled
+            // Check if compression is enabled
             // `unstable_target_features` is used here because "c" is gated behind riscv_target_feature.
             if sess.unstable_target_features.contains(&sym::c) {
                 e_flags |= elf::EF_RISCV_RVC;

--- a/compiler/rustc_codegen_ssa/src/back/metadata.rs
+++ b/compiler/rustc_codegen_ssa/src/back/metadata.rs
@@ -330,9 +330,15 @@ pub(super) fn elf_e_flags(architecture: Architecture, sess: &Session) -> u32 {
             let mut e_flags: u32 = 0x0;
 
             // Check if compression is enabled
-            // `unstable_target_features` is used here because "c" is gated behind riscv_target_feature.
-            if sess.unstable_target_features.contains(&sym::c) {
+            // `unstable_target_features` is used here because "zca" is gated behind riscv_target_feature.
+            if sess.unstable_target_features.contains(&sym::zca) {
                 e_flags |= elf::EF_RISCV_RVC;
+            }
+
+            // Check if RVTSO is enabled
+            // `unstable_target_features` is used here because "ztso" is gated behind riscv_target_feature.
+            if sess.unstable_target_features.contains(&sym::ztso) {
+                e_flags |= elf::EF_RISCV_TSO;
             }
 
             // Set the appropriate flag based on ABI

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -2419,9 +2419,11 @@ symbols! {
         yield_expr,
         ymm_reg,
         yreg,
+        zca,
         zfh,
         zfhmin,
         zmm_reg,
+        ztso,
         // tidy-alphabetical-end
     }
 }


### PR DESCRIPTION
This change implements more conformant, more comprehensive RISC-V ELF flags handling when generating certain object files directly from rustc.

*   Use `"zca"` instead of `"c"`  
    The "Zca" extension (a subset of "C") is the minimal configuration for compressed instructions to set `EF_RISCV_RVC` flag.
*   Set TSO flag from `"ztso"`  
    The "Ztso" extension denotes that the program depends on the RVTSO (Total Store Ordering) memory consistency model, which is stronger than the standard RVWMO (Weak Memory Ordering) consistency model and on ELF targets, we need to set `EF_RISCV_TSO` flag.

<!-- homu-ignore:start -->
@rustbot label +O-riscv
<!-- homu-ignore:end -->