### PR TITLE
give a better example why `std` modules named like primitives are needed

### DIFF
--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -63,10 +63,10 @@
 //!    type, but not the all-important methods.
 //!
 //! So for example there is a [page for the primitive type
-//! `i32`](primitive::i32) that lists all the methods that can be called on
-//! 32-bit integers (very useful), and there is a [page for the module
-//! `std::i32`] that documents the constant values [`MIN`] and [`MAX`] (rarely
-//! useful).
+//! `char`](primitive::char) that lists all the methods that can be called on
+//! characters (very useful), and there is a [page for the module
+//! `std::char`] that documents iterator and error types created by these methods
+//! (rarely useful).
 //!
 //! Note the documentation for the primitives [`str`] and [`[T]`][prim@slice] (also
 //! called 'slice'). Many method calls on [`String`] and [`Vec<T>`] are actually


### PR DESCRIPTION
A small update to the `std` `lib.rs` introduction to replace mentions of `std::i32` (never needed) with `std::char` (sometimes needed).
Related to rust-lang/rust#146882.