### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/compiler/rustc_borrowck/src/borrowck_errors.rs
+++ b/compiler/rustc_borrowck/src/borrowck_errors.rs
@@ -480,7 +480,7 @@ impl<'infcx, 'tcx> crate::MirBorrowckCtxt<'_, 'infcx, 'tcx> {
     }
 
     pub(crate) fn temporary_value_borrowed_for_too_long(&self, span: Span) -> Diag<'infcx> {
-        struct_span_code_err!(self.dcx(), span, E0716, "temporary value dropped while borrowed",)
+        struct_span_code_err!(self.dcx(), span, E0716, "temporary value dropped while borrowed")
     }
 }
 

--- a/compiler/rustc_borrowck/src/borrowck_errors.rs
+++ b/compiler/rustc_borrowck/src/borrowck_errors.rs
@@ -426,7 +426,7 @@ impl<'infcx, 'tcx> crate::MirBorrowckCtxt<'_, 'infcx, 'tcx> {
     }
 
     pub(crate) fn path_does_not_live_long_enough(&self, span: Span, path: &str) -> Diag<'infcx> {
-        struct_span_code_err!(self.dcx(), span, E0597, "{} does not live long enough", path,)
+        struct_span_code_err!(self.dcx(), span, E0597, "{} does not live long enough", path)
     }
 
     pub(crate) fn cannot_return_reference_to_local(

--- a/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
@@ -3031,6 +3031,15 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
 
         let mut err = self.path_does_not_live_long_enough(borrow_span, &name);
 
+        if let BorrowExplanation::MustBeValidFor { ref path, region_name, .. } = explanation {
+            for constraint in path {
+                if let ConstraintCategory::Predicate(pred) = constraint.category
+                    && !pred.is_dummy()
+                {
+                    err.span_note(pred, format!("requirement that {name} is borrowed for `{region_name}` introduced here"));
+                }
+            }
+        }
         if let Some(annotation) = self.annotate_argument_and_return_for_borrow(borrow) {
             let region_name = annotation.emit(self, &mut err);
 

--- a/compiler/rustc_borrowck/src/diagnostics/explain_borrow.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/explain_borrow.rs
@@ -417,18 +417,21 @@ impl<'tcx> BorrowExplanation<'tcx> {
                     self.add_object_lifetime_default_note(tcx, err, unsize_ty);
                 }
 
-                if let Some(pred) = path
+                let mut preds = path
                     .iter()
                     .filter_map(|constraint| match constraint.category {
                         ConstraintCategory::Predicate(pred) if !pred.is_dummy() => Some(pred),
                         _ => None,
                     })
-                    .next()
-                {
+                    .collect::<Vec<Span>>();
+                preds.sort();
+                preds.dedup();
+                if !preds.is_empty() {
+                    let s = if preds.len() == 1 { "" } else { "s" };
                     err.span_note(
-                        pred,
+                        preds,
                         format!(
-                            "requirement that the value outlives `{region_name}` introduced here"
+                            "requirement{s} that the value outlives `{region_name}` introduced here"
                         ),
                     );
                 }

--- a/compiler/rustc_borrowck/src/diagnostics/explain_borrow.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/explain_borrow.rs
@@ -416,6 +416,19 @@ impl<'tcx> BorrowExplanation<'tcx> {
                 {
                     self.add_object_lifetime_default_note(tcx, err, unsize_ty);
                 }
+
+                for constraint in path {
+                    if let ConstraintCategory::Predicate(pred) = constraint.category
+                        && !pred.is_dummy()
+                    {
+                        err.span_note(
+                            pred,
+                            format!("requirement for `{region_name}` introduced here"),
+                        );
+                        break;
+                    }
+                }
+
                 self.add_lifetime_bound_suggestion_to_diagnostic(err, &category, span, region_name);
             }
             _ => {}

--- a/compiler/rustc_borrowck/src/diagnostics/explain_borrow.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/explain_borrow.rs
@@ -423,7 +423,7 @@ impl<'tcx> BorrowExplanation<'tcx> {
                     {
                         err.span_note(
                             pred,
-                            format!("requirement for `{region_name}` introduced here"),
+                            format!("requirement that the value outlives `{region_name}` introduced here"),
                         );
                         break;
                     }

--- a/compiler/rustc_borrowck/src/lib.rs
+++ b/compiler/rustc_borrowck/src/lib.rs
@@ -116,10 +116,7 @@ pub fn provide(providers: &mut Providers) {
 /// Provider for `query mir_borrowck`. Similar to `typeck`, this must
 /// only be called for typeck roots which will then borrowck all
 /// nested bodies as well.
-fn mir_borrowck(
-    tcx: TyCtxt<'_>,
-    def: LocalDefId,
-) -> Result<&ConcreteOpaqueTypes<'_>, ErrorGuaranteed> {
+fn mir_borrowck(tcx: TyCtxt<'_>, def: LocalDefId) -> Result<&HiddenTypes<'_>, ErrorGuaranteed> {
     assert!(!tcx.is_typeck_child(def.to_def_id()));
     let (input_body, _) = tcx.mir_promoted(def);
     debug!("run query mir_borrowck: {}", tcx.def_path_str(def));
@@ -130,7 +127,7 @@ fn mir_borrowck(
         Err(guar)
     } else if input_body.should_skip() {
         debug!("Skipping borrowck because of injected body");
-        let opaque_types = ConcreteOpaqueTypes(Default::default());
+        let opaque_types = HiddenTypes(Default::default());
         Ok(tcx.arena.alloc(opaque_types))
     } else {
         let mut root_cx = BorrowCheckRootCtxt::new(tcx, def, None);

--- a/compiler/rustc_borrowck/src/lib.rs
+++ b/compiler/rustc_borrowck/src/lib.rs
@@ -116,7 +116,10 @@ pub fn provide(providers: &mut Providers) {
 /// Provider for `query mir_borrowck`. Similar to `typeck`, this must
 /// only be called for typeck roots which will then borrowck all
 /// nested bodies as well.
-fn mir_borrowck(tcx: TyCtxt<'_>, def: LocalDefId) -> Result<&HiddenTypes<'_>, ErrorGuaranteed> {
+fn mir_borrowck(
+    tcx: TyCtxt<'_>,
+    def: LocalDefId,
+) -> Result<&DefinitionSiteHiddenTypes<'_>, ErrorGuaranteed> {
     assert!(!tcx.is_typeck_child(def.to_def_id()));
     let (input_body, _) = tcx.mir_promoted(def);
     debug!("run query mir_borrowck: {}", tcx.def_path_str(def));
@@ -127,7 +130,7 @@ fn mir_borrowck(tcx: TyCtxt<'_>, def: LocalDefId) -> Result<&HiddenTypes<'_>, Er
         Err(guar)
     } else if input_body.should_skip() {
         debug!("Skipping borrowck because of injected body");
-        let opaque_types = HiddenTypes(Default::default());
+        let opaque_types = DefinitionSiteHiddenTypes(Default::default());
         Ok(tcx.arena.alloc(opaque_types))
     } else {
         let mut root_cx = BorrowCheckRootCtxt::new(tcx, def, None);

--- a/compiler/rustc_borrowck/src/region_infer/mod.rs
+++ b/compiler/rustc_borrowck/src/region_infer/mod.rs
@@ -1382,10 +1382,10 @@ impl<'tcx> RegionInferenceContext<'tcx> {
     }
 
     /// The constraints we get from equating the hidden type of each use of an opaque
-    /// with its final concrete type may end up getting preferred over other, potentially
+    /// with its final hidden type may end up getting preferred over other, potentially
     /// longer constraint paths.
     ///
-    /// Given that we compute the final concrete type by relying on this existing constraint
+    /// Given that we compute the final hidden type by relying on this existing constraint
     /// path, this can easily end up hiding the actual reason for why we require these regions
     /// to be equal.
     ///

--- a/compiler/rustc_borrowck/src/region_infer/opaque_types/mod.rs
+++ b/compiler/rustc_borrowck/src/region_infer/opaque_types/mod.rs
@@ -8,7 +8,7 @@ use rustc_infer::infer::outlives::env::RegionBoundPairs;
 use rustc_infer::infer::{InferCtxt, NllRegionVariableOrigin, OpaqueTypeStorageEntries};
 use rustc_infer::traits::ObligationCause;
 use rustc_macros::extension;
-use rustc_middle::mir::{Body, ConcreteOpaqueTypes, ConstraintCategory};
+use rustc_middle::mir::{Body, ConstraintCategory, HiddenTypes};
 use rustc_middle::ty::{
     self, DefiningScopeKind, EarlyBinder, FallibleTypeFolder, GenericArg, GenericArgsRef,
     OpaqueHiddenType, OpaqueTypeKey, Region, RegionVid, Ty, TyCtxt, TypeFoldable,
@@ -129,9 +129,9 @@ fn nll_var_to_universal_region<'tcx>(
 /// Collect all defining uses of opaque types inside of this typeck root. This
 /// expects the hidden type to be mapped to the definition parameters of the opaque
 /// and errors if we end up with distinct hidden types.
-fn add_concrete_opaque_type<'tcx>(
+fn add_hidden_type<'tcx>(
     tcx: TyCtxt<'tcx>,
-    concrete_opaque_types: &mut ConcreteOpaqueTypes<'tcx>,
+    hidden_types: &mut HiddenTypes<'tcx>,
     def_id: LocalDefId,
     hidden_ty: OpaqueHiddenType<'tcx>,
 ) {
@@ -139,7 +139,7 @@ fn add_concrete_opaque_type<'tcx>(
     // back to the opaque type definition. E.g. we may have `OpaqueType<X, Y>` mapped to
     // `(X, Y)` and `OpaqueType<Y, X>` mapped to `(Y, X)`, and those are the same, but we
     // only know that once we convert the generic parameters to those of the opaque type.
-    if let Some(prev) = concrete_opaque_types.0.get_mut(&def_id) {
+    if let Some(prev) = hidden_types.0.get_mut(&def_id) {
         if prev.ty != hidden_ty.ty {
             let guar = hidden_ty.ty.error_reported().err().unwrap_or_else(|| {
                 let (Ok(e) | Err(e)) = prev.build_mismatch_error(&hidden_ty, tcx).map(|d| d.emit());
@@ -151,15 +151,15 @@ fn add_concrete_opaque_type<'tcx>(
         // FIXME(oli-obk): collect multiple spans for better diagnostics down the road.
         prev.span = prev.span.substitute_dummy(hidden_ty.span);
     } else {
-        concrete_opaque_types.0.insert(def_id, hidden_ty);
+        hidden_types.0.insert(def_id, hidden_ty);
     }
 }
 
-fn get_concrete_opaque_type<'tcx>(
-    concrete_opaque_types: &ConcreteOpaqueTypes<'tcx>,
+fn get_hidden_type<'tcx>(
+    hidden_types: &HiddenTypes<'tcx>,
     def_id: LocalDefId,
 ) -> Option<EarlyBinder<'tcx, OpaqueHiddenType<'tcx>>> {
-    concrete_opaque_types.0.get(&def_id).map(|ty| EarlyBinder::bind(*ty))
+    hidden_types.0.get(&def_id).map(|ty| EarlyBinder::bind(*ty))
 }
 
 #[derive(Debug)]
@@ -173,22 +173,22 @@ struct DefiningUse<'tcx> {
 }
 
 /// This computes the actual hidden types of the opaque types and maps them to their
-/// definition sites. Outside of registering the computed concrete types this function
+/// definition sites. Outside of registering the computed hidden types this function
 /// does not mutate the current borrowck state.
 ///
 /// While it may fail to infer the hidden type and return errors, we always apply
-/// the computed concrete hidden type to all opaque type uses to check whether they
+/// the computed hidden type to all opaque type uses to check whether they
 /// are correct. This is necessary to support non-defining uses of opaques in their
 /// defining scope.
 ///
 /// It also means that this whole function is not really soundness critical as we
 /// recheck all uses of the opaques regardless.
-pub(crate) fn compute_concrete_opaque_types<'tcx>(
+pub(crate) fn compute_hidden_types<'tcx>(
     infcx: &BorrowckInferCtxt<'tcx>,
     universal_region_relations: &Frozen<UniversalRegionRelations<'tcx>>,
     constraints: &MirTypeckRegionConstraints<'tcx>,
     location_map: Rc<DenseLocationMap>,
-    concrete_opaque_types: &mut ConcreteOpaqueTypes<'tcx>,
+    hidden_types: &mut HiddenTypes<'tcx>,
     opaque_types: &[(OpaqueTypeKey<'tcx>, OpaqueHiddenType<'tcx>)],
 ) -> Vec<DeferredOpaqueTypeError<'tcx>> {
     let mut errors = Vec::new();
@@ -201,8 +201,7 @@ pub(crate) fn compute_concrete_opaque_types<'tcx>(
     // We start by checking each use of an opaque type during type check and
     // check whether the generic arguments of the opaque type are fully
     // universal, if so, it's a defining use.
-    let defining_uses =
-        collect_defining_uses(&mut rcx, concrete_opaque_types, opaque_types, &mut errors);
+    let defining_uses = collect_defining_uses(&mut rcx, hidden_types, opaque_types, &mut errors);
 
     // We now compute and apply member constraints for all regions in the hidden
     // types of each defining use. This mutates the region values of the `rcx` which
@@ -210,21 +209,16 @@ pub(crate) fn compute_concrete_opaque_types<'tcx>(
     apply_member_constraints(&mut rcx, &defining_uses);
 
     // After applying member constraints, we now check whether all member regions ended
-    // up equal to one of their choice regions and compute the actual concrete type of
+    // up equal to one of their choice regions and compute the actual hidden type of
     // the opaque type definition. This is stored in the `root_cx`.
-    compute_concrete_types_from_defining_uses(
-        &rcx,
-        concrete_opaque_types,
-        &defining_uses,
-        &mut errors,
-    );
+    compute_hidden_types_from_defining_uses(&rcx, hidden_types, &defining_uses, &mut errors);
     errors
 }
 
 #[instrument(level = "debug", skip_all, ret)]
 fn collect_defining_uses<'tcx>(
     rcx: &mut RegionCtxt<'_, 'tcx>,
-    concrete_opaque_types: &mut ConcreteOpaqueTypes<'tcx>,
+    hidden_types: &mut HiddenTypes<'tcx>,
     opaque_types: &[(OpaqueTypeKey<'tcx>, OpaqueHiddenType<'tcx>)],
     errors: &mut Vec<DeferredOpaqueTypeError<'tcx>>,
 ) -> Vec<DefiningUse<'tcx>> {
@@ -244,9 +238,9 @@ fn collect_defining_uses<'tcx>(
             // with `TypingMode::Borrowck`.
             if infcx.tcx.use_typing_mode_borrowck() {
                 match err {
-                    NonDefiningUseReason::Tainted(guar) => add_concrete_opaque_type(
+                    NonDefiningUseReason::Tainted(guar) => add_hidden_type(
                         infcx.tcx,
-                        concrete_opaque_types,
+                        hidden_types,
                         opaque_type_key.def_id,
                         OpaqueHiddenType::new_error(infcx.tcx, guar),
                     ),
@@ -277,9 +271,9 @@ fn collect_defining_uses<'tcx>(
     defining_uses
 }
 
-fn compute_concrete_types_from_defining_uses<'tcx>(
+fn compute_hidden_types_from_defining_uses<'tcx>(
     rcx: &RegionCtxt<'_, 'tcx>,
-    concrete_opaque_types: &mut ConcreteOpaqueTypes<'tcx>,
+    hidden_types: &mut HiddenTypes<'tcx>,
     defining_uses: &[DefiningUse<'tcx>],
     errors: &mut Vec<DeferredOpaqueTypeError<'tcx>>,
 ) {
@@ -358,9 +352,9 @@ fn compute_concrete_types_from_defining_uses<'tcx>(
                 },
             ));
         }
-        add_concrete_opaque_type(
+        add_hidden_type(
             tcx,
-            concrete_opaque_types,
+            hidden_types,
             opaque_type_key.def_id,
             OpaqueHiddenType { span: hidden_type.span, ty },
         );
@@ -489,20 +483,20 @@ impl<'tcx> FallibleTypeFolder<TyCtxt<'tcx>> for ToArgRegionsFolder<'_, 'tcx> {
 ///
 /// It does this by equating the hidden type of each use with the instantiated final
 /// hidden type of the opaque.
-pub(crate) fn apply_computed_concrete_opaque_types<'tcx>(
+pub(crate) fn apply_hidden_types<'tcx>(
     infcx: &BorrowckInferCtxt<'tcx>,
     body: &Body<'tcx>,
     universal_regions: &UniversalRegions<'tcx>,
     region_bound_pairs: &RegionBoundPairs<'tcx>,
     known_type_outlives_obligations: &[ty::PolyTypeOutlivesPredicate<'tcx>],
     constraints: &mut MirTypeckRegionConstraints<'tcx>,
-    concrete_opaque_types: &mut ConcreteOpaqueTypes<'tcx>,
+    hidden_types: &mut HiddenTypes<'tcx>,
     opaque_types: &[(OpaqueTypeKey<'tcx>, OpaqueHiddenType<'tcx>)],
 ) -> Vec<DeferredOpaqueTypeError<'tcx>> {
     let tcx = infcx.tcx;
     let mut errors = Vec::new();
     for &(key, hidden_type) in opaque_types {
-        let Some(expected) = get_concrete_opaque_type(concrete_opaque_types, key.def_id) else {
+        let Some(expected) = get_hidden_type(hidden_types, key.def_id) else {
             if !tcx.use_typing_mode_borrowck() {
                 if let ty::Alias(ty::Opaque, alias_ty) = hidden_type.ty.kind()
                     && alias_ty.def_id == key.def_id.to_def_id()
@@ -521,12 +515,7 @@ pub(crate) fn apply_computed_concrete_opaque_types<'tcx>(
                 hidden_type.span,
                 "non-defining use in the defining scope with no defining uses",
             );
-            add_concrete_opaque_type(
-                tcx,
-                concrete_opaque_types,
-                key.def_id,
-                OpaqueHiddenType::new_error(tcx, guar),
-            );
+            add_hidden_type(tcx, hidden_types, key.def_id, OpaqueHiddenType::new_error(tcx, guar));
             continue;
         };
 
@@ -566,18 +555,13 @@ pub(crate) fn apply_computed_concrete_opaque_types<'tcx>(
                 "equating opaque types",
             ),
         ) {
-            add_concrete_opaque_type(
-                tcx,
-                concrete_opaque_types,
-                key.def_id,
-                OpaqueHiddenType::new_error(tcx, guar),
-            );
+            add_hidden_type(tcx, hidden_types, key.def_id, OpaqueHiddenType::new_error(tcx, guar));
         }
     }
     errors
 }
 
-/// In theory `apply_concrete_opaque_types` could introduce new uses of opaque types.
+/// In theory `apply_hidden_types` could introduce new uses of opaque types.
 /// We do not check these new uses so this could be unsound.
 ///
 /// We detect any new uses and simply delay a bug if they occur. If this results in
@@ -682,13 +666,6 @@ impl<'tcx> InferCtxt<'tcx> {
     ///
     /// (*) C1 and C2 were introduced in the comments on
     /// `register_member_constraints`. Read that comment for more context.
-    ///
-    /// # Parameters
-    ///
-    /// - `def_id`, the `impl Trait` type
-    /// - `args`, the args used to instantiate this opaque type
-    /// - `instantiated_ty`, the inferred type C1 -- fully resolved, lifted version of
-    ///   `opaque_defn.concrete_ty`
     #[instrument(level = "debug", skip(self))]
     fn infer_opaque_definition_from_instantiation(
         &self,

--- a/compiler/rustc_borrowck/src/root_cx.rs
+++ b/compiler/rustc_borrowck/src/root_cx.rs
@@ -12,12 +12,12 @@ use smallvec::SmallVec;
 use crate::consumers::BorrowckConsumer;
 use crate::nll::compute_closure_requirements_modulo_opaques;
 use crate::region_infer::opaque_types::{
-    apply_computed_concrete_opaque_types, clone_and_resolve_opaque_types,
-    compute_concrete_opaque_types, detect_opaque_types_added_while_handling_opaque_types,
+    apply_hidden_types, clone_and_resolve_opaque_types, compute_hidden_types,
+    detect_opaque_types_added_while_handling_opaque_types,
 };
 use crate::type_check::{Locations, constraint_conversion};
 use crate::{
-    ClosureRegionRequirements, CollectRegionConstraintsResult, ConcreteOpaqueTypes,
+    ClosureRegionRequirements, CollectRegionConstraintsResult, HiddenTypes,
     PropagatedBorrowCheckResults, borrowck_check_region_constraints,
     borrowck_collect_region_constraints,
 };
@@ -27,7 +27,7 @@ use crate::{
 pub(super) struct BorrowCheckRootCtxt<'tcx> {
     pub tcx: TyCtxt<'tcx>,
     root_def_id: LocalDefId,
-    concrete_opaque_types: ConcreteOpaqueTypes<'tcx>,
+    hidden_types: HiddenTypes<'tcx>,
     /// The region constraints computed by [borrowck_collect_region_constraints]. This uses
     /// an [FxIndexMap] to guarantee that iterating over it visits nested bodies before
     /// their parents.
@@ -49,7 +49,7 @@ impl<'tcx> BorrowCheckRootCtxt<'tcx> {
         BorrowCheckRootCtxt {
             tcx,
             root_def_id,
-            concrete_opaque_types: Default::default(),
+            hidden_types: Default::default(),
             collect_region_constraints_results: Default::default(),
             propagated_borrowck_results: Default::default(),
             tainted_by_errors: None,
@@ -72,11 +72,11 @@ impl<'tcx> BorrowCheckRootCtxt<'tcx> {
         &self.propagated_borrowck_results[&nested_body_def_id].used_mut_upvars
     }
 
-    pub(super) fn finalize(self) -> Result<&'tcx ConcreteOpaqueTypes<'tcx>, ErrorGuaranteed> {
+    pub(super) fn finalize(self) -> Result<&'tcx HiddenTypes<'tcx>, ErrorGuaranteed> {
         if let Some(guar) = self.tainted_by_errors {
             Err(guar)
         } else {
-            Ok(self.tcx.arena.alloc(self.concrete_opaque_types))
+            Ok(self.tcx.arena.alloc(self.hidden_types))
         }
     }
 
@@ -88,12 +88,12 @@ impl<'tcx> BorrowCheckRootCtxt<'tcx> {
                 &input.universal_region_relations,
                 &mut input.constraints,
             );
-            input.deferred_opaque_type_errors = compute_concrete_opaque_types(
+            input.deferred_opaque_type_errors = compute_hidden_types(
                 &input.infcx,
                 &input.universal_region_relations,
                 &input.constraints,
                 Rc::clone(&input.location_map),
-                &mut self.concrete_opaque_types,
+                &mut self.hidden_types,
                 &opaque_types,
             );
             per_body_info.push((num_entries, opaque_types));
@@ -103,14 +103,14 @@ impl<'tcx> BorrowCheckRootCtxt<'tcx> {
             self.collect_region_constraints_results.values_mut().zip(per_body_info)
         {
             if input.deferred_opaque_type_errors.is_empty() {
-                input.deferred_opaque_type_errors = apply_computed_concrete_opaque_types(
+                input.deferred_opaque_type_errors = apply_hidden_types(
                     &input.infcx,
                     &input.body_owned,
                     &input.universal_region_relations.universal_regions,
                     &input.region_bound_pairs,
                     &input.known_type_outlives_obligations,
                     &mut input.constraints,
-                    &mut self.concrete_opaque_types,
+                    &mut self.hidden_types,
                     &opaque_types,
                 );
             }

--- a/compiler/rustc_hir_analysis/src/check/check.rs
+++ b/compiler/rustc_hir_analysis/src/check/check.rs
@@ -219,7 +219,7 @@ fn check_opaque(tcx: TyCtxt<'_>, def_id: LocalDefId) {
 
     // HACK(jynelson): trying to infer the type of `impl trait` breaks documenting
     // `async-std` (and `pub async fn` in general).
-    // Since rustdoc doesn't care about the concrete type behind `impl Trait`, just don't look at it!
+    // Since rustdoc doesn't care about the hidden type behind `impl Trait`, just don't look at it!
     // See https://github.com/rust-lang/rust/issues/75100
     if tcx.sess.opts.actually_rustdoc {
         return;
@@ -252,7 +252,7 @@ pub(super) fn check_opaque_for_cycles<'tcx>(
     Ok(())
 }
 
-/// Check that the concrete type behind `impl Trait` actually implements `Trait`.
+/// Check that the hidden type behind `impl Trait` actually implements `Trait`.
 ///
 /// This is mostly checked at the places that specify the opaque type, but we
 /// check those cases in the `param_env` of that function, which may have

--- a/compiler/rustc_hir_typeck/src/opaque_types.rs
+++ b/compiler/rustc_hir_typeck/src/opaque_types.rs
@@ -15,7 +15,7 @@ use crate::FnCtxt;
 
 impl<'tcx> FnCtxt<'_, 'tcx> {
     /// This takes all the opaque type uses during HIR typeck. It first computes
-    /// the concrete hidden type by iterating over all defining uses.
+    /// the hidden type by iterating over all defining uses.
     ///
     /// A use during HIR typeck is defining if all non-lifetime arguments are
     /// unique generic parameters and the hidden type does not reference any
@@ -35,8 +35,8 @@ impl<'tcx> FnCtxt<'_, 'tcx> {
         }
         debug!(?opaque_types);
 
-        self.compute_concrete_opaque_types(&opaque_types);
-        self.apply_computed_concrete_opaque_types(&opaque_types);
+        self.compute_hidden_types(&opaque_types);
+        self.apply_hidden_types(&opaque_types);
     }
 }
 
@@ -71,7 +71,7 @@ impl<'tcx> UsageKind<'tcx> {
 }
 
 impl<'tcx> FnCtxt<'_, 'tcx> {
-    fn compute_concrete_opaque_types(
+    fn compute_hidden_types(
         &mut self,
         opaque_types: &[(OpaqueTypeKey<'tcx>, OpaqueHiddenType<'tcx>)],
     ) {
@@ -142,7 +142,7 @@ impl<'tcx> FnCtxt<'_, 'tcx> {
 
             self.typeck_results
                 .borrow_mut()
-                .concrete_opaque_types
+                .hidden_types
                 .insert(def_id, OpaqueHiddenType::new_error(tcx, guar));
             self.set_tainted_by_errors(guar);
         }
@@ -161,7 +161,7 @@ impl<'tcx> FnCtxt<'_, 'tcx> {
         ) {
             match err {
                 NonDefiningUseReason::Tainted(guar) => {
-                    self.typeck_results.borrow_mut().concrete_opaque_types.insert(
+                    self.typeck_results.borrow_mut().hidden_types.insert(
                         opaque_type_key.def_id,
                         OpaqueHiddenType::new_error(self.tcx, guar),
                     );
@@ -197,20 +197,19 @@ impl<'tcx> FnCtxt<'_, 'tcx> {
         let prev = self
             .typeck_results
             .borrow_mut()
-            .concrete_opaque_types
+            .hidden_types
             .insert(opaque_type_key.def_id, hidden_type);
         assert!(prev.is_none());
         UsageKind::HasDefiningUse
     }
 
-    fn apply_computed_concrete_opaque_types(
+    fn apply_hidden_types(
         &mut self,
         opaque_types: &[(OpaqueTypeKey<'tcx>, OpaqueHiddenType<'tcx>)],
     ) {
         let tcx = self.tcx;
         for &(key, hidden_type) in opaque_types {
-            let expected =
-                *self.typeck_results.borrow_mut().concrete_opaque_types.get(&key.def_id).unwrap();
+            let expected = *self.typeck_results.borrow_mut().hidden_types.get(&key.def_id).unwrap();
 
             let expected = EarlyBinder::bind(expected.ty).instantiate(tcx, key.args);
             self.demand_eqtype(hidden_type.span, expected, hidden_type.ty);

--- a/compiler/rustc_hir_typeck/src/opaque_types.rs
+++ b/compiler/rustc_hir_typeck/src/opaque_types.rs
@@ -35,8 +35,8 @@ impl<'tcx> FnCtxt<'_, 'tcx> {
         }
         debug!(?opaque_types);
 
-        self.compute_hidden_types(&opaque_types);
-        self.apply_hidden_types(&opaque_types);
+        self.compute_definition_site_hidden_types(&opaque_types);
+        self.apply_definition_site_hidden_types(&opaque_types);
     }
 }
 
@@ -71,7 +71,7 @@ impl<'tcx> UsageKind<'tcx> {
 }
 
 impl<'tcx> FnCtxt<'_, 'tcx> {
-    fn compute_hidden_types(
+    fn compute_definition_site_hidden_types(
         &mut self,
         opaque_types: &[(OpaqueTypeKey<'tcx>, OpaqueHiddenType<'tcx>)],
     ) {
@@ -203,7 +203,7 @@ impl<'tcx> FnCtxt<'_, 'tcx> {
         UsageKind::HasDefiningUse
     }
 
-    fn apply_hidden_types(
+    fn apply_definition_site_hidden_types(
         &mut self,
         opaque_types: &[(OpaqueTypeKey<'tcx>, OpaqueHiddenType<'tcx>)],
     ) {

--- a/compiler/rustc_middle/src/arena.rs
+++ b/compiler/rustc_middle/src/arena.rs
@@ -27,7 +27,7 @@ macro_rules! arena_types {
                     rustc_middle::mir::Body<'tcx>
                 >,
             [decode] typeck_results: rustc_middle::ty::TypeckResults<'tcx>,
-            [decode] borrowck_result: rustc_middle::mir::ConcreteOpaqueTypes<'tcx>,
+            [decode] borrowck_result: rustc_middle::mir::HiddenTypes<'tcx>,
             [] resolver: rustc_data_structures::steal::Steal<(
                 rustc_middle::ty::ResolverAstLowering,
                 std::sync::Arc<rustc_ast::Crate>,

--- a/compiler/rustc_middle/src/arena.rs
+++ b/compiler/rustc_middle/src/arena.rs
@@ -27,7 +27,7 @@ macro_rules! arena_types {
                     rustc_middle::mir::Body<'tcx>
                 >,
             [decode] typeck_results: rustc_middle::ty::TypeckResults<'tcx>,
-            [decode] borrowck_result: rustc_middle::mir::HiddenTypes<'tcx>,
+            [decode] borrowck_result: rustc_middle::mir::DefinitionSiteHiddenTypes<'tcx>,
             [] resolver: rustc_data_structures::steal::Steal<(
                 rustc_middle::ty::ResolverAstLowering,
                 std::sync::Arc<rustc_ast::Crate>,

--- a/compiler/rustc_middle/src/mir/query.rs
+++ b/compiler/rustc_middle/src/mir/query.rs
@@ -84,11 +84,10 @@ impl Debug for CoroutineLayout<'_> {
     }
 }
 
-/// All the opaque types that are restricted to concrete types
-/// by this function. Unlike the value in `TypeckResults`, this has
-/// unerased regions.
+/// All the opaque types that have had their hidden type fully computed.
+/// Unlike the value in `TypeckResults`, this has unerased regions.
 #[derive(Default, Debug, TyEncodable, TyDecodable, HashStable)]
-pub struct ConcreteOpaqueTypes<'tcx>(pub FxIndexMap<LocalDefId, OpaqueHiddenType<'tcx>>);
+pub struct HiddenTypes<'tcx>(pub FxIndexMap<LocalDefId, OpaqueHiddenType<'tcx>>);
 
 /// The result of the `mir_const_qualif` query.
 ///

--- a/compiler/rustc_middle/src/mir/query.rs
+++ b/compiler/rustc_middle/src/mir/query.rs
@@ -87,7 +87,7 @@ impl Debug for CoroutineLayout<'_> {
 /// All the opaque types that have had their hidden type fully computed.
 /// Unlike the value in `TypeckResults`, this has unerased regions.
 #[derive(Default, Debug, TyEncodable, TyDecodable, HashStable)]
-pub struct HiddenTypes<'tcx>(pub FxIndexMap<LocalDefId, OpaqueHiddenType<'tcx>>);
+pub struct DefinitionSiteHiddenTypes<'tcx>(pub FxIndexMap<LocalDefId, OpaqueHiddenType<'tcx>>);
 
 /// The result of the `mir_const_qualif` query.
 ///

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -1244,7 +1244,7 @@ rustc_queries! {
 
     /// Borrow-checks the given typeck root, e.g. functions, const/static items,
     /// and its children, e.g. closures, inline consts.
-    query mir_borrowck(key: LocalDefId) -> Result<&'tcx mir::ConcreteOpaqueTypes<'tcx>, ErrorGuaranteed> {
+    query mir_borrowck(key: LocalDefId) -> Result<&'tcx mir::HiddenTypes<'tcx>, ErrorGuaranteed> {
         desc { |tcx| "borrow-checking `{}`", tcx.def_path_str(key) }
     }
 

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -1244,7 +1244,7 @@ rustc_queries! {
 
     /// Borrow-checks the given typeck root, e.g. functions, const/static items,
     /// and its children, e.g. closures, inline consts.
-    query mir_borrowck(key: LocalDefId) -> Result<&'tcx mir::HiddenTypes<'tcx>, ErrorGuaranteed> {
+    query mir_borrowck(key: LocalDefId) -> Result<&'tcx mir::DefinitionSiteHiddenTypes<'tcx>, ErrorGuaranteed> {
         desc { |tcx| "borrow-checking `{}`", tcx.def_path_str(key) }
     }
 

--- a/compiler/rustc_middle/src/ty/typeck_results.rs
+++ b/compiler/rustc_middle/src/ty/typeck_results.rs
@@ -167,7 +167,7 @@ pub struct TypeckResults<'tcx> {
     /// We also store the type here, so that the compiler can use it as a hint
     /// for figuring out hidden types, even if they are only set in dead code
     /// (which doesn't show up in MIR).
-    pub concrete_opaque_types: FxIndexMap<LocalDefId, ty::OpaqueHiddenType<'tcx>>,
+    pub hidden_types: FxIndexMap<LocalDefId, ty::OpaqueHiddenType<'tcx>>,
 
     /// Tracks the minimum captures required for a closure;
     /// see `MinCaptureInformationMap` for more details.
@@ -250,7 +250,7 @@ impl<'tcx> TypeckResults<'tcx> {
             coercion_casts: Default::default(),
             used_trait_imports: Default::default(),
             tainted_by_errors: None,
-            concrete_opaque_types: Default::default(),
+            hidden_types: Default::default(),
             closure_min_captures: Default::default(),
             closure_fake_reads: Default::default(),
             rvalue_scopes: Default::default(),

--- a/compiler/rustc_pattern_analysis/src/rustc.rs
+++ b/compiler/rustc_pattern_analysis/src/rustc.rs
@@ -120,7 +120,7 @@ impl<'p, 'tcx: 'p> fmt::Debug for RustcPatCtxt<'p, 'tcx> {
 impl<'p, 'tcx: 'p> RustcPatCtxt<'p, 'tcx> {
     /// Type inference occasionally gives us opaque types in places where corresponding patterns
     /// have more specific types. To avoid inconsistencies as well as detect opaque uninhabited
-    /// types, we use the corresponding concrete type if possible.
+    /// types, we use the corresponding hidden type if possible.
     // FIXME(#132279): This will be unnecessary once we have a TypingMode which supports revealing
     // opaque types defined in a body.
     #[inline]
@@ -146,7 +146,7 @@ impl<'p, 'tcx: 'p> RustcPatCtxt<'p, 'tcx> {
     /// know it.
     fn reveal_opaque_key(&self, key: OpaqueTypeKey<'tcx>) -> Option<Ty<'tcx>> {
         self.typeck_results
-            .concrete_opaque_types
+            .hidden_types
             .get(&key.def_id)
             .map(|x| ty::EarlyBinder::bind(x.ty).instantiate(self.tcx, key.args))
     }

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -2359,7 +2359,7 @@ impl<'tcx> SelectionContext<'_, 'tcx> {
                 if self.infcx.can_define_opaque_ty(def_id) {
                     unreachable!()
                 } else {
-                    // We can resolve the `impl Trait` to its concrete type,
+                    // We can resolve the opaque type to its hidden type,
                     // which enforces a DAG between the functions requiring
                     // the auto trait bounds in question.
                     match self.tcx().type_of_opaque(def_id) {

--- a/compiler/rustc_type_ir/src/infer_ctxt.rs
+++ b/compiler/rustc_type_ir/src/infer_ctxt.rs
@@ -80,7 +80,7 @@ pub enum TypingMode<I: Interner> {
     /// the old solver as well.
     PostBorrowckAnalysis { defined_opaque_types: I::LocalDefIds },
     /// After analysis, mostly during codegen and MIR optimizations, we're able to
-    /// reveal all opaque types. As the concrete type should *never* be observable
+    /// reveal all opaque types. As the hidden type should *never* be observable
     /// directly by the user, this should not be used by checks which may expose
     /// such details to the user.
     ///

--- a/tests/ui/async-await/async-closures/without-precise-captures-we-are-powerless.rs
+++ b/tests/ui/async-await/async-closures/without-precise-captures-we-are-powerless.rs
@@ -44,4 +44,18 @@ fn through_field_and_ref_move<'a>(x: &S<'a>) {
     outlives::<'a>(call_once(c)); //~ ERROR explicit lifetime required in the type of `x`
 }
 
+struct T;
+impl T {
+    fn outlives<'a>(&'a self, _: impl Sized + 'a) {}
+}
+fn through_method<'a>(x: &'a i32) {
+    let c = async || { println!("{}", *x); }; //~ ERROR `x` does not live long enough
+    T.outlives::<'a>(c());
+    T.outlives::<'a>(call_once(c));
+
+    let c = async move || { println!("{}", *x); };
+    T.outlives::<'a>(c()); //~ ERROR `c` does not live long enough
+    T.outlives::<'a>(call_once(c));
+}
+
 fn main() {}

--- a/tests/ui/async-await/async-closures/without-precise-captures-we-are-powerless.stderr
+++ b/tests/ui/async-await/async-closures/without-precise-captures-we-are-powerless.stderr
@@ -28,6 +28,12 @@ LL |     outlives::<'a>(c());
 LL |     outlives::<'a>(call_once(c));
 LL | }
    | - `c` dropped here while still borrowed
+   |
+note: requirement that `c` is borrowed for `'a` introduced here
+  --> $DIR/without-precise-captures-we-are-powerless.rs:7:33
+   |
+LL | fn outlives<'a>(_: impl Sized + 'a) {}
+   |                                 ^^
 
 error[E0597]: `x` does not live long enough
   --> $DIR/without-precise-captures-we-are-powerless.rs:26:13
@@ -73,6 +79,12 @@ LL |     outlives::<'a>(c());
 LL |     outlives::<'a>(call_once(c));
 LL | }
    | - `c` dropped here while still borrowed
+   |
+note: requirement that `c` is borrowed for `'a` introduced here
+  --> $DIR/without-precise-captures-we-are-powerless.rs:7:33
+   |
+LL | fn outlives<'a>(_: impl Sized + 'a) {}
+   |                                 ^^
 
 error[E0505]: cannot move out of `c` because it is borrowed
   --> $DIR/without-precise-captures-we-are-powerless.rs:32:30
@@ -129,6 +141,12 @@ LL |     outlives::<'a>(c());
 LL |     outlives::<'a>(call_once(c));
 LL | }
    | - `c` dropped here while still borrowed
+   |
+note: requirement that `c` is borrowed for `'a` introduced here
+  --> $DIR/without-precise-captures-we-are-powerless.rs:7:33
+   |
+LL | fn outlives<'a>(_: impl Sized + 'a) {}
+   |                                 ^^
 
 error[E0621]: explicit lifetime required in the type of `x`
   --> $DIR/without-precise-captures-we-are-powerless.rs:44:5
@@ -141,7 +159,44 @@ help: add explicit lifetime `'a` to the type of `x`
 LL | fn through_field_and_ref_move<'a>(x: &'a S<'a>) {
    |                                       ++
 
-error: aborting due to 10 previous errors
+error[E0597]: `x` does not live long enough
+  --> $DIR/without-precise-captures-we-are-powerless.rs:52:13
+   |
+LL | fn through_method<'a>(x: &'a i32) {
+   |                   -- lifetime `'a` defined here
+LL |     let c = async || { println!("{}", *x); };
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ borrowed value does not live long enough
+LL |     T.outlives::<'a>(c());
+LL |     T.outlives::<'a>(call_once(c));
+   |     ------------------------------ argument requires that `x` is borrowed for `'a`
+...
+LL | }
+   |  - `x` dropped here while still borrowed
+
+error[E0597]: `c` does not live long enough
+  --> $DIR/without-precise-captures-we-are-powerless.rs:57:22
+   |
+LL | fn through_method<'a>(x: &'a i32) {
+   |                   -- lifetime `'a` defined here
+...
+LL |     let c = async move || { println!("{}", *x); };
+   |         - binding `c` declared here
+LL |     T.outlives::<'a>(c());
+   |     -----------------^---
+   |     |                |
+   |     |                borrowed value does not live long enough
+   |     argument requires that `c` is borrowed for `'a`
+LL |     T.outlives::<'a>(call_once(c));
+LL | }
+   | - `c` dropped here while still borrowed
+   |
+note: requirement that `c` is borrowed for `'a` introduced here
+  --> $DIR/without-precise-captures-we-are-powerless.rs:49:47
+   |
+LL |     fn outlives<'a>(&'a self, _: impl Sized + 'a) {}
+   |                                               ^^
+
+error: aborting due to 12 previous errors
 
 Some errors have detailed explanations: E0505, E0597, E0621.
 For more information about an error, try `rustc --explain E0505`.

--- a/tests/ui/async-await/async-closures/without-precise-captures-we-are-powerless.stderr
+++ b/tests/ui/async-await/async-closures/without-precise-captures-we-are-powerless.stderr
@@ -29,7 +29,7 @@ LL |     outlives::<'a>(call_once(c));
 LL | }
    | - `c` dropped here while still borrowed
    |
-note: requirement for `'a` introduced here
+note: requirement that the value outlives `'a` introduced here
   --> $DIR/without-precise-captures-we-are-powerless.rs:7:33
    |
 LL | fn outlives<'a>(_: impl Sized + 'a) {}
@@ -80,7 +80,7 @@ LL |     outlives::<'a>(call_once(c));
 LL | }
    | - `c` dropped here while still borrowed
    |
-note: requirement for `'a` introduced here
+note: requirement that the value outlives `'a` introduced here
   --> $DIR/without-precise-captures-we-are-powerless.rs:7:33
    |
 LL | fn outlives<'a>(_: impl Sized + 'a) {}
@@ -102,7 +102,7 @@ LL |     outlives::<'a>(c());
 LL |     outlives::<'a>(call_once(c));
    |                              ^ move out of `c` occurs here
    |
-note: requirement for `'a` introduced here
+note: requirement that the value outlives `'a` introduced here
   --> $DIR/without-precise-captures-we-are-powerless.rs:7:33
    |
 LL | fn outlives<'a>(_: impl Sized + 'a) {}
@@ -148,7 +148,7 @@ LL |     outlives::<'a>(call_once(c));
 LL | }
    | - `c` dropped here while still borrowed
    |
-note: requirement for `'a` introduced here
+note: requirement that the value outlives `'a` introduced here
   --> $DIR/without-precise-captures-we-are-powerless.rs:7:33
    |
 LL | fn outlives<'a>(_: impl Sized + 'a) {}
@@ -196,7 +196,7 @@ LL |     T.outlives::<'a>(call_once(c));
 LL | }
    | - `c` dropped here while still borrowed
    |
-note: requirement for `'a` introduced here
+note: requirement that the value outlives `'a` introduced here
   --> $DIR/without-precise-captures-we-are-powerless.rs:49:47
    |
 LL |     fn outlives<'a>(&'a self, _: impl Sized + 'a) {}

--- a/tests/ui/async-await/async-closures/without-precise-captures-we-are-powerless.stderr
+++ b/tests/ui/async-await/async-closures/without-precise-captures-we-are-powerless.stderr
@@ -29,7 +29,7 @@ LL |     outlives::<'a>(call_once(c));
 LL | }
    | - `c` dropped here while still borrowed
    |
-note: requirement that `c` is borrowed for `'a` introduced here
+note: requirement for `'a` introduced here
   --> $DIR/without-precise-captures-we-are-powerless.rs:7:33
    |
 LL | fn outlives<'a>(_: impl Sized + 'a) {}
@@ -80,7 +80,7 @@ LL |     outlives::<'a>(call_once(c));
 LL | }
    | - `c` dropped here while still borrowed
    |
-note: requirement that `c` is borrowed for `'a` introduced here
+note: requirement for `'a` introduced here
   --> $DIR/without-precise-captures-we-are-powerless.rs:7:33
    |
 LL | fn outlives<'a>(_: impl Sized + 'a) {}
@@ -101,6 +101,12 @@ LL |     outlives::<'a>(c());
    |     argument requires that `c` is borrowed for `'a`
 LL |     outlives::<'a>(call_once(c));
    |                              ^ move out of `c` occurs here
+   |
+note: requirement for `'a` introduced here
+  --> $DIR/without-precise-captures-we-are-powerless.rs:7:33
+   |
+LL | fn outlives<'a>(_: impl Sized + 'a) {}
+   |                                 ^^
 
 error[E0597]: `x` does not live long enough
   --> $DIR/without-precise-captures-we-are-powerless.rs:36:13
@@ -142,7 +148,7 @@ LL |     outlives::<'a>(call_once(c));
 LL | }
    | - `c` dropped here while still borrowed
    |
-note: requirement that `c` is borrowed for `'a` introduced here
+note: requirement for `'a` introduced here
   --> $DIR/without-precise-captures-we-are-powerless.rs:7:33
    |
 LL | fn outlives<'a>(_: impl Sized + 'a) {}
@@ -190,7 +196,7 @@ LL |     T.outlives::<'a>(call_once(c));
 LL | }
    | - `c` dropped here while still borrowed
    |
-note: requirement that `c` is borrowed for `'a` introduced here
+note: requirement for `'a` introduced here
   --> $DIR/without-precise-captures-we-are-powerless.rs:49:47
    |
 LL |     fn outlives<'a>(&'a self, _: impl Sized + 'a) {}

--- a/tests/ui/borrowck/fn-item-check-type-params.stderr
+++ b/tests/ui/borrowck/fn-item-check-type-params.stderr
@@ -28,7 +28,7 @@ LL |     want(&String::new(), extend_lt);
    |     |     creates a temporary value which is freed while still in use
    |     argument requires that borrow lasts for `'static`
    |
-note: requirement for `'static` introduced here
+note: requirement that the value outlives `'static` introduced here
   --> $DIR/fn-item-check-type-params.rs:47:33
    |
 LL |     fn want<I, O>(_: I, _: impl Fn(I) -> O) {}
@@ -43,7 +43,7 @@ LL |     let val = extend_lt(&String::from("blah blah blah"));
    |               |          creates a temporary value which is freed while still in use
    |               argument requires that borrow lasts for `'static`
    |
-note: requirement for `'static` introduced here
+note: requirement that the value outlives `'static` introduced here
   --> $DIR/fn-item-check-type-params.rs:22:21
    |
 LL |     (T, Option<U>): Displayable,

--- a/tests/ui/borrowck/fn-item-check-type-params.stderr
+++ b/tests/ui/borrowck/fn-item-check-type-params.stderr
@@ -27,6 +27,12 @@ LL |     want(&String::new(), extend_lt);
    |     |     |
    |     |     creates a temporary value which is freed while still in use
    |     argument requires that borrow lasts for `'static`
+   |
+note: requirement for `'static` introduced here
+  --> $DIR/fn-item-check-type-params.rs:47:33
+   |
+LL |     fn want<I, O>(_: I, _: impl Fn(I) -> O) {}
+   |                                 ^^^^^^^^^^
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/fn-item-check-type-params.rs:54:26
@@ -36,6 +42,12 @@ LL |     let val = extend_lt(&String::from("blah blah blah"));
    |               |          |
    |               |          creates a temporary value which is freed while still in use
    |               argument requires that borrow lasts for `'static`
+   |
+note: requirement for `'static` introduced here
+  --> $DIR/fn-item-check-type-params.rs:22:21
+   |
+LL |     (T, Option<U>): Displayable,
+   |                     ^^^^^^^^^^^
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/borrowck/implementation-not-general-enough-ice-133252.stderr
+++ b/tests/ui/borrowck/implementation-not-general-enough-ice-133252.stderr
@@ -23,7 +23,7 @@ LL |         force_send(async_load(&not_static));
 LL |     }
    |     - `not_static` dropped here while still borrowed
    |
-note: requirement that `not_static` is borrowed for `'1` introduced here
+note: requirement for `'1` introduced here
   --> $DIR/implementation-not-general-enough-ice-133252.rs:16:18
    |
 LL | fn force_send<T: Send>(_: T) {}

--- a/tests/ui/borrowck/implementation-not-general-enough-ice-133252.stderr
+++ b/tests/ui/borrowck/implementation-not-general-enough-ice-133252.stderr
@@ -22,6 +22,12 @@ LL |         force_send(async_load(&not_static));
 ...
 LL |     }
    |     - `not_static` dropped here while still borrowed
+   |
+note: requirement that `not_static` is borrowed for `'1` introduced here
+  --> $DIR/implementation-not-general-enough-ice-133252.rs:16:18
+   |
+LL | fn force_send<T: Send>(_: T) {}
+   |                  ^^^^
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/borrowck/implementation-not-general-enough-ice-133252.stderr
+++ b/tests/ui/borrowck/implementation-not-general-enough-ice-133252.stderr
@@ -23,7 +23,7 @@ LL |         force_send(async_load(&not_static));
 LL |     }
    |     - `not_static` dropped here while still borrowed
    |
-note: requirement for `'1` introduced here
+note: requirement that the value outlives `'1` introduced here
   --> $DIR/implementation-not-general-enough-ice-133252.rs:16:18
    |
 LL | fn force_send<T: Send>(_: T) {}

--- a/tests/ui/borrowck/issue-17545.stderr
+++ b/tests/ui/borrowck/issue-17545.stderr
@@ -10,6 +10,9 @@ LL | |     ));
    | |      -- temporary value is freed at the end of this statement
    | |______|
    |        argument requires that borrow lasts for `'a`
