### PR TITLE
use `field_with` to print "<locked>" and "<uninit>" in `Debug`

### DIFF
--- a/library/core/src/cell/lazy.rs
+++ b/library/core/src/cell/lazy.rs
@@ -364,7 +364,7 @@ impl<T: fmt::Debug, F> fmt::Debug for LazyCell<T, F> {
         let mut d = f.debug_tuple("LazyCell");
         match LazyCell::get(self) {
             Some(data) => d.field(data),
-            None => d.field(&format_args!("<uninit>")),
+            None => d.field_with(|f| f.write_str("<uninit>")),
         };
         d.finish()
     }

--- a/library/core/src/cell/once.rs
+++ b/library/core/src/cell/once.rs
@@ -362,7 +362,7 @@ impl<T: fmt::Debug> fmt::Debug for OnceCell<T> {
         let mut d = f.debug_tuple("OnceCell");
         match self.get() {
             Some(v) => d.field(v),
-            None => d.field(&format_args!("<uninit>")),
+            None => d.field_with(|f| f.write_str("<uninit>")),
         };
         d.finish()
     }

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -339,6 +339,7 @@
 #![feature(const_try)]
 #![feature(core_intrinsics)]
 #![feature(core_io_borrowed_buf)]
+#![feature(debug_closure_helpers)]
 #![feature(drop_guard)]
 #![feature(duration_constants)]
 #![feature(error_generic_member_access)]

--- a/library/std/src/sync/lazy_lock.rs
+++ b/library/std/src/sync/lazy_lock.rs
@@ -395,7 +395,7 @@ impl<T: fmt::Debug, F> fmt::Debug for LazyLock<T, F> {
         let mut d = f.debug_tuple("LazyLock");
         match LazyLock::get(self) {
             Some(v) => d.field(v),
-            None => d.field(&format_args!("<uninit>")),
+            None => d.field_with(|f| f.write_str("<uninit>")),
         };
         d.finish()
     }

--- a/library/std/src/sync/once_lock.rs
+++ b/library/std/src/sync/once_lock.rs
@@ -600,7 +600,7 @@ impl<T: fmt::Debug> fmt::Debug for OnceLock<T> {
         let mut d = f.debug_tuple("OnceLock");
         match self.get() {
             Some(v) => d.field(v),
-            None => d.field(&format_args!("<uninit>")),
+            None => d.field_with(|f| f.write_str("<uninit>")),
         };
         d.finish()
     }

--- a/library/std/src/sync/poison/rwlock.rs
+++ b/library/std/src/sync/poison/rwlock.rs
@@ -684,7 +684,7 @@ impl<T: ?Sized + fmt::Debug> fmt::Debug for RwLock<T> {
                 d.field("data", &&**err.get_ref());
             }
             Err(TryLockError::WouldBlock) => {
-                d.field("data", &format_args!("<locked>"));
+                d.field_with("data", |f| f.write_str("<locked>"));
             }
         }
         d.field("poisoned", &self.poison.get());

--- a/library/std/src/sync/reentrant_lock.rs
+++ b/library/std/src/sync/reentrant_lock.rs
@@ -373,7 +373,7 @@ impl<T: fmt::Debug + ?Sized> fmt::Debug for ReentrantLock<T> {
         let mut d = f.debug_struct("ReentrantLock");
         match self.try_lock() {
             Some(v) => d.field("data", &&*v),
-            None => d.field("data", &format_args!("<locked>")),
+            None => d.field_with("data", |f| f.write_str("<locked>")),
         };
         d.finish_non_exhaustive()
     }


### PR DESCRIPTION
This avoids having to create a new `Arguments` just for printing a string.