### PR TITLE
Linker-plugin-based LTO: update list of good combinations (inc. beta + nightly)

### DIFF
--- a/src/doc/rustc/src/linker-plugin-lto.md
+++ b/src/doc/rustc/src/linker-plugin-lto.md
@@ -144,7 +144,7 @@ def minor_version(version):
 INSTALL_TOOLCHAIN = ["rustup", "toolchain", "install", "--profile", "minimal"]
 subprocess.run(INSTALL_TOOLCHAIN + ["nightly"])
 
-LOWER_BOUND = 73
+LOWER_BOUND = 87
 NIGHTLY_VERSION = minor_version(subprocess.run(
     ["rustc", "+nightly", "--version"],
     capture_output=True,
@@ -201,6 +201,9 @@ The following table shows known good combinations of toolchain versions.
 | 1.65 - 1.69  |      15       |
 | 1.70 - 1.72  |      16       |
 | 1.73 - 1.77  |      17       |
-| 1.78         |      18       |
+| 1.78 - 1.81  |      18       |
+| 1.82 - 1.86  |      19       |
+| 1.87 - 1.90  |      20       |
+| 1.91 - 1.92  |      21       |
 
 Note that the compatibility policy for this feature might change in the future.


### PR DESCRIPTION
This PR updates the list of good combinations of Rust toolchains and LLVM releases for linker-plugin-based LTO

Related to first question in https://users.rust-lang.org/t/questions-regarding-linker-plugin-based-lto/134070