### PR TITLE
Fix removed version numbers of `doc_auto_cfg` and `doc_cfg_hide`

### DIFF
--- a/compiler/rustc_feature/src/removed.rs
+++ b/compiler/rustc_feature/src/removed.rs
@@ -102,9 +102,9 @@ declare_features! (
     /// Allows deriving traits as per `SmartPointer` specification
     (removed, derive_smart_pointer, "1.84.0", Some(123430), Some("replaced by `CoercePointee`"), 131284),
     /// Tells rustdoc to automatically generate `#[doc(cfg(...))]`.
-    (removed, doc_auto_cfg, "1.58.0", Some(43781), Some("merged into `doc_cfg`"), 138907),
+    (removed, doc_auto_cfg, "CURRENT_RUSTC_VERSION", Some(43781), Some("merged into `doc_cfg`"), 138907),
     /// Allows `#[doc(cfg_hide(...))]`.
-    (removed, doc_cfg_hide, "1.57.0", Some(43781), Some("merged into `doc_cfg`"), 138907),
+    (removed, doc_cfg_hide, "CURRENT_RUSTC_VERSION", Some(43781), Some("merged into `doc_cfg`"), 138907),
     /// Allows using `#[doc(keyword = "...")]`.
     (removed, doc_keyword, "1.58.0", Some(51315),
      Some("merged into `#![feature(rustdoc_internals)]`"), 90420),


### PR DESCRIPTION
Tracking issue: https://github.com/rust-lang/rust/issues/43781

The `doc_auto_cfg` and `doc_cfg_hide` features were removed in a recent nightly (by https://github.com/rust-lang/rust/pull/138907).
I believe that the rustc version numbers at which the features were declared to be removed were incorrect, however, and should both be "1.92" (±1). As evidence in favour of this, the error we get from using this was:

```text
error[E0557]: feature has been removed
  --> src/lib.rs:22:29
   |
22 | #![cfg_attr(docsrs, feature(doc_auto_cfg))]
   |                             ^^^^^^^^^^^^ feature has been removed
   |
   = note: removed in 1.58.0; see <https://github.com/rust-lang/rust/pull/138907> for more information
   = note: merged into `doc_cfg`
```

Note especially the "removed in 1.58" claim. Further evidence is found in the comment further up this file: https://github.com/rust-lang/rust/blob/4ffeda10e10d4fa0c8edbd0dd9642d8ae7d3e66e/compiler/rustc_feature/src/removed.rs#L49-L53

I've chosen 1.92 as that was the milestone which https://github.com/rust-lang/rust/pull/138907 was added to.

cc @GuillaumeGomez 

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
