### PR TITLE
bootstrap: Explicitly mark the end of a failed test's captured output

### DIFF
--- a/src/bootstrap/src/utils/render_tests.rs
+++ b/src/bootstrap/src/utils/render_tests.rs
@@ -250,8 +250,14 @@ impl<'a> Renderer<'a> {
                 if failure.stdout.is_some() || failure.message.is_some() {
                     println!("---- {} stdout ----", failure.name);
                     if let Some(stdout) = &failure.stdout {
-                        println!("{stdout}");
+                        // Captured test output normally ends with a newline,
+                        // so only use `println!` if it doesn't.
+                        print!("{stdout}");
+                        if !stdout.ends_with('\n') {
+                            println!("\n\\ (no newline at end of output)");
+                        }
                     }
+                    println!("---- {} stdout end ----", failure.name);
                     if let Some(message) = &failure.message {
                         println!("NOTE: {message}");
                     }


### PR DESCRIPTION
While working on some compiletest stuff, I noticed that when bootstrap prints a failed test's captured output, there's no indication of where that output actually ends.

In addition to indicating where the captured output ends, this end marker also makes it easier to see the relevant test name when scrolling upwards in terminal output.