### PR TITLE
Inhibit all-absent-variant optimization for all enum reprs that inhibit layout optimization, not just repr(C).

### DIFF
--- a/compiler/rustc_abi/src/layout.rs
+++ b/compiler/rustc_abi/src/layout.rs
@@ -317,9 +317,9 @@ impl<Cx: HasDataLayout> LayoutCalculator<Cx> {
         always_sized: bool,
     ) -> LayoutCalculatorResult<FieldIdx, VariantIdx, F> {
         let (present_first, present_second) = {
-            let mut present_variants = variants
-                .iter_enumerated()
-                .filter_map(|(i, v)| if !repr.c() && absent(v) { None } else { Some(i) });
+            let mut present_variants = variants.iter_enumerated().filter_map(|(i, v)| {
+                if !repr.inhibit_enum_layout_opt() && absent(v) { None } else { Some(i) }
+            });
             (present_variants.next(), present_variants.next())
         };
         let present_first = match present_first {

--- a/tests/ui/layout/enum.rs
+++ b/tests/ui/layout/enum.rs
@@ -22,3 +22,13 @@ enum ScalarPairDifferingSign { //~ERROR: abi: ScalarPair
     A(u8),
     B(i8),
 }
+
+enum Never {}
+
+// See https://github.com/rust-lang/rust/issues/146984
+#[rustc_layout(size)]
+#[repr(u32)]
+enum DefinedLayoutAllUninhabited { //~ERROR: size: Size(4 bytes)
+    A(Never),
+    B(Never),
+}

--- a/tests/ui/layout/enum.stderr
+++ b/tests/ui/layout/enum.stderr
@@ -16,5 +16,11 @@ error: abi: ScalarPair(Initialized { value: Int(I8, false), valid_range: 0..=1 }
 LL | enum ScalarPairDifferingSign {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 3 previous errors
+error: size: Size(4 bytes)
+  --> $DIR/enum.rs:31:1
+   |
+LL | enum DefinedLayoutAllUninhabited {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 4 previous errors
 


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/146989)*

Fixes https://github.com/rust-lang/rust/issues/146984

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
