### PR TITLE
Don't allow PassMode::Pair for unadjusted calls

### DIFF
--- a/compiler/rustc_target/src/callconv/mod.rs
+++ b/compiler/rustc_target/src/callconv/mod.rs
@@ -424,8 +424,10 @@ impl<'a, Ty> ArgAbi<'a, Ty> {
             PassMode::Indirect { .. } => {
                 self.mode = PassMode::Direct(ArgAttributes::new());
             }
-            PassMode::Ignore | PassMode::Direct(_) | PassMode::Pair(_, _) => {} // already direct
-            _ => panic!("Tried to make {:?} direct", self.mode),
+            PassMode::Ignore | PassMode::Direct(_) => {} // already direct
+            PassMode::Pair(_, _) | PassMode::Cast { .. } => {
+                panic!("Tried to make {:?} direct", self.mode)
+            }
         }
     }
 

--- a/compiler/rustc_ty_utils/src/abi.rs
+++ b/compiler/rustc_ty_utils/src/abi.rs
@@ -592,8 +592,6 @@ fn fn_abi_adjust_for_abi<'tcx>(
         // The "unadjusted" ABI passes aggregates in "direct" mode. That's fragile but needed for
         // some LLVM intrinsics.
         fn unadjust<'tcx>(arg: &mut ArgAbi<'tcx, Ty<'tcx>>) {
-            // This still uses `PassMode::Pair` for ScalarPair types. That's unlikely to be intended,
-            // but who knows what breaks if we change this now.
             if matches!(arg.layout.backend_repr, BackendRepr::Memory { .. }) {
                 assert!(
                     arg.layout.backend_repr.is_sized(),


### PR DESCRIPTION
I don't think we use them anywhere inside stdarch. And not supporting them will make some future changes I plan to make to unadjusted calls a bit easier. I'm opening this as a separate PR now to make it easier to revert if it turns out stdarch does need it after all.