### PR TITLE
Make Barrier RefUnwindSafe again

### DIFF
--- a/library/std/src/sync/barrier.rs
+++ b/library/std/src/sync/barrier.rs
@@ -1,6 +1,5 @@
-use core::panic::RefUnwindSafe;
-
 use crate::fmt;
+use crate::panic::RefUnwindSafe;
 use crate::sync::nonpoison::{Condvar, Mutex};
 
 /// A barrier enables multiple threads to synchronize the beginning
@@ -33,7 +32,7 @@ pub struct Barrier {
     num_threads: usize,
 }
 
-#[stable(feature = "rust1", since = "1.0.0")]
+#[stable(feature = "unwind_safe_lock_refs", since = "1.12.0")]
 impl RefUnwindSafe for Barrier {}
 
 // The inner state of a double barrier

--- a/library/std/src/sync/barrier.rs
+++ b/library/std/src/sync/barrier.rs
@@ -1,3 +1,5 @@
+use core::panic::RefUnwindSafe;
+
 use crate::fmt;
 use crate::sync::nonpoison::{Condvar, Mutex};
 
@@ -30,6 +32,9 @@ pub struct Barrier {
     cvar: Condvar,
     num_threads: usize,
 }
+
+#[stable(feature = "rust1", since = "1.0.0")]
+impl RefUnwindSafe for Barrier {}
 
 // The inner state of a double barrier
 struct BarrierState {

--- a/library/std/tests/sync/barrier.rs
+++ b/library/std/tests/sync/barrier.rs
@@ -35,11 +35,10 @@ fn test_barrier() {
     assert!(leader_found);
 }
 
-#[expect(dead_code, reason = "this is essentially a compile pass test")]
-fn check_barrier_is_ref_unwind_safe() {
-    let barrier = Arc::new(Barrier::new(10));
-
-    fn check<T: RefUnwindSafe>(_: T) {}
-
-    check(barrier);
-}
+/// Asserts that `Barrier` is ref unwind safe.
+///
+/// See <https://github.com/rust-lang/rust/issues/146087>.
+const _: () = {
+    const fn check_ref_unwind_safe<T: RefUnwindSafe>() {}
+    check_ref_unwind_safe::<Barrier>();
+};

--- a/library/std/tests/sync/barrier.rs
+++ b/library/std/tests/sync/barrier.rs
@@ -1,3 +1,4 @@
+use std::panic::RefUnwindSafe;
 use std::sync::mpsc::{TryRecvError, channel};
 use std::sync::{Arc, Barrier};
 use std::thread;
@@ -32,4 +33,13 @@ fn test_barrier() {
         }
     }
     assert!(leader_found);
+}
+
+#[expect(dead_code, reason = "this is essentially a compile pass test")]
+fn check_barrier_is_ref_unwind_safe() {
+    let barrier = Arc::new(Barrier::new(10));
+
+    fn check<T: RefUnwindSafe>(_: T) {}
+
+    check(barrier);
 }


### PR DESCRIPTION
This commit manually implements `RefUnwindSafe` for `std::sync::Barrier` to fix rust-lang/rust#146087. This is a fix for a regression indroduced by https://github.com/rust-lang/rust/commit/e95db591a4550e28ad92660b753ad85b89271882

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
