### PR TITLE
Don’t suggest foreign `doc(hidden)` types in "the following other types implement trait" diagnostics

### DIFF
--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -1894,6 +1894,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         other: bool,
         param_env: ty::ParamEnv<'tcx>,
     ) -> bool {
+        let parent_map = self.tcx.visible_parent_map(());
         let alternative_candidates = |def_id: DefId| {
             let mut impl_candidates: Vec<_> = self
                 .tcx
@@ -1918,7 +1919,21 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                         // FIXME(compiler-errors): This could be generalized, both to
                         // be more granular, and probably look past other `#[fundamental]`
                         // types, too.
-                        self.tcx.visibility(def.did()).is_accessible_from(body_def_id, self.tcx)
+                        let mut did = def.did();
+                        if self.tcx.visibility(did).is_accessible_from(body_def_id, self.tcx) {
+                            // don't suggest foreign `#[doc(hidden)]` types
+                            if !did.is_local() {
+                                while let Some(parent) = parent_map.get(&did) {
+                                    if self.tcx.is_doc_hidden(did) {
+                                        return false;
+                                    }
+                                    did = *parent;
+                                }
+                            }
+                            true
+                        } else {
+                            false
+                        }
                     } else {
                         true
                     }

--- a/tests/ui/proc-macro/quote/not-quotable.stderr
+++ b/tests/ui/proc-macro/quote/not-quotable.stderr
@@ -15,8 +15,8 @@ LL |     let _ = quote! { $ip };
              Cow<'_, T>
              Option<T>
              Rc<T>
-             RepInterp<T>
-           and 25 others
+             bool
+           and 24 others
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/suggestions/auxiliary/hidden-struct.rs
+++ b/tests/ui/suggestions/auxiliary/hidden-struct.rs
@@ -1,3 +1,5 @@
+// `Foo` and `Bar` should not be suggested in diagnostics of dependents
+
 #[doc(hidden)]
 pub mod hidden {
     pub struct Foo;
@@ -5,13 +7,29 @@ pub mod hidden {
 
 pub mod hidden1 {
     #[doc(hidden)]
-    pub struct Foo;
-}
-
-
-#[doc(hidden)]
-pub(crate) mod hidden2 {
     pub struct Bar;
 }
 
-pub use hidden2::Bar;
+// `Baz` and `Quux` *should* be suggested in diagnostics of dependents
+
+#[doc(hidden)]
+pub mod hidden2 {
+    pub struct Baz;
+}
+
+pub use hidden2::Baz;
+
+#[doc(hidden)]
+pub(crate) mod hidden3 {
+    pub struct Quux;
+}
+
+pub use hidden3::Quux;
+
+pub trait Marker {}
+
+impl Marker for Option<u32> {}
+impl Marker for hidden::Foo {}
+impl Marker for hidden1::Bar {}
+impl Marker for Baz {}
+impl Marker for Quux {}

--- a/tests/ui/suggestions/dont-suggest-foreign-doc-hidden.rs
+++ b/tests/ui/suggestions/dont-suggest-foreign-doc-hidden.rs
@@ -1,5 +1,4 @@
 //@ aux-build:hidden-struct.rs
-//@ compile-flags: --crate-type lib
 
 extern crate hidden_struct;
 
@@ -9,7 +8,20 @@ mod local {
 }
 
 pub fn test(_: Foo) {}
-//~^ ERROR cannot find type `Foo` in this scope
+//~^ ERROR [E0412]
 
 pub fn test2(_: Bar) {}
-//~^ ERROR cannot find type `Bar` in this scope
+//~^ ERROR [E0412]
+
+pub fn test3(_: Baz) {}
+//~^ ERROR [E0412]
+
+pub fn test4(_: Quux) {}
+//~^ ERROR [E0412]
+
+fn test5<T: hidden_struct::Marker>() {}
+
+fn main() {
+    test5::<i32>();
+    //~^ ERROR [E0277]
+}

--- a/tests/ui/suggestions/dont-suggest-foreign-doc-hidden.stderr
+++ b/tests/ui/suggestions/dont-suggest-foreign-doc-hidden.stderr
@@ -1,5 +1,5 @@
 error[E0412]: cannot find type `Foo` in this scope
-  --> $DIR/dont-suggest-foreign-doc-hidden.rs:11:16
+  --> $DIR/dont-suggest-foreign-doc-hidden.rs:10:16
    |
 LL | pub fn test(_: Foo) {}
    |                ^^^ not found in this scope
@@ -10,16 +10,50 @@ LL + use local::Foo;
    |
 
 error[E0412]: cannot find type `Bar` in this scope
-  --> $DIR/dont-suggest-foreign-doc-hidden.rs:14:17
+  --> $DIR/dont-suggest-foreign-doc-hidden.rs:13:17
    |
 LL | pub fn test2(_: Bar) {}
+   |                 ^^^ not found in this scope
+
+error[E0412]: cannot find type `Baz` in this scope
+  --> $DIR/dont-suggest-foreign-doc-hidden.rs:16:17
+   |
+LL | pub fn test3(_: Baz) {}
    |                 ^^^ not found in this scope
    |
 help: consider importing this struct
    |
-LL + use hidden_struct::Bar;
+LL + use hidden_struct::Baz;
    |
 
-error: aborting due to 2 previous errors
+error[E0412]: cannot find type `Quux` in this scope
+  --> $DIR/dont-suggest-foreign-doc-hidden.rs:19:17
+   |
+LL | pub fn test4(_: Quux) {}
+   |                 ^^^^ not found in this scope
+   |
+help: consider importing this struct
+   |
+LL + use hidden_struct::Quux;
+   |
 
-For more information about this error, try `rustc --explain E0412`.
+error[E0277]: the trait bound `i32: Marker` is not satisfied
+  --> $DIR/dont-suggest-foreign-doc-hidden.rs:25:13
+   |
+LL |     test5::<i32>();
+   |             ^^^ the trait `Marker` is not implemented for `i32`
+   |
+   = help: the following other types implement trait `Marker`:
+             Baz
+             Option<u32>
+             Quux
+note: required by a bound in `test5`
+  --> $DIR/dont-suggest-foreign-doc-hidden.rs:22:13
+   |
+LL | fn test5<T: hidden_struct::Marker>() {}
+   |             ^^^^^^^^^^^^^^^^^^^^^ required by this bound in `test5`
+
+error: aborting due to 5 previous errors
+
+Some errors have detailed explanations: E0277, E0412.
+For more information about an error, try `rustc --explain E0277`.


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/132024.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

@rustbot label A-diagnostics T-compiler