### PR TITLE
Do not lifetime-extend array/slice indices

### DIFF
--- a/compiler/rustc_mir_build/src/builder/expr/as_place.rs
+++ b/compiler/rustc_mir_build/src/builder/expr/as_place.rs
@@ -454,7 +454,6 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 index,
                 mutability,
                 fake_borrow_temps,
-                expr.temp_lifetime,
                 expr_span,
                 source_info,
             ),
@@ -625,7 +624,6 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         index: ExprId,
         mutability: Mutability,
         fake_borrow_temps: Option<&mut Vec<Local>>,
-        temp_lifetime: TempLifetime,
         expr_span: Span,
         source_info: SourceInfo,
     ) -> BlockAnd<PlaceBuilder<'tcx>> {
@@ -639,7 +637,8 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         // Making this a *fresh* temporary means we do not have to worry about
         // the index changing later: Nothing will ever change this temporary.
         // The "retagging" transformation (for Stacked Borrows) relies on this.
-        let idx = unpack!(block = self.as_temp(block, temp_lifetime, index, Mutability::Not));
+        let index_lifetime = self.thir[index].temp_lifetime;
+        let idx = unpack!(block = self.as_temp(block, index_lifetime, index, Mutability::Not));
 
         block = self.bounds_check(block, &base_place, idx, expr_span, source_info);
 

--- a/tests/mir-opt/gvn.dereference_indexing.GVN.panic-abort.diff
+++ b/tests/mir-opt/gvn.dereference_indexing.GVN.panic-abort.diff
@@ -41,6 +41,7 @@
 -         StorageDead(_4);
 +         _3 = &_1[_4];
 +         nop;
+          StorageDead(_6);
           StorageLive(_8);
           StorageLive(_9);
           _9 = copy (*_3);
@@ -51,7 +52,6 @@
           StorageDead(_9);
           StorageDead(_8);
           _0 = const ();
-          StorageDead(_6);
           StorageDead(_3);
           return;
       }

--- a/tests/mir-opt/gvn.dereference_indexing.GVN.panic-unwind.diff
+++ b/tests/mir-opt/gvn.dereference_indexing.GVN.panic-unwind.diff
@@ -41,6 +41,7 @@
 -         StorageDead(_4);
 +         _3 = &_1[_4];
 +         nop;
+          StorageDead(_6);
           StorageLive(_8);
           StorageLive(_9);
           _9 = copy (*_3);
@@ -51,7 +52,6 @@
           StorageDead(_9);
           StorageDead(_8);
           _0 = const ();
-          StorageDead(_6);
           StorageDead(_3);
           return;
       }

--- a/tests/mir-opt/gvn.wide_ptr_same_provenance.GVN.panic-abort.diff
+++ b/tests/mir-opt/gvn.wide_ptr_same_provenance.GVN.panic-abort.diff
@@ -89,6 +89,7 @@
 -         StorageDead(_4);
 +         _3 = copy _4;
 +         nop;
+          StorageDead(_8);
           StorageDead(_7);
           StorageDead(_5);
           StorageLive(_10);
@@ -116,6 +117,7 @@
 -         StorageDead(_11);
 +         _10 = copy _11;
 +         nop;
+          StorageDead(_15);
           StorageDead(_14);
           StorageDead(_12);
           StorageLive(_17);
@@ -251,9 +253,7 @@
           StorageDead(_43);
           StorageDead(_42);
           _0 = const ();
-          StorageDead(_15);
           StorageDead(_10);
-          StorageDead(_8);
           StorageDead(_3);
           StorageDead(_1);
           return;

--- a/tests/mir-opt/gvn.wide_ptr_same_provenance.GVN.panic-unwind.diff
+++ b/tests/mir-opt/gvn.wide_ptr_same_provenance.GVN.panic-unwind.diff
@@ -89,6 +89,7 @@
 -         StorageDead(_4);
 +         _3 = copy _4;
 +         nop;
+          StorageDead(_8);
           StorageDead(_7);
           StorageDead(_5);
           StorageLive(_10);
@@ -116,6 +117,7 @@
 -         StorageDead(_11);
 +         _10 = copy _11;
 +         nop;
+          StorageDead(_15);
           StorageDead(_14);
           StorageDead(_12);
           StorageLive(_17);
@@ -251,9 +253,7 @@
           StorageDead(_43);
           StorageDead(_42);
           _0 = const ();
-          StorageDead(_15);
           StorageDead(_10);
-          StorageDead(_8);
           StorageDead(_3);
           StorageDead(_1);
           return;

