### PR TITLE
chore: fix incorrect comment

### DIFF
--- a/library/core/src/str/iter.rs
+++ b/library/core/src/str/iter.rs
@@ -1523,7 +1523,7 @@ impl<'a> Iterator for EncodeUtf16<'a> {
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         let len = self.chars.iter.len();
-        // The highest bytes:code units ratio occurs for 3-byte sequences,
+        // The lowest bytes:code units ratio occurs for 3-byte sequences,
         // since a 4-byte sequence results in 2 code units. The lower bound
         // is therefore determined by assuming the remaining bytes contain as
         // many 3-byte sequences as possible. The highest bytes:code units


### PR DESCRIPTION
The comment describing the functionality of `EncodeUtf16::size_hint` has a double claim for highest bytes-to-code-units-ratio. This commit replaces one of the repeated occurrences to be about the _lowest_ ratio.