### PR TITLE
Add `Bound::copied`

### DIFF
--- a/library/core/src/ops/range.rs
+++ b/library/core/src/ops/range.rs
@@ -742,6 +742,8 @@ impl<T: Copy> Bound<&T> {
     /// # Examples
     ///
     /// ```
+    /// #![feature(bound_copied)]
+    ///
     /// use std::ops::Bound::*;
     /// use std::ops::RangeBounds;
     ///

--- a/library/core/src/ops/range.rs
+++ b/library/core/src/ops/range.rs
@@ -751,6 +751,7 @@ impl<T: Copy> Bound<&T> {
     /// assert_eq!((1..12).start_bound().copied(), Included(1));
     /// ```
     #[unstable(feature = "bound_copied", issue = "145966")]
+    #[must_use]
     pub fn copied(self) -> Bound<T> {
         match self {
             Bound::Unbounded => Bound::Unbounded,
@@ -769,8 +770,11 @@ impl<T: Clone> Bound<&T> {
     /// use std::ops::Bound::*;
     /// use std::ops::RangeBounds;
     ///
-    /// assert_eq!((1..12).start_bound(), Included(&1));
-    /// assert_eq!((1..12).start_bound().cloned(), Included(1));
+    /// let a1 = String::from("a");
+    /// let (a2, a3, a4) = (a1.clone(), a1.clone(), a1.clone());
+    ///
+    /// assert_eq!(Included(&a1), (a2..).start_bound());
+    /// assert_eq!(Included(a3), (a4..).start_bound().cloned());
     /// ```
     #[must_use = "`self` will be dropped if the result is not used"]
     #[stable(feature = "bound_cloned", since = "1.55.0")]

--- a/library/core/src/ops/range.rs
+++ b/library/core/src/ops/range.rs
@@ -736,6 +736,28 @@ impl<T> Bound<T> {
     }
 }
 
+impl<T: Copy> Bound<&T> {
+    /// Map a `Bound<&T>` to a `Bound<T>` by copying the contents of the bound.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::ops::Bound::*;
+    /// use std::ops::RangeBounds;
+    ///
+    /// assert_eq!((1..12).start_bound(), Included(&1));
+    /// assert_eq!((1..12).start_bound().copied(), Included(1));
+    /// ```
+    #[unstable(feature = "bound_copied", issue = "145966")]
+    pub fn copied(self) -> Bound<T> {
+        match self {
+            Bound::Unbounded => Bound::Unbounded,
+            Bound::Included(x) => Bound::Included(*x),
+            Bound::Excluded(x) => Bound::Excluded(*x),
+        }
+    }
+}
+
 impl<T: Clone> Bound<&T> {
     /// Map a `Bound<&T>` to a `Bound<T>` by cloning the contents of the bound.
     ///


### PR DESCRIPTION
Tracking Issue: https://github.com/rust-lang/rust/issues/145966

Some questions:

- [x] Should I update the documentation for `cloned` to actual used a `Clone` type instead of an integer?
- [x] I removed the `must_use` since this is a cheap copy, does that make sense?