### PR TITLE
Deref is not a projection: VarDebugInfo

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
@@ -558,7 +558,15 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
         err: &mut Diag<'infcx>,
     ) {
         let var_info = self.body.var_debug_info.iter().find(|info| match info.value {
-            VarDebugInfoContents::Place(ref p) => p == place,
+            VarDebugInfoContents::Place(ref p) => {
+                // This will become a simple == when Derefer is moved before borrowck
+                place.local == p.local
+                    && p.projection_chain
+                        .iter()
+                        .flatten()
+                        .enumerate()
+                        .all(|(i, elem)| place.projection.get(i) == Some(&elem))
+            }
             _ => false,
         });
         let arg_name = if let Some(var_info) = var_info {

--- a/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
@@ -561,9 +561,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
             VarDebugInfoContents::Place(ref p) => {
                 // This will become a simple == when Derefer is moved before borrowck
                 place.local == p.local
-                    && p.projection_chain
-                        .iter()
-                        .flatten()
+                    && p.iter_projection_elems()
                         .enumerate()
                         .all(|(i, elem)| place.projection.get(i) == Some(&elem))
             }

--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -19,7 +19,7 @@ use rustc_infer::infer::{
     BoundRegionConversionTime, InferCtxt, NllRegionVariableOrigin, RegionVariableOrigin,
 };
 use rustc_infer::traits::PredicateObligations;
-use rustc_middle::mir::visit::{NonMutatingUseContext, PlaceContext, Visitor};
+use rustc_middle::mir::visit::{NonMutatingUseContext, PlaceContext, ProjectionBase, Visitor};
 use rustc_middle::mir::*;
 use rustc_middle::traits::query::NoSolution;
 use rustc_middle::ty::adjustment::PointerCoercion;
@@ -1807,13 +1807,15 @@ impl<'a, 'tcx> Visitor<'tcx> for TypeChecker<'a, 'tcx> {
         }
     }
 
