### PR TITLE
Add avr_target_feature

### DIFF
--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -373,6 +373,8 @@ declare_features! (
     (unstable, async_for_loop, "1.77.0", Some(118898)),
     /// Allows `async` trait bound modifier.
     (unstable, async_trait_bounds, "1.85.0", Some(62290)),
+    /// Target features on avr.
+    (unstable, avr_target_feature, "CURRENT_RUSTC_VERSION", Some(146889)),
     /// Allows using Intel AVX10 target features and intrinsics
     (unstable, avx10_target_feature, "1.88.0", Some(138843)),
     /// Target features on bpf.

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -577,6 +577,7 @@ symbols! {
         automatically_derived,
         available_externally,
         avr,
+        avr_target_feature,
         avx,
         avx10_target_feature,
         avx512_target_feature,

--- a/compiler/rustc_target/src/target_features.rs
+++ b/compiler/rustc_target/src/target_features.rs
@@ -898,6 +898,28 @@ static M68K_FEATURES: &[(&str, Stability, ImpliedFeatures)] = &[
     // tidy-alphabetical-end
 ];
 
+static AVR_FEATURES: &[(&str, Stability, ImpliedFeatures)] = &[
+    // tidy-alphabetical-start
+    ("addsubiw", Unstable(sym::avr_target_feature), &[]),
+    ("break", Unstable(sym::avr_target_feature), &[]),
+    ("eijmpcall", Unstable(sym::avr_target_feature), &[]),
+    ("elpm", Unstable(sym::avr_target_feature), &[]),
+    ("elpmx", Unstable(sym::avr_target_feature), &[]),
+    ("ijmpcall", Unstable(sym::avr_target_feature), &[]),
+    ("jmpcall", Unstable(sym::avr_target_feature), &[]),
+    ("lowbytefirst", Unstable(sym::avr_target_feature), &[]),
+    ("lpm", Unstable(sym::avr_target_feature), &[]),
+    ("lpmx", Unstable(sym::avr_target_feature), &[]),
+    ("movw", Unstable(sym::avr_target_feature), &[]),
+    ("mul", Unstable(sym::avr_target_feature), &[]),
+    ("rmw", Unstable(sym::avr_target_feature), &[]),
+    ("spm", Unstable(sym::avr_target_feature), &[]),
+    ("spmx", Unstable(sym::avr_target_feature), &[]),
+    ("sram", Unstable(sym::avr_target_feature), &[]),
+    ("tinyencoding", Unstable(sym::avr_target_feature), &[]),
+    // tidy-alphabetical-end
+];
+
 /// When rustdoc is running, provide a list of all known features so that all their respective
 /// primitives may be documented.
 ///
@@ -919,6 +941,7 @@ pub fn all_rust_features() -> impl Iterator<Item = (&'static str, Stability)> {
         .chain(IBMZ_FEATURES)
         .chain(SPARC_FEATURES)
         .chain(M68K_FEATURES)
+        .chain(AVR_FEATURES)
         .cloned()
         .map(|(f, s, _)| (f, s))
 }
@@ -996,8 +1019,8 @@ impl Target {
             Arch::S390x => IBMZ_FEATURES,
             Arch::Sparc | Arch::Sparc64 => SPARC_FEATURES,
             Arch::M68k => M68K_FEATURES,
+            Arch::Avr => AVR_FEATURES,
             Arch::AmdGpu
-            | Arch::Avr
             | Arch::Msp430
             | Arch::SpirV
             | Arch::Xtensa
@@ -1023,11 +1046,11 @@ impl Target {
                 MIPS_FEATURES_FOR_CORRECT_FIXED_LENGTH_VECTOR_ABI
             }
             Arch::AmdGpu => AMDGPU_FEATURES_FOR_CORRECT_FIXED_LENGTH_VECTOR_ABI,
-            Arch::Nvptx64 | Arch::Bpf | Arch::M68k => &[], // no vector ABI
+            Arch::Nvptx64 | Arch::Bpf | Arch::M68k | Arch::Avr => &[], // no vector ABI
             Arch::CSky => CSKY_FEATURES_FOR_CORRECT_FIXED_LENGTH_VECTOR_ABI,
             // FIXME: for some tier3 targets, we are overly cautious and always give warnings
             // when passing args in vector registers.
-            Arch::Avr | Arch::Msp430 | Arch::SpirV | Arch::Xtensa | Arch::Other(_) => &[],
+            Arch::Msp430 | Arch::SpirV | Arch::Xtensa | Arch::Other(_) => &[],
         }
     }
 

--- a/compiler/rustc_target/src/target_features.rs
+++ b/compiler/rustc_target/src/target_features.rs
@@ -915,7 +915,7 @@ static AVR_FEATURES: &[(&str, Stability, ImpliedFeatures)] = &[
     ("rmw", Unstable(sym::avr_target_feature), &[]),
     ("spm", Unstable(sym::avr_target_feature), &[]),
     ("spmx", Unstable(sym::avr_target_feature), &[]),
-    ("sram", Unstable(sym::avr_target_feature), &[]),
+    ("sram", Forbidden { reason: "devices that have no SRAM are unsupported" }, &[]),
     ("tinyencoding", Unstable(sym::avr_target_feature), &[]),
     // tidy-alphabetical-end
 ];
@@ -1020,11 +1020,7 @@ impl Target {
             Arch::Sparc | Arch::Sparc64 => SPARC_FEATURES,
             Arch::M68k => M68K_FEATURES,
             Arch::Avr => AVR_FEATURES,
-            Arch::AmdGpu
-            | Arch::Msp430
-            | Arch::SpirV
-            | Arch::Xtensa
-            | Arch::Other(_) => &[],
+            Arch::AmdGpu | Arch::Msp430 | Arch::SpirV | Arch::Xtensa | Arch::Other(_) => &[],
         }
     }
 
