### PR TITLE
Support borrowed locals in DestinationPropagation.

### DIFF
--- a/compiler/rustc_mir_transform/src/coroutine.rs
+++ b/compiler/rustc_mir_transform/src/coroutine.rs
@@ -708,8 +708,9 @@ fn locals_live_across_suspend_points<'tcx>(
     );
 
     // Calculate the liveness of MIR locals ignoring borrows.
-    let mut liveness =
-        MaybeLiveLocals.iterate_to_fixpoint(tcx, body, Some("coroutine")).into_results_cursor(body);
+    let mut liveness = MaybeLiveLocals(|_| std::iter::empty())
+        .iterate_to_fixpoint(tcx, body, Some("coroutine"))
+        .into_results_cursor(body);
 
     let mut storage_liveness_map = IndexVec::from_elem(None, &body.basic_blocks);
     let mut live_locals_at_suspension_points = Vec::new();

--- a/tests/codegen-llvm/function-arguments.rs
+++ b/tests/codegen-llvm/function-arguments.rs
@@ -185,7 +185,7 @@ pub fn _box(x: Box<i32>) -> Box<i32> {
 // With a custom allocator, it should *not* have `noalias`. (See
 // <https://github.com/rust-lang/miri/issues/3341> for why.) The second argument is the allocator,
 // which is a reference here that still carries `noalias` as usual.
-// CHECK: @_box_custom(ptr noundef nonnull align 4 %x.0, ptr noalias noundef nonnull readonly align 1{{( captures\(address, read_provenance\))?}} %x.1)
+// CHECK: @_box_custom(ptr noundef nonnull align 4 %0, ptr noalias noundef nonnull readonly align 1{{( captures\(address, read_provenance\))?}} %1)
 #[no_mangle]
 pub fn _box_custom(x: Box<i32, &std::alloc::Global>) {
     drop(x)

--- a/tests/codegen-llvm/noalias-box-off.rs
+++ b/tests/codegen-llvm/noalias-box-off.rs
@@ -4,7 +4,7 @@
 
 // CHECK-LABEL: @box_should_not_have_noalias_if_disabled(
 // CHECK-NOT: noalias
-// CHECK-SAME: %foo)
+// CHECK-SAME: %0)
 #[no_mangle]
 pub fn box_should_not_have_noalias_if_disabled(foo: Box<u8>) {
     drop(foo);

--- a/tests/codegen-llvm/zip.rs
+++ b/tests/codegen-llvm/zip.rs
@@ -1,6 +1,8 @@
-//@ compile-flags: -Cno-prepopulate-passes -Copt-level=3
+//@ compile-flags: -Copt-level=3
 
 #![crate_type = "lib"]
+
+// CHECK-LABEL: @zip_copy_mapped = unnamed_addr alias void (ptr, i64, ptr, i64), ptr @zip_copy
 
 // CHECK-LABEL: @zip_copy
 #[no_mangle]
@@ -11,10 +13,8 @@ pub fn zip_copy(xs: &[u8], ys: &mut [u8]) {
     }
 }
 
-// CHECK-LABEL: @zip_copy_mapped
 #[no_mangle]
 pub fn zip_copy_mapped(xs: &[u8], ys: &mut [u8]) {
-    // CHECK: memcpy
     for (x, y) in xs.iter().map(|&x| x).zip(ys) {
         *y = x;
     }

--- a/tests/mir-opt/dest-prop/nrvo_borrowed.nrvo.DestinationPropagation.panic-abort.diff
+++ b/tests/mir-opt/dest-prop/nrvo_borrowed.nrvo.DestinationPropagation.panic-abort.diff
@@ -10,12 +10,15 @@
       let mut _5: &mut [u8; 1024];
       let mut _6: &mut [u8; 1024];
       scope 1 {
-          debug buf => _2;
+-         debug buf => _2;
++         debug buf => _0;
       }
   
       bb0: {
-          StorageLive(_2);
-          _2 = [const 0_u8; 1024];
+-         StorageLive(_2);
+-         _2 = [const 0_u8; 1024];
++         nop;
++         _0 = [const 0_u8; 1024];
           StorageLive(_3);
 -         StorageLive(_4);
 -         _4 = copy _1;
@@ -23,7 +26,8 @@
 +         nop;
           StorageLive(_5);
           StorageLive(_6);
-          _6 = &mut _2;
+-         _6 = &mut _2;
++         _6 = &mut _0;
           _5 = &mut (*_6);
 -         _3 = move _4(move _5) -> [return: bb1, unwind unreachable];
 +         _3 = move _1(move _5) -> [return: bb1, unwind unreachable];
@@ -35,8 +39,10 @@
 +         nop;
           StorageDead(_6);
           StorageDead(_3);
-          _0 = copy _2;
-          StorageDead(_2);
+-         _0 = copy _2;
+-         StorageDead(_2);
++         nop;
++         nop;
           return;
       }
   }

--- a/tests/mir-opt/dest-prop/nrvo_borrowed.nrvo.DestinationPropagation.panic-unwind.diff
+++ b/tests/mir-opt/dest-prop/nrvo_borrowed.nrvo.DestinationPropagation.panic-unwind.diff
@@ -10,12 +10,15 @@
       let mut _5: &mut [u8; 1024];
       let mut _6: &mut [u8; 1024];
       scope 1 {
-          debug buf => _2;
+-         debug buf => _2;
++         debug buf => _0;
       }
   
       bb0: {
-          StorageLive(_2);
-          _2 = [const 0_u8; 1024];
+-         StorageLive(_2);
+-         _2 = [const 0_u8; 1024];
++         nop;
++         _0 = [const 0_u8; 1024];
           StorageLive(_3);
 -         StorageLive(_4);
 -         _4 = copy _1;
@@ -23,7 +26,8 @@
 +         nop;
           StorageLive(_5);
           StorageLive(_6);
-          _6 = &mut _2;
+-         _6 = &mut _2;
++         _6 = &mut _0;
           _5 = &mut (*_6);
 -         _3 = move _4(move _5) -> [return: bb1, unwind continue];
 +         _3 = move _1(move _5) -> [return: bb1, unwind continue];
@@ -35,8 +39,10 @@
 +         nop;
           StorageDead(_6);
           StorageDead(_3);
-          _0 = copy _2;
-          StorageDead(_2);
+-         _0 = copy _2;
+-         StorageDead(_2);
++         nop;
++         nop;
           return;
       }
   }

--- a/tests/mir-opt/dest-prop/simple.nrvo.DestinationPropagation.panic-abort.diff
+++ b/tests/mir-opt/dest-prop/simple.nrvo.DestinationPropagation.panic-abort.diff
@@ -10,12 +10,15 @@
       let mut _5: &mut [u8; 1024];
       let mut _6: &mut [u8; 1024];
       scope 1 {
-          debug buf => _2;
+-         debug buf => _2;
++         debug buf => _0;
       }
   
       bb0: {
-          StorageLive(_2);
-          _2 = [const 0_u8; 1024];
+-         StorageLive(_2);
+-         _2 = [const 0_u8; 1024];
++         nop;
++         _0 = [const 0_u8; 1024];
           StorageLive(_3);
 -         StorageLive(_4);
 -         _4 = copy _1;
@@ -23,7 +26,8 @@
 +         nop;
           StorageLive(_5);
           StorageLive(_6);
-          _6 = &mut _2;
+-         _6 = &mut _2;
++         _6 = &mut _0;
           _5 = &mut (*_6);
 -         _3 = move _4(move _5) -> [return: bb1, unwind unreachable];
 +         _3 = move _1(move _5) -> [return: bb1, unwind unreachable];
@@ -35,8 +39,10 @@
 +         nop;
           StorageDead(_6);
           StorageDead(_3);
-          _0 = copy _2;
-          StorageDead(_2);
+-         _0 = copy _2;
+-         StorageDead(_2);
++         nop;
++         nop;
           return;
       }
   }

