### PR TITLE
rustdoc: instrument call to lib_embargo_visit_item

### DIFF
--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -383,9 +383,11 @@ pub(crate) fn run_global_ctxt(
         show_coverage,
     };
 
-    for cnum in tcx.crates(()) {
-        crate::visit_lib::lib_embargo_visit_item(&mut ctxt, cnum.as_def_id());
-    }
+    tcx.sess.time("lib_embargo_visit_crates", || {
+        for cnum in tcx.crates(()) {
+            crate::visit_lib::lib_embargo_visit_item(&mut ctxt, cnum.as_def_id());
+        }
+    });
 
     // Small hack to force the Sized trait to be present.
     //


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

I had a thought randomly that we could reduce the amount of times lib_embargo_visit_item is called by only calling it when we want to get the effective visibility of an item in a given crate, since DefId contains a CrateNum.  However, this could require some fairly complex locking, so I thought I should instrument this pass to get a ceiling of how much performance gain this could give.

If this would make a difference ever, it would be in crates with a large number of dependencies that are never referenced from the docs (no intra-doc links, trait impls, or re-exports)
