### PR TITLE
Suggest parentheses when `match` or `if` expression in binop is parsed as statement

### DIFF
--- a/compiler/rustc_hir_typeck/src/coercion.rs
+++ b/compiler/rustc_hir_typeck/src/coercion.rs
@@ -1897,7 +1897,7 @@ impl<'tcx, 'exprs, E: AsCoercionSite> CoerceMany<'tcx, 'exprs, E> {
                     fcx.suggest_semicolon_at_end(cond_expr.span, &mut err);
                 }
             }
-        };
+        }
 
         // If this is due to an explicit `return`, suggest adding a return type.
         if let Some((fn_id, fn_decl)) = fcx.get_fn_decl(block_or_return_id)

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
@@ -1912,39 +1912,23 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             hir::StmtKind::Expr(ref expr) => {
                 // Check with expected type of `()`.
                 self.check_expr_has_type_or_error(expr, self.tcx.types.unit, |err| {
-                    if expr.can_have_side_effects() {
-                        let hir_id = stmt.hir_id;
-                        if let hir::ExprKind::Match(..) = expr.kind
-                            && let hir::Node::Block(b) = self.tcx.parent_hir_node(hir_id)
-                            && let mut stmts = b.stmts.iter().skip_while(|s| s.hir_id != hir_id)
-                            && let Some(_) = stmts.next() // The statement from the `match`
-                            && let Some(next) = match (stmts.next(), b.expr) {
-                                (Some(next), _) => match next.kind {
-                                    hir::StmtKind::Expr(next) | hir::StmtKind::Semi(next) => Some(next),
-                                    _ => None,
-                                },
-                                (None, Some(next)) => Some(next),
-                                _ => None,
-                            }
-                            && let hir::ExprKind::AddrOf(..)
-                                | hir::ExprKind::Unary(..)
-                                | hir::ExprKind::Err(_) = next.kind
-                        {
-                            // We have something like `match () { _ => true } && true`. Suggest
-                            // wrapping in parentheses. We find the statement or expression
-                            // following the `match` (`&& true`) and see if it is something that
-                            // can reasonably be interpreted as a binop following an expression.
-                            err.multipart_suggestion(
-                                "parentheses are required to parse this as an expression",
-                                vec![
-                                    (expr.span.shrink_to_lo(), "(".to_string()),
-                                    (expr.span.shrink_to_hi(), ")".to_string()),
-                                ],
-                                Applicability::MachineApplicable,
-                            );
-                        } else {
-                            self.suggest_semicolon_at_end(expr.span, err);
-                        }
+                    if self.is_next_stmt_expr_continuation(stmt.hir_id)
+                        && let hir::ExprKind::Match(..) | hir::ExprKind::If(..) = expr.kind
+                    {
+                        // We have something like `match () { _ => true } && true`. Suggest
+                        // wrapping in parentheses. We find the statement or expression
+                        // following the `match` (`&& true`) and see if it is something that
+                        // can reasonably be interpreted as a binop following an expression.
+                        err.multipart_suggestion(
+                            "parentheses are required to parse this as an expression",
+                            vec![
+                                (expr.span.shrink_to_lo(), "(".to_string()),
+                                (expr.span.shrink_to_hi(), ")".to_string()),
+                            ],
+                            Applicability::MachineApplicable,
+                        );
+                    } else if expr.can_have_side_effects() {
+                        self.suggest_semicolon_at_end(expr.span, err);
                     }
                 });
             }

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
@@ -1914,6 +1914,17 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 self.check_expr_has_type_or_error(expr, self.tcx.types.unit, |err| {
                     if expr.can_have_side_effects() {
                         self.suggest_semicolon_at_end(expr.span, err);
+                        if let hir::ExprKind::Match(..) = expr.kind {
+                            err.multipart_suggestion(
+                                "alternatively, parentheses are required to parse this as an \
+                                 expression",
+                                vec![
+                                    (expr.span.shrink_to_lo(), "(".to_string()),
+                                    (expr.span.shrink_to_hi(), ")".to_string()),
+                                ],
+                                Applicability::MaybeIncorrect,
+                            );
+                        }
                     }
                 });
             }

