### PR TITLE
Add support for removed library features

### DIFF
--- a/compiler/rustc_const_eval/messages.ftl
+++ b/compiler/rustc_const_eval/messages.ftl
@@ -153,6 +153,10 @@ const_eval_intern_kind = {$kind ->
 }
 
 const_eval_interrupted = compilation was interrupted
+const_eval_intrinsic_cannot_be_removed =
+    The intrinsic `{ $def_path }` cannot be marked as `#[unstable_removed]`
+    .note = Intrinsics are language features, not library features, so `Removed` is invalid
+
 
 const_eval_invalid_align_details =
     invalid align passed to `{$name}`: {$align} is {$err_kind ->
@@ -364,6 +368,8 @@ const_eval_remainder_by_zero =
     calculating the remainder with a divisor of zero
 const_eval_remainder_overflow =
     overflow in signed remainder (dividing MIN by -1)
+const_eval_removed_const_item =
+    use of removed const item `{$def_path}`
 const_eval_scalar_size_mismatch =
     scalar size mismatch: expected {$target_size} bytes but got {$data_size} bytes instead
 const_eval_size_overflow =

--- a/compiler/rustc_const_eval/src/errors.rs
+++ b/compiler/rustc_const_eval/src/errors.rs
@@ -79,6 +79,23 @@ pub(crate) struct UnstableInStableExposed {
 }
 
 #[derive(Diagnostic)]
+#[diag(const_eval_removed_const_item)] // FIXME: code needed (todo)
+pub(crate) struct RemovedConstItem {
+    #[primary_span]
+    pub span: Span,
+    pub def_path: String,
+}
+
+#[derive(Diagnostic)]
+#[diag(const_eval_intrinsic_cannot_be_removed)] // FIXME: code needed (todo)
+#[note]
+pub(crate) struct IntrinsicCannotBeRemoved {
+    #[primary_span]
+    pub span: Span,
+    pub def_path: String,
+}
+
+#[derive(Diagnostic)]
 #[diag(const_eval_thread_local_access, code = E0625)]
 pub(crate) struct ThreadLocalAccessErr {
     #[primary_span]

--- a/compiler/rustc_feature/src/builtin_attrs.rs
+++ b/compiler/rustc_feature/src/builtin_attrs.rs
@@ -907,6 +907,11 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
         EncodeCrossCrate::Yes
     ),
     ungated!(
+        unstable_removed, Normal,
+        template!(List: &[r#"feature = "name", reason = "...", issue = "N", since = "version""#]),
+        DuplicatesOk, EncodeCrossCrate::No
+    ),
+    ungated!(
         unstable_feature_bound, Normal, template!(Word, List: &["feat1, feat2, ..."]),
         DuplicatesOk, EncodeCrossCrate::No,
     ),

--- a/compiler/rustc_hir/src/stability.rs
+++ b/compiler/rustc_hir/src/stability.rs
@@ -143,6 +143,13 @@ pub enum StabilityLevel {
         /// the `Symbol` is the deprecation message printed in that case.
         allowed_through_unstable_modules: Option<Symbol>,
     },
+    /// `#[unstable_removed]`
+    Removed {
+        /// Rust release which removed this feature.
+        since: StableSince,
+        issue: Option<NonZero<u32>>,
+        reason: UnstableReason,
+    },
 }
 
 /// Rust release in which a feature is stabilized.
@@ -164,10 +171,14 @@ impl StabilityLevel {
     pub fn is_stable(&self) -> bool {
         matches!(self, StabilityLevel::Stable { .. })
     }
+    pub fn is_removed(&self) -> bool {
+        matches!(self, StabilityLevel::Removed { .. })
+    }
     pub fn stable_since(&self) -> Option<StableSince> {
         match *self {
             StabilityLevel::Stable { since, .. } => Some(since),
             StabilityLevel::Unstable { .. } => None,
+            StabilityLevel::Removed { since, .. } => Some(since),
         }
     }
 }

--- a/compiler/rustc_hir_analysis/src/check/check.rs
+++ b/compiler/rustc_hir_analysis/src/check/check.rs
@@ -17,7 +17,7 @@ use rustc_lint_defs::builtin::{
 };
 use rustc_middle::hir::nested_filter;
 use rustc_middle::middle::resolve_bound_vars::ResolvedArg;
-use rustc_middle::middle::stability::EvalResult;
+use rustc_middle::middle::stability::{EvalResult, report_removed};
 use rustc_middle::ty::error::TypeErrorToStringExt;
 use rustc_middle::ty::layout::{LayoutError, MAX_SIMD_LANES};
 use rustc_middle::ty::util::Discr;
@@ -1259,7 +1259,11 @@ fn check_impl_items_against_trait<'tcx>(
                         reason,
                         issue,
                     ),
-
+                    EvalResult::Removed { feature, since, reason, issue } => {
+                        // Removed will always give error
+                        // Use report_removed to emit the error
+                        report_removed(tcx.sess, feature, since, reason, issue, full_impl_span);
+                    }
                     // Unmarked default bodies are considered stable (at least for now).
                     EvalResult::Allow | EvalResult::Unmarked => {}
                 }

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
@@ -2045,10 +2045,11 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     ) -> bool {
         // The field must be visible in the containing module.
         field.vis.is_accessible_from(self.tcx.parent_module(hir_id), self.tcx)
-            // The field must not be unstable.
+            // The field must not be unstable or removed.
             && !matches!(
                 self.tcx.eval_stability(field.did, None, rustc_span::DUMMY_SP, None),
                 rustc_middle::middle::stability::EvalResult::Deny { .. }
+                | rustc_middle::middle::stability::EvalResult::Removed { .. }
             )
             // If the field is from an external crate it must not be `doc(hidden)`.
             && (field.did.is_local() || !self.tcx.is_doc_hidden(field.did))

--- a/compiler/rustc_middle/src/middle/mod.rs
+++ b/compiler/rustc_middle/src/middle/mod.rs
@@ -13,6 +13,7 @@ pub mod lib_features {
     pub enum FeatureStability {
         AcceptedSince(Symbol),
         Unstable { old_name: Option<Symbol> },
+        Removed(Symbol),
     }
 
     #[derive(HashStable, Debug, Default)]

--- a/compiler/rustc_passes/messages.ftl
+++ b/compiler/rustc_passes/messages.ftl
@@ -287,6 +287,9 @@ passes_extern_main =
 passes_feature_previously_declared =
     feature `{$feature}` is declared {$declared}, but was previously declared {$prev_declared}
 
+passes_feature_removed_twice =
+    feature `{$feature}` was removed in {$since}, but was previously removed in {$prev_since}
+
 passes_feature_stable_twice =
     feature `{$feature}` is declared stable since {$since}, but was previously declared stable since {$prev_since}
 
@@ -492,6 +495,9 @@ passes_remove_fields =
       [one] field
      *[other] fields
     }
+
+passes_removed_feature =
+    feature `{$feature}` has been removed and can no longer be used
 
 passes_repr_align_greater_than_target_max =
     alignment must not be greater than `isize::MAX` bytes

--- a/compiler/rustc_passes/src/errors.rs
+++ b/compiler/rustc_passes/src/errors.rs
@@ -844,6 +844,16 @@ pub(crate) struct FeatureStableTwice {
 }
 
 #[derive(Diagnostic)]
+#[diag(passes_feature_removed_twice)] // FIXME: code needed (todo)
+pub(crate) struct FeatureRemovedTwice {
+    #[primary_span]
+    pub span: Span,
+    pub feature: Symbol,
+    pub since: Symbol,
+    pub prev_since: Symbol,
+}
+
+#[derive(Diagnostic)]
 #[diag(passes_feature_previously_declared, code = E0711)]
 pub(crate) struct FeaturePreviouslyDeclared<'a> {
     #[primary_span]
@@ -1199,6 +1209,14 @@ pub(crate) struct RenamedFeature {
     pub span: Span,
     pub feature: Symbol,
     pub alias: Symbol,
+}
+
+#[derive(Diagnostic)]
+#[diag(passes_removed_feature)] // FIXME: code needed (todo)
+pub(crate) struct RemovedFeature {
+    #[primary_span]
+    pub span: Span,
+    pub feature: Symbol,
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_passes/src/stability.rs
+++ b/compiler/rustc_passes/src/stability.rs
@@ -1015,6 +1015,12 @@ pub fn check_unused_or_stable_features(tcx: TyCtxt<'_>) {
                 tcx.dcx().emit_err(errors::RenamedFeature { span, feature, alias });
             }
 
+            if let FeatureStability::Removed(_since) = stability
+                && let Some(span) = remaining_lib_features.swap_remove(&feature)
+            {
+                tcx.dcx().emit_err(errors::RemovedFeature { span, feature });
+            }
+
             if remaining_lib_features.is_empty() && remaining_implications.is_empty() {
                 break;
             }

--- a/compiler/rustc_pattern_analysis/src/rustc.rs
+++ b/compiler/rustc_pattern_analysis/src/rustc.rs
@@ -370,10 +370,10 @@ impl<'p, 'tcx: 'p> RustcPatCtxt<'p, 'tcx> {
                             .apply_revealing_opaque(cx.tcx, cx.typing_env, cx.module, &|key| {
                                 cx.reveal_opaque_key(key)
                             });
-                        // Variants that depend on a disabled unstable feature.
+                        // Variants that depend on a disabled unstable or removed feature.
                         let is_unstable = matches!(
                             cx.tcx.eval_stability(variant_def_id, None, DUMMY_SP, None),
-                            EvalResult::Deny { .. }
+                            EvalResult::Deny { .. } | EvalResult::Removed { .. }
                         );
                         // Foreign `#[doc(hidden)]` variants.
                         let is_doc_hidden =

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -1508,6 +1508,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                     false
                 }
             }
