### PR TITLE
Improve derive suggestion of const param

### DIFF
--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -1305,8 +1305,8 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 {
                     if ty.is_structural_eq_shallow(self.tcx) {
                         diag.span_suggestion(
-                            span,
-                            "add `#[derive(ConstParamTy)]` to the struct",
+                            span.shrink_to_lo(),
+                            format!("add `#[derive(ConstParamTy)]` to the {}", def.descr()),
                             "#[derive(ConstParamTy)]\n",
                             Applicability::MachineApplicable,
                         );
@@ -1314,8 +1314,11 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                         // FIXME(adt_const_params): We should check there's not already an
                         // overlapping `Eq`/`PartialEq` impl.
                         diag.span_suggestion(
-                            span,
-                            "add `#[derive(ConstParamTy, PartialEq, Eq)]` to the struct",
+                            span.shrink_to_lo(),
+                            format!(
+                                "add `#[derive(ConstParamTy, PartialEq, Eq)]` to the {}",
+                                def.descr()
+                            ),
                             "#[derive(ConstParamTy, PartialEq, Eq)]\n",
                             Applicability::MachineApplicable,
                         );

--- a/tests/ui/const-generics/forbid-non-structural_match-types.stderr
+++ b/tests/ui/const-generics/forbid-non-structural_match-types.stderr
@@ -6,8 +6,8 @@ LL | struct D<const X: C>;
    |
 help: add `#[derive(ConstParamTy, PartialEq, Eq)]` to the struct
    |
-LL - struct C;
 LL + #[derive(ConstParamTy, PartialEq, Eq)]
+LL | struct C;
    |
 
 error: aborting due to 1 previous error

--- a/tests/ui/const-generics/issue-80471.stderr
+++ b/tests/ui/const-generics/issue-80471.stderr
@@ -4,10 +4,10 @@ error[E0741]: `Nat` must implement `ConstParamTy` to be used as the type of a co
 LL | fn foo<const N: Nat>() {}
    |                 ^^^
    |
-help: add `#[derive(ConstParamTy)]` to the struct
+help: add `#[derive(ConstParamTy)]` to the enum
    |
-LL - enum Nat {
 LL + #[derive(ConstParamTy)]
+LL | enum Nat {
    |
 
 error: aborting due to 1 previous error

--- a/tests/ui/const-generics/issues/issue-97278.stderr
+++ b/tests/ui/const-generics/issues/issue-97278.stderr
@@ -4,10 +4,10 @@ error[E0741]: `Bar` must implement `ConstParamTy` to be used as the type of a co
 LL | fn test<const BAR: Bar>() {}
    |                    ^^^
    |
-help: add `#[derive(ConstParamTy)]` to the struct
+help: add `#[derive(ConstParamTy)]` to the enum
    |
-LL - enum Bar {
 LL + #[derive(ConstParamTy)]
+LL | enum Bar {
    |
 
 error: aborting due to 1 previous error

--- a/tests/ui/consts/refs_check_const_eq-issue-88384.stderr
+++ b/tests/ui/consts/refs_check_const_eq-issue-88384.stderr
@@ -15,8 +15,8 @@ LL | struct Foo<const T: CompileTimeSettings>;
    |
 help: add `#[derive(ConstParamTy)]` to the struct
    |
-LL - struct CompileTimeSettings {
 LL + #[derive(ConstParamTy)]
+LL | struct CompileTimeSettings {
    |
 
 error[E0741]: `CompileTimeSettings` must implement `ConstParamTy` to be used as the type of a const generic parameter
@@ -27,8 +27,8 @@ LL | impl<const T: CompileTimeSettings> Foo<T> {
    |
 help: add `#[derive(ConstParamTy)]` to the struct
    |
-LL - struct CompileTimeSettings {
 LL + #[derive(ConstParamTy)]
+LL | struct CompileTimeSettings {
    |
 
 error: aborting due to 2 previous errors; 1 warning emitted


### PR DESCRIPTION
Make the suggestion not to remove the adt and use the name of the adt variant in the diagnostic.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

r? @BoxyUwU 