### PR TITLE
cmse: fix 'region variables should not be hashed'

### DIFF
--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/cmse.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/cmse.rs
@@ -128,6 +128,7 @@ fn is_valid_cmse_inputs<'tcx>(
 
     // this type is only used for layout computation, which does not rely on regions
     let fn_sig = tcx.instantiate_bound_regions_with_erased(fn_sig);
+    let fn_sig = tcx.erase_and_anonymize_regions(fn_sig);
 
     for (index, ty) in fn_sig.inputs().iter().enumerate() {
         let layout = tcx.layout_of(ty::TypingEnv::fully_monomorphized().as_query_input(*ty))?;

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-call/undeclared-lifetime.rs
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-call/undeclared-lifetime.rs
@@ -1,0 +1,20 @@
+//@ add-core-stubs
+//@ compile-flags: --target thumbv8m.main-none-eabi --crate-type lib -Cincremental=true
+//@ needs-llvm-components: arm
+#![feature(abi_cmse_nonsecure_call, no_core)]
+#![no_core]
+
+extern crate minicore;
+use minicore::*;
+
+// A regression test for https://github.com/rust-lang/rust/issues/131639.
+// NOTE: -Cincremental=true was required for triggering the bug.
+
+fn foo() {
+    id::<extern "cmse-nonsecure-call" fn(&'a ())>(PhantomData);
+    //~^ ERROR use of undeclared lifetime name `'a`
+}
+
+fn id<T>(x: PhantomData<T>) -> PhantomData<T> {
+    x
+}

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-call/undeclared-lifetime.stderr
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-call/undeclared-lifetime.stderr
@@ -1,0 +1,19 @@
+error[E0261]: use of undeclared lifetime name `'a`
+  --> $DIR/undeclared-lifetime.rs:14:43
+   |
+LL |     id::<extern "cmse-nonsecure-call" fn(&'a ())>(PhantomData);
+   |                                           ^^ undeclared lifetime
+   |
+   = note: for more information on higher-ranked polymorphism, visit https://doc.rust-lang.org/nomicon/hrtb.html
+help: consider making the type lifetime-generic with a new `'a` lifetime
+   |
+LL |     id::<for<'a> extern "cmse-nonsecure-call" fn(&'a ())>(PhantomData);
+   |          +++++++
+help: consider introducing lifetime `'a` here
+   |
+LL | fn foo<'a>() {
+   |       ++++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0261`.


### PR DESCRIPTION
tracking issue: https://github.com/rust-lang/rust/issues/81391
fixes https://github.com/rust-lang/rust/issues/131639

Some background: the `cmse-nonsecure-call` calling convention is used for a call from "secure" to "non-secure" code. To make sure that "non-secure" cannot read any secrets, restrictions are put on the signatures of functions with this calling convention: they can only use 4 arguments for passing arguments, and one register for passing a result. No arguments are passed via the stack, and all other registers are cleared before the call.

We check during `hir_ty_lowering` that the signature follows these rules. We do that by determining and then inspecting the layout of the type. That works well overall, but can run into asserts when the type itself is ill-formed. This PR fixes one such case.

I believe that the fix here, just erasing the regions, is the right shape, but there may be some nuance that I'm missing.

r? types