### PR TITLE
PassWrapper: use non-deprecated lookupTarget method

### DIFF
--- a/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
@@ -283,7 +283,11 @@ extern "C" LLVMTargetMachineRef LLVMRustCreateTargetMachine(
   std::string Error;
   auto Trip = Triple(Triple::normalize(TripleStr));
   const llvm::Target *TheTarget =
+#if LLVM_VERSION_GE(21, 0)
+      TargetRegistry::lookupTarget(Trip, Error);
+#else
       TargetRegistry::lookupTarget(Trip.getTriple(), Error);
+#endif
   if (TheTarget == nullptr) {
     LLVMRustSetLastError(Error.c_str());
     return nullptr;


### PR DESCRIPTION
This avoids an extra trip through a triple string by directly passing the Triple, and has been available since LLVM 21. The string overload was deprecated today and throws an error on our CI for HEAD due to -Werror paranoia, so we may as well clean this up now and also skip the conversion on LLVM 21 since we can.

@rustbot label llvm-main

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
