### PR TITLE
collect-license-metadata: update submodules before running

### DIFF
--- a/src/bootstrap/src/core/build_steps/run.rs
+++ b/src/bootstrap/src/core/build_steps/run.rs
@@ -6,6 +6,7 @@
 use std::path::PathBuf;
 
 use build_helper::exit;
+use build_helper::git::get_git_untracked_files;
 use clap_complete::{Generator, shells};
 
 use crate::core::build_steps::dist::distdir;
@@ -207,6 +208,16 @@ impl Step for CollectLicenseMetadata {
         };
 
         let dest = builder.src.join("license-metadata.json");
+
+        if !builder.config.dry_run() {
+            builder.require_and_update_all_submodules();
+            if let Ok(Some(untracked)) = get_git_untracked_files(None) {
+                eprintln!(
+                    "Warning: {} untracked files may cause the license report to be incorrect.",
+                    untracked.len()
+                );
+            }
+        }
 
         let mut cmd = builder.tool_cmd(Tool::CollectLicenseMetadata);
         cmd.env("REUSE_EXE", reuse);


### PR DESCRIPTION
Previously, this could cause incorrect failures like the following:
```
diff --git a/license-metadata.json b/license-metadata.json
index 4fb59210854..b1291c00b94 100644
--- a/license-metadata.json
+++ b/license-metadata.json
@@ -244,19 +172,6 @@
             },
             "name": "src/doc/rustc-dev-guide/mermaid.min.js",
             "type": "file"
-          },
-          {
-            "children": [],
-            "license": {
-              "copyright": [
-                "2003-2019 University of Illinois at Urbana-Champaign",
-                "2003-2019 by the contributors listed in CREDITS.TXT (https://github.com/rust-lang/llvm-project/blob/7738295178045041669876bf32b0543ec8319a5c/llvm/CREDITS.TXT)",
-                "2010 Apple Inc"
-              ],
-              "spdx": "Apache-2.0 WITH LLVM-exception AND NCSA"
-            },
-            "name": "src/llvm-project",
-            "type": "directory"
```

Additionally, this prints a warning if there were untracked files, which could cause a failure like the following:
```
diff --git a/license-metadata.json b/license-metadata.json
index 4fb59210854..ebf1c478282 100644
--- a/license-metadata.json
+++ b/license-metadata.json
@@ -155,6 +155,22 @@
             "name": "src/librustdoc/html/static/fonts",
             "type": "directory"
           },
+          {
+            "directories": [],
+            "files": [
+              "2015-edition.txt",
+              "diagnostics.json",
+              "license.diff",
+              "test.fixed.rs"
+            ],
+            "license": {
+              "copyright": [
+                "NONE"
+              ],
+              "spdx": "NONE"
+            },
+            "type": "group"
+          },
           {
             "license": {
               "copyright": [
```

r? @Kobzol cc rust-lang/rust#147422 

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
