### PR TITLE
Trim paths less in MIR dumping

### DIFF
--- a/compiler/rustc_middle/src/mir/pretty.rs
+++ b/compiler/rustc_middle/src/mir/pretty.rs
@@ -78,8 +78,9 @@ impl<'dis, 'de, 'tcx> MirDumper<'dis, 'de, 'tcx> {
     pub fn new(tcx: TyCtxt<'tcx>, pass_name: &'static str, body: &Body<'tcx>) -> Option<Self> {
         let dump_enabled = if let Some(ref filters) = tcx.sess.opts.unstable_opts.dump_mir {
             // see notes on #41697 below
-            let node_path =
-                ty::print::with_forced_impl_filename_line!(tcx.def_path_str(body.source.def_id()));
+            let node_path = ty::print::with_no_trimmed_paths!(
+                ty::print::with_forced_impl_filename_line!(tcx.def_path_str(body.source.def_id()))
+            );
             filters.split('|').any(|or_filter| {
                 or_filter.split('&').all(|and_filter| {
                     let and_filter_trimmed = and_filter.trim();
@@ -173,9 +174,10 @@ impl<'dis, 'de, 'tcx> MirDumper<'dis, 'de, 'tcx> {
     // trigger `type_of`, and this can run while we are already attempting to evaluate `type_of`.
     pub fn dump_mir_to_writer(&self, body: &Body<'tcx>, w: &mut dyn io::Write) -> io::Result<()> {
         // see notes on #41697 above
-        let def_path = ty::print::with_forced_impl_filename_line!(
-            self.tcx().def_path_str(body.source.def_id())
-        );
+        let def_path =
+            ty::print::with_no_trimmed_paths!(ty::print::with_forced_impl_filename_line!(
+                self.tcx().def_path_str(body.source.def_id())
+            ));
         // ignore-tidy-odd-backticks the literal below is fine
         write!(w, "// MIR for `{def_path}")?;
         match body.source.promoted {

--- a/tests/mir-opt/retag.core.ptr-drop_in_place.Test.SimplifyCfg-make_shim.after.panic-abort.mir
+++ b/tests/mir-opt/retag.core.ptr-drop_in_place.Test.SimplifyCfg-make_shim.after.panic-abort.mir
@@ -1,4 +1,4 @@
-// MIR for `drop_in_place` after SimplifyCfg-make_shim
+// MIR for `std::ptr::drop_in_place` after SimplifyCfg-make_shim
 
 fn drop_in_place(_1: *mut Test) -> () {
     let mut _0: ();

--- a/tests/mir-opt/retag.core.ptr-drop_in_place.Test.SimplifyCfg-make_shim.after.panic-unwind.mir
+++ b/tests/mir-opt/retag.core.ptr-drop_in_place.Test.SimplifyCfg-make_shim.after.panic-unwind.mir
@@ -1,4 +1,4 @@
-// MIR for `drop_in_place` after SimplifyCfg-make_shim
+// MIR for `std::ptr::drop_in_place` after SimplifyCfg-make_shim
 
 fn drop_in_place(_1: *mut Test) -> () {
     let mut _0: ();

--- a/tests/mir-opt/slice_drop_shim.core.ptr-drop_in_place.[String;42].AddMovesForPackedDrops.before.mir
+++ b/tests/mir-opt/slice_drop_shim.core.ptr-drop_in_place.[String;42].AddMovesForPackedDrops.before.mir
@@ -1,4 +1,4 @@
-// MIR for `drop_in_place` before AddMovesForPackedDrops
+// MIR for `std::ptr::drop_in_place` before AddMovesForPackedDrops
 
 fn drop_in_place(_1: *mut [String; 42]) -> () {
     let mut _0: ();

--- a/tests/mir-opt/slice_drop_shim.core.ptr-drop_in_place.[String].AddMovesForPackedDrops.before.mir
+++ b/tests/mir-opt/slice_drop_shim.core.ptr-drop_in_place.[String].AddMovesForPackedDrops.before.mir
@@ -1,4 +1,4 @@
-// MIR for `drop_in_place` before AddMovesForPackedDrops
+// MIR for `std::ptr::drop_in_place` before AddMovesForPackedDrops
 
 fn drop_in_place(_1: *mut [String]) -> () {
     let mut _0: ();

--- a/tests/mir-opt/unusual_item_types.core.ptr-drop_in_place.Vec_i32_.AddMovesForPackedDrops.before.mir
+++ b/tests/mir-opt/unusual_item_types.core.ptr-drop_in_place.Vec_i32_.AddMovesForPackedDrops.before.mir
@@ -1,4 +1,4 @@
-// MIR for `drop_in_place` before AddMovesForPackedDrops
+// MIR for `std::ptr::drop_in_place` before AddMovesForPackedDrops
 
 fn drop_in_place(_1: *mut Vec<i32>) -> () {
     let mut _0: ();


### PR DESCRIPTION
With this PR, the paths MIR dump filters and that are printed at the start of a dump file are no longer trimmed. They don't include the crate that is being compiled, however.