### PR TITLE
Fix `bump-stage0` build failure, and check-build `bump-stage0` in CI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -336,7 +336,7 @@ dependencies = [
  "curl",
  "indexmap",
  "serde",
- "toml 0.7.8",
+ "toml 0.8.23",
 ]
 
 [[package]]

--- a/src/bootstrap/src/core/build_steps/check.rs
+++ b/src/bootstrap/src/core/build_steps/check.rs
@@ -839,3 +839,9 @@ tool_check_step!(Linkchecker {
     mode: |_builder| Mode::ToolBootstrap,
     default: false
 });
+
+tool_check_step!(BumpStage0 {
+    path: "src/tools/bump-stage0",
+    mode: |_builder| Mode::ToolBootstrap,
+    default: false
+});

--- a/src/bootstrap/src/core/builder/mod.rs
+++ b/src/bootstrap/src/core/builder/mod.rs
@@ -1061,6 +1061,7 @@ impl<'a> Builder<'a> {
                 check::FeaturesStatusDump,
                 check::CoverageDump,
                 check::Linkchecker,
+                check::BumpStage0,
                 // This has special staging logic, it may run on stage 1 while others run on stage 0.
                 // It takes quite some time to build stage 1, so put this at the end.
                 //

--- a/src/ci/docker/host-x86_64/pr-check-2/Dockerfile
+++ b/src/ci/docker/host-x86_64/pr-check-2/Dockerfile
@@ -28,6 +28,7 @@ RUN sh /scripts/sccache.sh
 
 ENV SCRIPT \
         python3 ../x.py check && \
+        python3 ../x.py check src/tools/bump-stage0 && \
         python3 ../x.py clippy ci --stage 2 && \
         python3 ../x.py test --stage 1 core alloc std test proc_macro && \
         python3 ../x.py test --stage 1 src/tools/compiletest && \

--- a/src/tools/bump-stage0/Cargo.toml
+++ b/src/tools/bump-stage0/Cargo.toml
@@ -11,4 +11,4 @@ build_helper = { path = "../../build_helper" }
 curl = "0.4.38"
 indexmap = { version = "2.0.0", features = ["serde"] }
 serde = { version = "1.0.125", features = ["derive"] }
-toml = "0.7"
+toml = "0.8.23"

--- a/src/tools/bump-stage0/src/main.rs
+++ b/src/tools/bump-stage0/src/main.rs
@@ -185,7 +185,11 @@ fn fetch_manifest(
         format!("{}/dist/channel-rust-{}.toml", config.dist_server, channel)
     };
 
-    Ok(toml::from_slice(&http_get(&url)?)?)
+    // FIXME: on newer `toml` (>= `0.9.*`), use `toml::from_slice`. For now, we use the most recent
+    // `toml` available in-tree which is `0.8.*`, so we have to do an additional dance here.
+    let response = http_get(&url)?;
+    let response = String::from_utf8(response)?;
+    Ok(toml::from_str(&response)?)
 }
 
 fn http_get(url: &str) -> Result<Vec<u8>, Error> {


### PR DESCRIPTION
This PR bumps the `toml` dependency of the `bump-stage0` tool to `0.8.23`, which AFAICT is the highest `toml` version that's present in the r-l/r workspace's `Cargo.lock` already (so we don't introduce _another_ `toml 0.x.*` series). I added some byte-buffer-to-string intermediary to workaround `toml 0.8.*` not having the `toml 0.9.*` `toml::from_slice` API.

To catch obvious build failures of the `src/tools/bump-stage0` tool early, before we find out it can't even build when we really need it to work.

Contexts:

- https://github.com/rust-lang/rust/pull/146250#issue-3388327410
- [#t-release > Bump stage0 rustfmt separately ("one-off") @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/241545-t-release/topic/Bump.20stage0.20rustfmt.20separately.20.28.22one-off.22.29/near/537916615)

Fixes rust-lang/rust#146252.