### PR TITLE
[beta-1.91] Warn on future errors from temporary lifetimes shortening in Rust 1.92

### DIFF
--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -441,8 +441,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             // Check scope of binding.
             fn is_sub_scope(&self, sub_id: hir::ItemLocalId, super_id: hir::ItemLocalId) -> bool {
                 let scope_tree = self.fcx.tcx.region_scope_tree(self.fcx.body_id);
-                if let Some(sub_var_scope) = scope_tree.var_scope(sub_id)
-                    && let Some(super_var_scope) = scope_tree.var_scope(super_id)
+                if let (Some(sub_var_scope), _) = scope_tree.var_scope(sub_id)
+                    && let (Some(super_var_scope), _) = scope_tree.var_scope(super_id)
                     && scope_tree.is_subscope_of(sub_var_scope, super_var_scope)
                 {
                     return true;

--- a/compiler/rustc_middle/src/mir/syntax.rs
+++ b/compiler/rustc_middle/src/mir/syntax.rs
@@ -989,17 +989,21 @@ pub enum TerminatorKind<'tcx> {
 
 #[derive(
     Clone,
+    Copy,
     Debug,
     TyEncodable,
     TyDecodable,
     Hash,
     HashStable,
     PartialEq,
+    Eq,
     TypeFoldable,
     TypeVisitable
 )]
 pub enum BackwardIncompatibleDropReason {
     Edition2024,
+    /// Used by the `macro_extended_temporary_scopes` lint.
+    MacroExtendedScope,
 }
 
 #[derive(Debug, Clone, TyEncodable, TyDecodable, Hash, HashStable, PartialEq)]

--- a/compiler/rustc_middle/src/thir.rs
+++ b/compiler/rustc_middle/src/thir.rs
@@ -27,7 +27,9 @@ use tracing::instrument;
 
 use crate::middle::region;
 use crate::mir::interpret::AllocId;
-use crate::mir::{self, AssignOp, BinOp, BorrowKind, FakeReadCause, UnOp};
+use crate::mir::{
+    self, AssignOp, BackwardIncompatibleDropReason, BinOp, BorrowKind, FakeReadCause, UnOp,
+};
 use crate::thir::visit::for_each_immediate_subpat;
 use crate::ty::adjustment::PointerCoercion;
 use crate::ty::layout::IntegerExt;
@@ -272,7 +274,7 @@ pub struct TempLifetime {
     pub temp_lifetime: Option<region::Scope>,
     /// If `Some(lt)`, indicates that the lifetime of this temporary will change to `lt` in a future edition.
     /// If `None`, then no changes are expected, or lints are disabled.
-    pub backwards_incompatible: Option<region::Scope>,
+    pub backwards_incompatible: Option<(region::Scope, BackwardIncompatibleDropReason)>,
 }
 
 #[derive(Clone, Debug, HashStable)]
