### PR TITLE
resolve: Avoid a regression from splitting prelude into two scopes

### DIFF
--- a/tests/ui/imports/overwritten-extern-flag-ambig.rs
+++ b/tests/ui/imports/overwritten-extern-flag-ambig.rs
@@ -1,0 +1,13 @@
+// Test for issue #145575.
+
+//@ check-pass
+//@ edition: 2018
+
+extern crate core as std;
+
+mod inner {
+    use crate::*;
+    use std::str; // OK for now
+}
+
+fn main() {}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/145575.