### PR TITLE
Mark pipe2 supported in Android

### DIFF
--- a/library/std/src/sys/pal/unix/pipe.rs
+++ b/library/std/src/sys/pal/unix/pipe.rs
@@ -20,6 +20,7 @@ pub fn anon_pipe() -> io::Result<(AnonPipe, AnonPipe)> {
     // and musl 0.9.3, and some other targets also have it.
     cfg_select! {
         any(
+            target_os = "android",
             target_os = "dragonfly",
             target_os = "freebsd",
             target_os = "hurd",


### PR DESCRIPTION
Android has supported pipe2 since 2010, long before the current min SDK.
