### PR TITLE
Point at fn bound that introduced lifetime obligation

### DIFF
--- a/compiler/rustc_borrowck/src/borrowck_errors.rs
+++ b/compiler/rustc_borrowck/src/borrowck_errors.rs
@@ -480,7 +480,7 @@ impl<'infcx, 'tcx> crate::MirBorrowckCtxt<'_, 'infcx, 'tcx> {
     }
 
     pub(crate) fn temporary_value_borrowed_for_too_long(&self, span: Span) -> Diag<'infcx> {
-        struct_span_code_err!(self.dcx(), span, E0716, "temporary value dropped while borrowed",)
+        struct_span_code_err!(self.dcx(), span, E0716, "temporary value dropped while borrowed")
     }
 }
 

--- a/compiler/rustc_borrowck/src/borrowck_errors.rs
+++ b/compiler/rustc_borrowck/src/borrowck_errors.rs
@@ -426,7 +426,7 @@ impl<'infcx, 'tcx> crate::MirBorrowckCtxt<'_, 'infcx, 'tcx> {
     }
 
     pub(crate) fn path_does_not_live_long_enough(&self, span: Span, path: &str) -> Diag<'infcx> {
-        struct_span_code_err!(self.dcx(), span, E0597, "{} does not live long enough", path,)
+        struct_span_code_err!(self.dcx(), span, E0597, "{} does not live long enough", path)
     }
 
     pub(crate) fn cannot_return_reference_to_local(

--- a/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
@@ -3031,6 +3031,15 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
 
         let mut err = self.path_does_not_live_long_enough(borrow_span, &name);
 
+        if let BorrowExplanation::MustBeValidFor { ref path, region_name, .. } = explanation {
+            for constraint in path {
+                if let ConstraintCategory::Predicate(pred) = constraint.category
+                    && !pred.is_dummy()
+                {
+                    err.span_note(pred, format!("requirement that {name} is borrowed for `{region_name}` introduced here"));
+                }
+            }
+        }
         if let Some(annotation) = self.annotate_argument_and_return_for_borrow(borrow) {
             let region_name = annotation.emit(self, &mut err);
 

--- a/compiler/rustc_borrowck/src/diagnostics/explain_borrow.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/explain_borrow.rs
@@ -417,18 +417,21 @@ impl<'tcx> BorrowExplanation<'tcx> {
                     self.add_object_lifetime_default_note(tcx, err, unsize_ty);
                 }
 
-                if let Some(pred) = path
+                let mut preds = path
                     .iter()
                     .filter_map(|constraint| match constraint.category {
                         ConstraintCategory::Predicate(pred) if !pred.is_dummy() => Some(pred),
                         _ => None,
                     })
-                    .next()
-                {
+                    .collect::<Vec<Span>>();
+                preds.sort();
+                preds.dedup();
+                if !preds.is_empty() {
+                    let s = if preds.len() == 1 { "" } else { "s" };
                     err.span_note(
-                        pred,
+                        preds,
                         format!(
-                            "requirement that the value outlives `{region_name}` introduced here"
+                            "requirement{s} that the value outlives `{region_name}` introduced here"
                         ),
                     );
                 }

--- a/compiler/rustc_borrowck/src/diagnostics/explain_borrow.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/explain_borrow.rs
@@ -416,6 +416,19 @@ impl<'tcx> BorrowExplanation<'tcx> {
                 {
                     self.add_object_lifetime_default_note(tcx, err, unsize_ty);
                 }
+
+                for constraint in path {
+                    if let ConstraintCategory::Predicate(pred) = constraint.category
+                        && !pred.is_dummy()
+                    {
+                        err.span_note(
+                            pred,
+                            format!("requirement for `{region_name}` introduced here"),
+                        );
+                        break;
+                    }
+                }
+
                 self.add_lifetime_bound_suggestion_to_diagnostic(err, &category, span, region_name);
             }
             _ => {}

--- a/compiler/rustc_borrowck/src/diagnostics/explain_borrow.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/explain_borrow.rs
@@ -423,7 +423,7 @@ impl<'tcx> BorrowExplanation<'tcx> {
                     {
                         err.span_note(
                             pred,
-                            format!("requirement for `{region_name}` introduced here"),
+                            format!("requirement that the value outlives `{region_name}` introduced here"),
                         );
                         break;
                     }

--- a/tests/ui/async-await/async-closures/without-precise-captures-we-are-powerless.rs
+++ b/tests/ui/async-await/async-closures/without-precise-captures-we-are-powerless.rs
@@ -44,4 +44,18 @@ fn through_field_and_ref_move<'a>(x: &S<'a>) {
     outlives::<'a>(call_once(c)); //~ ERROR explicit lifetime required in the type of `x`
 }
 
+struct T;
+impl T {
+    fn outlives<'a>(&'a self, _: impl Sized + 'a) {}
+}
+fn through_method<'a>(x: &'a i32) {
+    let c = async || { println!("{}", *x); }; //~ ERROR `x` does not live long enough
+    T.outlives::<'a>(c());
+    T.outlives::<'a>(call_once(c));
+
+    let c = async move || { println!("{}", *x); };
+    T.outlives::<'a>(c()); //~ ERROR `c` does not live long enough
+    T.outlives::<'a>(call_once(c));
+}
+
 fn main() {}

--- a/tests/ui/async-await/async-closures/without-precise-captures-we-are-powerless.stderr
+++ b/tests/ui/async-await/async-closures/without-precise-captures-we-are-powerless.stderr
@@ -28,6 +28,12 @@ LL |     outlives::<'a>(c());
 LL |     outlives::<'a>(call_once(c));
 LL | }
    | - `c` dropped here while still borrowed
+   |
+note: requirement that `c` is borrowed for `'a` introduced here
+  --> $DIR/without-precise-captures-we-are-powerless.rs:7:33
+   |
+LL | fn outlives<'a>(_: impl Sized + 'a) {}
+   |                                 ^^
 
 error[E0597]: `x` does not live long enough
   --> $DIR/without-precise-captures-we-are-powerless.rs:26:13
@@ -73,6 +79,12 @@ LL |     outlives::<'a>(c());
 LL |     outlives::<'a>(call_once(c));
 LL | }
    | - `c` dropped here while still borrowed
+   |
+note: requirement that `c` is borrowed for `'a` introduced here
+  --> $DIR/without-precise-captures-we-are-powerless.rs:7:33
+   |
+LL | fn outlives<'a>(_: impl Sized + 'a) {}
+   |                                 ^^
 
 error[E0505]: cannot move out of `c` because it is borrowed
   --> $DIR/without-precise-captures-we-are-powerless.rs:32:30
@@ -129,6 +141,12 @@ LL |     outlives::<'a>(c());
 LL |     outlives::<'a>(call_once(c));
 LL | }
    | - `c` dropped here while still borrowed
+   |
+note: requirement that `c` is borrowed for `'a` introduced here
+  --> $DIR/without-precise-captures-we-are-powerless.rs:7:33
+   |
+LL | fn outlives<'a>(_: impl Sized + 'a) {}
+   |                                 ^^
 
 error[E0621]: explicit lifetime required in the type of `x`
   --> $DIR/without-precise-captures-we-are-powerless.rs:44:5
@@ -141,7 +159,44 @@ help: add explicit lifetime `'a` to the type of `x`
 LL | fn through_field_and_ref_move<'a>(x: &'a S<'a>) {
    |                                       ++
 
