### PR TITLE
Rename "non-inline module" to "file module" in proc macro diagnostics

### DIFF
--- a/compiler/rustc_expand/messages.ftl
+++ b/compiler/rustc_expand/messages.ftl
@@ -49,6 +49,9 @@ expand_feature_removed =
     .note = removed in {$removed_rustc_version}{$pull_note}
     .reason = {$reason}
 
+expand_file_modules_in_proc_macro_input_are_unstable =
+    file modules in proc macro input are unstable
+
 expand_glob_delegation_outside_impls =
     glob delegation is only supported in impls
 
@@ -156,9 +159,6 @@ expand_mve_unrecognized_expr =
 
 expand_mve_unrecognized_var =
     variable `{$key}` is not recognized in meta-variable expression
-
-expand_non_inline_modules_in_proc_macro_input_are_unstable =
-    non-inline modules in proc macro input are unstable
 
 expand_or_patterns_back_compat = the meaning of the `pat` fragment specifier is changing in Rust 2021, which may affect this macro
     .suggestion = use pat_param to preserve semantics

--- a/compiler/rustc_expand/src/expand.rs
+++ b/compiler/rustc_expand/src/expand.rs
@@ -1050,7 +1050,7 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
                             self.sess,
                             sym::proc_macro_hygiene,
                             item.span,
-                            fluent_generated::expand_non_inline_modules_in_proc_macro_input_are_unstable,
+                            fluent_generated::expand_file_modules_in_proc_macro_input_are_unstable,
                         )
                         .emit();
                     }

--- a/tests/ui/proc-macro/attributes-on-modules-fail.rs
+++ b/tests/ui/proc-macro/attributes-on-modules-fail.rs
@@ -17,11 +17,11 @@ type A = X; //~ ERROR cannot find type `X` in this scope
 mod n {}
 
 #[empty_attr]
-mod module; //~ ERROR non-inline modules in proc macro input are unstable
+mod module; //~ ERROR file modules in proc macro input are unstable
 
 #[empty_attr]
 mod outer {
-    mod inner; //~ ERROR non-inline modules in proc macro input are unstable
+    mod inner; //~ ERROR file modules in proc macro input are unstable
 
     mod inner_inline {} // OK
 }
@@ -30,16 +30,16 @@ mod outer {
 struct S {
     field: [u8; {
         #[path = "outer/inner.rs"]
-        mod inner; //~ ERROR non-inline modules in proc macro input are unstable
+        mod inner; //~ ERROR file modules in proc macro input are unstable
         mod inner_inline {} // OK
         0
-    }]
+    }],
 }
 
 #[identity_attr]
 fn f() {
     #[path = "outer/inner.rs"]
-    mod inner; //~ ERROR non-inline modules in proc macro input are unstable
+    mod inner; //~ ERROR file modules in proc macro input are unstable
     mod inner_inline {} // OK
 }
 

--- a/tests/ui/proc-macro/attributes-on-modules-fail.stderr
+++ b/tests/ui/proc-macro/attributes-on-modules-fail.stderr
@@ -6,7 +6,7 @@ LL | #[derive(Copy)]
 LL | mod n {}
    | -------- not a `struct`, `enum` or `union`
 
-error[E0658]: non-inline modules in proc macro input are unstable
+error[E0658]: file modules in proc macro input are unstable
   --> $DIR/attributes-on-modules-fail.rs:20:1
    |
 LL | mod module;
@@ -16,7 +16,7 @@ LL | mod module;
    = help: add `#![feature(proc_macro_hygiene)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: non-inline modules in proc macro input are unstable
+error[E0658]: file modules in proc macro input are unstable
   --> $DIR/attributes-on-modules-fail.rs:24:5
    |
 LL |     mod inner;
@@ -26,7 +26,7 @@ LL |     mod inner;
    = help: add `#![feature(proc_macro_hygiene)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: non-inline modules in proc macro input are unstable
+error[E0658]: file modules in proc macro input are unstable
   --> $DIR/attributes-on-modules-fail.rs:33:9
    |
 LL |         mod inner;
@@ -36,7 +36,7 @@ LL |         mod inner;
    = help: add `#![feature(proc_macro_hygiene)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: non-inline modules in proc macro input are unstable
+error[E0658]: file modules in proc macro input are unstable
   --> $DIR/attributes-on-modules-fail.rs:42:5
    |
 LL |     mod inner;

--- a/tests/ui/proc-macro/inner-attr-file-mod.rs
+++ b/tests/ui/proc-macro/inner-attr-file-mod.rs
@@ -9,7 +9,7 @@ extern crate test_macros;
 
 #[deny(unused_attributes)]
 mod module_with_attrs;
-//~^ ERROR non-inline modules in proc macro input are unstable
+//~^ ERROR file modules in proc macro input are unstable
 //~| ERROR custom inner attributes are unstable
 
 fn main() {}

--- a/tests/ui/proc-macro/inner-attr-file-mod.stderr
+++ b/tests/ui/proc-macro/inner-attr-file-mod.stderr
@@ -18,8 +18,8 @@ LL | #![print_attr]
    = help: add `#![feature(custom_inner_attributes)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: non-inline modules in proc macro input are unstable