+   |
+note: requirement for `'a` introduced here
+  --> $SRC_DIR/core/src/ops/function.rs:LL:COL
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/borrowck/issue-17545.stderr
+++ b/tests/ui/borrowck/issue-17545.stderr
@@ -11,7 +11,7 @@ LL | |     ));
    | |______|
    |        argument requires that borrow lasts for `'a`
    |
-note: requirement for `'a` introduced here
+note: requirement that the value outlives `'a` introduced here
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
 
 error: aborting due to 1 previous error

--- a/tests/ui/errors/span-format_args-issue-140578.rs
+++ b/tests/ui/errors/span-format_args-issue-140578.rs
@@ -1,0 +1,31 @@
+fn check_format_args() {
+  print!("{:?} {a} {a:?}", [], a = 1 + 1);
+  //~^ ERROR type annotations needed
+}
+
+fn check_format_args_nl() {
+  println!("{:?} {a} {a:?}", [], a = 1 + 1);
+  //~^ ERROR type annotations needed
+}
+
+fn check_multi1() {
+  println!("{:?} {:?} {a} {a:?}", [], [], a = 1 + 1);
+  //~^ ERROR type annotations needed
+}
+
+fn check_multi2() {
+  println!("{:?} {:?} {a} {a:?} {b:?}", [], [], a = 1 + 1, b = []);
+  //~^ ERROR type annotations needed
+}
+
+fn check_unformatted() {
+  println!(" //~ ERROR type annotations needed
+  {:?} {:?}
+{a}
+{a:?}",
+        [],
+ [],
+a = 1 + 1);
+}
+
+fn main() {}

