### PR TITLE
Add vsx register support for ppc inline asm, and implement preserves_flag option

### DIFF
--- a/compiler/rustc_codegen_gcc/src/asm.rs
+++ b/compiler/rustc_codegen_gcc/src/asm.rs
@@ -546,9 +546,16 @@ impl<'a, 'gcc, 'tcx> AsmBuilderMethods<'tcx> for Builder<'a, 'gcc, 'tcx> {
         }
 
         if !options.contains(InlineAsmOptions::PRESERVES_FLAGS) {
-            // TODO(@Commeownist): I'm not 100% sure this one clobber is sufficient
-            // on all architectures. For instance, what about FP stack?
-            extended_asm.add_clobber("cc");
+            match asm_arch {
+                InlineAsmArch::PowerPC | InlineAsmArch::PowerPC64 => {
+                    // "cc" is cr0 on powerpc.
+                }
+                // TODO(@Commeownist): I'm not 100% sure this one clobber is sufficient
+                // on all architectures. For instance, what about FP stack?
+                _ => {
+                    extended_asm.add_clobber("cc");
+                }
+            }
         }
         if !options.contains(InlineAsmOptions::NOMEM) {
             extended_asm.add_clobber("memory");

--- a/compiler/rustc_codegen_gcc/src/asm.rs
+++ b/compiler/rustc_codegen_gcc/src/asm.rs
@@ -698,6 +698,7 @@ fn reg_class_to_gcc(reg_class: InlineAsmRegClass) -> &'static str {
         InlineAsmRegClass::PowerPC(PowerPCInlineAsmRegClass::reg_nonzero) => "b",
         InlineAsmRegClass::PowerPC(PowerPCInlineAsmRegClass::freg) => "f",
         InlineAsmRegClass::PowerPC(PowerPCInlineAsmRegClass::vreg) => "v",
+        InlineAsmRegClass::PowerPC(PowerPCInlineAsmRegClass::vsreg) => "wa",
         InlineAsmRegClass::PowerPC(
             PowerPCInlineAsmRegClass::cr
             | PowerPCInlineAsmRegClass::ctr
@@ -778,9 +779,9 @@ fn dummy_output_type<'gcc, 'tcx>(cx: &CodegenCx<'gcc, 'tcx>, reg: InlineAsmRegCl
         InlineAsmRegClass::PowerPC(PowerPCInlineAsmRegClass::reg) => cx.type_i32(),
         InlineAsmRegClass::PowerPC(PowerPCInlineAsmRegClass::reg_nonzero) => cx.type_i32(),
         InlineAsmRegClass::PowerPC(PowerPCInlineAsmRegClass::freg) => cx.type_f64(),
-        InlineAsmRegClass::PowerPC(PowerPCInlineAsmRegClass::vreg) => {
-            cx.type_vector(cx.type_i32(), 4)
-        }
+        InlineAsmRegClass::PowerPC(
+            PowerPCInlineAsmRegClass::vreg | PowerPCInlineAsmRegClass::vsreg,
+        ) => cx.type_vector(cx.type_i32(), 4),
         InlineAsmRegClass::PowerPC(
             PowerPCInlineAsmRegClass::cr
             | PowerPCInlineAsmRegClass::ctr
@@ -957,6 +958,13 @@ fn modifier_to_gcc(
         InlineAsmRegClass::LoongArch(_) => None,
         InlineAsmRegClass::Mips(_) => None,
         InlineAsmRegClass::Nvptx(_) => None,
+        InlineAsmRegClass::PowerPC(PowerPCInlineAsmRegClass::vsreg) => {
+            if modifier.is_none() {
+                Some('x')
+            } else {
+                modifier
+            }
+        }
         InlineAsmRegClass::PowerPC(_) => None,
         InlineAsmRegClass::RiscV(RiscVInlineAsmRegClass::reg)
         | InlineAsmRegClass::RiscV(RiscVInlineAsmRegClass::freg) => None,

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -2410,6 +2410,7 @@ symbols! {
         volatile_store,
         vreg,
         vreg_low16,
+        vsreg,
         vsx,
         vtable_align,
         vtable_size,

--- a/compiler/rustc_target/src/asm/mod.rs
+++ b/compiler/rustc_target/src/asm/mod.rs
@@ -1251,9 +1251,17 @@ impl InlineAsmClobberAbi {
                     r3, r4, r5, r6, r7,
                     r8, r9, r10, r11, r12,
 
-                    // f0-f13
+                    // f0-f13 and their vsx overlays.
                     f0, f1, f2, f3, f4, f5, f6, f7,
                     f8, f9, f10, f11, f12, f13,
+                    vs0, vs1, vs2, vs3, vs4, vs5, vs6, vs7,
+                    vs8, vs9, vs10, vs11, vs12, vs13,
+
+                    // vs14-31, the fpr portion is saved, but the rest of the register is volatile.
+                    // We can't express that here, so mark the entire vsx register as volatile.
+                    vs14, vs15, vs16, vs17, vs18, vs19, vs20,
+                    vs21, vs22, vs23, vs24, vs25, vs26, vs27,
+                    vs28, vs29, vs30, vs31,
 
                     // v0-v19
                     v0, v1, v2, v3, v4, v5, v6, v7,

--- a/compiler/rustc_target/src/asm/powerpc.rs
+++ b/compiler/rustc_target/src/asm/powerpc.rs
@@ -12,6 +12,7 @@ def_reg_class! {
         reg_nonzero,
         freg,
         vreg,
+        vsreg,
         cr,
         ctr,
         lr,
@@ -58,6 +59,10 @@ impl PowerPCInlineAsmRegClass {
                 altivec: VecI8(16), VecI16(8), VecI32(4), VecF32(4);
                 vsx: F32, F64, VecI64(2), VecF64(2);
             },
+            // VSX is a superset of altivec.
+            Self::vsreg => types! {
+                vsx: F32, F64, VecI8(16), VecI16(8), VecI32(4), VecI64(2), VecF32(4), VecF64(2);
+            },
             Self::cr | Self::ctr | Self::lr | Self::xer => &[],
         }
     }
@@ -86,7 +91,7 @@ fn reserved_v20to31(
 ) -> Result<(), &'static str> {
     if target.is_like_aix {
         match &*target.options.abi {
-            "vec-default" => Err("v20-v31 are reserved on vec-default ABI"),
+            "vec-default" => Err("v20-v31 (vs52-vs63) are reserved on vec-default ABI"),
             "vec-extabi" => Ok(()),
             _ => unreachable!("unrecognized AIX ABI"),
         }
@@ -188,6 +193,71 @@ def_regs! {
         v29: vreg = ["v29"] % reserved_v20to31,
         v30: vreg = ["v30"] % reserved_v20to31,
         v31: vreg = ["v31"] % reserved_v20to31,
+        vs0: vsreg = ["vs0"],
+        vs1: vsreg = ["vs1"],
+        vs2: vsreg = ["vs2"],
+        vs3: vsreg = ["vs3"],
+        vs4: vsreg = ["vs4"],
+        vs5: vsreg = ["vs5"],
+        vs6: vsreg = ["vs6"],
+        vs7: vsreg = ["vs7"],
+        vs8: vsreg = ["vs8"],
+        vs9: vsreg = ["vs9"],
+        vs10: vsreg = ["vs10"],
+        vs11: vsreg = ["vs11"],
+        vs12: vsreg = ["vs12"],
+        vs13: vsreg = ["vs13"],
+        vs14: vsreg = ["vs14"],
+        vs15: vsreg = ["vs15"],
+        vs16: vsreg = ["vs16"],
+        vs17: vsreg = ["vs17"],
+        vs18: vsreg = ["vs18"],
+        vs19: vsreg = ["vs19"],
+        vs20: vsreg = ["vs20"],
+        vs21: vsreg = ["vs21"],
+        vs22: vsreg = ["vs22"],
+        vs23: vsreg = ["vs23"],
+        vs24: vsreg = ["vs24"],
+        vs25: vsreg = ["vs25"],
+        vs26: vsreg = ["vs26"],
+        vs27: vsreg = ["vs27"],
+        vs28: vsreg = ["vs28"],
+        vs29: vsreg = ["vs29"],
+        vs30: vsreg = ["vs30"],
+        vs31: vsreg = ["vs31"],
+        vs32: vsreg = ["vs32"],
+        vs33: vsreg = ["vs33"],
+        vs34: vsreg = ["vs34"],
+        vs35: vsreg = ["vs35"],
+        vs36: vsreg = ["vs36"],
+        vs37: vsreg = ["vs37"],
+        vs38: vsreg = ["vs38"],
+        vs39: vsreg = ["vs39"],
+        vs40: vsreg = ["vs40"],
+        vs41: vsreg = ["vs41"],
+        vs42: vsreg = ["vs42"],
+        vs43: vsreg = ["vs43"],
+        vs44: vsreg = ["vs44"],
+        vs45: vsreg = ["vs45"],
+        vs46: vsreg = ["vs46"],
+        vs47: vsreg = ["vs47"],
+        vs48: vsreg = ["vs48"],
+        vs49: vsreg = ["vs49"],
+        vs50: vsreg = ["vs50"],
+        vs51: vsreg = ["vs51"],
+        // vs52 - vs63 are aliases of v20-v31.
+        vs52: vsreg = ["vs52"] % reserved_v20to31,
+        vs53: vsreg = ["vs53"] % reserved_v20to31,
+        vs54: vsreg = ["vs54"] % reserved_v20to31,
+        vs55: vsreg = ["vs55"] % reserved_v20to31,
+        vs56: vsreg = ["vs56"] % reserved_v20to31,
+        vs57: vsreg = ["vs57"] % reserved_v20to31,
+        vs58: vsreg = ["vs58"] % reserved_v20to31,
+        vs59: vsreg = ["vs59"] % reserved_v20to31,
+        vs60: vsreg = ["vs60"] % reserved_v20to31,
+        vs61: vsreg = ["vs61"] % reserved_v20to31,
+        vs62: vsreg = ["vs62"] % reserved_v20to31,
+        vs63: vsreg = ["vs63"] % reserved_v20to31,
         cr: cr = ["cr"],
         cr0: cr = ["cr0"],
         cr1: cr = ["cr1"],
@@ -245,6 +315,15 @@ impl PowerPCInlineAsmReg {
             (v8, "8"), (v9, "9"), (v10, "10"), (v11, "11"), (v12, "12"), (v13, "13"), (v14, "14"), (v15, "15");
             (v16, "16"), (v17, "17"), (v18, "18"), (v19, "19"), (v20, "20"), (v21, "21"), (v22, "22"), (v23, "23");
             (v24, "24"), (v25, "25"), (v26, "26"), (v27, "27"), (v28, "28"), (v29, "29"), (v30, "30"), (v31, "31");
+            (vs0, "0"), (vs1, "1"), (vs2, "2"), (vs3, "3"), (vs4, "4"), (vs5, "5"), (vs6, "6"), (vs7, "7"),
+            (vs8, "8"), (vs9, "9"), (vs10, "10"), (vs11, "11"), (vs12, "12"), (vs13, "13"), (vs14, "14"),
+            (vs15, "15"), (vs16, "16"), (vs17, "17"), (vs18, "18"), (vs19, "19"), (vs20, "20"), (vs21, "21"),
+            (vs22, "22"), (vs23, "23"), (vs24, "24"), (vs25, "25"), (vs26, "26"), (vs27, "27"), (vs28, "28"),
+            (vs29, "29"), (vs30, "30"), (vs31, "31"), (vs32, "32"), (vs33, "33"), (vs34, "34"), (vs35, "35"),
+            (vs36, "36"), (vs37, "37"), (vs38, "38"), (vs39, "39"), (vs40, "40"), (vs41, "41"), (vs42, "42"),
+            (vs43, "43"), (vs44, "44"), (vs45, "45"), (vs46, "46"), (vs47, "47"), (vs48, "48"), (vs49, "49"),
+            (vs50, "50"), (vs51, "51"), (vs52, "52"), (vs53, "53"), (vs54, "54"), (vs55, "55"), (vs56, "56"),
+            (vs57, "57"), (vs58, "58"), (vs59, "59"), (vs60, "60"), (vs61, "61"), (vs62, "62"), (vs63, "63"),
             (cr, "cr");
             (cr0, "0"), (cr1, "1"), (cr2, "2"), (cr3, "3"), (cr4, "4"), (cr5, "5"), (cr6, "6"), (cr7, "7");
             (ctr, "ctr");
@@ -276,8 +355,77 @@ impl PowerPCInlineAsmReg {
             };
         }
         reg_conflicts! {
-            cr : cr0 cr1 cr2 cr3 cr4 cr5 cr6 cr7;
+            cr : cr0 cr1 cr2 cr3 cr4 cr5 cr6 cr7,
+            // f0-f31 overlap half of each of vs0-vs32.
+            vs0 : f0,
+            vs1 : f1,
+            vs2 : f2,
+            vs3 : f3,
+            vs4 : f4,
+            vs5 : f5,
+            vs6 : f6,
+            vs7 : f7,
+            vs8 : f8,
+            vs9 : f9,
+            vs10 : f10,
+            vs11 : f11,
+            vs12 : f12,
+            vs13 : f13,
+            vs14 : f14,
+            vs15 : f15,
+            vs16 : f16,
+            vs17 : f17,
+            vs18 : f18,
+            vs19 : f19,
+            vs20 : f20,
+            vs21 : f21,
+            vs22 : f22,
+            vs23 : f23,
+            vs24 : f24,
+            vs25 : f25,
+            vs26 : f26,
+            vs27 : f27,
+            vs28 : f28,
+            vs29 : f29,
+            vs30 : f30,
+            vs31 : f31,
+            // vs32-v63 are aliases of v0-v31
+            vs32 : v0,
+            vs33 : v1,
+            vs34 : v2,
+            vs35 : v3,
+            vs36 : v4,
+            vs37 : v5,
+            vs38 : v6,
+            vs39 : v7,
+            vs40 : v8,
+            vs41 : v9,
+            vs42 : v10,
+            vs43 : v11,
+            vs44 : v12,
+            vs45 : v13,
+            vs46 : v14,
+            vs47 : v15,
+            vs48 : v16,
+            vs49 : v17,
+            vs50 : v18,
+            vs51 : v19,
+            vs52 : v20,
+            vs53 : v21,
+            vs54 : v22,
+            vs55 : v23,
+            vs56 : v24,
+            vs57 : v25,
+            vs58 : v26,
+            vs59 : v27,
+            vs60 : v28,
+            vs61 : v29,
+            vs62 : v30,
+            vs63 : v31;
         }
-        // f0-f31 (vsr0-vsr31) and v0-v31 (vsr32-vsr63) do not conflict.
+        // For more detail on how vsx, vmx (altivec), fpr, and mma registers overlap
+        // see OpenPOWER ISA 3.1C, Book I, Section 7.2.1.1 through 7.2.1.3.
+        //
+        // https://files.openpower.foundation/s/9izgC5Rogi5Ywmm
     }
 }

--- a/src/doc/unstable-book/src/language-features/asm-experimental-arch.md
+++ b/src/doc/unstable-book/src/language-features/asm-experimental-arch.md
@@ -35,6 +35,7 @@ This feature tracks `asm!` and `global_asm!` support for the following architect
 | PowerPC      | `reg_nonzero`  | `r[3-12]`, `r[14-28]`              | `b`                  |
 | PowerPC      | `freg`         | `f[0-31]`                          | `f`                  |
 | PowerPC      | `vreg`         | `v[0-31]`                          | `v`                  |
+| PowerPC      | `vsreg         | `vs[0-63]`                         | `wa`                 |
 | PowerPC      | `cr`           | `cr[0-7]`, `cr`                    | Only clobbers        |
 | PowerPC      | `ctr`          | `ctr`                              | Only clobbers        |
 | PowerPC      | `lr`           | `lr`                               | Only clobbers        |
@@ -79,6 +80,7 @@ This feature tracks `asm!` and `global_asm!` support for the following architect
 | PowerPC      | `freg`                          | None           | `f32`, `f64`                            |
 | PowerPC      | `vreg`                          | `altivec`      | `i8x16`, `i16x8`, `i32x4`, `f32x4`      |
 | PowerPC      | `vreg`                          | `vsx`          | `f32`, `f64`, `i64x2`, `f64x2`          |
+| PowerPC      | `vsreg`                         | `vsx`          | The union of vsx and altivec vreg types |
 | PowerPC      | `cr`                            | N/A            | Only clobbers                           |
 | PowerPC      | `ctr`                           | N/A            | Only clobbers                           |
 | PowerPC      | `lr`                            | N/A            | Only clobbers                           |
@@ -185,6 +187,7 @@ This feature tracks `asm!` and `global_asm!` support for the following architect
 | PowerPC      | `reg_nonzero`  | None     | `3`            | None          |
 | PowerPC      | `freg`         | None     | `0`            | None          |
 | PowerPC      | `vreg`         | None     | `0`            | None          |
+| PowerPC      | `vsreg`        | None     | `0`            | None          |
 | SPARC        | `reg`          | None     | `%o0`          | None          |
 | CSKY         | `reg`          | None     | `r0`           | None          |
 | CSKY         | `freg`         | None     | `f0`           | None          |

--- a/tests/assembly-llvm/asm/powerpc-types.rs
+++ b/tests/assembly-llvm/asm/powerpc-types.rs
@@ -223,6 +223,94 @@ check!(vreg_f32, f32, vreg, "vmr");
 #[cfg(vsx)]
 check!(vreg_f64, f64, vreg, "vmr");
 
+// powerpc_vsx-LABEL: vsreg_i8x16:
+// powerpc_vsx: #APP
+// powerpc_vsx: xvsqrtdp {{[0-9]+}}, {{[0-9]+}}
+// powerpc_vsx: #NO_APP
+// powerpc64_vsx-LABEL: vsreg_i8x16:
+// powerpc64_vsx: #APP
+// powerpc64_vsx: xvsqrtdp {{[0-9]+}}, {{[0-9]+}}
+// powerpc64_vsx: #NO_APP
+#[cfg(vsx)]
+check!(vsreg_i8x16, i8x16, vsreg, "xvsqrtdp");
+
+// powerpc_vsx-LABEL: vsreg_i16x8:
+// powerpc_vsx: #APP
+// powerpc_vsx: xvsqrtdp {{[0-9]+}}, {{[0-9]+}}
+// powerpc_vsx: #NO_APP
+// powerpc64_vsx-LABEL: vsreg_i16x8:
+// powerpc64_vsx: #APP
+// powerpc64_vsx: xvsqrtdp {{[0-9]+}}, {{[0-9]+}}
+// powerpc64_vsx: #NO_APP
+#[cfg(vsx)]
+check!(vsreg_i16x8, i16x8, vsreg, "xvsqrtdp");
+
+// powerpc_vsx-LABEL: vsreg_i32x4:
+// powerpc_vsx: #APP
+// powerpc_vsx: xvsqrtdp {{[0-9]+}}, {{[0-9]+}}
+// powerpc_vsx: #NO_APP
+// powerpc64_vsx-LABEL: vsreg_i32x4:
+// powerpc64_vsx: #APP
+// powerpc64_vsx: xvsqrtdp {{[0-9]+}}, {{[0-9]+}}
+// powerpc64_vsx: #NO_APP
+#[cfg(vsx)]
+check!(vsreg_i32x4, i32x4, vsreg, "xvsqrtdp");
+
+// powerpc_vsx-LABEL: vsreg_i64x2:
+// powerpc_vsx: #APP
+// powerpc_vsx: xvsqrtdp {{[0-9]+}}, {{[0-9]+}}
+// powerpc_vsx: #NO_APP
+// powerpc64_vsx-LABEL: vsreg_i64x2:
+// powerpc64_vsx: #APP
+// powerpc64_vsx: xvsqrtdp {{[0-9]+}}, {{[0-9]+}}
+// powerpc64_vsx: #NO_APP
+#[cfg(vsx)]
+check!(vsreg_i64x2, i64x2, vsreg, "xvsqrtdp");
+
+// powerpc_vsx-LABEL: vsreg_f32x4:
+// powerpc_vsx: #APP
+// powerpc_vsx: xvsqrtdp {{[0-9]+}}, {{[0-9]+}}
+// powerpc_vsx: #NO_APP
+// powerpc64_vsx-LABEL: vsreg_f32x4:
+// powerpc64_vsx: #APP
+// powerpc64_vsx: xvsqrtdp {{[0-9]+}}, {{[0-9]+}}
+// powerpc64_vsx: #NO_APP
+#[cfg(vsx)]
+check!(vsreg_f32x4, f32x4, vsreg, "xvsqrtdp");
+
+// powerpc_vsx-LABEL: vsreg_f64x2:
+// powerpc_vsx: #APP
+// powerpc_vsx: xvsqrtdp {{[0-9]+}}, {{[0-9]+}}
+// powerpc_vsx: #NO_APP
+// powerpc64_vsx-LABEL: vsreg_f64x2:
+// powerpc64_vsx: #APP
+// powerpc64_vsx: xvsqrtdp {{[0-9]+}}, {{[0-9]+}}
+// powerpc64_vsx: #NO_APP
+#[cfg(vsx)]
+check!(vsreg_f64x2, f64x2, vsreg, "xvsqrtdp");
+
+// powerpc_vsx-LABEL: vsreg_f32:
+// powerpc_vsx: #APP
+// powerpc_vsx: xvsqrtdp {{[0-9]+}}, {{[0-9]+}}
+// powerpc_vsx: #NO_APP
+// powerpc64_vsx-LABEL: vsreg_f32:
+// powerpc64_vsx: #APP
+// powerpc64_vsx: xvsqrtdp {{[0-9]+}}, {{[0-9]+}}
+// powerpc64_vsx: #NO_APP
+#[cfg(vsx)]
+check!(vsreg_f32, f32, vsreg, "xvsqrtdp");
+
+// powerpc_vsx-LABEL: vsreg_f64:
+// powerpc_vsx: #APP
+// powerpc_vsx: xvsqrtdp {{[0-9]+}}, {{[0-9]+}}
+// powerpc_vsx: #NO_APP
+// powerpc64_vsx-LABEL: vsreg_f64:
+// powerpc64_vsx: #APP
+// powerpc64_vsx: xvsqrtdp {{[0-9]+}}, {{[0-9]+}}
+// powerpc64_vsx: #NO_APP
+#[cfg(vsx)]
+check!(vsreg_f64, f64, vsreg, "xvsqrtdp");
+
 // CHECK-LABEL: reg_i8_r0:
 // CHECK: #APP
 // CHECK: mr 0, 0
@@ -472,3 +560,179 @@ check_reg!(vreg_f32_v18, f32, "18", "v18", "vmr");
 // powerpc64_vsx: #NO_APP
 #[cfg(vsx)]
 check_reg!(vreg_f64_v18, f64, "18", "v18", "vmr");
+
+// powerpc_vsx-LABEL: vsreg_i8x16_vs0:
+// powerpc_vsx: #APP
+// powerpc_vsx: xvsqrtdp 0, 0
+// powerpc_vsx: #NO_APP
+// powerpc64_vsx-LABEL: vsreg_i8x16_vs0:
+// powerpc64_vsx: #APP
+// powerpc64_vsx: xvsqrtdp 0, 0
+// powerpc64_vsx: #NO_APP
+#[cfg(vsx)]
+check_reg!(vsreg_i8x16_vs0, i8x16, "0", "vs0", "xvsqrtdp");
+
+// powerpc_vsx-LABEL: vsreg_i16x8_vs0:
+// powerpc_vsx: #APP
+// powerpc_vsx: xvsqrtdp 0, 0
+// powerpc_vsx: #NO_APP
+// powerpc64_vsx-LABEL: vsreg_i16x8_vs0:
+// powerpc64_vsx: #APP
+// powerpc64_vsx: xvsqrtdp 0, 0
+// powerpc64_vsx: #NO_APP
+#[cfg(vsx)]
+check_reg!(vsreg_i16x8_vs0, i16x8, "0", "vs0", "xvsqrtdp");
+
+// powerpc_vsx-LABEL: vsreg_i32x4_vs0:
+// powerpc_vsx: #APP
+// powerpc_vsx: xvsqrtdp 0, 0
+// powerpc_vsx: #NO_APP
+// powerpc64_vsx-LABEL: vsreg_i32x4_vs0:
+// powerpc64_vsx: #APP
+// powerpc64_vsx: xvsqrtdp 0, 0
+// powerpc64_vsx: #NO_APP
+#[cfg(vsx)]
+check_reg!(vsreg_i32x4_vs0, i32x4, "0", "vs0", "xvsqrtdp");
+
+// powerpc_vsx-LABEL: vsreg_i64x2_vs0:
+// powerpc_vsx: #APP
+// powerpc_vsx: xvsqrtdp 0, 0
+// powerpc_vsx: #NO_APP
+// powerpc64_vsx-LABEL: vsreg_i64x2_vs0:
+// powerpc64_vsx: #APP
+// powerpc64_vsx: xvsqrtdp 0, 0
+// powerpc64_vsx: #NO_APP
+#[cfg(vsx)]
+check_reg!(vsreg_i64x2_vs0, i64x2, "0", "vs0", "xvsqrtdp");
+
+// powerpc_vsx-LABEL: vsreg_f32x4_vs0:
+// powerpc_vsx: #APP
+// powerpc_vsx: xvsqrtdp 0, 0
+// powerpc_vsx: #NO_APP
+// powerpc64_vsx-LABEL: vsreg_f32x4_vs0:
+// powerpc64_vsx: #APP
+// powerpc64_vsx: xvsqrtdp 0, 0
+// powerpc64_vsx: #NO_APP
+#[cfg(vsx)]
+check_reg!(vsreg_f32x4_vs0, f32x4, "0", "vs0", "xvsqrtdp");
+
+// powerpc_vsx-LABEL: vsreg_f64x2_vs0:
+// powerpc_vsx: #APP
+// powerpc_vsx: xvsqrtdp 0, 0
+// powerpc_vsx: #NO_APP
+// powerpc64_vsx-LABEL: vsreg_f64x2_vs0:
+// powerpc64_vsx: #APP
+// powerpc64_vsx: xvsqrtdp 0, 0
+// powerpc64_vsx: #NO_APP
+#[cfg(vsx)]
+check_reg!(vsreg_f64x2_vs0, f64x2, "0", "vs0", "xvsqrtdp");
+
+// powerpc_vsx-LABEL: vsreg_f32_vs0:
+// powerpc_vsx: #APP
+// powerpc_vsx: xvsqrtdp 0, 0
+// powerpc_vsx: #NO_APP
+// powerpc64_vsx-LABEL: vsreg_f32_vs0:
+// powerpc64_vsx: #APP
+// powerpc64_vsx: xvsqrtdp 0, 0
+// powerpc64_vsx: #NO_APP
+#[cfg(vsx)]
+check_reg!(vsreg_f32_vs0, f32, "0", "vs0", "xvsqrtdp");
+
+// powerpc_vsx-LABEL: vsreg_f64_vs0:
+// powerpc_vsx: #APP
+// powerpc_vsx: xvsqrtdp 0, 0
+// powerpc_vsx: #NO_APP
+// powerpc64_vsx-LABEL: vsreg_f64_vs0:
+// powerpc64_vsx: #APP
+// powerpc64_vsx: xvsqrtdp 0, 0
+// powerpc64_vsx: #NO_APP
+#[cfg(vsx)]
+check_reg!(vsreg_f64_vs0, f64, "0", "vs0", "xvsqrtdp");
+
+// powerpc_vsx-LABEL: vsreg_i8x16_v40:
+// powerpc_vsx: #APP
+// powerpc_vsx: xvsqrtdp 40, 40
+// powerpc_vsx: #NO_APP
+// powerpc64_vsx-LABEL: vsreg_i8x16_v40:
+// powerpc64_vsx: #APP
+// powerpc64_vsx: xvsqrtdp 40, 40
+// powerpc64_vsx: #NO_APP
+#[cfg(vsx)]
+check_reg!(vsreg_i8x16_v40, i8x16, "40", "vs40", "xvsqrtdp");
+
+// powerpc_vsx-LABEL: vsreg_i16x8_v40:
+// powerpc_vsx: #APP
+// powerpc_vsx: xvsqrtdp 40, 40
+// powerpc_vsx: #NO_APP
+// powerpc64_vsx-LABEL: vsreg_i16x8_v40:
+// powerpc64_vsx: #APP
+// powerpc64_vsx: xvsqrtdp 40, 40
+// powerpc64_vsx: #NO_APP
+#[cfg(vsx)]
+check_reg!(vsreg_i16x8_v40, i16x8, "40", "vs40", "xvsqrtdp");
+
+// powerpc_vsx-LABEL: vsreg_i32x4_v40:
+// powerpc_vsx: #APP
+// powerpc_vsx: xvsqrtdp 40, 40
+// powerpc_vsx: #NO_APP
+// powerpc64_vsx-LABEL: vsreg_i32x4_v40:
+// powerpc64_vsx: #APP
+// powerpc64_vsx: xvsqrtdp 40, 40
+// powerpc64_vsx: #NO_APP
+#[cfg(vsx)]
+check_reg!(vsreg_i32x4_v40, i32x4, "40", "vs40", "xvsqrtdp");
+
+// powerpc_vsx-LABEL: vsreg_i64x2_v40:
+// powerpc_vsx: #APP
+// powerpc_vsx: xvsqrtdp 40, 40
+// powerpc_vsx: #NO_APP
+// powerpc64_vsx-LABEL: vsreg_i64x2_v40:
+// powerpc64_vsx: #APP
+// powerpc64_vsx: xvsqrtdp 40, 40
+// powerpc64_vsx: #NO_APP
+#[cfg(vsx)]
+check_reg!(vsreg_i64x2_v40, i64x2, "40", "vs40", "xvsqrtdp");
+
+// powerpc_vsx-LABEL: vsreg_f32x4_v40:
+// powerpc_vsx: #APP
+// powerpc_vsx: xvsqrtdp 40, 40
+// powerpc_vsx: #NO_APP
+// powerpc64_vsx-LABEL: vsreg_f32x4_v40:
+// powerpc64_vsx: #APP
+// powerpc64_vsx: xvsqrtdp 40, 40
+// powerpc64_vsx: #NO_APP
+#[cfg(vsx)]
+check_reg!(vsreg_f32x4_v40, f32x4, "40", "vs40", "xvsqrtdp");
+
+// powerpc_vsx-LABEL: vsreg_f64x2_v40:
+// powerpc_vsx: #APP
+// powerpc_vsx: xvsqrtdp 40, 40
+// powerpc_vsx: #NO_APP
+// powerpc64_vsx-LABEL: vsreg_f64x2_v40:
+// powerpc64_vsx: #APP
+// powerpc64_vsx: xvsqrtdp 40, 40
+// powerpc64_vsx: #NO_APP
+#[cfg(vsx)]
+check_reg!(vsreg_f64x2_v40, f64x2, "40", "vs40", "xvsqrtdp");
+
+// powerpc_vsx-LABEL: vsreg_f32_v40:
+// powerpc_vsx: #APP
+// powerpc_vsx: xvsqrtdp 40, 40
+// powerpc_vsx: #NO_APP
+// powerpc64_vsx-LABEL: vsreg_f32_v40:
+// powerpc64_vsx: #APP
+// powerpc64_vsx: xvsqrtdp 40, 40
+// powerpc64_vsx: #NO_APP
+#[cfg(vsx)]
+check_reg!(vsreg_f32_v40, f32, "40", "vs40", "xvsqrtdp");
+
+// powerpc_vsx-LABEL: vsreg_f64_v40:
+// powerpc_vsx: #APP
+// powerpc_vsx: xvsqrtdp 40, 40
+// powerpc_vsx: #NO_APP
+// powerpc64_vsx-LABEL: vsreg_f64_v40:
+// powerpc64_vsx: #APP
+// powerpc64_vsx: xvsqrtdp 40, 40
+// powerpc64_vsx: #NO_APP
+#[cfg(vsx)]
+check_reg!(vsreg_f64_v40, f64, "40", "vs40", "xvsqrtdp");

--- a/tests/codegen-llvm/asm/powerpc-clobbers.rs
+++ b/tests/codegen-llvm/asm/powerpc-clobbers.rs
@@ -56,12 +56,23 @@ pub unsafe fn v0_clobber() {
     asm!("", out("v0") _, options(nostack, nomem, preserves_flags));
 }
 
-// Output format depends on the availability of altivec.
+// Output format depends on the availability of vsx.
+// CHECK-LABEL: @vs32_clobber
+// powerpc: call void asm sideeffect "", "~{vs32}"()
+// powerpc64: call void asm sideeffect "", "~{vs32}"()
+// powerpc64le: call <4 x i32> asm sideeffect "", "=&{vs32}"()
+// aix64: call <4 x i32> asm sideeffect "", "=&{vs32}"()
+#[no_mangle]
+pub unsafe fn vs32_clobber() {
+    asm!("", out("vs32") _, options(nostack, nomem, preserves_flags));
+}
+
+// Output format depends on the availability of altivec and vsx
 // CHECK-LABEL: @clobber_abi
-// powerpc: asm sideeffect "", "={r0},={r3},={r4},={r5},={r6},={r7},={r8},={r9},={r10},={r11},={r12},={f0},={f1},={f2},={f3},={f4},={f5},={f6},={f7},={f8},={f9},={f10},={f11},={f12},={f13},~{v0},~{v1},~{v2},~{v3},~{v4},~{v5},~{v6},~{v7},~{v8},~{v9},~{v10},~{v11},~{v12},~{v13},~{v14},~{v15},~{v16},~{v17},~{v18},~{v19},~{cr0},~{cr1},~{cr5},~{cr6},~{cr7},~{ctr},~{lr},~{xer}"()
-// powerpc64: asm sideeffect "", "={r0},={r3},={r4},={r5},={r6},={r7},={r8},={r9},={r10},={r11},={r12},={f0},={f1},={f2},={f3},={f4},={f5},={f6},={f7},={f8},={f9},={f10},={f11},={f12},={f13},={v0},={v1},={v2},={v3},={v4},={v5},={v6},={v7},={v8},={v9},={v10},={v11},={v12},={v13},={v14},={v15},={v16},={v17},={v18},={v19},~{cr0},~{cr1},~{cr5},~{cr6},~{cr7},~{ctr},~{lr},~{xer}"()
-// powerpc64le: asm sideeffect "", "={r0},={r3},={r4},={r5},={r6},={r7},={r8},={r9},={r10},={r11},={r12},={f0},={f1},={f2},={f3},={f4},={f5},={f6},={f7},={f8},={f9},={f10},={f11},={f12},={f13},={v0},={v1},={v2},={v3},={v4},={v5},={v6},={v7},={v8},={v9},={v10},={v11},={v12},={v13},={v14},={v15},={v16},={v17},={v18},={v19},~{cr0},~{cr1},~{cr5},~{cr6},~{cr7},~{ctr},~{lr},~{xer}"()
-// aix64: asm sideeffect "", "={r0},={r3},={r4},={r5},={r6},={r7},={r8},={r9},={r10},={r11},={r12},={f0},={f1},={f2},={f3},={f4},={f5},={f6},={f7},={f8},={f9},={f10},={f11},={f12},={f13},={v0},={v1},={v2},={v3},={v4},={v5},={v6},={v7},={v8},={v9},={v10},={v11},={v12},={v13},={v14},={v15},={v16},={v17},={v18},={v19},~{cr0},~{cr1},~{cr5},~{cr6},~{cr7},~{ctr},~{lr},~{xer}"()
+// powerpc: asm sideeffect "", "={r0},={r3},={r4},={r5},={r6},={r7},={r8},={r9},={r10},={r11},={r12},={f0},={f1},={f2},={f3},={f4},={f5},={f6},={f7},={f8},={f9},={f10},={f11},={f12},={f13},~{vs0},~{vs1},~{vs2},~{vs3},~{vs4},~{vs5},~{vs6},~{vs7},~{vs8},~{vs9},~{vs10},~{vs11},~{vs12},~{vs13},~{vs14},~{vs15},~{vs16},~{vs17},~{vs18},~{vs19},~{vs20},~{vs21},~{vs22},~{vs23},~{vs24},~{vs25},~{vs26},~{vs27},~{vs28},~{vs29},~{vs30},~{vs31},~{v0},~{v1},~{v2},~{v3},~{v4},~{v5},~{v6},~{v7},~{v8},~{v9},~{v10},~{v11},~{v12},~{v13},~{v14},~{v15},~{v16},~{v17},~{v18},~{v19},~{cr0},~{cr1},~{cr5},~{cr6},~{cr7},~{ctr},~{lr},~{xer}"()
+// powerpc64: asm sideeffect "", "={r0},={r3},={r4},={r5},={r6},={r7},={r8},={r9},={r10},={r11},={r12},={f0},={f1},={f2},={f3},={f4},={f5},={f6},={f7},={f8},={f9},={f10},={f11},={f12},={f13},={v0},={v1},={v2},={v3},={v4},={v5},={v6},={v7},={v8},={v9},={v10},={v11},={v12},={v13},={v14},={v15},={v16},={v17},={v18},={v19},~{vs0},~{vs1},~{vs2},~{vs3},~{vs4},~{vs5},~{vs6},~{vs7},~{vs8},~{vs9},~{vs10},~{vs11},~{vs12},~{vs13},~{vs14},~{vs15},~{vs16},~{vs17},~{vs18},~{vs19},~{vs20},~{vs21},~{vs22},~{vs23},~{vs24},~{vs25},~{vs26},~{vs27},~{vs28},~{vs29},~{vs30},~{vs31},~{cr0},~{cr1},~{cr5},~{cr6},~{cr7},~{ctr},~{lr},~{xer}"()
+// powerpc64le: asm sideeffect "", "={r0},={r3},={r4},={r5},={r6},={r7},={r8},={r9},={r10},={r11},={r12},={f0},={f1},={f2},={f3},={f4},={f5},={f6},={f7},={f8},={f9},={f10},={f11},={f12},={f13},={vs0},={vs1},={vs2},={vs3},={vs4},={vs5},={vs6},={vs7},={vs8},={vs9},={vs10},={vs11},={vs12},={vs13},={vs14},={vs15},={vs16},={vs17},={vs18},={vs19},={vs20},={vs21},={vs22},={vs23},={vs24},={vs25},={vs26},={vs27},={vs28},={vs29},={vs30},={vs31},={v0},={v1},={v2},={v3},={v4},={v5},={v6},={v7},={v8},={v9},={v10},={v11},={v12},={v13},={v14},={v15},={v16},={v17},={v18},={v19},~{cr0},~{cr1},~{cr5},~{cr6},~{cr7},~{ctr},~{lr},~{xer}"()
+// aix64: asm sideeffect "", "={r0},={r3},={r4},={r5},={r6},={r7},={r8},={r9},={r10},={r11},={r12},={f0},={f1},={f2},={f3},={f4},={f5},={f6},={f7},={f8},={f9},={f10},={f11},={f12},={f13},={vs0},={vs1},={vs2},={vs3},={vs4},={vs5},={vs6},={vs7},={vs8},={vs9},={vs10},={vs11},={vs12},={vs13},={vs14},={vs15},={vs16},={vs17},={vs18},={vs19},={vs20},={vs21},={vs22},={vs23},={vs24},={vs25},={vs26},={vs27},={vs28},={vs29},={vs30},={vs31},={v0},={v1},={v2},={v3},={v4},={v5},={v6},={v7},={v8},={v9},={v10},={v11},={v12},={v13},={v14},={v15},={v16},={v17},={v18},={v19},~{cr0},~{cr1},~{cr5},~{cr6},~{cr7},~{ctr},~{lr},~{xer}"()
 #[no_mangle]
 pub unsafe fn clobber_abi() {
     asm!("", clobber_abi("C"), options(nostack, nomem, preserves_flags));

--- a/tests/codegen-llvm/asm/powerpc-clobbers.rs
+++ b/tests/codegen-llvm/asm/powerpc-clobbers.rs
@@ -77,3 +77,38 @@ pub unsafe fn vs32_clobber() {
 pub unsafe fn clobber_abi() {
     asm!("", clobber_abi("C"), options(nostack, nomem, preserves_flags));
 }
+
+// CHECK-LABEL: @clobber_no_preserves_flags
+// CHECK: call void asm sideeffect "nop", ""()
+#[no_mangle]
+pub unsafe fn clobber_no_preserves_flags() {
+    // Use a nop to prevent aliasing of identical functions here.
+    asm!("nop", options(nostack, nomem));
+}
+
+// CHECK-LABEL: @cr0_clobber_no_preserves_flags
+// CHECK: call void asm sideeffect "nop; nop", "~{cr0}"()
+#[no_mangle]
+pub unsafe fn cr0_clobber_no_preserves_flags() {
+    // Use nop; nop to prevent aliasing of identical functions here.
+    asm!("nop; nop", out("cr0") _, options(nostack, nomem));
+}
+
+// CHECK-LABEL: @clobber_preservesflags
+// CHECK: call void asm sideeffect "", "~{memory}"()
+#[no_mangle]
+pub unsafe fn clobber_preservesflags() {
+    asm!("", options(nostack, preserves_flags));
+}
+
+// Output format depends on the availability of altivec and vsx
+// CHECK-LABEL: @clobber_abi_no_preserves_flags
+#[no_mangle]
+// powerpc: asm sideeffect "nop", "={r0},={r3},={r4},={r5},={r6},={r7},={r8},={r9},={r10},={r11},={r12},={f0},={f1},={f2},={f3},={f4},={f5},={f6},={f7},={f8},={f9},={f10},={f11},={f12},={f13},~{vs0},~{vs1},~{vs2},~{vs3},~{vs4},~{vs5},~{vs6},~{vs7},~{vs8},~{vs9},~{vs10},~{vs11},~{vs12},~{vs13},~{vs14},~{vs15},~{vs16},~{vs17},~{vs18},~{vs19},~{vs20},~{vs21},~{vs22},~{vs23},~{vs24},~{vs25},~{vs26},~{vs27},~{vs28},~{vs29},~{vs30},~{vs31},~{v0},~{v1},~{v2},~{v3},~{v4},~{v5},~{v6},~{v7},~{v8},~{v9},~{v10},~{v11},~{v12},~{v13},~{v14},~{v15},~{v16},~{v17},~{v18},~{v19},~{cr0},~{cr1},~{cr5},~{cr6},~{cr7},~{ctr},~{lr},~{xer}"()
+// powerpc64: asm sideeffect "nop", "={r0},={r3},={r4},={r5},={r6},={r7},={r8},={r9},={r10},={r11},={r12},={f0},={f1},={f2},={f3},={f4},={f5},={f6},={f7},={f8},={f9},={f10},={f11},={f12},={f13},={v0},={v1},={v2},={v3},={v4},={v5},={v6},={v7},={v8},={v9},={v10},={v11},={v12},={v13},={v14},={v15},={v16},={v17},={v18},={v19},~{vs0},~{vs1},~{vs2},~{vs3},~{vs4},~{vs5},~{vs6},~{vs7},~{vs8},~{vs9},~{vs10},~{vs11},~{vs12},~{vs13},~{vs14},~{vs15},~{vs16},~{vs17},~{vs18},~{vs19},~{vs20},~{vs21},~{vs22},~{vs23},~{vs24},~{vs25},~{vs26},~{vs27},~{vs28},~{vs29},~{vs30},~{vs31},~{cr0},~{cr1},~{cr5},~{cr6},~{cr7},~{ctr},~{lr},~{xer}"()
+// powerpc64le: asm sideeffect "nop", "={r0},={r3},={r4},={r5},={r6},={r7},={r8},={r9},={r10},={r11},={r12},={f0},={f1},={f2},={f3},={f4},={f5},={f6},={f7},={f8},={f9},={f10},={f11},={f12},={f13},={vs0},={vs1},={vs2},={vs3},={vs4},={vs5},={vs6},={vs7},={vs8},={vs9},={vs10},={vs11},={vs12},={vs13},={vs14},={vs15},={vs16},={vs17},={vs18},={vs19},={vs20},={vs21},={vs22},={vs23},={vs24},={vs25},={vs26},={vs27},={vs28},={vs29},={vs30},={vs31},={v0},={v1},={v2},={v3},={v4},={v5},={v6},={v7},={v8},={v9},={v10},={v11},={v12},={v13},={v14},={v15},={v16},={v17},={v18},={v19},~{cr0},~{cr1},~{cr5},~{cr6},~{cr7},~{ctr},~{lr},~{xer}"()
+// aix64: asm sideeffect "nop", "={r0},={r3},={r4},={r5},={r6},={r7},={r8},={r9},={r10},={r11},={r12},={f0},={f1},={f2},={f3},={f4},={f5},={f6},={f7},={f8},={f9},={f10},={f11},={f12},={f13},={vs0},={vs1},={vs2},={vs3},={vs4},={vs5},={vs6},={vs7},={vs8},={vs9},={vs10},={vs11},={vs12},={vs13},={vs14},={vs15},={vs16},={vs17},={vs18},={vs19},={vs20},={vs21},={vs22},={vs23},={vs24},={vs25},={vs26},={vs27},={vs28},={vs29},={vs30},={vs31},={v0},={v1},={v2},={v3},={v4},={v5},={v6},={v7},={v8},={v9},={v10},={v11},={v12},={v13},={v14},={v15},={v16},={v17},={v18},={v19},~{cr0},~{cr1},~{cr5},~{cr6},~{cr7},~{ctr},~{lr},~{xer}"()
+pub unsafe fn clobber_abi_no_preserves_flags() {
+    // Use a nop to prevent aliasing of identical functions here.
+    asm!("nop", clobber_abi("C"), options(nostack, nomem));
+}

--- a/tests/ui/asm/powerpc/bad-reg.aix64.stderr
+++ b/tests/ui/asm/powerpc/bad-reg.aix64.stderr
@@ -35,103 +35,103 @@ LL |         asm!("", out("vrsave") _);
    |                  ^^^^^^^^^^^^^^^
 
 error: register class `cr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:97:18
+  --> $DIR/bad-reg.rs:138:18
    |
 LL |         asm!("", in("cr") x);
    |                  ^^^^^^^^^^
 
 error: register class `cr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:100:18
+  --> $DIR/bad-reg.rs:141:18
    |
 LL |         asm!("", out("cr") x);
    |                  ^^^^^^^^^^^
 
 error: register class `cr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:103:26
+  --> $DIR/bad-reg.rs:144:26
    |
 LL |         asm!("/* {} */", in(cr) x);
    |                          ^^^^^^^^
 
 error: register class `cr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:106:26
+  --> $DIR/bad-reg.rs:147:26
    |
 LL |         asm!("/* {} */", out(cr) _);
    |                          ^^^^^^^^^
 
 error: register class `ctr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:110:18
+  --> $DIR/bad-reg.rs:151:18
    |
 LL |         asm!("", in("ctr") x);
    |                  ^^^^^^^^^^^
 
 error: register class `ctr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:113:18
+  --> $DIR/bad-reg.rs:154:18
    |
 LL |         asm!("", out("ctr") x);
    |                  ^^^^^^^^^^^^
 
 error: register class `ctr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:116:26
+  --> $DIR/bad-reg.rs:157:26
    |
 LL |         asm!("/* {} */", in(ctr) x);
    |                          ^^^^^^^^^
 
 error: register class `ctr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:119:26
+  --> $DIR/bad-reg.rs:160:26
    |
 LL |         asm!("/* {} */", out(ctr) _);
    |                          ^^^^^^^^^^
 
 error: register class `lr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:123:18
+  --> $DIR/bad-reg.rs:164:18
    |
 LL |         asm!("", in("lr") x);
    |                  ^^^^^^^^^^
 
 error: register class `lr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:126:18
+  --> $DIR/bad-reg.rs:167:18
    |
 LL |         asm!("", out("lr") x);
    |                  ^^^^^^^^^^^
 
 error: register class `lr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:129:26
+  --> $DIR/bad-reg.rs:170:26
    |
 LL |         asm!("/* {} */", in(lr) x);
    |                          ^^^^^^^^
 
 error: register class `lr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:132:26
+  --> $DIR/bad-reg.rs:173:26
    |
 LL |         asm!("/* {} */", out(lr) _);
    |                          ^^^^^^^^^
 
 error: register class `xer` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:136:18
+  --> $DIR/bad-reg.rs:177:18
    |
 LL |         asm!("", in("xer") x);
    |                  ^^^^^^^^^^^
 
 error: register class `xer` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:139:18
+  --> $DIR/bad-reg.rs:180:18
    |
 LL |         asm!("", out("xer") x);
    |                  ^^^^^^^^^^^^
 
 error: register class `xer` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:142:26
+  --> $DIR/bad-reg.rs:183:26
    |
 LL |         asm!("/* {} */", in(xer) x);
    |                          ^^^^^^^^^
 
 error: register class `xer` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:145:26
+  --> $DIR/bad-reg.rs:186:26
    |
 LL |         asm!("/* {} */", out(xer) _);
    |                          ^^^^^^^^^^
 
 error: register `cr0` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:149:31
+  --> $DIR/bad-reg.rs:190:31
    |
 LL |         asm!("", out("cr") _, out("cr0") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr0`
@@ -139,7 +139,7 @@ LL |         asm!("", out("cr") _, out("cr0") _);
    |                  register `cr`
 
 error: register `cr1` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:151:31
+  --> $DIR/bad-reg.rs:192:31
    |
 LL |         asm!("", out("cr") _, out("cr1") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr1`
@@ -147,7 +147,7 @@ LL |         asm!("", out("cr") _, out("cr1") _);
    |                  register `cr`
 
 error: register `cr2` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:153:31
+  --> $DIR/bad-reg.rs:194:31
    |
 LL |         asm!("", out("cr") _, out("cr2") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr2`
@@ -155,7 +155,7 @@ LL |         asm!("", out("cr") _, out("cr2") _);
    |                  register `cr`
 
 error: register `cr3` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:155:31
+  --> $DIR/bad-reg.rs:196:31
    |
 LL |         asm!("", out("cr") _, out("cr3") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr3`
@@ -163,7 +163,7 @@ LL |         asm!("", out("cr") _, out("cr3") _);
    |                  register `cr`
 
 error: register `cr4` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:157:31
+  --> $DIR/bad-reg.rs:198:31
    |
 LL |         asm!("", out("cr") _, out("cr4") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr4`
@@ -171,7 +171,7 @@ LL |         asm!("", out("cr") _, out("cr4") _);
    |                  register `cr`
 
 error: register `cr5` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:159:31
+  --> $DIR/bad-reg.rs:200:31
    |
 LL |         asm!("", out("cr") _, out("cr5") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr5`
@@ -179,7 +179,7 @@ LL |         asm!("", out("cr") _, out("cr5") _);
    |                  register `cr`
 
 error: register `cr6` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:161:31
+  --> $DIR/bad-reg.rs:202:31
    |
 LL |         asm!("", out("cr") _, out("cr6") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr6`
@@ -187,12 +187,524 @@ LL |         asm!("", out("cr") _, out("cr6") _);
    |                  register `cr`
 
 error: register `cr7` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:163:31
+  --> $DIR/bad-reg.rs:204:31
    |
 LL |         asm!("", out("cr") _, out("cr7") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr7`
    |                  |
    |                  register `cr`
+
+error: register `vs0` conflicts with register `f0`
+  --> $DIR/bad-reg.rs:207:31
+   |
+LL |         asm!("", out("f0") _, out("vs0") _);
+   |                  -----------  ^^^^^^^^^^^^ register `vs0`
+   |                  |
+   |                  register `f0`
+
+error: register `vs1` conflicts with register `f1`
+  --> $DIR/bad-reg.rs:209:31
+   |
+LL |         asm!("", out("f1") _, out("vs1") _);
+   |                  -----------  ^^^^^^^^^^^^ register `vs1`
+   |                  |
+   |                  register `f1`
+
+error: register `vs2` conflicts with register `f2`
+  --> $DIR/bad-reg.rs:211:31
+   |
+LL |         asm!("", out("f2") _, out("vs2") _);
+   |                  -----------  ^^^^^^^^^^^^ register `vs2`
+   |                  |
+   |                  register `f2`
+
+error: register `vs3` conflicts with register `f3`
+  --> $DIR/bad-reg.rs:213:31
+   |
+LL |         asm!("", out("f3") _, out("vs3") _);
+   |                  -----------  ^^^^^^^^^^^^ register `vs3`
+   |                  |
+   |                  register `f3`
+
+error: register `vs4` conflicts with register `f4`
+  --> $DIR/bad-reg.rs:215:31
+   |
+LL |         asm!("", out("f4") _, out("vs4") _);
+   |                  -----------  ^^^^^^^^^^^^ register `vs4`
+   |                  |
+   |                  register `f4`
+
+error: register `vs5` conflicts with register `f5`
+  --> $DIR/bad-reg.rs:217:31
+   |
+LL |         asm!("", out("f5") _, out("vs5") _);
+   |                  -----------  ^^^^^^^^^^^^ register `vs5`
+   |                  |
+   |                  register `f5`
+
+error: register `vs6` conflicts with register `f6`
+  --> $DIR/bad-reg.rs:219:31
+   |
+LL |         asm!("", out("f6") _, out("vs6") _);
+   |                  -----------  ^^^^^^^^^^^^ register `vs6`
+   |                  |
+   |                  register `f6`
+
+error: register `vs7` conflicts with register `f7`
+  --> $DIR/bad-reg.rs:221:31
+   |
+LL |         asm!("", out("f7") _, out("vs7") _);
+   |                  -----------  ^^^^^^^^^^^^ register `vs7`
+   |                  |
+   |                  register `f7`
+
+error: register `vs8` conflicts with register `f8`
+  --> $DIR/bad-reg.rs:223:31
+   |
+LL |         asm!("", out("f8") _, out("vs8") _);
+   |                  -----------  ^^^^^^^^^^^^ register `vs8`
+   |                  |
+   |                  register `f8`
+
+error: register `vs9` conflicts with register `f9`
+  --> $DIR/bad-reg.rs:225:31
+   |
+LL |         asm!("", out("f9") _, out("vs9") _);
+   |                  -----------  ^^^^^^^^^^^^ register `vs9`
+   |                  |
+   |                  register `f9`
+
+error: register `vs10` conflicts with register `f10`
+  --> $DIR/bad-reg.rs:227:32
+   |
+LL |         asm!("", out("f10") _, out("vs10") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs10`
+   |                  |
+   |                  register `f10`
+
+error: register `vs11` conflicts with register `f11`
+  --> $DIR/bad-reg.rs:229:32
+   |
+LL |         asm!("", out("f11") _, out("vs11") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs11`
+   |                  |
+   |                  register `f11`
+
+error: register `vs12` conflicts with register `f12`
+  --> $DIR/bad-reg.rs:231:32
+   |
+LL |         asm!("", out("f12") _, out("vs12") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs12`
+   |                  |
+   |                  register `f12`
+
+error: register `vs13` conflicts with register `f13`
+  --> $DIR/bad-reg.rs:233:32
+   |
+LL |         asm!("", out("f13") _, out("vs13") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs13`
+   |                  |
+   |                  register `f13`
+
+error: register `vs14` conflicts with register `f14`
+  --> $DIR/bad-reg.rs:235:32
+   |
+LL |         asm!("", out("f14") _, out("vs14") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs14`
+   |                  |
+   |                  register `f14`
+
+error: register `vs15` conflicts with register `f15`
+  --> $DIR/bad-reg.rs:237:32
+   |
+LL |         asm!("", out("f15") _, out("vs15") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs15`
+   |                  |
+   |                  register `f15`
+
+error: register `vs16` conflicts with register `f16`
+  --> $DIR/bad-reg.rs:239:32
+   |
+LL |         asm!("", out("f16") _, out("vs16") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs16`
+   |                  |
+   |                  register `f16`
+
+error: register `vs17` conflicts with register `f17`
+  --> $DIR/bad-reg.rs:241:32
+   |
+LL |         asm!("", out("f17") _, out("vs17") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs17`
+   |                  |
+   |                  register `f17`
+
+error: register `vs18` conflicts with register `f18`
+  --> $DIR/bad-reg.rs:243:32
+   |
+LL |         asm!("", out("f18") _, out("vs18") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs18`
+   |                  |
+   |                  register `f18`
+
+error: register `vs19` conflicts with register `f19`
+  --> $DIR/bad-reg.rs:245:32
+   |
+LL |         asm!("", out("f19") _, out("vs19") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs19`
+   |                  |
+   |                  register `f19`
+
+error: register `vs20` conflicts with register `f20`
+  --> $DIR/bad-reg.rs:247:32
+   |
+LL |         asm!("", out("f20") _, out("vs20") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs20`
+   |                  |
+   |                  register `f20`
+
+error: register `vs21` conflicts with register `f21`
+  --> $DIR/bad-reg.rs:249:32
+   |
+LL |         asm!("", out("f21") _, out("vs21") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs21`
+   |                  |
+   |                  register `f21`
+
+error: register `vs22` conflicts with register `f22`
+  --> $DIR/bad-reg.rs:251:32
+   |
+LL |         asm!("", out("f22") _, out("vs22") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs22`
+   |                  |
+   |                  register `f22`
+
+error: register `vs23` conflicts with register `f23`
+  --> $DIR/bad-reg.rs:253:32
+   |
+LL |         asm!("", out("f23") _, out("vs23") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs23`
+   |                  |
+   |                  register `f23`
+
+error: register `vs24` conflicts with register `f24`
+  --> $DIR/bad-reg.rs:255:32
+   |
+LL |         asm!("", out("f24") _, out("vs24") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs24`
+   |                  |
+   |                  register `f24`
+
+error: register `vs25` conflicts with register `f25`
+  --> $DIR/bad-reg.rs:257:32
+   |
+LL |         asm!("", out("f25") _, out("vs25") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs25`
+   |                  |
+   |                  register `f25`
+
+error: register `vs26` conflicts with register `f26`
+  --> $DIR/bad-reg.rs:259:32
+   |
+LL |         asm!("", out("f26") _, out("vs26") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs26`
+   |                  |
+   |                  register `f26`
+
+error: register `vs27` conflicts with register `f27`
+  --> $DIR/bad-reg.rs:261:32
+   |
+LL |         asm!("", out("f27") _, out("vs27") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs27`
+   |                  |
+   |                  register `f27`
+
+error: register `vs28` conflicts with register `f28`
+  --> $DIR/bad-reg.rs:263:32
+   |
+LL |         asm!("", out("f28") _, out("vs28") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs28`
+   |                  |
+   |                  register `f28`
+
+error: register `vs29` conflicts with register `f29`
+  --> $DIR/bad-reg.rs:265:32
+   |
+LL |         asm!("", out("f29") _, out("vs29") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs29`
+   |                  |
+   |                  register `f29`
+
+error: register `vs30` conflicts with register `f30`
+  --> $DIR/bad-reg.rs:267:32
+   |
+LL |         asm!("", out("f30") _, out("vs30") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs30`
+   |                  |
+   |                  register `f30`
+
+error: register `vs31` conflicts with register `f31`
+  --> $DIR/bad-reg.rs:269:32
+   |
+LL |         asm!("", out("f31") _, out("vs31") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs31`
+   |                  |
+   |                  register `f31`
+
+error: register `v0` conflicts with register `vs32`
+  --> $DIR/bad-reg.rs:271:33
+   |
+LL |         asm!("", out("vs32") _, out("v0") _);
+   |                  -------------  ^^^^^^^^^^^ register `v0`
+   |                  |
+   |                  register `vs32`
+
+error: register `v1` conflicts with register `vs33`
+  --> $DIR/bad-reg.rs:273:33
+   |
+LL |         asm!("", out("vs33") _, out("v1") _);
+   |                  -------------  ^^^^^^^^^^^ register `v1`
+   |                  |
+   |                  register `vs33`
+
+error: register `v2` conflicts with register `vs34`
+  --> $DIR/bad-reg.rs:275:33
+   |
+LL |         asm!("", out("vs34") _, out("v2") _);
+   |                  -------------  ^^^^^^^^^^^ register `v2`
+   |                  |
+   |                  register `vs34`
+
+error: register `v3` conflicts with register `vs35`
+  --> $DIR/bad-reg.rs:277:33
+   |
+LL |         asm!("", out("vs35") _, out("v3") _);
+   |                  -------------  ^^^^^^^^^^^ register `v3`
+   |                  |
+   |                  register `vs35`
+
+error: register `v4` conflicts with register `vs36`
+  --> $DIR/bad-reg.rs:279:33
+   |
+LL |         asm!("", out("vs36") _, out("v4") _);
+   |                  -------------  ^^^^^^^^^^^ register `v4`
+   |                  |
+   |                  register `vs36`
+
+error: register `v5` conflicts with register `vs37`
+  --> $DIR/bad-reg.rs:281:33
+   |
+LL |         asm!("", out("vs37") _, out("v5") _);
+   |                  -------------  ^^^^^^^^^^^ register `v5`
+   |                  |
+   |                  register `vs37`
+
+error: register `v6` conflicts with register `vs38`
+  --> $DIR/bad-reg.rs:283:33
+   |
+LL |         asm!("", out("vs38") _, out("v6") _);
+   |                  -------------  ^^^^^^^^^^^ register `v6`
+   |                  |
+   |                  register `vs38`
+
+error: register `v7` conflicts with register `vs39`
+  --> $DIR/bad-reg.rs:285:33
+   |
+LL |         asm!("", out("vs39") _, out("v7") _);
+   |                  -------------  ^^^^^^^^^^^ register `v7`
+   |                  |
+   |                  register `vs39`
+
+error: register `v8` conflicts with register `vs40`
+  --> $DIR/bad-reg.rs:287:33
+   |
+LL |         asm!("", out("vs40") _, out("v8") _);
+   |                  -------------  ^^^^^^^^^^^ register `v8`
+   |                  |
+   |                  register `vs40`
+
+error: register `v9` conflicts with register `vs41`
+  --> $DIR/bad-reg.rs:289:33
+   |
+LL |         asm!("", out("vs41") _, out("v9") _);
+   |                  -------------  ^^^^^^^^^^^ register `v9`
+   |                  |
+   |                  register `vs41`
+
+error: register `v10` conflicts with register `vs42`
+  --> $DIR/bad-reg.rs:291:33
+   |
+LL |         asm!("", out("vs42") _, out("v10") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v10`
+   |                  |
+   |                  register `vs42`
+
+error: register `v11` conflicts with register `vs43`
+  --> $DIR/bad-reg.rs:293:33
+   |
+LL |         asm!("", out("vs43") _, out("v11") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v11`
+   |                  |
+   |                  register `vs43`
+
+error: register `v12` conflicts with register `vs44`
+  --> $DIR/bad-reg.rs:295:33
+   |
+LL |         asm!("", out("vs44") _, out("v12") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v12`
+   |                  |
+   |                  register `vs44`
+
+error: register `v13` conflicts with register `vs45`
+  --> $DIR/bad-reg.rs:297:33
+   |
+LL |         asm!("", out("vs45") _, out("v13") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v13`
+   |                  |
+   |                  register `vs45`
+
+error: register `v14` conflicts with register `vs46`
+  --> $DIR/bad-reg.rs:299:33
+   |
+LL |         asm!("", out("vs46") _, out("v14") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v14`
+   |                  |
+   |                  register `vs46`
+
+error: register `v15` conflicts with register `vs47`
+  --> $DIR/bad-reg.rs:301:33
+   |
+LL |         asm!("", out("vs47") _, out("v15") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v15`
+   |                  |
+   |                  register `vs47`
+
+error: register `v16` conflicts with register `vs48`
+  --> $DIR/bad-reg.rs:303:33
+   |
+LL |         asm!("", out("vs48") _, out("v16") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v16`
+   |                  |
+   |                  register `vs48`
+
+error: register `v17` conflicts with register `vs49`
+  --> $DIR/bad-reg.rs:305:33
+   |
+LL |         asm!("", out("vs49") _, out("v17") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v17`
+   |                  |
+   |                  register `vs49`
+
+error: register `v18` conflicts with register `vs50`
+  --> $DIR/bad-reg.rs:307:33
+   |
+LL |         asm!("", out("vs50") _, out("v18") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v18`
+   |                  |
+   |                  register `vs50`
+
+error: register `v19` conflicts with register `vs51`
+  --> $DIR/bad-reg.rs:309:33
+   |
+LL |         asm!("", out("vs51") _, out("v19") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v19`
+   |                  |
+   |                  register `vs51`
+
+error: register `v20` conflicts with register `vs52`
+  --> $DIR/bad-reg.rs:311:33
+   |
+LL |         asm!("", out("vs52") _, out("v20") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v20`
+   |                  |
+   |                  register `vs52`
+
+error: register `v21` conflicts with register `vs53`
+  --> $DIR/bad-reg.rs:313:33
+   |
+LL |         asm!("", out("vs53") _, out("v21") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v21`
+   |                  |
+   |                  register `vs53`
+
+error: register `v22` conflicts with register `vs54`
+  --> $DIR/bad-reg.rs:315:33
+   |
+LL |         asm!("", out("vs54") _, out("v22") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v22`
+   |                  |
+   |                  register `vs54`
+
+error: register `v23` conflicts with register `vs55`
+  --> $DIR/bad-reg.rs:317:33
+   |
+LL |         asm!("", out("vs55") _, out("v23") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v23`
+   |                  |
+   |                  register `vs55`
+
+error: register `v24` conflicts with register `vs56`
+  --> $DIR/bad-reg.rs:319:33
+   |
+LL |         asm!("", out("vs56") _, out("v24") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v24`
+   |                  |
+   |                  register `vs56`
+
+error: register `v25` conflicts with register `vs57`
+  --> $DIR/bad-reg.rs:321:33
+   |
+LL |         asm!("", out("vs57") _, out("v25") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v25`
+   |                  |
+   |                  register `vs57`
+
+error: register `v26` conflicts with register `vs58`
+  --> $DIR/bad-reg.rs:323:33
+   |
+LL |         asm!("", out("vs58") _, out("v26") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v26`
+   |                  |
+   |                  register `vs58`
+
+error: register `v27` conflicts with register `vs59`
+  --> $DIR/bad-reg.rs:325:33
+   |
+LL |         asm!("", out("vs59") _, out("v27") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v27`
+   |                  |
+   |                  register `vs59`
+
+error: register `v28` conflicts with register `vs60`
+  --> $DIR/bad-reg.rs:327:33
+   |
+LL |         asm!("", out("vs60") _, out("v28") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v28`
+   |                  |
+   |                  register `vs60`
+
+error: register `v29` conflicts with register `vs61`
+  --> $DIR/bad-reg.rs:329:33
+   |
+LL |         asm!("", out("vs61") _, out("v29") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v29`
+   |                  |
+   |                  register `vs61`
+
+error: register `v30` conflicts with register `vs62`
+  --> $DIR/bad-reg.rs:331:33
+   |
+LL |         asm!("", out("vs62") _, out("v30") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v30`
+   |                  |
+   |                  register `vs62`
+
+error: register `v31` conflicts with register `vs63`
+  --> $DIR/bad-reg.rs:333:33
+   |
+LL |         asm!("", out("vs63") _, out("v31") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v31`
+   |                  |
+   |                  register `vs63`
 
 error: cannot use register `r13`: r13 is a reserved register on this target
   --> $DIR/bad-reg.rs:41:18
@@ -225,7 +737,31 @@ LL |         asm!("/* {} */", in(vreg) x); // FIXME: should be ok if vsx is avai
    = note: register class `vreg` supports these types: i8x16, i16x8, i32x4, f32x4, f32, f64, i64x2, f64x2
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:97:27
+  --> $DIR/bad-reg.rs:105:28
+   |
+LL |         asm!("", in("vs0") x); // FIXME: should be ok if vsx is available
+   |                            ^
+   |
+   = note: register class `vsreg` supports these types: f32, f64, i8x16, i16x8, i32x4, i64x2, f32x4, f64x2
+
+error: type `i32` cannot be used with this register class
+  --> $DIR/bad-reg.rs:108:29
+   |
+LL |         asm!("", out("vs0") x); // FIXME: should be ok if vsx is available
+   |                             ^
+   |
+   = note: register class `vsreg` supports these types: f32, f64, i8x16, i16x8, i32x4, i64x2, f32x4, f64x2
+
+error: type `i32` cannot be used with this register class
+  --> $DIR/bad-reg.rs:115:36
+   |
+LL |         asm!("/* {} */", in(vsreg) x); // FIXME: should be ok if vsx is available
+   |                                    ^
+   |
+   = note: register class `vsreg` supports these types: f32, f64, i8x16, i16x8, i32x4, i64x2, f32x4, f64x2
+
+error: type `i32` cannot be used with this register class
+  --> $DIR/bad-reg.rs:138:27
    |
 LL |         asm!("", in("cr") x);
    |                           ^
@@ -233,7 +769,7 @@ LL |         asm!("", in("cr") x);
    = note: register class `cr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:100:28
+  --> $DIR/bad-reg.rs:141:28
    |
 LL |         asm!("", out("cr") x);
    |                            ^
@@ -241,7 +777,7 @@ LL |         asm!("", out("cr") x);
    = note: register class `cr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:103:33
+  --> $DIR/bad-reg.rs:144:33
    |
 LL |         asm!("/* {} */", in(cr) x);
    |                                 ^
@@ -249,7 +785,7 @@ LL |         asm!("/* {} */", in(cr) x);
    = note: register class `cr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:110:28
+  --> $DIR/bad-reg.rs:151:28
    |
 LL |         asm!("", in("ctr") x);
    |                            ^
@@ -257,7 +793,7 @@ LL |         asm!("", in("ctr") x);
    = note: register class `ctr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:113:29
+  --> $DIR/bad-reg.rs:154:29
    |
 LL |         asm!("", out("ctr") x);
    |                             ^
@@ -265,7 +801,7 @@ LL |         asm!("", out("ctr") x);
    = note: register class `ctr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:116:34
+  --> $DIR/bad-reg.rs:157:34
    |
 LL |         asm!("/* {} */", in(ctr) x);
    |                                  ^
@@ -273,7 +809,7 @@ LL |         asm!("/* {} */", in(ctr) x);
    = note: register class `ctr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:123:27
+  --> $DIR/bad-reg.rs:164:27
    |
 LL |         asm!("", in("lr") x);
    |                           ^
@@ -281,7 +817,7 @@ LL |         asm!("", in("lr") x);
    = note: register class `lr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:126:28
+  --> $DIR/bad-reg.rs:167:28
    |
 LL |         asm!("", out("lr") x);
    |                            ^
@@ -289,7 +825,7 @@ LL |         asm!("", out("lr") x);
    = note: register class `lr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:129:33
+  --> $DIR/bad-reg.rs:170:33
    |
 LL |         asm!("/* {} */", in(lr) x);
    |                                 ^
@@ -297,7 +833,7 @@ LL |         asm!("/* {} */", in(lr) x);
    = note: register class `lr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:136:28
+  --> $DIR/bad-reg.rs:177:28
    |
 LL |         asm!("", in("xer") x);
    |                            ^
@@ -305,7 +841,7 @@ LL |         asm!("", in("xer") x);
    = note: register class `xer` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:139:29
+  --> $DIR/bad-reg.rs:180:29
    |
 LL |         asm!("", out("xer") x);
    |                             ^
@@ -313,12 +849,12 @@ LL |         asm!("", out("xer") x);
    = note: register class `xer` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:142:34
+  --> $DIR/bad-reg.rs:183:34
    |
 LL |         asm!("/* {} */", in(xer) x);
    |                                  ^
    |
    = note: register class `xer` supports these types: 
 
-error: aborting due to 46 previous errors
+error: aborting due to 113 previous errors
 

--- a/tests/ui/asm/powerpc/bad-reg.powerpc.stderr
+++ b/tests/ui/asm/powerpc/bad-reg.powerpc.stderr
@@ -35,103 +35,103 @@ LL |         asm!("", out("vrsave") _);
    |                  ^^^^^^^^^^^^^^^
 
 error: register class `cr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:97:18
+  --> $DIR/bad-reg.rs:138:18
    |
 LL |         asm!("", in("cr") x);
    |                  ^^^^^^^^^^
 
 error: register class `cr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:100:18
+  --> $DIR/bad-reg.rs:141:18
    |
 LL |         asm!("", out("cr") x);
    |                  ^^^^^^^^^^^
 
 error: register class `cr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:103:26
+  --> $DIR/bad-reg.rs:144:26
    |
 LL |         asm!("/* {} */", in(cr) x);
    |                          ^^^^^^^^
 
 error: register class `cr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:106:26
+  --> $DIR/bad-reg.rs:147:26
    |
 LL |         asm!("/* {} */", out(cr) _);
    |                          ^^^^^^^^^
 
 error: register class `ctr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:110:18
+  --> $DIR/bad-reg.rs:151:18
    |
 LL |         asm!("", in("ctr") x);
    |                  ^^^^^^^^^^^
 
 error: register class `ctr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:113:18
+  --> $DIR/bad-reg.rs:154:18
    |
 LL |         asm!("", out("ctr") x);
    |                  ^^^^^^^^^^^^
 
 error: register class `ctr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:116:26
+  --> $DIR/bad-reg.rs:157:26
    |
 LL |         asm!("/* {} */", in(ctr) x);
    |                          ^^^^^^^^^
 
 error: register class `ctr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:119:26
+  --> $DIR/bad-reg.rs:160:26
    |
 LL |         asm!("/* {} */", out(ctr) _);
    |                          ^^^^^^^^^^
 
 error: register class `lr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:123:18
+  --> $DIR/bad-reg.rs:164:18
    |
 LL |         asm!("", in("lr") x);
    |                  ^^^^^^^^^^
 
 error: register class `lr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:126:18
+  --> $DIR/bad-reg.rs:167:18
    |
 LL |         asm!("", out("lr") x);
    |                  ^^^^^^^^^^^
 
 error: register class `lr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:129:26
+  --> $DIR/bad-reg.rs:170:26
    |
 LL |         asm!("/* {} */", in(lr) x);
    |                          ^^^^^^^^
 
 error: register class `lr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:132:26
+  --> $DIR/bad-reg.rs:173:26
    |
 LL |         asm!("/* {} */", out(lr) _);
    |                          ^^^^^^^^^
 
 error: register class `xer` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:136:18
+  --> $DIR/bad-reg.rs:177:18
    |
 LL |         asm!("", in("xer") x);
    |                  ^^^^^^^^^^^
 
 error: register class `xer` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:139:18
+  --> $DIR/bad-reg.rs:180:18
    |
 LL |         asm!("", out("xer") x);
    |                  ^^^^^^^^^^^^
 
 error: register class `xer` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:142:26
+  --> $DIR/bad-reg.rs:183:26
    |
 LL |         asm!("/* {} */", in(xer) x);
    |                          ^^^^^^^^^
 
 error: register class `xer` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:145:26
+  --> $DIR/bad-reg.rs:186:26
    |
 LL |         asm!("/* {} */", out(xer) _);
    |                          ^^^^^^^^^^
 
 error: register `cr0` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:149:31
+  --> $DIR/bad-reg.rs:190:31
    |
 LL |         asm!("", out("cr") _, out("cr0") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr0`
@@ -139,7 +139,7 @@ LL |         asm!("", out("cr") _, out("cr0") _);
    |                  register `cr`
 
 error: register `cr1` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:151:31
+  --> $DIR/bad-reg.rs:192:31
    |
 LL |         asm!("", out("cr") _, out("cr1") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr1`
@@ -147,7 +147,7 @@ LL |         asm!("", out("cr") _, out("cr1") _);
    |                  register `cr`
 
 error: register `cr2` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:153:31
+  --> $DIR/bad-reg.rs:194:31
    |
 LL |         asm!("", out("cr") _, out("cr2") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr2`
@@ -155,7 +155,7 @@ LL |         asm!("", out("cr") _, out("cr2") _);
    |                  register `cr`
 
 error: register `cr3` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:155:31
+  --> $DIR/bad-reg.rs:196:31
    |
 LL |         asm!("", out("cr") _, out("cr3") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr3`
@@ -163,7 +163,7 @@ LL |         asm!("", out("cr") _, out("cr3") _);
    |                  register `cr`
 
 error: register `cr4` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:157:31
+  --> $DIR/bad-reg.rs:198:31
    |
 LL |         asm!("", out("cr") _, out("cr4") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr4`
@@ -171,7 +171,7 @@ LL |         asm!("", out("cr") _, out("cr4") _);
    |                  register `cr`
 
 error: register `cr5` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:159:31
+  --> $DIR/bad-reg.rs:200:31
    |
 LL |         asm!("", out("cr") _, out("cr5") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr5`
@@ -179,7 +179,7 @@ LL |         asm!("", out("cr") _, out("cr5") _);
    |                  register `cr`
 
 error: register `cr6` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:161:31
+  --> $DIR/bad-reg.rs:202:31
    |
 LL |         asm!("", out("cr") _, out("cr6") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr6`
@@ -187,12 +187,524 @@ LL |         asm!("", out("cr") _, out("cr6") _);
    |                  register `cr`
 
 error: register `cr7` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:163:31
+  --> $DIR/bad-reg.rs:204:31
    |
 LL |         asm!("", out("cr") _, out("cr7") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr7`
    |                  |
    |                  register `cr`
+
+error: register `vs0` conflicts with register `f0`
+  --> $DIR/bad-reg.rs:207:31
+   |
+LL |         asm!("", out("f0") _, out("vs0") _);
+   |                  -----------  ^^^^^^^^^^^^ register `vs0`
+   |                  |
+   |                  register `f0`
+
+error: register `vs1` conflicts with register `f1`
+  --> $DIR/bad-reg.rs:209:31
+   |
+LL |         asm!("", out("f1") _, out("vs1") _);
+   |                  -----------  ^^^^^^^^^^^^ register `vs1`
+   |                  |
+   |                  register `f1`
+
+error: register `vs2` conflicts with register `f2`
+  --> $DIR/bad-reg.rs:211:31
+   |
+LL |         asm!("", out("f2") _, out("vs2") _);
+   |                  -----------  ^^^^^^^^^^^^ register `vs2`
+   |                  |
+   |                  register `f2`
+
+error: register `vs3` conflicts with register `f3`
+  --> $DIR/bad-reg.rs:213:31
+   |
+LL |         asm!("", out("f3") _, out("vs3") _);
+   |                  -----------  ^^^^^^^^^^^^ register `vs3`
+   |                  |
+   |                  register `f3`
+
+error: register `vs4` conflicts with register `f4`
+  --> $DIR/bad-reg.rs:215:31
+   |
+LL |         asm!("", out("f4") _, out("vs4") _);
+   |                  -----------  ^^^^^^^^^^^^ register `vs4`
+   |                  |
+   |                  register `f4`
+
+error: register `vs5` conflicts with register `f5`
+  --> $DIR/bad-reg.rs:217:31
+   |
+LL |         asm!("", out("f5") _, out("vs5") _);
+   |                  -----------  ^^^^^^^^^^^^ register `vs5`
+   |                  |
+   |                  register `f5`
+
+error: register `vs6` conflicts with register `f6`
+  --> $DIR/bad-reg.rs:219:31
+   |
+LL |         asm!("", out("f6") _, out("vs6") _);
+   |                  -----------  ^^^^^^^^^^^^ register `vs6`
+   |                  |
+   |                  register `f6`
+
+error: register `vs7` conflicts with register `f7`
+  --> $DIR/bad-reg.rs:221:31
+   |
+LL |         asm!("", out("f7") _, out("vs7") _);
+   |                  -----------  ^^^^^^^^^^^^ register `vs7`
+   |                  |
+   |                  register `f7`
+
+error: register `vs8` conflicts with register `f8`
+  --> $DIR/bad-reg.rs:223:31
+   |
+LL |         asm!("", out("f8") _, out("vs8") _);
+   |                  -----------  ^^^^^^^^^^^^ register `vs8`
+   |                  |
+   |                  register `f8`
+
+error: register `vs9` conflicts with register `f9`
+  --> $DIR/bad-reg.rs:225:31
+   |
+LL |         asm!("", out("f9") _, out("vs9") _);
+   |                  -----------  ^^^^^^^^^^^^ register `vs9`
+   |                  |
+   |                  register `f9`
+
+error: register `vs10` conflicts with register `f10`
+  --> $DIR/bad-reg.rs:227:32
+   |
+LL |         asm!("", out("f10") _, out("vs10") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs10`
+   |                  |
+   |                  register `f10`
+
+error: register `vs11` conflicts with register `f11`
+  --> $DIR/bad-reg.rs:229:32
+   |
+LL |         asm!("", out("f11") _, out("vs11") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs11`
+   |                  |
+   |                  register `f11`
+
+error: register `vs12` conflicts with register `f12`
+  --> $DIR/bad-reg.rs:231:32
+   |
+LL |         asm!("", out("f12") _, out("vs12") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs12`
+   |                  |
+   |                  register `f12`
+
+error: register `vs13` conflicts with register `f13`
+  --> $DIR/bad-reg.rs:233:32
+   |
+LL |         asm!("", out("f13") _, out("vs13") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs13`
+   |                  |
+   |                  register `f13`
+
+error: register `vs14` conflicts with register `f14`
+  --> $DIR/bad-reg.rs:235:32
+   |
+LL |         asm!("", out("f14") _, out("vs14") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs14`
+   |                  |
+   |                  register `f14`
+
+error: register `vs15` conflicts with register `f15`
+  --> $DIR/bad-reg.rs:237:32
+   |
+LL |         asm!("", out("f15") _, out("vs15") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs15`
+   |                  |
+   |                  register `f15`
+
+error: register `vs16` conflicts with register `f16`
+  --> $DIR/bad-reg.rs:239:32
+   |
+LL |         asm!("", out("f16") _, out("vs16") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs16`
+   |                  |
+   |                  register `f16`
+
+error: register `vs17` conflicts with register `f17`
+  --> $DIR/bad-reg.rs:241:32
+   |
+LL |         asm!("", out("f17") _, out("vs17") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs17`
+   |                  |
+   |                  register `f17`
+
+error: register `vs18` conflicts with register `f18`
+  --> $DIR/bad-reg.rs:243:32
+   |
+LL |         asm!("", out("f18") _, out("vs18") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs18`
+   |                  |
+   |                  register `f18`
+
+error: register `vs19` conflicts with register `f19`
+  --> $DIR/bad-reg.rs:245:32
+   |
+LL |         asm!("", out("f19") _, out("vs19") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs19`
+   |                  |
+   |                  register `f19`
+
+error: register `vs20` conflicts with register `f20`
+  --> $DIR/bad-reg.rs:247:32
+   |
+LL |         asm!("", out("f20") _, out("vs20") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs20`
+   |                  |
+   |                  register `f20`
+
+error: register `vs21` conflicts with register `f21`
+  --> $DIR/bad-reg.rs:249:32
+   |
+LL |         asm!("", out("f21") _, out("vs21") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs21`
+   |                  |
+   |                  register `f21`
+
+error: register `vs22` conflicts with register `f22`
+  --> $DIR/bad-reg.rs:251:32
+   |
+LL |         asm!("", out("f22") _, out("vs22") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs22`
+   |                  |
+   |                  register `f22`
+
+error: register `vs23` conflicts with register `f23`
+  --> $DIR/bad-reg.rs:253:32
+   |
+LL |         asm!("", out("f23") _, out("vs23") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs23`
+   |                  |
+   |                  register `f23`
+
+error: register `vs24` conflicts with register `f24`
+  --> $DIR/bad-reg.rs:255:32
+   |
+LL |         asm!("", out("f24") _, out("vs24") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs24`
+   |                  |
+   |                  register `f24`
+
+error: register `vs25` conflicts with register `f25`
+  --> $DIR/bad-reg.rs:257:32
+   |
+LL |         asm!("", out("f25") _, out("vs25") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs25`
+   |                  |
+   |                  register `f25`
+
+error: register `vs26` conflicts with register `f26`
+  --> $DIR/bad-reg.rs:259:32
+   |
+LL |         asm!("", out("f26") _, out("vs26") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs26`
+   |                  |
+   |                  register `f26`
+
+error: register `vs27` conflicts with register `f27`
+  --> $DIR/bad-reg.rs:261:32
+   |
+LL |         asm!("", out("f27") _, out("vs27") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs27`
+   |                  |
+   |                  register `f27`
+
+error: register `vs28` conflicts with register `f28`
+  --> $DIR/bad-reg.rs:263:32
+   |
+LL |         asm!("", out("f28") _, out("vs28") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs28`
+   |                  |
+   |                  register `f28`
+
+error: register `vs29` conflicts with register `f29`
+  --> $DIR/bad-reg.rs:265:32
+   |
+LL |         asm!("", out("f29") _, out("vs29") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs29`
+   |                  |
+   |                  register `f29`
+
+error: register `vs30` conflicts with register `f30`
+  --> $DIR/bad-reg.rs:267:32
+   |
+LL |         asm!("", out("f30") _, out("vs30") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs30`
+   |                  |
+   |                  register `f30`
+
+error: register `vs31` conflicts with register `f31`
+  --> $DIR/bad-reg.rs:269:32
+   |
+LL |         asm!("", out("f31") _, out("vs31") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs31`
+   |                  |
+   |                  register `f31`
+
+error: register `v0` conflicts with register `vs32`
+  --> $DIR/bad-reg.rs:271:33
+   |
+LL |         asm!("", out("vs32") _, out("v0") _);
+   |                  -------------  ^^^^^^^^^^^ register `v0`
+   |                  |
+   |                  register `vs32`
+
+error: register `v1` conflicts with register `vs33`
+  --> $DIR/bad-reg.rs:273:33
+   |
+LL |         asm!("", out("vs33") _, out("v1") _);
+   |                  -------------  ^^^^^^^^^^^ register `v1`
+   |                  |
+   |                  register `vs33`
+
+error: register `v2` conflicts with register `vs34`
+  --> $DIR/bad-reg.rs:275:33
+   |
+LL |         asm!("", out("vs34") _, out("v2") _);
+   |                  -------------  ^^^^^^^^^^^ register `v2`
+   |                  |
+   |                  register `vs34`
+
+error: register `v3` conflicts with register `vs35`
+  --> $DIR/bad-reg.rs:277:33
+   |
+LL |         asm!("", out("vs35") _, out("v3") _);
+   |                  -------------  ^^^^^^^^^^^ register `v3`
+   |                  |
+   |                  register `vs35`
+
+error: register `v4` conflicts with register `vs36`
+  --> $DIR/bad-reg.rs:279:33
+   |
+LL |         asm!("", out("vs36") _, out("v4") _);
+   |                  -------------  ^^^^^^^^^^^ register `v4`
+   |                  |
+   |                  register `vs36`
+
+error: register `v5` conflicts with register `vs37`
+  --> $DIR/bad-reg.rs:281:33
+   |
+LL |         asm!("", out("vs37") _, out("v5") _);
+   |                  -------------  ^^^^^^^^^^^ register `v5`
+   |                  |
+   |                  register `vs37`
+
+error: register `v6` conflicts with register `vs38`
+  --> $DIR/bad-reg.rs:283:33
+   |
+LL |         asm!("", out("vs38") _, out("v6") _);
+   |                  -------------  ^^^^^^^^^^^ register `v6`
+   |                  |
+   |                  register `vs38`
+
+error: register `v7` conflicts with register `vs39`
+  --> $DIR/bad-reg.rs:285:33
+   |
+LL |         asm!("", out("vs39") _, out("v7") _);
+   |                  -------------  ^^^^^^^^^^^ register `v7`
+   |                  |
+   |                  register `vs39`
+
+error: register `v8` conflicts with register `vs40`
+  --> $DIR/bad-reg.rs:287:33
+   |
+LL |         asm!("", out("vs40") _, out("v8") _);
+   |                  -------------  ^^^^^^^^^^^ register `v8`
+   |                  |
+   |                  register `vs40`
+
+error: register `v9` conflicts with register `vs41`
+  --> $DIR/bad-reg.rs:289:33
+   |
+LL |         asm!("", out("vs41") _, out("v9") _);
+   |                  -------------  ^^^^^^^^^^^ register `v9`
+   |                  |
+   |                  register `vs41`
+
+error: register `v10` conflicts with register `vs42`
+  --> $DIR/bad-reg.rs:291:33
+   |
+LL |         asm!("", out("vs42") _, out("v10") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v10`
+   |                  |
+   |                  register `vs42`
+
+error: register `v11` conflicts with register `vs43`
+  --> $DIR/bad-reg.rs:293:33
+   |
+LL |         asm!("", out("vs43") _, out("v11") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v11`
+   |                  |
+   |                  register `vs43`
+
+error: register `v12` conflicts with register `vs44`
+  --> $DIR/bad-reg.rs:295:33
+   |
+LL |         asm!("", out("vs44") _, out("v12") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v12`
+   |                  |
+   |                  register `vs44`
+
+error: register `v13` conflicts with register `vs45`
+  --> $DIR/bad-reg.rs:297:33
+   |
+LL |         asm!("", out("vs45") _, out("v13") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v13`
+   |                  |
+   |                  register `vs45`
+
+error: register `v14` conflicts with register `vs46`
+  --> $DIR/bad-reg.rs:299:33
+   |
+LL |         asm!("", out("vs46") _, out("v14") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v14`
+   |                  |
+   |                  register `vs46`
+
+error: register `v15` conflicts with register `vs47`
+  --> $DIR/bad-reg.rs:301:33
+   |
+LL |         asm!("", out("vs47") _, out("v15") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v15`
+   |                  |
+   |                  register `vs47`
+
+error: register `v16` conflicts with register `vs48`
+  --> $DIR/bad-reg.rs:303:33
+   |
+LL |         asm!("", out("vs48") _, out("v16") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v16`
+   |                  |
+   |                  register `vs48`
+
+error: register `v17` conflicts with register `vs49`
+  --> $DIR/bad-reg.rs:305:33
+   |
+LL |         asm!("", out("vs49") _, out("v17") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v17`
+   |                  |
+   |                  register `vs49`
+
+error: register `v18` conflicts with register `vs50`
+  --> $DIR/bad-reg.rs:307:33
+   |
+LL |         asm!("", out("vs50") _, out("v18") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v18`
+   |                  |
+   |                  register `vs50`
+
+error: register `v19` conflicts with register `vs51`
+  --> $DIR/bad-reg.rs:309:33
+   |
+LL |         asm!("", out("vs51") _, out("v19") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v19`
+   |                  |
+   |                  register `vs51`
+
+error: register `v20` conflicts with register `vs52`
+  --> $DIR/bad-reg.rs:311:33
+   |
+LL |         asm!("", out("vs52") _, out("v20") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v20`
+   |                  |
+   |                  register `vs52`
+
+error: register `v21` conflicts with register `vs53`
+  --> $DIR/bad-reg.rs:313:33
+   |
+LL |         asm!("", out("vs53") _, out("v21") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v21`
+   |                  |
+   |                  register `vs53`
+
+error: register `v22` conflicts with register `vs54`
+  --> $DIR/bad-reg.rs:315:33
+   |
+LL |         asm!("", out("vs54") _, out("v22") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v22`
+   |                  |
+   |                  register `vs54`
+
+error: register `v23` conflicts with register `vs55`
+  --> $DIR/bad-reg.rs:317:33
+   |
+LL |         asm!("", out("vs55") _, out("v23") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v23`
+   |                  |
+   |                  register `vs55`
+
+error: register `v24` conflicts with register `vs56`
+  --> $DIR/bad-reg.rs:319:33
+   |
+LL |         asm!("", out("vs56") _, out("v24") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v24`
+   |                  |
+   |                  register `vs56`
+
+error: register `v25` conflicts with register `vs57`
+  --> $DIR/bad-reg.rs:321:33
+   |
+LL |         asm!("", out("vs57") _, out("v25") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v25`
+   |                  |
+   |                  register `vs57`
+
+error: register `v26` conflicts with register `vs58`
+  --> $DIR/bad-reg.rs:323:33
+   |
+LL |         asm!("", out("vs58") _, out("v26") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v26`
+   |                  |
+   |                  register `vs58`
+
+error: register `v27` conflicts with register `vs59`
+  --> $DIR/bad-reg.rs:325:33
+   |
+LL |         asm!("", out("vs59") _, out("v27") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v27`
+   |                  |
+   |                  register `vs59`
+
+error: register `v28` conflicts with register `vs60`
+  --> $DIR/bad-reg.rs:327:33
+   |
+LL |         asm!("", out("vs60") _, out("v28") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v28`
+   |                  |
+   |                  register `vs60`
+
+error: register `v29` conflicts with register `vs61`
+  --> $DIR/bad-reg.rs:329:33
+   |
+LL |         asm!("", out("vs61") _, out("v29") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v29`
+   |                  |
+   |                  register `vs61`
+
+error: register `v30` conflicts with register `vs62`
+  --> $DIR/bad-reg.rs:331:33
+   |
+LL |         asm!("", out("vs62") _, out("v30") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v30`
+   |                  |
+   |                  register `vs62`
+
+error: register `v31` conflicts with register `vs63`
+  --> $DIR/bad-reg.rs:333:33
+   |
+LL |         asm!("", out("vs63") _, out("v31") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v31`
+   |                  |
+   |                  register `vs63`
 
 error: cannot use register `r13`: r13 is a reserved register on this target
   --> $DIR/bad-reg.rs:41:18
@@ -260,8 +772,68 @@ error: register class `vreg` requires at least one of the following target featu
 LL |         asm!("/* {} */", out(vreg) _); // requires altivec
    |                          ^^^^^^^^^^^
 
+error: register class `vsreg` requires the `vsx` target feature
+  --> $DIR/bad-reg.rs:97:18
+   |
+LL |         asm!("", in("vs0") v32x4); // requires vsx
+   |                  ^^^^^^^^^^^^^^^
+
+error: register class `vsreg` requires the `vsx` target feature
+  --> $DIR/bad-reg.rs:99:18
+   |
+LL |         asm!("", out("vs0") v32x4); // requires vsx
+   |                  ^^^^^^^^^^^^^^^^
+
+error: register class `vsreg` requires the `vsx` target feature
+  --> $DIR/bad-reg.rs:101:18
+   |
+LL |         asm!("", in("vs0") v64x2); // requires vsx
+   |                  ^^^^^^^^^^^^^^^
+
+error: register class `vsreg` requires the `vsx` target feature
+  --> $DIR/bad-reg.rs:103:18
+   |
+LL |         asm!("", out("vs0") v64x2); // requires vsx
+   |                  ^^^^^^^^^^^^^^^^
+
+error: register class `vsreg` requires the `vsx` target feature
+  --> $DIR/bad-reg.rs:105:18
+   |
+LL |         asm!("", in("vs0") x); // FIXME: should be ok if vsx is available
+   |                  ^^^^^^^^^^^
+
+error: register class `vsreg` requires the `vsx` target feature
+  --> $DIR/bad-reg.rs:108:18
+   |
+LL |         asm!("", out("vs0") x); // FIXME: should be ok if vsx is available
+   |                  ^^^^^^^^^^^^
+
+error: register class `vsreg` requires the `vsx` target feature
+  --> $DIR/bad-reg.rs:111:26
+   |
+LL |         asm!("/* {} */", in(vsreg) v32x4); // requires vsx
+   |                          ^^^^^^^^^^^^^^^
+
+error: register class `vsreg` requires the `vsx` target feature
+  --> $DIR/bad-reg.rs:113:26
+   |
+LL |         asm!("/* {} */", in(vsreg) v64x2); // requires vsx
+   |                          ^^^^^^^^^^^^^^^
+
+error: register class `vsreg` requires the `vsx` target feature
+  --> $DIR/bad-reg.rs:115:26
+   |
+LL |         asm!("/* {} */", in(vsreg) x); // FIXME: should be ok if vsx is available
+   |                          ^^^^^^^^^^^
+
+error: register class `vsreg` requires the `vsx` target feature
+  --> $DIR/bad-reg.rs:118:26
+   |
+LL |         asm!("/* {} */", out(vsreg) _); // requires vsx
+   |                          ^^^^^^^^^^^^
+
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:97:27
+  --> $DIR/bad-reg.rs:138:27
    |
 LL |         asm!("", in("cr") x);
    |                           ^
@@ -269,7 +841,7 @@ LL |         asm!("", in("cr") x);
    = note: register class `cr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:100:28
+  --> $DIR/bad-reg.rs:141:28
    |
 LL |         asm!("", out("cr") x);
    |                            ^
@@ -277,7 +849,7 @@ LL |         asm!("", out("cr") x);
    = note: register class `cr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:103:33
+  --> $DIR/bad-reg.rs:144:33
    |
 LL |         asm!("/* {} */", in(cr) x);
    |                                 ^
@@ -285,7 +857,7 @@ LL |         asm!("/* {} */", in(cr) x);
    = note: register class `cr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:110:28
+  --> $DIR/bad-reg.rs:151:28
    |
 LL |         asm!("", in("ctr") x);
    |                            ^
@@ -293,7 +865,7 @@ LL |         asm!("", in("ctr") x);
    = note: register class `ctr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:113:29
+  --> $DIR/bad-reg.rs:154:29
    |
 LL |         asm!("", out("ctr") x);
    |                             ^
@@ -301,7 +873,7 @@ LL |         asm!("", out("ctr") x);
    = note: register class `ctr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:116:34
+  --> $DIR/bad-reg.rs:157:34
    |
 LL |         asm!("/* {} */", in(ctr) x);
    |                                  ^
@@ -309,7 +881,7 @@ LL |         asm!("/* {} */", in(ctr) x);
    = note: register class `ctr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:123:27
+  --> $DIR/bad-reg.rs:164:27
    |
 LL |         asm!("", in("lr") x);
    |                           ^
@@ -317,7 +889,7 @@ LL |         asm!("", in("lr") x);
    = note: register class `lr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:126:28
+  --> $DIR/bad-reg.rs:167:28
    |
 LL |         asm!("", out("lr") x);
    |                            ^
@@ -325,7 +897,7 @@ LL |         asm!("", out("lr") x);
    = note: register class `lr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:129:33
+  --> $DIR/bad-reg.rs:170:33
    |
 LL |         asm!("/* {} */", in(lr) x);
    |                                 ^
@@ -333,7 +905,7 @@ LL |         asm!("/* {} */", in(lr) x);
    = note: register class `lr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:136:28
+  --> $DIR/bad-reg.rs:177:28
    |
 LL |         asm!("", in("xer") x);
    |                            ^
@@ -341,7 +913,7 @@ LL |         asm!("", in("xer") x);
    = note: register class `xer` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:139:29
+  --> $DIR/bad-reg.rs:180:29
    |
 LL |         asm!("", out("xer") x);
    |                             ^
@@ -349,12 +921,12 @@ LL |         asm!("", out("xer") x);
    = note: register class `xer` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:142:34
+  --> $DIR/bad-reg.rs:183:34
    |
 LL |         asm!("/* {} */", in(xer) x);
    |                                  ^
    |
    = note: register class `xer` supports these types: 
 
-error: aborting due to 53 previous errors
+error: aborting due to 127 previous errors
 

--- a/tests/ui/asm/powerpc/bad-reg.powerpc64.stderr
+++ b/tests/ui/asm/powerpc/bad-reg.powerpc64.stderr
@@ -35,103 +35,103 @@ LL |         asm!("", out("vrsave") _);
    |                  ^^^^^^^^^^^^^^^
 
 error: register class `cr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:97:18
+  --> $DIR/bad-reg.rs:138:18
    |
 LL |         asm!("", in("cr") x);
    |                  ^^^^^^^^^^
 
 error: register class `cr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:100:18
+  --> $DIR/bad-reg.rs:141:18
    |
 LL |         asm!("", out("cr") x);
    |                  ^^^^^^^^^^^
 
 error: register class `cr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:103:26
+  --> $DIR/bad-reg.rs:144:26
    |
 LL |         asm!("/* {} */", in(cr) x);
    |                          ^^^^^^^^
 
 error: register class `cr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:106:26
+  --> $DIR/bad-reg.rs:147:26
    |
 LL |         asm!("/* {} */", out(cr) _);
    |                          ^^^^^^^^^
 
 error: register class `ctr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:110:18
+  --> $DIR/bad-reg.rs:151:18
    |
 LL |         asm!("", in("ctr") x);
    |                  ^^^^^^^^^^^
 
 error: register class `ctr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:113:18
+  --> $DIR/bad-reg.rs:154:18
    |
 LL |         asm!("", out("ctr") x);
    |                  ^^^^^^^^^^^^
 
 error: register class `ctr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:116:26
+  --> $DIR/bad-reg.rs:157:26
    |
 LL |         asm!("/* {} */", in(ctr) x);
    |                          ^^^^^^^^^
 
 error: register class `ctr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:119:26
+  --> $DIR/bad-reg.rs:160:26
    |
 LL |         asm!("/* {} */", out(ctr) _);
    |                          ^^^^^^^^^^
 
 error: register class `lr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:123:18
+  --> $DIR/bad-reg.rs:164:18
    |
 LL |         asm!("", in("lr") x);
    |                  ^^^^^^^^^^
 
 error: register class `lr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:126:18
+  --> $DIR/bad-reg.rs:167:18
    |
 LL |         asm!("", out("lr") x);
    |                  ^^^^^^^^^^^
 
 error: register class `lr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:129:26
+  --> $DIR/bad-reg.rs:170:26
    |
 LL |         asm!("/* {} */", in(lr) x);
    |                          ^^^^^^^^
 
 error: register class `lr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:132:26
+  --> $DIR/bad-reg.rs:173:26
    |
 LL |         asm!("/* {} */", out(lr) _);
    |                          ^^^^^^^^^
 
 error: register class `xer` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:136:18
+  --> $DIR/bad-reg.rs:177:18
    |
 LL |         asm!("", in("xer") x);
    |                  ^^^^^^^^^^^
 
 error: register class `xer` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:139:18
+  --> $DIR/bad-reg.rs:180:18
    |
 LL |         asm!("", out("xer") x);
    |                  ^^^^^^^^^^^^
 
 error: register class `xer` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:142:26
+  --> $DIR/bad-reg.rs:183:26
    |
 LL |         asm!("/* {} */", in(xer) x);
    |                          ^^^^^^^^^
 
 error: register class `xer` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:145:26
+  --> $DIR/bad-reg.rs:186:26
    |
 LL |         asm!("/* {} */", out(xer) _);
    |                          ^^^^^^^^^^
 
 error: register `cr0` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:149:31
+  --> $DIR/bad-reg.rs:190:31
    |
 LL |         asm!("", out("cr") _, out("cr0") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr0`
@@ -139,7 +139,7 @@ LL |         asm!("", out("cr") _, out("cr0") _);
    |                  register `cr`
 
 error: register `cr1` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:151:31
+  --> $DIR/bad-reg.rs:192:31
    |
 LL |         asm!("", out("cr") _, out("cr1") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr1`
@@ -147,7 +147,7 @@ LL |         asm!("", out("cr") _, out("cr1") _);
    |                  register `cr`
 
 error: register `cr2` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:153:31
+  --> $DIR/bad-reg.rs:194:31
    |
 LL |         asm!("", out("cr") _, out("cr2") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr2`
@@ -155,7 +155,7 @@ LL |         asm!("", out("cr") _, out("cr2") _);
    |                  register `cr`
 
 error: register `cr3` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:155:31
+  --> $DIR/bad-reg.rs:196:31
    |
 LL |         asm!("", out("cr") _, out("cr3") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr3`
@@ -163,7 +163,7 @@ LL |         asm!("", out("cr") _, out("cr3") _);
    |                  register `cr`
 
 error: register `cr4` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:157:31
+  --> $DIR/bad-reg.rs:198:31
    |
 LL |         asm!("", out("cr") _, out("cr4") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr4`
@@ -171,7 +171,7 @@ LL |         asm!("", out("cr") _, out("cr4") _);
    |                  register `cr`
 
 error: register `cr5` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:159:31
+  --> $DIR/bad-reg.rs:200:31
    |
 LL |         asm!("", out("cr") _, out("cr5") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr5`
@@ -179,7 +179,7 @@ LL |         asm!("", out("cr") _, out("cr5") _);
    |                  register `cr`
 
 error: register `cr6` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:161:31
+  --> $DIR/bad-reg.rs:202:31
    |
 LL |         asm!("", out("cr") _, out("cr6") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr6`
@@ -187,12 +187,524 @@ LL |         asm!("", out("cr") _, out("cr6") _);
    |                  register `cr`
 
 error: register `cr7` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:163:31
+  --> $DIR/bad-reg.rs:204:31
    |
 LL |         asm!("", out("cr") _, out("cr7") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr7`
    |                  |
    |                  register `cr`
+
+error: register `vs0` conflicts with register `f0`
+  --> $DIR/bad-reg.rs:207:31
+   |
+LL |         asm!("", out("f0") _, out("vs0") _);
+   |                  -----------  ^^^^^^^^^^^^ register `vs0`
+   |                  |
+   |                  register `f0`
+
+error: register `vs1` conflicts with register `f1`
+  --> $DIR/bad-reg.rs:209:31
+   |
+LL |         asm!("", out("f1") _, out("vs1") _);
+   |                  -----------  ^^^^^^^^^^^^ register `vs1`
+   |                  |
+   |                  register `f1`
+
+error: register `vs2` conflicts with register `f2`
+  --> $DIR/bad-reg.rs:211:31
+   |
+LL |         asm!("", out("f2") _, out("vs2") _);
+   |                  -----------  ^^^^^^^^^^^^ register `vs2`
+   |                  |
+   |                  register `f2`
+
+error: register `vs3` conflicts with register `f3`
+  --> $DIR/bad-reg.rs:213:31
+   |
+LL |         asm!("", out("f3") _, out("vs3") _);
+   |                  -----------  ^^^^^^^^^^^^ register `vs3`
+   |                  |
+   |                  register `f3`
+
+error: register `vs4` conflicts with register `f4`
+  --> $DIR/bad-reg.rs:215:31
+   |
+LL |         asm!("", out("f4") _, out("vs4") _);
+   |                  -----------  ^^^^^^^^^^^^ register `vs4`
+   |                  |
+   |                  register `f4`
+
+error: register `vs5` conflicts with register `f5`
+  --> $DIR/bad-reg.rs:217:31
+   |
+LL |         asm!("", out("f5") _, out("vs5") _);
+   |                  -----------  ^^^^^^^^^^^^ register `vs5`
+   |                  |
+   |                  register `f5`
+
+error: register `vs6` conflicts with register `f6`
+  --> $DIR/bad-reg.rs:219:31
+   |
+LL |         asm!("", out("f6") _, out("vs6") _);
+   |                  -----------  ^^^^^^^^^^^^ register `vs6`
+   |                  |
+   |                  register `f6`
+
+error: register `vs7` conflicts with register `f7`
+  --> $DIR/bad-reg.rs:221:31
+   |
+LL |         asm!("", out("f7") _, out("vs7") _);
+   |                  -----------  ^^^^^^^^^^^^ register `vs7`
+   |                  |
+   |                  register `f7`
+
+error: register `vs8` conflicts with register `f8`
+  --> $DIR/bad-reg.rs:223:31
+   |
+LL |         asm!("", out("f8") _, out("vs8") _);
+   |                  -----------  ^^^^^^^^^^^^ register `vs8`
+   |                  |
+   |                  register `f8`
+
+error: register `vs9` conflicts with register `f9`
+  --> $DIR/bad-reg.rs:225:31
+   |
+LL |         asm!("", out("f9") _, out("vs9") _);
+   |                  -----------  ^^^^^^^^^^^^ register `vs9`
+   |                  |
+   |                  register `f9`
+
+error: register `vs10` conflicts with register `f10`
+  --> $DIR/bad-reg.rs:227:32
+   |
+LL |         asm!("", out("f10") _, out("vs10") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs10`
+   |                  |
+   |                  register `f10`
+
+error: register `vs11` conflicts with register `f11`
+  --> $DIR/bad-reg.rs:229:32
+   |
+LL |         asm!("", out("f11") _, out("vs11") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs11`
+   |                  |
+   |                  register `f11`
+
+error: register `vs12` conflicts with register `f12`
+  --> $DIR/bad-reg.rs:231:32
+   |
+LL |         asm!("", out("f12") _, out("vs12") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs12`
+   |                  |
+   |                  register `f12`
+
+error: register `vs13` conflicts with register `f13`
+  --> $DIR/bad-reg.rs:233:32
+   |
+LL |         asm!("", out("f13") _, out("vs13") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs13`
+   |                  |
+   |                  register `f13`
+
+error: register `vs14` conflicts with register `f14`
+  --> $DIR/bad-reg.rs:235:32
+   |
+LL |         asm!("", out("f14") _, out("vs14") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs14`
+   |                  |
+   |                  register `f14`
+
+error: register `vs15` conflicts with register `f15`
+  --> $DIR/bad-reg.rs:237:32
+   |
+LL |         asm!("", out("f15") _, out("vs15") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs15`
+   |                  |
+   |                  register `f15`
+
+error: register `vs16` conflicts with register `f16`
+  --> $DIR/bad-reg.rs:239:32
+   |
+LL |         asm!("", out("f16") _, out("vs16") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs16`
+   |                  |
+   |                  register `f16`
+
+error: register `vs17` conflicts with register `f17`
+  --> $DIR/bad-reg.rs:241:32
+   |
+LL |         asm!("", out("f17") _, out("vs17") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs17`
+   |                  |
+   |                  register `f17`
+
+error: register `vs18` conflicts with register `f18`
+  --> $DIR/bad-reg.rs:243:32
+   |
+LL |         asm!("", out("f18") _, out("vs18") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs18`
+   |                  |
+   |                  register `f18`
+
+error: register `vs19` conflicts with register `f19`
+  --> $DIR/bad-reg.rs:245:32
+   |
+LL |         asm!("", out("f19") _, out("vs19") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs19`
+   |                  |
+   |                  register `f19`
+
+error: register `vs20` conflicts with register `f20`
+  --> $DIR/bad-reg.rs:247:32
+   |
+LL |         asm!("", out("f20") _, out("vs20") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs20`
+   |                  |
+   |                  register `f20`
+
+error: register `vs21` conflicts with register `f21`
+  --> $DIR/bad-reg.rs:249:32
+   |
+LL |         asm!("", out("f21") _, out("vs21") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs21`
+   |                  |
+   |                  register `f21`
+
+error: register `vs22` conflicts with register `f22`
+  --> $DIR/bad-reg.rs:251:32
+   |
+LL |         asm!("", out("f22") _, out("vs22") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs22`
+   |                  |
+   |                  register `f22`
+
+error: register `vs23` conflicts with register `f23`
+  --> $DIR/bad-reg.rs:253:32
+   |
+LL |         asm!("", out("f23") _, out("vs23") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs23`
+   |                  |
+   |                  register `f23`
+
+error: register `vs24` conflicts with register `f24`
+  --> $DIR/bad-reg.rs:255:32
+   |
+LL |         asm!("", out("f24") _, out("vs24") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs24`
+   |                  |
+   |                  register `f24`
+
+error: register `vs25` conflicts with register `f25`
+  --> $DIR/bad-reg.rs:257:32
+   |
+LL |         asm!("", out("f25") _, out("vs25") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs25`
+   |                  |
+   |                  register `f25`
+
+error: register `vs26` conflicts with register `f26`
+  --> $DIR/bad-reg.rs:259:32
+   |
+LL |         asm!("", out("f26") _, out("vs26") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs26`
+   |                  |
+   |                  register `f26`
+
+error: register `vs27` conflicts with register `f27`
+  --> $DIR/bad-reg.rs:261:32
+   |
+LL |         asm!("", out("f27") _, out("vs27") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs27`
+   |                  |
+   |                  register `f27`
+
+error: register `vs28` conflicts with register `f28`
+  --> $DIR/bad-reg.rs:263:32
+   |
+LL |         asm!("", out("f28") _, out("vs28") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs28`
+   |                  |
+   |                  register `f28`
+
+error: register `vs29` conflicts with register `f29`
+  --> $DIR/bad-reg.rs:265:32
+   |
+LL |         asm!("", out("f29") _, out("vs29") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs29`
+   |                  |
+   |                  register `f29`
+
+error: register `vs30` conflicts with register `f30`
+  --> $DIR/bad-reg.rs:267:32
+   |
+LL |         asm!("", out("f30") _, out("vs30") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs30`
+   |                  |
+   |                  register `f30`
+
+error: register `vs31` conflicts with register `f31`
+  --> $DIR/bad-reg.rs:269:32
+   |
+LL |         asm!("", out("f31") _, out("vs31") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs31`
+   |                  |
+   |                  register `f31`
+
+error: register `v0` conflicts with register `vs32`
+  --> $DIR/bad-reg.rs:271:33
+   |
+LL |         asm!("", out("vs32") _, out("v0") _);
+   |                  -------------  ^^^^^^^^^^^ register `v0`
+   |                  |
+   |                  register `vs32`
+
+error: register `v1` conflicts with register `vs33`
+  --> $DIR/bad-reg.rs:273:33
+   |
+LL |         asm!("", out("vs33") _, out("v1") _);
+   |                  -------------  ^^^^^^^^^^^ register `v1`
+   |                  |
+   |                  register `vs33`
+
+error: register `v2` conflicts with register `vs34`
+  --> $DIR/bad-reg.rs:275:33
+   |
+LL |         asm!("", out("vs34") _, out("v2") _);
+   |                  -------------  ^^^^^^^^^^^ register `v2`
+   |                  |
+   |                  register `vs34`
+
+error: register `v3` conflicts with register `vs35`
+  --> $DIR/bad-reg.rs:277:33
+   |
+LL |         asm!("", out("vs35") _, out("v3") _);
+   |                  -------------  ^^^^^^^^^^^ register `v3`
+   |                  |
+   |                  register `vs35`
+
+error: register `v4` conflicts with register `vs36`
+  --> $DIR/bad-reg.rs:279:33
+   |
+LL |         asm!("", out("vs36") _, out("v4") _);
+   |                  -------------  ^^^^^^^^^^^ register `v4`
+   |                  |
+   |                  register `vs36`
+
+error: register `v5` conflicts with register `vs37`
+  --> $DIR/bad-reg.rs:281:33
+   |
+LL |         asm!("", out("vs37") _, out("v5") _);
+   |                  -------------  ^^^^^^^^^^^ register `v5`
+   |                  |
+   |                  register `vs37`
+
+error: register `v6` conflicts with register `vs38`
+  --> $DIR/bad-reg.rs:283:33
+   |
+LL |         asm!("", out("vs38") _, out("v6") _);
+   |                  -------------  ^^^^^^^^^^^ register `v6`
+   |                  |
+   |                  register `vs38`
+
+error: register `v7` conflicts with register `vs39`
+  --> $DIR/bad-reg.rs:285:33
+   |
+LL |         asm!("", out("vs39") _, out("v7") _);
+   |                  -------------  ^^^^^^^^^^^ register `v7`
+   |                  |
+   |                  register `vs39`
+
+error: register `v8` conflicts with register `vs40`
+  --> $DIR/bad-reg.rs:287:33
+   |
+LL |         asm!("", out("vs40") _, out("v8") _);
+   |                  -------------  ^^^^^^^^^^^ register `v8`
+   |                  |
+   |                  register `vs40`
+
+error: register `v9` conflicts with register `vs41`
+  --> $DIR/bad-reg.rs:289:33
+   |
+LL |         asm!("", out("vs41") _, out("v9") _);
+   |                  -------------  ^^^^^^^^^^^ register `v9`
+   |                  |
+   |                  register `vs41`
+
+error: register `v10` conflicts with register `vs42`
+  --> $DIR/bad-reg.rs:291:33
+   |
+LL |         asm!("", out("vs42") _, out("v10") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v10`
+   |                  |
+   |                  register `vs42`
+
+error: register `v11` conflicts with register `vs43`
+  --> $DIR/bad-reg.rs:293:33
+   |
+LL |         asm!("", out("vs43") _, out("v11") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v11`
+   |                  |
+   |                  register `vs43`
+
+error: register `v12` conflicts with register `vs44`
+  --> $DIR/bad-reg.rs:295:33
+   |
+LL |         asm!("", out("vs44") _, out("v12") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v12`
+   |                  |
+   |                  register `vs44`
+
+error: register `v13` conflicts with register `vs45`
+  --> $DIR/bad-reg.rs:297:33
+   |
+LL |         asm!("", out("vs45") _, out("v13") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v13`
+   |                  |
+   |                  register `vs45`
+
+error: register `v14` conflicts with register `vs46`
+  --> $DIR/bad-reg.rs:299:33
+   |
+LL |         asm!("", out("vs46") _, out("v14") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v14`
+   |                  |
+   |                  register `vs46`
+
+error: register `v15` conflicts with register `vs47`
+  --> $DIR/bad-reg.rs:301:33
+   |
+LL |         asm!("", out("vs47") _, out("v15") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v15`
+   |                  |
+   |                  register `vs47`
+
+error: register `v16` conflicts with register `vs48`
+  --> $DIR/bad-reg.rs:303:33
+   |
+LL |         asm!("", out("vs48") _, out("v16") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v16`
+   |                  |
+   |                  register `vs48`
+
+error: register `v17` conflicts with register `vs49`
+  --> $DIR/bad-reg.rs:305:33
+   |
+LL |         asm!("", out("vs49") _, out("v17") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v17`
+   |                  |
+   |                  register `vs49`
+
+error: register `v18` conflicts with register `vs50`
+  --> $DIR/bad-reg.rs:307:33
+   |
+LL |         asm!("", out("vs50") _, out("v18") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v18`
+   |                  |
+   |                  register `vs50`
+
+error: register `v19` conflicts with register `vs51`
+  --> $DIR/bad-reg.rs:309:33
+   |
+LL |         asm!("", out("vs51") _, out("v19") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v19`
+   |                  |
+   |                  register `vs51`
+
+error: register `v20` conflicts with register `vs52`
+  --> $DIR/bad-reg.rs:311:33
+   |
+LL |         asm!("", out("vs52") _, out("v20") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v20`
+   |                  |
+   |                  register `vs52`
+
+error: register `v21` conflicts with register `vs53`
+  --> $DIR/bad-reg.rs:313:33
+   |
+LL |         asm!("", out("vs53") _, out("v21") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v21`
+   |                  |
+   |                  register `vs53`
+
+error: register `v22` conflicts with register `vs54`
+  --> $DIR/bad-reg.rs:315:33
+   |
+LL |         asm!("", out("vs54") _, out("v22") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v22`
+   |                  |
+   |                  register `vs54`
+
+error: register `v23` conflicts with register `vs55`
+  --> $DIR/bad-reg.rs:317:33
+   |
+LL |         asm!("", out("vs55") _, out("v23") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v23`
+   |                  |
+   |                  register `vs55`
+
+error: register `v24` conflicts with register `vs56`
+  --> $DIR/bad-reg.rs:319:33
+   |
+LL |         asm!("", out("vs56") _, out("v24") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v24`
+   |                  |
+   |                  register `vs56`
+
+error: register `v25` conflicts with register `vs57`
+  --> $DIR/bad-reg.rs:321:33
+   |
+LL |         asm!("", out("vs57") _, out("v25") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v25`
+   |                  |
+   |                  register `vs57`
+
+error: register `v26` conflicts with register `vs58`
+  --> $DIR/bad-reg.rs:323:33
+   |
+LL |         asm!("", out("vs58") _, out("v26") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v26`
+   |                  |
+   |                  register `vs58`
+
+error: register `v27` conflicts with register `vs59`
+  --> $DIR/bad-reg.rs:325:33
+   |
+LL |         asm!("", out("vs59") _, out("v27") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v27`
+   |                  |
+   |                  register `vs59`
+
+error: register `v28` conflicts with register `vs60`
+  --> $DIR/bad-reg.rs:327:33
+   |
+LL |         asm!("", out("vs60") _, out("v28") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v28`
+   |                  |
+   |                  register `vs60`
+
+error: register `v29` conflicts with register `vs61`
+  --> $DIR/bad-reg.rs:329:33
+   |
+LL |         asm!("", out("vs61") _, out("v29") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v29`
+   |                  |
+   |                  register `vs61`
+
+error: register `v30` conflicts with register `vs62`
+  --> $DIR/bad-reg.rs:331:33
+   |
+LL |         asm!("", out("vs62") _, out("v30") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v30`
+   |                  |
+   |                  register `vs62`
+
+error: register `v31` conflicts with register `vs63`
+  --> $DIR/bad-reg.rs:333:33
+   |
+LL |         asm!("", out("vs63") _, out("v31") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v31`
+   |                  |
+   |                  register `vs63`
 
 error: cannot use register `r13`: r13 is a reserved register on this target
   --> $DIR/bad-reg.rs:41:18
@@ -248,8 +760,68 @@ LL |         asm!("/* {} */", in(vreg) x); // FIXME: should be ok if vsx is avai
    |
    = note: register class `vreg` supports these types: i8x16, i16x8, i32x4, f32x4, f32, f64, i64x2, f64x2
 
+error: register class `vsreg` requires the `vsx` target feature
+  --> $DIR/bad-reg.rs:97:18
+   |
+LL |         asm!("", in("vs0") v32x4); // requires vsx
+   |                  ^^^^^^^^^^^^^^^
+
+error: register class `vsreg` requires the `vsx` target feature
+  --> $DIR/bad-reg.rs:99:18
+   |
+LL |         asm!("", out("vs0") v32x4); // requires vsx
+   |                  ^^^^^^^^^^^^^^^^
+
+error: register class `vsreg` requires the `vsx` target feature
+  --> $DIR/bad-reg.rs:101:18
+   |
+LL |         asm!("", in("vs0") v64x2); // requires vsx
+   |                  ^^^^^^^^^^^^^^^
+
+error: register class `vsreg` requires the `vsx` target feature
+  --> $DIR/bad-reg.rs:103:18
+   |
+LL |         asm!("", out("vs0") v64x2); // requires vsx
+   |                  ^^^^^^^^^^^^^^^^
+
+error: register class `vsreg` requires the `vsx` target feature
+  --> $DIR/bad-reg.rs:105:18
+   |
+LL |         asm!("", in("vs0") x); // FIXME: should be ok if vsx is available
+   |                  ^^^^^^^^^^^
+
+error: register class `vsreg` requires the `vsx` target feature
+  --> $DIR/bad-reg.rs:108:18
+   |
+LL |         asm!("", out("vs0") x); // FIXME: should be ok if vsx is available
+   |                  ^^^^^^^^^^^^
+
+error: register class `vsreg` requires the `vsx` target feature
+  --> $DIR/bad-reg.rs:111:26
+   |
+LL |         asm!("/* {} */", in(vsreg) v32x4); // requires vsx
+   |                          ^^^^^^^^^^^^^^^
+
+error: register class `vsreg` requires the `vsx` target feature
+  --> $DIR/bad-reg.rs:113:26
+   |
+LL |         asm!("/* {} */", in(vsreg) v64x2); // requires vsx
+   |                          ^^^^^^^^^^^^^^^
+
+error: register class `vsreg` requires the `vsx` target feature
+  --> $DIR/bad-reg.rs:115:26
+   |
+LL |         asm!("/* {} */", in(vsreg) x); // FIXME: should be ok if vsx is available
+   |                          ^^^^^^^^^^^
+
+error: register class `vsreg` requires the `vsx` target feature
+  --> $DIR/bad-reg.rs:118:26
+   |
+LL |         asm!("/* {} */", out(vsreg) _); // requires vsx
+   |                          ^^^^^^^^^^^^
+
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:97:27
+  --> $DIR/bad-reg.rs:138:27
    |
 LL |         asm!("", in("cr") x);
    |                           ^
@@ -257,7 +829,7 @@ LL |         asm!("", in("cr") x);
    = note: register class `cr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:100:28
+  --> $DIR/bad-reg.rs:141:28
    |
 LL |         asm!("", out("cr") x);
    |                            ^
@@ -265,7 +837,7 @@ LL |         asm!("", out("cr") x);
    = note: register class `cr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:103:33
+  --> $DIR/bad-reg.rs:144:33
    |
 LL |         asm!("/* {} */", in(cr) x);
    |                                 ^
@@ -273,7 +845,7 @@ LL |         asm!("/* {} */", in(cr) x);
    = note: register class `cr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:110:28
+  --> $DIR/bad-reg.rs:151:28
    |
 LL |         asm!("", in("ctr") x);
    |                            ^
@@ -281,7 +853,7 @@ LL |         asm!("", in("ctr") x);
    = note: register class `ctr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:113:29
+  --> $DIR/bad-reg.rs:154:29
    |
 LL |         asm!("", out("ctr") x);
    |                             ^
@@ -289,7 +861,7 @@ LL |         asm!("", out("ctr") x);
    = note: register class `ctr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:116:34
+  --> $DIR/bad-reg.rs:157:34
    |
 LL |         asm!("/* {} */", in(ctr) x);
    |                                  ^
@@ -297,7 +869,7 @@ LL |         asm!("/* {} */", in(ctr) x);
    = note: register class `ctr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:123:27
+  --> $DIR/bad-reg.rs:164:27
    |
 LL |         asm!("", in("lr") x);
    |                           ^
@@ -305,7 +877,7 @@ LL |         asm!("", in("lr") x);
    = note: register class `lr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:126:28
+  --> $DIR/bad-reg.rs:167:28
    |
 LL |         asm!("", out("lr") x);
    |                            ^
@@ -313,7 +885,7 @@ LL |         asm!("", out("lr") x);
    = note: register class `lr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:129:33
+  --> $DIR/bad-reg.rs:170:33
    |
 LL |         asm!("/* {} */", in(lr) x);
    |                                 ^
@@ -321,7 +893,7 @@ LL |         asm!("/* {} */", in(lr) x);
    = note: register class `lr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:136:28
+  --> $DIR/bad-reg.rs:177:28
    |
 LL |         asm!("", in("xer") x);
    |                            ^
@@ -329,7 +901,7 @@ LL |         asm!("", in("xer") x);
    = note: register class `xer` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:139:29
+  --> $DIR/bad-reg.rs:180:29
    |
 LL |         asm!("", out("xer") x);
    |                             ^
@@ -337,12 +909,12 @@ LL |         asm!("", out("xer") x);
    = note: register class `xer` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:142:34
+  --> $DIR/bad-reg.rs:183:34
    |
 LL |         asm!("/* {} */", in(xer) x);
    |                                  ^
    |
    = note: register class `xer` supports these types: 
 
-error: aborting due to 49 previous errors
+error: aborting due to 123 previous errors
 

--- a/tests/ui/asm/powerpc/bad-reg.powerpc64le.stderr
+++ b/tests/ui/asm/powerpc/bad-reg.powerpc64le.stderr
@@ -35,103 +35,103 @@ LL |         asm!("", out("vrsave") _);
    |                  ^^^^^^^^^^^^^^^
 
 error: register class `cr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:97:18
+  --> $DIR/bad-reg.rs:138:18
    |
 LL |         asm!("", in("cr") x);
    |                  ^^^^^^^^^^
 
 error: register class `cr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:100:18
+  --> $DIR/bad-reg.rs:141:18
    |
 LL |         asm!("", out("cr") x);
    |                  ^^^^^^^^^^^
 
 error: register class `cr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:103:26
+  --> $DIR/bad-reg.rs:144:26
    |
 LL |         asm!("/* {} */", in(cr) x);
    |                          ^^^^^^^^
 
 error: register class `cr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:106:26
+  --> $DIR/bad-reg.rs:147:26
    |
 LL |         asm!("/* {} */", out(cr) _);
    |                          ^^^^^^^^^
 
 error: register class `ctr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:110:18
+  --> $DIR/bad-reg.rs:151:18
    |
 LL |         asm!("", in("ctr") x);
    |                  ^^^^^^^^^^^
 
 error: register class `ctr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:113:18
+  --> $DIR/bad-reg.rs:154:18
    |
 LL |         asm!("", out("ctr") x);
    |                  ^^^^^^^^^^^^
 
 error: register class `ctr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:116:26
+  --> $DIR/bad-reg.rs:157:26
    |
 LL |         asm!("/* {} */", in(ctr) x);
    |                          ^^^^^^^^^
 
 error: register class `ctr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:119:26
+  --> $DIR/bad-reg.rs:160:26
    |
 LL |         asm!("/* {} */", out(ctr) _);
    |                          ^^^^^^^^^^
 
 error: register class `lr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:123:18
+  --> $DIR/bad-reg.rs:164:18
    |
 LL |         asm!("", in("lr") x);
    |                  ^^^^^^^^^^
 
 error: register class `lr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:126:18
+  --> $DIR/bad-reg.rs:167:18
    |
 LL |         asm!("", out("lr") x);
    |                  ^^^^^^^^^^^
 
 error: register class `lr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:129:26
+  --> $DIR/bad-reg.rs:170:26
    |
 LL |         asm!("/* {} */", in(lr) x);
    |                          ^^^^^^^^
 
 error: register class `lr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:132:26
+  --> $DIR/bad-reg.rs:173:26
    |
 LL |         asm!("/* {} */", out(lr) _);
    |                          ^^^^^^^^^
 
 error: register class `xer` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:136:18
+  --> $DIR/bad-reg.rs:177:18
    |
 LL |         asm!("", in("xer") x);
    |                  ^^^^^^^^^^^
 
 error: register class `xer` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:139:18
+  --> $DIR/bad-reg.rs:180:18
    |
 LL |         asm!("", out("xer") x);
    |                  ^^^^^^^^^^^^
 
 error: register class `xer` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:142:26
+  --> $DIR/bad-reg.rs:183:26
    |
 LL |         asm!("/* {} */", in(xer) x);
    |                          ^^^^^^^^^
 
 error: register class `xer` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:145:26
+  --> $DIR/bad-reg.rs:186:26
    |
 LL |         asm!("/* {} */", out(xer) _);
    |                          ^^^^^^^^^^
 
 error: register `cr0` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:149:31
+  --> $DIR/bad-reg.rs:190:31
    |
 LL |         asm!("", out("cr") _, out("cr0") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr0`
@@ -139,7 +139,7 @@ LL |         asm!("", out("cr") _, out("cr0") _);
    |                  register `cr`
 
 error: register `cr1` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:151:31
+  --> $DIR/bad-reg.rs:192:31
    |
 LL |         asm!("", out("cr") _, out("cr1") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr1`
@@ -147,7 +147,7 @@ LL |         asm!("", out("cr") _, out("cr1") _);
    |                  register `cr`
 
 error: register `cr2` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:153:31
+  --> $DIR/bad-reg.rs:194:31
    |
 LL |         asm!("", out("cr") _, out("cr2") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr2`
@@ -155,7 +155,7 @@ LL |         asm!("", out("cr") _, out("cr2") _);
    |                  register `cr`
 
 error: register `cr3` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:155:31
+  --> $DIR/bad-reg.rs:196:31
    |
 LL |         asm!("", out("cr") _, out("cr3") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr3`
@@ -163,7 +163,7 @@ LL |         asm!("", out("cr") _, out("cr3") _);
    |                  register `cr`
 
 error: register `cr4` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:157:31
+  --> $DIR/bad-reg.rs:198:31
    |
 LL |         asm!("", out("cr") _, out("cr4") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr4`
@@ -171,7 +171,7 @@ LL |         asm!("", out("cr") _, out("cr4") _);
    |                  register `cr`
 
 error: register `cr5` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:159:31
+  --> $DIR/bad-reg.rs:200:31
    |
 LL |         asm!("", out("cr") _, out("cr5") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr5`
@@ -179,7 +179,7 @@ LL |         asm!("", out("cr") _, out("cr5") _);
    |                  register `cr`
 
 error: register `cr6` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:161:31
+  --> $DIR/bad-reg.rs:202:31
    |
 LL |         asm!("", out("cr") _, out("cr6") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr6`
@@ -187,12 +187,524 @@ LL |         asm!("", out("cr") _, out("cr6") _);
    |                  register `cr`
 
 error: register `cr7` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:163:31
+  --> $DIR/bad-reg.rs:204:31
    |
 LL |         asm!("", out("cr") _, out("cr7") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr7`
    |                  |
    |                  register `cr`
+
+error: register `vs0` conflicts with register `f0`
+  --> $DIR/bad-reg.rs:207:31
+   |
+LL |         asm!("", out("f0") _, out("vs0") _);
+   |                  -----------  ^^^^^^^^^^^^ register `vs0`
+   |                  |
+   |                  register `f0`
+
+error: register `vs1` conflicts with register `f1`
+  --> $DIR/bad-reg.rs:209:31
+   |
+LL |         asm!("", out("f1") _, out("vs1") _);
+   |                  -----------  ^^^^^^^^^^^^ register `vs1`
+   |                  |
+   |                  register `f1`
+
+error: register `vs2` conflicts with register `f2`
+  --> $DIR/bad-reg.rs:211:31
+   |
+LL |         asm!("", out("f2") _, out("vs2") _);
+   |                  -----------  ^^^^^^^^^^^^ register `vs2`
+   |                  |
+   |                  register `f2`
+
+error: register `vs3` conflicts with register `f3`
+  --> $DIR/bad-reg.rs:213:31
+   |
+LL |         asm!("", out("f3") _, out("vs3") _);
+   |                  -----------  ^^^^^^^^^^^^ register `vs3`
+   |                  |
+   |                  register `f3`
+
+error: register `vs4` conflicts with register `f4`
+  --> $DIR/bad-reg.rs:215:31
+   |
+LL |         asm!("", out("f4") _, out("vs4") _);
+   |                  -----------  ^^^^^^^^^^^^ register `vs4`
+   |                  |
+   |                  register `f4`
+
+error: register `vs5` conflicts with register `f5`
+  --> $DIR/bad-reg.rs:217:31
+   |
+LL |         asm!("", out("f5") _, out("vs5") _);
+   |                  -----------  ^^^^^^^^^^^^ register `vs5`
+   |                  |
+   |                  register `f5`
+
+error: register `vs6` conflicts with register `f6`
+  --> $DIR/bad-reg.rs:219:31
+   |
+LL |         asm!("", out("f6") _, out("vs6") _);
+   |                  -----------  ^^^^^^^^^^^^ register `vs6`
+   |                  |
+   |                  register `f6`
+
+error: register `vs7` conflicts with register `f7`
+  --> $DIR/bad-reg.rs:221:31
+   |
+LL |         asm!("", out("f7") _, out("vs7") _);
+   |                  -----------  ^^^^^^^^^^^^ register `vs7`
+   |                  |
+   |                  register `f7`
+
+error: register `vs8` conflicts with register `f8`
+  --> $DIR/bad-reg.rs:223:31
+   |
+LL |         asm!("", out("f8") _, out("vs8") _);
+   |                  -----------  ^^^^^^^^^^^^ register `vs8`
+   |                  |
+   |                  register `f8`
+
+error: register `vs9` conflicts with register `f9`
+  --> $DIR/bad-reg.rs:225:31
+   |
+LL |         asm!("", out("f9") _, out("vs9") _);
+   |                  -----------  ^^^^^^^^^^^^ register `vs9`
+   |                  |
+   |                  register `f9`
+
+error: register `vs10` conflicts with register `f10`
+  --> $DIR/bad-reg.rs:227:32
+   |
+LL |         asm!("", out("f10") _, out("vs10") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs10`
+   |                  |
+   |                  register `f10`
+
+error: register `vs11` conflicts with register `f11`
+  --> $DIR/bad-reg.rs:229:32
+   |
+LL |         asm!("", out("f11") _, out("vs11") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs11`
+   |                  |
+   |                  register `f11`
+
+error: register `vs12` conflicts with register `f12`
+  --> $DIR/bad-reg.rs:231:32
+   |
+LL |         asm!("", out("f12") _, out("vs12") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs12`
+   |                  |
+   |                  register `f12`
+
+error: register `vs13` conflicts with register `f13`
+  --> $DIR/bad-reg.rs:233:32
+   |
+LL |         asm!("", out("f13") _, out("vs13") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs13`
+   |                  |
+   |                  register `f13`
+
+error: register `vs14` conflicts with register `f14`
+  --> $DIR/bad-reg.rs:235:32
+   |
+LL |         asm!("", out("f14") _, out("vs14") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs14`
+   |                  |
+   |                  register `f14`
+
+error: register `vs15` conflicts with register `f15`
+  --> $DIR/bad-reg.rs:237:32
+   |
+LL |         asm!("", out("f15") _, out("vs15") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs15`
+   |                  |
+   |                  register `f15`
+
+error: register `vs16` conflicts with register `f16`
+  --> $DIR/bad-reg.rs:239:32
+   |
+LL |         asm!("", out("f16") _, out("vs16") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs16`
+   |                  |
+   |                  register `f16`
+
+error: register `vs17` conflicts with register `f17`
+  --> $DIR/bad-reg.rs:241:32
+   |
+LL |         asm!("", out("f17") _, out("vs17") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs17`
+   |                  |
+   |                  register `f17`
+
+error: register `vs18` conflicts with register `f18`
+  --> $DIR/bad-reg.rs:243:32
+   |
+LL |         asm!("", out("f18") _, out("vs18") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs18`
+   |                  |
+   |                  register `f18`
+
+error: register `vs19` conflicts with register `f19`
+  --> $DIR/bad-reg.rs:245:32
+   |
+LL |         asm!("", out("f19") _, out("vs19") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs19`
+   |                  |
+   |                  register `f19`
+
+error: register `vs20` conflicts with register `f20`
+  --> $DIR/bad-reg.rs:247:32
+   |
+LL |         asm!("", out("f20") _, out("vs20") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs20`
+   |                  |
+   |                  register `f20`
+
+error: register `vs21` conflicts with register `f21`
+  --> $DIR/bad-reg.rs:249:32
+   |
+LL |         asm!("", out("f21") _, out("vs21") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs21`
+   |                  |
+   |                  register `f21`
+
+error: register `vs22` conflicts with register `f22`
+  --> $DIR/bad-reg.rs:251:32
+   |
+LL |         asm!("", out("f22") _, out("vs22") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs22`
+   |                  |
+   |                  register `f22`
+
+error: register `vs23` conflicts with register `f23`
+  --> $DIR/bad-reg.rs:253:32
+   |
+LL |         asm!("", out("f23") _, out("vs23") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs23`
+   |                  |
+   |                  register `f23`
+
+error: register `vs24` conflicts with register `f24`
+  --> $DIR/bad-reg.rs:255:32
+   |
+LL |         asm!("", out("f24") _, out("vs24") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs24`
+   |                  |
+   |                  register `f24`
+
+error: register `vs25` conflicts with register `f25`
+  --> $DIR/bad-reg.rs:257:32
+   |
+LL |         asm!("", out("f25") _, out("vs25") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs25`
+   |                  |
+   |                  register `f25`
+
+error: register `vs26` conflicts with register `f26`
+  --> $DIR/bad-reg.rs:259:32
+   |
+LL |         asm!("", out("f26") _, out("vs26") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs26`
+   |                  |
+   |                  register `f26`
+
+error: register `vs27` conflicts with register `f27`
+  --> $DIR/bad-reg.rs:261:32
+   |
+LL |         asm!("", out("f27") _, out("vs27") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs27`
+   |                  |
+   |                  register `f27`
+
+error: register `vs28` conflicts with register `f28`
+  --> $DIR/bad-reg.rs:263:32
+   |
+LL |         asm!("", out("f28") _, out("vs28") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs28`
+   |                  |
+   |                  register `f28`
+
+error: register `vs29` conflicts with register `f29`
+  --> $DIR/bad-reg.rs:265:32
+   |
+LL |         asm!("", out("f29") _, out("vs29") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs29`
+   |                  |
+   |                  register `f29`
+
+error: register `vs30` conflicts with register `f30`
+  --> $DIR/bad-reg.rs:267:32
+   |
+LL |         asm!("", out("f30") _, out("vs30") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs30`
+   |                  |
+   |                  register `f30`
+
+error: register `vs31` conflicts with register `f31`
+  --> $DIR/bad-reg.rs:269:32
+   |
+LL |         asm!("", out("f31") _, out("vs31") _);
+   |                  ------------  ^^^^^^^^^^^^^ register `vs31`
+   |                  |
+   |                  register `f31`
+
+error: register `v0` conflicts with register `vs32`
+  --> $DIR/bad-reg.rs:271:33
+   |
+LL |         asm!("", out("vs32") _, out("v0") _);
+   |                  -------------  ^^^^^^^^^^^ register `v0`
+   |                  |
+   |                  register `vs32`
+
+error: register `v1` conflicts with register `vs33`
+  --> $DIR/bad-reg.rs:273:33
+   |
+LL |         asm!("", out("vs33") _, out("v1") _);
+   |                  -------------  ^^^^^^^^^^^ register `v1`
+   |                  |
+   |                  register `vs33`
+
+error: register `v2` conflicts with register `vs34`
+  --> $DIR/bad-reg.rs:275:33
+   |
+LL |         asm!("", out("vs34") _, out("v2") _);
+   |                  -------------  ^^^^^^^^^^^ register `v2`
+   |                  |
+   |                  register `vs34`
+
+error: register `v3` conflicts with register `vs35`
+  --> $DIR/bad-reg.rs:277:33
+   |
+LL |         asm!("", out("vs35") _, out("v3") _);
+   |                  -------------  ^^^^^^^^^^^ register `v3`
+   |                  |
+   |                  register `vs35`
+
+error: register `v4` conflicts with register `vs36`
+  --> $DIR/bad-reg.rs:279:33
+   |
+LL |         asm!("", out("vs36") _, out("v4") _);
+   |                  -------------  ^^^^^^^^^^^ register `v4`
+   |                  |
+   |                  register `vs36`
+
+error: register `v5` conflicts with register `vs37`
+  --> $DIR/bad-reg.rs:281:33
+   |
+LL |         asm!("", out("vs37") _, out("v5") _);
+   |                  -------------  ^^^^^^^^^^^ register `v5`
+   |                  |
+   |                  register `vs37`
+
+error: register `v6` conflicts with register `vs38`
+  --> $DIR/bad-reg.rs:283:33
+   |
+LL |         asm!("", out("vs38") _, out("v6") _);
+   |                  -------------  ^^^^^^^^^^^ register `v6`
+   |                  |
+   |                  register `vs38`
+
+error: register `v7` conflicts with register `vs39`
+  --> $DIR/bad-reg.rs:285:33
+   |
+LL |         asm!("", out("vs39") _, out("v7") _);
+   |                  -------------  ^^^^^^^^^^^ register `v7`
+   |                  |
+   |                  register `vs39`
+
+error: register `v8` conflicts with register `vs40`
+  --> $DIR/bad-reg.rs:287:33
+   |
+LL |         asm!("", out("vs40") _, out("v8") _);
+   |                  -------------  ^^^^^^^^^^^ register `v8`
+   |                  |
+   |                  register `vs40`
+
+error: register `v9` conflicts with register `vs41`
+  --> $DIR/bad-reg.rs:289:33
+   |
+LL |         asm!("", out("vs41") _, out("v9") _);
+   |                  -------------  ^^^^^^^^^^^ register `v9`
+   |                  |
+   |                  register `vs41`
+
+error: register `v10` conflicts with register `vs42`
+  --> $DIR/bad-reg.rs:291:33
+   |
+LL |         asm!("", out("vs42") _, out("v10") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v10`
+   |                  |
+   |                  register `vs42`
+
+error: register `v11` conflicts with register `vs43`
+  --> $DIR/bad-reg.rs:293:33
+   |
+LL |         asm!("", out("vs43") _, out("v11") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v11`
+   |                  |
+   |                  register `vs43`
+
+error: register `v12` conflicts with register `vs44`
+  --> $DIR/bad-reg.rs:295:33
+   |
+LL |         asm!("", out("vs44") _, out("v12") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v12`
+   |                  |
+   |                  register `vs44`
+
+error: register `v13` conflicts with register `vs45`
+  --> $DIR/bad-reg.rs:297:33
+   |
+LL |         asm!("", out("vs45") _, out("v13") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v13`
+   |                  |
+   |                  register `vs45`
+
+error: register `v14` conflicts with register `vs46`
+  --> $DIR/bad-reg.rs:299:33
+   |
+LL |         asm!("", out("vs46") _, out("v14") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v14`
+   |                  |
+   |                  register `vs46`
+
+error: register `v15` conflicts with register `vs47`
+  --> $DIR/bad-reg.rs:301:33
+   |
+LL |         asm!("", out("vs47") _, out("v15") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v15`
+   |                  |
+   |                  register `vs47`
+
+error: register `v16` conflicts with register `vs48`
+  --> $DIR/bad-reg.rs:303:33
+   |
+LL |         asm!("", out("vs48") _, out("v16") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v16`
+   |                  |
+   |                  register `vs48`
+
+error: register `v17` conflicts with register `vs49`
+  --> $DIR/bad-reg.rs:305:33
+   |
+LL |         asm!("", out("vs49") _, out("v17") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v17`
+   |                  |
+   |                  register `vs49`
+
+error: register `v18` conflicts with register `vs50`
+  --> $DIR/bad-reg.rs:307:33
+   |
+LL |         asm!("", out("vs50") _, out("v18") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v18`
+   |                  |
+   |                  register `vs50`
+
+error: register `v19` conflicts with register `vs51`
+  --> $DIR/bad-reg.rs:309:33
+   |
+LL |         asm!("", out("vs51") _, out("v19") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v19`
+   |                  |
+   |                  register `vs51`
+
+error: register `v20` conflicts with register `vs52`
+  --> $DIR/bad-reg.rs:311:33
+   |
+LL |         asm!("", out("vs52") _, out("v20") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v20`
+   |                  |
+   |                  register `vs52`
+
+error: register `v21` conflicts with register `vs53`
+  --> $DIR/bad-reg.rs:313:33
+   |
+LL |         asm!("", out("vs53") _, out("v21") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v21`
+   |                  |
+   |                  register `vs53`
+
+error: register `v22` conflicts with register `vs54`
+  --> $DIR/bad-reg.rs:315:33
+   |
+LL |         asm!("", out("vs54") _, out("v22") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v22`
+   |                  |
+   |                  register `vs54`
+
+error: register `v23` conflicts with register `vs55`
+  --> $DIR/bad-reg.rs:317:33
+   |
+LL |         asm!("", out("vs55") _, out("v23") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v23`
+   |                  |
+   |                  register `vs55`
+
+error: register `v24` conflicts with register `vs56`
+  --> $DIR/bad-reg.rs:319:33
+   |
+LL |         asm!("", out("vs56") _, out("v24") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v24`
+   |                  |
+   |                  register `vs56`
+
+error: register `v25` conflicts with register `vs57`
+  --> $DIR/bad-reg.rs:321:33
+   |
+LL |         asm!("", out("vs57") _, out("v25") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v25`
+   |                  |
+   |                  register `vs57`
+
+error: register `v26` conflicts with register `vs58`
+  --> $DIR/bad-reg.rs:323:33
+   |
+LL |         asm!("", out("vs58") _, out("v26") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v26`
+   |                  |
+   |                  register `vs58`
+
+error: register `v27` conflicts with register `vs59`
+  --> $DIR/bad-reg.rs:325:33
+   |
+LL |         asm!("", out("vs59") _, out("v27") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v27`
+   |                  |
+   |                  register `vs59`
+
+error: register `v28` conflicts with register `vs60`
+  --> $DIR/bad-reg.rs:327:33
+   |
+LL |         asm!("", out("vs60") _, out("v28") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v28`
+   |                  |
+   |                  register `vs60`
+
+error: register `v29` conflicts with register `vs61`
+  --> $DIR/bad-reg.rs:329:33
+   |
+LL |         asm!("", out("vs61") _, out("v29") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v29`
+   |                  |
+   |                  register `vs61`
+
+error: register `v30` conflicts with register `vs62`
+  --> $DIR/bad-reg.rs:331:33
+   |
+LL |         asm!("", out("vs62") _, out("v30") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v30`
+   |                  |
+   |                  register `vs62`
+
+error: register `v31` conflicts with register `vs63`
+  --> $DIR/bad-reg.rs:333:33
+   |
+LL |         asm!("", out("vs63") _, out("v31") _);
+   |                  -------------  ^^^^^^^^^^^^ register `v31`
+   |                  |
+   |                  register `vs63`
 
 error: cannot use register `r13`: r13 is a reserved register on this target
   --> $DIR/bad-reg.rs:41:18
@@ -225,7 +737,31 @@ LL |         asm!("/* {} */", in(vreg) x); // FIXME: should be ok if vsx is avai
    = note: register class `vreg` supports these types: i8x16, i16x8, i32x4, f32x4, f32, f64, i64x2, f64x2
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:97:27
+  --> $DIR/bad-reg.rs:105:28
+   |
+LL |         asm!("", in("vs0") x); // FIXME: should be ok if vsx is available
+   |                            ^
+   |
+   = note: register class `vsreg` supports these types: f32, f64, i8x16, i16x8, i32x4, i64x2, f32x4, f64x2
+
+error: type `i32` cannot be used with this register class
+  --> $DIR/bad-reg.rs:108:29
+   |
+LL |         asm!("", out("vs0") x); // FIXME: should be ok if vsx is available
+   |                             ^
+   |
+   = note: register class `vsreg` supports these types: f32, f64, i8x16, i16x8, i32x4, i64x2, f32x4, f64x2
+
+error: type `i32` cannot be used with this register class
+  --> $DIR/bad-reg.rs:115:36
+   |
+LL |         asm!("/* {} */", in(vsreg) x); // FIXME: should be ok if vsx is available
+   |                                    ^
+   |
+   = note: register class `vsreg` supports these types: f32, f64, i8x16, i16x8, i32x4, i64x2, f32x4, f64x2
+
+error: type `i32` cannot be used with this register class
+  --> $DIR/bad-reg.rs:138:27
    |
 LL |         asm!("", in("cr") x);
    |                           ^
@@ -233,7 +769,7 @@ LL |         asm!("", in("cr") x);
    = note: register class `cr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:100:28
+  --> $DIR/bad-reg.rs:141:28
    |
 LL |         asm!("", out("cr") x);
    |                            ^
@@ -241,7 +777,7 @@ LL |         asm!("", out("cr") x);
    = note: register class `cr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:103:33
+  --> $DIR/bad-reg.rs:144:33
    |
 LL |         asm!("/* {} */", in(cr) x);
    |                                 ^
@@ -249,7 +785,7 @@ LL |         asm!("/* {} */", in(cr) x);
    = note: register class `cr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:110:28
+  --> $DIR/bad-reg.rs:151:28
    |
 LL |         asm!("", in("ctr") x);
    |                            ^
@@ -257,7 +793,7 @@ LL |         asm!("", in("ctr") x);
    = note: register class `ctr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:113:29
+  --> $DIR/bad-reg.rs:154:29
    |
 LL |         asm!("", out("ctr") x);
    |                             ^
@@ -265,7 +801,7 @@ LL |         asm!("", out("ctr") x);
    = note: register class `ctr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:116:34
+  --> $DIR/bad-reg.rs:157:34
    |
 LL |         asm!("/* {} */", in(ctr) x);
    |                                  ^
@@ -273,7 +809,7 @@ LL |         asm!("/* {} */", in(ctr) x);
    = note: register class `ctr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:123:27
+  --> $DIR/bad-reg.rs:164:27
    |
 LL |         asm!("", in("lr") x);
    |                           ^
@@ -281,7 +817,7 @@ LL |         asm!("", in("lr") x);
    = note: register class `lr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:126:28
+  --> $DIR/bad-reg.rs:167:28
    |
 LL |         asm!("", out("lr") x);
    |                            ^
@@ -289,7 +825,7 @@ LL |         asm!("", out("lr") x);
    = note: register class `lr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:129:33
+  --> $DIR/bad-reg.rs:170:33
    |
 LL |         asm!("/* {} */", in(lr) x);
    |                                 ^
@@ -297,7 +833,7 @@ LL |         asm!("/* {} */", in(lr) x);
    = note: register class `lr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:136:28
+  --> $DIR/bad-reg.rs:177:28
    |
 LL |         asm!("", in("xer") x);
    |                            ^
@@ -305,7 +841,7 @@ LL |         asm!("", in("xer") x);
    = note: register class `xer` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:139:29
+  --> $DIR/bad-reg.rs:180:29
    |
 LL |         asm!("", out("xer") x);
    |                             ^
@@ -313,12 +849,12 @@ LL |         asm!("", out("xer") x);
    = note: register class `xer` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:142:34
+  --> $DIR/bad-reg.rs:183:34
    |
 LL |         asm!("/* {} */", in(xer) x);
    |                                  ^
    |
    = note: register class `xer` supports these types: 
 
-error: aborting due to 46 previous errors
+error: aborting due to 113 previous errors
 

--- a/tests/ui/asm/powerpc/bad-reg.rs
+++ b/tests/ui/asm/powerpc/bad-reg.rs
@@ -77,7 +77,7 @@ fn f() {
         //[powerpc64,powerpc64le,aix64]~^^ ERROR type `i32` cannot be used with this register class
         asm!("/* {} */", out(vreg) _); // requires altivec
         //[powerpc]~^ ERROR register class `vreg` requires at least one of the following target features: altivec, vsx
-        // v20-v31 are reserved on AIX with vec-default ABI (this ABI is not currently used in Rust's builtin AIX targets).
+        // v20-v31 (vs52-vs63) are reserved on AIX with vec-default ABI (this ABI is not currently used in Rust's builtin AIX targets).
         asm!("", out("v20") _);
         asm!("", out("v21") _);
         asm!("", out("v22") _);
@@ -90,6 +90,47 @@ fn f() {
         asm!("", out("v29") _);
         asm!("", out("v30") _);
         asm!("", out("v31") _);
+
+
+        // vsreg
+        asm!("", out("vs0") _); // always ok
+        asm!("", in("vs0") v32x4); // requires vsx
+        //[powerpc,powerpc64]~^ ERROR register class `vsreg` requires the `vsx` target feature
+        asm!("", out("vs0") v32x4); // requires vsx
+        //[powerpc,powerpc64]~^ ERROR register class `vsreg` requires the `vsx` target feature
+        asm!("", in("vs0") v64x2); // requires vsx
+        //[powerpc,powerpc64]~^ ERROR register class `vsreg` requires the `vsx` target feature
+        asm!("", out("vs0") v64x2); // requires vsx
+        //[powerpc,powerpc64]~^ ERROR register class `vsreg` requires the `vsx` target feature
+        asm!("", in("vs0") x); // FIXME: should be ok if vsx is available
+        //[powerpc,powerpc64]~^ ERROR register class `vsreg` requires the `vsx` target feature
+        //[powerpc64le,aix64]~^^ ERROR type `i32` cannot be used with this register class
+        asm!("", out("vs0") x); // FIXME: should be ok if vsx is available
+        //[powerpc,powerpc64]~^ ERROR register class `vsreg` requires the `vsx` target feature
+        //[powerpc64le,aix64]~^^ ERROR type `i32` cannot be used with this register class
+        asm!("/* {} */", in(vsreg) v32x4); // requires vsx
+        //[powerpc,powerpc64]~^ ERROR register class `vsreg` requires the `vsx` target feature
+        asm!("/* {} */", in(vsreg) v64x2); // requires vsx
+        //[powerpc,powerpc64]~^ ERROR register class `vsreg` requires the `vsx` target feature
+        asm!("/* {} */", in(vsreg) x); // FIXME: should be ok if vsx is available
+        //[powerpc,powerpc64]~^ ERROR register class `vsreg` requires the `vsx` target feature
+        //[powerpc64le,aix64]~^^ ERROR type `i32` cannot be used with this register class
+        asm!("/* {} */", out(vsreg) _); // requires vsx
+        //[powerpc,powerpc64]~^ ERROR register class `vsreg` requires the `vsx` target feature
+
+        // v20-v31 (vs52-vs63) are reserved on AIX with vec-default ABI (this ABI is not currently used in Rust's builtin AIX targets).
+        asm!("", out("vs52") _);
+        asm!("", out("vs53") _);
+        asm!("", out("vs54") _);
+        asm!("", out("vs55") _);
+        asm!("", out("vs56") _);
+        asm!("", out("vs57") _);
+        asm!("", out("vs58") _);
+        asm!("", out("vs59") _);
+        asm!("", out("vs60") _);
+        asm!("", out("vs61") _);
+        asm!("", out("vs62") _);
+        asm!("", out("vs63") _);
 
         // Clobber-only registers
         // cr
@@ -163,5 +204,133 @@ fn f() {
         asm!("", out("cr") _, out("cr7") _);
         //~^ ERROR register `cr7` conflicts with register `cr`
         asm!("", out("f0") _, out("v0") _); // ok
+        asm!("", out("f0") _, out("vs0") _);
+        //~^ ERROR register `vs0` conflicts with register `f0`
+        asm!("", out("f1") _, out("vs1") _);
+        //~^ ERROR register `vs1` conflicts with register `f1`
+        asm!("", out("f2") _, out("vs2") _);
+        //~^ ERROR register `vs2` conflicts with register `f2`
+        asm!("", out("f3") _, out("vs3") _);
+        //~^ ERROR register `vs3` conflicts with register `f3`
+        asm!("", out("f4") _, out("vs4") _);
+        //~^ ERROR register `vs4` conflicts with register `f4`
+        asm!("", out("f5") _, out("vs5") _);
+        //~^ ERROR register `vs5` conflicts with register `f5`
+        asm!("", out("f6") _, out("vs6") _);
+        //~^ ERROR register `vs6` conflicts with register `f6`
+        asm!("", out("f7") _, out("vs7") _);
+        //~^ ERROR register `vs7` conflicts with register `f7`
+        asm!("", out("f8") _, out("vs8") _);
+        //~^ ERROR register `vs8` conflicts with register `f8`
+        asm!("", out("f9") _, out("vs9") _);
+        //~^ ERROR register `vs9` conflicts with register `f9`
+        asm!("", out("f10") _, out("vs10") _);
+        //~^ ERROR register `vs10` conflicts with register `f10`
+        asm!("", out("f11") _, out("vs11") _);
+        //~^ ERROR register `vs11` conflicts with register `f11`
+        asm!("", out("f12") _, out("vs12") _);
+        //~^ ERROR register `vs12` conflicts with register `f12`
+        asm!("", out("f13") _, out("vs13") _);
+        //~^ ERROR register `vs13` conflicts with register `f13`
+        asm!("", out("f14") _, out("vs14") _);
+        //~^ ERROR register `vs14` conflicts with register `f14`
+        asm!("", out("f15") _, out("vs15") _);
+        //~^ ERROR register `vs15` conflicts with register `f15`
+        asm!("", out("f16") _, out("vs16") _);
+        //~^ ERROR register `vs16` conflicts with register `f16`
+        asm!("", out("f17") _, out("vs17") _);
+        //~^ ERROR register `vs17` conflicts with register `f17`
+        asm!("", out("f18") _, out("vs18") _);
+        //~^ ERROR register `vs18` conflicts with register `f18`
+        asm!("", out("f19") _, out("vs19") _);
+        //~^ ERROR register `vs19` conflicts with register `f19`
+        asm!("", out("f20") _, out("vs20") _);
+        //~^ ERROR register `vs20` conflicts with register `f20`
+        asm!("", out("f21") _, out("vs21") _);
+        //~^ ERROR register `vs21` conflicts with register `f21`
+        asm!("", out("f22") _, out("vs22") _);
+        //~^ ERROR register `vs22` conflicts with register `f22`
+        asm!("", out("f23") _, out("vs23") _);
+        //~^ ERROR register `vs23` conflicts with register `f23`
+        asm!("", out("f24") _, out("vs24") _);
+        //~^ ERROR register `vs24` conflicts with register `f24`
+        asm!("", out("f25") _, out("vs25") _);
+        //~^ ERROR register `vs25` conflicts with register `f25`
+        asm!("", out("f26") _, out("vs26") _);
+        //~^ ERROR register `vs26` conflicts with register `f26`
+        asm!("", out("f27") _, out("vs27") _);
+        //~^ ERROR register `vs27` conflicts with register `f27`
+        asm!("", out("f28") _, out("vs28") _);
+        //~^ ERROR register `vs28` conflicts with register `f28`
+        asm!("", out("f29") _, out("vs29") _);
+        //~^ ERROR register `vs29` conflicts with register `f29`
+        asm!("", out("f30") _, out("vs30") _);
+        //~^ ERROR register `vs30` conflicts with register `f30`
+        asm!("", out("f31") _, out("vs31") _);
+        //~^ ERROR register `vs31` conflicts with register `f31`
+        asm!("", out("vs32") _, out("v0") _);
+        //~^ ERROR register `v0` conflicts with register `vs32`
+        asm!("", out("vs33") _, out("v1") _);
+        //~^ ERROR register `v1` conflicts with register `vs33`
+        asm!("", out("vs34") _, out("v2") _);
+        //~^ ERROR register `v2` conflicts with register `vs34`
+        asm!("", out("vs35") _, out("v3") _);
+        //~^ ERROR register `v3` conflicts with register `vs35`
+        asm!("", out("vs36") _, out("v4") _);
+        //~^ ERROR register `v4` conflicts with register `vs36`
+        asm!("", out("vs37") _, out("v5") _);
+        //~^ ERROR register `v5` conflicts with register `vs37`
+        asm!("", out("vs38") _, out("v6") _);
+        //~^ ERROR register `v6` conflicts with register `vs38`
+        asm!("", out("vs39") _, out("v7") _);
+        //~^ ERROR register `v7` conflicts with register `vs39`
+        asm!("", out("vs40") _, out("v8") _);
+        //~^ ERROR register `v8` conflicts with register `vs40`
+        asm!("", out("vs41") _, out("v9") _);
+        //~^ ERROR register `v9` conflicts with register `vs41`
+        asm!("", out("vs42") _, out("v10") _);
+        //~^ ERROR register `v10` conflicts with register `vs42`
+        asm!("", out("vs43") _, out("v11") _);
+        //~^ ERROR register `v11` conflicts with register `vs43`
+        asm!("", out("vs44") _, out("v12") _);
+        //~^ ERROR register `v12` conflicts with register `vs44`
+        asm!("", out("vs45") _, out("v13") _);
+        //~^ ERROR register `v13` conflicts with register `vs45`
+        asm!("", out("vs46") _, out("v14") _);
+        //~^ ERROR register `v14` conflicts with register `vs46`
+        asm!("", out("vs47") _, out("v15") _);
+        //~^ ERROR register `v15` conflicts with register `vs47`
+        asm!("", out("vs48") _, out("v16") _);
+        //~^ ERROR register `v16` conflicts with register `vs48`
+        asm!("", out("vs49") _, out("v17") _);
+        //~^ ERROR register `v17` conflicts with register `vs49`
+        asm!("", out("vs50") _, out("v18") _);
+        //~^ ERROR register `v18` conflicts with register `vs50`
+        asm!("", out("vs51") _, out("v19") _);
+        //~^ ERROR register `v19` conflicts with register `vs51`
+        asm!("", out("vs52") _, out("v20") _);
+        //~^ ERROR register `v20` conflicts with register `vs52`
+        asm!("", out("vs53") _, out("v21") _);
+        //~^ ERROR register `v21` conflicts with register `vs53`
+        asm!("", out("vs54") _, out("v22") _);
+        //~^ ERROR register `v22` conflicts with register `vs54`
+        asm!("", out("vs55") _, out("v23") _);
+        //~^ ERROR register `v23` conflicts with register `vs55`
+        asm!("", out("vs56") _, out("v24") _);
+        //~^ ERROR register `v24` conflicts with register `vs56`
+        asm!("", out("vs57") _, out("v25") _);
+        //~^ ERROR register `v25` conflicts with register `vs57`
+        asm!("", out("vs58") _, out("v26") _);
+        //~^ ERROR register `v26` conflicts with register `vs58`
+        asm!("", out("vs59") _, out("v27") _);
+        //~^ ERROR register `v27` conflicts with register `vs59`
+        asm!("", out("vs60") _, out("v28") _);
+        //~^ ERROR register `v28` conflicts with register `vs60`
+        asm!("", out("vs61") _, out("v29") _);
+        //~^ ERROR register `v29` conflicts with register `vs61`
+        asm!("", out("vs62") _, out("v30") _);
+        //~^ ERROR register `v30` conflicts with register `vs62`
+        asm!("", out("vs63") _, out("v31") _);
+        //~^ ERROR register `v31` conflicts with register `vs63`
     }
 }


### PR DESCRIPTION
This should address the last(?) missing pieces of inline asm for ppc:

* Explicit VSX register support. ISA 2.06 (POWER7) added a 64x128b register overlay extending the fpr's to 128b, and unifies them with the vmx (altivec) registers. Implementations details within gcc/llvm percolate up, and require using the `x` template modifier. I have updated the inline asm to implicitly include this for vsx arguments which do not specify it. ~~Support for the gcc codegen backend is still a todo.~~

* Implement the `preserves_flags` option. All ABI's, and all ISAs store their flags in `cr`, and the carry bit lives inside `xer`. The other status registers hold sticky bits or control bits which do not affect branch instructions.

There is some interest in the e500 (powerpcspe) port. Architecturally, it has a very different FP ISA, and includes a simd extension called SPR (which is not IBM's cell SPE). Notably, it does not have altivec/fpr/vsx registers. It also has an SPE accumulator register which its ABI marks as volatile, but I am not sure if the compiler uses it.