### PR TITLE
Rename `Location::file_with_nul` to `file_as_c_str`

### DIFF
--- a/library/core/src/panic/location.rs
+++ b/library/core/src/panic/location.rs
@@ -39,7 +39,7 @@ use crate::ptr::NonNull;
 pub struct Location<'a> {
     // A raw pointer is used rather than a reference because the pointer is valid for one more byte
     // than the length stored in this pointer; the additional byte is the NUL-terminator used by
-    // `Location::file_with_nul`.
+    // `Location::file_as_c_str`.
     filename: NonNull<str>,
     line: u32,
     col: u32,
@@ -195,7 +195,7 @@ impl<'a> Location<'a> {
     #[must_use]
     #[unstable(feature = "file_with_nul", issue = "141727")]
     #[inline]
-    pub const fn file_with_nul(&self) -> &'a CStr {
+    pub const fn file_as_c_str(&self) -> &'a CStr {
         let filename = self.filename.as_ptr();
 
         // SAFETY: The filename is valid for `filename_len+1` bytes, so this addition can't

--- a/tests/ui/rfcs/rfc-2091-track-caller/file-is-nul-terminated.rs
+++ b/tests/ui/rfcs/rfc-2091-track-caller/file-is-nul-terminated.rs
@@ -5,12 +5,12 @@
 const fn assert_file_has_trailing_zero() {
     let caller = core::panic::Location::caller();
     let file_str = caller.file();
-    let file_with_nul = caller.file_with_nul();
-    if file_str.len() != file_with_nul.count_bytes() {
+    let file_cstr = caller.file_as_c_str();
+    if file_str.len() != file_cstr.count_bytes() {
         panic!("mismatched lengths");
     }
     let trailing_byte: core::ffi::c_char = unsafe {
-        *file_with_nul.as_ptr().offset(file_with_nul.count_bytes() as _)
+        *file_cstr.as_ptr().offset(file_cstr.count_bytes() as _)
     };
     if trailing_byte != 0 {
         panic!("trailing byte was nonzero")


### PR DESCRIPTION
This renames the method to be consistent with the ongoing T-libs-api FCP found at https://github.com/rust-lang/rust/issues/141727#issuecomment-3228016708.

I did not rename the unstable feature as we are going to be stabilizing it soon anyway. This will probably break RfL, so it will require an updated commit hash for the Linux Kernel that I will add here soon.

r? @Amanieu
