### PR TITLE
Forbid `//@ compile-flags: -Cincremental=` in tests

### DIFF
--- a/src/tools/compiletest/src/directives.rs
+++ b/src/tools/compiletest/src/directives.rs
@@ -415,9 +415,17 @@ impl TestProps {
                         config.parse_name_value_directive(ln, COMPILE_FLAGS, testfile)
                     {
                         let flags = split_flags(&flags);
-                        for flag in &flags {
+                        for (i, flag) in flags.iter().enumerate() {
                             if flag == "--edition" || flag.starts_with("--edition=") {
                                 panic!("you must use `//@ edition` to configure the edition");
+                            }
+                            if (flag == "-C"
+                                && flags.get(i + 1).is_some_and(|v| v.starts_with("incremental=")))
+                                || flag.starts_with("-Cincremental=")
+                            {
+                                panic!(
+                                    "you must use `//@ incremental` to enable incremental compilation"
+                                );
                             }
                         }
                         self.compile_flags.extend(flags);

--- a/tests/ui/compiletest-self-test/compile-flags-incremental.rs
+++ b/tests/ui/compiletest-self-test/compile-flags-incremental.rs
@@ -1,0 +1,17 @@
+//@ revisions: good bad bad-space
+//@ check-pass
+
+//@[bad] compile-flags: -Cincremental=true
+//@[bad] should-fail
+
+//@[bad-space] compile-flags:  -C  incremental=dir
+//@[bad-space] should-fail
+
+fn main() {}
+
+// Tests should not try to manually enable incremental compilation with
+// `-Cincremental`, because that typically results in stray directories being
+// created in the repository root.
+//
+// Instead, use the `//@ incremental` directive, which instructs compiletest
+// to handle the details of passing `-Cincremental` with a fresh directory.


### PR DESCRIPTION
Tests should not try to manually enable incremental compilation with `-Cincremental`, because that typically results in stray directories being created in the repository root.

Also, if the incremental directory is not cleared, there is a risk of interference between successive runs of the same test.

Instead, use the `//@ incremental` directive, which instructs compiletest to handle the details of passing `-Cincremental` with a fresh directory.
