### PR TITLE
Parallel frontend by default

### DIFF
--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -2673,12 +2673,8 @@ written to standard error output)"),
     #[rustc_lint_opt_deny_field_access("use `Session::lto` instead of this field")]
     thinlto: Option<bool> = (None, parse_opt_bool, [TRACKED],
         "enable ThinLTO when possible"),
-    /// We default to 1 here since we want to behave like
-    /// a sequential compiler for now. This'll likely be adjusted
-    /// in the future. Note that -Zthreads=0 is the way to get
-    /// the num_cpus behavior.
     #[rustc_lint_opt_deny_field_access("use `Session::threads` instead of this field")]
-    threads: usize = (1, parse_threads, [UNTRACKED],
+    threads: usize = (std::thread::available_parallelism().map_or(1, NonZero::get), parse_threads, [UNTRACKED],
         "use a thread pool with N threads"),
     time_llvm_passes: bool = (false, parse_bool, [UNTRACKED],
         "measure time of each LLVM pass (default: no)"),


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/146237)*
<!-- homu-ignore:end -->

I would like to help push progress on parallel compiler. I think it will be necessary at some point to test compiler in its multi-threaded mode (we already "have" parallel compiler but it is single-threaded by default) via crater. It would allow us to diagnose new issues, measure impact on the ecosystem and estimate amount of remaining work.

I have modified compiler to use ~~"num_cpus" number of~~ 8 threads by default. But I am not sure if there's better value for the cloud environment, so please tell if there is one. I am also not aware of any other nuances of cloud computing, but @Mark-Simulacrum on zulip [have confirmed](https://rust-lang.zulipchat.com/#narrow/channel/187679-t-compiler.2Fparallel-rustc/topic/Run.20crater.20with.20.60-Zthreads.3D.24NUM_CPUS.60.20set/near/537712572) it should be fine.

I believe `build-and-test` crater mode should provide us with more useful information than the other modes, but if necessary you can scale it down to just `build only`.

Related zulip thread: [#t-compiler/parallel-rustc > Run crater with &#96;-Zthreads=$NUM_CPUS&#96; set](https://rust-lang.zulipchat.com/#narrow/channel/187679-t-compiler.2Fparallel-rustc/topic/Run.20crater.20with.20.60-Zthreads.3D.24NUM_CPUS.60.20set/with/537712572)

EDIT: Switched from num_cpus to 8 threads