--- a/tests/ui/parser/expr-as-stmt-2.rs
+++ b/tests/ui/parser/expr-as-stmt-2.rs
@@ -7,4 +7,25 @@ fn foo(a: Option<u32>, b: Option<u32>) -> bool {
     if let Some(y) = a { true } else { false }
 }
 
-fn main() {}
+fn bar() -> bool {
+    false
+}
+
+fn main() {
+    if true { true } else { false } && true;
+    //~^ ERROR mismatched types
+    //~| ERROR mismatched types
+    if true { true } else { false } && if true { true } else { false };
+    //~^ ERROR mismatched types
+    //~| ERROR mismatched types
+    if true { true } else { false } if true { true } else { false };
+    //~^ ERROR mismatched types
+    //~| ERROR mismatched types
+    if true { bar() } else { bar() } && if true { bar() } else { bar() };
+    //~^ ERROR mismatched types
+    //~| ERROR mismatched types
+    if true { bar() } else { bar() } if true { bar() } else { bar() };
+    //~^ ERROR mismatched types
+    //~| ERROR mismatched types
+    let _ = if true { true } else { false } && true; // ok
+}

--- a/tests/ui/parser/expr-as-stmt-2.stderr
+++ b/tests/ui/parser/expr-as-stmt-2.stderr
@@ -7,6 +7,10 @@ LL |     if let Some(x) = a { true } else { false }
    |     |                    expected `()`, found `bool`
    |     expected this to be `()`
    |
+help: parentheses are required to parse this as an expression
+   |
+LL |     (if let Some(x) = a { true } else { false })
+   |     +                                          +
 help: you might have meant to return this value
    |
 LL |     if let Some(x) = a { return true; } else { false }
@@ -21,6 +25,10 @@ LL |     if let Some(x) = a { true } else { false }
    |     |                                  expected `()`, found `bool`
    |     expected this to be `()`
    |
+help: parentheses are required to parse this as an expression
+   |
+LL |     (if let Some(x) = a { true } else { false })
+   |     +                                          +
 help: you might have meant to return this value
    |
 LL |     if let Some(x) = a { true } else { return false; }
@@ -41,6 +49,152 @@ help: parentheses are required to parse this as an expression
 LL |     (if let Some(x) = a { true } else { false })
    |     +                                          +
 
