### PR TITLE
#140368 Mutex/RwLock/ReentrantLock::data_ptr to be const fn

### DIFF
--- a/library/std/src/sync/nonpoison/mutex.rs
+++ b/library/std/src/sync/nonpoison/mutex.rs
@@ -373,7 +373,7 @@ impl<T: ?Sized> Mutex<T> {
     /// or written through after the mutex is dropped.
     #[unstable(feature = "mutex_data_ptr", issue = "140368")]
     // #[unstable(feature = "nonpoison_mutex", issue = "134645")]
-    pub fn data_ptr(&self) -> *mut T {
+    pub const fn data_ptr(&self) -> *mut T {
         self.data.get()
     }
 }

--- a/library/std/src/sync/nonpoison/rwlock.rs
+++ b/library/std/src/sync/nonpoison/rwlock.rs
@@ -495,7 +495,7 @@ impl<T: ?Sized> RwLock<T> {
     /// or written through after the lock is dropped.
     #[unstable(feature = "rwlock_data_ptr", issue = "140368")]
     // #[unstable(feature = "nonpoison_rwlock", issue = "134645")]
-    pub fn data_ptr(&self) -> *mut T {
+    pub const fn data_ptr(&self) -> *mut T {
         self.data.get()
     }
 }

--- a/library/std/src/sync/poison/mutex.rs
+++ b/library/std/src/sync/poison/mutex.rs
@@ -668,7 +668,7 @@ impl<T: ?Sized> Mutex<T> {
     /// are properly synchronized to avoid data races, and that it is not read
     /// or written through after the mutex is dropped.
     #[unstable(feature = "mutex_data_ptr", issue = "140368")]
-    pub fn data_ptr(&self) -> *mut T {
+    pub const fn data_ptr(&self) -> *mut T {
         self.data.get()
     }
 }

--- a/library/std/src/sync/poison/rwlock.rs
+++ b/library/std/src/sync/poison/rwlock.rs
@@ -667,7 +667,7 @@ impl<T: ?Sized> RwLock<T> {
     /// are properly synchronized to avoid data races, and that it is not read
     /// or written through after the lock is dropped.
     #[unstable(feature = "rwlock_data_ptr", issue = "140368")]
-    pub fn data_ptr(&self) -> *mut T {
+    pub const fn data_ptr(&self) -> *mut T {
         self.data.get()
     }
 }

--- a/library/std/src/sync/reentrant_lock.rs
+++ b/library/std/src/sync/reentrant_lock.rs
@@ -355,7 +355,7 @@ impl<T: ?Sized> ReentrantLock<T> {
     /// properly synchronized to avoid data races, and that it is not read
     /// through after the lock is dropped.
     #[unstable(feature = "reentrant_lock_data_ptr", issue = "140368")]
-    pub fn data_ptr(&self) -> *const T {
+    pub const fn data_ptr(&self) -> *const T {
         &raw const self.data
     }
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
For rust-lang/rust#140368. See my [comment in that tracking issue](https://github.com/rust-lang/rust/issues/140368#issuecomment-3321196162).
<!-- homu-ignore:end -->
