### PR TITLE
cg_llvm: More preparation for moving FFI bindings to `rustc_llvm`

### DIFF
--- a/compiler/rustc_codegen_llvm/src/debuginfo/mod.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/mod.rs
@@ -38,8 +38,9 @@ use self::namespace::mangled_name_of_instance;
 use self::utils::{DIB, create_DIArray, is_node_local_to_unit};
 use crate::builder::Builder;
 use crate::common::{AsCCharPtr, CodegenCx};
+use crate::debuginfo::di_builder::DIBuilderBox;
 use crate::llvm::debuginfo::{
-    DIArray, DIBuilderBox, DIFile, DIFlags, DILexicalBlock, DILocation, DISPFlags, DIScope,
+    DIArray, DIFile, DIFlags, DILexicalBlock, DILocation, DISPFlags, DIScope,
     DITemplateTypeParameter, DIType, DIVariable,
 };
 use crate::llvm::{self, Value};

--- a/compiler/rustc_codegen_llvm/src/llvm/conversions.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/conversions.rs
@@ -1,6 +1,6 @@
 //! Conversions from backend-independent data types to/from LLVM FFI types.
 
-use rustc_codegen_ssa::common::{AtomicRmwBinOp, IntPredicate, RealPredicate};
+use rustc_codegen_ssa::common::{AtomicRmwBinOp, IntPredicate, RealPredicate, TypeKind};
 use rustc_middle::ty::AtomicOrdering;
 use rustc_session::config::DebugInfo;
 use rustc_target::spec::SymbolVisibility;
@@ -9,8 +9,20 @@ use crate::llvm;
 
 /// Helper trait for converting backend-independent types to LLVM-specific
 /// types, for FFI purposes.
+///
+/// FIXME(#147327): These trait/method names were chosen to avoid churn in
+/// existing code, but are not great and could probably be made clearer.
 pub(crate) trait FromGeneric<T> {
     fn from_generic(other: T) -> Self;
+}
+
+/// Helper trait for converting LLVM-specific types to backend-independent
+/// types, for FFI purposes.
+///
+/// FIXME(#147327): These trait/method names were chosen to avoid churn in
+/// existing code, but are not great and could probably be made clearer.
+pub(crate) trait ToGeneric<T> {
+    fn to_generic(&self) -> T;
 }
 
 impl FromGeneric<SymbolVisibility> for llvm::Visibility {
@@ -110,6 +122,32 @@ impl FromGeneric<DebugInfo> for llvm::debuginfo::DebugEmissionKind {
             DebugInfo::LineDirectivesOnly => Self::DebugDirectivesOnly,
             DebugInfo::LineTablesOnly => Self::LineTablesOnly,
             DebugInfo::Limited | DebugInfo::Full => Self::FullDebug,
+        }
+    }
+}
+
+impl ToGeneric<TypeKind> for llvm::TypeKind {
+    fn to_generic(&self) -> TypeKind {
+        match self {
+            Self::Void => TypeKind::Void,
+            Self::Half => TypeKind::Half,
+            Self::Float => TypeKind::Float,
+            Self::Double => TypeKind::Double,
+            Self::X86_FP80 => TypeKind::X86_FP80,
+            Self::FP128 => TypeKind::FP128,
+            Self::PPC_FP128 => TypeKind::PPC_FP128,
+            Self::Label => TypeKind::Label,
+            Self::Integer => TypeKind::Integer,
+            Self::Function => TypeKind::Function,
+            Self::Struct => TypeKind::Struct,
+            Self::Array => TypeKind::Array,
+            Self::Pointer => TypeKind::Pointer,
+            Self::Vector => TypeKind::Vector,
+            Self::Metadata => TypeKind::Metadata,
+            Self::Token => TypeKind::Token,
+            Self::ScalableVector => TypeKind::ScalableVector,
+            Self::BFloat => TypeKind::BFloat,
+            Self::X86_AMX => TypeKind::X86_AMX,
         }
     }
 }

--- a/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
@@ -363,33 +363,6 @@ pub(crate) enum TypeKind {
     X86_AMX = 19,
 }
 
-impl TypeKind {
-    pub(crate) fn to_generic(self) -> rustc_codegen_ssa::common::TypeKind {
-        use rustc_codegen_ssa::common::TypeKind as Common;
-        match self {
-            Self::Void => Common::Void,
-            Self::Half => Common::Half,
-            Self::Float => Common::Float,
-            Self::Double => Common::Double,
-            Self::X86_FP80 => Common::X86_FP80,
-            Self::FP128 => Common::FP128,
-            Self::PPC_FP128 => Common::PPC_FP128,
-            Self::Label => Common::Label,
-            Self::Integer => Common::Integer,
-            Self::Function => Common::Function,
-            Self::Struct => Common::Struct,
-            Self::Array => Common::Array,
-            Self::Pointer => Common::Pointer,
-            Self::Vector => Common::Vector,
-            Self::Metadata => Common::Metadata,
-            Self::Token => Common::Token,
-            Self::ScalableVector => Common::ScalableVector,
-            Self::BFloat => Common::BFloat,
-            Self::X86_AMX => Common::X86_AMX,
-        }
-    }
-}
-
 /// LLVMAtomicRmwBinOp
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/compiler/rustc_codegen_llvm/src/type_.rs
+++ b/compiler/rustc_codegen_llvm/src/type_.rs
@@ -15,7 +15,7 @@ use rustc_target::callconv::{CastTarget, FnAbi};
 use crate::abi::{FnAbiLlvmExt, LlvmType};
 use crate::common;
 use crate::context::{CodegenCx, GenericCx, SCx};
-use crate::llvm::{self, FALSE, Metadata, TRUE, ToLlvmBool, Type, Value};
+use crate::llvm::{self, FALSE, Metadata, TRUE, ToGeneric, ToLlvmBool, Type, Value};
 use crate::type_of::LayoutLlvmExt;
 
 impl PartialEq for Type {


### PR DESCRIPTION
- Sequel to https://github.com/rust-lang/rust/pull/147327
- Motivated by https://github.com/rust-lang/rust/pull/142897

---

This is another batch of adjustments to code that would otherwise interfere with moving FFI bindings out of `rustc_codegen_llvm` and into `rustc_llvm`.