### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_attr_parsing/src/context.rs
+++ b/compiler/rustc_attr_parsing/src/context.rs
@@ -40,7 +40,7 @@ use crate::attributes::lint_helpers::{
 };
 use crate::attributes::loop_match::{ConstContinueParser, LoopMatchParser};
 use crate::attributes::macro_attrs::{
-    AllowInternalUnsafeParser, MacroEscapeParser, MacroUseParser,
+    AllowInternalUnsafeParser, MacroEscapeParser, MacroExportParser, MacroUseParser,
 };
 use crate::attributes::must_use::MustUseParser;
 use crate::attributes::no_implicit_prelude::NoImplicitPreludeParser;
@@ -183,6 +183,7 @@ attribute_parsers!(
         Single<LinkOrdinalParser>,
         Single<LinkSectionParser>,
         Single<LinkageParser>,
+        Single<MacroExportParser>,
         Single<MoveSizeLimitParser>,
         Single<MustUseParser>,
         Single<ObjcClassParser>,

--- a/compiler/rustc_attr_parsing/src/lints.rs
+++ b/compiler/rustc_attr_parsing/src/lints.rs
@@ -31,6 +31,18 @@ pub fn emit_attribute_lint<L: LintEmitter>(lint: &AttributeLint<L::Id>, lint_emi
                 },
             );
         }
