### PR TITLE
cg_llvm: Perform target-machine command-line quoting as bytes, not characters

### DIFF
--- a/compiler/rustc_codegen_llvm/src/back/command_line_args.rs
+++ b/compiler/rustc_codegen_llvm/src/back/command_line_args.rs
@@ -7,31 +7,41 @@ mod tests;
 /// The result is intended to be informational, for embedding in debug metadata,
 /// and might not be properly quoted/escaped for actual command-line use.
 pub(crate) fn quote_command_line_args(args: &[String]) -> String {
-    // Start with a decent-sized buffer, since rustc invocations tend to be long.
-    let mut buf = String::with_capacity(128);
+    // The characters we care about quoting are all ASCII, so we can get some free
+    // performance by performing the quoting step on bytes instead of characters.
+    //
+    // Non-ASCII bytes will be copied as-is, so the result is still UTF-8.
+
+    // Calculate an adequate buffer size, assuming no escaping will be needed.
+    // The `+ 3` represents an extra space and pair of quotes per arg.
+    let capacity_estimate = args.iter().map(|arg| arg.len() + 3).sum::<usize>();
+    let mut buf = Vec::with_capacity(capacity_estimate);
 
     for arg in args {
         if !buf.is_empty() {
-            buf.push(' ');
+            buf.push(b' ');
         }
 
         print_arg_quoted(&mut buf, arg);
     }
 
-    buf
+    // Converting back to String isn't strictly necessary, since the bytes are
+    // only passed to LLVM which doesn't care, but validating should be cheap
+    // and it's nice to have some assurance that we didn't mess up.
+    String::from_utf8(buf).expect("quoted args should still be UTF-8")
 }
 
 /// Equivalent to LLVM's `sys::printArg` with quoting always enabled
 /// (see llvm/lib/Support/Program.cpp).
-fn print_arg_quoted(buf: &mut String, arg: &str) {
+fn print_arg_quoted(buf: &mut Vec<u8>, arg: &str) {
     buf.reserve(arg.len() + 2);
 
-    buf.push('"');
-    for ch in arg.chars() {
-        if matches!(ch, '"' | '\\' | '$') {
-            buf.push('\\');
+    buf.push(b'"');
+    for &byte in arg.as_bytes() {
+        if matches!(byte, b'"' | b'\\' | b'$') {
+            buf.push(b'\\');
         }
-        buf.push(ch);
+        buf.push(byte);
     }
-    buf.push('"');
+    buf.push(b'"');
 }


### PR DESCRIPTION
EDIT: There is now a proposal to remove the underlying code entirely, which would make this PR obsolete.
- https://github.com/rust-lang/rust/pull/147022

---

(Slightly modified version of the original experiment at rust-lang/rust#146804.)

This works because the only characters we care about escaping are ASCII characters, so forwarding non-ASCII UTF-8 bytes as-is still produces correct results.

A perf run at https://github.com/rust-lang/rust/pull/146804#issuecomment-3314716491 indicates that this has a big impact on several versions of the `large-workspace` benchmark.

---

This PR doesn't address the underlying problem, which is that we're doing this quoting far too many times overall. Really we shouldn't be doing it more than once per process, but in practice we do it multiple times per CGU, which is bad news for incremental builds.
- See rust-lang/rust#146973.

But these changes are basically a free win, so I'm happy to merge them anyway.