### PR TITLE
Fix typo in default.rs

### DIFF
--- a/library/core/src/default.rs
+++ b/library/core/src/default.rs
@@ -33,7 +33,7 @@ use crate::ascii::Char as AsciiChar;
 /// }
 /// ```
 ///
-/// Now, you get all of the default values. Rust implements `Default` for various primitives types.
+/// Now, you get all of the default values. Rust implements `Default` for various primitive types.
 ///
 /// If you want to override a particular option, but still retain the other defaults:
 ///


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

This sentence currently reads:

> Rust implements `Default` for various primitives types.

I think it should just be "primitive types".