-error: aborting due to 10 previous errors
+error[E0597]: `x` does not live long enough
+  --> $DIR/without-precise-captures-we-are-powerless.rs:52:13
+   |
+LL | fn through_method<'a>(x: &'a i32) {
+   |                   -- lifetime `'a` defined here
+LL |     let c = async || { println!("{}", *x); };
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ borrowed value does not live long enough
+LL |     T.outlives::<'a>(c());
+LL |     T.outlives::<'a>(call_once(c));
+   |     ------------------------------ argument requires that `x` is borrowed for `'a`
+...
+LL | }
+   |  - `x` dropped here while still borrowed
+
+error[E0597]: `c` does not live long enough
+  --> $DIR/without-precise-captures-we-are-powerless.rs:57:22
+   |
+LL | fn through_method<'a>(x: &'a i32) {
+   |                   -- lifetime `'a` defined here
+...
+LL |     let c = async move || { println!("{}", *x); };
+   |         - binding `c` declared here
+LL |     T.outlives::<'a>(c());
+   |     -----------------^---
+   |     |                |
+   |     |                borrowed value does not live long enough
+   |     argument requires that `c` is borrowed for `'a`
+LL |     T.outlives::<'a>(call_once(c));
+LL | }
+   | - `c` dropped here while still borrowed
+   |
+note: requirement that `c` is borrowed for `'a` introduced here
+  --> $DIR/without-precise-captures-we-are-powerless.rs:49:47
+   |
+LL |     fn outlives<'a>(&'a self, _: impl Sized + 'a) {}
+   |                                               ^^
+
+error: aborting due to 12 previous errors
 
 Some errors have detailed explanations: E0505, E0597, E0621.
 For more information about an error, try `rustc --explain E0505`.

--- a/tests/ui/async-await/async-closures/without-precise-captures-we-are-powerless.stderr
+++ b/tests/ui/async-await/async-closures/without-precise-captures-we-are-powerless.stderr
@@ -29,7 +29,7 @@ LL |     outlives::<'a>(call_once(c));
 LL | }
    | - `c` dropped here while still borrowed
    |
-note: requirement for `'a` introduced here
+note: requirement that the value outlives `'a` introduced here
   --> $DIR/without-precise-captures-we-are-powerless.rs:7:33
    |
 LL | fn outlives<'a>(_: impl Sized + 'a) {}
@@ -80,7 +80,7 @@ LL |     outlives::<'a>(call_once(c));
 LL | }
    | - `c` dropped here while still borrowed
    |
-note: requirement for `'a` introduced here
+note: requirement that the value outlives `'a` introduced here
   --> $DIR/without-precise-captures-we-are-powerless.rs:7:33
    |
 LL | fn outlives<'a>(_: impl Sized + 'a) {}
@@ -102,7 +102,7 @@ LL |     outlives::<'a>(c());
 LL |     outlives::<'a>(call_once(c));
    |                              ^ move out of `c` occurs here
    |
-note: requirement for `'a` introduced here
+note: requirement that the value outlives `'a` introduced here
   --> $DIR/without-precise-captures-we-are-powerless.rs:7:33
    |
 LL | fn outlives<'a>(_: impl Sized + 'a) {}
@@ -148,7 +148,7 @@ LL |     outlives::<'a>(call_once(c));
 LL | }
    | - `c` dropped here while still borrowed
    |
-note: requirement for `'a` introduced here
+note: requirement that the value outlives `'a` introduced here
   --> $DIR/without-precise-captures-we-are-powerless.rs:7:33
    |
 LL | fn outlives<'a>(_: impl Sized + 'a) {}
@@ -196,7 +196,7 @@ LL |     T.outlives::<'a>(call_once(c));
 LL | }
    | - `c` dropped here while still borrowed
    |
-note: requirement for `'a` introduced here
+note: requirement that the value outlives `'a` introduced here
   --> $DIR/without-precise-captures-we-are-powerless.rs:49:47
    |
 LL |     fn outlives<'a>(&'a self, _: impl Sized + 'a) {}

--- a/tests/ui/async-await/async-closures/without-precise-captures-we-are-powerless.stderr
+++ b/tests/ui/async-await/async-closures/without-precise-captures-we-are-powerless.stderr
@@ -29,7 +29,7 @@ LL |     outlives::<'a>(call_once(c));
 LL | }
    | - `c` dropped here while still borrowed
    |
-note: requirement that `c` is borrowed for `'a` introduced here
+note: requirement for `'a` introduced here
   --> $DIR/without-precise-captures-we-are-powerless.rs:7:33
    |
 LL | fn outlives<'a>(_: impl Sized + 'a) {}
@@ -80,7 +80,7 @@ LL |     outlives::<'a>(call_once(c));
 LL | }
    | - `c` dropped here while still borrowed
    |
-note: requirement that `c` is borrowed for `'a` introduced here
+note: requirement for `'a` introduced here
   --> $DIR/without-precise-captures-we-are-powerless.rs:7:33
    |
 LL | fn outlives<'a>(_: impl Sized + 'a) {}
@@ -101,6 +101,12 @@ LL |     outlives::<'a>(c());
    |     argument requires that `c` is borrowed for `'a`
 LL |     outlives::<'a>(call_once(c));
    |                              ^ move out of `c` occurs here
+   |
+note: requirement for `'a` introduced here
+  --> $DIR/without-precise-captures-we-are-powerless.rs:7:33
+   |
+LL | fn outlives<'a>(_: impl Sized + 'a) {}
+   |                                 ^^
 
 error[E0597]: `x` does not live long enough
   --> $DIR/without-precise-captures-we-are-powerless.rs:36:13
@@ -142,7 +148,7 @@ LL |     outlives::<'a>(call_once(c));
 LL | }
    | - `c` dropped here while still borrowed
    |
-note: requirement that `c` is borrowed for `'a` introduced here
+note: requirement for `'a` introduced here
   --> $DIR/without-precise-captures-we-are-powerless.rs:7:33
    |
 LL | fn outlives<'a>(_: impl Sized + 'a) {}
@@ -190,7 +196,7 @@ LL |     T.outlives::<'a>(call_once(c));
 LL | }
    | - `c` dropped here while still borrowed
    |
-note: requirement that `c` is borrowed for `'a` introduced here
+note: requirement for `'a` introduced here
   --> $DIR/without-precise-captures-we-are-powerless.rs:49:47
    |
 LL |     fn outlives<'a>(&'a self, _: impl Sized + 'a) {}

--- a/tests/ui/borrowck/fn-item-check-type-params.stderr
+++ b/tests/ui/borrowck/fn-item-check-type-params.stderr
@@ -28,7 +28,7 @@ LL |     want(&String::new(), extend_lt);
    |     |     creates a temporary value which is freed while still in use
    |     argument requires that borrow lasts for `'static`
    |
-note: requirement for `'static` introduced here
+note: requirement that the value outlives `'static` introduced here
   --> $DIR/fn-item-check-type-params.rs:47:33
    |
 LL |     fn want<I, O>(_: I, _: impl Fn(I) -> O) {}
@@ -43,7 +43,7 @@ LL |     let val = extend_lt(&String::from("blah blah blah"));
    |               |          creates a temporary value which is freed while still in use
    |               argument requires that borrow lasts for `'static`
    |
