### PR TITLE
In the rustc_llvm build script, don't consider arm64* to be 32-bit

### DIFF
--- a/compiler/rustc_llvm/build.rs
+++ b/compiler/rustc_llvm/build.rs
@@ -254,7 +254,10 @@ fn main() {
         println!("cargo:rustc-link-lib=kstat");
     }
 
-    if (target.starts_with("arm") && !target.contains("freebsd") && !target.contains("ohos"))
+    if (target.starts_with("arm")
+        && !target.starts_with("arm64")
+        && !target.contains("freebsd")
+        && !target.contains("ohos"))
         || target.starts_with("mips-")
         || target.starts_with("mipsel-")
         || target.starts_with("powerpc-")


### PR DESCRIPTION
The build script for `rustc_llvm` needs to detect 32-bit targets so that it links against `libatomics`. To do this, it matches the target architecture against `arm`, unfortunately incorrectly matches Arm64EC, Arm64E, etc.

This change adds a check that the target arch doesn't match `arm64`.