### PR TITLE
Add warn-by-default lint for visibility on `const _` declarations

### DIFF
--- a/compiler/rustc_ast_passes/src/ast_validation.rs
+++ b/compiler/rustc_ast_passes/src/ast_validation.rs
@@ -1349,6 +1349,7 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                 }
                 if ident.name == kw::Underscore
                     && !matches!(item.vis.kind, VisibilityKind::Inherited)
+                    && ident.span.eq_ctxt(item.vis.span)
                 {
                     self.lint_buffer.buffer_lint(
                         UNUSED_VISIBILITIES,

--- a/compiler/rustc_ast_passes/src/ast_validation.rs
+++ b/compiler/rustc_ast_passes/src/ast_validation.rs
@@ -33,7 +33,7 @@ use rustc_session::Session;
 use rustc_session::lint::BuiltinLintDiag;
 use rustc_session::lint::builtin::{
     DEPRECATED_WHERE_CLAUSE_LOCATION, MISSING_ABI, MISSING_UNSAFE_ON_EXTERN,
-    PATTERNS_IN_FNS_WITHOUT_BODY,
+    PATTERNS_IN_FNS_WITHOUT_BODY, UNUSED_VISIBILITIES,
 };
 use rustc_session::parse::feature_err;
 use rustc_span::{Ident, Span, kw, sym};
@@ -1339,7 +1339,7 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                     }
                 });
             }
