### PR TITLE
Skip stack overflow handler for panic=immediate-abort

### DIFF
--- a/library/std/src/sys/pal/windows/mod.rs
+++ b/library/std/src/sys/pal/windows/mod.rs
@@ -22,7 +22,8 @@ pub mod os;
 pub mod pipe;
 pub mod time;
 cfg_select! {
-    not(target_vendor = "uwp") => {
+    // We don't care about printing nice error messages for panic=immediate-abort
+    all(not(target_vendor = "uwp"), not(panic = "immediate-abort")) => {
         pub mod stack_overflow;
     }
     _ => {


### PR DESCRIPTION
std installs guard pages and a signal handler to ensure that stackoverflows 1) terminate abruptly and 2) print an nice message. Even for panic=immediate-abort, 1) is desirable, we don't want silent data corruption there. But 2) is completely unnecessary, as users deliberately *don't* want nice messages, they want minimum binary size.

Therefore, skip the entire guard signal handler setup, which saves a lot of bytes.

I tested this with a hello world binary using fat LTO, build-std, panic=immediate-abort, opt-level=s, strip=debuginfo.

`size` reports significant savings:

```
   text	   data	    bss	    dec	    hex	filename
  15252	   1032	    104	  16388	   4004	tiny-before
   6881	    964	     48	   7893	   1ed5	tiny-after2
```

`nm -U` goes from 71 to 56, getting rid of a bunch of stack overflow related symbols. The disk size goes from `31k` to `24k`.

The impact on the error message is minimal, as the message was already
missing.

before:
```
fish: Job 1, './tiny-so-before' terminated by signal SIGABRT (Abort)
```

after:
```
fish: Job 1, './tiny-so-after' terminated by signal SIGSEGV (Address boundary error)
```

I didn't test the Windows part, but it likely also has savings.