### PR TITLE
Fix broken STD build for ESP-IDF

### DIFF
--- a/library/std/src/sys/net/hostname/mod.rs
+++ b/library/std/src/sys/net/hostname/mod.rs
@@ -1,5 +1,5 @@
 cfg_select! {
-    target_family = "unix" => {
+    all(target_family = "unix", not(target_os = "espidf")) => {
         mod unix;
         pub use unix::hostname;
     }


### PR DESCRIPTION
PRs rust-lang/rust#147162 and rust-lang/rust#146937 did [broke](https://github.com/esp-rs/esp-idf-sys/actions/runs/18151791720/job/51663969786) the STD build for `target_os = "espidf"` because that target [does not have neither a `gethostname`, not a `libc::_SC_HOST_NAME_MAX` by default](https://github.com/espressif/esp-idf/issues/14849).

While there is a [3rd party component for this syscall](https://components.espressif.com/components/espressif/sock_utils/versions/0.2.2/readme) in the ESP-IDF component registry, I don't think we should use it, because it does not come with ESP-IDF by default.

Therefore, the one-liner fix just re-routes ESP-IDF into the `unsupported` branch.
