### PR TITLE
Improve diagnostics: update note and add help message

### DIFF
--- a/compiler/rustc_expand/messages.ftl
+++ b/compiler/rustc_expand/messages.ftl
@@ -118,8 +118,9 @@ expand_module_file_not_found =
     .note = if there is a `mod {$name}` elsewhere in the crate already, import it with `use crate::...` instead
 
 expand_module_in_block =
-    cannot declare a non-inline module inside a block unless it has a path attribute
-    .note = maybe `use` the module `{$name}` instead of redeclaring it
+    cannot declare a file module inside a block unless it has a path attribute
+    .help = maybe `use` the module `{$name}` instead of redeclaring it
+    .note = file modules are usually placed outside of blocks, at the top level of the file
 
 expand_module_multiple_candidates =
     file for module `{$name}` found at both "{$default_path}" and "{$secondary_path}"

--- a/compiler/rustc_expand/src/errors.rs
+++ b/compiler/rustc_expand/src/errors.rs
@@ -265,6 +265,7 @@ pub(crate) struct ModuleCircular {
 
 #[derive(Diagnostic)]
 #[diag(expand_module_in_block)]
+#[note]
 pub(crate) struct ModuleInBlock {
     #[primary_span]
     pub span: Span,
@@ -273,7 +274,7 @@ pub(crate) struct ModuleInBlock {
 }
 
 #[derive(Subdiagnostic)]
-#[note(expand_note)]
+#[help(expand_help)]
 pub(crate) struct ModuleInBlockName {
     #[primary_span]
     pub span: Span,

--- a/tests/ui/directory_ownership/file-mod-restriction.rs
+++ b/tests/ui/directory_ownership/file-mod-restriction.rs
@@ -1,0 +1,5 @@
+// Test that file modules are not allowed inside blocks.
+
+fn main() {
+    mod foo; //~ ERROR cannot declare a file module inside a block unless it has a path attribute
+}

--- a/tests/ui/directory_ownership/file-mod-restriction.stderr
+++ b/tests/ui/directory_ownership/file-mod-restriction.stderr
@@ -1,0 +1,10 @@
+error: cannot declare a file module inside a block unless it has a path attribute
+  --> $DIR/file-mod-restriction.rs:4:5
+   |
+LL |     mod foo;
+   |     ^^^^^^^^
+   |
+   = note: file modules are usually placed outside of blocks, at the top level of the file
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/directory_ownership/macro-expanded-mod.rs
+++ b/tests/ui/directory_ownership/macro-expanded-mod.rs
@@ -1,8 +1,8 @@
-// Test that macro-expanded non-inline modules behave correctly
+// Test that macro-expanded file modules behave correctly
 
 macro_rules! mod_decl {
     ($i:ident) => {
-        mod $i; //~ ERROR cannot declare a non-inline module inside a block
+        mod $i; //~ ERROR cannot declare a file module inside a block unless it has a path attribute
     };
 }
 

--- a/tests/ui/directory_ownership/macro-expanded-mod.stderr
+++ b/tests/ui/directory_ownership/macro-expanded-mod.stderr
@@ -1,4 +1,4 @@
-error: cannot declare a non-inline module inside a block unless it has a path attribute
+error: cannot declare a file module inside a block unless it has a path attribute
   --> $DIR/macro-expanded-mod.rs:5:9
    |
 LL |         mod $i;
@@ -7,6 +7,7 @@ LL |         mod $i;
 LL |     mod_decl!(foo);
    |     -------------- in this macro invocation
    |
+   = note: file modules are usually placed outside of blocks, at the top level of the file
    = note: this error originates in the macro `mod_decl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error

--- a/tests/ui/directory_ownership/non-inline-mod-restriction.rs
+++ b/tests/ui/directory_ownership/non-inline-mod-restriction.rs
@@ -1,5 +1,0 @@
-// Test that non-inline modules are not allowed inside blocks.
-
-fn main() {
-    mod foo; //~ ERROR cannot declare a non-inline module inside a block
-}

--- a/tests/ui/directory_ownership/non-inline-mod-restriction.stderr
+++ b/tests/ui/directory_ownership/non-inline-mod-restriction.stderr
@@ -1,8 +1,0 @@
-error: cannot declare a non-inline module inside a block unless it has a path attribute
-  --> $DIR/non-inline-mod-restriction.rs:4:5
-   |
-LL |     mod foo;
-   |     ^^^^^^^^
-
-error: aborting due to 1 previous error
-


### PR DESCRIPTION
I moved the content from the note to a help message, as it seemed more appropriate there, and then added new information to the note(`Modules are usually placed outside of blocks, at the top level of the file`)!


resolve: rust-lang/rust#147314
