### PR TITLE
minimal dirfd implementation (1/4)

### DIFF
--- a/library/std/src/fs/tests.rs
+++ b/library/std/src/fs/tests.rs
@@ -1,7 +1,11 @@
 use rand::RngCore;
 
+#[cfg(not(miri))]
+use super::Dir;
 use crate::assert_matches::assert_matches;
 use crate::fs::{self, File, FileTimes, OpenOptions, TryLockError};
+#[cfg(not(miri))]
+use crate::io;
 use crate::io::prelude::*;
 use crate::io::{BorrowedBuf, ErrorKind, SeekFrom};
 use crate::mem::MaybeUninit;
@@ -2464,4 +2468,31 @@ fn test_fs_set_times_nofollow() {
     let target_metadata = fs::metadata(&target).unwrap();
     assert_ne!(target_metadata.accessed().unwrap(), accessed);
     assert_ne!(target_metadata.modified().unwrap(), modified);
+}
+
+#[test]
+// FIXME: libc calls fail on miri
+#[cfg(not(miri))]
+fn test_dir_smoke_test() {
+    let tmpdir = tmpdir();
+    let dir = Dir::open(tmpdir.path());
+    check!(dir);
+}
+
+#[test]
+// FIXME: libc calls fail on miri
+#[cfg(not(miri))]
+fn test_dir_read_file() {
+    let tmpdir = tmpdir();
+    let mut f = check!(File::create(tmpdir.join("foo.txt")));
+    check!(f.write(b"bar"));
+    check!(f.flush());
+    drop(f);
+    let dir = check!(Dir::open(tmpdir.path()));
+    let f = check!(dir.open_file("foo.txt"));
+    let buf = check!(io::read_to_string(f));
+    assert_eq!("bar", &buf);
+    let f = check!(dir.open_file(tmpdir.join("foo.txt")));
+    let buf = check!(io::read_to_string(f));
+    assert_eq!("bar", &buf);
 }

--- a/library/std/src/sys/fs/common.rs
+++ b/library/std/src/sys/fs/common.rs
@@ -1,9 +1,10 @@
 #![allow(dead_code)] // not used on all platforms
 
-use crate::fs;
 use crate::io::{self, Error, ErrorKind};
-use crate::path::Path;
+use crate::path::{Path, PathBuf};
+use crate::sys::fs::{File, OpenOptions};
 use crate::sys::helpers::ignore_notfound;
+use crate::{fmt, fs};
 
 pub(crate) const NOT_FILE_ERROR: Error = io::const_error!(
     ErrorKind::InvalidInput,
@@ -56,5 +57,25 @@ pub fn exists(path: &Path) -> io::Result<bool> {
         Ok(_) => Ok(true),
         Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(false),
         Err(error) => Err(error),
+    }
+}
+
+pub struct Dir {
+    path: PathBuf,
+}
+
+impl Dir {
+    pub fn open(path: &Path, _opts: &OpenOptions) -> io::Result<Self> {
+        path.canonicalize().map(|path| Self { path })
+    }
+
+    pub fn open_file(&self, path: &Path, opts: &OpenOptions) -> io::Result<File> {
+        File::open(&self.path.join(path), &opts)
+    }
+}
+
+impl fmt::Debug for Dir {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Dir").field("path", &self.path).finish()
     }
 }

--- a/library/std/src/sys/fs/hermit.rs
+++ b/library/std/src/sys/fs/hermit.rs
@@ -10,7 +10,7 @@ use crate::os::hermit::io::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, Raw
 use crate::path::{Path, PathBuf};
 use crate::sync::Arc;
 use crate::sys::fd::FileDesc;
-pub use crate::sys::fs::common::{copy, exists};
+pub use crate::sys::fs::common::{Dir, copy, exists};
 use crate::sys::helpers::run_path_with_cstr;
 use crate::sys::time::SystemTime;
 use crate::sys::{AsInner, AsInnerMut, FromInner, IntoInner, cvt, unsupported, unsupported_err};
@@ -18,6 +18,7 @@ use crate::{fmt, mem};
 
 #[derive(Debug)]
 pub struct File(FileDesc);
+
 #[derive(Clone)]
 pub struct FileAttr {
     stat_val: stat_struct,

--- a/library/std/src/sys/fs/mod.rs
+++ b/library/std/src/sys/fs/mod.rs
@@ -59,7 +59,7 @@ pub fn with_native_path<T>(path: &Path, f: &dyn Fn(&Path) -> io::Result<T>) -> i
 }
 
 pub use imp::{
-    DirBuilder, DirEntry, File, FileAttr, FilePermissions, FileTimes, FileType, OpenOptions,
+    Dir, DirBuilder, DirEntry, File, FileAttr, FilePermissions, FileTimes, FileType, OpenOptions,
     ReadDir,
 };
 