-    fn visit_projection_elem(
+    fn visit_projection_elem<P>(
         &mut self,
-        place: PlaceRef<'tcx>,
+        place: P,
         elem: PlaceElem<'tcx>,
         context: PlaceContext,
         location: Location,
-    ) {
+    ) where
+        P: ProjectionBase<'tcx>,
+    {
         let tcx = self.tcx();
         let base_ty = place.ty(self.body(), tcx);
         match elem {

--- a/compiler/rustc_codegen_ssa/src/mir/debuginfo.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/debuginfo.rs
@@ -571,7 +571,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                         // FIXME change field to be projection chain
                         projection: bx
                             .tcx()
-                            .mk_place_elems_from_iter(place.projection_chain.iter().flatten()),
+                            .mk_place_elems_from_iter(place.iter_projection_elems()),
                     });
                 }
                 mir::VarDebugInfoContents::Const(c) => {

--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -1187,8 +1187,8 @@ impl<'tcx> LocalDecl<'tcx> {
 
 #[derive(Clone, TyEncodable, TyDecodable, HashStable, TypeFoldable, TypeVisitable)]
 pub enum VarDebugInfoContents<'tcx> {
-    /// This `Place` only contains projection which satisfy `can_use_in_debuginfo`.
-    Place(Place<'tcx>),
+    /// This `CompoundPlace` only contains projection which satisfy `can_use_in_debuginfo`.
+    Place(CompoundPlace<'tcx>),
     Const(ConstOperand<'tcx>),
 }
 

--- a/compiler/rustc_middle/src/mir/pretty.rs
+++ b/compiler/rustc_middle/src/mir/pretty.rs
@@ -1284,9 +1284,11 @@ impl Debug for CompoundPlaceRef<'_> {
         for projection in stem.iter().rev() {
             pre_fmt_projection(projection, fmt)?;
         }
+        pre_fmt_projection(self.direct_projection, fmt)?;
 
         write!(fmt, "{:?}", self.local)?;
 
+        post_fmt_projection(self.direct_projection, fmt)?;
         for projection in stem {
             post_fmt_projection(projection, fmt)?;
         }

--- a/compiler/rustc_middle/src/mir/pretty.rs
+++ b/compiler/rustc_middle/src/mir/pretty.rs
@@ -1278,17 +1278,19 @@ impl Debug for CompoundPlace<'_> {
 
 impl Debug for CompoundPlaceRef<'_> {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> fmt::Result {
-        pre_fmt_projection(self.last_projection, fmt)?;
-        for projection in self.projection_chain_base.iter().rev() {
+        let (stem, suffix) = self.projection_chain.unwrap_or_default();
+
+        pre_fmt_projection(suffix, fmt)?;
+        for projection in stem.iter().rev() {
             pre_fmt_projection(projection, fmt)?;
         }
 
         write!(fmt, "{:?}", self.local)?;
 
-        for projection in self.projection_chain_base {
+        for projection in stem {
             post_fmt_projection(projection, fmt)?;
         }
-        post_fmt_projection(self.last_projection, fmt)?;
+        post_fmt_projection(suffix, fmt)?;
 
         Ok(())
     }

--- a/compiler/rustc_middle/src/mir/pretty.rs
+++ b/compiler/rustc_middle/src/mir/pretty.rs
@@ -1270,6 +1270,30 @@ impl Debug for PlaceRef<'_> {
     }
 }
 
+impl Debug for CompoundPlace<'_> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> fmt::Result {
+        self.as_ref().fmt(fmt)
+    }
+}
+
+impl Debug for CompoundPlaceRef<'_> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> fmt::Result {
+        pre_fmt_projection(self.last_projection, fmt)?;
+        for projection in self.projection_chain_base.iter().rev() {
+            pre_fmt_projection(projection, fmt)?;
+        }
+
+        write!(fmt, "{:?}", self.local)?;
+
+        for projection in self.projection_chain_base {
+            post_fmt_projection(projection, fmt)?;
+        }
+        post_fmt_projection(self.last_projection, fmt)?;
+
+        Ok(())
+    }
+}
+
 fn pre_fmt_projection(projection: &[PlaceElem<'_>], fmt: &mut Formatter<'_>) -> fmt::Result {
     for &elem in projection.iter().rev() {
         match elem {

--- a/compiler/rustc_middle/src/mir/statement.rs
+++ b/compiler/rustc_middle/src/mir/statement.rs
@@ -161,7 +161,7 @@ impl<'tcx> PlaceTy<'tcx> {
     pub fn projection_chain_ty(
         self,
         tcx: TyCtxt<'tcx>,
-        chain: &[&List<PlaceElem<'tcx>>],
+        chain: &[ProjectionFragment<'tcx>],
     ) -> PlaceTy<'tcx> {
         chain
             .iter()
@@ -556,6 +556,13 @@ impl From<Local> for PlaceRef<'_> {
     }
 }
 
+// In the future this will also have the type being projected alongside it.
+// This will be needed to represent derefs of non-pointer types like `Box`.
+//
+// (`Ty::builtin_deref` currently works on `Box` but that will be changed too)
+pub type ProjectionFragment<'tcx> = &'tcx List<PlaceElem<'tcx>>;
+pub type ProjectionFragmentRef<'tcx> = &'tcx [PlaceElem<'tcx>];
+
 /// A place possibly containing derefs in the middle of its projection by chaining projection lists.
 ///
 /// In `AnalysisPhase::PostCleanup` and later, [`Place`] and [`PlaceRef`] cannot represent these
@@ -567,15 +574,15 @@ pub struct CompoundPlace<'tcx> {
     /// - All segments in the chain other than the first must start with a deref.
     /// - Derefs may only appear at the start of a segment.
     /// - No segment may be empty.
-    pub projection_chain: &'tcx List<&'tcx List<PlaceElem<'tcx>>>,
+    pub projection_chain: &'tcx List<ProjectionFragment<'tcx>>,
 }
 
 /// Borrowed form of [`CompoundPlace`].
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub struct CompoundPlaceRef<'tcx> {
     pub local: Local,
-    pub projection_chain_base: &'tcx [&'tcx List<PlaceElem<'tcx>>],
-    pub last_projection: &'tcx [PlaceElem<'tcx>],
+    pub projection_chain_base: &'tcx [ProjectionFragment<'tcx>],
+    pub last_projection: ProjectionFragmentRef<'tcx>,
 }
 
 // these impls are bare-bones for now

--- a/compiler/rustc_middle/src/mir/statement.rs
+++ b/compiler/rustc_middle/src/mir/statement.rs
@@ -589,14 +589,6 @@ impl<'tcx> CompoundPlace<'tcx> {
         CompoundPlaceRef { local: self.local, projection_chain_base: base, last_projection: last }
     }
 
-    pub fn ty<D: ?Sized>(&self, local_decls: &D, tcx: TyCtxt<'tcx>) -> PlaceTy<'tcx>
-    where
-        D: HasLocalDecls<'tcx>,
-    {
-        PlaceTy::from_ty(local_decls.local_decls()[self.local].ty)
-            .projection_chain_ty(tcx, self.projection_chain)
-    }
-
     pub fn iter_projections(
         self,
     ) -> impl Iterator<Item = (CompoundPlaceRef<'tcx>, PlaceElem<'tcx>)> + DoubleEndedIterator {
@@ -623,6 +615,14 @@ impl<'tcx> CompoundPlace<'tcx> {
                 (base, elem)
             })
         })
+    }
+
+    pub fn ty<D: ?Sized>(&self, local_decls: &D, tcx: TyCtxt<'tcx>) -> PlaceTy<'tcx>
+    where
+        D: HasLocalDecls<'tcx>,
+    {
+        PlaceTy::from_ty(local_decls.local_decls()[self.local].ty)
+            .projection_chain_ty(tcx, self.projection_chain)
     }
 }
 

