### PR TITLE
Fix `sys::process::windows::tests::test_thread_handle` spurious failure

### DIFF
--- a/library/std/src/sys/process/windows/tests.rs
+++ b/library/std/src/sys/process/windows/tests.rs
@@ -1,7 +1,8 @@
 use super::{Arg, make_command_line};
 use crate::env;
 use crate::ffi::{OsStr, OsString};
-use crate::process::Command;
+use crate::os::windows::io::AsHandle;
+use crate::process::{Command, Stdio};
 
 #[test]
 fn test_raw_args() {
@@ -29,18 +30,29 @@ fn test_thread_handle() {
     use crate::os::windows::process::{ChildExt, CommandExt};
     const CREATE_SUSPENDED: u32 = 0x00000004;
 
-    let p = Command::new("cmd").args(&["/C", "exit 0"]).creation_flags(CREATE_SUSPENDED).spawn();
+    let p = Command::new("whoami").stdout(Stdio::null()).creation_flags(CREATE_SUSPENDED).spawn();
     assert!(p.is_ok());
-    let mut p = p.unwrap();
+
+    // Ensure the process is killed in the event something goes wrong.
+    struct DropGuard(crate::process::Child);
+    impl Drop for DropGuard {
+        fn drop(&mut self) {
+            let _ = self.0.kill();
+        }
+    }
+    let mut p = DropGuard(p.unwrap());
+    let p = &mut p.0;
 
     unsafe extern "system" {
-        fn ResumeThread(_: BorrowedHandle<'_>) -> u32;
+        unsafe fn ResumeThread(hHandle: BorrowedHandle<'_>) -> u32;
+        unsafe fn WaitForSingleObject(hHandle: BorrowedHandle<'_>, dwMilliseconds: u32) -> u32;
     }
     unsafe {
         ResumeThread(p.main_thread_handle());
+        // Wait until the process exits or 1 minute passes.
+        // We don't bother checking the result here as that's done below using `try_wait`.
+        WaitForSingleObject(p.as_handle(), 1000 * 60);
     }
-
-    crate::thread::sleep(crate::time::Duration::from_millis(100));
 
     let res = p.try_wait();
     assert!(res.is_ok());


### PR DESCRIPTION
Instead of sleeping, wait for the process to finish so that we can be sure it's done. We use a timeout because otherwise this test can be stuck indefinitely if it fails (unfortunately std doesn't currently have a way to wait with a timeout so a manual OS API call is necessary).

I also changed the test to run `whoami` and pipe the output to null so that it doesn't clutter up the test output.

Fixes rust-lang/rust#146024