### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/compiler/rustc_hir_typeck/src/method/mod.rs
+++ b/compiler/rustc_hir_typeck/src/method/mod.rs
@@ -117,7 +117,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             Err(Ambiguity(..)) => true,
             Err(PrivateMatch(..)) => false,
             Err(IllegalSizedBound { .. }) => true,
-            Err(BadReturnType) => false,
+            Err(BadReturnType) => true,
             Err(ErrorReported(_)) => false,
         }
     }

--- a/library/core/src/ops/range.rs
+++ b/library/core/src/ops/range.rs
@@ -742,6 +742,8 @@ impl<T: Copy> Bound<&T> {
     /// # Examples
     ///
     /// ```
+    /// #![feature(bound_copied)]
+    ///
     /// use std::ops::Bound::*;
     /// use std::ops::RangeBounds;
     ///

--- a/library/core/src/ops/range.rs
+++ b/library/core/src/ops/range.rs
@@ -751,6 +751,7 @@ impl<T: Copy> Bound<&T> {
     /// assert_eq!((1..12).start_bound().copied(), Included(1));
     /// ```
     #[unstable(feature = "bound_copied", issue = "145966")]
+    #[must_use]
     pub fn copied(self) -> Bound<T> {
         match self {
             Bound::Unbounded => Bound::Unbounded,
@@ -769,8 +770,11 @@ impl<T: Clone> Bound<&T> {
     /// use std::ops::Bound::*;
     /// use std::ops::RangeBounds;
     ///
-    /// assert_eq!((1..12).start_bound(), Included(&1));
-    /// assert_eq!((1..12).start_bound().cloned(), Included(1));
+    /// let a1 = String::from("a");
+    /// let (a2, a3, a4) = (a1.clone(), a1.clone(), a1.clone());
+    ///
+    /// assert_eq!(Included(&a1), (a2..).start_bound());
+    /// assert_eq!(Included(a3), (a4..).start_bound().cloned());
     /// ```
     #[must_use = "`self` will be dropped if the result is not used"]
     #[stable(feature = "bound_cloned", since = "1.55.0")]

--- a/library/core/src/ops/range.rs
+++ b/library/core/src/ops/range.rs
@@ -736,6 +736,28 @@ impl<T> Bound<T> {
     }
 }
 
+impl<T: Copy> Bound<&T> {
+    /// Map a `Bound<&T>` to a `Bound<T>` by copying the contents of the bound.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::ops::Bound::*;
+    /// use std::ops::RangeBounds;
+    ///
+    /// assert_eq!((1..12).start_bound(), Included(&1));
+    /// assert_eq!((1..12).start_bound().copied(), Included(1));
+    /// ```
+    #[unstable(feature = "bound_copied", issue = "145966")]
+    pub fn copied(self) -> Bound<T> {
+        match self {
+            Bound::Unbounded => Bound::Unbounded,
+            Bound::Included(x) => Bound::Included(*x),
+            Bound::Excluded(x) => Bound::Excluded(*x),
+        }
+    }
+}
+
 impl<T: Clone> Bound<&T> {
     /// Map a `Bound<&T>` to a `Bound<T>` by cloning the contents of the bound.
     ///

--- a/library/std/tests/floats/f32.rs
+++ b/library/std/tests/floats/f32.rs
@@ -79,8 +79,8 @@ fn test_log() {
     let nan: f32 = f32::NAN;
     let inf: f32 = f32::INFINITY;
     let neg_inf: f32 = f32::NEG_INFINITY;
-    assert_approx_eq!(10.0f32.log(10.0), 1.0);
-    assert_approx_eq!(2.3f32.log(3.5), 0.664858);
+    assert_approx_eq!(10.0f32.log(10.0), 1.0, APPROX_DELTA);
+    assert_approx_eq!(2.3f32.log(3.5), 0.664858, APPROX_DELTA);
     assert_approx_eq!(1.0f32.exp().log(1.0f32.exp()), 1.0, APPROX_DELTA);
     assert!(1.0f32.log(1.0).is_nan());
     assert!(1.0f32.log(-13.9).is_nan());

--- a/tests/ui/async-await/dont-suggest-await-on-method-return-mismatch.stderr
+++ b/tests/ui/async-await/dont-suggest-await-on-method-return-mismatch.stderr
@@ -3,6 +3,11 @@ error[E0599]: no method named `test` found for opaque type `impl Future<Output =
    |
 LL |     let x: u32 = foo().test();
    |                        ^^^^ method not found in `impl Future<Output = A>`
+   |
+help: consider `await`ing on the `Future` and calling the method on its `Output`
+   |
+LL |     let x: u32 = foo().await.test();
+   |                        ++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/privacy/private-field-ty-err.stderr
+++ b/tests/ui/privacy/private-field-ty-err.stderr
@@ -3,6 +3,11 @@ error[E0616]: field `len` of struct `Foo` is private
    |
 LL |     if x.len {
    |          ^^^ private field
+   |
+help: a method `len` also exists, call it with parentheses
+   |
+LL |     if x.len() {
+   |             ++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/typeck/suggest-method-name-with-maybe-ty-mismatch-146008.rs
+++ b/tests/ui/typeck/suggest-method-name-with-maybe-ty-mismatch-146008.rs
@@ -1,0 +1,14 @@
+struct LlamaModel;
+
+impl LlamaModel {
+    fn chat_template(&self) -> Result<&str, ()> {
+        todo!()
+    }
+}
+
+fn template_from_str(_x: &str) {}
+
+fn main() {
+    let model = LlamaModel;
+    template_from_str(&model.chat_template); //~ ERROR attempted to take value of method `chat_template` on type `LlamaModel`
+}

--- a/tests/ui/typeck/suggest-method-name-with-maybe-ty-mismatch-146008.stderr
+++ b/tests/ui/typeck/suggest-method-name-with-maybe-ty-mismatch-146008.stderr
@@ -1,0 +1,14 @@
+error[E0615]: attempted to take value of method `chat_template` on type `LlamaModel`
+  --> $DIR/suggest-method-name-with-maybe-ty-mismatch-146008.rs:13:30
+   |
+LL |     template_from_str(&model.chat_template);
+   |                              ^^^^^^^^^^^^^ method, not a field
+   |
+help: use parentheses to call the method
+   |
+LL |     template_from_str(&model.chat_template());
+   |                                           ++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0615`.


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#145968 (Add `Bound::copied`)
 - rust-lang/rust#146046 (Suggest method name with maybe ty mismatch)
 - rust-lang/rust#146051 (Change std f32 test to pass under Miri)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=145968,146046,146051)
<!-- homu-ignore:end -->