### PR TITLE
arbitrary_self_types: Split the Autoderef chain

### DIFF
--- a/compiler/rustc_codegen_cranelift/example/arbitrary_self_types_pointers_and_wrappers.rs
+++ b/compiler/rustc_codegen_cranelift/example/arbitrary_self_types_pointers_and_wrappers.rs
@@ -3,7 +3,7 @@
 #![feature(arbitrary_self_types, unsize, coerce_unsized, dispatch_from_dyn)]
 
 use std::marker::Unsize;
-use std::ops::{CoerceUnsized, Deref, DispatchFromDyn};
+use std::ops::{CoerceUnsized, Deref, DispatchFromDyn, Receiver};
 
 struct Ptr<T: ?Sized>(Box<T>);
 
@@ -13,6 +13,9 @@ impl<T: ?Sized> Deref for Ptr<T> {
     fn deref(&self) -> &T {
         &*self.0
     }
+}
+impl<T: ?Sized> Receiver for Ptr<T> {
+    type Target = T;
 }
 
 impl<T: Unsize<U> + ?Sized, U: ?Sized> CoerceUnsized<Ptr<U>> for Ptr<T> {}
@@ -26,6 +29,9 @@ impl<T: ?Sized> Deref for Wrapper<T> {
     fn deref(&self) -> &T {
         &self.0
     }
+}
+impl<T: ?Sized> Receiver for Wrapper<T> {
+    type Target = T;
 }
 
 impl<T: CoerceUnsized<U>, U> CoerceUnsized<Wrapper<U>> for Wrapper<T> {}

--- a/compiler/rustc_codegen_gcc/example/arbitrary_self_types_pointers_and_wrappers.rs
+++ b/compiler/rustc_codegen_gcc/example/arbitrary_self_types_pointers_and_wrappers.rs
@@ -4,10 +4,8 @@
 #![feature(rustc_attrs)]
 #![allow(internal_features)]
 
-use std::{
-    ops::{Deref, CoerceUnsized, DispatchFromDyn},
-    marker::Unsize,
-};
+use std::marker::Unsize;
+use std::ops::{CoerceUnsized, Deref, DispatchFromDyn, Receiver};
 
 struct Ptr<T: ?Sized>(Box<T>);
 
@@ -17,6 +15,9 @@ impl<T: ?Sized> Deref for Ptr<T> {
     fn deref(&self) -> &T {
         &*self.0
     }
+}
+impl<T: ?Sized> Receiver for Ptr<T> {
+    type Target = T;
 }
 
 impl<T: Unsize<U> + ?Sized, U: ?Sized> CoerceUnsized<Ptr<U>> for Ptr<T> {}
@@ -31,10 +32,12 @@ impl<T: ?Sized> Deref for Wrapper<T> {
         &self.0
     }
 }
+impl<T: ?Sized> Receiver for Wrapper<T> {
+    type Target = T;
+}
 
 impl<T: CoerceUnsized<U>, U> CoerceUnsized<Wrapper<U>> for Wrapper<T> {}
 impl<T: DispatchFromDyn<U>, U> DispatchFromDyn<Wrapper<U>> for Wrapper<T> {}
-
 
 trait Trait {
     fn ptr_wrapper(self: Ptr<Wrapper<Self>>) -> i32;

--- a/compiler/rustc_data_structures/src/intern.rs
+++ b/compiler/rustc_data_structures/src/intern.rs
@@ -2,6 +2,8 @@ use std::cmp::Ordering;
 use std::fmt::{self, Debug};
 use std::hash::{Hash, Hasher};
 use std::ops::Deref;
+#[cfg(not(bootstrap))]
+use std::ops::Receiver;
 use std::ptr;
 
 use crate::stable_hasher::{HashStable, StableHasher};
@@ -52,6 +54,11 @@ impl<'a, T> Deref for Interned<'a, T> {
     fn deref(&self) -> &T {
         self.0
     }
+}
+
+#[cfg(not(bootstrap))]
+impl<'a, T> Receiver for Interned<'a, T> {
+    type Target = T;
 }
 
 impl<'a, T> PartialEq for Interned<'a, T> {

--- a/compiler/rustc_data_structures/src/lib.rs
+++ b/compiler/rustc_data_structures/src/lib.rs
@@ -13,6 +13,7 @@
 #![cfg_attr(test, feature(test))]
 #![deny(unsafe_op_in_unsafe_fn)]
 #![feature(allocator_api)]
+#![feature(arbitrary_self_types)]
 #![feature(ascii_char)]
 #![feature(ascii_char_variants)]
 #![feature(auto_traits)]

--- a/compiler/rustc_error_codes/src/error_codes/E0307.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0307.md
@@ -67,8 +67,6 @@ impl Trait for Foo {
 The nightly feature [Arbitrary self types][AST] extends the accepted
 set of receiver types to also include any type that implements the
 `Receiver` trait and can follow its chain of `Target` types to `Self`.
-There's a blanket implementation of `Receiver` for `T: Deref`, so any
-type which dereferences to `Self` can be used.
 
 ```
 #![feature(arbitrary_self_types)]
@@ -76,13 +74,9 @@ type which dereferences to `Self` can be used.
 struct Foo;
 struct Bar;
 
-// Because you can dereference `Bar` into `Foo`...
-impl std::ops::Deref for Bar {
+// Because you can set `Bar` as method receiver for `Foo`...
+impl std::ops::Receiver for Bar {
     type Target = Foo;
-
-    fn deref(&self) -> &Foo {
-        &Foo
-    }
 }
 
 impl Foo {

--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -359,6 +359,8 @@ declare_features! (
     (unstable, arbitrary_self_types, "1.23.0", Some(44874)),
     /// Allows inherent and trait methods with arbitrary self types that are raw pointers.
     (unstable, arbitrary_self_types_pointers, "1.83.0", Some(44874)),
+    /// Enforce agreement between `Receiver::Target` and `Deref::Target`
+    (unstable, arbitrary_self_types_split_chains, "1.23.0", Some(44874)),
     /// Target features on arm.
     (unstable, arm_target_feature, "1.27.0", Some(150246)),
     /// Enables experimental inline assembly support for additional architectures.

--- a/compiler/rustc_hir_analysis/src/check/wfcheck.rs
+++ b/compiler/rustc_hir_analysis/src/check/wfcheck.rs
@@ -1800,7 +1800,9 @@ fn check_method_receiver<'tcx>(
             // Report error; would not have worked with `arbitrary_self_types[_pointers]`.
             {
                 match receiver_validity_err {
-                    ReceiverValidityError::DoesNotDeref if arbitrary_self_types_level.is_some() => {
+                    ReceiverValidityError::DoesNotReceive
+                        if arbitrary_self_types_level.is_some() =>
+                    {
                         let hint = match receiver_ty
                             .builtin_deref(false)
                             .unwrap_or(receiver_ty)
@@ -1814,7 +1816,7 @@ fn check_method_receiver<'tcx>(
 
                         tcx.dcx().emit_err(errors::InvalidReceiverTy { span, receiver_ty, hint })
                     }
-                    ReceiverValidityError::DoesNotDeref => {
+                    ReceiverValidityError::DoesNotReceive => {
                         tcx.dcx().emit_err(errors::InvalidReceiverTyNoArbitrarySelfTypes {
                             span,
                             receiver_ty,
@@ -1836,7 +1838,7 @@ fn check_method_receiver<'tcx>(
 enum ReceiverValidityError {
     /// The self type does not get to the receiver type by following the
     /// autoderef chain.
-    DoesNotDeref,
+    DoesNotReceive,
     /// A type was found which is a method type parameter, and that's not allowed.
     MethodGenericParamUsed,
 }
@@ -1892,17 +1894,21 @@ fn receiver_is_valid<'tcx>(
 
     confirm_type_is_not_a_method_generic_param(receiver_ty, method_generics)?;
 
-    let mut autoderef = Autoderef::new(infcx, wfcx.param_env, wfcx.body_def_id, span, receiver_ty);
+    let cache = Default::default();
+    let mut autoderef =
+        Autoderef::new(infcx, Some(&cache), wfcx.param_env, wfcx.body_def_id, span, receiver_ty);
 
     // The `arbitrary_self_types` feature allows custom smart pointer
-    // types to be method receivers, as identified by following the Receiver<Target=T>
+    // types to be method receivers, as identified by following the Receiver<Target = T>
     // chain.
     if arbitrary_self_types_enabled.is_some() {
-        autoderef = autoderef.use_receiver_trait();
+        // We are in the wf check, so we would like to deref the references in the type head.
+        // However, we do not want to walk `Deref` chain.
+        autoderef = autoderef.follow_receiver_chain();
     }
 
     // The `arbitrary_self_types_pointers` feature allows raw pointer receivers like `self: *const Self`.
-    if arbitrary_self_types_enabled == Some(ArbitrarySelfTypesLevel::WithPointers) {
+    if matches!(arbitrary_self_types_enabled, Some(ArbitrarySelfTypesLevel::WithPointers)) {
         autoderef = autoderef.include_raw_pointers();
     }
 
@@ -1956,7 +1962,7 @@ fn receiver_is_valid<'tcx>(
     }
 
     debug!("receiver_is_valid: type `{:?}` does not deref to `{:?}`", receiver_ty, self_ty);
-    Err(ReceiverValidityError::DoesNotDeref)
+    Err(ReceiverValidityError::DoesNotReceive)
 }
 
 fn legacy_receiver_is_implemented<'tcx>(

--- a/compiler/rustc_hir_analysis/src/coherence/builtin.rs
+++ b/compiler/rustc_hir_analysis/src/coherence/builtin.rs
@@ -16,13 +16,14 @@ use rustc_middle::ty::print::PrintTraitRefExt as _;
 use rustc_middle::ty::{
     self, Ty, TyCtxt, TypeVisitableExt, TypingMode, suggest_constraining_type_params,
 };
+use rustc_session::parse::feature_err;
 use rustc_span::{DUMMY_SP, Span, sym};
 use rustc_trait_selection::error_reporting::InferCtxtErrorExt;
 use rustc_trait_selection::traits::misc::{
     ConstParamTyImplementationError, CopyImplementationError, InfringingFieldsReason,
     type_allowed_to_implement_const_param_ty, type_allowed_to_implement_copy,
 };
-use rustc_trait_selection::traits::{self, ObligationCause, ObligationCtxt};
+use rustc_trait_selection::traits::{self, NormalizeExt, ObligationCause, ObligationCtxt};
 use tracing::debug;
 
 use crate::errors;
@@ -49,6 +50,7 @@ pub(super) fn check_trait<'tcx>(
         lang_items.coerce_pointee_validated_trait(),
         visit_implementation_of_coerce_pointee_validity,
     )?;
+    checker.check(lang_items.receiver_trait(), visit_implementation_of_receiver)?;
     Ok(())
 }
 
@@ -791,4 +793,56 @@ fn visit_implementation_of_coerce_pointee_validity(
         return Err(tcx.dcx().emit_err(errors::CoercePointeeNoField { span }));
     }
     Ok(())
+}
+
+fn visit_implementation_of_receiver(checker: &Checker<'_>) -> Result<(), ErrorGuaranteed> {
+    let tcx = checker.tcx;
+    if tcx.features().arbitrary_self_types_split_chains() {
+        return Ok(());
+    }
+    let impl_did = checker.impl_def_id;
+    let span = tcx.def_span(impl_did);
+    let deref_target_did = tcx.require_lang_item(LangItem::DerefTarget, span);
+    let receiver_target_did = tcx.require_lang_item(LangItem::ReceiverTarget, span);
+    let self_ty = tcx.impl_trait_ref(impl_did).instantiate_identity().self_ty();
+    let param_env = tcx.param_env(impl_did);
+    let infcx = tcx.infer_ctxt().build(TypingMode::non_body_analysis());
+    let ocx = ObligationCtxt::new(&infcx);
+    let cause = ObligationCause::misc(span, impl_did);
+    ocx.register_obligation(Obligation::new(
+        tcx,
+        cause.clone(),
+        param_env,
+        ty::TraitRef::new(tcx, tcx.require_lang_item(LangItem::Deref, span), [self_ty]),
+    ));
+    if !ocx.evaluate_obligations_error_on_ambiguity().is_empty() {
+        // We cannot enforce Deref::Target == Receiver::Target because we cannot find `impl Deref`
+        return Ok(());
+    }
+    let infer::InferOk { value: deref_target_ty, .. } = infcx.at(&cause, param_env).normalize(
+        Ty::new_projection_from_args(tcx, deref_target_did, tcx.mk_args(&[self_ty.into()])),
+    );
+    let infer::InferOk { value: receiver_target_ty, .. } = infcx.at(&cause, param_env).normalize(
+        Ty::new_projection_from_args(tcx, receiver_target_did, tcx.mk_args(&[self_ty.into()])),
+    );
+    if let Err(_) = infcx.at(&cause, param_env).eq(
+        infer::DefineOpaqueTypes::No,
+        deref_target_ty,
+        receiver_target_ty,
+    ) {
+        feature_err(
+            tcx.sess,
+            sym::arbitrary_self_types_split_chains,
+            span,
+            "`Receiver::Target` diverging from `Deref::Target` is not supported; we look forward to your feedback",
+        )
+        .emit();
+        Err(tcx.dcx().emit_err(errors::DerefReceiverTargetDiverge {
+            span,
+            deref_ty: deref_target_ty,
+            recv_ty: receiver_target_ty,
+        }))
+    } else {
+        Ok(())
+    }
 }

--- a/compiler/rustc_hir_analysis/src/errors.rs
+++ b/compiler/rustc_hir_analysis/src/errors.rs
@@ -1727,7 +1727,8 @@ pub(crate) enum InvalidReceiverTyHint {
 #[diag("invalid `self` parameter type: `{$receiver_ty}`", code = E0307)]
 #[note("type of `self` must be `Self` or a type that dereferences to it")]
 #[help(
-    "consider changing to `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)"
+    "consider changing to `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` where P is one of the previous types except `Self`; \
+alternatively, consider implement `Receiver` trait on the type of `self`, where applicable"
 )]
 pub(crate) struct InvalidReceiverTyNoArbitrarySelfTypes<'tcx> {
     #[primary_span]

--- a/compiler/rustc_hir_analysis/src/errors.rs
+++ b/compiler/rustc_hir_analysis/src/errors.rs
@@ -1217,6 +1217,17 @@ pub(crate) struct CoercePointeeNoField {
 }
 
 #[derive(Diagnostic)]
+#[diag("`Deref::Target` does not agree with `Receiver::Target`", code = E0390)]
+#[note("`Deref::Target` is `{$deref_ty}` but `Receiver::Target` is `{$recv_ty}`")]
+#[note("`#![feature(arbitrary_self_types_merge_chains)]` rejects this kind of divergence")]
+pub(crate) struct DerefReceiverTargetDiverge<'a> {
+    #[primary_span]
+    pub span: Span,
+    pub deref_ty: Ty<'a>,
+    pub recv_ty: Ty<'a>,
+}
+
+#[derive(Diagnostic)]
 #[diag("cannot define inherent `impl` for a type outside of the crate where the type is defined", code = E0390)]
 #[help("consider moving this inherent impl into the crate defining the type if possible")]
 pub(crate) struct InherentTyOutsideRelevant {

--- a/compiler/rustc_hir_typeck/src/autoderef.rs
+++ b/compiler/rustc_hir_typeck/src/autoderef.rs
@@ -15,7 +15,7 @@ use super::{FnCtxt, PlaceOp};
 
 impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     pub(crate) fn autoderef(&'a self, span: Span, base_ty: Ty<'tcx>) -> Autoderef<'a, 'tcx> {
-        Autoderef::new(self, self.param_env, self.body_id, span, base_ty)
+        Autoderef::new(self, None, self.param_env, self.body_id, span, base_ty)
     }
 
     pub(crate) fn try_overloaded_deref(

--- a/compiler/rustc_hir_typeck/src/method/probe.rs
+++ b/compiler/rustc_hir_typeck/src/method/probe.rs
@@ -4,11 +4,15 @@ use std::debug_assert_matches;
 use std::ops::Deref;
 
 use rustc_data_structures::fx::FxHashSet;
+use rustc_data_structures::indexmap::IndexSet;
 use rustc_data_structures::sso::SsoHashSet;
+use rustc_data_structures::unord::{UnordMap, UnordSet};
 use rustc_errors::{Applicability, Diag, DiagCtxtHandle, Diagnostic, Level};
 use rustc_hir::def::DefKind;
 use rustc_hir::{self as hir, ExprKind, HirId, Node, find_attr};
 use rustc_hir_analysis::autoderef::{self, Autoderef};
+use rustc_index::bit_set::DenseBitSet;
+use rustc_index::{IndexVec, indexvec};
 use rustc_infer::infer::canonical::{Canonical, OriginalQueryValues, QueryResponse};
 use rustc_infer::infer::{BoundRegionConversionTime, DefineOpaqueTypes, InferOk, TyCtxtInferExt};
 use rustc_infer::traits::{ObligationCauseCode, PredicateObligation, query};
@@ -49,6 +53,11 @@ use crate::FnCtxt;
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct IsSuggestion(pub bool);
 
+rustc_index::newtype_index! {
+    #[orderable]
+    struct CandidateIdx {}
+}
+
 pub(crate) struct ProbeContext<'a, 'tcx> {
     fcx: &'a FnCtxt<'a, 'tcx>,
     span: Span,
@@ -61,9 +70,38 @@ pub(crate) struct ProbeContext<'a, 'tcx> {
     orig_steps_var_values: &'a OriginalQueryValues<'tcx>,
     steps: &'tcx [CandidateStep<'tcx>],
 
-    inherent_candidates: Vec<Candidate<'tcx>>,
+    /// Central registry of inherent candidates.
+    /// Inherent candidates may appear multiple times by enumerating [`Autoderef`],
+    /// and this list is to cache those duplicate candidates.
+    raw_inherent_candidates: IndexVec<CandidateIdx, Candidate<'tcx>>,
+    /// Lookup of inherent method DefIds into the candidate registry
+    /// [`Self::raw_inherent_candidates`].
+    did_to_inherent_candidates: UnordMap<DefId, CandidateIdx>,
+    /// For each possible type, be it `Deref` or `Receiver` target type,
+    /// the inherent candidates that are visible.
+    /// This list contains inherent candidates for possible `self` variables as well as possible
+    /// `Self` type.
+    inherent_probe_candidates: Vec<SmallVec<[CandidateIdx; 1]>>,
+    /// For n-th type in the enumeration of [`Autoderef`], be it `Deref` or `Receiver` target type,
+    /// the corresponding index into [`Self::inherent_probe_candidates`].
+    /// A type may receive an index out of bound of [`Self::inherent_probe_candidates`] to signal
+    /// that the candidates have been collected for this type.
+    inherent_probe_step_to_slot: Vec<usize>,
+    /// For n-th type in the enumeration of [`Autoderef`], be it `Deref` or `Receiver` target type,
+    /// the index `<Self as Receiver>::Target` type into [`Self::inherent_probe_step_to_slot`].
+    receiver_chain_next: Vec<usize>,
+    /// After n dereferencing step, the index of the type of `self` variable into the enumeration of
+    /// [`Autoderef`].
+    /// It is used to look up in [`Self::inherent_probe_step_to_slot`],
+    /// then [`Self::inherent_probe_candidates`] to retrieve the candidates.
+    /// See [`Self::flatten_candidates`].
+    inherent_probe_start: Vec<usize>,
+    /// After completely enumerating through [`Autoderef`], the inherent method candidates for
+    /// the `self` value after n-th dereferencing step is collected into this nested list.
+    /// Each nested list contains these candidates in descendending order of priority.
+    flattened_inherent_candidates: Vec<SmallVec<[CandidateIdx; 1]>>,
+
     extension_candidates: Vec<Candidate<'tcx>>,
-    impl_dups: FxHashSet<DefId>,
 
     /// When probing for names, include names that are close to the
     /// requested name (by edit distance)
@@ -86,6 +124,7 @@ pub(crate) struct ProbeContext<'a, 'tcx> {
     /// machinery, since we don't particularly care about, for example, similarly named
     /// candidates if we're *reporting* similarly named candidates.
     is_suggestion: IsSuggestion,
+    isolate_receiver_chain: bool,
 }
 
 impl<'a, 'tcx> Deref for ProbeContext<'a, 'tcx> {
@@ -367,7 +406,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             scope,
             |probe_cx| {
                 Ok(probe_cx
-                    .inherent_candidates
+                    .raw_inherent_candidates
                     .into_iter()
                     .chain(probe_cx.extension_candidates)
                     .collect())
@@ -569,19 +608,14 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     let trait_args = self.fresh_args_for_item(trait_span, trait_def_id);
                     let trait_ref = ty::TraitRef::new_from_args(self.tcx, trait_def_id, trait_args);
 
-                    probe_cx.push_candidate(
-                        Candidate {
-                            item,
-                            kind: CandidateKind::TraitCandidate(
-                                ty::Binder::dummy(trait_ref),
-                                false,
-                            ),
-                            import_ids: &[],
-                        },
-                        false,
-                    );
+                    probe_cx.push_extension_candidate(Candidate {
+                        item,
+                        kind: CandidateKind::TraitCandidate(ty::Binder::dummy(trait_ref), false),
+                        import_ids: &[],
+                    });
                 }
             };
+            probe_cx.flatten_candidates();
             op(probe_cx)
         })
     }
