### PR TITLE
Suggest examples of format specifiers in error messages

### DIFF
--- a/compiler/rustc_builtin_macros/src/format.rs
+++ b/compiler/rustc_builtin_macros/src/format.rs
@@ -565,6 +565,7 @@ fn make_format_args(
             &used,
             &args,
             &pieces,
+            &invalid_refs,
             detect_foreign_fmt,
             str_style,
             fmt_str,
@@ -645,6 +646,7 @@ fn report_missing_placeholders(
     used: &[bool],
     args: &FormatArguments,
     pieces: &[parse::Piece<'_>],
+    invalid_refs: &[(usize, Option<Span>, PositionUsedAs, FormatArgPositionKind)],
     detect_foreign_fmt: bool,
     str_style: Option<usize>,
     fmt_str: &str,
@@ -758,31 +760,47 @@ fn report_missing_placeholders(
             check_foreign!(shell);
         }
     }
-    if !found_foreign {
-        if unused.len() == 1 {
-            diag.span_label(fmt_span, "formatting specifier missing");
+    if !found_foreign && unused.len() == 1 {
+        diag.span_label(fmt_span, "formatting specifier missing");
+    }
+
+    if !found_foreign && invalid_refs.is_empty() {
+        // Show example if user didn't use any format specifiers
+        let show_example = used.iter().all(|used| !used);
+
+        if !show_example && unused.len() > 1 {
+            diag.note(format!("consider adding {} format specifiers", unused.len()));
         }
-        if used.iter().all(|used| !used) {
+
+        let original_fmt_str = if fmt_str.len() >= 1 { &fmt_str[..fmt_str.len() - 1] } else { "" };
+
+        if show_example && unused.len() == 1 {
             diag.note("format specifiers use curly braces: `{}`");
+
+            diag.span_suggestion_verbose(
+                fmt_span,
+                "consider adding format specifier",
+                format!("\"{}{{}}\"", original_fmt_str),
+                Applicability::MaybeIncorrect,
+            );
         }
 
-        let mut suggest_fixed_fmt = format!("\"{}", &fmt_str[..fmt_str.len() - 1]);
-        for _ in &unused {
-            suggest_fixed_fmt.push_str("{}");
-        }
-        suggest_fixed_fmt.push('"');
+        if show_example && unused.len() > 1 {
+            diag.note("format specifiers use curly braces: `{}`");
 
-        let suggest_fmt_count = if unused.len() == 1 {
-            "consider adding format specifier".to_string()
-        } else {
-            format!("consider adding {} format specifiers", unused.len())
-        };
-        diag.span_suggestion_verbose(
-            fmt_span,
-            suggest_fmt_count,
-            suggest_fixed_fmt,
-            Applicability::MaybeIncorrect,
-        );
+            let mut suggest_fixed_fmt = format!("\"{}", original_fmt_str);
+            for _ in &unused {
+                suggest_fixed_fmt.push_str("{}");
+            }
+            suggest_fixed_fmt.push('"');
+
+            diag.span_suggestion_verbose(
+                fmt_span,
+                format!("consider adding {} format specifiers", unused.len()),
+                suggest_fixed_fmt,
+                Applicability::MaybeIncorrect,
+            );
+        }
     }
 
     diag.emit();

--- a/compiler/rustc_builtin_macros/src/format.rs
+++ b/compiler/rustc_builtin_macros/src/format.rs
@@ -768,38 +768,24 @@ fn report_missing_placeholders(
         // Show example if user didn't use any format specifiers
         let show_example = used.iter().all(|used| !used);
 
-        if !show_example && unused.len() > 1 {
-            diag.note(format!("consider adding {} format specifiers", unused.len()));
-        }
-
-        let original_fmt_str = if fmt_str.len() >= 1 { &fmt_str[..fmt_str.len() - 1] } else { "" };
-
-        if show_example && unused.len() == 1 {
-            diag.note("format specifiers use curly braces: `{}`");
-
-            diag.span_suggestion_verbose(
-                fmt_span,
-                "consider adding format specifier",
-                format!("\"{}{{}}\"", original_fmt_str),
-                Applicability::MaybeIncorrect,
-            );
-        }
-
-        if show_example && unused.len() > 1 {
-            diag.note("format specifiers use curly braces: `{}`");
-
-            let mut suggest_fixed_fmt = format!("\"{}", original_fmt_str);
-            for _ in &unused {
-                suggest_fixed_fmt.push_str("{}");
+        if !show_example {
+            if unused.len() > 1 {
+                diag.note(format!("consider adding {} format specifiers", unused.len()));
             }
-            suggest_fixed_fmt.push('"');
+        } else {
+            let original_fmt_str =
+                if fmt_str.len() >= 1 { &fmt_str[..fmt_str.len() - 1] } else { "" };
 
-            diag.span_suggestion_verbose(
-                fmt_span,
-                format!("consider adding {} format specifiers", unused.len()),
-                suggest_fixed_fmt,
-                Applicability::MaybeIncorrect,
-            );
+            let msg = if unused.len() == 1 {
+                "a format specifier".to_string()
+            } else {
+                format!("{} format specifiers", unused.len())
+            };
+
+            let sugg = format!("\"{}{}\"", original_fmt_str, "{}".repeat(unused.len()));
+            let msg = format!("format specifiers use curly braces, consider adding {msg}");
+
+            diag.span_suggestion_verbose(fmt_span, msg, sugg, Applicability::MaybeIncorrect);
         }
     }
 

--- a/tests/ui/fmt/ifmt-bad-arg.stderr
+++ b/tests/ui/fmt/ifmt-bad-arg.stderr
@@ -63,8 +63,7 @@ LL |     format!("", 1, 2);
    |             |   argument never used
    |             multiple missing formatting specifiers
    |
-   = note: format specifiers use curly braces: `{}`
-help: consider adding 2 format specifiers
+help: format specifiers use curly braces, consider adding 2 format specifiers
    |
 LL |     format!("{}{}", 1, 2);
    |              ++++
@@ -109,8 +108,7 @@ LL |     format!("", foo=2);
    |             |
    |             formatting specifier missing
    |
-   = note: format specifiers use curly braces: `{}`
-help: consider adding format specifier
+help: format specifiers use curly braces, consider adding a format specifier
    |
 LL |     format!("{}", foo=2);
    |              ++

--- a/tests/ui/fmt/ifmt-bad-arg.stderr
+++ b/tests/ui/fmt/ifmt-bad-arg.stderr
@@ -62,6 +62,12 @@ LL |     format!("", 1, 2);
    |             |   |
    |             |   argument never used
    |             multiple missing formatting specifiers
+   |
+   = note: format specifiers use curly braces: `{}`
+help: consider adding 2 format specifiers
+   |
+LL |     format!("{}{}", 1, 2);
+   |              ++++
 
 error: argument never used
   --> $DIR/ifmt-bad-arg.rs:33:22
@@ -102,6 +108,12 @@ LL |     format!("", foo=2);
    |             --      ^ named argument never used
    |             |
    |             formatting specifier missing
+   |
+   = note: format specifiers use curly braces: `{}`
+help: consider adding format specifier
+   |
+LL |     format!("{}", foo=2);
+   |              ++
 
 error: multiple unused formatting arguments
   --> $DIR/ifmt-bad-arg.rs:38:32
@@ -111,6 +123,8 @@ LL |     format!("{} {}", 1, 2, foo=1, bar=2);
    |             |                  |
    |             |                  named argument never used
    |             multiple missing formatting specifiers
+   |
+   = note: consider adding 2 format specifiers
 
 error: duplicate argument named `foo`
   --> $DIR/ifmt-bad-arg.rs:40:29

--- a/tests/ui/macros/format-unused-lables.stderr
+++ b/tests/ui/macros/format-unused-lables.stderr
@@ -8,8 +8,7 @@ LL |     println!("Test", 123, 456, 789);
    |              |       argument never used
    |              multiple missing formatting specifiers
    |
-   = note: format specifiers use curly braces: `{}`
-help: consider adding 3 format specifiers
+help: format specifiers use curly braces, consider adding 3 format specifiers
    |
 LL |     println!("Test{}{}{}", 123, 456, 789);
    |                   ++++++
@@ -26,8 +25,7 @@ LL |         456,
 LL |         789
    |         ^^^ argument never used
    |
-   = note: format specifiers use curly braces: `{}`
-help: consider adding 3 format specifiers
+help: format specifiers use curly braces, consider adding 3 format specifiers
    |
 LL |     println!("Test2{}{}{}",
    |                    ++++++
@@ -40,8 +38,7 @@ LL |     println!("Some stuff", UNUSED="args");
    |              |
    |              formatting specifier missing
    |
-   = note: format specifiers use curly braces: `{}`
-help: consider adding format specifier
+help: format specifiers use curly braces, consider adding a format specifier
    |
 LL |     println!("Some stuff{}", UNUSED="args");
    |                         ++

--- a/tests/ui/macros/format-unused-lables.stderr
+++ b/tests/ui/macros/format-unused-lables.stderr
@@ -7,6 +7,12 @@ LL |     println!("Test", 123, 456, 789);
    |              |       |    argument never used
    |              |       argument never used
    |              multiple missing formatting specifiers
+   |
+   = note: format specifiers use curly braces: `{}`
+help: consider adding 3 format specifiers
+   |
+LL |     println!("Test{}{}{}", 123, 456, 789);
+   |                   ++++++
 
 error: multiple unused formatting arguments
   --> $DIR/format-unused-lables.rs:6:9
@@ -19,6 +25,12 @@ LL |         456,
    |         ^^^ argument never used
 LL |         789
    |         ^^^ argument never used
+   |
+   = note: format specifiers use curly braces: `{}`
+help: consider adding 3 format specifiers
+   |
+LL |     println!("Test2{}{}{}",
+   |                    ++++++
 
 error: named argument never used
   --> $DIR/format-unused-lables.rs:11:35
@@ -27,6 +39,12 @@ LL |     println!("Some stuff", UNUSED="args");
    |              ------------         ^^^^^^ named argument never used
    |              |
    |              formatting specifier missing
+   |
+   = note: format specifiers use curly braces: `{}`
+help: consider adding format specifier
+   |
+LL |     println!("Some stuff{}", UNUSED="args");
+   |                         ++
 
 error: multiple unused formatting arguments
   --> $DIR/format-unused-lables.rs:14:9

--- a/tests/ui/mir/unsized-extern-static.stderr
+++ b/tests/ui/mir/unsized-extern-static.stderr
@@ -5,6 +5,12 @@ LL |     println!("C", unsafe { &symbol });
    |              ---  ^^^^^^^^^^^^^^^^^^ argument never used
    |              |
    |              formatting specifier missing
+   |
+   = note: format specifiers use curly braces: `{}`
+help: consider adding format specifier
+   |
+LL |     println!("C{}", unsafe { &symbol });
+   |                ++
 
 error[E0277]: the size for values of type `[i8]` cannot be known at compilation time
   --> $DIR/unsized-extern-static.rs:6:5

--- a/tests/ui/mir/unsized-extern-static.stderr
+++ b/tests/ui/mir/unsized-extern-static.stderr
@@ -6,8 +6,7 @@ LL |     println!("C", unsafe { &symbol });
    |              |
    |              formatting specifier missing
    |
-   = note: format specifiers use curly braces: `{}`
-help: consider adding format specifier
+help: format specifiers use curly braces, consider adding a format specifier
    |
 LL |     println!("C{}", unsafe { &symbol });
    |                ++

--- a/tests/ui/suggestions/missing-format-specifiers-issue-68293.rs
+++ b/tests/ui/suggestions/missing-format-specifiers-issue-68293.rs
@@ -29,6 +29,7 @@ fn missing_format_specifiers_multiple_unused_args() {
     //~| NOTE multiple missing formatting specifiers
     //~| NOTE argument never used
     //~| NOTE argument never used
+    //~| NOTE consider adding 2 format specifiers
 }
 
 fn main() { }

--- a/tests/ui/suggestions/missing-format-specifiers-issue-68293.rs
+++ b/tests/ui/suggestions/missing-format-specifiers-issue-68293.rs
@@ -2,18 +2,18 @@ fn no_format_specifier_two_unused_args() {
     println!("Hello", "World");
     //~^ ERROR argument never used
     //~| NOTE formatting specifier missing
-    //~| NOTE format specifiers use curly braces: `{}`
     //~| NOTE argument never used
+    //~| HELP format specifiers use curly braces, consider adding a format specifier
 }
 
 fn no_format_specifier_multiple_unused_args() {
     println!("list: ", 1, 2, 3);
     //~^ ERROR multiple unused formatting arguments
     //~| NOTE multiple missing formatting specifiers
-    //~| NOTE format specifiers use curly braces: `{}`
     //~| NOTE argument never used
     //~| NOTE argument never used
     //~| NOTE argument never used
+    //~| HELP format specifiers use curly braces, consider adding 3 format specifiers
 }
 
 fn missing_format_specifiers_one_unused_arg() {

--- a/tests/ui/suggestions/missing-format-specifiers-issue-68293.rs
+++ b/tests/ui/suggestions/missing-format-specifiers-issue-68293.rs
@@ -1,0 +1,34 @@
+fn no_format_specifier_two_unused_args() {
+    println!("Hello", "World");
+    //~^ ERROR argument never used
+    //~| NOTE formatting specifier missing
+    //~| NOTE format specifiers use curly braces: `{}`
+    //~| NOTE argument never used
+}
+
+fn no_format_specifier_multiple_unused_args() {
+    println!("list: ", 1, 2, 3);
+    //~^ ERROR multiple unused formatting arguments
+    //~| NOTE multiple missing formatting specifiers
+    //~| NOTE format specifiers use curly braces: `{}`
+    //~| NOTE argument never used
+    //~| NOTE argument never used
+    //~| NOTE argument never used
+}
+
+fn missing_format_specifiers_one_unused_arg() {
+    println!("list: {}, {}", 1, 2, 3);
+    //~^ ERROR argument never used
+    //~| NOTE formatting specifier missing
+    //~| NOTE argument never used
+}
+
+fn missing_format_specifiers_multiple_unused_args() {
+    println!("list: {}", 1, 2, 3);
+    //~^ ERROR multiple unused formatting arguments
+    //~| NOTE multiple missing formatting specifiers
+    //~| NOTE argument never used
+    //~| NOTE argument never used
+}
+
+fn main() { }

--- a/tests/ui/suggestions/missing-format-specifiers-issue-68293.stderr
+++ b/tests/ui/suggestions/missing-format-specifiers-issue-68293.stderr
@@ -6,8 +6,7 @@ LL |     println!("Hello", "World");
    |              |
    |              formatting specifier missing
    |
-   = note: format specifiers use curly braces: `{}`
-help: consider adding format specifier
+help: format specifiers use curly braces, consider adding a format specifier
    |
 LL |     println!("Hello{}", "World");
    |                    ++
@@ -22,8 +21,7 @@ LL |     println!("list: ", 1, 2, 3);
    |              |         argument never used
    |              multiple missing formatting specifiers
    |
-   = note: format specifiers use curly braces: `{}`
-help: consider adding 3 format specifiers
+help: format specifiers use curly braces, consider adding 3 format specifiers
    |
 LL |     println!("list: {}{}{}", 1, 2, 3);
    |                     ++++++

--- a/tests/ui/suggestions/missing-format-specifiers-issue-68293.stderr
+++ b/tests/ui/suggestions/missing-format-specifiers-issue-68293.stderr
@@ -35,11 +35,6 @@ LL |     println!("list: {}, {}", 1, 2, 3);
    |              --------------        ^ argument never used
    |              |
    |              formatting specifier missing
-   |
-help: consider adding format specifier
-   |
-LL |     println!("list: {}, {}{}", 1, 2, 3);
-   |                           ++
 
 error: multiple unused formatting arguments
   --> $DIR/missing-format-specifiers-issue-68293.rs:27:29
@@ -50,10 +45,7 @@ LL |     println!("list: {}", 1, 2, 3);
    |              |              argument never used
    |              multiple missing formatting specifiers
    |
-help: consider adding 2 format specifiers
-   |
-LL |     println!("list: {}{}{}", 1, 2, 3);
-   |                       ++++
+   = note: consider adding 2 format specifiers
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/suggestions/missing-format-specifiers-issue-68293.stderr
+++ b/tests/ui/suggestions/missing-format-specifiers-issue-68293.stderr
@@ -1,0 +1,59 @@
+error: argument never used
+  --> $DIR/missing-format-specifiers-issue-68293.rs:2:23
+   |
+LL |     println!("Hello", "World");
+   |              -------  ^^^^^^^ argument never used
+   |              |
+   |              formatting specifier missing
+   |
+   = note: format specifiers use curly braces: `{}`
+help: consider adding format specifier
+   |
+LL |     println!("Hello{}", "World");
+   |                    ++
+
+error: multiple unused formatting arguments
+  --> $DIR/missing-format-specifiers-issue-68293.rs:10:24
+   |
+LL |     println!("list: ", 1, 2, 3);
+   |              --------  ^  ^  ^ argument never used
+   |              |         |  |
+   |              |         |  argument never used
+   |              |         argument never used
+   |              multiple missing formatting specifiers
+   |
+   = note: format specifiers use curly braces: `{}`
+help: consider adding 3 format specifiers
+   |
+LL |     println!("list: {}{}{}", 1, 2, 3);
+   |                     ++++++
+
+error: argument never used
+  --> $DIR/missing-format-specifiers-issue-68293.rs:20:36
+   |
+LL |     println!("list: {}, {}", 1, 2, 3);
+   |              --------------        ^ argument never used
+   |              |
+   |              formatting specifier missing
+   |
+help: consider adding format specifier
+   |
+LL |     println!("list: {}, {}{}", 1, 2, 3);
+   |                           ++
+
+error: multiple unused formatting arguments
+  --> $DIR/missing-format-specifiers-issue-68293.rs:27:29
+   |
+LL |     println!("list: {}", 1, 2, 3);
+   |              ----------     ^  ^ argument never used
+   |              |              |
+   |              |              argument never used
+   |              multiple missing formatting specifiers
+   |
+help: consider adding 2 format specifiers
+   |
+LL |     println!("list: {}{}{}", 1, 2, 3);
+   |                       ++++
+
+error: aborting due to 4 previous errors
+


### PR DESCRIPTION
Format macro now suggests adding `{}` if no formatting specifiers are present. It also gives an example:
```rust
LL |     println!("Hello", "World");
   |              -------  ^^^^^^^ argument never used
   |              |
   |              formatting specifier missing
   |
   = note: format specifiers use curly braces: `{}`
help: consider adding format specifier
   |
LL |     println!("Hello{}", "World");
   |                    ++
```
When one or more `{}` are present, it doesn't show 'format specifiers use curly braces: `{}`' and example, just small hint on how many you missing:
```rust
LL |     println!("list: {}", 1, 2, 3);
   |              ----------     ^  ^ argument never used
   |              |              |
   |              |              argument never used
   |              multiple missing formatting specifiers
   |
   = help: consider adding 2 format specifiers
```

Original issue: rust-lang/rust#68293
Based on discussion in this PR: rust-lang/rust#76443

Let me know if something is missing