### PR TITLE
Detect negative literal inferred to unsigned integer

### DIFF
--- a/compiler/rustc_hir_typeck/src/op.rs
+++ b/compiler/rustc_hir_typeck/src/op.rs
@@ -962,13 +962,15 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let (opt_rhs_expr, opt_rhs_ty) = opt_rhs.unzip();
         let cause = self.cause(
             span,
-            ObligationCauseCode::BinOp {
-                lhs_hir_id: lhs_expr.hir_id,
-                rhs_hir_id: opt_rhs_expr.map(|expr| expr.hir_id),
-                rhs_span: opt_rhs_expr.map(|expr| expr.span),
-                rhs_is_lit: opt_rhs_expr
-                    .is_some_and(|expr| matches!(expr.kind, hir::ExprKind::Lit(_))),
-                output_ty: expected.only_has_type(self),
+            match opt_rhs_expr {
+                Some(rhs) => ObligationCauseCode::BinOp {
+                    lhs_hir_id: lhs_expr.hir_id,
+                    rhs_hir_id: rhs.hir_id,
+                    rhs_span: rhs.span,
+                    rhs_is_lit: matches!(rhs.kind, hir::ExprKind::Lit(_)),
+                    output_ty: expected.only_has_type(self),
+                },
+                None => ObligationCauseCode::UnOp { hir_id: lhs_expr.hir_id },
             },
         );
 

--- a/compiler/rustc_middle/src/traits/mod.rs
+++ b/compiler/rustc_middle/src/traits/mod.rs
@@ -389,10 +389,14 @@ pub enum ObligationCauseCode<'tcx> {
     /// against.
     MatchImpl(ObligationCause<'tcx>, DefId),
 
+    UnOp {
+        hir_id: HirId,
+    },
+
     BinOp {
         lhs_hir_id: HirId,
-        rhs_hir_id: Option<HirId>,
-        rhs_span: Option<Span>,
+        rhs_hir_id: HirId,
+        rhs_span: Span,
         rhs_is_lit: bool,
         output_ty: Option<Ty<'tcx>>,
     },

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -963,8 +963,8 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         trait_pred: ty::PolyTraitPredicate<'tcx>,
         err: &mut Diag<'_>,
     ) -> bool {
-        if let ObligationCauseCode::BinOp { lhs_hir_id, .. } = obligation.cause.code()
-            && let hir::Node::Expr(expr) = self.tcx.hir_node(*lhs_hir_id)
+        if let ObligationCauseCode::UnOp { hir_id, .. } = obligation.cause.code()
+            && let hir::Node::Expr(expr) = self.tcx.hir_node(*hir_id)
             && let hir::ExprKind::Unary(hir::UnOp::Neg, inner) = expr.kind
             && let hir::ExprKind::Lit(lit) = inner.kind
             && let LitKind::Int(_, LitIntType::Unsuffixed) = lit.node
@@ -2769,9 +2769,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         suggested: bool,
     ) {
         let body_def_id = obligation.cause.body_id;
-        let span = if let ObligationCauseCode::BinOp { rhs_span: Some(rhs_span), .. } =
-            obligation.cause.code()
-        {
+        let span = if let ObligationCauseCode::BinOp { rhs_span, .. } = obligation.cause.code() {
             *rhs_span
         } else {
             span

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -3,7 +3,8 @@ use std::borrow::Cow;
 use std::path::PathBuf;
 
 use rustc_abi::ExternAbi;
-use rustc_ast::TraitObjectSyntax;
+use rustc_ast::ast::LitKind;
+use rustc_ast::{LitIntType, TraitObjectSyntax};
 use rustc_data_structures::fx::FxHashMap;
 use rustc_data_structures::unord::UnordSet;
 use rustc_errors::codes::*;
@@ -279,6 +280,12 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                         if is_try_conversion || is_question_mark {
                             (suggested, noted_missing_impl) = self.try_conversion_context(&obligation, main_trait_predicate, &mut err);
                         }
+
+                        suggested |= self.detect_negative_literal(
+                            &obligation,
+                            main_trait_predicate,
+                            &mut err,
+                        );
 
                         if let Some(ret_span) = self.return_type_span(&obligation) {
                             if is_try_conversion {
@@ -948,6 +955,38 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             return Err(*guar);
         }
         Ok(())
+    }
+
+    fn detect_negative_literal(
+        &self,
+        obligation: &PredicateObligation<'tcx>,
+        trait_pred: ty::PolyTraitPredicate<'tcx>,
+        err: &mut Diag<'_>,
+    ) -> bool {
+        if let ObligationCauseCode::BinOp { lhs_hir_id, .. } = obligation.cause.code()
+            && let hir::Node::Expr(expr) = self.tcx.hir_node(*lhs_hir_id)
+            && let hir::ExprKind::Unary(hir::UnOp::Neg, inner) = expr.kind
+            && let hir::ExprKind::Lit(lit) = inner.kind
+            && let LitKind::Int(_, LitIntType::Unsuffixed) = lit.node
+        {
+            err.span_suggestion_verbose(
+                lit.span.shrink_to_hi(),
+                "consider specifying an integer type that can be negative",
+                match trait_pred.skip_binder().self_ty().kind() {
+                    ty::Uint(ty::UintTy::Usize) => "isize",
+                    ty::Uint(ty::UintTy::U8) => "i8",
+                    ty::Uint(ty::UintTy::U16) => "i16",
+                    ty::Uint(ty::UintTy::U32) => "i32",
+                    ty::Uint(ty::UintTy::U64) => "i64",
+                    ty::Uint(ty::UintTy::U128) => "i128",
+                    _ => "i64",
+                }
+                .to_string(),
+                Applicability::MaybeIncorrect,
+            );
+            return true;
+        }
+        false
     }
 
     /// When the `E` of the resulting `Result<T, E>` in an expression `foo().bar().baz()?`,

--- a/tests/ui/suggestions/negative-literal-infered-to-unsigned.rs
+++ b/tests/ui/suggestions/negative-literal-infered-to-unsigned.rs
@@ -1,0 +1,13 @@
+fn main() {
+    for x in -5..5 {
+        //~^ ERROR: the trait bound `usize: Neg` is not satisfied
+        //~| HELP: consider specifying an integer type that can be negative
+        do_something(x);
+    }
+    let x = -5;
+    //~^ ERROR: the trait bound `usize: Neg` is not satisfied
+    //~| HELP: consider specifying an integer type that can be negative
+    do_something(x);
+}
+
+fn do_something(_val: usize) {}

--- a/tests/ui/suggestions/negative-literal-infered-to-unsigned.stderr
+++ b/tests/ui/suggestions/negative-literal-infered-to-unsigned.stderr
@@ -1,0 +1,25 @@
+error[E0277]: the trait bound `usize: Neg` is not satisfied
+  --> $DIR/negative-literal-infered-to-unsigned.rs:2:14
+   |
+LL |     for x in -5..5 {
+   |              ^^ the trait `Neg` is not implemented for `usize`
+   |
+help: consider specifying an integer type that can be negative
+   |
+LL |     for x in -5isize..5 {
+   |                +++++
+
+error[E0277]: the trait bound `usize: Neg` is not satisfied
+  --> $DIR/negative-literal-infered-to-unsigned.rs:7:13
+   |
+LL |     let x = -5;
+   |             ^^ the trait `Neg` is not implemented for `usize`
+   |
+help: consider specifying an integer type that can be negative
+   |
+LL |     let x = -5isize;
+   |               +++++
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
```
error[E0277]: the trait bound `usize: Neg` is not satisfied
  --> $DIR/negative-literal-infered-to-unsigned.rs:2:14
   |
LL |     for x in -5..5 {
   |              ^^ the trait `Neg` is not implemented for `usize`
   |
help: consider specifying an integer type that can be negative
   |
LL |     for x in -5isize..5 {
   |                +++++
```

Applying this suggestion will always end up in another E0308 error at the point where the unsigned inference comes from, which should help with understanding what the actual problem is.

Fix rust-lang/rust#83413.