### PR TITLE
Fix some crash-test directives

### DIFF
--- a/tests/crashes/125772.rs
+++ b/tests/crashes/125772.rs
@@ -1,5 +1,5 @@
 //@ known-bug: rust-lang/rust#125772
-//@ only-x86_64
+//@ only-64bit
 #![feature(generic_const_exprs)]
 
 struct Outer<const A: i64, const B: i64>();

--- a/tests/crashes/131292.rs
+++ b/tests/crashes/131292.rs
@@ -1,5 +1,5 @@
 //@ known-bug: #131292
-//@ only-x86_64
+//@ needs-asm-support
 use std::arch::asm;
 
 unsafe fn f6() {

--- a/tests/crashes/34127.rs
+++ b/tests/crashes/34127.rs
@@ -1,6 +1,6 @@
 //@ compile-flags: -g -Copt-level=0 -Z verify-llvm-ir
 //@ known-bug: #34127
-//@ only-x86_64
+//@ only-64bit
 
 pub fn main() {
 let _a = [(); 1 << 63];


### PR DESCRIPTION
- 120175 fails to crash for non-ELF targets; presumably this wasn't noticed because the CI jobs don't enable rustc assertions for non-ELF hosts.
- 34127, 125722, and 131292 have `only-x86_64`, which is overly specific.
  - Unnecessary x86 directives cause friction for contributors using aarch64, especially now that many PR CI jobs also use aarch64.

r? ghost