### PR TITLE
triagebot: warn about #[rustc_intrinsic_const_stable_indirect]

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1308,18 +1308,29 @@ cc = ["@m-ou-se"]
 [mentions."compiler/rustc_ast_lowering/src/format.rs"]
 cc = ["@m-ou-se"]
 
+# Content-based mentions
+
 [mentions."#[miri::intrinsic_fallback_is_spec]"]
 type = "content"
 message = """
-`#[miri::intrinsic_fallback_is_spec]` must only be used if the function actively checks for all UB cases,
+⚠️ `#[miri::intrinsic_fallback_is_spec]` must only be used if the function actively checks for all UB cases,
 and explores the possible non-determinism of the intrinsic.
 """
 cc = ["@rust-lang/miri"]
+
 [mentions."#[rustc_allow_const_fn_unstable"]
 type = "content"
 message = """
-`#[rustc_allow_const_fn_unstable]` needs careful audit to avoid accidentally exposing unstable
+⚠️ `#[rustc_allow_const_fn_unstable]` needs careful audit to avoid accidentally exposing unstable
 implementation details on stable.
+"""
+cc = ["@rust-lang/wg-const-eval"]
+
+[mentions."#[rustc_intrinsic_const_stable_indirect]"]
+type = "content"
+message = """
+⚠️ `#[rustc_intrinsic_const_stable_indirect]` controls whether intrinsics can be exposed to stable const
+code; adding it needs t-lang approval.
 """
 cc = ["@rust-lang/wg-const-eval"]
 


### PR DESCRIPTION
Also make the warnings a bit more noticeable by adding a ⚠️.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
