### PR TITLE
`const`ify (the unstable) `str::as_str`

### DIFF
--- a/library/core/src/str/mod.rs
+++ b/library/core/src/str/mod.rs
@@ -3072,7 +3072,7 @@ impl str {
     /// for example references to `Box<str>` or `Arc<str>`.
     #[inline]
     #[unstable(feature = "str_as_str", issue = "130366")]
-    pub fn as_str(&self) -> &str {
+    pub const fn as_str(&self) -> &str {
         self
     }
 }


### PR DESCRIPTION
Tracking issue: rust-lang/rust#130366

The method was not initially marked `const` presumably because it is only useful with `Deref`. But now that const traits seem to be a thing that can actually become real, why not make it `const`?

PR `const`ifying `Deref`: rust-lang/rust#145279

