### PR TITLE
Convert impossible cases in macro resolution into assertions

### DIFF
--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -2226,16 +2226,14 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         // Some non-controversial subset of ambiguities "modularized macro name" vs "macro_rules"
         // is disambiguated to mitigate regressions from macro modularization.
         // Scoping for `macro_rules` behaves like scoping for `let` at module level, in general.
-        match (
-            self.binding_parent_modules.get(&macro_rules),
-            self.binding_parent_modules.get(&modularized),
-        ) {
-            (Some(macro_rules), Some(modularized)) => {
-                macro_rules.nearest_parent_mod() == modularized.nearest_parent_mod()
-                    && modularized.is_ancestor_of(*macro_rules)
-            }
-            _ => false,
-        }
+        //
+        // panic on index should be impossible, the only name_bindings passed in should be from
+        // `resolve_ident_in_scope_set` which will always refer to a local binding from an
+        // import or macro definition
+        let macro_rules = &self.binding_parent_modules[&macro_rules];
+        let modularized = &self.binding_parent_modules[&modularized];
+        macro_rules.nearest_parent_mod() == modularized.nearest_parent_mod()
+            && modularized.is_ancestor_of(*macro_rules)
     }
 
     fn extern_prelude_get_item<'r>(


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
associated discussion with @petrochenkov: [#t-compiler/help > understanding early name resolution of imports @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/182449-t-compiler.2Fhelp/topic/understanding.20early.20name.20resolution.20of.20imports/near/542936677)