### PR TITLE
Save x.py's help text for saving output time

### DIFF
--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -1379,11 +1379,26 @@ def main():
         sys.argv[1] = "-h"
 
     args = parse_args(sys.argv)
-    help_triggered = args.help or len(sys.argv) == 1
 
-    # If the user is asking for help, let them know that the whole download-and-build
+    # Root help (e.g., x.py --help) prints help from the saved file to save the time
+    if len(sys.argv) == 1 or sys.argv[1] in ["-h", "--help"]:
+        try:
+            with open(
+                os.path.join(os.path.dirname(__file__), "../etc/xhelp"), "r"
+            ) as f:
+                # The file from bootstrap func already has newline.
+                print(f.read(), end="")
+                sys.exit(0)
+        except Exception as error:
+            eprint(
+                f"ERROR: unable to run help: {error}\n",
+                "x.py run generate-help may solve the problem.",
+            )
+            sys.exit(1)
+
+    # If the user is asking for other helps, let them know that the whole download-and-build
     # process has to happen before anything is printed out.
-    if help_triggered:
+    if args.help:
         eprint(
             "INFO: Downloading and building bootstrap before processing --help command.\n"
             "      See src/bootstrap/README.md for help with common commands."
@@ -1401,13 +1416,14 @@ def main():
             eprint(error)
         success_word = "unsuccessfully"
 
-    if not help_triggered:
+    if not args.help:
         eprint(
             "Build completed",
             success_word,
             "in",
             format_build_time(time() - start_time),
         )
+
     sys.exit(exit_code)
 
 

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -15,7 +15,7 @@ use crate::core::build_steps::compile::{Std, run_cargo};
 use crate::core::build_steps::doc::{DocumentationFormat, prepare_doc_compiler};
 use crate::core::build_steps::gcc::{Gcc, add_cg_gcc_cargo_flags};
 use crate::core::build_steps::llvm::get_llvm_version;
-use crate::core::build_steps::run::get_completion_paths;
+use crate::core::build_steps::run::{get_completion_paths, get_help_path};
 use crate::core::build_steps::synthetic_targets::MirOptPanicAbortSyntheticTarget;
 use crate::core::build_steps::tool::{
     self, RustcPrivateCompilers, SourceType, TEST_FLOAT_PARSE_ALLOW_FEATURES, Tool,
@@ -28,7 +28,7 @@ use crate::core::builder::{
     crate_description,
 };
 use crate::core::config::TargetSelection;
-use crate::core::config::flags::{Subcommand, get_completion};
+use crate::core::config::flags::{Subcommand, get_completion, top_level_help};
 use crate::utils::build_stamp::{self, BuildStamp};
 use crate::utils::exec::{BootstrapCommand, command};
 use crate::utils::helpers::{
@@ -1291,6 +1291,23 @@ HELP: to skip test's attempt to check tidiness, pass `--skip src/tools/tidy` to 
                 "x.py completions were changed; run `x.py run generate-completions` to update them"
             );
             crate::exit!(1);
+        }
+
+        builder.info("x.py help check");
+        if builder.config.cmd.bless() {
+            builder.ensure(crate::core::build_steps::run::GenerateHelp);
+        } else {
+            let help_path = get_help_path(builder);
+            let cur_help = std::fs::read_to_string(&help_path).unwrap_or_else(|err| {
+                eprintln!("couldn't read {}: {}", help_path.display(), err);
+                crate::exit!(1);
+            });
+            let new_help = top_level_help();
+
+            if new_help != cur_help {
+                eprintln!("x.py help was changed; run `x.py run generate-help` to update it");
+                crate::exit!(1);
+            }
         }
     }
 

--- a/src/bootstrap/src/core/builder/mod.rs
+++ b/src/bootstrap/src/core/builder/mod.rs
@@ -1239,6 +1239,7 @@ impl<'a> Builder<'a> {
                 run::CyclicStep,
                 run::CoverageDump,
                 run::Rustfmt,
+                run::GenerateHelp,
             ),
             Kind::Setup => {
                 describe!(setup::Profile, setup::Hook, setup::Link, setup::Editor)

--- a/src/bootstrap/src/core/config/flags.rs
+++ b/src/bootstrap/src/core/config/flags.rs
@@ -701,3 +701,9 @@ pub fn get_completion(shell: &dyn Generator, path: &Path) -> Option<String> {
     }
     Some(String::from_utf8(buf).expect("completion script should be UTF-8"))
 }
+
+/// Return the top level help of the bootstrap.
+pub fn top_level_help() -> String {
+    let mut cmd = Flags::command();
+    cmd.render_help().to_string()
+}

