### PR TITLE
compiler: Include span of too huge array with `-Cdebuginfo=2`

### DIFF
--- a/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
@@ -103,16 +103,17 @@ fn build_fixed_size_array_di_node<'ll, 'tcx>(
     cx: &CodegenCx<'ll, 'tcx>,
     unique_type_id: UniqueTypeId<'tcx>,
     array_type: Ty<'tcx>,
+    span: Span,
 ) -> DINodeCreationResult<'ll> {
     let ty::Array(element_type, len) = array_type.kind() else {
         bug!("build_fixed_size_array_di_node() called with non-ty::Array type `{:?}`", array_type)
     };
 
-    let element_type_di_node = type_di_node(cx, *element_type);
+    let element_type_di_node = spanned_type_di_node(cx, *element_type, span);
 
     return_if_di_node_created_in_meantime!(cx, unique_type_id);
 
-    let (size, align) = cx.size_and_align_of(array_type);
+    let (size, align) = cx.spanned_size_and_align_of(array_type, span);
 
     let upper_bound = len
         .try_to_target_usize(cx.tcx)
@@ -447,7 +448,7 @@ pub(crate) fn spanned_type_di_node<'ll, 'tcx>(
             build_basic_type_di_node(cx, t)
         }
         ty::Tuple(elements) if elements.is_empty() => build_basic_type_di_node(cx, t),
-        ty::Array(..) => build_fixed_size_array_di_node(cx, unique_type_id, t),
+        ty::Array(..) => build_fixed_size_array_di_node(cx, unique_type_id, t, span),
         ty::Slice(_) | ty::Str => build_slice_type_di_node(cx, t, unique_type_id),
         ty::Dynamic(..) => build_dyn_type_di_node(cx, t, unique_type_id),
         ty::Foreign(..) => build_foreign_type_di_node(cx, t, unique_type_id),

--- a/compiler/rustc_codegen_llvm/src/type_of.rs
+++ b/compiler/rustc_codegen_llvm/src/type_of.rs
@@ -7,6 +7,7 @@ use rustc_middle::bug;
 use rustc_middle::ty::layout::{LayoutOf, TyAndLayout};
 use rustc_middle::ty::print::{with_no_trimmed_paths, with_no_visible_paths};
 use rustc_middle::ty::{self, CoroutineArgsExt, Ty, TypeVisitableExt};
+use rustc_span::{DUMMY_SP, Span};
 use tracing::debug;
 
 use crate::common::*;
@@ -149,7 +150,11 @@ impl<'a, 'tcx> CodegenCx<'a, 'tcx> {
     }
 
     pub(crate) fn size_and_align_of(&self, ty: Ty<'tcx>) -> (Size, Align) {
-        let layout = self.layout_of(ty);
+        self.spanned_size_and_align_of(ty, DUMMY_SP)
+    }
+
+    pub(crate) fn spanned_size_and_align_of(&self, ty: Ty<'tcx>, span: Span) -> (Size, Align) {
+        let layout = self.spanned_layout_of(ty, span);
         (layout.size, layout.align.abi)
     }
 }

--- a/tests/ui/limits/huge-array-simple-64.full-debuginfo.stderr
+++ b/tests/ui/limits/huge-array-simple-64.full-debuginfo.stderr
@@ -1,5 +1,5 @@
 error: values of the type `[u8; 2305843011361177600]` are too big for the target architecture
-  --> $DIR/huge-array-simple-64.rs:7:9
+  --> $DIR/huge-array-simple-64.rs:12:9
    |
 LL |     let _fat: [u8; (1<<61)+(1<<31)] =
    |         ^^^^

