### PR TITLE
std::thread spawn: Docs: Link to Builder::spawn; Make same.

### DIFF
--- a/library/std/src/thread/mod.rs
+++ b/library/std/src/thread/mod.rs
@@ -620,9 +620,8 @@ impl Builder {
 /// (It is the responsibility of the program to either eventually join threads it
 /// creates or detach them; otherwise, a resource leak will result.)
 ///
-/// This call will create a thread using default parameters of [`Builder`], if you
-/// want to specify the stack size or the name of the thread, use this API
-/// instead.
+/// This function creates a thread with the default parameters. To specify the
+/// new thread's stack size or the name, use [`Builder::spawn`].
 ///
 /// As you can see in the signature of `spawn` there are two constraints on
 /// both the closure given to `spawn` and its return value, let's explain them:

--- a/library/std/src/thread/mod.rs
+++ b/library/std/src/thread/mod.rs
@@ -620,8 +620,8 @@ impl Builder {
 /// (It is the responsibility of the program to either eventually join threads it
 /// creates or detach them; otherwise, a resource leak will result.)
 ///
-/// This function creates a thread with the default parameters. To specify the
-/// new thread's stack size or the name, use [`Builder::spawn`].
+/// This function creates a thread with the default parameters of [`Builder`].
+/// To specify the new thread's stack size or the name, use [`Builder::spawn`].
 ///
 /// As you can see in the signature of `spawn` there are two constraints on
 /// both the closure given to `spawn` and its return value, let's explain them:

--- a/library/std/src/thread/scoped.rs
+++ b/library/std/src/thread/scoped.rs
@@ -181,9 +181,8 @@ impl<'scope, 'env> Scope<'scope, 'env> {
     /// end of the scope. In that case, if the spawned thread panics, [`scope`] will
     /// panic after all threads are joined.
     ///
-    /// This call will create a thread using default parameters of [`Builder`].
-    /// If you want to specify the stack size or the name of the thread, use
-    /// [`Builder::spawn_scoped`] instead.
+    /// This function creates a thread with the default parameters. To specify the
+    /// new thread's stack size or the name, use [`Builder::spawn_scoped`].
     ///
     /// # Panics
     ///

--- a/library/std/src/thread/scoped.rs
+++ b/library/std/src/thread/scoped.rs
@@ -181,8 +181,8 @@ impl<'scope, 'env> Scope<'scope, 'env> {
     /// end of the scope. In that case, if the spawned thread panics, [`scope`] will
     /// panic after all threads are joined.
     ///
-    /// This function creates a thread with the default parameters. To specify the
-    /// new thread's stack size or the name, use [`Builder::spawn_scoped`].
+    /// This function creates a thread with the default parameters of [`Builder`].
+    /// To specify the new thread's stack size or the name, use [`Builder::spawn_scoped`].
     ///
     /// # Panics
     ///


### PR DESCRIPTION
Replace "use this API instead" with a link to Builder::spawn. Edit the paragraph to make it slightly clearer.

The Scope::spawn method already included a link to `Builder::spawn_scoped`. Make the docs for `Scope::spawn` and `thread::spawn` nearly the same.