+        AttributeLintKind::InvalidMacroExportArguments { suggestions } => lint_emitter
+            .emit_node_span_lint(
+                rustc_session::lint::builtin::INVALID_MACRO_EXPORT_ARGUMENTS,
+                *id,
+                *span,
+                session_diagnostics::IllFormedAttributeInput {
+                    num_suggestions: suggestions.len(),
+                    suggestions: DiagArgValue::StrListSepByAnd(
+                        suggestions.into_iter().map(|s| format!("`{s}`").into()).collect(),
+                    ),
+                },
+            ),
         AttributeLintKind::EmptyAttribute { first_span } => lint_emitter.emit_node_span_lint(
             rustc_session::lint::builtin::UNUSED_ATTRIBUTES,
             *id,

--- a/compiler/rustc_expand/src/base.rs
+++ b/compiler/rustc_expand/src/base.rs
@@ -942,9 +942,9 @@ impl SyntaxExtension {
                 .unwrap_or_default();
         let allow_internal_unsafe = find_attr!(attrs, AttributeKind::AllowInternalUnsafe(_));
 
-        let local_inner_macros = ast::attr::find_by_name(attrs, sym::macro_export)
-            .and_then(|macro_export| macro_export.meta_item_list())
-            .is_some_and(|l| ast::attr::list_contains_name(&l, sym::local_inner_macros));
+        let local_inner_macros =
+            *find_attr!(attrs, AttributeKind::MacroExport {local_inner_macros: l, ..} => l)
+                .unwrap_or(&false);
         let collapse_debuginfo = Self::get_collapse_debuginfo(sess, attrs, !is_local);
         tracing::debug!(?name, ?local_inner_macros, ?collapse_debuginfo, ?allow_internal_unsafe);
 

--- a/compiler/rustc_hir/src/attrs/data_structures.rs
+++ b/compiler/rustc_hir/src/attrs/data_structures.rs
@@ -551,6 +551,9 @@ pub enum AttributeKind {
     /// Represents `#[macro_escape]`.
     MacroEscape(Span),
 
+    /// Represents [`#[macro_export]`](https://doc.rust-lang.org/reference/macros-by-example.html#r-macro.decl.scope.path).
+    MacroExport { span: Span, local_inner_macros: bool },
+
     /// Represents `#[rustc_macro_transparency]`.
     MacroTransparency(Transparency),
 

--- a/compiler/rustc_hir/src/attrs/encode_cross_crate.rs
+++ b/compiler/rustc_hir/src/attrs/encode_cross_crate.rs
@@ -56,6 +56,7 @@ impl AttributeKind {
             Linkage(..) => No,
             LoopMatch(..) => No,
             MacroEscape(..) => No,
+            MacroExport { .. } => Yes,
             MacroTransparency(..) => Yes,
             MacroUse { .. } => No,
             Marker(..) => No,

--- a/compiler/rustc_hir/src/lints.rs
+++ b/compiler/rustc_hir/src/lints.rs
@@ -31,9 +31,34 @@ pub struct AttributeLint<Id> {
 
 #[derive(Clone, Debug, HashStable_Generic)]
 pub enum AttributeLintKind {
-    UnusedDuplicate { this: Span, other: Span, warning: bool },
-    IllFormedAttributeInput { suggestions: Vec<String> },
-    EmptyAttribute { first_span: Span },
-    InvalidTarget { name: AttrPath, target: Target, applied: Vec<String>, only: &'static str },
-    InvalidStyle { name: AttrPath, is_used_as_inner: bool, target: Target, target_span: Span },
+    UnusedDuplicate {
+        this: Span,
+        other: Span,
+        warning: bool,
+    },
+    IllFormedAttributeInput {
+        suggestions: Vec<String>,
+    },
+    EmptyAttribute {
+        first_span: Span,
+    },
+
+    /// Copy of `IllFormedAttributeInput`
+    /// specifically for the `invalid_macro_export_arguments` lint until that is removed,
+    /// see <https://github.com/rust-lang/rust/pull/143857#issuecomment-3079175663>
+    InvalidMacroExportArguments {
+        suggestions: Vec<String>,
+    },
+    InvalidTarget {
+        name: AttrPath,
+        target: Target,
+        applied: Vec<String>,
+        only: &'static str,
+    },
+    InvalidStyle {
+        name: AttrPath,
+        is_used_as_inner: bool,
+        target: Target,
+        target_span: Span,
+    },
 }

--- a/compiler/rustc_lint/src/non_local_def.rs
+++ b/compiler/rustc_lint/src/non_local_def.rs
@@ -1,11 +1,12 @@
 use rustc_errors::MultiSpan;
+use rustc_hir::attrs::AttributeKind;
 use rustc_hir::def::{DefKind, Res};
 use rustc_hir::intravisit::{self, Visitor, VisitorExt};
-use rustc_hir::{Body, HirId, Item, ItemKind, Node, Path, TyKind};
+use rustc_hir::{Body, HirId, Item, ItemKind, Node, Path, TyKind, find_attr};
 use rustc_middle::ty::TyCtxt;
 use rustc_session::{declare_lint, impl_lint_pass};
 use rustc_span::def_id::{DefId, LOCAL_CRATE};
-use rustc_span::{ExpnKind, Span, kw, sym};
+use rustc_span::{ExpnKind, Span, kw};
 
 use crate::lints::{NonLocalDefinitionsCargoUpdateNote, NonLocalDefinitionsDiag};
 use crate::{LateContext, LateLintPass, LintContext, fluent_generated as fluent};
@@ -241,7 +242,10 @@ impl<'tcx> LateLintPass<'tcx> for NonLocalDefinitions {
                 )
             }
             ItemKind::Macro(_, _macro, _kinds)
-                if cx.tcx.has_attr(item.owner_id.def_id, sym::macro_export) =>
+                if find_attr!(
+                    cx.tcx.get_all_attrs(item.owner_id.def_id),
+                    AttributeKind::MacroExport { .. }
+                ) =>
             {
                 cx.emit_span_lint(
                     NON_LOCAL_DEFINITIONS,

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -4191,8 +4191,13 @@ declare_lint! {
     /// You can't have multiple arguments in a `#[macro_export(..)]`, or mention arguments other than `local_inner_macros`.
     ///
     pub INVALID_MACRO_EXPORT_ARGUMENTS,
-    Warn,
+    Deny,
     "\"invalid_parameter\" isn't a valid argument for `#[macro_export]`",
+    @future_incompatible = FutureIncompatibleInfo {
+        reason: FutureIncompatibilityReason::FutureReleaseError,
+        reference: "issue #57571 <https://github.com/rust-lang/rust/issues/57571>",
+        report_in_deps: true,
+    };
 }
 
 declare_lint! {

--- a/compiler/rustc_passes/messages.ftl
+++ b/compiler/rustc_passes/messages.ftl
@@ -349,10 +349,6 @@ passes_invalid_attr_at_crate_level =
 passes_invalid_attr_at_crate_level_item =
     the inner attribute doesn't annotate this {$kind}
 
-passes_invalid_macro_export_arguments = invalid `#[macro_export]` argument
-
-passes_invalid_macro_export_arguments_too_many_items = `#[macro_export]` can only take 1 or 0 arguments
-
 passes_lang_item_fn = {$name ->
     [panic_impl] `#[panic_handler]`
     *[other] `{$name}` lang item
@@ -391,9 +387,6 @@ passes_link =
 passes_loop_match_attr =
     `#[loop_match]` should be applied to a loop
     .label = not a loop
-
-passes_macro_export =
-    `#[macro_export]` only has an effect on macro definitions
 
 passes_macro_export_on_decl_macro =
     `#[macro_export]` has no effect on declarative macro definitions

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -38,8 +38,8 @@ use rustc_middle::{bug, span_bug};
 use rustc_session::config::CrateType;
 use rustc_session::lint;
 use rustc_session::lint::builtin::{
-    CONFLICTING_REPR_HINTS, INVALID_DOC_ATTRIBUTES, INVALID_MACRO_EXPORT_ARGUMENTS,
-    MALFORMED_DIAGNOSTIC_ATTRIBUTES, MISPLACED_DIAGNOSTIC_ATTRIBUTES, UNUSED_ATTRIBUTES,
+    CONFLICTING_REPR_HINTS, INVALID_DOC_ATTRIBUTES, MALFORMED_DIAGNOSTIC_ATTRIBUTES,
+    MISPLACED_DIAGNOSTIC_ATTRIBUTES, UNUSED_ATTRIBUTES,
 };
 use rustc_session::parse::feature_err;
 use rustc_span::edition::Edition;
@@ -217,7 +217,10 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                 },
                 Attribute::Parsed(AttributeKind::Link(_, attr_span)) => {
                     self.check_link(hir_id, *attr_span, span, target)
-                }
+                },
+                Attribute::Parsed(AttributeKind::MacroExport { span, .. }) => {
+                    self.check_macro_export(hir_id, *span, target)
+                },
                 Attribute::Parsed(
                     AttributeKind::BodyStability { .. }
                     | AttributeKind::ConstStabilityIndirect
@@ -331,7 +334,6 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                         [sym::rustc_has_incoherent_inherent_impls, ..] => {
                             self.check_has_incoherent_inherent_impls(attr, span, target)
                         }
-                        [sym::macro_export, ..] => self.check_macro_export(hir_id, attr, target),
                         [sym::autodiff_forward, ..] | [sym::autodiff_reverse, ..] => {
                             self.check_autodiff(hir_id, attr, span, target)
                         }
@@ -1850,45 +1852,22 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
         }
     }
 
-    fn check_macro_export(&self, hir_id: HirId, attr: &Attribute, target: Target) {
+    fn check_macro_export(&self, hir_id: HirId, attr_span: Span, target: Target) {
         if target != Target::MacroDef {
+            return;
+        }
+
+        // special case when `#[macro_export]` is applied to a macro 2.0
+        let (_, macro_definition, _) = self.tcx.hir_node(hir_id).expect_item().expect_macro();
+        let is_decl_macro = !macro_definition.macro_rules;
+
+        if is_decl_macro {
             self.tcx.emit_node_span_lint(
                 UNUSED_ATTRIBUTES,
                 hir_id,
-                attr.span(),
-                errors::MacroExport::Normal,
+                attr_span,
+                errors::MacroExport::OnDeclMacro,
             );
-        } else if let Some(meta_item_list) = attr.meta_item_list()
-            && !meta_item_list.is_empty()
-        {
-            if meta_item_list.len() > 1 {
-                self.tcx.emit_node_span_lint(
-                    INVALID_MACRO_EXPORT_ARGUMENTS,
-                    hir_id,
-                    attr.span(),
-                    errors::MacroExport::TooManyItems,
-                );
-            } else if !meta_item_list[0].has_name(sym::local_inner_macros) {
-                self.tcx.emit_node_span_lint(
-                    INVALID_MACRO_EXPORT_ARGUMENTS,
-                    hir_id,
-                    meta_item_list[0].span(),
-                    errors::MacroExport::InvalidArgument,
-                );
-            }
-        } else {
-            // special case when `#[macro_export]` is applied to a macro 2.0
-            let (_, macro_definition, _) = self.tcx.hir_node(hir_id).expect_item().expect_macro();
-            let is_decl_macro = !macro_definition.macro_rules;
-
-            if is_decl_macro {
-                self.tcx.emit_node_span_lint(
-                    UNUSED_ATTRIBUTES,
-                    hir_id,
-                    attr.span(),
-                    errors::MacroExport::OnDeclMacro,
-                );
-            }
         }
     }
 
@@ -2253,7 +2232,9 @@ impl<'tcx> Visitor<'tcx> for CheckAttrVisitor<'tcx> {
         // In the long run, the checks should be harmonized.
         if let ItemKind::Macro(_, macro_def, _) = item.kind {
             let def_id = item.owner_id.to_def_id();
-            if macro_def.macro_rules && !self.tcx.has_attr(def_id, sym::macro_export) {
+            if macro_def.macro_rules
+                && !find_attr!(self.tcx.get_all_attrs(def_id), AttributeKind::MacroExport { .. })
+            {
                 check_non_exported_macro_for_invalid_attrs(self.tcx, item);
             }
         }
@@ -2384,7 +2365,6 @@ fn check_invalid_crate_level_attr(tcx: TyCtxt<'_>, attrs: &[Attribute]) {
     // which were unsuccessfully resolved due to cannot determine
     // resolution for the attribute macro error.
     const ATTRS_TO_CHECK: &[Symbol] = &[
-        sym::macro_export,
         sym::rustc_main,
         sym::derive,
         sym::test,

--- a/compiler/rustc_passes/src/errors.rs
+++ b/compiler/rustc_passes/src/errors.rs
@@ -530,18 +530,9 @@ pub(crate) struct RustcForceInlineCoro {
 
 #[derive(LintDiagnostic)]
 pub(crate) enum MacroExport {
-    #[diag(passes_macro_export)]
-    Normal,
-
     #[diag(passes_macro_export_on_decl_macro)]
     #[note]
     OnDeclMacro,
-
-    #[diag(passes_invalid_macro_export_arguments)]
-    InvalidArgument,
-
-    #[diag(passes_invalid_macro_export_arguments_too_many_items)]
-    TooManyItems,
 }
 
 #[derive(Subdiagnostic)]

--- a/library/coretests/tests/atomic.rs
+++ b/library/coretests/tests/atomic.rs
@@ -12,6 +12,38 @@ fn bool_() {
 }
 
 #[test]
+#[should_panic = "there is no such thing as an acquire store"]
+fn store_illegal_rt_store_acquire_ordering() {
+    let a = AtomicBool::new(false);
+    let ord = Ordering::Acquire;
+    a.store(true, ord);
+}
+
+#[test]
+#[should_panic = "there is no such thing as an acquire-release store"]
+fn store_illegal_rt_store_acq_rel_ordering() {
+    let a = AtomicBool::new(false);
+    let ord = Ordering::AcqRel;
+    a.store(true, ord);
+}
+
+#[test]
+#[should_panic = "there is no such thing as a release load"]
+fn store_illegal_rt_load_release_ordering() {
+    let a = AtomicBool::new(false);
+    let ord = Ordering::Release;
+    a.load(ord);
+}
+
+#[test]
+#[should_panic = "there is no such thing as an acquire-release load"]
+fn store_illegal_rt_load_acq_rel_ordering() {
+    let a = AtomicBool::new(false);
+    let ord = Ordering::AcqRel;
+    a.load(ord);
+}
+
+#[test]
 fn bool_and() {
     let a = AtomicBool::new(true);
     assert_eq!(a.fetch_and(false, SeqCst), true);
@@ -283,23 +315,227 @@ fn atomic_compare_exchange() {
     static ATOMIC: AtomicIsize = AtomicIsize::new(0);
 
     ATOMIC.compare_exchange(0, 1, Relaxed, Relaxed).ok();
+    ATOMIC.compare_exchange(0, 1, Relaxed, Acquire).ok();
+    ATOMIC.compare_exchange(0, 1, Relaxed, SeqCst).ok();
     ATOMIC.compare_exchange(0, 1, Acquire, Relaxed).ok();
-    ATOMIC.compare_exchange(0, 1, Release, Relaxed).ok();
-    ATOMIC.compare_exchange(0, 1, AcqRel, Relaxed).ok();
-    ATOMIC.compare_exchange(0, 1, SeqCst, Relaxed).ok();
     ATOMIC.compare_exchange(0, 1, Acquire, Acquire).ok();
+    ATOMIC.compare_exchange(0, 1, Acquire, SeqCst).ok();
+    ATOMIC.compare_exchange(0, 1, Release, Relaxed).ok();
+    ATOMIC.compare_exchange(0, 1, Release, Acquire).ok();
+    ATOMIC.compare_exchange(0, 1, Release, SeqCst).ok();
+    ATOMIC.compare_exchange(0, 1, AcqRel, Relaxed).ok();
     ATOMIC.compare_exchange(0, 1, AcqRel, Acquire).ok();
+    ATOMIC.compare_exchange(0, 1, AcqRel, SeqCst).ok();
+    ATOMIC.compare_exchange(0, 1, SeqCst, Relaxed).ok();
     ATOMIC.compare_exchange(0, 1, SeqCst, Acquire).ok();
     ATOMIC.compare_exchange(0, 1, SeqCst, SeqCst).ok();
     ATOMIC.compare_exchange_weak(0, 1, Relaxed, Relaxed).ok();
+    ATOMIC.compare_exchange_weak(0, 1, Relaxed, Acquire).ok();
+    ATOMIC.compare_exchange_weak(0, 1, Relaxed, SeqCst).ok();
     ATOMIC.compare_exchange_weak(0, 1, Acquire, Relaxed).ok();
-    ATOMIC.compare_exchange_weak(0, 1, Release, Relaxed).ok();
-    ATOMIC.compare_exchange_weak(0, 1, AcqRel, Relaxed).ok();
-    ATOMIC.compare_exchange_weak(0, 1, SeqCst, Relaxed).ok();
     ATOMIC.compare_exchange_weak(0, 1, Acquire, Acquire).ok();
+    ATOMIC.compare_exchange_weak(0, 1, Acquire, SeqCst).ok();
+    ATOMIC.compare_exchange_weak(0, 1, Release, Relaxed).ok();
+    ATOMIC.compare_exchange_weak(0, 1, Release, Acquire).ok();
+    ATOMIC.compare_exchange_weak(0, 1, Release, SeqCst).ok();
+    ATOMIC.compare_exchange_weak(0, 1, AcqRel, Relaxed).ok();
     ATOMIC.compare_exchange_weak(0, 1, AcqRel, Acquire).ok();
+    ATOMIC.compare_exchange_weak(0, 1, AcqRel, SeqCst).ok();
+    ATOMIC.compare_exchange_weak(0, 1, SeqCst, Relaxed).ok();
     ATOMIC.compare_exchange_weak(0, 1, SeqCst, Acquire).ok();
     ATOMIC.compare_exchange_weak(0, 1, SeqCst, SeqCst).ok();
+}
+
+#[test]
+#[should_panic = "there is no such thing as an acquire-release failure ordering"]
+fn atomic_compare_exchange_illegal_acq_rel() {
+    use Ordering::*;
+
+    static ATOMIC: AtomicIsize = AtomicIsize::new(0);
+
+    let failure = AcqRel;
+
+    ATOMIC.compare_exchange(0, 1, Relaxed, failure).ok();
+}
+
+#[test]
+#[should_panic = "there is no such thing as a release failure ordering"]
+fn atomic_compare_exchange_illegal_release() {
+    use Ordering::*;
+
+    static ATOMIC: AtomicIsize = AtomicIsize::new(0);
+
+    let failure = Release;
+
+    ATOMIC.compare_exchange(0, 1, Relaxed, failure).ok();
+}
+
+#[test]
+#[should_panic = "there is no such thing as an acquire-release failure ordering"]
+fn atomic_compare_exchange_weak_illegal_acq_rel() {
+    use Ordering::*;
+
+    static ATOMIC: AtomicIsize = AtomicIsize::new(0);
+
+    let failure = AcqRel;
+
+    ATOMIC.compare_exchange_weak(0, 1, Relaxed, failure).ok();
+}
+
+#[test]
+#[should_panic = "there is no such thing as a release failure ordering"]
+fn atomic_compare_exchange_weak_illegal_release() {
+    use Ordering::*;
+
+    static ATOMIC: AtomicIsize = AtomicIsize::new(0);
+
+    let failure = Release;
+
+    ATOMIC.compare_exchange_weak(0, 1, Relaxed, failure).ok();
+}
+
+#[test]
+fn atomic_swap() {
+    use Ordering::*;
+
+    static ATOMIC: AtomicBool = AtomicBool::new(false);
+
+    assert_eq!(ATOMIC.swap(true, Relaxed), false);
+    assert_eq!(ATOMIC.swap(false, Acquire), true);
+    assert_eq!(ATOMIC.swap(true, Release), false);
+    assert_eq!(ATOMIC.swap(false, AcqRel), true);
+    assert_eq!(ATOMIC.swap(true, SeqCst), false);
+}
+
+#[test]
+fn atomic_add() {
+    use Ordering::*;
+
+    static ATOMIC: AtomicU8 = AtomicU8::new(0);
+
+    assert_eq!(ATOMIC.fetch_add(1, Relaxed), 0);
+    assert_eq!(ATOMIC.fetch_add(1, Acquire), 1);
+    assert_eq!(ATOMIC.fetch_add(1, Release), 2);
+    assert_eq!(ATOMIC.fetch_add(1, AcqRel), 3);
+    assert_eq!(ATOMIC.fetch_add(1, SeqCst), 4);
+    assert_eq!(ATOMIC.load(Relaxed), 5);
+}
+
+#[test]
+fn atomic_sub() {
+    use Ordering::*;
+
+    static ATOMIC: AtomicU8 = AtomicU8::new(5);
+
+    assert_eq!(ATOMIC.fetch_sub(1, Relaxed), 5);
+    assert_eq!(ATOMIC.fetch_sub(1, Acquire), 4);
+    assert_eq!(ATOMIC.fetch_sub(1, Release), 3);
+    assert_eq!(ATOMIC.fetch_sub(1, AcqRel), 2);
+    assert_eq!(ATOMIC.fetch_sub(1, SeqCst), 1);
+    assert_eq!(ATOMIC.load(Relaxed), 0);
+}
+
+#[test]
+fn atomic_and_or() {
+    use Ordering::*;
+
+    static ATOMIC: AtomicBool = AtomicBool::new(false);
+
+    assert_eq!(ATOMIC.fetch_or(true, Relaxed), false);
+    assert_eq!(ATOMIC.fetch_and(false, Relaxed), true);
+    assert_eq!(ATOMIC.fetch_or(true, Acquire), false);
+    assert_eq!(ATOMIC.fetch_and(false, Acquire), true);
+    assert_eq!(ATOMIC.fetch_or(true, Release), false);
+    assert_eq!(ATOMIC.fetch_and(false, Release), true);
+    assert_eq!(ATOMIC.fetch_or(true, AcqRel), false);
+    assert_eq!(ATOMIC.fetch_and(false, AcqRel), true);
+    assert_eq!(ATOMIC.fetch_or(true, SeqCst), false);
+    assert_eq!(ATOMIC.fetch_and(false, SeqCst), true);
+    assert_eq!(ATOMIC.load(Relaxed), false);
+}
+
+#[test]
+fn atomic_nand() {
+    use Ordering::*;
+
+    static ATOMIC: AtomicU8 = AtomicU8::new(0x13);
+
+    assert_eq!(ATOMIC.fetch_nand(0x13, Relaxed), 0x13);
+    assert_eq!(ATOMIC.fetch_nand(0xec, Acquire), 0xec);
+    assert_eq!(ATOMIC.fetch_nand(0x13, Release), 0x13);
+    assert_eq!(ATOMIC.fetch_nand(0xec, AcqRel), 0xec);
+    assert_eq!(ATOMIC.fetch_nand(0x13, SeqCst), 0x13);
+    assert_eq!(ATOMIC.load(Relaxed), 0xec);
+}
+
+#[test]
+fn atomic_xor() {
+    use Ordering::*;
+
+    static ATOMIC: AtomicBool = AtomicBool::new(false);
+
+    assert_eq!(ATOMIC.fetch_xor(true, Relaxed), false);
+    assert_eq!(ATOMIC.fetch_xor(true, Acquire), true);
+    assert_eq!(ATOMIC.fetch_xor(true, Release), false);
+    assert_eq!(ATOMIC.fetch_xor(true, AcqRel), true);
+    assert_eq!(ATOMIC.fetch_xor(true, SeqCst), false);
+    assert_eq!(ATOMIC.load(Relaxed), true);
+}
+
+#[test]
+fn atomic_max() {
+    use Ordering::*;
+
+    static ATOMIC: AtomicI8 = AtomicI8::new(0);
+
+    assert_eq!(ATOMIC.fetch_max(1, Relaxed), 0);
+    assert_eq!(ATOMIC.fetch_max(2, Acquire), 1);
+    assert_eq!(ATOMIC.fetch_max(3, Release), 2);
+    assert_eq!(ATOMIC.fetch_max(4, AcqRel), 3);
+    assert_eq!(ATOMIC.fetch_max(5, SeqCst), 4);
+    assert_eq!(ATOMIC.load(Relaxed), 5);
+}
+
+#[test]
+fn atomic_umax() {
+    use Ordering::*;
+
+    static ATOMIC: AtomicU8 = AtomicU8::new(0);
+
+    assert_eq!(ATOMIC.fetch_max(1, Relaxed), 0);
+    assert_eq!(ATOMIC.fetch_max(2, Acquire), 1);
+    assert_eq!(ATOMIC.fetch_max(3, Release), 2);
+    assert_eq!(ATOMIC.fetch_max(4, AcqRel), 3);
+    assert_eq!(ATOMIC.fetch_max(5, SeqCst), 4);
+    assert_eq!(ATOMIC.load(Relaxed), 5);
+}
+
+#[test]
+fn atomic_min() {
+    use Ordering::*;
+
+    static ATOMIC: AtomicI8 = AtomicI8::new(5);
+
+    assert_eq!(ATOMIC.fetch_min(4, Relaxed), 5);
+    assert_eq!(ATOMIC.fetch_min(3, Acquire), 4);
+    assert_eq!(ATOMIC.fetch_min(2, Release), 3);
+    assert_eq!(ATOMIC.fetch_min(1, AcqRel), 2);
+    assert_eq!(ATOMIC.fetch_min(0, SeqCst), 1);
+    assert_eq!(ATOMIC.load(Relaxed), 0);
+}
+
+#[test]
+fn atomic_umin() {
+    use Ordering::*;
+
+    static ATOMIC: AtomicU8 = AtomicU8::new(5);
+
+    assert_eq!(ATOMIC.fetch_min(4, Relaxed), 5);
+    assert_eq!(ATOMIC.fetch_min(3, Acquire), 4);
+    assert_eq!(ATOMIC.fetch_min(2, Release), 3);
+    assert_eq!(ATOMIC.fetch_min(1, AcqRel), 2);
+    assert_eq!(ATOMIC.fetch_min(0, SeqCst), 1);
+    assert_eq!(ATOMIC.load(Relaxed), 0);
 }
 
 /* FIXME(#110395)

--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -268,8 +268,8 @@ impl AsInner<imp::Process> for Child {
     }
 }
 
-impl FromInner<(imp::Process, imp::StdioPipes)> for Child {
-    fn from_inner((handle, io): (imp::Process, imp::StdioPipes)) -> Child {
+impl FromInner<(imp::Process, StdioPipes)> for Child {
+    fn from_inner((handle, io): (imp::Process, StdioPipes)) -> Child {
         Child {
             handle,
             stdin: io.stdin.map(ChildStdin::from_inner),
@@ -294,6 +294,15 @@ impl fmt::Debug for Child {
             .field("stderr", &self.stderr)
             .finish_non_exhaustive()
     }
+}
+
+/// The pipes connected to a spawned process.
+///
+/// Used to pass pipe handles between this module and [`imp`].
+pub(crate) struct StdioPipes {
+    pub stdin: Option<AnonPipe>,
+    pub stdout: Option<AnonPipe>,
+    pub stderr: Option<AnonPipe>,
 }
 
 /// A handle to a child process's standard input (stdin).

--- a/library/std/src/sys/process/mod.rs
+++ b/library/std/src/sys/process/mod.rs
@@ -24,7 +24,7 @@ mod env;
 
 pub use env::CommandEnvs;
 pub use imp::{
-    Command, CommandArgs, EnvKey, ExitCode, ExitStatus, ExitStatusError, Process, Stdio, StdioPipes,
+    Command, CommandArgs, EnvKey, ExitCode, ExitStatus, ExitStatusError, Process, Stdio,
 };
 
 #[cfg(any(

--- a/library/std/src/sys/process/uefi.rs
+++ b/library/std/src/sys/process/uefi.rs
@@ -6,6 +6,7 @@ pub use crate::ffi::OsString as EnvKey;
 use crate::ffi::{OsStr, OsString};
 use crate::num::{NonZero, NonZeroI32};
 use crate::path::Path;
+use crate::process::StdioPipes;
 use crate::sys::fs::File;
 use crate::sys::pal::helpers;
 use crate::sys::pal::os::error_string;
@@ -25,14 +26,6 @@ pub struct Command {
     stderr: Option<Stdio>,
     stdin: Option<Stdio>,
     env: CommandEnv,
-}
-
-// passed back to std::process with the pipes connected to the child, if any
-// were requested
-pub struct StdioPipes {
-    pub stdin: Option<AnonPipe>,
-    pub stdout: Option<AnonPipe>,
-    pub stderr: Option<AnonPipe>,
 }
 
 #[derive(Copy, Clone, Debug)]

--- a/library/std/src/sys/process/unix/common.rs
+++ b/library/std/src/sys/process/unix/common.rs
@@ -9,6 +9,7 @@ use crate::collections::BTreeMap;
 use crate::ffi::{CStr, CString, OsStr, OsString};
 use crate::os::unix::prelude::*;
 use crate::path::Path;
+use crate::process::StdioPipes;
 use crate::sys::fd::FileDesc;
 use crate::sys::fs::File;
 #[cfg(not(target_os = "fuchsia"))]
@@ -102,14 +103,6 @@ pub struct Command {
     create_pidfd: bool,
     pgroup: Option<pid_t>,
     setsid: bool,
-}
-
-// passed back to std::process with the pipes connected to the child, if any
-// were requested
-pub struct StdioPipes {
-    pub stdin: Option<AnonPipe>,
-    pub stdout: Option<AnonPipe>,
-    pub stderr: Option<AnonPipe>,
 }
 
 // passed to do_exec() with configuration of what the child stdio should look

--- a/library/std/src/sys/process/unix/fuchsia.rs
+++ b/library/std/src/sys/process/unix/fuchsia.rs
@@ -2,6 +2,7 @@ use libc::{c_int, size_t};
 
 use super::common::*;
 use crate::num::NonZero;
+use crate::process::StdioPipes;
 use crate::sys::pal::fuchsia::*;
 use crate::{fmt, io, mem, ptr};
 

--- a/library/std/src/sys/process/unix/mod.rs
+++ b/library/std/src/sys/process/unix/mod.rs
@@ -23,5 +23,5 @@ cfg_select! {
 
 pub use imp::{ExitStatus, ExitStatusError, Process};
 
-pub use self::common::{Command, CommandArgs, ExitCode, Stdio, StdioPipes};
+pub use self::common::{Command, CommandArgs, ExitCode, Stdio};
 pub use crate::ffi::OsString as EnvKey;

--- a/library/std/src/sys/process/unix/unix.rs
+++ b/library/std/src/sys/process/unix/unix.rs
@@ -13,6 +13,7 @@ use libc::{gid_t, uid_t};
 use super::common::*;
 use crate::io::{self, Error, ErrorKind};
 use crate::num::NonZero;
+use crate::process::StdioPipes;
 use crate::sys::cvt;
 #[cfg(target_os = "linux")]
 use crate::sys::pal::linux::pidfd::PidFd;

--- a/library/std/src/sys/process/unix/unsupported.rs
+++ b/library/std/src/sys/process/unix/unsupported.rs
@@ -3,6 +3,7 @@ use libc::{c_int, pid_t};
 use super::common::*;
 use crate::io;
 use crate::num::NonZero;
+use crate::process::StdioPipes;
 use crate::sys::pal::unsupported::*;
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/library/std/src/sys/process/unix/vxworks.rs
+++ b/library/std/src/sys/process/unix/vxworks.rs
@@ -4,6 +4,7 @@ use libc::{self, RTP_ID, c_char, c_int};
 use super::common::*;
 use crate::io::{self, ErrorKind};
 use crate::num::NonZero;
+use crate::process::StdioPipes;
 use crate::sys::{cvt, thread};
 use crate::{fmt, sys};
 

--- a/library/std/src/sys/process/unsupported.rs
+++ b/library/std/src/sys/process/unsupported.rs
@@ -3,6 +3,7 @@ pub use crate::ffi::OsString as EnvKey;
 use crate::ffi::{OsStr, OsString};
 use crate::num::NonZero;
 use crate::path::Path;
+use crate::process::StdioPipes;
 use crate::sys::fs::File;
 use crate::sys::pipe::AnonPipe;
 use crate::sys::unsupported;
@@ -21,14 +22,6 @@ pub struct Command {
     stdin: Option<Stdio>,
     stdout: Option<Stdio>,
     stderr: Option<Stdio>,
-}
-
-// passed back to std::process with the pipes connected to the child, if any
-// were requested
-pub struct StdioPipes {
-    pub stdin: Option<AnonPipe>,
-    pub stdout: Option<AnonPipe>,
-    pub stderr: Option<AnonPipe>,
 }
 
 #[derive(Debug)]

--- a/library/std/src/sys/process/windows.rs
+++ b/library/std/src/sys/process/windows.rs
@@ -15,6 +15,7 @@ use crate::os::windows::ffi::{OsStrExt, OsStringExt};
 use crate::os::windows::io::{AsHandle, AsRawHandle, BorrowedHandle, FromRawHandle, IntoRawHandle};
 use crate::os::windows::process::ProcThreadAttributeList;
 use crate::path::{Path, PathBuf};
+use crate::process::StdioPipes;
 use crate::sync::Mutex;
 use crate::sys::args::{self, Arg};
 use crate::sys::c::{self, EXIT_FAILURE, EXIT_SUCCESS};
@@ -167,12 +168,6 @@ pub enum Stdio {
     MakePipe,
     Pipe(AnonPipe),
     Handle(Handle),
-}
-
-pub struct StdioPipes {
-    pub stdin: Option<AnonPipe>,
-    pub stdout: Option<AnonPipe>,
-    pub stderr: Option<AnonPipe>,
 }
 
 impl Command {

--- a/src/ci/docker/host-x86_64/x86_64-gnu-tools/checktools.sh
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-tools/checktools.sh
@@ -30,3 +30,10 @@ cat /tmp/toolstate/toolstates.json
 python3 "$X_PY" test --stage 2 check-tools
 python3 "$X_PY" test --stage 2 src/tools/clippy
 python3 "$X_PY" test --stage 2 src/tools/rustfmt
+
+# The below is a regression test for https://github.com/rust-lang/rust/pull/146501#issuecomment-3292608398.
+# The bug caused 0 tests to run. By grepping on that 1 test is run we prevent regressing.
+# Any test can be used. We arbitrarily chose `tests/ui/lint/unused/unused-result.rs`.
+python3 "$X_PY" test tests/ui --test-args tests/ui/lint/unused/unused-result.rs --force-rerun |
+grep --fixed-strings 'test result: ok. 1 passed; 0 failed; 0 ignored;' ||
+( echo "ERROR: --test-args functionality is broken" && exit 1 )

--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -912,12 +912,8 @@ fn maybe_from_hir_attr(
         hir::Attribute::Parsed(kind) => kind,
 
         hir::Attribute::Unparsed(_) => {
-            return Some(if attr.has_name(sym::macro_export) {
-                Attribute::MacroExport
-                // FIXME: We should handle `#[doc(hidden)]`.
-            } else {
-                other_attr(tcx, attr)
-            });
+            // FIXME: We should handle `#[doc(hidden)]`.
+            return Some(other_attr(tcx, attr));
         }
     };
 
@@ -925,6 +921,7 @@ fn maybe_from_hir_attr(
         AK::Deprecation { .. } => return None, // Handled separately into Item::deprecation.
         AK::DocComment { .. } => unreachable!("doc comments stripped out earlier"),
 
+        AK::MacroExport { .. } => Attribute::MacroExport,
         AK::MustUse { reason, span: _ } => {
             Attribute::MustUse { reason: reason.map(|s| s.to_string()) }
         }

--- a/src/librustdoc/passes/strip_hidden.rs
+++ b/src/librustdoc/passes/strip_hidden.rs
@@ -2,9 +2,10 @@
 
 use std::mem;
 
+use rustc_hir::attrs::AttributeKind;
 use rustc_hir::def_id::{CRATE_DEF_ID, LocalDefId};
+use rustc_hir::find_attr;
 use rustc_middle::ty::TyCtxt;
-use rustc_span::symbol::sym;
 use tracing::debug;
 
 use crate::clean::utils::inherits_doc_hidden;
@@ -114,7 +115,7 @@ impl DocFolder for Stripper<'_, '_> {
             // If the macro has the `#[macro_export]` attribute, it means it's accessible at the
             // crate level so it should be handled differently.
             clean::MacroItem(..) => {
-                i.attrs.other_attrs.iter().any(|attr| attr.has_name(sym::macro_export))
+                find_attr!(&i.attrs.other_attrs, AttributeKind::MacroExport { .. })
             }
             _ => false,
         };

--- a/src/tools/clippy/clippy_lints/src/macro_metavars_in_unsafe.rs
+++ b/src/tools/clippy/clippy_lints/src/macro_metavars_in_unsafe.rs
@@ -5,10 +5,12 @@ use itertools::Itertools;
 use rustc_hir::def_id::LocalDefId;
 use rustc_hir::intravisit::{Visitor, walk_block, walk_expr, walk_stmt};
 use rustc_hir::{BlockCheckMode, Expr, ExprKind, HirId, Stmt, UnsafeSource};
+use rustc_hir::attrs::AttributeKind;
+use rustc_hir::find_attr;
 use rustc_lint::{LateContext, LateLintPass, Level, LintContext};
 use rustc_middle::lint::LevelAndSource;
 use rustc_session::impl_lint_pass;
-use rustc_span::{Span, SyntaxContext, sym};
+use rustc_span::{Span, SyntaxContext};
 use std::collections::BTreeMap;
 use std::collections::btree_map::Entry;
 
@@ -146,7 +148,8 @@ struct BodyVisitor<'a, 'tcx> {
 }
 
 fn is_public_macro(cx: &LateContext<'_>, def_id: LocalDefId) -> bool {
-    (cx.effective_visibilities.is_exported(def_id) || cx.tcx.has_attr(def_id, sym::macro_export))
+    ( cx.effective_visibilities.is_exported(def_id) ||
+        find_attr!(cx.tcx.get_all_attrs(def_id), AttributeKind::MacroExport{..}) )
         && !cx.tcx.is_doc_hidden(def_id)
 }
 

--- a/tests/ui/attributes/invalid_macro_export_argument.allow.stderr
+++ b/tests/ui/attributes/invalid_macro_export_argument.allow.stderr
@@ -1,0 +1,40 @@
+Future incompatibility report: Future breakage diagnostic:
+warning: valid forms for the attribute are `#![macro_export(local_inner_macros)]` and `#![macro_export]`
+  --> $DIR/invalid_macro_export_argument.rs:7:1
+   |
+LL | #[macro_export(hello, world)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
+
+Future breakage diagnostic:
+warning: valid forms for the attribute are `#![macro_export(local_inner_macros)]` and `#![macro_export]`
+  --> $DIR/invalid_macro_export_argument.rs:14:1
+   |
+LL | #[macro_export(not_local_inner_macros)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
+
+Future breakage diagnostic:
+warning: valid forms for the attribute are `#![macro_export(local_inner_macros)]` and `#![macro_export]`
+  --> $DIR/invalid_macro_export_argument.rs:31:1
+   |
+LL | #[macro_export()]
+   | ^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
+
+Future breakage diagnostic:
+warning: valid forms for the attribute are `#![macro_export(local_inner_macros)]` and `#![macro_export]`
+  --> $DIR/invalid_macro_export_argument.rs:38:1
+   |
+LL | #[macro_export("blah")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
+

--- a/tests/ui/attributes/invalid_macro_export_argument.deny.stderr
+++ b/tests/ui/attributes/invalid_macro_export_argument.deny.stderr
@@ -1,26 +1,103 @@
-error: `#[macro_export]` can only take 1 or 0 arguments
+error: valid forms for the attribute are `#![macro_export(local_inner_macros)]` and `#![macro_export]`
   --> $DIR/invalid_macro_export_argument.rs:7:1
    |
 LL | #[macro_export(hello, world)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
 note: the lint level is defined here
   --> $DIR/invalid_macro_export_argument.rs:4:24
    |
 LL | #![cfg_attr(deny, deny(invalid_macro_export_arguments))]
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: invalid `#[macro_export]` argument
-  --> $DIR/invalid_macro_export_argument.rs:13:16
+error: valid forms for the attribute are `#![macro_export(local_inner_macros)]` and `#![macro_export]`
+  --> $DIR/invalid_macro_export_argument.rs:14:1
    |
 LL | #[macro_export(not_local_inner_macros)]
-   |                ^^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
 
-error: invalid `#[macro_export]` argument
-  --> $DIR/invalid_macro_export_argument.rs:33:16
+error: valid forms for the attribute are `#![macro_export(local_inner_macros)]` and `#![macro_export]`
+  --> $DIR/invalid_macro_export_argument.rs:31:1
+   |
+LL | #[macro_export()]
+   | ^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
+
+error: valid forms for the attribute are `#![macro_export(local_inner_macros)]` and `#![macro_export]`
+  --> $DIR/invalid_macro_export_argument.rs:38:1
    |
 LL | #[macro_export("blah")]
-   |                ^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
 
-error: aborting due to 3 previous errors
+error: aborting due to 4 previous errors
+
+Future incompatibility report: Future breakage diagnostic:
+error: valid forms for the attribute are `#![macro_export(local_inner_macros)]` and `#![macro_export]`
+  --> $DIR/invalid_macro_export_argument.rs:7:1
+   |
+LL | #[macro_export(hello, world)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
+note: the lint level is defined here
+  --> $DIR/invalid_macro_export_argument.rs:4:24
+   |
+LL | #![cfg_attr(deny, deny(invalid_macro_export_arguments))]
+   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Future breakage diagnostic:
+error: valid forms for the attribute are `#![macro_export(local_inner_macros)]` and `#![macro_export]`
+  --> $DIR/invalid_macro_export_argument.rs:14:1
+   |
+LL | #[macro_export(not_local_inner_macros)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
+note: the lint level is defined here
+  --> $DIR/invalid_macro_export_argument.rs:4:24
+   |
+LL | #![cfg_attr(deny, deny(invalid_macro_export_arguments))]
+   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Future breakage diagnostic:
+error: valid forms for the attribute are `#![macro_export(local_inner_macros)]` and `#![macro_export]`
+  --> $DIR/invalid_macro_export_argument.rs:31:1
+   |
+LL | #[macro_export()]
+   | ^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
+note: the lint level is defined here
+  --> $DIR/invalid_macro_export_argument.rs:4:24
+   |
+LL | #![cfg_attr(deny, deny(invalid_macro_export_arguments))]
+   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Future breakage diagnostic:
+error: valid forms for the attribute are `#![macro_export(local_inner_macros)]` and `#![macro_export]`
+  --> $DIR/invalid_macro_export_argument.rs:38:1
+   |
+LL | #[macro_export("blah")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
+note: the lint level is defined here
+  --> $DIR/invalid_macro_export_argument.rs:4:24
+   |
+LL | #![cfg_attr(deny, deny(invalid_macro_export_arguments))]
+   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/tests/ui/attributes/invalid_macro_export_argument.rs
+++ b/tests/ui/attributes/invalid_macro_export_argument.rs
@@ -5,13 +5,15 @@
 #![cfg_attr(allow, allow(invalid_macro_export_arguments))]
 
 #[macro_export(hello, world)]
-//[deny]~^ ERROR `#[macro_export]` can only take 1 or 0 arguments
+//[deny]~^ ERROR valid forms for the attribute are
+//[deny]~| WARN this was previously accepted
 macro_rules! a {
     () => ()
 }
 
 #[macro_export(not_local_inner_macros)]
-//[deny]~^ ERROR invalid `#[macro_export]` argument
+//[deny]~^ ERROR valid forms for the attribute are
+//[deny]~| WARN this was previously accepted
 macro_rules! b {
     () => ()
 }
@@ -20,18 +22,22 @@ macro_rules! b {
 macro_rules! c {
     () => ()
 }
+
 #[macro_export(local_inner_macros)]
 macro_rules! d {
     () => ()
 }
 
 #[macro_export()]
+//[deny]~^ ERROR valid forms for the attribute are
+//[deny]~| WARN this was previously accepted
 macro_rules! e {
     () => ()
 }
 
 #[macro_export("blah")]
-//[deny]~^ ERROR invalid `#[macro_export]` argument
+//[deny]~^ ERROR valid forms for the attribute are
+//[deny]~| WARN this was previously accepted
 macro_rules! f {
     () => ()
 }

--- a/tests/ui/attributes/malformed-attrs.rs
+++ b/tests/ui/attributes/malformed-attrs.rs
@@ -211,7 +211,7 @@ extern crate wloop;
 //~^ ERROR can't find crate for `wloop` [E0463]
 
 #[macro_export = 18]
-//~^ ERROR malformed `macro_export` attribute input
+//~^ ERROR valid forms for the attribute are
 #[allow_internal_unsafe = 1]
 //~^ ERROR malformed
 //~| ERROR allow_internal_unsafe side-steps the unsafe_code lint

--- a/tests/ui/attributes/malformed-attrs.stderr
+++ b/tests/ui/attributes/malformed-attrs.stderr
@@ -178,22 +178,6 @@ LL | #[no_link()]
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/extern-crates.html#the-no_link-attribute>
 
-error: malformed `macro_export` attribute input
-  --> $DIR/malformed-attrs.rs:213:1
-   |
-LL | #[macro_export = 18]
-   | ^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: for more information, visit <https://doc.rust-lang.org/reference/macros-by-example.html#path-based-scope>
-help: the following are the possible correct uses
-   |
-LL - #[macro_export = 18]
-LL + #[macro_export(local_inner_macros)]
-   |
-LL - #[macro_export = 18]
-LL + #[macro_export]
-   |
-
 error: the `#[proc_macro]` attribute is only usable with crates of the `proc-macro` crate type
   --> $DIR/malformed-attrs.rs:98:1
    |
@@ -724,6 +708,12 @@ error: valid forms for the attribute are `#[macro_use(name1, name2, ...)]` and `
    |
 LL | #[macro_use = 1]
    | ^^^^^^^^^^^^^^^^
+
+error: valid forms for the attribute are `#![macro_export(local_inner_macros)]` and `#![macro_export]`
+  --> $DIR/malformed-attrs.rs:213:1
+   |
+LL | #[macro_export = 18]
+   | ^^^^^^^^^^^^^^^^^^^^
 
 error[E0565]: malformed `allow_internal_unsafe` attribute input
   --> $DIR/malformed-attrs.rs:215:1

--- a/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs-error.rs
+++ b/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs-error.rs
@@ -8,7 +8,7 @@
 
 
 #![macro_export]
-//~^ ERROR: `macro_export` attribute cannot be used at crate level
+//~^ ERROR:  `#[macro_export]` attribute cannot be used on crates
 #![rustc_main]
 //~^ ERROR: `rustc_main` attribute cannot be used at crate level
 //~| ERROR: use of an internal attribute [E0658]
@@ -31,7 +31,6 @@
 //~^ ERROR attribute cannot be used on
 mod inline {
     //~^ NOTE the inner attribute doesn't annotate this module
-    //~| NOTE the inner attribute doesn't annotate this module
     //~| NOTE the inner attribute doesn't annotate this module
 
     mod inner { #![inline] }

--- a/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs-error.stderr
+++ b/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs-error.stderr
@@ -8,6 +8,14 @@ LL | #![rustc_main]
    = note: the `#[rustc_main]` attribute is an internal implementation detail that will never be stable
    = note: the `#[rustc_main]` attribute is used internally to specify test entry point function
 
+error: `#[macro_export]` attribute cannot be used on crates
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:10:1
+   |
+LL | #![macro_export]
+   | ^^^^^^^^^^^^^^^^
+   |
+   = help: `#[macro_export]` can only be applied to macro defs
+
 error: `#[path]` attribute cannot be used on crates
   --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:19:1
    |
@@ -49,7 +57,7 @@ LL | #[inline]
    = help: `#[inline]` can only be applied to functions
 
 error: `#[inline]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:37:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:36:17
    |
 LL |     mod inner { #![inline] }
    |                 ^^^^^^^^^^
@@ -57,7 +65,7 @@ LL |     mod inner { #![inline] }
    = help: `#[inline]` can only be applied to functions
 
 error: `#[inline]` attribute cannot be used on structs
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:46:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:45:5
    |
 LL |     #[inline] struct S;
    |     ^^^^^^^^^
@@ -65,7 +73,7 @@ LL |     #[inline] struct S;
    = help: `#[inline]` can only be applied to functions
 
 error: `#[inline]` attribute cannot be used on type aliases
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:49:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:48:5
    |
 LL |     #[inline] type T = S;
    |     ^^^^^^^^^
@@ -73,7 +81,7 @@ LL |     #[inline] type T = S;
    = help: `#[inline]` can only be applied to functions
 
 error: `#[inline]` attribute cannot be used on inherent impl blocks
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:52:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:51:5
    |
 LL |     #[inline] impl S { }
    |     ^^^^^^^^^
@@ -81,7 +89,7 @@ LL |     #[inline] impl S { }
    = help: `#[inline]` can only be applied to functions
 
 error: `#[export_name]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:82:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:81:1
    |
 LL | #[export_name = "2200"]
    | ^^^^^^^^^^^^^^^^^^^^^^^
@@ -89,7 +97,7 @@ LL | #[export_name = "2200"]
    = help: `#[export_name]` can be applied to functions and statics
 
 error: `#[export_name]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:85:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:84:17
    |
 LL |     mod inner { #![export_name="2200"] }
    |                 ^^^^^^^^^^^^^^^^^^^^^^
@@ -97,7 +105,7 @@ LL |     mod inner { #![export_name="2200"] }
    = help: `#[export_name]` can be applied to functions and statics
 
 error: `#[export_name]` attribute cannot be used on structs
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:90:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:89:5
    |
 LL |     #[export_name = "2200"] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^
@@ -105,7 +113,7 @@ LL |     #[export_name = "2200"] struct S;
    = help: `#[export_name]` can be applied to functions and statics
 
 error: `#[export_name]` attribute cannot be used on type aliases
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:93:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:92:5
    |
 LL |     #[export_name = "2200"] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^
@@ -113,7 +121,7 @@ LL |     #[export_name = "2200"] type T = S;
    = help: `#[export_name]` can be applied to functions and statics
 
 error: `#[export_name]` attribute cannot be used on inherent impl blocks
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:96:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:95:5
    |
 LL |     #[export_name = "2200"] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^
@@ -121,7 +129,7 @@ LL |     #[export_name = "2200"] impl S { }
    = help: `#[export_name]` can be applied to functions and statics
 
 error: `#[export_name]` attribute cannot be used on required trait methods
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:100:9
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:99:9
    |
 LL |         #[export_name = "2200"] fn foo();
    |         ^^^^^^^^^^^^^^^^^^^^^^^
@@ -129,7 +137,7 @@ LL |         #[export_name = "2200"] fn foo();
    = help: `#[export_name]` can be applied to statics, functions, inherent methods, provided trait methods, and trait methods in impl blocks
 
 error: attribute should be applied to an `extern crate` item
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:56:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:55:1
    |
 LL |   #[no_link]
    |   ^^^^^^^^^^
@@ -143,7 +151,7 @@ LL | | }
    | |_- not an `extern crate` item
 
 error[E0517]: attribute should be applied to a struct, enum, or union
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:107:8
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:106:8
    |
 LL |   #[repr(C)]
    |          ^
@@ -156,7 +164,7 @@ LL | | }
    | |_- not a struct, enum, or union
 
 error[E0517]: attribute should be applied to a struct, enum, or union
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:131:8
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:130:8
    |
 LL |   #[repr(Rust)]
    |          ^^^^
@@ -173,21 +181,6 @@ error: attribute should be applied to an `extern crate` item
    |
 LL | #![no_link]
    | ^^^^^^^^^^^ not an `extern crate` item
-
-error: `macro_export` attribute cannot be used at crate level
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:10:1
-   |
-LL | #![macro_export]
-   | ^^^^^^^^^^^^^^^^
-...
-LL | mod inline {
-   |     ------ the inner attribute doesn't annotate this module
-   |
-help: perhaps you meant to use an outer attribute
-   |
-LL - #![macro_export]
-LL + #[macro_export]
-   |
 
 error: `rustc_main` attribute cannot be used at crate level
   --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:12:1
@@ -220,85 +213,85 @@ LL + #[repr()]
    |
 
 error: attribute should be applied to an `extern crate` item
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:61:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:60:17
    |
 LL |     mod inner { #![no_link] }
    |     ------------^^^^^^^^^^^-- not an `extern crate` item
 
 error: attribute should be applied to an `extern crate` item
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:65:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:64:5
    |
 LL |     #[no_link] fn f() { }
    |     ^^^^^^^^^^ ---------- not an `extern crate` item
 
 error: attribute should be applied to an `extern crate` item
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:69:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:68:5
    |
 LL |     #[no_link] struct S;
    |     ^^^^^^^^^^ --------- not an `extern crate` item
 
 error: attribute should be applied to an `extern crate` item
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:73:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:72:5
    |
 LL |     #[no_link]type T = S;
    |     ^^^^^^^^^^----------- not an `extern crate` item
 
 error: attribute should be applied to an `extern crate` item
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:77:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:76:5
    |
 LL |     #[no_link] impl S { }
    |     ^^^^^^^^^^ ---------- not an `extern crate` item
 
 error[E0517]: attribute should be applied to a struct, enum, or union
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:111:25
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:110:25
    |
 LL |     mod inner { #![repr(C)] }
    |     --------------------^---- not a struct, enum, or union
 
 error[E0517]: attribute should be applied to a struct, enum, or union
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:115:12
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:114:12
    |
 LL |     #[repr(C)] fn f() { }
    |            ^   ---------- not a struct, enum, or union
 
 error[E0517]: attribute should be applied to a struct, enum, or union
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:121:12
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:120:12
    |
 LL |     #[repr(C)] type T = S;
    |            ^   ----------- not a struct, enum, or union
 
 error[E0517]: attribute should be applied to a struct, enum, or union
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:125:12
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:124:12
    |
 LL |     #[repr(C)] impl S { }
    |            ^   ---------- not a struct, enum, or union
 
 error[E0517]: attribute should be applied to a struct, enum, or union
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:135:25
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:134:25
    |
 LL |     mod inner { #![repr(Rust)] }
    |     --------------------^^^^---- not a struct, enum, or union
 
 error[E0517]: attribute should be applied to a struct, enum, or union
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:139:12
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:138:12
    |
 LL |     #[repr(Rust)] fn f() { }
    |            ^^^^   ---------- not a struct, enum, or union
 
 error[E0517]: attribute should be applied to a struct, enum, or union
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:145:12
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:144:12
    |
 LL |     #[repr(Rust)] type T = S;
    |            ^^^^   ----------- not a struct, enum, or union
 
 error[E0517]: attribute should be applied to a struct, enum, or union
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:149:12
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:148:12
    |
 LL |     #[repr(Rust)] impl S { }
    |            ^^^^   ---------- not a struct, enum, or union
 
 error: valid forms for the attribute are `#[inline(always)]`, `#[inline(never)]`, and `#[inline]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:40:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:39:5
    |
 LL |     #[inline = "2100"] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^
@@ -313,7 +306,7 @@ Some errors have detailed explanations: E0517, E0658.
 For more information about an error, try `rustc --explain E0517`.
 Future incompatibility report: Future breakage diagnostic:
 error: valid forms for the attribute are `#[inline(always)]`, `#[inline(never)]`, and `#[inline]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:40:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:39:5
    |
 LL |     #[inline = "2100"] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^

--- a/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs.rs
+++ b/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs.rs
@@ -214,22 +214,40 @@ mod macro_use {
 }
 
 #[macro_export]
-//~^ WARN `#[macro_export]` only has an effect on macro definitions
+//~^ WARN `#[macro_export]` attribute cannot be used on modules [unused_attributes]
+//~| WARN previously accepted
+//~| HELP can only be applied to
+//~| HELP remove the attribute
 mod macro_export {
     mod inner { #![macro_export] }
-    //~^ WARN `#[macro_export]` only has an effect on macro definitions
+    //~^ WARN `#[macro_export]` attribute cannot be used on modules
+    //~| WARN previously accepted
+    //~| HELP can only be applied to
+    //~| HELP remove the attribute
 
     #[macro_export] fn f() { }
-    //~^ WARN `#[macro_export]` only has an effect on macro definitions
+    //~^ WARN `#[macro_export]` attribute cannot be used on function
+    //~| WARN previously accepted
+    //~| HELP can only be applied to
+    //~| HELP remove the attribute
 
     #[macro_export] struct S;
-    //~^ WARN `#[macro_export]` only has an effect on macro definitions
+    //~^ WARN `#[macro_export]` attribute cannot be used on structs
+    //~| WARN previously accepted
+    //~| HELP can only be applied to
+    //~| HELP remove the attribute
 
     #[macro_export] type T = S;
-    //~^ WARN `#[macro_export]` only has an effect on macro definitions
+    //~^ WARN `#[macro_export]` attribute cannot be used on type aliases
+    //~| WARN previously accepted
+    //~| HELP can only be applied to
+    //~| HELP remove the attribute
 
     #[macro_export] impl S { }
-    //~^ WARN `#[macro_export]` only has an effect on macro definitions
+    //~^ WARN  `#[macro_export]` attribute cannot be used on inherent impl blocks
+    //~| WARN previously accepted
+    //~| HELP can only be applied to
+    //~| HELP remove the attribute
 }
 
 // At time of unit test authorship, if compiling without `--test` then

--- a/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs.stderr
+++ b/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs.stderr
@@ -1,5 +1,5 @@
 warning: `#[macro_escape]` is a deprecated synonym for `#[macro_use]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:511:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:529:17
    |
 LL |     mod inner { #![macro_escape] }
    |                 ^^^^^^^^^^^^^^^^
@@ -7,7 +7,7 @@ LL |     mod inner { #![macro_escape] }
    = help: try an outer attribute: `#[macro_use]`
 
 warning: `#[macro_escape]` is a deprecated synonym for `#[macro_use]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:508:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:526:1
    |
 LL | #[macro_escape]
    | ^^^^^^^^^^^^^^^
@@ -186,31 +186,24 @@ warning: unknown lint: `x5100`
 LL |     #[deny(x5100)] impl S { }
    |            ^^^^^
 
-warning: `#[macro_export]` only has an effect on macro definitions
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:216:1
+warning: crate-level attribute should be an inner attribute
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:501:1
    |
-LL | #[macro_export]
-   | ^^^^^^^^^^^^^^^
+LL | #[reexport_test_harness_main = "2900"]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: the lint level is defined here
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:37:9
    |
 LL | #![warn(unused_attributes, unknown_lints)]
    |         ^^^^^^^^^^^^^^^^^
-
-warning: crate-level attribute should be an inner attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:483:1
-   |
-LL | #[reexport_test_harness_main = "2900"]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
 help: add a `!`
    |
 LL | #![reexport_test_harness_main = "2900"]
    |  +
 
 warning: attribute should be applied to an `extern` block with non-Rust ABI
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:695:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:713:1
    |
 LL |   #[link(name = "x")]
    |   ^^^^^^^^^^^^^^^^^^^
@@ -226,7 +219,7 @@ LL | | }
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: crate-level attribute should be an inner attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:771:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:789:1
    |
 LL | #[windows_subsystem = "windows"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -237,7 +230,7 @@ LL | #![windows_subsystem = "windows"]
    |  +
 
 warning: crate-level attribute should be an inner attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:821:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:839:1
    |
 LL | #[crate_type = "0800"]
    | ^^^^^^^^^^^^^^^^^^^^^^
@@ -248,7 +241,7 @@ LL | #![crate_type = "0800"]
    |  +
 
 warning: crate-level attribute should be an inner attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:845:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:863:1
    |
 LL | #[feature(x0600)]
    | ^^^^^^^^^^^^^^^^^
@@ -259,7 +252,7 @@ LL | #![feature(x0600)]
    |  +
 
 warning: crate-level attribute should be an inner attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:870:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:888:1
    |
 LL | #[no_main]
    | ^^^^^^^^^^
@@ -270,7 +263,7 @@ LL | #![no_main]
    |  +
 
 warning: crate-level attribute should be an inner attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:894:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:912:1
    |
 LL | #[no_builtins]
    | ^^^^^^^^^^^^^^
@@ -296,44 +289,14 @@ LL | #![feature(rust1)]
    |
    = note: `#[warn(stable_features)]` on by default
 
-warning: `#[macro_export]` only has an effect on macro definitions
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:219:17
-   |
-LL |     mod inner { #![macro_export] }
-   |                 ^^^^^^^^^^^^^^^^
-
-warning: `#[macro_export]` only has an effect on macro definitions
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:222:5
-   |
-LL |     #[macro_export] fn f() { }
-   |     ^^^^^^^^^^^^^^^
-
-warning: `#[macro_export]` only has an effect on macro definitions
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:225:5
-   |
-LL |     #[macro_export] struct S;
-   |     ^^^^^^^^^^^^^^^
-
-warning: `#[macro_export]` only has an effect on macro definitions
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:228:5
-   |
-LL |     #[macro_export] type T = S;
-   |     ^^^^^^^^^^^^^^^
-
-warning: `#[macro_export]` only has an effect on macro definitions
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:231:5
-   |
-LL |     #[macro_export] impl S { }
-   |     ^^^^^^^^^^^^^^^
-
 warning: crate-level attribute should be in the root module
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:487:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:505:17
    |
 LL |     mod inner { #![reexport_test_harness_main="2900"] }
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:490:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:508:5
    |
 LL |     #[reexport_test_harness_main = "2900"] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -344,7 +307,7 @@ LL |     #![reexport_test_harness_main = "2900"] fn f() { }
    |      +
 
 warning: crate-level attribute should be an inner attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:494:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:512:5
    |
 LL |     #[reexport_test_harness_main = "2900"] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -355,7 +318,7 @@ LL |     #![reexport_test_harness_main = "2900"] struct S;
    |      +
 
 warning: crate-level attribute should be an inner attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:498:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:516:5
    |
 LL |     #[reexport_test_harness_main = "2900"] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -366,7 +329,7 @@ LL |     #![reexport_test_harness_main = "2900"] type T = S;
    |      +
 
 warning: crate-level attribute should be an inner attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:502:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:520:5
    |
 LL |     #[reexport_test_harness_main = "2900"] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -377,7 +340,7 @@ LL |     #![reexport_test_harness_main = "2900"] impl S { }
    |      +
 
 warning: attribute should be applied to an `extern` block with non-Rust ABI
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:701:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:719:17
    |
 LL |     mod inner { #![link(name = "x")] }
    |     ------------^^^^^^^^^^^^^^^^^^^^-- not an `extern` block
@@ -385,7 +348,7 @@ LL |     mod inner { #![link(name = "x")] }
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: attribute should be applied to an `extern` block with non-Rust ABI
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:706:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:724:5
    |
 LL |     #[link(name = "x")] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^^ ---------- not an `extern` block
@@ -393,7 +356,7 @@ LL |     #[link(name = "x")] fn f() { }
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: attribute should be applied to an `extern` block with non-Rust ABI
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:711:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:729:5
    |
 LL |     #[link(name = "x")] struct S;
    |     ^^^^^^^^^^^^^^^^^^^ --------- not an `extern` block
@@ -401,7 +364,7 @@ LL |     #[link(name = "x")] struct S;
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: attribute should be applied to an `extern` block with non-Rust ABI
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:716:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:734:5
    |
 LL |     #[link(name = "x")] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^ ----------- not an `extern` block
@@ -409,7 +372,7 @@ LL |     #[link(name = "x")] type T = S;
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: attribute should be applied to an `extern` block with non-Rust ABI
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:721:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:739:5
    |
 LL |     #[link(name = "x")] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^ ---------- not an `extern` block
@@ -417,7 +380,7 @@ LL |     #[link(name = "x")] impl S { }
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: attribute should be applied to an `extern` block with non-Rust ABI
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:726:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:744:5
    |
 LL |     #[link(name = "x")] extern "Rust" {}
    |     ^^^^^^^^^^^^^^^^^^^
@@ -425,13 +388,13 @@ LL |     #[link(name = "x")] extern "Rust" {}
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: crate-level attribute should be in the root module
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:775:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:793:17
    |
 LL |     mod inner { #![windows_subsystem="windows"] }
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:778:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:796:5
    |
 LL |     #[windows_subsystem = "windows"] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -442,7 +405,7 @@ LL |     #![windows_subsystem = "windows"] fn f() { }
    |      +
 
 warning: crate-level attribute should be an inner attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:782:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:800:5
    |
 LL |     #[windows_subsystem = "windows"] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -453,7 +416,7 @@ LL |     #![windows_subsystem = "windows"] struct S;
    |      +
 
 warning: crate-level attribute should be an inner attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:786:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:804:5
    |
 LL |     #[windows_subsystem = "windows"] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -464,7 +427,7 @@ LL |     #![windows_subsystem = "windows"] type T = S;
    |      +
 
 warning: crate-level attribute should be an inner attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:790:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:808:5
    |
 LL |     #[windows_subsystem = "windows"] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -475,13 +438,13 @@ LL |     #![windows_subsystem = "windows"] impl S { }
    |      +
 
 warning: crate-level attribute should be in the root module
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:825:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:843:17
    |
 LL |     mod inner { #![crate_type="0800"] }
    |                 ^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:828:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:846:5
    |
 LL |     #[crate_type = "0800"] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^^^^^
@@ -492,7 +455,7 @@ LL |     #![crate_type = "0800"] fn f() { }
    |      +
 
 warning: crate-level attribute should be an inner attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:832:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:850:5
    |
 LL |     #[crate_type = "0800"] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^^
@@ -503,7 +466,7 @@ LL |     #![crate_type = "0800"] struct S;
    |      +
 
 warning: crate-level attribute should be an inner attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:836:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:854:5
    |
 LL |     #[crate_type = "0800"] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^^^^
@@ -514,7 +477,7 @@ LL |     #![crate_type = "0800"] type T = S;
    |      +
 
 warning: crate-level attribute should be an inner attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:840:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:858:5
    |
 LL |     #[crate_type = "0800"] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^^
@@ -525,13 +488,13 @@ LL |     #![crate_type = "0800"] impl S { }
    |      +
 
 warning: crate-level attribute should be in the root module
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:849:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:867:17
    |
 LL |     mod inner { #![feature(x0600)] }
    |                 ^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:852:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:870:5
    |
 LL |     #[feature(x0600)] fn f() { }
    |     ^^^^^^^^^^^^^^^^^
@@ -542,7 +505,7 @@ LL |     #![feature(x0600)] fn f() { }
    |      +
 
 warning: crate-level attribute should be an inner attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:856:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:874:5
    |
 LL |     #[feature(x0600)] struct S;
    |     ^^^^^^^^^^^^^^^^^
@@ -553,7 +516,7 @@ LL |     #![feature(x0600)] struct S;
    |      +
 
 warning: crate-level attribute should be an inner attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:860:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:878:5
    |
 LL |     #[feature(x0600)] type T = S;
    |     ^^^^^^^^^^^^^^^^^
@@ -564,7 +527,7 @@ LL |     #![feature(x0600)] type T = S;
    |      +
 
 warning: crate-level attribute should be an inner attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:864:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:882:5
    |
 LL |     #[feature(x0600)] impl S { }
    |     ^^^^^^^^^^^^^^^^^
@@ -575,13 +538,13 @@ LL |     #![feature(x0600)] impl S { }
    |      +
 
 warning: crate-level attribute should be in the root module
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:874:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:892:17
    |
 LL |     mod inner { #![no_main] }
    |                 ^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:877:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:895:5
    |
 LL |     #[no_main] fn f() { }
    |     ^^^^^^^^^^
@@ -592,7 +555,7 @@ LL |     #![no_main] fn f() { }
    |      +
 
 warning: crate-level attribute should be an inner attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:881:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:899:5
    |
 LL |     #[no_main] struct S;
    |     ^^^^^^^^^^
@@ -603,7 +566,7 @@ LL |     #![no_main] struct S;
    |      +
 
 warning: crate-level attribute should be an inner attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:885:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:903:5
    |
 LL |     #[no_main] type T = S;
    |     ^^^^^^^^^^
@@ -614,7 +577,7 @@ LL |     #![no_main] type T = S;
    |      +
 
 warning: crate-level attribute should be an inner attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:889:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:907:5
    |
 LL |     #[no_main] impl S { }
    |     ^^^^^^^^^^
@@ -625,13 +588,13 @@ LL |     #![no_main] impl S { }
    |      +
 
 warning: crate-level attribute should be in the root module
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:898:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:916:17
    |
 LL |     mod inner { #![no_builtins] }
    |                 ^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:901:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:919:5
    |
 LL |     #[no_builtins] fn f() { }
    |     ^^^^^^^^^^^^^^
@@ -642,7 +605,7 @@ LL |     #![no_builtins] fn f() { }
    |      +
 
 warning: crate-level attribute should be an inner attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:905:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:923:5
    |
 LL |     #[no_builtins] struct S;
    |     ^^^^^^^^^^^^^^
@@ -653,7 +616,7 @@ LL |     #![no_builtins] struct S;
    |      +
 
 warning: crate-level attribute should be an inner attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:909:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:927:5
    |
 LL |     #[no_builtins] type T = S;
    |     ^^^^^^^^^^^^^^
@@ -664,7 +627,7 @@ LL |     #![no_builtins] type T = S;
    |      +
 
 warning: crate-level attribute should be an inner attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:913:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:931:5
    |
 LL |     #[no_builtins] impl S { }
    |     ^^^^^^^^^^^^^^
@@ -710,8 +673,62 @@ LL |     #[macro_use] impl S { }
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = help: `#[macro_use]` can be applied to modules, extern crates, and crates
 
+warning: `#[macro_export]` attribute cannot be used on modules
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:216:1
+   |
+LL | #[macro_export]
+   | ^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = help: `#[macro_export]` can only be applied to macro defs
+
+warning: `#[macro_export]` attribute cannot be used on modules
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:222:17
+   |
+LL |     mod inner { #![macro_export] }
+   |                 ^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = help: `#[macro_export]` can only be applied to macro defs
+
+warning: `#[macro_export]` attribute cannot be used on functions
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:228:5
+   |
+LL |     #[macro_export] fn f() { }
+   |     ^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = help: `#[macro_export]` can only be applied to macro defs
+
+warning: `#[macro_export]` attribute cannot be used on structs
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:234:5
+   |
+LL |     #[macro_export] struct S;
+   |     ^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = help: `#[macro_export]` can only be applied to macro defs
+
+warning: `#[macro_export]` attribute cannot be used on type aliases
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:240:5
+   |
+LL |     #[macro_export] type T = S;
+   |     ^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = help: `#[macro_export]` can only be applied to macro defs
+
+warning: `#[macro_export]` attribute cannot be used on inherent impl blocks
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:246:5
+   |
+LL |     #[macro_export] impl S { }
+   |     ^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = help: `#[macro_export]` can only be applied to macro defs
+
 warning: `#[path]` attribute cannot be used on functions
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:271:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:289:5
    |
 LL |     #[path = "3800"] fn f() { }
    |     ^^^^^^^^^^^^^^^^
@@ -720,7 +737,7 @@ LL |     #[path = "3800"] fn f() { }
    = help: `#[path]` can only be applied to modules
 
 warning: `#[path]` attribute cannot be used on structs
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:277:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:295:5
    |
 LL |     #[path = "3800"]  struct S;
    |     ^^^^^^^^^^^^^^^^
@@ -729,7 +746,7 @@ LL |     #[path = "3800"]  struct S;
    = help: `#[path]` can only be applied to modules
 
 warning: `#[path]` attribute cannot be used on type aliases
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:283:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:301:5
    |
 LL |     #[path = "3800"] type T = S;
    |     ^^^^^^^^^^^^^^^^
@@ -738,7 +755,7 @@ LL |     #[path = "3800"] type T = S;
    = help: `#[path]` can only be applied to modules
 
 warning: `#[path]` attribute cannot be used on inherent impl blocks
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:289:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:307:5
    |
 LL |     #[path = "3800"] impl S { }
    |     ^^^^^^^^^^^^^^^^
@@ -747,7 +764,7 @@ LL |     #[path = "3800"] impl S { }
    = help: `#[path]` can only be applied to modules
 
 warning: `#[automatically_derived]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:296:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:314:1
    |
 LL | #[automatically_derived]
    | ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -756,7 +773,7 @@ LL | #[automatically_derived]
    = help: `#[automatically_derived]` can only be applied to trait impl blocks
 
 warning: `#[automatically_derived]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:302:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:320:17
    |
 LL |     mod inner { #![automatically_derived] }
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -765,7 +782,7 @@ LL |     mod inner { #![automatically_derived] }
    = help: `#[automatically_derived]` can only be applied to trait impl blocks
 
 warning: `#[automatically_derived]` attribute cannot be used on functions
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:308:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:326:5
    |
 LL |     #[automatically_derived] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -774,7 +791,7 @@ LL |     #[automatically_derived] fn f() { }
    = help: `#[automatically_derived]` can only be applied to trait impl blocks
 
 warning: `#[automatically_derived]` attribute cannot be used on structs
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:314:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:332:5
    |
 LL |     #[automatically_derived] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -783,7 +800,7 @@ LL |     #[automatically_derived] struct S;
    = help: `#[automatically_derived]` can only be applied to trait impl blocks
 
 warning: `#[automatically_derived]` attribute cannot be used on type aliases
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:320:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:338:5
    |
 LL |     #[automatically_derived] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -792,7 +809,7 @@ LL |     #[automatically_derived] type T = S;
    = help: `#[automatically_derived]` can only be applied to trait impl blocks
 
 warning: `#[automatically_derived]` attribute cannot be used on traits
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:326:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:344:5
    |
 LL |     #[automatically_derived] trait W { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -801,7 +818,7 @@ LL |     #[automatically_derived] trait W { }
    = help: `#[automatically_derived]` can only be applied to trait impl blocks
 
 warning: `#[automatically_derived]` attribute cannot be used on inherent impl blocks
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:332:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:350:5
    |
 LL |     #[automatically_derived] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -810,7 +827,7 @@ LL |     #[automatically_derived] impl S { }
    = help: `#[automatically_derived]` can only be applied to trait impl blocks
 
 warning: `#[no_mangle]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:341:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:359:1
    |
 LL | #[no_mangle]
    | ^^^^^^^^^^^^
@@ -819,7 +836,7 @@ LL | #[no_mangle]
    = help: `#[no_mangle]` can be applied to functions and statics
 
 warning: `#[no_mangle]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:347:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:365:17
    |
 LL |     mod inner { #![no_mangle] }
    |                 ^^^^^^^^^^^^^
@@ -828,7 +845,7 @@ LL |     mod inner { #![no_mangle] }
    = help: `#[no_mangle]` can be applied to functions and statics
 
 warning: `#[no_mangle]` attribute cannot be used on structs
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:355:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:373:5
    |
 LL |     #[no_mangle] struct S;
    |     ^^^^^^^^^^^^
@@ -837,7 +854,7 @@ LL |     #[no_mangle] struct S;
    = help: `#[no_mangle]` can be applied to functions and statics
 
 warning: `#[no_mangle]` attribute cannot be used on type aliases
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:361:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:379:5
    |
 LL |     #[no_mangle] type T = S;
    |     ^^^^^^^^^^^^
@@ -846,7 +863,7 @@ LL |     #[no_mangle] type T = S;
    = help: `#[no_mangle]` can be applied to functions and statics
 
 warning: `#[no_mangle]` attribute cannot be used on inherent impl blocks
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:367:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:385:5
    |
 LL |     #[no_mangle] impl S { }
    |     ^^^^^^^^^^^^
@@ -855,7 +872,7 @@ LL |     #[no_mangle] impl S { }
    = help: `#[no_mangle]` can be applied to functions and statics
 
 warning: `#[no_mangle]` attribute cannot be used on required trait methods
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:374:9
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:392:9
    |
 LL |         #[no_mangle] fn foo();
    |         ^^^^^^^^^^^^
@@ -864,7 +881,7 @@ LL |         #[no_mangle] fn foo();
    = help: `#[no_mangle]` can be applied to functions, statics, inherent methods, and trait methods in impl blocks
 
 warning: `#[no_mangle]` attribute cannot be used on provided trait methods
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:380:9
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:398:9
    |
 LL |         #[no_mangle] fn bar() {}
    |         ^^^^^^^^^^^^
@@ -873,7 +890,7 @@ LL |         #[no_mangle] fn bar() {}
    = help: `#[no_mangle]` can be applied to functions, statics, inherent methods, and trait methods in impl blocks
 
 warning: `#[should_panic]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:388:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:406:1
    |
 LL | #[should_panic]
    | ^^^^^^^^^^^^^^^
@@ -882,7 +899,7 @@ LL | #[should_panic]
    = help: `#[should_panic]` can only be applied to functions
 
 warning: `#[should_panic]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:394:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:412:17
    |
 LL |     mod inner { #![should_panic] }
    |                 ^^^^^^^^^^^^^^^^
@@ -891,7 +908,7 @@ LL |     mod inner { #![should_panic] }
    = help: `#[should_panic]` can only be applied to functions
 
 warning: `#[should_panic]` attribute cannot be used on structs
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:402:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:420:5
    |
 LL |     #[should_panic] struct S;
    |     ^^^^^^^^^^^^^^^
@@ -900,7 +917,7 @@ LL |     #[should_panic] struct S;
    = help: `#[should_panic]` can only be applied to functions
 
 warning: `#[should_panic]` attribute cannot be used on type aliases
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:408:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:426:5
    |
 LL |     #[should_panic] type T = S;
    |     ^^^^^^^^^^^^^^^
@@ -909,7 +926,7 @@ LL |     #[should_panic] type T = S;
    = help: `#[should_panic]` can only be applied to functions
 
 warning: `#[should_panic]` attribute cannot be used on inherent impl blocks
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:414:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:432:5
    |
 LL |     #[should_panic] impl S { }
    |     ^^^^^^^^^^^^^^^
@@ -918,7 +935,7 @@ LL |     #[should_panic] impl S { }
    = help: `#[should_panic]` can only be applied to functions
 
 warning: `#[ignore]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:421:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:439:1
    |
 LL | #[ignore]
    | ^^^^^^^^^
@@ -927,7 +944,7 @@ LL | #[ignore]
    = help: `#[ignore]` can only be applied to functions
 
 warning: `#[ignore]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:427:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:445:17
    |
 LL |     mod inner { #![ignore] }
    |                 ^^^^^^^^^^
@@ -936,7 +953,7 @@ LL |     mod inner { #![ignore] }
    = help: `#[ignore]` can only be applied to functions
 
 warning: `#[ignore]` attribute cannot be used on structs
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:435:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:453:5
    |
 LL |     #[ignore] struct S;
    |     ^^^^^^^^^
@@ -945,7 +962,7 @@ LL |     #[ignore] struct S;
    = help: `#[ignore]` can only be applied to functions
 
 warning: `#[ignore]` attribute cannot be used on type aliases
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:441:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:459:5
    |
 LL |     #[ignore] type T = S;
    |     ^^^^^^^^^
@@ -954,7 +971,7 @@ LL |     #[ignore] type T = S;
    = help: `#[ignore]` can only be applied to functions
 
 warning: `#[ignore]` attribute cannot be used on inherent impl blocks
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:447:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:465:5
    |
 LL |     #[ignore] impl S { }
    |     ^^^^^^^^^
@@ -963,7 +980,7 @@ LL |     #[ignore] impl S { }
    = help: `#[ignore]` can only be applied to functions
 
 warning: `#[no_implicit_prelude]` attribute cannot be used on functions
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:458:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:476:5
    |
 LL |     #[no_implicit_prelude] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^^^^^
@@ -972,7 +989,7 @@ LL |     #[no_implicit_prelude] fn f() { }
    = help: `#[no_implicit_prelude]` can be applied to modules and crates
 
 warning: `#[no_implicit_prelude]` attribute cannot be used on structs
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:464:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:482:5
    |
 LL |     #[no_implicit_prelude] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^^
@@ -981,7 +998,7 @@ LL |     #[no_implicit_prelude] struct S;
    = help: `#[no_implicit_prelude]` can be applied to modules and crates
 
 warning: `#[no_implicit_prelude]` attribute cannot be used on type aliases
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:470:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:488:5
    |
 LL |     #[no_implicit_prelude] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^^^^
@@ -990,7 +1007,7 @@ LL |     #[no_implicit_prelude] type T = S;
    = help: `#[no_implicit_prelude]` can be applied to modules and crates
 
 warning: `#[no_implicit_prelude]` attribute cannot be used on inherent impl blocks
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:476:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:494:5
    |
 LL |     #[no_implicit_prelude] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^^
@@ -999,7 +1016,7 @@ LL |     #[no_implicit_prelude] impl S { }
    = help: `#[no_implicit_prelude]` can be applied to modules and crates
 
 warning: `#[macro_escape]` attribute cannot be used on functions
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:515:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:533:5
    |
 LL |     #[macro_escape] fn f() { }
    |     ^^^^^^^^^^^^^^^
@@ -1008,7 +1025,7 @@ LL |     #[macro_escape] fn f() { }
    = help: `#[macro_escape]` can be applied to modules, extern crates, and crates
 
 warning: `#[macro_escape]` attribute cannot be used on structs
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:521:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:539:5
    |
 LL |     #[macro_escape] struct S;
    |     ^^^^^^^^^^^^^^^
@@ -1017,7 +1034,7 @@ LL |     #[macro_escape] struct S;
    = help: `#[macro_escape]` can be applied to modules, extern crates, and crates
 
 warning: `#[macro_escape]` attribute cannot be used on type aliases
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:527:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:545:5
    |
 LL |     #[macro_escape] type T = S;
    |     ^^^^^^^^^^^^^^^
@@ -1026,7 +1043,7 @@ LL |     #[macro_escape] type T = S;
    = help: `#[macro_escape]` can be applied to modules, extern crates, and crates
 
 warning: `#[macro_escape]` attribute cannot be used on inherent impl blocks
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:533:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:551:5
    |
 LL |     #[macro_escape] impl S { }
    |     ^^^^^^^^^^^^^^^
@@ -1035,13 +1052,13 @@ LL |     #[macro_escape] impl S { }
    = help: `#[macro_escape]` can be applied to modules, extern crates, and crates
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![no_std]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:540:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:558:1
    |
 LL | #[no_std]
    | ^^^^^^^^^
    |
 note: This attribute does not have an `!`, which means it is applied to this module
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:542:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:560:1
    |
 LL | / mod no_std {
 LL | |
@@ -1051,61 +1068,61 @@ LL | | }
    | |_^
 
 warning: the `#![no_std]` attribute can only be used at the crate root
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:544:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:562:17
    |
 LL |     mod inner { #![no_std] }
    |                 ^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![no_std]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:547:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:565:5
    |
 LL |     #[no_std] fn f() { }
    |     ^^^^^^^^^
    |
 note: This attribute does not have an `!`, which means it is applied to this function
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:547:15
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:565:15
    |
 LL |     #[no_std] fn f() { }
    |               ^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![no_std]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:551:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:569:5
    |
 LL |     #[no_std] struct S;
    |     ^^^^^^^^^
    |
 note: This attribute does not have an `!`, which means it is applied to this struct
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:551:15
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:569:15
    |
 LL |     #[no_std] struct S;
    |               ^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![no_std]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:555:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:573:5
    |
 LL |     #[no_std] type T = S;
    |     ^^^^^^^^^
    |
 note: This attribute does not have an `!`, which means it is applied to this type alias
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:555:15
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:573:15
    |
 LL |     #[no_std] type T = S;
    |               ^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![no_std]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:559:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:577:5
    |
 LL |     #[no_std] impl S { }
    |     ^^^^^^^^^
    |
 note: This attribute does not have an `!`, which means it is applied to this implementation block
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:559:15
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:577:15
    |
 LL |     #[no_std] impl S { }
    |               ^^^^^^^^^^
 
 warning: `#[cold]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:581:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:599:1
    |
 LL | #[cold]
    | ^^^^^^^
@@ -1114,7 +1131,7 @@ LL | #[cold]
    = help: `#[cold]` can only be applied to functions
 
 warning: `#[cold]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:588:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:606:17
    |
 LL |     mod inner { #![cold] }
    |                 ^^^^^^^^
@@ -1123,7 +1140,7 @@ LL |     mod inner { #![cold] }
    = help: `#[cold]` can only be applied to functions
 
 warning: `#[cold]` attribute cannot be used on structs
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:596:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:614:5
    |
 LL |     #[cold] struct S;
    |     ^^^^^^^
@@ -1132,7 +1149,7 @@ LL |     #[cold] struct S;
    = help: `#[cold]` can only be applied to functions
 
 warning: `#[cold]` attribute cannot be used on type aliases
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:602:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:620:5
    |
 LL |     #[cold] type T = S;
    |     ^^^^^^^
@@ -1141,7 +1158,7 @@ LL |     #[cold] type T = S;
    = help: `#[cold]` can only be applied to functions
 
 warning: `#[cold]` attribute cannot be used on inherent impl blocks
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:608:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:626:5
    |
 LL |     #[cold] impl S { }
    |     ^^^^^^^
@@ -1150,7 +1167,7 @@ LL |     #[cold] impl S { }
    = help: `#[cold]` can only be applied to functions
 
 warning: `#[link_name]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:615:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:633:1
    |
 LL | #[link_name = "1900"]
    | ^^^^^^^^^^^^^^^^^^^^^
@@ -1159,7 +1176,7 @@ LL | #[link_name = "1900"]
    = help: `#[link_name]` can be applied to foreign functions and foreign statics
 
 warning: `#[link_name]` attribute cannot be used on foreign modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:621:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:639:5
    |
 LL |     #[link_name = "1900"]
    |     ^^^^^^^^^^^^^^^^^^^^^
@@ -1168,7 +1185,7 @@ LL |     #[link_name = "1900"]
    = help: `#[link_name]` can be applied to foreign functions and foreign statics
 
 warning: `#[link_name]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:628:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:646:17
    |
 LL |     mod inner { #![link_name="1900"] }
    |                 ^^^^^^^^^^^^^^^^^^^^
@@ -1177,7 +1194,7 @@ LL |     mod inner { #![link_name="1900"] }
    = help: `#[link_name]` can be applied to foreign functions and foreign statics
 
 warning: `#[link_name]` attribute cannot be used on functions
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:634:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:652:5
    |
 LL |     #[link_name = "1900"] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^^^^
@@ -1186,7 +1203,7 @@ LL |     #[link_name = "1900"] fn f() { }
    = help: `#[link_name]` can be applied to foreign functions and foreign statics
 
 warning: `#[link_name]` attribute cannot be used on structs
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:640:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:658:5
    |
 LL |     #[link_name = "1900"] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^
@@ -1195,7 +1212,7 @@ LL |     #[link_name = "1900"] struct S;
    = help: `#[link_name]` can be applied to foreign functions and foreign statics
 
 warning: `#[link_name]` attribute cannot be used on type aliases
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:646:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:664:5
    |
 LL |     #[link_name = "1900"] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^^^
@@ -1204,7 +1221,7 @@ LL |     #[link_name = "1900"] type T = S;
    = help: `#[link_name]` can be applied to foreign functions and foreign statics
 
 warning: `#[link_name]` attribute cannot be used on inherent impl blocks
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:652:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:670:5
    |
 LL |     #[link_name = "1900"] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^
@@ -1213,7 +1230,7 @@ LL |     #[link_name = "1900"] impl S { }
    = help: `#[link_name]` can be applied to foreign functions and foreign statics
 
 warning: `#[link_section]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:659:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:677:1
    |
 LL | #[link_section = "1800"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1222,7 +1239,7 @@ LL | #[link_section = "1800"]
    = help: `#[link_section]` can be applied to statics and functions
 
 warning: `#[link_section]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:665:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:683:17
    |
 LL |     mod inner { #![link_section="1800"] }
    |                 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -1231,7 +1248,7 @@ LL |     mod inner { #![link_section="1800"] }
    = help: `#[link_section]` can be applied to statics and functions
 
 warning: `#[link_section]` attribute cannot be used on structs
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:673:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:691:5
    |
 LL |     #[link_section = "1800"] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1240,7 +1257,7 @@ LL |     #[link_section = "1800"] struct S;
    = help: `#[link_section]` can be applied to statics and functions
 
 warning: `#[link_section]` attribute cannot be used on type aliases
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:679:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:697:5
    |
 LL |     #[link_section = "1800"] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1249,7 +1266,7 @@ LL |     #[link_section = "1800"] type T = S;
    = help: `#[link_section]` can be applied to statics and functions
 
 warning: `#[link_section]` attribute cannot be used on inherent impl blocks
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:685:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:703:5
    |
 LL |     #[link_section = "1800"] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1258,7 +1275,7 @@ LL |     #[link_section = "1800"] impl S { }
    = help: `#[link_section]` can be applied to statics and functions
 
 warning: `#[must_use]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:746:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:764:1
    |
 LL | #[must_use]
    | ^^^^^^^^^^^
@@ -1267,7 +1284,7 @@ LL | #[must_use]
    = help: `#[must_use]` can be applied to functions, data types, unions, and traits
 
 warning: `#[must_use]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:751:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:769:17
    |
 LL |     mod inner { #![must_use] }
    |                 ^^^^^^^^^^^^
@@ -1276,7 +1293,7 @@ LL |     mod inner { #![must_use] }
    = help: `#[must_use]` can be applied to functions, data types, unions, and traits
 
 warning: `#[must_use]` attribute cannot be used on type aliases
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:760:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:778:5
    |
 LL |     #[must_use] type T = S;
    |     ^^^^^^^^^^^
@@ -1285,7 +1302,7 @@ LL |     #[must_use] type T = S;
    = help: `#[must_use]` can be applied to functions, data types, unions, and traits
 
 warning: `#[must_use]` attribute cannot be used on inherent impl blocks
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:765:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:783:5
    |
 LL |     #[must_use] impl S { }
    |     ^^^^^^^^^^^
@@ -1294,13 +1311,13 @@ LL |     #[must_use] impl S { }
    = help: `#[must_use]` can be applied to functions, data types, unions, and traits
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![crate_name]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:797:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:815:1
    |
 LL | #[crate_name = "0900"]
    | ^^^^^^^^^^^^^^^^^^^^^^
    |
 note: This attribute does not have an `!`, which means it is applied to this module
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:799:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:817:1
    |
 LL | / mod crate_name {
 LL | |
@@ -1310,67 +1327,67 @@ LL | | }
    | |_^
 
 warning: the `#![crate_name]` attribute can only be used at the crate root
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:801:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:819:17
    |
 LL |     mod inner { #![crate_name="0900"] }
    |                 ^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![crate_name]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:804:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:822:5
    |
 LL |     #[crate_name = "0900"] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^^^^^
    |
 note: This attribute does not have an `!`, which means it is applied to this function
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:804:28
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:822:28
    |
 LL |     #[crate_name = "0900"] fn f() { }
    |                            ^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![crate_name]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:808:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:826:5
    |
 LL |     #[crate_name = "0900"] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^^
    |
 note: This attribute does not have an `!`, which means it is applied to this struct
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:808:28
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:826:28
    |
 LL |     #[crate_name = "0900"] struct S;
    |                            ^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![crate_name]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:812:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:830:5
    |
 LL |     #[crate_name = "0900"] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^^^^
    |
 note: This attribute does not have an `!`, which means it is applied to this type alias
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:812:28
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:830:28
    |
 LL |     #[crate_name = "0900"] type T = S;
    |                            ^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![crate_name]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:816:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:834:5
    |
 LL |     #[crate_name = "0900"] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^^
    |
 note: This attribute does not have an `!`, which means it is applied to this implementation block
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:816:28
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:834:28
    |
 LL |     #[crate_name = "0900"] impl S { }
    |                            ^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![recursion_limit]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:918:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:936:1
    |
 LL | #[recursion_limit="0200"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: This attribute does not have an `!`, which means it is applied to this module
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:920:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:938:1
    |
 LL | / mod recursion_limit {
 LL | |
@@ -1380,67 +1397,67 @@ LL | | }
    | |_^
 
 warning: the `#![recursion_limit]` attribute can only be used at the crate root
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:922:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:940:17
    |
 LL |     mod inner { #![recursion_limit="0200"] }
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![recursion_limit]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:925:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:943:5
    |
 LL |     #[recursion_limit="0200"] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: This attribute does not have an `!`, which means it is applied to this function
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:925:31
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:943:31
    |
 LL |     #[recursion_limit="0200"] fn f() { }
    |                               ^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![recursion_limit]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:929:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:947:5
    |
 LL |     #[recursion_limit="0200"] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: This attribute does not have an `!`, which means it is applied to this struct
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:929:31
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:947:31
    |
 LL |     #[recursion_limit="0200"] struct S;
    |                               ^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![recursion_limit]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:933:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:951:5
    |
 LL |     #[recursion_limit="0200"] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: This attribute does not have an `!`, which means it is applied to this type alias
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:933:31
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:951:31
    |
 LL |     #[recursion_limit="0200"] type T = S;
    |                               ^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![recursion_limit]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:937:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:955:5
    |
 LL |     #[recursion_limit="0200"] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: This attribute does not have an `!`, which means it is applied to this implementation block
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:937:31
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:955:31
    |
 LL |     #[recursion_limit="0200"] impl S { }
    |                               ^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![type_length_limit]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:942:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:960:1
    |
 LL | #[type_length_limit="0100"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: This attribute does not have an `!`, which means it is applied to this module
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:944:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:962:1
    |
 LL | / mod type_length_limit {
 LL | |
@@ -1450,55 +1467,55 @@ LL | | }
    | |_^
 
 warning: the `#![type_length_limit]` attribute can only be used at the crate root
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:946:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:964:17
    |
 LL |     mod inner { #![type_length_limit="0100"] }
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![type_length_limit]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:949:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:967:5
    |
 LL |     #[type_length_limit="0100"] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: This attribute does not have an `!`, which means it is applied to this function
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:949:33
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:967:33
    |
 LL |     #[type_length_limit="0100"] fn f() { }
    |                                 ^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![type_length_limit]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:953:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:971:5
    |
 LL |     #[type_length_limit="0100"] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: This attribute does not have an `!`, which means it is applied to this struct
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:953:33
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:971:33
    |
 LL |     #[type_length_limit="0100"] struct S;
    |                                 ^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![type_length_limit]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:957:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:975:5
    |
 LL |     #[type_length_limit="0100"] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: This attribute does not have an `!`, which means it is applied to this type alias
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:957:33
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:975:33
    |
 LL |     #[type_length_limit="0100"] type T = S;
    |                                 ^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![type_length_limit]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:961:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:979:5
    |
 LL |     #[type_length_limit="0100"] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: This attribute does not have an `!`, which means it is applied to this implementation block
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:961:33
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:979:33
    |
 LL |     #[type_length_limit="0100"] impl S { }
    |                                 ^^^^^^^^^^

--- a/tests/ui/lint/unused/unused-attr-duplicate.stderr
+++ b/tests/ui/lint/unused/unused-attr-duplicate.stderr
@@ -54,18 +54,6 @@ LL | #![no_builtins]
    | ^^^^^^^^^^^^^^^
 
 error: unused attribute
-  --> $DIR/unused-attr-duplicate.rs:44:5
-   |
-LL |     #[macro_export]
-   |     ^^^^^^^^^^^^^^^ help: remove this attribute
-   |
-note: attribute also specified here
-  --> $DIR/unused-attr-duplicate.rs:43:5
-   |
-LL |     #[macro_export]
-   |     ^^^^^^^^^^^^^^^
-
-error: unused attribute
   --> $DIR/unused-attr-duplicate.rs:41:1
    |
 LL | #[macro_use]
@@ -76,6 +64,18 @@ note: attribute also specified here
    |
 LL | #[macro_use]
    | ^^^^^^^^^^^^
+
+error: unused attribute
+  --> $DIR/unused-attr-duplicate.rs:44:5
+   |
+LL |     #[macro_export]
+   |     ^^^^^^^^^^^^^^^ help: remove this attribute
+   |
+note: attribute also specified here
+  --> $DIR/unused-attr-duplicate.rs:43:5
+   |
+LL |     #[macro_export]
+   |     ^^^^^^^^^^^^^^^
 
 error: unused attribute
   --> $DIR/unused-attr-duplicate.rs:51:1


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#143857 (Port #[macro_export] to the new attribute parsing infrastructure)
 - rust-lang/rust#146486 (Improve `core::sync::atomic` coverage)
 - rust-lang/rust#146606 (ci: x86_64-gnu-tools: Add `--test-args` regression test)
 - rust-lang/rust#146639 (std: merge definitions of `StdioPipes`)
 - rust-lang/rust#146675 (Allow shared access to `Exclusive<T>` when `T: Sync`)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=143857,146486,146606,146639,146675)
<!-- homu-ignore:end -->