### PR TITLE
Don't require next-solver `ProbeRef` to be `Copy`

### DIFF
--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -738,8 +738,8 @@ impl<'tcx> Interner for TyCtxt<'tcx> {
         )
     }
 
-    type ProbeRef = &'tcx inspect::Probe<TyCtxt<'tcx>>;
-    fn mk_probe_ref(self, probe: inspect::Probe<Self>) -> &'tcx inspect::Probe<TyCtxt<'tcx>> {
+    type Probe = &'tcx inspect::Probe<TyCtxt<'tcx>>;
+    fn mk_probe(self, probe: inspect::Probe<Self>) -> &'tcx inspect::Probe<TyCtxt<'tcx>> {
         self.arena.alloc(probe)
     }
     fn evaluate_root_goal_for_proof_tree_raw(

--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
@@ -1275,7 +1275,7 @@ pub fn evaluate_root_goal_for_proof_tree_raw_provider<
 >(
     cx: I,
     canonical_goal: CanonicalInput<I>,
-) -> (QueryResult<I>, I::ProbeRef) {
+) -> (QueryResult<I>, I::Probe) {
     let mut inspect = inspect::ProofTreeBuilder::new();
     let canonical_result = SearchGraph::<D>::evaluate_root_goal_for_proof_tree(
         cx,
@@ -1284,7 +1284,7 @@ pub fn evaluate_root_goal_for_proof_tree_raw_provider<
         &mut inspect,
     );
     let final_revision = inspect.unwrap();
-    (canonical_result, cx.mk_probe_ref(final_revision))
+    (canonical_result, cx.mk_probe(final_revision))
 }
 
 /// Evaluate a goal to build a proof tree.

--- a/compiler/rustc_type_ir/src/interner.rs
+++ b/compiler/rustc_type_ir/src/interner.rs
@@ -1,3 +1,4 @@
+use std::borrow::Borrow;
 use std::fmt::Debug;
 use std::hash::Hash;
 use std::ops::Deref;
@@ -383,12 +384,12 @@ pub trait Interner:
         defining_anchor: Self::LocalDefId,
     ) -> Self::LocalDefIds;
 
-    type ProbeRef: Copy + Debug + Hash + Eq + Deref<Target = inspect::Probe<Self>>;
-    fn mk_probe_ref(self, probe: inspect::Probe<Self>) -> Self::ProbeRef;
+    type Probe: Debug + Hash + Eq + Borrow<inspect::Probe<Self>>;
+    fn mk_probe(self, probe: inspect::Probe<Self>) -> Self::Probe;
     fn evaluate_root_goal_for_proof_tree_raw(
         self,
         canonical_goal: CanonicalInput<Self>,
-    ) -> (QueryResult<Self>, Self::ProbeRef);
+    ) -> (QueryResult<Self>, Self::Probe);
 }
 
 /// Imagine you have a function `F: FnOnce(&[T]) -> R`, plus an iterator `iter`

--- a/compiler/rustc_type_ir/src/solve/inspect.rs
+++ b/compiler/rustc_type_ir/src/solve/inspect.rs
@@ -49,7 +49,7 @@ pub type CanonicalState<I, T> = Canonical<I, State<I, T>>;
 pub struct GoalEvaluation<I: Interner> {
     pub uncanonicalized_goal: Goal<I, I::Predicate>,
     pub orig_values: Vec<I::GenericArg>,
-    pub final_revision: I::ProbeRef,
+    pub final_revision: I::Probe,
     pub result: QueryResult<I>,
 }
 


### PR DESCRIPTION
rust-analyzer would like to use a non-interned `Probe` there.

Also rename it to `Probe` for this reason.

We can make it `Copy` (although then `Probe` will need to be `Clone` for rust-analyzer) but it seems just non-needed.

r? types

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
