### PR TITLE
Rollup of 2 pull requests

### DIFF
--- a/compiler/rustc_mir_transform/src/lint_tail_expr_drop_order.rs
+++ b/compiler/rustc_mir_transform/src/lint_tail_expr_drop_order.rs
@@ -2,6 +2,7 @@ use std::cell::RefCell;
 use std::collections::hash_map;
 use std::rc::Rc;
 
+use itertools::Itertools as _;
 use rustc_data_structures::fx::{FxHashMap, FxHashSet, FxIndexMap};
 use rustc_data_structures::unord::{UnordMap, UnordSet};
 use rustc_errors::Subdiagnostic;
@@ -339,9 +340,9 @@ pub(crate) fn run_lint<'tcx>(tcx: TyCtxt<'tcx>, def_id: LocalDefId, body: &Body<
             // Suppose that all BIDs point into the same local,
             // we can remove the this local from the observed drops,
             // so that we can focus our diagnosis more on the others.
-            if candidates.iter().all(|&(_, place)| candidates[0].1.local == place.local) {
+            if let Ok(local) = candidates.iter().map(|&(_, place)| place.local).all_equal_value() {
                 for path_idx in all_locals_dropped.iter() {
-                    if move_data.move_paths[path_idx].place.local == candidates[0].1.local {
+                    if move_data.move_paths[path_idx].place.local == local {
                         to_exclude.insert(path_idx);
                     }
                 }

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -1,3 +1,4 @@
+use itertools::Itertools as _;
 use rustc_ast::visit::{self, Visitor};
 use rustc_ast::{
     self as ast, CRATE_NODE_ID, Crate, ItemKind, ModKind, NodeId, Path, join_path_idents,
@@ -3469,16 +3470,11 @@ fn show_candidates(
                 err.note(note.to_string());
             }
         } else {
-            let (_, descr_first, _, _, _) = &inaccessible_path_strings[0];
-            let descr = if inaccessible_path_strings
+            let descr = inaccessible_path_strings
                 .iter()
-                .skip(1)
-                .all(|(_, descr, _, _, _)| descr == descr_first)
-            {
-                descr_first
-            } else {
-                "item"
-            };
+                .map(|&(_, descr, _, _, _)| descr)
+                .all_equal_value()
+                .unwrap_or("item");
             let plural_descr =
                 if descr.ends_with('s') { format!("{descr}es") } else { format!("{descr}s") };
 

--- a/compiler/rustc_span/src/analyze_source_file.rs
+++ b/compiler/rustc_span/src/analyze_source_file.rs
@@ -81,8 +81,8 @@ cfg_select! {
                 // use `loadu`, which supports unaligned loading.
                 let chunk = unsafe { _mm_loadu_si128(chunk.as_ptr() as *const __m128i) };
 
-                // For each character in the chunk, see if its byte value is < 0,
-                // which indicates that it's part of a UTF-8 char.
+                // For character in the chunk, see if its byte value is < 0, which
+                // indicates that it's part of a UTF-8 char.
                 let multibyte_test = _mm_cmplt_epi8(chunk, _mm_set1_epi8(0));
                 // Create a bit mask from the comparison results.
                 let multibyte_mask = _mm_movemask_epi8(multibyte_test);
@@ -132,111 +132,8 @@ cfg_select! {
             }
         }
     }
-    target_arch = "loongarch64" => {
-        fn analyze_source_file_dispatch(
-            src: &str,
-            lines: &mut Vec<RelativeBytePos>,
-            multi_byte_chars: &mut Vec<MultiByteChar>,
-        ) {
-            use std::arch::is_loongarch_feature_detected;
-
-            if is_loongarch_feature_detected!("lsx") {
-                unsafe {
-                    analyze_source_file_lsx(src, lines, multi_byte_chars);
-                }
-            } else {
-                analyze_source_file_generic(
-                    src,
-                    src.len(),
-                    RelativeBytePos::from_u32(0),
-                    lines,
-                    multi_byte_chars,
-                );
-            }
-        }
-
-        /// Checks 16 byte chunks of text at a time. If the chunk contains
-        /// something other than printable ASCII characters and newlines, the
-        /// function falls back to the generic implementation. Otherwise it uses
-        /// LSX intrinsics to quickly find all newlines.
-        #[target_feature(enable = "lsx")]
-        unsafe fn analyze_source_file_lsx(
-            src: &str,
-            lines: &mut Vec<RelativeBytePos>,
-            multi_byte_chars: &mut Vec<MultiByteChar>,
-        ) {
-            use std::arch::loongarch64::*;
-
-            const CHUNK_SIZE: usize = 16;
-
-            let (chunks, tail) = src.as_bytes().as_chunks::<CHUNK_SIZE>();
-
-            // This variable keeps track of where we should start decoding a
-            // chunk. If a multi-byte character spans across chunk boundaries,
-            // we need to skip that part in the next chunk because we already
-            // handled it.
-            let mut intra_chunk_offset = 0;
-
-            for (chunk_index, chunk) in chunks.iter().enumerate() {
-                // All LSX memory instructions support unaligned access, so using
-                // vld is fine.
-                let chunk = unsafe { lsx_vld::<0>(chunk.as_ptr() as *const i8) };
-
-                // For each character in the chunk, see if its byte value is < 0,
-                // which indicates that it's part of a UTF-8 char.
-                let multibyte_mask = lsx_vmskltz_b(chunk);
-                // Create a bit mask from the comparison results.
-                let multibyte_mask = lsx_vpickve2gr_w::<0>(multibyte_mask);
-
-                // If the bit mask is all zero, we only have ASCII chars here:
-                if multibyte_mask == 0 {
-                    assert!(intra_chunk_offset == 0);
-
-                    // Check for newlines in the chunk
-                    let newlines_test = lsx_vseqi_b::<{b'\n' as i32}>(chunk);
-                    let newlines_mask = lsx_vmskltz_b(newlines_test);
-                    let mut newlines_mask = lsx_vpickve2gr_w::<0>(newlines_mask);
-
-                    let output_offset = RelativeBytePos::from_usize(chunk_index * CHUNK_SIZE + 1);
-
-                    while newlines_mask != 0 {
-                        let index = newlines_mask.trailing_zeros();
-
-                        lines.push(RelativeBytePos(index) + output_offset);
-
-                        // Clear the bit, so we can find the next one.
-                        newlines_mask &= newlines_mask - 1;
-                    }
-                } else {
-                    // The slow path.
-                    // There are multibyte chars in here, fallback to generic decoding.
-                    let scan_start = chunk_index * CHUNK_SIZE + intra_chunk_offset;
-                    intra_chunk_offset = analyze_source_file_generic(
-                        &src[scan_start..],
-                        CHUNK_SIZE - intra_chunk_offset,
-                        RelativeBytePos::from_usize(scan_start),
-                        lines,
-                        multi_byte_chars,
-                    );
-                }
-            }
-
-            // There might still be a tail left to analyze
-            let tail_start = src.len() - tail.len() + intra_chunk_offset;
-            if tail_start < src.len() {
-                analyze_source_file_generic(
-                    &src[tail_start..],
-                    src.len() - tail_start,
-                    RelativeBytePos::from_usize(tail_start),
-                    lines,
-                    multi_byte_chars,
-                );
-            }
-        }
-    }
     _ => {
-        // The target (or compiler version) does not support vector instructions
-        // our specialized implementations need (x86 SSE2, loongarch64 LSX)...
+        // The target (or compiler version) does not support SSE2 ...
         fn analyze_source_file_dispatch(
             src: &str,
             lines: &mut Vec<RelativeBytePos>,

--- a/compiler/rustc_span/src/lib.rs
+++ b/compiler/rustc_span/src/lib.rs
@@ -18,7 +18,6 @@
 // tidy-alphabetical-start
 #![allow(internal_features)]
 #![cfg_attr(bootstrap, feature(round_char_boundary))]
-#![cfg_attr(target_arch = "loongarch64", feature(stdarch_loongarch))]
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
 #![doc(rust_logo)]
 #![feature(array_windows)]


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#146254 (Use `Itertools::all_equal_value()` where applicable)
 - rust-lang/rust#146290 (Revert "Add LSX accelerated implementation for source file analysis")

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=146254,146290)
<!-- homu-ignore:end -->