### PR TITLE
Tidy: revert `flt` to `ftl`

### DIFF
--- a/compiler/rustc_attr_parsing/messages.ftl
+++ b/compiler/rustc_attr_parsing/messages.ftl
@@ -1,3 +1,9 @@
+attr_parsing_as_needed_compatibility =
+    linking modifier `as-needed` is only compatible with `dylib` and `framework` linking kinds
+
+attr_parsing_bundle_needs_static =
+    linking modifier `bundle` is only compatible with `static` linking kind
+
 attr_parsing_cfg_predicate_identifier =
     `cfg` predicate key must be an identifier
 
@@ -18,16 +24,12 @@ attr_parsing_empty_attribute =
     }
 
 
-attr_parsing_invalid_target = `#[{$name}]` attribute cannot be used on {$target}
-    .help = `#[{$name}]` can {$only}be applied to {$applied}
-    .suggestion = remove the attribute
-attr_parsing_invalid_target_lint = `#[{$name}]` attribute cannot be used on {$target}
-    .warn = {-attr_parsing_previously_accepted}
-    .help = `#[{$name}]` can {$only}be applied to {$applied}
-    .suggestion = remove the attribute
-
 attr_parsing_empty_confusables =
     expected at least one confusable name
+attr_parsing_empty_link_name =
+    link name must not be empty
+    .label = empty link name
+
 attr_parsing_expected_one_cfg_pattern =
     expected 1 cfg-pattern
 
@@ -48,6 +50,15 @@ attr_parsing_ill_formed_attribute_input = {$num_suggestions ->
         *[other] valid forms for the attribute are {$suggestions}
     }
 
+attr_parsing_import_name_type_raw =
+    import name type can only be used with link kind `raw-dylib`
+
+attr_parsing_import_name_type_x86 =
+    import name type is only supported on x86
+
+attr_parsing_incompatible_wasm_link =
+    `wasm_import_module` is incompatible with other arguments in `#[link]` attributes
+
 attr_parsing_incorrect_repr_format_align_one_arg =
     incorrect `repr(align)` attribute format: `align` takes exactly one argument in parentheses
 
@@ -67,6 +78,11 @@ attr_parsing_incorrect_repr_format_packed_one_or_zero_arg =
 attr_parsing_invalid_alignment_value =
     invalid alignment value: {$error_part}
 
+attr_parsing_invalid_attr_unsafe = `{$name}` is not an unsafe attribute
+    .label = this is not an unsafe attribute
+    .suggestion = remove the `unsafe(...)`
+    .note = extraneous unsafe is not allowed in attributes
+
 attr_parsing_invalid_issue_string =
     `issue` must be a non-zero numeric string or "none"
     .must_not_be_zero = `issue` must not be "0", use "none" instead
@@ -74,6 +90,13 @@ attr_parsing_invalid_issue_string =
     .invalid_digit = invalid digit found in string
     .pos_overflow = number too large to fit in target type
     .neg_overflow = number too small to fit in target type
+
+attr_parsing_invalid_link_modifier =
+    invalid linking modifier syntax, expected '+' or '-' prefix before one of: bundle, verbatim, whole-archive, as-needed
+
+attr_parsing_invalid_meta_item = expected a literal (`1u8`, `1.0f32`, `"string"`, etc.) here, found {$descr}
+    .remove_neg_sugg = negative numbers are not literals, try removing the `-` sign
+    .quote_ident_sugg = surround the identifier with quotation marks to make it into a string literal
 
 attr_parsing_invalid_predicate =
     invalid predicate `{$predicate}`
@@ -100,8 +123,35 @@ attr_parsing_invalid_style = {$is_used_as_inner ->
     }
     .note = This attribute does not have an `!`, which means it is applied to this {$target}
 
+attr_parsing_invalid_target = `#[{$name}]` attribute cannot be used on {$target}
+    .help = `#[{$name}]` can {$only}be applied to {$applied}
+    .suggestion = remove the attribute
+attr_parsing_invalid_target_lint = `#[{$name}]` attribute cannot be used on {$target}
+    .warn = {-attr_parsing_previously_accepted}
+    .help = `#[{$name}]` can {$only}be applied to {$applied}
+    .suggestion = remove the attribute
+
+attr_parsing_limit_invalid =
+    `limit` must be a non-negative integer
+    .label = {$error_str}
+attr_parsing_link_arg_unstable =
+    link kind `link-arg` is unstable
+
+attr_parsing_link_cfg_unstable =
+    link cfg is unstable
+
+attr_parsing_link_framework_apple =
+    link kind `framework` is only supported on Apple targets
+
 attr_parsing_link_ordinal_out_of_range = ordinal value in `link_ordinal` is too large: `{$ordinal}`
     .note = the value may not exceed `u16::MAX`
