### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,10 +8,13 @@ root = true
 end_of_line = lf
 charset = utf-8
 insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
 
 # some tests need trailing whitespace in output snapshots
-[!tests/]
-trim_trailing_whitespace = true
+[tests/**]
+trim_trailing_whitespace = false
 # for actual source code files of test, we still don't want trailing whitespace
 [tests/**.{rs,js}]
 trim_trailing_whitespace = true
@@ -19,9 +22,9 @@ trim_trailing_whitespace = true
 [tests/ui/{frontmatter/frontmatter-whitespace-3.rs,parser/shebang/shebang-space.rs}]
 trim_trailing_whitespace = false
 
-[!src/llvm-project]
-indent_style = space
-indent_size = 4
+[src/llvm-project]
+indent_style = unset
+indent_size = unset
 
 [*.rs]
 max_line_length = 100

--- a/compiler/rustc_ast/src/token.rs
+++ b/compiler/rustc_ast/src/token.rs
@@ -22,8 +22,7 @@ pub enum CommentKind {
     Block,
 }
 
-// This type must not implement `Hash` due to the unusual `PartialEq` impl below.
-#[derive(Copy, Clone, Debug, Encodable, Decodable, HashStable_Generic)]
+#[derive(Copy, Clone, PartialEq, Debug, Encodable, Decodable, HashStable_Generic)]
 pub enum InvisibleOrigin {
     // From the expansion of a metavariable in a declarative macro.
     MetaVar(MetaVarKind),
@@ -42,20 +41,6 @@ impl InvisibleOrigin {
             InvisibleOrigin::MetaVar(_) => false,
             InvisibleOrigin::ProcMacro => true,
         }
-    }
-}
-
-impl PartialEq for InvisibleOrigin {
-    #[inline]
-    fn eq(&self, _other: &InvisibleOrigin) -> bool {
-        // When we had AST-based nonterminals we couldn't compare them, and the
-        // old `Nonterminal` type had an `eq` that always returned false,
-        // resulting in this restriction:
-        // https://doc.rust-lang.org/nightly/reference/macros-by-example.html#forwarding-a-matched-fragment
-        // This `eq` emulates that behaviour. We could consider lifting this
-        // restriction now but there are still cases involving invisible
-        // delimiters that make it harder than it first appears.
-        false
     }
 }
 
@@ -142,7 +127,8 @@ impl Delimiter {
         }
     }
 
-    // This exists because `InvisibleOrigin`s should be compared. It is only used for assertions.
+    // This exists because `InvisibleOrigin`s should not be compared. It is only used for
+    // assertions.
     pub fn eq_ignoring_invisible_origin(&self, other: &Delimiter) -> bool {
         match (self, other) {
             (Delimiter::Parenthesis, Delimiter::Parenthesis) => true,

--- a/compiler/rustc_codegen_llvm/src/context.rs
+++ b/compiler/rustc_codegen_llvm/src/context.rs
@@ -217,6 +217,10 @@ pub(crate) unsafe fn create_module<'ll>(
             // LLVM 22.0 updated the default layout on avr: https://github.com/llvm/llvm-project/pull/153010
             target_data_layout = target_data_layout.replace("n8:16", "n8")
         }
+        if sess.target.arch == "nvptx64" {
+            // LLVM 22 updated the NVPTX layout to indicate 256-bit vector load/store: https://github.com/llvm/llvm-project/pull/155198
+            target_data_layout = target_data_layout.replace("-i256:256", "");
+        }
     }
 
     // Ensure the data-layout values hardcoded remain the defaults.

--- a/compiler/rustc_codegen_ssa/src/back/linker.rs
+++ b/compiler/rustc_codegen_ssa/src/back/linker.rs
@@ -11,8 +11,9 @@ use rustc_metadata::{
 };
 use rustc_middle::bug;
 use rustc_middle::middle::dependency_format::Linkage;
-use rustc_middle::middle::exported_symbols;
-use rustc_middle::middle::exported_symbols::{ExportedSymbol, SymbolExportInfo, SymbolExportKind};
+use rustc_middle::middle::exported_symbols::{
+    self, ExportedSymbol, SymbolExportInfo, SymbolExportKind, SymbolExportLevel,
+};
 use rustc_middle::ty::TyCtxt;
 use rustc_session::Session;
 use rustc_session::config::{self, CrateType, DebugInfo, LinkerPluginLto, Lto, OptLevel, Strip};
@@ -22,6 +23,8 @@ use tracing::{debug, warn};
 
 use super::command::Command;
 use super::symbol_export;
+use crate::back::symbol_export::allocator_shim_symbols;
+use crate::base::needs_allocator_shim_for_linking;
 use crate::errors;
 
 #[cfg(test)]
@@ -1837,6 +1840,14 @@ fn exported_symbols_for_non_proc_macro(
             symbol_export::extend_exported_symbols(&mut symbols, tcx, symbol, cnum);
         }
     });
+
+    // Mark allocator shim symbols as exported only if they were generated.
+    if export_threshold == SymbolExportLevel::Rust
+        && needs_allocator_shim_for_linking(tcx.dependency_formats(()), crate_type)
+        && tcx.allocator_kind(()).is_some()
+    {
+        symbols.extend(allocator_shim_symbols(tcx));
+    }
 
     symbols
 }

--- a/compiler/rustc_codegen_ssa/src/back/linker.rs
+++ b/compiler/rustc_codegen_ssa/src/back/linker.rs
@@ -1827,7 +1827,7 @@ fn exported_symbols_for_non_proc_macro(
     let export_threshold = symbol_export::crates_export_threshold(&[crate_type]);
     for_each_exported_symbols_include_dep(tcx, crate_type, |symbol, info, cnum| {
         // Do not export mangled symbols from cdylibs and don't attempt to export compiler-builtins
-        // from any cdylib. The latter doesn't work anyway as we use hidden visibility for
+        // from any dylib. The latter doesn't work anyway as we use hidden visibility for
         // compiler-builtins. Most linkers silently ignore it, but ld64 gives a warning.
         if info.level.is_below_threshold(export_threshold) && !tcx.is_compiler_builtins(cnum) {
             symbols.push((

--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -1160,7 +1160,7 @@ impl<'a> DiagCtxtHandle<'a> {
         // - It's only produce with JSON output.
         // - It's not emitted the usual way, via `emit_diagnostic`.
         // - The `$message_type` field is "unused_externs" rather than the usual
-        //   "diagnosic".
+        //   "diagnostic".
         //
         // We count it as a lint error because it has a lint level. The value
         // of `loud` (which comes from "unused-externs" or

--- a/compiler/rustc_target/src/spec/targets/loongarch64_unknown_none.rs
+++ b/compiler/rustc_target/src/spec/targets/loongarch64_unknown_none.rs
@@ -17,7 +17,7 @@ pub(crate) fn target() -> Target {
         arch: "loongarch64".into(),
         options: TargetOptions {
             cpu: "generic".into(),
-            features: "+f,+d".into(),
+            features: "+f,+d,-lsx".into(),
             linker_flavor: LinkerFlavor::Gnu(Cc::No, Lld::Yes),
             linker: Some("rust-lld".into()),
             llvm_abiname: "lp64d".into(),

--- a/compiler/rustc_target/src/spec/targets/nvptx64_nvidia_cuda.rs
+++ b/compiler/rustc_target/src/spec/targets/nvptx64_nvidia_cuda.rs
@@ -6,7 +6,7 @@ use crate::spec::{
 pub(crate) fn target() -> Target {
     Target {
         arch: "nvptx64".into(),
-        data_layout: "e-p6:32:32-i64:64-i128:128-v16:16-v32:32-n16:32:64".into(),
+        data_layout: "e-p6:32:32-i64:64-i128:128-i256:256-v16:16-v32:32-n16:32:64".into(),
         llvm_target: "nvptx64-nvidia-cuda".into(),
         metadata: TargetMetadata {
             description: Some("--emit=asm generates PTX code that runs on NVIDIA GPUs".into()),

--- a/src/doc/unstable-book/src/compiler-flags/sanitizer.md
+++ b/src/doc/unstable-book/src/compiler-flags/sanitizer.md
@@ -244,7 +244,7 @@ See the [Clang ControlFlowIntegrity documentation][clang-cfi] for more details.
 
 ## Example 1: Redirecting control flow using an indirect branch/call to an invalid destination
 
-```rust,ignore (making doc tests pass cross-platform is hard)
+```rust
 use std::arch::naked_asm;
 use std::mem;
 
@@ -253,6 +253,7 @@ fn add_one(x: i32) -> i32 {
 }
 
 #[unsafe(naked)]
+# #[cfg(target_arch = "x86_64")]
 pub extern "C" fn add_two(x: i32) {
     // x + 2 preceded by a landing pad/nop block
     naked_asm!(
@@ -276,6 +277,7 @@ fn do_twice(f: fn(i32) -> i32, arg: i32) -> i32 {
     f(arg) + f(arg)
 }
 
+# #[cfg(target_arch = "x86_64")]
 fn main() {
     let answer = do_twice(add_one, 5);
 
@@ -292,6 +294,7 @@ fn main() {
 
     println!("The next answer is: {}", next_answer);
 }
+# #[cfg(not(target_arch = "x86_64"))] fn main() {}
 ```
 Fig. 1. Redirecting control flow using an indirect branch/call to an invalid
 destination (i.e., within the body of the function).

--- a/src/tools/clippy/tests/ui/bool_assert_comparison.stderr
+++ b/src/tools/clippy/tests/ui/bool_assert_comparison.stderr
@@ -272,10 +272,8 @@ LL |     assert_eq!(a!(), true);
    |
 help: replace it with `assert!(..)`
    |
-LL |         true
-...
-LL |
-LL ~     assert!(a!());
+LL -     assert_eq!(a!(), true);
+LL +     assert!(a!());
    |
 
 error: used `assert_eq!` with a literal bool
@@ -286,10 +284,8 @@ LL |     assert_eq!(true, b!());
    |
 help: replace it with `assert!(..)`
    |
-LL |         true
-...
-LL |
-LL ~     assert!(b!());
+LL -     assert_eq!(true, b!());
+LL +     assert!(b!());
    |
 
 error: used `debug_assert_eq!` with a literal bool

--- a/tests/ui/linking/mixed-allocator-shim.rs
+++ b/tests/ui/linking/mixed-allocator-shim.rs
@@ -1,6 +1,7 @@
 //@ build-pass
 //@ compile-flags: --crate-type staticlib,dylib -Zstaticlib-prefer-dynamic
 //@ no-prefer-dynamic
+//@ needs-crate-type: dylib
 
 // Test that compiling for multiple crate types in a single compilation with
 // mismatching allocator shim requirements doesn't result in the allocator shim

--- a/tests/ui/linking/mixed-allocator-shim.rs
+++ b/tests/ui/linking/mixed-allocator-shim.rs
@@ -1,0 +1,15 @@
+//@ build-pass
+//@ compile-flags: --crate-type staticlib,dylib -Zstaticlib-prefer-dynamic
+//@ no-prefer-dynamic
+
+// Test that compiling for multiple crate types in a single compilation with
+// mismatching allocator shim requirements doesn't result in the allocator shim
+// missing entirely.
+// In this particular test the dylib crate type will statically link libstd and
+// thus need an allocator shim, while the staticlib crate type will dynamically
+// link libstd and thus not need an allocator shim.
+// The -Zstaticlib-prefer-dynamic flag could be avoided by doing it the other
+// way around, but testing that the staticlib correctly has the allocator shim
+// in that case would require a run-make test instead.
+
+pub fn foo() {}


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#139113 (unstable book: in a sanitizer example, check the code)
 - rust-lang/rust#145823 (editorconfig: don't use nonexistent syntax)
 - rust-lang/rust#145962 (Ensure we emit an allocator shim when only some crate types need one)
 - rust-lang/rust#146032 (Explicity disable LSX feature for `loongarch64-unknown-none` target)
 - rust-lang/rust#146090 (Derive `PartialEq` for `InvisibleOrigin`)
 - rust-lang/rust#146120 (Correct typo in `rustc_errors` comment)
 - rust-lang/rust#146121 (fix: Filter suggestion parts that match existing code)
 - rust-lang/rust#146134 (llvm: nvptx: Layout update to match LLVM)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=139113,145823,145962,146032,146090,146120,146121,146134)
<!-- homu-ignore:end -->