### PR TITLE
Ignore tests in `tests/ui/abi` for the GCC backend

### DIFF
--- a/tests/ui/abi/abi-sysv64-arg-passing.rs
+++ b/tests/ui/abi/abi-sysv64-arg-passing.rs
@@ -28,6 +28,7 @@
 //@ ignore-arm
 //@ ignore-aarch64
 //@ ignore-windows
+//@ ignore-backends: gcc
 
 // Windows is ignored because bootstrap doesn't yet know to compile rust_test_helpers with
 // the sysv64 ABI on Windows.

--- a/tests/ui/abi/abi-sysv64-register-usage.rs
+++ b/tests/ui/abi/abi-sysv64-register-usage.rs
@@ -6,6 +6,7 @@
 //@ ignore-arm
 //@ ignore-aarch64
 //@ needs-asm-support
+//@ ignore-backends: gcc
 
 #[cfg(target_arch = "x86_64")]
 pub extern "sysv64" fn all_the_registers(

--- a/tests/ui/abi/issue-28676.rs
+++ b/tests/ui/abi/issue-28676.rs
@@ -1,4 +1,6 @@
 //@ run-pass
+//@ ignore-backends: gcc
+
 #![allow(dead_code)]
 #![allow(improper_ctypes)]
 

--- a/tests/ui/abi/large-byval-align.rs
+++ b/tests/ui/abi/large-byval-align.rs
@@ -1,6 +1,7 @@
 //@ compile-flags: -Copt-level=0
 //@ only-x86_64
 //@ build-pass
+//@ ignore-backends: gcc
 
 #[repr(align(536870912))]
 pub struct A(i64);

--- a/tests/ui/abi/numbers-arithmetic/float-struct.rs
+++ b/tests/ui/abi/numbers-arithmetic/float-struct.rs
@@ -1,4 +1,5 @@
 //@ run-pass
+//@ ignore-backends: gcc
 
 use std::fmt::Debug;
 use std::hint::black_box;

--- a/tests/ui/abi/stack-probes-lto.rs
+++ b/tests/ui/abi/stack-probes-lto.rs
@@ -13,5 +13,6 @@
 //@ ignore-tvos Stack probes are enabled, but the SIGSEGV handler isn't
 //@ ignore-watchos Stack probes are enabled, but the SIGSEGV handler isn't
 //@ ignore-visionos Stack probes are enabled, but the SIGSEGV handler isn't
+//@ ignore-backends: gcc
 
 include!("stack-probes.rs");

--- a/tests/ui/abi/stack-probes.rs
+++ b/tests/ui/abi/stack-probes.rs
@@ -10,6 +10,7 @@
 //@ ignore-tvos Stack probes are enabled, but the SIGSEGV handler isn't
 //@ ignore-watchos Stack probes are enabled, but the SIGSEGV handler isn't
 //@ ignore-visionos Stack probes are enabled, but the SIGSEGV handler isn't
+//@ ignore-backends: gcc
 
 use std::env;
 use std::mem::MaybeUninit;

--- a/tests/ui/abi/stack-protector.rs
+++ b/tests/ui/abi/stack-protector.rs
@@ -4,6 +4,7 @@
 //@ [ssp] compile-flags: -Z stack-protector=all
 //@ compile-flags: -C opt-level=2
 //@ compile-flags: -g
+//@ ignore-backends: gcc
 
 use std::env;
 use std::process::{Command, ExitStatus};

--- a/tests/ui/abi/struct-enums/struct-return.rs
+++ b/tests/ui/abi/struct-enums/struct-return.rs
@@ -1,4 +1,6 @@
 //@ run-pass
+//@ ignore-backends: gcc
+
 #![allow(dead_code)]
 
 #[repr(C)]

--- a/tests/ui/abi/variadic-ffi.rs
+++ b/tests/ui/abi/variadic-ffi.rs
@@ -1,4 +1,6 @@
 //@ run-pass
+//@ ignore-backends: gcc
+
 #![feature(c_variadic)]
 
 use std::ffi::VaList;

--- a/tests/ui/abi/x86stdcall.rs
+++ b/tests/ui/abi/x86stdcall.rs
@@ -1,5 +1,6 @@
 //@ run-pass
 //@ only-windows
+//@ ignore-backends: gcc
 // GetLastError doesn't seem to work with stack switching
 
 #[cfg(windows)]


### PR DESCRIPTION
Needed for https://github.com/rust-lang/rust/pull/146414.

Currently we ignore them in the GCC backend and until this situation changes, it'll block rust-lang/rust#146414.

r? @Kobzol 