### PR TITLE
Fix the bevy implied bounds hack for the next solver

### DIFF
--- a/compiler/rustc_infer/src/infer/outlives/obligations.rs
+++ b/compiler/rustc_infer/src/infer/outlives/obligations.rs
@@ -170,6 +170,10 @@ impl<'tcx> InferCtxt<'tcx> {
         std::mem::take(&mut self.inner.borrow_mut().region_obligations)
     }
 
+    pub fn clone_registered_region_obligations(&self) -> Vec<TypeOutlivesConstraint<'tcx>> {
+        self.inner.borrow().region_obligations.clone()
+    }
+
     pub fn register_region_assumption(&self, assumption: ty::ArgOutlivesPredicate<'tcx>) {
         let mut inner = self.inner.borrow_mut();
         inner.undo_log.push(UndoLog::PushRegionAssumption);

--- a/tests/ui/implied-bounds/bevy_world_query.rs
+++ b/tests/ui/implied-bounds/bevy_world_query.rs
@@ -1,6 +1,8 @@
-#![crate_name = "bevy_ecs"]
-
 //@ check-pass
+//@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@[next] compile-flags: -Znext-solver
+#![crate_name = "bevy_ecs"]
 
 // We currently special case bevy from erroring on incorrect implied bounds
 // from normalization (issue #109628).


### PR DESCRIPTION
The diff is trivial, of course, and basically what you already suggested. Mostly dug around a bunch to learn. I hope this is roughly what you had in mind.

Fixes https://github.com/rust-lang/trait-system-refactor-initiative/issues/236.

r? @lcnr 