### PR TITLE
Don't strip shebang in expr-ctxt `include!(…)`

### DIFF
--- a/compiler/rustc_builtin_macros/src/source_util.rs
+++ b/compiler/rustc_builtin_macros/src/source_util.rs
@@ -147,9 +147,7 @@ pub(crate) fn expand_include<'cx>(
             let mut p = unwrap_or_emit_fatal(new_parser_from_file(
                 self.psess,
                 &self.path,
-                // Don't strip frontmatter for backward compatibility, `---` may be the start of a
-                // manifold negation. FIXME: Ideally, we wouldn't strip shebangs here either.
-                StripTokens::Shebang,
+                StripTokens::Nothing,
                 Some(self.span),
             ));
             let expr = parse_expr(&mut p).ok()?;

--- a/tests/ui/include-macros/auxiliary/shebang-expr.rs
+++ b/tests/ui/include-macros/auxiliary/shebang-expr.rs
@@ -1,0 +1,3 @@
+#!/usr/bin/env my-rust-expr-evaluator
+
+2 * (1 + 3)

--- a/tests/ui/include-macros/auxiliary/shebang-items.rs
+++ b/tests/ui/include-macros/auxiliary/shebang-items.rs
@@ -1,0 +1,3 @@
+#!/usr/bin/env my-rust-script-runner
+
+fn main() {}

--- a/tests/ui/include-macros/shebang-in-expr-ctxt.rs
+++ b/tests/ui/include-macros/shebang-in-expr-ctxt.rs
@@ -1,0 +1,16 @@
+// Check that we *don't* strip shebang in files that were `include`d in an expression or
+// expression statement context.
+// We do that to be consistent with frontmatter (see test `frontmatter/include-in-expr-ctxt.rs`).
+// While there could be niche use cases for such shebang, it seems more confusing than beneficial.
+
+fn main() {
+    // expr ctxt
+    _ = include!("auxiliary/shebang-expr.rs");
+    //~^ ERROR non-expression macro in expression position
+    //~? ERROR expected `[`, found `/`
+
+    // stmt ctxt (reuses expr expander)
+    include!("auxiliary/shebang-expr.rs");
+    //~^ ERROR non-statement macro in statement position
+    //~? ERROR expected `[`, found `/`
+}

--- a/tests/ui/include-macros/shebang-in-expr-ctxt.stderr
+++ b/tests/ui/include-macros/shebang-in-expr-ctxt.stderr
@@ -1,0 +1,33 @@
+error: expected `[`, found `/`
+  --> $DIR/auxiliary/shebang-expr.rs:1:3
+   |
+LL | #!/usr/bin/env my-rust-expr-evaluator
+   |   ^ expected `[`
+   |
+   = note: the token sequence `#!` here looks like the start of a shebang interpreter directive but it is not
+   = help: if you meant this to be a shebang interpreter directive, move it to the very start of the file
+
+error: non-expression macro in expression position: include
+  --> $DIR/shebang-in-expr-ctxt.rs:8:9
+   |
+LL |     _ = include!("auxiliary/shebang-expr.rs");
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: expected `[`, found `/`
+  --> $DIR/auxiliary/shebang-expr.rs:1:3
+   |
+LL | #!/usr/bin/env my-rust-expr-evaluator
+   |   ^ expected `[`
+   |
+   = note: the token sequence `#!` here looks like the start of a shebang interpreter directive but it is not
+   = help: if you meant this to be a shebang interpreter directive, move it to the very start of the file
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: non-statement macro in statement position: include
+  --> $DIR/shebang-in-expr-ctxt.rs:13:5
+   |
+LL |     include!("auxiliary/shebang-expr.rs");
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 4 previous errors
+

--- a/tests/ui/include-macros/shebang-in-item-ctxt.rs
+++ b/tests/ui/include-macros/shebang-in-item-ctxt.rs
@@ -1,0 +1,4 @@
+// Ensure that we strip shebang in files `include`d in item contexts.
+//@ check-pass
+
+include!("auxiliary/shebang-items.rs");


### PR DESCRIPTION
No longer strip shebang interpreter directives in files that were `include`d in expression (statement) contexts.