-note: requirement for `'static` introduced here
+note: requirement that the value outlives `'static` introduced here
   --> $DIR/fn-item-check-type-params.rs:22:21
    |
 LL |     (T, Option<U>): Displayable,

--- a/tests/ui/borrowck/fn-item-check-type-params.stderr
+++ b/tests/ui/borrowck/fn-item-check-type-params.stderr
@@ -27,6 +27,12 @@ LL |     want(&String::new(), extend_lt);
    |     |     |
    |     |     creates a temporary value which is freed while still in use
    |     argument requires that borrow lasts for `'static`
+   |
+note: requirement for `'static` introduced here
+  --> $DIR/fn-item-check-type-params.rs:47:33
+   |
+LL |     fn want<I, O>(_: I, _: impl Fn(I) -> O) {}
+   |                                 ^^^^^^^^^^
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/fn-item-check-type-params.rs:54:26
@@ -36,6 +42,12 @@ LL |     let val = extend_lt(&String::from("blah blah blah"));
    |               |          |
    |               |          creates a temporary value which is freed while still in use
    |               argument requires that borrow lasts for `'static`
+   |
+note: requirement for `'static` introduced here
+  --> $DIR/fn-item-check-type-params.rs:22:21
+   |
+LL |     (T, Option<U>): Displayable,
+   |                     ^^^^^^^^^^^
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/borrowck/implementation-not-general-enough-ice-133252.stderr
+++ b/tests/ui/borrowck/implementation-not-general-enough-ice-133252.stderr
@@ -23,7 +23,7 @@ LL |         force_send(async_load(&not_static));
 LL |     }
    |     - `not_static` dropped here while still borrowed
    |
-note: requirement that `not_static` is borrowed for `'1` introduced here
+note: requirement for `'1` introduced here
   --> $DIR/implementation-not-general-enough-ice-133252.rs:16:18
    |
 LL | fn force_send<T: Send>(_: T) {}

--- a/tests/ui/borrowck/implementation-not-general-enough-ice-133252.stderr
+++ b/tests/ui/borrowck/implementation-not-general-enough-ice-133252.stderr
@@ -22,6 +22,12 @@ LL |         force_send(async_load(&not_static));
 ...
 LL |     }
    |     - `not_static` dropped here while still borrowed
+   |
+note: requirement that `not_static` is borrowed for `'1` introduced here
+  --> $DIR/implementation-not-general-enough-ice-133252.rs:16:18
+   |
+LL | fn force_send<T: Send>(_: T) {}
+   |                  ^^^^
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/borrowck/implementation-not-general-enough-ice-133252.stderr
+++ b/tests/ui/borrowck/implementation-not-general-enough-ice-133252.stderr
@@ -23,7 +23,7 @@ LL |         force_send(async_load(&not_static));
 LL |     }
    |     - `not_static` dropped here while still borrowed
    |
-note: requirement for `'1` introduced here
+note: requirement that the value outlives `'1` introduced here
   --> $DIR/implementation-not-general-enough-ice-133252.rs:16:18
    |
 LL | fn force_send<T: Send>(_: T) {}

--- a/tests/ui/borrowck/issue-17545.stderr
+++ b/tests/ui/borrowck/issue-17545.stderr
@@ -10,6 +10,9 @@ LL | |     ));
    | |      -- temporary value is freed at the end of this statement
    | |______|
    |        argument requires that borrow lasts for `'a`
+   |
+note: requirement for `'a` introduced here
+  --> $SRC_DIR/core/src/ops/function.rs:LL:COL
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/borrowck/issue-17545.stderr
+++ b/tests/ui/borrowck/issue-17545.stderr
@@ -11,7 +11,7 @@ LL | |     ));
    | |______|
    |        argument requires that borrow lasts for `'a`
    |
-note: requirement for `'a` introduced here
+note: requirement that the value outlives `'a` introduced here
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
 
 error: aborting due to 1 previous error

--- a/tests/ui/generic-associated-types/bugs/hrtb-implied-1.stderr
+++ b/tests/ui/generic-associated-types/bugs/hrtb-implied-1.stderr
@@ -14,7 +14,7 @@ note: due to a current limitation of the type system, this implies a `'static` l
    |
 LL |     for<'a> I::Item<'a>: Debug,
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: requirement for `'static` introduced here
+note: requirement that the value outlives `'static` introduced here
   --> $DIR/hrtb-implied-1.rs:26:26
    |
 LL |     for<'a> I::Item<'a>: Debug,

