### PR TITLE
fix 404 MCP link

### DIFF
--- a/src/doc/rustc/src/target-tier-policy.md
+++ b/src/doc/rustc/src/target-tier-policy.md
@@ -701,4 +701,4 @@ RFC process, with approval by the compiler and infra teams. Any such proposal
 will be communicated widely to the Rust community, both when initially proposed
 and before being dropped from a stable release.
 
-[MCP]: https://forge.rust-lang.org/compiler/mcp.html
+[MCP]: https://forge.rust-lang.org/compiler/proposals-and-stabilization.html#how-do-i-submit-an-mcp


### PR DESCRIPTION
I think this is what this should point to.

The old link did a redirect, so one could also fix the redirect, but i wasn't able to find where the redirect target is defined.

Found in https://rust-lang.zulipchat.com/#narrow/channel/242906-t-compiler.2Farm/topic/Tier.20changes.20for.20bare-metal.20Arm.20AArch32.20targets/with/539395822