### PR TITLE
fix a crash in rustdoc merge finalize without input file

### DIFF
--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -835,8 +835,10 @@ fn main_args(early_dcx: &mut EarlyDiagCtxt, at_args: &[String]) {
         config::InputMode::NoInputMergeFinalize => {
             return wrap_return(
                 dcx,
-                run_merge_finalize(render_options)
-                    .map_err(|e| format!("could not write merged cross-crate info: {e}")),
+                rustc_span::create_session_globals_then(options.edition, &[], None, || {
+                    run_merge_finalize(render_options)
+                        .map_err(|e| format!("could not write merged cross-crate info: {e}"))
+                }),
             );
         }
     };

--- a/tests/run-make/rustdoc-merge-no-input-finalize/rmake.rs
+++ b/tests/run-make/rustdoc-merge-no-input-finalize/rmake.rs
@@ -3,20 +3,26 @@
 
 //@ needs-target-std
 
-use run_make_support::rustdoc;
+use run_make_support::{path, rustdoc};
 
 fn main() {
+    let out_dir = path("out");
+    let merged_dir = path("merged");
+    let parts_out_dir = path("parts");
     rustdoc()
         .input("sierra.rs")
+        .out_dir(&out_dir)
         .arg("-Zunstable-options")
-        .arg("--parts-out-dir=parts")
+        .arg(format!("--parts-out-dir={}", parts_out_dir.display()))
         .arg("--merge=none")
         .run();
 
-    rustdoc()
+    let output = rustdoc()
         .arg("-Zunstable-options")
-        .arg("--include-parts-dir=parts")
+        .out_dir(&out_dir)
+        .arg(format!("--include-parts-dir={}", parts_out_dir.display()))
         .arg("--merge=finalize")
-        .out_dir("out")
         .run();
+
+    output.assert_exit_code(0);
 }

--- a/tests/run-make/rustdoc-merge-no-input-finalize/rmake.rs
+++ b/tests/run-make/rustdoc-merge-no-input-finalize/rmake.rs
@@ -16,6 +16,7 @@ fn main() {
         .arg(format!("--parts-out-dir={}", parts_out_dir.display()))
         .arg("--merge=none")
         .run();
+    assert!(parts_out_dir.join("crate-info").exists());
 
     let output = rustdoc()
         .arg("-Zunstable-options")
@@ -23,6 +24,5 @@ fn main() {
         .arg(format!("--include-parts-dir={}", parts_out_dir.display()))
         .arg("--merge=finalize")
         .run();
-
-    output.assert_exit_code(0);
+    output.assert_stderr_not_contains("error: the compiler unexpectedly panicked. this is a bug.");
 }

--- a/tests/run-make/rustdoc-merge-no-input-finalize/rmake.rs
+++ b/tests/run-make/rustdoc-merge-no-input-finalize/rmake.rs
@@ -1,0 +1,22 @@
+// Running --merge=finalize without an input crate root should not trigger ICE.
+// Issue: https://github.com/rust-lang/rust/issues/146646
+
+//@ needs-target-std
+
+use run_make_support::rustdoc;
+
+fn main() {
+    rustdoc()
+        .input("sierra.rs")
+        .arg("-Zunstable-options")
+        .arg("--parts-out-dir=parts")
+        .arg("--merge=none")
+        .run();
+
+    rustdoc()
+        .arg("-Zunstable-options")
+        .arg("--include-parts-dir=parts")
+        .arg("--merge=finalize")
+        .out_dir("out")
+        .run();
+}

--- a/tests/run-make/rustdoc-merge-no-input-finalize/sierra.rs
+++ b/tests/run-make/rustdoc-merge-no-input-finalize/sierra.rs
@@ -1,0 +1,1 @@
+pub struct Sierra;


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
- Closes rust-lang/rust#146646 

`SerializedSearchIndex::union` calls `Symbol::intern`, requiring `SESSION_GLOBALS` to be set.