### PR TITLE
Quieter tidy

### DIFF
--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -1249,7 +1249,6 @@ impl Step for Tidy {
 
         if builder.config.channel == "dev" || builder.config.channel == "nightly" {
             if !builder.config.json_output {
-                builder.info("fmt check");
                 if builder.config.initial_rustfmt.is_none() {
                     let inferred_rustfmt_dir = builder.initial_sysroot.join("bin");
                     eprintln!(
@@ -1277,10 +1276,8 @@ HELP: to skip test's attempt to check tidiness, pass `--skip src/tools/tidy` to 
             }
         }
 
-        builder.info("tidy check");
         cmd.delay_failure().run(builder);
 
-        builder.info("x.py completions check");
         let completion_paths = get_completion_paths(builder);
         if builder.config.cmd.bless() {
             builder.ensure(crate::core::build_steps::run::GenerateCompletions);

--- a/src/tools/tidy/src/error_codes.rs
+++ b/src/tools/tidy/src/error_codes.rs
@@ -95,7 +95,6 @@ fn check_removed_error_code_explanation(ci_info: &crate::CiInfo, bad: &mut bool)
         eprintln!("Take a look at E0001 to see how to handle it.");
         return;
     }
-    println!("No error code explanation was removed!");
 }
 
 /// Stage 1: Parses a list of error codes from `error_codes.rs`.

--- a/src/tools/tidy/src/rustdoc_json.rs
+++ b/src/tools/tidy/src/rustdoc_json.rs
@@ -7,7 +7,6 @@ use std::str::FromStr;
 const RUSTDOC_JSON_TYPES: &str = "src/rustdoc-json-types";
 
 pub fn check(src_path: &Path, ci_info: &crate::CiInfo, bad: &mut bool) {
-    println!("Checking tidy rustdoc_json...");
     let Some(base_commit) = &ci_info.base_commit else {
         eprintln!("No base commit, skipping rustdoc_json check");
         return;
@@ -16,7 +15,6 @@ pub fn check(src_path: &Path, ci_info: &crate::CiInfo, bad: &mut bool) {
     // First we check that `src/rustdoc-json-types` was modified.
     if !crate::files_modified(ci_info, |p| p == RUSTDOC_JSON_TYPES) {
         // `rustdoc-json-types` was not modified so nothing more to check here.
-        println!("`rustdoc-json-types` was not modified.");
         return;
     }
     // Then we check that if `FORMAT_VERSION` was updated, the `Latest feature:` was also updated.


### PR DESCRIPTION
When I run `tidy` I currently get output like this:
```text
Building bootstrap
    Finished `dev` profile [unoptimized] target(s) in 0.06s
Building stage1 tidy (stage0 -> stage1, x86_64-unknown-linux-gnu)
    Finished `release` profile [optimized + debuginfo] target(s) in 0.16s
fmt check
fmt: skipped 374 untracked files
fmt info: No modified files detected for formatting.
tidy check
Checking tidy rustdoc_json...
No error code explanation was removed!
`rustdoc-json-types` was not modified.
x.py completions check
Build completed successfully in 0:00:06
```
Several of these output lines seem unnecessary. E.g. there are lots of different tidy tests, why do a couple of them print output saying that they don't need to do anything?

r? @GuillaumeGomez 