### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/compiler/rustc_codegen_llvm/src/coverageinfo/llvm_cov.rs
+++ b/compiler/rustc_codegen_llvm/src/coverageinfo/llvm_cov.rs
@@ -6,21 +6,21 @@ use crate::coverageinfo::ffi;
 use crate::llvm;
 
 pub(crate) fn covmap_var_name() -> CString {
-    CString::new(llvm::build_byte_buffer(|s| unsafe {
+    CString::new(llvm::build_byte_buffer(|s| {
         llvm::LLVMRustCoverageWriteCovmapVarNameToString(s);
     }))
     .expect("covmap variable name should not contain NUL")
 }
 
 pub(crate) fn covmap_section_name(llmod: &llvm::Module) -> CString {
-    CString::new(llvm::build_byte_buffer(|s| unsafe {
+    CString::new(llvm::build_byte_buffer(|s| {
         llvm::LLVMRustCoverageWriteCovmapSectionNameToString(llmod, s);
     }))
     .expect("covmap section name should not contain NUL")
 }
 
 pub(crate) fn covfun_section_name(llmod: &llvm::Module) -> CString {
-    CString::new(llvm::build_byte_buffer(|s| unsafe {
+    CString::new(llvm::build_byte_buffer(|s| {
         llvm::LLVMRustCoverageWriteCovfunSectionNameToString(llmod, s);
     }))
     .expect("covfun section name should not contain NUL")
@@ -95,5 +95,5 @@ pub(crate) fn hash_bytes(bytes: &[u8]) -> u64 {
 /// as a raw numeric value. For historical reasons, the numeric value is 1 less
 /// than the number in the version's name, so `Version7` is actually `6u32`.
 pub(crate) fn mapping_version() -> u32 {
-    unsafe { llvm::LLVMRustCoverageMappingVersion() }
+    llvm::LLVMRustCoverageMappingVersion()
 }

--- a/compiler/rustc_codegen_llvm/src/coverageinfo/llvm_cov.rs
+++ b/compiler/rustc_codegen_llvm/src/coverageinfo/llvm_cov.rs
@@ -2,7 +2,6 @@
 
 use std::ffi::CString;
 
-use crate::common::AsCCharPtr;
 use crate::coverageinfo::ffi;
 use crate::llvm;
 
@@ -34,7 +33,7 @@ pub(crate) fn create_pgo_func_name_var<'ll>(
     unsafe {
         llvm::LLVMRustCoverageCreatePGOFuncNameVar(
             llfn,
-            mangled_fn_name.as_c_char_ptr(),
+            mangled_fn_name.as_ptr(),
             mangled_fn_name.len(),
         )
     }
@@ -44,7 +43,7 @@ pub(crate) fn write_filenames_to_buffer(filenames: &[impl AsRef<str>]) -> Vec<u8
     let (pointers, lengths) = filenames
         .into_iter()
         .map(AsRef::as_ref)
-        .map(|s: &str| (s.as_c_char_ptr(), s.len()))
+        .map(|s: &str| (s.as_ptr(), s.len()))
         .unzip::<_, _, Vec<_>, Vec<_>>();
 
     llvm::build_byte_buffer(|buffer| unsafe {
@@ -89,7 +88,7 @@ pub(crate) fn write_function_mappings_to_buffer(
 /// Hashes some bytes into a 64-bit hash, via LLVM's `IndexedInstrProf::ComputeHash`,
 /// as required for parts of the LLVM coverage mapping format.
 pub(crate) fn hash_bytes(bytes: &[u8]) -> u64 {
-    unsafe { llvm::LLVMRustCoverageHashBytes(bytes.as_c_char_ptr(), bytes.len()) }
+    unsafe { llvm::LLVMRustCoverageHashBytes(bytes.as_ptr(), bytes.len()) }
 }
 
 /// Returns LLVM's `coverage::CovMapVersion::CurrentVersion` (CoverageMapping.h)

--- a/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
@@ -2080,8 +2080,11 @@ unsafe extern "C" {
         ConstraintsLen: size_t,
     ) -> bool;
 
+    /// A list of pointer-length strings is passed as two pointer-length slices,
+    /// one slice containing pointers and one slice containing their corresponding
+    /// lengths. The implementation will check that both slices have the same length.
     pub(crate) fn LLVMRustCoverageWriteFilenamesToBuffer(
-        Filenames: *const *const c_char,
+        Filenames: *const *const c_uchar, // See "PTR_LEN_STR".
         FilenamesLen: size_t,
         Lengths: *const size_t,
         LengthsLen: size_t,
@@ -2104,10 +2107,13 @@ unsafe extern "C" {
 
     pub(crate) fn LLVMRustCoverageCreatePGOFuncNameVar(
         F: &Value,
-        FuncName: *const c_char,
+        FuncName: *const c_uchar, // See "PTR_LEN_STR".
         FuncNameLen: size_t,
     ) -> &Value;
-    pub(crate) fn LLVMRustCoverageHashBytes(Bytes: *const c_char, NumBytes: size_t) -> u64;
+    pub(crate) fn LLVMRustCoverageHashBytes(
+        Bytes: *const c_uchar, // See "PTR_LEN_STR".
+        NumBytes: size_t,
+    ) -> u64;
 
     pub(crate) fn LLVMRustCoverageWriteCovmapSectionNameToString(M: &Module, OutStr: &RustString);
 

--- a/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
@@ -2115,13 +2115,17 @@ unsafe extern "C" {
         NumBytes: size_t,
     ) -> u64;
 
-    pub(crate) fn LLVMRustCoverageWriteCovmapSectionNameToString(M: &Module, OutStr: &RustString);
+    pub(crate) safe fn LLVMRustCoverageWriteCovmapSectionNameToString(
+        M: &Module,
+        OutStr: &RustString,
+    );
+    pub(crate) safe fn LLVMRustCoverageWriteCovfunSectionNameToString(
+        M: &Module,
+        OutStr: &RustString,
+    );
+    pub(crate) safe fn LLVMRustCoverageWriteCovmapVarNameToString(OutStr: &RustString);
 
-    pub(crate) fn LLVMRustCoverageWriteCovfunSectionNameToString(M: &Module, OutStr: &RustString);
-
-    pub(crate) fn LLVMRustCoverageWriteCovmapVarNameToString(OutStr: &RustString);
-
-    pub(crate) fn LLVMRustCoverageMappingVersion() -> u32;
+    pub(crate) safe fn LLVMRustCoverageMappingVersion() -> u32;
     pub(crate) fn LLVMRustDebugMetadataVersion() -> u32;
     pub(crate) fn LLVMRustVersionMajor() -> u32;
     pub(crate) fn LLVMRustVersionMinor() -> u32;

--- a/compiler/rustc_target/src/spec/base/apple/mod.rs
+++ b/compiler/rustc_target/src/spec/base/apple/mod.rs
@@ -158,12 +158,22 @@ pub(crate) fn base(
             SplitDebuginfo::Off,
         ]),
 
+        // Tell the linker that we would like it to avoid irreproducible binaries.
+        //
         // This environment variable is pretty magical but is intended for
         // producing deterministic builds. This was first discovered to be used
         // by the `ar` tool as a way to control whether or not mtime entries in
-        // the archive headers were set to zero or not. It appears that
-        // eventually the linker got updated to do the same thing and now reads
-        // this environment variable too in recent versions.
+        // the archive headers were set to zero or not.
+        //
+        // In `ld64-351.8`, shipped with Xcode 9.3, the linker was updated to
+        // read this flag too. Linker versions that don't support this flag
+        // may embed modification timestamps in binaries (especially in debug
+        // information).
+        //
+        // A cleaner alternative would be to pass the `-reproducible` flag,
+        // though that is only supported since `ld64-819.6` shipped with Xcode
+        // 14, which is too new for our minimum supported version:
+        // https://doc.rust-lang.org/rustc/platform-support/apple-darwin.html#host-tooling
         //
         // For some more info see the commentary on #47086
         link_env: Cow::Borrowed(&[(Cow::Borrowed("ZERO_AR_DATE"), Cow::Borrowed("1"))]),

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -1894,6 +1894,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         other: bool,
         param_env: ty::ParamEnv<'tcx>,
     ) -> bool {
+        let parent_map = self.tcx.visible_parent_map(());
         let alternative_candidates = |def_id: DefId| {
             let mut impl_candidates: Vec<_> = self
                 .tcx
@@ -1918,7 +1919,21 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                         // FIXME(compiler-errors): This could be generalized, both to
                         // be more granular, and probably look past other `#[fundamental]`
                         // types, too.
-                        self.tcx.visibility(def.did()).is_accessible_from(body_def_id, self.tcx)
+                        let mut did = def.did();
+                        if self.tcx.visibility(did).is_accessible_from(body_def_id, self.tcx) {
+                            // don't suggest foreign `#[doc(hidden)]` types
+                            if !did.is_local() {
+                                while let Some(parent) = parent_map.get(&did) {
+                                    if self.tcx.is_doc_hidden(did) {
+                                        return false;
+                                    }
+                                    did = *parent;
+                                }
+                            }
+                            true
+                        } else {
+                            false
+                        }
                     } else {
                         true
                     }

--- a/tests/ui/proc-macro/quote/not-quotable.stderr
+++ b/tests/ui/proc-macro/quote/not-quotable.stderr
@@ -15,8 +15,8 @@ LL |     let _ = quote! { $ip };
              Cow<'_, T>
              Option<T>
              Rc<T>
-             RepInterp<T>
-           and 25 others
+             bool
+           and 24 others
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/suggestions/auxiliary/hidden-struct.rs
+++ b/tests/ui/suggestions/auxiliary/hidden-struct.rs
@@ -1,3 +1,5 @@
+// `Foo` and `Bar` should not be suggested in diagnostics of dependents
+
 #[doc(hidden)]
 pub mod hidden {
     pub struct Foo;
@@ -5,13 +7,29 @@ pub mod hidden {
 
 pub mod hidden1 {
     #[doc(hidden)]
-    pub struct Foo;
-}
-
-
-#[doc(hidden)]
-pub(crate) mod hidden2 {
     pub struct Bar;
 }
 
-pub use hidden2::Bar;
+// `Baz` and `Quux` *should* be suggested in diagnostics of dependents
+
+#[doc(hidden)]
+pub mod hidden2 {
+    pub struct Baz;
+}
+
+pub use hidden2::Baz;
+
+#[doc(hidden)]
+pub(crate) mod hidden3 {
+    pub struct Quux;
+}
+
+pub use hidden3::Quux;
+
+pub trait Marker {}
+
+impl Marker for Option<u32> {}
+impl Marker for hidden::Foo {}
+impl Marker for hidden1::Bar {}
+impl Marker for Baz {}
+impl Marker for Quux {}

--- a/tests/ui/suggestions/dont-suggest-foreign-doc-hidden.rs
+++ b/tests/ui/suggestions/dont-suggest-foreign-doc-hidden.rs
@@ -1,5 +1,4 @@
 //@ aux-build:hidden-struct.rs
-//@ compile-flags: --crate-type lib
 
 extern crate hidden_struct;
 
@@ -9,7 +8,20 @@ mod local {
 }
 
 pub fn test(_: Foo) {}
-//~^ ERROR cannot find type `Foo` in this scope
+//~^ ERROR [E0412]
 
 pub fn test2(_: Bar) {}
-//~^ ERROR cannot find type `Bar` in this scope
+//~^ ERROR [E0412]
+
+pub fn test3(_: Baz) {}
+//~^ ERROR [E0412]
+
+pub fn test4(_: Quux) {}
+//~^ ERROR [E0412]
+
+fn test5<T: hidden_struct::Marker>() {}
+
+fn main() {
+    test5::<i32>();
+    //~^ ERROR [E0277]
+}

--- a/tests/ui/suggestions/dont-suggest-foreign-doc-hidden.stderr
+++ b/tests/ui/suggestions/dont-suggest-foreign-doc-hidden.stderr
@@ -1,5 +1,5 @@
 error[E0412]: cannot find type `Foo` in this scope
-  --> $DIR/dont-suggest-foreign-doc-hidden.rs:11:16
+  --> $DIR/dont-suggest-foreign-doc-hidden.rs:10:16
    |
 LL | pub fn test(_: Foo) {}
    |                ^^^ not found in this scope
@@ -10,16 +10,50 @@ LL + use local::Foo;
    |
 
 error[E0412]: cannot find type `Bar` in this scope
-  --> $DIR/dont-suggest-foreign-doc-hidden.rs:14:17
+  --> $DIR/dont-suggest-foreign-doc-hidden.rs:13:17
    |
 LL | pub fn test2(_: Bar) {}
+   |                 ^^^ not found in this scope
+
+error[E0412]: cannot find type `Baz` in this scope
+  --> $DIR/dont-suggest-foreign-doc-hidden.rs:16:17
+   |
+LL | pub fn test3(_: Baz) {}
    |                 ^^^ not found in this scope
    |
 help: consider importing this struct
    |
-LL + use hidden_struct::Bar;
+LL + use hidden_struct::Baz;
    |
 
-error: aborting due to 2 previous errors
+error[E0412]: cannot find type `Quux` in this scope
+  --> $DIR/dont-suggest-foreign-doc-hidden.rs:19:17
+   |
+LL | pub fn test4(_: Quux) {}
+   |                 ^^^^ not found in this scope
+   |
+help: consider importing this struct
+   |
+LL + use hidden_struct::Quux;
+   |
 
-For more information about this error, try `rustc --explain E0412`.
+error[E0277]: the trait bound `i32: Marker` is not satisfied
+  --> $DIR/dont-suggest-foreign-doc-hidden.rs:25:13
+   |
+LL |     test5::<i32>();
+   |             ^^^ the trait `Marker` is not implemented for `i32`
+   |
+   = help: the following other types implement trait `Marker`:
+             Baz
+             Option<u32>
+             Quux
+note: required by a bound in `test5`
+  --> $DIR/dont-suggest-foreign-doc-hidden.rs:22:13
+   |
+LL | fn test5<T: hidden_struct::Marker>() {}
+   |             ^^^^^^^^^^^^^^^^^^^^^ required by this bound in `test5`
+
+error: aborting due to 5 previous errors
+
+Some errors have detailed explanations: E0277, E0412.
+For more information about an error, try `rustc --explain E0277`.


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#146518 (Improve the documentation around `ZERO_AR_DATE`)
 - rust-lang/rust#146596 (Add a dummy codegen backend)
 - rust-lang/rust#146617 (Don’t suggest foreign `doc(hidden)` types in "the following other types implement trait" diagnostics)
 - rust-lang/rust#146635 (cg_llvm: Stop using `as_c_char_ptr` for coverage-related bindings)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=146518,146596,146617,146635)
<!-- homu-ignore:end -->