### PR TITLE
fix: offline rustdoc html missing favicon

### DIFF
--- a/src/bootstrap/src/core/build_steps/doc.rs
+++ b/src/bootstrap/src/core/build_steps/doc.rs
@@ -575,6 +575,31 @@ impl Step for SharedAssets {
             FileType::Regular,
         );
 
+        builder.copy_link(
+            &builder
+                .src
+                .join("src")
+                .join("librustdoc")
+                .join("html")
+                .join("static")
+                .join("images")
+                .join("favicon.svg"),
+            &out.join("favicon.svg"),
+            FileType::Regular,
+        );
+        builder.copy_link(
+            &builder
+                .src
+                .join("src")
+                .join("librustdoc")
+                .join("html")
+                .join("static")
+                .join("images")
+                .join("favicon-32x32.png"),
+            &out.join("favicon-32x32.png"),
+            FileType::Regular,
+        );
+
         SharedAssetsPaths { version_info }
     }
 }

--- a/src/doc/favicon.inc
+++ b/src/doc/favicon.inc
@@ -1,1 +1,2 @@
-<link rel="icon" href="https://www.rust-lang.org/favicon.ico">
+<link rel="alternate icon" type="image/png" href="favicon-32x32.png">
+<link rel="icon" type="image/svg+xml" href="favicon.svg">

--- a/src/doc/redirect.inc
+++ b/src/doc/redirect.inc
@@ -1,2 +1,3 @@
 <meta name="robots" content="noindex,follow">
-<link rel="icon" href="https://www.rust-lang.org/favicon.ico">
+<link rel="alternate icon" type="image/png" href="../favicon-32x32.png">
+<link rel="icon" type="image/svg+xml" href="../favicon.svg">


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

As discussed in the rust-lang/rust#146149 the doc was missing the favicon icon when build locally and viewed on a browser. I changed the relative path and also now we explicitly copy both SVG and PNG. 

<img width="1132" height="425" alt="Screenshot 2025-09-03 at 11 57 46 PM" src="https://github.com/user-attachments/assets/062cbb08-04ec-4d88-a43a-710fb6190f82" />
