### PR TITLE
`-Znext-solver` allow `ExprKind::Call` for not-yet defined opaques

### DIFF
--- a/compiler/rustc_hir_typeck/src/opaque_types.rs
+++ b/compiler/rustc_hir_typeck/src/opaque_types.rs
@@ -117,21 +117,25 @@ impl<'tcx> FnCtxt<'_, 'tcx> {
                     )
                 }
                 UsageKind::UnconstrainedHiddenType(hidden_type) => {
-                    let infer_var = hidden_type
-                        .ty
-                        .walk()
-                        .filter_map(ty::GenericArg::as_term)
-                        .find(|term| term.is_infer())
-                        .unwrap_or_else(|| hidden_type.ty.into());
-                    self.err_ctxt()
-                        .emit_inference_failure_err(
-                            self.body_id,
-                            hidden_type.span,
-                            infer_var,
-                            TypeAnnotationNeeded::E0282,
-                            false,
-                        )
-                        .emit()
+                    if let Some(guar) = self.tainted_by_errors() {
+                        guar
+                    } else {
+                        let infer_var = hidden_type
+                            .ty
+                            .walk()
+                            .filter_map(ty::GenericArg::as_term)
+                            .find(|term| term.is_infer())
+                            .unwrap_or_else(|| hidden_type.ty.into());
+                        self.err_ctxt()
+                            .emit_inference_failure_err(
+                                self.body_id,
+                                hidden_type.span,
+                                infer_var,
+                                TypeAnnotationNeeded::E0282,
+                                false,
+                            )
+                            .emit()
+                    }
                 }
                 UsageKind::HasDefiningUse => continue,
             };

--- a/compiler/rustc_hir_typeck/src/place_op.rs
+++ b/compiler/rustc_hir_typeck/src/place_op.rs
@@ -12,7 +12,7 @@ use rustc_span::{Span, sym};
 use tracing::debug;
 use {rustc_ast as ast, rustc_hir as hir};
 
-use crate::method::MethodCallee;
+use crate::method::{MethodCallee, TreatNotYetDefinedOpaques};
 use crate::{FnCtxt, PlaceOp};
 
 impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
@@ -210,7 +210,17 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             return None;
         };
 
-        self.lookup_method_for_operator(self.misc(span), imm_op, imm_tr, base_ty, opt_rhs_ty)
+        // FIXME(trait-system-refactor-initiative#231): we may want to treat
+        // opaque types as rigid here to support `impl Deref<Target = impl Index<usize>>`.
+        let treat_opaques = TreatNotYetDefinedOpaques::AsInfer;
+        self.lookup_method_for_operator(
+            self.misc(span),
+            imm_op,
+            imm_tr,
+            base_ty,
+            opt_rhs_ty,
+            treat_opaques,
+        )
     }
 
     fn try_mutable_overloaded_place_op(
@@ -230,7 +240,19 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             return None;
         };
 
-        self.lookup_method_for_operator(self.misc(span), mut_op, mut_tr, base_ty, opt_rhs_ty)
+        // We have to replace the operator with the mutable variant for the
+        // program to compile, so we don't really have a choice here and want
+        // to just try using `DerefMut` even if its not in the item bounds
+        // of the opaque.
+        let treat_opaques = TreatNotYetDefinedOpaques::AsInfer;
+        self.lookup_method_for_operator(
+            self.misc(span),
+            mut_op,
+            mut_tr,
+            base_ty,
+            opt_rhs_ty,
+            treat_opaques,
+        )
     }
 
     /// Convert auto-derefs, indices, etc of an expression from `Deref` and `Index`

--- a/compiler/rustc_infer/src/infer/context.rs
+++ b/compiler/rustc_infer/src/infer/context.rs
@@ -302,6 +302,9 @@ impl<'tcx> rustc_type_ir::InferCtxtLike for InferCtxt<'tcx> {
             .map(|(k, h)| (k, h.ty))
             .collect()
     }