-error: aborting due to 3 previous errors
+error[E0308]: mismatched types
+  --> $DIR/expr-as-stmt-2.rs:15:15
+   |
+LL |     if true { true } else { false } && true;
+   |     ----------^^^^-----------------
+   |     |         |
+   |     |         expected `()`, found `bool`
+   |     expected this to be `()`
+   |
+help: parentheses are required to parse this as an expression
+   |
+LL |     (if true { true } else { false }) && true;
+   |     +                               +
+
+error[E0308]: mismatched types
+  --> $DIR/expr-as-stmt-2.rs:15:29
+   |
+LL |     if true { true } else { false } && true;
+   |     ------------------------^^^^^--
+   |     |                       |
+   |     |                       expected `()`, found `bool`
+   |     expected this to be `()`
+   |
+help: parentheses are required to parse this as an expression
+   |
+LL |     (if true { true } else { false }) && true;
+   |     +                               +
+
+error[E0308]: mismatched types
+  --> $DIR/expr-as-stmt-2.rs:18:15
+   |
+LL |     if true { true } else { false } && if true { true } else { false };
+   |     ----------^^^^-----------------
+   |     |         |
+   |     |         expected `()`, found `bool`
+   |     expected this to be `()`
+   |
+help: parentheses are required to parse this as an expression
+   |
+LL |     (if true { true } else { false }) && if true { true } else { false };
+   |     +                               +
+
+error[E0308]: mismatched types
+  --> $DIR/expr-as-stmt-2.rs:18:29
+   |
+LL |     if true { true } else { false } && if true { true } else { false };
+   |     ------------------------^^^^^--
+   |     |                       |
+   |     |                       expected `()`, found `bool`
+   |     expected this to be `()`
+   |
+help: parentheses are required to parse this as an expression
+   |
+LL |     (if true { true } else { false }) && if true { true } else { false };
+   |     +                               +
+
+error[E0308]: mismatched types
+  --> $DIR/expr-as-stmt-2.rs:21:15
+   |
+LL |     if true { true } else { false } if true { true } else { false };
+   |     ----------^^^^-----------------
+   |     |         |
+   |     |         expected `()`, found `bool`
+   |     expected this to be `()`
+
+error[E0308]: mismatched types
+  --> $DIR/expr-as-stmt-2.rs:21:29
+   |
+LL |     if true { true } else { false } if true { true } else { false };
+   |     ------------------------^^^^^--
+   |     |                       |
+   |     |                       expected `()`, found `bool`
+   |     expected this to be `()`
+
+error[E0308]: mismatched types
+  --> $DIR/expr-as-stmt-2.rs:24:15
+   |
+LL |     if true { bar() } else { bar() } && if true { bar() } else { bar() };
+   |     ----------^^^^^-----------------
+   |     |         |
+   |     |         expected `()`, found `bool`
+   |     expected this to be `()`
+   |
+help: parentheses are required to parse this as an expression
+   |
+LL |     (if true { bar() } else { bar() }) && if true { bar() } else { bar() };
+   |     +                                +
+help: consider using a semicolon here
+   |
+LL |     if true { bar() } else { bar() }; && if true { bar() } else { bar() };
+   |                                     +
+
+error[E0308]: mismatched types
+  --> $DIR/expr-as-stmt-2.rs:24:30
+   |
+LL |     if true { bar() } else { bar() } && if true { bar() } else { bar() };
+   |     -------------------------^^^^^--
+   |     |                        |
+   |     |                        expected `()`, found `bool`
+   |     expected this to be `()`
+   |
+help: parentheses are required to parse this as an expression
+   |
+LL |     (if true { bar() } else { bar() }) && if true { bar() } else { bar() };
+   |     +                                +
+help: consider using a semicolon here
+   |
+LL |     if true { bar() } else { bar() }; && if true { bar() } else { bar() };
+   |                                     +
+
+error[E0308]: mismatched types
+  --> $DIR/expr-as-stmt-2.rs:27:15
+   |
+LL |     if true { bar() } else { bar() } if true { bar() } else { bar() };
+   |     ----------^^^^^-----------------
+   |     |         |
+   |     |         expected `()`, found `bool`
+   |     expected this to be `()`
+   |
+help: consider using a semicolon here
+   |
+LL |     if true { bar(); } else { bar() } if true { bar() } else { bar() };
+   |                    +
+help: consider using a semicolon here
+   |
+LL |     if true { bar() } else { bar() }; if true { bar() } else { bar() };
+   |                                     +
+
+error[E0308]: mismatched types
+  --> $DIR/expr-as-stmt-2.rs:27:30
+   |
+LL |     if true { bar() } else { bar() } if true { bar() } else { bar() };
+   |     -------------------------^^^^^--
+   |     |                        |
+   |     |                        expected `()`, found `bool`
+   |     expected this to be `()`
+   |
+help: consider using a semicolon here
+   |
+LL |     if true { bar() } else { bar(); } if true { bar() } else { bar() };
+   |                                   +
+help: consider using a semicolon here
+   |
+LL |     if true { bar() } else { bar() }; if true { bar() } else { bar() };
+   |                                     +
+
+error: aborting due to 13 previous errors
 
 For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/parser/expr-as-stmt.fixed
+++ b/tests/ui/parser/expr-as-stmt.fixed
@@ -66,7 +66,7 @@ fn asteroids() -> impl FnOnce() -> bool {
 
 // https://github.com/rust-lang/rust/issues/105179
 fn r#match() -> i32 {
-    (match () { () => 1 }) + match () { () => 1 } //~ ERROR expected expression, found `+`
+    ((match () { () => 1 })) + match () { () => 1 } //~ ERROR expected expression, found `+`
     //~^ ERROR mismatched types
 }
 