--- a/tests/ui/errors/span-format_args-issue-140578.rs
+++ b/tests/ui/errors/span-format_args-issue-140578.rs
@@ -19,11 +19,12 @@ fn check_multi2() {
 }
 
 fn check_unformatted() {
-  println!(" //~ ERROR type annotations needed
+  println!("
   {:?} {:?}
 {a}
 {a:?}",
         [],
+        //~^ ERROR type annotations needed
  [],
 a = 1 + 1);
 }

--- a/tests/ui/errors/span-format_args-issue-140578.stderr
+++ b/tests/ui/errors/span-format_args-issue-140578.stderr
@@ -1,0 +1,49 @@
+error[E0282]: type annotations needed
+  --> $DIR/span-format_args-issue-140578.rs:2:3
+   |
+LL |   print!("{:?} {a} {a:?}", [], a = 1 + 1);
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type
+   |
+   = note: this error originates in the macro `print` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0282]: type annotations needed
+  --> $DIR/span-format_args-issue-140578.rs:7:3
+   |
+LL |   println!("{:?} {a} {a:?}", [], a = 1 + 1);
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type
+   |
+   = note: this error originates in the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0282]: type annotations needed
+  --> $DIR/span-format_args-issue-140578.rs:12:3
+   |
+LL |   println!("{:?} {:?} {a} {a:?}", [], [], a = 1 + 1);
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type
+   |
+   = note: this error originates in the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0282]: type annotations needed
+  --> $DIR/span-format_args-issue-140578.rs:17:3
+   |
+LL |   println!("{:?} {:?} {a} {a:?} {b:?}", [], [], a = 1 + 1, b = []);
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type
+   |
+   = note: this error originates in the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0282]: type annotations needed
+  --> $DIR/span-format_args-issue-140578.rs:22:3
+   |
+LL | /   println!("
+LL | |   {:?} {:?}
+LL | | {a}
+LL | | {a:?}",
+LL | |         [],
+LL | |  [],
+LL | | a = 1 + 1);
+   | |__________^ cannot infer type
+   |
+   = note: this error originates in the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 5 previous errors
+
+For more information about this error, try `rustc --explain E0282`.