+
+attr_parsing_link_requires_name =
+    `#[link]` attribute requires a `name = "string"` argument
+    .label = missing `name` argument
+
+attr_parsing_meta_bad_delim = wrong meta list delimiters
+attr_parsing_meta_bad_delim_suggestion = the delimiters should be `(` and `)`
 
 attr_parsing_missing_feature =
     missing 'feature'
@@ -114,6 +164,9 @@ attr_parsing_missing_note =
 
 attr_parsing_missing_since =
     missing 'since'
+
+attr_parsing_multiple_modifiers =
+    multiple `{$modifier}` modifiers in a single `modifiers` argument
 
 attr_parsing_multiple_stability_levels =
     multiple stability levels
@@ -138,6 +191,15 @@ attr_parsing_objc_class_expected_string_literal = `objc::class!` expected a stri
 
 attr_parsing_objc_selector_expected_string_literal = `objc::selector!` expected a string literal
 
+attr_parsing_raw_dylib_elf_unstable =
+    link kind `raw-dylib` is unstable on ELF platforms
+
+attr_parsing_raw_dylib_no_nul =
+    link name must not contain NUL characters if link kind is `raw-dylib`
+
+attr_parsing_raw_dylib_only_windows =
+    link kind `raw-dylib` is only supported on Windows targets
+
 attr_parsing_repr_ident =
     meta item in `repr` must be an identifier
 
@@ -152,6 +214,9 @@ attr_parsing_soft_no_args =
 
 attr_parsing_stability_outside_std = stability attributes may not be used outside of the standard library
 
+attr_parsing_suffixed_literal_in_attribute = suffixed literals are not allowed in attributes
+    .help = instead of using a suffixed literal (`1u8`, `1.0f32`, etc.), use an unsuffixed version (`1`, `1.0`, etc.)
+
 attr_parsing_unknown_meta_item =
     unknown meta item '{$item}'
     .label = expected one of {$expected}
@@ -163,6 +228,10 @@ attr_parsing_unrecognized_repr_hint =
     unrecognized representation hint
     .help = valid reprs are `Rust` (default), `C`, `align`, `packed`, `transparent`, `simd`, `i8`, `u8`, `i16`, `u16`, `i32`, `u32`, `i64`, `u64`, `i128`, `u128`, `isize`, `usize`
     .note = for more information, visit <https://doc.rust-lang.org/reference/type-layout.html?highlight=repr#representations>
+
+attr_parsing_unsafe_attr_outside_unsafe = unsafe attribute used without unsafe
+    .label = usage of unsafe attribute
+attr_parsing_unsafe_attr_outside_unsafe_suggestion = wrap the attribute in `unsafe(...)`
 
 attr_parsing_unstable_cfg_target_compact =
     compact `cfg(target(..))` is experimental and subject to change
@@ -193,77 +262,5 @@ attr_parsing_unused_multiple =
 -attr_parsing_previously_accepted =
     this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-attr_parsing_meta_bad_delim = wrong meta list delimiters
