### PR TITLE
Rollup of 9 pull requests

### DIFF
--- a/compiler/rustc_ast/src/token.rs
+++ b/compiler/rustc_ast/src/token.rs
@@ -22,8 +22,7 @@ pub enum CommentKind {
     Block,
 }
 
-// This type must not implement `Hash` due to the unusual `PartialEq` impl below.
-#[derive(Copy, Clone, Debug, Encodable, Decodable, HashStable_Generic)]
+#[derive(Copy, Clone, PartialEq, Debug, Encodable, Decodable, HashStable_Generic)]
 pub enum InvisibleOrigin {
     // From the expansion of a metavariable in a declarative macro.
     MetaVar(MetaVarKind),
@@ -42,20 +41,6 @@ impl InvisibleOrigin {
             InvisibleOrigin::MetaVar(_) => false,
             InvisibleOrigin::ProcMacro => true,
         }
-    }
-}
-
-impl PartialEq for InvisibleOrigin {
-    #[inline]
-    fn eq(&self, _other: &InvisibleOrigin) -> bool {
-        // When we had AST-based nonterminals we couldn't compare them, and the
-        // old `Nonterminal` type had an `eq` that always returned false,
-        // resulting in this restriction:
-        // https://doc.rust-lang.org/nightly/reference/macros-by-example.html#forwarding-a-matched-fragment
-        // This `eq` emulates that behaviour. We could consider lifting this
-        // restriction now but there are still cases involving invisible
-        // delimiters that make it harder than it first appears.
-        false
     }
 }
 
@@ -142,7 +127,8 @@ impl Delimiter {
         }
     }
 
-    // This exists because `InvisibleOrigin`s should be compared. It is only used for assertions.
+    // This exists because `InvisibleOrigin`s should not be compared. It is only used for
+    // assertions.
     pub fn eq_ignoring_invisible_origin(&self, other: &Delimiter) -> bool {
         match (self, other) {
             (Delimiter::Parenthesis, Delimiter::Parenthesis) => true,

--- a/compiler/rustc_codegen_ssa/src/back/linker.rs
+++ b/compiler/rustc_codegen_ssa/src/back/linker.rs
@@ -11,8 +11,9 @@ use rustc_metadata::{
 };
 use rustc_middle::bug;
 use rustc_middle::middle::dependency_format::Linkage;
-use rustc_middle::middle::exported_symbols;
-use rustc_middle::middle::exported_symbols::{ExportedSymbol, SymbolExportInfo, SymbolExportKind};
+use rustc_middle::middle::exported_symbols::{
+    self, ExportedSymbol, SymbolExportInfo, SymbolExportKind, SymbolExportLevel,
+};
 use rustc_middle::ty::TyCtxt;
 use rustc_session::Session;
 use rustc_session::config::{self, CrateType, DebugInfo, LinkerPluginLto, Lto, OptLevel, Strip};
@@ -22,6 +23,8 @@ use tracing::{debug, warn};
 
 use super::command::Command;
 use super::symbol_export;
+use crate::back::symbol_export::allocator_shim_symbols;
+use crate::base::needs_allocator_shim_for_linking;
 use crate::errors;
 
 #[cfg(test)]
@@ -1837,6 +1840,14 @@ fn exported_symbols_for_non_proc_macro(
             symbol_export::extend_exported_symbols(&mut symbols, tcx, symbol, cnum);
         }
     });
+
+    // Mark allocator shim symbols as exported only if they were generated.
+    if export_threshold == SymbolExportLevel::Rust
+        && needs_allocator_shim_for_linking(tcx.dependency_formats(()), crate_type)
+        && tcx.allocator_kind(()).is_some()
+    {
+        symbols.extend(allocator_shim_symbols(tcx));
+    }
 
     symbols
 }

