### PR TITLE
cg_llvm: Replace enum `MetadataType` with a list of `MetadataKindId` constants

### DIFF
--- a/compiler/rustc_codegen_llvm/src/context.rs
+++ b/compiler/rustc_codegen_llvm/src/context.rs
@@ -34,7 +34,7 @@ use smallvec::SmallVec;
 use crate::back::write::to_llvm_code_model;
 use crate::callee::get_fn;
 use crate::debuginfo::metadata::apply_vcall_visibility_metadata;
-use crate::llvm::Metadata;
+use crate::llvm::{Metadata, MetadataKindId};
 use crate::type_::Type;
 use crate::value::Value;
 use crate::{attributes, common, coverageinfo, debuginfo, llvm, llvm_util};
@@ -1006,11 +1006,11 @@ impl<'ll, CX: Borrow<SCx<'ll>>> GenericCx<'ll, CX> {
     pub(crate) fn set_metadata<'a>(
         &self,
         val: &'a Value,
-        kind_id: impl Into<llvm::MetadataKindId>,
+        kind_id: MetadataKindId,
         md: &'ll Metadata,
     ) {
         let node = self.get_metadata_value(md);
-        llvm::LLVMSetMetadata(val, kind_id.into(), node);
+        llvm::LLVMSetMetadata(val, kind_id, node);
     }
 }
 

--- a/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
@@ -1611,16 +1611,12 @@ pub(crate) fn apply_vcall_visibility_metadata<'ll, 'tcx>(
         let v = [llvm::LLVMValueAsMetadata(cx.const_usize(0)), typeid];
         llvm::LLVMRustGlobalAddMetadata(
             vtable,
-            llvm::MD_type as c_uint,
+            llvm::MD_type,
             llvm::LLVMMDNodeInContext2(cx.llcx, v.as_ptr(), v.len()),
         );
         let vcall_visibility = llvm::LLVMValueAsMetadata(cx.const_u64(vcall_visibility as u64));
         let vcall_visibility_metadata = llvm::LLVMMDNodeInContext2(cx.llcx, &vcall_visibility, 1);
-        llvm::LLVMGlobalSetMetadata(
-            vtable,
-            llvm::MetadataType::MD_vcall_visibility as c_uint,
-            vcall_visibility_metadata,
-        );
+        llvm::LLVMGlobalSetMetadata(vtable, llvm::MD_vcall_visibility, vcall_visibility_metadata);
     }
 }
 

--- a/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
@@ -29,6 +29,7 @@ use super::debuginfo::{
     DITemplateTypeParameter, DIType, DebugEmissionKind, DebugNameTableKind,
 };
 use crate::llvm;
+use crate::llvm::MetadataKindId;
 
 /// In the LLVM-C API, boolean values are passed as `typedef int LLVMBool`,
 /// which has a different ABI from Rust or C++ `bool`.
@@ -1034,16 +1035,6 @@ pub(crate) type SelfProfileAfterPassCallback = unsafe extern "C" fn(*mut c_void)
 pub(crate) type GetSymbolsCallback =
     unsafe extern "C" fn(*mut c_void, *const c_char) -> *mut c_void;
 pub(crate) type GetSymbolsErrorCallback = unsafe extern "C" fn(*const c_char) -> *mut c_void;
