### PR TITLE
Improve librustdoc error when a file creation/modification failed

### DIFF
--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -760,7 +760,9 @@ fn run_renderer<
                 tcx.dcx().struct_fatal(format!("couldn't generate documentation: {}", e.error));
             let file = e.file.display().to_string();
             if !file.is_empty() {
-                msg.note(format!("failed to create or modify \"{file}\""));
+                msg.note(format!("failed to create or modify {e}"));
+            } else {
+                msg.note(format!("failed to create or modify file: {e}"));
             }
             msg.emit();
         }


### PR DESCRIPTION
The message before looks like this:

```
failed to create or modify "/build/x86_64-unknown-linux-gnu/test/rustdoc-gui/doc/search.index/entry/"
```

And with this change it looks like this:

```
failed to create or modify "/build/x86_64-unknown-linux-gnu/test/rustdoc-gui/doc/search.index/entry/": failed to read column from disk: data consumer error: missing field `unknown number` at line 1 column 8
```

r? @lolbinarycat 