### PR TITLE
Remove needs-asm-support directive in tests with explicit targets

### DIFF
--- a/src/doc/rustc-dev-guide/src/tests/directives.md
+++ b/src/doc/rustc-dev-guide/src/tests/directives.md
@@ -163,8 +163,10 @@ Some examples of `X` in `ignore-X` or `only-X`:
 The following directives will check rustc build settings and target
 settings:
 
-- `needs-asm-support` — ignores if it is running on a target that doesn't have
-  stable support for `asm!`
+- `needs-asm-support` — ignores if the **host** architecture doesn't have
+  stable support for `asm!`. For tests that cross-compile to explicit targets
+  via `--target`, use `needs-llvm-components` instead to ensure the appropriate
+  backend is available.
 - `needs-profiler-runtime` — ignores the test if the profiler runtime was not
   enabled for the target
   (`build.profiler = true` in rustc's `bootstrap.toml`)

--- a/tests/ui/asm/aarch64/arm64ec-sve.rs
+++ b/tests/ui/asm/aarch64/arm64ec-sve.rs
@@ -1,6 +1,5 @@
 //@ add-core-stubs
 //@ compile-flags: --target arm64ec-pc-windows-msvc
-//@ needs-asm-support
 //@ needs-llvm-components: aarch64
 //@ ignore-backends: gcc
 

--- a/tests/ui/asm/aarch64/arm64ec-sve.stderr
+++ b/tests/ui/asm/aarch64/arm64ec-sve.stderr
@@ -1,11 +1,11 @@
 error: cannot use register `p0`: x13, x14, x23, x24, x28, v16-v31, p*, ffr cannot be used for Arm64EC
-  --> $DIR/arm64ec-sve.rs:19:18
+  --> $DIR/arm64ec-sve.rs:18:18
    |
 LL |         asm!("", out("p0") _);
    |                  ^^^^^^^^^^^
 
 error: cannot use register `ffr`: x13, x14, x23, x24, x28, v16-v31, p*, ffr cannot be used for Arm64EC
-  --> $DIR/arm64ec-sve.rs:21:18
+  --> $DIR/arm64ec-sve.rs:20:18
    |
 LL |         asm!("", out("ffr") _);
    |                  ^^^^^^^^^^^^

--- a/tests/ui/asm/inline-syntax.arm.stderr
+++ b/tests/ui/asm/inline-syntax.arm.stderr
@@ -15,7 +15,7 @@ LL | .intel_syntax noprefix
    | ^
 
 error: unknown directive
-  --> $DIR/inline-syntax.rs:22:15
+  --> $DIR/inline-syntax.rs:21:15
    |
 LL |         asm!(".intel_syntax noprefix", "nop");
    |               ^^^^^^^^^^^^^^^^^^^^^^
@@ -27,7 +27,7 @@ LL |     .intel_syntax noprefix
    |     ^
 
 error: unknown directive
-  --> $DIR/inline-syntax.rs:25:15
+  --> $DIR/inline-syntax.rs:24:15
    |
 LL |         asm!(".intel_syntax aaa noprefix", "nop");
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -39,7 +39,7 @@ LL |     .intel_syntax aaa noprefix
    |     ^
 
 error: unknown directive
-  --> $DIR/inline-syntax.rs:28:15
+  --> $DIR/inline-syntax.rs:27:15
    |
 LL |         asm!(".att_syntax noprefix", "nop");
    |               ^^^^^^^^^^^^^^^^^^^^
@@ -51,7 +51,7 @@ LL |     .att_syntax noprefix
    |     ^
 
 error: unknown directive
-  --> $DIR/inline-syntax.rs:31:15
+  --> $DIR/inline-syntax.rs:30:15
    |
 LL |         asm!(".att_syntax bbb noprefix", "nop");
    |               ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -63,7 +63,7 @@ LL |     .att_syntax bbb noprefix
    |     ^
 
 error: unknown directive
-  --> $DIR/inline-syntax.rs:34:15
+  --> $DIR/inline-syntax.rs:33:15
    |
 LL |         asm!(".intel_syntax noprefix; nop");
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -75,7 +75,7 @@ LL |     .intel_syntax noprefix; nop
    |     ^
 
 error: unknown directive
-  --> $DIR/inline-syntax.rs:40:13
+  --> $DIR/inline-syntax.rs:39:13
    |
 LL |             .intel_syntax noprefix
    |             ^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/asm/inline-syntax.rs
+++ b/tests/ui/asm/inline-syntax.rs
@@ -7,7 +7,6 @@
 //@[arm] compile-flags: --target armv7-unknown-linux-gnueabihf
 //@[arm] build-fail
 //@[arm] needs-llvm-components: arm
-//@ needs-asm-support
 //@ ignore-backends: gcc
 
 #![feature(no_core)]

--- a/tests/ui/asm/inline-syntax.x86_64.stderr
+++ b/tests/ui/asm/inline-syntax.x86_64.stderr
@@ -1,5 +1,5 @@
 warning: avoid using `.intel_syntax`, Intel syntax is the default
-  --> $DIR/inline-syntax.rs:48:14
+  --> $DIR/inline-syntax.rs:47:14
    |
 LL | global_asm!(".intel_syntax noprefix", "nop");
    |              ^^^^^^^^^^^^^^^^^^^^^^
@@ -7,37 +7,37 @@ LL | global_asm!(".intel_syntax noprefix", "nop");
    = note: `#[warn(bad_asm_style)]` on by default
 
 warning: avoid using `.intel_syntax`, Intel syntax is the default
-  --> $DIR/inline-syntax.rs:22:15
+  --> $DIR/inline-syntax.rs:21:15
    |
 LL |         asm!(".intel_syntax noprefix", "nop");
    |               ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: avoid using `.intel_syntax`, Intel syntax is the default
-  --> $DIR/inline-syntax.rs:25:15
+  --> $DIR/inline-syntax.rs:24:15
    |
 LL |         asm!(".intel_syntax aaa noprefix", "nop");
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: avoid using `.att_syntax`, prefer using `options(att_syntax)` instead
-  --> $DIR/inline-syntax.rs:28:15
+  --> $DIR/inline-syntax.rs:27:15
    |
 LL |         asm!(".att_syntax noprefix", "nop");
    |               ^^^^^^^^^^^^^^^^^^^^
 
 warning: avoid using `.att_syntax`, prefer using `options(att_syntax)` instead
-  --> $DIR/inline-syntax.rs:31:15
+  --> $DIR/inline-syntax.rs:30:15
    |
 LL |         asm!(".att_syntax bbb noprefix", "nop");
    |               ^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: avoid using `.intel_syntax`, Intel syntax is the default
-  --> $DIR/inline-syntax.rs:34:15
+  --> $DIR/inline-syntax.rs:33:15
    |
 LL |         asm!(".intel_syntax noprefix; nop");
    |               ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: avoid using `.intel_syntax`, Intel syntax is the default
-  --> $DIR/inline-syntax.rs:40:13
+  --> $DIR/inline-syntax.rs:39:13
    |
 LL |             .intel_syntax noprefix
    |             ^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/asm/issue-92378.rs
+++ b/tests/ui/asm/issue-92378.rs
@@ -1,7 +1,6 @@
 //@ add-core-stubs
 //@ compile-flags: --target armv5te-unknown-linux-gnueabi
 //@ needs-llvm-components: arm
-//@ needs-asm-support
 //@ build-pass
 //@ ignore-backends: gcc
 

--- a/tests/ui/asm/issue-99071.rs
+++ b/tests/ui/asm/issue-99071.rs
@@ -1,7 +1,6 @@
 //@ add-core-stubs
 //@ compile-flags: --target thumbv6m-none-eabi
 //@ needs-llvm-components: arm
-//@ needs-asm-support
 //@ ignore-backends: gcc
 
 #![feature(no_core)]

--- a/tests/ui/asm/issue-99071.stderr
+++ b/tests/ui/asm/issue-99071.stderr
@@ -1,5 +1,5 @@
 error: cannot use register `r8`: high registers (r8+) can only be used as clobbers in Thumb-1 code
-  --> $DIR/issue-99071.rs:16:18
+  --> $DIR/issue-99071.rs:15:18
    |
 LL |         asm!("", in("r8") 0);
    |                  ^^^^^^^^^^

--- a/tests/ui/asm/loongarch/bad-reg.loongarch32_ilp32d.stderr
+++ b/tests/ui/asm/loongarch/bad-reg.loongarch32_ilp32d.stderr
@@ -1,35 +1,35 @@
 error: invalid register `$r0`: constant zero cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:27:18
+  --> $DIR/bad-reg.rs:26:18
    |
 LL |         asm!("", out("$r0") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `$tp`: reserved for TLS
-  --> $DIR/bad-reg.rs:29:18
+  --> $DIR/bad-reg.rs:28:18
    |
 LL |         asm!("", out("$tp") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `$sp`: the stack pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:31:18
+  --> $DIR/bad-reg.rs:30:18
    |
 LL |         asm!("", out("$sp") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `$r21`: reserved by the ABI
-  --> $DIR/bad-reg.rs:33:18
+  --> $DIR/bad-reg.rs:32:18
    |
 LL |         asm!("", out("$r21") _);
    |                  ^^^^^^^^^^^^^
 
 error: invalid register `$fp`: the frame pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:35:18
+  --> $DIR/bad-reg.rs:34:18
    |
 LL |         asm!("", out("$fp") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `$r31`: $r31 is used internally by LLVM and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:37:18
+  --> $DIR/bad-reg.rs:36:18
    |
 LL |         asm!("", out("$r31") _);
    |                  ^^^^^^^^^^^^^

--- a/tests/ui/asm/loongarch/bad-reg.loongarch32_ilp32s.stderr
+++ b/tests/ui/asm/loongarch/bad-reg.loongarch32_ilp32s.stderr
@@ -1,59 +1,59 @@
 error: invalid register `$r0`: constant zero cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:27:18
+  --> $DIR/bad-reg.rs:26:18
    |
 LL |         asm!("", out("$r0") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `$tp`: reserved for TLS
-  --> $DIR/bad-reg.rs:29:18
+  --> $DIR/bad-reg.rs:28:18
    |
 LL |         asm!("", out("$tp") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `$sp`: the stack pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:31:18
+  --> $DIR/bad-reg.rs:30:18
    |
 LL |         asm!("", out("$sp") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `$r21`: reserved by the ABI
-  --> $DIR/bad-reg.rs:33:18
+  --> $DIR/bad-reg.rs:32:18
    |
 LL |         asm!("", out("$r21") _);
    |                  ^^^^^^^^^^^^^
 
 error: invalid register `$fp`: the frame pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:35:18
+  --> $DIR/bad-reg.rs:34:18
    |
 LL |         asm!("", out("$fp") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `$r31`: $r31 is used internally by LLVM and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:37:18
+  --> $DIR/bad-reg.rs:36:18
    |
 LL |         asm!("", out("$r31") _);
    |                  ^^^^^^^^^^^^^
 
 error: register class `freg` requires at least one of the following target features: d, f
-  --> $DIR/bad-reg.rs:41:26
+  --> $DIR/bad-reg.rs:40:26
    |
 LL |         asm!("/* {} */", in(freg) f);
    |                          ^^^^^^^^^^
 
 error: register class `freg` requires at least one of the following target features: d, f
-  --> $DIR/bad-reg.rs:43:26
+  --> $DIR/bad-reg.rs:42:26
    |
 LL |         asm!("/* {} */", out(freg) _);
    |                          ^^^^^^^^^^^
 
 error: register class `freg` requires at least one of the following target features: d, f
-  --> $DIR/bad-reg.rs:45:26
+  --> $DIR/bad-reg.rs:44:26
    |
 LL |         asm!("/* {} */", in(freg) d);
    |                          ^^^^^^^^^^
 
 error: register class `freg` requires at least one of the following target features: d, f
-  --> $DIR/bad-reg.rs:47:26
+  --> $DIR/bad-reg.rs:46:26
    |
 LL |         asm!("/* {} */", out(freg) d);
    |                          ^^^^^^^^^^^

--- a/tests/ui/asm/loongarch/bad-reg.loongarch64_lp64d.stderr
+++ b/tests/ui/asm/loongarch/bad-reg.loongarch64_lp64d.stderr
@@ -1,35 +1,35 @@
 error: invalid register `$r0`: constant zero cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:27:18
+  --> $DIR/bad-reg.rs:26:18
    |
 LL |         asm!("", out("$r0") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `$tp`: reserved for TLS
-  --> $DIR/bad-reg.rs:29:18
+  --> $DIR/bad-reg.rs:28:18
    |
 LL |         asm!("", out("$tp") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `$sp`: the stack pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:31:18
+  --> $DIR/bad-reg.rs:30:18
    |
 LL |         asm!("", out("$sp") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `$r21`: reserved by the ABI
-  --> $DIR/bad-reg.rs:33:18
+  --> $DIR/bad-reg.rs:32:18
    |
 LL |         asm!("", out("$r21") _);
    |                  ^^^^^^^^^^^^^
 
 error: invalid register `$fp`: the frame pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:35:18
+  --> $DIR/bad-reg.rs:34:18
    |
 LL |         asm!("", out("$fp") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `$r31`: $r31 is used internally by LLVM and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:37:18
+  --> $DIR/bad-reg.rs:36:18
    |
 LL |         asm!("", out("$r31") _);
    |                  ^^^^^^^^^^^^^

--- a/tests/ui/asm/loongarch/bad-reg.loongarch64_lp64s.stderr
+++ b/tests/ui/asm/loongarch/bad-reg.loongarch64_lp64s.stderr
@@ -1,59 +1,59 @@
 error: invalid register `$r0`: constant zero cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:27:18
+  --> $DIR/bad-reg.rs:26:18
    |
 LL |         asm!("", out("$r0") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `$tp`: reserved for TLS
-  --> $DIR/bad-reg.rs:29:18
+  --> $DIR/bad-reg.rs:28:18
    |
 LL |         asm!("", out("$tp") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `$sp`: the stack pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:31:18
+  --> $DIR/bad-reg.rs:30:18
    |
 LL |         asm!("", out("$sp") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `$r21`: reserved by the ABI
-  --> $DIR/bad-reg.rs:33:18
+  --> $DIR/bad-reg.rs:32:18
    |
 LL |         asm!("", out("$r21") _);
    |                  ^^^^^^^^^^^^^
 
 error: invalid register `$fp`: the frame pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:35:18
+  --> $DIR/bad-reg.rs:34:18
    |
 LL |         asm!("", out("$fp") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `$r31`: $r31 is used internally by LLVM and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:37:18
+  --> $DIR/bad-reg.rs:36:18
    |
 LL |         asm!("", out("$r31") _);
    |                  ^^^^^^^^^^^^^
 
 error: register class `freg` requires at least one of the following target features: d, f
-  --> $DIR/bad-reg.rs:41:26
+  --> $DIR/bad-reg.rs:40:26
    |
 LL |         asm!("/* {} */", in(freg) f);
    |                          ^^^^^^^^^^
 
 error: register class `freg` requires at least one of the following target features: d, f
-  --> $DIR/bad-reg.rs:43:26
+  --> $DIR/bad-reg.rs:42:26
    |
 LL |         asm!("/* {} */", out(freg) _);
    |                          ^^^^^^^^^^^
 
 error: register class `freg` requires at least one of the following target features: d, f
-  --> $DIR/bad-reg.rs:45:26
+  --> $DIR/bad-reg.rs:44:26
    |
 LL |         asm!("/* {} */", in(freg) d);
    |                          ^^^^^^^^^^
 
 error: register class `freg` requires at least one of the following target features: d, f
-  --> $DIR/bad-reg.rs:47:26
+  --> $DIR/bad-reg.rs:46:26
    |
 LL |         asm!("/* {} */", out(freg) d);
    |                          ^^^^^^^^^^^

--- a/tests/ui/asm/loongarch/bad-reg.rs
+++ b/tests/ui/asm/loongarch/bad-reg.rs
@@ -1,5 +1,4 @@
 //@ add-core-stubs
-//@ needs-asm-support
 //@ revisions: loongarch32_ilp32d loongarch32_ilp32s loongarch64_lp64d loongarch64_lp64s
 //@[loongarch32_ilp32d] compile-flags: --target loongarch32-unknown-none
 //@[loongarch32_ilp32d] needs-llvm-components: loongarch

--- a/tests/ui/asm/naked-functions-instruction-set.rs
+++ b/tests/ui/asm/naked-functions-instruction-set.rs
@@ -1,7 +1,6 @@
 //@ add-core-stubs
 //@ compile-flags: --target armv5te-unknown-linux-gnueabi
 //@ needs-llvm-components: arm
-//@ needs-asm-support
 //@ build-pass
 //@ ignore-backends: gcc
 

--- a/tests/ui/asm/powerpc/bad-reg.aix64.stderr
+++ b/tests/ui/asm/powerpc/bad-reg.aix64.stderr
@@ -1,137 +1,137 @@
 error: invalid register `sp`: the stack pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:37:18
+  --> $DIR/bad-reg.rs:36:18
    |
 LL |         asm!("", out("sp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `r2`: r2 is a system reserved register and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:39:18
+  --> $DIR/bad-reg.rs:38:18
    |
 LL |         asm!("", out("r2") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `r29`: r29 is used internally by LLVM and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:43:18
+  --> $DIR/bad-reg.rs:42:18
    |
 LL |         asm!("", out("r29") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `r30`: r30 is used internally by LLVM and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:45:18
+  --> $DIR/bad-reg.rs:44:18
    |
 LL |         asm!("", out("r30") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `fp`: the frame pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:47:18
+  --> $DIR/bad-reg.rs:46:18
    |
 LL |         asm!("", out("fp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `vrsave`: the vrsave register cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:49:18
+  --> $DIR/bad-reg.rs:48:18
    |
 LL |         asm!("", out("vrsave") _);
    |                  ^^^^^^^^^^^^^^^
 
 error: register class `cr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:138:18
+  --> $DIR/bad-reg.rs:137:18
    |
 LL |         asm!("", in("cr") x);
    |                  ^^^^^^^^^^
 
 error: register class `cr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:141:18
+  --> $DIR/bad-reg.rs:140:18
    |
 LL |         asm!("", out("cr") x);
    |                  ^^^^^^^^^^^
 
 error: register class `cr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:144:26
+  --> $DIR/bad-reg.rs:143:26
    |
 LL |         asm!("/* {} */", in(cr) x);
    |                          ^^^^^^^^
 
 error: register class `cr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:147:26
+  --> $DIR/bad-reg.rs:146:26
    |
 LL |         asm!("/* {} */", out(cr) _);
    |                          ^^^^^^^^^
 
 error: register class `ctr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:151:18
+  --> $DIR/bad-reg.rs:150:18
    |
 LL |         asm!("", in("ctr") x);
    |                  ^^^^^^^^^^^
 
 error: register class `ctr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:154:18
+  --> $DIR/bad-reg.rs:153:18
    |
 LL |         asm!("", out("ctr") x);
    |                  ^^^^^^^^^^^^
 
 error: register class `ctr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:157:26
+  --> $DIR/bad-reg.rs:156:26
    |
 LL |         asm!("/* {} */", in(ctr) x);
    |                          ^^^^^^^^^
 
 error: register class `ctr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:160:26
+  --> $DIR/bad-reg.rs:159:26
    |
 LL |         asm!("/* {} */", out(ctr) _);
    |                          ^^^^^^^^^^
 
 error: register class `lr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:164:18
+  --> $DIR/bad-reg.rs:163:18
    |
 LL |         asm!("", in("lr") x);
    |                  ^^^^^^^^^^
 
 error: register class `lr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:167:18
+  --> $DIR/bad-reg.rs:166:18
    |
 LL |         asm!("", out("lr") x);
    |                  ^^^^^^^^^^^
 
 error: register class `lr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:170:26
+  --> $DIR/bad-reg.rs:169:26
    |
 LL |         asm!("/* {} */", in(lr) x);
    |                          ^^^^^^^^
 
 error: register class `lr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:173:26
+  --> $DIR/bad-reg.rs:172:26
    |
 LL |         asm!("/* {} */", out(lr) _);
    |                          ^^^^^^^^^
 
 error: register class `xer` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:177:18
+  --> $DIR/bad-reg.rs:176:18
    |
 LL |         asm!("", in("xer") x);
    |                  ^^^^^^^^^^^
 
 error: register class `xer` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:180:18
+  --> $DIR/bad-reg.rs:179:18
    |
 LL |         asm!("", out("xer") x);
    |                  ^^^^^^^^^^^^
 
 error: register class `xer` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:183:26
+  --> $DIR/bad-reg.rs:182:26
    |
 LL |         asm!("/* {} */", in(xer) x);
    |                          ^^^^^^^^^
 
 error: register class `xer` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:186:26
+  --> $DIR/bad-reg.rs:185:26
    |
 LL |         asm!("/* {} */", out(xer) _);
    |                          ^^^^^^^^^^
 
 error: register `cr0` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:190:31
+  --> $DIR/bad-reg.rs:189:31
    |
 LL |         asm!("", out("cr") _, out("cr0") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr0`
@@ -139,7 +139,7 @@ LL |         asm!("", out("cr") _, out("cr0") _);
    |                  register `cr`
 
 error: register `cr1` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:192:31
+  --> $DIR/bad-reg.rs:191:31
    |
 LL |         asm!("", out("cr") _, out("cr1") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr1`
@@ -147,7 +147,7 @@ LL |         asm!("", out("cr") _, out("cr1") _);
    |                  register `cr`
 
 error: register `cr2` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:194:31
+  --> $DIR/bad-reg.rs:193:31
    |
 LL |         asm!("", out("cr") _, out("cr2") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr2`
@@ -155,7 +155,7 @@ LL |         asm!("", out("cr") _, out("cr2") _);
    |                  register `cr`
 
 error: register `cr3` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:196:31
+  --> $DIR/bad-reg.rs:195:31
    |
 LL |         asm!("", out("cr") _, out("cr3") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr3`
@@ -163,7 +163,7 @@ LL |         asm!("", out("cr") _, out("cr3") _);
    |                  register `cr`
 
 error: register `cr4` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:198:31
+  --> $DIR/bad-reg.rs:197:31
    |
 LL |         asm!("", out("cr") _, out("cr4") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr4`
@@ -171,7 +171,7 @@ LL |         asm!("", out("cr") _, out("cr4") _);
    |                  register `cr`
 
 error: register `cr5` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:200:31
+  --> $DIR/bad-reg.rs:199:31
    |
 LL |         asm!("", out("cr") _, out("cr5") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr5`
@@ -179,7 +179,7 @@ LL |         asm!("", out("cr") _, out("cr5") _);
    |                  register `cr`
 
 error: register `cr6` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:202:31
+  --> $DIR/bad-reg.rs:201:31
    |
 LL |         asm!("", out("cr") _, out("cr6") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr6`
@@ -187,7 +187,7 @@ LL |         asm!("", out("cr") _, out("cr6") _);
    |                  register `cr`
 
 error: register `cr7` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:204:31
+  --> $DIR/bad-reg.rs:203:31
    |
 LL |         asm!("", out("cr") _, out("cr7") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr7`
@@ -195,7 +195,7 @@ LL |         asm!("", out("cr") _, out("cr7") _);
    |                  register `cr`
 
 error: register `vs0` conflicts with register `f0`
-  --> $DIR/bad-reg.rs:207:31
+  --> $DIR/bad-reg.rs:206:31
    |
 LL |         asm!("", out("f0") _, out("vs0") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs0`
@@ -203,7 +203,7 @@ LL |         asm!("", out("f0") _, out("vs0") _);
    |                  register `f0`
 
 error: register `vs1` conflicts with register `f1`
-  --> $DIR/bad-reg.rs:209:31
+  --> $DIR/bad-reg.rs:208:31
    |
 LL |         asm!("", out("f1") _, out("vs1") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs1`
@@ -211,7 +211,7 @@ LL |         asm!("", out("f1") _, out("vs1") _);
    |                  register `f1`
 
 error: register `vs2` conflicts with register `f2`
-  --> $DIR/bad-reg.rs:211:31
+  --> $DIR/bad-reg.rs:210:31
    |
 LL |         asm!("", out("f2") _, out("vs2") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs2`
@@ -219,7 +219,7 @@ LL |         asm!("", out("f2") _, out("vs2") _);
    |                  register `f2`
 
 error: register `vs3` conflicts with register `f3`
-  --> $DIR/bad-reg.rs:213:31
+  --> $DIR/bad-reg.rs:212:31
    |
 LL |         asm!("", out("f3") _, out("vs3") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs3`
@@ -227,7 +227,7 @@ LL |         asm!("", out("f3") _, out("vs3") _);
    |                  register `f3`
 
 error: register `vs4` conflicts with register `f4`
-  --> $DIR/bad-reg.rs:215:31
+  --> $DIR/bad-reg.rs:214:31
    |
 LL |         asm!("", out("f4") _, out("vs4") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs4`
@@ -235,7 +235,7 @@ LL |         asm!("", out("f4") _, out("vs4") _);
    |                  register `f4`
 
 error: register `vs5` conflicts with register `f5`
-  --> $DIR/bad-reg.rs:217:31
+  --> $DIR/bad-reg.rs:216:31
    |
 LL |         asm!("", out("f5") _, out("vs5") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs5`
@@ -243,7 +243,7 @@ LL |         asm!("", out("f5") _, out("vs5") _);
    |                  register `f5`
 
 error: register `vs6` conflicts with register `f6`
-  --> $DIR/bad-reg.rs:219:31
+  --> $DIR/bad-reg.rs:218:31
    |
 LL |         asm!("", out("f6") _, out("vs6") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs6`
@@ -251,7 +251,7 @@ LL |         asm!("", out("f6") _, out("vs6") _);
    |                  register `f6`
 
 error: register `vs7` conflicts with register `f7`
-  --> $DIR/bad-reg.rs:221:31
+  --> $DIR/bad-reg.rs:220:31
    |
 LL |         asm!("", out("f7") _, out("vs7") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs7`
@@ -259,7 +259,7 @@ LL |         asm!("", out("f7") _, out("vs7") _);
    |                  register `f7`
 
 error: register `vs8` conflicts with register `f8`
-  --> $DIR/bad-reg.rs:223:31
+  --> $DIR/bad-reg.rs:222:31
    |
 LL |         asm!("", out("f8") _, out("vs8") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs8`
@@ -267,7 +267,7 @@ LL |         asm!("", out("f8") _, out("vs8") _);
    |                  register `f8`
 
 error: register `vs9` conflicts with register `f9`
-  --> $DIR/bad-reg.rs:225:31
+  --> $DIR/bad-reg.rs:224:31
    |
 LL |         asm!("", out("f9") _, out("vs9") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs9`
@@ -275,7 +275,7 @@ LL |         asm!("", out("f9") _, out("vs9") _);
    |                  register `f9`
 
 error: register `vs10` conflicts with register `f10`
-  --> $DIR/bad-reg.rs:227:32
+  --> $DIR/bad-reg.rs:226:32
    |
 LL |         asm!("", out("f10") _, out("vs10") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs10`
@@ -283,7 +283,7 @@ LL |         asm!("", out("f10") _, out("vs10") _);
    |                  register `f10`
 
 error: register `vs11` conflicts with register `f11`
-  --> $DIR/bad-reg.rs:229:32
+  --> $DIR/bad-reg.rs:228:32
    |
 LL |         asm!("", out("f11") _, out("vs11") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs11`
@@ -291,7 +291,7 @@ LL |         asm!("", out("f11") _, out("vs11") _);
    |                  register `f11`
 
 error: register `vs12` conflicts with register `f12`
-  --> $DIR/bad-reg.rs:231:32
+  --> $DIR/bad-reg.rs:230:32
    |
 LL |         asm!("", out("f12") _, out("vs12") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs12`
@@ -299,7 +299,7 @@ LL |         asm!("", out("f12") _, out("vs12") _);
    |                  register `f12`
 
 error: register `vs13` conflicts with register `f13`
-  --> $DIR/bad-reg.rs:233:32
+  --> $DIR/bad-reg.rs:232:32
    |
 LL |         asm!("", out("f13") _, out("vs13") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs13`
@@ -307,7 +307,7 @@ LL |         asm!("", out("f13") _, out("vs13") _);
    |                  register `f13`
 
 error: register `vs14` conflicts with register `f14`
-  --> $DIR/bad-reg.rs:235:32
+  --> $DIR/bad-reg.rs:234:32
    |
 LL |         asm!("", out("f14") _, out("vs14") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs14`
@@ -315,7 +315,7 @@ LL |         asm!("", out("f14") _, out("vs14") _);
    |                  register `f14`
 
 error: register `vs15` conflicts with register `f15`
-  --> $DIR/bad-reg.rs:237:32
+  --> $DIR/bad-reg.rs:236:32
    |
 LL |         asm!("", out("f15") _, out("vs15") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs15`
@@ -323,7 +323,7 @@ LL |         asm!("", out("f15") _, out("vs15") _);
    |                  register `f15`
 
 error: register `vs16` conflicts with register `f16`
-  --> $DIR/bad-reg.rs:239:32
+  --> $DIR/bad-reg.rs:238:32
    |
 LL |         asm!("", out("f16") _, out("vs16") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs16`
@@ -331,7 +331,7 @@ LL |         asm!("", out("f16") _, out("vs16") _);
    |                  register `f16`
 
 error: register `vs17` conflicts with register `f17`
-  --> $DIR/bad-reg.rs:241:32
+  --> $DIR/bad-reg.rs:240:32
    |
 LL |         asm!("", out("f17") _, out("vs17") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs17`
@@ -339,7 +339,7 @@ LL |         asm!("", out("f17") _, out("vs17") _);
    |                  register `f17`
 
 error: register `vs18` conflicts with register `f18`
-  --> $DIR/bad-reg.rs:243:32
+  --> $DIR/bad-reg.rs:242:32
    |
 LL |         asm!("", out("f18") _, out("vs18") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs18`
@@ -347,7 +347,7 @@ LL |         asm!("", out("f18") _, out("vs18") _);
    |                  register `f18`
 
 error: register `vs19` conflicts with register `f19`
-  --> $DIR/bad-reg.rs:245:32
+  --> $DIR/bad-reg.rs:244:32
    |
 LL |         asm!("", out("f19") _, out("vs19") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs19`
@@ -355,7 +355,7 @@ LL |         asm!("", out("f19") _, out("vs19") _);
    |                  register `f19`
 
 error: register `vs20` conflicts with register `f20`
-  --> $DIR/bad-reg.rs:247:32
+  --> $DIR/bad-reg.rs:246:32
    |
 LL |         asm!("", out("f20") _, out("vs20") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs20`
@@ -363,7 +363,7 @@ LL |         asm!("", out("f20") _, out("vs20") _);
    |                  register `f20`
 
 error: register `vs21` conflicts with register `f21`
-  --> $DIR/bad-reg.rs:249:32
+  --> $DIR/bad-reg.rs:248:32
    |
 LL |         asm!("", out("f21") _, out("vs21") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs21`
@@ -371,7 +371,7 @@ LL |         asm!("", out("f21") _, out("vs21") _);
    |                  register `f21`
 
 error: register `vs22` conflicts with register `f22`
-  --> $DIR/bad-reg.rs:251:32
+  --> $DIR/bad-reg.rs:250:32
    |
 LL |         asm!("", out("f22") _, out("vs22") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs22`
@@ -379,7 +379,7 @@ LL |         asm!("", out("f22") _, out("vs22") _);
    |                  register `f22`
 
 error: register `vs23` conflicts with register `f23`
-  --> $DIR/bad-reg.rs:253:32
+  --> $DIR/bad-reg.rs:252:32
    |
 LL |         asm!("", out("f23") _, out("vs23") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs23`
@@ -387,7 +387,7 @@ LL |         asm!("", out("f23") _, out("vs23") _);
    |                  register `f23`
 
 error: register `vs24` conflicts with register `f24`
-  --> $DIR/bad-reg.rs:255:32
+  --> $DIR/bad-reg.rs:254:32
    |
 LL |         asm!("", out("f24") _, out("vs24") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs24`
@@ -395,7 +395,7 @@ LL |         asm!("", out("f24") _, out("vs24") _);
    |                  register `f24`
 
 error: register `vs25` conflicts with register `f25`
-  --> $DIR/bad-reg.rs:257:32
+  --> $DIR/bad-reg.rs:256:32
    |
 LL |         asm!("", out("f25") _, out("vs25") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs25`
@@ -403,7 +403,7 @@ LL |         asm!("", out("f25") _, out("vs25") _);
    |                  register `f25`
 
 error: register `vs26` conflicts with register `f26`
-  --> $DIR/bad-reg.rs:259:32
+  --> $DIR/bad-reg.rs:258:32
    |
 LL |         asm!("", out("f26") _, out("vs26") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs26`
@@ -411,7 +411,7 @@ LL |         asm!("", out("f26") _, out("vs26") _);
    |                  register `f26`
 
 error: register `vs27` conflicts with register `f27`
-  --> $DIR/bad-reg.rs:261:32
+  --> $DIR/bad-reg.rs:260:32
    |
 LL |         asm!("", out("f27") _, out("vs27") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs27`
@@ -419,7 +419,7 @@ LL |         asm!("", out("f27") _, out("vs27") _);
    |                  register `f27`
 
 error: register `vs28` conflicts with register `f28`
-  --> $DIR/bad-reg.rs:263:32
+  --> $DIR/bad-reg.rs:262:32
    |
 LL |         asm!("", out("f28") _, out("vs28") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs28`
@@ -427,7 +427,7 @@ LL |         asm!("", out("f28") _, out("vs28") _);
    |                  register `f28`
 
 error: register `vs29` conflicts with register `f29`
-  --> $DIR/bad-reg.rs:265:32
+  --> $DIR/bad-reg.rs:264:32
    |
 LL |         asm!("", out("f29") _, out("vs29") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs29`
@@ -435,7 +435,7 @@ LL |         asm!("", out("f29") _, out("vs29") _);
    |                  register `f29`
 
 error: register `vs30` conflicts with register `f30`
-  --> $DIR/bad-reg.rs:267:32
+  --> $DIR/bad-reg.rs:266:32
    |
 LL |         asm!("", out("f30") _, out("vs30") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs30`
@@ -443,7 +443,7 @@ LL |         asm!("", out("f30") _, out("vs30") _);
    |                  register `f30`
 
 error: register `vs31` conflicts with register `f31`
-  --> $DIR/bad-reg.rs:269:32
+  --> $DIR/bad-reg.rs:268:32
    |
 LL |         asm!("", out("f31") _, out("vs31") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs31`
@@ -451,7 +451,7 @@ LL |         asm!("", out("f31") _, out("vs31") _);
    |                  register `f31`
 
 error: register `v0` conflicts with register `vs32`
-  --> $DIR/bad-reg.rs:271:33
+  --> $DIR/bad-reg.rs:270:33
    |
 LL |         asm!("", out("vs32") _, out("v0") _);
    |                  -------------  ^^^^^^^^^^^ register `v0`
@@ -459,7 +459,7 @@ LL |         asm!("", out("vs32") _, out("v0") _);
    |                  register `vs32`
 
 error: register `v1` conflicts with register `vs33`
-  --> $DIR/bad-reg.rs:273:33
+  --> $DIR/bad-reg.rs:272:33
    |
 LL |         asm!("", out("vs33") _, out("v1") _);
    |                  -------------  ^^^^^^^^^^^ register `v1`
@@ -467,7 +467,7 @@ LL |         asm!("", out("vs33") _, out("v1") _);
    |                  register `vs33`
 
 error: register `v2` conflicts with register `vs34`
-  --> $DIR/bad-reg.rs:275:33
+  --> $DIR/bad-reg.rs:274:33
    |
 LL |         asm!("", out("vs34") _, out("v2") _);
    |                  -------------  ^^^^^^^^^^^ register `v2`
@@ -475,7 +475,7 @@ LL |         asm!("", out("vs34") _, out("v2") _);
    |                  register `vs34`
 
 error: register `v3` conflicts with register `vs35`
-  --> $DIR/bad-reg.rs:277:33
+  --> $DIR/bad-reg.rs:276:33
    |
 LL |         asm!("", out("vs35") _, out("v3") _);
    |                  -------------  ^^^^^^^^^^^ register `v3`
@@ -483,7 +483,7 @@ LL |         asm!("", out("vs35") _, out("v3") _);
    |                  register `vs35`
 
 error: register `v4` conflicts with register `vs36`
-  --> $DIR/bad-reg.rs:279:33
+  --> $DIR/bad-reg.rs:278:33
    |
 LL |         asm!("", out("vs36") _, out("v4") _);
    |                  -------------  ^^^^^^^^^^^ register `v4`
@@ -491,7 +491,7 @@ LL |         asm!("", out("vs36") _, out("v4") _);
    |                  register `vs36`
 
 error: register `v5` conflicts with register `vs37`
-  --> $DIR/bad-reg.rs:281:33
+  --> $DIR/bad-reg.rs:280:33
    |
 LL |         asm!("", out("vs37") _, out("v5") _);
    |                  -------------  ^^^^^^^^^^^ register `v5`
@@ -499,7 +499,7 @@ LL |         asm!("", out("vs37") _, out("v5") _);
    |                  register `vs37`
 
 error: register `v6` conflicts with register `vs38`
-  --> $DIR/bad-reg.rs:283:33
+  --> $DIR/bad-reg.rs:282:33
    |
 LL |         asm!("", out("vs38") _, out("v6") _);
    |                  -------------  ^^^^^^^^^^^ register `v6`
@@ -507,7 +507,7 @@ LL |         asm!("", out("vs38") _, out("v6") _);
    |                  register `vs38`
 
 error: register `v7` conflicts with register `vs39`
-  --> $DIR/bad-reg.rs:285:33
+  --> $DIR/bad-reg.rs:284:33
    |
 LL |         asm!("", out("vs39") _, out("v7") _);
    |                  -------------  ^^^^^^^^^^^ register `v7`
@@ -515,7 +515,7 @@ LL |         asm!("", out("vs39") _, out("v7") _);
    |                  register `vs39`
 
 error: register `v8` conflicts with register `vs40`
-  --> $DIR/bad-reg.rs:287:33
+  --> $DIR/bad-reg.rs:286:33
    |
 LL |         asm!("", out("vs40") _, out("v8") _);
    |                  -------------  ^^^^^^^^^^^ register `v8`
@@ -523,7 +523,7 @@ LL |         asm!("", out("vs40") _, out("v8") _);
    |                  register `vs40`
 
 error: register `v9` conflicts with register `vs41`
-  --> $DIR/bad-reg.rs:289:33
+  --> $DIR/bad-reg.rs:288:33
    |
 LL |         asm!("", out("vs41") _, out("v9") _);
    |                  -------------  ^^^^^^^^^^^ register `v9`
@@ -531,7 +531,7 @@ LL |         asm!("", out("vs41") _, out("v9") _);
    |                  register `vs41`
 
 error: register `v10` conflicts with register `vs42`
-  --> $DIR/bad-reg.rs:291:33
+  --> $DIR/bad-reg.rs:290:33
    |
 LL |         asm!("", out("vs42") _, out("v10") _);
    |                  -------------  ^^^^^^^^^^^^ register `v10`
@@ -539,7 +539,7 @@ LL |         asm!("", out("vs42") _, out("v10") _);
    |                  register `vs42`
 
 error: register `v11` conflicts with register `vs43`
-  --> $DIR/bad-reg.rs:293:33
+  --> $DIR/bad-reg.rs:292:33
    |
 LL |         asm!("", out("vs43") _, out("v11") _);
    |                  -------------  ^^^^^^^^^^^^ register `v11`
@@ -547,7 +547,7 @@ LL |         asm!("", out("vs43") _, out("v11") _);
    |                  register `vs43`
 
 error: register `v12` conflicts with register `vs44`
-  --> $DIR/bad-reg.rs:295:33
+  --> $DIR/bad-reg.rs:294:33
    |
 LL |         asm!("", out("vs44") _, out("v12") _);
    |                  -------------  ^^^^^^^^^^^^ register `v12`
@@ -555,7 +555,7 @@ LL |         asm!("", out("vs44") _, out("v12") _);
    |                  register `vs44`
 
 error: register `v13` conflicts with register `vs45`
-  --> $DIR/bad-reg.rs:297:33
+  --> $DIR/bad-reg.rs:296:33
    |
 LL |         asm!("", out("vs45") _, out("v13") _);
    |                  -------------  ^^^^^^^^^^^^ register `v13`
@@ -563,7 +563,7 @@ LL |         asm!("", out("vs45") _, out("v13") _);
    |                  register `vs45`
 
 error: register `v14` conflicts with register `vs46`
-  --> $DIR/bad-reg.rs:299:33
+  --> $DIR/bad-reg.rs:298:33
    |
 LL |         asm!("", out("vs46") _, out("v14") _);
    |                  -------------  ^^^^^^^^^^^^ register `v14`
@@ -571,7 +571,7 @@ LL |         asm!("", out("vs46") _, out("v14") _);
    |                  register `vs46`
 
 error: register `v15` conflicts with register `vs47`
-  --> $DIR/bad-reg.rs:301:33
+  --> $DIR/bad-reg.rs:300:33
    |
 LL |         asm!("", out("vs47") _, out("v15") _);
    |                  -------------  ^^^^^^^^^^^^ register `v15`
@@ -579,7 +579,7 @@ LL |         asm!("", out("vs47") _, out("v15") _);
    |                  register `vs47`
 
 error: register `v16` conflicts with register `vs48`
-  --> $DIR/bad-reg.rs:303:33
+  --> $DIR/bad-reg.rs:302:33
    |
 LL |         asm!("", out("vs48") _, out("v16") _);
    |                  -------------  ^^^^^^^^^^^^ register `v16`
@@ -587,7 +587,7 @@ LL |         asm!("", out("vs48") _, out("v16") _);
    |                  register `vs48`
 
 error: register `v17` conflicts with register `vs49`
-  --> $DIR/bad-reg.rs:305:33
+  --> $DIR/bad-reg.rs:304:33
    |
 LL |         asm!("", out("vs49") _, out("v17") _);
    |                  -------------  ^^^^^^^^^^^^ register `v17`
@@ -595,7 +595,7 @@ LL |         asm!("", out("vs49") _, out("v17") _);
    |                  register `vs49`
 
 error: register `v18` conflicts with register `vs50`
-  --> $DIR/bad-reg.rs:307:33
+  --> $DIR/bad-reg.rs:306:33
    |
 LL |         asm!("", out("vs50") _, out("v18") _);
    |                  -------------  ^^^^^^^^^^^^ register `v18`
@@ -603,7 +603,7 @@ LL |         asm!("", out("vs50") _, out("v18") _);
    |                  register `vs50`
 
 error: register `v19` conflicts with register `vs51`
-  --> $DIR/bad-reg.rs:309:33
+  --> $DIR/bad-reg.rs:308:33
    |
 LL |         asm!("", out("vs51") _, out("v19") _);
    |                  -------------  ^^^^^^^^^^^^ register `v19`
@@ -611,7 +611,7 @@ LL |         asm!("", out("vs51") _, out("v19") _);
    |                  register `vs51`
 
 error: register `v20` conflicts with register `vs52`
-  --> $DIR/bad-reg.rs:311:33
+  --> $DIR/bad-reg.rs:310:33
    |
 LL |         asm!("", out("vs52") _, out("v20") _);
    |                  -------------  ^^^^^^^^^^^^ register `v20`
@@ -619,7 +619,7 @@ LL |         asm!("", out("vs52") _, out("v20") _);
    |                  register `vs52`
 
 error: register `v21` conflicts with register `vs53`
-  --> $DIR/bad-reg.rs:313:33
+  --> $DIR/bad-reg.rs:312:33
    |
 LL |         asm!("", out("vs53") _, out("v21") _);
    |                  -------------  ^^^^^^^^^^^^ register `v21`
@@ -627,7 +627,7 @@ LL |         asm!("", out("vs53") _, out("v21") _);
    |                  register `vs53`
 
 error: register `v22` conflicts with register `vs54`
-  --> $DIR/bad-reg.rs:315:33
+  --> $DIR/bad-reg.rs:314:33
    |
 LL |         asm!("", out("vs54") _, out("v22") _);
    |                  -------------  ^^^^^^^^^^^^ register `v22`
@@ -635,7 +635,7 @@ LL |         asm!("", out("vs54") _, out("v22") _);
    |                  register `vs54`
 
 error: register `v23` conflicts with register `vs55`
-  --> $DIR/bad-reg.rs:317:33
+  --> $DIR/bad-reg.rs:316:33
    |
 LL |         asm!("", out("vs55") _, out("v23") _);
    |                  -------------  ^^^^^^^^^^^^ register `v23`
@@ -643,7 +643,7 @@ LL |         asm!("", out("vs55") _, out("v23") _);
    |                  register `vs55`
 
 error: register `v24` conflicts with register `vs56`
-  --> $DIR/bad-reg.rs:319:33
+  --> $DIR/bad-reg.rs:318:33
    |
 LL |         asm!("", out("vs56") _, out("v24") _);
    |                  -------------  ^^^^^^^^^^^^ register `v24`
@@ -651,7 +651,7 @@ LL |         asm!("", out("vs56") _, out("v24") _);
    |                  register `vs56`
 
 error: register `v25` conflicts with register `vs57`
-  --> $DIR/bad-reg.rs:321:33
+  --> $DIR/bad-reg.rs:320:33
    |
 LL |         asm!("", out("vs57") _, out("v25") _);
    |                  -------------  ^^^^^^^^^^^^ register `v25`
@@ -659,7 +659,7 @@ LL |         asm!("", out("vs57") _, out("v25") _);
    |                  register `vs57`
 
 error: register `v26` conflicts with register `vs58`
-  --> $DIR/bad-reg.rs:323:33
+  --> $DIR/bad-reg.rs:322:33
    |
 LL |         asm!("", out("vs58") _, out("v26") _);
    |                  -------------  ^^^^^^^^^^^^ register `v26`
@@ -667,7 +667,7 @@ LL |         asm!("", out("vs58") _, out("v26") _);
    |                  register `vs58`
 
 error: register `v27` conflicts with register `vs59`
-  --> $DIR/bad-reg.rs:325:33
+  --> $DIR/bad-reg.rs:324:33
    |
 LL |         asm!("", out("vs59") _, out("v27") _);
    |                  -------------  ^^^^^^^^^^^^ register `v27`
@@ -675,7 +675,7 @@ LL |         asm!("", out("vs59") _, out("v27") _);
    |                  register `vs59`
 
 error: register `v28` conflicts with register `vs60`
-  --> $DIR/bad-reg.rs:327:33
+  --> $DIR/bad-reg.rs:326:33
    |
 LL |         asm!("", out("vs60") _, out("v28") _);
    |                  -------------  ^^^^^^^^^^^^ register `v28`
@@ -683,7 +683,7 @@ LL |         asm!("", out("vs60") _, out("v28") _);
    |                  register `vs60`
 
 error: register `v29` conflicts with register `vs61`
-  --> $DIR/bad-reg.rs:329:33
+  --> $DIR/bad-reg.rs:328:33
    |
 LL |         asm!("", out("vs61") _, out("v29") _);
    |                  -------------  ^^^^^^^^^^^^ register `v29`
@@ -691,7 +691,7 @@ LL |         asm!("", out("vs61") _, out("v29") _);
    |                  register `vs61`
 
 error: register `v30` conflicts with register `vs62`
-  --> $DIR/bad-reg.rs:331:33
+  --> $DIR/bad-reg.rs:330:33
    |
 LL |         asm!("", out("vs62") _, out("v30") _);
    |                  -------------  ^^^^^^^^^^^^ register `v30`
@@ -699,7 +699,7 @@ LL |         asm!("", out("vs62") _, out("v30") _);
    |                  register `vs62`
 
 error: register `v31` conflicts with register `vs63`
-  --> $DIR/bad-reg.rs:333:33
+  --> $DIR/bad-reg.rs:332:33
    |
 LL |         asm!("", out("vs63") _, out("v31") _);
    |                  -------------  ^^^^^^^^^^^^ register `v31`
@@ -707,13 +707,13 @@ LL |         asm!("", out("vs63") _, out("v31") _);
    |                  register `vs63`
 
 error: cannot use register `r13`: r13 is a reserved register on this target
-  --> $DIR/bad-reg.rs:41:18
+  --> $DIR/bad-reg.rs:40:18
    |
 LL |         asm!("", out("r13") _);
    |                  ^^^^^^^^^^^^
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:64:27
+  --> $DIR/bad-reg.rs:63:27
    |
 LL |         asm!("", in("v0") x); // FIXME: should be ok if vsx is available
    |                           ^
@@ -721,7 +721,7 @@ LL |         asm!("", in("v0") x); // FIXME: should be ok if vsx is available
    = note: register class `vreg` supports these types: i8x16, i16x8, i32x4, f32x4, f32, f64, i64x2, f64x2
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:67:28
+  --> $DIR/bad-reg.rs:66:28
    |
 LL |         asm!("", out("v0") x); // FIXME: should be ok if vsx is available
    |                            ^
@@ -729,7 +729,7 @@ LL |         asm!("", out("v0") x); // FIXME: should be ok if vsx is available
    = note: register class `vreg` supports these types: i8x16, i16x8, i32x4, f32x4, f32, f64, i64x2, f64x2
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:75:35
+  --> $DIR/bad-reg.rs:74:35
    |
 LL |         asm!("/* {} */", in(vreg) x); // FIXME: should be ok if vsx is available
    |                                   ^
@@ -737,7 +737,7 @@ LL |         asm!("/* {} */", in(vreg) x); // FIXME: should be ok if vsx is avai
    = note: register class `vreg` supports these types: i8x16, i16x8, i32x4, f32x4, f32, f64, i64x2, f64x2
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:105:28
+  --> $DIR/bad-reg.rs:104:28
    |
 LL |         asm!("", in("vs0") x); // FIXME: should be ok if vsx is available
    |                            ^
@@ -745,7 +745,7 @@ LL |         asm!("", in("vs0") x); // FIXME: should be ok if vsx is available
    = note: register class `vsreg` supports these types: f32, f64, i8x16, i16x8, i32x4, i64x2, f32x4, f64x2
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:108:29
+  --> $DIR/bad-reg.rs:107:29
    |
 LL |         asm!("", out("vs0") x); // FIXME: should be ok if vsx is available
    |                             ^
@@ -753,7 +753,7 @@ LL |         asm!("", out("vs0") x); // FIXME: should be ok if vsx is available
    = note: register class `vsreg` supports these types: f32, f64, i8x16, i16x8, i32x4, i64x2, f32x4, f64x2
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:115:36
+  --> $DIR/bad-reg.rs:114:36
    |
 LL |         asm!("/* {} */", in(vsreg) x); // FIXME: should be ok if vsx is available
    |                                    ^
@@ -761,7 +761,7 @@ LL |         asm!("/* {} */", in(vsreg) x); // FIXME: should be ok if vsx is ava
    = note: register class `vsreg` supports these types: f32, f64, i8x16, i16x8, i32x4, i64x2, f32x4, f64x2
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:138:27
+  --> $DIR/bad-reg.rs:137:27
    |
 LL |         asm!("", in("cr") x);
    |                           ^
@@ -769,7 +769,7 @@ LL |         asm!("", in("cr") x);
    = note: register class `cr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:141:28
+  --> $DIR/bad-reg.rs:140:28
    |
 LL |         asm!("", out("cr") x);
    |                            ^
@@ -777,7 +777,7 @@ LL |         asm!("", out("cr") x);
    = note: register class `cr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:144:33
+  --> $DIR/bad-reg.rs:143:33
    |
 LL |         asm!("/* {} */", in(cr) x);
    |                                 ^
@@ -785,7 +785,7 @@ LL |         asm!("/* {} */", in(cr) x);
    = note: register class `cr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:151:28
+  --> $DIR/bad-reg.rs:150:28
    |
 LL |         asm!("", in("ctr") x);
    |                            ^
@@ -793,7 +793,7 @@ LL |         asm!("", in("ctr") x);
    = note: register class `ctr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:154:29
+  --> $DIR/bad-reg.rs:153:29
    |
 LL |         asm!("", out("ctr") x);
    |                             ^
@@ -801,7 +801,7 @@ LL |         asm!("", out("ctr") x);
    = note: register class `ctr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:157:34
+  --> $DIR/bad-reg.rs:156:34
    |
 LL |         asm!("/* {} */", in(ctr) x);
    |                                  ^
@@ -809,7 +809,7 @@ LL |         asm!("/* {} */", in(ctr) x);
    = note: register class `ctr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:164:27
+  --> $DIR/bad-reg.rs:163:27
    |
 LL |         asm!("", in("lr") x);
    |                           ^
@@ -817,7 +817,7 @@ LL |         asm!("", in("lr") x);
    = note: register class `lr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:167:28
+  --> $DIR/bad-reg.rs:166:28
    |
 LL |         asm!("", out("lr") x);
    |                            ^
@@ -825,7 +825,7 @@ LL |         asm!("", out("lr") x);
    = note: register class `lr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:170:33
+  --> $DIR/bad-reg.rs:169:33
    |
 LL |         asm!("/* {} */", in(lr) x);
    |                                 ^
@@ -833,7 +833,7 @@ LL |         asm!("/* {} */", in(lr) x);
    = note: register class `lr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:177:28
+  --> $DIR/bad-reg.rs:176:28
    |
 LL |         asm!("", in("xer") x);
    |                            ^
@@ -841,7 +841,7 @@ LL |         asm!("", in("xer") x);
    = note: register class `xer` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:180:29
+  --> $DIR/bad-reg.rs:179:29
    |
 LL |         asm!("", out("xer") x);
    |                             ^
@@ -849,7 +849,7 @@ LL |         asm!("", out("xer") x);
    = note: register class `xer` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:183:34
+  --> $DIR/bad-reg.rs:182:34
    |
 LL |         asm!("/* {} */", in(xer) x);
    |                                  ^

--- a/tests/ui/asm/powerpc/bad-reg.powerpc.stderr
+++ b/tests/ui/asm/powerpc/bad-reg.powerpc.stderr
@@ -1,137 +1,137 @@
 error: invalid register `sp`: the stack pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:37:18
+  --> $DIR/bad-reg.rs:36:18
    |
 LL |         asm!("", out("sp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `r2`: r2 is a system reserved register and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:39:18
+  --> $DIR/bad-reg.rs:38:18
    |
 LL |         asm!("", out("r2") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `r29`: r29 is used internally by LLVM and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:43:18
+  --> $DIR/bad-reg.rs:42:18
    |
 LL |         asm!("", out("r29") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `r30`: r30 is used internally by LLVM and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:45:18
+  --> $DIR/bad-reg.rs:44:18
    |
 LL |         asm!("", out("r30") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `fp`: the frame pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:47:18
+  --> $DIR/bad-reg.rs:46:18
    |
 LL |         asm!("", out("fp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `vrsave`: the vrsave register cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:49:18
+  --> $DIR/bad-reg.rs:48:18
    |
 LL |         asm!("", out("vrsave") _);
    |                  ^^^^^^^^^^^^^^^
 
 error: register class `cr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:138:18
+  --> $DIR/bad-reg.rs:137:18
    |
 LL |         asm!("", in("cr") x);
    |                  ^^^^^^^^^^
 
 error: register class `cr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:141:18
+  --> $DIR/bad-reg.rs:140:18
    |
 LL |         asm!("", out("cr") x);
    |                  ^^^^^^^^^^^
 
 error: register class `cr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:144:26
+  --> $DIR/bad-reg.rs:143:26
    |
 LL |         asm!("/* {} */", in(cr) x);
    |                          ^^^^^^^^
 
 error: register class `cr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:147:26
+  --> $DIR/bad-reg.rs:146:26
    |
 LL |         asm!("/* {} */", out(cr) _);
    |                          ^^^^^^^^^
 
 error: register class `ctr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:151:18
+  --> $DIR/bad-reg.rs:150:18
    |
 LL |         asm!("", in("ctr") x);
    |                  ^^^^^^^^^^^
 
 error: register class `ctr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:154:18
+  --> $DIR/bad-reg.rs:153:18
    |
 LL |         asm!("", out("ctr") x);
    |                  ^^^^^^^^^^^^
 
 error: register class `ctr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:157:26
+  --> $DIR/bad-reg.rs:156:26
    |
 LL |         asm!("/* {} */", in(ctr) x);
    |                          ^^^^^^^^^
 
 error: register class `ctr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:160:26
+  --> $DIR/bad-reg.rs:159:26
    |
 LL |         asm!("/* {} */", out(ctr) _);
    |                          ^^^^^^^^^^
 
 error: register class `lr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:164:18
+  --> $DIR/bad-reg.rs:163:18
    |
 LL |         asm!("", in("lr") x);
    |                  ^^^^^^^^^^
 
 error: register class `lr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:167:18
+  --> $DIR/bad-reg.rs:166:18
    |
 LL |         asm!("", out("lr") x);
    |                  ^^^^^^^^^^^
 
 error: register class `lr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:170:26
+  --> $DIR/bad-reg.rs:169:26
    |
 LL |         asm!("/* {} */", in(lr) x);
    |                          ^^^^^^^^
 
 error: register class `lr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:173:26
+  --> $DIR/bad-reg.rs:172:26
    |
 LL |         asm!("/* {} */", out(lr) _);
    |                          ^^^^^^^^^
 
 error: register class `xer` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:177:18
+  --> $DIR/bad-reg.rs:176:18
    |
 LL |         asm!("", in("xer") x);
    |                  ^^^^^^^^^^^
 
 error: register class `xer` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:180:18
+  --> $DIR/bad-reg.rs:179:18
    |
 LL |         asm!("", out("xer") x);
    |                  ^^^^^^^^^^^^
 
 error: register class `xer` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:183:26
+  --> $DIR/bad-reg.rs:182:26
    |
 LL |         asm!("/* {} */", in(xer) x);
    |                          ^^^^^^^^^
 
 error: register class `xer` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:186:26
+  --> $DIR/bad-reg.rs:185:26
    |
 LL |         asm!("/* {} */", out(xer) _);
    |                          ^^^^^^^^^^
 
 error: register `cr0` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:190:31
+  --> $DIR/bad-reg.rs:189:31
    |
 LL |         asm!("", out("cr") _, out("cr0") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr0`
@@ -139,7 +139,7 @@ LL |         asm!("", out("cr") _, out("cr0") _);
    |                  register `cr`
 
 error: register `cr1` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:192:31
+  --> $DIR/bad-reg.rs:191:31
    |
 LL |         asm!("", out("cr") _, out("cr1") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr1`
@@ -147,7 +147,7 @@ LL |         asm!("", out("cr") _, out("cr1") _);
    |                  register `cr`
 
 error: register `cr2` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:194:31
+  --> $DIR/bad-reg.rs:193:31
    |
 LL |         asm!("", out("cr") _, out("cr2") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr2`
@@ -155,7 +155,7 @@ LL |         asm!("", out("cr") _, out("cr2") _);
    |                  register `cr`
 
 error: register `cr3` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:196:31
+  --> $DIR/bad-reg.rs:195:31
    |
 LL |         asm!("", out("cr") _, out("cr3") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr3`
@@ -163,7 +163,7 @@ LL |         asm!("", out("cr") _, out("cr3") _);
    |                  register `cr`
 
 error: register `cr4` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:198:31
+  --> $DIR/bad-reg.rs:197:31
    |
 LL |         asm!("", out("cr") _, out("cr4") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr4`
@@ -171,7 +171,7 @@ LL |         asm!("", out("cr") _, out("cr4") _);
    |                  register `cr`
 
 error: register `cr5` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:200:31
+  --> $DIR/bad-reg.rs:199:31
    |
 LL |         asm!("", out("cr") _, out("cr5") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr5`
@@ -179,7 +179,7 @@ LL |         asm!("", out("cr") _, out("cr5") _);
    |                  register `cr`
 
 error: register `cr6` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:202:31
+  --> $DIR/bad-reg.rs:201:31
    |
 LL |         asm!("", out("cr") _, out("cr6") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr6`
@@ -187,7 +187,7 @@ LL |         asm!("", out("cr") _, out("cr6") _);
    |                  register `cr`
 
 error: register `cr7` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:204:31
+  --> $DIR/bad-reg.rs:203:31
    |
 LL |         asm!("", out("cr") _, out("cr7") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr7`
@@ -195,7 +195,7 @@ LL |         asm!("", out("cr") _, out("cr7") _);
    |                  register `cr`
 
 error: register `vs0` conflicts with register `f0`
-  --> $DIR/bad-reg.rs:207:31
+  --> $DIR/bad-reg.rs:206:31
    |
 LL |         asm!("", out("f0") _, out("vs0") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs0`
@@ -203,7 +203,7 @@ LL |         asm!("", out("f0") _, out("vs0") _);
    |                  register `f0`
 
 error: register `vs1` conflicts with register `f1`
-  --> $DIR/bad-reg.rs:209:31
+  --> $DIR/bad-reg.rs:208:31
    |
 LL |         asm!("", out("f1") _, out("vs1") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs1`
@@ -211,7 +211,7 @@ LL |         asm!("", out("f1") _, out("vs1") _);
    |                  register `f1`
 
 error: register `vs2` conflicts with register `f2`
-  --> $DIR/bad-reg.rs:211:31
+  --> $DIR/bad-reg.rs:210:31
    |
 LL |         asm!("", out("f2") _, out("vs2") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs2`
@@ -219,7 +219,7 @@ LL |         asm!("", out("f2") _, out("vs2") _);
    |                  register `f2`
 
 error: register `vs3` conflicts with register `f3`
-  --> $DIR/bad-reg.rs:213:31
+  --> $DIR/bad-reg.rs:212:31
    |
 LL |         asm!("", out("f3") _, out("vs3") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs3`
@@ -227,7 +227,7 @@ LL |         asm!("", out("f3") _, out("vs3") _);
    |                  register `f3`
 
 error: register `vs4` conflicts with register `f4`
-  --> $DIR/bad-reg.rs:215:31
+  --> $DIR/bad-reg.rs:214:31
    |
 LL |         asm!("", out("f4") _, out("vs4") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs4`
@@ -235,7 +235,7 @@ LL |         asm!("", out("f4") _, out("vs4") _);
    |                  register `f4`
 
 error: register `vs5` conflicts with register `f5`
-  --> $DIR/bad-reg.rs:217:31
+  --> $DIR/bad-reg.rs:216:31
    |
 LL |         asm!("", out("f5") _, out("vs5") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs5`
@@ -243,7 +243,7 @@ LL |         asm!("", out("f5") _, out("vs5") _);
    |                  register `f5`
 
 error: register `vs6` conflicts with register `f6`
-  --> $DIR/bad-reg.rs:219:31
+  --> $DIR/bad-reg.rs:218:31
    |
 LL |         asm!("", out("f6") _, out("vs6") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs6`
@@ -251,7 +251,7 @@ LL |         asm!("", out("f6") _, out("vs6") _);
    |                  register `f6`
 
 error: register `vs7` conflicts with register `f7`
-  --> $DIR/bad-reg.rs:221:31
+  --> $DIR/bad-reg.rs:220:31
    |
 LL |         asm!("", out("f7") _, out("vs7") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs7`
@@ -259,7 +259,7 @@ LL |         asm!("", out("f7") _, out("vs7") _);
    |                  register `f7`
 
 error: register `vs8` conflicts with register `f8`
-  --> $DIR/bad-reg.rs:223:31
+  --> $DIR/bad-reg.rs:222:31
    |
 LL |         asm!("", out("f8") _, out("vs8") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs8`
@@ -267,7 +267,7 @@ LL |         asm!("", out("f8") _, out("vs8") _);
    |                  register `f8`
 
 error: register `vs9` conflicts with register `f9`
-  --> $DIR/bad-reg.rs:225:31
+  --> $DIR/bad-reg.rs:224:31
    |
 LL |         asm!("", out("f9") _, out("vs9") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs9`
@@ -275,7 +275,7 @@ LL |         asm!("", out("f9") _, out("vs9") _);
    |                  register `f9`
 
 error: register `vs10` conflicts with register `f10`
-  --> $DIR/bad-reg.rs:227:32
+  --> $DIR/bad-reg.rs:226:32
    |
 LL |         asm!("", out("f10") _, out("vs10") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs10`
@@ -283,7 +283,7 @@ LL |         asm!("", out("f10") _, out("vs10") _);
    |                  register `f10`
 
 error: register `vs11` conflicts with register `f11`
-  --> $DIR/bad-reg.rs:229:32
+  --> $DIR/bad-reg.rs:228:32
    |
 LL |         asm!("", out("f11") _, out("vs11") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs11`
@@ -291,7 +291,7 @@ LL |         asm!("", out("f11") _, out("vs11") _);
    |                  register `f11`
 
 error: register `vs12` conflicts with register `f12`
-  --> $DIR/bad-reg.rs:231:32
+  --> $DIR/bad-reg.rs:230:32
    |
 LL |         asm!("", out("f12") _, out("vs12") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs12`
@@ -299,7 +299,7 @@ LL |         asm!("", out("f12") _, out("vs12") _);
    |                  register `f12`
 
 error: register `vs13` conflicts with register `f13`
-  --> $DIR/bad-reg.rs:233:32
+  --> $DIR/bad-reg.rs:232:32
    |
 LL |         asm!("", out("f13") _, out("vs13") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs13`
@@ -307,7 +307,7 @@ LL |         asm!("", out("f13") _, out("vs13") _);
    |                  register `f13`
 
 error: register `vs14` conflicts with register `f14`
-  --> $DIR/bad-reg.rs:235:32
+  --> $DIR/bad-reg.rs:234:32
    |
 LL |         asm!("", out("f14") _, out("vs14") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs14`
@@ -315,7 +315,7 @@ LL |         asm!("", out("f14") _, out("vs14") _);
    |                  register `f14`
 
 error: register `vs15` conflicts with register `f15`
-  --> $DIR/bad-reg.rs:237:32
+  --> $DIR/bad-reg.rs:236:32
    |
 LL |         asm!("", out("f15") _, out("vs15") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs15`
@@ -323,7 +323,7 @@ LL |         asm!("", out("f15") _, out("vs15") _);
    |                  register `f15`
 
 error: register `vs16` conflicts with register `f16`
-  --> $DIR/bad-reg.rs:239:32
+  --> $DIR/bad-reg.rs:238:32
    |
 LL |         asm!("", out("f16") _, out("vs16") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs16`
@@ -331,7 +331,7 @@ LL |         asm!("", out("f16") _, out("vs16") _);
    |                  register `f16`
 
 error: register `vs17` conflicts with register `f17`
-  --> $DIR/bad-reg.rs:241:32
+  --> $DIR/bad-reg.rs:240:32
    |
 LL |         asm!("", out("f17") _, out("vs17") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs17`
@@ -339,7 +339,7 @@ LL |         asm!("", out("f17") _, out("vs17") _);
    |                  register `f17`
 
 error: register `vs18` conflicts with register `f18`
-  --> $DIR/bad-reg.rs:243:32
+  --> $DIR/bad-reg.rs:242:32
    |
 LL |         asm!("", out("f18") _, out("vs18") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs18`
@@ -347,7 +347,7 @@ LL |         asm!("", out("f18") _, out("vs18") _);
    |                  register `f18`
 
 error: register `vs19` conflicts with register `f19`
-  --> $DIR/bad-reg.rs:245:32
+  --> $DIR/bad-reg.rs:244:32
    |
 LL |         asm!("", out("f19") _, out("vs19") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs19`
@@ -355,7 +355,7 @@ LL |         asm!("", out("f19") _, out("vs19") _);
    |                  register `f19`
 
 error: register `vs20` conflicts with register `f20`
-  --> $DIR/bad-reg.rs:247:32
+  --> $DIR/bad-reg.rs:246:32
    |
 LL |         asm!("", out("f20") _, out("vs20") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs20`
@@ -363,7 +363,7 @@ LL |         asm!("", out("f20") _, out("vs20") _);
    |                  register `f20`
 
 error: register `vs21` conflicts with register `f21`
-  --> $DIR/bad-reg.rs:249:32
+  --> $DIR/bad-reg.rs:248:32
    |
 LL |         asm!("", out("f21") _, out("vs21") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs21`
@@ -371,7 +371,7 @@ LL |         asm!("", out("f21") _, out("vs21") _);
    |                  register `f21`
 
 error: register `vs22` conflicts with register `f22`
-  --> $DIR/bad-reg.rs:251:32
+  --> $DIR/bad-reg.rs:250:32
    |
 LL |         asm!("", out("f22") _, out("vs22") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs22`
@@ -379,7 +379,7 @@ LL |         asm!("", out("f22") _, out("vs22") _);
    |                  register `f22`
 
 error: register `vs23` conflicts with register `f23`
-  --> $DIR/bad-reg.rs:253:32
+  --> $DIR/bad-reg.rs:252:32
    |
 LL |         asm!("", out("f23") _, out("vs23") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs23`
@@ -387,7 +387,7 @@ LL |         asm!("", out("f23") _, out("vs23") _);
    |                  register `f23`
 
 error: register `vs24` conflicts with register `f24`
-  --> $DIR/bad-reg.rs:255:32
+  --> $DIR/bad-reg.rs:254:32
    |
 LL |         asm!("", out("f24") _, out("vs24") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs24`
@@ -395,7 +395,7 @@ LL |         asm!("", out("f24") _, out("vs24") _);
    |                  register `f24`
 
 error: register `vs25` conflicts with register `f25`
-  --> $DIR/bad-reg.rs:257:32
+  --> $DIR/bad-reg.rs:256:32
    |
 LL |         asm!("", out("f25") _, out("vs25") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs25`
@@ -403,7 +403,7 @@ LL |         asm!("", out("f25") _, out("vs25") _);
    |                  register `f25`
 
 error: register `vs26` conflicts with register `f26`
-  --> $DIR/bad-reg.rs:259:32
+  --> $DIR/bad-reg.rs:258:32
    |
 LL |         asm!("", out("f26") _, out("vs26") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs26`
@@ -411,7 +411,7 @@ LL |         asm!("", out("f26") _, out("vs26") _);
    |                  register `f26`
 
 error: register `vs27` conflicts with register `f27`
-  --> $DIR/bad-reg.rs:261:32
+  --> $DIR/bad-reg.rs:260:32
    |
 LL |         asm!("", out("f27") _, out("vs27") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs27`
@@ -419,7 +419,7 @@ LL |         asm!("", out("f27") _, out("vs27") _);
    |                  register `f27`
 
 error: register `vs28` conflicts with register `f28`
-  --> $DIR/bad-reg.rs:263:32
+  --> $DIR/bad-reg.rs:262:32
    |
 LL |         asm!("", out("f28") _, out("vs28") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs28`
@@ -427,7 +427,7 @@ LL |         asm!("", out("f28") _, out("vs28") _);
    |                  register `f28`
 
 error: register `vs29` conflicts with register `f29`
-  --> $DIR/bad-reg.rs:265:32
+  --> $DIR/bad-reg.rs:264:32
    |
 LL |         asm!("", out("f29") _, out("vs29") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs29`
@@ -435,7 +435,7 @@ LL |         asm!("", out("f29") _, out("vs29") _);
    |                  register `f29`
 
 error: register `vs30` conflicts with register `f30`
-  --> $DIR/bad-reg.rs:267:32
+  --> $DIR/bad-reg.rs:266:32
    |
 LL |         asm!("", out("f30") _, out("vs30") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs30`
@@ -443,7 +443,7 @@ LL |         asm!("", out("f30") _, out("vs30") _);
    |                  register `f30`
 
 error: register `vs31` conflicts with register `f31`
-  --> $DIR/bad-reg.rs:269:32
+  --> $DIR/bad-reg.rs:268:32
    |
 LL |         asm!("", out("f31") _, out("vs31") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs31`
@@ -451,7 +451,7 @@ LL |         asm!("", out("f31") _, out("vs31") _);
    |                  register `f31`
 
 error: register `v0` conflicts with register `vs32`
-  --> $DIR/bad-reg.rs:271:33
+  --> $DIR/bad-reg.rs:270:33
    |
 LL |         asm!("", out("vs32") _, out("v0") _);
    |                  -------------  ^^^^^^^^^^^ register `v0`
@@ -459,7 +459,7 @@ LL |         asm!("", out("vs32") _, out("v0") _);
    |                  register `vs32`
 
 error: register `v1` conflicts with register `vs33`
-  --> $DIR/bad-reg.rs:273:33
+  --> $DIR/bad-reg.rs:272:33
    |
 LL |         asm!("", out("vs33") _, out("v1") _);
    |                  -------------  ^^^^^^^^^^^ register `v1`
@@ -467,7 +467,7 @@ LL |         asm!("", out("vs33") _, out("v1") _);
    |                  register `vs33`
 
 error: register `v2` conflicts with register `vs34`
-  --> $DIR/bad-reg.rs:275:33
+  --> $DIR/bad-reg.rs:274:33
    |
 LL |         asm!("", out("vs34") _, out("v2") _);
    |                  -------------  ^^^^^^^^^^^ register `v2`
@@ -475,7 +475,7 @@ LL |         asm!("", out("vs34") _, out("v2") _);
    |                  register `vs34`
 
 error: register `v3` conflicts with register `vs35`
-  --> $DIR/bad-reg.rs:277:33
+  --> $DIR/bad-reg.rs:276:33
    |
 LL |         asm!("", out("vs35") _, out("v3") _);
    |                  -------------  ^^^^^^^^^^^ register `v3`
@@ -483,7 +483,7 @@ LL |         asm!("", out("vs35") _, out("v3") _);
    |                  register `vs35`
 
 error: register `v4` conflicts with register `vs36`
-  --> $DIR/bad-reg.rs:279:33
+  --> $DIR/bad-reg.rs:278:33
    |
 LL |         asm!("", out("vs36") _, out("v4") _);
    |                  -------------  ^^^^^^^^^^^ register `v4`
@@ -491,7 +491,7 @@ LL |         asm!("", out("vs36") _, out("v4") _);
    |                  register `vs36`
 
 error: register `v5` conflicts with register `vs37`
-  --> $DIR/bad-reg.rs:281:33
+  --> $DIR/bad-reg.rs:280:33
    |
 LL |         asm!("", out("vs37") _, out("v5") _);
    |                  -------------  ^^^^^^^^^^^ register `v5`
@@ -499,7 +499,7 @@ LL |         asm!("", out("vs37") _, out("v5") _);
    |                  register `vs37`
 
 error: register `v6` conflicts with register `vs38`
-  --> $DIR/bad-reg.rs:283:33
+  --> $DIR/bad-reg.rs:282:33
    |
 LL |         asm!("", out("vs38") _, out("v6") _);
    |                  -------------  ^^^^^^^^^^^ register `v6`
@@ -507,7 +507,7 @@ LL |         asm!("", out("vs38") _, out("v6") _);
    |                  register `vs38`
 
 error: register `v7` conflicts with register `vs39`
-  --> $DIR/bad-reg.rs:285:33
+  --> $DIR/bad-reg.rs:284:33
    |
 LL |         asm!("", out("vs39") _, out("v7") _);
    |                  -------------  ^^^^^^^^^^^ register `v7`
@@ -515,7 +515,7 @@ LL |         asm!("", out("vs39") _, out("v7") _);
    |                  register `vs39`
 
 error: register `v8` conflicts with register `vs40`
-  --> $DIR/bad-reg.rs:287:33
+  --> $DIR/bad-reg.rs:286:33
    |
 LL |         asm!("", out("vs40") _, out("v8") _);
    |                  -------------  ^^^^^^^^^^^ register `v8`
@@ -523,7 +523,7 @@ LL |         asm!("", out("vs40") _, out("v8") _);
    |                  register `vs40`
 
 error: register `v9` conflicts with register `vs41`
-  --> $DIR/bad-reg.rs:289:33
+  --> $DIR/bad-reg.rs:288:33
    |
 LL |         asm!("", out("vs41") _, out("v9") _);
    |                  -------------  ^^^^^^^^^^^ register `v9`
@@ -531,7 +531,7 @@ LL |         asm!("", out("vs41") _, out("v9") _);
    |                  register `vs41`
 
 error: register `v10` conflicts with register `vs42`
-  --> $DIR/bad-reg.rs:291:33
+  --> $DIR/bad-reg.rs:290:33
    |
 LL |         asm!("", out("vs42") _, out("v10") _);
    |                  -------------  ^^^^^^^^^^^^ register `v10`
@@ -539,7 +539,7 @@ LL |         asm!("", out("vs42") _, out("v10") _);
    |                  register `vs42`
 
 error: register `v11` conflicts with register `vs43`
-  --> $DIR/bad-reg.rs:293:33
+  --> $DIR/bad-reg.rs:292:33
    |
 LL |         asm!("", out("vs43") _, out("v11") _);
    |                  -------------  ^^^^^^^^^^^^ register `v11`
@@ -547,7 +547,7 @@ LL |         asm!("", out("vs43") _, out("v11") _);
    |                  register `vs43`
 
 error: register `v12` conflicts with register `vs44`
-  --> $DIR/bad-reg.rs:295:33
+  --> $DIR/bad-reg.rs:294:33
    |
 LL |         asm!("", out("vs44") _, out("v12") _);
    |                  -------------  ^^^^^^^^^^^^ register `v12`
@@ -555,7 +555,7 @@ LL |         asm!("", out("vs44") _, out("v12") _);
    |                  register `vs44`
 
 error: register `v13` conflicts with register `vs45`
-  --> $DIR/bad-reg.rs:297:33
+  --> $DIR/bad-reg.rs:296:33
    |
 LL |         asm!("", out("vs45") _, out("v13") _);
    |                  -------------  ^^^^^^^^^^^^ register `v13`
@@ -563,7 +563,7 @@ LL |         asm!("", out("vs45") _, out("v13") _);
    |                  register `vs45`
 
 error: register `v14` conflicts with register `vs46`
-  --> $DIR/bad-reg.rs:299:33
+  --> $DIR/bad-reg.rs:298:33
    |
 LL |         asm!("", out("vs46") _, out("v14") _);
    |                  -------------  ^^^^^^^^^^^^ register `v14`
@@ -571,7 +571,7 @@ LL |         asm!("", out("vs46") _, out("v14") _);
    |                  register `vs46`
 
 error: register `v15` conflicts with register `vs47`
-  --> $DIR/bad-reg.rs:301:33
+  --> $DIR/bad-reg.rs:300:33
    |
 LL |         asm!("", out("vs47") _, out("v15") _);
    |                  -------------  ^^^^^^^^^^^^ register `v15`
@@ -579,7 +579,7 @@ LL |         asm!("", out("vs47") _, out("v15") _);
    |                  register `vs47`
 
 error: register `v16` conflicts with register `vs48`
-  --> $DIR/bad-reg.rs:303:33
+  --> $DIR/bad-reg.rs:302:33
    |
 LL |         asm!("", out("vs48") _, out("v16") _);
    |                  -------------  ^^^^^^^^^^^^ register `v16`
@@ -587,7 +587,7 @@ LL |         asm!("", out("vs48") _, out("v16") _);
    |                  register `vs48`
 
 error: register `v17` conflicts with register `vs49`
-  --> $DIR/bad-reg.rs:305:33
+  --> $DIR/bad-reg.rs:304:33
    |
 LL |         asm!("", out("vs49") _, out("v17") _);
    |                  -------------  ^^^^^^^^^^^^ register `v17`
@@ -595,7 +595,7 @@ LL |         asm!("", out("vs49") _, out("v17") _);
    |                  register `vs49`
 
 error: register `v18` conflicts with register `vs50`
-  --> $DIR/bad-reg.rs:307:33
+  --> $DIR/bad-reg.rs:306:33
    |
 LL |         asm!("", out("vs50") _, out("v18") _);
    |                  -------------  ^^^^^^^^^^^^ register `v18`
@@ -603,7 +603,7 @@ LL |         asm!("", out("vs50") _, out("v18") _);
    |                  register `vs50`
 
 error: register `v19` conflicts with register `vs51`
-  --> $DIR/bad-reg.rs:309:33
+  --> $DIR/bad-reg.rs:308:33
    |
 LL |         asm!("", out("vs51") _, out("v19") _);
    |                  -------------  ^^^^^^^^^^^^ register `v19`
@@ -611,7 +611,7 @@ LL |         asm!("", out("vs51") _, out("v19") _);
    |                  register `vs51`
 
 error: register `v20` conflicts with register `vs52`
-  --> $DIR/bad-reg.rs:311:33
+  --> $DIR/bad-reg.rs:310:33
    |
 LL |         asm!("", out("vs52") _, out("v20") _);
    |                  -------------  ^^^^^^^^^^^^ register `v20`
@@ -619,7 +619,7 @@ LL |         asm!("", out("vs52") _, out("v20") _);
    |                  register `vs52`
 
 error: register `v21` conflicts with register `vs53`
-  --> $DIR/bad-reg.rs:313:33
+  --> $DIR/bad-reg.rs:312:33
    |
 LL |         asm!("", out("vs53") _, out("v21") _);
    |                  -------------  ^^^^^^^^^^^^ register `v21`
@@ -627,7 +627,7 @@ LL |         asm!("", out("vs53") _, out("v21") _);
    |                  register `vs53`
 
 error: register `v22` conflicts with register `vs54`
-  --> $DIR/bad-reg.rs:315:33
+  --> $DIR/bad-reg.rs:314:33
    |
 LL |         asm!("", out("vs54") _, out("v22") _);
    |                  -------------  ^^^^^^^^^^^^ register `v22`
@@ -635,7 +635,7 @@ LL |         asm!("", out("vs54") _, out("v22") _);
    |                  register `vs54`
 
 error: register `v23` conflicts with register `vs55`
-  --> $DIR/bad-reg.rs:317:33
+  --> $DIR/bad-reg.rs:316:33
    |
 LL |         asm!("", out("vs55") _, out("v23") _);
    |                  -------------  ^^^^^^^^^^^^ register `v23`
@@ -643,7 +643,7 @@ LL |         asm!("", out("vs55") _, out("v23") _);
    |                  register `vs55`
 
 error: register `v24` conflicts with register `vs56`
-  --> $DIR/bad-reg.rs:319:33
+  --> $DIR/bad-reg.rs:318:33
    |
 LL |         asm!("", out("vs56") _, out("v24") _);
    |                  -------------  ^^^^^^^^^^^^ register `v24`
@@ -651,7 +651,7 @@ LL |         asm!("", out("vs56") _, out("v24") _);
    |                  register `vs56`
 
 error: register `v25` conflicts with register `vs57`
-  --> $DIR/bad-reg.rs:321:33
+  --> $DIR/bad-reg.rs:320:33
    |
 LL |         asm!("", out("vs57") _, out("v25") _);
    |                  -------------  ^^^^^^^^^^^^ register `v25`
@@ -659,7 +659,7 @@ LL |         asm!("", out("vs57") _, out("v25") _);
    |                  register `vs57`
 
 error: register `v26` conflicts with register `vs58`
-  --> $DIR/bad-reg.rs:323:33
+  --> $DIR/bad-reg.rs:322:33
    |
 LL |         asm!("", out("vs58") _, out("v26") _);
    |                  -------------  ^^^^^^^^^^^^ register `v26`
@@ -667,7 +667,7 @@ LL |         asm!("", out("vs58") _, out("v26") _);
    |                  register `vs58`
 
 error: register `v27` conflicts with register `vs59`
-  --> $DIR/bad-reg.rs:325:33
+  --> $DIR/bad-reg.rs:324:33
    |
 LL |         asm!("", out("vs59") _, out("v27") _);
    |                  -------------  ^^^^^^^^^^^^ register `v27`
@@ -675,7 +675,7 @@ LL |         asm!("", out("vs59") _, out("v27") _);
    |                  register `vs59`
 
 error: register `v28` conflicts with register `vs60`
-  --> $DIR/bad-reg.rs:327:33
+  --> $DIR/bad-reg.rs:326:33
    |
 LL |         asm!("", out("vs60") _, out("v28") _);
    |                  -------------  ^^^^^^^^^^^^ register `v28`
@@ -683,7 +683,7 @@ LL |         asm!("", out("vs60") _, out("v28") _);
    |                  register `vs60`
 
 error: register `v29` conflicts with register `vs61`
-  --> $DIR/bad-reg.rs:329:33
+  --> $DIR/bad-reg.rs:328:33
    |
 LL |         asm!("", out("vs61") _, out("v29") _);
    |                  -------------  ^^^^^^^^^^^^ register `v29`
@@ -691,7 +691,7 @@ LL |         asm!("", out("vs61") _, out("v29") _);
    |                  register `vs61`
 
 error: register `v30` conflicts with register `vs62`
-  --> $DIR/bad-reg.rs:331:33
+  --> $DIR/bad-reg.rs:330:33
    |
 LL |         asm!("", out("vs62") _, out("v30") _);
    |                  -------------  ^^^^^^^^^^^^ register `v30`
@@ -699,7 +699,7 @@ LL |         asm!("", out("vs62") _, out("v30") _);
    |                  register `vs62`
 
 error: register `v31` conflicts with register `vs63`
-  --> $DIR/bad-reg.rs:333:33
+  --> $DIR/bad-reg.rs:332:33
    |
 LL |         asm!("", out("vs63") _, out("v31") _);
    |                  -------------  ^^^^^^^^^^^^ register `v31`
@@ -707,133 +707,133 @@ LL |         asm!("", out("vs63") _, out("v31") _);
    |                  register `vs63`
 
 error: cannot use register `r13`: r13 is a reserved register on this target
-  --> $DIR/bad-reg.rs:41:18
+  --> $DIR/bad-reg.rs:40:18
    |
 LL |         asm!("", out("r13") _);
    |                  ^^^^^^^^^^^^
 
 error: register class `vreg` requires at least one of the following target features: altivec, vsx
-  --> $DIR/bad-reg.rs:54:18
+  --> $DIR/bad-reg.rs:53:18
    |
 LL |         asm!("", in("v0") v32x4); // requires altivec
    |                  ^^^^^^^^^^^^^^
 
 error: register class `vreg` requires at least one of the following target features: altivec, vsx
-  --> $DIR/bad-reg.rs:56:18
+  --> $DIR/bad-reg.rs:55:18
    |
 LL |         asm!("", out("v0") v32x4); // requires altivec
    |                  ^^^^^^^^^^^^^^^
 
 error: register class `vreg` requires at least one of the following target features: altivec, vsx
-  --> $DIR/bad-reg.rs:58:18
+  --> $DIR/bad-reg.rs:57:18
    |
 LL |         asm!("", in("v0") v64x2); // requires vsx
    |                  ^^^^^^^^^^^^^^
 
 error: register class `vreg` requires at least one of the following target features: altivec, vsx
-  --> $DIR/bad-reg.rs:61:18
+  --> $DIR/bad-reg.rs:60:18
    |
 LL |         asm!("", out("v0") v64x2); // requires vsx
    |                  ^^^^^^^^^^^^^^^
 
 error: register class `vreg` requires at least one of the following target features: altivec, vsx
-  --> $DIR/bad-reg.rs:64:18
+  --> $DIR/bad-reg.rs:63:18
    |
 LL |         asm!("", in("v0") x); // FIXME: should be ok if vsx is available
    |                  ^^^^^^^^^^
 
 error: register class `vreg` requires at least one of the following target features: altivec, vsx
-  --> $DIR/bad-reg.rs:67:18
+  --> $DIR/bad-reg.rs:66:18
    |
 LL |         asm!("", out("v0") x); // FIXME: should be ok if vsx is available
    |                  ^^^^^^^^^^^
 
 error: register class `vreg` requires at least one of the following target features: altivec, vsx
-  --> $DIR/bad-reg.rs:70:26
+  --> $DIR/bad-reg.rs:69:26
    |
 LL |         asm!("/* {} */", in(vreg) v32x4); // requires altivec
    |                          ^^^^^^^^^^^^^^
 
 error: register class `vreg` requires at least one of the following target features: altivec, vsx
-  --> $DIR/bad-reg.rs:72:26
+  --> $DIR/bad-reg.rs:71:26
    |
 LL |         asm!("/* {} */", in(vreg) v64x2); // requires vsx
    |                          ^^^^^^^^^^^^^^
 
 error: register class `vreg` requires at least one of the following target features: altivec, vsx
-  --> $DIR/bad-reg.rs:75:26
+  --> $DIR/bad-reg.rs:74:26
    |
 LL |         asm!("/* {} */", in(vreg) x); // FIXME: should be ok if vsx is available
    |                          ^^^^^^^^^^
 
 error: register class `vreg` requires at least one of the following target features: altivec, vsx
-  --> $DIR/bad-reg.rs:78:26
+  --> $DIR/bad-reg.rs:77:26
    |
 LL |         asm!("/* {} */", out(vreg) _); // requires altivec
    |                          ^^^^^^^^^^^
 
 error: register class `vsreg` requires the `vsx` target feature
-  --> $DIR/bad-reg.rs:97:18
+  --> $DIR/bad-reg.rs:96:18
    |
 LL |         asm!("", in("vs0") v32x4); // requires vsx
    |                  ^^^^^^^^^^^^^^^
 
 error: register class `vsreg` requires the `vsx` target feature
-  --> $DIR/bad-reg.rs:99:18
+  --> $DIR/bad-reg.rs:98:18
    |
 LL |         asm!("", out("vs0") v32x4); // requires vsx
    |                  ^^^^^^^^^^^^^^^^
 
 error: register class `vsreg` requires the `vsx` target feature
-  --> $DIR/bad-reg.rs:101:18
+  --> $DIR/bad-reg.rs:100:18
    |
 LL |         asm!("", in("vs0") v64x2); // requires vsx
    |                  ^^^^^^^^^^^^^^^
 
 error: register class `vsreg` requires the `vsx` target feature
-  --> $DIR/bad-reg.rs:103:18
+  --> $DIR/bad-reg.rs:102:18
    |
 LL |         asm!("", out("vs0") v64x2); // requires vsx
    |                  ^^^^^^^^^^^^^^^^
 
 error: register class `vsreg` requires the `vsx` target feature
-  --> $DIR/bad-reg.rs:105:18
+  --> $DIR/bad-reg.rs:104:18
    |
 LL |         asm!("", in("vs0") x); // FIXME: should be ok if vsx is available
    |                  ^^^^^^^^^^^
 
 error: register class `vsreg` requires the `vsx` target feature
-  --> $DIR/bad-reg.rs:108:18
+  --> $DIR/bad-reg.rs:107:18
    |
 LL |         asm!("", out("vs0") x); // FIXME: should be ok if vsx is available
    |                  ^^^^^^^^^^^^
 
 error: register class `vsreg` requires the `vsx` target feature
-  --> $DIR/bad-reg.rs:111:26
+  --> $DIR/bad-reg.rs:110:26
    |
 LL |         asm!("/* {} */", in(vsreg) v32x4); // requires vsx
    |                          ^^^^^^^^^^^^^^^
 
 error: register class `vsreg` requires the `vsx` target feature
-  --> $DIR/bad-reg.rs:113:26
+  --> $DIR/bad-reg.rs:112:26
    |
 LL |         asm!("/* {} */", in(vsreg) v64x2); // requires vsx
    |                          ^^^^^^^^^^^^^^^
 
 error: register class `vsreg` requires the `vsx` target feature
-  --> $DIR/bad-reg.rs:115:26
+  --> $DIR/bad-reg.rs:114:26
    |
 LL |         asm!("/* {} */", in(vsreg) x); // FIXME: should be ok if vsx is available
    |                          ^^^^^^^^^^^
 
 error: register class `vsreg` requires the `vsx` target feature
-  --> $DIR/bad-reg.rs:118:26
+  --> $DIR/bad-reg.rs:117:26
    |
 LL |         asm!("/* {} */", out(vsreg) _); // requires vsx
    |                          ^^^^^^^^^^^^
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:138:27
+  --> $DIR/bad-reg.rs:137:27
    |
 LL |         asm!("", in("cr") x);
    |                           ^
@@ -841,7 +841,7 @@ LL |         asm!("", in("cr") x);
    = note: register class `cr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:141:28
+  --> $DIR/bad-reg.rs:140:28
    |
 LL |         asm!("", out("cr") x);
    |                            ^
@@ -849,7 +849,7 @@ LL |         asm!("", out("cr") x);
    = note: register class `cr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:144:33
+  --> $DIR/bad-reg.rs:143:33
    |
 LL |         asm!("/* {} */", in(cr) x);
    |                                 ^
@@ -857,7 +857,7 @@ LL |         asm!("/* {} */", in(cr) x);
    = note: register class `cr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:151:28
+  --> $DIR/bad-reg.rs:150:28
    |
 LL |         asm!("", in("ctr") x);
    |                            ^
@@ -865,7 +865,7 @@ LL |         asm!("", in("ctr") x);
    = note: register class `ctr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:154:29
+  --> $DIR/bad-reg.rs:153:29
    |
 LL |         asm!("", out("ctr") x);
    |                             ^
@@ -873,7 +873,7 @@ LL |         asm!("", out("ctr") x);
    = note: register class `ctr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:157:34
+  --> $DIR/bad-reg.rs:156:34
    |
 LL |         asm!("/* {} */", in(ctr) x);
    |                                  ^
@@ -881,7 +881,7 @@ LL |         asm!("/* {} */", in(ctr) x);
    = note: register class `ctr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:164:27
+  --> $DIR/bad-reg.rs:163:27
    |
 LL |         asm!("", in("lr") x);
    |                           ^
@@ -889,7 +889,7 @@ LL |         asm!("", in("lr") x);
    = note: register class `lr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:167:28
+  --> $DIR/bad-reg.rs:166:28
    |
 LL |         asm!("", out("lr") x);
    |                            ^
@@ -897,7 +897,7 @@ LL |         asm!("", out("lr") x);
    = note: register class `lr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:170:33
+  --> $DIR/bad-reg.rs:169:33
    |
 LL |         asm!("/* {} */", in(lr) x);
    |                                 ^
@@ -905,7 +905,7 @@ LL |         asm!("/* {} */", in(lr) x);
    = note: register class `lr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:177:28
+  --> $DIR/bad-reg.rs:176:28
    |
 LL |         asm!("", in("xer") x);
    |                            ^
@@ -913,7 +913,7 @@ LL |         asm!("", in("xer") x);
    = note: register class `xer` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:180:29
+  --> $DIR/bad-reg.rs:179:29
    |
 LL |         asm!("", out("xer") x);
    |                             ^
@@ -921,7 +921,7 @@ LL |         asm!("", out("xer") x);
    = note: register class `xer` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:183:34
+  --> $DIR/bad-reg.rs:182:34
    |
 LL |         asm!("/* {} */", in(xer) x);
    |                                  ^

--- a/tests/ui/asm/powerpc/bad-reg.powerpc64.stderr
+++ b/tests/ui/asm/powerpc/bad-reg.powerpc64.stderr
@@ -1,137 +1,137 @@
 error: invalid register `sp`: the stack pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:37:18
+  --> $DIR/bad-reg.rs:36:18
    |
 LL |         asm!("", out("sp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `r2`: r2 is a system reserved register and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:39:18
+  --> $DIR/bad-reg.rs:38:18
    |
 LL |         asm!("", out("r2") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `r29`: r29 is used internally by LLVM and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:43:18
+  --> $DIR/bad-reg.rs:42:18
    |
 LL |         asm!("", out("r29") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `r30`: r30 is used internally by LLVM and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:45:18
+  --> $DIR/bad-reg.rs:44:18
    |
 LL |         asm!("", out("r30") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `fp`: the frame pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:47:18
+  --> $DIR/bad-reg.rs:46:18
    |
 LL |         asm!("", out("fp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `vrsave`: the vrsave register cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:49:18
+  --> $DIR/bad-reg.rs:48:18
    |
 LL |         asm!("", out("vrsave") _);
    |                  ^^^^^^^^^^^^^^^
 
 error: register class `cr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:138:18
+  --> $DIR/bad-reg.rs:137:18
    |
 LL |         asm!("", in("cr") x);
    |                  ^^^^^^^^^^
 
 error: register class `cr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:141:18
+  --> $DIR/bad-reg.rs:140:18
    |
 LL |         asm!("", out("cr") x);
    |                  ^^^^^^^^^^^
 
 error: register class `cr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:144:26
+  --> $DIR/bad-reg.rs:143:26
    |
 LL |         asm!("/* {} */", in(cr) x);
    |                          ^^^^^^^^
 
 error: register class `cr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:147:26
+  --> $DIR/bad-reg.rs:146:26
    |
 LL |         asm!("/* {} */", out(cr) _);
    |                          ^^^^^^^^^
 
 error: register class `ctr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:151:18
+  --> $DIR/bad-reg.rs:150:18
    |
 LL |         asm!("", in("ctr") x);
    |                  ^^^^^^^^^^^
 
 error: register class `ctr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:154:18
+  --> $DIR/bad-reg.rs:153:18
    |
 LL |         asm!("", out("ctr") x);
    |                  ^^^^^^^^^^^^
 
 error: register class `ctr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:157:26
+  --> $DIR/bad-reg.rs:156:26
    |
 LL |         asm!("/* {} */", in(ctr) x);
    |                          ^^^^^^^^^
 
 error: register class `ctr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:160:26
+  --> $DIR/bad-reg.rs:159:26
    |
 LL |         asm!("/* {} */", out(ctr) _);
    |                          ^^^^^^^^^^
 
 error: register class `lr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:164:18
+  --> $DIR/bad-reg.rs:163:18
    |
 LL |         asm!("", in("lr") x);
    |                  ^^^^^^^^^^
 
 error: register class `lr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:167:18
+  --> $DIR/bad-reg.rs:166:18
    |
 LL |         asm!("", out("lr") x);
    |                  ^^^^^^^^^^^
 
 error: register class `lr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:170:26
+  --> $DIR/bad-reg.rs:169:26
    |
 LL |         asm!("/* {} */", in(lr) x);
    |                          ^^^^^^^^
 
 error: register class `lr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:173:26
+  --> $DIR/bad-reg.rs:172:26
    |
 LL |         asm!("/* {} */", out(lr) _);
    |                          ^^^^^^^^^
 
 error: register class `xer` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:177:18
+  --> $DIR/bad-reg.rs:176:18
    |
 LL |         asm!("", in("xer") x);
    |                  ^^^^^^^^^^^
 
 error: register class `xer` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:180:18
+  --> $DIR/bad-reg.rs:179:18
    |
 LL |         asm!("", out("xer") x);
    |                  ^^^^^^^^^^^^
 
 error: register class `xer` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:183:26
+  --> $DIR/bad-reg.rs:182:26
    |
 LL |         asm!("/* {} */", in(xer) x);
    |                          ^^^^^^^^^
 
 error: register class `xer` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:186:26
+  --> $DIR/bad-reg.rs:185:26
    |
 LL |         asm!("/* {} */", out(xer) _);
    |                          ^^^^^^^^^^
 
 error: register `cr0` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:190:31
+  --> $DIR/bad-reg.rs:189:31
    |
 LL |         asm!("", out("cr") _, out("cr0") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr0`
@@ -139,7 +139,7 @@ LL |         asm!("", out("cr") _, out("cr0") _);
    |                  register `cr`
 
 error: register `cr1` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:192:31
+  --> $DIR/bad-reg.rs:191:31
    |
 LL |         asm!("", out("cr") _, out("cr1") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr1`
@@ -147,7 +147,7 @@ LL |         asm!("", out("cr") _, out("cr1") _);
    |                  register `cr`
 
 error: register `cr2` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:194:31
+  --> $DIR/bad-reg.rs:193:31
    |
 LL |         asm!("", out("cr") _, out("cr2") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr2`
@@ -155,7 +155,7 @@ LL |         asm!("", out("cr") _, out("cr2") _);
    |                  register `cr`
 
 error: register `cr3` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:196:31
+  --> $DIR/bad-reg.rs:195:31
    |
 LL |         asm!("", out("cr") _, out("cr3") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr3`
@@ -163,7 +163,7 @@ LL |         asm!("", out("cr") _, out("cr3") _);
    |                  register `cr`
 
 error: register `cr4` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:198:31
+  --> $DIR/bad-reg.rs:197:31
    |
 LL |         asm!("", out("cr") _, out("cr4") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr4`
@@ -171,7 +171,7 @@ LL |         asm!("", out("cr") _, out("cr4") _);
    |                  register `cr`
 
 error: register `cr5` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:200:31
+  --> $DIR/bad-reg.rs:199:31
    |
 LL |         asm!("", out("cr") _, out("cr5") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr5`
@@ -179,7 +179,7 @@ LL |         asm!("", out("cr") _, out("cr5") _);
    |                  register `cr`
 
 error: register `cr6` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:202:31
+  --> $DIR/bad-reg.rs:201:31
    |
 LL |         asm!("", out("cr") _, out("cr6") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr6`
@@ -187,7 +187,7 @@ LL |         asm!("", out("cr") _, out("cr6") _);
    |                  register `cr`
 
 error: register `cr7` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:204:31
+  --> $DIR/bad-reg.rs:203:31
    |
 LL |         asm!("", out("cr") _, out("cr7") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr7`
@@ -195,7 +195,7 @@ LL |         asm!("", out("cr") _, out("cr7") _);
    |                  register `cr`
 
 error: register `vs0` conflicts with register `f0`
-  --> $DIR/bad-reg.rs:207:31
+  --> $DIR/bad-reg.rs:206:31
    |
 LL |         asm!("", out("f0") _, out("vs0") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs0`
@@ -203,7 +203,7 @@ LL |         asm!("", out("f0") _, out("vs0") _);
    |                  register `f0`
 
 error: register `vs1` conflicts with register `f1`
-  --> $DIR/bad-reg.rs:209:31
+  --> $DIR/bad-reg.rs:208:31
    |
 LL |         asm!("", out("f1") _, out("vs1") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs1`
@@ -211,7 +211,7 @@ LL |         asm!("", out("f1") _, out("vs1") _);
    |                  register `f1`
 
 error: register `vs2` conflicts with register `f2`
-  --> $DIR/bad-reg.rs:211:31
+  --> $DIR/bad-reg.rs:210:31
    |
 LL |         asm!("", out("f2") _, out("vs2") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs2`
@@ -219,7 +219,7 @@ LL |         asm!("", out("f2") _, out("vs2") _);
    |                  register `f2`
 
 error: register `vs3` conflicts with register `f3`
-  --> $DIR/bad-reg.rs:213:31
+  --> $DIR/bad-reg.rs:212:31
    |
 LL |         asm!("", out("f3") _, out("vs3") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs3`
@@ -227,7 +227,7 @@ LL |         asm!("", out("f3") _, out("vs3") _);
    |                  register `f3`
 
 error: register `vs4` conflicts with register `f4`
-  --> $DIR/bad-reg.rs:215:31
+  --> $DIR/bad-reg.rs:214:31
    |
 LL |         asm!("", out("f4") _, out("vs4") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs4`
@@ -235,7 +235,7 @@ LL |         asm!("", out("f4") _, out("vs4") _);
    |                  register `f4`
 
 error: register `vs5` conflicts with register `f5`
-  --> $DIR/bad-reg.rs:217:31
+  --> $DIR/bad-reg.rs:216:31
    |
 LL |         asm!("", out("f5") _, out("vs5") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs5`
@@ -243,7 +243,7 @@ LL |         asm!("", out("f5") _, out("vs5") _);
    |                  register `f5`
 
 error: register `vs6` conflicts with register `f6`
-  --> $DIR/bad-reg.rs:219:31
+  --> $DIR/bad-reg.rs:218:31
    |
 LL |         asm!("", out("f6") _, out("vs6") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs6`
@@ -251,7 +251,7 @@ LL |         asm!("", out("f6") _, out("vs6") _);
    |                  register `f6`
 
 error: register `vs7` conflicts with register `f7`
-  --> $DIR/bad-reg.rs:221:31
+  --> $DIR/bad-reg.rs:220:31
    |
 LL |         asm!("", out("f7") _, out("vs7") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs7`
@@ -259,7 +259,7 @@ LL |         asm!("", out("f7") _, out("vs7") _);
    |                  register `f7`
 
 error: register `vs8` conflicts with register `f8`
-  --> $DIR/bad-reg.rs:223:31
+  --> $DIR/bad-reg.rs:222:31
    |
 LL |         asm!("", out("f8") _, out("vs8") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs8`
@@ -267,7 +267,7 @@ LL |         asm!("", out("f8") _, out("vs8") _);
    |                  register `f8`
 
 error: register `vs9` conflicts with register `f9`
-  --> $DIR/bad-reg.rs:225:31
+  --> $DIR/bad-reg.rs:224:31
    |
 LL |         asm!("", out("f9") _, out("vs9") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs9`
@@ -275,7 +275,7 @@ LL |         asm!("", out("f9") _, out("vs9") _);
    |                  register `f9`
 
 error: register `vs10` conflicts with register `f10`
-  --> $DIR/bad-reg.rs:227:32
+  --> $DIR/bad-reg.rs:226:32
    |
 LL |         asm!("", out("f10") _, out("vs10") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs10`
@@ -283,7 +283,7 @@ LL |         asm!("", out("f10") _, out("vs10") _);
    |                  register `f10`
 
 error: register `vs11` conflicts with register `f11`
-  --> $DIR/bad-reg.rs:229:32
+  --> $DIR/bad-reg.rs:228:32
    |
 LL |         asm!("", out("f11") _, out("vs11") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs11`
@@ -291,7 +291,7 @@ LL |         asm!("", out("f11") _, out("vs11") _);
    |                  register `f11`
 
 error: register `vs12` conflicts with register `f12`
-  --> $DIR/bad-reg.rs:231:32
+  --> $DIR/bad-reg.rs:230:32
    |
 LL |         asm!("", out("f12") _, out("vs12") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs12`
@@ -299,7 +299,7 @@ LL |         asm!("", out("f12") _, out("vs12") _);
    |                  register `f12`
 
 error: register `vs13` conflicts with register `f13`
-  --> $DIR/bad-reg.rs:233:32
+  --> $DIR/bad-reg.rs:232:32
    |
 LL |         asm!("", out("f13") _, out("vs13") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs13`
@@ -307,7 +307,7 @@ LL |         asm!("", out("f13") _, out("vs13") _);
    |                  register `f13`
 
 error: register `vs14` conflicts with register `f14`
-  --> $DIR/bad-reg.rs:235:32
+  --> $DIR/bad-reg.rs:234:32
    |
 LL |         asm!("", out("f14") _, out("vs14") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs14`
@@ -315,7 +315,7 @@ LL |         asm!("", out("f14") _, out("vs14") _);
    |                  register `f14`
 
 error: register `vs15` conflicts with register `f15`
-  --> $DIR/bad-reg.rs:237:32
+  --> $DIR/bad-reg.rs:236:32
    |
 LL |         asm!("", out("f15") _, out("vs15") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs15`
@@ -323,7 +323,7 @@ LL |         asm!("", out("f15") _, out("vs15") _);
    |                  register `f15`
 
 error: register `vs16` conflicts with register `f16`
-  --> $DIR/bad-reg.rs:239:32
+  --> $DIR/bad-reg.rs:238:32
    |
 LL |         asm!("", out("f16") _, out("vs16") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs16`
@@ -331,7 +331,7 @@ LL |         asm!("", out("f16") _, out("vs16") _);
    |                  register `f16`
 
 error: register `vs17` conflicts with register `f17`
-  --> $DIR/bad-reg.rs:241:32
+  --> $DIR/bad-reg.rs:240:32
    |
 LL |         asm!("", out("f17") _, out("vs17") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs17`
@@ -339,7 +339,7 @@ LL |         asm!("", out("f17") _, out("vs17") _);
    |                  register `f17`
 
 error: register `vs18` conflicts with register `f18`
-  --> $DIR/bad-reg.rs:243:32
+  --> $DIR/bad-reg.rs:242:32
    |
 LL |         asm!("", out("f18") _, out("vs18") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs18`
@@ -347,7 +347,7 @@ LL |         asm!("", out("f18") _, out("vs18") _);
    |                  register `f18`
 
 error: register `vs19` conflicts with register `f19`
-  --> $DIR/bad-reg.rs:245:32
+  --> $DIR/bad-reg.rs:244:32
    |
 LL |         asm!("", out("f19") _, out("vs19") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs19`
@@ -355,7 +355,7 @@ LL |         asm!("", out("f19") _, out("vs19") _);
    |                  register `f19`
 
 error: register `vs20` conflicts with register `f20`
-  --> $DIR/bad-reg.rs:247:32
+  --> $DIR/bad-reg.rs:246:32
    |
 LL |         asm!("", out("f20") _, out("vs20") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs20`
@@ -363,7 +363,7 @@ LL |         asm!("", out("f20") _, out("vs20") _);
    |                  register `f20`
 
 error: register `vs21` conflicts with register `f21`
-  --> $DIR/bad-reg.rs:249:32
+  --> $DIR/bad-reg.rs:248:32
    |
 LL |         asm!("", out("f21") _, out("vs21") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs21`
@@ -371,7 +371,7 @@ LL |         asm!("", out("f21") _, out("vs21") _);
    |                  register `f21`
 
 error: register `vs22` conflicts with register `f22`
-  --> $DIR/bad-reg.rs:251:32
+  --> $DIR/bad-reg.rs:250:32
    |
 LL |         asm!("", out("f22") _, out("vs22") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs22`
@@ -379,7 +379,7 @@ LL |         asm!("", out("f22") _, out("vs22") _);
    |                  register `f22`
 
 error: register `vs23` conflicts with register `f23`
-  --> $DIR/bad-reg.rs:253:32
+  --> $DIR/bad-reg.rs:252:32
    |
 LL |         asm!("", out("f23") _, out("vs23") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs23`
@@ -387,7 +387,7 @@ LL |         asm!("", out("f23") _, out("vs23") _);
    |                  register `f23`
 
 error: register `vs24` conflicts with register `f24`
-  --> $DIR/bad-reg.rs:255:32
+  --> $DIR/bad-reg.rs:254:32
    |
 LL |         asm!("", out("f24") _, out("vs24") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs24`
@@ -395,7 +395,7 @@ LL |         asm!("", out("f24") _, out("vs24") _);
    |                  register `f24`
 
 error: register `vs25` conflicts with register `f25`
-  --> $DIR/bad-reg.rs:257:32
+  --> $DIR/bad-reg.rs:256:32
    |
 LL |         asm!("", out("f25") _, out("vs25") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs25`
@@ -403,7 +403,7 @@ LL |         asm!("", out("f25") _, out("vs25") _);
    |                  register `f25`
 
 error: register `vs26` conflicts with register `f26`
-  --> $DIR/bad-reg.rs:259:32
+  --> $DIR/bad-reg.rs:258:32
    |
 LL |         asm!("", out("f26") _, out("vs26") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs26`
@@ -411,7 +411,7 @@ LL |         asm!("", out("f26") _, out("vs26") _);
    |                  register `f26`
 
 error: register `vs27` conflicts with register `f27`
-  --> $DIR/bad-reg.rs:261:32
+  --> $DIR/bad-reg.rs:260:32
    |
 LL |         asm!("", out("f27") _, out("vs27") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs27`
@@ -419,7 +419,7 @@ LL |         asm!("", out("f27") _, out("vs27") _);
    |                  register `f27`
 
 error: register `vs28` conflicts with register `f28`
-  --> $DIR/bad-reg.rs:263:32
+  --> $DIR/bad-reg.rs:262:32
    |
 LL |         asm!("", out("f28") _, out("vs28") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs28`
@@ -427,7 +427,7 @@ LL |         asm!("", out("f28") _, out("vs28") _);
    |                  register `f28`
 
 error: register `vs29` conflicts with register `f29`
-  --> $DIR/bad-reg.rs:265:32
+  --> $DIR/bad-reg.rs:264:32
    |
 LL |         asm!("", out("f29") _, out("vs29") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs29`
@@ -435,7 +435,7 @@ LL |         asm!("", out("f29") _, out("vs29") _);
    |                  register `f29`
 
 error: register `vs30` conflicts with register `f30`
-  --> $DIR/bad-reg.rs:267:32
+  --> $DIR/bad-reg.rs:266:32
    |
 LL |         asm!("", out("f30") _, out("vs30") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs30`
@@ -443,7 +443,7 @@ LL |         asm!("", out("f30") _, out("vs30") _);
    |                  register `f30`
 
 error: register `vs31` conflicts with register `f31`
-  --> $DIR/bad-reg.rs:269:32
+  --> $DIR/bad-reg.rs:268:32
    |
 LL |         asm!("", out("f31") _, out("vs31") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs31`
@@ -451,7 +451,7 @@ LL |         asm!("", out("f31") _, out("vs31") _);
    |                  register `f31`
 
 error: register `v0` conflicts with register `vs32`
-  --> $DIR/bad-reg.rs:271:33
+  --> $DIR/bad-reg.rs:270:33
    |
 LL |         asm!("", out("vs32") _, out("v0") _);
    |                  -------------  ^^^^^^^^^^^ register `v0`
@@ -459,7 +459,7 @@ LL |         asm!("", out("vs32") _, out("v0") _);
    |                  register `vs32`
 
 error: register `v1` conflicts with register `vs33`
-  --> $DIR/bad-reg.rs:273:33
+  --> $DIR/bad-reg.rs:272:33
    |
 LL |         asm!("", out("vs33") _, out("v1") _);
    |                  -------------  ^^^^^^^^^^^ register `v1`
@@ -467,7 +467,7 @@ LL |         asm!("", out("vs33") _, out("v1") _);
    |                  register `vs33`
 
 error: register `v2` conflicts with register `vs34`
-  --> $DIR/bad-reg.rs:275:33
+  --> $DIR/bad-reg.rs:274:33
    |
 LL |         asm!("", out("vs34") _, out("v2") _);
    |                  -------------  ^^^^^^^^^^^ register `v2`
@@ -475,7 +475,7 @@ LL |         asm!("", out("vs34") _, out("v2") _);
    |                  register `vs34`
 
 error: register `v3` conflicts with register `vs35`
-  --> $DIR/bad-reg.rs:277:33
+  --> $DIR/bad-reg.rs:276:33
    |
 LL |         asm!("", out("vs35") _, out("v3") _);
    |                  -------------  ^^^^^^^^^^^ register `v3`
@@ -483,7 +483,7 @@ LL |         asm!("", out("vs35") _, out("v3") _);
    |                  register `vs35`
 
 error: register `v4` conflicts with register `vs36`
-  --> $DIR/bad-reg.rs:279:33
+  --> $DIR/bad-reg.rs:278:33
    |
 LL |         asm!("", out("vs36") _, out("v4") _);
    |                  -------------  ^^^^^^^^^^^ register `v4`
@@ -491,7 +491,7 @@ LL |         asm!("", out("vs36") _, out("v4") _);
    |                  register `vs36`
 
 error: register `v5` conflicts with register `vs37`
-  --> $DIR/bad-reg.rs:281:33
+  --> $DIR/bad-reg.rs:280:33
    |
 LL |         asm!("", out("vs37") _, out("v5") _);
    |                  -------------  ^^^^^^^^^^^ register `v5`
@@ -499,7 +499,7 @@ LL |         asm!("", out("vs37") _, out("v5") _);
    |                  register `vs37`
 
 error: register `v6` conflicts with register `vs38`
-  --> $DIR/bad-reg.rs:283:33
+  --> $DIR/bad-reg.rs:282:33
    |
 LL |         asm!("", out("vs38") _, out("v6") _);
    |                  -------------  ^^^^^^^^^^^ register `v6`
@@ -507,7 +507,7 @@ LL |         asm!("", out("vs38") _, out("v6") _);
    |                  register `vs38`
 
 error: register `v7` conflicts with register `vs39`
-  --> $DIR/bad-reg.rs:285:33
+  --> $DIR/bad-reg.rs:284:33
    |
 LL |         asm!("", out("vs39") _, out("v7") _);
    |                  -------------  ^^^^^^^^^^^ register `v7`
@@ -515,7 +515,7 @@ LL |         asm!("", out("vs39") _, out("v7") _);
    |                  register `vs39`
 
 error: register `v8` conflicts with register `vs40`
-  --> $DIR/bad-reg.rs:287:33
+  --> $DIR/bad-reg.rs:286:33
    |
 LL |         asm!("", out("vs40") _, out("v8") _);
    |                  -------------  ^^^^^^^^^^^ register `v8`
@@ -523,7 +523,7 @@ LL |         asm!("", out("vs40") _, out("v8") _);
    |                  register `vs40`
 
 error: register `v9` conflicts with register `vs41`
-  --> $DIR/bad-reg.rs:289:33
+  --> $DIR/bad-reg.rs:288:33
    |
 LL |         asm!("", out("vs41") _, out("v9") _);
    |                  -------------  ^^^^^^^^^^^ register `v9`
@@ -531,7 +531,7 @@ LL |         asm!("", out("vs41") _, out("v9") _);
    |                  register `vs41`
 
 error: register `v10` conflicts with register `vs42`
-  --> $DIR/bad-reg.rs:291:33
+  --> $DIR/bad-reg.rs:290:33
    |
 LL |         asm!("", out("vs42") _, out("v10") _);
    |                  -------------  ^^^^^^^^^^^^ register `v10`
@@ -539,7 +539,7 @@ LL |         asm!("", out("vs42") _, out("v10") _);
    |                  register `vs42`
 
 error: register `v11` conflicts with register `vs43`
-  --> $DIR/bad-reg.rs:293:33
+  --> $DIR/bad-reg.rs:292:33
    |
 LL |         asm!("", out("vs43") _, out("v11") _);
    |                  -------------  ^^^^^^^^^^^^ register `v11`
@@ -547,7 +547,7 @@ LL |         asm!("", out("vs43") _, out("v11") _);
    |                  register `vs43`
 
 error: register `v12` conflicts with register `vs44`
-  --> $DIR/bad-reg.rs:295:33
+  --> $DIR/bad-reg.rs:294:33
    |
 LL |         asm!("", out("vs44") _, out("v12") _);
    |                  -------------  ^^^^^^^^^^^^ register `v12`
@@ -555,7 +555,7 @@ LL |         asm!("", out("vs44") _, out("v12") _);
    |                  register `vs44`
 
 error: register `v13` conflicts with register `vs45`
-  --> $DIR/bad-reg.rs:297:33
+  --> $DIR/bad-reg.rs:296:33
    |
 LL |         asm!("", out("vs45") _, out("v13") _);
    |                  -------------  ^^^^^^^^^^^^ register `v13`
@@ -563,7 +563,7 @@ LL |         asm!("", out("vs45") _, out("v13") _);
    |                  register `vs45`
 
 error: register `v14` conflicts with register `vs46`
-  --> $DIR/bad-reg.rs:299:33
+  --> $DIR/bad-reg.rs:298:33
    |
 LL |         asm!("", out("vs46") _, out("v14") _);
    |                  -------------  ^^^^^^^^^^^^ register `v14`
@@ -571,7 +571,7 @@ LL |         asm!("", out("vs46") _, out("v14") _);
    |                  register `vs46`
 
 error: register `v15` conflicts with register `vs47`
-  --> $DIR/bad-reg.rs:301:33
+  --> $DIR/bad-reg.rs:300:33
    |
 LL |         asm!("", out("vs47") _, out("v15") _);
    |                  -------------  ^^^^^^^^^^^^ register `v15`
@@ -579,7 +579,7 @@ LL |         asm!("", out("vs47") _, out("v15") _);
    |                  register `vs47`
 
 error: register `v16` conflicts with register `vs48`
-  --> $DIR/bad-reg.rs:303:33
+  --> $DIR/bad-reg.rs:302:33
    |
 LL |         asm!("", out("vs48") _, out("v16") _);
    |                  -------------  ^^^^^^^^^^^^ register `v16`
@@ -587,7 +587,7 @@ LL |         asm!("", out("vs48") _, out("v16") _);
    |                  register `vs48`
 
 error: register `v17` conflicts with register `vs49`
-  --> $DIR/bad-reg.rs:305:33
+  --> $DIR/bad-reg.rs:304:33
    |
 LL |         asm!("", out("vs49") _, out("v17") _);
    |                  -------------  ^^^^^^^^^^^^ register `v17`
@@ -595,7 +595,7 @@ LL |         asm!("", out("vs49") _, out("v17") _);
    |                  register `vs49`
 
 error: register `v18` conflicts with register `vs50`
-  --> $DIR/bad-reg.rs:307:33
+  --> $DIR/bad-reg.rs:306:33
    |
 LL |         asm!("", out("vs50") _, out("v18") _);
    |                  -------------  ^^^^^^^^^^^^ register `v18`
@@ -603,7 +603,7 @@ LL |         asm!("", out("vs50") _, out("v18") _);
    |                  register `vs50`
 
 error: register `v19` conflicts with register `vs51`
-  --> $DIR/bad-reg.rs:309:33
+  --> $DIR/bad-reg.rs:308:33
    |
 LL |         asm!("", out("vs51") _, out("v19") _);
    |                  -------------  ^^^^^^^^^^^^ register `v19`
@@ -611,7 +611,7 @@ LL |         asm!("", out("vs51") _, out("v19") _);
    |                  register `vs51`
 
 error: register `v20` conflicts with register `vs52`
-  --> $DIR/bad-reg.rs:311:33
+  --> $DIR/bad-reg.rs:310:33
    |
 LL |         asm!("", out("vs52") _, out("v20") _);
    |                  -------------  ^^^^^^^^^^^^ register `v20`
@@ -619,7 +619,7 @@ LL |         asm!("", out("vs52") _, out("v20") _);
    |                  register `vs52`
 
 error: register `v21` conflicts with register `vs53`
-  --> $DIR/bad-reg.rs:313:33
+  --> $DIR/bad-reg.rs:312:33
    |
 LL |         asm!("", out("vs53") _, out("v21") _);
    |                  -------------  ^^^^^^^^^^^^ register `v21`
@@ -627,7 +627,7 @@ LL |         asm!("", out("vs53") _, out("v21") _);
    |                  register `vs53`
 
 error: register `v22` conflicts with register `vs54`
-  --> $DIR/bad-reg.rs:315:33
+  --> $DIR/bad-reg.rs:314:33
    |
 LL |         asm!("", out("vs54") _, out("v22") _);
    |                  -------------  ^^^^^^^^^^^^ register `v22`
@@ -635,7 +635,7 @@ LL |         asm!("", out("vs54") _, out("v22") _);
    |                  register `vs54`
 
 error: register `v23` conflicts with register `vs55`
-  --> $DIR/bad-reg.rs:317:33
+  --> $DIR/bad-reg.rs:316:33
    |
 LL |         asm!("", out("vs55") _, out("v23") _);
    |                  -------------  ^^^^^^^^^^^^ register `v23`
@@ -643,7 +643,7 @@ LL |         asm!("", out("vs55") _, out("v23") _);
    |                  register `vs55`
 
 error: register `v24` conflicts with register `vs56`
-  --> $DIR/bad-reg.rs:319:33
+  --> $DIR/bad-reg.rs:318:33
    |
 LL |         asm!("", out("vs56") _, out("v24") _);
    |                  -------------  ^^^^^^^^^^^^ register `v24`
@@ -651,7 +651,7 @@ LL |         asm!("", out("vs56") _, out("v24") _);
    |                  register `vs56`
 
 error: register `v25` conflicts with register `vs57`
-  --> $DIR/bad-reg.rs:321:33
+  --> $DIR/bad-reg.rs:320:33
    |
 LL |         asm!("", out("vs57") _, out("v25") _);
    |                  -------------  ^^^^^^^^^^^^ register `v25`
@@ -659,7 +659,7 @@ LL |         asm!("", out("vs57") _, out("v25") _);
    |                  register `vs57`
 
 error: register `v26` conflicts with register `vs58`
-  --> $DIR/bad-reg.rs:323:33
+  --> $DIR/bad-reg.rs:322:33
    |
 LL |         asm!("", out("vs58") _, out("v26") _);
    |                  -------------  ^^^^^^^^^^^^ register `v26`
@@ -667,7 +667,7 @@ LL |         asm!("", out("vs58") _, out("v26") _);
    |                  register `vs58`
 
 error: register `v27` conflicts with register `vs59`
-  --> $DIR/bad-reg.rs:325:33
+  --> $DIR/bad-reg.rs:324:33
    |
 LL |         asm!("", out("vs59") _, out("v27") _);
    |                  -------------  ^^^^^^^^^^^^ register `v27`
@@ -675,7 +675,7 @@ LL |         asm!("", out("vs59") _, out("v27") _);
    |                  register `vs59`
 
 error: register `v28` conflicts with register `vs60`
-  --> $DIR/bad-reg.rs:327:33
+  --> $DIR/bad-reg.rs:326:33
    |
 LL |         asm!("", out("vs60") _, out("v28") _);
    |                  -------------  ^^^^^^^^^^^^ register `v28`
@@ -683,7 +683,7 @@ LL |         asm!("", out("vs60") _, out("v28") _);
    |                  register `vs60`
 
 error: register `v29` conflicts with register `vs61`
-  --> $DIR/bad-reg.rs:329:33
+  --> $DIR/bad-reg.rs:328:33
    |
 LL |         asm!("", out("vs61") _, out("v29") _);
    |                  -------------  ^^^^^^^^^^^^ register `v29`
@@ -691,7 +691,7 @@ LL |         asm!("", out("vs61") _, out("v29") _);
    |                  register `vs61`
 
 error: register `v30` conflicts with register `vs62`
-  --> $DIR/bad-reg.rs:331:33
+  --> $DIR/bad-reg.rs:330:33
    |
 LL |         asm!("", out("vs62") _, out("v30") _);
    |                  -------------  ^^^^^^^^^^^^ register `v30`
@@ -699,7 +699,7 @@ LL |         asm!("", out("vs62") _, out("v30") _);
    |                  register `vs62`
 
 error: register `v31` conflicts with register `vs63`
-  --> $DIR/bad-reg.rs:333:33
+  --> $DIR/bad-reg.rs:332:33
    |
 LL |         asm!("", out("vs63") _, out("v31") _);
    |                  -------------  ^^^^^^^^^^^^ register `v31`
@@ -707,13 +707,13 @@ LL |         asm!("", out("vs63") _, out("v31") _);
    |                  register `vs63`
 
 error: cannot use register `r13`: r13 is a reserved register on this target
-  --> $DIR/bad-reg.rs:41:18
+  --> $DIR/bad-reg.rs:40:18
    |
 LL |         asm!("", out("r13") _);
    |                  ^^^^^^^^^^^^
 
 error: `vsx` target feature is not enabled
-  --> $DIR/bad-reg.rs:58:27
+  --> $DIR/bad-reg.rs:57:27
    |
 LL |         asm!("", in("v0") v64x2); // requires vsx
    |                           ^^^^^
@@ -721,7 +721,7 @@ LL |         asm!("", in("v0") v64x2); // requires vsx
    = note: this is required to use type `i64x2` with register class `vreg`
 
 error: `vsx` target feature is not enabled
-  --> $DIR/bad-reg.rs:61:28
+  --> $DIR/bad-reg.rs:60:28
    |
 LL |         asm!("", out("v0") v64x2); // requires vsx
    |                            ^^^^^
@@ -729,7 +729,7 @@ LL |         asm!("", out("v0") v64x2); // requires vsx
    = note: this is required to use type `i64x2` with register class `vreg`
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:64:27
+  --> $DIR/bad-reg.rs:63:27
    |
 LL |         asm!("", in("v0") x); // FIXME: should be ok if vsx is available
    |                           ^
@@ -737,7 +737,7 @@ LL |         asm!("", in("v0") x); // FIXME: should be ok if vsx is available
    = note: register class `vreg` supports these types: i8x16, i16x8, i32x4, f32x4, f32, f64, i64x2, f64x2
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:67:28
+  --> $DIR/bad-reg.rs:66:28
    |
 LL |         asm!("", out("v0") x); // FIXME: should be ok if vsx is available
    |                            ^
@@ -745,7 +745,7 @@ LL |         asm!("", out("v0") x); // FIXME: should be ok if vsx is available
    = note: register class `vreg` supports these types: i8x16, i16x8, i32x4, f32x4, f32, f64, i64x2, f64x2
 
 error: `vsx` target feature is not enabled
-  --> $DIR/bad-reg.rs:72:35
+  --> $DIR/bad-reg.rs:71:35
    |
 LL |         asm!("/* {} */", in(vreg) v64x2); // requires vsx
    |                                   ^^^^^
@@ -753,7 +753,7 @@ LL |         asm!("/* {} */", in(vreg) v64x2); // requires vsx
    = note: this is required to use type `i64x2` with register class `vreg`
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:75:35
+  --> $DIR/bad-reg.rs:74:35
    |
 LL |         asm!("/* {} */", in(vreg) x); // FIXME: should be ok if vsx is available
    |                                   ^
@@ -761,67 +761,67 @@ LL |         asm!("/* {} */", in(vreg) x); // FIXME: should be ok if vsx is avai
    = note: register class `vreg` supports these types: i8x16, i16x8, i32x4, f32x4, f32, f64, i64x2, f64x2
 
 error: register class `vsreg` requires the `vsx` target feature
-  --> $DIR/bad-reg.rs:97:18
+  --> $DIR/bad-reg.rs:96:18
    |
 LL |         asm!("", in("vs0") v32x4); // requires vsx
    |                  ^^^^^^^^^^^^^^^
 
 error: register class `vsreg` requires the `vsx` target feature
-  --> $DIR/bad-reg.rs:99:18
+  --> $DIR/bad-reg.rs:98:18
    |
 LL |         asm!("", out("vs0") v32x4); // requires vsx
    |                  ^^^^^^^^^^^^^^^^
 
 error: register class `vsreg` requires the `vsx` target feature
-  --> $DIR/bad-reg.rs:101:18
+  --> $DIR/bad-reg.rs:100:18
    |
 LL |         asm!("", in("vs0") v64x2); // requires vsx
    |                  ^^^^^^^^^^^^^^^
 
 error: register class `vsreg` requires the `vsx` target feature
-  --> $DIR/bad-reg.rs:103:18
+  --> $DIR/bad-reg.rs:102:18
    |
 LL |         asm!("", out("vs0") v64x2); // requires vsx
    |                  ^^^^^^^^^^^^^^^^
 
 error: register class `vsreg` requires the `vsx` target feature
-  --> $DIR/bad-reg.rs:105:18
+  --> $DIR/bad-reg.rs:104:18
    |
 LL |         asm!("", in("vs0") x); // FIXME: should be ok if vsx is available
    |                  ^^^^^^^^^^^
 
 error: register class `vsreg` requires the `vsx` target feature
-  --> $DIR/bad-reg.rs:108:18
+  --> $DIR/bad-reg.rs:107:18
    |
 LL |         asm!("", out("vs0") x); // FIXME: should be ok if vsx is available
    |                  ^^^^^^^^^^^^
 
 error: register class `vsreg` requires the `vsx` target feature
-  --> $DIR/bad-reg.rs:111:26
+  --> $DIR/bad-reg.rs:110:26
    |
 LL |         asm!("/* {} */", in(vsreg) v32x4); // requires vsx
    |                          ^^^^^^^^^^^^^^^
 
 error: register class `vsreg` requires the `vsx` target feature
-  --> $DIR/bad-reg.rs:113:26
+  --> $DIR/bad-reg.rs:112:26
    |
 LL |         asm!("/* {} */", in(vsreg) v64x2); // requires vsx
    |                          ^^^^^^^^^^^^^^^
 
 error: register class `vsreg` requires the `vsx` target feature
-  --> $DIR/bad-reg.rs:115:26
+  --> $DIR/bad-reg.rs:114:26
    |
 LL |         asm!("/* {} */", in(vsreg) x); // FIXME: should be ok if vsx is available
    |                          ^^^^^^^^^^^
 
 error: register class `vsreg` requires the `vsx` target feature
-  --> $DIR/bad-reg.rs:118:26
+  --> $DIR/bad-reg.rs:117:26
    |
 LL |         asm!("/* {} */", out(vsreg) _); // requires vsx
    |                          ^^^^^^^^^^^^
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:138:27
+  --> $DIR/bad-reg.rs:137:27
    |
 LL |         asm!("", in("cr") x);
    |                           ^
@@ -829,7 +829,7 @@ LL |         asm!("", in("cr") x);
    = note: register class `cr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:141:28
+  --> $DIR/bad-reg.rs:140:28
    |
 LL |         asm!("", out("cr") x);
    |                            ^
@@ -837,7 +837,7 @@ LL |         asm!("", out("cr") x);
    = note: register class `cr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:144:33
+  --> $DIR/bad-reg.rs:143:33
    |
 LL |         asm!("/* {} */", in(cr) x);
    |                                 ^
@@ -845,7 +845,7 @@ LL |         asm!("/* {} */", in(cr) x);
    = note: register class `cr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:151:28
+  --> $DIR/bad-reg.rs:150:28
    |
 LL |         asm!("", in("ctr") x);
    |                            ^
@@ -853,7 +853,7 @@ LL |         asm!("", in("ctr") x);
    = note: register class `ctr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:154:29
+  --> $DIR/bad-reg.rs:153:29
    |
 LL |         asm!("", out("ctr") x);
    |                             ^
@@ -861,7 +861,7 @@ LL |         asm!("", out("ctr") x);
    = note: register class `ctr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:157:34
+  --> $DIR/bad-reg.rs:156:34
    |
 LL |         asm!("/* {} */", in(ctr) x);
    |                                  ^
@@ -869,7 +869,7 @@ LL |         asm!("/* {} */", in(ctr) x);
    = note: register class `ctr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:164:27
+  --> $DIR/bad-reg.rs:163:27
    |
 LL |         asm!("", in("lr") x);
    |                           ^
@@ -877,7 +877,7 @@ LL |         asm!("", in("lr") x);
    = note: register class `lr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:167:28
+  --> $DIR/bad-reg.rs:166:28
    |
 LL |         asm!("", out("lr") x);
    |                            ^
@@ -885,7 +885,7 @@ LL |         asm!("", out("lr") x);
    = note: register class `lr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:170:33
+  --> $DIR/bad-reg.rs:169:33
    |
 LL |         asm!("/* {} */", in(lr) x);
    |                                 ^
@@ -893,7 +893,7 @@ LL |         asm!("/* {} */", in(lr) x);
    = note: register class `lr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:177:28
+  --> $DIR/bad-reg.rs:176:28
    |
 LL |         asm!("", in("xer") x);
    |                            ^
@@ -901,7 +901,7 @@ LL |         asm!("", in("xer") x);
    = note: register class `xer` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:180:29
+  --> $DIR/bad-reg.rs:179:29
    |
 LL |         asm!("", out("xer") x);
    |                             ^
@@ -909,7 +909,7 @@ LL |         asm!("", out("xer") x);
    = note: register class `xer` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:183:34
+  --> $DIR/bad-reg.rs:182:34
    |
 LL |         asm!("/* {} */", in(xer) x);
    |                                  ^

--- a/tests/ui/asm/powerpc/bad-reg.powerpc64le.stderr
+++ b/tests/ui/asm/powerpc/bad-reg.powerpc64le.stderr
@@ -1,137 +1,137 @@
 error: invalid register `sp`: the stack pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:37:18
+  --> $DIR/bad-reg.rs:36:18
    |
 LL |         asm!("", out("sp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `r2`: r2 is a system reserved register and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:39:18
+  --> $DIR/bad-reg.rs:38:18
    |
 LL |         asm!("", out("r2") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `r29`: r29 is used internally by LLVM and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:43:18
+  --> $DIR/bad-reg.rs:42:18
    |
 LL |         asm!("", out("r29") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `r30`: r30 is used internally by LLVM and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:45:18
+  --> $DIR/bad-reg.rs:44:18
    |
 LL |         asm!("", out("r30") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `fp`: the frame pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:47:18
+  --> $DIR/bad-reg.rs:46:18
    |
 LL |         asm!("", out("fp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `vrsave`: the vrsave register cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:49:18
+  --> $DIR/bad-reg.rs:48:18
    |
 LL |         asm!("", out("vrsave") _);
    |                  ^^^^^^^^^^^^^^^
 
 error: register class `cr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:138:18
+  --> $DIR/bad-reg.rs:137:18
    |
 LL |         asm!("", in("cr") x);
    |                  ^^^^^^^^^^
 
 error: register class `cr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:141:18
+  --> $DIR/bad-reg.rs:140:18
    |
 LL |         asm!("", out("cr") x);
    |                  ^^^^^^^^^^^
 
 error: register class `cr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:144:26
+  --> $DIR/bad-reg.rs:143:26
    |
 LL |         asm!("/* {} */", in(cr) x);
    |                          ^^^^^^^^
 
 error: register class `cr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:147:26
+  --> $DIR/bad-reg.rs:146:26
    |
 LL |         asm!("/* {} */", out(cr) _);
    |                          ^^^^^^^^^
 
 error: register class `ctr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:151:18
+  --> $DIR/bad-reg.rs:150:18
    |
 LL |         asm!("", in("ctr") x);
    |                  ^^^^^^^^^^^
 
 error: register class `ctr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:154:18
+  --> $DIR/bad-reg.rs:153:18
    |
 LL |         asm!("", out("ctr") x);
    |                  ^^^^^^^^^^^^
 
 error: register class `ctr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:157:26
+  --> $DIR/bad-reg.rs:156:26
    |
 LL |         asm!("/* {} */", in(ctr) x);
    |                          ^^^^^^^^^
 
 error: register class `ctr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:160:26
+  --> $DIR/bad-reg.rs:159:26
    |
 LL |         asm!("/* {} */", out(ctr) _);
    |                          ^^^^^^^^^^
 
 error: register class `lr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:164:18
+  --> $DIR/bad-reg.rs:163:18
    |
 LL |         asm!("", in("lr") x);
    |                  ^^^^^^^^^^
 
 error: register class `lr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:167:18
+  --> $DIR/bad-reg.rs:166:18
    |
 LL |         asm!("", out("lr") x);
    |                  ^^^^^^^^^^^
 
 error: register class `lr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:170:26
+  --> $DIR/bad-reg.rs:169:26
    |
 LL |         asm!("/* {} */", in(lr) x);
    |                          ^^^^^^^^
 
 error: register class `lr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:173:26
+  --> $DIR/bad-reg.rs:172:26
    |
 LL |         asm!("/* {} */", out(lr) _);
    |                          ^^^^^^^^^
 
 error: register class `xer` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:177:18
+  --> $DIR/bad-reg.rs:176:18
    |
 LL |         asm!("", in("xer") x);
    |                  ^^^^^^^^^^^
 
 error: register class `xer` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:180:18
+  --> $DIR/bad-reg.rs:179:18
    |
 LL |         asm!("", out("xer") x);
    |                  ^^^^^^^^^^^^
 
 error: register class `xer` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:183:26
+  --> $DIR/bad-reg.rs:182:26
    |
 LL |         asm!("/* {} */", in(xer) x);
    |                          ^^^^^^^^^
 
 error: register class `xer` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:186:26
+  --> $DIR/bad-reg.rs:185:26
    |
 LL |         asm!("/* {} */", out(xer) _);
    |                          ^^^^^^^^^^
 
 error: register `cr0` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:190:31
+  --> $DIR/bad-reg.rs:189:31
    |
 LL |         asm!("", out("cr") _, out("cr0") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr0`
@@ -139,7 +139,7 @@ LL |         asm!("", out("cr") _, out("cr0") _);
    |                  register `cr`
 
 error: register `cr1` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:192:31
+  --> $DIR/bad-reg.rs:191:31
    |
 LL |         asm!("", out("cr") _, out("cr1") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr1`
@@ -147,7 +147,7 @@ LL |         asm!("", out("cr") _, out("cr1") _);
    |                  register `cr`
 
 error: register `cr2` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:194:31
+  --> $DIR/bad-reg.rs:193:31
    |
 LL |         asm!("", out("cr") _, out("cr2") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr2`
@@ -155,7 +155,7 @@ LL |         asm!("", out("cr") _, out("cr2") _);
    |                  register `cr`
 
 error: register `cr3` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:196:31
+  --> $DIR/bad-reg.rs:195:31
    |
 LL |         asm!("", out("cr") _, out("cr3") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr3`
@@ -163,7 +163,7 @@ LL |         asm!("", out("cr") _, out("cr3") _);
    |                  register `cr`
 
 error: register `cr4` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:198:31
+  --> $DIR/bad-reg.rs:197:31
    |
 LL |         asm!("", out("cr") _, out("cr4") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr4`
@@ -171,7 +171,7 @@ LL |         asm!("", out("cr") _, out("cr4") _);
    |                  register `cr`
 
 error: register `cr5` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:200:31
+  --> $DIR/bad-reg.rs:199:31
    |
 LL |         asm!("", out("cr") _, out("cr5") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr5`
@@ -179,7 +179,7 @@ LL |         asm!("", out("cr") _, out("cr5") _);
    |                  register `cr`
 
 error: register `cr6` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:202:31
+  --> $DIR/bad-reg.rs:201:31
    |
 LL |         asm!("", out("cr") _, out("cr6") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr6`
@@ -187,7 +187,7 @@ LL |         asm!("", out("cr") _, out("cr6") _);
    |                  register `cr`
 
 error: register `cr7` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:204:31
+  --> $DIR/bad-reg.rs:203:31
    |
 LL |         asm!("", out("cr") _, out("cr7") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr7`
@@ -195,7 +195,7 @@ LL |         asm!("", out("cr") _, out("cr7") _);
    |                  register `cr`
 
 error: register `vs0` conflicts with register `f0`
-  --> $DIR/bad-reg.rs:207:31
+  --> $DIR/bad-reg.rs:206:31
    |
 LL |         asm!("", out("f0") _, out("vs0") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs0`
@@ -203,7 +203,7 @@ LL |         asm!("", out("f0") _, out("vs0") _);
    |                  register `f0`
 
 error: register `vs1` conflicts with register `f1`
-  --> $DIR/bad-reg.rs:209:31
+  --> $DIR/bad-reg.rs:208:31
    |
 LL |         asm!("", out("f1") _, out("vs1") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs1`
@@ -211,7 +211,7 @@ LL |         asm!("", out("f1") _, out("vs1") _);
    |                  register `f1`
 
 error: register `vs2` conflicts with register `f2`
-  --> $DIR/bad-reg.rs:211:31
+  --> $DIR/bad-reg.rs:210:31
    |
 LL |         asm!("", out("f2") _, out("vs2") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs2`
@@ -219,7 +219,7 @@ LL |         asm!("", out("f2") _, out("vs2") _);
    |                  register `f2`
 
 error: register `vs3` conflicts with register `f3`
-  --> $DIR/bad-reg.rs:213:31
+  --> $DIR/bad-reg.rs:212:31
    |
 LL |         asm!("", out("f3") _, out("vs3") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs3`
@@ -227,7 +227,7 @@ LL |         asm!("", out("f3") _, out("vs3") _);
    |                  register `f3`
 
 error: register `vs4` conflicts with register `f4`
-  --> $DIR/bad-reg.rs:215:31
+  --> $DIR/bad-reg.rs:214:31
    |
 LL |         asm!("", out("f4") _, out("vs4") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs4`
@@ -235,7 +235,7 @@ LL |         asm!("", out("f4") _, out("vs4") _);
    |                  register `f4`
 
 error: register `vs5` conflicts with register `f5`
-  --> $DIR/bad-reg.rs:217:31
+  --> $DIR/bad-reg.rs:216:31
    |
 LL |         asm!("", out("f5") _, out("vs5") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs5`
@@ -243,7 +243,7 @@ LL |         asm!("", out("f5") _, out("vs5") _);
    |                  register `f5`
 
 error: register `vs6` conflicts with register `f6`
-  --> $DIR/bad-reg.rs:219:31
+  --> $DIR/bad-reg.rs:218:31
    |
 LL |         asm!("", out("f6") _, out("vs6") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs6`
@@ -251,7 +251,7 @@ LL |         asm!("", out("f6") _, out("vs6") _);
    |                  register `f6`
 
 error: register `vs7` conflicts with register `f7`
-  --> $DIR/bad-reg.rs:221:31
+  --> $DIR/bad-reg.rs:220:31
    |
 LL |         asm!("", out("f7") _, out("vs7") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs7`
@@ -259,7 +259,7 @@ LL |         asm!("", out("f7") _, out("vs7") _);
    |                  register `f7`
 
 error: register `vs8` conflicts with register `f8`
-  --> $DIR/bad-reg.rs:223:31
+  --> $DIR/bad-reg.rs:222:31
    |
 LL |         asm!("", out("f8") _, out("vs8") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs8`
@@ -267,7 +267,7 @@ LL |         asm!("", out("f8") _, out("vs8") _);
    |                  register `f8`
 
 error: register `vs9` conflicts with register `f9`
-  --> $DIR/bad-reg.rs:225:31
+  --> $DIR/bad-reg.rs:224:31
    |
 LL |         asm!("", out("f9") _, out("vs9") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs9`
@@ -275,7 +275,7 @@ LL |         asm!("", out("f9") _, out("vs9") _);
    |                  register `f9`
 
 error: register `vs10` conflicts with register `f10`
-  --> $DIR/bad-reg.rs:227:32
+  --> $DIR/bad-reg.rs:226:32
    |
 LL |         asm!("", out("f10") _, out("vs10") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs10`
@@ -283,7 +283,7 @@ LL |         asm!("", out("f10") _, out("vs10") _);
    |                  register `f10`
 
 error: register `vs11` conflicts with register `f11`
-  --> $DIR/bad-reg.rs:229:32
+  --> $DIR/bad-reg.rs:228:32
    |
 LL |         asm!("", out("f11") _, out("vs11") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs11`
@@ -291,7 +291,7 @@ LL |         asm!("", out("f11") _, out("vs11") _);
    |                  register `f11`
 
 error: register `vs12` conflicts with register `f12`
-  --> $DIR/bad-reg.rs:231:32
+  --> $DIR/bad-reg.rs:230:32
    |
 LL |         asm!("", out("f12") _, out("vs12") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs12`
@@ -299,7 +299,7 @@ LL |         asm!("", out("f12") _, out("vs12") _);
    |                  register `f12`
 
 error: register `vs13` conflicts with register `f13`
-  --> $DIR/bad-reg.rs:233:32
+  --> $DIR/bad-reg.rs:232:32
    |
 LL |         asm!("", out("f13") _, out("vs13") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs13`
@@ -307,7 +307,7 @@ LL |         asm!("", out("f13") _, out("vs13") _);
    |                  register `f13`
 
 error: register `vs14` conflicts with register `f14`
-  --> $DIR/bad-reg.rs:235:32
+  --> $DIR/bad-reg.rs:234:32
    |
 LL |         asm!("", out("f14") _, out("vs14") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs14`
@@ -315,7 +315,7 @@ LL |         asm!("", out("f14") _, out("vs14") _);
    |                  register `f14`
 
 error: register `vs15` conflicts with register `f15`
-  --> $DIR/bad-reg.rs:237:32
+  --> $DIR/bad-reg.rs:236:32
    |
 LL |         asm!("", out("f15") _, out("vs15") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs15`
@@ -323,7 +323,7 @@ LL |         asm!("", out("f15") _, out("vs15") _);
    |                  register `f15`
 
 error: register `vs16` conflicts with register `f16`
-  --> $DIR/bad-reg.rs:239:32
+  --> $DIR/bad-reg.rs:238:32
    |
 LL |         asm!("", out("f16") _, out("vs16") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs16`
@@ -331,7 +331,7 @@ LL |         asm!("", out("f16") _, out("vs16") _);
    |                  register `f16`
 
 error: register `vs17` conflicts with register `f17`
-  --> $DIR/bad-reg.rs:241:32
+  --> $DIR/bad-reg.rs:240:32
    |
 LL |         asm!("", out("f17") _, out("vs17") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs17`
@@ -339,7 +339,7 @@ LL |         asm!("", out("f17") _, out("vs17") _);
    |                  register `f17`
 
 error: register `vs18` conflicts with register `f18`
-  --> $DIR/bad-reg.rs:243:32
+  --> $DIR/bad-reg.rs:242:32
    |
 LL |         asm!("", out("f18") _, out("vs18") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs18`
@@ -347,7 +347,7 @@ LL |         asm!("", out("f18") _, out("vs18") _);
    |                  register `f18`
 
 error: register `vs19` conflicts with register `f19`
-  --> $DIR/bad-reg.rs:245:32
+  --> $DIR/bad-reg.rs:244:32
    |
 LL |         asm!("", out("f19") _, out("vs19") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs19`
@@ -355,7 +355,7 @@ LL |         asm!("", out("f19") _, out("vs19") _);
    |                  register `f19`
 
 error: register `vs20` conflicts with register `f20`
-  --> $DIR/bad-reg.rs:247:32
+  --> $DIR/bad-reg.rs:246:32
    |
 LL |         asm!("", out("f20") _, out("vs20") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs20`
@@ -363,7 +363,7 @@ LL |         asm!("", out("f20") _, out("vs20") _);
    |                  register `f20`
 
 error: register `vs21` conflicts with register `f21`
-  --> $DIR/bad-reg.rs:249:32
+  --> $DIR/bad-reg.rs:248:32
    |
 LL |         asm!("", out("f21") _, out("vs21") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs21`
@@ -371,7 +371,7 @@ LL |         asm!("", out("f21") _, out("vs21") _);
    |                  register `f21`
 
 error: register `vs22` conflicts with register `f22`
-  --> $DIR/bad-reg.rs:251:32
+  --> $DIR/bad-reg.rs:250:32
    |
 LL |         asm!("", out("f22") _, out("vs22") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs22`
@@ -379,7 +379,7 @@ LL |         asm!("", out("f22") _, out("vs22") _);
    |                  register `f22`
 
 error: register `vs23` conflicts with register `f23`
-  --> $DIR/bad-reg.rs:253:32
+  --> $DIR/bad-reg.rs:252:32
    |
 LL |         asm!("", out("f23") _, out("vs23") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs23`
@@ -387,7 +387,7 @@ LL |         asm!("", out("f23") _, out("vs23") _);
    |                  register `f23`
 
 error: register `vs24` conflicts with register `f24`
-  --> $DIR/bad-reg.rs:255:32
+  --> $DIR/bad-reg.rs:254:32
    |
 LL |         asm!("", out("f24") _, out("vs24") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs24`
@@ -395,7 +395,7 @@ LL |         asm!("", out("f24") _, out("vs24") _);
    |                  register `f24`
 
 error: register `vs25` conflicts with register `f25`
-  --> $DIR/bad-reg.rs:257:32
+  --> $DIR/bad-reg.rs:256:32
    |
 LL |         asm!("", out("f25") _, out("vs25") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs25`
@@ -403,7 +403,7 @@ LL |         asm!("", out("f25") _, out("vs25") _);
    |                  register `f25`
 
 error: register `vs26` conflicts with register `f26`
-  --> $DIR/bad-reg.rs:259:32
+  --> $DIR/bad-reg.rs:258:32
    |
 LL |         asm!("", out("f26") _, out("vs26") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs26`
@@ -411,7 +411,7 @@ LL |         asm!("", out("f26") _, out("vs26") _);
    |                  register `f26`
 
 error: register `vs27` conflicts with register `f27`
-  --> $DIR/bad-reg.rs:261:32
+  --> $DIR/bad-reg.rs:260:32
    |
 LL |         asm!("", out("f27") _, out("vs27") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs27`
@@ -419,7 +419,7 @@ LL |         asm!("", out("f27") _, out("vs27") _);
    |                  register `f27`
 
 error: register `vs28` conflicts with register `f28`
-  --> $DIR/bad-reg.rs:263:32
+  --> $DIR/bad-reg.rs:262:32
    |
 LL |         asm!("", out("f28") _, out("vs28") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs28`
@@ -427,7 +427,7 @@ LL |         asm!("", out("f28") _, out("vs28") _);
    |                  register `f28`
 
 error: register `vs29` conflicts with register `f29`
-  --> $DIR/bad-reg.rs:265:32
+  --> $DIR/bad-reg.rs:264:32
    |
 LL |         asm!("", out("f29") _, out("vs29") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs29`
@@ -435,7 +435,7 @@ LL |         asm!("", out("f29") _, out("vs29") _);
    |                  register `f29`
 
 error: register `vs30` conflicts with register `f30`
-  --> $DIR/bad-reg.rs:267:32
+  --> $DIR/bad-reg.rs:266:32
    |
 LL |         asm!("", out("f30") _, out("vs30") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs30`
@@ -443,7 +443,7 @@ LL |         asm!("", out("f30") _, out("vs30") _);
    |                  register `f30`
 
 error: register `vs31` conflicts with register `f31`
-  --> $DIR/bad-reg.rs:269:32
+  --> $DIR/bad-reg.rs:268:32
    |
 LL |         asm!("", out("f31") _, out("vs31") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs31`
@@ -451,7 +451,7 @@ LL |         asm!("", out("f31") _, out("vs31") _);
    |                  register `f31`
 
 error: register `v0` conflicts with register `vs32`
-  --> $DIR/bad-reg.rs:271:33
+  --> $DIR/bad-reg.rs:270:33
    |
 LL |         asm!("", out("vs32") _, out("v0") _);
    |                  -------------  ^^^^^^^^^^^ register `v0`
@@ -459,7 +459,7 @@ LL |         asm!("", out("vs32") _, out("v0") _);
    |                  register `vs32`
 
 error: register `v1` conflicts with register `vs33`
-  --> $DIR/bad-reg.rs:273:33
+  --> $DIR/bad-reg.rs:272:33
    |
 LL |         asm!("", out("vs33") _, out("v1") _);
    |                  -------------  ^^^^^^^^^^^ register `v1`
@@ -467,7 +467,7 @@ LL |         asm!("", out("vs33") _, out("v1") _);
    |                  register `vs33`
 
 error: register `v2` conflicts with register `vs34`
-  --> $DIR/bad-reg.rs:275:33
+  --> $DIR/bad-reg.rs:274:33
    |
 LL |         asm!("", out("vs34") _, out("v2") _);
    |                  -------------  ^^^^^^^^^^^ register `v2`
@@ -475,7 +475,7 @@ LL |         asm!("", out("vs34") _, out("v2") _);
    |                  register `vs34`
 
 error: register `v3` conflicts with register `vs35`
-  --> $DIR/bad-reg.rs:277:33
+  --> $DIR/bad-reg.rs:276:33
    |
 LL |         asm!("", out("vs35") _, out("v3") _);
    |                  -------------  ^^^^^^^^^^^ register `v3`
@@ -483,7 +483,7 @@ LL |         asm!("", out("vs35") _, out("v3") _);
    |                  register `vs35`
 
 error: register `v4` conflicts with register `vs36`
-  --> $DIR/bad-reg.rs:279:33
+  --> $DIR/bad-reg.rs:278:33
    |
 LL |         asm!("", out("vs36") _, out("v4") _);
    |                  -------------  ^^^^^^^^^^^ register `v4`
@@ -491,7 +491,7 @@ LL |         asm!("", out("vs36") _, out("v4") _);
    |                  register `vs36`
 
 error: register `v5` conflicts with register `vs37`
-  --> $DIR/bad-reg.rs:281:33
+  --> $DIR/bad-reg.rs:280:33
    |
 LL |         asm!("", out("vs37") _, out("v5") _);
    |                  -------------  ^^^^^^^^^^^ register `v5`
@@ -499,7 +499,7 @@ LL |         asm!("", out("vs37") _, out("v5") _);
    |                  register `vs37`
 
 error: register `v6` conflicts with register `vs38`
-  --> $DIR/bad-reg.rs:283:33
+  --> $DIR/bad-reg.rs:282:33
    |
 LL |         asm!("", out("vs38") _, out("v6") _);
    |                  -------------  ^^^^^^^^^^^ register `v6`
@@ -507,7 +507,7 @@ LL |         asm!("", out("vs38") _, out("v6") _);
    |                  register `vs38`
 
 error: register `v7` conflicts with register `vs39`
-  --> $DIR/bad-reg.rs:285:33
+  --> $DIR/bad-reg.rs:284:33
    |
 LL |         asm!("", out("vs39") _, out("v7") _);
    |                  -------------  ^^^^^^^^^^^ register `v7`
@@ -515,7 +515,7 @@ LL |         asm!("", out("vs39") _, out("v7") _);
    |                  register `vs39`
 
 error: register `v8` conflicts with register `vs40`
-  --> $DIR/bad-reg.rs:287:33
+  --> $DIR/bad-reg.rs:286:33
    |
 LL |         asm!("", out("vs40") _, out("v8") _);
    |                  -------------  ^^^^^^^^^^^ register `v8`
@@ -523,7 +523,7 @@ LL |         asm!("", out("vs40") _, out("v8") _);
    |                  register `vs40`
 
 error: register `v9` conflicts with register `vs41`
-  --> $DIR/bad-reg.rs:289:33
+  --> $DIR/bad-reg.rs:288:33
    |
 LL |         asm!("", out("vs41") _, out("v9") _);
    |                  -------------  ^^^^^^^^^^^ register `v9`
@@ -531,7 +531,7 @@ LL |         asm!("", out("vs41") _, out("v9") _);
    |                  register `vs41`
 
 error: register `v10` conflicts with register `vs42`
-  --> $DIR/bad-reg.rs:291:33
+  --> $DIR/bad-reg.rs:290:33
    |
 LL |         asm!("", out("vs42") _, out("v10") _);
    |                  -------------  ^^^^^^^^^^^^ register `v10`
@@ -539,7 +539,7 @@ LL |         asm!("", out("vs42") _, out("v10") _);
    |                  register `vs42`
 
 error: register `v11` conflicts with register `vs43`
-  --> $DIR/bad-reg.rs:293:33
+  --> $DIR/bad-reg.rs:292:33
    |
 LL |         asm!("", out("vs43") _, out("v11") _);
    |                  -------------  ^^^^^^^^^^^^ register `v11`
@@ -547,7 +547,7 @@ LL |         asm!("", out("vs43") _, out("v11") _);
    |                  register `vs43`
 
 error: register `v12` conflicts with register `vs44`
-  --> $DIR/bad-reg.rs:295:33
+  --> $DIR/bad-reg.rs:294:33
    |
 LL |         asm!("", out("vs44") _, out("v12") _);
    |                  -------------  ^^^^^^^^^^^^ register `v12`
@@ -555,7 +555,7 @@ LL |         asm!("", out("vs44") _, out("v12") _);
    |                  register `vs44`
 
 error: register `v13` conflicts with register `vs45`
-  --> $DIR/bad-reg.rs:297:33
+  --> $DIR/bad-reg.rs:296:33
    |
 LL |         asm!("", out("vs45") _, out("v13") _);
    |                  -------------  ^^^^^^^^^^^^ register `v13`
@@ -563,7 +563,7 @@ LL |         asm!("", out("vs45") _, out("v13") _);
    |                  register `vs45`
 
 error: register `v14` conflicts with register `vs46`
-  --> $DIR/bad-reg.rs:299:33
+  --> $DIR/bad-reg.rs:298:33
    |
 LL |         asm!("", out("vs46") _, out("v14") _);
    |                  -------------  ^^^^^^^^^^^^ register `v14`
@@ -571,7 +571,7 @@ LL |         asm!("", out("vs46") _, out("v14") _);
    |                  register `vs46`
 
 error: register `v15` conflicts with register `vs47`
-  --> $DIR/bad-reg.rs:301:33
+  --> $DIR/bad-reg.rs:300:33
    |
 LL |         asm!("", out("vs47") _, out("v15") _);
    |                  -------------  ^^^^^^^^^^^^ register `v15`
@@ -579,7 +579,7 @@ LL |         asm!("", out("vs47") _, out("v15") _);
    |                  register `vs47`
 
 error: register `v16` conflicts with register `vs48`
-  --> $DIR/bad-reg.rs:303:33
+  --> $DIR/bad-reg.rs:302:33
    |
 LL |         asm!("", out("vs48") _, out("v16") _);
    |                  -------------  ^^^^^^^^^^^^ register `v16`
@@ -587,7 +587,7 @@ LL |         asm!("", out("vs48") _, out("v16") _);
    |                  register `vs48`
 
 error: register `v17` conflicts with register `vs49`
-  --> $DIR/bad-reg.rs:305:33
+  --> $DIR/bad-reg.rs:304:33
    |
 LL |         asm!("", out("vs49") _, out("v17") _);
    |                  -------------  ^^^^^^^^^^^^ register `v17`
@@ -595,7 +595,7 @@ LL |         asm!("", out("vs49") _, out("v17") _);
    |                  register `vs49`
 
 error: register `v18` conflicts with register `vs50`
-  --> $DIR/bad-reg.rs:307:33
+  --> $DIR/bad-reg.rs:306:33
    |
 LL |         asm!("", out("vs50") _, out("v18") _);
    |                  -------------  ^^^^^^^^^^^^ register `v18`
@@ -603,7 +603,7 @@ LL |         asm!("", out("vs50") _, out("v18") _);
    |                  register `vs50`
 
 error: register `v19` conflicts with register `vs51`
-  --> $DIR/bad-reg.rs:309:33
+  --> $DIR/bad-reg.rs:308:33
    |
 LL |         asm!("", out("vs51") _, out("v19") _);
    |                  -------------  ^^^^^^^^^^^^ register `v19`
@@ -611,7 +611,7 @@ LL |         asm!("", out("vs51") _, out("v19") _);
    |                  register `vs51`
 
 error: register `v20` conflicts with register `vs52`
-  --> $DIR/bad-reg.rs:311:33
+  --> $DIR/bad-reg.rs:310:33
    |
 LL |         asm!("", out("vs52") _, out("v20") _);
    |                  -------------  ^^^^^^^^^^^^ register `v20`
@@ -619,7 +619,7 @@ LL |         asm!("", out("vs52") _, out("v20") _);
    |                  register `vs52`
 
 error: register `v21` conflicts with register `vs53`
-  --> $DIR/bad-reg.rs:313:33
+  --> $DIR/bad-reg.rs:312:33
    |
 LL |         asm!("", out("vs53") _, out("v21") _);
    |                  -------------  ^^^^^^^^^^^^ register `v21`
@@ -627,7 +627,7 @@ LL |         asm!("", out("vs53") _, out("v21") _);
    |                  register `vs53`
 
 error: register `v22` conflicts with register `vs54`
-  --> $DIR/bad-reg.rs:315:33
+  --> $DIR/bad-reg.rs:314:33
    |
 LL |         asm!("", out("vs54") _, out("v22") _);
    |                  -------------  ^^^^^^^^^^^^ register `v22`
@@ -635,7 +635,7 @@ LL |         asm!("", out("vs54") _, out("v22") _);
    |                  register `vs54`
 
 error: register `v23` conflicts with register `vs55`
-  --> $DIR/bad-reg.rs:317:33
+  --> $DIR/bad-reg.rs:316:33
    |
 LL |         asm!("", out("vs55") _, out("v23") _);
    |                  -------------  ^^^^^^^^^^^^ register `v23`
@@ -643,7 +643,7 @@ LL |         asm!("", out("vs55") _, out("v23") _);
    |                  register `vs55`
 
 error: register `v24` conflicts with register `vs56`
-  --> $DIR/bad-reg.rs:319:33
+  --> $DIR/bad-reg.rs:318:33
    |
 LL |         asm!("", out("vs56") _, out("v24") _);
    |                  -------------  ^^^^^^^^^^^^ register `v24`
@@ -651,7 +651,7 @@ LL |         asm!("", out("vs56") _, out("v24") _);
    |                  register `vs56`
 
 error: register `v25` conflicts with register `vs57`
-  --> $DIR/bad-reg.rs:321:33
+  --> $DIR/bad-reg.rs:320:33
    |
 LL |         asm!("", out("vs57") _, out("v25") _);
    |                  -------------  ^^^^^^^^^^^^ register `v25`
@@ -659,7 +659,7 @@ LL |         asm!("", out("vs57") _, out("v25") _);
    |                  register `vs57`
 
 error: register `v26` conflicts with register `vs58`
-  --> $DIR/bad-reg.rs:323:33
+  --> $DIR/bad-reg.rs:322:33
    |
 LL |         asm!("", out("vs58") _, out("v26") _);
    |                  -------------  ^^^^^^^^^^^^ register `v26`
@@ -667,7 +667,7 @@ LL |         asm!("", out("vs58") _, out("v26") _);
    |                  register `vs58`
 
 error: register `v27` conflicts with register `vs59`
-  --> $DIR/bad-reg.rs:325:33
+  --> $DIR/bad-reg.rs:324:33
    |
 LL |         asm!("", out("vs59") _, out("v27") _);
    |                  -------------  ^^^^^^^^^^^^ register `v27`
@@ -675,7 +675,7 @@ LL |         asm!("", out("vs59") _, out("v27") _);
    |                  register `vs59`
 
 error: register `v28` conflicts with register `vs60`
-  --> $DIR/bad-reg.rs:327:33
+  --> $DIR/bad-reg.rs:326:33
    |
 LL |         asm!("", out("vs60") _, out("v28") _);
    |                  -------------  ^^^^^^^^^^^^ register `v28`
@@ -683,7 +683,7 @@ LL |         asm!("", out("vs60") _, out("v28") _);
    |                  register `vs60`
 
 error: register `v29` conflicts with register `vs61`
-  --> $DIR/bad-reg.rs:329:33
+  --> $DIR/bad-reg.rs:328:33
    |
 LL |         asm!("", out("vs61") _, out("v29") _);
    |                  -------------  ^^^^^^^^^^^^ register `v29`
@@ -691,7 +691,7 @@ LL |         asm!("", out("vs61") _, out("v29") _);
    |                  register `vs61`
 
 error: register `v30` conflicts with register `vs62`
-  --> $DIR/bad-reg.rs:331:33
+  --> $DIR/bad-reg.rs:330:33
    |
 LL |         asm!("", out("vs62") _, out("v30") _);
    |                  -------------  ^^^^^^^^^^^^ register `v30`
@@ -699,7 +699,7 @@ LL |         asm!("", out("vs62") _, out("v30") _);
    |                  register `vs62`
 
 error: register `v31` conflicts with register `vs63`
-  --> $DIR/bad-reg.rs:333:33
+  --> $DIR/bad-reg.rs:332:33
    |
 LL |         asm!("", out("vs63") _, out("v31") _);
    |                  -------------  ^^^^^^^^^^^^ register `v31`
@@ -707,13 +707,13 @@ LL |         asm!("", out("vs63") _, out("v31") _);
    |                  register `vs63`
 
 error: cannot use register `r13`: r13 is a reserved register on this target
-  --> $DIR/bad-reg.rs:41:18
+  --> $DIR/bad-reg.rs:40:18
    |
 LL |         asm!("", out("r13") _);
    |                  ^^^^^^^^^^^^
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:64:27
+  --> $DIR/bad-reg.rs:63:27
    |
 LL |         asm!("", in("v0") x); // FIXME: should be ok if vsx is available
    |                           ^
@@ -721,7 +721,7 @@ LL |         asm!("", in("v0") x); // FIXME: should be ok if vsx is available
    = note: register class `vreg` supports these types: i8x16, i16x8, i32x4, f32x4, f32, f64, i64x2, f64x2
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:67:28
+  --> $DIR/bad-reg.rs:66:28
    |
 LL |         asm!("", out("v0") x); // FIXME: should be ok if vsx is available
    |                            ^
@@ -729,7 +729,7 @@ LL |         asm!("", out("v0") x); // FIXME: should be ok if vsx is available
    = note: register class `vreg` supports these types: i8x16, i16x8, i32x4, f32x4, f32, f64, i64x2, f64x2
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:75:35
+  --> $DIR/bad-reg.rs:74:35
    |
 LL |         asm!("/* {} */", in(vreg) x); // FIXME: should be ok if vsx is available
    |                                   ^
@@ -737,7 +737,7 @@ LL |         asm!("/* {} */", in(vreg) x); // FIXME: should be ok if vsx is avai
    = note: register class `vreg` supports these types: i8x16, i16x8, i32x4, f32x4, f32, f64, i64x2, f64x2
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:105:28
+  --> $DIR/bad-reg.rs:104:28
    |
 LL |         asm!("", in("vs0") x); // FIXME: should be ok if vsx is available
    |                            ^
@@ -745,7 +745,7 @@ LL |         asm!("", in("vs0") x); // FIXME: should be ok if vsx is available
    = note: register class `vsreg` supports these types: f32, f64, i8x16, i16x8, i32x4, i64x2, f32x4, f64x2
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:108:29
+  --> $DIR/bad-reg.rs:107:29
    |
 LL |         asm!("", out("vs0") x); // FIXME: should be ok if vsx is available
    |                             ^
@@ -753,7 +753,7 @@ LL |         asm!("", out("vs0") x); // FIXME: should be ok if vsx is available
    = note: register class `vsreg` supports these types: f32, f64, i8x16, i16x8, i32x4, i64x2, f32x4, f64x2
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:115:36
+  --> $DIR/bad-reg.rs:114:36
    |
 LL |         asm!("/* {} */", in(vsreg) x); // FIXME: should be ok if vsx is available
    |                                    ^
@@ -761,7 +761,7 @@ LL |         asm!("/* {} */", in(vsreg) x); // FIXME: should be ok if vsx is ava
    = note: register class `vsreg` supports these types: f32, f64, i8x16, i16x8, i32x4, i64x2, f32x4, f64x2
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:138:27
+  --> $DIR/bad-reg.rs:137:27
    |
 LL |         asm!("", in("cr") x);
    |                           ^
@@ -769,7 +769,7 @@ LL |         asm!("", in("cr") x);
    = note: register class `cr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:141:28
+  --> $DIR/bad-reg.rs:140:28
    |
 LL |         asm!("", out("cr") x);
    |                            ^
@@ -777,7 +777,7 @@ LL |         asm!("", out("cr") x);
    = note: register class `cr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:144:33
+  --> $DIR/bad-reg.rs:143:33
    |
 LL |         asm!("/* {} */", in(cr) x);
    |                                 ^
@@ -785,7 +785,7 @@ LL |         asm!("/* {} */", in(cr) x);
    = note: register class `cr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:151:28
+  --> $DIR/bad-reg.rs:150:28
    |
 LL |         asm!("", in("ctr") x);
    |                            ^
@@ -793,7 +793,7 @@ LL |         asm!("", in("ctr") x);
    = note: register class `ctr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:154:29
+  --> $DIR/bad-reg.rs:153:29
    |
 LL |         asm!("", out("ctr") x);
    |                             ^
@@ -801,7 +801,7 @@ LL |         asm!("", out("ctr") x);
    = note: register class `ctr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:157:34
+  --> $DIR/bad-reg.rs:156:34
    |
 LL |         asm!("/* {} */", in(ctr) x);
    |                                  ^
@@ -809,7 +809,7 @@ LL |         asm!("/* {} */", in(ctr) x);
    = note: register class `ctr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:164:27
+  --> $DIR/bad-reg.rs:163:27
    |
 LL |         asm!("", in("lr") x);
    |                           ^
@@ -817,7 +817,7 @@ LL |         asm!("", in("lr") x);
    = note: register class `lr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:167:28
+  --> $DIR/bad-reg.rs:166:28
    |
 LL |         asm!("", out("lr") x);
    |                            ^
@@ -825,7 +825,7 @@ LL |         asm!("", out("lr") x);
    = note: register class `lr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:170:33
+  --> $DIR/bad-reg.rs:169:33
    |
 LL |         asm!("/* {} */", in(lr) x);
    |                                 ^
@@ -833,7 +833,7 @@ LL |         asm!("/* {} */", in(lr) x);
    = note: register class `lr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:177:28
+  --> $DIR/bad-reg.rs:176:28
    |
 LL |         asm!("", in("xer") x);
    |                            ^
@@ -841,7 +841,7 @@ LL |         asm!("", in("xer") x);
    = note: register class `xer` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:180:29
+  --> $DIR/bad-reg.rs:179:29
    |
 LL |         asm!("", out("xer") x);
    |                             ^
@@ -849,7 +849,7 @@ LL |         asm!("", out("xer") x);
    = note: register class `xer` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:183:34
+  --> $DIR/bad-reg.rs:182:34
    |
 LL |         asm!("/* {} */", in(xer) x);
    |                                  ^

--- a/tests/ui/asm/powerpc/bad-reg.rs
+++ b/tests/ui/asm/powerpc/bad-reg.rs
@@ -8,7 +8,6 @@
 //@[powerpc64le] needs-llvm-components: powerpc
 //@[aix64] compile-flags: --target powerpc64-ibm-aix
 //@[aix64] needs-llvm-components: powerpc
-//@ needs-asm-support
 //@ ignore-backends: gcc
 // ignore-tidy-linelength
 

--- a/tests/ui/asm/riscv/bad-reg.riscv32e.stderr
+++ b/tests/ui/asm/riscv/bad-reg.riscv32e.stderr
@@ -1,185 +1,185 @@
 error: invalid register `s1`: s1 is used internally by LLVM and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:34:18
+  --> $DIR/bad-reg.rs:33:18
    |
 LL |         asm!("", out("s1") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `fp`: the frame pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:36:18
+  --> $DIR/bad-reg.rs:35:18
    |
 LL |         asm!("", out("fp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `sp`: the stack pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:38:18
+  --> $DIR/bad-reg.rs:37:18
    |
 LL |         asm!("", out("sp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `gp`: the global pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:40:18
+  --> $DIR/bad-reg.rs:39:18
    |
 LL |         asm!("", out("gp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `tp`: the thread pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:42:18
+  --> $DIR/bad-reg.rs:41:18
    |
 LL |         asm!("", out("tp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `zero`: the zero register cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:44:18
+  --> $DIR/bad-reg.rs:43:18
    |
 LL |         asm!("", out("zero") _);
    |                  ^^^^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:95:18
+  --> $DIR/bad-reg.rs:94:18
    |
 LL |         asm!("", in("v0") x);
    |                  ^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:98:18
+  --> $DIR/bad-reg.rs:97:18
    |
 LL |         asm!("", out("v0") x);
    |                  ^^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:101:26
+  --> $DIR/bad-reg.rs:100:26
    |
 LL |         asm!("/* {} */", in(vreg) x);
    |                          ^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:104:26
+  --> $DIR/bad-reg.rs:103:26
    |
 LL |         asm!("/* {} */", out(vreg) _);
    |                          ^^^^^^^^^^^
 
 error: cannot use register `x16`: register can't be used with the `e` target feature
-  --> $DIR/bad-reg.rs:47:18
+  --> $DIR/bad-reg.rs:46:18
    |
 LL |         asm!("", out("x16") _);
    |                  ^^^^^^^^^^^^
 
 error: cannot use register `x17`: register can't be used with the `e` target feature
-  --> $DIR/bad-reg.rs:49:18
+  --> $DIR/bad-reg.rs:48:18
    |
 LL |         asm!("", out("x17") _);
    |                  ^^^^^^^^^^^^
 
 error: cannot use register `x18`: register can't be used with the `e` target feature
-  --> $DIR/bad-reg.rs:51:18
+  --> $DIR/bad-reg.rs:50:18
    |
 LL |         asm!("", out("x18") _);
    |                  ^^^^^^^^^^^^
 
 error: cannot use register `x19`: register can't be used with the `e` target feature
-  --> $DIR/bad-reg.rs:53:18
+  --> $DIR/bad-reg.rs:52:18
    |
 LL |         asm!("", out("x19") _);
    |                  ^^^^^^^^^^^^
 
 error: cannot use register `x20`: register can't be used with the `e` target feature
-  --> $DIR/bad-reg.rs:55:18
+  --> $DIR/bad-reg.rs:54:18
    |
 LL |         asm!("", out("x20") _);
    |                  ^^^^^^^^^^^^
 
 error: cannot use register `x21`: register can't be used with the `e` target feature
-  --> $DIR/bad-reg.rs:57:18
+  --> $DIR/bad-reg.rs:56:18
    |
 LL |         asm!("", out("x21") _);
    |                  ^^^^^^^^^^^^
 
 error: cannot use register `x22`: register can't be used with the `e` target feature
-  --> $DIR/bad-reg.rs:59:18
+  --> $DIR/bad-reg.rs:58:18
    |
 LL |         asm!("", out("x22") _);
    |                  ^^^^^^^^^^^^
 
 error: cannot use register `x23`: register can't be used with the `e` target feature
-  --> $DIR/bad-reg.rs:61:18
+  --> $DIR/bad-reg.rs:60:18
    |
 LL |         asm!("", out("x23") _);
    |                  ^^^^^^^^^^^^
 
 error: cannot use register `x24`: register can't be used with the `e` target feature
-  --> $DIR/bad-reg.rs:63:18
+  --> $DIR/bad-reg.rs:62:18
    |
 LL |         asm!("", out("x24") _);
    |                  ^^^^^^^^^^^^
 
 error: cannot use register `x25`: register can't be used with the `e` target feature
-  --> $DIR/bad-reg.rs:65:18
+  --> $DIR/bad-reg.rs:64:18
    |
 LL |         asm!("", out("x25") _);
    |                  ^^^^^^^^^^^^
 
 error: cannot use register `x26`: register can't be used with the `e` target feature
-  --> $DIR/bad-reg.rs:67:18
+  --> $DIR/bad-reg.rs:66:18
    |
 LL |         asm!("", out("x26") _);
    |                  ^^^^^^^^^^^^
 
 error: cannot use register `x27`: register can't be used with the `e` target feature
-  --> $DIR/bad-reg.rs:69:18
+  --> $DIR/bad-reg.rs:68:18
    |
 LL |         asm!("", out("x27") _);
    |                  ^^^^^^^^^^^^
 
 error: cannot use register `x28`: register can't be used with the `e` target feature
-  --> $DIR/bad-reg.rs:71:18
+  --> $DIR/bad-reg.rs:70:18
    |
 LL |         asm!("", out("x28") _);
    |                  ^^^^^^^^^^^^
 
 error: cannot use register `x29`: register can't be used with the `e` target feature
-  --> $DIR/bad-reg.rs:73:18
+  --> $DIR/bad-reg.rs:72:18
    |
 LL |         asm!("", out("x29") _);
    |                  ^^^^^^^^^^^^
 
 error: cannot use register `x30`: register can't be used with the `e` target feature
-  --> $DIR/bad-reg.rs:75:18
+  --> $DIR/bad-reg.rs:74:18
    |
 LL |         asm!("", out("x30") _);
    |                  ^^^^^^^^^^^^
 
 error: cannot use register `x31`: register can't be used with the `e` target feature
-  --> $DIR/bad-reg.rs:77:18
+  --> $DIR/bad-reg.rs:76:18
    |
 LL |         asm!("", out("x31") _);
    |                  ^^^^^^^^^^^^
 
 error: register class `freg` requires at least one of the following target features: d, f
-  --> $DIR/bad-reg.rs:81:26
+  --> $DIR/bad-reg.rs:80:26
    |
 LL |         asm!("/* {} */", in(freg) f);
    |                          ^^^^^^^^^^
 
 error: register class `freg` requires at least one of the following target features: d, f
-  --> $DIR/bad-reg.rs:83:26
+  --> $DIR/bad-reg.rs:82:26
    |
 LL |         asm!("/* {} */", out(freg) _);
    |                          ^^^^^^^^^^^
 
 error: register class `freg` requires at least one of the following target features: d, f
-  --> $DIR/bad-reg.rs:85:26
+  --> $DIR/bad-reg.rs:84:26
    |
 LL |         asm!("/* {} */", in(freg) d);
    |                          ^^^^^^^^^^
 
 error: register class `freg` requires at least one of the following target features: d, f
-  --> $DIR/bad-reg.rs:88:26
+  --> $DIR/bad-reg.rs:87:26
    |
 LL |         asm!("/* {} */", out(freg) d);
    |                          ^^^^^^^^^^^
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:95:27
+  --> $DIR/bad-reg.rs:94:27
    |
 LL |         asm!("", in("v0") x);
    |                           ^
@@ -187,7 +187,7 @@ LL |         asm!("", in("v0") x);
    = note: register class `vreg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:98:28
+  --> $DIR/bad-reg.rs:97:28
    |
 LL |         asm!("", out("v0") x);
    |                            ^
@@ -195,7 +195,7 @@ LL |         asm!("", out("v0") x);
    = note: register class `vreg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:101:35
+  --> $DIR/bad-reg.rs:100:35
    |
 LL |         asm!("/* {} */", in(vreg) x);
    |                                   ^

--- a/tests/ui/asm/riscv/bad-reg.riscv32gc.stderr
+++ b/tests/ui/asm/riscv/bad-reg.riscv32gc.stderr
@@ -1,65 +1,65 @@
 error: invalid register `s1`: s1 is used internally by LLVM and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:34:18
+  --> $DIR/bad-reg.rs:33:18
    |
 LL |         asm!("", out("s1") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `fp`: the frame pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:36:18
+  --> $DIR/bad-reg.rs:35:18
    |
 LL |         asm!("", out("fp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `sp`: the stack pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:38:18
+  --> $DIR/bad-reg.rs:37:18
    |
 LL |         asm!("", out("sp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `gp`: the global pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:40:18
+  --> $DIR/bad-reg.rs:39:18
    |
 LL |         asm!("", out("gp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `tp`: the thread pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:42:18
+  --> $DIR/bad-reg.rs:41:18
    |
 LL |         asm!("", out("tp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `zero`: the zero register cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:44:18
+  --> $DIR/bad-reg.rs:43:18
    |
 LL |         asm!("", out("zero") _);
    |                  ^^^^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:95:18
+  --> $DIR/bad-reg.rs:94:18
    |
 LL |         asm!("", in("v0") x);
    |                  ^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:98:18
+  --> $DIR/bad-reg.rs:97:18
    |
 LL |         asm!("", out("v0") x);
    |                  ^^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:101:26
+  --> $DIR/bad-reg.rs:100:26
    |
 LL |         asm!("/* {} */", in(vreg) x);
    |                          ^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:104:26
+  --> $DIR/bad-reg.rs:103:26
    |
 LL |         asm!("/* {} */", out(vreg) _);
    |                          ^^^^^^^^^^^
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:95:27
+  --> $DIR/bad-reg.rs:94:27
    |
 LL |         asm!("", in("v0") x);
    |                           ^
@@ -67,7 +67,7 @@ LL |         asm!("", in("v0") x);
    = note: register class `vreg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:98:28
+  --> $DIR/bad-reg.rs:97:28
    |
 LL |         asm!("", out("v0") x);
    |                            ^
@@ -75,7 +75,7 @@ LL |         asm!("", out("v0") x);
    = note: register class `vreg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:101:35
+  --> $DIR/bad-reg.rs:100:35
    |
 LL |         asm!("/* {} */", in(vreg) x);
    |                                   ^

--- a/tests/ui/asm/riscv/bad-reg.riscv32i.stderr
+++ b/tests/ui/asm/riscv/bad-reg.riscv32i.stderr
@@ -1,89 +1,89 @@
 error: invalid register `s1`: s1 is used internally by LLVM and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:34:18
+  --> $DIR/bad-reg.rs:33:18
    |
 LL |         asm!("", out("s1") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `fp`: the frame pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:36:18
+  --> $DIR/bad-reg.rs:35:18
    |
 LL |         asm!("", out("fp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `sp`: the stack pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:38:18
+  --> $DIR/bad-reg.rs:37:18
    |
 LL |         asm!("", out("sp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `gp`: the global pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:40:18
+  --> $DIR/bad-reg.rs:39:18
    |
 LL |         asm!("", out("gp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `tp`: the thread pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:42:18
+  --> $DIR/bad-reg.rs:41:18
    |
 LL |         asm!("", out("tp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `zero`: the zero register cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:44:18
+  --> $DIR/bad-reg.rs:43:18
    |
 LL |         asm!("", out("zero") _);
    |                  ^^^^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:95:18
+  --> $DIR/bad-reg.rs:94:18
    |
 LL |         asm!("", in("v0") x);
    |                  ^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:98:18
+  --> $DIR/bad-reg.rs:97:18
    |
 LL |         asm!("", out("v0") x);
    |                  ^^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:101:26
+  --> $DIR/bad-reg.rs:100:26
    |
 LL |         asm!("/* {} */", in(vreg) x);
    |                          ^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:104:26
+  --> $DIR/bad-reg.rs:103:26
    |
 LL |         asm!("/* {} */", out(vreg) _);
    |                          ^^^^^^^^^^^
 
 error: register class `freg` requires at least one of the following target features: d, f
-  --> $DIR/bad-reg.rs:81:26
+  --> $DIR/bad-reg.rs:80:26
    |
 LL |         asm!("/* {} */", in(freg) f);
    |                          ^^^^^^^^^^
 
 error: register class `freg` requires at least one of the following target features: d, f
-  --> $DIR/bad-reg.rs:83:26
+  --> $DIR/bad-reg.rs:82:26
    |
 LL |         asm!("/* {} */", out(freg) _);
    |                          ^^^^^^^^^^^
 
 error: register class `freg` requires at least one of the following target features: d, f
-  --> $DIR/bad-reg.rs:85:26
+  --> $DIR/bad-reg.rs:84:26
    |
 LL |         asm!("/* {} */", in(freg) d);
    |                          ^^^^^^^^^^
 
 error: register class `freg` requires at least one of the following target features: d, f
-  --> $DIR/bad-reg.rs:88:26
+  --> $DIR/bad-reg.rs:87:26
    |
 LL |         asm!("/* {} */", out(freg) d);
    |                          ^^^^^^^^^^^
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:95:27
+  --> $DIR/bad-reg.rs:94:27
    |
 LL |         asm!("", in("v0") x);
    |                           ^
@@ -91,7 +91,7 @@ LL |         asm!("", in("v0") x);
    = note: register class `vreg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:98:28
+  --> $DIR/bad-reg.rs:97:28
    |
 LL |         asm!("", out("v0") x);
    |                            ^
@@ -99,7 +99,7 @@ LL |         asm!("", out("v0") x);
    = note: register class `vreg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:101:35
+  --> $DIR/bad-reg.rs:100:35
    |
 LL |         asm!("/* {} */", in(vreg) x);
    |                                   ^

--- a/tests/ui/asm/riscv/bad-reg.riscv32imafc.stderr
+++ b/tests/ui/asm/riscv/bad-reg.riscv32imafc.stderr
@@ -1,65 +1,65 @@
 error: invalid register `s1`: s1 is used internally by LLVM and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:34:18
+  --> $DIR/bad-reg.rs:33:18
    |
 LL |         asm!("", out("s1") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `fp`: the frame pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:36:18
+  --> $DIR/bad-reg.rs:35:18
    |
 LL |         asm!("", out("fp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `sp`: the stack pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:38:18
+  --> $DIR/bad-reg.rs:37:18
    |
 LL |         asm!("", out("sp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `gp`: the global pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:40:18
+  --> $DIR/bad-reg.rs:39:18
    |
 LL |         asm!("", out("gp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `tp`: the thread pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:42:18
+  --> $DIR/bad-reg.rs:41:18
    |
 LL |         asm!("", out("tp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `zero`: the zero register cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:44:18
+  --> $DIR/bad-reg.rs:43:18
    |
 LL |         asm!("", out("zero") _);
    |                  ^^^^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:95:18
+  --> $DIR/bad-reg.rs:94:18
    |
 LL |         asm!("", in("v0") x);
    |                  ^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:98:18
+  --> $DIR/bad-reg.rs:97:18
    |
 LL |         asm!("", out("v0") x);
    |                  ^^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:101:26
+  --> $DIR/bad-reg.rs:100:26
    |
 LL |         asm!("/* {} */", in(vreg) x);
    |                          ^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:104:26
+  --> $DIR/bad-reg.rs:103:26
    |
 LL |         asm!("/* {} */", out(vreg) _);
    |                          ^^^^^^^^^^^
 
 error: `d` target feature is not enabled
-  --> $DIR/bad-reg.rs:85:35
+  --> $DIR/bad-reg.rs:84:35
    |
 LL |         asm!("/* {} */", in(freg) d);
    |                                   ^
@@ -67,7 +67,7 @@ LL |         asm!("/* {} */", in(freg) d);
    = note: this is required to use type `f64` with register class `freg`
 
 error: `d` target feature is not enabled
-  --> $DIR/bad-reg.rs:88:36
+  --> $DIR/bad-reg.rs:87:36
    |
 LL |         asm!("/* {} */", out(freg) d);
    |                                    ^
@@ -75,7 +75,7 @@ LL |         asm!("/* {} */", out(freg) d);
    = note: this is required to use type `f64` with register class `freg`
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:95:27
+  --> $DIR/bad-reg.rs:94:27
    |
 LL |         asm!("", in("v0") x);
    |                           ^
@@ -83,7 +83,7 @@ LL |         asm!("", in("v0") x);
    = note: register class `vreg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:98:28
+  --> $DIR/bad-reg.rs:97:28
    |
 LL |         asm!("", out("v0") x);
    |                            ^
@@ -91,7 +91,7 @@ LL |         asm!("", out("v0") x);
    = note: register class `vreg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:101:35
+  --> $DIR/bad-reg.rs:100:35
    |
 LL |         asm!("/* {} */", in(vreg) x);
    |                                   ^

--- a/tests/ui/asm/riscv/bad-reg.riscv64gc.stderr
+++ b/tests/ui/asm/riscv/bad-reg.riscv64gc.stderr
@@ -1,65 +1,65 @@
 error: invalid register `s1`: s1 is used internally by LLVM and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:34:18
+  --> $DIR/bad-reg.rs:33:18
    |
 LL |         asm!("", out("s1") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `fp`: the frame pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:36:18
+  --> $DIR/bad-reg.rs:35:18
    |
 LL |         asm!("", out("fp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `sp`: the stack pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:38:18
+  --> $DIR/bad-reg.rs:37:18
    |
 LL |         asm!("", out("sp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `gp`: the global pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:40:18
+  --> $DIR/bad-reg.rs:39:18
    |
 LL |         asm!("", out("gp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `tp`: the thread pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:42:18
+  --> $DIR/bad-reg.rs:41:18
    |
 LL |         asm!("", out("tp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `zero`: the zero register cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:44:18
+  --> $DIR/bad-reg.rs:43:18
    |
 LL |         asm!("", out("zero") _);
    |                  ^^^^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:95:18
+  --> $DIR/bad-reg.rs:94:18
    |
 LL |         asm!("", in("v0") x);
    |                  ^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:98:18
+  --> $DIR/bad-reg.rs:97:18
    |
 LL |         asm!("", out("v0") x);
    |                  ^^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:101:26
+  --> $DIR/bad-reg.rs:100:26
    |
 LL |         asm!("/* {} */", in(vreg) x);
    |                          ^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:104:26
+  --> $DIR/bad-reg.rs:103:26
    |
 LL |         asm!("/* {} */", out(vreg) _);
    |                          ^^^^^^^^^^^
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:95:27
+  --> $DIR/bad-reg.rs:94:27
    |
 LL |         asm!("", in("v0") x);
    |                           ^
@@ -67,7 +67,7 @@ LL |         asm!("", in("v0") x);
    = note: register class `vreg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:98:28
+  --> $DIR/bad-reg.rs:97:28
    |
 LL |         asm!("", out("v0") x);
    |                            ^
@@ -75,7 +75,7 @@ LL |         asm!("", out("v0") x);
    = note: register class `vreg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:101:35
+  --> $DIR/bad-reg.rs:100:35
    |
 LL |         asm!("/* {} */", in(vreg) x);
    |                                   ^

--- a/tests/ui/asm/riscv/bad-reg.riscv64imac.stderr
+++ b/tests/ui/asm/riscv/bad-reg.riscv64imac.stderr
@@ -1,89 +1,89 @@
 error: invalid register `s1`: s1 is used internally by LLVM and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:34:18
+  --> $DIR/bad-reg.rs:33:18
    |
 LL |         asm!("", out("s1") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `fp`: the frame pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:36:18
+  --> $DIR/bad-reg.rs:35:18
    |
 LL |         asm!("", out("fp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `sp`: the stack pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:38:18
+  --> $DIR/bad-reg.rs:37:18
    |
 LL |         asm!("", out("sp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `gp`: the global pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:40:18
+  --> $DIR/bad-reg.rs:39:18
    |
 LL |         asm!("", out("gp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `tp`: the thread pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:42:18
+  --> $DIR/bad-reg.rs:41:18
    |
 LL |         asm!("", out("tp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `zero`: the zero register cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:44:18
+  --> $DIR/bad-reg.rs:43:18
    |
 LL |         asm!("", out("zero") _);
    |                  ^^^^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:95:18
+  --> $DIR/bad-reg.rs:94:18
    |
 LL |         asm!("", in("v0") x);
    |                  ^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:98:18
+  --> $DIR/bad-reg.rs:97:18
    |
 LL |         asm!("", out("v0") x);
    |                  ^^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:101:26
+  --> $DIR/bad-reg.rs:100:26
    |
 LL |         asm!("/* {} */", in(vreg) x);
    |                          ^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:104:26
+  --> $DIR/bad-reg.rs:103:26
    |
 LL |         asm!("/* {} */", out(vreg) _);
    |                          ^^^^^^^^^^^
 
 error: register class `freg` requires at least one of the following target features: d, f
-  --> $DIR/bad-reg.rs:81:26
+  --> $DIR/bad-reg.rs:80:26
    |
 LL |         asm!("/* {} */", in(freg) f);
    |                          ^^^^^^^^^^
 
 error: register class `freg` requires at least one of the following target features: d, f
-  --> $DIR/bad-reg.rs:83:26
+  --> $DIR/bad-reg.rs:82:26
    |
 LL |         asm!("/* {} */", out(freg) _);
    |                          ^^^^^^^^^^^
 
 error: register class `freg` requires at least one of the following target features: d, f
-  --> $DIR/bad-reg.rs:85:26
+  --> $DIR/bad-reg.rs:84:26
    |
 LL |         asm!("/* {} */", in(freg) d);
    |                          ^^^^^^^^^^
 
 error: register class `freg` requires at least one of the following target features: d, f
-  --> $DIR/bad-reg.rs:88:26
+  --> $DIR/bad-reg.rs:87:26
    |
 LL |         asm!("/* {} */", out(freg) d);
    |                          ^^^^^^^^^^^
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:95:27
+  --> $DIR/bad-reg.rs:94:27
    |
 LL |         asm!("", in("v0") x);
    |                           ^
@@ -91,7 +91,7 @@ LL |         asm!("", in("v0") x);
    = note: register class `vreg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:98:28
+  --> $DIR/bad-reg.rs:97:28
    |
 LL |         asm!("", out("v0") x);
    |                            ^
@@ -99,7 +99,7 @@ LL |         asm!("", out("v0") x);
    = note: register class `vreg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:101:35
+  --> $DIR/bad-reg.rs:100:35
    |
 LL |         asm!("/* {} */", in(vreg) x);
    |                                   ^

--- a/tests/ui/asm/riscv/bad-reg.rs
+++ b/tests/ui/asm/riscv/bad-reg.rs
@@ -1,5 +1,4 @@
 //@ add-core-stubs
-//@ needs-asm-support
 //@ revisions: riscv32i riscv32imafc riscv32gc riscv32e riscv64imac riscv64gc
 //@[riscv32i] compile-flags: --target riscv32i-unknown-none-elf
 //@[riscv32i] needs-llvm-components: riscv

--- a/tests/ui/asm/s390x/bad-reg.rs
+++ b/tests/ui/asm/s390x/bad-reg.rs
@@ -1,5 +1,4 @@
 //@ add-core-stubs
-//@ needs-asm-support
 //@ revisions: s390x s390x_vector s390x_vector_stable
 //@[s390x] compile-flags: --target s390x-unknown-linux-gnu -C target-feature=-vector
 //@[s390x] needs-llvm-components: systemz

--- a/tests/ui/asm/s390x/bad-reg.s390x.stderr
+++ b/tests/ui/asm/s390x/bad-reg.s390x.stderr
@@ -1,149 +1,149 @@
 error: invalid register `r11`: The frame pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:32:18
+  --> $DIR/bad-reg.rs:31:18
    |
 LL |         asm!("", out("r11") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `r15`: The stack pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:34:18
+  --> $DIR/bad-reg.rs:33:18
    |
 LL |         asm!("", out("r15") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `c0`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:36:18
+  --> $DIR/bad-reg.rs:35:18
    |
 LL |         asm!("", out("c0") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `c1`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:38:18
+  --> $DIR/bad-reg.rs:37:18
    |
 LL |         asm!("", out("c1") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `c2`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:40:18
+  --> $DIR/bad-reg.rs:39:18
    |
 LL |         asm!("", out("c2") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `c3`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:42:18
+  --> $DIR/bad-reg.rs:41:18
    |
 LL |         asm!("", out("c3") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `c4`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:44:18
+  --> $DIR/bad-reg.rs:43:18
    |
 LL |         asm!("", out("c4") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `c5`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:46:18
+  --> $DIR/bad-reg.rs:45:18
    |
 LL |         asm!("", out("c5") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `c6`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:48:18
+  --> $DIR/bad-reg.rs:47:18
    |
 LL |         asm!("", out("c6") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `c7`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:50:18
+  --> $DIR/bad-reg.rs:49:18
    |
 LL |         asm!("", out("c7") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `c8`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:52:18
+  --> $DIR/bad-reg.rs:51:18
    |
 LL |         asm!("", out("c8") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `c9`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:54:18
+  --> $DIR/bad-reg.rs:53:18
    |
 LL |         asm!("", out("c9") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `c10`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:56:18
+  --> $DIR/bad-reg.rs:55:18
    |
 LL |         asm!("", out("c10") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `c11`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:58:18
+  --> $DIR/bad-reg.rs:57:18
    |
 LL |         asm!("", out("c11") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `c12`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:60:18
+  --> $DIR/bad-reg.rs:59:18
    |
 LL |         asm!("", out("c12") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `c13`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:62:18
+  --> $DIR/bad-reg.rs:61:18
    |
 LL |         asm!("", out("c13") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `c14`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:64:18
+  --> $DIR/bad-reg.rs:63:18
    |
 LL |         asm!("", out("c14") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `c15`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:66:18
+  --> $DIR/bad-reg.rs:65:18
    |
 LL |         asm!("", out("c15") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `a0`: a0 and a1 are reserved for system use and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:68:18
+  --> $DIR/bad-reg.rs:67:18
    |
 LL |         asm!("", out("a0") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `a1`: a0 and a1 are reserved for system use and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:70:18
+  --> $DIR/bad-reg.rs:69:18
    |
 LL |         asm!("", out("a1") _);
    |                  ^^^^^^^^^^^
 
 error: register class `areg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:121:18
+  --> $DIR/bad-reg.rs:120:18
    |
 LL |         asm!("", in("a2") x);
    |                  ^^^^^^^^^^
 
 error: register class `areg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:124:18
+  --> $DIR/bad-reg.rs:123:18
    |
 LL |         asm!("", out("a2") x);
    |                  ^^^^^^^^^^^
 
 error: register class `areg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:127:26
+  --> $DIR/bad-reg.rs:126:26
    |
 LL |         asm!("/* {} */", in(areg) x);
    |                          ^^^^^^^^^^
 
 error: register class `areg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:130:26
+  --> $DIR/bad-reg.rs:129:26
    |
 LL |         asm!("/* {} */", out(areg) _);
    |                          ^^^^^^^^^^^
 
 error: register `f0` conflicts with register `v0`
-  --> $DIR/bad-reg.rs:135:31
+  --> $DIR/bad-reg.rs:134:31
    |
 LL |         asm!("", out("v0") _, out("f0") _);
    |                  -----------  ^^^^^^^^^^^ register `f0`
@@ -151,7 +151,7 @@ LL |         asm!("", out("v0") _, out("f0") _);
    |                  register `v0`
 
 error: register `f1` conflicts with register `v1`
-  --> $DIR/bad-reg.rs:137:31
+  --> $DIR/bad-reg.rs:136:31
    |
 LL |         asm!("", out("v1") _, out("f1") _);
    |                  -----------  ^^^^^^^^^^^ register `f1`
@@ -159,7 +159,7 @@ LL |         asm!("", out("v1") _, out("f1") _);
    |                  register `v1`
 
 error: register `f2` conflicts with register `v2`
-  --> $DIR/bad-reg.rs:139:31
+  --> $DIR/bad-reg.rs:138:31
    |
 LL |         asm!("", out("v2") _, out("f2") _);
    |                  -----------  ^^^^^^^^^^^ register `f2`
@@ -167,7 +167,7 @@ LL |         asm!("", out("v2") _, out("f2") _);
    |                  register `v2`
 
 error: register `f3` conflicts with register `v3`
-  --> $DIR/bad-reg.rs:141:31
+  --> $DIR/bad-reg.rs:140:31
    |
 LL |         asm!("", out("v3") _, out("f3") _);
    |                  -----------  ^^^^^^^^^^^ register `f3`
@@ -175,7 +175,7 @@ LL |         asm!("", out("v3") _, out("f3") _);
    |                  register `v3`
 
 error: register `f4` conflicts with register `v4`
-  --> $DIR/bad-reg.rs:143:31
+  --> $DIR/bad-reg.rs:142:31
    |
 LL |         asm!("", out("v4") _, out("f4") _);
    |                  -----------  ^^^^^^^^^^^ register `f4`
@@ -183,7 +183,7 @@ LL |         asm!("", out("v4") _, out("f4") _);
    |                  register `v4`
 
 error: register `f5` conflicts with register `v5`
-  --> $DIR/bad-reg.rs:145:31
+  --> $DIR/bad-reg.rs:144:31
    |
 LL |         asm!("", out("v5") _, out("f5") _);
    |                  -----------  ^^^^^^^^^^^ register `f5`
@@ -191,7 +191,7 @@ LL |         asm!("", out("v5") _, out("f5") _);
    |                  register `v5`
 
 error: register `f6` conflicts with register `v6`
-  --> $DIR/bad-reg.rs:147:31
+  --> $DIR/bad-reg.rs:146:31
    |
 LL |         asm!("", out("v6") _, out("f6") _);
    |                  -----------  ^^^^^^^^^^^ register `f6`
@@ -199,7 +199,7 @@ LL |         asm!("", out("v6") _, out("f6") _);
    |                  register `v6`
 
 error: register `f7` conflicts with register `v7`
-  --> $DIR/bad-reg.rs:149:31
+  --> $DIR/bad-reg.rs:148:31
    |
 LL |         asm!("", out("v7") _, out("f7") _);
    |                  -----------  ^^^^^^^^^^^ register `f7`
@@ -207,7 +207,7 @@ LL |         asm!("", out("v7") _, out("f7") _);
    |                  register `v7`
 
 error: register `f8` conflicts with register `v8`
-  --> $DIR/bad-reg.rs:151:31
+  --> $DIR/bad-reg.rs:150:31
    |
 LL |         asm!("", out("v8") _, out("f8") _);
    |                  -----------  ^^^^^^^^^^^ register `f8`
@@ -215,7 +215,7 @@ LL |         asm!("", out("v8") _, out("f8") _);
    |                  register `v8`
 
 error: register `f9` conflicts with register `v9`
-  --> $DIR/bad-reg.rs:153:31
+  --> $DIR/bad-reg.rs:152:31
    |
 LL |         asm!("", out("v9") _, out("f9") _);
    |                  -----------  ^^^^^^^^^^^ register `f9`
@@ -223,7 +223,7 @@ LL |         asm!("", out("v9") _, out("f9") _);
    |                  register `v9`
 
 error: register `f10` conflicts with register `v10`
-  --> $DIR/bad-reg.rs:155:32
+  --> $DIR/bad-reg.rs:154:32
    |
 LL |         asm!("", out("v10") _, out("f10") _);
    |                  ------------  ^^^^^^^^^^^^ register `f10`
@@ -231,7 +231,7 @@ LL |         asm!("", out("v10") _, out("f10") _);
    |                  register `v10`
 
 error: register `f11` conflicts with register `v11`
-  --> $DIR/bad-reg.rs:157:32
+  --> $DIR/bad-reg.rs:156:32
    |
 LL |         asm!("", out("v11") _, out("f11") _);
    |                  ------------  ^^^^^^^^^^^^ register `f11`
@@ -239,7 +239,7 @@ LL |         asm!("", out("v11") _, out("f11") _);
    |                  register `v11`
 
 error: register `f12` conflicts with register `v12`
-  --> $DIR/bad-reg.rs:159:32
+  --> $DIR/bad-reg.rs:158:32
    |
 LL |         asm!("", out("v12") _, out("f12") _);
    |                  ------------  ^^^^^^^^^^^^ register `f12`
@@ -247,7 +247,7 @@ LL |         asm!("", out("v12") _, out("f12") _);
    |                  register `v12`
 
 error: register `f13` conflicts with register `v13`
-  --> $DIR/bad-reg.rs:161:32
+  --> $DIR/bad-reg.rs:160:32
    |
 LL |         asm!("", out("v13") _, out("f13") _);
    |                  ------------  ^^^^^^^^^^^^ register `f13`
@@ -255,7 +255,7 @@ LL |         asm!("", out("v13") _, out("f13") _);
    |                  register `v13`
 
 error: register `f14` conflicts with register `v14`
-  --> $DIR/bad-reg.rs:163:32
+  --> $DIR/bad-reg.rs:162:32
    |
 LL |         asm!("", out("v14") _, out("f14") _);
    |                  ------------  ^^^^^^^^^^^^ register `f14`
@@ -263,7 +263,7 @@ LL |         asm!("", out("v14") _, out("f14") _);
    |                  register `v14`
 
 error: register `f15` conflicts with register `v15`
-  --> $DIR/bad-reg.rs:165:32
+  --> $DIR/bad-reg.rs:164:32
    |
 LL |         asm!("", out("v15") _, out("f15") _);
    |                  ------------  ^^^^^^^^^^^^ register `f15`
@@ -271,73 +271,73 @@ LL |         asm!("", out("v15") _, out("f15") _);
    |                  register `v15`
 
 error: invalid register `f16`: unknown register
-  --> $DIR/bad-reg.rs:168:32
+  --> $DIR/bad-reg.rs:167:32
    |
 LL |         asm!("", out("v16") _, out("f16") _);
    |                                ^^^^^^^^^^^^
 
 error: register class `vreg` requires the `vector` target feature
-  --> $DIR/bad-reg.rs:75:18
+  --> $DIR/bad-reg.rs:74:18
    |
 LL |         asm!("", in("v0") v); // requires vector & asm_experimental_reg
    |                  ^^^^^^^^^^
 
 error: register class `vreg` requires the `vector` target feature
-  --> $DIR/bad-reg.rs:79:18
+  --> $DIR/bad-reg.rs:78:18
    |
 LL |         asm!("", out("v0") v); // requires vector & asm_experimental_reg
    |                  ^^^^^^^^^^^
 
 error: register class `vreg` requires the `vector` target feature
-  --> $DIR/bad-reg.rs:83:18
+  --> $DIR/bad-reg.rs:82:18
    |
 LL |         asm!("", in("v0") x); // requires vector & asm_experimental_reg
    |                  ^^^^^^^^^^
 
 error: register class `vreg` requires the `vector` target feature
-  --> $DIR/bad-reg.rs:87:18
+  --> $DIR/bad-reg.rs:86:18
    |
 LL |         asm!("", out("v0") x); // requires vector & asm_experimental_reg
    |                  ^^^^^^^^^^^
 
 error: register class `vreg` requires the `vector` target feature
-  --> $DIR/bad-reg.rs:91:18
+  --> $DIR/bad-reg.rs:90:18
    |
 LL |         asm!("", in("v0") b);
    |                  ^^^^^^^^^^
 
 error: register class `vreg` requires the `vector` target feature
-  --> $DIR/bad-reg.rs:96:18
+  --> $DIR/bad-reg.rs:95:18
    |
 LL |         asm!("", out("v0") b);
    |                  ^^^^^^^^^^^
 
 error: register class `vreg` requires the `vector` target feature
-  --> $DIR/bad-reg.rs:101:26
+  --> $DIR/bad-reg.rs:100:26
    |
 LL |         asm!("/* {} */", in(vreg) v); // requires vector & asm_experimental_reg
    |                          ^^^^^^^^^^
 
 error: register class `vreg` requires the `vector` target feature
-  --> $DIR/bad-reg.rs:105:26
+  --> $DIR/bad-reg.rs:104:26
    |
 LL |         asm!("/* {} */", in(vreg) x); // requires vector & asm_experimental_reg
    |                          ^^^^^^^^^^
 
 error: register class `vreg` requires the `vector` target feature
-  --> $DIR/bad-reg.rs:109:26
+  --> $DIR/bad-reg.rs:108:26
    |
 LL |         asm!("/* {} */", in(vreg) b);
    |                          ^^^^^^^^^^
 
 error: register class `vreg` requires the `vector` target feature
-  --> $DIR/bad-reg.rs:114:26
+  --> $DIR/bad-reg.rs:113:26
    |
 LL |         asm!("/* {} */", out(vreg) _); // requires vector & asm_experimental_reg
    |                          ^^^^^^^^^^^
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:121:27
+  --> $DIR/bad-reg.rs:120:27
    |
 LL |         asm!("", in("a2") x);
    |                           ^
@@ -345,7 +345,7 @@ LL |         asm!("", in("a2") x);
    = note: register class `areg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:124:28
+  --> $DIR/bad-reg.rs:123:28
    |
 LL |         asm!("", out("a2") x);
    |                            ^
@@ -353,7 +353,7 @@ LL |         asm!("", out("a2") x);
    = note: register class `areg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:127:35
+  --> $DIR/bad-reg.rs:126:35
    |
 LL |         asm!("/* {} */", in(areg) x);
    |                                   ^

--- a/tests/ui/asm/s390x/bad-reg.s390x_vector.stderr
+++ b/tests/ui/asm/s390x/bad-reg.s390x_vector.stderr
@@ -1,149 +1,149 @@
 error: invalid register `r11`: The frame pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:32:18
+  --> $DIR/bad-reg.rs:31:18
    |
 LL |         asm!("", out("r11") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `r15`: The stack pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:34:18
+  --> $DIR/bad-reg.rs:33:18
    |
 LL |         asm!("", out("r15") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `c0`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:36:18
+  --> $DIR/bad-reg.rs:35:18
    |
 LL |         asm!("", out("c0") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `c1`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:38:18
+  --> $DIR/bad-reg.rs:37:18
    |
 LL |         asm!("", out("c1") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `c2`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:40:18
+  --> $DIR/bad-reg.rs:39:18
    |
 LL |         asm!("", out("c2") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `c3`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:42:18
+  --> $DIR/bad-reg.rs:41:18
    |
 LL |         asm!("", out("c3") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `c4`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:44:18
+  --> $DIR/bad-reg.rs:43:18
    |
 LL |         asm!("", out("c4") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `c5`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:46:18
+  --> $DIR/bad-reg.rs:45:18
    |
 LL |         asm!("", out("c5") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `c6`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:48:18
+  --> $DIR/bad-reg.rs:47:18
    |
 LL |         asm!("", out("c6") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `c7`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:50:18
+  --> $DIR/bad-reg.rs:49:18
    |
 LL |         asm!("", out("c7") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `c8`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:52:18
+  --> $DIR/bad-reg.rs:51:18
    |
 LL |         asm!("", out("c8") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `c9`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:54:18
+  --> $DIR/bad-reg.rs:53:18
    |
 LL |         asm!("", out("c9") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `c10`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:56:18
+  --> $DIR/bad-reg.rs:55:18
    |
 LL |         asm!("", out("c10") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `c11`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:58:18
+  --> $DIR/bad-reg.rs:57:18
    |
 LL |         asm!("", out("c11") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `c12`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:60:18
+  --> $DIR/bad-reg.rs:59:18
    |
 LL |         asm!("", out("c12") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `c13`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:62:18
+  --> $DIR/bad-reg.rs:61:18
    |
 LL |         asm!("", out("c13") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `c14`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:64:18
+  --> $DIR/bad-reg.rs:63:18
    |
 LL |         asm!("", out("c14") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `c15`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:66:18
+  --> $DIR/bad-reg.rs:65:18
    |
 LL |         asm!("", out("c15") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `a0`: a0 and a1 are reserved for system use and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:68:18
+  --> $DIR/bad-reg.rs:67:18
    |
 LL |         asm!("", out("a0") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `a1`: a0 and a1 are reserved for system use and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:70:18
+  --> $DIR/bad-reg.rs:69:18
    |
 LL |         asm!("", out("a1") _);
    |                  ^^^^^^^^^^^
 
 error: register class `areg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:121:18
+  --> $DIR/bad-reg.rs:120:18
    |
 LL |         asm!("", in("a2") x);
    |                  ^^^^^^^^^^
 
 error: register class `areg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:124:18
+  --> $DIR/bad-reg.rs:123:18
    |
 LL |         asm!("", out("a2") x);
    |                  ^^^^^^^^^^^
 
 error: register class `areg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:127:26
+  --> $DIR/bad-reg.rs:126:26
    |
 LL |         asm!("/* {} */", in(areg) x);
    |                          ^^^^^^^^^^
 
 error: register class `areg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:130:26
+  --> $DIR/bad-reg.rs:129:26
    |
 LL |         asm!("/* {} */", out(areg) _);
    |                          ^^^^^^^^^^^
 
 error: register `f0` conflicts with register `v0`
-  --> $DIR/bad-reg.rs:135:31
+  --> $DIR/bad-reg.rs:134:31
    |
 LL |         asm!("", out("v0") _, out("f0") _);
    |                  -----------  ^^^^^^^^^^^ register `f0`
@@ -151,7 +151,7 @@ LL |         asm!("", out("v0") _, out("f0") _);
    |                  register `v0`
 
 error: register `f1` conflicts with register `v1`
-  --> $DIR/bad-reg.rs:137:31
+  --> $DIR/bad-reg.rs:136:31
    |
 LL |         asm!("", out("v1") _, out("f1") _);
    |                  -----------  ^^^^^^^^^^^ register `f1`
@@ -159,7 +159,7 @@ LL |         asm!("", out("v1") _, out("f1") _);
    |                  register `v1`
 
 error: register `f2` conflicts with register `v2`
-  --> $DIR/bad-reg.rs:139:31
+  --> $DIR/bad-reg.rs:138:31
    |
 LL |         asm!("", out("v2") _, out("f2") _);
    |                  -----------  ^^^^^^^^^^^ register `f2`
@@ -167,7 +167,7 @@ LL |         asm!("", out("v2") _, out("f2") _);
    |                  register `v2`
 
 error: register `f3` conflicts with register `v3`
-  --> $DIR/bad-reg.rs:141:31
+  --> $DIR/bad-reg.rs:140:31
    |
 LL |         asm!("", out("v3") _, out("f3") _);
    |                  -----------  ^^^^^^^^^^^ register `f3`
@@ -175,7 +175,7 @@ LL |         asm!("", out("v3") _, out("f3") _);
    |                  register `v3`
 
 error: register `f4` conflicts with register `v4`
-  --> $DIR/bad-reg.rs:143:31
+  --> $DIR/bad-reg.rs:142:31
    |
 LL |         asm!("", out("v4") _, out("f4") _);
    |                  -----------  ^^^^^^^^^^^ register `f4`
@@ -183,7 +183,7 @@ LL |         asm!("", out("v4") _, out("f4") _);
    |                  register `v4`
 
 error: register `f5` conflicts with register `v5`
-  --> $DIR/bad-reg.rs:145:31
+  --> $DIR/bad-reg.rs:144:31
    |
 LL |         asm!("", out("v5") _, out("f5") _);
    |                  -----------  ^^^^^^^^^^^ register `f5`
@@ -191,7 +191,7 @@ LL |         asm!("", out("v5") _, out("f5") _);
    |                  register `v5`
 
 error: register `f6` conflicts with register `v6`
-  --> $DIR/bad-reg.rs:147:31
+  --> $DIR/bad-reg.rs:146:31
    |
 LL |         asm!("", out("v6") _, out("f6") _);
    |                  -----------  ^^^^^^^^^^^ register `f6`
@@ -199,7 +199,7 @@ LL |         asm!("", out("v6") _, out("f6") _);
    |                  register `v6`
 
 error: register `f7` conflicts with register `v7`
-  --> $DIR/bad-reg.rs:149:31
+  --> $DIR/bad-reg.rs:148:31
    |
 LL |         asm!("", out("v7") _, out("f7") _);
    |                  -----------  ^^^^^^^^^^^ register `f7`
@@ -207,7 +207,7 @@ LL |         asm!("", out("v7") _, out("f7") _);
    |                  register `v7`
 
 error: register `f8` conflicts with register `v8`
-  --> $DIR/bad-reg.rs:151:31
+  --> $DIR/bad-reg.rs:150:31
    |
 LL |         asm!("", out("v8") _, out("f8") _);
    |                  -----------  ^^^^^^^^^^^ register `f8`
@@ -215,7 +215,7 @@ LL |         asm!("", out("v8") _, out("f8") _);
    |                  register `v8`
 
 error: register `f9` conflicts with register `v9`
-  --> $DIR/bad-reg.rs:153:31
+  --> $DIR/bad-reg.rs:152:31
    |
 LL |         asm!("", out("v9") _, out("f9") _);
    |                  -----------  ^^^^^^^^^^^ register `f9`
@@ -223,7 +223,7 @@ LL |         asm!("", out("v9") _, out("f9") _);
    |                  register `v9`
 
 error: register `f10` conflicts with register `v10`
-  --> $DIR/bad-reg.rs:155:32
+  --> $DIR/bad-reg.rs:154:32
    |
 LL |         asm!("", out("v10") _, out("f10") _);
    |                  ------------  ^^^^^^^^^^^^ register `f10`
@@ -231,7 +231,7 @@ LL |         asm!("", out("v10") _, out("f10") _);
    |                  register `v10`
 
 error: register `f11` conflicts with register `v11`
-  --> $DIR/bad-reg.rs:157:32
+  --> $DIR/bad-reg.rs:156:32
    |
 LL |         asm!("", out("v11") _, out("f11") _);
    |                  ------------  ^^^^^^^^^^^^ register `f11`
@@ -239,7 +239,7 @@ LL |         asm!("", out("v11") _, out("f11") _);
    |                  register `v11`
 
 error: register `f12` conflicts with register `v12`
-  --> $DIR/bad-reg.rs:159:32
+  --> $DIR/bad-reg.rs:158:32
    |
 LL |         asm!("", out("v12") _, out("f12") _);
    |                  ------------  ^^^^^^^^^^^^ register `f12`
@@ -247,7 +247,7 @@ LL |         asm!("", out("v12") _, out("f12") _);
    |                  register `v12`
 
 error: register `f13` conflicts with register `v13`
-  --> $DIR/bad-reg.rs:161:32
+  --> $DIR/bad-reg.rs:160:32
    |
 LL |         asm!("", out("v13") _, out("f13") _);
    |                  ------------  ^^^^^^^^^^^^ register `f13`
@@ -255,7 +255,7 @@ LL |         asm!("", out("v13") _, out("f13") _);
    |                  register `v13`
 
 error: register `f14` conflicts with register `v14`
-  --> $DIR/bad-reg.rs:163:32
+  --> $DIR/bad-reg.rs:162:32
    |
 LL |         asm!("", out("v14") _, out("f14") _);
    |                  ------------  ^^^^^^^^^^^^ register `f14`
@@ -263,7 +263,7 @@ LL |         asm!("", out("v14") _, out("f14") _);
    |                  register `v14`
 
 error: register `f15` conflicts with register `v15`
-  --> $DIR/bad-reg.rs:165:32
+  --> $DIR/bad-reg.rs:164:32
    |
 LL |         asm!("", out("v15") _, out("f15") _);
    |                  ------------  ^^^^^^^^^^^^ register `f15`
@@ -271,13 +271,13 @@ LL |         asm!("", out("v15") _, out("f15") _);
    |                  register `v15`
 
 error: invalid register `f16`: unknown register
-  --> $DIR/bad-reg.rs:168:32
+  --> $DIR/bad-reg.rs:167:32
    |
 LL |         asm!("", out("v16") _, out("f16") _);
    |                                ^^^^^^^^^^^^
 
 error: type `u8` cannot be used with this register class
-  --> $DIR/bad-reg.rs:91:27
+  --> $DIR/bad-reg.rs:90:27
    |
 LL |         asm!("", in("v0") b);
    |                           ^
@@ -285,7 +285,7 @@ LL |         asm!("", in("v0") b);
    = note: register class `vreg` supports these types: i32, f32, i64, f64, i128, f128, i8x16, i16x8, i32x4, i64x2, f32x4, f64x2
 
 error: type `u8` cannot be used with this register class
-  --> $DIR/bad-reg.rs:96:28
+  --> $DIR/bad-reg.rs:95:28
    |
 LL |         asm!("", out("v0") b);
    |                            ^
@@ -293,7 +293,7 @@ LL |         asm!("", out("v0") b);
    = note: register class `vreg` supports these types: i32, f32, i64, f64, i128, f128, i8x16, i16x8, i32x4, i64x2, f32x4, f64x2
 
 error: type `u8` cannot be used with this register class
-  --> $DIR/bad-reg.rs:109:35
+  --> $DIR/bad-reg.rs:108:35
    |
 LL |         asm!("/* {} */", in(vreg) b);
    |                                   ^
@@ -301,7 +301,7 @@ LL |         asm!("/* {} */", in(vreg) b);
    = note: register class `vreg` supports these types: i32, f32, i64, f64, i128, f128, i8x16, i16x8, i32x4, i64x2, f32x4, f64x2
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:121:27
+  --> $DIR/bad-reg.rs:120:27
    |
 LL |         asm!("", in("a2") x);
    |                           ^
@@ -309,7 +309,7 @@ LL |         asm!("", in("a2") x);
    = note: register class `areg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:124:28
+  --> $DIR/bad-reg.rs:123:28
    |
 LL |         asm!("", out("a2") x);
    |                            ^
@@ -317,7 +317,7 @@ LL |         asm!("", out("a2") x);
    = note: register class `areg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:127:35
+  --> $DIR/bad-reg.rs:126:35
    |
 LL |         asm!("/* {} */", in(areg) x);
    |                                   ^

--- a/tests/ui/asm/s390x/bad-reg.s390x_vector_stable.stderr
+++ b/tests/ui/asm/s390x/bad-reg.s390x_vector_stable.stderr
@@ -1,125 +1,125 @@
 error: invalid register `r11`: The frame pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:32:18
+  --> $DIR/bad-reg.rs:31:18
    |
 LL |         asm!("", out("r11") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `r15`: The stack pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:34:18
+  --> $DIR/bad-reg.rs:33:18
    |
 LL |         asm!("", out("r15") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `c0`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:36:18
+  --> $DIR/bad-reg.rs:35:18
    |
 LL |         asm!("", out("c0") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `c1`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:38:18
+  --> $DIR/bad-reg.rs:37:18
    |
 LL |         asm!("", out("c1") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `c2`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:40:18
+  --> $DIR/bad-reg.rs:39:18
    |
 LL |         asm!("", out("c2") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `c3`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:42:18
+  --> $DIR/bad-reg.rs:41:18
    |
 LL |         asm!("", out("c3") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `c4`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:44:18
+  --> $DIR/bad-reg.rs:43:18
    |
 LL |         asm!("", out("c4") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `c5`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:46:18
+  --> $DIR/bad-reg.rs:45:18
    |
 LL |         asm!("", out("c5") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `c6`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:48:18
+  --> $DIR/bad-reg.rs:47:18
    |
 LL |         asm!("", out("c6") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `c7`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:50:18
+  --> $DIR/bad-reg.rs:49:18
    |
 LL |         asm!("", out("c7") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `c8`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:52:18
+  --> $DIR/bad-reg.rs:51:18
    |
 LL |         asm!("", out("c8") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `c9`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:54:18
+  --> $DIR/bad-reg.rs:53:18
    |
 LL |         asm!("", out("c9") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `c10`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:56:18
+  --> $DIR/bad-reg.rs:55:18
    |
 LL |         asm!("", out("c10") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `c11`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:58:18
+  --> $DIR/bad-reg.rs:57:18
    |
 LL |         asm!("", out("c11") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `c12`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:60:18
+  --> $DIR/bad-reg.rs:59:18
    |
 LL |         asm!("", out("c12") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `c13`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:62:18
+  --> $DIR/bad-reg.rs:61:18
    |
 LL |         asm!("", out("c13") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `c14`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:64:18
+  --> $DIR/bad-reg.rs:63:18
    |
 LL |         asm!("", out("c14") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `c15`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:66:18
+  --> $DIR/bad-reg.rs:65:18
    |
 LL |         asm!("", out("c15") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `a0`: a0 and a1 are reserved for system use and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:68:18
+  --> $DIR/bad-reg.rs:67:18
    |
 LL |         asm!("", out("a0") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `a1`: a0 and a1 are reserved for system use and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:70:18
+  --> $DIR/bad-reg.rs:69:18
    |
 LL |         asm!("", out("a1") _);
    |                  ^^^^^^^^^^^
 
 error[E0658]: register class `vreg` can only be used as a clobber in stable
-  --> $DIR/bad-reg.rs:75:18
+  --> $DIR/bad-reg.rs:74:18
    |
 LL |         asm!("", in("v0") v); // requires vector & asm_experimental_reg
    |                  ^^^^^^^^^^
@@ -129,7 +129,7 @@ LL |         asm!("", in("v0") v); // requires vector & asm_experimental_reg
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: register class `vreg` can only be used as a clobber in stable
-  --> $DIR/bad-reg.rs:79:18
+  --> $DIR/bad-reg.rs:78:18
    |
 LL |         asm!("", out("v0") v); // requires vector & asm_experimental_reg
    |                  ^^^^^^^^^^^
@@ -139,7 +139,7 @@ LL |         asm!("", out("v0") v); // requires vector & asm_experimental_reg
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: register class `vreg` can only be used as a clobber in stable
-  --> $DIR/bad-reg.rs:83:18
+  --> $DIR/bad-reg.rs:82:18
    |
 LL |         asm!("", in("v0") x); // requires vector & asm_experimental_reg
    |                  ^^^^^^^^^^
@@ -149,7 +149,7 @@ LL |         asm!("", in("v0") x); // requires vector & asm_experimental_reg
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: register class `vreg` can only be used as a clobber in stable
-  --> $DIR/bad-reg.rs:87:18
+  --> $DIR/bad-reg.rs:86:18
    |
 LL |         asm!("", out("v0") x); // requires vector & asm_experimental_reg
    |                  ^^^^^^^^^^^
@@ -159,7 +159,7 @@ LL |         asm!("", out("v0") x); // requires vector & asm_experimental_reg
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: register class `vreg` can only be used as a clobber in stable
-  --> $DIR/bad-reg.rs:91:18
+  --> $DIR/bad-reg.rs:90:18
    |
 LL |         asm!("", in("v0") b);
    |                  ^^^^^^^^^^
@@ -169,7 +169,7 @@ LL |         asm!("", in("v0") b);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: register class `vreg` can only be used as a clobber in stable
-  --> $DIR/bad-reg.rs:96:18
+  --> $DIR/bad-reg.rs:95:18
    |
 LL |         asm!("", out("v0") b);
    |                  ^^^^^^^^^^^
@@ -179,7 +179,7 @@ LL |         asm!("", out("v0") b);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: register class `vreg` can only be used as a clobber in stable
-  --> $DIR/bad-reg.rs:101:26
+  --> $DIR/bad-reg.rs:100:26
    |
 LL |         asm!("/* {} */", in(vreg) v); // requires vector & asm_experimental_reg
    |                          ^^^^^^^^^^
@@ -189,7 +189,7 @@ LL |         asm!("/* {} */", in(vreg) v); // requires vector & asm_experimental
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: register class `vreg` can only be used as a clobber in stable
-  --> $DIR/bad-reg.rs:105:26
+  --> $DIR/bad-reg.rs:104:26
    |
 LL |         asm!("/* {} */", in(vreg) x); // requires vector & asm_experimental_reg
    |                          ^^^^^^^^^^
@@ -199,7 +199,7 @@ LL |         asm!("/* {} */", in(vreg) x); // requires vector & asm_experimental
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: register class `vreg` can only be used as a clobber in stable
-  --> $DIR/bad-reg.rs:109:26
+  --> $DIR/bad-reg.rs:108:26
    |
 LL |         asm!("/* {} */", in(vreg) b);
    |                          ^^^^^^^^^^
@@ -209,7 +209,7 @@ LL |         asm!("/* {} */", in(vreg) b);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: register class `vreg` can only be used as a clobber in stable
-  --> $DIR/bad-reg.rs:114:26
+  --> $DIR/bad-reg.rs:113:26
    |
 LL |         asm!("/* {} */", out(vreg) _); // requires vector & asm_experimental_reg
    |                          ^^^^^^^^^^^
@@ -219,31 +219,31 @@ LL |         asm!("/* {} */", out(vreg) _); // requires vector & asm_experimenta
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: register class `areg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:121:18
+  --> $DIR/bad-reg.rs:120:18
    |
 LL |         asm!("", in("a2") x);
    |                  ^^^^^^^^^^
 
 error: register class `areg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:124:18
+  --> $DIR/bad-reg.rs:123:18
    |
 LL |         asm!("", out("a2") x);
    |                  ^^^^^^^^^^^
 
 error: register class `areg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:127:26
+  --> $DIR/bad-reg.rs:126:26
    |
 LL |         asm!("/* {} */", in(areg) x);
    |                          ^^^^^^^^^^
 
 error: register class `areg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:130:26
+  --> $DIR/bad-reg.rs:129:26
    |
 LL |         asm!("/* {} */", out(areg) _);
    |                          ^^^^^^^^^^^
 
 error: register `f0` conflicts with register `v0`
-  --> $DIR/bad-reg.rs:135:31
+  --> $DIR/bad-reg.rs:134:31
    |
 LL |         asm!("", out("v0") _, out("f0") _);
    |                  -----------  ^^^^^^^^^^^ register `f0`
@@ -251,7 +251,7 @@ LL |         asm!("", out("v0") _, out("f0") _);
    |                  register `v0`
 
 error: register `f1` conflicts with register `v1`
-  --> $DIR/bad-reg.rs:137:31
+  --> $DIR/bad-reg.rs:136:31
    |
 LL |         asm!("", out("v1") _, out("f1") _);
    |                  -----------  ^^^^^^^^^^^ register `f1`
@@ -259,7 +259,7 @@ LL |         asm!("", out("v1") _, out("f1") _);
    |                  register `v1`
 
 error: register `f2` conflicts with register `v2`
-  --> $DIR/bad-reg.rs:139:31
+  --> $DIR/bad-reg.rs:138:31
    |
 LL |         asm!("", out("v2") _, out("f2") _);
    |                  -----------  ^^^^^^^^^^^ register `f2`
@@ -267,7 +267,7 @@ LL |         asm!("", out("v2") _, out("f2") _);
    |                  register `v2`
 
 error: register `f3` conflicts with register `v3`
-  --> $DIR/bad-reg.rs:141:31
+  --> $DIR/bad-reg.rs:140:31
    |
 LL |         asm!("", out("v3") _, out("f3") _);
    |                  -----------  ^^^^^^^^^^^ register `f3`
@@ -275,7 +275,7 @@ LL |         asm!("", out("v3") _, out("f3") _);
    |                  register `v3`
 
 error: register `f4` conflicts with register `v4`
-  --> $DIR/bad-reg.rs:143:31
+  --> $DIR/bad-reg.rs:142:31
    |
 LL |         asm!("", out("v4") _, out("f4") _);
    |                  -----------  ^^^^^^^^^^^ register `f4`
@@ -283,7 +283,7 @@ LL |         asm!("", out("v4") _, out("f4") _);
    |                  register `v4`
 
 error: register `f5` conflicts with register `v5`
-  --> $DIR/bad-reg.rs:145:31
+  --> $DIR/bad-reg.rs:144:31
    |
 LL |         asm!("", out("v5") _, out("f5") _);
    |                  -----------  ^^^^^^^^^^^ register `f5`
@@ -291,7 +291,7 @@ LL |         asm!("", out("v5") _, out("f5") _);
    |                  register `v5`
 
 error: register `f6` conflicts with register `v6`
-  --> $DIR/bad-reg.rs:147:31
+  --> $DIR/bad-reg.rs:146:31
    |
 LL |         asm!("", out("v6") _, out("f6") _);
    |                  -----------  ^^^^^^^^^^^ register `f6`
@@ -299,7 +299,7 @@ LL |         asm!("", out("v6") _, out("f6") _);
    |                  register `v6`
 
 error: register `f7` conflicts with register `v7`
-  --> $DIR/bad-reg.rs:149:31
+  --> $DIR/bad-reg.rs:148:31
    |
 LL |         asm!("", out("v7") _, out("f7") _);
    |                  -----------  ^^^^^^^^^^^ register `f7`
@@ -307,7 +307,7 @@ LL |         asm!("", out("v7") _, out("f7") _);
    |                  register `v7`
 
 error: register `f8` conflicts with register `v8`
-  --> $DIR/bad-reg.rs:151:31
+  --> $DIR/bad-reg.rs:150:31
    |
 LL |         asm!("", out("v8") _, out("f8") _);
    |                  -----------  ^^^^^^^^^^^ register `f8`
@@ -315,7 +315,7 @@ LL |         asm!("", out("v8") _, out("f8") _);
    |                  register `v8`
 
 error: register `f9` conflicts with register `v9`
-  --> $DIR/bad-reg.rs:153:31
+  --> $DIR/bad-reg.rs:152:31
    |
 LL |         asm!("", out("v9") _, out("f9") _);
    |                  -----------  ^^^^^^^^^^^ register `f9`
@@ -323,7 +323,7 @@ LL |         asm!("", out("v9") _, out("f9") _);
    |                  register `v9`
 
 error: register `f10` conflicts with register `v10`
-  --> $DIR/bad-reg.rs:155:32
+  --> $DIR/bad-reg.rs:154:32
    |
 LL |         asm!("", out("v10") _, out("f10") _);
    |                  ------------  ^^^^^^^^^^^^ register `f10`
@@ -331,7 +331,7 @@ LL |         asm!("", out("v10") _, out("f10") _);
    |                  register `v10`
 
 error: register `f11` conflicts with register `v11`
-  --> $DIR/bad-reg.rs:157:32
+  --> $DIR/bad-reg.rs:156:32
    |
 LL |         asm!("", out("v11") _, out("f11") _);
    |                  ------------  ^^^^^^^^^^^^ register `f11`
@@ -339,7 +339,7 @@ LL |         asm!("", out("v11") _, out("f11") _);
    |                  register `v11`
 
 error: register `f12` conflicts with register `v12`
-  --> $DIR/bad-reg.rs:159:32
+  --> $DIR/bad-reg.rs:158:32
    |
 LL |         asm!("", out("v12") _, out("f12") _);
    |                  ------------  ^^^^^^^^^^^^ register `f12`
@@ -347,7 +347,7 @@ LL |         asm!("", out("v12") _, out("f12") _);
    |                  register `v12`
 
 error: register `f13` conflicts with register `v13`
-  --> $DIR/bad-reg.rs:161:32
+  --> $DIR/bad-reg.rs:160:32
    |
 LL |         asm!("", out("v13") _, out("f13") _);
    |                  ------------  ^^^^^^^^^^^^ register `f13`
@@ -355,7 +355,7 @@ LL |         asm!("", out("v13") _, out("f13") _);
    |                  register `v13`
 
 error: register `f14` conflicts with register `v14`
-  --> $DIR/bad-reg.rs:163:32
+  --> $DIR/bad-reg.rs:162:32
    |
 LL |         asm!("", out("v14") _, out("f14") _);
    |                  ------------  ^^^^^^^^^^^^ register `f14`
@@ -363,7 +363,7 @@ LL |         asm!("", out("v14") _, out("f14") _);
    |                  register `v14`
 
 error: register `f15` conflicts with register `v15`
-  --> $DIR/bad-reg.rs:165:32
+  --> $DIR/bad-reg.rs:164:32
    |
 LL |         asm!("", out("v15") _, out("f15") _);
    |                  ------------  ^^^^^^^^^^^^ register `f15`
@@ -371,13 +371,13 @@ LL |         asm!("", out("v15") _, out("f15") _);
    |                  register `v15`
 
 error: invalid register `f16`: unknown register
-  --> $DIR/bad-reg.rs:168:32
+  --> $DIR/bad-reg.rs:167:32
    |
 LL |         asm!("", out("v16") _, out("f16") _);
    |                                ^^^^^^^^^^^^
 
 error[E0658]: type `i64x2` cannot be used with this register class in stable
-  --> $DIR/bad-reg.rs:75:27
+  --> $DIR/bad-reg.rs:74:27
    |
 LL |         asm!("", in("v0") v); // requires vector & asm_experimental_reg
    |                           ^
@@ -387,7 +387,7 @@ LL |         asm!("", in("v0") v); // requires vector & asm_experimental_reg
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: type `i64x2` cannot be used with this register class in stable
-  --> $DIR/bad-reg.rs:79:28
+  --> $DIR/bad-reg.rs:78:28
    |
 LL |         asm!("", out("v0") v); // requires vector & asm_experimental_reg
    |                            ^
@@ -397,7 +397,7 @@ LL |         asm!("", out("v0") v); // requires vector & asm_experimental_reg
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: type `i32` cannot be used with this register class in stable
-  --> $DIR/bad-reg.rs:83:27
+  --> $DIR/bad-reg.rs:82:27
    |
 LL |         asm!("", in("v0") x); // requires vector & asm_experimental_reg
    |                           ^
@@ -407,7 +407,7 @@ LL |         asm!("", in("v0") x); // requires vector & asm_experimental_reg
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: type `i32` cannot be used with this register class in stable
-  --> $DIR/bad-reg.rs:87:28
+  --> $DIR/bad-reg.rs:86:28
    |
 LL |         asm!("", out("v0") x); // requires vector & asm_experimental_reg
    |                            ^
@@ -417,7 +417,7 @@ LL |         asm!("", out("v0") x); // requires vector & asm_experimental_reg
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: type `u8` cannot be used with this register class
-  --> $DIR/bad-reg.rs:91:27
+  --> $DIR/bad-reg.rs:90:27
    |
 LL |         asm!("", in("v0") b);
    |                           ^
@@ -425,7 +425,7 @@ LL |         asm!("", in("v0") b);
    = note: register class `vreg` supports these types: 
 
 error: type `u8` cannot be used with this register class
-  --> $DIR/bad-reg.rs:96:28
+  --> $DIR/bad-reg.rs:95:28
    |
 LL |         asm!("", out("v0") b);
    |                            ^
@@ -433,7 +433,7 @@ LL |         asm!("", out("v0") b);
    = note: register class `vreg` supports these types: 
 
 error[E0658]: type `i64x2` cannot be used with this register class in stable
-  --> $DIR/bad-reg.rs:101:35
+  --> $DIR/bad-reg.rs:100:35
    |
 LL |         asm!("/* {} */", in(vreg) v); // requires vector & asm_experimental_reg
    |                                   ^
@@ -443,7 +443,7 @@ LL |         asm!("/* {} */", in(vreg) v); // requires vector & asm_experimental
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: type `i32` cannot be used with this register class in stable
-  --> $DIR/bad-reg.rs:105:35
+  --> $DIR/bad-reg.rs:104:35
    |
 LL |         asm!("/* {} */", in(vreg) x); // requires vector & asm_experimental_reg
    |                                   ^
@@ -453,7 +453,7 @@ LL |         asm!("/* {} */", in(vreg) x); // requires vector & asm_experimental
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: type `u8` cannot be used with this register class
-  --> $DIR/bad-reg.rs:109:35
+  --> $DIR/bad-reg.rs:108:35
    |
 LL |         asm!("/* {} */", in(vreg) b);
    |                                   ^
@@ -461,7 +461,7 @@ LL |         asm!("/* {} */", in(vreg) b);
    = note: register class `vreg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:121:27
+  --> $DIR/bad-reg.rs:120:27
    |
 LL |         asm!("", in("a2") x);
    |                           ^
@@ -469,7 +469,7 @@ LL |         asm!("", in("a2") x);
    = note: register class `areg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:124:28
+  --> $DIR/bad-reg.rs:123:28
    |
 LL |         asm!("", out("a2") x);
    |                            ^
@@ -477,7 +477,7 @@ LL |         asm!("", out("a2") x);
    = note: register class `areg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:127:35
+  --> $DIR/bad-reg.rs:126:35
    |
 LL |         asm!("/* {} */", in(areg) x);
    |                                   ^

--- a/tests/ui/asm/sparc/bad-reg.rs
+++ b/tests/ui/asm/sparc/bad-reg.rs
@@ -6,7 +6,6 @@
 //@[sparcv8plus] needs-llvm-components: sparc
 //@[sparc64] compile-flags: --target sparc64-unknown-linux-gnu
 //@[sparc64] needs-llvm-components: sparc
-//@ needs-asm-support
 //@ ignore-backends: gcc
 
 #![crate_type = "rlib"]

--- a/tests/ui/asm/sparc/bad-reg.sparc.stderr
+++ b/tests/ui/asm/sparc/bad-reg.sparc.stderr
@@ -1,77 +1,77 @@
 error: invalid register `g0`: g0 is always zero and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:23:18
+  --> $DIR/bad-reg.rs:22:18
    |
 LL |         asm!("", out("g0") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `g1`: reserved by LLVM and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:26:18
+  --> $DIR/bad-reg.rs:25:18
    |
 LL |         asm!("", out("g1") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `g6`: reserved for system and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:33:18
+  --> $DIR/bad-reg.rs:32:18
    |
 LL |         asm!("", out("g6") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `g7`: reserved for system and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:35:18
+  --> $DIR/bad-reg.rs:34:18
    |
 LL |         asm!("", out("g7") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `sp`: the stack pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:37:18
+  --> $DIR/bad-reg.rs:36:18
    |
 LL |         asm!("", out("sp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `fp`: the frame pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:39:18
+  --> $DIR/bad-reg.rs:38:18
    |
 LL |         asm!("", out("fp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `i7`: the return address register cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:41:18
+  --> $DIR/bad-reg.rs:40:18
    |
 LL |         asm!("", out("i7") _);
    |                  ^^^^^^^^^^^
 
 error: register class `yreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:47:18
+  --> $DIR/bad-reg.rs:46:18
    |
 LL |         asm!("", in("y") x);
    |                  ^^^^^^^^^
 
 error: register class `yreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:50:18
+  --> $DIR/bad-reg.rs:49:18
    |
 LL |         asm!("", out("y") x);
    |                  ^^^^^^^^^^
 
 error: register class `yreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:53:26
+  --> $DIR/bad-reg.rs:52:26
    |
 LL |         asm!("/* {} */", in(yreg) x);
    |                          ^^^^^^^^^^
 
 error: register class `yreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:56:26
+  --> $DIR/bad-reg.rs:55:26
    |
 LL |         asm!("/* {} */", out(yreg) _);
    |                          ^^^^^^^^^^^
 
 error: cannot use register `r5`: g5 is reserved for system on SPARC32
-  --> $DIR/bad-reg.rs:31:18
+  --> $DIR/bad-reg.rs:30:18
    |
 LL |         asm!("", out("g5") _);
    |                  ^^^^^^^^^^^
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:47:26
+  --> $DIR/bad-reg.rs:46:26
    |
 LL |         asm!("", in("y") x);
    |                          ^
@@ -79,7 +79,7 @@ LL |         asm!("", in("y") x);
    = note: register class `yreg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:50:27
+  --> $DIR/bad-reg.rs:49:27
    |
 LL |         asm!("", out("y") x);
    |                           ^
@@ -87,7 +87,7 @@ LL |         asm!("", out("y") x);
    = note: register class `yreg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:53:35
+  --> $DIR/bad-reg.rs:52:35
    |
 LL |         asm!("/* {} */", in(yreg) x);
    |                                   ^

--- a/tests/ui/asm/sparc/bad-reg.sparc64.stderr
+++ b/tests/ui/asm/sparc/bad-reg.sparc64.stderr
@@ -1,71 +1,71 @@
 error: invalid register `g0`: g0 is always zero and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:23:18
+  --> $DIR/bad-reg.rs:22:18
    |
 LL |         asm!("", out("g0") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `g1`: reserved by LLVM and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:26:18
+  --> $DIR/bad-reg.rs:25:18
    |
 LL |         asm!("", out("g1") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `g6`: reserved for system and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:33:18
+  --> $DIR/bad-reg.rs:32:18
    |
 LL |         asm!("", out("g6") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `g7`: reserved for system and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:35:18
+  --> $DIR/bad-reg.rs:34:18
    |
 LL |         asm!("", out("g7") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `sp`: the stack pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:37:18
+  --> $DIR/bad-reg.rs:36:18
    |
 LL |         asm!("", out("sp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `fp`: the frame pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:39:18
+  --> $DIR/bad-reg.rs:38:18
    |
 LL |         asm!("", out("fp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `i7`: the return address register cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:41:18
+  --> $DIR/bad-reg.rs:40:18
    |
 LL |         asm!("", out("i7") _);
    |                  ^^^^^^^^^^^
 
 error: register class `yreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:47:18
+  --> $DIR/bad-reg.rs:46:18
    |
 LL |         asm!("", in("y") x);
    |                  ^^^^^^^^^
 
 error: register class `yreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:50:18
+  --> $DIR/bad-reg.rs:49:18
    |
 LL |         asm!("", out("y") x);
    |                  ^^^^^^^^^^
 
 error: register class `yreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:53:26
+  --> $DIR/bad-reg.rs:52:26
    |
 LL |         asm!("/* {} */", in(yreg) x);
    |                          ^^^^^^^^^^
 
 error: register class `yreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:56:26
+  --> $DIR/bad-reg.rs:55:26
    |
 LL |         asm!("/* {} */", out(yreg) _);
    |                          ^^^^^^^^^^^
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:47:26
+  --> $DIR/bad-reg.rs:46:26
    |
 LL |         asm!("", in("y") x);
    |                          ^
@@ -73,7 +73,7 @@ LL |         asm!("", in("y") x);
    = note: register class `yreg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:50:27
+  --> $DIR/bad-reg.rs:49:27
    |
 LL |         asm!("", out("y") x);
    |                           ^
@@ -81,7 +81,7 @@ LL |         asm!("", out("y") x);
    = note: register class `yreg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:53:35
+  --> $DIR/bad-reg.rs:52:35
    |
 LL |         asm!("/* {} */", in(yreg) x);
    |                                   ^

--- a/tests/ui/asm/sparc/bad-reg.sparcv8plus.stderr
+++ b/tests/ui/asm/sparc/bad-reg.sparcv8plus.stderr
@@ -1,77 +1,77 @@
 error: invalid register `g0`: g0 is always zero and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:23:18
+  --> $DIR/bad-reg.rs:22:18
    |
 LL |         asm!("", out("g0") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `g1`: reserved by LLVM and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:26:18
+  --> $DIR/bad-reg.rs:25:18
    |
 LL |         asm!("", out("g1") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `g6`: reserved for system and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:33:18
+  --> $DIR/bad-reg.rs:32:18
    |
 LL |         asm!("", out("g6") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `g7`: reserved for system and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:35:18
+  --> $DIR/bad-reg.rs:34:18
    |
 LL |         asm!("", out("g7") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `sp`: the stack pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:37:18
+  --> $DIR/bad-reg.rs:36:18
    |
 LL |         asm!("", out("sp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `fp`: the frame pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:39:18
+  --> $DIR/bad-reg.rs:38:18
    |
 LL |         asm!("", out("fp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `i7`: the return address register cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:41:18
+  --> $DIR/bad-reg.rs:40:18
    |
 LL |         asm!("", out("i7") _);
    |                  ^^^^^^^^^^^
 
 error: register class `yreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:47:18
+  --> $DIR/bad-reg.rs:46:18
    |
 LL |         asm!("", in("y") x);
    |                  ^^^^^^^^^
 
 error: register class `yreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:50:18
+  --> $DIR/bad-reg.rs:49:18
    |
 LL |         asm!("", out("y") x);
    |                  ^^^^^^^^^^
 
 error: register class `yreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:53:26
+  --> $DIR/bad-reg.rs:52:26
    |
 LL |         asm!("/* {} */", in(yreg) x);
    |                          ^^^^^^^^^^
 
 error: register class `yreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:56:26
+  --> $DIR/bad-reg.rs:55:26
    |
 LL |         asm!("/* {} */", out(yreg) _);
    |                          ^^^^^^^^^^^
 
 error: cannot use register `r5`: g5 is reserved for system on SPARC32
-  --> $DIR/bad-reg.rs:31:18
+  --> $DIR/bad-reg.rs:30:18
    |
 LL |         asm!("", out("g5") _);
    |                  ^^^^^^^^^^^
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:47:26
+  --> $DIR/bad-reg.rs:46:26
    |
 LL |         asm!("", in("y") x);
    |                          ^
@@ -79,7 +79,7 @@ LL |         asm!("", in("y") x);
    = note: register class `yreg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:50:27
+  --> $DIR/bad-reg.rs:49:27
    |
 LL |         asm!("", out("y") x);
    |                           ^
@@ -87,7 +87,7 @@ LL |         asm!("", out("y") x);
    = note: register class `yreg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:53:35
+  --> $DIR/bad-reg.rs:52:35
    |
 LL |         asm!("/* {} */", in(yreg) x);
    |                                   ^

--- a/tests/ui/feature-gates/feature-gate-asm_experimental_reg.rs
+++ b/tests/ui/feature-gates/feature-gate-asm_experimental_reg.rs
@@ -1,5 +1,4 @@
 //@ add-core-stubs
-//@ needs-asm-support
 //@ compile-flags: --target s390x-unknown-linux-gnu
 //@ needs-llvm-components: systemz
 //@ ignore-backends: gcc

--- a/tests/ui/feature-gates/feature-gate-asm_experimental_reg.stderr
+++ b/tests/ui/feature-gates/feature-gate-asm_experimental_reg.stderr
@@ -1,5 +1,5 @@
 error[E0658]: register class `vreg` can only be used as a clobber in stable
-  --> $DIR/feature-gate-asm_experimental_reg.rs:15:14
+  --> $DIR/feature-gate-asm_experimental_reg.rs:14:14
    |
 LL |     asm!("", in("v0") 0);
    |              ^^^^^^^^^^
@@ -9,7 +9,7 @@ LL |     asm!("", in("v0") 0);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: type `i32` cannot be used with this register class in stable
-  --> $DIR/feature-gate-asm_experimental_reg.rs:15:23
+  --> $DIR/feature-gate-asm_experimental_reg.rs:14:23
    |
 LL |     asm!("", in("v0") 0);
    |                       ^


### PR DESCRIPTION
The `needs-asm-support` directive checks whether the host architecture supports inline assembly, not the target architecture. For tests that explicitly specify a target via `--target` in their compile-flags, this directive is incorrect and unnecessary.

These tests are cross-compiling to specific targets (like x86_64, arm, aarch64, riscv, etc.) that are already known to have stable asm support. The directive was causing these tests to be incorrectly skipped on hosts that don't support asm, even though the target does.

Tests with explicit targets should rely on `needs-llvm-components` to ensure the appropriate backend is available, rather than checking host asm support.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