+            Some(Stability { level: StabilityLevel::Removed { .. }, .. }) => false, // explicitly deny removed features
             Some(_) => true,
             None => false,
         }

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -2334,6 +2334,7 @@ symbols! {
         unstable_location_reason_default: "this crate is being loaded from the sysroot, an \
                           unstable location; did you mean to load this crate \
                           from crates.io via `Cargo.toml` instead?",
+        unstable_removed,
         untagged_unions,
         unused_imports,
         unwind,

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -398,3 +398,12 @@ pub mod simd {
 }
 
 include!("primitive_docs.rs");
+
+// For testing `#[unstable_removed]`
+#[unstable_removed(
+    feature = "removed_lib_features",
+    reason = "testing removed features",
+    issue = "123456",
+    since = "1.89.0"
+)]
+pub mod removed_lib_features;

--- a/library/core/src/removed_lib_features.rs
+++ b/library/core/src/removed_lib_features.rs
@@ -1,0 +1,103 @@
+//! Removed features library for testing `#[unstable_removed]`.
+
+#![allow(unused)]
+#![allow(dead_code)]
+#![allow(missing_docs)]
+#![allow(missing_debug_implementations)]
+
+/// ============================================================
+/// 1. Removed const item
+#[unstable_removed(
+    feature = "removed_const_item",
+    reason = "testing removed const",
+    issue = "123456",
+    since = "1.89.0"
+)]
+pub const REMOVED_CONST: u32 = 42;
+
+#[unstable_removed(
+    feature = "removed_const_item",
+    reason = "testing removed const",
+    issue = "123456",
+    since = "1.89.0"
+)]
+pub mod const_removed {
+    #[unstable_removed(
+        feature = "removed_const_item",
+        reason = "testing removed const",
+        issue = "123456",
+        since = "1.89.0"
+    )]
+    pub fn use_removed_const() -> u32 {
+        super::REMOVED_CONST
+    }
+}
+
+/// ============================================================
+/// 2. Removed trait / default items
+#[unstable_removed(
+    feature = "removed_trait_fn",
+    reason = "testing removed trait fn",
+    issue = "123456",
+    since = "1.89.0"
+)]
+pub trait TraitRemoved {
+    #[unstable_removed(
+        feature = "removed_trait_fn",
+        reason = "testing removed trait fn",
+        issue = "123456",
+        since = "1.89.0"
+    )]
+    fn removed_fn() -> u32 {
+        42
+    }
+
+    #[unstable_removed(
+        feature = "removed_trait_fn",
+        reason = "testing removed trait fn",
+        issue = "123456",
+        since = "1.89.0"
+    )]
+    const REMOVED_TRAIT_CONST: u32 = 1;
+}
+
+#[unstable_removed(
+    feature = "removed_trait_impl",
+    reason = "testing removed trait impl",
+    issue = "123456",
+    since = "1.89.0"
+)]
+pub struct Impl;
+
+#[unstable_removed(
+    feature = "removed_trait_impl",
+    reason = "testing removed trait impl",
+    issue = "123456",
+    since = "1.89.0"
+)]
+impl TraitRemoved for Impl {
+    fn removed_fn() -> u32 {
+        0
+    }
+    const REMOVED_TRAIT_CONST: u32 = 0;
+}
+
+/// ============================================================
+/// 3. Removed macro
+#[unstable_removed(
+    feature = "removed_macro_item",
+    reason = "testing removed macro",
+    issue = "123456",
+    since = "1.89.0"
+)]
+#[macro_export]
+macro_rules! removed_macro {
+    () => {
+        const REMOVED_MACRO_CONST: u32 = 0;
+    };
+}
+
+/// ============================================================
+/// 4. Removed function for missing field tests
+#[unstable_removed(feature = "removed_no_reason", since = "1.89.0", issue = "123456")]
+pub fn removed_no_reason() {}

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -1504,6 +1504,11 @@ pub(crate) fn print_constness_with_space(
             }
             // const unstable (and overall stable)
             (Some(_), Some(ConstStability { level: StabilityLevel::Unstable { .. }, .. })) => "",
