### PR TITLE
Remove incorrect fixme on deprecation target

### DIFF
--- a/compiler/rustc_attr_parsing/src/attributes/deprecation.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/deprecation.rs
@@ -58,7 +58,7 @@ impl<S: Stage> SingleAttributeParser<S> for DeprecationParser {
         Allow(Target::AssocTy),
         Allow(Target::AssocConst),
         Allow(Target::Variant),
-        Allow(Target::Impl { of_trait: false }), //FIXME This does not make sense
+        Allow(Target::Impl { of_trait: false }),
         Allow(Target::Crate),
         Error(Target::WherePredicate),
     ]);


### PR DESCRIPTION
This does actually working suprisingly enough, applying deprecation to all methods in the impl block

r? @jdonszelmann 