### PR TITLE
unused_must_use: Don't warn on `Result<(), Uninhabited>` or `ControlFlow<Uninhabited, ()>`

### DIFF
--- a/compiler/rustc_lint/src/unused.rs
+++ b/compiler/rustc_lint/src/unused.rs
@@ -273,13 +273,11 @@ impl<'tcx> LateLintPass<'tcx> for UnusedResults {
             expr: &hir::Expr<'_>,
             span: Span,
         ) -> Option<MustUsePath> {
-            if ty.is_unit()
-                || !ty.is_inhabited_from(
-                    cx.tcx,
-                    cx.tcx.parent_module(expr.hir_id).to_def_id(),
-                    cx.typing_env(),
-                )
-            {
+            if ty.is_unit() {
+                return Some(MustUsePath::Suppressed);
+            }
+            let parent_mod_did = cx.tcx.parent_module(expr.hir_id).to_def_id();
+            if !ty.is_inhabited_from(cx.tcx, parent_mod_did, cx.typing_env()) {
                 return Some(MustUsePath::Suppressed);
             }
 

--- a/tests/ui/lint/unused/auxiliary/must_use_result_unit_uninhabited_extern_crate.rs
+++ b/tests/ui/lint/unused/auxiliary/must_use_result_unit_uninhabited_extern_crate.rs
@@ -1,0 +1,4 @@
+pub enum MyUninhabited {}
+
+#[non_exhaustive]
+pub enum MyUninhabitedNonexhaustive {}

--- a/tests/ui/lint/unused/must_use-result-unit-uninhabited.rs
+++ b/tests/ui/lint/unused/must_use-result-unit-uninhabited.rs
@@ -1,0 +1,55 @@
+//@ edition: 2024
+//@ aux-crate:dep=must_use_result_unit_uninhabited_extern_crate.rs
+
+#![deny(unused_must_use)]
+#![feature(never_type)]
+
+use dep::{MyUninhabited, MyUninhabitedNonexhaustive};
+
+fn f1() -> Result<(), ()> {
+    Ok(())
+}
+
+fn f2() -> Result<(), core::convert::Infallible> {
+    Ok(())
+}
+
+fn f3() -> Result<(), !> {
+    Ok(())
+}
+
+fn f4() -> Result<(), MyUninhabited> {
+    Ok(())
+}
+
+fn f5() -> Result<(), MyUninhabitedNonexhaustive> {
+    Ok(())
+}
+
+trait AssocType {
+    type Error;
+}
+
+struct S1;
+impl AssocType for S1 {
+    type Error = !;
+}
+
+struct S2;
+impl AssocType for S2 {
+    type Error = ();
+}
+
+fn f6<AT: AssocType>(_: AT) -> Result<(), AT::Error> {
+    Ok(())
+}
+
+fn main() {
+    f1(); //~ ERROR: unused `Result` that must be used
+    f2();
+    f3();
+    f4();
+    f5(); //~ ERROR: unused `Result` that must be used
+    f6(S1);
+    f6(S2); //~ ERROR: unused `Result` that must be used
+}

--- a/tests/ui/lint/unused/must_use-result-unit-uninhabited.rs
+++ b/tests/ui/lint/unused/must_use-result-unit-uninhabited.rs
@@ -7,23 +7,23 @@
 use core::ops::{ControlFlow, ControlFlow::Continue};
 use dep::{MyUninhabited, MyUninhabitedNonexhaustive};
 
-fn f1() -> Result<(), ()> {
+fn result_unit_unit() -> Result<(), ()> {
     Ok(())
 }
 
-fn f2() -> Result<(), core::convert::Infallible> {
+fn result_unit_infallible() -> Result<(), core::convert::Infallible> {
     Ok(())
 }
 
-fn f3() -> Result<(), !> {
+fn result_unit_never() -> Result<(), !> {
     Ok(())
 }
 
-fn f4() -> Result<(), MyUninhabited> {
+fn result_unit_myuninhabited() -> Result<(), MyUninhabited> {
     Ok(())
 }
 
-fn f5() -> Result<(), MyUninhabitedNonexhaustive> {
+fn result_unit_myuninhabited_nonexhaustive() -> Result<(), MyUninhabitedNonexhaustive> {
     Ok(())
 }
 
@@ -41,53 +41,53 @@ impl AssocType for S2 {
     type Error = ();
 }
 
-fn f6<AT: AssocType>(_: AT) -> Result<(), AT::Error> {
+fn result_unit_assoctype<AT: AssocType>(_: AT) -> Result<(), AT::Error> {
     Ok(())
 }
 
 trait UsesAssocType {
     type Error;
-    fn method(&self) -> Result<(), Self::Error>;
+    fn method_use_assoc_type(&self) -> Result<(), Self::Error>;
 }
 
 impl UsesAssocType for S1 {
     type Error = !;
-    fn method(&self) -> Result<(), Self::Error> {
+    fn method_use_assoc_type(&self) -> Result<(), Self::Error> {
         Ok(())
     }
 }
 
 impl UsesAssocType for S2 {
     type Error = ();
-    fn method(&self) -> Result<(), Self::Error> {
+    fn method_use_assoc_type(&self) -> Result<(), Self::Error> {
         Err(())
     }
 }
 
-fn c1() -> ControlFlow<()> {
+fn controlflow_unit() -> ControlFlow<()> {
     Continue(())
 }
 
-fn c2() -> ControlFlow<core::convert::Infallible, ()> {
+fn controlflow_infallible_unit() -> ControlFlow<core::convert::Infallible, ()> {
     Continue(())
 }
 
-fn c3() -> ControlFlow<!> {
+fn controlflow_never() -> ControlFlow<!> {
     Continue(())
 }
 
 fn main() {
-    f1(); //~ ERROR: unused `Result` that must be used
-    f2();
-    f3();
-    f4();
-    f5(); //~ ERROR: unused `Result` that must be used
-    f6(S1);
-    f6(S2); //~ ERROR: unused `Result` that must be used
-    S1.method();
-    S2.method(); //~ ERROR: unused `Result` that must be used
+    result_unit_unit(); //~ ERROR: unused `Result` that must be used
+    result_unit_infallible();
+    result_unit_never();
+    result_unit_myuninhabited();
+    result_unit_myuninhabited_nonexhaustive(); //~ ERROR: unused `Result` that must be used
+    result_unit_assoctype(S1);
+    result_unit_assoctype(S2); //~ ERROR: unused `Result` that must be used
+    S1.method_use_assoc_type();
+    S2.method_use_assoc_type(); //~ ERROR: unused `Result` that must be used
 
-    c1(); //~ ERROR: unused `ControlFlow` that must be used
-    c2();
-    c3();
+    controlflow_unit(); //~ ERROR: unused `ControlFlow` that must be used
+    controlflow_infallible_unit();
+    controlflow_never();
 }

--- a/tests/ui/lint/unused/must_use-result-unit-uninhabited.rs
+++ b/tests/ui/lint/unused/must_use-result-unit-uninhabited.rs
@@ -44,6 +44,25 @@ fn f6<AT: AssocType>(_: AT) -> Result<(), AT::Error> {
     Ok(())
 }
 
+trait UsesAssocType {
+    type Error;
+    fn method(&self) -> Result<(), Self::Error>;
+}
+
+impl UsesAssocType for S1 {
+    type Error = !;
+    fn method(&self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+}
+
+impl UsesAssocType for S2 {
+    type Error = ();
+    fn method(&self) -> Result<(), Self::Error> {
+        Err(())
+    }
+}
+
 fn main() {
     f1(); //~ ERROR: unused `Result` that must be used
     f2();
@@ -52,4 +71,6 @@ fn main() {
     f5(); //~ ERROR: unused `Result` that must be used
     f6(S1);
     f6(S2); //~ ERROR: unused `Result` that must be used
+    S1.method();
+    S2.method(); //~ ERROR: unused `Result` that must be used
 }

--- a/tests/ui/lint/unused/must_use-result-unit-uninhabited.rs
+++ b/tests/ui/lint/unused/must_use-result-unit-uninhabited.rs
@@ -91,3 +91,11 @@ fn main() {
     controlflow_infallible_unit();
     controlflow_never();
 }
+
+trait AssocTypeBeforeMonomorphisation {
+    type Error;
+    fn generate(&self) -> Result<(), Self::Error>;
+    fn process(&self) {
+        self.generate(); //~ ERROR: unused `Result` that must be used
+    }
+}

--- a/tests/ui/lint/unused/must_use-result-unit-uninhabited.rs
+++ b/tests/ui/lint/unused/must_use-result-unit-uninhabited.rs
@@ -4,6 +4,7 @@
 #![deny(unused_must_use)]
 #![feature(never_type)]
 
+use core::ops::{ControlFlow, ControlFlow::Continue};
 use dep::{MyUninhabited, MyUninhabitedNonexhaustive};
 
 fn f1() -> Result<(), ()> {
@@ -63,6 +64,18 @@ impl UsesAssocType for S2 {
     }
 }
 
+fn c1() -> ControlFlow<()> {
+    Continue(())
+}
+
+fn c2() -> ControlFlow<core::convert::Infallible, ()> {
+    Continue(())
+}
+
+fn c3() -> ControlFlow<!> {
+    Continue(())
+}
+
 fn main() {
     f1(); //~ ERROR: unused `Result` that must be used
     f2();
@@ -73,4 +86,8 @@ fn main() {
     f6(S2); //~ ERROR: unused `Result` that must be used
     S1.method();
     S2.method(); //~ ERROR: unused `Result` that must be used
+
+    c1(); //~ ERROR: unused `ControlFlow` that must be used
+    c2();
+    c3();
 }

--- a/tests/ui/lint/unused/must_use-result-unit-uninhabited.stderr
+++ b/tests/ui/lint/unused/must_use-result-unit-uninhabited.stderr
@@ -1,8 +1,8 @@
 error: unused `Result` that must be used
   --> $DIR/must_use-result-unit-uninhabited.rs:80:5
    |
-LL |     f1();
-   |     ^^^^
+LL |     result_unit_unit();
+   |     ^^^^^^^^^^^^^^^^^^
    |
    = note: this `Result` may be an `Err` variant, which should be handled
 note: the lint level is defined here
@@ -12,54 +12,54 @@ LL | #![deny(unused_must_use)]
    |         ^^^^^^^^^^^^^^^
 help: use `let _ = ...` to ignore the resulting value
    |
-LL |     let _ = f1();
+LL |     let _ = result_unit_unit();
    |     +++++++
 
 error: unused `Result` that must be used
   --> $DIR/must_use-result-unit-uninhabited.rs:84:5
    |
-LL |     f5();
-   |     ^^^^
+LL |     result_unit_myuninhabited_nonexhaustive();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: this `Result` may be an `Err` variant, which should be handled
 help: use `let _ = ...` to ignore the resulting value
    |
-LL |     let _ = f5();
+LL |     let _ = result_unit_myuninhabited_nonexhaustive();
    |     +++++++
 
 error: unused `Result` that must be used
   --> $DIR/must_use-result-unit-uninhabited.rs:86:5
    |
-LL |     f6(S2);
-   |     ^^^^^^
+LL |     result_unit_assoctype(S2);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: this `Result` may be an `Err` variant, which should be handled
 help: use `let _ = ...` to ignore the resulting value
    |
-LL |     let _ = f6(S2);
+LL |     let _ = result_unit_assoctype(S2);
    |     +++++++
 
 error: unused `Result` that must be used
   --> $DIR/must_use-result-unit-uninhabited.rs:88:5
    |
-LL |     S2.method();
-   |     ^^^^^^^^^^^
+LL |     S2.method_use_assoc_type();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: this `Result` may be an `Err` variant, which should be handled
 help: use `let _ = ...` to ignore the resulting value
    |
-LL |     let _ = S2.method();
+LL |     let _ = S2.method_use_assoc_type();
    |     +++++++
 
 error: unused `ControlFlow` that must be used
   --> $DIR/must_use-result-unit-uninhabited.rs:90:5
    |
-LL |     c1();
-   |     ^^^^
+LL |     controlflow_unit();
+   |     ^^^^^^^^^^^^^^^^^^
    |
 help: use `let _ = ...` to ignore the resulting value
    |
-LL |     let _ = c1();
+LL |     let _ = controlflow_unit();
    |     +++++++
 
 error: aborting due to 5 previous errors

--- a/tests/ui/lint/unused/must_use-result-unit-uninhabited.stderr
+++ b/tests/ui/lint/unused/must_use-result-unit-uninhabited.stderr
@@ -62,5 +62,17 @@ help: use `let _ = ...` to ignore the resulting value
 LL |     let _ = controlflow_unit();
    |     +++++++
 
-error: aborting due to 5 previous errors
+error: unused `Result` that must be used
+  --> $DIR/must_use-result-unit-uninhabited.rs:99:9
+   |
+LL |         self.generate();
+   |         ^^^^^^^^^^^^^^^
+   |
+   = note: this `Result` may be an `Err` variant, which should be handled
+help: use `let _ = ...` to ignore the resulting value
+   |
+LL |         let _ = self.generate();
+   |         +++++++
+
+error: aborting due to 6 previous errors
 

--- a/tests/ui/lint/unused/must_use-result-unit-uninhabited.stderr
+++ b/tests/ui/lint/unused/must_use-result-unit-uninhabited.stderr
@@ -1,5 +1,5 @@
 error: unused `Result` that must be used
-  --> $DIR/must_use-result-unit-uninhabited.rs:48:5
+  --> $DIR/must_use-result-unit-uninhabited.rs:67:5
    |
 LL |     f1();
    |     ^^^^
@@ -16,7 +16,7 @@ LL |     let _ = f1();
    |     +++++++
 
 error: unused `Result` that must be used
-  --> $DIR/must_use-result-unit-uninhabited.rs:52:5
+  --> $DIR/must_use-result-unit-uninhabited.rs:71:5
    |
 LL |     f5();
    |     ^^^^
@@ -28,7 +28,7 @@ LL |     let _ = f5();
    |     +++++++
 
 error: unused `Result` that must be used
-  --> $DIR/must_use-result-unit-uninhabited.rs:54:5
+  --> $DIR/must_use-result-unit-uninhabited.rs:73:5
    |
 LL |     f6(S2);
    |     ^^^^^^
@@ -39,5 +39,17 @@ help: use `let _ = ...` to ignore the resulting value
 LL |     let _ = f6(S2);
    |     +++++++
 
-error: aborting due to 3 previous errors
+error: unused `Result` that must be used
+  --> $DIR/must_use-result-unit-uninhabited.rs:75:5
+   |
+LL |     S2.method();
+   |     ^^^^^^^^^^^
+   |
+   = note: this `Result` may be an `Err` variant, which should be handled
+help: use `let _ = ...` to ignore the resulting value
+   |
+LL |     let _ = S2.method();
+   |     +++++++
+
+error: aborting due to 4 previous errors
 

--- a/tests/ui/lint/unused/must_use-result-unit-uninhabited.stderr
+++ b/tests/ui/lint/unused/must_use-result-unit-uninhabited.stderr
@@ -1,0 +1,43 @@
+error: unused `Result` that must be used
+  --> $DIR/must_use-result-unit-uninhabited.rs:48:5
+   |
+LL |     f1();
+   |     ^^^^
+   |
+   = note: this `Result` may be an `Err` variant, which should be handled
+note: the lint level is defined here
+  --> $DIR/must_use-result-unit-uninhabited.rs:4:9
+   |
+LL | #![deny(unused_must_use)]
+   |         ^^^^^^^^^^^^^^^
+help: use `let _ = ...` to ignore the resulting value
+   |
+LL |     let _ = f1();
+   |     +++++++
+
+error: unused `Result` that must be used
+  --> $DIR/must_use-result-unit-uninhabited.rs:52:5
+   |
+LL |     f5();
+   |     ^^^^
+   |
+   = note: this `Result` may be an `Err` variant, which should be handled
+help: use `let _ = ...` to ignore the resulting value
+   |
+LL |     let _ = f5();
+   |     +++++++
+
+error: unused `Result` that must be used
+  --> $DIR/must_use-result-unit-uninhabited.rs:54:5
+   |
+LL |     f6(S2);
+   |     ^^^^^^
+   |
+   = note: this `Result` may be an `Err` variant, which should be handled
+help: use `let _ = ...` to ignore the resulting value
+   |
+LL |     let _ = f6(S2);
+   |     +++++++
+
+error: aborting due to 3 previous errors
+

--- a/tests/ui/lint/unused/must_use-result-unit-uninhabited.stderr
+++ b/tests/ui/lint/unused/must_use-result-unit-uninhabited.stderr
@@ -1,5 +1,5 @@
 error: unused `Result` that must be used
-  --> $DIR/must_use-result-unit-uninhabited.rs:67:5
+  --> $DIR/must_use-result-unit-uninhabited.rs:80:5
    |
 LL |     f1();
    |     ^^^^
@@ -16,7 +16,7 @@ LL |     let _ = f1();
    |     +++++++
 
 error: unused `Result` that must be used
-  --> $DIR/must_use-result-unit-uninhabited.rs:71:5
+  --> $DIR/must_use-result-unit-uninhabited.rs:84:5
    |
 LL |     f5();
    |     ^^^^
@@ -28,7 +28,7 @@ LL |     let _ = f5();
    |     +++++++
 
 error: unused `Result` that must be used
-  --> $DIR/must_use-result-unit-uninhabited.rs:73:5
+  --> $DIR/must_use-result-unit-uninhabited.rs:86:5
    |
 LL |     f6(S2);
    |     ^^^^^^
@@ -40,7 +40,7 @@ LL |     let _ = f6(S2);
    |     +++++++
 
 error: unused `Result` that must be used
-  --> $DIR/must_use-result-unit-uninhabited.rs:75:5
+  --> $DIR/must_use-result-unit-uninhabited.rs:88:5
    |
 LL |     S2.method();
    |     ^^^^^^^^^^^
@@ -51,5 +51,16 @@ help: use `let _ = ...` to ignore the resulting value
 LL |     let _ = S2.method();
    |     +++++++
 
-error: aborting due to 4 previous errors
+error: unused `ControlFlow` that must be used
+  --> $DIR/must_use-result-unit-uninhabited.rs:90:5
+   |
+LL |     c1();
+   |     ^^^^
+   |
+help: use `let _ = ...` to ignore the resulting value
+   |
+LL |     let _ = c1();
+   |     +++++++
+
+error: aborting due to 5 previous errors
 


### PR DESCRIPTION
This suppresses warnings on things like `Result<(), !>`, which helps simplify code using the common pattern of having an `Error` associated type: code will only have to check the error if there is a possibility of error.

This will, for instance, help with future refactorings of `write!` in the standard library.

As this is a user-visible change to lint behavior, it'll require a lang FCP.

---

My proposal, here, is that we handle this simple case to make common patterns more usable. This does not rule out the possibility of adding more cases in the future, including general trait-based cases. However, I don't think we should make this common case wait on the more general cases. In particular, this solution does not close any doors on replacing this special case with a general case.

This would unblock some planned work in the standard library to make `write!` more usable for infallible cases (e.g. writing into a `Vec` or `String`).