--- a/tests/mir-opt/dest-prop/simple.nrvo.DestinationPropagation.panic-unwind.diff
+++ b/tests/mir-opt/dest-prop/simple.nrvo.DestinationPropagation.panic-unwind.diff
@@ -10,12 +10,15 @@
       let mut _5: &mut [u8; 1024];
       let mut _6: &mut [u8; 1024];
       scope 1 {
-          debug buf => _2;
+-         debug buf => _2;
++         debug buf => _0;
       }
   
       bb0: {
-          StorageLive(_2);
-          _2 = [const 0_u8; 1024];
+-         StorageLive(_2);
+-         _2 = [const 0_u8; 1024];
++         nop;
++         _0 = [const 0_u8; 1024];
           StorageLive(_3);
 -         StorageLive(_4);
 -         _4 = copy _1;
@@ -23,7 +26,8 @@
 +         nop;
           StorageLive(_5);
           StorageLive(_6);
-          _6 = &mut _2;
+-         _6 = &mut _2;
++         _6 = &mut _0;
           _5 = &mut (*_6);
 -         _3 = move _4(move _5) -> [return: bb1, unwind continue];
 +         _3 = move _1(move _5) -> [return: bb1, unwind continue];
@@ -35,8 +39,10 @@
 +         nop;
           StorageDead(_6);
           StorageDead(_3);
-          _0 = copy _2;
-          StorageDead(_2);
+-         _0 = copy _2;
+-         StorageDead(_2);
++         nop;
++         nop;
           return;
       }
   }

