### PR TITLE
fully deprecate the legacy integral modules

### DIFF
--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -237,12 +237,10 @@ mod internal_macros;
 #[path = "num/shells/legacy_int_modules.rs"]
 mod legacy_int_modules;
 #[stable(feature = "rust1", since = "1.0.0")]
-#[allow(clippy::useless_attribute)] // FIXME false positive (https://github.com/rust-lang/rust-clippy/issues/15636)
-#[allow(deprecated_in_future)]
+#[allow(deprecated)]
 pub use legacy_int_modules::{i8, i16, i32, i64, isize, u8, u16, u32, u64, usize};
 #[stable(feature = "i128", since = "1.26.0")]
-#[allow(clippy::useless_attribute)] // FIXME false positive (https://github.com/rust-lang/rust-clippy/issues/15636)
-#[allow(deprecated_in_future)]
+#[allow(deprecated)]
 pub use legacy_int_modules::{i128, u128};
 
 #[path = "num/f128.rs"]

--- a/library/core/src/num/f32.rs
+++ b/library/core/src/num/f32.rs
@@ -23,14 +23,17 @@ use crate::{cfg_select, intrinsics, mem};
 ///
 /// ```rust
 /// // deprecated way
-/// # #[allow(deprecated, deprecated_in_future)]
+/// # #[allow(deprecated)]
 /// let r = std::f32::RADIX;
 ///
 /// // intended way
 /// let r = f32::RADIX;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-#[deprecated(since = "TBD", note = "replaced by the `RADIX` associated constant on `f32`")]
+#[deprecated(
+    since = "CURRENT_RUSTC_VERSION",
+    note = "replaced by the `RADIX` associated constant on `f32`"
+)]
 #[rustc_diagnostic_item = "f32_legacy_const_radix"]
 pub const RADIX: u32 = f32::RADIX;
 
@@ -41,7 +44,7 @@ pub const RADIX: u32 = f32::RADIX;
 ///
 /// ```rust
 /// // deprecated way
-/// # #[allow(deprecated, deprecated_in_future)]
+/// # #[allow(deprecated)]
 /// let d = std::f32::MANTISSA_DIGITS;
 ///
 /// // intended way
@@ -49,7 +52,7 @@ pub const RADIX: u32 = f32::RADIX;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 #[deprecated(
-    since = "TBD",
+    since = "CURRENT_RUSTC_VERSION",
     note = "replaced by the `MANTISSA_DIGITS` associated constant on `f32`"
 )]
 #[rustc_diagnostic_item = "f32_legacy_const_mantissa_dig"]
@@ -62,14 +65,17 @@ pub const MANTISSA_DIGITS: u32 = f32::MANTISSA_DIGITS;
 ///
 /// ```rust
 /// // deprecated way
-/// # #[allow(deprecated, deprecated_in_future)]
+/// # #[allow(deprecated)]
 /// let d = std::f32::DIGITS;
 ///
 /// // intended way
 /// let d = f32::DIGITS;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-#[deprecated(since = "TBD", note = "replaced by the `DIGITS` associated constant on `f32`")]
+#[deprecated(
+    since = "CURRENT_RUSTC_VERSION",
+    note = "replaced by the `DIGITS` associated constant on `f32`"
+)]
 #[rustc_diagnostic_item = "f32_legacy_const_digits"]
 pub const DIGITS: u32 = f32::DIGITS;
 
@@ -84,14 +90,17 @@ pub const DIGITS: u32 = f32::DIGITS;
 ///
 /// ```rust
 /// // deprecated way
-/// # #[allow(deprecated, deprecated_in_future)]
+/// # #[allow(deprecated)]
 /// let e = std::f32::EPSILON;
 ///
 /// // intended way
 /// let e = f32::EPSILON;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-#[deprecated(since = "TBD", note = "replaced by the `EPSILON` associated constant on `f32`")]
+#[deprecated(
+    since = "CURRENT_RUSTC_VERSION",
+    note = "replaced by the `EPSILON` associated constant on `f32`"
+)]
 #[rustc_diagnostic_item = "f32_legacy_const_epsilon"]
 pub const EPSILON: f32 = f32::EPSILON;
 
@@ -102,14 +111,17 @@ pub const EPSILON: f32 = f32::EPSILON;
 ///
 /// ```rust
 /// // deprecated way
-/// # #[allow(deprecated, deprecated_in_future)]
+/// # #[allow(deprecated)]
 /// let min = std::f32::MIN;
 ///
 /// // intended way
 /// let min = f32::MIN;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-#[deprecated(since = "TBD", note = "replaced by the `MIN` associated constant on `f32`")]
