### PR TITLE
std: remove misleading doc of UdpSocket::send_to/send

### DIFF
--- a/library/std/src/net/udp.rs
+++ b/library/std/src/net/udp.rs
@@ -177,8 +177,7 @@ impl UdpSocket {
 
     /// Sends data on the socket to the given address. On success, returns the
     /// number of bytes written. Note that the operating system may refuse
-    /// buffers larger than 65507. However, partial writes are not possible
-    /// until buffer sizes above `i32::MAX`.
+    /// buffers larger than 65507.
     ///
     /// Address type can be any implementor of [`ToSocketAddrs`] trait. See its
     /// documentation for concrete examples.
@@ -682,8 +681,7 @@ impl UdpSocket {
 
     /// Sends data on the socket to the remote address to which it is connected.
     /// On success, returns the number of bytes written. Note that the operating
-    /// system may refuse buffers larger than 65507. However, partial writes are
-    /// not possible until buffer sizes above `i32::MAX`.
+    /// system may refuse buffers larger than 65507.
     ///
     /// [`UdpSocket::connect`] will connect this socket to a remote address. This
     /// method will fail if the socket is not connected.


### PR DESCRIPTION
Fixes rust-lang/rust#145862

I think the most misleading expression is that UDP transmits data as packets  rather than as streams, so it appears that partial writes does not occur? 

> Additionally, the code might consider checking to see if buffer length exceeds the 16-byte limit, and erroring early as a small optimization, during the clamping of buffer length.

For this suggestion in rust-lang/rust#145862, I think the check should be managed by OS. Either the packet is accepted, or the operating system generates an error, such as EMSGSIZE.

r? libs