### PR TITLE
Make `render_example_with_highlighting` return an `impl fmt::Display`

### DIFF
--- a/src/librustdoc/html/highlight.rs
+++ b/src/librustdoc/html/highlight.rs
@@ -57,18 +57,13 @@ pub(crate) fn render_example_with_highlighting(
     extra_classes: &[String],
 ) -> impl Display {
     fmt::from_fn(move |f| {
-        write_header("rust-example-rendered", None, tooltip, extra_classes).fmt(f)?;
+        write_header("rust-example-rendered", tooltip, extra_classes).fmt(f)?;
         write_code(f, src, None, None, None);
         write_footer(playground_button).fmt(f)
     })
 }
 
-fn write_header(
-    class: &str,
-    extra_content: Option<&str>,
-    tooltip: Option<&Tooltip>,
-    extra_classes: &[String],
-) -> impl Display {
+fn write_header(class: &str, tooltip: Option<&Tooltip>, extra_classes: &[String]) -> impl Display {
     fmt::from_fn(move |f| {
         write!(
             f,
@@ -107,10 +102,6 @@ fn write_header(
             });
 
             write!(f, "<a href=\"#\" class=\"tooltip\" title=\"{tooltip}\">ⓘ</a>")?;
-        }
-
-        if let Some(extra) = extra_content {
-            f.write_str(extra)?;
         }
 
         let classes = fmt::from_fn(|f| {

--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -321,18 +321,22 @@ impl<'a, I: Iterator<Item = Event<'a>>> Iterator for CodeBlocks<'_, 'a, I> {
             ))
         });
 
-        let tooltip = if ignore == Ignore::All {
-            highlight::Tooltip::IgnoreAll
-        } else if let Ignore::Some(platforms) = ignore {
-            highlight::Tooltip::IgnoreSome(platforms)
-        } else if compile_fail {
-            highlight::Tooltip::CompileFail
-        } else if should_panic {
-            highlight::Tooltip::ShouldPanic
-        } else if explicit_edition {
-            highlight::Tooltip::Edition(edition)
-        } else {
-            highlight::Tooltip::None
+        let tooltip = {
+            use highlight::Tooltip::*;
+
+            if ignore == Ignore::All {
+                Some(IgnoreAll)
+            } else if let Ignore::Some(platforms) = ignore {
+                Some(IgnoreSome(platforms))
+            } else if compile_fail {
+                Some(CompileFail)
+            } else if should_panic {
+                Some(ShouldPanic)
+            } else if explicit_edition {
+                Some(Edition(edition))
+            } else {
+                None
+            }
         };
 
         // insert newline to clearly separate it from the
@@ -341,7 +345,7 @@ impl<'a, I: Iterator<Item = Event<'a>>> Iterator for CodeBlocks<'_, 'a, I> {
             "\n{}",
             highlight::render_example_with_highlighting(
                 &text,
-                &tooltip,
+                tooltip.as_ref(),
                 playground_button.as_deref(),
                 &added_classes,
             )

--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -337,15 +337,14 @@ impl<'a, I: Iterator<Item = Event<'a>>> Iterator for CodeBlocks<'_, 'a, I> {
 
         // insert newline to clearly separate it from the
         // previous block so we can shorten the html output
-        let mut s = String::new();
-        s.push('\n');
-
-        highlight::render_example_with_highlighting(
-            &text,
-            &mut s,
-            tooltip,
-            playground_button.as_deref(),
-            &added_classes,
+        let s = format!(
+            "\n{}",
+            highlight::render_example_with_highlighting(
+                &text,
+                &tooltip,
+                playground_button.as_deref(),
+                &added_classes,
+            )
         );
         Some(Event::Html(s.into()))
     }


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
Removes some more usages of `write_str`. Shouldn't affect runtime, but makes the codebase a bit more consistent.
Each commit can be reviewed separately