### PR TITLE
Add regression test for issue #91831

### DIFF
--- a/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-one-is-struct-5.rs
+++ b/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-one-is-struct-5.rs
@@ -1,0 +1,13 @@
+// Regression test for #91831
+
+struct Foo<'a>(&'a i32);
+
+impl<'a> Foo<'a> {
+    fn modify(&'a mut self) {}
+}
+
+fn bar(foo: &mut Foo) {
+    foo.modify(); //~ ERROR lifetime may not live long enough
+}
+
+fn main() {}

--- a/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-one-is-struct-5.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-one-is-struct-5.stderr
@@ -1,0 +1,20 @@
+error: lifetime may not live long enough
+  --> $DIR/ex3-both-anon-regions-one-is-struct-5.rs:10:5
+   |
+LL | fn bar(foo: &mut Foo) {
+   |        ---  - let's call the lifetime of this reference `'1`
+   |        |
+   |        has type `&mut Foo<'2>`
+LL |     foo.modify();
+   |     ^^^^^^^^^^^^ argument requires that `'1` must outlive `'2`
+   |
+   = note: requirement occurs because of a mutable reference to `Foo<'_>`
+   = note: mutable references are invariant over their type parameter
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
+help: consider introducing a named lifetime parameter
+   |
+LL | fn bar<'a>(foo: &'a mut Foo<'a>) {
+   |       ++++       ++        ++++
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
The requested test for rust-lang/rust#91831. I'm unsure about the filename, the file structure in `tests/ui/lifetimes/lifetime-errors/` isn't entirely clear to me. Any suggestions?


Closes rust-lang/rust#91831 