### PR TITLE
Stabilize `vec_deque_pop_if`

### DIFF
--- a/library/alloc/src/collections/vec_deque/mod.rs
+++ b/library/alloc/src/collections/vec_deque/mod.rs
@@ -1831,7 +1831,6 @@ impl<T, A: Allocator> VecDeque<T, A> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(vec_deque_pop_if)]
     /// use std::collections::VecDeque;
     ///
     /// let mut deque: VecDeque<i32> = vec![0, 1, 2, 3, 4].into();
@@ -1841,7 +1840,7 @@ impl<T, A: Allocator> VecDeque<T, A> {
     /// assert_eq!(deque, [1, 2, 3, 4]);
     /// assert_eq!(deque.pop_front_if(pred), None);
     /// ```
-    #[unstable(feature = "vec_deque_pop_if", issue = "135889")]
+    #[stable(feature = "vec_deque_pop_if", since = "CURRENT_RUSTC_VERSION")]
     pub fn pop_front_if(&mut self, predicate: impl FnOnce(&mut T) -> bool) -> Option<T> {
         let first = self.front_mut()?;
         if predicate(first) { self.pop_front() } else { None }
@@ -1854,7 +1853,6 @@ impl<T, A: Allocator> VecDeque<T, A> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(vec_deque_pop_if)]
     /// use std::collections::VecDeque;
     ///
     /// let mut deque: VecDeque<i32> = vec![0, 1, 2, 3, 4].into();
@@ -1864,10 +1862,10 @@ impl<T, A: Allocator> VecDeque<T, A> {
     /// assert_eq!(deque, [0, 1, 2, 3]);
     /// assert_eq!(deque.pop_back_if(pred), None);
     /// ```
-    #[unstable(feature = "vec_deque_pop_if", issue = "135889")]
+    #[stable(feature = "vec_deque_pop_if", since = "CURRENT_RUSTC_VERSION")]
     pub fn pop_back_if(&mut self, predicate: impl FnOnce(&mut T) -> bool) -> Option<T> {
-        let first = self.back_mut()?;
-        if predicate(first) { self.pop_back() } else { None }
+        let last = self.back_mut()?;
+        if predicate(last) { self.pop_back() } else { None }
     }
 
     /// Prepends an element to the deque.

--- a/library/alloctests/tests/lib.rs
+++ b/library/alloctests/tests/lib.rs
@@ -37,7 +37,6 @@
 #![feature(str_as_str)]
 #![feature(strict_provenance_lints)]
 #![feature(string_replace_in_place)]
-#![feature(vec_deque_pop_if)]
 #![feature(vec_deque_truncate_front)]
 #![feature(unique_rc_arc)]
 #![feature(macro_metavar_expr_concat)]


### PR DESCRIPTION
Tracking issue: rust-lang/rust#135889
Closes rust-lang/rust#135889
Also fixes a typo mentioned in https://github.com/rust-lang/rust/issues/135889#issuecomment-2991213248

FCP: https://github.com/rust-lang/rust/issues/135889#issuecomment-3238777731

@rustbot label -T-libs +T-libs-api +needs-fcp +S-waiting-on-fcp

r? t-libs-api