### PR TITLE
Do two passes of `handle_opaque_type_uses_next`

### DIFF
--- a/compiler/rustc_borrowck/src/region_infer/opaque_types/mod.rs
+++ b/compiler/rustc_borrowck/src/region_infer/opaque_types/mod.rs
@@ -155,13 +155,6 @@ fn add_hidden_type<'tcx>(
     }
 }
 
-fn get_hidden_type<'tcx>(
-    hidden_types: &DefinitionSiteHiddenTypes<'tcx>,
-    def_id: LocalDefId,
-) -> Option<EarlyBinder<'tcx, OpaqueHiddenType<'tcx>>> {
-    hidden_types.0.get(&def_id).map(|ty| EarlyBinder::bind(*ty))
-}
-
 #[derive(Debug)]
 struct DefiningUse<'tcx> {
     /// The opaque type using non NLL vars. This uses the actual
@@ -501,7 +494,8 @@ pub(crate) fn apply_definition_site_hidden_types<'tcx>(
     let tcx = infcx.tcx;
     let mut errors = Vec::new();
     for &(key, hidden_type) in opaque_types {
-        let Some(expected) = get_hidden_type(hidden_types, key.def_id) else {
+        let Some(expected) = hidden_types.0.get(&key.def_id).map(|ty| EarlyBinder::bind(*ty))
+        else {
             if !tcx.use_typing_mode_borrowck() {
                 if let ty::Alias(ty::Opaque, alias_ty) = hidden_type.ty.kind()
                     && alias_ty.def_id == key.def_id.to_def_id()

--- a/compiler/rustc_hir_typeck/src/lib.rs
+++ b/compiler/rustc_hir_typeck/src/lib.rs
@@ -219,6 +219,12 @@ fn typeck_with_inspect<'tcx>(
     // the future.
     fcx.check_repeat_exprs();
 
+    // We need to handle opaque types before emitting ambiguity errors as applying
+    // defining uses may guide type inference.
+    if fcx.next_trait_solver() {
+        fcx.try_handle_opaque_type_uses_next();
+    }
+
     fcx.type_inference_fallback();
 
     // Even though coercion casts provide type hints, we check casts after fallback for

--- a/compiler/rustc_hir_typeck/src/opaque_types.rs
+++ b/compiler/rustc_hir_typeck/src/opaque_types.rs
@@ -26,15 +26,15 @@ impl<'tcx> FnCtxt<'_, 'tcx> {
     /// Unlike `handle_opaque_type_uses_next`, this does not report errors.
     #[instrument(level = "debug", skip(self))]
     pub(super) fn try_handle_opaque_type_uses_next(&mut self) {
-        // We clone the opaques instead of stealing them here as they are still used for
-        // normalization in the next generation trait solver.
+        // We clone the opaques instead of stealing them here as we still need
+        // to use them after fallback.
         let mut opaque_types: Vec<_> = self.infcx.clone_opaque_types();
         for entry in &mut opaque_types {
             *entry = self.resolve_vars_if_possible(*entry);
         }
         debug!(?opaque_types);
 
-        self.compute_definition_site_hidden_types(&opaque_types, true);
+        self.compute_definition_site_hidden_types(&opaque_types, false);
     }
 
     /// This takes all the opaque type uses during HIR typeck. It first computes
@@ -58,7 +58,7 @@ impl<'tcx> FnCtxt<'_, 'tcx> {
         }
         debug!(?opaque_types);
 
-        self.compute_definition_site_hidden_types(&opaque_types, false);
+        self.compute_definition_site_hidden_types(&opaque_types, true);
     }
 }
 
@@ -97,7 +97,7 @@ impl<'tcx> FnCtxt<'_, 'tcx> {
     fn compute_definition_site_hidden_types(
         &mut self,
         opaque_types: &[(OpaqueTypeKey<'tcx>, OpaqueHiddenType<'tcx>)],
-        first_pass: bool,
+        error_on_missing_defining_use: bool,
     ) {
         let tcx = self.tcx;
         let TypingMode::Analysis { defining_opaque_types_and_generators } = self.typing_mode()
@@ -138,19 +138,16 @@ impl<'tcx> FnCtxt<'_, 'tcx> {
                     self.demand_eqtype(hidden_type.span, expected, hidden_type.ty);
                 }
 
-                let prev = self.typeck_results.borrow_mut().hidden_types.insert(def_id, ty);
-
-                // We do want to insert opaque types the first pass, because
-                // we want to equate them. So, the second pass (where we
-                // report errors) may have a hidden type inserted.
-                if first_pass {
-                    assert!(prev.is_none());
-                }
+                // Being explicit here: it may be possible that we in a
+                // previous call to this function we did an insert, but this
+                // should be just fine, since they all get equated anyways and
+                // we shouldn't ever go from `HasDefiningUse` to anyway else.
+                let _ = self.typeck_results.borrow_mut().hidden_types.insert(def_id, ty);
             }
 
             // If this the first pass (`try_handle_opaque_type_uses_next`),
             // then do not report any errors.
-            if first_pass {
+            if !error_on_missing_defining_use {
                 continue;
             }
 
@@ -204,7 +201,7 @@ impl<'tcx> FnCtxt<'_, 'tcx> {
 
     #[tracing::instrument(skip(self), ret)]
     fn consider_opaque_type_use(
-        &mut self,
+        &self,
         opaque_type_key: OpaqueTypeKey<'tcx>,
         hidden_type: OpaqueHiddenType<'tcx>,
     ) -> UsageKind<'tcx> {

--- a/tests/ui/traits/next-solver/opaques/hidden-types-equate-before-fallback.rs
+++ b/tests/ui/traits/next-solver/opaques/hidden-types-equate-before-fallback.rs
@@ -6,7 +6,6 @@
 // Regression test for trait-system-refactor-initiative#240. Hidden types should
 // equate *before* inference var fallback, otherwise we can get mismatched types.
 
-
 #[derive(Clone, Copy)]
 struct FileSystem;
 impl FileSystem {

--- a/tests/ui/traits/next-solver/opaques/hidden-types-equate-before-fallback.rs
+++ b/tests/ui/traits/next-solver/opaques/hidden-types-equate-before-fallback.rs
@@ -1,0 +1,27 @@
+//@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@[next] compile-flags: -Znext-solver
+//@ check-pass
+
+// Regression test for trait-system-refactor-initiative#240. Hidden types should
+// equate *before* inference var fallback, otherwise we can get mismatched types.
+
+
+#[derive(Clone, Copy)]
+struct FileSystem;
+impl FileSystem {
+    fn build<T>(self, commands: T) -> Option<impl Sized> {
+        match false {
+            true => Some(commands),
+            false => {
+                drop(match self.build::<_>(commands) {
+                    Some(x) => x,
+                    None => return None,
+                });
+                panic!()
+            },
+        }
+    }
+}
+
+fn main() {}

--- a/tests/ui/traits/next-solver/opaques/hidden-types-equate-before-fallback.rs
+++ b/tests/ui/traits/next-solver/opaques/hidden-types-equate-before-fallback.rs
@@ -23,4 +23,22 @@ impl FileSystem {
     }
 }
 
+fn build2<T, U>() -> impl Sized {
+    if false {
+        build2::<U, T>()
+    } else {
+        loop {}
+    };
+    1u32
+}
+
+fn build3<'a>() -> impl Sized + use<'a> {
+    if false {
+        build3()
+    } else {
+        loop {}
+    };
+    1u32
+}
+
 fn main() {}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/trait-system-refactor-initiative/issues/240

Also did a little bit of cleanup, can squash the commits if decided.

r? lcnr