+    fn opaques_with_sub_unified_hidden_type(&self, ty: ty::TyVid) -> Vec<ty::AliasTy<'tcx>> {
+        self.opaques_with_sub_unified_hidden_type(ty)
+    }
 
     fn register_hidden_type_in_storage(
         &self,

--- a/compiler/rustc_next_trait_solver/src/solve/assembly/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/assembly/mod.rs
@@ -23,7 +23,8 @@ use crate::delegate::SolverDelegate;
 use crate::solve::inspect::ProbeKind;
 use crate::solve::{
     BuiltinImplSource, CandidateSource, CanonicalResponse, Certainty, EvalCtxt, Goal, GoalSource,
-    MaybeCause, NoSolution, ParamEnvSource, QueryResult, has_no_inference_or_external_constraints,
+    MaybeCause, NoSolution, OpaqueTypesJank, ParamEnvSource, QueryResult,
+    has_no_inference_or_external_constraints,
 };
 
 enum AliasBoundKind {
@@ -474,7 +475,7 @@ where
         //
         // cc trait-system-refactor-initiative#105
         let source = CandidateSource::BuiltinImpl(BuiltinImplSource::Misc);
-        let certainty = Certainty::Maybe(cause);
+        let certainty = Certainty::Maybe { cause, opaque_types_jank: OpaqueTypesJank::AllGood };
         self.probe_trait_candidate(source)
             .enter(|this| this.evaluate_added_goals_and_make_canonical_response(certainty))
     }
@@ -974,11 +975,21 @@ where
         candidates: &mut Vec<Candidate<I>>,
     ) {
         let self_ty = goal.predicate.self_ty();
-        // If the self type is sub unified with any opaque type, we
-        // also look at blanket impls for it.
-        let mut assemble_blanket_impls = false;
-        for alias_ty in self.opaques_with_sub_unified_hidden_type(self_ty) {
-            assemble_blanket_impls = true;
+        // We only use this hack during HIR typeck.
+        let opaque_types = match self.typing_mode() {
+            TypingMode::Analysis { .. } => self.opaques_with_sub_unified_hidden_type(self_ty),
+            TypingMode::Coherence
+            | TypingMode::Borrowck { .. }
+            | TypingMode::PostBorrowckAnalysis { .. }
+            | TypingMode::PostAnalysis => vec![],
+        };
+
+        if opaque_types.is_empty() {
+            candidates.extend(self.forced_ambiguity(MaybeCause::Ambiguity));
+            return;
+        }
+
+        for &alias_ty in &opaque_types {
             debug!("self ty is sub unified with {alias_ty:?}");
 
             struct ReplaceOpaque<I: Interner> {
@@ -1028,10 +1039,11 @@ where
             }
         }
 
-        // We also need to consider blanket impls for not-yet-defined opaque types.
+        // If the self type is sub unified with any opaque type, we also look at blanket
+        // impls for it.
         //
         // See tests/ui/impl-trait/non-defining-uses/use-blanket-impl.rs for an example.
-        if assemble_blanket_impls && assemble_from.should_assemble_impl_candidates() {
+        if assemble_from.should_assemble_impl_candidates() {
             let cx = self.cx();
             cx.for_each_blanket_impl(goal.predicate.trait_def_id(cx), |impl_def_id| {
                 // For every `default impl`, there's always a non-default `impl`
@@ -1062,7 +1074,15 @@ where
         }
 
         if candidates.is_empty() {
-            candidates.extend(self.forced_ambiguity(MaybeCause::Ambiguity));
+            let source = CandidateSource::BuiltinImpl(BuiltinImplSource::Misc);
+            let certainty = Certainty::Maybe {
+                cause: MaybeCause::Ambiguity,
+                opaque_types_jank: OpaqueTypesJank::ErrorIfRigidSelfTy,
+            };
+            candidates
+                .extend(self.probe_trait_candidate(source).enter(|this| {
+                    this.evaluate_added_goals_and_make_canonical_response(certainty)
+                }));
         }
     }
 

--- a/compiler/rustc_next_trait_solver/src/solve/search_graph.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/search_graph.rs
@@ -93,7 +93,7 @@ where
     fn is_ambiguous_result(result: QueryResult<I>) -> bool {
         result.is_ok_and(|response| {
             has_no_inference_or_external_constraints(response)
-                && matches!(response.value.certainty, Certainty::Maybe(_))
+                && matches!(response.value.certainty, Certainty::Maybe { .. })
         })
     }
 

--- a/compiler/rustc_trait_selection/src/solve/fulfill.rs
+++ b/compiler/rustc_trait_selection/src/solve/fulfill.rs
@@ -204,7 +204,7 @@ where
                         //
                         // Only goals proven via the trait solver should be region dependent.
                         Certainty::Yes => {}
-                        Certainty::Maybe(_) => {
+                        Certainty::Maybe { .. } => {
                             self.obligations.register(obligation, None);
                         }
                     }
@@ -258,7 +258,7 @@ where
                             infcx.push_hir_typeck_potentially_region_dependent_goal(obligation);
                         }
                     }
-                    Certainty::Maybe(_) => self.obligations.register(obligation, stalled_on),
+                    Certainty::Maybe { .. } => self.obligations.register(obligation, stalled_on),
                 }
             }
 