-attr_parsing_meta_bad_delim_suggestion = the delimiters should be `(` and `)`
-
-attr_parsing_unsafe_attr_outside_unsafe = unsafe attribute used without unsafe
-    .label = usage of unsafe attribute
-attr_parsing_unsafe_attr_outside_unsafe_suggestion = wrap the attribute in `unsafe(...)`
-
-attr_parsing_invalid_attr_unsafe = `{$name}` is not an unsafe attribute
-    .label = this is not an unsafe attribute
-    .suggestion = remove the `unsafe(...)`
-    .note = extraneous unsafe is not allowed in attributes
-
-attr_parsing_invalid_meta_item = expected a literal (`1u8`, `1.0f32`, `"string"`, etc.) here, found {$descr}
-    .remove_neg_sugg = negative numbers are not literals, try removing the `-` sign
-    .quote_ident_sugg = surround the identifier with quotation marks to make it into a string literal
-
-attr_parsing_suffixed_literal_in_attribute = suffixed literals are not allowed in attributes
-    .help = instead of using a suffixed literal (`1u8`, `1.0f32`, etc.), use an unsuffixed version (`1`, `1.0`, etc.)
-
-attr_parsing_as_needed_compatibility =
-    linking modifier `as-needed` is only compatible with `dylib` and `framework` linking kinds
-
-attr_parsing_bundle_needs_static =
-    linking modifier `bundle` is only compatible with `static` linking kind
-
-attr_parsing_empty_link_name =
-    link name must not be empty
-    .label = empty link name
-
-attr_parsing_import_name_type_raw =
-    import name type can only be used with link kind `raw-dylib`
-
-attr_parsing_import_name_type_x86 =
-    import name type is only supported on x86
-
-attr_parsing_incompatible_wasm_link =
-    `wasm_import_module` is incompatible with other arguments in `#[link]` attributes
-
-attr_parsing_invalid_link_modifier =
-    invalid linking modifier syntax, expected '+' or '-' prefix before one of: bundle, verbatim, whole-archive, as-needed
-
-attr_parsing_link_arg_unstable =
-    link kind `link-arg` is unstable
-
-attr_parsing_link_cfg_unstable =
-    link cfg is unstable
-
-attr_parsing_link_framework_apple =
-    link kind `framework` is only supported on Apple targets
-
-attr_parsing_link_requires_name =
-    `#[link]` attribute requires a `name = "string"` argument
-    .label = missing `name` argument
-
-attr_parsing_multiple_modifiers =
-    multiple `{$modifier}` modifiers in a single `modifiers` argument
-
-attr_parsing_multiple_renamings =
-    multiple renamings were specified for library `{$lib_name}`
-attr_parsing_raw_dylib_no_nul =
-    link name must not contain NUL characters if link kind is `raw-dylib`
-
-attr_parsing_raw_dylib_elf_unstable =
-    link kind `raw-dylib` is unstable on ELF platforms
-
-attr_parsing_raw_dylib_only_windows =
-    link kind `raw-dylib` is only supported on Windows targets
-
 attr_parsing_whole_archive_needs_static =
     linking modifier `whole-archive` is only compatible with `static` linking kind
-
-attr_parsing_limit_invalid =
-    `limit` must be a non-negative integer
-    .label = {$error_str}

--- a/compiler/rustc_builtin_macros/messages.ftl
+++ b/compiler/rustc_builtin_macros/messages.ftl
@@ -135,6 +135,15 @@ builtin_macros_concat_missing_literal = expected a literal
 builtin_macros_default_arg = `#[default]` attribute does not accept a value
     .suggestion = try using `#[default]`
 
+builtin_macros_derive_from_usage_note = `#[derive(From)]` can only be used on structs with exactly one field
+
+builtin_macros_derive_from_wrong_field_count = `#[derive(From)]` used on a struct with {$multiple_fields ->
+    [true] multiple fields
+    *[false] no fields
+}
+
+builtin_macros_derive_from_wrong_target = `#[derive(From)]` used on {$kind}
+
 builtin_macros_derive_macro_call = `derive` cannot be used on items with type macros
 
 builtin_macros_derive_path_args_list = traits in `#[derive(...)]` don't accept arguments
@@ -228,15 +237,6 @@ builtin_macros_format_unused_args = multiple unused formatting arguments
     .label = multiple missing formatting specifiers
 
 builtin_macros_format_use_positional = consider using a positional formatting argument instead
-
-builtin_macros_derive_from_wrong_target = `#[derive(From)]` used on {$kind}
-
-builtin_macros_derive_from_wrong_field_count = `#[derive(From)]` used on a struct with {$multiple_fields ->
-    [true] multiple fields
-    *[false] no fields
-}
-
-builtin_macros_derive_from_usage_note = `#[derive(From)]` can only be used on structs with exactly one field
 
 builtin_macros_incomplete_include = include macro expected single expression in source
 

--- a/compiler/rustc_codegen_ssa/messages.ftl
+++ b/compiler/rustc_codegen_ssa/messages.ftl
@@ -97,9 +97,9 @@ codegen_ssa_invalid_literal_value = invalid literal value
 
 codegen_ssa_invalid_monomorphization_basic_float_type = invalid monomorphization of `{$name}` intrinsic: expected basic float type, found `{$ty}`
 
