### PR TITLE
Fix tracking issue number for feature(macro_attr)

### DIFF
--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -554,7 +554,7 @@ declare_features! (
     /// Allows fused `loop`/`match` for direct intraprocedural jumps.
     (incomplete, loop_match, "1.90.0", Some(132306)),
     /// Allow `macro_rules!` attribute rules
-    (unstable, macro_attr, "1.91.0", Some(83527)),
+    (unstable, macro_attr, "1.91.0", Some(143547)),
     /// Allow `macro_rules!` derive rules
     (unstable, macro_derive, "1.91.0", Some(143549)),
     /// Give access to additional metadata about declarative macro meta-variables.

--- a/tests/ui/feature-gates/feature-gate-macro-attr.stderr
+++ b/tests/ui/feature-gates/feature-gate-macro-attr.stderr
@@ -4,7 +4,7 @@ error[E0658]: `macro_rules!` attributes are unstable
 LL | macro_rules! myattr { attr() {} => {} }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: see issue #83527 <https://github.com/rust-lang/rust/issues/83527> for more information
+   = note: see issue #143547 <https://github.com/rust-lang/rust/issues/143547> for more information
    = help: add `#![feature(macro_attr)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 


### PR DESCRIPTION
The ability to define an attribute macro with `macro_rules!` is tracked at https://github.com/rust-lang/rust/issues/143547, not https://github.com/rust-lang/rust/issues/83527