### PR TITLE
`-Znext-solver` slightly strenghten deduce closure sig

### DIFF
--- a/tests/ui/closures/deduce-signature/deduce-signature-infer-vars.rs
+++ b/tests/ui/closures/deduce-signature/deduce-signature-infer-vars.rs
@@ -1,0 +1,40 @@
+//@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@[next] compile-flags: -Znext-solver
+//@ check-pass
+
+// Regression test for an issue found in #146720.
+
+trait Trait {
+    type Assoc;
+}
+
+struct W<T>(T);
+impl<T: Trait> Trait for W<T>
+where
+    u32: Trait<Assoc = T::Assoc>,
+{
+    type Assoc = T;
+}
+
+impl<T> Trait for (T,) {
+    type Assoc = T;
+}
+
+impl Trait for u32 {
+    type Assoc = u32;
+}
+
+fn foo<T: Trait>(_: impl FnOnce(T::Assoc)) {}
+
+fn main() {
+    // The closure signature is `fn(<W<?infer> as Trait>::Assoc)`.
+    // Normalizing it results in `?t` with `u32: Trait<Assoc = <?t>::Assoc>`.
+    // Equating `?t` with the argument pattern constrains it to `(?t,)`, at
+    // which point the `u32: Trait<Assoc = <?t>::Assoc>` obligations constrains
+    // `(?t,)` to `(u32,)`.
+    //
+    // This breaks when fudging inference to replace `?t` with an unconstrained
+    // infer var.
+    foo::<W<_>>(|(field,)| { let _ = field.count_ones(); })
+}

--- a/tests/ui/closures/deduce-signature/higher-ranked-alias-norm-to-hr.current_ambig.stderr
+++ b/tests/ui/closures/deduce-signature/higher-ranked-alias-norm-to-hr.current_ambig.stderr
@@ -1,0 +1,49 @@
+error: implementation of `Foo` is not general enough
+  --> $DIR/higher-ranked-alias-norm-to-hr.rs:23:5
+   |
+LL |     needs_super(|_| {});
+   |     ^^^^^^^^^^^^^^^^^^^ implementation of `Foo` is not general enough
+   |
+   = note: `{closure@$DIR/higher-ranked-alias-norm-to-hr.rs:23:17: 23:20}` must implement `Foo<'0>`, for any lifetime `'0`...
+   = note: ...but it actually implements `Foo<'1>`, for some specific lifetime `'1`
+
+error: implementation of `Fn` is not general enough
+  --> $DIR/higher-ranked-alias-norm-to-hr.rs:23:5
+   |
+LL |     needs_super(|_| {});
+   |     ^^^^^^^^^^^^^^^^^^^ implementation of `Fn` is not general enough
+   |
+   = note: closure with signature `fn(&'2 u32)` must implement `Fn<(&'1 u32,)>`, for any lifetime `'1`...
+   = note: ...but it actually implements `Fn<(&'2 u32,)>`, for some specific lifetime `'2`
+
+error: implementation of `Foo` is not general enough
+  --> $DIR/higher-ranked-alias-norm-to-hr.rs:23:5
+   |
+LL |     needs_super(|_| {});
+   |     ^^^^^^^^^^^^^^^^^^^ implementation of `Foo` is not general enough
+   |
+   = note: `{closure@$DIR/higher-ranked-alias-norm-to-hr.rs:23:17: 23:20}` must implement `Foo<'0>`, for any lifetime `'0`...
+   = note: ...but it actually implements `Foo<'1>`, for some specific lifetime `'1`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: implementation of `FnOnce` is not general enough
+  --> $DIR/higher-ranked-alias-norm-to-hr.rs:23:5
+   |
+LL |     needs_super(|_| {});
+   |     ^^^^^^^^^^^^^^^^^^^ implementation of `FnOnce` is not general enough
+   |
+   = note: closure with signature `fn(&'2 u32)` must implement `FnOnce<(&'1 u32,)>`, for any lifetime `'1`...
+   = note: ...but it actually implements `FnOnce<(&'2 u32,)>`, for some specific lifetime `'2`
+
+error: implementation of `Foo` is not general enough
+  --> $DIR/higher-ranked-alias-norm-to-hr.rs:23:5
+   |
+LL |     needs_super(|_| {});
+   |     ^^^^^^^^^^^^^^^^^^^ implementation of `Foo` is not general enough
+   |
+   = note: `{closure@$DIR/higher-ranked-alias-norm-to-hr.rs:23:17: 23:20}` must implement `Foo<'0>`, for any lifetime `'0`...
+   = note: ...but it actually implements `Foo<'1>`, for some specific lifetime `'1`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 5 previous errors
+