--- a/tests/ui/generic-associated-types/bugs/hrtb-implied-1.stderr
+++ b/tests/ui/generic-associated-types/bugs/hrtb-implied-1.stderr
@@ -14,6 +14,11 @@ note: due to a current limitation of the type system, this implies a `'static` l
    |
 LL |     for<'a> I::Item<'a>: Debug,
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: requirement for `'static` introduced here
+  --> $DIR/hrtb-implied-1.rs:26:26
+   |
+LL |     for<'a> I::Item<'a>: Debug,
+   |                          ^^^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/impl-trait/precise-capturing/migration-note.rs
+++ b/tests/ui/impl-trait/precise-capturing/migration-note.rs
@@ -32,6 +32,7 @@ fn needs_static() {
     //~| NOTE borrowed value does not live long enoug
 
     fn needs_static(_: impl Sized + 'static) {}
+    //~^ NOTE requirement that `x` is borrowed for `'static` introduced here
     needs_static(a);
     //~^ NOTE argument requires that `x` is borrowed for `'static`
 }
@@ -79,6 +80,7 @@ fn needs_static_mut() {
     //~| NOTE borrowed value does not live long enough
 
     fn needs_static(_: impl Sized + 'static) {}
+    //~^ NOTE requirement that `x` is borrowed for `'static` introduced here
     needs_static(a);
     //~^ NOTE argument requires that `x` is borrowed for `'static`
 }

--- a/tests/ui/impl-trait/precise-capturing/migration-note.rs
+++ b/tests/ui/impl-trait/precise-capturing/migration-note.rs
@@ -32,7 +32,7 @@ fn needs_static() {
     //~| NOTE borrowed value does not live long enoug
 
     fn needs_static(_: impl Sized + 'static) {}
-    //~^ NOTE requirement that `x` is borrowed for `'static` introduced here
+    //~^ NOTE requirement for `'static` introduced here
     needs_static(a);
     //~^ NOTE argument requires that `x` is borrowed for `'static`
 }
@@ -80,7 +80,7 @@ fn needs_static_mut() {
     //~| NOTE borrowed value does not live long enough
 
     fn needs_static(_: impl Sized + 'static) {}
-    //~^ NOTE requirement that `x` is borrowed for `'static` introduced here
+    //~^ NOTE requirement for `'static` introduced here
     needs_static(a);
     //~^ NOTE argument requires that `x` is borrowed for `'static`
 }

--- a/tests/ui/impl-trait/precise-capturing/migration-note.rs
+++ b/tests/ui/impl-trait/precise-capturing/migration-note.rs
@@ -32,7 +32,7 @@ fn needs_static() {
     //~| NOTE borrowed value does not live long enoug
 
     fn needs_static(_: impl Sized + 'static) {}
-    //~^ NOTE requirement for `'static` introduced here
+    //~^ NOTE requirement that the value outlives `'static` introduced here
     needs_static(a);
     //~^ NOTE argument requires that `x` is borrowed for `'static`
 }
@@ -80,7 +80,7 @@ fn needs_static_mut() {
     //~| NOTE borrowed value does not live long enough
 
     fn needs_static(_: impl Sized + 'static) {}
-    //~^ NOTE requirement for `'static` introduced here
+    //~^ NOTE requirement that the value outlives `'static` introduced here
     needs_static(a);
     //~^ NOTE argument requires that `x` is borrowed for `'static`
 }

--- a/tests/ui/impl-trait/precise-capturing/migration-note.stderr
+++ b/tests/ui/impl-trait/precise-capturing/migration-note.stderr
@@ -50,7 +50,7 @@ LL |
 LL | }
    | - `x` dropped here while still borrowed
    |
-note: requirement for `'static` introduced here
+note: requirement that the value outlives `'static` introduced here
   --> $DIR/migration-note.rs:34:37
    |
 LL |     fn needs_static(_: impl Sized + 'static) {}
@@ -131,7 +131,7 @@ LL |
 LL | }
    | - `x` dropped here while still borrowed
    |
-note: requirement for `'static` introduced here
+note: requirement that the value outlives `'static` introduced here
   --> $DIR/migration-note.rs:82:37
    |
 LL |     fn needs_static(_: impl Sized + 'static) {}

--- a/tests/ui/impl-trait/precise-capturing/migration-note.stderr
+++ b/tests/ui/impl-trait/precise-capturing/migration-note.stderr
@@ -1,5 +1,5 @@
 error[E0597]: `x` does not live long enough
-  --> $DIR/migration-note.rs:182:17
+  --> $DIR/migration-note.rs:184:17
    |
 LL |     let x = vec![0];
    |         - binding `x` declared here
@@ -50,6 +50,11 @@ LL |
 LL | }
    | - `x` dropped here while still borrowed
    |
+note: requirement that `x` is borrowed for `'static` introduced here
+  --> $DIR/migration-note.rs:34:37
+   |
+LL |     fn needs_static(_: impl Sized + 'static) {}
+   |                                     ^^^^^^^
 note: this call may capture more lifetimes than intended, because Rust 2024 has adjusted the `impl Trait` lifetime capture rules
   --> $DIR/migration-note.rs:29:13
    |
@@ -61,7 +66,7 @@ LL | fn display_len<T>(x: &Vec<T>) -> impl Display + use<T> {
    |                                               ++++++++
 
 error[E0505]: cannot move out of `x` because it is borrowed
-  --> $DIR/migration-note.rs:48:8
+  --> $DIR/migration-note.rs:49:8
    |
 LL |     let x = vec![1];
    |         - binding `x` declared here
@@ -76,7 +81,7 @@ LL | }
    | - borrow might be used here, when `a` is dropped and runs the destructor for type `impl std::fmt::Display`
    |
 note: this call may capture more lifetimes than intended, because Rust 2024 has adjusted the `impl Trait` lifetime capture rules
-  --> $DIR/migration-note.rs:43:13
+  --> $DIR/migration-note.rs:44:13
    |
 LL |     let a = display_len(&x);
    |             ^^^^^^^^^^^^^^^
@@ -90,7 +95,7 @@ LL |     let a = display_len(&x.clone());
    |                           ++++++++
 
 error[E0499]: cannot borrow `x` as mutable more than once at a time
-  --> $DIR/migration-note.rs:66:5
+  --> $DIR/migration-note.rs:67:5
    |
 LL |     let a = display_len_mut(&mut x);
    |                             ------ first mutable borrow occurs here
@@ -102,7 +107,7 @@ LL |     println!("{a}");
    |                - first borrow later used here
    |
 note: this call may capture more lifetimes than intended, because Rust 2024 has adjusted the `impl Trait` lifetime capture rules
-  --> $DIR/migration-note.rs:63:13
+  --> $DIR/migration-note.rs:64:13
    |
 LL |     let a = display_len_mut(&mut x);
    |             ^^^^^^^^^^^^^^^^^^^^^^^
@@ -112,7 +117,7 @@ LL | fn display_len_mut<T>(x: &mut Vec<T>) -> impl Display + use<T> {
    |                                                       ++++++++
 
 error[E0597]: `x` does not live long enough
-  --> $DIR/migration-note.rs:76:29
+  --> $DIR/migration-note.rs:77:29
    |
 LL |     let mut x = vec![1];
    |         ----- binding `x` declared here
@@ -126,8 +131,13 @@ LL |
 LL | }
    | - `x` dropped here while still borrowed
    |
+note: requirement that `x` is borrowed for `'static` introduced here
+  --> $DIR/migration-note.rs:82:37
+   |
+LL |     fn needs_static(_: impl Sized + 'static) {}
+   |                                     ^^^^^^^
 note: this call may capture more lifetimes than intended, because Rust 2024 has adjusted the `impl Trait` lifetime capture rules
-  --> $DIR/migration-note.rs:76:13
+  --> $DIR/migration-note.rs:77:13
    |
 LL |     let a = display_len_mut(&mut x);
    |             ^^^^^^^^^^^^^^^^^^^^^^^
@@ -137,7 +147,7 @@ LL | fn display_len_mut<T>(x: &mut Vec<T>) -> impl Display + use<T> {
    |                                                       ++++++++
 
 error[E0505]: cannot move out of `x` because it is borrowed
-  --> $DIR/migration-note.rs:95:8
+  --> $DIR/migration-note.rs:97:8
    |
 LL |     let mut x = vec![1];
    |         ----- binding `x` declared here
@@ -152,7 +162,7 @@ LL | }
    | - borrow might be used here, when `a` is dropped and runs the destructor for type `impl std::fmt::Display`
    |
 note: this call may capture more lifetimes than intended, because Rust 2024 has adjusted the `impl Trait` lifetime capture rules
-  --> $DIR/migration-note.rs:90:13
+  --> $DIR/migration-note.rs:92:13
    |
 LL |     let a = display_len_mut(&mut x);
    |             ^^^^^^^^^^^^^^^^^^^^^^^
@@ -166,7 +176,7 @@ LL |     let a = display_len_mut(&mut x.clone());
    |                                   ++++++++
 
 error[E0506]: cannot assign to `s.f` because it is borrowed
-  --> $DIR/migration-note.rs:115:5
+  --> $DIR/migration-note.rs:117:5
    |
 LL |     let a = display_field(&s.f);
    |                           ---- `s.f` is borrowed here
@@ -178,7 +188,7 @@ LL |     println!("{a}");
    |                - borrow later used here
    |
 note: this call may capture more lifetimes than intended, because Rust 2024 has adjusted the `impl Trait` lifetime capture rules
-  --> $DIR/migration-note.rs:112:13
+  --> $DIR/migration-note.rs:114:13
    |
 LL |     let a = display_field(&s.f);
    |             ^^^^^^^^^^^^^^^^^^^
@@ -188,7 +198,7 @@ LL | fn display_field<T: Copy + Display>(t: &T) -> impl Display + use<T> {
    |                                                            ++++++++
 
 error[E0506]: cannot assign to `s.f` because it is borrowed
-  --> $DIR/migration-note.rs:131:5
+  --> $DIR/migration-note.rs:133:5
    |
 LL |     let a = display_field(&mut s.f);
    |                           -------- `s.f` is borrowed here
@@ -200,7 +210,7 @@ LL |     println!("{a}");
    |                - borrow later used here
    |
 note: this call may capture more lifetimes than intended, because Rust 2024 has adjusted the `impl Trait` lifetime capture rules
-  --> $DIR/migration-note.rs:128:13
+  --> $DIR/migration-note.rs:130:13
    |
 LL |     let a = display_field(&mut s.f);
    |             ^^^^^^^^^^^^^^^^^^^^^^^
@@ -210,7 +220,7 @@ LL | fn display_field<T: Copy + Display>(t: &T) -> impl Display + use<T> {
    |                                                            ++++++++
 
 error[E0503]: cannot use `s.f` because it was mutably borrowed
-  --> $DIR/migration-note.rs:143:5
+  --> $DIR/migration-note.rs:145:5
    |
 LL |     let a = display_field(&mut s.f);
    |                           -------- `s.f` is borrowed here
@@ -222,7 +232,7 @@ LL |     println!("{a}");
    |                - borrow later used here
    |
 note: this call may capture more lifetimes than intended, because Rust 2024 has adjusted the `impl Trait` lifetime capture rules
-  --> $DIR/migration-note.rs:140:13
+  --> $DIR/migration-note.rs:142:13
    |
 LL |     let a = display_field(&mut s.f);
    |             ^^^^^^^^^^^^^^^^^^^^^^^
@@ -232,7 +242,7 @@ LL | fn display_field<T: Copy + Display>(t: &T) -> impl Display + use<T> {
    |                                                            ++++++++
 
 error[E0597]: `z.f` does not live long enough
-  --> $DIR/migration-note.rs:159:25
+  --> $DIR/migration-note.rs:161:25
    |
 LL |         let z = Z { f: vec![1] };
    |             - binding `z` declared here
@@ -248,7 +258,7 @@ LL | }
    |
    = note: values in a scope are dropped in the opposite order they are defined
 note: this call may capture more lifetimes than intended, because Rust 2024 has adjusted the `impl Trait` lifetime capture rules
-  --> $DIR/migration-note.rs:159:13
+  --> $DIR/migration-note.rs:161:13
    |
 LL |         x = display_len(&z.f);
    |             ^^^^^^^^^^^^^^^^^
@@ -258,7 +268,7 @@ LL | fn display_len<T>(x: &Vec<T>) -> impl Display + use<T> {
    |                                               ++++++++
 
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/migration-note.rs:170:40
+  --> $DIR/migration-note.rs:172:40
    |
 LL |     let x = { let x = display_len(&mut vec![0]); x };
    |                                        ^^^^^^^ - - borrow later used here
@@ -268,7 +278,7 @@ LL |     let x = { let x = display_len(&mut vec![0]); x };
    |
    = note: consider using a `let` binding to create a longer lived value
 note: this call may capture more lifetimes than intended, because Rust 2024 has adjusted the `impl Trait` lifetime capture rules
-  --> $DIR/migration-note.rs:170:23
+  --> $DIR/migration-note.rs:172:23
    |
 LL |     let x = { let x = display_len(&mut vec![0]); x };
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -279,7 +289,7 @@ LL | fn display_len<T>(x: &Vec<T>) -> impl Display + use<T> {
    |                                               ++++++++
 
 error[E0505]: cannot move out of `x` because it is borrowed
-  --> $DIR/migration-note.rs:198:10
+  --> $DIR/migration-note.rs:200:10
    |
 LL |     let x = String::new();
    |         - binding `x` declared here
@@ -294,12 +304,12 @@ LL | }
    | - borrow might be used here, when `y` is dropped and runs the destructor for type `impl Sized`
    |
 note: this call may capture more lifetimes than intended, because Rust 2024 has adjusted the `impl Trait` lifetime capture rules
-  --> $DIR/migration-note.rs:195:13
+  --> $DIR/migration-note.rs:197:13
    |
 LL |     let y = capture_apit(&x);
    |             ^^^^^^^^^^^^^^^^
 note: you could use a `use<...>` bound to explicitly specify captures, but argument-position `impl Trait`s are not nameable
-  --> $DIR/migration-note.rs:189:21
+  --> $DIR/migration-note.rs:191:21
    |
 LL | fn capture_apit(x: &impl Sized) -> impl Sized {}
    |                     ^^^^^^^^^^

--- a/tests/ui/impl-trait/precise-capturing/migration-note.stderr
+++ b/tests/ui/impl-trait/precise-capturing/migration-note.stderr
@@ -50,7 +50,7 @@ LL |
 LL | }
    | - `x` dropped here while still borrowed
    |
-note: requirement that `x` is borrowed for `'static` introduced here
+note: requirement for `'static` introduced here
   --> $DIR/migration-note.rs:34:37
    |
 LL |     fn needs_static(_: impl Sized + 'static) {}
@@ -131,7 +131,7 @@ LL |
 LL | }
    | - `x` dropped here while still borrowed
    |
-note: requirement that `x` is borrowed for `'static` introduced here
+note: requirement for `'static` introduced here
   --> $DIR/migration-note.rs:82:37
    |
 LL |     fn needs_static(_: impl Sized + 'static) {}

--- a/tests/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-comparing-against-free.stderr
+++ b/tests/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-comparing-against-free.stderr
@@ -69,6 +69,12 @@ LL |         cell_x.set(cell_a.get()); // forces 'a: 'x, implies 'a = 'static ->
 LL |     })
 LL | }
    | - `a` dropped here while still borrowed
+   |
+note: requirement that `a` is borrowed for `'static` introduced here
+  --> $DIR/propagate-approximated-shorter-to-static-comparing-against-free.rs:13:8
+   |
+LL |     F: for<'x> FnOnce(Cell<&'a u32>, Cell<&'x u32>),
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-comparing-against-free.stderr
+++ b/tests/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-comparing-against-free.stderr
@@ -70,7 +70,7 @@ LL |     })
 LL | }
    | - `a` dropped here while still borrowed
    |
-note: requirement for `'static` introduced here
+note: requirement that the value outlives `'static` introduced here
   --> $DIR/propagate-approximated-shorter-to-static-comparing-against-free.rs:13:8
    |
 LL |     F: for<'x> FnOnce(Cell<&'a u32>, Cell<&'x u32>),

--- a/tests/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-comparing-against-free.stderr
+++ b/tests/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-comparing-against-free.stderr
@@ -70,7 +70,7 @@ LL |     })
 LL | }
    | - `a` dropped here while still borrowed
    |
-note: requirement that `a` is borrowed for `'static` introduced here
+note: requirement for `'static` introduced here
   --> $DIR/propagate-approximated-shorter-to-static-comparing-against-free.rs:13:8
    |
 LL |     F: for<'x> FnOnce(Cell<&'a u32>, Cell<&'x u32>),

--- a/tests/ui/nll/closure-requirements/propagate-multiple-requirements.stderr
+++ b/tests/ui/nll/closure-requirements/propagate-multiple-requirements.stderr
@@ -14,7 +14,7 @@ LL |         z = &local_arr;
 LL | }
    | - `local_arr` dropped here while still borrowed
    |
