### PR TITLE
Don't show warnings from xcrun with -Zverbose-internals

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/apple.rs
+++ b/compiler/rustc_codegen_ssa/src/back/apple.rs
@@ -164,7 +164,7 @@ pub(super) fn get_sdk_root(sess: &Session) -> Option<PathBuf> {
     //
     // Note that when cross-compiling from e.g. Linux, the `xcrun` binary may sometimes be provided
     // as a shim by a cross-compilation helper tool. It usually isn't, but we still try nonetheless.
-    match xcrun_show_sdk_path(sdk_name, sess.verbose_internals()) {
+    match xcrun_show_sdk_path(sdk_name, false) {
         Ok((path, stderr)) => {
             // Emit extra stderr, such as if `-verbose` was passed, or if `xcrun` emitted a warning.
             if !stderr.is_empty() {


### PR DESCRIPTION
These kinds of warnings can make our test suite fail spuriously, so if we want them, we'll need a different flag.

This was introduced in https://github.com/rust-lang/rust/pull/131477. Fixes https://github.com/rust-lang/rust/issues/145543.

r? apiraino
@bors rollup