--- a/tests/ui/closures/deduce-signature/higher-ranked-alias-norm-to-hr.next_ambig.stderr
+++ b/tests/ui/closures/deduce-signature/higher-ranked-alias-norm-to-hr.next_ambig.stderr
@@ -1,0 +1,51 @@
+error[E0277]: expected a `Fn(&'a u32)` closure, found `{closure@$DIR/higher-ranked-alias-norm-to-hr.rs:23:17: 23:20}`
+  --> $DIR/higher-ranked-alias-norm-to-hr.rs:23:17
+   |
+LL |     needs_super(|_| {});
+   |     ----------- ^^^^^^ expected an `Fn(&'a u32)` closure, found `{closure@$DIR/higher-ranked-alias-norm-to-hr.rs:23:17: 23:20}`
+   |     |
+   |     required by a bound introduced by this call
+   |
+   = help: the trait `for<'a> Fn(&'a u32)` is not implemented for closure `{closure@$DIR/higher-ranked-alias-norm-to-hr.rs:23:17: 23:20}`
+   = note: expected a closure with signature `for<'a> fn(&'a _)`
+              found a closure with signature `fn(&_)`
+note: this is a known limitation of the trait solver that will be lifted in the future
+  --> $DIR/higher-ranked-alias-norm-to-hr.rs:23:17
+   |
+LL |     needs_super(|_| {});
+   |     ------------^^^----
+   |     |           |
+   |     |           the trait solver is unable to infer the generic types that should be inferred from this argument
+   |     add turbofish arguments to this call to specify the types manually, even if it's redundant
+note: required by a bound in `needs_super`
+  --> $DIR/higher-ranked-alias-norm-to-hr.rs:17:19
+   |
+LL | fn needs_super<F: for<'a> Fn(<F as Foo<'a>>::Input) + for<'a> Foo<'a>>(_: F) {}
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `needs_super`
+
+error[E0277]: the trait bound `for<'a> {closure@$DIR/higher-ranked-alias-norm-to-hr.rs:23:17: 23:20}: Foo<'a>` is not satisfied
+  --> $DIR/higher-ranked-alias-norm-to-hr.rs:23:17
+   |
+LL |     needs_super(|_| {});
+   |     ----------- ^^^^^^ unsatisfied trait bound
+   |     |
+   |     required by a bound introduced by this call
+   |
+   = help: the trait `for<'a> Foo<'a>` is not implemented for closure `{closure@$DIR/higher-ranked-alias-norm-to-hr.rs:23:17: 23:20}`
+note: this is a known limitation of the trait solver that will be lifted in the future
+  --> $DIR/higher-ranked-alias-norm-to-hr.rs:23:17
+   |
+LL |     needs_super(|_| {});
+   |     ------------^^^----
+   |     |           |
+   |     |           the trait solver is unable to infer the generic types that should be inferred from this argument
+   |     add turbofish arguments to this call to specify the types manually, even if it's redundant
+note: required by a bound in `needs_super`
+  --> $DIR/higher-ranked-alias-norm-to-hr.rs:17:55
+   |
+LL | fn needs_super<F: for<'a> Fn(<F as Foo<'a>>::Input) + for<'a> Foo<'a>>(_: F) {}
+   |                                                       ^^^^^^^^^^^^^^^ required by this bound in `needs_super`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/closures/deduce-signature/higher-ranked-alias-norm-to-hr.rs
+++ b/tests/ui/closures/deduce-signature/higher-ranked-alias-norm-to-hr.rs
@@ -1,0 +1,31 @@
+//@ revisions: current_ok next_ok current_ambig next_ambig
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@[next_ok] compile-flags: -Znext-solver
+//@[next_ambig] compile-flags: -Znext-solver
+//@[current_ok] check-pass
+//@[next_ok] check-pass
+
+// Regression test for trait-system-refactor-initiative#191.
+trait Foo<'a> {
+    type Input;
+}
+
+impl<'a, F: Fn(&'a u32)> Foo<'a> for F {
+    type Input = &'a u32;
+}
+
+fn needs_super<F: for<'a> Fn(<F as Foo<'a>>::Input) + for<'a> Foo<'a>>(_: F) {}
+
+fn main() {
+    #[cfg(any(current_ok, next_ok))]
+    needs_super(|_: &u32| {});
+    #[cfg(any(current_ambig, next_ambig))]
+    needs_super(|_| {});
+    //[next_ambig]~^ ERROR expected a `Fn(&'a u32)` closure, found
+    //[next_ambig]~| ERROR the trait bound
+    //[current_ambig]~^^^ ERROR implementation of `Foo` is not general enough
+    //[current_ambig]~| ERROR implementation of `Fn` is not general enough
+    //[current_ambig]~| ERROR implementation of `Foo` is not general enough
+    //[current_ambig]~| ERROR implementation of `FnOnce` is not general enough
+    //[current_ambig]~| ERROR implementation of `Foo` is not general enough
+}