--- a/tests/mir-opt/dest-prop/simple.rs
+++ b/tests/mir-opt/dest-prop/simple.rs
@@ -5,11 +5,11 @@
 fn nrvo(init: fn(&mut [u8; 1024])) -> [u8; 1024] {
     // CHECK-LABEL: fn nrvo(
     // CHECK: debug init => [[init:_.*]];
-    // CHECK: debug buf => [[buf:_.*]];
-    // CHECK: [[buf]] = [const 0_u8; 1024];
+    // CHECK: debug buf => _0;
+    // CHECK: _0 = [const 0_u8; 1024];
     // CHECK-NOT: {{_.*}} = copy [[init]];
+    // CHECK: {{_.*}} = &mut _0;
     // CHECK: move [[init]](move {{_.*}})
-    // CHECK: {{_.*}} = copy [[buf]]
     let mut buf = [0; 1024];
     init(&mut buf);
     buf

--- a/tests/mir-opt/inline/inline_diverging.h.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/inline_diverging.h.Inline.panic-unwind.diff
@@ -5,14 +5,13 @@
       let mut _0: ();
       let _1: (!, !);
 +     let mut _2: fn() -> ! {sleep};
++     let mut _7: ();
 +     let mut _8: ();
-+     let mut _9: ();
 +     scope 1 (inlined call_twice::<!, fn() -> ! {sleep}>) {
 +         debug f => _2;
 +         let mut _3: &fn() -> ! {sleep};
 +         let _4: !;
 +         let mut _5: &fn() -> ! {sleep};
-+         let mut _7: !;
 +         scope 2 {
 +             debug a => _4;
 +             let _6: !;
@@ -35,12 +34,12 @@
 -         _1 = call_twice::<!, fn() -> ! {sleep}>(sleep) -> unwind continue;
 +         StorageLive(_2);
 +         _2 = sleep;
-+         StorageLive(_6);
 +         StorageLive(_4);
++         StorageLive(_6);
 +         StorageLive(_3);
 +         _3 = &_2;
-+         StorageLive(_8);
-+         _8 = const ();
++         StorageLive(_7);
++         _7 = const ();
 +         goto -> bb1;
 +     }
 + 

--- a/tests/mir-opt/pre-codegen/loops.filter_mapped.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/loops.filter_mapped.PreCodegen.after.mir
@@ -5,21 +5,20 @@ fn filter_mapped(_1: impl Iterator<Item = T>, _2: impl Fn(T) -> Option<U>) -> ()
     debug f => _2;
     let mut _0: ();
     let mut _3: std::iter::FilterMap<impl Iterator<Item = T>, impl Fn(T) -> Option<U>>;
-    let mut _4: std::iter::FilterMap<impl Iterator<Item = T>, impl Fn(T) -> Option<U>>;
-    let mut _5: &mut std::iter::FilterMap<impl Iterator<Item = T>, impl Fn(T) -> Option<U>>;
-    let mut _8: std::option::Option<U>;
-    let mut _9: isize;
-    let _11: ();
+    let mut _4: &mut std::iter::FilterMap<impl Iterator<Item = T>, impl Fn(T) -> Option<U>>;
+    let mut _7: std::option::Option<U>;
+    let mut _8: isize;
+    let _10: ();
     scope 1 {
-        debug iter => _4;
-        let _10: U;
+        debug iter => _3;
+        let _9: U;
         scope 2 {
-            debug x => _10;
+            debug x => _9;
         }
         scope 4 (inlined <FilterMap<impl Iterator<Item = T>, impl Fn(T) -> Option<U>> as Iterator>::next) {
-            debug self => _5;
-            let mut _6: &mut impl Iterator<Item = T>;
-            let mut _7: &mut impl Fn(T) -> Option<U>;
+            debug self => _4;
+            let mut _5: &mut impl Iterator<Item = T>;
+            let mut _6: &mut impl Fn(T) -> Option<U>;
         }
     }
     scope 3 (inlined <FilterMap<impl Iterator<Item = T>, impl Fn(T) -> Option<U>> as IntoIterator>::into_iter) {
@@ -31,45 +30,42 @@ fn filter_mapped(_1: impl Iterator<Item = T>, _2: impl Fn(T) -> Option<U>) -> ()
     }
 
     bb1: {
-        StorageLive(_4);
-        _4 = copy _3;
         goto -> bb2;
     }
 
     bb2: {
-        StorageLive(_8);
-        _5 = &mut _4;
-        StorageLive(_6);
-        _6 = &mut (_4.0: impl Iterator<Item = T>);
         StorageLive(_7);
-        _7 = &mut (_4.1: impl Fn(T) -> Option<U>);
-        _8 = <impl Iterator<Item = T> as Iterator>::find_map::<U, &mut impl Fn(T) -> Option<U>>(move _6, move _7) -> [return: bb3, unwind: bb9];
+        _4 = &mut _3;
+        StorageLive(_5);
+        _5 = &mut (_3.0: impl Iterator<Item = T>);
+        StorageLive(_6);
+        _6 = &mut (_3.1: impl Fn(T) -> Option<U>);
+        _7 = <impl Iterator<Item = T> as Iterator>::find_map::<U, &mut impl Fn(T) -> Option<U>>(move _5, move _6) -> [return: bb3, unwind: bb9];
     }
 
     bb3: {
-        StorageDead(_7);
         StorageDead(_6);
-        _9 = discriminant(_8);
-        switchInt(move _9) -> [0: bb4, 1: bb6, otherwise: bb8];
+        StorageDead(_5);
+        _8 = discriminant(_7);
+        switchInt(move _8) -> [0: bb4, 1: bb6, otherwise: bb8];
     }
 
     bb4: {
-        StorageDead(_8);
-        drop(_4) -> [return: bb5, unwind continue];
+        StorageDead(_7);
+        drop(_3) -> [return: bb5, unwind continue];
     }
 
     bb5: {
-        StorageDead(_4);
         return;
     }
 
     bb6: {
-        _10 = move ((_8 as Some).0: U);
-        _11 = opaque::<U>(move _10) -> [return: bb7, unwind: bb9];
+        _9 = move ((_7 as Some).0: U);
+        _10 = opaque::<U>(move _9) -> [return: bb7, unwind: bb9];
     }
 
     bb7: {
-        StorageDead(_8);
+        StorageDead(_7);
         goto -> bb2;
     }
 
@@ -78,7 +74,7 @@ fn filter_mapped(_1: impl Iterator<Item = T>, _2: impl Fn(T) -> Option<U>) -> ()
     }
 
     bb9 (cleanup): {
-        drop(_4) -> [return: bb10, unwind terminate(cleanup)];
+        drop(_3) -> [return: bb10, unwind terminate(cleanup)];
     }
 
     bb10 (cleanup): {

--- a/tests/mir-opt/pre-codegen/loops.int_range.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/loops.int_range.PreCodegen.after.mir
@@ -5,32 +5,31 @@ fn int_range(_1: usize, _2: usize) -> () {
     debug end => _2;
     let mut _0: ();
     let mut _3: std::ops::Range<usize>;
-    let mut _4: std::ops::Range<usize>;
-    let mut _5: &mut std::ops::Range<usize>;
-    let mut _13: std::option::Option<usize>;
-    let _15: ();
+    let mut _4: &mut std::ops::Range<usize>;
+    let mut _12: std::option::Option<usize>;
+    let _14: ();
     scope 1 {
-        debug iter => _4;
-        let _14: usize;
+        debug iter => _3;
+        let _13: usize;
         scope 2 {
-            debug i => _14;
+            debug i => _13;
         }
         scope 4 (inlined iter::range::<impl Iterator for std::ops::Range<usize>>::next) {
-            debug self => _5;
+            debug self => _4;
             scope 5 (inlined <std::ops::Range<usize> as iter::range::RangeIteratorImpl>::spec_next) {
-                debug self => _5;
+                debug self => _4;
+                let mut _5: &usize;
                 let mut _6: &usize;
-                let mut _7: &usize;
-                let mut _10: bool;
-                let _11: usize;
-                let mut _12: usize;
+                let mut _9: bool;
+                let _10: usize;
+                let mut _11: usize;
                 scope 6 {
-                    debug old => _11;
+                    debug old => _10;
                     scope 8 (inlined <usize as Step>::forward_unchecked) {
-                        debug start => _11;
+                        debug start => _10;
                         debug n => const 1_usize;
                         scope 9 (inlined #[track_caller] core::num::<impl usize>::unchecked_add) {
-                            debug self => _11;
+                            debug self => _10;
                             debug rhs => const 1_usize;
                             scope 10 (inlined core::ub_checks::check_language_ub) {
                                 scope 11 (inlined core::ub_checks::check_language_ub::runtime) {
@@ -40,10 +39,10 @@ fn int_range(_1: usize, _2: usize) -> () {
                     }
                 }
                 scope 7 (inlined std::cmp::impls::<impl PartialOrd for usize>::lt) {
-                    debug self => _6;
-                    debug other => _7;
+                    debug self => _5;
+                    debug other => _6;
+                    let mut _7: usize;
                     let mut _8: usize;
-                    let mut _9: usize;
                 }
             }
         }
@@ -54,54 +53,51 @@ fn int_range(_1: usize, _2: usize) -> () {
 
     bb0: {
         _3 = std::ops::Range::<usize> { start: copy _1, end: copy _2 };
-        StorageLive(_4);
-        _4 = copy _3;
         goto -> bb1;
     }
 
     bb1: {
-        StorageLive(_13);
-        _5 = &mut _4;
-        StorageLive(_10);
-        StorageLive(_6);
-        _6 = &(_4.0: usize);
-        StorageLive(_7);
-        _7 = &(_4.1: usize);
-        StorageLive(_8);
-        _8 = copy (_4.0: usize);
+        StorageLive(_12);
+        _4 = &mut _3;
         StorageLive(_9);
-        _9 = copy (_4.1: usize);
-        _10 = Lt(move _8, move _9);
-        StorageDead(_9);
+        StorageLive(_5);
+        _5 = &(_3.0: usize);
+        StorageLive(_6);
+        _6 = &(_3.1: usize);
+        StorageLive(_7);
+        _7 = copy (_3.0: usize);
+        StorageLive(_8);
+        _8 = copy (_3.1: usize);
+        _9 = Lt(move _7, move _8);
         StorageDead(_8);
-        switchInt(move _10) -> [0: bb2, otherwise: bb3];
+        StorageDead(_7);
+        switchInt(move _9) -> [0: bb2, otherwise: bb3];
     }
 
     bb2: {
-        StorageDead(_7);
         StorageDead(_6);
-        StorageDead(_10);
-        StorageDead(_13);
-        StorageDead(_4);
+        StorageDead(_5);
+        StorageDead(_9);
+        StorageDead(_12);
         return;
     }
 
     bb3: {
-        StorageDead(_7);
         StorageDead(_6);
-        _11 = copy (_4.0: usize);
-        StorageLive(_12);
-        _12 = AddUnchecked(copy _11, const 1_usize);
-        (_4.0: usize) = move _12;
-        StorageDead(_12);
-        _13 = Option::<usize>::Some(copy _11);
-        StorageDead(_10);
-        _14 = copy ((_13 as Some).0: usize);
-        _15 = opaque::<usize>(move _14) -> [return: bb4, unwind continue];
+        StorageDead(_5);
+        _10 = copy (_3.0: usize);
+        StorageLive(_11);
+        _11 = AddUnchecked(copy _10, const 1_usize);
+        (_3.0: usize) = move _11;
+        StorageDead(_11);
+        _12 = Option::<usize>::Some(copy _10);
+        StorageDead(_9);
+        _13 = copy ((_12 as Some).0: usize);
+        _14 = opaque::<usize>(move _13) -> [return: bb4, unwind continue];
     }
 
     bb4: {
-        StorageDead(_13);
+        StorageDead(_12);
         goto -> bb1;
     }
 }

--- a/tests/mir-opt/pre-codegen/loops.mapped.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/loops.mapped.PreCodegen.after.mir
@@ -5,33 +5,32 @@ fn mapped(_1: impl Iterator<Item = T>, _2: impl Fn(T) -> U) -> () {
     debug f => _2;
     let mut _0: ();
     let mut _3: std::iter::Map<impl Iterator<Item = T>, impl Fn(T) -> U>;
-    let mut _4: std::iter::Map<impl Iterator<Item = T>, impl Fn(T) -> U>;
-    let mut _5: &mut std::iter::Map<impl Iterator<Item = T>, impl Fn(T) -> U>;
-    let mut _13: std::option::Option<U>;
-    let _15: ();
+    let mut _4: &mut std::iter::Map<impl Iterator<Item = T>, impl Fn(T) -> U>;
+    let mut _12: std::option::Option<U>;
+    let _14: ();
     scope 1 {
-        debug iter => _4;
-        let _14: U;
+        debug iter => _3;
+        let _13: U;
         scope 2 {
-            debug x => _14;
+            debug x => _13;
         }
         scope 4 (inlined <Map<impl Iterator<Item = T>, impl Fn(T) -> U> as Iterator>::next) {
-            debug self => _5;
-            let mut _6: &mut impl Iterator<Item = T>;
-            let mut _7: std::option::Option<T>;
-            let mut _8: &mut impl Fn(T) -> U;
+            debug self => _4;
+            let mut _5: &mut impl Iterator<Item = T>;
+            let mut _6: std::option::Option<T>;
+            let mut _7: &mut impl Fn(T) -> U;
             scope 5 (inlined Option::<T>::map::<U, &mut impl Fn(T) -> U>) {
-                debug self => _7;
-                debug f => _8;
-                let mut _9: isize;
-                let _10: T;
-                let mut _11: (T,);
-                let mut _12: U;
+                debug self => _6;
+                debug f => _7;
+                let mut _8: isize;
+                let _9: T;
+                let mut _10: (T,);
+                let mut _11: U;
                 scope 6 {
-                    debug x => _10;
+                    debug x => _9;
                     scope 7 (inlined ops::function::impls::<impl FnOnce<(T,)> for &mut impl Fn(T) -> U>::call_once) {
-                        debug self => _8;
-                        debug args => _11;
+                        debug self => _7;
+                        debug args => _10;
                     }
                 }
             }
@@ -46,66 +45,63 @@ fn mapped(_1: impl Iterator<Item = T>, _2: impl Fn(T) -> U) -> () {
     }
 
     bb1: {
-        StorageLive(_4);
-        _4 = copy _3;
         goto -> bb2;
     }
 
     bb2: {
-        StorageLive(_13);
-        _5 = &mut _4;
-        StorageLive(_8);
-        StorageLive(_7);
+        StorageLive(_12);
+        _4 = &mut _3;
         StorageLive(_6);
-        _6 = &mut (_4.0: impl Iterator<Item = T>);
-        _7 = <impl Iterator<Item = T> as Iterator>::next(move _6) -> [return: bb3, unwind: bb10];
+        StorageLive(_5);
+        _5 = &mut (_3.0: impl Iterator<Item = T>);
+        _6 = <impl Iterator<Item = T> as Iterator>::next(move _5) -> [return: bb3, unwind: bb10];
     }
 
     bb3: {
-        StorageDead(_6);
-        _8 = &mut (_4.1: impl Fn(T) -> U);
+        StorageDead(_5);
+        StorageLive(_7);
+        _7 = &mut (_3.1: impl Fn(T) -> U);
+        StorageLive(_8);
         StorageLive(_9);
-        StorageLive(_10);
-        _9 = discriminant(_7);
-        switchInt(move _9) -> [0: bb4, 1: bb6, otherwise: bb9];
+        _8 = discriminant(_6);
+        switchInt(move _8) -> [0: bb4, 1: bb6, otherwise: bb9];
     }
 
     bb4: {
-        StorageDead(_10);
         StorageDead(_9);
-        StorageDead(_7);
         StorageDead(_8);
-        StorageDead(_13);
-        drop(_4) -> [return: bb5, unwind continue];
+        StorageDead(_7);
+        StorageDead(_6);
+        StorageDead(_12);
+        drop(_3) -> [return: bb5, unwind continue];
     }
 
     bb5: {
-        StorageDead(_4);
         return;
     }
 
     bb6: {
-        _10 = move ((_7 as Some).0: T);
-        StorageLive(_12);
+        _9 = move ((_6 as Some).0: T);
         StorageLive(_11);
-        _11 = (copy _10,);
-        _12 = <impl Fn(T) -> U as FnMut<(T,)>>::call_mut(move _8, move _11) -> [return: bb7, unwind: bb10];
+        StorageLive(_10);
+        _10 = (copy _9,);
+        _11 = <impl Fn(T) -> U as FnMut<(T,)>>::call_mut(move _7, move _10) -> [return: bb7, unwind: bb10];
     }
 
     bb7: {
-        StorageDead(_11);
-        _13 = Option::<U>::Some(move _12);
-        StorageDead(_12);
         StorageDead(_10);
+        _12 = Option::<U>::Some(move _11);
+        StorageDead(_11);
         StorageDead(_9);
-        StorageDead(_7);
         StorageDead(_8);
-        _14 = move ((_13 as Some).0: U);
-        _15 = opaque::<U>(move _14) -> [return: bb8, unwind: bb10];
+        StorageDead(_7);
+        StorageDead(_6);
+        _13 = move ((_12 as Some).0: U);
+        _14 = opaque::<U>(move _13) -> [return: bb8, unwind: bb10];
     }
 
     bb8: {
-        StorageDead(_13);
+        StorageDead(_12);
         goto -> bb2;
     }
 
@@ -114,7 +110,7 @@ fn mapped(_1: impl Iterator<Item = T>, _2: impl Fn(T) -> U) -> () {
     }
 
     bb10 (cleanup): {
-        drop(_4) -> [return: bb11, unwind terminate(cleanup)];
+        drop(_3) -> [return: bb11, unwind terminate(cleanup)];
     }
 
     bb11 (cleanup): {

--- a/tests/mir-opt/pre-codegen/loops.vec_move.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/loops.vec_move.PreCodegen.after.mir
@@ -4,59 +4,53 @@ fn vec_move(_1: Vec<impl Sized>) -> () {
     debug v => _1;
     let mut _0: ();
     let mut _2: std::vec::IntoIter<impl Sized>;
-    let mut _3: std::vec::IntoIter<impl Sized>;
-    let mut _4: &mut std::vec::IntoIter<impl Sized>;
-    let mut _5: std::option::Option<impl Sized>;
-    let mut _6: isize;
-    let _8: ();
+    let mut _3: &mut std::vec::IntoIter<impl Sized>;
+    let mut _4: std::option::Option<impl Sized>;
+    let mut _5: isize;
+    let _7: ();
     scope 1 {
-        debug iter => _3;
-        let _7: impl Sized;
+        debug iter => _2;
+        let _6: impl Sized;
         scope 2 {
-            debug x => _7;
+            debug x => _6;
         }
     }
 
     bb0: {
-        StorageLive(_2);
         _2 = <Vec<impl Sized> as IntoIterator>::into_iter(move _1) -> [return: bb1, unwind continue];
     }
 
     bb1: {
-        StorageLive(_3);
-        _3 = move _2;
         goto -> bb2;
     }
 
     bb2: {
-        StorageLive(_5);
-        _4 = &mut _3;
-        _5 = <std::vec::IntoIter<impl Sized> as Iterator>::next(move _4) -> [return: bb3, unwind: bb9];
+        StorageLive(_4);
+        _3 = &mut _2;
+        _4 = <std::vec::IntoIter<impl Sized> as Iterator>::next(move _3) -> [return: bb3, unwind: bb9];
     }
 
     bb3: {
-        _6 = discriminant(_5);
-        switchInt(move _6) -> [0: bb4, 1: bb6, otherwise: bb8];
+        _5 = discriminant(_4);
+        switchInt(move _5) -> [0: bb4, 1: bb6, otherwise: bb8];
     }
 
     bb4: {
-        StorageDead(_5);
-        drop(_3) -> [return: bb5, unwind continue];
+        StorageDead(_4);
+        drop(_2) -> [return: bb5, unwind continue];
     }
 
     bb5: {
-        StorageDead(_3);
-        StorageDead(_2);
         return;
     }
 
     bb6: {
-        _7 = move ((_5 as Some).0: impl Sized);
-        _8 = opaque::<impl Sized>(move _7) -> [return: bb7, unwind: bb9];
+        _6 = move ((_4 as Some).0: impl Sized);
+        _7 = opaque::<impl Sized>(move _6) -> [return: bb7, unwind: bb9];
     }
 
     bb7: {
-        StorageDead(_5);
+        StorageDead(_4);
         goto -> bb2;
     }
 
@@ -65,7 +59,7 @@ fn vec_move(_1: Vec<impl Sized>) -> () {
     }
 
     bb9 (cleanup): {
-        drop(_3) -> [return: bb10, unwind terminate(cleanup)];
+        drop(_2) -> [return: bb10, unwind terminate(cleanup)];
     }
 
     bb10 (cleanup): {

--- a/tests/mir-opt/pre-codegen/range_iter.inclusive_loop.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/range_iter.inclusive_loop.PreCodegen.after.panic-abort.mir
@@ -6,18 +6,17 @@ fn inclusive_loop(_1: u32, _2: u32, _3: impl Fn(u32)) -> () {
     debug f => _3;
     let mut _0: ();
     let mut _4: std::ops::RangeInclusive<u32>;
-    let mut _5: std::ops::RangeInclusive<u32>;
-    let mut _6: &mut std::ops::RangeInclusive<u32>;
-    let mut _7: std::option::Option<u32>;
-    let mut _8: isize;
-    let mut _10: &impl Fn(u32);
-    let mut _11: (u32,);
-    let _12: ();
+    let mut _5: &mut std::ops::RangeInclusive<u32>;
+    let mut _6: std::option::Option<u32>;
+    let mut _7: isize;
+    let mut _9: &impl Fn(u32);
+    let mut _10: (u32,);
+    let _11: ();
     scope 1 {
-        debug iter => _5;
-        let _9: u32;
+        debug iter => _4;
+        let _8: u32;
         scope 2 {
-            debug x => _9;
+            debug x => _8;
         }
         scope 5 (inlined iter::range::<impl Iterator for std::ops::RangeInclusive<u32>>::next) {
         }
@@ -29,25 +28,22 @@ fn inclusive_loop(_1: u32, _2: u32, _3: impl Fn(u32)) -> () {
 
     bb0: {
         _4 = std::ops::RangeInclusive::<u32> { start: copy _1, end: copy _2, exhausted: const false };
-        StorageLive(_5);
-        _5 = copy _4;
         goto -> bb1;
     }
 
     bb1: {
-        StorageLive(_7);
-        _6 = &mut _5;
-        _7 = <std::ops::RangeInclusive<u32> as iter::range::RangeInclusiveIteratorImpl>::spec_next(move _6) -> [return: bb2, unwind unreachable];
+        StorageLive(_6);
+        _5 = &mut _4;
+        _6 = <std::ops::RangeInclusive<u32> as iter::range::RangeInclusiveIteratorImpl>::spec_next(move _5) -> [return: bb2, unwind unreachable];
     }
 
     bb2: {
-        _8 = discriminant(_7);
-        switchInt(move _8) -> [0: bb3, 1: bb5, otherwise: bb7];
+        _7 = discriminant(_6);
+        switchInt(move _7) -> [0: bb3, 1: bb5, otherwise: bb7];
     }
 
     bb3: {
-        StorageDead(_7);
-        StorageDead(_5);
+        StorageDead(_6);
         drop(_3) -> [return: bb4, unwind unreachable];
     }
 
@@ -56,18 +52,18 @@ fn inclusive_loop(_1: u32, _2: u32, _3: impl Fn(u32)) -> () {
     }
 
     bb5: {
-        _9 = copy ((_7 as Some).0: u32);
+        _8 = copy ((_6 as Some).0: u32);
+        StorageLive(_9);
+        _9 = &_3;
         StorageLive(_10);
-        _10 = &_3;
-        StorageLive(_11);
-        _11 = (copy _9,);
-        _12 = <impl Fn(u32) as Fn<(u32,)>>::call(move _10, move _11) -> [return: bb6, unwind unreachable];
+        _10 = (copy _8,);
+        _11 = <impl Fn(u32) as Fn<(u32,)>>::call(move _9, move _10) -> [return: bb6, unwind unreachable];
     }
 
     bb6: {
-        StorageDead(_11);
         StorageDead(_10);
-        StorageDead(_7);
+        StorageDead(_9);
+        StorageDead(_6);
         goto -> bb1;
     }
 

--- a/tests/mir-opt/pre-codegen/range_iter.inclusive_loop.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/range_iter.inclusive_loop.PreCodegen.after.panic-unwind.mir
@@ -6,18 +6,17 @@ fn inclusive_loop(_1: u32, _2: u32, _3: impl Fn(u32)) -> () {
     debug f => _3;
     let mut _0: ();
     let mut _4: std::ops::RangeInclusive<u32>;
-    let mut _5: std::ops::RangeInclusive<u32>;
-    let mut _6: &mut std::ops::RangeInclusive<u32>;
-    let mut _7: std::option::Option<u32>;
-    let mut _8: isize;
-    let mut _10: &impl Fn(u32);
-    let mut _11: (u32,);
-    let _12: ();
+    let mut _5: &mut std::ops::RangeInclusive<u32>;
+    let mut _6: std::option::Option<u32>;
+    let mut _7: isize;
+    let mut _9: &impl Fn(u32);
+    let mut _10: (u32,);
+    let _11: ();
     scope 1 {
-        debug iter => _5;
-        let _9: u32;
+        debug iter => _4;
+        let _8: u32;
         scope 2 {
-            debug x => _9;
+            debug x => _8;
         }
         scope 5 (inlined iter::range::<impl Iterator for std::ops::RangeInclusive<u32>>::next) {
         }
@@ -29,25 +28,22 @@ fn inclusive_loop(_1: u32, _2: u32, _3: impl Fn(u32)) -> () {
 
     bb0: {
         _4 = std::ops::RangeInclusive::<u32> { start: copy _1, end: copy _2, exhausted: const false };
-        StorageLive(_5);
-        _5 = copy _4;
         goto -> bb1;
     }
 
     bb1: {
-        StorageLive(_7);
-        _6 = &mut _5;
-        _7 = <std::ops::RangeInclusive<u32> as iter::range::RangeInclusiveIteratorImpl>::spec_next(move _6) -> [return: bb2, unwind: bb8];
+        StorageLive(_6);
+        _5 = &mut _4;
+        _6 = <std::ops::RangeInclusive<u32> as iter::range::RangeInclusiveIteratorImpl>::spec_next(move _5) -> [return: bb2, unwind: bb8];
     }
 
     bb2: {
-        _8 = discriminant(_7);
-        switchInt(move _8) -> [0: bb3, 1: bb5, otherwise: bb7];
+        _7 = discriminant(_6);
+        switchInt(move _7) -> [0: bb3, 1: bb5, otherwise: bb7];
     }
 
     bb3: {
-        StorageDead(_7);
-        StorageDead(_5);
+        StorageDead(_6);
         drop(_3) -> [return: bb4, unwind continue];
     }
 
@@ -56,18 +52,18 @@ fn inclusive_loop(_1: u32, _2: u32, _3: impl Fn(u32)) -> () {
     }
 
     bb5: {
-        _9 = copy ((_7 as Some).0: u32);
+        _8 = copy ((_6 as Some).0: u32);
+        StorageLive(_9);
+        _9 = &_3;
         StorageLive(_10);
-        _10 = &_3;
-        StorageLive(_11);
-        _11 = (copy _9,);
-        _12 = <impl Fn(u32) as Fn<(u32,)>>::call(move _10, move _11) -> [return: bb6, unwind: bb8];
+        _10 = (copy _8,);
+        _11 = <impl Fn(u32) as Fn<(u32,)>>::call(move _9, move _10) -> [return: bb6, unwind: bb8];
     }
 
     bb6: {
-        StorageDead(_11);
         StorageDead(_10);
-        StorageDead(_7);
+        StorageDead(_9);
+        StorageDead(_6);
         goto -> bb1;
     }
 

--- a/tests/mir-opt/pre-codegen/slice_iter.enumerated_loop.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.enumerated_loop.PreCodegen.after.panic-unwind.mir
@@ -6,20 +6,19 @@ fn enumerated_loop(_1: &[T], _2: impl Fn(usize, &T)) -> () {
     let mut _0: ();
     let mut _10: std::slice::Iter<'_, T>;
     let mut _11: std::iter::Enumerate<std::slice::Iter<'_, T>>;
-    let mut _12: std::iter::Enumerate<std::slice::Iter<'_, T>>;
-    let mut _13: &mut std::iter::Enumerate<std::slice::Iter<'_, T>>;
-    let mut _14: std::option::Option<(usize, &T)>;
-    let mut _15: isize;
-    let mut _18: &impl Fn(usize, &T);
-    let mut _19: (usize, &T);
-    let _20: ();
+    let mut _12: &mut std::iter::Enumerate<std::slice::Iter<'_, T>>;
+    let mut _13: std::option::Option<(usize, &T)>;
+    let mut _14: isize;
+    let mut _17: &impl Fn(usize, &T);
+    let mut _18: (usize, &T);
+    let _19: ();
     scope 1 {
-        debug iter => _12;
-        let _16: usize;
-        let _17: &T;
+        debug iter => _11;
+        let _15: usize;
+        let _16: &T;
         scope 2 {
-            debug i => _16;
-            debug x => _17;
+            debug i => _15;
+            debug x => _16;
         }
     }
     scope 3 (inlined core::slice::<impl [T]>::iter) {
@@ -99,23 +98,20 @@ fn enumerated_loop(_1: &[T], _2: impl Fn(usize, &T)) -> () {
         StorageDead(_3);
         _11 = Enumerate::<std::slice::Iter<'_, T>> { iter: copy _10, count: const 0_usize };
         StorageDead(_10);
-        StorageLive(_12);
-        _12 = copy _11;
         goto -> bb4;
     }
 
     bb4: {
-        _13 = &mut _12;
-        _14 = <Enumerate<std::slice::Iter<'_, T>> as Iterator>::next(move _13) -> [return: bb5, unwind: bb11];
+        _12 = &mut _11;
+        _13 = <Enumerate<std::slice::Iter<'_, T>> as Iterator>::next(move _12) -> [return: bb5, unwind: bb11];
     }
 
     bb5: {
-        _15 = discriminant(_14);
-        switchInt(move _15) -> [0: bb6, 1: bb8, otherwise: bb10];
+        _14 = discriminant(_13);
+        switchInt(move _14) -> [0: bb6, 1: bb8, otherwise: bb10];
     }
 
     bb6: {
-        StorageDead(_12);
         drop(_2) -> [return: bb7, unwind continue];
     }
 
@@ -124,18 +120,18 @@ fn enumerated_loop(_1: &[T], _2: impl Fn(usize, &T)) -> () {
     }
 
     bb8: {
-        _16 = copy (((_14 as Some).0: (usize, &T)).0: usize);
-        _17 = copy (((_14 as Some).0: (usize, &T)).1: &T);
+        _15 = copy (((_13 as Some).0: (usize, &T)).0: usize);
+        _16 = copy (((_13 as Some).0: (usize, &T)).1: &T);
+        StorageLive(_17);
+        _17 = &_2;
         StorageLive(_18);
-        _18 = &_2;
-        StorageLive(_19);
-        _19 = copy ((_14 as Some).0: (usize, &T));
-        _20 = <impl Fn(usize, &T) as Fn<(usize, &T)>>::call(move _18, move _19) -> [return: bb9, unwind: bb11];
+        _18 = copy ((_13 as Some).0: (usize, &T));
+        _19 = <impl Fn(usize, &T) as Fn<(usize, &T)>>::call(move _17, move _18) -> [return: bb9, unwind: bb11];
     }
 
     bb9: {
-        StorageDead(_19);
         StorageDead(_18);
+        StorageDead(_17);
         goto -> bb4;
     }
 

--- a/tests/mir-opt/pre-codegen/slice_iter.reverse_loop.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.reverse_loop.PreCodegen.after.panic-abort.mir
@@ -6,20 +6,19 @@ fn reverse_loop(_1: &[T], _2: impl Fn(&T)) -> () {
     let mut _0: ();
     let mut _10: std::slice::Iter<'_, T>;
     let mut _11: std::iter::Rev<std::slice::Iter<'_, T>>;
-    let mut _12: std::iter::Rev<std::slice::Iter<'_, T>>;
-    let mut _14: std::option::Option<&T>;
-    let mut _15: isize;
-    let mut _17: &impl Fn(&T);
-    let mut _18: (&T,);
-    let _19: ();
+    let mut _13: std::option::Option<&T>;
+    let mut _14: isize;
+    let mut _16: &impl Fn(&T);
+    let mut _17: (&T,);
+    let _18: ();
     scope 1 {
-        debug iter => _12;
-        let _16: &T;
+        debug iter => _11;
+        let _15: &T;
         scope 2 {
-            debug x => _16;
+            debug x => _15;
         }
         scope 18 (inlined <Rev<std::slice::Iter<'_, T>> as Iterator>::next) {
-            let mut _13: &mut std::slice::Iter<'_, T>;
+            let mut _12: &mut std::slice::Iter<'_, T>;
         }
     }
     scope 3 (inlined core::slice::<impl [T]>::iter) {
@@ -99,27 +98,24 @@ fn reverse_loop(_1: &[T], _2: impl Fn(&T)) -> () {
         StorageDead(_3);
         _11 = Rev::<std::slice::Iter<'_, T>> { iter: copy _10 };
         StorageDead(_10);
-        StorageLive(_12);
-        _12 = copy _11;
         goto -> bb4;
     }
 
     bb4: {
-        StorageLive(_14);
         StorageLive(_13);
-        _13 = &mut (_12.0: std::slice::Iter<'_, T>);
-        _14 = <std::slice::Iter<'_, T> as DoubleEndedIterator>::next_back(move _13) -> [return: bb5, unwind unreachable];
+        StorageLive(_12);
+        _12 = &mut (_11.0: std::slice::Iter<'_, T>);
+        _13 = <std::slice::Iter<'_, T> as DoubleEndedIterator>::next_back(move _12) -> [return: bb5, unwind unreachable];
     }
 
     bb5: {
-        StorageDead(_13);
-        _15 = discriminant(_14);
-        switchInt(move _15) -> [0: bb6, 1: bb8, otherwise: bb10];
+        StorageDead(_12);
+        _14 = discriminant(_13);
+        switchInt(move _14) -> [0: bb6, 1: bb8, otherwise: bb10];
     }
 
     bb6: {
-        StorageDead(_14);
-        StorageDead(_12);
+        StorageDead(_13);
         drop(_2) -> [return: bb7, unwind unreachable];
     }
 
@@ -128,18 +124,18 @@ fn reverse_loop(_1: &[T], _2: impl Fn(&T)) -> () {
     }
 
     bb8: {
-        _16 = copy ((_14 as Some).0: &T);
+        _15 = copy ((_13 as Some).0: &T);
+        StorageLive(_16);
+        _16 = &_2;
         StorageLive(_17);
-        _17 = &_2;
-        StorageLive(_18);
-        _18 = (copy _16,);
-        _19 = <impl Fn(&T) as Fn<(&T,)>>::call(move _17, move _18) -> [return: bb9, unwind unreachable];
+        _17 = (copy _15,);
+        _18 = <impl Fn(&T) as Fn<(&T,)>>::call(move _16, move _17) -> [return: bb9, unwind unreachable];
     }
 
     bb9: {
-        StorageDead(_18);
         StorageDead(_17);
-        StorageDead(_14);
+        StorageDead(_16);
+        StorageDead(_13);
         goto -> bb4;
     }
 

--- a/tests/mir-opt/pre-codegen/slice_iter.reverse_loop.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.reverse_loop.PreCodegen.after.panic-unwind.mir
@@ -6,20 +6,19 @@ fn reverse_loop(_1: &[T], _2: impl Fn(&T)) -> () {
     let mut _0: ();
     let mut _10: std::slice::Iter<'_, T>;
     let mut _11: std::iter::Rev<std::slice::Iter<'_, T>>;
-    let mut _12: std::iter::Rev<std::slice::Iter<'_, T>>;
-    let mut _14: std::option::Option<&T>;
-    let mut _15: isize;
-    let mut _17: &impl Fn(&T);
-    let mut _18: (&T,);
-    let _19: ();
+    let mut _13: std::option::Option<&T>;
+    let mut _14: isize;
+    let mut _16: &impl Fn(&T);
+    let mut _17: (&T,);
+    let _18: ();
     scope 1 {
-        debug iter => _12;
-        let _16: &T;
+        debug iter => _11;
+        let _15: &T;
         scope 2 {
-            debug x => _16;
+            debug x => _15;
         }
         scope 18 (inlined <Rev<std::slice::Iter<'_, T>> as Iterator>::next) {
-            let mut _13: &mut std::slice::Iter<'_, T>;
+            let mut _12: &mut std::slice::Iter<'_, T>;
         }
     }
     scope 3 (inlined core::slice::<impl [T]>::iter) {
@@ -99,27 +98,24 @@ fn reverse_loop(_1: &[T], _2: impl Fn(&T)) -> () {
         StorageDead(_3);
         _11 = Rev::<std::slice::Iter<'_, T>> { iter: copy _10 };
         StorageDead(_10);
-        StorageLive(_12);
-        _12 = copy _11;
         goto -> bb4;
     }
 
     bb4: {
-        StorageLive(_14);
         StorageLive(_13);
-        _13 = &mut (_12.0: std::slice::Iter<'_, T>);
-        _14 = <std::slice::Iter<'_, T> as DoubleEndedIterator>::next_back(move _13) -> [return: bb5, unwind: bb11];
+        StorageLive(_12);
+        _12 = &mut (_11.0: std::slice::Iter<'_, T>);
+        _13 = <std::slice::Iter<'_, T> as DoubleEndedIterator>::next_back(move _12) -> [return: bb5, unwind: bb11];
     }
 
     bb5: {
-        StorageDead(_13);
-        _15 = discriminant(_14);
-        switchInt(move _15) -> [0: bb6, 1: bb8, otherwise: bb10];
+        StorageDead(_12);
+        _14 = discriminant(_13);
+        switchInt(move _14) -> [0: bb6, 1: bb8, otherwise: bb10];
     }
 
     bb6: {
-        StorageDead(_14);
-        StorageDead(_12);
+        StorageDead(_13);
         drop(_2) -> [return: bb7, unwind continue];
     }
 
@@ -128,18 +124,18 @@ fn reverse_loop(_1: &[T], _2: impl Fn(&T)) -> () {
     }
 
     bb8: {
-        _16 = copy ((_14 as Some).0: &T);
+        _15 = copy ((_13 as Some).0: &T);
+        StorageLive(_16);
+        _16 = &_2;
         StorageLive(_17);
-        _17 = &_2;
-        StorageLive(_18);
-        _18 = (copy _16,);
-        _19 = <impl Fn(&T) as Fn<(&T,)>>::call(move _17, move _18) -> [return: bb9, unwind: bb11];
+        _17 = (copy _15,);
+        _18 = <impl Fn(&T) as Fn<(&T,)>>::call(move _16, move _17) -> [return: bb9, unwind: bb11];
     }
 
     bb9: {
-        StorageDead(_18);
         StorageDead(_17);
-        StorageDead(_14);
+        StorageDead(_16);
+        StorageDead(_13);
         goto -> bb4;
     }
 


### PR DESCRIPTION
Follow-up to https://github.com/rust-lang/rust/pull/142915

The current implementation of `DestinationPropagation` refuses to consider locals that are borrowed at any point in the MIR.

This PR attempts to relax this requirement without trying to perform alias analysis.

For each local, we consider they are borrowed from the first `Rvalue::Ref` or `Rvalue::RawPtr` statement until they are marked `StorageDead`.

The liveness analysis is modified to consider that:
- an indirect write may write to *any* currently borrowed local;
- an indirect read may read to *any* currently borrowed local;
- a call/tailcall/drop/yield/inlineasm terminator may read and write to *any* currently borrowed local.

Future extensions may consider a `move` to discard borrows, but this requires work on MIR semantics beforehand.

r? @Amanieu 

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
