### PR TITLE
triagebot: fix rustc_allow_const_fn_unstable matcher

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1313,7 +1313,7 @@ message = """
 and explores the possible non-determinism of the intrinsic.
 """
 cc = ["@rust-lang/miri"]
-[mentions."#[rustc_allow_const_fn_unstable]"]
+[mentions."#[rustc_allow_const_fn_unstable"]
 type = "content"
 message = """
 `#[rustc_allow_const_fn_unstable]` needs careful audit to avoid accidentally exposing unstable


### PR DESCRIPTION
The attribute is used like `#[rustc_allow_const_fn_unstable(const_precise_live_drops)]` so we can't have the final `]` here...

r? @Urgau 