-
-#[derive(Copy, Clone)]
-#[repr(transparent)]
-pub(crate) struct MetadataKindId(c_uint);
-
-impl From<MetadataType> for MetadataKindId {
-    fn from(value: MetadataType) -> Self {
-        Self(value as c_uint)
-    }
-}
 
 unsafe extern "C" {
     // Create and destroy contexts.

--- a/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
@@ -514,31 +514,6 @@ pub(crate) enum FileType {
     ObjectFile,
 }
 
-/// LLVMMetadataType
-#[derive(Copy, Clone)]
-#[repr(C)]
-#[expect(dead_code, reason = "Some variants are unused, but are kept to match LLVM-C")]
-pub(crate) enum MetadataType {
-    MD_dbg = 0,
-    MD_tbaa = 1,
-    MD_prof = 2,
-    MD_fpmath = 3,
-    MD_range = 4,
-    MD_tbaa_struct = 5,
-    MD_invariant_load = 6,
-    MD_alias_scope = 7,
-    MD_noalias = 8,
-    MD_nontemporal = 9,
-    MD_mem_parallel_loop_access = 10,
-    MD_nonnull = 11,
-    MD_unpredictable = 15,
-    MD_align = 17,
-    MD_type = 19,
-    MD_vcall_visibility = 28,
-    MD_noundef = 29,
-    MD_kcfi_type = 36,
-}
-
 /// Must match the layout of `LLVMInlineAsmDialect`.
 #[derive(Copy, Clone, PartialEq)]
 #[repr(C)]
@@ -1130,7 +1105,11 @@ unsafe extern "C" {
     pub(crate) fn LLVMSetValueName2(Val: &Value, Name: *const c_char, NameLen: size_t);
     pub(crate) fn LLVMReplaceAllUsesWith<'a>(OldVal: &'a Value, NewVal: &'a Value);
     pub(crate) safe fn LLVMSetMetadata<'a>(Val: &'a Value, KindID: MetadataKindId, Node: &'a Value);
-    pub(crate) fn LLVMGlobalSetMetadata<'a>(Val: &'a Value, KindID: c_uint, Metadata: &'a Metadata);
+    pub(crate) fn LLVMGlobalSetMetadata<'a>(
+        Val: &'a Value,
+        KindID: MetadataKindId,
+        Metadata: &'a Metadata,
+    );
     pub(crate) safe fn LLVMValueAsMetadata(Node: &Value) -> &Metadata;
 
     // Operations on constants of any type
@@ -2050,7 +2029,7 @@ unsafe extern "C" {
     // Operations on all values
     pub(crate) fn LLVMRustGlobalAddMetadata<'a>(
         Val: &'a Value,
-        KindID: c_uint,
+        KindID: MetadataKindId,
         Metadata: &'a Metadata,
     );
     pub(crate) fn LLVMRustIsNonGVFunctionPointerTy(Val: &Value) -> bool;

--- a/compiler/rustc_codegen_llvm/src/llvm/metadata_kind.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/metadata_kind.rs
@@ -1,0 +1,13 @@
+use libc::c_uint;
+
+use crate::llvm::MetadataType;
+
+#[derive(Copy, Clone)]
+#[repr(transparent)]
+pub(crate) struct MetadataKindId(c_uint);
+
+impl From<MetadataType> for MetadataKindId {
+    fn from(value: MetadataType) -> Self {
+        Self(value as c_uint)
+    }
+}

--- a/compiler/rustc_codegen_llvm/src/llvm/metadata_kind.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/metadata_kind.rs
@@ -11,3 +11,67 @@ impl From<MetadataType> for MetadataKindId {
         Self(value as c_uint)
     }
 }
+
+macro_rules! declare_fixed_metadata_kinds {
+    (
+        $(
+            FIXED_MD_KIND($variant:ident, $value:literal)
+        )*
+    ) => {
+        // Use a submodule to group all declarations into one `#[expect(..)]`.
+        #[expect(dead_code)]
+        mod fixed_kinds {
+            use super::MetadataKindId;
+            $(
+                #[expect(non_upper_case_globals)]
+                pub(crate) const $variant: MetadataKindId = MetadataKindId($value);
+            )*
+        }
+    };
+}
+
+// Must be kept in sync with the corresponding static assertions in `RustWrapper.cpp`.
+declare_fixed_metadata_kinds! {
+    FIXED_MD_KIND(MD_dbg, 0)
+    FIXED_MD_KIND(MD_tbaa, 1)
+    FIXED_MD_KIND(MD_prof, 2)
+    FIXED_MD_KIND(MD_fpmath, 3)
+    FIXED_MD_KIND(MD_range, 4)
+    FIXED_MD_KIND(MD_tbaa_struct, 5)
+    FIXED_MD_KIND(MD_invariant_load, 6)
+    FIXED_MD_KIND(MD_alias_scope, 7)
+    FIXED_MD_KIND(MD_noalias, 8)
+    FIXED_MD_KIND(MD_nontemporal, 9)
+    FIXED_MD_KIND(MD_mem_parallel_loop_access, 10)
+    FIXED_MD_KIND(MD_nonnull, 11)
+    FIXED_MD_KIND(MD_dereferenceable, 12)
+    FIXED_MD_KIND(MD_dereferenceable_or_null, 13)
+    FIXED_MD_KIND(MD_make_implicit, 14)
+    FIXED_MD_KIND(MD_unpredictable, 15)
+    FIXED_MD_KIND(MD_invariant_group, 16)
+    FIXED_MD_KIND(MD_align, 17)
+    FIXED_MD_KIND(MD_loop, 18)
+    FIXED_MD_KIND(MD_type, 19)
+    FIXED_MD_KIND(MD_section_prefix, 20)
+    FIXED_MD_KIND(MD_absolute_symbol, 21)
+    FIXED_MD_KIND(MD_associated, 22)
+    FIXED_MD_KIND(MD_callees, 23)
+    FIXED_MD_KIND(MD_irr_loop, 24)
+    FIXED_MD_KIND(MD_access_group, 25)
+    FIXED_MD_KIND(MD_callback, 26)
+    FIXED_MD_KIND(MD_preserve_access_index, 27)
+    FIXED_MD_KIND(MD_vcall_visibility, 28)
+    FIXED_MD_KIND(MD_noundef, 29)
+    FIXED_MD_KIND(MD_annotation, 30)
+    FIXED_MD_KIND(MD_nosanitize, 31)
+    FIXED_MD_KIND(MD_func_sanitize, 32)
+    FIXED_MD_KIND(MD_exclude, 33)
+    FIXED_MD_KIND(MD_memprof, 34)
+    FIXED_MD_KIND(MD_callsite, 35)
+    FIXED_MD_KIND(MD_kcfi_type, 36)
+    FIXED_MD_KIND(MD_pcsections, 37)
+    FIXED_MD_KIND(MD_DIAssignID, 38)
+    FIXED_MD_KIND(MD_coro_outside_frame, 39)
+    FIXED_MD_KIND(MD_mmra, 40)
+    FIXED_MD_KIND(MD_noalias_addrspace, 41)
+}

