### PR TITLE
Re-export `f16` and `f128` into `core::primitive`.

### DIFF
--- a/library/core/src/primitive.rs
+++ b/library/core/src/primitive.rs
@@ -41,10 +41,14 @@
 pub use bool;
 #[stable(feature = "core_primitive", since = "1.43.0")]
 pub use char;
+#[unstable(feature = "f16", issue = "116909")]
+pub use f16;
 #[stable(feature = "core_primitive", since = "1.43.0")]
 pub use f32;
 #[stable(feature = "core_primitive", since = "1.43.0")]
 pub use f64;
+#[unstable(feature = "f128", issue = "116909")]
+pub use f128;
 #[stable(feature = "core_primitive", since = "1.43.0")]
 pub use i8;
 #[stable(feature = "core_primitive", since = "1.43.0")]


### PR DESCRIPTION
Tracking issue: rust-lang/rust#116909.

This PR re-exports `f16` and `f128` into `core::primitive`.

IIRC we already have unstable re-exports in other places of the standard library.

C.c. @joseluis.