### PR TITLE
std: pass the `Thread` for the newly spawned thread to the platform

### DIFF
--- a/library/std/src/rt.rs
+++ b/library/std/src/rt.rs
@@ -109,14 +109,16 @@ fn handle_rt_panic<T>(e: Box<dyn Any + Send>) -> T {
 // `compiler/rustc_session/src/config/sigpipe.rs`.
 #[cfg_attr(test, allow(dead_code))]
 unsafe fn init(argc: isize, argv: *const *const u8, sigpipe: u8) {
+    // Remember the main thread ID to give it the correct name. Do this
+    // immediately to make sure the correct name available to the platform
+    // functions.
+    // SAFETY: this is the only time and place where we call this function.
+    unsafe { main_thread::set(thread::current_id()) };
+
     #[cfg_attr(target_os = "teeos", allow(unused_unsafe))]
     unsafe {
         sys::init(argc, argv, sigpipe)
     };
-
-    // Remember the main thread ID to give it the correct name.
-    // SAFETY: this is the only time and place where we call this function.
-    unsafe { main_thread::set(thread::current_id()) };
 }
 
 /// Clean up the thread-local runtime state. This *should* be run after all other

--- a/library/std/src/sys/pal/unix/stack_overflow.rs
+++ b/library/std/src/sys/pal/unix/stack_overflow.rs
@@ -8,8 +8,8 @@ pub struct Handler {
 }
 
 impl Handler {
-    pub unsafe fn new(thread_name: Option<Box<str>>) -> Handler {
-        make_handler(false, thread_name)
+    pub unsafe fn new() -> Handler {
+        make_handler(false)
     }
 
     fn null() -> Handler {
@@ -118,8 +118,15 @@ mod imp {
                 if let Some(thread_info) = thread_info
                     && thread_info.guard_page_range.contains(&fault_addr)
                 {
-                    let name = thread_info.thread_name.as_deref().unwrap_or("<unknown>");
-                    let tid = crate::thread::current_os_id();
+                    // Hey you! Yes, you modifying the stack overflow message!
+                    // Please make sure that all functions called here are
+                    // actually async-signal-safe. If they're not, try retrieving
+                    // the information beforehand and storing it in `ThreadInfo`.
+                    // Thank you!
+                    // - says Jonas after having had to watch his carefully
+                    //   written code get made unsound again.
+                    let tid = thread_info.tid;
+                    let name = thread_info.name.as_deref().unwrap_or("<unknown>");
                     rtprintpanic!("\nthread '{name}' ({tid}) has overflowed its stack\n");
                     rtabort!("stack overflow");
                 }
@@ -158,12 +165,12 @@ mod imp {
                 if !NEED_ALTSTACK.load(Ordering::Relaxed) {
                     // haven't set up our sigaltstack yet
                     NEED_ALTSTACK.store(true, Ordering::Release);
-                    let handler = unsafe { make_handler(true, None) };
+                    let handler = unsafe { make_handler(true) };
                     MAIN_ALTSTACK.store(handler.data, Ordering::Relaxed);
                     mem::forget(handler);
 
                     if let Some(guard_page_range) = guard_page_range.take() {
-                        set_current_info(guard_page_range, Some(Box::from("main")));
+                        set_current_info(guard_page_range);
                     }
                 }
 
@@ -229,14 +236,14 @@ mod imp {
     /// # Safety
     /// Mutates the alternate signal stack
     #[forbid(unsafe_op_in_unsafe_fn)]
-    pub unsafe fn make_handler(main_thread: bool, thread_name: Option<Box<str>>) -> Handler {
+    pub unsafe fn make_handler(main_thread: bool) -> Handler {
         if !NEED_ALTSTACK.load(Ordering::Acquire) {
             return Handler::null();
         }
 
         if !main_thread {
             if let Some(guard_page_range) = unsafe { current_guard() } {
-                set_current_info(guard_page_range, thread_name);
+                set_current_info(guard_page_range);
             }
         }
 
@@ -632,10 +639,7 @@ mod imp {
 
     pub unsafe fn cleanup() {}
 
-    pub unsafe fn make_handler(
-        _main_thread: bool,
-        _thread_name: Option<Box<str>>,
-    ) -> super::Handler {
+    pub unsafe fn make_handler(_main_thread: bool) -> super::Handler {
         super::Handler::null()
     }
 
@@ -719,10 +723,7 @@ mod imp {
 
     pub unsafe fn cleanup() {}
 
-    pub unsafe fn make_handler(
-        main_thread: bool,
-        _thread_name: Option<Box<str>>,
-    ) -> super::Handler {
+    pub unsafe fn make_handler(main_thread: bool) -> super::Handler {
         if !main_thread {
             reserve_stack();
         }

--- a/library/std/src/sys/thread/mod.rs
+++ b/library/std/src/sys/thread/mod.rs
@@ -4,7 +4,7 @@ cfg_select! {
         pub use hermit::{Thread, available_parallelism, sleep, yield_now, DEFAULT_MIN_STACK_SIZE};
         #[expect(dead_code)]
         mod unsupported;
-        pub use unsupported::{current_os_id, set_name};
+        pub use unsupported::current_os_id;
     }
     all(target_vendor = "fortanix", target_env = "sgx") => {
         mod sgx;
@@ -21,41 +21,32 @@ cfg_select! {
         // as-is with the SGX target.
         #[expect(dead_code)]
         mod unsupported;
-        pub use unsupported::{available_parallelism, set_name};
+        pub use unsupported::available_parallelism;
     }
     target_os = "solid_asp3" => {
         mod solid;
         pub use solid::{Thread, sleep, yield_now, DEFAULT_MIN_STACK_SIZE};
         #[expect(dead_code)]
         mod unsupported;
-        pub use unsupported::{available_parallelism, current_os_id, set_name};
+        pub use unsupported::{available_parallelism, current_os_id};
     }
     target_os = "teeos" => {
         mod teeos;
         pub use teeos::{Thread, sleep, yield_now, DEFAULT_MIN_STACK_SIZE};
         #[expect(dead_code)]
         mod unsupported;
-        pub use unsupported::{available_parallelism, current_os_id, set_name};
+        pub use unsupported::{available_parallelism, current_os_id};
     }
     target_os = "uefi" => {
         mod uefi;
         pub use uefi::{available_parallelism, sleep};
         #[expect(dead_code)]
         mod unsupported;
-        pub use unsupported::{Thread, current_os_id, set_name, yield_now, DEFAULT_MIN_STACK_SIZE};
+        pub use unsupported::{Thread, current_os_id, yield_now, DEFAULT_MIN_STACK_SIZE};
     }
     target_family = "unix" => {
         mod unix;
         pub use unix::{Thread, available_parallelism, current_os_id, sleep, yield_now, DEFAULT_MIN_STACK_SIZE};
-        #[cfg(not(any(
-            target_env = "newlib",
-            target_os = "l4re",
-            target_os = "emscripten",
-            target_os = "redox",
-            target_os = "hurd",
-            target_os = "aix",
-        )))]
-        pub use unix::set_name;
         #[cfg(any(
             target_os = "freebsd",
             target_os = "netbsd",
@@ -69,17 +60,8 @@ cfg_select! {
             target_os = "vxworks",
         ))]
         pub use unix::sleep_until;
-        #[expect(dead_code)]
-        mod unsupported;
-        #[cfg(any(
-            target_env = "newlib",
-            target_os = "l4re",
-            target_os = "emscripten",
-            target_os = "redox",
-            target_os = "hurd",
-            target_os = "aix",
-        ))]
-        pub use unsupported::set_name;
+        // This is used to name the main thread in the platform init function.
+        pub(super) use unix::set_name;
     }
     all(target_os = "wasi", target_env = "p1") => {
         mod wasip1;
@@ -88,7 +70,7 @@ cfg_select! {
         pub use wasip1::{Thread, available_parallelism};
         #[expect(dead_code)]
         mod unsupported;
-        pub use unsupported::{current_os_id, set_name};
+        pub use unsupported::current_os_id;
         #[cfg(not(target_feature = "atomics"))]
         pub use unsupported::{Thread, available_parallelism};
     }
@@ -100,7 +82,7 @@ cfg_select! {
         // Note that unlike WASIp1 even if the wasm `atomics` feature is enabled
         // there is no support for threads, not even experimentally, not even in
         // wasi-libc. Thus this is unconditionally unsupported.
-        pub use unsupported::{Thread, available_parallelism, current_os_id, set_name, yield_now, DEFAULT_MIN_STACK_SIZE};
+        pub use unsupported::{Thread, available_parallelism, current_os_id, yield_now, DEFAULT_MIN_STACK_SIZE};
     }
     all(target_family = "wasm", target_feature = "atomics") => {
         mod wasm;
@@ -108,11 +90,11 @@ cfg_select! {
 
         #[expect(dead_code)]
         mod unsupported;
-        pub use unsupported::{Thread, available_parallelism, current_os_id, set_name, yield_now, DEFAULT_MIN_STACK_SIZE};
+        pub use unsupported::{Thread, available_parallelism, current_os_id, yield_now, DEFAULT_MIN_STACK_SIZE};
     }
     target_os = "windows" => {
         mod windows;
-        pub use windows::{Thread, available_parallelism, current_os_id, set_name, set_name_wide, sleep, yield_now, DEFAULT_MIN_STACK_SIZE};
+        pub use windows::{Thread, available_parallelism, current_os_id, set_name_wide, sleep, yield_now, DEFAULT_MIN_STACK_SIZE};
     }
     target_os = "xous" => {
         mod xous;
@@ -120,11 +102,11 @@ cfg_select! {
 
         #[expect(dead_code)]
         mod unsupported;
-        pub use unsupported::{current_os_id, set_name};
+        pub use unsupported::current_os_id;
     }
     _ => {
         mod unsupported;
-        pub use unsupported::{Thread, available_parallelism, current_os_id, set_name, sleep, yield_now, DEFAULT_MIN_STACK_SIZE};
+        pub use unsupported::{Thread, available_parallelism, current_os_id, sleep, yield_now, DEFAULT_MIN_STACK_SIZE};
     }
 }
 

--- a/library/std/src/sys/thread/solid.rs
+++ b/library/std/src/sys/thread/solid.rs
@@ -27,9 +27,9 @@ unsafe impl Sync for Thread {}
 /// State data shared between a parent thread and child thread. It's dropped on
 /// a transition to one of the final states.
 struct ThreadInner {
-    /// This field is used on thread creation to pass a closure from
-    /// `Thread::new` to the created task.
-    start: UnsafeCell<ManuallyDrop<Box<dyn FnOnce()>>>,
+    /// This field is used on thread creation to pass the thread handle and closure
+    /// to the newly created thread.
+    data: UnsafeCell<ManuallyDrop<(crate::thread::Thread, Box<dyn FnOnce()>)>>,
 
     /// A state machine. Each transition is annotated with `[...]` in the
     /// source code.
@@ -65,7 +65,7 @@ struct ThreadInner {
     lifecycle: Atomic<usize>,
 }
 
-// Safety: The only `!Sync` field, `ThreadInner::start`, is only touched by
+// Safety: The only `!Sync` field, `ThreadInner::data`, is only touched by
 //         the task represented by `ThreadInner`.
 unsafe impl Sync for ThreadInner {}
 
@@ -86,11 +86,11 @@ impl Thread {
     /// See `thread::Builder::spawn_unchecked` for safety requirements.
     pub unsafe fn new(
         stack: usize,
-        _name: Option<&str>,
-        p: Box<dyn FnOnce()>,
+        handle: crate::thread::Thread,
+        main: Box<dyn FnOnce()>,
     ) -> io::Result<Thread> {
         let inner = Box::new(ThreadInner {
-            start: UnsafeCell::new(ManuallyDrop::new(p)),
+            data: UnsafeCell::new(ManuallyDrop::new((handle, main))),
             lifecycle: AtomicUsize::new(LIFECYCLE_INIT),
         });
 
@@ -100,10 +100,11 @@ impl Thread {
             let inner = unsafe { &*p_inner };
 
             // Safety: Since `trampoline` is called only once for each
-            //         `ThreadInner` and only `trampoline` touches `start`,
-            //         `start` contains contents and is safe to mutably borrow.
-            let p = unsafe { ManuallyDrop::take(&mut *inner.start.get()) };
-            p();
+            //         `ThreadInner` and only `trampoline` touches `data`,
+            //         `data` contains contents and is safe to mutably borrow.
+            let (handle, main) = unsafe { ManuallyDrop::take(&mut *inner.data.get()) };
+            crate::thread::set_current(handle);
+            main();
 
             // Fix the current thread's state just in case, so that the
             // destructors won't abort

--- a/library/std/src/sys/thread/teeos.rs
+++ b/library/std/src/sys/thread/teeos.rs
@@ -22,14 +22,19 @@ pub struct Thread {
 unsafe impl Send for Thread {}
 unsafe impl Sync for Thread {}
 
+struct ThreadData {
+    handle: crate::thread::Thread,
+    main: Box<dyn FnOnce()>,
+}
+
 impl Thread {
     // unsafe: see thread::Builder::spawn_unchecked for safety requirements
     pub unsafe fn new(
         stack: usize,
-        _name: Option<&str>,
-        p: Box<dyn FnOnce()>,
+        handle: crate::thread::Thread,
+        main: Box<dyn FnOnce()>,
     ) -> io::Result<Thread> {
-        let p = Box::into_raw(Box::new(p));
+        let data = Box::into_raw(Box::new(ThreadData { handle, main }));
         let mut native: libc::pthread_t = unsafe { mem::zeroed() };
         let mut attr: libc::pthread_attr_t = unsafe { mem::zeroed() };
         assert_eq!(unsafe { libc::pthread_attr_init(&mut attr) }, 0);
@@ -62,16 +67,17 @@ impl Thread {
             }
         };
 
-        let ret = unsafe { libc::pthread_create(&mut native, &attr, thread_start, p as *mut _) };
-        // Note: if the thread creation fails and this assert fails, then p will
-        // be leaked. However, an alternative design could cause double-free
+        let ret = unsafe { libc::pthread_create(&mut native, &attr, thread_start, data as *mut _) };
+        // Note: if the thread creation fails and this assert fails, then data
+        // will be leaked. However, an alternative design could cause double-free
         // which is clearly worse.
         assert_eq!(unsafe { libc::pthread_attr_destroy(&mut attr) }, 0);
 
         return if ret != 0 {
-            // The thread failed to start and as a result p was not consumed. Therefore, it is
-            // safe to reconstruct the box so that it gets deallocated.
-            drop(unsafe { Box::from_raw(p) });
+            // The thread failed to start and as a result data was not consumed.
+            // Therefore, it is safe to reconstruct the box so that it gets
+            // deallocated.
+            drop(unsafe { Box::from_raw(data) });
             Err(io::Error::from_raw_os_error(ret))
         } else {
             // The new thread will start running earliest after the next yield.
@@ -80,15 +86,10 @@ impl Thread {
             Ok(Thread { id: native })
         };
 
-        extern "C" fn thread_start(main: *mut libc::c_void) -> *mut libc::c_void {
-            unsafe {
-                // Next, set up our stack overflow handler which may get triggered if we run
-                // out of stack.
-                // this is not necessary in TEE.
-                //let _handler = stack_overflow::Handler::new();
-                // Finally, let's run some code.
-                Box::from_raw(main as *mut Box<dyn FnOnce()>)();
-            }
+        extern "C" fn thread_start(data: *mut libc::c_void) -> *mut libc::c_void {
+            let data = unsafe { Box::from_raw(data as *mut ThreadData) };
+            crate::thread::set_current(data.handle);
+            (data.main)();
             ptr::null_mut()
         }
     }

--- a/library/std/src/sys/thread/unsupported.rs
+++ b/library/std/src/sys/thread/unsupported.rs
@@ -1,4 +1,3 @@
-use crate::ffi::CStr;
 use crate::io;
 use crate::num::NonZero;
 use crate::time::Duration;
@@ -11,7 +10,7 @@ impl Thread {
     // unsafe: see thread::Builder::spawn_unchecked for safety requirements
     pub unsafe fn new(
         _stack: usize,
-        _name: Option<&str>,
+        _handle: crate::thread::Thread,
         _p: Box<dyn FnOnce()>,
     ) -> io::Result<Thread> {
         Err(io::Error::UNSUPPORTED_PLATFORM)
@@ -32,10 +31,6 @@ pub fn current_os_id() -> Option<u64> {
 
 pub fn yield_now() {
     // do nothing
-}
-
-pub fn set_name(_name: &CStr) {
-    // nope
 }
 
 pub fn sleep(_dur: Duration) {


### PR DESCRIPTION
This PR moves the responsibility for calling `set_current` (which initialises the thread handle) to the platform implementation. This unblocks rust-lang/rust#144465 and cleans up the fallout from rust-lang/rust#144500, as well as enabling the removal of the `set_name` function on platforms without thread names (as we now have access to the thread name in the platform thread main function).

This PR also contains a second commit (sorry, I couldn't help myself) that fixes a (mostly theoretical) unsoundness introduced by rust-lang/rust#115746, which added a call to `current_os_id` to the SIGSEGV signal handler even though that function might not be async-signal-safe. The thread ID is now initialised before the stack overflow information, so the ID can be stored therein.