### PR TITLE
ci: Increase `rust.debuginfo-level-tests` to `2` in `x86_64-gnu-debug` job

### DIFF
--- a/src/ci/docker/host-x86_64/x86_64-gnu-debug/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-debug/Dockerfile
@@ -38,7 +38,7 @@ ENV RUST_CONFIGURE_ARGS \
       --build=x86_64-unknown-linux-gnu \
       --enable-debug \
       --enable-lld \
-      --set rust.debuginfo-level-tests=1 \
+      --set rust.debuginfo-level-tests=2 \
       --set llvm.use-linker=lld \
       --set target.x86_64-unknown-linux-gnu.linker=clang \
       --set target.x86_64-unknown-linux-gnu.cc=clang \

--- a/tests/ui/async-await/future-sizes/async-awaiting-fut.rs
+++ b/tests/ui/async-await/future-sizes/async-awaiting-fut.rs
@@ -1,3 +1,5 @@
+// FIXME(#61117): Respect debuginfo-level-tests, do not force debuginfo=0
+//@ compile-flags: -C debuginfo=0
 //@ compile-flags: -C panic=abort -Z print-type-sizes --crate-type lib
 //@ needs-deterministic-layouts
 //@ edition:2021

--- a/tests/ui/async-await/future-sizes/large-arg.rs
+++ b/tests/ui/async-await/future-sizes/large-arg.rs
@@ -1,3 +1,5 @@
+// FIXME(#61117): Respect debuginfo-level-tests, do not force debuginfo=0
+//@ compile-flags: -C debuginfo=0
 //@ compile-flags: -C panic=abort -Z print-type-sizes --crate-type=lib
 //@ needs-deterministic-layouts
 //@ edition: 2021

--- a/tests/ui/consts/required-consts/collect-in-promoted-const.noopt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-promoted-const.noopt.stderr
@@ -1,17 +1,17 @@
 error[E0080]: evaluation panicked: explicit panic
-  --> $DIR/collect-in-promoted-const.rs:9:19
+  --> $DIR/collect-in-promoted-const.rs:11:19
    |
 LL |     const C: () = panic!();
    |                   ^^^^^^^^ evaluation of `Fail::<i32>::C` failed here
 
 note: erroneous constant encountered
-  --> $DIR/collect-in-promoted-const.rs:20:21
+  --> $DIR/collect-in-promoted-const.rs:22:21
    |
 LL |         let _val = &Fail::<T>::C;
    |                     ^^^^^^^^^^^^
 
 note: the above error was encountered while instantiating `fn f::<i32>`
-  --> $DIR/collect-in-promoted-const.rs:25:5
+  --> $DIR/collect-in-promoted-const.rs:27:5
    |
 LL |     f::<i32>();
    |     ^^^^^^^^^^

--- a/tests/ui/consts/required-consts/collect-in-promoted-const.opt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-promoted-const.opt.stderr
@@ -1,23 +1,23 @@
 error[E0080]: evaluation panicked: explicit panic
-  --> $DIR/collect-in-promoted-const.rs:9:19
+  --> $DIR/collect-in-promoted-const.rs:11:19
    |
 LL |     const C: () = panic!();
    |                   ^^^^^^^^ evaluation of `Fail::<T>::C` failed here
 
 note: erroneous constant encountered
-  --> $DIR/collect-in-promoted-const.rs:20:21
+  --> $DIR/collect-in-promoted-const.rs:22:21
    |
 LL |         let _val = &Fail::<T>::C;
    |                     ^^^^^^^^^^^^
 
 error[E0080]: evaluation panicked: explicit panic
-  --> $DIR/collect-in-promoted-const.rs:9:19
+  --> $DIR/collect-in-promoted-const.rs:11:19
    |
 LL |     const C: () = panic!();
    |                   ^^^^^^^^ evaluation of `Fail::<i32>::C` failed here
 
 note: erroneous constant encountered
-  --> $DIR/collect-in-promoted-const.rs:20:21
+  --> $DIR/collect-in-promoted-const.rs:22:21
    |
 LL |         let _val = &Fail::<T>::C;
    |                     ^^^^^^^^^^^^
@@ -25,7 +25,7 @@ LL |         let _val = &Fail::<T>::C;
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 note: the above error was encountered while instantiating `fn f::<i32>`
-  --> $DIR/collect-in-promoted-const.rs:25:5
+  --> $DIR/collect-in-promoted-const.rs:27:5
    |
 LL |     f::<i32>();
    |     ^^^^^^^^^^

--- a/tests/ui/consts/required-consts/collect-in-promoted-const.rs
+++ b/tests/ui/consts/required-consts/collect-in-promoted-const.rs
@@ -1,6 +1,8 @@
 //@revisions: noopt opt
 //@ build-fail
 //@[noopt] compile-flags: -Copt-level=0
+// FIXME(#61117): Respect debuginfo-level-tests, do not force debuginfo=0
+//@[opt] compile-flags: -C debuginfo=0
 //@[opt] compile-flags: -O
 //! Make sure we error on erroneous consts even if they get promoted.
 

--- a/tests/ui/print_type_sizes/async.rs
+++ b/tests/ui/print_type_sizes/async.rs
@@ -1,3 +1,5 @@
+// FIXME(#61117): Respect debuginfo-level-tests, do not force debuginfo=0
+//@ compile-flags: -C debuginfo=0
 //@ compile-flags: -C panic=abort -Z print-type-sizes --crate-type lib
 //@ needs-deterministic-layouts
 //@ edition:2021


### PR DESCRIPTION
Simply to increase the scope of the testing.

Part of https://github.com/rust-lang/rust/issues/61117.

cc rust-lang/rust#145967 and rust-lang/rust#146025 which prepared for this. And rust-lang/rust#144499 that set to level to `1`

try-job: x86_64-gnu-debug
