### PR TITLE
constify `Cow::Owned` types

### DIFF
--- a/library/alloc/src/slice.rs
+++ b/library/alloc/src/slice.rs
@@ -784,9 +784,10 @@ impl<T: Clone, V: Borrow<[T]>> Join<&[T]> for [V] {
 ////////////////////////////////////////////////////////////////////////////////
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T, A: Allocator> Borrow<[T]> for Vec<T, A> {
+#[rustc_const_unstable(feature = "const_convert", issue = "143773")]
+impl<T, A: Allocator> const Borrow<[T]> for Vec<T, A> {
     fn borrow(&self) -> &[T] {
-        &self[..]
+        self.as_slice()
     }
 }
 

--- a/library/alloc/src/str.rs
+++ b/library/alloc/src/str.rs
@@ -186,10 +186,11 @@ where
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl Borrow<str> for String {
+#[rustc_const_unstable(feature = "const_convert", issue = "143773")]
+impl const Borrow<str> for String {
     #[inline]
     fn borrow(&self) -> &str {
-        &self[..]
+        self.as_str()
     }
 }
 

--- a/library/alloctests/tests/borrow.rs
+++ b/library/alloctests/tests/borrow.rs
@@ -58,3 +58,21 @@ fn cow_const() {
     const IS_OWNED: bool = COW.is_owned();
     assert!(!IS_OWNED);
 }
+
+#[test]
+fn test_const_deref_cow_str() {
+    // Test Cow<str> - both borrowed and owned variants
+    const COW_STR_BORROWED: Cow<'_, str> = Cow::Borrowed("hello");
+    const COW_STR_OWNED: Cow<'_, str> = Cow::Owned(String::new());
+    const _: &str = &*COW_STR_BORROWED;
+    const _: &str = &*COW_STR_OWNED;
+}
+
+#[test]
+fn test_const_deref_cow_slice() {
+    // Test Cow<[T]> - both borrowed and owned variants
+    const COW_SLICE_BORROWED: Cow<'_, [i32]> = Cow::Borrowed(&[1, 2, 3]);
+    const COW_SLICE_OWNED: Cow<'_, [i32]> = Cow::Owned(Vec::new());
+    const _: &[i32] = &*COW_SLICE_BORROWED;
+    const _: &[i32] = &*COW_SLICE_OWNED;
+}

--- a/library/alloctests/tests/lib.rs
+++ b/library/alloctests/tests/lib.rs
@@ -28,6 +28,7 @@
 #![feature(string_remove_matches)]
 #![feature(const_btree_len)]
 #![feature(const_trait_impl)]
+#![feature(const_convert)]
 #![feature(panic_update_hook)]
 #![feature(pointer_is_aligned_to)]
 #![feature(test)]


### PR DESCRIPTION
`Cow` already has a `Deref<Target=B>` implementation that is `const` when the `Borrow` impl from the owned type is also `const`. However, none of the major types actually implement this, so the `Deref` impl doesn't really work.

This change constifies the two major `Cow::Owned` types so that the `Deref` impl on `Cow` will work for those two types.