### PR TITLE
Do `x check` on various bootstrap tools in CI

### DIFF
--- a/src/bootstrap/src/core/build_steps/check.rs
+++ b/src/bootstrap/src/core/build_steps/check.rs
@@ -821,6 +821,15 @@ tool_check_step!(Compiletest {
     default: false,
 });
 
+// As with compiletest, rustdoc-gui-test is automatically built when running
+// relevant tests. So being able to check it is mainly useful for people
+// working on on rustdoc-gui-test itself, or on its compiletest dependency.
+tool_check_step!(RustdocGuiTest {
+    path: "src/tools/rustdoc-gui-test",
+    mode: Mode::ToolBootstrap,
+    default: false,
+});
+
 tool_check_step!(Linkchecker {
     path: "src/tools/linkchecker",
     mode: Mode::ToolBootstrap,

--- a/src/bootstrap/src/core/builder/mod.rs
+++ b/src/bootstrap/src/core/builder/mod.rs
@@ -1071,6 +1071,7 @@ impl<'a> Builder<'a> {
                 check::Bootstrap,
                 check::RunMakeSupport,
                 check::Compiletest,
+                check::RustdocGuiTest,
                 check::FeaturesStatusDump,
                 check::CoverageDump,
                 check::Linkchecker,

--- a/src/ci/docker/host-x86_64/pr-check-1/Dockerfile
+++ b/src/ci/docker/host-x86_64/pr-check-1/Dockerfile
@@ -40,7 +40,17 @@ COPY host-x86_64/pr-check-1/validate-toolstate.sh /scripts/
 # We disable optimized compiler built-ins because that requires a C toolchain for the target.
 # We also skip the x86_64-unknown-linux-gnu target as it is well-tested by other jobs.
 ENV SCRIPT \
-  python3 ../x.py check bootstrap && \
+  # Check some tools that aren't included in `x check` by default, to
+  # ensure that maintainers can still do check builds locally.
+  python3 ../x.py check \
+    bootstrap \
+    bump-stage0 \
+    compiletest \
+    coverage-dump \
+    linkchecker \
+    run-make-support \
+    rustdoc-gui-test \
+    && \
   /scripts/check-default-config-profiles.sh && \
   python3 ../x.py build src/tools/build-manifest && \
   python3 ../x.py check --target=i686-pc-windows-gnu --host=i686-pc-windows-gnu && \

--- a/src/ci/docker/host-x86_64/pr-check-2/Dockerfile
+++ b/src/ci/docker/host-x86_64/pr-check-2/Dockerfile
@@ -28,7 +28,6 @@ RUN sh /scripts/sccache.sh
 
 ENV SCRIPT \
         python3 ../x.py check && \
-        python3 ../x.py check src/tools/bump-stage0 && \
         python3 ../x.py clippy ci --stage 2 && \
         python3 ../x.py test --stage 1 core alloc std test proc_macro && \
         python3 ../x.py test --stage 1 src/tools/compiletest && \


### PR DESCRIPTION
These tools aren't included in a default `x check`, but checking them locally is still useful for maintainers working on the tools themselves:

- bootstrap
- bump-stage0
- compiletest
- coverage-dump
- linkchecker
- run-make-support
- rustdoc-gui-test

This PR therefore explicitly checks them in one CI job, to ensure that check builds for them continue to work.
