### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_attr_parsing/src/attributes/crate_level.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/crate_level.rs
@@ -176,3 +176,15 @@ impl<S: Stage> SingleAttributeParser<S> for PatternComplexityLimitParser {
         })
     }
 }
+
+pub(crate) struct NoCoreParser;
+
+impl<S: Stage> NoArgsAttributeParser<S> for NoCoreParser {
+    const PATH: &[Symbol] = &[sym::no_core];
+    const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Warn;
+    // FIXME: recursion limit is allowed on all targets and ignored,
+    //        even though it should only be valid on crates of course
+    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(ALL_TARGETS);
+    const CREATE: fn(Span) -> AttributeKind = AttributeKind::NoCore;
+    const TYPE: AttributeType = AttributeType::CrateLevel;
+}

--- a/compiler/rustc_attr_parsing/src/attributes/crate_level.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/crate_level.rs
@@ -182,19 +182,20 @@ pub(crate) struct NoCoreParser;
 impl<S: Stage> NoArgsAttributeParser<S> for NoCoreParser {
     const PATH: &[Symbol] = &[sym::no_core];
     const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Warn;
-    // FIXME: recursion limit is allowed on all targets and ignored,
-    //        even though it should only be valid on crates of course
+    // because it's a crate-level attribute, we already warn about it.
+    // Putting target limitations here would give duplicate warnings
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(ALL_TARGETS);
     const CREATE: fn(Span) -> AttributeKind = AttributeKind::NoCore;
     const TYPE: AttributeType = AttributeType::CrateLevel;
 }
 
 pub(crate) struct NoStdParser;