@@ -76,4 +76,13 @@ fn r#unsafe() -> i32 {
     //~^ ERROR mismatched types
 }
 
+// https://github.com/rust-lang/rust/issues/88727
+fn matches() -> bool {
+    (match () { _ => true }) && match () { _ => true }; //~ ERROR mismatched types
+    (match () { _ => true }) && match () { _ => true }; //~ ERROR mismatched types
+    //~^ ERROR expected `;`, found keyword `match`
+    (match () { _ => true }) && true; //~ ERROR mismatched types
+    ((match () { _ => true })) && true //~ ERROR mismatched types
+    //~^ ERROR mismatched types
+}
 fn main() {}

--- a/tests/ui/parser/expr-as-stmt.rs
+++ b/tests/ui/parser/expr-as-stmt.rs
@@ -76,4 +76,13 @@ fn r#unsafe() -> i32 {
     //~^ ERROR mismatched types
 }
 
+// https://github.com/rust-lang/rust/issues/88727
+fn matches() -> bool {
+    match () { _ => true } && match () { _ => true }; //~ ERROR mismatched types
+    match () { _ => true } && match () { _ => true } //~ ERROR mismatched types
+    //~^ ERROR expected `;`, found keyword `match`
+    match () { _ => true } && true; //~ ERROR mismatched types
+    match () { _ => true } && true //~ ERROR mismatched types
+    //~^ ERROR mismatched types
+}
 fn main() {}

--- a/tests/ui/parser/expr-as-stmt.stderr
+++ b/tests/ui/parser/expr-as-stmt.stderr
@@ -77,6 +77,15 @@ help: parentheses are required to parse this as an expression
 LL |     (unsafe { 1 }) + unsafe { 1 }
    |     +            +
 
+error: expected `;`, found keyword `match`
+  --> $DIR/expr-as-stmt.rs:82:53
+   |
+LL |     match () { _ => true } && match () { _ => true }
+   |                                                     ^ help: add `;` here
+LL |
+LL |     match () { _ => true } && true;
+   |     ----- unexpected token
+
 error[E0308]: mismatched types
   --> $DIR/expr-as-stmt.rs:64:7
    |
@@ -229,11 +238,7 @@ error[E0308]: mismatched types
 LL |     match () { () => 1 } + match () { () => 1 }
    |     ^^^^^^^^^^^^^^^^^^^^ expected `()`, found integer
    |
-help: consider using a semicolon here
-   |
-LL |     match () { () => 1 }; + match () { () => 1 }
-   |                         +
-help: alternatively, parentheses are required to parse this as an expression
+help: parentheses are required to parse this as an expression
    |
 LL |     (match () { () => 1 }) + match () { () => 1 }
    |     +                    +
@@ -249,7 +254,65 @@ help: you might have meant to return this value
 LL |     unsafe { return 1; } + unsafe { 1 }
    |              ++++++  +
 
