### PR TITLE
Add a new lint `UNCONSTRUCTIBLE_PUB_STRUCTS`

### DIFF
--- a/compiler/rustc_lint/src/lib.rs
+++ b/compiler/rustc_lint/src/lib.rs
@@ -301,6 +301,7 @@ fn register_builtins(store: &mut LintStore) {
         UNUSED_VISIBILITIES,
         UNUSED_ASSIGNMENTS,
         DEAD_CODE,
+        UNUSED_UNCONSTRUCTABLE_PUB_STRUCTS,
         UNUSED_MUT,
         // FIXME: add this lint when it becomes stable,
         // see https://github.com/rust-lang/rust/issues/115585.

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -843,8 +843,7 @@ declare_lint! {
     ///   cannot construct a value of the type.
     /// * It is not used locally and does not appear in any reachable path from
     ///   external APIs other than the public struct item itself.
-    /// * It has no field that marks intentional unconstructability, such as a
-    ///   field with unit or never type.
+    /// * It is not uninhabited, is not composed only of ZST fields, and has no unit field.
     ///
     /// Such structs may have been unused for a long time, but are now effectively dead code.
     /// This lint helps find those items.

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -857,7 +857,7 @@ declare_lint! {
     ///
     /// Otherwise, consider removing it if the struct is no longer in use.
     pub UNUSED_UNCONSTRUCTABLE_PUB_STRUCTS,
-    Allow,
+    Deny,
     "detects public structs with private fields that cannot be constructed or otherwise used through the external API"
 }
 

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -147,6 +147,7 @@ declare_lint_pass! {
         UNUSED_MACRO_RULES,
         UNUSED_MUT,
         UNUSED_QUALIFICATIONS,
+        UNUSED_UNCONSTRUCTABLE_PUB_STRUCTS,
         UNUSED_UNSAFE,
         UNUSED_VARIABLES,
         UNUSED_VISIBILITIES,
@@ -816,6 +817,48 @@ declare_lint! {
     Allow,
     "detect public items in executable crates that are never used",
     crate_level_only
+}
+
+declare_lint! {
+    /// The `unused_unconstructable_pub_structs` lint detects public structs
+    /// with private fields that cannot be constructed or otherwise used through
+    /// the external API.
+    ///
+    /// ### Example
+    ///
+    /// ```rust,compile_fail
+    /// #![deny(unused_unconstructable_pub_structs)]
+    ///
+    /// pub struct Foo(i32);
+    /// # fn main() {}
+    /// ```
+    ///
+    /// {{produces}}
+    ///
+    /// ### Explanation
+    ///
+    /// This lint is emitted for a `pub` struct when:
+    ///
+    /// * It has private fields and no public constructor, so downstream crates
+    ///   cannot construct a value of the type.
+    /// * It is not used locally and does not appear in any reachable path from
+    ///   external APIs other than the public struct item itself.
+    /// * It has no field that marks intentional unconstructability, such as a
+    ///   field with unit or never type.
+    ///
+    /// Such structs may have been unused for a long time, but are now effectively dead code.
+    /// This lint helps find those items.
+    ///
+    /// To silence the warning for individual items, prefix the name with an
+    /// underscore such as `_Foo`.
+    ///
+    /// To indicate that the behavior is intentional, add a field with unit or
+    /// never type if the struct is only used at the type level.
+    ///
+    /// Otherwise, consider removing it if the struct is no longer in use.
+    pub UNUSED_UNCONSTRUCTABLE_PUB_STRUCTS,
+    Allow,
+    "detects public structs with private fields that cannot be constructed or otherwise used through the external API"
 }
 
 declare_lint! {

--- a/compiler/rustc_middle/src/middle/dead_code.rs
+++ b/compiler/rustc_middle/src/middle/dead_code.rs
@@ -11,13 +11,17 @@ pub struct DeadCodeLivenessSnapshot {
     pub ignored_derived_traits: LocalDefIdMap<FxIndexSet<DefId>>,
 }
 
-/// Dead-code liveness data for both analysis phases.
+/// Dead-code liveness data for different analysis phases.
 ///
 /// `pre_deferred_seeding` is computed before reachable-public and `#[allow(dead_code)]` seeding,
 /// and is used for lint `dead_code_pub_in_binary`.
+/// `pre_unconstructable_pubs` is computed before reachable public structs that cannot be
+/// directly constructed externally are seeded, and is used for lint
+/// `unused_unconstructable_pub_structs`.
 /// `final_result` is the final liveness snapshot used for lint `dead_code`.
 #[derive(Clone, Debug, StableHash)]
 pub struct DeadCodeLivenessSummary {
     pub pre_deferred_seeding: DeadCodeLivenessSnapshot,
+    pub pre_unconstructable_pubs: DeadCodeLivenessSnapshot,
     pub final_result: DeadCodeLivenessSnapshot,
 }

--- a/compiler/rustc_passes/src/dead.rs
+++ b/compiler/rustc_passes/src/dead.rs
@@ -10,7 +10,7 @@ use hir::def_id::{LocalDefIdMap, LocalDefIdSet};
 use rustc_abi::FieldIdx;
 use rustc_data_structures::fx::{FxHashSet, FxIndexSet};
 use rustc_errors::{ErrorGuaranteed, MultiSpan};
-use rustc_hir::def::{CtorOf, DefKind, Res};
+use rustc_hir::def::{CtorKind, CtorOf, DefKind, Res};
 use rustc_hir::def_id::{DefId, LocalDefId, LocalModDefId};
 use rustc_hir::intravisit::{self, Visitor};
 use rustc_hir::{self as hir, ForeignItemId, ItemId, Node, PatKind, QPath, find_attr};
@@ -21,13 +21,15 @@ use rustc_middle::query::Providers;
 use rustc_middle::ty::{self, AssocTag, TyCtxt};
 use rustc_middle::{bug, span_bug};
 use rustc_session::config::CrateType;
-use rustc_session::lint::builtin::{DEAD_CODE, DEAD_CODE_PUB_IN_BINARY};
+use rustc_session::lint::builtin::{
+    DEAD_CODE, DEAD_CODE_PUB_IN_BINARY, UNUSED_UNCONSTRUCTABLE_PUB_STRUCTS,
+};
 use rustc_session::lint::{self, Lint, StableLintExpectationId};
 use rustc_span::{Symbol, kw};
 
 use crate::errors::{
     ChangeFields, DeadCodePubInBinaryNote, IgnoredDerivedImpls, MultipleDeadCodes, ParentInfo,
-    UselessAssignment,
+    UnusedUnconstructablePubStructsNote, UselessAssignment,
 };
 
 /// Any local definition that may call something in its body block should be explored. For example,
@@ -68,6 +70,42 @@ fn should_explore(tcx: TyCtxt<'_>, def_id: LocalDefId) -> bool {
         | DefKind::Closure
         | DefKind::SyntheticCoroutineBody => false,
     }
+}
+
+fn struct_can_be_constructed_directly(tcx: TyCtxt<'_>, id: LocalDefId) -> bool {
+    // Skip language items
+    if tcx.as_lang_item(id.to_def_id()).is_some() {
+        return true;
+    }
+
+    let adt_def = tcx.adt_def(id.to_def_id());
+
+    // We only care about structs for now
+    if !adt_def.is_struct() {
+        return true;
+    }
+
+    // Such types often declared in Rust but constructed by FFI, so ignore
+    if adt_def.repr().c() || adt_def.repr().transparent() {
+        return true;
+    }
+
+    // Skip types contain fields of unit, never or PhantomData,
+    // it's usually intentional to make the type not constructible
+    if adt_def.all_fields().any(|field| {
+        let field_type = tcx.type_of(field.did).skip_binder();
+        field_type.is_unit() || field_type.is_never()
+    }) {
+        return true;
+    }
+
+    adt_def.all_fields().all(|field| field.vis.is_public())
+        || adt_def.all_fields().all(|field| tcx.type_of(field.did).skip_binder().is_phantom_data())
+}
+
+fn method_has_receiver(tcx: TyCtxt<'_>, id: LocalDefId) -> bool {
+    tcx.hir_fn_decl_by_hir_id(tcx.local_def_id_to_hir_id(id))
+        .is_some_and(|fn_decl| fn_decl.implicit_self().has_implicit_self())
 }
 
 /// Determine if a work from the worklist is coming from a `#[allow]`
@@ -561,9 +599,12 @@ impl<'tcx> MarkSymbolVisitor<'tcx> {
                 (self.tcx.local_parent(local_def_id), trait_item_id)
             }
             // impl items are live if the corresponding traits are live
-            DefKind::Impl { of_trait: true } => {
-                (local_def_id, self.tcx.impl_trait_id(local_def_id).as_local())
-            }
+            DefKind::Impl { of_trait } => (
+                local_def_id,
+                of_trait
+                    .then(|| self.tcx.impl_trait_id(local_def_id))
+                    .and_then(|did| did.as_local()),
+            ),
             _ => bug!(),
         };
 
@@ -921,12 +962,14 @@ fn maybe_record_as_seed<'tcx>(
 struct SeedWorklists {
     worklist: Vec<WorkItem>,
     deferred_seeds: Vec<WorkItem>,
+    deferred_unconstructable_pubs: Vec<WorkItem>,
     unsolved_items: Vec<LocalDefId>,
 }
 
 fn create_and_seed_worklist(tcx: TyCtxt<'_>) -> SeedWorklists {
     let mut unsolved_items = Vec::new();
     let mut deferred_seeds = Vec::new();
+    let mut deferred_unconstructable_pubs = Vec::new();
     let mut worklist = Vec::new();
 
     if let Some((def_id, _)) = tcx.entry_fn(())
@@ -940,12 +983,47 @@ fn create_and_seed_worklist(tcx: TyCtxt<'_>) -> SeedWorklists {
     }
 
     for (id, effective_vis) in tcx.effective_visibilities(()).iter() {
-        if effective_vis.is_public_at_level(Level::Reachable) {
-            deferred_seeds.push(WorkItem {
-                id: *id,
-                propagated: ComesFromAllowExpect::No,
-                own: ComesFromAllowExpect::No,
-            });
+        if !effective_vis.is_public_at_level(Level::Reachable) {
+            continue;
+        }
+
+        let work_item = WorkItem {
+            id: *id,
+            propagated: ComesFromAllowExpect::No,
+            own: ComesFromAllowExpect::No,
+        };
+
+        match tcx.def_kind(*id) {
+            DefKind::Struct if !struct_can_be_constructed_directly(tcx, *id) => {
+                deferred_unconstructable_pubs.push(work_item);
+            }
+            DefKind::Ctor(CtorOf::Struct, CtorKind::Fn)
+                if !struct_can_be_constructed_directly(tcx, tcx.local_parent(*id)) =>
+            {
+                deferred_unconstructable_pubs.push(work_item);
+            }
+
+            DefKind::Impl { of_trait } => {
+                if !of_trait {
+                    unsolved_items.push(*id);
+                }
+
+                deferred_unconstructable_pubs.push(work_item);
+            }
+            DefKind::AssocFn
+                if let DefKind::Impl { of_trait } = tcx.def_kind(tcx.local_parent(*id))
+                    && method_has_receiver(tcx, *id) =>
+            {
+                if !of_trait {
+                    unsolved_items.push(*id);
+                }
+
+                deferred_unconstructable_pubs.push(work_item);
+            }
+
+            _ => {
+                deferred_seeds.push(work_item);
+            }
         }
     }
 
@@ -958,15 +1036,19 @@ fn create_and_seed_worklist(tcx: TyCtxt<'_>) -> SeedWorklists {
         maybe_record_as_seed(tcx, id, &mut push_into_worklist, &mut unsolved_items);
     }
 
-    SeedWorklists { worklist, deferred_seeds, unsolved_items }
+    SeedWorklists { worklist, deferred_seeds, deferred_unconstructable_pubs, unsolved_items }
 }
 
 fn live_symbols_and_ignored_derived_traits(
     tcx: TyCtxt<'_>,
     (): (),
 ) -> Result<DeadCodeLivenessSummary, ErrorGuaranteed> {
-    let SeedWorklists { worklist, deferred_seeds, mut unsolved_items } =
-        create_and_seed_worklist(tcx);
+    let SeedWorklists {
+        worklist,
+        deferred_seeds,
+        deferred_unconstructable_pubs,
+        mut unsolved_items,
+    } = create_and_seed_worklist(tcx);
     let mut symbol_visitor = MarkSymbolVisitor {
         worklist,
         tcx,
@@ -989,8 +1071,17 @@ fn live_symbols_and_ignored_derived_traits(
     symbol_visitor.worklist.extend(deferred_seeds);
     mark_live_symbols_and_ignored_derived_traits(&mut symbol_visitor, &mut unsolved_items)?;
 
+    let pre_unconstructable_pubs = DeadCodeLivenessSnapshot {
+        live_symbols: symbol_visitor.live_symbols.clone(),
+        ignored_derived_traits: symbol_visitor.ignored_derived_traits.clone(),
+    };
+
+    symbol_visitor.worklist.extend(deferred_unconstructable_pubs);
+    mark_live_symbols_and_ignored_derived_traits(&mut symbol_visitor, &mut unsolved_items)?;
+
     Ok(DeadCodeLivenessSummary {
         pre_deferred_seeding,
+        pre_unconstructable_pubs,
         final_result: DeadCodeLivenessSnapshot {
             live_symbols: symbol_visitor.live_symbols,
             ignored_derived_traits: symbol_visitor.ignored_derived_traits,
@@ -1093,6 +1184,15 @@ impl<'tcx> DeadVisitor<'tcx> {
 
     fn dead_code_pub_in_binary_note(&self) -> Option<DeadCodePubInBinaryNote> {
         self.target_lint.name.eq(DEAD_CODE_PUB_IN_BINARY.name).then_some(DeadCodePubInBinaryNote)
+    }
+
+    fn unused_unconstructable_pub_structs_note(
+        &self,
+    ) -> Option<UnusedUnconstructablePubStructsNote> {
+        self.target_lint
+            .name
+            .eq(UNUSED_UNCONSTRUCTABLE_PUB_STRUCTS.name)
+            .then_some(UnusedUnconstructablePubStructsNote)
     }
 
     // # Panics
@@ -1207,6 +1307,8 @@ impl<'tcx> DeadVisitor<'tcx> {
                     participle,
                     name_list,
                     dead_code_pub_in_binary_note: self.dead_code_pub_in_binary_note(),
+                    unused_unconstructable_pub_structs_note: self
+                        .unused_unconstructable_pub_structs_note(),
                     change_fields_suggestion: fields_suggestion,
                     parent_info,
                     ignored_derived_impls,
@@ -1244,6 +1346,8 @@ impl<'tcx> DeadVisitor<'tcx> {
                     participle,
                     name_list,
                     dead_code_pub_in_binary_note: self.dead_code_pub_in_binary_note(),
+                    unused_unconstructable_pub_structs_note: self
+                        .unused_unconstructable_pub_structs_note(),
                     parent_info,
                     ignored_derived_impls,
                     enum_variants_with_same_name,
@@ -1320,8 +1424,11 @@ impl<'tcx> DeadVisitor<'tcx> {
 }
 
 fn check_mod_deathness(tcx: TyCtxt<'_>, module: LocalModDefId) {
-    let Ok(DeadCodeLivenessSummary { pre_deferred_seeding, final_result }) =
-        tcx.live_symbols_and_ignored_derived_traits(()).as_ref()
+    let Ok(DeadCodeLivenessSummary {
+        pre_deferred_seeding,
+        pre_unconstructable_pubs,
+        final_result,
+    }) = tcx.live_symbols_and_ignored_derived_traits(()).as_ref()
     else {
         return;
     };
@@ -1346,6 +1453,26 @@ fn check_mod_deathness(tcx: TyCtxt<'_>, module: LocalModDefId) {
                 .filter(|foreign_item| is_unused_pub(foreign_item.owner_id.def_id)),
         );
     }
+
+    let is_unused_unconstructable_pub = |def_id| {
+        tcx.effective_visibilities(()).is_public_at_level(def_id, Level::Reachable)
+            && !pre_unconstructable_pubs.live_symbols.contains(&def_id)
+            && tcx.def_kind(def_id) == DefKind::Struct
+            && !struct_can_be_constructed_directly(tcx, def_id)
+    };
+    lint_dead_codes(
+        tcx,
+        UNUSED_UNCONSTRUCTABLE_PUB_STRUCTS,
+        module,
+        &pre_unconstructable_pubs.live_symbols,
+        &pre_unconstructable_pubs.ignored_derived_traits,
+        module_items
+            .free_items()
+            .filter(|free_item| is_unused_unconstructable_pub(free_item.owner_id.def_id)),
+        module_items
+            .foreign_items()
+            .filter(|foreign_item| is_unused_unconstructable_pub(foreign_item.owner_id.def_id)),
+    );
 
     lint_dead_codes(
         tcx,

--- a/compiler/rustc_passes/src/dead.rs
+++ b/compiler/rustc_passes/src/dead.rs
@@ -85,22 +85,24 @@ fn struct_can_be_constructed_directly(tcx: TyCtxt<'_>, id: LocalDefId) -> bool {
         return true;
     }
 
-    // Such types often declared in Rust but constructed by FFI, so ignore
+    // Such types may be declared in Rust but constructed by FFI, so skip them
     if adt_def.repr().c() || adt_def.repr().transparent() {
         return true;
     }
 
-    // Skip types contain fields of unit, never or PhantomData,
-    // it's usually intentional to make the type not constructible
-    if adt_def.all_fields().any(|field| {
-        let field_type = tcx.type_of(field.did).skip_binder();
-        field_type.is_unit() || field_type.is_never()
-    }) {
+    let typing_env = ty::TypingEnv::non_body_analysis(tcx, id);
+    let struct_ty = tcx.type_of(id).skip_binder();
+
+    // Skip if uninhabited, containing only ZST fields, or containing unit fields.
+    // Since such types are usually intentional type-level markers
+    if struct_ty.is_privately_uninhabited(tcx, typing_env)
+        || tcx.layout_of(typing_env.as_query_input(struct_ty)).is_ok_and(|layout| layout.is_zst())
+        || adt_def.all_fields().any(|field| tcx.type_of(field.did).skip_binder().is_unit())
+    {
         return true;
     }
 
     adt_def.all_fields().all(|field| field.vis.is_public())
-        || adt_def.all_fields().all(|field| tcx.type_of(field.did).skip_binder().is_phantom_data())
 }
 
 fn method_has_receiver(tcx: TyCtxt<'_>, id: LocalDefId) -> bool {

--- a/compiler/rustc_passes/src/errors.rs
+++ b/compiler/rustc_passes/src/errors.rs
@@ -924,6 +924,8 @@ pub(crate) enum MultipleDeadCodes<'tcx> {
         #[subdiagnostic]
         dead_code_pub_in_binary_note: Option<DeadCodePubInBinaryNote>,
         #[subdiagnostic]
+        unused_unconstructable_pub_structs_note: Option<UnusedUnconstructablePubStructsNote>,
+        #[subdiagnostic]
         // only on DeadCodes since it's never a problem for tuple struct fields
         enum_variants_with_same_name: Vec<EnumVariantSameName<'tcx>>,
         #[subdiagnostic]
@@ -949,6 +951,8 @@ pub(crate) enum MultipleDeadCodes<'tcx> {
         #[subdiagnostic]
         dead_code_pub_in_binary_note: Option<DeadCodePubInBinaryNote>,
         #[subdiagnostic]
+        unused_unconstructable_pub_structs_note: Option<UnusedUnconstructablePubStructsNote>,
+        #[subdiagnostic]
         change_fields_suggestion: ChangeFields,
         #[subdiagnostic]
         parent_info: Option<ParentInfo<'tcx>>,
@@ -962,6 +966,12 @@ pub(crate) enum MultipleDeadCodes<'tcx> {
     "in libraries, `pub` items can be used by dependent crates; in binaries, they cannot, so this `pub` item is unused"
 )]
 pub(crate) struct DeadCodePubInBinaryNote;
+
+#[derive(Subdiagnostic)]
+#[note(
+    "this `pub` struct has private fields, no public constructor, and is not otherwise reachable through the external API, so consider providing a public constructor or removing it"
+)]
+pub(crate) struct UnusedUnconstructablePubStructsNote;
 
 #[derive(Subdiagnostic)]
 #[note(

--- a/compiler/rustc_passes/src/errors.rs
+++ b/compiler/rustc_passes/src/errors.rs
@@ -969,8 +969,10 @@ pub(crate) struct DeadCodePubInBinaryNote;
 
 #[derive(Subdiagnostic)]
 #[note(
-    "this `pub` struct has private fields, no public constructor, and is not otherwise reachable through the external API, so consider providing a public constructor or removing it"
+    "this `pub` struct has private fields, no public constructor, and is not otherwise reachable through the external API"
 )]
+#[help("consider removing it if it has not been used")]
+#[help("consider adding a field of type `!` or `()` if it is intended")]
 pub(crate) struct UnusedUnconstructablePubStructsNote;
 
 #[derive(Subdiagnostic)]

--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -409,6 +409,7 @@ pub struct FromUtf8Error {
 /// assert!(String::from_utf16(v).is_err());
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
+#[cfg_attr(no_global_oom_handling, expect(unused_unconstructable_pub_structs))]
 #[derive(Debug)]
 pub struct FromUtf16Error {
     kind: FromUtf16ErrorKind,

--- a/src/tools/rust-analyzer/crates/hir-ty/src/next_solver/infer/mod.rs
+++ b/src/tools/rust-analyzer/crates/hir-ty/src/next_solver/infer/mod.rs
@@ -1,7 +1,6 @@
 //! Infer context the next-trait-solver.
 
 use std::cell::{Cell, RefCell};
-use std::fmt;
 use std::ops::Range;
 use std::sync::Arc;
 
@@ -306,32 +305,6 @@ pub enum BoundRegionConversionTime {
 
     /// when projecting an associated type
     AssocTypeProjection(SolverDefId),
-}
-
-#[derive(Copy, Clone, Debug)]
-pub struct FixupError {
-    unresolved: TyOrConstInferVar,
-}
-
-impl fmt::Display for FixupError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        use TyOrConstInferVar::*;
-
-        match self.unresolved {
-            TyInt(_) => write!(
-                f,
-                "cannot determine the type of this integer; \
-                 add a suffix to specify the type explicitly"
-            ),
-            TyFloat(_) => write!(
-                f,
-                "cannot determine the type of this number; \
-                 add a suffix to specify the type explicitly"
-            ),
-            Ty(_) => write!(f, "unconstrained type"),
-            Const(_) => write!(f, "unconstrained const value"),
-        }
-    }
 }
 
 /// See the `region_obligations` field for more information.

--- a/tests/assembly-llvm/asm/arm-types.rs
+++ b/tests/assembly-llvm/asm/arm-types.rs
@@ -12,7 +12,7 @@
 #![feature(no_core, repr_simd, f16)]
 #![crate_type = "rlib"]
 #![no_core]
-#![allow(asm_sub_register, non_camel_case_types)]
+#![allow(asm_sub_register, non_camel_case_types, unused_unconstructable_pub_structs)]
 
 extern crate minicore;
 use minicore::*;

--- a/tests/assembly-llvm/asm/powerpc-types.rs
+++ b/tests/assembly-llvm/asm/powerpc-types.rs
@@ -16,7 +16,7 @@
 #![feature(no_core, repr_simd, asm_experimental_arch)]
 #![crate_type = "rlib"]
 #![no_core]
-#![allow(asm_sub_register, non_camel_case_types)]
+#![allow(asm_sub_register, non_camel_case_types, unused_unconstructable_pub_structs)]
 
 extern crate minicore;
 use minicore::*;

--- a/tests/assembly-llvm/asm/s390x-types.rs
+++ b/tests/assembly-llvm/asm/s390x-types.rs
@@ -10,7 +10,7 @@
 #![feature(no_core, repr_simd, f16, f128)]
 #![crate_type = "rlib"]
 #![no_core]
-#![allow(asm_sub_register, non_camel_case_types)]
+#![allow(asm_sub_register, non_camel_case_types, unused_unconstructable_pub_structs)]
 
 extern crate minicore;
 use minicore::*;

--- a/tests/assembly-llvm/simd-bitmask.rs
+++ b/tests/assembly-llvm/simd-bitmask.rs
@@ -15,7 +15,7 @@
 
 #![feature(no_core, lang_items, repr_simd, intrinsics)]
 #![no_core]
-#![allow(non_camel_case_types)]
+#![allow(non_camel_case_types, unused_unconstructable_pub_structs)]
 
 extern crate minicore;
 use minicore::*;

--- a/tests/assembly-llvm/simd-intrinsic-select.rs
+++ b/tests/assembly-llvm/simd-intrinsic-select.rs
@@ -13,7 +13,7 @@
 
 #![feature(no_core, lang_items, repr_simd, intrinsics)]
 #![no_core]
-#![allow(non_camel_case_types)]
+#![allow(non_camel_case_types, unused_unconstructable_pub_structs)]
 
 extern crate minicore;
 use minicore::*;

--- a/tests/codegen-llvm/is_val_statically_known.rs
+++ b/tests/codegen-llvm/is_val_statically_known.rs
@@ -2,6 +2,7 @@
 
 #![feature(core_intrinsics)]
 #![feature(f16, f128)]
+#![allow(unused_unconstructable_pub_structs)]
 
 use std::intrinsics::is_val_statically_known;
 

--- a/tests/codegen-llvm/simd/extract-insert-dyn.rs
+++ b/tests/codegen-llvm/simd/extract-insert-dyn.rs
@@ -9,7 +9,7 @@
 )]
 #![no_std]
 #![crate_type = "lib"]
-#![allow(non_camel_case_types)]
+#![allow(non_camel_case_types, unused_unconstructable_pub_structs)]
 
 // Test that `core::intrinsics::simd::{simd_extract_dyn, simd_insert_dyn}`
 // lower to an LLVM extractelement or insertelement operation.

--- a/tests/codegen-units/item-collection/generic-impl.rs
+++ b/tests/codegen-units/item-collection/generic-impl.rs
@@ -1,6 +1,7 @@
 //@ compile-flags:-Clink-dead-code -Zinline-mir=no
 
 #![deny(dead_code)]
+#![allow(unused_unconstructable_pub_structs)]
 #![crate_type = "lib"]
 
 struct Struct<T> {

--- a/tests/codegen-units/item-collection/overloaded-operators.rs
+++ b/tests/codegen-units/item-collection/overloaded-operators.rs
@@ -1,6 +1,7 @@
 //@ compile-flags:-Clink-dead-code
 
 #![deny(dead_code)]
+#![allow(unused_unconstructable_pub_structs)]
 #![crate_type = "lib"]
 
 use std::ops::{Add, Deref, Index, IndexMut};

--- a/tests/crashes/130797.rs
+++ b/tests/crashes/130797.rs
@@ -1,5 +1,7 @@
 //@ known-bug: #130797
 
+#![allow(unused_unconstructable_pub_structs)]
+
 trait Transform {
     type Output<'a>;
 }

--- a/tests/crashes/98322.rs
+++ b/tests/crashes/98322.rs
@@ -1,6 +1,7 @@
 //@ known-bug: #98322
 
 #![feature(generic_const_exprs)]
+#![allow(unused_unconstructable_pub_structs)]
 
 // Main function seems irrelevant
 fn main() {}

--- a/tests/incremental/auxiliary/issue-79661.rs
+++ b/tests/incremental/auxiliary/issue-79661.rs
@@ -1,4 +1,5 @@
 #![feature(rustc_attrs)]
+#![allow(unused_unconstructable_pub_structs)]
 
 #[cfg_attr(any(rpass2, rpass3), doc = "Some comment")]
 pub struct Foo;

--- a/tests/incremental/issue-79661-missing-def-path-hash.rs
+++ b/tests/incremental/issue-79661-missing-def-path-hash.rs
@@ -11,5 +11,6 @@
 extern crate issue_79661;
 use issue_79661::Wrapper;
 
+#[allow(unused_unconstructable_pub_structs)]
 pub struct Outer(Wrapper);
 fn main() {}

--- a/tests/mir-opt/pre-codegen/derived_ord_debug.rs
+++ b/tests/mir-opt/pre-codegen/derived_ord_debug.rs
@@ -4,6 +4,7 @@
 #![crate_type = "lib"]
 
 #[derive(PartialOrd, Ord, PartialEq, Eq)]
+#[allow(unused_unconstructable_pub_structs)]
 pub struct MultiField(char, i16);
 
 // EMIT_MIR derived_ord_debug.{impl#0}-partial_cmp.runtime-optimized.after.mir

--- a/tests/pretty/issue-4264.pp
+++ b/tests/pretty/issue-4264.pp
@@ -41,6 +41,7 @@ type Foo = [i32; (3 as usize)];
 struct Bar {
     x: [i32; (3 as usize)],
 }
+#[allow(unused_unconstructable_pub_structs)]
 struct TupleBar([i32; (4 as usize)]);
 enum Baz { BazVariant([i32; (5 as usize)]), }
 fn id<T>(x: T) -> T ({ (x as T) } as T)

--- a/tests/pretty/issue-4264.rs
+++ b/tests/pretty/issue-4264.rs
@@ -23,6 +23,7 @@ pub struct Bar {
     pub x: [i32; 3]
 }
 
+#[allow(unused_unconstructable_pub_structs)]
 pub struct TupleBar([i32; 4]);
 
 pub enum Baz {

--- a/tests/run-make/reproducible-build-2/reproducible-build.rs
+++ b/tests/run-make/reproducible-build-2/reproducible-build.rs
@@ -20,7 +20,7 @@
 
 // ignore-tidy-linelength
 
-#![allow(dead_code, warnings)]
+#![allow(dead_code, warnings, unused_unconstructable_pub_structs)]
 
 extern crate reproducible_build_aux;
 

--- a/tests/run-make/reproducible-build/reproducible-build.rs
+++ b/tests/run-make/reproducible-build/reproducible-build.rs
@@ -20,7 +20,7 @@
 
 // ignore-tidy-linelength
 
-#![allow(dead_code, warnings)]
+#![allow(dead_code, warnings, unused_unconstructable_pub_structs)]
 
 extern crate reproducible_build_aux;
 

--- a/tests/rustdoc-html/inline_cross/auxiliary/issue-46727.rs
+++ b/tests/rustdoc-html/inline_cross/auxiliary/issue-46727.rs
@@ -1,5 +1,7 @@
 //@ compile-flags: -Cmetadata=aux
 
+#![allow(unused_unconstructable_pub_structs)]
+
 pub trait Foo {}
 
 pub struct Bar<T> { x: T }

--- a/tests/rustdoc-html/intra-doc/auxiliary/extern-builtin-type-impl-dep.rs
+++ b/tests/rustdoc-html/intra-doc/auxiliary/extern-builtin-type-impl-dep.rs
@@ -3,6 +3,7 @@
 #![feature(lang_items, rustc_attrs)]
 #![crate_type = "rlib"]
 #![no_std]
+#![allow(unused_unconstructable_pub_structs)]
 
 pub struct DerefsToF64(f64);
 

--- a/tests/rustdoc-html/reexport/auxiliary/wrap-unnamable-type.rs
+++ b/tests/rustdoc-html/reexport/auxiliary/wrap-unnamable-type.rs
@@ -1,3 +1,5 @@
+#![allow(unused_unconstructable_pub_structs)]
+
 pub trait Assoc {
     type Ty;
 }

--- a/tests/rustdoc-html/type-alias/auxiliary/parent-crate-115718.rs
+++ b/tests/rustdoc-html/type-alias/auxiliary/parent-crate-115718.rs
@@ -1,3 +1,5 @@
+#![allow(unused_unconstructable_pub_structs)]
+
 pub struct MyStruct<T>(T);
 
 pub trait MyTrait1 {

--- a/tests/rustdoc-js/auxiliary/reexport-search_unbox.rs
+++ b/tests/rustdoc-js/auxiliary/reexport-search_unbox.rs
@@ -1,4 +1,5 @@
 #![feature(rustdoc_internals)]
+#![allow(unused_unconstructable_pub_structs)]
 
 #[doc(search_unbox)]
 pub struct Inside<T>(T);

--- a/tests/ui/borrowck/issue-115259-suggest-iter-mut.fixed
+++ b/tests/ui/borrowck/issue-115259-suggest-iter-mut.fixed
@@ -1,6 +1,7 @@
 //@ run-rustfix
 #![allow(unused_mut)]
 #![allow(dead_code)]
+#![allow(unused_unconstructable_pub_structs)]
 
 pub trait Layer {
     fn process(&mut self) -> u32;

--- a/tests/ui/borrowck/issue-115259-suggest-iter-mut.rs
+++ b/tests/ui/borrowck/issue-115259-suggest-iter-mut.rs
@@ -1,6 +1,7 @@
 //@ run-rustfix
 #![allow(unused_mut)]
 #![allow(dead_code)]
+#![allow(unused_unconstructable_pub_structs)]
 
 pub trait Layer {
     fn process(&mut self) -> u32;

--- a/tests/ui/borrowck/issue-115259-suggest-iter-mut.stderr
+++ b/tests/ui/borrowck/issue-115259-suggest-iter-mut.stderr
@@ -1,5 +1,5 @@
 error[E0596]: cannot borrow `**layer` as mutable, as it is behind a `&` reference
-  --> $DIR/issue-115259-suggest-iter-mut.rs:15:65
+  --> $DIR/issue-115259-suggest-iter-mut.rs:16:65
    |
 LL |         self.layers.iter().fold(0, |result, mut layer| result + layer.process())
    |                                                                 ^^^^^ `layer` is a `&` reference, so it cannot be borrowed as mutable

--- a/tests/ui/borrowck/struct-with-reference-to-trait-5708.rs
+++ b/tests/ui/borrowck/struct-with-reference-to-trait-5708.rs
@@ -1,3 +1,4 @@
+#![allow(unused_unconstructable_pub_structs)]
 // https://github.com/rust-lang/rust/issues/5708
 //@ run-pass
 #![allow(unused_variables)]

--- a/tests/ui/coherence/auxiliary/coherence_copy_like_lib.rs
+++ b/tests/ui/coherence/auxiliary/coherence_copy_like_lib.rs
@@ -1,5 +1,6 @@
 #![crate_type = "rlib"]
 #![feature(fundamental)]
+#![allow(unused_unconstructable_pub_structs)]
 
 pub trait MyCopy { }
 impl MyCopy for i32 { }

--- a/tests/ui/coherence/auxiliary/coherence_lib.rs
+++ b/tests/ui/coherence/auxiliary/coherence_lib.rs
@@ -1,4 +1,5 @@
 #![crate_type="lib"]
+#![allow(unused_unconstructable_pub_structs)]
 
 pub trait Remote {
     fn foo(&self) { }

--- a/tests/ui/const-generics/adt_const_params/auxiliary/unsized_const_param.rs
+++ b/tests/ui/const-generics/adt_const_params/auxiliary/unsized_const_param.rs
@@ -1,4 +1,5 @@
 #![feature(adt_const_params, unsized_const_params)]
+#![allow(unused_unconstructable_pub_structs)]
 
 #[derive(std::marker::ConstParamTy, Eq, PartialEq)]
 pub struct Foo([u8]);

--- a/tests/ui/const-generics/adt_const_params/unsized_field-1.rs
+++ b/tests/ui/const-generics/adt_const_params/unsized_field-1.rs
@@ -1,5 +1,6 @@
 //@ aux-build:unsized_const_param.rs
 #![feature(adt_const_params)]
+#![allow(unused_unconstructable_pub_structs)]
 
 extern crate unsized_const_param;
 

--- a/tests/ui/const-generics/adt_const_params/unsized_field-1.stderr
+++ b/tests/ui/const-generics/adt_const_params/unsized_field-1.stderr
@@ -1,5 +1,5 @@
 error[E0204]: the trait `ConstParamTy_` cannot be implemented for this type
-  --> $DIR/unsized_field-1.rs:9:8
+  --> $DIR/unsized_field-1.rs:10:8
    |
 LL | #[derive(ConstParamTy, Eq, PartialEq)]
    |          ------------ in this derive macro expansion
@@ -7,13 +7,13 @@ LL | struct A([u8]);
    |        ^ ---- this field does not implement `ConstParamTy_`
    |
 note: the `ConstParamTy_` impl for `[u8]` requires that `feature(unsized_const_params) is enabled`
-  --> $DIR/unsized_field-1.rs:9:10
+  --> $DIR/unsized_field-1.rs:10:10
    |
 LL | struct A([u8]);
    |          ^^^^
 
 error[E0204]: the trait `ConstParamTy_` cannot be implemented for this type
-  --> $DIR/unsized_field-1.rs:13:8
+  --> $DIR/unsized_field-1.rs:14:8
    |
 LL | #[derive(ConstParamTy, Eq, PartialEq)]
    |          ------------ in this derive macro expansion
@@ -21,13 +21,13 @@ LL | struct B(&'static [u8]);
    |        ^ ------------- this field does not implement `ConstParamTy_`
    |
 note: the `ConstParamTy_` impl for `&'static [u8]` requires that `feature(unsized_const_params) is enabled`
-  --> $DIR/unsized_field-1.rs:13:10
+  --> $DIR/unsized_field-1.rs:14:10
    |
 LL | struct B(&'static [u8]);
    |          ^^^^^^^^^^^^^
 
 error[E0204]: the trait `ConstParamTy_` cannot be implemented for this type
-  --> $DIR/unsized_field-1.rs:20:8
+  --> $DIR/unsized_field-1.rs:21:8
    |
 LL | #[derive(std::marker::ConstParamTy, Eq, PartialEq)]
    |          ------------------------- in this derive macro expansion
@@ -35,7 +35,7 @@ LL | struct D(unsized_const_param::GenericNotUnsizedParam<&'static [u8]>);
    |        ^ ---------------------------------------------------------- this field does not implement `ConstParamTy_`
    |
 note: the `ConstParamTy_` impl for `GenericNotUnsizedParam<&'static [u8]>` requires that `feature(unsized_const_params) is enabled`
-  --> $DIR/unsized_field-1.rs:20:10
+  --> $DIR/unsized_field-1.rs:21:10
    |
 LL | struct D(unsized_const_param::GenericNotUnsizedParam<&'static [u8]>);
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/const-generics/auxiliary/generics_of_parent.rs
+++ b/tests/ui/const-generics/auxiliary/generics_of_parent.rs
@@ -1,4 +1,5 @@
 #![feature(generic_const_exprs)]
+#![allow(unused_unconstructable_pub_structs)]
 
 // library portion of regression test for #87674
 pub struct Foo<const N: usize>([(); N + 1])

--- a/tests/ui/const-generics/defaults/auxiliary/trait_object_lt_defaults_lib.rs
+++ b/tests/ui/const-generics/defaults/auxiliary/trait_object_lt_defaults_lib.rs
@@ -1,1 +1,2 @@
+#![allow(unused_unconstructable_pub_structs)]
 pub struct Foo<'a, const N: usize, T: 'a + ?Sized>(pub &'a T, [(); N]);

--- a/tests/ui/const-generics/defaults/trait_object_lt_defaults.rs
+++ b/tests/ui/const-generics/defaults/trait_object_lt_defaults.rs
@@ -1,6 +1,7 @@
 //@ aux-build:trait_object_lt_defaults_lib.rs
 //@ run-pass
 #![allow(dead_code, unused)]
+#![allow(unused_unconstructable_pub_structs)]
 extern crate trait_object_lt_defaults_lib;
 
 // Tests that `A<'a, 3, dyn Test>` is short for `A<'a, 3, dyn Test + 'a>`

--- a/tests/ui/const-generics/generic_const_exprs/associated-consts.rs
+++ b/tests/ui/const-generics/generic_const_exprs/associated-consts.rs
@@ -1,6 +1,7 @@
 //@ run-pass
 #![feature(generic_const_exprs)]
 #![allow(incomplete_features)]
+#![allow(unused_unconstructable_pub_structs)]
 
 pub trait BlockCipher {
     const BLOCK_SIZE: usize;

--- a/tests/ui/const-generics/parent_generics_of_encoding.rs
+++ b/tests/ui/const-generics/parent_generics_of_encoding.rs
@@ -2,6 +2,7 @@
 //@ check-pass
 #![feature(generic_const_exprs)]
 #![allow(incomplete_features)]
+#![allow(unused_unconstructable_pub_structs)]
 
 extern crate generics_of_parent;
 

--- a/tests/ui/cross-crate/auxiliary/xcrate_unit_struct.rs
+++ b/tests/ui/cross-crate/auxiliary/xcrate_unit_struct.rs
@@ -1,4 +1,5 @@
 #![crate_type = "lib"]
+#![allow(unused_unconstructable_pub_structs)]
 
 // used by the rpass test
 

--- a/tests/ui/cross-crate/unit-struct.stderr
+++ b/tests/ui/cross-crate/unit-struct.stderr
@@ -4,7 +4,7 @@ error[E0423]: expected value, found struct `xcrate_unit_struct::StructWithFields
 LL |     let _ = xcrate_unit_struct::StructWithFields;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use struct literal syntax instead: `xcrate_unit_struct::StructWithFields { foo: val }`
    |
-  ::: $DIR/auxiliary/xcrate_unit_struct.rs:20:1
+  ::: $DIR/auxiliary/xcrate_unit_struct.rs:21:1
    |
 LL | pub struct StructWithFields {
    | --------------------------- `xcrate_unit_struct::StructWithFields` defined here
@@ -15,7 +15,7 @@ error[E0423]: expected value, found struct `xcrate_unit_struct::StructWithPrivFi
 LL |     let _ = xcrate_unit_struct::StructWithPrivFields;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-  ::: $DIR/auxiliary/xcrate_unit_struct.rs:25:1
+  ::: $DIR/auxiliary/xcrate_unit_struct.rs:26:1
    |
 LL | pub struct StructWithPrivFields {
    | ------------------------------- `xcrate_unit_struct::StructWithPrivFields` defined here

--- a/tests/ui/extern/auxiliary/fat_drop.rs
+++ b/tests/ui/extern/auxiliary/fat_drop.rs
@@ -1,3 +1,4 @@
+#![allow(unused_unconstructable_pub_structs)]
 pub static mut DROPPED: bool = false;
 
 pub struct S {

--- a/tests/ui/extern/extern_fat_drop.rs
+++ b/tests/ui/extern/extern_fat_drop.rs
@@ -1,6 +1,7 @@
 //@ run-pass
 //@ aux-build:fat_drop.rs
 
+#![allow(unused_unconstructable_pub_structs)]
 extern crate fat_drop;
 
 fn main() {

--- a/tests/ui/issues/auxiliary/issue-31702-2.rs
+++ b/tests/ui/issues/auxiliary/issue-31702-2.rs
@@ -1,5 +1,6 @@
 //@ compile-flags: -g
 
+#![allow(unused_unconstructable_pub_structs)]
 extern crate issue_31702_1;
 
 use std::collections::HashMap;

--- a/tests/ui/issues/issue-31702.rs
+++ b/tests/ui/issues/issue-31702.rs
@@ -2,6 +2,7 @@
 //@ aux-build:issue-31702-1.rs
 //@ aux-build:issue-31702-2.rs
 
+#![allow(unused_unconstructable_pub_structs)]
 // this test is actually entirely in the linked library crates
 
 extern crate issue_31702_1;

--- a/tests/ui/issues/issue-4875.rs
+++ b/tests/ui/issues/issue-4875.rs
@@ -1,5 +1,6 @@
 //@ run-pass
 #![allow(dead_code)]
+#![allow(unused_unconstructable_pub_structs)]
 // regression test for issue 4875
 
 

--- a/tests/ui/lint/issue-70819-dont-override-forbid-in-same-scope.stderr
+++ b/tests/ui/lint/issue-70819-dont-override-forbid-in-same-scope.stderr
@@ -431,3 +431,21 @@ note: the lint level is defined here
 LL | #![forbid(forbidden_lint_groups)]
    |           ^^^^^^^^^^^^^^^^^^^^^
 
+Future breakage diagnostic:
+error: warn(unused) incompatible with previous forbid
+  --> $DIR/issue-70819-dont-override-forbid-in-same-scope.rs:22:13
+   |
+LL |     #![forbid(unused)]
+   |               ------ `forbid` level set here
+LL |     #![deny(unused)]
+LL |     #![warn(unused)]
+   |             ^^^^^^ overruled by previous forbid
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #81670 <https://github.com/rust-lang/rust/issues/81670>
+note: the lint level is defined here
+  --> $DIR/issue-70819-dont-override-forbid-in-same-scope.rs:17:11
+   |
+LL | #![forbid(forbidden_lint_groups)]
+   |           ^^^^^^^^^^^^^^^^^^^^^
+

--- a/tests/ui/lint/outer-forbid.stderr
+++ b/tests/ui/lint/outer-forbid.stderr
@@ -471,3 +471,21 @@ note: the lint level is defined here
 LL | #![forbid(forbidden_lint_groups)]
    |           ^^^^^^^^^^^^^^^^^^^^^
 
+Future breakage diagnostic:
+error: allow(unused) incompatible with previous forbid
+  --> $DIR/outer-forbid.rs:25:9
+   |
+LL | #![forbid(unused, non_snake_case)]
+   |           ------ `forbid` level set here
+...
+LL | #[allow(unused)]
+   |         ^^^^^^ overruled by previous forbid
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #81670 <https://github.com/rust-lang/rust/issues/81670>
+note: the lint level is defined here
+  --> $DIR/outer-forbid.rs:18:11
+   |
+LL | #![forbid(forbidden_lint_groups)]
+   |           ^^^^^^^^^^^^^^^^^^^^^
+

--- a/tests/ui/lint/unused-unconstructable-pub-structs/external-api-path.rs
+++ b/tests/ui/lint/unused-unconstructable-pub-structs/external-api-path.rs
@@ -1,0 +1,11 @@
+//@ check-pass
+
+#![deny(unused_unconstructable_pub_structs)]
+
+pub struct Foo(i32);
+
+pub fn foo(x: Foo) {
+    let _ = x;
+}
+
+fn main() {}

--- a/tests/ui/lint/unused-unconstructable-pub-structs/intentional-marker-fields.rs
+++ b/tests/ui/lint/unused-unconstructable-pub-structs/intentional-marker-fields.rs
@@ -1,0 +1,26 @@
+//@ check-pass
+
+#![feature(never_type)]
+#![deny(unused_unconstructable_pub_structs)]
+
+pub struct TupleNever(!);
+
+pub struct TupleUnit(());
+
+pub struct TuplePhantom<T>(std::marker::PhantomData<T>);
+
+pub struct NamedNever<T> {
+    _never: !,
+    _value: T,
+}
+
+pub struct NamedUnit<T> {
+    _unit: (),
+    _value: T,
+}
+
+pub struct NamedPhantom<T> {
+    _marker: std::marker::PhantomData<T>,
+}
+
+fn main() {}

--- a/tests/ui/lint/unused-unconstructable-pub-structs/intentional-marker-fields.rs
+++ b/tests/ui/lint/unused-unconstructable-pub-structs/intentional-marker-fields.rs
@@ -5,19 +5,41 @@
 
 pub struct TupleNever(!);
 
+enum Void {}
+
+pub struct TupleUninhabited(Void);
+
+struct Token;
+
+pub struct TupleZst(Token);
+
 pub struct TupleUnit(());
 
 pub struct TuplePhantom<T>(std::marker::PhantomData<T>);
+
+pub struct TupleNestedPhantom<T>(TuplePhantom<T>);
 
 pub struct NamedNever<T> {
     _never: !,
     _value: T,
 }
 
-pub struct NamedUnit<T> {
-    _unit: (),
+pub struct NamedUninhabited<T> {
+    _void: Void,
     _value: T,
 }
+
+pub struct NamedZst<T> {
+    _marker: std::marker::PhantomData<T>,
+    _token: Token,
+    _unit: (),
+}
+
+pub struct NamedUnit {
+    _unit: (),
+}
+
+pub struct MixedUnit((), i32);
 
 pub struct NamedPhantom<T> {
     _marker: std::marker::PhantomData<T>,

--- a/tests/ui/lint/unused-unconstructable-pub-structs/local-construction.rs
+++ b/tests/ui/lint/unused-unconstructable-pub-structs/local-construction.rs
@@ -1,0 +1,29 @@
+//@ check-pass
+
+#![deny(unused_unconstructable_pub_structs)]
+
+pub struct Constructed(i32);
+
+impl Constructed {
+    pub fn construct_self() -> Self {
+        Constructed(0)
+    }
+}
+
+impl Clone for Constructed {
+    fn clone(&self) -> Constructed {
+        Constructed(0)
+    }
+}
+
+pub trait Trait {
+    fn method(&self);
+}
+
+impl Trait for Constructed {
+    fn method(&self) {
+        self.0;
+    }
+}
+
+fn main() {}

--- a/tests/ui/lint/unused-unconstructable-pub-structs/name-and-reachability-exemptions.rs
+++ b/tests/ui/lint/unused-unconstructable-pub-structs/name-and-reachability-exemptions.rs
@@ -1,0 +1,11 @@
+//@ check-pass
+
+#![deny(unused_unconstructable_pub_structs)]
+
+pub struct _Prefixed(i32);
+
+mod private {
+    pub struct Unreachable(i32);
+}
+
+fn main() {}

--- a/tests/ui/lint/unused-unconstructable-pub-structs/private-constructor.rs
+++ b/tests/ui/lint/unused-unconstructable-pub-structs/private-constructor.rs
@@ -1,0 +1,17 @@
+#![deny(unused_unconstructable_pub_structs)]
+
+pub struct PrivateTuple(i32);
+//~^ ERROR: struct `PrivateTuple` is never constructed
+
+pub struct PrivateField {
+//~^ ERROR: struct `PrivateField` is never constructed
+    _field: i32,
+}
+
+pub struct MixedPhantom<T> {
+//~^ ERROR: struct `MixedPhantom` is never constructed
+    _marker: std::marker::PhantomData<T>,
+    _field: i32,
+}
+
+fn main() {}

--- a/tests/ui/lint/unused-unconstructable-pub-structs/private-constructor.stderr
+++ b/tests/ui/lint/unused-unconstructable-pub-structs/private-constructor.stderr
@@ -1,0 +1,31 @@
+error: struct `PrivateTuple` is never constructed
+  --> $DIR/private-constructor.rs:3:12
+   |
+LL | pub struct PrivateTuple(i32);
+   |            ^^^^^^^^^^^^
+   |
+   = note: this `pub` struct has private fields, no public constructor, and is not otherwise reachable through the external API, so consider providing a public constructor or removing it
+note: the lint level is defined here
+  --> $DIR/private-constructor.rs:1:9
+   |
+LL | #![deny(unused_unconstructable_pub_structs)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: struct `PrivateField` is never constructed
+  --> $DIR/private-constructor.rs:6:12
+   |
+LL | pub struct PrivateField {
+   |            ^^^^^^^^^^^^
+   |
+   = note: this `pub` struct has private fields, no public constructor, and is not otherwise reachable through the external API, so consider providing a public constructor or removing it
+
+error: struct `MixedPhantom` is never constructed
+  --> $DIR/private-constructor.rs:11:12
+   |
+LL | pub struct MixedPhantom<T> {
+   |            ^^^^^^^^^^^^
+   |
+   = note: this `pub` struct has private fields, no public constructor, and is not otherwise reachable through the external API, so consider providing a public constructor or removing it
+
+error: aborting due to 3 previous errors
+

--- a/tests/ui/lint/unused-unconstructable-pub-structs/private-constructor.stderr
+++ b/tests/ui/lint/unused-unconstructable-pub-structs/private-constructor.stderr
@@ -4,7 +4,9 @@ error: struct `PrivateTuple` is never constructed
 LL | pub struct PrivateTuple(i32);
    |            ^^^^^^^^^^^^
    |
-   = note: this `pub` struct has private fields, no public constructor, and is not otherwise reachable through the external API, so consider providing a public constructor or removing it
+   = note: this `pub` struct has private fields, no public constructor, and is not otherwise reachable through the external API
+   = help: consider removing it if it has not been used
+   = help: consider adding a field of type `!` or `()` if it is intended
 note: the lint level is defined here
   --> $DIR/private-constructor.rs:1:9
    |
@@ -17,7 +19,9 @@ error: struct `PrivateField` is never constructed
 LL | pub struct PrivateField {
    |            ^^^^^^^^^^^^
    |
-   = note: this `pub` struct has private fields, no public constructor, and is not otherwise reachable through the external API, so consider providing a public constructor or removing it
+   = note: this `pub` struct has private fields, no public constructor, and is not otherwise reachable through the external API
+   = help: consider removing it if it has not been used
+   = help: consider adding a field of type `!` or `()` if it is intended
 
 error: struct `MixedPhantom` is never constructed
   --> $DIR/private-constructor.rs:11:12
@@ -25,7 +29,9 @@ error: struct `MixedPhantom` is never constructed
 LL | pub struct MixedPhantom<T> {
    |            ^^^^^^^^^^^^
    |
-   = note: this `pub` struct has private fields, no public constructor, and is not otherwise reachable through the external API, so consider providing a public constructor or removing it
+   = note: this `pub` struct has private fields, no public constructor, and is not otherwise reachable through the external API
+   = help: consider removing it if it has not been used
+   = help: consider adding a field of type `!` or `()` if it is intended
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/lint/unused-unconstructable-pub-structs/receiver-methods-do-not-construct.rs
+++ b/tests/ui/lint/unused-unconstructable-pub-structs/receiver-methods-do-not-construct.rs
@@ -1,0 +1,26 @@
+#![deny(unused_unconstructable_pub_structs)]
+
+pub struct ReceiverOnly(i32);
+//~^ ERROR: struct `ReceiverOnly` is never constructed
+
+impl ReceiverOnly {
+    pub fn method(&self) {}
+}
+
+impl Clone for ReceiverOnly {
+    fn clone(&self) -> ReceiverOnly {
+        ReceiverOnly(0)
+    }
+}
+
+pub trait Trait {
+    fn method(&self);
+}
+
+impl Trait for ReceiverOnly {
+    fn method(&self) {
+        self.0;
+    }
+}
+
+fn main() {}

--- a/tests/ui/lint/unused-unconstructable-pub-structs/receiver-methods-do-not-construct.stderr
+++ b/tests/ui/lint/unused-unconstructable-pub-structs/receiver-methods-do-not-construct.stderr
@@ -4,7 +4,9 @@ error: struct `ReceiverOnly` is never constructed
 LL | pub struct ReceiverOnly(i32);
    |            ^^^^^^^^^^^^
    |
-   = note: this `pub` struct has private fields, no public constructor, and is not otherwise reachable through the external API, so consider providing a public constructor or removing it
+   = note: this `pub` struct has private fields, no public constructor, and is not otherwise reachable through the external API
+   = help: consider removing it if it has not been used
+   = help: consider adding a field of type `!` or `()` if it is intended
 note: the lint level is defined here
   --> $DIR/receiver-methods-do-not-construct.rs:1:9
    |

--- a/tests/ui/lint/unused-unconstructable-pub-structs/receiver-methods-do-not-construct.stderr
+++ b/tests/ui/lint/unused-unconstructable-pub-structs/receiver-methods-do-not-construct.stderr
@@ -1,0 +1,15 @@
+error: struct `ReceiverOnly` is never constructed
+  --> $DIR/receiver-methods-do-not-construct.rs:3:12
+   |
+LL | pub struct ReceiverOnly(i32);
+   |            ^^^^^^^^^^^^
+   |
+   = note: this `pub` struct has private fields, no public constructor, and is not otherwise reachable through the external API, so consider providing a public constructor or removing it
+note: the lint level is defined here
+  --> $DIR/receiver-methods-do-not-construct.rs:1:9
+   |
+LL | #![deny(unused_unconstructable_pub_structs)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/lint/unused-unconstructable-pub-structs/repr-exemptions.rs
+++ b/tests/ui/lint/unused-unconstructable-pub-structs/repr-exemptions.rs
@@ -1,0 +1,11 @@
+//@ check-pass
+
+#![deny(unused_unconstructable_pub_structs)]
+
+#[repr(C)]
+pub struct CRepr(i32);
+
+#[repr(transparent)]
+pub struct Transparent(i32);
+
+fn main() {}

--- a/tests/ui/packed/auxiliary/packed.rs
+++ b/tests/ui/packed/auxiliary/packed.rs
@@ -1,3 +1,4 @@
+#![allow(unused_unconstructable_pub_structs)]
 #[repr(packed)]
 pub struct P1S5 {
     a: u8,

--- a/tests/ui/parser/recover/recover-where-clause-before-tuple-struct-body-0.fixed
+++ b/tests/ui/parser/recover/recover-where-clause-before-tuple-struct-body-0.fixed
@@ -1,3 +1,4 @@
+#![allow(unused_unconstructable_pub_structs)]
 // Regression test for issues #100790 and #106439.
 //@ run-rustfix
 

--- a/tests/ui/parser/recover/recover-where-clause-before-tuple-struct-body-0.rs
+++ b/tests/ui/parser/recover/recover-where-clause-before-tuple-struct-body-0.rs
@@ -1,3 +1,4 @@
+#![allow(unused_unconstructable_pub_structs)]
 // Regression test for issues #100790 and #106439.
 //@ run-rustfix
 

--- a/tests/ui/parser/recover/recover-where-clause-before-tuple-struct-body-0.stderr
+++ b/tests/ui/parser/recover/recover-where-clause-before-tuple-struct-body-0.stderr
@@ -1,5 +1,5 @@
 error: where clauses are not allowed before tuple struct bodies
-  --> $DIR/recover-where-clause-before-tuple-struct-body-0.rs:7:1
+  --> $DIR/recover-where-clause-before-tuple-struct-body-0.rs:8:1
    |
 LL |   pub struct Example
    |              ------- while parsing this tuple struct
@@ -17,7 +17,7 @@ LL ~     (): Sized;
    |
 
 error: where clauses are not allowed before tuple struct bodies
-  --> $DIR/recover-where-clause-before-tuple-struct-body-0.rs:13:1
+  --> $DIR/recover-where-clause-before-tuple-struct-body-0.rs:14:1
    |
 LL |   struct _Demo
    |          ----- while parsing this tuple struct

--- a/tests/ui/pattern/usefulness/auxiliary/empty.rs
+++ b/tests/ui/pattern/usefulness/auxiliary/empty.rs
@@ -1,4 +1,5 @@
 #![crate_type = "rlib"]
+#![allow(unused_unconstructable_pub_structs)]
 pub enum EmptyForeignEnum {}
 
 pub struct VisiblyUninhabitedForeignStruct {

--- a/tests/ui/pattern/usefulness/empty-match-check-notes.exhaustive_patterns.stderr
+++ b/tests/ui/pattern/usefulness/empty-match-check-notes.exhaustive_patterns.stderr
@@ -1,5 +1,5 @@
 error: unreachable pattern
-  --> $DIR/empty-match-check-notes.rs:17:9
+  --> $DIR/empty-match-check-notes.rs:18:9
    |
 LL |         _ => {}
    |         ^------
@@ -9,13 +9,13 @@ LL |         _ => {}
    |
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 note: the lint level is defined here
-  --> $DIR/empty-match-check-notes.rs:7:9
+  --> $DIR/empty-match-check-notes.rs:8:9
    |
 LL | #![deny(unreachable_patterns)]
    |         ^^^^^^^^^^^^^^^^^^^^
 
 error: unreachable pattern
-  --> $DIR/empty-match-check-notes.rs:22:9
+  --> $DIR/empty-match-check-notes.rs:23:9
    |
 LL |         _ if false => {}
    |         ^---------------
@@ -26,7 +26,7 @@ LL |         _ if false => {}
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
-  --> $DIR/empty-match-check-notes.rs:31:9
+  --> $DIR/empty-match-check-notes.rs:32:9
    |
 LL |         _ => {}
    |         ^------
@@ -37,7 +37,7 @@ LL |         _ => {}
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
-  --> $DIR/empty-match-check-notes.rs:36:9
+  --> $DIR/empty-match-check-notes.rs:37:9
    |
 LL |         _ if false => {}
    |         ^---------------
@@ -48,7 +48,7 @@ LL |         _ if false => {}
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error[E0005]: refutable pattern in local binding
-  --> $DIR/empty-match-check-notes.rs:43:9
+  --> $DIR/empty-match-check-notes.rs:44:9
    |
 LL |     let None = *x;
    |         ^^^^ pattern `Some(_)` not covered
@@ -63,7 +63,7 @@ LL |     if let None = *x { todo!() };
    |     ++               +++++++++++
 
 error[E0004]: non-exhaustive patterns: `0_u8..=u8::MAX` not covered
-  --> $DIR/empty-match-check-notes.rs:53:11
+  --> $DIR/empty-match-check-notes.rs:54:11
    |
 LL |     match 0u8 {
    |           ^^^ pattern `0_u8..=u8::MAX` not covered

--- a/tests/ui/pattern/usefulness/empty-match-check-notes.normal.stderr
+++ b/tests/ui/pattern/usefulness/empty-match-check-notes.normal.stderr
@@ -1,5 +1,5 @@
 error: unreachable pattern
-  --> $DIR/empty-match-check-notes.rs:17:9
+  --> $DIR/empty-match-check-notes.rs:18:9
    |
 LL |         _ => {}
    |         ^------
@@ -9,13 +9,13 @@ LL |         _ => {}
    |
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 note: the lint level is defined here
-  --> $DIR/empty-match-check-notes.rs:7:9
+  --> $DIR/empty-match-check-notes.rs:8:9
    |
 LL | #![deny(unreachable_patterns)]
    |         ^^^^^^^^^^^^^^^^^^^^
 
 error: unreachable pattern
-  --> $DIR/empty-match-check-notes.rs:22:9
+  --> $DIR/empty-match-check-notes.rs:23:9
    |
 LL |         _ if false => {}
    |         ^---------------
@@ -26,7 +26,7 @@ LL |         _ if false => {}
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
-  --> $DIR/empty-match-check-notes.rs:31:9
+  --> $DIR/empty-match-check-notes.rs:32:9
    |
 LL |         _ => {}
    |         ^------
@@ -37,7 +37,7 @@ LL |         _ => {}
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
-  --> $DIR/empty-match-check-notes.rs:36:9
+  --> $DIR/empty-match-check-notes.rs:37:9
    |
 LL |         _ if false => {}
    |         ^---------------
@@ -48,7 +48,7 @@ LL |         _ if false => {}
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error[E0005]: refutable pattern in local binding
-  --> $DIR/empty-match-check-notes.rs:43:9
+  --> $DIR/empty-match-check-notes.rs:44:9
    |
 LL |     let None = *x;
    |         ^^^^ pattern `Some(_)` not covered
@@ -63,7 +63,7 @@ LL |     if let None = *x { todo!() };
    |     ++               +++++++++++
 
 error[E0004]: non-exhaustive patterns: `0_u8..=u8::MAX` not covered
-  --> $DIR/empty-match-check-notes.rs:53:11
+  --> $DIR/empty-match-check-notes.rs:54:11
    |
 LL |     match 0u8 {
    |           ^^^ pattern `0_u8..=u8::MAX` not covered

--- a/tests/ui/pattern/usefulness/empty-match-check-notes.rs
+++ b/tests/ui/pattern/usefulness/empty-match-check-notes.rs
@@ -1,5 +1,6 @@
 //@ aux-build:empty.rs
 //@ revisions: normal exhaustive_patterns
+#![allow(unused_unconstructable_pub_structs)]
 //
 // This tests a match with no arms on various types, and checks NOTEs.
 #![feature(never_type)]

--- a/tests/ui/pattern/usefulness/uninhabited.rs
+++ b/tests/ui/pattern/usefulness/uninhabited.rs
@@ -1,6 +1,7 @@
 //@ check-pass
 //@ edition: 2024
 //@ aux-build:empty.rs
+#![allow(unused_unconstructable_pub_structs)]
 //
 // This tests plays with matching and uninhabited types. This also serves as a test for the
 // `Ty::is_inhabited_from` function.

--- a/tests/ui/privacy/auxiliary/non_exhaustive_with_private.rs
+++ b/tests/ui/privacy/auxiliary/non_exhaustive_with_private.rs
@@ -1,5 +1,6 @@
 // Auxiliary crate for testing non-exhaustive struct with private fields
 
+#![allow(unused_unconstructable_pub_structs)]
 #[non_exhaustive]
 pub struct Foo {
     pub my_field: u32,

--- a/tests/ui/privacy/auxiliary/privacy_tuple_struct.rs
+++ b/tests/ui/privacy/auxiliary/privacy_tuple_struct.rs
@@ -1,3 +1,4 @@
+#![allow(unused_unconstructable_pub_structs)]
 pub struct A(());
 pub struct B(isize);
 pub struct C(pub isize, isize);

--- a/tests/ui/privacy/auxiliary/private-fields-diagnostic-aux-issue-151408.rs
+++ b/tests/ui/privacy/auxiliary/private-fields-diagnostic-aux-issue-151408.rs
@@ -1,3 +1,4 @@
+#![allow(unused_unconstructable_pub_structs)]
 pub struct Named {
     hidden: u8,
 }

--- a/tests/ui/privacy/auxiliary/private-inferred-type.rs
+++ b/tests/ui/privacy/auxiliary/private-inferred-type.rs
@@ -1,4 +1,5 @@
 #![feature(decl_macro)]
+#![allow(unused_unconstructable_pub_structs)]
 
 fn priv_fn() {}
 static PRIV_STATIC: u8 = 0;

--- a/tests/ui/privacy/non-exhaustive-with-private-fields-147513.rs
+++ b/tests/ui/privacy/non-exhaustive-with-private-fields-147513.rs
@@ -1,5 +1,6 @@
 //@ aux-build:non_exhaustive_with_private.rs
 
+#![allow(unused_unconstructable_pub_structs)]
 extern crate non_exhaustive_with_private;
 
 use non_exhaustive_with_private::{Bar, Foo};

--- a/tests/ui/privacy/non-exhaustive-with-private-fields-147513.stderr
+++ b/tests/ui/privacy/non-exhaustive-with-private-fields-147513.stderr
@@ -1,5 +1,5 @@
 error[E0639]: cannot create non-exhaustive struct using struct expression
-  --> $DIR/non-exhaustive-with-private-fields-147513.rs:8:15
+  --> $DIR/non-exhaustive-with-private-fields-147513.rs:9:15
    |
 LL |       let foo = Foo {
    |  _______________^
@@ -9,7 +9,7 @@ LL | |     };
    | |_____^
 
 error[E0639]: cannot create non-exhaustive struct using struct expression
-  --> $DIR/non-exhaustive-with-private-fields-147513.rs:13:15
+  --> $DIR/non-exhaustive-with-private-fields-147513.rs:14:15
    |
 LL |       let bar = Bar {
    |  _______________^

--- a/tests/ui/privacy/privacy5.rs
+++ b/tests/ui/privacy/privacy5.rs
@@ -1,5 +1,6 @@
 //@ aux-build:privacy_tuple_struct.rs
 
+#![allow(unused_unconstructable_pub_structs)]
 extern crate privacy_tuple_struct as other;
 
 mod a {

--- a/tests/ui/privacy/privacy5.stderr
+++ b/tests/ui/privacy/privacy5.stderr
@@ -1,5 +1,5 @@
 error[E0603]: tuple struct constructor `A` is private
-  --> $DIR/privacy5.rs:51:16
+  --> $DIR/privacy5.rs:52:16
    |
 LL |     pub struct A(());
    |                  -- a constructor is private if any of the fields is private
@@ -8,7 +8,7 @@ LL |     let a = a::A(());
    |                ^ private tuple struct constructor
    |
 note: the tuple struct constructor `A` is defined here
-  --> $DIR/privacy5.rs:6:5
+  --> $DIR/privacy5.rs:7:5
    |
 LL |     pub struct A(());
    |     ^^^^^^^^^^^^^^^^^
@@ -18,7 +18,7 @@ LL |     pub struct A(pub ());
    |                  +++
 
 error[E0603]: tuple struct constructor `B` is private
-  --> $DIR/privacy5.rs:52:16
+  --> $DIR/privacy5.rs:53:16
    |
 LL |     pub struct B(isize);
    |                  ----- a constructor is private if any of the fields is private
@@ -27,7 +27,7 @@ LL |     let b = a::B(2);
    |                ^ private tuple struct constructor
    |
 note: the tuple struct constructor `B` is defined here
-  --> $DIR/privacy5.rs:7:5
+  --> $DIR/privacy5.rs:8:5
    |
 LL |     pub struct B(isize);
    |     ^^^^^^^^^^^^^^^^^^^^
@@ -37,7 +37,7 @@ LL |     pub struct B(pub isize);
    |                  +++
 
 error[E0603]: tuple struct constructor `C` is private
-  --> $DIR/privacy5.rs:53:16
+  --> $DIR/privacy5.rs:54:16
    |
 LL |     pub struct C(pub isize, isize);
    |                  ---------------- a constructor is private if any of the fields is private
@@ -46,7 +46,7 @@ LL |     let c = a::C(2, 3);
    |                ^ private tuple struct constructor
    |
 note: the tuple struct constructor `C` is defined here
-  --> $DIR/privacy5.rs:8:5
+  --> $DIR/privacy5.rs:9:5
    |
 LL |     pub struct C(pub isize, isize);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -56,7 +56,7 @@ LL |     pub struct C(pub isize, pub isize);
    |                             +++
 
 error[E0603]: tuple struct constructor `A` is private
-  --> $DIR/privacy5.rs:56:12
+  --> $DIR/privacy5.rs:57:12
    |
 LL |     pub struct A(());
    |                  -- a constructor is private if any of the fields is private
@@ -65,7 +65,7 @@ LL |     let a::A(()) = a;
    |            ^ private tuple struct constructor
    |
 note: the tuple struct constructor `A` is defined here
-  --> $DIR/privacy5.rs:6:5
+  --> $DIR/privacy5.rs:7:5
    |
 LL |     pub struct A(());
    |     ^^^^^^^^^^^^^^^^^
@@ -75,7 +75,7 @@ LL |     pub struct A(pub ());
    |                  +++
 
 error[E0603]: tuple struct constructor `A` is private
-  --> $DIR/privacy5.rs:57:12
+  --> $DIR/privacy5.rs:58:12
    |
 LL |     pub struct A(());
    |                  -- a constructor is private if any of the fields is private
@@ -84,26 +84,7 @@ LL |     let a::A(_) = a;
    |            ^ private tuple struct constructor
    |
 note: the tuple struct constructor `A` is defined here
-  --> $DIR/privacy5.rs:6:5
-   |
-LL |     pub struct A(());
-   |     ^^^^^^^^^^^^^^^^^
-help: consider making the field publicly accessible
-   |
-LL |     pub struct A(pub ());
-   |                  +++
-
-error[E0603]: tuple struct constructor `A` is private
-  --> $DIR/privacy5.rs:58:18
-   |
-LL |     pub struct A(());
-   |                  -- a constructor is private if any of the fields is private
-...
-LL |     match a { a::A(()) => {} }
-   |                  ^ private tuple struct constructor
-   |
-note: the tuple struct constructor `A` is defined here
-  --> $DIR/privacy5.rs:6:5
+  --> $DIR/privacy5.rs:7:5
    |
 LL |     pub struct A(());
    |     ^^^^^^^^^^^^^^^^^
@@ -118,11 +99,30 @@ error[E0603]: tuple struct constructor `A` is private
 LL |     pub struct A(());
    |                  -- a constructor is private if any of the fields is private
 ...
+LL |     match a { a::A(()) => {} }
+   |                  ^ private tuple struct constructor
+   |
+note: the tuple struct constructor `A` is defined here
+  --> $DIR/privacy5.rs:7:5
+   |
+LL |     pub struct A(());
+   |     ^^^^^^^^^^^^^^^^^
+help: consider making the field publicly accessible
+   |
+LL |     pub struct A(pub ());
+   |                  +++
+
+error[E0603]: tuple struct constructor `A` is private
+  --> $DIR/privacy5.rs:60:18
+   |
+LL |     pub struct A(());
+   |                  -- a constructor is private if any of the fields is private
+...
 LL |     match a { a::A(_) => {} }
    |                  ^ private tuple struct constructor
    |
 note: the tuple struct constructor `A` is defined here
-  --> $DIR/privacy5.rs:6:5
+  --> $DIR/privacy5.rs:7:5
    |
 LL |     pub struct A(());
    |     ^^^^^^^^^^^^^^^^^
@@ -132,7 +132,7 @@ LL |     pub struct A(pub ());
    |                  +++
 
 error[E0603]: tuple struct constructor `B` is private
-  --> $DIR/privacy5.rs:61:12
+  --> $DIR/privacy5.rs:62:12
    |
 LL |     pub struct B(isize);
    |                  ----- a constructor is private if any of the fields is private
@@ -141,7 +141,7 @@ LL |     let a::B(_) = b;
    |            ^ private tuple struct constructor
    |
 note: the tuple struct constructor `B` is defined here
-  --> $DIR/privacy5.rs:7:5
+  --> $DIR/privacy5.rs:8:5
    |
 LL |     pub struct B(isize);
    |     ^^^^^^^^^^^^^^^^^^^^
@@ -151,7 +151,7 @@ LL |     pub struct B(pub isize);
    |                  +++
 
 error[E0603]: tuple struct constructor `B` is private
-  --> $DIR/privacy5.rs:62:12
+  --> $DIR/privacy5.rs:63:12
    |
 LL |     pub struct B(isize);
    |                  ----- a constructor is private if any of the fields is private
@@ -160,26 +160,7 @@ LL |     let a::B(_b) = b;
    |            ^ private tuple struct constructor
    |
 note: the tuple struct constructor `B` is defined here
-  --> $DIR/privacy5.rs:7:5
-   |
-LL |     pub struct B(isize);
-   |     ^^^^^^^^^^^^^^^^^^^^
-help: consider making the field publicly accessible
-   |
-LL |     pub struct B(pub isize);
-   |                  +++
-
-error[E0603]: tuple struct constructor `B` is private
-  --> $DIR/privacy5.rs:63:18
-   |
-LL |     pub struct B(isize);
-   |                  ----- a constructor is private if any of the fields is private
-...
-LL |     match b { a::B(_) => {} }
-   |                  ^ private tuple struct constructor
-   |
-note: the tuple struct constructor `B` is defined here
-  --> $DIR/privacy5.rs:7:5
+  --> $DIR/privacy5.rs:8:5
    |
 LL |     pub struct B(isize);
    |     ^^^^^^^^^^^^^^^^^^^^
@@ -194,11 +175,11 @@ error[E0603]: tuple struct constructor `B` is private
 LL |     pub struct B(isize);
    |                  ----- a constructor is private if any of the fields is private
 ...
-LL |     match b { a::B(_b) => {} }
+LL |     match b { a::B(_) => {} }
    |                  ^ private tuple struct constructor
    |
 note: the tuple struct constructor `B` is defined here
-  --> $DIR/privacy5.rs:7:5
+  --> $DIR/privacy5.rs:8:5
    |
 LL |     pub struct B(isize);
    |     ^^^^^^^^^^^^^^^^^^^^
@@ -213,11 +194,11 @@ error[E0603]: tuple struct constructor `B` is private
 LL |     pub struct B(isize);
    |                  ----- a constructor is private if any of the fields is private
 ...
-LL |     match b { a::B(1) => {} a::B(_) => {} }
+LL |     match b { a::B(_b) => {} }
    |                  ^ private tuple struct constructor
    |
 note: the tuple struct constructor `B` is defined here
-  --> $DIR/privacy5.rs:7:5
+  --> $DIR/privacy5.rs:8:5
    |
 LL |     pub struct B(isize);
    |     ^^^^^^^^^^^^^^^^^^^^
@@ -227,7 +208,26 @@ LL |     pub struct B(pub isize);
    |                  +++
 
 error[E0603]: tuple struct constructor `B` is private
-  --> $DIR/privacy5.rs:65:32
+  --> $DIR/privacy5.rs:66:18
+   |
+LL |     pub struct B(isize);
+   |                  ----- a constructor is private if any of the fields is private
+...
+LL |     match b { a::B(1) => {} a::B(_) => {} }
+   |                  ^ private tuple struct constructor
+   |
+note: the tuple struct constructor `B` is defined here
+  --> $DIR/privacy5.rs:8:5
+   |
+LL |     pub struct B(isize);
+   |     ^^^^^^^^^^^^^^^^^^^^
+help: consider making the field publicly accessible
+   |
+LL |     pub struct B(pub isize);
+   |                  +++
+
+error[E0603]: tuple struct constructor `B` is private
+  --> $DIR/privacy5.rs:66:32
    |
 LL |     pub struct B(isize);
    |                  ----- a constructor is private if any of the fields is private
@@ -236,7 +236,7 @@ LL |     match b { a::B(1) => {} a::B(_) => {} }
    |                                ^ private tuple struct constructor
    |
 note: the tuple struct constructor `B` is defined here
-  --> $DIR/privacy5.rs:7:5
+  --> $DIR/privacy5.rs:8:5
    |
 LL |     pub struct B(isize);
    |     ^^^^^^^^^^^^^^^^^^^^
@@ -246,7 +246,7 @@ LL |     pub struct B(pub isize);
    |                  +++
 
 error[E0603]: tuple struct constructor `C` is private
-  --> $DIR/privacy5.rs:68:12
+  --> $DIR/privacy5.rs:69:12
    |
 LL |     pub struct C(pub isize, isize);
    |                  ---------------- a constructor is private if any of the fields is private
@@ -255,26 +255,7 @@ LL |     let a::C(_, _) = c;
    |            ^ private tuple struct constructor
    |
 note: the tuple struct constructor `C` is defined here
-  --> $DIR/privacy5.rs:8:5
-   |
-LL |     pub struct C(pub isize, isize);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-help: consider making the fields publicly accessible
-   |
-LL |     pub struct C(pub isize, pub isize);
-   |                             +++
-
-error[E0603]: tuple struct constructor `C` is private
-  --> $DIR/privacy5.rs:69:12
-   |
-LL |     pub struct C(pub isize, isize);
-   |                  ---------------- a constructor is private if any of the fields is private
-...
-LL |     let a::C(_a, _) = c;
-   |            ^ private tuple struct constructor
-   |
-note: the tuple struct constructor `C` is defined here
-  --> $DIR/privacy5.rs:8:5
+  --> $DIR/privacy5.rs:9:5
    |
 LL |     pub struct C(pub isize, isize);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -289,11 +270,11 @@ error[E0603]: tuple struct constructor `C` is private
 LL |     pub struct C(pub isize, isize);
    |                  ---------------- a constructor is private if any of the fields is private
 ...
-LL |     let a::C(_, _b) = c;
+LL |     let a::C(_a, _) = c;
    |            ^ private tuple struct constructor
    |
 note: the tuple struct constructor `C` is defined here
-  --> $DIR/privacy5.rs:8:5
+  --> $DIR/privacy5.rs:9:5
    |
 LL |     pub struct C(pub isize, isize);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -308,11 +289,11 @@ error[E0603]: tuple struct constructor `C` is private
 LL |     pub struct C(pub isize, isize);
    |                  ---------------- a constructor is private if any of the fields is private
 ...
-LL |     let a::C(_a, _b) = c;
+LL |     let a::C(_, _b) = c;
    |            ^ private tuple struct constructor
    |
 note: the tuple struct constructor `C` is defined here
-  --> $DIR/privacy5.rs:8:5
+  --> $DIR/privacy5.rs:9:5
    |
 LL |     pub struct C(pub isize, isize);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -322,16 +303,16 @@ LL |     pub struct C(pub isize, pub isize);
    |                             +++
 
 error[E0603]: tuple struct constructor `C` is private
-  --> $DIR/privacy5.rs:72:18
+  --> $DIR/privacy5.rs:72:12
    |
 LL |     pub struct C(pub isize, isize);
    |                  ---------------- a constructor is private if any of the fields is private
 ...
-LL |     match c { a::C(_, _) => {} }
-   |                  ^ private tuple struct constructor
+LL |     let a::C(_a, _b) = c;
+   |            ^ private tuple struct constructor
    |
 note: the tuple struct constructor `C` is defined here
-  --> $DIR/privacy5.rs:8:5
+  --> $DIR/privacy5.rs:9:5
    |
 LL |     pub struct C(pub isize, isize);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -346,11 +327,11 @@ error[E0603]: tuple struct constructor `C` is private
 LL |     pub struct C(pub isize, isize);
    |                  ---------------- a constructor is private if any of the fields is private
 ...
-LL |     match c { a::C(_a, _) => {} }
+LL |     match c { a::C(_, _) => {} }
    |                  ^ private tuple struct constructor
    |
 note: the tuple struct constructor `C` is defined here
-  --> $DIR/privacy5.rs:8:5
+  --> $DIR/privacy5.rs:9:5
    |
 LL |     pub struct C(pub isize, isize);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -365,11 +346,11 @@ error[E0603]: tuple struct constructor `C` is private
 LL |     pub struct C(pub isize, isize);
    |                  ---------------- a constructor is private if any of the fields is private
 ...
-LL |     match c { a::C(_, _b) => {} }
+LL |     match c { a::C(_a, _) => {} }
    |                  ^ private tuple struct constructor
    |
 note: the tuple struct constructor `C` is defined here
-  --> $DIR/privacy5.rs:8:5
+  --> $DIR/privacy5.rs:9:5
    |
 LL |     pub struct C(pub isize, isize);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -384,11 +365,30 @@ error[E0603]: tuple struct constructor `C` is private
 LL |     pub struct C(pub isize, isize);
    |                  ---------------- a constructor is private if any of the fields is private
 ...
+LL |     match c { a::C(_, _b) => {} }
+   |                  ^ private tuple struct constructor
+   |
+note: the tuple struct constructor `C` is defined here
+  --> $DIR/privacy5.rs:9:5
+   |
+LL |     pub struct C(pub isize, isize);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: consider making the fields publicly accessible
+   |
+LL |     pub struct C(pub isize, pub isize);
+   |                             +++
+
+error[E0603]: tuple struct constructor `C` is private
+  --> $DIR/privacy5.rs:76:18
+   |
+LL |     pub struct C(pub isize, isize);
+   |                  ---------------- a constructor is private if any of the fields is private
+...
 LL |     match c { a::C(_a, _b) => {} }
    |                  ^ private tuple struct constructor
    |
 note: the tuple struct constructor `C` is defined here
-  --> $DIR/privacy5.rs:8:5
+  --> $DIR/privacy5.rs:9:5
    |
 LL |     pub struct C(pub isize, isize);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -398,7 +398,7 @@ LL |     pub struct C(pub isize, pub isize);
    |                             +++
 
 error[E0603]: tuple struct constructor `A` is private
-  --> $DIR/privacy5.rs:83:17
+  --> $DIR/privacy5.rs:84:17
    |
 LL |     pub struct A(());
    |                  -- a constructor is private if any of the fields is private
@@ -407,7 +407,7 @@ LL |     let a2 = a::A;
    |                 ^ private tuple struct constructor
    |
 note: the tuple struct constructor `A` is defined here
-  --> $DIR/privacy5.rs:6:5
+  --> $DIR/privacy5.rs:7:5
    |
 LL |     pub struct A(());
    |     ^^^^^^^^^^^^^^^^^
@@ -417,7 +417,7 @@ LL |     pub struct A(pub ());
    |                  +++
 
 error[E0603]: tuple struct constructor `B` is private
-  --> $DIR/privacy5.rs:84:17
+  --> $DIR/privacy5.rs:85:17
    |
 LL |     pub struct B(isize);
    |                  ----- a constructor is private if any of the fields is private
@@ -426,7 +426,7 @@ LL |     let b2 = a::B;
    |                 ^ private tuple struct constructor
    |
 note: the tuple struct constructor `B` is defined here
-  --> $DIR/privacy5.rs:7:5
+  --> $DIR/privacy5.rs:8:5
    |
 LL |     pub struct B(isize);
    |     ^^^^^^^^^^^^^^^^^^^^
@@ -436,7 +436,7 @@ LL |     pub struct B(pub isize);
    |                  +++
 
 error[E0603]: tuple struct constructor `C` is private
-  --> $DIR/privacy5.rs:85:17
+  --> $DIR/privacy5.rs:86:17
    |
 LL |     pub struct C(pub isize, isize);
    |                  ---------------- a constructor is private if any of the fields is private
@@ -445,7 +445,7 @@ LL |     let c2 = a::C;
    |                 ^ private tuple struct constructor
    |
 note: the tuple struct constructor `C` is defined here
-  --> $DIR/privacy5.rs:8:5
+  --> $DIR/privacy5.rs:9:5
    |
 LL |     pub struct C(pub isize, isize);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -455,103 +455,86 @@ LL |     pub struct C(pub isize, pub isize);
    |                             +++
 
 error[E0603]: tuple struct constructor `A` is private
-  --> $DIR/privacy5.rs:90:20
+  --> $DIR/privacy5.rs:91:20
    |
 LL |     let a = other::A(());
    |                    ^ private tuple struct constructor
    |
-  ::: $DIR/auxiliary/privacy_tuple_struct.rs:1:14
+  ::: $DIR/auxiliary/privacy_tuple_struct.rs:2:14
    |
 LL | pub struct A(());
    |              -- a constructor is private if any of the fields is private
    |
 note: the tuple struct constructor `A` is defined here
-  --> $DIR/auxiliary/privacy_tuple_struct.rs:1:1
+  --> $DIR/auxiliary/privacy_tuple_struct.rs:2:1
    |
 LL | pub struct A(());
    | ^^^^^^^^^^^^
 
 error[E0603]: tuple struct constructor `B` is private
-  --> $DIR/privacy5.rs:91:20
+  --> $DIR/privacy5.rs:92:20
    |
 LL |     let b = other::B(2);
    |                    ^ private tuple struct constructor
    |
-  ::: $DIR/auxiliary/privacy_tuple_struct.rs:2:14
+  ::: $DIR/auxiliary/privacy_tuple_struct.rs:3:14
    |
 LL | pub struct B(isize);
    |              ----- a constructor is private if any of the fields is private
    |
 note: the tuple struct constructor `B` is defined here
-  --> $DIR/auxiliary/privacy_tuple_struct.rs:2:1
+  --> $DIR/auxiliary/privacy_tuple_struct.rs:3:1
    |
 LL | pub struct B(isize);
    | ^^^^^^^^^^^^
 
 error[E0603]: tuple struct constructor `C` is private
-  --> $DIR/privacy5.rs:92:20
+  --> $DIR/privacy5.rs:93:20
    |
 LL |     let c = other::C(2, 3);
    |                    ^ private tuple struct constructor
    |
-  ::: $DIR/auxiliary/privacy_tuple_struct.rs:3:14
+  ::: $DIR/auxiliary/privacy_tuple_struct.rs:4:14
    |
 LL | pub struct C(pub isize, isize);
    |              ---------------- a constructor is private if any of the fields is private
    |
 note: the tuple struct constructor `C` is defined here
-  --> $DIR/auxiliary/privacy_tuple_struct.rs:3:1
+  --> $DIR/auxiliary/privacy_tuple_struct.rs:4:1
    |
 LL | pub struct C(pub isize, isize);
    | ^^^^^^^^^^^^
 
 error[E0603]: tuple struct constructor `A` is private
-  --> $DIR/privacy5.rs:95:16
+  --> $DIR/privacy5.rs:96:16
    |
 LL |     let other::A(()) = a;
    |                ^ private tuple struct constructor
    |
-  ::: $DIR/auxiliary/privacy_tuple_struct.rs:1:14
+  ::: $DIR/auxiliary/privacy_tuple_struct.rs:2:14
    |
 LL | pub struct A(());
    |              -- a constructor is private if any of the fields is private
    |
 note: the tuple struct constructor `A` is defined here
-  --> $DIR/auxiliary/privacy_tuple_struct.rs:1:1
+  --> $DIR/auxiliary/privacy_tuple_struct.rs:2:1
    |
 LL | pub struct A(());
    | ^^^^^^^^^^^^
 
 error[E0603]: tuple struct constructor `A` is private
-  --> $DIR/privacy5.rs:96:16
+  --> $DIR/privacy5.rs:97:16
    |
 LL |     let other::A(_) = a;
    |                ^ private tuple struct constructor
    |
-  ::: $DIR/auxiliary/privacy_tuple_struct.rs:1:14
+  ::: $DIR/auxiliary/privacy_tuple_struct.rs:2:14
    |
 LL | pub struct A(());
    |              -- a constructor is private if any of the fields is private
    |
 note: the tuple struct constructor `A` is defined here
-  --> $DIR/auxiliary/privacy_tuple_struct.rs:1:1
-   |
-LL | pub struct A(());
-   | ^^^^^^^^^^^^
-
-error[E0603]: tuple struct constructor `A` is private
-  --> $DIR/privacy5.rs:97:22
-   |
-LL |     match a { other::A(()) => {} }
-   |                      ^ private tuple struct constructor
-   |
-  ::: $DIR/auxiliary/privacy_tuple_struct.rs:1:14
-   |
-LL | pub struct A(());
-   |              -- a constructor is private if any of the fields is private
-   |
-note: the tuple struct constructor `A` is defined here
-  --> $DIR/auxiliary/privacy_tuple_struct.rs:1:1
+  --> $DIR/auxiliary/privacy_tuple_struct.rs:2:1
    |
 LL | pub struct A(());
    | ^^^^^^^^^^^^
@@ -559,67 +542,67 @@ LL | pub struct A(());
 error[E0603]: tuple struct constructor `A` is private
   --> $DIR/privacy5.rs:98:22
    |
-LL |     match a { other::A(_) => {} }
+LL |     match a { other::A(()) => {} }
    |                      ^ private tuple struct constructor
    |
-  ::: $DIR/auxiliary/privacy_tuple_struct.rs:1:14
+  ::: $DIR/auxiliary/privacy_tuple_struct.rs:2:14
    |
 LL | pub struct A(());
    |              -- a constructor is private if any of the fields is private
    |
 note: the tuple struct constructor `A` is defined here
-  --> $DIR/auxiliary/privacy_tuple_struct.rs:1:1
+  --> $DIR/auxiliary/privacy_tuple_struct.rs:2:1
+   |
+LL | pub struct A(());
+   | ^^^^^^^^^^^^
+
+error[E0603]: tuple struct constructor `A` is private
+  --> $DIR/privacy5.rs:99:22
+   |
+LL |     match a { other::A(_) => {} }
+   |                      ^ private tuple struct constructor
+   |
+  ::: $DIR/auxiliary/privacy_tuple_struct.rs:2:14
+   |
+LL | pub struct A(());
+   |              -- a constructor is private if any of the fields is private
+   |
+note: the tuple struct constructor `A` is defined here
+  --> $DIR/auxiliary/privacy_tuple_struct.rs:2:1
    |
 LL | pub struct A(());
    | ^^^^^^^^^^^^
 
 error[E0603]: tuple struct constructor `B` is private
-  --> $DIR/privacy5.rs:100:16
+  --> $DIR/privacy5.rs:101:16
    |
 LL |     let other::B(_) = b;
    |                ^ private tuple struct constructor
    |
-  ::: $DIR/auxiliary/privacy_tuple_struct.rs:2:14
+  ::: $DIR/auxiliary/privacy_tuple_struct.rs:3:14
    |
 LL | pub struct B(isize);
    |              ----- a constructor is private if any of the fields is private
    |
 note: the tuple struct constructor `B` is defined here
-  --> $DIR/auxiliary/privacy_tuple_struct.rs:2:1
+  --> $DIR/auxiliary/privacy_tuple_struct.rs:3:1
    |
 LL | pub struct B(isize);
    | ^^^^^^^^^^^^
 
 error[E0603]: tuple struct constructor `B` is private
-  --> $DIR/privacy5.rs:101:16
+  --> $DIR/privacy5.rs:102:16
    |
 LL |     let other::B(_b) = b;
    |                ^ private tuple struct constructor
    |
-  ::: $DIR/auxiliary/privacy_tuple_struct.rs:2:14
+  ::: $DIR/auxiliary/privacy_tuple_struct.rs:3:14
    |
 LL | pub struct B(isize);
    |              ----- a constructor is private if any of the fields is private
    |
 note: the tuple struct constructor `B` is defined here
-  --> $DIR/auxiliary/privacy_tuple_struct.rs:2:1
-   |
-LL | pub struct B(isize);
-   | ^^^^^^^^^^^^
-
-error[E0603]: tuple struct constructor `B` is private
-  --> $DIR/privacy5.rs:102:22
-   |
-LL |     match b { other::B(_) => {} }
-   |                      ^ private tuple struct constructor
-   |
-  ::: $DIR/auxiliary/privacy_tuple_struct.rs:2:14
-   |
-LL | pub struct B(isize);
-   |              ----- a constructor is private if any of the fields is private
-   |
-note: the tuple struct constructor `B` is defined here
-  --> $DIR/auxiliary/privacy_tuple_struct.rs:2:1
+  --> $DIR/auxiliary/privacy_tuple_struct.rs:3:1
    |
 LL | pub struct B(isize);
    | ^^^^^^^^^^^^
@@ -627,16 +610,16 @@ LL | pub struct B(isize);
 error[E0603]: tuple struct constructor `B` is private
   --> $DIR/privacy5.rs:103:22
    |
-LL |     match b { other::B(_b) => {} }
+LL |     match b { other::B(_) => {} }
    |                      ^ private tuple struct constructor
    |
-  ::: $DIR/auxiliary/privacy_tuple_struct.rs:2:14
+  ::: $DIR/auxiliary/privacy_tuple_struct.rs:3:14
    |
 LL | pub struct B(isize);
    |              ----- a constructor is private if any of the fields is private
    |
 note: the tuple struct constructor `B` is defined here
-  --> $DIR/auxiliary/privacy_tuple_struct.rs:2:1
+  --> $DIR/auxiliary/privacy_tuple_struct.rs:3:1
    |
 LL | pub struct B(isize);
    | ^^^^^^^^^^^^
@@ -644,67 +627,67 @@ LL | pub struct B(isize);
 error[E0603]: tuple struct constructor `B` is private
   --> $DIR/privacy5.rs:104:22
    |
-LL |     match b { other::B(1) => {}
+LL |     match b { other::B(_b) => {} }
    |                      ^ private tuple struct constructor
    |
-  ::: $DIR/auxiliary/privacy_tuple_struct.rs:2:14
+  ::: $DIR/auxiliary/privacy_tuple_struct.rs:3:14
    |
 LL | pub struct B(isize);
    |              ----- a constructor is private if any of the fields is private
    |
 note: the tuple struct constructor `B` is defined here
-  --> $DIR/auxiliary/privacy_tuple_struct.rs:2:1
+  --> $DIR/auxiliary/privacy_tuple_struct.rs:3:1
    |
 LL | pub struct B(isize);
    | ^^^^^^^^^^^^
 
 error[E0603]: tuple struct constructor `B` is private
-  --> $DIR/privacy5.rs:105:16
+  --> $DIR/privacy5.rs:105:22
    |
-LL |         other::B(_) => {} }
-   |                ^ private tuple struct constructor
+LL |     match b { other::B(1) => {}
+   |                      ^ private tuple struct constructor
    |
-  ::: $DIR/auxiliary/privacy_tuple_struct.rs:2:14
+  ::: $DIR/auxiliary/privacy_tuple_struct.rs:3:14
    |
 LL | pub struct B(isize);
    |              ----- a constructor is private if any of the fields is private
    |
 note: the tuple struct constructor `B` is defined here
-  --> $DIR/auxiliary/privacy_tuple_struct.rs:2:1
+  --> $DIR/auxiliary/privacy_tuple_struct.rs:3:1
+   |
+LL | pub struct B(isize);
+   | ^^^^^^^^^^^^
+
+error[E0603]: tuple struct constructor `B` is private
+  --> $DIR/privacy5.rs:106:16
+   |
+LL |         other::B(_) => {} }
+   |                ^ private tuple struct constructor
+   |
+  ::: $DIR/auxiliary/privacy_tuple_struct.rs:3:14
+   |
+LL | pub struct B(isize);
+   |              ----- a constructor is private if any of the fields is private
+   |
+note: the tuple struct constructor `B` is defined here
+  --> $DIR/auxiliary/privacy_tuple_struct.rs:3:1
    |
 LL | pub struct B(isize);
    | ^^^^^^^^^^^^
 
 error[E0603]: tuple struct constructor `C` is private
-  --> $DIR/privacy5.rs:107:16
+  --> $DIR/privacy5.rs:108:16
    |
 LL |     let other::C(_, _) = c;
    |                ^ private tuple struct constructor
    |
-  ::: $DIR/auxiliary/privacy_tuple_struct.rs:3:14
+  ::: $DIR/auxiliary/privacy_tuple_struct.rs:4:14
    |
 LL | pub struct C(pub isize, isize);
    |              ---------------- a constructor is private if any of the fields is private
    |
 note: the tuple struct constructor `C` is defined here
-  --> $DIR/auxiliary/privacy_tuple_struct.rs:3:1
-   |
-LL | pub struct C(pub isize, isize);
-   | ^^^^^^^^^^^^
-
-error[E0603]: tuple struct constructor `C` is private
-  --> $DIR/privacy5.rs:108:16
-   |
-LL |     let other::C(_a, _) = c;
-   |                ^ private tuple struct constructor
-   |
-  ::: $DIR/auxiliary/privacy_tuple_struct.rs:3:14
-   |
-LL | pub struct C(pub isize, isize);
-   |              ---------------- a constructor is private if any of the fields is private
-   |
-note: the tuple struct constructor `C` is defined here
-  --> $DIR/auxiliary/privacy_tuple_struct.rs:3:1
+  --> $DIR/auxiliary/privacy_tuple_struct.rs:4:1
    |
 LL | pub struct C(pub isize, isize);
    | ^^^^^^^^^^^^
@@ -712,16 +695,16 @@ LL | pub struct C(pub isize, isize);
 error[E0603]: tuple struct constructor `C` is private
   --> $DIR/privacy5.rs:109:16
    |
-LL |     let other::C(_, _b) = c;
+LL |     let other::C(_a, _) = c;
    |                ^ private tuple struct constructor
    |
-  ::: $DIR/auxiliary/privacy_tuple_struct.rs:3:14
+  ::: $DIR/auxiliary/privacy_tuple_struct.rs:4:14
    |
 LL | pub struct C(pub isize, isize);
    |              ---------------- a constructor is private if any of the fields is private
    |
 note: the tuple struct constructor `C` is defined here
-  --> $DIR/auxiliary/privacy_tuple_struct.rs:3:1
+  --> $DIR/auxiliary/privacy_tuple_struct.rs:4:1
    |
 LL | pub struct C(pub isize, isize);
    | ^^^^^^^^^^^^
@@ -729,33 +712,33 @@ LL | pub struct C(pub isize, isize);
 error[E0603]: tuple struct constructor `C` is private
   --> $DIR/privacy5.rs:110:16
    |
-LL |     let other::C(_a, _b) = c;
+LL |     let other::C(_, _b) = c;
    |                ^ private tuple struct constructor
    |
-  ::: $DIR/auxiliary/privacy_tuple_struct.rs:3:14
+  ::: $DIR/auxiliary/privacy_tuple_struct.rs:4:14
    |
 LL | pub struct C(pub isize, isize);
    |              ---------------- a constructor is private if any of the fields is private
    |
 note: the tuple struct constructor `C` is defined here
-  --> $DIR/auxiliary/privacy_tuple_struct.rs:3:1
+  --> $DIR/auxiliary/privacy_tuple_struct.rs:4:1
    |
 LL | pub struct C(pub isize, isize);
    | ^^^^^^^^^^^^
 
 error[E0603]: tuple struct constructor `C` is private
-  --> $DIR/privacy5.rs:111:22
+  --> $DIR/privacy5.rs:111:16
    |
-LL |     match c { other::C(_, _) => {} }
-   |                      ^ private tuple struct constructor
+LL |     let other::C(_a, _b) = c;
+   |                ^ private tuple struct constructor
    |
-  ::: $DIR/auxiliary/privacy_tuple_struct.rs:3:14
+  ::: $DIR/auxiliary/privacy_tuple_struct.rs:4:14
    |
 LL | pub struct C(pub isize, isize);
    |              ---------------- a constructor is private if any of the fields is private
    |
 note: the tuple struct constructor `C` is defined here
-  --> $DIR/auxiliary/privacy_tuple_struct.rs:3:1
+  --> $DIR/auxiliary/privacy_tuple_struct.rs:4:1
    |
 LL | pub struct C(pub isize, isize);
    | ^^^^^^^^^^^^
@@ -763,16 +746,16 @@ LL | pub struct C(pub isize, isize);
 error[E0603]: tuple struct constructor `C` is private
   --> $DIR/privacy5.rs:112:22
    |
-LL |     match c { other::C(_a, _) => {} }
+LL |     match c { other::C(_, _) => {} }
    |                      ^ private tuple struct constructor
    |
-  ::: $DIR/auxiliary/privacy_tuple_struct.rs:3:14
+  ::: $DIR/auxiliary/privacy_tuple_struct.rs:4:14
    |
 LL | pub struct C(pub isize, isize);
    |              ---------------- a constructor is private if any of the fields is private
    |
 note: the tuple struct constructor `C` is defined here
-  --> $DIR/auxiliary/privacy_tuple_struct.rs:3:1
+  --> $DIR/auxiliary/privacy_tuple_struct.rs:4:1
    |
 LL | pub struct C(pub isize, isize);
    | ^^^^^^^^^^^^
@@ -780,16 +763,16 @@ LL | pub struct C(pub isize, isize);
 error[E0603]: tuple struct constructor `C` is private
   --> $DIR/privacy5.rs:113:22
    |
-LL |     match c { other::C(_, _b) => {} }
+LL |     match c { other::C(_a, _) => {} }
    |                      ^ private tuple struct constructor
    |
-  ::: $DIR/auxiliary/privacy_tuple_struct.rs:3:14
+  ::: $DIR/auxiliary/privacy_tuple_struct.rs:4:14
    |
 LL | pub struct C(pub isize, isize);
    |              ---------------- a constructor is private if any of the fields is private
    |
 note: the tuple struct constructor `C` is defined here
-  --> $DIR/auxiliary/privacy_tuple_struct.rs:3:1
+  --> $DIR/auxiliary/privacy_tuple_struct.rs:4:1
    |
 LL | pub struct C(pub isize, isize);
    | ^^^^^^^^^^^^
@@ -797,67 +780,84 @@ LL | pub struct C(pub isize, isize);
 error[E0603]: tuple struct constructor `C` is private
   --> $DIR/privacy5.rs:114:22
    |
-LL |     match c { other::C(_a, _b) => {} }
+LL |     match c { other::C(_, _b) => {} }
    |                      ^ private tuple struct constructor
    |
-  ::: $DIR/auxiliary/privacy_tuple_struct.rs:3:14
+  ::: $DIR/auxiliary/privacy_tuple_struct.rs:4:14
    |
 LL | pub struct C(pub isize, isize);
    |              ---------------- a constructor is private if any of the fields is private
    |
 note: the tuple struct constructor `C` is defined here
-  --> $DIR/auxiliary/privacy_tuple_struct.rs:3:1
+  --> $DIR/auxiliary/privacy_tuple_struct.rs:4:1
+   |
+LL | pub struct C(pub isize, isize);
+   | ^^^^^^^^^^^^
+
+error[E0603]: tuple struct constructor `C` is private
+  --> $DIR/privacy5.rs:115:22
+   |
+LL |     match c { other::C(_a, _b) => {} }
+   |                      ^ private tuple struct constructor
+   |
+  ::: $DIR/auxiliary/privacy_tuple_struct.rs:4:14
+   |
+LL | pub struct C(pub isize, isize);
+   |              ---------------- a constructor is private if any of the fields is private
+   |
+note: the tuple struct constructor `C` is defined here
+  --> $DIR/auxiliary/privacy_tuple_struct.rs:4:1
    |
 LL | pub struct C(pub isize, isize);
    | ^^^^^^^^^^^^
 
 error[E0603]: tuple struct constructor `A` is private
-  --> $DIR/privacy5.rs:122:21
+  --> $DIR/privacy5.rs:123:21
    |
 LL |     let a2 = other::A;
    |                     ^ private tuple struct constructor
    |
-  ::: $DIR/auxiliary/privacy_tuple_struct.rs:1:14
+  ::: $DIR/auxiliary/privacy_tuple_struct.rs:2:14
    |
 LL | pub struct A(());
    |              -- a constructor is private if any of the fields is private
    |
 note: the tuple struct constructor `A` is defined here
-  --> $DIR/auxiliary/privacy_tuple_struct.rs:1:1
+  --> $DIR/auxiliary/privacy_tuple_struct.rs:2:1
    |
 LL | pub struct A(());
    | ^^^^^^^^^^^^
 
 error[E0603]: tuple struct constructor `B` is private
-  --> $DIR/privacy5.rs:123:21
+  --> $DIR/privacy5.rs:124:21
    |
 LL |     let b2 = other::B;
    |                     ^ private tuple struct constructor
    |
-  ::: $DIR/auxiliary/privacy_tuple_struct.rs:2:14
+  ::: $DIR/auxiliary/privacy_tuple_struct.rs:3:14
    |
 LL | pub struct B(isize);
    |              ----- a constructor is private if any of the fields is private
    |
 note: the tuple struct constructor `B` is defined here
-  --> $DIR/auxiliary/privacy_tuple_struct.rs:2:1
+  --> $DIR/auxiliary/privacy_tuple_struct.rs:3:1
    |
 LL | pub struct B(isize);
    | ^^^^^^^^^^^^
 
 error[E0603]: tuple struct constructor `C` is private
-  --> $DIR/privacy5.rs:124:21
+  --> $DIR/privacy5.rs:125:21
    |
 LL |     let c2 = other::C;
    |                     ^ private tuple struct constructor
    |
-  ::: $DIR/auxiliary/privacy_tuple_struct.rs:3:14
+  ::: $DIR/auxiliary/privacy_tuple_struct.rs:4:14
    |
 LL | pub struct C(pub isize, isize);
    |              ---------------- a constructor is private if any of the fields is private
    |
 note: the tuple struct constructor `C` is defined here
-  --> $DIR/auxiliary/privacy_tuple_struct.rs:3:1
+  --> $DIR/auxiliary/privacy_tuple_struct.rs:4:1
    |
 LL | pub struct C(pub isize, isize);
    | ^^^^^^^^^^^^

--- a/tests/ui/privacy/private-fields-diagnostic-issue-151408.rs
+++ b/tests/ui/privacy/private-fields-diagnostic-issue-151408.rs
@@ -1,5 +1,6 @@
 //@ aux-build:private-fields-diagnostic-aux-issue-151408.rs
 
+#![allow(unused_unconstructable_pub_structs)]
 extern crate private_fields_diagnostic_aux_issue_151408 as aux;
 
 use aux::{Named, NamedWithMultipleFields, PublicTuple};

--- a/tests/ui/privacy/private-fields-diagnostic-issue-151408.stderr
+++ b/tests/ui/privacy/private-fields-diagnostic-issue-151408.stderr
@@ -1,5 +1,5 @@
 error: cannot construct `aux::Named` with struct literal syntax due to private fields
-  --> $DIR/private-fields-diagnostic-issue-151408.rs:8:13
+  --> $DIR/private-fields-diagnostic-issue-151408.rs:9:13
    |
 LL |     let _ = Named {};
    |             ^^^^^
@@ -11,13 +11,13 @@ LL +     let _ = Named::new();
    |
 
 error[E0423]: cannot initialize a tuple struct which contains private fields
-  --> $DIR/private-fields-diagnostic-issue-151408.rs:11:13
+  --> $DIR/private-fields-diagnostic-issue-151408.rs:12:13
    |
 LL |     let _ = PublicTuple();
    |             ^^^^^^^^^^^
    |
 note: constructor is not visible here due to private fields
-  --> $DIR/auxiliary/private-fields-diagnostic-aux-issue-151408.rs:18:24
+  --> $DIR/auxiliary/private-fields-diagnostic-aux-issue-151408.rs:19:24
    |
 LL | pub struct PublicTuple(PrivateInner);
    |                        ^^^^^^^^^^^^ private field
@@ -27,7 +27,7 @@ LL |     let _ = PublicTuple::new();
    |                        +++++
 
 error: cannot construct `NamedWithMultipleFields` with struct literal syntax due to private fields
-  --> $DIR/private-fields-diagnostic-issue-151408.rs:15:13
+  --> $DIR/private-fields-diagnostic-issue-151408.rs:16:13
    |
 LL |     let _ = NamedWithMultipleFields { visible: 1 };
    |             ^^^^^^^^^^^^^^^^^^^^^^^
@@ -35,7 +35,7 @@ LL |     let _ = NamedWithMultipleFields { visible: 1 };
    = note: ...and other private field `hidden` that was not provided
 
 error: cannot construct `NamedWithMultipleFields` with struct literal syntax due to private fields
-  --> $DIR/private-fields-diagnostic-issue-151408.rs:18:13
+  --> $DIR/private-fields-diagnostic-issue-151408.rs:19:13
    |
 LL |     let _ = NamedWithMultipleFields {};
    |             ^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/privacy/private-inferred-type-2.rs
+++ b/tests/ui/privacy/private-inferred-type-2.rs
@@ -1,5 +1,6 @@
 //@ aux-build:private-inferred-type.rs
 #![allow(private_interfaces)]
+#![allow(unused_unconstructable_pub_structs)]
 
 extern crate private_inferred_type as ext;
 

--- a/tests/ui/privacy/private-inferred-type-2.stderr
+++ b/tests/ui/privacy/private-inferred-type-2.stderr
@@ -1,17 +1,17 @@
 error: type `Priv` is private
-  --> $DIR/private-inferred-type-2.rs:17:5
+  --> $DIR/private-inferred-type-2.rs:18:5
    |
 LL |     m::Pub::get_priv;
    |     ^^^^^^^^^^^^^^^^ private type
 
 error: type `Priv` is private
-  --> $DIR/private-inferred-type-2.rs:18:5
+  --> $DIR/private-inferred-type-2.rs:19:5
    |
 LL |     m::Pub::static_method;
    |     ^^^^^^^^^^^^^^^^^^^^^ private type
 
 error: type `ext::Priv` is private
-  --> $DIR/private-inferred-type-2.rs:19:5
+  --> $DIR/private-inferred-type-2.rs:20:5
    |
 LL |     ext::Pub::static_method;
    |     ^^^^^^^^^^^^^^^^^^^^^^^ private type

--- a/tests/ui/privacy/private-inferred-type-3.rs
+++ b/tests/ui/privacy/private-inferred-type-3.rs
@@ -1,6 +1,7 @@
 //@ aux-build:private-inferred-type.rs
 
 #![feature(decl_macro)]
+#![allow(unused_unconstructable_pub_structs)]
 
 extern crate private_inferred_type as ext;
 

--- a/tests/ui/privacy/private-inferred-type-3.stderr
+++ b/tests/ui/privacy/private-inferred-type-3.stderr
@@ -1,5 +1,5 @@
 error: type `fn() {ext::priv_fn}` is private
-  --> $DIR/private-inferred-type-3.rs:8:5
+  --> $DIR/private-inferred-type-3.rs:9:5
    |
 LL |     ext::m!();
    |     ^^^^^^^^^ private type
@@ -7,7 +7,7 @@ LL |     ext::m!();
    = note: this error originates in the macro `ext::m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: static `ext::PRIV_STATIC` is private
-  --> $DIR/private-inferred-type-3.rs:8:5
+  --> $DIR/private-inferred-type-3.rs:9:5
    |
 LL |     ext::m!();
    |     ^^^^^^^^^ private static
@@ -15,7 +15,7 @@ LL |     ext::m!();
    = note: this error originates in the macro `ext::m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: type `ext::PrivEnum` is private
-  --> $DIR/private-inferred-type-3.rs:8:5
+  --> $DIR/private-inferred-type-3.rs:9:5
    |
 LL |     ext::m!();
    |     ^^^^^^^^^ private type
@@ -23,7 +23,7 @@ LL |     ext::m!();
    = note: this error originates in the macro `ext::m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: type `fn() {<u8 as ext::PrivTrait>::method}` is private
-  --> $DIR/private-inferred-type-3.rs:8:5
+  --> $DIR/private-inferred-type-3.rs:9:5
    |
 LL |     ext::m!();
    |     ^^^^^^^^^ private type
@@ -31,7 +31,7 @@ LL |     ext::m!();
    = note: this error originates in the macro `ext::m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: type `fn(u8) -> ext::PrivTupleStruct {ext::PrivTupleStruct}` is private
-  --> $DIR/private-inferred-type-3.rs:8:5
+  --> $DIR/private-inferred-type-3.rs:9:5
    |
 LL |     ext::m!();
    |     ^^^^^^^^^ private type
@@ -39,7 +39,7 @@ LL |     ext::m!();
    = note: this error originates in the macro `ext::m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: type `fn(u8) -> PubTupleStruct {PubTupleStruct}` is private
-  --> $DIR/private-inferred-type-3.rs:8:5
+  --> $DIR/private-inferred-type-3.rs:9:5
    |
 LL |     ext::m!();
    |     ^^^^^^^^^ private type
@@ -47,7 +47,7 @@ LL |     ext::m!();
    = note: this error originates in the macro `ext::m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: type `for<'a> fn(&'a Pub<u8>) {Pub::<u8>::priv_method}` is private
-  --> $DIR/private-inferred-type-3.rs:8:5
+  --> $DIR/private-inferred-type-3.rs:9:5
    |
 LL |     ext::m!();
    |     ^^^^^^^^^ private type

--- a/tests/ui/privacy/private-type-in-interface.rs
+++ b/tests/ui/privacy/private-type-in-interface.rs
@@ -2,6 +2,7 @@
 
 #![allow(warnings)]
 #![allow(private_interfaces)]
+#![allow(unused_unconstructable_pub_structs)]
 
 extern crate private_inferred_type as ext;
 

--- a/tests/ui/privacy/private-type-in-interface.stderr
+++ b/tests/ui/privacy/private-type-in-interface.stderr
@@ -1,53 +1,53 @@
 error: type `Priv` is private
-  --> $DIR/private-type-in-interface.rs:16:9
+  --> $DIR/private-type-in-interface.rs:17:9
    |
 LL | fn f(_: m::Alias) {}
    |         ^^^^^^^^ private type
 
 error: type `Priv` is private
-  --> $DIR/private-type-in-interface.rs:16:6
+  --> $DIR/private-type-in-interface.rs:17:6
    |
 LL | fn f(_: m::Alias) {}
    |      ^ private type
 
 error: type `ext::Priv` is private
-  --> $DIR/private-type-in-interface.rs:18:13
+  --> $DIR/private-type-in-interface.rs:19:13
    |
 LL | fn f_ext(_: ext::Alias) {}
    |             ^^^^^^^^^^ private type
 
 error: type `ext::Priv` is private
-  --> $DIR/private-type-in-interface.rs:18:10
+  --> $DIR/private-type-in-interface.rs:19:10
    |
 LL | fn f_ext(_: ext::Alias) {}
    |          ^ private type
 
 error: type `Priv` is private
-  --> $DIR/private-type-in-interface.rs:22:6
+  --> $DIR/private-type-in-interface.rs:23:6
    |
 LL | impl m::Alias {}
    |      ^^^^^^^^ private type
 
 error: type `ext::Priv` is private
-  --> $DIR/private-type-in-interface.rs:23:14
+  --> $DIR/private-type-in-interface.rs:24:14
    |
 LL | impl Tr1 for ext::Alias {}
    |              ^^^^^^^^^^ private type
 
 error: type `Priv` is private
-  --> $DIR/private-type-in-interface.rs:24:10
+  --> $DIR/private-type-in-interface.rs:25:10
    |
 LL | type A = <m::Alias as m::Trait>::X;
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^ private type
 
 error: type `Priv` is private
-  --> $DIR/private-type-in-interface.rs:28:11
+  --> $DIR/private-type-in-interface.rs:29:11
    |
 LL | fn g() -> impl Tr2<m::Alias> { 0 }
    |           ^^^^^^^^^^^^^^^^^^ private type
 
 error: type `ext::Priv` is private
-  --> $DIR/private-type-in-interface.rs:29:15
+  --> $DIR/private-type-in-interface.rs:30:15
    |
 LL | fn g_ext() -> impl Tr2<ext::Alias> { 0 }
    |               ^^^^^^^^^^^^^^^^^^^^ private type

--- a/tests/ui/pub/pub-ident-struct-4.fixed
+++ b/tests/ui/pub/pub-ident-struct-4.fixed
@@ -1,5 +1,6 @@
 //@ run-rustfix
 
+#![allow(unused_unconstructable_pub_structs)]
 pub struct T(#[allow(dead_code)] String);
 //~^ ERROR missing `struct` for struct definition
 

--- a/tests/ui/pub/pub-ident-struct-4.rs
+++ b/tests/ui/pub/pub-ident-struct-4.rs
@@ -1,5 +1,6 @@
 //@ run-rustfix
 
+#![allow(unused_unconstructable_pub_structs)]
 pub T(#[allow(dead_code)] String);
 //~^ ERROR missing `struct` for struct definition
 

--- a/tests/ui/pub/pub-ident-struct-4.stderr
+++ b/tests/ui/pub/pub-ident-struct-4.stderr
@@ -1,5 +1,5 @@
 error: missing `struct` for struct definition
-  --> $DIR/pub-ident-struct-4.rs:3:1
+  --> $DIR/pub-ident-struct-4.rs:4:1
    |
 LL | pub T(#[allow(dead_code)] String);
    | ^^^^^

--- a/tests/ui/reachable/auxiliary/foreign-priv-aux.rs
+++ b/tests/ui/reachable/auxiliary/foreign-priv-aux.rs
@@ -1,3 +1,4 @@
+#![allow(unused_unconstructable_pub_structs)]
 trait PrivTrait {
     fn priv_fn(&self);
 }

--- a/tests/ui/reachable/foreign-priv.rs
+++ b/tests/ui/reachable/foreign-priv.rs
@@ -2,6 +2,7 @@
 //@ build-pass
 
 #![crate_type = "lib"]
+#![allow(unused_unconstructable_pub_structs)]
 
 extern crate foreign_priv_aux;
 

--- a/tests/ui/regions/regions-issue-21422.rs
+++ b/tests/ui/regions/regions-issue-21422.rs
@@ -1,4 +1,5 @@
 //@ run-pass
+#![allow(unused_unconstructable_pub_structs)]
 // Regression test for issue #21422, which was related to failing to
 // add inference constraints that the operands of a binary operator
 // should outlive the binary operation itself.

--- a/tests/ui/regions/regions-issue-22246.rs
+++ b/tests/ui/regions/regions-issue-22246.rs
@@ -1,5 +1,6 @@
 //@ run-pass
 #![allow(unused_imports)]
+#![allow(unused_unconstructable_pub_structs)]
 // Regression test for issue #22246 -- we should be able to deduce
 // that `&'a B::Owned` implies that `B::Owned : 'a`.
 

--- a/tests/ui/rfcs/rfc-2008-non-exhaustive/uninhabited/auxiliary/uninhabited.rs
+++ b/tests/ui/rfcs/rfc-2008-non-exhaustive/uninhabited/auxiliary/uninhabited.rs
@@ -1,5 +1,6 @@
 #![crate_type = "rlib"]
 #![feature(never_type)]
+#![allow(unused_unconstructable_pub_structs)]
 
 #[non_exhaustive]
 pub enum UninhabitedEnum {

--- a/tests/ui/rfcs/rfc-2008-non-exhaustive/uninhabited/coercions.rs
+++ b/tests/ui/rfcs/rfc-2008-non-exhaustive/uninhabited/coercions.rs
@@ -1,5 +1,6 @@
 //@ aux-build:uninhabited.rs
 #![feature(never_type)]
+#![allow(unused_unconstructable_pub_structs)]
 
 extern crate uninhabited;
 

--- a/tests/ui/rfcs/rfc-2008-non-exhaustive/uninhabited/coercions.stderr
+++ b/tests/ui/rfcs/rfc-2008-non-exhaustive/uninhabited/coercions.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/coercions.rs:23:5
+  --> $DIR/coercions.rs:24:5
    |
 LL | fn cannot_coerce_empty_enum_to_anything(x: UninhabitedEnum) -> A {
    |                                                                - expected `A` because of return type
@@ -7,7 +7,7 @@ LL |     x
    |     ^ expected `A`, found `UninhabitedEnum`
 
 error[E0308]: mismatched types
-  --> $DIR/coercions.rs:27:5
+  --> $DIR/coercions.rs:28:5
    |
 LL | fn cannot_coerce_empty_tuple_struct_to_anything(x: UninhabitedTupleStruct) -> A {
    |                                                                               - expected `A` because of return type
@@ -15,7 +15,7 @@ LL |     x
    |     ^ expected `A`, found `UninhabitedTupleStruct`
 
 error[E0308]: mismatched types
-  --> $DIR/coercions.rs:31:5
+  --> $DIR/coercions.rs:32:5
    |
 LL | fn cannot_coerce_empty_struct_to_anything(x: UninhabitedStruct) -> A {
    |                                                                    - expected `A` because of return type
@@ -23,7 +23,7 @@ LL |     x
    |     ^ expected `A`, found `UninhabitedStruct`
 
 error[E0308]: mismatched types
-  --> $DIR/coercions.rs:35:5
+  --> $DIR/coercions.rs:36:5
    |
 LL | fn cannot_coerce_enum_with_empty_variants_to_anything(x: UninhabitedVariants) -> A {
    |                                                                                  - expected `A` because of return type

--- a/tests/ui/rfcs/rfc-2008-non-exhaustive/uninhabited/indirect_match.rs
+++ b/tests/ui/rfcs/rfc-2008-non-exhaustive/uninhabited/indirect_match.rs
@@ -1,5 +1,6 @@
 //@ aux-build:uninhabited.rs
 #![feature(never_type)]
+#![allow(unused_unconstructable_pub_structs)]
 
 extern crate uninhabited;
 

--- a/tests/ui/rfcs/rfc-2008-non-exhaustive/uninhabited/indirect_match.stderr
+++ b/tests/ui/rfcs/rfc-2008-non-exhaustive/uninhabited/indirect_match.stderr
@@ -1,11 +1,11 @@
 error[E0004]: non-exhaustive patterns: type `IndirectUninhabitedEnum` is non-empty
-  --> $DIR/indirect_match.rs:19:11
+  --> $DIR/indirect_match.rs:20:11
    |
 LL |     match x {}
    |           ^
    |
 note: `IndirectUninhabitedEnum` defined here
-  --> $DIR/auxiliary/uninhabited.rs:32:1
+  --> $DIR/auxiliary/uninhabited.rs:33:1
    |
 LL | pub struct IndirectUninhabitedEnum(UninhabitedEnum);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -18,13 +18,13 @@ LL ~     }
    |
 
 error[E0004]: non-exhaustive patterns: type `IndirectUninhabitedStruct` is non-empty
-  --> $DIR/indirect_match.rs:23:11
+  --> $DIR/indirect_match.rs:24:11
    |
 LL |     match x {}
    |           ^
    |
 note: `IndirectUninhabitedStruct` defined here
-  --> $DIR/auxiliary/uninhabited.rs:34:1
+  --> $DIR/auxiliary/uninhabited.rs:35:1
    |
 LL | pub struct IndirectUninhabitedStruct(UninhabitedStruct);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -37,13 +37,13 @@ LL ~     }
    |
 
 error[E0004]: non-exhaustive patterns: type `IndirectUninhabitedTupleStruct` is non-empty
-  --> $DIR/indirect_match.rs:27:11
+  --> $DIR/indirect_match.rs:28:11
    |
 LL |     match x {}
    |           ^
    |
 note: `IndirectUninhabitedTupleStruct` defined here
-  --> $DIR/auxiliary/uninhabited.rs:36:1
+  --> $DIR/auxiliary/uninhabited.rs:37:1
    |
 LL | pub struct IndirectUninhabitedTupleStruct(UninhabitedTupleStruct);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -56,13 +56,13 @@ LL ~     }
    |
 
 error[E0004]: non-exhaustive patterns: type `IndirectUninhabitedVariants` is non-empty
-  --> $DIR/indirect_match.rs:33:11
+  --> $DIR/indirect_match.rs:34:11
    |
 LL |     match x {}
    |           ^
    |
 note: `IndirectUninhabitedVariants` defined here
-  --> $DIR/auxiliary/uninhabited.rs:38:1
+  --> $DIR/auxiliary/uninhabited.rs:39:1
    |
 LL | pub struct IndirectUninhabitedVariants(UninhabitedVariants);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/rfcs/rfc-2008-non-exhaustive/uninhabited/indirect_match_with_exhaustive_patterns.rs
+++ b/tests/ui/rfcs/rfc-2008-non-exhaustive/uninhabited/indirect_match_with_exhaustive_patterns.rs
@@ -1,6 +1,7 @@
 //@ aux-build:uninhabited.rs
 #![deny(unreachable_patterns)]
 #![feature(never_type)]
+#![allow(unused_unconstructable_pub_structs)]
 
 extern crate uninhabited;
 

--- a/tests/ui/rfcs/rfc-2008-non-exhaustive/uninhabited/indirect_match_with_exhaustive_patterns.stderr
+++ b/tests/ui/rfcs/rfc-2008-non-exhaustive/uninhabited/indirect_match_with_exhaustive_patterns.stderr
@@ -1,11 +1,11 @@
 error[E0004]: non-exhaustive patterns: type `IndirectUninhabitedEnum` is non-empty
-  --> $DIR/indirect_match_with_exhaustive_patterns.rs:22:11
+  --> $DIR/indirect_match_with_exhaustive_patterns.rs:23:11
    |
 LL |     match x {}
    |           ^
    |
 note: `IndirectUninhabitedEnum` defined here
-  --> $DIR/auxiliary/uninhabited.rs:32:1
+  --> $DIR/auxiliary/uninhabited.rs:33:1
    |
 LL | pub struct IndirectUninhabitedEnum(UninhabitedEnum);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -18,13 +18,13 @@ LL ~     }
    |
 
 error[E0004]: non-exhaustive patterns: type `IndirectUninhabitedStruct` is non-empty
-  --> $DIR/indirect_match_with_exhaustive_patterns.rs:26:11
+  --> $DIR/indirect_match_with_exhaustive_patterns.rs:27:11
    |
 LL |     match x {}
    |           ^
    |
 note: `IndirectUninhabitedStruct` defined here
-  --> $DIR/auxiliary/uninhabited.rs:34:1
+  --> $DIR/auxiliary/uninhabited.rs:35:1
    |
 LL | pub struct IndirectUninhabitedStruct(UninhabitedStruct);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -37,13 +37,13 @@ LL ~     }
    |
 
 error[E0004]: non-exhaustive patterns: type `IndirectUninhabitedTupleStruct` is non-empty
-  --> $DIR/indirect_match_with_exhaustive_patterns.rs:30:11
+  --> $DIR/indirect_match_with_exhaustive_patterns.rs:31:11
    |
 LL |     match x {}
    |           ^
    |
 note: `IndirectUninhabitedTupleStruct` defined here
-  --> $DIR/auxiliary/uninhabited.rs:36:1
+  --> $DIR/auxiliary/uninhabited.rs:37:1
    |
 LL | pub struct IndirectUninhabitedTupleStruct(UninhabitedTupleStruct);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -56,13 +56,13 @@ LL ~     }
    |
 
 error[E0004]: non-exhaustive patterns: type `IndirectUninhabitedVariants` is non-empty
-  --> $DIR/indirect_match_with_exhaustive_patterns.rs:36:11
+  --> $DIR/indirect_match_with_exhaustive_patterns.rs:37:11
    |
 LL |     match x {}
    |           ^
    |
 note: `IndirectUninhabitedVariants` defined here
-  --> $DIR/auxiliary/uninhabited.rs:38:1
+  --> $DIR/auxiliary/uninhabited.rs:39:1
    |
 LL | pub struct IndirectUninhabitedVariants(UninhabitedVariants);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/rfcs/rfc-2008-non-exhaustive/uninhabited/issue-65157-repeated-match-arm.rs
+++ b/tests/ui/rfcs/rfc-2008-non-exhaustive/uninhabited/issue-65157-repeated-match-arm.rs
@@ -1,6 +1,7 @@
 //@ aux-build:uninhabited.rs
 #![deny(unreachable_patterns)]
 #![feature(never_type)]
+#![allow(unused_unconstructable_pub_structs)]
 
 extern crate uninhabited;
 

--- a/tests/ui/rfcs/rfc-2008-non-exhaustive/uninhabited/issue-65157-repeated-match-arm.stderr
+++ b/tests/ui/rfcs/rfc-2008-non-exhaustive/uninhabited/issue-65157-repeated-match-arm.stderr
@@ -1,5 +1,5 @@
 error: unreachable pattern
-  --> $DIR/issue-65157-repeated-match-arm.rs:15:9
+  --> $DIR/issue-65157-repeated-match-arm.rs:16:9
    |
 LL |         PartiallyInhabitedVariants::Struct { .. } => {}
    |         ----------------------------------------- matches all the relevant values

--- a/tests/ui/rfcs/rfc-2008-non-exhaustive/uninhabited/match.rs
+++ b/tests/ui/rfcs/rfc-2008-non-exhaustive/uninhabited/match.rs
@@ -1,5 +1,6 @@
 //@ aux-build:uninhabited.rs
 #![feature(never_type)]
+#![allow(unused_unconstructable_pub_structs)]
 
 extern crate uninhabited;
 

--- a/tests/ui/rfcs/rfc-2008-non-exhaustive/uninhabited/match.stderr
+++ b/tests/ui/rfcs/rfc-2008-non-exhaustive/uninhabited/match.stderr
@@ -1,11 +1,11 @@
 error[E0004]: non-exhaustive patterns: type `uninhabited::UninhabitedEnum` is non-empty
-  --> $DIR/match.rs:14:11
+  --> $DIR/match.rs:15:11
    |
 LL |     match x {}
    |           ^
    |
 note: `uninhabited::UninhabitedEnum` defined here
-  --> $DIR/auxiliary/uninhabited.rs:5:1
+  --> $DIR/auxiliary/uninhabited.rs:6:1
    |
 LL | pub enum UninhabitedEnum {
    | ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -18,13 +18,13 @@ LL ~     }
    |
 
 error[E0004]: non-exhaustive patterns: type `uninhabited::PrivatelyUninhabitedStruct` is non-empty
-  --> $DIR/match.rs:22:11
+  --> $DIR/match.rs:23:11
    |
 LL |     match x {}
    |           ^
    |
 note: `uninhabited::PrivatelyUninhabitedStruct` defined here
-  --> $DIR/auxiliary/uninhabited.rs:15:1
+  --> $DIR/auxiliary/uninhabited.rs:16:1
    |
 LL | pub struct PrivatelyUninhabitedStruct {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/rfcs/rfc-2008-non-exhaustive/uninhabited/match_with_exhaustive_patterns.rs
+++ b/tests/ui/rfcs/rfc-2008-non-exhaustive/uninhabited/match_with_exhaustive_patterns.rs
@@ -1,6 +1,7 @@
 //@ aux-build:uninhabited.rs
 #![deny(unreachable_patterns)]
 #![feature(never_type)]
+#![allow(unused_unconstructable_pub_structs)]
 
 extern crate uninhabited;
 

--- a/tests/ui/rfcs/rfc-2008-non-exhaustive/uninhabited/match_with_exhaustive_patterns.stderr
+++ b/tests/ui/rfcs/rfc-2008-non-exhaustive/uninhabited/match_with_exhaustive_patterns.stderr
@@ -1,11 +1,11 @@
 error[E0004]: non-exhaustive patterns: type `UninhabitedEnum` is non-empty
-  --> $DIR/match_with_exhaustive_patterns.rs:17:11
+  --> $DIR/match_with_exhaustive_patterns.rs:18:11
    |
 LL |     match x {}
    |           ^
    |
 note: `UninhabitedEnum` defined here
-  --> $DIR/auxiliary/uninhabited.rs:5:1
+  --> $DIR/auxiliary/uninhabited.rs:6:1
    |
 LL | pub enum UninhabitedEnum {
    | ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/rfcs/rfc-2008-non-exhaustive/uninhabited/patterns.rs
+++ b/tests/ui/rfcs/rfc-2008-non-exhaustive/uninhabited/patterns.rs
@@ -1,6 +1,7 @@
 //@ aux-build:uninhabited.rs
 #![feature(exhaustive_patterns)]
 #![deny(unreachable_patterns)]
+#![allow(unused_unconstructable_pub_structs)]
 
 extern crate uninhabited;
 

--- a/tests/ui/rfcs/rfc-2008-non-exhaustive/uninhabited/patterns.stderr
+++ b/tests/ui/rfcs/rfc-2008-non-exhaustive/uninhabited/patterns.stderr
@@ -1,5 +1,5 @@
 error: unreachable pattern
-  --> $DIR/patterns.rs:42:9
+  --> $DIR/patterns.rs:43:9
    |
 LL |         Some(_x) => (),
    |         ^^^^^^^^-------
@@ -15,7 +15,7 @@ LL | #![deny(unreachable_patterns)]
    |         ^^^^^^^^^^^^^^^^^^^^
 
 error: unreachable pattern
-  --> $DIR/patterns.rs:47:15
+  --> $DIR/patterns.rs:48:15
    |
 LL |     while let PartiallyInhabitedVariants::Struct { x, .. } = partially_inhabited_variant() {}
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ matches no values because `!` is uninhabited
@@ -23,7 +23,7 @@ LL |     while let PartiallyInhabitedVariants::Struct { x, .. } = partially_inha
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
-  --> $DIR/patterns.rs:49:15
+  --> $DIR/patterns.rs:50:15
    |
 LL |     while let Some(_x) = uninhabited_struct() {
    |               ^^^^^^^^ matches no values because `UninhabitedStruct` is uninhabited
@@ -31,7 +31,7 @@ LL |     while let Some(_x) = uninhabited_struct() {
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
-  --> $DIR/patterns.rs:52:15
+  --> $DIR/patterns.rs:53:15
    |
 LL |     while let Some(_x) = uninhabited_tuple_struct() {
    |               ^^^^^^^^ matches no values because `UninhabitedTupleStruct` is uninhabited

--- a/tests/ui/rfcs/rfc-2093-infer-outlives/privacy.rs
+++ b/tests/ui/rfcs/rfc-2093-infer-outlives/privacy.rs
@@ -1,3 +1,4 @@
+#![allow(unused_unconstructable_pub_structs)]
 // Test that we do not get a privacy error here.  Initially, we did,
 // because we inferred an outlives predciate of `<Foo<'a> as
 // Private>::Out: 'a`, but the private trait is -- well -- private,

--- a/tests/ui/static/auxiliary/nested_item.rs
+++ b/tests/ui/static/auxiliary/nested_item.rs
@@ -1,4 +1,5 @@
 // original problem
+#![allow(unused_unconstructable_pub_structs)]
 pub fn foo<T>() -> isize {
     {
         static foo: isize = 2;

--- a/tests/ui/static/nested_item_main.rs
+++ b/tests/ui/static/nested_item_main.rs
@@ -2,6 +2,7 @@
 //@ aux-build:nested_item.rs
 
 
+#![allow(unused_unconstructable_pub_structs)]
 extern crate nested_item;
 
 pub fn main() {

--- a/tests/ui/structs/auxiliary/struct_field_privacy.rs
+++ b/tests/ui/structs/auxiliary/struct_field_privacy.rs
@@ -1,3 +1,4 @@
+#![allow(unused_unconstructable_pub_structs)]
 pub struct A {
     a: isize,
     pub b: isize,

--- a/tests/ui/structs/struct-field-privacy.rs
+++ b/tests/ui/structs/struct-field-privacy.rs
@@ -1,5 +1,6 @@
 //@ aux-build:struct_field_privacy.rs
 
+#![allow(unused_unconstructable_pub_structs)]
 extern crate struct_field_privacy as xc;
 
 struct A {

--- a/tests/ui/structs/struct-field-privacy.stderr
+++ b/tests/ui/structs/struct-field-privacy.stderr
@@ -1,29 +1,29 @@
 error[E0616]: field `a` of struct `inner::A` is private
-  --> $DIR/struct-field-privacy.rs:23:7
+  --> $DIR/struct-field-privacy.rs:24:7
    |
 LL |     b.a;
    |       ^ private field
 
 error[E0616]: field `b` of struct `inner::B` is private
-  --> $DIR/struct-field-privacy.rs:26:7
+  --> $DIR/struct-field-privacy.rs:27:7
    |
 LL |     c.b;
    |       ^ private field
 
 error[E0616]: field `a` of struct `xc::A` is private
-  --> $DIR/struct-field-privacy.rs:28:7
+  --> $DIR/struct-field-privacy.rs:29:7
    |
 LL |     d.a;
    |       ^ private field
 
 error[E0616]: field `b` of struct `xc::B` is private
-  --> $DIR/struct-field-privacy.rs:32:7
+  --> $DIR/struct-field-privacy.rs:33:7
    |
 LL |     e.b;
    |       ^ private field
 
 error[E0616]: field `1` of struct `Z` is private
-  --> $DIR/struct-field-privacy.rs:35:7
+  --> $DIR/struct-field-privacy.rs:36:7
    |
 LL |     z.1;
    |       ^ private field

--- a/tests/ui/structs/suggest-private-fields.rs
+++ b/tests/ui/structs/suggest-private-fields.rs
@@ -1,5 +1,6 @@
 //@ aux-build:struct_field_privacy.rs
 
+#![allow(unused_unconstructable_pub_structs)]
 extern crate struct_field_privacy as xc;
 
 use xc::B;

--- a/tests/ui/structs/suggest-private-fields.stderr
+++ b/tests/ui/structs/suggest-private-fields.stderr
@@ -1,5 +1,5 @@
 error[E0560]: struct `B` has no field named `aa`
-  --> $DIR/suggest-private-fields.rs:15:9
+  --> $DIR/suggest-private-fields.rs:16:9
    |
 LL |         aa: 20,
    |         ^^ unknown field
@@ -11,7 +11,7 @@ LL +         a: 20,
    |
 
 error[E0560]: struct `B` has no field named `bb`
-  --> $DIR/suggest-private-fields.rs:17:9
+  --> $DIR/suggest-private-fields.rs:18:9
    |
 LL |         bb: 20,
    |         ^^ `B` does not have this field
@@ -19,7 +19,7 @@ LL |         bb: 20,
    = note: available fields are: `a`
 
 error[E0560]: struct `A` has no field named `aa`
-  --> $DIR/suggest-private-fields.rs:22:9
+  --> $DIR/suggest-private-fields.rs:23:9
    |
 LL |         aa: 20,
    |         ^^ unknown field
@@ -31,7 +31,7 @@ LL +         a: 20,
    |
 
 error[E0560]: struct `A` has no field named `bb`
-  --> $DIR/suggest-private-fields.rs:24:9
+  --> $DIR/suggest-private-fields.rs:25:9
    |
 LL |         bb: 20,
    |         ^^ unknown field

--- a/tests/ui/suggestions/auxiliary/generics_other_crate.rs
+++ b/tests/ui/suggestions/auxiliary/generics_other_crate.rs
@@ -1,4 +1,6 @@
 //! This file is used to test suggestions for generics in other crates.
 
+#![allow(unused_unconstructable_pub_structs)]
+
 pub struct External;
 pub struct ExternalGeneric<T>(T);

--- a/tests/ui/suggestions/derive-clone-for-eq.fixed
+++ b/tests/ui/suggestions/derive-clone-for-eq.fixed
@@ -1,4 +1,5 @@
 //@ run-rustfix
+#![allow(unused_unconstructable_pub_structs)]
 // https://github.com/rust-lang/rust/issues/79076
 
 #[derive(Clone, Eq)]

--- a/tests/ui/suggestions/derive-clone-for-eq.rs
+++ b/tests/ui/suggestions/derive-clone-for-eq.rs
@@ -1,4 +1,5 @@
 //@ run-rustfix
+#![allow(unused_unconstructable_pub_structs)]
 // https://github.com/rust-lang/rust/issues/79076
 
 #[derive(Clone, Eq)]

--- a/tests/ui/suggestions/derive-clone-for-eq.stderr
+++ b/tests/ui/suggestions/derive-clone-for-eq.stderr
@@ -1,5 +1,5 @@
 error[E0277]: the trait bound `T: Clone` is not satisfied
-  --> $DIR/derive-clone-for-eq.rs:5:12
+  --> $DIR/derive-clone-for-eq.rs:6:12
    |
 LL | #[derive(Clone, Eq)]
    |                 -- in this derive macro expansion
@@ -7,7 +7,7 @@ LL | pub struct Struct<T>(T);
    |            ^^^^^^ the trait `Clone` is not implemented for `T`
    |
 note: required for `Struct<T>` to implement `PartialEq`
-  --> $DIR/derive-clone-for-eq.rs:7:19
+  --> $DIR/derive-clone-for-eq.rs:8:19
    |
 LL | impl<T: Clone, U> PartialEq<U> for Struct<T>
    |         -----     ^^^^^^^^^^^^     ^^^^^^^^^

--- a/tests/ui/suggestions/option-content-move.fixed
+++ b/tests/ui/suggestions/option-content-move.fixed
@@ -1,4 +1,5 @@
 //@ run-rustfix
+#![allow(unused_unconstructable_pub_structs)]
 pub struct LipogramCorpora {
     selections: Vec<(char, Option<String>)>,
 }

--- a/tests/ui/suggestions/option-content-move.rs
+++ b/tests/ui/suggestions/option-content-move.rs
@@ -1,4 +1,5 @@
 //@ run-rustfix
+#![allow(unused_unconstructable_pub_structs)]
 pub struct LipogramCorpora {
     selections: Vec<(char, Option<String>)>,
 }

--- a/tests/ui/suggestions/option-content-move.stderr
+++ b/tests/ui/suggestions/option-content-move.stderr
@@ -1,5 +1,5 @@
 error[E0507]: cannot move out of `selection.1` which is behind a shared reference
-  --> $DIR/option-content-move.rs:10:20
+  --> $DIR/option-content-move.rs:11:20
    |
 LL |                 if selection.1.unwrap().contains(selection.0) {
    |                    ^^^^^^^^^^^ -------- `selection.1` moved due to this method call
@@ -22,7 +22,7 @@ LL |                 if selection.1.clone().unwrap().contains(selection.0) {
    |                               ++++++++
 
 error[E0507]: cannot move out of `selection.1` which is behind a shared reference
-  --> $DIR/option-content-move.rs:28:20
+  --> $DIR/option-content-move.rs:29:20
    |
 LL |                 if selection.1.unwrap().contains(selection.0) {
    |                    ^^^^^^^^^^^ -------- `selection.1` moved due to this method call

--- a/tests/ui/traits/issue-4107.rs
+++ b/tests/ui/traits/issue-4107.rs
@@ -1,5 +1,6 @@
 //@ run-pass
 #![allow(dead_code)]
+#![allow(unused_unconstructable_pub_structs)]
 
 pub fn main() {
     let _id: &Mat2<f64> = &Matrix::identity(1.0);

--- a/tests/ui/traits/object/generics.rs
+++ b/tests/ui/traits/object/generics.rs
@@ -1,4 +1,5 @@
 //@ run-pass
+#![allow(unused_unconstructable_pub_structs)]
 // test for #8664
 
 use std::marker;

--- a/tests/ui/traits/where-clause-vs-impl.rs
+++ b/tests/ui/traits/where-clause-vs-impl.rs
@@ -1,6 +1,7 @@
 //@ run-pass
 #![allow(dead_code)]
 #![allow(unused_variables)]
+#![allow(unused_unconstructable_pub_structs)]
 // Test that when there is a conditional (but blanket) impl and a
 // where clause, we don't get confused in trait resolution.
 //

--- a/tests/ui/type-alias-impl-trait/auxiliary/drop-shim-relates-opaque-aux.rs
+++ b/tests/ui/type-alias-impl-trait/auxiliary/drop-shim-relates-opaque-aux.rs
@@ -1,3 +1,4 @@
+#![allow(unused_unconstructable_pub_structs)]
 // crate foo
 
 #![feature(type_alias_impl_trait)]

--- a/tests/ui/typeck/auxiliary/tdticc_coherence_lib.rs
+++ b/tests/ui/typeck/auxiliary/tdticc_coherence_lib.rs
@@ -1,5 +1,6 @@
 #![feature(auto_traits, core)]
 #![crate_type = "rlib"]
+#![allow(unused_unconstructable_pub_structs)]
 
 pub auto trait DefaultedTrait { }
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/146440)*
<!-- homu-ignore:end -->

Add a new lint `UNCONSTRUCTIBLE_PUB_STRUCTS` to detect unused unconstructable public structs, based on the following observations:

1. A public struct with private field(s) cannot be directly constructed from external crates.
2. Associated functions with a receiver require an already constructed value of type Self.
3. Therefore, public structs with private fields and their associated functions that take a receiver can be included in the local crate's dead code analysis.
4. If a public struct with private fields cannot be constructed in any reachable code path, it could be considered dead.

And, with the similar approach of the lint `dead_code_pub_in_binary`, this lint is also independent of `dead_code` and `dead_code_pub_in_binary`.