### PR TITLE
sort attribute targets for more consistent error messages

### DIFF
--- a/compiler/rustc_attr_parsing/src/target_checking.rs
+++ b/compiler/rustc_attr_parsing/src/target_checking.rs
@@ -198,16 +198,20 @@ pub(crate) fn allowed_targets_applied(
     filter_targets(&mut allowed_targets, IMPL_LIKE, "impl blocks", target, &mut added_fake_targets);
     filter_targets(&mut allowed_targets, ADT_LIKE, "data types", target, &mut added_fake_targets);
 
+    let mut target_strings: Vec<_> = added_fake_targets
+        .iter()
+        .copied()
+        .chain(allowed_targets.iter().map(|t| t.plural_name()))
+        .map(|i| i.to_string())
+        .collect();
+
+    // ensure a consistent order
+    target_strings.sort();
+
     // If there is now only 1 target left, show that as the only possible target
-    (
-        added_fake_targets
-            .iter()
-            .copied()
-            .chain(allowed_targets.iter().map(|t| t.plural_name()))
-            .map(|i| i.to_string())
-            .collect(),
-        allowed_targets.len() + added_fake_targets.len() == 1,
-    )
+    let only_target = target_strings.len() == 1;
+
+    (target_strings, only_target)
 }
 
 fn filter_targets(

--- a/tests/ui/asm/naked-invalid-attr.stderr
+++ b/tests/ui/asm/naked-invalid-attr.stderr
@@ -18,7 +18,7 @@ error: `#[naked]` attribute cannot be used on foreign functions
 LL |     #[unsafe(naked)]
    |     ^^^^^^^^^^^^^^^^
    |
-   = help: `#[naked]` can be applied to methods and functions
+   = help: `#[naked]` can be applied to functions and methods
 
 error: `#[naked]` attribute cannot be used on structs
   --> $DIR/naked-invalid-attr.rs:13:1
@@ -50,7 +50,7 @@ error: `#[naked]` attribute cannot be used on closures
 LL |     #[unsafe(naked)]
    |     ^^^^^^^^^^^^^^^^
    |
-   = help: `#[naked]` can be applied to methods and functions
+   = help: `#[naked]` can be applied to functions and methods
 
 error[E0736]: attribute incompatible with `#[unsafe(naked)]`
   --> $DIR/naked-invalid-attr.rs:56:3

--- a/tests/ui/attributes/attr-on-mac-call.stderr
+++ b/tests/ui/attributes/attr-on-mac-call.stderr
@@ -55,7 +55,7 @@ LL |     #[deprecated]
    |     ^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[deprecated]` can be applied to functions, data types, modules, unions, constants, statics, macro defs, type aliases, use statements, foreign statics, struct fields, traits, associated types, associated consts, enum variants, inherent impl blocks, and crates
+   = help: `#[deprecated]` can be applied to associated consts, associated types, constants, crates, data types, enum variants, foreign statics, functions, inherent impl blocks, macro defs, modules, statics, struct fields, traits, type aliases, unions, and use statements
 
 warning: `#[inline]` attribute cannot be used on macro calls
   --> $DIR/attr-on-mac-call.rs:24:5
@@ -136,7 +136,7 @@ LL |     #[deprecated]
    |     ^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[deprecated]` can be applied to functions, data types, modules, unions, constants, statics, macro defs, type aliases, use statements, foreign statics, struct fields, traits, associated types, associated consts, enum variants, inherent impl blocks, and crates
+   = help: `#[deprecated]` can be applied to associated consts, associated types, constants, crates, data types, enum variants, foreign statics, functions, inherent impl blocks, macro defs, modules, statics, struct fields, traits, type aliases, unions, and use statements
 
 warning: `#[automatically_derived]` attribute cannot be used on macro calls
   --> $DIR/attr-on-mac-call.rs:51:5
@@ -154,7 +154,7 @@ LL |     #[macro_use]
    |     ^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[macro_use]` can be applied to modules, extern crates, and crates
+   = help: `#[macro_use]` can be applied to crates, extern crates, and modules
 
 warning: `#[must_use]` attribute cannot be used on macro calls
   --> $DIR/attr-on-mac-call.rs:57:5
@@ -163,7 +163,7 @@ LL |     #[must_use]
    |     ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to functions, data types, unions, and traits
+   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
 
 warning: `#[no_implicit_prelude]` attribute cannot be used on macro calls
   --> $DIR/attr-on-mac-call.rs:60:5
@@ -172,7 +172,7 @@ LL |     #[no_implicit_prelude]
    |     ^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[no_implicit_prelude]` can be applied to modules and crates
+   = help: `#[no_implicit_prelude]` can be applied to crates and modules
 
 warning: `#[path]` attribute cannot be used on macro calls
   --> $DIR/attr-on-mac-call.rs:63:5

--- a/tests/ui/attributes/linkage.stderr
+++ b/tests/ui/attributes/linkage.stderr
@@ -4,7 +4,7 @@ error: `#[linkage]` attribute cannot be used on type aliases
 LL | #[linkage = "weak"]
    | ^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[linkage]` can be applied to functions, statics, and foreign statics
+   = help: `#[linkage]` can be applied to foreign statics, functions, and statics
 
 error: `#[linkage]` attribute cannot be used on modules
   --> $DIR/linkage.rs:9:1
@@ -12,7 +12,7 @@ error: `#[linkage]` attribute cannot be used on modules
 LL | #[linkage = "weak"]
    | ^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[linkage]` can be applied to functions, statics, and foreign statics
+   = help: `#[linkage]` can be applied to foreign statics, functions, and statics
 
 error: `#[linkage]` attribute cannot be used on structs
   --> $DIR/linkage.rs:12:1
@@ -20,7 +20,7 @@ error: `#[linkage]` attribute cannot be used on structs
 LL | #[linkage = "weak"]
    | ^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[linkage]` can be applied to functions, statics, and foreign statics
+   = help: `#[linkage]` can be applied to foreign statics, functions, and statics
 
 error: `#[linkage]` attribute cannot be used on inherent impl blocks
   --> $DIR/linkage.rs:15:1
@@ -28,7 +28,7 @@ error: `#[linkage]` attribute cannot be used on inherent impl blocks
 LL | #[linkage = "weak"]
    | ^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[linkage]` can be applied to functions, statics, and foreign statics
+   = help: `#[linkage]` can be applied to foreign statics, functions, and statics
 
 error: `#[linkage]` attribute cannot be used on expressions
   --> $DIR/linkage.rs:23:5
@@ -36,7 +36,7 @@ error: `#[linkage]` attribute cannot be used on expressions
 LL |     #[linkage = "weak"]
    |     ^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[linkage]` can be applied to functions, statics, and foreign statics
+   = help: `#[linkage]` can be applied to foreign statics, functions, and statics
 
 error: `#[linkage]` attribute cannot be used on closures
   --> $DIR/linkage.rs:39:13
@@ -44,7 +44,7 @@ error: `#[linkage]` attribute cannot be used on closures
 LL |     let _ = #[linkage = "weak"]
    |             ^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[linkage]` can be applied to methods, functions, statics, foreign statics, and foreign functions
+   = help: `#[linkage]` can be applied to foreign functions, foreign statics, functions, methods, and statics
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/attributes/malformed-static-align.stderr
+++ b/tests/ui/attributes/malformed-static-align.stderr
@@ -25,7 +25,7 @@ error: `#[rustc_align_static]` attribute cannot be used on structs
 LL | #[rustc_align_static(16)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_align_static]` can be applied to statics and foreign statics
+   = help: `#[rustc_align_static]` can be applied to foreign statics and statics
 
 error: `#[repr(align(...))]` is not supported on statics
   --> $DIR/malformed-static-align.rs:13:8

--- a/tests/ui/coverage-attr/allowed-positions.stderr
+++ b/tests/ui/coverage-attr/allowed-positions.stderr
@@ -14,7 +14,7 @@ error: `#[coverage]` attribute cannot be used on type aliases
 LL | #[coverage(off)]
    | ^^^^^^^^^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to functions, impl blocks, modules, and crates
+   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
 
 error: `#[coverage]` attribute cannot be used on traits
   --> $DIR/allowed-positions.rs:17:1
@@ -22,7 +22,7 @@ error: `#[coverage]` attribute cannot be used on traits
 LL | #[coverage(off)]
    | ^^^^^^^^^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to functions, impl blocks, modules, and crates
+   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
 
 error: `#[coverage]` attribute cannot be used on associated consts
   --> $DIR/allowed-positions.rs:19:5
@@ -30,7 +30,7 @@ error: `#[coverage]` attribute cannot be used on associated consts
 LL |     #[coverage(off)]
    |     ^^^^^^^^^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to functions, impl blocks, modules, and crates
+   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
 
 error: `#[coverage]` attribute cannot be used on associated types
   --> $DIR/allowed-positions.rs:22:5
@@ -38,7 +38,7 @@ error: `#[coverage]` attribute cannot be used on associated types
 LL |     #[coverage(off)]
    |     ^^^^^^^^^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to functions, impl blocks, modules, and crates
+   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
 
 error: `#[coverage]` attribute cannot be used on required trait methods
   --> $DIR/allowed-positions.rs:25:5
@@ -46,7 +46,7 @@ error: `#[coverage]` attribute cannot be used on required trait methods
 LL |     #[coverage(off)]
    |     ^^^^^^^^^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to impl blocks, functions, closures, provided trait methods, trait methods in impl blocks, inherent methods, modules, and crates
+   = help: `#[coverage]` can be applied to closures, crates, functions, impl blocks, inherent methods, modules, provided trait methods, and trait methods in impl blocks
 
 error: `#[coverage]` attribute cannot be used on required trait methods
   --> $DIR/allowed-positions.rs:31:5
@@ -54,7 +54,7 @@ error: `#[coverage]` attribute cannot be used on required trait methods
 LL |     #[coverage(off)]
    |     ^^^^^^^^^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to impl blocks, functions, closures, provided trait methods, trait methods in impl blocks, inherent methods, modules, and crates
+   = help: `#[coverage]` can be applied to closures, crates, functions, impl blocks, inherent methods, modules, provided trait methods, and trait methods in impl blocks
 
 error: `#[coverage]` attribute cannot be used on associated types
   --> $DIR/allowed-positions.rs:39:5
@@ -62,7 +62,7 @@ error: `#[coverage]` attribute cannot be used on associated types
 LL |     #[coverage(off)]
    |     ^^^^^^^^^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to functions, impl blocks, modules, and crates
+   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
 
 error: `#[coverage]` attribute cannot be used on associated types
   --> $DIR/allowed-positions.rs:56:5
@@ -70,7 +70,7 @@ error: `#[coverage]` attribute cannot be used on associated types
 LL |     #[coverage(off)]
    |     ^^^^^^^^^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to functions, impl blocks, modules, and crates
+   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
 
 error: `#[coverage]` attribute cannot be used on structs
   --> $DIR/allowed-positions.rs:61:1
@@ -78,7 +78,7 @@ error: `#[coverage]` attribute cannot be used on structs
 LL | #[coverage(off)]
    | ^^^^^^^^^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to functions, impl blocks, modules, and crates
+   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
 
 error: `#[coverage]` attribute cannot be used on struct fields
   --> $DIR/allowed-positions.rs:63:5
@@ -86,7 +86,7 @@ error: `#[coverage]` attribute cannot be used on struct fields
 LL |     #[coverage(off)]
    |     ^^^^^^^^^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to functions, impl blocks, modules, and crates
+   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
 
 error: `#[coverage]` attribute cannot be used on foreign statics
   --> $DIR/allowed-positions.rs:76:5
@@ -94,7 +94,7 @@ error: `#[coverage]` attribute cannot be used on foreign statics
 LL |     #[coverage(off)]
    |     ^^^^^^^^^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to functions, impl blocks, modules, and crates
+   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
 
 error: `#[coverage]` attribute cannot be used on foreign types
   --> $DIR/allowed-positions.rs:79:5
@@ -102,7 +102,7 @@ error: `#[coverage]` attribute cannot be used on foreign types
 LL |     #[coverage(off)]
    |     ^^^^^^^^^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to functions, impl blocks, modules, and crates
+   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
 
 error: `#[coverage]` attribute cannot be used on foreign functions
   --> $DIR/allowed-positions.rs:82:5
@@ -110,7 +110,7 @@ error: `#[coverage]` attribute cannot be used on foreign functions
 LL |     #[coverage(off)]
    |     ^^^^^^^^^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to methods, impl blocks, functions, closures, modules, and crates
+   = help: `#[coverage]` can be applied to closures, crates, functions, impl blocks, methods, and modules
 
 error: `#[coverage]` attribute cannot be used on statements
   --> $DIR/allowed-positions.rs:88:5
@@ -118,7 +118,7 @@ error: `#[coverage]` attribute cannot be used on statements
 LL |     #[coverage(off)]
    |     ^^^^^^^^^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to functions, impl blocks, modules, and crates
+   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
 
 error: `#[coverage]` attribute cannot be used on statements
   --> $DIR/allowed-positions.rs:94:5
@@ -126,7 +126,7 @@ error: `#[coverage]` attribute cannot be used on statements
 LL |     #[coverage(off)]
    |     ^^^^^^^^^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to functions, impl blocks, modules, and crates
+   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
 
 error: `#[coverage]` attribute cannot be used on match arms
   --> $DIR/allowed-positions.rs:110:9
@@ -134,7 +134,7 @@ error: `#[coverage]` attribute cannot be used on match arms
 LL |         #[coverage(off)]
    |         ^^^^^^^^^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to functions, impl blocks, modules, and crates
+   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
 
 error: `#[coverage]` attribute cannot be used on expressions
   --> $DIR/allowed-positions.rs:114:5
@@ -142,7 +142,7 @@ error: `#[coverage]` attribute cannot be used on expressions
 LL |     #[coverage(off)]
    |     ^^^^^^^^^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to functions, impl blocks, modules, and crates
+   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
 
 error: aborting due to 18 previous errors
 

--- a/tests/ui/coverage-attr/name-value.stderr
+++ b/tests/ui/coverage-attr/name-value.stderr
@@ -49,7 +49,7 @@ error: `#[coverage]` attribute cannot be used on structs
 LL | #[coverage = "off"]
    | ^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to functions, impl blocks, modules, and crates
+   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
 
 error[E0539]: malformed `coverage` attribute input
   --> $DIR/name-value.rs:26:1
@@ -87,7 +87,7 @@ error: `#[coverage]` attribute cannot be used on associated consts
 LL |     #[coverage = "off"]
    |     ^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to functions, impl blocks, modules, and crates
+   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
 
 error[E0539]: malformed `coverage` attribute input
   --> $DIR/name-value.rs:35:1
@@ -110,7 +110,7 @@ error: `#[coverage]` attribute cannot be used on traits
 LL | #[coverage = "off"]
    | ^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to functions, impl blocks, modules, and crates
+   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
 
 error[E0539]: malformed `coverage` attribute input
   --> $DIR/name-value.rs:39:5
@@ -133,7 +133,7 @@ error: `#[coverage]` attribute cannot be used on associated consts
 LL |     #[coverage = "off"]
    |     ^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to functions, impl blocks, modules, and crates
+   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
 
 error[E0539]: malformed `coverage` attribute input
   --> $DIR/name-value.rs:44:5
@@ -156,7 +156,7 @@ error: `#[coverage]` attribute cannot be used on associated types
 LL |     #[coverage = "off"]
    |     ^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to functions, impl blocks, modules, and crates
+   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
 
 error[E0539]: malformed `coverage` attribute input
   --> $DIR/name-value.rs:50:1
@@ -194,7 +194,7 @@ error: `#[coverage]` attribute cannot be used on associated consts
 LL |     #[coverage = "off"]
    |     ^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to functions, impl blocks, modules, and crates
+   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
 
 error[E0539]: malformed `coverage` attribute input
   --> $DIR/name-value.rs:58:5
@@ -217,7 +217,7 @@ error: `#[coverage]` attribute cannot be used on associated types
 LL |     #[coverage = "off"]
    |     ^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to functions, impl blocks, modules, and crates
+   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
 
 error[E0539]: malformed `coverage` attribute input
   --> $DIR/name-value.rs:64:1

--- a/tests/ui/coverage-attr/word-only.stderr
+++ b/tests/ui/coverage-attr/word-only.stderr
@@ -43,7 +43,7 @@ error: `#[coverage]` attribute cannot be used on structs
 LL | #[coverage]
    | ^^^^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to functions, impl blocks, modules, and crates
+   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
 
 error[E0539]: malformed `coverage` attribute input
   --> $DIR/word-only.rs:26:1
@@ -77,7 +77,7 @@ error: `#[coverage]` attribute cannot be used on associated consts
 LL |     #[coverage]
    |     ^^^^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to functions, impl blocks, modules, and crates
+   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
 
 error[E0539]: malformed `coverage` attribute input
   --> $DIR/word-only.rs:35:1
@@ -98,7 +98,7 @@ error: `#[coverage]` attribute cannot be used on traits
 LL | #[coverage]
    | ^^^^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to functions, impl blocks, modules, and crates
+   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
 
 error[E0539]: malformed `coverage` attribute input
   --> $DIR/word-only.rs:39:5
@@ -119,7 +119,7 @@ error: `#[coverage]` attribute cannot be used on associated consts
 LL |     #[coverage]
    |     ^^^^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to functions, impl blocks, modules, and crates
+   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
 
 error[E0539]: malformed `coverage` attribute input
   --> $DIR/word-only.rs:44:5
@@ -140,7 +140,7 @@ error: `#[coverage]` attribute cannot be used on associated types
 LL |     #[coverage]
    |     ^^^^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to functions, impl blocks, modules, and crates
+   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
 
 error[E0539]: malformed `coverage` attribute input
   --> $DIR/word-only.rs:50:1
@@ -174,7 +174,7 @@ error: `#[coverage]` attribute cannot be used on associated consts
 LL |     #[coverage]
    |     ^^^^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to functions, impl blocks, modules, and crates
+   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
 
 error[E0539]: malformed `coverage` attribute input
   --> $DIR/word-only.rs:58:5
@@ -195,7 +195,7 @@ error: `#[coverage]` attribute cannot be used on associated types
 LL |     #[coverage]
    |     ^^^^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to functions, impl blocks, modules, and crates
+   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
 
 error[E0539]: malformed `coverage` attribute input
   --> $DIR/word-only.rs:64:1

--- a/tests/ui/deprecation/deprecation-sanity.stderr
+++ b/tests/ui/deprecation/deprecation-sanity.stderr
@@ -177,7 +177,7 @@ LL | #[deprecated = "hello"]
    | ^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[deprecated]` can be applied to functions, data types, modules, unions, constants, statics, macro defs, type aliases, use statements, foreign statics, struct fields, traits, associated types, associated consts, enum variants, inherent impl blocks, and crates
+   = help: `#[deprecated]` can be applied to associated consts, associated types, constants, crates, data types, enum variants, foreign statics, functions, inherent impl blocks, macro defs, modules, statics, struct fields, traits, type aliases, unions, and use statements
    = note: `#[deny(useless_deprecated)]` on by default
 
 error: aborting due to 10 previous errors

--- a/tests/ui/extern/extern-no-mangle.stderr
+++ b/tests/ui/extern/extern-no-mangle.stderr
@@ -19,7 +19,7 @@ LL |     #[no_mangle]
    |     ^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[no_mangle]` can be applied to methods, functions, and statics
+   = help: `#[no_mangle]` can be applied to functions, methods, and statics
 
 warning: `#[no_mangle]` attribute cannot be used on statements
   --> $DIR/extern-no-mangle.rs:24:5

--- a/tests/ui/feature-gates/feature-gate-allow-internal-unstable-struct.stderr
+++ b/tests/ui/feature-gates/feature-gate-allow-internal-unstable-struct.stderr
@@ -13,7 +13,7 @@ error: `#[allow_internal_unstable]` attribute cannot be used on structs
 LL | #[allow_internal_unstable(something)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[allow_internal_unstable]` can be applied to macro defs and functions
+   = help: `#[allow_internal_unstable]` can be applied to functions and macro defs
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs-error.stderr
+++ b/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs-error.stderr
@@ -134,7 +134,7 @@ error: `#[export_name]` attribute cannot be used on required trait methods
 LL |         #[export_name = "2200"] fn foo();
    |         ^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[export_name]` can be applied to statics, functions, inherent methods, provided trait methods, and trait methods in impl blocks
+   = help: `#[export_name]` can be applied to functions, inherent methods, provided trait methods, statics, and trait methods in impl blocks
 
 error: attribute should be applied to an `extern crate` item
   --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:55:1

--- a/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs.stderr
+++ b/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs.stderr
@@ -644,7 +644,7 @@ LL |     #[macro_use] fn f() { }
    |     ^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[macro_use]` can be applied to modules, extern crates, and crates
+   = help: `#[macro_use]` can be applied to crates, extern crates, and modules
 
 warning: `#[macro_use]` attribute cannot be used on structs
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:197:5
@@ -653,7 +653,7 @@ LL |     #[macro_use] struct S;
    |     ^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[macro_use]` can be applied to modules, extern crates, and crates
+   = help: `#[macro_use]` can be applied to crates, extern crates, and modules
 
 warning: `#[macro_use]` attribute cannot be used on type aliases
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:203:5
@@ -662,7 +662,7 @@ LL |     #[macro_use] type T = S;
    |     ^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[macro_use]` can be applied to modules, extern crates, and crates
+   = help: `#[macro_use]` can be applied to crates, extern crates, and modules
 
 warning: `#[macro_use]` attribute cannot be used on inherent impl blocks
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:209:5
@@ -671,7 +671,7 @@ LL |     #[macro_use] impl S { }
    |     ^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[macro_use]` can be applied to modules, extern crates, and crates
+   = help: `#[macro_use]` can be applied to crates, extern crates, and modules
 
 warning: `#[macro_export]` attribute cannot be used on modules
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:216:1
@@ -878,7 +878,7 @@ LL |         #[no_mangle] fn foo();
    |         ^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[no_mangle]` can be applied to functions, statics, inherent methods, and trait methods in impl blocks
+   = help: `#[no_mangle]` can be applied to functions, inherent methods, statics, and trait methods in impl blocks
 
 warning: `#[no_mangle]` attribute cannot be used on provided trait methods
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:398:9
@@ -887,7 +887,7 @@ LL |         #[no_mangle] fn bar() {}
    |         ^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[no_mangle]` can be applied to functions, statics, inherent methods, and trait methods in impl blocks
+   = help: `#[no_mangle]` can be applied to functions, inherent methods, statics, and trait methods in impl blocks
 
 warning: `#[should_panic]` attribute cannot be used on modules
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:406:1
@@ -986,7 +986,7 @@ LL |     #[no_implicit_prelude] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[no_implicit_prelude]` can be applied to modules and crates
+   = help: `#[no_implicit_prelude]` can be applied to crates and modules
 
 warning: `#[no_implicit_prelude]` attribute cannot be used on structs
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:482:5
@@ -995,7 +995,7 @@ LL |     #[no_implicit_prelude] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[no_implicit_prelude]` can be applied to modules and crates
+   = help: `#[no_implicit_prelude]` can be applied to crates and modules
 
 warning: `#[no_implicit_prelude]` attribute cannot be used on type aliases
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:488:5
@@ -1004,7 +1004,7 @@ LL |     #[no_implicit_prelude] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[no_implicit_prelude]` can be applied to modules and crates
+   = help: `#[no_implicit_prelude]` can be applied to crates and modules
 
 warning: `#[no_implicit_prelude]` attribute cannot be used on inherent impl blocks
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:494:5
@@ -1013,7 +1013,7 @@ LL |     #[no_implicit_prelude] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[no_implicit_prelude]` can be applied to modules and crates
+   = help: `#[no_implicit_prelude]` can be applied to crates and modules
 
 warning: `#[macro_escape]` attribute cannot be used on functions
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:533:5
@@ -1022,7 +1022,7 @@ LL |     #[macro_escape] fn f() { }
    |     ^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[macro_escape]` can be applied to modules, extern crates, and crates
+   = help: `#[macro_escape]` can be applied to crates, extern crates, and modules
 
 warning: `#[macro_escape]` attribute cannot be used on structs
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:539:5
@@ -1031,7 +1031,7 @@ LL |     #[macro_escape] struct S;
    |     ^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[macro_escape]` can be applied to modules, extern crates, and crates
+   = help: `#[macro_escape]` can be applied to crates, extern crates, and modules
 
 warning: `#[macro_escape]` attribute cannot be used on type aliases
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:545:5
@@ -1040,7 +1040,7 @@ LL |     #[macro_escape] type T = S;
    |     ^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[macro_escape]` can be applied to modules, extern crates, and crates
+   = help: `#[macro_escape]` can be applied to crates, extern crates, and modules
 
 warning: `#[macro_escape]` attribute cannot be used on inherent impl blocks
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:551:5
@@ -1049,7 +1049,7 @@ LL |     #[macro_escape] impl S { }
    |     ^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[macro_escape]` can be applied to modules, extern crates, and crates
+   = help: `#[macro_escape]` can be applied to crates, extern crates, and modules
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![no_std]`
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:558:1
@@ -1290,7 +1290,7 @@ LL | #[must_use]
    | ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to functions, data types, unions, and traits
+   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
 
 warning: `#[must_use]` attribute cannot be used on modules
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:795:17
@@ -1299,7 +1299,7 @@ LL |     mod inner { #![must_use] }
    |                 ^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to functions, data types, unions, and traits
+   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
 
 warning: `#[must_use]` attribute cannot be used on type aliases
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:804:5
@@ -1308,7 +1308,7 @@ LL |     #[must_use] type T = S;
    |     ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to functions, data types, unions, and traits
+   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
 
 warning: `#[must_use]` attribute cannot be used on inherent impl blocks
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:809:5
@@ -1317,7 +1317,7 @@ LL |     #[must_use] impl S { }
    |     ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to functions, data types, unions, and traits
+   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![crate_name]`
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:841:1
@@ -1590,7 +1590,7 @@ LL | #![must_use]
    | ^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to functions, data types, unions, and traits
+   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
 
 warning: 174 warnings emitted
 

--- a/tests/ui/invalid/invalid-debugger-visualizer-target.stderr
+++ b/tests/ui/invalid/invalid-debugger-visualizer-target.stderr
@@ -4,7 +4,7 @@ error: `#[debugger_visualizer]` attribute cannot be used on functions
 LL | #[debugger_visualizer(natvis_file = "./foo.natvis.xml")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[debugger_visualizer]` can be applied to modules and crates
+   = help: `#[debugger_visualizer]` can be applied to crates and modules
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/issues/issue-32782.stderr
+++ b/tests/ui/issues/issue-32782.stderr
@@ -20,7 +20,7 @@ LL |         #[allow_internal_unstable()]
 LL | foo!();
    | ------ in this macro invocation
    |
-   = help: `#[allow_internal_unstable]` can be applied to macro defs and functions
+   = help: `#[allow_internal_unstable]` can be applied to functions and macro defs
    = note: this error originates in the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors

--- a/tests/ui/lint/unused/unused-attr-macro-rules.stderr
+++ b/tests/ui/lint/unused/unused-attr-macro-rules.stderr
@@ -5,7 +5,7 @@ LL | #[macro_use]
    | ^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[macro_use]` can be applied to modules, extern crates, and crates
+   = help: `#[macro_use]` can be applied to crates, extern crates, and modules
 note: the lint level is defined here
   --> $DIR/unused-attr-macro-rules.rs:1:9
    |

--- a/tests/ui/lint/unused/unused_attributes-must_use.stderr
+++ b/tests/ui/lint/unused/unused_attributes-must_use.stderr
@@ -5,7 +5,7 @@ LL | #[must_use]
    | ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to functions, data types, unions, and traits
+   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
 note: the lint level is defined here
   --> $DIR/unused_attributes-must_use.rs:4:9
    |
@@ -19,7 +19,7 @@ LL | #[must_use]
    | ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to functions, data types, unions, and traits
+   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
 
 error: `#[must_use]` attribute cannot be used on modules
   --> $DIR/unused_attributes-must_use.rs:11:1
@@ -28,7 +28,7 @@ LL | #[must_use]
    | ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to functions, data types, unions, and traits
+   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
 
 error: `#[must_use]` attribute cannot be used on use statements
   --> $DIR/unused_attributes-must_use.rs:15:1
@@ -37,7 +37,7 @@ LL | #[must_use]
    | ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to functions, data types, unions, and traits
+   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
 
 error: `#[must_use]` attribute cannot be used on constants
   --> $DIR/unused_attributes-must_use.rs:19:1
@@ -46,7 +46,7 @@ LL | #[must_use]
    | ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to functions, data types, unions, and traits
+   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
 
 error: `#[must_use]` attribute cannot be used on statics
   --> $DIR/unused_attributes-must_use.rs:22:1
@@ -55,7 +55,7 @@ LL | #[must_use]
    | ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to functions, data types, unions, and traits
+   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
 
 error: `#[must_use]` attribute cannot be used on inherent impl blocks
   --> $DIR/unused_attributes-must_use.rs:40:1
@@ -64,7 +64,7 @@ LL | #[must_use]
    | ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to functions, data types, unions, and traits
+   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
 
 error: `#[must_use]` attribute cannot be used on foreign modules
   --> $DIR/unused_attributes-must_use.rs:55:1
@@ -73,7 +73,7 @@ LL | #[must_use]
    | ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to functions, data types, unions, and traits
+   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
 
 error: `#[must_use]` attribute cannot be used on foreign statics
   --> $DIR/unused_attributes-must_use.rs:59:5
@@ -82,7 +82,7 @@ LL |     #[must_use]
    |     ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to functions, data types, unions, and traits
+   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
 
 error: `#[must_use]` attribute cannot be used on type aliases
   --> $DIR/unused_attributes-must_use.rs:73:1
@@ -91,7 +91,7 @@ LL | #[must_use]
    | ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to functions, data types, unions, and traits
+   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
 
 error: `#[must_use]` attribute cannot be used on function params
   --> $DIR/unused_attributes-must_use.rs:77:8
@@ -100,7 +100,7 @@ LL | fn qux<#[must_use] T>(_: T) {}
    |        ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to functions, data types, unions, and traits
+   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
 
 error: `#[must_use]` attribute cannot be used on associated consts
   --> $DIR/unused_attributes-must_use.rs:82:5
@@ -109,7 +109,7 @@ LL |     #[must_use]
    |     ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to functions, data types, unions, and traits
+   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
 
 error: `#[must_use]` attribute cannot be used on associated types
   --> $DIR/unused_attributes-must_use.rs:85:5
@@ -118,7 +118,7 @@ LL |     #[must_use]
    |     ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to functions, data types, unions, and traits
+   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
 
 error: `#[must_use]` attribute cannot be used on trait impl blocks
   --> $DIR/unused_attributes-must_use.rs:95:1
@@ -127,7 +127,7 @@ LL | #[must_use]
    | ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to functions, data types, unions, and traits
+   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
 
 error: `#[must_use]` attribute cannot be used on trait methods in impl blocks
   --> $DIR/unused_attributes-must_use.rs:100:5
@@ -136,7 +136,7 @@ LL |     #[must_use]
    |     ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to data types, functions, unions, required trait methods, provided trait methods, inherent methods, foreign functions, and traits
+   = help: `#[must_use]` can be applied to data types, foreign functions, functions, inherent methods, provided trait methods, required trait methods, traits, and unions
 
 error: `#[must_use]` attribute cannot be used on trait aliases
   --> $DIR/unused_attributes-must_use.rs:107:1
@@ -145,7 +145,7 @@ LL | #[must_use]
    | ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to functions, data types, unions, and traits
+   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
 
 error: `#[must_use]` attribute cannot be used on macro defs
   --> $DIR/unused_attributes-must_use.rs:111:1
@@ -154,7 +154,7 @@ LL | #[must_use]
    | ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to functions, data types, unions, and traits
+   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
 
 error: `#[must_use]` attribute cannot be used on statements
   --> $DIR/unused_attributes-must_use.rs:120:5
@@ -163,7 +163,7 @@ LL |     #[must_use]
    |     ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to functions, data types, unions, and traits
+   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
 
 error: `#[must_use]` attribute cannot be used on closures
   --> $DIR/unused_attributes-must_use.rs:125:13
@@ -172,7 +172,7 @@ LL |     let x = #[must_use]
    |             ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to methods, data types, functions, unions, foreign functions, and traits
+   = help: `#[must_use]` can be applied to data types, foreign functions, functions, methods, traits, and unions
 
 error: `#[must_use]` attribute cannot be used on match arms
   --> $DIR/unused_attributes-must_use.rs:148:9
@@ -181,7 +181,7 @@ LL |         #[must_use]
    |         ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to functions, data types, unions, and traits
+   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
 
 error: `#[must_use]` attribute cannot be used on struct fields
   --> $DIR/unused_attributes-must_use.rs:157:28
@@ -190,7 +190,7 @@ LL |     let s = PatternField { #[must_use]  foo: 123 };
    |                            ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to functions, data types, unions, and traits
+   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
 
 error: `#[must_use]` attribute cannot be used on pattern fields
   --> $DIR/unused_attributes-must_use.rs:159:24
@@ -199,7 +199,7 @@ LL |     let PatternField { #[must_use] foo } = s;
    |                        ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to functions, data types, unions, and traits
+   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
 
 error: unused `X` that must be used
   --> $DIR/unused_attributes-must_use.rs:130:5

--- a/tests/ui/lint/warn-unused-inline-on-fn-prototypes.stderr
+++ b/tests/ui/lint/warn-unused-inline-on-fn-prototypes.stderr
@@ -5,7 +5,7 @@ LL |     #[inline]
    |     ^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[inline]` can be applied to functions, inherent methods, provided trait methods, trait methods in impl blocks, and closures
+   = help: `#[inline]` can be applied to closures, functions, inherent methods, provided trait methods, and trait methods in impl blocks
 note: the lint level is defined here
   --> $DIR/warn-unused-inline-on-fn-prototypes.rs:1:9
    |
@@ -19,7 +19,7 @@ LL |     #[inline]
    |     ^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[inline]` can be applied to methods, functions, and closures
+   = help: `#[inline]` can be applied to closures, functions, and methods
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/macros/issue-68060.stderr
+++ b/tests/ui/macros/issue-68060.stderr
@@ -4,7 +4,7 @@ error: `#[target_feature]` attribute cannot be used on closures
 LL |             #[target_feature(enable = "")]
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[target_feature]` can be applied to methods and functions
+   = help: `#[target_feature]` can be applied to functions and methods
 
 error[E0658]: `#[track_caller]` on closures is currently unstable
   --> $DIR/issue-68060.rs:6:13

--- a/tests/ui/target-feature/invalid-attribute.stderr
+++ b/tests/ui/target-feature/invalid-attribute.stderr
@@ -143,7 +143,7 @@ error: `#[target_feature]` attribute cannot be used on closures
 LL |     #[target_feature(enable = "sse2")]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[target_feature]` can be applied to methods and functions
+   = help: `#[target_feature]` can be applied to functions and methods
 
 error[E0658]: cannot use `#[inline(always)]` with `#[target_feature]`
   --> $DIR/invalid-attribute.rs:62:1

--- a/tests/ui/where-clauses/unsupported_attribute.stderr
+++ b/tests/ui/where-clauses/unsupported_attribute.stderr
@@ -48,7 +48,7 @@ error: `#[macro_use]` attribute cannot be used on where predicates
 LL |     #[macro_use] T: Trait,
    |     ^^^^^^^^^^^^
    |
-   = help: `#[macro_use]` can be applied to modules, extern crates, and crates
+   = help: `#[macro_use]` can be applied to crates, extern crates, and modules
 
 error: `#[macro_use]` attribute cannot be used on where predicates
   --> $DIR/unsupported_attribute.rs:21:5
@@ -56,7 +56,7 @@ error: `#[macro_use]` attribute cannot be used on where predicates
 LL |     #[macro_use] 'a: 'static,
    |     ^^^^^^^^^^^^
    |
-   = help: `#[macro_use]` can be applied to modules, extern crates, and crates
+   = help: `#[macro_use]` can be applied to crates, extern crates, and modules
 
 error: `#[deprecated]` attribute cannot be used on where predicates
   --> $DIR/unsupported_attribute.rs:24:5
@@ -64,7 +64,7 @@ error: `#[deprecated]` attribute cannot be used on where predicates
 LL |     #[deprecated] T: Trait,
    |     ^^^^^^^^^^^^^
    |
-   = help: `#[deprecated]` can be applied to functions, data types, modules, unions, constants, statics, macro defs, type aliases, use statements, foreign statics, struct fields, traits, associated types, associated consts, enum variants, inherent impl blocks, and crates
+   = help: `#[deprecated]` can be applied to associated consts, associated types, constants, crates, data types, enum variants, foreign statics, functions, inherent impl blocks, macro defs, modules, statics, struct fields, traits, type aliases, unions, and use statements
 
 error: `#[deprecated]` attribute cannot be used on where predicates
   --> $DIR/unsupported_attribute.rs:25:5
@@ -72,7 +72,7 @@ error: `#[deprecated]` attribute cannot be used on where predicates
 LL |     #[deprecated] 'a: 'static,
    |     ^^^^^^^^^^^^^
    |
-   = help: `#[deprecated]` can be applied to functions, data types, modules, unions, constants, statics, macro defs, type aliases, use statements, foreign statics, struct fields, traits, associated types, associated consts, enum variants, inherent impl blocks, and crates
+   = help: `#[deprecated]` can be applied to associated consts, associated types, constants, crates, data types, enum variants, foreign statics, functions, inherent impl blocks, macro defs, modules, statics, struct fields, traits, type aliases, unions, and use statements
 
 error: `#[automatically_derived]` attribute cannot be used on where predicates
   --> $DIR/unsupported_attribute.rs:26:5


### PR DESCRIPTION
In this PR I noticed that we don't sort attribute targets, so a rather trivial change to the source changed the ordering in an error message even though its meaning stayed the same.

See: https://github.com/rust-lang/rust/pull/147418#discussion_r2410852750

I think sorting might be a good thing to do in general. I also prefer it when reading error messages. Quite a few tests changed, but not in meaning, only sorting order obviously.

r? @jieyouxu 