### PR TITLE
Remove `FromResidual` param default

### DIFF
--- a/compiler/rustc_middle/src/mir/interpret/error.rs
+++ b/compiler/rustc_middle/src/mir/interpret/error.rs
@@ -817,7 +817,7 @@ impl<'tcx, T> ops::Residual<T> for InterpResult<'tcx, convert::Infallible> {
     type TryType = InterpResult<'tcx, T>;
 }
 
-impl<'tcx, T> ops::FromResidual for InterpResult<'tcx, T> {
+impl<'tcx, T> ops::FromResidual<InterpResult<'tcx, convert::Infallible>> for InterpResult<'tcx, T> {
     #[inline]
     #[track_caller]
     fn from_residual(residual: InterpResult<'tcx, convert::Infallible>) -> Self {

--- a/library/core/src/ops/try_trait.rs
+++ b/library/core/src/ops/try_trait.rs
@@ -129,7 +129,7 @@ use crate::ops::ControlFlow;
 #[doc(alias = "?")]
 #[lang = "Try"]
 #[rustc_const_unstable(feature = "const_try", issue = "74935")]
-pub const trait Try: [const] FromResidual {
+pub const trait Try: [const] FromResidual<Self::Residual> {
     /// The type of the value produced by `?` when *not* short-circuiting.
     #[unstable(feature = "try_trait_v2", issue = "84277", old_name = "try_trait")]
     type Output;
@@ -306,7 +306,7 @@ pub const trait Try: [const] FromResidual {
 #[rustc_diagnostic_item = "FromResidual"]
 #[unstable(feature = "try_trait_v2", issue = "84277", old_name = "try_trait")]
 #[rustc_const_unstable(feature = "const_try", issue = "74935")]
-pub const trait FromResidual<R = <Self as Try>::Residual> {
+pub const trait FromResidual<R> {
     /// Constructs the type from a compatible `Residual` type.
     ///
     /// This should be implemented consistently with the `branch` method such
@@ -416,7 +416,7 @@ impl<T> Try for NeverShortCircuit<T> {
     }
 }
 
-impl<T> FromResidual for NeverShortCircuit<T> {
+impl<T> FromResidual<NeverShortCircuitResidual> for NeverShortCircuit<T> {
     #[inline]
     fn from_residual(never: NeverShortCircuitResidual) -> Self {
         match never {}

--- a/tests/ui/traits/const-traits/ice-119717-constant-lifetime.rs
+++ b/tests/ui/traits/const-traits/ice-119717-constant-lifetime.rs
@@ -3,7 +3,7 @@
 
 use std::ops::FromResidual;
 
-impl<T> const FromResidual for T {
+impl<T> const FromResidual<T> for T {
     //~^ ERROR type parameter `T` must be used as the type parameter for some local type
     fn from_residual(t: T) -> _ {
         //~^ ERROR the placeholder `_` is not allowed

--- a/tests/ui/traits/const-traits/ice-119717-constant-lifetime.stderr
+++ b/tests/ui/traits/const-traits/ice-119717-constant-lifetime.stderr
@@ -1,7 +1,7 @@
 error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
   --> $DIR/ice-119717-constant-lifetime.rs:6:6
    |
-LL | impl<T> const FromResidual for T {
+LL | impl<T> const FromResidual<T> for T {
    |      ^ type parameter `T` must be used as the type parameter for some local type
    |
    = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local

--- a/tests/ui/traits/const-traits/trait-default-body-stability.rs
+++ b/tests/ui/traits/const-traits/trait-default-body-stability.rs
@@ -31,7 +31,7 @@ impl const Try for T {
 
 #[stable(feature = "foo", since = "1.0")]
 #[rustc_const_unstable(feature = "const_t_try", issue = "none")]
-impl const FromResidual for T {
+impl const FromResidual<T> for T {
     fn from_residual(t: T) -> T {
         t
     }


### PR DESCRIPTION
[Tracking issue](https://github.com/rust-lang/rust/issues/84277)

This resolves a concern that has been raised several times in the tracking issue. I'll summarize the reasons as:

* Explicitly naming the type is better for readability, both in `impl FromResidual` instances and in the `trait Try` definition.
* The convenience of omitting the type is small.
* The default value can be difficult to parse when reading the docs.
* It can be confusing that `FromResidual` uses `Self as Try` when it does not depend on `Try`.