### PR TITLE
Add regression test for issue #147146 ( ICE)

### DIFF
--- a/tests/ui/typeof-reserved-ice.rs
+++ b/tests/ui/typeof-reserved-ice.rs
@@ -1,0 +1,7 @@
+// check-pass
+// compile-flags: --error-format=short
+// Regression test for issue #147146
+// `typeof` is reserved but not implemented.
+// This should produce a normal error, not ICE.
+
+impl typeof(|| {}) {}


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->


Add regression test for issue rust-lang/rust#147146 (ICE)

This PR adds a minimal UI test reproducing the ICE triggered by using typeof in an impl:
`
impl typeof(|| {}) {}
`

The compiler currently panics with an internal compiler error (ICE) when compiling this code.

This test ensures that future fixes to the compiler can be validated against this specific scenario.

Note: This PR does not fix the ICE itself; it only provides a regression test.

References: [rust-lang#147146](https://github.com/rust-lang/rust/issues/147146)