### PR TITLE
test: resolve glob of prelude trait

### DIFF
--- a/tests/ui/imports/use-glob-for-trait.rs
+++ b/tests/ui/imports/use-glob-for-trait.rs
@@ -1,0 +1,9 @@
+//@ edition: 2024
+//@ check-pass
+
+#![feature(prelude_import)]
+
+#[prelude_import]
+use Eq::*;
+
+fn main() {}


### PR DESCRIPTION
Close rust-lang/rust#144242 

I noticed that this ICE disappeared when I attempted to investigate it further, so add this into test.

cc @petrochenkov 