-            ItemKind::Const(box ConstItem { defaultness, rhs, .. }) => {
+            ItemKind::Const(box ConstItem { defaultness, ident, rhs, .. }) => {
                 self.check_defaultness(item.span, *defaultness);
                 if rhs.is_none() {
                     self.dcx().emit_err(errors::ConstWithoutBody {
@@ -1347,6 +1347,17 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                         replace_span: self.ending_semi_or_hi(item.span),
                     });
                 }
+                if ident.name == kw::Underscore
+                    && !matches!(item.vis.kind, VisibilityKind::Inherited)
+                {
+                    self.lint_buffer.buffer_lint(
+                        UNUSED_VISIBILITIES,
+                        item.id,
+                        item.vis.span,
+                        BuiltinLintDiag::UnusedVisibility(item.vis.span),
+                    )
+                }
+
                 visit::walk_item(self, item);
             }
             ItemKind::Static(box StaticItem { expr, safety, .. }) => {

--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -979,7 +979,7 @@ lint_unused_op = unused {$op} that must be used
 lint_unused_result = unused result of type `{$ty}`
 
 lint_unused_visibilities = visibility qualifiers have no effect on `const _` declarations
-    .note = there is no declared name for the qualifier to affect
+    .note = `const _` does not declare a name, so there is nothing for the qualifier to apply to
     .suggestion = remove the qualifier
 
 lint_use_let_underscore_ignore_suggestion = use `let _ = ...` to ignore the expression or result

--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -979,6 +979,7 @@ lint_unused_op = unused {$op} that must be used
 lint_unused_result = unused result of type `{$ty}`
 
 lint_unused_visibilities = visibility qualifiers have no effect on `const _` declarations
+    .note = there is no declared name for the qualifier to affect
     .suggestion = remove the qualifier
 
 lint_use_let_underscore_ignore_suggestion = use `let _ = ...` to ignore the expression or result

--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -978,6 +978,9 @@ lint_unused_op = unused {$op} that must be used
 
 lint_unused_result = unused result of type `{$ty}`
 
+lint_unused_visibilities = visibility qualifiers have no effect on `const _` declarations
+    .suggestion = remove the qualifier
+
 lint_use_let_underscore_ignore_suggestion = use `let _ = ...` to ignore the expression or result
 
 lint_useless_ptr_null_checks_fn_ptr = function pointers are not nullable, so checking them for null will always return false

--- a/compiler/rustc_lint/src/early/diagnostics.rs
+++ b/compiler/rustc_lint/src/early/diagnostics.rs
@@ -302,6 +302,9 @@ pub fn decorate_builtin_lint(
         BuiltinLintDiag::UnusedCrateDependency { extern_crate, local_crate } => {
             lints::UnusedCrateDependency { extern_crate, local_crate }.decorate_lint(diag)
         }
+        BuiltinLintDiag::UnusedVisibility(span) => {
+            lints::UnusedVisibility { span }.decorate_lint(diag)
+        }
         BuiltinLintDiag::AttributeLint(kind) => decorate_attribute_lint(sess, tcx, &kind, diag),
     }
 }

--- a/compiler/rustc_lint/src/lib.rs
+++ b/compiler/rustc_lint/src/lib.rs
@@ -291,6 +291,7 @@ fn register_builtins(store: &mut LintStore) {
         "unused",
         UNUSED_IMPORTS,
         UNUSED_VARIABLES,
+        UNUSED_VISIBILITIES,
         UNUSED_ASSIGNMENTS,
         DEAD_CODE,
         UNUSED_MUT,

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -3191,3 +3191,10 @@ pub(crate) struct UnsafeAttrOutsideUnsafeSuggestion {
     #[suggestion_part(code = ")")]
     pub right: Span,
 }
+
+#[derive(LintDiagnostic)]
+#[diag(lint_unused_visibilities)]
+pub(crate) struct UnusedVisibility {
+    #[suggestion(style = "short", code = "", applicability = "machine-applicable")]
+    pub span: Span,
+}

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -3194,6 +3194,7 @@ pub(crate) struct UnsafeAttrOutsideUnsafeSuggestion {
 
 #[derive(LintDiagnostic)]
 #[diag(lint_unused_visibilities)]
+#[note]
 pub(crate) struct UnusedVisibility {
     #[suggestion(style = "short", code = "", applicability = "machine-applicable")]
     pub span: Span,

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -143,6 +143,7 @@ declare_lint_pass! {
         UNUSED_QUALIFICATIONS,
         UNUSED_UNSAFE,
         UNUSED_VARIABLES,
+        UNUSED_VISIBILITIES,
         USELESS_DEPRECATED,
         VARARGS_WITHOUT_PATTERN,
         WARNINGS,
@@ -691,6 +692,26 @@ declare_lint! {
     pub UNUSED_VARIABLES,
     Warn,
     "detect variables which are not used in any way"
+}
+
+declare_lint! {
+    /// The `unused_visibilities` lint detects visibility qualifiers (like `pub`)
+    /// on a `const _` item.
+    ///
+    /// ### Example
+    ///
+    /// ```rust
+    /// pub const _: () = {};
+    /// ```
+    ///
+    /// {{produces}}
+    ///
+    /// ### Explanation
+    ///
+    /// These qualifiers have no effect.
+    pub UNUSED_VISIBILITIES,
+    Warn,
+    "detect visibility qualifiers on `const _` items"
 }
 
 declare_lint! {

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -708,7 +708,7 @@ declare_lint! {
     ///
     /// ### Explanation
     ///
-    /// These qualifiers have no effect.
+    /// These qualifiers have no effect, as `const _` items are unnameable.
     pub UNUSED_VISIBILITIES,
     Warn,
     "detect visibility qualifiers on `const _` items"

--- a/compiler/rustc_lint_defs/src/lib.rs
+++ b/compiler/rustc_lint_defs/src/lib.rs
@@ -696,6 +696,7 @@ pub enum BuiltinLintDiag {
         extern_crate: Symbol,
         local_crate: Symbol,
     },
+    UnusedVisibility(Span),
     AttributeLint(AttributeLintKind),
 }
 

--- a/src/tools/clippy/tests/ui-toml/absolute_paths/absolute_paths.no_short.stderr
+++ b/src/tools/clippy/tests/ui-toml/absolute_paths/absolute_paths.no_short.stderr
@@ -71,10 +71,10 @@ LL |         impl<T: core::cmp::Eq> core::fmt::Display for X<T>
    |                                ^^^^^^^^^^^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
-  --> tests/ui-toml/absolute_paths/absolute_paths.rs:113:14
+  --> tests/ui-toml/absolute_paths/absolute_paths.rs:113:10
    |
-LL | pub const _: crate::S = {
-   |              ^^^^^^^^
+LL | const _: crate::S = {
+   |          ^^^^^^^^
 
 error: consider bringing this path into scope with the `use` keyword
   --> tests/ui-toml/absolute_paths/absolute_paths.rs:114:9

--- a/src/tools/clippy/tests/ui-toml/absolute_paths/absolute_paths.rs
+++ b/src/tools/clippy/tests/ui-toml/absolute_paths/absolute_paths.rs
@@ -110,7 +110,7 @@ mod m1 {
 }
 
 //~[no_short]v absolute_paths
-pub const _: crate::S = {
+const _: crate::S = {
     let crate::S = m1::S; //~[no_short] absolute_paths
 
     crate::m1::S

--- a/tests/ui/consts/promoted_const_call3.rs
+++ b/tests/ui/consts/promoted_const_call3.rs
@@ -4,12 +4,12 @@ pub const C: () = {
     //~^ ERROR: destructor of `String` cannot be evaluated at compile-time
 };
 
-pub const _: () = {
+const _: () = {
     let _: &'static _ = &id(&String::new());
     //~^ ERROR: destructor of `String` cannot be evaluated at compile-time
 };
 
-pub const _: () = {
+const _: () = {
     let _: &'static _ = &std::mem::ManuallyDrop::new(String::new());
     //~^ ERROR: temporary value dropped while borrowed
 };

--- a/tests/ui/consts/ptr_is_null.rs
+++ b/tests/ui/consts/ptr_is_null.rs
@@ -5,12 +5,12 @@
 
 const FOO: &usize = &42;
 
-pub const _: () = assert!(!(FOO as *const usize).is_null());
+const _: () = assert!(!(FOO as *const usize).is_null());
 
-pub const _: () = assert!(!(42 as *const usize).is_null());
+const _: () = assert!(!(42 as *const usize).is_null());
 
-pub const _: () = assert!((0 as *const usize).is_null());
+const _: () = assert!((0 as *const usize).is_null());
 
-pub const _: () = assert!(std::ptr::null::<usize>().is_null());
+const _: () = assert!(std::ptr::null::<usize>().is_null());
 
-pub const _: () = assert!(!("foo" as *const str).is_null());
+const _: () = assert!(!("foo" as *const str).is_null());

--- a/tests/ui/lint/issue-70819-dont-override-forbid-in-same-scope.stderr
+++ b/tests/ui/lint/issue-70819-dont-override-forbid-in-same-scope.stderr
@@ -413,3 +413,21 @@ note: the lint level is defined here
 LL | #![forbid(forbidden_lint_groups)]
    |           ^^^^^^^^^^^^^^^^^^^^^
 
+Future breakage diagnostic:
+error: warn(unused) incompatible with previous forbid
+  --> $DIR/issue-70819-dont-override-forbid-in-same-scope.rs:22:13
+   |
+LL |     #![forbid(unused)]
+   |               ------ `forbid` level set here
+LL |     #![deny(unused)]
+LL |     #![warn(unused)]
+   |             ^^^^^^ overruled by previous forbid
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #81670 <https://github.com/rust-lang/rust/issues/81670>
+note: the lint level is defined here
+  --> $DIR/issue-70819-dont-override-forbid-in-same-scope.rs:17:11
+   |
+LL | #![forbid(forbidden_lint_groups)]
+   |           ^^^^^^^^^^^^^^^^^^^^^
+

--- a/tests/ui/lint/outer-forbid.stderr
+++ b/tests/ui/lint/outer-forbid.stderr
@@ -453,3 +453,21 @@ note: the lint level is defined here
 LL | #![forbid(forbidden_lint_groups)]
    |           ^^^^^^^^^^^^^^^^^^^^^
 
+Future breakage diagnostic:
+error: allow(unused) incompatible with previous forbid
+  --> $DIR/outer-forbid.rs:25:9
+   |
+LL | #![forbid(unused, non_snake_case)]
+   |           ------ `forbid` level set here
+...
+LL | #[allow(unused)]
+   |         ^^^^^^ overruled by previous forbid
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #81670 <https://github.com/rust-lang/rust/issues/81670>
+note: the lint level is defined here
+  --> $DIR/outer-forbid.rs:18:11
+   |
+LL | #![forbid(forbidden_lint_groups)]
+   |           ^^^^^^^^^^^^^^^^^^^^^
+

--- a/tests/ui/lint/unused-visibilities.fixed
+++ b/tests/ui/lint/unused-visibilities.fixed
@@ -9,4 +9,21 @@
  const _: () = {};
 //~^WARN visibility qualifiers have no effect on `const _` declarations
 
+macro_rules! foo {
+    () => {
+         const _: () = {};
+        //~^WARN visibility qualifiers have no effect on `const _` declarations
+    };
+}
+
+foo!();
+
+macro_rules! bar {
+    ($tt:tt) => {
+        pub const $tt: () = {};
+    };
+}
+
+bar!(_);
+
 fn main() {}

--- a/tests/ui/lint/unused-visibilities.fixed
+++ b/tests/ui/lint/unused-visibilities.fixed
@@ -1,0 +1,12 @@
+//@ check-pass
+//@ run-rustfix
+
+#![warn(unused_visibilities)]
+
+ const _: () = {};
+//~^WARN visibility qualifiers have no effect on `const _` declarations
+
+ const _: () = {};
+//~^WARN visibility qualifiers have no effect on `const _` declarations
+
+fn main() {}

--- a/tests/ui/lint/unused-visibilities.rs
+++ b/tests/ui/lint/unused-visibilities.rs
@@ -1,0 +1,12 @@
+//@ check-pass
+//@ run-rustfix
+
+#![warn(unused_visibilities)]
+
+pub const _: () = {};
+//~^WARN visibility qualifiers have no effect on `const _` declarations
+
+pub(self) const _: () = {};
+//~^WARN visibility qualifiers have no effect on `const _` declarations
+
+fn main() {}

--- a/tests/ui/lint/unused-visibilities.rs
+++ b/tests/ui/lint/unused-visibilities.rs
@@ -9,4 +9,21 @@ pub const _: () = {};
 pub(self) const _: () = {};
 //~^WARN visibility qualifiers have no effect on `const _` declarations
 
+macro_rules! foo {
+    () => {
+        pub const _: () = {};
+        //~^WARN visibility qualifiers have no effect on `const _` declarations
+    };
+}
+
+foo!();
+
+macro_rules! bar {
+    ($tt:tt) => {
+        pub const $tt: () = {};
+    };
+}
+
+bar!(_);
+
 fn main() {}

--- a/tests/ui/lint/unused-visibilities.stderr
+++ b/tests/ui/lint/unused-visibilities.stderr
@@ -4,6 +4,7 @@ warning: visibility qualifiers have no effect on `const _` declarations
 LL | pub const _: () = {};
    | ^^^ help: remove the qualifier
    |
+   = note: there is no declared name for the qualifier to affect
 note: the lint level is defined here
   --> $DIR/unused-visibilities.rs:4:9
    |
@@ -15,6 +16,8 @@ warning: visibility qualifiers have no effect on `const _` declarations
    |
 LL | pub(self) const _: () = {};
    | ^^^^^^^^^ help: remove the qualifier
+   |
+   = note: there is no declared name for the qualifier to affect
 
 warning: visibility qualifiers have no effect on `const _` declarations
   --> $DIR/unused-visibilities.rs:14:9
@@ -25,6 +28,7 @@ LL |         pub const _: () = {};
 LL | foo!();
    | ------ in this macro invocation
    |
+   = note: there is no declared name for the qualifier to affect
    = note: this warning originates in the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: 3 warnings emitted

--- a/tests/ui/lint/unused-visibilities.stderr
+++ b/tests/ui/lint/unused-visibilities.stderr
@@ -4,7 +4,7 @@ warning: visibility qualifiers have no effect on `const _` declarations
 LL | pub const _: () = {};
    | ^^^ help: remove the qualifier
    |
-   = note: there is no declared name for the qualifier to affect
+   = note: `const _` does not declare a name, so there is nothing for the qualifier to apply to
 note: the lint level is defined here
   --> $DIR/unused-visibilities.rs:4:9
    |
@@ -17,7 +17,7 @@ warning: visibility qualifiers have no effect on `const _` declarations
 LL | pub(self) const _: () = {};
    | ^^^^^^^^^ help: remove the qualifier
    |
-   = note: there is no declared name for the qualifier to affect
+   = note: `const _` does not declare a name, so there is nothing for the qualifier to apply to
 
 warning: visibility qualifiers have no effect on `const _` declarations
   --> $DIR/unused-visibilities.rs:14:9
@@ -28,7 +28,7 @@ LL |         pub const _: () = {};
 LL | foo!();
    | ------ in this macro invocation
    |
-   = note: there is no declared name for the qualifier to affect
+   = note: `const _` does not declare a name, so there is nothing for the qualifier to apply to
    = note: this warning originates in the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: 3 warnings emitted

--- a/tests/ui/lint/unused-visibilities.stderr
+++ b/tests/ui/lint/unused-visibilities.stderr
@@ -1,0 +1,20 @@
+warning: visibility qualifiers have no effect on `const _` declarations
+  --> $DIR/unused-visibilities.rs:6:1
+   |
+LL | pub const _: () = {};
+   | ^^^ help: remove the qualifier
+   |
+note: the lint level is defined here
+  --> $DIR/unused-visibilities.rs:4:9
+   |
+LL | #![warn(unused_visibilities)]
+   |         ^^^^^^^^^^^^^^^^^^^
+
+warning: visibility qualifiers have no effect on `const _` declarations
+  --> $DIR/unused-visibilities.rs:9:1
+   |
+LL | pub(self) const _: () = {};
+   | ^^^^^^^^^ help: remove the qualifier
+
+warning: 2 warnings emitted
+

--- a/tests/ui/lint/unused-visibilities.stderr
+++ b/tests/ui/lint/unused-visibilities.stderr
@@ -16,5 +16,16 @@ warning: visibility qualifiers have no effect on `const _` declarations
 LL | pub(self) const _: () = {};
    | ^^^^^^^^^ help: remove the qualifier
 
-warning: 2 warnings emitted
+warning: visibility qualifiers have no effect on `const _` declarations
+  --> $DIR/unused-visibilities.rs:14:9
+   |
+LL |         pub const _: () = {};
+   |         ^^^ help: remove the qualifier
+...
+LL | foo!();
+   | ------ in this macro invocation
+   |
+   = note: this warning originates in the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+warning: 3 warnings emitted
 

--- a/tests/ui/traits/const-traits/call.rs
+++ b/tests/ui/traits/const-traits/call.rs
@@ -3,7 +3,7 @@
 #![feature(const_closures, const_trait_impl)]
 #![allow(incomplete_features)]
 
-pub const _: () = {
+const _: () = {
     assert!((const || true)());
     //~^ ERROR }: [const] Fn()` is not satisfied
 };


### PR DESCRIPTION
Add a warn-by-default `unused_visibilities` lint for visibility qualifiers on `const _` declarations—e.g. `pub const _: () = ();`. Such qualifiers have no effect.

A [Sourcegraph search](https://sourcegraph.com/search?q=context:global+lang:Rust+pub%5Cs*%28%5C%28.*%5C%29%29%3F%5Cs*const%5Cs%2B_%5Cs*:&patternType=regexp&case=yes&sm=0) suggests that this pattern is relatively rare, and mostly found in tests (with only 3 exceptions). So perhaps this could become an FCW/hard error in the future.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

@rustbot label T-lang A-lints A-visibility -T-clippy