### PR TITLE
specialize `slice::fill` to use memset

### DIFF
--- a/compiler/rustc_codegen_cranelift/example/mini_core.rs
+++ b/compiler/rustc_codegen_cranelift/example/mini_core.rs
@@ -666,7 +666,7 @@ pub mod intrinsics {
     #[rustc_intrinsic]
     pub fn bswap<T>(x: T) -> T;
     #[rustc_intrinsic]
-    pub unsafe fn write_bytes<T>(dst: *mut T, val: u8, count: usize);
+    pub unsafe fn write_bytes<T, B>(dst: *mut T, val: B, count: usize);
     #[rustc_intrinsic]
     pub unsafe fn unreachable() -> !;
 }

--- a/compiler/rustc_codegen_cranelift/example/mini_core_hello_world.rs
+++ b/compiler/rustc_codegen_cranelift/example/mini_core_hello_world.rs
@@ -125,7 +125,7 @@ static NUM_REF: &'static u8 = unsafe { &*&raw const NUM };
 
 unsafe fn zeroed<T>() -> T {
     let mut uninit = MaybeUninit { uninit: () };
-    intrinsics::write_bytes(&mut uninit.value.value as *mut T, 0, 1);
+    intrinsics::write_bytes(&mut uninit.value.value as *mut T, 0u8, 1);
     uninit.value.value
 }
 

