### PR TITLE
wip tcmalloc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -493,8 +493,10 @@ checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-link",
 ]
 
@@ -583,6 +585,7 @@ dependencies = [
  "declare_clippy_lint",
  "filetime",
  "itertools",
+ "libtcmalloc-sys",
  "pulldown-cmark",
  "regex",
  "rustc_tools_util 0.4.2",
@@ -1193,6 +1196,15 @@ name = "dissimilar"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8975ffdaa0ef3661bfe02dbdcc06c9f829dfafe6a3c474de366a8d5e44276921"
+
+[[package]]
+name = "document-features"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95249b50c6c185bee49034bcb378a49dc2b5dff0be90ff6616d31d64febab05d"
+dependencies = [
+ "litrs",
+]
 
 [[package]]
 name = "dyn-clone"
@@ -2162,6 +2174,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "libtcmalloc-sys"
+version = "0.1.14"
+source = "git+https://github.com/0xdeafbeef/tcmalloc-better.git?rev=781a440a0919#781a440a091933e35ecbfd082fc0393bea6481ad"
+dependencies = [
+ "cc",
+ "document-features",
+ "libc",
+ "patch",
+ "strum 0.27.2",
+]
+
+[[package]]
 name = "libz-sys"
 version = "1.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2212,6 +2236,12 @@ name = "litemap"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
+
+[[package]]
+name = "litrs"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5e54036fe321fd421e10d732f155734c4e4afd610dd556d9a82833ab3ee0bed"
 
 [[package]]
 name = "lld-wrapper"
@@ -2392,6 +2422,7 @@ dependencies = [
  "libc",
  "libffi",
  "libloading",
+ "libtcmalloc-sys",
  "measureme",
  "nix",
  "rand 0.9.2",
@@ -2401,7 +2432,6 @@ dependencies = [
  "serde_json",
  "smallvec",
  "tempfile",
- "tikv-jemalloc-sys",
  "ui_test",
 ]
 
@@ -2435,6 +2465,17 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nom_locate"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e3c83c053b0713da60c5b8de47fe8e494fe3ece5267b2f23090a07a053ba8f3"
+dependencies = [
+ "bytecount",
+ "memchr",
+ "nom",
 ]
 
 [[package]]
@@ -2750,6 +2791,17 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "patch"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15c07fdcdd8b05bdcf2a25bc195b6c34cbd52762ada9dba88bf81e7686d14e7a"
+dependencies = [
+ "chrono",
+ "nom",
+ "nom_locate",
 ]
 
 [[package]]
@@ -3285,13 +3337,13 @@ checksum = "e4ee29da77c5a54f42697493cd4c9b9f31b74df666a6c04dfc4fde77abe0438b"
 name = "rustc-main"
 version = "0.0.0"
 dependencies = [
+ "libtcmalloc-sys",
  "rustc_codegen_ssa",
  "rustc_driver",
  "rustc_driver_impl",
  "rustc_public",
  "rustc_public_bridge",
  "rustc_windows_rc",
- "tikv-jemalloc-sys",
 ]
 
 [[package]]
@@ -4781,6 +4833,7 @@ dependencies = [
  "expect-test",
  "indexmap",
  "itertools",
+ "libtcmalloc-sys",
  "minifier",
  "pulldown-cmark-escape",
  "regex",
@@ -5183,8 +5236,8 @@ dependencies = [
  "nom",
  "serde",
  "spdx-expression",
- "strum",
- "strum_macros",
+ "strum 0.24.1",
+ "strum_macros 0.24.3",
  "thiserror 1.0.69",
  "uuid",
 ]
@@ -5261,6 +5314,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
 
 [[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros 0.27.2",
+]
+
+[[package]]
 name = "strum_macros"
 version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5271,6 +5333,18 @@ dependencies = [
  "quote",
  "rustversion",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -5502,16 +5576,6 @@ dependencies = [
 [[package]]
 name = "tier-check"
 version = "0.1.0"
-
-[[package]]
-name = "tikv-jemalloc-sys"
-version = "0.6.0+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd3c60906412afa9c2b5b5a48ca6a5abe5736aec9eb48ad05037a677e52e4e2d"
-dependencies = [
- "cc",
- "libc",
-]
 
 [[package]]
 name = "tinystr"

--- a/compiler/rustc/Cargo.toml
+++ b/compiler/rustc/Cargo.toml
@@ -20,15 +20,14 @@ rustc_public = { path = "../rustc_public" }
 rustc_public_bridge = { path = "../rustc_public_bridge" }
 # tidy-alphabetical-end
 
-[dependencies.tikv-jemalloc-sys]
-version = "0.6.0"
-optional = true
-features = ['unprefixed_malloc_on_supported_platforms']
+
+[target.'cfg(all(target_os = "linux", target_arch = "x86_64"))'.dependencies]
+libtcmalloc-sys = { git = "https://github.com/0xdeafbeef/tcmalloc-better.git", rev = "781a440a0919", default-features = false, features = ["unprefixed_malloc_on_supported_platforms", "32k_pages", "override_cpp_operators"] }
 
 [features]
 # tidy-alphabetical-start
 check_only = ['rustc_driver_impl/check_only']
-jemalloc = ['dep:tikv-jemalloc-sys']
+jemalloc = []
 llvm = ['rustc_driver_impl/llvm']
 llvm_enzyme = ['rustc_driver_impl/llvm_enzyme']
 max_level_info = ['rustc_driver_impl/max_level_info']

--- a/src/librustdoc/Cargo.toml
+++ b/src/librustdoc/Cargo.toml
@@ -29,6 +29,9 @@ tracing-tree = "0.3.0"
 unicode-segmentation = "1.9"
 # tidy-alphabetical-end
 
+[target.'cfg(all(target_os = "linux", target_arch = "x86_64"))'.dependencies]
+libtcmalloc-sys = { git = "https://github.com/0xdeafbeef/tcmalloc-better.git", rev = "781a440a0919", default-features = false, features = ["unprefixed_malloc_on_supported_platforms", "32k_pages", "override_cpp_operators"] }
+
 [dependencies.tracing-subscriber]
 version = "0.3.3"
 default-features = false
@@ -40,9 +43,6 @@ minifier = { version = "0.3.2", default-features = false }
 
 [dev-dependencies]
 expect-test = "1.4.0"
-
-[features]
-jemalloc = []
 
 [package.metadata.rust-analyzer]
 rustc_private = true

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -62,11 +62,6 @@ extern crate rustc_target;
 extern crate rustc_trait_selection;
 extern crate test;
 
-// See docs in https://github.com/rust-lang/rust/blob/master/compiler/rustc/src/main.rs
-// about jemalloc.
-#[cfg(feature = "jemalloc")]
-extern crate tikv_jemalloc_sys as jemalloc_sys;
-
 use std::env::{self, VarError};
 use std::io::{self, IsTerminal};
 use std::path::Path;
@@ -126,34 +121,44 @@ mod visit_lib;
 
 pub fn main() {
     // See docs in https://github.com/rust-lang/rust/blob/master/compiler/rustc/src/main.rs
-    // about jemalloc.
-    #[cfg(feature = "jemalloc")]
+    // about tcmalloc.
+    #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
     {
         use std::os::raw::{c_int, c_void};
 
-        #[used]
-        static _F1: unsafe extern "C" fn(usize, usize) -> *mut c_void = jemalloc_sys::calloc;
-        #[used]
-        static _F2: unsafe extern "C" fn(*mut *mut c_void, usize, usize) -> c_int =
-            jemalloc_sys::posix_memalign;
-        #[used]
-        static _F3: unsafe extern "C" fn(usize, usize) -> *mut c_void = jemalloc_sys::aligned_alloc;
-        #[used]
-        static _F4: unsafe extern "C" fn(usize) -> *mut c_void = jemalloc_sys::malloc;
-        #[used]
-        static _F5: unsafe extern "C" fn(*mut c_void, usize) -> *mut c_void = jemalloc_sys::realloc;
-        #[used]
-        static _F6: unsafe extern "C" fn(*mut c_void) = jemalloc_sys::free;
-
-        #[cfg(target_os = "macos")]
-        {
-            unsafe extern "C" {
-                fn _rjem_je_zone_register();
-            }
-
-            #[used]
-            static _F7: unsafe extern "C" fn() = _rjem_je_zone_register;
+        unsafe extern "C" {
+            fn calloc(count: usize, size: usize) -> *mut c_void;
+            fn posix_memalign(ptr: *mut *mut c_void, alignment: usize, size: usize) -> c_int;
+            fn aligned_alloc(alignment: usize, size: usize) -> *mut c_void;
+            fn malloc(size: usize) -> *mut c_void;
+            fn realloc(ptr: *mut c_void, size: usize) -> *mut c_void;
+            fn free(ptr: *mut c_void);
         }
+
+        #[used]
+        static _TCMALLOC_BRIDGE_ALLOC: unsafe extern "C" fn(usize, usize) -> *mut c_void =
+            libtcmalloc_sys::BridgeTCMallocInternalNewAlignedNothrow;
+        #[used]
+        static _TCMALLOC_BRIDGE_DELETE_ALIGNED: unsafe extern "C" fn(*mut c_void, usize) =
+            libtcmalloc_sys::TCMallocInternalDeleteAligned;
+
+        #[used]
+        static _TCMALLOC_CALLOC: unsafe extern "C" fn(usize, usize) -> *mut c_void = calloc;
+        #[used]
+        static _TCMALLOC_POSIX_MEMALIGN: unsafe extern "C" fn(
+            *mut *mut c_void,
+            usize,
+            usize,
+        ) -> c_int = posix_memalign;
+        #[used]
+        static _TCMALLOC_ALIGNED_ALLOC: unsafe extern "C" fn(usize, usize) -> *mut c_void =
+            aligned_alloc;
+        #[used]
+        static _TCMALLOC_MALLOC: unsafe extern "C" fn(usize) -> *mut c_void = malloc;
+        #[used]
+        static _TCMALLOC_REALLOC: unsafe extern "C" fn(*mut c_void, usize) -> *mut c_void = realloc;
+        #[used]
+        static _TCMALLOC_FREE: unsafe extern "C" fn(*mut c_void) = free;
     }
 
     let mut early_dcx = EarlyDiagCtxt::new(ErrorOutputType::default());

--- a/src/tools/clippy/Cargo.toml
+++ b/src/tools/clippy/Cargo.toml
@@ -32,6 +32,9 @@ termize = "0.2"
 color-print = "0.3.4"
 anstream = "0.6.18"
 
+[target.'cfg(all(target_os = "linux", target_arch = "x86_64"))'.dependencies]
+libtcmalloc-sys = { git = "https://github.com/0xdeafbeef/tcmalloc-better.git", rev = "781a440a0919", default-features = false, features = ["unprefixed_malloc_on_supported_platforms", "32k_pages", "override_cpp_operators"] }
+
 [dev-dependencies]
 cargo_metadata = "0.18.1"
 ui_test = "0.30.2"
@@ -51,7 +54,6 @@ rustc_tools_util = { path = "rustc_tools_util", version = "0.4.2" }
 [features]
 integration = ["dep:tempfile"]
 internal = ["dep:clippy_lints_internal", "dep:tempfile"]
-jemalloc = []
 
 [package.metadata.rust-analyzer]
 # This package uses #[feature(rustc_private)]

--- a/src/tools/clippy/src/driver.rs
+++ b/src/tools/clippy/src/driver.rs
@@ -13,11 +13,6 @@ extern crate rustc_interface;
 extern crate rustc_session;
 extern crate rustc_span;
 
-// See docs in https://github.com/rust-lang/rust/blob/master/compiler/rustc/src/main.rs
-// about jemalloc.
-#[cfg(feature = "jemalloc")]
-extern crate tikv_jemalloc_sys as jemalloc_sys;
-
 use clippy_utils::sym;
 use declare_clippy_lint::LintListBuilder;
 use rustc_interface::interface;
@@ -193,33 +188,40 @@ const BUG_REPORT_URL: &str = "https://github.com/rust-lang/rust-clippy/issues/ne
 #[allow(clippy::ignored_unit_patterns)]
 pub fn main() {
     // See docs in https://github.com/rust-lang/rust/blob/master/compiler/rustc/src/main.rs
-    // about jemalloc.
-    #[cfg(feature = "jemalloc")]
+    // about tcmalloc.
+    #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
     {
         use std::os::raw::{c_int, c_void};
 
-        #[used]
-        static _F1: unsafe extern "C" fn(usize, usize) -> *mut c_void = jemalloc_sys::calloc;
-        #[used]
-        static _F2: unsafe extern "C" fn(*mut *mut c_void, usize, usize) -> c_int = jemalloc_sys::posix_memalign;
-        #[used]
-        static _F3: unsafe extern "C" fn(usize, usize) -> *mut c_void = jemalloc_sys::aligned_alloc;
-        #[used]
-        static _F4: unsafe extern "C" fn(usize) -> *mut c_void = jemalloc_sys::malloc;
-        #[used]
-        static _F5: unsafe extern "C" fn(*mut c_void, usize) -> *mut c_void = jemalloc_sys::realloc;
-        #[used]
-        static _F6: unsafe extern "C" fn(*mut c_void) = jemalloc_sys::free;
-
-        #[cfg(target_os = "macos")]
-        {
-            unsafe extern "C" {
-                fn _rjem_je_zone_register();
-            }
-
-            #[used]
-            static _F7: unsafe extern "C" fn() = _rjem_je_zone_register;
+        extern "C" {
+            fn calloc(count: usize, size: usize) -> *mut c_void;
+            fn posix_memalign(ptr: *mut *mut c_void, alignment: usize, size: usize) -> c_int;
+            fn aligned_alloc(alignment: usize, size: usize) -> *mut c_void;
+            fn malloc(size: usize) -> *mut c_void;
+            fn realloc(ptr: *mut c_void, size: usize) -> *mut c_void;
+            fn free(ptr: *mut c_void);
         }
+
+        #[used]
+        static _TCMALLOC_BRIDGE_ALLOC: unsafe extern "C" fn(usize, usize) -> *mut c_void =
+            libtcmalloc_sys::BridgeTCMallocInternalNewAlignedNothrow;
+        #[used]
+        static _TCMALLOC_BRIDGE_DELETE_ALIGNED: unsafe extern "C" fn(*mut c_void, usize) =
+            libtcmalloc_sys::TCMallocInternalDeleteAligned;
+
+        #[used]
+        static _TCMALLOC_CALLOC: unsafe extern "C" fn(usize, usize) -> *mut c_void = calloc;
+        #[used]
+        static _TCMALLOC_POSIX_MEMALIGN: unsafe extern "C" fn(*mut *mut c_void, usize, usize) -> c_int =
+            posix_memalign;
+        #[used]
+        static _TCMALLOC_ALIGNED_ALLOC: unsafe extern "C" fn(usize, usize) -> *mut c_void = aligned_alloc;
+        #[used]
+        static _TCMALLOC_MALLOC: unsafe extern "C" fn(usize) -> *mut c_void = malloc;
+        #[used]
+        static _TCMALLOC_REALLOC: unsafe extern "C" fn(*mut c_void, usize) -> *mut c_void = realloc;
+        #[used]
+        static _TCMALLOC_FREE: unsafe extern "C" fn(*mut c_void) = free;
     }
 
     let early_dcx = EarlyDiagCtxt::new(ErrorOutputType::default());

--- a/src/tools/miri/Cargo.toml
+++ b/src/tools/miri/Cargo.toml
@@ -32,9 +32,8 @@ serde_json = { version = "1.0", optional = true }
 # Copied from `compiler/rustc/Cargo.toml`.
 # But only for some targets, it fails for others. Rustc configures this in its CI, but we can't
 # easily use that since we support of-tree builds.
-[target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies.tikv-jemalloc-sys]
-version = "0.6.0"
-features = ['unprefixed_malloc_on_supported_platforms']
+[target.'cfg(all(target_os = "linux", target_arch = "x86_64"))'.dependencies]
+libtcmalloc-sys = { git = "https://github.com/0xdeafbeef/tcmalloc-better.git", rev = "781a440a0919", default-features = false, features = ["unprefixed_malloc_on_supported_platforms", "32k_pages", "override_cpp_operators"] }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/src/tools/rustdoc/Cargo.toml
+++ b/src/tools/rustdoc/Cargo.toml
@@ -10,8 +10,8 @@ edition = "2024"
 name = "rustdoc_tool_binary"
 path = "main.rs"
 
+[features]
+jemalloc = []
+
 [dependencies]
 rustdoc = { path = "../../librustdoc" }
-
-[features]
-jemalloc = ['rustdoc/jemalloc']


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/147333)*
<!-- homu-ignore:end -->


```sh
hyperfine  --prepare 'cargo clean' 'cargo +stock build -r' 'cargo +stage2 build  -r'  --runs 3 --warmup 0
Benchmark 1: cargo +stock build -r
  Time (mean ± σ):     269.238 s ±  0.906 s    [User: 2343.174 s, System: 198.200 s]
  Range (min … max):   268.623 s … 270.278 s    3 runs

Benchmark 2: cargo +stage2 build  -r
  Time (mean ± σ):     246.692 s ±  0.094 s    [User: 2300.234 s, System: 165.301 s]
  Range (min … max):   246.617 s … 246.798 s    3 runs

Summary
  cargo +stage2 build  -r ran
    1.09 ± 0.00 times faster than cargo +stock build -r

 Command being timed: "cargo +stage2 build -r"
        User time (seconds): 2255.06
        System time (seconds): 167.08
        Percent of CPU this job got: 1007%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 4:00.39
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 5841344
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 272
        Minor (reclaiming a frame) page faults: 45702476
        Voluntary context switches: 177243
        Involuntary context switches: 531296
        Swaps: 0
        File system inputs: 26184
        File system outputs: 33975408
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0
        
 Command being timed: "cargo +stock build -r"
        User time (seconds): 2288.81
        System time (seconds): 196.81
        Percent of CPU this job got: 950%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 4:21.50
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 9643212
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 268
        Minor (reclaiming a frame) page faults: 58525292
        Voluntary context switches: 207169
        Involuntary context switches: 525091
        Swaps: 0
        File system inputs: 9272
        File system outputs: 33879056
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0
```

Metric | +stage2 | +stock | Δ (stage2 – stock) | Stage2 vs stock
-- | -- | -- | -- | --
Wall time | 4:00.39 | 4:21.50 | −21.11 s | 8.07% faster
Total CPU time (user+sys) | 2422.14 s | 2485.62 s | −63.48 s | −2.55%
CPU utilization | 1007% | 950% | +57 pp | ~6% higher (avg 10.08 vs 9.51 cores)
Max RSS | 5.57 GiB | 9.20 GiB | −3.63 GiB | −39.4% mem
Minor page faults | 45.7 M | 58.5 M | −12.8 M | −21.9%
Major page faults | 272 | 268 | +4 | ~same
Voluntary ctx switches | 177,243 | 207,169 | −29,926 | −14.4%
Involuntary ctx switches | 531,296 | 525,091 | -6,205 | -1.18%
        
I've compared with compiler built from master.


Interestingly, i've got millions of errors from gwp-asan like

```
        discovered for pointer 0xe507ffb15c0: this pointer was recently freed with a size argument in the range [1, 8], but the associated span of allocated memory is for allocations with sizes [9, 16]
```
        
until i've patched operator delete to use regular delete. All errors came from llvm


```
     Thread 17 "lto cgu.00" received signal SIGABRT, Aborted.
[Switching to Thread 0x7fffe17f56c0 (LWP 393688)]
__pthread_kill_implementation (threadid=<optimized out>, signo=signo@entry=6, no_tid=no_tid@entry=0)
    at pthread_kill.c:44
44            return INTERNAL_SYSCALL_ERROR_P (ret) ? INTERNAL_SYSCALL_ERRNO (ret) : 0;
(gdb) bt
#0  __pthread_kill_implementation (threadid=<optimized out>, signo=signo@entry=6,
    no_tid=no_tid@entry=0) at pthread_kill.c:44
#1  0x00007fffe8881f63 in __pthread_kill_internal (threadid=<optimized out>, signo=6)
    at pthread_kill.c:89
#2  0x00007fffe8827f3e in __GI_raise (sig=sig@entry=6) at ../sysdeps/posix/raise.c:26
#3  0x00007fffe880f6d0 in __GI_abort () at abort.c:77
#4  0x0000555555587930 in tcmalloc::tcmalloc_internal::ReportMismatchedSizeClass(tcmalloc::tcmalloc_int
#5  0x0000555555584702 in tcmalloc::tcmalloc_internal::central_freelist_internal::StaticForwarder::MapO
#6  0x0000555555558892 in tcmalloc::tcmalloc_internal::central_freelist_internal::CentralFreeList<tcmal
#7  0x00005555555b5321 in tcmalloc::tcmalloc_internal::ThreadCache::ReleaseToTransferCache(tcmalloc::tc
#8  0x00005555555b5611 in tcmalloc::tcmalloc_internal::ThreadCache::ListTooLong(tcmalloc::tcmalloc_inte
#9  0x00005555555b572f in tcmalloc::tcmalloc_internal::ThreadCache::DeallocateSlow(void*, tcmalloc::tcmalloc_internal::ThreadCache::FreeList*, unsigned long) ()
#10 0x0000555555560bc2 in tcmalloc::tcmalloc_internal::FreeWithHooksOrPerThread(void*, unsigned long)
    ()
#11 0x00005555555be97b in operator delete(void*, unsigned long) ()
#12 0x00007ffff30cfeab in std::_Rb_tree<unsigned long, std::pair<unsigned long const, llvm::GlobalValueSummaryInfo>, std::_Select1st<std::pair<unsigned long const, llvm::GlobalValueSummaryInfo> >, std::less<unsigned long>, std::allocator<std::pair<unsigned long const, llvm::GlobalValueSummaryInfo> > >::_M_erase(std::_Rb_tree_node<std::pair<unsigned long const, llvm::GlobalValueSummaryInfo> >*) [clone .isra.0] ()
   from /home/odm3n/dev/oss/rust/build/x86_64-unknown-linux-gnu/stage2/bin/../lib/librustc_driver-9c7769cfa025b531.so
#13 0x00007ffff30d30bd in LLVMRustThinLTOData::~LLVMRustThinLTOData() ()
   from /home/odm3n/dev/oss/rust/build/x86_64-unknown-linux-gnu/stage2/bin/../lib/librustc_driver-9c7769cfa025b531.so
#14 0x00007ffff30d3163 in LLVMRustFreeThinLTOData ()
   from /home/odm3n/dev/oss/rust/build/x86_64-unknown-linux-gnu/stage2/bin/../lib/librustc_driver-9c7769cfa025b531.so
#15 0x00007ffff30bebf6 in <alloc::sync::Arc<rustc_codegen_ssa::back::lto::ThinShared<rustc_codegen_llvm::LlvmCodegenBackend>>>::drop_slow ()
   from /home/odm3n/dev/oss/rust/build/x86_64-unknown-linux-gnu/stage2/bin/../lib/librustc_driver-9c7769cfa025b531.so
#16 0x00007ffff2f7a647 in <rustc_codegen_llvm::LlvmCodegenBackend as rustc_codegen_ssa::traits::write::WriteBackendMethods>::optimize_thin ()
   from /home/odm3n/dev/oss/rust/build/x86_64-unknown-linux-gnu/stage2/bin/../lib/librustc_driver-9c7769cfa025b531.so
#17 0x00007ffff307d20e in std::sys::backtrace::__rust_begin_short_backtrace::<<rustc_codegen_llvm::LlvmCodegenBackend as rustc_codegen_ssa::traits::backend::ExtraBackendMethods>::spawn_named_thread<rustc_codegen_ssa::back::write::spawn_work<rustc_codegen_llvm::LlvmCodegenBackend>::{closure#0}, ()>::{closure#0}, ()> ()
   from /home/odm3n/dev/oss/rust/build/x86_64-unknown-linux-gnu/stage2/bin/../lib/librustc_driver-9c7769cfa025b531.so
```
        



If it's interesting i can clean this all up, or mb we should run rust-perf test-suite before.