### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -873,6 +873,7 @@ symbols! {
         div,
         div_assign,
         diverging_block_default,
+        dl,
         do_not_recommend,
         doc,
         doc_alias,

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -467,7 +467,8 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                             span,
                             leaf_trait_predicate,
                         );
-                        self.note_version_mismatch(&mut err, leaf_trait_predicate);
+                        self.note_trait_version_mismatch(&mut err, leaf_trait_predicate);
+                        self.note_adt_version_mismatch(&mut err, leaf_trait_predicate);
                         self.suggest_remove_await(&obligation, &mut err);
                         self.suggest_derive(&obligation, &mut err, leaf_trait_predicate);
 
@@ -2406,7 +2407,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
     /// If the `Self` type of the unsatisfied trait `trait_ref` implements a trait
     /// with the same path as `trait_ref`, a help message about
     /// a probable version mismatch is added to `err`
-    fn note_version_mismatch(
+    fn note_trait_version_mismatch(
         &self,
         err: &mut Diag<'_>,
         trait_pred: ty::PolyTraitPredicate<'tcx>,
@@ -2446,13 +2447,85 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 impl_spans,
                 format!("trait impl{} with same name found", pluralize!(trait_impls.len())),
             );
-            let trait_crate = self.tcx.crate_name(trait_with_same_path.krate);
-            let crate_msg =
-                format!("perhaps two different versions of crate `{trait_crate}` are being used?");
-            err.note(crate_msg);
+            self.note_two_crate_versions(trait_with_same_path, err);
             suggested = true;
         }
         suggested
+    }
+
+    fn note_two_crate_versions(&self, did: DefId, err: &mut Diag<'_>) {
+        let crate_name = self.tcx.crate_name(did.krate);
+        let crate_msg =
+            format!("perhaps two different versions of crate `{crate_name}` are being used?");
+        err.note(crate_msg);
+    }
+
+    fn note_adt_version_mismatch(
+        &self,
+        err: &mut Diag<'_>,
+        trait_pred: ty::PolyTraitPredicate<'tcx>,
+    ) {
+        let ty::Adt(impl_self_def, _) = trait_pred.self_ty().skip_binder().peel_refs().kind()
+        else {
+            return;
+        };
+
+        let impl_self_did = impl_self_def.did();
+
+        // We only want to warn about different versions of a dependency.
+        // If no dependency is involved, bail.
+        if impl_self_did.krate == LOCAL_CRATE {
+            return;
+        }
+
+        let impl_self_path = self.comparable_path(impl_self_did);
+        let impl_self_crate_name = self.tcx.crate_name(impl_self_did.krate);
+        let similar_items: UnordSet<_> = self
+            .tcx
+            .visible_parent_map(())
+            .items()
+            .filter_map(|(&item, _)| {
+                // If we found ourselves, ignore.
+                if impl_self_did == item {
+                    return None;
+                }
+                // We only want to warn about different versions of a dependency.
+                // Ignore items from our own crate.
+                if item.krate == LOCAL_CRATE {
+                    return None;
+                }
+                // We want to warn about different versions of a dependency.
+                // So make sure the crate names are the same.
+                if impl_self_crate_name != self.tcx.crate_name(item.krate) {
+                    return None;
+                }
+                // Filter out e.g. constructors that often have the same path
+                // str as the relevant ADT.
+                if !self.tcx.def_kind(item).is_adt() {
+                    return None;
+                }
+                let path = self.comparable_path(item);
+                // We don't know if our item or the one we found is the re-exported one.
+                // Check both cases.
+                let is_similar = path.ends_with(&impl_self_path) || impl_self_path.ends_with(&path);
+                is_similar.then_some((item, path))
+            })
+            .collect();
+
+        let mut similar_items =
+            similar_items.into_items().into_sorted_stable_ord_by_key(|(_, path)| path);
+        similar_items.dedup();
+
+        for (similar_item, _) in similar_items {
+            err.span_help(self.tcx.def_span(similar_item), "item with same name found");
+            self.note_two_crate_versions(similar_item, err);
+        }
+    }
+
+    /// Add a `::` prefix when comparing paths so that paths with just one item
+    /// like "Foo" does not equal the end of "OtherFoo".
+    fn comparable_path(&self, did: DefId) -> String {
+        format!("::{}", self.tcx.def_path_str(did))
     }
 
     /// Creates a `PredicateObligation` with `new_self_ty` replacing the existing type in the

--- a/tests/codegen-llvm/autodiff/autodiffv2.rs
+++ b/tests/codegen-llvm/autodiff/autodiffv2.rs
@@ -18,11 +18,6 @@
 // but each shadow argument is `width` times larger (thus 16 and 20 elements here).
 // `d_square3` instead takes `width` (4) shadow arguments, which are all the same size as the
 // original function arguments.
