### PR TITLE
add approx_delta to all gamma tests

### DIFF
--- a/library/std/tests/floats/f32.rs
+++ b/library/std/tests/floats/f32.rs
@@ -193,13 +193,13 @@ fn test_atanh() {
 #[test]
 fn test_gamma() {
     // precision can differ between platforms
-    assert_approx_eq!(1.0f32.gamma(), 1.0f32);
-    assert_approx_eq!(2.0f32.gamma(), 1.0f32);
-    assert_approx_eq!(3.0f32.gamma(), 2.0f32);
+    assert_approx_eq!(1.0f32.gamma(), 1.0f32, APPROX_DELTA);
+    assert_approx_eq!(2.0f32.gamma(), 1.0f32, APPROX_DELTA);
+    assert_approx_eq!(3.0f32.gamma(), 2.0f32, APPROX_DELTA);
     assert_approx_eq!(4.0f32.gamma(), 6.0f32, APPROX_DELTA);
     assert_approx_eq!(5.0f32.gamma(), 24.0f32, APPROX_DELTA);
-    assert_approx_eq!(0.5f32.gamma(), consts::PI.sqrt());
-    assert_approx_eq!((-0.5f32).gamma(), -2.0 * consts::PI.sqrt());
+    assert_approx_eq!(0.5f32.gamma(), consts::PI.sqrt(), APPROX_DELTA);
+    assert_approx_eq!((-0.5f32).gamma(), -2.0 * consts::PI.sqrt(), APPROX_DELTA);
     assert_eq!(0.0f32.gamma(), f32::INFINITY);
     assert_eq!((-0.0f32).gamma(), f32::NEG_INFINITY);
     assert!((-1.0f32).gamma().is_nan());


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

f32::gamma tests are less precise in CI, so we increase the tolerance for these tests. See [#miri > Miri test-libstd Failure (2025-09) @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/269128-miri/topic/Miri.20test-libstd.20Failure.20.282025-09.29/near/538138742)

r? @RalfJung 
