### PR TITLE
Rollup of 9 pull requests

### DIFF
--- a/bootstrap.example.toml
+++ b/bootstrap.example.toml
@@ -768,8 +768,7 @@
 # make this default to false.
 #rust.lld = false in all cases, except on `x86_64-unknown-linux-gnu` as described above, where it is true
 
-# Indicates whether LLD will be used to link Rust crates during bootstrap on
-# supported platforms.
+# Indicates if we should override the linker used to link Rust crates during bootstrap to be LLD.
 # If set to `true` or `"external"`, a global `lld` binary that has to be in $PATH
 # will be used.
 # If set to `"self-contained"`, rust-lld from the snapshot compiler will be used.
@@ -777,7 +776,7 @@
 # On MSVC, LLD will not be used if we're cross linking.
 #
 # Explicitly setting the linker for a target will override this option when targeting MSVC.
-#rust.use-lld = false
+#rust.bootstrap-override-lld = false
 
 # Indicates whether some LLVM tools, like llvm-objdump, will be made available in the
 # sysroot.
@@ -950,7 +949,7 @@
 # Linker to be used to bootstrap Rust code. Note that the
 # default value is platform specific, and if not specified it may also depend on
 # what platform is crossing to what platform.
-# Setting this will override the `use-lld` option for Rust code when targeting MSVC.
+# Setting this will override the `bootstrap-override-lld` option for Rust code when targeting MSVC.
 #linker = "cc" (path)
 
 # Should rustc and the standard library be built with split debuginfo? Default

--- a/compiler/rustc_hir/src/lang_items.rs
+++ b/compiler/rustc_hir/src/lang_items.rs
@@ -441,6 +441,7 @@ language_item_table! {
 
     // Reborrowing related lang-items
     Reborrow,                sym::reborrow,            reborrow,                   Target::Trait,          GenericRequirement::Exact(0);
+    CoerceShared,            sym::coerce_shared,       coerce_shared,              Target::Trait,          GenericRequirement::Exact(0);
 }
 
 /// The requirement imposed on the generics of a lang item

--- a/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
@@ -569,7 +569,7 @@ extern "C" LLVMRustResult LLVMRustOptimize(
   }
 
   std::optional<PGOOptions> PGOOpt;
