### PR TITLE
Stabilise `rotate_left` and `rotate_right` in `[_]` as `const fn` items.

### DIFF
--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -3629,7 +3629,7 @@ impl<T> [T] {
     /// assert_eq!(a, ['a', 'c', 'd', 'e', 'b', 'f']);
     /// ```
     #[stable(feature = "slice_rotate", since = "1.26.0")]
-    #[rustc_const_unstable(feature = "const_slice_rotate", issue = "143812")]
+    #[rustc_const_stable(feature = "const_slice_rotate", since = "CURRENT_RUSTC_VERSION")]
     pub const fn rotate_left(&mut self, mid: usize) {
         assert!(mid <= self.len());
         let k = self.len() - mid;
@@ -3675,7 +3675,7 @@ impl<T> [T] {
     /// assert_eq!(a, ['a', 'e', 'b', 'c', 'd', 'f']);
     /// ```
     #[stable(feature = "slice_rotate", since = "1.26.0")]
-    #[rustc_const_unstable(feature = "const_slice_rotate", issue = "143812")]
+    #[rustc_const_stable(feature = "const_slice_rotate", since = "CURRENT_RUSTC_VERSION")]
     pub const fn rotate_right(&mut self, k: usize) {
         assert!(k <= self.len());
         let mid = self.len() - k;


### PR DESCRIPTION
Tracking issue: rust-lang/rust#143812

Closes: rust-lang/rust#143812

This PR stabilises the `const_slice_rotate` feature:

```rust
impl<T> [T] {
    pub const fn rotate_left(&mut self, mid: usize);

    pub const fn rotate_right(&mut self, k: usize);
}
```

No blockers or unresolved questions. FCP required.

Courtesy of @okaneco.