--- a/tests/ui/limits/huge-array-simple-64.no-debuginfo.stderr
+++ b/tests/ui/limits/huge-array-simple-64.no-debuginfo.stderr
@@ -1,0 +1,8 @@
+error: values of the type `[u8; 2305843011361177600]` are too big for the target architecture
+  --> $DIR/huge-array-simple-64.rs:12:9
+   |
+LL |     let _fat: [u8; (1<<61)+(1<<31)] =
+   |         ^^^^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/limits/huge-array-simple-64.rs
+++ b/tests/ui/limits/huge-array-simple-64.rs
@@ -1,3 +1,8 @@
+// FIXME(#61117): Remove revisions once x86_64-gnu-debug CI job sets rust.debuginfo-level-tests=2
+// NOTE: The .stderr for both revisions shall be identical.
+//@ revisions: no-debuginfo full-debuginfo
+//@[no-debuginfo] compile-flags: -Cdebuginfo=0
+//@[full-debuginfo] compile-flags: -Cdebuginfo=2
 //@ build-fail
 //@ ignore-32bit
 

--- a/tests/ui/limits/huge-array.full-debuginfo.stderr
+++ b/tests/ui/limits/huge-array.full-debuginfo.stderr
@@ -1,5 +1,5 @@
 error: values of the type `[[u8; 1518599999]; 1518600000]` are too big for the target architecture
-  --> $DIR/huge-array.rs:4:9
+  --> $DIR/huge-array.rs:9:9
    |
 LL |     let s: [T; 1518600000] = [t; 1518600000];
    |         ^