-#if LLVM_VERSION_LE(22, 0)
+#if LLVM_VERSION_LT(22, 0)
   auto FS = vfs::getRealFileSystem();
 #endif
   if (PGOGenPath) {

--- a/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
@@ -569,7 +569,9 @@ extern "C" LLVMRustResult LLVMRustOptimize(
   }
 
   std::optional<PGOOptions> PGOOpt;
+#if LLVM_VERSION_LE(22, 0)
   auto FS = vfs::getRealFileSystem();
+#endif
   if (PGOGenPath) {
     assert(!PGOUsePath && !PGOSampleUsePath);
     PGOOpt = PGOOptions(

--- a/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
@@ -573,21 +573,37 @@ extern "C" LLVMRustResult LLVMRustOptimize(
   if (PGOGenPath) {
     assert(!PGOUsePath && !PGOSampleUsePath);
     PGOOpt = PGOOptions(
+#if LLVM_VERSION_GE(22, 0)
+        PGOGenPath, "", "", "", PGOOptions::IRInstr, PGOOptions::NoCSAction,
+#else
         PGOGenPath, "", "", "", FS, PGOOptions::IRInstr, PGOOptions::NoCSAction,
+#endif
         PGOOptions::ColdFuncOpt::Default, DebugInfoForProfiling);
   } else if (PGOUsePath) {
     assert(!PGOSampleUsePath);
     PGOOpt = PGOOptions(
+#if LLVM_VERSION_GE(22, 0)
+        PGOUsePath, "", "", "", PGOOptions::IRUse, PGOOptions::NoCSAction,
+#else
         PGOUsePath, "", "", "", FS, PGOOptions::IRUse, PGOOptions::NoCSAction,
+#endif
         PGOOptions::ColdFuncOpt::Default, DebugInfoForProfiling);
   } else if (PGOSampleUsePath) {
     PGOOpt =
+#if LLVM_VERSION_GE(22, 0)
+        PGOOptions(PGOSampleUsePath, "", "", "", PGOOptions::SampleUse,
+#else
         PGOOptions(PGOSampleUsePath, "", "", "", FS, PGOOptions::SampleUse,
+#endif
                    PGOOptions::NoCSAction, PGOOptions::ColdFuncOpt::Default,
                    DebugInfoForProfiling);
   } else if (DebugInfoForProfiling) {
     PGOOpt = PGOOptions(
+#if LLVM_VERSION_GE(22, 0)
+        "", "", "", "", PGOOptions::NoAction, PGOOptions::NoCSAction,
+#else
         "", "", "", "", FS, PGOOptions::NoAction, PGOOptions::NoCSAction,
+#endif
         PGOOptions::ColdFuncOpt::Default, DebugInfoForProfiling);
   }
 

--- a/compiler/rustc_metadata/src/rmeta/decoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder.rs
@@ -1555,7 +1555,7 @@ impl<'a> CrateMetadataRef<'a> {
     }
 
     #[inline]
-    fn def_path_hash_to_def_index(self, hash: DefPathHash) -> DefIndex {
+    fn def_path_hash_to_def_index(self, hash: DefPathHash) -> Option<DefIndex> {
         self.def_path_hash_map.def_path_hash_to_def_index(&hash)
     }
 

--- a/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
@@ -691,8 +691,8 @@ fn provide_cstore_hooks(providers: &mut Providers) {
             .get(&stable_crate_id)
             .unwrap_or_else(|| bug!("uninterned StableCrateId: {stable_crate_id:?}"));
         assert_ne!(cnum, LOCAL_CRATE);
-        let def_index = cstore.get_crate_data(cnum).def_path_hash_to_def_index(hash);
-        DefId { krate: cnum, index: def_index }
+        let def_index = cstore.get_crate_data(cnum).def_path_hash_to_def_index(hash)?;
+        Some(DefId { krate: cnum, index: def_index })
     };
 
     providers.hooks.expn_hash_to_expn_id = |tcx, cnum, index_guess, hash| {

--- a/compiler/rustc_metadata/src/rmeta/def_path_hash_map.rs
+++ b/compiler/rustc_metadata/src/rmeta/def_path_hash_map.rs
@@ -12,11 +12,12 @@ pub(crate) enum DefPathHashMapRef<'tcx> {
 
 impl DefPathHashMapRef<'_> {
     #[inline]
-    pub(crate) fn def_path_hash_to_def_index(&self, def_path_hash: &DefPathHash) -> DefIndex {
+    pub(crate) fn def_path_hash_to_def_index(
+        &self,
+        def_path_hash: &DefPathHash,
+    ) -> Option<DefIndex> {
         match *self {
-            DefPathHashMapRef::OwnedFromMetadata(ref map) => {
-                map.get(&def_path_hash.local_hash()).unwrap()
-            }
+            DefPathHashMapRef::OwnedFromMetadata(ref map) => map.get(&def_path_hash.local_hash()),
             DefPathHashMapRef::BorrowedFromTcx(_) => {
                 panic!("DefPathHashMap::BorrowedFromTcx variant only exists for serialization")
             }

--- a/compiler/rustc_middle/src/hooks/mod.rs
+++ b/compiler/rustc_middle/src/hooks/mod.rs
@@ -77,7 +77,7 @@ declare_hooks! {
     /// session, if it still exists. This is used during incremental compilation to
     /// turn a deserialized `DefPathHash` into its current `DefId`.
     /// Will fetch a DefId from a DefPathHash for a foreign crate.
-    hook def_path_hash_to_def_id_extern(hash: DefPathHash, stable_crate_id: StableCrateId) -> DefId;
+    hook def_path_hash_to_def_id_extern(hash: DefPathHash, stable_crate_id: StableCrateId) -> Option<DefId>;
 
     /// Returns `true` if we should codegen an instance in the local crate, or returns `false` if we
     /// can just link to the upstream crate and therefore don't need a mono item.

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -2012,7 +2012,7 @@ impl<'tcx> TyCtxt<'tcx> {
         if stable_crate_id == self.stable_crate_id(LOCAL_CRATE) {
             Some(self.untracked.definitions.read().local_def_path_hash_to_def_id(hash)?.to_def_id())
         } else {
-            Some(self.def_path_hash_to_def_id_extern(hash, stable_crate_id))
+            self.def_path_hash_to_def_id_extern(hash, stable_crate_id)
         }
     }
 

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -679,6 +679,7 @@ symbols! {
         cmpxchg16b_target_feature,
         cmse_nonsecure_entry,
         coerce_pointee_validated,
+        coerce_shared,
         coerce_unsized,
         cold,
         cold_path,

--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -1364,11 +1364,3 @@ pub macro CoercePointee($item:item) {
 pub trait CoercePointeeValidated {
     /* compiler built-in */
 }
-
-/// Allows value to be reborrowed as exclusive, creating a copy of the value
-/// that disables the source for reads and writes for the lifetime of the copy.
-#[lang = "reborrow"]
-#[unstable(feature = "reborrow", issue = "145612")]
-pub trait Reborrow {
-    // Empty.
-}

--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -1372,12 +1372,3 @@ pub trait CoercePointeeValidated {
 pub trait Reborrow {
     // Empty.
 }
-
-/// Allows reborrowable value to be reborrowed as shared, creating a copy of
-/// that disables the source for writes for the lifetime of the copy.
-#[lang = "coerce_shared"]
-#[unstable(feature = "reborrow", issue = "145612")]
-pub trait CoerceShared: Reborrow {
-    /// The type of this value when reborrowed as shared.
-    type Target: Copy;
-}

--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -1372,3 +1372,12 @@ pub trait CoercePointeeValidated {
 pub trait Reborrow {
     // Empty.
 }
+
+/// Allows reborrowable value to be reborrowed as shared, creating a copy of
+/// that disables the source for writes for the lifetime of the copy.
+#[lang = "coerce_shared"]
+#[unstable(feature = "reborrow", issue = "145612")]
+pub trait CoerceShared: Reborrow {
+    /// The type of this value when reborrowed as shared.
+    type Target: Copy;
+}

--- a/library/core/src/num/f128.rs
+++ b/library/core/src/num/f128.rs
@@ -33,12 +33,12 @@ pub mod consts {
 
     /// The golden ratio (φ)
     #[unstable(feature = "f128", issue = "116909")]
-    // Also, #[unstable(feature = "more_float_constants", issue = "103883")]
+    // Also, #[unstable(feature = "more_float_constants", issue = "146939")]
     pub const PHI: f128 = 1.61803398874989484820458683436563811772030917980576286213545_f128;
 
     /// The Euler-Mascheroni constant (γ)
     #[unstable(feature = "f128", issue = "116909")]
-    // Also, #[unstable(feature = "more_float_constants", issue = "103883")]
+    // Also, #[unstable(feature = "more_float_constants", issue = "146939")]
     pub const EGAMMA: f128 = 0.577215664901532860606512090082402431042159335939923598805767_f128;
 
     /// π/2
@@ -67,14 +67,14 @@ pub mod consts {
 
     /// 1/sqrt(π)
     #[unstable(feature = "f128", issue = "116909")]
-    // Also, #[unstable(feature = "more_float_constants", issue = "103883")]
+    // Also, #[unstable(feature = "more_float_constants", issue = "146939")]
     pub const FRAC_1_SQRT_PI: f128 =
         0.564189583547756286948079451560772585844050629328998856844086_f128;
 
     /// 1/sqrt(2π)
     #[doc(alias = "FRAC_1_SQRT_TAU")]
     #[unstable(feature = "f128", issue = "116909")]
-    // Also, #[unstable(feature = "more_float_constants", issue = "103883")]
+    // Also, #[unstable(feature = "more_float_constants", issue = "146939")]
     pub const FRAC_1_SQRT_2PI: f128 =
         0.398942280401432677939946059934381868475858631164934657665926_f128;
 
@@ -98,12 +98,12 @@ pub mod consts {
 
     /// sqrt(3)
     #[unstable(feature = "f128", issue = "116909")]
-    // Also, #[unstable(feature = "more_float_constants", issue = "103883")]
+    // Also, #[unstable(feature = "more_float_constants", issue = "146939")]
     pub const SQRT_3: f128 = 1.73205080756887729352744634150587236694280525381038062805581_f128;
 
     /// 1/sqrt(3)
     #[unstable(feature = "f128", issue = "116909")]
-    // Also, #[unstable(feature = "more_float_constants", issue = "103883")]
+    // Also, #[unstable(feature = "more_float_constants", issue = "146939")]
     pub const FRAC_1_SQRT_3: f128 =
         0.577350269189625764509148780501957455647601751270126876018602_f128;
 

--- a/library/core/src/num/f16.rs
+++ b/library/core/src/num/f16.rs
@@ -35,12 +35,12 @@ pub mod consts {
 
     /// The golden ratio (φ)
     #[unstable(feature = "f16", issue = "116909")]
-    // Also, #[unstable(feature = "more_float_constants", issue = "103883")]
+    // Also, #[unstable(feature = "more_float_constants", issue = "146939")]
     pub const PHI: f16 = 1.618033988749894848204586834365638118_f16;
 
     /// The Euler-Mascheroni constant (γ)
     #[unstable(feature = "f16", issue = "116909")]
-    // Also, #[unstable(feature = "more_float_constants", issue = "103883")]
+    // Also, #[unstable(feature = "more_float_constants", issue = "146939")]
     pub const EGAMMA: f16 = 0.577215664901532860606512090082402431_f16;
 
     /// π/2
@@ -69,13 +69,13 @@ pub mod consts {
 
     /// 1/sqrt(π)
     #[unstable(feature = "f16", issue = "116909")]
-    // Also, #[unstable(feature = "more_float_constants", issue = "103883")]
+    // Also, #[unstable(feature = "more_float_constants", issue = "146939")]
     pub const FRAC_1_SQRT_PI: f16 = 0.564189583547756286948079451560772586_f16;
 
     /// 1/sqrt(2π)
     #[doc(alias = "FRAC_1_SQRT_TAU")]
     #[unstable(feature = "f16", issue = "116909")]
-    // Also, #[unstable(feature = "more_float_constants", issue = "103883")]
+    // Also, #[unstable(feature = "more_float_constants", issue = "146939")]
     pub const FRAC_1_SQRT_2PI: f16 = 0.398942280401432677939946059934381868_f16;
 
     /// 2/π
@@ -96,12 +96,12 @@ pub mod consts {
 
     /// sqrt(3)
     #[unstable(feature = "f16", issue = "116909")]
-    // Also, #[unstable(feature = "more_float_constants", issue = "103883")]
+    // Also, #[unstable(feature = "more_float_constants", issue = "146939")]
     pub const SQRT_3: f16 = 1.732050807568877293527446341505872367_f16;
 
     /// 1/sqrt(3)
     #[unstable(feature = "f16", issue = "116909")]
-    // Also, #[unstable(feature = "more_float_constants", issue = "103883")]
+    // Also, #[unstable(feature = "more_float_constants", issue = "146939")]
     pub const FRAC_1_SQRT_3: f16 = 0.577350269189625764509148780501957456_f16;
 
     /// Euler's number (e)

--- a/library/core/src/num/f32.rs
+++ b/library/core/src/num/f32.rs
@@ -291,11 +291,11 @@ pub mod consts {
     pub const TAU: f32 = 6.28318530717958647692528676655900577_f32;
 
     /// The golden ratio (φ)
-    #[unstable(feature = "more_float_constants", issue = "103883")]
+    #[unstable(feature = "more_float_constants", issue = "146939")]
     pub const PHI: f32 = 1.618033988749894848204586834365638118_f32;
 
     /// The Euler-Mascheroni constant (γ)
-    #[unstable(feature = "more_float_constants", issue = "103883")]
+    #[unstable(feature = "more_float_constants", issue = "146939")]
     pub const EGAMMA: f32 = 0.577215664901532860606512090082402431_f32;
 
     /// π/2
@@ -323,12 +323,12 @@ pub mod consts {
     pub const FRAC_1_PI: f32 = 0.318309886183790671537767526745028724_f32;
 
     /// 1/sqrt(π)
-    #[unstable(feature = "more_float_constants", issue = "103883")]
+    #[unstable(feature = "more_float_constants", issue = "146939")]
     pub const FRAC_1_SQRT_PI: f32 = 0.564189583547756286948079451560772586_f32;
 
     /// 1/sqrt(2π)
     #[doc(alias = "FRAC_1_SQRT_TAU")]
-    #[unstable(feature = "more_float_constants", issue = "103883")]
+    #[unstable(feature = "more_float_constants", issue = "146939")]
     pub const FRAC_1_SQRT_2PI: f32 = 0.398942280401432677939946059934381868_f32;
 
     /// 2/π
@@ -348,11 +348,11 @@ pub mod consts {
     pub const FRAC_1_SQRT_2: f32 = 0.707106781186547524400844362104849039_f32;
 
     /// sqrt(3)
-    #[unstable(feature = "more_float_constants", issue = "103883")]
+    #[unstable(feature = "more_float_constants", issue = "146939")]
     pub const SQRT_3: f32 = 1.732050807568877293527446341505872367_f32;
 
     /// 1/sqrt(3)
-    #[unstable(feature = "more_float_constants", issue = "103883")]
+    #[unstable(feature = "more_float_constants", issue = "146939")]
     pub const FRAC_1_SQRT_3: f32 = 0.577350269189625764509148780501957456_f32;
 
     /// Euler's number (e)

--- a/library/core/src/num/f64.rs
+++ b/library/core/src/num/f64.rs
@@ -291,11 +291,11 @@ pub mod consts {
     pub const TAU: f64 = 6.28318530717958647692528676655900577_f64;
 
     /// The golden ratio (φ)
-    #[unstable(feature = "more_float_constants", issue = "103883")]
+    #[unstable(feature = "more_float_constants", issue = "146939")]
     pub const PHI: f64 = 1.618033988749894848204586834365638118_f64;
 
     /// The Euler-Mascheroni constant (γ)
-    #[unstable(feature = "more_float_constants", issue = "103883")]
+    #[unstable(feature = "more_float_constants", issue = "146939")]
     pub const EGAMMA: f64 = 0.577215664901532860606512090082402431_f64;
 
     /// π/2
@@ -323,12 +323,12 @@ pub mod consts {
     pub const FRAC_1_PI: f64 = 0.318309886183790671537767526745028724_f64;
 
     /// 1/sqrt(π)
-    #[unstable(feature = "more_float_constants", issue = "103883")]
+    #[unstable(feature = "more_float_constants", issue = "146939")]
     pub const FRAC_1_SQRT_PI: f64 = 0.564189583547756286948079451560772586_f64;
 
     /// 1/sqrt(2π)
     #[doc(alias = "FRAC_1_SQRT_TAU")]
-    #[unstable(feature = "more_float_constants", issue = "103883")]
+    #[unstable(feature = "more_float_constants", issue = "146939")]
     pub const FRAC_1_SQRT_2PI: f64 = 0.398942280401432677939946059934381868_f64;
 
     /// 2/π
@@ -348,11 +348,11 @@ pub mod consts {
     pub const FRAC_1_SQRT_2: f64 = 0.707106781186547524400844362104849039_f64;
 
     /// sqrt(3)
-    #[unstable(feature = "more_float_constants", issue = "103883")]
+    #[unstable(feature = "more_float_constants", issue = "146939")]
     pub const SQRT_3: f64 = 1.732050807568877293527446341505872367_f64;
 
     /// 1/sqrt(3)
-    #[unstable(feature = "more_float_constants", issue = "103883")]
+    #[unstable(feature = "more_float_constants", issue = "146939")]
     pub const FRAC_1_SQRT_3: f64 = 0.577350269189625764509148780501957456_f64;
 
     /// Euler's number (e)

--- a/library/core/src/ops/mod.rs
+++ b/library/core/src/ops/mod.rs
@@ -191,7 +191,7 @@ pub use self::range::{OneSidedRange, OneSidedRangeBound};
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use self::range::{Range, RangeFrom, RangeFull, RangeTo};
 #[unstable(feature = "reborrow", issue = "145612")]
-pub use self::reborrow::CoerceShared;
+pub use self::reborrow::{CoerceShared, Reborrow};
 #[unstable(feature = "try_trait_v2_residual", issue = "91285")]
 pub use self::try_trait::Residual;
 #[unstable(feature = "try_trait_v2_yeet", issue = "96374")]

--- a/library/core/src/ops/mod.rs
+++ b/library/core/src/ops/mod.rs
@@ -149,6 +149,7 @@ mod function;
 mod index;
 mod index_range;
 mod range;
+mod reborrow;
 mod try_trait;
 mod unsize;
 
@@ -189,6 +190,8 @@ pub use self::range::{Bound, RangeBounds, RangeInclusive, RangeToInclusive};
 pub use self::range::{OneSidedRange, OneSidedRangeBound};
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use self::range::{Range, RangeFrom, RangeFull, RangeTo};
+#[unstable(feature = "reborrow", issue = "145612")]
+pub use self::reborrow::CoerceShared;
 #[unstable(feature = "try_trait_v2_residual", issue = "91285")]
 pub use self::try_trait::Residual;
 #[unstable(feature = "try_trait_v2_yeet", issue = "96374")]

--- a/library/core/src/ops/reborrow.rs
+++ b/library/core/src/ops/reborrow.rs
@@ -1,0 +1,10 @@
+use crate::marker::Reborrow;
+
+/// Allows reborrowable value to be reborrowed as shared, creating a copy
+/// that disables the source for writes for the lifetime of the copy.
+#[lang = "coerce_shared"]
+#[unstable(feature = "reborrow", issue = "145612")]
+pub trait CoerceShared: Reborrow {
+    /// The type of this value when reborrowed as shared.
+    type Target: Copy;
+}

--- a/library/core/src/ops/reborrow.rs
+++ b/library/core/src/ops/reborrow.rs
@@ -1,4 +1,10 @@
-use crate::marker::Reborrow;
+/// Allows value to be reborrowed as exclusive, creating a copy of the value
+/// that disables the source for reads and writes for the lifetime of the copy.
+#[lang = "reborrow"]
+#[unstable(feature = "reborrow", issue = "145612")]
+pub trait Reborrow {
+    // Empty.
+}
 
 /// Allows reborrowable value to be reborrowed as shared, creating a copy
 /// that disables the source for writes for the lifetime of the copy.

--- a/library/std/src/os/net/linux_ext/tcp.rs
+++ b/library/std/src/os/net/linux_ext/tcp.rs
@@ -4,6 +4,7 @@
 
 use crate::sealed::Sealed;
 use crate::sys_common::AsInner;
+use crate::time::Duration;
 use crate::{io, net};
 
 /// Os-specific extensions for [`TcpStream`]
@@ -59,11 +60,13 @@ pub trait TcpStreamExt: Sealed {
 
     /// A socket listener will be awakened solely when data arrives.
     ///
-    /// The `accept` argument set the delay in seconds until the
+    /// The `accept` argument set the maximum delay until the
     /// data is available to read, reducing the number of short lived
     /// connections without data to process.
     /// Contrary to other platforms `SO_ACCEPTFILTER` feature equivalent, there is
     /// no necessity to set it after the `listen` call.
+    /// Note that the delay is expressed as Duration from user's perspective
+    /// the call rounds it down to the nearest second expressible as a `c_int`.
     ///
     /// See [`man 7 tcp`](https://man7.org/linux/man-pages/man7/tcp.7.html)
     ///
@@ -73,16 +76,17 @@ pub trait TcpStreamExt: Sealed {
     /// #![feature(tcp_deferaccept)]
     /// use std::net::TcpStream;
     /// use std::os::linux::net::TcpStreamExt;
+    /// use std::time::Duration;
     ///
     /// let stream = TcpStream::connect("127.0.0.1:8080")
     ///         .expect("Couldn't connect to the server...");
-    /// stream.set_deferaccept(1).expect("set_deferaccept call failed");
+    /// stream.set_deferaccept(Duration::from_secs(1u64)).expect("set_deferaccept call failed");
     /// ```
     #[unstable(feature = "tcp_deferaccept", issue = "119639")]
     #[cfg(target_os = "linux")]
-    fn set_deferaccept(&self, accept: u32) -> io::Result<()>;
+    fn set_deferaccept(&self, accept: Duration) -> io::Result<()>;
 
-    /// Gets the accept delay value (in seconds) of the `TCP_DEFER_ACCEPT` option.
+    /// Gets the accept delay value of the `TCP_DEFER_ACCEPT` option.
     ///
     /// For more information about this option, see [`TcpStreamExt::set_deferaccept`].
     ///
@@ -92,15 +96,16 @@ pub trait TcpStreamExt: Sealed {
     /// #![feature(tcp_deferaccept)]
     /// use std::net::TcpStream;
     /// use std::os::linux::net::TcpStreamExt;
+    /// use std::time::Duration;
     ///
     /// let stream = TcpStream::connect("127.0.0.1:8080")
     ///         .expect("Couldn't connect to the server...");
-    /// stream.set_deferaccept(1).expect("set_deferaccept call failed");
-    /// assert_eq!(stream.deferaccept().unwrap_or(0), 1);
+    /// stream.set_deferaccept(Duration::from_secs(1u64)).expect("set_deferaccept call failed");
+    /// assert_eq!(stream.deferaccept().unwrap(), Duration::from_secs(1u64));
     /// ```
     #[unstable(feature = "tcp_deferaccept", issue = "119639")]
     #[cfg(target_os = "linux")]
-    fn deferaccept(&self) -> io::Result<u32>;
+    fn deferaccept(&self) -> io::Result<Duration>;
 }
 
 #[stable(feature = "tcp_quickack", since = "1.89.0")]
@@ -117,12 +122,12 @@ impl TcpStreamExt for net::TcpStream {
     }
 
     #[cfg(target_os = "linux")]
-    fn set_deferaccept(&self, accept: u32) -> io::Result<()> {
+    fn set_deferaccept(&self, accept: Duration) -> io::Result<()> {
         self.as_inner().as_inner().set_deferaccept(accept)
     }
 
     #[cfg(target_os = "linux")]
-    fn deferaccept(&self) -> io::Result<u32> {
+    fn deferaccept(&self) -> io::Result<Duration> {
         self.as_inner().as_inner().deferaccept()
     }
 }

--- a/library/std/src/os/net/linux_ext/tests.rs
+++ b/library/std/src/os/net/linux_ext/tests.rs
@@ -32,6 +32,7 @@ fn deferaccept() {
     use crate::net::test::next_test_ip4;
     use crate::net::{TcpListener, TcpStream};
     use crate::os::net::linux_ext::tcp::TcpStreamExt;
+    use crate::time::Duration;
 
     macro_rules! t {
         ($e:expr) => {
@@ -43,10 +44,12 @@ fn deferaccept() {
     }
 
     let addr = next_test_ip4();
+    let one = Duration::from_secs(1u64);
+    let zero = Duration::from_secs(0u64);
     let _listener = t!(TcpListener::bind(&addr));
     let stream = t!(TcpStream::connect(&("localhost", addr.port())));
-    stream.set_deferaccept(1).expect("set_deferaccept failed");
-    assert_eq!(stream.deferaccept().unwrap(), 1);
-    stream.set_deferaccept(0).expect("set_deferaccept failed");
-    assert_eq!(stream.deferaccept().unwrap(), 0);
+    stream.set_deferaccept(one).expect("set_deferaccept failed");
+    assert_eq!(stream.deferaccept().unwrap(), one);
+    stream.set_deferaccept(zero).expect("set_deferaccept failed");
+    assert_eq!(stream.deferaccept().unwrap(), zero);
 }

--- a/library/std/src/sys/net/connection/socket/unix.rs
+++ b/library/std/src/sys/net/connection/socket/unix.rs
@@ -485,14 +485,15 @@ impl Socket {
 
     // bionic libc makes no use of this flag
     #[cfg(target_os = "linux")]
-    pub fn set_deferaccept(&self, accept: u32) -> io::Result<()> {
-        setsockopt(self, libc::IPPROTO_TCP, libc::TCP_DEFER_ACCEPT, accept as c_int)
+    pub fn set_deferaccept(&self, accept: Duration) -> io::Result<()> {
+        let val = cmp::min(accept.as_secs(), c_int::MAX as u64) as c_int;
+        setsockopt(self, libc::IPPROTO_TCP, libc::TCP_DEFER_ACCEPT, val)
     }
 
     #[cfg(target_os = "linux")]
-    pub fn deferaccept(&self) -> io::Result<u32> {
+    pub fn deferaccept(&self) -> io::Result<Duration> {
         let raw: c_int = getsockopt(self, libc::IPPROTO_TCP, libc::TCP_DEFER_ACCEPT)?;
-        Ok(raw as u32)
+        Ok(Duration::from_secs(raw as _))
     }
 
     #[cfg(any(target_os = "freebsd", target_os = "netbsd"))]

--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -1219,7 +1219,7 @@ pub fn rustc_cargo(
     // us a faster startup time. However GNU ld < 2.40 will error if we try to link a shared object
     // with direct references to protected symbols, so for now we only use protected symbols if
     // linking with LLD is enabled.
-    if builder.build.config.lld_mode.is_used() {
+    if builder.build.config.bootstrap_override_lld.is_used() {
         cargo.rustflag("-Zdefault-visibility=protected");
     }
 
@@ -1256,7 +1256,7 @@ pub fn rustc_cargo(
     // is already on by default in MSVC optimized builds, which is interpreted as --icf=all:
     // https://github.com/llvm/llvm-project/blob/3329cec2f79185bafd678f310fafadba2a8c76d2/lld/COFF/Driver.cpp#L1746
     // https://github.com/rust-lang/rust/blob/f22819bcce4abaff7d1246a56eec493418f9f4ee/compiler/rustc_codegen_ssa/src/back/linker.rs#L827
-    if builder.config.lld_mode.is_used() && !build_compiler.host.is_msvc() {
+    if builder.config.bootstrap_override_lld.is_used() && !build_compiler.host.is_msvc() {
         cargo.rustflag("-Clink-args=-Wl,--icf=all");
     }
 

--- a/src/bootstrap/src/core/config/mod.rs
+++ b/src/bootstrap/src/core/config/mod.rs
@@ -37,7 +37,7 @@ use serde_derive::Deserialize;
 pub use target_selection::TargetSelection;
 pub use toml::BUILDER_CONFIG_FILENAME;
 pub use toml::change_id::ChangeId;
-pub use toml::rust::LldMode;
+pub use toml::rust::BootstrapOverrideLld;
 pub use toml::target::Target;
 
 use crate::Display;

--- a/src/bootstrap/src/core/config/tests.rs
+++ b/src/bootstrap/src/core/config/tests.rs
@@ -17,7 +17,9 @@ use crate::core::build_steps::clippy::{LintConfig, get_clippy_rules_in_order};
 use crate::core::build_steps::llvm::LLVM_INVALIDATION_PATHS;
 use crate::core::build_steps::{llvm, test};
 use crate::core::config::toml::TomlConfig;
-use crate::core::config::{CompilerBuiltins, LldMode, StringOrBool, Target, TargetSelection};
+use crate::core::config::{
+    BootstrapOverrideLld, CompilerBuiltins, StringOrBool, Target, TargetSelection,
+};
 use crate::utils::tests::TestCtx;
 use crate::utils::tests::git::git_test;
 
@@ -222,11 +224,33 @@ fn verify_file_integrity() {
 
 #[test]
 fn rust_lld() {
-    assert!(matches!(parse("").lld_mode, LldMode::Unused));
-    assert!(matches!(parse("rust.use-lld = \"self-contained\"").lld_mode, LldMode::SelfContained));
-    assert!(matches!(parse("rust.use-lld = \"external\"").lld_mode, LldMode::External));
-    assert!(matches!(parse("rust.use-lld = true").lld_mode, LldMode::External));
-    assert!(matches!(parse("rust.use-lld = false").lld_mode, LldMode::Unused));
+    assert!(matches!(parse("").bootstrap_override_lld, BootstrapOverrideLld::None));
+    assert!(matches!(
+        parse("rust.bootstrap-override-lld = \"self-contained\"").bootstrap_override_lld,
+        BootstrapOverrideLld::SelfContained
+    ));
+    assert!(matches!(
+        parse("rust.bootstrap-override-lld = \"external\"").bootstrap_override_lld,
+        BootstrapOverrideLld::External
+    ));
+    assert!(matches!(
+        parse("rust.bootstrap-override-lld = true").bootstrap_override_lld,
+        BootstrapOverrideLld::External
+    ));
+    assert!(matches!(
+        parse("rust.bootstrap-override-lld = false").bootstrap_override_lld,
+        BootstrapOverrideLld::None
+    ));
+
+    // Also check the legacy options
+    assert!(matches!(
+        parse("rust.use-lld = true").bootstrap_override_lld,
+        BootstrapOverrideLld::External
+    ));
+    assert!(matches!(
+        parse("rust.use-lld = false").bootstrap_override_lld,
+        BootstrapOverrideLld::None
+    ));
 }
 
 #[test]

--- a/src/bootstrap/src/lib.rs
+++ b/src/bootstrap/src/lib.rs
@@ -35,7 +35,7 @@ use utils::exec::ExecutionContext;
 
 use crate::core::builder;
 use crate::core::builder::Kind;
-use crate::core::config::{DryRun, LldMode, LlvmLibunwind, TargetSelection, flags};
+use crate::core::config::{BootstrapOverrideLld, DryRun, LlvmLibunwind, TargetSelection, flags};
 use crate::utils::exec::{BootstrapCommand, command};
 use crate::utils::helpers::{self, dir_is_empty, exe, libdir, set_file_times, split_debuginfo};
 
@@ -1358,14 +1358,14 @@ impl Build {
             && !target.is_msvc()
         {
             Some(self.cc(target))
-        } else if self.config.lld_mode.is_used()
+        } else if self.config.bootstrap_override_lld.is_used()
             && self.is_lld_direct_linker(target)
             && self.host_target == target
         {
-            match self.config.lld_mode {
-                LldMode::SelfContained => Some(self.initial_lld.clone()),
-                LldMode::External => Some("lld".into()),
-                LldMode::Unused => None,
+            match self.config.bootstrap_override_lld {
+                BootstrapOverrideLld::SelfContained => Some(self.initial_lld.clone()),
+                BootstrapOverrideLld::External => Some("lld".into()),
+                BootstrapOverrideLld::None => None,
             }
         } else {
             None

--- a/src/bootstrap/src/utils/change_tracker.rs
+++ b/src/bootstrap/src/utils/change_tracker.rs
@@ -556,4 +556,9 @@ pub const CONFIG_CHANGE_HISTORY: &[ChangeInfo] = &[
         severity: ChangeSeverity::Info,
         summary: "New option `build.windows-rc` that will override which resource compiler on Windows will be used to compile Rust.",
     },
+    ChangeInfo {
+        change_id: 99999,
+        severity: ChangeSeverity::Warning,
+        summary: "The `rust.use-lld` option has been renamed to `rust.bootstrap-override-lld`. Note that it only serves for overriding the linker used when building Rust code in bootstrap to be LLD.",
+    },
 ];

--- a/src/ci/docker/host-aarch64/dist-aarch64-linux/Dockerfile
+++ b/src/ci/docker/host-aarch64/dist-aarch64-linux/Dockerfile
@@ -91,7 +91,7 @@ ENV RUST_CONFIGURE_ARGS \
       --set llvm.ninja=false \
       --set rust.debug-assertions=false \
       --set rust.jemalloc \
-      --set rust.use-lld=true \
+      --set rust.bootstrap-override-lld=true \
       --set rust.lto=thin \
       --set rust.codegen-units=1
 

--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/Dockerfile
@@ -92,7 +92,7 @@ ENV RUST_CONFIGURE_ARGS \
       --set llvm.ninja=false \
       --set llvm.libzstd=true \
       --set rust.jemalloc \
-      --set rust.use-lld=true \
+      --set rust.bootstrap-override-lld=true \
       --set rust.lto=thin \
       --set rust.codegen-units=1
 

--- a/src/librustdoc/doctest.rs
+++ b/src/librustdoc/doctest.rs
@@ -404,11 +404,15 @@ pub(crate) fn run_tests(
             std::mem::drop(temp_dir.take());
             times.display_times();
         });
-    }
-    if nb_errors != 0 {
-        // We ensure temp dir destructor is called.
-        std::mem::drop(temp_dir);
+    } else {
+        // If the first condition branch exited successfully, `test_main_with_exit_callback` will
+        // not exit the process. So to prevent displaying the times twice, we put it behind an
+        // `else` condition.
         times.display_times();
+    }
+    // We ensure temp dir destructor is called.
+    std::mem::drop(temp_dir);
+    if nb_errors != 0 {
         std::process::exit(test::ERROR_EXIT_CODE);
     }
 }

--- a/tests/codegen-llvm/issues/issue-122600-ptr-discriminant-update.rs
+++ b/tests/codegen-llvm/issues/issue-122600-ptr-discriminant-update.rs
@@ -1,6 +1,6 @@
 //@ compile-flags: -Copt-level=3
 //@ revisions: new old
-//@ [old] ignore-llvm-version: 22 - 99
+//@ [old] max-llvm-major-version: 21
 //@ [new] min-llvm-version: 22
 
 #![crate_type = "lib"]

--- a/tests/codegen-llvm/issues/issue-122600-ptr-discriminant-update.rs
+++ b/tests/codegen-llvm/issues/issue-122600-ptr-discriminant-update.rs
@@ -1,4 +1,7 @@
 //@ compile-flags: -Copt-level=3
+//@ revisions: new old
+//@ [old] ignore-llvm-version: 22 - 99
+//@ [new] min-llvm-version: 22
 
 #![crate_type = "lib"]
 
@@ -22,8 +25,8 @@ pub unsafe fn update(s: *mut State) {
     // CHECK-NOT: memcpy
     // CHECK-NOT: 75{{3|4}}
 
-    // CHECK: %[[TAG:.+]] = load i8, ptr %s, align 1
-    // CHECK-NEXT: trunc nuw i8 %[[TAG]] to i1
+    // old: %[[TAG:.+]] = load i8, ptr %s, align 1
+    // old-NEXT: trunc nuw i8 %[[TAG]] to i1
 
     // CHECK-NOT: load
     // CHECK-NOT: store

--- a/tests/codegen-llvm/vec_pop_push_noop.rs
+++ b/tests/codegen-llvm/vec_pop_push_noop.rs
@@ -1,6 +1,6 @@
 //@ compile-flags: -Copt-level=3
 //@ revisions: new old
-//@ [old] ignore-llvm-version: 22 - 99
+//@ [old] max-llvm-major-version: 21
 //@ [new] min-llvm-version: 22
 
 #![crate_type = "lib"]

--- a/tests/codegen-llvm/vec_pop_push_noop.rs
+++ b/tests/codegen-llvm/vec_pop_push_noop.rs
@@ -1,4 +1,7 @@
 //@ compile-flags: -Copt-level=3
+//@ revisions: new old
+//@ [old] ignore-llvm-version: 22 - 99
+//@ [new] min-llvm-version: 22
 
 #![crate_type = "lib"]
 
@@ -7,7 +10,7 @@
 pub fn noop(v: &mut Vec<u8>) {
     // CHECK-NOT: grow_one
     // CHECK-NOT: call
-    // CHECK: tail call void @llvm.assume
+    // old: tail call void @llvm.assume
     // CHECK-NOT: grow_one
     // CHECK-NOT: call
     // CHECK: {{ret|[}]}}

--- a/tests/codegen-llvm/vecdeque_pop_push.rs
+++ b/tests/codegen-llvm/vecdeque_pop_push.rs
@@ -1,4 +1,7 @@
 //@ compile-flags: -Copt-level=3
+//@ revisions: new old
+//@ [old] ignore-llvm-version: 22 - 99
+//@ [new] min-llvm-version: 22
 
 #![crate_type = "lib"]
 
@@ -8,7 +11,7 @@ use std::collections::VecDeque;
 // CHECK-LABEL: @noop_back(
 pub fn noop_back(v: &mut VecDeque<u8>) {
     // CHECK-NOT: grow
-    // CHECK: tail call void @llvm.assume
+    // old: tail call void @llvm.assume
     // CHECK-NOT: grow
     // CHECK: ret
     if let Some(x) = v.pop_back() {

--- a/tests/codegen-llvm/vecdeque_pop_push.rs
+++ b/tests/codegen-llvm/vecdeque_pop_push.rs
@@ -1,6 +1,6 @@
 //@ compile-flags: -Copt-level=3
 //@ revisions: new old
-//@ [old] ignore-llvm-version: 22 - 99
+//@ [old] max-llvm-major-version: 21
 //@ [new] min-llvm-version: 22
 
 #![crate_type = "lib"]

--- a/tests/run-make/doctests-compilation-time-info/rmake.rs
+++ b/tests/run-make/doctests-compilation-time-info/rmake.rs
@@ -1,0 +1,119 @@
+//@ ignore-cross-compile (needs to run doctests)
+
+use run_make_support::rfs::write;
+use run_make_support::{cwd, rustdoc};
+
+fn assert_presence_of_compilation_time_report(
+    content: &str,
+    success: bool,
+    should_contain_compile_time: bool,
+) {
+    let mut cmd = rustdoc();
+    let file = cwd().join("foo.rs");
+
+    write(&file, content);
+    cmd.input(&file).arg("--test").edition("2024").env("RUST_BACKTRACE", "0");
+    let output = if success { cmd.run() } else { cmd.run_fail() };
+
+    assert_eq!(
+        output
+            .stdout_utf8()
+            .split("all doctests ran in ")
+            .last()
+            .is_some_and(|s| s.contains("; merged doctests compilation took")),
+        should_contain_compile_time,
+    );
+}
+
+fn main() {
+    // Checking with only successful merged doctests.
+    assert_presence_of_compilation_time_report(
+        "\
+//! ```
+//! let x = 12;
+//! ```",
+        true,
+        true,
+    );
+    // Checking with only failing merged doctests.
+    assert_presence_of_compilation_time_report(
+        "\
+//! ```
+//! panic!();
+//! ```",
+        false,
+        true,
+    );
+    // Checking with mix of successful doctests.
+    assert_presence_of_compilation_time_report(
+        "\
+//! ```
+//! let x = 12;
+//! ```
+//!
+//! ```compile_fail
+//! let x
+//! ```",
+        true,
+        true,
+    );
+    // Checking with mix of failing doctests.
+    assert_presence_of_compilation_time_report(
+        "\
+//! ```
+//! panic!();
+//! ```
+//!
+//! ```compile_fail
+//! let x
+//! ```",
+        false,
+        true,
+    );
+    // Checking with mix of failing doctests (v2).
+    assert_presence_of_compilation_time_report(
+        "\
+//! ```
+//! let x = 12;
+//! ```
+//!
+//! ```compile_fail
+//! let x = 12;
+//! ```",
+        false,
+        true,
+    );
+    // Checking with mix of failing doctests (v3).
+    assert_presence_of_compilation_time_report(
+        "\
+//! ```
+//! panic!();
+//! ```
+//!
+//! ```compile_fail
+//! let x = 12;
+//! ```",
+        false,
+        true,
+    );
+    // Checking with successful non-merged doctests.
+    assert_presence_of_compilation_time_report(
+        "\
+//! ```compile_fail
+//! let x
+//! ```",
+        true,
+        // If there is no merged doctests, then we should not display compilation time.
+        false,
+    );
+    // Checking with failing non-merged doctests.
+    assert_presence_of_compilation_time_report(
+        "\
+//! ```compile_fail
+//! let x = 12;
+//! ```",
+        false,
+        // If there is no merged doctests, then we should not display compilation time.
+        false,
+    );
+}

--- a/tests/run-make/doctests-merge/doctest-2024.stdout
+++ b/tests/run-make/doctests-merge/doctest-2024.stdout
@@ -5,3 +5,4 @@ test doctest.rs - init (line 8) ... ok
 
 test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
 
+all doctests ran in $TIME; merged doctests compilation took $TIME

--- a/tests/run-make/doctests-merge/rmake.rs
+++ b/tests/run-make/doctests-merge/rmake.rs
@@ -20,6 +20,8 @@ fn test_and_compare(input_file: &str, stdout_file: &str, edition: &str, dep: &Pa
         .expected_file(stdout_file)
         .actual_text("output", output.stdout_utf8())
         .normalize(r#"finished in \d+\.\d+s"#, "finished in $$TIME")
+        .normalize(r#"ran in \d+\.\d+s"#, "ran in $$TIME")
+        .normalize(r#"compilation took \d+\.\d+s"#, "compilation took $$TIME")
         .run();
 }
 

--- a/tests/run-make/linker-warning/rmake.rs
+++ b/tests/run-make/linker-warning/rmake.rs
@@ -61,13 +61,13 @@ fn main() {
         diff()
             .expected_file("short-error.txt")
             .actual_text("(linker error)", out.stderr())
-            .normalize("libpanic_abort", "libpanic_unwind")
             .normalize(
                 regex::escape(
                     run_make_support::build_root().canonicalize().unwrap().to_str().unwrap(),
                 ),
                 "/build-root",
             )
+            .normalize("libpanic_abort", "libpanic_unwind")
             .normalize(r#""[^"]*\/symbols.o""#, "\"/symbols.o\"")
             .normalize(r#""[^"]*\/raw-dylibs""#, "\"/raw-dylibs\"")
             .run();

--- a/tests/rustdoc-ui/doctest/doctest-output.edition2015.stdout
+++ b/tests/rustdoc-ui/doctest/doctest-output.edition2015.stdout
@@ -1,8 +1,8 @@
 
 running 3 tests
-test $DIR/doctest-output.rs - (line 12) ... ok
-test $DIR/doctest-output.rs - ExpandedStruct (line 28) ... ok
-test $DIR/doctest-output.rs - foo::bar (line 22) ... ok
+test $DIR/doctest-output.rs - (line 14) ... ok
+test $DIR/doctest-output.rs - ExpandedStruct (line 30) ... ok
+test $DIR/doctest-output.rs - foo::bar (line 24) ... ok
 
 test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
 

--- a/tests/rustdoc-ui/doctest/doctest-output.edition2024.stdout
+++ b/tests/rustdoc-ui/doctest/doctest-output.edition2024.stdout
@@ -1,8 +1,9 @@
 
 running 3 tests
-test $DIR/doctest-output.rs - (line 12) ... ok
-test $DIR/doctest-output.rs - ExpandedStruct (line 28) ... ok
-test $DIR/doctest-output.rs - foo::bar (line 22) ... ok
+test $DIR/doctest-output.rs - (line 14) ... ok
+test $DIR/doctest-output.rs - ExpandedStruct (line 30) ... ok
+test $DIR/doctest-output.rs - foo::bar (line 24) ... ok
 
 test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
 
+all doctests ran in $TIME; merged doctests compilation took $TIME

--- a/tests/rustdoc-ui/doctest/doctest-output.rs
+++ b/tests/rustdoc-ui/doctest/doctest-output.rs
@@ -7,6 +7,8 @@
 //@[edition2024]compile-flags:--test --test-args=--test-threads=1
 //@ normalize-stdout: "tests/rustdoc-ui/doctest" -> "$$DIR"
 //@ normalize-stdout: "finished in \d+\.\d+s" -> "finished in $$TIME"
+//@ normalize-stdout: "ran in \d+\.\d+s" -> "ran in $$TIME"
+//@ normalize-stdout: "compilation took \d+\.\d+s" -> "compilation took $$TIME"
 //@ check-pass
 
 //! ```

--- a/tests/rustdoc-ui/doctest/merged-ignore-no_run.rs
+++ b/tests/rustdoc-ui/doctest/merged-ignore-no_run.rs
@@ -2,6 +2,8 @@
 //@ compile-flags:--test --test-args=--test-threads=1
 //@ normalize-stdout: "tests/rustdoc-ui/doctest" -> "$$DIR"
 //@ normalize-stdout: "finished in \d+\.\d+s" -> "finished in $$TIME"
+//@ normalize-stdout: "ran in \d+\.\d+s" -> "ran in $$TIME"
+//@ normalize-stdout: "compilation took \d+\.\d+s" -> "compilation took $$TIME"
 //@ check-pass
 
 /// ```ignore (test)

--- a/tests/rustdoc-ui/doctest/merged-ignore-no_run.stdout
+++ b/tests/rustdoc-ui/doctest/merged-ignore-no_run.stdout
@@ -1,7 +1,8 @@
 
 running 2 tests
-test $DIR/merged-ignore-no_run.rs - ignored (line 7) ... ignored
-test $DIR/merged-ignore-no_run.rs - no_run (line 12) - compile ... ok
+test $DIR/merged-ignore-no_run.rs - ignored (line 9) ... ignored
+test $DIR/merged-ignore-no_run.rs - no_run (line 14) - compile ... ok
 
 test result: ok. 1 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in $TIME
 
+all doctests ran in $TIME; merged doctests compilation took $TIME

--- a/tests/ui/feature-gates/feature-gate-reborrow-coerce-shared.rs
+++ b/tests/ui/feature-gates/feature-gate-reborrow-coerce-shared.rs
@@ -1,0 +1,3 @@
+use std::marker::CoerceShared; //~ ERROR  use of unstable library feature `reborrow`
+
+fn main() {}

--- a/tests/ui/feature-gates/feature-gate-reborrow-coerce-shared.rs
+++ b/tests/ui/feature-gates/feature-gate-reborrow-coerce-shared.rs
@@ -1,3 +1,3 @@
-use std::marker::CoerceShared; //~ ERROR  use of unstable library feature `reborrow`
+use std::ops::CoerceShared; //~ ERROR  use of unstable library feature `reborrow`
 
 fn main() {}

--- a/tests/ui/feature-gates/feature-gate-reborrow-coerce-shared.stderr
+++ b/tests/ui/feature-gates/feature-gate-reborrow-coerce-shared.stderr
@@ -1,0 +1,13 @@
+error[E0658]: use of unstable library feature `reborrow`
+  --> $DIR/feature-gate-reborrow-coerce-shared.rs:1:5
+   |
+LL | use std::marker::CoerceShared;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #145612 <https://github.com/rust-lang/rust/issues/145612> for more information
+   = help: add `#![feature(reborrow)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/feature-gates/feature-gate-reborrow-coerce-shared.stderr
+++ b/tests/ui/feature-gates/feature-gate-reborrow-coerce-shared.stderr
@@ -1,8 +1,8 @@
 error[E0658]: use of unstable library feature `reborrow`
   --> $DIR/feature-gate-reborrow-coerce-shared.rs:1:5
    |
-LL | use std::marker::CoerceShared;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | use std::ops::CoerceShared;
+   |     ^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #145612 <https://github.com/rust-lang/rust/issues/145612> for more information
    = help: add `#![feature(reborrow)]` to the crate attributes to enable

--- a/tests/ui/feature-gates/feature-gate-reborrow.rs
+++ b/tests/ui/feature-gates/feature-gate-reborrow.rs
@@ -1,3 +1,3 @@
-use std::marker::Reborrow; //~ ERROR  use of unstable library feature `reborrow`
+use std::ops::Reborrow; //~ ERROR  use of unstable library feature `reborrow`
 
 fn main() {}

--- a/tests/ui/feature-gates/feature-gate-reborrow.stderr
+++ b/tests/ui/feature-gates/feature-gate-reborrow.stderr
@@ -1,8 +1,8 @@
 error[E0658]: use of unstable library feature `reborrow`
   --> $DIR/feature-gate-reborrow.rs:1:5
    |
-LL | use std::marker::Reborrow;
-   |     ^^^^^^^^^^^^^^^^^^^^^
+LL | use std::ops::Reborrow;
+   |     ^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #145612 <https://github.com/rust-lang/rust/issues/145612> for more information
    = help: add `#![feature(reborrow)]` to the crate attributes to enable

--- a/tests/ui/reborrow/custom_mut.rs
+++ b/tests/ui/reborrow/custom_mut.rs
@@ -1,0 +1,13 @@
+#![feature(reborrow)]
+use std::marker::Reborrow;
+
+struct CustomMut<'a, T>(&'a mut T);
+impl<'a, T> Reborrow for CustomMut<'a, T> {}
+
+fn method(a: CustomMut<'_, ()>) {}
+
+fn main() {
+    let a = CustomMut(&mut ());
+    let _ = method(a);
+    let _ = method(a); //~ERROR use of moved value: `a`
+}

--- a/tests/ui/reborrow/custom_mut.rs
+++ b/tests/ui/reborrow/custom_mut.rs
@@ -1,5 +1,5 @@
 #![feature(reborrow)]
-use std::marker::Reborrow;
+use std::ops::Reborrow;
 
 struct CustomMut<'a, T>(&'a mut T);
 impl<'a, T> Reborrow for CustomMut<'a, T> {}

--- a/tests/ui/reborrow/custom_mut.stderr
+++ b/tests/ui/reborrow/custom_mut.stderr
@@ -1,0 +1,29 @@
+error[E0382]: use of moved value: `a`
+  --> $DIR/custom_mut.rs:12:20
+   |
+LL |     let a = CustomMut(&mut ());
+   |         - move occurs because `a` has type `CustomMut<'_, ()>`, which does not implement the `Copy` trait
+LL |     let _ = method(a);
+   |                    - value moved here
+LL |     let _ = method(a);
+   |                    ^ value used here after move
+   |
+note: consider changing this parameter type in function `method` to borrow instead if owning the value isn't necessary
+  --> $DIR/custom_mut.rs:7:14
+   |
+LL | fn method(a: CustomMut<'_, ()>) {}
+   |    ------    ^^^^^^^^^^^^^^^^^ this parameter takes ownership of the value
+   |    |
+   |    in this function
+note: if `CustomMut<'_, ()>` implemented `Clone`, you could clone the value
+  --> $DIR/custom_mut.rs:4:1
+   |
+LL | struct CustomMut<'a, T>(&'a mut T);
+   | ^^^^^^^^^^^^^^^^^^^^^^^ consider implementing `Clone` for this type
+...
+LL |     let _ = method(a);
+   |                    - you could clone this value
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0382`.

--- a/tests/ui/reborrow/custom_mut_coerce_shared.rs
+++ b/tests/ui/reborrow/custom_mut_coerce_shared.rs
@@ -1,0 +1,28 @@
+#![feature(reborrow)]
+use std::marker::{Reborrow, CoerceShared};
+
+struct CustomMut<'a, T>(&'a mut T);
+impl<'a, T> Reborrow for CustomMut<'a, T> {}
+impl<'a, T> CoerceShared for CustomMut<'a, T> {
+    type Target = CustomRef<'a, T>;
+}
+
+struct CustomRef<'a, T>(&'a T);
+
+impl<'a, T> Clone for CustomRef<'a, T> {
+    fn clone(&self) -> Self {
+        Self(self.0)
+    }
+}
+impl<'a, T> Copy for CustomRef<'a, T> {}
+
+fn method(a: CustomRef<'_, ()>) {}  //~NOTE function defined here
+
+fn main() {
+    let a = CustomMut(&mut ());
+    method(a);
+    //~^ ERROR mismatched types
+    //~| NOTE expected `CustomRef<'_, ()>`, found `CustomMut<'_, ()>`
+    //~| NOTE arguments to this function are incorrect
+    //~| NOTE expected struct `CustomRef<'_, ()>`
+}

--- a/tests/ui/reborrow/custom_mut_coerce_shared.rs
+++ b/tests/ui/reborrow/custom_mut_coerce_shared.rs
@@ -1,6 +1,5 @@
 #![feature(reborrow)]
-use std::marker::Reborrow;
-use std::ops::CoerceShared;
+use std::ops::{CoerceShared, Reborrow};
 
 struct CustomMut<'a, T>(&'a mut T);
 impl<'a, T> Reborrow for CustomMut<'a, T> {}

--- a/tests/ui/reborrow/custom_mut_coerce_shared.rs
+++ b/tests/ui/reborrow/custom_mut_coerce_shared.rs
@@ -1,5 +1,6 @@
 #![feature(reborrow)]
-use std::marker::{Reborrow, CoerceShared};
+use std::marker::Reborrow;
+use std::ops::CoerceShared;
 
 struct CustomMut<'a, T>(&'a mut T);
 impl<'a, T> Reborrow for CustomMut<'a, T> {}

--- a/tests/ui/reborrow/custom_mut_coerce_shared.stderr
+++ b/tests/ui/reborrow/custom_mut_coerce_shared.stderr
@@ -1,0 +1,19 @@
+error[E0308]: mismatched types
+  --> $DIR/custom_mut_coerce_shared.rs:23:12
+   |
+LL |     method(a);
+   |     ------ ^ expected `CustomRef<'_, ()>`, found `CustomMut<'_, ()>`
+   |     |
+   |     arguments to this function are incorrect
+   |
+   = note: expected struct `CustomRef<'_, ()>`
+              found struct `CustomMut<'_, ()>`
+note: function defined here
+  --> $DIR/custom_mut_coerce_shared.rs:19:4
+   |
+LL | fn method(a: CustomRef<'_, ()>) {}
+   |    ^^^^^^ --------------------
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/reborrow/custom_mut_coerce_shared.stderr
+++ b/tests/ui/reborrow/custom_mut_coerce_shared.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/custom_mut_coerce_shared.rs:23:12
+  --> $DIR/custom_mut_coerce_shared.rs:24:12
    |
 LL |     method(a);
    |     ------ ^ expected `CustomRef<'_, ()>`, found `CustomMut<'_, ()>`
@@ -9,7 +9,7 @@ LL |     method(a);
    = note: expected struct `CustomRef<'_, ()>`
               found struct `CustomMut<'_, ()>`
 note: function defined here
-  --> $DIR/custom_mut_coerce_shared.rs:19:4
+  --> $DIR/custom_mut_coerce_shared.rs:20:4
    |
 LL | fn method(a: CustomRef<'_, ()>) {}
    |    ^^^^^^ --------------------

--- a/tests/ui/reborrow/custom_mut_coerce_shared.stderr
+++ b/tests/ui/reborrow/custom_mut_coerce_shared.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/custom_mut_coerce_shared.rs:24:12
+  --> $DIR/custom_mut_coerce_shared.rs:23:12
    |
 LL |     method(a);
    |     ------ ^ expected `CustomRef<'_, ()>`, found `CustomMut<'_, ()>`
@@ -9,7 +9,7 @@ LL |     method(a);
    = note: expected struct `CustomRef<'_, ()>`
               found struct `CustomMut<'_, ()>`
 note: function defined here
-  --> $DIR/custom_mut_coerce_shared.rs:20:4
+  --> $DIR/custom_mut_coerce_shared.rs:19:4
    |
 LL | fn method(a: CustomRef<'_, ()>) {}
    |    ^^^^^^ --------------------

--- a/tests/ui/reborrow/option_mut.rs
+++ b/tests/ui/reborrow/option_mut.rs
@@ -1,0 +1,7 @@
+fn method(a: Option<& mut ()>) {}
+
+fn main() {
+    let a = Some(&mut ());
+    let _ = method(a);
+    let _ = method(a); //~ERROR use of moved value: `a`
+}

--- a/tests/ui/reborrow/option_mut.rs
+++ b/tests/ui/reborrow/option_mut.rs
@@ -1,4 +1,4 @@
-fn method(a: Option<& mut ()>) {}
+fn method(a: Option<&mut ()>) {}
 
 fn main() {
     let a = Some(&mut ());

--- a/tests/ui/reborrow/option_mut.stderr
+++ b/tests/ui/reborrow/option_mut.stderr
@@ -1,0 +1,21 @@
+error[E0382]: use of moved value: `a`
+  --> $DIR/option_mut.rs:6:20
+   |
+LL |     let a = Some(&mut ());
+   |         - move occurs because `a` has type `Option<&mut ()>`, which does not implement the `Copy` trait
+LL |     let _ = method(a);
+   |                    - value moved here
+LL |     let _ = method(a);
+   |                    ^ value used here after move
+   |
+note: consider changing this parameter type in function `method` to borrow instead if owning the value isn't necessary
+  --> $DIR/option_mut.rs:1:14
+   |
+LL | fn method(a: Option<& mut ()>) {}
+   |    ------    ^^^^^^^^^^^^^^^^ this parameter takes ownership of the value
+   |    |
+   |    in this function
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0382`.

--- a/tests/ui/reborrow/option_mut.stderr
+++ b/tests/ui/reborrow/option_mut.stderr
@@ -11,8 +11,8 @@ LL |     let _ = method(a);
 note: consider changing this parameter type in function `method` to borrow instead if owning the value isn't necessary
   --> $DIR/option_mut.rs:1:14
    |
-LL | fn method(a: Option<& mut ()>) {}
-   |    ------    ^^^^^^^^^^^^^^^^ this parameter takes ownership of the value
+LL | fn method(a: Option<&mut ()>) {}
+   |    ------    ^^^^^^^^^^^^^^^ this parameter takes ownership of the value
    |    |
    |    in this function
 

--- a/tests/ui/reborrow/option_mut_coerce_shared.rs
+++ b/tests/ui/reborrow/option_mut_coerce_shared.rs
@@ -1,0 +1,11 @@
+fn method(a: Option<&()>) {}  //~NOTE function defined here
+
+fn main() {
+    let a = Some(&mut ());
+    method(a);
+    //~^ ERROR mismatched types
+    //~| NOTE arguments to this function are incorrect
+    //~| NOTE types differ in mutability
+    //~| NOTE expected enum `Option<&()>`
+    //~| NOTE    found enum `Option<&mut ()>`
+}

--- a/tests/ui/reborrow/option_mut_coerce_shared.stderr
+++ b/tests/ui/reborrow/option_mut_coerce_shared.stderr
@@ -1,0 +1,23 @@
+error[E0308]: mismatched types
+  --> $DIR/option_mut_coerce_shared.rs:5:12
+   |
+LL |     method(a);
+   |     ------ ^ types differ in mutability
+   |     |
+   |     arguments to this function are incorrect
+   |
+   = note: expected enum `Option<&()>`
+              found enum `Option<&mut ()>`
+note: function defined here
+  --> $DIR/option_mut_coerce_shared.rs:1:4
+   |
+LL | fn method(a: Option<&()>) {}
+   |    ^^^^^^ --------------
+help: try using `.as_deref()` to convert `Option<&mut ()>` to `Option<&()>`
+   |
+LL |     method(a.as_deref());
+   |             +++++++++++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/reborrow/pin_mut.rs
+++ b/tests/ui/reborrow/pin_mut.rs
@@ -1,0 +1,10 @@
+use std::pin::Pin;
+
+fn method(a: Pin<& mut ()>) {}
+
+fn main() {
+    let a = &mut ();
+    let a = Pin::new(a);
+    let _ = method(a);
+    let _ = method(a); //~ERROR use of moved value: `a`
+}

--- a/tests/ui/reborrow/pin_mut.rs
+++ b/tests/ui/reborrow/pin_mut.rs
@@ -1,6 +1,6 @@
 use std::pin::Pin;
 
-fn method(a: Pin<& mut ()>) {}
+fn method(a: Pin<&mut ()>) {}
 
 fn main() {
     let a = &mut ();

--- a/tests/ui/reborrow/pin_mut.stderr
+++ b/tests/ui/reborrow/pin_mut.stderr
@@ -1,0 +1,21 @@
+error[E0382]: use of moved value: `a`
+  --> $DIR/pin_mut.rs:9:20
+   |
+LL |     let a = Pin::new(a);
+   |         - move occurs because `a` has type `Pin<&mut ()>`, which does not implement the `Copy` trait
+LL |     let _ = method(a);
+   |                    - value moved here
+LL |     let _ = method(a);
+   |                    ^ value used here after move
+   |
+note: consider changing this parameter type in function `method` to borrow instead if owning the value isn't necessary
+  --> $DIR/pin_mut.rs:3:14
+   |
+LL | fn method(a: Pin<& mut ()>) {}
+   |    ------    ^^^^^^^^^^^^^ this parameter takes ownership of the value
+   |    |
+   |    in this function
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0382`.

--- a/tests/ui/reborrow/pin_mut.stderr
+++ b/tests/ui/reborrow/pin_mut.stderr
@@ -11,8 +11,8 @@ LL |     let _ = method(a);
 note: consider changing this parameter type in function `method` to borrow instead if owning the value isn't necessary
   --> $DIR/pin_mut.rs:3:14
    |
-LL | fn method(a: Pin<& mut ()>) {}
-   |    ------    ^^^^^^^^^^^^^ this parameter takes ownership of the value
+LL | fn method(a: Pin<&mut ()>) {}
+   |    ------    ^^^^^^^^^^^^ this parameter takes ownership of the value
    |    |
    |    in this function
 

--- a/tests/ui/reborrow/pin_mut_coerce_shared.rs
+++ b/tests/ui/reborrow/pin_mut_coerce_shared.rs
@@ -1,0 +1,14 @@
+use std::pin::Pin;
+
+fn method(a: Pin<&()>) {}  //~NOTE function defined here
+
+fn main() {
+    let a = &mut ();
+    let a = Pin::new(a);
+    method(a);
+    //~^ ERROR mismatched types
+    //~| NOTE arguments to this function are incorrect
+    //~| NOTE types differ in mutability
+    //~| NOTE expected struct `Pin<&()>`
+    //~| NOTE    found struct `Pin<&mut ()>`
+}

--- a/tests/ui/reborrow/pin_mut_coerce_shared.rs
+++ b/tests/ui/reborrow/pin_mut_coerce_shared.rs
@@ -10,5 +10,4 @@ fn main() {
     //~| NOTE arguments to this function are incorrect
     //~| NOTE types differ in mutability
     //~| NOTE expected struct `Pin<&()>`
-    //~| NOTE    found struct `Pin<&mut ()>`
 }

--- a/tests/ui/reborrow/pin_mut_coerce_shared.stderr
+++ b/tests/ui/reborrow/pin_mut_coerce_shared.stderr
@@ -1,0 +1,19 @@
+error[E0308]: mismatched types
+  --> $DIR/pin_mut_coerce_shared.rs:8:12
+   |
+LL |     method(a);
+   |     ------ ^ types differ in mutability
+   |     |
+   |     arguments to this function are incorrect
+   |
+   = note: expected struct `Pin<&()>`
+              found struct `Pin<&mut ()>`
+note: function defined here
+  --> $DIR/pin_mut_coerce_shared.rs:3:4
+   |
+LL | fn method(a: Pin<&()>) {}
+   |    ^^^^^^ -----------
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#140482 (std::net: update tcp deferaccept delay type to Duration.)
 - rust-lang/rust#146037 (Introduce CoerceShared lang item and trait, and basic Reborrow tests)
 - rust-lang/rust#146732 (tests: relax expectations after llvm change 902ddda120a5)
 - rust-lang/rust#147018 (re-order normalizations in run-make linker-warning test)
 - rust-lang/rust#147032 (Fix doctest compilation time display)
 - rust-lang/rust#147046 (Rename `rust.use-lld` to `rust.bootstrap-override-lld`)
 - rust-lang/rust#147050 (PassWrapper: update for new PGOOptions args in LLVM 22)
 - rust-lang/rust#147075 (Make `def_path_hash_to_def_id` not panic when passed an invalid hash)
 - rust-lang/rust#147076 (update issue number for more_float_constants)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=140482,146037,146732,147018,147032,147046,147050,147075,147076)
<!-- homu-ignore:end -->