### PR TITLE
Cleanup `FnDecl::inner_full_print`

### DIFF
--- a/src/librustdoc/display.rs
+++ b/src/librustdoc/display.rs
@@ -10,7 +10,7 @@ pub(crate) trait Joined: IntoIterator {
     ///
     /// The performance of `joined` is slightly better than `format`, since it doesn't need to use a `Cell` to keep track of whether [`fmt`](Display::fmt)
     /// was already called (`joined`'s API doesn't allow it be called more than once).
-    fn joined(self, sep: &str, f: &mut Formatter<'_>) -> fmt::Result;
+    fn joined(self, sep: impl Display, f: &mut Formatter<'_>) -> fmt::Result;
 }
 
 impl<I, T> Joined for I
@@ -18,12 +18,12 @@ where
     I: IntoIterator<Item = T>,
     T: Display,
 {
-    fn joined(self, sep: &str, f: &mut Formatter<'_>) -> fmt::Result {
+    fn joined(self, sep: impl Display, f: &mut Formatter<'_>) -> fmt::Result {
         let mut iter = self.into_iter();
         let Some(first) = iter.next() else { return Ok(()) };
         first.fmt(f)?;
         for item in iter {
-            f.write_str(sep)?;
+            sep.fmt(f)?;
             item.fmt(f)?;
         }
         Ok(())


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

`inner_full_print` was pretty hard to follow IMHO.
Hopefully this cleans it up a little bit.

Also, it was checking whether `self.inputs` is empty twice, and then handling an unreachable match arm:
https://github.com/yotamofek/rust/blob/f836ae4e663b6e8938096b8559e094d18361be55/src/librustdoc/html/format.rs#L1368C1-L1368C33
`last_input_index` could only be `None` if the fn has no parameters, in which case the loop body would never run.

r? @GuillaumeGomez if you have the capacity :)

BTW, can we rename `FnDecl::inputs` to `parameters` or something? And `output` to `return_ty`?