### PR TITLE
Track diagnostic attributes pre proc macro expansion, prepend post expansion.

### DIFF
--- a/compiler/rustc_expand/src/expand.rs
+++ b/compiler/rustc_expand/src/expand.rs
@@ -29,7 +29,7 @@ use rustc_session::parse::feature_err;
 use rustc_session::{Limit, Session};
 use rustc_span::hygiene::SyntaxContext;
 use rustc_span::{ErrorGuaranteed, FileName, Ident, LocalExpnId, Span, Symbol, sym};
-use smallvec::SmallVec;
+use smallvec::{SmallVec, smallvec};
 
 use crate::base::*;
 use crate::config::{StripUnconfigured, attr_into_trace};
@@ -45,6 +45,22 @@ use crate::module::{
 };
 use crate::placeholders::{PlaceholderExpander, placeholder};
 use crate::stats::*;
+
+/// Visitor to apply diagnostic attributes to expanded AST fragments
+struct DiagnosticAttrApplier {
+    attrs: Vec<ast::Attribute>,
+}
+
+impl MutVisitor for DiagnosticAttrApplier {
+    fn flat_map_item(&mut self, item: Box<ast::Item>) -> SmallVec<[Box<ast::Item>; 1]> {
+        let mut new_item = item;
+        // Prepend diagnostic attributes to preserve their position
+        let mut new_attrs = self.attrs.clone();
+        new_attrs.extend(new_item.attrs);
+        new_item.attrs = new_attrs.into();
+        smallvec![new_item]
+    }
+}
 
 macro_rules! ast_fragments {
     (
@@ -818,12 +834,43 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
                     let inner_tokens = attr_item.args.inner_tokens();
                     match expander.expand(self.cx, span, inner_tokens, tokens) {
                         Ok(tok_result) => {
-                            let fragment = self.parse_ast_fragment(
+                            // Extract diagnostic attributes from the original item before parsing
+                            let diagnostic_attrs = {
+                                match &item {
+                                    Annotatable::Item(item) => item
+                                        .attrs
+                                        .iter()
+                                        .filter(|attr| {
+                                            attr.name().map_or(false, |name| {
+                                                matches!(
+                                                    name,
+                                                    sym::expect
+                                                        | sym::allow
+                                                        | sym::warn
+                                                        | sym::deny
+                                                        | sym::forbid
+                                                )
+                                            })
+                                        })
+                                        .cloned()
+                                        .collect::<Vec<_>>(),
+                                    _ => Vec::new(),
+                                }
+                            };
+
+                            let mut fragment = self.parse_ast_fragment(
                                 tok_result,
                                 fragment_kind,
                                 &attr_item.path,
                                 span,
                             );
+
+                            // Apply diagnostic attributes to the expanded fragment
+                            if !diagnostic_attrs.is_empty() {
+                                fragment.mut_visit_with(&mut DiagnosticAttrApplier {
+                                    attrs: diagnostic_attrs,
+                                });
+                            }
                             if macro_stats {
                                 update_attr_macro_stats(
                                     self.cx,

--- a/src/tools/clippy/clippy_lints/src/disallowed_macros.rs
+++ b/src/tools/clippy/clippy_lints/src/disallowed_macros.rs
@@ -139,6 +139,7 @@ impl LateLintPass<'_> for DisallowedMacros {
                 | AttributeKind::ConstStability { span, .. }
                 | AttributeKind::ConstTrait(span)
                 | AttributeKind::Coverage(span, _)
+                | AttributeKind::CrateName { attr_span: span, .. }
                 | AttributeKind::DenyExplicitImpl(span)
                 | AttributeKind::Deprecation { span, .. }
                 | AttributeKind::DoNotImplementViaObject(span)
@@ -174,11 +175,12 @@ impl LateLintPass<'_> for DisallowedMacros {
                 | AttributeKind::RustcBuiltinMacro { span, .. }
                 | AttributeKind::RustcLayoutScalarValidRangeEnd(_, span)
                 | AttributeKind::RustcLayoutScalarValidRangeStart(_, span)
+                | AttributeKind::Sanitize { span, .. }
                 | AttributeKind::SkipDuringMethodDispatch { span, .. }
                 | AttributeKind::SpecializationTrait(span)
                 | AttributeKind::Stability { span, .. }
                 | AttributeKind::StdInternalSymbol(span)
-                | AttributeKind::TargetFeature(_, span)
+                | AttributeKind::TargetFeature { attr_span: span, .. }
                 | AttributeKind::TrackCaller(span)
                 | AttributeKind::TypeConst(span)
                 | AttributeKind::UnsafeSpecializationMarker(span)
@@ -186,6 +188,7 @@ impl LateLintPass<'_> for DisallowedMacros {
                 | AttributeKind::Coroutine(span)
                 | AttributeKind::Linkage(_, span)
                 | AttributeKind::ShouldPanic { span, .. }
+                | AttributeKind::CustomMir(_, _, span)
                 | AttributeKind::Used { span, .. } => *span,
 
                 AttributeKind::CoherenceIsCore

--- a/src/tools/clippy/clippy_lints/src/lib.rs
+++ b/src/tools/clippy/clippy_lints/src/lib.rs
@@ -658,8 +658,7 @@ pub fn register_lint_passes(store: &mut rustc_lint::LintStore, conf: &'static Co
     store.register_late_pass(|_| Box::new(unwrap_in_result::UnwrapInResult));
     store.register_late_pass(|_| Box::new(semicolon_if_nothing_returned::SemicolonIfNothingReturned));
     store.register_late_pass(|_| Box::new(async_yields_async::AsyncYieldsAsync));
-    let attrs = attr_storage.clone();
-    store.register_late_pass(move |tcx| Box::new(disallowed_macros::DisallowedMacros::new(tcx, conf, attrs.clone())));
+    store.register_late_pass(move |tcx| Box::new(disallowed_macros::DisallowedMacros::new(tcx, conf)));
     store.register_late_pass(move |tcx| Box::new(disallowed_methods::DisallowedMethods::new(tcx, conf)));
     store.register_early_pass(|| Box::new(asm_syntax::InlineAsmX86AttSyntax));
     store.register_early_pass(|| Box::new(asm_syntax::InlineAsmX86IntelSyntax));

--- a/src/tools/clippy/tests/ui-toml/disallowed_macros/clippy.toml
+++ b/src/tools/clippy/tests/ui-toml/disallowed_macros/clippy.toml
@@ -1,4 +1,5 @@
 disallowed-macros = [
+    "std::panic",
     "std::println",
     "std::vec",
     { path = "std::cfg" },

--- a/src/tools/clippy/tests/ui-toml/disallowed_macros/disallowed_macros.stderr
+++ b/src/tools/clippy/tests/ui-toml/disallowed_macros/disallowed_macros.stderr
@@ -1,33 +1,11 @@
-error: use of a disallowed macro `serde::Serialize`
-  --> tests/ui-toml/disallowed_macros/disallowed_macros.rs:22:14
-   |
-LL |     #[derive(Serialize)]
-   |              ^^^^^^^^^
-   |
-   = note: no serializing
-   = note: `-D clippy::disallowed-macros` implied by `-D warnings`
-   = help: to override `-D warnings` add `#[allow(clippy::disallowed_macros)]`
-
-error: use of a disallowed macro `macros::attr`
-  --> tests/ui-toml/disallowed_macros/disallowed_macros.rs:42:1
-   |
-LL | / macros::attr! {
-LL | |
-LL | |     struct S;
-LL | | }
-   | |_^
-
-error: use of a disallowed macro `proc_macros::Derive`
-  --> tests/ui-toml/disallowed_macros/disallowed_macros.rs:62:10
-   |
-LL | #[derive(Derive)]
-   |          ^^^^^^
-
 error: use of a disallowed macro `std::println`
   --> tests/ui-toml/disallowed_macros/disallowed_macros.rs:13:5
    |
 LL |     println!("one");
    |     ^^^^^^^^^^^^^^^
+   |
+   = note: `-D clippy::disallowed-macros` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::disallowed_macros)]`
 
 error: use of a disallowed macro `std::println`
   --> tests/ui-toml/disallowed_macros/disallowed_macros.rs:15:5
@@ -46,6 +24,14 @@ error: use of a disallowed macro `std::vec`
    |
 LL |     vec![1, 2, 3];
    |     ^^^^^^^^^^^^^
+
+error: use of a disallowed macro `serde::Serialize`
+  --> tests/ui-toml/disallowed_macros/disallowed_macros.rs:22:14
+   |
+LL |     #[derive(Serialize)]
+   |              ^^^^^^^^^
+   |
+   = note: no serializing
 
 error: use of a disallowed macro `macros::expr`
   --> tests/ui-toml/disallowed_macros/disallowed_macros.rs:26:13
@@ -83,6 +69,15 @@ error: use of a disallowed macro `macros::binop`
 LL |     let _ = macros::binop!(1);
    |             ^^^^^^^^^^^^^^^^^
 
+error: use of a disallowed macro `macros::attr`
+  --> tests/ui-toml/disallowed_macros/disallowed_macros.rs:42:1
+   |
+LL | / macros::attr! {
+LL | |
+LL | |     struct S;
+LL | | }
+   | |_^
+
 error: use of a disallowed macro `macros::item`
   --> tests/ui-toml/disallowed_macros/disallowed_macros.rs:48:5
    |
@@ -100,6 +95,12 @@ error: use of a disallowed macro `macros::item`
    |
 LL |     macros::item!();
    |     ^^^^^^^^^^^^^^^
+
+error: use of a disallowed macro `proc_macros::Derive`
+  --> tests/ui-toml/disallowed_macros/disallowed_macros.rs:62:10
+   |
+LL | #[derive(Derive)]
+   |          ^^^^^^
 
 error: aborting due to 16 previous errors
 

--- a/src/tools/clippy/tests/ui-toml/disallowed_macros/disallowed_macros_regression.rs
+++ b/src/tools/clippy/tests/ui-toml/disallowed_macros/disallowed_macros_regression.rs
@@ -1,0 +1,70 @@
+fn test_allow_on_function() {
+    #![allow(clippy::disallowed_macros)]
+
+    panic!();
+    panic!("message");
+    panic!("{}", 123);
+    panic!("{} {}", 123, 456);
+    println!("test");
+    println!("{}", 123);
+    vec![1, 2, 3];
+}
+
+fn test_expect_on_function() {
+    #![expect(clippy::disallowed_macros)]
+
+    panic!();
+    panic!("message");
+    panic!("{}", 123);
+    panic!("{} {}", 123, 456);
+    println!("test");
+    println!("{}", 123);
+    vec![1, 2, 3];
+}
+
+fn test_no_attributes() {
+    panic!();
+    //~^ disallowed_macros
+    panic!("message");
+    //~^ disallowed_macros
+    panic!("{}", 123);
+    //~^ disallowed_macros
+    panic!("{} {}", 123, 456);
+    //~^ disallowed_macros
+    println!("test");
+    //~^ disallowed_macros
+    println!("{}", 123);
+    //~^ disallowed_macros
+    vec![1, 2, 3];
+    //~^ disallowed_macros
+}
+
+#[allow(clippy::disallowed_macros)]
+mod allowed_module {
+    pub fn test() {
+        panic!();
+        panic!("message");
+        panic!("{}", 123);
+        println!("test");
+        vec![1, 2, 3];
+    }
+}
+
+#[expect(clippy::disallowed_macros)]
+mod expected_module {
+    pub fn test() {
+        panic!();
+        panic!("message");
+        panic!("{}", 123);
+        println!("test");
+        vec![1, 2, 3];
+    }
+}
+
+fn main() {
+    test_allow_on_function();
+    test_expect_on_function();
+    test_no_attributes();
+    allowed_module::test();
+    expected_module::test();
+}

--- a/src/tools/clippy/tests/ui-toml/disallowed_macros/disallowed_macros_regression.stderr
+++ b/src/tools/clippy/tests/ui-toml/disallowed_macros/disallowed_macros_regression.stderr
@@ -1,0 +1,47 @@
+error: use of a disallowed macro `std::panic`
+  --> tests/ui-toml/disallowed_macros/disallowed_macros_regression.rs:26:5
+   |
+LL |     panic!();
+   |     ^^^^^^^^
+   |
+   = note: `-D clippy::disallowed-macros` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::disallowed_macros)]`
+
+error: use of a disallowed macro `std::panic`
+  --> tests/ui-toml/disallowed_macros/disallowed_macros_regression.rs:28:5
+   |
+LL |     panic!("message");
+   |     ^^^^^^^^^^^^^^^^^
+
+error: use of a disallowed macro `std::panic`
+  --> tests/ui-toml/disallowed_macros/disallowed_macros_regression.rs:30:5
+   |
+LL |     panic!("{}", 123);
+   |     ^^^^^^^^^^^^^^^^^
+
+error: use of a disallowed macro `std::panic`
+  --> tests/ui-toml/disallowed_macros/disallowed_macros_regression.rs:32:5
+   |
+LL |     panic!("{} {}", 123, 456);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: use of a disallowed macro `std::println`
+  --> tests/ui-toml/disallowed_macros/disallowed_macros_regression.rs:34:5
+   |
+LL |     println!("test");
+   |     ^^^^^^^^^^^^^^^^
+
+error: use of a disallowed macro `std::println`
+  --> tests/ui-toml/disallowed_macros/disallowed_macros_regression.rs:36:5
+   |
+LL |     println!("{}", 123);
+   |     ^^^^^^^^^^^^^^^^^^^
+
+error: use of a disallowed macro `std::vec`
+  --> tests/ui-toml/disallowed_macros/disallowed_macros_regression.rs:38:5
+   |
+LL |     vec![1, 2, 3];
+   |     ^^^^^^^^^^^^^
+
+error: aborting due to 7 previous errors
+


### PR DESCRIPTION
A fix for https://github.com/rust-lang/rust-clippy/issues/13521.
Leaving as draft for now.

The first two commits are for a [different clippy issue](https://github.com/rust-lang/rust-clippy/issues/14017).  That fix is a prereq for this, because it ensures that this particular clippy lint is emitted at the correct hir id.

Small repro: https://github.com/2asoft/clippy_13521_repro