### PR TITLE
btree: remove useless drops

### DIFF
--- a/library/alloc/src/collections/btree/map.rs
+++ b/library/alloc/src/collections/btree/map.rs
@@ -3257,7 +3257,6 @@ impl<'a, K: Ord, V, A: Allocator + Clone> CursorMutKey<'a, K, V, A> {
         };
 
         let handle = edge.insert_recursing(key, value, self.alloc.clone(), |ins| {
-            drop(ins.left);
             // SAFETY: The handle to the newly inserted value is always on a
             // leaf node, so adding a new root node doesn't invalidate it.
             let root = unsafe { self.root.reborrow().as_mut().unwrap() };
@@ -3303,7 +3302,6 @@ impl<'a, K: Ord, V, A: Allocator + Clone> CursorMutKey<'a, K, V, A> {
         };
 
         let handle = edge.insert_recursing(key, value, self.alloc.clone(), |ins| {
-            drop(ins.left);
             // SAFETY: The handle to the newly inserted value is always on a
             // leaf node, so adding a new root node doesn't invalidate it.
             let root = unsafe { self.root.reborrow().as_mut().unwrap() };

--- a/library/alloc/src/collections/btree/map/entry.rs
+++ b/library/alloc/src/collections/btree/map/entry.rs
@@ -406,7 +406,6 @@ impl<'a, K: Ord, V, A: Allocator + Clone> VacantEntry<'a, K, V, A> {
                 }
             }
             Some(handle) => handle.insert_recursing(self.key, value, self.alloc.clone(), |ins| {
-                drop(ins.left);
                 // SAFETY: Pushing a new root node doesn't invalidate
                 // handles to existing nodes.
                 let map = unsafe { self.dormant_map.reborrow() };


### PR DESCRIPTION
Gets rid of:
```text
warning: call to `std::mem::drop` with a value that does not implement `Drop`. Dropping such a type only extends its contained lifetimes
   --> library/alloc/src/collections/btree/map/entry.rs:409:17
    |
409 |                 drop(ins.left);
    |                 ^^^^^^^^^^^^^^
    |
note: argument has type `collections::btree::node::NodeRef<collections::btree::node::marker::Mut<'_>, K, V, collections::btree::node::marker::LeafOrInternal>`
   --> library/alloc/src/collections/btree/map/entry.rs:409:22
    |
409 |                 drop(ins.left);
    |                      ^^^^^^^^
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#drop_non_drop
    = note: `-W clippy::drop-non-drop` implied by `-W clippy::suspicious`
    = help: to override `-W clippy::suspicious` add `#[allow(clippy::drop_non_drop)]`

warning: call to `std::mem::drop` with a value that does not implement `Drop`. Dropping such a type only extends its contained lifetimes
    --> library/alloc/src/collections/btree/map.rs:3260:13
     |
3260 |             drop(ins.left);
     |             ^^^^^^^^^^^^^^
     |
note: argument has type `collections::btree::node::NodeRef<collections::btree::node::marker::Mut<'_>, K, V, collections::btree::node::marker::LeafOrInternal>`
    --> library/alloc/src/collections/btree/map.rs:3260:18
     |
3260 |             drop(ins.left);
     |                  ^^^^^^^^
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#drop_non_drop

warning: call to `std::mem::drop` with a value that does not implement `Drop`. Dropping such a type only extends its contained lifetimes
    --> library/alloc/src/collections/btree/map.rs:3306:13
     |
3306 |             drop(ins.left);
     |             ^^^^^^^^^^^^^^
     |
note: argument has type `collections::btree::node::NodeRef<collections::btree::node::marker::Mut<'_>, K, V, collections::btree::node::marker::LeafOrInternal>`
    --> library/alloc/src/collections/btree/map.rs:3306:18
     |
3306 |             drop(ins.left);
     |                  ^^^^^^^^
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#drop_non_drop
```