--- a/tests/ui/closures/deduce-signature/higher-ranked-alias-norm-to-non-hr.rs
+++ b/tests/ui/closures/deduce-signature/higher-ranked-alias-norm-to-non-hr.rs
@@ -1,0 +1,24 @@
+//@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@[next] compile-flags: -Znext-solver
+//@ check-pass
+
+// Regression test for trait-system-refactor-initiative#191.
+
+trait Indir<T>: FnOnce(T) -> Self::Ret {
+    type Ret;
+}
+impl<F, T, R> Indir<T> for F where F: FnOnce(T) -> R {
+    type Ret = R;
+}
+
+trait Mirror {
+    type Assoc<'a>;
+}
+
+fn needs<T: Mirror>(_: impl for<'a> Indir<T::Assoc<'a>>) {}
+
+fn test<T>() where for<'a> T: Mirror<Assoc<'a> = i32> {
+    needs::<T>(|x| { x.to_string(); });
+}
+fn main() {}

--- a/tests/ui/coherence/occurs-check/associated-type.next.stderr
+++ b/tests/ui/coherence/occurs-check/associated-type.next.stderr
@@ -1,5 +1,3 @@
- WARN rustc_infer::infer::relate::generalize may incompletely handle alias type: AliasTy { args: [*const ?1t, '^0.Named(DefId(0:27 ~ associated_type[f554]::{impl#3}::'a#1))], def_id: DefId(0:5 ~ associated_type[f554]::ToUnit::Unit), .. }
- WARN rustc_infer::infer::relate::generalize may incompletely handle alias type: AliasTy { args: [*const ?1t, '^0.Named(DefId(0:27 ~ associated_type[f554]::{impl#3}::'a#1))], def_id: DefId(0:5 ~ associated_type[f554]::ToUnit::Unit), .. }
 error[E0119]: conflicting implementations of trait `Overlap<for<'a> fn(&'a (), ())>` for type `for<'a> fn(&'a (), ())`
   --> $DIR/associated-type.rs:32:1
    |

--- a/tests/ui/coherence/occurs-check/associated-type.old.stderr
+++ b/tests/ui/coherence/occurs-check/associated-type.old.stderr
@@ -1,5 +1,3 @@
- WARN rustc_infer::infer::relate::generalize may incompletely handle alias type: AliasTy { args: [*const ?1t, '^0.Named(DefId(0:27 ~ associated_type[f554]::{impl#3}::'a#1))], def_id: DefId(0:5 ~ associated_type[f554]::ToUnit::Unit), .. }
- WARN rustc_infer::infer::relate::generalize may incompletely handle alias type: AliasTy { args: [*const ?1t, '^0.Named(DefId(0:27 ~ associated_type[f554]::{impl#3}::'a#1))], def_id: DefId(0:5 ~ associated_type[f554]::ToUnit::Unit), .. }
 error[E0119]: conflicting implementations of trait `Overlap<for<'a> fn(&'a (), ())>` for type `for<'a> fn(&'a (), ())`
   --> $DIR/associated-type.rs:32:1
    |

--- a/tests/ui/higher-ranked/structually-relate-aliases.stderr
+++ b/tests/ui/higher-ranked/structually-relate-aliases.stderr
@@ -1,4 +1,3 @@
- WARN rustc_infer::infer::relate::generalize may incompletely handle alias type: AliasTy { args: [?1t, '^0.Named(DefId(0:15 ~ structually_relate_aliases[de75]::{impl#1}::'a))], def_id: DefId(0:5 ~ structually_relate_aliases[de75]::ToUnit::Unit), .. }
 error[E0277]: the trait bound `for<'a> T: ToUnit<'a>` is not satisfied
   --> $DIR/structually-relate-aliases.rs:13:36
    |

--- a/tests/ui/mismatched_types/closure-arg-type-mismatch-issue-45727.current.fixed
+++ b/tests/ui/mismatched_types/closure-arg-type-mismatch-issue-45727.current.fixed
@@ -8,6 +8,5 @@ fn main() {
     //[next]~^^ ERROR expected a `FnMut(&<std::ops::RangeInclusive<{integer}> as Iterator>::Item)` closure, found
     let _ = (-10..=10).find(|x: &i32| x.signum() == 0);
     //[current]~^ ERROR type mismatch in closure arguments
-    //[next]~^^ ERROR expected `RangeInclusive<{integer}>` to be an iterator that yields `&&i32`, but it yields `{integer}`
-    //[next]~| ERROR expected a `FnMut(&<std::ops::RangeInclusive<{integer}> as Iterator>::Item)` closure, found
+    //[next]~^^ ERROR expected a `FnMut(&<std::ops::RangeInclusive<{integer}> as Iterator>::Item)` closure, found
 }

--- a/tests/ui/mismatched_types/closure-arg-type-mismatch-issue-45727.next.stderr
+++ b/tests/ui/mismatched_types/closure-arg-type-mismatch-issue-45727.next.stderr
@@ -12,12 +12,6 @@ LL |     let _ = (-10..=10).find(|x: i32| x.signum() == 0);
 note: required by a bound in `find`
   --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
 
-error[E0271]: expected `RangeInclusive<{integer}>` to be an iterator that yields `&&i32`, but it yields `{integer}`
-  --> $DIR/closure-arg-type-mismatch-issue-45727.rs:9:24
-   |
-LL |     let _ = (-10..=10).find(|x: &&&i32| x.signum() == 0);
-   |                        ^^^^ expected `&&i32`, found integer
-
 error[E0277]: expected a `FnMut(&<std::ops::RangeInclusive<{integer}> as Iterator>::Item)` closure, found `{closure@$DIR/closure-arg-type-mismatch-issue-45727.rs:9:29: 9:40}`
   --> $DIR/closure-arg-type-mismatch-issue-45727.rs:9:29
    |
@@ -32,7 +26,6 @@ LL |     let _ = (-10..=10).find(|x: &&&i32| x.signum() == 0);
 note: required by a bound in `find`
   --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
 
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 
-Some errors have detailed explanations: E0271, E0277.
-For more information about an error, try `rustc --explain E0271`.
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/mismatched_types/closure-arg-type-mismatch-issue-45727.rs
+++ b/tests/ui/mismatched_types/closure-arg-type-mismatch-issue-45727.rs
@@ -8,6 +8,5 @@ fn main() {
     //[next]~^^ ERROR expected a `FnMut(&<std::ops::RangeInclusive<{integer}> as Iterator>::Item)` closure, found
     let _ = (-10..=10).find(|x: &&&i32| x.signum() == 0);
     //[current]~^ ERROR type mismatch in closure arguments
-    //[next]~^^ ERROR expected `RangeInclusive<{integer}>` to be an iterator that yields `&&i32`, but it yields `{integer}`
-    //[next]~| ERROR expected a `FnMut(&<std::ops::RangeInclusive<{integer}> as Iterator>::Item)` closure, found
+    //[next]~^^ ERROR expected a `FnMut(&<std::ops::RangeInclusive<{integer}> as Iterator>::Item)` closure, found
 }

--- a/tests/ui/traits/next-solver/issue-118950-root-region.stderr
+++ b/tests/ui/traits/next-solver/issue-118950-root-region.stderr
@@ -25,7 +25,6 @@ help: this trait has no implementations, consider adding one
 LL | trait ToUnit<'a> {
    | ^^^^^^^^^^^^^^^^
 
- WARN rustc_infer::infer::relate::generalize may incompletely handle alias type: AliasTy { args: ['^0.Named(DefId(0:15 ~ issue_118950_root_region[d54f]::{impl#1}::'a)), ?1t], def_id: DefId(0:8 ~ issue_118950_root_region[d54f]::Assoc), .. }
 error[E0277]: the trait bound `for<'a> *const T: ToUnit<'a>` is not satisfied
   --> $DIR/issue-118950-root-region.rs:19:9
    |


### PR DESCRIPTION
doesn't fully fix https://github.com/rust-lang/trait-system-refactor-initiative/issues/191 due to remaining issues in https://github.com/rust-lang/trait-system-refactor-initiative/issues/8. Notably, the following still breaks when switching solvers and would rely on actual eager norm to fix
```rust
trait Ref<'a, F> {
    type Input;
}

impl<'a, F> Ref<'a, F> for u32 {
    type Input = &'a u32;
}

fn needs_super<F: for<'a> Fn(<u32 as Ref<'a, F>>::Input)>(_: F) {}

fn main() {
    needs_super(|_| {});
}
```


r? @BoxyUwU 