### PR TITLE
bootstrap: don't build book redirect pages during dry-run/test

### DIFF
--- a/src/bootstrap/src/core/build_steps/doc.rs
+++ b/src/bootstrap/src/core/build_steps/doc.rs
@@ -274,6 +274,10 @@ impl Step for TheBook {
 
         // build the redirect pages
         let _guard = builder.msg(Kind::Doc, "book redirect pages", None, build_compiler, target);
+        if builder.config.dry_run() {
+            return;
+        }
+
         for file in t!(fs::read_dir(redirect_path)) {
             let file = t!(file);
             let path = file.path();

--- a/src/bootstrap/src/core/builder/tests.rs
+++ b/src/bootstrap/src/core/builder/tests.rs
@@ -1270,12 +1270,12 @@ mod snapshot {
         [doc] book/first-edition (book) <host>
         [doc] book/second-edition (book) <host>
         [doc] book/2018-edition (book) <host>
-        [build] rustdoc 1 <host>
         [build] rustc 1 <host> -> std 1 <target1>
         [doc] book (book) <target1>
         [doc] book/first-edition (book) <target1>
         [doc] book/second-edition (book) <target1>
         [doc] book/2018-edition (book) <target1>
+        [build] rustdoc 1 <host>
         [doc] rustc 1 <host> -> standalone 2 <host>
         [doc] rustc 1 <host> -> standalone 2 <target1>
         [doc] rustc 1 <host> -> std 1 <host> crates=[alloc,compiler_builtins,core,panic_abort,panic_unwind,proc_macro,rustc-std-workspace-core,std,std_detect,sysroot,test,unwind]
@@ -1409,12 +1409,12 @@ mod snapshot {
         [doc] book/first-edition (book) <host>
         [doc] book/second-edition (book) <host>
         [doc] book/2018-edition (book) <host>
-        [build] rustdoc 1 <host>
         [build] rustc 1 <host> -> std 1 <target1>
         [doc] book (book) <target1>
         [doc] book/first-edition (book) <target1>
         [doc] book/second-edition (book) <target1>
         [doc] book/2018-edition (book) <target1>
+        [build] rustdoc 1 <host>
         [doc] rustc 1 <host> -> standalone 2 <host>
         [doc] rustc 1 <host> -> standalone 2 <target1>
         [doc] rustc 1 <host> -> std 1 <host> crates=[alloc,compiler_builtins,core,panic_abort,panic_unwind,proc_macro,rustc-std-workspace-core,std,std_detect,sysroot,test,unwind]
@@ -1493,8 +1493,8 @@ mod snapshot {
         [doc] book/first-edition (book) <target1>
         [doc] book/second-edition (book) <target1>
         [doc] book/2018-edition (book) <target1>
-        [build] rustdoc 1 <host>
         [build] rustc 1 <host> -> std 1 <host>
+        [build] rustdoc 1 <host>
         [doc] rustc 1 <host> -> standalone 2 <target1>
         [doc] rustc 1 <host> -> std 1 <target1> crates=[alloc,compiler_builtins,core,panic_abort,panic_unwind,proc_macro,rustc-std-workspace-core,std,std_detect,sysroot,test,unwind]
         [doc] nomicon (book) <target1>
@@ -1537,8 +1537,8 @@ mod snapshot {
         [doc] book/first-edition (book) <target1>
         [doc] book/second-edition (book) <target1>
         [doc] book/2018-edition (book) <target1>
-        [build] rustdoc 1 <host>
         [build] rustc 1 <host> -> std 1 <host>
+        [build] rustdoc 1 <host>
         [doc] rustc 1 <host> -> standalone 2 <target1>
         [doc] rustc 1 <host> -> std 1 <target1> crates=[alloc,compiler_builtins,core,panic_abort,panic_unwind,proc_macro,rustc-std-workspace-core,std,std_detect,sysroot,test,unwind]
         [build] llvm <target1>


### PR DESCRIPTION
Currently, `./x test bootstrap` does not automatically transitively checkout submodules needed to pass all involved test steps. Apparently one place where bootstrap's self-test can choke on locally is trying to build book redirect pages without the book submodules checked out.

This change is orthogonal to making bootstrap checking out required submodules for self-tests, and IMO is beneficial regardless since IMO we should not be building these redirect pages during test/dry-run _anyway_.

This was blocking me trying to rebless bootstrap self-tests for rust-lang/rust#147372. cf. [#t-infra/bootstrap > Bootstrap self-tests @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/326414-t-infra.2Fbootstrap/topic/Bootstrap.20self-tests/near/543157194).

r? @Kobzol (or bootstrap)