### PR TITLE
Initialize llvm submodule if not already the case to run citool

### DIFF
--- a/src/ci/citool/Cargo.toml
+++ b/src/ci/citool/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "citool"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 anyhow = "1"

--- a/src/ci/citool/src/main.rs
+++ b/src/ci/citool/src/main.rs
@@ -24,7 +24,7 @@ use crate::github::JobInfoResolver;
 use crate::jobs::RunType;
 use crate::metrics::{JobMetrics, download_auto_job_metrics, download_job_metrics, load_metrics};
 use crate::test_dashboard::generate_test_dashboard;
-use crate::utils::{load_env_var, output_details};
+use crate::utils::{init_submodule_if_needed, load_env_var, output_details};
 
 const CI_DIRECTORY: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/..");
 pub const DOCKER_DIRECTORY: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../docker");
@@ -120,6 +120,8 @@ fn run_workflow_locally(db: JobDatabase, job_type: JobType, name: String) -> any
         };
         (key.clone(), value)
     }));
+
+    init_submodule_if_needed("src/llvm-project/")?;
 
     let mut cmd = Command::new(Path::new(DOCKER_DIRECTORY).join("run.sh"));
     cmd.arg(job.image());

--- a/src/ci/citool/src/utils.rs
+++ b/src/ci/citool/src/utils.rs
@@ -1,5 +1,7 @@
 use std::borrow::Cow;
+use std::convert::AsRef;
 use std::path::Path;
+use std::process::Command;
 
 use anyhow::Context;
 
@@ -33,4 +35,20 @@ where
 /// Normalizes Windows-style path delimiters to Unix-style paths.
 pub fn normalize_path_delimiters(name: &str) -> Cow<'_, str> {
     if name.contains("\\") { name.replace('\\', "/").into() } else { name.into() }
+}
+
+pub fn init_submodule_if_needed<P: AsRef<Path>>(path_to_submodule: P) -> anyhow::Result<()> {
+    let path_to_submodule = path_to_submodule.as_ref();
+
+    if let Ok(mut iter) = path_to_submodule.read_dir()
+        && iter.any(|entry| entry.is_ok())
+    {
+        // Seems like the submodule is already initialized, nothing to be done here.
+        return Ok(());
+    }
+    let mut child = Command::new("git")
+        .args(&["submodule", "update", "--init"])
+        .arg(path_to_submodule)
+        .spawn()?;
+    if !child.wait()?.success() { Err(anyhow::anyhow!("git command failed")) } else { Ok(()) }
 }


### PR DESCRIPTION
While working on https://github.com/rust-lang/rust/pull/146414, I ran the following command (to run CI docker locally):

```
cargo run --manifest-path src/ci/citool/Cargo.toml run-local --type pr x86_64-gnu-gcc
```

However, since I didn't have `src/llvm` submodule initialized, it failed. Apparently it's a common issue for people using this tool so this PR removes this small inconvenience.

r? @Kobzol 