### PR TITLE
Remove erroneous normalization step in `tests/run-make/linker-warning`

### DIFF
--- a/tests/run-make/linker-warning/rmake.rs
+++ b/tests/run-make/linker-warning/rmake.rs
@@ -61,7 +61,6 @@ fn main() {
         diff()
             .expected_file("short-error.txt")
             .actual_text("(linker error)", out.stderr())
-            .normalize(r#"/rustc[^/_-]*/"#, "/rustc/")
             .normalize("libpanic_abort", "libpanic_unwind")
             .normalize(
                 regex::escape(


### PR DESCRIPTION
Fixes rust-lang/rust#146977.

r? bjorn3 or reassign