### PR TITLE
std: haiku: fix `B_FIND_PATH_IMAGE_PATH`

### DIFF
--- a/library/std/src/sys/pal/unix/os.rs
+++ b/library/std/src/sys/pal/unix/os.rs
@@ -469,7 +469,7 @@ pub fn current_exe() -> io::Result<PathBuf> {
     unsafe {
         let result = libc::find_path(
             crate::ptr::null_mut(),
-            libc::path_base_directory::B_FIND_PATH_IMAGE_PATH,
+            libc::B_FIND_PATH_IMAGE_PATH,
             crate::ptr::null_mut(),
             name.as_mut_ptr(),
             name.len(),


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/145952, which was caused by https://github.com/rust-lang/libc/pull/4575

@rustbot label T-libs O-haiku