### PR TITLE
Implement `Receiver` for `Exclusive`

### DIFF
--- a/library/core/src/sync/exclusive.rs
+++ b/library/core/src/sync/exclusive.rs
@@ -224,7 +224,10 @@ where
     }
 }
 
-// FIXME: implement `DerefMut` when this becomes possible
+// FIXME: implement `DerefMut` when this becomes possible.
+// Currently, this can't be done because `DerefMut` has `Deref`
+// as a supertrait. But RFC 3437 would allow changing that:
+// https://github.com/rust-lang/rust/issues/98407#issuecomment-3238181337
 #[unstable(feature = "arbitrary_self_types", issue = "44874")]
 impl<T> Receiver for Exclusive<T>
 where


### PR DESCRIPTION
In the hope of being able to implement `DerefMut` in the future.

Changes `Exclusive`'s methods to associated functions.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

cc rust-lang/rust#98407

@rustbot label T-libs-api
