### PR TITLE
builtin `Fn`-trait impls: instantiate binder before the return type `Sized` check

### DIFF
--- a/compiler/rustc_next_trait_solver/src/solve/assembly/structural_traits.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/assembly/structural_traits.rs
@@ -664,7 +664,7 @@ fn coroutine_closure_to_ambiguous_coroutine<I: Interner>(
 pub(in crate::solve) fn extract_fn_def_from_const_callable<I: Interner>(
     cx: I,
     self_ty: I::Ty,
-) -> Result<(ty::Binder<I, (I::FnInputTys, I::Ty)>, I::FunctionId, I::GenericArgs), NoSolution> {
+) -> Result<(ty::Binder<I, (I::Ty, I::Ty)>, I::FunctionId, I::GenericArgs), NoSolution> {
     match self_ty.kind() {
         ty::FnDef(def_id, args) => {
             let sig = cx.fn_sig(def_id);
@@ -673,7 +673,8 @@ pub(in crate::solve) fn extract_fn_def_from_const_callable<I: Interner>(
                 && cx.fn_is_const(def_id)
             {
                 Ok((
-                    sig.instantiate(cx, args).map_bound(|sig| (sig.inputs(), sig.output())),
+                    sig.instantiate(cx, args)
+                        .map_bound(|sig| (Ty::new_tup(cx, sig.inputs().as_slice()), sig.output())),
                     def_id,
                     args,
                 ))

--- a/tests/ui/traits/next-solver/opaques/overflow-hr-fn-trait-sized-1.rs
+++ b/tests/ui/traits/next-solver/opaques/overflow-hr-fn-trait-sized-1.rs
@@ -1,0 +1,25 @@
+//@ ignore-compare-mode-next-solver
+//@ compile-flags: -Znext-solver
+//@ check-pass
+
+// Regression test for trait-system-refactor-initiative#220. Builtin `Fn`-trait
+// candidates required `for<'latebound> Output<'latebound>: Sized` which ended
+// up resulting in overflow if the return type is an opaque in the defining scope.
+//
+// We now eagerly instantiate the binder of the function definition which avoids
+// that overflow by relating the lifetime of the opaque to something from the
+// input.
+fn flat_map<T, F, I, G>(_: F, _: G)
+where
+    F: FnOnce(T) -> I,
+    I: Iterator,
+    G: Fn(<I as Iterator>::Item) -> usize,
+{
+}
+
+fn rarw<'a>(_: &'a ()) -> impl Iterator<Item = &'a str> {
+    flat_map(rarw, |x| x.len());
+    std::iter::empty()
+}
+
+fn main() {}

--- a/tests/ui/traits/next-solver/opaques/overflow-hr-fn-trait-sized-2.rs
+++ b/tests/ui/traits/next-solver/opaques/overflow-hr-fn-trait-sized-2.rs
@@ -1,0 +1,14 @@
+//@ ignore-compare-mode-next-solver
+//@ compile-flags: -Znext-solver
+//@ check-pass
+
+// Regression test for trait-system-refactor-initiative#204, see
+// the sibling test for more details.
+
+fn constrain<'a, F: FnOnce(&'a ())>(_: F) {}
+fn foo<'a>(_: &'a ()) -> impl Sized + use<'a> {
+    constrain(foo);
+    ()
+}
+
+fn main() {}


### PR DESCRIPTION
fixes
- https://github.com/rust-lang/trait-system-refactor-initiative/issues/220
- https://github.com/rust-lang/trait-system-refactor-initiative/issues/204

r? @BoxyUwU 