--- a/tests/ui/errors/span-format_args-issue-140578.stderr
+++ b/tests/ui/errors/span-format_args-issue-140578.stderr
@@ -1,48 +1,42 @@
 error[E0282]: type annotations needed
-  --> $DIR/span-format_args-issue-140578.rs:2:3
+  --> $DIR/span-format_args-issue-140578.rs:2:28
    |
 LL |   print!("{:?} {a} {a:?}", [], a = 1 + 1);
-   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type
+   |                            ^^ cannot infer type
    |
-   = note: this error originates in the macro `print` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::format_args` which comes from the expansion of the macro `print` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0282]: type annotations needed
-  --> $DIR/span-format_args-issue-140578.rs:7:3
+  --> $DIR/span-format_args-issue-140578.rs:7:30
    |
 LL |   println!("{:?} {a} {a:?}", [], a = 1 + 1);
-   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type
+   |                              ^^ cannot infer type
    |
-   = note: this error originates in the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0282]: type annotations needed
-  --> $DIR/span-format_args-issue-140578.rs:12:3
+  --> $DIR/span-format_args-issue-140578.rs:12:35
    |
 LL |   println!("{:?} {:?} {a} {a:?}", [], [], a = 1 + 1);
-   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type
+   |                                   ^^ cannot infer type
    |
-   = note: this error originates in the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0282]: type annotations needed
-  --> $DIR/span-format_args-issue-140578.rs:17:3
+  --> $DIR/span-format_args-issue-140578.rs:17:41
    |
 LL |   println!("{:?} {:?} {a} {a:?} {b:?}", [], [], a = 1 + 1, b = []);
-   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type
+   |                                         ^^ cannot infer type
    |
-   = note: this error originates in the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0282]: type annotations needed
-  --> $DIR/span-format_args-issue-140578.rs:22:3
+  --> $DIR/span-format_args-issue-140578.rs:26:9
    |
-LL | /   println!("
-LL | |   {:?} {:?}
-LL | | {a}
-LL | | {a:?}",
-LL | |         [],
-LL | |  [],
-LL | | a = 1 + 1);
-   | |__________^ cannot infer type
+LL |         [],
+   |         ^^ cannot infer type
    |
-   = note: this error originates in the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/generic-associated-types/bugs/hrtb-implied-1.stderr
+++ b/tests/ui/generic-associated-types/bugs/hrtb-implied-1.stderr
@@ -14,7 +14,7 @@ note: due to a current limitation of the type system, this implies a `'static` l
    |
 LL |     for<'a> I::Item<'a>: Debug,
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: requirement for `'static` introduced here
+note: requirement that the value outlives `'static` introduced here
   --> $DIR/hrtb-implied-1.rs:26:26
    |
 LL |     for<'a> I::Item<'a>: Debug,

