### PR TITLE
CI: rfl: move job forward to Linux v6.17-rc5 to remove temporary commits

### DIFF
--- a/src/ci/docker/scripts/rfl-build.sh
+++ b/src/ci/docker/scripts/rfl-build.sh
@@ -2,9 +2,7 @@
 
 set -euo pipefail
 
-# https://github.com/rust-lang/rust/pull/144443
-# https://github.com/rust-lang/rust/pull/145928
-LINUX_VERSION=8851e27d2cb947ea8bbbe8e812068f7bf5cbd00b
+LINUX_VERSION=v6.17-rc5
 
 # Build rustc, rustdoc, cargo, clippy-driver and rustfmt
 ../x.py build --stage 2 library rustdoc clippy rustfmt


### PR DESCRIPTION
v6.17-rc5 contains the equivalent of the two commits we had here, thus move the Rust for Linux job forward to that so that we don't need the temporary commits anymore.

r? @lqd @Kobzol
try-job: x86_64-rust-for-linux
@rustbot label A-rust-for-linux
@bors try