### PR TITLE
Improve the advice given by panic_immediate_abort

### DIFF
--- a/library/core/src/panicking.rs
+++ b/library/core/src/panicking.rs
@@ -35,7 +35,8 @@ use crate::panic::{Location, PanicInfo};
 #[cfg(feature = "panic_immediate_abort")]
 compile_error!(
     "panic_immediate_abort is now a real panic strategy! \
-    Enable it with the compiler flags `-Zunstable-options -Cpanic=immediate-abort`"
+    Enable it with `panic = \"immediate-abort\"` in Cargo.toml, \
+    or with the compiler flags `-Zunstable-options -Cpanic=immediate-abort`"
 );
 
 // First we define the two main entry points that all panics go through.


### PR DESCRIPTION
Now that https://github.com/rust-lang/rust/pull/147338 is merged, users should consider using the Cargo support for immediate-aborting panics.