### PR TITLE
Suggest method syntax `x.max(y)` for unresolved `max(x, y)` calls

### DIFF
--- a/tests/ui/did_you_mean/method-syntax-for-min-max.rs
+++ b/tests/ui/did_you_mean/method-syntax-for-min-max.rs
@@ -1,0 +1,29 @@
+fn main() {
+    //~^ HELP consider importing this function
+    //~| HELP consider importing this function
+    //~| HELP consider importing this function
+    //~| HELP consider importing this function
+    let x = 2;
+    let y = 4;
+
+    max(x, y);
+    //~^ ERROR cannot find function `max` in this scope
+    //~| HELP you may have meant to use the method syntax
+    let _ = min(x, y);
+    //~^ ERROR cannot find function `min` in this scope
+    //~| HELP you may have meant to use the method syntax
+    println!("{}", min(43, 43));
+    //~^ ERROR cannot find function `min` in this scope
+    //~| HELP you may have meant to use the method syntax
+    let _ = vec![max(f(), g())];
+    //~^ ERROR cannot find function `max` in this scope
+    //~| HELP you may have meant to use the method syntax
+}
+
+const fn f() -> u32 {
+    4
+}
+
+const fn g() -> u32 {
+    2
+}

--- a/tests/ui/did_you_mean/method-syntax-for-min-max.stderr
+++ b/tests/ui/did_you_mean/method-syntax-for-min-max.stderr
@@ -1,0 +1,67 @@
+error[E0425]: cannot find function `max` in this scope
+  --> $DIR/method-syntax-for-min-max.rs:9:5
+   |
+LL |     max(x, y);
+   |     ^^^ not found in this scope
+   |
+help: you may have meant to use the method syntax
+   |
+LL -     max(x, y);
+LL +     x.max(y);
+   |
+help: consider importing this function
+   |
+LL + use std::cmp::max;
+   |
+
+error[E0425]: cannot find function `min` in this scope
+  --> $DIR/method-syntax-for-min-max.rs:12:13
+   |
+LL |     let _ = min(x, y);
+   |             ^^^ not found in this scope
+   |
+help: you may have meant to use the method syntax
+   |
+LL -     let _ = min(x, y);
+LL +     let _ = x.min(y);
+   |
+help: consider importing this function
+   |
+LL + use std::cmp::min;
+   |
+
+error[E0425]: cannot find function `min` in this scope
+  --> $DIR/method-syntax-for-min-max.rs:15:20
+   |
+LL |     println!("{}", min(43, 43));
+   |                    ^^^ not found in this scope
+   |
+help: you may have meant to use the method syntax
+   |
+LL -     println!("{}", min(43, 43));
+LL +     println!("{}", 43.min(43));
+   |
+help: consider importing this function
+   |
+LL + use std::cmp::min;
+   |
+
+error[E0425]: cannot find function `max` in this scope
+  --> $DIR/method-syntax-for-min-max.rs:18:18
+   |
+LL |     let _ = vec![max(f(), g())];
+   |                  ^^^ not found in this scope
+   |
+help: you may have meant to use the method syntax
+   |
+LL -     let _ = vec![max(f(), g())];
+LL +     let _ = vec![f().max(g())];
+   |
+help: consider importing this function
+   |
+LL + use std::cmp::max;
+   |
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0425`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Fixes https://github.com/rust-lang/rust/issues/76386

r? compiler
