### PR TITLE
Bump rustfix 0.8.1 -> 0.8.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4817,9 +4817,9 @@ dependencies = [
 
 [[package]]
 name = "rustfix"
-version = "0.8.1"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81864b097046da5df3758fdc6e4822bbb70afa06317e8ca45ea1b51cb8c5e5a4"
+checksum = "82fa69b198d894d84e23afde8e9ab2af4400b2cba20d6bf2b428a8b01c222c5a"
 dependencies = [
  "serde",
  "serde_json",

--- a/tests/ui/associated-types/associated-types-for-unimpl-trait.fixed
+++ b/tests/ui/associated-types/associated-types-for-unimpl-trait.fixed
@@ -8,7 +8,7 @@ trait Get {
 }
 
 trait Other {
-    fn uhoh<U: Get>(&self, foo: U, bar: <Self as Get>::Value) where Self: Sized, Self: Get, Self: Get {}
+    fn uhoh<U: Get>(&self, foo: U, bar: <Self as Get>::Value) where Self: Sized, Self: Get {}
     //~^ ERROR the trait bound `Self: Get` is not satisfied
     //~| ERROR the trait bound `Self: Get` is not satisfied
 }

--- a/tests/ui/lifetimes/issue-105507.fixed
+++ b/tests/ui/lifetimes/issue-105507.fixed
@@ -31,7 +31,7 @@ impl<T> ProjectedMyTrait for T
 
 fn require_trait<T: MyTrait>(_: T) {}
 
-fn foo<T : MyTrait + 'static + 'static, U : MyTrait + 'static + 'static>(wrap: Wrapper<'_, Option<T>>, wrap1: Wrapper<'_, Option<U>>) {
+fn foo<T : MyTrait + 'static, U : MyTrait + 'static>(wrap: Wrapper<'_, Option<T>>, wrap1: Wrapper<'_, Option<U>>) {
     //~^ HELP consider restricting the type parameter to the `'static` lifetime
     //~| HELP consider restricting the type parameter to the `'static` lifetime
     require_trait(wrap);

--- a/tests/ui/parser/expr-as-stmt.fixed
+++ b/tests/ui/parser/expr-as-stmt.fixed
@@ -66,7 +66,7 @@ fn asteroids() -> impl FnOnce() -> bool {
 
 // https://github.com/rust-lang/rust/issues/105179
 fn r#match() -> i32 {
-    ((match () { () => 1 })) + match () { () => 1 } //~ ERROR expected expression, found `+`
+    (match () { () => 1 }) + match () { () => 1 } //~ ERROR expected expression, found `+`
     //~^ ERROR mismatched types
 }
 
@@ -82,7 +82,7 @@ fn matches() -> bool {
     (match () { _ => true }) && match () { _ => true }; //~ ERROR mismatched types
     //~^ ERROR expected `;`, found keyword `match`
     (match () { _ => true }) && true; //~ ERROR mismatched types
-    ((match () { _ => true })) && true //~ ERROR mismatched types
+    (match () { _ => true }) && true //~ ERROR mismatched types
     //~^ ERROR mismatched types
 }
 fn main() {}

--- a/tests/ui/suggestions/missing-bound-in-derive-copy-impl-2.fixed
+++ b/tests/ui/suggestions/missing-bound-in-derive-copy-impl-2.fixed
@@ -8,7 +8,7 @@ pub struct Vector2<T: Debug + Copy + Clone> {
 }
 
 #[derive(Debug, Copy, Clone)]
-pub struct AABB<K: Debug + std::marker::Copy + std::marker::Copy + std::marker::Copy + std::marker::Copy> {
+pub struct AABB<K: Debug + std::marker::Copy> {
     pub loc: Vector2<K>, //~ ERROR the trait bound `K: Copy` is not satisfied
     //~^ ERROR the trait bound `K: Copy` is not satisfied
     //~| ERROR the trait bound `K: Copy` is not satisfied

--- a/tests/ui/suggestions/missing-bound-in-derive-copy-impl-3.fixed
+++ b/tests/ui/suggestions/missing-bound-in-derive-copy-impl-3.fixed
@@ -8,7 +8,7 @@ pub struct Vector2<T: Debug + Copy + Clone>{
 }
 
 #[derive(Debug, Copy, Clone)] //~ ERROR the trait `Copy` cannot be implemented for this type
-pub struct AABB<K: Copy + Debug + std::fmt::Debug + std::fmt::Debug + std::fmt::Debug>{
+pub struct AABB<K: Copy + Debug + std::fmt::Debug>{
     pub loc: Vector2<K>, //~ ERROR `K` doesn't implement `Debug`
     //~^ ERROR `K` doesn't implement `Debug`
     pub size: Vector2<K> //~ ERROR `K` doesn't implement `Debug`

--- a/tests/ui/suggestions/trait-impl-bound-suggestions.fixed
+++ b/tests/ui/suggestions/trait-impl-bound-suggestions.fixed
@@ -10,7 +10,7 @@ struct ConstrainedStruct<X: Copy> {
 }
 
 #[allow(dead_code)]
-trait InsufficientlyConstrainedGeneric<X=()> where Self: Sized, X: std::marker::Copy, X: std::marker::Copy {
+trait InsufficientlyConstrainedGeneric<X=()> where Self: Sized, X: std::marker::Copy {
     fn return_the_constrained_type(&self, x: X) -> ConstrainedStruct<X> {
         //~^ ERROR the trait bound `X: Copy` is not satisfied
         ConstrainedStruct { x }
@@ -20,7 +20,7 @@ trait InsufficientlyConstrainedGeneric<X=()> where Self: Sized, X: std::marker::
 
 // Regression test for #120838
 #[allow(dead_code)]
-trait InsufficientlyConstrainedGenericWithEmptyWhere<X=()> where Self: Sized, X: std::marker::Copy, X: std::marker::Copy {
+trait InsufficientlyConstrainedGenericWithEmptyWhere<X=()> where Self: Sized, X: std::marker::Copy {
     fn return_the_constrained_type(&self, x: X) -> ConstrainedStruct<X> {
         //~^ ERROR the trait bound `X: Copy` is not satisfied
         ConstrainedStruct { x }


### PR DESCRIPTION
This commit can be replicated by running `cargo update -p rustfix --precise 0.8.7 && x test ui --bless`.

---

The reasons this affects UI tests is as follows:
- The UI test suite runs rustc with `-Z deduplicate-diagnostics=no --error-format=json`, which means that rustc emits multiple errors containing identical suggestions. That caused the weird-looking code that had multiple `X: Copy` suggestions.
- Those suggestions are interpreted not by rustc itself, but by the `rustfix` library, maintained by cargo but published as a separate crates.io library and used by compiletest.
- Sometime between rustfix 0.8.1 and 0.8.7 (probably in rust-lang/cargo#14747, but it's hard to tell because rustfix's versioning doesn't match cargo's), rustfix got smarter and stopped applying duplicate suggestions.

Update rustfix to match cargo's behavior. Ideally, we would always share a version of rustfix between cargo and rustc (perhaps with a path dependency?), to make sure we are testing the behavior we ship. But for now, just manually update it to match.

Note that the latest version of rustfix published to crates.io is 0.9.1, not 0.8.7. But 0.9.1 is not the version used in cargo, which is 0.9.3. Rather than trying to match versions exactly, I just updated rustfix to the latest in the 0.8 branch.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
