### PR TITLE
add regression test

### DIFF
--- a/tests/ui/methods/overflow-if-subtyping.rs
+++ b/tests/ui/methods/overflow-if-subtyping.rs
@@ -1,0 +1,30 @@
+//@ check-pass
+
+// Regression test for #128887.
+#![allow(unconditional_recursion)]
+trait Mappable<T> {
+    type Output;
+}
+
+trait Bound<T> {}
+// Deleting this impl made it compile on beta
+impl<T> Bound<T> for T {}
+
+trait Generic<M> {}
+
+// Deleting the `: Mappable<T>` already made it error on stable.
+struct IndexWithIter<I, M: Mappable<T>, T>(I, M, T);
+
+impl<I, M, T> IndexWithIter<I, M, T>
+where
+    <M as Mappable<T>>::Output: Bound<T>,
+    // Flipping these where bounds causes this to succeed, even when removing
+    // the where-clause on the struct definition.
+    M: Mappable<T>,
+    I: Generic<M>,
+{
+    fn new(x: I) {
+        IndexWithIter::<_, _, _>::new(x);
+    }
+}
+fn main() {}


### PR DESCRIPTION
closes rust-lang/rust#128887

the errors in that issue are due to two separate issues:
- MIR inlining causing the trait solver to hit the recursion limit (partially fixed in rust-lang/rust#129714) 
- using subtyping in method selection for paths (fixed in https://github.com/rust-lang/rust/pull/129073)

We moved any remaining issues due to MIR inlining into https://github.com/rust-lang/rust/issues/131960, but keeping rust-lang/rust#128887 open as well seems unhelpful and confusing.
