### PR TITLE
Allow `lld` to be enabled on `aarch64-unknown-linux-gnu`

### DIFF
--- a/bootstrap.example.toml
+++ b/bootstrap.example.toml
@@ -759,10 +759,11 @@
 #rust.codegen-backends = ["llvm"]
 
 # Indicates whether LLD will be compiled and made available in the sysroot for rustc to execute, and
-# whether to set it as rustc's default linker on `x86_64-unknown-linux-gnu`. This will also only be
-# when *not* building an external LLVM (so only when using `download-ci-llvm` or building LLVM from
-# the in-tree source): setting `llvm-config` in the `[target.x86_64-unknown-linux-gnu]` section will
-# make this default to false.
+# whether to set it as rustc's default linker on `x86_64-unknown-linux-gnu` and
+# `aarch64-unknown-linux-gnu`. This will also only be when *not* building an external LLVM (so only
+# when using `download-ci-llvm` or building LLVM from the in-tree source): setting `llvm-config` in
+# the `[target.x86_64-unknown-linux-gnu]` or `[target.aarch64-unknown-linux-gnu`] section will make
+# this default to false.
 #rust.lld = false in all cases, except on `x86_64-unknown-linux-gnu` as described above, where it is true
 
 # Indicates whether LLD will be used to link Rust crates during bootstrap on

--- a/compiler/rustc_target/src/spec/targets/aarch64_unknown_linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_unknown_linux_gnu.rs
@@ -1,8 +1,37 @@
 use crate::spec::{
-    FramePointer, SanitizerSet, StackProbeType, Target, TargetMetadata, TargetOptions, base,
+    Cc, FramePointer, LinkerFlavor, Lld, SanitizerSet, StackProbeType, Target, TargetMetadata,
+    TargetOptions, base,
 };
 
 pub(crate) fn target() -> Target {
+    let mut base = TargetOptions {
+        features: "+v8a,+outline-atomics".into(),
+        // the AAPCS64 expects use of non-leaf frame pointers per
+        // https://github.com/ARM-software/abi-aa/blob/4492d1570eb70c8fd146623e0db65b2d241f12e7/aapcs64/aapcs64.rst#the-frame-pointer
+        // and we tend to encounter interesting bugs in AArch64 unwinding code if we do not
+        frame_pointer: FramePointer::NonLeaf,
+        mcount: "\u{1}_mcount".into(),
+        max_atomic_width: Some(128),
+        stack_probes: StackProbeType::Inline,
+        supported_sanitizers: SanitizerSet::ADDRESS
+            | SanitizerSet::CFI
+            | SanitizerSet::KCFI
+            | SanitizerSet::LEAK
+            | SanitizerSet::MEMORY
+            | SanitizerSet::MEMTAG
+            | SanitizerSet::THREAD
+            | SanitizerSet::HWADDRESS,
+        supports_xray: true,
+        ..base::linux_gnu::opts()
+    };
+
+    // When we're asked to use the `rust-lld` linker by default, set the appropriate lld-using
+    // linker flavor, and self-contained linker component.
+    if option_env!("CFG_USE_SELF_CONTAINED_LINKER").is_some() {
+        base.linker_flavor = LinkerFlavor::Gnu(Cc::Yes, Lld::Yes);
+        base.link_self_contained = crate::spec::LinkSelfContainedDefault::with_linker();
+    }
+
     Target {
         llvm_target: "aarch64-unknown-linux-gnu".into(),
         metadata: TargetMetadata {
@@ -14,25 +43,6 @@ pub(crate) fn target() -> Target {
         pointer_width: 64,
         data_layout: "e-m:e-p270:32:32-p271:32:32-p272:64:64-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128-Fn32".into(),
         arch: "aarch64".into(),
-        options: TargetOptions {
-            features: "+v8a,+outline-atomics".into(),
-            // the AAPCS64 expects use of non-leaf frame pointers per
-            // https://github.com/ARM-software/abi-aa/blob/4492d1570eb70c8fd146623e0db65b2d241f12e7/aapcs64/aapcs64.rst#the-frame-pointer
-            // and we tend to encounter interesting bugs in AArch64 unwinding code if we do not
-            frame_pointer: FramePointer::NonLeaf,
-            mcount: "\u{1}_mcount".into(),
-            max_atomic_width: Some(128),
-            stack_probes: StackProbeType::Inline,
-            supported_sanitizers: SanitizerSet::ADDRESS
-                | SanitizerSet::CFI
-                | SanitizerSet::KCFI
-                | SanitizerSet::LEAK
-                | SanitizerSet::MEMORY
-                | SanitizerSet::MEMTAG
-                | SanitizerSet::THREAD
-                | SanitizerSet::HWADDRESS,
-            supports_xray: true,
-            ..base::linux_gnu::opts()
-        },
+        options: base,
     }
 }

--- a/src/bootstrap/src/utils/change_tracker.rs
+++ b/src/bootstrap/src/utils/change_tracker.rs
@@ -546,4 +546,9 @@ pub const CONFIG_CHANGE_HISTORY: &[ChangeInfo] = &[
         severity: ChangeSeverity::Info,
         summary: "The default value of the `gcc.download-ci-gcc` option has been changed to `true`.",
     },
+    ChangeInfo {
+        change_id: 146604,
+        severity: ChangeSeverity::Info,
+        summary: "Setting `rust.lld = true` when building rustc for the `aarch64-unknown-linux-gnu` target will now also cause that rustc to use the LLD linker by default.",
+    },
 ];


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

On Ferrocene, we set `rust.lld = true` and have recently added a check to validate that the `-fuse-ld=lld` argument is passed in https://github.com/ferrocene/ferrocene/pull/1733. When running our tests I noticed the `aarch64-unknown-linux-gnu` target was failing.

Looking into it, I noticed that the aarch64 target lacks what the x86_64 target has in this regard:

https://github.com/rust-lang/rust/blob/f3fd3efe4f698ad9dc2ccd6b46a3b07e1bc911da/compiler/rustc_target/src/spec/targets/x86_64_unknown_linux_gnu.rs#L23-L28

I adjusted the target to the included the related changes to Ferrocene and ran our full suite as well as validated the check from https://github.com/ferrocene/ferrocene/pull/1733 also passes.

## Testing

You can validate this by taking an `aarch64-unknown-linux-gnu` host with a config like:

```toml
profile = "compiler"

[rust]
lld = true
```

Validate that `rustc` doesn't pass anything about `lld`:

```bash
./x.py build --stage 1
```

Then, with a your [toolchain link, as specified in the `rustc-dev-guide`](https://rustc-dev-guide.rust-lang.org/building/how-to-build-and-run.html#creating-a-rustup-toolchain), run the following:

```bash
echo "fn main() {}" > main.rs
rustc +stage1 main.rs --print link-args | grep lld
```

Notice no output is provided. Next, using this branch:

```bash
./x.py build --stage 1
rustc +stage1 main.rs --print link-args | grep lld
```

Validate how the output includes `-fuse-ld=lld`.
