### PR TITLE
[beta] Backport "Less greedily parse `[const]` bounds"

### DIFF
--- a/compiler/rustc_parse/src/parser/ty.rs
+++ b/compiler/rustc_parse/src/parser/ty.rs
@@ -951,10 +951,16 @@ impl<'a> Parser<'a> {
             || self.check(exp!(Tilde))
             || self.check_keyword(exp!(For))
             || self.check(exp!(OpenParen))
-            || self.check(exp!(OpenBracket))
+            || self.can_begin_maybe_const_bound()
             || self.check_keyword(exp!(Const))
             || self.check_keyword(exp!(Async))
             || self.check_keyword(exp!(Use))
+    }
+
+    fn can_begin_maybe_const_bound(&mut self) -> bool {
+        self.check(exp!(OpenBracket))
+            && self.look_ahead(1, |t| t.is_keyword(kw::Const))
+            && self.look_ahead(2, |t| *t == token::CloseBracket)
     }
 
     /// Parses a bound according to the grammar:
@@ -1137,10 +1143,7 @@ impl<'a> Parser<'a> {
             let span = tilde.to(self.prev_token.span);
             self.psess.gated_spans.gate(sym::const_trait_impl, span);
             BoundConstness::Maybe(span)
-        } else if self.check(exp!(OpenBracket))
-            && self.look_ahead(1, |t| t.is_keyword(kw::Const))
-            && self.look_ahead(2, |t| *t == token::CloseBracket)
-        {
+        } else if self.can_begin_maybe_const_bound() {
             let start = self.token.span;
             self.bump();
             self.expect_keyword(exp!(Const)).unwrap();

--- a/tests/ui/traits/const-traits/macro-maybe-const-trait-bounds.rs
+++ b/tests/ui/traits/const-traits/macro-maybe-const-trait-bounds.rs
@@ -1,0 +1,25 @@
+// Ensure that we don't consider `[` to begin trait bounds to contain breakages.
+// Only `[const]` in its entirety begins a trait bound.
+// See also test `macro-const-trait-bound-theoretical-regression.rs`.
+
+//@ check-pass (KEEP THIS AS A PASSING TEST!)
+// Setting the edition to >2015 since we didn't regress `check! { dyn [const] Trait }` in Rust 2015.
+// See also test `traits/const-traits/macro-dyn-const-2015.rs`.
+//@ edition:2018
+
+macro_rules! check {
+    ($ty:ty) => { compile_error!("ty"); }; // KEEP THIS RULE FIRST AND AS IS!
+
+    // DON'T MODIFY THE MATCHERS BELOW UNLESS THE CONST TRAIT MODIFIER SYNTAX CHANGES!
+
+    (dyn [$($any:tt)*] Trait) => { /* KEEP THIS EMPTY! */ };
+    (impl [$($any:tt)*] Trait) => { /* KEEP THIS EMPTY! */ };
+}
+
+check!(dyn [T] Trait);
+
+// issue: <https://github.com/rust-lang/rust/issues/146417>
+check!(impl [T] Trait);
+check!(impl [T: Bound] Trait);
+
+fn main() {}


### PR DESCRIPTION
Backport of rust-lang/rust#146422.
Following https://forge.rust-lang.org/release/backporting.html#beta-backporting-in-rust-langrust.

Not part of some hypothetical future backport rollup because we're under time pressure as release procedures will commence very soon: https://forge.rust-lang.org/#current-release-versions, https://forge.rust-lang.org/release/process.html.

cc @cuviper