### PR TITLE
Implement `raw-dylib` on Mach-O

### DIFF
--- a/compiler/rustc_attr_parsing/messages.ftl
+++ b/compiler/rustc_attr_parsing/messages.ftl
@@ -242,6 +242,12 @@ attr_parsing_raw_dylib_no_nul =
 attr_parsing_raw_dylib_elf_unstable =
     link kind `raw-dylib` is unstable on ELF platforms
 
+attr_parsing_raw_dylib_macho_unstable =
+    link kind `raw-dylib` is unstable on Mach-O platforms
+
+attr_parsing_raw_dylib_macho_use_verbatim =
+    link kind `raw-dylib` should use the `+verbatim` linkage modifier
+
 attr_parsing_raw_dylib_only_windows =
     link kind `raw-dylib` is only supported on Windows targets
 

--- a/compiler/rustc_attr_parsing/src/session_diagnostics.rs
+++ b/compiler/rustc_attr_parsing/src/session_diagnostics.rs
@@ -882,6 +882,13 @@ pub(crate) struct RawDylibOnlyWindows {
 }
 
 #[derive(Diagnostic)]
+#[diag(attr_parsing_raw_dylib_macho_use_verbatim)]
+pub(crate) struct RawDylibMachoUseVerbatim {
+    #[primary_span]
+    pub span: Span,
+}
+
+#[derive(Diagnostic)]
 #[diag(attr_parsing_invalid_link_modifier)]
 pub(crate) struct InvalidLinkModifier {
     #[primary_span]

--- a/compiler/rustc_codegen_ssa/src/back/link/raw_dylib.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link/raw_dylib.rs
@@ -1,5 +1,7 @@
+use std::ffi::CString;
 use std::fs;
 use std::io::{BufWriter, Write};
+use std::mem::ManuallyDrop;
 use std::path::{Path, PathBuf};
 
 use rustc_abi::Endian;
@@ -11,6 +13,7 @@ use rustc_hir::attrs::NativeLibKind;
 use rustc_session::Session;
 use rustc_session::cstore::DllImport;
 use rustc_span::Symbol;
+use rustc_target::spec::apple::OSVersion;
 
 use crate::back::archive::ImportLibraryItem;
 use crate::back::link::ArchiveBuilderBuilder;
@@ -124,6 +127,129 @@ pub(super) fn create_raw_dylib_dll_import_libs<'a>(
             output_path
         })
         .collect()
