### PR TITLE
Fix doctest compilation time display

### DIFF
--- a/src/librustdoc/doctest.rs
+++ b/src/librustdoc/doctest.rs
@@ -404,11 +404,15 @@ pub(crate) fn run_tests(
             std::mem::drop(temp_dir.take());
             times.display_times();
         });
-    }
-    if nb_errors != 0 {
-        // We ensure temp dir destructor is called.
-        std::mem::drop(temp_dir);
+    } else {
+        // If the first condition branch exited successfully, `test_main_with_exit_callback` will
+        // not exit the process. So to prevent displaying the times twice, we put it behind an
+        // `else` condition.
         times.display_times();
+    }
+    // We ensure temp dir destructor is called.
+    std::mem::drop(temp_dir);
+    if nb_errors != 0 {
         std::process::exit(test::ERROR_EXIT_CODE);
     }
 }

--- a/tests/run-make/doctests-compilation-time-info/rmake.rs
+++ b/tests/run-make/doctests-compilation-time-info/rmake.rs
@@ -1,0 +1,119 @@
+//@ ignore-cross-compile (needs to run doctests)
+
+use run_make_support::rfs::write;
+use run_make_support::{cwd, rustdoc};
+
+fn assert_presence_of_compilation_time_report(
+    content: &str,
+    success: bool,
+    should_contain_compile_time: bool,
+) {
+    let mut cmd = rustdoc();
+    let file = cwd().join("foo.rs");
+
+    write(&file, content);
+    cmd.input(&file).arg("--test").edition("2024").env("RUST_BACKTRACE", "0");
+    let output = if success { cmd.run() } else { cmd.run_fail() };
+
+    assert_eq!(
+        output
+            .stdout_utf8()
+            .split("all doctests ran in ")
+            .last()
+            .is_some_and(|s| s.contains("; merged doctests compilation took")),
+        should_contain_compile_time,
+    );
+}
+
+fn main() {
+    // Checking with only successful merged doctests.
+    assert_presence_of_compilation_time_report(
+        "\
+//! ```
+//! let x = 12;
+//! ```",
+        true,
+        true,
+    );
+    // Checking with only failing merged doctests.
+    assert_presence_of_compilation_time_report(
+        "\
+//! ```
+//! panic!();
+//! ```",
+        false,
+        true,
+    );
+    // Checking with mix of successful doctests.
+    assert_presence_of_compilation_time_report(
+        "\
+//! ```
+//! let x = 12;
+//! ```
+//!
+//! ```compile_fail
+//! let x
+//! ```",
+        true,
+        true,
+    );
+    // Checking with mix of failing doctests.
+    assert_presence_of_compilation_time_report(
+        "\
+//! ```
+//! panic!();
+//! ```
+//!
+//! ```compile_fail
+//! let x
+//! ```",
+        false,
+        true,
+    );
+    // Checking with mix of failing doctests (v2).
+    assert_presence_of_compilation_time_report(
+        "\
+//! ```
+//! let x = 12;
+//! ```
+//!
+//! ```compile_fail
+//! let x = 12;
+//! ```",
+        false,
+        true,
+    );
+    // Checking with mix of failing doctests (v3).
+    assert_presence_of_compilation_time_report(
+        "\
+//! ```
+//! panic!();
+//! ```
+//!
+//! ```compile_fail
+//! let x = 12;
+//! ```",
+        false,
+        true,
+    );
+    // Checking with successful non-merged doctests.
+    assert_presence_of_compilation_time_report(
+        "\
+//! ```compile_fail
+//! let x
+//! ```",
+        true,
+        // If there is no merged doctests, then we should not display compilation time.
+        false,
+    );
+    // Checking with failing non-merged doctests.
+    assert_presence_of_compilation_time_report(
+        "\
+//! ```compile_fail
+//! let x = 12;
+//! ```",
+        false,
+        // If there is no merged doctests, then we should not display compilation time.
+        false,
+    );
+}

--- a/tests/run-make/doctests-merge/doctest-2024.stdout
+++ b/tests/run-make/doctests-merge/doctest-2024.stdout
@@ -5,3 +5,4 @@ test doctest.rs - init (line 8) ... ok
 
 test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
 
+all doctests ran in $TIME; merged doctests compilation took $TIME

