### PR TITLE
Weakly export `platform_version` symbols

### DIFF
--- a/library/std/src/sys/platform_version/darwin/public_extern.rs
+++ b/library/std/src/sys/platform_version/darwin/public_extern.rs
@@ -77,6 +77,10 @@ use super::{current_version, pack_i32_os_version};
 // NOTE: This symbol has a workaround in the compiler's symbol mangling to avoid mangling it, while
 // still not exposing it from non-cdylib (like `#[no_mangle]` would).
 #[rustc_std_internal_symbol]
+// NOTE: Making this a weak symbol might not be entirely the right solution for this, `compiler_rt`
+// doesn't do that, it instead makes the symbol have "hidden" visibility. But since this is placed
+// in `libstd`, which might be used as a dylib, we cannot do the same here.
+#[linkage = "weak"]
 // extern "C" is correct, Clang assumes the function cannot unwind:
 // https://github.com/llvm/llvm-project/blob/llvmorg-20.1.0/clang/lib/CodeGen/CGObjC.cpp#L3980
 //
@@ -145,6 +149,7 @@ pub(super) extern "C" fn __isPlatformVersionAtLeast(
 /// Old entry point for availability. Used when compiling with older Clang versions.
 // SAFETY: Same as for `__isPlatformVersionAtLeast`.
 #[rustc_std_internal_symbol]
+#[linkage = "weak"]
 pub(super) extern "C" fn __isOSVersionAtLeast(major: i32, minor: i32, subminor: i32) -> i32 {
     let version = pack_i32_os_version(major, minor, subminor);
     (version <= current_version()) as i32

--- a/library/std/src/sys/platform_version/darwin/tests.rs
+++ b/library/std/src/sys/platform_version/darwin/tests.rs
@@ -28,6 +28,9 @@ fn compare_against_sw_vers() {
     let subminor: i32 = sw_vers.next().unwrap_or("0").parse().unwrap();
     assert_eq!(sw_vers.count(), 0);
 
+    // Test directly against the lookup
+    assert_eq!(lookup_version().get(), pack_os_version(major as _, minor as _, subminor as _));
+
     // Current version is available
     assert_eq!(__isOSVersionAtLeast(major, minor, subminor), 1);
 
@@ -40,9 +43,6 @@ fn compare_against_sw_vers() {
     assert_eq!(__isOSVersionAtLeast(major, minor, subminor + 1), 0);
     assert_eq!(__isOSVersionAtLeast(major, minor + 1, subminor), 0);
     assert_eq!(__isOSVersionAtLeast(major + 1, minor, subminor), 0);
-
-    // Test directly against the lookup
-    assert_eq!(lookup_version().get(), pack_os_version(major as _, minor as _, subminor as _));
 }
 
 #[test]


### PR DESCRIPTION
The symbols `__isPlatformVersionAtLeast` and `__isOSVersionAtLeast`. This should allow linking both `compiler-rt` and `std`, which fixes https://github.com/rust-lang/rust/pull/138944#issuecomment-3266574582.

r? tgross35
CC @zmodem, could you please verify that this works for you?