### PR TITLE
Perform InstSimplify before ReferencePropagation.

### DIFF
--- a/compiler/rustc_mir_transform/src/lib.rs
+++ b/compiler/rustc_mir_transform/src/lib.rs
@@ -699,8 +699,8 @@ pub(crate) fn run_optimization_passes<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body<'
             &o1(simplify::SimplifyCfg::AfterUnreachableEnumBranching),
             &multiple_return_terminators::MultipleReturnTerminators,
             // After simplifycfg, it allows us to discover new opportunities for peephole
-            // optimizations. This invalidates CFG caches, so avoid putting between two SSA
-            // analyses.
+            // optimizations. This invalidates CFG caches, so avoid putting between
+            // `ReferencePropagation` and `GVN` which both use the dominator tree.
             &instsimplify::InstSimplify::AfterSimplifyCfg,
             &ref_prop::ReferencePropagation,
             &sroa::ScalarReplacementOfAggregates,

--- a/compiler/rustc_mir_transform/src/lib.rs
+++ b/compiler/rustc_mir_transform/src/lib.rs
@@ -684,6 +684,8 @@ pub(crate) fn run_optimization_passes<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body<'
             &inline::ForceInline,
             // Perform inlining, which may add a lot of code.
             &inline::Inline,
+            // Inlining may have introduced a lot of redundant code and a large move pattern.
+            // Now, we need to shrink the generated MIR.
             // Code from other crates may have storage markers, so this needs to happen after
             // inlining.
             &remove_storage_markers::RemoveStorageMarkers,
@@ -695,14 +697,13 @@ pub(crate) fn run_optimization_passes<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body<'
             &unreachable_enum_branching::UnreachableEnumBranching,
             &unreachable_prop::UnreachablePropagation,
             &o1(simplify::SimplifyCfg::AfterUnreachableEnumBranching),
-            // Inlining may have introduced a lot of redundant code and a large move pattern.
-            // Now, we need to shrink the generated MIR.
-            &ref_prop::ReferencePropagation,
-            &sroa::ScalarReplacementOfAggregates,
             &multiple_return_terminators::MultipleReturnTerminators,
             // After simplifycfg, it allows us to discover new opportunities for peephole
-            // optimizations.
+            // optimizations. This invalidates CFG caches, so avoid putting between two SSA
+            // analyses.
             &instsimplify::InstSimplify::AfterSimplifyCfg,
+            &ref_prop::ReferencePropagation,
+            &sroa::ScalarReplacementOfAggregates,
             &simplify::SimplifyLocals::BeforeConstProp,
             &dead_store_elimination::DeadStoreElimination::Initial,
             &gvn::GVN,


### PR DESCRIPTION
`InstSimplify` clears CFG caches.

But it currently happens between `ReferencePropagation` and `GVN`, which both use dominators, a quite expensive computation.

r? @ghost

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
