### PR TITLE
Remove panic-prone .unwrap() calls from build_helper

### DIFF
--- a/src/build_helper/src/git.rs
+++ b/src/build_helper/src/git.rs
@@ -274,14 +274,14 @@ pub fn get_git_modified_files(
     let files = output_result(git.args(["diff-index", "--name-status", merge_base.trim()]))?
         .lines()
         .filter_map(|f| {
-            let (status, name) = f.trim().split_once(char::is_whitespace).unwrap();
+            let (status, name) = f.trim().split_once(char::is_whitespace)?
             if status == "D" {
                 None
             } else if Path::new(name).extension().map_or(extensions.is_empty(), |ext| {
                 // If there is no extension, we allow the path if `extensions` is empty
                 // If there is an extension, we allow it if `extension` is empty or it contains the
                 // extension.
-                extensions.is_empty() || extensions.contains(&ext.to_str().unwrap())
+                extensions.is_empty() || ext.to_str().map_or(false, |ext_str| extensions.contains(&ext_str))
             }) {
                 Some(name.to_owned())
             } else {

--- a/src/build_helper/src/git.rs
+++ b/src/build_helper/src/git.rs
@@ -274,14 +274,15 @@ pub fn get_git_modified_files(
     let files = output_result(git.args(["diff-index", "--name-status", merge_base.trim()]))?
         .lines()
         .filter_map(|f| {
-            let (status, name) = f.trim().split_once(char::is_whitespace)?
+            let (status, name) = f.trim().split_once(char::is_whitespace)?;
             if status == "D" {
                 None
             } else if Path::new(name).extension().map_or(extensions.is_empty(), |ext| {
                 // If there is no extension, we allow the path if `extensions` is empty
                 // If there is an extension, we allow it if `extension` is empty or it contains the
                 // extension.
-                extensions.is_empty() || ext.to_str().map_or(false, |ext_str| extensions.contains(&ext_str))
+                extensions.is_empty()
+                    || ext.to_str().map_or(false, |ext_str| extensions.contains(&ext_str))
             }) {
                 Some(name.to_owned())
             } else {

--- a/src/build_helper/src/stage0_parser.rs
+++ b/src/build_helper/src/stage0_parser.rs
@@ -39,7 +39,13 @@ pub fn parse_stage0_file() -> Stage0 {
             continue;
         }
 
-        let (key, value) = line.split_once('=').unwrap();
+        let (key, value) = match line.split_once('=') {
+            Some((k, v)) => (k, v),
+            None => {
+                println!("Warning: Skipping malformed config line {}", line);
+                continue;
+            }
+        };
 
         match key {
             "dist_server" => stage0.config.dist_server = value.to_owned(),

--- a/src/build_helper/src/util.rs
+++ b/src/build_helper/src/util.rs
@@ -64,7 +64,13 @@ pub fn parse_gitmodules(target_dir: &Path) -> Vec<String> {
     let gitmodules = target_dir.join(".gitmodules");
     assert!(gitmodules.exists(), "'{}' file is missing.", gitmodules.display());
 
-    let file = File::open(gitmodules).unwrap();
+    let file = match File::open(&gitmodules) {
+        Ok(f) => f,
+        Err(_) => {
+            eprintln!("Warning: Could not open .gitmodules file at {}", gitmodules.display());
+            return Vec::new();
+        }
+    };
 
     let mut submodules_paths = vec![];
     for line in BufReader::new(file).lines().map_while(Result::ok) {


### PR DESCRIPTION
## Summary
  Replace panic-prone `.unwrap()` calls with defensive error handling in the build
  helper crate.

  ## Problem
  The build system could panic on malformed input from:
  - Git commands returning unexpected output format
  - Missing or unreadable .gitmodules files
  - Invalid stage0 configuration lines

  ## Solution
  - **git.rs**: Use `?` operator for safe git diff-index parsing
  - **util.rs**: Provide safe fallback for missing .gitmodules files
  - **stage0_parser.rs**: Skip malformed config lines with warnings