### PR TITLE
Add auto extra-checks in pre-push hook

### DIFF
--- a/src/etc/pre-push.sh
+++ b/src/etc/pre-push.sh
@@ -26,7 +26,10 @@ ROOT_DIR="$(git rev-parse --show-toplevel)"
 echo "Running pre-push script $ROOT_DIR/x test tidy"
 
 cd "$ROOT_DIR"
-./x test tidy --set build.locked-deps=true
+# The env var is necessary for printing diffs in py (fmt/lint) and cpp.
+TIDY_PRINT_DIFF=1 ./x test tidy \
+    --set build.locked-deps=true \
+    --extra-checks auto:py,auto:cpp,auto:js
 if [ $? -ne 0 ]; then
     echo "You may use \`git push --no-verify\` to skip this check."
     exit 1


### PR DESCRIPTION
Fixes rust-lang/rust#147088 

This PR adds auto py, cpp, and js extra checks into the pre-push script.
- It checks those non-Rust files only if they are modified in the commit
- Thanks to auto mode, the pre-push doesn't check them if none of them are modified. It means that it doesn't build venv, nor install node_packages under build/

Note that this PR doesn't add shellcheck and spellcheck, because
- Currently shellcheck isn't installed by the tidy command unlike venv/node_modules. So it forces developers to take a extra task to enable pre-push hook
- Spellcheck is built whenever I kick test tidy with the option. If I enables it, developers should wait extra time for running pre-push hook