+            // const removed
+            (None, Some(ConstStability { level: StabilityLevel::Removed { .. }, .. }))
+            | (Some(_), Some(ConstStability { level: StabilityLevel::Removed { .. }, .. })) => {
+                "removed "
+            }
         },
         // not const
         hir::Constness::NotConst => "",

--- a/tests/ui/stability-attribute/removed_lib_features.rs
+++ b/tests/ui/stability-attribute/removed_lib_features.rs
@@ -1,0 +1,31 @@
+#![allow(unused)]
+
+// compile-flags: -Zunstable-options
+// run-pass
+
+extern crate core;
+
+//1. Removed library module
+use core::removed_lib_features::*;      //~ ERROR use of removed library feature `removed_lib_features` [E0658]
+use core::removed_macro;                //~ ERROR use of removed library feature `removed_macro_item` [E0658]
+
+fn main() {
+    // 2. Removed library macro
+    removed_macro!();                   //~ ERROR use of removed library feature `removed_macro_item` [E0658]
+
+    // 3. Removed library trait
+    // This triggers *both* removed_trait_impl and removed_trait_fn
+    Impl::removed_fn();                 //~ ERROR use of removed library feature `removed_trait_impl` [E0658]
+                                        //~| ERROR use of removed library feature `removed_trait_fn` [E0658]
+
+    // Same here for const
+    let _ = Impl::REMOVED_TRAIT_CONST;  //~ ERROR use of removed library feature `removed_trait_impl` [E0658]
+                                        //~| ERROR use of removed library feature `removed_trait_fn` [E0658]
+
+    // 4. Removed library const
+    let _ = const_removed::use_removed_const(); //~ ERROR use of removed library feature `removed_const_item` [E0658]
+
+
+    // 5. Missing Firlds
+    removed_no_reason(); //~ ERROR use of removed library feature `removed_no_reason` [E0658]
+}