+#[deprecated(
+    since = "CURRENT_RUSTC_VERSION",
+    note = "replaced by the `MIN` associated constant on `f32`"
+)]
 #[rustc_diagnostic_item = "f32_legacy_const_min"]
 pub const MIN: f32 = f32::MIN;
 
@@ -120,14 +132,17 @@ pub const MIN: f32 = f32::MIN;
 ///
 /// ```rust
 /// // deprecated way
-/// # #[allow(deprecated, deprecated_in_future)]
+/// # #[allow(deprecated)]
 /// let min = std::f32::MIN_POSITIVE;
 ///
 /// // intended way
 /// let min = f32::MIN_POSITIVE;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-#[deprecated(since = "TBD", note = "replaced by the `MIN_POSITIVE` associated constant on `f32`")]
+#[deprecated(
+    since = "CURRENT_RUSTC_VERSION",
+    note = "replaced by the `MIN_POSITIVE` associated constant on `f32`"
+)]
 #[rustc_diagnostic_item = "f32_legacy_const_min_positive"]
 pub const MIN_POSITIVE: f32 = f32::MIN_POSITIVE;
 
@@ -138,14 +153,17 @@ pub const MIN_POSITIVE: f32 = f32::MIN_POSITIVE;
 ///
 /// ```rust
 /// // deprecated way
-/// # #[allow(deprecated, deprecated_in_future)]
+/// # #[allow(deprecated)]
 /// let max = std::f32::MAX;
 ///
 /// // intended way
 /// let max = f32::MAX;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-#[deprecated(since = "TBD", note = "replaced by the `MAX` associated constant on `f32`")]
+#[deprecated(
+    since = "CURRENT_RUSTC_VERSION",
+    note = "replaced by the `MAX` associated constant on `f32`"
+)]
 #[rustc_diagnostic_item = "f32_legacy_const_max"]
 pub const MAX: f32 = f32::MAX;
 
@@ -156,14 +174,17 @@ pub const MAX: f32 = f32::MAX;
 ///
 /// ```rust
 /// // deprecated way
-/// # #[allow(deprecated, deprecated_in_future)]
+/// # #[allow(deprecated)]
 /// let min = std::f32::MIN_EXP;
 ///
 /// // intended way
 /// let min = f32::MIN_EXP;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-#[deprecated(since = "TBD", note = "replaced by the `MIN_EXP` associated constant on `f32`")]
+#[deprecated(
+    since = "CURRENT_RUSTC_VERSION",
+    note = "replaced by the `MIN_EXP` associated constant on `f32`"
+)]
 #[rustc_diagnostic_item = "f32_legacy_const_min_exp"]
 pub const MIN_EXP: i32 = f32::MIN_EXP;
 
@@ -174,14 +195,17 @@ pub const MIN_EXP: i32 = f32::MIN_EXP;
 ///
 /// ```rust
 /// // deprecated way
-/// # #[allow(deprecated, deprecated_in_future)]
+/// # #[allow(deprecated)]
 /// let max = std::f32::MAX_EXP;
 ///
 /// // intended way
 /// let max = f32::MAX_EXP;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-#[deprecated(since = "TBD", note = "replaced by the `MAX_EXP` associated constant on `f32`")]
+#[deprecated(
+    since = "CURRENT_RUSTC_VERSION",
+    note = "replaced by the `MAX_EXP` associated constant on `f32`"
+)]
 #[rustc_diagnostic_item = "f32_legacy_const_max_exp"]
 pub const MAX_EXP: i32 = f32::MAX_EXP;
 
@@ -192,14 +216,17 @@ pub const MAX_EXP: i32 = f32::MAX_EXP;
 ///
 /// ```rust
 /// // deprecated way
-/// # #[allow(deprecated, deprecated_in_future)]
+/// # #[allow(deprecated)]
 /// let min = std::f32::MIN_10_EXP;
 ///
 /// // intended way
 /// let min = f32::MIN_10_EXP;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-#[deprecated(since = "TBD", note = "replaced by the `MIN_10_EXP` associated constant on `f32`")]
+#[deprecated(
+    since = "CURRENT_RUSTC_VERSION",
+    note = "replaced by the `MIN_10_EXP` associated constant on `f32`"
+)]
 #[rustc_diagnostic_item = "f32_legacy_const_min_10_exp"]
 pub const MIN_10_EXP: i32 = f32::MIN_10_EXP;
 
@@ -210,14 +237,17 @@ pub const MIN_10_EXP: i32 = f32::MIN_10_EXP;
 ///
 /// ```rust
 /// // deprecated way
