### PR TITLE
Add maintainer for VxWorks

### DIFF
--- a/src/doc/rustc/src/platform-support/vxworks.md
+++ b/src/doc/rustc/src/platform-support/vxworks.md
@@ -20,6 +20,7 @@ Target triplets available:
 ## Target maintainers
 
 [@biabbas](https://github.com/biabbas)
+[@hax0kartik](https://github.com/hax0kartik)
 
 ## Requirements
 


### PR DESCRIPTION
Hi,

This adds me as a target maintainer for VxWorks. I am currently a member of the VxWorks compiler team and I am actively working on improving rust support for VxWorks.

Thanks!

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