-note: requirement for `'static` introduced here
+note: requirement that the value outlives `'static` introduced here
   --> $DIR/propagate-multiple-requirements.rs:4:21
    |
 LL | fn once<S, T, U, F: FnOnce(S, T) -> U>(f: F, s: S, t: T) -> U {

--- a/tests/ui/nll/closure-requirements/propagate-multiple-requirements.stderr
+++ b/tests/ui/nll/closure-requirements/propagate-multiple-requirements.stderr
@@ -13,6 +13,12 @@ LL |         z = &local_arr;
 ...
 LL | }
    | - `local_arr` dropped here while still borrowed
+   |
+note: requirement that `local_arr` is borrowed for `'static` introduced here
+  --> $DIR/propagate-multiple-requirements.rs:4:21
+   |
+LL | fn once<S, T, U, F: FnOnce(S, T) -> U>(f: F, s: S, t: T) -> U {
+   |                     ^^^^^^^^^^^^^^^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/nll/closure-requirements/propagate-multiple-requirements.stderr
+++ b/tests/ui/nll/closure-requirements/propagate-multiple-requirements.stderr
@@ -14,7 +14,7 @@ LL |         z = &local_arr;
 LL | }
    | - `local_arr` dropped here while still borrowed
    |
-note: requirement that `local_arr` is borrowed for `'static` introduced here
+note: requirement for `'static` introduced here
   --> $DIR/propagate-multiple-requirements.rs:4:21
    |
 LL | fn once<S, T, U, F: FnOnce(S, T) -> U>(f: F, s: S, t: T) -> U {

--- a/tests/ui/nll/local-outlives-static-via-hrtb.stderr
+++ b/tests/ui/nll/local-outlives-static-via-hrtb.stderr
@@ -12,16 +12,16 @@ LL |     assert_static_via_hrtb_with_assoc_type(&&local);
 LL | }
    | - `local` dropped here while still borrowed
    |
