### PR TITLE
identity uses are ok, even if there are no defining uses

### DIFF
--- a/tests/ui/impl-trait/non-defining-uses/ice-issue-146191.current.stderr
+++ b/tests/ui/impl-trait/non-defining-uses/ice-issue-146191.current.stderr
@@ -1,0 +1,29 @@
+error[E0277]: the trait bound `(): ReturnsSend` is not satisfied
+  --> $DIR/ice-issue-146191.rs:6:52
+   |
+LL | fn create_complex_future() -> impl Future<Output = impl ReturnsSend> {
+   |                                                    ^^^^^^^^^^^^^^^^ the trait `ReturnsSend` is not implemented for `()`
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/ice-issue-146191.rs:14:1
+   |
+LL | trait ReturnsSend {}
+   | ^^^^^^^^^^^^^^^^^
+note: required by a bound in an opaque type
+  --> $DIR/ice-issue-146191.rs:6:57
+   |
+LL | fn create_complex_future() -> impl Future<Output = impl ReturnsSend> {
+   |                                                         ^^^^^^^^^^^
+
+error[E0733]: recursion in an async block requires boxing
+  --> $DIR/ice-issue-146191.rs:8:5
+   |
+LL |     async { create_complex_future().await }
+   |     ^^^^^   ----------------------------- recursive call here
+   |
+   = note: a recursive `async fn` call must introduce indirection such as `Box::pin` to avoid an infinitely sized future
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0277, E0733.
+For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/impl-trait/non-defining-uses/ice-issue-146191.next.stderr
+++ b/tests/ui/impl-trait/non-defining-uses/ice-issue-146191.next.stderr
@@ -1,0 +1,17 @@
+error[E0282]: type annotations needed
+  --> $DIR/ice-issue-146191.rs:8:5
+   |
+LL |     async { create_complex_future().await }
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type
+
+error[E0282]: type annotations needed
+  --> $DIR/ice-issue-146191.rs:8:5
+   |
+LL |     async { create_complex_future().await }
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0282`.

--- a/tests/ui/impl-trait/non-defining-uses/ice-issue-146191.rs
+++ b/tests/ui/impl-trait/non-defining-uses/ice-issue-146191.rs
@@ -1,0 +1,15 @@
+//@ edition: 2024
+//@ revisions: current next
+//@[next] compile-flags: -Znext-solver
+//@ ignore-compare-mode-next-solver (explicit revisions)
+
+fn create_complex_future() -> impl Future<Output = impl ReturnsSend> {
+    //[current]~^ ERROR the trait bound `(): ReturnsSend` is not satisfied
+    async { create_complex_future().await }
+    //[current]~^ ERROR recursion in an async block requires
+    //[next]~^^ ERROR type annotations needed
+    //[next]~| ERROR type annotations needed
+}
+
+trait ReturnsSend {}
+fn main() {}


### PR DESCRIPTION
fix rust-lang/rust#146191

I've tried moving the "is this an identity use" check to `fn clone_and_resolve_opaque_types` and this would allow the following code to compile as it now ignores `Opaque<'!a> = Opaque<'!a>` while they previously resulted in errors https://github.com/rust-lang/rust/blob/71289c378d0a406a4f537fe4001282d19362931f/tests/ui/type-alias-impl-trait/hkl_forbidden.rs#L42-L46

The closure signature gets inferred to `for<'a> fn(&'a ()) -> Inner<'a>`. The closure then has a defining use `Inner<'a_latbound> = &'a_latebound ()` while the parent function has a non-defining `Inner<'!a> = Inner<'!a>`. By eagerly discarding identity uses we don't error on the non-defining use in the parent.

r? @BoxyUwU 