### PR TITLE
fix 2 borrowck issues

### DIFF
--- a/compiler/rustc_borrowck/src/region_infer/mod.rs
+++ b/compiler/rustc_borrowck/src/region_infer/mod.rs
@@ -1726,9 +1726,10 @@ impl<'tcx> RegionInferenceContext<'tcx> {
                 // `BoringNoLocation` constraints can point to user-written code, but are less
                 // specific, and are not used for relations that would make sense to blame.
                 ConstraintCategory::BoringNoLocation => 6,
-                // Do not blame internal constraints.
-                ConstraintCategory::OutlivesUnnameablePlaceholder(_) => 7,
-                ConstraintCategory::Internal => 8,
+                // Do not blame internal constraints if we can avoid it. Never blame
+                // the `'region: 'static` constraints introduced by placeholder outlives.
+                ConstraintCategory::Internal => 7,
+                ConstraintCategory::OutlivesUnnameablePlaceholder(_) => 8,
             };
 
             debug!("constraint {constraint:?} category: {category:?}, interest: {interest:?}");

--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -505,6 +505,7 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
         let mut constraints = Default::default();
         let mut liveness_constraints =
             LivenessValues::without_specific_points(Rc::new(DenseLocationMap::new(promoted_body)));
+        let mut deferred_closure_requirements = Default::default();
 
         // Don't try to add borrow_region facts for the promoted MIR as they refer
         // to the wrong locations.
@@ -512,6 +513,7 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
             mem::swap(this.polonius_facts, polonius_facts);
             mem::swap(&mut this.constraints.outlives_constraints, &mut constraints);
             mem::swap(&mut this.constraints.liveness_constraints, &mut liveness_constraints);
+            mem::swap(this.deferred_closure_requirements, &mut deferred_closure_requirements);
         };
 
         swap_constraints(self);
@@ -536,6 +538,17 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
             }
             self.constraints.outlives_constraints.push(constraint)
         }
+
+        // If there are nested bodies in promoteds, we also need to update their
+        // location to something in the actually body, not the promoted.
+        //
+        // We don't update the constraint categories of the resulting constraints
+        // as returns in nested bodies are a proper return, even if that nested body
+        // is in a promoted.
+        for (closure_def_id, args, _locations) in deferred_closure_requirements {
+            self.deferred_closure_requirements.push((closure_def_id, args, locations));
+        }
+
         // If the region is live at least one location in the promoted MIR,
         // then add a liveness constraint to the main MIR for this region
         // at the location provided as an argument to this method

--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -540,7 +540,7 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
         }
 
         // If there are nested bodies in promoteds, we also need to update their
-        // location to something in the actually body, not the promoted.
+        // location to something in the actual body, not the promoted.
         //
         // We don't update the constraint categories of the resulting constraints
         // as returns in nested bodies are a proper return, even if that nested body

--- a/tests/ui/associated-inherent-types/hr-do-not-blame-outlives-static-ice.rs
+++ b/tests/ui/associated-inherent-types/hr-do-not-blame-outlives-static-ice.rs
@@ -1,0 +1,17 @@
+//@ compile-flags: -Zdeduplicate-diagnostics=yes
+
+// Regression test for #146467.
+#![feature(inherent_associated_types)]
+//~^ WARN the feature `inherent_associated_types` is incomplete
+
+struct Foo<T>(T);
+
+impl<'a> Foo<fn(&())> {
+    //~^ ERROR the lifetime parameter `'a` is not constrained by the impl trait
+    type Assoc = &'a ();
+}
+
+fn foo(_: for<'a> fn(Foo<fn(&'a ())>::Assoc)) {}
+//~^ ERROR mismatched types
+//~| ERROR higher-ranked subtype error
+fn main() {}

