### PR TITLE
Improve `core::ops` coverage

### DIFF
--- a/library/coretests/tests/lib.rs
+++ b/library/coretests/tests/lib.rs
@@ -81,6 +81,7 @@
 #![feature(next_index)]
 #![feature(non_exhaustive_omitted_patterns_lint)]
 #![feature(numfmt)]
+#![feature(one_sided_range)]
 #![feature(option_reduce)]
 #![feature(pattern)]
 #![feature(peekable_next_if_map)]

--- a/library/coretests/tests/ops.rs
+++ b/library/coretests/tests/ops.rs
@@ -2,7 +2,8 @@ mod control_flow;
 mod from_residual;
 
 use core::ops::{
-    Bound, Deref, DerefMut, Range, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive,
+    Bound, Deref, DerefMut, OneSidedRange, OneSidedRangeBound, Range, RangeBounds, RangeFrom,
+    RangeFull, RangeInclusive, RangeTo, RangeToInclusive,
 };
 
 // Test the Range structs and syntax.
@@ -71,6 +72,35 @@ fn test_range_to_inclusive() {
 }
 
 #[test]
+fn test_range_contains() {
+    assert!(!(1u32..5).contains(&0u32));
+    assert!((1u32..5).contains(&1u32));
+    assert!((1u32..5).contains(&4u32));
+    assert!(!(1u32..5).contains(&5u32));
+    assert!(!(1u32..5).contains(&6u32));
+}
+
+#[test]
+fn test_range_to_contains() {
+    assert!(!(1u32..=5).contains(&0));
+    assert!((1u32..=5).contains(&1));
+    assert!((1u32..=5).contains(&4));
+    assert!((1u32..=5).contains(&5));
+    assert!(!(1u32..=5).contains(&6));
+}
+
+// This test covers `RangeBounds::contains` when the start is excluded.
+#[test]
+fn test_range_bounds_contains() {
+    let r = (Bound::Excluded(1u32), Bound::Included(5u32));
+    assert!(!r.contains(&0));
+    assert!(!r.contains(&1));
+    assert!(r.contains(&3));
+    assert!(r.contains(&5));
+    assert!(!r.contains(&6));
+}
+
+#[test]
 fn test_range_is_empty() {
     assert!(!(0.0..10.0).is_empty());
     assert!((-0.0..0.0).is_empty());
@@ -89,6 +119,34 @@ fn test_range_is_empty() {
     assert!((f32::EPSILON..=f32::NAN).is_empty());
     assert!((f32::NAN..=f32::EPSILON).is_empty());
     assert!((f32::NAN..=f32::NAN).is_empty());
+}
+
+#[test]
+fn test_range_inclusive_end_bound() {
+    let mut r = 1u32..=1;
+    r.next().unwrap();
+    assert!(!r.contains(&1));
+}
+
+#[test]
+fn test_range_bounds() {
+    let r = (Bound::Included(1u32), Bound::Excluded(5u32));
+    assert!(!r.contains(&0));
+    assert!(r.contains(&1));
+    assert!(r.contains(&3));
+    assert!(!r.contains(&5));
+    assert!(!r.contains(&6));
+
+    let r = (Bound::<u32>::Unbounded, Bound::Unbounded);
+    assert!(r.contains(&0));
+    assert!(r.contains(&u32::MAX));
+}
+
+#[test]
+fn test_one_sided_range_bound() {
+    assert!(matches!((..1u32).bound(), (OneSidedRangeBound::End, 1)));
+    assert!(matches!((1u32..).bound(), (OneSidedRangeBound::StartInclusive, 1)));
+    assert!(matches!((..=1u32).bound(), (OneSidedRangeBound::EndInclusive, 1)));
 }
 
 #[test]
@@ -239,4 +297,18 @@ fn deref_on_ref() {
 #[allow(unreachable_code)]
 fn test_not_never() {
     if !return () {}
+}
+
+#[test]
+fn test_fmt() {
+    let mut r = 1..=1;
+    assert_eq!(format!("{:?}", r), "1..=1");
+    r.next().unwrap();
+    assert_eq!(format!("{:?}", r), "1..=1 (exhausted)");
+
+    assert_eq!(format!("{:?}", 1..1), "1..1");
+    assert_eq!(format!("{:?}", 1..), "1..");
+    assert_eq!(format!("{:?}", ..1), "..1");
+    assert_eq!(format!("{:?}", ..=1), "..=1");
+    assert_eq!(format!("{:?}", ..), "..");
 }

--- a/library/coretests/tests/ops.rs
+++ b/library/coretests/tests/ops.rs
@@ -89,7 +89,8 @@ fn test_range_to_contains() {
     assert!(!(1u32..=5).contains(&6));
 }
 
-// This test covers `RangeBounds::contains` when the start is excluded.
+// This test covers `RangeBounds::contains` when the start is excluded,
+// which cannot be directly expressed by Rust's built-in range syntax.
 #[test]
 fn test_range_bounds_contains() {
     let r = (Bound::Excluded(1u32), Bound::Included(5u32));


### PR DESCRIPTION
This PR improves the `core::ops` coverage by adding new tests to `coretests`
