### PR TITLE
Improve the pretty print of UnstableFeature clause

### DIFF
--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -3177,8 +3177,7 @@ define_print! {
                 write!(p, "` can be evaluated")?;
             }
             ty::ClauseKind::UnstableFeature(symbol) => {
-                write!(p, "unstable feature: ")?;
-                write!(p, "`{symbol}`")?;
+                write!(p, "feature({symbol}) is enabled")?;
             }
         }
     }

--- a/tests/ui/const-generics/adt_const_params/unsized_field-1.stderr
+++ b/tests/ui/const-generics/adt_const_params/unsized_field-1.stderr
@@ -7,7 +7,7 @@ LL |
 LL | struct A([u8]);
    |          ---- this field does not implement `ConstParamTy_`
    |
-note: the `ConstParamTy_` impl for `[u8]` requires that `unstable feature: `unsized_const_params``
+note: the `ConstParamTy_` impl for `[u8]` requires that `feature(unsized_const_params) is enabled`
   --> $DIR/unsized_field-1.rs:10:10
    |
 LL | struct A([u8]);
@@ -22,7 +22,7 @@ LL |
 LL | struct B(&'static [u8]);
    |          ------------- this field does not implement `ConstParamTy_`
    |
-note: the `ConstParamTy_` impl for `&'static [u8]` requires that `unstable feature: `unsized_const_params``
+note: the `ConstParamTy_` impl for `&'static [u8]` requires that `feature(unsized_const_params) is enabled`
   --> $DIR/unsized_field-1.rs:14:10
    |
 LL | struct B(&'static [u8]);
@@ -37,7 +37,7 @@ LL |
 LL | struct D(unsized_const_param::GenericNotUnsizedParam<&'static [u8]>);
    |          ---------------------------------------------------------- this field does not implement `ConstParamTy_`
    |
-note: the `ConstParamTy_` impl for `GenericNotUnsizedParam<&'static [u8]>` requires that `unstable feature: `unsized_const_params``
+note: the `ConstParamTy_` impl for `GenericNotUnsizedParam<&'static [u8]>` requires that `feature(unsized_const_params) is enabled`
   --> $DIR/unsized_field-1.rs:21:10
    |
 LL | struct D(unsized_const_param::GenericNotUnsizedParam<&'static [u8]>);

--- a/tests/ui/unstable-feature-bound/unstable_impl_coherence.disabled.stderr
+++ b/tests/ui/unstable-feature-bound/unstable_impl_coherence.disabled.stderr
@@ -6,7 +6,7 @@ LL | impl aux::Trait for LocalTy {}
    |
    = note: conflicting implementation in crate `unstable_impl_coherence_aux`:
            - impl<T> Trait for T
-             where unstable feature: `foo`;
+             where feature(foo) is enabled;
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/unstable-feature-bound/unstable_impl_coherence.enabled.stderr
+++ b/tests/ui/unstable-feature-bound/unstable_impl_coherence.enabled.stderr
@@ -6,7 +6,7 @@ LL | impl aux::Trait for LocalTy {}
    |
    = note: conflicting implementation in crate `unstable_impl_coherence_aux`:
            - impl<T> Trait for T
-             where unstable feature: `foo`;
+             where feature(foo) is enabled;
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/unstable-feature-bound/unstable_impl_method_selection.stderr
+++ b/tests/ui/unstable-feature-bound/unstable_impl_method_selection.stderr
@@ -7,7 +7,7 @@ LL |     vec![].foo();
    = note: multiple `impl`s satisfying `Vec<_>: Trait` found in the `unstable_impl_method_selection_aux` crate:
            - impl Trait for Vec<u32>;
            - impl Trait for Vec<u64>
-             where unstable feature: `bar`;
+             where feature(bar) is enabled;
 
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

As per https://github.com/rust-lang/rust/pull/145095#discussion_r2349439492, we could make the diagnostic for unsatisfiable ``UnstableFeature`` clause better.

r? @BoxyUwU 
