### PR TITLE
Fill out AVR target metadata

### DIFF
--- a/compiler/rustc_target/src/spec/targets/avr_none.rs
+++ b/compiler/rustc_target/src/spec/targets/avr_none.rs
@@ -5,9 +5,9 @@ pub(crate) fn target() -> Target {
         arch: "avr".into(),
         metadata: crate::spec::TargetMetadata {
             description: None,
-            tier: None,
-            host_tools: None,
-            std: None,
+            tier: Some(3),
+            host_tools: Some(false),
+            std: Some(false),
         },
         data_layout: "e-P1-p:16:8-i8:8-i16:8-i32:8-i64:8-f32:8-f64:8-n8:16-a:8".into(),
         llvm_target: "avr-unknown-unknown".into(),


### PR DESCRIPTION
This will make `-Zbuild-std` automatically build the right crates, notably not building `std` by default, which will both be useful for users and also fix the build for https://does-it-build.noratrieb.dev, which currently tries to build std: http://localhost:3000/build?nightly=2025-07-12&target=avr-none&mode=std.

cc @Patryk27 but I don't think this necessarily needs your approval