### PR TITLE
Implement round-ties-to-even for Duration Debug for consistency with f64

### DIFF
--- a/library/core/src/time.rs
+++ b/library/core/src/time.rs
@@ -1315,9 +1315,12 @@ impl fmt::Debug for Duration {
             // need to perform rounding to match the semantics of printing
             // normal floating point numbers. However, we only need to do work
             // when rounding up. This happens if the first digit of the
-            // remaining ones is > 5. When the first  digit is exactly 5, rounding
-            // follows IEEE-754 round-ties-to-even semantics.
-            let integer_part = if fractional_part > 0 && fractional_part == divisor * 5 {
+            // remaining ones is >= 5. When the first digit is exactly 5, rounding
+            // follows IEEE-754 round-ties-to-even semantics: we only round up
+            // if the last written digit is odd.
+            let integer_part = if fractional_part > 0 && fractional_part >= divisor * 5 {
+                // For ties (fractional_part == divisor * 5), only round up if last digit is odd
+                let is_tie = fractional_part == divisor * 5;
                 let last_digit_is_odd = if pos > 0 {
                     (buf[pos - 1] - b'0') % 2 == 1
                 } else {
@@ -1325,12 +1328,20 @@ impl fmt::Debug for Duration {
                     (integer_part % 2) == 1
                 };
 
-                if last_digit_is_odd {
+                if is_tie && !last_digit_is_odd {
+                    Some(integer_part)
+                } else {
+                    // Round up the number contained in the buffer. We go through
+                    // the buffer backwards and keep track of the carry.
                     let mut rev_pos = pos;
                     let mut carry = true;
                     while carry && rev_pos > 0 {
                         rev_pos -= 1;
 
+                        // If the digit in the buffer is not '9', we just need to
+                        // increment it and can stop then (since we don't have a
+                        // carry anymore). Otherwise, we set it to '0' (overflow)
+                        // and continue.
                         if buf[rev_pos] < b'9' {
                             buf[rev_pos] += 1;
                             carry = false;
@@ -1339,42 +1350,19 @@ impl fmt::Debug for Duration {
                         }
                     }
 
-                    if carry { integer_part.checked_add(1) } else { Some(integer_part) }
-                } else {
-                    Some(integer_part)
-                }
-            } else if fractional_part > 0 && fractional_part > divisor * 5 {
-                // Round up the number contained in the buffer. We go through
-                // the buffer backwards and keep track of the carry.
-                let mut rev_pos = pos;
-                let mut carry = true;
-                while carry && rev_pos > 0 {
-                    rev_pos -= 1;
-
-                    // If the digit in the buffer is not '9', we just need to
-                    // increment it and can stop then (since we don't have a
-                    // carry anymore). Otherwise, we set it to '0' (overflow)
-                    // and continue.
-                    if buf[rev_pos] < b'9' {
-                        buf[rev_pos] += 1;
-                        carry = false;
+                    // If we still have the carry bit set, that means that we set
+                    // the whole buffer to '0's and need to increment the integer
+                    // part.
+                    if carry {
+                        // If `integer_part == u64::MAX` and precision < 9, any
+                        // carry of the overflow during rounding of the
+                        // `fractional_part` into the `integer_part` will cause the
+                        // `integer_part` itself to overflow. Avoid this by using an
+                        // `Option<u64>`, with `None` representing `u64::MAX + 1`.
+                        integer_part.checked_add(1)
                     } else {
-                        buf[rev_pos] = b'0';
+                        Some(integer_part)
                     }
-                }
-
-                // If we still have the carry bit set, that means that we set
-                // the whole buffer to '0's and need to increment the integer
-                // part.
-                if carry {
-                    // If `integer_part == u64::MAX` and precision < 9, any
-                    // carry of the overflow during rounding of the
-                    // `fractional_part` into the `integer_part` will cause the
-                    // `integer_part` itself to overflow. Avoid this by using an
-                    // `Option<u64>`, with `None` representing `u64::MAX + 1`.
-                    integer_part.checked_add(1)
-                } else {
-                    Some(integer_part)
                 }
             } else {
                 Some(integer_part)

--- a/library/core/src/time.rs
+++ b/library/core/src/time.rs
@@ -1315,7 +1315,8 @@ impl fmt::Debug for Duration {
             // need to perform rounding to match the semantics of printing
             // normal floating point numbers. However, we only need to do work
             // when rounding up. This happens if the first digit of the
-            // remaining ones is >= 5.
+            // remaining ones is > 5. When the first  digit is exactly 5, rounding
+            // follows IEEE-754 round-ties-to-even semantics.
             let integer_part = if fractional_part > 0 && fractional_part == divisor * 5 {
                 let last_digit_is_odd = if pos > 0 {
                     (buf[pos - 1] - b'0') % 2 == 1

--- a/library/coretests/tests/time.rs
+++ b/library/coretests/tests/time.rs
@@ -439,7 +439,6 @@ fn debug_formatting_precision_two() {
     assert_eq!(format!("{:.2?}", Duration::new(4, 001_000_000)), "4.00s");
     assert_eq!(format!("{:.2?}", Duration::new(2, 100_000_000)), "2.10s");
     assert_eq!(format!("{:.2?}", Duration::new(2, 104_990_000)), "2.10s");
-    assert_eq!(format!("{:.2?}", Duration::new(2, 105_000_000)), "2.11s");
     assert_eq!(format!("{:.2?}", Duration::new(8, 999_999_999)), "9.00s");
 }
 
@@ -478,6 +477,15 @@ fn debug_formatting_precision_high() {
     assert_eq!(format!("{:.9?}", Duration::new(1, 000_000_000)), "1.000000000s");
     assert_eq!(format!("{:.10?}", Duration::new(4, 001_000_000)), "4.0010000000s");
     assert_eq!(format!("{:.20?}", Duration::new(4, 001_000_000)), "4.00100000000000000000s");
+}
+
+#[test]
+fn debug_formatting_round_to_even() {
+    assert_eq!(format!("{:.0?}", Duration::new(1, 500_000_000)), "2s");
+    assert_eq!(format!("{:.0?}", Duration::new(2, 500_000_000)), "2s");
+    assert_eq!(format!("{:.0?}", Duration::new(0, 1_500_000)), "2ms");
+    assert_eq!(format!("{:.0?}", Duration::new(0, 2_500_000)), "2ms");
+    assert_eq!(format!("{:.2?}", Duration::new(2, 105_000_000)), "2.10s");
 }
 
 #[test]


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

## Summary

This PR proposes a fix for rust-lang/rust#103747 implementing IEEE-754 S4.3 roundTiesToEven for Duration Debug implementation.

## Testing

Added new test in `time.rs` for  validating roundTiesToEven behavior in Duration formatting. Reran all debug formatting tests in `time.rs` with `./x test library/coretests --test-args time::debug_formatting`.