-note: requirement that `local` is borrowed for `'static` introduced here
-  --> $DIR/local-outlives-static-via-hrtb.rs:15:53
-   |
-LL | fn assert_static_via_hrtb<G>(_: G) where for<'a> G: Outlives<'a> {}
-   |                                                     ^^^^^^^^^^^^
 note: due to a current limitation of the type system, this implies a `'static` lifetime
   --> $DIR/local-outlives-static-via-hrtb.rs:15:42
    |
 LL | fn assert_static_via_hrtb<G>(_: G) where for<'a> G: Outlives<'a> {}
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^
+note: requirement for `'static` introduced here
+  --> $DIR/local-outlives-static-via-hrtb.rs:15:53
+   |
+LL | fn assert_static_via_hrtb<G>(_: G) where for<'a> G: Outlives<'a> {}
+   |                                                     ^^^^^^^^^^^^
 
 error[E0597]: `local` does not live long enough
   --> $DIR/local-outlives-static-via-hrtb.rs:25:45
@@ -37,16 +37,16 @@ LL |     assert_static_via_hrtb_with_assoc_type(&&local);
 LL | }
    | - `local` dropped here while still borrowed
    |
-note: requirement that `local` is borrowed for `'static` introduced here
-  --> $DIR/local-outlives-static-via-hrtb.rs:19:30
-   |
-LL |     for<'a> &'a T: Reference<AssociatedType = &'a ()>,
-   |                              ^^^^^^^^^^^^^^^^^^^^^^^
 note: due to a current limitation of the type system, this implies a `'static` lifetime
   --> $DIR/local-outlives-static-via-hrtb.rs:19:5
    |
 LL |     for<'a> &'a T: Reference<AssociatedType = &'a ()>,
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: requirement for `'static` introduced here
+  --> $DIR/local-outlives-static-via-hrtb.rs:19:30
+   |
+LL |     for<'a> &'a T: Reference<AssociatedType = &'a ()>,
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/nll/local-outlives-static-via-hrtb.stderr
+++ b/tests/ui/nll/local-outlives-static-via-hrtb.stderr
@@ -17,7 +17,7 @@ note: due to a current limitation of the type system, this implies a `'static` l
    |
 LL | fn assert_static_via_hrtb<G>(_: G) where for<'a> G: Outlives<'a> {}
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^
-note: requirement for `'static` introduced here
+note: requirement that the value outlives `'static` introduced here
   --> $DIR/local-outlives-static-via-hrtb.rs:15:53
    |
 LL | fn assert_static_via_hrtb<G>(_: G) where for<'a> G: Outlives<'a> {}
@@ -42,7 +42,7 @@ note: due to a current limitation of the type system, this implies a `'static` l
    |
 LL |     for<'a> &'a T: Reference<AssociatedType = &'a ()>,
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: requirement for `'static` introduced here
+note: requirement that the value outlives `'static` introduced here
   --> $DIR/local-outlives-static-via-hrtb.rs:19:30
    |
 LL |     for<'a> &'a T: Reference<AssociatedType = &'a ()>,

--- a/tests/ui/nll/local-outlives-static-via-hrtb.stderr
+++ b/tests/ui/nll/local-outlives-static-via-hrtb.stderr
@@ -12,6 +12,11 @@ LL |     assert_static_via_hrtb_with_assoc_type(&&local);
 LL | }
    | - `local` dropped here while still borrowed
    |
+note: requirement that `local` is borrowed for `'static` introduced here
+  --> $DIR/local-outlives-static-via-hrtb.rs:15:53
+   |
+LL | fn assert_static_via_hrtb<G>(_: G) where for<'a> G: Outlives<'a> {}
+   |                                                     ^^^^^^^^^^^^
 note: due to a current limitation of the type system, this implies a `'static` lifetime
   --> $DIR/local-outlives-static-via-hrtb.rs:15:42
    |
@@ -32,6 +37,11 @@ LL |     assert_static_via_hrtb_with_assoc_type(&&local);
 LL | }
    | - `local` dropped here while still borrowed
    |
+note: requirement that `local` is borrowed for `'static` introduced here
+  --> $DIR/local-outlives-static-via-hrtb.rs:19:30
+   |
+LL |     for<'a> &'a T: Reference<AssociatedType = &'a ()>,
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^
 note: due to a current limitation of the type system, this implies a `'static` lifetime
   --> $DIR/local-outlives-static-via-hrtb.rs:19:5
    |

--- a/tests/ui/nll/polonius/location-insensitive-scopes-issue-117146.nll.stderr
+++ b/tests/ui/nll/polonius/location-insensitive-scopes-issue-117146.nll.stderr
@@ -13,6 +13,11 @@ LL |     let b = |_| &a;
 LL | }
    | - `a` dropped here while still borrowed
    |
+note: requirement that `a` is borrowed for `'static` introduced here
+  --> $DIR/location-insensitive-scopes-issue-117146.rs:20:22
+   |
+LL | fn bad<F: Fn(&()) -> &()>(_: F) {}
+   |                      ^^^
 note: due to a current limitation of the type system, this implies a `'static` lifetime
   --> $DIR/location-insensitive-scopes-issue-117146.rs:20:11
    |

--- a/tests/ui/nll/polonius/location-insensitive-scopes-issue-117146.nll.stderr
+++ b/tests/ui/nll/polonius/location-insensitive-scopes-issue-117146.nll.stderr
@@ -18,7 +18,7 @@ note: due to a current limitation of the type system, this implies a `'static` l
    |
 LL | fn bad<F: Fn(&()) -> &()>(_: F) {}
    |           ^^^^^^^^^^^^^^
-note: requirement for `'static` introduced here
+note: requirement that the value outlives `'static` introduced here
   --> $DIR/location-insensitive-scopes-issue-117146.rs:20:22
    |
 LL | fn bad<F: Fn(&()) -> &()>(_: F) {}