--- a/library/std/src/sys/fs/solid.rs
+++ b/library/std/src/sys/fs/solid.rs
@@ -9,7 +9,7 @@ use crate::os::raw::{c_int, c_short};
 use crate::os::solid::ffi::OsStrExt;
 use crate::path::{Path, PathBuf};
 use crate::sync::Arc;
-pub use crate::sys::fs::common::exists;
+pub use crate::sys::fs::common::{Dir, exists};
 use crate::sys::helpers::ignore_notfound;
 use crate::sys::pal::{abi, error};
 use crate::sys::time::SystemTime;

--- a/library/std/src/sys/fs/uefi.rs
+++ b/library/std/src/sys/fs/uefi.rs
@@ -6,6 +6,7 @@ use crate::fs::TryLockError;
 use crate::hash::Hash;
 use crate::io::{self, BorrowedCursor, IoSlice, IoSliceMut, SeekFrom};
 use crate::path::{Path, PathBuf};
+pub use crate::sys::fs::common::Dir;
 use crate::sys::pal::{helpers, unsupported};
 use crate::sys::time::SystemTime;
 

--- a/library/std/src/sys/fs/unix/dir.rs
+++ b/library/std/src/sys/fs/unix/dir.rs
@@ -1,0 +1,114 @@
+use libc::c_int;
+
+cfg_select! {
+    not(
+        any(
+            all(target_os = "linux", not(target_env = "musl")),
+            target_os = "l4re",
+            target_os = "android",
+            target_os = "hurd",
+        )
+    ) => {
+        use libc::{open as open64, openat as openat64};
+    }
+    _ => {
+        use libc::{open64, openat64};
+    }
+}
+
+use crate::ffi::CStr;
+use crate::os::fd::{AsFd, BorrowedFd, IntoRawFd, OwnedFd, RawFd};
+#[cfg(target_family = "unix")]
+use crate::os::unix::io::{AsRawFd, FromRawFd};
+#[cfg(target_os = "wasi")]
+use crate::os::wasi::io::{AsRawFd, FromRawFd};
+use crate::path::Path;
+use crate::sys::fd::FileDesc;
+use crate::sys::fs::OpenOptions;
+use crate::sys::fs::unix::{File, debug_path_fd};
+use crate::sys::helpers::run_path_with_cstr;
+use crate::sys::{AsInner, FromInner, IntoInner, cvt_r};
+use crate::{fmt, fs, io};
+
+pub struct Dir(OwnedFd);
+
+impl Dir {
+    pub fn open(path: &Path, opts: &OpenOptions) -> io::Result<Self> {
+        run_path_with_cstr(path, &|path| Self::open_with_c(path, opts))
+    }
+
+    pub fn open_file(&self, path: &Path, opts: &OpenOptions) -> io::Result<File> {
+        run_path_with_cstr(path.as_ref(), &|path| self.open_file_c(path, &opts))
+    }
+
+    pub fn open_with_c(path: &CStr, opts: &OpenOptions) -> io::Result<Self> {
+        let flags = libc::O_CLOEXEC
+            | libc::O_DIRECTORY
+            | opts.get_access_mode()?
+            | opts.get_creation_mode()?
+            | (opts.custom_flags as c_int & !libc::O_ACCMODE);
+        let fd = cvt_r(|| unsafe { open64(path.as_ptr(), flags, opts.mode as c_int) })?;
+        Ok(Self(unsafe { OwnedFd::from_raw_fd(fd) }))
+    }
+
+    fn open_file_c(&self, path: &CStr, opts: &OpenOptions) -> io::Result<File> {
+        let flags = libc::O_CLOEXEC
+            | opts.get_access_mode()?
+            | opts.get_creation_mode()?
+            | (opts.custom_flags as c_int & !libc::O_ACCMODE);
+        let fd = cvt_r(|| unsafe {
+            openat64(self.0.as_raw_fd(), path.as_ptr(), flags, opts.mode as c_int)
+        })?;
+        Ok(File(unsafe { FileDesc::from_raw_fd(fd) }))
+    }
+}
+
+impl fmt::Debug for Dir {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let fd = self.0.as_raw_fd();
+        let mut b = debug_path_fd(fd, f, "Dir");
+        b.finish()
+    }
+}
+
+#[unstable(feature = "dirfd", issue = "120426")]
+impl AsRawFd for fs::Dir {
+    fn as_raw_fd(&self) -> RawFd {
+        self.as_inner().0.as_raw_fd()
+    }
+}
+
+#[unstable(feature = "dirfd", issue = "120426")]
+impl IntoRawFd for fs::Dir {
+    fn into_raw_fd(self) -> RawFd {
+        self.into_inner().0.into_raw_fd()
+    }
+}
+
+#[unstable(feature = "dirfd", issue = "120426")]
+impl FromRawFd for fs::Dir {
+    unsafe fn from_raw_fd(fd: RawFd) -> Self {
+        Self::from_inner(Dir(unsafe { FromRawFd::from_raw_fd(fd) }))
+    }
+}
+
+#[unstable(feature = "dirfd", issue = "120426")]
+impl AsFd for fs::Dir {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        self.as_inner().0.as_fd()
+    }
+}
+
+#[unstable(feature = "dirfd", issue = "120426")]
+impl From<fs::Dir> for OwnedFd {
+    fn from(value: fs::Dir) -> Self {
+        value.into_inner().0
+    }
+}
+
+#[unstable(feature = "dirfd", issue = "120426")]
+impl From<OwnedFd> for fs::Dir {
+    fn from(value: OwnedFd) -> Self {
+        Self::from_inner(Dir(value))
+    }
+}

