### PR TITLE
Change `Location<'_>` lifetime to `'static` in `Panic[Hook]Info`

### DIFF
--- a/library/core/src/panic/panic_info.rs
+++ b/library/core/src/panic/panic_info.rs
@@ -13,7 +13,7 @@ use crate::panic::Location;
 #[derive(Debug)]
 pub struct PanicInfo<'a> {
     message: &'a fmt::Arguments<'a>,
-    location: &'a Location<'static>,
+    location: &'static Location<'static>,
     can_unwind: bool,
     force_no_backtrace: bool,
 }
@@ -33,7 +33,7 @@ impl<'a> PanicInfo<'a> {
     #[inline]
     pub(crate) fn new(
         message: &'a fmt::Arguments<'a>,
-        location: &'a Location<'static>,
+        location: &'static Location<'static>,
         can_unwind: bool,
         force_no_backtrace: bool,
     ) -> Self {
@@ -88,10 +88,10 @@ impl<'a> PanicInfo<'a> {
     /// ```
     #[must_use]
     #[stable(feature = "panic_hooks", since = "1.10.0")]
-    pub fn location(&self) -> Option<&Location<'static>> {
+    pub fn location(&self) -> Option<&'static Location<'static>> {
         // NOTE: If this is changed to sometimes return None,
         // deal with that case in std::panicking::default_hook and core::panicking::panic_fmt.
-        Some(&self.location)
+        Some(self.location)
     }
 
     /// Returns the payload associated with the panic.

--- a/library/core/src/panic/panic_info.rs
+++ b/library/core/src/panic/panic_info.rs
@@ -13,7 +13,7 @@ use crate::panic::Location;
 #[derive(Debug)]
 pub struct PanicInfo<'a> {
     message: &'a fmt::Arguments<'a>,
-    location: &'a Location<'a>,
+    location: &'a Location<'static>,
     can_unwind: bool,
     force_no_backtrace: bool,
 }
@@ -33,7 +33,7 @@ impl<'a> PanicInfo<'a> {
     #[inline]
     pub(crate) fn new(
         message: &'a fmt::Arguments<'a>,
-        location: &'a Location<'a>,
+        location: &'a Location<'static>,
         can_unwind: bool,
         force_no_backtrace: bool,
     ) -> Self {
@@ -88,7 +88,7 @@ impl<'a> PanicInfo<'a> {
     /// ```
     #[must_use]
     #[stable(feature = "panic_hooks", since = "1.10.0")]
-    pub fn location(&self) -> Option<&Location<'_>> {
+    pub fn location(&self) -> Option<&Location<'static>> {
         // NOTE: If this is changed to sometimes return None,
         // deal with that case in std::panicking::default_hook and core::panicking::panic_fmt.
         Some(&self.location)

--- a/library/std/src/panic.rs
+++ b/library/std/src/panic.rs
@@ -41,7 +41,7 @@ pub type PanicInfo<'a> = PanicHookInfo<'a>;
 #[derive(Debug)]
 pub struct PanicHookInfo<'a> {
     payload: &'a (dyn Any + Send),
-    location: &'a Location<'static>,
+    location: &'static Location<'static>,
     can_unwind: bool,
     force_no_backtrace: bool,
 }
@@ -49,7 +49,7 @@ pub struct PanicHookInfo<'a> {
 impl<'a> PanicHookInfo<'a> {
     #[inline]
     pub(crate) fn new(
-        location: &'a Location<'static>,
+        location: &'static Location<'static>,
         payload: &'a (dyn Any + Send),
         can_unwind: bool,
         force_no_backtrace: bool,
@@ -160,10 +160,10 @@ impl<'a> PanicHookInfo<'a> {
     #[must_use]
     #[inline]
     #[stable(feature = "panic_hooks", since = "1.10.0")]
-    pub fn location(&self) -> Option<&Location<'static>> {
+    pub fn location(&self) -> Option<&'static Location<'static>> {
         // NOTE: If this is changed to sometimes return None,
         // deal with that case in std::panicking::default_hook and core::panicking::panic_fmt.
-        Some(&self.location)
+        Some(self.location)
     }
 
     /// Returns whether the panic handler is allowed to unwind the stack from

--- a/library/std/src/panic.rs
+++ b/library/std/src/panic.rs
@@ -41,7 +41,7 @@ pub type PanicInfo<'a> = PanicHookInfo<'a>;
 #[derive(Debug)]
 pub struct PanicHookInfo<'a> {
     payload: &'a (dyn Any + Send),
-    location: &'a Location<'a>,
+    location: &'a Location<'static>,
     can_unwind: bool,
     force_no_backtrace: bool,
 }
@@ -49,7 +49,7 @@ pub struct PanicHookInfo<'a> {
 impl<'a> PanicHookInfo<'a> {
     #[inline]
     pub(crate) fn new(
-        location: &'a Location<'a>,
+        location: &'a Location<'static>,
         payload: &'a (dyn Any + Send),
         can_unwind: bool,
         force_no_backtrace: bool,
@@ -160,7 +160,7 @@ impl<'a> PanicHookInfo<'a> {
     #[must_use]
     #[inline]
     #[stable(feature = "panic_hooks", since = "1.10.0")]
-    pub fn location(&self) -> Option<&Location<'_>> {
+    pub fn location(&self) -> Option<&Location<'static>> {
         // NOTE: If this is changed to sometimes return None,
         // deal with that case in std::panicking::default_hook and core::panicking::panic_fmt.
         Some(&self.location)

--- a/library/std/src/panicking.rs
+++ b/library/std/src/panicking.rs
@@ -795,7 +795,7 @@ fn payload_as_str(payload: &dyn Any) -> &str {
 #[optimize(size)]
 fn panic_with_hook(
     payload: &mut dyn PanicPayload,
-    location: &Location<'_>,
+    location: &Location<'static>,
     can_unwind: bool,
     force_no_backtrace: bool,
 ) -> ! {

--- a/library/std/src/panicking.rs
+++ b/library/std/src/panicking.rs
@@ -795,7 +795,7 @@ fn payload_as_str(payload: &dyn Any) -> &str {
 #[optimize(size)]
 fn panic_with_hook(
     payload: &mut dyn PanicPayload,
-    location: &Location<'static>,
+    location: &'static Location<'static>,
     can_unwind: bool,
     force_no_backtrace: bool,
 ) -> ! {

--- a/library/std/tests/panic.rs
+++ b/library/std/tests/panic.rs
@@ -1,7 +1,8 @@
 #![allow(dead_code)]
 
+use core::panic::PanicInfo;
 use std::cell::RefCell;
-use std::panic::{AssertUnwindSafe, UnwindSafe};
+use std::panic::{AssertUnwindSafe, Location, PanicHookInfo, UnwindSafe};
 use std::rc::Rc;
 use std::sync::{Arc, Mutex, RwLock};
 
@@ -53,4 +54,21 @@ fn panic_safety_traits() {
         assert::<Rc<AssertUnwindSafe<T>>>();
         assert::<Arc<AssertUnwindSafe<T>>>();
     }
+}
+
+#[test]
+fn panic_info_static_location<'x>() {
+    // Verify that the returned `Location<'_>`s generic lifetime is 'static when
+    // calling `PanicInfo::location`. Test failure is indicated by a compile
+    // failure, not a runtime panic.
+    let _: for<'a> fn(&'a PanicInfo<'x>) -> Option<&'a Location<'static>> = PanicInfo::location;
+}
+
+#[test]
+fn panic_hook_info_static_location<'x>() {
+    // Verify that the returned `Location<'_>`s generic lifetime is 'static when
+    // calling `PanicHookInfo::location`. Test failure is indicated by a compile
+    // failure, not a runtime panic.
+    let _: for<'a> fn(&'a PanicHookInfo<'x>) -> Option<&'a Location<'static>> =
+        PanicHookInfo::location;
 }

--- a/library/std/tests/panic.rs
+++ b/library/std/tests/panic.rs
@@ -1,8 +1,7 @@
 #![allow(dead_code)]
 
-use core::panic::PanicInfo;
 use std::cell::RefCell;
-use std::panic::{AssertUnwindSafe, Location, PanicHookInfo, UnwindSafe};
+use std::panic::{AssertUnwindSafe, UnwindSafe};
 use std::rc::Rc;
 use std::sync::{Arc, Mutex, RwLock};
 
@@ -54,21 +53,4 @@ fn panic_safety_traits() {
         assert::<Rc<AssertUnwindSafe<T>>>();
         assert::<Arc<AssertUnwindSafe<T>>>();
     }
-}
-
-#[test]
-fn panic_info_static_location<'x>() {
-    // Verify that the returned `Location<'_>`s generic lifetime is 'static when
-    // calling `PanicInfo::location`. Test failure is indicated by a compile
-    // failure, not a runtime panic.
-    let _: for<'a> fn(&'a PanicInfo<'x>) -> Option<&'a Location<'static>> = PanicInfo::location;
-}
-
-#[test]
-fn panic_hook_info_static_location<'x>() {
-    // Verify that the returned `Location<'_>`s generic lifetime is 'static when
-    // calling `PanicHookInfo::location`. Test failure is indicated by a compile
-    // failure, not a runtime panic.
-    let _: for<'a> fn(&'a PanicHookInfo<'x>) -> Option<&'a Location<'static>> =
-        PanicHookInfo::location;
 }


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/146561)*
<!-- homu-ignore:end -->

I'm writing a library that would benefit from being able to store a `&'static str` instead of a `String` for the file location of a panic. Currently, the API of [`std::panic::PanicHookInfo::location`](https://doc.rust-lang.org/nightly/std/panic/struct.PanicHookInfo.html#method.location) and [`core::panic::PanicInfo::location`](https://doc.rust-lang.org/nightly/core/panic/struct.PanicInfo.html#method.location) return a `Location<'_>` (and by extension, a file name `&str`) whose lifetime is tied to the borrow of the `Panic[Hook]Info`.

It is my understanding that the `Location`/`&str` will always be `Location<'static>`/`&'static str`, since the file name is embedded directly into the compiled binary (and I don't see a likely reason/way for that to ever change in the future). Since it seems unlikely to ever need to change, and since making the guarantee that the returned lifetime is `'static` has a real benefit (allows users to avoid unnecessary allocations), I think changing to the returned `Location<'_>`'s lifetime to `'static` would be a worthwhile change.

see also the recent [#1320870](https://github.com/rust-lang/rust/pull/132087), which made a similar change to [`std::panic::Location`](https://doc.rust-lang.org/nightly/std/panic/struct.Location.html)