### PR TITLE
Explicity disable LSX feature for `loongarch64-unknown-none` target

### DIFF
--- a/compiler/rustc_target/src/spec/targets/loongarch64_unknown_none.rs
+++ b/compiler/rustc_target/src/spec/targets/loongarch64_unknown_none.rs
@@ -17,7 +17,7 @@ pub(crate) fn target() -> Target {
         arch: "loongarch64".into(),
         options: TargetOptions {
             cpu: "generic".into(),
-            features: "+f,+d".into(),
+            features: "+f,+d,-lsx".into(),
             linker_flavor: LinkerFlavor::Gnu(Cc::No, Lld::Yes),
             linker: Some("rust-lld".into()),
             llvm_abiname: "lp64d".into(),


### PR DESCRIPTION
The `loongarch64-unknown-none` target is a bare-metal target with hardware floating-point support and should not enable SIMD extensions by default. However, LLVM's LoongArch64 backend enables LSX implicitly, inadvertently activating SIMD instructions for this target. This patch explicitly disable LSX feature to prevent unintended SIMD usage.
