### PR TITLE
compiletest: Enable new-output-capture by default

### DIFF
--- a/src/tools/compiletest/src/lib.rs
+++ b/src/tools/compiletest/src/lib.rs
@@ -472,7 +472,7 @@ pub fn parse_config(args: Vec<String>) -> Config {
             let value = matches
                 .opt_str("new-output-capture")
                 .or_else(|| env::var("COMPILETEST_NEW_OUTPUT_CAPTURE").ok())
-                .unwrap_or_else(|| "off".to_owned());
+                .unwrap_or_else(|| "on".to_owned());
             parse_bool_option(&value)
                 .unwrap_or_else(|| panic!("unknown `--new-output-capture` value `{value}` given"))
         },


### PR DESCRIPTION
The new output-capture implementation was added in rust-lang/rust#146119, but was disabled by default and required opt-in.

Since then, I haven't encountered any problems in my own testing/usage, and I haven't heard any problem reports from other contributors who might have opted in.

It's unlikely that more opt-in testing will help, so the next step is to enable new-output-capture by default and see if anyone complains. (Hopefully nobody!)

If needed, the new default can be overridden (for now) by setting environment variable `COMPILETEST_NEW_OUTPUT_CAPTURE=off`. Please file an issue (or let me know) if anyone finds a reason to do this.

r? jieyouxu