### PR TITLE
Don't normalize higher-ranked assumptions if they're not used

### DIFF
--- a/tests/ui/async-await/higher-ranked-normalize-assumptions-2.rs
+++ b/tests/ui/async-await/higher-ranked-normalize-assumptions-2.rs
@@ -1,0 +1,38 @@
+//@ revisions: stock hr
+//@[hr] compile-flags: -Zhigher-ranked-assumptions
+//@ edition: 2024
+//@ check-pass
+
+// Test that we don't normalize the higher-ranked assumptions of an auto trait goal
+// unless we have `-Zhigher-ranked-assumptions`, since obligations that result from
+// this normalization may lead to higher-ranked lifetime errors when the flag is not
+// enabled.
+
+// Regression test for <https://github.com/rust-lang/rust/issues/147244>.
+
+pub fn a() -> impl Future + Send {
+    async {
+        let queries = core::iter::empty().map(Thing::f);
+        b(queries).await;
+    }
+}
+
+async fn b(queries: impl IntoIterator) {
+    c(queries).await;
+}
+
+fn c<'a, I>(_queries: I) -> impl Future
+where
+    I: IntoIterator,
+    I::IntoIter: 'a,
+{
+    async {}
+}
+
+pub struct Thing<'a>(pub &'a ());
+
+impl Thing<'_> {
+    fn f(_: &Self) {}
+}
+
+fn main() {}

--- a/tests/ui/async-await/higher-ranked-normalize-assumptions.rs
+++ b/tests/ui/async-await/higher-ranked-normalize-assumptions.rs
@@ -1,0 +1,51 @@
+//@ revisions: stock hr
+//@[hr] compile-flags: -Zhigher-ranked-assumptions
+//@ edition: 2024
+//@ check-pass
+
+// Test that we don't normalize the higher-ranked assumptions of an auto trait goal
+// unless we have `-Zhigher-ranked-assumptions`, since obligations that result from
+// this normalization may lead to higher-ranked lifetime errors when the flag is not
+// enabled.
+
+// Regression test for <https://github.com/rust-lang/rust/issues/147285>.
+
+pub trait Service {
+    type Response;
+}
+
+impl<T, R> Service for T
+where
+    T: FnMut() -> R,
+    R: 'static,
+{
+    type Response = R;
+}
+
+async fn serve<C>(_: C)
+where
+    C: Service,
+    C::Response: 'static,
+{
+    connect::<C>().await;
+}
+
+async fn connect<C>()
+where
+    C: Service,
+    C::Response: 'static,
+{
+}
+
+fn repro() -> impl Send {
+    async {
+        let server = || do_something();
+        serve(server).await;
+    }
+}
+
+fn do_something() -> Box<dyn std::error::Error> {
+    unimplemented!()
+}
+
+fn main() {}


### PR DESCRIPTION
See the comment in the code. 

Normalizing these assumptions may cause us to register things like new placeholder outlives obligations that cause higher-ranked lifetime errors, and this is problematic if we're not even using these assumptions in borrowck.

Fixes rust-lang/rust#147244
Fixes rust-lang/rust#147285