### PR TITLE
std: fix warning in VEXos stdio module

### DIFF
--- a/library/std/src/sys/stdio/vexos.rs
+++ b/library/std/src/sys/stdio/vexos.rs
@@ -13,7 +13,7 @@ impl Stdin {
 }
 
 impl io::Read for Stdin {
-    fn read(&mut self, mut buf: &mut [u8]) -> io::Result<usize> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         let mut count = 0;
 
         for out_byte in buf.iter_mut() {


### PR DESCRIPTION
Fixes building `std` on the `armv7a-vex-v5` target due to an unnecessarily mutable argument in `Stdin`.

This was a stupid oversight on my part towards the end of rust-lang/rust#145973's review process. Missed a warning and had a bad bootstrap config that didn't tell me about it when testing changes.