+
 impl<S: Stage> NoArgsAttributeParser<S> for NoStdParser {
     const PATH: &[Symbol] = &[sym::no_std];
     const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Warn;
-    // FIXME: recursion limit is allowed on all targets and ignored,
-    //        even though it should only be valid on crates of course
+    // because it's a crate-level attribute, we already warn about it.
+    // Putting target limitations here would give duplicate warnings
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(ALL_TARGETS);
     const CREATE: fn(Span) -> AttributeKind = AttributeKind::NoStd;
     const TYPE: AttributeType = AttributeType::CrateLevel;

--- a/compiler/rustc_attr_parsing/src/attributes/crate_level.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/crate_level.rs
@@ -188,3 +188,14 @@ impl<S: Stage> NoArgsAttributeParser<S> for NoCoreParser {
     const CREATE: fn(Span) -> AttributeKind = AttributeKind::NoCore;
     const TYPE: AttributeType = AttributeType::CrateLevel;
 }
+
+pub(crate) struct NoStdParser;
+impl<S: Stage> NoArgsAttributeParser<S> for NoStdParser {
+    const PATH: &[Symbol] = &[sym::no_std];
+    const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Warn;
+    // FIXME: recursion limit is allowed on all targets and ignored,
+    //        even though it should only be valid on crates of course
+    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(ALL_TARGETS);
+    const CREATE: fn(Span) -> AttributeKind = AttributeKind::NoStd;
+    const TYPE: AttributeType = AttributeType::CrateLevel;
+}

--- a/compiler/rustc_attr_parsing/src/context.rs
+++ b/compiler/rustc_attr_parsing/src/context.rs
@@ -25,8 +25,8 @@ use crate::attributes::codegen_attrs::{
 };
 use crate::attributes::confusables::ConfusablesParser;
 use crate::attributes::crate_level::{
-    CrateNameParser, MoveSizeLimitParser, PatternComplexityLimitParser, RecursionLimitParser,
-    TypeLengthLimitParser,
+    CrateNameParser, MoveSizeLimitParser, NoCoreParser, PatternComplexityLimitParser,
+    RecursionLimitParser, TypeLengthLimitParser,
 };
 use crate::attributes::deprecation::DeprecationParser;
 use crate::attributes::dummy::DummyParser;
@@ -222,6 +222,7 @@ attribute_parsers!(
         Single<WithoutArgs<MacroEscapeParser>>,
         Single<WithoutArgs<MarkerParser>>,
         Single<WithoutArgs<MayDangleParser>>,
+        Single<WithoutArgs<NoCoreParser>>,
         Single<WithoutArgs<NoImplicitPreludeParser>>,
         Single<WithoutArgs<NoMangleParser>>,
         Single<WithoutArgs<NonExhaustiveParser>>,

--- a/compiler/rustc_attr_parsing/src/context.rs
+++ b/compiler/rustc_attr_parsing/src/context.rs
@@ -25,7 +25,7 @@ use crate::attributes::codegen_attrs::{
 };
 use crate::attributes::confusables::ConfusablesParser;
 use crate::attributes::crate_level::{
-    CrateNameParser, MoveSizeLimitParser, NoCoreParser, PatternComplexityLimitParser,
+    CrateNameParser, MoveSizeLimitParser, NoCoreParser, NoStdParser, PatternComplexityLimitParser,
     RecursionLimitParser, TypeLengthLimitParser,
 };
 use crate::attributes::deprecation::DeprecationParser;
@@ -225,6 +225,7 @@ attribute_parsers!(
         Single<WithoutArgs<NoCoreParser>>,
         Single<WithoutArgs<NoImplicitPreludeParser>>,
         Single<WithoutArgs<NoMangleParser>>,
+        Single<WithoutArgs<NoStdParser>>,
         Single<WithoutArgs<NonExhaustiveParser>>,
         Single<WithoutArgs<ParenSugarParser>>,
         Single<WithoutArgs<PassByValueParser>>,

--- a/compiler/rustc_hir/src/attrs/data_structures.rs
+++ b/compiler/rustc_hir/src/attrs/data_structures.rs
@@ -579,6 +579,9 @@ pub enum AttributeKind {
     /// Represents `#[naked]`
     Naked(Span),
 
+    /// Represents `#[no_core]`
+    NoCore(Span),
+
     /// Represents `#[no_implicit_prelude]`
     NoImplicitPrelude(Span),
 

--- a/compiler/rustc_hir/src/attrs/data_structures.rs
+++ b/compiler/rustc_hir/src/attrs/data_structures.rs
@@ -588,6 +588,9 @@ pub enum AttributeKind {
     /// Represents `#[no_mangle]`
     NoMangle(Span),
 
+    /// Represents `#[no_std]`
+    NoStd(Span),
+
     /// Represents `#[non_exhaustive]`
     NonExhaustive(Span),
 

--- a/compiler/rustc_hir/src/attrs/encode_cross_crate.rs
+++ b/compiler/rustc_hir/src/attrs/encode_cross_crate.rs
@@ -66,7 +66,8 @@ impl AttributeKind {
             Naked(..) => No,
             NoCore(..) => No,
             NoImplicitPrelude(..) => No,
-            NoMangle(..) => Yes,      // Needed for rustdoc
+            NoMangle(..) => Yes, // Needed for rustdoc
+            NoStd(..) => No,
             NonExhaustive(..) => Yes, // Needed for rustdoc
             Optimize(..) => No,
             ParenSugar(..) => No,

--- a/compiler/rustc_hir/src/attrs/encode_cross_crate.rs
+++ b/compiler/rustc_hir/src/attrs/encode_cross_crate.rs
@@ -64,6 +64,7 @@ impl AttributeKind {
             MoveSizeLimit { .. } => No,
             MustUse { .. } => Yes,
             Naked(..) => No,
+            NoCore(..) => No,
             NoImplicitPrelude(..) => No,
             NoMangle(..) => Yes,      // Needed for rustdoc
             NonExhaustive(..) => Yes, // Needed for rustdoc

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -274,6 +274,7 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                     | AttributeKind::MoveSizeLimit { .. }
                     | AttributeKind::TypeLengthLimit { .. }
                     | AttributeKind::PatternComplexityLimit { .. }
+                    | AttributeKind::NoCore { .. }
                 ) => { /* do nothing  */ }
                 Attribute::Unparsed(attr_item) => {
                     style = Some(attr_item.style);

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -275,6 +275,7 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                     | AttributeKind::TypeLengthLimit { .. }
                     | AttributeKind::PatternComplexityLimit { .. }
                     | AttributeKind::NoCore { .. }
+                    | AttributeKind::NoStd { .. }
                 ) => { /* do nothing  */ }
                 Attribute::Unparsed(attr_item) => {
                     style = Some(attr_item.style);

--- a/library/coretests/tests/alloc.rs
+++ b/library/coretests/tests/alloc.rs
@@ -56,6 +56,30 @@ fn layout_array_edge_cases() {
 }
 
 #[test]
+fn layout_errors() {
+    let layout = Layout::new::<[u8; 2]>();
+    // Should error if the alignment is not a power of two.
+    assert!(layout.align_to(3).is_err());
+
+    // The remaining assertions ensure that the methods error on arithmetic overflow as the
+    // alignment cannot overflow `isize`.
+    let size = layout.size();
+    let size_max = isize::MAX as usize;
+    let align_max = size_max / size;
+
+    assert!(layout.align_to(size_max + 1).is_err());
+
+    assert!(layout.repeat(align_max).is_ok());
+    assert!(layout.repeat(align_max + 1).is_err());
+
+    assert!(layout.repeat_packed(align_max).is_ok());
+    assert!(layout.repeat_packed(align_max + 1).is_err());
+
+    let next = Layout::from_size_align(size_max, 1).unwrap();
+    assert!(layout.extend(next).is_err());
+}
+
+#[test]
 fn layout_debug_shows_log2_of_alignment() {
     // `Debug` is not stable, but here's what it does right now
     let layout = Layout::from_size_align(24576, 8192).unwrap();

--- a/library/coretests/tests/char.rs
+++ b/library/coretests/tests/char.rs
@@ -220,6 +220,7 @@ fn test_escape_default() {
     }
     assert_eq!(string('\n'), "\\n");
     assert_eq!(string('\r'), "\\r");
+    assert_eq!(string('\t'), "\\t");
     assert_eq!(string('\''), "\\'");
     assert_eq!(string('"'), "\\\"");
     assert_eq!(string(' '), " ");
@@ -416,4 +417,46 @@ fn eu_iterator_specializations() {
     check('\u{1234}');
     check('\u{12340}');
     check('\u{10FFFF}');
+}
+
+#[test]
+#[should_panic]
+fn test_from_digit_radix_too_high() {
+    let _ = char::from_digit(0, 37);
+}
+
+#[test]
+fn test_from_digit_invalid_radix() {
+    assert!(char::from_digit(10, 9).is_none());
+}
+
+#[test]
+#[should_panic]
+fn test_to_digit_radix_too_low() {
+    let _ = 'a'.to_digit(1);
+}
+
+#[test]
+#[should_panic]
+fn test_to_digit_radix_too_high() {
+    let _ = 'a'.to_digit(37);
+}
+
+#[test]
+fn test_as_ascii_invalid() {
+    assert!('❤'.as_ascii().is_none());
+}
+
+#[test]
+#[should_panic]
+fn test_encode_utf8_raw_buffer_too_small() {
+    let mut buf = [0u8; 1];
+    let _ = char::encode_utf8_raw('ß'.into(), &mut buf);
+}
+
+#[test]
+#[should_panic]
+fn test_encode_utf16_raw_buffer_too_small() {
+    let mut buf = [0u16; 1];
+    let _ = char::encode_utf16_raw('𐐷'.into(), &mut buf);
 }

--- a/library/coretests/tests/hash/mod.rs
+++ b/library/coretests/tests/hash/mod.rs
@@ -53,12 +53,14 @@ fn test_writer_hasher() {
     assert_eq!(hash(&5_u16), 5);
     assert_eq!(hash(&5_u32), 5);
     assert_eq!(hash(&5_u64), 5);
+    assert_eq!(hash(&5_u128), 5);
     assert_eq!(hash(&5_usize), 5);
 
     assert_eq!(hash(&5_i8), 5);
     assert_eq!(hash(&5_i16), 5);
     assert_eq!(hash(&5_i32), 5);
     assert_eq!(hash(&5_i64), 5);
+    assert_eq!(hash(&5_i128), 5);
     assert_eq!(hash(&5_isize), 5);
 
     assert_eq!(hash(&false), 0);
@@ -84,6 +86,17 @@ fn test_writer_hasher() {
 
     let ptr = ptr::without_provenance_mut::<i32>(5_usize);
     assert_eq!(hash(&ptr), 5);
+
+    // Use a newtype to test the `Hash::hash_slice` default implementation.
+    struct Byte(u8);
+
+    impl Hash for Byte {
+        fn hash<H: Hasher>(&self, state: &mut H) {
+            state.write_u8(self.0)
+        }
+    }
+
+    assert_eq!(hash(&[Byte(b'a')]), 97 + 1);
 
     if cfg!(miri) {
         // Miri cannot hash pointers

--- a/library/coretests/tests/lib.rs
+++ b/library/coretests/tests/lib.rs
@@ -13,6 +13,7 @@
 #![feature(bool_to_result)]
 #![feature(bstr)]
 #![feature(cfg_target_has_reliable_f16_f128)]
+#![feature(char_internals)]
 #![feature(char_max_len)]
 #![feature(clone_to_uninit)]
 #![feature(const_convert)]

--- a/src/tools/clippy/clippy_utils/src/lib.rs
+++ b/src/tools/clippy/clippy_utils/src/lib.rs
@@ -2133,17 +2133,11 @@ pub fn std_or_core(cx: &LateContext<'_>) -> Option<&'static str> {
 }
 
 pub fn is_no_std_crate(cx: &LateContext<'_>) -> bool {
-    cx.tcx
-        .hir_attrs(hir::CRATE_HIR_ID)
-        .iter()
-        .any(|attr| attr.has_name(sym::no_std))
+    find_attr!(cx.tcx.hir_attrs(hir::CRATE_HIR_ID), AttributeKind::NoStd(..))
 }
 
 pub fn is_no_core_crate(cx: &LateContext<'_>) -> bool {
-    cx.tcx
-        .hir_attrs(hir::CRATE_HIR_ID)
-        .iter()
-        .any(|attr| attr.has_name(sym::no_core))
+    find_attr!(cx.tcx.hir_attrs(hir::CRATE_HIR_ID), AttributeKind::NoCore(..))
 }
 
 /// Check if parent of a hir node is a trait implementation block.

--- a/tests/ui/attributes/malformed-no-std.rs
+++ b/tests/ui/attributes/malformed-no-std.rs
@@ -1,0 +1,25 @@
+#![feature(no_core)]
+// these all still apply no_std and then later error
+#![no_std = "foo"]
+//~^ ERROR malformed `no_std` attribute input
+#![no_std("bar")]
+//~^ ERROR malformed `no_std` attribute input
+#![no_std(foo = "bar")]
+//~^ ERROR malformed `no_std` attribute input
+#![no_core = "foo"]
+//~^ ERROR malformed `no_core` attribute input
+#![no_core("bar")]
+//~^ ERROR malformed `no_core` attribute input
+#![no_core(foo = "bar")]
+//~^ ERROR malformed `no_core` attribute input
+
+#[deny(unused_attributes)]
+#[no_std]
+//~^ ERROR crate-level attribute should be an inner attribute: add an exclamation mark:
+#[no_core]
+//~^ ERROR crate-level attribute should be an inner attribute: add an exclamation mark:
+// to fix compilation
+extern crate core;
+extern crate std;
+
+fn main() {}

--- a/tests/ui/attributes/malformed-no-std.stderr
+++ b/tests/ui/attributes/malformed-no-std.stderr
@@ -1,0 +1,86 @@
+error[E0565]: malformed `no_std` attribute input
+  --> $DIR/malformed-no-std.rs:3:1
+   |
+LL | #![no_std = "foo"]
+   | ^^^^^^^^^^-------^
+   | |         |
+   | |         didn't expect any arguments here
+   | help: must be of the form: `#![no_std]`
+
+error[E0565]: malformed `no_std` attribute input
+  --> $DIR/malformed-no-std.rs:5:1
+   |
+LL | #![no_std("bar")]
+   | ^^^^^^^^^-------^
+   | |        |
+   | |        didn't expect any arguments here
+   | help: must be of the form: `#![no_std]`
+
+error[E0565]: malformed `no_std` attribute input
+  --> $DIR/malformed-no-std.rs:7:1
+   |
+LL | #![no_std(foo = "bar")]
+   | ^^^^^^^^^-------------^
+   | |        |
+   | |        didn't expect any arguments here
+   | help: must be of the form: `#![no_std]`
+
+error[E0565]: malformed `no_core` attribute input
+  --> $DIR/malformed-no-std.rs:9:1
+   |
+LL | #![no_core = "foo"]
+   | ^^^^^^^^^^^-------^
+   | |          |
+   | |          didn't expect any arguments here
+   | help: must be of the form: `#![no_core]`
+
+error[E0565]: malformed `no_core` attribute input
+  --> $DIR/malformed-no-std.rs:11:1
+   |
+LL | #![no_core("bar")]
+   | ^^^^^^^^^^-------^
+   | |         |
+   | |         didn't expect any arguments here
+   | help: must be of the form: `#![no_core]`
+
+error[E0565]: malformed `no_core` attribute input
+  --> $DIR/malformed-no-std.rs:13:1
+   |
+LL | #![no_core(foo = "bar")]
+   | ^^^^^^^^^^-------------^
+   | |         |
+   | |         didn't expect any arguments here
+   | help: must be of the form: `#![no_core]`
+
+error: crate-level attribute should be an inner attribute: add an exclamation mark: `#![no_std]`
+  --> $DIR/malformed-no-std.rs:17:1
+   |
+LL | #[no_std]
+   | ^^^^^^^^^
+   |
+note: This attribute does not have an `!`, which means it is applied to this extern crate
+  --> $DIR/malformed-no-std.rs:22:1
+   |
+LL | extern crate core;
+   | ^^^^^^^^^^^^^^^^^^
+note: the lint level is defined here
+  --> $DIR/malformed-no-std.rs:16:8
+   |
+LL | #[deny(unused_attributes)]
+   |        ^^^^^^^^^^^^^^^^^
+
+error: crate-level attribute should be an inner attribute: add an exclamation mark: `#![no_core]`
+  --> $DIR/malformed-no-std.rs:19:1
+   |
+LL | #[no_core]
+   | ^^^^^^^^^^
+   |
+note: This attribute does not have an `!`, which means it is applied to this extern crate
+  --> $DIR/malformed-no-std.rs:22:1
+   |
+LL | extern crate core;
+   | ^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 8 previous errors
+
+For more information about this error, try `rustc --explain E0565`.

--- a/tests/ui/consts/missing-larger-array-impl.stderr
+++ b/tests/ui/consts/missing-larger-array-impl.stderr
@@ -8,11 +8,11 @@ LL |     <[X; 35] as Default>::default();
              &[T]
              &mut [T]
              [T; 0]
-             [T; 10]
-             [T; 11]
-             [T; 12]
-             [T; 13]
-             [T; 14]
+             [T; 1]
+             [T; 2]
+             [T; 3]
+             [T; 4]
+             [T; 5]
            and 27 others
 
 error: aborting due to 1 previous error

--- a/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs.rs
+++ b/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs.rs
@@ -539,26 +539,26 @@ mod macro_escape {
 
 #[no_std]
 //~^ WARN crate-level attribute should be an inner attribute
-//~| HELP add a `!`
 mod no_std {
+    //~^ NOTE This attribute does not have an `!`, which means it is applied to this module
     mod inner { #![no_std] }
-//~^ WARN crate-level attribute should be in the root module
+//~^ WARN the `#![no_std]` attribute can only be used at the crate root
 
     #[no_std] fn f() { }
     //~^ WARN crate-level attribute should be an inner attribute
-    //~| HELP add a `!`
+    //~| NOTE This attribute does not have an `!`, which means it is applied to this function
 
     #[no_std] struct S;
     //~^ WARN crate-level attribute should be an inner attribute
-    //~| HELP add a `!`
+    //~| NOTE This attribute does not have an `!`, which means it is applied to this struct
 
     #[no_std] type T = S;
     //~^ WARN crate-level attribute should be an inner attribute
-    //~| HELP add a `!`
+    //~| NOTE This attribute does not have an `!`, which means it is applied to this type alias
 
     #[no_std] impl S { }
     //~^ WARN crate-level attribute should be an inner attribute
-    //~| HELP add a `!`
+    //~| NOTE This attribute does not have an `!`, which means it is applied to this implementation block
 }
 
 // At time of authorship, #[proc_macro_derive = "2500"] signals error

--- a/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs.stderr
+++ b/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs.stderr
@@ -209,17 +209,6 @@ help: add a `!`
 LL | #![reexport_test_harness_main = "2900"]
    |  +
 
-warning: crate-level attribute should be an inner attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:540:1
-   |
-LL | #[no_std]
-   | ^^^^^^^^^
-   |
-help: add a `!`
-   |
-LL | #![no_std]
-   |  +
-
 warning: attribute should be applied to an `extern` block with non-Rust ABI
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:695:1
    |
@@ -385,56 +374,6 @@ LL |     #[reexport_test_harness_main = "2900"] impl S { }
 help: add a `!`
    |
 LL |     #![reexport_test_harness_main = "2900"] impl S { }
-   |      +
-
-warning: crate-level attribute should be in the root module
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:544:17
-   |
-LL |     mod inner { #![no_std] }
-   |                 ^^^^^^^^^^
-
-warning: crate-level attribute should be an inner attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:547:5
-   |
-LL |     #[no_std] fn f() { }
-   |     ^^^^^^^^^
-   |
-help: add a `!`
-   |
-LL |     #![no_std] fn f() { }
-   |      +
-
-warning: crate-level attribute should be an inner attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:551:5
-   |
-LL |     #[no_std] struct S;
-   |     ^^^^^^^^^
-   |
-help: add a `!`
-   |
-LL |     #![no_std] struct S;
-   |      +
-
-warning: crate-level attribute should be an inner attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:555:5
-   |
-LL |     #[no_std] type T = S;
-   |     ^^^^^^^^^
-   |
-help: add a `!`
-   |
-LL |     #![no_std] type T = S;
-   |      +
-
-warning: crate-level attribute should be an inner attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:559:5
-   |
-LL |     #[no_std] impl S { }
-   |     ^^^^^^^^^
-   |
-help: add a `!`
-   |
-LL |     #![no_std] impl S { }
    |      +
 
 warning: attribute should be applied to an `extern` block with non-Rust ABI
@@ -1094,6 +1033,76 @@ LL |     #[macro_escape] impl S { }
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = help: `#[macro_escape]` can be applied to modules, extern crates, and crates
+
+warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![no_std]`
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:540:1
+   |
+LL | #[no_std]
+   | ^^^^^^^^^
+   |
+note: This attribute does not have an `!`, which means it is applied to this module
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:542:1
+   |
+LL | / mod no_std {
+LL | |
+LL | |     mod inner { #![no_std] }
+...  |
+LL | | }
+   | |_^
+
+warning: the `#![no_std]` attribute can only be used at the crate root
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:544:17
+   |
+LL |     mod inner { #![no_std] }
+   |                 ^^^^^^^^^^
+
+warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![no_std]`
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:547:5
+   |
+LL |     #[no_std] fn f() { }
+   |     ^^^^^^^^^
+   |
+note: This attribute does not have an `!`, which means it is applied to this function
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:547:15
+   |
+LL |     #[no_std] fn f() { }
+   |               ^^^^^^^^^^
+
+warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![no_std]`
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:551:5
+   |
+LL |     #[no_std] struct S;
+   |     ^^^^^^^^^
+   |
+note: This attribute does not have an `!`, which means it is applied to this struct
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:551:15
+   |
+LL |     #[no_std] struct S;
+   |               ^^^^^^^^^
+
+warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![no_std]`
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:555:5
+   |
+LL |     #[no_std] type T = S;
+   |     ^^^^^^^^^
+   |
+note: This attribute does not have an `!`, which means it is applied to this type alias
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:555:15
+   |
+LL |     #[no_std] type T = S;
+   |               ^^^^^^^^^^^
+
+warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![no_std]`
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:559:5
+   |
+LL |     #[no_std] impl S { }
+   |     ^^^^^^^^^
+   |
+note: This attribute does not have an `!`, which means it is applied to this implementation block
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:559:15
+   |
+LL |     #[no_std] impl S { }
+   |               ^^^^^^^^^^
 
 warning: `#[cold]` attribute cannot be used on modules
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:581:1

--- a/tests/ui/lint/unused/unused-attr-duplicate.stderr
+++ b/tests/ui/lint/unused/unused-attr-duplicate.stderr
@@ -29,18 +29,6 @@ LL | #[no_link]
    | ^^^^^^^^^^
 
 error: unused attribute
-  --> $DIR/unused-attr-duplicate.rs:27:1
-   |
-LL | #![no_std]
-   | ^^^^^^^^^^ help: remove this attribute
-   |
-note: attribute also specified here
-  --> $DIR/unused-attr-duplicate.rs:26:1
-   |
-LL | #![no_std]
-   | ^^^^^^^^^^
-
-error: unused attribute
   --> $DIR/unused-attr-duplicate.rs:31:1
    |
 LL | #![windows_subsystem = "windows"]
@@ -303,6 +291,18 @@ note: attribute also specified here
 LL | #![type_length_limit = "1048576"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+
+error: unused attribute
+  --> $DIR/unused-attr-duplicate.rs:27:1
+   |
+LL | #![no_std]
+   | ^^^^^^^^^^ help: remove this attribute
+   |
+note: attribute also specified here
+  --> $DIR/unused-attr-duplicate.rs:26:1
+   |
+LL | #![no_std]
+   | ^^^^^^^^^^
 
 error: unused attribute
   --> $DIR/unused-attr-duplicate.rs:29:1

--- a/tests/ui/suggestions/issue-71394-no-from-impl.stderr
+++ b/tests/ui/suggestions/issue-71394-no-from-impl.stderr
@@ -5,14 +5,14 @@ LL |     let _: &[i8] = data.into();
    |                         ^^^^ the trait `From<&[u8]>` is not implemented for `&[i8]`
    |
    = help: the following other types implement trait `From<T>`:
-             `[T; 10]` implements `From<(T, T, T, T, T, T, T, T, T, T)>`
-             `[T; 11]` implements `From<(T, T, T, T, T, T, T, T, T, T, T)>`
-             `[T; 12]` implements `From<(T, T, T, T, T, T, T, T, T, T, T, T)>`
              `[T; 1]` implements `From<(T,)>`
              `[T; 2]` implements `From<(T, T)>`
              `[T; 3]` implements `From<(T, T, T)>`
              `[T; 4]` implements `From<(T, T, T, T)>`
              `[T; 5]` implements `From<(T, T, T, T, T)>`
+             `[T; 6]` implements `From<(T, T, T, T, T, T)>`
+             `[T; 7]` implements `From<(T, T, T, T, T, T, T)>`
+             `[T; 8]` implements `From<(T, T, T, T, T, T, T, T)>`
            and 6 others
    = note: required for `&[u8]` to implement `Into<&[i8]>`
 

--- a/tests/ui/unpretty/exhaustive.hir.stdout
+++ b/tests/ui/unpretty/exhaustive.hir.stdout
@@ -55,7 +55,7 @@ use self::prelude::*;
      */
 #[doc = "inner doc attribute"]
 #[allow(dead_code, unused_variables)]
-#[no_std]
+#[attr = NoStd]
 mod attributes {
 
     /// outer single-line doc comment


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#146389 (Convert `no_std` and `no_core` to the new attribute infrastructure)
 - rust-lang/rust#146403 (sort array trait implementation suggestions correctly)
 - rust-lang/rust#146452 (Improve `alloc::Layout` coverage)
 - rust-lang/rust#146477 (Improve `core::char` coverage)
 - rust-lang/rust#146481 (Improve `core::hash` coverage)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=146389,146403,146452,146477,146481)
<!-- homu-ignore:end -->