### PR TITLE
allocator_kind and related queries converted to hooks

### DIFF
--- a/compiler/rustc_codegen_cranelift/src/allocator.rs
+++ b/compiler/rustc_codegen_cranelift/src/allocator.rs
@@ -19,7 +19,7 @@ pub(crate) fn codegen(tcx: TyCtxt<'_>, module: &mut dyn Module) -> bool {
         tcx,
         module,
         kind,
-        tcx.alloc_error_handler_kind(()).unwrap(),
+        tcx.alloc_error_handler_kind().unwrap(),
         tcx.sess.opts.unstable_opts.oom,
     );
     true

--- a/compiler/rustc_codegen_ssa/src/back/linker.rs
+++ b/compiler/rustc_codegen_ssa/src/back/linker.rs
@@ -1857,7 +1857,7 @@ fn exported_symbols_for_non_proc_macro(
     // Mark allocator shim symbols as exported only if they were generated.
     if export_threshold == SymbolExportLevel::Rust
         && needs_allocator_shim_for_linking(tcx.dependency_formats(()), crate_type)
-        && tcx.allocator_kind(()).is_some()
+        && tcx.allocator_kind().is_some()
     {
         symbols.extend(allocator_shim_symbols(tcx));
     }

--- a/compiler/rustc_codegen_ssa/src/base.rs
+++ b/compiler/rustc_codegen_ssa/src/base.rs
@@ -639,7 +639,7 @@ pub fn allocator_kind_for_codegen(tcx: TyCtxt<'_>) -> Option<AllocatorKind> {
         use rustc_middle::middle::dependency_format::Linkage;
         list.iter().any(|&linkage| linkage == Linkage::Dynamic)
     });
-    if all_crate_types_any_dynamic_crate { None } else { tcx.allocator_kind(()) }
+    if all_crate_types_any_dynamic_crate { None } else { tcx.allocator_kind() }
 }
 
 /// Decide if this particular crate type needs an allocator shim linked in.
@@ -705,7 +705,7 @@ pub fn codegen_crate<B: ExtraBackendMethods>(
                 kind,
                 // If allocator_kind is Some then alloc_error_handler_kind must
                 // also be Some.
-                tcx.alloc_error_handler_kind(()).unwrap(),
+                tcx.alloc_error_handler_kind().unwrap(),
             );
             Some(ModuleCodegen::new_allocator(llmod_id, module))
         })

--- a/compiler/rustc_middle/src/hooks/mod.rs
+++ b/compiler/rustc_middle/src/hooks/mod.rs
@@ -3,6 +3,7 @@
 //! similar to queries, but queries come with a lot of machinery for caching and incremental
 //! compilation, whereas hooks are just plain function pointers without any of the query magic.
 
+use rustc_ast::expand::allocator::AllocatorKind;
 use rustc_hir::def_id::{DefId, DefPathHash};
 use rustc_session::StableCrateId;
 use rustc_span::def_id::{CrateNum, LocalDefId};
@@ -102,6 +103,11 @@ declare_hooks! {
     /// Ensure the given scalar is valid for the given type.
     /// This checks non-recursive runtime validity.
     hook validate_scalar_in_layout(scalar: crate::ty::ScalarInt, ty: Ty<'tcx>) -> bool;
+
+    hook allocator_kind() -> Option<AllocatorKind>;
+    hook alloc_error_handler_kind() -> Option<AllocatorKind>;
+    hook has_global_allocator(krate: CrateNum) -> bool;
+    hook has_alloc_error_handler(krate: CrateNum) -> bool;
 }
 
 #[cold]

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -1812,14 +1812,14 @@ rustc_queries! {
         desc { "checking if the crate is_compiler_builtins" }
         separate_provide_extern
     }
-    query has_global_allocator(_: CrateNum) -> bool {
+    query has_global_allocator_q(_: CrateNum) -> bool {
         // This query depends on untracked global state in CStore
         eval_always
         fatal_cycle
         desc { "checking if the crate has_global_allocator" }
         separate_provide_extern
     }
-    query has_alloc_error_handler(_: CrateNum) -> bool {
+    query has_alloc_error_handler_q(_: CrateNum) -> bool {
         // This query depends on untracked global state in CStore
         eval_always
         fatal_cycle
@@ -2301,11 +2301,11 @@ rustc_queries! {
         desc { "checking whether crate `{}` is a private dependency", c }
         separate_provide_extern
     }
-    query allocator_kind(_: ()) -> Option<AllocatorKind> {
+    query allocator_kind_q(_: ()) -> Option<AllocatorKind> {
         eval_always
         desc { "getting the allocator kind for the current crate" }
     }
-    query alloc_error_handler_kind(_: ()) -> Option<AllocatorKind> {
+    query alloc_error_handler_kind_q(_: ()) -> Option<AllocatorKind> {
         eval_always
         desc { "alloc error handler kind for the current crate" }
     }

--- a/src/tools/miri/src/shims/alloc.rs
+++ b/src/tools/miri/src/shims/alloc.rs
@@ -61,7 +61,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
     ) -> InterpResult<'tcx, EmulateItemResult> {
         let this = self.eval_context_mut();
 
-        let Some(allocator_kind) = this.tcx.allocator_kind(()) else {
+        let Some(allocator_kind) = this.tcx.allocator_kind() else {
             // in real code, this symbol does not exist without an allocator
             return interp_ok(EmulateItemResult::NotSupported);
         };

--- a/src/tools/miri/src/shims/foreign_items.rs
+++ b/src/tools/miri/src/shims/foreign_items.rs
@@ -53,7 +53,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         match link_name.as_str() {
             name if name == this.mangle_internal_symbol("__rust_alloc_error_handler") => {
                 // Forward to the right symbol that implements this function.
-                let Some(handler_kind) = this.tcx.alloc_error_handler_kind(()) else {
+                let Some(handler_kind) = this.tcx.alloc_error_handler_kind() else {
                     // in real code, this symbol does not exist without an allocator
                     throw_unsup_format!(
                         "`__rust_alloc_error_handler` cannot be called when no alloc error handler is set"


### PR DESCRIPTION
'allocator_kind' and related queries converted to hooks to measure performance optimization.

<!-- homu-ignore:start -->
<!--
-->
<!-- homu-ignore:end -->