@@ -1125,7 +1127,7 @@ mod size_asserts {
     use super::*;
     // tidy-alphabetical-start
     static_assert_size!(Block, 48);
-    static_assert_size!(Expr<'_>, 72);
+    static_assert_size!(Expr<'_>, 80);
     static_assert_size!(ExprKind<'_>, 40);
     static_assert_size!(Pat<'_>, 64);
     static_assert_size!(PatKind<'_>, 48);

--- a/compiler/rustc_middle/src/ty/rvalue_scopes.rs
+++ b/compiler/rustc_middle/src/ty/rvalue_scopes.rs
@@ -3,13 +3,14 @@ use rustc_hir::ItemLocalMap;
 use rustc_macros::{HashStable, TyDecodable, TyEncodable};
 use tracing::debug;
 
-use crate::middle::region::{Scope, ScopeData, ScopeTree};
+use crate::middle::region::{ScopeCompatibility, Scope, ScopeData, ScopeTree};
+use crate::mir::BackwardIncompatibleDropReason;
 
 /// `RvalueScopes` is a mapping from sub-expressions to _extended_ lifetime as determined by
 /// rules laid out in `rustc_hir_analysis::check::rvalue_scopes`.
 #[derive(TyEncodable, TyDecodable, Clone, Debug, Default, Eq, PartialEq, HashStable)]
 pub struct RvalueScopes {
-    map: ItemLocalMap<Option<Scope>>,
+    map: ItemLocalMap<(Option<Scope>, Option<(Scope, BackwardIncompatibleDropReason)>)>,
 }
 
 impl RvalueScopes {
@@ -24,11 +25,11 @@ impl RvalueScopes {
         &self,
         region_scope_tree: &ScopeTree,
         expr_id: hir::ItemLocalId,
-    ) -> (Option<Scope>, Option<Scope>) {
+    ) -> (Option<Scope>, Option<(Scope, BackwardIncompatibleDropReason)>) {
         // Check for a designated rvalue scope.
-        if let Some(&s) = self.map.get(&expr_id) {
+        if let Some(&(s, future_scope)) = self.map.get(&expr_id) {
             debug!("temporary_scope({expr_id:?}) = {s:?} [custom]");
-            return (s, None);
+            return (s, future_scope);
         }
 
         // Otherwise, locate the innermost terminating scope
@@ -40,11 +41,23 @@ impl RvalueScopes {
     }
 
     /// Make an association between a sub-expression and an extended lifetime
-    pub fn record_rvalue_scope(&mut self, var: hir::ItemLocalId, lifetime: Option<Scope>) {
+    pub fn record_rvalue_scope(
+        &mut self,
+        var: hir::ItemLocalId,
+        lifetime: Option<Scope>,
+        compat: ScopeCompatibility,
+    ) {
         debug!("record_rvalue_scope(var={var:?}, lifetime={lifetime:?})");
         if let Some(lifetime) = lifetime {
             assert!(var != lifetime.local_id);
         }
-        self.map.insert(var, lifetime);
+        let future_scope =
+            if let ScopeCompatibility::FutureIncompatible { shortens_to } = compat
+            {
+                Some((shortens_to, BackwardIncompatibleDropReason::MacroExtendedScope))
+            } else {
+                None
+            };
+        self.map.insert(var, (lifetime, future_scope));
     }
 }

--- a/compiler/rustc_mir_build/src/builder/expr/as_temp.rs
+++ b/compiler/rustc_mir_build/src/builder/expr/as_temp.rs
@@ -129,8 +129,13 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             this.schedule_drop(expr_span, temp_lifetime, temp, DropKind::Value);
         }
 
-        if let Some(backwards_incompatible) = temp_lifetime.backwards_incompatible {
-            this.schedule_backwards_incompatible_drop(expr_span, backwards_incompatible, temp);
+        if let Some((backwards_incompatible, reason)) = temp_lifetime.backwards_incompatible {
+            this.schedule_backwards_incompatible_drop(
+                expr_span,
+                backwards_incompatible,
+                temp,
+                reason,
+            );
         }
 
         block.and(temp)

--- a/src/tools/clippy/clippy_lints/src/loops/needless_range_loop.rs
+++ b/src/tools/clippy/clippy_lints/src/loops/needless_range_loop.rs
@@ -64,7 +64,7 @@ pub(super) fn check<'tcx>(
             if let Some(indexed_extent) = indexed_extent {
                 let parent_def_id = cx.tcx.hir_get_parent_item(expr.hir_id);
                 let region_scope_tree = cx.tcx.region_scope_tree(parent_def_id);
-                let pat_extent = region_scope_tree.var_scope(pat.hir_id.local_id).unwrap();
+                let pat_extent = region_scope_tree.var_scope(pat.hir_id.local_id).0.unwrap();
                 if region_scope_tree.is_subscope_of(indexed_extent, pat_extent) {
                     return;
                 }
@@ -298,6 +298,7 @@ impl<'tcx> VarVisitor<'_, 'tcx> {
                         .tcx
                         .region_scope_tree(parent_def_id)
                         .var_scope(hir_id.local_id)
+                        .0
                         .unwrap();
                     if index_used_directly {
                         self.indexed_directly.insert(

--- a/src/tools/clippy/clippy_lints/src/shadow.rs
+++ b/src/tools/clippy/clippy_lints/src/shadow.rs
@@ -180,8 +180,8 @@ impl<'tcx> LateLintPass<'tcx> for Shadow {
 
 fn is_shadow(cx: &LateContext<'_>, owner: LocalDefId, first: ItemLocalId, second: ItemLocalId) -> bool {
     let scope_tree = cx.tcx.region_scope_tree(owner.to_def_id());
-    if let Some(first_scope) = scope_tree.var_scope(first)
-        && let Some(second_scope) = scope_tree.var_scope(second)
+    if let Some(first_scope) = scope_tree.var_scope(first).0
+        && let Some(second_scope) = scope_tree.var_scope(second).0
     {
         return scope_tree.is_subscope_of(second_scope, first_scope);
     }

--- a/tests/ui/lifetimes/lint-macro-extended-temporary-scopes/auxiliary/external-macros.rs
+++ b/tests/ui/lifetimes/lint-macro-extended-temporary-scopes/auxiliary/external-macros.rs
@@ -1,0 +1,12 @@
+//! The macros that are in `../user-defined-macros.rs`, but external to test diagnostics.
+//@ edition: 2024
+
+#[macro_export]
+macro_rules! wrap {
+    ($arg:expr) => { { &$arg } }
+}
+
+#[macro_export]
+macro_rules! print_with_internal_wrap {
+    () => { println!("{:?}{}", (), $crate::wrap!(String::new())) }
+}

--- a/tests/ui/lifetimes/lint-macro-extended-temporary-scopes/extended-super-let-bindings.rs
+++ b/tests/ui/lifetimes/lint-macro-extended-temporary-scopes/extended-super-let-bindings.rs
@@ -7,5 +7,6 @@ fn main() {
     // The `()` argument to the inner `format_args!` is promoted, but the lifetimes of the internal
     // `super let` temporaries in its expansion shorten, making this an error in Rust 1.92.
     println!("{:?}{}", (), { format_args!("{:?}", ()) });
-    // TODO: warn
+    //~^ WARN temporary lifetime will be shortened in Rust 1.92
+    //~| WARN this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 }

--- a/tests/ui/lifetimes/lint-macro-extended-temporary-scopes/extended-super-let-bindings.rs
+++ b/tests/ui/lifetimes/lint-macro-extended-temporary-scopes/extended-super-let-bindings.rs
@@ -1,0 +1,11 @@
+//! Some temporaries are implemented as local variables bound with `super let`. These can be
+//! lifetime-extended, and as such are subject to shortening after #145838.
+//@ edition: 2024
+//@ check-pass
+
+fn main() {
+    // The `()` argument to the inner `format_args!` is promoted, but the lifetimes of the internal
+    // `super let` temporaries in its expansion shorten, making this an error in Rust 1.92.
+    println!("{:?}{}", (), { format_args!("{:?}", ()) });
+    // TODO: warn
+}

--- a/tests/ui/lifetimes/lint-macro-extended-temporary-scopes/extended-super-let-bindings.stderr
+++ b/tests/ui/lifetimes/lint-macro-extended-temporary-scopes/extended-super-let-bindings.stderr
@@ -1,0 +1,15 @@
+warning: temporary lifetime will be shortened in Rust 1.92
+  --> $DIR/extended-super-let-bindings.rs:9:30
+   |
+LL |     println!("{:?}{}", (), { format_args!("{:?}", ()) });
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^ - ...which will be dropped at the end of this block in Rust 1.92
+   |                              |
+   |                              this expression creates a temporary value...
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see <https://doc.rust-lang.org/rustc/lints/listing/warn-by-default.html#macro-extended-temporary-scopes>
+   = note: consider using a `let` binding to create a longer lived value
+   = note: `#[warn(macro_extended_temporary_scopes)]` (part of `#[warn(future_incompatible)]`) on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/lifetimes/lint-macro-extended-temporary-scopes/macro-extended-temporary-scopes.e2021.stderr
+++ b/tests/ui/lifetimes/lint-macro-extended-temporary-scopes/macro-extended-temporary-scopes.e2021.stderr
@@ -1,0 +1,92 @@
+warning: temporary lifetime will be shortened in Rust 1.92
+  --> $DIR/macro-extended-temporary-scopes.rs:33:43
+   |
+LL |     println!("{:?}{:?}", (), if cond() { &format!("") } else { "" });
+   |                                           ^^^^^^^^^^^ - ...which will be dropped at the end of this block in Rust 1.92
+   |                                           |
+   |                                           this expression creates a temporary value...
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see <https://doc.rust-lang.org/rustc/lints/listing/warn-by-default.html#macro-extended-temporary-scopes>
+   = note: consider using a `let` binding to create a longer lived value
+   = note: `#[warn(macro_extended_temporary_scopes)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: this warning originates in the macro `format` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+warning: temporary lifetime will be shortened in Rust 1.92
+  --> $DIR/macro-extended-temporary-scopes.rs:36:43
+   |
+LL |     println!("{:?}{:?}", (), if cond() { &"".to_string() } else { "" });
+   |                                           ^^^^^^^^^^^^^^ - ...which will be dropped at the end of this block in Rust 1.92
+   |                                           |
+   |                                           this expression creates a temporary value...
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see <https://doc.rust-lang.org/rustc/lints/listing/warn-by-default.html#macro-extended-temporary-scopes>
+   = note: consider using a `let` binding to create a longer lived value
+
+warning: temporary lifetime will be shortened in Rust 1.92
+  --> $DIR/macro-extended-temporary-scopes.rs:39:43
+   |
+LL |     println!("{:?}{:?}", (), if cond() { &("string".to_owned() + "string") } else { "" });
+   |                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - ...which will be dropped at the end of this block in Rust 1.92
+   |                                           |
+   |                                           this expression creates a temporary value...
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see <https://doc.rust-lang.org/rustc/lints/listing/warn-by-default.html#macro-extended-temporary-scopes>
+   = note: consider using a `let` binding to create a longer lived value
+
+warning: temporary lifetime will be shortened in Rust 1.92
+  --> $DIR/macro-extended-temporary-scopes.rs:58:17
+   |
+LL |             &*&*smart_ptr_temp()
+   |                 ^^^^^^^^^^^^^^^^ this expression creates a temporary value...
+...
+LL |         }
+   |         - ...which will be dropped at the end of this block in Rust 1.92
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see <https://doc.rust-lang.org/rustc/lints/listing/warn-by-default.html#macro-extended-temporary-scopes>
+   = note: consider using a `let` binding to create a longer lived value
+
+warning: temporary lifetime will be shortened in Rust 1.92
+  --> $DIR/macro-extended-temporary-scopes.rs:54:14
+   |
+LL |             &struct_temp().field
+   |              ^^^^^^^^^^^^^ this expression creates a temporary value...
+...
+LL |         } else {
+   |         - ...which will be dropped at the end of this block in Rust 1.92
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see <https://doc.rust-lang.org/rustc/lints/listing/warn-by-default.html#macro-extended-temporary-scopes>
+   = note: consider using a `let` binding to create a longer lived value
+
+warning: temporary lifetime will be shortened in Rust 1.92
+  --> $DIR/macro-extended-temporary-scopes.rs:50:14
+   |
+LL |             &tuple_temp().0
+   |              ^^^^^^^^^^^^ this expression creates a temporary value...
+...
+LL |         } else if cond() {
+   |         - ...which will be dropped at the end of this block in Rust 1.92
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see <https://doc.rust-lang.org/rustc/lints/listing/warn-by-default.html#macro-extended-temporary-scopes>
+   = note: consider using a `let` binding to create a longer lived value
+
+warning: temporary lifetime will be shortened in Rust 1.92
+  --> $DIR/macro-extended-temporary-scopes.rs:46:14
+   |
+LL |             &array_temp()[0]
+   |              ^^^^^^^^^^^^ this expression creates a temporary value...
+...
+LL |         } else if cond() {
+   |         - ...which will be dropped at the end of this block in Rust 1.92
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see <https://doc.rust-lang.org/rustc/lints/listing/warn-by-default.html#macro-extended-temporary-scopes>
+   = note: consider using a `let` binding to create a longer lived value
+
+warning: 7 warnings emitted
+

--- a/tests/ui/lifetimes/lint-macro-extended-temporary-scopes/macro-extended-temporary-scopes.e2024.stderr
+++ b/tests/ui/lifetimes/lint-macro-extended-temporary-scopes/macro-extended-temporary-scopes.e2024.stderr
@@ -1,0 +1,188 @@
+warning: temporary lifetime will be shortened in Rust 1.92
+  --> $DIR/macro-extended-temporary-scopes.rs:26:29
+   |
+LL |     println!("{:?}{:?}", { &temp() }, ());
+   |                             ^^^^^^ - ...which will be dropped at the end of this block in Rust 1.92
+   |                             |
+   |                             this expression creates a temporary value...
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see <https://doc.rust-lang.org/rustc/lints/listing/warn-by-default.html#macro-extended-temporary-scopes>
+   = note: consider using a `let` binding to create a longer lived value
+   = note: `#[warn(macro_extended_temporary_scopes)]` (part of `#[warn(future_incompatible)]`) on by default
+
+warning: temporary lifetime will be shortened in Rust 1.92
+  --> $DIR/macro-extended-temporary-scopes.rs:33:43
+   |
+LL |     println!("{:?}{:?}", (), if cond() { &format!("") } else { "" });
+   |                                           ^^^^^^^^^^^ - ...which will be dropped at the end of this block in Rust 1.92
+   |                                           |
+   |                                           this expression creates a temporary value...
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see <https://doc.rust-lang.org/rustc/lints/listing/warn-by-default.html#macro-extended-temporary-scopes>
+   = note: consider using a `let` binding to create a longer lived value
+   = note: this warning originates in the macro `format` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+warning: temporary lifetime will be shortened in Rust 1.92
+  --> $DIR/macro-extended-temporary-scopes.rs:36:43
+   |
+LL |     println!("{:?}{:?}", (), if cond() { &"".to_string() } else { "" });
+   |                                           ^^^^^^^^^^^^^^ - ...which will be dropped at the end of this block in Rust 1.92
+   |                                           |
+   |                                           this expression creates a temporary value...
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see <https://doc.rust-lang.org/rustc/lints/listing/warn-by-default.html#macro-extended-temporary-scopes>
+   = note: consider using a `let` binding to create a longer lived value
+
+warning: temporary lifetime will be shortened in Rust 1.92
+  --> $DIR/macro-extended-temporary-scopes.rs:39:43
+   |
+LL |     println!("{:?}{:?}", (), if cond() { &("string".to_owned() + "string") } else { "" });
+   |                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - ...which will be dropped at the end of this block in Rust 1.92
+   |                                           |
+   |                                           this expression creates a temporary value...
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see <https://doc.rust-lang.org/rustc/lints/listing/warn-by-default.html#macro-extended-temporary-scopes>
+   = note: consider using a `let` binding to create a longer lived value
+
+warning: temporary lifetime will be shortened in Rust 1.92
+  --> $DIR/macro-extended-temporary-scopes.rs:58:17
+   |
+LL |             &*&*smart_ptr_temp()
+   |                 ^^^^^^^^^^^^^^^^ this expression creates a temporary value...
+...
+LL |         }
+   |         - ...which will be dropped at the end of this block in Rust 1.92
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see <https://doc.rust-lang.org/rustc/lints/listing/warn-by-default.html#macro-extended-temporary-scopes>
+   = note: consider using a `let` binding to create a longer lived value
+
+warning: temporary lifetime will be shortened in Rust 1.92
+  --> $DIR/macro-extended-temporary-scopes.rs:54:14
+   |
+LL |             &struct_temp().field
+   |              ^^^^^^^^^^^^^ this expression creates a temporary value...
+...
+LL |         } else {
+   |         - ...which will be dropped at the end of this block in Rust 1.92
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see <https://doc.rust-lang.org/rustc/lints/listing/warn-by-default.html#macro-extended-temporary-scopes>
+   = note: consider using a `let` binding to create a longer lived value
+
+warning: temporary lifetime will be shortened in Rust 1.92
+  --> $DIR/macro-extended-temporary-scopes.rs:50:14
+   |
+LL |             &tuple_temp().0
+   |              ^^^^^^^^^^^^ this expression creates a temporary value...
+...
+LL |         } else if cond() {
+   |         - ...which will be dropped at the end of this block in Rust 1.92
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see <https://doc.rust-lang.org/rustc/lints/listing/warn-by-default.html#macro-extended-temporary-scopes>
+   = note: consider using a `let` binding to create a longer lived value
+
+warning: temporary lifetime will be shortened in Rust 1.92
+  --> $DIR/macro-extended-temporary-scopes.rs:46:14
+   |
+LL |             &array_temp()[0]
+   |              ^^^^^^^^^^^^ this expression creates a temporary value...
+...
+LL |         } else if cond() {
+   |         - ...which will be dropped at the end of this block in Rust 1.92
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see <https://doc.rust-lang.org/rustc/lints/listing/warn-by-default.html#macro-extended-temporary-scopes>
+   = note: consider using a `let` binding to create a longer lived value
+
+warning: temporary lifetime will be shortened in Rust 1.92
+  --> $DIR/macro-extended-temporary-scopes.rs:65:18
+   |
+LL |     pin!(pin!({ &temp() }));
+   |                  ^^^^^^ - ...which will be dropped at the end of this block in Rust 1.92
+   |                  |
+   |                  this expression creates a temporary value...
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see <https://doc.rust-lang.org/rustc/lints/listing/warn-by-default.html#macro-extended-temporary-scopes>
+   = note: consider using a `let` binding to create a longer lived value
+
+warning: temporary lifetime will be shortened in Rust 1.92
+  --> $DIR/macro-extended-temporary-scopes.rs:96:13
+   |
+LL |     pin!({ &(1 / 0) });
+   |             ^^^^^^^ - ...which will be dropped at the end of this block in Rust 1.92
+   |             |
+   |             this expression creates a temporary value...
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see <https://doc.rust-lang.org/rustc/lints/listing/warn-by-default.html#macro-extended-temporary-scopes>
+   = note: consider using a `let` binding to create a longer lived value
+
+warning: temporary lifetime will be shortened in Rust 1.92
+  --> $DIR/macro-extended-temporary-scopes.rs:99:17
+   |
+LL |     pin!({ &mut [()] });
+   |                 ^^^^ - ...which will be dropped at the end of this block in Rust 1.92
+   |                 |
+   |                 this expression creates a temporary value...
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see <https://doc.rust-lang.org/rustc/lints/listing/warn-by-default.html#macro-extended-temporary-scopes>
+   = note: consider using a `let` binding to create a longer lived value
+
+warning: temporary lifetime will be shortened in Rust 1.92
+  --> $DIR/macro-extended-temporary-scopes.rs:102:13
+   |
+LL |     pin!({ &Some(String::new()) });
+   |             ^^^^^^^^^^^^^^^^^^^ - ...which will be dropped at the end of this block in Rust 1.92
+   |             |
+   |             this expression creates a temporary value...
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see <https://doc.rust-lang.org/rustc/lints/listing/warn-by-default.html#macro-extended-temporary-scopes>
+   = note: consider using a `let` binding to create a longer lived value
+
+warning: temporary lifetime will be shortened in Rust 1.92
+  --> $DIR/macro-extended-temporary-scopes.rs:105:13
+   |
+LL |     pin!({ &(|| ())() });
+   |             ^^^^^^^^^ - ...which will be dropped at the end of this block in Rust 1.92
+   |             |
+   |             this expression creates a temporary value...
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see <https://doc.rust-lang.org/rustc/lints/listing/warn-by-default.html#macro-extended-temporary-scopes>
+   = note: consider using a `let` binding to create a longer lived value
+
+warning: temporary lifetime will be shortened in Rust 1.92
+  --> $DIR/macro-extended-temporary-scopes.rs:108:13
+   |
+LL |     pin!({ &|| &local });
+   |             ^^^^^^^^^ - ...which will be dropped at the end of this block in Rust 1.92
+   |             |
+   |             this expression creates a temporary value...
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see <https://doc.rust-lang.org/rustc/lints/listing/warn-by-default.html#macro-extended-temporary-scopes>
+   = note: consider using a `let` binding to create a longer lived value
+
+warning: temporary lifetime will be shortened in Rust 1.92
+  --> $DIR/macro-extended-temporary-scopes.rs:111:13
+   |
+LL |     pin!({ &CONST_STRING });
+   |             ^^^^^^^^^^^^ - ...which will be dropped at the end of this block in Rust 1.92
+   |             |
+   |             this expression creates a temporary value...
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see <https://doc.rust-lang.org/rustc/lints/listing/warn-by-default.html#macro-extended-temporary-scopes>
+   = note: consider using a `let` binding to create a longer lived value
+
+warning: 15 warnings emitted
+

--- a/tests/ui/lifetimes/lint-macro-extended-temporary-scopes/macro-extended-temporary-scopes.rs
+++ b/tests/ui/lifetimes/lint-macro-extended-temporary-scopes/macro-extended-temporary-scopes.rs
@@ -1,0 +1,102 @@
+//! Future-compatibility warning test for #145838: make sure we catch all expected breakage.
+//! Shortening temporaries in the tails of block expressions should warn in Rust 2024, and
+//! shortening temporaries in the tails of `if` expressions' blocks should warn in all editions.
+//@ revisions: e2021 e2024
+//@ [e2021] edition: 2021
+//@ [e2024] edition: 2024
+//@ check-pass
+use std::pin::pin;
+
+struct Struct { field: () }
+
+fn cond() -> bool { true }
+fn temp() {}
+fn array_temp() -> [(); 1] { [()] }
+fn tuple_temp() -> ((),) { ((),) }
+fn struct_temp() -> Struct { Struct { field: () } }
+fn smart_ptr_temp() -> Box<()> { Box::new(()) }
+
+const CONST_STRING: String = String::new();
+static STATIC_UNIT: () = ();
+
+fn main() {
+    let local = String::new();
+
+    // #145880 doesn't apply here, so this `temp()`'s lifetime is reduced by #145838 in Rust 2024.
+    println!("{:?}{:?}", { &temp() }, ());
+    // TODO: warn in Rust 2024
+
+    // In real-world projects, this breakage typically appeared in `if` expressions with a reference
+    // to a `String` temporary in one branch's tail expression. This is edition-independent since
+    // `if` expressions' blocks are temporary scopes in all editions.
+    println!("{:?}{:?}", (), if cond() { &format!("") } else { "" });
+    // TODO: warn in all editions
+    println!("{:?}{:?}", (), if cond() { &"".to_string() } else { "" });
+    // TODO: warn in all editions
+    println!("{:?}{:?}", (), if cond() { &("string".to_owned() + "string") } else { "" });
+    // TODO: warn in all editions
+
+    // Make sure we catch indexed and dereferenced temporaries.
+    pin!(
+        if cond() {
+            &array_temp()[0]
+            // TODO: warn in all editions
+        } else if cond() {
+            &tuple_temp().0
+            // TODO: warn in all editions
+        } else if cond() {
+            &struct_temp().field
+            // TODO: warn in all editions
+        } else {
+            &*&*smart_ptr_temp()
+            // TODO: warn in all editions
+        }
+    );
+
+    // Test that `super let` extended by parent `super let`s in non-extending blocks are caught.
+    pin!(pin!({ &temp() }));
+    // TODO: warn in Rust 2024
+
+    // We shouldn't warn when lifetime extension applies.
+    let _ = format_args!("{:?}{:?}", { &temp() }, if cond() { &temp() } else { &temp() });
+    let _ = pin!(
+        if cond() {
+            &array_temp()[0]
+        } else if cond() {
+            &tuple_temp().0
+        } else if cond() {
+            &struct_temp().field
+        } else {
+            &*&*smart_ptr_temp()
+        }
+    );
+    let _ = pin!(pin!({ &temp() }));
+
+    // We shouldn't warn when borrowing from non-temporary places.
+    pin!({ &local });
+    pin!({ &STATIC_UNIT });
+
+    // We shouldn't warn for promoted constants.
+    pin!({ &size_of::<()>() });
+    pin!({ &(1 / 1) });
+    pin!({ &mut ([] as [(); 0]) });
+    pin!({ &None::<String> });
+    pin!({ &|| String::new() });
+
+    // But we do warn on these temporaries, since they aren't promoted.
+    pin!({ &(1 / 0) });
+    // TODO: warn in Rust 2024
+    pin!({ &mut [()] });
+    // TODO: warn in Rust 2024
+    pin!({ &Some(String::new()) });
+    // TODO: warn in Rust 2024
+    pin!({ &(|| ())() });
+    // TODO: warn in Rust 2024
+    pin!({ &|| &local });
+    // TODO: warn in Rust 2024
+    pin!({ &CONST_STRING });
+    // TODO: warn in Rust 2024
+
+    // This lint only catches future errors. Future dangling pointers do not produce warnings.
+    pin!({ &raw const *&temp() });
+}

--- a/tests/ui/lifetimes/lint-macro-extended-temporary-scopes/macro-extended-temporary-scopes.rs
+++ b/tests/ui/lifetimes/lint-macro-extended-temporary-scopes/macro-extended-temporary-scopes.rs
@@ -24,38 +24,47 @@ fn main() {
 
     // #145880 doesn't apply here, so this `temp()`'s lifetime is reduced by #145838 in Rust 2024.
     println!("{:?}{:?}", { &temp() }, ());
-    // TODO: warn in Rust 2024
+    //[e2024]~^ WARN temporary lifetime will be shortened in Rust 1.92
+    //[e2024]~| WARN this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
     // In real-world projects, this breakage typically appeared in `if` expressions with a reference
     // to a `String` temporary in one branch's tail expression. This is edition-independent since
     // `if` expressions' blocks are temporary scopes in all editions.
     println!("{:?}{:?}", (), if cond() { &format!("") } else { "" });
-    // TODO: warn in all editions
+    //~^ WARN temporary lifetime will be shortened in Rust 1.92
+    //~| WARN this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
     println!("{:?}{:?}", (), if cond() { &"".to_string() } else { "" });
-    // TODO: warn in all editions
+    //~^ WARN temporary lifetime will be shortened in Rust 1.92
+    //~| WARN this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
     println!("{:?}{:?}", (), if cond() { &("string".to_owned() + "string") } else { "" });
-    // TODO: warn in all editions
+    //~^ WARN temporary lifetime will be shortened in Rust 1.92
+    //~| WARN this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
     // Make sure we catch indexed and dereferenced temporaries.
     pin!(
         if cond() {
             &array_temp()[0]
-            // TODO: warn in all editions
+            //~^ WARN temporary lifetime will be shortened in Rust 1.92
+            //~| WARN this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
         } else if cond() {
             &tuple_temp().0
-            // TODO: warn in all editions
+            //~^ WARN temporary lifetime will be shortened in Rust 1.92
+            //~| WARN this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
         } else if cond() {
             &struct_temp().field
-            // TODO: warn in all editions
+            //~^ WARN temporary lifetime will be shortened in Rust 1.92
+            //~| WARN this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
         } else {
             &*&*smart_ptr_temp()
-            // TODO: warn in all editions
+            //~^ WARN temporary lifetime will be shortened in Rust 1.92
+            //~| WARN this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
         }
     );
 
     // Test that `super let` extended by parent `super let`s in non-extending blocks are caught.
     pin!(pin!({ &temp() }));
-    // TODO: warn in Rust 2024
+    //[e2024]~^ WARN temporary lifetime will be shortened in Rust 1.92
+    //[e2024]~| WARN this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
     // We shouldn't warn when lifetime extension applies.
     let _ = format_args!("{:?}{:?}", { &temp() }, if cond() { &temp() } else { &temp() });
@@ -85,17 +94,23 @@ fn main() {
 
     // But we do warn on these temporaries, since they aren't promoted.
     pin!({ &(1 / 0) });
-    // TODO: warn in Rust 2024
+    //[e2024]~^ WARN temporary lifetime will be shortened in Rust 1.92
+    //[e2024]~| WARN this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
     pin!({ &mut [()] });
-    // TODO: warn in Rust 2024
+    //[e2024]~^ WARN temporary lifetime will be shortened in Rust 1.92
+    //[e2024]~| WARN this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
     pin!({ &Some(String::new()) });
-    // TODO: warn in Rust 2024
+    //[e2024]~^ WARN temporary lifetime will be shortened in Rust 1.92
+    //[e2024]~| WARN this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
     pin!({ &(|| ())() });
-    // TODO: warn in Rust 2024
+    //[e2024]~^ WARN temporary lifetime will be shortened in Rust 1.92
+    //[e2024]~| WARN this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
     pin!({ &|| &local });
-    // TODO: warn in Rust 2024
+    //[e2024]~^ WARN temporary lifetime will be shortened in Rust 1.92
+    //[e2024]~| WARN this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
     pin!({ &CONST_STRING });
-    // TODO: warn in Rust 2024
+    //[e2024]~^ WARN temporary lifetime will be shortened in Rust 1.92
+    //[e2024]~| WARN this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
     // This lint only catches future errors. Future dangling pointers do not produce warnings.
     pin!({ &raw const *&temp() });

--- a/tests/ui/lifetimes/lint-macro-extended-temporary-scopes/non-extended.rs
+++ b/tests/ui/lifetimes/lint-macro-extended-temporary-scopes/non-extended.rs
@@ -1,0 +1,15 @@
+//! Test that `macro_extended_temporary_scopes` doesn't warn on non-extended temporaries.
+//@ edition: 2024
+#![deny(macro_extended_temporary_scopes)] //~ WARN unknown lint
+
+fn temp() {}
+
+fn main() {
+    // Due to #145880, this argument isn't an extending context.
+    println!("{:?}", { &temp() });
+    //~^ ERROR temporary value dropped while borrowed
+
+    // Subexpressions of function call expressions are not extending.
+    println!("{:?}{:?}", (), { std::convert::identity(&temp()) });
+    //~^ ERROR temporary value dropped while borrowed
+}

--- a/tests/ui/lifetimes/lint-macro-extended-temporary-scopes/non-extended.rs
+++ b/tests/ui/lifetimes/lint-macro-extended-temporary-scopes/non-extended.rs
@@ -1,6 +1,6 @@
 //! Test that `macro_extended_temporary_scopes` doesn't warn on non-extended temporaries.
 //@ edition: 2024
-#![deny(macro_extended_temporary_scopes)] //~ WARN unknown lint
+#![deny(macro_extended_temporary_scopes)]
 
 fn temp() {}
 

--- a/tests/ui/lifetimes/lint-macro-extended-temporary-scopes/non-extended.stderr
+++ b/tests/ui/lifetimes/lint-macro-extended-temporary-scopes/non-extended.stderr
@@ -1,0 +1,35 @@
+warning: unknown lint: `macro_extended_temporary_scopes`
+  --> $DIR/non-extended.rs:3:9
+   |
+LL | #![deny(macro_extended_temporary_scopes)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(unknown_lints)]` on by default
+
+error[E0716]: temporary value dropped while borrowed
+  --> $DIR/non-extended.rs:9:25
+   |
+LL |     println!("{:?}", { &temp() });
+   |                      ---^^^^^---
+   |                      |  |    |
+   |                      |  |    temporary value is freed at the end of this statement
+   |                      |  creates a temporary value which is freed while still in use
+   |                      borrow later used here
+   |
+   = note: consider using a `let` binding to create a longer lived value
+
+error[E0716]: temporary value dropped while borrowed
+  --> $DIR/non-extended.rs:13:56
+   |
+LL |     println!("{:?}{:?}", (), { std::convert::identity(&temp()) });
+   |                              --------------------------^^^^^^---
+   |                              |                         |     |
+   |                              |                         |     temporary value is freed at the end of this statement
+   |                              |                         creates a temporary value which is freed while still in use
+   |                              borrow later used here
+   |
+   = note: consider using a `let` binding to create a longer lived value
+
+error: aborting due to 2 previous errors; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0716`.

--- a/tests/ui/lifetimes/lint-macro-extended-temporary-scopes/non-extended.stderr
+++ b/tests/ui/lifetimes/lint-macro-extended-temporary-scopes/non-extended.stderr
@@ -1,11 +1,3 @@
-warning: unknown lint: `macro_extended_temporary_scopes`
-  --> $DIR/non-extended.rs:3:9
-   |
-LL | #![deny(macro_extended_temporary_scopes)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: `#[warn(unknown_lints)]` on by default
-
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/non-extended.rs:9:25
    |
@@ -30,6 +22,6 @@ LL |     println!("{:?}{:?}", (), { std::convert::identity(&temp()) });
    |
    = note: consider using a `let` binding to create a longer lived value
 
-error: aborting due to 2 previous errors; 1 warning emitted
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0716`.

--- a/tests/ui/lifetimes/lint-macro-extended-temporary-scopes/user-defined-macros.rs
+++ b/tests/ui/lifetimes/lint-macro-extended-temporary-scopes/user-defined-macros.rs
@@ -1,0 +1,50 @@
+//! Test that the future-compatibility warning for #145838 doesn't break in the presence of
+//! user-defined macros.
+//@ build-pass
+//@ edition: 2024
+//@ aux-build:external-macros.rs
+//@ dont-require-annotations: NOTE
+
+extern crate external_macros;
+
+macro_rules! wrap {
+    ($arg:expr) => { { &$arg } }
+}
+
+macro_rules! print_with_internal_wrap {
+    () => { println!("{:?}{}", (), wrap!(String::new())) }
+}
+
+fn main() {
+    print!(
+        "{:?}{}",
+        (),
+        format_args!(
+            "{:?}{:?}",
+
+            // This is promoted; do not warn.
+            wrap!(None::<String>),
+
+            // This does not promote; warn.
+            wrap!(String::new())
+            // TODO: warn
+        )
+    );
+
+    print_with_internal_wrap!();
+    // TODO: warn
+
+    print!(
+        "{:?}{:?}",
+
+        // This is promoted; do not warn.
+        external_macros::wrap!(None::<String>),
+
+        // This does not promote; warn.
+        external_macros::wrap!(String::new())
+        // TODO: warn
+    );
+
+    external_macros::print_with_internal_wrap!();
+    // TODO: warn
+}

--- a/tests/ui/lifetimes/lint-macro-extended-temporary-scopes/user-defined-macros.rs
+++ b/tests/ui/lifetimes/lint-macro-extended-temporary-scopes/user-defined-macros.rs
@@ -13,6 +13,8 @@ macro_rules! wrap {
 
 macro_rules! print_with_internal_wrap {
     () => { println!("{:?}{}", (), wrap!(String::new())) }
+    //~^ WARN temporary lifetime will be shortened in Rust 1.92
+    //~| WARN this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 }
 
 fn main() {
@@ -27,12 +29,13 @@ fn main() {
 
             // This does not promote; warn.
             wrap!(String::new())
-            // TODO: warn
+            //~^ WARN temporary lifetime will be shortened in Rust 1.92
+            //~| WARN this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
         )
     );
 
     print_with_internal_wrap!();
-    // TODO: warn
+    //~^ NOTE in this expansion of print_with_internal_wrap!
 
     print!(
         "{:?}{:?}",
@@ -42,9 +45,11 @@ fn main() {
 
         // This does not promote; warn.
         external_macros::wrap!(String::new())
-        // TODO: warn
+        //~^ WARN temporary lifetime will be shortened in Rust 1.92
+        //~| WARN this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
     );
 
     external_macros::print_with_internal_wrap!();
-    // TODO: warn
+    //~^ WARN temporary lifetime will be shortened in Rust 1.92
+    //~| WARN this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 }

--- a/tests/ui/lifetimes/lint-macro-extended-temporary-scopes/user-defined-macros.stderr
+++ b/tests/ui/lifetimes/lint-macro-extended-temporary-scopes/user-defined-macros.stderr
@@ -1,0 +1,60 @@
+warning: temporary lifetime will be shortened in Rust 1.92
+  --> $DIR/user-defined-macros.rs:31:19
+   |
+LL |     ($arg:expr) => { { &$arg } }
+   |                              - ...which will be dropped at the end of this block in Rust 1.92
+...
+LL |             wrap!(String::new())
+   |                   ^^^^^^^^^^^^^ this expression creates a temporary value...
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see <https://doc.rust-lang.org/rustc/lints/listing/warn-by-default.html#macro-extended-temporary-scopes>
+   = note: consider using a `let` binding to create a longer lived value
+   = note: `#[warn(macro_extended_temporary_scopes)]` (part of `#[warn(future_incompatible)]`) on by default
+
+warning: temporary lifetime will be shortened in Rust 1.92
+  --> $DIR/user-defined-macros.rs:15:42
+   |
+LL |     ($arg:expr) => { { &$arg } }
+   |                              - ...which will be dropped at the end of this block in Rust 1.92
+...
+LL |     () => { println!("{:?}{}", (), wrap!(String::new())) }
+   |                                          ^^^^^^^^^^^^^ this expression creates a temporary value...
+...
+LL |     print_with_internal_wrap!();
+   |     --------------------------- in this macro invocation
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see <https://doc.rust-lang.org/rustc/lints/listing/warn-by-default.html#macro-extended-temporary-scopes>
+   = note: consider using a `let` binding to create a longer lived value
+   = note: this warning originates in the macro `print_with_internal_wrap` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+warning: temporary lifetime will be shortened in Rust 1.92
+  --> $DIR/user-defined-macros.rs:47:32
+   |
+LL |         external_macros::wrap!(String::new())
+   |         -----------------------^^^^^^^^^^^^^-
+   |         |                      |
+   |         |                      this expression creates a temporary value...
+   |         ...which will be dropped at the end of this block in Rust 1.92
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see <https://doc.rust-lang.org/rustc/lints/listing/warn-by-default.html#macro-extended-temporary-scopes>
+   = note: consider using a `let` binding to create a longer lived value
+
+warning: temporary lifetime will be shortened in Rust 1.92
+  --> $DIR/user-defined-macros.rs:52:5
+   |
+LL |     external_macros::print_with_internal_wrap!();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     |
+   |     this expression creates a temporary value...
+   |     ...which will be dropped at the end of this block in Rust 1.92
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see <https://doc.rust-lang.org/rustc/lints/listing/warn-by-default.html#macro-extended-temporary-scopes>
+   = note: consider using a `let` binding to create a longer lived value
+   = note: this warning originates in the macro `external_macros::print_with_internal_wrap` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+warning: 4 warnings emitted
+


### PR DESCRIPTION
Pursuant to [discussion on Zulip](https://rust-lang.zulipchat.com/#narrow/channel/474880-t-compiler.2Fbackports/topic/.23145838.3A.20beta-nominated/near/540530631), this implements a future-compatibility warning lint `macro_extended_temporary_scopes` for errors in Rust 1.92 caused by rust-lang/rust#145838:

```
warning: temporary lifetime shortening in Rust 1.92
  --> $DIR/macro-extended-temporary-scopes.rs:54:14
   |
LL |             &struct_temp().field
   |              ^^^^^^^^^^^^^ this expression creates a temporary value...
...
LL |         } else {
   |         - ...which will be dropped at the end of this block in Rust 1.92
   |
   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
   = note: for more information, see <https://doc.rust-lang.org/rustc/lints/listing/warn-by-default.html#macro-extended-temporary-scopes>
   = note: consider using a `let` binding to create a longer lived value
```

Implementation-wise, this reuses the existing temporary scoping FCW machinery introduced for the `tail_expr_drop_order` edition lint: this adds `BackwardIncompatibleDropHint` statements to the MIR at the end of the shortened scopes for affected temporaries; these are then checked in borrowck to warn if the temporary is used after the future drop hint. There are trade-offs here: on one hand, I believe this gives some assurance over ad-hoc pattern-recognition that there are no false positives[^1]. On the other hand, this fails to lint on future dangling raw pointers and it complicates the potential addition of explanatory diagnostics or suggestions[^2]. I'm hopeful that the limitation around dangling pointers won't be relevant in real code, though; the only real instance we've seen of breakage so far is future errors in formatting macro invocations, which this should be able to catch.

Release logistics notes:
- This PR targets the beta branch directly, since the breakage it's a FCW for is landing in the next Rust version.
- rust-lang/rust#146098 undoes the breakage this is a FCW for. If that behavior is merged and stabilizes in Rust 1.92, this PR should be reverted (or shouldn't be merged) in order to avoid spurious warnings.

cc @traviscross

@rustbot label +T-lang

[^1]: In particular, more syntactic approaches are complicated by having to avoid warning on promoted constants; they'd either be full of holes, they'd need a lot of extra logic, or they'd need to hack more MIR-to-HIR mapping into `PromoteTemps`.
[^2]: It's definitely possible to add more context and a suggestion, but the ways I've thought of to do so are either too hacky or too complex to feel appropriate for a last-minute direct-to-beta lint.