-/// # #[allow(deprecated, deprecated_in_future)]
+/// # #[allow(deprecated)]
 /// let max = std::f32::MAX_10_EXP;
 ///
 /// // intended way
 /// let max = f32::MAX_10_EXP;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-#[deprecated(since = "TBD", note = "replaced by the `MAX_10_EXP` associated constant on `f32`")]
+#[deprecated(
+    since = "CURRENT_RUSTC_VERSION",
+    note = "replaced by the `MAX_10_EXP` associated constant on `f32`"
+)]
 #[rustc_diagnostic_item = "f32_legacy_const_max_10_exp"]
 pub const MAX_10_EXP: i32 = f32::MAX_10_EXP;
 
@@ -228,14 +258,17 @@ pub const MAX_10_EXP: i32 = f32::MAX_10_EXP;
 ///
 /// ```rust
 /// // deprecated way
-/// # #[allow(deprecated, deprecated_in_future)]
+/// # #[allow(deprecated)]
 /// let nan = std::f32::NAN;
 ///
 /// // intended way
 /// let nan = f32::NAN;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-#[deprecated(since = "TBD", note = "replaced by the `NAN` associated constant on `f32`")]
+#[deprecated(
+    since = "CURRENT_RUSTC_VERSION",
+    note = "replaced by the `NAN` associated constant on `f32`"
+)]
 #[rustc_diagnostic_item = "f32_legacy_const_nan"]
 pub const NAN: f32 = f32::NAN;
 
@@ -246,14 +279,17 @@ pub const NAN: f32 = f32::NAN;
 ///
 /// ```rust
 /// // deprecated way
-/// # #[allow(deprecated, deprecated_in_future)]
+/// # #[allow(deprecated)]
 /// let inf = std::f32::INFINITY;
 ///
 /// // intended way
 /// let inf = f32::INFINITY;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-#[deprecated(since = "TBD", note = "replaced by the `INFINITY` associated constant on `f32`")]
+#[deprecated(
+    since = "CURRENT_RUSTC_VERSION",
+    note = "replaced by the `INFINITY` associated constant on `f32`"
+)]
 #[rustc_diagnostic_item = "f32_legacy_const_infinity"]
 pub const INFINITY: f32 = f32::INFINITY;
 
@@ -264,14 +300,17 @@ pub const INFINITY: f32 = f32::INFINITY;
 ///
 /// ```rust
 /// // deprecated way
-/// # #[allow(deprecated, deprecated_in_future)]
+/// # #[allow(deprecated)]
 /// let ninf = std::f32::NEG_INFINITY;
 ///
 /// // intended way
 /// let ninf = f32::NEG_INFINITY;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-#[deprecated(since = "TBD", note = "replaced by the `NEG_INFINITY` associated constant on `f32`")]
+#[deprecated(
+    since = "CURRENT_RUSTC_VERSION",
+    note = "replaced by the `NEG_INFINITY` associated constant on `f32`"
+)]
 #[rustc_diagnostic_item = "f32_legacy_const_neg_infinity"]
 pub const NEG_INFINITY: f32 = f32::NEG_INFINITY;
 

--- a/library/core/src/num/f64.rs
+++ b/library/core/src/num/f64.rs
@@ -23,14 +23,17 @@ use crate::{intrinsics, mem};
 ///
 /// ```rust
 /// // deprecated way
-/// # #[allow(deprecated, deprecated_in_future)]
+/// # #[allow(deprecated)]
 /// let r = std::f64::RADIX;
 ///
 /// // intended way
 /// let r = f64::RADIX;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-#[deprecated(since = "TBD", note = "replaced by the `RADIX` associated constant on `f64`")]
+#[deprecated(
+    since = "CURRENT_RUSTC_VERSION",
+    note = "replaced by the `RADIX` associated constant on `f64`"
+)]
 #[rustc_diagnostic_item = "f64_legacy_const_radix"]
 pub const RADIX: u32 = f64::RADIX;
 
@@ -41,7 +44,7 @@ pub const RADIX: u32 = f64::RADIX;
 ///
 /// ```rust
 /// // deprecated way
-/// # #[allow(deprecated, deprecated_in_future)]
+/// # #[allow(deprecated)]
 /// let d = std::f64::MANTISSA_DIGITS;
 ///
 /// // intended way
@@ -49,7 +52,7 @@ pub const RADIX: u32 = f64::RADIX;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 #[deprecated(
-    since = "TBD",
+    since = "CURRENT_RUSTC_VERSION",
     note = "replaced by the `MANTISSA_DIGITS` associated constant on `f64`"
 )]
 #[rustc_diagnostic_item = "f64_legacy_const_mantissa_dig"]
@@ -62,14 +65,17 @@ pub const MANTISSA_DIGITS: u32 = f64::MANTISSA_DIGITS;
 ///
 /// ```rust
 /// // deprecated way
