### PR TITLE
Implement ExactSizeIterator for `Zip<A, Repeat<B>>`

### DIFF
--- a/library/core/src/iter/adapters/zip.rs
+++ b/library/core/src/iter/adapters/zip.rs
@@ -1,7 +1,7 @@
 use crate::cmp;
 use crate::fmt::{self, Debug};
 use crate::iter::{
-    FusedIterator, InPlaceIterable, SourceIter, TrustedFused, TrustedLen, UncheckedIterator,
+    FusedIterator, InPlaceIterable, Repeat, SourceIter, TrustedFused, TrustedLen, UncheckedIterator,
 };
 use crate::num::NonZero;
 
@@ -409,6 +409,22 @@ where
 impl<A, B> ExactSizeIterator for Zip<A, B>
 where
     A: ExactSizeIterator,
+    B: ExactSizeIterator,
+{
+}
+
+#[stable(feature = "exact_size_zip_repeat", since = "CURRENT_RUSTC_VERSION")]
+impl<A, B> ExactSizeIterator for Zip<A, Repeat<B>>
+where
+    A: ExactSizeIterator,
+    B: Clone,
+{
+}
+
+#[stable(feature = "exact_size_zip_repeat", since = "CURRENT_RUSTC_VERSION")]
+impl<A, B> ExactSizeIterator for Zip<Repeat<A>, B>
+where
+    A: Clone,
     B: ExactSizeIterator,
 {
 }

--- a/library/coretests/tests/iter/adapters/zip.rs
+++ b/library/coretests/tests/iter/adapters/zip.rs
@@ -370,3 +370,18 @@ fn test_issue_82291() {
     zip.next();
     assert_eq!(called.get(), 1);
 }
+
+#[test]
+fn zip_repeat_bounds() {
+    let iter = [1, 2, 3].into_iter().zip(repeat(2));
+    let (lower, upper) = iter.size_hint();
+    assert_eq!(lower, 3);
+    assert_eq!(upper, Some(3));
+    assert_eq!(iter.len(), 3);
+
+    let iter = repeat(2).zip([1, 2, 3].into_iter());
+    let (lower, upper) = iter.size_hint();
+    assert_eq!(lower, 3);
+    assert_eq!(upper, Some(3));
+    assert_eq!(iter.len(), 3);
+}


### PR DESCRIPTION
Where:
    A: ExactSizeIterator,
    B: Clone,

And the symmetrical instance.

The only other instance for `ExactSizeIterator<Zip<_, _>>` requires each zipped iterator to be `ExactSizeIterator`, and since `Repeat` does not implement `ExactSizeIterator`, these instances don't overlap with anything.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

---

I [posted](https://internals.rust-lang.org/t/pre-rfc-implement-exactsizeiterator-for-zip-a-repeat-b-where-a-exactsizeiterator-b-clone/23537) on the internals forum, and was told these instances would be `insta-stable`.

The `stable` attribute seems to require `feature` and `since` attributes, which I'm not entirely sure I've done correctly. Pointers are welcome.