### PR TITLE
Fix `SystemTime::duration_since` error for extreme value

### DIFF
--- a/library/std/src/sys/pal/hermit/time.rs
+++ b/library/std/src/sys/pal/hermit/time.rs
@@ -28,7 +28,7 @@ impl Timespec {
     #[rustc_const_unstable(feature = "const_system_time", issue = "144517")]
     const fn sub_timespec(&self, other: &Timespec) -> Result<Duration, Duration> {
         // FIXME: const PartialOrd
-        let mut cmp = self.t.tv_sec - other.t.tv_sec;
+        let mut cmp = self.t.tv_sec.saturating_sub(other.t.tv_sec);
         if cmp == 0 {
             cmp = self.t.tv_nsec as i64 - other.t.tv_nsec as i64;
         }
@@ -36,12 +36,12 @@ impl Timespec {
         if cmp >= 0 {
             Ok(if self.t.tv_nsec >= other.t.tv_nsec {
                 Duration::new(
-                    (self.t.tv_sec - other.t.tv_sec) as u64,
+                    self.t.tv_sec.wrapping_sub(other.t.tv_sec) as u64,
                     (self.t.tv_nsec - other.t.tv_nsec) as u32,
                 )
             } else {
                 Duration::new(
-                    (self.t.tv_sec - 1 - other.t.tv_sec) as u64,
+                    self.t.tv_sec.wrapping_sub(other.t.tv_sec) as u64 - 1_u64,
                     (self.t.tv_nsec + NSEC_PER_SEC - other.t.tv_nsec) as u32,
                 )
             })

--- a/library/std/src/sys/pal/uefi/time.rs
+++ b/library/std/src/sys/pal/uefi/time.rs
@@ -95,7 +95,7 @@ impl SystemTime {
 
         // Check if can be represented in UEFI
         // FIXME: const PartialOrd
-        let mut cmp = temp.as_secs() - MAX_UEFI_TIME.0.as_secs();
+        let mut cmp = temp.as_secs().saturating_sub(MAX_UEFI_TIME.0.as_secs());
         if cmp == 0 {
             cmp = temp.subsec_nanos() as u64 - MAX_UEFI_TIME.0.subsec_nanos() as u64;
         }

--- a/library/std/src/sys/pal/unix/time.rs
+++ b/library/std/src/sys/pal/unix/time.rs
@@ -139,7 +139,7 @@ impl Timespec {
     #[rustc_const_unstable(feature = "const_system_time", issue = "144517")]
     pub const fn sub_timespec(&self, other: &Timespec) -> Result<Duration, Duration> {
         // FIXME: const PartialOrd
-        let mut cmp = self.tv_sec - other.tv_sec;
+        let mut cmp = self.tv_sec.saturating_sub(other.tv_sec);
         if cmp == 0 {
             cmp = self.tv_nsec.as_inner() as i64 - other.tv_nsec.as_inner() as i64;
         }
@@ -160,12 +160,12 @@ impl Timespec {
             // directly expresses the lower-cost behavior we want from it.
             let (secs, nsec) = if self.tv_nsec.as_inner() >= other.tv_nsec.as_inner() {
                 (
-                    (self.tv_sec - other.tv_sec) as u64,
+                    self.tv_sec.wrapping_sub(other.tv_sec) as u64,
                     self.tv_nsec.as_inner() - other.tv_nsec.as_inner(),
                 )
             } else {
                 (
-                    (self.tv_sec - other.tv_sec - 1) as u64,
+                    self.tv_sec.wrapping_sub(other.tv_sec) as u64 - 1_u64,
                     self.tv_nsec.as_inner() + (NSEC_PER_SEC as u32) - other.tv_nsec.as_inner(),
                 )
             };


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
This PR intends to fix rust-lang/rust#146228
