### PR TITLE
changes for vxworks

### DIFF
--- a/library/std/src/fs/tests.rs
+++ b/library/std/src/fs/tests.rs
@@ -716,6 +716,7 @@ fn recursive_mkdir_failure() {
 }
 
 #[test]
+#[cfg_attr(target_os = "vxworks", ignore)]
 fn concurrent_recursive_mkdir() {
     for _ in 0..100 {
         let dir = tmpdir();
@@ -801,8 +802,10 @@ fn recursive_rmdir_of_file_fails() {
     let canary = tmpdir.join("do_not_delete");
     check!(check!(File::create(&canary)).write(b"foo"));
     let result = fs::remove_dir_all(&canary);
-    #[cfg(unix)]
+    #[cfg(all(not(target_os = "vxworks"),unix))]
     error!(result, "Not a directory");
+    #[cfg(target_os = "vxworks")]
+    error!(result, "not a directory");
     #[cfg(windows)]
     error!(result, 267); // ERROR_DIRECTORY - The directory name is invalid.
     assert!(result.is_err());

--- a/library/std/src/os/unix/net/tests.rs
+++ b/library/std/src/os/unix/net/tests.rs
@@ -21,7 +21,7 @@ macro_rules! or_panic {
 }
 
 #[test]
-#[cfg_attr(target_os = "android", ignore)] // Android SELinux rules prevent creating Unix sockets
+#[cfg_attr(any(target_os = "vxworks", target_os = "android"), ignore)]
 fn basic() {
     let dir = tmpdir();
     let socket_path = dir.path().join("sock");
@@ -49,6 +49,7 @@ fn basic() {
 }
 
 #[test]
+#[cfg_attr(target_os = "vxworks", ignore)]
 fn vectored() {
     let (mut s1, mut s2) = or_panic!(UnixStream::pair());
 
@@ -69,6 +70,7 @@ fn vectored() {
 }
 
 #[test]
+#[cfg_attr(target_os = "vxworks", ignore)]
 fn pair() {
     let msg1 = b"hello";
     let msg2 = b"world!";
@@ -92,7 +94,7 @@ fn pair() {
 }
 
 #[test]
-#[cfg_attr(target_os = "android", ignore)] // Android SELinux rules prevent creating Unix sockets
+#[cfg_attr(any(target_os = "vxworks", target_os = "android"), ignore)]
 fn try_clone() {
     let dir = tmpdir();
     let socket_path = dir.path().join("sock");
@@ -119,7 +121,7 @@ fn try_clone() {
 }
 
 #[test]
-#[cfg_attr(target_os = "android", ignore)] // Android SELinux rules prevent creating Unix sockets
+#[cfg_attr(any(target_os = "vxworks", target_os = "android"), ignore)]
 fn iter() {
     let dir = tmpdir();
     let socket_path = dir.path().join("sock");
@@ -142,6 +144,7 @@ fn iter() {
 }
 
 #[test]
+#[cfg_attr(target_os = "vxworks", ignore)]
 fn long_path() {
     let dir = tmpdir();
     let socket_path = dir.path().join(
@@ -169,7 +172,7 @@ fn long_path() {
 
 #[test]
 #[cfg(not(target_os = "nto"))]
-#[cfg_attr(target_os = "android", ignore)] // Android SELinux rules prevent creating Unix sockets
+#[cfg_attr(any(target_os = "vxworks", target_os = "android"), ignore)]
 fn timeouts() {
     let dir = tmpdir();
     let socket_path = dir.path().join("sock");
@@ -197,7 +200,7 @@ fn timeouts() {
 }
 
 #[test]
-#[cfg_attr(target_os = "android", ignore)] // Android SELinux rules prevent creating Unix sockets
+#[cfg_attr(any(target_os = "vxworks", target_os = "android"), ignore)]
 fn test_read_timeout() {
     let dir = tmpdir();
     let socket_path = dir.path().join("sock");
@@ -217,7 +220,7 @@ fn test_read_timeout() {
 }
 
 #[test]
-#[cfg_attr(target_os = "android", ignore)] // Android SELinux rules prevent creating Unix sockets
+#[cfg_attr(any(target_os = "vxworks", target_os = "android"), ignore)]
 fn test_read_with_timeout() {
     let dir = tmpdir();
     let socket_path = dir.path().join("sock");
@@ -245,7 +248,7 @@ fn test_read_with_timeout() {
 // Ensure the `set_read_timeout` and `set_write_timeout` calls return errors
 // when passed zero Durations
 #[test]
-#[cfg_attr(target_os = "android", ignore)] // Android SELinux rules prevent creating Unix sockets
+#[cfg_attr(any(target_os = "vxworks", target_os = "android"), ignore)]
 fn test_unix_stream_timeout_zero_duration() {
     let dir = tmpdir();
     let socket_path = dir.path().join("sock");
@@ -265,7 +268,7 @@ fn test_unix_stream_timeout_zero_duration() {
 }
 
 #[test]
-#[cfg_attr(target_os = "android", ignore)] // Android SELinux rules prevent creating Unix sockets
+#[cfg_attr(any(target_os = "vxworks", target_os = "android"), ignore)]
 fn test_unix_datagram() {
     let dir = tmpdir();
     let path1 = dir.path().join("sock1");
@@ -282,7 +285,7 @@ fn test_unix_datagram() {
 }
 
 #[test]
-#[cfg_attr(target_os = "android", ignore)] // Android SELinux rules prevent creating Unix sockets
+#[cfg_attr(any(target_os = "vxworks", target_os = "android"), ignore)]
 fn test_unnamed_unix_datagram() {
     let dir = tmpdir();
     let path1 = dir.path().join("sock1");
@@ -300,7 +303,7 @@ fn test_unnamed_unix_datagram() {
 }
 
 #[test]
-#[cfg_attr(target_os = "android", ignore)] // Android SELinux rules prevent creating Unix sockets
+#[cfg_attr(any(target_os = "vxworks", target_os = "android"), ignore)]
 fn test_unix_datagram_connect_to_recv_addr() {
     let dir = tmpdir();
     let path1 = dir.path().join("sock1");
@@ -325,7 +328,7 @@ fn test_unix_datagram_connect_to_recv_addr() {
 }
 
 #[test]
-#[cfg_attr(target_os = "android", ignore)] // Android SELinux rules prevent creating Unix sockets
+#[cfg_attr(any(target_os = "vxworks", target_os = "android"), ignore)]
 fn test_connect_unix_datagram() {
     let dir = tmpdir();
     let path1 = dir.path().join("sock1");
@@ -352,7 +355,7 @@ fn test_connect_unix_datagram() {
 }
 
 #[test]
-#[cfg_attr(target_os = "android", ignore)] // Android SELinux rules prevent creating Unix sockets
+#[cfg_attr(any(target_os = "vxworks", target_os = "android"), ignore)]
 fn test_unix_datagram_recv() {
     let dir = tmpdir();
     let path1 = dir.path().join("sock1");
@@ -370,6 +373,7 @@ fn test_unix_datagram_recv() {
 }
 
 #[test]
+#[cfg_attr(target_os = "vxworks", ignore)]
 fn datagram_pair() {
     let msg1 = b"hello";
     let msg2 = b"world!";
@@ -395,7 +399,7 @@ fn datagram_pair() {
 // Ensure the `set_read_timeout` and `set_write_timeout` calls return errors
 // when passed zero Durations
 #[test]
-#[cfg_attr(target_os = "android", ignore)] // Android SELinux rules prevent creating Unix sockets
+#[cfg_attr(any(target_os = "vxworks", target_os = "android"), ignore)]
 fn test_unix_datagram_timeout_zero_duration() {
     let dir = tmpdir();
     let path = dir.path().join("sock");
@@ -549,7 +553,7 @@ fn test_abstract_no_pathname_and_not_unnamed() {
 }
 
 #[test]
-#[cfg_attr(target_os = "android", ignore)] // Android SELinux rules prevent creating Unix sockets
+#[cfg_attr(any(target_os = "vxworks", target_os = "android"), ignore)]
 fn test_unix_stream_peek() {
     let (txdone, rxdone) = crate::sync::mpsc::channel();
 
@@ -582,7 +586,7 @@ fn test_unix_stream_peek() {
 }
 
 #[test]
-#[cfg_attr(target_os = "android", ignore)] // Android SELinux rules prevent creating Unix sockets
+#[cfg_attr(any(target_os = "vxworks", target_os = "android"), ignore)]
 fn test_unix_datagram_peek() {
     let dir = tmpdir();
     let path1 = dir.path().join("sock");
@@ -607,7 +611,7 @@ fn test_unix_datagram_peek() {
 }
 
 #[test]
-#[cfg_attr(target_os = "android", ignore)] // Android SELinux rules prevent creating Unix sockets
+#[cfg_attr(any(target_os = "vxworks", target_os = "android"), ignore)]
 fn test_unix_datagram_peek_from() {
     let dir = tmpdir();
     let path1 = dir.path().join("sock");


### PR DESCRIPTION
### Summary

This PR improves support for the `vxworks` target in the Rust standard library by fixing platform-specific issues and ensuring better compatibility with VxWorks.

These changes are isolated to `vxworks` and do not affect other platforms.

### Notes

Tested manually on a VxWorks environment. Feedback on potential edge cases or additional tests would be appreciated.
