### PR TITLE
f16_f128: enable some more tests in Miri

### DIFF
--- a/library/coretests/tests/floats/mod.rs
+++ b/library/coretests/tests/floats/mod.rs
@@ -1180,15 +1180,12 @@ float_test! {
     }
 }
 
-// FIXME(f16_f128,miri): many of these have to be disabled since miri does not yet support
-// the intrinsics.
-
 float_test! {
     name: sqrt_domain,
     attrs: {
         const: #[cfg(false)],
-        f16: #[cfg(all(not(miri), target_has_reliable_f16_math))],
-        f128: #[cfg(all(not(miri), target_has_reliable_f128_math))],
+        f16: #[cfg(any(miri, target_has_reliable_f16_math))],
+        f128: #[cfg(any(miri, target_has_reliable_f128_math))],
     },
     test<Float> {
         assert!(Float::NAN.sqrt().is_nan());
@@ -1246,8 +1243,8 @@ float_test! {
 float_test! {
     name: total_cmp,
     attrs: {
-        f16: #[cfg(all(not(miri), target_has_reliable_f16_math))],
-        f128: #[cfg(all(not(miri), target_has_reliable_f128_math))],
+        f16: #[cfg(any(miri, target_has_reliable_f16_math))],
+        f128: #[cfg(any(miri, target_has_reliable_f128_math))],
     },
     test<Float> {
         use core::cmp::Ordering;
@@ -1355,8 +1352,8 @@ float_test! {
     name: total_cmp_s_nan,
     attrs: {
         const: #[cfg(false)],
-        f16: #[cfg(false)],
-        f128: #[cfg(all(not(miri), target_has_reliable_f128_math))],
+        f16: #[cfg(miri)],
+        f128: #[cfg(any(miri, target_has_reliable_f128_math))],
     },
     test<Float> {
         use core::cmp::Ordering;
@@ -1432,6 +1429,7 @@ float_test! {
     name: powi,
     attrs: {
         const: #[cfg(false)],
+        // FIXME(f16_f128): `powi` does not work in Miri for these types
         f16: #[cfg(all(not(miri), target_has_reliable_f16_math))],
         f128: #[cfg(all(not(miri), target_has_reliable_f128_math))],
     },
@@ -1452,8 +1450,8 @@ float_test! {
 float_test! {
     name: to_degrees,
     attrs: {
-        f16: #[cfg(target_has_reliable_f16)],
-        f128: #[cfg(target_has_reliable_f128)],
+        f16: #[cfg(any(miri, target_has_reliable_f16))],
+        f128: #[cfg(any(miri, target_has_reliable_f128))],
     },
     test<Float> {
         let pi: Float = Float::PI;
@@ -1473,8 +1471,8 @@ float_test! {
 float_test! {
     name: to_radians,
     attrs: {
-        f16: #[cfg(target_has_reliable_f16)],
-        f128: #[cfg(target_has_reliable_f128)],
+        f16: #[cfg(any(miri, target_has_reliable_f16))],
+        f128: #[cfg(any(miri, target_has_reliable_f128))],
     },
     test<Float> {
         let pi: Float = Float::PI;
@@ -1494,8 +1492,8 @@ float_test! {
 float_test! {
     name: to_algebraic,
     attrs: {
-        f16: #[cfg(target_has_reliable_f16)],
-        f128: #[cfg(target_has_reliable_f128)],
+        f16: #[cfg(any(miri, target_has_reliable_f16))],
+        f128: #[cfg(any(miri, target_has_reliable_f128))],
     },
     test<Float> {
         let a: Float = 123.0;
@@ -1518,8 +1516,8 @@ float_test! {
 float_test! {
     name: to_bits_conv,
     attrs: {
-        f16: #[cfg(target_has_reliable_f16)],
-        f128: #[cfg(target_has_reliable_f128)],
+        f16: #[cfg(any(miri, target_has_reliable_f16))],
+        f128: #[cfg(any(miri, target_has_reliable_f128))],
     },
     test<Float> {
         assert_biteq!(flt(1.0), Float::RAW_1);


### PR DESCRIPTION
For some reason, a bunch of tests were disabled in Miri that don't use any fancy intrinsics. Let's enable them.

I verified this with `./x miri library/core --no-doc -- float`.

r? @tgross35 