### PR TITLE
fix(rustdoc): match rustc `--emit` precedence 

### DIFF
--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -454,15 +454,22 @@ impl Options {
             return None;
         }
 
-        let mut emit = Vec::new();
+        let mut emit = FxIndexMap::<_, EmitType>::default();
         for list in matches.opt_strs("emit") {
             for kind in list.split(',') {
                 match kind.parse() {
-                    Ok(kind) => emit.push(kind),
+                    Ok(kind) => {
+                        // De-duplicate emit types and the last wins.
+                        // Only one instance for each type is allowed
+                        // regardless the actual data it carries.
+                        // This matches rustc's `--emit` behavior.
+                        emit.insert(std::mem::discriminant(&kind), kind);
+                    }
                     Err(()) => dcx.fatal(format!("unrecognized emission type: {kind}")),
                 }
             }
         }
+        let emit = emit.into_values().collect::<Vec<_>>();
 
         let show_coverage = matches.opt_present("show-coverage");
         let output_format_s = matches.opt_str("output-format");

--- a/tests/run-make/rustdoc-dep-info/rmake.rs
+++ b/tests/run-make/rustdoc-dep-info/rmake.rs
@@ -35,7 +35,6 @@ fn main() {
     assert!(path("bla.d").exists());
 
     // The last emit-type wins. The same behavior as rustc.
-    // TODO: this shows the wrong behavior as a MRE, which will be fixed in the next commit
     rustdoc()
         .input("lib.rs")
         .arg("-Zunstable-options")
@@ -43,7 +42,7 @@ fn main() {
         .emit("dep-info=precedence2.d")
         .emit("dep-info=precedence3.d")
         .run();
-    assert!(path("precedence1.d").exists());
+    assert!(!path("precedence1.d").exists());
     assert!(!path("precedence2.d").exists());
-    assert!(!path("precedence3.d").exists());
+    assert!(path("precedence3.d").exists());
 }

--- a/tests/run-make/rustdoc-dep-info/rmake.rs
+++ b/tests/run-make/rustdoc-dep-info/rmake.rs
@@ -33,4 +33,17 @@ fn main() {
     // Now we check that we can provide a file name to the `dep-info` argument.
     rustdoc().input("lib.rs").arg("-Zunstable-options").emit("dep-info=bla.d").run();
     assert!(path("bla.d").exists());
+
+    // The last emit-type wins. The same behavior as rustc.
+    // TODO: this shows the wrong behavior as a MRE, which will be fixed in the next commit
+    rustdoc()
+        .input("lib.rs")
+        .arg("-Zunstable-options")
+        .emit("dep-info=precedence1.d")
+        .emit("dep-info=precedence2.d")
+        .emit("dep-info=precedence3.d")
+        .run();
+    assert!(path("precedence1.d").exists());
+    assert!(!path("precedence2.d").exists());
+    assert!(!path("precedence3.d").exists());
 }


### PR DESCRIPTION
Resolves rust-lang/rust#141664 

This changes rustdoc's `--emit` to allow only one instance of each type, regardless of the actual data that `--emit` carries. This matches rustc's `--emit` behavior.

As of the writing, only `dep-info` emit type carries extra data.

