### PR TITLE
Improve cg_llvm codegen for `simd_select_bitmask`

### DIFF
--- a/tests/codegen-llvm/simd-intrinsic/simd-intrinsic-generic-select.rs
+++ b/tests/codegen-llvm/simd-intrinsic/simd-intrinsic-generic-select.rs
@@ -46,3 +46,12 @@ pub unsafe fn select_bitmask(m: i8, a: f32x8, b: f32x8) -> f32x8 {
     // CHECK: select <8 x i1> [[A]]
     simd_select_bitmask(m, a, b)
 }
+
+// CHECK-LABEL: @select_bitmask_small
+#[no_mangle]
+pub unsafe fn select_bitmask_small(m: i8, a: f32x4, b: f32x4) -> f32x4 {
+    // CHECK: [[A:%[0-9]+]] = bitcast i8 {{.*}} to <8 x i1>
+    // CHECK: [[B:%[0-9]+]] = shufflevector <8 x i1> [[A]], <8 x i1> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+    // CHECK: select <4 x i1> [[B]]
+    simd_select_bitmask(m, a, b)
+}


### PR DESCRIPTION
While testing out some intrinsic-based implementation in stdarch, I noticed that LLVM can't optimize it well if we use simple `bitcast` and `trunc`s to get the actual `i1xN`s from the bitmasks. LLVM actually seems to like it better if we use `shufflevector`s, and for autoupgraded intrinsics that used integer returns, but were migrated to use `i1xN` returns, LLVM actually use this exact form (https://godbolt.org/z/YT99Phzj5)

This doesn't affect any codegen that uses vectors that are multiples-of-8-length. This is mostly targeted towards 2- and 4-width vectors

@rustbot A-LLVM A-codegen T-compiler

r? codegen