### PR TITLE
DynamicConfig: use canonical clone impl

### DIFF
--- a/compiler/rustc_query_impl/src/lib.rs
+++ b/compiler/rustc_query_impl/src/lib.rs
@@ -58,7 +58,7 @@ impl<'tcx, C: QueryCache, const ANON: bool, const DEPTH_LIMIT: bool, const FEEDA
     for DynamicConfig<'tcx, C, ANON, DEPTH_LIMIT, FEEDABLE>
 {
     fn clone(&self) -> Self {
-        DynamicConfig { dynamic: self.dynamic }
+        *self
     }
 }
 


### PR DESCRIPTION
Fixes clippy warning:
```text
warning: non-canonical implementation of `clone` on a `Copy` type
  --> compiler/rustc_query_impl/src/lib.rs:60:29
   |
60 |       fn clone(&self) -> Self {
   |  _____________________________^
61 | |         DynamicConfig { dynamic: self.dynamic }
62 | |     }
   | |_____^ help: change this to: `{ *self }`
```
