### PR TITLE
Update the LoongArch target documentation

### DIFF
--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -95,8 +95,8 @@ target | notes
 `arm-unknown-linux-gnueabihf` | Armv6 Linux, hardfloat (kernel 3.2+, glibc 2.17)
 `armv7-unknown-linux-gnueabihf` | Armv7-A Linux, hardfloat (kernel 3.2+, glibc 2.17)
 [`armv7-unknown-linux-ohos`](platform-support/openharmony.md) | Armv7-A OpenHarmony
-[`loongarch64-unknown-linux-gnu`](platform-support/loongarch-linux.md) | LoongArch64 Linux, LP64D ABI (kernel 5.19+, glibc 2.36)
-[`loongarch64-unknown-linux-musl`](platform-support/loongarch-linux.md) | LoongArch64 Linux, LP64D ABI (kernel 5.19+, musl 1.2.5)
+[`loongarch64-unknown-linux-gnu`](platform-support/loongarch-linux.md) | LoongArch64 Linux, LP64D ABI (kernel 5.19+, glibc 2.36), LSX required
+[`loongarch64-unknown-linux-musl`](platform-support/loongarch-linux.md) | LoongArch64 Linux, LP64D ABI (kernel 5.19+, musl 1.2.5), LSX required
 [`i686-pc-windows-gnu`](platform-support/windows-gnu.md) | 32-bit MinGW (Windows 10+, Windows Server 2016+, Pentium 4) [^x86_32-floats-return-ABI] [^win32-msvc-alignment]
 `powerpc-unknown-linux-gnu` | PowerPC Linux (kernel 3.2+, glibc 2.17)
 `powerpc64-unknown-linux-gnu` | PPC64 Linux (kernel 3.2+, glibc 2.17)

--- a/src/doc/rustc/src/platform-support/loongarch-linux.md
+++ b/src/doc/rustc/src/platform-support/loongarch-linux.md
@@ -7,8 +7,8 @@ LoongArch is a RISC ISA developed by Loongson Technology Corporation Limited.
 
 | Target | Description |
 |--------|-------------|
-| `loongarch64-unknown-linux-gnu` | LoongArch64 Linux, LP64D ABI (kernel 5.19, glibc 2.36) |
-| `loongarch64-unknown-linux-musl` | LoongArch64 Linux, LP64D ABI (kernel 5.19, musl 1.2.5) |
+| `loongarch64-unknown-linux-gnu` | LoongArch64 Linux, LP64D ABI (kernel 5.19, glibc 2.36), LSX required |
+| `loongarch64-unknown-linux-musl` | LoongArch64 Linux, LP64D ABI (kernel 5.19, musl 1.2.5), LSX required |
 
 These support both native and cross builds, and have full support for `std`.
 
@@ -23,8 +23,6 @@ Reference material:
 ## Target maintainers
 
 [@heiher](https://github.com/heiher)
-[@xiangzhai](https://github.com/xiangzhai)
-[@zhaixiaojuan](https://github.com/zhaixiaojuan)
 [@xen0n](https://github.com/xen0n)
 
 ## Requirements
@@ -46,8 +44,8 @@ The targets require a reasonably up-to-date LoongArch toolchain on the host.
 Currently the following components are used by the Rust CI to build the target,
 and the versions can be seen as the minimum requirement:
 
-* GNU Binutils 2.40
-* GCC 13.x
+* GNU Binutils 2.42
+* GCC 14.x
 * glibc 2.36
 * linux-headers 5.19
 
@@ -58,6 +56,11 @@ for newer LoongArch ELF relocation types, among other features.
 
 Recent LLVM/Clang toolchains may be able to build the targets, but are not
 currently being actively tested.
+
+### CPU features
+
+These targets require the double-precision floating-point and LSX (LoongArch
+SIMD Extension) features.
 
 ## Building
 


### PR DESCRIPTION
This patch defines minimum CPU feature requirements, updates toolchain baseline, and streamlines maintainer list:

- Specify double-precision floating-point and LSX as mandatory CPU features
- Raise the minimum required binutils version to 2.42+, due to relocations introduced by the default medium code model
- Remove outdated maintainers to reduce irrelevant notifications

r? @jieyouxu 