### PR TITLE
disable core dumps for panic-uninitialized-zeroed

### DIFF
--- a/tests/ui/intrinsics/panic-uninitialized-zeroed.rs
+++ b/tests/ui/intrinsics/panic-uninitialized-zeroed.rs
@@ -5,15 +5,19 @@
 //@ [strict]compile-flags: -Zstrict-init-checks
 //@ needs-subprocess
 //@ ignore-backends: gcc
+//@ edition:2024
 
 #![allow(deprecated, invalid_value)]
-#![feature(never_type)]
+#![feature(never_type, rustc_private)]
 
 use std::{
     mem::{self, MaybeUninit, ManuallyDrop},
     ptr::NonNull,
     num,
 };
+
+#[cfg(target_os = "linux")]
+extern crate libc;
 
 #[allow(dead_code)]
 struct Foo {
@@ -108,6 +112,17 @@ fn test_panic_msg_only_if_strict<T>(op: impl (FnOnce() -> T) + 'static, msg: &st
 
 fn main() {
     unsafe {
+        #[cfg(target_os = "linux")]
+        {
+            // This test causes a large amount of crashes. If a system
+            // has a /proc/sys/kernel/core_pattern that uploads core dumps enabled,
+            // it will take a long time to complete. Set dumpable to 0 to avoid that.
+            if libc::prctl(libc::PR_SET_DUMPABLE, 0) < 0 {
+                let err = std::io::Error::last_os_error();
+                panic!("failed to disable core dumps {err:?}");
+            }
+        }
+
         // Uninhabited types
         test_panic_msg(
             || mem::uninitialized::<!>(),


### PR DESCRIPTION
That test causes a large amount of crashes. If a system has a /proc/sys/kernel/core_pattern that uploads core dumps enabled, it will take a long time to complete. Set dumpable to 0 to avoid that.

Before:
```
$ time ./panic-uninitialized-zeroed

real    0m47.457s
user    0m0.023s
sys     0m0.021s
```

After:
```
$ ./panic-uninitialized-zeroed

real    0m0.029s
user    0m0.019s
sys     0m0.010s
```
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
