### PR TITLE
rustdoc-search: skip loading unneeded fnData

### DIFF
--- a/src/librustdoc/html/static/js/rustdoc.d.ts
+++ b/src/librustdoc/html/static/js/rustdoc.d.ts
@@ -289,7 +289,7 @@ declare namespace rustdoc {
         exactModulePath: string,
         entry: EntryData?,
         path: PathData?,
-        type: FunctionData?,
+        functionData: FunctionData?,
         deprecated: boolean,
         parent: { path: PathData, name: string}?,
     }


### PR DESCRIPTION
Fixes rust-lang/rust#146063 (probably)

Based on the test I ran, it seems like most of the CPU time is being spent loading function signature data. This PR should avoid that.

https://notriddle.com/rustdoc-html-demo-12/skip-loading-function-data/doc/std/index.html