--- a/tests/ui/stability-attribute/removed_lib_features.stderr
+++ b/tests/ui/stability-attribute/removed_lib_features.stderr
@@ -1,0 +1,110 @@
+error[E0658]: use of removed library feature `removed_macro_item`
+  --> $DIR/removed_lib_features.rs:14:5
+   |
+LL |     removed_macro!();
+   |     ^^^^^^^^^^^^^
+   |
+   = note: see issue #123456 <https://github.com/rust-lang/rust/issues/123456> for more information
+   = help: add `#![feature(removed_macro_item)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+   = note: since: removed since 1.89.0
+   = note: reason: testing removed macro
+
+error[E0658]: use of removed library feature `removed_lib_features`
+  --> $DIR/removed_lib_features.rs:9:5
+   |
+LL | use core::removed_lib_features::*;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #123456 <https://github.com/rust-lang/rust/issues/123456> for more information
+   = help: add `#![feature(removed_lib_features)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+   = note: since: removed since 1.89.0
+   = note: reason: testing removed features
+
+error[E0658]: use of removed library feature `removed_macro_item`
+  --> $DIR/removed_lib_features.rs:10:5
+   |
+LL | use core::removed_macro;
+   |     ^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #123456 <https://github.com/rust-lang/rust/issues/123456> for more information
+   = help: add `#![feature(removed_macro_item)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+   = note: since: removed since 1.89.0
+   = note: reason: testing removed macro
+
+error[E0658]: use of removed library feature `removed_trait_impl`
+  --> $DIR/removed_lib_features.rs:18:5
+   |
+LL |     Impl::removed_fn();
+   |     ^^^^
+   |
+   = note: see issue #123456 <https://github.com/rust-lang/rust/issues/123456> for more information
+   = help: add `#![feature(removed_trait_impl)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+   = note: since: removed since 1.89.0
+   = note: reason: testing removed trait impl
+
+error[E0658]: use of removed library feature `removed_trait_impl`
+  --> $DIR/removed_lib_features.rs:22:13
+   |
+LL |     let _ = Impl::REMOVED_TRAIT_CONST;
+   |             ^^^^
+   |
+   = note: see issue #123456 <https://github.com/rust-lang/rust/issues/123456> for more information
+   = help: add `#![feature(removed_trait_impl)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+   = note: since: removed since 1.89.0
+   = note: reason: testing removed trait impl
+
+error[E0658]: use of removed library feature `removed_const_item`
+  --> $DIR/removed_lib_features.rs:26:13
+   |
+LL |     let _ = const_removed::use_removed_const();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #123456 <https://github.com/rust-lang/rust/issues/123456> for more information
+   = help: add `#![feature(removed_const_item)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+   = note: since: removed since 1.89.0
+   = note: reason: testing removed const
+
+error[E0658]: use of removed library feature `removed_no_reason`
+  --> $DIR/removed_lib_features.rs:30:5
+   |
+LL |     removed_no_reason();
+   |     ^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #123456 <https://github.com/rust-lang/rust/issues/123456> for more information
+   = help: add `#![feature(removed_no_reason)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+   = note: since: removed since 1.89.0
+
+error[E0658]: use of removed library feature `removed_trait_fn`
+  --> $DIR/removed_lib_features.rs:18:5
+   |
+LL |     Impl::removed_fn();
+   |     ^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #123456 <https://github.com/rust-lang/rust/issues/123456> for more information
+   = help: add `#![feature(removed_trait_fn)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+   = note: since: removed since 1.89.0
+   = note: reason: testing removed trait fn
+
+error[E0658]: use of removed library feature `removed_trait_fn`
+  --> $DIR/removed_lib_features.rs:22:13
+   |
+LL |     let _ = Impl::REMOVED_TRAIT_CONST;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #123456 <https://github.com/rust-lang/rust/issues/123456> for more information
+   = help: add `#![feature(removed_trait_fn)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+   = note: since: removed since 1.89.0
+   = note: reason: testing removed trait fn
+
+error: aborting due to 9 previous errors
+
+For more information about this error, try `rustc --explain E0658`.


### PR DESCRIPTION
## PR: Add support for removed library features

### Overview

This PR extends the Rust stability system to handle *removed* library features. The new attribute `#[unstable_removed]` can be applied to APIs that have been permanently removed from the standard library. This ensures removed items always produce an error when referenced.

