### PR TITLE
Early return if span is from expansion so we dont get empty span and ice later on

### DIFF
--- a/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
@@ -942,6 +942,11 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             err.span_label(block.span, "this empty block is missing a tail expression");
             return;
         };
+        // FIXME expr and stmt have the same span if expr comes from expansion
+        // cc: https://github.com/rust-lang/rust/pull/147416#discussion_r2499407523
+        if stmt.span.from_expansion() {
+            return;
+        }
         let hir::StmtKind::Semi(tail_expr) = stmt.kind else {
             return;
         };

--- a/tests/ui/macros/macro-expansion-empty-span-147255.rs
+++ b/tests/ui/macros/macro-expansion-empty-span-147255.rs
@@ -1,0 +1,10 @@
+//! Regression test for <https://github.com/rust-lang/rust/issues/147255>
+
+fn main() {
+    let mut x = 4;
+    let x_str = {
+        format!("{}", x);
+        //()
+    };
+    println!("{}", x_str); //~ ERROR `()` doesn't implement `std::fmt::Display`
+}

--- a/tests/ui/macros/macro-expansion-empty-span-147255.stderr
+++ b/tests/ui/macros/macro-expansion-empty-span-147255.stderr
@@ -1,0 +1,15 @@
+error[E0277]: `()` doesn't implement `std::fmt::Display`
+  --> $DIR/macro-expansion-empty-span-147255.rs:9:20
+   |
+LL |     println!("{}", x_str);
+   |               --   ^^^^^ `()` cannot be formatted with the default formatter
+   |               |
+   |               required by this formatting parameter
+   |
+   = help: the trait `std::fmt::Display` is not implemented for `()`
+   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
+   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Fixes https://github.com/rust-lang/rust/issues/147255

The problem original was from that stmt.span was from expansion and it span was bigger than right part which is block.span, so it causes empty span and panic later on, I decided to add checks for both of them to be on the safe side

r? @fmease (you were in discussion on this issue so I decided to assign you, feel free to reroll) 
