### PR TITLE
constify `From` impls for the `Cow::Borrowed` variant

### DIFF
--- a/library/alloc/src/bstr.rs
+++ b/library/alloc/src/bstr.rs
@@ -598,7 +598,8 @@ impl Clone for Box<ByteStr> {
 }
 
 #[unstable(feature = "bstr", issue = "134915")]
-impl<'a> From<&'a ByteStr> for Cow<'a, ByteStr> {
+#[rustc_const_unstable(feature = "const_convert", issue = "143773")]
+impl<'a> const From<&'a ByteStr> for Cow<'a, ByteStr> {
     #[inline]
     fn from(s: &'a ByteStr) -> Self {
         Cow::Borrowed(s)

--- a/library/alloc/src/ffi/c_str.rs
+++ b/library/alloc/src/ffi/c_str.rs
@@ -878,7 +878,8 @@ impl<'a> From<CString> for Cow<'a, CStr> {
 }
 
 #[stable(feature = "cow_from_cstr", since = "1.28.0")]
-impl<'a> From<&'a CStr> for Cow<'a, CStr> {
+#[rustc_const_unstable(feature = "const_convert", issue = "143773")]
+impl<'a> const From<&'a CStr> for Cow<'a, CStr> {
     /// Converts a [`CStr`] into a borrowed [`Cow`] without copying or allocating.
     #[inline]
     fn from(s: &'a CStr) -> Cow<'a, CStr> {

--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -3096,7 +3096,8 @@ impl<'a> From<Cow<'a, str>> for String {
 
 #[cfg(not(no_global_oom_handling))]
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'a> From<&'a str> for Cow<'a, str> {
+#[rustc_const_unstable(feature = "const_convert", issue = "143773")]
+impl<'a> const From<&'a str> for Cow<'a, str> {
     /// Converts a string slice into a [`Borrowed`] variant.
     /// No heap allocation is performed, and the string
     /// is not copied.

--- a/library/alloc/src/vec/cow.rs
+++ b/library/alloc/src/vec/cow.rs
@@ -2,7 +2,8 @@ use super::Vec;
 use crate::borrow::Cow;
 
 #[stable(feature = "cow_from_vec", since = "1.8.0")]
-impl<'a, T: Clone> From<&'a [T]> for Cow<'a, [T]> {
+#[rustc_const_unstable(feature = "const_convert", issue = "143773")]
+impl<'a, T: Clone> const From<&'a [T]> for Cow<'a, [T]> {
     /// Creates a [`Borrowed`] variant of [`Cow`]
     /// from a slice.
     ///
@@ -15,7 +16,8 @@ impl<'a, T: Clone> From<&'a [T]> for Cow<'a, [T]> {
 }
 
 #[stable(feature = "cow_from_array_ref", since = "1.77.0")]
-impl<'a, T: Clone, const N: usize> From<&'a [T; N]> for Cow<'a, [T]> {
+#[rustc_const_unstable(feature = "const_convert", issue = "143773")]
+impl<'a, T: Clone, const N: usize> const From<&'a [T; N]> for Cow<'a, [T]> {
     /// Creates a [`Borrowed`] variant of [`Cow`]
     /// from a reference to an array.
     ///


### PR DESCRIPTION
This issue is a follow-up PR from https://github.com/rust-lang/rust/pull/146067 with the controversial impls removed.

This is useful in at least two cases:

1. Generic interfaces which may be `const`.
2. Conditional compilation (`&str` vs `Cow<str>`).