@@ -785,15 +819,20 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
         scope_expr_id: HirId,
         is_suggestion: IsSuggestion,
     ) -> ProbeContext<'a, 'tcx> {
-        ProbeContext {
+        let mut this = ProbeContext {
             fcx,
             span,
             mode,
             method_name,
             return_type,
-            inherent_candidates: Vec::new(),
+            raw_inherent_candidates: indexvec![],
+            did_to_inherent_candidates: Default::default(),
+            inherent_probe_candidates: vec![],
+            inherent_probe_step_to_slot: vec![],
+            receiver_chain_next: vec![],
+            flattened_inherent_candidates: vec![],
+            inherent_probe_start: vec![],
             extension_candidates: Vec::new(),
-            impl_dups: FxHashSet::default(),
             orig_steps_var_values,
             steps,
             allow_similar_names: false,
@@ -802,16 +841,60 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
             static_candidates: RefCell::new(Vec::new()),
             scope_expr_id,
             is_suggestion,
-        }
+            isolate_receiver_chain: fcx.tcx.features().arbitrary_self_types()
+                || fcx.tcx.features().arbitrary_self_types_pointers(),
+        };
+        this.reset();
+        this
     }
 
     fn reset(&mut self) {
-        self.inherent_candidates.clear();
+        self.raw_inherent_candidates.raw.clear();
+        self.did_to_inherent_candidates.clear();
+        self.inherent_probe_candidates.clear();
+        self.inherent_probe_step_to_slot.clear();
+        self.receiver_chain_next.clear();
+        self.inherent_probe_start.clear();
+        self.flattened_inherent_candidates.clear();
         self.extension_candidates.clear();
-        self.impl_dups.clear();
         self.private_candidates.clear();
         self.private_candidate.set(None);
         self.static_candidates.borrow_mut().clear();
+
+        let nr_steps = self.steps.len();
+        let mut receiver_to_probe_step: UnordMap<Ty<'tcx>, usize> = Default::default();
+        let mut last_receiver_chain_step = None;
+        self.receiver_chain_next.resize(nr_steps, nr_steps);
+        self.inherent_probe_candidates.reserve(nr_steps);
+        self.inherent_probe_step_to_slot.reserve(nr_steps);
+        self.inherent_probe_start
+            .reserve(self.steps.iter().filter(|s| s.reachable_via_deref).count());
+        for (mut id, step) in self.steps.iter().enumerate() {
+            let mut fresh = true;
+            let context_ty = step.self_ty.value.value;
+            debug!(?context_ty, id);
+            if let Some(&seen_id) = receiver_to_probe_step.get(&context_ty) {
+                id = seen_id;
+                self.inherent_probe_step_to_slot.push(nr_steps);
+                fresh = false;
+            } else {
+                receiver_to_probe_step.insert(context_ty, id);
+                let slot = self.inherent_probe_candidates.len();
+                self.inherent_probe_candidates.push(Default::default());
+                self.inherent_probe_step_to_slot.push(slot);
+            }
+            if step.reachable_via_deref {
+                self.inherent_probe_start.push(id);
+                self.flattened_inherent_candidates.push(Default::default());
+                if self.isolate_receiver_chain {
+                    last_receiver_chain_step = None;
+                }
+            }
+            if let Some(last) = last_receiver_chain_step {
+                self.receiver_chain_next[last] = id;
+            }
+            last_receiver_chain_step = fresh.then_some(id);
+        }
     }
 
     /// When we're looking up a method by path (UFCS), we relate the receiver
@@ -827,8 +910,39 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
     ///////////////////////////////////////////////////////////////////////////
     // CANDIDATE ASSEMBLY
 
-    fn push_candidate(&mut self, candidate: Candidate<'tcx>, is_inherent: bool) {
-        let is_accessible = if let Some(name) = self.method_name {
+    fn push_extension_candidate(&mut self, candidate: Candidate<'tcx>) {
+        if !self.is_candidate_visible(&candidate) {
+            self.private_candidates.push(candidate);
+            return;
+        }
+
+        self.extension_candidates.push(candidate);
+    }
+
+    fn push_inherent_candidate(&mut self, candidate: Candidate<'tcx>, context: usize) {
+        if !self.is_candidate_visible(&candidate) {
+            self.private_candidates.push(candidate);
+            return;
+        }
+
+        debug!(?context, ?candidate, "push inherent");
+        let id = if let InherentImplCandidate { .. } = candidate.kind {
+            let did = candidate.item.def_id;
+            if let Some(&id) = self.did_to_inherent_candidates.get(&did) {
+                id
+            } else {
+                let id = self.raw_inherent_candidates.push(candidate);
+                self.did_to_inherent_candidates.insert(did, id);
+                id
+            }
+        } else {
+            self.raw_inherent_candidates.push(candidate)
+        };
+        self.inherent_probe_candidates[self.inherent_probe_step_to_slot[context]].push(id);
+    }
+
+    fn is_candidate_visible(&self, candidate: &Candidate<'tcx>) -> bool {
+        if let Some(name) = self.method_name {
             let item = candidate.item;
             let hir_id = self.tcx.local_def_id_to_hir_id(self.body_id);
             let def_scope =
@@ -836,22 +950,57 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
             item.visibility(self.tcx).is_accessible_from(def_scope, self.tcx)
         } else {
             true
-        };
-        if is_accessible {
-            if is_inherent {
-                self.inherent_candidates.push(candidate);
-            } else {
-                self.extension_candidates.push(candidate);
+        }
+    }
+
+    fn flatten_candidates(&mut self) {
+        let nr_steps = self.steps.len();
+        for (deref_step, &step) in self.inherent_probe_start.iter().enumerate() {
+            let mut step = step;
+            let mut visited = DenseBitSet::new_empty(nr_steps);
+            let mut all_candidates = IndexSet::new();
+            while step < nr_steps && visited.insert(step) {
+                let Some(candidates) =
+                    self.inherent_probe_candidates.get(self.inherent_probe_step_to_slot[step])
+                else {
+                    break;
+                };
+                debug!(?step, ?candidates);
+                all_candidates.extend(candidates.iter().copied());
+                step = self.receiver_chain_next[step];
             }
-        } else {
-            self.private_candidates.push(candidate);
+            debug!(?deref_step, ?all_candidates);
+            self.flattened_inherent_candidates[deref_step] = all_candidates.into_iter().collect();
         }
     }
 
     fn assemble_inherent_candidates(&mut self) {
-        for step in self.steps.iter() {
-            self.assemble_probe(&step.self_ty, step.receiver_depth);
+        for (context, step) in self.steps.iter().enumerate() {
+            self.assemble_probe(&step.self_ty, step.receiver_depth, context);
         }
+    }
+
+    fn generalized_ty(&self, ty: &Canonical<'tcx, QueryResponse<'tcx, Ty<'tcx>>>) -> Ty<'tcx> {
+        // Subtle: we can't use `instantiate_query_response` here: using it will
+        // commit to all of the type equalities assumed by inference going through
+        // autoderef (see the `method-probe-no-guessing` test).
+        //
+        // However, in this code, it is OK if we end up with an object type that is
+        // "more general" than the object type that we are evaluating. For *every*
+        // object type `MY_OBJECT`, a function call that goes through a trait-ref
+        // of the form `<MY_OBJECT as SuperTraitOf(MY_OBJECT)>::func` is a valid
+        // `ObjectCandidate`, and it should be discoverable "exactly" through one
+        // of the iterations in the autoderef loop, so there is no problem with it
+        // being discoverable in another one of these iterations.
+        //
+        // Using `instantiate_canonical` on our
+        // `Canonical<QueryResponse<Ty<'tcx>>>` and then *throwing away* the
+        // `CanonicalVarValues` will exactly give us such a generalization - it
+        // will still match the original object type, but it won't pollute our
+        // type variables in any form, so just do that!
+        let (QueryResponse { value, .. }, _ignored_var_values) =
+            self.fcx.instantiate_canonical(self.span, ty);
+        value
     }
 
     #[instrument(level = "debug", skip(self))]
@@ -859,45 +1008,47 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
         &mut self,
         self_ty: &Canonical<'tcx, QueryResponse<'tcx, Ty<'tcx>>>,
         receiver_steps: usize,
+        context: usize,
     ) {
         let raw_self_ty = self_ty.value.value;
+        if self.inherent_probe_step_to_slot[context] >= self.inherent_probe_candidates.len() {
+            // This context has been explored.
+            // Let us not repeat the work.
+            return;
+        }
         match *raw_self_ty.kind() {
             ty::Dynamic(data, ..) if let Some(p) = data.principal() => {
-                // Subtle: we can't use `instantiate_query_response` here: using it will
-                // commit to all of the type equalities assumed by inference going through
-                // autoderef (see the `method-probe-no-guessing` test).
-                //
-                // However, in this code, it is OK if we end up with an object type that is
-                // "more general" than the object type that we are evaluating. For *every*
-                // object type `MY_OBJECT`, a function call that goes through a trait-ref
-                // of the form `<MY_OBJECT as SuperTraitOf(MY_OBJECT)>::func` is a valid
-                // `ObjectCandidate`, and it should be discoverable "exactly" through one
-                // of the iterations in the autoderef loop, so there is no problem with it
-                // being discoverable in another one of these iterations.
-                //
-                // Using `instantiate_canonical` on our
-                // `Canonical<QueryResponse<Ty<'tcx>>>` and then *throwing away* the
-                // `CanonicalVarValues` will exactly give us such a generalization - it
-                // will still match the original object type, but it won't pollute our
-                // type variables in any form, so just do that!
-                let (QueryResponse { value: generalized_self_ty, .. }, _ignored_var_values) =
-                    self.fcx.instantiate_canonical(self.span, self_ty);
-
-                self.assemble_inherent_candidates_from_object(generalized_self_ty);
-                self.assemble_inherent_impl_candidates_for_type(p.def_id(), receiver_steps);
-                self.assemble_inherent_candidates_for_incoherent_ty(raw_self_ty, receiver_steps);
+                self.assemble_inherent_candidates_from_object(self_ty, context);
+                self.assemble_inherent_impl_candidates_for_type(
+                    p.def_id(),
+                    context,
+                    receiver_steps,
+                );
+                self.assemble_inherent_candidates_for_incoherent_ty(
+                    raw_self_ty,
+                    context,
+                    receiver_steps,
+                );
             }
             ty::Adt(def, _) => {
                 let def_id = def.did();
-                self.assemble_inherent_impl_candidates_for_type(def_id, receiver_steps);
-                self.assemble_inherent_candidates_for_incoherent_ty(raw_self_ty, receiver_steps);
+                self.assemble_inherent_impl_candidates_for_type(def_id, context, receiver_steps);
+                self.assemble_inherent_candidates_for_incoherent_ty(
+                    raw_self_ty,
+                    context,
+                    receiver_steps,
+                );
             }
             ty::Foreign(did) => {
-                self.assemble_inherent_impl_candidates_for_type(did, receiver_steps);
-                self.assemble_inherent_candidates_for_incoherent_ty(raw_self_ty, receiver_steps);
+                self.assemble_inherent_impl_candidates_for_type(did, context, receiver_steps);
+                self.assemble_inherent_candidates_for_incoherent_ty(
+                    raw_self_ty,
+                    context,
+                    receiver_steps,
+                );
             }
             ty::Param(_) => {
-                self.assemble_inherent_candidates_from_param(raw_self_ty);
+                self.assemble_inherent_candidates_from_param(raw_self_ty, context);
             }
             ty::Bool
             | ty::Char
@@ -911,7 +1062,11 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
             | ty::Ref(..)
             | ty::Never
             | ty::Tuple(..) => {
-                self.assemble_inherent_candidates_for_incoherent_ty(raw_self_ty, receiver_steps)
+                self.assemble_inherent_candidates_for_incoherent_ty(
+                    raw_self_ty,
+                    context,
+                    receiver_steps,
+                );
             }
             ty::Alias(..)
             | ty::Bound(..)
@@ -932,50 +1087,63 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
 
     fn assemble_inherent_candidates_for_incoherent_ty(
         &mut self,
-        self_ty: Ty<'tcx>,
+        receiver_ty: Ty<'tcx>,
+        context: usize,
         receiver_steps: usize,
     ) {
-        let Some(simp) = simplify_type(self.tcx, self_ty, TreatParams::InstantiateWithInfer) else {
-            bug!("unexpected incoherent type: {:?}", self_ty)
+        let Some(simp) = simplify_type(self.tcx, receiver_ty, TreatParams::InstantiateWithInfer)
+        else {
+            bug!("unexpected incoherent type: {:?}", receiver_ty)
         };
         for &impl_def_id in self.tcx.incoherent_impls(simp).into_iter() {
-            self.assemble_inherent_impl_probe(impl_def_id, receiver_steps);
+            self.assemble_inherent_impl_probe(impl_def_id, context, receiver_steps);
         }
     }
 
-    fn assemble_inherent_impl_candidates_for_type(&mut self, def_id: DefId, receiver_steps: usize) {
+    fn assemble_inherent_impl_candidates_for_type(
+        &mut self,
+        def_id: DefId,
+        context: usize,
+        receiver_steps: usize,
+    ) {
         let impl_def_ids = self.tcx.at(self.span).inherent_impls(def_id).into_iter();
         for &impl_def_id in impl_def_ids {
-            self.assemble_inherent_impl_probe(impl_def_id, receiver_steps);
+            self.assemble_inherent_impl_probe(impl_def_id, context, receiver_steps);
         }
     }
 
     #[instrument(level = "debug", skip(self))]
-    fn assemble_inherent_impl_probe(&mut self, impl_def_id: DefId, receiver_steps: usize) {
-        if !self.impl_dups.insert(impl_def_id) {
-            return; // already visited
-        }
-
+    fn assemble_inherent_impl_probe(
+        &mut self,
+        impl_def_id: DefId,
+        context: usize,
+        receiver_steps: usize,
+    ) {
         for item in self.impl_or_trait_item(impl_def_id) {
             if !self.has_applicable_self(&item) {
                 // No receiver declared. Not a candidate.
                 self.record_static_candidate(CandidateSource::Impl(impl_def_id));
                 continue;
             }
-            self.push_candidate(
+            self.push_inherent_candidate(
                 Candidate {
                     item,
                     kind: InherentImplCandidate { impl_def_id, receiver_steps },
                     import_ids: &[],
                 },
-                true,
+                context,
             );
         }
     }
 
     #[instrument(level = "debug", skip(self))]
-    fn assemble_inherent_candidates_from_object(&mut self, self_ty: Ty<'tcx>) {
-        let principal = match self_ty.kind() {
+    fn assemble_inherent_candidates_from_object(
+        &mut self,
+        self_ty: &Canonical<'tcx, QueryResponse<'tcx, Ty<'tcx>>>,
+        context: usize,
+    ) {
+        let generalized_self_ty = self.generalized_ty(self_ty);
+        let principal = match generalized_self_ty.kind() {
             ty::Dynamic(data, ..) => Some(data),
             _ => None,
         }
@@ -984,7 +1152,7 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
             span_bug!(
                 self.span,
                 "non-object {:?} in assemble_inherent_candidates_from_object",
-                self_ty
+                generalized_self_ty
             )
         });
 
@@ -994,20 +1162,20 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
         // `Self` type anywhere other than the receiver. Here, we use a
         // instantiation that replaces `Self` with the object type itself. Hence,
         // a `&self` method will wind up with an argument type like `&dyn Trait`.
-        let trait_ref = principal.with_self_ty(self.tcx, self_ty);
+        let trait_ref = principal.with_self_ty(self.tcx, generalized_self_ty);
         self.assemble_candidates_for_bounds(
             traits::supertraits(self.tcx, trait_ref),
             |this, new_trait_ref, item| {
-                this.push_candidate(
+                this.push_inherent_candidate(
                     Candidate { item, kind: ObjectCandidate(new_trait_ref), import_ids: &[] },
-                    true,
+                    context,
                 );
             },
         );
     }
 
     #[instrument(level = "debug", skip(self))]
-    fn assemble_inherent_candidates_from_param(&mut self, param_ty: Ty<'tcx>) {
+    fn assemble_inherent_candidates_from_param(&mut self, param_ty: Ty<'tcx>, context: usize) {
         debug_assert_matches!(param_ty.kind(), ty::Param(_));
 
         let tcx = self.tcx;
@@ -1033,9 +1201,9 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
         });
 
         self.assemble_candidates_for_bounds(bounds, |this, poly_trait_ref, item| {
-            this.push_candidate(
+            this.push_inherent_candidate(
                 Candidate { item, kind: WhereClauseCandidate(poly_trait_ref), import_ids: &[] },
-                true,
+                context,
             );
         });
     }
@@ -1105,7 +1273,6 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
         }
     }
 
-    #[instrument(level = "debug", skip(self))]
     fn assemble_extension_candidates_for_trait(
         &mut self,
         import_ids: &'tcx [LocalDefId],
@@ -1128,14 +1295,11 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
                             bound_trait_ref.def_id(),
                         ));
                     } else {
-                        self.push_candidate(
-                            Candidate {
-                                item,
-                                import_ids,
-                                kind: TraitCandidate(bound_trait_ref, lint_ambiguous),
-                            },
-                            false,
-                        );
+                        self.push_extension_candidate(Candidate {
+                            item,
+                            import_ids,
+                            kind: TraitCandidate(bound_trait_ref, lint_ambiguous),
+                        });
                     }
                 }
             }
@@ -1151,14 +1315,11 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
                     self.record_static_candidate(CandidateSource::Trait(trait_def_id));
                     continue;
                 }
-                self.push_candidate(
-                    Candidate {
-                        item,
-                        import_ids,
-                        kind: TraitCandidate(ty::Binder::dummy(trait_ref), lint_ambiguous),
-                    },
-                    false,
-                );
+                self.push_extension_candidate(Candidate {
+                    item,
+                    import_ids,
+                    kind: TraitCandidate(ty::Binder::dummy(trait_ref), lint_ambiguous),
+                });
             }
         }
     }
@@ -1167,9 +1328,9 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
         &self,
         candidate_filter: impl Fn(&ty::AssocItem) -> bool,
     ) -> Vec<Ident> {
-        let mut set = FxHashSet::default();
+        let mut set = UnordSet::default();
         let mut names: Vec<_> = self
-            .inherent_candidates
+            .raw_inherent_candidates
             .iter()
             .chain(&self.extension_candidates)
             .filter(|candidate| candidate_filter(&candidate.item))
@@ -1265,6 +1426,7 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
         }))
     }
 
