### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,8 +31,8 @@ bootstrapping, the compiler architecture, source code representation, and more.
 
 ## [Getting help](https://rustc-dev-guide.rust-lang.org/getting-started.html#asking-questions)
 
-There are many ways you can get help when you're stuck. Rust has many platforms for this:
-[internals], [rust-zulip], and [rust-discord]. It is recommended to ask for help on
+There are many ways you can get help when you're stuck. Rust has two platforms for this:
+[internals] and [rust-zulip]. It is recommended to ask for help on
 the [rust-zulip], but any of these platforms are great ways to seek help and even
 find a mentor! You can learn more about asking questions and getting help in the
 [Asking Questions](https://rustc-dev-guide.rust-lang.org/getting-started.html#asking-questions) chapter of the [rustc-dev-guide].

--- a/compiler/rustc_expand/src/mbe/macro_rules.rs
+++ b/compiler/rustc_expand/src/mbe/macro_rules.rs
@@ -702,7 +702,7 @@ pub fn compile_declarative_macro(
             kinds |= MacroKinds::DERIVE;
             let derive_keyword_span = p.prev_token.span;
             if !features.macro_derive() {
-                feature_err(sess, sym::macro_attr, span, "`macro_rules!` derives are unstable")
+                feature_err(sess, sym::macro_derive, span, "`macro_rules!` derives are unstable")
                     .emit();
             }
             if let Some(guar) = check_no_eof(sess, &p, "expected `()` after `derive`") {

--- a/compiler/rustc_hir_typeck/src/op.rs
+++ b/compiler/rustc_hir_typeck/src/op.rs
@@ -566,7 +566,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     rhs_ty,
                     lhs_expr,
                     lhs_ty,
-                    |lhs_ty, rhs_ty| is_compatible_after_call(lhs_ty, rhs_ty),
+                    is_compatible_after_call,
                 ) {
                     // Cool
                 }
@@ -1170,8 +1170,8 @@ fn deref_ty_if_possible(ty: Ty<'_>) -> Ty<'_> {
     }
 }
 
-/// Returns `true` if this is a built-in arithmetic operation (e.g., u32
-/// + u32, i16x4 == i16x4) and false if these types would have to be
+/// Returns `true` if this is a built-in arithmetic operation (e.g.,
+/// u32 + u32, i16x4 == i16x4) and false if these types would have to be
 /// overloaded to be legal. There are two reasons that we distinguish
 /// builtin operations from overloaded ones (vs trying to drive
 /// everything uniformly through the trait system and intrinsics or
@@ -1191,7 +1191,7 @@ fn is_builtin_binop<'tcx>(lhs: Ty<'tcx>, rhs: Ty<'tcx>, category: BinOpCategory)
     // (See https://github.com/rust-lang/rust/issues/57447.)
     let (lhs, rhs) = (deref_ty_if_possible(lhs), deref_ty_if_possible(rhs));
 
-    match category.into() {
+    match category {
         BinOpCategory::Shortcircuit => true,
         BinOpCategory::Shift => {
             lhs.references_error()

--- a/library/alloc/src/collections/btree/node.rs
+++ b/library/alloc/src/collections/btree/node.rs
@@ -67,6 +67,10 @@ struct LeafNode<K, V> {
 
 impl<K, V> LeafNode<K, V> {
     /// Initializes a new `LeafNode` in-place.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that `this` points to a (possibly uninitialized) `LeafNode`
     unsafe fn init(this: *mut Self) {
         // As a general policy, we leave fields uninitialized if they can be, as this should
         // be both slightly faster and easier to track in Valgrind.
@@ -79,9 +83,11 @@ impl<K, V> LeafNode<K, V> {
 
     /// Creates a new boxed `LeafNode`.
     fn new<A: Allocator + Clone>(alloc: A) -> Box<Self, A> {
+        let mut leaf = Box::new_uninit_in(alloc);
         unsafe {
-            let mut leaf = Box::new_uninit_in(alloc);
+            // SAFETY: `leaf` points to a `LeafNode`
             LeafNode::init(leaf.as_mut_ptr());
+            // SAFETY: `leaf` was just initialized
             leaf.assume_init()
         }
     }

--- a/library/core/src/cmp.rs
+++ b/library/core/src/cmp.rs
@@ -1351,7 +1351,9 @@ pub macro Ord($item:item) {
 #[rustc_diagnostic_item = "PartialOrd"]
 #[allow(multiple_supertrait_upcastable)] // FIXME(sized_hierarchy): remove this
 #[rustc_const_unstable(feature = "const_cmp", issue = "143800")]
-pub const trait PartialOrd<Rhs: PointeeSized = Self>: PartialEq<Rhs> + PointeeSized {
+pub const trait PartialOrd<Rhs: PointeeSized = Self>:
+    [const] PartialEq<Rhs> + PointeeSized
+{
     /// This method returns an ordering between `self` and `other` values if one exists.
     ///
     /// # Examples

--- a/tests/ui/feature-gates/feature-gate-macro-derive.stderr
+++ b/tests/ui/feature-gates/feature-gate-macro-derive.stderr
@@ -4,8 +4,8 @@ error[E0658]: `macro_rules!` derives are unstable
 LL | macro_rules! MyDerive { derive() {} => {} }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: see issue #83527 <https://github.com/rust-lang/rust/issues/83527> for more information
-   = help: add `#![feature(macro_attr)]` to the crate attributes to enable
+   = note: see issue #143549 <https://github.com/rust-lang/rust/issues/143549> for more information
+   = help: add `#![feature(macro_derive)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error

--- a/x
+++ b/x
@@ -15,7 +15,8 @@ realpath() {
     if [ -L "$path" ]; then
         readlink -f "$path"
     elif [ -d "$path" ]; then
-        (cd -P "$path" && pwd)
+        # "cd" is not always silent (e.g. when CDPATH is set), so discard its output.
+        (cd -P "$path" >/dev/null && pwd)
     else
         echo "$(realpath "$(dirname "$path")")/$(basename "$path")"
     fi


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#146690 (add `[const] PartialEq` bound to `PartialOrd`)
 - rust-lang/rust#146776 (fixes for numerous clippy warnings)
 - rust-lang/rust#146777 (fix ./x readdir logic when CDPATH is set)
 - rust-lang/rust#146781 (mbe: Fix feature gate for `macro_derive`)
 - rust-lang/rust#146785 (btree: safety comments for init and new)
 - rust-lang/rust#146788 (chore: removes deprecated discord.)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=146690,146776,146777,146781,146785,146788)
<!-- homu-ignore:end -->