### PR TITLE
hir_owner_parent optimized to inlined call for non-incremental build

### DIFF
--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -266,7 +266,7 @@ rustc_queries! {
     ///
     /// This can be conveniently accessed by `tcx.hir_*` methods.
     /// Avoid calling this query directly.
-    query hir_owner_parent(key: hir::OwnerId) -> hir::HirId {
+    query hir_owner_parent_q(key: hir::OwnerId) -> hir::HirId {
         desc { |tcx| "getting HIR parent of `{}`", tcx.def_path_str(key) }
     }
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
-->
<!-- homu-ignore:end -->
Continuation of https://github.com/rust-lang/rust/pull/146880 and https://github.com/rust-lang/rust/pull/147232.
'hir_owner_parent' query renamed 'hir_owner_parent_q'. hir_owner_parent inlined function added to optimize performance in case of non-incremental build.

'hir_owner_parent' query has low normalized average execution time (163ns) and good cache_hits (5773) according Daria's processed statistics. 'source_span', for comparison, has avg_ns_norm = 66ns and cache_hits = 11361.

Optimization may be profitable for queries with low normalized average execution time (to replace cache lookup into inlined call) and be significant with good cache_hits.
| Query | cache_hits | min_ns | max_ns | avg_ns_norm |
| ------------- | ------------- | ------------- | ------------- | ------------- |
source_span | 11361 | 18 | 2991 | 66
hir_owner_parent | 5773 | 52 | 1773 | 163
is_doc_hidden | 3134 | 47 | 1111 | 285
lookup_deprecation_entry | 13905 | 36 | 6208 | 287
object_lifetime_default | 5840 | 63 | 4688 | 290
upvars_mentioned | 2575 | 75 | 7722 | 322
intrinsic_raw | 21235 | 73 | 3453 | 367

Draft PR to measure performance changes.