### PR TITLE
fix path str eq

### DIFF
--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -2107,7 +2107,7 @@ impl PartialEq for PathBuf {
 impl cmp::PartialEq<str> for PathBuf {
     #[inline]
     fn eq(&self, other: &str) -> bool {
-        &*self == other
+        Path::eq(self, other)
     }
 }
 

--- a/library/std/tests/path.rs
+++ b/library/std/tests/path.rs
@@ -2526,3 +2526,9 @@ fn normalize_lexically() {
         check_err(r"\\?\UNC\server\share\a\..\..");
     }
 }
+
+#[test]
+/// See issue#146183
+fn compare_path_to_str() {
+    assert!(&PathBuf::from("x") == "x");
+}


### PR DESCRIPTION
fixes rust-lang/rust#146183
where the impl for partialeq<str> for pathbuf resulted in infinite recursion