### PR TITLE
If a trait item appears in rustdoc search, hide the corrosponding impl items

### DIFF
--- a/src/ci/docker/host-x86_64/pr-check-2/Dockerfile
+++ b/src/ci/docker/host-x86_64/pr-check-2/Dockerfile
@@ -32,7 +32,7 @@ ENV SCRIPT \
         python3 ../x.py clippy ci --stage 2 && \
         python3 ../x.py test --stage 1 core alloc std test proc_macro && \
         python3 ../x.py test --stage 1 src/tools/compiletest && \
-        python3 ../x.py doc bootstrap && \
+        python3 ../x.py doc bootstrap --stage 1 && \
         # Build both public and internal documentation.
         RUSTDOCFLAGS=\"--document-private-items --document-hidden-items\" python3 ../x.py doc compiler --stage 1 && \
         RUSTDOCFLAGS=\"--document-private-items --document-hidden-items\" python3 ../x.py doc library --stage 1 && \

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -134,6 +134,8 @@ pub(crate) struct IndexItem {
     pub(crate) desc: String,
     pub(crate) parent: Option<DefId>,
     pub(crate) parent_idx: Option<usize>,
+    pub(crate) trait_parent: Option<DefId>,
+    pub(crate) trait_parent_idx: Option<usize>,
     pub(crate) exact_module_path: Option<Vec<Symbol>>,
     pub(crate) impl_id: Option<DefId>,
     pub(crate) search_type: Option<IndexItemFunctionType>,

--- a/src/librustdoc/html/render/search_index.rs
+++ b/src/librustdoc/html/render/search_index.rs
@@ -580,6 +580,7 @@ impl SerializedSearchIndex {
                          module_path,
                          exact_module_path,
                          parent,
+                         trait_parent,
                          deprecated,
                          associated_item_disambiguator,
                      }| EntryData {
@@ -589,6 +590,7 @@ impl SerializedSearchIndex {
                         exact_module_path: exact_module_path
                             .and_then(|path_id| map.get(&path_id).copied()),
                         parent: parent.and_then(|path_id| map.get(&path_id).copied()),
+                        trait_parent: trait_parent.and_then(|path_id| map.get(&path_id).copied()),
                         deprecated: *deprecated,
                         associated_item_disambiguator: associated_item_disambiguator.clone(),
                     },
@@ -870,6 +872,7 @@ struct EntryData {
     module_path: Option<usize>,
     exact_module_path: Option<usize>,
     parent: Option<usize>,
+    trait_parent: Option<usize>,
     deprecated: bool,
     associated_item_disambiguator: Option<String>,
 }
@@ -885,6 +888,7 @@ impl Serialize for EntryData {
         seq.serialize_element(&self.module_path.map(|id| id + 1).unwrap_or(0))?;
         seq.serialize_element(&self.exact_module_path.map(|id| id + 1).unwrap_or(0))?;
         seq.serialize_element(&self.parent.map(|id| id + 1).unwrap_or(0))?;
+        seq.serialize_element(&self.trait_parent.map(|id| id + 1).unwrap_or(0))?;
         seq.serialize_element(&if self.deprecated { 1 } else { 0 })?;
         if let Some(disambig) = &self.associated_item_disambiguator {
             seq.serialize_element(&disambig)?;
@@ -916,6 +920,9 @@ impl<'de> Deserialize<'de> for EntryData {
                     .ok_or_else(|| A::Error::missing_field("exact_module_path"))?;
                 let parent: SerializedOptional32 =
                     v.next_element()?.ok_or_else(|| A::Error::missing_field("parent"))?;
+                let trait_parent: SerializedOptional32 =
+                    v.next_element()?.ok_or_else(|| A::Error::missing_field("trait_parent"))?;
+
                 let deprecated: u32 = v.next_element()?.unwrap_or(0);
                 let associated_item_disambiguator: Option<String> = v.next_element()?;
                 Ok(EntryData {
@@ -925,6 +932,7 @@ impl<'de> Deserialize<'de> for EntryData {
                     exact_module_path: Option::<i32>::from(exact_module_path)
                         .map(|path| path as usize),
                     parent: Option::<i32>::from(parent).map(|path| path as usize),
+                    trait_parent: Option::<i32>::from(trait_parent).map(|path| path as usize),
                     deprecated: deprecated != 0,
                     associated_item_disambiguator,
                 })
@@ -1275,7 +1283,8 @@ pub(crate) fn build_index(
 
     // Attach all orphan items to the type's definition if the type
     // has since been learned.
-    for &OrphanImplItem { impl_id, parent, ref item, ref impl_generics } in &cache.orphan_impl_items
+    for &OrphanImplItem { impl_id, parent, trait_parent, ref item, ref impl_generics } in
+        &cache.orphan_impl_items
     {
         if let Some((fqp, _)) = cache.paths.get(&parent) {
             let desc = short_markdown_summary(&item.doc_value(), &item.link_names(cache));
@@ -1287,6 +1296,8 @@ pub(crate) fn build_index(
                 desc,
                 parent: Some(parent),
                 parent_idx: None,
+                trait_parent,
+                trait_parent_idx: None,
                 exact_module_path: None,
                 impl_id,
                 search_type: get_function_type_for_search(
@@ -1391,6 +1402,7 @@ pub(crate) fn build_index(
                         module_path: None,
                         exact_module_path: None,
                         parent: None,
+                        trait_parent: None,
                         deprecated: false,
                         associated_item_disambiguator: None,
                     }),
@@ -1404,39 +1416,46 @@ pub(crate) fn build_index(
         }
     };
 
-    // First, populate associated item parents
+    // First, populate associated item parents and trait parents
     let crate_items: Vec<&mut IndexItem> = search_index
         .iter_mut()
         .map(|item| {
-            item.parent_idx = item.parent.and_then(|defid| {
-                cache.paths.get(&defid).map(|&(ref fqp, ty)| {
-                    let pathid = serialized_index.names.len();
-                    match serialized_index.crate_paths_index.entry((ty, fqp.clone())) {
-                        Entry::Occupied(entry) => *entry.get(),
-                        Entry::Vacant(entry) => {
-                            entry.insert(pathid);
-                            let (name, path) = fqp.split_last().unwrap();
-                            serialized_index.push_path(
-                                name.as_str().to_string(),
-                                PathData {
-                                    ty,
-                                    module_path: path.to_vec(),
-                                    exact_module_path: if let Some(exact_path) =
-                                        cache.exact_paths.get(&defid)
-                                        && let Some((name2, exact_path)) = exact_path.split_last()
-                                        && name == name2
-                                    {
-                                        Some(exact_path.to_vec())
-                                    } else {
-                                        None
+            let mut defid_to_rowid = |defid, check_external: bool| {
+                cache
+                    .paths
+                    .get(&defid)
+                    .or_else(|| check_external.then(|| cache.external_paths.get(&defid)).flatten())
+                    .map(|&(ref fqp, ty)| {
+                        let pathid = serialized_index.names.len();
+                        match serialized_index.crate_paths_index.entry((ty, fqp.clone())) {
+                            Entry::Occupied(entry) => *entry.get(),
+                            Entry::Vacant(entry) => {
+                                entry.insert(pathid);
+                                let (name, path) = fqp.split_last().unwrap();
+                                serialized_index.push_path(
+                                    name.as_str().to_string(),
+                                    PathData {
+                                        ty,
+                                        module_path: path.to_vec(),
+                                        exact_module_path: if let Some(exact_path) =
+                                            cache.exact_paths.get(&defid)
+                                            && let Some((name2, exact_path)) =
+                                                exact_path.split_last()
+                                            && name == name2
+                                        {
+                                            Some(exact_path.to_vec())
+                                        } else {
+                                            None
+                                        },
                                     },
-                                },
-                            );
-                            usize::try_from(pathid).unwrap()
+                                );
+                                usize::try_from(pathid).unwrap()
+                            }
                         }
-                    }
-                })
-            });
+                    })
+            };
+            item.parent_idx = item.parent.and_then(|p| defid_to_rowid(p, false));
+            item.trait_parent_idx = item.trait_parent.and_then(|p| defid_to_rowid(p, true));
 
             if let Some(defid) = item.defid
                 && item.parent_idx.is_none()
@@ -1519,6 +1538,7 @@ pub(crate) fn build_index(
             Some(EntryData {
                 ty: item.ty,
                 parent: item.parent_idx,
+                trait_parent: item.trait_parent_idx,
                 module_path,
                 exact_module_path,
                 deprecated: item.deprecation.is_some(),

--- a/src/librustdoc/html/static/js/rustdoc.d.ts
+++ b/src/librustdoc/html/static/js/rustdoc.d.ts
@@ -241,6 +241,7 @@ declare namespace rustdoc {
         modulePath: number?,
         exactModulePath: number?,
         parent: number?,
+        traitParent: number?,
         deprecated: boolean,
         associatedItemDisambiguator: string?,
     }
@@ -291,8 +292,11 @@ declare namespace rustdoc {
         path: PathData?,
         functionData: FunctionData?,
         deprecated: boolean,
-        parent: { path: PathData, name: string}?,
+        parent: RowParent,
+        traitParent: RowParent,
     }
+
+    type RowParent = { path: PathData, name: string } | null;
 
     type ItemType = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 |
         11 | 12 | 13 | 14 | 15 | 16 | 17 | 18 | 19 | 20 |
@@ -316,7 +320,23 @@ declare namespace rustdoc {
     interface ResultObject {
         desc: Promise<string|null>,
         displayPath: string,
+        /**
+         * path to where the item was defined (not inlined),
+         * then `|`, then the `ItemType` of the item.
+         *
+         * This is often a private path, so it should not be displayed,
+         * but this allows us to use it to reliably deduplicate reexported and inlined items
+         */
         fullPath: string,
+        /**
+         * The `fullPath` of the corresponding item within a trait.
+         * For example, for `File::read`, this would be `std::io::Read::read|12`
+         *
+         * This is used to hide items from trait impls when the trait itself is in the search results.
+         *
+         * `null` if the item is not from a trait impl block.
+         */
+        traitPath: string | null,
         href: string,
         id: number,
         dist: number,

--- a/src/librustdoc/html/static/js/search.js
+++ b/src/librustdoc/html/static/js/search.js
@@ -1077,6 +1077,34 @@ function isPathSeparator(c) {
 }
 
 /**
+ * Given an array and an ascending list of indices,
+ * efficiently removes each index in the array.
+ *
+ * @template T
+ * @param {Array<T>} a
+ * @param {Array<number>} idxList
+ */
+function removeIdxListAsc(a, idxList) {
+    if (idxList.length === 0) {
+        return;
+    }
+    let removed = 0;
+    let i = idxList[0];
+    let nextToRemove = idxList[0];
+    while (i < a.length - idxList.length) {
+        while (i === nextToRemove && removed < idxList.length) {
+            removed++;
+            i++;
+            nextToRemove = idxList[removed];
+        }
+        a[i] = a[i + removed];
+        i++;
+    }
+    // truncate array
+    a.length -= idxList.length;
+}
+
+/**
  * @template T
  */
 class VlqHexDecoder {
@@ -2615,7 +2643,7 @@ class DocSearch {
          */
         const transformResults = (results, typeInfo, duplicates) => {
             /** @type {rustdoc.ResultObject[]} */
-            let out = [];
+            const out = [];
 
             // if we match a trait-associated item, we want to go back and
             // remove all the items that are their equivalent but in an impl block.
@@ -2712,16 +2740,9 @@ class DocSearch {
                         list.push(out.length);
                         traitImplIdxMap.set(obj.traitPath, list);
                     } else {
-                        // FIXME: this is `O(n*m)` because we're repeatedly
-                        // shifting with Array.splice, but could be `O(n+m)` if
-                        // we did the shifting manually in a more clever way.
                         const toRemoveList = traitImplIdxMap.get(obj.fullPath);
                         if (toRemoveList) {
-                            // iterate in reverse order so we don't shift the indexes
-                            for (let i = toRemoveList.length - 1; i >= 0; i--) {
-                                const rmIdx = toRemoveList[i];
-                                out = out.splice(rmIdx, 1);
-                            }
+                            removeIdxListAsc(out, toRemoveList);
                         }
                         traitImplIdxMap.delete(obj.fullPath);
                     }

--- a/tests/rustdoc-gui/search-result-color.goml
+++ b/tests/rustdoc-gui/search-result-color.goml
@@ -5,7 +5,7 @@ include: "utils.goml"
 define-function: (
     "check-search-color",
     [
-        theme, count_color, desc_color, path_color, bottom_border_color, keyword_color,
+        theme, count_color, path_color, bottom_border_color, keyword_color,
         struct_color, associatedtype_color, tymethod_color, method_color, structfield_color,
         structfield_hover_color, macro_color, fn_color, hover_path_color, hover_background,
         attribute_color, grey
@@ -20,10 +20,6 @@ define-function: (
             "#search-tabs > button > .count",
             {"color": |count_color|},
             ALL,
-        )
-        assert-css: (
-            "//*[@class='desc'][normalize-space()='Just a normal struct.']",
-            {"color": |desc_color|},
         )
         assert-css: (
             "//*[@class='result-name']//*[normalize-space()='test_docs::']",
@@ -97,16 +93,6 @@ define-function: (
             ALL,
         )
 
-        // Checking color and background on hover.
-        move-cursor-to: "//*[@class='desc'][normalize-space()='Just a normal struct.']"
-        assert-css: (
-            "//*[@class='result-name']//*[normalize-space()='test_docs::']",
-            {"color": |hover_path_color|},
-        )
-        assert-css: (
-            "//*[@class='result-name']//*[normalize-space()='test_docs::']/ancestor::a",
-            {"color": |hover_path_color|, "background-color": |hover_background|},
-        )
     }
 )
 
@@ -157,7 +143,6 @@ show-text: true
 call-function: ("check-search-color", {
     "theme": "ayu",
     "count_color": "#888",
-    "desc_color": "#c5c5c5",
     "path_color": "#0096cf",
     "bottom_border_color": "#aaa3",
     "keyword_color": "#39afd7",
@@ -179,7 +164,6 @@ call-function: ("check-search-color", {
 call-function: ("check-search-color", {
     "theme": "dark",
     "count_color": "#888",
-    "desc_color": "#ddd",
     "path_color": "#ddd",
     "bottom_border_color": "#aaa3",
     "keyword_color": "#d2991d",
@@ -201,7 +185,6 @@ call-function: ("check-search-color", {
 call-function: ("check-search-color", {
     "theme": "light",
     "count_color": "#888",
-    "desc_color": "#000",
     "path_color": "#000",
     "bottom_border_color": "#aaa3",
     "keyword_color": "#3873ad",
@@ -226,12 +209,27 @@ call-function: ("perform-search", {"query": "thisisanalias"})
 
 define-function: (
     "check-alias",
-    [theme, alias, grey],
+    [theme, alias, grey, desc_color, hover_path_color, hover_background],
     block {
         call-function: ("switch-theme", {"theme": |theme|})
         // Checking that the colors for the alias element are the ones expected.
         assert-css: (".result-name .path .alias", {"color": |alias|})
         assert-css: (".result-name .path .alias > .grey", {"color": |grey|})
+        assert-css: (
+            "//*[@class='desc'][normalize-space()='Just a normal enum.']",
+            {"color": |desc_color|},
+        )
+        // Checking color and background on hover.
+        move-cursor-to: "//*[@class='desc'][normalize-space()='Just a normal enum.']"
+        assert-css: (
+            "//*[@class='result-name']//*[normalize-space()='test_docs::']",
+            {"color": |hover_path_color|},
+        )
+        assert-css: (
+            "//*[@class='result-name']//*[normalize-space()='test_docs::']/ancestor::a",
+            {"color": |hover_path_color|, "background-color": |hover_background|},
+        )
+
     },
 )
 
@@ -239,14 +237,23 @@ call-function: ("check-alias", {
     "theme": "ayu",
     "alias": "#c5c5c5",
     "grey": "#999",
+    "desc_color": "#c5c5c5",
+    "hover_path_color": "#fff",
+    "hover_background": "#3c3c3c",
 })
 call-function: ("check-alias", {
     "theme": "dark",
     "alias": "#fff",
     "grey": "#ccc",
+    "desc_color": "#ddd",
+    "hover_path_color": "#ddd",
+    "hover_background": "#616161",
 })
 call-function: ("check-alias", {
     "theme": "light",
     "alias": "#000",
     "grey": "#999",
+    "desc_color": "#000",
+    "hover_path_color": "#000",
+    "hover_background": "#ccc",
 })

--- a/tests/rustdoc-gui/search-tab.goml
+++ b/tests/rustdoc-gui/search-tab.goml
@@ -79,7 +79,7 @@ call-function: ("check-colors", {
 set-window-size: (851, 600)
 
 // Check the size and count in tabs
-assert-text: ("#search-tabs > button:nth-child(1) > .count", " (27) ")
+assert-text: ("#search-tabs > button:nth-child(1) > .count", " (25) ")
 assert-text: ("#search-tabs > button:nth-child(2) > .count", " (7)  ")
 assert-text: ("#search-tabs > button:nth-child(3) > .count", " (0)  ")
 store-property: ("#search-tabs > button:nth-child(1)", {"offsetWidth": buttonWidth})

--- a/tests/rustdoc-gui/sidebar.goml
+++ b/tests/rustdoc-gui/sidebar.goml
@@ -1,5 +1,7 @@
 // Checks multiple things on the sidebar display (width of its elements, colors, etc).
 include: "utils.goml"
+// Disable animations so they don't mess up color assertions later.
+emulate-media-features: { "prefers-reduced-motion": "reduce" }
 go-to: "file://" + |DOC_PATH| + "/test_docs/index.html"
 assert-property: (".sidebar", {"clientWidth": "199"})
 show-text: true

--- a/tests/rustdoc-js-std/asrawfd.js
+++ b/tests/rustdoc-js-std/asrawfd.js
@@ -1,12 +1,10 @@
 // ignore-order
 
 const EXPECTED = {
-    'query': 'RawFd::as_raw_fd',
+    'query': 'method:RawFd::as_raw_fd',
     'others': [
         // Reproduction test for https://github.com/rust-lang/rust/issues/78724
         // Validate that type alias methods get the correct path.
-        { 'path': 'std::os::fd::AsRawFd', 'name': 'as_raw_fd' },
-        { 'path': 'std::os::fd::AsRawFd', 'name': 'as_raw_fd' },
         { 'path': 'std::os::fd::RawFd', 'name': 'as_raw_fd' },
     ],
 };

--- a/tests/rustdoc-js-std/quoted.js
+++ b/tests/rustdoc-js-std/quoted.js
@@ -1,21 +1,21 @@
+// make sure quoted search works both for items and and without generics
 // ignore-order
 
 const FILTER_CRATE = 'std';
 
 const EXPECTED = {
-    'query': '"error"',
+    'query': '"result"',
     'others': [
-        { 'path': 'std', 'name': 'error' },
-        { 'path': 'std::fmt', 'name': 'Error' },
-        { 'path': 'std::io', 'name': 'Error' },
+        { 'path': 'std', 'name': 'result' },
+        { 'path': 'std::result', 'name': 'Result' },
+        { 'path': 'std::fmt', 'name': 'Result' },
     ],
     'in_args': [
-        { 'path': 'std::fmt::Error', 'name': 'eq' },
-        { 'path': 'std::fmt::Error', 'name': 'cmp' },
-        { 'path': 'std::fmt::Error', 'name': 'partial_cmp' },
-
+        { 'path': 'std::result::Result', 'name': 'branch' },
+        { 'path': 'std::result::Result', 'name': 'ok' },
+        { 'path': 'std::result::Result', 'name': 'unwrap' },
     ],
     'returned': [
-        { 'path': 'std::fmt::LowerExp', 'name': 'fmt' },
+        { 'path': 'std::bool', 'name': 'try_into' },
     ],
 };

--- a/tests/rustdoc-js-std/trait-unbox.js
+++ b/tests/rustdoc-js-std/trait-unbox.js
@@ -1,10 +1,10 @@
-// ignore-order
+// make sure type-based searches with traits get unboxed too
 
 const EXPECTED = [
     {
-        'query': 'bufread -> result<[u8]>',
+        'query': 'any -> result<box>',
         'others': [
-            { 'path': 'std::boxed::Box', 'name': 'fill_buf' },
+            { 'path': 'std::boxed::Box', 'name': 'downcast' },
         ],
     },
     {

--- a/tests/rustdoc-js/trait-methods.js
+++ b/tests/rustdoc-js/trait-methods.js
@@ -9,4 +9,24 @@ const EXPECTED = [
             { 'path': 'trait_methods::MyTrait', 'name': 'next' },
         ],
     },
+    // the traitParent deduplication pass should remove
+    // Empty::next, as it would be redundant
+    {
+        'query': 'next',
+        'correction': null,
+        'in_args': [],
+        'others': [
+            { 'path': 'trait_methods::MyTrait', 'name': 'next' },
+        ],
+    },
+    // if the trait does not match, no deduplication happens
+    {
+        'query': '-> option<()>',
+        'correction': null,
+        'in_args': [],
+        'others': [
+            { 'path': 'trait_methods::Empty', 'name': 'next' },
+                    { 'path': 'trait_methods::Void', 'name': 'next' },
+        ],
+    },
 ];

--- a/tests/rustdoc-js/trait-methods.rs
+++ b/tests/rustdoc-js/trait-methods.rs
@@ -2,3 +2,21 @@ pub trait MyTrait {
     type Item;
     fn next(&mut self) -> Option<Self::Item>;
 }
+
+pub struct Empty;
+
+impl MyTrait for Empty {
+    type Item = ();
+    fn next(&mut self) -> Option<()> {
+        None
+    }
+}
+
+pub struct Void;
+
+impl MyTrait for Void {
+    type Item = ();
+    fn next(&mut self) -> Option<()> {
+        Some(())
+    }
+}


### PR DESCRIPTION
fixes rust-lang/rust#138251

cc @notriddle 

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
