### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_ast_passes/src/feature_gate.rs
+++ b/compiler/rustc_ast_passes/src/feature_gate.rs
@@ -622,11 +622,7 @@ fn maybe_stage_features(sess: &Session, features: &Features, krate: &ast::Crate)
 }
 
 fn check_incompatible_features(sess: &Session, features: &Features) {
-    let enabled_lang_features =
-        features.enabled_lang_features().iter().map(|feat| (feat.gate_name, feat.attr_sp));
-    let enabled_lib_features =
-        features.enabled_lib_features().iter().map(|feat| (feat.gate_name, feat.attr_sp));
-    let enabled_features = enabled_lang_features.chain(enabled_lib_features);
+    let enabled_features = features.enabled_features_iter_stable_order();
 
     for (f1, f2) in rustc_feature::INCOMPATIBLE_FEATURES
         .iter()

--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -93,6 +93,16 @@ impl Features {
         &self.enabled_features
     }
 
+    /// Returns a iterator of enabled features in stable order.
+    pub fn enabled_features_iter_stable_order(
+        &self,
+    ) -> impl Iterator<Item = (Symbol, Span)> + Clone {
+        self.enabled_lang_features
+            .iter()
+            .map(|feat| (feat.gate_name, feat.attr_sp))
+            .chain(self.enabled_lib_features.iter().map(|feat| (feat.gate_name, feat.attr_sp)))
+    }
+
     /// Is the given feature enabled (via `#[feature(...)]`)?
     pub fn enabled(&self, feature: Symbol) -> bool {
         self.enabled_features.contains(&feature)

--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -2331,13 +2331,9 @@ declare_lint_pass!(
 impl EarlyLintPass for IncompleteInternalFeatures {
     fn check_crate(&mut self, cx: &EarlyContext<'_>, _: &ast::Crate) {
         let features = cx.builder.features();
-        let lang_features =
-            features.enabled_lang_features().iter().map(|feat| (feat.gate_name, feat.attr_sp));
-        let lib_features =
-            features.enabled_lib_features().iter().map(|feat| (feat.gate_name, feat.attr_sp));
 
-        lang_features
-            .chain(lib_features)
+        features
+            .enabled_features_iter_stable_order()
             .filter(|(name, _)| features.incomplete(*name) || features.internal(*name))
             .for_each(|(name, span)| {
                 if features.incomplete(name) {

--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -2961,7 +2961,7 @@ impl<'a> Parser<'a> {
         if let CommaRecoveryMode::EitherTupleOrPipe = rt {
             err.span_suggestion(
                 comma_span,
-                "...or a vertical bar to match on alternative",
+                "...or a vertical bar to match on alternatives",
                 " |",
                 Applicability::MachineApplicable,
             );

--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -2947,26 +2947,24 @@ impl<'a> Parser<'a> {
         }
         let seq_span = lo.to(self.prev_token.span);
         let mut err = self.dcx().struct_span_err(comma_span, "unexpected `,` in pattern");
-        if let Ok(seq_snippet) = self.span_to_snippet(seq_span) {
-            err.multipart_suggestion(
-                format!(
-                    "try adding parentheses to match on a tuple{}",
-                    if let CommaRecoveryMode::LikelyTuple = rt { "" } else { "..." },
-                ),
-                vec![
-                    (seq_span.shrink_to_lo(), "(".to_string()),
-                    (seq_span.shrink_to_hi(), ")".to_string()),
-                ],
+        err.multipart_suggestion(
+            format!(
+                "try adding parentheses to match on a tuple{}",
+                if let CommaRecoveryMode::LikelyTuple = rt { "" } else { "..." },
+            ),
+            vec![
+                (seq_span.shrink_to_lo(), "(".to_string()),
+                (seq_span.shrink_to_hi(), ")".to_string()),
+            ],
+            Applicability::MachineApplicable,
+        );
+        if let CommaRecoveryMode::EitherTupleOrPipe = rt {
+            err.span_suggestion(
+                comma_span,
+                "...or a vertical bar to match on alternative",
+                " |",
                 Applicability::MachineApplicable,
             );
-            if let CommaRecoveryMode::EitherTupleOrPipe = rt {
-                err.span_suggestion(
-                    seq_span,
-                    "...or a vertical bar to match on multiple alternatives",
-                    seq_snippet.replace(',', " |"),
-                    Applicability::MachineApplicable,
-                );
-            }
         }
         Err(err)
     }

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -3182,6 +3182,7 @@ impl Target {
             "avr" => (Architecture::Avr, None),
             "msp430" => (Architecture::Msp430, None),
             "hexagon" => (Architecture::Hexagon, None),
+            "xtensa" => (Architecture::Xtensa, None),
             "bpf" => (Architecture::Bpf, None),
             "loongarch32" => (Architecture::LoongArch32, None),
             "loongarch64" => (Architecture::LoongArch64, None),

--- a/src/librustdoc/doctest.rs
+++ b/src/librustdoc/doctest.rs
@@ -173,6 +173,7 @@ pub(crate) fn run(dcx: DiagCtxtHandle<'_>, input: Input, options: RustdocOptions
         target_triple: options.target.clone(),
         crate_name: options.crate_name.clone(),
         remap_path_prefix: options.remap_path_prefix.clone(),
+        unstable_opts: options.unstable_opts.clone(),
         ..config::Options::default()
     };
 

--- a/src/librustdoc/doctest.rs
+++ b/src/librustdoc/doctest.rs
@@ -174,6 +174,7 @@ pub(crate) fn run(dcx: DiagCtxtHandle<'_>, input: Input, options: RustdocOptions
         crate_name: options.crate_name.clone(),
         remap_path_prefix: options.remap_path_prefix.clone(),
         unstable_opts: options.unstable_opts.clone(),
+        error_format: options.error_format.clone(),
         ..config::Options::default()
     };
 

--- a/tests/rustdoc-ui/doctest/check-attr-test.rs
+++ b/tests/rustdoc-ui/doctest/check-attr-test.rs
@@ -2,6 +2,9 @@
 
 #![deny(rustdoc::invalid_codeblock_attributes)]
 
+//~vvv ERROR unknown attribute `compile-fail`
+//~| ERROR unknown attribute `compilefail`
+//~| ERROR unknown attribute `comPile_fail`
 /// foo
 ///
 /// ```compile-fail,compilefail,comPile_fail
@@ -9,6 +12,9 @@
 /// ```
 pub fn foo() {}
 
+//~vvv ERROR unknown attribute `should-panic`
+//~| ERROR unknown attribute `shouldpanic`
+//~| ERROR unknown attribute `shOuld_panic`
 /// bar
 ///
 /// ```should-panic,shouldpanic,shOuld_panic
@@ -16,6 +22,9 @@ pub fn foo() {}
 /// ```
 pub fn bar() {}
 
+//~vvv ERROR unknown attribute `no-run`
+//~| ERROR unknown attribute `norun`
+//~| ERROR unknown attribute `nO_run`
 /// foobar
 ///
 /// ```no-run,norun,nO_run
@@ -23,6 +32,9 @@ pub fn bar() {}
 /// ```
 pub fn foobar() {}
 
+//~vvv ERROR unknown attribute `test-harness`
+//~| ERROR unknown attribute `testharness`
+//~| ERROR unknown attribute `tesT_harness`
 /// b
 ///
 /// ```test-harness,testharness,tesT_harness

--- a/tests/rustdoc-ui/doctest/check-attr-test.stderr
+++ b/tests/rustdoc-ui/doctest/check-attr-test.stderr
@@ -1,5 +1,5 @@
 error: unknown attribute `compile-fail`
-  --> $DIR/check-attr-test.rs:5:1
+  --> $DIR/check-attr-test.rs:8:1
    |
 LL | / /// foo
 LL | | ///
@@ -17,7 +17,7 @@ LL | #![deny(rustdoc::invalid_codeblock_attributes)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: unknown attribute `compilefail`
-  --> $DIR/check-attr-test.rs:5:1
+  --> $DIR/check-attr-test.rs:8:1
    |
 LL | / /// foo
 LL | | ///
@@ -30,7 +30,7 @@ LL | | /// ```
    = help: this code block may be skipped during testing, because unknown attributes are treated as markers for code samples written in other programming languages, unless it is also explicitly marked as `rust`
 
 error: unknown attribute `comPile_fail`
-  --> $DIR/check-attr-test.rs:5:1
+  --> $DIR/check-attr-test.rs:8:1
    |
 LL | / /// foo
 LL | | ///
@@ -43,7 +43,7 @@ LL | | /// ```
    = help: this code block may be skipped during testing, because unknown attributes are treated as markers for code samples written in other programming languages, unless it is also explicitly marked as `rust`
 
 error: unknown attribute `should-panic`
-  --> $DIR/check-attr-test.rs:12:1
+  --> $DIR/check-attr-test.rs:18:1
    |
 LL | / /// bar
 LL | | ///
@@ -56,7 +56,7 @@ LL | | /// ```
    = help: this code block may be skipped during testing, because unknown attributes are treated as markers for code samples written in other programming languages, unless it is also explicitly marked as `rust`
 
 error: unknown attribute `shouldpanic`
-  --> $DIR/check-attr-test.rs:12:1
+  --> $DIR/check-attr-test.rs:18:1
    |
 LL | / /// bar
 LL | | ///
@@ -69,7 +69,7 @@ LL | | /// ```
    = help: this code block may be skipped during testing, because unknown attributes are treated as markers for code samples written in other programming languages, unless it is also explicitly marked as `rust`
 
 error: unknown attribute `shOuld_panic`
-  --> $DIR/check-attr-test.rs:12:1
+  --> $DIR/check-attr-test.rs:18:1
    |
 LL | / /// bar
 LL | | ///
@@ -82,7 +82,7 @@ LL | | /// ```
    = help: this code block may be skipped during testing, because unknown attributes are treated as markers for code samples written in other programming languages, unless it is also explicitly marked as `rust`
 
 error: unknown attribute `no-run`
-  --> $DIR/check-attr-test.rs:19:1
+  --> $DIR/check-attr-test.rs:28:1
    |
 LL | / /// foobar
 LL | | ///
@@ -95,7 +95,7 @@ LL | | /// ```
    = help: this code block may be skipped during testing, because unknown attributes are treated as markers for code samples written in other programming languages, unless it is also explicitly marked as `rust`
 
 error: unknown attribute `norun`
-  --> $DIR/check-attr-test.rs:19:1
+  --> $DIR/check-attr-test.rs:28:1
    |
 LL | / /// foobar
 LL | | ///
@@ -108,7 +108,7 @@ LL | | /// ```
    = help: this code block may be skipped during testing, because unknown attributes are treated as markers for code samples written in other programming languages, unless it is also explicitly marked as `rust`
 
 error: unknown attribute `nO_run`
-  --> $DIR/check-attr-test.rs:19:1
+  --> $DIR/check-attr-test.rs:28:1
    |
 LL | / /// foobar
 LL | | ///
@@ -121,7 +121,7 @@ LL | | /// ```
    = help: this code block may be skipped during testing, because unknown attributes are treated as markers for code samples written in other programming languages, unless it is also explicitly marked as `rust`
 
 error: unknown attribute `test-harness`
-  --> $DIR/check-attr-test.rs:26:1
+  --> $DIR/check-attr-test.rs:38:1
    |
 LL | / /// b
 LL | | ///
@@ -134,7 +134,7 @@ LL | | /// ```
    = help: this code block may be skipped during testing, because unknown attributes are treated as markers for code samples written in other programming languages, unless it is also explicitly marked as `rust`
 
 error: unknown attribute `testharness`
-  --> $DIR/check-attr-test.rs:26:1
+  --> $DIR/check-attr-test.rs:38:1
    |
 LL | / /// b
 LL | | ///
@@ -147,7 +147,7 @@ LL | | /// ```
    = help: this code block may be skipped during testing, because unknown attributes are treated as markers for code samples written in other programming languages, unless it is also explicitly marked as `rust`
 
 error: unknown attribute `tesT_harness`
-  --> $DIR/check-attr-test.rs:26:1
+  --> $DIR/check-attr-test.rs:38:1
    |
 LL | / /// b
 LL | | ///

--- a/tests/rustdoc-ui/doctest/check-attr-test.stderr
+++ b/tests/rustdoc-ui/doctest/check-attr-test.stderr
@@ -1,55 +1,55 @@
 error: unknown attribute `compile-fail`
- --> $DIR/check-attr-test.rs:5:1
-  |
-5 | / /// foo
-6 | | ///
-7 | | /// ```compile-fail,compilefail,comPile_fail
-8 | | /// boo
-9 | | /// ```
-  | |_______^
-  |
-  = help: use `compile_fail` to invert the results of this test, so that it passes if it cannot be compiled and fails if it can
-  = help: this code block may be skipped during testing, because unknown attributes are treated as markers for code samples written in other programming languages, unless it is also explicitly marked as `rust`
+  --> $DIR/check-attr-test.rs:5:1
+   |
+LL | / /// foo
+LL | | ///
+LL | | /// ```compile-fail,compilefail,comPile_fail
+LL | | /// boo
+LL | | /// ```
+   | |_______^
+   |
+   = help: use `compile_fail` to invert the results of this test, so that it passes if it cannot be compiled and fails if it can
+   = help: this code block may be skipped during testing, because unknown attributes are treated as markers for code samples written in other programming languages, unless it is also explicitly marked as `rust`
 note: the lint level is defined here
- --> $DIR/check-attr-test.rs:3:9
-  |
-3 | #![deny(rustdoc::invalid_codeblock_attributes)]
-  |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  --> $DIR/check-attr-test.rs:3:9
+   |
+LL | #![deny(rustdoc::invalid_codeblock_attributes)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: unknown attribute `compilefail`
- --> $DIR/check-attr-test.rs:5:1
-  |
-5 | / /// foo
-6 | | ///
-7 | | /// ```compile-fail,compilefail,comPile_fail
-8 | | /// boo
-9 | | /// ```
-  | |_______^
-  |
-  = help: use `compile_fail` to invert the results of this test, so that it passes if it cannot be compiled and fails if it can
-  = help: this code block may be skipped during testing, because unknown attributes are treated as markers for code samples written in other programming languages, unless it is also explicitly marked as `rust`
+  --> $DIR/check-attr-test.rs:5:1
+   |
+LL | / /// foo
+LL | | ///
+LL | | /// ```compile-fail,compilefail,comPile_fail
+LL | | /// boo
+LL | | /// ```
+   | |_______^
+   |
+   = help: use `compile_fail` to invert the results of this test, so that it passes if it cannot be compiled and fails if it can
+   = help: this code block may be skipped during testing, because unknown attributes are treated as markers for code samples written in other programming languages, unless it is also explicitly marked as `rust`
 
 error: unknown attribute `comPile_fail`
- --> $DIR/check-attr-test.rs:5:1
-  |
-5 | / /// foo
-6 | | ///
-7 | | /// ```compile-fail,compilefail,comPile_fail
-8 | | /// boo
-9 | | /// ```
-  | |_______^
-  |
-  = help: use `compile_fail` to invert the results of this test, so that it passes if it cannot be compiled and fails if it can
-  = help: this code block may be skipped during testing, because unknown attributes are treated as markers for code samples written in other programming languages, unless it is also explicitly marked as `rust`
+  --> $DIR/check-attr-test.rs:5:1
+   |
+LL | / /// foo
+LL | | ///
+LL | | /// ```compile-fail,compilefail,comPile_fail
+LL | | /// boo
+LL | | /// ```
+   | |_______^
+   |
+   = help: use `compile_fail` to invert the results of this test, so that it passes if it cannot be compiled and fails if it can
+   = help: this code block may be skipped during testing, because unknown attributes are treated as markers for code samples written in other programming languages, unless it is also explicitly marked as `rust`
 
 error: unknown attribute `should-panic`
   --> $DIR/check-attr-test.rs:12:1
    |
-12 | / /// bar
-13 | | ///
-14 | | /// ```should-panic,shouldpanic,shOuld_panic
-15 | | /// boo
-16 | | /// ```
+LL | / /// bar
+LL | | ///
+LL | | /// ```should-panic,shouldpanic,shOuld_panic
+LL | | /// boo
+LL | | /// ```
    | |_______^
    |
    = help: use `should_panic` to invert the results of this test, so that if passes if it panics and fails if it does not
@@ -58,11 +58,11 @@ error: unknown attribute `should-panic`
 error: unknown attribute `shouldpanic`
   --> $DIR/check-attr-test.rs:12:1
    |
-12 | / /// bar
-13 | | ///
-14 | | /// ```should-panic,shouldpanic,shOuld_panic
-15 | | /// boo
-16 | | /// ```
+LL | / /// bar
+LL | | ///
+LL | | /// ```should-panic,shouldpanic,shOuld_panic
+LL | | /// boo
+LL | | /// ```
    | |_______^
    |
    = help: use `should_panic` to invert the results of this test, so that if passes if it panics and fails if it does not
@@ -71,11 +71,11 @@ error: unknown attribute `shouldpanic`
 error: unknown attribute `shOuld_panic`
   --> $DIR/check-attr-test.rs:12:1
    |
-12 | / /// bar
-13 | | ///
-14 | | /// ```should-panic,shouldpanic,shOuld_panic
-15 | | /// boo
-16 | | /// ```
+LL | / /// bar
+LL | | ///
+LL | | /// ```should-panic,shouldpanic,shOuld_panic
+LL | | /// boo
+LL | | /// ```
    | |_______^
    |
    = help: use `should_panic` to invert the results of this test, so that if passes if it panics and fails if it does not
@@ -84,11 +84,11 @@ error: unknown attribute `shOuld_panic`
 error: unknown attribute `no-run`
   --> $DIR/check-attr-test.rs:19:1
    |
-19 | / /// foobar
-20 | | ///
-21 | | /// ```no-run,norun,nO_run
-22 | | /// boo
-23 | | /// ```
+LL | / /// foobar
+LL | | ///
+LL | | /// ```no-run,norun,nO_run
+LL | | /// boo
+LL | | /// ```
    | |_______^
    |
    = help: use `no_run` to compile, but not run, the code sample during testing
@@ -97,11 +97,11 @@ error: unknown attribute `no-run`
 error: unknown attribute `norun`
   --> $DIR/check-attr-test.rs:19:1
    |
-19 | / /// foobar
-20 | | ///
-21 | | /// ```no-run,norun,nO_run
-22 | | /// boo
-23 | | /// ```
+LL | / /// foobar
+LL | | ///
+LL | | /// ```no-run,norun,nO_run
+LL | | /// boo
+LL | | /// ```
    | |_______^
    |
    = help: use `no_run` to compile, but not run, the code sample during testing
@@ -110,11 +110,11 @@ error: unknown attribute `norun`
 error: unknown attribute `nO_run`
   --> $DIR/check-attr-test.rs:19:1
    |
-19 | / /// foobar
-20 | | ///
-21 | | /// ```no-run,norun,nO_run
-22 | | /// boo
-23 | | /// ```
+LL | / /// foobar
+LL | | ///
+LL | | /// ```no-run,norun,nO_run
+LL | | /// boo
+LL | | /// ```
    | |_______^
    |
    = help: use `no_run` to compile, but not run, the code sample during testing
@@ -123,11 +123,11 @@ error: unknown attribute `nO_run`
 error: unknown attribute `test-harness`
   --> $DIR/check-attr-test.rs:26:1
    |
-26 | / /// b
-27 | | ///
-28 | | /// ```test-harness,testharness,tesT_harness
-29 | | /// boo
-30 | | /// ```
+LL | / /// b
+LL | | ///
+LL | | /// ```test-harness,testharness,tesT_harness
+LL | | /// boo
+LL | | /// ```
    | |_______^
    |
    = help: use `test_harness` to run functions marked `#[test]` instead of a potentially-implicit `main` function
@@ -136,11 +136,11 @@ error: unknown attribute `test-harness`
 error: unknown attribute `testharness`
   --> $DIR/check-attr-test.rs:26:1
    |
-26 | / /// b
-27 | | ///
-28 | | /// ```test-harness,testharness,tesT_harness
-29 | | /// boo
-30 | | /// ```
+LL | / /// b
+LL | | ///
+LL | | /// ```test-harness,testharness,tesT_harness
+LL | | /// boo
+LL | | /// ```
    | |_______^
    |
    = help: use `test_harness` to run functions marked `#[test]` instead of a potentially-implicit `main` function
@@ -149,11 +149,11 @@ error: unknown attribute `testharness`
 error: unknown attribute `tesT_harness`
   --> $DIR/check-attr-test.rs:26:1
    |
-26 | / /// b
-27 | | ///
-28 | | /// ```test-harness,testharness,tesT_harness
-29 | | /// boo
-30 | | /// ```
+LL | / /// b
+LL | | ///
+LL | | /// ```test-harness,testharness,tesT_harness
+LL | | /// boo
+LL | | /// ```
    | |_______^
    |
    = help: use `test_harness` to run functions marked `#[test]` instead of a potentially-implicit `main` function

--- a/tests/rustdoc-ui/doctest/failed-doctest-extra-semicolon-on-item.rs
+++ b/tests/rustdoc-ui/doctest/failed-doctest-extra-semicolon-on-item.rs
@@ -9,6 +9,7 @@
 /// <https://github.com/rust-lang/rust/issues/91014>
 ///
 /// ```rust
+//~^ WARN the `main` function of this doctest won't be run
 /// struct S {};
 ///
 /// fn main() {

--- a/tests/rustdoc-ui/doctest/failed-doctest-extra-semicolon-on-item.stderr
+++ b/tests/rustdoc-ui/doctest/failed-doctest-extra-semicolon-on-item.stderr
@@ -1,7 +1,7 @@
 warning: the `main` function of this doctest won't be run as it contains expressions at the top level, meaning that the whole doctest code will be wrapped in a function
   --> $DIR/failed-doctest-extra-semicolon-on-item.rs:11:1
    |
-11 | /// ```rust
+LL | /// ```rust
    | ^^^^^^^^^^^
 
 warning: 1 warning emitted

--- a/tests/rustdoc-ui/doctest/main-alongside-stmts.rs
+++ b/tests/rustdoc-ui/doctest/main-alongside-stmts.rs
@@ -14,6 +14,7 @@
 //@ normalize-stdout: "finished in \d+\.\d+s" -> "finished in $$TIME"
 //@ check-pass
 
+//~v WARN the `main` function of this doctest won't be run
 //! ```
 //! # if cfg!(miri) { return; }
 //! use std::ops::Deref;
@@ -22,6 +23,7 @@
 //!     assert!(false);
 //! }
 //! ```
+//~v WARN the `main` function of this doctest won't be run
 //!
 //! ```
 //! let x = 2;

--- a/tests/rustdoc-ui/doctest/main-alongside-stmts.stderr
+++ b/tests/rustdoc-ui/doctest/main-alongside-stmts.stderr
@@ -1,13 +1,13 @@
 warning: the `main` function of this doctest won't be run as it contains expressions at the top level, meaning that the whole doctest code will be wrapped in a function
   --> $DIR/main-alongside-stmts.rs:17:1
    |
-17 | //! ```
+LL | //! ```
    | ^^^^^^^
 
 warning: the `main` function of this doctest won't be run as it contains expressions at the top level, meaning that the whole doctest code will be wrapped in a function
   --> $DIR/main-alongside-stmts.rs:26:1
    |
-26 | //! ```
+LL | //! ```
    | ^^^^^^^
 
 warning: 2 warnings emitted

--- a/tests/rustdoc-ui/doctest/main-alongside-stmts.stderr
+++ b/tests/rustdoc-ui/doctest/main-alongside-stmts.stderr
@@ -1,14 +1,14 @@
 warning: the `main` function of this doctest won't be run as it contains expressions at the top level, meaning that the whole doctest code will be wrapped in a function
-  --> $DIR/main-alongside-stmts.rs:17:1
+  --> $DIR/main-alongside-stmts.rs:18:1
    |
 LL | //! ```
    | ^^^^^^^
 
 warning: the `main` function of this doctest won't be run as it contains expressions at the top level, meaning that the whole doctest code will be wrapped in a function
-  --> $DIR/main-alongside-stmts.rs:26:1
+  --> $DIR/main-alongside-stmts.rs:27:1
    |
-LL | //! ```
-   | ^^^^^^^
+LL | //!
+   | ^^^
 
 warning: 2 warnings emitted
 

--- a/tests/rustdoc-ui/doctest/main-alongside-stmts.stdout
+++ b/tests/rustdoc-ui/doctest/main-alongside-stmts.stdout
@@ -1,7 +1,7 @@
 
 running 2 tests
-test $DIR/main-alongside-stmts.rs - (line 17) ... ok
-test $DIR/main-alongside-stmts.rs - (line 26) ... ok
+test $DIR/main-alongside-stmts.rs - (line 18) ... ok
+test $DIR/main-alongside-stmts.rs - (line 27) ... ok
 
 test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
 

--- a/tests/rustdoc-ui/doctest/standalone-warning-2024.rs
+++ b/tests/rustdoc-ui/doctest/standalone-warning-2024.rs
@@ -9,6 +9,8 @@
 #![deny(warnings)]
 
 //! ```standalone
+//~^ ERROR unknown attribute `standalone`
+//~| ERROR unknown attribute `standalone-crate`
 //! bla
 //! ```
 //!

--- a/tests/rustdoc-ui/doctest/standalone-warning-2024.stderr
+++ b/tests/rustdoc-ui/doctest/standalone-warning-2024.stderr
@@ -2,10 +2,10 @@ error: unknown attribute `standalone`
   --> $DIR/standalone-warning-2024.rs:11:1
    |
 LL | / //! ```standalone
+LL | |
+LL | |
 LL | | //! bla
-LL | | //! ```
-LL | | //!
-LL | | //! ```standalone-crate
+...  |
 LL | | //! bla
 LL | | //! ```
    | |_______^
@@ -23,10 +23,10 @@ error: unknown attribute `standalone-crate`
   --> $DIR/standalone-warning-2024.rs:11:1
    |
 LL | / //! ```standalone
+LL | |
+LL | |
 LL | | //! bla
-LL | | //! ```
-LL | | //!
-LL | | //! ```standalone-crate
+...  |
 LL | | //! bla
 LL | | //! ```
    | |_______^

--- a/tests/rustdoc-ui/doctest/standalone-warning-2024.stderr
+++ b/tests/rustdoc-ui/doctest/standalone-warning-2024.stderr
@@ -1,13 +1,13 @@
 error: unknown attribute `standalone`
   --> $DIR/standalone-warning-2024.rs:11:1
    |
-11 | / //! ```standalone
-12 | | //! bla
-13 | | //! ```
-14 | | //!
-15 | | //! ```standalone-crate
-16 | | //! bla
-17 | | //! ```
+LL | / //! ```standalone
+LL | | //! bla
+LL | | //! ```
+LL | | //!
+LL | | //! ```standalone-crate
+LL | | //! bla
+LL | | //! ```
    | |_______^
    |
    = help: use `standalone_crate` to compile this code block separately
@@ -15,20 +15,20 @@ error: unknown attribute `standalone`
 note: the lint level is defined here
   --> $DIR/standalone-warning-2024.rs:9:9
    |
- 9 | #![deny(warnings)]
+LL | #![deny(warnings)]
    |         ^^^^^^^^
    = note: `#[deny(rustdoc::invalid_codeblock_attributes)]` implied by `#[deny(warnings)]`
 
 error: unknown attribute `standalone-crate`
   --> $DIR/standalone-warning-2024.rs:11:1
    |
-11 | / //! ```standalone
-12 | | //! bla
-13 | | //! ```
-14 | | //!
-15 | | //! ```standalone-crate
-16 | | //! bla
-17 | | //! ```
+LL | / //! ```standalone
+LL | | //! bla
+LL | | //! ```
+LL | | //!
+LL | | //! ```standalone-crate
+LL | | //! bla
+LL | | //! ```
    | |_______^
    |
    = help: use `standalone_crate` to compile this code block separately

--- a/tests/rustdoc-ui/doctest/test-compile-fail1.rs
+++ b/tests/rustdoc-ui/doctest/test-compile-fail1.rs
@@ -6,3 +6,4 @@
 pub fn f() {}
 
 pub fn f() {}
+//~^ ERROR the name `f` is defined multiple times

--- a/tests/rustdoc-ui/doctest/test-compile-fail1.stderr
+++ b/tests/rustdoc-ui/doctest/test-compile-fail1.stderr
@@ -1,13 +1,13 @@
 error[E0428]: the name `f` is defined multiple times
- --> $DIR/test-compile-fail1.rs:8:1
-  |
-6 | pub fn f() {}
-  | ---------- previous definition of the value `f` here
-7 |
-8 | pub fn f() {}
-  | ^^^^^^^^^^ `f` redefined here
-  |
-  = note: `f` must be defined only once in the value namespace of this module
+  --> $DIR/test-compile-fail1.rs:8:1
+   |
+LL | pub fn f() {}
+   | ---------- previous definition of the value `f` here
+LL |
+LL | pub fn f() {}
+   | ^^^^^^^^^^ `f` redefined here
+   |
+   = note: `f` must be defined only once in the value namespace of this module
 
 error: aborting due to 1 previous error
 

--- a/tests/rustdoc-ui/doctest/test-compile-fail2.rs
+++ b/tests/rustdoc-ui/doctest/test-compile-fail2.rs
@@ -1,3 +1,4 @@
 //@ compile-flags:--test
 
 fail
+//~^ ERROR

--- a/tests/rustdoc-ui/doctest/test-compile-fail2.stderr
+++ b/tests/rustdoc-ui/doctest/test-compile-fail2.stderr
@@ -1,8 +1,8 @@
 error: expected one of `!` or `::`, found `<eof>`
- --> $DIR/test-compile-fail2.rs:3:1
-  |
-3 | fail
-  | ^^^^ expected one of `!` or `::`
+  --> $DIR/test-compile-fail2.rs:3:1
+   |
+LL | fail
+   | ^^^^ expected one of `!` or `::`
 
 error: aborting due to 1 previous error
 

--- a/tests/rustdoc-ui/doctest/test-compile-fail3.rs
+++ b/tests/rustdoc-ui/doctest/test-compile-fail3.rs
@@ -1,3 +1,4 @@
 //@ compile-flags:--test
 
 "fail
+//~^ ERROR

--- a/tests/rustdoc-ui/doctest/test-compile-fail3.stderr
+++ b/tests/rustdoc-ui/doctest/test-compile-fail3.stderr
@@ -1,8 +1,8 @@
 error[E0765]: unterminated double quote string
- --> $DIR/test-compile-fail3.rs:3:1
-  |
-3 | "fail
-  | ^^^^^
+  --> $DIR/test-compile-fail3.rs:3:1
+   |
+LL | "fail
+   | ^^^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/rustdoc-ui/doctest/test-compile-fail3.stderr
+++ b/tests/rustdoc-ui/doctest/test-compile-fail3.stderr
@@ -1,8 +1,9 @@
 error[E0765]: unterminated double quote string
   --> $DIR/test-compile-fail3.rs:3:1
    |
-LL | "fail
-   | ^^^^^
+LL | / "fail
+LL | |
+   | |___________^
 
 error: aborting due to 1 previous error
 

--- a/tests/rustdoc-ui/doctest/unstable-opts-143930.rs
+++ b/tests/rustdoc-ui/doctest/unstable-opts-143930.rs
@@ -1,0 +1,14 @@
+// This test verifies that unstable options like `-Zcrate-attr` are respected when `--test` is
+// passed.
+//
+// <https://github.com/rust-lang/rust/issues/143930>
+//
+// NOTE: If any of these command line arguments or features get stabilized, please replace with
+// another unstable one.
+
+//@ check-pass
+//@ normalize-stdout: "finished in \d+\.\d+s" -> "finished in $$TIME"
+//@ compile-flags: --test -Zcrate-attr=feature(register_tool) -Zcrate-attr=register_tool(rapx)
+
+#[rapx::tag]
+fn f() {}

--- a/tests/rustdoc-ui/doctest/unstable-opts-143930.stdout
+++ b/tests/rustdoc-ui/doctest/unstable-opts-143930.stdout
@@ -1,0 +1,5 @@
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
+

--- a/tests/rustdoc-ui/doctest/unstable-opts-147276.crate_attr.stdout
+++ b/tests/rustdoc-ui/doctest/unstable-opts-147276.crate_attr.stdout
@@ -1,0 +1,5 @@
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
+

--- a/tests/rustdoc-ui/doctest/unstable-opts-147276.normal.stderr
+++ b/tests/rustdoc-ui/doctest/unstable-opts-147276.normal.stderr
@@ -1,0 +1,13 @@
+error[E0658]: `#[used(linker)]` is currently unstable
+  --> $DIR/unstable-opts-147276.rs:15:1
+   |
+LL | #[used(linker)]
+   | ^^^^^^^^^^^^^^^
+   |
+   = note: see issue #93798 <https://github.com/rust-lang/rust/issues/93798> for more information
+   = help: add `#![feature(used_with_arg)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/rustdoc-ui/doctest/unstable-opts-147276.rs
+++ b/tests/rustdoc-ui/doctest/unstable-opts-147276.rs
@@ -1,0 +1,17 @@
+// This test verifies that unstable options like `-Zcrate-attr` are respected when `--test` is
+// passed.
+//
+// <https://github.com/rust-lang/rust/issues/147276>
+//
+// NOTE: If any of these command line arguments or features get stabilized, please replace with
+// another unstable one.
+
+//@ revisions: normal crate_attr
+//@ compile-flags: --test
+//@ normalize-stdout: "finished in \d+\.\d+s" -> "finished in $$TIME"
+//@[crate_attr] check-pass
+//@[crate_attr] compile-flags: -Zcrate-attr=feature(used_with_arg)
+
+#[used(linker)]
+//[normal]~^ ERROR `#[used(linker)]` is currently unstable
+static REPRO: isize = 1;

--- a/tests/rustdoc-ui/doctest/warn-main-not-called.rs
+++ b/tests/rustdoc-ui/doctest/warn-main-not-called.rs
@@ -8,6 +8,7 @@
 // won't be called.
 
 //! ```
+//~^ WARN the `main` function of this doctest won't be run
 //! macro_rules! bla {
 //!     ($($x:tt)*) => {}
 //! }
@@ -17,6 +18,7 @@
 //! ```
 //!
 //! ```
+//~^^ WARN the `main` function of this doctest won't be run
 //! let x = 12;
 //! fn main() {}
 //! ```

--- a/tests/rustdoc-ui/doctest/warn-main-not-called.stderr
+++ b/tests/rustdoc-ui/doctest/warn-main-not-called.stderr
@@ -1,13 +1,13 @@
 warning: the `main` function of this doctest won't be run as it contains expressions at the top level, meaning that the whole doctest code will be wrapped in a function
   --> $DIR/warn-main-not-called.rs:10:1
    |
-10 | //! ```
+LL | //! ```
    | ^^^^^^^
 
 warning: the `main` function of this doctest won't be run as it contains expressions at the top level, meaning that the whole doctest code will be wrapped in a function
   --> $DIR/warn-main-not-called.rs:19:1
    |
-19 | //! ```
+LL | //! ```
    | ^^^^^^^
 
 warning: 2 warnings emitted

--- a/tests/rustdoc-ui/doctest/warn-main-not-called.stderr
+++ b/tests/rustdoc-ui/doctest/warn-main-not-called.stderr
@@ -7,8 +7,8 @@ LL | //! ```
 warning: the `main` function of this doctest won't be run as it contains expressions at the top level, meaning that the whole doctest code will be wrapped in a function
   --> $DIR/warn-main-not-called.rs:19:1
    |
-LL | //! ```
-   | ^^^^^^^
+LL | //!
+   | ^^^
 
 warning: 2 warnings emitted
 

--- a/tests/ui/associated-types/projection-dyn-associated-type.rs
+++ b/tests/ui/associated-types/projection-dyn-associated-type.rs
@@ -1,0 +1,28 @@
+// Regression test for the projection bug in <https://github.com/rust-lang/rust/issues/123953>
+//
+//@ compile-flags: -Zincremental-verify-ich=yes
+//@ incremental
+
+pub trait A {}
+pub trait B: A {}
+
+pub trait Mirror {
+    type Assoc: ?Sized;
+}
+
+impl<T: ?Sized> Mirror for A {
+    //~^ ERROR the type parameter `T` is not constrained by the impl trait, self type, or predicates [E0207]
+    //~| WARN trait objects without an explicit `dyn` are deprecated [bare_trait_objects]
+    //~| WARN this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
+    type Assoc = T;
+}
+
+pub fn foo<'a>(
+    x: &'a <dyn A + 'static as Mirror>::Assoc
+) -> &'a <dyn B + 'static as Mirror>::Assoc {
+    //~^ ERROR the trait bound `(dyn B + 'static): Mirror` is not satisfied [E0277]
+    //~| ERROR the trait bound `(dyn B + 'static): Mirror` is not satisfied [E0277]
+    static
+} //~ ERROR expected identifier, found `}`
+
+pub fn main() {}

--- a/tests/ui/associated-types/projection-dyn-associated-type.stderr
+++ b/tests/ui/associated-types/projection-dyn-associated-type.stderr
@@ -1,0 +1,52 @@
+error: expected identifier, found `}`
+  --> $DIR/projection-dyn-associated-type.rs:26:1
+   |
+LL | }
+   | ^ expected identifier
+
+warning: trait objects without an explicit `dyn` are deprecated
+  --> $DIR/projection-dyn-associated-type.rs:13:28
+   |
+LL | impl<T: ?Sized> Mirror for A {
+   |                            ^
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: `#[warn(bare_trait_objects)]` (part of `#[warn(rust_2021_compatibility)]`) on by default
+help: if this is a dyn-compatible trait, use `dyn`
+   |
+LL | impl<T: ?Sized> Mirror for dyn A {
+   |                            +++
+help: alternatively use a blanket implementation to implement `Mirror` for all types that also implement `A`
+   |
+LL - impl<T: ?Sized> Mirror for A {
+LL + impl<T: ?Sized, U: A> Mirror for U {
+   |
+
+error[E0207]: the type parameter `T` is not constrained by the impl trait, self type, or predicates
+  --> $DIR/projection-dyn-associated-type.rs:13:6
+   |
+LL | impl<T: ?Sized> Mirror for A {
+   |      ^ unconstrained type parameter
+
+error[E0277]: the trait bound `(dyn B + 'static): Mirror` is not satisfied
+  --> $DIR/projection-dyn-associated-type.rs:22:6
+   |
+LL | ) -> &'a <dyn B + 'static as Mirror>::Assoc {
+   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Mirror` is not implemented for `(dyn B + 'static)`
+   |
+   = help: the trait `Mirror` is implemented for `dyn A`
+
+error[E0277]: the trait bound `(dyn B + 'static): Mirror` is not satisfied
+  --> $DIR/projection-dyn-associated-type.rs:22:6
+   |
+LL | ) -> &'a <dyn B + 'static as Mirror>::Assoc {
+   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Mirror` is not implemented for `(dyn B + 'static)`
+   |
+   = help: the trait `Mirror` is implemented for `dyn A`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 4 previous errors; 1 warning emitted
+
+Some errors have detailed explanations: E0207, E0277.
+For more information about an error, try `rustc --explain E0207`.

--- a/tests/ui/did_you_mean/issue-48492-tuple-destructure-missing-parens.stderr
+++ b/tests/ui/did_you_mean/issue-48492-tuple-destructure-missing-parens.stderr
@@ -32,10 +32,10 @@ help: try adding parentheses to match on a tuple...
    |
 LL |         (Nucleotide::Adenine, Nucleotide::Cytosine, _) => true
    |         +                                            +
-help: ...or a vertical bar to match on multiple alternatives
+help: ...or a vertical bar to match on alternative
    |
 LL -         Nucleotide::Adenine, Nucleotide::Cytosine, _ => true
-LL +         Nucleotide::Adenine | Nucleotide::Cytosine | _ => true
+LL +         Nucleotide::Adenine | Nucleotide::Cytosine, _ => true
    |
 
 error: unexpected `,` in pattern

--- a/tests/ui/did_you_mean/issue-48492-tuple-destructure-missing-parens.stderr
+++ b/tests/ui/did_you_mean/issue-48492-tuple-destructure-missing-parens.stderr
@@ -32,7 +32,7 @@ help: try adding parentheses to match on a tuple...
    |
 LL |         (Nucleotide::Adenine, Nucleotide::Cytosine, _) => true
    |         +                                            +
-help: ...or a vertical bar to match on alternative
+help: ...or a vertical bar to match on alternatives
    |
 LL -         Nucleotide::Adenine, Nucleotide::Cytosine, _ => true
 LL +         Nucleotide::Adenine | Nucleotide::Cytosine, _ => true

--- a/tests/ui/feature-gates/feature-gate-never_patterns.stderr
+++ b/tests/ui/feature-gates/feature-gate-never_patterns.stderr
@@ -8,7 +8,7 @@ help: try adding parentheses to match on a tuple...
    |
 LL |         (Some(_),)
    |         +        +
-help: ...or a vertical bar to match on alternative
+help: ...or a vertical bar to match on alternatives
    |
 LL -         Some(_),
 LL +         Some(_) |

--- a/tests/ui/feature-gates/feature-gate-never_patterns.stderr
+++ b/tests/ui/feature-gates/feature-gate-never_patterns.stderr
@@ -8,7 +8,7 @@ help: try adding parentheses to match on a tuple...
    |
 LL |         (Some(_),)
    |         +        +
-help: ...or a vertical bar to match on multiple alternatives
+help: ...or a vertical bar to match on alternative
    |
 LL -         Some(_),
 LL +         Some(_) |

--- a/tests/ui/parser/match-arm-without-body.rs
+++ b/tests/ui/parser/match-arm-without-body.rs
@@ -17,13 +17,13 @@ fn main() {
         Some(_),
         //~^ ERROR unexpected `,` in pattern
         //~| HELP try adding parentheses to match on a tuple
-        //~| HELP or a vertical bar to match on multiple alternatives
+        //~| HELP or a vertical bar to match on alternative
     }
     match Some(false) {
         Some(_),
         //~^ ERROR unexpected `,` in pattern
         //~| HELP try adding parentheses to match on a tuple
-        //~| HELP or a vertical bar to match on multiple alternatives
+        //~| HELP or a vertical bar to match on alternative
         _ => {}
     }
     match Some(false) {

--- a/tests/ui/parser/match-arm-without-body.stderr
+++ b/tests/ui/parser/match-arm-without-body.stderr
@@ -16,7 +16,7 @@ help: try adding parentheses to match on a tuple...
    |
 LL |         (Some(_),)
    |         +        +
-help: ...or a vertical bar to match on multiple alternatives
+help: ...or a vertical bar to match on alternative
    |
 LL -         Some(_),
 LL +         Some(_) |
@@ -36,13 +36,10 @@ LL |
 LL |
 LL ~         _) => {}
    |
-help: ...or a vertical bar to match on multiple alternatives
+help: ...or a vertical bar to match on alternative
    |
-LL ~         Some(_) |
-LL +
-LL +
-LL +
-LL ~         _ => {}
+LL -         Some(_),
+LL +         Some(_) |
    |
 
 error: expected one of `.`, `=>`, `?`, or an operator, found reserved identifier `_`

--- a/tests/ui/parser/match-arm-without-body.stderr
+++ b/tests/ui/parser/match-arm-without-body.stderr
@@ -16,7 +16,7 @@ help: try adding parentheses to match on a tuple...
    |
 LL |         (Some(_),)
    |         +        +
-help: ...or a vertical bar to match on alternative
+help: ...or a vertical bar to match on alternatives
    |
 LL -         Some(_),
 LL +         Some(_) |
@@ -36,7 +36,7 @@ LL |
 LL |
 LL ~         _) => {}
    |
-help: ...or a vertical bar to match on alternative
+help: ...or a vertical bar to match on alternatives
    |
 LL -         Some(_),
 LL +         Some(_) |

--- a/tests/ui/suggestions/only-replace-intended-bar-not-all-in-pattern.fixed
+++ b/tests/ui/suggestions/only-replace-intended-bar-not-all-in-pattern.fixed
@@ -1,0 +1,18 @@
+//@ run-rustfix
+
+// Regression test for issue #143330.
+// Ensure we suggest to replace only the intended bar with a comma, not all bars in the pattern.
+
+fn main() {
+    struct Foo { x: i32, ch: char }
+    let pos = Foo { x: 2, ch: 'x' };
+    match pos {
+        // All commas here were replaced with bars.
+        // Foo { x: 2 | ch: ' |' } | Foo { x: 3 | ch: '@' } => (),
+        (Foo { x: 2, ch: ',' } | Foo { x: 3, ch: '@' }) => (),
+        //~^ ERROR unexpected `,` in pattern
+        //~| HELP try adding parentheses to match on a tuple...
+        //~| HELP ...or a vertical bar to match on alternative
+        _ => todo!(),
+    }
+}

--- a/tests/ui/suggestions/only-replace-intended-bar-not-all-in-pattern.rs
+++ b/tests/ui/suggestions/only-replace-intended-bar-not-all-in-pattern.rs
@@ -1,0 +1,18 @@
+//@ run-rustfix
+
+// Regression test for issue #143330.
+// Ensure we suggest to replace only the intended bar with a comma, not all bars in the pattern.
+
+fn main() {
+    struct Foo { x: i32, ch: char }
+    let pos = Foo { x: 2, ch: 'x' };
+    match pos {
+        // All commas here were replaced with bars.
+        // Foo { x: 2 | ch: ' |' } | Foo { x: 3 | ch: '@' } => (),
+        Foo { x: 2, ch: ',' }, Foo { x: 3, ch: '@' } => (),
+        //~^ ERROR unexpected `,` in pattern
+        //~| HELP try adding parentheses to match on a tuple...
+        //~| HELP ...or a vertical bar to match on alternative
+        _ => todo!(),
+    }
+}

--- a/tests/ui/suggestions/only-replace-intended-bar-not-all-in-pattern.stderr
+++ b/tests/ui/suggestions/only-replace-intended-bar-not-all-in-pattern.stderr
@@ -1,0 +1,18 @@
+error: unexpected `,` in pattern
+  --> $DIR/only-replace-intended-bar-not-all-in-pattern.rs:12:30
+   |
+LL |         Foo { x: 2, ch: ',' }, Foo { x: 3, ch: '@' } => (),
+   |                              ^
+   |
+help: try adding parentheses to match on a tuple...
+   |
+LL |         (Foo { x: 2, ch: ',' }, Foo { x: 3, ch: '@' }) => (),
+   |         +                                            +
+help: ...or a vertical bar to match on alternative
+   |
+LL -         Foo { x: 2, ch: ',' }, Foo { x: 3, ch: '@' } => (),
+LL +         Foo { x: 2, ch: ',' } | Foo { x: 3, ch: '@' } => (),
+   |
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/suggestions/only-replace-intended-coma-not-all-in-pattern.fixed
+++ b/tests/ui/suggestions/only-replace-intended-coma-not-all-in-pattern.fixed
@@ -1,7 +1,7 @@
 //@ run-rustfix
 
 // Regression test for issue #143330.
-// Ensure we suggest to replace only the intended bar with a comma, not all bars in the pattern.
+// Ensure we suggest to replace only the intended coma with a bar, not all commas in the pattern.
 
 fn main() {
     struct Foo { x: i32, ch: char }

--- a/tests/ui/suggestions/only-replace-intended-coma-not-all-in-pattern.rs
+++ b/tests/ui/suggestions/only-replace-intended-coma-not-all-in-pattern.rs
@@ -1,7 +1,7 @@
 //@ run-rustfix
 
 // Regression test for issue #143330.
-// Ensure we suggest to replace only the intended bar with a comma, not all bars in the pattern.
+// Ensure we suggest to replace only the intended coma with a bar, not all commas in the pattern.
 
 fn main() {
     struct Foo { x: i32, ch: char }

--- a/tests/ui/suggestions/only-replace-intended-coma-not-all-in-pattern.stderr
+++ b/tests/ui/suggestions/only-replace-intended-coma-not-all-in-pattern.stderr
@@ -8,7 +8,7 @@ help: try adding parentheses to match on a tuple...
    |
 LL |         (Foo { x: 2, ch: ',' }, Foo { x: 3, ch: '@' }) => (),
    |         +                                            +
-help: ...or a vertical bar to match on alternative
+help: ...or a vertical bar to match on alternatives
    |
 LL -         Foo { x: 2, ch: ',' }, Foo { x: 3, ch: '@' } => (),
 LL +         Foo { x: 2, ch: ',' } | Foo { x: 3, ch: '@' } => (),

--- a/tests/ui/suggestions/only-replace-intended-coma-not-all-in-pattern.stderr
+++ b/tests/ui/suggestions/only-replace-intended-coma-not-all-in-pattern.stderr
@@ -1,5 +1,5 @@
 error: unexpected `,` in pattern
-  --> $DIR/only-replace-intended-bar-not-all-in-pattern.rs:12:30
+  --> $DIR/only-replace-intended-coma-not-all-in-pattern.rs:12:30
    |
 LL |         Foo { x: 2, ch: ',' }, Foo { x: 3, ch: '@' } => (),
    |                              ^


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#147245 (only replace the intended comma in pattern suggestions)
 - rust-lang/rust#147269 (Add regression test for 123953)
 - rust-lang/rust#147277 (Extract common logic for iterating over features)
 - rust-lang/rust#147292 (Respect `-Z` unstable options in `rustdoc --test`)
 - rust-lang/rust#147300 (Add xtensa arch to object file creation)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=147245,147269,147277,147292,147300)
<!-- homu-ignore:end -->