### PR TITLE
Current platform's target tuple in std::env::consts

### DIFF
--- a/library/std/build.rs
+++ b/library/std/build.rs
@@ -3,6 +3,7 @@ use std::env;
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
     let target_arch = env::var("CARGO_CFG_TARGET_ARCH").expect("CARGO_CFG_TARGET_ARCH was not set");
+    let target = env::var("TARGET").expect("TARGET was not set");
     let target_os = env::var("CARGO_CFG_TARGET_OS").expect("CARGO_CFG_TARGET_OS was not set");
     let target_vendor =
         env::var("CARGO_CFG_TARGET_VENDOR").expect("CARGO_CFG_TARGET_VENDOR was not set");
@@ -73,5 +74,6 @@ fn main() {
     println!("cargo:rustc-check-cfg=cfg(backtrace_in_libstd)");
     println!("cargo:rustc-cfg=backtrace_in_libstd");
 
-    println!("cargo:rustc-env=STD_ENV_ARCH={}", env::var("CARGO_CFG_TARGET_ARCH").unwrap());
+    println!("cargo:rustc-env=STD_ENV_ARCH={target_arch}");
+    println!("cargo:rustc-env=STD_ENV_HOST_TUPLE={target}"); // the target becomes the host from std's perspective
 }

--- a/library/std/src/env.rs
+++ b/library/std/src/env.rs
@@ -1045,6 +1045,48 @@ pub mod consts {
     #[stable(feature = "env", since = "1.0.0")]
     pub const ARCH: &str = env!("STD_ENV_ARCH");
 
+    /// A string identifying the platform for which the standard library was built
+    #[doc = concat!("(`\"", env!("STD_ENV_HOST_TUPLE"), "\"`).")]
+    ///
+    /// This is also known as a *host tuple*, *target triple*, or *target platform*.
+    ///
+    /// The exact format of this string may vary. For details about the platform,
+    /// use the [`ARCH`], [`FAMILY`], and [`OS`] constants.
+    ///
+    /// For platform-specific code, use the [`#[cfg]` attribute][cfg] or [`cfg!` macro](crate::cfg!)
+    /// with the predefined [`target_*` options][target_cfg].
+    ///
+    /// When cross-compiling, the `HOST` seen by build scripts and procedural macros is going
+    /// to be the platform running the cross-compilation, not the target platform of the build.
+    ///
+    /// [cfg]: ../../../reference/conditional-compilation.html#the-cfg-attribute
+    /// [target_cfg]: ../../../reference/conditional-compilation.html#r-cfg.options.set
+    ///
+    /// <details><summary>Example values</summary>
+    ///
+    /// * `"aarch64-apple-ios-sim"`
+    /// * `"aarch64-unknown-linux-gnu"`
+    /// * `"aarch64-unknown-linux-gnu_ilp32"`
+    /// * `"avr-none"`
+    /// * `"loongarch64-unknown-none-softfloat"`
+    /// * `"mipsel-sony-psx"`
+    /// * `"nvptx64-nvidia-cuda"`
+    /// * `"powerpc64le-unknown-freebsd"`
+    /// * `"riscv64-linux-android"`
+    /// * `"sparcv9-sun-solaris"`
+    /// * `"thumbv7a-uwp-windows-msvc"`
+    /// * `"thumbv7neon-unknown-linux-musleabihf"`
+    /// * `"thumbv8m.main-none-eabihf"`
+    /// * `"wasm32-wasip1"`
+    /// * `"x86_64-pc-windows-msvc"`
+    /// * `"x86_64-unknown-redox"`
+    /// * `"xtensa-esp32s3-none-elf"`
+    ///
+    /// </details>
+    #[unstable(feature = "env_host_tuple", issue = "146295")]
+    #[doc(alias = "TARGET")]
+    pub const HOST: &str = env!("STD_ENV_HOST_TUPLE");
+
     /// A string describing the family of the operating system.
     /// An example value may be: `"unix"`, or `"windows"`.
     ///


### PR DESCRIPTION
Implementation for https://github.com/rust-lang/rust/issues/146295

The terminology follows https://github.com/rust-lang/rust/pull/125579

I wasn't sure if it's appropriate to refer users to `rustc --print target-list` in the doc. I haven't seen any other references to compiler flags in std.

I've added a doc alias for `TARGET`, because that's [unfortunately](https://internals.rust-lang.org/t/renaming-cargo-target/21585) the name users may be more familiar with.

I've picked weird platform examples in the doc to discourage users from trying to parse it.