### PR TITLE
tests: Stop ignoring android in backtrace tests

### DIFF
--- a/tests/ui/backtrace/backtrace.rs
+++ b/tests/ui/backtrace/backtrace.rs
@@ -1,5 +1,4 @@
 //@ run-pass
-//@ ignore-android FIXME #17520
 //@ needs-subprocess
 //@ ignore-openbsd no support for libbacktrace without filename
 //@ ignore-msvc see #62897 and `backtrace-debuginfo.rs` test

--- a/tests/ui/backtrace/dylib-dep.rs
+++ b/tests/ui/backtrace/dylib-dep.rs
@@ -4,7 +4,6 @@
 // Original test:
 // <https://github.com/rust-lang/backtrace-rs/tree/6fa4b85b9962c3e1be8c2e5cc605cd078134152b/crates/dylib-dep>
 // ignore-tidy-linelength
-//@ ignore-android FIXME #17520
 //@ ignore-fuchsia Backtraces not symbolized
 //@ ignore-musl musl doesn't support dynamic libraries (at least when the original test was written).
 //@ ignore-ios needs the `.dSYM` files to be moved to the device

--- a/tests/ui/backtrace/line-tables-only.rs
+++ b/tests/ui/backtrace/line-tables-only.rs
@@ -8,7 +8,6 @@
 // ignore-tidy-linelength
 //@ run-pass
 //@ compile-flags: -Cstrip=none -Cdebuginfo=line-tables-only
-//@ ignore-android FIXME #17520
 //@ ignore-fuchsia Backtraces not symbolized
 //@ ignore-emscripten Requires custom symbolization code
 //@ ignore-ios needs the `.dSYM` files to be moved to the device

--- a/tests/ui/backtrace/std-backtrace.rs
+++ b/tests/ui/backtrace/std-backtrace.rs
@@ -1,5 +1,4 @@
 //@ run-pass
-//@ ignore-android FIXME #17520
 //@ needs-subprocess
 //@ ignore-openbsd no support for libbacktrace without filename
 //@ ignore-fuchsia Backtraces not symbolized

--- a/tests/ui/panics/issue-47429-short-backtraces.rs
+++ b/tests/ui/panics/issue-47429-short-backtraces.rs
@@ -18,7 +18,6 @@
 //@ normalize-stderr: "\n +at [^\n]+" -> ""
 
 //@ ignore-msvc see #62897 and `backtrace-debuginfo.rs` test
-//@ ignore-android FIXME #17520
 //@ ignore-openbsd no support for libbacktrace without filename
 //@ ignore-fuchsia Backtraces not symbolized
 //@ needs-subprocess

--- a/tests/ui/panics/issue-47429-short-backtraces.run.stderr
+++ b/tests/ui/panics/issue-47429-short-backtraces.run.stderr
@@ -1,5 +1,5 @@
 
-thread 'main' ($TID) panicked at $DIR/issue-47429-short-backtraces.rs:27:5:
+thread 'main' ($TID) panicked at $DIR/issue-47429-short-backtraces.rs:26:5:
 explicit panic
 stack backtrace:
    0: std::panicking::begin_panic

--- a/tests/ui/panics/location-detail-unwrap-multiline.rs
+++ b/tests/ui/panics/location-detail-unwrap-multiline.rs
@@ -1,9 +1,8 @@
 //@ run-fail
 //@ compile-flags: -Cstrip=none -Cdebuginfo=line-tables-only -Copt-level=0
 //@ exec-env:RUST_BACKTRACE=1
-//@ regex-error-pattern: location-detail-unwrap-multiline\.rs:11(:10)?:\n
+//@ regex-error-pattern: location-detail-unwrap-multiline\.rs:10(:10)?:\n
 //@ needs-unwind
-//@ ignore-android FIXME #17520
 
 fn main() {
     let opt: Option<u32> = None;

--- a/tests/ui/panics/runtime-switch.rs
+++ b/tests/ui/panics/runtime-switch.rs
@@ -18,7 +18,6 @@
 //@ normalize-stderr: "\n +at [^\n]+" -> ""
 
 //@ ignore-msvc see #62897 and `backtrace-debuginfo.rs` test
-//@ ignore-android FIXME #17520
 //@ ignore-openbsd no support for libbacktrace without filename
 //@ ignore-wasm no backtrace support
 //@ ignore-fuchsia Backtrace not symbolized

--- a/tests/ui/panics/runtime-switch.run.stderr
+++ b/tests/ui/panics/runtime-switch.run.stderr
@@ -1,5 +1,5 @@
 
-thread 'main' ($TID) panicked at $DIR/runtime-switch.rs:31:5:
+thread 'main' ($TID) panicked at $DIR/runtime-switch.rs:30:5:
 explicit panic
 stack backtrace:
    0: std::panicking::begin_panic

--- a/tests/ui/panics/short-ice-remove-middle-frames-2.rs
+++ b/tests/ui/panics/short-ice-remove-middle-frames-2.rs
@@ -3,7 +3,6 @@
 //@ check-run-results
 //@ exec-env:RUST_BACKTRACE=1
 //@ needs-unwind
-//@ ignore-android FIXME #17520
 //@ ignore-openbsd no support for libbacktrace without filename
 //@ ignore-sgx Backtraces not symbolized
 //@ ignore-fuchsia Backtraces not symbolized

--- a/tests/ui/panics/short-ice-remove-middle-frames-2.run.stderr
+++ b/tests/ui/panics/short-ice-remove-middle-frames-2.run.stderr
@@ -1,5 +1,5 @@
 
-thread 'main' ($TID) panicked at $DIR/short-ice-remove-middle-frames-2.rs:62:5:
+thread 'main' ($TID) panicked at $DIR/short-ice-remove-middle-frames-2.rs:61:5:
 debug!!!
 stack backtrace:
    0: std::panicking::begin_panic

--- a/tests/ui/panics/short-ice-remove-middle-frames.rs
+++ b/tests/ui/panics/short-ice-remove-middle-frames.rs
@@ -3,7 +3,6 @@
 //@ check-run-results
 //@ exec-env:RUST_BACKTRACE=1
 //@ needs-unwind
-//@ ignore-android FIXME #17520
 //@ ignore-openbsd no support for libbacktrace without filename
 //@ ignore-sgx Backtraces not symbolized
 //@ ignore-fuchsia Backtraces not symbolized

--- a/tests/ui/panics/short-ice-remove-middle-frames.run.stderr
+++ b/tests/ui/panics/short-ice-remove-middle-frames.run.stderr
@@ -1,5 +1,5 @@
 
-thread 'main' ($TID) panicked at $DIR/short-ice-remove-middle-frames.rs:58:5:
+thread 'main' ($TID) panicked at $DIR/short-ice-remove-middle-frames.rs:57:5:
 debug!!!
 stack backtrace:
    0: std::panicking::begin_panic


### PR DESCRIPTION
I suspect https://github.com/rust-lang/rust/issues/17520#issuecomment-2957567749 is not a problem any longer. Let's try.

r? @ghost
