### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/compiler/rustc_attr_parsing/messages.ftl
+++ b/compiler/rustc_attr_parsing/messages.ftl
@@ -1,5 +1,5 @@
 attr_parsing_as_needed_compatibility =
-    linking modifier `as-needed` is only compatible with `dylib` and `framework` linking kinds
+    linking modifier `as-needed` is only compatible with `dylib`, `framework` and `raw-dylib` linking kinds
 
 attr_parsing_bundle_needs_static =
     linking modifier `bundle` is only compatible with `static` linking kind

--- a/compiler/rustc_hir/src/attrs/data_structures.rs
+++ b/compiler/rustc_hir/src/attrs/data_structures.rs
@@ -309,7 +309,10 @@ pub enum NativeLibKind {
     },
     /// Dynamic library (e.g. `foo.dll` on Windows) without a corresponding import library.
     /// On Linux, it refers to a generated shared library stub.
-    RawDylib,
+    RawDylib {
+        /// Whether the dynamic library will be linked only if it satisfies some undefined symbols
+        as_needed: Option<bool>,
+    },
     /// A macOS-specific kind of dynamic libraries.
     Framework {
         /// Whether the framework will be linked only if it satisfies some undefined symbols
@@ -332,11 +335,10 @@ impl NativeLibKind {
             NativeLibKind::Static { bundle, whole_archive } => {
                 bundle.is_some() || whole_archive.is_some()
             }
-            NativeLibKind::Dylib { as_needed } | NativeLibKind::Framework { as_needed } => {
-                as_needed.is_some()
-            }
-            NativeLibKind::RawDylib
-            | NativeLibKind::Unspecified
+            NativeLibKind::Dylib { as_needed }
+            | NativeLibKind::Framework { as_needed }
+            | NativeLibKind::RawDylib { as_needed } => as_needed.is_some(),
+            NativeLibKind::Unspecified
             | NativeLibKind::LinkArg
             | NativeLibKind::WasmImportModule => false,
         }
@@ -349,7 +351,9 @@ impl NativeLibKind {
     pub fn is_dllimport(&self) -> bool {
         matches!(
             self,
-            NativeLibKind::Dylib { .. } | NativeLibKind::RawDylib | NativeLibKind::Unspecified
+            NativeLibKind::Dylib { .. }
+                | NativeLibKind::RawDylib { .. }
+                | NativeLibKind::Unspecified
         )
     }
 }

--- a/compiler/rustc_metadata/src/native_libs.rs
+++ b/compiler/rustc_metadata/src/native_libs.rs
@@ -218,7 +218,7 @@ impl<'tcx> Collector<'tcx> {
                 .flatten()
         {
             let dll_imports = match attr.kind {
-                NativeLibKind::RawDylib => foreign_items
+                NativeLibKind::RawDylib { .. } => foreign_items
                     .iter()
                     .map(|&child_item| {
                         self.build_dll_import(

--- a/compiler/rustc_session/src/config/native_libs.rs
+++ b/compiler/rustc_session/src/config/native_libs.rs
@@ -135,7 +135,8 @@ fn parse_and_apply_modifier(cx: &ParseNativeLibCx<'_>, modifier: &str, native_li
         ),
 
         ("as-needed", NativeLibKind::Dylib { as_needed })
-        | ("as-needed", NativeLibKind::Framework { as_needed }) => {
+        | ("as-needed", NativeLibKind::Framework { as_needed })
+        | ("as-needed", NativeLibKind::RawDylib { as_needed }) => {
             cx.on_unstable_value(
                 "linking modifier `as-needed` is unstable",
                 ", the `-Z unstable-options` flag must also be passed to use it",

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -467,7 +467,8 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                             span,
                             leaf_trait_predicate,
                         );
-                        self.note_version_mismatch(&mut err, leaf_trait_predicate);
+                        self.note_trait_version_mismatch(&mut err, leaf_trait_predicate);
+                        self.note_adt_version_mismatch(&mut err, leaf_trait_predicate);
                         self.suggest_remove_await(&obligation, &mut err);
                         self.suggest_derive(&obligation, &mut err, leaf_trait_predicate);
 
@@ -2406,7 +2407,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
     /// If the `Self` type of the unsatisfied trait `trait_ref` implements a trait
     /// with the same path as `trait_ref`, a help message about
     /// a probable version mismatch is added to `err`
-    fn note_version_mismatch(
+    fn note_trait_version_mismatch(
         &self,
         err: &mut Diag<'_>,
         trait_pred: ty::PolyTraitPredicate<'tcx>,
@@ -2446,13 +2447,85 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 impl_spans,
                 format!("trait impl{} with same name found", pluralize!(trait_impls.len())),
             );
-            let trait_crate = self.tcx.crate_name(trait_with_same_path.krate);
-            let crate_msg =
-                format!("perhaps two different versions of crate `{trait_crate}` are being used?");
-            err.note(crate_msg);
+            self.note_two_crate_versions(trait_with_same_path, err);
             suggested = true;
         }
         suggested
+    }
+
+    fn note_two_crate_versions(&self, did: DefId, err: &mut Diag<'_>) {
+        let crate_name = self.tcx.crate_name(did.krate);
+        let crate_msg =
+            format!("perhaps two different versions of crate `{crate_name}` are being used?");
+        err.note(crate_msg);
+    }
+
+    fn note_adt_version_mismatch(
+        &self,
+        err: &mut Diag<'_>,
+        trait_pred: ty::PolyTraitPredicate<'tcx>,
+    ) {
+        let ty::Adt(impl_self_def, _) = trait_pred.self_ty().skip_binder().peel_refs().kind()
+        else {
+            return;
+        };
+
+        let impl_self_did = impl_self_def.did();
+
+        // We only want to warn about different versions of a dependency.
+        // If no dependency is involved, bail.
+        if impl_self_did.krate == LOCAL_CRATE {
+            return;
+        }
+
+        let impl_self_path = self.comparable_path(impl_self_did);
+        let impl_self_crate_name = self.tcx.crate_name(impl_self_did.krate);
+        let similar_items: UnordSet<_> = self
+            .tcx
+            .visible_parent_map(())
+            .items()
+            .filter_map(|(&item, _)| {
+                // If we found ourselves, ignore.
+                if impl_self_did == item {
+                    return None;
+                }
+                // We only want to warn about different versions of a dependency.
+                // Ignore items from our own crate.
+                if item.krate == LOCAL_CRATE {
+                    return None;
+                }
+                // We want to warn about different versions of a dependency.
+                // So make sure the crate names are the same.
+                if impl_self_crate_name != self.tcx.crate_name(item.krate) {
+                    return None;
+                }
+                // Filter out e.g. constructors that often have the same path
+                // str as the relevant ADT.
+                if !self.tcx.def_kind(item).is_adt() {
+                    return None;
+                }
+                let path = self.comparable_path(item);
+                // We don't know if our item or the one we found is the re-exported one.
+                // Check both cases.
+                let is_similar = path.ends_with(&impl_self_path) || impl_self_path.ends_with(&path);
+                is_similar.then_some((item, path))
+            })
+            .collect();
+
+        let mut similar_items =
+            similar_items.into_items().into_sorted_stable_ord_by_key(|(_, path)| path);
+        similar_items.dedup();
+
+        for (similar_item, _) in similar_items {
+            err.span_help(self.tcx.def_span(similar_item), "item with same name found");
+            self.note_two_crate_versions(similar_item, err);
+        }
+    }
+
+    /// Add a `::` prefix when comparing paths so that paths with just one item
+    /// like "Foo" does not equal the end of "OtherFoo".
+    fn comparable_path(&self, did: DefId) -> String {
+        format!("::{}", self.tcx.def_path_str(did))
     }
 
     /// Creates a `PredicateObligation` with `new_self_ty` replacing the existing type in the

--- a/src/librustdoc/html/highlight.rs
+++ b/src/librustdoc/html/highlight.rs
@@ -8,7 +8,7 @@
 use std::borrow::Cow;
 use std::collections::VecDeque;
 use std::fmt::{self, Display, Write};
-use std::iter;
+use std::{cmp, iter};
 
 use rustc_data_structures::fx::FxIndexMap;
 use rustc_lexer::{Cursor, FrontmatterAllowed, LiteralKind, TokenKind};
@@ -345,33 +345,26 @@ fn end_expansion<'a, W: Write>(
         token_handler.pending_elems.push((Cow::Borrowed("</span>"), Some(Class::Expansion)));
         return Some(expanded_code);
     }
-    if expansion_start_tags.is_empty() && token_handler.closing_tags.is_empty() {
-        // No need tag opened so we can just close expansion.
-        token_handler.pending_elems.push((Cow::Borrowed("</span></span>"), Some(Class::Expansion)));
-        return None;
+
+    let skip = iter::zip(token_handler.closing_tags.as_slice(), expansion_start_tags)
+        .position(|(tag, start_tag)| tag != start_tag)
+        .unwrap_or_else(|| cmp::min(token_handler.closing_tags.len(), expansion_start_tags.len()));
+
+    let tags = iter::chain(
+        expansion_start_tags.iter().skip(skip),
+        token_handler.closing_tags.iter().skip(skip),
+    );
+
+    let mut elem = Cow::Borrowed("</span></span>");
+
+    for (tag, _) in tags.clone() {
+        elem.to_mut().push_str(tag);
+    }
+    for (_, class) in tags {
+        write!(elem.to_mut(), "<span class=\"{}\">", class.as_html()).unwrap();
     }
 
-    // If tags were opened inside the expansion, we need to close them and re-open them outside
-    // of the expansion span.
-    let mut out = String::new();
-    let mut end = String::new();
-
-    let mut closing_tags = token_handler.closing_tags.iter().peekable();
-    let mut start_closing_tags = expansion_start_tags.iter().peekable();
-
-    while let (Some(tag), Some(start_tag)) = (closing_tags.peek(), start_closing_tags.peek())
-        && tag == start_tag
-    {
-        closing_tags.next();
-        start_closing_tags.next();
-    }
-    for (tag, class) in start_closing_tags.chain(closing_tags) {
-        out.push_str(tag);
-        end.push_str(&format!("<span class=\"{}\">", class.as_html()));
-    }
-    token_handler
-        .pending_elems
-        .push((Cow::Owned(format!("</span></span>{out}{end}")), Some(Class::Expansion)));
+    token_handler.pending_elems.push((elem, Some(Class::Expansion)));
     None
 }
 

--- a/tests/run-make/duplicate-dependency/foo-v1.rs
+++ b/tests/run-make/duplicate-dependency/foo-v1.rs
@@ -1,0 +1,1 @@
+pub struct Foo;

--- a/tests/run-make/duplicate-dependency/foo-v2.rs
+++ b/tests/run-make/duplicate-dependency/foo-v2.rs
@@ -1,0 +1,1 @@
+pub struct Foo;

--- a/tests/run-make/duplicate-dependency/main.rs
+++ b/tests/run-make/duplicate-dependency/main.rs
@@ -1,0 +1,15 @@
+struct Bar;
+
+impl From<Bar> for foo::Foo {
+    fn from(_: Bar) -> Self {
+        foo::Foo
+    }
+}
+
+fn main() {
+    // The user might wrongly expect this to work since From<Bar> for Foo
+    // implies Into<Foo> for Bar. What the user missed is that different
+    // versions of Foo exist in the dependency graph, and the impl is for the
+    // wrong version.
+    re_export_foo::into_foo(Bar);
+}

--- a/tests/run-make/duplicate-dependency/main.stderr
+++ b/tests/run-make/duplicate-dependency/main.stderr
@@ -1,0 +1,18 @@
+error[E0277]: the trait bound `re_export_foo::foo::Foo: From<Bar>` is not satisfied
+  --> main.rs:14:29
+   |
+LL |     re_export_foo::into_foo(Bar);
+   |     ----------------------- ^^^ the trait `From<Bar>` is not implemented for `re_export_foo::foo::Foo`
+   |     |
+   |     required by a bound introduced by this call
+   |
+   = note: required for `Bar` to implement `Into<re_export_foo::foo::Foo>`
+note: required by a bound in `into_foo`
+  --> $DIR/re-export-foo.rs:3:25
+   |
+LL | pub fn into_foo(_: impl Into<foo::Foo>) {}
+   |                         ^^^^^^^^^^^^^^ required by this bound in `into_foo`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/run-make/duplicate-dependency/main.stderr
+++ b/tests/run-make/duplicate-dependency/main.stderr
@@ -6,6 +6,12 @@ LL |     re_export_foo::into_foo(Bar);
    |     |
    |     required by a bound introduced by this call
    |
+help: item with same name found
+  --> $DIR/foo-v1.rs:1:1
+   |
+LL | pub struct Foo;
+   | ^^^^^^^^^^^^^^
+   = note: perhaps two different versions of crate `foo` are being used?
    = note: required for `Bar` to implement `Into<re_export_foo::foo::Foo>`
 note: required by a bound in `into_foo`
   --> $DIR/re-export-foo.rs:3:25

--- a/tests/run-make/duplicate-dependency/re-export-foo.rs
+++ b/tests/run-make/duplicate-dependency/re-export-foo.rs
@@ -1,0 +1,3 @@
+pub use foo;
+
+pub fn into_foo(_: impl Into<foo::Foo>) {}

--- a/tests/run-make/duplicate-dependency/rmake.rs
+++ b/tests/run-make/duplicate-dependency/rmake.rs
@@ -1,0 +1,43 @@
+use run_make_support::{Rustc, cwd, diff, rust_lib_name, rustc};
+
+fn rustc_with_common_args() -> Rustc {
+    let mut rustc = rustc();
+    rustc.remap_path_prefix(cwd(), "$DIR");
+    rustc.edition("2018"); // Don't require `extern crate`
+    rustc
+}
+
+fn main() {
+    rustc_with_common_args()
+        .input("foo-v1.rs")
+        .crate_type("rlib")
+        .crate_name("foo")
+        .extra_filename("-v1")
+        .metadata("-v1")
+        .run();
+
+    rustc_with_common_args()
+        .input("foo-v2.rs")
+        .crate_type("rlib")
+        .crate_name("foo")
+        .extra_filename("-v2")
+        .metadata("-v2")
+        .run();
+
+    rustc_with_common_args()
+        .input("re-export-foo.rs")
+        .crate_type("rlib")
+        .extern_("foo", rust_lib_name("foo-v2"))
+        .run();
+
+    let stderr = rustc_with_common_args()
+        .input("main.rs")
+        .extern_("foo", rust_lib_name("foo-v1"))
+        .extern_("re_export_foo", rust_lib_name("re_export_foo"))
+        .library_search_path(cwd())
+        .ui_testing()
+        .run_fail()
+        .stderr_utf8();
+
+    diff().expected_file("main.stderr").actual_text("(rustc)", &stderr).run();
+}

--- a/tests/run-make/duplicate-dependency/rmake.rs
+++ b/tests/run-make/duplicate-dependency/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+
 use run_make_support::{Rustc, cwd, diff, rust_lib_name, rustc};
 
 fn rustc_with_common_args() -> Rustc {
@@ -39,5 +41,5 @@ fn main() {
         .run_fail()
         .stderr_utf8();
 
-    diff().expected_file("main.stderr").actual_text("(rustc)", &stderr).run();
+    diff().expected_file("main.stderr").normalize(r"\\", "/").actual_text("(rustc)", &stderr).run();
 }

--- a/tests/ui/linkage-attr/raw-dylib/elf/as_needed.rs
+++ b/tests/ui/linkage-attr/raw-dylib/elf/as_needed.rs
@@ -1,0 +1,43 @@
+//@ only-elf
+//@ needs-dynamic-linking
+
+//@ only-gnu
+//@ only-x86_64
+//@ revisions: as_needed no_as_needed no_modifier merge_1 merge_2 merge_3 merge_4
+
+//@ [as_needed] run-pass
+//@ [no_as_needed] run-fail
+//@ [no_modifier] run-pass
+//@ [merge_1] run-fail
+//@ [merge_2] run-fail
+//@ [merge_3] run-fail
+//@ [merge_4] run-pass
+
+#![allow(incomplete_features)]
+#![feature(raw_dylib_elf)]
+#![feature(native_link_modifiers_as_needed)]
+
+#[cfg_attr(
+    as_needed,
+    link(name = "taiqannf1y28z2rw", kind = "raw-dylib", modifiers = "+as-needed")
+)]
+#[cfg_attr(
+    no_as_needed,
+    link(name = "taiqannf1y28z2rw", kind = "raw-dylib", modifiers = "-as-needed")
+)]
+#[cfg_attr(no_modifier, link(name = "taiqannf1y28z2rw", kind = "raw-dylib"))]
+unsafe extern "C" {}
+
+#[cfg_attr(merge_1, link(name = "k9nm7qxoa79bg7e6", kind = "raw-dylib", modifiers = "+as-needed"))]
+#[cfg_attr(merge_2, link(name = "k9nm7qxoa79bg7e6", kind = "raw-dylib", modifiers = "-as-needed"))]
+#[cfg_attr(merge_3, link(name = "k9nm7qxoa79bg7e6", kind = "raw-dylib", modifiers = "-as-needed"))]
+#[cfg_attr(merge_4, link(name = "k9nm7qxoa79bg7e6", kind = "raw-dylib", modifiers = "+as-needed"))]
+unsafe extern "C" {}
+
+#[cfg_attr(merge_1, link(name = "k9nm7qxoa79bg7e6", kind = "raw-dylib", modifiers = "-as-needed"))]
+#[cfg_attr(merge_2, link(name = "k9nm7qxoa79bg7e6", kind = "raw-dylib", modifiers = "+as-needed"))]
+#[cfg_attr(merge_3, link(name = "k9nm7qxoa79bg7e6", kind = "raw-dylib", modifiers = "-as-needed"))]
+#[cfg_attr(merge_4, link(name = "k9nm7qxoa79bg7e6", kind = "raw-dylib", modifiers = "+as-needed"))]
+unsafe extern "C" {}
+
+fn main() {}


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#146027 (support link modifier `as-needed` for raw-dylib-elf)
 - rust-lang/rust#146874 (compiler: Hint at multiple crate versions if trait impl is for wrong ADT )
 - rust-lang/rust#147237 ([rustdoc] Cleanup "highlight::end_expansion")

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=146027,146874,147237)
<!-- homu-ignore:end -->