### PR TITLE
Add new `tyalias` intra-doc link disambiguator

### DIFF
--- a/src/doc/rustdoc/src/write-documentation/linking-to-items-by-name.md
+++ b/src/doc/rustdoc/src/write-documentation/linking-to-items-by-name.md
@@ -90,7 +90,7 @@ fn Foo() {}
 These prefixes will be stripped when displayed in the documentation, so `[struct@Foo]` will be
 rendered as `Foo`. The following prefixes are available: `struct`, `enum`, `trait`, `union`,
 `mod`, `module`, `const`, `constant`, `fn`, `function`, `field`, `variant`, `method`, `derive`,
-`type`, `value`, `macro`, `prim` or `primitive`.
+`type`, `value`, `macro`, `tyalias`, `typealias`, `prim` or `primitive`.
 
 You can also disambiguate for functions by adding `()` after the function name,
 or for macros by adding `!` after the macro name. The macro `!` can be followed by `()`, `{}`,

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -130,6 +130,7 @@ impl Res {
             DefKind::Static { .. } => "static",
             DefKind::Field => "field",
             DefKind::Variant | DefKind::Ctor(..) => "variant",
+            DefKind::TyAlias => "tyalias",
             // Now handle things that don't have a specific disambiguator
             _ => match kind
                 .ns()
@@ -1708,6 +1709,7 @@ impl Disambiguator {
                 "value" => NS(Namespace::ValueNS),
                 "macro" => NS(Namespace::MacroNS),
                 "prim" | "primitive" => Primitive,
+                "tyalias" | "typealias" => Kind(DefKind::TyAlias),
                 _ => return Err((format!("unknown disambiguator `{prefix}`"), 0..idx)),
             };
 

--- a/tests/rustdoc-ui/intra-doc/type-alias-primitive-suggestion.rs
+++ b/tests/rustdoc-ui/intra-doc/type-alias-primitive-suggestion.rs
@@ -1,0 +1,21 @@
+// Ensure that no warning is emitted if the disambiguator is used for type alias.
+// Regression test for <https://github.com/rust-lang/rust/issues/146855>.
+
+#![deny(rustdoc::broken_intra_doc_links)]
+
+pub struct Foo;
+
+#[allow(non_camel_case_types)]
+pub type f32 = Foo;
+
+/// This function returns [`f32`].
+//~^ ERROR: `f32` is both a type alias and a primitive type
+//~| HELP: to link to the type alias, prefix with `tyalias@`
+//~| HELP: to link to the primitive type, prefix with `prim@`
+pub fn my_fn() -> f32 {}
+
+/// This function returns [type@f32].
+//~^ ERROR: `f32` is both a type alias and a primitive type
+//~| HELP: to link to the type alias, prefix with `tyalias@`
+//~| HELP: to link to the primitive type, prefix with `prim@`
+pub fn my_fn2() -> f32 {}

--- a/tests/rustdoc-ui/intra-doc/type-alias-primitive-suggestion.stderr
+++ b/tests/rustdoc-ui/intra-doc/type-alias-primitive-suggestion.stderr
@@ -1,0 +1,39 @@
+error: `f32` is both a type alias and a primitive type
+  --> $DIR/type-alias-primitive-suggestion.rs:11:29
+   |
+LL | /// This function returns [`f32`].
+   |                             ^^^ ambiguous link
+   |
+note: the lint level is defined here
+  --> $DIR/type-alias-primitive-suggestion.rs:4:9
+   |
+LL | #![deny(rustdoc::broken_intra_doc_links)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: to link to the type alias, prefix with `tyalias@`
+   |
+LL | /// This function returns [`tyalias@f32`].
+   |                             ++++++++
+help: to link to the primitive type, prefix with `prim@`
+   |
+LL | /// This function returns [`prim@f32`].
+   |                             +++++
+
+error: `f32` is both a type alias and a primitive type
+  --> $DIR/type-alias-primitive-suggestion.rs:17:28
+   |
+LL | /// This function returns [type@f32].
+   |                            ^^^^^^^^ ambiguous link
+   |
+help: to link to the type alias, prefix with `tyalias@`
+   |
+LL - /// This function returns [type@f32].
+LL + /// This function returns [tyalias@f32].
+   |
+help: to link to the primitive type, prefix with `prim@`
+   |
+LL - /// This function returns [type@f32].
+LL + /// This function returns [prim@f32].
+   |
+
+error: aborting due to 2 previous errors
+

--- a/tests/rustdoc-ui/intra-doc/type-alias-primitive.rs
+++ b/tests/rustdoc-ui/intra-doc/type-alias-primitive.rs
@@ -1,0 +1,14 @@
+// Ensure that no warning is emitted if the disambiguator is used for type alias.
+// Regression test for <https://github.com/rust-lang/rust/issues/146855>.
+
+//@ check-pass
+
+#![deny(rustdoc::broken_intra_doc_links)]
+
+pub struct Foo;
+
+#[allow(non_camel_case_types)]
+pub type f32 = Foo;
+
+/// This function returns [`tyalias@f32`] and not [`prim@f32`].
+pub fn my_fn() -> f32 {}

--- a/tests/rustdoc/intra-doc/type-alias-primitive.rs
+++ b/tests/rustdoc/intra-doc/type-alias-primitive.rs
@@ -1,0 +1,21 @@
+// Ensure that no warning is emitted if the disambiguator is used for type alias.
+// Regression test for <https://github.com/rust-lang/rust/issues/146855>.
+
+#![crate_name = "foo"]
+#![deny(rustdoc::broken_intra_doc_links)]
+
+pub struct Foo;
+
+#[allow(non_camel_case_types)]
+pub type f32 = Foo;
+
+/// This function returns [`tyalias@f32`] and not [bla][`prim@f32`].
+//@ has 'foo/fn.my_fn.html'
+//@ has - '//a[@href="type.f32.html"]' "f32"
+//@ has - '//a[@href="{{channel}}/std/primitive.f32.html"]' "bla"
+pub fn my_fn() -> f32 { 0. }
+
+/// This function returns [`typealias@f32`].
+//@ has 'foo/fn.my_other_fn.html'
+//@ has - '//a[@href="type.f32.html"]' "f32"
+pub fn my_other_fn() -> f32 { 0. }


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/146855.

Alternative to rust-lang/rust#146866.

This adds support for a new disambiguator: `tyalias`. I think it's common enough to have type aliases nowaday, so no reason to not be able to have a disambiguator for them.

cc @fmease
r? lolbinarycat