--- a/compiler/rustc_middle/src/mir/visit.rs
+++ b/compiler/rustc_middle/src/mir/visit.rs
@@ -923,7 +923,7 @@ macro_rules! make_mir_visitor {
                 match value {
                     VarDebugInfoContents::Const(c) => self.visit_const_operand(c, location),
                     VarDebugInfoContents::Place(place) =>
-                        self.visit_place(
+                        self.visit_compound_place(
                             place,
                             PlaceContext::NonUse(NonUseContext::VarDebugInfo),
                             location

--- a/compiler/rustc_middle/src/mir/visit.rs
+++ b/compiler/rustc_middle/src/mir/visit.rs
@@ -1200,6 +1200,12 @@ macro_rules! visit_place_fns {
         ) {
             self.visit_local(&mut place.local, context, location);
 
+            if let Some(new_direct_projection) =
+                self.process_projection(&place.direct_projection, location)
+            {
+                place.direct_projection = self.tcx().mk_place_elems(&new_direct_projection);
+            }
+
             if let Some(new_projection_chain) =
                 self.process_projection_chain(&place.projection_chain, location)
             {

--- a/compiler/rustc_middle/src/ty/codec.rs
+++ b/compiler/rustc_middle/src/ty/codec.rs
@@ -300,7 +300,7 @@ impl<'tcx, D: TyDecoder<'tcx>> Decodable<D> for mir::Place<'tcx> {
 
 impl<'tcx, D: TyDecoder<'tcx>> Decodable<D> for mir::CompoundPlace<'tcx> {
     fn decode(decoder: &mut D) -> Self {
-        let local: mir::Local = Decodable::decode(decoder);
+        let base_place: mir::Place<'tcx> = Decodable::decode(decoder);
         let chain_len = decoder.read_usize();
         let projection_chain =
             decoder.interner().mk_place_elem_chain_from_iter((0..chain_len).map(|_| {
@@ -309,7 +309,11 @@ impl<'tcx, D: TyDecoder<'tcx>> Decodable<D> for mir::CompoundPlace<'tcx> {
                     (0..projs_len).map::<mir::PlaceElem<'tcx>, _>(|_| Decodable::decode(decoder)),
                 )
             }));
-        mir::CompoundPlace { local, projection_chain }
+        mir::CompoundPlace {
+            local: base_place.local,
+            direct_projection: base_place.projection,
+            projection_chain,
+        }
     }
 }
 

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -68,7 +68,7 @@ use crate::metadata::ModChild;
 use crate::middle::codegen_fn_attrs::{CodegenFnAttrs, TargetFeature};
 use crate::middle::resolve_bound_vars;
 use crate::mir::interpret::{self, Allocation, ConstAllocation};
-use crate::mir::{Body, Local, Place, PlaceElem, ProjectionKind, Promoted};
+use crate::mir::{Body, Local, Place, PlaceElem, ProjectionFragment, ProjectionKind, Promoted};
 use crate::query::plumbing::QuerySystem;
 use crate::query::{IntoQueryParam, LocalCrate, Providers, TyCtxtAt};
 use crate::thir::Thir;
@@ -2781,7 +2781,7 @@ slice_interners!(
     poly_existential_predicates: intern_poly_existential_predicates(PolyExistentialPredicate<'tcx>),
     projs: pub mk_projs(ProjectionKind),
     place_elems: pub mk_place_elems(PlaceElem<'tcx>),
-    place_elem_chains: pub mk_place_elem_chain(&'tcx List<PlaceElem<'tcx>>),
+    place_elem_chains: pub mk_place_elem_chain(ProjectionFragment<'tcx>),
     bound_variable_kinds: pub mk_bound_variable_kinds(ty::BoundVariableKind),
     fields: pub mk_fields(FieldIdx),
     local_def_ids: intern_local_def_ids(LocalDefId),
@@ -3175,7 +3175,7 @@ impl<'tcx> TyCtxt<'tcx> {
     pub fn mk_place_elem_chain_from_iter<I, T>(self, iter: I) -> T::Output
     where
         I: Iterator<Item = T>,
-        T: CollectAndApply<&'tcx List<PlaceElem<'tcx>>, &'tcx List<&'tcx List<PlaceElem<'tcx>>>>,
+        T: CollectAndApply<&'tcx List<PlaceElem<'tcx>>, &'tcx List<ProjectionFragment<'tcx>>>,
     {
         T::collect_and_apply(iter, |xs| self.mk_place_elem_chain(xs))
     }

--- a/compiler/rustc_middle/src/ty/structural_impls.rs
+++ b/compiler/rustc_middle/src/ty/structural_impls.rs
@@ -13,7 +13,7 @@ use rustc_span::source_map::Spanned;
 use rustc_type_ir::{ConstKind, TypeFolder, VisitorResult, try_visit};
 
 use super::{GenericArg, GenericArgKind, Pattern, Region};
-use crate::mir::PlaceElem;
+use crate::mir::{PlaceElem, ProjectionFragment};
 use crate::ty::print::{FmtPrinter, Printer, with_no_trimmed_paths};
 use crate::ty::{
     self, FallibleTypeFolder, Lift, Term, TermKind, Ty, TyCtxt, TypeFoldable, TypeSuperFoldable,
@@ -797,7 +797,7 @@ macro_rules! list_fold {
 list_fold! {
     &'tcx ty::List<ty::PolyExistentialPredicate<'tcx>> : mk_poly_existential_predicates,
     &'tcx ty::List<PlaceElem<'tcx>> : mk_place_elems,
-    &'tcx ty::List<&'tcx ty::List<PlaceElem<'tcx>>> : mk_place_elem_chain,
+    &'tcx ty::List<ProjectionFragment<'tcx>> : mk_place_elem_chain,
     &'tcx ty::List<ty::Pattern<'tcx>> : mk_patterns,
     &'tcx ty::List<ty::ArgOutlivesPredicate<'tcx>> : mk_outlives,
 }

--- a/compiler/rustc_middle/src/ty/structural_impls.rs
+++ b/compiler/rustc_middle/src/ty/structural_impls.rs
@@ -797,6 +797,7 @@ macro_rules! list_fold {
 list_fold! {
     &'tcx ty::List<ty::PolyExistentialPredicate<'tcx>> : mk_poly_existential_predicates,
     &'tcx ty::List<PlaceElem<'tcx>> : mk_place_elems,
+    &'tcx ty::List<&'tcx ty::List<PlaceElem<'tcx>>> : mk_place_elem_chain,
     &'tcx ty::List<ty::Pattern<'tcx>> : mk_patterns,
     &'tcx ty::List<ty::ArgOutlivesPredicate<'tcx>> : mk_outlives,
 }

--- a/compiler/rustc_mir_build/src/builder/custom/parse.rs
+++ b/compiler/rustc_mir_build/src/builder/custom/parse.rs
@@ -260,7 +260,9 @@ impl<'a, 'tcx> ParseCtxt<'a, 'tcx> {
             let operand = self.parse_operand(operand)?;
             let value = match operand {
                 Operand::Constant(c) => VarDebugInfoContents::Const(*c),
-                Operand::Copy(p) | Operand::Move(p) => VarDebugInfoContents::Place(p),
+                Operand::Copy(p) | Operand::Move(p) => {
+                    VarDebugInfoContents::Place(CompoundPlace::from_place(p, self.tcx))
+                }
             };
             let dbginfo = VarDebugInfo {
                 name,

--- a/compiler/rustc_mir_build/src/builder/mod.rs
+++ b/compiler/rustc_mir_build/src/builder/mod.rs
@@ -840,9 +840,9 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         let Some(closure_arg) = self.local_decls.get(ty::CAPTURE_STRUCT_LOCAL) else { return };
 
         let mut closure_ty = closure_arg.ty;
-        let mut closure_env_projs = vec![];
+        let mut closure_env_projs: &[_] = &[];
         if let ty::Ref(_, ty, _) = closure_ty.kind() {
-            closure_env_projs.push(ProjectionElem::Deref);
+            closure_env_projs = &[ProjectionElem::Deref];
             closure_ty = *ty;
         }
 
@@ -881,7 +881,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
 
                 let mutability = captured_place.mutability;
 
-                let mut projs = closure_env_projs.clone();
+                let mut projs = closure_env_projs.to_vec();
                 projs.push(ProjectionElem::Field(FieldIdx::new(i), ty));
                 match capture {
                     ty::UpvarCapture::ByValue | ty::UpvarCapture::ByUse => {}
@@ -897,7 +897,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 self.var_debug_info.push(VarDebugInfo {
                     name,
                     source_info: SourceInfo::outermost(captured_place.var_ident.span),
-                    value: VarDebugInfoContents::Place(use_place),
+                    value: VarDebugInfoContents::Place(CompoundPlace::from_place(use_place, tcx)),
                     composite: None,
                     argument_index: None,
                 });

--- a/compiler/rustc_mir_transform/src/coroutine.rs
+++ b/compiler/rustc_mir_transform/src/coroutine.rs
@@ -170,7 +170,7 @@ impl<'tcx> MutVisitor<'tcx> for SelfArgVisitor<'tcx> {
         } else {
             self.visit_local(&mut place.local, context, location);
 
-            for elem in place.projection_chain.iter().flatten() {
+            for elem in place.iter_projection_elems() {
                 if let PlaceElem::Index(local) = elem {
                     assert_ne!(local, SELF_ARG);
                 }

--- a/compiler/rustc_mir_transform/src/dataflow_const_prop.rs
+++ b/compiler/rustc_mir_transform/src/dataflow_const_prop.rs
@@ -14,7 +14,7 @@ use rustc_data_structures::fx::FxHashMap;
 use rustc_hir::def::DefKind;
 use rustc_middle::bug;
 use rustc_middle::mir::interpret::{InterpResult, Scalar};
-use rustc_middle::mir::visit::{MutVisitor, PlaceContext, Visitor};
+use rustc_middle::mir::visit::{MutVisitor, PlaceContext, ProjectionBase, Visitor};
 use rustc_middle::mir::*;
 use rustc_middle::ty::{self, Ty, TyCtxt};
 use rustc_mir_dataflow::fmt::DebugWithContext;
@@ -1069,13 +1069,15 @@ struct OperandCollector<'a, 'b, 'tcx> {
 }
 
 impl<'tcx> Visitor<'tcx> for OperandCollector<'_, '_, 'tcx> {
-    fn visit_projection_elem(
+    fn visit_projection_elem<P>(
         &mut self,
-        _: PlaceRef<'tcx>,
+        _: P,
         elem: PlaceElem<'tcx>,
         _: PlaceContext,
         location: Location,
-    ) {
+    ) where
+        P: ProjectionBase<'tcx>,
+    {
         if let PlaceElem::Index(local) = elem
             && let Some(value) =
                 self.visitor.try_make_constant(self.ecx, local.into(), self.state, self.map)

--- a/compiler/rustc_mir_transform/src/deref_separator.rs
+++ b/compiler/rustc_mir_transform/src/deref_separator.rs
@@ -1,4 +1,3 @@
-use rustc_middle::mir::visit::NonUseContext::VarDebugInfo;
 use rustc_middle::mir::visit::{MutVisitor, PlaceContext};
 use rustc_middle::mir::*;
 use rustc_middle::ty::TyCtxt;
@@ -18,11 +17,8 @@ impl<'a, 'tcx> MutVisitor<'tcx> for DerefChecker<'a, 'tcx> {
         self.tcx
     }
 
-    fn visit_place(&mut self, place: &mut Place<'tcx>, cntxt: PlaceContext, loc: Location) {
-        if !place.projection.is_empty()
-            && cntxt != PlaceContext::NonUse(VarDebugInfo)
-            && place.projection[1..].contains(&ProjectionElem::Deref)
-        {
+    fn visit_place(&mut self, place: &mut Place<'tcx>, _cntxt: PlaceContext, loc: Location) {
+        if !place.projection.is_empty() && place.projection[1..].contains(&ProjectionElem::Deref) {
             let mut place_local = place.local;
             let mut last_len = 0;
             let mut last_deref_idx = 0;

--- a/compiler/rustc_mir_transform/src/gvn.rs
+++ b/compiler/rustc_mir_transform/src/gvn.rs
@@ -1780,7 +1780,7 @@ impl<'tcx> MutVisitor<'tcx> for VnState<'_, 'tcx> {
 
     fn visit_place(&mut self, place: &mut Place<'tcx>, context: PlaceContext, location: Location) {
         self.simplify_place_projection(place, location);
-        if context.is_mutating_use() && place.is_indirect() {
+        if context.is_mutating_use() && place.is_indirect_first_projection() {
             // Non-local mutation maybe invalidate deref.
             self.invalidate_derefs();
         }

--- a/compiler/rustc_mir_transform/src/known_panics_lint.rs
+++ b/compiler/rustc_mir_transform/src/known_panics_lint.rs
@@ -911,12 +911,16 @@ impl<'tcx> Visitor<'tcx> for CanConstProp {
         use rustc_middle::mir::visit::PlaceContext::*;
 
         // Dereferencing just read the address of `place.local`.
-        if place.projection.first() == Some(&PlaceElem::Deref) {
+        if place.is_indirect_first_projection() {
             context = NonMutatingUse(NonMutatingUseContext::Copy);
         }
 
         self.visit_local(place.local, context, loc);
         self.visit_projection(place.as_ref(), context, loc);
+    }
+
+    fn visit_var_debug_info(&mut self, _: &VarDebugInfo<'tcx>) {
+        // explicitly skip debug info
     }
 
     fn visit_local(&mut self, local: Local, context: PlaceContext, _: Location) {

--- a/compiler/rustc_mir_transform/src/sroa.rs
+++ b/compiler/rustc_mir_transform/src/sroa.rs
@@ -269,12 +269,14 @@ impl<'tcx> ReplacementVisitor<'tcx, '_> {
                 VarDebugInfoContents::Place(ref mut place) => place,
             };
 
-            if let Some(repl) = self.replacements.replace_place(self.tcx, place.as_ref()) {
-                *place = repl;
+            let base_place = place.base_place();
+
+            if let Some(repl) = self.replacements.replace_place(self.tcx, base_place.as_ref()) {
+                place.replace_base_place(repl, self.tcx);
                 return vec![var_debug_info];
             }
 
-            let Some(parts) = self.replacements.place_fragments(*place) else {
+            let Some(parts) = self.replacements.place_fragments(base_place) else {
                 return vec![var_debug_info];
             };
 

--- a/compiler/rustc_mir_transform/src/sroa.rs
+++ b/compiler/rustc_mir_transform/src/sroa.rs
@@ -272,7 +272,8 @@ impl<'tcx> ReplacementVisitor<'tcx, '_> {
             let base_place = place.base_place();
 
             if let Some(repl) = self.replacements.replace_place(self.tcx, base_place.as_ref()) {
-                place.replace_base_place(repl, self.tcx);
+                place.local = repl.local;
+                place.direct_projection = repl.projection;
                 return vec![var_debug_info];
             }
 

--- a/compiler/rustc_mir_transform/src/validate.rs
+++ b/compiler/rustc_mir_transform/src/validate.rs
@@ -9,7 +9,7 @@ use rustc_index::bit_set::DenseBitSet;
 use rustc_infer::infer::TyCtxtInferExt;
 use rustc_infer::traits::{Obligation, ObligationCause};
 use rustc_middle::mir::coverage::CoverageKind;
-use rustc_middle::mir::visit::{NonUseContext, PlaceContext, Visitor};
+use rustc_middle::mir::visit::{NonUseContext, PlaceContext, ProjectionBase, Visitor};
 use rustc_middle::mir::*;
 use rustc_middle::ty::adjustment::PointerCoercion;
 use rustc_middle::ty::print::with_no_trimmed_paths;
@@ -646,13 +646,15 @@ impl<'a, 'tcx> Visitor<'tcx> for TypeChecker<'a, 'tcx> {
         self.super_operand(operand, location);
     }
 
-    fn visit_projection_elem(
+    fn visit_projection_elem<P>(
         &mut self,
-        place_ref: PlaceRef<'tcx>,
+        place_ref: P,
         elem: PlaceElem<'tcx>,
         context: PlaceContext,
         location: Location,
-    ) {
+    ) where
+        P: ProjectionBase<'tcx>,
+    {
         match elem {
             ProjectionElem::OpaqueCast(ty)
                 if self.body.phase >= MirPhase::Runtime(RuntimePhase::Initial) =>
@@ -923,6 +925,40 @@ impl<'a, 'tcx> Visitor<'tcx> for TypeChecker<'a, 'tcx> {
         }
 
         self.super_place(place, cntxt, location);
+    }
+
+    fn visit_compound_place(
+        &mut self,
+        place: &CompoundPlace<'tcx>,
+        cntxt: PlaceContext,
+        location: Location,
+    ) {
+        // Set off any `bug!`s in the type computation code
+        let _ = place.ty(&self.body.local_decls, self.tcx);
+
+        for (i, projection) in place.projection_chain.iter().enumerate() {
+            if projection.is_empty() {
+                self.fail(location, format!("compound place {place:?} has empty segment {i}"));
+            }
+
+            if i > 0 && projection.first() != Some(&ProjectionElem::Deref) {
+                self.fail(
+                    location,
+                    format!(
+                        "compound place {place:?} has later segment without deref (segment {i})"
+                    ),
+                );
+            }
+
+            if projection[1..].contains(&ProjectionElem::Deref) {
+                self.fail(
+                location,
+                format!("compound place {place:?} has deref as a later projection in segment {i} (it is only permitted as the first projection)"),
+            );
+            }
+        }
+
+        self.super_compound_place(place, cntxt, location);
     }
 
     fn visit_rvalue(&mut self, rvalue: &Rvalue<'tcx>, location: Location) {

--- a/compiler/rustc_public/src/unstable/convert/stable/mir.rs
+++ b/compiler/rustc_public/src/unstable/convert/stable/mir.rs
@@ -432,12 +432,7 @@ impl<'tcx> Stable<'tcx> for mir::CompoundPlace<'tcx> {
     ) -> Self::T {
         crate::mir::Place {
             local: self.local.as_usize(),
-            projection: self
-                .projection_chain
-                .iter()
-                .flatten()
-                .map(|e| e.stable(tables, cx))
-                .collect(),
+            projection: self.iter_projection_elems().map(|e| e.stable(tables, cx)).collect(),
         }
     }
 }

--- a/compiler/rustc_public/src/unstable/convert/stable/mir.rs
+++ b/compiler/rustc_public/src/unstable/convert/stable/mir.rs
@@ -422,6 +422,26 @@ impl<'tcx> Stable<'tcx> for mir::Place<'tcx> {
     }
 }
 
+// lowering to just Place for now
+impl<'tcx> Stable<'tcx> for mir::CompoundPlace<'tcx> {
+    type T = crate::mir::Place;
+    fn stable<'cx>(
+        &self,
+        tables: &mut Tables<'cx, BridgeTys>,
+        cx: &CompilerCtxt<'cx, BridgeTys>,
+    ) -> Self::T {
+        crate::mir::Place {
+            local: self.local.as_usize(),
+            projection: self
+                .projection_chain
+                .iter()
+                .flatten()
+                .map(|e| e.stable(tables, cx))
+                .collect(),
+        }
+    }
+}
+
 impl<'tcx> Stable<'tcx> for mir::PlaceElem<'tcx> {
     type T = crate::mir::ProjectionElem;
     fn stable<'cx>(


### PR DESCRIPTION
See https://github.com/rust-lang/compiler-team/issues/532

The `Derefer` MIR pass ensures that all places' projections are an optional deref followed by a direct projection (no derefs, points to the same region of memory), except in `VarDebugInfo`. There is no way to represent debug info's places in general like this.

To solve this, this PR introduces `CompoundPlace` and `CompoundPlaceRef` to for places with multiple derefs in arbitrary positions by instead representing them as multiple direct projections seperated by derefs. These types are also necessary for moving `Derefer` before borrowck because having to deal with these split-up single-deref places in borrowck would be a nightmare (I tried already).

Couple points of uncertainty:
- I put them in `rustc_middle::mir::statement` along side `Place`'s methods and `PlaceRef`, not sure if that's the best place
- `CompoundPlace` is just turned into a regular `Place` in stable MIR. Should it?
- Visitor changes feel like a big hack

r? oli-obk (not sure if they're still on vacation)
