### PR TITLE
Fix uses of "adaptor"

### DIFF
--- a/library/core/src/iter/adapters/flatten.rs
+++ b/library/core/src/iter/adapters/flatten.rs
@@ -779,7 +779,7 @@ impl<T> OneShot for result::IterMut<'_, T> {}
 impl<T> OneShot for Empty<T> {}
 impl<T> OneShot for array::IntoIter<T, 0> {}
 
-// These adaptors never increase the number of items.
+// These adapters never increase the number of items.
 // (There are more possible, but for now this matches BoundedSize above.)
 impl<I: OneShot> OneShot for Cloned<I> {}
 impl<I: OneShot> OneShot for Copied<I> {}

--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -1081,7 +1081,7 @@ pub trait Read {
         default_read_buf_exact(self, cursor)
     }
 
-    /// Creates a "by reference" adaptor for this instance of `Read`.
+    /// Creates a "by reference" adapter for this instance of `Read`.
     ///
     /// The returned adapter also implements `Read` and will simply borrow this
     /// current reader.

--- a/tests/ui/iterators/issue-58952-filter-type-length.rs
+++ b/tests/ui/iterators/issue-58952-filter-type-length.rs
@@ -2,7 +2,7 @@
 
 //! This snippet causes the type length to blowup exponentially,
 //! so check that we don't accidentally exceed the type length limit.
-// FIXME: Once the size of iterator adaptors is further reduced,
+// FIXME: Once the size of iterator adapters is further reduced,
 // increase the complexity of this test.
 use std::collections::VecDeque;
 

--- a/tests/ui/traits/next-solver/typeck/normalize-in-upvar-collection.rs
+++ b/tests/ui/traits/next-solver/typeck/normalize-in-upvar-collection.rs
@@ -1,7 +1,7 @@
 //@ compile-flags: -Znext-solver
 //@ check-pass
 
-// Fixes a regression in icu_provider_adaptors where we weren't normalizing the
+// Fixes a regression in icu_provider_adapters where we weren't normalizing the
 // return type of a function type before performing a `Ty::builtin_deref` call,
 // leading to an ICE.
 


### PR DESCRIPTION
These docs are in en_US, so "adapter" is the correct spelling (and indeed used in the next line.)

A second commit comes along for the ride to fix other instances in non-rustdoc comments.