### PR TITLE
Fix backtraces with `-C panic=abort` on qnx; emit unwind tables by default

### DIFF
--- a/compiler/rustc_target/src/spec/base/nto_qnx.rs
+++ b/compiler/rustc_target/src/spec/base/nto_qnx.rs
@@ -12,6 +12,9 @@ pub(crate) fn opts() -> TargetOptions {
         has_thread_local: false,
         linker: Some("qcc".into()),
         os: "nto".into(),
+        // We want backtraces to work by default and they rely on unwind tables
+        // (regardless of `-C panic` strategy).
+        default_uwtable: true,
         position_independent_executables: true,
         static_position_independent_executables: true,
         relro_level: RelroLevel::Full,


### PR DESCRIPTION
While syncing https://github.com/rust-lang/rust/pull/143613 into Ferrocene as part of https://github.com/ferrocene/ferrocene/pull/1803, we noted a failure on our QNX targets:

```
---- [ui] tests/ui/panics/panic-abort-backtrace-without-debuginfo.rs stdout ----

error: test did not exit with success! code=Some(134) so test would pass with `run-crash`
status: exit status: 134
command: RUSTC="/home/ci/project/build/x86_64-unknown-linux-gnu/stage2/bin/rustc" RUST_TEST_THREADS="1" "/home/ci/project/build/x86_64-unknown-linux-gnu/stage1-tools-bin/remote-test-client" "run" "0" "/home/ci/project/build/x86_64-unknown-linux-gnu/test/ui/panics/panic-abort-backtrace-without-debuginfo/a"
--- stdout -------------------------------
uploaded "/home/ci/project/build/x86_64-unknown-linux-gnu/test/ui/panics/panic-abort-backtrace-without-debuginfo/a", waiting for result
died due to signal 6
------------------------------------------
--- stderr -------------------------------

thread 'main' (1) panicked at /home/ci/project/tests/ui/panics/panic-abort-backtrace-without-debuginfo.rs:39:9:
ERROR: no `this_function_must_be_in_the_backtrace` in stderr! actual stderr: 
thread 'main' (1) panicked at /home/ci/project/tests/ui/panics/panic-abort-backtrace-without-debuginfo.rs:27:5:
generate panic backtrace
stack backtrace:
   0:       0x4e66a53643 - <std::sys::backtrace::BacktraceLock::print::DisplayBacktrace as core::fmt::Display>::fmt::h55e010263b1e3169
   1:       0x4e66a68cd2 - core::fmt::write::h0d6e2e8752abc333
   2:       0x4e66a16919 - std::io::Write::write_fmt::h71c4c024d832b384
   3:       0x4e66a1f8e2 - std::sys::backtrace::BacktraceLock::print::hdd80dfdf90bb7100
   4:       0x4e66a221e0 - std::panicking::default_hook::{{closure}}::h77758f25a686500f
   5:       0x4e66a21f69 - std::panicking::default_hook::ha63f7d476af6c267
   6:       0x4e66a22999 - std::panicking::panic_with_hook::h3a36a8a0f0dd8ccd
   7:       0x4e66a21cac - std::panicking::begin_panic::{{closure}}::h570dedb92e232392
   8:       0x4e66a1fa69 - std::sys::backtrace::__rust_end_short_backtrace::h5366eec354f92733
   9:       0x4e669f9589 - std::panicking::begin_panic::h04a4bd4c33dd4056
  10:       0x4e66a00aca - panic_abort_backtrace_without_debuginfo::and_this_function_too::h5b034b94cbe9c3d3

note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
------------------------------------------

---- [ui] tests/ui/panics/panic-abort-backtrace-without-debuginfo.rs stdout end ----

failures:
    [ui] tests/ui/panics/panic-abort-backtrace-without-debuginfo.rs

test result: FAILED. 19958 passed; 1 failed; 328 ignored; 0 measured; 0 filtered out; finished in 1827.71s

Some tests failed in compiletest suite=ui mode=ui host=x86_64-unknown-linux-gnu target=x86_64-pc-nto-qnx710
Build completed unsuccessfully in 0:43:28

Exited with code exit status 1
```

This patch applies the same fix as the one found in https://github.com/rust-lang/rust/pull/143613 of adding the `default_uwtable: true` to the target.

I've run it locally, when https://github.com/ferrocene/ferrocene/pull/1803 merges we'll know it has passed within our CI, which is about a close an analog as I can offer to Rust.