### PR TITLE
Set the minimum deployment target for `aarch64-apple-watchos`

### DIFF
--- a/compiler/rustc_target/src/spec/base/apple/mod.rs
+++ b/compiler/rustc_target/src/spec/base/apple/mod.rs
@@ -304,7 +304,7 @@ impl OSVersion {
     /// to raise the minimum OS version.
     ///
     /// This matches what LLVM does, see in part:
-    /// <https://github.com/llvm/llvm-project/blob/llvmorg-18.1.8/llvm/lib/TargetParser/Triple.cpp#L1900-L1932>
+    /// <https://github.com/llvm/llvm-project/blob/llvmorg-21.1.3/llvm/lib/TargetParser/Triple.cpp#L2140-L2175>
     pub fn minimum_deployment_target(target: &Target) -> Self {
         let (major, minor, patch) = match (&*target.os, &*target.arch, &*target.env) {
             ("macos", "aarch64", _) => (11, 0, 0),
@@ -315,6 +315,9 @@ impl OSVersion {
             ("ios", _, "macabi") => (13, 1, 0),
             ("tvos", "aarch64", "sim") => (14, 0, 0),
             ("watchos", "aarch64", "sim") => (7, 0, 0),
+            // True Aarch64 on watchOS (instead of their Aarch64 Ilp32 called `arm64_32`) has been
+            // available since Xcode 14, but it's only actually used more recently in watchOS 26.
+            ("watchos", "aarch64", "") if !target.llvm_target.starts_with("arm64_32") => (26, 0, 0),
             (os, _, _) => return Self::os_minimum_deployment_target(os),
         };
         Self { major, minor, patch }

--- a/tests/run-make/apple-deployment-target/rmake.rs
+++ b/tests/run-make/apple-deployment-target/rmake.rs
@@ -33,6 +33,7 @@ fn main() {
         // armv7s-apple-ios and i386-apple-ios only supports iOS 10.0
         "ios" if target() == "armv7s-apple-ios" || target() == "i386-apple-ios" => ("10.0", "10.0"),
         "ios" => ("15.0", "16.0"),
+        "watchos" if target() == "aarch64-apple-watchos" => ("28.0", "30.0"),
         "watchos" => ("7.0", "9.0"),
         "tvos" => ("14.0", "15.0"),
         "visionos" => ("1.1", "1.2"),


### PR DESCRIPTION
To match what's done in LLVM 21 and Xcode 26, watchOS 26 is the first OS version that actually runs true Aarch64 binaries. This affects the object files we create, and the linker invocation when using `-Clinker=ld`.

See also investigation in https://github.com/rust-lang/rust/issues/147223.