### PR TITLE
Clarified error note for usize range matching

### DIFF
--- a/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
@@ -1275,13 +1275,13 @@ fn report_non_exhaustive_match<'p, 'tcx>(
             if ty.is_ptr_sized_integral() {
                 if ty.inner() == cx.tcx.types.usize {
                     err.note(format!(
-                        "`{ty}` does not have a fixed maximum value, so half-open ranges are \
-                         necessary to match exhaustively",
+                        "`{ty}::MAX` is not treated as exhaustive, \
+                        so half-open ranges are necessary to match exhaustively",
                     ));
                 } else if ty.inner() == cx.tcx.types.isize {
                     err.note(format!(
-                        "`{ty}` does not have fixed minimum and maximum values, so half-open \
-                         ranges are necessary to match exhaustively",
+                        "`{ty}::MIN` and `{ty}::MAX` are not treated as exhaustive, \
+                        so half-open ranges are necessary to match exhaustively",
                     ));
                 }
             } else if ty.inner() == cx.tcx.types.str_ {

--- a/tests/ui/feature-gates/feature-gate-precise_pointer_size_matching.rs
+++ b/tests/ui/feature-gates/feature-gate-precise_pointer_size_matching.rs
@@ -3,7 +3,7 @@ fn main() {
         //~^ ERROR non-exhaustive patterns: `usize::MAX..` not covered
         //~| NOTE pattern `usize::MAX..` not covered
         //~| NOTE the matched value is of type `usize`
-        //~| NOTE `usize` does not have a fixed maximum value
+        //~| NOTE `usize::MAX` is not treated as exhaustive, so half-open ranges are necessary to match exhaustively
         0..=usize::MAX => {}
     }
 
@@ -11,7 +11,7 @@ fn main() {
         //~^ ERROR non-exhaustive patterns: `..isize::MIN` and `isize::MAX..` not covered
         //~| NOTE patterns `..isize::MIN` and `isize::MAX..` not covered
         //~| NOTE the matched value is of type `isize`
-        //~| NOTE `isize` does not have fixed minimum and maximum values
+        //~| NOTE `isize::MIN` and `isize::MAX` are not treated as exhaustive, so half-open ranges are necessary to match exhaustively
         isize::MIN..=isize::MAX => {}
     }
 }

--- a/tests/ui/feature-gates/feature-gate-precise_pointer_size_matching.stderr
+++ b/tests/ui/feature-gates/feature-gate-precise_pointer_size_matching.stderr
@@ -5,7 +5,7 @@ LL |     match 0usize {
    |           ^^^^^^ pattern `usize::MAX..` not covered
    |
    = note: the matched value is of type `usize`
-   = note: `usize` does not have a fixed maximum value, so half-open ranges are necessary to match exhaustively
+   = note: `usize::MAX` is not treated as exhaustive, so half-open ranges are necessary to match exhaustively
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         0..=usize::MAX => {},
@@ -19,7 +19,7 @@ LL |     match 0isize {
    |           ^^^^^^ patterns `..isize::MIN` and `isize::MAX..` not covered
    |
    = note: the matched value is of type `isize`
-   = note: `isize` does not have fixed minimum and maximum values, so half-open ranges are necessary to match exhaustively
+   = note: `isize::MIN` and `isize::MAX` are not treated as exhaustive, so half-open ranges are necessary to match exhaustively
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
 LL ~         isize::MIN..=isize::MAX => {},

--- a/tests/ui/pattern/usefulness/integer-ranges/pointer-sized-int.deny.stderr
+++ b/tests/ui/pattern/usefulness/integer-ranges/pointer-sized-int.deny.stderr
@@ -5,7 +5,7 @@ LL |     match 0usize {
    |           ^^^^^^ pattern `usize::MAX..` not covered
    |
    = note: the matched value is of type `usize`
-   = note: `usize` does not have a fixed maximum value, so half-open ranges are necessary to match exhaustively
+   = note: `usize::MAX` is not treated as exhaustive, so half-open ranges are necessary to match exhaustively
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         0..=usize::MAX => {},
@@ -19,7 +19,7 @@ LL |     match 0isize {
    |           ^^^^^^ patterns `..isize::MIN` and `isize::MAX..` not covered
    |
    = note: the matched value is of type `isize`
-   = note: `isize` does not have fixed minimum and maximum values, so half-open ranges are necessary to match exhaustively
+   = note: `isize::MIN` and `isize::MAX` are not treated as exhaustive, so half-open ranges are necessary to match exhaustively
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
 LL ~         isize::MIN..=isize::MAX => {},
@@ -33,7 +33,7 @@ LL |     m!(0usize, 0..=usize::MAX);
    |        ^^^^^^ pattern `usize::MAX..` not covered
    |
    = note: the matched value is of type `usize`
-   = note: `usize` does not have a fixed maximum value, so half-open ranges are necessary to match exhaustively
+   = note: `usize::MAX` is not treated as exhaustive, so half-open ranges are necessary to match exhaustively
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL |         match $s { $($t)+ => {}, usize::MAX.. => todo!() }
@@ -46,7 +46,7 @@ LL |     m!(0usize, 0..5 | 5..=usize::MAX);
    |        ^^^^^^ pattern `usize::MAX..` not covered
    |
    = note: the matched value is of type `usize`
-   = note: `usize` does not have a fixed maximum value, so half-open ranges are necessary to match exhaustively
+   = note: `usize::MAX` is not treated as exhaustive, so half-open ranges are necessary to match exhaustively
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL |         match $s { $($t)+ => {}, usize::MAX.. => todo!() }
@@ -59,7 +59,7 @@ LL |     m!(0usize, 0..usize::MAX | usize::MAX);
    |        ^^^^^^ pattern `usize::MAX..` not covered
    |
    = note: the matched value is of type `usize`
-   = note: `usize` does not have a fixed maximum value, so half-open ranges are necessary to match exhaustively
+   = note: `usize::MAX` is not treated as exhaustive, so half-open ranges are necessary to match exhaustively
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL |         match $s { $($t)+ => {}, usize::MAX.. => todo!() }
@@ -72,7 +72,7 @@ LL |     m!((0usize, true), (0..5, true) | (5..=usize::MAX, true) | (0..=usize::
    |        ^^^^^^^^^^^^^^ pattern `(usize::MAX.., _)` not covered
    |
    = note: the matched value is of type `(usize, bool)`
-   = note: `usize` does not have a fixed maximum value, so half-open ranges are necessary to match exhaustively
+   = note: `usize::MAX` is not treated as exhaustive, so half-open ranges are necessary to match exhaustively
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL |         match $s { $($t)+ => {}, (usize::MAX.., _) => todo!() }
@@ -85,7 +85,7 @@ LL |     m!(0isize, isize::MIN..=isize::MAX);
    |        ^^^^^^ patterns `..isize::MIN` and `isize::MAX..` not covered
    |
    = note: the matched value is of type `isize`
-   = note: `isize` does not have fixed minimum and maximum values, so half-open ranges are necessary to match exhaustively
+   = note: `isize::MIN` and `isize::MAX` are not treated as exhaustive, so half-open ranges are necessary to match exhaustively
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
 LL |         match $s { $($t)+ => {}, ..isize::MIN | isize::MAX.. => todo!() }
@@ -98,7 +98,7 @@ LL |     m!(0isize, isize::MIN..5 | 5..=isize::MAX);
    |        ^^^^^^ patterns `..isize::MIN` and `isize::MAX..` not covered
    |
    = note: the matched value is of type `isize`
-   = note: `isize` does not have fixed minimum and maximum values, so half-open ranges are necessary to match exhaustively
+   = note: `isize::MIN` and `isize::MAX` are not treated as exhaustive, so half-open ranges are necessary to match exhaustively
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
 LL |         match $s { $($t)+ => {}, ..isize::MIN | isize::MAX.. => todo!() }
@@ -111,7 +111,7 @@ LL |     m!(0isize, isize::MIN..=-1 | 0 | 1..=isize::MAX);
    |        ^^^^^^ patterns `..isize::MIN` and `isize::MAX..` not covered
    |
    = note: the matched value is of type `isize`
-   = note: `isize` does not have fixed minimum and maximum values, so half-open ranges are necessary to match exhaustively
+   = note: `isize::MIN` and `isize::MAX` are not treated as exhaustive, so half-open ranges are necessary to match exhaustively
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
 LL |         match $s { $($t)+ => {}, ..isize::MIN | isize::MAX.. => todo!() }
@@ -124,7 +124,7 @@ LL |     m!(0isize, isize::MIN..isize::MAX | isize::MAX);
    |        ^^^^^^ patterns `..isize::MIN` and `isize::MAX..` not covered
    |
    = note: the matched value is of type `isize`
-   = note: `isize` does not have fixed minimum and maximum values, so half-open ranges are necessary to match exhaustively
+   = note: `isize::MIN` and `isize::MAX` are not treated as exhaustive, so half-open ranges are necessary to match exhaustively
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
 LL |         match $s { $($t)+ => {}, ..isize::MIN | isize::MAX.. => todo!() }
@@ -137,7 +137,7 @@ LL |         (0isize, true),
    |         ^^^^^^^^^^^^^^ patterns `(..isize::MIN, _)` and `(isize::MAX.., _)` not covered
    |
    = note: the matched value is of type `(isize, bool)`
-   = note: `isize` does not have fixed minimum and maximum values, so half-open ranges are necessary to match exhaustively
+   = note: `isize::MIN` and `isize::MAX` are not treated as exhaustive, so half-open ranges are necessary to match exhaustively
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
 LL |         match $s { $($t)+ => {}, (..isize::MIN, _) | (isize::MAX.., _) => todo!() }

--- a/tests/ui/pattern/usefulness/integer-ranges/precise_pointer_matching-message.rs
+++ b/tests/ui/pattern/usefulness/integer-ranges/precise_pointer_matching-message.rs
@@ -4,7 +4,7 @@ fn main() {
         //~^ ERROR non-exhaustive patterns: `usize::MAX..` not covered
         //~| NOTE pattern `usize::MAX..` not covered
         //~| NOTE the matched value is of type `usize`
-        //~| NOTE `usize` does not have a fixed maximum value
+        //~| NOTE `usize::MAX` is not treated as exhaustive, so half-open ranges are necessary to match exhaustively
         0..=usize::MAX => {}
     }
 
@@ -12,7 +12,7 @@ fn main() {
         //~^ ERROR non-exhaustive patterns: `..isize::MIN` and `isize::MAX..` not covered
         //~| NOTE patterns `..isize::MIN` and `isize::MAX..` not covered
         //~| NOTE the matched value is of type `isize`
-        //~| NOTE `isize` does not have fixed minimum and maximum values
+        //~| NOTE `isize::MIN` and `isize::MAX` are not treated as exhaustive, so half-open ranges are necessary to match exhaustively
         isize::MIN..=isize::MAX => {}
     }
 }

--- a/tests/ui/pattern/usefulness/integer-ranges/precise_pointer_matching-message.stderr
+++ b/tests/ui/pattern/usefulness/integer-ranges/precise_pointer_matching-message.stderr
@@ -5,7 +5,7 @@ LL |     match 0usize {
    |           ^^^^^^ pattern `usize::MAX..` not covered
    |
    = note: the matched value is of type `usize`
-   = note: `usize` does not have a fixed maximum value, so half-open ranges are necessary to match exhaustively
+   = note: `usize::MAX` is not treated as exhaustive, so half-open ranges are necessary to match exhaustively
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         0..=usize::MAX => {},
@@ -19,7 +19,7 @@ LL |     match 0isize {
    |           ^^^^^^ patterns `..isize::MIN` and `isize::MAX..` not covered
    |
    = note: the matched value is of type `isize`
-   = note: `isize` does not have fixed minimum and maximum values, so half-open ranges are necessary to match exhaustively
+   = note: `isize::MIN` and `isize::MAX` are not treated as exhaustive, so half-open ranges are necessary to match exhaustively
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
 LL ~         isize::MIN..=isize::MAX => {},

--- a/tests/ui/pattern/usefulness/issue-85222-types-containing-non-exhaustive-types.stderr
+++ b/tests/ui/pattern/usefulness/issue-85222-types-containing-non-exhaustive-types.stderr
@@ -5,7 +5,7 @@ LL |     match 0 {
    |           ^ pattern `usize::MAX..` not covered
    |
    = note: the matched value is of type `usize`
-   = note: `usize` does not have a fixed maximum value, so half-open ranges are necessary to match exhaustively
+   = note: `usize::MAX` is not treated as exhaustive, so half-open ranges are necessary to match exhaustively
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         1..=usize::MAX => (),
@@ -19,7 +19,7 @@ LL |     match (0usize, 0usize) {
    |           ^^^^^^^^^^^^^^^^ pattern `(usize::MAX.., _)` not covered
    |
    = note: the matched value is of type `(usize, usize)`
-   = note: `usize` does not have a fixed maximum value, so half-open ranges are necessary to match exhaustively
+   = note: `usize::MAX` is not treated as exhaustive, so half-open ranges are necessary to match exhaustively
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         (1..=usize::MAX, 1..=usize::MAX) => (),
@@ -33,7 +33,7 @@ LL |     match (0isize, 0usize) {
    |           ^^^^^^^^^^^^^^^^ patterns `(..isize::MIN, _)` and `(isize::MAX.., _)` not covered
    |
    = note: the matched value is of type `(isize, usize)`
-   = note: `isize` does not have fixed minimum and maximum values, so half-open ranges are necessary to match exhaustively
+   = note: `isize::MIN` and `isize::MAX` are not treated as exhaustive, so half-open ranges are necessary to match exhaustively
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
 LL ~         (isize::MIN..=isize::MAX, 1..=usize::MAX) => (),
@@ -70,7 +70,7 @@ note: `Option<usize>` defined here
    |
    = note: not covered
    = note: the matched value is of type `Option<usize>`
-   = note: `usize` does not have a fixed maximum value, so half-open ranges are necessary to match exhaustively
+   = note: `usize::MAX` is not treated as exhaustive, so half-open ranges are necessary to match exhaustively
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         None => (),
@@ -93,7 +93,7 @@ note: `Option<Option<Option<usize>>>` defined here
    |
    = note: not covered
    = note: the matched value is of type `Option<Option<Option<usize>>>`
-   = note: `usize` does not have a fixed maximum value, so half-open ranges are necessary to match exhaustively
+   = note: `usize::MAX` is not treated as exhaustive, so half-open ranges are necessary to match exhaustively
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         None => (),
@@ -112,7 +112,7 @@ note: `A<usize>` defined here
 LL | struct A<T> {
    |        ^
    = note: the matched value is of type `A<usize>`
-   = note: `usize` does not have a fixed maximum value, so half-open ranges are necessary to match exhaustively
+   = note: `usize::MAX` is not treated as exhaustive, so half-open ranges are necessary to match exhaustively
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         A { a: 1..=usize::MAX } => (),
@@ -131,7 +131,7 @@ note: `B<isize, usize>` defined here
 LL | struct B<T, U>(T, U);
    |        ^
    = note: the matched value is of type `B<isize, usize>`
-   = note: `isize` does not have fixed minimum and maximum values, so half-open ranges are necessary to match exhaustively
+   = note: `isize::MIN` and `isize::MAX` are not treated as exhaustive, so half-open ranges are necessary to match exhaustively
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
 LL ~         B(isize::MIN..=isize::MAX, 1..=usize::MAX) => (),
@@ -150,7 +150,7 @@ note: `B<isize, usize>` defined here
 LL | struct B<T, U>(T, U);
    |        ^
    = note: the matched value is of type `B<isize, usize>`
-   = note: `usize` does not have a fixed maximum value, so half-open ranges are necessary to match exhaustively
+   = note: `usize::MAX` is not treated as exhaustive, so half-open ranges are necessary to match exhaustively
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         B(_, 1..=usize::MAX) => (),


### PR DESCRIPTION
Fixes rust-lang/rust#146476

This is kinda rough, but it gets the point across a little better and stays short.

<!-- homu-ignore:start -->
r? @workingjubilee 
@rustbot label A-diagnostics A-exhaustiveness-checking A-patterns
<!-- homu-ignore:end -->