### PR TITLE
bootstrap: relax `compiler-rt` root assertion

### DIFF
--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -590,7 +590,12 @@ pub fn std_cargo(builder: &Builder<'_>, target: TargetSelection, cargo: &mut Car
                 ),
             );
             let compiler_builtins_root = builder.src.join("src/llvm-project/compiler-rt");
-            assert!(compiler_builtins_root.exists());
+            if !builder.config.dry_run() {
+                // This assertion would otherwise trigger during tests if `llvm-project` is not
+                // checked out.
+                assert!(compiler_builtins_root.exists());
+            }
+
             // The path to `compiler-rt` is also used by `profiler_builtins` (above),
             // so if you're changing something here please also change that as appropriate.
             cargo.env("RUST_COMPILER_RT_ROOT", &compiler_builtins_root);


### PR DESCRIPTION
Not needed during tests. This would otherwise require `src/llvm-project` submodule to be initialized and `compiler-rt/` subdirectory to be present.

I need this and rust-lang/rust#147374 to get bootstrap self-tests to pass with no git submodules checked out locally.

r? @Kobzol (or bootstrap)
