### PR TITLE
tests: Remove ignore-android directive for fixed issue

### DIFF
--- a/tests/ui/test-attrs/test-panic-abort-nocapture.rs
+++ b/tests/ui/test-attrs/test-panic-abort-nocapture.rs
@@ -6,7 +6,6 @@
 //@ exec-env:RUST_BACKTRACE=0
 //@ normalize-stdout: "finished in \d+\.\d+s" -> "finished in $$TIME"
 
-//@ ignore-android #120567
 //@ needs-subprocess
 
 #![cfg(test)]

--- a/tests/ui/test-attrs/test-panic-abort-nocapture.run.stderr
+++ b/tests/ui/test-attrs/test-panic-abort-nocapture.run.stderr
@@ -1,11 +1,11 @@
 
-thread 'main' ($TID) panicked at $DIR/test-panic-abort-nocapture.rs:32:5:
+thread 'main' ($TID) panicked at $DIR/test-panic-abort-nocapture.rs:31:5:
 assertion `left == right` failed
   left: 2
  right: 4
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 
-thread 'main' ($TID) panicked at $DIR/test-panic-abort-nocapture.rs:26:5:
+thread 'main' ($TID) panicked at $DIR/test-panic-abort-nocapture.rs:25:5:
 assertion `left == right` failed
   left: 2
  right: 4

--- a/tests/ui/test-attrs/test-panic-abort.rs
+++ b/tests/ui/test-attrs/test-panic-abort.rs
@@ -6,7 +6,6 @@
 //@ exec-env:RUST_BACKTRACE=0
 //@ normalize-stdout: "finished in \d+\.\d+s" -> "finished in $$TIME"
 
-//@ ignore-android #120567
 //@ needs-subprocess
 
 #![cfg(test)]

--- a/tests/ui/test-attrs/test-panic-abort.run.stdout
+++ b/tests/ui/test-attrs/test-panic-abort.run.stdout
@@ -18,7 +18,7 @@ testing123
 ---- it_fails stderr ----
 testing321
 
-thread 'main' ($TID) panicked at $DIR/test-panic-abort.rs:37:5:
+thread 'main' ($TID) panicked at $DIR/test-panic-abort.rs:36:5:
 assertion `left == right` failed
   left: 2
  right: 5


### PR DESCRIPTION
rust-lang/rust#120567 is marked as fixed, so let's see if we can remove the ignore directives tied to that issue.

<!-- Note to self: wait for https://github.com/rust-lang/team/pull/2002 -->

try-job: arm-android
