### PR TITLE
Library: Remove remaining private `#[repr]` workarounds

### DIFF
--- a/library/core/src/ffi/mod.rs
+++ b/library/core/src/ffi/mod.rs
@@ -56,7 +56,7 @@ pub use self::primitives::{c_ptrdiff_t, c_size_t, c_ssize_t};
 //     be UB.
 #[doc = include_str!("c_void.md")]
 #[lang = "c_void"]
-#[cfg_attr(not(doc), repr(u8))] // An implementation detail we don't want to show up in rustdoc
+#[repr(u8)]
 #[stable(feature = "core_c_void", since = "1.30.0")]
 pub enum c_void {
     #[unstable(

--- a/library/core/src/ffi/va_list.rs
+++ b/library/core/src/ffi/va_list.rs
@@ -25,7 +25,7 @@ crate::cfg_select! {
         ///
         /// [AArch64 Procedure Call Standard]:
         /// http://infocenter.arm.com/help/topic/com.arm.doc.ihi0055b/IHI0055B_aapcs64.pdf
-        #[cfg_attr(not(doc), repr(C))] // work around https://github.com/rust-lang/rust/issues/66401
+        #[repr(C)]
         #[derive(Debug)]
         #[lang = "va_list"]
         pub struct VaListImpl<'f> {
@@ -39,7 +39,7 @@ crate::cfg_select! {
     }
     all(target_arch = "powerpc", not(target_os = "uefi"), not(windows)) => {
         /// PowerPC ABI implementation of a `va_list`.
-        #[cfg_attr(not(doc), repr(C))] // work around https://github.com/rust-lang/rust/issues/66401
+        #[repr(C)]
         #[derive(Debug)]
         #[lang = "va_list"]
         pub struct VaListImpl<'f> {
@@ -53,7 +53,7 @@ crate::cfg_select! {
     }
     target_arch = "s390x" => {
         /// s390x ABI implementation of a `va_list`.
-        #[cfg_attr(not(doc), repr(C))] // work around https://github.com/rust-lang/rust/issues/66401
+        #[repr(C)]
         #[derive(Debug)]
         #[lang = "va_list"]
         pub struct VaListImpl<'f> {
@@ -66,7 +66,7 @@ crate::cfg_select! {
     }
     all(target_arch = "x86_64", not(target_os = "uefi"), not(windows)) => {
         /// x86_64 ABI implementation of a `va_list`.
-        #[cfg_attr(not(doc), repr(C))] // work around https://github.com/rust-lang/rust/issues/66401
+        #[repr(C)]
         #[derive(Debug)]
         #[lang = "va_list"]
         pub struct VaListImpl<'f> {

--- a/library/core/src/os/darwin/objc.rs
+++ b/library/core/src/os/darwin/objc.rs
@@ -6,7 +6,7 @@
 use crate::fmt;
 
 /// Equivalent to Objective-C’s `struct objc_class` type.
-#[cfg_attr(not(doc), repr(u8))] // An implementation detail we don't want to show up in rustdoc
+#[repr(u8)]
 pub enum objc_class {
     #[unstable(
         feature = "objc_class_variant",
@@ -31,7 +31,7 @@ impl fmt::Debug for objc_class {
 }
 
 /// Equivalent to Objective-C’s `struct objc_selector` type.
-#[cfg_attr(not(doc), repr(u8))] // An implementation detail we don't want to show up in rustdoc
+#[repr(u8)]
 pub enum objc_selector {
     #[unstable(
         feature = "objc_selector_variant",


### PR DESCRIPTION
With https://github.com/rust-lang/rust/pull/116882 finally merged, gating these `repr`s behind cfg `not(doc)` is no longer necessary to achieve a private repr.

Follow up to https://github.com/rust-lang/rust/pull/128046 (that was enabled via https://github.com/rust-lang/rust/pull/115439). With that, https://github.com/rust-lang/rust/pull/116743 is now fully realized at long last.

cc @dtolnay