### PR TITLE
`proc_macro` cleanups (3/N)

### DIFF
--- a/library/proc_macro/src/bridge/client.rs
+++ b/library/proc_macro/src/bridge/client.rs
@@ -58,7 +58,7 @@ macro_rules! define_client_handles {
                 }
             }
 
-            impl<S> DecodeMut<'_, '_, S> for $oty {
+            impl<S> Decode<'_, '_, S> for $oty {
                 fn decode(r: &mut Reader<'_>, s: &mut S) -> Self {
                     $oty {
                         handle: handle::Handle::decode(r, s),
@@ -82,7 +82,7 @@ macro_rules! define_client_handles {
                 }
             }
 
-            impl<S> DecodeMut<'_, '_, S> for $ity {
+            impl<S> Decode<'_, '_, S> for $ity {
                 fn decode(r: &mut Reader<'_>, s: &mut S) -> Self {
                     $ity {
                         handle: handle::Handle::decode(r, s),
@@ -276,7 +276,7 @@ fn maybe_install_panic_hook(force_show_panics: bool) {
 /// Client-side helper for handling client panics, entering the bridge,
 /// deserializing input and serializing output.
 // FIXME(eddyb) maybe replace `Bridge::enter` with this?
-fn run_client<A: for<'a, 's> DecodeMut<'a, 's, ()>, R: Encode<()>>(
+fn run_client<A: for<'a, 's> Decode<'a, 's, ()>, R: Encode<()>>(
     config: BridgeConfig<'_>,
     f: impl FnOnce(A) -> R,
 ) -> Buffer {

--- a/library/proc_macro/src/bridge/mod.rs
+++ b/library/proc_macro/src/bridge/mod.rs
@@ -143,7 +143,7 @@ mod symbol;
 
 use buffer::Buffer;
 pub use rpc::PanicMessage;
-use rpc::{DecodeMut, Encode, Reader, Writer};
+use rpc::{Decode, Encode, Reader, Writer};
 
 /// Configuration for establishing an active connection between a server and a
 /// client.  The server creates the bridge config (`run_server` in `server.rs`),
@@ -168,7 +168,7 @@ impl !Sync for BridgeConfig<'_> {}
 #[forbid(unsafe_code)]
 #[allow(non_camel_case_types)]
 mod api_tags {
-    use super::rpc::{DecodeMut, Encode, Reader, Writer};
+    use super::rpc::{Decode, Encode, Reader, Writer};
 
     macro_rules! declare_tags {
         ($($name:ident {

--- a/library/proc_macro/src/bridge/rpc.rs
+++ b/library/proc_macro/src/bridge/rpc.rs
@@ -58,16 +58,11 @@ macro_rules! rpc_encode_decode {
             fn encode(self, w: &mut Writer, s: &mut S) {
                 // HACK(eddyb): `Tag` enum duplicated between the
                 // two impls as there's no other place to stash it.
-                #[allow(non_upper_case_globals)]
-                mod tag {
-                    #[repr(u8)] enum Tag { $($variant),* }
-
-                    $(pub(crate) const $variant: u8 = Tag::$variant as u8;)*
-                }
+                #[repr(u8)] enum Tag { $($variant),* }
 
                 match self {
                     $($name::$variant $(($field))* => {
-                        tag::$variant.encode(w, s);
+                        (Tag::$variant as u8).encode(w, s);
                         $($field.encode(w, s);)*
                     })*
                 }

--- a/library/proc_macro/src/bridge/rpc.rs
+++ b/library/proc_macro/src/bridge/rpc.rs
@@ -12,7 +12,7 @@ pub(super) trait Encode<S>: Sized {
 
 pub(super) type Reader<'a> = &'a [u8];
 
-pub(super) trait DecodeMut<'a, 's, S>: Sized {
+pub(super) trait Decode<'a, 's, S>: Sized {
     fn decode(r: &mut Reader<'a>, s: &'s mut S) -> Self;
 }
 
@@ -24,7 +24,7 @@ macro_rules! rpc_encode_decode {
             }
         }
 
-        impl<S> DecodeMut<'_, '_, S> for $ty {
+        impl<S> Decode<'_, '_, S> for $ty {
             fn decode(r: &mut Reader<'_>, _: &mut S) -> Self {
                 const N: usize = size_of::<$ty>();
 
@@ -43,12 +43,12 @@ macro_rules! rpc_encode_decode {
             }
         }
 
-        impl<'a, S, $($($T: for<'s> DecodeMut<'a, 's, S>),+)?> DecodeMut<'a, '_, S>
+        impl<'a, S, $($($T: for<'s> Decode<'a, 's, S>),+)?> Decode<'a, '_, S>
             for $name $(<$($T),+>)?
         {
             fn decode(r: &mut Reader<'a>, s: &mut S) -> Self {
                 $name {
-                    $($field: DecodeMut::decode(r, s)),*
+                    $($field: Decode::decode(r, s)),*
                 }
             }
         }
@@ -69,7 +69,7 @@ macro_rules! rpc_encode_decode {
             }
         }
 
-        impl<'a, S, $($($T: for<'s> DecodeMut<'a, 's, S>),+)?> DecodeMut<'a, '_, S>
+        impl<'a, S, $($($T: for<'s> Decode<'a, 's, S>),+)?> Decode<'a, '_, S>
             for $name $(<$($T),+>)?
         {
             fn decode(r: &mut Reader<'a>, s: &mut S) -> Self {
@@ -84,7 +84,7 @@ macro_rules! rpc_encode_decode {
 
                 match u8::decode(r, s) {
                     $(tag::$variant => {
-                        $(let $field = DecodeMut::decode(r, s);)*
+                        $(let $field = Decode::decode(r, s);)*
                         $name::$variant $(($field))*
                     })*
                     _ => unreachable!(),
@@ -98,7 +98,7 @@ impl<S> Encode<S> for () {
     fn encode(self, _: &mut Writer, _: &mut S) {}
 }
 
-impl<S> DecodeMut<'_, '_, S> for () {
+impl<S> Decode<'_, '_, S> for () {
     fn decode(_: &mut Reader<'_>, _: &mut S) -> Self {}
 }
 
@@ -108,7 +108,7 @@ impl<S> Encode<S> for u8 {
     }
 }
 
-impl<S> DecodeMut<'_, '_, S> for u8 {
+impl<S> Decode<'_, '_, S> for u8 {
     fn decode(r: &mut Reader<'_>, _: &mut S) -> Self {
         let x = r[0];
         *r = &r[1..];
@@ -125,7 +125,7 @@ impl<S> Encode<S> for bool {
     }
 }
 
-impl<S> DecodeMut<'_, '_, S> for bool {
+impl<S> Decode<'_, '_, S> for bool {
     fn decode(r: &mut Reader<'_>, s: &mut S) -> Self {
         match u8::decode(r, s) {
             0 => false,
@@ -141,7 +141,7 @@ impl<S> Encode<S> for char {
     }
 }
 
-impl<S> DecodeMut<'_, '_, S> for char {
+impl<S> Decode<'_, '_, S> for char {
     fn decode(r: &mut Reader<'_>, s: &mut S) -> Self {
         char::from_u32(u32::decode(r, s)).unwrap()
     }
@@ -153,7 +153,7 @@ impl<S> Encode<S> for NonZero<u32> {
     }
 }
 
-impl<S> DecodeMut<'_, '_, S> for NonZero<u32> {
+impl<S> Decode<'_, '_, S> for NonZero<u32> {
     fn decode(r: &mut Reader<'_>, s: &mut S) -> Self {
         Self::new(u32::decode(r, s)).unwrap()
     }
@@ -166,11 +166,11 @@ impl<S, A: Encode<S>, B: Encode<S>> Encode<S> for (A, B) {
     }
 }
 
-impl<'a, S, A: for<'s> DecodeMut<'a, 's, S>, B: for<'s> DecodeMut<'a, 's, S>> DecodeMut<'a, '_, S>
+impl<'a, S, A: for<'s> Decode<'a, 's, S>, B: for<'s> Decode<'a, 's, S>> Decode<'a, '_, S>
     for (A, B)
 {
     fn decode(r: &mut Reader<'a>, s: &mut S) -> Self {
-        (DecodeMut::decode(r, s), DecodeMut::decode(r, s))
+        (Decode::decode(r, s), Decode::decode(r, s))
     }
 }
 
@@ -181,7 +181,7 @@ impl<S> Encode<S> for &[u8] {
     }
 }
 
-impl<'a, S> DecodeMut<'a, '_, S> for &'a [u8] {
+impl<'a, S> Decode<'a, '_, S> for &'a [u8] {
     fn decode(r: &mut Reader<'a>, s: &mut S) -> Self {
         let len = usize::decode(r, s);
         let xs = &r[..len];
@@ -196,7 +196,7 @@ impl<S> Encode<S> for &str {
     }
 }
 
-impl<'a, S> DecodeMut<'a, '_, S> for &'a str {
+impl<'a, S> Decode<'a, '_, S> for &'a str {
     fn decode(r: &mut Reader<'a>, s: &mut S) -> Self {
         str::from_utf8(<&[u8]>::decode(r, s)).unwrap()
     }
@@ -208,7 +208,7 @@ impl<S> Encode<S> for String {
     }
 }
 
-impl<S> DecodeMut<'_, '_, S> for String {
+impl<S> Decode<'_, '_, S> for String {
     fn decode(r: &mut Reader<'_>, s: &mut S) -> Self {
         <&str>::decode(r, s).to_string()
     }
@@ -223,7 +223,7 @@ impl<S, T: Encode<S>> Encode<S> for Vec<T> {
     }
 }
 
-impl<'a, S, T: for<'s> DecodeMut<'a, 's, S>> DecodeMut<'a, '_, S> for Vec<T> {
+impl<'a, S, T: for<'s> Decode<'a, 's, S>> Decode<'a, '_, S> for Vec<T> {
     fn decode(r: &mut Reader<'a>, s: &mut S) -> Self {
         let len = usize::decode(r, s);
         let mut vec = Vec::with_capacity(len);
@@ -283,7 +283,7 @@ impl<S> Encode<S> for PanicMessage {
     }
 }
 
-impl<S> DecodeMut<'_, '_, S> for PanicMessage {
+impl<S> Decode<'_, '_, S> for PanicMessage {
     fn decode(r: &mut Reader<'_>, s: &mut S) -> Self {
         match Option::<String>::decode(r, s) {
             Some(s) => PanicMessage::String(s),

--- a/library/proc_macro/src/bridge/selfless_reify.rs
+++ b/library/proc_macro/src/bridge/selfless_reify.rs
@@ -50,7 +50,7 @@ macro_rules! define_reify_functions {
         >(f: F) -> $(extern $abi)? fn($($arg_ty),*) -> $ret_ty {
             // FIXME(eddyb) describe the `F` type (e.g. via `type_name::<F>`) once panic
             // formatting becomes possible in `const fn`.
-            assert!(size_of::<F>() == 0, "selfless_reify: closure must be zero-sized");
+            const { assert!(size_of::<F>() == 0, "selfless_reify: closure must be zero-sized"); }
 
             $(extern $abi)? fn wrapper<
                 $($($param,)*)?

--- a/library/proc_macro/src/bridge/server.rs
+++ b/library/proc_macro/src/bridge/server.rs
@@ -32,7 +32,7 @@ macro_rules! define_server_handles {
                 }
             }
 
-            impl<S: Types> DecodeMut<'_, '_, HandleStore<MarkedTypes<S>>>
+            impl<S: Types> Decode<'_, '_, HandleStore<MarkedTypes<S>>>
                 for Marked<S::$oty, client::$oty>
             {
                 fn decode(r: &mut Reader<'_>, s: &mut HandleStore<MarkedTypes<S>>) -> Self {
@@ -40,7 +40,7 @@ macro_rules! define_server_handles {
                 }
             }
 
-            impl<'s, S: Types> DecodeMut<'_, 's, HandleStore<MarkedTypes<S>>>
+            impl<'s, S: Types> Decode<'_, 's, HandleStore<MarkedTypes<S>>>
                 for &'s Marked<S::$oty, client::$oty>
             {
                 fn decode(r: &mut Reader<'_>, s: &'s mut HandleStore<MarkedTypes<S>>) -> Self {
@@ -48,7 +48,7 @@ macro_rules! define_server_handles {
                 }
             }
 
-            impl<'s, S: Types> DecodeMut<'_, 's, HandleStore<MarkedTypes<S>>>
+            impl<'s, S: Types> Decode<'_, 's, HandleStore<MarkedTypes<S>>>
                 for &'s mut Marked<S::$oty, client::$oty>
             {
                 fn decode(
@@ -67,7 +67,7 @@ macro_rules! define_server_handles {
                 }
             }
 
-            impl<S: Types> DecodeMut<'_, '_, HandleStore<MarkedTypes<S>>>
+            impl<S: Types> Decode<'_, '_, HandleStore<MarkedTypes<S>>>
                 for Marked<S::$ity, client::$ity>
             {
                 fn decode(r: &mut Reader<'_>, s: &mut HandleStore<MarkedTypes<S>>) -> Self {
@@ -355,7 +355,7 @@ pub trait MessagePipe<T>: Sized {
 fn run_server<
     S: Server,
     I: Encode<HandleStore<MarkedTypes<S>>>,
-    O: for<'a, 's> DecodeMut<'a, 's, HandleStore<MarkedTypes<S>>>,
+    O: for<'a, 's> Decode<'a, 's, HandleStore<MarkedTypes<S>>>,
 >(
     strategy: &impl ExecutionStrategy,
     handle_counters: &'static client::HandleCounters,

--- a/library/proc_macro/src/bridge/symbol.rs
+++ b/library/proc_macro/src/bridge/symbol.rs
@@ -102,7 +102,7 @@ impl<S> Encode<S> for Symbol {
     }
 }
 
-impl<S: server::Server> DecodeMut<'_, '_, server::HandleStore<server::MarkedTypes<S>>>
+impl<S: server::Server> Decode<'_, '_, server::HandleStore<server::MarkedTypes<S>>>
     for Marked<S::Symbol, Symbol>
 {
     fn decode(r: &mut Reader<'_>, s: &mut server::HandleStore<server::MarkedTypes<S>>) -> Self {
@@ -118,7 +118,7 @@ impl<S: server::Server> Encode<server::HandleStore<server::MarkedTypes<S>>>
     }
 }
 
-impl<S> DecodeMut<'_, '_, S> for Symbol {
+impl<S> Decode<'_, '_, S> for Symbol {
     fn decode(r: &mut Reader<'_>, s: &mut S) -> Self {
         Symbol::new(<&str>::decode(r, s))
     }


### PR DESCRIPTION
Followup to rust-lang/rust#147386, which removed the old `Decode` trait.
Can be reviewed commit by commit.