--- a/tests/ui/nll/polonius/location-insensitive-scopes-issue-117146.nll.stderr
+++ b/tests/ui/nll/polonius/location-insensitive-scopes-issue-117146.nll.stderr
@@ -13,16 +13,16 @@ LL |     let b = |_| &a;
 LL | }
    | - `a` dropped here while still borrowed
    |
-note: requirement that `a` is borrowed for `'static` introduced here
-  --> $DIR/location-insensitive-scopes-issue-117146.rs:20:22
-   |
-LL | fn bad<F: Fn(&()) -> &()>(_: F) {}
-   |                      ^^^
 note: due to a current limitation of the type system, this implies a `'static` lifetime
   --> $DIR/location-insensitive-scopes-issue-117146.rs:20:11
    |
 LL | fn bad<F: Fn(&()) -> &()>(_: F) {}
    |           ^^^^^^^^^^^^^^
+note: requirement for `'static` introduced here
+  --> $DIR/location-insensitive-scopes-issue-117146.rs:20:22
+   |
+LL | fn bad<F: Fn(&()) -> &()>(_: F) {}
+   |                      ^^^
 
 error: implementation of `Fn` is not general enough
   --> $DIR/location-insensitive-scopes-issue-117146.rs:13:5

--- a/tests/ui/nll/polonius/location-insensitive-scopes-issue-117146.polonius.stderr
+++ b/tests/ui/nll/polonius/location-insensitive-scopes-issue-117146.polonius.stderr
@@ -13,6 +13,11 @@ LL |     let b = |_| &a;
 LL | }
    | - `a` dropped here while still borrowed
    |
+note: requirement that `a` is borrowed for `'static` introduced here
+  --> $DIR/location-insensitive-scopes-issue-117146.rs:20:22
+   |
+LL | fn bad<F: Fn(&()) -> &()>(_: F) {}
+   |                      ^^^
 note: due to a current limitation of the type system, this implies a `'static` lifetime
   --> $DIR/location-insensitive-scopes-issue-117146.rs:20:11
    |

--- a/tests/ui/nll/polonius/location-insensitive-scopes-issue-117146.polonius.stderr
+++ b/tests/ui/nll/polonius/location-insensitive-scopes-issue-117146.polonius.stderr
@@ -18,7 +18,7 @@ note: due to a current limitation of the type system, this implies a `'static` l
    |
 LL | fn bad<F: Fn(&()) -> &()>(_: F) {}
    |           ^^^^^^^^^^^^^^
-note: requirement for `'static` introduced here
+note: requirement that the value outlives `'static` introduced here
   --> $DIR/location-insensitive-scopes-issue-117146.rs:20:22
    |
 LL | fn bad<F: Fn(&()) -> &()>(_: F) {}

--- a/tests/ui/nll/polonius/location-insensitive-scopes-issue-117146.polonius.stderr
+++ b/tests/ui/nll/polonius/location-insensitive-scopes-issue-117146.polonius.stderr
@@ -13,16 +13,16 @@ LL |     let b = |_| &a;
 LL | }
    | - `a` dropped here while still borrowed
    |
-note: requirement that `a` is borrowed for `'static` introduced here
-  --> $DIR/location-insensitive-scopes-issue-117146.rs:20:22
-   |
-LL | fn bad<F: Fn(&()) -> &()>(_: F) {}
-   |                      ^^^
 note: due to a current limitation of the type system, this implies a `'static` lifetime
   --> $DIR/location-insensitive-scopes-issue-117146.rs:20:11
    |
 LL | fn bad<F: Fn(&()) -> &()>(_: F) {}
    |           ^^^^^^^^^^^^^^
+note: requirement for `'static` introduced here
+  --> $DIR/location-insensitive-scopes-issue-117146.rs:20:22
+   |
+LL | fn bad<F: Fn(&()) -> &()>(_: F) {}
+   |                      ^^^
 
 error: implementation of `Fn` is not general enough
   --> $DIR/location-insensitive-scopes-issue-117146.rs:13:5

--- a/tests/ui/regions/multiple-sources-for-outlives-requirement.rs
+++ b/tests/ui/regions/multiple-sources-for-outlives-requirement.rs
@@ -1,0 +1,11 @@
+fn outlives_indir<'a: 'b, 'b, T: 'a>(_x: T) {}
+//~^ NOTE: requirements that the value outlives `'b` introduced here
+
+fn foo<'b>() { //~ NOTE: lifetime `'b` defined here
+    outlives_indir::<'_, 'b, _>(&mut 1u32); //~ ERROR: temporary value dropped while borrowed
+    //~^ NOTE: argument requires that borrow lasts for `'b`
+    //~| NOTE: creates a temporary value which is freed while still in use
+    //~| NOTE: temporary value is freed at the end of this statement
+}
+
+fn main() {}

--- a/tests/ui/regions/multiple-sources-for-outlives-requirement.stderr
+++ b/tests/ui/regions/multiple-sources-for-outlives-requirement.stderr
@@ -1,0 +1,20 @@
+error[E0716]: temporary value dropped while borrowed
+  --> $DIR/multiple-sources-for-outlives-requirement.rs:5:38
+   |
+LL | fn foo<'b>() {
+   |        -- lifetime `'b` defined here
+LL |     outlives_indir::<'_, 'b, _>(&mut 1u32);
+   |     ---------------------------------^^^^-- temporary value is freed at the end of this statement
+   |     |                                |
+   |     |                                creates a temporary value which is freed while still in use
+   |     argument requires that borrow lasts for `'b`
+   |
+note: requirements that the value outlives `'b` introduced here
+  --> $DIR/multiple-sources-for-outlives-requirement.rs:1:23
+   |
+LL | fn outlives_indir<'a: 'b, 'b, T: 'a>(_x: T) {}
+   |                       ^^         ^^
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0716`.

--- a/tests/ui/regions/regions-infer-proc-static-upvar.stderr
+++ b/tests/ui/regions/regions-infer-proc-static-upvar.stderr
@@ -11,6 +11,12 @@ LL | |     });
    | |______- argument requires that `x` is borrowed for `'static`
 LL |   }
    |   - `x` dropped here while still borrowed
+   |
+note: requirement that `x` is borrowed for `'static` introduced here
+  --> $DIR/regions-infer-proc-static-upvar.rs:4:19
+   |
+LL | fn foo<F:FnOnce()+'static>(_p: F) { }
+   |                   ^^^^^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/regions/regions-infer-proc-static-upvar.stderr
+++ b/tests/ui/regions/regions-infer-proc-static-upvar.stderr
@@ -12,7 +12,7 @@ LL | |     });
 LL |   }
    |   - `x` dropped here while still borrowed
    |
-note: requirement that `x` is borrowed for `'static` introduced here
+note: requirement for `'static` introduced here
   --> $DIR/regions-infer-proc-static-upvar.rs:4:19
    |
 LL | fn foo<F:FnOnce()+'static>(_p: F) { }

--- a/tests/ui/regions/regions-infer-proc-static-upvar.stderr
+++ b/tests/ui/regions/regions-infer-proc-static-upvar.stderr
@@ -12,7 +12,7 @@ LL | |     });
 LL |   }
    |   - `x` dropped here while still borrowed
    |
-note: requirement for `'static` introduced here
+note: requirement that the value outlives `'static` introduced here
   --> $DIR/regions-infer-proc-static-upvar.rs:4:19
    |
 LL | fn foo<F:FnOnce()+'static>(_p: F) { }

