### PR TITLE
Update tracing and fix binary regression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5518,11 +5518,10 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tracing"
-version = "0.1.37"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
- "cfg-if",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",

--- a/compiler/rustc_log/Cargo.toml
+++ b/compiler/rustc_log/Cargo.toml
@@ -5,13 +5,12 @@ edition = "2024"
 
 [dependencies]
 # tidy-alphabetical-start
-# tracing > 0.1.37 have huge binary size / instructions regression
-tracing = "=0.1.37"
+tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.3", default-features = false, features = ["fmt", "env-filter", "smallvec", "parking_lot", "ansi"] }
 tracing-tree = "0.3.1"
 # tidy-alphabetical-end
 
 [features]
 # tidy-alphabetical-start
-max_level_info = ['tracing/max_level_info']
+max_level_info = ['tracing/max_level_info', 'tracing/release_max_level_info']
 # tidy-alphabetical-end


### PR DESCRIPTION
Previous attempts (rust-lang/rust#127316, rust-lang/rust#134770) saw binary size regressions, this was root caused to <https://github.com/tokio-rs/tracing/pull/2553> which changed the behavior of the `max_level_info` feature flag to match the docs (i.e., that flag only applies for debug builds and `release_max_level_info` applies for release builds).

This change bumps the `tracing` version and sets both `max_level_info` and `release_max_level_info` when to match rustc's own `max_level_info`.