### PR TITLE
tests/run-make: Update list of statically linked musl targets

### DIFF
--- a/tests/run-make/musl-default-linking/rmake.rs
+++ b/tests/run-make/musl-default-linking/rmake.rs
@@ -4,7 +4,7 @@ use run_make_support::{rustc, serde_json};
 // Per https://github.com/rust-lang/compiler-team/issues/422,
 // we should be trying to move these targets to dynamically link
 // musl libc by default.
-//@ needs-llvm-components: aarch64 arm mips powerpc riscv systemz x86
+//@ needs-llvm-components: aarch64 arm mips powerpc x86
 static LEGACY_STATIC_LINKING_TARGETS: &[&'static str] = &[
     "aarch64-unknown-linux-musl",
     "arm-unknown-linux-musleabi",
@@ -14,16 +14,8 @@ static LEGACY_STATIC_LINKING_TARGETS: &[&'static str] = &[
     "armv7-unknown-linux-musleabihf",
     "i586-unknown-linux-musl",
     "i686-unknown-linux-musl",
-    "mips64-unknown-linux-musl",
-    "mips64-unknown-linux-muslabi64",
     "mips64el-unknown-linux-muslabi64",
-    "powerpc-unknown-linux-musl",
-    "powerpc-unknown-linux-muslspe",
-    "powerpc64-unknown-linux-musl",
     "powerpc64le-unknown-linux-musl",
-    "riscv32gc-unknown-linux-musl",
-    "s390x-unknown-linux-musl",
-    "thumbv7neon-unknown-linux-musleabihf",
     "x86_64-unknown-linux-musl",
 ];
 


### PR DESCRIPTION
All of the tier 3 targets in the list now link dynamically by default (except `mips64el-unknown-linux-muslabi64`, I apparently overlooked that one in my PR that changed this).

Adjust the list of targets expected to link statically accordingly.

See also https://github.com/rust-lang/rust/pull/144410, which changed these targets.

Target by target:
- `mips64-unknown-linux-musl`: this target does not exist AFAICT
- `mips64-unknown-linux-muslabi64`: updated in the linked PR
- `powerpc-unknown-linux-musl`: updated in the linked PR
- `powerpc-unknown-linux-muslspe`: updated in the linked PR
- `powerpc64-unknown-linux-musl`: updated in the linked PR
- `riscv32gc-unknown-linux-musl`: updated in the linked PR
- `s390x-unknown-linux-musl`: updated in the linked PR
- `thumbv7neon-unknown-linux-musleabihf`: updated in the linked PR