### PR TITLE
Optimize `checked_ilog` and `pow` when `base` is a power of two

### DIFF
--- a/library/core/src/num/imp/overflow_panic.rs
+++ b/library/core/src/num/imp/overflow_panic.rs
@@ -52,6 +52,12 @@ pub(in crate::num) const fn shl() -> ! {
 
 #[cold]
 #[track_caller]
+pub(in crate::num) const fn pow() -> ! {
+    panic!("attempt to exponentiate with overflow")
+}
+
+#[cold]
+#[track_caller]
 pub(in crate::num) const fn cast_integer() -> ! {
     panic!("attempt to cast integer with overflow")
 }

--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -1851,6 +1851,22 @@ macro_rules! int_impl {
             let mut base = self;
             let mut acc: Self = 1;
 
+            if intrinsics::is_val_statically_known(exp) {
+                while exp > 1 {
+                    if (exp & 1) == 1 {
+                        acc = try_opt!(acc.checked_mul(base));
+                    }
+                    exp /= 2;
+                    base = try_opt!(base.checked_mul(base));
+                }
+
+                // since exp!=0, finally the exp must be 1.
+                // Deal with the final bit of the exponent separately, since
+                // squaring the base afterwards is not necessary and may cause a
+                // needless overflow.
+                return acc.checked_mul(base);
+            }
+
             loop {
                 if (exp & 1) == 1 {
                     acc = try_opt!(acc.checked_mul(base));
@@ -3088,6 +3104,26 @@ macro_rules! int_impl {
             let mut acc: Self = 1;
             let mut overflow = false;
             let mut tmp_overflow;
+
+            if intrinsics::is_val_statically_known(exp) {
+                while exp > 1 {
+                    if (exp & 1) == 1 {
+                        (acc, tmp_overflow) = acc.overflowing_mul(base);
+                        overflow |= tmp_overflow;
+                    }
+                    exp /= 2;
+                    (base, tmp_overflow) = base.overflowing_mul(base);
+                    overflow |= tmp_overflow;
+                }
+
+                // since exp!=0, finally the exp must be 1.
+                // Deal with the final bit of the exponent separately, since
+                // squaring the base afterwards is not necessary and may cause a
+                // needless overflow.
+                (acc, tmp_overflow) = acc.overflowing_mul(base);
+                overflow |= tmp_overflow;
+                return (acc, overflow);
+            }
 
             loop {
                 if (exp & 1) == 1 {

--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -1891,23 +1891,10 @@ macro_rules! int_impl {
                       without modifying the original"]
         #[inline]
         #[track_caller]
-        pub const fn strict_pow(self, mut exp: u32) -> Self {
-            if exp == 0 {
-                return 1;
-            }
-            let mut base = self;
-            let mut acc: Self = 1;
-
-            loop {
-                if (exp & 1) == 1 {
-                    acc = acc.strict_mul(base);
-                    // since exp!=0, finally the exp must be 1.
-                    if exp == 1 {
-                        return acc;
-                    }
-                }
-                exp /= 2;
-                base = base.strict_mul(base);
+        pub const fn strict_pow(self, exp: u32) -> Self {
+            match self.checked_pow(exp) {
+                Some(x) => x,
+                None => imp::overflow_panic::pow(),
             }
         }
 
@@ -2526,43 +2513,9 @@ macro_rules! int_impl {
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]
-        pub const fn wrapping_pow(self, mut exp: u32) -> Self {
-            if exp == 0 {
-                return 1;
-            }
-            let mut base = self;
-            let mut acc: Self = 1;
-
-            if intrinsics::is_val_statically_known(exp) {
-                while exp > 1 {
-                    if (exp & 1) == 1 {
-                        acc = acc.wrapping_mul(base);
-                    }
-                    exp /= 2;
-                    base = base.wrapping_mul(base);
-                }
-
-                // since exp!=0, finally the exp must be 1.
-                // Deal with the final bit of the exponent separately, since
-                // squaring the base afterwards is not necessary.
-                acc.wrapping_mul(base)
-            } else {
-                // This is faster than the above when the exponent is not known
-                // at compile time. We can't use the same code for the constant
-                // exponent case because LLVM is currently unable to unroll
-                // this loop.
-                loop {
-                    if (exp & 1) == 1 {
-                        acc = acc.wrapping_mul(base);
-                        // since exp!=0, finally the exp must be 1.
-                        if exp == 1 {
-                            return acc;
-                        }
-                    }
-                    exp /= 2;
-                    base = base.wrapping_mul(base);
-                }
-            }
+        pub const fn wrapping_pow(self, exp: u32) -> Self {
+            let (a, _) = self.overflowing_pow(exp);
+            a
         }
 
         /// Calculates `self` + `rhs`.
@@ -3128,29 +3081,26 @@ macro_rules! int_impl {
         #[inline]
         pub const fn overflowing_pow(self, mut exp: u32) -> (Self, bool) {
             if exp == 0 {
-                return (1,false);
+                return (1, false);
             }
+
             let mut base = self;
             let mut acc: Self = 1;
-            let mut overflown = false;
-            // Scratch space for storing results of overflowing_mul.
-            let mut r;
+            let mut overflow = false;
+            let mut tmp_overflow;
 
             loop {
                 if (exp & 1) == 1 {
-                    r = acc.overflowing_mul(base);
+                    (acc, tmp_overflow) = acc.overflowing_mul(base);
+                    overflow |= tmp_overflow;
                     // since exp!=0, finally the exp must be 1.
                     if exp == 1 {
-                        r.1 |= overflown;
-                        return r;
+                        return (acc, overflow);
                     }
-                    acc = r.0;
-                    overflown |= r.1;
                 }
                 exp /= 2;
-                r = base.overflowing_mul(base);
-                base = r.0;
-                overflown |= r.1;
+                (base, tmp_overflow) = base.overflowing_mul(base);
+                overflow |= tmp_overflow;
             }
         }
 
@@ -3170,43 +3120,11 @@ macro_rules! int_impl {
                       without modifying the original"]
         #[inline]
         #[rustc_inherit_overflow_checks]
-        pub const fn pow(self, mut exp: u32) -> Self {
-            if exp == 0 {
-                return 1;
-            }
-            let mut base = self;
-            let mut acc = 1;
-
-            if intrinsics::is_val_statically_known(exp) {
-                while exp > 1 {
-                    if (exp & 1) == 1 {
-                        acc = acc * base;
-                    }
-                    exp /= 2;
-                    base = base * base;
-                }
-
-                // since exp!=0, finally the exp must be 1.
-                // Deal with the final bit of the exponent separately, since
-                // squaring the base afterwards is not necessary and may cause a
-                // needless overflow.
-                acc * base
+        pub const fn pow(self, exp: u32) -> Self {
+            if intrinsics::overflow_checks() {
+                self.strict_pow(exp)
             } else {
-                // This is faster than the above when the exponent is not known
-                // at compile time. We can't use the same code for the constant
-                // exponent case because LLVM is currently unable to unroll
-                // this loop.
-                loop {
-                    if (exp & 1) == 1 {
-                        acc = acc * base;
-                        // since exp!=0, finally the exp must be 1.
-                        if exp == 1 {
-                            return acc;
-                        }
-                    }
-                    exp /= 2;
-                    base = base * base;
-                }
+                self.wrapping_pow(exp)
             }
         }
 

--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -1845,11 +1845,22 @@ macro_rules! int_impl {
                       without modifying the original"]
         #[inline]
         pub const fn checked_pow(self, mut exp: u32) -> Option<Self> {
+            let mut base = self;
+            let mut acc: Self = 1;
+
+            if intrinsics::is_val_statically_known(base) && base.unsigned_abs().is_power_of_two() {
+                let k = base.unsigned_abs().ilog2();
+                let shift = try_opt!(k.checked_mul(exp));
+                return if base < 0 && (exp % 2) == 1 {
+                    (-1 as Self).shl_exact(shift)
+                } else {
+                    (1 as Self).shl_exact(shift)
+                }
+            }
+
             if exp == 0 {
                 return Some(1);
             }
-            let mut base = self;
-            let mut acc: Self = 1;
 
             if intrinsics::is_val_statically_known(exp) {
                 while exp > 1 {
@@ -3096,14 +3107,23 @@ macro_rules! int_impl {
                       without modifying the original"]
         #[inline]
         pub const fn overflowing_pow(self, mut exp: u32) -> (Self, bool) {
-            if exp == 0 {
-                return (1, false);
-            }
-
             let mut base = self;
             let mut acc: Self = 1;
             let mut overflow = false;
             let mut tmp_overflow;
+
+            if intrinsics::is_val_statically_known(base) && base.unsigned_abs().is_power_of_two() {
+                let k = base.unsigned_abs().ilog2();
+                let Some(shift) = k.checked_mul(exp) else {
+                    return (0, true)
+                };
+                let base: Self = if base < 0 && (exp % 2) != 0 { -1 } else { 1 };
+                return (base.unbounded_shl(shift), base.shl_exact(shift).is_none());
+            }
+
+            if exp == 0 {
+                return (1, false);
+            }
 
             if intrinsics::is_val_statically_known(exp) {
                 while exp > 1 {

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -2373,6 +2373,22 @@ macro_rules! uint_impl {
             let mut base = self;
             let mut acc: Self = 1;
 
+            if intrinsics::is_val_statically_known(exp) {
+                while exp > 1 {
+                    if (exp & 1) == 1 {
+                        acc = try_opt!(acc.checked_mul(base));
+                    }
+                    exp /= 2;
+                    base = try_opt!(base.checked_mul(base));
+                }
+
+                // since exp!=0, finally the exp must be 1.
+                // Deal with the final bit of the exponent separately, since
+                // squaring the base afterwards is not necessary and may cause a
+                // needless overflow.
+                return acc.checked_mul(base);
+            }
+
             loop {
                 if (exp & 1) == 1 {
                     acc = try_opt!(acc.checked_mul(base));
@@ -3557,6 +3573,26 @@ macro_rules! uint_impl {
             let mut acc: Self = 1;
             let mut overflow = false;
             let mut tmp_overflow;
+
+            if intrinsics::is_val_statically_known(exp) {
+                while exp > 1 {
+                    if (exp & 1) == 1 {
+                        (acc, tmp_overflow) = acc.overflowing_mul(base);
+                        overflow |= tmp_overflow;
+                    }
+                    exp /= 2;
+                    (base, tmp_overflow) = base.overflowing_mul(base);
+                    overflow |= tmp_overflow;
+                }
+
+                // since exp!=0, finally the exp must be 1.
+                // Deal with the final bit of the exponent separately, since
+                // squaring the base afterwards is not necessary and may cause a
+                // needless overflow.
+                (acc, tmp_overflow) = acc.overflowing_mul(base);
+                overflow |= tmp_overflow;
+                return (acc, overflow);
+            }
 
             loop {
                 if (exp & 1) == 1 {

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -2367,11 +2367,23 @@ macro_rules! uint_impl {
                       without modifying the original"]
         #[inline]
         pub const fn checked_pow(self, mut exp: u32) -> Option<Self> {
+            let mut base = self;
+            let mut acc: Self = 1;
+
+            if intrinsics::is_val_statically_known(base) && base.is_power_of_two() {
+                // change of base:
+                // if base == 2 ** k, then
+                //    (2 ** k) ** n
+                // == 2 ** (k * n)
+                // == 1 << (k * n)
+                let k = base.ilog2();
+                let shift = try_opt!(k.checked_mul(exp));
+                return (1 as Self).checked_shl(shift);
+            }
+
             if exp == 0 {
                 return Some(1);
             }
-            let mut base = self;
-            let mut acc: Self = 1;
 
             if intrinsics::is_val_statically_known(exp) {
                 while exp > 1 {
@@ -3566,13 +3578,27 @@ macro_rules! uint_impl {
                       without modifying the original"]
         #[inline]
         pub const fn overflowing_pow(self, mut exp: u32) -> (Self, bool) {
-            if exp == 0 {
-                return (1, false);
-            }
             let mut base = self;
             let mut acc: Self = 1;
             let mut overflow = false;
             let mut tmp_overflow;
+
+            if intrinsics::is_val_statically_known(base) && base.is_power_of_two() {
+                // change of base:
+                // if base == 2 ** k, then
+                //    (2 ** k) ** n
+                // == 2 ** (k * n)
+                // == 1 << (k * n)
+                let k = base.ilog2();
+                let Some(shift) = k.checked_mul(exp) else {
+                    return (0, true)
+                };
+                return ((1 as Self).unbounded_shl(shift), shift >= Self::BITS)
+            }
+
+            if exp == 0 {
+                return (1, false);
+            }
 
             if intrinsics::is_val_statically_known(exp) {
                 while exp > 1 {

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -1823,6 +1823,10 @@ macro_rules! uint_impl {
         ///
         /// ```
         #[doc = concat!("assert_eq!(5", stringify!($SelfT), ".checked_ilog(5), Some(1));")]
+        #[doc = concat!("assert_eq!(4", stringify!($SelfT), ".checked_ilog(5), Some(0));")]
+        #[doc = concat!("assert_eq!(5", stringify!($SelfT), ".checked_ilog(0), None);")]
+        #[doc = concat!("assert_eq!(5", stringify!($SelfT), ".checked_ilog(1), None);")]
+        #[doc = concat!("assert_eq!(0", stringify!($SelfT), ".checked_ilog(1), None);")]
         /// ```
         #[stable(feature = "int_log", since = "1.67.0")]
         #[rustc_const_stable(feature = "int_log", since = "1.67.0")]
@@ -1837,9 +1841,14 @@ macro_rules! uint_impl {
             // applied by the compiler. If you want those specific bases,
             // use `.checked_ilog2()` or `.checked_ilog10()` directly.
             if core::intrinsics::is_val_statically_known(base) {
-                if base == 2 {
-                    return self.checked_ilog2();
-                } else if base == 10 {
+                // change of base:
+                // if base == 2 ** k, then
+                // log(base, n) == log(2, n) / k
+                if base.is_power_of_two() && base > 1 {
+                    let k = base.ilog2();
+                    return Some(try_opt!(self.checked_ilog2()) / k);
+                }
+                if base == 10 {
                     return self.checked_ilog10();
                 }
             }

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -2413,23 +2413,10 @@ macro_rules! uint_impl {
                       without modifying the original"]
         #[inline]
         #[track_caller]
-        pub const fn strict_pow(self, mut exp: u32) -> Self {
-            if exp == 0 {
-                return 1;
-            }
-            let mut base = self;
-            let mut acc: Self = 1;
-
-            loop {
-                if (exp & 1) == 1 {
-                    acc = acc.strict_mul(base);
-                    // since exp!=0, finally the exp must be 1.
-                    if exp == 1 {
-                        return acc;
-                    }
-                }
-                exp /= 2;
-                base = base.strict_mul(base);
+        pub const fn strict_pow(self, exp: u32) -> Self {
+            match self.checked_pow(exp) {
+                None => imp::overflow_panic::pow(),
+                Some(a) => a,
             }
         }
 
@@ -2919,43 +2906,9 @@ macro_rules! uint_impl {
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]
-        pub const fn wrapping_pow(self, mut exp: u32) -> Self {
-            if exp == 0 {
-                return 1;
-            }
-            let mut base = self;
-            let mut acc: Self = 1;
-
-            if intrinsics::is_val_statically_known(exp) {
-                while exp > 1 {
-                    if (exp & 1) == 1 {
-                        acc = acc.wrapping_mul(base);
-                    }
-                    exp /= 2;
-                    base = base.wrapping_mul(base);
-                }
-
-                // since exp!=0, finally the exp must be 1.
-                // Deal with the final bit of the exponent separately, since
-                // squaring the base afterwards is not necessary.
-                acc.wrapping_mul(base)
-            } else {
-                // This is faster than the above when the exponent is not known
-                // at compile time. We can't use the same code for the constant
-                // exponent case because LLVM is currently unable to unroll
-                // this loop.
-                loop {
-                    if (exp & 1) == 1 {
-                        acc = acc.wrapping_mul(base);
-                        // since exp!=0, finally the exp must be 1.
-                        if exp == 1 {
-                            return acc;
-                        }
-                    }
-                    exp /= 2;
-                    base = base.wrapping_mul(base);
-                }
-            }
+        pub const fn wrapping_pow(self, exp: u32) -> Self {
+            let (a, _) = self.overflowing_pow(exp);
+            a
         }
 
         /// Calculates `self` + `rhs`.
@@ -3597,30 +3550,26 @@ macro_rules! uint_impl {
                       without modifying the original"]
         #[inline]
         pub const fn overflowing_pow(self, mut exp: u32) -> (Self, bool) {
-            if exp == 0{
-                return (1,false);
+            if exp == 0 {
+                return (1, false);
             }
             let mut base = self;
             let mut acc: Self = 1;
-            let mut overflown = false;
-            // Scratch space for storing results of overflowing_mul.
-            let mut r;
+            let mut overflow = false;
+            let mut tmp_overflow;
 
             loop {
                 if (exp & 1) == 1 {
-                    r = acc.overflowing_mul(base);
+                    (acc, tmp_overflow) = acc.overflowing_mul(base);
+                    overflow |= tmp_overflow;
                     // since exp!=0, finally the exp must be 1.
                     if exp == 1 {
-                        r.1 |= overflown;
-                        return r;
+                        return (acc, overflow);
                     }
-                    acc = r.0;
-                    overflown |= r.1;
                 }
                 exp /= 2;
-                r = base.overflowing_mul(base);
-                base = r.0;
-                overflown |= r.1;
+                (base, tmp_overflow) = base.overflowing_mul(base);
+                overflow |= tmp_overflow;
             }
         }
 
@@ -3638,43 +3587,11 @@ macro_rules! uint_impl {
                       without modifying the original"]
         #[inline]
         #[rustc_inherit_overflow_checks]
-        pub const fn pow(self, mut exp: u32) -> Self {
-            if exp == 0 {
-                return 1;
-            }
-            let mut base = self;
-            let mut acc = 1;
-
-            if intrinsics::is_val_statically_known(exp) {
-                while exp > 1 {
-                    if (exp & 1) == 1 {
-                        acc = acc * base;
-                    }
-                    exp /= 2;
-                    base = base * base;
-                }
-
-                // since exp!=0, finally the exp must be 1.
-                // Deal with the final bit of the exponent separately, since
-                // squaring the base afterwards is not necessary and may cause a
-                // needless overflow.
-                acc * base
+        pub const fn pow(self, exp: u32) -> Self {
+            if intrinsics::overflow_checks() {
+                self.strict_pow(exp)
             } else {
-                // This is faster than the above when the exponent is not known
-                // at compile time. We can't use the same code for the constant
-                // exponent case because LLVM is currently unable to unroll
-                // this loop.
-                loop {
-                    if (exp & 1) == 1 {
-                        acc = acc * base;
-                        // since exp!=0, finally the exp must be 1.
-                        if exp == 1 {
-                            return acc;
-                        }
-                    }
-                    exp /= 2;
-                    base = base * base;
-                }
+                self.wrapping_pow(exp)
             }
         }
 

--- a/library/coretests/tests/num/int_macros.rs
+++ b/library/coretests/tests/num/int_macros.rs
@@ -318,49 +318,290 @@ macro_rules! int_module {
 
             fn test_pow() {
                 {
-                    const R: $T = 2;
-                    assert_eq_const_safe!($T: R.pow(2), 4 as $T);
-                    assert_eq_const_safe!($T: R.pow(0), 1 as $T);
-                    assert_eq_const_safe!($T: R.wrapping_pow(2), 4 as $T);
+                    const R: $T = 0;
                     assert_eq_const_safe!($T: R.wrapping_pow(0), 1 as $T);
-                    assert_eq_const_safe!(Option<$T>: R.checked_pow(2), Some(4 as $T));
+                    assert_eq_const_safe!($T: R.wrapping_pow(1), 0 as $T);
+                    assert_eq_const_safe!($T: R.wrapping_pow(2), 0 as $T);
+                    assert_eq_const_safe!($T: R.wrapping_pow($T::BITS - 1), 0 as $T);
+                    assert_eq_const_safe!($T: R.wrapping_pow($T::BITS), 0 as $T);
+                    assert_eq_const_safe!($T: R.wrapping_pow($T::BITS + 1), 0 as $T);
+                    assert_eq_const_safe!($T: R.wrapping_pow(128), 0 as $T);
+                    assert_eq_const_safe!($T: R.wrapping_pow(129), 0 as $T);
+
                     assert_eq_const_safe!(Option<$T>: R.checked_pow(0), Some(1 as $T));
-                    assert_eq_const_safe!(($T, bool): R.overflowing_pow(2), (4 as $T, false));
+                    assert_eq_const_safe!(Option<$T>: R.checked_pow(1), Some(0 as $T));
+                    assert_eq_const_safe!(Option<$T>: R.checked_pow(2), Some(0 as $T));
+                    assert_eq_const_safe!(Option<$T>: R.checked_pow($T::BITS - 1), Some(0 as $T));
+                    assert_eq_const_safe!(Option<$T>: R.checked_pow($T::BITS), Some(0 as $T));
+                    assert_eq_const_safe!(Option<$T>: R.checked_pow($T::BITS + 1), Some(0 as $T));
+                    assert_eq_const_safe!(Option<$T>: R.checked_pow(128), Some(0 as $T));
+                    assert_eq_const_safe!(Option<$T>: R.checked_pow(129), Some(0 as $T));
+
                     assert_eq_const_safe!(($T, bool): R.overflowing_pow(0), (1 as $T, false));
-                    assert_eq_const_safe!($T: R.saturating_pow(2), 4 as $T);
+                    assert_eq_const_safe!(($T, bool): R.overflowing_pow(1), (0 as $T, false));
+                    assert_eq_const_safe!(($T, bool): R.overflowing_pow(2), (0 as $T, false));
+                    assert_eq_const_safe!(($T, bool): R.overflowing_pow($T::BITS - 1), (0 as $T, false));
+                    assert_eq_const_safe!(($T, bool): R.overflowing_pow($T::BITS), (0 as $T, false));
+                    assert_eq_const_safe!(($T, bool): R.overflowing_pow($T::BITS + 1), (0 as $T, false));
+                    assert_eq_const_safe!(($T, bool): R.overflowing_pow(128), (0 as $T, false));
+                    assert_eq_const_safe!(($T, bool): R.overflowing_pow(129), (0 as $T, false));
+
                     assert_eq_const_safe!($T: R.saturating_pow(0), 1 as $T);
+                    assert_eq_const_safe!($T: R.saturating_pow(1), 0 as $T);
+                    assert_eq_const_safe!($T: R.saturating_pow(2), 0 as $T);
+                    assert_eq_const_safe!($T: R.saturating_pow($T::BITS - 1), 0 as $T);
+                    assert_eq_const_safe!($T: R.saturating_pow($T::BITS), 0 as $T);
+                    assert_eq_const_safe!($T: R.saturating_pow($T::BITS + 1), 0 as $T);
+                    assert_eq_const_safe!($T: R.saturating_pow(128), 0 as $T);
+                    assert_eq_const_safe!($T: R.saturating_pow(129), 0 as $T);
                 }
 
                 {
-                    const R: $T = MAX;
-                    // use `^` to represent .pow() with no overflow.
-                    // if itest::MAX == 2^j-1, then itest is a `j` bit int,
-                    // so that `itest::MAX*itest::MAX == 2^(2*j)-2^(j+1)+1`,
-                    // thussaturating_pow the overflowing result is exactly 1.
+                    const R: $T = 1;
+                    assert_eq_const_safe!($T: R.wrapping_pow(0), 1 as $T);
+                    assert_eq_const_safe!($T: R.wrapping_pow(1), 1 as $T);
                     assert_eq_const_safe!($T: R.wrapping_pow(2), 1 as $T);
-                    assert_eq_const_safe!(Option<$T>: R.checked_pow(2), None);
-                    assert_eq_const_safe!(($T, bool): R.overflowing_pow(2), (1 as $T, true));
-                    assert_eq_const_safe!($T: R.saturating_pow(2), MAX);
+                    assert_eq_const_safe!($T: R.wrapping_pow($T::BITS - 1), 1 as $T);
+                    assert_eq_const_safe!($T: R.wrapping_pow($T::BITS), 1 as $T);
+                    assert_eq_const_safe!($T: R.wrapping_pow($T::BITS + 1), 1 as $T);
+                    assert_eq_const_safe!($T: R.wrapping_pow(128), 1 as $T);
+                    assert_eq_const_safe!($T: R.wrapping_pow(129), 1 as $T);
+
+                    assert_eq_const_safe!(Option<$T>: R.checked_pow(0), Some(1 as $T));
+                    assert_eq_const_safe!(Option<$T>: R.checked_pow(1), Some(1 as $T));
+                    assert_eq_const_safe!(Option<$T>: R.checked_pow(2), Some(1 as $T));
+                    assert_eq_const_safe!(Option<$T>: R.checked_pow($T::BITS - 1), Some(1 as $T));
+                    assert_eq_const_safe!(Option<$T>: R.checked_pow($T::BITS), Some(1 as $T));
+                    assert_eq_const_safe!(Option<$T>: R.checked_pow($T::BITS + 1), Some(1 as $T));
+                    assert_eq_const_safe!(Option<$T>: R.checked_pow(128), Some(1 as $T));
+                    assert_eq_const_safe!(Option<$T>: R.checked_pow(129), Some(1 as $T));
+
+                    assert_eq_const_safe!(($T, bool): R.overflowing_pow(0), (1 as $T, false));
+                    assert_eq_const_safe!(($T, bool): R.overflowing_pow(1), (1 as $T, false));
+                    assert_eq_const_safe!(($T, bool): R.overflowing_pow(2), (1 as $T, false));
+                    assert_eq_const_safe!(($T, bool): R.overflowing_pow($T::BITS - 1), (1 as $T, false));
+                    assert_eq_const_safe!(($T, bool): R.overflowing_pow($T::BITS), (1 as $T, false));
+                    assert_eq_const_safe!(($T, bool): R.overflowing_pow($T::BITS + 1), (1 as $T, false));
+                    assert_eq_const_safe!(($T, bool): R.overflowing_pow(128), (1 as $T, false));
+                    assert_eq_const_safe!(($T, bool): R.overflowing_pow(129), (1 as $T, false));
+
+                    assert_eq_const_safe!($T: R.saturating_pow(0), 1 as $T);
+                    assert_eq_const_safe!($T: R.saturating_pow(1), 1 as $T);
+                    assert_eq_const_safe!($T: R.saturating_pow(2), 1 as $T);
+                    assert_eq_const_safe!($T: R.saturating_pow($T::BITS - 1), 1 as $T);
+                    assert_eq_const_safe!($T: R.saturating_pow($T::BITS), 1 as $T);
+                    assert_eq_const_safe!($T: R.saturating_pow($T::BITS + 1), 1 as $T);
+                    assert_eq_const_safe!($T: R.saturating_pow(128), 1 as $T);
+                    assert_eq_const_safe!($T: R.saturating_pow(129), 1 as $T);
                 }
 
                 {
-                    // test for negative exponent.
-                    const R: $T = -2;
-                    assert_eq_const_safe!($T: R.pow(2), 4 as $T);
-                    assert_eq_const_safe!($T: R.pow(3), -8 as $T);
-                    assert_eq_const_safe!($T: R.pow(0), 1 as $T);
-                    assert_eq_const_safe!($T: R.wrapping_pow(2), 4 as $T);
-                    assert_eq_const_safe!($T: R.wrapping_pow(3), -8 as $T);
+                    const R: $T = -1;
                     assert_eq_const_safe!($T: R.wrapping_pow(0), 1 as $T);
-                    assert_eq_const_safe!(Option<$T>: R.checked_pow(2), Some(4 as $T));
-                    assert_eq_const_safe!(Option<$T>: R.checked_pow(3), Some(-8 as $T));
+                    assert_eq_const_safe!($T: R.wrapping_pow(1), -1 as $T);
+                    assert_eq_const_safe!($T: R.wrapping_pow(2), 1 as $T);
+                    assert_eq_const_safe!($T: R.wrapping_pow($T::BITS - 1), -1 as $T);
+                    assert_eq_const_safe!($T: R.wrapping_pow($T::BITS), 1 as $T);
+                    assert_eq_const_safe!($T: R.wrapping_pow($T::BITS + 1), -1 as $T);
+                    assert_eq_const_safe!($T: R.wrapping_pow(128), 1 as $T);
+                    assert_eq_const_safe!($T: R.wrapping_pow(129), -1 as $T);
+
                     assert_eq_const_safe!(Option<$T>: R.checked_pow(0), Some(1 as $T));
-                    assert_eq_const_safe!(($T, bool): R.overflowing_pow(2), (4 as $T, false));
-                    assert_eq_const_safe!(($T, bool): R.overflowing_pow(3), (-8 as $T, false));
+                    assert_eq_const_safe!(Option<$T>: R.checked_pow(1), Some(-1 as $T));
+                    assert_eq_const_safe!(Option<$T>: R.checked_pow(2), Some(1 as $T));
+                    assert_eq_const_safe!(Option<$T>: R.checked_pow($T::BITS - 1), Some(-1 as $T));
+                    assert_eq_const_safe!(Option<$T>: R.checked_pow($T::BITS), Some(1 as $T));
+                    assert_eq_const_safe!(Option<$T>: R.checked_pow($T::BITS + 1), Some(-1 as $T));
+                    assert_eq_const_safe!(Option<$T>: R.checked_pow(128), Some(1 as $T));
+                    assert_eq_const_safe!(Option<$T>: R.checked_pow(129), Some(-1 as $T));
+
                     assert_eq_const_safe!(($T, bool): R.overflowing_pow(0), (1 as $T, false));
-                    assert_eq_const_safe!($T: R.saturating_pow(2), 4 as $T);
-                    assert_eq_const_safe!($T: R.saturating_pow(3), -8 as $T);
+                    assert_eq_const_safe!(($T, bool): R.overflowing_pow(1), (-1 as $T, false));
+                    assert_eq_const_safe!(($T, bool): R.overflowing_pow(2), (1 as $T, false));
+                    assert_eq_const_safe!(($T, bool): R.overflowing_pow($T::BITS - 1), (-1 as $T, false));
+                    assert_eq_const_safe!(($T, bool): R.overflowing_pow($T::BITS), (1 as $T, false));
+                    assert_eq_const_safe!(($T, bool): R.overflowing_pow($T::BITS + 1), (-1 as $T, false));
+                    assert_eq_const_safe!(($T, bool): R.overflowing_pow(128), (1 as $T, false));
+                    assert_eq_const_safe!(($T, bool): R.overflowing_pow(129), (-1 as $T, false));
+
                     assert_eq_const_safe!($T: R.saturating_pow(0), 1 as $T);
+                    assert_eq_const_safe!($T: R.saturating_pow(1), -1 as $T);
+                    assert_eq_const_safe!($T: R.saturating_pow(2), 1 as $T);
+                    assert_eq_const_safe!($T: R.saturating_pow($T::BITS - 1), -1 as $T);
+                    assert_eq_const_safe!($T: R.saturating_pow($T::BITS), 1 as $T);
+                    assert_eq_const_safe!($T: R.saturating_pow($T::BITS + 1), -1 as $T);
+                    assert_eq_const_safe!($T: R.saturating_pow(128), 1 as $T);
+                    assert_eq_const_safe!($T: R.saturating_pow(129), -1 as $T);
+                }
+
+                {
+                    const R: $T = 2;
+                    assert_eq_const_safe!($T: R.wrapping_pow(0), 1 as $T);
+                    assert_eq_const_safe!($T: R.wrapping_pow(1), 2 as $T);
+                    assert_eq_const_safe!($T: R.wrapping_pow(2), 4 as $T);
+                    assert_eq_const_safe!($T: R.wrapping_pow($T::BITS - 1), $T::MIN);
+                    assert_eq_const_safe!($T: R.wrapping_pow($T::BITS), 0 as $T);
+                    assert_eq_const_safe!($T: R.wrapping_pow($T::BITS + 1), 0 as $T);
+                    assert_eq_const_safe!($T: R.wrapping_pow(128), 0 as $T);
+                    assert_eq_const_safe!($T: R.wrapping_pow(129), 0 as $T);
+
+                    assert_eq_const_safe!(Option<$T>: R.checked_pow(0), Some(1 as $T));
+                    assert_eq_const_safe!(Option<$T>: R.checked_pow(1), Some(2 as $T));
+                    assert_eq_const_safe!(Option<$T>: R.checked_pow(2), Some(4 as $T));
+                    assert_eq_const_safe!(Option<$T>: R.checked_pow($T::BITS - 1), None);
+                    assert_eq_const_safe!(Option<$T>: R.checked_pow($T::BITS), None);
+                    assert_eq_const_safe!(Option<$T>: R.checked_pow($T::BITS + 1), None);
+                    assert_eq_const_safe!(Option<$T>: R.checked_pow(128), None);
+                    assert_eq_const_safe!(Option<$T>: R.checked_pow(129), None);
+
+                    assert_eq_const_safe!(($T, bool): R.overflowing_pow(0), (1 as $T, false));
+                    assert_eq_const_safe!(($T, bool): R.overflowing_pow(1), (2 as $T, false));
+                    assert_eq_const_safe!(($T, bool): R.overflowing_pow(2), (4 as $T, false));
+                    assert_eq_const_safe!(($T, bool): R.overflowing_pow($T::BITS - 1), ($T::MIN, true));
+                    assert_eq_const_safe!(($T, bool): R.overflowing_pow($T::BITS), (0 as $T, true));
+                    assert_eq_const_safe!(($T, bool): R.overflowing_pow($T::BITS + 1), (0 as $T, true));
+                    assert_eq_const_safe!(($T, bool): R.overflowing_pow(128), (0 as $T, true));
+                    assert_eq_const_safe!(($T, bool): R.overflowing_pow(129), (0 as $T, true));
+
+                    assert_eq_const_safe!($T: R.saturating_pow(0), 1 as $T);
+                    assert_eq_const_safe!($T: R.saturating_pow(1), 2 as $T);
+                    assert_eq_const_safe!($T: R.saturating_pow(2), 4 as $T);
+                    assert_eq_const_safe!($T: R.saturating_pow($T::BITS - 1), $T::MAX);
+                    assert_eq_const_safe!($T: R.saturating_pow($T::BITS), $T::MAX);
+                    assert_eq_const_safe!($T: R.saturating_pow($T::BITS + 1), $T::MAX);
+                    assert_eq_const_safe!($T: R.saturating_pow(128), $T::MAX);
+                    assert_eq_const_safe!($T: R.saturating_pow(129), $T::MAX);
+                }
+
+                {
+                    const R: $T = -2;
+                    assert_eq_const_safe!($T: R.wrapping_pow(0), 1 as $T);
+                    assert_eq_const_safe!($T: R.wrapping_pow(1), -2 as $T);
+                    assert_eq_const_safe!($T: R.wrapping_pow(2), 4 as $T);
+                    assert_eq_const_safe!($T: R.wrapping_pow($T::BITS - 1), $T::MIN);
+                    assert_eq_const_safe!($T: R.wrapping_pow($T::BITS), 0 as $T);
+                    assert_eq_const_safe!($T: R.wrapping_pow($T::BITS + 1), 0 as $T);
+                    assert_eq_const_safe!($T: R.wrapping_pow(128), 0 as $T);
+                    assert_eq_const_safe!($T: R.wrapping_pow(129), 0 as $T);
+
+                    assert_eq_const_safe!(Option<$T>: R.checked_pow(0), Some(1 as $T));
+                    assert_eq_const_safe!(Option<$T>: R.checked_pow(1), Some(-2 as $T));
+                    assert_eq_const_safe!(Option<$T>: R.checked_pow(2), Some(4 as $T));
+                    assert_eq_const_safe!(Option<$T>: R.checked_pow($T::BITS - 1), Some($T::MIN));
+                    assert_eq_const_safe!(Option<$T>: R.checked_pow($T::BITS), None);
+                    assert_eq_const_safe!(Option<$T>: R.checked_pow($T::BITS + 1), None);
+                    assert_eq_const_safe!(Option<$T>: R.checked_pow(128), None);
+                    assert_eq_const_safe!(Option<$T>: R.checked_pow(129), None);
+
+                    assert_eq_const_safe!(($T, bool): R.overflowing_pow(0), (1 as $T, false));
+                    assert_eq_const_safe!(($T, bool): R.overflowing_pow(1), (-2 as $T, false));
+                    assert_eq_const_safe!(($T, bool): R.overflowing_pow(2), (4 as $T, false));
+                    assert_eq_const_safe!(($T, bool): R.overflowing_pow($T::BITS - 1), ($T::MIN, false));
+                    assert_eq_const_safe!(($T, bool): R.overflowing_pow($T::BITS), (0 as $T, true));
+                    assert_eq_const_safe!(($T, bool): R.overflowing_pow($T::BITS + 1), (0 as $T, true));
+                    assert_eq_const_safe!(($T, bool): R.overflowing_pow(128), (0 as $T, true));
+                    assert_eq_const_safe!(($T, bool): R.overflowing_pow(129), (0 as $T, true));
+
+                    assert_eq_const_safe!($T: R.saturating_pow(0), 1 as $T);
+                    assert_eq_const_safe!($T: R.saturating_pow(1), -2 as $T);
+                    assert_eq_const_safe!($T: R.saturating_pow(2), 4 as $T);
+                    assert_eq_const_safe!($T: R.saturating_pow($T::BITS - 1), $T::MIN);
+                    assert_eq_const_safe!($T: R.saturating_pow($T::BITS), $T::MAX);
+                    assert_eq_const_safe!($T: R.saturating_pow($T::BITS + 1), $T::MIN);
+                    assert_eq_const_safe!($T: R.saturating_pow(128), $T::MAX);
+                    assert_eq_const_safe!($T: R.saturating_pow(129), $T::MIN);
+                }
+
+                // Overflow in the shift caclculation should result in the final
+                // result being 0 rather than accidentally succeeding due to a
+                // shift within the word size.
+                // eg `4 ** 0x8000_0000` should give 0 rather than 1 << 0
+                {
+                    const R: $T = 4;
+                    const HALF: u32 = u32::MAX / 2 + 1;
+                    assert_eq_const_safe!($T: R.wrapping_pow(HALF), 0 as $T);
+                    assert_eq_const_safe!(Option<$T>: R.checked_pow(HALF), None);
+                    assert_eq_const_safe!(($T, bool): R.overflowing_pow(HALF), (0 as $T, true));
+                    assert_eq_const_safe!($T: R.saturating_pow(HALF), $T::MAX);
+                }
+
+                {
+                    const R: $T = -4;
+                    const HALF: u32 = u32::MAX / 2 + 1;
+                    assert_eq_const_safe!($T: R.wrapping_pow(HALF), 0 as $T);
+                    assert_eq_const_safe!(Option<$T>: R.checked_pow(HALF), None);
+                    assert_eq_const_safe!(($T, bool): R.overflowing_pow(HALF), (0 as $T, true));
+                    assert_eq_const_safe!($T: R.saturating_pow(HALF), $T::MAX);
+                }
+
+                {
+                    const R: $T = $T::MAX;
+                    assert_eq_const_safe!($T: R.wrapping_pow(0), 1 as $T);
+                    assert_eq_const_safe!($T: R.wrapping_pow(1), R as $T);
+                    assert_eq_const_safe!($T: R.wrapping_pow(2), 1 as $T);
+
+                    assert_eq_const_safe!($T: R.wrapping_pow(128), 1 as $T);
+                    assert_eq_const_safe!($T: R.wrapping_pow(129), R as $T);
+
+                    assert_eq_const_safe!(Option<$T>: R.checked_pow(0), Some(1 as $T));
+                    assert_eq_const_safe!(Option<$T>: R.checked_pow(1), Some(R as $T));
+                    assert_eq_const_safe!(Option<$T>: R.checked_pow(2), None);
+                    assert_eq_const_safe!(Option<$T>: R.checked_pow(128), None);
+                    assert_eq_const_safe!(Option<$T>: R.checked_pow(129), None);
+
+                    assert_eq_const_safe!(($T, bool): R.overflowing_pow(0), (1 as $T, false));
+                    assert_eq_const_safe!(($T, bool): R.overflowing_pow(1), (R as $T, false));
+                    assert_eq_const_safe!(($T, bool): R.overflowing_pow(2), (1 as $T, true));
+                    assert_eq_const_safe!(($T, bool): R.overflowing_pow(128), (1 as $T, true));
+                    assert_eq_const_safe!(($T, bool): R.overflowing_pow(129), (R as $T, true));
+
+                    assert_eq_const_safe!($T: R.saturating_pow(0), 1 as $T);
+                    assert_eq_const_safe!($T: R.saturating_pow(1), R as $T);
+                    assert_eq_const_safe!($T: R.saturating_pow(2), $T::MAX);
+                    assert_eq_const_safe!($T: R.saturating_pow($T::BITS - 1), $T::MAX);
+                    assert_eq_const_safe!($T: R.saturating_pow($T::BITS), $T::MAX);
+                    assert_eq_const_safe!($T: R.saturating_pow($T::BITS + 1), $T::MAX);
+                    assert_eq_const_safe!($T: R.saturating_pow(128), $T::MAX);
+                    assert_eq_const_safe!($T: R.saturating_pow(129), $T::MAX);
+                }
+
+                {
+                    const R: $T = $T::MIN;
+                    assert_eq_const_safe!($T: R.wrapping_pow(0), 1 as $T);
+                    assert_eq_const_safe!($T: R.wrapping_pow(1), R as $T);
+                    assert_eq_const_safe!($T: R.wrapping_pow(2), 0 as $T);
+                    assert_eq_const_safe!($T: R.wrapping_pow($T::BITS - 1), 0 as $T);
+                    assert_eq_const_safe!($T: R.wrapping_pow($T::BITS), 0 as $T);
+                    assert_eq_const_safe!($T: R.wrapping_pow($T::BITS + 1), 0 as $T);
+                    assert_eq_const_safe!($T: R.wrapping_pow(128), 0 as $T);
+                    assert_eq_const_safe!($T: R.wrapping_pow(129), 0 as $T);
+
+                    assert_eq_const_safe!(Option<$T>: R.checked_pow(0), Some(1 as $T));
+                    assert_eq_const_safe!(Option<$T>: R.checked_pow(1), Some(R as $T));
+                    assert_eq_const_safe!(Option<$T>: R.checked_pow(2), None);
+                    assert_eq_const_safe!(Option<$T>: R.checked_pow($T::BITS - 1), None);
+                    assert_eq_const_safe!(Option<$T>: R.checked_pow($T::BITS), None);
+                    assert_eq_const_safe!(Option<$T>: R.checked_pow($T::BITS + 1), None);
+                    assert_eq_const_safe!(Option<$T>: R.checked_pow(128), None);
+                    assert_eq_const_safe!(Option<$T>: R.checked_pow(129), None);
+
+                    assert_eq_const_safe!(($T, bool): R.overflowing_pow(0), (1 as $T, false));
+                    assert_eq_const_safe!(($T, bool): R.overflowing_pow(1), (R as $T, false));
+                    assert_eq_const_safe!(($T, bool): R.overflowing_pow(2), (0 as $T, true));
+                    assert_eq_const_safe!(($T, bool): R.overflowing_pow($T::BITS - 1), (0 as $T, true));
+                    assert_eq_const_safe!(($T, bool): R.overflowing_pow($T::BITS), (0 as $T, true));
+                    assert_eq_const_safe!(($T, bool): R.overflowing_pow($T::BITS + 1), (0 as $T, true));
+                    assert_eq_const_safe!(($T, bool): R.overflowing_pow(128), (0 as $T, true));
+                    assert_eq_const_safe!(($T, bool): R.overflowing_pow(129), (0 as $T, true));
+
+                    assert_eq_const_safe!($T: R.saturating_pow(0), 1 as $T);
+                    assert_eq_const_safe!($T: R.saturating_pow(1), R as $T);
+                    assert_eq_const_safe!($T: R.saturating_pow(2), $T::MAX);
+                    assert_eq_const_safe!($T: R.saturating_pow($T::BITS - 1), $T::MIN);
+                    assert_eq_const_safe!($T: R.saturating_pow($T::BITS), $T::MAX);
+                    assert_eq_const_safe!($T: R.saturating_pow($T::BITS + 1), $T::MIN);
+                    assert_eq_const_safe!($T: R.saturating_pow(128), $T::MAX);
+                    assert_eq_const_safe!($T: R.saturating_pow(129), $T::MIN);
                 }
             }
 

--- a/library/coretests/tests/num/uint_macros.rs
+++ b/library/coretests/tests/num/uint_macros.rs
@@ -338,29 +338,124 @@ macro_rules! uint_module {
 
             fn test_pow() {
                 {
-                    const R: $T = 2;
-                    assert_eq_const_safe!($T: R.pow(2), 4 as $T);
-                    assert_eq_const_safe!($T: R.pow(0), 1 as $T);
-                    assert_eq_const_safe!($T: R.wrapping_pow(2), 4 as $T);
+                    const R: $T = 0;
                     assert_eq_const_safe!($T: R.wrapping_pow(0), 1 as $T);
-                    assert_eq_const_safe!(Option<$T>: R.checked_pow(2), Some(4 as $T));
+                    assert_eq_const_safe!($T: R.wrapping_pow(1), 0 as $T);
+                    assert_eq_const_safe!($T: R.wrapping_pow(2), 0 as $T);
+                    assert_eq_const_safe!($T: R.wrapping_pow(128), 0 as $T);
+                    assert_eq_const_safe!($T: R.wrapping_pow(129), 0 as $T);
+
                     assert_eq_const_safe!(Option<$T>: R.checked_pow(0), Some(1 as $T));
-                    assert_eq_const_safe!(($T, bool): R.overflowing_pow(2), (4 as $T, false));
+                    assert_eq_const_safe!(Option<$T>: R.checked_pow(1), Some(0 as $T));
+                    assert_eq_const_safe!(Option<$T>: R.checked_pow(2), Some(0 as $T));
+                    assert_eq_const_safe!(Option<$T>: R.checked_pow(128), Some(0 as $T));
+                    assert_eq_const_safe!(Option<$T>: R.checked_pow(129), Some(0 as $T));
+
                     assert_eq_const_safe!(($T, bool): R.overflowing_pow(0), (1 as $T, false));
-                    assert_eq_const_safe!($T: R.saturating_pow(2), 4 as $T);
+                    assert_eq_const_safe!(($T, bool): R.overflowing_pow(1), (0 as $T, false));
+                    assert_eq_const_safe!(($T, bool): R.overflowing_pow(2), (0 as $T, false));
+                    assert_eq_const_safe!(($T, bool): R.overflowing_pow(128), (0 as $T, false));
+                    assert_eq_const_safe!(($T, bool): R.overflowing_pow(129), (0 as $T, false));
+
                     assert_eq_const_safe!($T: R.saturating_pow(0), 1 as $T);
+                    assert_eq_const_safe!($T: R.saturating_pow(1), 0 as $T);
+                    assert_eq_const_safe!($T: R.saturating_pow(2), 0 as $T);
+                    assert_eq_const_safe!($T: R.saturating_pow(128), 0 as $T);
+                    assert_eq_const_safe!($T: R.saturating_pow(129), 0 as $T);
+                }
+
+                {
+                    const R: $T = 1;
+                    assert_eq_const_safe!($T: R.wrapping_pow(0), 1 as $T);
+                    assert_eq_const_safe!($T: R.wrapping_pow(1), 1 as $T);
+                    assert_eq_const_safe!($T: R.wrapping_pow(2), 1 as $T);
+                    assert_eq_const_safe!($T: R.wrapping_pow(128), 1 as $T);
+                    assert_eq_const_safe!($T: R.wrapping_pow(129), 1 as $T);
+
+                    assert_eq_const_safe!(Option<$T>: R.checked_pow(0), Some(1 as $T));
+                    assert_eq_const_safe!(Option<$T>: R.checked_pow(1), Some(1 as $T));
+                    assert_eq_const_safe!(Option<$T>: R.checked_pow(2), Some(1 as $T));
+                    assert_eq_const_safe!(Option<$T>: R.checked_pow(128), Some(1 as $T));
+                    assert_eq_const_safe!(Option<$T>: R.checked_pow(129), Some(1 as $T));
+
+                    assert_eq_const_safe!(($T, bool): R.overflowing_pow(0), (1 as $T, false));
+                    assert_eq_const_safe!(($T, bool): R.overflowing_pow(1), (1 as $T, false));
+                    assert_eq_const_safe!(($T, bool): R.overflowing_pow(2), (1 as $T, false));
+                    assert_eq_const_safe!(($T, bool): R.overflowing_pow(128), (1 as $T, false));
+                    assert_eq_const_safe!(($T, bool): R.overflowing_pow(129), (1 as $T, false));
+
+                    assert_eq_const_safe!($T: R.saturating_pow(0), 1 as $T);
+                    assert_eq_const_safe!($T: R.saturating_pow(1), 1 as $T);
+                    assert_eq_const_safe!($T: R.saturating_pow(2), 1 as $T);
+                    assert_eq_const_safe!($T: R.saturating_pow(128), 1 as $T);
+                    assert_eq_const_safe!($T: R.saturating_pow(129), 1 as $T);
+                }
+
+                {
+                    const R: $T = 2;
+                    assert_eq_const_safe!($T: R.wrapping_pow(0), 1 as $T);
+                    assert_eq_const_safe!($T: R.wrapping_pow(1), 2 as $T);
+                    assert_eq_const_safe!($T: R.wrapping_pow(2), 4 as $T);
+                    assert_eq_const_safe!($T: R.wrapping_pow(128), 0 as $T);
+                    assert_eq_const_safe!($T: R.wrapping_pow(129), 0 as $T);
+
+                    assert_eq_const_safe!(Option<$T>: R.checked_pow(0), Some(1 as $T));
+                    assert_eq_const_safe!(Option<$T>: R.checked_pow(1), Some(2 as $T));
+                    assert_eq_const_safe!(Option<$T>: R.checked_pow(2), Some(4 as $T));
+                    assert_eq_const_safe!(Option<$T>: R.checked_pow(128), None);
+                    assert_eq_const_safe!(Option<$T>: R.checked_pow(129), None);
+
+                    assert_eq_const_safe!(($T, bool): R.overflowing_pow(0), (1 as $T, false));
+                    assert_eq_const_safe!(($T, bool): R.overflowing_pow(1), (2 as $T, false));
+                    assert_eq_const_safe!(($T, bool): R.overflowing_pow(2), (4 as $T, false));
+                    assert_eq_const_safe!(($T, bool): R.overflowing_pow(128), (0 as $T, true));
+                    assert_eq_const_safe!(($T, bool): R.overflowing_pow(129), (0 as $T, true));
+
+                    assert_eq_const_safe!($T: R.saturating_pow(0), 1 as $T);
+                    assert_eq_const_safe!($T: R.saturating_pow(1), 2 as $T);
+                    assert_eq_const_safe!($T: R.saturating_pow(2), 4 as $T);
+                    assert_eq_const_safe!($T: R.saturating_pow(128), $T::MAX);
+                    assert_eq_const_safe!($T: R.saturating_pow(129), $T::MAX);
+                }
+
+                // Overflow in the shift caclculation should result in the final
+                // result being 0 rather than accidentally succeeding due to a
+                // shift within the word size.
+                // eg `4 ** 0x8000_0000` should give 0 rather than 1 << 0
+                {
+                    const R: $T = 4;
+                    const HALF: u32 = u32::MAX / 2 + 1;
+                    assert_eq_const_safe!($T: R.wrapping_pow(HALF), 0 as $T);
+                    assert_eq_const_safe!(Option<$T>: R.checked_pow(HALF), None);
+                    assert_eq_const_safe!(($T, bool): R.overflowing_pow(HALF), (0 as $T, true));
+                    assert_eq_const_safe!($T: R.saturating_pow(HALF), $T::MAX);
                 }
 
                 {
                     const R: $T = $T::MAX;
-                    // use `^` to represent .pow() with no overflow.
-                    // if itest::MAX == 2^j-1, then itest is a `j` bit int,
-                    // so that `itest::MAX*itest::MAX == 2^(2*j)-2^(j+1)+1`,
-                    // thussaturating_pow the overflowing result is exactly 1.
+                    assert_eq_const_safe!($T: R.wrapping_pow(0), 1 as $T);
+                    assert_eq_const_safe!($T: R.wrapping_pow(1), R as $T);
                     assert_eq_const_safe!($T: R.wrapping_pow(2), 1 as $T);
+                    assert_eq_const_safe!($T: R.wrapping_pow(128), 1 as $T);
+                    assert_eq_const_safe!($T: R.wrapping_pow(129), R as $T);
+
+                    assert_eq_const_safe!(Option<$T>: R.checked_pow(0), Some(1 as $T));
+                    assert_eq_const_safe!(Option<$T>: R.checked_pow(1), Some(R as $T));
                     assert_eq_const_safe!(Option<$T>: R.checked_pow(2), None);
+                    assert_eq_const_safe!(Option<$T>: R.checked_pow(128), None);
+                    assert_eq_const_safe!(Option<$T>: R.checked_pow(129), None);
+
+                    assert_eq_const_safe!(($T, bool): R.overflowing_pow(0), (1 as $T, false));
+                    assert_eq_const_safe!(($T, bool): R.overflowing_pow(1), (R as $T, false));
                     assert_eq_const_safe!(($T, bool): R.overflowing_pow(2), (1 as $T, true));
+                    assert_eq_const_safe!(($T, bool): R.overflowing_pow(128), (1 as $T, true));
+                    assert_eq_const_safe!(($T, bool): R.overflowing_pow(129), (R as $T, true));
+
+                    assert_eq_const_safe!($T: R.saturating_pow(0), 1 as $T);
+                    assert_eq_const_safe!($T: R.saturating_pow(1), R as $T);
                     assert_eq_const_safe!($T: R.saturating_pow(2), $T::MAX);
+                    assert_eq_const_safe!($T: R.saturating_pow(128), $T::MAX);
+                    assert_eq_const_safe!($T: R.saturating_pow(129), $T::MAX);
                 }
             }
 

--- a/tests/codegen-llvm/ilog_known_base.rs
+++ b/tests/codegen-llvm/ilog_known_base.rs
@@ -1,0 +1,36 @@
+//@ compile-flags: -Copt-level=3
+// Test that `checked_ilog` can use a faster implementation when `base` is a
+// known power of two
+
+#![crate_type = "lib"]
+
+// CHECK-LABEL: @checked_ilog2
+#[no_mangle]
+pub fn checked_ilog2(val: u32) -> Option<u32> {
+    // CHECK: %[[ICMP:.+]] = icmp ne i32 %val, 0
+    // CHECK: %[[CTZ:.+]] = tail call range(i32 0, 33) i32 @llvm.ctlz.i32(i32 %val, i1 true)
+    // CHECK: %[[LOG2:.+]] = xor i32 %[[CTZ]], 31
+    val.checked_ilog(2)
+}
+
+// log(4, x) == log(2, x) / 2
+// CHECK-LABEL: @checked_ilog4
+#[no_mangle]
+pub fn checked_ilog4(val: u32) -> Option<u32> {
+    // CHECK: %[[ICMP:.+]] = icmp ne i32 %val, 0
+    // CHECK: %[[CTZ:.+]] = tail call range(i32 0, 33) i32 @llvm.ctlz.i32(i32 %val, i1 true)
+    // CHECK: %[[DIV2:.+]] = lshr i32 %[[CTZ]], 1
+    // CHECK: %[[LOG4:.+]] = xor i32 %[[DIV2]], 15
+    val.checked_ilog(4)
+}
+
+// log(16, x) == log(2, x) / 4
+// CHECK-LABEL: @checked_ilog16
+#[no_mangle]
+pub fn checked_ilog16(val: u32) -> Option<u32> {
+    // CHECK: %[[ICMP:.+]] = icmp ne i32 %val, 0
+    // CHECK: %[[CTZ:.+]] = tail call range(i32 0, 33) i32 @llvm.ctlz.i32(i32 %val, i1 true)
+    // CHECK: %[[DIV4:.+]] = lshr i32 %[[CTZ]], 2
+    // CHECK: %[[LOG16:.+]] = xor i32 %[[DIV2]], 7
+    val.checked_ilog(16)
+}

--- a/tests/codegen-llvm/pow_known_base.rs
+++ b/tests/codegen-llvm/pow_known_base.rs
@@ -1,0 +1,58 @@
+//@ compile-flags: -Copt-level=3
+// Test that `pow` can use a faster implementation when `base` is a
+// known power of two
+
+#![crate_type = "lib"]
+
+// 2 ** n == 2 ** (1 * n) == 1 << (1 * n)
+// CHECK-LABEL: @pow2
+#[no_mangle]
+pub fn pow2(exp: u32) -> u32 {
+    // CHECK: %[[OVERFLOW:.+]] = icmp ult i32 %exp, 32
+    // CHECK: %[[POW:.+]] = shl nuw i32 1, %exp
+    // CHECK: %[[RET:.+]] = select i1 %[[OVERFLOW]], i32 %[[POW]], i32 0
+    // CHECK: ret i32 %[[RET]]
+    2u32.pow(exp)
+}
+
+// 4 ** n == 2 ** (2 * n) == 1 << (2 * n)
+// CHECK-LABEL: @pow4
+#[no_mangle]
+pub fn pow4(exp: u32) -> u32 {
+    // CHECK: %[[ICMP1:.+]] = icmp slt i32 %exp, 0
+    // CHECK: %[[SHIFT_AMOUNT:.+]] = shl i32 %exp, 1
+    // CHECK: %[[ICMP2:.+]] = icmp ult i32 %[[SHIFT_AMOUNT]], 32
+    // CHECK: %[[POW:.+]] = shl nuw i32 1, %[[SHIFT_AMOUNT]]
+    // CHECK: %[[SEL:.+]] = select i1 %[[ICMP2]], i32 %[[POW]], i32 0
+    // CHECK: %[[RET:.+]] = select i1 %[[ICMP1]], i32 0, i32 %[[SEL]]
+    // CHECK: ret i32 %[[RET]]
+    4u32.pow(exp)
+}
+
+// 16 ** n == 2 ** (4 * n) == 1 << (4 * n)
+// CHECK-LABEL: @pow16
+#[no_mangle]
+pub fn pow16(exp: u32) -> u32 {
+    // CHECK: %[[ICMP1:.+]] = icmp ugt i32 %exp, 1073741823
+    // CHECK: %[[SHIFT_AMOUNT:.+]] = shl i32 %exp, 2
+    // CHECK: %[[ICMP2:.+]] = icmp ult i32 %[[SHIFT_AMOUNT]], 32
+    // CHECK: %[[POW:.+]] = shl nuw i32 1, %[[SHIFT_AMOUNT]]
+    // CHECK: %[[SEL:.+]] = select i1 %[[ICMP2]], i32 %[[POW]], i32 0
+    // CHECK: %[[RET:.+]] = select i1 %[[ICMP1]], i32 0, i32 %[[SEL]]
+    // CHECK: ret i32 %[[RET]]
+    16u32.pow(exp)
+}
+
+// (-2) ** n == (-2) ** (1 * n) == 1 << (1 * n)
+// CHECK-LABEL: @pow_minus_2
+#[no_mangle]
+pub fn pow_minus_2(exp: u32) -> i32 {
+    // CHECK: %[[IS_ODD:.+]] = and i32 %exp, 1
+    // CHECK: %[[IS_EVEN:.+]] = icmp eq i32 %[[IS_ODD]], 0
+    // CHECK: %[[BASE:.+]] = select i1 %[[IS_EVEN]], i32 1, i32 -1
+    // CHECK: %[[OVERFLOW:.+]] = icmp ult i32 %exp, 32
+    // CHECK: %[[SHIFT:.+]] = shl i32 %[[BASE]], %exp
+    // CHECK: %[[RET:.+]] = select i1 %[[OVERFLOW]], i32 %[[SHIFT]], i32 0
+    // CHECK: ret i32 %[[RET]]
+    (-2i32).pow(exp)
+}

--- a/tests/ui/numbers-arithmetic/overflowing-pow-signed.rs
+++ b/tests/ui/numbers-arithmetic/overflowing-pow-signed.rs
@@ -1,6 +1,6 @@
 //@ run-fail
 //@ regex-error-pattern: thread 'main'.*panicked
-//@ error-pattern: attempt to multiply with overflow
+//@ regex-error-pattern: attempt to exponentiate with overflow
 //@ needs-subprocess
 //@ compile-flags: -C debug-assertions
 

--- a/tests/ui/numbers-arithmetic/overflowing-pow-unsigned.rs
+++ b/tests/ui/numbers-arithmetic/overflowing-pow-unsigned.rs
@@ -1,6 +1,6 @@
 //@ run-fail
 //@ regex-error-pattern: thread 'main'.*panicked
-//@ error-pattern: attempt to multiply with overflow
+//@ regex-error-pattern: attempt to exponentiate with overflow
 //@ needs-subprocess
 //@ compile-flags: -C debug-assertions
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/147250)*
<!-- homu-ignore:end -->

Optimize `checked_ilog` and `pow` when the base is a power of two