### PR TITLE
Split overlapping_{inherent,trait}_impls

### DIFF
--- a/compiler/rustc_hir_analysis/src/coherence/inherent_impls_overlap.rs
+++ b/compiler/rustc_hir_analysis/src/coherence/inherent_impls_overlap.rs
@@ -154,7 +154,7 @@ impl<'tcx> InherentOverlapChecker<'tcx> {
         impl1_def_id: DefId,
         impl2_def_id: DefId,
     ) -> Result<(), ErrorGuaranteed> {
-        let maybe_overlap = traits::overlapping_impls(
+        let maybe_overlap = traits::overlapping_inherent_impls(
             self.tcx,
             impl1_def_id,
             impl2_def_id,

--- a/compiler/rustc_trait_selection/src/traits/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/mod.rs
@@ -42,7 +42,8 @@ use tracing::{debug, instrument};
 
 pub use self::coherence::{
     InCrate, IsFirstInputType, OrphanCheckErr, OrphanCheckMode, OverlapResult, UncoveredTyParams,
-    add_placeholder_note, orphan_check_trait_ref, overlapping_impls,
+    add_placeholder_note, orphan_check_trait_ref, overlapping_inherent_impls,
+    overlapping_trait_impls,
 };
 pub use self::dyn_compatibility::{
     DynCompatibilityViolation, dyn_compatibility_violations_for_assoc_item,

--- a/compiler/rustc_trait_selection/src/traits/specialize/specialization_graph.rs
+++ b/compiler/rustc_trait_selection/src/traits/specialize/specialization_graph.rs
@@ -113,7 +113,7 @@ impl<'tcx> Children {
                 // Found overlap, but no specialization; error out or report future-compat warning.
 
                 // Do we *still* get overlap if we disable the future-incompatible modes?
-                let should_err = traits::overlapping_impls(
+                let should_err = traits::overlapping_trait_impls(
                     tcx,
                     possible_sibling,
                     impl_def_id,
@@ -137,7 +137,7 @@ impl<'tcx> Children {
             };
 
             let last_lint_mut = &mut last_lint;
-            let (le, ge) = traits::overlapping_impls(
+            let (le, ge) = traits::overlapping_trait_impls(
                 tcx,
                 possible_sibling,
                 impl_def_id,


### PR DESCRIPTION
This yielded some perf improvement for me. Reduces some calls to `impl_trait_header` query. But I think the llvm optimization is more relevant.