### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/compiler/rustc_attr_parsing/src/attributes/link_attrs.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/link_attrs.rs
@@ -467,8 +467,14 @@ impl<S: Stage> SingleAttributeParser<S> for LinkSectionParser {
     const PATH: &[Symbol] = &[sym::link_section];
     const ATTRIBUTE_ORDER: AttributeOrder = AttributeOrder::KeepInnermost;
     const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::WarnButFutureError;
-    const ALLOWED_TARGETS: AllowedTargets =
-        AllowedTargets::AllowListWarnRest(&[Allow(Target::Static), Allow(Target::Fn)]);
+    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowListWarnRest(&[
+        Allow(Target::Static),
+        Allow(Target::Fn),
+        Allow(Target::Method(MethodKind::Inherent)),
+        Allow(Target::Method(MethodKind::Trait { body: false })),
+        Allow(Target::Method(MethodKind::Trait { body: true })),
+        Allow(Target::Method(MethodKind::TraitImpl)),
+    ]);
     const TEMPLATE: AttributeTemplate = template!(
         NameValueStr: "name",
         "https://doc.rust-lang.org/reference/abi.html#the-link_section-attribute"

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/cmse.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/cmse.rs
@@ -1,8 +1,8 @@
-use rustc_abi::ExternAbi;
+use rustc_abi::{BackendRepr, ExternAbi, Float, Integer, Primitive, Scalar};
 use rustc_errors::{DiagCtxtHandle, E0781, struct_span_code_err};
 use rustc_hir::{self as hir, HirId};
 use rustc_middle::bug;
-use rustc_middle::ty::layout::LayoutError;
+use rustc_middle::ty::layout::{LayoutError, TyAndLayout};
 use rustc_middle::ty::{self, TyCtxt};
 
 use crate::errors;
@@ -164,44 +164,34 @@ fn is_valid_cmse_output<'tcx>(
 ) -> Result<bool, &'tcx LayoutError<'tcx>> {
     // this type is only used for layout computation, which does not rely on regions
     let fn_sig = tcx.instantiate_bound_regions_with_erased(fn_sig);
+    let fn_sig = tcx.erase_and_anonymize_regions(fn_sig);
 
     let typing_env = ty::TypingEnv::fully_monomorphized();
+    let layout = tcx.layout_of(typing_env.as_query_input(fn_sig.output()))?;
 
-    let mut ret_ty = fn_sig.output();
-    let layout = tcx.layout_of(typing_env.as_query_input(ret_ty))?;
+    Ok(is_valid_cmse_output_layout(layout))
+}
+
+/// Returns whether the output will fit into the available registers
+fn is_valid_cmse_output_layout<'tcx>(layout: TyAndLayout<'tcx>) -> bool {
     let size = layout.layout.size().bytes();
 
     if size <= 4 {
-        return Ok(true);
+        return true;
     } else if size > 8 {
-        return Ok(false);
+        return false;
     }
 
-    // next we need to peel any repr(transparent) layers off
-    'outer: loop {
-        let ty::Adt(adt_def, args) = ret_ty.kind() else {
-            break;
-        };
+    // Accept scalar 64-bit types.
+    let BackendRepr::Scalar(scalar) = layout.layout.backend_repr else {
+        return false;
+    };
 
-        if !adt_def.repr().transparent() {
-            break;
-        }
+    let Scalar::Initialized { value, .. } = scalar else {
+        return false;
+    };
 
-        // the first field with non-trivial size and alignment must be the data
-        for variant_def in adt_def.variants() {
-            for field_def in variant_def.fields.iter() {
-                let ty = field_def.ty(tcx, args);
-                let layout = tcx.layout_of(typing_env.as_query_input(ty))?;
-
-                if !layout.layout.is_1zst() {
-                    ret_ty = ty;
-                    continue 'outer;
-                }
-            }
-        }
-    }
-
-    Ok(ret_ty == tcx.types.i64 || ret_ty == tcx.types.u64 || ret_ty == tcx.types.f64)
+    matches!(value, Primitive::Int(Integer::I64, _) | Primitive::Float(Float::F64))
 }
 
 fn should_emit_generic_error<'tcx>(abi: ExternAbi, layout_err: &'tcx LayoutError<'tcx>) -> bool {

--- a/compiler/rustc_middle/src/mir/interpret/pointer.rs
+++ b/compiler/rustc_middle/src/mir/interpret/pointer.rs
@@ -167,7 +167,7 @@ impl CtfeProvenance {
 }
 
 impl Provenance for CtfeProvenance {
-    // With the `AllocId` as provenance, the `offset` is interpreted *relative to the allocation*,
+    // With the `CtfeProvenance` as provenance, the `offset` is interpreted *relative to the allocation*,
     // so ptr-to-int casts are not possible (since we do not know the global physical offset).
     const OFFSET_IS_ADDR: bool = false;
 

--- a/compiler/rustc_mir_build/src/thir/print.rs
+++ b/compiler/rustc_mir_build/src/thir/print.rs
@@ -689,7 +689,9 @@ impl<'a, 'tcx> ThirPrinter<'a, 'tcx> {
         print_indented!(self, "kind: PatKind {", depth_lvl);
 
         match pat_kind {
-            PatKind::Missing => unreachable!(),
+            PatKind::Missing => {
+                print_indented!(self, "Missing", depth_lvl + 1);
+            }
             PatKind::Wild => {
                 print_indented!(self, "Wild", depth_lvl + 1);
             }

--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -951,8 +951,9 @@ pub(crate) mod builtin {
     /// format string in `format_args!`.
     ///
     /// ```rust
-    /// let debug = format!("{:?}", format_args!("{} foo {:?}", 1, 2));
-    /// let display = format!("{}", format_args!("{} foo {:?}", 1, 2));
+    /// let args = format_args!("{} foo {:?}", 1, 2);
+    /// let debug = format!("{args:?}");
+    /// let display = format!("{args}");
     /// assert_eq!("1 foo 2", display);
     /// assert_eq!(display, debug);
     /// ```
@@ -976,13 +977,17 @@ pub(crate) mod builtin {
     /// assert_eq!(s, format!("hello {}", "world"));
     /// ```
     ///
-    /// # Lifetime limitation
+    /// # Argument lifetimes
     ///
     /// Except when no formatting arguments are used,
-    /// the produced `fmt::Arguments` value borrows temporary values,
-    /// which means it can only be used within the same expression
-    /// and cannot be stored for later use.
-    /// This is a known limitation, see [#92698](https://github.com/rust-lang/rust/issues/92698).
+    /// the produced `fmt::Arguments` value borrows temporary values.
+    /// To allow it to be stored for later use, the arguments' lifetimes, as well as those of
+    /// temporaries they borrow, may be [extended] when `format_args!` appears in the initializer
+    /// expression of a `let` statement. The syntactic rules used to determine when temporaries'
+    /// lifetimes are extended are documented in the [Reference].
+    ///
+    /// [extended]: ../reference/destructors.html#temporary-lifetime-extension
+    /// [Reference]: ../reference/destructors.html#extending-based-on-expressions
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_diagnostic_item = "format_args_macro"]
     #[allow_internal_unsafe]

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -61,8 +61,6 @@ use rustc_middle::ty::print::PrintTraitRefExt;
 use rustc_middle::ty::{self, TyCtxt};
 use rustc_span::symbol::{Symbol, sym};
 use rustc_span::{BytePos, DUMMY_SP, FileName, RealFileName};
-use serde::ser::SerializeSeq as _;
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use tracing::{debug, info};
 
 pub(crate) use self::context::*;
@@ -422,102 +420,6 @@ impl IndexItemFunctionType {
             }
             string.push('}');
         }
-    }
-}
-
-impl Serialize for IndexItemFunctionType {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        struct ParamNames<'a>(&'a [Option<Symbol>]);
-
-        impl<'a> Serialize for ParamNames<'a> {
-            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-            where
-                S: Serializer,
-            {
-                serializer.collect_seq(
-                    self.0
-                        .iter()
-                        .map(|symbol| symbol.as_ref().map(Symbol::as_str).unwrap_or_default()),
-                )
-            }
-        }
-
-        let mut seq = serializer.serialize_seq(Some(2))?;
-
-        let mut fn_type = String::new();
-        self.write_to_string_without_param_names(&mut fn_type);
-        seq.serialize_element(&fn_type)?;
-
-        seq.serialize_element(&ParamNames(&self.param_names))?;
-
-        seq.end()
-    }
-}
-
-impl<'de> Deserialize<'de> for IndexItemFunctionType {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        use serde::de::{self, SeqAccess};
-
-        #[derive(Deserialize)]
-        struct Deserialized {
-            #[serde(deserialize_with = "function_signature")]
-            function_signature: IndexItemFunctionType,
-            #[serde(deserialize_with = "param_names")]
-            param_names: Vec<Option<Symbol>>,
-        }
-
-        fn function_signature<'de, D: Deserializer<'de>>(
-            deserializer: D,
-        ) -> Result<IndexItemFunctionType, D::Error> {
-            String::deserialize(deserializer).map(|sig| {
-                IndexItemFunctionType::read_from_string_without_param_names(sig.as_bytes()).0
-            })
-        }
-
-        fn param_names<'de, D: Deserializer<'de>>(
-            deserializer: D,
-        ) -> Result<Vec<Option<Symbol>>, D::Error> {
-            struct Visitor;
-
-            impl<'de> de::Visitor<'de> for Visitor {
-                type Value = Vec<Option<Symbol>>;
-
-                fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                    f.write_str("seq of param names")
-                }
-
-                fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
-                where
-                    A: SeqAccess<'de>,
-                {
-                    let mut param_names = Vec::with_capacity(seq.size_hint().unwrap_or_default());
-
-                    while let Some(symbol) = seq.next_element::<String>()? {
-                        param_names.push(if symbol.is_empty() {
-                            None
-                        } else {
-                            Some(Symbol::intern(&symbol))
-                        });
-                    }
-
-                    Ok(param_names)
-                }
-            }
-
-            deserializer.deserialize_seq(Visitor)
-        }
-
-        let Deserialized { mut function_signature, param_names } =
-            Deserialized::deserialize(deserializer)?;
-        function_signature.param_names = param_names;
-
-        Ok(function_signature)
     }
 }
 

