### PR TITLE
Display ?Sized, const, and lifetime parameters in trait item suggestions across a crate boundary

### DIFF
--- a/tests/ui/suggestions/apitit-unimplemented-method.rs
+++ b/tests/ui/suggestions/apitit-unimplemented-method.rs
@@ -4,9 +4,12 @@ extern crate dep;
 use dep::*;
 
 struct Local;
+
 impl Trait for Local {}
 //~^ ERROR not all trait items implemented
 //~| HELP implement the missing item: `fn foo(_: impl Sized) { todo!() }`
-//~| HELP implement the missing item: `fn bar<T>(_: impl Sized) { todo!() }`
+//~| HELP implement the missing item: `fn bar<T>(_: impl Sized) where Foo<T>: MetaSized { todo!() }`
+//~| HELP implement the missing item: `fn baz<const N: usize>() { todo!() }`
+//~| HELP implement the missing item: `fn quux<'a: 'b, 'b, T>() where T: ?Sized { todo!() }`
 
 fn main() {}

--- a/tests/ui/suggestions/apitit-unimplemented-method.stderr
+++ b/tests/ui/suggestions/apitit-unimplemented-method.stderr
@@ -1,11 +1,13 @@
-error[E0046]: not all trait items implemented, missing: `foo`, `bar`
-  --> $DIR/apitit-unimplemented-method.rs:7:1
+error[E0046]: not all trait items implemented, missing: `foo`, `bar`, `baz`, `quux`
+  --> $DIR/apitit-unimplemented-method.rs:8:1
    |
 LL | impl Trait for Local {}
-   | ^^^^^^^^^^^^^^^^^^^^ missing `foo`, `bar` in implementation
+   | ^^^^^^^^^^^^^^^^^^^^ missing `foo`, `bar`, `baz`, `quux` in implementation
    |
    = help: implement the missing item: `fn foo(_: impl Sized) { todo!() }`
-   = help: implement the missing item: `fn bar<T>(_: impl Sized) { todo!() }`
+   = help: implement the missing item: `fn bar<T>(_: impl Sized) where Foo<T>: MetaSized { todo!() }`
+   = help: implement the missing item: `fn baz<const N: usize>() { todo!() }`
+   = help: implement the missing item: `fn quux<'a: 'b, 'b, T>() where T: ?Sized { todo!() }`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/suggestions/auxiliary/dep.rs
+++ b/tests/ui/suggestions/auxiliary/dep.rs
@@ -1,4 +1,16 @@
+#![feature(sized_hierarchy)]
+
+use std::marker::MetaSized;
+
+pub struct Foo<T> {
+    inner: T,
+}
+
 pub trait Trait {
     fn foo(_: impl Sized);
-    fn bar<T>(_: impl Sized);
+    fn bar<T>(_: impl Sized)
+    where
+        Foo<T>: MetaSized;
+    fn baz<'a, const N: usize>();
+    fn quux<'a: 'b, 'b, T: ?Sized>();
 }


### PR DESCRIPTION
context: rust-lang/rust#145929

This fixes the MetaSized issue and adds const generics and early bound lifetimes. Late bound lifetimes are harder because they aren't returned by `generics_of`. I'm going to look into it, but there's no guarantee I'll be successful.

Fixes https://github.com/rust-lang/rust/issues/146404.

r? @BoxyUwu
