### PR TITLE
Re-enable assertions on macOS alt builds

### DIFF
--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -431,9 +431,6 @@ auto:
       MACOSX_DEPLOYMENT_TARGET: 10.12
       MACOSX_STD_DEPLOYMENT_TARGET: 10.12
       SELECT_XCODE: /Applications/Xcode_15.2.app
-      NO_LLVM_ASSERTIONS: 1
-      NO_DEBUG_ASSERTIONS: 1
-      NO_OVERFLOW_CHECKS: 1
       DIST_REQUIRE_ALL_TOOLS: 1
       CODEGEN_BACKENDS: llvm,cranelift
     <<: *job-macos
@@ -449,9 +446,6 @@ auto:
       MACOSX_DEPLOYMENT_TARGET: 10.12
       MACOSX_STD_DEPLOYMENT_TARGET: 10.12
       SELECT_XCODE: /Applications/Xcode_15.2.app
-      NO_LLVM_ASSERTIONS: 1
-      NO_DEBUG_ASSERTIONS: 1
-      NO_OVERFLOW_CHECKS: 1
     <<: *job-macos
 
   - name: dist-aarch64-apple
@@ -471,9 +465,6 @@ auto:
       # supports the hardware.
       MACOSX_DEPLOYMENT_TARGET: 11.0
       MACOSX_STD_DEPLOYMENT_TARGET: 11.0
-      NO_LLVM_ASSERTIONS: 1
-      NO_DEBUG_ASSERTIONS: 1
-      NO_OVERFLOW_CHECKS: 1
       DIST_REQUIRE_ALL_TOOLS: 1
       CODEGEN_BACKENDS: llvm,cranelift
     <<: *job-macos
@@ -493,9 +484,6 @@ auto:
       # supports the hardware, so only need to test it there.
       MACOSX_DEPLOYMENT_TARGET: 11.0
       MACOSX_STD_DEPLOYMENT_TARGET: 11.0
-      NO_LLVM_ASSERTIONS: 1
-      NO_DEBUG_ASSERTIONS: 1
-      NO_OVERFLOW_CHECKS: 1
     <<: *job-macos
 
   ######################

--- a/tests/crashes/120175.rs
+++ b/tests/crashes/120175.rs
@@ -1,5 +1,6 @@
 //@ known-bug: #120175
 //@ needs-rustc-debug-assertions
+//@ ignore-apple (raw-dylib doesn't work on Apple targets yet)
 
 #![feature(extern_types)]
 #![feature(raw_dylib_elf)]


### PR DESCRIPTION
These were previously disabled, in part for performance reasons, in part due to needing availability symbols `__isPlatformVersionAtLeast` and `__isOSVersionAtLeast` that `compiler-builtins` did not provide, see https://github.com/rust-lang/rust/pull/62592#issuecomment-510670657 and https://github.com/rust-lang/rust/pull/134275#issuecomment-2543067830 for failed checks.

Since https://github.com/rust-lang/rust/pull/138944 though, `std` now provides these symbols, so we should be able to re-enable LLVM assertions, debug assertions and overflow checks.

Fixes https://github.com/rust-lang/rust/issues/59637.

try-job: `*apple*`