### PR TITLE
Fix panic and incorrectly suggested examples in `format_args` macro.

### DIFF
--- a/tests/ui/suggestions/missing-format-specifiers-issue-68293.rs
+++ b/tests/ui/suggestions/missing-format-specifiers-issue-68293.rs
@@ -32,4 +32,33 @@ fn missing_format_specifiers_multiple_unused_args() {
     //~| NOTE consider adding 2 format specifiers
 }
 
+fn unicode_unused_args() {
+    panic!("👆", "👆", 1);
+    //~^ ERROR multiple unused formatting arguments
+    //~| NOTE multiple missing formatting specifiers
+    //~| NOTE argument never used
+    //~| NOTE argument never used
+    //~| HELP format specifiers use curly braces, consider adding 2 format specifiers
+}
+
+fn raw_str_unused_arg() {
+    format_args!(r##"lJ𐏿Æ�.𐏿�"##, r#"r}J𐏿Æ" {}"#, 1);
+    //~^ ERROR multiple unused formatting arguments
+    //~| NOTE multiple missing formatting specifiers
+    //~| NOTE argument never used
+    //~| NOTE argument never used
+    //~| HELP format specifiers use curly braces, consider adding 2 format specifiers
+}
+
+fn valid_new_lines_unused_args() {
+    panic!("Expect 2 newlines
+
+", "👆", 1);
+    //~^ ERROR multiple unused formatting arguments
+    //~| NOTE argument never used
+    //~| NOTE argument never used
+    //~^^^^^^ NOTE multiple missing formatting specifiers
+    //~| HELP format specifiers use curly braces, consider adding 2 format specifiers
+}
+
 fn main() { }

--- a/tests/ui/suggestions/missing-format-specifiers-issue-68293.stderr
+++ b/tests/ui/suggestions/missing-format-specifiers-issue-68293.stderr
@@ -45,5 +45,52 @@ LL |     println!("list: {}", 1, 2, 3);
    |
    = note: consider adding 2 format specifiers
 
-error: aborting due to 4 previous errors
+error: multiple unused formatting arguments
+  --> $DIR/missing-format-specifiers-issue-68293.rs:36:17
+   |
+LL |     panic!("👆", "👆", 1);
+   |            ----  ^^^^  ^ argument never used
+   |            |     |
+   |            |     argument never used
+   |            multiple missing formatting specifiers
+   |
+help: format specifiers use curly braces, consider adding 2 format specifiers
+   |
+LL |     panic!("👆{}{}", "👆", 1);
+   |               ++++
+
+error: multiple unused formatting arguments
+  --> $DIR/missing-format-specifiers-issue-68293.rs:45:35
+   |
+LL |     format_args!(r##"lJ𐏿Æ�.𐏿�"##, r#"r}J𐏿Æ" {}"#, 1);
+   |                  ---------------  ^^^^^^^^^^^^^^  ^ argument never used
+   |                  |                |
+   |                  |                argument never used
+   |                  multiple missing formatting specifiers
+   |
+help: format specifiers use curly braces, consider adding 2 format specifiers
+   |
+LL |     format_args!(r##"lJ𐏿Æ�.𐏿�{}{}"##, r#"r}J𐏿Æ" {}"#, 1);
+   |                              ++++
+
+error: multiple unused formatting arguments
+  --> $DIR/missing-format-specifiers-issue-68293.rs:56:4
+   |
+LL |       panic!("Expect 2 newlines
+   |  ____________-
+LL | |
+LL | | ", "👆", 1);
+   | | -  ^^^^  ^ argument never used
+   | | |  |
+   | |_|  argument never used
+   |   multiple missing formatting specifiers
+   |
+help: format specifiers use curly braces, consider adding 2 format specifiers
+   |
+LL |     panic!("Expect 2 newlines
+LL |
+LL ~ {}{}", "👆", 1);
+   |
+
+error: aborting due to 7 previous errors
 


### PR DESCRIPTION
Follow up on rust-lang/rust#146123
Fixes: rust-lang/rust#146446
r? @estebank