### PR TITLE
Add new optional tidy check to check if ftl error messages are unused

### DIFF
--- a/compiler/rustc_attr_parsing/messages.ftl
+++ b/compiler/rustc_attr_parsing/messages.ftl
@@ -242,8 +242,6 @@ attr_parsing_link_requires_name =
 attr_parsing_multiple_modifiers =
     multiple `{$modifier}` modifiers in a single `modifiers` argument
 
-attr_parsing_multiple_renamings =
-    multiple renamings were specified for library `{$lib_name}`
 attr_parsing_raw_dylib_no_nul =
     link name must not contain NUL characters if link kind is `raw-dylib`
 

--- a/compiler/rustc_const_eval/src/const_eval/error.rs
+++ b/compiler/rustc_const_eval/src/const_eval/error.rs
@@ -44,20 +44,22 @@ impl MachineStopType for ConstEvalErrKind {
     fn diagnostic_message(&self) -> DiagMessage {
         use ConstEvalErrKind::*;
 
-        use crate::fluent_generated::*;
+        use crate::fluent_generated as fluent;
         match self {
-            ConstAccessesMutGlobal => const_eval_const_accesses_mut_global,
-            ModifiedGlobal => const_eval_modified_global,
-            Panic { .. } => const_eval_panic,
-            RecursiveStatic => const_eval_recursive_static,
+            ConstAccessesMutGlobal => fluent::const_eval_const_accesses_mut_global,
+            ModifiedGlobal => fluent::const_eval_modified_global,
+            Panic { .. } => fluent::const_eval_panic,
+            RecursiveStatic => fluent::const_eval_recursive_static,
             AssertFailure(x) => x.diagnostic_message(),
-            WriteThroughImmutablePointer => const_eval_write_through_immutable_pointer,
+            WriteThroughImmutablePointer => fluent::const_eval_write_through_immutable_pointer,
             ConstMakeGlobalPtrAlreadyMadeGlobal { .. } => {
-                const_eval_const_make_global_ptr_already_made_global
+                fluent::const_eval_const_make_global_ptr_already_made_global
             }
-            ConstMakeGlobalPtrIsNonHeap(_) => const_eval_const_make_global_ptr_is_non_heap,
-            ConstMakeGlobalWithDanglingPtr(_) => const_eval_const_make_global_with_dangling_ptr,
-            ConstMakeGlobalWithOffset(_) => const_eval_const_make_global_with_offset,
+            ConstMakeGlobalPtrIsNonHeap(_) => fluent::const_eval_const_make_global_ptr_is_non_heap,
+            ConstMakeGlobalWithDanglingPtr(_) => {
+                fluent::const_eval_const_make_global_with_dangling_ptr
+            }
+            ConstMakeGlobalWithOffset(_) => fluent::const_eval_const_make_global_with_offset,
         }
     }
     fn add_args(self: Box<Self>, adder: &mut dyn FnMut(DiagArgName, DiagArgValue)) {

--- a/compiler/rustc_const_eval/src/errors.rs
+++ b/compiler/rustc_const_eval/src/errors.rs
@@ -466,51 +466,50 @@ impl<'a> ReportErrorExt for UndefinedBehaviorInfo<'a> {
     fn diagnostic_message(&self) -> DiagMessage {
         use UndefinedBehaviorInfo::*;
 
-        use crate::fluent_generated::*;
         match self {
             Ub(msg) => msg.clone().into(),
             Custom(x) => (x.msg)(),
             ValidationError(e) => e.diagnostic_message(),
 
-            Unreachable => const_eval_unreachable,
-            BoundsCheckFailed { .. } => const_eval_bounds_check_failed,
-            DivisionByZero => const_eval_division_by_zero,
-            RemainderByZero => const_eval_remainder_by_zero,
-            DivisionOverflow => const_eval_division_overflow,
-            RemainderOverflow => const_eval_remainder_overflow,
-            PointerArithOverflow => const_eval_pointer_arithmetic_overflow,
-            ArithOverflow { .. } => const_eval_overflow_arith,
-            ShiftOverflow { .. } => const_eval_overflow_shift,
-            InvalidMeta(InvalidMetaKind::SliceTooBig) => const_eval_invalid_meta_slice,
-            InvalidMeta(InvalidMetaKind::TooBig) => const_eval_invalid_meta,
-            UnterminatedCString(_) => const_eval_unterminated_c_string,
-            PointerUseAfterFree(_, _) => const_eval_pointer_use_after_free,
-            PointerOutOfBounds { .. } => const_eval_pointer_out_of_bounds,
-            DanglingIntPointer { addr: 0, .. } => const_eval_dangling_null_pointer,
-            DanglingIntPointer { .. } => const_eval_dangling_int_pointer,
-            AlignmentCheckFailed { .. } => const_eval_alignment_check_failed,
-            WriteToReadOnly(_) => const_eval_write_to_read_only,
-            DerefFunctionPointer(_) => const_eval_deref_function_pointer,
-            DerefVTablePointer(_) => const_eval_deref_vtable_pointer,
-            DerefTypeIdPointer(_) => const_eval_deref_typeid_pointer,
-            InvalidBool(_) => const_eval_invalid_bool,
-            InvalidChar(_) => const_eval_invalid_char,
-            InvalidTag(_) => const_eval_invalid_tag,
-            InvalidFunctionPointer(_) => const_eval_invalid_function_pointer,
-            InvalidVTablePointer(_) => const_eval_invalid_vtable_pointer,
-            InvalidVTableTrait { .. } => const_eval_invalid_vtable_trait,
-            InvalidStr(_) => const_eval_invalid_str,
-            InvalidUninitBytes(None) => const_eval_invalid_uninit_bytes_unknown,
-            InvalidUninitBytes(Some(_)) => const_eval_invalid_uninit_bytes,
-            DeadLocal => const_eval_dead_local,
-            ScalarSizeMismatch(_) => const_eval_scalar_size_mismatch,
-            UninhabitedEnumVariantWritten(_) => const_eval_uninhabited_enum_variant_written,
-            UninhabitedEnumVariantRead(_) => const_eval_uninhabited_enum_variant_read,
+            Unreachable => fluent::const_eval_unreachable,
+            BoundsCheckFailed { .. } => fluent::const_eval_bounds_check_failed,
+            DivisionByZero => fluent::const_eval_division_by_zero,
+            RemainderByZero => fluent::const_eval_remainder_by_zero,
+            DivisionOverflow => fluent::const_eval_division_overflow,
+            RemainderOverflow => fluent::const_eval_remainder_overflow,
+            PointerArithOverflow => fluent::const_eval_pointer_arithmetic_overflow,
+            ArithOverflow { .. } => fluent::const_eval_overflow_arith,
+            ShiftOverflow { .. } => fluent::const_eval_overflow_shift,
+            InvalidMeta(InvalidMetaKind::SliceTooBig) => fluent::const_eval_invalid_meta_slice,
+            InvalidMeta(InvalidMetaKind::TooBig) => fluent::const_eval_invalid_meta,
+            UnterminatedCString(_) => fluent::const_eval_unterminated_c_string,
+            PointerUseAfterFree(_, _) => fluent::const_eval_pointer_use_after_free,
+            PointerOutOfBounds { .. } => fluent::const_eval_pointer_out_of_bounds,
+            DanglingIntPointer { addr: 0, .. } => fluent::const_eval_dangling_null_pointer,
+            DanglingIntPointer { .. } => fluent::const_eval_dangling_int_pointer,
+            AlignmentCheckFailed { .. } => fluent::const_eval_alignment_check_failed,
+            WriteToReadOnly(_) => fluent::const_eval_write_to_read_only,
+            DerefFunctionPointer(_) => fluent::const_eval_deref_function_pointer,
+            DerefVTablePointer(_) => fluent::const_eval_deref_vtable_pointer,
+            DerefTypeIdPointer(_) => fluent::const_eval_deref_typeid_pointer,
+            InvalidBool(_) => fluent::const_eval_invalid_bool,
+            InvalidChar(_) => fluent::const_eval_invalid_char,
+            InvalidTag(_) => fluent::const_eval_invalid_tag,
+            InvalidFunctionPointer(_) => fluent::const_eval_invalid_function_pointer,
+            InvalidVTablePointer(_) => fluent::const_eval_invalid_vtable_pointer,
+            InvalidVTableTrait { .. } => fluent::const_eval_invalid_vtable_trait,
+            InvalidStr(_) => fluent::const_eval_invalid_str,
+            InvalidUninitBytes(None) => fluent::const_eval_invalid_uninit_bytes_unknown,
+            InvalidUninitBytes(Some(_)) => fluent::const_eval_invalid_uninit_bytes,
+            DeadLocal => fluent::const_eval_dead_local,
+            ScalarSizeMismatch(_) => fluent::const_eval_scalar_size_mismatch,
+            UninhabitedEnumVariantWritten(_) => fluent::const_eval_uninhabited_enum_variant_written,
+            UninhabitedEnumVariantRead(_) => fluent::const_eval_uninhabited_enum_variant_read,
             InvalidNichedEnumVariantWritten { .. } => {
-                const_eval_invalid_niched_enum_variant_written
+                fluent::const_eval_invalid_niched_enum_variant_written
             }
-            AbiMismatchArgument { .. } => const_eval_incompatible_arg_types,
-            AbiMismatchReturn { .. } => const_eval_incompatible_return_types,
+            AbiMismatchArgument { .. } => fluent::const_eval_incompatible_arg_types,
+            AbiMismatchReturn { .. } => fluent::const_eval_incompatible_return_types,
         }
     }
 
@@ -653,79 +652,78 @@ impl<'tcx> ReportErrorExt for ValidationErrorInfo<'tcx> {
     fn diagnostic_message(&self) -> DiagMessage {
         use rustc_middle::mir::interpret::ValidationErrorKind::*;
 
-        use crate::fluent_generated::*;
         match self.kind {
             PtrToUninhabited { ptr_kind: PointerKind::Box, .. } => {
-                const_eval_validation_box_to_uninhabited
+                fluent::const_eval_validation_box_to_uninhabited
             }
             PtrToUninhabited { ptr_kind: PointerKind::Ref(_), .. } => {
-                const_eval_validation_ref_to_uninhabited
+                fluent::const_eval_validation_ref_to_uninhabited
             }
 
-            PointerAsInt { .. } => const_eval_validation_pointer_as_int,
-            PartialPointer => const_eval_validation_partial_pointer,
-            MutableRefToImmutable => const_eval_validation_mutable_ref_to_immutable,
-            MutableRefInConst => const_eval_validation_mutable_ref_in_const,
-            NullFnPtr => const_eval_validation_null_fn_ptr,
-            NeverVal => const_eval_validation_never_val,
-            NonnullPtrMaybeNull { .. } => const_eval_validation_nonnull_ptr_out_of_range,
-            PtrOutOfRange { .. } => const_eval_validation_ptr_out_of_range,
-            OutOfRange { .. } => const_eval_validation_out_of_range,
-            UnsafeCellInImmutable => const_eval_validation_unsafe_cell,
-            UninhabitedVal { .. } => const_eval_validation_uninhabited_val,
-            InvalidEnumTag { .. } => const_eval_validation_invalid_enum_tag,
-            UninhabitedEnumVariant => const_eval_validation_uninhabited_enum_variant,
-            Uninit { .. } => const_eval_validation_uninit,
-            InvalidVTablePtr { .. } => const_eval_validation_invalid_vtable_ptr,
-            InvalidMetaWrongTrait { .. } => const_eval_validation_invalid_vtable_trait,
+            PointerAsInt { .. } => fluent::const_eval_validation_pointer_as_int,
+            PartialPointer => fluent::const_eval_validation_partial_pointer,
+            MutableRefToImmutable => fluent::const_eval_validation_mutable_ref_to_immutable,
+            MutableRefInConst => fluent::const_eval_validation_mutable_ref_in_const,
+            NullFnPtr => fluent::const_eval_validation_null_fn_ptr,
+            NeverVal => fluent::const_eval_validation_never_val,
+            NonnullPtrMaybeNull { .. } => fluent::const_eval_validation_nonnull_ptr_out_of_range,
+            PtrOutOfRange { .. } => fluent::const_eval_validation_ptr_out_of_range,
+            OutOfRange { .. } => fluent::const_eval_validation_out_of_range,
+            UnsafeCellInImmutable => fluent::const_eval_validation_unsafe_cell,
+            UninhabitedVal { .. } => fluent::const_eval_validation_uninhabited_val,
+            InvalidEnumTag { .. } => fluent::const_eval_validation_invalid_enum_tag,
+            UninhabitedEnumVariant => fluent::const_eval_validation_uninhabited_enum_variant,
+            Uninit { .. } => fluent::const_eval_validation_uninit,
+            InvalidVTablePtr { .. } => fluent::const_eval_validation_invalid_vtable_ptr,
+            InvalidMetaWrongTrait { .. } => fluent::const_eval_validation_invalid_vtable_trait,
             InvalidMetaSliceTooLarge { ptr_kind: PointerKind::Box } => {
-                const_eval_validation_invalid_box_slice_meta
+                fluent::const_eval_validation_invalid_box_slice_meta
             }
             InvalidMetaSliceTooLarge { ptr_kind: PointerKind::Ref(_) } => {
-                const_eval_validation_invalid_ref_slice_meta
+                fluent::const_eval_validation_invalid_ref_slice_meta
             }
 
             InvalidMetaTooLarge { ptr_kind: PointerKind::Box } => {
-                const_eval_validation_invalid_box_meta
+                fluent::const_eval_validation_invalid_box_meta
             }
             InvalidMetaTooLarge { ptr_kind: PointerKind::Ref(_) } => {
-                const_eval_validation_invalid_ref_meta
+                fluent::const_eval_validation_invalid_ref_meta
             }
             UnalignedPtr { ptr_kind: PointerKind::Ref(_), .. } => {
-                const_eval_validation_unaligned_ref
+                fluent::const_eval_validation_unaligned_ref
             }
-            UnalignedPtr { ptr_kind: PointerKind::Box, .. } => const_eval_validation_unaligned_box,
+            UnalignedPtr { ptr_kind: PointerKind::Box, .. } => {
+                fluent::const_eval_validation_unaligned_box
+            }
 
-            NullPtr { ptr_kind: PointerKind::Box, .. } => const_eval_validation_null_box,
-            NullPtr { ptr_kind: PointerKind::Ref(_), .. } => const_eval_validation_null_ref,
+            NullPtr { ptr_kind: PointerKind::Box, .. } => fluent::const_eval_validation_null_box,
+            NullPtr { ptr_kind: PointerKind::Ref(_), .. } => fluent::const_eval_validation_null_ref,
             DanglingPtrNoProvenance { ptr_kind: PointerKind::Box, .. } => {
-                const_eval_validation_dangling_box_no_provenance
+                fluent::const_eval_validation_dangling_box_no_provenance
             }
             DanglingPtrNoProvenance { ptr_kind: PointerKind::Ref(_), .. } => {
-                const_eval_validation_dangling_ref_no_provenance
+                fluent::const_eval_validation_dangling_ref_no_provenance
             }
             DanglingPtrOutOfBounds { ptr_kind: PointerKind::Box } => {
-                const_eval_validation_dangling_box_out_of_bounds
+                fluent::const_eval_validation_dangling_box_out_of_bounds
             }
             DanglingPtrOutOfBounds { ptr_kind: PointerKind::Ref(_) } => {
-                const_eval_validation_dangling_ref_out_of_bounds
+                fluent::const_eval_validation_dangling_ref_out_of_bounds
             }
             DanglingPtrUseAfterFree { ptr_kind: PointerKind::Box } => {
-                const_eval_validation_dangling_box_use_after_free
+                fluent::const_eval_validation_dangling_box_use_after_free
             }
             DanglingPtrUseAfterFree { ptr_kind: PointerKind::Ref(_) } => {
-                const_eval_validation_dangling_ref_use_after_free
+                fluent::const_eval_validation_dangling_ref_use_after_free
             }
-            InvalidBool { .. } => const_eval_validation_invalid_bool,
-            InvalidChar { .. } => const_eval_validation_invalid_char,
-            InvalidFnPtr { .. } => const_eval_validation_invalid_fn_ptr,
+            InvalidBool { .. } => fluent::const_eval_validation_invalid_bool,
+            InvalidChar { .. } => fluent::const_eval_validation_invalid_char,
+            InvalidFnPtr { .. } => fluent::const_eval_validation_invalid_fn_ptr,
         }
     }
 
     fn add_args<G: EmissionGuarantee>(self, err: &mut Diag<'_, G>) {
         use rustc_middle::mir::interpret::ValidationErrorKind::*;
-
-        use crate::fluent_generated as fluent;
 
         if let PointerAsInt { .. } | PartialPointer = self.kind {
             err.help(fluent::const_eval_ptr_as_bytes_1);
@@ -841,25 +839,23 @@ impl<'tcx> ReportErrorExt for ValidationErrorInfo<'tcx> {
 
 impl ReportErrorExt for UnsupportedOpInfo {
     fn diagnostic_message(&self) -> DiagMessage {
-        use crate::fluent_generated::*;
         match self {
             UnsupportedOpInfo::Unsupported(s) => s.clone().into(),
-            UnsupportedOpInfo::ExternTypeField => const_eval_extern_type_field,
-            UnsupportedOpInfo::UnsizedLocal => const_eval_unsized_local,
-            UnsupportedOpInfo::ReadPartialPointer(_) => const_eval_partial_pointer_read,
-            UnsupportedOpInfo::ReadPointerAsInt(_) => const_eval_read_pointer_as_int,
-            UnsupportedOpInfo::ThreadLocalStatic(_) => const_eval_thread_local_static,
-            UnsupportedOpInfo::ExternStatic(_) => const_eval_extern_static,
+            UnsupportedOpInfo::ExternTypeField => fluent::const_eval_extern_type_field,
+            UnsupportedOpInfo::UnsizedLocal => fluent::const_eval_unsized_local,
+            UnsupportedOpInfo::ReadPartialPointer(_) => fluent::const_eval_partial_pointer_read,
+            UnsupportedOpInfo::ReadPointerAsInt(_) => fluent::const_eval_read_pointer_as_int,
+            UnsupportedOpInfo::ThreadLocalStatic(_) => fluent::const_eval_thread_local_static,
+            UnsupportedOpInfo::ExternStatic(_) => fluent::const_eval_extern_static,
         }
     }
 
     fn add_args<G: EmissionGuarantee>(self, diag: &mut Diag<'_, G>) {
         use UnsupportedOpInfo::*;
 
-        use crate::fluent_generated::*;
         if let ReadPointerAsInt(_) | ReadPartialPointer(_) = self {
-            diag.help(const_eval_ptr_as_bytes_1);
-            diag.help(const_eval_ptr_as_bytes_2);
+            diag.help(fluent::const_eval_ptr_as_bytes_1);
+            diag.help(fluent::const_eval_ptr_as_bytes_2);
         }
         match self {
             // `ReadPointerAsInt(Some(info))` is never printed anyway, it only serves as an error to
@@ -904,10 +900,9 @@ impl<'tcx> ReportErrorExt for InterpErrorKind<'tcx> {
 
 impl<'tcx> ReportErrorExt for InvalidProgramInfo<'tcx> {
     fn diagnostic_message(&self) -> DiagMessage {
-        use crate::fluent_generated::*;
         match self {
-            InvalidProgramInfo::TooGeneric => const_eval_too_generic,
-            InvalidProgramInfo::AlreadyReported(_) => const_eval_already_reported,
+            InvalidProgramInfo::TooGeneric => fluent::const_eval_too_generic,
+            InvalidProgramInfo::AlreadyReported(_) => fluent::const_eval_already_reported,
             InvalidProgramInfo::Layout(e) => e.diagnostic_message(),
         }
     }
@@ -929,12 +924,13 @@ impl<'tcx> ReportErrorExt for InvalidProgramInfo<'tcx> {
 
 impl ReportErrorExt for ResourceExhaustionInfo {
     fn diagnostic_message(&self) -> DiagMessage {
-        use crate::fluent_generated::*;
         match self {
-            ResourceExhaustionInfo::StackFrameLimitReached => const_eval_stack_frame_limit_reached,
-            ResourceExhaustionInfo::MemoryExhausted => const_eval_memory_exhausted,
-            ResourceExhaustionInfo::AddressSpaceFull => const_eval_address_space_full,
-            ResourceExhaustionInfo::Interrupted => const_eval_interrupted,
+            ResourceExhaustionInfo::StackFrameLimitReached => {
+                fluent::const_eval_stack_frame_limit_reached
+            }
+            ResourceExhaustionInfo::MemoryExhausted => fluent::const_eval_memory_exhausted,
+            ResourceExhaustionInfo::AddressSpaceFull => fluent::const_eval_address_space_full,
+            ResourceExhaustionInfo::Interrupted => fluent::const_eval_interrupted,
         }
     }
     fn add_args<G: EmissionGuarantee>(self, _: &mut Diag<'_, G>) {}

--- a/compiler/rustc_metadata/messages.ftl
+++ b/compiler/rustc_metadata/messages.ftl
@@ -237,11 +237,5 @@ metadata_unknown_target_modifier_unsafe_allowed = unknown target modifier `{$fla
 metadata_wasm_c_abi =
     older versions of the `wasm-bindgen` crate are incompatible with current versions of Rust; please update to `wasm-bindgen` v0.2.88
 
-metadata_wasm_import_form =
-    wasm import module must be of the form `wasm_import_module = "string"`
-
-metadata_whole_archive_needs_static =
-    linking modifier `whole-archive` is only compatible with `static` linking kind
-
 metadata_raw_dylib_malformed =
     link name must be well-formed if link kind is `raw-dylib`

--- a/compiler/rustc_middle/src/mir/terminator.rs
+++ b/compiler/rustc_middle/src/mir/terminator.rs
@@ -336,18 +336,18 @@ impl<O> AssertKind<O> {
     pub fn diagnostic_message(&self) -> DiagMessage {
         use AssertKind::*;
 
-        use crate::fluent_generated::*;
+        use crate::fluent_generated as fluent;
 
         match self {
-            BoundsCheck { .. } => middle_bounds_check,
-            Overflow(BinOp::Shl, _, _) => middle_assert_shl_overflow,
-            Overflow(BinOp::Shr, _, _) => middle_assert_shr_overflow,
-            Overflow(_, _, _) => middle_assert_op_overflow,
-            OverflowNeg(_) => middle_assert_overflow_neg,
-            DivisionByZero(_) => middle_assert_divide_by_zero,
-            RemainderByZero(_) => middle_assert_remainder_by_zero,
+            BoundsCheck { .. } => fluent::middle_bounds_check,
+            Overflow(BinOp::Shl, _, _) => fluent::middle_assert_shl_overflow,
+            Overflow(BinOp::Shr, _, _) => fluent::middle_assert_shr_overflow,
+            Overflow(_, _, _) => fluent::middle_assert_op_overflow,
+            OverflowNeg(_) => fluent::middle_assert_overflow_neg,
+            DivisionByZero(_) => fluent::middle_assert_divide_by_zero,
+            RemainderByZero(_) => fluent::middle_assert_remainder_by_zero,
             ResumedAfterReturn(CoroutineKind::Desugared(CoroutineDesugaring::Async, _)) => {
-                middle_assert_async_resume_after_return
+                fluent::middle_assert_async_resume_after_return
             }
             ResumedAfterReturn(CoroutineKind::Desugared(CoroutineDesugaring::AsyncGen, _)) => {
                 todo!()
@@ -356,36 +356,36 @@ impl<O> AssertKind<O> {
                 bug!("gen blocks can be resumed after they return and will keep returning `None`")
             }
             ResumedAfterReturn(CoroutineKind::Coroutine(_)) => {
-                middle_assert_coroutine_resume_after_return
+                fluent::middle_assert_coroutine_resume_after_return
             }
             ResumedAfterPanic(CoroutineKind::Desugared(CoroutineDesugaring::Async, _)) => {
-                middle_assert_async_resume_after_panic
+                fluent::middle_assert_async_resume_after_panic
             }
             ResumedAfterPanic(CoroutineKind::Desugared(CoroutineDesugaring::AsyncGen, _)) => {
                 todo!()
             }
             ResumedAfterPanic(CoroutineKind::Desugared(CoroutineDesugaring::Gen, _)) => {
-                middle_assert_gen_resume_after_panic
+                fluent::middle_assert_gen_resume_after_panic
             }
             ResumedAfterPanic(CoroutineKind::Coroutine(_)) => {
-                middle_assert_coroutine_resume_after_panic
+                fluent::middle_assert_coroutine_resume_after_panic
             }
-            NullPointerDereference => middle_assert_null_ptr_deref,
-            InvalidEnumConstruction(_) => middle_assert_invalid_enum_construction,
+            NullPointerDereference => fluent::middle_assert_null_ptr_deref,
+            InvalidEnumConstruction(_) => fluent::middle_assert_invalid_enum_construction,
             ResumedAfterDrop(CoroutineKind::Desugared(CoroutineDesugaring::Async, _)) => {
-                middle_assert_async_resume_after_drop
+                fluent::middle_assert_async_resume_after_drop
             }
             ResumedAfterDrop(CoroutineKind::Desugared(CoroutineDesugaring::AsyncGen, _)) => {
                 todo!()
             }
             ResumedAfterDrop(CoroutineKind::Desugared(CoroutineDesugaring::Gen, _)) => {
-                middle_assert_gen_resume_after_drop
+                fluent::middle_assert_gen_resume_after_drop
             }
             ResumedAfterDrop(CoroutineKind::Coroutine(_)) => {
-                middle_assert_coroutine_resume_after_drop
+                fluent::middle_assert_coroutine_resume_after_drop
             }
 
-            MisalignedPointerDereference { .. } => middle_assert_misaligned_ptr_deref,
+            MisalignedPointerDereference { .. } => fluent::middle_assert_misaligned_ptr_deref,
         }
     }
 

--- a/compiler/rustc_parse/messages.ftl
+++ b/compiler/rustc_parse/messages.ftl
@@ -868,7 +868,6 @@ parse_too_many_hashes = too many `#` symbols: raw strings may be delimited by up
 parse_too_short_hex_escape = numeric character escape is too short
 
 parse_trailing_vert_not_allowed = a trailing `{$token}` is not allowed in an or-pattern
-parse_trailing_vert_not_allowed_suggestion = remove the `{$token}`
 
 parse_trait_alias_cannot_be_auto = trait aliases cannot be `auto`
 parse_trait_alias_cannot_be_const = trait aliases cannot be `const`

--- a/compiler/rustc_ty_utils/messages.ftl
+++ b/compiler/rustc_ty_utils/messages.ftl
@@ -52,8 +52,6 @@ ty_utils_non_primitive_simd_type = monomorphising SIMD type `{$ty}` with a non-p
 
 ty_utils_operation_not_supported = unsupported operation in generic constants
 
-ty_utils_oversized_simd_type = monomorphising SIMD type `{$ty}` of length greater than {$max_lanes}
-
 ty_utils_pointer_not_supported = pointer casts are not allowed in generic constants
 
 ty_utils_tuple_not_supported = tuple construction is not supported in generic constants
@@ -61,5 +59,3 @@ ty_utils_tuple_not_supported = tuple construction is not supported in generic co
 ty_utils_unexpected_fnptr_associated_item = `FnPtr` trait with unexpected associated item
 
 ty_utils_yield_not_supported = coroutine control flow is not allowed in generic constants
-
-ty_utils_zero_length_simd_type = monomorphising SIMD type `{$ty}` of zero length

--- a/src/tools/tidy/src/error_messages.rs
+++ b/src/tools/tidy/src/error_messages.rs
@@ -1,0 +1,96 @@
+use std::collections::HashMap;
+use std::path::Path;
+
+use fluent_syntax::ast::{Entry, Expression, InlineExpression, PatternElement};
+use fluent_syntax::parser;
+use regex::Regex;
+
+use crate::diagnostics::{CheckId, DiagCtx, RunningCheck};
+
+pub fn check(root_path: &Path, diag_ctx: DiagCtx) {
+    let path = &root_path.join("compiler");
+    let mut check = diag_ctx.start_check(CheckId::new("error_messages").path(path));
+    let regex = Regex::new(r#"(?:(?:#\[(diag|label|suggestion|note|help|help_once|multipart_suggestion)\()|(?:fluent(_generated)?::))\s*(?<id>[a-z_][a-zA-Z0-9_]+)\s*[\n,\)};]"#).unwrap();
+
+    for dir in std::fs::read_dir(path).unwrap() {
+        let Ok(dir) = dir else { continue };
+        let dir = dir.path();
+        let messages_file = dir.join("messages.ftl");
+
+        if messages_file.is_file() {
+            check_if_messages_are_used(&mut check, &dir.join("src"), &messages_file, &regex);
+        }
+    }
+}
+
+fn check_fluent_ast<'a>(ids: &mut HashMap<&'a str, bool>, elem: &PatternElement<&'a str>) {
+    if let PatternElement::Placeable { expression } = elem {
+        match expression {
+            Expression::Inline(InlineExpression::MessageReference { id, .. }) => {
+                *ids.entry(&id.name).or_default() = true;
+            }
+            Expression::Select { variants, .. } => {
+                for variant in variants {
+                    for elem in &variant.value.elements {
+                        check_fluent_ast(ids, elem);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+fn check_if_messages_are_used(
+    check: &mut RunningCheck,
+    src_path: &Path,
+    messages_file: &Path,
+    regex: &Regex,
+) {
+    // First we retrieve all error messages ID.
+    let content = std::fs::read_to_string(messages_file).expect("failed to read file");
+    let resource =
+        parser::parse(content.as_str()).expect("Errors encountered while parsing a resource.");
+
+    let mut ids: HashMap<&str, bool> = HashMap::new();
+    for entry in &resource.body {
+        if let Entry::Message(msg) = entry {
+            let id: &str = &msg.id.name;
+            if !ids.contains_key(&id) {
+                ids.insert(id, false);
+            }
+            if let Some(value) = &msg.value {
+                for elem in &value.elements {
+                    check_fluent_ast(&mut ids, elem);
+                }
+            }
+            for attr in &msg.attributes {
+                for elem in &attr.value.elements {
+                    check_fluent_ast(&mut ids, elem);
+                }
+            }
+        }
+    }
+
+    assert!(!ids.is_empty());
+
+    let skip = |f: &Path, is_dir: bool| !is_dir && !f.extension().is_some_and(|ext| ext == "rs");
+    crate::walk::walk(src_path, skip, &mut |_path: &_, content: &str| {
+        for cap in regex.captures_iter(content) {
+            let id = &cap["id"];
+            if let Some(found) = ids.get_mut(id) {
+                // Error message IDs can be used more than once.
+                *found = true;
+            }
+        }
+    });
+    const TO_IGNORE: &[&str] = &[
+        // FIXME: #114050
+        "hir_typeck_option_result_asref",
+    ];
+    for (id, found) in ids {
+        if !found && !TO_IGNORE.iter().any(|to_ignore| *to_ignore == id) {
+            check.error(format!("unused message ID `{id}` from `{}`", messages_file.display()));
+        }
+    }
+}

--- a/src/tools/tidy/src/lib.rs
+++ b/src/tools/tidy/src/lib.rs
@@ -229,6 +229,7 @@ pub mod deps;
 pub mod diagnostics;
 pub mod edition;
 pub mod error_codes;
+pub mod error_messages;
 pub mod extdeps;
 pub mod extra_checks;
 pub mod features;


### PR DESCRIPTION
I realized recently while removing a rustdoc feature that error messages could be unused and we apparently had no checks for that. This PR fills this void.

There is one unresolved question (likely due to my ignorance rather than an actual issue): we have (a lot of) error message IDs that are actually not anywhere in `ftl` files, like `attr_parsing_remove_neg_sugg`. Is it expected or not?

In any case, there were unused error message IDs so I removed them in this PR as well.

cc @davidtwco 
r? @Kobzol 