### PR TITLE
Fix; correct placement of type inference error for method calls

### DIFF
--- a/tests/ui/autoref-autoderef/deref-ambiguity-becomes-nonambiguous.stderr
+++ b/tests/ui/autoref-autoderef/deref-ambiguity-becomes-nonambiguous.stderr
@@ -5,7 +5,7 @@ LL |     let var_fn = Value::wrap();
    |         ^^^^^^
 ...
 LL |     let _ = var_fn.clone();
-   |                    ----- type must be known at this point
+   |             ------ type must be known at this point
    |
 help: consider giving `var_fn` an explicit type, where the placeholders `_` are specified
    |

--- a/tests/ui/closures/deduce-signature/obligation-with-leaking-placeholders.next.stderr
+++ b/tests/ui/closures/deduce-signature/obligation-with-leaking-placeholders.next.stderr
@@ -5,7 +5,7 @@ LL |     needs_foo(|x| {
    |                ^
 ...
 LL |         x.to_string();
-   |           --------- type must be known at this point
+   |         - type must be known at this point
    |
 help: consider giving this closure parameter an explicit type
    |

--- a/tests/ui/impl-trait/hidden-type-is-opaque-2.default.stderr
+++ b/tests/ui/impl-trait/hidden-type-is-opaque-2.default.stderr
@@ -5,7 +5,7 @@ LL |     Thunk::new(|mut cont| {
    |                 ^^^^^^^^
 LL |
 LL |         cont.reify_as();
-   |              -------- type must be known at this point
+   |         ---- type must be known at this point
    |
 help: consider giving this closure parameter an explicit type
    |
@@ -19,7 +19,7 @@ LL |     Thunk::new(|mut cont| {
    |                 ^^^^^^^^
 LL |
 LL |         cont.reify_as();
-   |              -------- type must be known at this point
+   |         ---- type must be known at this point
    |
 help: consider giving this closure parameter an explicit type
    |

--- a/tests/ui/impl-trait/hidden-type-is-opaque-2.next.stderr
+++ b/tests/ui/impl-trait/hidden-type-is-opaque-2.next.stderr
@@ -5,7 +5,7 @@ LL |     Thunk::new(|mut cont| {
    |                 ^^^^^^^^
 LL |
 LL |         cont.reify_as();
-   |              -------- type must be known at this point
+   |         ---- type must be known at this point
    |
 help: consider giving this closure parameter an explicit type
    |
@@ -19,7 +19,7 @@ LL |     Thunk::new(|mut cont| {
    |                 ^^^^^^^^
 LL |
 LL |         cont.reify_as();
-   |              -------- type must be known at this point
+   |         ---- type must be known at this point
    |
 help: consider giving this closure parameter an explicit type
    |

--- a/tests/ui/inference/need_type_info/incompat-call-after-qualified-path-0.stderr
+++ b/tests/ui/inference/need_type_info/incompat-call-after-qualified-path-0.stderr
@@ -2,7 +2,7 @@ error[E0282]: type annotations needed
   --> $DIR/incompat-call-after-qualified-path-0.rs:21:6
    |
 LL |   f(|a, b| a.cmp(b));
-   |      ^       --- type must be known at this point
+   |      ^     - type must be known at this point
    |
 help: consider giving this closure parameter an explicit type
    |

--- a/tests/ui/inference/need_type_info/incompat-call-after-qualified-path-1.stderr
+++ b/tests/ui/inference/need_type_info/incompat-call-after-qualified-path-1.stderr
@@ -2,7 +2,7 @@ error[E0282]: type annotations needed
   --> $DIR/incompat-call-after-qualified-path-1.rs:25:6
    |
 LL |   f(|a, b| a.cmp(b));
-   |      ^       --- type must be known at this point
+   |      ^     - type must be known at this point
    |
 help: consider giving this closure parameter an explicit type
    |

--- a/tests/ui/issues/issue-20261.stderr
+++ b/tests/ui/issues/issue-20261.stderr
@@ -1,8 +1,8 @@
 error[E0282]: type annotations needed
-  --> $DIR/issue-20261.rs:4:11
+  --> $DIR/issue-20261.rs:4:9
    |
 LL |         i.clone();
-   |           ^^^^^ cannot infer type
+   |         ^ cannot infer type
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/issues/issue-2151.stderr
+++ b/tests/ui/issues/issue-2151.stderr
@@ -4,7 +4,7 @@ error[E0282]: type annotations needed
 LL |     let x = panic!();
    |         ^
 LL |     x.clone();
-   |       ----- type must be known at this point
+   |     - type must be known at this point
    |
 help: consider giving `x` an explicit type
    |

--- a/tests/ui/lazy-type-alias-impl-trait/branches3.stderr
+++ b/tests/ui/lazy-type-alias-impl-trait/branches3.stderr
@@ -2,7 +2,7 @@ error[E0282]: type annotations needed
   --> $DIR/branches3.rs:9:10
    |
 LL |         |s| s.len()
-   |          ^    --- type must be known at this point
+   |          ^  - type must be known at this point
    |
 help: consider giving this closure parameter an explicit type
    |
@@ -13,7 +13,7 @@ error[E0282]: type annotations needed
   --> $DIR/branches3.rs:18:10
    |
 LL |         |s| s.len()
-   |          ^    --- type must be known at this point
+   |          ^  - type must be known at this point
    |
 help: consider giving this closure parameter an explicit type
    |
@@ -24,7 +24,7 @@ error[E0282]: type annotations needed
   --> $DIR/branches3.rs:26:10
    |
 LL |         |s| s.len()
-   |          ^    --- type must be known at this point
+   |          ^  - type must be known at this point
    |
 help: consider giving this closure parameter an explicit type
    |
@@ -35,7 +35,7 @@ error[E0282]: type annotations needed
   --> $DIR/branches3.rs:33:10
    |
 LL |         |s| s.len()
-   |          ^    --- type must be known at this point
+   |          ^  - type must be known at this point
    |
 help: consider giving this closure parameter an explicit type
    |

--- a/tests/ui/methods/call_method_unknown_pointee.stderr
+++ b/tests/ui/methods/call_method_unknown_pointee.stderr
@@ -1,11 +1,10 @@
 error[E0282]: type annotations needed
-  --> $DIR/call_method_unknown_pointee.rs:10:41
+  --> $DIR/call_method_unknown_pointee.rs:10:23
    |
 LL |         let _a: i32 = (ptr as *const _).read();
-   |                                         ^^^^
-   |                                         |
-   |                                         cannot infer type
-   |                                         cannot call a method on a raw pointer with an unknown pointee type
+   |                       ^^^^^^^^^^^^^^^^^ ---- cannot call a method on a raw pointer with an unknown pointee type
+   |                       |
+   |                       cannot infer type
 
 error[E0282]: type annotations needed for `*const _`
   --> $DIR/call_method_unknown_pointee.rs:12:13
@@ -22,13 +21,12 @@ LL |         let b: *const _ = ptr as *const _;
    |              ++++++++++
 
 error[E0282]: type annotations needed
-  --> $DIR/call_method_unknown_pointee.rs:21:39
+  --> $DIR/call_method_unknown_pointee.rs:21:23
    |
 LL |         let _a: i32 = (ptr as *mut _).read();
-   |                                       ^^^^
-   |                                       |
-   |                                       cannot infer type
-   |                                       cannot call a method on a raw pointer with an unknown pointee type
+   |                       ^^^^^^^^^^^^^^^ ---- cannot call a method on a raw pointer with an unknown pointee type
+   |                       |
+   |                       cannot infer type
 
 error[E0282]: type annotations needed for `*mut _`
   --> $DIR/call_method_unknown_pointee.rs:23:13

--- a/tests/ui/methods/call_method_unknown_referent.stderr
+++ b/tests/ui/methods/call_method_unknown_referent.stderr
@@ -1,14 +1,14 @@
 error[E0282]: type annotations needed
-  --> $DIR/call_method_unknown_referent.rs:20:31
+  --> $DIR/call_method_unknown_referent.rs:20:19
    |
 LL |     let _a: i32 = (ptr as &_).read();
-   |                               ^^^^ cannot infer type
+   |                   ^^^^^^^^^^^ cannot infer type
 
 error[E0282]: type annotations needed
-  --> $DIR/call_method_unknown_referent.rs:26:37
+  --> $DIR/call_method_unknown_referent.rs:26:14
    |
 LL |     let _b = (rc as std::rc::Rc<_>).read();
-   |                                     ^^^^ cannot infer type
+   |              ^^^^^^^^^^^^^^^^^^^^^^ cannot infer type
 
 error[E0599]: no method named `read` found for struct `SmartPtr<T>` in the current scope
   --> $DIR/call_method_unknown_referent.rs:46:35

--- a/tests/ui/proc-macro/quote/not-repeatable.stderr
+++ b/tests/ui/proc-macro/quote/not-repeatable.stderr
@@ -21,10 +21,10 @@ note: the traits `Iterator` and `ToTokens` must be implemented
   --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
 
 error[E0282]: type annotations needed
-  --> $DIR/not-repeatable.rs:11:13
+  --> $DIR/not-repeatable.rs:11:25
    |
 LL |     let _ = quote! { $($ip)* };
-   |             ^^^^^^^^^^^^^^^^^^ cannot infer type
+   |                         ^^ cannot infer type
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/repeat-expr/copy-inference-side-effects-are-lazy.stderr
+++ b/tests/ui/repeat-expr/copy-inference-side-effects-are-lazy.stderr
@@ -5,7 +5,7 @@ LL |     let x = [Foo(PhantomData); 2];
    |         ^
 LL |
 LL |     extract(x).max(2);
-   |                --- type must be known at this point
+   |     ---------- type must be known at this point
    |
 help: consider giving `x` an explicit type, where the placeholders `_` are specified
    |

--- a/tests/ui/span/issue-42234-unknown-receiver-type.stderr
+++ b/tests/ui/span/issue-42234-unknown-receiver-type.stderr
@@ -4,7 +4,7 @@ error[E0282]: type annotations needed
 LL |     let x: Option<_> = None;
    |                        ^^^^ cannot infer type of the type parameter `T` declared on the enum `Option`
 LL |     x.unwrap().method_that_could_exist_on_some_type();
-   |                ------------------------------------ type must be known at this point
+   |     ---------- type must be known at this point
    |
 help: consider specifying the generic argument
    |
@@ -16,8 +16,6 @@ error[E0282]: type annotations needed
    |
 LL |         .sum::<_>()
    |          ^^^ cannot infer type of the type parameter `S` declared on the method `sum`
-LL |         .to_string()
-   |          --------- type must be known at this point
    |
 
 error: aborting due to 2 previous errors

--- a/tests/ui/type-alias-impl-trait/closures_in_branches.stderr
+++ b/tests/ui/type-alias-impl-trait/closures_in_branches.stderr
@@ -2,7 +2,7 @@ error[E0282]: type annotations needed
   --> $DIR/closures_in_branches.rs:8:10
    |
 LL |         |x| x.len()
-   |          ^    --- type must be known at this point
+   |          ^  - type must be known at this point
    |
 help: consider giving this closure parameter an explicit type
    |
@@ -13,7 +13,7 @@ error[E0282]: type annotations needed
   --> $DIR/closures_in_branches.rs:22:10
    |
 LL |         |x| x.len()
-   |          ^    --- type must be known at this point
+   |          ^  - type must be known at this point
    |
 help: consider giving this closure parameter an explicit type
    |

--- a/tests/ui/type-inference/regression-issue-81317.stderr
+++ b/tests/ui/type-inference/regression-issue-81317.stderr
@@ -5,7 +5,7 @@ LL |     let iv = S ^ index.into();
    |         ^^
 LL |
 LL |     &iv.to_bytes_be();
-   |         ----------- type must be known at this point
+   |      -- type must be known at this point
    |
 help: consider giving `iv` an explicit type
    |

--- a/tests/ui/typeck/issue-13853.stderr
+++ b/tests/ui/typeck/issue-13853.stderr
@@ -18,10 +18,10 @@ LL |     for node in graph.iter() {
    |                       ^^^^ method not found in `&G`
 
 error[E0282]: type annotations needed
-  --> $DIR/issue-13853.rs:28:14
+  --> $DIR/issue-13853.rs:28:9
    |
 LL |         node.zomg();
-   |              ^^^^ cannot infer type
+   |         ^^^^ cannot infer type
 
 error[E0308]: mismatched types
   --> $DIR/issue-13853.rs:37:13


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? lncr
-->
<!-- homu-ignore:end -->

Addresses a FIXME for displaying errors on method calls;

Before;
```
error[E0282]: type annotations needed
  --> /<location>/src/main.rs:48:15
   |
## |             e.is_conversion_error();
   |               ^^^^^^^^^^^^^^^^^^^ cannot infer type
```

After;

```
error[E0282]: type annotations needed
  --> /<location>/src/main.rs:48:15
   |
## |             e.is_conversion_error();
   |             ^ cannot infer type
```