The approach follows the existing stability infrastructure (`#[unstable]`, `#[stable]`), introducing a new `Removed` state with dedicated compiler diagnostics.

---

### Implementation details

* **New attribute:**

  ```rust
  #[unstable_removed(
      feature = "removed_example",
      since = "1.89.0",
      issue = "123456",
      reason = "testing removed feature"
  )]
  ```
* **Library integration:**

  * Fake removed items are defined in `library/core/src/removed_lib_features.rs`.
  * These serve as test cases and examples of usage.
* **Compiler changes:**

  * Extended stability handling to include `StabilityLevel::Removed`.
  * Updated checks in:

    * `rustc_const_eval` → reports errors on evaluation of removed consts.
    * `rustc_hir_analysis` → enforces removed status during analysis.
    * `rustc_passes` → detects duplicates and unused/invalid declarations.
    * `rustc_resolve` → reports errors for removed macros and intrinsic resolution.
* **Validation:** Missing fields (`since`, `issue`) are rejected with compiler errors.

---

### Flow

1. A library item is annotated with `#[unstable_removed]`.
2. During HIR lowering and stability passes, it is recognized as `Removed`.
3. Any reference to such an item triggers a hard error (`E0658`).
4. Compiler ensures consistency across all passes and diagnostics.

---

### Testing

* **Location:** UI tests under `tests/ui/stability-attribute/`.
* **Coverage:**

  * Direct use of removed items.
  * Removed trait functions and associated constants.
  * Intrinsic wrappers.
  * Invalid attributes (missing `since`, `issue`).
  * Duplicate stability declarations (removed vs stable/unstable).

---

### What’s left / To Fix

* **Error codes**: All new diagnostics currently reuse existing errors (e.g., `E0658`). Explicit, dedicated error codes should be added for clarity.
* **Lang/intrinsics distinction**: Real intrinsics and lang items aren’t yet cleanly separated in the removed-feature handling. Right now, only simulated intrinsics are tested.
* **Polish**: Some duplicated error emissions (e.g., trait fn + trait impl both firing) could be made cleaner.

Issue: rust-lang/rust#141617