### PR TITLE
core: simplify `CStr::default()`

### DIFF
--- a/library/alloc/src/ffi/c_str.rs
+++ b/library/alloc/src/ffi/c_str.rs
@@ -970,17 +970,14 @@ impl Default for Rc<CStr> {
     /// This may or may not share an allocation with other Rcs on the same thread.
     #[inline]
     fn default() -> Self {
-        let rc = Rc::<[u8]>::from(*b"\0");
-        // `[u8]` has the same layout as `CStr`, and it is `NUL` terminated.
-        unsafe { Rc::from_raw(Rc::into_raw(rc) as *const CStr) }
+        Rc::from(c"")
     }
 }
 
 #[stable(feature = "default_box_extra", since = "1.17.0")]
 impl Default for Box<CStr> {
     fn default() -> Box<CStr> {
-        let boxed: Box<[u8]> = Box::from([0]);
-        unsafe { Box::from_raw(Box::into_raw(boxed) as *mut CStr) }
+        Box::from(c"")
     }
 }
 

--- a/library/core/src/ffi/c_str.rs
+++ b/library/core/src/ffi/c_str.rs
@@ -179,9 +179,7 @@ impl fmt::Debug for CStr {
 impl Default for &CStr {
     #[inline]
     fn default() -> Self {
-        const SLICE: &[c_char] = &[0];
-        // SAFETY: `SLICE` is indeed pointing to a valid nul-terminated string.
-        unsafe { CStr::from_ptr(SLICE.as_ptr()) }
+        c""
     }
 }
 


### PR DESCRIPTION
Just use a `CStr`-literal...