### PR TITLE
Make #[link="dl"] an FCW rather than an error

### DIFF
--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -873,6 +873,7 @@ symbols! {
         div,
         div_assign,
         diverging_block_default,
+        dl,
         do_not_recommend,
         doc,
         doc_alias,

--- a/tests/ui/attributes/link-dl.allowed.stderr
+++ b/tests/ui/attributes/link-dl.allowed.stderr
@@ -1,0 +1,10 @@
+Future incompatibility report: Future breakage diagnostic:
+warning: valid forms for the attribute are `#[link(name = "...")]`, `#[link(name = "...", import_name_type = "decorated|noprefix|undecorated")]`, `#[link(name = "...", kind = "dylib|static|...")]`, `#[link(name = "...", kind = "dylib|static|...", wasm_import_module = "...", import_name_type = "decorated|noprefix|undecorated")]`, and `#[link(name = "...", wasm_import_module = "...")]`
+  --> $DIR/link-dl.rs:14:1
+   |
+LL | #[link="dl"]
+   | ^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
+

--- a/tests/ui/attributes/link-dl.default_fcw.stderr
+++ b/tests/ui/attributes/link-dl.default_fcw.stderr
@@ -1,0 +1,26 @@
+error[E0539]: malformed `link` attribute input
+  --> $DIR/link-dl.rs:14:1
+   |
+LL | #[link="dl"]
+   | ^^^^^^^^^^^^ expected this to be a list
+   |
+   = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute>
+help: try changing it to one of the following valid forms of the attribute
+   |
+LL - #[link="dl"]
+LL + #[link(name = "...")]
+   |
+LL - #[link="dl"]
+LL + #[link(name = "...", import_name_type = "decorated|noprefix|undecorated")]
+   |
+LL - #[link="dl"]
+LL + #[link(name = "...", kind = "dylib|static|...")]
+   |
+LL - #[link="dl"]
+LL + #[link(name = "...", kind = "dylib|static|...", wasm_import_module = "...", import_name_type = "decorated|noprefix|undecorated")]
+   |
+   = and 1 other candidate
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0539`.

--- a/tests/ui/attributes/link-dl.default_fcw.stderr
+++ b/tests/ui/attributes/link-dl.default_fcw.stderr
@@ -1,26 +1,23 @@
-error[E0539]: malformed `link` attribute input
+error: valid forms for the attribute are `#[link(name = "...")]`, `#[link(name = "...", import_name_type = "decorated|noprefix|undecorated")]`, `#[link(name = "...", kind = "dylib|static|...")]`, `#[link(name = "...", kind = "dylib|static|...", wasm_import_module = "...", import_name_type = "decorated|noprefix|undecorated")]`, and `#[link(name = "...", wasm_import_module = "...")]`
   --> $DIR/link-dl.rs:14:1
    |
 LL | #[link="dl"]
-   | ^^^^^^^^^^^^ expected this to be a list
+   | ^^^^^^^^^^^^
    |
-   = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute>
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL - #[link="dl"]
-LL + #[link(name = "...")]
-   |
-LL - #[link="dl"]
-LL + #[link(name = "...", import_name_type = "decorated|noprefix|undecorated")]
-   |
-LL - #[link="dl"]
-LL + #[link(name = "...", kind = "dylib|static|...")]
-   |
-LL - #[link="dl"]
-LL + #[link(name = "...", kind = "dylib|static|...", wasm_import_module = "...", import_name_type = "decorated|noprefix|undecorated")]
-   |
-   = and 1 other candidate
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
+   = note: `#[deny(ill_formed_attribute_input)]` (part of `#[deny(future_incompatible)]`) on by default
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0539`.
+Future incompatibility report: Future breakage diagnostic:
+error: valid forms for the attribute are `#[link(name = "...")]`, `#[link(name = "...", import_name_type = "decorated|noprefix|undecorated")]`, `#[link(name = "...", kind = "dylib|static|...")]`, `#[link(name = "...", kind = "dylib|static|...", wasm_import_module = "...", import_name_type = "decorated|noprefix|undecorated")]`, and `#[link(name = "...", wasm_import_module = "...")]`
+  --> $DIR/link-dl.rs:14:1
+   |
+LL | #[link="dl"]
+   | ^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
+   = note: `#[deny(ill_formed_attribute_input)]` (part of `#[deny(future_incompatible)]`) on by default
+

--- a/tests/ui/attributes/link-dl.rs
+++ b/tests/ui/attributes/link-dl.rs
@@ -1,0 +1,19 @@
+// Regression test for an issue discovered in https://github.com/rust-lang/rust/pull/143193/files and rediscovered in https://github.com/rust-lang/rust/issues/147254#event-20049906781
+// Malformed #[link] attribute was supposed to be deny-by-default report-in-deps FCW,
+// but accidentally was landed as a hard error.
+//
+// revision `default_fcw` tests that with `ill_formed_attribute_input` (the default) denied,
+// the attribute produces an FCW
+// revision `allowed` tests that with `ill_formed_attribute_input` allowed the test passes
+
+//@ revisions: default_fcw allowed
+//@[allowed] check-pass
+
+#[cfg_attr(allowed, allow(ill_formed_attribute_input))]
+
+#[link="dl"]
+//[default_fcw]~^ ERROR valid forms for the attribute are
+//[default_fcw]~| WARN previously accepted
+extern "C" { }
+
+fn main() {}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/147254
I forgot to implement the T-lang decision in https://github.com/rust-lang/rust/pull/143193#issuecomment-3138479942, this implements that decision

r? @jdonszelmann 
Can be reviewed commit-by-commit
This needs a beta backport