-/// # #[allow(deprecated, deprecated_in_future)]
+/// # #[allow(deprecated)]
 /// let d = std::f64::DIGITS;
 ///
 /// // intended way
 /// let d = f64::DIGITS;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-#[deprecated(since = "TBD", note = "replaced by the `DIGITS` associated constant on `f64`")]
+#[deprecated(
+    since = "CURRENT_RUSTC_VERSION",
+    note = "replaced by the `DIGITS` associated constant on `f64`"
+)]
 #[rustc_diagnostic_item = "f64_legacy_const_digits"]
 pub const DIGITS: u32 = f64::DIGITS;
 
@@ -84,14 +90,17 @@ pub const DIGITS: u32 = f64::DIGITS;
 ///
 /// ```rust
 /// // deprecated way
-/// # #[allow(deprecated, deprecated_in_future)]
+/// # #[allow(deprecated)]
 /// let e = std::f64::EPSILON;
 ///
 /// // intended way
 /// let e = f64::EPSILON;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-#[deprecated(since = "TBD", note = "replaced by the `EPSILON` associated constant on `f64`")]
+#[deprecated(
+    since = "CURRENT_RUSTC_VERSION",
+    note = "replaced by the `EPSILON` associated constant on `f64`"
+)]
 #[rustc_diagnostic_item = "f64_legacy_const_epsilon"]
 pub const EPSILON: f64 = f64::EPSILON;
 
@@ -102,14 +111,17 @@ pub const EPSILON: f64 = f64::EPSILON;
 ///
 /// ```rust
 /// // deprecated way
-/// # #[allow(deprecated, deprecated_in_future)]
+/// # #[allow(deprecated)]
 /// let min = std::f64::MIN;
 ///
 /// // intended way
 /// let min = f64::MIN;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-#[deprecated(since = "TBD", note = "replaced by the `MIN` associated constant on `f64`")]
+#[deprecated(
+    since = "CURRENT_RUSTC_VERSION",
+    note = "replaced by the `MIN` associated constant on `f64`"
+)]
 #[rustc_diagnostic_item = "f64_legacy_const_min"]
 pub const MIN: f64 = f64::MIN;
 
@@ -120,14 +132,17 @@ pub const MIN: f64 = f64::MIN;
 ///
 /// ```rust
 /// // deprecated way
-/// # #[allow(deprecated, deprecated_in_future)]
+/// # #[allow(deprecated)]
 /// let min = std::f64::MIN_POSITIVE;
 ///
 /// // intended way
 /// let min = f64::MIN_POSITIVE;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-#[deprecated(since = "TBD", note = "replaced by the `MIN_POSITIVE` associated constant on `f64`")]
+#[deprecated(
+    since = "CURRENT_RUSTC_VERSION",
+    note = "replaced by the `MIN_POSITIVE` associated constant on `f64`"
+)]
 #[rustc_diagnostic_item = "f64_legacy_const_min_positive"]
 pub const MIN_POSITIVE: f64 = f64::MIN_POSITIVE;
 
@@ -138,14 +153,17 @@ pub const MIN_POSITIVE: f64 = f64::MIN_POSITIVE;
 ///
 /// ```rust
 /// // deprecated way
-/// # #[allow(deprecated, deprecated_in_future)]
+/// # #[allow(deprecated)]
 /// let max = std::f64::MAX;
 ///
 /// // intended way
 /// let max = f64::MAX;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-#[deprecated(since = "TBD", note = "replaced by the `MAX` associated constant on `f64`")]
+#[deprecated(
+    since = "CURRENT_RUSTC_VERSION",
+    note = "replaced by the `MAX` associated constant on `f64`"
+)]
 #[rustc_diagnostic_item = "f64_legacy_const_max"]
 pub const MAX: f64 = f64::MAX;
 
@@ -156,14 +174,17 @@ pub const MAX: f64 = f64::MAX;
 ///
 /// ```rust
 /// // deprecated way
-/// # #[allow(deprecated, deprecated_in_future)]
+/// # #[allow(deprecated)]
 /// let min = std::f64::MIN_EXP;
 ///
 /// // intended way
 /// let min = f64::MIN_EXP;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-#[deprecated(since = "TBD", note = "replaced by the `MIN_EXP` associated constant on `f64`")]
+#[deprecated(
+    since = "CURRENT_RUSTC_VERSION",
+    note = "replaced by the `MIN_EXP` associated constant on `f64`"
+)]
 #[rustc_diagnostic_item = "f64_legacy_const_min_exp"]
 pub const MIN_EXP: i32 = f64::MIN_EXP;
 
