### PR TITLE
Fix double warnings on `#[no_mangle]`

### DIFF
--- a/compiler/rustc_attr_parsing/src/attributes/codegen_attrs.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/codegen_attrs.rs
@@ -6,6 +6,7 @@ use crate::session_diagnostics::{
     NakedFunctionIncompatibleAttribute, NullOnExport, NullOnObjcClass, NullOnObjcSelector,
     ObjcClassExpectedStringLiteral, ObjcSelectorExpectedStringLiteral,
 };
+use crate::target_checking::Policy::AllowSilent;
 
 pub(crate) struct OptimizeParser;
 
@@ -362,6 +363,7 @@ impl<S: Stage> NoArgsAttributeParser<S> for NoMangleParser {
         Allow(Target::Static),
         Allow(Target::Method(MethodKind::Inherent)),
         Allow(Target::Method(MethodKind::TraitImpl)),
+        AllowSilent(Target::Const), // Handled in the `InvalidNoMangleItems` pass
         Error(Target::Closure),
     ]);
     const CREATE: fn(Span) -> AttributeKind = AttributeKind::NoMangle;

--- a/compiler/rustc_attr_parsing/src/attributes/codegen_attrs.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/codegen_attrs.rs
@@ -362,6 +362,7 @@ impl<S: Stage> NoArgsAttributeParser<S> for NoMangleParser {
         Allow(Target::Static),
         Allow(Target::Method(MethodKind::Inherent)),
         Allow(Target::Method(MethodKind::TraitImpl)),
+        Error(Target::Closure),
     ]);
     const CREATE: fn(Span) -> AttributeKind = AttributeKind::NoMangle;
 }

--- a/compiler/rustc_codegen_ssa/messages.ftl
+++ b/compiler/rustc_codegen_ssa/messages.ftl
@@ -223,8 +223,6 @@ codegen_ssa_multiple_main_functions = entry symbol `main` declared multiple time
 
 codegen_ssa_no_field = no field `{$name}`
 
-codegen_ssa_no_mangle_nameless = `#[no_mangle]` cannot be used on {$definition} as it has no name
-
 codegen_ssa_no_module_named =
     no module named `{$user_path}` (mangled: {$cgu_name}). available modules: {$cgu_names}
 

--- a/compiler/rustc_codegen_ssa/src/codegen_attrs.rs
+++ b/compiler/rustc_codegen_ssa/src/codegen_attrs.rs
@@ -19,7 +19,6 @@ use rustc_span::{Ident, Span, sym};
 use rustc_target::spec::SanitizerSet;
 
 use crate::errors;
-use crate::errors::NoMangleNameless;
 use crate::target_features::{
     check_target_feature_trait_unsafe, check_tied_features, from_target_feature_attr,
 };
@@ -182,14 +181,10 @@ fn process_builtin_attrs(
                     if tcx.opt_item_name(did.to_def_id()).is_some() {
                         codegen_fn_attrs.flags |= CodegenFnAttrFlags::NO_MANGLE;
                     } else {
-                        tcx.dcx().emit_err(NoMangleNameless {
-                            span: *attr_span,
-                            definition: format!(
-                                "{} {}",
-                                tcx.def_descr_article(did.to_def_id()),
-                                tcx.def_descr(did.to_def_id())
-                            ),
-                        });
+                        tcx.dcx().span_delayed_bug(
+                            *attr_span,
+                            "no_mangle should be on a named function",
+                        );
                     }
                 }
                 AttributeKind::Optimize(optimize, _) => codegen_fn_attrs.optimize = *optimize,

--- a/compiler/rustc_codegen_ssa/src/errors.rs
+++ b/compiler/rustc_codegen_ssa/src/errors.rs
@@ -1285,14 +1285,6 @@ impl<G: EmissionGuarantee> Diagnostic<'_, G> for TargetFeatureDisableOrEnable<'_
 }
 
 #[derive(Diagnostic)]
-#[diag(codegen_ssa_no_mangle_nameless)]
-pub(crate) struct NoMangleNameless {
-    #[primary_span]
-    pub span: Span,
-    pub definition: String,
-}
-
-#[derive(Diagnostic)]
 #[diag(codegen_ssa_feature_not_valid)]
 pub(crate) struct FeatureNotValid<'a> {
     pub feature: &'a str,

--- a/tests/ui/attributes/no-mangle-closure.rs
+++ b/tests/ui/attributes/no-mangle-closure.rs
@@ -7,5 +7,5 @@ pub struct S([usize; 8]);
 
 pub fn outer_function(x: S, y: S) -> usize {
     (#[no_mangle] || y.0[0])()
-    //~^ ERROR `#[no_mangle]` cannot be used on a closure as it has no name
+    //~^ ERROR `#[no_mangle]` attribute cannot be used on closures
 }

--- a/tests/ui/attributes/no-mangle-closure.stderr
+++ b/tests/ui/attributes/no-mangle-closure.stderr
@@ -1,8 +1,10 @@
-error: `#[no_mangle]` cannot be used on a closure as it has no name
+error: `#[no_mangle]` attribute cannot be used on closures
   --> $DIR/no-mangle-closure.rs:9:6
    |
 LL |     (#[no_mangle] || y.0[0])()
    |      ^^^^^^^^^^^^
+   |
+   = help: `#[no_mangle]` can be applied to functions, methods, and statics
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/issues/issue-45562.fixed
+++ b/tests/ui/issues/issue-45562.fixed
@@ -1,5 +1,7 @@
 //@ run-rustfix
 
+#![deny(unused_attributes)]
+
 #[no_mangle] pub static RAH: usize = 5;
 //~^ ERROR const items should never be `#[no_mangle]`
 

--- a/tests/ui/issues/issue-45562.rs
+++ b/tests/ui/issues/issue-45562.rs
@@ -1,5 +1,7 @@
 //@ run-rustfix
 
+#![deny(unused_attributes)]
+
 #[no_mangle] pub const RAH: usize = 5;
 //~^ ERROR const items should never be `#[no_mangle]`
 

--- a/tests/ui/issues/issue-45562.stderr
+++ b/tests/ui/issues/issue-45562.stderr
@@ -1,5 +1,5 @@
 error: const items should never be `#[no_mangle]`
-  --> $DIR/issue-45562.rs:3:14
+  --> $DIR/issue-45562.rs:5:14
    |
 LL | #[no_mangle] pub const RAH: usize = 5;
    |              ---------^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Fixes 2 out of 3 cases in https://github.com/rust-lang/rust/issues/147417
The fix on closures removes the old error and marks closures as an error target.
The fix on consts adds `AllowSilent` to to ignore a target, and uses the old error because that one has a nice suggestion.

r? @jdonszelmann 