### PR TITLE
Introduce CoerceShared lang item and trait, and basic Reborrow tests

### DIFF
--- a/compiler/rustc_hir/src/lang_items.rs
+++ b/compiler/rustc_hir/src/lang_items.rs
@@ -441,6 +441,7 @@ language_item_table! {
 
     // Reborrowing related lang-items
     Reborrow,                sym::reborrow,            reborrow,                   Target::Trait,          GenericRequirement::Exact(0);
+    CoerceShared,            sym::coerce_shared,       coerce_shared,              Target::Trait,          GenericRequirement::Exact(0);
 }
 
 /// The requirement imposed on the generics of a lang item

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -679,6 +679,7 @@ symbols! {
         cmpxchg16b_target_feature,
         cmse_nonsecure_entry,
         coerce_pointee_validated,
+        coerce_shared,
         coerce_unsized,
         cold,
         cold_path,

--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -1364,11 +1364,3 @@ pub macro CoercePointee($item:item) {
 pub trait CoercePointeeValidated {
     /* compiler built-in */
 }
-
-/// Allows value to be reborrowed as exclusive, creating a copy of the value
-/// that disables the source for reads and writes for the lifetime of the copy.
-#[lang = "reborrow"]
-#[unstable(feature = "reborrow", issue = "145612")]
-pub trait Reborrow {
-    // Empty.
-}

--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -1372,12 +1372,3 @@ pub trait CoercePointeeValidated {
 pub trait Reborrow {
     // Empty.
 }
-
-/// Allows reborrowable value to be reborrowed as shared, creating a copy of
-/// that disables the source for writes for the lifetime of the copy.
-#[lang = "coerce_shared"]
-#[unstable(feature = "reborrow", issue = "145612")]
-pub trait CoerceShared: Reborrow {
-    /// The type of this value when reborrowed as shared.
-    type Target: Copy;
-}

--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -1372,3 +1372,12 @@ pub trait CoercePointeeValidated {
 pub trait Reborrow {
     // Empty.
 }
+
+/// Allows reborrowable value to be reborrowed as shared, creating a copy of
+/// that disables the source for writes for the lifetime of the copy.
+#[lang = "coerce_shared"]
+#[unstable(feature = "reborrow", issue = "145612")]
+pub trait CoerceShared: Reborrow {
+    /// The type of this value when reborrowed as shared.
+    type Target: Copy;
+}

--- a/library/core/src/ops/mod.rs
+++ b/library/core/src/ops/mod.rs
@@ -191,7 +191,7 @@ pub use self::range::{OneSidedRange, OneSidedRangeBound};
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use self::range::{Range, RangeFrom, RangeFull, RangeTo};
 #[unstable(feature = "reborrow", issue = "145612")]
-pub use self::reborrow::CoerceShared;
+pub use self::reborrow::{CoerceShared, Reborrow};
 #[unstable(feature = "try_trait_v2_residual", issue = "91285")]
 pub use self::try_trait::Residual;
 #[unstable(feature = "try_trait_v2_yeet", issue = "96374")]

--- a/library/core/src/ops/mod.rs
+++ b/library/core/src/ops/mod.rs
@@ -149,6 +149,7 @@ mod function;
 mod index;
 mod index_range;
 mod range;
+mod reborrow;
 mod try_trait;
 mod unsize;
 
@@ -189,6 +190,8 @@ pub use self::range::{Bound, RangeBounds, RangeInclusive, RangeToInclusive};
 pub use self::range::{OneSidedRange, OneSidedRangeBound};
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use self::range::{Range, RangeFrom, RangeFull, RangeTo};
+#[unstable(feature = "reborrow", issue = "145612")]
+pub use self::reborrow::CoerceShared;
 #[unstable(feature = "try_trait_v2_residual", issue = "91285")]
 pub use self::try_trait::Residual;
 #[unstable(feature = "try_trait_v2_yeet", issue = "96374")]

--- a/library/core/src/ops/reborrow.rs
+++ b/library/core/src/ops/reborrow.rs
@@ -1,0 +1,10 @@
+use crate::marker::Reborrow;
+
+/// Allows reborrowable value to be reborrowed as shared, creating a copy
+/// that disables the source for writes for the lifetime of the copy.
+#[lang = "coerce_shared"]
+#[unstable(feature = "reborrow", issue = "145612")]
+pub trait CoerceShared: Reborrow {
+    /// The type of this value when reborrowed as shared.
+    type Target: Copy;
+}

--- a/library/core/src/ops/reborrow.rs
+++ b/library/core/src/ops/reborrow.rs
@@ -1,4 +1,10 @@
-use crate::marker::Reborrow;
+/// Allows value to be reborrowed as exclusive, creating a copy of the value
+/// that disables the source for reads and writes for the lifetime of the copy.
+#[lang = "reborrow"]
+#[unstable(feature = "reborrow", issue = "145612")]
+pub trait Reborrow {
+    // Empty.
+}
 
 /// Allows reborrowable value to be reborrowed as shared, creating a copy
 /// that disables the source for writes for the lifetime of the copy.

--- a/tests/ui/feature-gates/feature-gate-reborrow-coerce-shared.rs
+++ b/tests/ui/feature-gates/feature-gate-reborrow-coerce-shared.rs
@@ -1,0 +1,3 @@
+use std::marker::CoerceShared; //~ ERROR  use of unstable library feature `reborrow`
+
+fn main() {}

--- a/tests/ui/feature-gates/feature-gate-reborrow-coerce-shared.rs
+++ b/tests/ui/feature-gates/feature-gate-reborrow-coerce-shared.rs
@@ -1,3 +1,3 @@
-use std::marker::CoerceShared; //~ ERROR  use of unstable library feature `reborrow`
+use std::ops::CoerceShared; //~ ERROR  use of unstable library feature `reborrow`
 
 fn main() {}

--- a/tests/ui/feature-gates/feature-gate-reborrow-coerce-shared.stderr
+++ b/tests/ui/feature-gates/feature-gate-reborrow-coerce-shared.stderr
@@ -1,0 +1,13 @@
+error[E0658]: use of unstable library feature `reborrow`
+  --> $DIR/feature-gate-reborrow-coerce-shared.rs:1:5
+   |
+LL | use std::marker::CoerceShared;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #145612 <https://github.com/rust-lang/rust/issues/145612> for more information
+   = help: add `#![feature(reborrow)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/feature-gates/feature-gate-reborrow-coerce-shared.stderr
+++ b/tests/ui/feature-gates/feature-gate-reborrow-coerce-shared.stderr
@@ -1,8 +1,8 @@
 error[E0658]: use of unstable library feature `reborrow`
   --> $DIR/feature-gate-reborrow-coerce-shared.rs:1:5
    |
-LL | use std::marker::CoerceShared;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | use std::ops::CoerceShared;
+   |     ^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #145612 <https://github.com/rust-lang/rust/issues/145612> for more information
    = help: add `#![feature(reborrow)]` to the crate attributes to enable

--- a/tests/ui/feature-gates/feature-gate-reborrow.rs
+++ b/tests/ui/feature-gates/feature-gate-reborrow.rs
@@ -1,3 +1,3 @@
-use std::marker::Reborrow; //~ ERROR  use of unstable library feature `reborrow`
+use std::ops::Reborrow; //~ ERROR  use of unstable library feature `reborrow`
 
 fn main() {}

--- a/tests/ui/feature-gates/feature-gate-reborrow.stderr
+++ b/tests/ui/feature-gates/feature-gate-reborrow.stderr
@@ -1,8 +1,8 @@
 error[E0658]: use of unstable library feature `reborrow`
   --> $DIR/feature-gate-reborrow.rs:1:5
    |
-LL | use std::marker::Reborrow;
-   |     ^^^^^^^^^^^^^^^^^^^^^
+LL | use std::ops::Reborrow;
+   |     ^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #145612 <https://github.com/rust-lang/rust/issues/145612> for more information
    = help: add `#![feature(reborrow)]` to the crate attributes to enable

--- a/tests/ui/reborrow/custom_mut.rs
+++ b/tests/ui/reborrow/custom_mut.rs
@@ -1,0 +1,13 @@
+#![feature(reborrow)]
+use std::marker::Reborrow;
+
+struct CustomMut<'a, T>(&'a mut T);
+impl<'a, T> Reborrow for CustomMut<'a, T> {}
+
+fn method(a: CustomMut<'_, ()>) {}
+
+fn main() {
+    let a = CustomMut(&mut ());
+    let _ = method(a);
+    let _ = method(a); //~ERROR use of moved value: `a`
+}

--- a/tests/ui/reborrow/custom_mut.rs
+++ b/tests/ui/reborrow/custom_mut.rs
@@ -1,5 +1,5 @@
 #![feature(reborrow)]
-use std::marker::Reborrow;
+use std::ops::Reborrow;
 
 struct CustomMut<'a, T>(&'a mut T);
 impl<'a, T> Reborrow for CustomMut<'a, T> {}

--- a/tests/ui/reborrow/custom_mut.stderr
+++ b/tests/ui/reborrow/custom_mut.stderr
@@ -1,0 +1,29 @@
+error[E0382]: use of moved value: `a`
+  --> $DIR/custom_mut.rs:12:20
+   |
+LL |     let a = CustomMut(&mut ());
+   |         - move occurs because `a` has type `CustomMut<'_, ()>`, which does not implement the `Copy` trait
+LL |     let _ = method(a);
+   |                    - value moved here
+LL |     let _ = method(a);
+   |                    ^ value used here after move
+   |
+note: consider changing this parameter type in function `method` to borrow instead if owning the value isn't necessary
+  --> $DIR/custom_mut.rs:7:14
+   |
+LL | fn method(a: CustomMut<'_, ()>) {}
+   |    ------    ^^^^^^^^^^^^^^^^^ this parameter takes ownership of the value
+   |    |
+   |    in this function
+note: if `CustomMut<'_, ()>` implemented `Clone`, you could clone the value
+  --> $DIR/custom_mut.rs:4:1
+   |
+LL | struct CustomMut<'a, T>(&'a mut T);
+   | ^^^^^^^^^^^^^^^^^^^^^^^ consider implementing `Clone` for this type
+...
+LL |     let _ = method(a);
+   |                    - you could clone this value
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0382`.

--- a/tests/ui/reborrow/custom_mut_coerce_shared.rs
+++ b/tests/ui/reborrow/custom_mut_coerce_shared.rs
@@ -1,0 +1,28 @@
+#![feature(reborrow)]
+use std::marker::{Reborrow, CoerceShared};
+
+struct CustomMut<'a, T>(&'a mut T);
+impl<'a, T> Reborrow for CustomMut<'a, T> {}
+impl<'a, T> CoerceShared for CustomMut<'a, T> {
+    type Target = CustomRef<'a, T>;
+}
+
+struct CustomRef<'a, T>(&'a T);
+
+impl<'a, T> Clone for CustomRef<'a, T> {
+    fn clone(&self) -> Self {
+        Self(self.0)
+    }
+}
+impl<'a, T> Copy for CustomRef<'a, T> {}
+
+fn method(a: CustomRef<'_, ()>) {}  //~NOTE function defined here
+
+fn main() {
+    let a = CustomMut(&mut ());
+    method(a);
+    //~^ ERROR mismatched types
+    //~| NOTE expected `CustomRef<'_, ()>`, found `CustomMut<'_, ()>`
+    //~| NOTE arguments to this function are incorrect
+    //~| NOTE expected struct `CustomRef<'_, ()>`
+}

--- a/tests/ui/reborrow/custom_mut_coerce_shared.rs
+++ b/tests/ui/reborrow/custom_mut_coerce_shared.rs
@@ -1,6 +1,5 @@
 #![feature(reborrow)]
-use std::marker::Reborrow;
-use std::ops::CoerceShared;
+use std::ops::{CoerceShared, Reborrow};
 
 struct CustomMut<'a, T>(&'a mut T);
 impl<'a, T> Reborrow for CustomMut<'a, T> {}

--- a/tests/ui/reborrow/custom_mut_coerce_shared.rs
+++ b/tests/ui/reborrow/custom_mut_coerce_shared.rs
@@ -1,5 +1,6 @@
 #![feature(reborrow)]
-use std::marker::{Reborrow, CoerceShared};
+use std::marker::Reborrow;
+use std::ops::CoerceShared;
 
 struct CustomMut<'a, T>(&'a mut T);
 impl<'a, T> Reborrow for CustomMut<'a, T> {}

