### PR TITLE
rustdoc: split build_impl into build_{local,external}_impl

### DIFF
--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -572,29 +572,29 @@ pub(crate) fn build_impl(
         super::build_deref_target_impls(cx, &trait_items, ret);
     }
 
-    // Return if the trait itself or any types of the generic parameters are doc(hidden).
-    let mut stack: Vec<&Type> = vec![&for_];
+    if !document_hidden {
+        // Return if the trait itself or any types of the generic parameters are doc(hidden).
+        let mut stack: Vec<&Type> = vec![&for_];
 
-    if let Some(did) = trait_.as_ref().map(|t| t.def_id())
-        && !document_hidden
-        && tcx.is_doc_hidden(did)
-    {
-        return;
-    }
-
-    if let Some(generics) = trait_.as_ref().and_then(|t| t.generics()) {
-        stack.extend(generics);
-    }
-
-    while let Some(ty) = stack.pop() {
-        if let Some(did) = ty.def_id(&cx.cache)
-            && !document_hidden
+        if let Some(did) = trait_.as_ref().map(|t| t.def_id())
             && tcx.is_doc_hidden(did)
         {
             return;
         }
-        if let Some(generics) = ty.generics() {
+
+        if let Some(generics) = trait_.as_ref().and_then(|t| t.generics()) {
             stack.extend(generics);
+        }
+
+        while let Some(ty) = stack.pop() {
+            if let Some(did) = ty.def_id(&cx.cache)
+                && tcx.is_doc_hidden(did)
+            {
+                return;
+            }
+            if let Some(generics) = ty.generics() {
+                stack.extend(generics);
+            }
         }
     }
 

--- a/src/librustdoc/passes/collect_trait_impls.rs
+++ b/src/librustdoc/passes/collect_trait_impls.rs
@@ -52,7 +52,7 @@ pub(crate) fn collect_trait_impls(mut krate: Crate, cx: &mut DocContext<'_>) -> 
         for &cnum in tcx.crates(()) {
             for &impl_def_id in tcx.trait_impls_in_crate(cnum) {
                 cx.with_param_env(impl_def_id, |cx| {
-                    inline::build_impl(cx, impl_def_id, None, &mut new_items_external);
+                    inline::build_external_impl(cx, impl_def_id, None, &mut new_items_external);
                 });
             }
         }
@@ -79,7 +79,12 @@ pub(crate) fn collect_trait_impls(mut krate: Crate, cx: &mut DocContext<'_>) -> 
                 parent = tcx.opt_parent(did);
             }
             cx.with_param_env(impl_def_id, |cx| {
-                inline::build_impl(cx, impl_def_id, Some((&attr_buf, None)), &mut new_items_local);
+                inline::build_local_impl(
+                    cx,
+                    impl_def_id,
+                    Some((&attr_buf, None)),
+                    &mut new_items_local,
+                );
             });
             attr_buf.clear();
         }
@@ -90,7 +95,7 @@ pub(crate) fn collect_trait_impls(mut krate: Crate, cx: &mut DocContext<'_>) -> 
             // Try to inline primitive impls from other crates.
             if !def_id.is_local() {
                 cx.with_param_env(def_id, |cx| {
-                    inline::build_impl(cx, def_id, None, &mut new_items_external);
+                    inline::build_external_impl(cx, def_id, None, &mut new_items_external);
                 });
             }
         }


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
splitting these out should let us avoid quite a few more branches, and hopefully also improve cache locality of the code.

followup to https://github.com/rust-lang/rust/pull/145851