### PR TITLE
Fix using SIMD for basic loop iteration with sufficient capacity

### DIFF
--- a/library/alloc/src/raw_vec/mod.rs
+++ b/library/alloc/src/raw_vec/mod.rs
@@ -334,7 +334,7 @@ impl<T, A: Allocator> RawVec<T, A> {
     /// A specialized version of `self.reserve(len, 1)` which requires the
     /// caller to ensure `len == self.capacity()`.
     #[cfg(not(no_global_oom_handling))]
-    #[inline(never)]
+    #[inline]
     #[track_caller]
     pub(crate) fn grow_one(&mut self) {
         self.inner.grow_one(T::LAYOUT)


### PR DESCRIPTION
~I noticed that this was not inlined when trying to `push` and probably the reason why the compiler lose the information about the capacity (fixes https://github.com/rust-lang/rust/issues/82801) - is there a way I can test that to make sure the issue is fixed?~

The reason is due to LLVM not marking the condition for capacity as dead code, opened an issue:
- https://github.com/llvm/llvm-project/issues/160001.