### PR TITLE
`DepNodeColor` tweaks

### DIFF
--- a/compiler/rustc_query_system/src/dep_graph/graph.rs
+++ b/compiler/rustc_query_system/src/dep_graph/graph.rs
@@ -148,10 +148,9 @@ impl<D: Deps> DepGraph<D> {
         );
         assert_eq!(red_node_index, DepNodeIndex::FOREVER_RED_NODE);
         if prev_graph_node_count > 0 {
-            colors.insert(
-                SerializedDepNodeIndex::from_u32(DepNodeIndex::FOREVER_RED_NODE.as_u32()),
-                DepNodeColor::Red,
-            );
+            colors.insert_red(SerializedDepNodeIndex::from_u32(
+                DepNodeIndex::FOREVER_RED_NODE.as_u32(),
+            ));
         }
 
         DepGraph {
@@ -1384,14 +1383,8 @@ impl DepNodeColorMap {
     }
 
     #[inline]
-    pub(super) fn insert(&self, index: SerializedDepNodeIndex, color: DepNodeColor) {
-        self.values[index].store(
-            match color {
-                DepNodeColor::Red => COMPRESSED_RED,
-                DepNodeColor::Green(index) => index.as_u32(),
-            },
-            Ordering::Release,
-        )
+    pub(super) fn insert_red(&self, index: SerializedDepNodeIndex) {
+        self.values[index].store(COMPRESSED_RED, Ordering::Release)
     }
 }
 

--- a/compiler/rustc_query_system/src/dep_graph/mod.rs
+++ b/compiler/rustc_query_system/src/dep_graph/mod.rs
@@ -63,7 +63,7 @@ pub trait DepContext: Copy {
         self,
         dep_node: DepNode,
         prev_index: SerializedDepNodeIndex,
-        frame: Option<&MarkFrame<'_>>,
+        frame: &MarkFrame<'_>,
     ) -> bool {
         let cb = self.dep_kind_info(dep_node.kind);
         if let Some(f) = cb.force_from_dep_node {

--- a/compiler/rustc_query_system/src/dep_graph/serialized.rs
+++ b/compiler/rustc_query_system/src/dep_graph/serialized.rs
@@ -914,8 +914,9 @@ impl<D: Deps> GraphEncoder<D> {
         index
     }
 
-    /// Encodes a node that was promoted from the previous graph. It reads the information directly from
-    /// the previous dep graph and expects all edges to already have a new dep node index assigned.
+    /// Encodes a node that was promoted from the previous graph. It reads the information directly
+    /// from the previous dep graph and expects all edges to already have a new dep node index
+    /// assigned.
     ///
     /// This will also ensure the dep node is marked green.
     #[inline]

--- a/compiler/rustc_query_system/src/dep_graph/serialized.rs
+++ b/compiler/rustc_query_system/src/dep_graph/serialized.rs
@@ -59,7 +59,7 @@ use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
 use rustc_session::Session;
 use tracing::{debug, instrument};
 
-use super::graph::{CurrentDepGraph, DepNodeColor, DepNodeColorMap};
+use super::graph::{CurrentDepGraph, DepNodeColorMap};
 use super::query::DepGraphQuery;
 use super::{DepKind, DepNode, DepNodeIndex, Deps};
 use crate::dep_graph::edges::EdgesVec;
@@ -906,7 +906,7 @@ impl<D: Deps> GraphEncoder<D> {
                 Err(dep_node_index) => return dep_node_index,
             }
         } else {
-            colors.insert(prev_index, DepNodeColor::Red);
+            colors.insert_red(prev_index);
         }
 
         self.status.bump_index(&mut *local);


### PR DESCRIPTION
A follow-up to rust-lang/rust#147293, where I attempted and mostly failed to make things faster again, but I found a few cleanups worth doing.

r? @saethlin 