### PR TITLE
Generalize `impl<T> Clone for Box<T>` to unsized types

### DIFF
--- a/library/alloc/src/boxed.rs
+++ b/library/alloc/src/boxed.rs
@@ -217,6 +217,8 @@ mod convert;
 mod iter;
 /// [`ThinBox`] implementation.
 mod thin;
+#[cfg(not(no_global_oom_handling))]
+mod uninit;
 
 #[stable(feature = "boxed_array_value_iter", since = "CURRENT_RUSTC_VERSION")]
 pub use iter::BoxedArrayIntoIter;

--- a/library/alloc/src/boxed.rs
+++ b/library/alloc/src/boxed.rs
@@ -217,6 +217,8 @@ mod convert;
 mod iter;
 /// [`ThinBox`] implementation.
 mod thin;
+#[cfg(not(no_global_oom_handling))]
+mod uninit;
 
 #[stable(feature = "boxed_array_value_iter", since = "1.99.0")]
 pub use iter::BoxedArrayIntoIter;

--- a/library/alloc/src/boxed.rs
+++ b/library/alloc/src/boxed.rs
@@ -208,8 +208,6 @@ use core::task::{Context, Poll};
 use crate::alloc::handle_alloc_error;
 use crate::alloc::{AllocError, Allocator, Global, Layout, StaticAllocator};
 use crate::raw_vec::RawVec;
-#[cfg(not(no_global_oom_handling))]
-use crate::str::from_boxed_utf8_unchecked_in;
 
 /// Conversion related impls for `Box<_>` (`From`, `downcast`, etc)
 mod convert;
@@ -2070,7 +2068,8 @@ where
 #[stable(feature = "rust1", since = "1.0.0")]
 // NB: This is not `AllocatorClone` since we don't care about allocator
 // equivalence when cloning boxes.
