### PR TITLE
mark `format_args_nl!` as `#[doc(hidden)]`

### DIFF
--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -1017,6 +1017,7 @@ pub(crate) mod builtin {
     )]
     #[allow_internal_unstable(fmt_internals)]
     #[rustc_builtin_macro]
+    #[doc(hidden)]
     #[macro_export]
     macro_rules! format_args_nl {
         ($fmt:expr) => {{ /* compiler built-in */ }};

--- a/src/librustdoc/html/highlight.rs
+++ b/src/librustdoc/html/highlight.rs
@@ -578,7 +578,7 @@ pub(super) fn write_code(
 }
 
 fn write_footer(out: &mut String, playground_button: Option<&str>) {
-    write_str(out, format_args_nl!("</code></pre>{}</div>", playground_button.unwrap_or_default()));
+    write_str(out, format_args!("</code></pre>{}</div>", playground_button.unwrap_or_default()));
 }
 
 /// How a span of text is classified. Mostly corresponds to token kinds.

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -10,7 +10,6 @@
 #![feature(box_patterns)]
 #![feature(debug_closure_helpers)]
 #![feature(file_buffered)]
-#![feature(format_args_nl)]
 #![feature(if_let_guard)]
 #![feature(iter_advance_by)]
 #![feature(iter_intersperse)]


### PR DESCRIPTION
The `#[unstable]` attribute of the macro already says: 

> `format_args_nl` is only for internal language use and is subject to change

It does seem plausible to hide it from the `std` docs accordingly.

The PR also removes the single usage of the macro outside of `std` as it does not seem like the macro is actually needed there.
