### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
@@ -2955,6 +2955,28 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         )
                     {
                         let deref_kind = if checked_ty.is_box() {
+                            // detect Box::new(..)
+                            if let ExprKind::Call(box_new, [_]) = expr.kind
+                                && let ExprKind::Path(qpath) = &box_new.kind
+                                && let Res::Def(DefKind::AssocFn, fn_id) =
+                                    self.typeck_results.borrow().qpath_res(qpath, box_new.hir_id)
+                                && let Some(impl_id) = self.tcx.inherent_impl_of_assoc(fn_id)
+                                && self.tcx.type_of(impl_id).skip_binder().is_box()
+                                && self.tcx.item_name(fn_id) == sym::new
+                            {
+                                let l_paren = self.tcx.sess.source_map().next_point(box_new.span);
+                                let r_paren = self.tcx.sess.source_map().end_point(expr.span);
+                                return Some((
+                                    vec![
+                                        (box_new.span.to(l_paren), String::new()),
+                                        (r_paren, String::new()),
+                                    ],
+                                    "consider removing the Box".to_string(),
+                                    Applicability::MachineApplicable,
+                                    false,
+                                    false,
+                                ));
+                            }
                             "unboxing the value"
                         } else if checked_ty.is_ref() {
                             "dereferencing the borrow"

--- a/compiler/rustc_middle/src/ty/util.rs
+++ b/compiler/rustc_middle/src/ty/util.rs
@@ -1359,6 +1359,7 @@ impl<'tcx> Ty<'tcx> {
     /// 2229 drop reorder migration analysis.
     #[inline]
     pub fn has_significant_drop(self, tcx: TyCtxt<'tcx>, typing_env: ty::TypingEnv<'tcx>) -> bool {
+        assert!(!self.has_non_region_infer());
         // Avoid querying in simple cases.
         match needs_drop_components(tcx, self) {
             Err(AlwaysRequiresDrop) => true,
@@ -1370,14 +1371,6 @@ impl<'tcx> Ty<'tcx> {
                     [component_ty] => component_ty,
                     _ => self,
                 };
-
-                // FIXME(#86868): We should be canonicalizing, or else moving this to a method of inference
-                // context, or *something* like that, but for now just avoid passing inference
-                // variables to queries that can't cope with them. Instead, conservatively
-                // return "true" (may change drop order).
-                if query_ty.has_infer() {
-                    return true;
-                }
 
                 // This doesn't depend on regions, so try to minimize distinct
                 // query keys used.

--- a/tests/run-make/musl-default-linking/rmake.rs
+++ b/tests/run-make/musl-default-linking/rmake.rs
@@ -4,7 +4,7 @@ use run_make_support::{rustc, serde_json};
 // Per https://github.com/rust-lang/compiler-team/issues/422,
 // we should be trying to move these targets to dynamically link
 // musl libc by default.
-//@ needs-llvm-components: aarch64 arm mips powerpc riscv systemz x86
+//@ needs-llvm-components: aarch64 arm mips powerpc x86
 static LEGACY_STATIC_LINKING_TARGETS: &[&'static str] = &[
     "aarch64-unknown-linux-musl",
     "arm-unknown-linux-musleabi",
@@ -14,16 +14,8 @@ static LEGACY_STATIC_LINKING_TARGETS: &[&'static str] = &[
     "armv7-unknown-linux-musleabihf",
     "i586-unknown-linux-musl",
     "i686-unknown-linux-musl",
-    "mips64-unknown-linux-musl",
-    "mips64-unknown-linux-muslabi64",
     "mips64el-unknown-linux-muslabi64",
-    "powerpc-unknown-linux-musl",
-    "powerpc-unknown-linux-muslspe",
-    "powerpc64-unknown-linux-musl",
     "powerpc64le-unknown-linux-musl",
-    "riscv32gc-unknown-linux-musl",
-    "s390x-unknown-linux-musl",
-    "thumbv7neon-unknown-linux-musleabihf",
     "x86_64-unknown-linux-musl",
 ];
 

--- a/tests/ui/coercion/coerce-block-tail.stderr
+++ b/tests/ui/coercion/coerce-block-tail.stderr
@@ -6,10 +6,11 @@ LL |     let _: &i32 = & { Box::new(1i32) };
    |
    = note: expected type `i32`
             found struct `Box<i32>`
-help: consider unboxing the value
+help: consider removing the Box
    |
-LL |     let _: &i32 = & { *Box::new(1i32) };
-   |                       +
+LL -     let _: &i32 = & { Box::new(1i32) };
+LL +     let _: &i32 = & { 1i32 };
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/coercion/coerce-box-new-to-unboxed.rs
+++ b/tests/ui/coercion/coerce-box-new-to-unboxed.rs
@@ -1,0 +1,4 @@
+fn main() {
+    let _: String = Box::new(String::new());
+    //~^ ERROR mismatched types
+}

--- a/tests/ui/coercion/coerce-box-new-to-unboxed.stderr
+++ b/tests/ui/coercion/coerce-box-new-to-unboxed.stderr
@@ -1,0 +1,19 @@
+error[E0308]: mismatched types
+  --> $DIR/coerce-box-new-to-unboxed.rs:2:21
+   |
+LL |     let _: String = Box::new(String::new());
+   |            ------   ^^^^^^^^^^^^^^^^^^^^^^^ expected `String`, found `Box<String>`
+   |            |
+   |            expected due to this
+   |
+   = note: expected struct `String`
+              found struct `Box<String>`
+help: consider removing the Box
+   |
+LL -     let _: String = Box::new(String::new());
+LL +     let _: String = String::new();
+   |
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/type-inference/has_sigdrop.rs
+++ b/tests/ui/type-inference/has_sigdrop.rs
@@ -1,0 +1,18 @@
+//@ run-pass
+// Inference, canonicalization, and significant drops should work nicely together.
+// Related issue: #86868
+
+#[clippy::has_significant_drop]
+struct DropGuy {}
+
+fn creator() -> DropGuy {
+    DropGuy {}
+}
+
+fn dropper() {
+    let _ = creator();
+}
+
+fn main() {
+    dropper();
+}


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#145181 (remove FIXME block from `has_significant_drop`, it never encounters inference variables)
 - rust-lang/rust#146259 (Suggest removing Box::new instead of unboxing it)
 - rust-lang/rust#146588 (tests/run-make: Update list of statically linked musl targets)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=145181,146259,146588)
<!-- homu-ignore:end -->