### PR TITLE
rustc_codegen_llvm: Tidying of `update_target_reliable_float_cfg`

### DIFF
--- a/compiler/rustc_codegen_llvm/src/llvm_util.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm_util.rs
@@ -393,6 +393,8 @@ fn update_target_reliable_float_cfg(sess: &Session, cfg: &mut TargetConfig) {
     };
 
     cfg.has_reliable_f128 = match (target_arch, target_os) {
+        // Unsupported https://github.com/llvm/llvm-project/issues/121122
+        (Arch::AmdGpu, _) => false,
         // Unsupported <https://github.com/llvm/llvm-project/issues/94434>
         (Arch::Arm64EC, _) => false,
         // Selection bug <https://github.com/llvm/llvm-project/issues/96432> (fixed in LLVM 20.1.0)
@@ -400,8 +402,6 @@ fn update_target_reliable_float_cfg(sess: &Session, cfg: &mut TargetConfig) {
         // Selection bug <https://github.com/llvm/llvm-project/issues/95471>. This issue is closed
         // but basic math still does not work.
         (Arch::Nvptx64, _) => false,
-        // Unsupported https://github.com/llvm/llvm-project/issues/121122
-        (Arch::AmdGpu, _) => false,
         // ABI bugs <https://github.com/rust-lang/rust/issues/125109> et al. (full
         // list at <https://github.com/rust-lang/rust/issues/116909>)
         (Arch::PowerPC | Arch::PowerPC64, _) => false,

--- a/compiler/rustc_codegen_llvm/src/llvm_util.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm_util.rs
@@ -364,11 +364,12 @@ fn update_target_reliable_float_cfg(sess: &Session, cfg: &mut TargetConfig) {
     let target_abi = &sess.target.options.abi;
     let target_pointer_width = sess.target.pointer_width;
     let version = get_version();
+    let lt_20_1_0 = version < (20, 1, 0);
     let lt_20_1_1 = version < (20, 1, 1);
     let lt_21_0_0 = version < (21, 0, 0);
 
     cfg.has_reliable_f16 = match (target_arch, target_os) {
-        // LLVM crash without neon <https://github.com/llvm/llvm-project/issues/129394> (fixed in llvm20)
+        // LLVM crash without neon <https://github.com/llvm/llvm-project/issues/129394> (fixed in LLVM 20.1.1)
         (Arch::AArch64, _)
             if !cfg.target_features.iter().any(|f| f.as_str() == "neon") && lt_20_1_1 =>
         {
@@ -395,8 +396,8 @@ fn update_target_reliable_float_cfg(sess: &Session, cfg: &mut TargetConfig) {
     cfg.has_reliable_f128 = match (target_arch, target_os) {
         // Unsupported <https://github.com/llvm/llvm-project/issues/94434>
         (Arch::Arm64EC, _) => false,
-        // Selection bug <https://github.com/llvm/llvm-project/issues/96432> (fixed in llvm20)
-        (Arch::Mips64 | Arch::Mips64r6, _) if lt_20_1_1 => false,
+        // Selection bug <https://github.com/llvm/llvm-project/issues/96432> (fixed in LLVM 20.1.0)
+        (Arch::Mips64 | Arch::Mips64r6, _) if lt_20_1_0 => false,
         // Selection bug <https://github.com/llvm/llvm-project/issues/95471>. This issue is closed
         // but basic math still does not work.
         (Arch::Nvptx64, _) => false,

--- a/compiler/rustc_codegen_llvm/src/llvm_util.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm_util.rs
@@ -364,26 +364,25 @@ fn update_target_reliable_float_cfg(sess: &Session, cfg: &mut TargetConfig) {
     let target_abi = &sess.target.options.abi;
     let target_pointer_width = sess.target.pointer_width;
     let version = get_version();
-    let lt_20_1_0 = version < (20, 1, 0);
-    let lt_20_1_1 = version < (20, 1, 1);
-    let lt_21_0_0 = version < (21, 0, 0);
+    let (major, _, _) = version;
 
     cfg.has_reliable_f16 = match (target_arch, target_os) {
         // LLVM crash without neon <https://github.com/llvm/llvm-project/issues/129394> (fixed in LLVM 20.1.1)
         (Arch::AArch64, _)
-            if !cfg.target_features.iter().any(|f| f.as_str() == "neon") && lt_20_1_1 =>
+            if !cfg.target_features.iter().any(|f| f.as_str() == "neon")
+                && version < (20, 1, 1) =>
         {
             false
         }
         // Unsupported <https://github.com/llvm/llvm-project/issues/94434>
         (Arch::Arm64EC, _) => false,
         // Selection failure <https://github.com/llvm/llvm-project/issues/50374> (fixed in llvm21)
-        (Arch::S390x, _) if lt_21_0_0 => false,
+        (Arch::S390x, _) if major < 21 => false,
         // MinGW ABI bugs <https://gcc.gnu.org/bugzilla/show_bug.cgi?id=115054>
         (Arch::X86_64, Os::Windows) if *target_env == Env::Gnu && *target_abi != Abi::Llvm => false,
         // Infinite recursion <https://github.com/llvm/llvm-project/issues/97981>
         (Arch::CSky, _) => false,
-        (Arch::Hexagon, _) if lt_21_0_0 => false, // (fixed in llvm21)
+        (Arch::Hexagon, _) if major < 21 => false, // (fixed in llvm21)
         (Arch::PowerPC | Arch::PowerPC64, _) => false,
         (Arch::Sparc | Arch::Sparc64, _) => false,
         (Arch::Wasm32 | Arch::Wasm64, _) => false,
@@ -397,7 +396,7 @@ fn update_target_reliable_float_cfg(sess: &Session, cfg: &mut TargetConfig) {
         // Unsupported <https://github.com/llvm/llvm-project/issues/94434>
         (Arch::Arm64EC, _) => false,
         // Selection bug <https://github.com/llvm/llvm-project/issues/96432> (fixed in LLVM 20.1.0)
-        (Arch::Mips64 | Arch::Mips64r6, _) if lt_20_1_0 => false,
+        (Arch::Mips64 | Arch::Mips64r6, _) if version < (20, 1, 0) => false,
         // Selection bug <https://github.com/llvm/llvm-project/issues/95471>. This issue is closed
         // but basic math still does not work.
         (Arch::Nvptx64, _) => false,
@@ -410,7 +409,7 @@ fn update_target_reliable_float_cfg(sess: &Session, cfg: &mut TargetConfig) {
         (Arch::Sparc, _) => false,
         // Stack alignment bug <https://github.com/llvm/llvm-project/issues/77401>. NB: tests may
         // not fail if our compiler-builtins is linked. (fixed in llvm21)
-        (Arch::X86, _) if lt_21_0_0 => false,
+        (Arch::X86, _) if major < 21 => false,
         // MinGW ABI bugs <https://gcc.gnu.org/bugzilla/show_bug.cgi?id=115054>
         (Arch::X86_64, Os::Windows) if *target_env == Env::Gnu && *target_abi != Abi::Llvm => false,
         // There are no known problems on other platforms, so the only requirement is that symbols


### PR DESCRIPTION
This PR simplifies floating type handling through `update_target_reliable_float_cfg` based on several facts:

1.  Major changes in behavior normally occurs only on the major LLVM upgrade.
2.  The first release of LLVM 20.x.x is 20.1.0.

Due to the first fact, we can normally ignore minor and patch releases of LLVM and we can remove obscure variables like `lt_xx_x_x`.
The second fact is missed when the minimum LLVM version is raised to LLVM 20 (cf. rust-lang/rust#145071) and one "fixed in LLVM 20" case can be safely removed (another cannot be removed since it's fixed on LLVM 20.1.1).

It also reorders certain `match` clauses by the architecture when there's no problems reordering it.

Note that, an LLVM issue on MIPS is fixed on LLVM 20.1.**0** and another on AArch64 is fixed on LLVM 20.1.**1**.
Originally, they are both considered fixed on LLVM 20.1.**1** but the author separated them into two cases (so that the MIPS bug checking can be removed).

<!-- homu-ignore:start -->

----

Related: rust-lang/rust#146615 (uses similar method to extract LLVM version)
Related: rust-lang/rust#145071 (follow-up of the minimum LLVM version upgrade to LLVM 20)
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
r? @workingjubilee
<!-- homu-ignore:end -->