### PR TITLE
sort array trait implementation suggestions correctly

### DIFF
--- a/tests/ui/consts/missing-larger-array-impl.stderr
+++ b/tests/ui/consts/missing-larger-array-impl.stderr
@@ -8,11 +8,11 @@ LL |     <[X; 35] as Default>::default();
              &[T]
              &mut [T]
              [T; 0]
-             [T; 10]
-             [T; 11]
-             [T; 12]
-             [T; 13]
-             [T; 14]
+             [T; 1]
+             [T; 2]
+             [T; 3]
+             [T; 4]
+             [T; 5]
            and 27 others
 
 error: aborting due to 1 previous error

--- a/tests/ui/suggestions/issue-71394-no-from-impl.stderr
+++ b/tests/ui/suggestions/issue-71394-no-from-impl.stderr
@@ -5,14 +5,14 @@ LL |     let _: &[i8] = data.into();
    |                         ^^^^ the trait `From<&[u8]>` is not implemented for `&[i8]`
    |
    = help: the following other types implement trait `From<T>`:
-             `[T; 10]` implements `From<(T, T, T, T, T, T, T, T, T, T)>`
-             `[T; 11]` implements `From<(T, T, T, T, T, T, T, T, T, T, T)>`
-             `[T; 12]` implements `From<(T, T, T, T, T, T, T, T, T, T, T, T)>`
              `[T; 1]` implements `From<(T,)>`
              `[T; 2]` implements `From<(T, T)>`
              `[T; 3]` implements `From<(T, T, T)>`
              `[T; 4]` implements `From<(T, T, T, T)>`
              `[T; 5]` implements `From<(T, T, T, T, T)>`
+             `[T; 6]` implements `From<(T, T, T, T, T, T)>`
+             `[T; 7]` implements `From<(T, T, T, T, T, T, T)>`
+             `[T; 8]` implements `From<(T, T, T, T, T, T, T, T)>`
            and 6 others
    = note: required for `&[u8]` to implement `Into<&[i8]>`
 


### PR DESCRIPTION
Fixes rust-lang/rust#135098.
Previously tried in rust-lang/rust#137428.