### PR TITLE
chore: fix setup script errors

### DIFF
--- a/src/ci/scripts/install-ninja.sh
+++ b/src/ci/scripts/install-ninja.sh
@@ -6,9 +6,13 @@ IFS=$'\n\t'
 
 source "$(cd "$(dirname "$0")" && pwd)/../shared.sh"
 
+# Check and set default values for variables
+: "${MIRRORS_BASE:?MIRRORS_BASE is not set}"
+: "${RUST_CONFIGURE_ARGS:=}"
+
 if isWindows; then
-    mkdir ninja
-    curl -o ninja.zip "${MIRRORS_BASE}/2024-03-28-v1.11.1-ninja-win.zip"
+    mkdir -p ninja
+    curl -fLo ninja.zip "${MIRRORS_BASE}/2024-03-28-v1.11.1-ninja-win.zip"
     7z x -oninja ninja.zip
     rm ninja.zip
     ciCommandSetEnv "RUST_CONFIGURE_ARGS" "${RUST_CONFIGURE_ARGS} --enable-ninja"


### PR DESCRIPTION
made the setup script more reliable:

* `MIRRORS_BASE` now errors if missing.
* `RUST_CONFIGURE_ARGS` defaults to empty.
* `mkdir -p ninja` avoids “already exists” errors.
* `curl -fLo` follows redirects and fails on HTTP errors.

simple, clear, and it just works.