### PR TITLE
Add move metadata into source info

### DIFF
--- a/compiler/rustc_mir_transform/src/add_move_metadata.rs
+++ b/compiler/rustc_mir_transform/src/add_move_metadata.rs
@@ -1,0 +1,129 @@
+//! This module provides a pass that modifies spans for statements with move operands,
+//! adding information about moved types and their sizes to the filename.
+
+use rustc_middle::mir::{Body, Operand, Rvalue, StatementKind};
+use rustc_middle::ty::{Ty, TyCtxt, TypingEnv};
+use rustc_span::{FileName, Span};
+use tracing::debug;
+
+pub(super) struct AddMoveMetadata;
+
+impl<'tcx> crate::MirPass<'tcx> for AddMoveMetadata {
+    fn run_pass(&self, tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
+        for basic_block in body.basic_blocks.as_mut() {
+            for statement in basic_block.statements.iter_mut() {
+                if let StatementKind::Assign(box (place, rvalue)) = &statement.kind {
+                    if rvalue_has_move(rvalue) {
+                        let moved_types =
+                            get_moved_types_from_rvalue(rvalue, &body.local_decls, tcx);
+                        let mut moved_types_with_sizes: Vec<_> = moved_types
+                            .iter()
+                            .map(|ty| {
+                                let size = tcx
+                                    .layout_of(TypingEnv::fully_monomorphized().as_query_input(*ty))
+                                    .map(|layout| layout.size.bytes())
+                                    .unwrap_or(0);
+                                (*ty, size)
+                            })
+                            .collect();
+                        moved_types_with_sizes.sort_by(|a, b| b.1.cmp(&a.1));
+                        let old_span = statement.source_info.span;
+                        statement.source_info.span = modify_span_filename(
+                            statement.source_info.span,
+                            &moved_types_with_sizes,
+                            tcx,
+                        );
+                        for (ty, size) in &moved_types_with_sizes {
+                            debug!("Moved type: {} (size: {} bytes)", ty, size);
+                        }
+                        debug!(
+                            "Changed span from {:?} to {:?}, place: {:?}, rvalue: {:?}",
+                            old_span, statement.source_info.span, place, rvalue
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    fn is_required(&self) -> bool {
+        true
+    }
+}
+
+fn rvalue_has_move(rvalue: &Rvalue<'_>) -> bool {
+    match rvalue {
+        Rvalue::Use(operand)
+        | Rvalue::Repeat(operand, _)
+        | Rvalue::Cast(_, operand, _)
+        | Rvalue::UnaryOp(_, operand) => matches!(operand, Operand::Move(_)),
+        Rvalue::BinaryOp(_, box (left, right)) => {
+            matches!(left, Operand::Move(_)) || matches!(right, Operand::Move(_))
+        }
+        Rvalue::Aggregate(_, operands) => operands.iter().any(|op| matches!(op, Operand::Move(_))),
+        _ => false,
+    }
+}
+
+fn get_moved_types_from_rvalue<'tcx>(
+    rvalue: &Rvalue<'tcx>,
+    local_decls: &rustc_middle::mir::LocalDecls<'tcx>,
+    tcx: TyCtxt<'tcx>,
+) -> Vec<Ty<'tcx>> {
+    let mut types = Vec::new();
+    match rvalue {
+        Rvalue::Use(Operand::Move(place))
+        | Rvalue::Repeat(Operand::Move(place), _)
+        | Rvalue::Cast(_, Operand::Move(place), _)
+        | Rvalue::UnaryOp(_, Operand::Move(place)) => {
+            types.push(place.ty(local_decls, tcx).ty);
+        }
+        Rvalue::BinaryOp(_, box (left, right)) => {
+            if let Operand::Move(place) = left {
+                types.push(place.ty(local_decls, tcx).ty);
+            }
+            if let Operand::Move(place) = right {
+                types.push(place.ty(local_decls, tcx).ty);
+            }
+        }
+        Rvalue::Aggregate(_, operands) => {
+            for operand in operands {
+                if let Operand::Move(place) = operand {
+                    types.push(place.ty(local_decls, tcx).ty);
+                }
+            }
+        }
+        _ => {}
+    }
+    types
+}
+
+fn modify_span_filename<'tcx>(
+    span: Span,
+    moved_types_with_sizes: &[(Ty<'tcx>, u64)],
+    tcx: TyCtxt<'tcx>,
+) -> Span {
+    let source_map = tcx.sess.source_map();
+    let source_file = source_map.lookup_source_file(span.lo());
+    let filename = source_file.name.prefer_local().to_string();
+    let types_str = moved_types_with_sizes
+        .iter()
+        .map(|(ty, size)| format!("{}({} bytes)", ty, size))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let new_filename = format!("{} Moved:[{}] Line:", filename, types_str);
+
+    let src = source_file.src.as_ref().map(|s| s.as_str()).unwrap_or("").to_string();
+    let new_source_file = source_map.new_source_file(
+        FileName::Real(rustc_span::RealFileName::LocalPath(std::path::PathBuf::from(new_filename))),
+        src,
+    );
+
+    let offset = span.lo() - source_file.start_pos;
+    Span::new(
+        new_source_file.start_pos + offset,
+        new_source_file.start_pos + offset + (span.hi() - span.lo()),
+        span.ctxt(),
+        span.parent(),
+    )
+}

--- a/compiler/rustc_mir_transform/src/lib.rs
+++ b/compiler/rustc_mir_transform/src/lib.rs
@@ -123,6 +123,7 @@ declare_passes! {
     mod check_packed_ref : CheckPackedRef;
     // This pass is public to allow external drivers to perform MIR cleanup
     pub mod cleanup_post_borrowck : CleanupPostBorrowck;
+    mod add_move_metadata : AddMoveMetadata;
 
     mod copy_prop : CopyProp;
     mod coroutine : StateTransform;
@@ -578,6 +579,7 @@ pub fn run_analysis_to_runtime_passes<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body<'
 fn run_analysis_cleanup_passes<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
     let passes: &[&dyn MirPass<'tcx>] = &[
         &impossible_predicates::ImpossiblePredicates,
+        &add_move_metadata::AddMoveMetadata,
         &cleanup_post_borrowck::CleanupPostBorrowck,
         &remove_noop_landing_pads::RemoveNoopLandingPads,
         &simplify::SimplifyCfg::PostAnalysis,


### PR DESCRIPTION
Add a new MIR pass which changes the source filename for statements with move operands to include information about the types being moved.

This is just a proof of concept to play with, we'll need a better approach if we want to make this a feature.

### Background

When profiling my applications to improve throughput, I've found lots of cases where I have a lot of CPU time spent in `memcpy`. Profiling tools show this to be directly called from my code, e.g. `copy::main` -> `memcpy`, but it's not always obvious to me where the memcpy comes from, to allow me to fix it (e.g. by moving some data on to the heap). Even with line number, it could come from values moved into a closure, but with complex code that could be several values of different types and sizes, so how do I know which are the expensive ones?

I would like to have some way to trace back from expensive `memcpy` at runtime to which values are being moved and why. As a proof of concept, I've looked for move operands and added the moved type into the source filename, which is obviously a hack, but allows profiling tools to show this alongside the runtime cost of `memcpy`.

Profile before:
<img width="1124" height="168" alt="before" src="https://github.com/user-attachments/assets/1b4d1f23-da77-4fb5-bf45-fcb8ce1a803d" />

Profile after:
The new filename/line number is like this: `/tmp/rust/copy.rs Moved:[[u8; 1234](1234 bytes)] Line::12`
<img width="2168" height="331" alt="after" src="https://github.com/user-attachments/assets/729e0b6d-311e-46d5-9669-e7b7737ea690" />

The new profile shows us the types that were moved for each `memcpy` operation.

I think static analysis is not enough to solve this satisfactorily, because we really only care about cases which are actually hot.

### Real implementation

As a first step, simply emitting a mapping of source location to moved types would allow for manual lookup by the developer. They can profile their code, then for each memcpy of interest, look up the mapping and see which type(s) were moved there (could this data be exposed somehow by rust-analyzer?). It would be nice to avoid the manual mapping step, though, and have the information available directly in the profile. Profiler tools could be modified to read the mapping, but that's a pain (I assume). Creative hacks include inserting wrapper method calls around memcpy which include this information in the method name. `copy::main` -> `memcpy` becomes `copy::main` -> `fake_methods::rustc_move_[[u8; 1234](1234 bytes)]` -> `memcpy`, so profilers see it automatically. This could be limited to moves over a size threshold to reduce overhead.

### Additional features/questions

* Do we have access to the variable names? That would be useful to include.
* Is this a legitimate way to find the relevant moves? Did I miss any cases?
* Is there already some easy way to solve this problem (finding the cause of expensive move memcpys) that I just don't know about?