### PR TITLE
Fix typo in comment of library/alloc/src/raw_vec/mod.rs

### DIFF
--- a/library/alloc/src/raw_vec/mod.rs
+++ b/library/alloc/src/raw_vec/mod.rs
@@ -155,7 +155,7 @@ impl RawVecInner<Global> {
 }
 
 // Tiny Vecs are dumb. Skip to:
-// - 8 if the element size is 1, because any heap allocators is likely
+// - 8 if the element size is 1, because any heap allocator is likely
 //   to round up a request of less than 8 bytes to at least 8 bytes.
 // - 4 if elements are moderate-sized (<= 1 KiB).
 // - 1 otherwise, to avoid wasting too much space for very short Vecs.


### PR DESCRIPTION
Turn "any heap allocators" into "any heap allocator".

Shoutout to [Let's Read OSS](https://github.com/stoeckmann/lets-read-oss).