+    #[instrument(level = "debug", skip_all)]
     fn pick_core(
         &self,
         unsatisfied_predicates: &mut UnsatisfiedPredicates<'tcx>,
@@ -1304,13 +1466,14 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
             // so we want to follow the `Deref` chain not the `Receiver` chain. Filter out
             // steps which can only be reached by following the (longer) `Receiver` chain.
             .filter(|step| step.reachable_via_deref)
-            .filter(|step| {
+            .enumerate()
+            .filter(|(_, step)| {
                 debug!(?step, ?step.from_unsafe_deref);
                 // skip types that are from a type error or that would require dereferencing
                 // a raw pointer
                 !step.self_ty.value.references_error() && !step.from_unsafe_deref
             })
-            .find_map(|step| {
+            .find_map(|(deref_depth, step)| {
                 let InferOk { value: self_ty, obligations: instantiate_self_ty_obligations } = self
                     .fcx
                     .probe_instantiate_query_response(
@@ -1325,6 +1488,7 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
                 let by_value_pick = self.pick_by_value_method(
                     step,
                     self_ty,
+                    deref_depth,
                     &instantiate_self_ty_obligations,
                     pick_diag_hints,
                 );
@@ -1339,6 +1503,7 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
                                 by_value_pick,
                                 step,
                                 self_ty,
+                                deref_depth,
                                 &instantiate_self_ty_obligations,
                                 mutbl,
                                 track_unstable_candidates,
@@ -1354,6 +1519,7 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
                 let autoref_pick = self.pick_autorefd_method(
                     step,
                     self_ty,
+                    deref_depth,
                     &instantiate_self_ty_obligations,
                     hir::Mutability::Not,
                     pick_diag_hints,
@@ -1369,6 +1535,7 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
                             autoref_pick,
                             step,
                             self_ty,
+                            deref_depth,
                             &instantiate_self_ty_obligations,
                             hir::Mutability::Mut,
                             track_unstable_candidates,
@@ -1406,6 +1573,7 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
                 self.pick_autorefd_method(
                     step,
                     self_ty,
+                    deref_depth,
                     &instantiate_self_ty_obligations,
                     hir::Mutability::Mut,
                     pick_diag_hints,
@@ -1415,6 +1583,7 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
                     self.pick_const_ptr_method(
                         step,
                         self_ty,
+                        deref_depth,
                         &instantiate_self_ty_obligations,
                         pick_diag_hints,
                     )
@@ -1423,6 +1592,7 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
                     self.pick_reborrow_pin_method(
                         step,
                         self_ty,
+                        deref_depth,
                         &instantiate_self_ty_obligations,
                         pick_diag_hints,
                     )
@@ -1451,11 +1621,13 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
     /// Here we report an error on the ground of shadowing `foo` in this case.
     /// Shadowing happens when an inherent method candidate appears deeper in
     /// the Receiver sub-chain that is rooted from the same `self` value.
+    #[instrument(level = "debug", skip(self))]
     fn check_for_shadowed_autorefd_method(
         &self,
         possible_shadower: &Pick<'tcx>,
         step: &CandidateStep<'tcx>,
         self_ty: Ty<'tcx>,
+        deref_depth: usize,
         instantiate_self_ty_obligations: &[PredicateObligation<'tcx>],
         mutbl: hir::Mutability,
         track_unstable_candidates: bool,
@@ -1525,6 +1697,7 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
         let potentially_shadowed_pick = self.pick_autorefd_method(
             step,
             self_ty,
+            deref_depth,
             instantiate_self_ty_obligations,
             mutbl,
             &mut pick_diag_hints,
@@ -1552,6 +1725,7 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
         &self,
         step: &CandidateStep<'tcx>,
         self_ty: Ty<'tcx>,
+        deref_depth: usize,
         instantiate_self_ty_obligations: &[PredicateObligation<'tcx>],
         pick_diag_hints: &mut PickDiagHints<'_, 'tcx>,
     ) -> Option<PickResult<'tcx>> {
@@ -1559,7 +1733,14 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
             return None;
         }
 
-        self.pick_method(self_ty, instantiate_self_ty_obligations, pick_diag_hints, None).map(|r| {
+        self.pick_method(
+            self_ty,
+            deref_depth,
+            instantiate_self_ty_obligations,
+            pick_diag_hints,
+            None,
+        )
+        .map(|r| {
             r.map(|mut pick| {
                 pick.autoderefs = step.autoderefs;
 
@@ -1596,6 +1777,7 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
         &self,
         step: &CandidateStep<'tcx>,
         self_ty: Ty<'tcx>,
+        deref_depth: usize,
         instantiate_self_ty_obligations: &[PredicateObligation<'tcx>],
         mutbl: hir::Mutability,
         pick_diag_hints: &mut PickDiagHints<'_, 'tcx>,
@@ -1615,6 +1797,7 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
         let autoref_ty = Ty::new_ref(tcx, region, self_ty, mutbl);
         self.pick_method(
             autoref_ty,
+            deref_depth,
             instantiate_self_ty_obligations,
             pick_diag_hints,
             pick_constraints,
@@ -1635,6 +1818,7 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
         &self,
         step: &CandidateStep<'tcx>,
         self_ty: Ty<'tcx>,
+        deref_depth: usize,
         instantiate_self_ty_obligations: &[PredicateObligation<'tcx>],
         pick_diag_hints: &mut PickDiagHints<'_, 'tcx>,
     ) -> Option<PickResult<'tcx>> {
@@ -1657,16 +1841,21 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
 
         let region = self.tcx.lifetimes.re_erased;
         let autopin_ty = Ty::new_pinned_ref(self.tcx, region, inner_ty, hir::Mutability::Not);
-        self.pick_method(autopin_ty, instantiate_self_ty_obligations, pick_diag_hints, None).map(
-            |r| {
-                r.map(|mut pick| {
-                    pick.autoderefs = step.autoderefs;
-                    pick.autoref_or_ptr_adjustment =
-                        Some(AutorefOrPtrAdjustment::ReborrowPin(hir::Mutability::Not));
-                    pick
-                })
-            },
+        self.pick_method(
+            autopin_ty,
+            deref_depth,
+            instantiate_self_ty_obligations,
+            pick_diag_hints,
+            None,
         )
+        .map(|r| {
+            r.map(|mut pick| {
+                pick.autoderefs = step.autoderefs;
+                pick.autoref_or_ptr_adjustment =
+                    Some(AutorefOrPtrAdjustment::ReborrowPin(hir::Mutability::Not));
+                pick
+            })
+        })
     }
 
     /// If `self_ty` is `*mut T` then this picks `*const T` methods. The reason why we have a
@@ -1677,6 +1866,7 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
         &self,
         step: &CandidateStep<'tcx>,
         self_ty: Ty<'tcx>,
+        deref_depth: usize,
         instantiate_self_ty_obligations: &[PredicateObligation<'tcx>],
         pick_diag_hints: &mut PickDiagHints<'_, 'tcx>,
     ) -> Option<PickResult<'tcx>> {
@@ -1690,41 +1880,53 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
         };
 
         let const_ptr_ty = Ty::new_imm_ptr(self.tcx, ty);
-        self.pick_method(const_ptr_ty, instantiate_self_ty_obligations, pick_diag_hints, None).map(
-            |r| {
-                r.map(|mut pick| {
-                    pick.autoderefs = step.autoderefs;
-                    pick.autoref_or_ptr_adjustment = Some(AutorefOrPtrAdjustment::ToConstPtr);
-                    pick
-                })
-            },
+        self.pick_method(
+            const_ptr_ty,
+            deref_depth,
+            instantiate_self_ty_obligations,
+            pick_diag_hints,
+            None,
         )
+        .map(|r| {
+            r.map(|mut pick| {
+                pick.autoderefs = step.autoderefs;
+                pick.autoref_or_ptr_adjustment = Some(AutorefOrPtrAdjustment::ToConstPtr);
+                pick
+            })
+        })
     }
 
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(level = "debug", skip_all, fields(?self_ty))]
     fn pick_method(
         &self,
         self_ty: Ty<'tcx>,
+        deref_depth: usize,
         instantiate_self_ty_obligations: &[PredicateObligation<'tcx>],
         pick_diag_hints: &mut PickDiagHints<'_, 'tcx>,
         pick_constraints: Option<&PickConstraintsForShadowed>,
     ) -> Option<PickResult<'tcx>> {
-        debug!("pick_method(self_ty={})", self.ty_to_string(self_ty));
+        debug!(%deref_depth, "searching inherent candidates");
+        if let res @ Some(_) = self.consider_candidates(
+            self_ty,
+            instantiate_self_ty_obligations,
+            self.flattened_inherent_candidates[deref_depth]
+                .iter()
+                .map(|&id| &self.raw_inherent_candidates[id]),
+            pick_diag_hints,
+            pick_constraints,
+        ) {
+            return res;
+        }
 
-        for (kind, candidates) in
-            [("inherent", &self.inherent_candidates), ("extension", &self.extension_candidates)]
-        {
-            debug!("searching {} candidates", kind);
-            let res = self.consider_candidates(
-                self_ty,
-                instantiate_self_ty_obligations,
-                candidates,
-                pick_diag_hints,
-                pick_constraints,
-            );
-            if let Some(pick) = res {
-                return Some(pick);
-            }
+        debug!("searching extension candidates");
+        if let res @ Some(_) = self.consider_candidates(
+            self_ty,
+            instantiate_self_ty_obligations,
+            &self.extension_candidates,
+            pick_diag_hints,
+            pick_constraints,
+        ) {
+            return res;
         }
 
         if self.private_candidate.get().is_none()
@@ -1744,19 +1946,20 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
         None
     }
 
-    fn consider_candidates(
-        &self,
+    #[instrument(level = "debug", skip_all, ret)]
+    fn consider_candidates<'s>(
+        &'s self,
         self_ty: Ty<'tcx>,
         instantiate_self_ty_obligations: &[PredicateObligation<'tcx>],
-        candidates: &[Candidate<'tcx>],
+        candidates: impl IntoIterator<Item = &'s Candidate<'tcx>>,
         pick_diag_hints: &mut PickDiagHints<'_, 'tcx>,
         pick_constraints: Option<&PickConstraintsForShadowed>,
     ) -> Option<PickResult<'tcx>> {
         let mut applicable_candidates: Vec<_> = candidates
-            .iter()
+            .into_iter()
             .filter(|candidate| {
                 pick_constraints.map_or(true, |pick_constraints| {
-                    pick_constraints.candidate_may_shadow(&candidate)
+                    pick_constraints.candidate_may_shadow(candidate)
                 })
             })
             .map(|probe| {
@@ -2501,6 +2704,7 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
                     pcx.method_name = Some(method_name);
                     pcx.assemble_inherent_candidates();
                     pcx.assemble_extension_candidates_for_all_traits();
+                    pcx.flatten_candidates();
                     pcx.pick_core(&mut Vec::new()).and_then(|pick| pick.ok()).map(|pick| pick.item)
                 })
                 .collect();

--- a/compiler/rustc_hir_typeck/src/method/probe.rs
+++ b/compiler/rustc_hir_typeck/src/method/probe.rs
@@ -375,6 +375,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         )
     }
 
+    #[instrument(level = "debug", skip(self, op))]
     pub(crate) fn probe_op<OP, R>(
         &'a self,
         span: Span,
@@ -429,6 +430,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         ),
                         self_ty_is_opaque: false,
                         autoderefs: 0,
+                        receiver_depth: 0,
                         from_unsafe_deref: false,
                         unsize: false,
                         reachable_via_deref: true,
@@ -585,12 +587,11 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     }
 }
 
+#[instrument(level = "debug", skip(tcx))]
 pub(crate) fn method_autoderef_steps<'tcx>(
     tcx: TyCtxt<'tcx>,
     goal: CanonicalMethodAutoderefStepsGoal<'tcx>,
 ) -> MethodAutoderefStepsResult<'tcx> {
-    debug!("method_autoderef_steps({:?})", goal);
-
     let (ref infcx, goal, inference_vars) = tcx.infer_ctxt().build_with_canonical(DUMMY_SP, &goal);
     let ParamEnvAnd {
         param_env,
@@ -628,35 +629,48 @@ pub(crate) fn method_autoderef_steps<'tcx>(
     };
 
     // If arbitrary self types is not enabled, we follow the chain of
-    // `Deref<Target=T>`. If arbitrary self types is enabled, we instead
-    // follow the chain of `Receiver<Target=T>`, but we also record whether
-    // such types are reachable by following the (potentially shorter)
-    // chain of `Deref<Target=T>`. We will use the first list when finding
-    // potentially relevant function implementations (e.g. relevant impl blocks)
-    // but the second list when determining types that the receiver may be
-    // converted to, in order to find out which of those methods might actually
-    // be callable.
-    let mut autoderef_via_deref =
-        Autoderef::new(infcx, param_env, hir::def_id::CRATE_DEF_ID, DUMMY_SP, self_ty)
-            .include_raw_pointers()
-            .silence_errors();
+    // `Deref` only.
+    // If arbitrary self types is enabled, we additionally
+    // follow the chain of `Receiver`.
+    // When the feature is enabled, we will use the first list when
+    // finding applicable method receiving value `self`,
+    // from which a second list chasing `Receiver` traits is followed
+    // when determining the type of `Self` and the `impl` block with
+    // such `Self` type.
+    let autoderef_cache = Default::default();
+    let mut autoderef_via_deref = Autoderef::new(
+        infcx,
+        Some(&autoderef_cache),
+        param_env,
+        hir::def_id::CRATE_DEF_ID,
+        DUMMY_SP,
+        self_ty,
+    )
+    .include_raw_pointers()
+    .silence_errors();
 
     let mut reached_raw_pointer = false;
     let arbitrary_self_types_enabled =
         tcx.features().arbitrary_self_types() || tcx.features().arbitrary_self_types_pointers();
     let (mut steps, reached_recursion_limit): (Vec<_>, bool) = if arbitrary_self_types_enabled {
-        let reachable_via_deref =
-            autoderef_via_deref.by_ref().map(|_| true).chain(std::iter::repeat(false));
+        let mut reached_recursion_limit = false;
+        let mut steps = vec![];
 
-        let mut autoderef_via_receiver =
-            Autoderef::new(infcx, param_env, hir::def_id::CRATE_DEF_ID, DUMMY_SP, self_ty)
-                .include_raw_pointers()
-                .use_receiver_trait()
-                .silence_errors();
-        let steps = autoderef_via_receiver
-            .by_ref()
-            .zip(reachable_via_deref)
-            .map(|((ty, d), reachable_via_deref)| {
+        for (ty, autoderefs) in &mut autoderef_via_deref {
+            let mut recv_chain = Autoderef::new(
+                infcx,
+                Some(&autoderef_cache),
+                param_env,
+                hir::def_id::CRATE_DEF_ID,
+                DUMMY_SP,
+                ty,
+            )
+            .follow_receiver_chain()
+            .silence_errors();
+            if tcx.features().arbitrary_self_types_pointers() {
+                recv_chain = recv_chain.include_raw_pointers();
+            }
+            steps.extend(recv_chain.by_ref().map(|(ty, receiver_depth)| {
                 let step = CandidateStep {
                     self_ty: infcx.make_query_response_ignoring_pending_obligations(
                         inference_vars,
@@ -664,23 +678,27 @@ pub(crate) fn method_autoderef_steps<'tcx>(
                         prev_opaque_entries,
                     ),
                     self_ty_is_opaque: self_ty_is_opaque(ty),
-                    autoderefs: d,
+                    autoderefs,
+                    receiver_depth,
                     from_unsafe_deref: reached_raw_pointer,
                     unsize: false,
-                    reachable_via_deref,
+                    reachable_via_deref: receiver_depth == 0,
                 };
-                if ty.is_raw_ptr() {
-                    // all the subsequent steps will be from_unsafe_deref
-                    reached_raw_pointer = true;
-                }
+
                 step
-            })
-            .collect();
-        (steps, autoderef_via_receiver.reached_recursion_limit())
+            }));
+            debug!(?steps, "finished walking receiver chain");
+            if ty.is_raw_ptr() {
+                // all the subsequent steps will be from_unsafe_deref
+                reached_raw_pointer = true;
+            }
+            reached_recursion_limit |= recv_chain.reached_recursion_limit();
+        }
+        (steps, reached_recursion_limit || autoderef_via_deref.reached_recursion_limit())
     } else {
         let steps = autoderef_via_deref
             .by_ref()
-            .map(|(ty, d)| {
+            .map(|(ty, autoderefs)| {
                 let step = CandidateStep {
                     self_ty: infcx.make_query_response_ignoring_pending_obligations(
                         inference_vars,
@@ -688,7 +706,8 @@ pub(crate) fn method_autoderef_steps<'tcx>(
                         prev_opaque_entries,
                     ),
                     self_ty_is_opaque: self_ty_is_opaque(ty),
-                    autoderefs: d,
+                    autoderefs,
+                    receiver_depth: 0,
                     from_unsafe_deref: reached_raw_pointer,
                     unsize: false,
                     reachable_via_deref: true,
@@ -730,6 +749,7 @@ pub(crate) fn method_autoderef_steps<'tcx>(
                 ),
                 self_ty_is_opaque: false,
                 autoderefs,
+                receiver_depth: 0,
                 // this could be from an unsafe deref if we had
                 // a *mut/const [T; N]
                 from_unsafe_deref: reached_raw_pointer,
@@ -830,7 +850,7 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
 
     fn assemble_inherent_candidates(&mut self) {
         for step in self.steps.iter() {
-            self.assemble_probe(&step.self_ty, step.autoderefs);
+            self.assemble_probe(&step.self_ty, step.receiver_depth);
         }
     }
 
@@ -1272,6 +1292,7 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
         })
     }
 
+    #[instrument(level = "debug", skip(self))]
     fn pick_all_method<'b>(
         &self,
         pick_diag_hints: &mut PickDiagHints<'b, 'tcx>,
@@ -1284,7 +1305,7 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
             // steps which can only be reached by following the (longer) `Receiver` chain.
             .filter(|step| step.reachable_via_deref)
             .filter(|step| {
-                debug!("pick_all_method: step={:?}", step);
+                debug!(?step, ?step.from_unsafe_deref);
                 // skip types that are from a type error or that would require dereferencing
                 // a raw pointer
                 !step.self_ty.value.references_error() && !step.from_unsafe_deref
@@ -1310,22 +1331,23 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
 
                 // Check for shadowing of a by-reference method by a by-value method (see comments on check_for_shadowing)
                 if let Some(by_value_pick) = by_value_pick {
-                    if let Ok(by_value_pick) = by_value_pick.as_ref() {
-                        if by_value_pick.kind == PickKind::InherentImplPick {
-                            for mutbl in [hir::Mutability::Not, hir::Mutability::Mut] {
-                                if let Err(e) = self.check_for_shadowed_autorefd_method(
-                                    by_value_pick,
-                                    step,
-                                    self_ty,
-                                    &instantiate_self_ty_obligations,
-                                    mutbl,
-                                    track_unstable_candidates,
-                                ) {
-                                    return Some(Err(e));
-                                }
+                    if let Ok(by_value_pick) = &by_value_pick
+                        && matches!(by_value_pick.kind, PickKind::InherentImplPick)
+                    {
+                        for mutbl in [hir::Mutability::Not, hir::Mutability::Mut] {
+                            if let Err(e) = self.check_for_shadowed_autorefd_method(
+                                by_value_pick,
+                                step,
+                                self_ty,
+                                &instantiate_self_ty_obligations,
+                                mutbl,
+                                track_unstable_candidates,
+                            ) {
+                                return Some(Err(e));
                             }
                         }
                     }
+
                     return Some(by_value_pick);
                 }
 
@@ -1339,21 +1361,22 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
                 );
                 // Check for shadowing of a by-mut-ref method by a by-reference method (see comments on check_for_shadowing)
                 if let Some(autoref_pick) = autoref_pick {
-                    if let Ok(autoref_pick) = autoref_pick.as_ref() {
+                    if let Ok(autoref_pick) = &autoref_pick
+                        && matches!(autoref_pick.kind, PickKind::InherentImplPick)
+                    {
                         // Check we're not shadowing others
-                        if autoref_pick.kind == PickKind::InherentImplPick {
-                            if let Err(e) = self.check_for_shadowed_autorefd_method(
-                                autoref_pick,
-                                step,
-                                self_ty,
-                                &instantiate_self_ty_obligations,
-                                hir::Mutability::Mut,
-                                track_unstable_candidates,
-                            ) {
-                                return Some(Err(e));
-                            }
+                        if let Err(e) = self.check_for_shadowed_autorefd_method(
+                            autoref_pick,
+                            step,
+                            self_ty,
+                            &instantiate_self_ty_obligations,
+                            hir::Mutability::Mut,
+                            track_unstable_candidates,
+                        ) {
+                            return Some(Err(e));
                         }
                     }
+
                     return Some(autoref_pick);
                 }
 
@@ -1408,20 +1431,26 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
     }
 
     /// Check for cases where arbitrary self types allows shadowing
-    /// of methods that might be a compatibility break. Specifically,
-    /// we have something like:
+    /// of methods that might be a compatibility break.
+    ///
+    /// As an example, first we examine this code.
     /// ```ignore (illustrative)
     /// struct A;
     /// impl A {
-    ///   fn foo(self: &NonNull<A>) {}
-    ///      // note this is by reference
+    ///     fn foo(self: &NonNull<A>) {
+    ///          //      ^ note that the receiver is a reference
+    ///     }
     /// }
     /// ```
-    /// then we've come along and added this method to `NonNull`:
+    /// Then we've come along and added this method to `NonNull`:
     /// ```ignore (illustrative)
-    ///   fn foo(self)  // note this is by value
+    /// impl A {
+    ///     fn foo(self: A)  // note this is by value
+    /// }
     /// ```
-    /// Report an error in this case.
+    /// Here we report an error on the ground of shadowing `foo` in this case.
+    /// Shadowing happens when an inherent method candidate appears deeper in
+    /// the Receiver sub-chain that is rooted from the same `self` value.
     fn check_for_shadowed_autorefd_method(
         &self,
         possible_shadower: &Pick<'tcx>,
@@ -1445,19 +1474,20 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
         // unstable_candidates in order to reflect the behavior of the
         // main search.
         let mut pick_diag_hints = PickDiagHints {
-            unstable_candidates: if track_unstable_candidates { Some(Vec::new()) } else { None },
-            unsatisfied_predicates: &mut Vec::new(),
+            unstable_candidates: track_unstable_candidates.then(Vec::new),
+            unsatisfied_predicates: &mut vec![],
         };
         // Set criteria for how we find methods possibly shadowed by 'possible_shadower'
         let pick_constraints = PickConstraintsForShadowed {
             // It's the same `self` type...
             autoderefs: possible_shadower.autoderefs,
             // ... but the method was found in an impl block determined
-            // by searching further along the Receiver chain than the other,
+            // by searching further along the Receiver sub-chain than the other,
             // showing that it's a smart pointer type causing the problem...
             receiver_steps: possible_shadower.receiver_steps,
             // ... and they don't end up pointing to the same item in the
-            // first place (could happen with things like blanket impls for T)
+            // first place.
+            // This could happen with things like blanket impls for T.
             def_id: possible_shadower.item.def_id,
         };
         // A note on the autoderefs above. Within pick_by_value_method, an extra
@@ -1477,13 +1507,16 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
         // ```
         // then we've come along and added this method to `NonNull`:
         // ```
-        //   fn foo(&self)  // note this is by single reference
+        // impl<T> NonNull<T> {
+        //   ..
+        //   fn foo(&self) { .. } // note this is by single reference
+        // }
         // ```
         // and the call is:
         // ```
-        // let bar = NonNull<Foo>;
-        // let bar = &foo;
-        // bar.foo();
+        // let a: NonNull<A> = ..;
+        // let ref_a = &a;
+        // ref_a.foo();
         // ```
         // In these circumstances, the logic is wrong, and we wouldn't spot
         // the shadowing, because the autoderef-based maths wouldn't line up.
@@ -1499,7 +1532,7 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
         );
         // Look for actual pairs of shadower/shadowed which are
         // the sort of shadowing case we want to avoid. Specifically...
-        if let Some(Ok(possible_shadowed)) = potentially_shadowed_pick.as_ref() {
+        if let Some(Ok(possible_shadowed)) = &potentially_shadowed_pick {
             let sources = [possible_shadower, possible_shadowed]
                 .into_iter()
                 .map(|p| self.candidate_source_from_pick(p))
@@ -1639,6 +1672,7 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
     /// If `self_ty` is `*mut T` then this picks `*const T` methods. The reason why we have a
     /// special case for this is because going from `*mut T` to `*const T` with autoderefs and
     /// autorefs would require dereferencing the pointer, which is not safe.
+    #[instrument(level = "debug", skip(self, pick_diag_hints))]
     fn pick_const_ptr_method(
         &self,
         step: &CandidateStep<'tcx>,
@@ -1667,6 +1701,7 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
         )
     }
 
+    #[instrument(level = "debug", skip_all)]
     fn pick_method(
         &self,
         self_ty: Ty<'tcx>,
@@ -1692,8 +1727,8 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
             }
         }
 
-        if self.private_candidate.get().is_none() {
-            if let Some(Ok(pick)) = self.consider_candidates(
+        if self.private_candidate.get().is_none()
+            && let Some(Ok(pick)) = self.consider_candidates(
                 self_ty,
                 instantiate_self_ty_obligations,
                 &self.private_candidates,
@@ -1702,9 +1737,9 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
                     unsatisfied_predicates: &mut vec![],
                 },
                 None,
-            ) {
-                self.private_candidate.set(Some((pick.item.as_def_kind(), pick.item.def_id)));
-            }
+            )
+        {
+            self.private_candidate.set(Some((pick.item.as_def_kind(), pick.item.def_id)));
         }
         None
     }
@@ -1720,9 +1755,9 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
         let mut applicable_candidates: Vec<_> = candidates
             .iter()
             .filter(|candidate| {
-                pick_constraints
-                    .map(|pick_constraints| pick_constraints.candidate_may_shadow(&candidate))
-                    .unwrap_or(true)
+                pick_constraints.map_or(true, |pick_constraints| {
+                    pick_constraints.candidate_may_shadow(&candidate)
+                })
             })
             .map(|probe| {
                 (
@@ -1735,7 +1770,7 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
                     ),
                 )
             })
-            .filter(|&(_, status)| status != ProbeResult::NoMatch)
+            .filter(|&(_, status)| !matches!(status, ProbeResult::NoMatch))
             .collect();
 
         debug!("applicable_candidates: {:?}", applicable_candidates);

--- a/compiler/rustc_middle/src/queries.rs
+++ b/compiler/rustc_middle/src/queries.rs
@@ -1146,7 +1146,7 @@ rustc_queries! {
     }
 
     query incoherent_impls(key: SimplifiedType) -> &'tcx [DefId] {
-        desc { "collecting all inherent impls for `{:?}`", key }
+        desc { "collecting all incoherent impls for `{:?}`", key }
     }
 
     /// Unsafety-check this `LocalDefId`.

--- a/compiler/rustc_middle/src/traits/query.rs
+++ b/compiler/rustc_middle/src/traits/query.rs
@@ -172,6 +172,7 @@ pub struct CandidateStep<'tcx> {
     /// reachable via Deref when examining what the receiver type can
     /// be converted into by autodereffing.
     pub reachable_via_deref: bool,
+    pub receiver_depth: usize,
 }
 
 #[derive(Copy, Clone, Debug, HashStable)]

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -2612,6 +2612,8 @@ mod ref_mut {
     use std::cell::{BorrowMutError, Cell, Ref, RefCell, RefMut};
     use std::fmt;
     use std::ops::Deref;
+    #[cfg(not(bootstrap))]
+    use std::ops::Receiver;
 
     use crate::Resolver;
 
@@ -2627,6 +2629,10 @@ mod ref_mut {
         fn deref(&self) -> &Self::Target {
             self.p
         }
+    }
+    #[cfg(not(bootstrap))]
+    impl<'a, T> Receiver for RefOrMut<'a, T> {
+        type Target = T;
     }
 
     impl<'a, T> AsRef<T> for RefOrMut<'a, T> {

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -404,6 +404,7 @@ symbols! {
         arbitrary_enum_discriminant,
         arbitrary_self_types,
         arbitrary_self_types_pointers,
+        arbitrary_self_types_split_chains,
         areg,
         args,
         arith_offset,

--- a/library/alloc/src/boxed.rs
+++ b/library/alloc/src/boxed.rs
@@ -196,7 +196,7 @@ use core::mem::MaybeUninit;
 use core::mem::{self, SizedTypeProperties};
 use core::ops::{
     AsyncFn, AsyncFnMut, AsyncFnOnce, CoerceUnsized, Coroutine, CoroutineState, Deref, DerefMut,
-    DerefPure, DispatchFromDyn, LegacyReceiver,
+    DerefPure, DispatchFromDyn, LegacyReceiver, Receiver,
 };
 #[cfg(not(no_global_oom_handling))]
 use core::ops::{Residual, Try};
@@ -2231,6 +2231,10 @@ unsafe impl<T: ?Sized, A: Allocator> DerefPure for Box<T, A> {}
 
 #[unstable(feature = "legacy_receiver_trait", issue = "none")]
 impl<T: ?Sized, A: Allocator> LegacyReceiver for Box<T, A> {}
+#[unstable(feature = "arbitrary_self_types", issue = "44874")]
+impl<T: ?Sized, A: Allocator> Receiver for Box<T, A> {
+    type Target = T;
+}
 
 #[stable(feature = "boxed_closure_impls", since = "1.35.0")]
 impl<Args: Tuple, F: FnOnce<Args> + ?Sized, A: Allocator> FnOnce<Args> for Box<F, A> {

--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -87,6 +87,8 @@
 // Library features:
 // tidy-alphabetical-start
 #![feature(allocator_api)]
+#![feature(arbitrary_self_types)]
+#![feature(arbitrary_self_types_pointers)]
 #![feature(array_into_iter_constructors)]
 #![feature(ascii_char)]
 #![feature(async_fn_traits)]

--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -254,7 +254,9 @@ use core::iter;
 use core::marker::{PhantomData, Unsize};
 use core::mem::{self, ManuallyDrop};
 use core::num::NonZeroUsize;
-use core::ops::{CoerceUnsized, Deref, DerefMut, DerefPure, DispatchFromDyn, LegacyReceiver};
+use core::ops::{
+    CoerceUnsized, Deref, DerefMut, DerefPure, DispatchFromDyn, LegacyReceiver, Receiver,
+};
 #[cfg(not(no_global_oom_handling))]
 use core::ops::{Residual, Try};
 use core::panic::{RefUnwindSafe, UnwindSafe};
@@ -2436,6 +2438,10 @@ unsafe impl<T: ?Sized, A: Allocator> DerefPure for UniqueRc<T, A> {}
 
 #[unstable(feature = "legacy_receiver_trait", issue = "none")]
 impl<T: ?Sized> LegacyReceiver for Rc<T> {}
+#[unstable(feature = "arbitrary_self_types", issue = "44874")]
+impl<T: ?Sized> Receiver for Rc<T> {
+    type Target = T;
+}
 
 #[stable(feature = "rust1", since = "1.0.0")]
 unsafe impl<#[may_dangle] T: ?Sized, A: Allocator> Drop for Rc<T, A> {

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -21,7 +21,9 @@ use core::iter;
 use core::marker::{PhantomData, Unsize};
 use core::mem::{self, ManuallyDrop};
 use core::num::NonZeroUsize;
-use core::ops::{CoerceUnsized, Deref, DerefMut, DerefPure, DispatchFromDyn, LegacyReceiver};
+use core::ops::{
+    CoerceUnsized, Deref, DerefMut, DerefPure, DispatchFromDyn, LegacyReceiver, Receiver,
+};
 #[cfg(not(no_global_oom_handling))]
 use core::ops::{Residual, Try};
 use core::panic::{RefUnwindSafe, UnwindSafe};
@@ -2434,6 +2436,10 @@ unsafe impl<T: ?Sized, A: Allocator> DerefPure for Arc<T, A> {}
 
 #[unstable(feature = "legacy_receiver_trait", issue = "none")]
 impl<T: ?Sized> LegacyReceiver for Arc<T> {}
+#[unstable(feature = "arbitrary_self_types", issue = "44874")]
+impl<T: ?Sized> Receiver for Arc<T> {
+    type Target = T;
+}
 
 #[cfg(not(no_global_oom_handling))]
 impl<T: ?Sized + CloneToUninit, A: Allocator + Clone> Arc<T, A> {

--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -1195,7 +1195,7 @@ pub trait FnPtr: Copy + Clone {
 /// ```
 /// #![feature(arbitrary_self_types, derive_coerce_pointee)]
 /// use std::marker::CoercePointee;
-/// use std::ops::Deref;
+/// use std::ops::{Deref, Receiver};
 ///
 /// #[derive(CoercePointee)]
 /// #[repr(transparent)]
@@ -1207,8 +1207,12 @@ pub trait FnPtr: Copy + Clone {
 ///         &self.0
 ///     }
 /// }
+/// impl<T: ?Sized> Receiver for MySmartPointer<T> {
+///     type Target = T;
+/// }
 ///
-/// // You can always define this trait. (as long as you have #![feature(arbitrary_self_types)])
+/// // You can define this trait,
+/// // given that you also enable `#![feature(arbitrary_self_types)]`.
 /// trait MyTrait {
 ///     fn func(self: MySmartPointer<Self>);
 /// }

--- a/library/core/src/ops/deref.rs
+++ b/library/core/src/ops/deref.rs
@@ -303,9 +303,8 @@ unsafe impl<T: ?Sized> DerefPure for &mut T {}
 
 /// Indicates that a struct can be used as a method receiver.
 /// That is, a type can use this type as a type of `self`, like this:
-/// ```compile_fail
-/// # // This is currently compile_fail because the compiler-side parts
-/// # // of arbitrary_self_types are not implemented
+/// ```
+/// #![feature(arbitrary_self_types)]
 /// use std::ops::Receiver;
 ///
 /// struct SmartPointer<T>(T);
@@ -374,14 +373,6 @@ pub trait Receiver: PointeeSized {
     type Target: ?Sized;
 }
 
-#[unstable(feature = "arbitrary_self_types", issue = "44874")]
-impl<P: ?Sized, T: ?Sized> Receiver for P
-where
-    P: Deref<Target = T>,
-{
-    type Target = T;
-}
-
 /// Indicates that a struct can be used as a method receiver, without the
 /// `arbitrary_self_types` feature. This is implemented by stdlib pointer types like `Box<T>`,
 /// `Rc<T>`, `&T`, and `Pin<P>`.
@@ -399,6 +390,14 @@ pub trait LegacyReceiver: PointeeSized {
 
 #[unstable(feature = "legacy_receiver_trait", issue = "none")]
 impl<T: PointeeSized> LegacyReceiver for &T {}
+#[unstable(feature = "arbitrary_self_types", issue = "44874")]
+impl<T: ?Sized> Receiver for &T {
+    type Target = T;
+}
 
 #[unstable(feature = "legacy_receiver_trait", issue = "none")]
 impl<T: PointeeSized> LegacyReceiver for &mut T {}
+#[unstable(feature = "arbitrary_self_types", issue = "44874")]
+impl<T: ?Sized> Receiver for &mut T {
+    type Target = T;
+}

--- a/library/core/src/pin.rs
+++ b/library/core/src/pin.rs
@@ -919,7 +919,9 @@
 #![stable(feature = "pin", since = "1.33.0")]
 
 use crate::hash::{Hash, Hasher};
-use crate::ops::{CoerceUnsized, Deref, DerefMut, DerefPure, DispatchFromDyn, LegacyReceiver};
+use crate::ops::{
+    CoerceUnsized, Deref, DerefMut, DerefPure, DispatchFromDyn, LegacyReceiver, Receiver,
+};
 #[allow(unused_imports)]
 use crate::{
     cell::{RefCell, UnsafeCell},
@@ -1780,6 +1782,10 @@ unsafe impl<Ptr: DerefPure> DerefPure for Pin<Ptr> {}
 
 #[unstable(feature = "legacy_receiver_trait", issue = "none")]
 impl<Ptr: LegacyReceiver> LegacyReceiver for Pin<Ptr> {}
+#[unstable(feature = "arbitrary_self_types", issue = "44874")]
+impl<Ptr> Receiver for Pin<Ptr> {
+    type Target = Ptr;
+}
 
 #[stable(feature = "pin", since = "1.33.0")]
 impl<Ptr: fmt::Debug> fmt::Debug for Pin<Ptr> {

--- a/src/tools/miri/src/shims/files.rs
+++ b/src/tools/miri/src/shims/files.rs
@@ -4,6 +4,8 @@ use std::fs::{File, Metadata};
 use std::io::{ErrorKind, IsTerminal, Seek, SeekFrom, Write};
 use std::marker::CoercePointee;
 use std::ops::Deref;
+#[cfg(not(bootstrap))]
+use std::ops::Receiver;
 use std::rc::{Rc, Weak};
 use std::{fs, io};
 
@@ -42,6 +44,10 @@ impl<T: ?Sized> Deref for FileDescriptionRef<T> {
     fn deref(&self) -> &T {
         &self.0.inner
     }
+}
+#[cfg(not(bootstrap))]
+impl<T: ?Sized> Receiver for FileDescriptionRef<T> {
+    type Target = T;
 }
 
 impl<T: ?Sized> FileDescriptionRef<T> {

--- a/src/tools/miri/tests/pass/dyn-arbitrary-self.rs
+++ b/src/tools/miri/tests/pass/dyn-arbitrary-self.rs
@@ -1,6 +1,12 @@
 //@revisions: stack tree
 //@[tree]compile-flags: -Zmiri-tree-borrows
-#![feature(arbitrary_self_types_pointers, unsize, coerce_unsized, dispatch_from_dyn)]
+#![feature(
+    arbitrary_self_types,
+    arbitrary_self_types_pointers,
+    unsize,
+    coerce_unsized,
+    dispatch_from_dyn
+)]
 #![feature(rustc_attrs)]
 
 fn pin_box_dyn() {
@@ -63,7 +69,7 @@ fn stdlib_pointers() {
 
 fn pointers_and_wrappers() {
     use std::marker::Unsize;
-    use std::ops::{CoerceUnsized, Deref, DispatchFromDyn};
+    use std::ops::{CoerceUnsized, Deref, DispatchFromDyn, Receiver};
 
     struct Ptr<T: ?Sized>(Box<T>);
 
@@ -73,6 +79,9 @@ fn pointers_and_wrappers() {
         fn deref(&self) -> &T {
             &*self.0
         }
+    }
+    impl<T: ?Sized> Receiver for Ptr<T> {
+        type Target = T;
     }
 
     impl<T: Unsize<U> + ?Sized, U: ?Sized> CoerceUnsized<Ptr<U>> for Ptr<T> {}
@@ -86,6 +95,9 @@ fn pointers_and_wrappers() {
         fn deref(&self) -> &T {
             &self.0
         }
+    }
+    impl<T: ?Sized> Receiver for Wrapper<T> {
+        type Target = T;
     }
 
     impl<T: CoerceUnsized<U>, U> CoerceUnsized<Wrapper<U>> for Wrapper<T> {}

--- a/tests/crashes/138564.rs
+++ b/tests/crashes/138564.rs
@@ -3,7 +3,7 @@
 #![feature(unsize, dispatch_from_dyn, arbitrary_self_types)]
 
 use std::marker::Unsize;
-use std::ops::{Deref, DispatchFromDyn};
+use std::ops::{Deref, DispatchFromDyn, Receiver};
 
 #[repr(align(16))]
 pub struct MyPointer<T: ?Sized>(*const T);
@@ -15,7 +15,9 @@ impl<T: ?Sized> Deref for MyPointer<T> {
         unimplemented!()
     }
 }
-
+impl<T: ?Sized> Receiver for MyPointer<T> {
+    type Target = T;
+}
 pub trait Trait {
     fn foo(self: MyPointer<Self>) {}
 }

--- a/tests/ui/abi/invalid-self-parameter-type-56806.stderr
+++ b/tests/ui/abi/invalid-self-parameter-type-56806.stderr
@@ -5,7 +5,7 @@ LL |     fn dyn_instead_of_self(self: Box<dyn Trait>);
    |                                  ^^^^^^^^^^^^^^
    |
    = note: type of `self` must be `Self` or a type that dereferences to it
-   = help: consider changing to `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
+   = help: consider changing to `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` where P is one of the previous types except `Self`; alternatively, consider implement `Receiver` trait on the type of `self`, where applicable
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/async-await/inference_var_self_argument.stderr
+++ b/tests/ui/async-await/inference_var_self_argument.stderr
@@ -5,7 +5,7 @@ LL |     async fn foo(self: &dyn Foo) {
    |                        ^^^^^^^^
    |
    = note: type of `self` must be `Self` or a type that dereferences to it
-   = help: consider changing to `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
+   = help: consider changing to `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` where P is one of the previous types except `Self`; alternatively, consider implement `Receiver` trait on the type of `self`, where applicable
 
 error[E0038]: the trait `Foo` is not dyn compatible
   --> $DIR/inference_var_self_argument.rs:5:33

--- a/tests/ui/async-await/issue-66312.stderr
+++ b/tests/ui/async-await/issue-66312.stderr
@@ -5,7 +5,7 @@ LL |     fn is_some(self: T);
    |                      ^
    |
    = note: type of `self` must be `Self` or a type that dereferences to it
-   = help: consider changing to `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
+   = help: consider changing to `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` where P is one of the previous types except `Self`; alternatively, consider implement `Receiver` trait on the type of `self`, where applicable
 
 error[E0308]: mismatched types
   --> $DIR/issue-66312.rs:9:8

--- a/tests/ui/deriving/deriving-coerce-pointee.rs
+++ b/tests/ui/deriving/deriving-coerce-pointee.rs
@@ -2,6 +2,7 @@
 #![feature(derive_coerce_pointee, arbitrary_self_types)]
 
 use std::marker::CoercePointee;
+use std::ops::{Deref, Receiver};
 
 #[derive(CoercePointee)]
 #[repr(transparent)]
@@ -16,11 +17,15 @@ impl<T: ?Sized> Clone for MyPointer<'_, T> {
     }
 }
 
-impl<'a, T: ?Sized> core::ops::Deref for MyPointer<'a, T> {
+impl<'a, T: ?Sized> Deref for MyPointer<'a, T> {
     type Target = T;
     fn deref(&self) -> &'a T {
         self.ptr
     }
+}
+
+impl<'a, T: ?Sized> Receiver for MyPointer<'a, T> {
+    type Target = T;
 }
 
 struct MyValue(u32);

--- a/tests/ui/feature-gates/feature-gate-arbitrary-self-types.rs
+++ b/tests/ui/feature-gates/feature-gate-arbitrary-self-types.rs
@@ -1,6 +1,4 @@
-use std::{
-    ops::Deref,
-};
+use std::ops::Deref;
 
 struct Ptr<T: ?Sized>(Box<T>);
 
@@ -13,17 +11,17 @@ impl<T: ?Sized> Deref for Ptr<T> {
 }
 
 trait Foo {
-    fn foo(self: Ptr<Self>); //~ ERROR `Ptr<Self>` cannot be used as the type of `self` without
+    fn foo(self: Ptr<Self>); //~ ERROR invalid `self` parameter type: `Ptr<Self>`
 }
 
 struct Bar;
 
 impl Foo for Bar {
-    fn foo(self: Ptr<Self>) {} //~ ERROR `Ptr<Bar>` cannot be used as the type of `self` without
+    fn foo(self: Ptr<Self>) {} //~ ERROR invalid `self` parameter type: `Ptr<Bar>`
 }
 
 impl Bar {
-    fn bar(self: Box<Ptr<Self>>) {} //~ ERROR `Box<Ptr<Bar>>` cannot be used as the
+    fn bar(self: Box<Ptr<Self>>) {} //~ ERROR invalid `self` parameter type: `Box<Ptr<Bar>>`
 }
 
 fn main() {}

--- a/tests/ui/feature-gates/feature-gate-arbitrary-self-types.stderr
+++ b/tests/ui/feature-gates/feature-gate-arbitrary-self-types.stderr
@@ -1,36 +1,30 @@
-error[E0658]: `Ptr<Bar>` cannot be used as the type of `self` without the `arbitrary_self_types` feature
-  --> $DIR/feature-gate-arbitrary-self-types.rs:22:18
+error[E0307]: invalid `self` parameter type: `Ptr<Bar>`
+  --> $DIR/feature-gate-arbitrary-self-types.rs:20:18
    |
 LL |     fn foo(self: Ptr<Self>) {}
    |                  ^^^^^^^^^
    |
-   = note: see issue #44874 <https://github.com/rust-lang/rust/issues/44874> for more information
-   = help: add `#![feature(arbitrary_self_types)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-   = help: consider changing to `self`, `&self`, `&mut self`, or a type implementing `Receiver` such as `self: Box<Self>`, `self: Rc<Self>`, or `self: Arc<Self>`
+   = note: type of `self` must be `Self` or a type that dereferences to it
+   = help: consider changing to `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` where P is one of the previous types except `Self`; alternatively, consider implement `Receiver` trait on the type of `self`, where applicable
 
-error[E0658]: `Box<Ptr<Bar>>` cannot be used as the type of `self` without the `arbitrary_self_types` feature
-  --> $DIR/feature-gate-arbitrary-self-types.rs:26:18
+error[E0307]: invalid `self` parameter type: `Box<Ptr<Bar>>`
+  --> $DIR/feature-gate-arbitrary-self-types.rs:24:18
    |
 LL |     fn bar(self: Box<Ptr<Self>>) {}
    |                  ^^^^^^^^^^^^^^
    |
-   = note: see issue #44874 <https://github.com/rust-lang/rust/issues/44874> for more information
-   = help: add `#![feature(arbitrary_self_types)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-   = help: consider changing to `self`, `&self`, `&mut self`, or a type implementing `Receiver` such as `self: Box<Self>`, `self: Rc<Self>`, or `self: Arc<Self>`
+   = note: type of `self` must be `Self` or a type that dereferences to it
+   = help: consider changing to `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` where P is one of the previous types except `Self`; alternatively, consider implement `Receiver` trait on the type of `self`, where applicable
 
-error[E0658]: `Ptr<Self>` cannot be used as the type of `self` without the `arbitrary_self_types` feature
-  --> $DIR/feature-gate-arbitrary-self-types.rs:16:18
+error[E0307]: invalid `self` parameter type: `Ptr<Self>`
+  --> $DIR/feature-gate-arbitrary-self-types.rs:14:18
    |
 LL |     fn foo(self: Ptr<Self>);
    |                  ^^^^^^^^^
    |
-   = note: see issue #44874 <https://github.com/rust-lang/rust/issues/44874> for more information
-   = help: add `#![feature(arbitrary_self_types)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-   = help: consider changing to `self`, `&self`, `&mut self`, or a type implementing `Receiver` such as `self: Box<Self>`, `self: Rc<Self>`, or `self: Arc<Self>`
+   = note: type of `self` must be `Self` or a type that dereferences to it
+   = help: consider changing to `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` where P is one of the previous types except `Self`; alternatively, consider implement `Receiver` trait on the type of `self`, where applicable
 
 error: aborting due to 3 previous errors
 
-For more information about this error, try `rustc --explain E0658`.
+For more information about this error, try `rustc --explain E0307`.

--- a/tests/ui/feature-gates/feature-gate-dispatch-from-dyn-cell.stderr
+++ b/tests/ui/feature-gates/feature-gate-dispatch-from-dyn-cell.stderr
@@ -5,7 +5,7 @@ LL |     fn cell(self: Cell<&Self>);
    |                   ^^^^^^^^^^^
    |
    = note: type of `self` must be `Self` or a type that dereferences to it
-   = help: consider changing to `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
+   = help: consider changing to `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` where P is one of the previous types except `Self`; alternatively, consider implement `Receiver` trait on the type of `self`, where applicable
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-dispatch-from-dyn-missing-impl.rs
+++ b/tests/ui/feature-gates/feature-gate-dispatch-from-dyn-missing-impl.rs
@@ -2,10 +2,8 @@
 
 #![feature(arbitrary_self_types, unsize, coerce_unsized)]
 
-use std::{
-    marker::Unsize,
-    ops::{CoerceUnsized, Deref},
-};
+use std::marker::Unsize;
+use std::ops::{CoerceUnsized, Deref, Receiver};
 
 struct Ptr<T: ?Sized>(Box<T>);
 
@@ -15,6 +13,9 @@ impl<T: ?Sized> Deref for Ptr<T> {
     fn deref(&self) -> &T {
         &*self.0
     }
+}
+impl<T: ?Sized> Receiver for Ptr<T> {
+    type Target = T;
 }
 
 impl<T: Unsize<U> + ?Sized, U: ?Sized> CoerceUnsized<Ptr<U>> for Ptr<T> {}

--- a/tests/ui/feature-gates/feature-gate-dispatch-from-dyn-missing-impl.stderr
+++ b/tests/ui/feature-gates/feature-gate-dispatch-from-dyn-missing-impl.stderr
@@ -1,5 +1,5 @@
 error[E0038]: the trait `Trait` is not dyn compatible
-  --> $DIR/feature-gate-dispatch-from-dyn-missing-impl.rs:32:33
+  --> $DIR/feature-gate-dispatch-from-dyn-missing-impl.rs:33:33
    |
 LL |     fn ptr(self: Ptr<Self>);
    |                  --------- help: consider changing method `ptr`'s `self` parameter to be `&self`: `&Self`
@@ -9,7 +9,7 @@ LL |     Ptr(Box::new(4)) as Ptr<dyn Trait>;
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
-  --> $DIR/feature-gate-dispatch-from-dyn-missing-impl.rs:25:18
+  --> $DIR/feature-gate-dispatch-from-dyn-missing-impl.rs:26:18
    |
 LL | trait Trait {
    |       ----- this trait is not dyn compatible...

--- a/tests/ui/methods/method-deref-to-same-trait-object-with-separate-params.rs
+++ b/tests/ui/methods/method-deref-to-same-trait-object-with-separate-params.rs
@@ -10,7 +10,7 @@
 use std::marker::PhantomData;
 
 mod internal {
-    use std::ops::{CoerceUnsized, Deref, DispatchFromDyn};
+    use std::ops::{CoerceUnsized, Deref, DispatchFromDyn, Receiver};
     use std::marker::{PhantomData, Unsize};
 
     pub struct Smaht<T: ?Sized, MISC>(pub Box<T>, pub PhantomData<MISC>);
@@ -21,6 +21,9 @@ mod internal {
         fn deref(&self) -> &Self::Target {
             &self.0
         }
+    }
+    impl<T: ?Sized, MISC> Receiver for Smaht<T, MISC> {
+        type Target = T;
     }
     impl<T: ?Sized + Unsize<U>, U: ?Sized, MISC> CoerceUnsized<Smaht<U, MISC>>
         for Smaht<T, MISC>
@@ -51,6 +54,9 @@ mod internal {
     impl Deref for dyn Foo {
         type Target = ();
         fn deref(&self) -> &() { &() }
+    }
+    impl Receiver for dyn Foo {
+        type Target = ();
     }
 
     impl Foo for () {}

--- a/tests/ui/methods/method-deref-to-same-trait-object-with-separate-params.stderr
+++ b/tests/ui/methods/method-deref-to-same-trait-object-with-separate-params.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/method-deref-to-same-trait-object-with-separate-params.rs:88:24
+  --> $DIR/method-deref-to-same-trait-object-with-separate-params.rs:94:24
    |
 LL |     let _seetype: () = z;
    |                   --   ^ expected `()`, found `u32`
@@ -7,7 +7,7 @@ LL |     let _seetype: () = z;
    |                   expected due to this
 
 error[E0308]: mismatched types
-  --> $DIR/method-deref-to-same-trait-object-with-separate-params.rs:105:24
+  --> $DIR/method-deref-to-same-trait-object-with-separate-params.rs:111:24
    |
 LL |     let _seetype: () = z;
    |                   --   ^ expected `()`, found `u64`
@@ -15,18 +15,18 @@ LL |     let _seetype: () = z;
    |                   expected due to this
 
 error[E0034]: multiple applicable items in scope
-  --> $DIR/method-deref-to-same-trait-object-with-separate-params.rs:123:15
+  --> $DIR/method-deref-to-same-trait-object-with-separate-params.rs:129:15
    |
 LL |     let z = x.foo();
    |               ^^^ multiple `foo` found
    |
 note: candidate #1 is defined in an impl of the trait `NuisanceFoo` for the type `T`
-  --> $DIR/method-deref-to-same-trait-object-with-separate-params.rs:73:9
+  --> $DIR/method-deref-to-same-trait-object-with-separate-params.rs:79:9
    |
 LL |         fn foo(self) {}
    |         ^^^^^^^^^^^^
 note: candidate #2 is defined in an impl of the trait `X` for the type `T`
-  --> $DIR/method-deref-to-same-trait-object-with-separate-params.rs:46:9
+  --> $DIR/method-deref-to-same-trait-object-with-separate-params.rs:49:9
    |
 LL |         fn foo(self: Smaht<Self, u64>) -> u64 {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -42,7 +42,7 @@ LL +     let z = X::foo(x);
    |
 
 error[E0308]: mismatched types
-  --> $DIR/method-deref-to-same-trait-object-with-separate-params.rs:140:24
+  --> $DIR/method-deref-to-same-trait-object-with-separate-params.rs:146:24
    |
 LL |     let _seetype: () = z;
    |                   --   ^ expected `()`, found `u8`
@@ -50,7 +50,7 @@ LL |     let _seetype: () = z;
    |                   expected due to this
 
 error[E0308]: mismatched types
-  --> $DIR/method-deref-to-same-trait-object-with-separate-params.rs:158:24
+  --> $DIR/method-deref-to-same-trait-object-with-separate-params.rs:164:24
    |
 LL |     let _seetype: () = z;
    |                   --   ^ expected `()`, found `u32`
@@ -58,7 +58,7 @@ LL |     let _seetype: () = z;
    |                   expected due to this
 
 error[E0308]: mismatched types
-  --> $DIR/method-deref-to-same-trait-object-with-separate-params.rs:175:24
+  --> $DIR/method-deref-to-same-trait-object-with-separate-params.rs:181:24
    |
 LL |     let _seetype: () = z;
    |                   --   ^ expected `()`, found `u32`

--- a/tests/ui/methods/receiver-complex.rs
+++ b/tests/ui/methods/receiver-complex.rs
@@ -1,0 +1,115 @@
+//@ run-pass
+
+#![feature(arbitrary_self_types, arbitrary_self_types_split_chains)]
+#![allow(unused)]
+
+use std::ops::{Deref, Receiver};
+
+// Let us construct weird receiver chains.
+
+//  ┌─────┐          ┌─────┐         ┌─────┐         ┌─────┐
+//  │     │  Deref   │     │  Deref  │     │  Deref  │     │
+//  │  A  ├──────────►  D  ├─────────►  C  ├─────────►  B  │
+//  │     │          │     │         │     │         │     │
+//  └──┬──┘          └──┬──┘         └─────┘         └──┬──┘
+//     │                │                               │
+//     │ Receiver       │ Receiver              Receiver│
+//  ┌──▼──┐          ┌──▼──┐                         ┌──▼──┐
+//  │     │          │     │                         │     │
+//  │  B  │          │  A  │                         │  C  │
+//  │     │          │     │                         │     │
+//  └──┬──┘          └──┬──┘                         └─────┘
+//     │ Receiver       │ Receiver
+//  ┌──▼──┐          ┌──▼──┐
+//  │     │          │     │
+//  │  C  │          │  B  │
+//  │     │          │     │
+//  └─────┘          └──┬──┘
+//                      │ Receiver
+//                   ┌──▼──┐
+//                   │     │
+//                   │  C  │
+//                   │     │
+//                   └─────┘
+
+struct A;
+struct B;
+struct C;
+struct D;
+
+impl Deref for A {
+    type Target = D;
+    fn deref(&self) -> &Self::Target {
+        &D
+    }
+}
+
+impl Deref for D {
+    type Target = C;
+    fn deref(&self) -> &Self::Target {
+        &C
+    }
+}
+
+impl Deref for C {
+    type Target = B;
+    fn deref(&self) -> &Self::Target {
+        &B
+    }
+}
+
+impl Receiver for A {
+    type Target = B;
+}
+
+impl Receiver for B {
+    type Target = C;
+}
+
+impl Receiver for D {
+    type Target = A;
+}
+
+impl A {
+    fn foo(self: &D) -> u8 {
+        64
+    }
+    fn bar(self: &D) -> u8 {
+        64
+    }
+}
+
+impl B {
+    fn foo(self: &D) -> u8 {
+        88
+    }
+    fn bar(self: &B) -> u8 {
+        88
+    }
+    fn boo(self: &B) -> u8 {
+        88
+    }
+}
+
+impl C {
+    fn foo(self: &A) -> u8 {
+        42
+    }
+    fn bar(self: &C) -> u8 {
+        42
+    }
+    fn baz(self: &C) -> u8 {
+        42
+    }
+    fn boo(self: &A, _: u8) -> u8 {
+        88
+    }
+}
+
+fn main() {
+    let a = A;
+    assert_eq!(a.foo(), 42); // This should be dispatched to C::foo
+    assert_eq!(a.bar(), 64); // This should be dispatched to A::bar
+    assert_eq!(a.baz(), 42); // This should be dispatched to C::baz
+    assert_eq!((*a).boo(), 88); // This should be dispatched to B::boo
+}

--- a/tests/ui/self/arbitrary-self-from-method-substs-with-receiver.stderr
+++ b/tests/ui/self/arbitrary-self-from-method-substs-with-receiver.stderr
@@ -1,53 +1,53 @@
 error[E0801]: invalid generic `self` parameter type: `R`
-  --> $DIR/arbitrary-self-from-method-substs-with-receiver.rs:25:42
+  --> $DIR/arbitrary-self-from-method-substs-with-receiver.rs:28:44
    |
-LL |     fn a<R: Receiver<Target=Self>>(self: R) -> u32 {
-   |                                          ^
+LL |     fn a<R: Receiver<Target = Self>>(self: R) -> u32 {
+   |                                            ^
    |
    = note: type of `self` must not be a method generic parameter type
    = help: use a concrete type such as `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
 
 error[E0801]: invalid generic `self` parameter type: `R`
-  --> $DIR/arbitrary-self-from-method-substs-with-receiver.rs:29:39
+  --> $DIR/arbitrary-self-from-method-substs-with-receiver.rs:32:67
    |
-LL |     fn b<R: Deref<Target=Self>>(self: R) -> u32 {
-   |                                       ^
+LL |     fn b<R: Deref<Target = Self> + Receiver<Target = Self>>(self: R) -> u32 {
+   |                                                                   ^
    |
    = note: type of `self` must not be a method generic parameter type
    = help: use a concrete type such as `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
 
 error[E0801]: invalid generic `self` parameter type: `impl Receiver<Target = Self>`
-  --> $DIR/arbitrary-self-from-method-substs-with-receiver.rs:33:16
+  --> $DIR/arbitrary-self-from-method-substs-with-receiver.rs:36:16
    |
-LL |     fn c(self: impl Receiver<Target=Self>) -> u32 {
-   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     fn c(self: impl Receiver<Target = Self>) -> u32 {
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: type of `self` must not be a method generic parameter type
    = help: use a concrete type such as `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
 
-error[E0801]: invalid generic `self` parameter type: `impl Deref<Target = Self>`
-  --> $DIR/arbitrary-self-from-method-substs-with-receiver.rs:37:16
+error[E0801]: invalid generic `self` parameter type: `impl Deref<Target = Self> + Receiver<Target = Self>`
+  --> $DIR/arbitrary-self-from-method-substs-with-receiver.rs:40:16
    |
-LL |     fn d(self: impl Deref<Target=Self>) -> u32 {
-   |                ^^^^^^^^^^^^^^^^^^^^^^^
+LL |     fn d(self: impl Deref<Target = Self> + Receiver<Target = Self>) -> u32 {
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: type of `self` must not be a method generic parameter type
    = help: use a concrete type such as `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
 
 error[E0308]: mismatched types
-  --> $DIR/arbitrary-self-from-method-substs-with-receiver.rs:51:16
+  --> $DIR/arbitrary-self-from-method-substs-with-receiver.rs:54:16
    |
 LL |     assert_eq!(foo.a::<&Foo>(), 2);
    |                ^^^ expected `&Foo`, found `Foo`
 
 error[E0308]: mismatched types
-  --> $DIR/arbitrary-self-from-method-substs-with-receiver.rs:53:16
+  --> $DIR/arbitrary-self-from-method-substs-with-receiver.rs:56:16
    |
 LL |     assert_eq!(foo.b::<&Foo>(), 1);
    |                ^^^ expected `&Foo`, found `Foo`
 
 error[E0308]: mismatched types
-  --> $DIR/arbitrary-self-from-method-substs-with-receiver.rs:60:16
+  --> $DIR/arbitrary-self-from-method-substs-with-receiver.rs:63:16
    |
 LL |     assert_eq!(smart_ptr.a::<&Foo>(), 2);
    |                ^^^^^^^^^ expected `&Foo`, found `SmartPtr<'_, Foo>`
@@ -56,7 +56,7 @@ LL |     assert_eq!(smart_ptr.a::<&Foo>(), 2);
                  found struct `SmartPtr<'_, Foo>`
 
 error[E0308]: mismatched types
-  --> $DIR/arbitrary-self-from-method-substs-with-receiver.rs:62:16
+  --> $DIR/arbitrary-self-from-method-substs-with-receiver.rs:65:16
    |
 LL |     assert_eq!(smart_ptr.b::<&Foo>(), 1);
    |                ^^^^^^^^^ expected `&Foo`, found `SmartPtr<'_, Foo>`

--- a/tests/ui/self/arbitrary-self-from-method-substs.default.stderr
+++ b/tests/ui/self/arbitrary-self-from-method-substs.default.stderr
@@ -1,87 +1,83 @@
 error[E0801]: invalid generic `self` parameter type: `R`
-  --> $DIR/arbitrary-self-from-method-substs.rs:9:43
+  --> $DIR/arbitrary-self-from-method-substs.rs:12:43
    |
-LL |     fn get<R: Deref<Target = Self>>(self: R) -> u32 {
+LL |     fn get<R: Deref<Target = Self>>(self: R) -> u32
    |                                           ^
    |
    = note: type of `self` must not be a method generic parameter type
    = help: use a concrete type such as `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
 
 error[E0801]: invalid generic `self` parameter type: `&R`
-  --> $DIR/arbitrary-self-from-method-substs.rs:13:44
+  --> $DIR/arbitrary-self-from-method-substs.rs:20:44
    |
-LL |     fn get1<R: Deref<Target = Self>>(self: &R) -> u32 {
+LL |     fn get1<R: Deref<Target = Self>>(self: &R) -> u32
    |                                            ^^
    |
    = note: type of `self` must not be a method generic parameter type
    = help: use a concrete type such as `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
 
 error[E0801]: invalid generic `self` parameter type: `&mut R`
-  --> $DIR/arbitrary-self-from-method-substs.rs:17:44
+  --> $DIR/arbitrary-self-from-method-substs.rs:28:44
    |
-LL |     fn get2<R: Deref<Target = Self>>(self: &mut R) -> u32 {
+LL |     fn get2<R: Deref<Target = Self>>(self: &mut R) -> u32
    |                                            ^^^^^^
    |
    = note: type of `self` must not be a method generic parameter type
    = help: use a concrete type such as `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
 
 error[E0801]: invalid generic `self` parameter type: `Rc<R>`
-  --> $DIR/arbitrary-self-from-method-substs.rs:21:44
+  --> $DIR/arbitrary-self-from-method-substs.rs:36:44
    |
-LL |     fn get3<R: Deref<Target = Self>>(self: std::rc::Rc<R>) -> u32 {
+LL |     fn get3<R: Deref<Target = Self>>(self: std::rc::Rc<R>) -> u32
    |                                            ^^^^^^^^^^^^^^
    |
    = note: type of `self` must not be a method generic parameter type
    = help: use a concrete type such as `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
 
 error[E0801]: invalid generic `self` parameter type: `&Rc<R>`
-  --> $DIR/arbitrary-self-from-method-substs.rs:25:44
+  --> $DIR/arbitrary-self-from-method-substs.rs:44:44
    |
-LL |     fn get4<R: Deref<Target = Self>>(self: &std::rc::Rc<R>) -> u32 {
+LL |     fn get4<R: Deref<Target = Self>>(self: &std::rc::Rc<R>) -> u32
    |                                            ^^^^^^^^^^^^^^^
    |
    = note: type of `self` must not be a method generic parameter type
    = help: use a concrete type such as `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
 
 error[E0801]: invalid generic `self` parameter type: `Rc<&R>`
-  --> $DIR/arbitrary-self-from-method-substs.rs:29:44
+  --> $DIR/arbitrary-self-from-method-substs.rs:52:44
    |
-LL |     fn get5<R: Deref<Target = Self>>(self: std::rc::Rc<&R>) -> u32 {
+LL |     fn get5<R: Deref<Target = Self>>(self: std::rc::Rc<&R>) -> u32
    |                                            ^^^^^^^^^^^^^^^
    |
    = note: type of `self` must not be a method generic parameter type
    = help: use a concrete type such as `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
 
-error[E0658]: `<FR as FindReceiver>::Receiver` cannot be used as the type of `self` without the `arbitrary_self_types` feature
-  --> $DIR/arbitrary-self-from-method-substs.rs:33:37
+error[E0307]: invalid `self` parameter type: `<FR as FindReceiver>::Receiver`
+  --> $DIR/arbitrary-self-from-method-substs.rs:63:37
    |
 LL |     fn get6<FR: FindReceiver>(self: FR::Receiver, other: FR) -> u32 {
    |                                     ^^^^^^^^^^^^
    |
-   = note: see issue #44874 <https://github.com/rust-lang/rust/issues/44874> for more information
-   = help: add `#![feature(arbitrary_self_types)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-   = help: consider changing to `self`, `&self`, `&mut self`, or a type implementing `Receiver` such as `self: Box<Self>`, `self: Rc<Self>`, or `self: Arc<Self>`
+   = note: type of `self` must be `Self` or a type that dereferences to it
+   = help: consider changing to `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` where P is one of the previous types except `Self`; alternatively, consider implement `Receiver` trait on the type of `self`, where applicable
 
-error[E0658]: `R` cannot be used as the type of `self` without the `arbitrary_self_types` feature
-  --> $DIR/arbitrary-self-from-method-substs.rs:61:18
+error[E0307]: invalid `self` parameter type: `R`
+  --> $DIR/arbitrary-self-from-method-substs.rs:102:18
    |
 LL |     fn get(self: R) {}
    |                  ^
    |
-   = note: see issue #44874 <https://github.com/rust-lang/rust/issues/44874> for more information
-   = help: add `#![feature(arbitrary_self_types)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-   = help: consider changing to `self`, `&self`, `&mut self`, or a type implementing `Receiver` such as `self: Box<Self>`, `self: Rc<Self>`, or `self: Arc<Self>`
+   = note: type of `self` must be `Self` or a type that dereferences to it
+   = help: consider changing to `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` where P is one of the previous types except `Self`; alternatively, consider implement `Receiver` trait on the type of `self`, where applicable
 
 error[E0271]: type mismatch resolving `<Silly as FindReceiver>::Receiver == Foo`
-  --> $DIR/arbitrary-self-from-method-substs.rs:92:9
+  --> $DIR/arbitrary-self-from-method-substs.rs:136:9
    |
 LL |     foo.get6(Silly);
    |         ^^^^ type mismatch resolving `<Silly as FindReceiver>::Receiver == Foo`
    |
 note: expected this to be `Foo`
-  --> $DIR/arbitrary-self-from-method-substs.rs:71:21
+  --> $DIR/arbitrary-self-from-method-substs.rs:115:21
    |
 LL |     type Receiver = std::rc::Rc<Foo>;
    |                     ^^^^^^^^^^^^^^^^
@@ -89,13 +85,13 @@ LL |     type Receiver = std::rc::Rc<Foo>;
               found struct `Rc<Foo>`
 
 error[E0271]: type mismatch resolving `<Silly as FindReceiver>::Receiver == &Foo`
-  --> $DIR/arbitrary-self-from-method-substs.rs:96:9
+  --> $DIR/arbitrary-self-from-method-substs.rs:140:9
    |
 LL |     foo.get6(Silly);
    |         ^^^^ type mismatch resolving `<Silly as FindReceiver>::Receiver == &Foo`
    |
 note: expected this to be `&Foo`
-  --> $DIR/arbitrary-self-from-method-substs.rs:71:21
+  --> $DIR/arbitrary-self-from-method-substs.rs:115:21
    |
 LL |     type Receiver = std::rc::Rc<Foo>;
    |                     ^^^^^^^^^^^^^^^^
@@ -103,7 +99,7 @@ LL |     type Receiver = std::rc::Rc<Foo>;
                  found struct `Rc<Foo>`
 
 error[E0599]: the method `get` exists for struct `Rc<Bar<_>>`, but its trait bounds were not satisfied
-  --> $DIR/arbitrary-self-from-method-substs.rs:100:7
+  --> $DIR/arbitrary-self-from-method-substs.rs:144:7
    |
 LL | struct Bar<R>(std::marker::PhantomData<R>);
    | ------------- doesn't satisfy `Bar<_>: Deref`
@@ -118,12 +114,12 @@ note: the following trait bounds were not satisfied:
       `<&mut Rc<Bar<_>> as Deref>::Target = Bar<&mut Rc<Bar<_>>>`
       `<Rc<Bar<_>> as Deref>::Target = Bar<Rc<Bar<_>>>`
       `Bar<_>: Deref`
-  --> $DIR/arbitrary-self-from-method-substs.rs:60:9
+  --> $DIR/arbitrary-self-from-method-substs.rs:97:9
    |
-LL | impl<R: std::ops::Deref<Target = Self>> Bar<R> {
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ------
-   |         |               |
-   |         |               unsatisfied trait bound introduced here
+LL | impl<R: Deref<Target = Self>> Bar<R>
+   |         ^^^^^^^^^^^^^^^^^^^^  ------
+   |         |     |
+   |         |     unsatisfied trait bound introduced here
    |         unsatisfied trait bound introduced here
 note: the trait `Deref` must be implemented
   --> $SRC_DIR/core/src/ops/deref.rs:LL:COL
@@ -132,7 +128,7 @@ note: the trait `Deref` must be implemented
            candidate #1: `SliceIndex`
 
 error[E0599]: the method `get` exists for reference `&Rc<Bar<_>>`, but its trait bounds were not satisfied
-  --> $DIR/arbitrary-self-from-method-substs.rs:108:7
+  --> $DIR/arbitrary-self-from-method-substs.rs:152:7
    |
 LL | struct Bar<R>(std::marker::PhantomData<R>);
    | ------------- doesn't satisfy `Bar<_>: Deref`
@@ -149,12 +145,12 @@ note: the following trait bounds were not satisfied:
       `<&mut Rc<Bar<_>> as Deref>::Target = Bar<&mut Rc<Bar<_>>>`
       `<Rc<Bar<_>> as Deref>::Target = Bar<Rc<Bar<_>>>`
       `Bar<_>: Deref`
-  --> $DIR/arbitrary-self-from-method-substs.rs:60:9
+  --> $DIR/arbitrary-self-from-method-substs.rs:97:9
    |
-LL | impl<R: std::ops::Deref<Target = Self>> Bar<R> {
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ------
-   |         |               |
-   |         |               unsatisfied trait bound introduced here
+LL | impl<R: Deref<Target = Self>> Bar<R>
+   |         ^^^^^^^^^^^^^^^^^^^^  ------
+   |         |     |
+   |         |     unsatisfied trait bound introduced here
    |         unsatisfied trait bound introduced here
 note: the trait `Deref` must be implemented
   --> $SRC_DIR/core/src/ops/deref.rs:LL:COL
@@ -164,5 +160,5 @@ note: the trait `Deref` must be implemented
 
 error: aborting due to 12 previous errors
 
-Some errors have detailed explanations: E0271, E0599, E0658, E0801.
+Some errors have detailed explanations: E0271, E0307, E0599, E0801.
 For more information about an error, try `rustc --explain E0271`.

--- a/tests/ui/self/arbitrary-self-from-method-substs.feature.stderr
+++ b/tests/ui/self/arbitrary-self-from-method-substs.feature.stderr
@@ -1,65 +1,65 @@
 error[E0801]: invalid generic `self` parameter type: `R`
-  --> $DIR/arbitrary-self-from-method-substs.rs:9:43
+  --> $DIR/arbitrary-self-from-method-substs.rs:12:43
    |
-LL |     fn get<R: Deref<Target = Self>>(self: R) -> u32 {
+LL |     fn get<R: Deref<Target = Self>>(self: R) -> u32
    |                                           ^
    |
    = note: type of `self` must not be a method generic parameter type
    = help: use a concrete type such as `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
 
 error[E0801]: invalid generic `self` parameter type: `&R`
-  --> $DIR/arbitrary-self-from-method-substs.rs:13:44
+  --> $DIR/arbitrary-self-from-method-substs.rs:20:44
    |
-LL |     fn get1<R: Deref<Target = Self>>(self: &R) -> u32 {
+LL |     fn get1<R: Deref<Target = Self>>(self: &R) -> u32
    |                                            ^^
    |
    = note: type of `self` must not be a method generic parameter type
    = help: use a concrete type such as `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
 
 error[E0801]: invalid generic `self` parameter type: `&mut R`
-  --> $DIR/arbitrary-self-from-method-substs.rs:17:44
+  --> $DIR/arbitrary-self-from-method-substs.rs:28:44
    |
-LL |     fn get2<R: Deref<Target = Self>>(self: &mut R) -> u32 {
+LL |     fn get2<R: Deref<Target = Self>>(self: &mut R) -> u32
    |                                            ^^^^^^
    |
    = note: type of `self` must not be a method generic parameter type
    = help: use a concrete type such as `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
 
 error[E0801]: invalid generic `self` parameter type: `Rc<R>`
-  --> $DIR/arbitrary-self-from-method-substs.rs:21:44
+  --> $DIR/arbitrary-self-from-method-substs.rs:36:44
    |
-LL |     fn get3<R: Deref<Target = Self>>(self: std::rc::Rc<R>) -> u32 {
+LL |     fn get3<R: Deref<Target = Self>>(self: std::rc::Rc<R>) -> u32
    |                                            ^^^^^^^^^^^^^^
    |
    = note: type of `self` must not be a method generic parameter type
    = help: use a concrete type such as `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
 
 error[E0801]: invalid generic `self` parameter type: `&Rc<R>`
-  --> $DIR/arbitrary-self-from-method-substs.rs:25:44
+  --> $DIR/arbitrary-self-from-method-substs.rs:44:44
    |
-LL |     fn get4<R: Deref<Target = Self>>(self: &std::rc::Rc<R>) -> u32 {
+LL |     fn get4<R: Deref<Target = Self>>(self: &std::rc::Rc<R>) -> u32
    |                                            ^^^^^^^^^^^^^^^
    |
    = note: type of `self` must not be a method generic parameter type
    = help: use a concrete type such as `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
 
 error[E0801]: invalid generic `self` parameter type: `Rc<&R>`
-  --> $DIR/arbitrary-self-from-method-substs.rs:29:44
+  --> $DIR/arbitrary-self-from-method-substs.rs:52:44
    |
-LL |     fn get5<R: Deref<Target = Self>>(self: std::rc::Rc<&R>) -> u32 {
+LL |     fn get5<R: Deref<Target = Self>>(self: std::rc::Rc<&R>) -> u32
    |                                            ^^^^^^^^^^^^^^^
    |
    = note: type of `self` must not be a method generic parameter type
    = help: use a concrete type such as `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
 
 error[E0308]: mismatched types
-  --> $DIR/arbitrary-self-from-method-substs.rs:76:5
+  --> $DIR/arbitrary-self-from-method-substs.rs:120:5
    |
 LL |     foo.get::<&Foo>();
    |     ^^^ expected `&Foo`, found `Foo`
 
 error[E0308]: mismatched types
-  --> $DIR/arbitrary-self-from-method-substs.rs:78:5
+  --> $DIR/arbitrary-self-from-method-substs.rs:122:5
    |
 LL |     foo.get::<std::rc::Rc<Foo>>();
    |     ^^^ expected `Rc<Foo>`, found `Foo`
@@ -68,7 +68,7 @@ LL |     foo.get::<std::rc::Rc<Foo>>();
               found struct `Foo`
 
 error[E0308]: mismatched types
-  --> $DIR/arbitrary-self-from-method-substs.rs:84:5
+  --> $DIR/arbitrary-self-from-method-substs.rs:128:5
    |
 LL |     smart_ptr.get::<SmartPtr2<Foo>>();
    |     ^^^^^^^^^ expected `SmartPtr2<'_, Foo>`, found `SmartPtr<'_, Foo>`
@@ -77,7 +77,7 @@ LL |     smart_ptr.get::<SmartPtr2<Foo>>();
               found struct `SmartPtr<'_, Foo>`
 
 error[E0308]: mismatched types
-  --> $DIR/arbitrary-self-from-method-substs.rs:86:5
+  --> $DIR/arbitrary-self-from-method-substs.rs:130:5
    |
 LL |     smart_ptr.get::<&Foo>();
    |     ^^^^^^^^^ expected `&Foo`, found `SmartPtr<'_, Foo>`
@@ -86,13 +86,13 @@ LL |     smart_ptr.get::<&Foo>();
                  found struct `SmartPtr<'_, Foo>`
 
 error[E0271]: type mismatch resolving `<Silly as FindReceiver>::Receiver == Foo`
-  --> $DIR/arbitrary-self-from-method-substs.rs:92:9
+  --> $DIR/arbitrary-self-from-method-substs.rs:136:9
    |
 LL |     foo.get6(Silly);
    |         ^^^^ type mismatch resolving `<Silly as FindReceiver>::Receiver == Foo`
    |
 note: expected this to be `Foo`
-  --> $DIR/arbitrary-self-from-method-substs.rs:71:21
+  --> $DIR/arbitrary-self-from-method-substs.rs:115:21
    |
 LL |     type Receiver = std::rc::Rc<Foo>;
    |                     ^^^^^^^^^^^^^^^^
@@ -100,13 +100,13 @@ LL |     type Receiver = std::rc::Rc<Foo>;
               found struct `Rc<Foo>`
 
 error[E0271]: type mismatch resolving `<Silly as FindReceiver>::Receiver == &Foo`
-  --> $DIR/arbitrary-self-from-method-substs.rs:96:9
+  --> $DIR/arbitrary-self-from-method-substs.rs:140:9
    |
 LL |     foo.get6(Silly);
    |         ^^^^ type mismatch resolving `<Silly as FindReceiver>::Receiver == &Foo`
    |
 note: expected this to be `&Foo`
-  --> $DIR/arbitrary-self-from-method-substs.rs:71:21
+  --> $DIR/arbitrary-self-from-method-substs.rs:115:21
    |
 LL |     type Receiver = std::rc::Rc<Foo>;
    |                     ^^^^^^^^^^^^^^^^
@@ -114,60 +114,86 @@ LL |     type Receiver = std::rc::Rc<Foo>;
                  found struct `Rc<Foo>`
 
 error[E0599]: the method `get` exists for struct `Rc<Bar<_>>`, but its trait bounds were not satisfied
-  --> $DIR/arbitrary-self-from-method-substs.rs:100:7
+  --> $DIR/arbitrary-self-from-method-substs.rs:144:7
    |
 LL | struct Bar<R>(std::marker::PhantomData<R>);
-   | ------------- doesn't satisfy `Bar<_>: Deref`
+   | ------------- doesn't satisfy `Bar<_>: Deref` or `Bar<_>: std::ops::Receiver`
 ...
 LL |     t.get();
    |       ^^^ method cannot be called on `Rc<Bar<_>>` due to unsatisfied trait bounds
    |
 note: the following trait bounds were not satisfied:
       `<&Bar<_> as Deref>::Target = Bar<&Bar<_>>`
+      `<&Bar<_> as std::ops::Receiver>::Target = Bar<&Bar<_>>`
       `<&Rc<Bar<_>> as Deref>::Target = Bar<&Rc<Bar<_>>>`
+      `<&Rc<Bar<_>> as std::ops::Receiver>::Target = Bar<&Rc<Bar<_>>>`
       `<&mut Bar<_> as Deref>::Target = Bar<&mut Bar<_>>`
+      `<&mut Bar<_> as std::ops::Receiver>::Target = Bar<&mut Bar<_>>`
       `<&mut Rc<Bar<_>> as Deref>::Target = Bar<&mut Rc<Bar<_>>>`
+      `<&mut Rc<Bar<_>> as std::ops::Receiver>::Target = Bar<&mut Rc<Bar<_>>>`
       `<Rc<Bar<_>> as Deref>::Target = Bar<Rc<Bar<_>>>`
+      `<Rc<Bar<_>> as std::ops::Receiver>::Target = Bar<Rc<Bar<_>>>`
       `Bar<_>: Deref`
-  --> $DIR/arbitrary-self-from-method-substs.rs:60:9
+      `Bar<_>: std::ops::Receiver`
+  --> $DIR/arbitrary-self-from-method-substs.rs:97:9
    |
-LL | impl<R: std::ops::Deref<Target = Self>> Bar<R> {
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ------
-   |         |               |
-   |         |               unsatisfied trait bound introduced here
+LL | impl<R: Deref<Target = Self>> Bar<R>
+   |         ^^^^^^^^^^^^^^^^^^^^  ------
+   |         |     |
+   |         |     unsatisfied trait bound introduced here
    |         unsatisfied trait bound introduced here
-note: the trait `Deref` must be implemented
+...
+LL |     R: Receiver<Target = Self>,
+   |        ^^^^^^^^^^^^^^^^^^^^^^^
+   |        |        |
+   |        |        unsatisfied trait bound introduced here
+   |        unsatisfied trait bound introduced here
+note: the traits `Deref` and `std::ops::Receiver` must be implemented
   --> $SRC_DIR/core/src/ops/deref.rs:LL:COL
    = help: items from traits can only be used if the trait is implemented and in scope
    = note: the following trait defines an item `get`, perhaps you need to implement it:
            candidate #1: `SliceIndex`
 
 error[E0599]: the method `get` exists for reference `&Rc<Bar<_>>`, but its trait bounds were not satisfied
-  --> $DIR/arbitrary-self-from-method-substs.rs:108:7
+  --> $DIR/arbitrary-self-from-method-substs.rs:152:7
    |
 LL | struct Bar<R>(std::marker::PhantomData<R>);
-   | ------------- doesn't satisfy `Bar<_>: Deref`
+   | ------------- doesn't satisfy `Bar<_>: Deref` or `Bar<_>: std::ops::Receiver`
 ...
 LL |     t.get();
    |       ^^^ method cannot be called on `&Rc<Bar<_>>` due to unsatisfied trait bounds
    |
 note: the following trait bounds were not satisfied:
       `<&&Rc<Bar<_>> as Deref>::Target = Bar<&&Rc<Bar<_>>>`
+      `<&&Rc<Bar<_>> as std::ops::Receiver>::Target = Bar<&&Rc<Bar<_>>>`
       `<&Bar<_> as Deref>::Target = Bar<&Bar<_>>`
+      `<&Bar<_> as std::ops::Receiver>::Target = Bar<&Bar<_>>`
       `<&Rc<Bar<_>> as Deref>::Target = Bar<&Rc<Bar<_>>>`
+      `<&Rc<Bar<_>> as std::ops::Receiver>::Target = Bar<&Rc<Bar<_>>>`
       `<&mut &Rc<Bar<_>> as Deref>::Target = Bar<&mut &Rc<Bar<_>>>`
+      `<&mut &Rc<Bar<_>> as std::ops::Receiver>::Target = Bar<&mut &Rc<Bar<_>>>`
       `<&mut Bar<_> as Deref>::Target = Bar<&mut Bar<_>>`
+      `<&mut Bar<_> as std::ops::Receiver>::Target = Bar<&mut Bar<_>>`
       `<&mut Rc<Bar<_>> as Deref>::Target = Bar<&mut Rc<Bar<_>>>`
+      `<&mut Rc<Bar<_>> as std::ops::Receiver>::Target = Bar<&mut Rc<Bar<_>>>`
       `<Rc<Bar<_>> as Deref>::Target = Bar<Rc<Bar<_>>>`
+      `<Rc<Bar<_>> as std::ops::Receiver>::Target = Bar<Rc<Bar<_>>>`
       `Bar<_>: Deref`
-  --> $DIR/arbitrary-self-from-method-substs.rs:60:9
+      `Bar<_>: std::ops::Receiver`
+  --> $DIR/arbitrary-self-from-method-substs.rs:97:9
    |
-LL | impl<R: std::ops::Deref<Target = Self>> Bar<R> {
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ------
-   |         |               |
-   |         |               unsatisfied trait bound introduced here
+LL | impl<R: Deref<Target = Self>> Bar<R>
+   |         ^^^^^^^^^^^^^^^^^^^^  ------
+   |         |     |
+   |         |     unsatisfied trait bound introduced here
    |         unsatisfied trait bound introduced here
-note: the trait `Deref` must be implemented
+...
+LL |     R: Receiver<Target = Self>,
+   |        ^^^^^^^^^^^^^^^^^^^^^^^
+   |        |        |
+   |        |        unsatisfied trait bound introduced here
+   |        unsatisfied trait bound introduced here
+note: the traits `Deref` and `std::ops::Receiver` must be implemented
   --> $SRC_DIR/core/src/ops/deref.rs:LL:COL
    = help: items from traits can only be used if the trait is implemented and in scope
    = note: the following trait defines an item `get`, perhaps you need to implement it:

--- a/tests/ui/self/arbitrary-self-opaque.stderr
+++ b/tests/ui/self/arbitrary-self-opaque.stderr
@@ -5,7 +5,7 @@ LL |     fn foo(self: Bar) {}
    |                  ^^^
    |
    = note: type of `self` must be `Self` or a type that dereferences to it
-   = help: consider changing to `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
+   = help: consider changing to `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` where P is one of the previous types except `Self`; alternatively, consider implement `Receiver` trait on the type of `self`, where applicable
 
 error: item does not constrain `Bar::{opaque#0}`
   --> $DIR/arbitrary-self-opaque.rs:8:8

--- a/tests/ui/self/arbitrary-self-types-merge-chains.rs
+++ b/tests/ui/self/arbitrary-self-types-merge-chains.rs
@@ -1,0 +1,59 @@
+// gate-test-arbitrary_self_types_split_chains
+
+#![feature(arbitrary_self_types)]
+
+use std::marker::PhantomData;
+use std::ops::{Deref, Receiver};
+
+struct A;
+impl Deref for A {
+    type Target = u8;
+    fn deref(&self) -> &u8 {
+        &0
+    }
+}
+impl Receiver for A {
+    //~^ ERROR `Deref::Target` does not agree with `Receiver::Target`
+    //~| ERROR `Receiver::Target` diverging from `Deref::Target` is not supported
+    type Target = u32;
+}
+
+struct B<'a, T>(&'a T);
+impl<'a, T> Deref for B<'a, T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        &*self.0
+    }
+}
+impl<'a, T> Receiver for B<'a, T> {
+    //~^ ERROR `Deref::Target` does not agree with `Receiver::Target`
+    //~| ERROR `Receiver::Target` diverging from `Deref::Target` is not supported
+    type Target = Box<T>;
+}
+
+struct C<'a, T>(&'a T);
+impl<'a, T> Deref for C<'a, T> {
+    type Target = Self;
+    fn deref(&self) -> &Self {
+        self
+    }
+}
+impl<'b, T> Receiver for C<'b, T> {
+    type Target = Self; // OK
+}
+
+struct D<T>(PhantomData<fn() -> T>);
+trait Trait {
+    type Output;
+}
+impl<T: Trait<Output = T>> Deref for D<T> {
+    type Target = T::Output;
+    fn deref(&self) -> &T {
+        unimplemented!()
+    }
+}
+impl<T> Receiver for D<T> {
+    type Target = T; // OK
+}
+
+fn main() {}

--- a/tests/ui/self/arbitrary-self-types-merge-chains.stderr
+++ b/tests/ui/self/arbitrary-self-types-merge-chains.stderr
@@ -1,0 +1,42 @@
+error[E0658]: `Receiver::Target` diverging from `Deref::Target` is not supported; we look forward to your feedback
+  --> $DIR/arbitrary-self-types-merge-chains.rs:15:1
+   |
+LL | impl Receiver for A {
+   | ^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #44874 <https://github.com/rust-lang/rust/issues/44874> for more information
+   = help: add `#![feature(arbitrary_self_types_split_chains)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0390]: `Deref::Target` does not agree with `Receiver::Target`
+  --> $DIR/arbitrary-self-types-merge-chains.rs:15:1
+   |
+LL | impl Receiver for A {
+   | ^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `Deref::Target` is `u8` but `Receiver::Target` is `u32`
+   = note: `#![feature(arbitrary_self_types_merge_chains)]` rejects this kind of divergence
+
+error[E0658]: `Receiver::Target` diverging from `Deref::Target` is not supported; we look forward to your feedback
+  --> $DIR/arbitrary-self-types-merge-chains.rs:28:1
+   |
+LL | impl<'a, T> Receiver for B<'a, T> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #44874 <https://github.com/rust-lang/rust/issues/44874> for more information
+   = help: add `#![feature(arbitrary_self_types_split_chains)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0390]: `Deref::Target` does not agree with `Receiver::Target`
+  --> $DIR/arbitrary-self-types-merge-chains.rs:28:1
+   |
+LL | impl<'a, T> Receiver for B<'a, T> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `Deref::Target` is `T` but `Receiver::Target` is `Box<T>`
+   = note: `#![feature(arbitrary_self_types_merge_chains)]` rejects this kind of divergence
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0390, E0658.
+For more information about an error, try `rustc --explain E0390`.

--- a/tests/ui/self/arbitrary-self-types-split-chains.rs
+++ b/tests/ui/self/arbitrary-self-types-split-chains.rs
@@ -1,0 +1,30 @@
+//@ check-pass
+
+#![feature(arbitrary_self_types)]
+#![feature(arbitrary_self_types_split_chains)]
+
+use std::ops::{Deref, Receiver};
+
+struct A;
+impl Deref for A {
+    type Target = u8;
+    fn deref(&self) -> &u8 {
+        &0
+    }
+}
+impl Receiver for A {
+    type Target = u32;
+}
+
+struct B<'a, T>(&'a T);
+impl<'a, T> Deref for B<'a, T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        &*self.0
+    }
+}
+impl<'a, T> Receiver for B<'a, T> {
+    type Target = Box<T>;
+}
+
+fn main() {}

--- a/tests/ui/self/arbitrary_self_types_generic_over_receiver.stderr
+++ b/tests/ui/self/arbitrary_self_types_generic_over_receiver.stderr
@@ -22,7 +22,6 @@ error[E0277]: the trait bound `Foo: std::ops::Receiver` is not satisfied
 LL |     foo.a();
    |         ^ the trait `std::ops::Receiver` is not implemented for `Foo`
    |
-   = note: required for `Foo` to implement `std::ops::Receiver`
 note: required by a bound in `Foo::a`
   --> $DIR/arbitrary_self_types_generic_over_receiver.rs:7:21
    |

--- a/tests/ui/self/arbitrary_self_types_silly.rs
+++ b/tests/ui/self/arbitrary_self_types_silly.rs
@@ -12,8 +12,14 @@ impl std::ops::Deref for Bar {
     }
 }
 
+impl std::ops::Receiver for Bar {
+    type Target = Foo;
+}
+
 impl Foo {
-    fn bar(self: Bar) -> i32 { 3 }
+    fn bar(self: Bar) -> i32 {
+        3
+    }
 }
 
 fn main() {

--- a/tests/ui/self/dispatch-dyn-incompatible-that-does-not-deref.stderr
+++ b/tests/ui/self/dispatch-dyn-incompatible-that-does-not-deref.stderr
@@ -23,7 +23,7 @@ LL |     fn method(self: &W) {}
    |                     ^^
    |
    = note: type of `self` must be `Self` or a type that dereferences to it
-   = help: consider changing to `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
+   = help: consider changing to `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` where P is one of the previous types except `Self`; alternatively, consider implement `Receiver` trait on the type of `self`, where applicable
 
 error[E0038]: the trait `Foo` is not dyn compatible
   --> $DIR/dispatch-dyn-incompatible-that-does-not-deref.rs:14:5

--- a/tests/ui/self/dispatch-from-dyn-layout-3.rs
+++ b/tests/ui/self/dispatch-from-dyn-layout-3.rs
@@ -6,10 +6,9 @@
 #![feature(dispatch_from_dyn)]
 #![feature(arbitrary_self_types)]
 
-use std::ops::Deref;
-use std::ops::DispatchFromDyn;
+use std::ops::{Deref, DispatchFromDyn, Receiver};
 
-trait Trait<T: Deref<Target = Self>>
+trait Trait<T: Deref<Target = Self> + Receiver<Target = Self>>
 where
     for<'a> &'a T: DispatchFromDyn<&'a T>,
 {

--- a/tests/ui/self/dispatch-from-dyn-layout.rs
+++ b/tests/ui/self/dispatch-from-dyn-layout.rs
@@ -6,9 +6,9 @@
 
 #![feature(arbitrary_self_types, dispatch_from_dyn)]
 
-use std::ops::{Deref, DispatchFromDyn};
+use std::ops::{Deref, DispatchFromDyn, Receiver};
 
-trait Trait<T: Deref<Target = Self> + DispatchFromDyn<T>> {
+trait Trait<T: Deref<Target = Self> + Receiver<Target = Self> + DispatchFromDyn<T>> {
     fn foo(self: T) -> dyn Trait<T>;
 }
 

--- a/tests/ui/self/dispatch-from-dyn-zst-transmute.rs
+++ b/tests/ui/self/dispatch-from-dyn-zst-transmute.rs
@@ -2,10 +2,8 @@
 #![feature(unsize)]
 #![feature(dispatch_from_dyn)]
 
-use std::marker::PhantomData;
-use std::marker::Unsize;
-use std::ops::DispatchFromDyn;
-use std::ops::Deref;
+use std::marker::{PhantomData, Unsize};
+use std::ops::{Deref, DispatchFromDyn, Receiver};
 
 struct IsSendToken<T: ?Sized>(PhantomData<fn(T) -> T>);
 
@@ -18,7 +16,9 @@ impl<'a, T, U> DispatchFromDyn<Foo<'a, U>> for Foo<'a, T>
 //~^ ERROR implementing `DispatchFromDyn` does not allow multiple fields to be coerced
 where
     T: Unsize<U> + ?Sized,
-    U: ?Sized {}
+    U: ?Sized,
+{
+}
 
 trait Bar {
     fn f(self: Foo<'_, Self>);
@@ -29,6 +29,9 @@ impl<U: ?Sized> Deref for Foo<'_, U> {
     fn deref(&self) -> &U {
         self.ptr
     }
+}
+impl<U: ?Sized> Receiver for Foo<'_, U> {
+    type Target = U;
 }
 
 fn main() {}

--- a/tests/ui/self/dispatch-from-dyn-zst-transmute.stderr
+++ b/tests/ui/self/dispatch-from-dyn-zst-transmute.stderr
@@ -1,15 +1,15 @@
 error[E0375]: implementing `DispatchFromDyn` does not allow multiple fields to be coerced
-  --> $DIR/dispatch-from-dyn-zst-transmute.rs:17:1
+  --> $DIR/dispatch-from-dyn-zst-transmute.rs:15:1
    |
 LL | / impl<'a, T, U> DispatchFromDyn<Foo<'a, U>> for Foo<'a, T>
 LL | |
 LL | | where
 LL | |     T: Unsize<U> + ?Sized,
-LL | |     U: ?Sized {}
-   | |_____________^
+LL | |     U: ?Sized,
+   | |______________^
    |
 note: the trait `DispatchFromDyn` may only be implemented when a single field is being coerced
-  --> $DIR/dispatch-from-dyn-zst-transmute.rs:13:5
+  --> $DIR/dispatch-from-dyn-zst-transmute.rs:11:5
    |
 LL |     token: IsSendToken<U>,
    |     ^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/self/dyn-dispatch-requires-supertrait-norm.rs
+++ b/tests/ui/self/dyn-dispatch-requires-supertrait-norm.rs
@@ -3,8 +3,8 @@
 #![feature(derive_coerce_pointee)]
 #![feature(arbitrary_self_types)]
 
-use std::ops::Deref;
 use std::marker::CoercePointee;
+use std::ops::{Deref, Receiver};
 use std::sync::Arc;
 
 trait MyTrait<T> {}
@@ -18,6 +18,9 @@ impl<T: ?Sized + MyTrait<u8>> Deref for MyArc<T> {
     fn deref(&self) -> &T {
         &self.0
     }
+}
+impl<T: ?Sized + MyTrait<u8>> Receiver for MyArc<T> {
+    type Target = T;
 }
 
 trait Mirror {

--- a/tests/ui/self/dyn-dispatch-requires-supertrait.rs
+++ b/tests/ui/self/dyn-dispatch-requires-supertrait.rs
@@ -3,8 +3,8 @@
 #![feature(derive_coerce_pointee)]
 #![feature(arbitrary_self_types)]
 
-use std::ops::Deref;
 use std::marker::CoercePointee;
+use std::ops::{Deref, Receiver};
 use std::sync::Arc;
 
 trait MyTrait {}
@@ -15,7 +15,7 @@ struct MyArc<T>
 where
     T: MyTrait + ?Sized,
 {
-    inner: Arc<T>
+    inner: Arc<T>,
 }
 
 impl<T: MyTrait + ?Sized> Deref for MyArc<T> {
@@ -23,6 +23,9 @@ impl<T: MyTrait + ?Sized> Deref for MyArc<T> {
     fn deref(&self) -> &T {
         &self.inner
     }
+}
+impl<T: MyTrait + ?Sized> Receiver for MyArc<T> {
+    type Target = T;
 }
 
 // Proving that `MyArc<Self>` is dyn-dispatchable requires proving `MyArc<T>` implements

--- a/tests/ui/self/elision/multiple-ref-self-async.rs
+++ b/tests/ui/self/elision/multiple-ref-self-async.rs
@@ -4,18 +4,22 @@
 #![allow(non_snake_case)]
 
 use std::marker::PhantomData;
-use std::ops::Deref;
+use std::ops::{Deref, Receiver};
 use std::pin::Pin;
 
-struct Struct { }
+struct Struct {}
 
 struct Wrap<T, P>(T, PhantomData<P>);
 
 impl<T, P> Deref for Wrap<T, P> {
     type Target = T;
-    fn deref(&self) -> &T { &self.0 }
+    fn deref(&self) -> &T {
+        &self.0
+    }
 }
-
+impl<T, P> Receiver for Wrap<T, P> {
+    type Target = T;
+}
 impl Struct {
     // Test using multiple `&Self`:
 
@@ -45,4 +49,4 @@ impl Struct {
     }
 }
 
-fn main() { }
+fn main() {}

--- a/tests/ui/self/elision/multiple-ref-self-async.stderr
+++ b/tests/ui/self/elision/multiple-ref-self-async.stderr
@@ -1,5 +1,5 @@
 error[E0106]: missing lifetime specifier
-  --> $DIR/multiple-ref-self-async.rs:22:74
+  --> $DIR/multiple-ref-self-async.rs:26:74
    |
 LL |     async fn wrap_ref_Self_ref_Self(self: Wrap<&Self, &Self>, f: &u8) -> &u8 {
    |                                           ------------------     ---     ^ expected named lifetime parameter
@@ -11,7 +11,7 @@ LL |     async fn wrap_ref_Self_ref_Self<'a>(self: Wrap<&'a Self, &'a Self>, f: 
    |                                    ++++             ++        ++            ++         ++
 
 error[E0106]: missing lifetime specifier
-  --> $DIR/multiple-ref-self-async.rs:27:84
+  --> $DIR/multiple-ref-self-async.rs:31:84
    |
 LL |     async fn box_wrap_ref_Self_ref_Self(self: Box<Wrap<&Self, &Self>>, f: &u32) -> &u32 {
    |                                               -----------------------     ----     ^ expected named lifetime parameter
@@ -23,7 +23,7 @@ LL |     async fn box_wrap_ref_Self_ref_Self<'a>(self: Box<Wrap<&'a Self, &'a Se
    |                                        ++++                 ++        ++             ++          ++
 
 error[E0106]: missing lifetime specifier
-  --> $DIR/multiple-ref-self-async.rs:32:84
+  --> $DIR/multiple-ref-self-async.rs:36:84
    |
 LL |     async fn pin_wrap_ref_Self_ref_Self(self: Pin<Wrap<&Self, &Self>>, f: &u32) -> &u32 {
    |                                               -----------------------     ----     ^ expected named lifetime parameter
@@ -35,7 +35,7 @@ LL |     async fn pin_wrap_ref_Self_ref_Self<'a>(self: Pin<Wrap<&'a Self, &'a Se
    |                                        ++++                 ++        ++             ++          ++
 
 error[E0106]: missing lifetime specifier
-  --> $DIR/multiple-ref-self-async.rs:37:93
+  --> $DIR/multiple-ref-self-async.rs:41:93
    |
 LL |     async fn box_box_wrap_ref_Self_ref_Self(self: Box<Box<Wrap<&Self, &Self>>>, f: &u32) -> &u32 {
    |                                                   ----------------------------     ----     ^ expected named lifetime parameter
@@ -47,7 +47,7 @@ LL |     async fn box_box_wrap_ref_Self_ref_Self<'a>(self: Box<Box<Wrap<&'a Self
    |                                            ++++                     ++        ++              ++          ++
 
 error[E0106]: missing lifetime specifier
-  --> $DIR/multiple-ref-self-async.rs:42:93
+  --> $DIR/multiple-ref-self-async.rs:46:93
    |
 LL |     async fn box_pin_wrap_ref_Self_ref_Self(self: Box<Pin<Wrap<&Self, &Self>>>, f: &u32) -> &u32 {
    |                                                   ----------------------------     ----     ^ expected named lifetime parameter

--- a/tests/ui/self/elision/multiple-ref-self.rs
+++ b/tests/ui/self/elision/multiple-ref-self.rs
@@ -2,16 +2,21 @@
 #![allow(non_snake_case)]
 
 use std::marker::PhantomData;
-use std::ops::Deref;
+use std::ops::{Deref, Receiver};
 use std::pin::Pin;
 
-struct Struct { }
+struct Struct {}
 
 struct Wrap<T, P>(T, PhantomData<P>);
 
 impl<T, P> Deref for Wrap<T, P> {
     type Target = T;
-    fn deref(&self) -> &T { &self.0 }
+    fn deref(&self) -> &T {
+        &self.0
+    }
+}
+impl<T, P> Receiver for Wrap<T, P> {
+    type Target = T;
 }
 
 impl Struct {
@@ -43,4 +48,4 @@ impl Struct {
     }
 }
 
-fn main() { }
+fn main() {}

--- a/tests/ui/self/elision/multiple-ref-self.stderr
+++ b/tests/ui/self/elision/multiple-ref-self.stderr
@@ -1,5 +1,5 @@
 error[E0106]: missing lifetime specifier
-  --> $DIR/multiple-ref-self.rs:20:68
+  --> $DIR/multiple-ref-self.rs:25:68
    |
 LL |     fn wrap_ref_Self_ref_Self(self: Wrap<&Self, &Self>, f: &u8) -> &u8 {
    |                                     ------------------     ---     ^ expected named lifetime parameter
@@ -11,7 +11,7 @@ LL |     fn wrap_ref_Self_ref_Self<'a>(self: Wrap<&'a Self, &'a Self>, f: &'a u8
    |                              ++++             ++        ++            ++         ++
 
 error[E0106]: missing lifetime specifier
-  --> $DIR/multiple-ref-self.rs:25:78
+  --> $DIR/multiple-ref-self.rs:30:78
    |
 LL |     fn box_wrap_ref_Self_ref_Self(self: Box<Wrap<&Self, &Self>>, f: &u32) -> &u32 {
    |                                         -----------------------     ----     ^ expected named lifetime parameter
@@ -23,7 +23,7 @@ LL |     fn box_wrap_ref_Self_ref_Self<'a>(self: Box<Wrap<&'a Self, &'a Self>>, 
    |                                  ++++                 ++        ++             ++          ++
 
 error[E0106]: missing lifetime specifier
-  --> $DIR/multiple-ref-self.rs:30:78
+  --> $DIR/multiple-ref-self.rs:35:78
    |
 LL |     fn pin_wrap_ref_Self_ref_Self(self: Pin<Wrap<&Self, &Self>>, f: &u32) -> &u32 {
    |                                         -----------------------     ----     ^ expected named lifetime parameter
@@ -35,7 +35,7 @@ LL |     fn pin_wrap_ref_Self_ref_Self<'a>(self: Pin<Wrap<&'a Self, &'a Self>>, 
    |                                  ++++                 ++        ++             ++          ++
 
 error[E0106]: missing lifetime specifier
-  --> $DIR/multiple-ref-self.rs:35:87
+  --> $DIR/multiple-ref-self.rs:40:87
    |
 LL |     fn box_box_wrap_ref_Self_ref_Self(self: Box<Box<Wrap<&Self, &Self>>>, f: &u32) -> &u32 {
    |                                             ----------------------------     ----     ^ expected named lifetime parameter
@@ -47,7 +47,7 @@ LL |     fn box_box_wrap_ref_Self_ref_Self<'a>(self: Box<Box<Wrap<&'a Self, &'a 
    |                                      ++++                     ++        ++              ++          ++
 
 error[E0106]: missing lifetime specifier
-  --> $DIR/multiple-ref-self.rs:40:87
+  --> $DIR/multiple-ref-self.rs:45:87
    |
 LL |     fn box_pin_wrap_ref_Self_ref_Self(self: Box<Pin<Wrap<&Self, &Self>>>, f: &u32) -> &u32 {
    |                                             ----------------------------     ----     ^ expected named lifetime parameter

--- a/tests/ui/self/elision/ref-self-async.rs
+++ b/tests/ui/self/elision/ref-self-async.rs
@@ -4,16 +4,21 @@
 #![feature(arbitrary_self_types)]
 
 use std::marker::PhantomData;
-use std::ops::Deref;
+use std::ops::{Deref, Receiver};
 use std::pin::Pin;
 
-struct Struct { }
+struct Struct {}
 
 struct Wrap<T, P>(T, PhantomData<P>);
 
 impl<T, P> Deref for Wrap<T, P> {
     type Target = T;
-    fn deref(&self) -> &T { &self.0 }
+    fn deref(&self) -> &T {
+        &self.0
+    }
+}
+impl<T, P> Receiver for Wrap<T, P> {
+    type Target = T;
 }
 
 impl Struct {
@@ -57,4 +62,4 @@ impl Struct {
     }
 }
 
-fn main() { }
+fn main() {}

--- a/tests/ui/self/elision/ref-self-async.stderr
+++ b/tests/ui/self/elision/ref-self-async.stderr
@@ -1,5 +1,5 @@
 error: lifetime may not live long enough
-  --> $DIR/ref-self-async.rs:23:9
+  --> $DIR/ref-self-async.rs:28:9
    |
 LL |     async fn ref_self(&self, f: &u32) -> &u32 {
    |                       -         - let's call the lifetime of this reference `'1`
@@ -14,7 +14,7 @@ LL |     async fn ref_self<'a>(&self, f: &'a u32) -> &'a u32 {
    |                      ++++            ++          ++
 
 error: lifetime may not live long enough
-  --> $DIR/ref-self-async.rs:30:9
+  --> $DIR/ref-self-async.rs:35:9
    |
 LL |     async fn ref_Self(self: &Self, f: &u32) -> &u32 {
    |                             -         - let's call the lifetime of this reference `'1`
@@ -29,7 +29,7 @@ LL |     async fn ref_Self<'a>(self: &Self, f: &'a u32) -> &'a u32 {
    |                      ++++                  ++          ++
 
 error: lifetime may not live long enough
-  --> $DIR/ref-self-async.rs:35:9
+  --> $DIR/ref-self-async.rs:40:9
    |
 LL |     async fn box_ref_Self(self: Box<&Self>, f: &u32) -> &u32 {
    |                                     -          - let's call the lifetime of this reference `'1`
@@ -44,7 +44,7 @@ LL |     async fn box_ref_Self<'a>(self: Box<&Self>, f: &'a u32) -> &'a u32 {
    |                          ++++                       ++          ++
 
 error: lifetime may not live long enough
-  --> $DIR/ref-self-async.rs:40:9
+  --> $DIR/ref-self-async.rs:45:9
    |
 LL |     async fn pin_ref_Self(self: Pin<&Self>, f: &u32) -> &u32 {
    |                                     -          - let's call the lifetime of this reference `'1`
@@ -59,7 +59,7 @@ LL |     async fn pin_ref_Self<'a>(self: Pin<&Self>, f: &'a u32) -> &'a u32 {
    |                          ++++                       ++          ++
 
 error: lifetime may not live long enough
-  --> $DIR/ref-self-async.rs:45:9
+  --> $DIR/ref-self-async.rs:50:9
    |
 LL |     async fn box_box_ref_Self(self: Box<Box<&Self>>, f: &u32) -> &u32 {
    |                                             -           - let's call the lifetime of this reference `'1`
@@ -74,7 +74,7 @@ LL |     async fn box_box_ref_Self<'a>(self: Box<Box<&Self>>, f: &'a u32) -> &'a
    |                              ++++                            ++          ++
 
 error: lifetime may not live long enough
-  --> $DIR/ref-self-async.rs:50:9
+  --> $DIR/ref-self-async.rs:55:9
    |
 LL |     async fn box_pin_ref_Self(self: Box<Pin<&Self>>, f: &u32) -> &u32 {
    |                                             -           - let's call the lifetime of this reference `'1`
@@ -89,7 +89,7 @@ LL |     async fn box_pin_ref_Self<'a>(self: Box<Pin<&Self>>, f: &'a u32) -> &'a
    |                              ++++                            ++          ++
 
 error: lifetime may not live long enough
-  --> $DIR/ref-self-async.rs:55:9
+  --> $DIR/ref-self-async.rs:60:9
    |
 LL |     async fn wrap_ref_Self_Self(self: Wrap<&Self, Self>, f: &u8) -> &u8 {
    |                                            -                - let's call the lifetime of this reference `'1`

--- a/tests/ui/self/elision/ref-self-multi.rs
+++ b/tests/ui/self/elision/ref-self-multi.rs
@@ -3,15 +3,20 @@
 #![allow(unused)]
 
 use std::marker::PhantomData;
-use std::ops::Deref;
+use std::ops::{Deref, Receiver};
 
-struct Struct { }
+struct Struct {}
 
 struct Wrap<T, P>(T, PhantomData<P>);
 
 impl<T, P> Deref for Wrap<T, P> {
     type Target = T;
-    fn deref(&self) -> &T { &self.0 }
+    fn deref(&self) -> &T {
+        &self.0
+    }
+}
+impl<T, P> Receiver for Wrap<T, P> {
+    type Target = T;
 }
 
 impl Struct {
@@ -26,4 +31,4 @@ impl Struct {
     }
 }
 
-fn main() { }
+fn main() {}

--- a/tests/ui/self/elision/ref-self-multi.stderr
+++ b/tests/ui/self/elision/ref-self-multi.stderr
@@ -1,5 +1,5 @@
 error[E0106]: missing lifetime specifier
-  --> $DIR/ref-self-multi.rs:18:56
+  --> $DIR/ref-self-multi.rs:23:56
    |
 LL |     fn ref_box_ref_Self(self: &Box<&Self>, f: &u32) -> &u32 {
    |                               -----------     ----     ^ expected named lifetime parameter
@@ -11,7 +11,7 @@ LL |     fn ref_box_ref_Self<'a>(self: &'a Box<&'a Self>, f: &'a u32) -> &'a u32
    |                        ++++        ++      ++            ++          ++
 
 error[E0106]: missing lifetime specifier
-  --> $DIR/ref-self-multi.rs:23:63
+  --> $DIR/ref-self-multi.rs:28:63
    |
 LL |     fn ref_wrap_ref_Self(self: &Wrap<&Self, u32>, f: &u32) -> &u32 {
    |                                -----------------     ----     ^ expected named lifetime parameter

--- a/tests/ui/self/elision/ref-self.fixed
+++ b/tests/ui/self/elision/ref-self.fixed
@@ -5,7 +5,7 @@
 #![allow(non_snake_case, dead_code)]
 
 use std::marker::PhantomData;
-use std::ops::Deref;
+use std::ops::{Deref, Receiver};
 use std::pin::Pin;
 
 struct Struct {}
@@ -17,6 +17,9 @@ impl<T, P> Deref for Wrap<T, P> {
     fn deref(&self) -> &T {
         &self.0
     }
+}
+impl<T, P> Receiver for Wrap<T, P> {
+    type Target = T;
 }
 
 impl Struct {

--- a/tests/ui/self/elision/ref-self.rs
+++ b/tests/ui/self/elision/ref-self.rs
@@ -5,7 +5,7 @@
 #![allow(non_snake_case, dead_code)]
 
 use std::marker::PhantomData;
-use std::ops::Deref;
+use std::ops::{Deref, Receiver};
 use std::pin::Pin;
 
 struct Struct {}
@@ -17,6 +17,9 @@ impl<T, P> Deref for Wrap<T, P> {
     fn deref(&self) -> &T {
         &self.0
     }
+}
+impl<T, P> Receiver for Wrap<T, P> {
+    type Target = T;
 }
 
 impl Struct {

--- a/tests/ui/self/elision/ref-self.stderr
+++ b/tests/ui/self/elision/ref-self.stderr
@@ -1,5 +1,5 @@
 error: lifetime may not live long enough
-  --> $DIR/ref-self.rs:26:9
+  --> $DIR/ref-self.rs:29:9
    |
 LL |     fn ref_self(&self, f: &u32) -> &u32 {
    |                 -         - let's call the lifetime of this reference `'1`
@@ -14,7 +14,7 @@ LL |     fn ref_self<'a>(&self, f: &'a u32) -> &'a u32 {
    |                ++++            ++          ++
 
 error: lifetime may not live long enough
-  --> $DIR/ref-self.rs:33:9
+  --> $DIR/ref-self.rs:36:9
    |
 LL |     fn ref_Self(self: &Self, f: &u32) -> &u32 {
    |                       -         - let's call the lifetime of this reference `'1`
@@ -29,7 +29,7 @@ LL |     fn ref_Self<'a>(self: &Self, f: &'a u32) -> &'a u32 {
    |                ++++                  ++          ++
 
 error: lifetime may not live long enough
-  --> $DIR/ref-self.rs:38:9
+  --> $DIR/ref-self.rs:41:9
    |
 LL |     fn box_ref_Self(self: Box<&Self>, f: &u32) -> &u32 {
    |                               -          - let's call the lifetime of this reference `'1`
@@ -44,7 +44,7 @@ LL |     fn box_ref_Self<'a>(self: Box<&Self>, f: &'a u32) -> &'a u32 {
    |                    ++++                       ++          ++
 
 error: lifetime may not live long enough
-  --> $DIR/ref-self.rs:43:9
+  --> $DIR/ref-self.rs:46:9
    |
 LL |     fn pin_ref_Self(self: Pin<&Self>, f: &u32) -> &u32 {
    |                               -          - let's call the lifetime of this reference `'1`
@@ -59,7 +59,7 @@ LL |     fn pin_ref_Self<'a>(self: Pin<&Self>, f: &'a u32) -> &'a u32 {
    |                    ++++                       ++          ++
 
 error: lifetime may not live long enough
-  --> $DIR/ref-self.rs:48:9
+  --> $DIR/ref-self.rs:51:9
    |
 LL |     fn box_box_ref_Self(self: Box<Box<&Self>>, f: &u32) -> &u32 {
    |                                       -           - let's call the lifetime of this reference `'1`
@@ -74,7 +74,7 @@ LL |     fn box_box_ref_Self<'a>(self: Box<Box<&Self>>, f: &'a u32) -> &'a u32 {
    |                        ++++                            ++          ++
 
 error: lifetime may not live long enough
-  --> $DIR/ref-self.rs:53:9
+  --> $DIR/ref-self.rs:56:9
    |
 LL |     fn box_pin_ref_Self(self: Box<Pin<&Self>>, f: &u32) -> &u32 {
    |                                       -           - let's call the lifetime of this reference `'1`
@@ -89,7 +89,7 @@ LL |     fn box_pin_ref_Self<'a>(self: Box<Pin<&Self>>, f: &'a u32) -> &'a u32 {
    |                        ++++                            ++          ++
 
 error: lifetime may not live long enough
-  --> $DIR/ref-self.rs:58:9
+  --> $DIR/ref-self.rs:61:9
    |
 LL |     fn wrap_ref_Self_Self(self: Wrap<&Self, Self>, f: &u8) -> &u8 {
    |                                      -                - let's call the lifetime of this reference `'1`
@@ -104,7 +104,7 @@ LL |     fn wrap_ref_Self_Self<'a>(self: Wrap<&Self, Self>, f: &'a u8) -> &'a u8
    |                          ++++                              ++         ++
 
 error: lifetime may not live long enough
-  --> $DIR/ref-self.rs:63:9
+  --> $DIR/ref-self.rs:66:9
    |
 LL |     fn ref_box_Self(self: &Box<Self>, f: &u32) -> &u32 {
    |                           -              - let's call the lifetime of this reference `'1`

--- a/tests/ui/self/invalid-self-dyn-receiver.rs
+++ b/tests/ui/self/invalid-self-dyn-receiver.rs
@@ -4,17 +4,18 @@
 
 #![feature(arbitrary_self_types)]
 
-use std::ops::Deref;
+use std::ops::{Deref, Receiver};
 
-trait Foo: Deref<Target = dyn Bar> {
-     fn method(self: &dyn Bar) {}
-     //~^ ERROR invalid `self` parameter type: `&dyn Bar`
+trait Foo: Deref<Target = dyn Bar> + Receiver<Target = dyn Bar> {
+    fn method(self: &dyn Bar) {}
+    //~^ ERROR invalid `self` parameter type: `&dyn Bar`
 }
 
 trait Bar {}
 
 fn test(x: &dyn Foo) {
-     x.method();
+    x.method();
+    //~^ ERROR type annotations needed
 }
 
 fn main() {}

--- a/tests/ui/self/invalid-self-dyn-receiver.stderr
+++ b/tests/ui/self/invalid-self-dyn-receiver.stderr
@@ -1,12 +1,26 @@
 error[E0307]: invalid `self` parameter type: `&dyn Bar`
-  --> $DIR/invalid-self-dyn-receiver.rs:10:22
+  --> $DIR/invalid-self-dyn-receiver.rs:10:21
    |
-LL |      fn method(self: &dyn Bar) {}
-   |                      ^^^^^^^^
+LL |     fn method(self: &dyn Bar) {}
+   |                     ^^^^^^^^
    |
    = note: type of `self` must be `Self` or some type implementing `Receiver`
    = help: consider changing to `self`, `&self`, `&mut self`, or a type implementing `Receiver` such as `self: Box<Self>`, `self: Rc<Self>`, or `self: Arc<Self>`
 
-error: aborting due to 1 previous error
+error[E0283]: type annotations needed
+  --> $DIR/invalid-self-dyn-receiver.rs:17:7
+   |
+LL |     x.method();
+   |       ^^^^^^
+   |
+   = note: cannot satisfy `_: Foo`
+help: try using a fully qualified path to specify the expected types
+   |
+LL -     x.method();
+LL +     <_ as Foo>::method(x);
+   |
 
-For more information about this error, try `rustc --explain E0307`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0283, E0307.
+For more information about an error, try `rustc --explain E0283`.

--- a/tests/ui/span/issue-27522.stderr
+++ b/tests/ui/span/issue-27522.stderr
@@ -5,7 +5,7 @@ LL |     fn handler(self: &SomeType);
    |                      ^^^^^^^^^
    |
    = note: type of `self` must be `Self` or a type that dereferences to it
-   = help: consider changing to `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
+   = help: consider changing to `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` where P is one of the previous types except `Self`; alternatively, consider implement `Receiver` trait on the type of `self`, where applicable
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/suggestions/dyn-incompatible-trait-should-use-where-sized.stderr
+++ b/tests/ui/suggestions/dyn-incompatible-trait-should-use-where-sized.stderr
@@ -35,7 +35,7 @@ LL |     fn bar(self: ()) {}
    |                  ^^
    |
    = note: type of `self` must be `Self` or a type that dereferences to it
-   = help: consider changing to `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
+   = help: consider changing to `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` where P is one of the previous types except `Self`; alternatively, consider implement `Receiver` trait on the type of `self`, where applicable
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/traits/issue-78372.stderr
+++ b/tests/ui/traits/issue-78372.stderr
@@ -69,7 +69,7 @@ LL |     fn foo(self: Smaht<Self, T>);
    |                  ^^^^^^^^^^^^^^
    |
    = note: type of `self` must be `Self` or a type that dereferences to it
-   = help: consider changing to `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
+   = help: consider changing to `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` where P is one of the previous types except `Self`; alternatively, consider implement `Receiver` trait on the type of `self`, where applicable
 
 error: aborting due to 7 previous errors
 

--- a/tests/ui/ufcs/ufcs-explicit-self-bad.stderr
+++ b/tests/ui/ufcs/ufcs-explicit-self-bad.stderr
@@ -24,7 +24,7 @@ LL |     fn foo(self: isize, x: isize) -> isize {
    |                  ^^^^^
    |
    = note: type of `self` must be `Self` or a type that dereferences to it
-   = help: consider changing to `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
+   = help: consider changing to `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` where P is one of the previous types except `Self`; alternatively, consider implement `Receiver` trait on the type of `self`, where applicable
 
 error[E0307]: invalid `self` parameter type: `Bar<isize>`
   --> $DIR/ufcs-explicit-self-bad.rs:19:18
@@ -33,7 +33,7 @@ LL |     fn foo(self: Bar<isize>, x: isize) -> isize {
    |                  ^^^^^^^^^^
    |
    = note: type of `self` must be `Self` or a type that dereferences to it
-   = help: consider changing to `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
+   = help: consider changing to `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` where P is one of the previous types except `Self`; alternatively, consider implement `Receiver` trait on the type of `self`, where applicable
 
 error[E0307]: invalid `self` parameter type: `&Bar<usize>`
   --> $DIR/ufcs-explicit-self-bad.rs:23:18
@@ -42,7 +42,7 @@ LL |     fn bar(self: &Bar<usize>, x: isize) -> isize {
    |                  ^^^^^^^^^^^
    |
    = note: type of `self` must be `Self` or a type that dereferences to it
-   = help: consider changing to `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
+   = help: consider changing to `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` where P is one of the previous types except `Self`; alternatively, consider implement `Receiver` trait on the type of `self`, where applicable
 
 error[E0308]: mismatched `self` parameter type
   --> $DIR/ufcs-explicit-self-bad.rs:37:21


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/146095)*

This patch separate the two traits and isolate their use in the language better.

## Compiler perspective

This means that in method probing, we will chase down a `Deref` chain for an applicable type for the variable `self`, from which we additionally chase down a Receiver chain for an applicable `Self` type from a list of methods that accepts one of these possible types of `self`.

What matters is that whether enabling `arbitrary_self_types` or not ...
- we make sure that method resolution results stay the same under the respective modes, so the only expected changes to UI tests are only so that `impl Receiver` is now mandatory and the wording on the diagnostics is tweaked to a very small extent;
- the perf results should be comparable, even when `arbitrary_self_types` is enabled; the only perf impact would come from resolving methods on types with `Deref::Target <> Receiver::Targe` in conjunction with `#![feature(arbitrary_self_types_split_chain)]` because we need explore more types out of necessity.

### Changes to the inherent method candidate assembly

The inherent method candidate assembly collects the candidate `Self` and `self` types into `AutoderefCache` type, which maps one observed type to its `Deref::Target` and `Receiver::Target` types.

This is because that it is very common that `Deref::Target` coincides with `Receiver::Target`. It would present a performance impact if we do not cache the projections or obligations from these projections as soon as we stop assuming that `impl Deref` implies `impl Receiver`.

Another observation is that the current prober will still try to match the `self` after *n + 1* dereferences and call `xform_self_ty` to unify its type with some `Self` that is after *1, 2, ..., n*-th dereference. This part of the computation is wasteful.

## Language perspective

Receiver chain has been an extension of Deref chain, but the consequence has been questioned as this would admit method signatures that are deemed dubious.

It is also debatable that Receiver trait which determines applicable `Self` type should have anything to do with dereference operation in general.

## t-lang discussion

To facilitate discussion, we can use the Zulip thread [#t-lang > Consequences of making Deref a subtrait of Receiver](https://rust-lang.zulipchat.com/#narrow/channel/213817-t-lang/topic/Consequences.20of.20making.20Deref.20a.20subtrait.20of.20Receiver).

#### Pending items
- [x] First, gather feedback on the proposed change and assess the impact on the overall feature.
- [x] Stomp out UI test changes due to lost diagnostics, by enabling search through Receiver side-chains, so that we can suggest enabling `arbitrary_self_types` gate again.