-  --> $DIR/inner-attr-non-inline-mod.rs:11:1
+error[E0658]: file modules in proc macro input are unstable
+  --> $DIR/inner-attr-file-mod.rs:11:1
    |
 LL | mod module_with_attrs;
    | ^^^^^^^^^^^^^^^^^^^^^^
@@ -29,7 +29,7 @@ LL | mod module_with_attrs;
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: custom inner attributes are unstable
-  --> $DIR/inner-attr-non-inline-mod.rs:11:1
+  --> $DIR/inner-attr-file-mod.rs:11:1
    |
 LL | mod module_with_attrs;
    | ^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/proc-macro/inner-attr-file-mod.stdout
+++ b/tests/ui/proc-macro/inner-attr-file-mod.stdout
@@ -4,35 +4,35 @@ PRINT-ATTR INPUT (DEBUG): TokenStream [
     Punct {
         ch: '#',
         spacing: Alone,
-        span: $DIR/inner-attr-non-inline-mod.rs:11:1: 11:23 (#0),
+        span: $DIR/inner-attr-file-mod.rs:11:1: 11:23 (#0),
     },
     Group {
         delimiter: Bracket,
         stream: TokenStream [
             Ident {
                 ident: "deny",
-                span: $DIR/inner-attr-non-inline-mod.rs:11:1: 11:23 (#0),
+                span: $DIR/inner-attr-file-mod.rs:11:1: 11:23 (#0),
             },
             Group {
                 delimiter: Parenthesis,
                 stream: TokenStream [
                     Ident {
                         ident: "unused_attributes",
-                        span: $DIR/inner-attr-non-inline-mod.rs:11:1: 11:23 (#0),
+                        span: $DIR/inner-attr-file-mod.rs:11:1: 11:23 (#0),
                     },
                 ],
-                span: $DIR/inner-attr-non-inline-mod.rs:11:1: 11:23 (#0),
+                span: $DIR/inner-attr-file-mod.rs:11:1: 11:23 (#0),
             },
         ],
-        span: $DIR/inner-attr-non-inline-mod.rs:11:1: 11:23 (#0),
+        span: $DIR/inner-attr-file-mod.rs:11:1: 11:23 (#0),
     },
     Ident {
         ident: "mod",
-        span: $DIR/inner-attr-non-inline-mod.rs:11:1: 11:23 (#0),
+        span: $DIR/inner-attr-file-mod.rs:11:1: 11:23 (#0),
     },
     Ident {
         ident: "module_with_attrs",
-        span: $DIR/inner-attr-non-inline-mod.rs:11:1: 11:23 (#0),
+        span: $DIR/inner-attr-file-mod.rs:11:1: 11:23 (#0),
     },
     Group {
         delimiter: Brace,
@@ -40,38 +40,38 @@ PRINT-ATTR INPUT (DEBUG): TokenStream [
             Punct {
                 ch: '#',
                 spacing: Joint,
-                span: $DIR/inner-attr-non-inline-mod.rs:11:1: 11:23 (#0),
+                span: $DIR/inner-attr-file-mod.rs:11:1: 11:23 (#0),
             },
             Punct {
                 ch: '!',
                 spacing: Alone,
-                span: $DIR/inner-attr-non-inline-mod.rs:11:1: 11:23 (#0),
+                span: $DIR/inner-attr-file-mod.rs:11:1: 11:23 (#0),
             },
             Group {
                 delimiter: Bracket,
                 stream: TokenStream [
                     Ident {
                         ident: "rustfmt",
-                        span: $DIR/inner-attr-non-inline-mod.rs:11:1: 11:23 (#0),
+                        span: $DIR/inner-attr-file-mod.rs:11:1: 11:23 (#0),
                     },
                     Punct {
                         ch: ':',
                         spacing: Joint,
-                        span: $DIR/inner-attr-non-inline-mod.rs:11:1: 11:23 (#0),
+                        span: $DIR/inner-attr-file-mod.rs:11:1: 11:23 (#0),
                     },
                     Punct {
                         ch: ':',
                         spacing: Alone,
-                        span: $DIR/inner-attr-non-inline-mod.rs:11:1: 11:23 (#0),
+                        span: $DIR/inner-attr-file-mod.rs:11:1: 11:23 (#0),
                     },
                     Ident {
                         ident: "skip",
-                        span: $DIR/inner-attr-non-inline-mod.rs:11:1: 11:23 (#0),
+                        span: $DIR/inner-attr-file-mod.rs:11:1: 11:23 (#0),
                     },
                 ],
-                span: $DIR/inner-attr-non-inline-mod.rs:11:1: 11:23 (#0),
+                span: $DIR/inner-attr-file-mod.rs:11:1: 11:23 (#0),
             },
         ],
-        span: $DIR/inner-attr-non-inline-mod.rs:11:1: 11:23 (#0),
+        span: $DIR/inner-attr-file-mod.rs:11:1: 11:23 (#0),
     },
 ]


### PR DESCRIPTION
This PR updates diagnostic messages to use "file module" instead of "non-inline module". because the term "non-inline module" can be confusing, especially for non-native English speakers.

follow up PR rust-lang/rust#147395
related of rust-lang/rust#147314, [#general > Rename "non-inline modules" to "external modules"](https://rust-lang.zulipchat.com/#narrow/channel/122651-general/topic/.E2.9C.94.20Rename.20.22non-inline.20modules.22.20to.20.22external.20modules.22/near/543361244)

cc @Kivooeo