### PR TITLE
make tidy slightly less noisy

### DIFF
--- a/src/tools/tidy/src/error_codes.rs
+++ b/src/tools/tidy/src/error_codes.rs
@@ -95,7 +95,7 @@ fn check_removed_error_code_explanation(ci_info: &crate::CiInfo, bad: &mut bool)
         eprintln!("Take a look at E0001 to see how to handle it.");
         return;
     }
-    println!("No error code explanation was removed!");
+    // All good, no error code explanation was removed.
 }
 
 /// Stage 1: Parses a list of error codes from `error_codes.rs`.

--- a/src/tools/tidy/src/rustdoc_json.rs
+++ b/src/tools/tidy/src/rustdoc_json.rs
@@ -16,7 +16,6 @@ pub fn check(src_path: &Path, ci_info: &crate::CiInfo, bad: &mut bool) {
     // First we check that `src/rustdoc-json-types` was modified.
     if !crate::files_modified(ci_info, |p| p == RUSTDOC_JSON_TYPES) {
         // `rustdoc-json-types` was not modified so nothing more to check here.
-        println!("`rustdoc-json-types` was not modified.");
         return;
     }
     // Then we check that if `FORMAT_VERSION` was updated, the `Latest feature:` was also updated.


### PR DESCRIPTION
For some reason, tidy prints a bunch of stuff even when there's nothing to complain about. That's not great, it means there's a bunch of text one has to parse to understand if there's any errors hidden inside those messages.

With this patch, the output for me is
```
fmt check
fmt: checked modified file src/tools/tidy/src/error_codes.rs
fmt: checked modified file src/tools/tidy/src/rustdoc_json.rs
tidy check
Checking tidy rustdoc_json...
x.py completions check
```
Do these lines saying what is being checked make sense? I kept them for now because it may be that the error messages are hard to parse without that context, though ideally the errors would all establish this context themselves.

Do we really need to list all files that are being formatted?