--- a/src/etc/xhelp
+++ b/src/etc/xhelp
@@ -1,0 +1,96 @@
+
+Usage: x.py <subcommand> [options] [<paths>...]
+
+Commands:
+  build    Compile either the compiler or libraries
+  check    Compile either the compiler or libraries, using cargo check
+  clippy   Run Clippy (uses rustup/cargo-installed clippy binary)
+  fix      Run cargo fix
+  fmt      Run rustfmt
+  doc      Build documentation
+  test     Build and run some test suites
+  miri     Build and run some test suites *in Miri*
+  bench    Build and run some benchmarks
+  clean    Clean out build directories
+  dist     Build distribution artifacts
+  install  Install distribution artifacts
+  run      Run tools contained in this repository
+  setup    Set up the environment for development
+  vendor   Vendor dependencies
+  perf     Perform profiling and benchmarking of the compiler using `rustc-perf`
+
+Arguments:
+  [PATHS]...  paths for the subcommand
+  [ARGS]...   arguments passed to subcommands
+
+Options:
+  -v, --verbose...
+          use verbose output (-vv for very verbose)
+  -i, --incremental
+          use incremental compilation
+      --config <FILE>
+          TOML configuration file for build
+      --build-dir <DIR>
+          Build directory, overrides `build.build-dir` in `bootstrap.toml`
+      --build <BUILD>
+          host target of the stage0 compiler
+      --host <HOST>
+          host targets to build
+      --target <TARGET>
+          target targets to build
+      --exclude <PATH>
+          build paths to exclude
+      --skip <PATH>
+          build paths to skip
+      --include-default-paths
+          include default paths in addition to the provided ones
+      --rustc-error-format <RUSTC_ERROR_FORMAT>
+          rustc error format
+      --on-fail <CMD>
+          command to run on failure
+      --dry-run
+          dry run; don't build anything
+      --dump-bootstrap-shims
+          Indicates whether to dump the work done from bootstrap shims
+      --stage <N>
+          stage to build (indicates compiler to use/test, e.g., stage 0 uses the bootstrap compiler, stage 1 the stage 0 rustc artifacts, etc.)
+      --keep-stage <N>
+          stage(s) to keep without recompiling (pass multiple times to keep e.g., both stages 0 and 1)
+      --keep-stage-std <N>
+          stage(s) of the standard library to keep without recompiling (pass multiple times to keep e.g., both stages 0 and 1)
+      --src <DIR>
+          path to the root of the rust checkout
+  -j, --jobs <JOBS>
+          number of jobs to run in parallel
+      --warnings <deny|warn>
+          if value is deny, will deny warnings if value is warn, will emit warnings otherwise, use the default configured behaviour [default: default] [possible values: deny, warn, default]
+      --json-output
+          use message-format=json
+      --compile-time-deps
+          only build proc-macros and build scripts (for rust-analyzer)
+      --color <STYLE>
+          whether to use color in cargo and rustc output [default: auto] [possible values: always, never, auto]
+      --bypass-bootstrap-lock
+          Bootstrap uses this value to decide whether it should bypass locking the build process. This is rarely needed (e.g., compiling the std library for different targets in parallel)
+      --rust-profile-generate <PROFILE>
+          generate PGO profile with rustc build
+      --rust-profile-use <PROFILE>
+          use PGO profile for rustc build
+      --llvm-profile-use <PROFILE>
+          use PGO profile for LLVM build
+      --llvm-profile-generate
+          generate PGO profile with llvm built for rustc
+      --enable-bolt-settings
+          Enable BOLT link flags
+      --skip-stage0-validation
+          Skip stage0 compiler validation
+      --reproducible-artifact <REPRODUCIBLE_ARTIFACT>
+          Additional reproducible artifacts that should be added to the reproducible artifacts archive
+      --set <section.option=value>
+          override options in bootstrap.toml
+      --ci <bool>
+          Make bootstrap to behave as it's running on the CI environment or not [possible values: true, false]
+      --skip-std-check-if-no-download-rustc
+          Skip checking the standard library if `rust.download-rustc` isn't available. This is mostly for RA as building the stage1 compiler to check the library tree on each code change might be too much for some computers
+  -h, --help
+          Print help (see more with '--help')


### PR DESCRIPTION
Fix rust-lang/rust#141903 

Currently x.py help (--help) builds bootstrap binary everytime, so it takes some seconds to print help. 
This PR does:
-  Saves current help text into a file (x.py run generate-help)
-  Changes bootstrap.py to print the help in the saved file and to exit without touching bootstrap binary
-  Modifies x.py test bootstrap to check if the help file is up-to-date