### PR TITLE
fix a constness ordering bug in rustfmt

### DIFF
--- a/src/tools/rustfmt/src/items.rs
+++ b/src/tools/rustfmt/src/items.rs
@@ -1175,8 +1175,8 @@ pub(crate) fn format_trait(
     let mut result = String::with_capacity(128);
     let header = format!(
         "{}{}{}{}trait ",
-        format_constness(constness),
         format_visibility(context, &item.vis),
+        format_constness(constness),
         format_safety(safety),
         format_auto(is_auto),
     );


### PR DESCRIPTION
Normally, changes to rustfmt go into the separate repo. But, in this case, the bug is introduced in a local change and therefore isn't present in the rustfmt repo.

Related to: https://github.com/rust-lang/rust/pull/146071
Fixes https://github.com/rust-lang/rustfmt/issues/6619.
