### PR TITLE
Suggest method name with maybe ty mismatch

### DIFF
--- a/compiler/rustc_hir_typeck/src/method/mod.rs
+++ b/compiler/rustc_hir_typeck/src/method/mod.rs
@@ -117,7 +117,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             Err(Ambiguity(..)) => true,
             Err(PrivateMatch(..)) => false,
             Err(IllegalSizedBound { .. }) => true,
-            Err(BadReturnType) => false,
+            Err(BadReturnType) => true,
             Err(ErrorReported(_)) => false,
         }
     }

--- a/tests/ui/async-await/dont-suggest-await-on-method-return-mismatch.stderr
+++ b/tests/ui/async-await/dont-suggest-await-on-method-return-mismatch.stderr
@@ -3,6 +3,11 @@ error[E0599]: no method named `test` found for opaque type `impl Future<Output =
    |
 LL |     let x: u32 = foo().test();
    |                        ^^^^ method not found in `impl Future<Output = A>`
+   |
+help: consider `await`ing on the `Future` and calling the method on its `Output`
+   |
+LL |     let x: u32 = foo().await.test();
+   |                        ++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/privacy/private-field-ty-err.stderr
+++ b/tests/ui/privacy/private-field-ty-err.stderr
@@ -3,6 +3,11 @@ error[E0616]: field `len` of struct `Foo` is private
    |
 LL |     if x.len {
    |          ^^^ private field
+   |
+help: a method `len` also exists, call it with parentheses
+   |
+LL |     if x.len() {
+   |             ++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/typeck/suggest-method-name-with-maybe-ty-mismatch-146008.rs
+++ b/tests/ui/typeck/suggest-method-name-with-maybe-ty-mismatch-146008.rs
@@ -1,0 +1,14 @@
+struct LlamaModel;
+
+impl LlamaModel {
+    fn chat_template(&self) -> Result<&str, ()> {
+        todo!()
+    }
+}
+
+fn template_from_str(_x: &str) {}
+
+fn main() {
+    let model = LlamaModel;
+    template_from_str(&model.chat_template); //~ ERROR attempted to take value of method `chat_template` on type `LlamaModel`
+}

--- a/tests/ui/typeck/suggest-method-name-with-maybe-ty-mismatch-146008.stderr
+++ b/tests/ui/typeck/suggest-method-name-with-maybe-ty-mismatch-146008.stderr
@@ -1,0 +1,14 @@
+error[E0615]: attempted to take value of method `chat_template` on type `LlamaModel`
+  --> $DIR/suggest-method-name-with-maybe-ty-mismatch-146008.rs:13:30
+   |
+LL |     template_from_str(&model.chat_template);
+   |                              ^^^^^^^^^^^^^ method, not a field
+   |
+help: use parentheses to call the method
+   |
+LL |     template_from_str(&model.chat_template());
+   |                                           ++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0615`.


### PR DESCRIPTION
Fixes rust-lang/rust#146008

I think it's ok to suggest method name even when the return ty mismatch, since we only reporting in `Applicability::MaybeIncorrect`, user may add `()` and continue to fix following errors.

r? @estebank 