### PR TITLE
Implement `Sum` and `Product` for `f16` and `f128`.

### DIFF
--- a/library/core/src/iter/traits/accum.rs
+++ b/library/core/src/iter/traits/accum.rs
@@ -203,7 +203,7 @@ macro_rules! float_sum_product {
 
 integer_sum_product! { i8 i16 i32 i64 i128 isize u8 u16 u32 u64 u128 usize }
 saturating_integer_sum_product! { u8 u16 u32 u64 u128 usize }
-float_sum_product! { f32 f64 }
+float_sum_product! { f16 f32 f64 f128 }
 
 #[stable(feature = "iter_arith_traits_result", since = "1.16.0")]
 impl<T, U, E> Sum<Result<U, E>> for Result<T, E>


### PR DESCRIPTION
Tracking issue: rust-lang/rust#116909.

This PR implements `core::iter::{Sum, Product}` for `f16` and `f128`.

I'm curious as to why these two traits aren't already implemented. I've been unable to find any information about it at all, so if there is anything that currently blocks them, I would appreciate if someone could fill me in.