### PR TITLE
Add documentation about unwinding to wasm targets

### DIFF
--- a/src/doc/rustc/src/platform-support/wasm32-wasip1.md
+++ b/src/doc/rustc/src/platform-support/wasm32-wasip1.md
@@ -133,3 +133,9 @@ to Rust 1.80 the `target_env` condition was not set.
 The default set of WebAssembly features enabled for compilation is currently the
 same as [`wasm32-unknown-unknown`](./wasm32-unknown-unknown.md). See the
 documentation there for more information.
+
+## Unwinding
+
+This target is compiled with `-Cpanic=abort` by default. For information on
+using `-Cpanic=unwind` see the [documentation about unwinding for
+`wasm32-unknown-unknown`](./wasm32-unknown-unknown.md#unwinding).

--- a/src/doc/rustc/src/platform-support/wasm32-wasip2.md
+++ b/src/doc/rustc/src/platform-support/wasm32-wasip2.md
@@ -67,3 +67,9 @@ It's recommended to conditionally compile code for this target with:
 The default set of WebAssembly features enabled for compilation is currently the
 same as [`wasm32-unknown-unknown`](./wasm32-unknown-unknown.md). See the
 documentation there for more information.
+
+## Unwinding
+
+This target is compiled with `-Cpanic=abort` by default. For information on
+using `-Cpanic=unwind` see the [documentation about unwinding for
+`wasm32-unknown-unknown`](./wasm32-unknown-unknown.md#unwinding).

--- a/src/doc/rustc/src/platform-support/wasm32v1-none.md
+++ b/src/doc/rustc/src/platform-support/wasm32v1-none.md
@@ -107,3 +107,14 @@ $ cargo +nightly build -Zbuild-std=panic_abort,std --target wasm32-unknown-unkno
 Which not only rebuilds `std`, `core` and `alloc` (which is somewhat costly and annoying) but more importantly requires the use of nightly Rust toolchains (for the `-Zbuild-std` flag). This is very undesirable for the target audience, which consists of people targeting WebAssembly implementations that prioritize stability, simplicity and/or security over feature support.
 
 This `wasm32v1-none` target exists as an alternative option that works on stable Rust toolchains, without rebuilding the stdlib.
+
+## Unwinding
+
+This target is compiled with `-Cpanic=abort` by default. Using `-Cpanic=unwind`
+would require using the WebAssembly exception-handling proposal stabilized
+mid-2025, and if that's desired then you most likely don't want to use this
+target and instead want to use `wasm32-unknown-unknown` instead. It's unlikely
+that this target will ever support unwinding with the precompiled artifacts
+shipped through rustup. For documentation about using `-Zbuild-std` to enable
+using `-Cpanic=unwind` see the [documentation of
+`wasm32-unknown-unknown`](./wasm32-unknown-unknown.md#unwinding).


### PR DESCRIPTION
This commit adds some documentation about the state of `-Cpanic=unwind` for the following wasm targets:

* `wasm32-unknown-unknown`
* `wasm32-wasip1`
* `wasm32-wasip2`
* `wasm32v1-none`

Notably it's possible to use `-Cpanic=unwind` with `-Zbuild-std` and it's also mentioned that there are no concrete proposals at this time to adding a new set of targets which support unwinding. My hunch is that in a few years' time it would make sense to enable it by default on these targets (except for `wasm32v1-none`) but that's a problem for future folks to debate. For now this is an attempt to document the status quo.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
