### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/bootstrap.example.toml
+++ b/bootstrap.example.toml
@@ -856,6 +856,9 @@
 # as libstd features, this option can also be used to configure features such as optimize_for_size.
 #rust.std-features = ["panic_unwind"]
 
+# Trigger a `DebugBreak` after an internal compiler error during bootstrap on Windows
+#rust.break-on-ice = true
+
 # =============================================================================
 # Distribution options
 #

--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -2107,7 +2107,7 @@ impl PartialEq for PathBuf {
 impl cmp::PartialEq<str> for PathBuf {
     #[inline]
     fn eq(&self, other: &str) -> bool {
-        &*self == other
+        Path::eq(self, other)
     }
 }
 

--- a/library/std/tests/path.rs
+++ b/library/std/tests/path.rs
@@ -2526,3 +2526,9 @@ fn normalize_lexically() {
         check_err(r"\\?\UNC\server\share\a\..\..");
     }
 }
+
+#[test]
+/// See issue#146183
+fn compare_path_to_str() {
+    assert!(&PathBuf::from("x") == "x");
+}

--- a/src/bootstrap/src/core/builder/cargo.rs
+++ b/src/bootstrap/src/core/builder/cargo.rs
@@ -877,8 +877,11 @@ impl Builder<'_> {
             .env("RUSTC_LIBDIR", libdir)
             .env("RUSTDOC", self.bootstrap_out.join("rustdoc"))
             .env("RUSTDOC_REAL", rustdoc_path)
