### PR TITLE
library: std: sys: net: uefi: tcp: Implement write_vectored

### DIFF
--- a/library/std/src/sys/net/connection/uefi/mod.rs
+++ b/library/std/src/sys/net/connection/uefi/mod.rs
@@ -82,12 +82,11 @@ impl TcpStream {
     }
 
     pub fn write_vectored(&self, buf: &[IoSlice<'_>]) -> io::Result<usize> {
-        // FIXME: UEFI does support vectored write, so implement that.
-        crate::io::default_write_vectored(|b| self.write(b), buf)
+        self.inner.write_vectored(buf, self.write_timeout()?)
     }
 
     pub fn is_write_vectored(&self) -> bool {
-        false
+        true
     }
 
     pub fn peer_addr(&self) -> io::Result<SocketAddr> {

--- a/library/std/src/sys/net/connection/uefi/tcp.rs
+++ b/library/std/src/sys/net/connection/uefi/tcp.rs
@@ -1,5 +1,5 @@
 use super::tcp4;
-use crate::io;
+use crate::io::{self, IoSlice};
 use crate::net::SocketAddr;
 use crate::ptr::NonNull;
 use crate::sys::{helpers, unsupported};
@@ -25,6 +25,16 @@ impl Tcp {
     pub(crate) fn write(&self, buf: &[u8], timeout: Option<Duration>) -> io::Result<usize> {
         match self {
             Self::V4(client) => client.write(buf, timeout),
+        }
+    }
+
+    pub(crate) fn write_vectored(
+        &self,
+        buf: &[IoSlice<'_>],
+        timeout: Option<Duration>,
+    ) -> io::Result<usize> {
+        match self {
+            Self::V4(client) => client.write_vectored(buf, timeout),
         }
     }
 


### PR DESCRIPTION
- A working vectored write implementation for TCP4.
- Also introduces a small helper UefiBox intended to be used with heap allocated UEFI DSTs.
- Tested on OVMF

cc @nicholasbishop 