--- a/tests/mir-opt/issue_91633.fun.built.after.mir
+++ b/tests/mir-opt/issue_91633.fun.built.after.mir
@@ -23,8 +23,8 @@ fn fun(_1: &[T]) -> &T {
     bb1: {
         _2 = &(*_1)[_3];
         FakeRead(ForLet(None), _2);
-        _0 = &(*_2);
         StorageDead(_3);
+        _0 = &(*_2);
         StorageDead(_2);
         return;
     }

--- a/tests/mir-opt/nll/region_subtyping_basic.main.nll.0.32bit.mir
+++ b/tests/mir-opt/nll/region_subtyping_basic.main.nll.0.32bit.mir
@@ -5,20 +5,20 @@
 | '?1 | Local | ['?1]
 |
 | Inferred Region Values
-| '?0 | U0 | {bb0[0..=8], bb1[0..=7], bb2[0..=3], bb3[0..=3], bb4[0..=1], bb5[0..=2], bb6[0..=5], bb7[0], '?0, '?1}
-| '?1 | U0 | {bb0[0..=8], bb1[0..=7], bb2[0..=3], bb3[0..=3], bb4[0..=1], bb5[0..=2], bb6[0..=5], bb7[0], '?1}
-| '?2 | U0 | {bb1[0..=7], bb2[0..=2]}
-| '?3 | U0 | {bb1[1..=7], bb2[0..=2]}
-| '?4 | U0 | {bb1[4..=7], bb2[0..=2]}
+| '?0 | U0 | {bb0[0..=8], bb1[0..=8], bb2[0..=3], bb3[0..=3], bb4[0..=1], bb5[0..=2], bb6[0..=4], bb7[0], '?0, '?1}
+| '?1 | U0 | {bb0[0..=8], bb1[0..=8], bb2[0..=3], bb3[0..=3], bb4[0..=1], bb5[0..=2], bb6[0..=4], bb7[0], '?1}
+| '?2 | U0 | {bb1[0..=8], bb2[0..=2]}
+| '?3 | U0 | {bb1[1..=8], bb2[0..=2]}
+| '?4 | U0 | {bb1[5..=8], bb2[0..=2]}
 |
 | Inference Constraints
-| '?0 live at {bb0[0..=8], bb1[0..=7], bb2[0..=3], bb3[0..=3], bb4[0..=1], bb5[0..=2], bb6[0..=5], bb7[0]}
-| '?1 live at {bb0[0..=8], bb1[0..=7], bb2[0..=3], bb3[0..=3], bb4[0..=1], bb5[0..=2], bb6[0..=5], bb7[0]}
+| '?0 live at {bb0[0..=8], bb1[0..=8], bb2[0..=3], bb3[0..=3], bb4[0..=1], bb5[0..=2], bb6[0..=4], bb7[0]}
+| '?1 live at {bb0[0..=8], bb1[0..=8], bb2[0..=3], bb3[0..=3], bb4[0..=1], bb5[0..=2], bb6[0..=4], bb7[0]}
 | '?2 live at {bb1[0]}