@@ -1246,6 +1242,12 @@ impl Target {
                 // The "vector" target feature does not affect the ABI for floats
                 // because the vector and float registers overlap.
                 FeatureConstraints { required: &[], incompatible: &["soft-float"] }
+            }
+            Arch::Avr => {
+                // SRAM is minimum requirement for C/C++ in both avr-gcc and Clang,
+                // and backends of them only support assembly for devices have no SRAM.
+                // See the discussion in https://github.com/rust-lang/rust/pull/146900 for more.
+                FeatureConstraints { required: &["sram"], incompatible: &[] }
             }
             _ => NOTHING,
         }

--- a/src/doc/rustc/src/platform-support/avr-none.md
+++ b/src/doc/rustc/src/platform-support/avr-none.md
@@ -68,6 +68,8 @@ the possible variants:
 
 https://github.com/llvm/llvm-project/blob/093d4db2f3c874d4683fb01194b00dbb20e5c713/clang/lib/Basic/Targets/AVR.cpp#L32
 
+Note that devices that have no SRAM are not supported, same as when compiling C/C++ programs with avr-gcc or Clang.
+
 ## Testing
 
 You can use [`simavr`](https://github.com/buserror/simavr) to emulate the

--- a/tests/ui/abi/avr-sram.disable_sram.stderr
+++ b/tests/ui/abi/avr-sram.disable_sram.stderr
@@ -1,0 +1,12 @@
+warning: target feature `sram` cannot be disabled with `-Ctarget-feature`: devices that have no SRAM are unsupported
+   |
+   = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #116344 <https://github.com/rust-lang/rust/issues/116344>
+
+warning: target feature `sram` must be enabled to ensure that the ABI of the current target can be implemented correctly
+   |
+   = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #116344 <https://github.com/rust-lang/rust/issues/116344>
+
+warning: 2 warnings emitted
+

--- a/tests/ui/abi/avr-sram.no_sram.stderr
+++ b/tests/ui/abi/avr-sram.no_sram.stderr
@@ -1,0 +1,7 @@
+warning: target feature `sram` must be enabled to ensure that the ABI of the current target can be implemented correctly
+   |
+   = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #116344 <https://github.com/rust-lang/rust/issues/116344>
+
+warning: 1 warning emitted
+

--- a/tests/ui/abi/avr-sram.rs
+++ b/tests/ui/abi/avr-sram.rs
@@ -1,0 +1,15 @@
+//@ revisions: has_sram no_sram disable_sram
+//@ build-pass
+//@[has_sram] compile-flags: --target avr-none -C target-cpu=atmega328p
+//@[has_sram] needs-llvm-components: avr
+//@[no_sram] compile-flags: --target avr-none -C target-cpu=attiny11
+//@[no_sram] needs-llvm-components: avr
+//@[disable_sram] compile-flags: --target avr-none -C target-cpu=atmega328p -C target-feature=-sram
+//@[disable_sram] needs-llvm-components: avr
+//@ ignore-backends: gcc
+//[no_sram,disable_sram]~? WARN target feature `sram` must be enabled
+//[disable_sram]~? WARN target feature `sram` cannot be disabled with `-Ctarget-feature`
+
+#![feature(no_core)]
+#![no_core]
+#![crate_type = "lib"]

--- a/tests/ui/check-cfg/target_feature.stderr
+++ b/tests/ui/check-cfg/target_feature.stderr
@@ -323,7 +323,6 @@ LL |     cfg!(target_feature = "_UNEXPECTED_VALUE");
 `spe`
 `spm`
 `spmx`
-`sram`
 `ssbs`
 `sse`
 `sse2`

--- a/tests/ui/check-cfg/target_feature.stderr
+++ b/tests/ui/check-cfg/target_feature.stderr
@@ -14,6 +14,7 @@ LL |     cfg!(target_feature = "_UNEXPECTED_VALUE");
 `7e10`
 `a`
 `aclass`
+`addsubiw`
 `adx`
 `aes`
 `altivec`
@@ -57,6 +58,7 @@ LL |     cfg!(target_feature = "_UNEXPECTED_VALUE");
 `bf16`
 `bmi1`
 `bmi2`
+`break`
 `bti`
 `bulk-memory`
 `c`
@@ -83,6 +85,9 @@ LL |     cfg!(target_feature = "_UNEXPECTED_VALUE");
 `e2`
 `ecv`
 `edsp`
+`eijmpcall`
+`elpm`
+`elpmx`
 `elrw`
 `enhanced-sort`
 `ermsb`
@@ -148,6 +153,7 @@ LL |     cfg!(target_feature = "_UNEXPECTED_VALUE");
 `hvxv79`
 `hwdiv`
 `i8mm`
+`ijmpcall`
 `isa-68000`
 `isa-68010`
 `isa-68020`
@@ -156,6 +162,7 @@ LL |     cfg!(target_feature = "_UNEXPECTED_VALUE");
 `isa-68060`
 `isa-68881`
 `isa-68882`
+`jmpcall`
 `jsconv`
 `kl`
 `lahfsahf`
@@ -166,6 +173,9 @@ LL |     cfg!(target_feature = "_UNEXPECTED_VALUE");
 `ld-seq-sa`
 `leoncasa`
 `lor`
+`lowbytefirst`
+`lpm`
+`lpmx`
 `lse`
 `lse128`
 `lse2`
@@ -187,11 +197,13 @@ LL |     cfg!(target_feature = "_UNEXPECTED_VALUE");
 `mops`
 `movbe`
 `movrs`
+`movw`
 `mp`
 `mp1e2`
 `msa`
 `msync`
 `mte`
+`mul`
 `multivalue`
 `mutable-globals`
 `neon`
@@ -256,6 +268,7 @@ LL |     cfg!(target_feature = "_UNEXPECTED_VALUE");
 `reference-types`
 `relax`
 `relaxed-simd`
+`rmw`
 `rtm`
 `rva23u64`
 `sb`
@@ -308,6 +321,9 @@ LL |     cfg!(target_feature = "_UNEXPECTED_VALUE");
 `sme2p1`
 `soft-float`
 `spe`
+`spm`
+`spmx`
+`sram`
 `ssbs`
 `sse`
 `sse2`
@@ -332,6 +348,7 @@ LL |     cfg!(target_feature = "_UNEXPECTED_VALUE");
 `tbm`
 `thumb-mode`
 `thumb2`
+`tinyencoding`
 `tme`
 `transactional-execution`
 `trust`

--- a/tests/ui/target-feature/gate.rs
+++ b/tests/ui/target-feature/gate.rs
@@ -20,6 +20,7 @@
 // gate-test-sparc_target_feature
 // gate-test-x87_target_feature
 // gate-test-m68k_target_feature
+// gate-test-avr_target_feature
 
 #[target_feature(enable = "x87")]
 //~^ ERROR: currently unstable

--- a/tests/ui/target-feature/gate.stderr
+++ b/tests/ui/target-feature/gate.stderr
@@ -1,5 +1,5 @@
 error[E0658]: the target feature `x87` is currently unstable
-  --> $DIR/gate.rs:24:18
+  --> $DIR/gate.rs:25:18
    |
 LL | #[target_feature(enable = "x87")]
    |                  ^^^^^^^^^^^^^^


### PR DESCRIPTION
This adds the following unstable target features (tracking issue: https://github.com/rust-lang/rust/issues/146889):

- The following two are particularly important for properly supporting inline assembly:
  - `tinyencoding`: AVR has devices that reduce the number of registers, similar to RISC-V's RV32E. This feature is necessary to support inline assembly in such devices. (see also https://github.com/rust-lang/rust/pull/146901)
  - `lowbytefirst`: AVR's memory access is per 8-bit, and when writing 16-bit ports, the bytes must be written in a specific order. This order depends on devices, making this feature necessary to write proper inline assembly for such use cases. (see also https://github.com/llvm/llvm-project/commit/2a528760bf20004066effcf8f91fedaabd261903)
- The followings help recognizing whether specific instructions are available:
  - `addsubiw`
  - `break`
  - `eijmpcall`
  - `elpm`
  - `elpmx`
  - `ijmpcall`
  - `jmpcall`
  - `lpm`
  - `lpmx`
  - `movw`
  - `mul`
  - `rmw`
  - `spm`
  - `spmx`

  Of these, all except `addsubiw`, `break`, `ijmpcall`, `lpm`, `rmw`, `spm`, and `spmx` have [corresponding conditional codes in avr-libc](https://github.com/search?q=repo%3Aavrdudes%2Favr-libc+%2F__AVR_HAVE_%2F&type=code&p=1). LLVM also has `des` feature, but I excluded it from this PR because [DES](https://en.wikipedia.org/wiki/Data_Encryption_Standard) is insecure.

- Report future-incompatible warning (https://github.com/rust-lang/rust/issues/116344) for -C target-feature=-sram and -C target-cpu=<device_without_sram> cases because SRAM is minimum requirement for non-assembly language in both avr-gcc and LLVM.
  - See https://github.com/rust-lang/rust/pull/146900#issuecomment-3323558005 for details.

LLVM also has `smallstack`, `wrappingrjmp`, and `memmappedregs` features, but I skipped them because they didn't seem to belong to either of the above categories, but I might have missed something.

(The feature names are match with [definitions in LLVM](https://github.com/llvm/llvm-project/blob/llvmorg-21.1.0/llvm/lib/Target/AVR/AVRDevices.td).)

cc @Patryk27 @Rahix
r? workingjubilee

@rustbot label +O-AVR +A-target-feature


