### PR TITLE
cmse: improve error messages

### DIFF
--- a/compiler/rustc_hir_analysis/messages.ftl
+++ b/compiler/rustc_hir_analysis/messages.ftl
@@ -80,11 +80,8 @@ hir_analysis_cmse_entry_generic =
 
 hir_analysis_cmse_inputs_stack_spill =
     arguments for `{$abi}` function too large to pass via registers
-    .label = {$plural ->
-        [false] this argument doesn't
-        *[true] these arguments don't
-    } fit in the available registers
-    .note = functions with the `{$abi}` ABI must pass all their arguments via the 4 32-bit available argument registers
+    .label = does not fit in the available registers
+    .note = functions with the `{$abi}` ABI must pass all their arguments via the 4 32-bit argument registers
 
 hir_analysis_cmse_output_stack_spill =
     return value of `{$abi}` function too large to pass via registers

--- a/compiler/rustc_hir_analysis/messages.ftl
+++ b/compiler/rustc_hir_analysis/messages.ftl
@@ -72,11 +72,11 @@ hir_analysis_cannot_capture_late_bound_ty =
 hir_analysis_closure_implicit_hrtb = implicit types in closure signatures are forbidden when `for<...>` is present
     .label = `for<...>` is here
 
-hir_analysis_cmse_call_generic =
-    function pointers with the `"cmse-nonsecure-call"` ABI cannot contain generics in their type
+hir_analysis_cmse_generic =
+    generics are not allowed in `extern {$abi}` signatures
 
-hir_analysis_cmse_entry_generic =
-    functions with the `"cmse-nonsecure-entry"` ABI cannot contain generics in their type
+hir_analysis_cmse_impl_trait =
+    `impl Trait` is not allowed in `extern {$abi}` signatures
 
 hir_analysis_cmse_inputs_stack_spill =
     arguments for `{$abi}` function too large to pass via registers

--- a/compiler/rustc_hir_analysis/src/errors.rs
+++ b/compiler/rustc_hir_analysis/src/errors.rs
@@ -1616,7 +1616,7 @@ pub(crate) struct InvalidGenericReceiverTy<'tcx> {
 pub(crate) struct CmseInputsStackSpill {
     #[primary_span]
     #[label]
-    pub span: Span,
+    pub spans: Vec<Span>,
     pub plural: bool,
     pub abi: ExternAbi,
 }

--- a/compiler/rustc_hir_analysis/src/errors.rs
+++ b/compiler/rustc_hir_analysis/src/errors.rs
@@ -1617,7 +1617,6 @@ pub(crate) struct CmseInputsStackSpill {
     #[primary_span]
     #[label]
     pub spans: Vec<Span>,
-    pub plural: bool,
     pub abi: ExternAbi,
 }
 

--- a/compiler/rustc_hir_analysis/src/errors.rs
+++ b/compiler/rustc_hir_analysis/src/errors.rs
@@ -1632,22 +1632,24 @@ pub(crate) struct CmseOutputStackSpill {
 }
 
 #[derive(Diagnostic)]
