### PR TITLE
Enable const tests for bool methods

### DIFF
--- a/library/core/src/bool.rs
+++ b/library/core/src/bool.rs
@@ -1,5 +1,7 @@
 //! impl bool {}
 
+use crate::marker::Destruct;
+
 impl bool {
     /// Returns `Some(t)` if the `bool` is [`true`](../std/keyword.true.html),
     /// or `None` otherwise.
@@ -29,6 +31,7 @@ impl bool {
     /// assert_eq!(a, 2);
     /// ```
     #[stable(feature = "bool_to_option", since = "1.62.0")]
+    #[rustc_const_stable(feature = "bool_to_option", since = "1.62.0")]
     #[inline]
     pub const fn then_some<T>(self, t: T) -> Option<T> {
         if self { Some(t) } else { None }
@@ -56,11 +59,12 @@ impl bool {
     /// ```
     #[doc(alias = "then_with")]
     #[stable(feature = "lazy_bool_to_option", since = "1.50.0")]
+    #[rustc_const_unstable(feature = "const_option_ops", issue = "143956")]
     #[rustc_diagnostic_item = "bool_then"]
     #[inline]
     pub const fn then<T, F: FnOnce() -> T>(self, f: F) -> Option<T>
     where
-        F: [const] FnOnce() -> T,
+        F: [const] FnOnce() -> T + [const] Destruct,
     {
         if self { Some(f()) } else { None }
     }

--- a/library/core/src/bool.rs
+++ b/library/core/src/bool.rs
@@ -30,7 +30,7 @@ impl bool {
     /// ```
     #[stable(feature = "bool_to_option", since = "1.62.0")]
     #[inline]
-    pub fn then_some<T>(self, t: T) -> Option<T> {
+    pub const fn then_some<T>(self, t: T) -> Option<T> {
         if self { Some(t) } else { None }
     }
 
@@ -58,7 +58,10 @@ impl bool {
     #[stable(feature = "lazy_bool_to_option", since = "1.50.0")]
     #[rustc_diagnostic_item = "bool_then"]
     #[inline]
-    pub fn then<T, F: FnOnce() -> T>(self, f: F) -> Option<T> {
+    pub const fn then<T, F: FnOnce() -> T>(self, f: F) -> Option<T>
+    where
+        F: [const] FnOnce() -> T,
+    {
         if self { Some(f()) } else { None }
     }
 

--- a/library/coretests/tests/bool.rs
+++ b/library/coretests/tests/bool.rs
@@ -89,7 +89,6 @@ fn test_bool_to_option() {
     assert_eq!(false.then(|| 0), None);
     assert_eq!(true.then(|| 0), Some(0));
 
-    /* FIXME(#110395)
     const fn zero() -> i32 {
         0
     }
@@ -103,7 +102,6 @@ fn test_bool_to_option() {
     assert_eq!(B, Some(0));
     assert_eq!(C, None);
     assert_eq!(D, Some(0));
-    */
 }
 
 #[test]


### PR DESCRIPTION
This change re-enables the const tests for bool::then_some and bool::then that were previously disabled with a FIXME comment referencing issue 110395.

The tests verify that these methods work correctly in const contexts, which is important for compile-time evaluation. These tests check that both the eager evaluation variant (then_some) and lazy evaluation variant (then) can be used to create constant Option values at compile time.

Tests added:
- Const evaluation of false.then_some(0) returning None
- Const evaluation of true.then_some(0) returning Some(0)
- Const evaluation of false.then(zero) returning None
- Const evaluation of true.then(zero) returning Some(0)

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
