### PR TITLE
Fix issue with callsite inline attribute not being applied sometimes.

### DIFF
--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -2090,6 +2090,8 @@ impl<'tcx> TyCtxt<'tcx> {
         self.sess.dcx()
     }
 
+    /// Checks to see if the caller (`body_features`) has all the features required by the callee
+    /// (`callee_features`).
     pub fn is_target_feature_call_safe(
         self,
         callee_features: &[TargetFeature],

--- a/tests/codegen-llvm/inline-always-callsite.rs
+++ b/tests/codegen-llvm/inline-always-callsite.rs
@@ -1,0 +1,37 @@
+//@ add-core-stubs
+//@ compile-flags: --target aarch64-unknown-linux-gnu -Zinline-mir=no -C no-prepopulate-passes
+//@ needs-llvm-components: aarch64
+
+#![crate_type = "lib"]
+#![feature(no_core, lang_items, target_feature_inline_always)]
+#![no_core]
+
+extern crate minicore;
+use minicore::*;
+
+#[inline(always)]
+#[target_feature(enable = "neon")]
+#[no_mangle]
+pub fn single_target_feature() -> i32 {
+    42
+}
+
+#[inline(always)]
+#[target_feature(enable = "neon,i8mm")]
+#[no_mangle]
+// CHECK: define noundef i32 @multiple_target_features() unnamed_addr #1 {
+pub fn multiple_target_features() -> i32 {
+    // CHECK: %_0 = call noundef i32 @single_target_feature() #3
+    single_target_feature()
+}
+
+#[no_mangle]
+// CHECK: define noundef i32 @inherits_from_global() unnamed_addr #2 {
+pub fn inherits_from_global() -> i32 {
+    unsafe {
+        // CHECK: %_0 = call noundef i32 @single_target_feature() #3
+        single_target_feature()
+    }
+}
+
+// CHECK: attributes #3 = { nounwind }

--- a/tests/codegen-llvm/inline-always-callsite.rs
+++ b/tests/codegen-llvm/inline-always-callsite.rs
@@ -1,4 +1,4 @@
-//@ add-core-stubs
+//@ add-minicore
 //@ compile-flags: --target aarch64-unknown-linux-gnu -Zinline-mir=no -C no-prepopulate-passes
 //@ needs-llvm-components: aarch64
 
@@ -19,19 +19,23 @@ pub fn single_target_feature() -> i32 {
 #[inline(always)]
 #[target_feature(enable = "neon,i8mm")]
 #[no_mangle]
-// CHECK: define noundef i32 @multiple_target_features() unnamed_addr #1 {
+// CHECK: define{{( noundef)?}} i32 @multiple_target_features() unnamed_addr #1 {
 pub fn multiple_target_features() -> i32 {
-    // CHECK: %_0 = call noundef i32 @single_target_feature() #3
+    // CHECK: %_0 = call{{( noundef)?}} i32 @single_target_feature() #3
     single_target_feature()
 }
 
 #[no_mangle]
-// CHECK: define noundef i32 @inherits_from_global() unnamed_addr #2 {
+// CHECK: define{{( noundef)?}} i32 @inherits_from_global() unnamed_addr #2 {
 pub fn inherits_from_global() -> i32 {
     unsafe {
-        // CHECK: %_0 = call noundef i32 @single_target_feature() #3
+        // CHECK: %_0 = call{{( noundef)?}} i32 @single_target_feature() #3
         single_target_feature()
     }
 }
 
-// CHECK: attributes #3 = { nounwind }
+// Attribute #3 requires the alwaysinline attribute, the alwaysinline attribute is not emitted on a
+// function definition when target features are present, rather it will be moved onto the function
+// call, if the features match up.
+//
+// CHECK: attributes #3 = { alwaysinline nounwind }


### PR DESCRIPTION
If the calling function had more target features enabled than the callee than the attribute wasn't being applied as the arguments for the check had been swapped round. Also includes target features that are part of the global set as the warning was checking those but when adding the attribute they were not checked.

Add a codegen-llvm test to check that the attribute is actually applied as previously only the warning was being checked.

Tracking issue: rust-lang/rust#145574
