### PR TITLE
Disable triagebot auto stable-regression compiler backport nominations pending redesign

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -61,10 +61,6 @@ required-issue-label = "regression-from-stable-to-beta"
 # if the above conditions matches, the PR will receive these labels
 add-labels = ["beta-nominated"]
 
-[backport.t-compiler-stable-backport]
-required-pr-labels = ["T-compiler"]
-required-issue-label = "regression-from-stable-to-stable"
-add-labels = ["stable-nominated"]
 
 # ------------------------------------------------------------------------------
 # Ping groups


### PR DESCRIPTION
Current auto compiler stable-regression backport nominations seem to be too aggressive, and seems to unfortunately lower signal-to-noise ratio of the compiler backport channel. So this PR disables the triagebot compiler auto stable-regression backport nominations pending a redesign. Beta-regression auto backport nominations are not modified, we might want to gather some more experience with it.

No prejudice against re-enabling them if the nominations include a bit more context on _why_ it's automatically nominated and _which_ regression(s) are being addressed. Or as proposed, it could also simply become a reminder-to-nominate _comment_.

cf. [#t-compiler/backports > #146919: stable-nominated @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/474880-t-compiler.2Fbackports/topic/.23146919.3A.20stable-nominated/near/540979327)

> I like the idea of rustbot just posting a message that suggests adding the label. That seems like a good compromise between avoiding forgotten nominations and avoiding spurious nominations.

In any case, this was very much worth experimenting!

r? @apiraino (or triagebot)