@@ -174,14 +195,17 @@ pub const MIN_EXP: i32 = f64::MIN_EXP;
 ///
 /// ```rust
 /// // deprecated way
-/// # #[allow(deprecated, deprecated_in_future)]
+/// # #[allow(deprecated)]
 /// let max = std::f64::MAX_EXP;
 ///
 /// // intended way
 /// let max = f64::MAX_EXP;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-#[deprecated(since = "TBD", note = "replaced by the `MAX_EXP` associated constant on `f64`")]
+#[deprecated(
+    since = "CURRENT_RUSTC_VERSION",
+    note = "replaced by the `MAX_EXP` associated constant on `f64`"
+)]
 #[rustc_diagnostic_item = "f64_legacy_const_max_exp"]
 pub const MAX_EXP: i32 = f64::MAX_EXP;
 
@@ -192,14 +216,17 @@ pub const MAX_EXP: i32 = f64::MAX_EXP;
 ///
 /// ```rust
 /// // deprecated way
-/// # #[allow(deprecated, deprecated_in_future)]
+/// # #[allow(deprecated)]
 /// let min = std::f64::MIN_10_EXP;
 ///
 /// // intended way
 /// let min = f64::MIN_10_EXP;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-#[deprecated(since = "TBD", note = "replaced by the `MIN_10_EXP` associated constant on `f64`")]
+#[deprecated(
+    since = "CURRENT_RUSTC_VERSION",
+    note = "replaced by the `MIN_10_EXP` associated constant on `f64`"
+)]
 #[rustc_diagnostic_item = "f64_legacy_const_min_10_exp"]
 pub const MIN_10_EXP: i32 = f64::MIN_10_EXP;
 
@@ -210,14 +237,17 @@ pub const MIN_10_EXP: i32 = f64::MIN_10_EXP;
 ///
 /// ```rust
 /// // deprecated way
-/// # #[allow(deprecated, deprecated_in_future)]
+/// # #[allow(deprecated)]
 /// let max = std::f64::MAX_10_EXP;
 ///
 /// // intended way
 /// let max = f64::MAX_10_EXP;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-#[deprecated(since = "TBD", note = "replaced by the `MAX_10_EXP` associated constant on `f64`")]
+#[deprecated(
+    since = "CURRENT_RUSTC_VERSION",
+    note = "replaced by the `MAX_10_EXP` associated constant on `f64`"
+)]
 #[rustc_diagnostic_item = "f64_legacy_const_max_10_exp"]
 pub const MAX_10_EXP: i32 = f64::MAX_10_EXP;
 
@@ -228,14 +258,17 @@ pub const MAX_10_EXP: i32 = f64::MAX_10_EXP;
 ///
 /// ```rust
 /// // deprecated way
-/// # #[allow(deprecated, deprecated_in_future)]
+/// # #[allow(deprecated)]
 /// let nan = std::f64::NAN;
 ///
 /// // intended way
 /// let nan = f64::NAN;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-#[deprecated(since = "TBD", note = "replaced by the `NAN` associated constant on `f64`")]
+#[deprecated(
+    since = "CURRENT_RUSTC_VERSION",
+    note = "replaced by the `NAN` associated constant on `f64`"
+)]
 #[rustc_diagnostic_item = "f64_legacy_const_nan"]
 pub const NAN: f64 = f64::NAN;
 
@@ -246,14 +279,17 @@ pub const NAN: f64 = f64::NAN;
 ///
 /// ```rust
 /// // deprecated way
-/// # #[allow(deprecated, deprecated_in_future)]
+/// # #[allow(deprecated)]
 /// let inf = std::f64::INFINITY;
 ///
 /// // intended way
 /// let inf = f64::INFINITY;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-#[deprecated(since = "TBD", note = "replaced by the `INFINITY` associated constant on `f64`")]
+#[deprecated(
+    since = "CURRENT_RUSTC_VERSION",
+    note = "replaced by the `INFINITY` associated constant on `f64`"
+)]
 #[rustc_diagnostic_item = "f64_legacy_const_infinity"]
 pub const INFINITY: f64 = f64::INFINITY;
 
@@ -264,14 +300,17 @@ pub const INFINITY: f64 = f64::INFINITY;
 ///
 /// ```rust
 /// // deprecated way
-/// # #[allow(deprecated, deprecated_in_future)]
+/// # #[allow(deprecated)]
 /// let ninf = std::f64::NEG_INFINITY;
 ///
 /// // intended way
 /// let ninf = f64::NEG_INFINITY;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-#[deprecated(since = "TBD", note = "replaced by the `NEG_INFINITY` associated constant on `f64`")]
