### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_attr_parsing/src/target_checking.rs
+++ b/compiler/rustc_attr_parsing/src/target_checking.rs
@@ -198,16 +198,20 @@ pub(crate) fn allowed_targets_applied(
     filter_targets(&mut allowed_targets, IMPL_LIKE, "impl blocks", target, &mut added_fake_targets);
     filter_targets(&mut allowed_targets, ADT_LIKE, "data types", target, &mut added_fake_targets);
 
+    let mut target_strings: Vec<_> = added_fake_targets
+        .iter()
+        .copied()
+        .chain(allowed_targets.iter().map(|t| t.plural_name()))
+        .map(|i| i.to_string())
+        .collect();
+
+    // ensure a consistent order
+    target_strings.sort();
+
     // If there is now only 1 target left, show that as the only possible target
-    (
-        added_fake_targets
-            .iter()
-            .copied()
-            .chain(allowed_targets.iter().map(|t| t.plural_name()))
-            .map(|i| i.to_string())
-            .collect(),
-        allowed_targets.len() + added_fake_targets.len() == 1,
-    )
+    let only_target = target_strings.len() == 1;
+
+    (target_strings, only_target)
 }
 
 fn filter_targets(

--- a/compiler/rustc_codegen_llvm/src/builder/autodiff.rs
+++ b/compiler/rustc_codegen_llvm/src/builder/autodiff.rs
@@ -12,7 +12,7 @@ use tracing::debug;
 use crate::builder::{Builder, PlaceRef, UNNAMED};
 use crate::context::SimpleCx;
 use crate::declare::declare_simple_fn;
-use crate::llvm::{self, Metadata, TRUE, Type, Value};
+use crate::llvm::{self, TRUE, Type, Value};
 
 pub(crate) fn adjust_activity_to_abi<'tcx>(
     tcx: TyCtxt<'tcx>,

--- a/compiler/rustc_codegen_llvm/src/builder/autodiff.rs
+++ b/compiler/rustc_codegen_llvm/src/builder/autodiff.rs
@@ -143,9 +143,9 @@ fn match_args_from_caller_to_enzyme<'ll, 'tcx>(
     cx: &SimpleCx<'ll>,
     builder: &mut Builder<'_, 'll, 'tcx>,
     width: u32,
-    args: &mut Vec<&'ll llvm::Value>,
+    args: &mut Vec<&'ll Value>,
     inputs: &[DiffActivity],
-    outer_args: &[&'ll llvm::Value],
+    outer_args: &[&'ll Value],
 ) {
     debug!("matching autodiff arguments");
     // We now handle the issue that Rust level arguments not always match the llvm-ir level
@@ -157,32 +157,36 @@ fn match_args_from_caller_to_enzyme<'ll, 'tcx>(
     let mut outer_pos: usize = 0;
     let mut activity_pos = 0;
 
-    let enzyme_const = cx.create_metadata(b"enzyme_const");
-    let enzyme_out = cx.create_metadata(b"enzyme_out");
-    let enzyme_dup = cx.create_metadata(b"enzyme_dup");
-    let enzyme_dupv = cx.create_metadata(b"enzyme_dupv");
-    let enzyme_dupnoneed = cx.create_metadata(b"enzyme_dupnoneed");
-    let enzyme_dupnoneedv = cx.create_metadata(b"enzyme_dupnoneedv");
+    // We used to use llvm's metadata to instruct enzyme how to differentiate a function.
+    // In debug mode we would use incremental compilation which caused the metadata to be
+    // dropped. This is prevented by now using named globals, which are also understood
+    // by Enzyme.
+    let global_const = cx.declare_global("enzyme_const", cx.type_ptr());
+    let global_out = cx.declare_global("enzyme_out", cx.type_ptr());
+    let global_dup = cx.declare_global("enzyme_dup", cx.type_ptr());
+    let global_dupv = cx.declare_global("enzyme_dupv", cx.type_ptr());
+    let global_dupnoneed = cx.declare_global("enzyme_dupnoneed", cx.type_ptr());
+    let global_dupnoneedv = cx.declare_global("enzyme_dupnoneedv", cx.type_ptr());
 
     while activity_pos < inputs.len() {
         let diff_activity = inputs[activity_pos as usize];
         // Duplicated arguments received a shadow argument, into which enzyme will write the
         // gradient.
-        let (activity, duplicated): (&Metadata, bool) = match diff_activity {
+        let (activity, duplicated): (&Value, bool) = match diff_activity {
             DiffActivity::None => panic!("not a valid input activity"),
-            DiffActivity::Const => (enzyme_const, false),
-            DiffActivity::Active => (enzyme_out, false),
-            DiffActivity::ActiveOnly => (enzyme_out, false),
-            DiffActivity::Dual => (enzyme_dup, true),
-            DiffActivity::Dualv => (enzyme_dupv, true),
-            DiffActivity::DualOnly => (enzyme_dupnoneed, true),
-            DiffActivity::DualvOnly => (enzyme_dupnoneedv, true),
-            DiffActivity::Duplicated => (enzyme_dup, true),
-            DiffActivity::DuplicatedOnly => (enzyme_dupnoneed, true),
-            DiffActivity::FakeActivitySize(_) => (enzyme_const, false),
+            DiffActivity::Const => (global_const, false),
+            DiffActivity::Active => (global_out, false),
+            DiffActivity::ActiveOnly => (global_out, false),
+            DiffActivity::Dual => (global_dup, true),
+            DiffActivity::Dualv => (global_dupv, true),
+            DiffActivity::DualOnly => (global_dupnoneed, true),
+            DiffActivity::DualvOnly => (global_dupnoneedv, true),
+            DiffActivity::Duplicated => (global_dup, true),
+            DiffActivity::DuplicatedOnly => (global_dupnoneed, true),
+            DiffActivity::FakeActivitySize(_) => (global_const, false),
         };
         let outer_arg = outer_args[outer_pos];
-        args.push(cx.get_metadata_value(activity));
+        args.push(activity);
         if matches!(diff_activity, DiffActivity::Dualv) {
             let next_outer_arg = outer_args[outer_pos + 1];
             let elem_bytes_size: u64 = match inputs[activity_pos + 1] {
@@ -242,7 +246,7 @@ fn match_args_from_caller_to_enzyme<'ll, 'tcx>(
                     assert_eq!(cx.type_kind(next_outer_ty3), TypeKind::Integer);
                     args.push(next_outer_arg2);
                 }
-                args.push(cx.get_metadata_value(enzyme_const));
+                args.push(global_const);
                 args.push(next_outer_arg);
                 outer_pos += 2 + 2 * iterations;
                 activity_pos += 2;
@@ -351,13 +355,13 @@ pub(crate) fn generate_enzyme_call<'ll, 'tcx>(
     let mut args = Vec::with_capacity(num_args as usize + 1);
     args.push(fn_to_diff);
 
-    let enzyme_primal_ret = cx.create_metadata(b"enzyme_primal_return");
+    let global_primal_ret = cx.declare_global("enzyme_primal_return", cx.type_ptr());
     if matches!(attrs.ret_activity, DiffActivity::Dual | DiffActivity::Active) {
-        args.push(cx.get_metadata_value(enzyme_primal_ret));
+        args.push(global_primal_ret);
     }
     if attrs.width > 1 {
-        let enzyme_width = cx.create_metadata(b"enzyme_width");
-        args.push(cx.get_metadata_value(enzyme_width));
+        let global_width = cx.declare_global("enzyme_width", cx.type_ptr());
+        args.push(global_width);
         args.push(cx.get_const_int(cx.type_i64(), attrs.width as u64));
     }
 

--- a/compiler/rustc_const_eval/messages.ftl
+++ b/compiler/rustc_const_eval/messages.ftl
@@ -481,7 +481,10 @@ const_eval_validation_null_box = {$front_matter}: encountered a {$maybe ->
     [true] maybe-null
     *[false] null
   } box
-const_eval_validation_null_fn_ptr = {$front_matter}: encountered a null function pointer
+const_eval_validation_null_fn_ptr = {$front_matter}: encountered a {$maybe ->
+    [true] maybe-null
+    *[false] null
+  } function pointer
 const_eval_validation_null_ref = {$front_matter}: encountered a {$maybe ->
     [true] maybe-null
     *[false] null

--- a/compiler/rustc_const_eval/src/errors.rs
+++ b/compiler/rustc_const_eval/src/errors.rs
@@ -666,7 +666,7 @@ impl<'tcx> ReportErrorExt for ValidationErrorInfo<'tcx> {
             PartialPointer => const_eval_validation_partial_pointer,
             MutableRefToImmutable => const_eval_validation_mutable_ref_to_immutable,
             MutableRefInConst => const_eval_validation_mutable_ref_in_const,
-            NullFnPtr => const_eval_validation_null_fn_ptr,
+            NullFnPtr { .. } => const_eval_validation_null_fn_ptr,
             NeverVal => const_eval_validation_never_val,
             NonnullPtrMaybeNull { .. } => const_eval_validation_nonnull_ptr_out_of_range,
             PtrOutOfRange { .. } => const_eval_validation_ptr_out_of_range,
@@ -820,12 +820,11 @@ impl<'tcx> ReportErrorExt for ValidationErrorInfo<'tcx> {
                 err.arg("vtable_dyn_type", vtable_dyn_type.to_string());
                 err.arg("expected_dyn_type", expected_dyn_type.to_string());
             }
-            NullPtr { maybe, .. } => {
+            NullPtr { maybe, .. } | NullFnPtr { maybe } => {
                 err.arg("maybe", maybe);
             }
             MutableRefToImmutable
             | MutableRefInConst
-            | NullFnPtr
             | NonnullPtrMaybeNull
             | NeverVal
             | UnsafeCellInImmutable

--- a/compiler/rustc_const_eval/src/interpret/validity.rs
+++ b/compiler/rustc_const_eval/src/interpret/validity.rs
@@ -757,14 +757,12 @@ impl<'rt, 'tcx, M: Machine<'tcx>> ValidityVisitor<'rt, 'tcx, M> {
                     );
                     // FIXME: Check if the signature matches
                 } else {
-                    // Otherwise (for standalone Miri), we have to still check it to be non-null.
+                    // Otherwise (for standalone Miri and for `-Zextra-const-ub-checks`),
+                    // we have to still check it to be non-null.
                     if self.ecx.scalar_may_be_null(scalar)? {
                         let maybe =
                             !M::Provenance::OFFSET_IS_ADDR && matches!(scalar, Scalar::Ptr(..));
-                        // This can't be a "maybe-null" pointer since the check for this being
-                        // a fn ptr at all already ensures that the pointer is inbounds.
-                        assert!(!maybe);
-                        throw_validation_failure!(self.path, NullFnPtr);
+                        throw_validation_failure!(self.path, NullFnPtr { maybe });
                     }
                 }
                 if self.reset_provenance_and_padding {

--- a/compiler/rustc_middle/src/mir/interpret/error.rs
+++ b/compiler/rustc_middle/src/mir/interpret/error.rs
@@ -497,7 +497,10 @@ pub enum ValidationErrorKind<'tcx> {
     MutableRefToImmutable,
     UnsafeCellInImmutable,
     MutableRefInConst,
-    NullFnPtr,
+    NullFnPtr {
+        /// Records whether this pointer is definitely null or just may be null.
+        maybe: bool,
+    },
     NeverVal,
     NonnullPtrMaybeNull,
     PtrOutOfRange {

--- a/src/bootstrap/src/core/build_steps/run.rs
+++ b/src/bootstrap/src/core/build_steps/run.rs
@@ -6,6 +6,7 @@
 use std::path::PathBuf;
 
 use build_helper::exit;
+use build_helper::git::get_git_untracked_files;
 use clap_complete::{Generator, shells};
 
 use crate::core::build_steps::dist::distdir;
@@ -207,6 +208,16 @@ impl Step for CollectLicenseMetadata {
         };
 
         let dest = builder.src.join("license-metadata.json");
+
+        if !builder.config.dry_run() {
+            builder.require_and_update_all_submodules();
+            if let Ok(Some(untracked)) = get_git_untracked_files(None) {
+                eprintln!(
+                    "Warning: {} untracked files may cause the license report to be incorrect.",
+                    untracked.len()
+                );
+            }
+        }
 
         let mut cmd = builder.tool_cmd(Tool::CollectLicenseMetadata);
         cmd.env("REUSE_EXE", reuse);

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -339,7 +339,6 @@ summary.hideme,
 .scraped-example-list,
 .rustdoc-breadcrumbs,
 .search-switcher,
-.search-throbber,
 /* This selector is for the items listed in the "all items" page. */
 ul.all-items {
 	font-family: "Fira Sans", Arial, NanumBarunGothic, sans-serif;
@@ -2007,12 +2006,6 @@ a.tooltip:hover::after {
 	color: transparent;
 }
 
-.search-throbber {
-	position: relative;
-	height: 34px;
-}
-
-.search-throbber::after,
 .search-form.loading::after
 {
 	width: 18px;

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -339,6 +339,7 @@ summary.hideme,
 .scraped-example-list,
 .rustdoc-breadcrumbs,
 .search-switcher,
+.search-throbber,
 /* This selector is for the items listed in the "all items" page. */
 ul.all-items {
 	font-family: "Fira Sans", Arial, NanumBarunGothic, sans-serif;
@@ -2004,6 +2005,57 @@ a.tooltip:hover::after {
 
 #search-tabs .count.loading {
 	color: transparent;
+}
+
+.search-throbber {
+	position: relative;
+	height: 34px;
+}
+
+.search-throbber::before,
+.search-form.loading::before
+{
+	width: 16px;
+	height: 16px;
+	border-radius: 16px;
+	background: radial-gradient(
+		var(--button-background-color) 0 50%,
+		transparent 50% 100%
+	), conic-gradient(
+		var(--code-highlight-kw-color) 0deg 30deg,
+		var(--code-highlight-prelude-color) 30deg 60deg,
+		var(--code-highlight-number-color) 90deg 120deg,
+		var(--code-highlight-lifetime-color ) 120deg 150deg,
+		var(--code-highlight-comment-color) 150deg 180deg,
+		var(--code-highlight-self-color) 180deg 210deg,
+		var(--code-highlight-attribute-color) 210deg 240deg,
+		var(--code-highlight-literal-color) 210deg 240deg,
+		var(--code-highlight-macro-color) 240deg 270deg,
+		var(--code-highlight-question-mark-color) 270deg 300deg,
+		var(--code-highlight-prelude-val-color) 300deg 330deg,
+		var(--code-highlight-doc-comment-color) 330deg 360deg
+	);
+	content: "";
+	position: absolute;
+	right: 9px;
+	top: 8px;
+	animation: rotating 1.25s linear infinite;
+}
+.search-throbber::after,
+.search-form.loading::after
+{
+	width: 18px;
+	height: 18px;
+	border-radius: 18px;
+	background: conic-gradient(
+		var(--button-background-color) 0deg 180deg,
+		transparent 270deg 360deg
+	);
+	content: "";
+	position: absolute;
+	right: 8px;
+	top: 8px;
+	animation: rotating 0.66s linear infinite;
 }
 
 #search .error code {

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -2012,50 +2012,28 @@ a.tooltip:hover::after {
 	height: 34px;
 }
 
-.search-throbber::before,
-.search-form.loading::before
-{
-	width: 16px;
-	height: 16px;
-	border-radius: 16px;
-	background: radial-gradient(
-		var(--button-background-color) 0 50%,
-		transparent 50% 100%
-	), conic-gradient(
-		var(--code-highlight-kw-color) 0deg 30deg,
-		var(--code-highlight-prelude-color) 30deg 60deg,
-		var(--code-highlight-number-color) 90deg 120deg,
-		var(--code-highlight-lifetime-color ) 120deg 150deg,
-		var(--code-highlight-comment-color) 150deg 180deg,
-		var(--code-highlight-self-color) 180deg 210deg,
-		var(--code-highlight-attribute-color) 210deg 240deg,
-		var(--code-highlight-literal-color) 210deg 240deg,
-		var(--code-highlight-macro-color) 240deg 270deg,
-		var(--code-highlight-question-mark-color) 270deg 300deg,
-		var(--code-highlight-prelude-val-color) 300deg 330deg,
-		var(--code-highlight-doc-comment-color) 330deg 360deg
-	);
-	content: "";
-	position: absolute;
-	right: 9px;
-	top: 8px;
-	animation: rotating 1.25s linear infinite;
-}
 .search-throbber::after,
 .search-form.loading::after
 {
 	width: 18px;
 	height: 18px;
 	border-radius: 18px;
-	background: conic-gradient(
-		var(--button-background-color) 0deg 180deg,
-		transparent 270deg 360deg
-	);
-	content: "";
+	/* hourglass */
+	content: url('data:image/svg+xml,\
+	<svg width="16" height="16" viewBox="0 0 8 8" xmlns="http://www.w3.org/2000/svg">\
+		<g fill="none">\
+			<path d="m3.019 1.496v1.496l0.5878 1.018-0.5751 0.996v1.494" stroke="%233f3f3f"/>\
+			<path d="m5.003 1.496v1.496l-0.5878 1.018 0.5751 0.996v1.494" stroke="%233f3f3f"/>\
+			<path d="m2.006 1.5h3.978" stroke="%23000"/>\
+			<path d="m2.006 6.49h3.993" stroke="%23000"/>\
+		</g>\
+		<path d="m4.005 5.301-0.3987 0.6905h0.7977z" fill="%237f7f7f"/>\
+		<path d="m4.011 3.712-0.3987-0.6905h0.7977z" fill="%237f7f7f"/>\
+	</svg>');
 	position: absolute;
 	right: 8px;
 	top: 8px;
-	animation: rotating 0.66s linear infinite;
+	filter: var(--settings-menu-filter);
 }
 
 #search .error code {

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1987,12 +1987,10 @@ a.tooltip:hover::after {
 	color: inherit;
 }
 #search-tabs button:not(.selected) {
-	--search-tab-button-background: var(--search-tab-button-not-selected-background);
 	background-color: var(--search-tab-button-not-selected-background);
 	border-top-color: var(--search-tab-button-not-selected-border-top-color);
 }
 #search-tabs button:hover, #search-tabs button.selected {
-	--search-tab-button-background: var(--search-tab-button-selected-background);
 	background-color: var(--search-tab-button-selected-background);
 	border-top-color: var(--search-tab-button-selected-border-top-color);
 }
@@ -2006,68 +2004,6 @@ a.tooltip:hover::after {
 
 #search-tabs .count.loading {
 	color: transparent;
-}
-
-.search-form.loading {
-	--search-tab-button-background: var(--button-background-color);
-}
-
-#search-tabs .count.loading::before,
-.search-form.loading::before
-{
-	width: 16px;
-	height: 16px;
-	border-radius: 16px;
-	background: radial-gradient(
-		var(--search-tab-button-background) 0 50%,
-		transparent 50% 100%
-	), conic-gradient(
-		var(--code-highlight-kw-color) 0deg 30deg,
-		var(--code-highlight-prelude-color) 30deg 60deg,
-		var(--code-highlight-number-color) 90deg 120deg,
-		var(--code-highlight-lifetime-color ) 120deg 150deg,
-		var(--code-highlight-comment-color) 150deg 180deg,
-		var(--code-highlight-self-color) 180deg 210deg,
-		var(--code-highlight-attribute-color) 210deg 240deg,
-		var(--code-highlight-literal-color) 210deg 240deg,
-		var(--code-highlight-macro-color) 240deg 270deg,
-		var(--code-highlight-question-mark-color) 270deg 300deg,
-		var(--code-highlight-prelude-val-color) 300deg 330deg,
-		var(--code-highlight-doc-comment-color) 330deg 360deg
-	);
-	content: "";
-	position: absolute;
-	left: 2px;
-	top: 2px;
-	animation: rotating 1.25s linear infinite;
-}
-#search-tabs .count.loading::after,
-.search-form.loading::after
-{
-	width: 18px;
-	height: 18px;
-	border-radius: 18px;
-	background: conic-gradient(
-		var(--search-tab-button-background) 0deg 180deg,
-		transparent 270deg 360deg
-	);
-	content: "";
-	position: absolute;
-	left: 1px;
-	top: 1px;
-	animation: rotating 0.66s linear infinite;
-}
-
-.search-form.loading::before {
-	left: auto;
-	right: 9px;
-	top: 8px;
-}
-
-.search-form.loading::after {
-	left: auto;
-	right: 8px;
-	top: 8px;
 }
 
 #search .error code {

--- a/tests/rustdoc-gui/search-throbber.goml
+++ b/tests/rustdoc-gui/search-throbber.goml
@@ -1,0 +1,23 @@
+// We are intentionally triggering errors for race-free throbber test
+fail-on-request-error: false
+fail-on-js-error: false
+
+// First, make sure the throbber goes away when done
+go-to: "file://" + |DOC_PATH| + "/test_docs/index.html?search="
+wait-for: ".search-input"
+wait-for-false: ".search-form.loading"
+write-into: (".search-input", "test")
+press-key: 'Enter'
+wait-for-false: ".search-form.loading"
+
+// Make sure the throbber shows up if we prevent the search from
+// ever finishing (this tactic is needed to make sure we don't get stuck
+// with any race conditions).
+go-to: "file://" + |DOC_PATH| + "/test_docs/index.html?search="
+block-network-request: "*/desc/*.js"
+reload:
+wait-for: ".search-input"
+wait-for-false: ".search-form.loading"
+write-into: (".search-input", "test")
+press-key: 'Enter'
+wait-for: ".search-form.loading"

--- a/tests/ui/asm/naked-invalid-attr.stderr
+++ b/tests/ui/asm/naked-invalid-attr.stderr
@@ -18,7 +18,7 @@ error: `#[naked]` attribute cannot be used on foreign functions
 LL |     #[unsafe(naked)]
    |     ^^^^^^^^^^^^^^^^
    |
-   = help: `#[naked]` can be applied to methods and functions
+   = help: `#[naked]` can be applied to functions and methods
 
 error: `#[naked]` attribute cannot be used on structs
   --> $DIR/naked-invalid-attr.rs:13:1
@@ -50,7 +50,7 @@ error: `#[naked]` attribute cannot be used on closures
 LL |     #[unsafe(naked)]
    |     ^^^^^^^^^^^^^^^^
    |
-   = help: `#[naked]` can be applied to methods and functions
+   = help: `#[naked]` can be applied to functions and methods
 
 error[E0736]: attribute incompatible with `#[unsafe(naked)]`
   --> $DIR/naked-invalid-attr.rs:56:3

--- a/tests/ui/attributes/attr-on-mac-call.stderr
+++ b/tests/ui/attributes/attr-on-mac-call.stderr
@@ -55,7 +55,7 @@ LL |     #[deprecated]
    |     ^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[deprecated]` can be applied to functions, data types, modules, unions, constants, statics, macro defs, type aliases, use statements, foreign statics, struct fields, traits, associated types, associated consts, enum variants, inherent impl blocks, and crates
+   = help: `#[deprecated]` can be applied to associated consts, associated types, constants, crates, data types, enum variants, foreign statics, functions, inherent impl blocks, macro defs, modules, statics, struct fields, traits, type aliases, unions, and use statements
 
 warning: `#[inline]` attribute cannot be used on macro calls
   --> $DIR/attr-on-mac-call.rs:24:5
@@ -136,7 +136,7 @@ LL |     #[deprecated]
    |     ^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[deprecated]` can be applied to functions, data types, modules, unions, constants, statics, macro defs, type aliases, use statements, foreign statics, struct fields, traits, associated types, associated consts, enum variants, inherent impl blocks, and crates
+   = help: `#[deprecated]` can be applied to associated consts, associated types, constants, crates, data types, enum variants, foreign statics, functions, inherent impl blocks, macro defs, modules, statics, struct fields, traits, type aliases, unions, and use statements
 
 warning: `#[automatically_derived]` attribute cannot be used on macro calls
   --> $DIR/attr-on-mac-call.rs:51:5
@@ -154,7 +154,7 @@ LL |     #[macro_use]
    |     ^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[macro_use]` can be applied to modules, extern crates, and crates
+   = help: `#[macro_use]` can be applied to crates, extern crates, and modules
 
 warning: `#[must_use]` attribute cannot be used on macro calls
   --> $DIR/attr-on-mac-call.rs:57:5
@@ -163,7 +163,7 @@ LL |     #[must_use]
    |     ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to functions, data types, unions, and traits
+   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
 
 warning: `#[no_implicit_prelude]` attribute cannot be used on macro calls
   --> $DIR/attr-on-mac-call.rs:60:5
@@ -172,7 +172,7 @@ LL |     #[no_implicit_prelude]
    |     ^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[no_implicit_prelude]` can be applied to modules and crates
+   = help: `#[no_implicit_prelude]` can be applied to crates and modules
 
 warning: `#[path]` attribute cannot be used on macro calls
   --> $DIR/attr-on-mac-call.rs:63:5

--- a/tests/ui/attributes/linkage.stderr
+++ b/tests/ui/attributes/linkage.stderr
@@ -4,7 +4,7 @@ error: `#[linkage]` attribute cannot be used on type aliases
 LL | #[linkage = "weak"]
    | ^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[linkage]` can be applied to functions, statics, and foreign statics
+   = help: `#[linkage]` can be applied to foreign statics, functions, and statics
 
 error: `#[linkage]` attribute cannot be used on modules
   --> $DIR/linkage.rs:9:1
@@ -12,7 +12,7 @@ error: `#[linkage]` attribute cannot be used on modules
 LL | #[linkage = "weak"]
    | ^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[linkage]` can be applied to functions, statics, and foreign statics
+   = help: `#[linkage]` can be applied to foreign statics, functions, and statics
 
 error: `#[linkage]` attribute cannot be used on structs
   --> $DIR/linkage.rs:12:1
@@ -20,7 +20,7 @@ error: `#[linkage]` attribute cannot be used on structs
 LL | #[linkage = "weak"]
    | ^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[linkage]` can be applied to functions, statics, and foreign statics
+   = help: `#[linkage]` can be applied to foreign statics, functions, and statics
 
 error: `#[linkage]` attribute cannot be used on inherent impl blocks
   --> $DIR/linkage.rs:15:1
@@ -28,7 +28,7 @@ error: `#[linkage]` attribute cannot be used on inherent impl blocks
 LL | #[linkage = "weak"]
    | ^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[linkage]` can be applied to functions, statics, and foreign statics
+   = help: `#[linkage]` can be applied to foreign statics, functions, and statics
 
 error: `#[linkage]` attribute cannot be used on expressions
   --> $DIR/linkage.rs:23:5
@@ -36,7 +36,7 @@ error: `#[linkage]` attribute cannot be used on expressions
 LL |     #[linkage = "weak"]
    |     ^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[linkage]` can be applied to functions, statics, and foreign statics
+   = help: `#[linkage]` can be applied to foreign statics, functions, and statics
 
 error: `#[linkage]` attribute cannot be used on closures
   --> $DIR/linkage.rs:39:13
@@ -44,7 +44,7 @@ error: `#[linkage]` attribute cannot be used on closures
 LL |     let _ = #[linkage = "weak"]
    |             ^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[linkage]` can be applied to methods, functions, statics, foreign statics, and foreign functions
+   = help: `#[linkage]` can be applied to foreign functions, foreign statics, functions, methods, and statics
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/attributes/malformed-static-align.stderr
+++ b/tests/ui/attributes/malformed-static-align.stderr
@@ -25,7 +25,7 @@ error: `#[rustc_align_static]` attribute cannot be used on structs
 LL | #[rustc_align_static(16)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_align_static]` can be applied to statics and foreign statics
+   = help: `#[rustc_align_static]` can be applied to foreign statics and statics
 
 error: `#[repr(align(...))]` is not supported on statics
   --> $DIR/malformed-static-align.rs:13:8

--- a/tests/ui/autodiff/autodiff_illegal.rs
+++ b/tests/ui/autodiff/autodiff_illegal.rs
@@ -110,15 +110,6 @@ fn f14(x: f32) -> Foo {
 
 type MyFloat = f32;
 
-// We would like to support type alias to f32/f64 in argument type in the future,
-// but that requires us to implement our checks at a later stage
-// like THIR which has type information available.
-#[autodiff_reverse(df15, Active, Active)]
-fn f15(x: MyFloat) -> f32 {
-    //~^^ ERROR failed to resolve: use of undeclared type `MyFloat` [E0433]
-    unimplemented!()
-}
-
 // We would like to support type alias to f32/f64 in return type in the future
 #[autodiff_reverse(df16, Active, Active)]
 fn f16(x: f32) -> MyFloat {
@@ -133,13 +124,6 @@ struct F64Trans {
 // We would like to support `#[repr(transparent)]` f32/f64 wrapper in return type in the future
 #[autodiff_reverse(df17, Active, Active)]
 fn f17(x: f64) -> F64Trans {
-    unimplemented!()
-}
-
-// We would like to support `#[repr(transparent)]` f32/f64 wrapper in argument type in the future
-#[autodiff_reverse(df18, Active, Active)]
-fn f18(x: F64Trans) -> f64 {
-    //~^^ ERROR failed to resolve: use of undeclared type `F64Trans` [E0433]
     unimplemented!()
 }
 
@@ -160,13 +144,6 @@ fn f20(x: f32) -> f32 {
 #[autodiff_reverse(df21, Active, Duplicated)]
 fn f21(x: f32) -> f32 {
     //~^^ ERROR invalid return activity Duplicated in Reverse Mode
-    unimplemented!()
-}
-
-struct DoesNotImplDefault;
-#[autodiff_forward(df22, Dual)]
-pub fn f22() -> DoesNotImplDefault {
-    //~^^ ERROR the function or associated item `default` exists for tuple `(DoesNotImplDefault, DoesNotImplDefault)`, but its trait bounds were not satisfied
     unimplemented!()
 }
 

--- a/tests/ui/autodiff/autodiff_illegal.stderr
+++ b/tests/ui/autodiff/autodiff_illegal.stderr
@@ -107,53 +107,24 @@ LL | #[autodiff_reverse(df13, Reverse)]
    |                          ^^^^^^^
 
 error: invalid return activity Active in Forward Mode
-  --> $DIR/autodiff_illegal.rs:147:1
+  --> $DIR/autodiff_illegal.rs:131:1
    |
 LL | #[autodiff_forward(df19, Dual, Active)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: invalid return activity Dual in Reverse Mode
-  --> $DIR/autodiff_illegal.rs:153:1
+  --> $DIR/autodiff_illegal.rs:137:1
    |
 LL | #[autodiff_reverse(df20, Active, Dual)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: invalid return activity Duplicated in Reverse Mode
-  --> $DIR/autodiff_illegal.rs:160:1
+  --> $DIR/autodiff_illegal.rs:144:1
    |
 LL | #[autodiff_reverse(df21, Active, Duplicated)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0433]: failed to resolve: use of undeclared type `MyFloat`
-  --> $DIR/autodiff_illegal.rs:116:1
-   |
-LL | #[autodiff_reverse(df15, Active, Active)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `MyFloat`
+error: aborting due to 18 previous errors
 
-error[E0433]: failed to resolve: use of undeclared type `F64Trans`
-  --> $DIR/autodiff_illegal.rs:140:1
-   |
-LL | #[autodiff_reverse(df18, Active, Active)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `F64Trans`
-
-error[E0599]: the function or associated item `default` exists for tuple `(DoesNotImplDefault, DoesNotImplDefault)`, but its trait bounds were not satisfied
-  --> $DIR/autodiff_illegal.rs:167:1
-   |
-LL | struct DoesNotImplDefault;
-   | ------------------------- doesn't satisfy `DoesNotImplDefault: Default`
-LL | #[autodiff_forward(df22, Dual)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function or associated item cannot be called on `(DoesNotImplDefault, DoesNotImplDefault)` due to unsatisfied trait bounds
-   |
-   = note: the following trait bounds were not satisfied:
-           `DoesNotImplDefault: Default`
-           which is required by `(DoesNotImplDefault, DoesNotImplDefault): Default`
-help: consider annotating `DoesNotImplDefault` with `#[derive(Default)]`
-   |
-LL + #[derive(Default)]
-LL | struct DoesNotImplDefault;
-   |
-
-error: aborting due to 21 previous errors
-
-Some errors have detailed explanations: E0428, E0433, E0599, E0658.
+Some errors have detailed explanations: E0428, E0658.
 For more information about an error, try `rustc --explain E0428`.

--- a/tests/ui/autodiff/incremental.rs
+++ b/tests/ui/autodiff/incremental.rs
@@ -1,0 +1,41 @@
+//@ revisions: DEBUG RELEASE
+//@[RELEASE] compile-flags: -Zautodiff=Enable,NoTT -C opt-level=3 -Clto=fat
+//@[DEBUG]   compile-flags: -Zautodiff=Enable,NoTT -C opt-level=0 -Clto=fat -C debuginfo=2
+//@ needs-enzyme
+//@ incremental
+//@ no-prefer-dynamic
+//@ build-pass
+#![crate_type = "bin"]
+#![feature(autodiff)]
+
+// We used to use llvm's metadata to instruct enzyme how to differentiate a function.
+// In debug mode we would use incremental compilation which caused the metadata to be
+// dropped. We now use globals instead and add this test to verify that incremental
+// keeps working. Also testing debug mode while at it.
+
+use std::autodiff::autodiff_reverse;
+
+#[autodiff_reverse(bar, Duplicated, Duplicated)]
+pub fn foo(r: &[f64; 10], res: &mut f64) {
+    let mut output = [0.0; 10];
+    output[0] = r[0];
+    output[1] = r[1] * r[2];
+    output[2] = r[4] * r[5];
+    output[3] = r[2] * r[6];
+    output[4] = r[1] * r[7];
+    output[5] = r[2] * r[8];
+    output[6] = r[1] * r[9];
+    output[7] = r[5] * r[6];
+    output[8] = r[5] * r[7];
+    output[9] = r[4] * r[8];
+    *res = output.iter().sum();
+}
+fn main() {
+    let inputs = Box::new([3.1; 10]);
+    let mut d_inputs = Box::new([0.0; 10]);
+    let mut res = Box::new(0.0);
+    let mut d_res = Box::new(1.0);
+
+    bar(&inputs, &mut d_inputs, &mut res, &mut d_res);
+    dbg!(&d_inputs);
+}

--- a/tests/ui/consts/extra-const-ub/detect-extra-ub.rs
+++ b/tests/ui/consts/extra-const-ub/detect-extra-ub.rs
@@ -52,6 +52,16 @@ const UNALIGNED_PTR: () = unsafe {
     //[with_flag]~^ ERROR: invalid value
 };
 
+// A function pointer offset to be maybe-null.
+const MAYBE_NULL_FN_PTR: () = unsafe {
+    let _x: fn() = transmute({
+    //[with_flag]~^ ERROR: invalid value
+        fn fun() {}
+        let ptr = fun as fn();
+        (ptr as *const u8).wrapping_add(10)
+    });
+};
+
 const UNINHABITED_VARIANT: () = unsafe {
     let data = [1u8];
     // Not using transmute, we want to hit the ImmTy code path.

--- a/tests/ui/consts/extra-const-ub/detect-extra-ub.with_flag.stderr
+++ b/tests/ui/consts/extra-const-ub/detect-extra-ub.with_flag.stderr
@@ -37,14 +37,26 @@ error[E0080]: constructing invalid value: encountered an unaligned reference (re
 LL |     let _x: &u32 = transmute(&[0u8; 4]);
    |                    ^^^^^^^^^^^^^^^^^^^^ evaluation of `UNALIGNED_PTR` failed here
 
+error[E0080]: constructing invalid value: encountered a maybe-null function pointer
+  --> $DIR/detect-extra-ub.rs:57:20
+   |
+LL |       let _x: fn() = transmute({
+   |  ____________________^
+LL | |
+LL | |         fn fun() {}
+LL | |         let ptr = fun as fn();
+LL | |         (ptr as *const u8).wrapping_add(10)
+LL | |     });
+   | |______^ evaluation of `MAYBE_NULL_FN_PTR` failed here
+
 error[E0080]: constructing invalid value at .<enum-tag>: encountered an uninhabited enum variant
-  --> $DIR/detect-extra-ub.rs:58:13
+  --> $DIR/detect-extra-ub.rs:68:13
    |
 LL |     let v = *addr_of!(data).cast::<UninhDiscriminant>();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `UNINHABITED_VARIANT` failed here
 
 error[E0080]: constructing invalid value at [0]: encountered a partial pointer or a mix of pointers
-  --> $DIR/detect-extra-ub.rs:77:16
+  --> $DIR/detect-extra-ub.rs:87:16
    |
 LL |     let _val = *(&mem as *const Align as *const [*const u8; 2]);
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `PARTIAL_POINTER` failed here
@@ -53,11 +65,11 @@ LL |     let _val = *(&mem as *const Align as *const [*const u8; 2]);
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
 error[E0080]: constructing invalid value: encountered invalid reference metadata: slice is bigger than largest supported object
-  --> $DIR/detect-extra-ub.rs:91:16
+  --> $DIR/detect-extra-ub.rs:101:16
    |
 LL |     let _val = &*slice;
    |                ^^^^^^^ evaluation of `OVERSIZED_REF` failed here
 
-error: aborting due to 8 previous errors
+error: aborting due to 9 previous errors
 
 For more information about this error, try `rustc --explain E0080`.

--- a/tests/ui/coverage-attr/allowed-positions.stderr
+++ b/tests/ui/coverage-attr/allowed-positions.stderr
@@ -14,7 +14,7 @@ error: `#[coverage]` attribute cannot be used on type aliases
 LL | #[coverage(off)]
    | ^^^^^^^^^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to functions, impl blocks, modules, and crates
+   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
 
 error: `#[coverage]` attribute cannot be used on traits
   --> $DIR/allowed-positions.rs:17:1
@@ -22,7 +22,7 @@ error: `#[coverage]` attribute cannot be used on traits
 LL | #[coverage(off)]
    | ^^^^^^^^^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to functions, impl blocks, modules, and crates
+   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
 
 error: `#[coverage]` attribute cannot be used on associated consts
   --> $DIR/allowed-positions.rs:19:5
@@ -30,7 +30,7 @@ error: `#[coverage]` attribute cannot be used on associated consts
 LL |     #[coverage(off)]
    |     ^^^^^^^^^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to functions, impl blocks, modules, and crates
+   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
 
 error: `#[coverage]` attribute cannot be used on associated types
   --> $DIR/allowed-positions.rs:22:5
@@ -38,7 +38,7 @@ error: `#[coverage]` attribute cannot be used on associated types
 LL |     #[coverage(off)]
    |     ^^^^^^^^^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to functions, impl blocks, modules, and crates
+   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
 
 error: `#[coverage]` attribute cannot be used on required trait methods
   --> $DIR/allowed-positions.rs:25:5
@@ -46,7 +46,7 @@ error: `#[coverage]` attribute cannot be used on required trait methods
 LL |     #[coverage(off)]
    |     ^^^^^^^^^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to impl blocks, functions, closures, provided trait methods, trait methods in impl blocks, inherent methods, modules, and crates
+   = help: `#[coverage]` can be applied to closures, crates, functions, impl blocks, inherent methods, modules, provided trait methods, and trait methods in impl blocks
 
 error: `#[coverage]` attribute cannot be used on required trait methods
   --> $DIR/allowed-positions.rs:31:5
@@ -54,7 +54,7 @@ error: `#[coverage]` attribute cannot be used on required trait methods
 LL |     #[coverage(off)]
    |     ^^^^^^^^^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to impl blocks, functions, closures, provided trait methods, trait methods in impl blocks, inherent methods, modules, and crates
+   = help: `#[coverage]` can be applied to closures, crates, functions, impl blocks, inherent methods, modules, provided trait methods, and trait methods in impl blocks
 
 error: `#[coverage]` attribute cannot be used on associated types
   --> $DIR/allowed-positions.rs:39:5
@@ -62,7 +62,7 @@ error: `#[coverage]` attribute cannot be used on associated types
 LL |     #[coverage(off)]
    |     ^^^^^^^^^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to functions, impl blocks, modules, and crates
+   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
 
 error: `#[coverage]` attribute cannot be used on associated types
   --> $DIR/allowed-positions.rs:56:5
@@ -70,7 +70,7 @@ error: `#[coverage]` attribute cannot be used on associated types
 LL |     #[coverage(off)]
    |     ^^^^^^^^^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to functions, impl blocks, modules, and crates
+   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
 
 error: `#[coverage]` attribute cannot be used on structs
   --> $DIR/allowed-positions.rs:61:1
@@ -78,7 +78,7 @@ error: `#[coverage]` attribute cannot be used on structs
 LL | #[coverage(off)]
    | ^^^^^^^^^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to functions, impl blocks, modules, and crates
+   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
 
 error: `#[coverage]` attribute cannot be used on struct fields
   --> $DIR/allowed-positions.rs:63:5
@@ -86,7 +86,7 @@ error: `#[coverage]` attribute cannot be used on struct fields
 LL |     #[coverage(off)]
    |     ^^^^^^^^^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to functions, impl blocks, modules, and crates
+   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
 
 error: `#[coverage]` attribute cannot be used on foreign statics
   --> $DIR/allowed-positions.rs:76:5
@@ -94,7 +94,7 @@ error: `#[coverage]` attribute cannot be used on foreign statics
 LL |     #[coverage(off)]
    |     ^^^^^^^^^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to functions, impl blocks, modules, and crates
+   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
 
 error: `#[coverage]` attribute cannot be used on foreign types
   --> $DIR/allowed-positions.rs:79:5
@@ -102,7 +102,7 @@ error: `#[coverage]` attribute cannot be used on foreign types
 LL |     #[coverage(off)]
    |     ^^^^^^^^^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to functions, impl blocks, modules, and crates
+   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
 
 error: `#[coverage]` attribute cannot be used on foreign functions
   --> $DIR/allowed-positions.rs:82:5
@@ -110,7 +110,7 @@ error: `#[coverage]` attribute cannot be used on foreign functions
 LL |     #[coverage(off)]
    |     ^^^^^^^^^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to methods, impl blocks, functions, closures, modules, and crates
+   = help: `#[coverage]` can be applied to closures, crates, functions, impl blocks, methods, and modules
 
 error: `#[coverage]` attribute cannot be used on statements
   --> $DIR/allowed-positions.rs:88:5
@@ -118,7 +118,7 @@ error: `#[coverage]` attribute cannot be used on statements
 LL |     #[coverage(off)]
    |     ^^^^^^^^^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to functions, impl blocks, modules, and crates
+   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
 
 error: `#[coverage]` attribute cannot be used on statements
   --> $DIR/allowed-positions.rs:94:5
@@ -126,7 +126,7 @@ error: `#[coverage]` attribute cannot be used on statements
 LL |     #[coverage(off)]
    |     ^^^^^^^^^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to functions, impl blocks, modules, and crates
+   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
 
 error: `#[coverage]` attribute cannot be used on match arms
   --> $DIR/allowed-positions.rs:110:9
@@ -134,7 +134,7 @@ error: `#[coverage]` attribute cannot be used on match arms
 LL |         #[coverage(off)]
    |         ^^^^^^^^^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to functions, impl blocks, modules, and crates
+   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
 
 error: `#[coverage]` attribute cannot be used on expressions
   --> $DIR/allowed-positions.rs:114:5
@@ -142,7 +142,7 @@ error: `#[coverage]` attribute cannot be used on expressions
 LL |     #[coverage(off)]
    |     ^^^^^^^^^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to functions, impl blocks, modules, and crates
+   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
 
 error: aborting due to 18 previous errors
 

--- a/tests/ui/coverage-attr/name-value.stderr
+++ b/tests/ui/coverage-attr/name-value.stderr
@@ -49,7 +49,7 @@ error: `#[coverage]` attribute cannot be used on structs
 LL | #[coverage = "off"]
    | ^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to functions, impl blocks, modules, and crates
+   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
 
 error[E0539]: malformed `coverage` attribute input
   --> $DIR/name-value.rs:26:1
@@ -87,7 +87,7 @@ error: `#[coverage]` attribute cannot be used on associated consts
 LL |     #[coverage = "off"]
    |     ^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to functions, impl blocks, modules, and crates
+   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
 
 error[E0539]: malformed `coverage` attribute input
   --> $DIR/name-value.rs:35:1
@@ -110,7 +110,7 @@ error: `#[coverage]` attribute cannot be used on traits
 LL | #[coverage = "off"]
    | ^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to functions, impl blocks, modules, and crates
+   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
 
 error[E0539]: malformed `coverage` attribute input
   --> $DIR/name-value.rs:39:5
@@ -133,7 +133,7 @@ error: `#[coverage]` attribute cannot be used on associated consts
 LL |     #[coverage = "off"]
    |     ^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to functions, impl blocks, modules, and crates
+   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
 
 error[E0539]: malformed `coverage` attribute input
   --> $DIR/name-value.rs:44:5
@@ -156,7 +156,7 @@ error: `#[coverage]` attribute cannot be used on associated types
 LL |     #[coverage = "off"]
    |     ^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to functions, impl blocks, modules, and crates
+   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
 
 error[E0539]: malformed `coverage` attribute input
   --> $DIR/name-value.rs:50:1
@@ -194,7 +194,7 @@ error: `#[coverage]` attribute cannot be used on associated consts
 LL |     #[coverage = "off"]
    |     ^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to functions, impl blocks, modules, and crates
+   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
 
 error[E0539]: malformed `coverage` attribute input
   --> $DIR/name-value.rs:58:5
@@ -217,7 +217,7 @@ error: `#[coverage]` attribute cannot be used on associated types
 LL |     #[coverage = "off"]
    |     ^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to functions, impl blocks, modules, and crates
+   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
 
 error[E0539]: malformed `coverage` attribute input
   --> $DIR/name-value.rs:64:1

--- a/tests/ui/coverage-attr/word-only.stderr
+++ b/tests/ui/coverage-attr/word-only.stderr
@@ -43,7 +43,7 @@ error: `#[coverage]` attribute cannot be used on structs
 LL | #[coverage]
    | ^^^^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to functions, impl blocks, modules, and crates
+   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
 
 error[E0539]: malformed `coverage` attribute input
   --> $DIR/word-only.rs:26:1
@@ -77,7 +77,7 @@ error: `#[coverage]` attribute cannot be used on associated consts
 LL |     #[coverage]
    |     ^^^^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to functions, impl blocks, modules, and crates
+   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
 
 error[E0539]: malformed `coverage` attribute input
   --> $DIR/word-only.rs:35:1
@@ -98,7 +98,7 @@ error: `#[coverage]` attribute cannot be used on traits
 LL | #[coverage]
    | ^^^^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to functions, impl blocks, modules, and crates
+   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
 
 error[E0539]: malformed `coverage` attribute input
   --> $DIR/word-only.rs:39:5
@@ -119,7 +119,7 @@ error: `#[coverage]` attribute cannot be used on associated consts
 LL |     #[coverage]
    |     ^^^^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to functions, impl blocks, modules, and crates
+   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
 
 error[E0539]: malformed `coverage` attribute input
   --> $DIR/word-only.rs:44:5
@@ -140,7 +140,7 @@ error: `#[coverage]` attribute cannot be used on associated types
 LL |     #[coverage]
    |     ^^^^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to functions, impl blocks, modules, and crates
+   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
 
 error[E0539]: malformed `coverage` attribute input
   --> $DIR/word-only.rs:50:1
@@ -174,7 +174,7 @@ error: `#[coverage]` attribute cannot be used on associated consts
 LL |     #[coverage]
    |     ^^^^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to functions, impl blocks, modules, and crates
+   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
 
 error[E0539]: malformed `coverage` attribute input
   --> $DIR/word-only.rs:58:5
@@ -195,7 +195,7 @@ error: `#[coverage]` attribute cannot be used on associated types
 LL |     #[coverage]
    |     ^^^^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to functions, impl blocks, modules, and crates
+   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
 
 error[E0539]: malformed `coverage` attribute input
   --> $DIR/word-only.rs:64:1

--- a/tests/ui/deprecation/deprecation-sanity.stderr
+++ b/tests/ui/deprecation/deprecation-sanity.stderr
@@ -177,7 +177,7 @@ LL | #[deprecated = "hello"]
    | ^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[deprecated]` can be applied to functions, data types, modules, unions, constants, statics, macro defs, type aliases, use statements, foreign statics, struct fields, traits, associated types, associated consts, enum variants, inherent impl blocks, and crates
+   = help: `#[deprecated]` can be applied to associated consts, associated types, constants, crates, data types, enum variants, foreign statics, functions, inherent impl blocks, macro defs, modules, statics, struct fields, traits, type aliases, unions, and use statements
    = note: `#[deny(useless_deprecated)]` on by default
 
 error: aborting due to 10 previous errors

--- a/tests/ui/extern/extern-no-mangle.stderr
+++ b/tests/ui/extern/extern-no-mangle.stderr
@@ -19,7 +19,7 @@ LL |     #[no_mangle]
    |     ^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[no_mangle]` can be applied to methods, functions, and statics
+   = help: `#[no_mangle]` can be applied to functions, methods, and statics
 
 warning: `#[no_mangle]` attribute cannot be used on statements
   --> $DIR/extern-no-mangle.rs:24:5

--- a/tests/ui/feature-gates/feature-gate-allow-internal-unstable-struct.stderr
+++ b/tests/ui/feature-gates/feature-gate-allow-internal-unstable-struct.stderr
@@ -13,7 +13,7 @@ error: `#[allow_internal_unstable]` attribute cannot be used on structs
 LL | #[allow_internal_unstable(something)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[allow_internal_unstable]` can be applied to macro defs and functions
+   = help: `#[allow_internal_unstable]` can be applied to functions and macro defs
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs-error.stderr
+++ b/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs-error.stderr
@@ -134,7 +134,7 @@ error: `#[export_name]` attribute cannot be used on required trait methods
 LL |         #[export_name = "2200"] fn foo();
    |         ^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[export_name]` can be applied to statics, functions, inherent methods, provided trait methods, and trait methods in impl blocks
+   = help: `#[export_name]` can be applied to functions, inherent methods, provided trait methods, statics, and trait methods in impl blocks
 
 error: attribute should be applied to an `extern crate` item
   --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:55:1

--- a/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs.stderr
+++ b/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs.stderr
@@ -644,7 +644,7 @@ LL |     #[macro_use] fn f() { }
    |     ^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[macro_use]` can be applied to modules, extern crates, and crates
+   = help: `#[macro_use]` can be applied to crates, extern crates, and modules
 
 warning: `#[macro_use]` attribute cannot be used on structs
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:197:5
@@ -653,7 +653,7 @@ LL |     #[macro_use] struct S;
    |     ^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[macro_use]` can be applied to modules, extern crates, and crates
+   = help: `#[macro_use]` can be applied to crates, extern crates, and modules
 
 warning: `#[macro_use]` attribute cannot be used on type aliases
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:203:5
@@ -662,7 +662,7 @@ LL |     #[macro_use] type T = S;
    |     ^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[macro_use]` can be applied to modules, extern crates, and crates
+   = help: `#[macro_use]` can be applied to crates, extern crates, and modules
 
 warning: `#[macro_use]` attribute cannot be used on inherent impl blocks
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:209:5
@@ -671,7 +671,7 @@ LL |     #[macro_use] impl S { }
    |     ^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[macro_use]` can be applied to modules, extern crates, and crates
+   = help: `#[macro_use]` can be applied to crates, extern crates, and modules
 
 warning: `#[macro_export]` attribute cannot be used on modules
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:216:1
@@ -878,7 +878,7 @@ LL |         #[no_mangle] fn foo();
    |         ^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[no_mangle]` can be applied to functions, statics, inherent methods, and trait methods in impl blocks
+   = help: `#[no_mangle]` can be applied to functions, inherent methods, statics, and trait methods in impl blocks
 
 warning: `#[no_mangle]` attribute cannot be used on provided trait methods
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:398:9
@@ -887,7 +887,7 @@ LL |         #[no_mangle] fn bar() {}
    |         ^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[no_mangle]` can be applied to functions, statics, inherent methods, and trait methods in impl blocks
+   = help: `#[no_mangle]` can be applied to functions, inherent methods, statics, and trait methods in impl blocks
 
 warning: `#[should_panic]` attribute cannot be used on modules
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:406:1
@@ -986,7 +986,7 @@ LL |     #[no_implicit_prelude] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[no_implicit_prelude]` can be applied to modules and crates
+   = help: `#[no_implicit_prelude]` can be applied to crates and modules
 
 warning: `#[no_implicit_prelude]` attribute cannot be used on structs
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:482:5
@@ -995,7 +995,7 @@ LL |     #[no_implicit_prelude] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[no_implicit_prelude]` can be applied to modules and crates
+   = help: `#[no_implicit_prelude]` can be applied to crates and modules
 
 warning: `#[no_implicit_prelude]` attribute cannot be used on type aliases
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:488:5
@@ -1004,7 +1004,7 @@ LL |     #[no_implicit_prelude] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[no_implicit_prelude]` can be applied to modules and crates
+   = help: `#[no_implicit_prelude]` can be applied to crates and modules
 
 warning: `#[no_implicit_prelude]` attribute cannot be used on inherent impl blocks
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:494:5
@@ -1013,7 +1013,7 @@ LL |     #[no_implicit_prelude] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[no_implicit_prelude]` can be applied to modules and crates
+   = help: `#[no_implicit_prelude]` can be applied to crates and modules
 
 warning: `#[macro_escape]` attribute cannot be used on functions
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:533:5
@@ -1022,7 +1022,7 @@ LL |     #[macro_escape] fn f() { }
    |     ^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[macro_escape]` can be applied to modules, extern crates, and crates
+   = help: `#[macro_escape]` can be applied to crates, extern crates, and modules
 
 warning: `#[macro_escape]` attribute cannot be used on structs
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:539:5
@@ -1031,7 +1031,7 @@ LL |     #[macro_escape] struct S;
    |     ^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[macro_escape]` can be applied to modules, extern crates, and crates
+   = help: `#[macro_escape]` can be applied to crates, extern crates, and modules
 
 warning: `#[macro_escape]` attribute cannot be used on type aliases
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:545:5
@@ -1040,7 +1040,7 @@ LL |     #[macro_escape] type T = S;
    |     ^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[macro_escape]` can be applied to modules, extern crates, and crates
+   = help: `#[macro_escape]` can be applied to crates, extern crates, and modules
 
 warning: `#[macro_escape]` attribute cannot be used on inherent impl blocks
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:551:5
@@ -1049,7 +1049,7 @@ LL |     #[macro_escape] impl S { }
    |     ^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[macro_escape]` can be applied to modules, extern crates, and crates
+   = help: `#[macro_escape]` can be applied to crates, extern crates, and modules
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![no_std]`
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:558:1
@@ -1290,7 +1290,7 @@ LL | #[must_use]
    | ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to functions, data types, unions, and traits
+   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
 
 warning: `#[must_use]` attribute cannot be used on modules
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:795:17
@@ -1299,7 +1299,7 @@ LL |     mod inner { #![must_use] }
    |                 ^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to functions, data types, unions, and traits
+   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
 
 warning: `#[must_use]` attribute cannot be used on type aliases
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:804:5
@@ -1308,7 +1308,7 @@ LL |     #[must_use] type T = S;
    |     ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to functions, data types, unions, and traits
+   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
 
 warning: `#[must_use]` attribute cannot be used on inherent impl blocks
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:809:5
@@ -1317,7 +1317,7 @@ LL |     #[must_use] impl S { }
    |     ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to functions, data types, unions, and traits
+   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![crate_name]`
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:841:1
@@ -1590,7 +1590,7 @@ LL | #![must_use]
    | ^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to functions, data types, unions, and traits
+   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
 
 warning: 174 warnings emitted
 

--- a/tests/ui/invalid/invalid-debugger-visualizer-target.stderr
+++ b/tests/ui/invalid/invalid-debugger-visualizer-target.stderr
@@ -4,7 +4,7 @@ error: `#[debugger_visualizer]` attribute cannot be used on functions
 LL | #[debugger_visualizer(natvis_file = "./foo.natvis.xml")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[debugger_visualizer]` can be applied to modules and crates
+   = help: `#[debugger_visualizer]` can be applied to crates and modules
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/issues/issue-32782.stderr
+++ b/tests/ui/issues/issue-32782.stderr
@@ -20,7 +20,7 @@ LL |         #[allow_internal_unstable()]
 LL | foo!();
    | ------ in this macro invocation
    |
-   = help: `#[allow_internal_unstable]` can be applied to macro defs and functions
+   = help: `#[allow_internal_unstable]` can be applied to functions and macro defs
    = note: this error originates in the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors

--- a/tests/ui/lint/unused/unused-attr-macro-rules.stderr
+++ b/tests/ui/lint/unused/unused-attr-macro-rules.stderr
@@ -5,7 +5,7 @@ LL | #[macro_use]
    | ^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[macro_use]` can be applied to modules, extern crates, and crates
+   = help: `#[macro_use]` can be applied to crates, extern crates, and modules
 note: the lint level is defined here
   --> $DIR/unused-attr-macro-rules.rs:1:9
    |

--- a/tests/ui/lint/unused/unused_attributes-must_use.stderr
+++ b/tests/ui/lint/unused/unused_attributes-must_use.stderr
@@ -5,7 +5,7 @@ LL | #[must_use]
    | ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to functions, data types, unions, and traits
+   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
 note: the lint level is defined here
   --> $DIR/unused_attributes-must_use.rs:4:9
    |
@@ -19,7 +19,7 @@ LL | #[must_use]
    | ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to functions, data types, unions, and traits
+   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
 
 error: `#[must_use]` attribute cannot be used on modules
   --> $DIR/unused_attributes-must_use.rs:11:1
@@ -28,7 +28,7 @@ LL | #[must_use]
    | ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to functions, data types, unions, and traits
+   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
 
 error: `#[must_use]` attribute cannot be used on use statements
   --> $DIR/unused_attributes-must_use.rs:15:1
@@ -37,7 +37,7 @@ LL | #[must_use]
    | ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to functions, data types, unions, and traits
+   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
 
 error: `#[must_use]` attribute cannot be used on constants
   --> $DIR/unused_attributes-must_use.rs:19:1
@@ -46,7 +46,7 @@ LL | #[must_use]
    | ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to functions, data types, unions, and traits
+   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
 
 error: `#[must_use]` attribute cannot be used on statics
   --> $DIR/unused_attributes-must_use.rs:22:1
@@ -55,7 +55,7 @@ LL | #[must_use]
    | ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to functions, data types, unions, and traits
+   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
 
 error: `#[must_use]` attribute cannot be used on inherent impl blocks
   --> $DIR/unused_attributes-must_use.rs:40:1
@@ -64,7 +64,7 @@ LL | #[must_use]
    | ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to functions, data types, unions, and traits
+   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
 
 error: `#[must_use]` attribute cannot be used on foreign modules
   --> $DIR/unused_attributes-must_use.rs:55:1
@@ -73,7 +73,7 @@ LL | #[must_use]
    | ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to functions, data types, unions, and traits
+   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
 
 error: `#[must_use]` attribute cannot be used on foreign statics
   --> $DIR/unused_attributes-must_use.rs:59:5
@@ -82,7 +82,7 @@ LL |     #[must_use]
    |     ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to functions, data types, unions, and traits
+   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
 
 error: `#[must_use]` attribute cannot be used on type aliases
   --> $DIR/unused_attributes-must_use.rs:73:1
@@ -91,7 +91,7 @@ LL | #[must_use]
    | ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to functions, data types, unions, and traits
+   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
 
 error: `#[must_use]` attribute cannot be used on function params
   --> $DIR/unused_attributes-must_use.rs:77:8
@@ -100,7 +100,7 @@ LL | fn qux<#[must_use] T>(_: T) {}
    |        ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to functions, data types, unions, and traits
+   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
 
 error: `#[must_use]` attribute cannot be used on associated consts
   --> $DIR/unused_attributes-must_use.rs:82:5
@@ -109,7 +109,7 @@ LL |     #[must_use]
    |     ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to functions, data types, unions, and traits
+   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
 
 error: `#[must_use]` attribute cannot be used on associated types
   --> $DIR/unused_attributes-must_use.rs:85:5
@@ -118,7 +118,7 @@ LL |     #[must_use]
    |     ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to functions, data types, unions, and traits
+   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
 
 error: `#[must_use]` attribute cannot be used on trait impl blocks
   --> $DIR/unused_attributes-must_use.rs:95:1
@@ -127,7 +127,7 @@ LL | #[must_use]
    | ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to functions, data types, unions, and traits
+   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
 
 error: `#[must_use]` attribute cannot be used on trait methods in impl blocks
   --> $DIR/unused_attributes-must_use.rs:100:5
@@ -136,7 +136,7 @@ LL |     #[must_use]
    |     ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to data types, functions, unions, required trait methods, provided trait methods, inherent methods, foreign functions, and traits
+   = help: `#[must_use]` can be applied to data types, foreign functions, functions, inherent methods, provided trait methods, required trait methods, traits, and unions
 
 error: `#[must_use]` attribute cannot be used on trait aliases
   --> $DIR/unused_attributes-must_use.rs:107:1
@@ -145,7 +145,7 @@ LL | #[must_use]
    | ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to functions, data types, unions, and traits
+   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
 
 error: `#[must_use]` attribute cannot be used on macro defs
   --> $DIR/unused_attributes-must_use.rs:111:1
@@ -154,7 +154,7 @@ LL | #[must_use]
    | ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to functions, data types, unions, and traits
+   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
 
 error: `#[must_use]` attribute cannot be used on statements
   --> $DIR/unused_attributes-must_use.rs:120:5
@@ -163,7 +163,7 @@ LL |     #[must_use]
    |     ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to functions, data types, unions, and traits
+   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
 
 error: `#[must_use]` attribute cannot be used on closures
   --> $DIR/unused_attributes-must_use.rs:125:13
@@ -172,7 +172,7 @@ LL |     let x = #[must_use]
    |             ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to methods, data types, functions, unions, foreign functions, and traits
+   = help: `#[must_use]` can be applied to data types, foreign functions, functions, methods, traits, and unions
 
 error: `#[must_use]` attribute cannot be used on match arms
   --> $DIR/unused_attributes-must_use.rs:148:9
@@ -181,7 +181,7 @@ LL |         #[must_use]
    |         ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to functions, data types, unions, and traits
+   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
 
 error: `#[must_use]` attribute cannot be used on struct fields
   --> $DIR/unused_attributes-must_use.rs:157:28
@@ -190,7 +190,7 @@ LL |     let s = PatternField { #[must_use]  foo: 123 };
    |                            ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to functions, data types, unions, and traits
+   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
 
 error: `#[must_use]` attribute cannot be used on pattern fields
   --> $DIR/unused_attributes-must_use.rs:159:24
@@ -199,7 +199,7 @@ LL |     let PatternField { #[must_use] foo } = s;
    |                        ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to functions, data types, unions, and traits
+   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
 
 error: unused `X` that must be used
   --> $DIR/unused_attributes-must_use.rs:130:5

--- a/tests/ui/lint/warn-unused-inline-on-fn-prototypes.stderr
+++ b/tests/ui/lint/warn-unused-inline-on-fn-prototypes.stderr
@@ -5,7 +5,7 @@ LL |     #[inline]
    |     ^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[inline]` can be applied to functions, inherent methods, provided trait methods, trait methods in impl blocks, and closures
+   = help: `#[inline]` can be applied to closures, functions, inherent methods, provided trait methods, and trait methods in impl blocks
 note: the lint level is defined here
   --> $DIR/warn-unused-inline-on-fn-prototypes.rs:1:9
    |
@@ -19,7 +19,7 @@ LL |     #[inline]
    |     ^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[inline]` can be applied to methods, functions, and closures
+   = help: `#[inline]` can be applied to closures, functions, and methods
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/macros/issue-68060.stderr
+++ b/tests/ui/macros/issue-68060.stderr
@@ -4,7 +4,7 @@ error: `#[target_feature]` attribute cannot be used on closures
 LL |             #[target_feature(enable = "")]
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[target_feature]` can be applied to methods and functions
+   = help: `#[target_feature]` can be applied to functions and methods
 
 error[E0658]: `#[track_caller]` on closures is currently unstable
   --> $DIR/issue-68060.rs:6:13

--- a/tests/ui/target-feature/invalid-attribute.stderr
+++ b/tests/ui/target-feature/invalid-attribute.stderr
@@ -143,7 +143,7 @@ error: `#[target_feature]` attribute cannot be used on closures
 LL |     #[target_feature(enable = "sse2")]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[target_feature]` can be applied to methods and functions
+   = help: `#[target_feature]` can be applied to functions and methods
 
 error[E0658]: cannot use `#[inline(always)]` with `#[target_feature]`
   --> $DIR/invalid-attribute.rs:62:1

--- a/tests/ui/where-clauses/unsupported_attribute.stderr
+++ b/tests/ui/where-clauses/unsupported_attribute.stderr
@@ -48,7 +48,7 @@ error: `#[macro_use]` attribute cannot be used on where predicates
 LL |     #[macro_use] T: Trait,
    |     ^^^^^^^^^^^^
    |
-   = help: `#[macro_use]` can be applied to modules, extern crates, and crates
+   = help: `#[macro_use]` can be applied to crates, extern crates, and modules
 
 error: `#[macro_use]` attribute cannot be used on where predicates
   --> $DIR/unsupported_attribute.rs:21:5
@@ -56,7 +56,7 @@ error: `#[macro_use]` attribute cannot be used on where predicates
 LL |     #[macro_use] 'a: 'static,
    |     ^^^^^^^^^^^^
    |
-   = help: `#[macro_use]` can be applied to modules, extern crates, and crates
+   = help: `#[macro_use]` can be applied to crates, extern crates, and modules
 
 error: `#[deprecated]` attribute cannot be used on where predicates
   --> $DIR/unsupported_attribute.rs:24:5
@@ -64,7 +64,7 @@ error: `#[deprecated]` attribute cannot be used on where predicates
 LL |     #[deprecated] T: Trait,
    |     ^^^^^^^^^^^^^
    |
-   = help: `#[deprecated]` can be applied to functions, data types, modules, unions, constants, statics, macro defs, type aliases, use statements, foreign statics, struct fields, traits, associated types, associated consts, enum variants, inherent impl blocks, and crates
+   = help: `#[deprecated]` can be applied to associated consts, associated types, constants, crates, data types, enum variants, foreign statics, functions, inherent impl blocks, macro defs, modules, statics, struct fields, traits, type aliases, unions, and use statements
 
 error: `#[deprecated]` attribute cannot be used on where predicates
   --> $DIR/unsupported_attribute.rs:25:5
@@ -72,7 +72,7 @@ error: `#[deprecated]` attribute cannot be used on where predicates
 LL |     #[deprecated] 'a: 'static,
    |     ^^^^^^^^^^^^^
    |
-   = help: `#[deprecated]` can be applied to functions, data types, modules, unions, constants, statics, macro defs, type aliases, use statements, foreign statics, struct fields, traits, associated types, associated consts, enum variants, inherent impl blocks, and crates
+   = help: `#[deprecated]` can be applied to associated consts, associated types, constants, crates, data types, enum variants, foreign statics, functions, inherent impl blocks, macro defs, modules, statics, struct fields, traits, type aliases, unions, and use statements
 
 error: `#[automatically_derived]` attribute cannot be used on where predicates
   --> $DIR/unsupported_attribute.rs:26:5


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#146385 (rustdoc-search: redesign throbber to be less distracting)
 - rust-lang/rust#147390 (Use globals instead of metadata for std::autodiff)
 - rust-lang/rust#147445 (sort attribute targets for more consistent error messages)
 - rust-lang/rust#147448 (collect-license-metadata: update submodules before running)
 - rust-lang/rust#147451 (fix panic with extra-const-ub-checks)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=146385,147390,147445,147448,147451)
<!-- homu-ignore:end -->