--- a/compiler/rustc_trait_selection/src/solve/fulfill/derive_errors.rs
+++ b/compiler/rustc_trait_selection/src/solve/fulfill/derive_errors.rs
@@ -95,15 +95,17 @@ pub(super) fn fulfillment_error_for_stalled<'tcx>(
             root_obligation.cause.span,
             None,
         ) {
-            Ok(GoalEvaluation { certainty: Certainty::Maybe(MaybeCause::Ambiguity), .. }) => {
-                (FulfillmentErrorCode::Ambiguity { overflow: None }, true)
-            }
+            Ok(GoalEvaluation {
+                certainty: Certainty::Maybe { cause: MaybeCause::Ambiguity, .. },
+                ..
+            }) => (FulfillmentErrorCode::Ambiguity { overflow: None }, true),
             Ok(GoalEvaluation {
                 certainty:
-                    Certainty::Maybe(MaybeCause::Overflow {
-                        suggest_increasing_limit,
-                        keep_constraints: _,
-                    }),
+                    Certainty::Maybe {
+                        cause:
+                            MaybeCause::Overflow { suggest_increasing_limit, keep_constraints: _ },
+                        ..
+                    },
                 ..
             }) => (
                 FulfillmentErrorCode::Ambiguity { overflow: Some(suggest_increasing_limit) },
@@ -266,7 +268,8 @@ impl<'tcx> BestObligation<'tcx> {
             );
             // Skip nested goals that aren't the *reason* for our goal's failure.
             match (self.consider_ambiguities, nested_goal.result()) {
-                (true, Ok(Certainty::Maybe(MaybeCause::Ambiguity))) | (false, Err(_)) => {}
+                (true, Ok(Certainty::Maybe { cause: MaybeCause::Ambiguity, .. }))
+                | (false, Err(_)) => {}
                 _ => continue,
             }
 
@@ -407,7 +410,8 @@ impl<'tcx> ProofTreeVisitor<'tcx> for BestObligation<'tcx> {
         let tcx = goal.infcx().tcx;
         // Skip goals that aren't the *reason* for our goal's failure.
         match (self.consider_ambiguities, goal.result()) {
-            (true, Ok(Certainty::Maybe(MaybeCause::Ambiguity))) | (false, Err(_)) => {}
+            (true, Ok(Certainty::Maybe { cause: MaybeCause::Ambiguity, .. })) | (false, Err(_)) => {
+            }
             _ => return ControlFlow::Continue(()),
         }
 

--- a/compiler/rustc_trait_selection/src/solve/inspect/analyse.rs
+++ b/compiler/rustc_trait_selection/src/solve/inspect/analyse.rs
@@ -332,7 +332,7 @@ impl<'a, 'tcx> InspectGoal<'a, 'tcx> {
                 inspect::ProbeStep::MakeCanonicalResponse { shallow_certainty: c } => {
                     assert_matches!(
                         shallow_certainty.replace(c),
-                        None | Some(Certainty::Maybe(MaybeCause::Ambiguity))
+                        None | Some(Certainty::Maybe { cause: MaybeCause::Ambiguity, .. })
                     );
                 }
                 inspect::ProbeStep::NestedProbe(ref probe) => {

--- a/compiler/rustc_trait_selection/src/solve/select.rs
+++ b/compiler/rustc_trait_selection/src/solve/select.rs
@@ -62,7 +62,7 @@ impl<'tcx> inspect::ProofTreeVisitor<'tcx> for Select {
 
         // Don't winnow until `Certainty::Yes` -- we don't need to winnow until
         // codegen, and only on the good path.
-        if matches!(goal.result().unwrap(), Certainty::Maybe(..)) {
+        if matches!(goal.result().unwrap(), Certainty::Maybe { .. }) {
             return ControlFlow::Break(Ok(None));
         }
 
@@ -95,7 +95,7 @@ fn candidate_should_be_dropped_in_favor_of<'tcx>(
 ) -> bool {
     // Don't winnow until `Certainty::Yes` -- we don't need to winnow until
     // codegen, and only on the good path.
-    if matches!(other.result().unwrap(), Certainty::Maybe(..)) {
+    if matches!(other.result().unwrap(), Certainty::Maybe { .. }) {
         return false;
     }
 
@@ -143,13 +143,13 @@ fn to_selection<'tcx>(
     span: Span,
     cand: inspect::InspectCandidate<'_, 'tcx>,
 ) -> Option<Selection<'tcx>> {
-    if let Certainty::Maybe(..) = cand.shallow_certainty() {
+    if let Certainty::Maybe { .. } = cand.shallow_certainty() {
         return None;
     }
 
     let nested = match cand.result().expect("expected positive result") {
         Certainty::Yes => thin_vec![],
-        Certainty::Maybe(_) => cand
+        Certainty::Maybe { .. } => cand
             .instantiate_nested_goals(span)
             .into_iter()
             .map(|nested| {

--- a/compiler/rustc_trait_selection/src/traits/coherence.rs
+++ b/compiler/rustc_trait_selection/src/traits/coherence.rs
@@ -682,7 +682,7 @@ impl<'a, 'tcx> ProofTreeVisitor<'tcx> for AmbiguityCausesVisitor<'a, 'tcx> {
         // was irrelevant.
         match goal.result() {
             Ok(Certainty::Yes) | Err(NoSolution) => return,
-            Ok(Certainty::Maybe(_)) => {}
+            Ok(Certainty::Maybe { .. }) => {}
         }
 
         // For bound predicates we simply call `infcx.enter_forall`

--- a/compiler/rustc_type_ir/src/infer_ctxt.rs
+++ b/compiler/rustc_type_ir/src/infer_ctxt.rs
@@ -6,7 +6,7 @@ use crate::fold::TypeFoldable;
 use crate::inherent::*;
 use crate::relate::RelateResult;
 use crate::relate::combine::PredicateEmittingRelation;
-use crate::{self as ty, Interner};
+use crate::{self as ty, Interner, TyVid};
 
 /// The current typing mode of an inference context. We unfortunately have some
 /// slightly different typing rules depending on the current context. See the
@@ -271,6 +271,7 @@ pub trait InferCtxtLike: Sized {
         &self,
         prev_entries: Self::OpaqueTypeStorageEntries,
     ) -> Vec<(ty::OpaqueTypeKey<Self::Interner>, <Self::Interner as Interner>::Ty)>;
+    fn opaques_with_sub_unified_hidden_type(&self, ty: TyVid) -> Vec<ty::AliasTy<Self::Interner>>;
 
     fn register_hidden_type_in_storage(
         &self,

--- a/tests/ui/impl-trait/non-defining-uses/ambiguous-ops.current.stderr
+++ b/tests/ui/impl-trait/non-defining-uses/ambiguous-ops.current.stderr
@@ -1,0 +1,62 @@
+error[E0369]: cannot add `{integer}` to `impl Sized`
+  --> $DIR/ambiguous-ops.rs:17:15
+   |
+LL |         add() + 1
+   |         ----- ^ - {integer}
+   |         |
+   |         impl Sized
+
+error[E0368]: binary assignment operation `*=` cannot be applied to type `impl Sized`
+  --> $DIR/ambiguous-ops.rs:31:9
+   |
+LL |         temp *= 2;
+   |         ----^^^^^
+   |         |
+   |         cannot use `*=` on type `impl Sized`
+
+error[E0614]: type `DerefWrapper<impl Sized>` cannot be dereferenced
+  --> $DIR/ambiguous-ops.rs:57:22
+   |
+LL |         let _rarw = &*explicit_deref();
+   |                      ^^^^^^^^^^^^^^^^^ can't be dereferenced
+
+error[E0614]: type `DerefWrapper<impl Sized>` cannot be dereferenced
+  --> $DIR/ambiguous-ops.rs:69:9
+   |
+LL |         *explicit_deref_mut() = 1;
+   |         ^^^^^^^^^^^^^^^^^^^^^ can't be dereferenced
+
+error[E0277]: the type `impl Sized` cannot be indexed by `_`
+  --> $DIR/ambiguous-ops.rs:94:18
+   |
+LL |         let _y = explicit_index()[0];
+   |                  ^^^^^^^^^^^^^^^^ `impl Sized` cannot be indexed by `_`
+   |
+   = help: the trait `Index<_>` is not implemented for `impl Sized`
+note: required for `IndexWrapper<impl Sized>` to implement `Index<_>`
+  --> $DIR/ambiguous-ops.rs:81:22
+   |
+LL | impl<T: Index<U>, U> Index<U> for IndexWrapper<T> {
+   |         --------     ^^^^^^^^     ^^^^^^^^^^^^^^^
+   |         |
+   |         unsatisfied trait bound introduced here
+
+error[E0277]: the type `impl Sized` cannot be indexed by `_`
+  --> $DIR/ambiguous-ops.rs:106:9
+   |
+LL |         explicit_index_mut()[0] = 1;
+   |         ^^^^^^^^^^^^^^^^^^^^ `impl Sized` cannot be indexed by `_`
+   |
+   = help: the trait `Index<_>` is not implemented for `impl Sized`
+note: required for `IndexWrapper<impl Sized>` to implement `Index<_>`
+  --> $DIR/ambiguous-ops.rs:81:22
+   |
+LL | impl<T: Index<U>, U> Index<U> for IndexWrapper<T> {
+   |         --------     ^^^^^^^^     ^^^^^^^^^^^^^^^
+   |         |
+   |         unsatisfied trait bound introduced here
+
+error: aborting due to 6 previous errors
+
+Some errors have detailed explanations: E0277, E0368, E0369, E0614.
+For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/impl-trait/non-defining-uses/ambiguous-ops.rs
+++ b/tests/ui/impl-trait/non-defining-uses/ambiguous-ops.rs
@@ -1,0 +1,117 @@
+//@ revisions: current next
+//@[next] compile-flags: -Znext-solver
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@[next] check-pass
+
+// Make sure we support non-call operations for opaque types even if
+// its not part of its item bounds.
+
+use std::ops::{Deref, DerefMut, Index, IndexMut};
+
+fn mk<T>() -> T {
+    todo!()
+}
+
+fn add() -> impl Sized {
+    let unconstrained = if false {
+        add() + 1
+        //[current]~^ ERROR cannot add `{integer}` to `impl Sized
+    } else {
+        let with_infer = mk();
+        let _ = with_infer + 1;
+        with_infer
+    };
+    let _: u32 = unconstrained;
+    1u32
+}
+
+fn mul_assign() -> impl Sized {
+    if false {
+        let mut temp = mul_assign();
+        temp *= 2;
+        //[current]~^ ERROR binary assignment operation `*=` cannot be applied to type `impl Sized`
+    }
+
+    let mut with_infer = mk();
+    with_infer *= 2;
+    let _: u32 = with_infer;
+
+    1u32
+}
+
+struct DerefWrapper<T>(T);
+impl<T: Deref> Deref for DerefWrapper<T> {
+    type Target = T::Target;
+    fn deref(&self) -> &Self::Target {
+        &*self.0
+    }
+}
+impl<T: DerefMut> DerefMut for DerefWrapper<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut *self.0
+    }
+}
+
+fn explicit_deref() -> DerefWrapper<impl Sized> {
+    if false {
+        let _rarw = &*explicit_deref();
+        //[current]~^ ERROR type `DerefWrapper<impl Sized>` cannot be dereferenced
+
+        let mut with_infer = DerefWrapper(mk());
+        let _rarw = &*with_infer;
+        with_infer
+    } else {
+        DerefWrapper(&1u32)
+    }
+}
+fn explicit_deref_mut() -> DerefWrapper<impl Sized> {
+    if false {
+        *explicit_deref_mut() = 1;
+        //[current]~^ ERROR type `DerefWrapper<impl Sized>` cannot be dereferenced
+
+        let mut with_infer = DerefWrapper(Default::default());
+        *with_infer = 1;
+        with_infer
+    } else {
+        DerefWrapper(Box::new(1u32))
+    }
+}
+
+struct IndexWrapper<T>(T);
+impl<T: Index<U>, U> Index<U> for IndexWrapper<T> {
+    type Output = T::Output;
+    fn index(&self, index: U) -> &Self::Output {
+        &self.0[index]
+    }
+}
+impl<T: IndexMut<U>, U> IndexMut<U> for IndexWrapper<T> {
+    fn index_mut(&mut self, index: U) -> &mut Self::Output {
+        &mut self.0[index]
+    }
+}
+fn explicit_index() -> IndexWrapper<impl Sized> {
+    if false {
+        let _y = explicit_index()[0];
+        //[current]~^ ERROR the type `impl Sized` cannot be indexed by `_`
+
+        let with_infer = IndexWrapper(Default::default());
+        let _y = with_infer[0];
+        with_infer
+    } else {
+        IndexWrapper([1u32])
+    }
+}
+fn explicit_index_mut() -> IndexWrapper<impl Sized> {
+    if false {
+        explicit_index_mut()[0] = 1;
+        //[current]~^ ERROR the type `impl Sized` cannot be indexed by `_`
+
+        let mut with_infer = IndexWrapper(Default::default());
+        with_infer[0] = 1;
+        with_infer
+    } else {
+        IndexWrapper([1u32])
+    }
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/non-defining-uses/call-expr-incorrect-choice-diagnostics.current.stderr
+++ b/tests/ui/impl-trait/non-defining-uses/call-expr-incorrect-choice-diagnostics.current.stderr
@@ -1,0 +1,53 @@
+error[E0382]: use of moved value: `var`
+  --> $DIR/call-expr-incorrect-choice-diagnostics.rs:14:9
+   |
+LL |         let mut var = item_bound_is_too_weak();
+   |             ------- move occurs because `var` has type `impl FnOnce()`, which does not implement the `Copy` trait
+LL |         var();
+   |         ----- `var` moved due to this call
+LL |         var();
+   |         ^^^ value used here after move
+   |
+note: this value implements `FnOnce`, which causes it to be moved when called
+  --> $DIR/call-expr-incorrect-choice-diagnostics.rs:13:9
+   |
+LL |         var();
+   |         ^^^
+
+error[E0618]: expected function, found `impl Sized`
+  --> $DIR/call-expr-incorrect-choice-diagnostics.rs:24:9
+   |
+LL | fn opaque_type_no_impl_fn() -> impl Sized {
+   | ----------------------------------------- `opaque_type_no_impl_fn` defined here returns `impl Sized`
+LL |     if false {
+LL |         opaque_type_no_impl_fn()();
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^--
+   |         |
+   |         call expression requires function
+
+error[E0618]: expected function, found `impl Sized`
+  --> $DIR/call-expr-incorrect-choice-diagnostics.rs:34:9
+   |
+LL | fn opaque_type_no_impl_fn_incorrect() -> impl Sized {
+   | --------------------------------------------------- `opaque_type_no_impl_fn_incorrect` defined here returns `impl Sized`
+LL |     if false {
+LL |         opaque_type_no_impl_fn_incorrect()();
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^--
+   |         |
+   |         call expression requires function
+
+error[E0618]: expected function, found `impl Deref<Target = impl Sized>`
+  --> $DIR/call-expr-incorrect-choice-diagnostics.rs:44:9
+   |
+LL | fn opaque_type_deref_no_impl_fn() -> impl Deref<Target = impl Sized> {
+   | -------------------------------------------------------------------- `opaque_type_deref_no_impl_fn` defined here returns `impl Deref<Target = impl Sized>`
+LL |     if false {
+LL |         opaque_type_deref_no_impl_fn()();
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^--
+   |         |
+   |         call expression requires function
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0382, E0618.
+For more information about an error, try `rustc --explain E0382`.

--- a/tests/ui/impl-trait/non-defining-uses/call-expr-incorrect-choice-diagnostics.next.stderr
+++ b/tests/ui/impl-trait/non-defining-uses/call-expr-incorrect-choice-diagnostics.next.stderr
@@ -1,0 +1,57 @@
+error[E0382]: use of moved value: `var`
+  --> $DIR/call-expr-incorrect-choice-diagnostics.rs:14:9
+   |
+LL |         let mut var = item_bound_is_too_weak();
+   |             ------- move occurs because `var` has type `{closure@$DIR/call-expr-incorrect-choice-diagnostics.rs:19:5: 19:12}`, which does not implement the `Copy` trait
+LL |         var();
+   |         ----- `var` moved due to this call
+LL |         var();
+   |         ^^^ value used here after move
+   |
+note: this value implements `FnOnce`, which causes it to be moved when called
+  --> $DIR/call-expr-incorrect-choice-diagnostics.rs:13:9
+   |
+LL |         var();
+   |         ^^^
+help: consider cloning the value if the performance cost is acceptable
+   |
+LL |         var.clone()();
+   |            ++++++++
+
+error[E0618]: expected function, found `_`
+  --> $DIR/call-expr-incorrect-choice-diagnostics.rs:24:9
+   |
+LL | fn opaque_type_no_impl_fn() -> impl Sized {
+   | ----------------------------------------- `opaque_type_no_impl_fn` defined here returns `_`
+LL |     if false {
+LL |         opaque_type_no_impl_fn()();
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^--
+   |         |
+   |         call expression requires function
+
+error[E0618]: expected function, found `_`
+  --> $DIR/call-expr-incorrect-choice-diagnostics.rs:34:9
+   |
+LL | fn opaque_type_no_impl_fn_incorrect() -> impl Sized {
+   | --------------------------------------------------- `opaque_type_no_impl_fn_incorrect` defined here returns `_`
+LL |     if false {
+LL |         opaque_type_no_impl_fn_incorrect()();
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^--
+   |         |
+   |         call expression requires function
+
+error[E0618]: expected function, found `_`
+  --> $DIR/call-expr-incorrect-choice-diagnostics.rs:44:9
+   |
+LL | fn opaque_type_deref_no_impl_fn() -> impl Deref<Target = impl Sized> {
+   | -------------------------------------------------------------------- `opaque_type_deref_no_impl_fn` defined here returns `_`
+LL |     if false {
+LL |         opaque_type_deref_no_impl_fn()();
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^--
+   |         |
+   |         call expression requires function
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0382, E0618.
+For more information about an error, try `rustc --explain E0382`.

--- a/tests/ui/impl-trait/non-defining-uses/call-expr-incorrect-choice-diagnostics.rs
+++ b/tests/ui/impl-trait/non-defining-uses/call-expr-incorrect-choice-diagnostics.rs
@@ -1,0 +1,52 @@
+//@ revisions: current next
+//@[next] compile-flags: -Znext-solver
+//@ ignore-compare-mode-next-solver (explicit revisions)
+
+// Testing the errors in case we've made a wrong choice when
+// calling an opaque.
+
+use std::ops::Deref;
+
+fn item_bound_is_too_weak() -> impl FnOnce() {
+    if false {
+        let mut var = item_bound_is_too_weak();
+        var();
+        var();
+        //~^ ERROR use of moved value: `var`
+    }
+
+    let mut state = String::new();
+    move || state.push('a')
+}
+
+fn opaque_type_no_impl_fn() -> impl Sized {
+    if false {
+        opaque_type_no_impl_fn()();
+        //[current]~^ ERROR expected function, found `impl Sized`
+        //[next]~^^ ERROR expected function, found `_`
+    }
+
+    1
+}
+
+fn opaque_type_no_impl_fn_incorrect() -> impl Sized {
+    if false {
+        opaque_type_no_impl_fn_incorrect()();
+        //[current]~^ ERROR expected function, found `impl Sized`
+        //[next]~^^ ERROR expected function, found `_`
+    }
+
+    || ()
+}
+
+fn opaque_type_deref_no_impl_fn() -> impl Deref<Target = impl Sized> {
+    if false {
+        opaque_type_deref_no_impl_fn()();
+        //[current]~^ ERROR expected function, found `impl Deref<Target = impl Sized>`
+        //[next]~^^ ERROR expected function, found `_`
+    }
+
+    &1
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/non-defining-uses/deref-constrains-self-ty.current.stderr
+++ b/tests/ui/impl-trait/non-defining-uses/deref-constrains-self-ty.current.stderr
@@ -1,0 +1,16 @@
+error[E0599]: no method named `len` found for struct `Wrapper<T>` in the current scope
+  --> $DIR/deref-constrains-self-ty.rs:22:32
+   |
+LL | struct Wrapper<T>(T);
+   | ----------------- method `len` not found for this struct
+...
+LL |         let _ = Wrapper(foo()).len();
+   |                                ^^^ method not found in `Wrapper<impl Sized>`
+   |
+   = help: items from traits can only be used if the trait is implemented and in scope
+   = note: the following trait defines an item `len`, perhaps you need to implement it:
+           candidate #1: `ExactSizeIterator`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0599`.

--- a/tests/ui/impl-trait/non-defining-uses/deref-constrains-self-ty.rs
+++ b/tests/ui/impl-trait/non-defining-uses/deref-constrains-self-ty.rs
@@ -1,0 +1,28 @@
+//@ revisions: current next
+//@[next] compile-flags: -Znext-solver
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@[next] check-pass
+
+// A test which shows that autoderef can constrain opaque types even
+// though it's supposed to treat not-yet-defined opaque types as
+// mostly rigid. I don't think this should necessarily compile :shrug:
+use std::ops::Deref;
+
+struct Wrapper<T>(T);
+
+impl<T> Deref for Wrapper<Vec<T>> {
+    type Target = Vec<T>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+fn foo() -> impl Sized {
+    if false {
+        let _ = Wrapper(foo()).len();
+        //[current]~^ ERROR no method named `len` found for struct `Wrapper<T>` in the current scope
+    }
+
+    std::iter::once(1).collect()
+}
+fn main() {}

--- a/tests/ui/impl-trait/non-defining-uses/double-wrap-with-defining-use.current.stderr
+++ b/tests/ui/impl-trait/non-defining-uses/double-wrap-with-defining-use.current.stderr
@@ -1,5 +1,5 @@
 error[E0792]: expected generic type parameter, found `impl Foo`
-  --> $DIR/double-wrap-with-defining-use.rs:12:26
+  --> $DIR/double-wrap-with-defining-use.rs:11:26
    |
 LL | fn a<T: Foo>(x: T) -> impl Foo {
    |      - this generic parameter must be used with a generic type parameter
@@ -7,7 +7,7 @@ LL |     if true { x } else { a(a(x)) }
    |                          ^^^^^^^
 
 error: type parameter `T` is part of concrete type but not used in parameter list for the `impl Trait` type alias
-  --> $DIR/double-wrap-with-defining-use.rs:12:26
+  --> $DIR/double-wrap-with-defining-use.rs:11:26
    |
 LL |     if true { x } else { a(a(x)) }
    |                          ^^^^^^^

--- a/tests/ui/impl-trait/non-defining-uses/double-wrap-with-defining-use.rs
+++ b/tests/ui/impl-trait/non-defining-uses/double-wrap-with-defining-use.rs
@@ -1,7 +1,6 @@
 // Regression test for ICE from issue #140545
 // The error message is confusing and wrong, but that's a different problem (#139350)
 
-//@ edition:2018
 //@ revisions: current next
 //@[next] compile-flags: -Znext-solver
 //@ ignore-compare-mode-next-solver (explicit revisions)

--- a/tests/ui/impl-trait/non-defining-uses/function-call-on-infer.rs
+++ b/tests/ui/impl-trait/non-defining-uses/function-call-on-infer.rs
@@ -1,0 +1,73 @@
+//@ revisions: current next
+//@[next] compile-flags: -Znext-solver
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@ check-pass
+
+// Regression test for trait-system-refactor-initiative#181. Make sure calling
+// opaque types works.
+
+fn fn_trait() -> impl Fn() {
+    if false {
+        let f = fn_trait();
+        f();
+    }
+
+    || ()
+}
+
+fn fn_trait_ref() -> impl Fn() {
+    if false {
+        let f = &fn_trait();
+        f();
+    }
+    || ()
+}
+
+fn fn_mut() -> impl FnMut() -> usize {
+    if false {
+        let mut f = fn_mut();
+        f();
+    }
+
+    let mut state = 0;
+    move || {
+        state += 1;
+        state
+    }
+}
+
+fn fn_mut_ref() -> impl FnMut() -> usize {
+    if false {
+        let mut f = &mut fn_mut();
+        f();
+    }
+
+    let mut state = 0;
+    move || {
+        state += 1;
+        state
+    }
+}
+
+
+fn fn_once() -> impl FnOnce() {
+    if false {
+        let mut f = fn_once();
+        f();
+    }
+
+    let string = String::new();
+    move || drop(string)
+}
+
+fn fn_once_ref() -> impl FnOnce() {
+    if false {
+        let mut f = Box::new(fn_once_ref());
+        f();
+    }
+
+    let string = String::new();
+    move || drop(string)
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/non-defining-uses/ice-issue-146191.current.stderr
+++ b/tests/ui/impl-trait/non-defining-uses/ice-issue-146191.current.stderr
@@ -5,7 +5,7 @@ LL | fn create_complex_future() -> impl Future<Output = impl ReturnsSend> {
    |                                                    ^^^^^^^^^^^^^^^^ the trait `ReturnsSend` is not implemented for `()`
    |
 help: this trait has no implementations, consider adding one
-  --> $DIR/ice-issue-146191.rs:14:1
+  --> $DIR/ice-issue-146191.rs:13:1
    |
 LL | trait ReturnsSend {}
    | ^^^^^^^^^^^^^^^^^

--- a/tests/ui/impl-trait/non-defining-uses/ice-issue-146191.next.stderr
+++ b/tests/ui/impl-trait/non-defining-uses/ice-issue-146191.next.stderr
@@ -4,14 +4,6 @@ error[E0282]: type annotations needed
 LL |     async { create_complex_future().await }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type
 
-error[E0282]: type annotations needed
-  --> $DIR/ice-issue-146191.rs:8:5
-   |
-LL |     async { create_complex_future().await }
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type
-   |
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0282`.

--- a/tests/ui/impl-trait/non-defining-uses/ice-issue-146191.rs
+++ b/tests/ui/impl-trait/non-defining-uses/ice-issue-146191.rs
@@ -8,7 +8,6 @@ fn create_complex_future() -> impl Future<Output = impl ReturnsSend> {
     async { create_complex_future().await }
     //[current]~^ ERROR recursion in an async block requires
     //[next]~^^ ERROR type annotations needed
-    //[next]~| ERROR type annotations needed
 }
 
 trait ReturnsSend {}

--- a/tests/ui/impl-trait/non-defining-uses/impl-deref-function-call.rs
+++ b/tests/ui/impl-trait/non-defining-uses/impl-deref-function-call.rs
@@ -1,0 +1,56 @@
+//@ revisions: current next
+//@[next] compile-flags: -Znext-solver
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@ check-pass
+
+// Regression test for trait-system-refactor-initiative#181. We want to
+// be able to step through `impl Deref` in its defining scope.
+use std::ops::{Deref, DerefMut};
+fn impl_deref_fn() -> impl Deref<Target = fn(fn(&str) -> usize)> {
+    if false {
+        let func = impl_deref_fn();
+        func(|s| s.len());
+    }
+
+    &((|_| ()) as fn(_))
+}
+
+fn impl_deref_impl_fn() -> impl Deref<Target = impl Fn()> {
+    if false {
+        let func = impl_deref_impl_fn();
+        func();
+    }
+
+    &|| ()
+}
+
+fn impl_deref_impl_deref_impl_fn() -> impl Deref<Target = impl Deref<Target = impl Fn()>> {
+    if false {
+        let func = impl_deref_impl_deref_impl_fn();
+        func();
+    }
+
+    &&|| ()
+}
+
+
+fn impl_deref_mut_impl_fn() -> impl DerefMut<Target = impl Fn()> {
+    if false {
+        let func = impl_deref_impl_fn();
+        func();
+    }
+
+    Box::new(|| ())
+}
+
+
+fn impl_deref_mut_impl_fn_mut() -> impl DerefMut<Target = impl FnMut()> {
+    if false {
+        let mut func = impl_deref_mut_impl_fn_mut();
+        func();
+    }
+
+    let mut state = 0;
+    Box::new(move || state += 1)
+}
+fn main() {}

--- a/tests/ui/impl-trait/non-defining-uses/shex_compat-regression-test.rs
+++ b/tests/ui/impl-trait/non-defining-uses/shex_compat-regression-test.rs
@@ -1,0 +1,19 @@
+//@ revisions: current next
+//@[next] compile-flags: -Znext-solver
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@ check-pass
+
+// Regression test for trait-system-refactor-initiative#181.
+
+struct ShExCompactPrinter;
+
+struct TripleExpr;
+
+impl ShExCompactPrinter {
+    fn pp_triple_expr(&self) -> impl Fn(&TripleExpr, &ShExCompactPrinter) + '_ {
+        move |te, printer| {
+            printer.pp_triple_expr()(te, printer);
+        }
+    }
+}
+fn main() {}

--- a/tests/ui/impl-trait/two_tait_defining_each_other2.next.stderr
+++ b/tests/ui/impl-trait/two_tait_defining_each_other2.next.stderr
@@ -4,12 +4,6 @@ error[E0282]: type annotations needed
 LL | fn muh(x: A) -> B {
    |        ^ cannot infer type
 
-error[E0282]: type annotations needed
-  --> $DIR/two_tait_defining_each_other2.rs:14:5
-   |
-LL |     x // B's hidden type is A (opaquely)
-   |     ^ cannot infer type
-
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0282`.

--- a/tests/ui/impl-trait/two_tait_defining_each_other2.rs
+++ b/tests/ui/impl-trait/two_tait_defining_each_other2.rs
@@ -12,8 +12,7 @@ trait Foo {}
 fn muh(x: A) -> B {
     //[next]~^ ERROR: type annotations needed
     x // B's hidden type is A (opaquely)
-    //[next]~^ ERROR: type annotations needed
-    //[current]~^^ ERROR opaque type's hidden type cannot be another opaque type
+    //[current]~^ ERROR opaque type's hidden type cannot be another opaque type
 }
 
 struct Bar;

--- a/tests/ui/inference/return-block-type-inference-15965.stderr
+++ b/tests/ui/inference/return-block-type-inference-15965.stderr
@@ -1,10 +1,8 @@
 error[E0282]: type annotations needed
   --> $DIR/return-block-type-inference-15965.rs:5:9
    |
-LL | /         { return () }
-LL | |
-LL | |     ()
-   | |______^ cannot infer type
+LL |         { return () }
+   |         ^^^^^^^^^^^^^ cannot infer type
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/unboxed-closures/unboxed-closures-failed-recursive-fn-2.stderr
+++ b/tests/ui/unboxed-closures/unboxed-closures-failed-recursive-fn-2.stderr
@@ -5,7 +5,7 @@ LL |     let mut closure0 = None;
    |         ^^^^^^^^^^^^
 ...
 LL |                         return c();
-   |                                --- type must be known at this point
+   |                                - type must be known at this point
    |
 help: consider giving `closure0` an explicit type, where the placeholders `_` are specified
    |


### PR DESCRIPTION
Based on https://github.com/rust-lang/rust/pull/146329. Revival of rust-lang/rust#140496. See the comment on `OpaqueTypesJank`. I've used the following document while working on this https://hackmd.io/Js61f8PRTcyaiyqS-fH9iQ.

Fixes https://github.com/rust-lang/trait-system-refactor-initiative/issues/181. It does introduce one subtle footgun we may want to handle before stabilization, opened https://github.com/rust-lang/trait-system-refactor-initiative/issues/230 for that. Also cc https://github.com/rust-lang/trait-system-refactor-initiative/issues/231 for deref and index operations

r? @BoxyUwU 