-            .env("RUSTC_ERROR_METADATA_DST", self.extended_error_dir())
-            .env("RUSTC_BREAK_ON_ICE", "1");
+            .env("RUSTC_ERROR_METADATA_DST", self.extended_error_dir());
+
+        if self.config.rust_break_on_ice {
+            cargo.env("RUSTC_BREAK_ON_ICE", "1");
+        }
 
         // Set RUSTC_WRAPPER to the bootstrap shim, which switches between beta and in-tree
         // sysroot depending on whether we're building build scripts.

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -221,6 +221,7 @@ pub struct Config {
     pub rust_lto: RustcLto,
     pub rust_validate_mir_opts: Option<u32>,
     pub rust_std_features: BTreeSet<String>,
+    pub rust_break_on_ice: bool,
     pub llvm_profile_use: Option<String>,
     pub llvm_profile_generate: bool,
     pub llvm_libunwind_default: Option<LlvmLibunwind>,
@@ -550,6 +551,7 @@ impl Config {
             strip: rust_strip,
             lld_mode: rust_lld_mode,
             std_features: rust_std_features,
+            break_on_ice: rust_break_on_ice,
         } = toml.rust.unwrap_or_default();
 
         let Llvm {
@@ -1269,6 +1271,7 @@ impl Config {
             reproducible_artifacts: flags_reproducible_artifact,
             reuse: build_reuse.map(PathBuf::from),
             rust_analyzer_info,
+            rust_break_on_ice: rust_break_on_ice.unwrap_or(true),
             rust_codegen_backends: rust_codegen_backends
                 .map(|backends| parse_codegen_backends(backends, "rust"))
                 .unwrap_or(vec![CodegenBackendKind::Llvm]),

--- a/src/bootstrap/src/core/config/toml/rust.rs
+++ b/src/bootstrap/src/core/config/toml/rust.rs
@@ -65,6 +65,7 @@ define_config! {
         lto: Option<String> = "lto",
         validate_mir_opts: Option<u32> = "validate-mir-opts",
         std_features: Option<BTreeSet<String>> = "std-features",
+        break_on_ice: Option<bool> = "break-on-ice",
     }
 }
 
@@ -355,6 +356,7 @@ pub fn check_incompatible_options_for_ci_rustc(
         download_rustc: _,
         validate_mir_opts: _,
         frame_pointers: _,
+        break_on_ice: _,
     } = ci_rust_config;
 
     // There are two kinds of checks for CI rustc incompatible options:

--- a/src/bootstrap/src/utils/change_tracker.rs
+++ b/src/bootstrap/src/utils/change_tracker.rs
@@ -536,4 +536,9 @@ pub const CONFIG_CHANGE_HISTORY: &[ChangeInfo] = &[
         severity: ChangeSeverity::Warning,
         summary: "It is no longer possible to `x test` with stage 0, except for running compiletest and opting into `build.compiletest-allow-stage0`.",
     },
+    ChangeInfo {
+        change_id: 145976,
+        severity: ChangeSeverity::Info,
+        summary: "Added a new option `rust.break-on-ice` to control if internal compiler errors cause a debug break on Windows.",
+    },
 ];

--- a/src/tools/tidy/src/extra_checks/mod.rs
+++ b/src/tools/tidy/src/extra_checks/mod.rs
@@ -720,21 +720,21 @@ impl ExtraCheckArg {
         if !self.auto {
             return true;
         }
-        let ext = match self.lang {
-            ExtraCheckLang::Py => ".py",
-            ExtraCheckLang::Cpp => ".cpp",
-            ExtraCheckLang::Shell => ".sh",
-            ExtraCheckLang::Js => ".js",
+        match self.lang {
             ExtraCheckLang::Spellcheck => {
-                for dir in SPELLCHECK_DIRS {
-                    if Path::new(filepath).starts_with(dir) {
-                        return true;
-                    }
-                }
-                return false;
+                SPELLCHECK_DIRS.iter().any(|dir| Path::new(filepath).starts_with(dir))
             }
-        };
-        filepath.ends_with(ext)
+            lang => {
+                let exts: &[&str] = match lang {
+                    ExtraCheckLang::Py => &[".py"],
+                    ExtraCheckLang::Cpp => &[".cpp"],
+                    ExtraCheckLang::Shell => &[".sh"],
+                    ExtraCheckLang::Js => &[".js", ".ts"],
+                    ExtraCheckLang::Spellcheck => unreachable!(),
+                };
+                exts.iter().any(|ext| filepath.ends_with(ext))
+            }
+        }
     }
 
     fn has_supported_kind(&self) -> bool {

--- a/src/tools/tidy/src/extra_checks/mod.rs
+++ b/src/tools/tidy/src/extra_checks/mod.rs
@@ -720,21 +720,19 @@ impl ExtraCheckArg {
         if !self.auto {
             return true;
         }
-        match self.lang {
+        let exts: &[&str] = match self.lang {
+            ExtraCheckLang::Py => &[".py"],
+            ExtraCheckLang::Cpp => &[".cpp"],
+            ExtraCheckLang::Shell => &[".sh"],
+            ExtraCheckLang::Js => &[".js", ".ts"],
             ExtraCheckLang::Spellcheck => {
-                SPELLCHECK_DIRS.iter().any(|dir| Path::new(filepath).starts_with(dir))
+                if SPELLCHECK_DIRS.iter().any(|dir| Path::new(filepath).starts_with(dir)) {
+                    return true;
+                }
+                &[]
             }
-            lang => {
-                let exts: &[&str] = match lang {
-                    ExtraCheckLang::Py => &[".py"],
-                    ExtraCheckLang::Cpp => &[".cpp"],
-                    ExtraCheckLang::Shell => &[".sh"],
-                    ExtraCheckLang::Js => &[".js", ".ts"],
-                    ExtraCheckLang::Spellcheck => unreachable!(),
-                };
-                exts.iter().any(|ext| filepath.ends_with(ext))
-            }
-        }
+        };
+        exts.iter().any(|ext| filepath.ends_with(ext))
     }
 
     fn has_supported_kind(&self) -> bool {

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1313,7 +1313,7 @@ message = """
 and explores the possible non-determinism of the intrinsic.
 """
 cc = ["@rust-lang/miri"]
-[mentions."#[rustc_allow_const_fn_unstable]"]
+[mentions."#[rustc_allow_const_fn_unstable"]
 type = "content"
 message = """
 `#[rustc_allow_const_fn_unstable]` needs careful audit to avoid accidentally exposing unstable


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#145976 (Add bootstrap.toml option to control debug breaking on ICEs on windows)
 - rust-lang/rust#146151 (fixes auto-run js checks in tidy)
 - rust-lang/rust#146194 (fix path str eq)
 - rust-lang/rust#146197 (triagebot: fix rustc_allow_const_fn_unstable matcher)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=145976,146151,146194,146197)
<!-- homu-ignore:end -->