### PR TITLE
docs(std): add error docs for path canonicalize

### DIFF
--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -3037,6 +3037,14 @@ impl Path {
     ///
     /// This is an alias to [`fs::canonicalize`].
     ///
+    /// # Errors
+    ///
+    /// This method will return an error in the following situations, but is not
+    /// limited to just these cases:
+    ///
+    /// * `path` does not exist.
+    /// * A non-final component in path is not a directory.
+    ///
     /// # Examples
     ///
     /// ```no_run


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

This PR adds the missing error documentation for both [Path.canonicalize](https://doc.rust-lang.org/std/path/struct.Path.html#method.canonicalize) and [PathBuf.canonicalize](https://doc.rust-lang.org/std/path/struct.PathBuf.html#method.canonicalize) methods. Since both methods are wappers around [fs::canonicalize](https://doc.rust-lang.org/std/fs/fn.canonicalize.html), the error doc is copied directly from that function.

This makes it faster to find what errors might arise when calling `path.canonicalize` or `path_buf.canonicalize` in the editor itself without needing to drill down to the  `fs::canonicalzie` docs.