--- a/tests/ui/generic-associated-types/bugs/hrtb-implied-1.stderr
+++ b/tests/ui/generic-associated-types/bugs/hrtb-implied-1.stderr
@@ -14,6 +14,11 @@ note: due to a current limitation of the type system, this implies a `'static` l
    |
 LL |     for<'a> I::Item<'a>: Debug,
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: requirement for `'static` introduced here
+  --> $DIR/hrtb-implied-1.rs:26:26
+   |
+LL |     for<'a> I::Item<'a>: Debug,
+   |                          ^^^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/impl-trait/precise-capturing/migration-note.rs
+++ b/tests/ui/impl-trait/precise-capturing/migration-note.rs
@@ -32,6 +32,7 @@ fn needs_static() {
     //~| NOTE borrowed value does not live long enoug
 
     fn needs_static(_: impl Sized + 'static) {}
+    //~^ NOTE requirement that `x` is borrowed for `'static` introduced here
     needs_static(a);
     //~^ NOTE argument requires that `x` is borrowed for `'static`
 }
@@ -79,6 +80,7 @@ fn needs_static_mut() {
     //~| NOTE borrowed value does not live long enough
 
     fn needs_static(_: impl Sized + 'static) {}
+    //~^ NOTE requirement that `x` is borrowed for `'static` introduced here
     needs_static(a);
     //~^ NOTE argument requires that `x` is borrowed for `'static`
 }

--- a/tests/ui/impl-trait/precise-capturing/migration-note.rs
+++ b/tests/ui/impl-trait/precise-capturing/migration-note.rs
@@ -32,7 +32,7 @@ fn needs_static() {
     //~| NOTE borrowed value does not live long enoug
 
     fn needs_static(_: impl Sized + 'static) {}
-    //~^ NOTE requirement that `x` is borrowed for `'static` introduced here
+    //~^ NOTE requirement for `'static` introduced here
     needs_static(a);
     //~^ NOTE argument requires that `x` is borrowed for `'static`
 }
@@ -80,7 +80,7 @@ fn needs_static_mut() {
     //~| NOTE borrowed value does not live long enough
 
     fn needs_static(_: impl Sized + 'static) {}
-    //~^ NOTE requirement that `x` is borrowed for `'static` introduced here
+    //~^ NOTE requirement for `'static` introduced here
     needs_static(a);
     //~^ NOTE argument requires that `x` is borrowed for `'static`
 }

--- a/tests/ui/impl-trait/precise-capturing/migration-note.rs
+++ b/tests/ui/impl-trait/precise-capturing/migration-note.rs
@@ -32,7 +32,7 @@ fn needs_static() {
     //~| NOTE borrowed value does not live long enoug
 
     fn needs_static(_: impl Sized + 'static) {}
-    //~^ NOTE requirement for `'static` introduced here
+    //~^ NOTE requirement that the value outlives `'static` introduced here
     needs_static(a);
     //~^ NOTE argument requires that `x` is borrowed for `'static`
 }
@@ -80,7 +80,7 @@ fn needs_static_mut() {
     //~| NOTE borrowed value does not live long enough
 
     fn needs_static(_: impl Sized + 'static) {}
-    //~^ NOTE requirement for `'static` introduced here
+    //~^ NOTE requirement that the value outlives `'static` introduced here
     needs_static(a);
     //~^ NOTE argument requires that `x` is borrowed for `'static`
 }

--- a/tests/ui/impl-trait/precise-capturing/migration-note.stderr
+++ b/tests/ui/impl-trait/precise-capturing/migration-note.stderr
@@ -50,7 +50,7 @@ LL |
 LL | }
    | - `x` dropped here while still borrowed
    |
-note: requirement for `'static` introduced here
+note: requirement that the value outlives `'static` introduced here
   --> $DIR/migration-note.rs:34:37
    |
 LL |     fn needs_static(_: impl Sized + 'static) {}
@@ -131,7 +131,7 @@ LL |
 LL | }
    | - `x` dropped here while still borrowed
    |
-note: requirement for `'static` introduced here
+note: requirement that the value outlives `'static` introduced here
   --> $DIR/migration-note.rs:82:37
    |
 LL |     fn needs_static(_: impl Sized + 'static) {}

--- a/tests/ui/impl-trait/precise-capturing/migration-note.stderr
+++ b/tests/ui/impl-trait/precise-capturing/migration-note.stderr
@@ -1,5 +1,5 @@
 error[E0597]: `x` does not live long enough
-  --> $DIR/migration-note.rs:182:17
+  --> $DIR/migration-note.rs:184:17
    |
 LL |     let x = vec![0];
    |         - binding `x` declared here
@@ -50,6 +50,11 @@ LL |
 LL | }
    | - `x` dropped here while still borrowed
    |
+note: requirement that `x` is borrowed for `'static` introduced here
+  --> $DIR/migration-note.rs:34:37
+   |
+LL |     fn needs_static(_: impl Sized + 'static) {}
+   |                                     ^^^^^^^
 note: this call may capture more lifetimes than intended, because Rust 2024 has adjusted the `impl Trait` lifetime capture rules
   --> $DIR/migration-note.rs:29:13
    |
@@ -61,7 +66,7 @@ LL | fn display_len<T>(x: &Vec<T>) -> impl Display + use<T> {
    |                                               ++++++++
 
 error[E0505]: cannot move out of `x` because it is borrowed
-  --> $DIR/migration-note.rs:48:8
+  --> $DIR/migration-note.rs:49:8
    |
 LL |     let x = vec![1];
    |         - binding `x` declared here
@@ -76,7 +81,7 @@ LL | }
    | - borrow might be used here, when `a` is dropped and runs the destructor for type `impl std::fmt::Display`
    |
 note: this call may capture more lifetimes than intended, because Rust 2024 has adjusted the `impl Trait` lifetime capture rules
-  --> $DIR/migration-note.rs:43:13
+  --> $DIR/migration-note.rs:44:13
    |
 LL |     let a = display_len(&x);
    |             ^^^^^^^^^^^^^^^
@@ -90,7 +95,7 @@ LL |     let a = display_len(&x.clone());
    |                           ++++++++
 
 error[E0499]: cannot borrow `x` as mutable more than once at a time
-  --> $DIR/migration-note.rs:66:5
+  --> $DIR/migration-note.rs:67:5
    |
 LL |     let a = display_len_mut(&mut x);
    |                             ------ first mutable borrow occurs here
@@ -102,7 +107,7 @@ LL |     println!("{a}");
    |                - first borrow later used here
    |
 note: this call may capture more lifetimes than intended, because Rust 2024 has adjusted the `impl Trait` lifetime capture rules
-  --> $DIR/migration-note.rs:63:13
+  --> $DIR/migration-note.rs:64:13
    |
 LL |     let a = display_len_mut(&mut x);
    |             ^^^^^^^^^^^^^^^^^^^^^^^
@@ -112,7 +117,7 @@ LL | fn display_len_mut<T>(x: &mut Vec<T>) -> impl Display + use<T> {
    |                                                       ++++++++
 
 error[E0597]: `x` does not live long enough
-  --> $DIR/migration-note.rs:76:29
+  --> $DIR/migration-note.rs:77:29
    |
 LL |     let mut x = vec![1];
    |         ----- binding `x` declared here
@@ -126,8 +131,13 @@ LL |
 LL | }
    | - `x` dropped here while still borrowed
    |
+note: requirement that `x` is borrowed for `'static` introduced here
+  --> $DIR/migration-note.rs:82:37
+   |
+LL |     fn needs_static(_: impl Sized + 'static) {}
+   |                                     ^^^^^^^
 note: this call may capture more lifetimes than intended, because Rust 2024 has adjusted the `impl Trait` lifetime capture rules
-  --> $DIR/migration-note.rs:76:13
+  --> $DIR/migration-note.rs:77:13
    |
 LL |     let a = display_len_mut(&mut x);
    |             ^^^^^^^^^^^^^^^^^^^^^^^
@@ -137,7 +147,7 @@ LL | fn display_len_mut<T>(x: &mut Vec<T>) -> impl Display + use<T> {
    |                                                       ++++++++
 
 error[E0505]: cannot move out of `x` because it is borrowed
-  --> $DIR/migration-note.rs:95:8
+  --> $DIR/migration-note.rs:97:8
    |
 LL |     let mut x = vec![1];
    |         ----- binding `x` declared here
@@ -152,7 +162,7 @@ LL | }
    | - borrow might be used here, when `a` is dropped and runs the destructor for type `impl std::fmt::Display`
    |
 note: this call may capture more lifetimes than intended, because Rust 2024 has adjusted the `impl Trait` lifetime capture rules
-  --> $DIR/migration-note.rs:90:13
+  --> $DIR/migration-note.rs:92:13
    |
 LL |     let a = display_len_mut(&mut x);
    |             ^^^^^^^^^^^^^^^^^^^^^^^
@@ -166,7 +176,7 @@ LL |     let a = display_len_mut(&mut x.clone());
    |                                   ++++++++
 
 error[E0506]: cannot assign to `s.f` because it is borrowed
-  --> $DIR/migration-note.rs:115:5
+  --> $DIR/migration-note.rs:117:5
    |
 LL |     let a = display_field(&s.f);
    |                           ---- `s.f` is borrowed here
@@ -178,7 +188,7 @@ LL |     println!("{a}");
    |                - borrow later used here
    |
 note: this call may capture more lifetimes than intended, because Rust 2024 has adjusted the `impl Trait` lifetime capture rules
-  --> $DIR/migration-note.rs:112:13
+  --> $DIR/migration-note.rs:114:13
    |
 LL |     let a = display_field(&s.f);
    |             ^^^^^^^^^^^^^^^^^^^
@@ -188,7 +198,7 @@ LL | fn display_field<T: Copy + Display>(t: &T) -> impl Display + use<T> {
    |                                                            ++++++++
 
 error[E0506]: cannot assign to `s.f` because it is borrowed
-  --> $DIR/migration-note.rs:131:5
+  --> $DIR/migration-note.rs:133:5
    |
 LL |     let a = display_field(&mut s.f);
    |                           -------- `s.f` is borrowed here
@@ -200,7 +210,7 @@ LL |     println!("{a}");
    |                - borrow later used here
    |
 note: this call may capture more lifetimes than intended, because Rust 2024 has adjusted the `impl Trait` lifetime capture rules
-  --> $DIR/migration-note.rs:128:13
+  --> $DIR/migration-note.rs:130:13
    |
 LL |     let a = display_field(&mut s.f);
    |             ^^^^^^^^^^^^^^^^^^^^^^^
@@ -210,7 +220,7 @@ LL | fn display_field<T: Copy + Display>(t: &T) -> impl Display + use<T> {
    |                                                            ++++++++
 
 error[E0503]: cannot use `s.f` because it was mutably borrowed
-  --> $DIR/migration-note.rs:143:5
+  --> $DIR/migration-note.rs:145:5
    |
 LL |     let a = display_field(&mut s.f);
    |                           -------- `s.f` is borrowed here
@@ -222,7 +232,7 @@ LL |     println!("{a}");
    |                - borrow later used here
    |
 note: this call may capture more lifetimes than intended, because Rust 2024 has adjusted the `impl Trait` lifetime capture rules
-  --> $DIR/migration-note.rs:140:13
+  --> $DIR/migration-note.rs:142:13
    |
 LL |     let a = display_field(&mut s.f);
    |             ^^^^^^^^^^^^^^^^^^^^^^^
@@ -232,7 +242,7 @@ LL | fn display_field<T: Copy + Display>(t: &T) -> impl Display + use<T> {
    |                                                            ++++++++
 
 error[E0597]: `z.f` does not live long enough
-  --> $DIR/migration-note.rs:159:25
+  --> $DIR/migration-note.rs:161:25
    |
 LL |         let z = Z { f: vec![1] };
    |             - binding `z` declared here
@@ -248,7 +258,7 @@ LL | }
    |
    = note: values in a scope are dropped in the opposite order they are defined
 note: this call may capture more lifetimes than intended, because Rust 2024 has adjusted the `impl Trait` lifetime capture rules
-  --> $DIR/migration-note.rs:159:13
+  --> $DIR/migration-note.rs:161:13
    |
 LL |         x = display_len(&z.f);
    |             ^^^^^^^^^^^^^^^^^
@@ -258,7 +268,7 @@ LL | fn display_len<T>(x: &Vec<T>) -> impl Display + use<T> {
    |                                               ++++++++
 
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/migration-note.rs:170:40
+  --> $DIR/migration-note.rs:172:40
    |
 LL |     let x = { let x = display_len(&mut vec![0]); x };
    |                                        ^^^^^^^ - - borrow later used here
@@ -268,7 +278,7 @@ LL |     let x = { let x = display_len(&mut vec![0]); x };
    |
    = note: consider using a `let` binding to create a longer lived value
 note: this call may capture more lifetimes than intended, because Rust 2024 has adjusted the `impl Trait` lifetime capture rules
-  --> $DIR/migration-note.rs:170:23
+  --> $DIR/migration-note.rs:172:23
    |
 LL |     let x = { let x = display_len(&mut vec![0]); x };
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -279,7 +289,7 @@ LL | fn display_len<T>(x: &Vec<T>) -> impl Display + use<T> {
    |                                               ++++++++
 
 error[E0505]: cannot move out of `x` because it is borrowed
-  --> $DIR/migration-note.rs:198:10
+  --> $DIR/migration-note.rs:200:10
    |
 LL |     let x = String::new();
    |         - binding `x` declared here
@@ -294,12 +304,12 @@ LL | }
    | - borrow might be used here, when `y` is dropped and runs the destructor for type `impl Sized`
    |
 note: this call may capture more lifetimes than intended, because Rust 2024 has adjusted the `impl Trait` lifetime capture rules
-  --> $DIR/migration-note.rs:195:13
+  --> $DIR/migration-note.rs:197:13
    |
 LL |     let y = capture_apit(&x);
    |             ^^^^^^^^^^^^^^^^
 note: you could use a `use<...>` bound to explicitly specify captures, but argument-position `impl Trait`s are not nameable
-  --> $DIR/migration-note.rs:189:21
+  --> $DIR/migration-note.rs:191:21
    |
 LL | fn capture_apit(x: &impl Sized) -> impl Sized {}
    |                     ^^^^^^^^^^

--- a/tests/ui/impl-trait/precise-capturing/migration-note.stderr
+++ b/tests/ui/impl-trait/precise-capturing/migration-note.stderr
@@ -50,7 +50,7 @@ LL |
 LL | }
    | - `x` dropped here while still borrowed
    |
-note: requirement that `x` is borrowed for `'static` introduced here
+note: requirement for `'static` introduced here
   --> $DIR/migration-note.rs:34:37
    |
 LL |     fn needs_static(_: impl Sized + 'static) {}
@@ -131,7 +131,7 @@ LL |
 LL | }
    | - `x` dropped here while still borrowed
    |
-note: requirement that `x` is borrowed for `'static` introduced here
+note: requirement for `'static` introduced here
   --> $DIR/migration-note.rs:82:37
    |
 LL |     fn needs_static(_: impl Sized + 'static) {}

--- a/tests/ui/inference/need_type_info/issue-107745-avoid-expr-from-macro-expansion.stderr
+++ b/tests/ui/inference/need_type_info/issue-107745-avoid-expr-from-macro-expansion.stderr
@@ -1,10 +1,10 @@
 error[E0282]: type annotations needed
-  --> $DIR/issue-107745-avoid-expr-from-macro-expansion.rs:17:5
+  --> $DIR/issue-107745-avoid-expr-from-macro-expansion.rs:17:22
    |
 LL |     println!("{:?}", []);
-   |     ^^^^^^^^^^^^^^^^^^^^ cannot infer type
+   |                      ^^ cannot infer type
    |
-   = note: this error originates in the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-comparing-against-free.stderr
+++ b/tests/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-comparing-against-free.stderr
@@ -69,6 +69,12 @@ LL |         cell_x.set(cell_a.get()); // forces 'a: 'x, implies 'a = 'static ->
 LL |     })
 LL | }
    | - `a` dropped here while still borrowed
+   |
+note: requirement that `a` is borrowed for `'static` introduced here
+  --> $DIR/propagate-approximated-shorter-to-static-comparing-against-free.rs:13:8
+   |
+LL |     F: for<'x> FnOnce(Cell<&'a u32>, Cell<&'x u32>),
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-comparing-against-free.stderr
+++ b/tests/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-comparing-against-free.stderr
@@ -70,7 +70,7 @@ LL |     })
 LL | }
    | - `a` dropped here while still borrowed
    |
-note: requirement for `'static` introduced here
+note: requirement that the value outlives `'static` introduced here
   --> $DIR/propagate-approximated-shorter-to-static-comparing-against-free.rs:13:8
    |
 LL |     F: for<'x> FnOnce(Cell<&'a u32>, Cell<&'x u32>),

--- a/tests/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-comparing-against-free.stderr
+++ b/tests/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-comparing-against-free.stderr
@@ -70,7 +70,7 @@ LL |     })
 LL | }
    | - `a` dropped here while still borrowed
    |
-note: requirement that `a` is borrowed for `'static` introduced here
+note: requirement for `'static` introduced here
   --> $DIR/propagate-approximated-shorter-to-static-comparing-against-free.rs:13:8
    |
 LL |     F: for<'x> FnOnce(Cell<&'a u32>, Cell<&'x u32>),

--- a/tests/ui/nll/closure-requirements/propagate-multiple-requirements.stderr
+++ b/tests/ui/nll/closure-requirements/propagate-multiple-requirements.stderr
@@ -14,7 +14,7 @@ LL |         z = &local_arr;
 LL | }
    | - `local_arr` dropped here while still borrowed
    |
