### PR TITLE
Improve `core` coverage

### DIFF
--- a/library/coretests/tests/cmp.rs
+++ b/library/coretests/tests/cmp.rs
@@ -119,6 +119,13 @@ fn test_user_defined_eq() {
 }
 
 #[test]
+fn test_clamp() {
+    assert_eq!((-3).clamp(-2, 1), -2);
+    assert_eq!(0.clamp(-2, 1), 0);
+    assert_eq!(2.clamp(-2, 1), 1);
+}
+
+#[test]
 fn ordering_const() {
     // test that the methods of `Ordering` are usable in a const context
 

--- a/library/coretests/tests/option.rs
+++ b/library/coretests/tests/option.rs
@@ -249,6 +249,12 @@ fn test_unwrap_or_else() {
 }
 
 #[test]
+fn test_unwrap_or_default() {
+    assert_eq!(Some(666u32).unwrap_or_default(), 666);
+    assert_eq!(None::<u32>.unwrap_or_default(), 0);
+}
+
+#[test]
 fn test_unwrap_unchecked() {
     assert_eq!(unsafe { Some(1).unwrap_unchecked() }, 1);
     let s = unsafe { Some("hello".to_string()).unwrap_unchecked() };

--- a/library/coretests/tests/result.rs
+++ b/library/coretests/tests/result.rs
@@ -45,6 +45,18 @@ fn test_or_else() {
 }
 
 #[test]
+fn test_map_or() {
+    assert_eq!(op1().map_or(667, |x| x), 666);
+    assert_eq!(op2().map_or(666, |_| panic!()), 666);
+}
+
+#[test]
+fn test_copied() {
+    assert!(Ok::<&isize, isize>(&1).copied() == Ok(1));
+    assert!(Err::<&isize, isize>(1).copied() == Err(1));
+}
+
+#[test]
 fn test_impl_map() {
     assert!(Ok::<isize, isize>(1).map(|x| x + 1) == Ok(2));
     assert!(Err::<isize, isize>(1).map(|x| x + 1) == Err(1));


### PR DESCRIPTION
This PR improves the coverage of the `cmp`, `result` and `option` modules by adding a few new tests to `coretests`.

r? libs