--- a/tests/ui/regions/regions-pattern-typing-issue-19552.stderr
+++ b/tests/ui/regions/regions-pattern-typing-issue-19552.stderr
@@ -11,7 +11,7 @@ LL |     }
 LL | }
    | - `line` dropped here while still borrowed
    |
-note: requirement that `line` is borrowed for `'static` introduced here
+note: requirement for `'static` introduced here
   --> $DIR/regions-pattern-typing-issue-19552.rs:1:21
    |
 LL | fn assert_static<T: 'static>(_t: T) {}

--- a/tests/ui/regions/regions-pattern-typing-issue-19552.stderr
+++ b/tests/ui/regions/regions-pattern-typing-issue-19552.stderr
@@ -10,6 +10,12 @@ LL |         [ word ] => { assert_static(word); }
 LL |     }
 LL | }
    | - `line` dropped here while still borrowed
+   |
+note: requirement that `line` is borrowed for `'static` introduced here
+  --> $DIR/regions-pattern-typing-issue-19552.rs:1:21
+   |
+LL | fn assert_static<T: 'static>(_t: T) {}
+   |                     ^^^^^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/regions/regions-pattern-typing-issue-19552.stderr
+++ b/tests/ui/regions/regions-pattern-typing-issue-19552.stderr
@@ -11,7 +11,7 @@ LL |     }
 LL | }
    | - `line` dropped here while still borrowed
    |
-note: requirement for `'static` introduced here
+note: requirement that the value outlives `'static` introduced here
   --> $DIR/regions-pattern-typing-issue-19552.rs:1:21
    |
 LL | fn assert_static<T: 'static>(_t: T) {}

--- a/tests/ui/static/static-lifetime-bound.stderr
+++ b/tests/ui/static/static-lifetime-bound.stderr
@@ -11,7 +11,7 @@ LL |     f(&x);
 LL | }
    | - `x` dropped here while still borrowed
    |
-note: requirement that `x` is borrowed for `'static` introduced here
+note: requirement for `'static` introduced here
   --> $DIR/static-lifetime-bound.rs:1:10
    |
 LL | fn f<'a: 'static>(_: &'a i32) {}

--- a/tests/ui/static/static-lifetime-bound.stderr
+++ b/tests/ui/static/static-lifetime-bound.stderr
@@ -11,7 +11,7 @@ LL |     f(&x);
 LL | }
    | - `x` dropped here while still borrowed
    |
-note: requirement for `'static` introduced here
+note: requirement that the value outlives `'static` introduced here
   --> $DIR/static-lifetime-bound.rs:1:10
    |
 LL | fn f<'a: 'static>(_: &'a i32) {}

--- a/tests/ui/static/static-lifetime-bound.stderr
+++ b/tests/ui/static/static-lifetime-bound.stderr
@@ -10,6 +10,12 @@ LL |     f(&x);
    |     argument requires that `x` is borrowed for `'static`
 LL | }
    | - `x` dropped here while still borrowed
+   |
+note: requirement that `x` is borrowed for `'static` introduced here
+  --> $DIR/static-lifetime-bound.rs:1:10
+   |
+LL | fn f<'a: 'static>(_: &'a i32) {}
+   |          ^^^^^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/static/static-region-bound.stderr
+++ b/tests/ui/static/static-region-bound.stderr
@@ -7,6 +7,12 @@ LL |     f(x);
    |     ---- argument requires that borrow lasts for `'static`
 LL | }
    | - temporary value is freed at the end of this statement
+   |
+note: requirement for `'static` introduced here
+  --> $DIR/static-region-bound.rs:3:8
+   |
+LL | fn f<T:'static>(_: T) {}
+   |        ^^^^^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/static/static-region-bound.stderr
+++ b/tests/ui/static/static-region-bound.stderr
@@ -8,7 +8,7 @@ LL |     f(x);
 LL | }
    | - temporary value is freed at the end of this statement
    |
-note: requirement for `'static` introduced here
+note: requirement that the value outlives `'static` introduced here
   --> $DIR/static-region-bound.rs:3:8
    |
 LL | fn f<T:'static>(_: T) {}

--- a/tests/ui/wf/wf-in-where-clause-static.current.stderr
+++ b/tests/ui/wf/wf-in-where-clause-static.current.stderr
@@ -7,7 +7,7 @@ LL |     let s = foo(&String::from("blah blah blah"));
    |             |    creates a temporary value which is freed while still in use
    |             argument requires that borrow lasts for `'static`
    |
-note: requirement for `'static` introduced here
+note: requirement that the value outlives `'static` introduced here
   --> $DIR/wf-in-where-clause-static.rs:12:17
    |
 LL |     &'static S: Static,

--- a/tests/ui/wf/wf-in-where-clause-static.current.stderr
+++ b/tests/ui/wf/wf-in-where-clause-static.current.stderr
@@ -6,6 +6,12 @@ LL |     let s = foo(&String::from("blah blah blah"));
    |             |    |
    |             |    creates a temporary value which is freed while still in use
    |             argument requires that borrow lasts for `'static`
+   |
+note: requirement for `'static` introduced here
+  --> $DIR/wf-in-where-clause-static.rs:12:17
+   |
+LL |     &'static S: Static,
+   |                 ^^^^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/wf/wf-in-where-clause-static.next.stderr
+++ b/tests/ui/wf/wf-in-where-clause-static.next.stderr
@@ -7,7 +7,7 @@ LL |     let s = foo(&String::from("blah blah blah"));
    |             |    creates a temporary value which is freed while still in use
    |             argument requires that borrow lasts for `'static`
    |
-note: requirement for `'static` introduced here
+note: requirement that the value outlives `'static` introduced here
   --> $DIR/wf-in-where-clause-static.rs:12:17
    |
 LL |     &'static S: Static,

--- a/tests/ui/wf/wf-in-where-clause-static.next.stderr
+++ b/tests/ui/wf/wf-in-where-clause-static.next.stderr
@@ -6,6 +6,12 @@ LL |     let s = foo(&String::from("blah blah blah"));
    |             |    |
    |             |    creates a temporary value which is freed while still in use
    |             argument requires that borrow lasts for `'static`
+   |
+note: requirement for `'static` introduced here
+  --> $DIR/wf-in-where-clause-static.rs:12:17
+   |
+LL |     &'static S: Static,
+   |                 ^^^^^^
 
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
The last note is new
```
error[E0597]: `c` does not live long enough
  --> $DIR/without-precise-captures-we-are-powerless.rs:19:20
   |
LL | fn simple<'a>(x: &'a i32) {
   |           -- lifetime `'a` defined here
...
LL |     let c = async move || { println!("{}", *x); };
   |         - binding `c` declared here
LL |     outlives::<'a>(c());
   |     ---------------^---
   |     |              |
   |     |              borrowed value does not live long enough
   |     argument requires that `c` is borrowed for `'a`
LL |     outlives::<'a>(call_once(c));
LL | }
   | - `c` dropped here while still borrowed
   |
note: requirement that `c` is borrowed for `'a` introduced here
  --> $DIR/without-precise-captures-we-are-powerless.rs:7:33
   |
LL | fn outlives<'a>(_: impl Sized + 'a) {}
   |                                 ^^
```

When encountering a `ConstraintCategory::Predicate` in a funtion call, point at the `Span` for that `Predicate` to explain where the lifetime obligation originates from.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->


CC rust-lang/rust#55307.