### PR TITLE
CI: rfl: move job forward to Linux v6.17-rc3 plus 2 commits

### DIFF
--- a/src/ci/docker/scripts/rfl-build.sh
+++ b/src/ci/docker/scripts/rfl-build.sh
@@ -3,7 +3,8 @@
 set -euo pipefail
 
 # https://github.com/rust-lang/rust/pull/144443
-LINUX_VERSION=7770d51bce622b13195b2d3c85407282fc9c27e5
+# https://github.com/rust-lang/rust/pull/145928
+LINUX_VERSION=8851e27d2cb947ea8bbbe8e812068f7bf5cbd00b
 
 # Build rustc, rustdoc, cargo, clippy-driver and rustfmt
 ../x.py build --stage 2 library rustdoc clippy rustfmt


### PR DESCRIPTION
This upgrades the Rust CI from v6.16-rc1 plus a temporary commit for the >= 1.91 target spec [1] to v6.17-rc3 with two commits pending to be merged upstream -- one for the same target spec format change [1] and another for the `file_as_c_str` change [2].

Link: https://github.com/rust-lang/rust/pull/144443 [1]
Link: https://github.com/rust-lang/rust/pull/145928 [2]

r? @lqd @Kobzol
try-job: x86_64-rust-for-linux
@rustbot label A-rust-for-linux
@bors try