--- a/tests/ui/associated-inherent-types/hr-do-not-blame-outlives-static-ice.stderr
+++ b/tests/ui/associated-inherent-types/hr-do-not-blame-outlives-static-ice.stderr
@@ -1,0 +1,34 @@
+warning: the feature `inherent_associated_types` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/hr-do-not-blame-outlives-static-ice.rs:4:12
+   |
+LL | #![feature(inherent_associated_types)]
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #8995 <https://github.com/rust-lang/rust/issues/8995> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+error[E0207]: the lifetime parameter `'a` is not constrained by the impl trait, self type, or predicates
+  --> $DIR/hr-do-not-blame-outlives-static-ice.rs:9:6
+   |
+LL | impl<'a> Foo<fn(&())> {
+   |      ^^ unconstrained lifetime parameter
+
+error[E0308]: mismatched types
+  --> $DIR/hr-do-not-blame-outlives-static-ice.rs:14:11
+   |
+LL | fn foo(_: for<'a> fn(Foo<fn(&'a ())>::Assoc)) {}
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ one type is more general than the other
+   |
+   = note: expected struct `Foo<for<'a> fn(&'a ())>`
+              found struct `Foo<for<'a> fn(&'a ())>`
+
+error: higher-ranked subtype error
+  --> $DIR/hr-do-not-blame-outlives-static-ice.rs:14:1
+   |
+LL | fn foo(_: for<'a> fn(Foo<fn(&'a ())>::Assoc)) {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 3 previous errors; 1 warning emitted
+
+Some errors have detailed explanations: E0207, E0308.
+For more information about an error, try `rustc --explain E0207`.

--- a/tests/ui/higher-ranked/do-not-blame-outlives-static-ice.rs
+++ b/tests/ui/higher-ranked/do-not-blame-outlives-static-ice.rs
@@ -1,0 +1,12 @@
+//@ compile-flags: -Zdeduplicate-diagnostics=yes
+
+// Regression test for #146467.
+trait Trait { type Assoc; }
+
+impl Trait for fn(&()) { type Assoc = (); }
+
+fn f(_: for<'a> fn(<fn(&'a ()) as Trait>::Assoc)) {}
+//~^ ERROR implementation of `Trait` is not general enough
+//~| ERROR higher-ranked subtype error
+
+fn main() {}

--- a/tests/ui/higher-ranked/do-not-blame-outlives-static-ice.stderr
+++ b/tests/ui/higher-ranked/do-not-blame-outlives-static-ice.stderr
@@ -1,0 +1,17 @@
+error: implementation of `Trait` is not general enough
+  --> $DIR/do-not-blame-outlives-static-ice.rs:8:9
+   |
+LL | fn f(_: for<'a> fn(<fn(&'a ()) as Trait>::Assoc)) {}
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ implementation of `Trait` is not general enough
+   |
+   = note: `for<'a> fn(&'a ())` must implement `Trait`, for any lifetime `'0`...
+   = note: ...but `Trait` is actually implemented for the type `for<'a> fn(&'a ())`
+
+error: higher-ranked subtype error
+  --> $DIR/do-not-blame-outlives-static-ice.rs:8:1
+   |
+LL | fn f(_: for<'a> fn(<fn(&'a ()) as Trait>::Assoc)) {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
fixes https://github.com/rust-lang/rust/issues/146467 cc @amandasystems 

our understanding here is as follows: region constraints from computing implied bounds gets `ConstraintCategory::Internal`. If there's a higher-ranked subtyping errors while computing implied bounds we then ended up with only `ConstraintCategory::Internal` and `ConstraintCategory::OutlivesUnnameablePlaceholder(_)` constraints.

The path was something like
- `'placeholderU2: 'placeholderU1` (`Internal`)
- `'placeholderU1: 'static` (`OutlivesUnnameablePlaceholder('placeholderU2)`)

It's generally somewhat subtle here as ideally relating placeholders doesn't introduce `'static` constraints. Relating the placeholders themselves will always error regardless, cc https://github.com/rust-lang/rust/pull/142623.

---

separately fixes https://github.com/rust-lang/rust/pull/145925#issuecomment-3303733357 by updating the location for deferred closure requirements inside of promoteds. I am not updating their category as doing so is 1) effort and 2) imo actually undesirable :thinking: see the comments in `TypeChecker::check_promoted` cc @lqd 

r? lqd