--- a/src/librustdoc/html/render/search_index.rs
+++ b/src/librustdoc/html/render/search_index.rs
@@ -34,7 +34,7 @@ pub(crate) struct SerializedSearchIndex {
     path_data: Vec<Option<PathData>>,
     entry_data: Vec<Option<EntryData>>,
     descs: Vec<String>,
-    function_data: Vec<Option<FunctionData>>,
+    function_data: Vec<Option<IndexItemFunctionType>>,
     alias_pointers: Vec<Option<usize>>,
     // inverted index for concrete types and generics
     type_data: Vec<Option<TypeData>>,
@@ -61,7 +61,7 @@ impl SerializedSearchIndex {
         let mut path_data: Vec<Option<PathData>> = Vec::new();
         let mut entry_data: Vec<Option<EntryData>> = Vec::new();
         let mut descs: Vec<String> = Vec::new();
-        let mut function_data: Vec<Option<FunctionData>> = Vec::new();
+        let mut function_data: Vec<Option<IndexItemFunctionType>> = Vec::new();
         let mut type_data: Vec<Option<TypeData>> = Vec::new();
         let mut alias_pointers: Vec<Option<usize>> = Vec::new();
 
@@ -207,7 +207,7 @@ impl SerializedSearchIndex {
         path_data: Option<PathData>,
         entry_data: Option<EntryData>,
         desc: String,
-        function_data: Option<FunctionData>,
+        function_data: Option<IndexItemFunctionType>,
         type_data: Option<TypeData>,
         alias_pointer: Option<usize>,
     ) -> usize {
@@ -446,73 +446,62 @@ impl SerializedSearchIndex {
                         ..other_entry_data.clone()
                     }),
                     other.descs[other_entryid].clone(),
-                    other.function_data[other_entryid].as_ref().map(|function_data| FunctionData {
-                        function_signature: {
-                            let (mut func, _offset) =
-                                IndexItemFunctionType::read_from_string_without_param_names(
-                                    function_data.function_signature.as_bytes(),
-                                );
-                            fn map_fn_sig_item(
-                                map_other_pathid_to_self_pathid: &mut Vec<usize>,
-                                ty: &mut RenderType,
-                            ) {
-                                match ty.id {
-                                    None => {}
-                                    Some(RenderTypeId::Index(generic)) if generic < 0 => {}
-                                    Some(RenderTypeId::Index(id)) => {
-                                        let id = usize::try_from(id).unwrap();
-                                        let id = map_other_pathid_to_self_pathid[id];
-                                        assert!(id != !0);
-                                        ty.id =
-                                            Some(RenderTypeId::Index(isize::try_from(id).unwrap()));
-                                    }
-                                    _ => unreachable!(),
+                    other.function_data[other_entryid].clone().map(|mut func| {
+                        fn map_fn_sig_item(
+                            map_other_pathid_to_self_pathid: &mut Vec<usize>,
+                            ty: &mut RenderType,
+                        ) {
+                            match ty.id {
+                                None => {}
+                                Some(RenderTypeId::Index(generic)) if generic < 0 => {}
+                                Some(RenderTypeId::Index(id)) => {
+                                    let id = usize::try_from(id).unwrap();
+                                    let id = map_other_pathid_to_self_pathid[id];
+                                    assert!(id != !0);
+                                    ty.id = Some(RenderTypeId::Index(isize::try_from(id).unwrap()));
                                 }
-                                if let Some(generics) = &mut ty.generics {
-                                    for generic in generics {
-                                        map_fn_sig_item(map_other_pathid_to_self_pathid, generic);
-                                    }
+                                _ => unreachable!(),
+                            }
+                            if let Some(generics) = &mut ty.generics {
+                                for generic in generics {
+                                    map_fn_sig_item(map_other_pathid_to_self_pathid, generic);
                                 }
-                                if let Some(bindings) = &mut ty.bindings {
-                                    for (param, constraints) in bindings {
-                                        *param = match *param {
-                                            param @ RenderTypeId::Index(generic) if generic < 0 => {
-                                                param
-                                            }
-                                            RenderTypeId::Index(id) => {
-                                                let id = usize::try_from(id).unwrap();
-                                                let id = map_other_pathid_to_self_pathid[id];
-                                                assert!(id != !0);
-                                                RenderTypeId::Index(isize::try_from(id).unwrap())
-                                            }
-                                            _ => unreachable!(),
-                                        };
-                                        for constraint in constraints {
-                                            map_fn_sig_item(
-                                                map_other_pathid_to_self_pathid,
-                                                constraint,
-                                            );
+                            }
+                            if let Some(bindings) = &mut ty.bindings {
+                                for (param, constraints) in bindings {
+                                    *param = match *param {
+                                        param @ RenderTypeId::Index(generic) if generic < 0 => {
+                                            param
                                         }
+                                        RenderTypeId::Index(id) => {
+                                            let id = usize::try_from(id).unwrap();
+                                            let id = map_other_pathid_to_self_pathid[id];
+                                            assert!(id != !0);
+                                            RenderTypeId::Index(isize::try_from(id).unwrap())
+                                        }
+                                        _ => unreachable!(),
+                                    };
+                                    for constraint in constraints {
+                                        map_fn_sig_item(
+                                            map_other_pathid_to_self_pathid,
+                                            constraint,
+                                        );
                                     }
                                 }
                             }
-                            for input in &mut func.inputs {
-                                map_fn_sig_item(&mut map_other_pathid_to_self_pathid, input);
+                        }
+                        for input in &mut func.inputs {
+                            map_fn_sig_item(&mut map_other_pathid_to_self_pathid, input);
+                        }
+                        for output in &mut func.output {
+                            map_fn_sig_item(&mut map_other_pathid_to_self_pathid, output);
+                        }
+                        for clause in &mut func.where_clause {
+                            for entry in clause {
+                                map_fn_sig_item(&mut map_other_pathid_to_self_pathid, entry);
                             }
-                            for output in &mut func.output {
-                                map_fn_sig_item(&mut map_other_pathid_to_self_pathid, output);
-                            }
-                            for clause in &mut func.where_clause {
-                                for entry in clause {
-                                    map_fn_sig_item(&mut map_other_pathid_to_self_pathid, entry);
-                                }
-                            }
-                            let mut result =
-                                String::with_capacity(function_data.function_signature.len());
-                            func.write_to_string_without_param_names(&mut result);
-                            result
-                        },
-                        param_names: function_data.param_names.clone(),
+                        }
+                        func
                     }),
                     other.type_data[other_entryid].as_ref().map(|type_data| TypeData {
                         inverted_function_inputs_index: type_data
@@ -626,69 +615,55 @@ impl SerializedSearchIndex {
                     },
                 ),
                 self.descs[id].clone(),
-                self.function_data[id].as_ref().map(
-                    |FunctionData { function_signature, param_names }| FunctionData {
-                        function_signature: {
-                            let (mut func, _offset) =
-                                IndexItemFunctionType::read_from_string_without_param_names(
-                                    function_signature.as_bytes(),
-                                );
-                            fn map_fn_sig_item(map: &FxHashMap<usize, usize>, ty: &mut RenderType) {
-                                match ty.id {
-                                    None => {}
-                                    Some(RenderTypeId::Index(generic)) if generic < 0 => {}
-                                    Some(RenderTypeId::Index(id)) => {
+                self.function_data[id].clone().map(|mut func| {
+                    fn map_fn_sig_item(map: &FxHashMap<usize, usize>, ty: &mut RenderType) {
+                        match ty.id {
+                            None => {}
+                            Some(RenderTypeId::Index(generic)) if generic < 0 => {}
+                            Some(RenderTypeId::Index(id)) => {
+                                let id = usize::try_from(id).unwrap();
+                                let id = *map.get(&id).unwrap();
+                                assert!(id != !0);
+                                ty.id = Some(RenderTypeId::Index(isize::try_from(id).unwrap()));
+                            }
+                            _ => unreachable!(),
+                        }
+                        if let Some(generics) = &mut ty.generics {
+                            for generic in generics {
+                                map_fn_sig_item(map, generic);
+                            }
+                        }
+                        if let Some(bindings) = &mut ty.bindings {
+                            for (param, constraints) in bindings {
+                                *param = match *param {
+                                    param @ RenderTypeId::Index(generic) if generic < 0 => param,
+                                    RenderTypeId::Index(id) => {
                                         let id = usize::try_from(id).unwrap();
                                         let id = *map.get(&id).unwrap();
                                         assert!(id != !0);
-                                        ty.id =
-                                            Some(RenderTypeId::Index(isize::try_from(id).unwrap()));
+                                        RenderTypeId::Index(isize::try_from(id).unwrap())
                                     }
                                     _ => unreachable!(),
-                                }
-                                if let Some(generics) = &mut ty.generics {
-                                    for generic in generics {
-                                        map_fn_sig_item(map, generic);
-                                    }
-                                }
-                                if let Some(bindings) = &mut ty.bindings {
-                                    for (param, constraints) in bindings {
-                                        *param = match *param {
-                                            param @ RenderTypeId::Index(generic) if generic < 0 => {
-                                                param
-                                            }
-                                            RenderTypeId::Index(id) => {
-                                                let id = usize::try_from(id).unwrap();
-                                                let id = *map.get(&id).unwrap();
-                                                assert!(id != !0);
-                                                RenderTypeId::Index(isize::try_from(id).unwrap())
-                                            }
-                                            _ => unreachable!(),
-                                        };
-                                        for constraint in constraints {
-                                            map_fn_sig_item(map, constraint);
-                                        }
-                                    }
+                                };
+                                for constraint in constraints {
+                                    map_fn_sig_item(map, constraint);
                                 }
                             }
-                            for input in &mut func.inputs {
-                                map_fn_sig_item(&map, input);
-                            }
-                            for output in &mut func.output {
-                                map_fn_sig_item(&map, output);
-                            }
-                            for clause in &mut func.where_clause {
-                                for entry in clause {
-                                    map_fn_sig_item(&map, entry);
-                                }
-                            }
-                            let mut result = String::with_capacity(function_signature.len());
-                            func.write_to_string_without_param_names(&mut result);
-                            result
-                        },
-                        param_names: param_names.clone(),
-                    },
-                ),
+                        }
+                    }
+                    for input in &mut func.inputs {
+                        map_fn_sig_item(&map, input);
+                    }
+                    for output in &mut func.output {
+                        map_fn_sig_item(&map, output);
+                    }
+                    for clause in &mut func.where_clause {
+                        for entry in clause {
+                            map_fn_sig_item(&map, entry);
+                        }
+                    }
+                    func
+                }),
                 self.type_data[id].as_ref().map(
                     |TypeData {
                          search_unbox,
@@ -1256,48 +1231,6 @@ impl<'de> Deserialize<'de> for SerializedOptional32 {
             }
         }
         deserializer.deserialize_any(SerializedOptional32Visitor)
-    }
-}
-
-#[derive(Clone, Debug)]
-pub struct FunctionData {
-    function_signature: String,
-    param_names: Vec<String>,
-}
-
-impl Serialize for FunctionData {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let mut seq = serializer.serialize_seq(None)?;
-        seq.serialize_element(&self.function_signature)?;
-        seq.serialize_element(&self.param_names)?;
-        seq.end()
-    }
-}
-
-impl<'de> Deserialize<'de> for FunctionData {
-    fn deserialize<D>(deserializer: D) -> Result<FunctionData, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        struct FunctionDataVisitor;
-        impl<'de> de::Visitor<'de> for FunctionDataVisitor {
-            type Value = FunctionData;
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                write!(formatter, "fn data")
-            }
-            fn visit_seq<A: de::SeqAccess<'de>>(self, mut v: A) -> Result<FunctionData, A::Error> {
-                let function_signature: String = v
-                    .next_element()?
-                    .ok_or_else(|| A::Error::missing_field("function_signature"))?;
-                let param_names: Vec<String> =
-                    v.next_element()?.ok_or_else(|| A::Error::missing_field("param_names"))?;
-                Ok(FunctionData { function_signature, param_names })
-            }
-        }
-        deserializer.deserialize_any(FunctionDataVisitor)
     }
 }
 
@@ -1927,18 +1860,7 @@ pub(crate) fn build_index(
                 // because the postings list has to fill in an empty array for each
                 // unoccupied size.
                 if item.ty.is_fn_like() { 0 } else { 16 };
-            serialized_index.function_data[new_entry_id] = Some(FunctionData {
-                function_signature: {
-                    let mut function_signature = String::new();
-                    search_type.write_to_string_without_param_names(&mut function_signature);
-                    function_signature
-                },
-                param_names: search_type
-                    .param_names
-                    .iter()
-                    .map(|sym| sym.map(|sym| sym.to_string()).unwrap_or(String::new()))
-                    .collect::<Vec<String>>(),
-            });
+            serialized_index.function_data[new_entry_id] = Some(search_type.clone());
             for index in used_in_function_inputs {
                 let postings = if index >= 0 {
                     assert!(serialized_index.path_data[index as usize].is_some());

--- a/src/librustdoc/html/render/search_index.rs
+++ b/src/librustdoc/html/render/search_index.rs
@@ -1,9 +1,13 @@
 pub(crate) mod encode;
+mod serde;
 
 use std::collections::BTreeSet;
 use std::collections::hash_map::Entry;
 use std::path::Path;
 
+use ::serde::de::{self, Deserializer, Error as _};
+use ::serde::ser::{SerializeSeq, Serializer};
+use ::serde::{Deserialize, Serialize};
 use rustc_ast::join_path_syms;
 use rustc_data_structures::fx::{FxHashMap, FxHashSet, FxIndexMap};
 use rustc_hir::attrs::AttributeKind;
@@ -12,9 +16,6 @@ use rustc_middle::ty::TyCtxt;
 use rustc_span::def_id::DefId;
 use rustc_span::sym;
 use rustc_span::symbol::{Symbol, kw};
-use serde::de::{self, Deserializer, Error as _};
-use serde::ser::{SerializeSeq, Serializer};
-use serde::{Deserialize, Serialize};
 use stringdex::internals as stringdex_internals;
 use thin_vec::ThinVec;
 use tracing::instrument;

--- a/src/librustdoc/html/render/search_index/serde.rs
+++ b/src/librustdoc/html/render/search_index/serde.rs
@@ -1,0 +1,102 @@
+use std::fmt::{self, Formatter};
+
+use rustc_span::Symbol;
+use serde::de::{self, SeqAccess};
+use serde::ser::SerializeSeq as _;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+use crate::html::render::IndexItemFunctionType;
+
+impl Serialize for IndexItemFunctionType {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        struct ParamNames<'a>(&'a [Option<Symbol>]);
+
+        impl<'a> Serialize for ParamNames<'a> {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: Serializer,
+            {
+                serializer.collect_seq(
+                    self.0
+                        .iter()
+                        .map(|symbol| symbol.as_ref().map(Symbol::as_str).unwrap_or_default()),
+                )
+            }
+        }
+
+        let mut seq = serializer.serialize_seq(Some(2))?;
+
+        let mut fn_type = String::new();
+        self.write_to_string_without_param_names(&mut fn_type);
+        seq.serialize_element(&fn_type)?;
+
+        seq.serialize_element(&ParamNames(&self.param_names))?;
+
+        seq.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for IndexItemFunctionType {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct Deserialized {
+            #[serde(deserialize_with = "function_signature")]
+            function_signature: IndexItemFunctionType,
+            #[serde(deserialize_with = "param_names")]
+            param_names: Vec<Option<Symbol>>,
+        }
+
+        fn function_signature<'de, D: Deserializer<'de>>(
+            deserializer: D,
+        ) -> Result<IndexItemFunctionType, D::Error> {
+            String::deserialize(deserializer).map(|sig| {
+                IndexItemFunctionType::read_from_string_without_param_names(sig.as_bytes()).0
+            })
+        }
+
+        fn param_names<'de, D: Deserializer<'de>>(
+            deserializer: D,
+        ) -> Result<Vec<Option<Symbol>>, D::Error> {
+            struct Visitor;
+
+            impl<'de> de::Visitor<'de> for Visitor {
+                type Value = Vec<Option<Symbol>>;
+
+                fn expecting(&self, f: &mut Formatter<'_>) -> fmt::Result {
+                    f.write_str("seq of param names")
+                }
+
+                fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+                where
+                    A: SeqAccess<'de>,
+                {
+                    let mut param_names = Vec::with_capacity(seq.size_hint().unwrap_or_default());
+
+                    while let Some(symbol) = seq.next_element::<String>()? {
+                        param_names.push(if symbol.is_empty() {
+                            None
+                        } else {
+                            Some(Symbol::intern(&symbol))
+                        });
+                    }
+
+                    Ok(param_names)
+                }
+            }
+
+            deserializer.deserialize_seq(Visitor)
+        }
+
+        let Deserialized { mut function_signature, param_names } =
+            Deserialized::deserialize(deserializer)?;
+        function_signature.param_names = param_names;
+
+        Ok(function_signature)
+    }
+}

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -878,6 +878,21 @@ impl<'test> TestCx<'test> {
                     prefix = self.error_prefix(),
                     n = not_found.len(),
                 );
+
+                // FIXME: Ideally, we should check this at the place where we actually parse error annotations.
+                // it's better to use (negated) heuristic inside normalize_output if possible
+                if let Some(human_format) = self.props.compile_flags.iter().find(|flag| {
+                    // `human`, `human-unicode`, `short` will not generate JSON output
+                    flag.contains("error-format")
+                        && (flag.contains("short") || flag.contains("human"))
+                }) {
+                    let msg = format!(
+                        "tests with compile flag `{}` should not have error annotations such as `//~ ERROR`",
+                        human_format
+                    ).color(Color::Red);
+                    writeln!(self.stdout, "{}", msg);
+                }
+
                 for error in &not_found {
                     print_error(error);
                     let mut suggestions = Vec::new();

--- a/tests/ui/attributes/attr-on-mac-call.stderr
+++ b/tests/ui/attributes/attr-on-mac-call.stderr
@@ -82,7 +82,7 @@ LL |     #[link_section = "x"]
    |     ^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[link_section]` can be applied to statics and functions
+   = help: `#[link_section]` can be applied to functions and statics
 
 warning: `#[link_ordinal]` attribute cannot be used on macro calls
   --> $DIR/attr-on-mac-call.rs:33:5

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-call/generics.rs
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-call/generics.rs
@@ -14,8 +14,9 @@ struct Test<T: Copy> {
     f1: extern "cmse-nonsecure-call" fn<U: Copy>(U, u32, u32, u32) -> u64,
     //~^ ERROR cannot find type `U` in this scope
     //~| ERROR function pointer types may not have generic parameters
-    f2: extern "cmse-nonsecure-call" fn(impl Copy, u32, u32, u32) -> u64,
+    f2: extern "cmse-nonsecure-call" fn(impl Copy, u32, u32, u32) -> impl Copy,
     //~^ ERROR `impl Trait` is not allowed in `fn` pointer parameters
+    //~| ERROR `impl Trait` is not allowed in `fn` pointer return types
     f3: extern "cmse-nonsecure-call" fn(T, u32, u32, u32) -> u64, //~ ERROR [E0798]
     f4: extern "cmse-nonsecure-call" fn(Wrapper<T>, u32, u32, u32) -> u64, //~ ERROR [E0798]
 }

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-call/generics.stderr
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-call/generics.stderr
@@ -25,25 +25,33 @@ LL | struct Test<T: Copy, U> {
 error[E0562]: `impl Trait` is not allowed in `fn` pointer parameters
   --> $DIR/generics.rs:17:41
    |
-LL |     f2: extern "cmse-nonsecure-call" fn(impl Copy, u32, u32, u32) -> u64,
+LL |     f2: extern "cmse-nonsecure-call" fn(impl Copy, u32, u32, u32) -> impl Copy,
    |                                         ^^^^^^^^^
    |
    = note: `impl Trait` is only allowed in arguments and return types of functions and methods
 
+error[E0562]: `impl Trait` is not allowed in `fn` pointer return types
+  --> $DIR/generics.rs:17:70
+   |
+LL |     f2: extern "cmse-nonsecure-call" fn(impl Copy, u32, u32, u32) -> impl Copy,
+   |                                                                      ^^^^^^^^^
+   |
+   = note: `impl Trait` is only allowed in arguments and return types of functions and methods
+
 error[E0798]: function pointers with the `"cmse-nonsecure-call"` ABI cannot contain generics in their type
-  --> $DIR/generics.rs:19:9
+  --> $DIR/generics.rs:20:9
    |
 LL |     f3: extern "cmse-nonsecure-call" fn(T, u32, u32, u32) -> u64,
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0798]: function pointers with the `"cmse-nonsecure-call"` ABI cannot contain generics in their type
-  --> $DIR/generics.rs:20:9
+  --> $DIR/generics.rs:21:9
    |
 LL |     f4: extern "cmse-nonsecure-call" fn(Wrapper<T>, u32, u32, u32) -> u64,
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0798]: return value of `"cmse-nonsecure-call"` function too large to pass via registers
-  --> $DIR/generics.rs:26:71
+  --> $DIR/generics.rs:27:71
    |
 LL | type WithTraitObject = extern "cmse-nonsecure-call" fn(&dyn Trait) -> &dyn Trait;
    |                                                                       ^^^^^^^^^^ this type doesn't fit in the available registers
@@ -52,7 +60,7 @@ LL | type WithTraitObject = extern "cmse-nonsecure-call" fn(&dyn Trait) -> &dyn 
    = note: the result must either be a (transparently wrapped) i64, u64 or f64, or be at most 4 bytes in size
 
 error[E0798]: return value of `"cmse-nonsecure-call"` function too large to pass via registers
-  --> $DIR/generics.rs:30:60
+  --> $DIR/generics.rs:31:60
    |
 LL |     extern "cmse-nonsecure-call" fn(&'static dyn Trait) -> &'static dyn Trait;
    |                                                            ^^^^^^^^^^^^^^^^^^ this type doesn't fit in the available registers
@@ -61,7 +69,7 @@ LL |     extern "cmse-nonsecure-call" fn(&'static dyn Trait) -> &'static dyn Tra
    = note: the result must either be a (transparently wrapped) i64, u64 or f64, or be at most 4 bytes in size
 
 error[E0798]: return value of `"cmse-nonsecure-call"` function too large to pass via registers
-  --> $DIR/generics.rs:37:60
+  --> $DIR/generics.rs:38:60
    |
 LL |     extern "cmse-nonsecure-call" fn(WrapperTransparent) -> WrapperTransparent;
    |                                                            ^^^^^^^^^^^^^^^^^^ this type doesn't fit in the available registers
@@ -70,12 +78,12 @@ LL |     extern "cmse-nonsecure-call" fn(WrapperTransparent) -> WrapperTranspare
    = note: the result must either be a (transparently wrapped) i64, u64 or f64, or be at most 4 bytes in size
 
 error[E0045]: C-variadic functions with the "cmse-nonsecure-call" calling convention are not supported
-  --> $DIR/generics.rs:40:20
+  --> $DIR/generics.rs:41:20
    |
 LL | type WithVarArgs = extern "cmse-nonsecure-call" fn(u32, ...);
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ C-variadic function must have a compatible calling convention
 
-error: aborting due to 9 previous errors
+error: aborting due to 10 previous errors
 
 Some errors have detailed explanations: E0045, E0412, E0562, E0798.
 For more information about an error, try `rustc --explain E0045`.

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/generics.rs
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/generics.rs
@@ -65,3 +65,15 @@ extern "cmse-nonsecure-entry" fn wrapped_trait_object(x: WrapperTransparent) -> 
     //~^ ERROR return value of `"cmse-nonsecure-entry"` function too large to pass via registers [E0798]
     x
 }
+
+extern "cmse-nonsecure-entry" fn return_impl_trait(_: impl Copy) -> impl Copy {
+    //~^ ERROR functions with the `"cmse-nonsecure-entry"` ABI cannot contain generics in their type
+    //~| ERROR functions with the `"cmse-nonsecure-entry"` ABI cannot contain generics in their type
+    0u128
+}
+
+extern "cmse-nonsecure-entry" fn return_impl_trait_nested(v: (impl Copy, i32)) -> (impl Copy, i32) {
+    //~^ ERROR functions with the `"cmse-nonsecure-entry"` ABI cannot contain generics in their type
+    //~| ERROR functions with the `"cmse-nonsecure-entry"` ABI cannot contain generics in their type
+    v
+}

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/generics.stderr
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/generics.stderr
@@ -17,6 +17,34 @@ LL | extern "cmse-nonsecure-entry" fn impl_trait(_: impl Copy, _: u32, _: u32, _
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0798]: functions with the `"cmse-nonsecure-entry"` ABI cannot contain generics in their type
+  --> $DIR/generics.rs:69:1
+   |
+LL | extern "cmse-nonsecure-entry" fn return_impl_trait(_: impl Copy) -> impl Copy {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0798]: functions with the `"cmse-nonsecure-entry"` ABI cannot contain generics in their type
+  --> $DIR/generics.rs:69:1
+   |
+LL | extern "cmse-nonsecure-entry" fn return_impl_trait(_: impl Copy) -> impl Copy {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0798]: functions with the `"cmse-nonsecure-entry"` ABI cannot contain generics in their type
+  --> $DIR/generics.rs:75:1
+   |
+LL | extern "cmse-nonsecure-entry" fn return_impl_trait_nested(v: (impl Copy, i32)) -> (impl Copy, i32) {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0798]: functions with the `"cmse-nonsecure-entry"` ABI cannot contain generics in their type
+  --> $DIR/generics.rs:75:1
+   |
+LL | extern "cmse-nonsecure-entry" fn return_impl_trait_nested(v: (impl Copy, i32)) -> (impl Copy, i32) {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0798]: functions with the `"cmse-nonsecure-entry"` ABI cannot contain generics in their type
   --> $DIR/generics.rs:14:5
    |
 LL |     extern "cmse-nonsecure-entry" fn ambient_generic(_: T, _: u32, _: u32, _: u32) -> u64 {
@@ -61,6 +89,6 @@ LL | extern "cmse-nonsecure-entry" fn wrapped_trait_object(x: WrapperTransparent
    = note: functions with the `"cmse-nonsecure-entry"` ABI must pass their result via the available return registers
    = note: the result must either be a (transparently wrapped) i64, u64 or f64, or be at most 4 bytes in size
 
-error: aborting due to 7 previous errors
+error: aborting due to 11 previous errors
 
 For more information about this error, try `rustc --explain E0798`.

--- a/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs.rs
+++ b/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs.rs
@@ -705,6 +705,32 @@ mod link_section {
     //~| WARN previously accepted
     //~| HELP can be applied to
     //~| HELP remove the attribute
+
+    #[link_section = "1800"]
+    //~^ WARN attribute cannot be used on
+    //~| WARN previously accepted
+    //~| HELP can be applied to
+    //~| HELP remove the attribute
+    trait Tr {
+        #[link_section = "1800"]
+        fn inside_tr_no_default(&self);
+
+        #[link_section = "1800"]
+        fn inside_tr_default(&self) { }
+    }
+
+    impl S {
+        #[link_section = "1800"]
+        fn inside_abc_123(&self) { }
+    }
+
+    impl Tr for S {
+        #[link_section = "1800"]
+        fn inside_tr_no_default(&self) { }
+    }
+
+    #[link_section = "1800"]
+    fn should_always_link() { }
 }
 
 

--- a/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs.stderr
+++ b/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs.stderr
@@ -1236,7 +1236,7 @@ LL | #[link_section = "1800"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[link_section]` can be applied to statics and functions
+   = help: `#[link_section]` can be applied to functions and statics
 
 warning: `#[link_section]` attribute cannot be used on modules
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:683:17
@@ -1245,7 +1245,7 @@ LL |     mod inner { #![link_section="1800"] }
    |                 ^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[link_section]` can be applied to statics and functions
+   = help: `#[link_section]` can be applied to functions and statics
 
 warning: `#[link_section]` attribute cannot be used on structs
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:691:5
@@ -1254,7 +1254,7 @@ LL |     #[link_section = "1800"] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[link_section]` can be applied to statics and functions
+   = help: `#[link_section]` can be applied to functions and statics
 
 warning: `#[link_section]` attribute cannot be used on type aliases
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:697:5
@@ -1263,7 +1263,7 @@ LL |     #[link_section = "1800"] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[link_section]` can be applied to statics and functions
+   = help: `#[link_section]` can be applied to functions and statics
 
 warning: `#[link_section]` attribute cannot be used on inherent impl blocks
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:703:5
@@ -1272,7 +1272,7 @@ LL |     #[link_section = "1800"] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[link_section]` can be applied to statics and functions
+   = help: `#[link_section]` can be applied to functions and statics
 
 warning: `#[must_use]` attribute cannot be used on modules
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:764:1
@@ -1572,7 +1572,7 @@ LL | #![link_section = "1800"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[link_section]` can be applied to statics and functions
+   = help: `#[link_section]` can be applied to functions and statics
 
 warning: `#[must_use]` attribute cannot be used on crates
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:84:1

--- a/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs.stderr
+++ b/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs.stderr
@@ -203,7 +203,7 @@ LL | #![reexport_test_harness_main = "2900"]
    |  +
 
 warning: attribute should be applied to an `extern` block with non-Rust ABI
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:713:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:739:1
    |
 LL |   #[link(name = "x")]
    |   ^^^^^^^^^^^^^^^^^^^
@@ -219,7 +219,7 @@ LL | | }
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: crate-level attribute should be an inner attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:789:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:815:1
    |
 LL | #[windows_subsystem = "windows"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -230,7 +230,7 @@ LL | #![windows_subsystem = "windows"]
    |  +
 
 warning: crate-level attribute should be an inner attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:839:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:865:1
    |
 LL | #[crate_type = "0800"]
    | ^^^^^^^^^^^^^^^^^^^^^^
@@ -241,7 +241,7 @@ LL | #![crate_type = "0800"]
    |  +
 
 warning: crate-level attribute should be an inner attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:863:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:889:1
    |
 LL | #[feature(x0600)]
    | ^^^^^^^^^^^^^^^^^
@@ -252,7 +252,7 @@ LL | #![feature(x0600)]
    |  +
 
 warning: crate-level attribute should be an inner attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:888:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:914:1
    |
 LL | #[no_main]
    | ^^^^^^^^^^
@@ -263,7 +263,7 @@ LL | #![no_main]
    |  +
 
 warning: crate-level attribute should be an inner attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:912:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:938:1
    |
 LL | #[no_builtins]
    | ^^^^^^^^^^^^^^
@@ -340,7 +340,7 @@ LL |     #![reexport_test_harness_main = "2900"] impl S { }
    |      +
 
 warning: attribute should be applied to an `extern` block with non-Rust ABI
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:719:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:745:17
    |
 LL |     mod inner { #![link(name = "x")] }
    |     ------------^^^^^^^^^^^^^^^^^^^^-- not an `extern` block
@@ -348,7 +348,7 @@ LL |     mod inner { #![link(name = "x")] }
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: attribute should be applied to an `extern` block with non-Rust ABI
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:724:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:750:5
    |
 LL |     #[link(name = "x")] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^^ ---------- not an `extern` block
@@ -356,7 +356,7 @@ LL |     #[link(name = "x")] fn f() { }
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: attribute should be applied to an `extern` block with non-Rust ABI
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:729:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:755:5
    |
 LL |     #[link(name = "x")] struct S;
    |     ^^^^^^^^^^^^^^^^^^^ --------- not an `extern` block
@@ -364,7 +364,7 @@ LL |     #[link(name = "x")] struct S;
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: attribute should be applied to an `extern` block with non-Rust ABI
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:734:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:760:5
    |
 LL |     #[link(name = "x")] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^ ----------- not an `extern` block
@@ -372,7 +372,7 @@ LL |     #[link(name = "x")] type T = S;
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: attribute should be applied to an `extern` block with non-Rust ABI
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:739:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:765:5
    |
 LL |     #[link(name = "x")] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^ ---------- not an `extern` block
@@ -380,7 +380,7 @@ LL |     #[link(name = "x")] impl S { }
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: attribute should be applied to an `extern` block with non-Rust ABI
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:744:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:770:5
    |
 LL |     #[link(name = "x")] extern "Rust" {}
    |     ^^^^^^^^^^^^^^^^^^^
@@ -388,13 +388,13 @@ LL |     #[link(name = "x")] extern "Rust" {}
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: crate-level attribute should be in the root module
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:793:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:819:17
    |
 LL |     mod inner { #![windows_subsystem="windows"] }
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:796:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:822:5
    |
 LL |     #[windows_subsystem = "windows"] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -405,7 +405,7 @@ LL |     #![windows_subsystem = "windows"] fn f() { }
    |      +
 
 warning: crate-level attribute should be an inner attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:800:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:826:5
    |
 LL |     #[windows_subsystem = "windows"] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -416,7 +416,7 @@ LL |     #![windows_subsystem = "windows"] struct S;
    |      +
 
 warning: crate-level attribute should be an inner attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:804:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:830:5
    |
 LL |     #[windows_subsystem = "windows"] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -427,7 +427,7 @@ LL |     #![windows_subsystem = "windows"] type T = S;
    |      +
 
 warning: crate-level attribute should be an inner attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:808:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:834:5
    |
 LL |     #[windows_subsystem = "windows"] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -438,13 +438,13 @@ LL |     #![windows_subsystem = "windows"] impl S { }
    |      +
 
 warning: crate-level attribute should be in the root module
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:843:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:869:17
    |
 LL |     mod inner { #![crate_type="0800"] }
    |                 ^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:846:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:872:5
    |
 LL |     #[crate_type = "0800"] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^^^^^
@@ -455,7 +455,7 @@ LL |     #![crate_type = "0800"] fn f() { }
    |      +
 
 warning: crate-level attribute should be an inner attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:850:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:876:5
    |
 LL |     #[crate_type = "0800"] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^^
@@ -466,7 +466,7 @@ LL |     #![crate_type = "0800"] struct S;
    |      +
 
 warning: crate-level attribute should be an inner attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:854:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:880:5
    |
 LL |     #[crate_type = "0800"] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^^^^
@@ -477,7 +477,7 @@ LL |     #![crate_type = "0800"] type T = S;
    |      +
 
 warning: crate-level attribute should be an inner attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:858:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:884:5
    |
 LL |     #[crate_type = "0800"] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^^
@@ -488,13 +488,13 @@ LL |     #![crate_type = "0800"] impl S { }
    |      +
 
 warning: crate-level attribute should be in the root module
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:867:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:893:17
    |
 LL |     mod inner { #![feature(x0600)] }
    |                 ^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:870:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:896:5
    |
 LL |     #[feature(x0600)] fn f() { }
    |     ^^^^^^^^^^^^^^^^^
@@ -505,7 +505,7 @@ LL |     #![feature(x0600)] fn f() { }
    |      +
 
 warning: crate-level attribute should be an inner attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:874:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:900:5
    |
 LL |     #[feature(x0600)] struct S;
    |     ^^^^^^^^^^^^^^^^^
@@ -516,7 +516,7 @@ LL |     #![feature(x0600)] struct S;
    |      +
 
 warning: crate-level attribute should be an inner attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:878:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:904:5
    |
 LL |     #[feature(x0600)] type T = S;
    |     ^^^^^^^^^^^^^^^^^
@@ -527,7 +527,7 @@ LL |     #![feature(x0600)] type T = S;
    |      +
 
 warning: crate-level attribute should be an inner attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:882:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:908:5
    |
 LL |     #[feature(x0600)] impl S { }
    |     ^^^^^^^^^^^^^^^^^
@@ -538,13 +538,13 @@ LL |     #![feature(x0600)] impl S { }
    |      +
 
 warning: crate-level attribute should be in the root module
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:892:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:918:17
    |
 LL |     mod inner { #![no_main] }
    |                 ^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:895:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:921:5
    |
 LL |     #[no_main] fn f() { }
    |     ^^^^^^^^^^
@@ -555,7 +555,7 @@ LL |     #![no_main] fn f() { }
    |      +
 
 warning: crate-level attribute should be an inner attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:899:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:925:5
    |
 LL |     #[no_main] struct S;
    |     ^^^^^^^^^^
@@ -566,7 +566,7 @@ LL |     #![no_main] struct S;
    |      +
 
 warning: crate-level attribute should be an inner attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:903:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:929:5
    |
 LL |     #[no_main] type T = S;
    |     ^^^^^^^^^^
@@ -577,7 +577,7 @@ LL |     #![no_main] type T = S;
    |      +
 
 warning: crate-level attribute should be an inner attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:907:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:933:5
    |
 LL |     #[no_main] impl S { }
    |     ^^^^^^^^^^
@@ -588,13 +588,13 @@ LL |     #![no_main] impl S { }
    |      +
 
 warning: crate-level attribute should be in the root module
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:916:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:942:17
    |
 LL |     mod inner { #![no_builtins] }
    |                 ^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:919:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:945:5
    |
 LL |     #[no_builtins] fn f() { }
    |     ^^^^^^^^^^^^^^
@@ -605,7 +605,7 @@ LL |     #![no_builtins] fn f() { }
    |      +
 
 warning: crate-level attribute should be an inner attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:923:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:949:5
    |
 LL |     #[no_builtins] struct S;
    |     ^^^^^^^^^^^^^^
@@ -616,7 +616,7 @@ LL |     #![no_builtins] struct S;
    |      +
 
 warning: crate-level attribute should be an inner attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:927:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:953:5
    |
 LL |     #[no_builtins] type T = S;
    |     ^^^^^^^^^^^^^^
@@ -627,7 +627,7 @@ LL |     #![no_builtins] type T = S;
    |      +
 
 warning: crate-level attribute should be an inner attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:931:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:957:5
    |
 LL |     #[no_builtins] impl S { }
    |     ^^^^^^^^^^^^^^
@@ -1274,8 +1274,17 @@ LL |     #[link_section = "1800"] impl S { }
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = help: `#[link_section]` can be applied to functions and statics
 
+warning: `#[link_section]` attribute cannot be used on traits
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:709:5
+   |
+LL |     #[link_section = "1800"]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = help: `#[link_section]` can be applied to functions and statics
+
 warning: `#[must_use]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:764:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:790:1
    |
 LL | #[must_use]
    | ^^^^^^^^^^^
@@ -1284,7 +1293,7 @@ LL | #[must_use]
    = help: `#[must_use]` can be applied to functions, data types, unions, and traits
 
 warning: `#[must_use]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:769:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:795:17
    |
 LL |     mod inner { #![must_use] }
    |                 ^^^^^^^^^^^^
@@ -1293,7 +1302,7 @@ LL |     mod inner { #![must_use] }
    = help: `#[must_use]` can be applied to functions, data types, unions, and traits
 
 warning: `#[must_use]` attribute cannot be used on type aliases
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:778:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:804:5
    |
 LL |     #[must_use] type T = S;
    |     ^^^^^^^^^^^
@@ -1302,7 +1311,7 @@ LL |     #[must_use] type T = S;
    = help: `#[must_use]` can be applied to functions, data types, unions, and traits
 
 warning: `#[must_use]` attribute cannot be used on inherent impl blocks
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:783:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:809:5
    |
 LL |     #[must_use] impl S { }
    |     ^^^^^^^^^^^
@@ -1311,13 +1320,13 @@ LL |     #[must_use] impl S { }
    = help: `#[must_use]` can be applied to functions, data types, unions, and traits
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![crate_name]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:815:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:841:1
    |
 LL | #[crate_name = "0900"]
    | ^^^^^^^^^^^^^^^^^^^^^^
    |
 note: This attribute does not have an `!`, which means it is applied to this module
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:817:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:843:1
    |
 LL | / mod crate_name {
 LL | |
@@ -1327,67 +1336,67 @@ LL | | }
    | |_^
 
 warning: the `#![crate_name]` attribute can only be used at the crate root
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:819:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:845:17
    |
 LL |     mod inner { #![crate_name="0900"] }
    |                 ^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![crate_name]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:822:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:848:5
    |
 LL |     #[crate_name = "0900"] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^^^^^
    |
 note: This attribute does not have an `!`, which means it is applied to this function
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:822:28
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:848:28
    |
 LL |     #[crate_name = "0900"] fn f() { }
    |                            ^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![crate_name]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:826:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:852:5
    |
 LL |     #[crate_name = "0900"] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^^
    |
 note: This attribute does not have an `!`, which means it is applied to this struct
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:826:28
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:852:28
    |
 LL |     #[crate_name = "0900"] struct S;
    |                            ^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![crate_name]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:830:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:856:5
    |
 LL |     #[crate_name = "0900"] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^^^^
    |
 note: This attribute does not have an `!`, which means it is applied to this type alias
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:830:28
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:856:28
    |
 LL |     #[crate_name = "0900"] type T = S;
    |                            ^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![crate_name]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:834:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:860:5
    |
 LL |     #[crate_name = "0900"] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^^
    |
 note: This attribute does not have an `!`, which means it is applied to this implementation block
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:834:28
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:860:28
    |
 LL |     #[crate_name = "0900"] impl S { }
    |                            ^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![recursion_limit]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:936:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:962:1
    |
 LL | #[recursion_limit="0200"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: This attribute does not have an `!`, which means it is applied to this module
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:938:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:964:1
    |
 LL | / mod recursion_limit {
 LL | |
@@ -1397,67 +1406,67 @@ LL | | }
    | |_^
 
 warning: the `#![recursion_limit]` attribute can only be used at the crate root
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:940:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:966:17
    |
 LL |     mod inner { #![recursion_limit="0200"] }
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![recursion_limit]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:943:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:969:5
    |
 LL |     #[recursion_limit="0200"] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: This attribute does not have an `!`, which means it is applied to this function
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:943:31
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:969:31
    |
 LL |     #[recursion_limit="0200"] fn f() { }
    |                               ^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![recursion_limit]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:947:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:973:5
    |
 LL |     #[recursion_limit="0200"] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: This attribute does not have an `!`, which means it is applied to this struct
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:947:31
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:973:31
    |
 LL |     #[recursion_limit="0200"] struct S;
    |                               ^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![recursion_limit]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:951:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:977:5
    |
 LL |     #[recursion_limit="0200"] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: This attribute does not have an `!`, which means it is applied to this type alias
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:951:31
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:977:31
    |
 LL |     #[recursion_limit="0200"] type T = S;
    |                               ^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![recursion_limit]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:955:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:981:5
    |
 LL |     #[recursion_limit="0200"] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: This attribute does not have an `!`, which means it is applied to this implementation block
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:955:31
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:981:31
    |
 LL |     #[recursion_limit="0200"] impl S { }
    |                               ^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![type_length_limit]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:960:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:986:1
    |
 LL | #[type_length_limit="0100"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: This attribute does not have an `!`, which means it is applied to this module
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:962:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:988:1
    |
 LL | / mod type_length_limit {
 LL | |
@@ -1467,55 +1476,55 @@ LL | | }
    | |_^
 
 warning: the `#![type_length_limit]` attribute can only be used at the crate root
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:964:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:990:17
    |
 LL |     mod inner { #![type_length_limit="0100"] }
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![type_length_limit]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:967:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:993:5
    |
 LL |     #[type_length_limit="0100"] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: This attribute does not have an `!`, which means it is applied to this function
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:967:33
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:993:33
    |
 LL |     #[type_length_limit="0100"] fn f() { }
    |                                 ^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![type_length_limit]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:971:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:997:5
    |
 LL |     #[type_length_limit="0100"] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: This attribute does not have an `!`, which means it is applied to this struct
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:971:33
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:997:33
    |
 LL |     #[type_length_limit="0100"] struct S;
    |                                 ^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![type_length_limit]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:975:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:1001:5
    |
 LL |     #[type_length_limit="0100"] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: This attribute does not have an `!`, which means it is applied to this type alias
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:975:33
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:1001:33
    |
 LL |     #[type_length_limit="0100"] type T = S;
    |                                 ^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![type_length_limit]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:979:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:1005:5
    |
 LL |     #[type_length_limit="0100"] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: This attribute does not have an `!`, which means it is applied to this implementation block
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:979:33
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:1005:33
    |
 LL |     #[type_length_limit="0100"] impl S { }
    |                                 ^^^^^^^^^^
@@ -1583,5 +1592,5 @@ LL | #![must_use]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = help: `#[must_use]` can be applied to functions, data types, unions, and traits
 
-warning: 173 warnings emitted
+warning: 174 warnings emitted
 

--- a/tests/ui/thir-print/c-variadic.rs
+++ b/tests/ui/thir-print/c-variadic.rs
@@ -1,0 +1,6 @@
+//@ compile-flags: -Zunpretty=thir-tree --crate-type=lib
+//@ check-pass
+#![feature(c_variadic)]
+
+// The `...` argument uses `PatKind::Missing`.
+unsafe extern "C" fn foo(_: i32, ...) {}

--- a/tests/ui/thir-print/c-variadic.stdout
+++ b/tests/ui/thir-print/c-variadic.stdout
@@ -1,0 +1,61 @@
+DefId(0:3 ~ c_variadic[a5de]::foo):
+params: [
+    Param {
+        ty: i32
+        ty_span: Some($DIR/c-variadic.rs:6:29: 6:32 (#0))
+        self_kind: None
+        hir_id: Some(HirId(DefId(0:3 ~ c_variadic[a5de]::foo).1))
+        param: Some( 
+            Pat: {
+                ty: i32
+                span: $DIR/c-variadic.rs:6:26: 6:27 (#0)
+                kind: PatKind {
+                    Wild
+                }
+            }
+        )
+    }
+    Param {
+        ty: std::ffi::VaListImpl<'{erased}>
+        ty_span: None
+        self_kind: None
+        hir_id: Some(HirId(DefId(0:3 ~ c_variadic[a5de]::foo).3))
+        param: Some( 
+            Pat: {
+                ty: std::ffi::VaListImpl<'{erased}>
+                span: $DIR/c-variadic.rs:6:34: 6:37 (#0)
+                kind: PatKind {
+                    Missing
+                }
+            }
+        )
+    }
+]
+body:
+    Expr {
+        ty: ()
+        temp_lifetime: TempLifetime { temp_lifetime: Some(Node(6)), backwards_incompatible: None }
+        span: $DIR/c-variadic.rs:6:39: 6:41 (#0)
+        kind: 
+            Scope {
+                region_scope: Node(6)
+                lint_level: Explicit(HirId(DefId(0:3 ~ c_variadic[a5de]::foo).6))
+                value:
+                    Expr {
+                        ty: ()
+                        temp_lifetime: TempLifetime { temp_lifetime: Some(Node(6)), backwards_incompatible: None }
+                        span: $DIR/c-variadic.rs:6:39: 6:41 (#0)
+                        kind: 
+                            Block {
+                                targeted_by_break: false
+                                span: $DIR/c-variadic.rs:6:39: 6:41 (#0)
+                                region_scope: Node(5)
+                                safety_mode: Safe
+                                stmts: []
+                                expr: []
+                            }
+                    }
+            }
+    }
+
+


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#145943 (stdlib docs: document lifetime extension for `format_args!`'s arguments)
 - rust-lang/rust#147243 (cmse: disallow `impl Trait` in `cmse-nonsecure-entry` return types)
 - rust-lang/rust#147402 ([rustdoc] Don't serialize & deserialize data that doesn't go OTW)
 - rust-lang/rust#147418 (Fix target list of `link_section`)
 - rust-lang/rust#147429 (Print tip for human error format in runtest)
 - rust-lang/rust#147441 (Fix comments error for Provenance impls)
 - rust-lang/rust#147442 (c-variadic: fix thir-print for `...` without a pattern)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=145943,147243,147402,147418,147429,147441,147442)
<!-- homu-ignore:end -->