--- a/compiler/rustc_codegen_llvm/src/llvm/metadata_kind.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/metadata_kind.rs
@@ -1,16 +1,10 @@
 use libc::c_uint;
 
-use crate::llvm::MetadataType;
+pub(crate) use self::fixed_kinds::*;
 
 #[derive(Copy, Clone)]
 #[repr(transparent)]
 pub(crate) struct MetadataKindId(c_uint);
-
-impl From<MetadataType> for MetadataKindId {
-    fn from(value: MetadataType) -> Self {
-        Self(value as c_uint)
-    }
-}
 
 macro_rules! declare_fixed_metadata_kinds {
     (

--- a/compiler/rustc_codegen_llvm/src/llvm/mod.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/mod.rs
@@ -13,11 +13,13 @@ pub(crate) use self::CallConv::*;
 pub(crate) use self::CodeGenOptSize::*;
 pub(crate) use self::MetadataType::*;
 pub(crate) use self::ffi::*;
+pub(crate) use self::metadata_kind::MetadataKindId;
 use crate::common::AsCCharPtr;
 
 pub(crate) mod diagnostic;
 pub(crate) mod enzyme_ffi;
 mod ffi;
+mod metadata_kind;
 
 pub(crate) use self::enzyme_ffi::*;
 

--- a/compiler/rustc_codegen_llvm/src/llvm/mod.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/mod.rs
@@ -11,9 +11,8 @@ use rustc_llvm::RustString;
 
 pub(crate) use self::CallConv::*;
 pub(crate) use self::CodeGenOptSize::*;
-pub(crate) use self::MetadataType::*;
 pub(crate) use self::ffi::*;
-pub(crate) use self::metadata_kind::MetadataKindId;
+pub(crate) use self::metadata_kind::*;
 use crate::common::AsCCharPtr;
 
 pub(crate) mod diagnostic;

--- a/compiler/rustc_codegen_llvm/src/type_.rs
+++ b/compiler/rustc_codegen_llvm/src/type_.rs
@@ -306,7 +306,7 @@ impl<'ll, 'tcx> TypeMembershipCodegenMethods<'tcx> for CodegenCx<'ll, 'tcx> {
             let v = [llvm::LLVMValueAsMetadata(self.const_usize(0)), typeid_metadata];
             llvm::LLVMRustGlobalAddMetadata(
                 function,
-                llvm::MD_type as c_uint,
+                llvm::MD_type,
                 llvm::LLVMMDNodeInContext2(self.llcx, v.as_ptr(), v.len()),
             )
         }
@@ -318,7 +318,7 @@ impl<'ll, 'tcx> TypeMembershipCodegenMethods<'tcx> for CodegenCx<'ll, 'tcx> {
             let v = [llvm::LLVMValueAsMetadata(self.const_usize(0)), typeid_metadata];
             llvm::LLVMGlobalSetMetadata(
                 function,
-                llvm::MD_type as c_uint,
+                llvm::MD_type,
                 llvm::LLVMMDNodeInContext2(self.llcx, v.as_ptr(), v.len()),
             )
         }
