### PR TITLE
 tests/debuginfo/basic-stepping.rs: Add revisions `default-mir-passes`, `no-SingleUseConsts-mir-pass`

### DIFF
--- a/tests/debuginfo/basic-stepping.rs
+++ b/tests/debuginfo/basic-stepping.rs
@@ -10,6 +10,10 @@
 // Debugger tests need debuginfo
 //@ compile-flags: -g
 
+// FIXME(#128945): SingleUseConsts shouldn't need to be disabled.
+//@ revisions: default-mir-passes no-SingleUseConsts-mir-pass
+//@ [no-SingleUseConsts-mir-pass] compile-flags: -Zmir-enable-passes=-SingleUseConsts
+
 //@ gdb-command: run
 // FIXME(#97083): Should we be able to break on initialization of zero-sized types?
 // FIXME(#97083): Right now the first breakable line is:
@@ -17,12 +21,12 @@
 //@ gdb-command: next
 //@ gdb-check:   let d = c = 99;
 //@ gdb-command: next
-// FIXME(#33013): gdb-check:   let e = "hi bob";
-// FIXME(#33013): gdb-command: next
-// FIXME(#33013): gdb-check:   let f = b"hi bob";
-// FIXME(#33013): gdb-command: next
-// FIXME(#33013): gdb-check:   let g = b'9';
-// FIXME(#33013): gdb-command: next
+//@ [no-SingleUseConsts-mir-pass] gdb-check:   let e = "hi bob";
+//@ [no-SingleUseConsts-mir-pass] gdb-command: next
+//@ [no-SingleUseConsts-mir-pass] gdb-check:   let f = b"hi bob";
+//@ [no-SingleUseConsts-mir-pass] gdb-command: next
+//@ [no-SingleUseConsts-mir-pass] gdb-check:   let g = b'9';
+//@ [no-SingleUseConsts-mir-pass] gdb-command: next
 //@ gdb-check:   let h = ["whatever"; 8];
 //@ gdb-command: next
 //@ gdb-check:   let i = [1,2,3,4];

--- a/tests/debuginfo/basic-stepping.rs
+++ b/tests/debuginfo/basic-stepping.rs
@@ -5,8 +5,10 @@
 //@ ignore-aarch64: Doesn't work yet.
 //@ ignore-loongarch64: Doesn't work yet.
 //@ ignore-riscv64: Doesn't work yet.
-//@ compile-flags: -g
 //@ ignore-backends: gcc
+
+// Debugger tests need debuginfo
+//@ compile-flags: -g
 
 //@ gdb-command: run
 // FIXME(#97083): Should we be able to break on initialization of zero-sized types?


### PR DESCRIPTION
To prevent regressions our test must cover the code both inside and outside of the `SingleUseConsts` MIR pass. Use revisions for that.

We know this use case is sensitive to regressions because it already happened at least once. See https://github.com/rust-lang/rust/issues/33013#issuecomment-3121579216.

CC https://github.com/rust-lang/rust/issues/130896
