### PR TITLE
Clarify how to remediate the panic_immediate_abort error

### DIFF
--- a/library/core/src/panicking.rs
+++ b/library/core/src/panicking.rs
@@ -36,7 +36,8 @@ use crate::panic::{Location, PanicInfo};
 compile_error!(
     "panic_immediate_abort is now a real panic strategy! \
     Enable it with `panic = \"immediate-abort\"` in Cargo.toml, \
-    or with the compiler flags `-Zunstable-options -Cpanic=immediate-abort`"
+    or with the compiler flags `-Zunstable-options -Cpanic=immediate-abort`. \
+    In both cases, you still need to build core, e.g. with `-Zbuild-std`"
 );
 
 // First we define the two main entry points that all panics go through.


### PR DESCRIPTION
Users who build `core` for the sole purpose of enabling `panic_immediate_abort` might expect "`panic_immediate_abort` is now a real panic strategy" to mean that setting `panic = "immediate-abort"` in `Cargo.toml` or `-Cpanic=immediate-abort` in `RUSTFLAGS` to be sufficient for migration. But this is not the case, `core` still needs to be built for those changes to take effect.

See https://github.com/rust-lang/rust/issues/146974 for additional context.

See https://github.com/rust-lang/rust/issues/147286 and https://github.com/rust-lang/cargo/issues/16042 for the revelant tracking issues.