### PR TITLE
tests/codegen-llvm: Make size argument to llvm.lifetime.{start,end} optional in c-variadic-lifetime test

### DIFF
--- a/tests/codegen-llvm/c-variadic-lifetime.rs
+++ b/tests/codegen-llvm/c-variadic-lifetime.rs
@@ -8,7 +8,7 @@
 
 #[unsafe(no_mangle)]
 unsafe extern "C" fn variadic(a: f64, mut args: ...) -> f64 {
-    // CHECK: call void @llvm.lifetime.start.p0(i64 {{[0-9]+}}, ptr nonnull %args)
+    // CHECK: call void @llvm.lifetime.start.p0({{(i64 [0-9]+, )?}}ptr nonnull %args)
     // CHECK: call void @llvm.va_start.p0(ptr nonnull %args)
 
     let b = args.arg::<f64>();
@@ -17,5 +17,5 @@ unsafe extern "C" fn variadic(a: f64, mut args: ...) -> f64 {
     a + b + c
 
     // CHECK: call void @llvm.va_end.p0(ptr nonnull %args)
-    // CHECK: call void @llvm.lifetime.end.p0(i64 {{[0-9]+}}, ptr nonnull %args)
+    // CHECK: call void @llvm.lifetime.end.p0({{(i64 [0-9]+, )?}}ptr nonnull %args)
 }


### PR DESCRIPTION
This parameter was removed in LLVM 22 and most tests are updated to make it optional, but apparently this one wasn't updated yet.

r? @nikic 