+}
+
+/// Mach-O linkers support the TAPI/TBD (TextAPI / Text-based Stubs) format as an alternative to
+/// a full dynamic library.
+///
+/// TODO.
+pub(super) fn create_raw_dylib_macho_tapi<'a>(
+    sess: &Session,
+    used_libraries: impl IntoIterator<Item = &'a NativeLib>,
+    tmpdir: &Path,
+) -> impl Iterator<Item = PathBuf> {
+    collate_raw_dylibs(sess, used_libraries).into_iter().map(|(install_name, raw_dylib_imports)| {
+        // TODO: Do this properly
+        let path = tmpdir.join(Path::new(&install_name).file_stem().unwrap()).with_extension("tbd");
+
+        let exports: Vec<_> = raw_dylib_imports
+            .iter()
+            .map(|import| {
+                let name = if let Some(name) = import.name.as_str().strip_prefix("\x01") {
+                    name.to_string()
+                } else {
+                    format!("_{}", import.name.as_str())
+                };
+                LLVMRustMachOTbdExport {
+                    // TODO
+                    name: ManuallyDrop::new(CString::new(name).unwrap()).as_ptr(),
+                    flags: if import.is_fn { SymbolFlags::Text } else { SymbolFlags::Data },
+                    kind: EncodeKind::GlobalSymbol,
+                }
+            })
+            .collect();
+
+        unsafe {
+            macho_tbd_write(
+                &path,
+                &sess.target.llvm_target,
+                &install_name,
+                OSVersion::new(1, 0, 0),
+                OSVersion::new(1, 0, 0),
+                &exports,
+            )
+            .unwrap()
+        };
+
+        path
+    })
+}
+
+bitflags::bitflags! {
+    #[repr(transparent)]
+    #[derive(Copy, Clone)]
+    pub(crate) struct SymbolFlags: u8 {
+        const None = 0;
+        const ThreadLocalValue = 1 << 0;
+        const WeakDefined = 1 << 1;
+        const WeakReferenced = 1 << 2;
+        const Undefined = 1 << 3;
+        const Rexported = 1 << 4;
+        const Data = 1 << 5;
+        const Text = 1 << 6;
+    }
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+#[repr(u8)]
+#[allow(unused)]
+pub(crate) enum EncodeKind {
+    GlobalSymbol = 0,
+    ObjectiveCClass = 1,
+    ObjectiveCClassEHType = 2,
+    ObjectiveCInstanceVariable = 3,
+}
+
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub(crate) struct LLVMRustMachOTbdExport {
+    pub(crate) name: *const std::ffi::c_char,
+    pub(crate) flags: SymbolFlags,
+    pub(crate) kind: EncodeKind,
+}
+
+unsafe extern "C" {
+    pub(crate) fn LLVMRustMachoTbdWrite(
+        path: *const std::ffi::c_char,
+        llvm_target_name: *const std::ffi::c_char,
+        install_name: *const std::ffi::c_char,
+        current_version: u32,
+        compatibility_version: u32,
+        exports: *const LLVMRustMachOTbdExport,
+        num_exports: libc::size_t,
+    ) -> u8;
+}
+
+unsafe fn macho_tbd_write(
+    path: &Path,
+    llvm_target_name: &str,
+    install_name: &str,
+    current_version: OSVersion,
+    compatibility_version: OSVersion,
+    exports: &[LLVMRustMachOTbdExport],
+) -> Result<(), ()> {
+    let path = CString::new(path.to_str().unwrap()).unwrap();
+    let llvm_target_name = CString::new(llvm_target_name).unwrap();
+    let install_name = CString::new(install_name).unwrap();
+
+    fn pack_version(OSVersion { major, minor, patch }: OSVersion) -> u32 {
+        let (major, minor, patch) = (major as u32, minor as u32, patch as u32);
+        (major << 16) | (minor << 8) | patch
+    }
+
+    let result = unsafe {
+        LLVMRustMachoTbdWrite(
+            path.as_ptr(),
+            llvm_target_name.as_ptr(),
+            install_name.as_ptr(),
+            pack_version(current_version),
+            pack_version(compatibility_version),
+            exports.as_ptr(),
+            exports.len(),
+        )
+    };
+
+    if result == 0 { Ok(()) } else { Err(()) }
 }
 
 pub(super) fn create_raw_dylib_elf_stub_shared_objects<'a>(

--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -611,8 +611,10 @@ declare_features! (
     (unstable, postfix_match, "1.79.0", Some(121618)),
     /// Allows macro attributes on expressions, statements and non-inline modules.
     (unstable, proc_macro_hygiene, "1.30.0", Some(54727)),
-    /// Allows the use of raw-dylibs on ELF platforms
+    /// Allows the use of raw-dylibs on ELF platforms.
     (incomplete, raw_dylib_elf, "1.87.0", Some(135694)),
+    /// Allows the use of raw-dylibs on Mach-O platforms.
+    (incomplete, raw_dylib_macho, "CURRENT_RUSTC_VERSION", Some(146356)),
     (unstable, reborrow, "CURRENT_RUSTC_VERSION", Some(145612)),
     /// Makes `&` and `&mut` patterns eat only one layer of references in Rust 2024.
     (incomplete, ref_pat_eat_one_layer_2024, "1.79.0", Some(123076)),

--- a/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
@@ -35,6 +35,10 @@
 #include "llvm/Support/Signals.h"
 #include "llvm/Support/Timer.h"
 #include "llvm/Support/ToolOutputFile.h"
+#include "llvm/TextAPI/Architecture.h"
+#include "llvm/TextAPI/InterfaceFile.h"
+#include "llvm/TextAPI/Platform.h"
+#include "llvm/TextAPI/TextAPIWriter.h"
 #include <iostream>
 
 // for raw `write` in the bad-alloc handler
@@ -1944,4 +1948,53 @@ extern "C" void LLVMRustSetNoSanitizeHWAddress(LLVMValueRef Global) {
     MD = GV.getSanitizerMetadata();
   MD.NoHWAddress = true;
   GV.setSanitizerMetadata(MD);
+}
+
+struct LLVMRustMachOTbdExport {
+  char *name;
+  MachO::SymbolFlags flags;
+  MachO::EncodeKind kind;
+};
+
+extern "C" uint8_t LLVMRustMachoTbdWrite(
+    const char *Path,
+    const char *LLVMTargetName,
+    const char *InstallName,
+    uint32_t CurrentVersion,
+    uint32_t CompatibilityVersion,
+    const LLVMRustMachOTbdExport *Exports,
+    size_t NumExports) {
+  MachO::InterfaceFile File;
+  File.setFileType(MachO::FileType::TBD_V1); // TODO
+
+  File.setInstallName(StringRef(InstallName));
+  File.setCurrentVersion(MachO::PackedVersion(CurrentVersion));
+  File.setCompatibilityVersion(MachO::PackedVersion(CompatibilityVersion));
+  // File.setTwoLevelNamespace();
+
+  // auto Arch = MachO::getArchitectureFromName(Arch);
+  // auto Platform = MachO::getPlatformFromName(PlatPlatform);
+  MachO::Target Target{Triple(LLVMTargetName)};
+  File.addTarget(Target);
+
+  for (size_t i = 0; i < NumExports; i++) {
+    File.addSymbol(Exports[i].kind, StringRef(Exports[i].name), Target, Exports[i].flags);
+  }
+
+  std::string ErrorInfo;
+  std::error_code EC;
+  raw_fd_ostream OS(Path, EC, sys::fs::CD_CreateAlways);
+  if (EC)
+    ErrorInfo = EC.message();
+  if (ErrorInfo != "") {
+    LLVMRustSetLastError(ErrorInfo.c_str());
+    return -1;
+  }
+
+  if (Error Err = MachO::TextAPIWriter::writeToStream(OS, File)) {
+      LLVMRustSetLastError(toString(std::move(Err)).c_str());
+      return -1;
+  }
+
+  return 0;
 }

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1751,6 +1751,7 @@ symbols! {
         raw_dash_dylib: "raw-dylib",
         raw_dylib,
         raw_dylib_elf,
+        raw_dylib_macho,
         raw_eq,
         raw_identifiers,
         raw_ref_op,

--- a/src/doc/unstable-book/src/language-features/raw-dylib-macho.md
+++ b/src/doc/unstable-book/src/language-features/raw-dylib-macho.md
@@ -1,0 +1,74 @@
+# `raw_dylib_macho`
+
+The tracking issue for this feature is: [#146356]
+
+[#146356]: https://github.com/rust-lang/rust/issues/146356
+
+------------------------
+
+The `raw_dylib_macho` feature enables support for Mach-O/Darwin/Apple platforms
+when using the `raw-dylib` linkage kind.
+
+The `+verbatim` modifier currently must be set (though this restriction may be
+lifted in the future).
+
+```rust
+//! Link to CoreFoundation without having to have the linker stubs available.
+#![feature(raw_dylib_macho)]
+#![cfg(target_vendor = "apple")]
+
+#[link(
+    name = "/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation",
+    kind = "raw-dylib",
+    modifiers = "+verbatim",
+)]
+unsafe extern "C" {
+    // Example function.
+    safe fn CFRunLoopGetTypeID() -> core::ffi::c_ulong;
+}
+
+fn main() {
+    let _ = CFRunLoopGetTypeID();
+}
+```
+
+```rust
+//! Weakly link to a symbol in libSystem.dylib that has been introduced
+//! later than macOS 10.12 (which might mean that host tooling will have
+//! trouble linking if it doesn't have the newer linker stubs available).
+#![feature(raw_dylib_macho)]
+#![feature(linkage)]
+#![cfg(target_vendor = "apple")]
+
+use std::ffi::{c_int, c_void};
+
+#[link(name = "/usr/lib/libSystem.B.dylib", kind = "raw-dylib", modifiers = "+verbatim")]
+unsafe extern "C" {
+    #[linkage = "extern_weak"]
+    safe static os_sync_wait_on_address: Option<unsafe extern "C" fn(*mut c_void, u64, usize, u32) -> c_int>;
+}
+
+fn main() {
+    if let Some(_wait_on_address) = os_sync_wait_on_address {
+        // Use new symbol
+    } else {
+        // Fallback implementation
+    }
+}
+```
+
+```rust,no_run
+//! Link to a library relative to where the current binary will be installed,
+//! without having that library available.
+#![feature(raw_dylib_macho)]
+#![cfg(target_vendor = "apple")]
+
+#[link(name = "@executable_path/libfoo.dylib", kind = "raw-dylib", modifiers = "+verbatim")]
+unsafe extern "C" {
+    safe fn foo();
+}
+
+fn main() {
+    foo();
+}
+```

--- a/tests/ui/feature-gates/feature-gate-raw-dylib-macho.rs
+++ b/tests/ui/feature-gates/feature-gate-raw-dylib-macho.rs
@@ -1,0 +1,10 @@
+//@ only-apple
+//@ needs-dynamic-linking
+
+#[link(name = "uwu", kind = "raw-dylib", modifiers = "+verbatim")]
+//~^ ERROR: link kind `raw-dylib` is unstable on Mach-O platforms
+unsafe extern "C" {
+    safe fn kawaii();
+}
+
+fn main() {}

--- a/tests/ui/feature-gates/feature-gate-raw-dylib-macho.stderr
+++ b/tests/ui/feature-gates/feature-gate-raw-dylib-macho.stderr
@@ -1,0 +1,12 @@
+error[E0658]: link kind `raw-dylib` is unstable on Mach-O platforms
+  --> $DIR/feature-gate-raw-dylib-macho.rs:4:29
+   |
+LL | #[link(name = "uwu", kind = "raw-dylib", modifiers = "+verbatim")]
+   |                             ^^^^^^^^^^^
+   |
+   = help: add `#![feature(raw_dylib_macho)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/linkage-attr/raw-dylib/macho/cf.rs
+++ b/tests/ui/linkage-attr/raw-dylib/macho/cf.rs
@@ -1,0 +1,21 @@
+//! Link to CoreFoundation without having to have the linker stubs available.
+
+//@ only-apple
+//@ run-pass
+
+#![allow(incomplete_features)]
+#![feature(raw_dylib_macho)]
+
+#[link(
+    name = "/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation",
+    kind = "raw-dylib",
+    modifiers = "+verbatim"
+)]
+unsafe extern "C" {
+    // Example function.
+    safe fn CFRunLoopGetTypeID() -> core::ffi::c_ulong;
+}
+
+fn main() {
+    let _ = CFRunLoopGetTypeID();
+}

--- a/tests/ui/linkage-attr/raw-dylib/macho/empty.rs
+++ b/tests/ui/linkage-attr/raw-dylib/macho/empty.rs
@@ -1,0 +1,10 @@
+//@ only-apple
+//@ build-pass
+
+#![allow(incomplete_features)]
+#![feature(raw_dylib_macho)]
+
+#[link(name = "hack", kind = "raw-dylib", modifiers = "+verbatim")]
+unsafe extern "C" {}
+
+fn main() {}

--- a/tests/ui/linkage-attr/raw-dylib/macho/system.rs
+++ b/tests/ui/linkage-attr/raw-dylib/macho/system.rs
@@ -1,0 +1,49 @@
+//! Check that we can link and run a `no_std` binary without.
+
+//@ only-apple
+//@ run-pass
+//@ compile-flags: -Cpanic=abort
+//@ compile-flags: -Clinker=ld -Clink-arg=-syslibroot -Clink-arg=./Empty.sdk
+
+#![allow(incomplete_features)]
+#![feature(raw_dylib_macho)]
+#![feature(lang_items)]
+#![no_std]
+#![no_main]
+
+use core::ffi::{c_char, c_int};
+use core::panic::PanicInfo;
+
+#[link(
+    name = "/usr/lib/libSystem.B.dylib",
+    kind = "raw-dylib",
+    modifiers = "+verbatim",
+    // current_version: 1351,
+    // compatibility_version: 1,
+)]
+#[allow(unused)]
+unsafe extern "C" {
+    #[link_name = "\x01dyld_stub_binder"]
+    unsafe fn dyld_stub_binder();
+}
+
+#[panic_handler]
+fn panic_handler(_info: &PanicInfo<'_>) -> ! {
+    loop {}
+}
+
+#[lang = "eh_personality"]
+extern "C" fn rust_eh_personality(
+    _version: i32,
+    _actions: i32,
+    _exception_class: u64,
+    _exception_object: *mut (),
+    _context: *mut (),
+) -> i32 {
+    loop {}
+}
+
+#[no_mangle]
+extern "C" fn main(_argc: c_int, _argv: *const *const c_char) -> c_int {
+    0
+}

--- a/tests/ui/linkage-attr/raw-dylib/windows/raw-dylib-windows-only.macho.stderr
+++ b/tests/ui/linkage-attr/raw-dylib/windows/raw-dylib-windows-only.macho.stderr
@@ -1,0 +1,18 @@
+error[E0658]: link kind `raw-dylib` is unstable on Mach-O platforms
+  --> $DIR/raw-dylib-windows-only.rs:8:29
+   |
+LL | #[link(name = "foo", kind = "raw-dylib")]
+   |                             ^^^^^^^^^^^
+   |
+   = help: add `#![feature(raw_dylib_macho)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: link kind `raw-dylib` should use the `+verbatim` linkage modifier
+  --> $DIR/raw-dylib-windows-only.rs:8:1
+   |
+LL | #[link(name = "foo", kind = "raw-dylib")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/linkage-attr/raw-dylib/windows/raw-dylib-windows-only.rs
+++ b/tests/ui/linkage-attr/raw-dylib/windows/raw-dylib-windows-only.rs
@@ -1,9 +1,13 @@
-//@ revisions: elf notelf
+//@ revisions: elf notelf macho
 //@ [elf] only-elf
+//@ [macho] only-apple
 //@ [notelf] ignore-windows
 //@ [notelf] ignore-elf
+//@ [notelf] ignore-apple
 //@ compile-flags: --crate-type lib
 #[link(name = "foo", kind = "raw-dylib")]
 //[notelf]~^ ERROR: link kind `raw-dylib` is only supported on Windows targets
 //[elf]~^^ ERROR: link kind `raw-dylib` is unstable on ELF platforms
+//[macho]~^^^ ERROR: link kind `raw-dylib` is unstable on Mach-O platforms
+//[macho]~^^^^ ERROR: link kind `raw-dylib` should use the `+verbatim` linkage modifier
 extern "C" {}


### PR DESCRIPTION
Implements https://github.com/rust-lang/rust/issues/146356 by adding the `raw_dylib_macho` feature flag.

@Noratrieb sniped me at RustWeek few months back to investigate this, never got around to finishing it.

This is a draft because I found out (after being 80% done with the impl) that using LLVM's TextAPI is probably not going to fly if we want to support other codegen backends, we'll need to write `.tbd` stubs ourselves.

TODO:
- [ ] Figure out which TextAPI version to support (should at least support [our minimum host tooling](https://doc.rust-lang.org/rustc/platform-support/apple-darwin.html#host-tooling)).
- [ ] Write some hacky code to output the yaml manually (we probably don't want to pull in a whole yaml library). Alternatively, emit a Mach-O stub file using `object`.
- [ ] Replace the LLVM TextAPI stuff I've done already.
- [ ] Write a properly detailed PR description.
- [ ] Add a bunch more tests in different scenarios.

r? bjorn3
CC @Noratrieb @thomcc @roblabla