### PR TITLE
Set lto to 'fat' with autodiff enabled

### DIFF
--- a/compiler/rustc_interface/src/interface.rs
+++ b/compiler/rustc_interface/src/interface.rs
@@ -482,6 +482,10 @@ pub fn run_compiler<R: Send>(config: Config, f: impl FnOnce(&Compiler) -> R + Se
                 config.using_internal_features,
                 config.expanded_args,
             );
+            // Forces lto="fat" if autodiff is enabled.
+			if sess.opts.unstable_opts.autodiff.contains(&config::AutoDiff::Enable) {
+				sess.opts.cg.lto = config::LtoCli::Fat;
+			}
 
             codegen_backend.init(&sess);
 


### PR DESCRIPTION
resolves rust-lang/rust#142796 

This took a whole lot longer than I expected it to. **A lot** longer. 