### PR TITLE
chore: fix typos in comment

### DIFF
--- a/src/tools/tidy/src/lib.rs
+++ b/src/tools/tidy/src/lib.rs
@@ -129,7 +129,7 @@ pub fn git_diff<S: AsRef<OsStr>>(base_commit: &str, extra_arg: S) -> Option<Stri
 
 /// Similar to `files_modified`, but only involves a single call to `git`.
 ///
-/// removes all elements from `items` that do not cause any match when `pred` is called with the list of modifed files.
+/// removes all elements from `items` that do not cause any match when `pred` is called with the list of modified files.
 ///
 /// if in CI, no elements will be removed.
 pub fn files_modified_batch_filter<T>(

--- a/src/tools/tidy/src/pal.rs
+++ b/src/tools/tidy/src/pal.rs
@@ -179,14 +179,14 @@ fn parse_cfgs(contents: &str) -> Vec<(usize, &str)> {
         let contents_after = &contents[*i..];
         let first_paren = contents_after.find('(');
         let paren_idx = first_paren.map(|ip| i + ip);
-        let preceeds_whitespace_and_paren = paren_idx
+        let precedes_whitespace_and_paren = paren_idx
             .map(|ip| {
                 let maybe_space = &contents[*i + "cfg".len()..ip];
                 maybe_space.chars().all(|c| char::is_whitespace(c) || c == '!')
             })
             .unwrap_or(false);
 
-        succeeds_non_ident && preceeds_whitespace_and_paren
+        succeeds_non_ident && precedes_whitespace_and_paren
     });
 
     cfgs.flat_map(|i| {


### PR DESCRIPTION
This PR addresses several typos in the Rust standard library's documentation comments:
 - Corrected "modifed" to "modified"
 - Corrected "preceeds" to "precedes"