### PR TITLE
Add `clippy::unconditional_recursion` to `./x clippy ci`

### DIFF
--- a/src/bootstrap/src/core/build_steps/clippy.rs
+++ b/src/bootstrap/src/core/build_steps/clippy.rs
@@ -564,6 +564,7 @@ impl Step for CI {
                 "clippy::same_item_push".into(),
                 "clippy::single_char_add_str".into(),
                 "clippy::to_string_in_format_args".into(),
+                "clippy::unconditional_recursion".into(),
             ],
             forbid: vec![],
         };
@@ -591,6 +592,7 @@ impl Step for CI {
                 "clippy::same_item_push".into(),
                 "clippy::single_char_add_str".into(),
                 "clippy::to_string_in_format_args".into(),
+                "clippy::unconditional_recursion".into(),
             ],
             forbid: vec![],
         };


### PR DESCRIPTION
The clippy lint catches some things that rustc's equivalent builtin lint
does not, for example rust-lang/rust#146940:

    error: function cannot return without recursing
        --> library/std/src/path.rs:3428:5
         |
    3428 | /     fn eq(&self, other: &String) -> bool {
    3429 | |         self == &*other
    3430 | |     }
         | |_____^
         |
    note: recursive call site
        --> library/std/src/path.rs:3429:9
         |
    3429 |         self == &*other
         |         ^^^^^^^^^^^^^^^
         = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unconditional_recursion
         = note: requested on the command line with `-D clippy::unconditional-recursion`