### PR TITLE
Make `Map::last` skip closure calls until last element

### DIFF
--- a/library/core/src/iter/adapters/map.rs
+++ b/library/core/src/iter/adapters/map.rs
@@ -112,6 +112,13 @@ where
         self.iter.size_hint()
     }
 
+    fn last(mut self) -> Option<Self::Item>
+    where
+        Self: Sized,
+    {
+        self.iter.last().map(&mut self.f)
+    }
+
     fn try_fold<Acc, G, R>(&mut self, init: Acc, g: G) -> R
     where
         Self: Sized,

--- a/library/coretests/tests/iter/sources.rs
+++ b/library/coretests/tests/iter/sources.rs
@@ -31,6 +31,22 @@ fn test_repeat_take_collect() {
 }
 
 #[test]
+#[should_panic = "iterator is infinite"]
+fn test_repeat_count() {
+    repeat(42).count();
+}
+
+#[test]
+fn test_repeat_last() {
+    assert_eq!(repeat(42).last(), Some(42));
+}
+
+#[test]
+fn test_repeat_map_double_last() {
+    assert_eq!(repeat(42).map(|e| 2 * e).last(), Some(2 * 42));
+}
+
+#[test]
 fn test_repeat_with() {
     #[derive(PartialEq, Debug)]
     struct NotClone(usize);


### PR DESCRIPTION
A continuation of rust-lang/rust#146410 <del>which changes the direct `count` impl for a `fold` impl, to which the default `count` delegates</del>. Also added tests for the new behavior.

EDIT: adds a `last` to `Map`.