### PR TITLE
std: fix `SplitPaths` regression

### DIFF
--- a/tests/ui/type-alias-impl-trait/split-paths-may-dangle.rs
+++ b/tests/ui/type-alias-impl-trait/split-paths-may-dangle.rs
@@ -1,0 +1,11 @@
+// Regression test for issue #146045 - ensure that the TAIT `SplitPaths` does not
+// require the borrowed string to be live.
+//@ check-pass
+//@ edition:2015
+
+pub fn repro() -> Option<std::path::PathBuf> {
+    let unparsed = std::ffi::OsString::new();
+    std::env::split_paths(&unparsed).next()
+}
+
+fn main() {}


### PR DESCRIPTION
Fixes rust-lang/rust#146045 by defining the TAIT more precisely, ensuring that `'a` does not need to be live on drop.