### PR TITLE
Rename `eval_always` query modifier to `no_incremental`

### DIFF
--- a/compiler/rustc_lint/src/expect.rs
+++ b/compiler/rustc_lint/src/expect.rs
@@ -36,7 +36,7 @@ fn check_expectations(tcx: TyCtxt<'_>, tool_filter: Option<Symbol>) {
                 (attr_id, lint_index)
             }
             LintExpectationId::Stable { hir_id, attr_index, lint_index: Some(lint_index) } => {
-                // We are an `eval_always` query, so looking at the attribute's `AttrId` is ok.
+                // We are an `no_incremental` query, so looking at the attribute's `AttrId` is ok.
                 let attr_id = tcx.hir_attrs(hir_id)[attr_index as usize].id();
 
                 (attr_id, lint_index)

--- a/compiler/rustc_macros/src/query.rs
+++ b/compiler/rustc_macros/src/query.rs
@@ -108,7 +108,7 @@ struct QueryModifiers {
     anon: Option<Ident>,
 
     /// Always evaluate the query, ignoring its dependencies
-    eval_always: Option<Ident>,
+    no_incremental: Option<Ident>,
 
     /// Whether the query has a call depth limit
     depth_limit: Option<Ident>,
@@ -141,7 +141,7 @@ fn parse_query_modifiers(input: ParseStream<'_>) -> Result<QueryModifiers> {
     let mut cycle_stash = None;
     let mut no_hash = None;
     let mut anon = None;
-    let mut eval_always = None;
+    let mut no_incremental = None;
     let mut depth_limit = None;
     let mut separate_provide_extern = None;
     let mut feedable = None;
@@ -199,8 +199,8 @@ fn parse_query_modifiers(input: ParseStream<'_>) -> Result<QueryModifiers> {
             try_insert!(no_hash = modifier);
         } else if modifier == "anon" {
             try_insert!(anon = modifier);
-        } else if modifier == "eval_always" {
-            try_insert!(eval_always = modifier);
+        } else if modifier == "no_incremental" {
+            try_insert!(no_incremental = modifier);
         } else if modifier == "depth_limit" {
             try_insert!(depth_limit = modifier);
         } else if modifier == "separate_provide_extern" {
@@ -225,7 +225,7 @@ fn parse_query_modifiers(input: ParseStream<'_>) -> Result<QueryModifiers> {
         cycle_stash,
         no_hash,
         anon,
-        eval_always,
+        no_incremental,
         depth_limit,
         separate_provide_extern,
         feedable,
@@ -372,7 +372,7 @@ pub(super) fn rustc_queries(input: TokenStream) -> TokenStream {
             cycle_stash,
             no_hash,
             anon,
-            eval_always,
+            no_incremental,
             depth_limit,
             separate_provide_extern,
             return_result_from_ensure_ok,
@@ -408,9 +408,9 @@ pub(super) fn rustc_queries(input: TokenStream) -> TokenStream {
                 "Query {name} cannot be both `feedable` and `anon`."
             );
             assert!(
-                modifiers.eval_always.is_none(),
+                modifiers.no_incremental.is_none(),
                 feedable.span(),
-                "Query {name} cannot be both `feedable` and `eval_always`."
+                "Query {name} cannot be both `feedable` and `no_incremental`."
             );
             feedable_queries.extend(quote! {
                 [#attribute_stream] fn #name(#arg) #result,

--- a/compiler/rustc_middle/src/query/plumbing.rs
+++ b/compiler/rustc_middle/src/query/plumbing.rs
@@ -20,7 +20,7 @@ use crate::ty::TyCtxt;
 
 pub struct DynamicQuery<'tcx, C: QueryCache> {
     pub name: &'static str,
-    pub eval_always: bool,
+    pub no_incremental: bool,
     pub dep_kind: DepKind,
     pub handle_cycle_error: HandleCycleError,
     // Offset of this query's state field in the QueryStates struct

--- a/compiler/rustc_query_impl/src/lib.rs
+++ b/compiler/rustc_query_impl/src/lib.rs
@@ -167,8 +167,8 @@ where
     }
 
     #[inline(always)]
-    fn eval_always(self) -> bool {
-        self.dynamic.eval_always
+    fn no_incremental(self) -> bool {
+        self.dynamic.no_incremental
     }
 
     #[inline(always)]

--- a/compiler/rustc_query_system/src/dep_graph/dep_node.rs
+++ b/compiler/rustc_query_system/src/dep_graph/dep_node.rs
@@ -235,7 +235,7 @@ pub struct DepKindStruct<Tcx: DepContext> {
     /// Eval-always queries do not track their dependencies, and are always recomputed, even if
     /// their inputs have not changed since the last compiler invocation. The result is still
     /// cached within one compiler invocation.
-    pub is_eval_always: bool,
+    pub is_no_incremental: bool,
 
     /// Whether the query key can be recovered from the hashed fingerprint.
     /// See [DepNodeParams] trait for the behaviour of each key type.

--- a/compiler/rustc_query_system/src/dep_graph/mod.rs
+++ b/compiler/rustc_query_system/src/dep_graph/mod.rs
@@ -48,8 +48,8 @@ pub trait DepContext: Copy {
 
     #[inline(always)]
     /// Return whether this kind always require evaluation.
-    fn is_eval_always(self, kind: DepKind) -> bool {
-        self.dep_kind_info(kind).is_eval_always
+    fn is_no_incremental(self, kind: DepKind) -> bool {
+        self.dep_kind_info(kind).is_no_incremental
     }
 
     /// Try to force a dep node to execute and see if it's green.

--- a/compiler/rustc_query_system/src/query/config.rs
+++ b/compiler/rustc_query_system/src/query/config.rs
@@ -63,7 +63,7 @@ pub trait QueryConfig<Qcx: QueryContext>: Copy {
     ) -> Self::Value;
 
     fn anon(self) -> bool;
-    fn eval_always(self) -> bool;
+    fn no_incremental(self) -> bool;
     fn depth_limit(self) -> bool;
     fn feedable(self) -> bool;
 

--- a/compiler/rustc_query_system/src/query/plumbing.rs
+++ b/compiler/rustc_query_system/src/query/plumbing.rs
@@ -520,7 +520,7 @@ where
     Q: QueryConfig<Qcx>,
     Qcx: QueryContext,
 {
-    if !query.anon() && !query.eval_always() {
+    if !query.anon() && !query.no_incremental() {
         // `to_dep_node` is expensive for some `DepKind`s.
         let dep_node =
             dep_node_opt.get_or_insert_with(|| query.construct_dep_node(*qcx.dep_context(), &key));
@@ -761,7 +761,7 @@ where
     Q: QueryConfig<Qcx>,
     Qcx: QueryContext,
 {
-    if query.eval_always() {
+    if query.no_incremental() {
         return (true, None);
     }
 

--- a/src/doc/rustc-dev-guide/src/queries/incremental-compilation-in-detail.md
+++ b/src/doc/rustc-dev-guide/src/queries/incremental-compilation-in-detail.md
@@ -410,16 +410,16 @@ The query system allows for applying [modifiers][mod] to queries. These
 modifiers affect certain aspects of how the system treats the query with
 respect to incremental compilation:
 
- - `eval_always` - A query with the `eval_always` attribute is re-executed
+ - `no_incremental` - A query with the `no_incremental` attribute is re-executed
    unconditionally during incremental compilation. I.e. the system will not
-   even try to mark the query's dep-node as green. This attribute has two use
-   cases:
+   even try to mark the query's dep-node as green, but the result is still cached for use in the same compilation.
+   This attribute has two use cases:
 
-    - `eval_always` queries can read inputs (from files, global state, etc).
+    - `no_incremental` queries can read inputs (from files, global state, etc).
       They can also produce side effects like writing to files and changing global state.
 
     - Some queries are very likely to be re-evaluated because their result
-      depends on the entire source code. In this case `eval_always` can be used
+      depends on the entire source code. In this case `no_incremental` can be used
       as an optimization because the system can skip recording dependencies in
       the first place.
 
@@ -472,7 +472,7 @@ respect to incremental compilation:
 
 ## The projection query pattern
 
-It's interesting to note that `eval_always` and `no_hash` can be used together
+It's interesting to note that `no_incremental` and `no_hash` can be used together
 in the so-called "projection query" pattern. It is often the case that there is
 one query that depends on the entirety of the compiler's input (e.g. the indexed HIR)
 and another query that projects individual values out of this monolithic value
@@ -505,10 +505,10 @@ red. As a consequence `foo(a)` needs to be re-executed; but `bar(b)` and
 directly depended on `monolithic_query` then all of them would have had to be
 re-evaluated.
 
-This pattern works even without `eval_always` and `no_hash` but the two
+This pattern works even without `no_incremental` and `no_hash`, but the two
 modifiers can be used to avoid unnecessary overhead. If the monolithic query
 is likely to change at any minor modification of the compiler's input it makes
-sense to mark it as `eval_always`, thus getting rid of its dependency tracking
+sense to mark it as `no_incremental`, thus getting rid of its dependency tracking
 cost. And it always makes sense to mark the monolithic query as `no_hash`
 because we have the projections to take care of keeping things green as much
 as possible.


### PR DESCRIPTION
`eval_always` gives the impression that the query is evaluated every time it's called. (thus, evaluated always). Turns out this isn't the truth, it just affects how the dependency graph behaves with that node (i.e. not even trying to mark it green)

This commit renames `eval_always` to `no_incremental`, I thought about `always_red_on_depgraph` or similar but I don't think that expecting every query author to know what "red" means in this context is preferable or useful.
