### PR TITLE
Update cell.rs, correct module level doc

### DIFF
--- a/library/core/src/cell.rs
+++ b/library/core/src/cell.rs
@@ -27,10 +27,9 @@
 //!
 //! ## `Cell<T>`
 //!
-//! [`Cell<T>`] implements interior mutability by moving values in and out of the cell. That is, an
-//! `&mut T` to the inner value can never be obtained, and the value itself cannot be directly
-//! obtained without replacing it with something else. Both of these rules ensure that there is
-//! never more than one reference pointing to the inner value. This type provides the following
+//! [`Cell<T>`] implements interior mutability by moving values in and out of the cell. That is, a
+//! `&T` to the inner value can never be obtained, and the value itself cannot be directly
+//! obtained without replacing it with something else. This type provides the following
 //! methods:
 //!
 //!  - For types that implement [`Copy`], the [`get`](Cell::get) method retrieves the current


### PR DESCRIPTION
This change corrects the Cell<T> section by replacing `&mut` with `&` so the statement reads "an &T to the inner value can never be obtained". It also emphasizes that a single &mut T to the inner value can be obtained (e.g. via method core::cell::Cell::get_mut).
