### PR TITLE
std: Update `wasi` crate dependency

### DIFF
--- a/library/Cargo.lock
+++ b/library/Cargo.lock
@@ -328,7 +328,7 @@ dependencies = [
  "std_detect",
  "unwind",
  "wasi 0.11.1+wasi-snapshot-preview1",
- "wasi 0.14.3+wasi-0.2.4",
+ "wasi 0.14.4+wasi-0.2.4",
  "windows-targets 0.0.0",
 ]
 
@@ -402,9 +402,9 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.14.3+wasi-0.2.4"
+version = "0.14.4+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a51ae83037bdd272a9e28ce236db8c07016dd0d50c27038b3f407533c030c95"
+checksum = "88a5f4a424faf49c3c2c344f166f0662341d470ea185e939657aaff130f0ec4a"
 dependencies = [
  "rustc-std-workspace-alloc",
  "rustc-std-workspace-core",

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -81,7 +81,7 @@ wasi = { version = "0.11.0", features = [
 ], default-features = false }
 
 [target.'cfg(all(target_os = "wasi", target_env = "p2"))'.dependencies]
-wasip2 = { version = '0.14.3', features = [
+wasip2 = { version = '0.14.4', features = [
     'rustc-dep-of-std',
 ], default-features = false, package = 'wasi' }
 


### PR DESCRIPTION
The recent work on the WASIp2 target being integrated into the standard library (rust-lang/rust#146207, rust-lang/rust#145944) ended up causing a bug in nightly on the target. This [has now been fixed](https://github.com/bytecodealliance/wasi-rs/pull/115) in the `wasi` crate so this commit pulls in the updated version to ensure bindings work correctly.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