-note: requirement for `'static` introduced here
+note: requirement that the value outlives `'static` introduced here
   --> $DIR/propagate-multiple-requirements.rs:4:21
    |
 LL | fn once<S, T, U, F: FnOnce(S, T) -> U>(f: F, s: S, t: T) -> U {

--- a/tests/ui/nll/closure-requirements/propagate-multiple-requirements.stderr
+++ b/tests/ui/nll/closure-requirements/propagate-multiple-requirements.stderr
@@ -13,6 +13,12 @@ LL |         z = &local_arr;
 ...
 LL | }
    | - `local_arr` dropped here while still borrowed
+   |
+note: requirement that `local_arr` is borrowed for `'static` introduced here
+  --> $DIR/propagate-multiple-requirements.rs:4:21
+   |
+LL | fn once<S, T, U, F: FnOnce(S, T) -> U>(f: F, s: S, t: T) -> U {
+   |                     ^^^^^^^^^^^^^^^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/nll/closure-requirements/propagate-multiple-requirements.stderr
+++ b/tests/ui/nll/closure-requirements/propagate-multiple-requirements.stderr
@@ -14,7 +14,7 @@ LL |         z = &local_arr;
 LL | }
    | - `local_arr` dropped here while still borrowed
    |
-note: requirement that `local_arr` is borrowed for `'static` introduced here
+note: requirement for `'static` introduced here
   --> $DIR/propagate-multiple-requirements.rs:4:21
    |
 LL | fn once<S, T, U, F: FnOnce(S, T) -> U>(f: F, s: S, t: T) -> U {

--- a/tests/ui/nll/local-outlives-static-via-hrtb.stderr
+++ b/tests/ui/nll/local-outlives-static-via-hrtb.stderr
@@ -12,16 +12,16 @@ LL |     assert_static_via_hrtb_with_assoc_type(&&local);
 LL | }
    | - `local` dropped here while still borrowed
    |
