### PR TITLE
[DebugInfo] Fix MSVC tuple child creation

### DIFF
--- a/src/etc/lldb_providers.py
+++ b/src/etc/lldb_providers.py
@@ -761,7 +761,8 @@ class MSVCTupleSyntheticProvider:
 
     def get_child_at_index(self, index: int) -> SBValue:
         child: SBValue = self.valobj.GetChildAtIndex(index)
-        return child.CreateChildAtOffset(str(index), 0, child.GetType())
+        offset = self.valobj.GetType().GetFieldAtIndex(index).byte_offset
+        return self.valobj.CreateChildAtOffset(str(index), offset, child.GetType())
 
     def update(self):
         pass
@@ -772,7 +773,7 @@ class MSVCTupleSyntheticProvider:
     def get_type_name(self) -> str:
         name = self.valobj.GetTypeName()
         # remove "tuple$<" and ">", str.removeprefix and str.removesuffix require python 3.9+
-        name = name[7:-1]
+        name = name[7:-1].strip()
         return "(" + name + ")"
 
 


### PR DESCRIPTION
This is a fix for the debugger visualizer scripts

For whatever reason, using `CreateChildAtOffset` on the child element sometimes caused issues with pointers (and maybe some other types). The resulting child's memory would be a block 4 bytes too far forward. Creating the child off of the parent `valobj` and using the type definition to get the correct offset seems to fix that.

Before:

<img width="489" height="136" alt="image" src="https://github.com/user-attachments/assets/fb4cb95c-f199-49a6-8eba-6d3ff486b69a" />

After:

<img width="518" height="145" alt="image" src="https://github.com/user-attachments/assets/3f50dbc3-19ca-4fd8-87c5-b4be295f6e7c" />

This shouldn't affect any tests as we don't run debuginfo tests for MSVC afaik