### PR TITLE
Emscripten: Turn wasm-eh on by default

### DIFF
--- a/compiler/rustc_interface/src/tests.rs
+++ b/compiler/rustc_interface/src/tests.rs
@@ -798,7 +798,7 @@ fn test_unstable_options_tracking_hash() {
     tracked!(embed_metadata, false);
     tracked!(embed_source, true);
     tracked!(emit_thin_lto, false);
-    tracked!(emscripten_wasm_eh, true);
+    tracked!(emscripten_wasm_eh, false);
     tracked!(export_executable_symbols, true);
     tracked!(fewer_names, Some(true));
     tracked!(fixed_x18, true);

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -2338,7 +2338,7 @@ options! {
         "emit a section containing stack size metadata (default: no)"),
     emit_thin_lto: bool = (true, parse_bool, [TRACKED],
         "emit the bc module with thin LTO info (default: yes)"),
-    emscripten_wasm_eh: bool = (false, parse_bool, [TRACKED],
+    emscripten_wasm_eh: bool = (true, parse_bool, [TRACKED],
         "Use WebAssembly error handling for wasm32-unknown-emscripten"),
     enforce_type_length_limit: bool = (false, parse_bool, [TRACKED],
         "enforce the type length limit when monomorphizing instances in codegen"),

--- a/src/doc/rustc/src/platform-support/wasm32-unknown-emscripten.md
+++ b/src/doc/rustc/src/platform-support/wasm32-unknown-emscripten.md
@@ -95,10 +95,11 @@ This target can be cross-compiled from any host.
 ## Emscripten ABI Compatibility
 
 The Emscripten compiler toolchain does not follow a semantic versioning scheme
-that clearly indicates when breaking changes to the ABI can be made. Additionally,
-Emscripten offers many different ABIs even for a single version of Emscripten
-depending on the linker flags used, e.g. `-fexceptions` and `-sWASM_BIGINT`. If
-the ABIs mismatch, your code may exhibit undefined behaviour.
+that clearly indicates when breaking changes to the ABI can be made.
+Additionally, Emscripten offers many different ABIs even for a single version of
+Emscripten depending on the linker flags used, e.g. `-fwasm-exceptions` and
+`-sWASM_BIGINT`. If the ABIs do not match, your code may exhibit undefined
+behaviour.
 
 To ensure that the ABIs of your Rust code, of the Rust standard library, and of
 other code compiled for Emscripten all match, you should rebuild the Rust standard
@@ -158,9 +159,9 @@ features can be disabled, and how Rust code can be conditionally compiled based 
 which features are enabled.
 
 Note that Rust code compiled for `wasm32-unknown-emscripten` currently enables
-`-fexceptions` (JS exceptions) by default unless the Rust code is compiled with
-`-Cpanic=abort`. `-fwasm-exceptions` (WASM exceptions) is not yet currently supported,
-see <https://github.com/rust-lang/rust/issues/112195>.
+`-fwasm-exceptions` (legacy WASM exceptions) by default unless the Rust code is
+compiled with `-Cpanic=abort`. It is possible to use JS exceptions by passing
+the flag ``-Z emscripten-wasm-eh=false`` but this will be removed in the future.
 
 Please refer to the [Emscripten ABI compatibility](#emscripten-abi-compatibility)
 section to ensure that the features that are enabled do not cause an ABI mismatch

--- a/tests/codegen-llvm/emscripten-catch-unwind-js-eh.rs
+++ b/tests/codegen-llvm/emscripten-catch-unwind-js-eh.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: -Copt-level=3 --target wasm32-unknown-emscripten
+//@ compile-flags: -Copt-level=3 --target wasm32-unknown-emscripten -Z emscripten-wasm-eh=false
 //@ needs-llvm-components: webassembly
 
 // Emscripten has its own unique implementation of catch_unwind (in `codegen_emcc_try`),

--- a/tests/ui/feature-gates/feature-gate-cfg-emscripten-wasm-eh.rs
+++ b/tests/ui/feature-gates/feature-gate-cfg-emscripten-wasm-eh.rs
@@ -1,4 +1,4 @@
 //@ compile-flags: --check-cfg=cfg(emscripten_wasm_eh)
-#[cfg(not(emscripten_wasm_eh))]
+#[cfg(emscripten_wasm_eh)]
 //~^ ERROR `cfg(emscripten_wasm_eh)` is experimental
 fn main() {}

--- a/tests/ui/feature-gates/feature-gate-cfg-emscripten-wasm-eh.stderr
+++ b/tests/ui/feature-gates/feature-gate-cfg-emscripten-wasm-eh.stderr
@@ -1,8 +1,8 @@
 error[E0658]: `cfg(emscripten_wasm_eh)` is experimental and subject to change
-  --> $DIR/feature-gate-cfg-emscripten-wasm-eh.rs:2:11
+  --> $DIR/feature-gate-cfg-emscripten-wasm-eh.rs:2:7
    |
-LL | #[cfg(not(emscripten_wasm_eh))]
-   |           ^^^^^^^^^^^^^^^^^^
+LL | #[cfg(emscripten_wasm_eh)]
+   |       ^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(cfg_emscripten_wasm_eh)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date


### PR DESCRIPTION
As specified by [MCP](https://github.com/rust-lang/compiler-team/issues/920)
Resolves https://github.com/rust-lang/rust/issues/148309
Resolves https://github.com/rust-lang/rust/issues/112195
