### PR TITLE
tests: relax expectations after llvm change 902ddda120a5

### DIFF
--- a/tests/codegen-llvm/issues/issue-122600-ptr-discriminant-update.rs
+++ b/tests/codegen-llvm/issues/issue-122600-ptr-discriminant-update.rs
@@ -1,6 +1,6 @@
 //@ compile-flags: -Copt-level=3
 //@ revisions: new old
-//@ [old] ignore-llvm-version: 22 - 99
+//@ [old] max-llvm-major-version: 21
 //@ [new] min-llvm-version: 22
 
 #![crate_type = "lib"]

--- a/tests/codegen-llvm/issues/issue-122600-ptr-discriminant-update.rs
+++ b/tests/codegen-llvm/issues/issue-122600-ptr-discriminant-update.rs
@@ -1,4 +1,7 @@
 //@ compile-flags: -Copt-level=3
+//@ revisions: new old
+//@ [old] ignore-llvm-version: 22 - 99
+//@ [new] min-llvm-version: 22
 
 #![crate_type = "lib"]
 
@@ -22,8 +25,8 @@ pub unsafe fn update(s: *mut State) {
     // CHECK-NOT: memcpy
     // CHECK-NOT: 75{{3|4}}
 
-    // CHECK: %[[TAG:.+]] = load i8, ptr %s, align 1
-    // CHECK-NEXT: trunc nuw i8 %[[TAG]] to i1
+    // old: %[[TAG:.+]] = load i8, ptr %s, align 1
+    // old-NEXT: trunc nuw i8 %[[TAG]] to i1
 
     // CHECK-NOT: load
     // CHECK-NOT: store

--- a/tests/codegen-llvm/vec_pop_push_noop.rs
+++ b/tests/codegen-llvm/vec_pop_push_noop.rs
@@ -1,6 +1,6 @@
 //@ compile-flags: -Copt-level=3
 //@ revisions: new old
-//@ [old] ignore-llvm-version: 22 - 99
+//@ [old] max-llvm-major-version: 21
 //@ [new] min-llvm-version: 22
 
 #![crate_type = "lib"]

--- a/tests/codegen-llvm/vec_pop_push_noop.rs
+++ b/tests/codegen-llvm/vec_pop_push_noop.rs
@@ -1,4 +1,7 @@
 //@ compile-flags: -Copt-level=3
+//@ revisions: new old
+//@ [old] ignore-llvm-version: 22 - 99
+//@ [new] min-llvm-version: 22
 
 #![crate_type = "lib"]
 
@@ -7,7 +10,7 @@
 pub fn noop(v: &mut Vec<u8>) {
     // CHECK-NOT: grow_one
     // CHECK-NOT: call
-    // CHECK: tail call void @llvm.assume
+    // old: tail call void @llvm.assume
     // CHECK-NOT: grow_one
     // CHECK-NOT: call
     // CHECK: {{ret|[}]}}

--- a/tests/codegen-llvm/vecdeque_pop_push.rs
+++ b/tests/codegen-llvm/vecdeque_pop_push.rs
@@ -1,4 +1,7 @@
 //@ compile-flags: -Copt-level=3
+//@ revisions: new old
+//@ [old] ignore-llvm-version: 22 - 99
+//@ [new] min-llvm-version: 22
 
 #![crate_type = "lib"]
 
@@ -8,7 +11,7 @@ use std::collections::VecDeque;
 // CHECK-LABEL: @noop_back(
 pub fn noop_back(v: &mut VecDeque<u8>) {
     // CHECK-NOT: grow
-    // CHECK: tail call void @llvm.assume
+    // old: tail call void @llvm.assume
     // CHECK-NOT: grow
     // CHECK: ret
     if let Some(x) = v.pop_back() {

--- a/tests/codegen-llvm/vecdeque_pop_push.rs
+++ b/tests/codegen-llvm/vecdeque_pop_push.rs
@@ -1,6 +1,6 @@
 //@ compile-flags: -Copt-level=3
 //@ revisions: new old
-//@ [old] ignore-llvm-version: 22 - 99
+//@ [old] max-llvm-major-version: 21
 //@ [new] min-llvm-version: 22
 
 #![crate_type = "lib"]


### PR DESCRIPTION
LLVM 22 is able to drop assumes that seem to not help further optimizations, which actually seems to dramatically _help_ further optimizations in some of our small test cases.

I'm a little unclear how to fix the last failure, in `tests/codegen-llvm/issues/issue-122600-ptr-discriminant-update.rs`:

```
-; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: readwrite, inaccessiblemem: write) uwtable
+; Function Attrs: mustprogress nofree norecurse nosync nounwind nonlazybind willreturn memory(argmem: readwrite, inaccessiblemem: write) uwtable
 define void @update(ptr noundef captures(none) %s) unnamed_addr #0 {
 start:
-  %_3.sroa.0.0.copyload = load i8, ptr %s, align 1
-  %0 = trunc nuw i8 %_3.sroa.0.0.copyload to i1
-  %1 = xor i1 %0, true
-  tail call void @llvm.assume(i1 %1)
   store i8 1, ptr %s, align 1
   ret void
 }
```

I'm just not conversant enough in LLVM IR to follow the changes here.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

@rustbot label llvm-main
r? nikic
