### PR TITLE
Add rustdoc crate name in error

### DIFF
--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -407,6 +407,9 @@ pub(crate) fn run_global_ctxt(
             crate::lint::MISSING_CRATE_LEVEL_DOCS,
             DocContext::as_local_hir_id(tcx, krate.module.item_id).unwrap(),
             |lint| {
+                if let Some(local_def_id) = krate.module.item_id.as_local_def_id() {
+                    lint.span(tcx.def_span(local_def_id));
+                }
                 lint.primary_message("no documentation found for this crate's top-level module");
                 lint.help(help);
             },

--- a/tests/rustdoc-ui/lints/check.rs
+++ b/tests/rustdoc-ui/lints/check.rs
@@ -2,7 +2,7 @@
 //@ compile-flags: -Z unstable-options --check
 //@ normalize-stderr: "nightly|beta|1\.[0-9][0-9]\.[0-9]" -> "$$CHANNEL"
 
-#![feature(rustdoc_missing_doc_code_examples)]
+#![feature(rustdoc_missing_doc_code_examples)] //~ WARN no documentation found for this crate's top-level module
 //~^ WARN
 
 #![warn(missing_docs)]
@@ -12,5 +12,3 @@
 pub fn foo() {}
 //~^ WARN
 //~^^ WARN
-
-//~? WARN no documentation found for this crate's top-level module

--- a/tests/rustdoc-ui/lints/check.stderr
+++ b/tests/rustdoc-ui/lints/check.stderr
@@ -22,6 +22,15 @@ LL | pub fn foo() {}
    | ^^^^^^^^^^^^
 
 warning: no documentation found for this crate's top-level module
+  --> $DIR/check.rs:5:1
+   |
+LL | / #![feature(rustdoc_missing_doc_code_examples)]
+LL | |
+LL | |
+LL | | #![warn(missing_docs)]
+...  |
+LL | | pub fn foo() {}
+   | |_______________^
    |
    = help: The following guide may be of use:
            https://doc.rust-lang.org/$CHANNEL/rustdoc/how-to-write-documentation.html

--- a/tests/rustdoc-ui/lints/no-crate-level-doc-lint.rs
+++ b/tests/rustdoc-ui/lints/no-crate-level-doc-lint.rs
@@ -1,7 +1,5 @@
 //@ normalize-stderr: "nightly|beta|1\.[0-9][0-9]\.[0-9]" -> "$$CHANNEL"
-#![deny(rustdoc::missing_crate_level_docs)]
+#![deny(rustdoc::missing_crate_level_docs)] //~ ERROR no documentation found for this crate's top-level module
 //^~ NOTE defined here
 
 pub fn foo() {}
-
-//~? ERROR no documentation found for this crate's top-level module

--- a/tests/rustdoc-ui/lints/no-crate-level-doc-lint.stderr
+++ b/tests/rustdoc-ui/lints/no-crate-level-doc-lint.stderr
@@ -1,4 +1,10 @@
 error: no documentation found for this crate's top-level module
+  --> $DIR/no-crate-level-doc-lint.rs:2:1
+   |
+LL | / #![deny(rustdoc::missing_crate_level_docs)]
+...  |
+LL | | pub fn foo() {}
+   | |_______________^
    |
    = help: The following guide may be of use:
            https://doc.rust-lang.org/$CHANNEL/rustdoc/how-to-write-documentation.html


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
Fixes https://github.com/rust-lang/rust/issues/147458

I'm not entirely sure if what I am doing with the span is correct