### PR TITLE
Safer sort partition

### DIFF
--- a/library/core/src/slice/sort/select.rs
+++ b/library/core/src/slice/sort/select.rs
@@ -126,10 +126,9 @@ fn partition_at_index_loop<'a, T, F>(
 
         // Split the slice into `left`, `pivot`, and `right`.
         let (left, right) = v.split_at_mut(mid);
-        let (pivot, right) = right.split_at_mut(1);
-        let pivot = &pivot[0];
 
         if mid < index {
+            let (pivot, right) = right.split_first_mut().unwrap();
             v = right;
             index = index - mid - 1;
             ancestor_pivot = Some(pivot);


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/147378)*
<!-- homu-ignore:end -->

This reduces amount of `unsafe` code in `partition()`, while generating essentially the same code.

~~`partition()` and functions calling it can only run into out-of-bounds issues if the `is_less` function is buggy, so I've used cold `panic_on_ord_violation()` to replace various other panics/aborts. This slightly reduces code size, and gives a more relevant error message.~~

Related to rust-lang/rust#144327