### PR TITLE
Revert "Auto merge of #144086 - clubby789:alloc-zeroed, r=nikic"

### DIFF
--- a/compiler/rustc_codegen_llvm/src/attributes.rs
+++ b/compiler/rustc_codegen_llvm/src/attributes.rs
@@ -435,16 +435,6 @@ pub(crate) fn llfn_attrs_from_instance<'ll, 'tcx>(
         || codegen_fn_attrs.flags.contains(CodegenFnAttrFlags::ALLOCATOR_ZEROED)
     {
         to_add.push(create_alloc_family_attr(cx.llcx));
-        if let Some(zv) =
-            cx.tcx.get_attr(instance.def_id(), rustc_span::sym::rustc_allocator_zeroed_variant)
-            && let Some(name) = zv.value_str()
-        {
-            to_add.push(llvm::CreateAttrStringValue(
-                cx.llcx,
-                "alloc-variant-zeroed",
-                &mangle_internal_symbol(cx.tcx, name.as_str()),
-            ));
-        }
         // apply to argument place instead of function
         let alloc_align = AttributeKind::AllocAlign.create_attr(cx.llcx);
         attributes::apply_to_llfn(llfn, AttributePlace::Argument(1), &[alloc_align]);

--- a/compiler/rustc_feature/src/builtin_attrs.rs
+++ b/compiler/rustc_feature/src/builtin_attrs.rs
@@ -1001,10 +1001,6 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
         rustc_allocator_zeroed, Normal, template!(Word), WarnFollowing,
         EncodeCrossCrate::No,
     ),
-    rustc_attr!(
-        rustc_allocator_zeroed_variant, Normal, template!(NameValueStr: "function"), ErrorPreceding,
-        EncodeCrossCrate::Yes,
-    ),
     gated!(
         default_lib_allocator, Normal, template!(Word), WarnFollowing,
         EncodeCrossCrate::No, allocator_internals, experimental!(default_lib_allocator),

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1850,7 +1850,6 @@ symbols! {
         rustc_align_static,
         rustc_allocator,
         rustc_allocator_zeroed,
-        rustc_allocator_zeroed_variant,
         rustc_allow_const_fn_unstable,
         rustc_allow_incoherent_impl,
         rustc_allowed_through_unstable_modules,

--- a/library/alloc/src/alloc.rs
+++ b/library/alloc/src/alloc.rs
@@ -17,7 +17,6 @@ unsafe extern "Rust" {
     #[rustc_allocator]
     #[rustc_nounwind]
     #[rustc_std_internal_symbol]
-    #[rustc_allocator_zeroed_variant = "__rust_alloc_zeroed"]
     fn __rust_alloc(size: usize, align: usize) -> *mut u8;
     #[rustc_deallocator]
     #[rustc_nounwind]

--- a/tests/codegen-llvm/vec-calloc.rs
+++ b/tests/codegen-llvm/vec-calloc.rs
@@ -1,6 +1,4 @@
-//@ revisions: normal llvm21
 //@ compile-flags: -Copt-level=3 -Z merge-functions=disabled
-//@ [llvm21] min-llvm-version: 21
 //@ only-x86_64
 
 #![crate_type = "lib"]
@@ -176,24 +174,6 @@ pub fn vec_option_i32(n: usize) -> Vec<Option<i32>> {
 
     // CHECK: ret void
     vec![None; n]
-}
-
-// LLVM21-LABEL: @vec_array
-#[cfg(llvm21)]
-#[no_mangle]
-pub fn vec_array(n: usize) -> Vec<[u32; 1_000_000]> {
-    // LLVM21-NOT: call {{.*}}alloc::vec::from_elem
-    // LLVM21-NOT: call {{.*}}reserve
-    // LLVM21-NOT: call {{.*}}__rust_alloc(
-
-    // LLVM21: call {{.*}}__rust_alloc_zeroed(
-
-    // LLVM21-NOT: call {{.*}}alloc::vec::from_elem
-    // LLVM21-NOT: call {{.*}}reserve
-    // LLVM21-NOT: call {{.*}}__rust_alloc(
-
-    // LLVM21: ret void
-    vec![[0; 1_000_000]; 3]
 }
 
 // Ensure that __rust_alloc_zeroed gets the right attributes for LLVM to optimize it away.


### PR DESCRIPTION
This reverts commit 040a98af70f0a7da03f3d5356531b28a2a7a77e4, reversing changes made to e8a792daf500b5ff8097896ddb6cc037abe92487.

This reverts https://github.com/rust-lang/rust/pull/144086 on beta due to https://github.com/rust-lang/rust/issues/145995. On master the issue will be fixed by https://github.com/rust-lang/rust/pull/146766.