### PR TITLE
Make ByteStr/ByteString a more-opaque wrapper like OsStr/OsString

### DIFF
--- a/library/alloc/src/byte_str.rs
+++ b/library/alloc/src/byte_str.rs
@@ -17,6 +17,7 @@ use core::{fmt, hash};
 
 use crate::borrow::{Cow, ToOwned};
 use crate::boxed::Box;
+use crate::collections::TryReserveError;
 #[cfg(not(no_rc))]
 use crate::rc::Rc;
 use crate::string::String;
@@ -44,22 +45,225 @@ use crate::vec::Vec;
 #[repr(transparent)]
 #[derive(Clone, Default)]
 #[doc(alias = "BString")]
-pub struct ByteString(pub Vec<u8>);
+pub struct ByteString(pub(crate) Vec<u8>);
 
 impl ByteString {
+    /// Creates an empty `ByteString`.
+    #[unstable(feature = "byte_str", issue = "134915")]
     #[inline]
-    pub(crate) fn as_bytes(&self) -> &[u8] {
-        &self.0
+    #[rustc_const_unstable(feature = "byte_str", issue = "134915")]
+    pub const fn new() -> ByteString {
+        ByteString(Vec::new())
     }
 
+    /// Converts to a [`ByteStr`] slice.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(byte_str)]
+    /// use std::byte_str::ByteStr;
+    ///
+    /// let byte_str = ByteStr::new("foo");
+    /// let byte_string = byte_str.to_byte_string();
+    /// assert_eq!(byte_string.as_byte_str(), byte_str);
+    /// ```
+    #[unstable(feature = "byte_str", issue = "134915")]
     #[inline]
-    pub(crate) fn as_bytestr(&self) -> &ByteStr {
+    pub fn as_byte_str(&self) -> &ByteStr {
         ByteStr::new(&self.0)
     }
 
+    /// Converts to a mutable [`ByteStr`] slice.
+    #[unstable(feature = "byte_str", issue = "134915")]
     #[inline]
-    pub(crate) fn as_mut_bytestr(&mut self) -> &mut ByteStr {
-        ByteStr::from_bytes_mut(&mut self.0)
+    pub fn as_mut_byte_str(&mut self) -> &mut ByteStr {
+        ByteStr::new_mut(&mut self.0)
+    }
+
+    /// Returns a reference to the underlying vector for this `ByteString`.
+    #[unstable(feature = "byte_str", issue = "134915")]
+    #[inline]
+    pub fn as_vec(&self) -> &Vec<u8> {
+        &self.0
+    }
+
+    /// Returns a mutable reference to the underlying vector for this `ByteString`.
+    #[unstable(feature = "byte_str", issue = "134915")]
+    #[inline]
+    pub fn as_mut_vec(&mut self) -> &mut Vec<u8> {
+        &mut self.0
+    }
+
+    /// Converts to a vector of bytes.
+    #[unstable(feature = "byte_str", issue = "134915")]
+    #[inline]
+    pub fn into_bytes(self) -> Vec<u8> {
+        self.0
+    }
+
+    /// Converts to a boxed slice of bytes.
+    #[unstable(feature = "byte_str", issue = "134915")]
+    #[inline]
+    pub fn into_boxed_bytes(self) -> Box<[u8]> {
+        self.into_bytes().into_boxed_slice()
+    }
+
+    /// Converts to a boxed byte string.
+    #[unstable(feature = "byte_str", issue = "134915")]
+    #[inline]
+    pub fn into_boxed_byte_str(self) -> Box<ByteStr> {
+        self.into_bytes().into_boxed_slice().into_boxed_byte_str()
+    }
+
+    /// Converts a `ByteString` into a [`String`] if it contains valid Unicode data.
+    ///
+    /// On failure, ownership of the original `ByteString` is returned.
+    #[unstable(feature = "byte_str", issue = "134915")]
+    #[inline]
+    pub fn into_string(self) -> Result<String, ByteString> {
+        String::from_utf8(self.0).map_err(|e| ByteString(e.into_bytes()))
+    }
+
+    /// Extends the byte string with the given <code>&[ByteStr]</code> slice.
+    #[unstable(feature = "byte_str", issue = "134915")]
+    #[inline]
+    pub fn push<S: AsRef<ByteStr>>(&mut self, s: S) {
+        self.0.extend_from_slice(s.as_ref().as_bytes())
+    }
+
+    /// Pushes a single byte onto the byte string.
+    #[unstable(feature = "byte_str", issue = "134915")]
+    #[inline]
+    pub fn push_byte(&mut self, b: u8) {
+        self.0.push(b)
+    }
+
+    /// Creates a new [`ByteString`] with at least the given capacity.
+    #[unstable(feature = "byte_str", issue = "134915")]
+    #[inline]
+    pub fn with_capacity(capacity: usize) -> ByteString {
+        ByteString(Vec::with_capacity(capacity))
+    }
+
+    /// Truncates the byte string to zero length.
+    #[unstable(feature = "byte_str", issue = "134915")]
+    #[inline]
+    pub fn clear(&mut self) {
+        self.0.clear()
+    }
+
+    /// Returns the number of bytes that can be pushed to this `ByteString` without reallocating.
+    #[unstable(feature = "byte_str", issue = "134915")]
+    #[inline]
+    pub fn capacity(&self) -> usize {
+        self.0.capacity()
+    }
+
+    /// Reserves capacity for at least `additional` more capacity to be inserted in the given
+    /// `ByteString`. Does nothing if the capacity is already sufficient.
+    ///
+    /// The collection may reserve more space to speculatively avoid frequent reallocations.
+    #[unstable(feature = "byte_str", issue = "134915")]
+    #[inline]
+    pub fn reserve(&mut self, additional: usize) {
+        self.0.reserve(additional)
+    }
+
+    /// Tries to reserve capacity for at least `additional` more bytes
+    /// in the given `ByteString`. The string may reserve more space to speculatively avoid
+    /// frequent reallocations. After calling `try_reserve`, capacity will be
+    /// greater than or equal to `self.len() + additional` if it returns `Ok(())`.
+    /// Does nothing if capacity is already sufficient. This method preserves
+    /// the contents even if an error occurs.
+    ///
+    /// # Errors
+    ///
+    /// If the capacity overflows, or the allocator reports a failure, then an error
+    /// is returned.
+    #[unstable(feature = "byte_str", issue = "134915")]
+    #[inline]
+    pub fn try_reserve(&mut self, additional: usize) -> Result<(), TryReserveError> {
+        self.0.try_reserve(additional)
+    }
+
+    /// Reserves the minimum capacity for at least `additional` more bytes to
+    /// be inserted in the given `ByteString`. Does nothing if the capacity is
+    /// already sufficient.
+    ///
+    /// Note that the allocator may give the collection more space than it
+    /// requests. Therefore, capacity can not be relied upon to be precisely
+    /// minimal. Prefer [`reserve`] if future insertions are expected.
+    ///
+    /// [`reserve`]: ByteString::reserve
+    #[unstable(feature = "byte_str", issue = "134915")]
+    #[inline]
+    pub fn reserve_exact(&mut self, additional: usize) {
+        self.0.reserve_exact(additional)
+    }
+
+    /// Tries to reserve the minimum capacity for at least `additional`
+    /// more bytes in the given `ByteString`. After calling
+    /// `try_reserve_exact`, capacity will be greater than or equal to
+    /// `self.len() + additional` if it returns `Ok(())`.
+    /// Does nothing if the capacity is already sufficient.
+    ///
+    /// Note that the allocator may give the `ByteString` more space than it
+    /// requests. Therefore, capacity can not be relied upon to be precisely
+    /// minimal. Prefer [`try_reserve`] if future insertions are expected.
+    ///
+    /// [`try_reserve`]: ByteString::try_reserve
+    ///
+    /// # Errors
+    ///
+    /// If the capacity overflows, or the allocator reports a failure, then an error
+    /// is returned.
+    #[unstable(feature = "byte_str", issue = "134915")]
+    #[inline]
+    pub fn try_reserve_exact(&mut self, additional: usize) -> Result<(), TryReserveError> {
+        self.0.try_reserve_exact(additional)
+    }
+
+    /// Shrinks the capacity of the `ByteString` to match its length.
+    #[unstable(feature = "byte_str", issue = "134915")]
+    #[inline]
+    pub fn shrink_to_fit(&mut self) {
+        self.0.shrink_to_fit()
+    }
+
+    /// Shrinks the capacity of the [`ByteString`] with a lower bound.
+    ///
+    /// The capacity will remain at least as large as both the length and the supplied value.
+    ///
+    /// If the current capacity is less than the lower limit, this is a no-op.
+    #[unstable(feature = "byte_str", issue = "134915")]
+    #[inline]
+    pub fn shrink_to(&mut self, min_capacity: usize) {
+        self.0.shrink_to(min_capacity)
+    }
+
+    /// Consumes and leaks the `ByteString`, returning a mutable reference to the contents,
+    /// `&'a mut ByteStr`.
+    ///
+    /// The caller has free choice over the returned lifetime, including `’static`. Indeed, this function is ideally used for data that lives for the remainder of the program’s life, as dropping the returned reference will cause a memory leak.
+    ///
+    /// It does not reallocate or shrink the `ByteString`, so the leaked allocation may include
+    /// unused capacity that is not part of the returned slice. If you want discard excess capacity,
+    /// call [`into_boxed_byte_str`], and then [`Box::leak`] instead. However, keep in mind that
+    /// trimming the capacity may result in a reallocation and copy.
+    ///
+    /// [`into_boxed_byte_str`]: ByteString::into_boxed_byte_str
+    #[unstable(feature = "byte_str", issue = "134915")]
+    #[inline]
+    pub fn leak<'a>(self) -> &'a mut ByteStr {
+        ByteStr::new_mut(self.0.leak())
+    }
+
+    /// Truncate the [`ByteString`] to the specified length.
+    #[unstable(feature = "byte_str", issue = "134915")]
+    #[inline]
+    pub fn truncate(&mut self, len: usize) {
+        self.0.truncate(len)
     }
     /// Try to get a `String` representation of the `&ByteString`, if it is
     /// valid UTF-8.
@@ -81,13 +285,104 @@ impl ByteString {
     }
 }
 
+impl ByteStr {
+    /// Converts a `ByteStr` to a <code>[Cow]<[str]></code>.
+    ///
+    /// Any non-UTF-8 sequences are replaced with
+    /// [U+FFFD REPLACEMENT CHARACTER][char::REPLACEMENT_CHARACTER].
+    ///
+    /// # Examples
+    ///
+    /// Calling `to_string_lossy` on a `ByteStr` with invalid unicode:
+    ///
+    /// ```
+    /// #![feature(byte_str)]
+    /// use std::byte_str::ByteStr;
+    ///
+    /// let byte_str = ByteStr::new(b"hello, \x80\x80!");
+    /// assert_eq!(byte_str.to_string_lossy(), "hello, ��!");
+    /// ```
+    #[unstable(feature = "byte_str", issue = "134915")]
+    #[inline]
+    #[rustc_allow_incoherent_impl]
+    pub fn to_string_lossy(&self) -> Cow<'_, str> {
+        String::from_utf8_lossy(self.as_bytes())
+    }
+
+    /// Converts a `ByteStr` to an owned [`ByteString`].
+    #[unstable(feature = "byte_str", issue = "134915")]
+    #[inline]
+    #[rustc_allow_incoherent_impl]
+    pub fn to_byte_string(&self) -> ByteString {
+        ByteString(self.as_bytes().to_vec())
+    }
+
+    /// Returns an owned [`ByteString`] containing a copy of this string where each byte
+    /// is mapped to its ASCII upper case equivalent.
+    ///
+    /// ASCII letters 'a' to 'z' are mapped to 'A' to 'Z',
+    /// but non-ASCII letters are unchanged.
+    ///
+    /// To uppercase the value in-place, use [`make_ascii_uppercase`].
+    ///
+    /// [`make_ascii_uppercase`]: ByteStr::make_ascii_uppercase
+    #[unstable(feature = "byte_str", issue = "134915")]
+    #[must_use = "this returns the uppercase bytes as a new ByteString, \
+                  without modifying the original"]
+    #[inline]
+    #[rustc_allow_incoherent_impl]
+    pub fn to_ascii_uppercase(&self) -> ByteString {
+        let mut me = self.to_byte_string();
+        me.make_ascii_uppercase();
+        me
+    }
+
+    /// Returns an owned [`ByteString`] containing a copy of this string where each byte
+    /// is mapped to its ASCII lower case equivalent.
+    ///
+    /// ASCII letters 'A' to 'Z' are mapped to 'a' to 'z',
+    /// but non-ASCII letters are unchanged.
+    ///
+    /// To lowercase the value in-place, use [`make_ascii_lowercase`].
+    ///
+    /// [`make_ascii_lowercase`]: ByteStr::make_ascii_lowercase
+    #[unstable(feature = "byte_str", issue = "134915")]
+    #[must_use = "this returns the uppercase bytes as a new ByteString, \
+                  without modifying the original"]
+    #[inline]
+    #[rustc_allow_incoherent_impl]
+    pub fn to_ascii_lowercase(&self) -> ByteString {
+        let mut me = self.to_byte_string();
+        me.make_ascii_lowercase();
+        me
+    }
+
+    /// Converts a <code>[Box]<[ByteStr]></code> into a <code>[Box]<\[u8\]></code> without
+    /// copying or allocating.
+    #[unstable(feature = "byte_str", issue = "134915")]
+    #[inline]
+    #[rustc_allow_incoherent_impl]
+    pub fn into_boxed_bytes(self: Box<Self>) -> Box<[u8]> {
+        // SAFETY: `ByteStr` is a transparent wrapper around `[u8]`.
+        unsafe { Box::from_raw(Box::into_raw(self) as _) }
+    }
+
+    /// Converts a <code>[Box]<[ByteStr]></code> to an owned [`ByteString`].
+    #[unstable(feature = "byte_str", issue = "134915")]
+    #[inline]
+    #[rustc_allow_incoherent_impl]
+    pub fn into_byte_string(self: Box<Self>) -> ByteString {
+        ByteString(self.into_boxed_bytes().into_vec())
+    }
+}
+
 #[unstable(feature = "byte_str", issue = "134915")]
 impl Deref for ByteString {
-    type Target = Vec<u8>;
+    type Target = ByteStr;
 
     #[inline]
     fn deref(&self) -> &Self::Target {
-        &self.0
+        self.as_byte_str()
     }
 }
 
@@ -95,7 +390,7 @@ impl Deref for ByteString {
 impl DerefMut for ByteString {
     #[inline]
     fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
+        self.as_mut_byte_str()
     }
 }
 
@@ -106,7 +401,7 @@ unsafe impl DerefPure for ByteString {}
 impl fmt::Debug for ByteString {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Debug::fmt(self.as_bytestr(), f)
+        fmt::Debug::fmt(self.as_byte_str(), f)
     }
 }
 
@@ -114,7 +409,7 @@ impl fmt::Debug for ByteString {
 impl fmt::Display for ByteString {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Display::fmt(self.as_bytestr(), f)
+        fmt::Display::fmt(self.as_byte_str(), f)
     }
 }
 
@@ -122,7 +417,7 @@ impl fmt::Display for ByteString {
 impl AsRef<[u8]> for ByteString {
     #[inline]
     fn as_ref(&self) -> &[u8] {
-        &self.0
+        self.as_bytes()
     }
 }
 
@@ -130,7 +425,7 @@ impl AsRef<[u8]> for ByteString {
 impl AsRef<ByteStr> for ByteString {
     #[inline]
     fn as_ref(&self) -> &ByteStr {
-        self.as_bytestr()
+        self.as_byte_str()
     }
 }
 
@@ -138,7 +433,7 @@ impl AsRef<ByteStr> for ByteString {
 impl AsMut<[u8]> for ByteString {
     #[inline]
     fn as_mut(&mut self) -> &mut [u8] {
-        &mut self.0
+        self.as_bytes_mut()
     }
 }
 
@@ -146,7 +441,7 @@ impl AsMut<[u8]> for ByteString {
 impl AsMut<ByteStr> for ByteString {
     #[inline]
     fn as_mut(&mut self) -> &mut ByteStr {
-        self.as_mut_bytestr()
+        self.as_mut_byte_str()
     }
 }
 
@@ -154,7 +449,7 @@ impl AsMut<ByteStr> for ByteString {
 impl Borrow<[u8]> for ByteString {
     #[inline]
     fn borrow(&self) -> &[u8] {
-        &self.0
+        self.as_bytes()
     }
 }
 
@@ -162,7 +457,7 @@ impl Borrow<[u8]> for ByteString {
 impl Borrow<ByteStr> for ByteString {
     #[inline]
     fn borrow(&self) -> &ByteStr {
-        self.as_bytestr()
+        self.as_byte_str()
     }
 }
 
@@ -173,7 +468,7 @@ impl Borrow<ByteStr> for ByteString {
 impl BorrowMut<[u8]> for ByteString {
     #[inline]
     fn borrow_mut(&mut self) -> &mut [u8] {
-        &mut self.0
+        self.as_bytes_mut()
     }
 }
 
@@ -181,7 +476,7 @@ impl BorrowMut<[u8]> for ByteString {
 impl BorrowMut<ByteStr> for ByteString {
     #[inline]
     fn borrow_mut(&mut self) -> &mut ByteStr {
-        self.as_mut_bytestr()
+        self.as_mut_byte_str()
     }
 }
 
@@ -251,7 +546,7 @@ impl From<ByteString> for Vec<u8> {
 impl<'a> From<&'a ByteStr> for ByteString {
     #[inline]
     fn from(s: &'a ByteStr) -> Self {
-        ByteString(s.0.to_vec())
+        s.to_byte_string()
     }
 }
 
@@ -267,7 +562,7 @@ impl<'a> From<ByteString> for Cow<'a, ByteStr> {
 impl<'a> From<&'a ByteString> for Cow<'a, ByteStr> {
     #[inline]
     fn from(s: &'a ByteString) -> Self {
-        Cow::Borrowed(s.as_bytestr())
+        Cow::Borrowed(s.as_byte_str())
     }
 }
 
@@ -299,11 +594,11 @@ impl<'a> FromIterator<&'a str> for ByteString {
 impl<'a> FromIterator<&'a [u8]> for ByteString {
     #[inline]
     fn from_iter<T: IntoIterator<Item = &'a [u8]>>(iter: T) -> Self {
-        let mut buf = Vec::new();
+        let mut buf = ByteString::new();
         for b in iter {
-            buf.extend_from_slice(b);
+            buf.push(ByteStr::new(b));
         }
-        ByteString(buf)
+        buf
     }
 }
 
@@ -311,11 +606,11 @@ impl<'a> FromIterator<&'a [u8]> for ByteString {
 impl<'a> FromIterator<&'a ByteStr> for ByteString {
     #[inline]
     fn from_iter<T: IntoIterator<Item = &'a ByteStr>>(iter: T) -> Self {
-        let mut buf = Vec::new();
+        let mut buf = ByteString::new();
         for b in iter {
-            buf.extend_from_slice(&b.0);
+            buf.push(b);
         }
-        ByteString(buf)
+        buf
     }
 }
 
@@ -357,7 +652,7 @@ impl Index<RangeFull> for ByteString {
 
     #[inline]
     fn index(&self, _: RangeFull) -> &ByteStr {
-        self.as_bytestr()
+        self.as_byte_str()
     }
 }
 
@@ -367,7 +662,7 @@ impl Index<Range<usize>> for ByteString {
 
     #[inline]
     fn index(&self, r: Range<usize>) -> &ByteStr {
-        ByteStr::from_bytes(&self.0[r])
+        ByteStr::new(&self.0[r])
     }
 }
 
@@ -377,7 +672,7 @@ impl Index<RangeInclusive<usize>> for ByteString {
 
     #[inline]
     fn index(&self, r: RangeInclusive<usize>) -> &ByteStr {
-        ByteStr::from_bytes(&self.0[r])
+        ByteStr::new(&self.0[r])
     }
 }
 
@@ -387,7 +682,7 @@ impl Index<RangeFrom<usize>> for ByteString {
 
     #[inline]
     fn index(&self, r: RangeFrom<usize>) -> &ByteStr {
-        ByteStr::from_bytes(&self.0[r])
+        ByteStr::new(&self.0[r])
     }
 }
 
@@ -397,7 +692,7 @@ impl Index<RangeTo<usize>> for ByteString {
 
     #[inline]
     fn index(&self, r: RangeTo<usize>) -> &ByteStr {
-        ByteStr::from_bytes(&self.0[r])
+        ByteStr::new(&self.0[r])
     }
 }
 
@@ -407,7 +702,7 @@ impl Index<RangeToInclusive<usize>> for ByteString {
 
     #[inline]
     fn index(&self, r: RangeToInclusive<usize>) -> &ByteStr {
-        ByteStr::from_bytes(&self.0[r])
+        ByteStr::new(&self.0[r])
     }
 }
 
@@ -423,7 +718,7 @@ impl IndexMut<usize> for ByteString {
 impl IndexMut<RangeFull> for ByteString {
     #[inline]
     fn index_mut(&mut self, _: RangeFull) -> &mut ByteStr {
-        self.as_mut_bytestr()
+        self.as_mut_byte_str()
     }
 }
 
@@ -431,7 +726,7 @@ impl IndexMut<RangeFull> for ByteString {
 impl IndexMut<Range<usize>> for ByteString {
     #[inline]
     fn index_mut(&mut self, r: Range<usize>) -> &mut ByteStr {
-        ByteStr::from_bytes_mut(&mut self.0[r])
+        ByteStr::new_mut(&mut self.0[r])
     }
 }
 
@@ -439,7 +734,7 @@ impl IndexMut<Range<usize>> for ByteString {
 impl IndexMut<RangeInclusive<usize>> for ByteString {
     #[inline]
     fn index_mut(&mut self, r: RangeInclusive<usize>) -> &mut ByteStr {
-        ByteStr::from_bytes_mut(&mut self.0[r])
+        ByteStr::new_mut(&mut self.0[r])
     }
 }
 
@@ -447,7 +742,7 @@ impl IndexMut<RangeInclusive<usize>> for ByteString {
 impl IndexMut<RangeFrom<usize>> for ByteString {
     #[inline]
     fn index_mut(&mut self, r: RangeFrom<usize>) -> &mut ByteStr {
-        ByteStr::from_bytes_mut(&mut self.0[r])
+        ByteStr::new_mut(&mut self.0[r])
     }
 }
 
@@ -455,7 +750,7 @@ impl IndexMut<RangeFrom<usize>> for ByteString {
 impl IndexMut<RangeTo<usize>> for ByteString {
     #[inline]
     fn index_mut(&mut self, r: RangeTo<usize>) -> &mut ByteStr {
-        ByteStr::from_bytes_mut(&mut self.0[r])
+        ByteStr::new_mut(&mut self.0[r])
     }
 }
 
@@ -463,7 +758,7 @@ impl IndexMut<RangeTo<usize>> for ByteString {
 impl IndexMut<RangeToInclusive<usize>> for ByteString {
     #[inline]
     fn index_mut(&mut self, r: RangeToInclusive<usize>) -> &mut ByteStr {
-        ByteStr::from_bytes_mut(&mut self.0[r])
+        ByteStr::new_mut(&mut self.0[r])
     }
 }
 
@@ -570,7 +865,7 @@ impl ToOwned for ByteStr {
 
     #[inline]
     fn to_owned(&self) -> ByteString {
-        ByteString(self.0.to_vec())
+        self.to_byte_string()
     }
 }
 
@@ -600,7 +895,7 @@ impl<'a> TryFrom<&'a ByteString> for &'a str {
 impl Clone for Box<ByteStr> {
     #[inline]
     fn clone(&self) -> Self {
-        Self::from(Box::<[u8]>::from(&self.0))
+        Self::from(Box::<[u8]>::from(self.as_bytes()))
     }
 }
 
@@ -684,7 +979,7 @@ impl<'a> TryFrom<&'a ByteStr> for String {
 
     #[inline]
     fn try_from(s: &'a ByteStr) -> Result<Self, Self::Error> {
-        Ok(core::str::from_utf8(&s.0)?.into())
+        Ok(core::str::from_utf8(s.as_bytes())?.into())
     }
 }
 
@@ -701,10 +996,10 @@ impl ByteStr {
     #[rustc_allow_incoherent_impl]
     pub fn to_string(&self) -> Result<String, Utf8Error> {
         // Avoid allocating a copy of the contents for invalid UTF-8
-        if let Err(e) = str::from_utf8(&self.0) {
+        if let Err(e) = str::from_utf8(self.as_bytes()) {
             return Err(e);
         }
         // SAFETY: we just checked that the contents are valid UTF-8
-        Ok(unsafe { String::from_utf8_unchecked(self.0.to_vec()) })
+        Ok(unsafe { String::from_utf8_unchecked(self.to_vec()) })
     }
 }

--- a/library/alloc/src/byte_str.rs
+++ b/library/alloc/src/byte_str.rs
@@ -4,9 +4,9 @@
 #![cfg(not(no_global_oom_handling))]
 
 use core::borrow::{Borrow, BorrowMut};
-#[unstable(feature = "bstr", issue = "134915")]
-pub use core::bstr::ByteStr;
-use core::bstr::{impl_partial_eq, impl_partial_eq_n, impl_partial_eq_ord};
+#[unstable(feature = "byte_str", issue = "134915")]
+pub use core::byte_str::ByteStr;
+use core::byte_str::{impl_partial_eq, impl_partial_eq_n, impl_partial_eq_ord};
 use core::cmp::Ordering;
 use core::ops::{
     Deref, DerefMut, DerefPure, Index, IndexMut, Range, RangeFrom, RangeFull, RangeInclusive,
@@ -32,7 +32,7 @@ use crate::vec::Vec;
 /// need to round-trip whatever data the user provides.
 ///
 /// A `ByteString` owns its contents and can grow and shrink, like a `Vec` or `String`. For a
-/// borrowed byte string, see [`ByteStr`](../../std/bstr/struct.ByteStr.html).
+/// borrowed byte string, see [`ByteStr`](../../std/byte_str/struct.ByteStr.html).
 ///
 /// `ByteString` implements `Deref` to `&Vec<u8>`, so all methods available on `&Vec<u8>` are
 /// available on `ByteString`. Similarly, `ByteString` implements `DerefMut` to `&mut Vec<u8>`,
@@ -40,7 +40,7 @@ use crate::vec::Vec;
 ///
 /// The `Debug` and `Display` implementations for `ByteString` are the same as those for `ByteStr`,
 /// showing invalid UTF-8 as hex escapes or the Unicode replacement character, respectively.
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 #[repr(transparent)]
 #[derive(Clone, Default)]
 #[doc(alias = "BString")]
@@ -69,7 +69,7 @@ impl ByteString {
     /// implementation for types that implement `Display`, and the trait version
     /// will use the Unicode replacement character rather than returning a
     /// `Result` and allowing for the possibility of the content not being UTF-8.
-    #[unstable(feature = "bstr_to_string", issue = "134915")]
+    #[unstable(feature = "byte_str_to_string", issue = "134915")]
     #[rustc_allow_incoherent_impl]
     pub fn to_string(&self) -> Result<String, Utf8Error> {
         // Avoid allocating a copy of the contents for invalid UTF-8
@@ -81,7 +81,7 @@ impl ByteString {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl Deref for ByteString {
     type Target = Vec<u8>;
 
@@ -91,7 +91,7 @@ impl Deref for ByteString {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl DerefMut for ByteString {
     #[inline]
     fn deref_mut(&mut self) -> &mut Self::Target {
@@ -102,7 +102,7 @@ impl DerefMut for ByteString {
 #[unstable(feature = "deref_pure_trait", issue = "87121")]
 unsafe impl DerefPure for ByteString {}
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl fmt::Debug for ByteString {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -110,7 +110,7 @@ impl fmt::Debug for ByteString {
     }
 }
 
-#[unstable(feature = "bstr_to_string", issue = "134915")]
+#[unstable(feature = "byte_str_to_string", issue = "134915")]
 impl fmt::Display for ByteString {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -118,7 +118,7 @@ impl fmt::Display for ByteString {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl AsRef<[u8]> for ByteString {
     #[inline]
     fn as_ref(&self) -> &[u8] {
@@ -126,7 +126,7 @@ impl AsRef<[u8]> for ByteString {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl AsRef<ByteStr> for ByteString {
     #[inline]
     fn as_ref(&self) -> &ByteStr {
@@ -134,7 +134,7 @@ impl AsRef<ByteStr> for ByteString {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl AsMut<[u8]> for ByteString {
     #[inline]
     fn as_mut(&mut self) -> &mut [u8] {
@@ -142,7 +142,7 @@ impl AsMut<[u8]> for ByteString {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl AsMut<ByteStr> for ByteString {
     #[inline]
     fn as_mut(&mut self) -> &mut ByteStr {
@@ -150,7 +150,7 @@ impl AsMut<ByteStr> for ByteString {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl Borrow<[u8]> for ByteString {
     #[inline]
     fn borrow(&self) -> &[u8] {
@@ -158,7 +158,7 @@ impl Borrow<[u8]> for ByteString {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl Borrow<ByteStr> for ByteString {
     #[inline]
     fn borrow(&self) -> &ByteStr {
@@ -169,7 +169,7 @@ impl Borrow<ByteStr> for ByteString {
 // `impl Borrow<ByteStr> for Vec<u8>` omitted to avoid inference failures
 // `impl Borrow<ByteStr> for String` omitted to avoid inference failures
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl BorrowMut<[u8]> for ByteString {
     #[inline]
     fn borrow_mut(&mut self) -> &mut [u8] {
@@ -177,7 +177,7 @@ impl BorrowMut<[u8]> for ByteString {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl BorrowMut<ByteStr> for ByteString {
     #[inline]
     fn borrow_mut(&mut self) -> &mut ByteStr {
@@ -189,7 +189,7 @@ impl BorrowMut<ByteStr> for ByteString {
 
 // Omitted due to inference failures
 //
-// #[unstable(feature = "bstr", issue = "134915")]
+// #[unstable(feature = "byte_str", issue = "134915")]
 // impl<'a, const N: usize> From<&'a [u8; N]> for ByteString {
 //     #[inline]
 //     fn from(s: &'a [u8; N]) -> Self {
@@ -197,7 +197,7 @@ impl BorrowMut<ByteStr> for ByteString {
 //     }
 // }
 //
-// #[unstable(feature = "bstr", issue = "134915")]
+// #[unstable(feature = "byte_str", issue = "134915")]
 // impl<const N: usize> From<[u8; N]> for ByteString {
 //     #[inline]
 //     fn from(s: [u8; N]) -> Self {
@@ -205,7 +205,7 @@ impl BorrowMut<ByteStr> for ByteString {
 //     }
 // }
 //
-// #[unstable(feature = "bstr", issue = "134915")]
+// #[unstable(feature = "byte_str", issue = "134915")]
 // impl<'a> From<&'a [u8]> for ByteString {
 //     #[inline]
 //     fn from(s: &'a [u8]) -> Self {
@@ -213,7 +213,7 @@ impl BorrowMut<ByteStr> for ByteString {
 //     }
 // }
 //
-// #[unstable(feature = "bstr", issue = "134915")]
+// #[unstable(feature = "byte_str", issue = "134915")]
 // impl From<Vec<u8>> for ByteString {
 //     #[inline]
 //     fn from(s: Vec<u8>) -> Self {
@@ -221,7 +221,7 @@ impl BorrowMut<ByteStr> for ByteString {
 //     }
 // }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl From<ByteString> for Vec<u8> {
     #[inline]
     fn from(s: ByteString) -> Self {
@@ -231,7 +231,7 @@ impl From<ByteString> for Vec<u8> {
 
 // Omitted due to inference failures
 //
-// #[unstable(feature = "bstr", issue = "134915")]
+// #[unstable(feature = "byte_str", issue = "134915")]
 // impl<'a> From<&'a str> for ByteString {
 //     #[inline]
 //     fn from(s: &'a str) -> Self {
@@ -239,7 +239,7 @@ impl From<ByteString> for Vec<u8> {
 //     }
 // }
 //
-// #[unstable(feature = "bstr", issue = "134915")]
+// #[unstable(feature = "byte_str", issue = "134915")]
 // impl From<String> for ByteString {
 //     #[inline]
 //     fn from(s: String) -> Self {
@@ -247,7 +247,7 @@ impl From<ByteString> for Vec<u8> {
 //     }
 // }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl<'a> From<&'a ByteStr> for ByteString {
     #[inline]
     fn from(s: &'a ByteStr) -> Self {
@@ -255,7 +255,7 @@ impl<'a> From<&'a ByteStr> for ByteString {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl<'a> From<ByteString> for Cow<'a, ByteStr> {
     #[inline]
     fn from(s: ByteString) -> Self {
@@ -263,7 +263,7 @@ impl<'a> From<ByteString> for Cow<'a, ByteStr> {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl<'a> From<&'a ByteString> for Cow<'a, ByteStr> {
     #[inline]
     fn from(s: &'a ByteString) -> Self {
@@ -271,7 +271,7 @@ impl<'a> From<&'a ByteString> for Cow<'a, ByteStr> {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl FromIterator<char> for ByteString {
     #[inline]
     fn from_iter<T: IntoIterator<Item = char>>(iter: T) -> Self {
@@ -279,7 +279,7 @@ impl FromIterator<char> for ByteString {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl FromIterator<u8> for ByteString {
     #[inline]
     fn from_iter<T: IntoIterator<Item = u8>>(iter: T) -> Self {
@@ -287,7 +287,7 @@ impl FromIterator<u8> for ByteString {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl<'a> FromIterator<&'a str> for ByteString {
     #[inline]
     fn from_iter<T: IntoIterator<Item = &'a str>>(iter: T) -> Self {
@@ -295,7 +295,7 @@ impl<'a> FromIterator<&'a str> for ByteString {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl<'a> FromIterator<&'a [u8]> for ByteString {
     #[inline]
     fn from_iter<T: IntoIterator<Item = &'a [u8]>>(iter: T) -> Self {
@@ -307,7 +307,7 @@ impl<'a> FromIterator<&'a [u8]> for ByteString {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl<'a> FromIterator<&'a ByteStr> for ByteString {
     #[inline]
     fn from_iter<T: IntoIterator<Item = &'a ByteStr>>(iter: T) -> Self {
@@ -319,7 +319,7 @@ impl<'a> FromIterator<&'a ByteStr> for ByteString {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl FromIterator<ByteString> for ByteString {
     #[inline]
     fn from_iter<T: IntoIterator<Item = ByteString>>(iter: T) -> Self {
@@ -331,7 +331,7 @@ impl FromIterator<ByteString> for ByteString {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl FromStr for ByteString {
     type Err = core::convert::Infallible;
 
@@ -341,7 +341,7 @@ impl FromStr for ByteString {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl Index<usize> for ByteString {
     type Output = u8;
 
@@ -351,7 +351,7 @@ impl Index<usize> for ByteString {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl Index<RangeFull> for ByteString {
     type Output = ByteStr;
 
@@ -361,7 +361,7 @@ impl Index<RangeFull> for ByteString {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl Index<Range<usize>> for ByteString {
     type Output = ByteStr;
 
@@ -371,7 +371,7 @@ impl Index<Range<usize>> for ByteString {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl Index<RangeInclusive<usize>> for ByteString {
     type Output = ByteStr;
 
@@ -381,7 +381,7 @@ impl Index<RangeInclusive<usize>> for ByteString {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl Index<RangeFrom<usize>> for ByteString {
     type Output = ByteStr;
 
@@ -391,7 +391,7 @@ impl Index<RangeFrom<usize>> for ByteString {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl Index<RangeTo<usize>> for ByteString {
     type Output = ByteStr;
 
@@ -401,7 +401,7 @@ impl Index<RangeTo<usize>> for ByteString {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl Index<RangeToInclusive<usize>> for ByteString {
     type Output = ByteStr;
 
@@ -411,7 +411,7 @@ impl Index<RangeToInclusive<usize>> for ByteString {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl IndexMut<usize> for ByteString {
     #[inline]
     fn index_mut(&mut self, idx: usize) -> &mut u8 {
@@ -419,7 +419,7 @@ impl IndexMut<usize> for ByteString {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl IndexMut<RangeFull> for ByteString {
     #[inline]
     fn index_mut(&mut self, _: RangeFull) -> &mut ByteStr {
@@ -427,7 +427,7 @@ impl IndexMut<RangeFull> for ByteString {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl IndexMut<Range<usize>> for ByteString {
     #[inline]
     fn index_mut(&mut self, r: Range<usize>) -> &mut ByteStr {
@@ -435,7 +435,7 @@ impl IndexMut<Range<usize>> for ByteString {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl IndexMut<RangeInclusive<usize>> for ByteString {
     #[inline]
     fn index_mut(&mut self, r: RangeInclusive<usize>) -> &mut ByteStr {
@@ -443,7 +443,7 @@ impl IndexMut<RangeInclusive<usize>> for ByteString {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl IndexMut<RangeFrom<usize>> for ByteString {
     #[inline]
     fn index_mut(&mut self, r: RangeFrom<usize>) -> &mut ByteStr {
@@ -451,7 +451,7 @@ impl IndexMut<RangeFrom<usize>> for ByteString {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl IndexMut<RangeTo<usize>> for ByteString {
     #[inline]
     fn index_mut(&mut self, r: RangeTo<usize>) -> &mut ByteStr {
@@ -459,7 +459,7 @@ impl IndexMut<RangeTo<usize>> for ByteString {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl IndexMut<RangeToInclusive<usize>> for ByteString {
     #[inline]
     fn index_mut(&mut self, r: RangeToInclusive<usize>) -> &mut ByteStr {
@@ -467,7 +467,7 @@ impl IndexMut<RangeToInclusive<usize>> for ByteString {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl hash::Hash for ByteString {
     #[inline]
     fn hash<H: hash::Hasher>(&self, state: &mut H) {
@@ -475,10 +475,10 @@ impl hash::Hash for ByteString {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl Eq for ByteString {}
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl PartialEq for ByteString {
     #[inline]
     fn eq(&self, other: &ByteString) -> bool {
@@ -488,7 +488,7 @@ impl PartialEq for ByteString {
 
 macro_rules! impl_partial_eq_ord_cow {
     ($lhs:ty, $rhs:ty) => {
-        #[unstable(feature = "bstr", issue = "134915")]
+        #[unstable(feature = "byte_str", issue = "134915")]
         impl PartialEq<$rhs> for $lhs {
             #[inline]
             fn eq(&self, other: &$rhs) -> bool {
@@ -497,7 +497,7 @@ macro_rules! impl_partial_eq_ord_cow {
             }
         }
 
-        #[unstable(feature = "bstr", issue = "134915")]
+        #[unstable(feature = "byte_str", issue = "134915")]
         impl PartialEq<$lhs> for $rhs {
             #[inline]
             fn eq(&self, other: &$lhs) -> bool {
@@ -506,7 +506,7 @@ macro_rules! impl_partial_eq_ord_cow {
             }
         }
 
-        #[unstable(feature = "bstr", issue = "134915")]
+        #[unstable(feature = "byte_str", issue = "134915")]
         impl PartialOrd<$rhs> for $lhs {
             #[inline]
             fn partial_cmp(&self, other: &$rhs) -> Option<Ordering> {
@@ -515,7 +515,7 @@ macro_rules! impl_partial_eq_ord_cow {
             }
         }
 
-        #[unstable(feature = "bstr", issue = "134915")]
+        #[unstable(feature = "byte_str", issue = "134915")]
         impl PartialOrd<$lhs> for $rhs {
             #[inline]
             fn partial_cmp(&self, other: &$lhs) -> Option<Ordering> {
@@ -548,7 +548,7 @@ impl_partial_eq_ord_cow!(ByteString, Cow<'_, ByteStr>);
 impl_partial_eq_ord_cow!(ByteString, Cow<'_, str>);
 impl_partial_eq_ord_cow!(ByteString, Cow<'_, [u8]>);
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl Ord for ByteString {
     #[inline]
     fn cmp(&self, other: &ByteString) -> Ordering {
@@ -556,7 +556,7 @@ impl Ord for ByteString {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl PartialOrd for ByteString {
     #[inline]
     fn partial_cmp(&self, other: &ByteString) -> Option<Ordering> {
@@ -564,7 +564,7 @@ impl PartialOrd for ByteString {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl ToOwned for ByteStr {
     type Owned = ByteString;
 
@@ -574,7 +574,7 @@ impl ToOwned for ByteStr {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl TryFrom<ByteString> for String {
     type Error = crate::string::FromUtf8Error;
 
@@ -584,7 +584,7 @@ impl TryFrom<ByteString> for String {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl<'a> TryFrom<&'a ByteString> for &'a str {
     type Error = crate::str::Utf8Error;
 
@@ -596,7 +596,7 @@ impl<'a> TryFrom<&'a ByteString> for &'a str {
 
 // Additional impls for `ByteStr` that require types from `alloc`:
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl Clone for Box<ByteStr> {
     #[inline]
     fn clone(&self) -> Self {
@@ -604,7 +604,7 @@ impl Clone for Box<ByteStr> {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl<'a> From<&'a ByteStr> for Cow<'a, ByteStr> {
     #[inline]
     fn from(s: &'a ByteStr) -> Self {
@@ -612,7 +612,7 @@ impl<'a> From<&'a ByteStr> for Cow<'a, ByteStr> {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl From<Box<[u8]>> for Box<ByteStr> {
     #[inline]
     fn from(s: Box<[u8]>) -> Box<ByteStr> {
@@ -621,7 +621,7 @@ impl From<Box<[u8]>> for Box<ByteStr> {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl From<Box<ByteStr>> for Box<[u8]> {
     #[inline]
     fn from(s: Box<ByteStr>) -> Box<[u8]> {
@@ -630,7 +630,7 @@ impl From<Box<ByteStr>> for Box<[u8]> {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 #[cfg(not(no_rc))]
 impl From<Rc<[u8]>> for Rc<ByteStr> {
     #[inline]
@@ -640,7 +640,7 @@ impl From<Rc<[u8]>> for Rc<ByteStr> {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 #[cfg(not(no_rc))]
 impl From<Rc<ByteStr>> for Rc<[u8]> {
     #[inline]
@@ -650,7 +650,7 @@ impl From<Rc<ByteStr>> for Rc<[u8]> {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 #[cfg(all(not(no_rc), not(no_sync), target_has_atomic = "ptr"))]
 impl From<Arc<[u8]>> for Arc<ByteStr> {
     #[inline]
@@ -660,7 +660,7 @@ impl From<Arc<[u8]>> for Arc<ByteStr> {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 #[cfg(all(not(no_rc), not(no_sync), target_has_atomic = "ptr"))]
 impl From<Arc<ByteStr>> for Arc<[u8]> {
     #[inline]
@@ -678,7 +678,7 @@ impl_partial_eq_ord_cow!(&ByteStr, Cow<'_, ByteStr>);
 impl_partial_eq_ord_cow!(&ByteStr, Cow<'_, str>);
 impl_partial_eq_ord_cow!(&ByteStr, Cow<'_, [u8]>);
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl<'a> TryFrom<&'a ByteStr> for String {
     type Error = core::str::Utf8Error;
 
@@ -697,7 +697,7 @@ impl ByteStr {
     /// implementation for types that implement `Display`, and the trait version
     /// will use the Unicode replacement character rather than returning a
     /// `Result` and allowing for the possibility of the content not being UTF-8.
-    #[unstable(feature = "bstr_to_string", issue = "134915")]
+    #[unstable(feature = "byte_str_to_string", issue = "134915")]
     #[rustc_allow_incoherent_impl]
     pub fn to_string(&self) -> Result<String, Utf8Error> {
         // Avoid allocating a copy of the contents for invalid UTF-8

--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -96,8 +96,8 @@
 #![feature(async_fn_traits)]
 #![feature(async_iterator)]
 #![feature(borrowed_buf_init)]
-#![feature(bstr)]
-#![feature(bstr_internals)]
+#![feature(byte_str)]
+#![feature(byte_str_internals)]
 #![feature(can_vector)]
 #![feature(case_ignorable)]
 #![feature(cast_maybe_uninit)]
@@ -246,8 +246,8 @@ pub mod alloc;
 // to allow code to have `use boxed::Box;` declarations.
 pub mod borrow;
 pub mod boxed;
-#[unstable(feature = "bstr", issue = "134915")]
-pub mod bstr;
+#[unstable(feature = "byte_str", issue = "134915")]
+pub mod byte_str;
 pub mod collections;
 #[cfg(all(not(no_rc), not(no_sync), not(no_global_oom_handling)))]
 pub mod ffi;

--- a/library/alloc/src/slice.rs
+++ b/library/alloc/src/slice.rs
@@ -11,6 +11,8 @@
 
 use core::borrow::{Borrow, BorrowMut};
 #[cfg(not(no_global_oom_handling))]
+use core::bstr::ByteStr;
+#[cfg(not(no_global_oom_handling))]
 use core::clone::TrivialClone;
 #[cfg(not(no_global_oom_handling))]
 use core::cmp::Ordering::{self, Less};
@@ -660,6 +662,16 @@ impl [u8] {
         let mut me = self.to_vec();
         me.make_ascii_lowercase();
         me
+    }
+
+    /// Converts a `Box<[u8]>` into a `Box<ByteStr>` without copying or allocating.
+    #[cfg(not(no_global_oom_handling))]
+    #[rustc_allow_incoherent_impl]
+    #[unstable(feature = "bstr", issue = "134915")]
+    #[inline]
+    pub fn into_boxed_byte_str(self: Box<[u8]>) -> Box<ByteStr> {
+        // SAFETY: `ByteStr` is a thin wrapper over `[u8]`
+        unsafe { Box::from_raw(Box::into_raw(self) as _) }
     }
 }
 

--- a/library/alloc/src/slice.rs
+++ b/library/alloc/src/slice.rs
@@ -11,6 +11,8 @@
 
 use core::borrow::{Borrow, BorrowMut};
 #[cfg(not(no_global_oom_handling))]
+use core::byte_str::ByteStr;
+#[cfg(not(no_global_oom_handling))]
 use core::clone::TrivialClone;
 #[cfg(not(no_global_oom_handling))]
 use core::cmp::Ordering::{self, Less};
@@ -659,6 +661,16 @@ impl [u8] {
     #[inline]
     pub fn to_ascii_lowercase(&self) -> Vec<u8> {
         self.iter().map(|b| b.to_ascii_lowercase()).collect()
+    }
+
+    /// Converts a `Box<[u8]>` into a `Box<ByteStr>` without copying or allocating.
+    #[cfg(not(no_global_oom_handling))]
+    #[rustc_allow_incoherent_impl]
+    #[unstable(feature = "byte_str", issue = "134915")]
+    #[inline]
+    pub fn into_boxed_byte_str(self: Box<[u8]>) -> Box<ByteStr> {
+        // SAFETY: `ByteStr` is a thin wrapper over `[u8]`
+        unsafe { Box::from_raw(Box::into_raw(self) as _) }
     }
 }
 

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -93,6 +93,8 @@ pub use self::extract_if::ExtractIf;
 use crate::alloc::{Allocator, Global};
 use crate::borrow::{Cow, ToOwned};
 use crate::boxed::Box;
+#[cfg(not(no_global_oom_handling))]
+use crate::bstr::ByteString;
 use crate::collections::TryReserveError;
 use crate::raw_vec::RawVec;
 
@@ -3347,6 +3349,17 @@ impl<T: Clone, A: Allocator> Vec<T, A> {
         unsafe {
             self.spec_extend_from_within(range);
         }
+    }
+}
+
+#[cfg(not(no_global_oom_handling))]
+impl Vec<u8> {
+    /// Converts a vector of bytes into a byte string.
+    #[unstable(feature = "bstr", issue = "134915")]
+    #[inline]
+    #[rustc_const_unstable(feature = "bstr", issue = "134915")]
+    pub const fn into_byte_string(self) -> ByteString {
+        ByteString(self)
     }
 }
 

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -91,6 +91,8 @@ pub use self::extract_if::ExtractIf;
 use crate::alloc::{Allocator, Global};
 use crate::borrow::{Cow, ToOwned};
 use crate::boxed::Box;
+#[cfg(not(no_global_oom_handling))]
+use crate::byte_str::ByteString;
 use crate::collections::TryReserveError;
 use crate::raw_vec::RawVec;
 
@@ -3660,6 +3662,17 @@ impl<A: Allocator> Vec<u8, A> {
         other: &[u8],
     ) -> Result<(), TryReserveError> {
         unsafe { self.try_append_elements(other) }
+    }
+}
+
+impl Vec<u8> {
+    /// Converts a vector of bytes into a byte string.
+    #[cfg(not(no_global_oom_handling))]
+    #[unstable(feature = "byte_str", issue = "134915")]
+    #[inline]
+    #[rustc_const_unstable(feature = "byte_str", issue = "134915")]
+    pub const fn into_byte_string(self) -> ByteString {
+        ByteString(self)
     }
 }
 

--- a/library/alloctests/tests/byte_str.rs
+++ b/library/alloctests/tests/byte_str.rs
@@ -1,11 +1,11 @@
-use alloc::byte_str::ByteString;
+use alloc::byte_str::ByteStr;
 use core::assert_matches;
 
 #[test]
 fn test_debug() {
-    let b1 = ByteString(
-        b"\0\x01\x02\x03\x04\x05\x06\x07\x08\t\n\x11\x12\r\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f \x7f\x80\x81\xfe\xff".to_vec()
-    );
+    let b1 = ByteStr::new(
+        b"\0\x01\x02\x03\x04\x05\x06\x07\x08\t\n\x11\x12\r\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f \x7f\x80\x81\xfe\xff"
+    ).to_byte_string();
     assert_eq!(
         r#""\0\x01\x02\x03\x04\x05\x06\x07\x08\t\n\x11\x12\r\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f \x7f\x80\x81\xfe\xff""#,
         format!("{:?}", b1),
@@ -14,8 +14,8 @@ fn test_debug() {
 
 #[test]
 fn test_display() {
-    let b1 = ByteString(b"abc".to_vec());
-    let b2 = ByteString(b"\xf0\x28\x8c\xbc".to_vec());
+    let b1 = ByteStr::new(b"abc").to_byte_string();
+    let b2 = ByteStr::new(b"\xf0\x28\x8c\xbc").to_byte_string();
 
     assert_eq!(&format!("{b1}"), "abc");
     assert_eq!(&format!("{b2}"), "�(��");
@@ -72,8 +72,8 @@ fn test_display() {
 
 #[test]
 fn test_to_string() {
-    let b1 = ByteString(b"abc".to_vec());
-    let b2 = ByteString(b"\xf0\x28\x8c\xbc".to_vec());
+    let b1 = ByteStr::new(b"abc").to_byte_string();
+    let b2 = ByteStr::new(b"\xf0\x28\x8c\xbc").to_byte_string();
 
     assert_eq!(Ok("abc".to_string()), b1.to_string());
     assert_matches!(b2.to_string(), Err(core::str::Utf8Error { .. }));

--- a/library/alloctests/tests/byte_str.rs
+++ b/library/alloctests/tests/byte_str.rs
@@ -1,17 +1,21 @@
-use core::bstr::ByteStr;
+use alloc::byte_str::ByteString;
+use core::assert_matches;
 
 #[test]
 fn test_debug() {
+    let b1 = ByteString(
+        b"\0\x01\x02\x03\x04\x05\x06\x07\x08\t\n\x11\x12\r\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f \x7f\x80\x81\xfe\xff".to_vec()
+    );
     assert_eq!(
         r#""\0\x01\x02\x03\x04\x05\x06\x07\x08\t\n\x11\x12\r\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f \x7f\x80\x81\xfe\xff""#,
-        format!("{:?}", ByteStr::new(b"\0\x01\x02\x03\x04\x05\x06\x07\x08\t\n\x11\x12\r\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f \x7f\x80\x81\xfe\xff")),
+        format!("{:?}", b1),
     );
 }
 
 #[test]
 fn test_display() {
-    let b1 = ByteStr::new("abc");
-    let b2 = ByteStr::new(b"\xf0\x28\x8c\xbc");
+    let b1 = ByteString(b"abc".to_vec());
+    let b2 = ByteString(b"\xf0\x28\x8c\xbc".to_vec());
 
     assert_eq!(&format!("{b1}"), "abc");
     assert_eq!(&format!("{b2}"), "�(��");
@@ -64,4 +68,17 @@ fn test_display() {
     assert_eq!(&format!("{b2:-<6.3}!"), "�(�---!");
     assert_eq!(&format!("{b2:-^6.3}!"), "-�(�--!");
     assert_eq!(&format!("{b2:->6.3}!"), "---�(�!");
+}
+
+#[test]
+fn test_to_string() {
+    let b1 = ByteString(b"abc".to_vec());
+    let b2 = ByteString(b"\xf0\x28\x8c\xbc".to_vec());
+
+    assert_eq!(Ok("abc".to_string()), b1.to_string());
+    assert_matches!(b2.to_string(), Err(core::str::Utf8Error { .. }));
+
+    // Can still directly use the trait
+    assert_eq!("abc".to_string(), ToString::to_string(&b1));
+    assert_eq!("�(��".to_string(), ToString::to_string(&b2));
 }

--- a/library/alloctests/tests/lib.rs
+++ b/library/alloctests/tests/lib.rs
@@ -8,9 +8,9 @@
 #![feature(binary_heap_into_iter_sorted)]
 #![feature(binary_heap_pop_if)]
 #![feature(borrowed_buf_init)]
-#![feature(bstr)]
-#![feature(bstr_to_string)]
 #![feature(buf_read_has_data_left)]
+#![feature(byte_str)]
+#![feature(byte_str_to_string)]
 #![feature(can_vector)]
 #![feature(casefold)]
 #![feature(const_btree_len)]
@@ -73,8 +73,8 @@ mod arc;
 mod autotraits;
 mod borrow;
 mod boxed;
-mod bstr;
 mod btree_set_hash;
+mod byte_str;
 mod c_str;
 mod c_str2;
 mod collections;

--- a/library/core/src/byte_str/mod.rs
+++ b/library/core/src/byte_str/mod.rs
@@ -2,7 +2,7 @@
 
 mod traits;
 
-#[unstable(feature = "bstr_internals", issue = "none")]
+#[unstable(feature = "byte_str_internals", issue = "none")]
 pub use traits::{impl_partial_eq, impl_partial_eq_n, impl_partial_eq_ord};
 
 use crate::borrow::{Borrow, BorrowMut};
@@ -17,7 +17,7 @@ use crate::ops::{Deref, DerefMut, DerefPure};
 /// need to round-trip whatever data the user provides.
 ///
 /// For an owned, growable byte string buffer, use
-/// [`ByteString`](../../std/bstr/struct.ByteString.html).
+/// [`ByteString`](../../std/byte_str/struct.ByteString.html).
 ///
 /// `ByteStr` implements `Deref` to `[u8]`, so all methods available on `[u8]` are available on
 /// `ByteStr`.
@@ -37,7 +37,7 @@ use crate::ops::{Deref, DerefMut, DerefPure};
 ///
 /// The `Display` implementation behaves as if the `ByteStr` were first lossily converted to a
 /// `str`, with invalid UTF-8 presented as the Unicode replacement character (�).
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 #[rustc_has_incoherent_inherent_impls]
 #[repr(transparent)]
 #[doc(alias = "BStr")]
@@ -53,8 +53,8 @@ impl ByteStr {
     /// You can create a `ByteStr` from a byte array, a byte slice or a string slice:
     ///
     /// ```
-    /// # #![feature(bstr)]
-    /// # use std::bstr::ByteStr;
+    /// # #![feature(byte_str)]
+    /// # use std::byte_str::ByteStr;
     /// let a = ByteStr::new(b"abc");
     /// let b = ByteStr::new(&b"abc"[..]);
     /// let c = ByteStr::new("abc");
@@ -63,7 +63,7 @@ impl ByteStr {
     /// assert_eq!(a, c);
     /// ```
     #[inline]
-    #[unstable(feature = "bstr", issue = "134915")]
+    #[unstable(feature = "byte_str", issue = "134915")]
     #[rustc_const_unstable(feature = "const_convert", issue = "143773")]
     pub const fn new<B: ?Sized + [const] AsRef<[u8]>>(bytes: &B) -> &Self {
         ByteStr::from_bytes(bytes.as_ref())
@@ -76,7 +76,7 @@ impl ByteStr {
     /// for example `Box<ByteStr>` or `Arc<ByteStr>`.
     #[inline]
     // #[unstable(feature = "str_as_str", issue = "130366")]
-    #[unstable(feature = "bstr", issue = "134915")]
+    #[unstable(feature = "byte_str", issue = "134915")]
     pub const fn as_byte_str(&self) -> &ByteStr {
         self
     }
@@ -88,15 +88,15 @@ impl ByteStr {
     /// for example `Box<ByteStr>` or `MutexGuard<ByteStr>`.
     #[inline]
     // #[unstable(feature = "str_as_str", issue = "130366")]
-    #[unstable(feature = "bstr", issue = "134915")]
+    #[unstable(feature = "byte_str", issue = "134915")]
     pub const fn as_mut_byte_str(&mut self) -> &mut ByteStr {
         self
     }
 
     #[doc(hidden)]
-    #[unstable(feature = "bstr_internals", issue = "none")]
+    #[unstable(feature = "byte_str_internals", issue = "none")]
     #[inline]
-    #[rustc_const_unstable(feature = "bstr_internals", issue = "none")]
+    #[rustc_const_unstable(feature = "byte_str_internals", issue = "none")]
     pub const fn from_bytes(slice: &[u8]) -> &Self {
         // SAFETY: `ByteStr` is a transparent wrapper around `[u8]`, so we can turn a reference to
         // the wrapped type into a reference to the wrapper type.
@@ -104,9 +104,9 @@ impl ByteStr {
     }
 
     #[doc(hidden)]
-    #[unstable(feature = "bstr_internals", issue = "none")]
+    #[unstable(feature = "byte_str_internals", issue = "none")]
     #[inline]
-    #[rustc_const_unstable(feature = "bstr_internals", issue = "none")]
+    #[rustc_const_unstable(feature = "byte_str_internals", issue = "none")]
     pub const fn from_bytes_mut(slice: &mut [u8]) -> &mut Self {
         // SAFETY: `ByteStr` is a transparent wrapper around `[u8]`, so we can turn a reference to
         // the wrapped type into a reference to the wrapper type.
@@ -114,23 +114,23 @@ impl ByteStr {
     }
 
     #[doc(hidden)]
-    #[unstable(feature = "bstr_internals", issue = "none")]
+    #[unstable(feature = "byte_str_internals", issue = "none")]
     #[inline]
-    #[rustc_const_unstable(feature = "bstr_internals", issue = "none")]
+    #[rustc_const_unstable(feature = "byte_str_internals", issue = "none")]
     pub const fn as_bytes(&self) -> &[u8] {
         &self.0
     }
 
     #[doc(hidden)]
-    #[unstable(feature = "bstr_internals", issue = "none")]
+    #[unstable(feature = "byte_str_internals", issue = "none")]
     #[inline]
-    #[rustc_const_unstable(feature = "bstr_internals", issue = "none")]
+    #[rustc_const_unstable(feature = "byte_str_internals", issue = "none")]
     pub const fn as_bytes_mut(&mut self) -> &mut [u8] {
         &mut self.0
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 #[rustc_const_unstable(feature = "const_convert", issue = "143773")]
 const impl Deref for ByteStr {
     type Target = [u8];
@@ -141,7 +141,7 @@ const impl Deref for ByteStr {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 #[rustc_const_unstable(feature = "const_convert", issue = "143773")]
 const impl DerefMut for ByteStr {
     #[inline]
@@ -153,7 +153,7 @@ const impl DerefMut for ByteStr {
 #[unstable(feature = "deref_pure_trait", issue = "87121")]
 unsafe impl DerefPure for ByteStr {}
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl fmt::Debug for ByteStr {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "\"")?;
@@ -172,7 +172,7 @@ impl fmt::Debug for ByteStr {
     }
 }
 
-#[unstable(feature = "bstr_to_string", issue = "134915")]
+#[unstable(feature = "byte_str_to_string", issue = "134915")]
 impl fmt::Display for ByteStr {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fn emit(byte_str: &ByteStr, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -257,7 +257,7 @@ impl fmt::Display for ByteStr {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 #[rustc_const_unstable(feature = "const_convert", issue = "143773")]
 const impl AsRef<[u8]> for ByteStr {
     #[inline]
@@ -266,7 +266,7 @@ const impl AsRef<[u8]> for ByteStr {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 #[rustc_const_unstable(feature = "const_convert", issue = "143773")]
 const impl AsRef<ByteStr> for ByteStr {
     #[inline]
@@ -277,7 +277,7 @@ const impl AsRef<ByteStr> for ByteStr {
 
 // `impl AsRef<ByteStr> for [u8]` omitted to avoid widespread inference failures
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 #[rustc_const_unstable(feature = "const_convert", issue = "143773")]
 const impl AsRef<ByteStr> for str {
     #[inline]
@@ -286,7 +286,7 @@ const impl AsRef<ByteStr> for str {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 #[rustc_const_unstable(feature = "const_convert", issue = "143773")]
 const impl AsMut<[u8]> for ByteStr {
     #[inline]
@@ -301,7 +301,7 @@ const impl AsMut<[u8]> for ByteStr {
 
 // `impl Borrow<ByteStr> for str` omitted to avoid widespread inference failures
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 #[rustc_const_unstable(feature = "const_convert", issue = "143773")]
 const impl Borrow<[u8]> for ByteStr {
     #[inline]
@@ -312,7 +312,7 @@ const impl Borrow<[u8]> for ByteStr {
 
 // `impl BorrowMut<ByteStr> for [u8]` omitted to avoid widespread inference failures
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 #[rustc_const_unstable(feature = "const_convert", issue = "143773")]
 const impl BorrowMut<[u8]> for ByteStr {
     #[inline]
@@ -321,14 +321,14 @@ const impl BorrowMut<[u8]> for ByteStr {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl<'a> Default for &'a ByteStr {
     fn default() -> Self {
         ByteStr::from_bytes(b"")
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl<'a> Default for &'a mut ByteStr {
     fn default() -> Self {
         ByteStr::from_bytes_mut(&mut [])
@@ -337,7 +337,7 @@ impl<'a> Default for &'a mut ByteStr {
 
 // Omitted due to inference failures
 //
-// #[unstable(feature = "bstr", issue = "134915")]
+// #[unstable(feature = "byte_str", issue = "134915")]
 // impl<'a, const N: usize> From<&'a [u8; N]> for &'a ByteStr {
 //     #[inline]
 //     fn from(s: &'a [u8; N]) -> Self {
@@ -345,7 +345,7 @@ impl<'a> Default for &'a mut ByteStr {
 //     }
 // }
 //
-// #[unstable(feature = "bstr", issue = "134915")]
+// #[unstable(feature = "byte_str", issue = "134915")]
 // impl<'a> From<&'a [u8]> for &'a ByteStr {
 //     #[inline]
 //     fn from(s: &'a [u8]) -> Self {
@@ -355,7 +355,7 @@ impl<'a> Default for &'a mut ByteStr {
 
 // Omitted due to slice-from-array-issue-113238:
 //
-// #[unstable(feature = "bstr", issue = "134915")]
+// #[unstable(feature = "byte_str", issue = "134915")]
 // impl<'a> From<&'a ByteStr> for &'a [u8] {
 //     #[inline]
 //     fn from(s: &'a ByteStr) -> Self {
@@ -363,7 +363,7 @@ impl<'a> Default for &'a mut ByteStr {
 //     }
 // }
 //
-// #[unstable(feature = "bstr", issue = "134915")]
+// #[unstable(feature = "byte_str", issue = "134915")]
 // impl<'a> From<&'a mut ByteStr> for &'a mut [u8] {
 //     #[inline]
 //     fn from(s: &'a mut ByteStr) -> Self {
@@ -373,7 +373,7 @@ impl<'a> Default for &'a mut ByteStr {
 
 // Omitted due to inference failures
 //
-// #[unstable(feature = "bstr", issue = "134915")]
+// #[unstable(feature = "byte_str", issue = "134915")]
 // impl<'a> From<&'a str> for &'a ByteStr {
 //     #[inline]
 //     fn from(s: &'a str) -> Self {
@@ -381,7 +381,7 @@ impl<'a> Default for &'a mut ByteStr {
 //     }
 // }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 #[rustc_const_unstable(feature = "const_convert", issue = "143773")]
 const impl<'a> TryFrom<&'a ByteStr> for &'a str {
     type Error = crate::str::Utf8Error;
@@ -392,7 +392,7 @@ const impl<'a> TryFrom<&'a ByteStr> for &'a str {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 #[rustc_const_unstable(feature = "const_convert", issue = "143773")]
 const impl<'a> TryFrom<&'a mut ByteStr> for &'a mut str {
     type Error = crate::str::Utf8Error;

--- a/library/core/src/byte_str/mod.rs
+++ b/library/core/src/byte_str/mod.rs
@@ -7,7 +7,9 @@ pub use traits::{impl_partial_eq, impl_partial_eq_n, impl_partial_eq_ord};
 
 use crate::borrow::{Borrow, BorrowMut};
 use crate::fmt::{self, Alignment};
+use crate::marker::Destruct;
 use crate::ops::{Deref, DerefMut, DerefPure};
+use crate::str;
 
 /// A wrapper for `&[u8]` representing a human-readable string that's conventionally, but not
 /// always, UTF-8.
@@ -41,7 +43,7 @@ use crate::ops::{Deref, DerefMut, DerefPure};
 #[rustc_has_incoherent_inherent_impls]
 #[repr(transparent)]
 #[doc(alias = "BStr")]
-pub struct ByteStr(pub [u8]);
+pub struct ByteStr(pub(crate) [u8]);
 
 impl ByteStr {
     /// Creates a `ByteStr` slice from anything that can be converted to a byte slice.
@@ -69,6 +71,36 @@ impl ByteStr {
         ByteStr::from_bytes(bytes.as_ref())
     }
 
+    /// Creates a mutable `ByteStr` slice from anything that can be converted to a mutable byte slice.
+    ///
+    /// This is a zero-cost conversion.
+    ///
+    /// # Example
+    ///
+    /// Unlike `str`, the raw bytes of a `ByteStr` can be safely mutated at any time, since the
+    /// result is not guaranteed to be valid UTF-8.
+    ///
+    /// ```
+    /// #![feature(byte_str)]
+    /// use std::byte_str::ByteStr;
+    ///
+    /// let mut buf = "😀".to_string().into_bytes().into_byte_string();
+    /// assert_eq!(format!("{buf}"), "😀");
+    ///
+    /// let s = ByteStr::new_mut(&mut buf);
+    /// s.as_bytes_mut().reverse();
+    /// s[1] = b':';
+    /// s[2] = b'(';
+    ///
+    /// assert_eq!(format!("{buf}"), "�:(�");
+    /// ```
+    #[inline]
+    #[unstable(feature = "byte_str", issue = "134915")]
+    #[rustc_const_unstable(feature = "const_convert", issue = "143773")]
+    pub const fn new_mut<B: ?Sized + [const] AsMut<[u8]>>(bytes: &mut B) -> &mut Self {
+        ByteStr::from_bytes_mut(bytes.as_mut())
+    }
+
     /// Returns the same string as `&ByteStr`.
     ///
     /// This method is redundant when used directly on `&ByteStr`, but
@@ -93,40 +125,235 @@ impl ByteStr {
         self
     }
 
-    #[doc(hidden)]
-    #[unstable(feature = "byte_str_internals", issue = "none")]
     #[inline]
-    #[rustc_const_unstable(feature = "byte_str_internals", issue = "none")]
-    pub const fn from_bytes(slice: &[u8]) -> &Self {
+    pub(crate) const fn from_bytes(slice: &[u8]) -> &Self {
         // SAFETY: `ByteStr` is a transparent wrapper around `[u8]`, so we can turn a reference to
         // the wrapped type into a reference to the wrapper type.
         unsafe { &*(slice as *const [u8] as *const Self) }
     }
 
-    #[doc(hidden)]
-    #[unstable(feature = "byte_str_internals", issue = "none")]
     #[inline]
-    #[rustc_const_unstable(feature = "byte_str_internals", issue = "none")]
-    pub const fn from_bytes_mut(slice: &mut [u8]) -> &mut Self {
+    pub(crate) const fn from_bytes_mut(slice: &mut [u8]) -> &mut Self {
         // SAFETY: `ByteStr` is a transparent wrapper around `[u8]`, so we can turn a reference to
         // the wrapped type into a reference to the wrapper type.
         unsafe { &mut *(slice as *mut [u8] as *mut Self) }
     }
 
-    #[doc(hidden)]
-    #[unstable(feature = "byte_str_internals", issue = "none")]
+    /// Converts a `ByteStr` slice to a byte slice. To convert the byte slice back into a byte string
+    /// slice, use [`ByteStr::new`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(byte_str)]
+    /// use std::byte_str::ByteStr;
+    ///
+    /// let s = ByteStr::new("bors");
+    /// let bytes = s.as_bytes();
+    /// assert_eq!(b"bors", bytes);
+    /// ```
+    #[unstable(feature = "byte_str", issue = "134915")]
     #[inline]
-    #[rustc_const_unstable(feature = "byte_str_internals", issue = "none")]
+    #[rustc_const_unstable(feature = "byte_str", issue = "134915")]
     pub const fn as_bytes(&self) -> &[u8] {
         &self.0
     }
 
-    #[doc(hidden)]
-    #[unstable(feature = "byte_str_internals", issue = "none")]
+    /// Converts a mutable `ByteStr` slice to a mutable byte slice.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// #![feature(byte_str)]
+    /// use std::byte_str::ByteStr;
+    ///
+    /// let mut s = ByteStr::new("Hello").to_byte_string();
+    /// let bytes = s.as_bytes_mut();
+    /// assert_eq!(b"Hello", bytes);
+    /// ```
+    ///
+    /// Mutability:
+    ///
+    /// ```
+    /// #![feature(byte_str)]
+    /// use std::byte_str::ByteStr;
+    ///
+    /// let mut s = ByteStr::new("🗻∈🌏").to_byte_string();
+    /// let bytes = s.as_bytes_mut();
+    ///
+    /// bytes[0] = 0xF0;
+    /// bytes[1] = 0x9F;
+    /// bytes[2] = 0x8D;
+    /// bytes[3] = 0x94;
+    ///
+    /// assert_eq!("🍔∈🌏", s);
+    /// ```
+    #[unstable(feature = "byte_str", issue = "134915")]
     #[inline]
-    #[rustc_const_unstable(feature = "byte_str_internals", issue = "none")]
+    #[rustc_const_unstable(feature = "byte_str", issue = "134915")]
     pub const fn as_bytes_mut(&mut self) -> &mut [u8] {
         &mut self.0
+    }
+
+    /// Yields a <code>&[prim@str]</code> slice if the `ByteStr` is valid unicode.
+    ///
+    /// This conversion may entail a check for UTF-8 validity.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(byte_str)]
+    /// use std::byte_str::ByteStr;
+    ///
+    /// let byte_str = ByteStr::new("foo");
+    /// assert_eq!(byte_str.to_str(), Some("foo"));
+    /// ```
+    #[unstable(feature = "byte_str", issue = "134915")]
+    #[inline]
+    #[rustc_const_unstable(feature = "byte_str", issue = "134915")]
+    pub const fn to_str(&self) -> Option<&str> {
+        str::from_utf8(&self.0).ok()
+    }
+
+    /// Checks whether the `ByteStr` is empty.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(byte_str)]
+    /// use std::byte_str::ByteStr;
+    ///
+    /// let byte_str = ByteStr::new("");
+    /// assert!(byte_str.is_empty());
+    ///
+    /// let byte_str = ByteStr::new("foo");
+    /// assert!(!byte_str.is_empty());
+    /// ```
+    #[unstable(feature = "byte_str", issue = "134915")]
+    #[inline]
+    #[rustc_const_unstable(feature = "byte_str", issue = "134915")]
+    pub const fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Returns the length of this `ByteStr` in bytes.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(byte_str)]
+    /// use std::byte_str::ByteStr;
+    ///
+    /// let byte_str = ByteStr::new("");
+    /// assert_eq!(byte_str.len(), 0);
+    ///
+    /// let byte_str = ByteStr::new("foo");
+    /// assert_eq!(byte_str.len(), 3);
+    /// ```
+    #[unstable(feature = "byte_str", issue = "134915")]
+    #[inline]
+    #[rustc_const_unstable(feature = "byte_str", issue = "134915")]
+    pub const fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Checks if all bytes in this byte string are within the ASCII range.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(byte_str)]
+    /// use std::byte_str::ByteStr;
+    ///
+    /// let ascii = ByteStr::new("hello!\n");
+    /// let non_ascii = ByteStr::new("Grüße, Jürgen ❤");
+    ///
+    /// assert!(ascii.is_ascii());
+    /// assert!(!non_ascii.is_ascii());
+    /// ```
+    #[unstable(feature = "byte_str", issue = "134915")]
+    #[inline]
+    #[rustc_const_unstable(feature = "byte_str", issue = "134915")]
+    pub const fn is_ascii(&self) -> bool {
+        self.0.is_ascii()
+    }
+
+    /// Converts this byte string to its ASCII lower case equivalent in-place.
+    ///
+    /// ASCII letters ‘A’ to ‘Z’ are mapped to ‘a’ to ‘z’, but non-ASCII letters are unchanged.
+    /// To return a new lowercased value without modifying the existing one, use
+    /// `ByteStr::to_ascii_lowercase`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(byte_str)]
+    /// use std::byte_str::ByteStr;
+    ///
+    /// let mut s = ByteStr::new("GRÜßE, JÜRGEN ❤").to_byte_string();
+    ///
+    /// s.make_ascii_lowercase();
+    ///
+    /// assert_eq!("grÜße, jÜrgen ❤", s);
+    /// ```
+    #[unstable(feature = "byte_str", issue = "134915")]
+    #[inline]
+    #[rustc_const_unstable(feature = "byte_str", issue = "134915")]
+    pub const fn make_ascii_lowercase(&mut self) {
+        self.0.make_ascii_lowercase()
+    }
+
+    /// Converts this byte string to its ASCII upper case equivalent in-place.
+    ///
+    /// ASCII letters ‘A’ to ‘Z’ are mapped to ‘a’ to ‘z’, but non-ASCII letters are unchanged.
+    /// To return a new uppercased value without modifying the existing one, use
+    /// `ByteStr::to_ascii_uppercase`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(byte_str)]
+    /// use std::byte_str::ByteStr;
+    ///
+    /// let mut s = ByteStr::new("Grüße, Jürgen ❤").to_byte_string();
+    ///
+    /// s.make_ascii_uppercase();
+    ///
+    /// assert_eq!("GRüßE, JüRGEN ❤", s);
+    /// ```
+    #[unstable(feature = "byte_str", issue = "134915")]
+    #[inline]
+    #[rustc_const_unstable(feature = "byte_str", issue = "134915")]
+    pub const fn make_ascii_uppercase(&mut self) {
+        self.0.make_ascii_uppercase()
+    }
+
+    /// Checks if two byte strings are an ASCII case-insensitive match.
+    ///
+    /// Same as `to_ascii_lowercase(a) == to_ascii_lowercase(b)`, but without allocating and copying
+    /// temporaries.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(byte_str)]
+    /// use std::byte_str::ByteStr;
+    ///
+    /// assert!(ByteStr::new("Ferris").eq_ignore_ascii_case("FERRIS"));
+    /// assert!(ByteStr::new("Ferrös").eq_ignore_ascii_case("FERRöS"));
+    /// assert!(!ByteStr::new("Ferrös").eq_ignore_ascii_case("FERRÖS"));
+    /// ```
+    #[unstable(feature = "byte_str", issue = "134915")]
+    #[inline]
+    #[rustc_const_unstable(feature = "byte_str", issue = "134915")]
+    pub const fn eq_ignore_ascii_case<S: [const] AsRef<ByteStr> + [const] Destruct>(
+        &self,
+        other: S,
+    ) -> bool {
+        let other: &ByteStr = other.as_ref();
+        self.0.eq_ignore_ascii_case(&other.0)
     }
 }
 
@@ -157,7 +384,7 @@ unsafe impl DerefPure for ByteStr {}
 impl fmt::Debug for ByteStr {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "\"")?;
-        for chunk in self.utf8_chunks() {
+        for chunk in self.0.utf8_chunks() {
             for c in chunk.valid().chars() {
                 match c {
                     '\0' => write!(f, "\\0")?,
@@ -176,7 +403,7 @@ impl fmt::Debug for ByteStr {
 impl fmt::Display for ByteStr {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fn emit(byte_str: &ByteStr, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            for chunk in byte_str.utf8_chunks() {
+            for chunk in byte_str.0.utf8_chunks() {
                 f.write_str(chunk.valid())?;
                 if !chunk.invalid().is_empty() {
                     f.write_str("\u{FFFD}")?;
@@ -388,7 +615,7 @@ const impl<'a> TryFrom<&'a ByteStr> for &'a str {
 
     #[inline]
     fn try_from(s: &'a ByteStr) -> Result<Self, Self::Error> {
-        crate::str::from_utf8(&s.0)
+        str::from_utf8(&s.0)
     }
 }
 
@@ -399,6 +626,6 @@ const impl<'a> TryFrom<&'a mut ByteStr> for &'a mut str {
 
     #[inline]
     fn try_from(s: &'a mut ByteStr) -> Result<Self, Self::Error> {
-        crate::str::from_utf8_mut(&mut s.0)
+        str::from_utf8_mut(&mut s.0)
     }
 }

--- a/library/core/src/byte_str/traits.rs
+++ b/library/core/src/byte_str/traits.rs
@@ -1,11 +1,11 @@
 //! Trait implementations for `ByteStr`.
 
-use crate::bstr::ByteStr;
+use crate::byte_str::ByteStr;
 use crate::cmp::Ordering;
 use crate::slice::SliceIndex;
 use crate::{hash, ops, range};
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl Ord for ByteStr {
     #[inline]
     fn cmp(&self, other: &ByteStr) -> Ordering {
@@ -13,7 +13,7 @@ impl Ord for ByteStr {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl PartialOrd for ByteStr {
     #[inline]
     fn partial_cmp(&self, other: &ByteStr) -> Option<Ordering> {
@@ -21,7 +21,7 @@ impl PartialOrd for ByteStr {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl PartialEq<ByteStr> for ByteStr {
     #[inline]
     fn eq(&self, other: &ByteStr) -> bool {
@@ -29,10 +29,10 @@ impl PartialEq<ByteStr> for ByteStr {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl Eq for ByteStr {}
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl hash::Hash for ByteStr {
     #[inline]
     fn hash<H: hash::Hasher>(&self, state: &mut H) {
@@ -42,7 +42,7 @@ impl hash::Hash for ByteStr {
 
 #[doc(hidden)]
 #[macro_export]
-#[unstable(feature = "bstr_internals", issue = "none")]
+#[unstable(feature = "byte_str_internals", issue = "none")]
 macro_rules! impl_partial_eq {
     ($lhs:ty, $rhs:ty) => {
         impl PartialEq<$rhs> for $lhs {
@@ -64,17 +64,17 @@ macro_rules! impl_partial_eq {
 }
 
 #[doc(hidden)]
-#[unstable(feature = "bstr_internals", issue = "none")]
+#[unstable(feature = "byte_str_internals", issue = "none")]
 pub use impl_partial_eq;
 
 #[doc(hidden)]
 #[macro_export]
-#[unstable(feature = "bstr_internals", issue = "none")]
+#[unstable(feature = "byte_str_internals", issue = "none")]
 macro_rules! impl_partial_eq_ord {
     ($lhs:ty, $rhs:ty) => {
-        $crate::bstr::impl_partial_eq!($lhs, $rhs);
+        $crate::byte_str::impl_partial_eq!($lhs, $rhs);
 
-        #[unstable(feature = "bstr", issue = "134915")]
+        #[unstable(feature = "byte_str", issue = "134915")]
         impl PartialOrd<$rhs> for $lhs {
             #[inline]
             fn partial_cmp(&self, other: &$rhs) -> Option<Ordering> {
@@ -83,7 +83,7 @@ macro_rules! impl_partial_eq_ord {
             }
         }
 
-        #[unstable(feature = "bstr", issue = "134915")]
+        #[unstable(feature = "byte_str", issue = "134915")]
         impl PartialOrd<$lhs> for $rhs {
             #[inline]
             fn partial_cmp(&self, other: &$lhs) -> Option<Ordering> {
@@ -95,15 +95,15 @@ macro_rules! impl_partial_eq_ord {
 }
 
 #[doc(hidden)]
-#[unstable(feature = "bstr_internals", issue = "none")]
+#[unstable(feature = "byte_str_internals", issue = "none")]
 pub use impl_partial_eq_ord;
 
 #[doc(hidden)]
 #[macro_export]
-#[unstable(feature = "bstr_internals", issue = "none")]
+#[unstable(feature = "byte_str_internals", issue = "none")]
 macro_rules! impl_partial_eq_n {
     ($lhs:ty, $rhs:ty) => {
-        #[unstable(feature = "bstr", issue = "134915")]
+        #[unstable(feature = "byte_str", issue = "134915")]
         impl<const N: usize> PartialEq<$rhs> for $lhs {
             #[inline]
             fn eq(&self, other: &$rhs) -> bool {
@@ -112,7 +112,7 @@ macro_rules! impl_partial_eq_n {
             }
         }
 
-        #[unstable(feature = "bstr", issue = "134915")]
+        #[unstable(feature = "byte_str", issue = "134915")]
         impl<const N: usize> PartialEq<$lhs> for $rhs {
             #[inline]
             fn eq(&self, other: &$lhs) -> bool {
@@ -124,7 +124,7 @@ macro_rules! impl_partial_eq_n {
 }
 
 #[doc(hidden)]
-#[unstable(feature = "bstr_internals", issue = "none")]
+#[unstable(feature = "byte_str_internals", issue = "none")]
 pub use impl_partial_eq_n;
 
 // PartialOrd with `[u8]` omitted to avoid inference failures
@@ -140,7 +140,7 @@ impl_partial_eq_n!(ByteStr, [u8; N]);
 // PartialOrd with `[u8; N]` omitted to avoid inference failures
 impl_partial_eq_n!(ByteStr, &[u8; N]);
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl<I> ops::Index<I> for ByteStr
 where
     I: SliceIndex<ByteStr>,
@@ -153,7 +153,7 @@ where
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl<I> ops::IndexMut<I> for ByteStr
 where
     I: SliceIndex<ByteStr>,
@@ -164,7 +164,7 @@ where
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 unsafe impl SliceIndex<ByteStr> for ops::RangeFull {
     type Output = ByteStr;
     #[inline]
@@ -193,7 +193,7 @@ unsafe impl SliceIndex<ByteStr> for ops::RangeFull {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 unsafe impl SliceIndex<ByteStr> for usize {
     type Output = u8;
     #[inline]
@@ -226,7 +226,7 @@ unsafe impl SliceIndex<ByteStr> for usize {
 
 macro_rules! impl_slice_index {
     ($index:ty) => {
-        #[unstable(feature = "bstr", issue = "134915")]
+        #[unstable(feature = "byte_str", issue = "134915")]
         unsafe impl SliceIndex<ByteStr> for $index {
             type Output = ByteStr;
             #[inline]

--- a/library/core/src/clone.rs
+++ b/library/core/src/clone.rs
@@ -686,8 +686,8 @@ unsafe impl CloneToUninit for crate::ffi::CStr {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
-unsafe impl CloneToUninit for crate::bstr::ByteStr {
+#[unstable(feature = "byte_str", issue = "134915")]
+unsafe impl CloneToUninit for crate::byte_str::ByteStr {
     #[inline]
     #[cfg_attr(debug_assertions, track_caller)]
     unsafe fn clone_to_uninit(&self, dst: *mut u8) {

--- a/library/core/src/ffi/c_str.rs
+++ b/library/core/src/ffi/c_str.rs
@@ -171,7 +171,7 @@ impl fmt::Display for FromBytesUntilNulError {
 #[stable(feature = "cstr_debug", since = "1.3.0")]
 impl fmt::Debug for CStr {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Debug::fmt(crate::bstr::ByteStr::from_bytes(self.to_bytes()), f)
+        fmt::Debug::fmt(crate::byte_str::ByteStr::from_bytes(self.to_bytes()), f)
     }
 }
 
@@ -652,7 +652,7 @@ impl CStr {
                   it returns an object that can be displayed"]
     #[inline]
     pub fn display(&self) -> impl fmt::Display {
-        crate::bstr::ByteStr::from_bytes(self.to_bytes())
+        crate::byte_str::ByteStr::from_bytes(self.to_bytes())
     }
 
     /// Returns the same string as a string slice `&CStr`.

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -86,7 +86,7 @@
 // Library features:
 // tidy-alphabetical-start
 #![feature(asm_experimental_arch)]
-#![feature(bstr_internals)]
+#![feature(byte_str_internals)]
 #![feature(cfg_target_has_reliable_f16_f128)]
 #![feature(const_carrying_mul_add)]
 #![feature(const_cmp)]
@@ -292,8 +292,8 @@ pub mod ascii;
 pub mod asserting;
 #[unstable(feature = "async_iterator", issue = "79024")]
 pub mod async_iter;
-#[unstable(feature = "bstr", issue = "134915")]
-pub mod bstr;
+#[unstable(feature = "byte_str", issue = "134915")]
+pub mod byte_str;
 pub mod cell;
 pub mod char;
 pub mod ffi;

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -6,6 +6,7 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
+use crate::bstr::ByteStr;
 use crate::clone::TrivialClone;
 use crate::cmp::Ordering::{self, Equal, Greater, Less};
 use crate::intrinsics::{exact_div, unchecked_sub};
@@ -4905,6 +4906,24 @@ impl<T> [T] {
         let end = start.wrapping_add(subslice.len());
 
         if start <= self.len() && end <= self.len() { Some(start..end) } else { None }
+    }
+}
+
+impl [u8] {
+    /// Casts a byte slice as a byte string.
+    #[unstable(feature = "bstr", issue = "134915")]
+    #[inline]
+    #[rustc_const_unstable(feature = "bstr", issue = "134915")]
+    pub const fn as_byte_str(&self) -> &ByteStr {
+        ByteStr::from_bytes(self)
+    }
+
+    /// Casts a mutable byte slice as a byte string.
+    #[unstable(feature = "bstr", issue = "134915")]
+    #[inline]
+    #[rustc_const_unstable(feature = "bstr", issue = "134915")]
+    pub const fn as_mut_byte_str(&mut self) -> &mut ByteStr {
+        ByteStr::from_bytes_mut(self)
     }
 }
 

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -6,6 +6,7 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
+use crate::byte_str::ByteStr;
 use crate::clone::TrivialClone;
 use crate::cmp::Ordering::{self, Equal, Greater, Less};
 use crate::intrinsics::{exact_div, unchecked_sub};
@@ -5377,6 +5378,24 @@ impl<T> [T] {
     #[unstable(feature = "str_as_str", issue = "130366")]
     pub const fn as_mut_slice(&mut self) -> &mut [T] {
         self
+    }
+}
+
+impl [u8] {
+    /// Casts a byte slice as a byte string.
+    #[unstable(feature = "byte_str", issue = "134915")]
+    #[inline]
+    #[rustc_const_unstable(feature = "byte_str", issue = "134915")]
+    pub const fn as_byte_str(&self) -> &ByteStr {
+        ByteStr::from_bytes(self)
+    }
+
+    /// Casts a mutable byte slice as a byte string.
+    #[unstable(feature = "byte_str", issue = "134915")]
+    #[inline]
+    #[rustc_const_unstable(feature = "byte_str", issue = "134915")]
+    pub const fn as_mut_byte_str(&mut self) -> &mut ByteStr {
+        ByteStr::from_bytes_mut(self)
     }
 }
 

--- a/library/coretests/tests/byte_str.rs
+++ b/library/coretests/tests/byte_str.rs
@@ -1,21 +1,17 @@
-use alloc::bstr::ByteString;
-use core::assert_matches;
+use core::byte_str::ByteStr;
 
 #[test]
 fn test_debug() {
-    let b1 = ByteString(
-        b"\0\x01\x02\x03\x04\x05\x06\x07\x08\t\n\x11\x12\r\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f \x7f\x80\x81\xfe\xff".to_vec()
-    );
     assert_eq!(
         r#""\0\x01\x02\x03\x04\x05\x06\x07\x08\t\n\x11\x12\r\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f \x7f\x80\x81\xfe\xff""#,
-        format!("{:?}", b1),
+        format!("{:?}", ByteStr::new(b"\0\x01\x02\x03\x04\x05\x06\x07\x08\t\n\x11\x12\r\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f \x7f\x80\x81\xfe\xff")),
     );
 }
 
 #[test]
 fn test_display() {
-    let b1 = ByteString(b"abc".to_vec());
-    let b2 = ByteString(b"\xf0\x28\x8c\xbc".to_vec());
+    let b1 = ByteStr::new("abc");
+    let b2 = ByteStr::new(b"\xf0\x28\x8c\xbc");
 
     assert_eq!(&format!("{b1}"), "abc");
     assert_eq!(&format!("{b2}"), "�(��");
@@ -68,17 +64,4 @@ fn test_display() {
     assert_eq!(&format!("{b2:-<6.3}!"), "�(�---!");
     assert_eq!(&format!("{b2:-^6.3}!"), "-�(�--!");
     assert_eq!(&format!("{b2:->6.3}!"), "---�(�!");
-}
-
-#[test]
-fn test_to_string() {
-    let b1 = ByteString(b"abc".to_vec());
-    let b2 = ByteString(b"\xf0\x28\x8c\xbc".to_vec());
-
-    assert_eq!(Ok("abc".to_string()), b1.to_string());
-    assert_matches!(b2.to_string(), Err(core::str::Utf8Error { .. }));
-
-    // Can still directly use the trait
-    assert_eq!("abc".to_string(), ToString::to_string(&b1));
-    assert_eq!("�(��".to_string(), ToString::to_string(&b2));
 }

--- a/library/coretests/tests/lib.rs
+++ b/library/coretests/tests/lib.rs
@@ -9,7 +9,7 @@
 #![feature(async_iter_from_iter)]
 #![feature(async_iterator)]
 #![feature(borrowed_buf_init)]
-#![feature(bstr)]
+#![feature(byte_str)]
 #![feature(casefold)]
 #![feature(cfg_overflow_checks)]
 #![feature(cfg_target_has_reliable_f16_f128)]
@@ -177,7 +177,7 @@ mod asserting;
 mod async_iter;
 mod atomic;
 mod bool;
-mod bstr;
+mod byte_str;
 mod cell;
 mod char;
 mod clone;

--- a/library/std/src/bstr.rs
+++ b/library/std/src/bstr.rs
@@ -1,4 +1,0 @@
-//! The `ByteStr` and `ByteString` types and trait implementations.
-
-#[unstable(feature = "bstr", issue = "134915")]
-pub use alloc::bstr::{ByteStr, ByteString};

--- a/library/std/src/byte_str.rs
+++ b/library/std/src/byte_str.rs
@@ -1,0 +1,4 @@
+//! The `ByteStr` and `ByteString` types and trait implementations.
+
+#[unstable(feature = "byte_str", issue = "134915")]
+pub use alloc::byte_str::{ByteStr, ByteString};

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -319,8 +319,8 @@
 // Library features (core):
 // tidy-alphabetical-start
 #![feature(borrowed_buf_init)]
-#![feature(bstr)]
-#![feature(bstr_internals)]
+#![feature(byte_str)]
+#![feature(byte_str_internals)]
 #![feature(c_size_t)]
 #![feature(can_vector)]
 #![feature(cast_maybe_uninit)]
@@ -628,8 +628,8 @@ pub mod f64;
 pub mod thread;
 pub mod ascii;
 pub mod backtrace;
-#[unstable(feature = "bstr", issue = "134915")]
-pub mod bstr;
+#[unstable(feature = "byte_str", issue = "134915")]
+pub mod byte_str;
 pub mod collections;
 pub mod env;
 pub mod error;

--- a/library/std/src/os/unix/net/addr.rs
+++ b/library/std/src/os/unix/net/addr.rs
@@ -246,7 +246,7 @@ impl SocketAddr {
         {
             AddressKind::Unnamed
         } else if self.addr.sun_path[0] == 0 {
-            AddressKind::Abstract(ByteStr::from_bytes(&path[1..len]))
+            AddressKind::Abstract(ByteStr::new(&path[1..len]))
         } else {
             AddressKind::Pathname(OsStr::from_bytes(&path[..len - 1]).as_ref())
         }

--- a/library/std/src/os/unix/net/addr.rs
+++ b/library/std/src/os/unix/net/addr.rs
@@ -260,7 +260,7 @@ impl SocketAddr {
         {
             AddressKind::Unnamed
         } else if self.addr.sun_path[0] == 0 {
-            AddressKind::Abstract(ByteStr::from_bytes(&path[1..len]))
+            AddressKind::Abstract(ByteStr::new(&path[1..len]))
         } else {
             // linux adds a trailing NUL and counts it in the length, freebsd, netbsd
             // and qnx do not, and a caller may bind(2) without one either. unix(7)

--- a/library/std/src/os/unix/net/addr.rs
+++ b/library/std/src/os/unix/net/addr.rs
@@ -1,4 +1,4 @@
-use crate::bstr::ByteStr;
+use crate::byte_str::ByteStr;
 use crate::ffi::OsStr;
 #[cfg(any(doc, target_os = "android", target_os = "linux", target_os = "cygwin"))]
 use crate::os::net::linux_ext;

--- a/library/std/src/os/windows/net/addr.rs
+++ b/library/std/src/os/windows/net/addr.rs
@@ -1,5 +1,5 @@
 #![unstable(feature = "windows_unix_domain_sockets", issue = "150487")]
-use crate::bstr::ByteStr;
+use crate::byte_str::ByteStr;
 use crate::ffi::OsStr;
 use crate::path::Path;
 #[cfg(not(doc))]

--- a/library/std/src/sys/os_str/bytes.rs
+++ b/library/std/src/sys/os_str/bytes.rs
@@ -4,7 +4,7 @@
 use core::clone::CloneToUninit;
 
 use crate::borrow::Cow;
-use crate::bstr::ByteStr;
+use crate::byte_str::ByteStr;
 use crate::collections::TryReserveError;
 use crate::rc::Rc;
 use crate::sync::Arc;

--- a/library/std/src/sys/platform_version/darwin/mod.rs
+++ b/library/std/src/sys/platform_version/darwin/mod.rs
@@ -3,7 +3,7 @@ use self::core_foundation::{
     kCFPropertyListImmutable, kCFStringEncodingUTF8,
 };
 use crate::borrow::Cow;
-use crate::bstr::ByteStr;
+use crate::byte_str::ByteStr;
 use crate::ffi::{CStr, c_char};
 use crate::num::{NonZero, ParseIntError};
 use crate::path::{Path, PathBuf};

--- a/tests/ui/associated-types/associated-types-in-ambiguous-context.stderr
+++ b/tests/ui/associated-types/associated-types-in-ambiguous-context.stderr
@@ -31,9 +31,6 @@ LL | type X = std::ops::Deref::Target;
 help: use fully-qualified syntax
    |
 LL - type X = std::ops::Deref::Target;
-LL + type X = <ByteStr as Deref>::Target;
-   |
-LL - type X = std::ops::Deref::Target;
 LL + type X = <ByteString as Deref>::Target;
    |
 LL - type X = std::ops::Deref::Target;
@@ -41,6 +38,9 @@ LL + type X = <CString as Deref>::Target;
    |
 LL - type X = std::ops::Deref::Target;
 LL + type X = <IoSlice<'_> as Deref>::Target;
+   |
+LL - type X = std::ops::Deref::Target;
+LL + type X = <IoSliceMut<'_> as Deref>::Target;
    |
    = and N other candidates
 

--- a/tests/ui/indexing/index-help.stderr
+++ b/tests/ui/indexing/index-help.stderr
@@ -9,7 +9,7 @@ help: `usize` implements trait `SliceIndex<T>`
   --> $SRC_DIR/core/src/slice/index.rs:LL:COL
    |
    = note: `SliceIndex<[T]>`
-  --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
+  --> $SRC_DIR/core/src/byte_str/traits.rs:LL:COL
    |
    = note: `SliceIndex<ByteStr>`
    = note: required for `Vec<{integer}>` to implement `Index<i32>`

--- a/tests/ui/indexing/indexing-integral-types.stderr
+++ b/tests/ui/indexing/indexing-integral-types.stderr
@@ -9,7 +9,7 @@ help: `usize` implements trait `SliceIndex<T>`
   --> $SRC_DIR/core/src/slice/index.rs:LL:COL
    |
    = note: `SliceIndex<[T]>`
-  --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
+  --> $SRC_DIR/core/src/byte_str/traits.rs:LL:COL
    |
    = note: `SliceIndex<ByteStr>`
    = note: required for `Vec<isize>` to implement `Index<u8>`
@@ -25,7 +25,7 @@ help: `usize` implements trait `SliceIndex<T>`
   --> $SRC_DIR/core/src/slice/index.rs:LL:COL
    |
    = note: `SliceIndex<[T]>`
-  --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
+  --> $SRC_DIR/core/src/byte_str/traits.rs:LL:COL
    |
    = note: `SliceIndex<ByteStr>`
    = note: required for `Vec<isize>` to implement `Index<i8>`
@@ -41,7 +41,7 @@ help: `usize` implements trait `SliceIndex<T>`
   --> $SRC_DIR/core/src/slice/index.rs:LL:COL
    |
    = note: `SliceIndex<[T]>`
-  --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
+  --> $SRC_DIR/core/src/byte_str/traits.rs:LL:COL
    |
    = note: `SliceIndex<ByteStr>`
    = note: required for `Vec<isize>` to implement `Index<u32>`
@@ -57,7 +57,7 @@ help: `usize` implements trait `SliceIndex<T>`
   --> $SRC_DIR/core/src/slice/index.rs:LL:COL
    |
    = note: `SliceIndex<[T]>`
-  --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
+  --> $SRC_DIR/core/src/byte_str/traits.rs:LL:COL
    |
    = note: `SliceIndex<ByteStr>`
    = note: required for `Vec<isize>` to implement `Index<i32>`
@@ -73,7 +73,7 @@ help: `usize` implements trait `SliceIndex<T>`
   --> $SRC_DIR/core/src/slice/index.rs:LL:COL
    |
    = note: `SliceIndex<[T]>`
-  --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
+  --> $SRC_DIR/core/src/byte_str/traits.rs:LL:COL
    |
    = note: `SliceIndex<ByteStr>`
    = note: required for `[u8]` to implement `Index<u8>`
@@ -89,7 +89,7 @@ help: `usize` implements trait `SliceIndex<T>`
   --> $SRC_DIR/core/src/slice/index.rs:LL:COL
    |
    = note: `SliceIndex<[T]>`
-  --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
+  --> $SRC_DIR/core/src/byte_str/traits.rs:LL:COL
    |
    = note: `SliceIndex<ByteStr>`
    = note: required for `[u8]` to implement `Index<i8>`
@@ -105,7 +105,7 @@ help: `usize` implements trait `SliceIndex<T>`
   --> $SRC_DIR/core/src/slice/index.rs:LL:COL
    |
    = note: `SliceIndex<[T]>`
-  --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
+  --> $SRC_DIR/core/src/byte_str/traits.rs:LL:COL
    |
    = note: `SliceIndex<ByteStr>`
    = note: required for `[u8]` to implement `Index<u32>`
@@ -121,7 +121,7 @@ help: `usize` implements trait `SliceIndex<T>`
   --> $SRC_DIR/core/src/slice/index.rs:LL:COL
    |
    = note: `SliceIndex<[T]>`
-  --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
+  --> $SRC_DIR/core/src/byte_str/traits.rs:LL:COL
    |
    = note: `SliceIndex<ByteStr>`
    = note: required for `[u8]` to implement `Index<i32>`

--- a/tests/ui/indexing/indexing-requires-a-uint.stderr
+++ b/tests/ui/indexing/indexing-requires-a-uint.stderr
@@ -9,7 +9,7 @@ help: `usize` implements trait `SliceIndex<T>`
   --> $SRC_DIR/core/src/slice/index.rs:LL:COL
    |
    = note: `SliceIndex<[T]>`
-  --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
+  --> $SRC_DIR/core/src/byte_str/traits.rs:LL:COL
    |
    = note: `SliceIndex<ByteStr>`
    = note: required for `[{integer}]` to implement `Index<u8>`

--- a/tests/ui/on-unimplemented/slice-index.stderr
+++ b/tests/ui/on-unimplemented/slice-index.stderr
@@ -9,7 +9,7 @@ help: `usize` implements trait `SliceIndex<T>`
   --> $SRC_DIR/core/src/slice/index.rs:LL:COL
    |
    = note: `SliceIndex<[T]>`
-  --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
+  --> $SRC_DIR/core/src/byte_str/traits.rs:LL:COL
    |
    = note: `SliceIndex<ByteStr>`
    = note: required for `[i32]` to implement `Index<i32>`
@@ -25,10 +25,10 @@ help: `RangeTo<usize>` implements trait `SliceIndex<T>`
   --> $SRC_DIR/core/src/slice/index.rs:LL:COL
    |
    = note: `SliceIndex<[T]>`
-  --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
+  --> $SRC_DIR/core/src/byte_str/traits.rs:LL:COL
    |
    = note: `SliceIndex<ByteStr>`
-  ::: $SRC_DIR/core/src/bstr/traits.rs:LL:COL
+  ::: $SRC_DIR/core/src/byte_str/traits.rs:LL:COL
    |
    = note: in this macro invocation
   --> $SRC_DIR/core/src/str/traits.rs:LL:COL

--- a/tests/ui/str/str-idx.stderr
+++ b/tests/ui/str/str-idx.stderr
@@ -11,7 +11,7 @@ help: `usize` implements trait `SliceIndex<T>`
   --> $SRC_DIR/core/src/slice/index.rs:LL:COL
    |
    = note: `SliceIndex<[T]>`
-  --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
+  --> $SRC_DIR/core/src/byte_str/traits.rs:LL:COL
    |
    = note: `SliceIndex<ByteStr>`
    = note: required for `str` to implement `Index<{integer}>`
@@ -31,7 +31,7 @@ help: `usize` implements trait `SliceIndex<T>`
   --> $SRC_DIR/core/src/slice/index.rs:LL:COL
    |
    = note: `SliceIndex<[T]>`
-  --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
+  --> $SRC_DIR/core/src/byte_str/traits.rs:LL:COL
    |
    = note: `SliceIndex<ByteStr>`
 note: required by a bound in `core::str::<impl str>::get`
@@ -52,7 +52,7 @@ help: `usize` implements trait `SliceIndex<T>`
   --> $SRC_DIR/core/src/slice/index.rs:LL:COL
    |
    = note: `SliceIndex<[T]>`
-  --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
+  --> $SRC_DIR/core/src/byte_str/traits.rs:LL:COL
    |
    = note: `SliceIndex<ByteStr>`
 note: required by a bound in `core::str::<impl str>::get_unchecked`

--- a/tests/ui/str/str-mut-idx.stderr
+++ b/tests/ui/str/str-mut-idx.stderr
@@ -35,7 +35,7 @@ help: `usize` implements trait `SliceIndex<T>`
   --> $SRC_DIR/core/src/slice/index.rs:LL:COL
    |
    = note: `SliceIndex<[T]>`
-  --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
+  --> $SRC_DIR/core/src/byte_str/traits.rs:LL:COL
    |
    = note: `SliceIndex<ByteStr>`
    = note: required for `str` to implement `Index<usize>`
@@ -55,7 +55,7 @@ help: `usize` implements trait `SliceIndex<T>`
   --> $SRC_DIR/core/src/slice/index.rs:LL:COL
    |
    = note: `SliceIndex<[T]>`
-  --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
+  --> $SRC_DIR/core/src/byte_str/traits.rs:LL:COL
    |
    = note: `SliceIndex<ByteStr>`
 note: required by a bound in `core::str::<impl str>::get_mut`
@@ -76,7 +76,7 @@ help: `usize` implements trait `SliceIndex<T>`
   --> $SRC_DIR/core/src/slice/index.rs:LL:COL
    |
    = note: `SliceIndex<[T]>`
-  --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
+  --> $SRC_DIR/core/src/byte_str/traits.rs:LL:COL
    |
    = note: `SliceIndex<ByteStr>`
 note: required by a bound in `core::str::<impl str>::get_unchecked_mut`

--- a/tests/ui/suggestions/suggest-dereferencing-index.stderr
+++ b/tests/ui/suggestions/suggest-dereferencing-index.stderr
@@ -9,7 +9,7 @@ help: `usize` implements trait `SliceIndex<T>`
   --> $SRC_DIR/core/src/slice/index.rs:LL:COL
    |
    = note: `SliceIndex<[T]>`
-  --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
+  --> $SRC_DIR/core/src/byte_str/traits.rs:LL:COL
    |
    = note: `SliceIndex<ByteStr>`
    = note: required for `[{integer}]` to implement `Index<&usize>`


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/146219)*
<!-- homu-ignore:end -->

This attempts to resolve the issues I brought up in the tracking issue (rust-lang/rust#134915) a few weeks ago by making `ByteStr` and `ByteString` into "more opaque" wrapper types like `OsStr` and `OsString`. I decided to put together a set of methods that are mostly drawn from `OsStr` and `OsString`, but include a few extras. I originally asked if an ACP would be required to do this, but without a response from libs-api and reasonable support from passers-by, I'm just making a PR instead.

The main issue with `ByteStr` is that it's not a "real" string type: they're just wrappers over `[u8]` and `Vec<u8>` with barely any methods of their own, relying instead on `Deref` impls. The inability to move out of deref here prevents methods like `Vec::leak` from being used without much effort, and the fact that the two types aren't linked via `Deref` means that any extra methods added to `ByteStr` would have to be added to `ByteString` too.

The new wrapper types act more in line with a "real" string type while still allowing easy access to the underlying `[u8]` and `Vec<u8>` without any complaining. In particular, this means that `ByteString` has an `as_mut_vec` method that can be executed safely (unlike `String::as_mut_vec`) and `ByteStr` has an `as_bytes_mut` method that can be executed safely. Any methods added to `ByteStr` can be accessed directly by `ByteString` due to the deref implementation, avoiding the need to add new methods to both types.

Note that these changes parallel `OsStr` and `OsString` for a reason: I was hoping to update `OsStr` and `OsString` to internally use these types on non-Windows targets. This feels like an obvious case where these types would be useful, and considering how I totally failed due to the issues I mentioned, I decided to at least start with what would be necessary to achieve that and we can build from there.

While the trait implementations remain untouched (except `Deref`, which now follows `ByteString -> ByteStr`), here is the new set of inherent methods added:

```rust
impl ByteStr {
    // constructors based on `OsStr`, but with new mutable version
    pub const fn new<S: ?Sized + [const] AsRef<ByteStr>>(bytes: &S) -> &ByteStr;
    pub const fn new_mut<S: ?Sized + [const] AsMut<ByteStr>>(bytes: &mut S) -> &mut ByteStr;

    // mirrors `OsStr` methods
    pub const fn is_empty(&self) -> bool;
    pub const fn len(&self) -> usize;
    pub const fn is_ascii(&self) -> bool;
    pub const fn make_ascii_lowercase(&mut self);
    pub const fn make_ascii_uppercase(&mut self);
    pub const fn eq_ignore_ascii_case<S: [const] AsRef<ByteStr> + [const] Destruct>(&self, other: S) -> bool;
    pub fn to_string_lossy(&self) -> Cow<'_, str>;
    pub fn to_byte_string(&self) -> ByteString;
    pub fn to_ascii_lowercase(&self) -> ByteString;
    pub fn to_ascii_uppercase(&self) -> ByteString;
    pub fn into_byte_string(self: Box<ByteStr>) -> ByteString;

    // mirrors `str` methods, but more safe due to invariant differences
    pub const fn as_bytes(&self) -> &[u8];
    pub const fn as_bytes_mut(&mut self) -> &mut [u8];
    pub fn into_boxed_bytes(self: Box<ByteStr>) -> Box<[u8]>;
}

impl ByteString {
    // mirrors `Vec` methods on `OsString`
    pub const fn new() -> ByteString;
    pub fn with_capacity(capacity: usize) -> ByteString;
    pub fn clear(&mut self);
    pub fn capacity(&self) -> usize;
    pub fn reserve(&mut self, additional: usize);
    pub fn try_reserve(&mut self, additional: usize) -> Result<(), TryReserveError>;
    pub fn reserve_exact(&mut self, additional: usize);
    pub fn try_reserve_exact(&mut self, additional: usize) -> Result<(), TryReserveError>;
    pub fn shrink_to_fit(&mut self);
    pub fn shrink_to(&mut self, min_capacity: usize);

    // mirrors `OsString` methods
    pub fn as_byte_str(&self) -> &ByteStr; 
    pub fn as_mut_byte_str(&mut self) -> &mut ByteStr;
    pub fn leak<'a>(self) -> &'a mut ByteStr;

    // mirrors `String` methods
    pub fn as_mut_vec(&mut self) -> &mut Vec<u8>;
    pub fn truncate(&mut self, len: usize);
    pub fn into_bytes(self) -> Vec<u8>;
    pub fn into_boxed_byte_str(self) -> Box<ByteStr>;

    // this parallels `OsString`, but is opposite to `String`, which has `push` and `push_str`
    pub fn push<S: AsRef<ByteStr>>(&mut self, s: S);
    pub fn push_byte(&mut self, b: u8);

    // not implemented on str, but implemented on Box<str> and required for conversion to Box<ByteStr>, so,
    // decided to make public
    pub fn into_boxed_bytes(self) -> Box<[u8]>;

    // this one's dubious, but I figured it is okay to add for completeness; not on `String`
    pub fn as_vec(&self) -> &Vec<u8>;
}
```

You may have also noticed these omitted, which I'm pointing out separately due to a bit of an API complication. `CStr` and `CString` decide to provide full access to the UTF-8 error here, but `OsStr` and `OsString` do not. I decided to go with `OsStr` and `OsString`'s API because they were simpler, but I personally think that the decision on what to do here should also be paired with one on what to do with the existing API discrepancy as well:

```rust
impl CStr {
    pub fn to_str(&self) -> Result<&str, Utf8Error>;
}
impl CString {
    pub fn into_string(self) -> Result<String, IntoStringError>;
}
impl OsStr {
    pub fn to_str(&self) -> Option<&str>;
}
impl OsString {
    pub fn into_string(self) -> Result<String, OsString>;
}
impl ByteStr {
    pub const fn to_str(&self) -> Option<&str>;
}
impl ByteString
    pub fn into_string(self) -> Result<String, ByteString>;
}
```

I also included these methods on `[u8]` and `Vec<u8>` because, currently, a lot of conversions from these types to `ByteStr` and `ByteString` are not available due to inference issues. Previously, these were resolved by making the actual type constructors public, but that forbids modifying the wrappers in the future, for example, to cache whether the string is valid UTF-8 like `OsString` currently does. So:

```rust
impl [u8] {
    pub fn as_byte_str(&self) -> &ByteStr;
    pub fn as_mut_byte_str(&mut self) -> &mut ByteStr;
    pub fn into_boxed_byte_str(self: Box<[u8]>) -> Box<ByteStr>;
}
impl Vec<u8> {
    pub fn into_byte_string(self) -> ByteString;
}
```

I think that the inference issues blocking all the relevant `AsRef`, `AsMut`, and `From` impls for these types should be seriously considered in terms of the future of this API. I'm avoiding this question for now since I think the changes to `Deref` will be needed regardless, but I added these methods to get around some of the issues in the meantime. If you'd like me to change the feature gate to put them under a different one, I can do that too, just to point out the issues here.

I would like to also apologise because I was mostly copying examples for half of them, then just got tired of it and copied the documentation for the methods only. We can add examples before stabilisation, and tests are unnecessary due to the fact that these are all shallow methods.

r? libs