@@ -333,7 +333,7 @@ impl<'ll, 'tcx> TypeMembershipCodegenMethods<'tcx> for CodegenCx<'ll, 'tcx> {
         unsafe {
             llvm::LLVMRustGlobalAddMetadata(
                 function,
-                llvm::MD_kcfi_type as c_uint,
+                llvm::MD_kcfi_type,
                 llvm::LLVMMDNodeInContext2(
                     self.llcx,
                     &llvm::LLVMValueAsMetadata(kcfi_type_metadata),
@@ -348,7 +348,7 @@ impl<'ll, 'tcx> TypeMembershipCodegenMethods<'tcx> for CodegenCx<'ll, 'tcx> {
         unsafe {
             llvm::LLVMGlobalSetMetadata(
                 function,
-                llvm::MD_kcfi_type as c_uint,
+                llvm::MD_kcfi_type,
                 llvm::LLVMMDNodeInContext2(
                     self.llcx,
                     &llvm::LLVMValueAsMetadata(kcfi_type_metadata),

--- a/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
@@ -1824,3 +1824,55 @@ extern "C" size_t LLVMRustEnzymeGetMaxTypeDepth() {
   return 6; // Default fallback depth
 }
 #endif
+
+// Statically assert that the fixed metadata kind IDs declared in
+// `metadata_kind.rs` match the ones actually used by LLVM.
+#define FIXED_MD_KIND(VARIANT, VALUE)                                          \
+  static_assert(::llvm::LLVMContext::VARIANT == VALUE);
+// Must be kept in sync with the corresponding list in `metadata_kind.rs`.
+FIXED_MD_KIND(MD_dbg, 0)
+FIXED_MD_KIND(MD_tbaa, 1)
+FIXED_MD_KIND(MD_prof, 2)
+FIXED_MD_KIND(MD_fpmath, 3)
+FIXED_MD_KIND(MD_range, 4)
+FIXED_MD_KIND(MD_tbaa_struct, 5)
+FIXED_MD_KIND(MD_invariant_load, 6)
+FIXED_MD_KIND(MD_alias_scope, 7)
+FIXED_MD_KIND(MD_noalias, 8)
+FIXED_MD_KIND(MD_nontemporal, 9)
+FIXED_MD_KIND(MD_mem_parallel_loop_access, 10)
+FIXED_MD_KIND(MD_nonnull, 11)
+FIXED_MD_KIND(MD_dereferenceable, 12)
+FIXED_MD_KIND(MD_dereferenceable_or_null, 13)
+FIXED_MD_KIND(MD_make_implicit, 14)
+FIXED_MD_KIND(MD_unpredictable, 15)
+FIXED_MD_KIND(MD_invariant_group, 16)
+FIXED_MD_KIND(MD_align, 17)
+FIXED_MD_KIND(MD_loop, 18)
+FIXED_MD_KIND(MD_type, 19)
+FIXED_MD_KIND(MD_section_prefix, 20)
+FIXED_MD_KIND(MD_absolute_symbol, 21)
+FIXED_MD_KIND(MD_associated, 22)
+FIXED_MD_KIND(MD_callees, 23)
+FIXED_MD_KIND(MD_irr_loop, 24)
+FIXED_MD_KIND(MD_access_group, 25)
+FIXED_MD_KIND(MD_callback, 26)
+FIXED_MD_KIND(MD_preserve_access_index, 27)
+FIXED_MD_KIND(MD_vcall_visibility, 28)
+FIXED_MD_KIND(MD_noundef, 29)
+FIXED_MD_KIND(MD_annotation, 30)
+FIXED_MD_KIND(MD_nosanitize, 31)
+FIXED_MD_KIND(MD_func_sanitize, 32)
+FIXED_MD_KIND(MD_exclude, 33)
+FIXED_MD_KIND(MD_memprof, 34)
+FIXED_MD_KIND(MD_callsite, 35)
+FIXED_MD_KIND(MD_kcfi_type, 36)
+FIXED_MD_KIND(MD_pcsections, 37)
+FIXED_MD_KIND(MD_DIAssignID, 38)
+FIXED_MD_KIND(MD_coro_outside_frame, 39)
+FIXED_MD_KIND(MD_mmra, 40)
+FIXED_MD_KIND(MD_noalias_addrspace, 41)
+// If some fixed metadata kinds are not present and consistent in all supported
+// LLVM versions, it's fine to omit them from this list; in that case Rust-side
+// code cannot declare them as fixed IDs and must look them up by name instead.
+#undef FIXED_MD_KIND


### PR DESCRIPTION
The metadata kind ID values declared in `MetadataType` are not part of the LLVM-C API, and are not machine-checked. If a value that we use ever goes out of sync with LLVM, the resulting bugs could be difficult to track down. And the existing values lack any clear indication of what LLVM declarations they correspond to.

On top of that, we currently have another way of expressing metadata kind IDs in the form of `MetadataKindId`, which creates confusing inconsistency in LLVM bindings.

This PR therefore consolidates all usage of “fixed” metadata kind IDs into one list of `MetadataKindId` constants, which is backed by static assertions in our C++ code that match them up with named anonymous-enum variants in `llvm::LLVMContext`.