### PR TITLE
compiler: Include span of too huge enum with `-Cdebuginfo=2`

### DIFF
--- a/compiler/rustc_codegen_llvm/src/debuginfo/metadata/enums/mod.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/metadata/enums/mod.rs
@@ -10,7 +10,7 @@ use rustc_middle::bug;
 use rustc_middle::mir::CoroutineLayout;
 use rustc_middle::ty::layout::{LayoutOf, TyAndLayout};
 use rustc_middle::ty::{self, AdtDef, CoroutineArgs, CoroutineArgsExt, Ty, VariantDef};
-use rustc_span::Symbol;
+use rustc_span::{Span, Symbol};
 
 use super::type_map::{DINodeCreationResult, UniqueTypeId};
 use super::{SmallVec, size_and_align_of};
@@ -30,13 +30,14 @@ mod native;
 pub(super) fn build_enum_type_di_node<'ll, 'tcx>(
     cx: &CodegenCx<'ll, 'tcx>,
     unique_type_id: UniqueTypeId<'tcx>,
+    span: Span,
 ) -> DINodeCreationResult<'ll> {
     let enum_type = unique_type_id.expect_ty();
     let &ty::Adt(enum_adt_def, _) = enum_type.kind() else {
         bug!("build_enum_type_di_node() called with non-enum type: `{:?}`", enum_type)
     };
 
-    let enum_type_and_layout = cx.layout_of(enum_type);
+    let enum_type_and_layout = cx.spanned_layout_of(enum_type, span);
 
     if wants_c_like_enum_debuginfo(cx.tcx, enum_type_and_layout) {
         return build_c_style_enum_di_node(cx, enum_adt_def, enum_type_and_layout);

--- a/compiler/rustc_codegen_llvm/src/debuginfo/mod.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/mod.rs
@@ -28,7 +28,9 @@ use rustc_target::spec::DebuginfoKind;
 use smallvec::SmallVec;
 use tracing::debug;
 
-use self::metadata::{UNKNOWN_COLUMN_NUMBER, UNKNOWN_LINE_NUMBER, file_metadata, type_di_node};
+use self::metadata::{
+    UNKNOWN_COLUMN_NUMBER, UNKNOWN_LINE_NUMBER, file_metadata, spanned_type_di_node, type_di_node,
+};
 use self::namespace::mangled_name_of_instance;
 use self::utils::{DIB, create_DIArray, is_node_local_to_unit};
 use crate::builder::Builder;
@@ -626,7 +628,7 @@ impl<'ll, 'tcx> DebugInfoCodegenMethods<'tcx> for CodegenCx<'ll, 'tcx> {
         let loc = self.lookup_debug_loc(span.lo());
         let file_metadata = file_metadata(self, &loc.file);
 
-        let type_metadata = type_di_node(self, variable_type);
+        let type_metadata = spanned_type_di_node(self, variable_type, span);
 
         let (argument_index, dwarf_tag) = match variable_kind {
             ArgumentVariable(index) => (index as c_uint, DW_TAG_arg_variable),

--- a/tests/ui/limits/huge-enum.full-debuginfo.stderr
+++ b/tests/ui/limits/huge-enum.full-debuginfo.stderr
@@ -1,5 +1,5 @@
 error: values of the type `Option<TYPE>` are too big for the target architecture
-  --> $DIR/huge-enum.rs:15:9
+  --> $DIR/huge-enum.rs:17:9
    |
 LL |     let big: BIG = None;
    |         ^^^

--- a/tests/ui/limits/huge-enum.no-debuginfo.stderr
+++ b/tests/ui/limits/huge-enum.no-debuginfo.stderr
@@ -1,0 +1,8 @@
+error: values of the type `Option<TYPE>` are too big for the target architecture
+  --> $DIR/huge-enum.rs:17:9
+   |
+LL |     let big: BIG = None;
+   |         ^^^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/limits/huge-enum.rs
+++ b/tests/ui/limits/huge-enum.rs
@@ -1,9 +1,11 @@
+// FIXME(#61117): Remove revisions once x86_64-gnu-debug CI job sets rust.debuginfo-level-tests=2
+// NOTE: The .stderr for both revisions shall be identical.
+//@ revisions: no-debuginfo full-debuginfo
 //@ build-fail
 //@ normalize-stderr: "std::option::Option<\[u32; \d+\]>" -> "TYPE"
 //@ normalize-stderr: "\[u32; \d+\]" -> "TYPE"
-
-// FIXME(#61117): Respect debuginfo-level-tests, do not force debuginfo-level=0
-//@ compile-flags: -Cdebuginfo=0
+//@[no-debuginfo] compile-flags: -Cdebuginfo=0
+//@[full-debuginfo] compile-flags: -Cdebuginfo=2
 
 #[cfg(target_pointer_width = "32")]
 type BIG = Option<[u32; (1<<29)-1]>;


### PR DESCRIPTION
We have the ui test `tests/ui/limits/huge-enum.rs` to ensure we emit an error if we encounter too big enums. Before this fix, compiling the test with `-Cdebuginfo=2` would not include the span of the instantiation site, because the error is then emitted from a different code path that does not include the span.

Propagate the span to the error also in the debuginfo case, so the test passes regardless of debuginfo level. I'm sure we can propagate spans in more places, but let's start small.

## Test failure without the fix

Here is what the failure looks like if you run the test without the fix:

```
[ui] tests/ui/limits/huge-enum.rs#full-debuginfo ... F
.

failures:

---- [ui] tests/ui/limits/huge-enum.rs#full-debuginfo stdout ----
Saved the actual stderr to `/home/martin/src/rust/build/x86_64-unknown-linux-gnu/test/ui/limits/huge-enum.full-debuginfo/huge-enum.full-debuginfo.stderr`
diff of stderr:

1       error: values of the type `Option<TYPE>` are too big for the target architecture
-         --> $DIR/huge-enum.rs:17:9
-          |
-       LL |     let big: BIG = None;
-          |         ^^^
6
7       error: aborting due to 1 previous error
8


The actual stderr differed from the expected stderr
To update references, rerun the tests and pass the `--bless` flag
To only update this specific test, also pass `--test-args limits/huge-enum.rs`
```

as can be seen, the `span` used to be missing with `debuginfo=2`.

## See also

This is one small step towards resolving rust-lang/rust#61117.

cc https://github.com/rust-lang/rust/pull/144499 which began running UI tests with `rust.debuginfo-level-tests=1`. This PR is part of preparing for increasing that to debuglevel 2.
