### PR TITLE
Mention crate being analyzed in query description

### DIFF
--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -397,7 +397,10 @@ rustc_queries! {
     /// The root query triggering all analysis passes like typeck or borrowck.
     query analysis(key: ()) {
         eval_always
-        desc { "running analysis passes on this crate" }
+        desc { |tcx|
+            "running analysis passes on crate `{}`",
+            tcx.crate_name(LOCAL_CRATE),
+        }
     }
 
     /// This query checks the fulfillment of collected lint expectations.

--- a/tests/ui/associated-consts/issue-24949-assoc-const-static-recursion-trait.stderr
+++ b/tests/ui/associated-consts/issue-24949-assoc-const-static-recursion-trait.stderr
@@ -30,7 +30,7 @@ note: ...which requires elaborating drops for `<impl at $DIR/issue-24949-assoc-c
 LL |     const BAR: u32 = TRAIT_REF_BAR;
    |                      ^^^^^^^^^^^^^
    = note: ...which again requires simplifying constant for the type system `TRAIT_REF_BAR`, completing the cycle
-   = note: cycle used when running analysis passes on this crate
+   = note: cycle used when running analysis passes on crate `issue_24949_assoc_const_static_recursion_trait`
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
 error: aborting due to 1 previous error

--- a/tests/ui/consts/const-eval/const-eval-query-stack.stderr
+++ b/tests/ui/consts/const-eval/const-eval-query-stack.stderr
@@ -10,5 +10,5 @@ note: please make sure that you have updated to the latest nightly
 query stack during panic:
 #0 [eval_to_allocation_raw] const-evaluating + checking `X`
 #1 [eval_to_const_value_raw] simplifying constant for the type system `X`
-#2 [analysis] running analysis passes on this crate
+#2 [analysis] running analysis passes on crate `const_eval_query_stack`
 end of query stack

--- a/tests/ui/consts/recursive-zst-static.default.stderr
+++ b/tests/ui/consts/recursive-zst-static.default.stderr
@@ -16,7 +16,7 @@ note: ...which requires evaluating initializer of static `B`...
 LL | static B: () = A;
    | ^^^^^^^^^^^^
    = note: ...which again requires evaluating initializer of static `A`, completing the cycle
-   = note: cycle used when running analysis passes on this crate
+   = note: cycle used when running analysis passes on crate `recursive_zst_static`
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
 error: aborting due to 2 previous errors

--- a/tests/ui/consts/recursive-zst-static.unleash.stderr
+++ b/tests/ui/consts/recursive-zst-static.unleash.stderr
@@ -16,7 +16,7 @@ note: ...which requires evaluating initializer of static `B`...
 LL | static B: () = A;
    | ^^^^^^^^^^^^
    = note: ...which again requires evaluating initializer of static `A`, completing the cycle
-   = note: cycle used when running analysis passes on this crate
+   = note: cycle used when running analysis passes on crate `recursive_zst_static`
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
 error: aborting due to 2 previous errors

--- a/tests/ui/track-diagnostics/track.stderr
+++ b/tests/ui/track-diagnostics/track.stderr
@@ -41,7 +41,7 @@ note: compiler flags: ... -Z ui-testing ... -Z track-diagnostics
 
 query stack during panic:
 #0 [typeck] type-checking `main`
-#1 [analysis] running analysis passes on this crate
+#1 [analysis] running analysis passes on crate `track`
 end of query stack
 error: aborting due to 3 previous errors
 

--- a/tests/ui/treat-err-as-bug/err.stderr
+++ b/tests/ui/treat-err-as-bug/err.stderr
@@ -9,5 +9,5 @@ error: the compiler unexpectedly panicked. this is a bug.
 
 query stack during panic:
 #0 [eval_static_initializer] evaluating initializer of static `C`
-#1 [analysis] running analysis passes on this crate
+#1 [analysis] running analysis passes on crate `err`
 end of query stack


### PR DESCRIPTION
"running analysis passes on this crate" -> "running analysis passes on crate `foo`"

This message is displayed in cycle errors in particular, and in some cases without any spans or any other identifiable information to determine which dependency introduced the cycle.

Address rust-lang/rust#74380, but we still need a test for that case in particular.