### PR TITLE
bootstrap: Don't force -static for musl targets in cc-rs

### DIFF
--- a/src/bootstrap/src/utils/cc_detect.rs
+++ b/src/bootstrap/src/utils/cc_detect.rs
@@ -48,9 +48,6 @@ fn new_cc_build(build: &Build, target: TargetSelection) -> cc::Build {
             if target.is_msvc() {
                 cfg.static_crt(true);
             }
-            if target.contains("musl") {
-                cfg.static_flag(true);
-            }
         }
     }
     cfg


### PR DESCRIPTION
I can't really make sense of this part.

For musl targets that default to static linkage, crt-static is set as a target feature and cc-rs should be able to correctly infer that -static should be used. However, you cannot compile rustc or run the tests with +crt-static, so you'd have to disable it in bootstrap.toml anyways, bypassing this codepath entirely.

But for targets that are defaulting to dynamic linkage, hardcoding -static for all musl targets in cc_detect just doesn't make sense. It breaks the run-make tests because the compiler defaults (and is configured!) to dynamically link dylibs, but the cc-rs configuration is hardcoded to link them statically, which will fail.

This fixes running `./x.py test --stage 2` on musl hosts that default to dynamic linkage and when not explicitly setting `crt-static = false` in bootstrap.toml (since that should be the default!).