### PR TITLE
support link modifier `as-needed` for raw-dylib-elf

### DIFF
--- a/compiler/rustc_attr_parsing/messages.ftl
+++ b/compiler/rustc_attr_parsing/messages.ftl
@@ -1,5 +1,5 @@
 attr_parsing_as_needed_compatibility =
-    linking modifier `as-needed` is only compatible with `dylib` and `framework` linking kinds
+    linking modifier `as-needed` is only compatible with `dylib`, `framework` and `raw-dylib` linking kinds
 
 attr_parsing_bundle_needs_static =
     linking modifier `bundle` is only compatible with `static` linking kind

--- a/compiler/rustc_hir/src/attrs/data_structures.rs
+++ b/compiler/rustc_hir/src/attrs/data_structures.rs
@@ -309,7 +309,10 @@ pub enum NativeLibKind {
     },
     /// Dynamic library (e.g. `foo.dll` on Windows) without a corresponding import library.
     /// On Linux, it refers to a generated shared library stub.
-    RawDylib,
+    RawDylib {
+        /// Whether the dynamic library will be linked only if it satisfies some undefined symbols
+        as_needed: Option<bool>,
+    },
     /// A macOS-specific kind of dynamic libraries.
     Framework {
         /// Whether the framework will be linked only if it satisfies some undefined symbols
@@ -332,11 +335,10 @@ impl NativeLibKind {
             NativeLibKind::Static { bundle, whole_archive } => {
                 bundle.is_some() || whole_archive.is_some()
             }
-            NativeLibKind::Dylib { as_needed } | NativeLibKind::Framework { as_needed } => {
-                as_needed.is_some()
-            }
-            NativeLibKind::RawDylib
-            | NativeLibKind::Unspecified
+            NativeLibKind::Dylib { as_needed }
+            | NativeLibKind::Framework { as_needed }
+            | NativeLibKind::RawDylib { as_needed } => as_needed.is_some(),
+            NativeLibKind::Unspecified
             | NativeLibKind::LinkArg
             | NativeLibKind::WasmImportModule => false,
         }
@@ -349,7 +351,9 @@ impl NativeLibKind {
     pub fn is_dllimport(&self) -> bool {
         matches!(
             self,
-            NativeLibKind::Dylib { .. } | NativeLibKind::RawDylib | NativeLibKind::Unspecified
+            NativeLibKind::Dylib { .. }
+                | NativeLibKind::RawDylib { .. }
+                | NativeLibKind::Unspecified
         )
     }
 }

--- a/compiler/rustc_metadata/src/native_libs.rs
+++ b/compiler/rustc_metadata/src/native_libs.rs
@@ -218,7 +218,7 @@ impl<'tcx> Collector<'tcx> {
                 .flatten()
         {
             let dll_imports = match attr.kind {
-                NativeLibKind::RawDylib => foreign_items
+                NativeLibKind::RawDylib { .. } => foreign_items
                     .iter()
                     .map(|&child_item| {
                         self.build_dll_import(

--- a/compiler/rustc_session/src/config/native_libs.rs
+++ b/compiler/rustc_session/src/config/native_libs.rs
@@ -135,7 +135,8 @@ fn parse_and_apply_modifier(cx: &ParseNativeLibCx<'_>, modifier: &str, native_li
         ),
 
         ("as-needed", NativeLibKind::Dylib { as_needed })
-        | ("as-needed", NativeLibKind::Framework { as_needed }) => {
+        | ("as-needed", NativeLibKind::Framework { as_needed })
+        | ("as-needed", NativeLibKind::RawDylib { as_needed }) => {
             cx.on_unstable_value(
                 "linking modifier `as-needed` is unstable",
                 ", the `-Z unstable-options` flag must also be passed to use it",

--- a/tests/ui/linkage-attr/raw-dylib/elf/as_needed.rs
+++ b/tests/ui/linkage-attr/raw-dylib/elf/as_needed.rs
@@ -1,0 +1,43 @@
+//@ only-elf
+//@ needs-dynamic-linking
+
+//@ only-gnu
+//@ only-x86_64
+//@ revisions: as_needed no_as_needed no_modifier merge_1 merge_2 merge_3 merge_4
+
+//@ [as_needed] run-pass
+//@ [no_as_needed] run-fail
+//@ [no_modifier] run-pass
+//@ [merge_1] run-fail
+//@ [merge_2] run-fail
+//@ [merge_3] run-fail
+//@ [merge_4] run-pass
+
+#![allow(incomplete_features)]
+#![feature(raw_dylib_elf)]
+#![feature(native_link_modifiers_as_needed)]
+
+#[cfg_attr(
+    as_needed,
+    link(name = "taiqannf1y28z2rw", kind = "raw-dylib", modifiers = "+as-needed")
+)]
+#[cfg_attr(
+    no_as_needed,
+    link(name = "taiqannf1y28z2rw", kind = "raw-dylib", modifiers = "-as-needed")
+)]
+#[cfg_attr(no_modifier, link(name = "taiqannf1y28z2rw", kind = "raw-dylib"))]
+unsafe extern "C" {}
+
+#[cfg_attr(merge_1, link(name = "k9nm7qxoa79bg7e6", kind = "raw-dylib", modifiers = "+as-needed"))]
+#[cfg_attr(merge_2, link(name = "k9nm7qxoa79bg7e6", kind = "raw-dylib", modifiers = "-as-needed"))]
+#[cfg_attr(merge_3, link(name = "k9nm7qxoa79bg7e6", kind = "raw-dylib", modifiers = "-as-needed"))]
+#[cfg_attr(merge_4, link(name = "k9nm7qxoa79bg7e6", kind = "raw-dylib", modifiers = "+as-needed"))]
+unsafe extern "C" {}
+
+#[cfg_attr(merge_1, link(name = "k9nm7qxoa79bg7e6", kind = "raw-dylib", modifiers = "-as-needed"))]
+#[cfg_attr(merge_2, link(name = "k9nm7qxoa79bg7e6", kind = "raw-dylib", modifiers = "+as-needed"))]
+#[cfg_attr(merge_3, link(name = "k9nm7qxoa79bg7e6", kind = "raw-dylib", modifiers = "-as-needed"))]
+#[cfg_attr(merge_4, link(name = "k9nm7qxoa79bg7e6", kind = "raw-dylib", modifiers = "+as-needed"))]
+unsafe extern "C" {}
+
+fn main() {}


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

This pull request:

* emits `-Wl,--as-needed` instead of `-Wl,--no-as-needed` for `raw-dylib-elf`, keeping it consistent with `dylib`
* allows combination of link kind `raw-dylib` and link modifier `as-needed`, thus allowing free choice of behavior

r? @bjorn3

cc https://github.com/rust-lang/rust/issues/135694
cc https://github.com/rust-lang/rust/issues/99424