### PR TITLE
Improve error messages around invalid literals in attribute arguments

### DIFF
--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -2077,7 +2077,7 @@ impl<'a> Parser<'a> {
         (token::Lit { symbol: name, suffix: None, kind: token::Char }, span)
     }
 
-    pub fn mk_meta_item_lit_char(name: Symbol, span: Span) -> MetaItemLit {
+    fn mk_meta_item_lit_char(name: Symbol, span: Span) -> MetaItemLit {
         ast::MetaItemLit {
             symbol: name,
             suffix: None,
@@ -2086,7 +2086,7 @@ impl<'a> Parser<'a> {
         }
     }
 
-    pub fn handle_missing_lit<L>(
+    fn handle_missing_lit<L>(
         &mut self,
         mk_lit_char: impl FnOnce(Symbol, Span) -> L,
     ) -> PResult<'a, L> {

--- a/compiler/rustc_session/src/errors.rs
+++ b/compiler/rustc_session/src/errors.rs
@@ -384,6 +384,10 @@ pub fn report_lit_error(
     lit: token::Lit,
     span: Span,
 ) -> ErrorGuaranteed {
+    create_lit_error(psess, err, lit, span).emit()
+}
+
+pub fn create_lit_error(psess: &ParseSess, err: LitError, lit: token::Lit, span: Span) -> Diag<'_> {
     // Checks if `s` looks like i32 or u1234 etc.
     fn looks_like_width_suffix(first_chars: &[char], s: &str) -> bool {
         s.len() > 1 && s.starts_with(first_chars) && s[1..].chars().all(|c| c.is_ascii_digit())
@@ -414,32 +418,32 @@ pub fn report_lit_error(
     let dcx = psess.dcx();
     match err {
         LitError::InvalidSuffix(suffix) => {
-            dcx.emit_err(InvalidLiteralSuffix { span, kind: lit.kind.descr(), suffix })
+            dcx.create_err(InvalidLiteralSuffix { span, kind: lit.kind.descr(), suffix })
         }
         LitError::InvalidIntSuffix(suffix) => {
             let suf = suffix.as_str();
             if looks_like_width_suffix(&['i', 'u'], suf) {
                 // If it looks like a width, try to be helpful.
-                dcx.emit_err(InvalidIntLiteralWidth { span, width: suf[1..].into() })
+                dcx.create_err(InvalidIntLiteralWidth { span, width: suf[1..].into() })
             } else if let Some(fixed) = fix_base_capitalisation(lit.symbol.as_str(), suf) {
-                dcx.emit_err(InvalidNumLiteralBasePrefix { span, fixed })
+                dcx.create_err(InvalidNumLiteralBasePrefix { span, fixed })
             } else {
-                dcx.emit_err(InvalidNumLiteralSuffix { span, suffix: suf.to_string() })
+                dcx.create_err(InvalidNumLiteralSuffix { span, suffix: suf.to_string() })
             }
         }
         LitError::InvalidFloatSuffix(suffix) => {
             let suf = suffix.as_str();
             if looks_like_width_suffix(&['f'], suf) {
                 // If it looks like a width, try to be helpful.
-                dcx.emit_err(InvalidFloatLiteralWidth { span, width: suf[1..].to_string() })
+                dcx.create_err(InvalidFloatLiteralWidth { span, width: suf[1..].to_string() })
             } else {
-                dcx.emit_err(InvalidFloatLiteralSuffix { span, suffix: suf.to_string() })
+                dcx.create_err(InvalidFloatLiteralSuffix { span, suffix: suf.to_string() })
             }
         }
         LitError::NonDecimalFloat(base) => match base {
-            16 => dcx.emit_err(HexadecimalFloatLiteralNotSupported { span }),
-            8 => dcx.emit_err(OctalFloatLiteralNotSupported { span }),
-            2 => dcx.emit_err(BinaryFloatLiteralNotSupported { span }),
+            16 => dcx.create_err(HexadecimalFloatLiteralNotSupported { span }),
+            8 => dcx.create_err(OctalFloatLiteralNotSupported { span }),
+            2 => dcx.create_err(BinaryFloatLiteralNotSupported { span }),
             _ => unreachable!(),
         },
         LitError::IntTooLarge(base) => {
@@ -450,7 +454,7 @@ pub fn report_lit_error(
                 16 => format!("{max:#x}"),
                 _ => format!("{max}"),
             };
-            dcx.emit_err(IntLiteralTooLarge { span, limit })
+            dcx.create_err(IntLiteralTooLarge { span, limit })
         }
     }
 }

--- a/tests/ui/parser/bad-lit-suffixes.rs
+++ b/tests/ui/parser/bad-lit-suffixes.rs
@@ -45,3 +45,10 @@ extern "C" {}
 //~^ ERROR invalid suffix `suffix` for number literal
 //~| ERROR malformed `rustc_layout_scalar_valid_range_start` attribute input
 struct S;
+
+impl S {
+    #[rustc_confusables("blah"suffix)]
+    //~^ ERROR suffixes on string literals are invalid
+    //~| ERROR malformed `rustc_confusables` attribute input
+    fn woof() { }
+}

--- a/tests/ui/parser/bad-lit-suffixes.rs
+++ b/tests/ui/parser/bad-lit-suffixes.rs
@@ -38,17 +38,14 @@ fn g() {}
 
 #[link(name = "string"suffix)]
 //~^ ERROR suffixes on string literals are invalid
-//~| ERROR malformed `link` attribute input
 extern "C" {}
 
 #[rustc_layout_scalar_valid_range_start(0suffix)]
 //~^ ERROR invalid suffix `suffix` for number literal
-//~| ERROR malformed `rustc_layout_scalar_valid_range_start` attribute input
 struct S;
 
 impl S {
     #[rustc_confusables("blah"suffix)]
     //~^ ERROR suffixes on string literals are invalid
-    //~| ERROR malformed `rustc_confusables` attribute input
     fn woof() { }
 }

--- a/tests/ui/parser/bad-lit-suffixes.stderr
+++ b/tests/ui/parser/bad-lit-suffixes.stderr
@@ -160,63 +160,20 @@ error: suffixes on string literals are invalid
 LL | #[link(name = "string"suffix)]
    |               ^^^^^^^^^^^^^^ invalid suffix `suffix`
 
-error[E0539]: malformed `link` attribute input
-  --> $DIR/bad-lit-suffixes.rs:39:1
-   |
-LL | #[link(name = "string"suffix)]
-   | ^^^^^^^---------------------^^
-   |        |
-   |        expected this to be of the form `name = "..."`
-   |
-   = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute>
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL - #[link(name = "string"suffix)]
-LL + #[link(name = "...")]
-   |
-LL - #[link(name = "string"suffix)]
-LL + #[link(name = "...", import_name_type = "decorated|noprefix|undecorated")]
-   |
-LL - #[link(name = "string"suffix)]
-LL + #[link(name = "...", kind = "dylib|static|...")]
-   |
-LL - #[link(name = "string"suffix)]
-LL + #[link(name = "...", kind = "dylib|static|...", wasm_import_module = "...", import_name_type = "decorated|noprefix|undecorated")]
-   |
-   = and 1 other candidate
-
 error: invalid suffix `suffix` for number literal
-  --> $DIR/bad-lit-suffixes.rs:44:41
+  --> $DIR/bad-lit-suffixes.rs:43:41
    |
 LL | #[rustc_layout_scalar_valid_range_start(0suffix)]
    |                                         ^^^^^^^ invalid suffix `suffix`
    |
    = help: the suffix must be one of the numeric types (`u32`, `isize`, `f32`, etc.)
 
-error[E0539]: malformed `rustc_layout_scalar_valid_range_start` attribute input
-  --> $DIR/bad-lit-suffixes.rs:44:1
-   |
-LL | #[rustc_layout_scalar_valid_range_start(0suffix)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-------^^
-   | |                                       |
-   | |                                       expected an integer literal here
-   | help: must be of the form: `#[rustc_layout_scalar_valid_range_start(start)]`
-
 error: suffixes on string literals are invalid
-  --> $DIR/bad-lit-suffixes.rs:50:25
+  --> $DIR/bad-lit-suffixes.rs:48:25
    |
 LL |     #[rustc_confusables("blah"suffix)]
    |                         ^^^^^^^^^^^^ invalid suffix `suffix`
 
-error[E0539]: malformed `rustc_confusables` attribute input
-  --> $DIR/bad-lit-suffixes.rs:50:5
-   |
-LL |     #[rustc_confusables("blah"suffix)]
-   |     ^^^^^^^^^^^^^^^^^^^^------------^^
-   |     |                   |
-   |     |                   expected a string literal here
-   |     help: must be of the form: `#[rustc_confusables("name1", "name2", ...)]`
-
-error: aborting due to 25 previous errors; 2 warnings emitted
+error: aborting due to 22 previous errors; 2 warnings emitted
 
 For more information about this error, try `rustc --explain E0539`.

--- a/tests/ui/parser/bad-lit-suffixes.stderr
+++ b/tests/ui/parser/bad-lit-suffixes.stderr
@@ -202,6 +202,21 @@ LL | #[rustc_layout_scalar_valid_range_start(0suffix)]
    | |                                       expected an integer literal here
    | help: must be of the form: `#[rustc_layout_scalar_valid_range_start(start)]`
 
-error: aborting due to 23 previous errors; 2 warnings emitted
+error: suffixes on string literals are invalid
+  --> $DIR/bad-lit-suffixes.rs:50:25
+   |
+LL |     #[rustc_confusables("blah"suffix)]
+   |                         ^^^^^^^^^^^^ invalid suffix `suffix`
+
+error[E0539]: malformed `rustc_confusables` attribute input
+  --> $DIR/bad-lit-suffixes.rs:50:5
+   |
+LL |     #[rustc_confusables("blah"suffix)]
+   |     ^^^^^^^^^^^^^^^^^^^^------------^^
+   |     |                   |
+   |     |                   expected a string literal here
+   |     help: must be of the form: `#[rustc_confusables("name1", "name2", ...)]`
+
+error: aborting due to 25 previous errors; 2 warnings emitted
 
 For more information about this error, try `rustc --explain E0539`.


### PR DESCRIPTION
r? @jdonszelmann 

This previously created two errors, which is a bit ugly and the second one didn't add any value
Blocked on https://github.com/rust-lang/rust/pull/143193