-codegen_ssa_invalid_monomorphization_basic_integer_type = invalid monomorphization of `{$name}` intrinsic: expected basic integer type, found `{$ty}`
-
 codegen_ssa_invalid_monomorphization_basic_integer_or_ptr_type = invalid monomorphization of `{$name}` intrinsic: expected basic integer or pointer type, found `{$ty}`
+
+codegen_ssa_invalid_monomorphization_basic_integer_type = invalid monomorphization of `{$name}` intrinsic: expected basic integer type, found `{$ty}`
 
 codegen_ssa_invalid_monomorphization_cannot_return = invalid monomorphization of `{$name}` intrinsic: cannot return `{$ret_ty}`, expected `u{$expected_int_bits}` or `[u8; {$expected_bytes}]`
 

--- a/compiler/rustc_const_eval/messages.ftl
+++ b/compiler/rustc_const_eval/messages.ftl
@@ -231,9 +231,6 @@ const_eval_mutable_borrow_escaping =
 
 const_eval_mutable_ptr_in_final = encountered mutable pointer in final value of {const_eval_intern_kind}
 
-const_eval_partial_pointer_in_final = encountered partial pointer in final value of {const_eval_intern_kind}
-    .note = while pointers can be broken apart into individual bytes during const-evaluation, only complete pointers (with all their bytes in the right order) are supported in the final value
-
 const_eval_nested_static_in_thread_local = #[thread_local] does not support implicit nested statics, please create explicit static items and refer to them instead
 
 const_eval_non_const_await =
@@ -301,6 +298,9 @@ const_eval_overflow_shift =
 const_eval_panic = evaluation panicked: {$msg}
 
 const_eval_panic_non_str = argument to `panic!()` in a const context must have type `&str`
+
+const_eval_partial_pointer_in_final = encountered partial pointer in final value of {const_eval_intern_kind}
+    .note = while pointers can be broken apart into individual bytes during const-evaluation, only complete pointers (with all their bytes in the right order) are supported in the final value
 
 const_eval_partial_pointer_read =
     unable to read parts of a pointer from memory at {$ptr}
@@ -476,6 +476,7 @@ const_eval_validation_invalid_vtable_trait = {$front_matter}: wrong trait in wid
 const_eval_validation_mutable_ref_in_const = {$front_matter}: encountered mutable reference in `const` value
 const_eval_validation_mutable_ref_to_immutable = {$front_matter}: encountered mutable reference or box pointing to read-only memory
 const_eval_validation_never_val = {$front_matter}: encountered a value of the never type `!`