--- a/library/std/src/sys/fs/unsupported.rs
+++ b/library/std/src/sys/fs/unsupported.rs
@@ -4,6 +4,7 @@ use crate::fs::TryLockError;
 use crate::hash::{Hash, Hasher};
 use crate::io::{self, BorrowedCursor, IoSlice, IoSliceMut, SeekFrom};
 use crate::path::{Path, PathBuf};
+pub use crate::sys::fs::common::Dir;
 use crate::sys::time::SystemTime;
 use crate::sys::unsupported;
 

--- a/library/std/src/sys/fs/windows/dir.rs
+++ b/library/std/src/sys/fs/windows/dir.rs
@@ -1,0 +1,153 @@
+use crate::os::windows::io::{
+    AsHandle, AsRawHandle, BorrowedHandle, FromRawHandle, HandleOrInvalid, IntoRawHandle,
+    OwnedHandle, RawHandle,
+};
+use crate::path::Path;
+use crate::sys::api::{UnicodeStrRef, WinError};
+use crate::sys::fs::windows::debug_path_handle;
+use crate::sys::fs::{File, OpenOptions};
+use crate::sys::handle::Handle;
+use crate::sys::path::{WCStr, with_native_path};
+use crate::sys::{AsInner, FromInner, IntoInner, IoResult, c, to_u16s};
+use crate::{fmt, fs, io, ptr};
+
+pub struct Dir {
+    handle: Handle,
+}
+
+/// A wrapper around a raw NtCreateFile call.
+///
+/// This isn't completely safe because `OBJECT_ATTRIBUTES` contains raw pointers.
+unsafe fn nt_create_file(
+    opts: &OpenOptions,
+    object_attributes: &c::OBJECT_ATTRIBUTES,
+    create_options: c::NTCREATEFILE_CREATE_OPTIONS,
+) -> io::Result<Handle> {
+    let mut handle = ptr::null_mut();
+    let mut io_status = c::IO_STATUS_BLOCK::PENDING;
+    // SYNCHRONIZE is included in FILE_GENERIC_READ, but not GENERIC_READ, so we add it manually
+    let access = opts.get_access_mode()? | c::SYNCHRONIZE;
+    // one of FILE_SYNCHRONOUS_IO_{,NON}ALERT is required for later operations to succeed.
+    let options = create_options | c::FILE_SYNCHRONOUS_IO_NONALERT;
+    let status = unsafe {
+        c::NtCreateFile(
+            &mut handle,
+            access,
+            object_attributes,
+            &mut io_status,
+            ptr::null(),
+            c::FILE_ATTRIBUTE_NORMAL,
+            opts.share_mode,
+            opts.get_disposition()?,
+            options,
+            ptr::null(),
+            0,
+        )
+    };
+    if c::nt_success(status) {
+        // SAFETY: nt_success guarantees that handle is no longer null
+        unsafe { Ok(Handle::from_raw_handle(handle)) }
+    } else {
+        Err(WinError::new(unsafe { c::RtlNtStatusToDosError(status) })).io_result()
+    }
+}
+
+impl Dir {
+    pub fn open(path: &Path, opts: &OpenOptions) -> io::Result<Self> {
+        with_native_path(path, &|path| Self::open_with_native(path, opts))
+    }
+
+    pub fn open_file(&self, path: &Path, opts: &OpenOptions) -> io::Result<File> {
+        // NtCreateFile will fail if given an absolute path and a non-null RootDirectory
+        if path.is_absolute() {
+            return File::open(path, opts);
+        }
+        let path = to_u16s(path)?;
+        let path = &path[..path.len() - 1]; // trim 0 byte
+        self.open_file_native(&path, opts).map(|handle| File { handle })
+    }
+
+    fn open_with_native(path: &WCStr, opts: &OpenOptions) -> io::Result<Self> {
+        let creation = opts.get_creation_mode()?;
+        let sa = c::SECURITY_ATTRIBUTES {
+            nLength: size_of::<c::SECURITY_ATTRIBUTES>() as u32,
+            lpSecurityDescriptor: ptr::null_mut(),
+            bInheritHandle: opts.inherit_handle as c::BOOL,
+        };
+        let handle = unsafe {
+            c::CreateFileW(
+                path.as_ptr(),
+                opts.get_access_mode()?,
+                opts.share_mode,
+                &raw const sa,
+                creation,
+                // FILE_FLAG_BACKUP_SEMANTICS is required to open a directory
+                opts.get_flags_and_attributes() | c::FILE_FLAG_BACKUP_SEMANTICS,
+                ptr::null_mut(),
+            )
+        };
+        match OwnedHandle::try_from(unsafe { HandleOrInvalid::from_raw_handle(handle) }) {
+            Ok(handle) => Ok(Self { handle: Handle::from_inner(handle) }),
+            Err(_) => Err(io::Error::last_os_error()),
+        }
+    }
+
+    fn open_file_native(&self, path: &[u16], opts: &OpenOptions) -> io::Result<Handle> {
+        let name = UnicodeStrRef::from_slice(path);
+        let object_attributes = c::OBJECT_ATTRIBUTES {
+            RootDirectory: self.handle.as_raw_handle(),
+            ObjectName: name.as_ptr(),
+            ..c::OBJECT_ATTRIBUTES::with_length()
+        };
+        unsafe { nt_create_file(opts, &object_attributes, c::FILE_NON_DIRECTORY_FILE) }
+    }
+}
+
+impl fmt::Debug for Dir {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut b = debug_path_handle(self.handle.as_handle(), f, "Dir");
+        b.finish()
+    }
+}
+
+#[unstable(feature = "dirfd", issue = "120426")]
+impl AsRawHandle for fs::Dir {
+    fn as_raw_handle(&self) -> RawHandle {
+        self.as_inner().handle.as_raw_handle()
+    }
+}
+
+#[unstable(feature = "dirhandle", issue = "120426")]
+impl IntoRawHandle for fs::Dir {
+    fn into_raw_handle(self) -> RawHandle {
+        self.into_inner().handle.into_raw_handle()
+    }
+}
+
+#[unstable(feature = "dirhandle", issue = "120426")]
+impl FromRawHandle for fs::Dir {
+    unsafe fn from_raw_handle(handle: RawHandle) -> Self {
+        Self::from_inner(Dir { handle: unsafe { FromRawHandle::from_raw_handle(handle) } })
+    }
+}
+
+#[unstable(feature = "dirhandle", issue = "120426")]
+impl AsHandle for fs::Dir {
+    fn as_handle(&self) -> BorrowedHandle<'_> {
+        self.as_inner().handle.as_handle()
+    }
+}
+
+#[unstable(feature = "dirhandle", issue = "120426")]
+impl From<fs::Dir> for OwnedHandle {
+    fn from(value: fs::Dir) -> Self {
+        value.into_inner().handle.into_inner()
+    }
+}
+
+#[unstable(feature = "dirhandle", issue = "120426")]
+impl From<OwnedHandle> for fs::Dir {
+    fn from(value: OwnedHandle) -> Self {
+        Self::from_inner(Dir { handle: Handle::from_inner(value) })
+    }
+}


### PR DESCRIPTION
This is the first of four smaller PRs that will eventually be equivalent to rust-lang/rust#139514.

A few notes:

- I renamed `new` to `open` because `open_dir` takes `&self` and opens a subdirectory.
  - I also renamed `open` to `open_file`.
- I'm not sure how to `impl AsRawFd` and friends because the `common` implementation uses `PathBuf`s. How should I proceed here?

The other PRs will be based on this one, so I'll make drafts and mark them ready as their predecessors get merged. They might take a bit though; I've never done this particular thing with git before.

Tracking issue: https://github.com/rust-lang/rust/issues/120426

<!-- homu-ignore:start -->

r? @tgross35

<!-- homu-ignore:end -->

try-job: aarch64-apple
try-job: dist-various*
try-job: test-various*
try-job: x86_64-msvc-1
try-job: x86_64-mingw*