### PR TITLE
fixes auto-run js checks in tidy

### DIFF
--- a/src/tools/tidy/src/extra_checks/mod.rs
+++ b/src/tools/tidy/src/extra_checks/mod.rs
@@ -720,21 +720,21 @@ impl ExtraCheckArg {
         if !self.auto {
             return true;
         }
-        let ext = match self.lang {
-            ExtraCheckLang::Py => ".py",
-            ExtraCheckLang::Cpp => ".cpp",
-            ExtraCheckLang::Shell => ".sh",
-            ExtraCheckLang::Js => ".js",
+        match self.lang {
             ExtraCheckLang::Spellcheck => {
-                for dir in SPELLCHECK_DIRS {
-                    if Path::new(filepath).starts_with(dir) {
-                        return true;
-                    }
-                }
-                return false;
+                SPELLCHECK_DIRS.iter().any(|dir| Path::new(filepath).starts_with(dir))
             }
-        };
-        filepath.ends_with(ext)
+            lang => {
+                let exts: &[&str] = match lang {
+                    ExtraCheckLang::Py => &[".py"],
+                    ExtraCheckLang::Cpp => &[".cpp"],
+                    ExtraCheckLang::Shell => &[".sh"],
+                    ExtraCheckLang::Js => &[".js", ".ts"],
+                    ExtraCheckLang::Spellcheck => unreachable!(),
+                };
+                exts.iter().any(|ext| filepath.ends_with(ext))
+            }
+        }
     }
 
     fn has_supported_kind(&self) -> bool {

--- a/src/tools/tidy/src/extra_checks/mod.rs
+++ b/src/tools/tidy/src/extra_checks/mod.rs
@@ -720,21 +720,19 @@ impl ExtraCheckArg {
         if !self.auto {
             return true;
         }
-        match self.lang {
+        let exts: &[&str] = match self.lang {
+            ExtraCheckLang::Py => &[".py"],
+            ExtraCheckLang::Cpp => &[".cpp"],
+            ExtraCheckLang::Shell => &[".sh"],
+            ExtraCheckLang::Js => &[".js", ".ts"],
             ExtraCheckLang::Spellcheck => {
-                SPELLCHECK_DIRS.iter().any(|dir| Path::new(filepath).starts_with(dir))
+                if SPELLCHECK_DIRS.iter().any(|dir| Path::new(filepath).starts_with(dir)) {
+                    return true;
+                }
+                &[]
             }
-            lang => {
-                let exts: &[&str] = match lang {
-                    ExtraCheckLang::Py => &[".py"],
-                    ExtraCheckLang::Cpp => &[".cpp"],
-                    ExtraCheckLang::Shell => &[".sh"],
-                    ExtraCheckLang::Js => &[".js", ".ts"],
-                    ExtraCheckLang::Spellcheck => unreachable!(),
-                };
-                exts.iter().any(|ext| filepath.ends_with(ext))
-            }
-        }
+        };
+        exts.iter().any(|ext| filepath.ends_with(ext))
     }
 
     fn has_supported_kind(&self) -> bool {


### PR DESCRIPTION
Modified is_non_auto_or_matches function in src/tools/tidy/src/extra_checks/mod.rs so that .ts extension is considered.
Tested locally with
`./x.py test tidy --extra-checks=auto:js`
