### PR TITLE
source_span query optimized to be inlined function in case of non-incremental build

### DIFF
--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -209,7 +209,7 @@ rustc_queries! {
     /// Contrary to `def_span` below, this query returns the full absolute span of the definition.
     /// This span is meant for dep-tracking rather than diagnostics. It should not be used outside
     /// of rustc_middle::hir::source_map.
-    query source_span(key: LocalDefId) -> Span {
+    query source_span_q(key: LocalDefId) -> Span {
         // Accesses untracked data
         eval_always
         desc { "getting the source span" }

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -3482,6 +3482,15 @@ impl<'tcx> TyCtxt<'tcx> {
         }
         false
     }
+
+    #[inline]
+    pub fn source_span(self, key: LocalDefId) -> Span {
+        if self.dep_graph.is_fully_enabled() {
+            self.source_span_q(key)
+        } else {
+            self.untracked.source_span.get(key).unwrap_or(DUMMY_SP)
+        }
+    }
 }
 
 /// Parameter attributes that can only be determined by examining the body of a function instead
@@ -3508,7 +3517,8 @@ pub fn provide(providers: &mut Providers) {
         // We want to check if the panic handler was defined in this crate
         tcx.lang_items().panic_impl().is_some_and(|did| did.is_local())
     };
-    providers.source_span = |tcx, def_id| tcx.untracked.source_span.get(def_id).unwrap_or(DUMMY_SP);
+    providers.source_span_q =
+        |tcx, def_id| tcx.untracked.source_span.get(def_id).unwrap_or(DUMMY_SP);
 }
 
 pub fn contains_name(attrs: &[Attribute], name: Symbol) -> bool {


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
-->
<!-- homu-ignore:end -->
source_span query renamed to source_span_q.
source_span inlined function implemented to call source_span implementation in case of non-incremental build and call query otherwise.

Some other queries may be optimized in a such way.
Statistics prepared (queries with small 'avg_ns_norm' and big 'cache_hits' may be optimized):
Non-feedable only and cache_hits > 500:
[queries_stat_non_feedable.csv](https://github.com/user-attachments/files/22533502/queries_stat_non_feedable.csv)
