### PR TITLE
ignore power alignment rule on unions

### DIFF
--- a/tests/ui/layout/reprc-power-alignment.rs
+++ b/tests/ui/layout/reprc-power-alignment.rs
@@ -5,12 +5,12 @@
 #![feature(no_core)]
 #![no_core]
 #![no_std]
+#![crate_type = "lib"]
 
 extern crate minicore;
 use minicore::*;
 
 #[warn(uses_power_alignment)]
-
 #[repr(C)]
 pub struct Floats {
     a: f64,
@@ -96,32 +96,32 @@ pub struct FloatAgg7 {
 
 #[repr(C)]
 pub struct A {
-  d: f64,
+    d: f64,
 }
 #[repr(C)]
 pub struct B {
-  a: A,
-  f: f32,
-  d: f64, //~ WARNING repr(C) does not follow the power alignment rule. This may affect platform C ABI compatibility for this type
+    a: A,
+    f: f32,
+    d: f64, //~ WARNING repr(C) does not follow the power alignment rule. This may affect platform C ABI compatibility for this type
 }
 #[repr(C)]
 pub struct C {
-  c: u8,
-  b: B, //~ WARNING repr(C) does not follow the power alignment rule. This may affect platform C ABI compatibility for this type
+    c: u8,
+    b: B, //~ WARNING repr(C) does not follow the power alignment rule. This may affect platform C ABI compatibility for this type
 }
 #[repr(C)]
 pub struct D {
-  x: f64,
+    x: f64,
 }
 #[repr(C)]
 pub struct E {
-  x: i32,
-  d: D, //~ WARNING repr(C) does not follow the power alignment rule. This may affect platform C ABI compatibility for this type
+    x: i32,
+    d: D, //~ WARNING repr(C) does not follow the power alignment rule. This may affect platform C ABI compatibility for this type
 }
 #[repr(C)]
 pub struct F {
-  a: u8,
-  b: f64, //~ WARNING repr(C) does not follow the power alignment rule. This may affect platform C ABI compatibility for this type
+    a: u8,
+    b: f64, //~ WARNING repr(C) does not follow the power alignment rule. This may affect platform C ABI compatibility for this type
 }
 #[repr(C)]
 pub struct G {
@@ -173,4 +173,3 @@ pub struct M {
     b: K,
     c: L,
 }
-fn main() { }

--- a/tests/ui/layout/reprc-power-alignment.rs
+++ b/tests/ui/layout/reprc-power-alignment.rs
@@ -173,3 +173,19 @@ pub struct M {
     b: K,
     c: L,
 }
+
+// The lint ignores unions
+#[repr(C)]
+pub union Union {
+    a: f64,
+    b: u8,
+    c: f64,
+    d: f32,
+}
+
+// The lint ignores enums
+#[repr(C)]
+pub enum Enum {
+    A { a: f64, b: u8, c: f64, d: f32 },
+    B,
+}

--- a/tests/ui/layout/reprc-power-alignment.stderr
+++ b/tests/ui/layout/reprc-power-alignment.stderr
@@ -5,7 +5,7 @@ LL |     c: f64,
    |     ^^^^^^
    |
 note: the lint level is defined here
-  --> $DIR/reprc-power-alignment.rs:12:8
+  --> $DIR/reprc-power-alignment.rs:13:8
    |
 LL | #[warn(uses_power_alignment)]
    |        ^^^^^^^^^^^^^^^^^^^^
@@ -73,28 +73,28 @@ LL |     y: Floats,
    |     ^^^^^^^^^
 
 warning: repr(C) does not follow the power alignment rule. This may affect platform C ABI compatibility for this type
-  --> $DIR/reprc-power-alignment.rs:105:3
+  --> $DIR/reprc-power-alignment.rs:105:5
    |
-LL |   d: f64,
-   |   ^^^^^^
+LL |     d: f64,
+   |     ^^^^^^
 
 warning: repr(C) does not follow the power alignment rule. This may affect platform C ABI compatibility for this type
-  --> $DIR/reprc-power-alignment.rs:110:3
+  --> $DIR/reprc-power-alignment.rs:110:5
    |
-LL |   b: B,
-   |   ^^^^
+LL |     b: B,
+   |     ^^^^
 
 warning: repr(C) does not follow the power alignment rule. This may affect platform C ABI compatibility for this type
-  --> $DIR/reprc-power-alignment.rs:119:3
+  --> $DIR/reprc-power-alignment.rs:119:5
    |
-LL |   d: D,
-   |   ^^^^
+LL |     d: D,
+   |     ^^^^
 
 warning: repr(C) does not follow the power alignment rule. This may affect platform C ABI compatibility for this type
-  --> $DIR/reprc-power-alignment.rs:124:3
+  --> $DIR/reprc-power-alignment.rs:124:5
    |
-LL |   b: f64,
-   |   ^^^^^^
+LL |     b: f64,
+   |     ^^^^^^
 
 warning: repr(C) does not follow the power alignment rule. This may affect platform C ABI compatibility for this type
   --> $DIR/reprc-power-alignment.rs:130:5


### PR DESCRIPTION
fixes https://github.com/rust-lang/rust/issues/147348

The power alignment rule only applies to the non-first field of a struct, and so should not apply to unions at all.

The current code also does not consider enums (whose fields might be, morally, structs). Given that C does not actually have ADTs like this it's probably fine from a compatibility perspective, but I'll leave that to the powerpc folks.

cc @daltenty @gilamn5tr
r? compiler