--- a/compiler/rustc_codegen_cranelift/src/intrinsics/mod.rs
+++ b/compiler/rustc_codegen_cranelift/src/intrinsics/mod.rs
@@ -685,6 +685,12 @@ fn codegen_regular_intrinsic_call<'tcx>(
 
         sym::write_bytes | sym::volatile_set_memory => {
             intrinsic_args!(fx, args => (dst, val, count); intrinsic);
+            if val.layout().size.bytes() != 1 {
+                // incorrect sizes can be encountered on dead branches
+                fx.bcx.ins().trap(TrapCode::user(1).unwrap());
+                return Ok(());
+            };
+
             let val = val.load_scalar(fx);
             let count = count.load_scalar(fx);
 

--- a/compiler/rustc_codegen_gcc/example/mini_core.rs
+++ b/compiler/rustc_codegen_gcc/example/mini_core.rs
@@ -677,7 +677,7 @@ pub mod intrinsics {
     #[rustc_intrinsic]
     pub fn bswap<T>(x: T) -> T;
     #[rustc_intrinsic]
-    pub unsafe fn write_bytes<T>(dst: *mut T, val: u8, count: usize);
+    pub unsafe fn write_bytes<T, B>(dst: *mut T, val: B, count: usize);
     #[rustc_intrinsic]
     pub unsafe fn unreachable() -> !;
 }

--- a/compiler/rustc_codegen_gcc/example/mini_core_hello_world.rs
+++ b/compiler/rustc_codegen_gcc/example/mini_core_hello_world.rs
@@ -127,7 +127,7 @@ impl<T: ?Sized, U: ?Sized> CoerceUnsized<Unique<U>> for Unique<T> where T: Unsiz
 
 unsafe fn zeroed<T>() -> T {
     let mut uninit = MaybeUninit { uninit: () };
-    intrinsics::write_bytes(&mut uninit.value.value as *mut T, 0, 1);
+    intrinsics::write_bytes(&mut uninit.value.value as *mut T, 0u8, 1);
     uninit.value.value
 }
 

--- a/compiler/rustc_codegen_ssa/src/mir/intrinsic.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/intrinsic.rs
@@ -198,12 +198,18 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                 return Ok(());
             }
             sym::write_bytes => {
+                // invalid types may be encountered on dead branches after a size check.
+                if args[1].layout.size.bytes() != 1 {
+                    bx.unreachable_nonterminator();
+                    return Ok(());
+                }
+                let val = bx.from_immediate(args[1].immediate());
                 memset_intrinsic(
                     bx,
                     false,
                     fn_args.type_at(0),
                     args[0].immediate(),
-                    args[1].immediate(),
+                    val,
                     args[2].immediate(),
                 );
                 return Ok(());

--- a/compiler/rustc_hir_analysis/src/check/intrinsic.rs
+++ b/compiler/rustc_hir_analysis/src/check/intrinsic.rs
@@ -341,7 +341,10 @@ pub(crate) fn check_intrinsic_type(
             let byte_ptr = Ty::new_imm_ptr(tcx, tcx.types.u8);
             (0, 0, vec![byte_ptr, byte_ptr, tcx.types.usize], tcx.types.i32)
         }
-        sym::write_bytes | sym::volatile_set_memory => (
+        sym::write_bytes => {
+            (2, 0, vec![Ty::new_mut_ptr(tcx, param(0)), param(1), tcx.types.usize], tcx.types.unit)
+        }
+        sym::volatile_set_memory => (
             1,
             0,
             vec![Ty::new_mut_ptr(tcx, param(0)), tcx.types.u8, tcx.types.usize],

--- a/library/core/src/intrinsics/mod.rs
+++ b/library/core/src/intrinsics/mod.rs
@@ -2882,6 +2882,8 @@ pub const unsafe fn copy_nonoverlapping<T>(src: *const T, dst: *mut T, count: us
 pub const unsafe fn copy<T>(src: *const T, dst: *mut T, count: usize);
 
 /// This is an accidentally-stable alias to [`ptr::write_bytes`]; use that instead.
+///
+/// `val` must be 1 byte wide, it is allowed to be uninit.
 // Note (intentionally not in the doc comment): `ptr::write_bytes` adds some extra
 // debug assertions; if you are writing compiler tests or code inside the standard library
 // that wants to avoid those debug assertions, directly call this intrinsic instead.
@@ -2890,7 +2892,7 @@ pub const unsafe fn copy<T>(src: *const T, dst: *mut T, count: usize);
 #[rustc_const_stable(feature = "const_intrinsic_copy", since = "1.83.0")]
 #[rustc_nounwind]
 #[rustc_intrinsic]
-pub const unsafe fn write_bytes<T>(dst: *mut T, val: u8, count: usize);
+pub const unsafe fn write_bytes<T, B>(dst: *mut T, val: B, count: usize);
 
 /// Returns the minimum (IEEE 754-2008 minNum) of two `f16` values.
 ///

--- a/library/core/src/slice/specialize.rs
+++ b/library/core/src/slice/specialize.rs
@@ -15,9 +15,43 @@ impl<T: Clone> SpecFill<T> for [T] {
 }
 
 impl<T: Copy> SpecFill<T> for [T] {
-    fn spec_fill(&mut self, value: T) {
+    default fn spec_fill(&mut self, value: T) {
+        if size_of::<T>() == 1 {
+            // SAFETY: The pointer is derived from a reference, so it's writable.
+            // And we checked that T is 1 byte wide.
+            unsafe {
+                // use the intrinsic since it allows any T as long as it's 1 byte wide
+                crate::intrinsics::write_bytes(self.as_mut_ptr(), value, self.len());
+            }
+            return;
+        }
         for item in self.iter_mut() {
             *item = value;
         }
     }
 }
+
+macro spec_fill_int {
+    ($($type:ty)*) => {$(
+        impl SpecFill<$type> for [$type] {
+            #[inline]
+            fn spec_fill(&mut self, value: $type) {
+                if crate::intrinsics::is_val_statically_known(value) {
+                    let bytes = value.to_ne_bytes();
+                    if value == <$type>::from_ne_bytes([bytes[0]; size_of::<$type>()]) {
+                        // SAFETY: The pointer is derived from a reference, so it's writable.
+                        unsafe {
+                            crate::intrinsics::write_bytes(self.as_mut_ptr(), bytes[0], self.len());
+                        }
+                        return;
+                    }
+                }
+                for item in self.iter_mut() {
+                    *item = value;
+                }
+            }
+        }
+    )*}
+}
+
+spec_fill_int! { u16 i16 u32 i32 u64 i64 u128 i128 usize isize }

--- a/library/coretests/tests/intrinsics.rs
+++ b/library/coretests/tests/intrinsics.rs
@@ -1,5 +1,7 @@
 use core::any::TypeId;
+use core::hint::black_box;
 use core::intrinsics::assume;
+use core::mem::MaybeUninit;
 
 #[test]
 fn test_typeid_sized_types() {
@@ -43,7 +45,7 @@ const fn test_write_bytes_in_const_contexts() {
     const TEST: [u32; 3] = {
         let mut arr = [1u32, 2, 3];
         unsafe {
-            write_bytes(arr.as_mut_ptr(), 0, 2);
+            write_bytes(arr.as_mut_ptr(), 0u8, 2);
         }
         arr
     };
@@ -55,7 +57,7 @@ const fn test_write_bytes_in_const_contexts() {
     const TEST2: [u32; 3] = {
         let mut arr = [1u32, 2, 3];
         unsafe {
-            write_bytes(arr.as_mut_ptr(), 1, 2);
+            write_bytes(arr.as_mut_ptr(), 1u8, 2);
         }
         arr
     };
@@ -63,6 +65,17 @@ const fn test_write_bytes_in_const_contexts() {
     assert!(TEST2[0] == 16843009);
     assert!(TEST2[1] == 16843009);
     assert!(TEST2[2] == 3);
+
+    const TEST3: [MaybeUninit<u32>; 2] = {
+        let mut arr: [MaybeUninit<u32>; 2] = [MaybeUninit::uninit(), MaybeUninit::new(1)];
+        unsafe {
+            write_bytes(arr.as_mut_ptr(), MaybeUninit::<u8>::uninit(), 2);
+        }
+        arr
+    };
+
+    // can't do much with uninitialized values, just make sure it compiles
+    black_box(TEST3);
 }
 
 #[test]

--- a/tests/codegen-llvm/lib-optimizations/slice_fill.rs
+++ b/tests/codegen-llvm/lib-optimizations/slice_fill.rs
@@ -1,0 +1,28 @@
+//@ compile-flags: -Copt-level=3
+#![crate_type = "lib"]
+
+use std::mem::MaybeUninit;
+
+// CHECK-LABEL: @slice_fill_pass_undef
+#[no_mangle]
+pub fn slice_fill_pass_undef(s: &mut [MaybeUninit<u8>], v: MaybeUninit<u8>) {
+    // CHECK: tail call void @llvm.memset.{{.*}}(ptr nonnull align 1 %s.0, i8 %v, {{.*}} %s.1, i1 false)
+    // CHECK: ret
+    s.fill(v);
+}
+
+// CHECK-LABEL: @slice_fill_uninit
+#[no_mangle]
+pub fn slice_fill_uninit(s: &mut [MaybeUninit<u8>]) {
+    // CHECK-NOT: call
+    // CHECK: ret void
+    s.fill(MaybeUninit::uninit());
+}
+
+// CHECK-LABEL: @slice_wide_memset
+#[no_mangle]
+pub fn slice_wide_memset(s: &mut [u16]) {
+    // CHECK: tail call void @llvm.memset.{{.*}}(ptr nonnull align 2 %s.0, i8 -1
+    // CHECK: ret
+    s.fill(0xFFFF);
+}


### PR DESCRIPTION
This was attempted previously in https://github.com/rust-lang/rust/pull/83245 but had to be reverted [#87891](https://github.com/rust-lang/rust/issues/87891) because the intrinsic didn't support uninitialized values.

This is my first attempt at modifying intrinsics and const-eval, so I have no clue if I'm doing this correctly.

It should also help const eval performance: https://github.com/rust-lang/miri/issues/4616