### PR TITLE
Reduce some uses of `LegacyBang`

### DIFF
--- a/compiler/rustc_expand/src/expand.rs
+++ b/compiler/rustc_expand/src/expand.rs
@@ -971,7 +971,7 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
                             });
                         }
                     },
-                    SyntaxExtensionKind::LegacyBang(..) => {
+                    SyntaxExtensionKind::Bang(..) => {
                         let msg = "expanded a dummy glob delegation";
                         let guar = self.cx.dcx().span_delayed_bug(span, msg);
                         return ExpandResult::Ready(fragment_kind.dummy(span, guar));


### PR DESCRIPTION
- **Switch `dummy_bang` from `LegacyBang` to `Bang`**
- **mbe: Switch dummy extension used for errors from `LegacyBang` to `Bang`**
