### PR TITLE
test: remove an outdated normalization for rustc versions

### DIFF
--- a/tests/ui/feature-gates/feature-gate-sanitize.rs
+++ b/tests/ui/feature-gates/feature-gate-sanitize.rs
@@ -1,4 +1,3 @@
-//@ normalize-stderr: "you are using [0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?( \([^)]*\))?" -> "you are using $$RUSTC_VERSION"
 #![feature(no_sanitize)] //~ ERROR feature has been removed
 
 #[sanitize(address = "on")]

--- a/tests/ui/feature-gates/feature-gate-sanitize.stderr
+++ b/tests/ui/feature-gates/feature-gate-sanitize.stderr
@@ -1,5 +1,5 @@
 error[E0557]: feature has been removed
-  --> $DIR/feature-gate-sanitize.rs:2:12
+  --> $DIR/feature-gate-sanitize.rs:1:12
    |
 LL | #![feature(no_sanitize)]
    |            ^^^^^^^^^^^ feature has been removed
@@ -8,7 +8,7 @@ LL | #![feature(no_sanitize)]
    = note: renamed to sanitize(xyz = "on|off")
 
 error[E0658]: the `#[sanitize]` attribute is an experimental feature
-  --> $DIR/feature-gate-sanitize.rs:4:1
+  --> $DIR/feature-gate-sanitize.rs:3:1
    |
 LL | #[sanitize(address = "on")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
These "you are using $RUSTC_VERSION" help messages were removed in
rust-lang/rust#142943, but rust-lang/rust#142681 started before that and
merged later, so its normalization is vestigial.
