### PR TITLE
Port all viable contracts from verify-rust-std

### DIFF
--- a/library/alloc/src/collections/vec_deque/iter.rs
+++ b/library/alloc/src/collections/vec_deque/iter.rs
@@ -144,6 +144,7 @@ impl<'a, T> Iterator for Iter<'a, T> {
     }
 
     #[inline]
+    #[core::contracts::requires(idx < self.len())]
     unsafe fn __iterator_get_unchecked(&mut self, idx: usize) -> Self::Item {
         // Safety: The TrustedRandomAccess contract requires that callers only pass an index
         // that is in bounds.

--- a/library/alloc/src/collections/vec_deque/iter_mut.rs
+++ b/library/alloc/src/collections/vec_deque/iter_mut.rs
@@ -208,6 +208,8 @@ impl<'a, T> Iterator for IterMut<'a, T> {
     }
 
     #[inline]
+    #[allow(unused_parens)]
+    #[core::contracts::requires(idx < self.len())]
     unsafe fn __iterator_get_unchecked(&mut self, idx: usize) -> Self::Item {
         // Safety: The TrustedRandomAccess contract requires that callers only pass an index
         // that is in bounds.

--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -106,6 +106,7 @@
 #![feature(const_default)]
 #![feature(const_eval_select)]
 #![feature(const_heap)]
+#![feature(contracts)]
 #![feature(core_intrinsics)]
 #![feature(deprecated_suggestion)]
 #![feature(deref_pure_trait)]

--- a/library/alloc/src/vec/into_iter.rs
+++ b/library/alloc/src/vec/into_iter.rs
@@ -360,6 +360,7 @@ impl<T, A: Allocator> Iterator for IntoIter<T, A> {
         R::from_output(accum)
     }
 
+    #[core::contracts::requires(i < self.len())]
     unsafe fn __iterator_get_unchecked(&mut self, i: usize) -> Self::Item
     where
         Self: TrustedRandomAccessNoCoerce,

--- a/library/alloctests/lib.rs
+++ b/library/alloctests/lib.rs
@@ -11,6 +11,8 @@
 #![allow(rustdoc::redundant_explicit_links)]
 #![warn(rustdoc::unescaped_backticks)]
 #![deny(ffi_unwind_calls)]
+// permit use of experimental feature contracts
+#![allow(incomplete_features)]
 //
 // Library features:
 // tidy-alphabetical-start
@@ -20,6 +22,7 @@
 #![feature(assert_matches)]
 #![feature(char_internals)]
 #![feature(char_max_len)]
+#![feature(contracts)]
 #![feature(core_intrinsics)]
 #![feature(exact_size_is_empty)]
 #![feature(extend_one)]

--- a/library/core/src/array/iter.rs
+++ b/library/core/src/array/iter.rs
@@ -138,6 +138,8 @@ impl<T, const N: usize> IntoIter<T, N> {
     /// ```
     #[unstable(feature = "array_into_iter_constructors", issue = "91583")]
     #[inline]
+    #[rustc_allow_const_fn_unstable(contracts)]
+    #[core::contracts::requires(initialized.start <= initialized.end && initialized.end <= N)]
     pub const unsafe fn new_unchecked(
         buffer: [MaybeUninit<T>; N],
         initialized: Range<usize>,
@@ -279,6 +281,7 @@ impl<T, const N: usize> Iterator for IntoIter<T, N> {
     }
 
     #[inline]
+    #[core::contracts::requires(idx < self.len())]
     unsafe fn __iterator_get_unchecked(&mut self, idx: usize) -> Self::Item {
         // SAFETY: The caller must provide an idx that is in bound of the remainder.
         let elem_ref = unsafe { self.as_mut_slice().get_unchecked_mut(idx) };

--- a/library/core/src/ascii/ascii_char.rs
+++ b/library/core/src/ascii/ascii_char.rs
@@ -458,6 +458,10 @@ impl AsciiChar {
     /// or returns `None` if it's too large.
     #[unstable(feature = "ascii_char", issue = "110998")]
     #[inline]
+    #[rustc_allow_const_fn_unstable(contracts)]
+    #[core::contracts::ensures(
+        move |result: &Option<AsciiChar>|
+        (b <= 127) == (result.is_some() && result.unwrap() as u8 == b))]
     pub const fn from_u8(b: u8) -> Option<Self> {
         if b <= 127 {
             // SAFETY: Just checked that `b` is in-range
@@ -475,6 +479,9 @@ impl AsciiChar {
     /// `b` must be in `0..=127`, or else this is UB.
     #[unstable(feature = "ascii_char", issue = "110998")]
     #[inline]
+    #[rustc_allow_const_fn_unstable(contracts)]
+    #[core::contracts::requires(b <= 127)]
+    #[core::contracts::ensures(move |result: &Self| *result as u8 == b)]
     pub const unsafe fn from_u8_unchecked(b: u8) -> Self {
         // SAFETY: Our safety precondition is that `b` is in-range.
         unsafe { transmute(b) }
@@ -513,6 +520,11 @@ impl AsciiChar {
     #[unstable(feature = "ascii_char", issue = "110998")]
     #[inline]
     #[track_caller]
+    // Only `d < 64` is required for safety as described above, but we use `d < 10` as in the
+    // `assert_unsafe_precondition` inside. See https://github.com/rust-lang/rust/pull/129374 for
+    // some context about the discrepancy.
+    #[rustc_allow_const_fn_unstable(contracts)]
+    #[core::contracts::requires(d < 10)]
     pub const unsafe fn digit_unchecked(d: u8) -> Self {
         assert_unsafe_precondition!(
             check_library_ub,
@@ -532,6 +544,8 @@ impl AsciiChar {
     /// Gets this ASCII character as a byte.
     #[unstable(feature = "ascii_char", issue = "110998")]
     #[inline]
+    #[rustc_allow_const_fn_unstable(contracts)]
+    #[core::contracts::ensures(|result: &u8| *result <= 127)]
     pub const fn to_u8(self) -> u8 {
         self as u8
     }

--- a/library/core/src/char/convert.rs
+++ b/library/core/src/char/convert.rs
@@ -23,6 +23,9 @@ pub(super) const fn from_u32(i: u32) -> Option<char> {
 #[must_use]
 #[allow(unnecessary_transmutes)]
 #[track_caller]
+#[rustc_allow_const_fn_unstable(contracts)]
+#[core::contracts::requires(char_try_from_u32(i).is_ok())]
+#[core::contracts::ensures(move |result: &char| *result as u32 == i)]
 pub(super) const unsafe fn from_u32_unchecked(i: u32) -> char {
     // SAFETY: the caller must guarantee that `i` is a valid char value.
     unsafe {

--- a/library/core/src/char/mod.rs
+++ b/library/core/src/char/mod.rs
@@ -138,6 +138,8 @@ pub const fn from_u32(i: u32) -> Option<char> {
 #[rustc_const_stable(feature = "const_char_from_u32_unchecked", since = "1.81.0")]
 #[must_use]
 #[inline]
+#[rustc_allow_const_fn_unstable(contracts)]
+#[core::contracts::requires(i <= 0x10FFFF && (i < 0xD800 || i > 0xDFFF))]
 pub const unsafe fn from_u32_unchecked(i: u32) -> char {
     // SAFETY: the safety contract must be upheld by the caller.
     unsafe { self::convert::from_u32_unchecked(i) }
@@ -399,6 +401,7 @@ macro_rules! casemappingiter_impls {
                 self.0.advance_by(n)
             }
 
+            #[core::contracts::requires(idx < self.0.len())]
             unsafe fn __iterator_get_unchecked(&mut self, idx: usize) -> Self::Item {
                 // SAFETY: just forwarding requirements to caller
                 unsafe { self.0.__iterator_get_unchecked(idx) }
@@ -533,6 +536,7 @@ impl Iterator for CaseMappingIter {
         self.0.advance_by(n)
     }
 
+    #[core::contracts::requires(idx < self.len())]
     unsafe fn __iterator_get_unchecked(&mut self, idx: usize) -> Self::Item {
         // SAFETY: just forwarding requirements to caller
         unsafe { self.0.__iterator_get_unchecked(idx) }

--- a/library/core/src/ffi/c_str.rs
+++ b/library/core/src/ffi/c_str.rs
@@ -250,6 +250,13 @@ impl CStr {
     #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_const_stable(feature = "const_cstr_from_ptr", since = "1.81.0")]
+    #[rustc_allow_const_fn_unstable(contracts)]
+    #[core::contracts::requires(!ptr.is_null())]
+    #[core::contracts::ensures(
+        |result: &&CStr|
+        !result.inner.is_empty() &&
+        result.inner[result.inner.len() - 1] == 0 &&
+        !result.inner[..result.inner.len() - 1].contains(&0))]
     pub const unsafe fn from_ptr<'a>(ptr: *const c_char) -> &'a CStr {
         // SAFETY: The caller has provided a pointer that points to a valid C
         // string with a NUL terminator less than `isize::MAX` from `ptr`.
@@ -385,6 +392,14 @@ impl CStr {
     #[stable(feature = "cstr_from_bytes", since = "1.10.0")]
     #[rustc_const_stable(feature = "const_cstr_unchecked", since = "1.59.0")]
     #[rustc_allow_const_fn_unstable(const_eval_select)]
+    #[rustc_allow_const_fn_unstable(contracts)]
+    #[core::contracts::requires(
+        !bytes.is_empty() && bytes[bytes.len() - 1] == 0 && !bytes[..bytes.len()-1].contains(&0))]
+    #[core::contracts::ensures(
+        |result: &&CStr|
+        !result.inner.is_empty() &&
+        result.inner[result.inner.len() - 1] == 0 &&
+        !result.inner[..result.inner.len() - 1].contains(&0))]
     pub const unsafe fn from_bytes_with_nul_unchecked(bytes: &[u8]) -> &CStr {
         const_eval_select!(
             @capture { bytes: &[u8] } -> &CStr:
@@ -723,6 +738,12 @@ impl const AsRef<CStr> for CStr {
 #[inline]
 #[unstable(feature = "cstr_internals", issue = "none")]
 #[rustc_allow_const_fn_unstable(const_eval_select)]
+#[rustc_allow_const_fn_unstable(contracts)]
+#[core::contracts::ensures(
+    move |&result|
+    result < isize::MAX as usize &&
+    // SAFETY: result is within isize::MAX
+    unsafe { *ptr.add(result) } == 0)]
 const unsafe fn strlen(ptr: *const c_char) -> usize {
     const_eval_select!(
         @capture { s: *const c_char = ptr } -> usize:

--- a/library/core/src/intrinsics/fallback.rs
+++ b/library/core/src/intrinsics/fallback.rs
@@ -130,6 +130,7 @@ macro_rules! impl_disjoint_bitor {
         impl const DisjointBitOr for $t {
             #[cfg_attr(miri, track_caller)]
             #[inline]
+            #[core::contracts::requires((self & other) == zero!($t))]
             unsafe fn disjoint_bitor(self, other: Self) -> Self {
                 // Note that the assume here is required for UB detection in Miri!
 

--- a/library/core/src/intrinsics/mod.rs
+++ b/library/core/src/intrinsics/mod.rs
@@ -2563,6 +2563,8 @@ pub const fn is_val_statically_known<T: Copy>(_arg: T) -> bool {
 #[inline]
 #[rustc_intrinsic]
 #[rustc_intrinsic_const_stable_indirect]
+#[rustc_allow_const_fn_unstable(contracts)]
+#[core::contracts::requires(x.addr() != y.addr() || core::mem::size_of::<T>() == 0)]
 pub const unsafe fn typed_swap_nonoverlapping<T>(x: *mut T, y: *mut T) {
     // SAFETY: The caller provided single non-overlapping items behind
     // pointers, so swapping them with `count: 1` is fine.

--- a/library/core/src/iter/adapters/cloned.rs
+++ b/library/core/src/iter/adapters/cloned.rs
@@ -61,6 +61,7 @@ where
         self.it.map(T::clone).fold(init, f)
     }
 
+    #[core::contracts::requires(idx < self.it.size_hint().0)]
     unsafe fn __iterator_get_unchecked(&mut self, idx: usize) -> T
     where
         Self: TrustedRandomAccessNoCoerce,

--- a/library/core/src/iter/adapters/copied.rs
+++ b/library/core/src/iter/adapters/copied.rs
@@ -92,6 +92,7 @@ where
         self.it.advance_by(n)
     }
 
+    #[core::contracts::requires(idx < self.it.size_hint().0)]
     unsafe fn __iterator_get_unchecked(&mut self, idx: usize) -> T
     where
         Self: TrustedRandomAccessNoCoerce,

--- a/library/core/src/iter/adapters/enumerate.rs
+++ b/library/core/src/iter/adapters/enumerate.rs
@@ -160,6 +160,7 @@ where
 
     #[rustc_inherit_overflow_checks]
     #[inline]
+    #[core::contracts::requires(idx < self.iter.size_hint().0)]
     unsafe fn __iterator_get_unchecked(&mut self, idx: usize) -> <Self as Iterator>::Item
     where
         Self: TrustedRandomAccessNoCoerce,

--- a/library/core/src/iter/adapters/fuse.rs
+++ b/library/core/src/iter/adapters/fuse.rs
@@ -109,6 +109,8 @@ where
     }
 
     #[inline]
+    #[core::contracts::requires(
+        self.iter.is_some() && idx < self.iter.as_ref().unwrap().size_hint().0)]
     unsafe fn __iterator_get_unchecked(&mut self, idx: usize) -> Self::Item
     where
         Self: TrustedRandomAccessNoCoerce,

--- a/library/core/src/iter/adapters/map.rs
+++ b/library/core/src/iter/adapters/map.rs
@@ -129,6 +129,7 @@ where
     }
 
     #[inline]
+    #[core::contracts::requires(idx < self.iter.size_hint().0)]
     unsafe fn __iterator_get_unchecked(&mut self, idx: usize) -> B
     where
         Self: TrustedRandomAccessNoCoerce,

--- a/library/core/src/iter/adapters/skip.rs
+++ b/library/core/src/iter/adapters/skip.rs
@@ -158,6 +158,7 @@ where
     }
 
     #[doc(hidden)]
+    #[core::contracts::requires(idx + self.n < self.iter.size_hint().0)]
     unsafe fn __iterator_get_unchecked(&mut self, idx: usize) -> Self::Item
     where
         Self: TrustedRandomAccessNoCoerce,

--- a/library/core/src/iter/adapters/zip.rs
+++ b/library/core/src/iter/adapters/zip.rs
@@ -104,6 +104,7 @@ where
     }
 
     #[inline]
+    #[core::contracts::requires(idx < self.size_hint().0)]
     unsafe fn __iterator_get_unchecked(&mut self, idx: usize) -> Self::Item
     where
         Self: TrustedRandomAccessNoCoerce,

--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -1710,6 +1710,7 @@ pub trait Iterator {
     /// ```
     #[inline]
     #[unstable(feature = "iter_map_windows", reason = "recently added", issue = "87155")]
+    #[core::contracts::requires(N > 0)]
     fn map_windows<F, R, const N: usize>(self, f: F) -> MapWindows<Self, F, N>
     where
         Self: Sized,

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -107,6 +107,7 @@
 #![feature(const_destruct)]
 #![feature(const_eval_select)]
 #![feature(const_select_unpredictable)]
+#![feature(contracts)]
 #![feature(core_intrinsics)]
 #![feature(coverage_attribute)]
 #![feature(disjoint_bitor)]

--- a/library/core/src/num/f128.rs
+++ b/library/core/src/num/f128.rs
@@ -875,6 +875,7 @@ impl f128 {
     #[inline]
     #[unstable(feature = "f128", issue = "116909")]
     #[must_use = "this returns the result of the operation, without modifying the original"]
+    #[core::contracts::requires(self.is_finite())]
     pub unsafe fn to_int_unchecked<Int>(self) -> Int
     where
         Self: FloatToInt<Int>,

--- a/library/core/src/num/f16.rs
+++ b/library/core/src/num/f16.rs
@@ -862,6 +862,7 @@ impl f16 {
     #[inline]
     #[unstable(feature = "f16", issue = "116909")]
     #[must_use = "this returns the result of the operation, without modifying the original"]
+    #[core::contracts::requires(self.is_finite())]
     pub unsafe fn to_int_unchecked<Int>(self) -> Int
     where
         Self: FloatToInt<Int>,

--- a/library/core/src/num/f32.rs
+++ b/library/core/src/num/f32.rs
@@ -1066,6 +1066,7 @@ impl f32 {
                   without modifying the original"]
     #[stable(feature = "float_approx_unchecked_to", since = "1.44.0")]
     #[inline]
+    #[core::contracts::requires(self.is_finite())]
     pub unsafe fn to_int_unchecked<Int>(self) -> Int
     where
         Self: FloatToInt<Int>,

--- a/library/core/src/num/f64.rs
+++ b/library/core/src/num/f64.rs
@@ -1065,6 +1065,7 @@ impl f64 {
                   without modifying the original"]
     #[stable(feature = "float_approx_unchecked_to", since = "1.44.0")]
     #[inline]
+    #[core::contracts::requires(self.is_finite())]
     pub unsafe fn to_int_unchecked<Int>(self) -> Int
     where
         Self: FloatToInt<Int>,

--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -554,6 +554,8 @@ macro_rules! int_impl {
                       without modifying the original"]
         #[inline(always)]
         #[track_caller]
+        #[rustc_allow_const_fn_unstable(contracts)]
+        #[core::contracts::requires(!self.overflowing_add(rhs).1)]
         pub const unsafe fn unchecked_add(self, rhs: Self) -> Self {
             assert_unsafe_precondition!(
                 check_language_ub,
@@ -694,6 +696,8 @@ macro_rules! int_impl {
                       without modifying the original"]
         #[inline(always)]
         #[track_caller]
+        #[rustc_allow_const_fn_unstable(contracts)]
+        #[core::contracts::requires(!self.overflowing_sub(rhs).1)]
         pub const unsafe fn unchecked_sub(self, rhs: Self) -> Self {
             assert_unsafe_precondition!(
                 check_language_ub,
@@ -834,6 +838,8 @@ macro_rules! int_impl {
                       without modifying the original"]
         #[inline(always)]
         #[track_caller]
+        #[rustc_allow_const_fn_unstable(contracts)]
+        #[core::contracts::requires(!self.overflowing_mul(rhs).1)]
         pub const unsafe fn unchecked_mul(self, rhs: Self) -> Self {
             assert_unsafe_precondition!(
                 check_language_ub,
@@ -1252,6 +1258,9 @@ macro_rules! int_impl {
                       without modifying the original"]
         #[inline(always)]
         #[track_caller]
+        #[rustc_allow_const_fn_unstable(contracts)]
+        #[core::contracts::requires(self != <$SelfT>::MIN)]
+        #[core::contracts::ensures(move |result| *result == -self)]
         pub const unsafe fn unchecked_neg(self) -> Self {
             assert_unsafe_precondition!(
                 check_language_ub,
@@ -1372,6 +1381,8 @@ macro_rules! int_impl {
                       without modifying the original"]
         #[inline(always)]
         #[track_caller]
+        #[rustc_allow_const_fn_unstable(contracts)]
+        #[core::contracts::requires(rhs < <$ActualT>::BITS)]
         pub const unsafe fn unchecked_shl(self, rhs: u32) -> Self {
             assert_unsafe_precondition!(
                 check_language_ub,
@@ -1547,6 +1558,8 @@ macro_rules! int_impl {
                       without modifying the original"]
         #[inline(always)]
         #[track_caller]
+        #[rustc_allow_const_fn_unstable(contracts)]
+        #[core::contracts::requires(rhs < <$ActualT>::BITS)]
         pub const unsafe fn unchecked_shr(self, rhs: u32) -> Self {
             assert_unsafe_precondition!(
                 check_language_ub,
@@ -2278,6 +2291,8 @@ macro_rules! int_impl {
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline(always)]
+        #[rustc_allow_const_fn_unstable(contracts)]
+        #[core::contracts::ensures(move |result| *result == self << (rhs & (Self::BITS - 1)))]
         pub const fn wrapping_shl(self, rhs: u32) -> Self {
             // SAFETY: the masking by the bitsize of the type ensures that we do not shift
             // out of bounds
@@ -2305,6 +2320,8 @@ macro_rules! int_impl {
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline(always)]
+        #[rustc_allow_const_fn_unstable(contracts)]
+        #[core::contracts::ensures(move |result| *result == self >> (rhs & (Self::BITS - 1)))]
         pub const fn wrapping_shr(self, rhs: u32) -> Self {
             // SAFETY: the masking by the bitsize of the type ensures that we do not shift
             // out of bounds

--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -505,6 +505,8 @@ impl u8 {
     #[must_use]
     #[unstable(feature = "ascii_char", issue = "110998")]
     #[inline]
+    #[rustc_allow_const_fn_unstable(contracts)]
+    #[core::contracts::requires(self.is_ascii())]
     pub const unsafe fn as_ascii_unchecked(&self) -> ascii::Char {
         assert_unsafe_precondition!(
             check_library_ub,

--- a/library/core/src/num/niche_types.rs
+++ b/library/core/src/num/niche_types.rs
@@ -33,6 +33,12 @@ macro_rules! define_valid_range_type {
 
         impl $name {
             #[inline]
+            #[rustc_allow_const_fn_unstable(contracts)]
+            #[core::contracts::ensures(
+                |result: &Option<$name>|
+                result.is_none() || (
+                    (result.unwrap().as_inner() as $uint) >= ($low as $uint) &&
+                    (result.unwrap().as_inner() as $uint) <= ($high as $uint)))]
             pub const fn new(val: $int) -> Option<Self> {
                 if (val as $uint) >= ($low as $uint) && (val as $uint) <= ($high as $uint) {
                     // SAFETY: just checked the inclusive range
@@ -49,12 +55,19 @@ macro_rules! define_valid_range_type {
             /// Immediate language UB if `val` is not within the valid range for this
             /// type, as it violates the validity invariant.
             #[inline]
+            #[rustc_allow_const_fn_unstable(contracts)]
+            #[core::contracts::requires(
+                (val as $uint) >= ($low as $uint) && (val as $uint) <= ($high as $uint))]
             pub const unsafe fn new_unchecked(val: $int) -> Self {
                 // SAFETY: Caller promised that `val` is within the valid range.
                 unsafe { $name(val) }
             }
 
             #[inline]
+            #[rustc_allow_const_fn_unstable(contracts)]
+            #[core::contracts::ensures(
+                |result|
+                (*result as $uint) >= ($low as $uint) && (*result as $uint) <= ($high as $uint))]
             pub const fn as_inner(self) -> $int {
                 // SAFETY: This is a transparent wrapper, so unwrapping it is sound
                 // (Not using `.0` due to MCP#807.)

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -817,6 +817,10 @@ macro_rules! nonzero_integer {
             #[must_use = "this returns the result of the operation, \
                         without modifying the original"]
             #[inline(always)]
+            #[rustc_allow_const_fn_unstable(contracts)]
+            #[core::contracts::requires(let old : NonZero<$Int> = self; true)]
+            #[core::contracts::ensures(
+                move |result: &NonZero<$Int>| result.rotate_right(n).get() == old.get())]
             pub const fn rotate_left(self, n: u32) -> Self {
                 let result = self.get().rotate_left(n);
                 // SAFETY: Rotating bits preserves the property int > 0.
@@ -848,6 +852,10 @@ macro_rules! nonzero_integer {
             #[must_use = "this returns the result of the operation, \
                         without modifying the original"]
             #[inline(always)]
+            #[rustc_allow_const_fn_unstable(contracts)]
+            #[core::contracts::requires(let old : NonZero<$Int> = self; true)]
+            #[core::contracts::ensures(
+                move |result: &NonZero<$Int>| result.rotate_left(n).get() == old.get())]
             pub const fn rotate_right(self, n: u32) -> Self {
                 let result = self.get().rotate_right(n);
                 // SAFETY: Rotating bits preserves the property int > 0.

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -411,6 +411,13 @@ where
     #[must_use]
     #[inline]
     #[track_caller]
+    #[rustc_allow_const_fn_unstable(contracts)]
+    #[core::contracts::requires({
+        let size = core::mem::size_of::<T>();
+        let ptr = &n as *const T as *const u8;
+        // SAFETY: to be confirmed
+        let slice = unsafe { core::slice::from_raw_parts(ptr, size) };
+        !slice.iter().all(|&byte| byte == 0) })]
     pub const unsafe fn new_unchecked(n: T) -> Self {
         match Self::new(n) {
             Some(n) => n,
@@ -452,6 +459,12 @@ where
     #[must_use]
     #[inline]
     #[track_caller]
+    #[core::contracts::requires({
+        let size = core::mem::size_of::<T>();
+        let ptr = n as *const T as *const u8;
+        // SAFETY: to be confirmed
+        let slice = unsafe { core::slice::from_raw_parts(ptr, size) };
+        !slice.iter().all(|&byte| byte == 0) })]
     pub unsafe fn from_mut_unchecked(n: &mut T) -> &mut Self {
         match Self::from_mut(n) {
             Some(n) => n,
@@ -771,6 +784,8 @@ macro_rules! nonzero_integer {
             #[must_use = "this returns the result of the operation, \
                         without modifying the original"]
             #[inline(always)]
+            #[rustc_allow_const_fn_unstable(contracts)]
+            #[core::contracts::ensures(|result: &NonZero<u32>| result.get() > 0)]
             pub const fn count_ones(self) -> NonZero<u32> {
                 // SAFETY:
                 // `self` is non-zero, which means it has at least one bit set, which means
@@ -1144,6 +1159,11 @@ macro_rules! nonzero_integer {
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
             #[inline]
+            #[rustc_allow_const_fn_unstable(contracts)]
+            #[core::contracts::requires(self.get().checked_mul(other.get()).is_some())]
+            #[core::contracts::ensures(
+                move |result: &Self|
+                self.get().checked_mul(other.get()).is_some_and(|product| product == result.get()))]
             pub const unsafe fn unchecked_mul(self, other: Self) -> Self {
                 // SAFETY: The caller ensures there is no overflow.
                 unsafe { Self::new_unchecked(self.get().unchecked_mul(other.get())) }
@@ -1552,6 +1572,11 @@ macro_rules! nonzero_integer_signedness_dependent_methods {
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]
+        #[rustc_allow_const_fn_unstable(contracts)]
+        #[core::contracts::requires(self.get().checked_add(other).is_some())]
+        #[core::contracts::ensures(
+            move |result: &Self|
+            self.get().checked_add(other).is_some_and(|sum| sum == result.get()))]
         pub const unsafe fn unchecked_add(self, other: $Int) -> Self {
             // SAFETY: The caller ensures there is no overflow.
             unsafe { Self::new_unchecked(self.get().unchecked_add(other)) }

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -702,6 +702,8 @@ macro_rules! uint_impl {
                       without modifying the original"]
         #[inline(always)]
         #[track_caller]
+        #[rustc_allow_const_fn_unstable(contracts)]
+        #[core::contracts::requires(!self.overflowing_add(rhs).1)]
         pub const unsafe fn unchecked_add(self, rhs: Self) -> Self {
             assert_unsafe_precondition!(
                 check_language_ub,
@@ -881,6 +883,8 @@ macro_rules! uint_impl {
                       without modifying the original"]
         #[inline(always)]
         #[track_caller]
+        #[rustc_allow_const_fn_unstable(contracts)]
+        #[core::contracts::requires(!self.overflowing_sub(rhs).1)]
         pub const unsafe fn unchecked_sub(self, rhs: Self) -> Self {
             assert_unsafe_precondition!(
                 check_language_ub,
@@ -1090,6 +1094,8 @@ macro_rules! uint_impl {
                       without modifying the original"]
         #[inline(always)]
         #[track_caller]
+        #[rustc_allow_const_fn_unstable(contracts)]
+        #[core::contracts::requires(!self.overflowing_mul(rhs).1)]
         pub const unsafe fn unchecked_mul(self, rhs: Self) -> Self {
             assert_unsafe_precondition!(
                 check_language_ub,
@@ -1449,6 +1455,7 @@ macro_rules! uint_impl {
         #[unstable(feature = "disjoint_bitor", issue = "135758")]
         #[rustc_const_unstable(feature = "disjoint_bitor", issue = "135758")]
         #[inline]
+        #[core::contracts::requires((self & other) == 0)]
         pub const unsafe fn unchecked_disjoint_bitor(self, other: Self) -> Self {
             assert_unsafe_precondition!(
                 check_language_ub,
@@ -1780,6 +1787,8 @@ macro_rules! uint_impl {
                       without modifying the original"]
         #[inline(always)]
         #[track_caller]
+        #[rustc_allow_const_fn_unstable(contracts)]
+        #[core::contracts::requires(rhs < <$ActualT>::BITS)]
         pub const unsafe fn unchecked_shl(self, rhs: u32) -> Self {
             assert_unsafe_precondition!(
                 check_language_ub,
@@ -1952,6 +1961,8 @@ macro_rules! uint_impl {
                       without modifying the original"]
         #[inline(always)]
         #[track_caller]
+        #[rustc_allow_const_fn_unstable(contracts)]
+        #[core::contracts::requires(rhs < <$ActualT>::BITS)]
         pub const unsafe fn unchecked_shr(self, rhs: u32) -> Self {
             assert_unsafe_precondition!(
                 check_language_ub,
@@ -2534,6 +2545,9 @@ macro_rules! uint_impl {
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline(always)]
+        #[rustc_allow_const_fn_unstable(contracts)]
+        #[core::contracts::ensures(
+            move |result: &Self| *result == self << (rhs & (Self::BITS - 1)))]
         pub const fn wrapping_shl(self, rhs: u32) -> Self {
             // SAFETY: the masking by the bitsize of the type ensures that we do not shift
             // out of bounds
@@ -2564,6 +2578,8 @@ macro_rules! uint_impl {
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline(always)]
+        #[rustc_allow_const_fn_unstable(contracts)]
+        #[core::contracts::ensures(move |result| *result == self >> (rhs & (Self::BITS - 1)))]
         pub const fn wrapping_shr(self, rhs: u32) -> Self {
             // SAFETY: the masking by the bitsize of the type ensures that we do not shift
             // out of bounds

--- a/library/core/src/ops/index_range.rs
+++ b/library/core/src/ops/index_range.rs
@@ -20,6 +20,8 @@ impl IndexRange {
     /// - `start <= end`
     #[inline]
     #[track_caller]
+    #[rustc_allow_const_fn_unstable(contracts)]
+    #[core::contracts::requires(start <= end)]
     pub(crate) const unsafe fn new_unchecked(start: usize, end: usize) -> Self {
         ub_checks::assert_unsafe_precondition!(
             check_library_ub,
@@ -54,6 +56,7 @@ impl IndexRange {
     /// # Safety
     /// - Can only be called when `start < end`, aka when `len > 0`.
     #[inline]
+    #[core::contracts::requires(self.start < self.end)]
     unsafe fn next_unchecked(&mut self) -> usize {
         debug_assert!(self.start < self.end);
 
@@ -66,6 +69,7 @@ impl IndexRange {
     /// # Safety
     /// - Can only be called when `start < end`, aka when `len > 0`.
     #[inline]
+    #[core::contracts::requires(self.start < self.end)]
     unsafe fn next_back_unchecked(&mut self) -> usize {
         debug_assert!(self.start < self.end);
 

--- a/library/core/src/ptr/const_ptr.rs
+++ b/library/core/src/ptr/const_ptr.rs
@@ -346,6 +346,12 @@ impl<T: PointeeSized> *const T {
     #[rustc_const_stable(feature = "const_ptr_offset", since = "1.61.0")]
     #[inline(always)]
     #[track_caller]
+    #[rustc_allow_const_fn_unstable(contracts)]
+    #[core::contracts::requires(
+        // Precondition 1: the computed offset `count * size_of::<T>()` does not overflow `isize`.
+        // Precondition 2: adding the computed offset to `self` does not cause overflow.
+        count.checked_mul(core::mem::size_of::<T>() as isize).is_some_and(
+            |computed_offset| (self as isize).checked_add(computed_offset).is_some()))]
     pub const unsafe fn offset(self, count: isize) -> *const T
     where
         T: Sized,
@@ -609,6 +615,16 @@ impl<T: PointeeSized> *const T {
     #[rustc_const_stable(feature = "const_ptr_offset_from", since = "1.65.0")]
     #[inline]
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
+    #[rustc_allow_const_fn_unstable(contracts)]
+    #[core::contracts::requires(
+        // Ensures subtracting `origin` from `self` doesn't overflow
+        (self as isize).checked_sub(origin as isize).is_some() &&
+        // Ensure the distance between `self` and `origin` is aligned to `T`
+        (self as isize - origin as isize) % (mem::size_of::<T>() as isize) == 0)]
+    // FIXME: requires `T` to be `'static`
+    // #[core::contracts::ensures(
+    //     move |result|
+    //     *result == (self as isize - origin as isize) / (mem::size_of::<T>() as isize))]
     pub const unsafe fn offset_from(self, origin: *const T) -> isize
     where
         T: Sized,
@@ -826,6 +842,14 @@ impl<T: PointeeSized> *const T {
     #[rustc_const_stable(feature = "const_ptr_offset", since = "1.61.0")]
     #[inline(always)]
     #[track_caller]
+    #[rustc_allow_const_fn_unstable(contracts)]
+    #[core::contracts::requires(
+        // Precondition 1: the computed offset `count * size_of::<T>()` does not overflow `isize`.
+        // Precondition 2: adding the computed offset to `self` does not cause overflow.
+        count.checked_mul(core::mem::size_of::<T>()).is_some_and(
+            |computed_offset|
+            computed_offset <= isize::MAX as usize &&
+            (self as isize).checked_add(computed_offset as isize).is_some()))]
     pub const unsafe fn add(self, count: usize) -> Self
     where
         T: Sized,
@@ -932,6 +956,14 @@ impl<T: PointeeSized> *const T {
     #[rustc_const_stable(feature = "const_ptr_offset", since = "1.61.0")]
     #[inline(always)]
     #[track_caller]
+    #[rustc_allow_const_fn_unstable(contracts)]
+    #[core::contracts::requires(
+        // Precondition 1: the computed offset `count * size_of::<T>()` does not overflow `isize`.
+        // Precondition 2: subtracting the computed offset from `self` does not cause overflow.
+        count.checked_mul(core::mem::size_of::<T>()).is_some_and(
+            |computed_offset|
+            computed_offset <= isize::MAX as usize &&
+            (self as isize).checked_sub(computed_offset as isize).is_some()))]
     pub const unsafe fn sub(self, count: usize) -> Self
     where
         T: Sized,

--- a/library/core/src/ptr/unique.rs
+++ b/library/core/src/ptr/unique.rs
@@ -83,6 +83,10 @@ impl<T: PointeeSized> Unique<T> {
     ///
     /// `ptr` must be non-null.
     #[inline]
+    #[rustc_allow_const_fn_unstable(contracts)]
+    #[core::contracts::requires(!ptr.is_null())]
+    // FIXME: requires `T` to be `'static`
+    // #[core::contracts::ensures(move |result: &Unique<T>| result.as_ptr() == ptr)]
     pub const unsafe fn new_unchecked(ptr: *mut T) -> Self {
         // SAFETY: the caller must guarantee that `ptr` is non-null.
         unsafe { Unique { pointer: NonNull::new_unchecked(ptr), _marker: PhantomData } }
@@ -90,6 +94,11 @@ impl<T: PointeeSized> Unique<T> {
 
     /// Creates a new `Unique` if `ptr` is non-null.
     #[inline]
+    #[rustc_allow_const_fn_unstable(contracts)]
+    // FIXME: requires `T` to be `'static`
+    // #[core::contracts::ensures(
+    //     move |result: &Option<Unique<T>>|
+    //     result.is_none() == ptr.is_null() && (result.is_none() || result.unwrap().as_ptr() == ptr))]
     pub const fn new(ptr: *mut T) -> Option<Self> {
         if let Some(pointer) = NonNull::new(ptr) {
             Some(Unique { pointer, _marker: PhantomData })
@@ -107,6 +116,8 @@ impl<T: PointeeSized> Unique<T> {
     /// Acquires the underlying `*mut` pointer.
     #[must_use = "`self` will be dropped if the result is not used"]
     #[inline]
+    #[rustc_allow_const_fn_unstable(contracts)]
+    #[core::contracts::ensures(|result: &*mut T| !result.is_null())]
     pub const fn as_ptr(self) -> *mut T {
         self.pointer.as_ptr()
     }
@@ -114,6 +125,9 @@ impl<T: PointeeSized> Unique<T> {
     /// Acquires the underlying `*mut` pointer.
     #[must_use = "`self` will be dropped if the result is not used"]
     #[inline]
+    // FIXME: requires `T` to be `'static`
+    // #[rustc_allow_const_fn_unstable(contracts)]
+    // #[core::contracts::ensures(move |result: &NonNull<T>| result.as_ptr() == self.pointer.as_ptr())]
     pub const fn as_non_null_ptr(self) -> NonNull<T> {
         self.pointer
     }

--- a/library/core/src/range/iter.rs
+++ b/library/core/src/range/iter.rs
@@ -104,6 +104,7 @@ impl<A: Step> Iterator for IterRange<A> {
     }
 
     #[inline]
+    #[core::contracts::requires(idx < self.size_hint().0)]
     unsafe fn __iterator_get_unchecked(&mut self, idx: usize) -> Self::Item
     where
         Self: TrustedRandomAccessNoCoerce,

--- a/library/core/src/slice/iter.rs
+++ b/library/core/src/slice/iter.rs
@@ -1403,6 +1403,7 @@ impl<'a, T> Iterator for Windows<'a, T> {
         }
     }
 
+    #[core::contracts::requires(idx < self.len())]
     unsafe fn __iterator_get_unchecked(&mut self, idx: usize) -> Self::Item {
         // SAFETY: since the caller guarantees that `i` is in bounds,
         // which means that `i` cannot overflow an `isize`, and the
@@ -1560,6 +1561,7 @@ impl<'a, T> Iterator for Chunks<'a, T> {
         }
     }
 
+    #[core::contracts::requires(idx < self.len())]
     unsafe fn __iterator_get_unchecked(&mut self, idx: usize) -> Self::Item {
         let start = idx * self.chunk_size;
         // SAFETY: the caller guarantees that `i` is in bounds,
@@ -1749,6 +1751,7 @@ impl<'a, T> Iterator for ChunksMut<'a, T> {
         }
     }
 
+    #[core::contracts::requires(idx < self.len())]
     unsafe fn __iterator_get_unchecked(&mut self, idx: usize) -> Self::Item {
         let start = idx * self.chunk_size;
         // SAFETY: see comments for `Chunks::__iterator_get_unchecked` and `self.v`.
@@ -1947,6 +1950,7 @@ impl<'a, T> Iterator for ChunksExact<'a, T> {
         self.next_back()
     }
 
+    #[core::contracts::requires(idx < self.len())]
     unsafe fn __iterator_get_unchecked(&mut self, idx: usize) -> Self::Item {
         let start = idx * self.chunk_size;
         // SAFETY: mostly identical to `Chunks::__iterator_get_unchecked`.
@@ -2108,6 +2112,7 @@ impl<'a, T> Iterator for ChunksExactMut<'a, T> {
         self.next_back()
     }
 
+    #[core::contracts::requires(idx < self.len())]
     unsafe fn __iterator_get_unchecked(&mut self, idx: usize) -> Self::Item {
         let start = idx * self.chunk_size;
         // SAFETY: see comments for `Chunks::__iterator_get_unchecked` and `self.v`.
@@ -2389,6 +2394,7 @@ impl<'a, T> Iterator for RChunks<'a, T> {
         }
     }
 
+    #[core::contracts::requires(idx < self.len())]
     unsafe fn __iterator_get_unchecked(&mut self, idx: usize) -> Self::Item {
         let end = self.v.len() - idx * self.chunk_size;
         let start = match end.checked_sub(self.chunk_size) {
@@ -2569,6 +2575,7 @@ impl<'a, T> Iterator for RChunksMut<'a, T> {
         }
     }
 
+    #[core::contracts::requires(idx < self.len())]
     unsafe fn __iterator_get_unchecked(&mut self, idx: usize) -> Self::Item {
         let end = self.v.len() - idx * self.chunk_size;
         let start = match end.checked_sub(self.chunk_size) {
@@ -2762,6 +2769,7 @@ impl<'a, T> Iterator for RChunksExact<'a, T> {
         self.next_back()
     }
 
+    #[core::contracts::requires(idx < self.len())]
     unsafe fn __iterator_get_unchecked(&mut self, idx: usize) -> Self::Item {
         let end = self.v.len() - idx * self.chunk_size;
         let start = end - self.chunk_size;
@@ -2928,6 +2936,7 @@ impl<'a, T> Iterator for RChunksExactMut<'a, T> {
         self.next_back()
     }
 
+    #[core::contracts::requires(idx < self.len())]
     unsafe fn __iterator_get_unchecked(&mut self, idx: usize) -> Self::Item {
         let end = self.v.len() - idx * self.chunk_size;
         let start = end - self.chunk_size;

--- a/library/core/src/slice/iter/macros.rs
+++ b/library/core/src/slice/iter/macros.rs
@@ -77,6 +77,7 @@ macro_rules! iterator {
             ///
             /// The iterator must not be empty
             #[inline]
+            #[core::contracts::requires(!is_empty!(self))]
             unsafe fn next_back_unchecked(&mut self) -> $elem {
                 // SAFETY: the caller promised it's not empty, so
                 // the offsetting is in-bounds and there's an element to return.
@@ -96,6 +97,7 @@ macro_rules! iterator {
             // returning the old start.
             // Unsafe because the offset must not exceed `self.len()`.
             #[inline(always)]
+            #[core::contracts::requires(offset <= len!(self))]
             unsafe fn post_inc_start(&mut self, offset: usize) -> NonNull<T> {
                 let old = self.ptr;
 
@@ -115,6 +117,7 @@ macro_rules! iterator {
             // returning the new end.
             // Unsafe because the offset must not exceed `self.len()`.
             #[inline(always)]
+            #[core::contracts::requires(offset <= len!(self))]
             unsafe fn pre_dec_end(&mut self, offset: usize) -> NonNull<T> {
                 if_zst!(mut self,
                     // SAFETY: By our precondition, `offset` can be at most the
@@ -392,6 +395,7 @@ macro_rules! iterator {
             }
 
             #[inline]
+            #[core::contracts::requires(idx < len!(self))]
             unsafe fn __iterator_get_unchecked(&mut self, idx: usize) -> Self::Item {
                 // SAFETY: the caller must guarantee that `i` is in bounds of
                 // the underlying slice, so `i` cannot overflow an `isize`, and
@@ -460,6 +464,7 @@ macro_rules! iterator {
 
         impl<'a, T> UncheckedIterator for $name<'a, T> {
             #[inline]
+            #[core::contracts::requires(!is_empty!(self))]
             unsafe fn next_unchecked(&mut self) -> $elem {
                 // SAFETY: The caller promised there's at least one more item.
                 unsafe {

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -4053,6 +4053,25 @@ impl<T> [T] {
     /// ```
     #[stable(feature = "slice_align_to", since = "1.30.0")]
     #[must_use]
+    // FIXME: requires `&self` to be `'static`
+    // #[core::contracts::ensures(
+    //     move |(prefix, middle, suffix): &(&[T], &[U], &[T])|
+    //     // The following clause guarantees that middle is of maximum size within self If U or T are
+    //     // ZSTs, then middle has size zero, so we adapt the check in that case
+    //     (((U::IS_ZST || T::IS_ZST) && prefix.len() == self.len()) || (
+    //         prefix.len() * size_of::<T>() < align_of::<U>() &&
+    //         suffix.len() * size_of::<T>() < size_of::<U>()
+    //     )) &&
+    //     // Either align_to just returns self in the prefix, or the 3 returned slices should be
+    //     // sequential, contiguous, and have same total length as self
+    //     prefix.as_ptr() == self.as_ptr() && (
+    //         prefix.len() == self.len() || (
+    //             unsafe { prefix.as_ptr().add(prefix.len()) } as *const u8 ==
+    //                 middle.as_ptr() as *const u8 &&
+    //             unsafe { middle.as_ptr().add(middle.len()) } as *const u8 ==
+    //                 suffix.as_ptr() as *const u8 &&
+    //             unsafe { suffix.as_ptr().add(suffix.len()) } ==
+    //                 unsafe { self.as_ptr().add(self.len()) })))]
     pub unsafe fn align_to<U>(&self) -> (&[T], &[U], &[T]) {
         // Note that most of this function will be constant-evaluated,
         if U::IS_ZST || T::IS_ZST {

--- a/library/core/src/str/iter.rs
+++ b/library/core/src/str/iter.rs
@@ -356,6 +356,7 @@ impl Iterator for Bytes<'_> {
     }
 
     #[inline]
+    #[core::contracts::requires(idx < self.0.len())]
     unsafe fn __iterator_get_unchecked(&mut self, idx: usize) -> u8 {
         // SAFETY: the caller must uphold the safety contract
         // for `Iterator::__iterator_get_unchecked`.

--- a/library/core/src/str/pattern.rs
+++ b/library/core/src/str/pattern.rs
@@ -1921,6 +1921,7 @@ fn simd_contains(needle: &str, haystack: &str) -> Option<bool> {
     all(target_arch = "loongarch64", target_feature = "lsx")
 ))]
 #[inline]
+#[core::contracts::requires(x.len() == y.len())]
 unsafe fn small_slice_eq(x: &[u8], y: &[u8]) -> bool {
     debug_assert_eq!(x.len(), y.len());
     // This function is adapted from

--- a/library/core/src/time.rs
+++ b/library/core/src/time.rs
@@ -191,6 +191,8 @@ impl Duration {
     #[inline]
     #[must_use]
     #[rustc_const_stable(feature = "duration_consts_2", since = "1.58.0")]
+    #[rustc_allow_const_fn_unstable(contracts)]
+    #[core::contracts::ensures(|duration: &Duration| duration.nanos.as_inner() < NANOS_PER_SEC)]
     pub const fn new(secs: u64, nanos: u32) -> Duration {
         if nanos < NANOS_PER_SEC {
             // SAFETY: nanos < NANOS_PER_SEC, therefore nanos is within the valid range
@@ -221,6 +223,10 @@ impl Duration {
     #[must_use]
     #[inline]
     #[rustc_const_stable(feature = "duration_consts", since = "1.32.0")]
+    #[rustc_allow_const_fn_unstable(contracts)]
+    #[core::contracts::ensures(
+        move |duration: &Duration|
+        duration.nanos.as_inner() < NANOS_PER_SEC && duration.secs == secs)]
     pub const fn from_secs(secs: u64) -> Duration {
         Duration { secs, nanos: Nanoseconds::ZERO }
     }
@@ -241,6 +247,8 @@ impl Duration {
     #[must_use]
     #[inline]
     #[rustc_const_stable(feature = "duration_consts", since = "1.32.0")]
+    #[rustc_allow_const_fn_unstable(contracts)]
+    #[core::contracts::ensures(|duration: &Duration| duration.nanos.as_inner() < NANOS_PER_SEC)]
     pub const fn from_millis(millis: u64) -> Duration {
         let secs = millis / MILLIS_PER_SEC;
         let subsec_millis = (millis % MILLIS_PER_SEC) as u32;
@@ -267,6 +275,8 @@ impl Duration {
     #[must_use]
     #[inline]
     #[rustc_const_stable(feature = "duration_consts", since = "1.32.0")]
+    #[rustc_allow_const_fn_unstable(contracts)]
+    #[core::contracts::ensures(|duration: &Duration| duration.nanos.as_inner() < NANOS_PER_SEC)]
     pub const fn from_micros(micros: u64) -> Duration {
         let secs = micros / MICROS_PER_SEC;
         let subsec_micros = (micros % MICROS_PER_SEC) as u32;
@@ -298,6 +308,8 @@ impl Duration {
     #[must_use]
     #[inline]
     #[rustc_const_stable(feature = "duration_consts", since = "1.32.0")]
+    #[rustc_allow_const_fn_unstable(contracts)]
+    #[core::contracts::ensures(|duration: &Duration| duration.nanos.as_inner() < NANOS_PER_SEC)]
     pub const fn from_nanos(nanos: u64) -> Duration {
         const NANOS_PER_SEC: u64 = self::NANOS_PER_SEC as u64;
         let secs = nanos / NANOS_PER_SEC;
@@ -504,6 +516,9 @@ impl Duration {
     #[rustc_const_stable(feature = "duration_consts", since = "1.32.0")]
     #[must_use]
     #[inline]
+    // FIXME: requires `&self` to be `'static`
+    // #[rustc_allow_const_fn_unstable(contracts)]
+    // #[core::contracts::ensures(move |secs: &u64| *secs == self.secs)]
     pub const fn as_secs(&self) -> u64 {
         self.secs
     }
@@ -527,6 +542,9 @@ impl Duration {
     #[rustc_const_stable(feature = "duration_consts", since = "1.32.0")]
     #[must_use]
     #[inline]
+    // FIXME: requires `&self` to be `'static`
+    // #[rustc_allow_const_fn_unstable(contracts)]
+    // #[core::contracts::ensures(move |ms| *ms == self.nanos.as_inner() / NANOS_PER_MILLI)]
     pub const fn subsec_millis(&self) -> u32 {
         self.nanos.as_inner() / NANOS_PER_MILLI
     }
@@ -550,6 +568,9 @@ impl Duration {
     #[rustc_const_stable(feature = "duration_consts", since = "1.32.0")]
     #[must_use]
     #[inline]
+    // FIXME: requires `&self` to be `'static`
+    // #[rustc_allow_const_fn_unstable(contracts)]
+    // #[core::contracts::ensures(|ms| *ms == self.nanos.as_inner() / NANOS_PER_MICRO)]
     pub const fn subsec_micros(&self) -> u32 {
         self.nanos.as_inner() / NANOS_PER_MICRO
     }
@@ -573,6 +594,9 @@ impl Duration {
     #[rustc_const_stable(feature = "duration_consts", since = "1.32.0")]
     #[must_use]
     #[inline]
+    // FIXME: requires `&self` to be `'static`
+    // #[rustc_allow_const_fn_unstable(contracts)]
+    // #[core::contracts::ensures(|nanos| *nanos == self.nanos.as_inner())]
     pub const fn subsec_nanos(&self) -> u32 {
         self.nanos.as_inner()
     }
@@ -591,6 +615,12 @@ impl Duration {
     #[rustc_const_stable(feature = "duration_as_u128", since = "1.33.0")]
     #[must_use]
     #[inline]
+    // FIXME: requires `&self` to be `'static`
+    // #[rustc_allow_const_fn_unstable(contracts)]
+    // #[core::contracts::ensures(
+    //     |ms|
+    //     *ms == self.secs as u128 * MILLIS_PER_SEC as u128 +
+    //         (self.nanos.as_inner() / NANOS_PER_MILLI) as u128)]
     pub const fn as_millis(&self) -> u128 {
         self.secs as u128 * MILLIS_PER_SEC as u128
             + (self.nanos.as_inner() / NANOS_PER_MILLI) as u128
@@ -610,6 +640,12 @@ impl Duration {
     #[rustc_const_stable(feature = "duration_as_u128", since = "1.33.0")]
     #[must_use]
     #[inline]
+    // FIXME: requires `&self` to be `'static`
+    // #[rustc_allow_const_fn_unstable(contracts)]
+    // #[core::contracts::ensures(
+    //     |ms|
+    //     *ms == self.secs as u128 * MICROS_PER_SEC as u128 +
+    //         (self.nanos.as_inner() / NANOS_PER_MICRO) as u128)]
     pub const fn as_micros(&self) -> u128 {
         self.secs as u128 * MICROS_PER_SEC as u128
             + (self.nanos.as_inner() / NANOS_PER_MICRO) as u128
@@ -668,6 +704,10 @@ impl Duration {
                   without modifying the original"]
     #[inline]
     #[rustc_const_stable(feature = "duration_consts_2", since = "1.58.0")]
+    #[rustc_allow_const_fn_unstable(contracts)]
+    #[core::contracts::ensures(
+        |duration: &Option<Duration>|
+        duration.is_none() || duration.unwrap().nanos.as_inner() < NANOS_PER_SEC)]
     pub const fn checked_add(self, rhs: Duration) -> Option<Duration> {
         if let Some(mut secs) = self.secs.checked_add(rhs.secs) {
             let mut nanos = self.nanos.as_inner() + rhs.nanos.as_inner();
@@ -726,6 +766,10 @@ impl Duration {
                   without modifying the original"]
     #[inline]
     #[rustc_const_stable(feature = "duration_consts_2", since = "1.58.0")]
+    #[rustc_allow_const_fn_unstable(contracts)]
+    #[core::contracts::ensures(
+        |duration: &Option<Duration>|
+        duration.is_none() || duration.unwrap().nanos.as_inner() < NANOS_PER_SEC)]
     pub const fn checked_sub(self, rhs: Duration) -> Option<Duration> {
         if let Some(mut secs) = self.secs.checked_sub(rhs.secs) {
             let nanos = if self.nanos.as_inner() >= rhs.nanos.as_inner() {
@@ -782,6 +826,10 @@ impl Duration {
                   without modifying the original"]
     #[inline]
     #[rustc_const_stable(feature = "duration_consts_2", since = "1.58.0")]
+    #[rustc_allow_const_fn_unstable(contracts)]
+    #[core::contracts::ensures(
+        |duration: &Option<Duration>|
+        duration.is_none() || duration.unwrap().nanos.as_inner() < NANOS_PER_SEC)]
     pub const fn checked_mul(self, rhs: u32) -> Option<Duration> {
         // Multiply nanoseconds as u64, because it cannot overflow that way.
         let total_nanos = self.nanos.as_inner() as u64 * rhs as u64;
@@ -838,6 +886,10 @@ impl Duration {
                   without modifying the original"]
     #[inline]
     #[rustc_const_stable(feature = "duration_consts_2", since = "1.58.0")]
+    #[rustc_allow_const_fn_unstable(contracts)]
+    #[core::contracts::ensures(
+        move |duration: &Option<Duration>|
+        rhs == 0 || duration.unwrap().nanos.as_inner() < NANOS_PER_SEC)]
     pub const fn checked_div(self, rhs: u32) -> Option<Duration> {
         if rhs != 0 {
             let (secs, extra_secs) = (self.secs / (rhs as u64), self.secs % (rhs as u64));

--- a/library/std/src/alloc.rs
+++ b/library/std/src/alloc.rs
@@ -151,6 +151,11 @@ impl System {
 
     // SAFETY: Same as `Allocator::grow`
     #[inline]
+    #[core::contracts::requires(
+        new_layout.size() >= old_layout.size() &&
+        ptr.as_ptr().is_aligned_to(old_layout.align()) &&
+        (old_layout.size() == 0 || old_layout.align() != 0) &&
+        (new_layout.size() == 0 || new_layout.align() != 0))]
     unsafe fn grow_impl(
         &self,
         ptr: NonNull<u8>,
@@ -213,6 +218,7 @@ unsafe impl Allocator for System {
     }
 
     #[inline]
+    #[core::contracts::requires(layout.size() != 0)]
     unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
         if layout.size() != 0 {
             // SAFETY: `layout` is non-zero in size,
@@ -222,6 +228,7 @@ unsafe impl Allocator for System {
     }
 
     #[inline]
+    #[core::contracts::requires(new_layout.size() >= old_layout.size())]
     unsafe fn grow(
         &self,
         ptr: NonNull<u8>,
@@ -233,6 +240,7 @@ unsafe impl Allocator for System {
     }
 
     #[inline]
+    #[core::contracts::requires(new_layout.size() >= old_layout.size())]
     unsafe fn grow_zeroed(
         &self,
         ptr: NonNull<u8>,
@@ -244,6 +252,7 @@ unsafe impl Allocator for System {
     }
 
     #[inline]
+    #[core::contracts::requires(new_layout.size() <= old_layout.size())]
     unsafe fn shrink(
         &self,
         ptr: NonNull<u8>,
@@ -395,6 +404,7 @@ pub mod __default_lib_allocator {
     // ABI
 
     #[rustc_std_internal_symbol]
+    #[core::contracts::requires(align.is_power_of_two())]
     pub unsafe extern "C" fn __rdl_alloc(size: usize, align: usize) -> *mut u8 {
         // SAFETY: see the guarantees expected by `Layout::from_size_align` and
         // `GlobalAlloc::alloc`.
@@ -405,6 +415,7 @@ pub mod __default_lib_allocator {
     }
 
     #[rustc_std_internal_symbol]
+    #[core::contracts::requires(align.is_power_of_two())]
     pub unsafe extern "C" fn __rdl_dealloc(ptr: *mut u8, size: usize, align: usize) {
         // SAFETY: see the guarantees expected by `Layout::from_size_align` and
         // `GlobalAlloc::dealloc`.
@@ -412,6 +423,7 @@ pub mod __default_lib_allocator {
     }
 
     #[rustc_std_internal_symbol]
+    #[core::contracts::requires(align.is_power_of_two())]
     pub unsafe extern "C" fn __rdl_realloc(
         ptr: *mut u8,
         old_size: usize,
@@ -427,6 +439,7 @@ pub mod __default_lib_allocator {
     }
 
     #[rustc_std_internal_symbol]
+    #[core::contracts::requires(align.is_power_of_two())]
     pub unsafe extern "C" fn __rdl_alloc_zeroed(size: usize, align: usize) -> *mut u8 {
         // SAFETY: see the guarantees expected by `Layout::from_size_align` and
         // `GlobalAlloc::alloc_zeroed`.

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -253,6 +253,8 @@
 #![deny(ffi_unwind_calls)]
 // std may use features in a platform-specific way
 #![allow(unused_features)]
+// permit use of experimental feature contracts
+#![allow(incomplete_features)]
 //
 // Features:
 #![cfg_attr(test, feature(internal_output_capture, print_internals, update_panic_count, rt))]
@@ -278,6 +280,7 @@
 #![feature(cfi_encoding)]
 #![feature(char_max_len)]
 #![feature(const_trait_impl)]
+#![feature(contracts)]
 #![feature(core_float_math)]
 #![feature(decl_macro)]
 #![feature(deprecated_suggestion)]

--- a/library/std/src/sync/mpmc/context.rs
+++ b/library/std/src/sync/mpmc/context.rs
@@ -116,6 +116,7 @@ impl Context {
     /// # Safety
     /// This may only be called from the thread this `Context` belongs to.
     #[inline]
+    #[core::contracts::requires(self.thread_id() == current_thread_id())]
     pub unsafe fn wait_until(&self, deadline: Option<Instant>) -> Selected {
         loop {
             // Check whether an operation has been selected.

--- a/src/tools/miri/tests/pass/shims/time-with-isolation.stdout
+++ b/src/tools/miri/tests/pass/shims/time-with-isolation.stdout
@@ -1,2 +1,2 @@
-The loop took around 1350ms
+The loop took around 1450ms
 (It's fine for this number to change when you `--bless` this test.)

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.32bit.panic-abort.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.32bit.panic-abort.diff
@@ -18,21 +18,29 @@
               scope 5 (inlined NonNull::<[bool; 0]>::dangling) {
                   let mut _6: std::num::NonZero<usize>;
                   scope 6 {
-                      scope 8 (inlined std::ptr::Alignment::as_nonzero) {
+                      scope 7 {
+                          scope 9 {
+                          }
                       }
-                      scope 9 (inlined NonNull::<[bool; 0]>::without_provenance) {
-                          let _7: *const [bool; 0];
-                          scope 10 {
+                      scope 8 {
+                          scope 12 (inlined std::ptr::Alignment::as_nonzero) {
                           }
-                          scope 11 (inlined NonZero::<usize>::get) {
-                          }
-                          scope 12 (inlined std::ptr::without_provenance::<[bool; 0]>) {
-                              scope 13 (inlined without_provenance_mut::<[bool; 0]>) {
+                          scope 13 (inlined NonNull::<[bool; 0]>::without_provenance) {
+                              let _7: *const [bool; 0];
+                              scope 14 {
+                              }
+                              scope 15 (inlined NonZero::<usize>::get) {
+                              }
+                              scope 16 (inlined std::ptr::without_provenance::<[bool; 0]>) {
+                                  scope 17 (inlined without_provenance_mut::<[bool; 0]>) {
+                                  }
                               }
                           }
                       }
+                      scope 11 (inlined std::ptr::Alignment::of::<[bool; 0]>) {
+                      }
                   }
-                  scope 7 (inlined std::ptr::Alignment::of::<[bool; 0]>) {
+                  scope 10 (inlined core::contracts::build_check_ensures::<NonNull<[bool; 0]>, {closure@NonNull<[bool; 0]>::dangling::{closure#0}}>) {
                   }
               }
           }

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.32bit.panic-unwind.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.32bit.panic-unwind.diff
@@ -18,21 +18,29 @@
               scope 5 (inlined NonNull::<[bool; 0]>::dangling) {
                   let mut _6: std::num::NonZero<usize>;
                   scope 6 {
-                      scope 8 (inlined std::ptr::Alignment::as_nonzero) {
+                      scope 7 {
+                          scope 9 {
+                          }
                       }
-                      scope 9 (inlined NonNull::<[bool; 0]>::without_provenance) {
-                          let _7: *const [bool; 0];
-                          scope 10 {
+                      scope 8 {
+                          scope 12 (inlined std::ptr::Alignment::as_nonzero) {
                           }
-                          scope 11 (inlined NonZero::<usize>::get) {
-                          }
-                          scope 12 (inlined std::ptr::without_provenance::<[bool; 0]>) {
-                              scope 13 (inlined without_provenance_mut::<[bool; 0]>) {
+                          scope 13 (inlined NonNull::<[bool; 0]>::without_provenance) {
+                              let _7: *const [bool; 0];
+                              scope 14 {
+                              }
+                              scope 15 (inlined NonZero::<usize>::get) {
+                              }
+                              scope 16 (inlined std::ptr::without_provenance::<[bool; 0]>) {
+                                  scope 17 (inlined without_provenance_mut::<[bool; 0]>) {
+                                  }
                               }
                           }
                       }
+                      scope 11 (inlined std::ptr::Alignment::of::<[bool; 0]>) {
+                      }
                   }
-                  scope 7 (inlined std::ptr::Alignment::of::<[bool; 0]>) {
+                  scope 10 (inlined core::contracts::build_check_ensures::<NonNull<[bool; 0]>, {closure@NonNull<[bool; 0]>::dangling::{closure#0}}>) {
                   }
               }
           }

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.64bit.panic-abort.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.64bit.panic-abort.diff
@@ -18,21 +18,29 @@
               scope 5 (inlined NonNull::<[bool; 0]>::dangling) {
                   let mut _6: std::num::NonZero<usize>;
                   scope 6 {
-                      scope 8 (inlined std::ptr::Alignment::as_nonzero) {
+                      scope 7 {
+                          scope 9 {
+                          }
                       }
-                      scope 9 (inlined NonNull::<[bool; 0]>::without_provenance) {
-                          let _7: *const [bool; 0];
-                          scope 10 {
+                      scope 8 {
+                          scope 12 (inlined std::ptr::Alignment::as_nonzero) {
                           }
-                          scope 11 (inlined NonZero::<usize>::get) {
-                          }
-                          scope 12 (inlined std::ptr::without_provenance::<[bool; 0]>) {
-                              scope 13 (inlined without_provenance_mut::<[bool; 0]>) {
+                          scope 13 (inlined NonNull::<[bool; 0]>::without_provenance) {
+                              let _7: *const [bool; 0];
+                              scope 14 {
+                              }
+                              scope 15 (inlined NonZero::<usize>::get) {
+                              }
+                              scope 16 (inlined std::ptr::without_provenance::<[bool; 0]>) {
+                                  scope 17 (inlined without_provenance_mut::<[bool; 0]>) {
+                                  }
                               }
                           }
                       }
+                      scope 11 (inlined std::ptr::Alignment::of::<[bool; 0]>) {
+                      }
                   }
-                  scope 7 (inlined std::ptr::Alignment::of::<[bool; 0]>) {
+                  scope 10 (inlined core::contracts::build_check_ensures::<NonNull<[bool; 0]>, {closure@NonNull<[bool; 0]>::dangling::{closure#0}}>) {
                   }
               }
           }

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.64bit.panic-unwind.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.64bit.panic-unwind.diff
@@ -18,21 +18,29 @@
               scope 5 (inlined NonNull::<[bool; 0]>::dangling) {
                   let mut _6: std::num::NonZero<usize>;
                   scope 6 {
-                      scope 8 (inlined std::ptr::Alignment::as_nonzero) {
+                      scope 7 {
+                          scope 9 {
+                          }
                       }
-                      scope 9 (inlined NonNull::<[bool; 0]>::without_provenance) {
-                          let _7: *const [bool; 0];
-                          scope 10 {
+                      scope 8 {
+                          scope 12 (inlined std::ptr::Alignment::as_nonzero) {
                           }
-                          scope 11 (inlined NonZero::<usize>::get) {
-                          }
-                          scope 12 (inlined std::ptr::without_provenance::<[bool; 0]>) {
-                              scope 13 (inlined without_provenance_mut::<[bool; 0]>) {
+                          scope 13 (inlined NonNull::<[bool; 0]>::without_provenance) {
+                              let _7: *const [bool; 0];
+                              scope 14 {
+                              }
+                              scope 15 (inlined NonZero::<usize>::get) {
+                              }
+                              scope 16 (inlined std::ptr::without_provenance::<[bool; 0]>) {
+                                  scope 17 (inlined without_provenance_mut::<[bool; 0]>) {
+                                  }
                               }
                           }
                       }
+                      scope 11 (inlined std::ptr::Alignment::of::<[bool; 0]>) {
+                      }
                   }
-                  scope 7 (inlined std::ptr::Alignment::of::<[bool; 0]>) {
+                  scope 10 (inlined core::contracts::build_check_ensures::<NonNull<[bool; 0]>, {closure@NonNull<[bool; 0]>::dangling::{closure#0}}>) {
                   }
               }
           }

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.32bit.panic-abort.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.32bit.panic-abort.diff
@@ -18,21 +18,29 @@
               scope 5 (inlined NonNull::<[bool; 0]>::dangling) {
                   let mut _6: std::num::NonZero<usize>;
                   scope 6 {
-                      scope 8 (inlined std::ptr::Alignment::as_nonzero) {
+                      scope 7 {
+                          scope 9 {
+                          }
                       }
-                      scope 9 (inlined NonNull::<[bool; 0]>::without_provenance) {
-                          let _7: *const [bool; 0];
-                          scope 10 {
+                      scope 8 {
+                          scope 12 (inlined std::ptr::Alignment::as_nonzero) {
                           }
-                          scope 11 (inlined NonZero::<usize>::get) {
-                          }
-                          scope 12 (inlined std::ptr::without_provenance::<[bool; 0]>) {
-                              scope 13 (inlined without_provenance_mut::<[bool; 0]>) {
+                          scope 13 (inlined NonNull::<[bool; 0]>::without_provenance) {
+                              let _7: *const [bool; 0];
+                              scope 14 {
+                              }
+                              scope 15 (inlined NonZero::<usize>::get) {
+                              }
+                              scope 16 (inlined std::ptr::without_provenance::<[bool; 0]>) {
+                                  scope 17 (inlined without_provenance_mut::<[bool; 0]>) {
+                                  }
                               }
                           }
                       }
+                      scope 11 (inlined std::ptr::Alignment::of::<[bool; 0]>) {
+                      }
                   }
-                  scope 7 (inlined std::ptr::Alignment::of::<[bool; 0]>) {
+                  scope 10 (inlined core::contracts::build_check_ensures::<NonNull<[bool; 0]>, {closure@NonNull<[bool; 0]>::dangling::{closure#0}}>) {
                   }
               }
           }

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.32bit.panic-unwind.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.32bit.panic-unwind.diff
@@ -18,21 +18,29 @@
               scope 5 (inlined NonNull::<[bool; 0]>::dangling) {
                   let mut _6: std::num::NonZero<usize>;
                   scope 6 {
-                      scope 8 (inlined std::ptr::Alignment::as_nonzero) {
+                      scope 7 {
+                          scope 9 {
+                          }
                       }
-                      scope 9 (inlined NonNull::<[bool; 0]>::without_provenance) {
-                          let _7: *const [bool; 0];
-                          scope 10 {
+                      scope 8 {
+                          scope 12 (inlined std::ptr::Alignment::as_nonzero) {
                           }
-                          scope 11 (inlined NonZero::<usize>::get) {
-                          }
-                          scope 12 (inlined std::ptr::without_provenance::<[bool; 0]>) {
-                              scope 13 (inlined without_provenance_mut::<[bool; 0]>) {
+                          scope 13 (inlined NonNull::<[bool; 0]>::without_provenance) {
+                              let _7: *const [bool; 0];
+                              scope 14 {
+                              }
+                              scope 15 (inlined NonZero::<usize>::get) {
+                              }
+                              scope 16 (inlined std::ptr::without_provenance::<[bool; 0]>) {
+                                  scope 17 (inlined without_provenance_mut::<[bool; 0]>) {
+                                  }
                               }
                           }
                       }
+                      scope 11 (inlined std::ptr::Alignment::of::<[bool; 0]>) {
+                      }
                   }
-                  scope 7 (inlined std::ptr::Alignment::of::<[bool; 0]>) {
+                  scope 10 (inlined core::contracts::build_check_ensures::<NonNull<[bool; 0]>, {closure@NonNull<[bool; 0]>::dangling::{closure#0}}>) {
                   }
               }
           }

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.64bit.panic-abort.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.64bit.panic-abort.diff
@@ -18,21 +18,29 @@
               scope 5 (inlined NonNull::<[bool; 0]>::dangling) {
                   let mut _6: std::num::NonZero<usize>;
                   scope 6 {
-                      scope 8 (inlined std::ptr::Alignment::as_nonzero) {
+                      scope 7 {
+                          scope 9 {
+                          }
                       }
-                      scope 9 (inlined NonNull::<[bool; 0]>::without_provenance) {
-                          let _7: *const [bool; 0];
-                          scope 10 {
+                      scope 8 {
+                          scope 12 (inlined std::ptr::Alignment::as_nonzero) {
                           }
-                          scope 11 (inlined NonZero::<usize>::get) {
-                          }
-                          scope 12 (inlined std::ptr::without_provenance::<[bool; 0]>) {
-                              scope 13 (inlined without_provenance_mut::<[bool; 0]>) {
+                          scope 13 (inlined NonNull::<[bool; 0]>::without_provenance) {
+                              let _7: *const [bool; 0];
+                              scope 14 {
+                              }
+                              scope 15 (inlined NonZero::<usize>::get) {
+                              }
+                              scope 16 (inlined std::ptr::without_provenance::<[bool; 0]>) {
+                                  scope 17 (inlined without_provenance_mut::<[bool; 0]>) {
+                                  }
                               }
                           }
                       }
+                      scope 11 (inlined std::ptr::Alignment::of::<[bool; 0]>) {
+                      }
                   }
-                  scope 7 (inlined std::ptr::Alignment::of::<[bool; 0]>) {
+                  scope 10 (inlined core::contracts::build_check_ensures::<NonNull<[bool; 0]>, {closure@NonNull<[bool; 0]>::dangling::{closure#0}}>) {
                   }
               }
           }

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.64bit.panic-unwind.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.64bit.panic-unwind.diff
@@ -18,21 +18,29 @@
               scope 5 (inlined NonNull::<[bool; 0]>::dangling) {
                   let mut _6: std::num::NonZero<usize>;
                   scope 6 {
-                      scope 8 (inlined std::ptr::Alignment::as_nonzero) {
+                      scope 7 {
+                          scope 9 {
+                          }
                       }
-                      scope 9 (inlined NonNull::<[bool; 0]>::without_provenance) {
-                          let _7: *const [bool; 0];
-                          scope 10 {
+                      scope 8 {
+                          scope 12 (inlined std::ptr::Alignment::as_nonzero) {
                           }
-                          scope 11 (inlined NonZero::<usize>::get) {
-                          }
-                          scope 12 (inlined std::ptr::without_provenance::<[bool; 0]>) {
-                              scope 13 (inlined without_provenance_mut::<[bool; 0]>) {
+                          scope 13 (inlined NonNull::<[bool; 0]>::without_provenance) {
+                              let _7: *const [bool; 0];
+                              scope 14 {
+                              }
+                              scope 15 (inlined NonZero::<usize>::get) {
+                              }
+                              scope 16 (inlined std::ptr::without_provenance::<[bool; 0]>) {
+                                  scope 17 (inlined without_provenance_mut::<[bool; 0]>) {
+                                  }
                               }
                           }
                       }
+                      scope 11 (inlined std::ptr::Alignment::of::<[bool; 0]>) {
+                      }
                   }
-                  scope 7 (inlined std::ptr::Alignment::of::<[bool; 0]>) {
+                  scope 10 (inlined core::contracts::build_check_ensures::<NonNull<[bool; 0]>, {closure@NonNull<[bool; 0]>::dangling::{closure#0}}>) {
                   }
               }
           }

--- a/tests/mir-opt/dont_reset_cast_kind_without_updating_operand.test.GVN.32bit.panic-abort.diff
+++ b/tests/mir-opt/dont_reset_cast_kind_without_updating_operand.test.GVN.32bit.panic-abort.diff
@@ -13,7 +13,7 @@
       let mut _11: *const ();
       let mut _16: usize;
       let mut _17: usize;
-      let mut _27: usize;
+      let mut _30: usize;
       scope 1 {
           debug vp_ctx => _1;
           let _5: *const ();
@@ -26,12 +26,12 @@
                   scope 4 {
                       debug _x => _8;
                   }
-                  scope 18 (inlined foo) {
-                      let mut _28: *const [()];
+                  scope 22 (inlined foo) {
+                      let mut _31: *const [()];
                   }
               }
-              scope 16 (inlined slice_from_raw_parts::<()>) {
-                  scope 17 (inlined std::ptr::from_raw_parts::<[()], ()>) {
+              scope 20 (inlined slice_from_raw_parts::<()>) {
+                  scope 21 (inlined std::ptr::from_raw_parts::<[()], ()>) {
                   }
               }
           }
@@ -49,25 +49,36 @@
               scope 7 {
                   let _21: std::ptr::NonNull<[u8]>;
                   scope 8 {
-                      scope 11 (inlined NonNull::<[u8]>::as_mut_ptr) {
-                          scope 12 (inlined NonNull::<[u8]>::as_non_null_ptr) {
-                              scope 13 (inlined NonNull::<[u8]>::cast::<u8>) {
-                                  let mut _26: *mut [u8];
-                                  scope 14 (inlined NonNull::<[u8]>::as_ptr) {
+                      scope 15 (inlined NonNull::<[u8]>::as_mut_ptr) {
+                          scope 16 (inlined NonNull::<[u8]>::as_non_null_ptr) {
+                              scope 17 (inlined NonNull::<[u8]>::cast::<u8>) {
+                                  let mut _27: *mut [u8];
+                                  scope 18 (inlined NonNull::<[u8]>::as_ptr) {
                                   }
                               }
                           }
-                          scope 15 (inlined NonNull::<u8>::as_ptr) {
+                          scope 19 (inlined NonNull::<u8>::as_ptr) {
                           }
                       }
                   }
-                  scope 10 (inlined <std::alloc::Global as Allocator>::allocate) {
+                  scope 14 (inlined <std::alloc::Global as Allocator>::allocate) {
                   }
               }
               scope 9 (inlined #[track_caller] Layout::from_size_align_unchecked) {
-                  let mut _23: bool;
-                  let _24: ();
-                  let mut _25: std::ptr::Alignment;
+                  let _23: std::option::Option<{closure@std::alloc::Layout::from_size_align_unchecked::{closure#1}}>;
+                  let mut _24: bool;
+                  let _25: ();
+                  let mut _26: std::ptr::Alignment;
+                  let mut _28: usize;
+                  let mut _29: usize;
+                  scope 10 {
+                      scope 11 {
+                          scope 12 {
+                          }
+                      }
+                  }
+                  scope 13 (inlined core::contracts::build_check_ensures::<Layout, {closure@Layout::from_size_align_unchecked::{closure#1}}>) {
+                  }
               }
           }
       }
@@ -94,10 +105,12 @@
           StorageLive(_20);
           StorageLive(_21);
           StorageLive(_22);
-          StorageLive(_24);
+          StorageLive(_25);
           StorageLive(_23);
-          _23 = UbChecks();
-          switchInt(move _23) -> [0: bb6, otherwise: bb5];
+          _23 = Option::<{closure@Layout::from_size_align_unchecked::{closure#1}}>::None;
+          StorageLive(_24);
+          _24 = UbChecks();
+          switchInt(move _24) -> [0: bb6, otherwise: bb5];
       }
   
       bb1: {
@@ -117,14 +130,14 @@
   
       bb4: {
           _21 = copy ((_19 as Ok).0: std::ptr::NonNull<[u8]>);
--         StorageLive(_26);
+-         StorageLive(_27);
 +         nop;
-          _26 = copy _21 as *mut [u8] (Transmute);
-          _12 = copy _26 as *mut u8 (PtrToPtr);
--         StorageDead(_26);
+          _27 = copy _21 as *mut [u8] (Transmute);
+          _12 = copy _27 as *mut u8 (PtrToPtr);
+-         StorageDead(_27);
 +         nop;
           StorageDead(_19);
-          StorageDead(_24);
+          StorageDead(_25);
           StorageDead(_22);
           StorageDead(_21);
           StorageDead(_20);
@@ -132,7 +145,7 @@
           StorageDead(_17);
           StorageDead(_16);
 -         _13 = copy _12 as *const () (PtrToPtr);
-+         _13 = copy _26 as *const () (PtrToPtr);
++         _13 = copy _27 as *const () (PtrToPtr);
           _14 = NonNull::<()> { pointer: copy _13 };
           _15 = Unique::<()> { pointer: copy _14, _marker: const PhantomData::<()> };
           _3 = Box::<()>(move _15, const std::alloc::Global);
@@ -157,21 +170,21 @@
 +         nop;
           StorageLive(_7);
           _7 = copy _5;
-          StorageLive(_27);
-          _27 = const 1_usize;
--         _6 = *const [()] from (copy _7, copy _27);
+          StorageLive(_30);
+          _30 = const 1_usize;
+-         _6 = *const [()] from (copy _7, copy _30);
 +         _6 = *const [()] from (copy _5, const 1_usize);
-          StorageDead(_27);
+          StorageDead(_30);
           StorageDead(_7);
           StorageLive(_8);
           StorageLive(_9);
           _9 = copy _6;
-          StorageLive(_28);
--         _28 = copy _9;
+          StorageLive(_31);
+-         _31 = copy _9;
 -         _8 = copy _9 as *mut () (PtrToPtr);
-+         _28 = copy _6;
++         _31 = copy _6;
 +         _8 = copy _5 as *mut () (PtrToPtr);
-          StorageDead(_28);
+          StorageDead(_31);
           StorageDead(_9);
           _0 = const ();
           StorageDead(_8);
@@ -183,18 +196,19 @@
       }
   
       bb5: {
--         _24 = Layout::from_size_align_unchecked::precondition_check(copy _16, copy _17) -> [return: bb6, unwind unreachable];
-+         _24 = Layout::from_size_align_unchecked::precondition_check(const 0_usize, const 1_usize) -> [return: bb6, unwind unreachable];
+-         _25 = Layout::from_size_align_unchecked::precondition_check(copy _16, copy _17) -> [return: bb6, unwind unreachable];
++         _25 = Layout::from_size_align_unchecked::precondition_check(const 0_usize, const 1_usize) -> [return: bb6, unwind unreachable];
       }
   
       bb6: {
-          StorageDead(_23);
-          StorageLive(_25);
--         _25 = copy _17 as std::ptr::Alignment (Transmute);
--         _18 = Layout { size: copy _16, align: move _25 };
-+         _25 = const std::ptr::Alignment(std::ptr::alignment::AlignmentEnum::_Align1Shl0);
+          StorageDead(_24);
+          StorageLive(_26);
+-         _26 = copy _17 as std::ptr::Alignment (Transmute);
+-         _18 = Layout { size: copy _16, align: move _26 };
++         _26 = const std::ptr::Alignment(std::ptr::alignment::AlignmentEnum::_Align1Shl0);
 +         _18 = const Layout {{ size: 0_usize, align: std::ptr::Alignment(std::ptr::alignment::AlignmentEnum::_Align1Shl0) }};
-          StorageDead(_25);
+          StorageDead(_26);
+          StorageDead(_23);
           StorageLive(_19);
 -         _19 = std::alloc::Global::alloc_impl(const alloc::alloc::exchange_malloc::promoted[0], copy _18, const false) -> [return: bb7, unwind unreachable];
 +         _19 = std::alloc::Global::alloc_impl(const alloc::alloc::exchange_malloc::promoted[0], const Layout {{ size: 0_usize, align: std::ptr::Alignment(std::ptr::alignment::AlignmentEnum::_Align1Shl0) }}, const false) -> [return: bb7, unwind unreachable];

--- a/tests/mir-opt/dont_reset_cast_kind_without_updating_operand.test.GVN.64bit.panic-abort.diff
+++ b/tests/mir-opt/dont_reset_cast_kind_without_updating_operand.test.GVN.64bit.panic-abort.diff
@@ -13,7 +13,7 @@
       let mut _11: *const ();
       let mut _16: usize;
       let mut _17: usize;
-      let mut _27: usize;
+      let mut _30: usize;
       scope 1 {
           debug vp_ctx => _1;
           let _5: *const ();
@@ -26,12 +26,12 @@
                   scope 4 {
                       debug _x => _8;
                   }
-                  scope 18 (inlined foo) {
-                      let mut _28: *const [()];
+                  scope 22 (inlined foo) {
+                      let mut _31: *const [()];
                   }
               }
-              scope 16 (inlined slice_from_raw_parts::<()>) {
-                  scope 17 (inlined std::ptr::from_raw_parts::<[()], ()>) {
+              scope 20 (inlined slice_from_raw_parts::<()>) {
+                  scope 21 (inlined std::ptr::from_raw_parts::<[()], ()>) {
                   }
               }
           }
@@ -49,25 +49,36 @@
               scope 7 {
                   let _21: std::ptr::NonNull<[u8]>;
                   scope 8 {
-                      scope 11 (inlined NonNull::<[u8]>::as_mut_ptr) {
-                          scope 12 (inlined NonNull::<[u8]>::as_non_null_ptr) {
-                              scope 13 (inlined NonNull::<[u8]>::cast::<u8>) {
-                                  let mut _26: *mut [u8];
-                                  scope 14 (inlined NonNull::<[u8]>::as_ptr) {
+                      scope 15 (inlined NonNull::<[u8]>::as_mut_ptr) {
+                          scope 16 (inlined NonNull::<[u8]>::as_non_null_ptr) {
+                              scope 17 (inlined NonNull::<[u8]>::cast::<u8>) {
+                                  let mut _27: *mut [u8];
+                                  scope 18 (inlined NonNull::<[u8]>::as_ptr) {
                                   }
                               }
                           }
-                          scope 15 (inlined NonNull::<u8>::as_ptr) {
+                          scope 19 (inlined NonNull::<u8>::as_ptr) {
                           }
                       }
                   }
-                  scope 10 (inlined <std::alloc::Global as Allocator>::allocate) {
+                  scope 14 (inlined <std::alloc::Global as Allocator>::allocate) {
                   }
               }
               scope 9 (inlined #[track_caller] Layout::from_size_align_unchecked) {
-                  let mut _23: bool;
-                  let _24: ();
-                  let mut _25: std::ptr::Alignment;
+                  let _23: std::option::Option<{closure@std::alloc::Layout::from_size_align_unchecked::{closure#1}}>;
+                  let mut _24: bool;
+                  let _25: ();
+                  let mut _26: std::ptr::Alignment;
+                  let mut _28: usize;
+                  let mut _29: usize;
+                  scope 10 {
+                      scope 11 {
+                          scope 12 {
+                          }
+                      }
+                  }
+                  scope 13 (inlined core::contracts::build_check_ensures::<Layout, {closure@Layout::from_size_align_unchecked::{closure#1}}>) {
+                  }
               }
           }
       }
@@ -94,10 +105,12 @@
           StorageLive(_20);
           StorageLive(_21);
           StorageLive(_22);
-          StorageLive(_24);
+          StorageLive(_25);
           StorageLive(_23);
-          _23 = UbChecks();
-          switchInt(move _23) -> [0: bb6, otherwise: bb5];
+          _23 = Option::<{closure@Layout::from_size_align_unchecked::{closure#1}}>::None;
+          StorageLive(_24);
+          _24 = UbChecks();
+          switchInt(move _24) -> [0: bb6, otherwise: bb5];
       }
   
       bb1: {
@@ -117,14 +130,14 @@
   
       bb4: {
           _21 = copy ((_19 as Ok).0: std::ptr::NonNull<[u8]>);
--         StorageLive(_26);
+-         StorageLive(_27);
 +         nop;
-          _26 = copy _21 as *mut [u8] (Transmute);
-          _12 = copy _26 as *mut u8 (PtrToPtr);
--         StorageDead(_26);
+          _27 = copy _21 as *mut [u8] (Transmute);
+          _12 = copy _27 as *mut u8 (PtrToPtr);
+-         StorageDead(_27);
 +         nop;
           StorageDead(_19);
-          StorageDead(_24);
+          StorageDead(_25);
           StorageDead(_22);
           StorageDead(_21);
           StorageDead(_20);
@@ -132,7 +145,7 @@
           StorageDead(_17);
           StorageDead(_16);
 -         _13 = copy _12 as *const () (PtrToPtr);
-+         _13 = copy _26 as *const () (PtrToPtr);
++         _13 = copy _27 as *const () (PtrToPtr);
           _14 = NonNull::<()> { pointer: copy _13 };
           _15 = Unique::<()> { pointer: copy _14, _marker: const PhantomData::<()> };
           _3 = Box::<()>(move _15, const std::alloc::Global);
@@ -157,21 +170,21 @@
 +         nop;
           StorageLive(_7);
           _7 = copy _5;
-          StorageLive(_27);
-          _27 = const 1_usize;
--         _6 = *const [()] from (copy _7, copy _27);
+          StorageLive(_30);
+          _30 = const 1_usize;
+-         _6 = *const [()] from (copy _7, copy _30);
 +         _6 = *const [()] from (copy _5, const 1_usize);
-          StorageDead(_27);
+          StorageDead(_30);
           StorageDead(_7);
           StorageLive(_8);
           StorageLive(_9);
           _9 = copy _6;
-          StorageLive(_28);
--         _28 = copy _9;
+          StorageLive(_31);
+-         _31 = copy _9;
 -         _8 = copy _9 as *mut () (PtrToPtr);
-+         _28 = copy _6;
++         _31 = copy _6;
 +         _8 = copy _5 as *mut () (PtrToPtr);
-          StorageDead(_28);
+          StorageDead(_31);
           StorageDead(_9);
           _0 = const ();
           StorageDead(_8);
@@ -183,18 +196,19 @@
       }
   
       bb5: {
--         _24 = Layout::from_size_align_unchecked::precondition_check(copy _16, copy _17) -> [return: bb6, unwind unreachable];
-+         _24 = Layout::from_size_align_unchecked::precondition_check(const 0_usize, const 1_usize) -> [return: bb6, unwind unreachable];
+-         _25 = Layout::from_size_align_unchecked::precondition_check(copy _16, copy _17) -> [return: bb6, unwind unreachable];
++         _25 = Layout::from_size_align_unchecked::precondition_check(const 0_usize, const 1_usize) -> [return: bb6, unwind unreachable];
       }
   
       bb6: {
-          StorageDead(_23);
-          StorageLive(_25);
--         _25 = copy _17 as std::ptr::Alignment (Transmute);
--         _18 = Layout { size: copy _16, align: move _25 };
-+         _25 = const std::ptr::Alignment(std::ptr::alignment::AlignmentEnum::_Align1Shl0);
+          StorageDead(_24);
+          StorageLive(_26);
+-         _26 = copy _17 as std::ptr::Alignment (Transmute);
+-         _18 = Layout { size: copy _16, align: move _26 };
++         _26 = const std::ptr::Alignment(std::ptr::alignment::AlignmentEnum::_Align1Shl0);
 +         _18 = const Layout {{ size: 0_usize, align: std::ptr::Alignment(std::ptr::alignment::AlignmentEnum::_Align1Shl0) }};
-          StorageDead(_25);
+          StorageDead(_26);
+          StorageDead(_23);
           StorageLive(_19);
 -         _19 = std::alloc::Global::alloc_impl(const alloc::alloc::exchange_malloc::promoted[0], copy _18, const false) -> [return: bb7, unwind unreachable];
 +         _19 = std::alloc::Global::alloc_impl(const alloc::alloc::exchange_malloc::promoted[0], const Layout {{ size: 0_usize, align: std::ptr::Alignment(std::ptr::alignment::AlignmentEnum::_Align1Shl0) }}, const false) -> [return: bb7, unwind unreachable];

--- a/tests/mir-opt/gvn_ptr_eq_with_constant.main.GVN.diff
+++ b/tests/mir-opt/gvn_ptr_eq_with_constant.main.GVN.diff
@@ -9,30 +9,38 @@
           scope 2 (inlined NonNull::<u8>::dangling) {
               let mut _3: std::num::NonZero<usize>;
               scope 3 {
-                  scope 5 (inlined std::ptr::Alignment::as_nonzero) {
+                  scope 4 {
+                      scope 6 {
+                      }
                   }
-                  scope 6 (inlined NonNull::<u8>::without_provenance) {
-                      scope 7 {
+                  scope 5 {
+                      scope 9 (inlined std::ptr::Alignment::as_nonzero) {
                       }
-                      scope 8 (inlined NonZero::<usize>::get) {
-                      }
-                      scope 9 (inlined std::ptr::without_provenance::<u8>) {
-                          scope 10 (inlined without_provenance_mut::<u8>) {
+                      scope 10 (inlined NonNull::<u8>::without_provenance) {
+                          scope 11 {
+                          }
+                          scope 12 (inlined NonZero::<usize>::get) {
+                          }
+                          scope 13 (inlined std::ptr::without_provenance::<u8>) {
+                              scope 14 (inlined without_provenance_mut::<u8>) {
+                              }
                           }
                       }
                   }
+                  scope 8 (inlined std::ptr::Alignment::of::<u8>) {
+                  }
               }
-              scope 4 (inlined std::ptr::Alignment::of::<u8>) {
+              scope 7 (inlined core::contracts::build_check_ensures::<NonNull<u8>, {closure@NonNull<u8>::dangling::{closure#0}}>) {
               }
           }
-          scope 11 (inlined NonNull::<u8>::as_ptr) {
+          scope 15 (inlined NonNull::<u8>::as_ptr) {
           }
       }
-      scope 12 (inlined Foo::<u8>::cmp_ptr) {
+      scope 16 (inlined Foo::<u8>::cmp_ptr) {
           let mut _4: *const u8;
           let mut _5: *mut u8;
           let mut _6: *const u8;
-          scope 13 (inlined std::ptr::eq::<u8>) {
+          scope 17 (inlined std::ptr::eq::<u8>) {
           }
       }
   

--- a/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.32bit.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.32bit.panic-abort.mir
@@ -12,50 +12,74 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
             scope 3 {
                 let _8: std::ptr::alignment::AlignmentEnum;
                 scope 4 {
-                    scope 12 (inlined Layout::size) {
+                    scope 11 (inlined Layout::size) {
                     }
-                    scope 13 (inlined Unique::<[T]>::cast::<u8>) {
-                        scope 14 (inlined NonNull::<[T]>::cast::<u8>) {
-                            scope 15 (inlined NonNull::<[T]>::as_ptr) {
+                    scope 12 (inlined Unique::<[T]>::cast::<u8>) {
+                        scope 13 (inlined NonNull::<[T]>::cast::<u8>) {
+                            scope 14 (inlined NonNull::<[T]>::as_ptr) {
                             }
                         }
                     }
-                    scope 16 (inlined <NonNull<u8> as From<Unique<u8>>>::from) {
-                        scope 17 (inlined Unique::<u8>::as_non_null_ptr) {
+                    scope 15 (inlined <NonNull<u8> as From<Unique<u8>>>::from) {
+                        scope 16 (inlined Unique::<u8>::as_non_null_ptr) {
                         }
                     }
-                    scope 18 (inlined <std::alloc::Global as Allocator>::deallocate) {
+                    scope 30 (inlined <std::alloc::Global as Allocator>::deallocate) {
                         let mut _9: *mut u8;
-                        scope 19 (inlined Layout::size) {
+                        scope 31 (inlined Layout::size) {
                         }
-                        scope 20 (inlined NonNull::<u8>::as_ptr) {
+                        scope 32 (inlined NonNull::<u8>::as_ptr) {
                         }
-                        scope 21 (inlined std::alloc::dealloc) {
+                        scope 33 (inlined std::alloc::dealloc) {
                             let mut _10: usize;
-                            scope 22 (inlined Layout::size) {
+                            scope 34 (inlined Layout::size) {
                             }
-                            scope 23 (inlined Layout::align) {
-                                scope 24 (inlined std::ptr::Alignment::as_usize) {
+                            scope 35 (inlined Layout::align) {
+                                scope 36 (inlined std::ptr::Alignment::as_usize) {
                                 }
                             }
                         }
                     }
                 }
                 scope 5 (inlined Unique::<[T]>::as_ptr) {
-                    scope 6 (inlined NonNull::<[T]>::as_ptr) {
-                    }
-                }
-                scope 7 (inlined Layout::for_value_raw::<[T]>) {
-                    let mut _5: usize;
-                    let mut _6: usize;
-                    scope 8 {
-                        scope 11 (inlined #[track_caller] Layout::from_size_align_unchecked) {
-                            let mut _7: std::ptr::Alignment;
+                    scope 6 {
+                        scope 7 {
+                            scope 8 {
+                            }
+                        }
+                        scope 10 (inlined NonNull::<[T]>::as_ptr) {
                         }
                     }
-                    scope 9 (inlined size_of_val_raw::<[T]>) {
+                    scope 9 (inlined core::contracts::build_check_ensures::<*mut [T], {closure@Unique<[T]>::as_ptr::{closure#0}}>) {
                     }
-                    scope 10 (inlined align_of_val_raw::<[T]>) {
+                }
+                scope 17 (inlined Layout::for_value_raw::<[T]>) {
+                    let mut _5: usize;
+                    let mut _6: usize;
+                    scope 18 {
+                        scope 19 {
+                            scope 21 {
+                            }
+                        }
+                        scope 20 {
+                            scope 25 (inlined #[track_caller] Layout::from_size_align_unchecked) {
+                                let mut _7: std::ptr::Alignment;
+                                scope 26 {
+                                    scope 27 {
+                                        scope 28 {
+                                        }
+                                    }
+                                }
+                                scope 29 (inlined core::contracts::build_check_ensures::<Layout, {closure@Layout::from_size_align_unchecked::{closure#1}}>) {
+                                }
+                            }
+                        }
+                        scope 23 (inlined size_of_val_raw::<[T]>) {
+                        }
+                        scope 24 (inlined align_of_val_raw::<[T]>) {
+                        }
+                    }
+                    scope 22 (inlined core::contracts::build_check_ensures::<Layout, {closure@Layout::for_value_raw<[T]>::{closure#0}}>) {
                     }
                 }
             }

--- a/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.32bit.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.32bit.panic-unwind.mir
@@ -12,50 +12,74 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
             scope 3 {
                 let _8: std::ptr::alignment::AlignmentEnum;
                 scope 4 {
-                    scope 12 (inlined Layout::size) {
+                    scope 11 (inlined Layout::size) {
                     }
-                    scope 13 (inlined Unique::<[T]>::cast::<u8>) {
-                        scope 14 (inlined NonNull::<[T]>::cast::<u8>) {
-                            scope 15 (inlined NonNull::<[T]>::as_ptr) {
+                    scope 12 (inlined Unique::<[T]>::cast::<u8>) {
+                        scope 13 (inlined NonNull::<[T]>::cast::<u8>) {
+                            scope 14 (inlined NonNull::<[T]>::as_ptr) {
                             }
                         }
                     }
-                    scope 16 (inlined <NonNull<u8> as From<Unique<u8>>>::from) {
-                        scope 17 (inlined Unique::<u8>::as_non_null_ptr) {
+                    scope 15 (inlined <NonNull<u8> as From<Unique<u8>>>::from) {
+                        scope 16 (inlined Unique::<u8>::as_non_null_ptr) {
                         }
                     }
-                    scope 18 (inlined <std::alloc::Global as Allocator>::deallocate) {
+                    scope 30 (inlined <std::alloc::Global as Allocator>::deallocate) {
                         let mut _9: *mut u8;
-                        scope 19 (inlined Layout::size) {
+                        scope 31 (inlined Layout::size) {
                         }
-                        scope 20 (inlined NonNull::<u8>::as_ptr) {
+                        scope 32 (inlined NonNull::<u8>::as_ptr) {
                         }
-                        scope 21 (inlined std::alloc::dealloc) {
+                        scope 33 (inlined std::alloc::dealloc) {
                             let mut _10: usize;
-                            scope 22 (inlined Layout::size) {
+                            scope 34 (inlined Layout::size) {
                             }
-                            scope 23 (inlined Layout::align) {
-                                scope 24 (inlined std::ptr::Alignment::as_usize) {
+                            scope 35 (inlined Layout::align) {
+                                scope 36 (inlined std::ptr::Alignment::as_usize) {
                                 }
                             }
                         }
                     }
                 }
                 scope 5 (inlined Unique::<[T]>::as_ptr) {
-                    scope 6 (inlined NonNull::<[T]>::as_ptr) {
-                    }
-                }
-                scope 7 (inlined Layout::for_value_raw::<[T]>) {
-                    let mut _5: usize;
-                    let mut _6: usize;
-                    scope 8 {
-                        scope 11 (inlined #[track_caller] Layout::from_size_align_unchecked) {
-                            let mut _7: std::ptr::Alignment;
+                    scope 6 {
+                        scope 7 {
+                            scope 8 {
+                            }
+                        }
+                        scope 10 (inlined NonNull::<[T]>::as_ptr) {
                         }
                     }
-                    scope 9 (inlined size_of_val_raw::<[T]>) {
+                    scope 9 (inlined core::contracts::build_check_ensures::<*mut [T], {closure@Unique<[T]>::as_ptr::{closure#0}}>) {
                     }
-                    scope 10 (inlined align_of_val_raw::<[T]>) {
+                }
+                scope 17 (inlined Layout::for_value_raw::<[T]>) {
+                    let mut _5: usize;
+                    let mut _6: usize;
+                    scope 18 {
+                        scope 19 {
+                            scope 21 {
+                            }
+                        }
+                        scope 20 {
+                            scope 25 (inlined #[track_caller] Layout::from_size_align_unchecked) {
+                                let mut _7: std::ptr::Alignment;
+                                scope 26 {
+                                    scope 27 {
+                                        scope 28 {
+                                        }
+                                    }
+                                }
+                                scope 29 (inlined core::contracts::build_check_ensures::<Layout, {closure@Layout::from_size_align_unchecked::{closure#1}}>) {
+                                }
+                            }
+                        }
+                        scope 23 (inlined size_of_val_raw::<[T]>) {
+                        }
+                        scope 24 (inlined align_of_val_raw::<[T]>) {
+                        }
+                    }
+                    scope 22 (inlined core::contracts::build_check_ensures::<Layout, {closure@Layout::for_value_raw<[T]>::{closure#0}}>) {
                     }
                 }
             }

--- a/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.64bit.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.64bit.panic-abort.mir
@@ -12,50 +12,74 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
             scope 3 {
                 let _8: std::ptr::alignment::AlignmentEnum;
                 scope 4 {
-                    scope 12 (inlined Layout::size) {
+                    scope 11 (inlined Layout::size) {
                     }
-                    scope 13 (inlined Unique::<[T]>::cast::<u8>) {
-                        scope 14 (inlined NonNull::<[T]>::cast::<u8>) {
-                            scope 15 (inlined NonNull::<[T]>::as_ptr) {
+                    scope 12 (inlined Unique::<[T]>::cast::<u8>) {
+                        scope 13 (inlined NonNull::<[T]>::cast::<u8>) {
+                            scope 14 (inlined NonNull::<[T]>::as_ptr) {
                             }
                         }
                     }
-                    scope 16 (inlined <NonNull<u8> as From<Unique<u8>>>::from) {
-                        scope 17 (inlined Unique::<u8>::as_non_null_ptr) {
+                    scope 15 (inlined <NonNull<u8> as From<Unique<u8>>>::from) {
+                        scope 16 (inlined Unique::<u8>::as_non_null_ptr) {
                         }
                     }
-                    scope 18 (inlined <std::alloc::Global as Allocator>::deallocate) {
+                    scope 30 (inlined <std::alloc::Global as Allocator>::deallocate) {
                         let mut _9: *mut u8;
-                        scope 19 (inlined Layout::size) {
+                        scope 31 (inlined Layout::size) {
                         }
-                        scope 20 (inlined NonNull::<u8>::as_ptr) {
+                        scope 32 (inlined NonNull::<u8>::as_ptr) {
                         }
-                        scope 21 (inlined std::alloc::dealloc) {
+                        scope 33 (inlined std::alloc::dealloc) {
                             let mut _10: usize;
-                            scope 22 (inlined Layout::size) {
+                            scope 34 (inlined Layout::size) {
                             }
-                            scope 23 (inlined Layout::align) {
-                                scope 24 (inlined std::ptr::Alignment::as_usize) {
+                            scope 35 (inlined Layout::align) {
+                                scope 36 (inlined std::ptr::Alignment::as_usize) {
                                 }
                             }
                         }
                     }
                 }
                 scope 5 (inlined Unique::<[T]>::as_ptr) {
-                    scope 6 (inlined NonNull::<[T]>::as_ptr) {
-                    }
-                }
-                scope 7 (inlined Layout::for_value_raw::<[T]>) {
-                    let mut _5: usize;
-                    let mut _6: usize;
-                    scope 8 {
-                        scope 11 (inlined #[track_caller] Layout::from_size_align_unchecked) {
-                            let mut _7: std::ptr::Alignment;
+                    scope 6 {
+                        scope 7 {
+                            scope 8 {
+                            }
+                        }
+                        scope 10 (inlined NonNull::<[T]>::as_ptr) {
                         }
                     }
-                    scope 9 (inlined size_of_val_raw::<[T]>) {
+                    scope 9 (inlined core::contracts::build_check_ensures::<*mut [T], {closure@Unique<[T]>::as_ptr::{closure#0}}>) {
                     }
-                    scope 10 (inlined align_of_val_raw::<[T]>) {
+                }
+                scope 17 (inlined Layout::for_value_raw::<[T]>) {
+                    let mut _5: usize;
+                    let mut _6: usize;
+                    scope 18 {
+                        scope 19 {
+                            scope 21 {
+                            }
+                        }
+                        scope 20 {
+                            scope 25 (inlined #[track_caller] Layout::from_size_align_unchecked) {
+                                let mut _7: std::ptr::Alignment;
+                                scope 26 {
+                                    scope 27 {
+                                        scope 28 {
+                                        }
+                                    }
+                                }
+                                scope 29 (inlined core::contracts::build_check_ensures::<Layout, {closure@Layout::from_size_align_unchecked::{closure#1}}>) {
+                                }
+                            }
+                        }
+                        scope 23 (inlined size_of_val_raw::<[T]>) {
+                        }
+                        scope 24 (inlined align_of_val_raw::<[T]>) {
+                        }
+                    }
+                    scope 22 (inlined core::contracts::build_check_ensures::<Layout, {closure@Layout::for_value_raw<[T]>::{closure#0}}>) {
                     }
                 }
             }

--- a/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.64bit.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.64bit.panic-unwind.mir
@@ -12,50 +12,74 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
             scope 3 {
                 let _8: std::ptr::alignment::AlignmentEnum;
                 scope 4 {
-                    scope 12 (inlined Layout::size) {
+                    scope 11 (inlined Layout::size) {
                     }
-                    scope 13 (inlined Unique::<[T]>::cast::<u8>) {
-                        scope 14 (inlined NonNull::<[T]>::cast::<u8>) {
-                            scope 15 (inlined NonNull::<[T]>::as_ptr) {
+                    scope 12 (inlined Unique::<[T]>::cast::<u8>) {
+                        scope 13 (inlined NonNull::<[T]>::cast::<u8>) {
+                            scope 14 (inlined NonNull::<[T]>::as_ptr) {
                             }
                         }
                     }
-                    scope 16 (inlined <NonNull<u8> as From<Unique<u8>>>::from) {
-                        scope 17 (inlined Unique::<u8>::as_non_null_ptr) {
+                    scope 15 (inlined <NonNull<u8> as From<Unique<u8>>>::from) {
+                        scope 16 (inlined Unique::<u8>::as_non_null_ptr) {
                         }
                     }
-                    scope 18 (inlined <std::alloc::Global as Allocator>::deallocate) {
+                    scope 30 (inlined <std::alloc::Global as Allocator>::deallocate) {
                         let mut _9: *mut u8;
-                        scope 19 (inlined Layout::size) {
+                        scope 31 (inlined Layout::size) {
                         }
-                        scope 20 (inlined NonNull::<u8>::as_ptr) {
+                        scope 32 (inlined NonNull::<u8>::as_ptr) {
                         }
-                        scope 21 (inlined std::alloc::dealloc) {
+                        scope 33 (inlined std::alloc::dealloc) {
                             let mut _10: usize;
-                            scope 22 (inlined Layout::size) {
+                            scope 34 (inlined Layout::size) {
                             }
-                            scope 23 (inlined Layout::align) {
-                                scope 24 (inlined std::ptr::Alignment::as_usize) {
+                            scope 35 (inlined Layout::align) {
+                                scope 36 (inlined std::ptr::Alignment::as_usize) {
                                 }
                             }
                         }
                     }
                 }
                 scope 5 (inlined Unique::<[T]>::as_ptr) {
-                    scope 6 (inlined NonNull::<[T]>::as_ptr) {
-                    }
-                }
-                scope 7 (inlined Layout::for_value_raw::<[T]>) {
-                    let mut _5: usize;
-                    let mut _6: usize;
-                    scope 8 {
-                        scope 11 (inlined #[track_caller] Layout::from_size_align_unchecked) {
-                            let mut _7: std::ptr::Alignment;
+                    scope 6 {
+                        scope 7 {
+                            scope 8 {
+                            }
+                        }
+                        scope 10 (inlined NonNull::<[T]>::as_ptr) {
                         }
                     }
-                    scope 9 (inlined size_of_val_raw::<[T]>) {
+                    scope 9 (inlined core::contracts::build_check_ensures::<*mut [T], {closure@Unique<[T]>::as_ptr::{closure#0}}>) {
                     }
-                    scope 10 (inlined align_of_val_raw::<[T]>) {
+                }
+                scope 17 (inlined Layout::for_value_raw::<[T]>) {
+                    let mut _5: usize;
+                    let mut _6: usize;
+                    scope 18 {
+                        scope 19 {
+                            scope 21 {
+                            }
+                        }
+                        scope 20 {
+                            scope 25 (inlined #[track_caller] Layout::from_size_align_unchecked) {
+                                let mut _7: std::ptr::Alignment;
+                                scope 26 {
+                                    scope 27 {
+                                        scope 28 {
+                                        }
+                                    }
+                                }
+                                scope 29 (inlined core::contracts::build_check_ensures::<Layout, {closure@Layout::from_size_align_unchecked::{closure#1}}>) {
+                                }
+                            }
+                        }
+                        scope 23 (inlined size_of_val_raw::<[T]>) {
+                        }
+                        scope 24 (inlined align_of_val_raw::<[T]>) {
+                        }
+                    }
+                    scope 22 (inlined core::contracts::build_check_ensures::<Layout, {closure@Layout::for_value_raw<[T]>::{closure#0}}>) {
                     }
                 }
             }

--- a/tests/mir-opt/pre-codegen/loops.vec_move.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/loops.vec_move.PreCodegen.after.mir
@@ -64,6 +64,14 @@ fn vec_move(_1: Vec<impl Sized>) -> () {
                                     let mut _20: core::num::niche_types::UsizeNoHighBit;
                                     scope 43 (inlined core::num::niche_types::UsizeNoHighBit::as_inner) {
                                         debug self => _20;
+                                        scope 44 {
+                                            scope 45 {
+                                                scope 46 {
+                                                }
+                                            }
+                                        }
+                                        scope 47 (inlined core::contracts::build_check_ensures::<usize, {closure@core::num::niche_types::UsizeNoHighBit::as_inner::{closure#0}}>) {
+                                        }
                                     }
                                 }
                             }

--- a/tests/mir-opt/pre-codegen/slice_iter.reverse_loop.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.reverse_loop.PreCodegen.after.panic-abort.mir
@@ -60,15 +60,23 @@ fn reverse_loop(_1: &[T], _2: impl Fn(&T)) -> () {
                             scope 32 {
                                 scope 35 (inlined NonNull::<T>::sub) {
                                     scope 36 (inlined #[track_caller] core::num::<impl isize>::unchecked_neg) {
-                                        scope 37 (inlined core::ub_checks::check_language_ub) {
-                                            scope 38 (inlined core::ub_checks::check_language_ub::runtime) {
+                                        scope 37 {
+                                            scope 38 {
+                                                scope 39 {
+                                                }
+                                            }
+                                            scope 41 (inlined core::ub_checks::check_language_ub) {
+                                                scope 42 (inlined core::ub_checks::check_language_ub::runtime) {
+                                                }
                                             }
                                         }
+                                        scope 40 (inlined core::contracts::build_check_ensures::<isize, {closure@core::num::<impl isize>::unchecked_neg::{closure#1}}>) {
+                                        }
                                     }
-                                    scope 39 (inlined NonNull::<T>::offset) {
+                                    scope 43 (inlined NonNull::<T>::offset) {
                                         let mut _24: *const T;
                                         let mut _25: *const T;
-                                        scope 40 (inlined NonNull::<T>::as_ptr) {
+                                        scope 44 (inlined NonNull::<T>::as_ptr) {
                                         }
                                     }
                                 }
@@ -79,11 +87,11 @@ fn reverse_loop(_1: &[T], _2: impl Fn(&T)) -> () {
                             }
                         }
                     }
-                    scope 41 (inlined NonNull::<T>::as_ref::<'_>) {
+                    scope 45 (inlined NonNull::<T>::as_ref::<'_>) {
                         let _31: *const T;
-                        scope 42 (inlined NonNull::<T>::as_ptr) {
+                        scope 46 (inlined NonNull::<T>::as_ptr) {
                         }
-                        scope 43 (inlined std::ptr::mut_ptr::<impl *mut T>::cast_const) {
+                        scope 47 (inlined std::ptr::mut_ptr::<impl *mut T>::cast_const) {
                         }
                     }
                 }

--- a/tests/mir-opt/pre-codegen/slice_iter.reverse_loop.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.reverse_loop.PreCodegen.after.panic-unwind.mir
@@ -60,15 +60,23 @@ fn reverse_loop(_1: &[T], _2: impl Fn(&T)) -> () {
                             scope 32 {
                                 scope 35 (inlined NonNull::<T>::sub) {
                                     scope 36 (inlined #[track_caller] core::num::<impl isize>::unchecked_neg) {
-                                        scope 37 (inlined core::ub_checks::check_language_ub) {
-                                            scope 38 (inlined core::ub_checks::check_language_ub::runtime) {
+                                        scope 37 {
+                                            scope 38 {
+                                                scope 39 {
+                                                }
+                                            }
+                                            scope 41 (inlined core::ub_checks::check_language_ub) {
+                                                scope 42 (inlined core::ub_checks::check_language_ub::runtime) {
+                                                }
                                             }
                                         }
+                                        scope 40 (inlined core::contracts::build_check_ensures::<isize, {closure@core::num::<impl isize>::unchecked_neg::{closure#1}}>) {
+                                        }
                                     }
-                                    scope 39 (inlined NonNull::<T>::offset) {
+                                    scope 43 (inlined NonNull::<T>::offset) {
                                         let mut _24: *const T;
                                         let mut _25: *const T;
-                                        scope 40 (inlined NonNull::<T>::as_ptr) {
+                                        scope 44 (inlined NonNull::<T>::as_ptr) {
                                         }
                                     }
                                 }
@@ -79,11 +87,11 @@ fn reverse_loop(_1: &[T], _2: impl Fn(&T)) -> () {
                             }
                         }
                     }
-                    scope 41 (inlined NonNull::<T>::as_ref::<'_>) {
+                    scope 45 (inlined NonNull::<T>::as_ref::<'_>) {
                         let _31: *const T;
-                        scope 42 (inlined NonNull::<T>::as_ptr) {
+                        scope 46 (inlined NonNull::<T>::as_ptr) {
                         }
-                        scope 43 (inlined std::ptr::mut_ptr::<impl *mut T>::cast_const) {
+                        scope 47 (inlined std::ptr::mut_ptr::<impl *mut T>::cast_const) {
                         }
                     }
                 }

--- a/tests/mir-opt/pre-codegen/slice_iter.slice_iter_mut_next_back.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.slice_iter_mut_next_back.PreCodegen.after.panic-abort.mir
@@ -45,15 +45,23 @@ fn slice_iter_mut_next_back(_1: &mut std::slice::IterMut<'_, T>) -> Option<&mut 
                     scope 14 {
                         scope 17 (inlined NonNull::<T>::sub) {
                             scope 18 (inlined #[track_caller] core::num::<impl isize>::unchecked_neg) {
-                                scope 19 (inlined core::ub_checks::check_language_ub) {
-                                    scope 20 (inlined core::ub_checks::check_language_ub::runtime) {
+                                scope 19 {
+                                    scope 20 {
+                                        scope 21 {
+                                        }
+                                    }
+                                    scope 23 (inlined core::ub_checks::check_language_ub) {
+                                        scope 24 (inlined core::ub_checks::check_language_ub::runtime) {
+                                        }
                                     }
                                 }
+                                scope 22 (inlined core::contracts::build_check_ensures::<isize, {closure@core::num::<impl isize>::unchecked_neg::{closure#1}}>) {
+                                }
                             }
-                            scope 21 (inlined NonNull::<T>::offset) {
+                            scope 25 (inlined NonNull::<T>::offset) {
                                 let mut _13: *const T;
                                 let mut _14: *const T;
-                                scope 22 (inlined NonNull::<T>::as_ptr) {
+                                scope 26 (inlined NonNull::<T>::as_ptr) {
                                 }
                             }
                         }
@@ -64,9 +72,9 @@ fn slice_iter_mut_next_back(_1: &mut std::slice::IterMut<'_, T>) -> Option<&mut 
                     }
                 }
             }
-            scope 23 (inlined NonNull::<T>::as_mut::<'_>) {
+            scope 27 (inlined NonNull::<T>::as_mut::<'_>) {
                 let mut _20: *mut T;
-                scope 24 (inlined NonNull::<T>::as_ptr) {
+                scope 28 (inlined NonNull::<T>::as_ptr) {
                 }
             }
         }

--- a/tests/mir-opt/pre-codegen/slice_iter.slice_iter_mut_next_back.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.slice_iter_mut_next_back.PreCodegen.after.panic-unwind.mir
@@ -45,15 +45,23 @@ fn slice_iter_mut_next_back(_1: &mut std::slice::IterMut<'_, T>) -> Option<&mut 
                     scope 14 {
                         scope 17 (inlined NonNull::<T>::sub) {
                             scope 18 (inlined #[track_caller] core::num::<impl isize>::unchecked_neg) {
-                                scope 19 (inlined core::ub_checks::check_language_ub) {
-                                    scope 20 (inlined core::ub_checks::check_language_ub::runtime) {
+                                scope 19 {
+                                    scope 20 {
+                                        scope 21 {
+                                        }
+                                    }
+                                    scope 23 (inlined core::ub_checks::check_language_ub) {
+                                        scope 24 (inlined core::ub_checks::check_language_ub::runtime) {
+                                        }
                                     }
                                 }
+                                scope 22 (inlined core::contracts::build_check_ensures::<isize, {closure@core::num::<impl isize>::unchecked_neg::{closure#1}}>) {
+                                }
                             }
-                            scope 21 (inlined NonNull::<T>::offset) {
+                            scope 25 (inlined NonNull::<T>::offset) {
                                 let mut _13: *const T;
                                 let mut _14: *const T;
-                                scope 22 (inlined NonNull::<T>::as_ptr) {
+                                scope 26 (inlined NonNull::<T>::as_ptr) {
                                 }
                             }
                         }
@@ -64,9 +72,9 @@ fn slice_iter_mut_next_back(_1: &mut std::slice::IterMut<'_, T>) -> Option<&mut 
                     }
                 }
             }
-            scope 23 (inlined NonNull::<T>::as_mut::<'_>) {
+            scope 27 (inlined NonNull::<T>::as_mut::<'_>) {
                 let mut _20: *mut T;
-                scope 24 (inlined NonNull::<T>::as_ptr) {
+                scope 28 (inlined NonNull::<T>::as_ptr) {
                 }
             }
         }


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/147148)*
<!-- homu-ignore:end -->

Ports over all contracts (other than those for `Alignment`, see the separate PR) that can be expressed using the current, experimental contracts syntax. (Notably, this excludes all contracts that refer to pointer validity.)


