### PR TITLE
Fix `compare_against_sw_vers` test

### DIFF
--- a/library/std/src/sys/platform_version/darwin/tests.rs
+++ b/library/std/src/sys/platform_version/darwin/tests.rs
@@ -35,9 +35,9 @@ fn compare_against_sw_vers() {
     assert_eq!(__isOSVersionAtLeast(major, minor, subminor), 1);
 
     // One lower is available
-    assert_eq!(__isOSVersionAtLeast(major, minor, subminor.saturating_sub(1)), 1);
-    assert_eq!(__isOSVersionAtLeast(major, minor.saturating_sub(1), subminor), 1);
-    assert_eq!(__isOSVersionAtLeast(major.saturating_sub(1), minor, subminor), 1);
+    assert_eq!(__isOSVersionAtLeast(major, minor, (subminor as u32).saturating_sub(1) as i32), 1);
+    assert_eq!(__isOSVersionAtLeast(major, (minor as u32).saturating_sub(1) as i32, subminor), 1);
+    assert_eq!(__isOSVersionAtLeast((major as u32).saturating_sub(1) as i32, minor, subminor), 1);
 
     // One higher isn't available
     assert_eq!(__isOSVersionAtLeast(major, minor, subminor + 1), 0);


### PR DESCRIPTION
The `saturating_sub` doesn't actually perform its intended since the version numbers are signed integers (which I changed in a later revision of https://github.com/rust-lang/rust/pull/138944).

Fixes the issue described in https://github.com/rust-lang/rust/pull/138944#issuecomment-3270662876.

r? tgross35