### PR TITLE
Inline `Deps::read_deps`.

### DIFF
--- a/compiler/rustc_middle/src/dep_graph/mod.rs
+++ b/compiler/rustc_middle/src/dep_graph/mod.rs
@@ -37,6 +37,7 @@ impl Deps for DepsType {
         })
     }
 
+    #[inline]
     fn read_deps<OP>(op: OP)
     where
         OP: for<'a> FnOnce(TaskDepsRef<'a>),


### PR DESCRIPTION
It's very hot in incremental builds.

r? @ghost