-//
-// FIXME(autodiff): We currently can't test `d_square1` and `d_square3` in the same file, since they
-// generate the same dummy functions which get merged by LLVM, breaking pieces of our pipeline which
-// try to rewrite the dummy functions later. We should consider to change to pure declarations both
-// in our frontend and in the llvm backend to avoid these issues.
 
 #![feature(autodiff)]
 
@@ -30,7 +25,7 @@ use std::autodiff::autodiff_forward;
 
 // CHECK: ;
 #[no_mangle]
-//#[autodiff(d_square1, Forward, Dual, Dual)]
+#[autodiff_forward(d_square1, Dual, Dual)]
 #[autodiff_forward(d_square2, 4, Dualv, Dualv)]
 #[autodiff_forward(d_square3, 4, Dual, Dual)]
 fn square(x: &[f32], y: &mut [f32]) {
@@ -79,25 +74,25 @@ fn main() {
     let mut dy3_4 = std::hint::black_box(vec![0.0; 5]);
 
     // scalar.
-    //d_square1(&x1, &z1, &mut y1, &mut dy1_1);
-    //d_square1(&x1, &z2, &mut y2, &mut dy1_2);
-    //d_square1(&x1, &z3, &mut y3, &mut dy1_3);
-    //d_square1(&x1, &z4, &mut y4, &mut dy1_4);
+    d_square1(&x1, &z1, &mut y1, &mut dy1_1);
+    d_square1(&x1, &z2, &mut y2, &mut dy1_2);
+    d_square1(&x1, &z3, &mut y3, &mut dy1_3);
+    d_square1(&x1, &z4, &mut y4, &mut dy1_4);
 
     // assert y1 == y2 == y3 == y4
-    //for i in 0..5 {
-    //    assert_eq!(y1[i], y2[i]);
-    //    assert_eq!(y1[i], y3[i]);
-    //    assert_eq!(y1[i], y4[i]);
-    //}
+    for i in 0..5 {
+        assert_eq!(y1[i], y2[i]);
+        assert_eq!(y1[i], y3[i]);
+        assert_eq!(y1[i], y4[i]);
+    }
 
     // batch mode A)
     d_square2(&x1, &z5, &mut y5, &mut dy2);
 
     // assert y1 == y2 == y3 == y4 == y5
-    //for i in 0..5 {
-    //    assert_eq!(y1[i], y5[i]);
-    //}
+    for i in 0..5 {
+        assert_eq!(y1[i], y5[i]);
+    }
 
     // batch mode B)
     d_square3(&x1, &z1, &z2, &z3, &z4, &mut y6, &mut dy3_1, &mut dy3_2, &mut dy3_3, &mut dy3_4);

--- a/tests/codegen-llvm/autodiff/identical_fnc.rs
+++ b/tests/codegen-llvm/autodiff/identical_fnc.rs
@@ -32,9 +32,9 @@ fn square2(x: &f64) -> f64 {
 // CHECK-NOT:br
 // CHECK-NOT:ret
 // CHECK:; call identical_fnc::d_square
-// CHECK-NEXT:call fastcc void @_ZN13identical_fnc8d_square17hcb5768e95528c35fE(double %x.val, ptr noalias noundef align 8 dereferenceable(8) %dx1)
+// CHECK-NEXT:call fastcc void @_ZN13identical_fnc8d_square[[HASH:.+]](double %x.val, ptr noalias noundef align 8 dereferenceable(8) %dx1)
 // CHECK:; call identical_fnc::d_square
-// CHECK-NEXT:call fastcc void @_ZN13identical_fnc8d_square17hcb5768e95528c35fE(double %x.val, ptr noalias noundef align 8 dereferenceable(8) %dx2)
+// CHECK-NEXT:call fastcc void @_ZN13identical_fnc8d_square[[HASH]](double %x.val, ptr noalias noundef align 8 dereferenceable(8) %dx2)
 
 fn main() {
     let x = std::hint::black_box(3.0);

--- a/tests/run-make/duplicate-dependency/foo-v1.rs
+++ b/tests/run-make/duplicate-dependency/foo-v1.rs
@@ -1,0 +1,1 @@
+pub struct Foo;

--- a/tests/run-make/duplicate-dependency/foo-v2.rs
+++ b/tests/run-make/duplicate-dependency/foo-v2.rs
@@ -1,0 +1,1 @@
+pub struct Foo;

--- a/tests/run-make/duplicate-dependency/main.rs
+++ b/tests/run-make/duplicate-dependency/main.rs
@@ -1,0 +1,15 @@
+struct Bar;
+
+impl From<Bar> for foo::Foo {
+    fn from(_: Bar) -> Self {
+        foo::Foo
+    }
+}
+
+fn main() {
+    // The user might wrongly expect this to work since From<Bar> for Foo
+    // implies Into<Foo> for Bar. What the user missed is that different
+    // versions of Foo exist in the dependency graph, and the impl is for the
+    // wrong version.
+    re_export_foo::into_foo(Bar);
+}

--- a/tests/run-make/duplicate-dependency/main.stderr
+++ b/tests/run-make/duplicate-dependency/main.stderr
@@ -1,0 +1,18 @@
+error[E0277]: the trait bound `re_export_foo::foo::Foo: From<Bar>` is not satisfied
+  --> main.rs:14:29
+   |
+LL |     re_export_foo::into_foo(Bar);
+   |     ----------------------- ^^^ the trait `From<Bar>` is not implemented for `re_export_foo::foo::Foo`
+   |     |
+   |     required by a bound introduced by this call
+   |
+   = note: required for `Bar` to implement `Into<re_export_foo::foo::Foo>`
+note: required by a bound in `into_foo`
+  --> $DIR/re-export-foo.rs:3:25
+   |
+LL | pub fn into_foo(_: impl Into<foo::Foo>) {}
+   |                         ^^^^^^^^^^^^^^ required by this bound in `into_foo`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/run-make/duplicate-dependency/main.stderr
+++ b/tests/run-make/duplicate-dependency/main.stderr
@@ -6,6 +6,12 @@ LL |     re_export_foo::into_foo(Bar);
    |     |
    |     required by a bound introduced by this call
    |
+help: item with same name found
+  --> $DIR/foo-v1.rs:1:1
+   |
+LL | pub struct Foo;
+   | ^^^^^^^^^^^^^^
+   = note: perhaps two different versions of crate `foo` are being used?
    = note: required for `Bar` to implement `Into<re_export_foo::foo::Foo>`
 note: required by a bound in `into_foo`
   --> $DIR/re-export-foo.rs:3:25

--- a/tests/run-make/duplicate-dependency/re-export-foo.rs
+++ b/tests/run-make/duplicate-dependency/re-export-foo.rs
@@ -1,0 +1,3 @@
+pub use foo;
+
+pub fn into_foo(_: impl Into<foo::Foo>) {}

--- a/tests/run-make/duplicate-dependency/rmake.rs
+++ b/tests/run-make/duplicate-dependency/rmake.rs
@@ -1,0 +1,43 @@
+use run_make_support::{Rustc, cwd, diff, rust_lib_name, rustc};
+
+fn rustc_with_common_args() -> Rustc {
+    let mut rustc = rustc();
+    rustc.remap_path_prefix(cwd(), "$DIR");
+    rustc.edition("2018"); // Don't require `extern crate`
+    rustc
+}
+
+fn main() {
+    rustc_with_common_args()
+        .input("foo-v1.rs")
+        .crate_type("rlib")
+        .crate_name("foo")
+        .extra_filename("-v1")
+        .metadata("-v1")
+        .run();
+
+    rustc_with_common_args()
+        .input("foo-v2.rs")
+        .crate_type("rlib")
+        .crate_name("foo")
+        .extra_filename("-v2")
+        .metadata("-v2")
+        .run();
+
+    rustc_with_common_args()
+        .input("re-export-foo.rs")
+        .crate_type("rlib")
+        .extern_("foo", rust_lib_name("foo-v2"))
+        .run();
+
+    let stderr = rustc_with_common_args()
+        .input("main.rs")
+        .extern_("foo", rust_lib_name("foo-v1"))
+        .extern_("re_export_foo", rust_lib_name("re_export_foo"))
+        .library_search_path(cwd())
+        .ui_testing()
+        .run_fail()
+        .stderr_utf8();
+
+    diff().expected_file("main.stderr").actual_text("(rustc)", &stderr).run();
+}

--- a/tests/run-make/duplicate-dependency/rmake.rs
+++ b/tests/run-make/duplicate-dependency/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+
 use run_make_support::{Rustc, cwd, diff, rust_lib_name, rustc};
 
 fn rustc_with_common_args() -> Rustc {

--- a/tests/ui/attributes/link-dl.allowed.stderr
+++ b/tests/ui/attributes/link-dl.allowed.stderr
@@ -1,0 +1,10 @@
+Future incompatibility report: Future breakage diagnostic:
+warning: valid forms for the attribute are `#[link(name = "...")]`, `#[link(name = "...", import_name_type = "decorated|noprefix|undecorated")]`, `#[link(name = "...", kind = "dylib|static|...")]`, `#[link(name = "...", kind = "dylib|static|...", wasm_import_module = "...", import_name_type = "decorated|noprefix|undecorated")]`, and `#[link(name = "...", wasm_import_module = "...")]`
+  --> $DIR/link-dl.rs:14:1
+   |
+LL | #[link="dl"]
+   | ^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
+

--- a/tests/ui/attributes/link-dl.default_fcw.stderr
+++ b/tests/ui/attributes/link-dl.default_fcw.stderr
@@ -1,0 +1,26 @@
+error[E0539]: malformed `link` attribute input
+  --> $DIR/link-dl.rs:14:1
+   |
+LL | #[link="dl"]
+   | ^^^^^^^^^^^^ expected this to be a list
+   |
+   = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute>
+help: try changing it to one of the following valid forms of the attribute
+   |
+LL - #[link="dl"]
+LL + #[link(name = "...")]
+   |
+LL - #[link="dl"]
+LL + #[link(name = "...", import_name_type = "decorated|noprefix|undecorated")]
+   |
+LL - #[link="dl"]
+LL + #[link(name = "...", kind = "dylib|static|...")]
+   |
+LL - #[link="dl"]
+LL + #[link(name = "...", kind = "dylib|static|...", wasm_import_module = "...", import_name_type = "decorated|noprefix|undecorated")]
+   |
+   = and 1 other candidate
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0539`.

--- a/tests/ui/attributes/link-dl.default_fcw.stderr
+++ b/tests/ui/attributes/link-dl.default_fcw.stderr
@@ -1,26 +1,23 @@
-error[E0539]: malformed `link` attribute input
+error: valid forms for the attribute are `#[link(name = "...")]`, `#[link(name = "...", import_name_type = "decorated|noprefix|undecorated")]`, `#[link(name = "...", kind = "dylib|static|...")]`, `#[link(name = "...", kind = "dylib|static|...", wasm_import_module = "...", import_name_type = "decorated|noprefix|undecorated")]`, and `#[link(name = "...", wasm_import_module = "...")]`
   --> $DIR/link-dl.rs:14:1
    |
 LL | #[link="dl"]
-   | ^^^^^^^^^^^^ expected this to be a list
+   | ^^^^^^^^^^^^
    |
-   = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute>
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL - #[link="dl"]
-LL + #[link(name = "...")]
-   |
-LL - #[link="dl"]
-LL + #[link(name = "...", import_name_type = "decorated|noprefix|undecorated")]
-   |
-LL - #[link="dl"]
-LL + #[link(name = "...", kind = "dylib|static|...")]
-   |
-LL - #[link="dl"]
-LL + #[link(name = "...", kind = "dylib|static|...", wasm_import_module = "...", import_name_type = "decorated|noprefix|undecorated")]
-   |
-   = and 1 other candidate
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
+   = note: `#[deny(ill_formed_attribute_input)]` (part of `#[deny(future_incompatible)]`) on by default
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0539`.
+Future incompatibility report: Future breakage diagnostic:
+error: valid forms for the attribute are `#[link(name = "...")]`, `#[link(name = "...", import_name_type = "decorated|noprefix|undecorated")]`, `#[link(name = "...", kind = "dylib|static|...")]`, `#[link(name = "...", kind = "dylib|static|...", wasm_import_module = "...", import_name_type = "decorated|noprefix|undecorated")]`, and `#[link(name = "...", wasm_import_module = "...")]`
+  --> $DIR/link-dl.rs:14:1
+   |
+LL | #[link="dl"]
+   | ^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
+   = note: `#[deny(ill_formed_attribute_input)]` (part of `#[deny(future_incompatible)]`) on by default
+

--- a/tests/ui/attributes/link-dl.rs
+++ b/tests/ui/attributes/link-dl.rs
@@ -1,0 +1,19 @@
+// Regression test for an issue discovered in https://github.com/rust-lang/rust/pull/143193/files and rediscovered in https://github.com/rust-lang/rust/issues/147254#event-20049906781
+// Malformed #[link] attribute was supposed to be deny-by-default report-in-deps FCW,
+// but accidentally was landed as a hard error.
+//
+// revision `default_fcw` tests that with `ill_formed_attribute_input` (the default) denied,
+// the attribute produces an FCW
+// revision `allowed` tests that with `ill_formed_attribute_input` allowed the test passes
+
+//@ revisions: default_fcw allowed
+//@[allowed] check-pass
+
+#[cfg_attr(allowed, allow(ill_formed_attribute_input))]
+
+#[link="dl"]
+//[default_fcw]~^ ERROR valid forms for the attribute are
+//[default_fcw]~| WARN previously accepted
+extern "C" { }
+
+fn main() {}


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#146874 (compiler: Hint at multiple crate versions if trait impl is for wrong ADT )
 - rust-lang/rust#147262 (Make #[link="dl"] an FCW rather than an error)
 - rust-lang/rust#147364 (update autodiff testcases)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=146874,147262,147364)
<!-- homu-ignore:end -->