### PR TITLE
-Zfused-futures

### DIFF
--- a/compiler/rustc_abi/src/layout/ty.rs
+++ b/compiler/rustc_abi/src/layout/ty.rs
@@ -65,6 +65,14 @@ rustc_index::newtype_index! {
         const FIRST_VARIANT = 0;
     }
 }
+
+impl VariantIdx {
+    /// The second variant, at index 1.
+    ///
+    /// For use alongside [`VariantIdx::ZERO`].
+    pub const ONE: VariantIdx = VariantIdx::from_u32(1);
+}
+
 #[derive(Copy, Clone, PartialEq, Eq, Hash, HashStable_Generic)]
 #[rustc_pass_by_value]
 pub struct Layout<'a>(pub Interned<'a, LayoutData<FieldIdx, VariantIdx>>);

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -2336,6 +2336,8 @@ options! {
         "replace returns with jumps to `__x86_return_thunk` (default: `keep`)"),
     function_sections: Option<bool> = (None, parse_opt_bool, [TRACKED],
         "whether each function should go in its own section"),
+    fused_futures: bool = (false, parse_bool, [TRACKED],
+        "make compiler-generated futures return `Poll::Pending` and not `panic!` when polled after completion"),
     future_incompat_test: bool = (false, parse_bool, [UNTRACKED],
         "forces all lints to be future incompatible, used for internal testing (default: no)"),
     graphviz_dark_mode: bool = (false, parse_bool, [UNTRACKED],

--- a/tests/mir-opt/fused_futures.future-{closure#0}.coroutine_resume.0.panic-abort.mir
+++ b/tests/mir-opt/fused_futures.future-{closure#0}.coroutine_resume.0.panic-abort.mir
@@ -1,0 +1,46 @@
+// MIR for `future::{closure#0}` 0 coroutine_resume
+/* coroutine_layout = CoroutineLayout {
+    field_tys: {},
+    variant_fields: {
+        Unresumed(0): [],
+        Returned (1): [],
+        Panicked (2): [],
+    },
+    storage_conflicts: BitMatrix(0x0) {},
+} */
+
+fn future::{closure#0}(_1: Pin<&mut {async fn body of future()}>, _2: &mut Context<'_>) -> Poll<u32> {
+    debug _task_context => _2;
+    let mut _0: std::task::Poll<u32>;
+    let mut _3: u32;
+    let mut _4: u32;
+
+    bb0: {
+        _4 = discriminant((*(_1.0: &mut {async fn body of future()})));
+        switchInt(move _4) -> [0: bb1, 1: bb4, otherwise: bb5];
+    }
+
+    bb1: {
+        _3 = const 42_u32;
+        goto -> bb3;
+    }
+
+    bb2: {
+        _0 = Poll::<u32>::Ready(move _3);
+        discriminant((*(_1.0: &mut {async fn body of future()}))) = 1;
+        return;
+    }
+
+    bb3: {
+        goto -> bb2;
+    }
+
+    bb4: {
+        _0 = Poll::<u32>::Pending;
+        return;
+    }
+
+    bb5: {
+        unreachable;
+    }
+}

--- a/tests/mir-opt/fused_futures.future-{closure#0}.coroutine_resume.0.panic-unwind.mir
+++ b/tests/mir-opt/fused_futures.future-{closure#0}.coroutine_resume.0.panic-unwind.mir
@@ -1,0 +1,46 @@
+// MIR for `future::{closure#0}` 0 coroutine_resume
+/* coroutine_layout = CoroutineLayout {
+    field_tys: {},
+    variant_fields: {
+        Unresumed(0): [],
+        Returned (1): [],
+        Panicked (2): [],
+    },
+    storage_conflicts: BitMatrix(0x0) {},
+} */
+
+fn future::{closure#0}(_1: Pin<&mut {async fn body of future()}>, _2: &mut Context<'_>) -> Poll<u32> {
+    debug _task_context => _2;
+    let mut _0: std::task::Poll<u32>;
+    let mut _3: u32;
+    let mut _4: u32;
+
+    bb0: {
+        _4 = discriminant((*(_1.0: &mut {async fn body of future()})));
+        switchInt(move _4) -> [0: bb1, 1: bb4, otherwise: bb5];
+    }
+
+    bb1: {
+        _3 = const 42_u32;
+        goto -> bb3;
+    }
+
+    bb2: {
+        _0 = Poll::<u32>::Ready(move _3);
+        discriminant((*(_1.0: &mut {async fn body of future()}))) = 1;
+        return;
+    }
+
+    bb3: {
+        goto -> bb2;
+    }
+
+    bb4: {
+        _0 = Poll::<u32>::Pending;
+        return;
+    }
+
+    bb5: {
+        unreachable;
+    }
+}

--- a/tests/mir-opt/fused_futures.main-{closure#0}.coroutine_resume.0.panic-abort.mir
+++ b/tests/mir-opt/fused_futures.main-{closure#0}.coroutine_resume.0.panic-abort.mir
@@ -1,0 +1,66 @@
+// MIR for `main::{closure#0}` 0 coroutine_resume
+/* coroutine_layout = CoroutineLayout {
+    field_tys: {},
+    variant_fields: {
+        Unresumed(0): [],
+        Returned (1): [],
+        Panicked (2): [],
+        Suspend0 (3): [],
+    },
+    storage_conflicts: BitMatrix(0x0) {},
+} */
+
+fn main::{closure#0}(_1: Pin<&mut {coroutine@$DIR/fused_futures.rs:17:5: 17:7}>, _2: ()) -> CoroutineState<i32, &str> {
+    let mut _0: std::ops::CoroutineState<i32, &str>;
+    let mut _3: !;
+    let _4: ();
+    let mut _5: &str;
+    let mut _6: u32;
+
+    bb0: {
+        _6 = discriminant((*(_1.0: &mut {coroutine@$DIR/fused_futures.rs:17:5: 17:7})));
+        switchInt(move _6) -> [0: bb1, 1: bb6, 3: bb5, otherwise: bb7];
+    }
+
+    bb1: {
+        StorageLive(_4);
+        _0 = CoroutineState::<i32, &str>::Yielded(const 1_i32);
+        StorageDead(_4);
+        discriminant((*(_1.0: &mut {coroutine@$DIR/fused_futures.rs:17:5: 17:7}))) = 3;
+        return;
+    }
+
+    bb2: {
+        StorageDead(_4);
+        _5 = const "foo";
+        goto -> bb4;
+    }
+
+    bb3: {
+        _0 = CoroutineState::<i32, &str>::Complete(move _5);
+        discriminant((*(_1.0: &mut {coroutine@$DIR/fused_futures.rs:17:5: 17:7}))) = 1;
+        return;
+    }
+
+    bb4: {
+        goto -> bb3;
+    }
+
+    bb5: {
+        StorageLive(_4);
+        _4 = move _2;
+        goto -> bb2;
+    }
+
+    bb6: {
+        assert(const false, "coroutine resumed after completion") -> [success: bb6, unwind unreachable];
+    }
+
+    bb7: {
+        unreachable;
+    }
+}
+
+ALLOC0 (size: 3, align: 1) {
+    66 6f 6f                                        │ foo
+}

--- a/tests/mir-opt/fused_futures.main-{closure#0}.coroutine_resume.0.panic-unwind.mir
+++ b/tests/mir-opt/fused_futures.main-{closure#0}.coroutine_resume.0.panic-unwind.mir
@@ -1,0 +1,66 @@
+// MIR for `main::{closure#0}` 0 coroutine_resume
+/* coroutine_layout = CoroutineLayout {
+    field_tys: {},
+    variant_fields: {
+        Unresumed(0): [],
+        Returned (1): [],
+        Panicked (2): [],
+        Suspend0 (3): [],
+    },
+    storage_conflicts: BitMatrix(0x0) {},
+} */
+
+fn main::{closure#0}(_1: Pin<&mut {coroutine@$DIR/fused_futures.rs:17:5: 17:7}>, _2: ()) -> CoroutineState<i32, &str> {
+    let mut _0: std::ops::CoroutineState<i32, &str>;
+    let mut _3: !;
+    let _4: ();
+    let mut _5: &str;
+    let mut _6: u32;
+
+    bb0: {
+        _6 = discriminant((*(_1.0: &mut {coroutine@$DIR/fused_futures.rs:17:5: 17:7})));
+        switchInt(move _6) -> [0: bb1, 1: bb6, 3: bb5, otherwise: bb7];
+    }
+
+    bb1: {
+        StorageLive(_4);
+        _0 = CoroutineState::<i32, &str>::Yielded(const 1_i32);
+        StorageDead(_4);
+        discriminant((*(_1.0: &mut {coroutine@$DIR/fused_futures.rs:17:5: 17:7}))) = 3;
+        return;
+    }
+
+    bb2: {
+        StorageDead(_4);
+        _5 = const "foo";
+        goto -> bb4;
+    }
+
+    bb3: {
+        _0 = CoroutineState::<i32, &str>::Complete(move _5);
+        discriminant((*(_1.0: &mut {coroutine@$DIR/fused_futures.rs:17:5: 17:7}))) = 1;
+        return;
+    }
+
+    bb4: {
+        goto -> bb3;
+    }
+
+    bb5: {
+        StorageLive(_4);
+        _4 = move _2;
+        goto -> bb2;
+    }
+
+    bb6: {
+        assert(const false, "coroutine resumed after completion") -> [success: bb6, unwind continue];
+    }
+
+    bb7: {
+        unreachable;
+    }
+}
+
+ALLOC0 (size: 3, align: 1) {
+    66 6f 6f                                        │ foo
+}

--- a/tests/mir-opt/fused_futures.rs
+++ b/tests/mir-opt/fused_futures.rs
@@ -1,0 +1,21 @@
+//@ edition:2024
+//@ compile-flags: -Zfused-futures
+// skip-filecheck
+// EMIT_MIR_FOR_EACH_PANIC_STRATEGY
+
+#![feature(coroutines, stmt_expr_attributes)]
+#![allow(unused)]
+
+// EMIT_MIR fused_futures.future-{closure#0}.coroutine_resume.0.mir
+pub async fn future() -> u32 {
+    42
+}
+
+// EMIT_MIR fused_futures.main-{closure#0}.coroutine_resume.0.mir
+fn main() {
+    let mut coroutine = #[coroutine]
+    || {
+        yield 1;
+        return "foo";
+    };
+}

--- a/tests/ui/coroutine/fused-futures.rs
+++ b/tests/ui/coroutine/fused-futures.rs
@@ -1,0 +1,21 @@
+//@ run-pass
+//@ edition: 2024
+//@ compile-flags: -Zfused-futures
+
+use std::pin::pin;
+use std::task::{Context, Poll, Waker};
+
+async fn foo() -> u8 {
+    12
+}
+
+const N: usize = 10;
+
+fn main() {
+    let cx = &mut Context::from_waker(Waker::noop());
+    let mut x = pin!(foo());
+    assert_eq!(x.as_mut().poll(cx), Poll::Ready(12));
+    for _ in 0..N {
+        assert_eq!(x.as_mut().poll(cx), Poll::Pending);
+    }
+}


### PR DESCRIPTION
Fixes (kinda) rust-lang/rust#147041

Introduces `-Zfused-futures`, a flag that makes compiler-generated futures return `Poll::Pending` instead of panicking when polled after completion.