### PR TITLE
rustdoc: even spacing in crate brand heading

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -848,26 +848,35 @@ ul.block, .block li, .block ul {
 	z-index: 1;
 }
 
+.sidebar {
+	/* Align the sidebar crate link with the search bar, which have different
+		font sizes. They should be the same height, so that the crate lockup and the
+		main header are also the same height.
+
+		|        | font-size | line-height | total line-height | padding/margin-y |     total    |
+		|:-------|----------:|------------:|------------------:|-----------------:|-------------:|
+		| crate  |  1.375rem |        1.25 |           1.72rem |                x |   4x+1.72rem |
+		| search |      1rem |        1.15 |           1.15rem |              8px | 1.15rem+16px |
+
+		4x + 1.72rem = 1.15rem + 16px
+		4x = 1.15rem + 16px - 1.72rem
+		4x = 16px - 0.57rem
+		x = ( 16px - 0.57rem ) / 4
+	*/
+	--sidebar-crate-margin-padding-y: calc( ( 16px - 0.57rem ) / 4 );
+}
+
 .sidebar-crate h2 a {
 	display: block;
 	/* extend click target to far edge of screen (mile wide bar) */
 	border-left: solid var(--sidebar-elems-left-padding) transparent;
 	background-clip: border-box;
-	margin: 0 calc(-24px + 0.25rem) 0 calc(-0.2rem - var(--sidebar-elems-left-padding));
-	/* Align the sidebar crate link with the search bar, which have different
-		font sizes.
-
-		|        | font-size | line-height | total line-height | padding-y |     total    |
-		|:-------|----------:|------------:|------------------:|----------:|-------------:|
-		| crate  |  1.375rem |        1.25 |           1.72rem |         x |   2x+1.72rem |
-		| search |      1rem |        1.15 |           1.15rem |       8px | 1.15rem+16px |
-
-		2x + 1.72rem = 1.15rem + 16px
-		2x = 1.15rem + 16px - 1.72rem
-		2x = 16px - 0.57rem
-		x = ( 16px - 0.57rem ) / 2
-	*/
-	padding: calc( ( 16px - 0.57rem ) / 2 ) 0.25rem;
+	margin:
+		var(--sidebar-crate-margin-padding-y)
+		calc(-24px + 0.25rem)
+		var(--sidebar-crate-margin-padding-y)
+		calc(-0.2rem - var(--sidebar-elems-left-padding));
+	padding: var(--sidebar-crate-margin-padding-y) 0.25rem;
 	padding-left: 0.2rem;
 }
 
@@ -876,10 +885,25 @@ ul.block, .block li, .block ul {
 	font-weight: normal;
 	font-size: 1rem;
 	overflow-wrap: break-word;
+	margin-top: calc(-1 * var(--sidebar-crate-margin-padding-y));
+	margin-bottom: var(--sidebar-crate-margin-padding-y);
 }
 
 .sidebar-crate + .version {
-	margin-top: -1rem;
+	/* make the git commit the same height as the Since · Source line,
+		even though these also have different font sizes
+
+		|        | font-size | line-height | total line-height | padding-y |     total     |
+		|:-------|----------:|------------:|------------------:|----------:|--------------:|
+		| Commit |  0.875rem |        1.25 |        1.09375rem |         x | 1.09375rem+2x |
+		| Since  |      1rem |        1.25 |        1.25rem    |   1.25rem |       1.25rem |
+
+		1.09375+2x = 1.25
+		2x = 0.15625
+		x = 0.078125
+	*/
+	padding-top: 0.078125rem;
+	margin-top: calc(-1 * var(--sidebar-crate-margin-padding-y) - 1rem);
 	margin-bottom: 1rem;
 }
 


### PR DESCRIPTION
Since the search bar and the crate name don't need aligned any more, the layout of the version can be a bit more natural-looking.

This PR is a bit of a follow-up for https://github.com/rust-lang/rust/pull/115948 and https://github.com/rust-lang/rust/pull/117906

Before:

<img width="2410" height="182" alt="image" src="https://github.com/user-attachments/assets/0243be94-b091-4204-9c24-94089da4a096" />

<img width="2410" height="182" alt="image" src="https://github.com/user-attachments/assets/0df8bff5-84f1-48ae-b126-7f12f746d9a9" />

<img width="2410" height="182" alt="image" src="https://github.com/user-attachments/assets/03b59fd0-9233-48ad-b74b-067542e95ab1" />

After:

<img width="2410" height="182" alt="image" src="https://github.com/user-attachments/assets/010b3296-6a1f-4943-b147-0f9dcb02f2b3" />

<img width="2410" height="182" alt="image" src="https://github.com/user-attachments/assets/949f6a7d-edbc-4663-88cd-094499b73ef7" />

<img width="2410" height="182" alt="image" src="https://github.com/user-attachments/assets/67997ea2-6ccb-43a8-9b1c-90bc24242cfe" />

