### PR TITLE
c-variadic: fix thir-print for `...` without a pattern

### DIFF
--- a/compiler/rustc_mir_build/src/thir/print.rs
+++ b/compiler/rustc_mir_build/src/thir/print.rs
@@ -689,7 +689,9 @@ impl<'a, 'tcx> ThirPrinter<'a, 'tcx> {
         print_indented!(self, "kind: PatKind {", depth_lvl);
 
         match pat_kind {
-            PatKind::Missing => unreachable!(),
+            PatKind::Missing => {
+                print_indented!(self, "Missing", depth_lvl + 1);
+            }
             PatKind::Wild => {
                 print_indented!(self, "Wild", depth_lvl + 1);
             }

--- a/tests/ui/thir-print/c-variadic.rs
+++ b/tests/ui/thir-print/c-variadic.rs
@@ -1,0 +1,6 @@
+//@ compile-flags: -Zunpretty=thir-tree --crate-type=lib
+//@ check-pass
+#![feature(c_variadic)]
+
+// The `...` argument uses `PatKind::Missing`.
+unsafe extern "C" fn foo(_: i32, ...) {}

--- a/tests/ui/thir-print/c-variadic.stdout
+++ b/tests/ui/thir-print/c-variadic.stdout
@@ -1,0 +1,61 @@
+DefId(0:3 ~ c_variadic[a5de]::foo):
+params: [
+    Param {
+        ty: i32
+        ty_span: Some($DIR/c-variadic.rs:6:29: 6:32 (#0))
+        self_kind: None
+        hir_id: Some(HirId(DefId(0:3 ~ c_variadic[a5de]::foo).1))
+        param: Some( 
+            Pat: {
+                ty: i32
+                span: $DIR/c-variadic.rs:6:26: 6:27 (#0)
+                kind: PatKind {
+                    Wild
+                }
+            }
+        )
+    }
+    Param {
+        ty: std::ffi::VaListImpl<'{erased}>
+        ty_span: None
+        self_kind: None
+        hir_id: Some(HirId(DefId(0:3 ~ c_variadic[a5de]::foo).3))
+        param: Some( 
+            Pat: {
+                ty: std::ffi::VaListImpl<'{erased}>
+                span: $DIR/c-variadic.rs:6:34: 6:37 (#0)
+                kind: PatKind {
+                    Missing
+                }
+            }
+        )
+    }
+]
+body:
+    Expr {
+        ty: ()
+        temp_lifetime: TempLifetime { temp_lifetime: Some(Node(6)), backwards_incompatible: None }
+        span: $DIR/c-variadic.rs:6:39: 6:41 (#0)
+        kind: 
+            Scope {
+                region_scope: Node(6)
+                lint_level: Explicit(HirId(DefId(0:3 ~ c_variadic[a5de]::foo).6))
+                value:
+                    Expr {
+                        ty: ()
+                        temp_lifetime: TempLifetime { temp_lifetime: Some(Node(6)), backwards_incompatible: None }
+                        span: $DIR/c-variadic.rs:6:39: 6:41 (#0)
+                        kind: 
+                            Block {
+                                targeted_by_break: false
+                                span: $DIR/c-variadic.rs:6:39: 6:41 (#0)
+                                region_scope: Node(5)
+                                safety_mode: Safe
+                                stmts: []
+                                expr: []
+                            }
+                    }
+            }
+    }
+
+


### PR DESCRIPTION
tracking issue: https://github.com/rust-lang/rust/issues/44930
fixes https://github.com/rust-lang/rust/issues/147409

r? @fmease 
