### PR TITLE
Add check if span is from macro expansion

### DIFF
--- a/tests/ui/macros/macro-expansion-empty-span-147408.rs
+++ b/tests/ui/macros/macro-expansion-empty-span-147408.rs
@@ -1,0 +1,24 @@
+//@ check-pass
+//@ compile-flags: -Afor_loops_over_fallibles -Warray_into_iter
+
+fn main() {
+    macro_rules! mac {
+        (iter $e:expr) => {
+            $e.iter()
+        };
+        (into_iter $e:expr) => {
+            $e.into_iter() //~ WARN this method call resolves to
+            //~^ WARN this changes meaning in Rust 2021
+        };
+        (next $e:expr) => {
+            $e.iter().next()
+        };
+    }
+
+    for _ in dbg!([1, 2]).iter() {}
+    for _ in dbg!([1, 2]).into_iter() {} //~ WARN this method call resolves to
+    //~^ WARN this changes meaning in Rust 2021
+    for _ in mac!(iter [1, 2]) {}
+    for _ in mac!(into_iter [1, 2]) {}
+    for _ in mac!(next [1, 2]) {}
+}

--- a/tests/ui/macros/macro-expansion-empty-span-147408.stderr
+++ b/tests/ui/macros/macro-expansion-empty-span-147408.stderr
@@ -1,0 +1,35 @@
+warning: this method call resolves to `<&[T; N] as IntoIterator>::into_iter` (due to backwards compatibility), but will resolve to `<[T; N] as IntoIterator>::into_iter` in Rust 2021
+  --> $DIR/macro-expansion-empty-span-147408.rs:19:27
+   |
+LL |     for _ in dbg!([1, 2]).into_iter() {}
+   |                           ^^^^^^^^^
+   |
+   = warning: this changes meaning in Rust 2021
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/IntoIterator-for-arrays.html>
+   = note: requested on the command line with `-W array-into-iter`
+help: use `.iter()` instead of `.into_iter()` to avoid ambiguity
+   |
+LL -     for _ in dbg!([1, 2]).into_iter() {}
+LL +     for _ in dbg!([1, 2]).iter() {}
+   |
+help: or remove `.into_iter()` to iterate by value
+   |
+LL -     for _ in dbg!([1, 2]).into_iter() {}
+LL +     for _ in dbg!([1, 2]) {}
+   |
+
+warning: this method call resolves to `<&[T; N] as IntoIterator>::into_iter` (due to backwards compatibility), but will resolve to `<[T; N] as IntoIterator>::into_iter` in Rust 2021
+  --> $DIR/macro-expansion-empty-span-147408.rs:10:16
+   |
+LL |             $e.into_iter()
+   |                ^^^^^^^^^ help: use `.iter()` instead of `.into_iter()` to avoid ambiguity: `iter`
+...
+LL |     for _ in mac!(into_iter [1, 2]) {}
+   |              ---------------------- in this macro invocation
+   |
+   = warning: this changes meaning in Rust 2021
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/IntoIterator-for-arrays.html>
+   = note: this warning originates in the macro `mac` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+warning: 2 warnings emitted
+


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

The same thing I did in https://github.com/rust-lang/rust/pull/147416, actually the same bug but in another place, I'm not really sure how this method is good for fixing such ICEs, but, it does work and not conflicting with any existing tests, so I guess, it's fine

Fixes https://github.com/rust-lang/rust/issues/147408

r? compiler
