### PR TITLE
Add compiler error when trying to use concat metavar expr in repetitions

### DIFF
--- a/compiler/rustc_expand/src/mbe/transcribe.rs
+++ b/compiler/rustc_expand/src/mbe/transcribe.rs
@@ -556,7 +556,12 @@ fn metavar_expr_concat<'tx>(
                         };
                         match &named_matches[*curr_idx] {
                             // FIXME(c410-f3r) Nested repetitions are unimplemented
-                            MatchedSeq(_) => unimplemented!(),
+                            MatchedSeq(_) => {
+                                return Err(dcx.struct_span_err(
+                                    ident.span,
+                                    "nested repetitions with `${concat(...)}` metavariable expressions are not yet supported",
+                                ));
+                            }
                             MatchedSingle(pnr) => extract_symbol_from_pnr(dcx, pnr, ident.span)?,
                         }
                     }

--- a/tests/crashes/140479.rs
+++ b/tests/crashes/140479.rs
@@ -1,5 +1,0 @@
-//@ known-bug: #140479
-macro_rules! a { ( $( { $ [ $b:c ] } )) => ( $(${ concat(d, $b)} ))}
-fn e() {
-    a!({})
-}

--- a/tests/ui/macros/macro-metavar-expr-concat/in-repetition.rs
+++ b/tests/ui/macros/macro-metavar-expr-concat/in-repetition.rs
@@ -1,0 +1,21 @@
+// issue: <https://github.com/rust-lang/rust/issues/140479>
+// Ensure a proper compiler error, instead of an ICE occurs.
+// FIXME(macro_metavar_expr_concat): this error message could be improved
+#![feature(macro_metavar_expr_concat)]
+
+macro_rules! InRepetition {
+    (
+        $(
+            $($arg:ident),+
+        )+
+     ) => {
+        $(
+            $(
+                ${concat(_, $arg)} //~ ERROR nested repetitions with `${concat(...)}` metavariable expressions are not yet supported
+            )*
+        )*
+    };
+}
+InRepetition!(other);
+
+fn main() {}

--- a/tests/ui/macros/macro-metavar-expr-concat/in-repetition.stderr
+++ b/tests/ui/macros/macro-metavar-expr-concat/in-repetition.stderr
@@ -1,0 +1,8 @@
+error: nested repetitions with `${concat(...)}` metavariable expressions are not yet supported
+  --> $DIR/in-repetition.rs:14:30
+   |
+LL |                 ${concat(_, $arg)}
+   |                              ^^^
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
## Disclaimer
This is my first PR to rust, so if I missed/could improve something about this PR, please excuse and tell me!
## The improvement
The [metavar_expr_concat feature](https://github.com/rust-lang/rust/issues/124225) currently does not seem to support nested repetitions, and throws an ICE without much explanation if the relevant code path is hit.
This PR adds a draft compiler error that attempts to explain the issue. I am not 100% sure what all the ways of triggering this error are, so the message is currently pretty generic, please do correct me if there's something wrong with it or it could be improved.

Thank you for you time!

Fixes rust-lang/rust#140479.