--- a/tests/ui/limits/huge-array.no-debuginfo.stderr
+++ b/tests/ui/limits/huge-array.no-debuginfo.stderr
@@ -1,0 +1,8 @@
+error: values of the type `[[u8; 1518599999]; 1518600000]` are too big for the target architecture
+  --> $DIR/huge-array.rs:9:9
+   |
+LL |     let s: [T; 1518600000] = [t; 1518600000];
+   |         ^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/limits/huge-array.rs
+++ b/tests/ui/limits/huge-array.rs
@@ -1,3 +1,8 @@
+// FIXME(#61117): Remove revisions once x86_64-gnu-debug CI job sets rust.debuginfo-level-tests=2
+// NOTE: The .stderr for both revisions shall be identical.
+//@ revisions: no-debuginfo full-debuginfo
+//@[no-debuginfo] compile-flags: -Cdebuginfo=0
+//@[full-debuginfo] compile-flags: -Cdebuginfo=2
 //@ build-fail
 
 fn generic<T: Copy>(t: T) {

--- a/tests/ui/limits/issue-15919-64.full-debuginfo.stderr
+++ b/tests/ui/limits/issue-15919-64.full-debuginfo.stderr
@@ -1,5 +1,5 @@
 error: values of the type `[usize; usize::MAX]` are too big for the target architecture
-  --> $DIR/issue-15919-64.rs:5:9
+  --> $DIR/issue-15919-64.rs:10:9
    |
 LL |     let x = [0usize; 0xffff_ffff_ffff_ffff];
    |         ^

--- a/tests/ui/limits/issue-15919-64.no-debuginfo.stderr
+++ b/tests/ui/limits/issue-15919-64.no-debuginfo.stderr
@@ -1,0 +1,8 @@
+error: values of the type `[usize; usize::MAX]` are too big for the target architecture
+  --> $DIR/issue-15919-64.rs:10:9
+   |
+LL |     let x = [0usize; 0xffff_ffff_ffff_ffff];
+   |         ^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/limits/issue-15919-64.rs
+++ b/tests/ui/limits/issue-15919-64.rs
@@ -1,3 +1,8 @@
+// FIXME(#61117): Remove revisions once x86_64-gnu-debug CI job sets rust.debuginfo-level-tests=2
+// NOTE: The .stderr for both revisions shall be identical.
+//@ revisions: no-debuginfo full-debuginfo
+//@[no-debuginfo] compile-flags: -Cdebuginfo=0
+//@[full-debuginfo] compile-flags: -Cdebuginfo=2
 //@ build-fail
 //@ ignore-32bit
 


### PR DESCRIPTION
We have a few ui tests to ensure we emit an error if we encounter too big arrays. Before this fix, compiling the tests with `-Cdebuginfo=2` would not include the spans of the instantiation sites, because the error is then emitted from a different code path that does not include the span.

Propagate the span to the error also in the debuginfo case, so the tests passes regardless of debuginfo level.

r? @wesleywiser since this is a natural continuation of https://github.com/rust-lang/rust/pull/145967 that you approved (thanks!).

cc https://github.com/rust-lang/rust/issues/61117 since this takes is one step closer to increasing `rust.debuginfo-level-tests` to `2` in the **x86_64-gnu-debug** CI job.

## Test failure output without the fix

<details>
<summary>
Here is what the test failures look like if you run the tests without the fix. (Click to expand.)
</summary>

```
$ ./x test --set rust.debuginfo-level-tests=2 tests/ui/limits/huge-array-simple-64.rs tests/ui/limits/huge-array.rs tests/ui/limits/issue-15919-64.rs
Building bootstrap
    Finished `dev` profile [unoptimized] target(s) in 0.16s
/home/martin/src/rust/build/x86_64-unknown-linux-gnu/ci-llvm/bin/llvm-strip does not exist; skipping copy
Building stage1 compiler artifacts (stage0 -> stage1, x86_64-unknown-linux-gnu)
    Finished `release` profile [optimized + debuginfo] target(s) in 0.40s
Creating a sysroot for stage1 compiler (use `rustup toolchain link 'name' build/host/stage1`)
Building stage1 lld-wrapper (stage0 -> stage1, x86_64-unknown-linux-gnu)
    Finished `release` profile [optimized + debuginfo] target(s) in 0.08s
Building stage1 library artifacts (stage1 -> stage1, x86_64-unknown-linux-gnu)
   Compiling addr2line v0.25.0
   Compiling std v0.0.0 (/home/martin/src/rust/library/std)
   Compiling rustc-std-workspace-std v1.99.0 (/home/martin/src/rust/library/rustc-std-workspace-std)
   Compiling unicode-width v0.2.1
   Compiling rustc-literal-escaper v0.0.5
   Compiling proc_macro v0.0.0 (/home/martin/src/rust/library/proc_macro)
   Compiling getopts v0.2.23
   Compiling test v0.0.0 (/home/martin/src/rust/library/test)
   Compiling sysroot v0.0.0 (/home/martin/src/rust/library/sysroot)
    Finished `release` profile [optimized + debuginfo] target(s) in 14.43s
Building stage1 compiletest (stage0 -> stage1, x86_64-unknown-linux-gnu)
    Finished `release` profile [optimized + debuginfo] target(s) in 0.14s
Testing stage2 compiletest suite=ui mode=ui (stage1 -> stage2, x86_64-unknown-linux-gnu)

running 6 tests

[ui] tests/ui/limits/huge-array.rs#full-debuginfo ... F

[ui] tests/ui/limits/issue-15919-64.rs#full-debuginfo ... F

[ui] tests/ui/limits/huge-array-simple-64.rs#full-debuginfo ... F
...

failures:

---- [ui] tests/ui/limits/huge-array.rs#full-debuginfo stdout ----
Saved the actual stderr to `/home/martin/src/rust/build/x86_64-unknown-linux-gnu/test/ui/limits/huge-array.full-debuginfo/huge-array.full-debuginfo.stderr`
diff of stderr:

1       error: values of the type `[[u8; 1518599999]; 1518600000]` are too big for the target architecture
-         --> $DIR/huge-array.rs:9:9
-          |
-       LL |     let s: [T; 1518600000] = [t; 1518600000];
-          |         ^
6
7       error: aborting due to 1 previous error
8


The actual stderr differed from the expected stderr
To update references, rerun the tests and pass the `--bless` flag
To only update this specific test, also pass `--test-args limits/huge-array.rs`

error in revision `full-debuginfo`: 1 errors occurred comparing output.
status: exit status: 1
command: env -u RUSTC_LOG_COLOR RUSTC_ICE="0" RUST_BACKTRACE="short" "/home/martin/src/rust/build/x86_64-unknown-linux-gnu/stage1/bin/rustc" "/home/martin/src/rust/tests/ui/limits/huge-array.rs" "-Zthreads=1" "-Zsimulate-remapped-rust-src-base=/rustc/FAKE_PREFIX" "-Ztranslate-remapped-path-to-local-path=no" "-Z" "ignore-directory-in-diagnostics-source-blocks=/home/martin/.cargo" "-Z" "ignore-directory-in-diagnostics-source-blocks=/home/martin/src/rust/vendor" "--sysroot" "/home/martin/src/rust/build/x86_64-unknown-linux-gnu/stage1" "--target=x86_64-unknown-linux-gnu" "--cfg" "full_debuginfo" "--check-cfg" "cfg(test,FALSE,no_debuginfo,full_debuginfo)" "--error-format" "json" "--json" "future-incompat" "-Ccodegen-units=1" "-Zui-testing" "-Zdeduplicate-diagnostics=no" "-Zwrite-long-types-to-disk=no" "-Cstrip=debuginfo" "-C" "prefer-dynamic" "--out-dir" "/home/martin/src/rust/build/x86_64-unknown-linux-gnu/test/ui/limits/huge-array.full-debuginfo" "-A" "unused" "-A" "internal_features" "-A" "unused_parens" "-A" "unused_braces" "-Crpath" "-Lnative=/home/martin/src/rust/build/x86_64-unknown-linux-gnu/native/rust-test-helpers" "-Cdebuginfo=2"
stdout: none
--- stderr -------------------------------
error: values of the type `[[u8; 1518599999]; 1518600000]` are too big for the target architecture

error: aborting due to 1 previous error
------------------------------------------

---- [ui] tests/ui/limits/huge-array.rs#full-debuginfo stdout end ----
---- [ui] tests/ui/limits/issue-15919-64.rs#full-debuginfo stdout ----
Saved the actual stderr to `/home/martin/src/rust/build/x86_64-unknown-linux-gnu/test/ui/limits/issue-15919-64.full-debuginfo/issue-15919-64.full-debuginfo.stderr`
diff of stderr:

1       error: values of the type `[usize; usize::MAX]` are too big for the target architecture
-         --> $DIR/issue-15919-64.rs:10:9
-          |
-       LL |     let x = [0usize; 0xffff_ffff_ffff_ffff];
-          |         ^
6
7       error: aborting due to 1 previous error
8


The actual stderr differed from the expected stderr
To update references, rerun the tests and pass the `--bless` flag
To only update this specific test, also pass `--test-args limits/issue-15919-64.rs`

error in revision `full-debuginfo`: 1 errors occurred comparing output.
status: exit status: 1
command: env -u RUSTC_LOG_COLOR RUSTC_ICE="0" RUST_BACKTRACE="short" "/home/martin/src/rust/build/x86_64-unknown-linux-gnu/stage1/bin/rustc" "/home/martin/src/rust/tests/ui/limits/issue-15919-64.rs" "-Zthreads=1" "-Zsimulate-remapped-rust-src-base=/rustc/FAKE_PREFIX" "-Ztranslate-remapped-path-to-local-path=no" "-Z" "ignore-directory-in-diagnostics-source-blocks=/home/martin/.cargo" "-Z" "ignore-directory-in-diagnostics-source-blocks=/home/martin/src/rust/vendor" "--sysroot" "/home/martin/src/rust/build/x86_64-unknown-linux-gnu/stage1" "--target=x86_64-unknown-linux-gnu" "--cfg" "full_debuginfo" "--check-cfg" "cfg(test,FALSE,no_debuginfo,full_debuginfo)" "--error-format" "json" "--json" "future-incompat" "-Ccodegen-units=1" "-Zui-testing" "-Zdeduplicate-diagnostics=no" "-Zwrite-long-types-to-disk=no" "-Cstrip=debuginfo" "-C" "prefer-dynamic" "--out-dir" "/home/martin/src/rust/build/x86_64-unknown-linux-gnu/test/ui/limits/issue-15919-64.full-debuginfo" "-A" "unused" "-A" "internal_features" "-A" "unused_parens" "-A" "unused_braces" "-Crpath" "-Lnative=/home/martin/src/rust/build/x86_64-unknown-linux-gnu/native/rust-test-helpers" "-Cdebuginfo=2"
stdout: none
--- stderr -------------------------------
error: values of the type `[usize; usize::MAX]` are too big for the target architecture

error: aborting due to 1 previous error
------------------------------------------

---- [ui] tests/ui/limits/issue-15919-64.rs#full-debuginfo stdout end ----
---- [ui] tests/ui/limits/huge-array-simple-64.rs#full-debuginfo stdout ----
Saved the actual stderr to `/home/martin/src/rust/build/x86_64-unknown-linux-gnu/test/ui/limits/huge-array-simple-64.full-debuginfo/huge-array-simple-64.full-debuginfo.stderr`
diff of stderr:

1       error: values of the type `[u8; 2305843011361177600]` are too big for the target architecture
-         --> $DIR/huge-array-simple-64.rs:12:9
-          |
-       LL |     let _fat: [u8; (1<<61)+(1<<31)] =
-          |         ^^^^
6
7       error: aborting due to 1 previous error
8


The actual stderr differed from the expected stderr
To update references, rerun the tests and pass the `--bless` flag
To only update this specific test, also pass `--test-args limits/huge-array-simple-64.rs`

error in revision `full-debuginfo`: 1 errors occurred comparing output.
status: exit status: 1
command: env -u RUSTC_LOG_COLOR RUSTC_ICE="0" RUST_BACKTRACE="short" "/home/martin/src/rust/build/x86_64-unknown-linux-gnu/stage1/bin/rustc" "/home/martin/src/rust/tests/ui/limits/huge-array-simple-64.rs" "-Zthreads=1" "-Zsimulate-remapped-rust-src-base=/rustc/FAKE_PREFIX" "-Ztranslate-remapped-path-to-local-path=no" "-Z" "ignore-directory-in-diagnostics-source-blocks=/home/martin/.cargo" "-Z" "ignore-directory-in-diagnostics-source-blocks=/home/martin/src/rust/vendor" "--sysroot" "/home/martin/src/rust/build/x86_64-unknown-linux-gnu/stage1" "--target=x86_64-unknown-linux-gnu" "--cfg" "full_debuginfo" "--check-cfg" "cfg(test,FALSE,no_debuginfo,full_debuginfo)" "--error-format" "json" "--json" "future-incompat" "-Ccodegen-units=1" "-Zui-testing" "-Zdeduplicate-diagnostics=no" "-Zwrite-long-types-to-disk=no" "-Cstrip=debuginfo" "-C" "prefer-dynamic" "--out-dir" "/home/martin/src/rust/build/x86_64-unknown-linux-gnu/test/ui/limits/huge-array-simple-64.full-debuginfo" "-A" "unused" "-A" "internal_features" "-A" "unused_parens" "-A" "unused_braces" "-Crpath" "-Lnative=/home/martin/src/rust/build/x86_64-unknown-linux-gnu/native/rust-test-helpers" "-Cdebuginfo=2"
stdout: none
--- stderr -------------------------------
error: values of the type `[u8; 2305843011361177600]` are too big for the target architecture

error: aborting due to 1 previous error
------------------------------------------

---- [ui] tests/ui/limits/huge-array-simple-64.rs#full-debuginfo stdout end ----

failures:
    [ui] tests/ui/limits/huge-array.rs#full-debuginfo
    [ui] tests/ui/limits/issue-15919-64.rs#full-debuginfo
    [ui] tests/ui/limits/huge-array-simple-64.rs#full-debuginfo

test result: FAILED. 3 passed; 3 failed; 0 ignored; 0 measured; 19720 filtered out; finished in 117.18ms

Some tests failed in compiletest suite=ui mode=ui host=x86_64-unknown-linux-gnu target=x86_64-unknown-linux-gnu
Build completed unsuccessfully in 0:00:17
```
</details>

As can be seen, the span info is missing with debuginfo=2 without the fix.