### PR TITLE
lub instead of relying on structural identity in coerce lub

### DIFF
--- a/tests/ui/coercion/issue-88097.rs
+++ b/tests/ui/coercion/issue-88097.rs
@@ -3,6 +3,9 @@
 // behavior has been fixed.
 
 //@ check-pass
+//@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@[next] compile-flags: -Znext-solver
 
 fn peculiar() -> impl Fn(u8) -> u8 {
     return |x| x + 1


### PR DESCRIPTION
Fixes rust-lang/trait-system-refactor-initiative#233

```rust
fn peculiar() -> impl Fn(u8) -> u8 {
    return |x| x + 1
}
```
the `|x| x + 1` expr has a type of `Closure(?31t)` which we wind up inferring the RPIT to. The `CoerceMany` `ret_coercion` for the whole `peculiar` typeck has an expected type of `RPIT` (unnormalized). When we type check the `return |x| x + 1` expr we go from the never type to `Closure(?31t)` which then participates in the `ret_coercion` giving us a `coerce-lub(RPIT, Closure(?31t))`. 

Normalizing `RPIT` gives us some `Closure(?50t)` where `?31t` and `?50t` have been unified with `?31t` as the root var. `resolve_vars_if_possible` doesn't resolve infer vars to their roots so these wind up with different structural identities so the fast path doesn't apply and we fall back to coercing to a `fn` ptr. cc rust-lang/rust#147193 which also fixes this

New solver probably just gets more inference variables here because canonicalization + generally different approach to normalization of opaques. Idk :3

In theory I feel like using a lub here ought to cause other code to work that currently doesn't :thinking: E.g. if the two types only differ in normalization. I'm not certain about how to construct such an example though :3

r? lcnr