--- a/tests/ui/reborrow/custom_mut_coerce_shared.stderr
+++ b/tests/ui/reborrow/custom_mut_coerce_shared.stderr
@@ -1,0 +1,19 @@
+error[E0308]: mismatched types
+  --> $DIR/custom_mut_coerce_shared.rs:23:12
+   |
+LL |     method(a);
+   |     ------ ^ expected `CustomRef<'_, ()>`, found `CustomMut<'_, ()>`
+   |     |
+   |     arguments to this function are incorrect
+   |
+   = note: expected struct `CustomRef<'_, ()>`
+              found struct `CustomMut<'_, ()>`
+note: function defined here
+  --> $DIR/custom_mut_coerce_shared.rs:19:4
+   |
+LL | fn method(a: CustomRef<'_, ()>) {}
+   |    ^^^^^^ --------------------
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/reborrow/custom_mut_coerce_shared.stderr
+++ b/tests/ui/reborrow/custom_mut_coerce_shared.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/custom_mut_coerce_shared.rs:23:12
+  --> $DIR/custom_mut_coerce_shared.rs:24:12
    |
 LL |     method(a);
    |     ------ ^ expected `CustomRef<'_, ()>`, found `CustomMut<'_, ()>`
@@ -9,7 +9,7 @@ LL |     method(a);
    = note: expected struct `CustomRef<'_, ()>`
               found struct `CustomMut<'_, ()>`
 note: function defined here
-  --> $DIR/custom_mut_coerce_shared.rs:19:4
+  --> $DIR/custom_mut_coerce_shared.rs:20:4
    |
 LL | fn method(a: CustomRef<'_, ()>) {}
    |    ^^^^^^ --------------------

--- a/tests/ui/reborrow/custom_mut_coerce_shared.stderr
+++ b/tests/ui/reborrow/custom_mut_coerce_shared.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/custom_mut_coerce_shared.rs:24:12
+  --> $DIR/custom_mut_coerce_shared.rs:23:12
    |
 LL |     method(a);
    |     ------ ^ expected `CustomRef<'_, ()>`, found `CustomMut<'_, ()>`
@@ -9,7 +9,7 @@ LL |     method(a);
    = note: expected struct `CustomRef<'_, ()>`
               found struct `CustomMut<'_, ()>`
 note: function defined here
-  --> $DIR/custom_mut_coerce_shared.rs:20:4
+  --> $DIR/custom_mut_coerce_shared.rs:19:4
    |
 LL | fn method(a: CustomRef<'_, ()>) {}
    |    ^^^^^^ --------------------

--- a/tests/ui/reborrow/option_mut.rs
+++ b/tests/ui/reborrow/option_mut.rs
@@ -1,0 +1,7 @@
+fn method(a: Option<& mut ()>) {}
+
+fn main() {
+    let a = Some(&mut ());
+    let _ = method(a);
+    let _ = method(a); //~ERROR use of moved value: `a`
+}

--- a/tests/ui/reborrow/option_mut.rs
+++ b/tests/ui/reborrow/option_mut.rs
@@ -1,4 +1,4 @@
-fn method(a: Option<& mut ()>) {}
+fn method(a: Option<&mut ()>) {}
 
 fn main() {
     let a = Some(&mut ());

--- a/tests/ui/reborrow/option_mut.stderr
+++ b/tests/ui/reborrow/option_mut.stderr
@@ -1,0 +1,21 @@
+error[E0382]: use of moved value: `a`
+  --> $DIR/option_mut.rs:6:20
+   |
+LL |     let a = Some(&mut ());
+   |         - move occurs because `a` has type `Option<&mut ()>`, which does not implement the `Copy` trait
+LL |     let _ = method(a);
+   |                    - value moved here
+LL |     let _ = method(a);
+   |                    ^ value used here after move
+   |
+note: consider changing this parameter type in function `method` to borrow instead if owning the value isn't necessary
+  --> $DIR/option_mut.rs:1:14
+   |
+LL | fn method(a: Option<& mut ()>) {}
+   |    ------    ^^^^^^^^^^^^^^^^ this parameter takes ownership of the value
+   |    |
+   |    in this function
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0382`.

--- a/tests/ui/reborrow/option_mut.stderr
+++ b/tests/ui/reborrow/option_mut.stderr
@@ -11,8 +11,8 @@ LL |     let _ = method(a);
 note: consider changing this parameter type in function `method` to borrow instead if owning the value isn't necessary
   --> $DIR/option_mut.rs:1:14
    |
-LL | fn method(a: Option<& mut ()>) {}
-   |    ------    ^^^^^^^^^^^^^^^^ this parameter takes ownership of the value
+LL | fn method(a: Option<&mut ()>) {}
+   |    ------    ^^^^^^^^^^^^^^^ this parameter takes ownership of the value
    |    |
    |    in this function
 

--- a/tests/ui/reborrow/option_mut_coerce_shared.rs
+++ b/tests/ui/reborrow/option_mut_coerce_shared.rs
@@ -1,0 +1,11 @@
+fn method(a: Option<&()>) {}  //~NOTE function defined here
+
+fn main() {
+    let a = Some(&mut ());
+    method(a);
+    //~^ ERROR mismatched types
+    //~| NOTE arguments to this function are incorrect
+    //~| NOTE types differ in mutability
+    //~| NOTE expected enum `Option<&()>`
+    //~| NOTE    found enum `Option<&mut ()>`
+}

--- a/tests/ui/reborrow/option_mut_coerce_shared.stderr
+++ b/tests/ui/reborrow/option_mut_coerce_shared.stderr
@@ -1,0 +1,23 @@
+error[E0308]: mismatched types
+  --> $DIR/option_mut_coerce_shared.rs:5:12
+   |
+LL |     method(a);
+   |     ------ ^ types differ in mutability
+   |     |
+   |     arguments to this function are incorrect
+   |
+   = note: expected enum `Option<&()>`
+              found enum `Option<&mut ()>`
+note: function defined here
+  --> $DIR/option_mut_coerce_shared.rs:1:4
+   |
+LL | fn method(a: Option<&()>) {}
+   |    ^^^^^^ --------------
+help: try using `.as_deref()` to convert `Option<&mut ()>` to `Option<&()>`
+   |
+LL |     method(a.as_deref());
+   |             +++++++++++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/reborrow/pin_mut.rs
+++ b/tests/ui/reborrow/pin_mut.rs
@@ -1,0 +1,10 @@
+use std::pin::Pin;
+
+fn method(a: Pin<& mut ()>) {}
+
+fn main() {
+    let a = &mut ();
+    let a = Pin::new(a);
+    let _ = method(a);
+    let _ = method(a); //~ERROR use of moved value: `a`
+}

--- a/tests/ui/reborrow/pin_mut.rs
+++ b/tests/ui/reborrow/pin_mut.rs
@@ -1,6 +1,6 @@
 use std::pin::Pin;
 
-fn method(a: Pin<& mut ()>) {}
+fn method(a: Pin<&mut ()>) {}
 
 fn main() {
     let a = &mut ();

--- a/tests/ui/reborrow/pin_mut.stderr
+++ b/tests/ui/reborrow/pin_mut.stderr
@@ -1,0 +1,21 @@
+error[E0382]: use of moved value: `a`
+  --> $DIR/pin_mut.rs:9:20
+   |
+LL |     let a = Pin::new(a);
+   |         - move occurs because `a` has type `Pin<&mut ()>`, which does not implement the `Copy` trait
+LL |     let _ = method(a);
+   |                    - value moved here
+LL |     let _ = method(a);
+   |                    ^ value used here after move
+   |
+note: consider changing this parameter type in function `method` to borrow instead if owning the value isn't necessary
+  --> $DIR/pin_mut.rs:3:14
+   |
+LL | fn method(a: Pin<& mut ()>) {}
+   |    ------    ^^^^^^^^^^^^^ this parameter takes ownership of the value
+   |    |
+   |    in this function
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0382`.

--- a/tests/ui/reborrow/pin_mut.stderr
+++ b/tests/ui/reborrow/pin_mut.stderr
@@ -11,8 +11,8 @@ LL |     let _ = method(a);
 note: consider changing this parameter type in function `method` to borrow instead if owning the value isn't necessary
   --> $DIR/pin_mut.rs:3:14
    |
-LL | fn method(a: Pin<& mut ()>) {}
-   |    ------    ^^^^^^^^^^^^^ this parameter takes ownership of the value
+LL | fn method(a: Pin<&mut ()>) {}
+   |    ------    ^^^^^^^^^^^^ this parameter takes ownership of the value
    |    |
    |    in this function
 

--- a/tests/ui/reborrow/pin_mut_coerce_shared.rs
+++ b/tests/ui/reborrow/pin_mut_coerce_shared.rs
@@ -1,0 +1,14 @@
+use std::pin::Pin;
+
+fn method(a: Pin<&()>) {}  //~NOTE function defined here
+
+fn main() {
+    let a = &mut ();
+    let a = Pin::new(a);
+    method(a);
+    //~^ ERROR mismatched types
+    //~| NOTE arguments to this function are incorrect
+    //~| NOTE types differ in mutability
+    //~| NOTE expected struct `Pin<&()>`
+    //~| NOTE    found struct `Pin<&mut ()>`
+}

--- a/tests/ui/reborrow/pin_mut_coerce_shared.rs
+++ b/tests/ui/reborrow/pin_mut_coerce_shared.rs
@@ -10,5 +10,4 @@ fn main() {
     //~| NOTE arguments to this function are incorrect
     //~| NOTE types differ in mutability
     //~| NOTE expected struct `Pin<&()>`
-    //~| NOTE    found struct `Pin<&mut ()>`
 }

--- a/tests/ui/reborrow/pin_mut_coerce_shared.stderr
+++ b/tests/ui/reborrow/pin_mut_coerce_shared.stderr
@@ -1,0 +1,19 @@
+error[E0308]: mismatched types
+  --> $DIR/pin_mut_coerce_shared.rs:8:12
+   |
+LL |     method(a);
+   |     ------ ^ types differ in mutability
+   |     |
+   |     arguments to this function are incorrect
+   |
+   = note: expected struct `Pin<&()>`
+              found struct `Pin<&mut ()>`
+note: function defined here
+  --> $DIR/pin_mut_coerce_shared.rs:3:4
+   |
+LL | fn method(a: Pin<&()>) {}
+   |    ^^^^^^ -----------
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Part of rust-lang/rust#145612: This introduces the `CoerceShared` trait which is the `Reborrow` equivalent of a `&mut T` -> `&T` coercion. The trait has a `Target` GAT which makes this (currently) unique in the `core/src/marker.rs`; I'm not sure if this can be considered problematic. Maybe this is not the way such things should be done at the marker trait level? Or maybe it is fine.

Improtantly, this PR introduces a battery of basic `Reborrow` and `CoerceShared` tests. These test the very basics of the feature; custom marker types intended to have exclusive semantics (`Custom<'a>(PhantomData<&'a mut ()>)`), custom exclusive reference wrappers, and standard library exclusive reference wrappers (`Pin<&mut T>` and `Option<&mut T>`). None of these of course work since the implementation for `Reborrow` and `CoerceShared` is entirely missing, but this is the first step towards making these work.

Future PRs will introduce more tests, such as "recursive" reborrowing (ie. reborrowing structs that contain multiple reborrowable fields) and checks around the lifetime semantics of reborrowing ie. that a reborrow produces a new type with the same lifetime as the original.