-error: aborting due to 22 previous errors
+error[E0308]: mismatched types
+  --> $DIR/expr-as-stmt.rs:81:5
+   |
+LL |     match () { _ => true } && match () { _ => true };
+   |     ^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found `bool`
+   |
+help: parentheses are required to parse this as an expression
+   |
+LL |     (match () { _ => true }) && match () { _ => true };
+   |     +                      +
+
+error[E0308]: mismatched types
+  --> $DIR/expr-as-stmt.rs:82:5
+   |
+LL |     match () { _ => true } && match () { _ => true }
+   |     ^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found `bool`
+   |
+help: parentheses are required to parse this as an expression
+   |
+LL |     (match () { _ => true }) && match () { _ => true }
+   |     +                      +
+
+error[E0308]: mismatched types
+  --> $DIR/expr-as-stmt.rs:84:5
+   |
+LL |     match () { _ => true } && true;
+   |     ^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found `bool`
+   |
+help: parentheses are required to parse this as an expression
+   |
+LL |     (match () { _ => true }) && true;
+   |     +                      +
+
+error[E0308]: mismatched types
+  --> $DIR/expr-as-stmt.rs:85:5
+   |
+LL |     match () { _ => true } && true
+   |     ^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found `bool`
+   |
+help: parentheses are required to parse this as an expression
+   |
+LL |     (match () { _ => true }) && true
+   |     +                      +
+
+error[E0308]: mismatched types
+  --> $DIR/expr-as-stmt.rs:85:28
+   |
+LL | fn matches() -> bool {
+   |                 ---- expected `bool` because of return type
+...
+LL |     match () { _ => true } && true
+   |                            ^^^^^^^ expected `bool`, found `&&bool`
+   |
+help: parentheses are required to parse this as an expression
+   |
+LL |     (match () { _ => true }) && true
+   |     +                      +
+
+error: aborting due to 28 previous errors
 
 Some errors have detailed explanations: E0308, E0600, E0614.
 For more information about an error, try `rustc --explain E0308`.

--- a/tests/ui/parser/expr-as-stmt.stderr
+++ b/tests/ui/parser/expr-as-stmt.stderr
@@ -227,9 +227,16 @@ error[E0308]: mismatched types
   --> $DIR/expr-as-stmt.rs:69:5
    |
 LL |     match () { () => 1 } + match () { () => 1 }
-   |     ^^^^^^^^^^^^^^^^^^^^- help: consider using a semicolon here
-   |     |
-   |     expected `()`, found integer
+   |     ^^^^^^^^^^^^^^^^^^^^ expected `()`, found integer
+   |
+help: consider using a semicolon here
+   |
+LL |     match () { () => 1 }; + match () { () => 1 }
+   |                         +
+help: alternatively, parentheses are required to parse this as an expression
+   |
+LL |     (match () { () => 1 }) + match () { () => 1 }
+   |     +                    +
 
 error[E0308]: mismatched types
   --> $DIR/expr-as-stmt.rs:75:14

--- a/tests/ui/suggestions/match-needing-semi.stderr
+++ b/tests/ui/suggestions/match-needing-semi.stderr
@@ -28,9 +28,20 @@ LL | |         4 => 1,
 LL | |         3 => 2,
 LL | |         _ => 2
 LL | |     }
-   | |     ^- help: consider using a semicolon here
-   | |_____|
-   |       expected `()`, found integer
+   | |_____^ expected `()`, found integer
+   |
+help: consider using a semicolon here
+   |
+LL |     };
+   |      +
+help: alternatively, parentheses are required to parse this as an expression
+   |
+LL ~     (match 3 {
+LL |         4 => 1,
+LL |         3 => 2,
+LL |         _ => 2
+LL ~     })
+   |
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/suggestions/match-needing-semi.stderr
+++ b/tests/ui/suggestions/match-needing-semi.stderr
@@ -28,20 +28,9 @@ LL | |         4 => 1,
 LL | |         3 => 2,
 LL | |         _ => 2
 LL | |     }
-   | |_____^ expected `()`, found integer
-   |
-help: consider using a semicolon here
-   |
-LL |     };
-   |      +
-help: alternatively, parentheses are required to parse this as an expression
-   |
-LL ~     (match 3 {
-LL |         4 => 1,
-LL |         3 => 2,
-LL |         _ => 2
-LL ~     })
-   |
+   | |     ^- help: consider using a semicolon here
+   | |_____|
+   |       expected `()`, found integer
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
```
error[E0308]: mismatched types
  --> $DIR/expr-as-stmt.rs:81:5
   |
LL |     match () { _ => true } && match () { _ => true };
   |     ^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found `bool`
   |
help: parentheses are required to parse this as an expression
   |
LL |     (match () { _ => true }) && match () { _ => true };
   |     +                      +
```

Address the common case from rust-lang/rust#88727. The original parse error is still outstanding, but the cases brought up in the thread are resolved.