### PR TITLE
Allow passing `expr` metavariable as `cfg` predicate

### DIFF
--- a/compiler/rustc_attr_parsing/src/attributes/cfg.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/cfg.rs
@@ -20,7 +20,9 @@ use rustc_span::{ErrorGuaranteed, Span, Symbol, sym};
 use thin_vec::ThinVec;
 
 use crate::context::{AcceptContext, ShouldEmit, Stage};
-use crate::parser::{ArgParser, MetaItemListParser, MetaItemOrLitParser, NameValueParser};
+use crate::parser::{
+    AllowExprMetavar, ArgParser, MetaItemListParser, MetaItemOrLitParser, NameValueParser,
+};
 use crate::session_diagnostics::{
     AttributeParseError, AttributeParseErrorReason, CfgAttrBadDelim, MetaBadDelimSugg,
     ParsedDescription,
@@ -363,7 +365,7 @@ fn parse_cfg_attr_internal<'a>(
     let meta = MetaItemOrLitParser::parse_single(
         parser,
         ShouldEmit::ErrorsAndLints { recovery: Recovery::Allowed },
-        true,
+        AllowExprMetavar::Yes,
     )?;
     let pred_span = pred_start.with_hi(parser.token.span.hi());
 

--- a/compiler/rustc_attr_parsing/src/attributes/cfg.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/cfg.rs
@@ -363,6 +363,7 @@ fn parse_cfg_attr_internal<'a>(
     let meta = MetaItemOrLitParser::parse_single(
         parser,
         ShouldEmit::ErrorsAndLints { recovery: Recovery::Allowed },
+        true,
     )?;
     let pred_span = pred_start.with_hi(parser.token.span.hi());
 

--- a/compiler/rustc_attr_parsing/src/attributes/cfg_select.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/cfg_select.rs
@@ -94,6 +94,7 @@ pub fn parse_cfg_select(
             let meta = MetaItemOrLitParser::parse_single(
                 p,
                 ShouldEmit::ErrorsAndLints { recovery: Recovery::Allowed },
+                true,
             )
             .map_err(|diag| diag.emit())?;
             let cfg_span = meta.span();

--- a/compiler/rustc_attr_parsing/src/attributes/cfg_select.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/cfg_select.rs
@@ -12,7 +12,7 @@ use rustc_session::lint::BuiltinLintDiag;
 use rustc_session::lint::builtin::UNREACHABLE_CFG_SELECT_PREDICATES;
 use rustc_span::{ErrorGuaranteed, Span, Symbol, sym};
 
-use crate::parser::MetaItemOrLitParser;
+use crate::parser::{AllowExprMetavar, MetaItemOrLitParser};
 use crate::{AttributeParser, ParsedDescription, ShouldEmit, parse_cfg_entry};
 
 #[derive(Clone)]
@@ -94,7 +94,7 @@ pub fn parse_cfg_select(
             let meta = MetaItemOrLitParser::parse_single(
                 p,
                 ShouldEmit::ErrorsAndLints { recovery: Recovery::Allowed },
-                true,
+                AllowExprMetavar::Yes,
             )
             .map_err(|diag| diag.emit())?;
             let cfg_span = meta.span();

--- a/compiler/rustc_attr_parsing/src/interface.rs
+++ b/compiler/rustc_attr_parsing/src/interface.rs
@@ -14,7 +14,7 @@ use rustc_span::{DUMMY_SP, Span, Symbol, sym};
 
 use crate::context::{AcceptContext, FinalizeContext, FinalizeFn, SharedContext, Stage};
 use crate::early_parsed::{EARLY_PARSED_ATTRIBUTES, EarlyParsedState};
-use crate::parser::{ArgParser, PathParser, RefPathParser};
+use crate::parser::{AllowExprMetavar, ArgParser, PathParser, RefPathParser};
 use crate::session_diagnostics::ParsedDescription;
 use crate::{Early, Late, OmitDoc, ShouldEmit};
 
@@ -139,7 +139,7 @@ impl<'sess> AttributeParser<'sess, Early> {
         emit_errors: ShouldEmit,
         parse_fn: fn(cx: &mut AcceptContext<'_, '_, Early>, item: &ArgParser) -> Option<T>,
         template: &AttributeTemplate,
-        allow_expr_metavar: bool,
+        allow_expr_metavar: AllowExprMetavar,
     ) -> Option<T> {
         let ast::AttrKind::Normal(normal_attr) = &attr.kind else {
             panic!("parse_single called on a doc attr")
@@ -335,7 +335,7 @@ impl<'sess, S: Stage> AttributeParser<'sess, S> {
                             &parts,
                             &self.sess.psess,
                             self.stage.should_emit(),
-                            false,
+                            AllowExprMetavar::No,
                         ) else {
                             continue;
                         };

--- a/compiler/rustc_attr_parsing/src/interface.rs
+++ b/compiler/rustc_attr_parsing/src/interface.rs
@@ -139,6 +139,7 @@ impl<'sess> AttributeParser<'sess, Early> {
         emit_errors: ShouldEmit,
         parse_fn: fn(cx: &mut AcceptContext<'_, '_, Early>, item: &ArgParser) -> Option<T>,
         template: &AttributeTemplate,
+        allow_expr_metavar: bool,
     ) -> Option<T> {
         let ast::AttrKind::Normal(normal_attr) = &attr.kind else {
             panic!("parse_single called on a doc attr")
@@ -152,6 +153,7 @@ impl<'sess> AttributeParser<'sess, Early> {
             &parts,
             &sess.psess,
             emit_errors,
+            allow_expr_metavar,
         )?;
         Self::parse_single_args(
             sess,
@@ -333,6 +335,7 @@ impl<'sess, S: Stage> AttributeParser<'sess, S> {
                             &parts,
                             &self.sess.psess,
                             self.stage.should_emit(),
+                            false,
                         ) else {
                             continue;
                         };

--- a/compiler/rustc_attr_parsing/src/parser.rs
+++ b/compiler/rustc_attr_parsing/src/parser.rs
@@ -109,7 +109,7 @@ impl ArgParser {
         parts: &[Symbol],
         psess: &'sess ParseSess,
         should_emit: ShouldEmit,
-        allow_expr_metavar: bool,
+        allow_expr_metavar: AllowExprMetavar,
     ) -> Option<Self> {
         Some(match value {
             AttrArgs::Empty => Self::NoArgs,
@@ -225,7 +225,7 @@ impl MetaItemOrLitParser {
     pub fn parse_single<'sess>(
         parser: &mut Parser<'sess>,
         should_emit: ShouldEmit,
-        allow_expr_metavar: bool,
+        allow_expr_metavar: AllowExprMetavar,
     ) -> PResult<'sess, MetaItemOrLitParser> {
         let mut this = MetaItemListParserContext { parser, should_emit, allow_expr_metavar };
         this.parse_meta_item_inner()
@@ -413,10 +413,19 @@ fn expr_to_lit<'sess>(
     }
 }
 
+/// Whether expansions of `expr` metavariables from decrarative macros
+/// are permitted. Used when parsing meta items; currently, only `cfg` predicates
+/// enable this option
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum AllowExprMetavar {
+    No,
+    Yes,
+}
+
 struct MetaItemListParserContext<'a, 'sess> {
     parser: &'a mut Parser<'sess>,
     should_emit: ShouldEmit,
-    allow_expr_metavar: bool,
+    allow_expr_metavar: AllowExprMetavar,
 }
 
 impl<'a, 'sess> MetaItemListParserContext<'a, 'sess> {
@@ -457,25 +466,25 @@ impl<'a, 'sess> MetaItemListParserContext<'a, 'sess> {
         Ok(lit)
     }
 
-    fn parse_attr_item(&mut self) -> PResult<'sess, MetaItemParser> {
+    fn parse_meta_item(&mut self) -> PResult<'sess, MetaItemParser> {
         if let Some(metavar) = self.parser.token.is_metavar_seq() {
-            match metavar {
-                kind @ MetaVarKind::Expr { .. } if self.allow_expr_metavar => {
+            match (metavar, self.allow_expr_metavar) {
+                (kind @ MetaVarKind::Expr { .. }, AllowExprMetavar::Yes) => {
                     return self
                         .parser
                         .eat_metavar_seq(kind, |this| {
                             MetaItemListParserContext {
                                 parser: this,
                                 should_emit: self.should_emit,
-                                allow_expr_metavar: true,
+                                allow_expr_metavar: AllowExprMetavar::Yes,
                             }
-                            .parse_attr_item()
+                            .parse_meta_item()
                         })
                         .ok_or_else(|| {
                             self.parser.unexpected_any::<core::convert::Infallible>().unwrap_err()
                         });
                 }
-                MetaVarKind::Meta { has_meta_form } => {
+                (MetaVarKind::Meta { has_meta_form }, _) => {
                     return if has_meta_form {
                         let attr_item = self
                             .parser
@@ -485,7 +494,7 @@ impl<'a, 'sess> MetaItemListParserContext<'a, 'sess> {
                                     should_emit: self.should_emit,
                                     allow_expr_metavar: self.allow_expr_metavar,
                                 }
-                                .parse_attr_item()
+                                .parse_meta_item()
                             })
                             .unwrap();
                         Ok(attr_item)
@@ -530,7 +539,7 @@ impl<'a, 'sess> MetaItemListParserContext<'a, 'sess> {
             Ok(MetaItemOrLitParser::Lit(self.unsuffixed_meta_item_from_lit(token_lit)?))
         } else {
             let prev_pros = self.parser.approx_token_stream_pos();
-            match self.parse_attr_item() {
+            match self.parse_meta_item() {
                 Ok(item) => Ok(MetaItemOrLitParser::MetaItemParser(item)),
                 Err(err) => {
                     // If `parse_attr_item` made any progress, it likely has a more precise error we should prefer
@@ -618,7 +627,7 @@ impl<'a, 'sess> MetaItemListParserContext<'a, 'sess> {
         psess: &'sess ParseSess,
         span: Span,
         should_emit: ShouldEmit,
-        allow_expr_metavar: bool,
+        allow_expr_metavar: AllowExprMetavar,
     ) -> PResult<'sess, MetaItemListParser> {
         let mut parser = Parser::new(psess, tokens, None);
         if let ShouldEmit::ErrorsAndLints { recovery } = should_emit {
@@ -658,7 +667,7 @@ impl MetaItemListParser {
         span: Span,
         psess: &'sess ParseSess,
         should_emit: ShouldEmit,
-        allow_expr_metavar: bool,
+        allow_expr_metavar: AllowExprMetavar,
     ) -> Result<Self, Diag<'sess>> {
         MetaItemListParserContext::parse(
             tokens.clone(),

--- a/compiler/rustc_attr_parsing/src/parser.rs
+++ b/compiler/rustc_attr_parsing/src/parser.rs
@@ -109,6 +109,7 @@ impl ArgParser {
         parts: &[Symbol],
         psess: &'sess ParseSess,
         should_emit: ShouldEmit,
+        allow_expr_metavar: bool,
     ) -> Option<Self> {
         Some(match value {
             AttrArgs::Empty => Self::NoArgs,
@@ -122,6 +123,7 @@ impl ArgParser {
                         args.dspan.entire(),
                         psess,
                         ShouldEmit::ErrorsAndLints { recovery: Recovery::Forbidden },
+                        allow_expr_metavar,
                     ) {
                         Ok(p) => return Some(ArgParser::List(p)),
                         Err(e) => {
@@ -147,9 +149,15 @@ impl ArgParser {
                 }
 
                 Self::List(
-                    MetaItemListParser::new(&args.tokens, args.dspan.entire(), psess, should_emit)
-                        .map_err(|e| should_emit.emit_err(e))
-                        .ok()?,
+                    MetaItemListParser::new(
+                        &args.tokens,
+                        args.dspan.entire(),
+                        psess,
+                        should_emit,
+                        allow_expr_metavar,
+                    )
+                    .map_err(|e| should_emit.emit_err(e))
+                    .ok()?,
                 )
             }
             AttrArgs::Eq { eq_span, expr } => Self::NameValue(NameValueParser {
@@ -217,8 +225,9 @@ impl MetaItemOrLitParser {
     pub fn parse_single<'sess>(
         parser: &mut Parser<'sess>,
         should_emit: ShouldEmit,
+        allow_expr_metavar: bool,
     ) -> PResult<'sess, MetaItemOrLitParser> {
-        let mut this = MetaItemListParserContext { parser, should_emit };
+        let mut this = MetaItemListParserContext { parser, should_emit, allow_expr_metavar };
         this.parse_meta_item_inner()
     }
 
@@ -407,6 +416,7 @@ fn expr_to_lit<'sess>(
 struct MetaItemListParserContext<'a, 'sess> {
     parser: &'a mut Parser<'sess>,
     should_emit: ShouldEmit,
+    allow_expr_metavar: bool,
 }
 
 impl<'a, 'sess> MetaItemListParserContext<'a, 'sess> {
@@ -448,19 +458,43 @@ impl<'a, 'sess> MetaItemListParserContext<'a, 'sess> {
     }
 
     fn parse_attr_item(&mut self) -> PResult<'sess, MetaItemParser> {
-        if let Some(MetaVarKind::Meta { has_meta_form }) = self.parser.token.is_metavar_seq() {
-            return if has_meta_form {
-                let attr_item = self
-                    .parser
-                    .eat_metavar_seq(MetaVarKind::Meta { has_meta_form: true }, |this| {
-                        MetaItemListParserContext { parser: this, should_emit: self.should_emit }
+        if let Some(metavar) = self.parser.token.is_metavar_seq() {
+            match metavar {
+                kind @ MetaVarKind::Expr { .. } if self.allow_expr_metavar => {
+                    return self
+                        .parser
+                        .eat_metavar_seq(kind, |this| {
+                            MetaItemListParserContext {
+                                parser: this,
+                                should_emit: self.should_emit,
+                                allow_expr_metavar: true,
+                            }
                             .parse_attr_item()
-                    })
-                    .unwrap();
-                Ok(attr_item)
-            } else {
-                self.parser.unexpected_any()
-            };
+                        })
+                        .ok_or_else(|| {
+                            self.parser.unexpected_any::<core::convert::Infallible>().unwrap_err()
+                        });
+                }
+                MetaVarKind::Meta { has_meta_form } => {
+                    return if has_meta_form {
+                        let attr_item = self
+                            .parser
+                            .eat_metavar_seq(MetaVarKind::Meta { has_meta_form: true }, |this| {
+                                MetaItemListParserContext {
+                                    parser: this,
+                                    should_emit: self.should_emit,
+                                    allow_expr_metavar: self.allow_expr_metavar,
+                                }
+                                .parse_attr_item()
+                            })
+                            .unwrap();
+                        Ok(attr_item)
+                    } else {
+                        self.parser.unexpected_any()
+                    };
+                }
+                _ => {}
+            }
         }
 
         let path = self.parser.parse_path(PathStyle::Mod)?;
@@ -469,8 +503,12 @@ impl<'a, 'sess> MetaItemListParserContext<'a, 'sess> {
         let args = if self.parser.check(exp!(OpenParen)) {
             let start = self.parser.token.span;
             let (sub_parsers, _) = self.parser.parse_paren_comma_seq(|parser| {
-                MetaItemListParserContext { parser, should_emit: self.should_emit }
-                    .parse_meta_item_inner()
+                MetaItemListParserContext {
+                    parser,
+                    should_emit: self.should_emit,
+                    allow_expr_metavar: self.allow_expr_metavar,
+                }
+                .parse_meta_item_inner()
             })?;
             let end = self.parser.prev_token.span;
             ArgParser::List(MetaItemListParser { sub_parsers, span: start.with_hi(end.hi()) })
@@ -580,13 +618,15 @@ impl<'a, 'sess> MetaItemListParserContext<'a, 'sess> {
         psess: &'sess ParseSess,
         span: Span,
         should_emit: ShouldEmit,
+        allow_expr_metavar: bool,
     ) -> PResult<'sess, MetaItemListParser> {
         let mut parser = Parser::new(psess, tokens, None);
         if let ShouldEmit::ErrorsAndLints { recovery } = should_emit {
             parser = parser.recovery(recovery);
         }
 
-        let mut this = MetaItemListParserContext { parser: &mut parser, should_emit };
+        let mut this =
+            MetaItemListParserContext { parser: &mut parser, should_emit, allow_expr_metavar };
 
         // Presumably, the majority of the time there will only be one attr.
         let mut sub_parsers = ThinVec::with_capacity(1);
@@ -618,8 +658,15 @@ impl MetaItemListParser {
         span: Span,
         psess: &'sess ParseSess,
         should_emit: ShouldEmit,
+        allow_expr_metavar: bool,
     ) -> Result<Self, Diag<'sess>> {
-        MetaItemListParserContext::parse(tokens.clone(), psess, span, should_emit)
+        MetaItemListParserContext::parse(
+            tokens.clone(),
+            psess,
+            span,
+            should_emit,
+            allow_expr_metavar,
+        )
     }
 
     /// Lets you pick and choose as what you want to parse each element in the list

--- a/compiler/rustc_builtin_macros/src/cfg.rs
+++ b/compiler/rustc_builtin_macros/src/cfg.rs
@@ -4,10 +4,9 @@
 
 use rustc_ast::tokenstream::TokenStream;
 use rustc_ast::{AttrStyle, token};
-use rustc_attr_parsing as attr;
-use rustc_attr_parsing::parser::MetaItemOrLitParser;
+use rustc_attr_parsing::parser::{AllowExprMetavar, MetaItemOrLitParser};
 use rustc_attr_parsing::{
-    AttributeParser, CFG_TEMPLATE, ParsedDescription, ShouldEmit, parse_cfg_entry,
+    self as attr, AttributeParser, CFG_TEMPLATE, ParsedDescription, ShouldEmit, parse_cfg_entry,
 };
 use rustc_expand::base::{DummyResult, ExpandResult, ExtCtxt, MacEager, MacroExpanderResult};
 use rustc_hir::attrs::CfgEntry;
@@ -44,7 +43,7 @@ fn parse_cfg(cx: &ExtCtxt<'_>, span: Span, tts: TokenStream) -> Result<CfgEntry,
     let meta = MetaItemOrLitParser::parse_single(
         &mut parser,
         ShouldEmit::ErrorsAndLints { recovery: Recovery::Allowed },
-        true,
+        AllowExprMetavar::Yes,
     )
     .map_err(|diag| diag.emit())?;
     let cfg = AttributeParser::parse_single_args(

--- a/compiler/rustc_builtin_macros/src/cfg.rs
+++ b/compiler/rustc_builtin_macros/src/cfg.rs
@@ -44,6 +44,7 @@ fn parse_cfg(cx: &ExtCtxt<'_>, span: Span, tts: TokenStream) -> Result<CfgEntry,
     let meta = MetaItemOrLitParser::parse_single(
         &mut parser,
         ShouldEmit::ErrorsAndLints { recovery: Recovery::Allowed },
+        true,
     )
     .map_err(|diag| diag.emit())?;
     let cfg = AttributeParser::parse_single_args(

--- a/compiler/rustc_expand/src/config.rs
+++ b/compiler/rustc_expand/src/config.rs
@@ -10,9 +10,10 @@ use rustc_ast::{
     self as ast, AttrItemKind, AttrKind, AttrStyle, Attribute, DUMMY_NODE_ID, EarlyParsedAttribute,
     HasAttrs, HasTokens, MetaItem, MetaItemInner, NodeId, NormalAttr,
 };
-use rustc_attr_parsing as attr;
+use rustc_attr_parsing::parser::AllowExprMetavar;
 use rustc_attr_parsing::{
-    AttributeParser, CFG_TEMPLATE, EvalConfigResult, ShouldEmit, eval_config_entry, parse_cfg,
+    self as attr, AttributeParser, CFG_TEMPLATE, EvalConfigResult, ShouldEmit, eval_config_entry,
+    parse_cfg,
 };
 use rustc_data_structures::flat_map_in_place::FlatMapInPlace;
 use rustc_errors::msg;
@@ -402,7 +403,7 @@ impl<'a> StripUnconfigured<'a> {
             emit_errors,
             parse_cfg,
             &CFG_TEMPLATE,
-            true,
+            AllowExprMetavar::Yes,
         ) else {
             // Cfg attribute was not parsable, give up
             return EvalConfigResult::True;

--- a/compiler/rustc_expand/src/config.rs
+++ b/compiler/rustc_expand/src/config.rs
@@ -402,6 +402,7 @@ impl<'a> StripUnconfigured<'a> {
             emit_errors,
             parse_cfg,
             &CFG_TEMPLATE,
+            true,
         ) else {
             // Cfg attribute was not parsable, give up
             return EvalConfigResult::True;

--- a/compiler/rustc_expand/src/expand.rs
+++ b/compiler/rustc_expand/src/expand.rs
@@ -2224,6 +2224,7 @@ impl<'a, 'b> InvocationCollector<'a, 'b> {
             ShouldEmit::ErrorsAndLints { recovery: Recovery::Allowed },
             parse_cfg,
             &CFG_TEMPLATE,
+            true,
         ) else {
             // Cfg attribute was not parsable, give up
             return EvalConfigResult::True;

--- a/compiler/rustc_expand/src/expand.rs
+++ b/compiler/rustc_expand/src/expand.rs
@@ -13,6 +13,7 @@ use rustc_ast::{
     TyKind, token,
 };
 use rustc_ast_pretty::pprust;
+use rustc_attr_parsing::parser::AllowExprMetavar;
 use rustc_attr_parsing::{
     AttributeParser, CFG_TEMPLATE, Early, EvalConfigResult, ShouldEmit, eval_config_entry,
     parse_cfg, validate_attr,
@@ -2224,7 +2225,7 @@ impl<'a, 'b> InvocationCollector<'a, 'b> {
             ShouldEmit::ErrorsAndLints { recovery: Recovery::Allowed },
             parse_cfg,
             &CFG_TEMPLATE,
-            true,
+            AllowExprMetavar::Yes,
         ) else {
             // Cfg attribute was not parsable, give up
             return EvalConfigResult::True;

--- a/library/std/src/sys/thread_local/os.rs
+++ b/library/std/src/sys/thread_local/os.rs
@@ -62,25 +62,7 @@ pub macro thread_local_inner {
     // by translating it into a `cfg`ed block and recursing.
     // https://doc.rust-lang.org/reference/conditional-compilation.html#railroad-ConfigurationPredicate
 
-    (@align $final_align:ident, cfg_attr(true, $($cfg_rhs:tt)*) $(, $($attr_rest:tt)+)?) => {
-        #[cfg(true)]
-        {
-            $crate::thread::local_impl::thread_local_inner!(@align $final_align, $($cfg_rhs)*);
-        }
-
-        $($crate::thread::local_impl::thread_local_inner!(@align $final_align, $($attr_rest)+);)?
-    },
-
-    (@align $final_align:ident, cfg_attr(false, $($cfg_rhs:tt)*) $(, $($attr_rest:tt)+)?) => {
-        #[cfg(false)]
-        {
-            $crate::thread::local_impl::thread_local_inner!(@align $final_align, $($cfg_rhs)*);
-        }
-
-        $($crate::thread::local_impl::thread_local_inner!(@align $final_align, $($attr_rest)+);)?
-    },
-
-    (@align $final_align:ident, cfg_attr($cfg_pred:meta, $($cfg_rhs:tt)*) $(, $($attr_rest:tt)+)?) => {
+    (@align $final_align:ident, cfg_attr($cfg_pred:expr, $($cfg_rhs:tt)*) $(, $($attr_rest:tt)+)?) => {
         #[cfg($cfg_pred)]
         {
             $crate::thread::local_impl::thread_local_inner!(@align $final_align, $($cfg_rhs)*);

--- a/library/std/src/thread/local.rs
+++ b/library/std/src/thread/local.rs
@@ -198,41 +198,10 @@ pub macro thread_local_process_attrs {
         );
     ),
 
-    // it's a nested `cfg_attr(true, ...)`; recurse into RHS
-    (
-        [$($prev_align_attrs:tt)*] [$($prev_other_attrs:tt)*];
-        @processing_cfg_attr { pred: ($($predicate:tt)*), rhs: [cfg_attr(true, $($cfg_rhs:tt)*) $(, $($attr_rhs:tt)*)?] };
-        $($rest:tt)*
-    ) => (
-        $crate::thread::local_impl::thread_local_process_attrs!(
-            [] [];
-            @processing_cfg_attr { pred: (true), rhs: [$($cfg_rhs)*] };
-            [$($prev_align_attrs)*] [$($prev_other_attrs)*];
-            @processing_cfg_attr { pred: ($($predicate)*), rhs: [$($($attr_rhs)*)?] };
-            $($rest)*
-        );
-    ),
-
-    // it's a nested `cfg_attr(false, ...)`; recurse into RHS
-    (
-        [$($prev_align_attrs:tt)*] [$($prev_other_attrs:tt)*];
-        @processing_cfg_attr { pred: ($($predicate:tt)*), rhs: [cfg_attr(false, $($cfg_rhs:tt)*) $(, $($attr_rhs:tt)*)?] };
-        $($rest:tt)*
-    ) => (
-        $crate::thread::local_impl::thread_local_process_attrs!(
-            [] [];
-            @processing_cfg_attr { pred: (false), rhs: [$($cfg_rhs)*] };
-            [$($prev_align_attrs)*] [$($prev_other_attrs)*];
-            @processing_cfg_attr { pred: ($($predicate)*), rhs: [$($($attr_rhs)*)?] };
-            $($rest)*
-        );
-    ),
-
-
     // it's a nested `cfg_attr(..., ...)`; recurse into RHS
     (
         [$($prev_align_attrs:tt)*] [$($prev_other_attrs:tt)*];
-        @processing_cfg_attr { pred: ($($predicate:tt)*), rhs: [cfg_attr($cfg_lhs:meta, $($cfg_rhs:tt)*) $(, $($attr_rhs:tt)*)?] };
+        @processing_cfg_attr { pred: ($($predicate:tt)*), rhs: [cfg_attr($cfg_lhs:expr, $($cfg_rhs:tt)*) $(, $($attr_rhs:tt)*)?] };
         $($rest:tt)*
     ) => (
         $crate::thread::local_impl::thread_local_process_attrs!(
@@ -268,28 +237,8 @@ pub macro thread_local_process_attrs {
         );
     ),
 
-    // `cfg_attr(true, ...)` attribute; parse it
-    ([$($prev_align_attrs:tt)*] [$($prev_other_attrs:tt)*]; #[cfg_attr(true, $($cfg_rhs:tt)*)] $($rest:tt)*) => (
-        $crate::thread::local_impl::thread_local_process_attrs!(
-            [] [];
-            @processing_cfg_attr { pred: (true), rhs: [$($cfg_rhs)*] };
-            [$($prev_align_attrs)*] [$($prev_other_attrs)*];
-            $($rest)*
-        );
-    ),
-
-    // `cfg_attr(false, ...)` attribute; parse it
-    ([$($prev_align_attrs:tt)*] [$($prev_other_attrs:tt)*]; #[cfg_attr(false, $($cfg_rhs:tt)*)] $($rest:tt)*) => (
-        $crate::thread::local_impl::thread_local_process_attrs!(
-            [] [];
-            @processing_cfg_attr { pred: (false), rhs: [$($cfg_rhs)*] };
-            [$($prev_align_attrs)*] [$($prev_other_attrs)*];
-            $($rest)*
-        );
-    ),
-
     // `cfg_attr(..., ...)` attribute; parse it
-    ([$($prev_align_attrs:tt)*] [$($prev_other_attrs:tt)*]; #[cfg_attr($cfg_pred:meta, $($cfg_rhs:tt)*)] $($rest:tt)*) => (
+    ([$($prev_align_attrs:tt)*] [$($prev_other_attrs:tt)*]; #[cfg_attr($cfg_pred:expr, $($cfg_rhs:tt)*)] $($rest:tt)*) => (
         $crate::thread::local_impl::thread_local_process_attrs!(
             [] [];
             @processing_cfg_attr { pred: ($cfg_pred), rhs: [$($cfg_rhs)*] };

--- a/tests/ui/macros/attr-expr.rs
+++ b/tests/ui/macros/attr-expr.rs
@@ -3,7 +3,17 @@ macro_rules! foo {
         #[$e]
         //~^ ERROR expected identifier, found metavariable
         fn foo() {}
-    }
+    };
 }
 foo!(inline);
+
+macro_rules! bar {
+    ($e:expr) => {
+        #[inline($e)]
+        //~^ ERROR expected a literal (`1u8`, `1.0f32`, `"string"`, etc.) here, found `expr` metavariable
+        fn bar() {}
+    };
+}
+bar!(always);
+
 fn main() {}

--- a/tests/ui/macros/attr-expr.rs
+++ b/tests/ui/macros/attr-expr.rs
@@ -1,0 +1,9 @@
+macro_rules! foo {
+    ($e:expr) => {
+        #[$e]
+        //~^ ERROR expected identifier, found metavariable
+        fn foo() {}
+    }
+}
+foo!(inline);
+fn main() {}

--- a/tests/ui/macros/attr-expr.stderr
+++ b/tests/ui/macros/attr-expr.stderr
@@ -1,0 +1,13 @@
+error: expected identifier, found metavariable
+  --> $DIR/attr-expr.rs:3:11
+   |
+LL |         #[$e]
+   |           ^^ expected identifier, found metavariable
+...
+LL | foo!(inline);
+   | ------------ in this macro invocation
+   |
+   = note: this error originates in the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/macros/attr-expr.stderr
+++ b/tests/ui/macros/attr-expr.stderr
@@ -9,5 +9,16 @@ LL | foo!(inline);
    |
    = note: this error originates in the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 1 previous error
+error: expected a literal (`1u8`, `1.0f32`, `"string"`, etc.) here, found `expr` metavariable
+  --> $DIR/attr-expr.rs:12:18
+   |
+LL |         #[inline($e)]
+   |                  ^^
+...
+LL | bar!(always);
+   | ------------ in this macro invocation
+   |
+   = note: this error originates in the macro `bar` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 2 previous errors
 

--- a/tests/ui/macros/cfg-expr.rs
+++ b/tests/ui/macros/cfg-expr.rs
@@ -1,0 +1,44 @@
+//@ run-pass
+macro_rules! foo {
+    ($e:expr, $n:ident) => {
+        #[cfg($e)]
+        macro_rules! $n {
+            () => {}
+        }
+
+        #[cfg_attr($e, allow(non_snake_case))]
+        #[cfg($e)]
+        fn $n() {
+            #[cfg($e)]
+            $n!();
+        }
+
+        #[cfg_attr(not($e), allow(unused))]
+        #[cfg(not($e))]
+        fn $n() {
+            panic!()
+        }
+    }
+}
+foo!(true, BAR);
+foo!(any(true, unix, target_pointer_width = "64"), baz);
+foo!(target_pointer_width = "64", quux);
+foo!(false, haha);
+
+fn main() {
+    BAR();
+    BAR!();
+    baz();
+    baz!();
+    #[cfg(target_pointer_width = "64")]
+    quux();
+    #[cfg(target_pointer_width = "64")]
+    quux!();
+    #[cfg(panic = "unwind")]
+    {
+        let result = std::panic::catch_unwind(|| {
+            haha();
+        });
+        assert!(result.is_err());
+    }
+}

--- a/tests/ui/macros/cfg_attr-expr.rs
+++ b/tests/ui/macros/cfg_attr-expr.rs
@@ -1,0 +1,9 @@
+macro_rules! foo {
+    ($e:expr) => {
+        #[cfg_attr(true, $e)]
+        //~^ ERROR expected identifier, found metavariable
+        fn foo() {}
+    }
+}
+foo!(inline);
+fn main() {}

--- a/tests/ui/macros/cfg_attr-expr.stderr
+++ b/tests/ui/macros/cfg_attr-expr.stderr
@@ -1,0 +1,17 @@
+error: expected identifier, found metavariable
+  --> $DIR/cfg_attr-expr.rs:3:26
+   |
+LL |         #[cfg_attr(true, $e)]
+   |         -----------------^^--
+   |         |                |
+   |         |                expected identifier, found metavariable
+   |         help: must be of the form: `#[cfg_attr(predicate, attr1, attr2, ...)]`
+...
+LL | foo!(inline);
+   | ------------ in this macro invocation
+   |
+   = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute>
+   = note: this error originates in the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/macros/cfg_select-expr.rs
+++ b/tests/ui/macros/cfg_select-expr.rs
@@ -1,0 +1,57 @@
+//@ run-pass
+#![allow(unreachable_cfg_select_predicates)]
+
+macro_rules! foo {
+    ($e:expr, $n:ident) => {
+        cfg_select! {
+            $e => {
+                macro_rules! $n {
+                    () => {}
+                }
+            }
+            _ => {}
+        }
+
+        cfg_select! {
+            $e => {
+                #[cfg_attr($e, allow(non_snake_case))]
+                fn $n() {
+                    cfg_select! {
+                        $e => {
+                            $n!();
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            not($e) => {
+                #[cfg_attr(not($e), allow(unused))]
+                fn $n() {
+                    panic!()
+                }
+            }
+        }
+    }
+}
+foo!(true, BAR);
+foo!(any(true, unix, target_pointer_width = "64"), baz);
+foo!(target_pointer_width = "64", quux);
+foo!(false, haha);
+
+fn main() {
+    BAR();
+    BAR!();
+    baz();
+    baz!();
+    #[cfg(target_pointer_width = "64")]
+    quux();
+    #[cfg(target_pointer_width = "64")]
+    quux!();
+    #[cfg(panic = "unwind")]
+    {
+        let result = std::panic::catch_unwind(|| {
+            haha();
+        });
+        assert!(result.is_err());
+    }
+}


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/146961)*
<!-- homu-ignore:end -->

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

This PR allows expanding `expr` metavariables inside the configuration predicates of `cfg` and `cfg_attr` invocations.
For example, the following code will now compile:

```rust
macro_rules! mac {
    ($e:expr) => {
        #[cfg_attr($e, inline)]
        #[cfg($e)]
        fn func() {}

        #[cfg(not($e))]
        fn func() {
            panic!()
        }
    }
}


mac!(any(unix, feature = "foo"));
```

There is currently no `macro_rules` fragment specifier that can represent all valid `cfg` predicates. `meta` comes closest, but excludes `true` and `false`. By fixing that, this change makes it easier to write declarative macros that parse `cfg` or `cfg_attr` invocations, for example https://github.com/rust-lang/rust/pull/146281/.

@rustbot label T-lang needs-fcp A-attributes A-cfg A-macros