### PR TITLE
Return to needs-llvm-components being info-only

### DIFF
--- a/src/tools/compiletest/src/directives/needs.rs
+++ b/src/tools/compiletest/src/directives/needs.rs
@@ -281,10 +281,7 @@ pub(super) fn handle_needs(
 
     // Handled elsewhere.
     if name == "needs-llvm-components" {
-        if config.default_codegen_backend.is_llvm() {
-            return IgnoreDecision::Continue;
-        }
-        return IgnoreDecision::Ignore { reason: "LLVM specific test".into() };
+        return IgnoreDecision::Continue;
     }
 
     let mut found_valid = false;


### PR DESCRIPTION
Partially revert a535042e80a38196a58c27a8c95552546affe5dc

Even with non-LLVM codegen backends, we want to allow for annotations that express dependencies to LLVM-specific parts of the test suite. This includes `//@ needs-llvm-components`, which just allows checking that LLVM is built with relevant target support before the test is run. It does not assert the test cannot work with another codegen backend.

<!-- homu-ignore:start -->
r? @Kobzol

Related PR: https://github.com/rust-lang/rust/pull/146618
<!-- homu-ignore:end -->
