### PR TITLE
Don't create a top-level `true` directory when running UI tests

### DIFF
--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-call/undeclared-lifetime.rs
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-call/undeclared-lifetime.rs
@@ -1,5 +1,6 @@
 //@ add-core-stubs
-//@ compile-flags: --target thumbv8m.main-none-eabi --crate-type lib -Cincremental=true
+//@ compile-flags: --target thumbv8m.main-none-eabi --crate-type lib
+//@ incremental (required to trigger the bug)
 //@ needs-llvm-components: arm
 #![feature(abi_cmse_nonsecure_call, no_core)]
 #![no_core]
@@ -8,7 +9,7 @@ extern crate minicore;
 use minicore::*;
 
 // A regression test for https://github.com/rust-lang/rust/issues/131639.
-// NOTE: -Cincremental=true was required for triggering the bug.
+// NOTE: `-Cincremental` was required for triggering the bug.
 
 fn foo() {
     id::<extern "cmse-nonsecure-call" fn(&'a ())>(PhantomData);

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-call/undeclared-lifetime.stderr
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-call/undeclared-lifetime.stderr
@@ -1,5 +1,5 @@
 error[E0261]: use of undeclared lifetime name `'a`
-  --> $DIR/undeclared-lifetime.rs:14:43
+  --> $DIR/undeclared-lifetime.rs:15:43
    |
 LL |     id::<extern "cmse-nonsecure-call" fn(&'a ())>(PhantomData);
    |                                           ^^ undeclared lifetime


### PR DESCRIPTION
The funny thing about writing `-Cincremental=true` is that it *does* enable incremental compilation ... using an incremental compilation dir of `./true`.

And for UI tests, that ends up creating a `true` directory in the repository root, which is annoying.

Fortunately, compiletest has an existing `//@ incremental` directive that takes care of creating an empty incremental directory, and passing it to `-Cincremental`.

---

I have manually checked that reverting rust-lang/rust#146649 still causes the updated test to fail.