### PR TITLE
lint ImproperCTypes: refactor linting architecture (part 2)

### DIFF
--- a/compiler/rustc_lint/src/types/improper_ctypes.rs
+++ b/compiler/rustc_lint/src/types/improper_ctypes.rs
@@ -257,10 +257,20 @@ fn check_struct_for_power_alignment<'tcx>(
     }
 }
 
+/// Annotates whether we are in the context of an item *defined* in rust
+/// and exposed to an FFI boundary,
+/// or the context of an item from elsewhere, whose interface is re-*declared* in rust.
 #[derive(Clone, Copy)]
 enum CItemKind {
     Declaration,
     Definition,
+}
+
+/// Annotates whether we are in the context of a function's argument types or return type.
+#[derive(Clone, Copy)]
+enum FnPos {
+    Arg,
+    Ret,
 }
 
 enum FfiResult<'tcx> {
@@ -286,8 +296,10 @@ enum IndirectionKind {
 }
 
 bitflags! {
+    /// VisitorState flags that are linked with the root type's use.
+    /// (These are the permanent part of the state, kept when visiting new Ty.)
     #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-    struct VisitorState: u8 {
+    struct RootUseFlags: u8 {
         /// For use in (externally-linked) static variables.
         const STATIC = 0b000001;
         /// For use in functions in general.
@@ -302,7 +314,45 @@ bitflags! {
     }
 }
 
-impl VisitorState {
+/// Description of the relationship between current Ty and
+/// the type (or lack thereof) immediately containing it
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+enum OuterTyKind {
+    None,
+    /// A variant that should not exist,
+    /// but is needed because we don't change the lint's behavior yet
+    NoneThroughFnPtr,
+    /// Placeholder for properties that will be used eventually
+    Other,
+}
+
+impl OuterTyKind {
+    /// Computes the relationship by providing the containing Ty itself
+    fn from_ty<'tcx>(ty: Ty<'tcx>) -> Self {
+        match ty.kind() {
+            ty::FnPtr(..) => Self::NoneThroughFnPtr,
+            ty::RawPtr(..)
+            | ty::Ref(..)
+            | ty::Adt(..)
+            | ty::Tuple(..)
+            | ty::Array(..)
+            | ty::Slice(_) => OuterTyKind::Other,
+            _ => bug!("Unexpected outer type {ty:?}"),
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+struct VisitorState {
+    /// Flags describing both the overall context in which the current Ty is,
+    /// linked to how the Visitor's original Ty was used.
+    root_use_flags: RootUseFlags,
+    /// Flags describing both the immediate context in which the current Ty is,
+    /// linked to how it relates to its parent Ty (or lack thereof).
+    outer_ty_kind: OuterTyKind,
+}
+
+impl RootUseFlags {
     // The values that can be set.
     const STATIC_TY: Self = Self::STATIC;
     const ARGUMENT_TY_IN_DEFINITION: Self =
@@ -317,86 +367,85 @@ impl VisitorState {
     const RETURN_TY_IN_FNPTR: Self =
         Self::from_bits(Self::FUNC.bits() | Self::THEORETICAL.bits() | Self::FN_RETURN.bits())
             .unwrap();
+}
 
-    /// Get the proper visitor state for a given function's arguments.
-    fn argument_from_fnmode(fn_mode: CItemKind) -> Self {
-        match fn_mode {
-            CItemKind::Definition => VisitorState::ARGUMENT_TY_IN_DEFINITION,
-            CItemKind::Declaration => VisitorState::ARGUMENT_TY_IN_DECLARATION,
+impl VisitorState {
+    /// From an existing state, compute the state of any subtype of the current type.
+    /// (General case. For the case where the current type is a function pointer, see `next_in_fnptr`.)
+    fn next(&self, current_ty: Ty<'_>) -> Self {
+        assert!(!matches!(current_ty.kind(), ty::FnPtr(..)));
+        VisitorState {
+            root_use_flags: self.root_use_flags,
+            outer_ty_kind: OuterTyKind::from_ty(current_ty),
         }
     }
 
-    /// Get the proper visitor state for a given function's return type.
-    fn return_from_fnmode(fn_mode: CItemKind) -> Self {
-        match fn_mode {
-            CItemKind::Definition => VisitorState::RETURN_TY_IN_DEFINITION,
-            CItemKind::Declaration => VisitorState::RETURN_TY_IN_DECLARATION,
+    /// From an existing state, compute the state of any subtype of the current type.
+    /// (Case where the current type is a function pointer,
+    /// meaning we need to specify if the subtype is an argument or the return.)
+    fn next_in_fnptr(&self, current_ty: Ty<'_>, fn_pos: FnPos) -> Self {
+        assert!(matches!(current_ty.kind(), ty::FnPtr(..)));
+        VisitorState {
+            root_use_flags: match fn_pos {
+                FnPos::Ret => RootUseFlags::RETURN_TY_IN_FNPTR,
+                FnPos::Arg => RootUseFlags::ARGUMENT_TY_IN_FNPTR,
+            },
+            outer_ty_kind: OuterTyKind::from_ty(current_ty),
         }
+    }
+
+    /// Get the proper visitor state for a given function's arguments or return type.
+    fn fn_entry_point(fn_mode: CItemKind, fn_pos: FnPos) -> Self {
+        let p_flags = match (fn_mode, fn_pos) {
+            (CItemKind::Definition, FnPos::Ret) => RootUseFlags::RETURN_TY_IN_DEFINITION,
+            (CItemKind::Declaration, FnPos::Ret) => RootUseFlags::RETURN_TY_IN_DECLARATION,
+            (CItemKind::Definition, FnPos::Arg) => RootUseFlags::ARGUMENT_TY_IN_DEFINITION,
+            (CItemKind::Declaration, FnPos::Arg) => RootUseFlags::ARGUMENT_TY_IN_DECLARATION,
+        };
+        VisitorState { root_use_flags: p_flags, outer_ty_kind: OuterTyKind::None }
+    }
+
+    /// Get the proper visitor state for a static variable's type
+    fn static_entry_point() -> Self {
+        VisitorState { root_use_flags: RootUseFlags::STATIC_TY, outer_ty_kind: OuterTyKind::None }
     }
 
     /// Whether the type is used in a function.
-    fn is_in_function(self) -> bool {
-        let ret = self.contains(Self::FUNC);
+    fn is_in_function(&self) -> bool {
+        let ret = self.root_use_flags.contains(RootUseFlags::FUNC);
         if ret {
-            debug_assert!(!self.contains(Self::STATIC));
+            debug_assert!(!self.root_use_flags.contains(RootUseFlags::STATIC));
         }
         ret
     }
+
     /// Whether the type is used (directly or not) in a function, in return position.
-    fn is_in_function_return(self) -> bool {
-        let ret = self.contains(Self::FN_RETURN);
+    fn is_in_function_return(&self) -> bool {
+        let ret = self.root_use_flags.contains(RootUseFlags::FN_RETURN);
         if ret {
             debug_assert!(self.is_in_function());
         }
         ret
     }
+
     /// Whether the type is used (directly or not) in a defined function.
     /// In other words, whether or not we allow non-FFI-safe types behind a C pointer,
     /// to be treated as an opaque type on the other side of the FFI boundary.
-    fn is_in_defined_function(self) -> bool {
-        self.contains(Self::DEFINED) && self.is_in_function()
+    fn is_in_defined_function(&self) -> bool {
+        self.root_use_flags.contains(RootUseFlags::DEFINED) && self.is_in_function()
     }
 
     /// Whether the type is used (directly or not) in a function pointer type.
     /// Here, we also allow non-FFI-safe types behind a C pointer,
     /// to be treated as an opaque type on the other side of the FFI boundary.
-    fn is_in_fnptr(self) -> bool {
-        self.contains(Self::THEORETICAL) && self.is_in_function()
+    fn is_in_fnptr(&self) -> bool {
+        self.root_use_flags.contains(RootUseFlags::THEORETICAL) && self.is_in_function()
     }
 
     /// Whether we can expect type parameters and co in a given type.
-    fn can_expect_ty_params(self) -> bool {
+    fn can_expect_ty_params(&self) -> bool {
         // rust-defined functions, as well as FnPtrs
-        self.contains(Self::THEORETICAL) || self.is_in_defined_function()
-    }
-}
-
-bitflags! {
-    /// Data that summarises how an "outer type" surrounds its inner type(s)
-    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-    struct OuterTyData: u8 {
-        /// To show that there is no outer type, the current type is directly used by a `static`
-        /// variable or a function/FnPtr
-        const NO_OUTER_TY = 0b01;
-        /// For NO_OUTER_TY cases, show that we are being directly used by a FnPtr specifically
-        /// FIXME(ctypes): this is only used for "bad behaviour" reproduced for compatibility's sake
-        const NO_OUTER_TY_FNPTR = 0b10;
-    }
-}
-
-impl OuterTyData {
-    /// Get the proper data for a given outer type.
-    fn from_ty<'tcx>(ty: Ty<'tcx>) -> Self {
-        match ty.kind() {
-            ty::FnPtr(..) => Self::NO_OUTER_TY | Self::NO_OUTER_TY_FNPTR,
-            ty::RawPtr(..)
-            | ty::Ref(..)
-            | ty::Adt(..)
-            | ty::Tuple(..)
-            | ty::Array(..)
-            | ty::Slice(_) => Self::empty(),
-            k @ _ => bug!("unexpected outer type {:?} of kind {:?}", ty, k),
-        }
+        self.root_use_flags.contains(RootUseFlags::THEORETICAL) || self.is_in_defined_function()
     }
 }
 
@@ -416,7 +465,7 @@ struct ImproperCTypesVisitor<'a, 'tcx> {
 
 impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
     fn new(cx: &'a LateContext<'tcx>, base_ty: Ty<'tcx>, base_fn_mode: CItemKind) -> Self {
-        Self { cx, base_ty, base_fn_mode, cache: FxHashSet::default() }
+        ImproperCTypesVisitor { cx, base_ty, base_fn_mode, cache: FxHashSet::default() }
     }
 
     /// Checks if the given indirection (box,ref,pointer) is "ffi-safe".
@@ -485,7 +534,7 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
                 {
                     FfiSafe
                 } else {
-                    self.visit_type(state, OuterTyData::from_ty(ty), inner_ty)
+                    self.visit_type(state.next(ty), inner_ty)
                 }
             }
         }
@@ -506,7 +555,7 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
             if let Some(field) = super::transparent_newtype_field(self.cx.tcx, variant) {
                 // Transparent newtypes have at most one non-ZST field which needs to be checked..
                 let field_ty = get_type_from_field(self.cx, field, args);
-                match self.visit_type(state, OuterTyData::from_ty(ty), field_ty) {
+                match self.visit_type(state.next(ty), field_ty) {
                     FfiUnsafe { ty, .. } if ty.is_unit() => (),
                     r => return r,
                 }
@@ -525,7 +574,7 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
         let mut all_phantom = !variant.fields.is_empty();
         for field in &variant.fields {
             let field_ty = get_type_from_field(self.cx, field, args);
-            all_phantom &= match self.visit_type(state, OuterTyData::from_ty(ty), field_ty) {
+            all_phantom &= match self.visit_type(state.next(ty), field_ty) {
                 FfiSafe => false,
                 // `()` fields are FFI-safe!
                 FfiUnsafe { ty, .. } if ty.is_unit() => false,
@@ -570,7 +619,7 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
                         "consider adding a `#[repr(C)]` or `#[repr(transparent)]` attribute to this struct"
                     ))
                 } else {
-                    // FIXME(ctypes): confirm that this makes sense for unions once #60405 / RFC2645 stabilises
+                    // FIXME(#60405): confirm that this makes sense for unions once #60405 / RFC2645 stabilises
                     Some(msg!(
                         "consider adding a `#[repr(C)]` or `#[repr(transparent)]` attribute to this union"
                     ))
@@ -628,7 +677,7 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
         if !def.repr().c() && !def.repr().transparent() && def.repr().int.is_none() {
             // Special-case types like `Option<extern fn()>` and `Result<extern fn(), ()>`
             if let Some(inner_ty) = repr_nullable_ptr(self.cx.tcx, self.cx.typing_env(), ty) {
-                return self.visit_type(state, OuterTyData::from_ty(ty), inner_ty);
+                return self.visit_type(state.next(ty), inner_ty);
             }
 
             return FfiUnsafe {
@@ -660,12 +709,7 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
 
     /// Checks if the given type is "ffi-safe" (has a stable, well-defined
     /// representation which can be exported to C code).
-    fn visit_type(
-        &mut self,
-        state: VisitorState,
-        outer_ty: OuterTyData,
-        ty: Ty<'tcx>,
-    ) -> FfiResult<'tcx> {
+    fn visit_type(&mut self, state: VisitorState, ty: Ty<'tcx>) -> FfiResult<'tcx> {
         use FfiResult::*;
 
         let tcx = self.cx.tcx;
@@ -709,7 +753,8 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
             // Pattern types are just extra invariants on the type that you need to uphold,
             // but only the base type is relevant for being representable in FFI.
             // (note: this lint was written when pattern types could only be integers constrained to ranges)
-            ty::Pat(pat_ty, _) => self.visit_type(state, outer_ty, pat_ty),
+            // (also note: the lack of ".next(ty)" on the state is on purpose)
+            ty::Pat(pat_ty, _) => self.visit_type(state, pat_ty),
 
             // types which likely have a stable representation, if the target architecture defines those
             // note: before rust 1.77, 128-bit ints were not FFI-safe on x86_64
@@ -740,12 +785,14 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
             },
 
             ty::Tuple(tuple) => {
-                // C functions can return void
-                let empty_and_safe = tuple.is_empty()
-                    && outer_ty.contains(OuterTyData::NO_OUTER_TY)
-                    && state.is_in_function_return();
-
-                if empty_and_safe {
+                if tuple.is_empty()
+                    && state.is_in_function_return()
+                    && matches!(
+                        state.outer_ty_kind,
+                        OuterTyKind::None | OuterTyKind::NoneThroughFnPtr
+                    )
+                {
+                    // C functions can return void
                     FfiSafe
                 } else {
                     FfiUnsafe {
@@ -774,9 +821,8 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
 
             ty::Array(inner_ty, _) => {
                 if state.is_in_function()
-                    && outer_ty.contains(OuterTyData::NO_OUTER_TY)
-                    // FIXME(ctypes): VVV-this-VVV shouldn't be the case
-                    && !outer_ty.contains(OuterTyData::NO_OUTER_TY_FNPTR)
+                    // FIXME(ctypes): VVV-this-VVV shouldn't make a difference between ::None and ::NoneThroughFnPtr
+                    && matches!(state.outer_ty_kind, OuterTyKind::None)
                 {
                     // C doesn't really support passing arrays by value - the only way to pass an array by value
                     // is through a struct.
@@ -788,7 +834,7 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
                 } else {
                     // let's allow phantoms to go through,
                     // since an array of 1-ZSTs is also a 1-ZST
-                    self.visit_type(state, OuterTyData::from_ty(ty), inner_ty)
+                    self.visit_type(state.next(ty), inner_ty)
                 }
             }
 
@@ -806,19 +852,14 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
 
                 let sig = tcx.instantiate_bound_regions_with_erased(sig);
                 for arg in sig.inputs() {
-                    match self.visit_type(
-                        VisitorState::ARGUMENT_TY_IN_FNPTR,
-                        OuterTyData::from_ty(ty),
-                        *arg,
-                    ) {
+                    match self.visit_type(state.next_in_fnptr(ty, FnPos::Arg), *arg) {
                         FfiSafe => {}
                         r => return r,
                     }
                 }
 
                 let ret_ty = sig.output();
-
-                self.visit_type(VisitorState::RETURN_TY_IN_FNPTR, OuterTyData::from_ty(ty), ret_ty)
+                self.visit_type(state.next_in_fnptr(ty, FnPos::Ret), ret_ty)
             }
 
             ty::Foreign(..) => FfiSafe,
@@ -896,7 +937,7 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
             return res;
         }
 
-        self.visit_type(state, OuterTyData::NO_OUTER_TY, ty)
+        self.visit_type(state, ty)
     }
 }
 
@@ -925,7 +966,7 @@ impl<'tcx> ImproperCTypesLint {
                     self.spans.push(ty.span);
                 }
 
-                hir::intravisit::walk_ty(self, ty)
+                hir::intravisit::walk_ty(self, ty);
             }
         }
 
@@ -970,12 +1011,12 @@ impl<'tcx> ImproperCTypesLint {
         let sig = cx.tcx.instantiate_bound_regions_with_erased(sig);
 
         for (input_ty, input_hir) in iter::zip(sig.inputs(), decl.inputs) {
-            let state = VisitorState::argument_from_fnmode(fn_mode);
+            let state = VisitorState::fn_entry_point(fn_mode, FnPos::Arg);
             self.check_type_for_external_abi_fnptr(cx, state, input_hir, *input_ty, fn_mode);
         }
 
         if let hir::FnRetTy::Return(ret_hir) = decl.output {
-            let state = VisitorState::return_from_fnmode(fn_mode);
+            let state = VisitorState::fn_entry_point(fn_mode, FnPos::Ret);
             self.check_type_for_external_abi_fnptr(cx, state, ret_hir, sig.output(), fn_mode);
         }
     }
@@ -1000,7 +1041,7 @@ impl<'tcx> ImproperCTypesLint {
     fn check_foreign_static(&mut self, cx: &LateContext<'tcx>, id: hir::OwnerId, span: Span) {
         let ty = cx.tcx.type_of(id).instantiate_identity().skip_norm_wip();
         let mut visitor = ImproperCTypesVisitor::new(cx, ty, CItemKind::Declaration);
-        let ffi_res = visitor.check_type(VisitorState::STATIC_TY, ty);
+        let ffi_res = visitor.check_type(VisitorState::static_entry_point(), ty);
         self.process_ffi_result(cx, span, ffi_res, CItemKind::Declaration);
     }
 
@@ -1016,14 +1057,14 @@ impl<'tcx> ImproperCTypesLint {
         let sig = cx.tcx.instantiate_bound_regions_with_erased(sig);
 
         for (input_ty, input_hir) in iter::zip(sig.inputs(), decl.inputs) {
-            let state = VisitorState::argument_from_fnmode(fn_mode);
+            let state = VisitorState::fn_entry_point(fn_mode, FnPos::Arg);
             let mut visitor = ImproperCTypesVisitor::new(cx, *input_ty, fn_mode);
             let ffi_res = visitor.check_type(state, *input_ty);
             self.process_ffi_result(cx, input_hir.span, ffi_res, fn_mode);
         }
 
         if let hir::FnRetTy::Return(ret_hir) = decl.output {
-            let state = VisitorState::return_from_fnmode(fn_mode);
+            let state = VisitorState::fn_entry_point(fn_mode, FnPos::Ret);
             let mut visitor = ImproperCTypesVisitor::new(cx, sig.output(), fn_mode);
             let ffi_res = visitor.check_type(state, sig.output());
             self.process_ffi_result(cx, ret_hir.span, ffi_res, fn_mode);
@@ -1124,7 +1165,7 @@ impl<'tcx> LateLintPass<'tcx> for ImproperCTypesLint {
             | hir::ItemKind::TyAlias(_, _, ty) => {
                 self.check_type_for_external_abi_fnptr(
                     cx,
-                    VisitorState::STATIC_TY,
+                    VisitorState::static_entry_point(),
                     ty,
                     cx.tcx.type_of(item.owner_id).instantiate_identity().skip_norm_wip(),
                     CItemKind::Definition,
@@ -1158,7 +1199,7 @@ impl<'tcx> LateLintPass<'tcx> for ImproperCTypesLint {
     fn check_field_def(&mut self, cx: &LateContext<'tcx>, field: &'tcx hir::FieldDef<'tcx>) {
         self.check_type_for_external_abi_fnptr(
             cx,
-            VisitorState::STATIC_TY,
+            VisitorState::static_entry_point(),
             field.ty,
             cx.tcx.type_of(field.def_id).instantiate_identity().skip_norm_wip(),
             CItemKind::Definition,

--- a/compiler/rustc_lint/src/types/improper_ctypes.rs
+++ b/compiler/rustc_lint/src/types/improper_ctypes.rs
@@ -138,17 +138,16 @@ declare_lint_pass!(ImproperCTypesLint => [
     USES_POWER_ALIGNMENT
 ]);
 
-/// Getting the (normalized) type out of a field (for, e.g., an enum variant or a tuple).
-#[inline]
-fn get_type_from_field<'tcx>(
+/// A common pattern in this lint is to attempt normalize_erasing_regions,
+/// but keep the original type if it were to fail.
+/// This may or may not be supported in the logic behind the `Unnormalized` wrapper,
+/// (FIXME?)
+/// but it should be enough for non-wrapped types to be as normalised as this lint needs them to be.
+fn maybe_normalize_erasing_regions<'tcx>(
     cx: &LateContext<'tcx>,
-    field: &ty::FieldDef,
-    args: GenericArgsRef<'tcx>,
+    value: Unnormalized<'tcx, Ty<'tcx>>,
 ) -> Ty<'tcx> {
-    let field_ty = field.ty(cx.tcx, args);
-    cx.tcx
-        .try_normalize_erasing_regions(cx.typing_env(), Unnormalized::new_wip(field_ty))
-        .unwrap_or(field_ty)
+    cx.tcx.try_normalize_erasing_regions(cx.typing_env(), value).unwrap_or(value.skip_norm_wip())
 }
 
 /// Check a variant of a non-exhaustive enum for improper ctypes
@@ -464,8 +463,17 @@ struct ImproperCTypesVisitor<'a, 'tcx> {
 }
 
 impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
-    fn new(cx: &'a LateContext<'tcx>, base_ty: Ty<'tcx>, base_fn_mode: CItemKind) -> Self {
-        ImproperCTypesVisitor { cx, base_ty, base_fn_mode, cache: FxHashSet::default() }
+    fn new(
+        cx: &'a LateContext<'tcx>,
+        base_ty: Unnormalized<'tcx, Ty<'tcx>>,
+        base_fn_mode: CItemKind,
+    ) -> Self {
+        ImproperCTypesVisitor {
+            cx,
+            base_ty: maybe_normalize_erasing_regions(cx, base_ty),
+            base_fn_mode,
+            cache: FxHashSet::default(),
+        }
     }
 
     /// Checks if the given indirection (box,ref,pointer) is "ffi-safe".
@@ -554,7 +562,10 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
         let transparent_with_all_zst_fields = if def.repr().transparent() {
             if let Some(field) = super::transparent_newtype_field(self.cx.tcx, variant) {
                 // Transparent newtypes have at most one non-ZST field which needs to be checked..
-                let field_ty = get_type_from_field(self.cx, field, args);
+                let field_ty = maybe_normalize_erasing_regions(
+                    self.cx,
+                    Unnormalized::new_wip(field.ty(self.cx.tcx, args)),
+                );
                 match self.visit_type(state.next(ty), field_ty) {
                     FfiUnsafe { ty, .. } if ty.is_unit() => (),
                     r => return r,
@@ -573,7 +584,10 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
         // We can't completely trust `repr(C)` markings, so make sure the fields are actually safe.
         let mut all_phantom = !variant.fields.is_empty();
         for field in &variant.fields {
-            let field_ty = get_type_from_field(self.cx, field, args);
+            let field_ty = maybe_normalize_erasing_regions(
+                self.cx,
+                Unnormalized::new_wip(field.ty(self.cx.tcx, args)),
+            );
             all_phantom &= match self.visit_type(state.next(ty), field_ty) {
                 FfiSafe => false,
                 // `()` fields are FFI-safe!
@@ -927,12 +941,12 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
         })
     }
 
-    fn check_type(&mut self, state: VisitorState, ty: Ty<'tcx>) -> FfiResult<'tcx> {
-        let ty = self
-            .cx
-            .tcx
-            .try_normalize_erasing_regions(self.cx.typing_env(), Unnormalized::new_wip(ty))
-            .unwrap_or(ty);
+    fn check_type(
+        &mut self,
+        state: VisitorState,
+        ty: Unnormalized<'tcx, Ty<'tcx>>,
+    ) -> FfiResult<'tcx> {
+        let ty = maybe_normalize_erasing_regions(self.cx, ty);
         if let Some(res) = self.visit_for_opaque_ty(ty) {
             return res;
         }
@@ -990,6 +1004,7 @@ impl<'tcx> ImproperCTypesLint {
 
         let all_types = iter::zip(visitor.tys.drain(..), visitor.spans.drain(..));
         for (fn_ptr_ty, span) in all_types {
+            let fn_ptr_ty = Unnormalized::new_wip(fn_ptr_ty);
             let mut visitor = ImproperCTypesVisitor::new(cx, fn_ptr_ty, fn_mode);
             // FIXME(ctypes): make a check_for_fnptr
             let ffi_res = visitor.check_type(state, fn_ptr_ty);
@@ -1039,7 +1054,7 @@ impl<'tcx> ImproperCTypesLint {
     }
 
     fn check_foreign_static(&mut self, cx: &LateContext<'tcx>, id: hir::OwnerId, span: Span) {
-        let ty = cx.tcx.type_of(id).instantiate_identity().skip_norm_wip();
+        let ty = cx.tcx.type_of(id).instantiate_identity();
         let mut visitor = ImproperCTypesVisitor::new(cx, ty, CItemKind::Declaration);
         let ffi_res = visitor.check_type(VisitorState::static_entry_point(), ty);
         self.process_ffi_result(cx, span, ffi_res, CItemKind::Declaration);
@@ -1057,16 +1072,18 @@ impl<'tcx> ImproperCTypesLint {
         let sig = cx.tcx.instantiate_bound_regions_with_erased(sig);
 
         for (input_ty, input_hir) in iter::zip(sig.inputs(), decl.inputs) {
+            let input_ty = Unnormalized::new_wip(*input_ty);
             let state = VisitorState::fn_entry_point(fn_mode, FnPos::Arg);
-            let mut visitor = ImproperCTypesVisitor::new(cx, *input_ty, fn_mode);
-            let ffi_res = visitor.check_type(state, *input_ty);
+            let mut visitor = ImproperCTypesVisitor::new(cx, input_ty, fn_mode);
+            let ffi_res = visitor.check_type(state, input_ty);
             self.process_ffi_result(cx, input_hir.span, ffi_res, fn_mode);
         }
 
         if let hir::FnRetTy::Return(ret_hir) = decl.output {
+            let output_ty = Unnormalized::new_wip(sig.output());
             let state = VisitorState::fn_entry_point(fn_mode, FnPos::Ret);
-            let mut visitor = ImproperCTypesVisitor::new(cx, sig.output(), fn_mode);
-            let ffi_res = visitor.check_type(state, sig.output());
+            let mut visitor = ImproperCTypesVisitor::new(cx, output_ty, fn_mode);
+            let ffi_res = visitor.check_type(state, output_ty);
             self.process_ffi_result(cx, ret_hir.span, ffi_res, fn_mode);
         }
     }


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/146273)*
<!-- homu-ignore:end -->

This is the second PR in an effort to split https://github.com/rust-lang/rust/pull/134697 (refactor plus overhaul of the ImproperCTypes family of lints) into individually-mergeable parts.

Contains the changes of the first PR, and splits the core type checking function into several bits, each focused on a specific aspect of FFI-safety.
Some logic which was outside of said core function was also moved into the new functions.

Superset of: rust-lang/rust#146271
