### PR TITLE
Add an ACP list item to the library tracking issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/library_tracking_issue.md
+++ b/.github/ISSUE_TEMPLATE/library_tracking_issue.md
@@ -51,6 +51,7 @@ If the feature is changed later, please add those PRs here as well.
 
 (Remember to update the `S-tracking-*` label when checking boxes.)
 
+- [ ] ACP: rust-lang/libs-team#...
 - [ ] Implementation: #...
 - [ ] Final comment period (FCP)[^1]
 - [ ] Stabilization PR


### PR DESCRIPTION
Most new API has an associated ACP that is useful to reference, but it doesn't appear anywhere on the template for new tracking issues. Update this template to include a link to the ACP.