### PR TITLE
gpu offload: change suspicious map into filter

### DIFF
--- a/compiler/rustc_codegen_llvm/src/builder/gpu_offload.rs
+++ b/compiler/rustc_codegen_llvm/src/builder/gpu_offload.rs
@@ -193,7 +193,7 @@ fn gen_define_handling<'ll>(
     // reference) types.
     let num_ptr_types = types
         .iter()
-        .map(|&x| matches!(cx.type_kind(x), rustc_codegen_ssa::common::TypeKind::Pointer))
+        .filter(|&x| matches!(cx.type_kind(x), rustc_codegen_ssa::common::TypeKind::Pointer))
         .count();
 
     // We do not know their size anymore at this level, so hardcode a placeholder.


### PR DESCRIPTION
Fixes clippy warning:
```text
warning: this call to `map()` won't have an effect on the call to `count()`
   --> compiler/rustc_codegen_llvm/src/builder/gpu_offload.rs:194:25
    |
194 |       let num_ptr_types = types
    |  _________________________^
195 | |         .iter()
196 | |         .map(|&x| matches!(cx.type_kind(x), rustc_codegen_ssa::common::TypeKind::Pointer))
197 | |         .count();
    | |________________^
    |
    = help: make sure you did not confuse `map` with `filter`, `for_each` or `inspect`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#suspicious_map
    = note: `-W clippy::suspicious-map` implied by `-W clippy::suspicious`
    = help: to override `-W clippy::suspicious` add `#[allow(clippy::suspicious_map)]`
```