+#[deprecated(
+    since = "CURRENT_RUSTC_VERSION",
+    note = "replaced by the `NEG_INFINITY` associated constant on `f64`"
+)]
 #[rustc_diagnostic_item = "f64_legacy_const_neg_infinity"]
 pub const NEG_INFINITY: f64 = f64::NEG_INFINITY;
 

--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -3924,7 +3924,7 @@ macro_rules! int_impl {
         #[inline(always)]
         #[rustc_promotable]
         #[rustc_const_stable(feature = "const_min_value", since = "1.32.0")]
-        #[deprecated(since = "TBD", note = "replaced by the `MIN` associated constant on this type")]
+        #[deprecated(since = "CURRENT_RUSTC_VERSION", note = "replaced by the `MIN` associated constant on this type")]
         #[rustc_diagnostic_item = concat!(stringify!($SelfT), "_legacy_fn_min_value")]
         pub const fn min_value() -> Self {
             Self::MIN
@@ -3938,7 +3938,7 @@ macro_rules! int_impl {
         #[inline(always)]
         #[rustc_promotable]
         #[rustc_const_stable(feature = "const_max_value", since = "1.32.0")]
-        #[deprecated(since = "TBD", note = "replaced by the `MAX` associated constant on this type")]
+        #[deprecated(since = "CURRENT_RUSTC_VERSION", note = "replaced by the `MAX` associated constant on this type")]
         #[rustc_diagnostic_item = concat!(stringify!($SelfT), "_legacy_fn_max_value")]
         pub const fn max_value() -> Self {
             Self::MAX

--- a/library/core/src/num/shells/legacy_int_modules.rs
+++ b/library/core/src/num/shells/legacy_int_modules.rs
@@ -5,8 +5,8 @@ macro_rules! legacy_int_module {
     ($T:ident, #[$attr:meta]) => (
         #[$attr]
         #[deprecated(
-            since = "TBD",
-            note = "all constants in this module replaced by associated constants on the type"
+            since = "CURRENT_RUSTC_VERSION",
+            note = "all constants in this module replaced by associated constants on the type",
         )]
         #[rustc_diagnostic_item = concat!(stringify!($T), "_legacy_mod")]
         pub mod $T {
@@ -30,7 +30,7 @@ macro_rules! legacy_int_module {
             /// ```
             ///
             #[$attr]
-            #[deprecated(since = "TBD", note = "replaced by the `MIN` associated constant on this type")]
+            #[deprecated(since = "CURRENT_RUSTC_VERSION", note = "replaced by the `MIN` associated constant on this type")]
             #[rustc_diagnostic_item = concat!(stringify!($T), "_legacy_const_min")]
             pub const MIN: $T = $T::MIN;
 
@@ -50,7 +50,7 @@ macro_rules! legacy_int_module {
             /// ```
             ///
             #[$attr]
-            #[deprecated(since = "TBD", note = "replaced by the `MAX` associated constant on this type")]
+            #[deprecated(since = "CURRENT_RUSTC_VERSION", note = "replaced by the `MAX` associated constant on this type")]
             #[rustc_diagnostic_item = concat!(stringify!($T), "_legacy_const_max")]
             pub const MAX: $T = $T::MAX;
         }

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -4128,7 +4128,7 @@ macro_rules! uint_impl {
         #[rustc_promotable]
         #[inline(always)]
         #[rustc_const_stable(feature = "const_max_value", since = "1.32.0")]
-        #[deprecated(since = "TBD", note = "replaced by the `MIN` associated constant on this type")]
+        #[deprecated(since = "CURRENT_RUSTC_VERSION", note = "replaced by the `MIN` associated constant on this type")]
         #[rustc_diagnostic_item = concat!(stringify!($SelfT), "_legacy_fn_min_value")]
         pub const fn min_value() -> Self { Self::MIN }
 
@@ -4140,7 +4140,7 @@ macro_rules! uint_impl {
         #[rustc_promotable]
         #[inline(always)]
         #[rustc_const_stable(feature = "const_max_value", since = "1.32.0")]
-        #[deprecated(since = "TBD", note = "replaced by the `MAX` associated constant on this type")]
+        #[deprecated(since = "CURRENT_RUSTC_VERSION", note = "replaced by the `MAX` associated constant on this type")]
         #[rustc_diagnostic_item = concat!(stringify!($SelfT), "_legacy_fn_max_value")]
         pub const fn max_value() -> Self { Self::MAX }
 

--- a/library/std/tests/sync/rwlock.rs
+++ b/library/std/tests/sync/rwlock.rs
@@ -7,7 +7,7 @@ use std::sync::{
     Arc, MappedRwLockReadGuard, MappedRwLockWriteGuard, RwLock, RwLockReadGuard, RwLockWriteGuard,
     TryLockError,
 };
-use std::{hint, mem, thread, u32};
+use std::{hint, mem, thread};
 
 use rand::Rng;
 

--- a/src/tools/clippy/tests/ui/confusing_method_to_numeric_cast.fixed
+++ b/src/tools/clippy/tests/ui/confusing_method_to_numeric_cast.fixed
@@ -1,6 +1,6 @@
 #![feature(float_minimum_maximum)]
 #![warn(clippy::confusing_method_to_numeric_cast)]
-#![allow(function_casts_as_integer)]
+#![allow(function_casts_as_integer, deprecated)]
 
 fn main() {
     let _ = u16::MAX as usize; //~ confusing_method_to_numeric_cast

--- a/src/tools/clippy/tests/ui/confusing_method_to_numeric_cast.rs
+++ b/src/tools/clippy/tests/ui/confusing_method_to_numeric_cast.rs
@@ -1,6 +1,6 @@
 #![feature(float_minimum_maximum)]
 #![warn(clippy::confusing_method_to_numeric_cast)]
-#![allow(function_casts_as_integer)]
+#![allow(function_casts_as_integer, deprecated)]
 
 fn main() {
     let _ = u16::max as usize; //~ confusing_method_to_numeric_cast

--- a/src/tools/clippy/tests/ui/legacy_numeric_constants.fixed
+++ b/src/tools/clippy/tests/ui/legacy_numeric_constants.fixed
@@ -1,6 +1,6 @@
 //@aux-build:proc_macros.rs
 #![warn(clippy::legacy_numeric_constants)]
-#![expect(renamed_and_removed_lints, clippy::no_effect, clippy::useless_attribute)]
+#![expect(renamed_and_removed_lints, clippy::no_effect, clippy::useless_attribute, deprecated)]
 
 #[macro_use]
 extern crate proc_macros;

--- a/src/tools/clippy/tests/ui/legacy_numeric_constants.rs
+++ b/src/tools/clippy/tests/ui/legacy_numeric_constants.rs
@@ -1,6 +1,6 @@
 //@aux-build:proc_macros.rs
 #![warn(clippy::legacy_numeric_constants)]
-#![expect(renamed_and_removed_lints, clippy::no_effect, clippy::useless_attribute)]
+#![expect(renamed_and_removed_lints, clippy::no_effect, clippy::useless_attribute, deprecated)]
 
 #[macro_use]
 extern crate proc_macros;

--- a/src/tools/clippy/tests/ui/legacy_numeric_constants_unfixable.rs
+++ b/src/tools/clippy/tests/ui/legacy_numeric_constants_unfixable.rs
@@ -2,6 +2,7 @@
 //@require-annotations-for-level: WARN
 //@aux-build:proc_macros.rs
 #![warn(clippy::legacy_numeric_constants)]
+#![expect(deprecated)]
 
 #[macro_use]
 extern crate proc_macros;

--- a/src/tools/clippy/tests/ui/legacy_numeric_constants_unfixable.stderr
+++ b/src/tools/clippy/tests/ui/legacy_numeric_constants_unfixable.stderr
@@ -1,5 +1,5 @@
 error: importing legacy numeric constants
-  --> tests/ui/legacy_numeric_constants_unfixable.rs:9:5
+  --> tests/ui/legacy_numeric_constants_unfixable.rs:10:5
    |
 LL | use std::u128 as _;
    |     ^^^^^^^^^
@@ -9,7 +9,7 @@ LL | use std::u128 as _;
    = help: to override `-D warnings` add `#[allow(clippy::legacy_numeric_constants)]`
 
 error: importing legacy numeric constants
-  --> tests/ui/legacy_numeric_constants_unfixable.rs:13:24
+  --> tests/ui/legacy_numeric_constants_unfixable.rs:14:24
    |
 LL |     pub use std::{mem, u128};
    |                        ^^^^
@@ -18,7 +18,7 @@ LL |     pub use std::{mem, u128};
    = note: then `u128::<CONST>` will resolve to the respective associated constant
 
 error: importing a legacy numeric constant
-  --> tests/ui/legacy_numeric_constants_unfixable.rs:29:9
+  --> tests/ui/legacy_numeric_constants_unfixable.rs:30:9
    |
 LL |     use std::u32::MAX;
    |         ^^^^^^^^^^^^^
@@ -26,7 +26,7 @@ LL |     use std::u32::MAX;
    = help: remove this import and use the associated constant `u32::MAX` from the primitive type instead
 
 error: importing a legacy numeric constant
-  --> tests/ui/legacy_numeric_constants_unfixable.rs:32:9
+  --> tests/ui/legacy_numeric_constants_unfixable.rs:33:9
    |
 LL |     use std::u8::MIN;
    |         ^^^^^^^^^^^^
@@ -34,7 +34,7 @@ LL |     use std::u8::MIN;
    = help: remove this import and use the associated constant `u8::MIN` from the primitive type instead
 
 error: importing legacy numeric constants
-  --> tests/ui/legacy_numeric_constants_unfixable.rs:36:9
+  --> tests/ui/legacy_numeric_constants_unfixable.rs:37:9
    |
 LL |     use std::u32;
    |         ^^^^^^^^
@@ -43,7 +43,7 @@ LL |     use std::u32;
    = note: then `u32::<CONST>` will resolve to the respective associated constant
 
 error: importing a legacy numeric constant
-  --> tests/ui/legacy_numeric_constants_unfixable.rs:40:9
+  --> tests/ui/legacy_numeric_constants_unfixable.rs:41:9
    |
 LL |     use std::f32::MIN_POSITIVE;
    |         ^^^^^^^^^^^^^^^^^^^^^^
@@ -51,7 +51,7 @@ LL |     use std::f32::MIN_POSITIVE;
    = help: remove this import and use the associated constant `f32::MIN_POSITIVE` from the primitive type instead
 
 error: importing legacy numeric constants
-  --> tests/ui/legacy_numeric_constants_unfixable.rs:44:9
+  --> tests/ui/legacy_numeric_constants_unfixable.rs:45:9
    |
 LL |     use std::i16::*;
    |         ^^^^^^^^
@@ -59,7 +59,7 @@ LL |     use std::i16::*;
    = help: remove this import and use associated constants `i16::<CONST>` from the primitive type instead
 
 error: importing legacy numeric constants
-  --> tests/ui/legacy_numeric_constants_unfixable.rs:21:17
+  --> tests/ui/legacy_numeric_constants_unfixable.rs:22:17
    |
 LL |             use std::u32;
    |                 ^^^^^^^^
@@ -72,7 +72,7 @@ LL |     b!();
    = note: this error originates in the macro `b` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: importing a legacy numeric constant
-  --> tests/ui/legacy_numeric_constants_unfixable.rs:76:9
+  --> tests/ui/legacy_numeric_constants_unfixable.rs:77:9
    |
 LL |     use std::u32::MAX;
    |         ^^^^^^^^^^^^^

--- a/src/tools/clippy/tests/ui/manual_saturating_arithmetic.fixed
+++ b/src/tools/clippy/tests/ui/manual_saturating_arithmetic.fixed
@@ -1,5 +1,5 @@
 #![warn(clippy::manual_saturating_arithmetic)]
-#![allow(clippy::legacy_numeric_constants)]
+#![allow(clippy::legacy_numeric_constants, deprecated)]
 
 fn main() {
     let _ = 1u32.saturating_add(1);

--- a/src/tools/clippy/tests/ui/manual_saturating_arithmetic.rs
+++ b/src/tools/clippy/tests/ui/manual_saturating_arithmetic.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::manual_saturating_arithmetic)]
-#![allow(clippy::legacy_numeric_constants)]
+#![allow(clippy::legacy_numeric_constants, deprecated)]
 
 fn main() {
     let _ = 1u32.checked_add(1).unwrap_or(u32::max_value());

--- a/src/tools/clippy/tests/ui/suspicious_arithmetic_impl.rs
+++ b/src/tools/clippy/tests/ui/suspicious_arithmetic_impl.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::legacy_numeric_constants)]
+#![allow(clippy::legacy_numeric_constants, deprecated)]
 #![warn(clippy::suspicious_arithmetic_impl)]
 use std::ops::{
     Add, AddAssign, BitAnd, BitOr, BitOrAssign, BitXor, Div, DivAssign, Mul, MulAssign, Rem, Shl, Shr, Sub,

--- a/tests/ui/codegen/huge-stacks.rs
+++ b/tests/ui/codegen/huge-stacks.rs
@@ -8,7 +8,7 @@
 // Verifies a program is not miscompiled if it includes a 4GB array on the stack
 
 fn func() {
-    const CAP: usize = std::u32::MAX as usize;
+    const CAP: usize = u32::MAX as usize;
     let mut x: [u8; CAP] = [0; CAP];
     x[2] = 123;
     assert_eq!(x[2], 123);


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/146882)*
<!-- homu-ignore:end -->

This PR implements the last step of rust-lang/rust#68490: marking the `std::u8` etc. modules and the constants in `std::f32` and `std::f64` (but not the undeprecated `consts` submodule) as fully deprecated.

Revival of rust-lang/rust#107587 (cc @tgross35).

Closes: https://github.com/rust-lang/rust/issues/68490

r? libs-api