--- a/tests/run-make/doctests-merge/rmake.rs
+++ b/tests/run-make/doctests-merge/rmake.rs
@@ -20,6 +20,8 @@ fn test_and_compare(input_file: &str, stdout_file: &str, edition: &str, dep: &Pa
         .expected_file(stdout_file)
         .actual_text("output", output.stdout_utf8())
         .normalize(r#"finished in \d+\.\d+s"#, "finished in $$TIME")
+        .normalize(r#"ran in \d+\.\d+s"#, "ran in $$TIME")
+        .normalize(r#"compilation took \d+\.\d+s"#, "compilation took $$TIME")
         .run();
 }
 

--- a/tests/rustdoc-ui/doctest/doctest-output.edition2015.stdout
+++ b/tests/rustdoc-ui/doctest/doctest-output.edition2015.stdout
@@ -1,8 +1,8 @@
 
 running 3 tests
-test $DIR/doctest-output.rs - (line 12) ... ok
-test $DIR/doctest-output.rs - ExpandedStruct (line 28) ... ok
-test $DIR/doctest-output.rs - foo::bar (line 22) ... ok
+test $DIR/doctest-output.rs - (line 14) ... ok
+test $DIR/doctest-output.rs - ExpandedStruct (line 30) ... ok
+test $DIR/doctest-output.rs - foo::bar (line 24) ... ok
 
 test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
 

--- a/tests/rustdoc-ui/doctest/doctest-output.edition2024.stdout
+++ b/tests/rustdoc-ui/doctest/doctest-output.edition2024.stdout
@@ -1,8 +1,9 @@
 
 running 3 tests
-test $DIR/doctest-output.rs - (line 12) ... ok
-test $DIR/doctest-output.rs - ExpandedStruct (line 28) ... ok
-test $DIR/doctest-output.rs - foo::bar (line 22) ... ok
+test $DIR/doctest-output.rs - (line 14) ... ok
+test $DIR/doctest-output.rs - ExpandedStruct (line 30) ... ok
+test $DIR/doctest-output.rs - foo::bar (line 24) ... ok
 
 test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
 
+all doctests ran in $TIME; merged doctests compilation took $TIME

--- a/tests/rustdoc-ui/doctest/doctest-output.rs
+++ b/tests/rustdoc-ui/doctest/doctest-output.rs
@@ -7,6 +7,8 @@
 //@[edition2024]compile-flags:--test --test-args=--test-threads=1
 //@ normalize-stdout: "tests/rustdoc-ui/doctest" -> "$$DIR"
 //@ normalize-stdout: "finished in \d+\.\d+s" -> "finished in $$TIME"
+//@ normalize-stdout: "ran in \d+\.\d+s" -> "ran in $$TIME"
+//@ normalize-stdout: "compilation took \d+\.\d+s" -> "compilation took $$TIME"
 //@ check-pass
 
 //! ```

--- a/tests/rustdoc-ui/doctest/merged-ignore-no_run.rs
+++ b/tests/rustdoc-ui/doctest/merged-ignore-no_run.rs
@@ -2,6 +2,8 @@
 //@ compile-flags:--test --test-args=--test-threads=1
 //@ normalize-stdout: "tests/rustdoc-ui/doctest" -> "$$DIR"
 //@ normalize-stdout: "finished in \d+\.\d+s" -> "finished in $$TIME"
+//@ normalize-stdout: "ran in \d+\.\d+s" -> "ran in $$TIME"
+//@ normalize-stdout: "compilation took \d+\.\d+s" -> "compilation took $$TIME"
 //@ check-pass
 
 /// ```ignore (test)

--- a/tests/rustdoc-ui/doctest/merged-ignore-no_run.stdout
+++ b/tests/rustdoc-ui/doctest/merged-ignore-no_run.stdout
@@ -1,7 +1,8 @@
 
 running 2 tests
-test $DIR/merged-ignore-no_run.rs - ignored (line 7) ... ignored
-test $DIR/merged-ignore-no_run.rs - no_run (line 12) - compile ... ok
+test $DIR/merged-ignore-no_run.rs - ignored (line 9) ... ignored
+test $DIR/merged-ignore-no_run.rs - no_run (line 14) - compile ... ok
 
 test result: ok. 1 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in $TIME
 
+all doctests ran in $TIME; merged doctests compilation took $TIME


### PR DESCRIPTION
Fixes rust-lang/rust#146960.

Small corner case that happened in case everything went fine and there was only merged doctests.

r? lolbinarycat