### PR TITLE
crater: check impact of ignoring outlived regions in alias liveness

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,7 +4,7 @@
 	shallow = true
 [submodule "src/tools/cargo"]
 	path = src/tools/cargo
-	url = https://github.com/rust-lang/cargo.git
+	url = https://github.com/lqd/cargo.git
 	shallow = true
 [submodule "src/doc/reference"]
 	path = src/doc/reference

--- a/compiler/rustc_const_eval/src/interpret/intern.rs
+++ b/compiler/rustc_const_eval/src/interpret/intern.rs
@@ -106,7 +106,7 @@ fn intern_shallow<'tcx, M: CompileTimeMachine<'tcx>>(
     alloc_id: AllocId,
     mutability: Mutability,
     disambiguator: Option<&mut DisambiguatorState>,
-) -> Result<impl Iterator<Item = CtfeProvenance> + 'tcx, InternError> {
+) -> Result<impl Iterator<Item = CtfeProvenance> + 'tcx + use<'tcx, M>, InternError> {
     trace!("intern_shallow {:?}", alloc_id);
     // remove allocation
     // FIXME(#120456) - is `swap_remove` correct?

--- a/compiler/rustc_expand/src/expand.rs
+++ b/compiler/rustc_expand/src/expand.rs
@@ -1954,7 +1954,7 @@ fn build_single_delegations<'a, Node: InvocationCollectorNode>(
     suffixes: &'a [(Ident, Option<Ident>)],
     item_span: Span,
     from_glob: bool,
-) -> impl Iterator<Item = ast::Item<Node::ItemKind>> + 'a {
+) -> impl Iterator<Item = ast::Item<Node::ItemKind>> + 'a + use<'a, Node> {
     if suffixes.is_empty() {
         // Report an error for now, to avoid keeping stem for resolution and
         // stability checks.

--- a/compiler/rustc_infer/src/infer/outlives/for_liveness.rs
+++ b/compiler/rustc_infer/src/infer/outlives/for_liveness.rs
@@ -85,11 +85,11 @@ where
                 // alias.
                 if outlives_bounds.contains(&tcx.lifetimes.re_static) {
                     // no
-                } else if let Some(r) = outlives_bounds.first()
-                    && outlives_bounds[1..].iter().all(|other_r| other_r == r)
-                {
-                    assert!(r.type_flags().intersects(ty::TypeFlags::HAS_FREE_REGIONS));
-                    r.visit_with(self);
+                    // } else if let Some(r) = outlives_bounds.first()
+                    //     && outlives_bounds[1..].iter().all(|other_r| other_r == r)
+                    // {
+                    //     assert!(r.type_flags().intersects(ty::TypeFlags::HAS_FREE_REGIONS));
+                    //     r.visit_with(self);
                 } else {
                     // Skip lifetime parameters that are not captured, since they do
                     // not need to be live.

--- a/src/tools/rust-analyzer/crates/ide-assists/src/handlers/extract_function.rs
+++ b/src/tools/rust-analyzer/crates/ide-assists/src/handlers/extract_function.rs
@@ -1001,7 +1001,7 @@ impl FunctionBody {
         &self,
         ctx: &'a AssistContext<'_>,
         parent: &SyntaxNode,
-    ) -> impl Iterator<Item = OutlivedLocal> + 'a {
+    ) -> impl Iterator<Item = OutlivedLocal> + 'a + use<'a> {
         let parent = parent.clone();
         let range = self.text_range();
         locals_defined_in_body(&ctx.sema, self)


### PR DESCRIPTION
Some of the captured regions are not considered live anywhere due to this liveness unification of outlives regions for opaque type captures. Check what relies on it on crater.

r? ghost