-#[diag(hir_analysis_cmse_call_generic, code = E0798)]
-pub(crate) struct CmseCallGeneric {
+#[diag(hir_analysis_cmse_generic, code = E0798)]
+pub(crate) struct CmseGeneric {
     #[primary_span]
     pub span: Span,
+    pub abi: ExternAbi,
+}
+
+#[derive(Diagnostic)]
+#[diag(hir_analysis_cmse_impl_trait, code = E0798)]
+pub(crate) struct CmseImplTrait {
+    #[primary_span]
+    pub span: Span,
+    pub abi: ExternAbi,
 }
 
 #[derive(Diagnostic)]
 #[diag(hir_analysis_bad_return_type_notation_position)]
 pub(crate) struct BadReturnTypeNotation {
-    #[primary_span]
-    pub span: Span,
-}
-
-#[derive(Diagnostic)]
-#[diag(hir_analysis_cmse_entry_generic, code = E0798)]
-pub(crate) struct CmseEntryGeneric {
     #[primary_span]
     pub span: Span,
 }

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/cmse.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/cmse.rs
@@ -216,7 +216,7 @@ fn should_emit_generic_error<'tcx>(abi: ExternAbi, layout_err: &'tcx LayoutError
             match abi {
                 ExternAbi::CmseNonSecureCall => {
                     // prevent double reporting of this error
-                    !ty.is_impl_trait()
+                    !ty.has_opaque_types()
                 }
                 ExternAbi::CmseNonSecureEntry => true,
                 _ => bug!("invalid ABI: {abi}"),

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/cmse.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/cmse.rs
@@ -124,8 +124,7 @@ fn is_valid_cmse_inputs<'tcx>(
     if !excess_argument_spans.is_empty() {
         // fn f(x: u32, y: u32, z: u32, w: u16, q: u16) -> u32,
         //                                      ^^^^^^
-        let plural = excess_argument_spans.len() != 1;
-        dcx.emit_err(errors::CmseInputsStackSpill { spans: excess_argument_spans, plural, abi });
+        dcx.emit_err(errors::CmseInputsStackSpill { spans: excess_argument_spans, abi });
     }
 
     Ok(())

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/cmse.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/cmse.rs
@@ -44,20 +44,8 @@ pub(crate) fn validate_cmse_abi<'tcx>(
                 return;
             };
 
-            match is_valid_cmse_inputs(tcx, fn_sig) {
-                Ok(Ok(())) => {}
-                Ok(Err(index)) => {
-                    // fn(x: u32, u32, u32, u16, y: u16) -> u32,
-                    //                           ^^^^^^
-                    let span = if let Some(ident) = fn_ptr_ty.param_idents[index] {
-                        ident.span.to(fn_ptr_ty.decl.inputs[index].span)
-                    } else {
-                        fn_ptr_ty.decl.inputs[index].span
-                    }
-                    .to(fn_ptr_ty.decl.inputs.last().unwrap().span);
-                    let plural = fn_ptr_ty.param_idents.len() - index != 1;
-                    dcx.emit_err(errors::CmseInputsStackSpill { span, plural, abi });
-                }
+            match is_valid_cmse_inputs(tcx, dcx, fn_sig, fn_ptr_ty.decl, abi) {
+                Ok(()) => {}
                 Err(layout_err) => {
                     if should_emit_generic_error(abi, layout_err) {
                         dcx.emit_err(errors::CmseCallGeneric { span: *fn_ptr_span });
@@ -65,18 +53,11 @@ pub(crate) fn validate_cmse_abi<'tcx>(
                 }
             }
 
-            match is_valid_cmse_output(tcx, fn_sig) {
-                Ok(true) => {}
-                Ok(false) => {
-                    let span = fn_ptr_ty.decl.output.span();
-                    dcx.emit_err(errors::CmseOutputStackSpill { span, abi });
+            if let Err(layout_err) = is_valid_cmse_output(tcx, dcx, fn_sig, fn_ptr_ty.decl, abi) {
+                if should_emit_generic_error(abi, layout_err) {
+                    dcx.emit_err(errors::CmseCallGeneric { span: *fn_ptr_span });
                 }
-                Err(layout_err) => {
-                    if should_emit_generic_error(abi, layout_err) {
-                        dcx.emit_err(errors::CmseCallGeneric { span: *fn_ptr_span });
-                    }
-                }
-            };
+            }
         }
         ExternAbi::CmseNonSecureEntry => {
             let hir_node = tcx.hir_node(hir_id);
@@ -91,15 +72,8 @@ pub(crate) fn validate_cmse_abi<'tcx>(
                 return;
             }
 
-            match is_valid_cmse_inputs(tcx, fn_sig) {
-                Ok(Ok(())) => {}
-                Ok(Err(index)) => {
-                    // fn f(x: u32, y: u32, z: u32, w: u16, q: u16) -> u32,
-                    //                                      ^^^^^^
-                    let span = decl.inputs[index].span.to(decl.inputs.last().unwrap().span);
-                    let plural = decl.inputs.len() - index != 1;
-                    dcx.emit_err(errors::CmseInputsStackSpill { span, plural, abi });
-                }
+            match is_valid_cmse_inputs(tcx, dcx, fn_sig, decl, abi) {
+                Ok(()) => {}
                 Err(layout_err) => {
                     if should_emit_generic_error(abi, layout_err) {
                         dcx.emit_err(errors::CmseEntryGeneric { span: *fn_sig_span });
@@ -107,18 +81,11 @@ pub(crate) fn validate_cmse_abi<'tcx>(
                 }
             }
 
-            match is_valid_cmse_output(tcx, fn_sig) {
-                Ok(true) => {}
-                Ok(false) => {
-                    let span = decl.output.span();
-                    dcx.emit_err(errors::CmseOutputStackSpill { span, abi });
+            if let Err(layout_err) = is_valid_cmse_output(tcx, dcx, fn_sig, decl, abi) {
+                if should_emit_generic_error(abi, layout_err) {
+                    dcx.emit_err(errors::CmseEntryGeneric { span: *fn_sig_span });
                 }
-                Err(layout_err) => {
-                    if should_emit_generic_error(abi, layout_err) {
-                        dcx.emit_err(errors::CmseEntryGeneric { span: *fn_sig_span });
-                    }
-                }
-            };
+            }
         }
         _ => (),
     }
@@ -127,16 +94,19 @@ pub(crate) fn validate_cmse_abi<'tcx>(
 /// Returns whether the inputs will fit into the available registers
 fn is_valid_cmse_inputs<'tcx>(
     tcx: TyCtxt<'tcx>,
+    dcx: DiagCtxtHandle<'_>,
     fn_sig: ty::PolyFnSig<'tcx>,
-) -> Result<Result<(), usize>, &'tcx LayoutError<'tcx>> {
-    let mut span = None;
+    fn_decl: &hir::FnDecl<'tcx>,
+    abi: ExternAbi,
+) -> Result<(), &'tcx LayoutError<'tcx>> {
     let mut accum = 0u64;
+    let mut excess_argument_spans = Vec::new();
 
     // this type is only used for layout computation, which does not rely on regions
     let fn_sig = tcx.instantiate_bound_regions_with_erased(fn_sig);
     let fn_sig = tcx.erase_and_anonymize_regions(fn_sig);
 
-    for (index, ty) in fn_sig.inputs().iter().enumerate() {
+    for (ty, hir_ty) in fn_sig.inputs().iter().zip(fn_decl.inputs) {
         let layout = tcx.layout_of(ty::TypingEnv::fully_monomorphized().as_query_input(*ty))?;
 
         let align = layout.layout.align().bytes();
@@ -147,21 +117,28 @@ fn is_valid_cmse_inputs<'tcx>(
 
         // i.e. exceeds 4 32-bit registers
         if accum > 16 {
-            span = span.or(Some(index));
+            excess_argument_spans.push(hir_ty.span);
         }
     }
 
-    match span {
-        None => Ok(Ok(())),
-        Some(span) => Ok(Err(span)),
+    if !excess_argument_spans.is_empty() {
+        // fn f(x: u32, y: u32, z: u32, w: u16, q: u16) -> u32,
+        //                                      ^^^^^^
+        let plural = excess_argument_spans.len() != 1;
+        dcx.emit_err(errors::CmseInputsStackSpill { spans: excess_argument_spans, plural, abi });
     }
+
+    Ok(())
 }
 
 /// Returns whether the output will fit into the available registers
 fn is_valid_cmse_output<'tcx>(
     tcx: TyCtxt<'tcx>,
+    dcx: DiagCtxtHandle<'_>,
     fn_sig: ty::PolyFnSig<'tcx>,
-) -> Result<bool, &'tcx LayoutError<'tcx>> {
+    fn_decl: &hir::FnDecl<'tcx>,
+    abi: ExternAbi,
+) -> Result<(), &'tcx LayoutError<'tcx>> {
     // this type is only used for layout computation, which does not rely on regions
     let fn_sig = tcx.instantiate_bound_regions_with_erased(fn_sig);
     let fn_sig = tcx.erase_and_anonymize_regions(fn_sig);
@@ -183,7 +160,11 @@ fn is_valid_cmse_output<'tcx>(
     let typing_env = ty::TypingEnv::fully_monomorphized();
     let layout = tcx.layout_of(typing_env.as_query_input(return_type))?;
 
-    Ok(is_valid_cmse_output_layout(layout))
+    if !is_valid_cmse_output_layout(layout) {
+        dcx.emit_err(errors::CmseOutputStackSpill { span: fn_decl.output.span(), abi });
+    }
+
+    Ok(())
 }
 
 /// Returns whether the output will fit into the available registers

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-call/generics.rs
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-call/generics.rs
@@ -17,8 +17,11 @@ struct Test<T: Copy> {
     f2: extern "cmse-nonsecure-call" fn(impl Copy, u32, u32, u32) -> impl Copy,
     //~^ ERROR `impl Trait` is not allowed in `fn` pointer parameters
     //~| ERROR `impl Trait` is not allowed in `fn` pointer return types
-    f3: extern "cmse-nonsecure-call" fn(T, u32, u32, u32) -> u64, //~ ERROR [E0798]
-    f4: extern "cmse-nonsecure-call" fn(Wrapper<T>, u32, u32, u32) -> u64, //~ ERROR [E0798]
+    f3: extern "cmse-nonsecure-call" fn((impl Copy, u32), u32, u32, u32) -> (impl Copy, u32),
+    //~^ ERROR `impl Trait` is not allowed in `fn` pointer parameters
+    //~| ERROR `impl Trait` is not allowed in `fn` pointer return types
+    f4: extern "cmse-nonsecure-call" fn(T, u32, u32, u32) -> u64, //~ ERROR [E0798]
+    f5: extern "cmse-nonsecure-call" fn(Wrapper<T>, u32, u32, u32) -> u64, //~ ERROR [E0798]
 }
 
 type WithReference = extern "cmse-nonsecure-call" fn(&usize);

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-call/generics.stderr
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-call/generics.stderr
@@ -55,16 +55,16 @@ LL |     f3: extern "cmse-nonsecure-call" fn((impl Copy, u32), u32, u32, u32) ->
    = note: `impl Trait` is only allowed in arguments and return types of functions and methods
 
 error[E0798]: generics are not allowed in `extern "cmse-nonsecure-call"` signatures
-  --> $DIR/generics.rs:23:9
+  --> $DIR/generics.rs:23:41
    |
 LL |     f4: extern "cmse-nonsecure-call" fn(T, u32, u32, u32) -> u64,
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                         ^
 
 error[E0798]: generics are not allowed in `extern "cmse-nonsecure-call"` signatures
-  --> $DIR/generics.rs:24:9
+  --> $DIR/generics.rs:24:41
    |
 LL |     f5: extern "cmse-nonsecure-call" fn(Wrapper<T>, u32, u32, u32) -> u64,
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                         ^^^^^^^^^^
 
 error[E0798]: return value of `"cmse-nonsecure-call"` function too large to pass via registers
   --> $DIR/generics.rs:30:71

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-call/generics.stderr
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-call/generics.stderr
@@ -38,20 +38,36 @@ LL |     f2: extern "cmse-nonsecure-call" fn(impl Copy, u32, u32, u32) -> impl C
    |
    = note: `impl Trait` is only allowed in arguments and return types of functions and methods
 
-error[E0798]: function pointers with the `"cmse-nonsecure-call"` ABI cannot contain generics in their type
-  --> $DIR/generics.rs:20:9
+error[E0562]: `impl Trait` is not allowed in `fn` pointer parameters
+  --> $DIR/generics.rs:20:42
    |
-LL |     f3: extern "cmse-nonsecure-call" fn(T, u32, u32, u32) -> u64,
+LL |     f3: extern "cmse-nonsecure-call" fn((impl Copy, u32), u32, u32, u32) -> (impl Copy, u32),
+   |                                          ^^^^^^^^^
+   |
+   = note: `impl Trait` is only allowed in arguments and return types of functions and methods
+
+error[E0562]: `impl Trait` is not allowed in `fn` pointer return types
+  --> $DIR/generics.rs:20:78
+   |
+LL |     f3: extern "cmse-nonsecure-call" fn((impl Copy, u32), u32, u32, u32) -> (impl Copy, u32),
+   |                                                                              ^^^^^^^^^
+   |
+   = note: `impl Trait` is only allowed in arguments and return types of functions and methods
+
+error[E0798]: function pointers with the `"cmse-nonsecure-call"` ABI cannot contain generics in their type
+  --> $DIR/generics.rs:23:9
+   |
+LL |     f4: extern "cmse-nonsecure-call" fn(T, u32, u32, u32) -> u64,
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0798]: function pointers with the `"cmse-nonsecure-call"` ABI cannot contain generics in their type
-  --> $DIR/generics.rs:21:9
+  --> $DIR/generics.rs:24:9
    |
-LL |     f4: extern "cmse-nonsecure-call" fn(Wrapper<T>, u32, u32, u32) -> u64,
+LL |     f5: extern "cmse-nonsecure-call" fn(Wrapper<T>, u32, u32, u32) -> u64,
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0798]: return value of `"cmse-nonsecure-call"` function too large to pass via registers
-  --> $DIR/generics.rs:27:71
+  --> $DIR/generics.rs:30:71
    |
 LL | type WithTraitObject = extern "cmse-nonsecure-call" fn(&dyn Trait) -> &dyn Trait;
    |                                                                       ^^^^^^^^^^ this type doesn't fit in the available registers
@@ -60,7 +76,7 @@ LL | type WithTraitObject = extern "cmse-nonsecure-call" fn(&dyn Trait) -> &dyn 
    = note: the result must either be a (transparently wrapped) i64, u64 or f64, or be at most 4 bytes in size
 
 error[E0798]: return value of `"cmse-nonsecure-call"` function too large to pass via registers
-  --> $DIR/generics.rs:31:60
+  --> $DIR/generics.rs:34:60
    |
 LL |     extern "cmse-nonsecure-call" fn(&'static dyn Trait) -> &'static dyn Trait;
    |                                                            ^^^^^^^^^^^^^^^^^^ this type doesn't fit in the available registers
@@ -69,7 +85,7 @@ LL |     extern "cmse-nonsecure-call" fn(&'static dyn Trait) -> &'static dyn Tra
    = note: the result must either be a (transparently wrapped) i64, u64 or f64, or be at most 4 bytes in size
 
 error[E0798]: return value of `"cmse-nonsecure-call"` function too large to pass via registers
-  --> $DIR/generics.rs:38:60
+  --> $DIR/generics.rs:41:60
    |
 LL |     extern "cmse-nonsecure-call" fn(WrapperTransparent) -> WrapperTransparent;
    |                                                            ^^^^^^^^^^^^^^^^^^ this type doesn't fit in the available registers
@@ -78,12 +94,12 @@ LL |     extern "cmse-nonsecure-call" fn(WrapperTransparent) -> WrapperTranspare
    = note: the result must either be a (transparently wrapped) i64, u64 or f64, or be at most 4 bytes in size
 
 error[E0045]: C-variadic functions with the "cmse-nonsecure-call" calling convention are not supported
-  --> $DIR/generics.rs:41:20
+  --> $DIR/generics.rs:44:20
    |
 LL | type WithVarArgs = extern "cmse-nonsecure-call" fn(u32, ...);
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ C-variadic function must have a compatible calling convention
 
-error: aborting due to 10 previous errors
+error: aborting due to 12 previous errors
 
 Some errors have detailed explanations: E0045, E0412, E0562, E0798.
 For more information about an error, try `rustc --explain E0045`.

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-call/generics.stderr
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-call/generics.stderr
@@ -54,13 +54,13 @@ LL |     f3: extern "cmse-nonsecure-call" fn((impl Copy, u32), u32, u32, u32) ->
    |
    = note: `impl Trait` is only allowed in arguments and return types of functions and methods
 
-error[E0798]: function pointers with the `"cmse-nonsecure-call"` ABI cannot contain generics in their type
+error[E0798]: generics are not allowed in `extern "cmse-nonsecure-call"` signatures
   --> $DIR/generics.rs:23:9
    |
 LL |     f4: extern "cmse-nonsecure-call" fn(T, u32, u32, u32) -> u64,
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0798]: function pointers with the `"cmse-nonsecure-call"` ABI cannot contain generics in their type
+error[E0798]: generics are not allowed in `extern "cmse-nonsecure-call"` signatures
   --> $DIR/generics.rs:24:9
    |
 LL |     f5: extern "cmse-nonsecure-call" fn(Wrapper<T>, u32, u32, u32) -> u64,

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-call/params-via-stack.stderr
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-call/params-via-stack.stderr
@@ -2,43 +2,43 @@ error[E0798]: arguments for `"cmse-nonsecure-call"` function too large to pass v
   --> $DIR/params-via-stack.rs:16:64
    |
 LL |     f1: extern "cmse-nonsecure-call" fn(u32, u32, u32, u32, x: u32, y: u32),
-   |                                                                ^^^     ^^^ these arguments don't fit in the available registers
+   |                                                                ^^^     ^^^ does not fit in the available registers
    |                                                                |
-   |                                                                these arguments don't fit in the available registers
+   |                                                                does not fit in the available registers
    |
-   = note: functions with the `"cmse-nonsecure-call"` ABI must pass all their arguments via the 4 32-bit available argument registers
+   = note: functions with the `"cmse-nonsecure-call"` ABI must pass all their arguments via the 4 32-bit argument registers
 
 error[E0798]: arguments for `"cmse-nonsecure-call"` function too large to pass via registers
   --> $DIR/params-via-stack.rs:17:61
    |
 LL |     f2: extern "cmse-nonsecure-call" fn(u32, u32, u32, u16, u16),
-   |                                                             ^^^ this argument doesn't fit in the available registers
+   |                                                             ^^^ does not fit in the available registers
    |
-   = note: functions with the `"cmse-nonsecure-call"` ABI must pass all their arguments via the 4 32-bit available argument registers
+   = note: functions with the `"cmse-nonsecure-call"` ABI must pass all their arguments via the 4 32-bit argument registers
 
 error[E0798]: arguments for `"cmse-nonsecure-call"` function too large to pass via registers
   --> $DIR/params-via-stack.rs:18:51
    |
 LL |     f3: extern "cmse-nonsecure-call" fn(u32, u64, u32),
-   |                                                   ^^^ this argument doesn't fit in the available registers
+   |                                                   ^^^ does not fit in the available registers
    |
-   = note: functions with the `"cmse-nonsecure-call"` ABI must pass all their arguments via the 4 32-bit available argument registers
+   = note: functions with the `"cmse-nonsecure-call"` ABI must pass all their arguments via the 4 32-bit argument registers
 
 error[E0798]: arguments for `"cmse-nonsecure-call"` function too large to pass via registers
   --> $DIR/params-via-stack.rs:19:56
    |
 LL |     f4: extern "cmse-nonsecure-call" fn(AlignRelevant, u32),
-   |                                                        ^^^ this argument doesn't fit in the available registers
+   |                                                        ^^^ does not fit in the available registers
    |
-   = note: functions with the `"cmse-nonsecure-call"` ABI must pass all their arguments via the 4 32-bit available argument registers
+   = note: functions with the `"cmse-nonsecure-call"` ABI must pass all their arguments via the 4 32-bit argument registers
 
 error[E0798]: arguments for `"cmse-nonsecure-call"` function too large to pass via registers
   --> $DIR/params-via-stack.rs:20:41
    |
 LL |     f5: extern "cmse-nonsecure-call" fn([u32; 5]),
-   |                                         ^^^^^^^^ this argument doesn't fit in the available registers
+   |                                         ^^^^^^^^ does not fit in the available registers
    |
-   = note: functions with the `"cmse-nonsecure-call"` ABI must pass all their arguments via the 4 32-bit available argument registers
+   = note: functions with the `"cmse-nonsecure-call"` ABI must pass all their arguments via the 4 32-bit argument registers
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-call/params-via-stack.stderr
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-call/params-via-stack.stderr
@@ -1,8 +1,10 @@
 error[E0798]: arguments for `"cmse-nonsecure-call"` function too large to pass via registers
-  --> $DIR/params-via-stack.rs:16:61
+  --> $DIR/params-via-stack.rs:16:64
    |
 LL |     f1: extern "cmse-nonsecure-call" fn(u32, u32, u32, u32, x: u32, y: u32),
-   |                                                             ^^^^^^^^^^^^^^ these arguments don't fit in the available registers
+   |                                                                ^^^     ^^^ these arguments don't fit in the available registers
+   |                                                                |
+   |                                                                these arguments don't fit in the available registers
    |
    = note: functions with the `"cmse-nonsecure-call"` ABI must pass all their arguments via the 4 32-bit available argument registers
 

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/generics.rs
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/generics.rs
@@ -67,25 +67,25 @@ extern "cmse-nonsecure-entry" fn impl_trait(_: impl Copy, _: u32, _: u32, _: u32
 }
 
 extern "cmse-nonsecure-entry" fn return_impl_trait() -> impl Copy {
-    //~^ ERROR functions with the `"cmse-nonsecure-entry"` ABI cannot contain generics in their type
+    //~^ ERROR `impl Trait` is not allowed in `extern "cmse-nonsecure-entry"` signatures
     0u128
 }
 
 extern "cmse-nonsecure-entry" fn return_impl_trait_nested() -> (impl Copy, i32) {
-    //~^ ERROR functions with the `"cmse-nonsecure-entry"` ABI cannot contain generics in their type
+    //~^ ERROR `impl Trait` is not allowed in `extern "cmse-nonsecure-entry"` signatures
     (0u128, 0i32)
 }
 
 extern "cmse-nonsecure-entry" fn identity_impl_trait(v: impl Copy) -> impl Copy {
-    //~^ ERROR functions with the `"cmse-nonsecure-entry"` ABI cannot contain generics in their type
-    //~| ERROR functions with the `"cmse-nonsecure-entry"` ABI cannot contain generics in their type
+    //~^ ERROR generics are not allowed in `extern "cmse-nonsecure-entry"` signatures
+    //~| ERROR `impl Trait` is not allowed in `extern "cmse-nonsecure-entry"` signatures
     v
 }
 
 extern "cmse-nonsecure-entry" fn identity_impl_trait_nested(
-    //~^ ERROR functions with the `"cmse-nonsecure-entry"` ABI cannot contain generics in their type
-    //~| ERROR functions with the `"cmse-nonsecure-entry"` ABI cannot contain generics in their type
+    //~^ ERROR generics are not allowed in `extern "cmse-nonsecure-entry"` signatures
     v: (impl Copy, i32),
 ) -> (impl Copy, i32) {
+    //~^ ERROR `impl Trait` is not allowed in `extern "cmse-nonsecure-entry"` signatures
     v
 }

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/generics.rs
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/generics.rs
@@ -37,11 +37,6 @@ extern "cmse-nonsecure-entry" fn introduced_generic<U: Copy>(
     0
 }
 
-extern "cmse-nonsecure-entry" fn impl_trait(_: impl Copy, _: u32, _: u32, _: u32) -> u64 {
-    //~^ ERROR [E0798]
-    0
-}
-
 extern "cmse-nonsecure-entry" fn reference(x: &usize) -> usize {
     *x
 }
@@ -66,14 +61,31 @@ extern "cmse-nonsecure-entry" fn wrapped_trait_object(x: WrapperTransparent) -> 
     x
 }
 
-extern "cmse-nonsecure-entry" fn return_impl_trait(_: impl Copy) -> impl Copy {
+extern "cmse-nonsecure-entry" fn impl_trait(_: impl Copy, _: u32, _: u32, _: u32) -> u64 {
+    //~^ ERROR [E0798]
+    0
+}
+
+extern "cmse-nonsecure-entry" fn return_impl_trait() -> impl Copy {
     //~^ ERROR functions with the `"cmse-nonsecure-entry"` ABI cannot contain generics in their type
-    //~| ERROR functions with the `"cmse-nonsecure-entry"` ABI cannot contain generics in their type
     0u128
 }
 
-extern "cmse-nonsecure-entry" fn return_impl_trait_nested(v: (impl Copy, i32)) -> (impl Copy, i32) {
+extern "cmse-nonsecure-entry" fn return_impl_trait_nested() -> (impl Copy, i32) {
+    //~^ ERROR functions with the `"cmse-nonsecure-entry"` ABI cannot contain generics in their type
+    (0u128, 0i32)
+}
+
+extern "cmse-nonsecure-entry" fn identity_impl_trait(v: impl Copy) -> impl Copy {
     //~^ ERROR functions with the `"cmse-nonsecure-entry"` ABI cannot contain generics in their type
     //~| ERROR functions with the `"cmse-nonsecure-entry"` ABI cannot contain generics in their type
+    v
+}
+
+extern "cmse-nonsecure-entry" fn identity_impl_trait_nested(
+    //~^ ERROR functions with the `"cmse-nonsecure-entry"` ABI cannot contain generics in their type
+    //~| ERROR functions with the `"cmse-nonsecure-entry"` ABI cannot contain generics in their type
+    v: (impl Copy, i32),
+) -> (impl Copy, i32) {
     v
 }

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/generics.rs
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/generics.rs
@@ -17,8 +17,8 @@ impl<T: Copy> Wrapper<T> {
     }
 
     extern "cmse-nonsecure-entry" fn ambient_generic_nested(
-        //~^ ERROR [E0798]
         _: Wrapper<T>,
+        //~^ ERROR [E0798]
         _: u32,
         _: u32,
         _: u32,
@@ -28,8 +28,8 @@ impl<T: Copy> Wrapper<T> {
 }
 
 extern "cmse-nonsecure-entry" fn introduced_generic<U: Copy>(
-    //~^ ERROR [E0798]
     _: U,
+    //~^ ERROR [E0798]
     _: u32,
     _: u32,
     _: u32,
@@ -83,8 +83,8 @@ extern "cmse-nonsecure-entry" fn identity_impl_trait(v: impl Copy) -> impl Copy 
 }
 
 extern "cmse-nonsecure-entry" fn identity_impl_trait_nested(
-    //~^ ERROR generics are not allowed in `extern "cmse-nonsecure-entry"` signatures
     v: (impl Copy, i32),
+    //~^ ERROR generics are not allowed in `extern "cmse-nonsecure-entry"` signatures
 ) -> (impl Copy, i32) {
     //~^ ERROR `impl Trait` is not allowed in `extern "cmse-nonsecure-entry"` signatures
     v

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/generics.stderr
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/generics.stderr
@@ -11,36 +11,44 @@ LL | | ) -> u64 {
    | |________^
 
 error[E0798]: functions with the `"cmse-nonsecure-entry"` ABI cannot contain generics in their type
-  --> $DIR/generics.rs:40:1
+  --> $DIR/generics.rs:64:1
    |
 LL | extern "cmse-nonsecure-entry" fn impl_trait(_: impl Copy, _: u32, _: u32, _: u32) -> u64 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0798]: functions with the `"cmse-nonsecure-entry"` ABI cannot contain generics in their type
-  --> $DIR/generics.rs:69:1
+  --> $DIR/generics.rs:79:1
    |
-LL | extern "cmse-nonsecure-entry" fn return_impl_trait(_: impl Copy) -> impl Copy {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | extern "cmse-nonsecure-entry" fn identity_impl_trait(v: impl Copy) -> impl Copy {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0798]: functions with the `"cmse-nonsecure-entry"` ABI cannot contain generics in their type
-  --> $DIR/generics.rs:69:1
+  --> $DIR/generics.rs:79:1
    |
-LL | extern "cmse-nonsecure-entry" fn return_impl_trait(_: impl Copy) -> impl Copy {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | extern "cmse-nonsecure-entry" fn identity_impl_trait(v: impl Copy) -> impl Copy {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0798]: functions with the `"cmse-nonsecure-entry"` ABI cannot contain generics in their type
-  --> $DIR/generics.rs:75:1
+  --> $DIR/generics.rs:85:1
    |
-LL | extern "cmse-nonsecure-entry" fn return_impl_trait_nested(v: (impl Copy, i32)) -> (impl Copy, i32) {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | / extern "cmse-nonsecure-entry" fn identity_impl_trait_nested(
+LL | |
+LL | |
+LL | |     v: (impl Copy, i32),
+LL | | ) -> (impl Copy, i32) {
+   | |_____________________^
 
 error[E0798]: functions with the `"cmse-nonsecure-entry"` ABI cannot contain generics in their type
-  --> $DIR/generics.rs:75:1
+  --> $DIR/generics.rs:85:1
    |
-LL | extern "cmse-nonsecure-entry" fn return_impl_trait_nested(v: (impl Copy, i32)) -> (impl Copy, i32) {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | / extern "cmse-nonsecure-entry" fn identity_impl_trait_nested(
+LL | |
+LL | |
+LL | |     v: (impl Copy, i32),
+LL | | ) -> (impl Copy, i32) {
+   | |_____________________^
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
@@ -63,7 +71,7 @@ LL | |     ) -> u64 {
    | |____________^
 
 error[E0798]: return value of `"cmse-nonsecure-entry"` function too large to pass via registers
-  --> $DIR/generics.rs:51:65
+  --> $DIR/generics.rs:46:65
    |
 LL | extern "cmse-nonsecure-entry" fn trait_object(x: &dyn Trait) -> &dyn Trait {
    |                                                                 ^^^^^^^^^^ this type doesn't fit in the available registers
@@ -72,7 +80,7 @@ LL | extern "cmse-nonsecure-entry" fn trait_object(x: &dyn Trait) -> &dyn Trait 
    = note: the result must either be a (transparently wrapped) i64, u64 or f64, or be at most 4 bytes in size
 
 error[E0798]: return value of `"cmse-nonsecure-entry"` function too large to pass via registers
-  --> $DIR/generics.rs:56:80
+  --> $DIR/generics.rs:51:80
    |
 LL | extern "cmse-nonsecure-entry" fn static_trait_object(x: &'static dyn Trait) -> &'static dyn Trait {
    |                                                                                ^^^^^^^^^^^^^^^^^^ this type doesn't fit in the available registers
@@ -81,7 +89,7 @@ LL | extern "cmse-nonsecure-entry" fn static_trait_object(x: &'static dyn Trait)
    = note: the result must either be a (transparently wrapped) i64, u64 or f64, or be at most 4 bytes in size
 
 error[E0798]: return value of `"cmse-nonsecure-entry"` function too large to pass via registers
-  --> $DIR/generics.rs:64:81
+  --> $DIR/generics.rs:59:81
    |
 LL | extern "cmse-nonsecure-entry" fn wrapped_trait_object(x: WrapperTransparent) -> WrapperTransparent {
    |                                                                                 ^^^^^^^^^^^^^^^^^^ this type doesn't fit in the available registers
@@ -89,6 +97,18 @@ LL | extern "cmse-nonsecure-entry" fn wrapped_trait_object(x: WrapperTransparent
    = note: functions with the `"cmse-nonsecure-entry"` ABI must pass their result via the available return registers
    = note: the result must either be a (transparently wrapped) i64, u64 or f64, or be at most 4 bytes in size
 
-error: aborting due to 11 previous errors
+error[E0798]: functions with the `"cmse-nonsecure-entry"` ABI cannot contain generics in their type
+  --> $DIR/generics.rs:69:1
+   |
+LL | extern "cmse-nonsecure-entry" fn return_impl_trait() -> impl Copy {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0798]: functions with the `"cmse-nonsecure-entry"` ABI cannot contain generics in their type
+  --> $DIR/generics.rs:74:1
+   |
+LL | extern "cmse-nonsecure-entry" fn return_impl_trait_nested() -> (impl Copy, i32) {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 13 previous errors
 
 For more information about this error, try `rustc --explain E0798`.

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/generics.stderr
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/generics.stderr
@@ -1,26 +1,20 @@
 error[E0798]: generics are not allowed in `extern "cmse-nonsecure-entry"` signatures
-  --> $DIR/generics.rs:30:1
+  --> $DIR/generics.rs:31:8
    |
-LL | / extern "cmse-nonsecure-entry" fn introduced_generic<U: Copy>(
-LL | |
-LL | |     _: U,
-LL | |     _: u32,
-LL | |     _: u32,
-LL | |     _: u32,
-LL | | ) -> u64 {
-   | |________^
+LL |     _: U,
+   |        ^
 
 error[E0798]: generics are not allowed in `extern "cmse-nonsecure-entry"` signatures
-  --> $DIR/generics.rs:64:1
+  --> $DIR/generics.rs:64:48
    |
 LL | extern "cmse-nonsecure-entry" fn impl_trait(_: impl Copy, _: u32, _: u32, _: u32) -> u64 {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                                ^^^^^^^^^
 
 error[E0798]: generics are not allowed in `extern "cmse-nonsecure-entry"` signatures
-  --> $DIR/generics.rs:79:1
+  --> $DIR/generics.rs:79:57
    |
 LL | extern "cmse-nonsecure-entry" fn identity_impl_trait(v: impl Copy) -> impl Copy {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                                         ^^^^^^^^^
 
 error[E0798]: `impl Trait` is not allowed in `extern "cmse-nonsecure-entry"` signatures
   --> $DIR/generics.rs:79:71
@@ -29,13 +23,10 @@ LL | extern "cmse-nonsecure-entry" fn identity_impl_trait(v: impl Copy) -> impl 
    |                                                                       ^^^^^^^^^
 
 error[E0798]: generics are not allowed in `extern "cmse-nonsecure-entry"` signatures
-  --> $DIR/generics.rs:85:1
+  --> $DIR/generics.rs:86:8
    |
-LL | / extern "cmse-nonsecure-entry" fn identity_impl_trait_nested(
-LL | |
-LL | |     v: (impl Copy, i32),
-LL | | ) -> (impl Copy, i32) {
-   | |_____________________^
+LL |     v: (impl Copy, i32),
+   |        ^^^^^^^^^^^^^^^^
 
 error[E0798]: `impl Trait` is not allowed in `extern "cmse-nonsecure-entry"` signatures
   --> $DIR/generics.rs:88:6
@@ -44,22 +35,16 @@ LL | ) -> (impl Copy, i32) {
    |      ^^^^^^^^^^^^^^^^
 
 error[E0798]: generics are not allowed in `extern "cmse-nonsecure-entry"` signatures
-  --> $DIR/generics.rs:14:5
+  --> $DIR/generics.rs:14:57
    |
 LL |     extern "cmse-nonsecure-entry" fn ambient_generic(_: T, _: u32, _: u32, _: u32) -> u64 {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                                         ^
 
 error[E0798]: generics are not allowed in `extern "cmse-nonsecure-entry"` signatures
-  --> $DIR/generics.rs:19:5
+  --> $DIR/generics.rs:20:12
    |
-LL | /     extern "cmse-nonsecure-entry" fn ambient_generic_nested(
-LL | |
-LL | |         _: Wrapper<T>,
-LL | |         _: u32,
-LL | |         _: u32,
-LL | |         _: u32,
-LL | |     ) -> u64 {
-   | |____________^
+LL |         _: Wrapper<T>,
+   |            ^^^^^^^^^^
 
 error[E0798]: return value of `"cmse-nonsecure-entry"` function too large to pass via registers
   --> $DIR/generics.rs:46:65

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/generics.stderr
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/generics.stderr
@@ -1,4 +1,4 @@
-error[E0798]: functions with the `"cmse-nonsecure-entry"` ABI cannot contain generics in their type
+error[E0798]: generics are not allowed in `extern "cmse-nonsecure-entry"` signatures
   --> $DIR/generics.rs:30:1
    |
 LL | / extern "cmse-nonsecure-entry" fn introduced_generic<U: Copy>(
@@ -10,55 +10,46 @@ LL | |     _: u32,
 LL | | ) -> u64 {
    | |________^
 
-error[E0798]: functions with the `"cmse-nonsecure-entry"` ABI cannot contain generics in their type
+error[E0798]: generics are not allowed in `extern "cmse-nonsecure-entry"` signatures
   --> $DIR/generics.rs:64:1
    |
 LL | extern "cmse-nonsecure-entry" fn impl_trait(_: impl Copy, _: u32, _: u32, _: u32) -> u64 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0798]: functions with the `"cmse-nonsecure-entry"` ABI cannot contain generics in their type
+error[E0798]: generics are not allowed in `extern "cmse-nonsecure-entry"` signatures
   --> $DIR/generics.rs:79:1
    |
 LL | extern "cmse-nonsecure-entry" fn identity_impl_trait(v: impl Copy) -> impl Copy {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0798]: functions with the `"cmse-nonsecure-entry"` ABI cannot contain generics in their type
-  --> $DIR/generics.rs:79:1
+error[E0798]: `impl Trait` is not allowed in `extern "cmse-nonsecure-entry"` signatures
+  --> $DIR/generics.rs:79:71
    |
 LL | extern "cmse-nonsecure-entry" fn identity_impl_trait(v: impl Copy) -> impl Copy {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+   |                                                                       ^^^^^^^^^
 
-error[E0798]: functions with the `"cmse-nonsecure-entry"` ABI cannot contain generics in their type
+error[E0798]: generics are not allowed in `extern "cmse-nonsecure-entry"` signatures
   --> $DIR/generics.rs:85:1
    |
 LL | / extern "cmse-nonsecure-entry" fn identity_impl_trait_nested(
-LL | |
 LL | |
 LL | |     v: (impl Copy, i32),
 LL | | ) -> (impl Copy, i32) {
    | |_____________________^
 
-error[E0798]: functions with the `"cmse-nonsecure-entry"` ABI cannot contain generics in their type
-  --> $DIR/generics.rs:85:1
+error[E0798]: `impl Trait` is not allowed in `extern "cmse-nonsecure-entry"` signatures
+  --> $DIR/generics.rs:88:6
    |
-LL | / extern "cmse-nonsecure-entry" fn identity_impl_trait_nested(
-LL | |
-LL | |
-LL | |     v: (impl Copy, i32),
-LL | | ) -> (impl Copy, i32) {
-   | |_____________________^
-   |
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+LL | ) -> (impl Copy, i32) {
+   |      ^^^^^^^^^^^^^^^^
 
-error[E0798]: functions with the `"cmse-nonsecure-entry"` ABI cannot contain generics in their type
+error[E0798]: generics are not allowed in `extern "cmse-nonsecure-entry"` signatures
   --> $DIR/generics.rs:14:5
    |
 LL |     extern "cmse-nonsecure-entry" fn ambient_generic(_: T, _: u32, _: u32, _: u32) -> u64 {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0798]: functions with the `"cmse-nonsecure-entry"` ABI cannot contain generics in their type
+error[E0798]: generics are not allowed in `extern "cmse-nonsecure-entry"` signatures
   --> $DIR/generics.rs:19:5
    |
 LL | /     extern "cmse-nonsecure-entry" fn ambient_generic_nested(
@@ -97,17 +88,17 @@ LL | extern "cmse-nonsecure-entry" fn wrapped_trait_object(x: WrapperTransparent
    = note: functions with the `"cmse-nonsecure-entry"` ABI must pass their result via the available return registers
    = note: the result must either be a (transparently wrapped) i64, u64 or f64, or be at most 4 bytes in size
 
-error[E0798]: functions with the `"cmse-nonsecure-entry"` ABI cannot contain generics in their type
-  --> $DIR/generics.rs:69:1
+error[E0798]: `impl Trait` is not allowed in `extern "cmse-nonsecure-entry"` signatures
+  --> $DIR/generics.rs:69:57
    |
 LL | extern "cmse-nonsecure-entry" fn return_impl_trait() -> impl Copy {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                                         ^^^^^^^^^
 
-error[E0798]: functions with the `"cmse-nonsecure-entry"` ABI cannot contain generics in their type
-  --> $DIR/generics.rs:74:1
+error[E0798]: `impl Trait` is not allowed in `extern "cmse-nonsecure-entry"` signatures
+  --> $DIR/generics.rs:74:64
    |
 LL | extern "cmse-nonsecure-entry" fn return_impl_trait_nested() -> (impl Copy, i32) {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                                                ^^^^^^^^^^^^^^^^
 
 error: aborting due to 13 previous errors
 

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/params-via-stack.stderr
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/params-via-stack.stderr
@@ -2,43 +2,43 @@ error[E0798]: arguments for `"cmse-nonsecure-entry"` function too large to pass 
   --> $DIR/params-via-stack.rs:15:76
    |
 LL | pub extern "cmse-nonsecure-entry" fn f1(_: u32, _: u32, _: u32, _: u32, _: u32, _: u32) {}
-   |                                                                            ^^^     ^^^ these arguments don't fit in the available registers
+   |                                                                            ^^^     ^^^ does not fit in the available registers
    |                                                                            |
-   |                                                                            these arguments don't fit in the available registers
+   |                                                                            does not fit in the available registers
    |
-   = note: functions with the `"cmse-nonsecure-entry"` ABI must pass all their arguments via the 4 32-bit available argument registers
+   = note: functions with the `"cmse-nonsecure-entry"` ABI must pass all their arguments via the 4 32-bit argument registers
 
 error[E0798]: arguments for `"cmse-nonsecure-entry"` function too large to pass via registers
   --> $DIR/params-via-stack.rs:17:76
    |
 LL | pub extern "cmse-nonsecure-entry" fn f2(_: u32, _: u32, _: u32, _: u16, _: u16) {}
-   |                                                                            ^^^ this argument doesn't fit in the available registers
+   |                                                                            ^^^ does not fit in the available registers
    |
-   = note: functions with the `"cmse-nonsecure-entry"` ABI must pass all their arguments via the 4 32-bit available argument registers
+   = note: functions with the `"cmse-nonsecure-entry"` ABI must pass all their arguments via the 4 32-bit argument registers
 
 error[E0798]: arguments for `"cmse-nonsecure-entry"` function too large to pass via registers
   --> $DIR/params-via-stack.rs:19:60
    |
 LL | pub extern "cmse-nonsecure-entry" fn f3(_: u32, _: u64, _: u32) {}
-   |                                                            ^^^ this argument doesn't fit in the available registers
+   |                                                            ^^^ does not fit in the available registers
    |
-   = note: functions with the `"cmse-nonsecure-entry"` ABI must pass all their arguments via the 4 32-bit available argument registers
+   = note: functions with the `"cmse-nonsecure-entry"` ABI must pass all their arguments via the 4 32-bit argument registers
 
 error[E0798]: arguments for `"cmse-nonsecure-entry"` function too large to pass via registers
   --> $DIR/params-via-stack.rs:21:62
    |
 LL | pub extern "cmse-nonsecure-entry" fn f4(_: AlignRelevant, _: u32) {}
-   |                                                              ^^^ this argument doesn't fit in the available registers
+   |                                                              ^^^ does not fit in the available registers
    |
-   = note: functions with the `"cmse-nonsecure-entry"` ABI must pass all their arguments via the 4 32-bit available argument registers
+   = note: functions with the `"cmse-nonsecure-entry"` ABI must pass all their arguments via the 4 32-bit argument registers
 
 error[E0798]: arguments for `"cmse-nonsecure-entry"` function too large to pass via registers
   --> $DIR/params-via-stack.rs:25:44
    |
 LL | pub extern "cmse-nonsecure-entry" fn f5(_: [u32; 5]) {}
-   |                                            ^^^^^^^^ this argument doesn't fit in the available registers
+   |                                            ^^^^^^^^ does not fit in the available registers
    |
-   = note: functions with the `"cmse-nonsecure-entry"` ABI must pass all their arguments via the 4 32-bit available argument registers
+   = note: functions with the `"cmse-nonsecure-entry"` ABI must pass all their arguments via the 4 32-bit argument registers
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/params-via-stack.stderr
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/params-via-stack.stderr
@@ -2,7 +2,9 @@ error[E0798]: arguments for `"cmse-nonsecure-entry"` function too large to pass 
   --> $DIR/params-via-stack.rs:15:76
    |
 LL | pub extern "cmse-nonsecure-entry" fn f1(_: u32, _: u32, _: u32, _: u32, _: u32, _: u32) {}
-   |                                                                            ^^^^^^^^^^^ these arguments don't fit in the available registers
+   |                                                                            ^^^     ^^^ these arguments don't fit in the available registers
+   |                                                                            |
+   |                                                                            these arguments don't fit in the available registers
    |
    = note: functions with the `"cmse-nonsecure-entry"` ABI must pass all their arguments via the 4 32-bit available argument registers
 


### PR DESCRIPTION
tracking issue: https://github.com/rust-lang/rust/issues/81391
tracking issue: https://github.com/rust-lang/rust/issues/75835

Improves the cmse error messages (e.g. by using more accurate spans), and attempts to clean up the control flow a bit. This is partially in preparation for one final addition: warnings when `union` types or types with niches cross the security boundary. That will be a folllow-up.

Meant to be reviewed commit-by-commit

r? @davidtwco 