### PR TITLE
More detail for `format!` `width` bigger than `u16::MAX`

### DIFF
--- a/library/core/src/fmt/rt.rs
+++ b/library/core/src/fmt/rt.rs
@@ -150,7 +150,7 @@ impl Argument<'_> {
     #[track_caller]
     pub const fn from_usize(x: &usize) -> Argument<'_> {
         if *x > u16::MAX as usize {
-            panic!("Formatting argument out of range");
+            panic!("Formatting argument out of range: `{x}` is bigger than `u16::MAX`");
         }
         Argument { ty: ArgumentType::Count(*x as u16) }
     }


### PR DESCRIPTION
Formatting the width of a numeric value is limited to a `u16`, but the macros accept any `usize` and can panic at runtime. Previously the panic didn't provide any additional information about the failure, other than "too big".

_Noticed in https://internals.rust-lang.org/t/diagnostic-for-136932-width-limit/23589_