-| '?3 live at {bb1[1..=3]}
-| '?4 live at {bb1[4..=7], bb2[0..=2]}
+| '?3 live at {bb1[1..=4]}
+| '?4 live at {bb1[5..=8], bb2[0..=2]}
 | '?2: '?3 due to Assignment at Single(bb1[0]) ($DIR/region_subtyping_basic.rs:19:13: 19:18 (#0)
-| '?3: '?4 due to Assignment at Single(bb1[3]) ($DIR/region_subtyping_basic.rs:20:13: 20:14 (#0)
+| '?3: '?4 due to Assignment at Single(bb1[4]) ($DIR/region_subtyping_basic.rs:20:13: 20:14 (#0)
 |
 | Borrows
 | bw0: issued at bb1[0] in '?2
@@ -59,6 +59,7 @@ fn main() -> () {
     bb1: {
         _2 = &'?2 _1[_3];
         FakeRead(ForLet(None), _2);
+        StorageDead(_3);
         StorageLive(_5);
         _5 = copy _2;
         FakeRead(ForLet(None), _5);
@@ -95,7 +96,6 @@ fn main() -> () {
     bb6: {
         StorageDead(_6);
         StorageDead(_5);
-        StorageDead(_3);
         StorageDead(_2);
         StorageDead(_1);
         return;

--- a/tests/mir-opt/nll/region_subtyping_basic.main.nll.0.64bit.mir
+++ b/tests/mir-opt/nll/region_subtyping_basic.main.nll.0.64bit.mir
@@ -5,20 +5,20 @@
 | '?1 | Local | ['?1]
 |
 | Inferred Region Values
-| '?0 | U0 | {bb0[0..=8], bb1[0..=7], bb2[0..=3], bb3[0..=3], bb4[0..=1], bb5[0..=2], bb6[0..=5], bb7[0], '?0, '?1}
-| '?1 | U0 | {bb0[0..=8], bb1[0..=7], bb2[0..=3], bb3[0..=3], bb4[0..=1], bb5[0..=2], bb6[0..=5], bb7[0], '?1}
-| '?2 | U0 | {bb1[0..=7], bb2[0..=2]}
-| '?3 | U0 | {bb1[1..=7], bb2[0..=2]}
-| '?4 | U0 | {bb1[4..=7], bb2[0..=2]}
+| '?0 | U0 | {bb0[0..=8], bb1[0..=8], bb2[0..=3], bb3[0..=3], bb4[0..=1], bb5[0..=2], bb6[0..=4], bb7[0], '?0, '?1}
+| '?1 | U0 | {bb0[0..=8], bb1[0..=8], bb2[0..=3], bb3[0..=3], bb4[0..=1], bb5[0..=2], bb6[0..=4], bb7[0], '?1}
+| '?2 | U0 | {bb1[0..=8], bb2[0..=2]}
+| '?3 | U0 | {bb1[1..=8], bb2[0..=2]}
+| '?4 | U0 | {bb1[5..=8], bb2[0..=2]}
 |
 | Inference Constraints
-| '?0 live at {bb0[0..=8], bb1[0..=7], bb2[0..=3], bb3[0..=3], bb4[0..=1], bb5[0..=2], bb6[0..=5], bb7[0]}
-| '?1 live at {bb0[0..=8], bb1[0..=7], bb2[0..=3], bb3[0..=3], bb4[0..=1], bb5[0..=2], bb6[0..=5], bb7[0]}
+| '?0 live at {bb0[0..=8], bb1[0..=8], bb2[0..=3], bb3[0..=3], bb4[0..=1], bb5[0..=2], bb6[0..=4], bb7[0]}
+| '?1 live at {bb0[0..=8], bb1[0..=8], bb2[0..=3], bb3[0..=3], bb4[0..=1], bb5[0..=2], bb6[0..=4], bb7[0]}
 | '?2 live at {bb1[0]}
-| '?3 live at {bb1[1..=3]}
-| '?4 live at {bb1[4..=7], bb2[0..=2]}
+| '?3 live at {bb1[1..=4]}
+| '?4 live at {bb1[5..=8], bb2[0..=2]}
 | '?2: '?3 due to Assignment at Single(bb1[0]) ($DIR/region_subtyping_basic.rs:19:13: 19:18 (#0)
-| '?3: '?4 due to Assignment at Single(bb1[3]) ($DIR/region_subtyping_basic.rs:20:13: 20:14 (#0)
+| '?3: '?4 due to Assignment at Single(bb1[4]) ($DIR/region_subtyping_basic.rs:20:13: 20:14 (#0)
 |
 | Borrows
 | bw0: issued at bb1[0] in '?2
@@ -59,6 +59,7 @@ fn main() -> () {
     bb1: {
         _2 = &'?2 _1[_3];
         FakeRead(ForLet(None), _2);
+        StorageDead(_3);
         StorageLive(_5);
         _5 = copy _2;
         FakeRead(ForLet(None), _5);
@@ -95,7 +96,6 @@ fn main() -> () {
     bb6: {
         StorageDead(_6);
         StorageDead(_5);
-        StorageDead(_3);
         StorageDead(_2);
         StorageDead(_1);
         return;


### PR DESCRIPTION
When lowering non-overloaded indexing operations to MIR, this uses the temporary lifetime of the index expression for the index temporary, rather than applying the temporary lifetime of the indexing operation as a whole to the index.

For example, in
```rust
let x = &xs[i];
```
previously, the temporary containing the result of evaluating `i` would live until the end of the block due to the indexing operation being [lifetime-extended](https://doc.rust-lang.org/nightly/reference/destructors.html#temporary-lifetime-extension). Under this PR, the index temporary only lives to the end of the `let` statement because it uses the more precise temporary lifetime of the index expression.

I don't think this will affect semantics in an observable way, but the more precise `StorageDead` placement may slightly improve analysis/codegen performance.

r? mir