-note: requirement that `local` is borrowed for `'static` introduced here
-  --> $DIR/local-outlives-static-via-hrtb.rs:15:53
-   |
-LL | fn assert_static_via_hrtb<G>(_: G) where for<'a> G: Outlives<'a> {}
-   |                                                     ^^^^^^^^^^^^
 note: due to a current limitation of the type system, this implies a `'static` lifetime
   --> $DIR/local-outlives-static-via-hrtb.rs:15:42
    |
 LL | fn assert_static_via_hrtb<G>(_: G) where for<'a> G: Outlives<'a> {}
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^
+note: requirement for `'static` introduced here
+  --> $DIR/local-outlives-static-via-hrtb.rs:15:53
+   |
+LL | fn assert_static_via_hrtb<G>(_: G) where for<'a> G: Outlives<'a> {}
+   |                                                     ^^^^^^^^^^^^
 
 error[E0597]: `local` does not live long enough
   --> $DIR/local-outlives-static-via-hrtb.rs:25:45
@@ -37,16 +37,16 @@ LL |     assert_static_via_hrtb_with_assoc_type(&&local);
 LL | }
    | - `local` dropped here while still borrowed
    |
-note: requirement that `local` is borrowed for `'static` introduced here
-  --> $DIR/local-outlives-static-via-hrtb.rs:19:30
-   |
-LL |     for<'a> &'a T: Reference<AssociatedType = &'a ()>,
-   |                              ^^^^^^^^^^^^^^^^^^^^^^^
 note: due to a current limitation of the type system, this implies a `'static` lifetime
   --> $DIR/local-outlives-static-via-hrtb.rs:19:5
    |
 LL |     for<'a> &'a T: Reference<AssociatedType = &'a ()>,
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: requirement for `'static` introduced here
+  --> $DIR/local-outlives-static-via-hrtb.rs:19:30
+   |
+LL |     for<'a> &'a T: Reference<AssociatedType = &'a ()>,
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/nll/local-outlives-static-via-hrtb.stderr
+++ b/tests/ui/nll/local-outlives-static-via-hrtb.stderr
@@ -17,7 +17,7 @@ note: due to a current limitation of the type system, this implies a `'static` l
    |
 LL | fn assert_static_via_hrtb<G>(_: G) where for<'a> G: Outlives<'a> {}
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^
-note: requirement for `'static` introduced here
+note: requirement that the value outlives `'static` introduced here
   --> $DIR/local-outlives-static-via-hrtb.rs:15:53
    |
 LL | fn assert_static_via_hrtb<G>(_: G) where for<'a> G: Outlives<'a> {}
@@ -42,7 +42,7 @@ note: due to a current limitation of the type system, this implies a `'static` l
    |
 LL |     for<'a> &'a T: Reference<AssociatedType = &'a ()>,
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: requirement for `'static` introduced here
+note: requirement that the value outlives `'static` introduced here
   --> $DIR/local-outlives-static-via-hrtb.rs:19:30
    |
 LL |     for<'a> &'a T: Reference<AssociatedType = &'a ()>,

--- a/tests/ui/nll/local-outlives-static-via-hrtb.stderr
+++ b/tests/ui/nll/local-outlives-static-via-hrtb.stderr
@@ -12,6 +12,11 @@ LL |     assert_static_via_hrtb_with_assoc_type(&&local);
 LL | }
    | - `local` dropped here while still borrowed
    |
+note: requirement that `local` is borrowed for `'static` introduced here
+  --> $DIR/local-outlives-static-via-hrtb.rs:15:53
+   |
+LL | fn assert_static_via_hrtb<G>(_: G) where for<'a> G: Outlives<'a> {}
+   |                                                     ^^^^^^^^^^^^
 note: due to a current limitation of the type system, this implies a `'static` lifetime
   --> $DIR/local-outlives-static-via-hrtb.rs:15:42
    |
@@ -32,6 +37,11 @@ LL |     assert_static_via_hrtb_with_assoc_type(&&local);
 LL | }
    | - `local` dropped here while still borrowed
    |
+note: requirement that `local` is borrowed for `'static` introduced here
+  --> $DIR/local-outlives-static-via-hrtb.rs:19:30
+   |
+LL |     for<'a> &'a T: Reference<AssociatedType = &'a ()>,
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^
 note: due to a current limitation of the type system, this implies a `'static` lifetime
   --> $DIR/local-outlives-static-via-hrtb.rs:19:5
    |

--- a/tests/ui/nll/polonius/location-insensitive-scopes-issue-117146.nll.stderr
+++ b/tests/ui/nll/polonius/location-insensitive-scopes-issue-117146.nll.stderr
@@ -13,6 +13,11 @@ LL |     let b = |_| &a;
 LL | }
    | - `a` dropped here while still borrowed
    |
+note: requirement that `a` is borrowed for `'static` introduced here
+  --> $DIR/location-insensitive-scopes-issue-117146.rs:20:22
+   |
+LL | fn bad<F: Fn(&()) -> &()>(_: F) {}
+   |                      ^^^
 note: due to a current limitation of the type system, this implies a `'static` lifetime
   --> $DIR/location-insensitive-scopes-issue-117146.rs:20:11
    |

--- a/tests/ui/nll/polonius/location-insensitive-scopes-issue-117146.nll.stderr
+++ b/tests/ui/nll/polonius/location-insensitive-scopes-issue-117146.nll.stderr
@@ -18,7 +18,7 @@ note: due to a current limitation of the type system, this implies a `'static` l
    |
 LL | fn bad<F: Fn(&()) -> &()>(_: F) {}
    |           ^^^^^^^^^^^^^^
-note: requirement for `'static` introduced here
+note: requirement that the value outlives `'static` introduced here
   --> $DIR/location-insensitive-scopes-issue-117146.rs:20:22
    |
 LL | fn bad<F: Fn(&()) -> &()>(_: F) {}

--- a/tests/ui/nll/polonius/location-insensitive-scopes-issue-117146.nll.stderr
+++ b/tests/ui/nll/polonius/location-insensitive-scopes-issue-117146.nll.stderr
@@ -13,16 +13,16 @@ LL |     let b = |_| &a;
 LL | }
    | - `a` dropped here while still borrowed
    |
-note: requirement that `a` is borrowed for `'static` introduced here
-  --> $DIR/location-insensitive-scopes-issue-117146.rs:20:22
-   |
-LL | fn bad<F: Fn(&()) -> &()>(_: F) {}
-   |                      ^^^
 note: due to a current limitation of the type system, this implies a `'static` lifetime
   --> $DIR/location-insensitive-scopes-issue-117146.rs:20:11
    |
 LL | fn bad<F: Fn(&()) -> &()>(_: F) {}
    |           ^^^^^^^^^^^^^^
+note: requirement for `'static` introduced here
+  --> $DIR/location-insensitive-scopes-issue-117146.rs:20:22
+   |
+LL | fn bad<F: Fn(&()) -> &()>(_: F) {}
+   |                      ^^^
 
 error: implementation of `Fn` is not general enough
   --> $DIR/location-insensitive-scopes-issue-117146.rs:13:5

--- a/tests/ui/nll/polonius/location-insensitive-scopes-issue-117146.polonius.stderr
+++ b/tests/ui/nll/polonius/location-insensitive-scopes-issue-117146.polonius.stderr
@@ -13,6 +13,11 @@ LL |     let b = |_| &a;
 LL | }
    | - `a` dropped here while still borrowed
    |
+note: requirement that `a` is borrowed for `'static` introduced here
+  --> $DIR/location-insensitive-scopes-issue-117146.rs:20:22
+   |
+LL | fn bad<F: Fn(&()) -> &()>(_: F) {}
+   |                      ^^^
 note: due to a current limitation of the type system, this implies a `'static` lifetime
   --> $DIR/location-insensitive-scopes-issue-117146.rs:20:11
    |

