### PR TITLE
Fix infinite recursion in Path::eq with String

### DIFF
--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -2107,7 +2107,7 @@ impl PartialEq for PathBuf {
 impl cmp::PartialEq<str> for PathBuf {
     #[inline]
     fn eq(&self, other: &str) -> bool {
-        Path::eq(self, other)
+        self.as_path() == other
     }
 }
 
@@ -2115,7 +2115,7 @@ impl cmp::PartialEq<str> for PathBuf {
 impl cmp::PartialEq<PathBuf> for str {
     #[inline]
     fn eq(&self, other: &PathBuf) -> bool {
-        other == self
+        self == other.as_path()
     }
 }
 
@@ -2123,7 +2123,7 @@ impl cmp::PartialEq<PathBuf> for str {
 impl cmp::PartialEq<String> for PathBuf {
     #[inline]
     fn eq(&self, other: &String) -> bool {
-        **self == **other
+        self.as_path() == other.as_str()
     }
 }
 
@@ -2131,7 +2131,7 @@ impl cmp::PartialEq<String> for PathBuf {
 impl cmp::PartialEq<PathBuf> for String {
     #[inline]
     fn eq(&self, other: &PathBuf) -> bool {
-        other == self
+        self.as_str() == other.as_path()
     }
 }
 
@@ -3426,7 +3426,7 @@ impl cmp::PartialEq<Path> for str {
 impl cmp::PartialEq<String> for Path {
     #[inline]
     fn eq(&self, other: &String) -> bool {
-        self == &*other
+        self == other.as_str()
     }
 }
 
@@ -3434,7 +3434,7 @@ impl cmp::PartialEq<String> for Path {
 impl cmp::PartialEq<Path> for String {
     #[inline]
     fn eq(&self, other: &Path) -> bool {
-        other == self
+        self.as_str() == other
     }
 }
 

--- a/library/std/tests/path.rs
+++ b/library/std/tests/path.rs
@@ -2528,7 +2528,17 @@ fn normalize_lexically() {
 }
 
 #[test]
-/// See issue#146183
-fn compare_path_to_str() {
-    assert!(&PathBuf::from("x") == "x");
+/// See issue#146183 and issue#146940
+fn compare_path_like_to_str_like() {
+    let path_buf = PathBuf::from("x");
+    let path = Path::new("x");
+    let s = String::from("x");
+    assert!(path == "x");
+    assert!("x" == path);
+    assert!(path == &s);
+    assert!(&s == path);
+    assert!(&path_buf == "x");
+    assert!("x" == &path_buf);
+    assert!(path_buf == s);
+    assert!(s == path_buf);
 }


### PR DESCRIPTION
- Closes [after beta backport] rust-lang/rust#146940