--- a/compiler/rustc_codegen_ssa/src/back/linker.rs
+++ b/compiler/rustc_codegen_ssa/src/back/linker.rs
@@ -1827,7 +1827,7 @@ fn exported_symbols_for_non_proc_macro(
     let export_threshold = symbol_export::crates_export_threshold(&[crate_type]);
     for_each_exported_symbols_include_dep(tcx, crate_type, |symbol, info, cnum| {
         // Do not export mangled symbols from cdylibs and don't attempt to export compiler-builtins
-        // from any cdylib. The latter doesn't work anyway as we use hidden visibility for
+        // from any dylib. The latter doesn't work anyway as we use hidden visibility for
         // compiler-builtins. Most linkers silently ignore it, but ld64 gives a warning.
         if info.level.is_below_threshold(export_threshold) && !tcx.is_compiler_builtins(cnum) {
             symbols.push((

--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -1160,7 +1160,7 @@ impl<'a> DiagCtxtHandle<'a> {
         // - It's only produce with JSON output.
         // - It's not emitted the usual way, via `emit_diagnostic`.
         // - The `$message_type` field is "unused_externs" rather than the usual
-        //   "diagnosic".
+        //   "diagnostic".
         //
         // We count it as a lint error because it has a lint level. The value
         // of `loud` (which comes from "unused-externs" or

--- a/compiler/rustc_span/src/lib.rs
+++ b/compiler/rustc_span/src/lib.rs
@@ -18,6 +18,7 @@
 // tidy-alphabetical-start
 #![allow(internal_features)]
 #![cfg_attr(bootstrap, feature(round_char_boundary))]
+#![cfg_attr(target_arch = "loongarch64", feature(stdarch_loongarch))]
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
 #![doc(rust_logo)]
 #![feature(array_windows)]

--- a/library/alloc/src/raw_vec/mod.rs
+++ b/library/alloc/src/raw_vec/mod.rs
@@ -468,10 +468,6 @@ impl<A: Allocator> RawVecInner<A> {
             return Ok(Self::new_in(alloc, elem_layout.alignment()));
         }
 
-        if let Err(err) = alloc_guard(layout.size()) {
-            return Err(err);
-        }
-
         let result = match init {
             AllocInit::Uninitialized => alloc.allocate(layout),
             #[cfg(not(no_global_oom_handling))]
@@ -662,7 +658,7 @@ impl<A: Allocator> RawVecInner<A> {
         let new_layout = layout_array(cap, elem_layout)?;
 
         let ptr = finish_grow(new_layout, self.current_memory(elem_layout), &mut self.alloc)?;
-        // SAFETY: finish_grow would have resulted in a capacity overflow if we tried to allocate more than `isize::MAX` items
+        // SAFETY: layout_array would have resulted in a capacity overflow if we tried to allocate more than `isize::MAX` items
 
         unsafe { self.set_ptr_and_cap(ptr, cap) };
         Ok(())
@@ -684,7 +680,7 @@ impl<A: Allocator> RawVecInner<A> {
         let new_layout = layout_array(cap, elem_layout)?;
 
         let ptr = finish_grow(new_layout, self.current_memory(elem_layout), &mut self.alloc)?;
-        // SAFETY: finish_grow would have resulted in a capacity overflow if we tried to allocate more than `isize::MAX` items
+        // SAFETY: layout_array would have resulted in a capacity overflow if we tried to allocate more than `isize::MAX` items
         unsafe {
             self.set_ptr_and_cap(ptr, cap);
         }
@@ -771,8 +767,6 @@ fn finish_grow<A>(
 where
     A: Allocator,
 {
-    alloc_guard(new_layout.size())?;
-
     let memory = if let Some((ptr, old_layout)) = current_memory {
         debug_assert_eq!(old_layout.align(), new_layout.align());
         unsafe {
@@ -796,23 +790,6 @@ fn handle_error(e: TryReserveError) -> ! {
     match e.kind() {
         CapacityOverflow => capacity_overflow(),
         AllocError { layout, .. } => handle_alloc_error(layout),
-    }
-}
-
-// We need to guarantee the following:
-// * We don't ever allocate `> isize::MAX` byte-size objects.
-// * We don't overflow `usize::MAX` and actually allocate too little.
-//
-// On 64-bit we just need to check for overflow since trying to allocate
-// `> isize::MAX` bytes will surely fail. On 32-bit and 16-bit we need to add
-// an extra guard for this in case we're running on a platform which can use
-// all 4GB in user-space, e.g., PAE or x32.
-#[inline]
-fn alloc_guard(alloc_size: usize) -> Result<(), TryReserveError> {
-    if usize::BITS < 64 && alloc_size > isize::MAX as usize {
-        Err(CapacityOverflow.into())
-    } else {
-        Ok(())
     }
 }
 

--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -48,6 +48,7 @@ pub use iter::IntoIter;
 /// assert_eq!(strings, ["Hello there!", "Hello there!"]);
 /// ```
 #[inline]
+#[must_use = "cloning is often expensive and is not expected to have side effects"]
 #[stable(feature = "array_repeat", since = "CURRENT_RUSTC_VERSION")]
 pub fn repeat<T: Clone, const N: usize>(val: T) -> [T; N] {
     from_trusted_iterator(repeat_n(val, N))

--- a/library/coretests/tests/lib.rs
+++ b/library/coretests/tests/lib.rs
@@ -78,6 +78,7 @@
 #![feature(next_index)]
 #![feature(numfmt)]
 #![feature(pattern)]
+#![feature(peekable_next_if_map)]
 #![feature(pointer_is_aligned_to)]
 #![feature(portable_simd)]
 #![feature(ptr_metadata)]

--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -1575,8 +1575,6 @@ impl PathBuf {
     /// # Examples
     ///
     /// ```
-    /// #![feature(path_add_extension)]
-    ///
     /// use std::path::{Path, PathBuf};
     ///
     /// let mut p = PathBuf::from("/feel/the");
@@ -1596,7 +1594,7 @@ impl PathBuf {
     /// p.add_extension("");
     /// assert_eq!(Path::new("/feel/the.formatted.dark"), p.as_path());
     /// ```
-    #[unstable(feature = "path_add_extension", issue = "127292")]
+    #[stable(feature = "path_add_extension", since = "CURRENT_RUSTC_VERSION")]
     pub fn add_extension<S: AsRef<OsStr>>(&mut self, extension: S) -> bool {
         self._add_extension(extension.as_ref())
     }
@@ -2846,8 +2844,6 @@ impl Path {
     /// # Examples
     ///
     /// ```
-    /// #![feature(path_add_extension)]
-    ///
     /// use std::path::{Path, PathBuf};
     ///
     /// let path = Path::new("foo.rs");
@@ -2858,7 +2854,7 @@ impl Path {
     /// assert_eq!(path.with_added_extension("xz"), PathBuf::from("foo.tar.gz.xz"));
     /// assert_eq!(path.with_added_extension("").with_added_extension("txt"), PathBuf::from("foo.tar.gz.txt"));
     /// ```
-    #[unstable(feature = "path_add_extension", issue = "127292")]
+    #[stable(feature = "path_add_extension", since = "CURRENT_RUSTC_VERSION")]
     pub fn with_added_extension<S: AsRef<OsStr>>(&self, extension: S) -> PathBuf {
         let mut new_path = self.to_path_buf();
         new_path.add_extension(extension);

--- a/library/std/tests/path.rs
+++ b/library/std/tests/path.rs
@@ -1,4 +1,4 @@
-#![feature(clone_to_uninit, path_add_extension, maybe_uninit_slice, normalize_lexically)]
+#![feature(clone_to_uninit, maybe_uninit_slice, normalize_lexically)]
 
 use std::clone::CloneToUninit;
 use std::ffi::OsStr;

--- a/src/etc/htmldocck.py
+++ b/src/etc/htmldocck.py
@@ -247,7 +247,7 @@ class CachedFiles(object):
             paths = list(Path(self.root).glob(path))
             if len(paths) != 1:
                 raise FailedCheck("glob path does not resolve to one file")
-            path = str(paths[0])
+            return str(paths[0])
         return os.path.join(self.root, path)
 
     def get_file(self, path):

--- a/tests/run-make/rustdoc-search-load-itemtype/bar.rs
+++ b/tests/run-make/rustdoc-search-load-itemtype/bar.rs
@@ -1,0 +1,27 @@
+#![crate_type = "proc-macro"]
+
+extern crate proc_macro;
+use proc_macro::*;
+
+//@ has bar/macro.a_procmacro.html
+//@ hasraw search.index/name/*.js a_procmacro
+#[proc_macro]
+pub fn a_procmacro(_: TokenStream) -> TokenStream {
+    unimplemented!()
+}
+
+//@ has bar/attr.a_procattribute.html
+//@ hasraw search.index/name/*.js a_procattribute
+#[proc_macro_attribute]
+pub fn a_procattribute(_: TokenStream, _: TokenStream) -> TokenStream {
+    unimplemented!()
+}
+
+//@ has bar/derive.AProcDerive.html
+//@ !has bar/derive.a_procderive.html
+//@ hasraw search.index/name/*.js AProcDerive
+//@ !hasraw search.index/name/*.js a_procderive
+#[proc_macro_derive(AProcDerive)]
+pub fn a_procderive(_: TokenStream) -> TokenStream {
+    unimplemented!()
+}

--- a/tests/run-make/rustdoc-search-load-itemtype/baz.rs
+++ b/tests/run-make/rustdoc-search-load-itemtype/baz.rs
@@ -1,0 +1,3 @@
+//@ has baz/struct.Baz.html
+//@ hasraw search.index/name/*.js Baz
+pub struct Baz;

--- a/tests/run-make/rustdoc-search-load-itemtype/foo.rs
+++ b/tests/run-make/rustdoc-search-load-itemtype/foo.rs
@@ -1,0 +1,119 @@
+#![feature(extern_types, rustc_attrs, rustdoc_internals, trait_alias)]
+#![allow(internal_features)]
+#![no_std]
+
+//@ has foo/keyword.while.html
+//@ hasraw search.index/name/*.js while
+//@ !hasraw search.index/name/*.js w_keyword
+#[doc(keyword = "while")]
+mod w_keyword {}
+
+//@ has foo/primitive.u32.html
+//@ hasraw search.index/name/*.js u32
+//@ !hasraw search.index/name/*.js u_primitive
+#[rustc_doc_primitive = "u32"]
+mod u_primitive {}
+
+//@ has foo/x_mod/index.html
+//@ hasraw search.index/name/*.js x_mod
+pub mod x_mod {}
+
+//@ hasraw foo/index.html y_crate
+//@ hasraw search.index/name/*.js y_crate
+#[doc(no_inline)]
+pub extern crate core as y_crate;
+
+//@ hasraw foo/index.html z_import
+//@ hasraw search.index/name/*.js z_import
+#[doc(no_inline)]
+pub use core::option as z_import;
+
+//@ has foo/struct.AStruct.html
+//@ hasraw search.index/name/*.js AStruct
+pub struct AStruct {
+    //@ hasraw foo/struct.AStruct.html a_structfield
+    //@ hasraw search.index/name/*.js a_structfield
+    pub a_structfield: i32,
+}
+
+//@ has foo/enum.AEnum.html
+//@ hasraw search.index/name/*.js AEnum
+pub enum AEnum {
+    //@ hasraw foo/enum.AEnum.html AVariant
+    //@ hasraw search.index/name/*.js AVariant
+    AVariant,
+}
+
+//@ has foo/fn.a_fn.html
+//@ hasraw search.index/name/*.js a_fn
+pub fn a_fn() {}
+
+//@ has foo/type.AType.html
+//@ hasraw search.index/name/*.js AType
+pub type AType = AStruct;
+
+//@ has foo/static.a_static.html
+//@ hasraw search.index/name/*.js a_static
+pub static a_static: i32 = 1;
+
+//@ has foo/trait.ATrait.html
+//@ hasraw search.index/name/*.js ATrait
+pub trait ATrait {
+    //@ hasraw foo/trait.ATrait.html a_tymethod
+    //@ hasraw search.index/name/*.js a_tymethod
+    fn a_tymethod();
+    //@ hasraw foo/trait.ATrait.html AAssocType
+    //@ hasraw search.index/name/*.js AAssocType
+    type AAssocType;
+    //@ hasraw foo/trait.ATrait.html AAssocConst
+    //@ hasraw search.index/name/*.js AAssocConst
+    const AAssocConst: bool;
+}
+
+// skip ItemType::Impl, since impls are anonymous
+// and have no search entry
+
+impl AStruct {
+    //@ hasraw foo/struct.AStruct.html a_method
+    //@ hasraw search.index/name/*.js a_method
+    pub fn a_method() {}
+}
+
+//@ has foo/macro.a_macro.html
+//@ hasraw search.index/name/*.js a_macro
+#[macro_export]
+macro_rules! a_macro {
+    () => {};
+}
+
+//@ has foo/constant.A_CONSTANT.html
+//@ hasraw search.index/name/*.js A_CONSTANT
+pub const A_CONSTANT: i32 = 1;
+
+//@ has foo/union.AUnion.html
+//@ hasraw search.index/name/*.js AUnion
+pub union AUnion {
+    //@ hasraw foo/union.AUnion.html a_unionfield
+    //@ hasraw search.index/name/*.js a_unionfield
+    pub a_unionfield: i32,
+}
+
+extern "C" {
+    //@ has foo/foreigntype.AForeignType.html
+    //@ hasraw search.index/name/*.js AForeignType
+    pub type AForeignType;
+}
+
+// procattribute and procderive are defined in
+// bar.rs, because they only work with proc_macro
+// crate type.
+
+//@ has foo/traitalias.ATraitAlias.html
+//@ hasraw search.index/name/*.js ATraitAlias
+pub trait ATraitAlias = ATrait;
+
+//@ has foo/attribute.doc.html
+//@ hasraw search.index/name/*.js doc
+//@ !hasraw search.index/name/*.js aa_mod
+#[doc(attribute = "doc")]
+mod aa_mod {}

--- a/tests/run-make/rustdoc-search-load-itemtype/rmake.rs
+++ b/tests/run-make/rustdoc-search-load-itemtype/rmake.rs
@@ -1,0 +1,18 @@
+// Test that rustdoc can deserialize a search index with every itemtype.
+// https://github.com/rust-lang/rust/pull/146117
+
+use std::path::Path;
+
+use run_make_support::{htmldocck, rfs, rustdoc, source_root};
+
+fn main() {
+    let out_dir = Path::new("rustdoc-search-load-itemtype");
+
+    rfs::create_dir_all(&out_dir);
+    rustdoc().out_dir(&out_dir).input("foo.rs").run();
+    rustdoc().out_dir(&out_dir).input("bar.rs").arg("--crate-type=proc-macro").run();
+    rustdoc().out_dir(&out_dir).input("baz.rs").run();
+    htmldocck().arg(out_dir).arg("foo.rs").run();
+    htmldocck().arg(out_dir).arg("bar.rs").run();
+    htmldocck().arg(out_dir).arg("baz.rs").run();
+}

--- a/tests/ui/linking/mixed-allocator-shim.rs
+++ b/tests/ui/linking/mixed-allocator-shim.rs
@@ -1,6 +1,7 @@
 //@ build-pass
 //@ compile-flags: --crate-type staticlib,dylib -Zstaticlib-prefer-dynamic
 //@ no-prefer-dynamic
+//@ needs-crate-type: dylib
 
 // Test that compiling for multiple crate types in a single compilation with
 // mismatching allocator shim requirements doesn't result in the allocator shim

--- a/tests/ui/linking/mixed-allocator-shim.rs
+++ b/tests/ui/linking/mixed-allocator-shim.rs
@@ -1,0 +1,15 @@
+//@ build-pass
+//@ compile-flags: --crate-type staticlib,dylib -Zstaticlib-prefer-dynamic
+//@ no-prefer-dynamic
+
+// Test that compiling for multiple crate types in a single compilation with
+// mismatching allocator shim requirements doesn't result in the allocator shim
+// missing entirely.
+// In this particular test the dylib crate type will statically link libstd and
+// thus need an allocator shim, while the staticlib crate type will dynamically
+// link libstd and thus not need an allocator shim.
+// The -Zstaticlib-prefer-dynamic flag could be avoided by doing it the other
+// way around, but testing that the staticlib correctly has the allocator shim
+// in that case would require a run-make test instead.
+
+pub fn foo() {}


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#143725 (core: add Peekable::next_if_map)
 - rust-lang/rust#145209 (Stabilize `path_add_extension`)
 - rust-lang/rust#145750 (raw_vec.rs: Remove superfluous fn alloc_guard)
 - rust-lang/rust#145962 (Ensure we emit an allocator shim when only some crate types need one)
 - rust-lang/rust#145963 (Add LSX accelerated implementation for source file analysis)
 - rust-lang/rust#146054 (add `#[must_use]` to `array::repeat`)
 - rust-lang/rust#146090 (Derive `PartialEq` for `InvisibleOrigin`)
 - rust-lang/rust#146120 (Correct typo in `rustc_errors` comment)
 - rust-lang/rust#146131 (rustdoc-search: add test case for indexing every item type)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=143725,145209,145750,145962,145963,146054,146090,146120,146131)
<!-- homu-ignore:end -->