### PR TITLE
Use `#[cfg(debug_assertions)]` instead of `if cfg!(debug_assertions)` for `debug_assert_*` macros

### DIFF
--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -291,7 +291,7 @@ pub macro cfg_select($($tt:tt)*) {
 #[allow_internal_unstable(edition_panic)]
 macro_rules! debug_assert {
     ($($arg:tt)*) => {
-        if $crate::cfg!(debug_assertions) {
+        #[cfg(debug_assertions)] {
             $crate::assert!($($arg)*);
         }
     };
@@ -321,7 +321,7 @@ macro_rules! debug_assert {
 #[rustc_diagnostic_item = "debug_assert_eq_macro"]
 macro_rules! debug_assert_eq {
     ($($arg:tt)*) => {
-        if $crate::cfg!(debug_assertions) {
+        #[cfg(debug_assertions)] {
             $crate::assert_eq!($($arg)*);
         }
     };
@@ -351,7 +351,7 @@ macro_rules! debug_assert_eq {
 #[rustc_diagnostic_item = "debug_assert_ne_macro"]
 macro_rules! debug_assert_ne {
     ($($arg:tt)*) => {
-        if $crate::cfg!(debug_assertions) {
+        #[cfg(debug_assertions)] {
             $crate::assert_ne!($($arg)*);
         }
     };
@@ -403,7 +403,7 @@ macro_rules! debug_assert_ne {
 #[allow_internal_unstable(assert_matches)]
 #[rustc_macro_transparency = "semitransparent"]
 pub macro debug_assert_matches($($arg:tt)*) {
-    if $crate::cfg!(debug_assertions) {
+    #[cfg(debug_assertions)] {
         $crate::assert_matches::assert_matches!($($arg)*);
     }
 }

--- a/tests/ui/macros/debug-assertation-debug-check.rs
+++ b/tests/ui/macros/debug-assertation-debug-check.rs
@@ -1,0 +1,13 @@
+//@ compile-flags: -C opt-level=3
+//@ check-pass
+
+fn main() {
+    let one = Thing;
+    let two = Thing;
+
+    debug_assert_eq!(one, two);
+}
+
+#[derive(Debug)]
+#[cfg_attr(debug_assertions, derive(PartialEq))]
+struct Thing;

--- a/tests/ui/macros/debug-assertation-release-check.rs
+++ b/tests/ui/macros/debug-assertation-release-check.rs
@@ -1,0 +1,13 @@
+//@ compile-flags: -C opt-level=0
+//@ check-pass
+
+fn main() {
+    let one = Thing;
+    let two = Thing;
+
+    debug_assert_eq!(one, two);
+}
+
+#[derive(Debug)]
+#[cfg_attr(debug_assertions, derive(PartialEq))]
+struct Thing;


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Due to limit knowledges about conditional compilation I'm not sure if this is fine change and will not cause any greater problems in future, but seems (according to new test) that is addresses https://github.com/rust-lang/rust/issues/147241 

So, even though it's a small change, it needs a thorough review by someone more tech-savvy

r? libs
