### PR TITLE
Make replacement suggestion `_` in type verbose

### DIFF
--- a/compiler/rustc_hir_analysis/src/collect.rs
+++ b/compiler/rustc_hir_analysis/src/collect.rs
@@ -1140,7 +1140,7 @@ fn recover_infer_ret_ty<'tcx>(
     // recursive function definition to leak out into the fn sig.
     let mut recovered_ret_ty = None;
     if let Some(suggestable_ret_ty) = ret_ty.make_suggestable(tcx, false, None) {
-        diag.span_suggestion(
+        diag.span_suggestion_verbose(
             infer_ret_ty.span,
             "replace with the correct return type",
             suggestable_ret_ty,
@@ -1152,7 +1152,7 @@ fn recover_infer_ret_ty<'tcx>(
         tcx.param_env(def_id),
         ret_ty,
     ) {
-        diag.span_suggestion(
+        diag.span_suggestion_verbose(
             infer_ret_ty.span,
             "replace with an appropriate return type",
             sugg,

--- a/tests/ui/const-generics/generic_arg_infer/in-signature.stderr
+++ b/tests/ui/const-generics/generic_arg_infer/in-signature.stderr
@@ -2,29 +2,39 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
   --> $DIR/in-signature.rs:6:21
    |
 LL | fn arr_fn() -> [u8; _] {
-   |                -----^-
-   |                |    |
-   |                |    not allowed in type signatures
-   |                help: replace with the correct return type: `[u8; 3]`
+   |                     ^ not allowed in type signatures
+   |
+help: replace with the correct return type
+   |
+LL - fn arr_fn() -> [u8; _] {
+LL + fn arr_fn() -> [u8; 3] {
+   |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
   --> $DIR/in-signature.rs:11:24
    |
 LL | fn ty_fn() -> Bar<i32, _> {
-   |               ---------^-
-   |               |        |
-   |               |        not allowed in type signatures
-   |               help: replace with the correct return type: `Bar<i32, 3>`
+   |                        ^ not allowed in type signatures
+   |
+help: replace with the correct return type
+   |
+LL - fn ty_fn() -> Bar<i32, _> {
+LL + fn ty_fn() -> Bar<i32, 3> {
+   |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
   --> $DIR/in-signature.rs:16:25
    |
 LL | fn ty_fn_mixed() -> Bar<_, _> {
-   |                     ----^--^-
-   |                     |   |  |
-   |                     |   |  not allowed in type signatures
-   |                     |   not allowed in type signatures
-   |                     help: replace with the correct return type: `Bar<i32, 3>`
+   |                         ^  ^ not allowed in type signatures
+   |                         |
+   |                         not allowed in type signatures
+   |
+help: replace with the correct return type
+   |
+LL - fn ty_fn_mixed() -> Bar<_, _> {
+LL + fn ty_fn_mixed() -> Bar<i32, 3> {
+   |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for constants
   --> $DIR/in-signature.rs:21:20

--- a/tests/ui/error-codes/E0121.stderr
+++ b/tests/ui/error-codes/E0121.stderr
@@ -2,10 +2,13 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
   --> $DIR/E0121.rs:1:13
    |
 LL | fn foo() -> _ { 5 }
-   |             ^
-   |             |
-   |             not allowed in type signatures
-   |             help: replace with the correct return type: `i32`
+   |             ^ not allowed in type signatures
+   |
+help: replace with the correct return type
+   |
+LL - fn foo() -> _ { 5 }
+LL + fn foo() -> i32 { 5 }
+   |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for static variables
   --> $DIR/E0121.rs:3:13

--- a/tests/ui/fn/issue-80179.stderr
+++ b/tests/ui/fn/issue-80179.stderr
@@ -2,21 +2,26 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
   --> $DIR/issue-80179.rs:10:24
    |
 LL | fn returns_fn_ptr() -> _ {
-   |                        ^
-   |                        |
-   |                        not allowed in type signatures
-   |                        help: replace with the correct return type: `fn() -> i32`
+   |                        ^ not allowed in type signatures
+   |
+help: replace with the correct return type
+   |
+LL - fn returns_fn_ptr() -> _ {
+LL + fn returns_fn_ptr() -> fn() -> i32 {
+   |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
   --> $DIR/issue-80179.rs:18:25
    |
 LL | fn returns_closure() -> _ {
-   |                         ^
-   |                         |
-   |                         not allowed in type signatures
-   |                         help: replace with an appropriate return type: `impl Fn() -> i32`
+   |                         ^ not allowed in type signatures
    |
    = note: for more information on `Fn` traits and closure types, see https://doc.rust-lang.org/book/ch13-01-closures.html
+help: replace with an appropriate return type
+   |
+LL - fn returns_closure() -> _ {
+LL + fn returns_closure() -> impl Fn() -> i32 {
+   |
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/fn/suggest-return-closure.stderr
+++ b/tests/ui/fn/suggest-return-closure.stderr
@@ -2,34 +2,40 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
   --> $DIR/suggest-return-closure.rs:1:17
    |
 LL | fn fn_once() -> _ {
-   |                 ^
-   |                 |
-   |                 not allowed in type signatures
-   |                 help: replace with an appropriate return type: `impl FnOnce()`
+   |                 ^ not allowed in type signatures
    |
    = note: for more information on `Fn` traits and closure types, see https://doc.rust-lang.org/book/ch13-01-closures.html
+help: replace with an appropriate return type
+   |
+LL - fn fn_once() -> _ {
+LL + fn fn_once() -> impl FnOnce() {
+   |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
   --> $DIR/suggest-return-closure.rs:13:16
    |
 LL | fn fn_mut() -> _ {
-   |                ^
-   |                |
-   |                not allowed in type signatures
-   |                help: replace with an appropriate return type: `impl FnMut(char)`
+   |                ^ not allowed in type signatures
    |
    = note: for more information on `Fn` traits and closure types, see https://doc.rust-lang.org/book/ch13-01-closures.html
+help: replace with an appropriate return type
+   |
+LL - fn fn_mut() -> _ {
+LL + fn fn_mut() -> impl FnMut(char) {
+   |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
   --> $DIR/suggest-return-closure.rs:33:13
    |
 LL | fn fun() -> _ {
-   |             ^
-   |             |
-   |             not allowed in type signatures
-   |             help: replace with an appropriate return type: `impl Fn() -> i32`
+   |             ^ not allowed in type signatures
    |
    = note: for more information on `Fn` traits and closure types, see https://doc.rust-lang.org/book/ch13-01-closures.html
+help: replace with an appropriate return type
+   |
+LL - fn fun() -> _ {
+LL + fn fun() -> impl Fn() -> i32 {
+   |
 
 error[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
   --> $DIR/suggest-return-closure.rs:24:9

--- a/tests/ui/fn/suggest-return-future.stderr
+++ b/tests/ui/fn/suggest-return-future.stderr
@@ -2,19 +2,25 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
   --> $DIR/suggest-return-future.rs:7:13
    |
 LL | fn foo() -> _ {
-   |             ^
-   |             |
-   |             not allowed in type signatures
-   |             help: replace with an appropriate return type: `impl Future<Output = i32>`
+   |             ^ not allowed in type signatures
+   |
+help: replace with an appropriate return type
+   |
+LL - fn foo() -> _ {
+LL + fn foo() -> impl Future<Output = i32> {
+   |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
   --> $DIR/suggest-return-future.rs:15:13
    |
 LL | fn bar() -> _ {
-   |             ^
-   |             |
-   |             not allowed in type signatures
-   |             help: replace with an appropriate return type: `impl Future<Output = i32>`
+   |             ^ not allowed in type signatures
+   |
+help: replace with an appropriate return type
+   |
+LL - fn bar() -> _ {
+LL + fn bar() -> impl Future<Output = i32> {
+   |
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/return/infer-return-ty-for-fn-sig-issue-125488.stderr
+++ b/tests/ui/return/infer-return-ty-for-fn-sig-issue-125488.stderr
@@ -2,37 +2,49 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
   --> $DIR/infer-return-ty-for-fn-sig-issue-125488.rs:8:24
    |
 LL |     fn f1(s: S<'_>) -> _ {
-   |                        ^
-   |                        |
-   |                        not allowed in type signatures
-   |                        help: replace with the correct return type: `S<'_>`
+   |                        ^ not allowed in type signatures
+   |
+help: replace with the correct return type
+   |
+LL -     fn f1(s: S<'_>) -> _ {
+LL +     fn f1(s: S<'_>) -> S<'_> {
+   |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
   --> $DIR/infer-return-ty-for-fn-sig-issue-125488.rs:13:24
    |
 LL |     fn f2(s: S<'_>) -> _ {
-   |                        ^
-   |                        |
-   |                        not allowed in type signatures
-   |                        help: replace with the correct return type: `S<'_>`
+   |                        ^ not allowed in type signatures
+   |
+help: replace with the correct return type
+   |
+LL -     fn f2(s: S<'_>) -> _ {
+LL +     fn f2(s: S<'_>) -> S<'_> {
+   |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
   --> $DIR/infer-return-ty-for-fn-sig-issue-125488.rs:23:24
    |
 LL |     fn f3(s: S<'_>) -> _ {
-   |                        ^
-   |                        |
-   |                        not allowed in type signatures
-   |                        help: replace with the correct return type: `S<'_>`
+   |                        ^ not allowed in type signatures
+   |
+help: replace with the correct return type
+   |
+LL -     fn f3(s: S<'_>) -> _ {
+LL +     fn f3(s: S<'_>) -> S<'_> {
+   |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
   --> $DIR/infer-return-ty-for-fn-sig-issue-125488.rs:28:24
    |
 LL |     fn f4(s: S<'_>) -> _ {
-   |                        ^
-   |                        |
-   |                        not allowed in type signatures
-   |                        help: replace with the correct return type: `S<'_>`
+   |                        ^ not allowed in type signatures
+   |
+help: replace with the correct return type
+   |
+LL -     fn f4(s: S<'_>) -> _ {
+LL +     fn f4(s: S<'_>) -> S<'_> {
+   |
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/suggestions/return-cycle-2.stderr
+++ b/tests/ui/suggestions/return-cycle-2.stderr
@@ -2,10 +2,13 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
   --> $DIR/return-cycle-2.rs:6:34
    |
 LL |     fn as_ref(_: i32, _: i32) -> _ {
-   |                                  ^
-   |                                  |
-   |                                  not allowed in type signatures
-   |                                  help: replace with the correct return type: `Token<&'static T>`
+   |                                  ^ not allowed in type signatures
+   |
+help: replace with the correct return type
+   |
+LL -     fn as_ref(_: i32, _: i32) -> _ {
+LL +     fn as_ref(_: i32, _: i32) -> Token<&'static T> {
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/suggestions/return-cycle.stderr
+++ b/tests/ui/suggestions/return-cycle.stderr
@@ -2,10 +2,13 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
   --> $DIR/return-cycle.rs:6:17
    |
 LL |     fn new() -> _ {
-   |                 ^
-   |                 |
-   |                 not allowed in type signatures
-   |                 help: replace with the correct return type: `Token<()>`
+   |                 ^ not allowed in type signatures
+   |
+help: replace with the correct return type
+   |
+LL -     fn new() -> _ {
+LL +     fn new() -> Token<()> {
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/suggestions/suggest-fn-ptr-for-fn-item-in-fn-ret.stderr
+++ b/tests/ui/suggestions/suggest-fn-ptr-for-fn-item-in-fn-ret.stderr
@@ -2,10 +2,13 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
   --> $DIR/suggest-fn-ptr-for-fn-item-in-fn-ret.rs:7:13
    |
 LL | fn bar() -> _ { Wrapper(foo) }
-   |             ^
-   |             |
-   |             not allowed in type signatures
-   |             help: replace with the correct return type: `Wrapper<fn()>`
+   |             ^ not allowed in type signatures
+   |
+help: replace with the correct return type
+   |
+LL - fn bar() -> _ { Wrapper(foo) }
+LL + fn bar() -> Wrapper<fn()> { Wrapper(foo) }
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/type-alias-impl-trait/issue-77179.stderr
+++ b/tests/ui/type-alias-impl-trait/issue-77179.stderr
@@ -11,10 +11,13 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
   --> $DIR/issue-77179.rs:8:22
    |
 LL | fn test() -> Pointer<_> {
-   |              --------^-
-   |              |       |
-   |              |       not allowed in type signatures
-   |              help: replace with the correct return type: `Pointer<i32>`
+   |                      ^ not allowed in type signatures
+   |
+help: replace with the correct return type
+   |
+LL - fn test() -> Pointer<_> {
+LL + fn test() -> Pointer<i32> {
+   |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
   --> $DIR/issue-77179.rs:19:25

--- a/tests/ui/typeck/issue-80779.stderr
+++ b/tests/ui/typeck/issue-80779.stderr
@@ -2,19 +2,25 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
   --> $DIR/issue-80779.rs:10:28
    |
 LL | pub fn g(_: T<'static>) -> _ {}
-   |                            ^
-   |                            |
-   |                            not allowed in type signatures
-   |                            help: replace with the correct return type: `()`
+   |                            ^ not allowed in type signatures
+   |
+help: replace with the correct return type
+   |
+LL - pub fn g(_: T<'static>) -> _ {}
+LL + pub fn g(_: T<'static>) -> () {}
+   |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
   --> $DIR/issue-80779.rs:5:29
    |
 LL | pub fn f<'a>(val: T<'a>) -> _ {
-   |                             ^
-   |                             |
-   |                             not allowed in type signatures
-   |                             help: replace with the correct return type: `()`
+   |                             ^ not allowed in type signatures
+   |
+help: replace with the correct return type
+   |
+LL - pub fn f<'a>(val: T<'a>) -> _ {
+LL + pub fn f<'a>(val: T<'a>) -> () {
+   |
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/typeck/issue-98260.stderr
+++ b/tests/ui/typeck/issue-98260.stderr
@@ -2,10 +2,13 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
   --> $DIR/issue-98260.rs:3:27
    |
 LL |     fn a(aa: B) -> Result<_, B> {
-   |                    -------^----
-   |                    |      |
-   |                    |      not allowed in type signatures
-   |                    help: replace with the correct return type: `Result<(), B>`
+   |                           ^ not allowed in type signatures
+   |
+help: replace with the correct return type
+   |
+LL -     fn a(aa: B) -> Result<_, B> {
+LL +     fn a(aa: B) -> Result<(), B> {
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/typeck/typeck_type_placeholder_item.stderr
+++ b/tests/ui/typeck/typeck_type_placeholder_item.stderr
@@ -48,20 +48,27 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
   --> $DIR/typeck_type_placeholder_item.rs:7:14
    |
 LL | fn test() -> _ { 5 }
-   |              ^
-   |              |
-   |              not allowed in type signatures
-   |              help: replace with the correct return type: `i32`
+   |              ^ not allowed in type signatures
+   |
+help: replace with the correct return type
+   |
+LL - fn test() -> _ { 5 }
+LL + fn test() -> i32 { 5 }
+   |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
   --> $DIR/typeck_type_placeholder_item.rs:10:16
    |
 LL | fn test2() -> (_, _) { (5, 5) }
-   |               -^--^-
-   |               ||  |
-   |               ||  not allowed in type signatures
-   |               |not allowed in type signatures
-   |               help: replace with the correct return type: `(i32, i32)`
+   |                ^  ^ not allowed in type signatures
+   |                |
+   |                not allowed in type signatures
+   |
+help: replace with the correct return type
+   |
+LL - fn test2() -> (_, _) { (5, 5) }
+LL + fn test2() -> (i32, i32) { (5, 5) }
+   |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for static variables
   --> $DIR/typeck_type_placeholder_item.rs:13:15
@@ -189,19 +196,25 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
   --> $DIR/typeck_type_placeholder_item.rs:47:26
    |
 LL | fn test11(x: &usize) -> &_ {
-   |                         -^
-   |                         ||
-   |                         |not allowed in type signatures
-   |                         help: replace with the correct return type: `&&usize`
+   |                          ^ not allowed in type signatures
+   |
+help: replace with the correct return type
+   |
+LL - fn test11(x: &usize) -> &_ {
+LL + fn test11(x: &usize) -> &&usize {
+   |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
   --> $DIR/typeck_type_placeholder_item.rs:52:52
    |
 LL | unsafe fn test12(x: *const usize) -> *const *const _ {
-   |                                      --------------^
-   |                                      |             |
-   |                                      |             not allowed in type signatures
-   |                                      help: replace with the correct return type: `*const *const usize`
+   |                                                    ^ not allowed in type signatures
+   |
+help: replace with the correct return type
+   |
+LL - unsafe fn test12(x: *const usize) -> *const *const _ {
+LL + unsafe fn test12(x: *const usize) -> *const *const usize {
+   |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for methods
   --> $DIR/typeck_type_placeholder_item.rs:58:24
@@ -261,20 +274,27 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
   --> $DIR/typeck_type_placeholder_item.rs:80:21
    |
 LL |     fn fn_test() -> _ { 5 }
-   |                     ^
-   |                     |
-   |                     not allowed in type signatures
-   |                     help: replace with the correct return type: `i32`
+   |                     ^ not allowed in type signatures
+   |
+help: replace with the correct return type
+   |
+LL -     fn fn_test() -> _ { 5 }
+LL +     fn fn_test() -> i32 { 5 }
+   |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
   --> $DIR/typeck_type_placeholder_item.rs:83:23
    |
 LL |     fn fn_test2() -> (_, _) { (5, 5) }
-   |                      -^--^-
-   |                      ||  |
-   |                      ||  not allowed in type signatures
-   |                      |not allowed in type signatures
-   |                      help: replace with the correct return type: `(i32, i32)`
+   |                       ^  ^ not allowed in type signatures
+   |                       |
+   |                       not allowed in type signatures
+   |
+help: replace with the correct return type
+   |
+LL -     fn fn_test2() -> (_, _) { (5, 5) }
+LL +     fn fn_test2() -> (i32, i32) { (5, 5) }
+   |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for static variables
   --> $DIR/typeck_type_placeholder_item.rs:86:22
@@ -374,20 +394,27 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
   --> $DIR/typeck_type_placeholder_item.rs:134:30
    |
 LL |     fn fn_test12(x: i32) -> (_, _) { (x, x) }
-   |                             -^--^-
-   |                             ||  |
-   |                             ||  not allowed in type signatures
-   |                             |not allowed in type signatures
-   |                             help: replace with the correct return type: `(i32, i32)`
+   |                              ^  ^ not allowed in type signatures
+   |                              |
+   |                              not allowed in type signatures
+   |
+help: replace with the correct return type
+   |
+LL -     fn fn_test12(x: i32) -> (_, _) { (x, x) }
+LL +     fn fn_test12(x: i32) -> (i32, i32) { (x, x) }
+   |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
   --> $DIR/typeck_type_placeholder_item.rs:137:33
    |
 LL |     fn fn_test13(x: _) -> (i32, _) { (x, x) }
-   |                           ------^-
-   |                           |     |
-   |                           |     not allowed in type signatures
-   |                           help: replace with the correct return type: `(i32, i32)`
+   |                                 ^ not allowed in type signatures
+   |
+help: replace with the correct return type
+   |
+LL -     fn fn_test13(x: _) -> (i32, _) { (x, x) }
+LL +     fn fn_test13(x: _) -> (i32, i32) { (x, x) }
+   |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for methods
   --> $DIR/typeck_type_placeholder_item.rs:142:31
@@ -528,10 +555,13 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
   --> $DIR/typeck_type_placeholder_item.rs:226:31
    |
 LL | fn value() -> Option<&'static _> {
-   |               ----------------^-
-   |               |               |
-   |               |               not allowed in type signatures
-   |               help: replace with the correct return type: `Option<&'static u8>`
+   |                               ^ not allowed in type signatures
+   |
+help: replace with the correct return type
+   |
+LL - fn value() -> Option<&'static _> {
+LL + fn value() -> Option<&'static u8> {
+   |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for constants
   --> $DIR/typeck_type_placeholder_item.rs:231:17
@@ -549,10 +579,13 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
   --> $DIR/typeck_type_placeholder_item.rs:235:31
    |
 LL | fn evens_squared(n: usize) -> _ {
-   |                               ^
-   |                               |
-   |                               not allowed in type signatures
-   |                               help: replace with an appropriate return type: `impl Iterator<Item = usize>`
+   |                               ^ not allowed in type signatures
+   |
+help: replace with an appropriate return type
+   |
+LL - fn evens_squared(n: usize) -> _ {
+LL + fn evens_squared(n: usize) -> impl Iterator<Item = usize> {
+   |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for constants
   --> $DIR/typeck_type_placeholder_item.rs:240:10
@@ -570,10 +603,13 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
   --> $DIR/typeck_type_placeholder_item.rs:40:24
    |
 LL |     fn test9(&self) -> _ { () }
-   |                        ^
-   |                        |
-   |                        not allowed in type signatures
-   |                        help: replace with the correct return type: `()`
+   |                        ^ not allowed in type signatures
+   |
+help: replace with the correct return type
+   |
+LL -     fn test9(&self) -> _ { () }
+LL +     fn test9(&self) -> () { () }
+   |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for methods
   --> $DIR/typeck_type_placeholder_item.rs:43:27
@@ -585,10 +621,13 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
   --> $DIR/typeck_type_placeholder_item.rs:107:31
    |
 LL |         fn fn_test9(&self) -> _ { () }
-   |                               ^
-   |                               |
-   |                               not allowed in type signatures
-   |                               help: replace with the correct return type: `()`
+   |                               ^ not allowed in type signatures
+   |
+help: replace with the correct return type
+   |
+LL -         fn fn_test9(&self) -> _ { () }
+LL +         fn fn_test9(&self) -> () { () }
+   |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for methods
   --> $DIR/typeck_type_placeholder_item.rs:110:34

--- a/tests/ui/typeck/typeck_type_placeholder_item_help.stderr
+++ b/tests/ui/typeck/typeck_type_placeholder_item_help.stderr
@@ -2,10 +2,13 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
   --> $DIR/typeck_type_placeholder_item_help.rs:4:15
    |
 LL | fn test1() -> _ { Some(42) }
-   |               ^
-   |               |
-   |               not allowed in type signatures
-   |               help: replace with the correct return type: `Option<i32>`
+   |               ^ not allowed in type signatures
+   |
+help: replace with the correct return type
+   |
+LL - fn test1() -> _ { Some(42) }
+LL + fn test1() -> Option<i32> { Some(42) }
+   |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for constants
   --> $DIR/typeck_type_placeholder_item_help.rs:7:14

--- a/tests/ui/variance/leaking-unnameables.stderr
+++ b/tests/ui/variance/leaking-unnameables.stderr
@@ -2,10 +2,13 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
   --> $DIR/leaking-unnameables.rs:8:18
    |
 LL | pub fn f<T>() -> _ {
-   |                  ^
-   |                  |
-   |                  not allowed in type signatures
-   |                  help: replace with the correct return type: `fn()`
+   |                  ^ not allowed in type signatures
+   |
+help: replace with the correct return type
+   |
+LL - pub fn f<T>() -> _ {
+LL + pub fn f<T>() -> fn() {
+   |
 
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
```
error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
  --> $DIR/in-signature.rs:6:21
   |
LL | fn arr_fn() -> [u8; _] {
   |                     ^ not allowed in type signatures
   |
help: replace with the correct return type
   |
LL - fn arr_fn() -> [u8; _] {
LL + fn arr_fn() -> [u8; 3] {
   |
```

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
