### PR TITLE
Improve diagnostic for Cow::to_owned() usage.

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
@@ -3426,6 +3426,25 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
                     Applicability::MaybeIncorrect,
                 );
             }
+            if let Some(cow_did) = tcx.get_diagnostic_item(sym::Cow)
+                && let ty::Adt(adt_def, _) = return_ty.kind()
+                && adt_def.did() == cow
+            {
+                if let Ok(snippet) = tcx.sess.source_map().span_to_snippet(return_span) {
+                    if let Some(pos) = snippet.rfind(".to_owned") {
+                        let byte_pos = BytePos(pos as u32 + 1u32);
+                        let to_owned_span = return_span.with_hi(return_span.lo() + byte_pos);
+                        err.span_suggestion_short(
+                            to_owned_span.shrink_to_hi(),
+                            "try using `.into_owned()` if you meant to convert 
+                            a `Cow<'_, T>` to an owned `T`",
+                            "in",
+                            Applicability::MaybeIncorrect,
+                        );
+                    }
+                }
+            }
+                            
         }
 
         Err(err)

--- a/tests/ui/errors/cow-into-owned-suggestion.stderr
+++ b/tests/ui/errors/cow-into-owned-suggestion.stderr
@@ -1,0 +1,17 @@
+error[E0515]: cannot return value referencing function parameter `x`
+  --> $DIR/cow-to-owned.rs:4:64
+   |
+LL |     _ = std::env::var_os("RUST_LOG").map_or("warn".into(), |x| x.to_string_lossy().to_owned());
+   |                                                                -^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                                                |
+   |                                                                returns a value referencing data owned by the current function
+   |                                                                `x` is borrowed here
+   |
+help: try using `.into_owned()` if you meant to convert a `Cow<'_, T>` to an owned `T`
+   |
+LL |     _ = std::env::var_os("RUST_LOG").map_or("warn".into(), |x| x.to_string_lossy().into_owned());
+   |                                                                                    ++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0515`.

--- a/tests/ui/suggestions/cow-into-owned-suggestion.rs
+++ b/tests/ui/suggestions/cow-into-owned-suggestion.rs
@@ -1,0 +1,26 @@
+//! Regression test for: https://github.com/rust-lang/rust/issues/144792
+
+fn test_cow_suggestion() -> String {
+    let os_string = std::ffi::OsString::from("test");
+    os_string.to_string_lossy().to_owned()
+    //~^ ERROR use of `.to_owned()` on `Cow`
+    //~| HELP try using `.into_owned()`
+}
+
+// Test multiple Cow scenarios
+fn test_cow_from_str() -> String {
+    let s = "hello";
+    let cow = std::borrow::Cow::from(s);
+    cow.to_owned() // Should suggest into_owned()
+    //~^ ERROR use of `.to_owned()` on `Cow`
+    //~| HELP try using `.into_owned()`
+}
+
+// Test with different Cow types
+fn test_cow_bytes() -> Vec<u8> {
+    let bytes = b"hello";
+    let cow = std::borrow::Cow::from(&bytes[..]);
+    cow.to_owned() // Should suggest into_owned()
+    //~^ ERROR use of `.to_owned()` on `Cow`
+    //~| HELP try using `.into_owned()`
+}


### PR DESCRIPTION
Fixes  rust-lang/rust#144792 

Guide users from Cow::to_owned() to Cow::into_owned() on lifetime error.
Improve diagnostic help for Cow to owned conversions.