+const_eval_validation_nonnull_ptr_out_of_range = {$front_matter}: encountered a maybe-null pointer, but expected something that is definitely non-zero
 const_eval_validation_null_box = {$front_matter}: encountered a {$maybe ->
     [true] maybe-null
     *[false] null
@@ -485,7 +486,6 @@ const_eval_validation_null_ref = {$front_matter}: encountered a {$maybe ->
     [true] maybe-null
     *[false] null
   } reference
-const_eval_validation_nonnull_ptr_out_of_range = {$front_matter}: encountered a maybe-null pointer, but expected something that is definitely non-zero
 const_eval_validation_out_of_range = {$front_matter}: encountered {$value}, but expected something {$in_range}
 const_eval_validation_partial_pointer = {$front_matter}: encountered a partial pointer or a mix of pointers
 const_eval_validation_pointer_as_int = {$front_matter}: encountered a pointer, but {$expected}

--- a/compiler/rustc_expand/messages.ftl
+++ b/compiler/rustc_expand/messages.ftl
@@ -95,14 +95,14 @@ expand_malformed_feature_attribute =
     malformed `feature` attribute input
     .expected = expected just one word
 
+expand_meta_var_dif_seq_matchers = {$msg}
+
 expand_metavar_still_repeating = variable `{$ident}` is still repeating at this depth
     .label = expected repetition
 
 expand_metavariable_wrong_operator = meta-variable repeats with different Kleene operator
     .binder_label = expected repetition
     .occurrence_label = conflicting repetition
-
-expand_meta_var_dif_seq_matchers = {$msg}
 
 expand_missing_fragment_specifier = missing fragment specifier
     .note = fragment specifiers must be provided
@@ -198,12 +198,12 @@ expand_trailing_semi_macro = trailing semicolon in macro used in expression posi
 
 expand_unknown_macro_variable = unknown macro variable `{$name}`
 
+expand_unsupported_key_value =
+    key-value macro attributes are not supported
+
 expand_unused_builtin_attribute = unused attribute `{$attr_name}`
     .note = the built-in attribute `{$attr_name}` will be ignored, since it's applied to the macro invocation `{$macro_name}`
     .suggestion = remove the attribute
-
-expand_unsupported_key_value =
-    key-value macro attributes are not supported
 
 expand_wrong_fragment_kind =
     non-{$kind} macro in {$kind} position: {$name}

--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -392,6 +392,14 @@ lint_improper_ctypes_union_layout_help = consider adding a `#[repr(C)]` or `#[re
 lint_improper_ctypes_union_layout_reason = this union has unspecified layout
 lint_improper_ctypes_union_non_exhaustive = this union is non-exhaustive
 
+lint_int_to_ptr_transmutes = transmuting an integer to a pointer creates a pointer without provenance
+    .note = this is dangerous because dereferencing the resulting pointer is undefined behavior
+    .note_exposed_provenance = exposed provenance semantics can be used to create a pointer based on some previously exposed provenance
+    .help_transmute = for more information about transmute, see <https://doc.rust-lang.org/std/mem/fn.transmute.html#transmutation-between-pointers-and-integers>
+    .help_exposed_provenance = for more information about exposed provenance, see <https://doc.rust-lang.org/std/ptr/index.html#exposed-provenance>
+    .suggestion_with_exposed_provenance = use `std::ptr::with_exposed_provenance{$suffix}` instead to use a previously exposed provenance
+    .suggestion_without_provenance_mut = if you truly mean to create a pointer without provenance, use `std::ptr::without_provenance_mut`
+
 lint_invalid_asm_label_binary = avoid using labels containing only the digits `0` and `1` in inline assembly
     .label = use a different label that doesn't start with `0` or `1`
     .help = start numbering with `2` instead
@@ -438,14 +446,6 @@ lint_invalid_reference_casting_borrow_as_mut = casting `&T` to `&mut T` is undef
 lint_invalid_reference_casting_note_book = for more information, visit <https://doc.rust-lang.org/book/ch15-05-interior-mutability.html>
 
 lint_invalid_reference_casting_note_ty_has_interior_mutability = even for types with interior mutability, the only legal way to obtain a mutable pointer from a shared reference is through `UnsafeCell::get`
-
-lint_int_to_ptr_transmutes = transmuting an integer to a pointer creates a pointer without provenance
-    .note = this is dangerous because dereferencing the resulting pointer is undefined behavior
-    .note_exposed_provenance = exposed provenance semantics can be used to create a pointer based on some previously exposed provenance
-    .help_transmute = for more information about transmute, see <https://doc.rust-lang.org/std/mem/fn.transmute.html#transmutation-between-pointers-and-integers>
-    .help_exposed_provenance = for more information about exposed provenance, see <https://doc.rust-lang.org/std/ptr/index.html#exposed-provenance>
-    .suggestion_with_exposed_provenance = use `std::ptr::with_exposed_provenance{$suffix}` instead to use a previously exposed provenance
-    .suggestion_without_provenance_mut = if you truly mean to create a pointer without provenance, use `std::ptr::without_provenance_mut`
 
 lint_lintpass_by_hand = implementing `LintPass` by hand
     .help = try using `declare_lint_pass!` or `impl_lint_pass!` instead

--- a/compiler/rustc_metadata/messages.ftl
+++ b/compiler/rustc_metadata/messages.ftl
@@ -98,13 +98,6 @@ metadata_full_metadata_not_found =
 metadata_global_alloc_required =
     no global memory allocator found but one is required; link to std or add `#[global_allocator]` to a static item that implements the GlobalAlloc trait
 
-metadata_incompatible_with_immediate_abort =
-    the crate `{$crate_name}` was compiled with a panic strategy which is incompatible with `immediate-abort`
-
-metadata_incompatible_with_immediate_abort_core =
-    the crate `core` was compiled with a panic strategy which is incompatible with `immediate-abort`
-    .help = consider building the standard library from source with `cargo build -Zbuild-std`
-
 metadata_incompatible_panic_in_drop_strategy =
     the crate `{$crate_name}` is compiled with the panic-in-drop strategy `{$found_strategy}` which is incompatible with this crate's strategy of `{$desired_strategy}`
 
@@ -131,6 +124,13 @@ metadata_incompatible_target_modifiers_r_missed =
     mixing `{$flag_name_prefixed}` will cause an ABI mismatch in crate `{$local_crate}`
     .note = `{$flag_name_prefixed}={$local_value}` in this crate is incompatible with unset `{$flag_name_prefixed}` in dependency `{$extern_crate}`
     .help = the `{$flag_name_prefixed}` flag modifies the ABI so Rust crates compiled with different values of this flag cannot be used together safely
+
+metadata_incompatible_with_immediate_abort =
+    the crate `{$crate_name}` was compiled with a panic strategy which is incompatible with `immediate-abort`
+
+metadata_incompatible_with_immediate_abort_core =
+    the crate `core` was compiled with a panic strategy which is incompatible with `immediate-abort`
+    .help = consider building the standard library from source with `cargo build -Zbuild-std`
 
 metadata_install_missing_components =
     maybe you need to install the missing components with: `rustup component add rust-src rustc-dev llvm-tools-preview`
@@ -197,6 +197,8 @@ metadata_prev_alloc_error_handler =
 metadata_prev_global_alloc =
     previous global allocator defined here
 
+metadata_raw_dylib_malformed =
+    link name must be well-formed if link kind is `raw-dylib`
 metadata_raw_dylib_unsupported_abi =
     ABI not supported by `#[link(kind = "raw-dylib")]` on this architecture
 
@@ -236,12 +238,3 @@ metadata_unknown_target_modifier_unsafe_allowed = unknown target modifier `{$fla
 
 metadata_wasm_c_abi =
     older versions of the `wasm-bindgen` crate are incompatible with current versions of Rust; please update to `wasm-bindgen` v0.2.88
-
-metadata_wasm_import_form =
-    wasm import module must be of the form `wasm_import_module = "string"`
-
-metadata_whole_archive_needs_static =
-    linking modifier `whole-archive` is only compatible with `static` linking kind
-
-metadata_raw_dylib_malformed =
-    link name must be well-formed if link kind is `raw-dylib`

--- a/compiler/rustc_middle/messages.ftl
+++ b/compiler/rustc_middle/messages.ftl
@@ -95,14 +95,14 @@ middle_layout_normalization_failure =
 middle_layout_references_error =
     the type has an unknown layout
 
-middle_layout_size_overflow =
-    values of the type `{$ty}` are too big for the target architecture
-
 middle_layout_simd_too_many =
     the SIMD type `{$ty}` has more elements than the limit {$max_lanes}
 
 middle_layout_simd_zero_length =
     the SIMD type `{$ty}` has zero elements
+
+middle_layout_size_overflow =
+    values of the type `{$ty}` are too big for the target architecture
 
 middle_layout_too_generic = the type `{$ty}` does not have a fixed layout
 

--- a/compiler/rustc_parse/messages.ftl
+++ b/compiler/rustc_parse/messages.ftl
@@ -68,19 +68,19 @@ parse_attr_after_generic = trailing attribute after generic parameter
 parse_attr_without_generics = attribute without generic parameters
     .label = attributes are only permitted when preceding parameters
 
+parse_attribute_on_empty_type = attributes cannot be applied here
+    .label = attributes are not allowed here
+
+parse_attribute_on_generic_arg = attributes cannot be applied to generic arguments
+    .label = attributes are not allowed here
+    .suggestion = remove attribute from here
+
 parse_attribute_on_param_type = attributes cannot be applied to a function parameter's type
     .label = attributes are not allowed here
 
 parse_attribute_on_type = attributes cannot be applied to types
     .label = attributes are not allowed here
     .suggestion = remove attribute from here
-
-parse_attribute_on_generic_arg = attributes cannot be applied to generic arguments
-    .label = attributes are not allowed here
-    .suggestion = remove attribute from here
-
-parse_attribute_on_empty_type = attributes cannot be applied here
-    .label = attributes are not allowed here
 
 parse_bad_assoc_type_bounds = bounds on associated types do not belong here
     .label = belongs in `where` clause
@@ -868,7 +868,6 @@ parse_too_many_hashes = too many `#` symbols: raw strings may be delimited by up
 parse_too_short_hex_escape = numeric character escape is too short
 
 parse_trailing_vert_not_allowed = a trailing `{$token}` is not allowed in an or-pattern
-parse_trailing_vert_not_allowed_suggestion = remove the `{$token}`
 
 parse_trait_alias_cannot_be_auto = trait aliases cannot be `auto`
 parse_trait_alias_cannot_be_const = trait aliases cannot be `const`

--- a/compiler/rustc_passes/messages.ftl
+++ b/compiler/rustc_passes/messages.ftl
@@ -13,10 +13,6 @@ passes_abi_ne =
 passes_abi_of =
     fn_abi_of({$fn_name}) = {$fn_abi}
 
-passes_macro_only_attribute =
-    attribute should be applied to a macro
-    .label = not a macro
-
 passes_attr_application_enum =
     attribute should be applied to an enum
     .label = not an enum
@@ -391,6 +387,10 @@ passes_loop_match_attr =
 passes_macro_export_on_decl_macro =
     `#[macro_export]` has no effect on declarative macro definitions
     .note = declarative macros follow the same exporting rules as regular items
+
+passes_macro_only_attribute =
+    attribute should be applied to a macro
+    .label = not a macro
 
 passes_may_dangle =
     `#[may_dangle]` must be applied to a lifetime or type generic parameter in `Drop` impl

--- a/compiler/rustc_resolve/messages.ftl
+++ b/compiler/rustc_resolve/messages.ftl
@@ -93,9 +93,6 @@ resolve_consider_adding_a_derive =
 resolve_consider_adding_macro_export =
     consider adding a `#[macro_export]` to the macro in the imported module
 
-resolve_consider_marking_as_pub_crate =
-    in case you want to use the macro within this crate only, reduce the visibility to `pub(crate)`
-
 resolve_consider_declaring_with_pub =
     consider declaring type or module `{$ident}` with `pub`
 
@@ -107,6 +104,9 @@ resolve_consider_making_the_field_public =
 
 resolve_consider_marking_as_pub =
     consider marking `{$ident}` as `pub` in the imported module
+
+resolve_consider_marking_as_pub_crate =
+    in case you want to use the macro within this crate only, reduce the visibility to `pub(crate)`
 
 resolve_consider_move_macro_position =
     consider moving the definition of `{$ident}` before this call
@@ -248,14 +248,14 @@ resolve_lowercase_self =
     attempt to use a non-constant value in a constant
     .suggestion = try using `Self`
 
-resolve_macro_cannot_use_as_fn_like =
-    `{$ident}` exists, but has no rules for function-like invocation
-
 resolve_macro_cannot_use_as_attr =
     `{$ident}` exists, but has no `attr` rules
 
 resolve_macro_cannot_use_as_derive =
      `{$ident}` exists, but has no `derive` rules
+
+resolve_macro_cannot_use_as_fn_like =
+    `{$ident}` exists, but has no rules for function-like invocation
 
 resolve_macro_defined_later =
     a macro with the same name exists, but it appears later

--- a/compiler/rustc_ty_utils/messages.ftl
+++ b/compiler/rustc_ty_utils/messages.ftl
@@ -52,8 +52,6 @@ ty_utils_non_primitive_simd_type = monomorphising SIMD type `{$ty}` with a non-p
 
 ty_utils_operation_not_supported = unsupported operation in generic constants
 
-ty_utils_oversized_simd_type = monomorphising SIMD type `{$ty}` of length greater than {$max_lanes}
-
 ty_utils_pointer_not_supported = pointer casts are not allowed in generic constants
 
 ty_utils_tuple_not_supported = tuple construction is not supported in generic constants
@@ -61,5 +59,3 @@ ty_utils_tuple_not_supported = tuple construction is not supported in generic co
 ty_utils_unexpected_fnptr_associated_item = `FnPtr` trait with unexpected associated item
 
 ty_utils_yield_not_supported = coroutine control flow is not allowed in generic constants
-
-ty_utils_zero_length_simd_type = monomorphising SIMD type `{$ty}` of zero length

--- a/src/tools/tidy/src/fluent_alphabetical.rs
+++ b/src/tools/tidy/src/fluent_alphabetical.rs
@@ -15,7 +15,7 @@ fn message() -> &'static Regex {
 }
 
 fn is_fluent(path: &Path) -> bool {
-    path.extension().is_some_and(|ext| ext == "flt")
+    path.extension().is_some_and(|ext| ext == "ftl")
 }
 
 fn check_alphabetic(


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

As was explained here https://github.com/rust-lang/rust/pull/147191#issuecomment-3353801210, this reverting this change because `flt` is incorrect format

Also maybe there is existed PR for that? I didn't found one

Follow up https://github.com/rust-lang/rust/pull/147191

cc @GuillaumeGomez 