### PR TITLE
rustc_codegen_llvm: Require `opt-level >= 1` for index-based write_operand_repeatedly() loop

### DIFF
--- a/tests/debuginfo/basic-stepping.rs
+++ b/tests/debuginfo/basic-stepping.rs
@@ -21,8 +21,8 @@
 // FIXME(#33013): gdb-command: next
 // FIXME(#33013): gdb-check:   let g = b'9';
 // FIXME(#33013): gdb-command: next
-// FIXME(#33013): gdb-check:   let h = ["whatever"; 8];
-// FIXME(#33013): gdb-command: next
+// gdb-check:   let h = ["whatever"; 8];
+// gdb-command: next
 // gdb-check:   let i = [1,2,3,4];
 // gdb-command: next
 // gdb-check:   let j = (23, "hi");


### PR DESCRIPTION
To make debugger stepping intuitive with `-Copt-level=0`. See the adjusted `basic-stepping.rs` test.

This is kind of a revert of **bd0aae92dc76d9 (cg_llvm: use index-based loop in write_operand_repeatedly)**, except we don't revert it, we just make it conditional on `opt-level`. That commit regressed `basic-stepping.rs`, but it was not noticed since that test did not exist back then (it was added later in rust-lang/rust#144876). I have retroactively bisected to find that out.

It seems messy to sprinkle if-cases inside of
`write_operand_repeatedly()` so make the whole function conditional.

The test that bd0aae92dc76d9 added in
`tests/codegen/issues/issue-111603.rs` already use `-Copt-level=3`, so we don't need to adjust the compiler flags for it to keep passing.

This PR takes us one step closer to fixing rust-lang/rust#33013.

CC rust-lang/rust#147426 which is related (there will be trivial conflicts for me to resolve in basic-stepping.rs once one of them lands)
