### PR TITLE
Update `browser-ui-test` version to `0.21.3`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "browser-ui-test": "^0.21.1",
+        "browser-ui-test": "^0.21.3",
         "es-check": "^6.2.1",
         "eslint": "^8.57.1",
         "eslint-js": "github:eslint/js",
@@ -555,7 +555,7 @@
       }
     },
     "node_modules/browser-ui-test": {
-      "version": "0.21.1",
+      "version": "0.21.3",
       "resolved": "https://registry.npmjs.org/browser-ui-test/-/browser-ui-test-0.21.1.tgz",
       "integrity": "sha512-b3a9mhALAmbP+GifoN/c295RPyuyfIUFMz0DtlBHbeDW5PYQTMHZZJtm7R2UyP6JiIQSkR+7227sS3maMGMUTg==",
       "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "browser-ui-test": "^0.21.1",
+    "browser-ui-test": "^0.21.3",
     "es-check": "^6.2.1",
     "eslint": "^8.57.1",
     "eslint-js": "github:eslint/js",


### PR DESCRIPTION
I cannot test it locally because of this bug:

```
error: couldn't generate documentation: failed to read column from disk: data consumer error: missing field `unknown number` at line 1 column 8
  |
  = note: failed to create or modify "build/x86_64-unknown-linux-gnu/test/rustdoc-gui/doc/search.index/entry/": failed to read column from disk: data consumer error: missing field `unknown number` at line 1 column 8
```

So I'll iterate through CI checks I guess.

r? ghost