--- a/tests/ui/nll/polonius/location-insensitive-scopes-issue-117146.polonius.stderr
+++ b/tests/ui/nll/polonius/location-insensitive-scopes-issue-117146.polonius.stderr
@@ -18,7 +18,7 @@ note: due to a current limitation of the type system, this implies a `'static` l
    |
 LL | fn bad<F: Fn(&()) -> &()>(_: F) {}
    |           ^^^^^^^^^^^^^^
-note: requirement for `'static` introduced here
+note: requirement that the value outlives `'static` introduced here
   --> $DIR/location-insensitive-scopes-issue-117146.rs:20:22
    |
 LL | fn bad<F: Fn(&()) -> &()>(_: F) {}

--- a/tests/ui/nll/polonius/location-insensitive-scopes-issue-117146.polonius.stderr
+++ b/tests/ui/nll/polonius/location-insensitive-scopes-issue-117146.polonius.stderr
@@ -13,16 +13,16 @@ LL |     let b = |_| &a;
 LL | }
    | - `a` dropped here while still borrowed
    |
-note: requirement that `a` is borrowed for `'static` introduced here
-  --> $DIR/location-insensitive-scopes-issue-117146.rs:20:22
-   |
-LL | fn bad<F: Fn(&()) -> &()>(_: F) {}
-   |                      ^^^
 note: due to a current limitation of the type system, this implies a `'static` lifetime
   --> $DIR/location-insensitive-scopes-issue-117146.rs:20:11
    |
 LL | fn bad<F: Fn(&()) -> &()>(_: F) {}
    |           ^^^^^^^^^^^^^^
+note: requirement for `'static` introduced here
+  --> $DIR/location-insensitive-scopes-issue-117146.rs:20:22
+   |
+LL | fn bad<F: Fn(&()) -> &()>(_: F) {}
+   |                      ^^^
 
 error: implementation of `Fn` is not general enough
   --> $DIR/location-insensitive-scopes-issue-117146.rs:13:5

--- a/tests/ui/regions/multiple-sources-for-outlives-requirement.rs
+++ b/tests/ui/regions/multiple-sources-for-outlives-requirement.rs
@@ -1,0 +1,11 @@
+fn outlives_indir<'a: 'b, 'b, T: 'a>(_x: T) {}
+//~^ NOTE: requirements that the value outlives `'b` introduced here
+
+fn foo<'b>() { //~ NOTE: lifetime `'b` defined here
+    outlives_indir::<'_, 'b, _>(&mut 1u32); //~ ERROR: temporary value dropped while borrowed
+    //~^ NOTE: argument requires that borrow lasts for `'b`
+    //~| NOTE: creates a temporary value which is freed while still in use
+    //~| NOTE: temporary value is freed at the end of this statement
+}
+
+fn main() {}

--- a/tests/ui/regions/multiple-sources-for-outlives-requirement.stderr
+++ b/tests/ui/regions/multiple-sources-for-outlives-requirement.stderr
@@ -1,0 +1,20 @@
+error[E0716]: temporary value dropped while borrowed
+  --> $DIR/multiple-sources-for-outlives-requirement.rs:5:38
+   |
+LL | fn foo<'b>() {
+   |        -- lifetime `'b` defined here
+LL |     outlives_indir::<'_, 'b, _>(&mut 1u32);
+   |     ---------------------------------^^^^-- temporary value is freed at the end of this statement
+   |     |                                |
+   |     |                                creates a temporary value which is freed while still in use
+   |     argument requires that borrow lasts for `'b`
+   |
+note: requirements that the value outlives `'b` introduced here
+  --> $DIR/multiple-sources-for-outlives-requirement.rs:1:23
+   |
+LL | fn outlives_indir<'a: 'b, 'b, T: 'a>(_x: T) {}
+   |                       ^^         ^^
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0716`.

--- a/tests/ui/regions/regions-infer-proc-static-upvar.stderr
+++ b/tests/ui/regions/regions-infer-proc-static-upvar.stderr
@@ -11,6 +11,12 @@ LL | |     });
    | |______- argument requires that `x` is borrowed for `'static`
 LL |   }
    |   - `x` dropped here while still borrowed
+   |
+note: requirement that `x` is borrowed for `'static` introduced here
+  --> $DIR/regions-infer-proc-static-upvar.rs:4:19
+   |
+LL | fn foo<F:FnOnce()+'static>(_p: F) { }
+   |                   ^^^^^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/regions/regions-infer-proc-static-upvar.stderr
+++ b/tests/ui/regions/regions-infer-proc-static-upvar.stderr
@@ -12,7 +12,7 @@ LL | |     });
 LL |   }
    |   - `x` dropped here while still borrowed
    |
-note: requirement that `x` is borrowed for `'static` introduced here
+note: requirement for `'static` introduced here
   --> $DIR/regions-infer-proc-static-upvar.rs:4:19
    |
 LL | fn foo<F:FnOnce()+'static>(_p: F) { }

--- a/tests/ui/regions/regions-infer-proc-static-upvar.stderr
+++ b/tests/ui/regions/regions-infer-proc-static-upvar.stderr
@@ -12,7 +12,7 @@ LL | |     });
 LL |   }
    |   - `x` dropped here while still borrowed
    |
-note: requirement for `'static` introduced here
+note: requirement that the value outlives `'static` introduced here
   --> $DIR/regions-infer-proc-static-upvar.rs:4:19
    |
 LL | fn foo<F:FnOnce()+'static>(_p: F) { }

--- a/tests/ui/regions/regions-pattern-typing-issue-19552.stderr
+++ b/tests/ui/regions/regions-pattern-typing-issue-19552.stderr
@@ -11,7 +11,7 @@ LL |     }
 LL | }
    | - `line` dropped here while still borrowed
    |
-note: requirement that `line` is borrowed for `'static` introduced here
+note: requirement for `'static` introduced here
   --> $DIR/regions-pattern-typing-issue-19552.rs:1:21
    |
 LL | fn assert_static<T: 'static>(_t: T) {}

--- a/tests/ui/regions/regions-pattern-typing-issue-19552.stderr
+++ b/tests/ui/regions/regions-pattern-typing-issue-19552.stderr
@@ -10,6 +10,12 @@ LL |         [ word ] => { assert_static(word); }
 LL |     }
 LL | }
    | - `line` dropped here while still borrowed
+   |
+note: requirement that `line` is borrowed for `'static` introduced here
+  --> $DIR/regions-pattern-typing-issue-19552.rs:1:21
+   |
+LL | fn assert_static<T: 'static>(_t: T) {}
+   |                     ^^^^^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/regions/regions-pattern-typing-issue-19552.stderr
+++ b/tests/ui/regions/regions-pattern-typing-issue-19552.stderr
@@ -11,7 +11,7 @@ LL |     }
 LL | }
    | - `line` dropped here while still borrowed
    |
-note: requirement for `'static` introduced here
+note: requirement that the value outlives `'static` introduced here
   --> $DIR/regions-pattern-typing-issue-19552.rs:1:21
    |
 LL | fn assert_static<T: 'static>(_t: T) {}

--- a/tests/ui/static/static-lifetime-bound.stderr
+++ b/tests/ui/static/static-lifetime-bound.stderr
@@ -11,7 +11,7 @@ LL |     f(&x);
 LL | }
    | - `x` dropped here while still borrowed
    |
-note: requirement that `x` is borrowed for `'static` introduced here
+note: requirement for `'static` introduced here
   --> $DIR/static-lifetime-bound.rs:1:10
    |
 LL | fn f<'a: 'static>(_: &'a i32) {}

--- a/tests/ui/static/static-lifetime-bound.stderr
+++ b/tests/ui/static/static-lifetime-bound.stderr
@@ -11,7 +11,7 @@ LL |     f(&x);
 LL | }
    | - `x` dropped here while still borrowed
    |
-note: requirement for `'static` introduced here
+note: requirement that the value outlives `'static` introduced here
   --> $DIR/static-lifetime-bound.rs:1:10
    |
 LL | fn f<'a: 'static>(_: &'a i32) {}

--- a/tests/ui/static/static-lifetime-bound.stderr
+++ b/tests/ui/static/static-lifetime-bound.stderr
@@ -10,6 +10,12 @@ LL |     f(&x);
    |     argument requires that `x` is borrowed for `'static`
 LL | }
    | - `x` dropped here while still borrowed
+   |
+note: requirement that `x` is borrowed for `'static` introduced here
+  --> $DIR/static-lifetime-bound.rs:1:10
+   |
+LL | fn f<'a: 'static>(_: &'a i32) {}
+   |          ^^^^^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/static/static-region-bound.stderr
+++ b/tests/ui/static/static-region-bound.stderr
@@ -7,6 +7,12 @@ LL |     f(x);
    |     ---- argument requires that borrow lasts for `'static`
 LL | }
    | - temporary value is freed at the end of this statement
+   |
+note: requirement for `'static` introduced here
+  --> $DIR/static-region-bound.rs:3:8
+   |
+LL | fn f<T:'static>(_: T) {}
+   |        ^^^^^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/static/static-region-bound.stderr
+++ b/tests/ui/static/static-region-bound.stderr
@@ -8,7 +8,7 @@ LL |     f(x);
 LL | }
    | - temporary value is freed at the end of this statement
    |
-note: requirement for `'static` introduced here
+note: requirement that the value outlives `'static` introduced here
   --> $DIR/static-region-bound.rs:3:8
    |
 LL | fn f<T:'static>(_: T) {}

--- a/tests/ui/wf/wf-in-where-clause-static.current.stderr
+++ b/tests/ui/wf/wf-in-where-clause-static.current.stderr
@@ -7,7 +7,7 @@ LL |     let s = foo(&String::from("blah blah blah"));
    |             |    creates a temporary value which is freed while still in use
    |             argument requires that borrow lasts for `'static`
    |
-note: requirement for `'static` introduced here
+note: requirement that the value outlives `'static` introduced here
   --> $DIR/wf-in-where-clause-static.rs:12:17
    |
 LL |     &'static S: Static,

--- a/tests/ui/wf/wf-in-where-clause-static.current.stderr
+++ b/tests/ui/wf/wf-in-where-clause-static.current.stderr
@@ -6,6 +6,12 @@ LL |     let s = foo(&String::from("blah blah blah"));
    |             |    |
    |             |    creates a temporary value which is freed while still in use
    |             argument requires that borrow lasts for `'static`
+   |
+note: requirement for `'static` introduced here
+  --> $DIR/wf-in-where-clause-static.rs:12:17
+   |
+LL |     &'static S: Static,
+   |                 ^^^^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/wf/wf-in-where-clause-static.next.stderr
+++ b/tests/ui/wf/wf-in-where-clause-static.next.stderr
@@ -7,7 +7,7 @@ LL |     let s = foo(&String::from("blah blah blah"));
    |             |    creates a temporary value which is freed while still in use
    |             argument requires that borrow lasts for `'static`
    |
-note: requirement for `'static` introduced here
+note: requirement that the value outlives `'static` introduced here
   --> $DIR/wf-in-where-clause-static.rs:12:17
    |
 LL |     &'static S: Static,

--- a/tests/ui/wf/wf-in-where-clause-static.next.stderr
+++ b/tests/ui/wf/wf-in-where-clause-static.next.stderr
@@ -6,6 +6,12 @@ LL |     let s = foo(&String::from("blah blah blah"));
    |             |    |
    |             |    creates a temporary value which is freed while still in use
    |             argument requires that borrow lasts for `'static`
+   |
+note: requirement for `'static` introduced here
+  --> $DIR/wf-in-where-clause-static.rs:12:17
+   |
+LL |     &'static S: Static,
+   |                 ^^^^^^
 
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#140916 (Fix unuseful span in type error in some format_args!() invocations)
 - rust-lang/rust#146011 (Point at fn bound that introduced lifetime obligation)
 - rust-lang/rust#147109 (Rename various "concrete opaque type" things to say "hidden type")

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=140916,146011,147109)
<!-- homu-ignore:end -->