### PR TITLE
Allow static regions in `type_name`.

### DIFF
--- a/compiler/rustc_const_eval/src/util/type_name.rs
+++ b/compiler/rustc_const_eval/src/util/type_name.rs
@@ -168,10 +168,11 @@ impl<'tcx> PrettyPrinter<'tcx> for TypeNamePrinter<'tcx> {
         // Bound regions are always printed (as `'_`), which gives some idea that they are special,
         // even though the `for` is omitted by the pretty printer.
         // E.g. `for<'a, 'b> fn(&'a u32, &'b u32)` is printed as "fn(&'_ u32, &'_ u32)".
+        let kind = region.kind();
         match region.kind() {
-            ty::ReErased | ty::ReEarlyParam(_) => false,
+            ty::ReErased | ty::ReEarlyParam(_) | ty::ReStatic => false,
             ty::ReBound(..) => true,
-            _ => unreachable!(),
+            _ => panic!("type_name unhandled region: {kind:?}"),
         }
     }
 

--- a/tests/ui/type/type-name-basic.rs
+++ b/tests/ui/type/type-name-basic.rs
@@ -107,4 +107,19 @@ pub fn main() {
     }
     let a = Wrap(&()).get();
     v!(a, "type_name_basic::main::Wrap<&()>::get::Info");
+
+    struct Issue146249<T>(T);
+    impl Issue146249<Box<dyn FnOnce()>> {
+        pub fn bar(&self) {
+            let f = || {};
+            v!(
+                f,
+                "type_name_basic::main::Issue146249<\
+                    alloc::boxed::Box<dyn core::ops::function::FnOnce()>\
+                >::bar::{{closure}}"
+            );
+        }
+    }
+    let v: Issue146249<Box<dyn FnOnce()>> = Issue146249(Box::new(|| {}));
+    v.bar();
 }


### PR DESCRIPTION
Fixes rust-lang/rust#146249.

r? @lcnr