### PR TITLE
Stop calling unwrap when format foreign has trailing dollar

### DIFF
--- a/compiler/rustc_builtin_macros/src/format_foreign.rs
+++ b/compiler/rustc_builtin_macros/src/format_foreign.rs
@@ -416,7 +416,7 @@ pub(crate) mod printf {
                         // Yes, this *is* the parameter.
                         Some(('$', end2)) => {
                             state = Flags;
-                            parameter = Some(at.slice_between(end).unwrap().parse().unwrap());
+                            parameter = at.slice_between(end).unwrap().parse().ok();
                             move_to!(end2);
                         }
                         // Wait, no, actually, it's the width.

--- a/tests/crashes/137580.rs
+++ b/tests/crashes/137580.rs
@@ -1,4 +1,0 @@
-//@ known-bug: #137580
-fn main() {
-    println!("%65536$", 1);
-}

--- a/tests/ui/macros/format-foreign-dollar-without-spec.rs
+++ b/tests/ui/macros/format-foreign-dollar-without-spec.rs
@@ -1,0 +1,4 @@
+fn main() {
+    println!("%65536$", 1);
+    //~^ ERROR never used
+}

--- a/tests/ui/macros/format-foreign-dollar-without-spec.rs
+++ b/tests/ui/macros/format-foreign-dollar-without-spec.rs
@@ -1,3 +1,4 @@
+// https://github.com/rust-lang/rust/issues/137580
 fn main() {
     println!("%65536$", 1);
     //~^ ERROR never used

--- a/tests/ui/macros/format-foreign-dollar-without-spec.stderr
+++ b/tests/ui/macros/format-foreign-dollar-without-spec.stderr
@@ -1,0 +1,16 @@
+error: argument never used
+  --> $DIR/format-foreign-dollar-without-spec.rs:2:25
+   |
+LL |     println!("%65536$", 1);
+   |                         ^ argument never used
+   |
+note: format specifiers use curly braces, and the conversion specifier `
+      ` is unknown or unsupported
+  --> $DIR/format-foreign-dollar-without-spec.rs:2:15
+   |
+LL |     println!("%65536$", 1);
+   |               ^^^^^^^^
+   = note: printf formatting is not supported; see the documentation for `std::fmt`
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/macros/format-foreign-dollar-without-spec.stderr
+++ b/tests/ui/macros/format-foreign-dollar-without-spec.stderr
@@ -1,12 +1,12 @@
 error: argument never used
-  --> $DIR/format-foreign-dollar-without-spec.rs:2:25
+  --> $DIR/format-foreign-dollar-without-spec.rs:3:25
    |
 LL |     println!("%65536$", 1);
    |                         ^ argument never used
    |
 note: format specifiers use curly braces, and the conversion specifier `
       ` is unknown or unsupported
-  --> $DIR/format-foreign-dollar-without-spec.rs:2:15
+  --> $DIR/format-foreign-dollar-without-spec.rs:3:15
    |
 LL |     println!("%65536$", 1);
    |               ^^^^^^^^


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Fixes rust-lang/rust#137580