### PR TITLE
fix issue with `cmse-nonsecure-entry` ABI being both async and c-variadic

### DIFF
--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/cmse.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/cmse.rs
@@ -85,6 +85,12 @@ pub(crate) fn validate_cmse_abi<'tcx>(
                 return;
             };
 
+            // An `extern "cmse-nonsecure-entry"` function cannot be c-variadic. We run
+            // into https://github.com/rust-lang/rust/issues/132142 if we don't explicitly bail.
+            if decl.c_variadic {
+                return;
+            }
+
             match is_valid_cmse_inputs(tcx, fn_sig) {
                 Ok(Ok(())) => {}
                 Ok(Err(index)) => {

--- a/tests/crashes/132142.rs
+++ b/tests/crashes/132142.rs
@@ -1,3 +1,0 @@
-//@ known-bug: #132142
-
-async extern "cmse-nonsecure-entry" fn fun(...) {}

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/c-variadic.rs
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/c-variadic.rs
@@ -1,0 +1,69 @@
+//@ add-core-stubs
+//@ edition: 2018
+//@ compile-flags: --target thumbv8m.main-none-eabi --crate-type lib
+//@ needs-llvm-components: arm
+#![feature(cmse_nonsecure_entry, c_variadic, no_core, lang_items)]
+#![no_core]
+
+extern crate minicore;
+use minicore::*;
+
+#[lang = "va_list"]
+struct VaList(*mut u8);
+
+unsafe extern "cmse-nonsecure-entry" fn c_variadic(_: u32, _: ...) {
+    //~^ ERROR `...` is not supported for `extern "cmse-nonsecure-entry"` functions
+}
+
+// A regression test for https://github.com/rust-lang/rust/issues/132142
+async unsafe extern "cmse-nonsecure-entry" fn async_and_c_variadic(_: ...) {
+    //~^ ERROR `...` is not supported for `extern "cmse-nonsecure-entry"` functions
+    //~| ERROR functions cannot be both `async` and C-variadic
+}
+
+// Below are the lang items that are required for a program that defines an `async` function.
+// Without them, the ICE that is tested for here is not reached for this target. For now they are in
+// this file, but they may be moved into `minicore` if/when other `#[no_core]` tests want to use
+// them.
+
+// NOTE: in `core` this type uses `NonNull`.
+#[lang = "ResumeTy"]
+pub struct ResumeTy(*mut Context<'static>);
+
+#[lang = "future_trait"]
+pub trait Future {
+    /// The type of value produced on completion.
+    #[lang = "future_output"]
+    type Output;
+
+    // NOTE: misses the `poll` method.
+}
+
+#[lang = "async_drop"]
+pub trait AsyncDrop {
+    // NOTE: misses the `drop` method.
+}
+
+#[lang = "Poll"]
+pub enum Poll<T> {
+    #[lang = "Ready"]
+    Ready(T),
+
+    #[lang = "Pending"]
+    Pending,
+}
+
+#[lang = "Context"]
+pub struct Context<'a> {
+    // NOTE: misses a bunch of fields.
+    _marker: PhantomData<fn(&'a ()) -> &'a ()>,
+}
+
+#[lang = "get_context"]
+pub unsafe fn get_context<'a, 'b>(cx: ResumeTy) -> &'a mut Context<'b> {
+    // NOTE: the actual implementation looks different.
+    mem::transmute(cx.0)
+}
+
+#[lang = "pin"]
+pub struct Pin<T>(T);

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/c-variadic.stderr
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/c-variadic.stderr
@@ -1,0 +1,28 @@
+error: `...` is not supported for `extern "cmse-nonsecure-entry"` functions
+  --> $DIR/c-variadic.rs:14:60
+   |
+LL | unsafe extern "cmse-nonsecure-entry" fn c_variadic(_: u32, _: ...) {
+   |        -----------------------------                       ^^^^^^
+   |        |
+   |        `extern "cmse-nonsecure-entry"` because of this
+   |
+   = help: only `extern "C"` and `extern "C-unwind"` functions may have a C variable argument list
+
+error: functions cannot be both `async` and C-variadic
+  --> $DIR/c-variadic.rs:19:1
+   |
+LL | async unsafe extern "cmse-nonsecure-entry" fn async_and_c_variadic(_: ...) {
+   | ^^^^^ `async` because of this                                      ^^^^^^ C-variadic because of this
+
+error: `...` is not supported for `extern "cmse-nonsecure-entry"` functions
+  --> $DIR/c-variadic.rs:19:68
+   |
+LL | async unsafe extern "cmse-nonsecure-entry" fn async_and_c_variadic(_: ...) {
+   |              -----------------------------                         ^^^^^^
+   |              |
+   |              `extern "cmse-nonsecure-entry"` because of this
+   |
+   = help: only `extern "C"` and `extern "C-unwind"` functions may have a C variable argument list
+
+error: aborting due to 3 previous errors
+

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/generics.rs
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/generics.rs
@@ -1,7 +1,7 @@
 //@ add-core-stubs
 //@ compile-flags: --target thumbv8m.main-none-eabi --crate-type lib
 //@ needs-llvm-components: arm
-#![feature(cmse_nonsecure_entry, c_variadic, no_core, lang_items)]
+#![feature(cmse_nonsecure_entry, no_core, lang_items)]
 #![no_core]
 
 extern crate minicore;
@@ -64,9 +64,4 @@ struct WrapperTransparent<'a>(&'a dyn Trait);
 extern "cmse-nonsecure-entry" fn wrapped_trait_object(x: WrapperTransparent) -> WrapperTransparent {
     //~^ ERROR return value of `"cmse-nonsecure-entry"` function too large to pass via registers [E0798]
     x
-}
-
-unsafe extern "cmse-nonsecure-entry" fn c_variadic(_: u32, _: ...) {
-    //~^ ERROR `...` is not supported for `extern "cmse-nonsecure-entry"` functions
-    //~| ERROR requires `va_list` lang_item
 }

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/generics.stderr
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/generics.stderr
@@ -1,13 +1,3 @@
-error: `...` is not supported for `extern "cmse-nonsecure-entry"` functions
-  --> $DIR/generics.rs:69:60
-   |
-LL | unsafe extern "cmse-nonsecure-entry" fn c_variadic(_: u32, _: ...) {
-   |        -----------------------------                       ^^^^^^
-   |        |
-   |        `extern "cmse-nonsecure-entry"` because of this
-   |
-   = help: only `extern "C"` and `extern "C-unwind"` functions may have a C variable argument list
-
 error[E0798]: functions with the `"cmse-nonsecure-entry"` ABI cannot contain generics in their type
   --> $DIR/generics.rs:30:1
    |
@@ -71,12 +61,6 @@ LL | extern "cmse-nonsecure-entry" fn wrapped_trait_object(x: WrapperTransparent
    = note: functions with the `"cmse-nonsecure-entry"` ABI must pass their result via the available return registers
    = note: the result must either be a (transparently wrapped) i64, u64 or f64, or be at most 4 bytes in size
 
-error: requires `va_list` lang_item
-  --> $DIR/generics.rs:69:60
-   |
-LL | unsafe extern "cmse-nonsecure-entry" fn c_variadic(_: u32, _: ...) {
-   |                                                            ^^^^^^
-
-error: aborting due to 9 previous errors
+error: aborting due to 7 previous errors
 
 For more information about this error, try `rustc --explain E0798`.


### PR DESCRIPTION
tracking issue: https://github.com/rust-lang/rust/issues/75835
fixes https://github.com/rust-lang/rust/issues/132142

An `extern "cmse-nonsecure-entry"` function cannot be c-variadic (or, in any case, clang/LLVM does not support it, see  https://godbolt.org/z/MaPjzGcE1). So just stop looking at the type if we know it'll be invalid anyway.

I'm not entirely sure how to test this. The ICE is only possible on the `thumbv8m.main-none-eabi` and some related targets. I think using `minicore` is the most convenient, but use of `async` requires quite a long list of lang items to be present. Maybe we want that anyway though? On the other hand, it's extra `minicore` surface that might go out of date.

An alternative is `run-make`, that should work, but is much less convenient. See also [#t-compiler/help > &#96;async fn&#96; and &#96;minicore&#96;](https://rust-lang.zulipchat.com/#narrow/channel/182449-t-compiler.2Fhelp/topic/.60async.20fn.60.20and.20.60minicore.60/with/539427262).

r? @ghost