-impl<T: Clone, A: Allocator + Clone> Clone for Box<T, A> {
+#[diagnostic::do_not_recommend]
+impl<T: CloneToUninit + ?Sized, A: Allocator + Clone> Clone for Box<T, A> {
     /// Returns a new box with a `clone()` of this box's contents.
     ///
     /// # Examples
@@ -2088,14 +2087,23 @@ impl<T: Clone, A: Allocator + Clone> Clone for Box<T, A> {
     #[inline]
     fn clone(&self) -> Self {
         // Pre-allocate memory to allow writing the cloned value directly.
-        let mut boxed = Self::new_uninit_in(self.1.clone());
+        // SAFETY: `ptr::metadata` yields valid metadata for `T`.
+        let mut boxed = unsafe {
+            uninit::UninitBox::<T, A>::new_for_metadata_in(
+                ptr::metadata(Self::as_ptr(self)),
+                self.1.clone(),
+            )
+        };
+
+        // SAFETY: `boxed` points to an uninitialized `T` with the right layout.
         unsafe {
             (**self).clone_to_uninit(boxed.as_mut_ptr().cast());
             boxed.assume_init()
         }
     }
 
-    /// Copies `source`'s contents into `self` without creating a new allocation.
+    /// Copies `source`'s contents into `self` without creating a new allocation,
+    /// so long as the two have the same metadata.
     ///
     /// # Examples
     ///
@@ -2114,51 +2122,40 @@ impl<T: Clone, A: Allocator + Clone> Clone for Box<T, A> {
     /// ```
     #[inline]
     fn clone_from(&mut self, source: &Self) {
-        (**self).clone_from(&(**source));
-    }
-}
+        trait MetadataEq: Copy {
+            fn meta_eq(self, other: Self) -> bool;
+        }
+        impl<T: Copy> MetadataEq for T {
+            // Comparing vtable pointer for trait objects can return true even
+            // if the concrete types are different, so we never allow them to
+            // go through `clone_from`.
+            #[inline]
+            default fn meta_eq(self, _: Self) -> bool {
+                false
+            }
+        }
+        impl MetadataEq for () {
+            // Sized types can always use `clone_from`
+            #[inline]
+            fn meta_eq(self, (): Self) -> bool {
+                true
+            }
+        }
+        impl MetadataEq for usize {
+            // Slice-like types can use `clone_from` if the two values are the
+            // same length.
+            #[inline]
+            fn meta_eq(self, other: Self) -> bool {
+                self == other
+            }
+        }
 
-#[cfg(not(no_global_oom_handling))]
-#[stable(feature = "box_slice_clone", since = "1.3.0")]
-impl<T: Clone, A: Allocator + Clone> Clone for Box<[T], A> {
-    fn clone(&self) -> Self {
-        let alloc = Box::allocator(self).clone();
-        self.to_vec_in(alloc).into_boxed_slice()
-    }
-
-    /// Copies `source`'s contents into `self` without creating a new allocation,
-    /// so long as the two are of the same length.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// let x = Box::new([5, 6, 7]);
-    /// let mut y = Box::new([8, 9, 10]);
-    /// let yp: *const [i32] = &*y;
-    ///
-    /// y.clone_from(&x);
-    ///
-    /// // The value is the same
-    /// assert_eq!(x, y);
-    ///
-    /// // And no allocation occurred
-    /// assert_eq!(yp, &*y);
-    /// ```
-    fn clone_from(&mut self, source: &Self) {
-        if self.len() == source.len() {
-            self.clone_from_slice(source);
+        if ptr::metadata(&**self).meta_eq(ptr::metadata(&**source)) {
+            // SAFETY: `meta_eq` ensures that `self` is a valid destination to clone `source`
+            unsafe { (**source).clone_to_init(Box::as_mut_ptr(self).cast()) };
         } else {
             *self = source.clone();
         }
-    }
-}
-
-#[cfg(not(no_global_oom_handling))]
-#[stable(feature = "box_slice_clone", since = "1.3.0")]
-impl<A: Allocator + Clone> Clone for Box<str, A> {
-    fn clone(&self) -> Self {
-        let buf = Box::clone_from_ref_in(self.as_bytes(), self.1.clone());
-        unsafe { from_boxed_utf8_unchecked_in(buf) }
     }
 }
 

--- a/library/alloc/src/boxed.rs
+++ b/library/alloc/src/boxed.rs
@@ -208,8 +208,6 @@ use core::task::{Context, Poll};
 use crate::alloc::handle_alloc_error;
 use crate::alloc::{AllocError, Allocator, Global, Layout};
 use crate::raw_vec::RawVec;
-#[cfg(not(no_global_oom_handling))]
-use crate::str::from_boxed_utf8_unchecked;
 
 /// Conversion related impls for `Box<_>` (`From`, `downcast`, etc)
 mod convert;
@@ -2075,7 +2073,8 @@ where
 
 #[cfg(not(no_global_oom_handling))]
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: Clone, A: Allocator + Clone> Clone for Box<T, A> {
+#[diagnostic::do_not_recommend]
+impl<T: CloneToUninit + ?Sized, A: Allocator + Clone> Clone for Box<T, A> {
     /// Returns a new box with a `clone()` of this box's contents.
     ///
     /// # Examples
@@ -2093,14 +2092,23 @@ impl<T: Clone, A: Allocator + Clone> Clone for Box<T, A> {
     #[inline]
     fn clone(&self) -> Self {
         // Pre-allocate memory to allow writing the cloned value directly.
-        let mut boxed = Self::new_uninit_in(self.1.clone());
+        // SAFETY: `ptr::metadata` yields valid metadata for `T`.
+        let mut boxed = unsafe {
+            uninit::UninitBox::<T, A>::new_for_metadata_in(
+                ptr::metadata(Self::as_ptr(self)),
+                self.1.clone(),
+            )
+        };
+
+        // SAFETY: `boxed` points to an uninitialized `T` with the right layout.
         unsafe {
             (**self).clone_to_uninit(boxed.as_mut_ptr().cast());
             boxed.assume_init()
         }
     }
 
-    /// Copies `source`'s contents into `self` without creating a new allocation.
+    /// Copies `source`'s contents into `self` without creating a new allocation,
+    /// so long as the two have the same metadata.
     ///
     /// # Examples
     ///
@@ -2119,52 +2127,40 @@ impl<T: Clone, A: Allocator + Clone> Clone for Box<T, A> {
     /// ```
     #[inline]
     fn clone_from(&mut self, source: &Self) {
-        (**self).clone_from(&(**source));
-    }
-}
+        trait MetadataEq: Copy {
+            fn meta_eq(self, other: Self) -> bool;
+        }
+        impl<T: Copy> MetadataEq for T {
+            // Comparing vtable pointer for trait objects can return true even
+            // if the concrete types are different, so we never allow them to
+            // go through `clone_from`.
+            #[inline]
+            default fn meta_eq(self, _: Self) -> bool {
+                false
+            }
+        }
+        impl MetadataEq for () {
+            // Sized types can always use `clone_from`
+            #[inline]
+            fn meta_eq(self, (): Self) -> bool {
+                true
+            }
+        }
+        impl MetadataEq for usize {
+            // Slice-like types can use `clone_from` if the two values are the
+            // same length.
+            #[inline]
+            fn meta_eq(self, other: Self) -> bool {
+                self == other
+            }
+        }
 
-#[cfg(not(no_global_oom_handling))]
-#[stable(feature = "box_slice_clone", since = "1.3.0")]
-impl<T: Clone, A: Allocator + Clone> Clone for Box<[T], A> {
-    fn clone(&self) -> Self {
-        let alloc = Box::allocator(self).clone();
-        self.to_vec_in(alloc).into_boxed_slice()
-    }
-
-    /// Copies `source`'s contents into `self` without creating a new allocation,
-    /// so long as the two are of the same length.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// let x = Box::new([5, 6, 7]);
-    /// let mut y = Box::new([8, 9, 10]);
-    /// let yp: *const [i32] = &*y;
-    ///
-    /// y.clone_from(&x);
-    ///
-    /// // The value is the same
-    /// assert_eq!(x, y);
-    ///
-    /// // And no allocation occurred
-    /// assert_eq!(yp, &*y);
-    /// ```
-    fn clone_from(&mut self, source: &Self) {
-        if self.len() == source.len() {
-            self.clone_from_slice(&source);
+        if ptr::metadata(&**self).meta_eq(ptr::metadata(&**source)) {
+            // SAFETY: `meta_eq` ensures that `self` is a valid destination to clone `source`
+            unsafe { (**source).clone_to_init(Box::as_mut_ptr(self).cast()) };
         } else {
             *self = source.clone();
         }
-    }
-}
-
-#[cfg(not(no_global_oom_handling))]
-#[stable(feature = "box_slice_clone", since = "1.3.0")]
-impl Clone for Box<str> {
-    fn clone(&self) -> Self {
-        // this makes a copy of the data
-        let buf: Box<[u8]> = self.as_bytes().into();
-        unsafe { from_boxed_utf8_unchecked(buf) }
     }
 }
 

--- a/library/alloc/src/boxed/uninit.rs
+++ b/library/alloc/src/boxed/uninit.rs
@@ -1,0 +1,67 @@
+use core::alloc::{Allocator, Layout};
+use core::mem;
+use core::ptr::{self, NonNull, Pointee};
+
+#[cfg(not(no_global_oom_handling))]
+use crate::alloc::handle_alloc_error;
+use crate::boxed::Box;
+
+pub(crate) struct UninitBox<T: Pointee + ?Sized, A: Allocator> {
+    ptr: NonNull<T>,
+    alloc: A,
+}
+
+impl<T: Pointee + ?Sized, A: Allocator> UninitBox<T, A> {
+    /// # Safety
+    ///
+    /// `meta` must hold the same conditions as for [`Layout::for_value_raw`].
+    #[cfg(not(no_global_oom_handling))]
+    pub(crate) unsafe fn new_for_metadata_in(meta: T::Metadata, alloc: A) -> Self {
+        let ptr = ptr::from_raw_parts_mut::<T>(ptr::null_mut::<()>(), meta);
+        // SAFETY: guaranteed by caller
+        let layout = unsafe { Layout::for_value_raw(ptr) };
+
+        let ptr = if layout.size() == 0 {
+            layout.dangling_ptr().cast::<()>()
+        } else {
+            alloc.allocate(layout).unwrap_or_else(|_| handle_alloc_error(layout)).cast()
+        };
+        let ptr = NonNull::from_raw_parts(ptr, meta);
+
+        Self { ptr, alloc }
+    }
+
+    #[inline]
+    pub(crate) fn as_mut_ptr(&mut self) -> *mut T {
+        self.ptr.as_ptr()
+    }
+
+    #[inline]
+    pub(crate) fn into_raw_with_allocator(b: Self) -> (NonNull<T>, A) {
+        let b = mem::ManuallyDrop::new(b);
+        let alloc = unsafe { ptr::read(&b.alloc) };
+        (b.ptr, alloc)
+    }
+
+    /// # Safety
+    ///
+    /// The inner value must be initialized properly.
+    #[inline]
+    pub(crate) unsafe fn assume_init(self) -> Box<T, A> {
+        let (ptr, alloc) = Self::into_raw_with_allocator(self);
+        unsafe { Box::from_non_null_in(ptr, alloc) }
+    }
+}
+
+impl<T: Pointee + ?Sized, A: Allocator> Drop for UninitBox<T, A> {
+    #[inline]
+    fn drop(&mut self) {
+        // Safety: by invariant of this type, `ptr` is a valid pointer to an allocation
+        unsafe {
+            let layout = Layout::for_value_raw(self.ptr.as_ptr());
+            if layout.size() != 0 {
+                self.alloc.deallocate(self.ptr.cast(), layout);
+            }
+        }
+    }
+}

--- a/library/alloc/src/bstr.rs
+++ b/library/alloc/src/bstr.rs
@@ -586,14 +586,6 @@ impl<'a> TryFrom<&'a ByteString> for &'a str {
 // Additional impls for `ByteStr` that require types from `alloc`:
 
 #[unstable(feature = "bstr", issue = "134915")]
-impl Clone for Box<ByteStr> {
-    #[inline]
-    fn clone(&self) -> Self {
-        Self::from(Box::<[u8]>::from(&self.0))
-    }
-}
-
-#[unstable(feature = "bstr", issue = "134915")]
 impl<'a> From<&'a ByteStr> for Cow<'a, ByteStr> {
     #[inline]
     fn from(s: &'a ByteStr) -> Self {

--- a/library/alloc/src/bstr.rs
+++ b/library/alloc/src/bstr.rs
@@ -604,14 +604,6 @@ impl<'a> TryFrom<&'a ByteString> for &'a str {
 // Additional impls for `ByteStr` that require types from `alloc`:
 
 #[unstable(feature = "bstr", issue = "134915")]
-impl Clone for Box<ByteStr> {
-    #[inline]
-    fn clone(&self) -> Self {
-        Self::from(Box::<[u8]>::from(&self.0))
-    }
-}
-
-#[unstable(feature = "bstr", issue = "134915")]
 impl<'a> From<&'a ByteStr> for Cow<'a, ByteStr> {
     #[inline]
     fn from(s: &'a ByteStr) -> Self {

--- a/library/alloc/src/ffi/c_str.rs
+++ b/library/alloc/src/ffi/c_str.rs
@@ -854,14 +854,6 @@ impl TryFrom<CString> for String {
     }
 }
 
-#[stable(feature = "more_box_slice_clone", since = "1.29.0")]
-impl Clone for Box<CStr> {
-    #[inline]
-    fn clone(&self) -> Self {
-        (**self).into()
-    }
-}
-
 #[stable(feature = "box_from_c_string", since = "1.20.0")]
 impl From<CString> for Box<CStr> {
     /// Converts a [`CString`] into a <code>[Box]<[CStr]></code> without copying or allocating.

--- a/library/alloc/src/str.rs
+++ b/library/alloc/src/str.rs
@@ -906,18 +906,6 @@ pub unsafe fn from_boxed_utf8_unchecked(v: Box<[u8]>) -> Box<str> {
     unsafe { Box::from_raw(Box::into_raw(v) as *mut str) }
 }
 
-/// Internal; same as `from_boxed_utf8_unchecked` but allocator-generic. Name
-/// probably not suitable for being made `pub` as-is.
-#[must_use]
-#[inline]
-#[cfg(not(no_global_oom_handling))]
-pub(crate) unsafe fn from_boxed_utf8_unchecked_in<A: crate::alloc::Allocator>(
-    v: Box<[u8], A>,
-) -> Box<str, A> {
-    let (ptr, alloc) = Box::into_raw_with_allocator(v);
-    unsafe { Box::from_raw_in(ptr as *mut str, alloc) }
-}
-
 /// Converts leading ascii bytes in `s` by calling the `convert` function.
 ///
 /// For better average performance, this happens in chunks of `2*size_of::<usize>()`.

--- a/library/alloctests/tests/boxed.rs
+++ b/library/alloctests/tests/boxed.rs
@@ -256,3 +256,18 @@ mod pin_coerce_unsized {
         assert_eq!(pin_box_struct.as_ref().action(), "MyStruct");
     }
 }
+
+#[allow(unused)]
+fn ensure_box_clone() {
+    fn test<T: ?Sized>()
+    where
+        Box<T>: Clone,
+    {
+    }
+
+    test::<str>();
+    test::<core::ffi::CStr>();
+    test::<std::ffi::OsStr>();
+    test::<std::path::Path>();
+    test::<[String]>();
+}

--- a/library/alloctests/tests/boxed.rs
+++ b/library/alloctests/tests/boxed.rs
@@ -249,3 +249,18 @@ mod pin_coerce_unsized {
         assert_eq!(pin_box_struct.as_ref().action(), "MyStruct");
     }
 }
+
+#[allow(unused)]
+fn ensure_box_clone() {
+    fn test<T: ?Sized>()
+    where
+        Box<T>: Clone,
+    {
+    }
+
+    test::<str>();
+    test::<core::ffi::CStr>();
+    test::<std::ffi::OsStr>();
+    test::<std::path::Path>();
+    test::<[String]>();
+}

--- a/library/core/src/clone.rs
+++ b/library/core/src/clone.rs
@@ -572,6 +572,16 @@ pub struct AssertParamIsCopy<T: Copy + PointeeSized> {
 ///         // All fields of the struct have been initialized; therefore, the struct is initialized,
 ///         // and we have satisfied our `unsafe impl CloneToUninit` obligations.
 ///     }
+///
+///     unsafe fn clone_to_init(&self, dest: *mut u8) {
+///         // SAFETY: The caller must provide a `dest` such that these field offsets are valid
+///         // to write to.
+///         unsafe {
+///             let offset_of_contents = (&raw const self.contents).byte_offset_from_unsigned(self);
+///             self.contents.clone_to_init(dest.add(offset_of_contents));
+///             self.label.clone_to_init(dest.add(offset_of!(Self, label)));
+///         }
+///     }
 /// }
 ///
 /// fn main() {
@@ -642,6 +652,15 @@ pub unsafe trait CloneToUninit {
     /// cloned, and the second of the three calls to `Foo::clone()` unwinds, then the first `Foo`
     /// cloned should be dropped.)
     unsafe fn clone_to_uninit(&self, dest: *mut u8);
+
+    /// Clones `self` to `dest`
+    ///
+    /// This is similar to `Clone::clone_from`, but unsafe and dyn-compatible.
+    ///
+    /// # Safety
+    ///
+    /// `dest` must be a valid pointer to a valid value of the same concrete type than `self`.
+    unsafe fn clone_to_init(&self, dest: *mut u8);
 }
 
 #[unstable(feature = "clone_to_uninit", issue = "126799")]
@@ -650,6 +669,13 @@ unsafe impl<T: Clone> CloneToUninit for T {
     unsafe fn clone_to_uninit(&self, dest: *mut u8) {
         // SAFETY: we're calling a specialization with the same contract
         unsafe { <T as self::uninit::CopySpec>::clone_one(self, dest.cast::<T>()) }
+    }
+
+    #[inline]
+    unsafe fn clone_to_init(&self, dest: *mut u8) {
+        // SAFETY: by contract, `dest` is a valid pointer to `T`
+        let dest = unsafe { dest.cast::<T>().as_mut_unchecked() };
+        dest.clone_from(self);
     }
 }
 
@@ -662,6 +688,15 @@ unsafe impl<T: Clone> CloneToUninit for [T] {
         // SAFETY: we're calling a specialization with the same contract
         unsafe { <T as self::uninit::CopySpec>::clone_slice(self, dest) }
     }
+
+    #[inline]
+    #[cfg_attr(debug_assertions, track_caller)]
+    unsafe fn clone_to_init(&self, dest: *mut u8) {
+        // SAFETY: by contract, `dest` is a valid pointer to a `[T]` with the
+        // same length as `self`
+        let dest = unsafe { dest.with_metadata_of(self).as_mut_unchecked() };
+        dest.clone_from_slice(self);
+    }
 }
 
 #[unstable(feature = "clone_to_uninit", issue = "126799")]
@@ -672,17 +707,32 @@ unsafe impl CloneToUninit for str {
         // SAFETY: str is just a [u8] with UTF-8 invariant
         unsafe { self.as_bytes().clone_to_uninit(dest) }
     }
+
+    #[inline]
+    #[cfg_attr(debug_assertions, track_caller)]
+    unsafe fn clone_to_init(&self, dest: *mut u8) {
+        // SAFETY: str is just a [u8] with UTF-8 invariant
+        unsafe { self.as_bytes().clone_to_init(dest) }
+    }
 }
 
 #[unstable(feature = "clone_to_uninit", issue = "126799")]
 unsafe impl CloneToUninit for crate::ffi::CStr {
     #[cfg_attr(debug_assertions, track_caller)]
     unsafe fn clone_to_uninit(&self, dest: *mut u8) {
-        // SAFETY: For now, CStr is just a #[repr(trasnsparent)] [c_char] with some invariants.
+        // SAFETY: For now, CStr is just a #[repr(transparent)] [c_char] with some invariants.
         // And we can cast [c_char] to [u8] on all supported platforms (see: to_bytes_with_nul).
         // The pointer metadata properly preserves the length (so NUL is also copied).
         // See: `cstr_metadata_is_length_with_nul` in tests.
         unsafe { self.to_bytes_with_nul().clone_to_uninit(dest) }
+    }
+
+    unsafe fn clone_to_init(&self, dest: *mut u8) {
+        // SAFETY: For now, CStr is just a #[repr(transparent)] [c_char] with some invariants.
+        // And we can cast [c_char] to [u8] on all supported platforms (see: to_bytes_with_nul).
+        // The pointer metadata properly preserves the length (so NUL is also copied).
+        // See: `cstr_metadata_is_length_with_nul` in tests.
+        unsafe { self.to_bytes_with_nul().clone_to_init(dest) }
     }
 }
 
@@ -691,6 +741,12 @@ unsafe impl CloneToUninit for crate::bstr::ByteStr {
     #[inline]
     #[cfg_attr(debug_assertions, track_caller)]
     unsafe fn clone_to_uninit(&self, dst: *mut u8) {
+        // SAFETY: ByteStr is a `#[repr(transparent)]` wrapper around `[u8]`
+        unsafe { self.as_bytes().clone_to_uninit(dst) }
+    }
+
+    #[inline]
+    unsafe fn clone_to_init(&self, dst: *mut u8) {
         // SAFETY: ByteStr is a `#[repr(transparent)]` wrapper around `[u8]`
         unsafe { self.as_bytes().clone_to_uninit(dst) }
     }

--- a/library/core/src/clone.rs
+++ b/library/core/src/clone.rs
@@ -489,17 +489,14 @@ pub struct AssertParamIsCopy<T: Copy + PointeeSized> {
 ///
 /// # Examples
 ///
-// FIXME(#126799): when `Box::clone` allows use of `CloneToUninit`, rewrite these examples with it
-// since `Rc` is a distraction.
 ///
 /// If you are defining a trait, you can add `CloneToUninit` as a supertrait to enable cloning of
 /// `dyn` values of your trait:
 ///
 /// ```
 /// #![feature(clone_to_uninit)]
-/// use std::rc::Rc;
 ///
-/// trait Foo: std::fmt::Debug + std::clone::CloneToUninit {
+/// trait Foo: std::clone::CloneToUninit {
 ///     fn modify(&mut self);
 ///     fn value(&self) -> i32;
 /// }
@@ -513,10 +510,10 @@ pub struct AssertParamIsCopy<T: Copy + PointeeSized> {
 ///     }
 /// }
 ///
-/// let first: Rc<dyn Foo> = Rc::new(1234);
+/// let first: Box<dyn Foo> = Box::new(1234);
 ///
-/// let mut second = first.clone();
-/// Rc::make_mut(&mut second).modify(); // make_mut() will call clone_to_uninit()
+/// let mut second = first.clone(); // clone() will call clone_to_uninit()
+/// second.modify();
 ///
 /// assert_eq!(first.value(), 1234);
 /// assert_eq!(second.value(), 12340);
@@ -530,7 +527,6 @@ pub struct AssertParamIsCopy<T: Copy + PointeeSized> {
 /// #![feature(clone_to_uninit)]
 /// use std::clone::CloneToUninit;
 /// use std::mem::offset_of;
-/// use std::rc::Rc;
 ///
 /// #[derive(PartialEq)]
 /// struct MyDst<T: ?Sized> {
@@ -586,14 +582,13 @@ pub struct AssertParamIsCopy<T: Copy + PointeeSized> {
 ///
 /// fn main() {
 ///     // Construct MyDst<[u8; 4]>, then coerce to MyDst<[u8]>.
-///     let first: Rc<MyDst<[u8]>> = Rc::new(MyDst {
+///     let first: Box<MyDst<[u8]>> = Box::new(MyDst {
 ///         label: String::from("hello"),
 ///         contents: [1, 2, 3, 4],
 ///     });
 ///
-///     let mut second = first.clone();
-///     // make_mut() will call clone_to_uninit().
-///     for elem in Rc::make_mut(&mut second).contents.iter_mut() {
+///     let mut second = first.clone(); // clone() will call clone_to_uninit().
+///     for elem in second.contents.iter_mut() {
 ///         *elem *= 10;
 ///     }
 ///

--- a/library/core/src/wtf8.rs
+++ b/library/core/src/wtf8.rs
@@ -657,4 +657,11 @@ unsafe impl CloneToUninit for Wtf8 {
         // SAFETY: we're just a transparent wrapper around [u8]
         unsafe { self.bytes.clone_to_uninit(dst) }
     }
+
+    #[inline]
+    #[cfg_attr(debug_assertions, track_caller)]
+    unsafe fn clone_to_init(&self, dst: *mut u8) {
+        // SAFETY: we're just a transparent wrapper around [u8]
+        unsafe { self.bytes.clone_to_init(dst) }
+    }
 }

--- a/library/core/src/wtf8.rs
+++ b/library/core/src/wtf8.rs
@@ -661,4 +661,11 @@ unsafe impl CloneToUninit for Wtf8 {
         // SAFETY: we're just a transparent wrapper around [u8]
         unsafe { self.bytes.clone_to_uninit(dst) }
     }
+
+    #[inline]
+    #[cfg_attr(debug_assertions, track_caller)]
+    unsafe fn clone_to_init(&self, dst: *mut u8) {
+        // SAFETY: we're just a transparent wrapper around [u8]
+        unsafe { self.bytes.clone_to_init(dst) }
+    }
 }

--- a/library/std/src/ffi/os_str.rs
+++ b/library/std/src/ffi/os_str.rs
@@ -1410,6 +1410,13 @@ unsafe impl CloneToUninit for OsStr {
         // SAFETY: we're just a transparent wrapper around a platform-specific Slice
         unsafe { self.inner.clone_to_uninit(dst) }
     }
+
+    #[inline]
+    #[cfg_attr(debug_assertions, track_caller)]
+    unsafe fn clone_to_init(&self, dst: *mut u8) {
+        // SAFETY: we're just a transparent wrapper around a platform-specific Slice
+        unsafe { self.inner.clone_to_init(dst) }
+    }
 }
 
 #[stable(feature = "shared_from_slice2", since = "1.24.0")]

--- a/library/std/src/ffi/os_str.rs
+++ b/library/std/src/ffi/os_str.rs
@@ -1394,14 +1394,6 @@ impl From<OsString> for Box<OsStr> {
     }
 }
 
-#[stable(feature = "more_box_slice_clone", since = "1.29.0")]
-impl Clone for Box<OsStr> {
-    #[inline]
-    fn clone(&self) -> Self {
-        self.to_os_string().into_boxed_os_str()
-    }
-}
-
 #[unstable(feature = "clone_to_uninit", issue = "126799")]
 unsafe impl CloneToUninit for OsStr {
     #[inline]

--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -3693,6 +3693,13 @@ unsafe impl CloneToUninit for Path {
         // SAFETY: Path is just a transparent wrapper around OsStr
         unsafe { self.inner.clone_to_uninit(dst) }
     }
+
+    #[inline]
+    #[cfg_attr(debug_assertions, track_caller)]
+    unsafe fn clone_to_init(&self, dst: *mut u8) {
+        // SAFETY: Path is just a transparent wrapper around OsStr
+        unsafe { self.inner.clone_to_init(dst) }
+    }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -1971,14 +1971,6 @@ impl From<PathBuf> for Box<Path> {
     }
 }
 
-#[stable(feature = "more_box_slice_clone", since = "1.29.0")]
-impl Clone for Box<Path> {
-    #[inline]
-    fn clone(&self) -> Self {
-        self.to_path_buf().into_boxed_path()
-    }
-}
-
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: ?Sized + AsRef<OsStr>> From<&T> for PathBuf {
     /// Converts a borrowed [`OsStr`] to a [`PathBuf`].

--- a/library/std/src/sys/os_str/bytes.rs
+++ b/library/std/src/sys/os_str/bytes.rs
@@ -368,4 +368,11 @@ unsafe impl CloneToUninit for Slice {
         // SAFETY: we're just a transparent wrapper around [u8]
         unsafe { self.inner.clone_to_uninit(dst) }
     }
+
+    #[inline]
+    #[cfg_attr(debug_assertions, track_caller)]
+    unsafe fn clone_to_init(&self, dst: *mut u8) {
+        // SAFETY: we're just a transparent wrapper around [u8]
+        unsafe { self.inner.clone_to_init(dst) }
+    }
 }

--- a/library/std/src/sys/os_str/wtf8.rs
+++ b/library/std/src/sys/os_str/wtf8.rs
@@ -332,4 +332,11 @@ unsafe impl CloneToUninit for Slice {
         // SAFETY: we're just a transparent wrapper around Wtf8
         unsafe { self.inner.clone_to_uninit(dst) }
     }
+
+    #[inline]
+    #[cfg_attr(debug_assertions, track_caller)]
+    unsafe fn clone_to_init(&self, dst: *mut u8) {
+        // SAFETY: we're just a transparent wrapper around Wtf8
+        unsafe { self.inner.clone_to_init(dst) }
+    }
 }

--- a/tests/ui/box/unit/unique-object-noncopyable.rs
+++ b/tests/ui/box/unit/unique-object-noncopyable.rs
@@ -21,5 +21,5 @@ impl Foo for Bar {
 fn main() {
     let x = Box::new(Bar { x: 10 });
     let y: Box<dyn Foo> = x as Box<dyn Foo>;
-    let _z = y.clone(); //~ ERROR the method
+    let _z = y.clone(); //~ ERROR no method named `clone` found for struct `Box<dyn Foo>` in the current scope [E0599]
 }

--- a/tests/ui/box/unit/unique-object-noncopyable.stderr
+++ b/tests/ui/box/unit/unique-object-noncopyable.stderr
@@ -1,17 +1,9 @@
-error[E0599]: the method `clone` exists for struct `Box<dyn Foo>`, but its trait bounds were not satisfied
+error[E0599]: no method named `clone` found for struct `Box<dyn Foo>` in the current scope
   --> $DIR/unique-object-noncopyable.rs:24:16
    |
-LL | trait Foo {
-   | --------- doesn't satisfy `dyn Foo: Clone` or `dyn Foo: Sized`
-...
 LL |     let _z = y.clone();
-   |                ^^^^^ method cannot be called on `Box<dyn Foo>` due to unsatisfied trait bounds
+   |                ^^^^^ method not found in `Box<dyn Foo>`
    |
-   = note: the following trait bounds were not satisfied:
-           `dyn Foo: Sized`
-           which is required by `Box<dyn Foo>: Clone`
-           `dyn Foo: Clone`
-           which is required by `Box<dyn Foo>: Clone`
    = help: items from traits can only be used if the trait is implemented and in scope
    = note: the following trait defines an item `clone`, perhaps you need to implement it:
            candidate #1: `Clone`

--- a/tests/ui/box/unit/unique-pinned-nocopy.rs
+++ b/tests/ui/box/unit/unique-pinned-nocopy.rs
@@ -9,6 +9,6 @@ impl Drop for R {
 
 fn main() {
     let i = Box::new(R { b: true });
-    let _j = i.clone(); //~ ERROR the method
+    let _j = i.clone(); //~ ERROR no method named `clone` found for struct `Box<R>` in the current scope [E0599]
     println!("{:?}", i);
 }

--- a/tests/ui/box/unit/unique-pinned-nocopy.stderr
+++ b/tests/ui/box/unit/unique-pinned-nocopy.stderr
@@ -1,20 +1,12 @@
-error[E0599]: the method `clone` exists for struct `Box<R>`, but its trait bounds were not satisfied
+error[E0599]: no method named `clone` found for struct `Box<R>` in the current scope
   --> $DIR/unique-pinned-nocopy.rs:12:16
    |
-LL | struct R {
-   | -------- doesn't satisfy `R: Clone`
-...
 LL |     let _j = i.clone();
-   |                ^^^^^ method cannot be called on `Box<R>` due to unsatisfied trait bounds
+   |                ^^^^^ method not found in `Box<R>`
    |
-   = note: the following trait bounds were not satisfied:
-           `R: Clone`
-           which is required by `Box<R>: Clone`
-help: consider annotating `R` with `#[derive(Clone)]`
-   |
-LL + #[derive(Clone)]
-LL | struct R {
-   |
+   = help: items from traits can only be used if the trait is implemented and in scope
+   = note: the following trait defines an item `clone`, perhaps you need to implement it:
+           candidate #1: `Clone`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/generic-associated-types/issue-74824.current.stderr
+++ b/tests/ui/generic-associated-types/issue-74824.current.stderr
@@ -1,32 +1,27 @@
 error[E0277]: the trait bound `Box<T>: Copy` is not satisfied
-  --> $DIR/issue-74824.rs:10:26
+  --> $DIR/issue-74824.rs:12:26
    |
 LL |     type Copy<T>: Copy = Box<T>;
    |                          ^^^^^^ the trait `Copy` is not implemented for `Box<T>`
    |
 note: required by a bound in `UnsafeCopy::Copy`
-  --> $DIR/issue-74824.rs:10:19
+  --> $DIR/issue-74824.rs:12:19
    |
 LL |     type Copy<T>: Copy = Box<T>;
    |                   ^^^^ required by this bound in `UnsafeCopy::Copy`
 
-error[E0277]: the trait bound `T: Clone` is not satisfied
-  --> $DIR/issue-74824.rs:10:26
+error[E0277]: the trait bound `Box<T>: Clone` is not satisfied
+  --> $DIR/issue-74824.rs:12:26
    |
 LL |     type Copy<T>: Copy = Box<T>;
-   |                          ^^^^^^ the trait `Clone` is not implemented for `T`
+   |                          ^^^^^^ the trait `Clone` is not implemented for `Box<T>`
    |
-   = note: required for `Box<T>` to implement `Clone`
    = note: required for `<Self as UnsafeCopy>::Copy<T>` to implement `Copy`
 note: required by a bound in `UnsafeCopy::Copy`
-  --> $DIR/issue-74824.rs:10:19
+  --> $DIR/issue-74824.rs:12:19
    |
 LL |     type Copy<T>: Copy = Box<T>;
    |                   ^^^^ required by this bound in `UnsafeCopy::Copy`
-help: consider restricting type parameter `T` with trait `Clone`
-   |
-LL |     type Copy<T: std::clone::Clone>: Copy = Box<T>;
-   |                +++++++++++++++++++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/generic-associated-types/issue-74824.next.stderr
+++ b/tests/ui/generic-associated-types/issue-74824.next.stderr
@@ -1,33 +1,15 @@
 error[E0277]: the trait bound `Box<T>: Copy` is not satisfied
-  --> $DIR/issue-74824.rs:10:26
+  --> $DIR/issue-74824.rs:12:26
    |
 LL |     type Copy<T>: Copy = Box<T>;
    |                          ^^^^^^ the trait `Copy` is not implemented for `Box<T>`
    |
 note: required by a bound in `UnsafeCopy::Copy`
-  --> $DIR/issue-74824.rs:10:19
+  --> $DIR/issue-74824.rs:12:19
    |
 LL |     type Copy<T>: Copy = Box<T>;
    |                   ^^^^ required by this bound in `UnsafeCopy::Copy`
 
-error[E0277]: the trait bound `T: Clone` is not satisfied
-  --> $DIR/issue-74824.rs:10:26
-   |
-LL |     type Copy<T>: Copy = Box<T>;
-   |                          ^^^^^^ the trait `Clone` is not implemented for `T`
-   |
-   = note: required for `Box<T>` to implement `Clone`
-   = note: required for `<Self as UnsafeCopy>::Copy<T>` to implement `Copy`
-note: required by a bound in `UnsafeCopy::Copy`
-  --> $DIR/issue-74824.rs:10:19
-   |
-LL |     type Copy<T>: Copy = Box<T>;
-   |                   ^^^^ required by this bound in `UnsafeCopy::Copy`
-help: consider restricting type parameter `T` with trait `Clone`
-   |
-LL |     type Copy<T: std::clone::Clone>: Copy = Box<T>;
-   |                +++++++++++++++++++
-
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/generic-associated-types/issue-74824.rs
+++ b/tests/ui/generic-associated-types/issue-74824.rs
@@ -2,6 +2,8 @@
 //@ ignore-compare-mode-next-solver (explicit revisions)
 //@[next] compile-flags: -Znext-solver
 
+//@ dont-require-annotations: NOTE
+
 #![feature(associated_type_defaults)]
 
 use std::ops::Deref;
@@ -9,7 +11,7 @@ use std::ops::Deref;
 trait UnsafeCopy {
     type Copy<T>: Copy = Box<T>;
     //~^ ERROR the trait bound `Box<T>: Copy` is not satisfied
-    //~^^ ERROR the trait bound `T: Clone` is not satisfied
+    //[current]~| ERROR the trait bound `Box<T>: Clone` is not satisfied [E0277]
     fn copy<T>(x: &Self::Copy<T>) -> Self::Copy<T> {
         *x
     }


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/146381)*
<!-- homu-ignore:end -->

Part of rust-lang/rust#142518

I had to add a non-default method to `CloneToUninit` for this to work, but I think this is fine. (I did not do the renaming to `CloneUnsized` as suggested in https://github.com/rust-lang/rust/issues/126799#issuecomment-2585490135, as this is quite orthogonal)

This also adds some infrastructure that will be helpful for in-place initialization.

Commits can be reviewed independently.