### PR TITLE
is_doc_hidden optimized to hook in case of non-incremental build

### DIFF
--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -968,6 +968,11 @@ pub fn create_and_enter_global_ctxt<T, F: for<'tcx> FnOnce(TyCtxt<'tcx>) -> T>(
 
     let incremental = dep_graph.is_fully_enabled();
 
+    // is_doc_hidden hook is reset to query call for incremental build (fallback for optimization)
+    if incremental {
+        providers.hooks.is_doc_hidden = |tcx, def_id| tcx.is_doc_hidden_q(def_id);
+    }
+
     // Note: this function body is the origin point of the widely-used 'tcx lifetime.
     //
     // `gcx_cell` is defined here and `&gcx_cell` is passed to `create_global_ctxt`, which then

--- a/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
@@ -4,8 +4,9 @@ use std::sync::Arc;
 
 use rustc_hir::attrs::Deprecation;
 use rustc_hir::def::{CtorKind, DefKind};
-use rustc_hir::def_id::{CrateNum, DefId, DefIdMap, LOCAL_CRATE};
+use rustc_hir::def_id::{CrateNum, DefId, DefIdMap, LOCAL_CRATE, LocalDefId};
 use rustc_hir::definitions::{DefKey, DefPath, DefPathHash};
+use rustc_hir::find_attr;
 use rustc_middle::arena::ArenaAllocatable;
 use rustc_middle::bug;
 use rustc_middle::metadata::{AmbigModChild, ModChild};
@@ -408,7 +409,7 @@ provide! { tcx, def_id, other, cdata,
     crate_extern_paths => { cdata.source().paths().cloned().collect() }
     expn_that_defined => { cdata.get_expn_that_defined(tcx, def_id.index) }
     default_field => { cdata.get_default_field(tcx, def_id.index) }
-    is_doc_hidden => { cdata.get_attr_flags(def_id.index).contains(AttrFlags::IS_DOC_HIDDEN) }
+    is_doc_hidden_q => { cdata.get_attr_flags(def_id.index).contains(AttrFlags::IS_DOC_HIDDEN) }
     doc_link_resolutions => { tcx.arena.alloc(cdata.get_doc_link_resolutions(tcx, def_id.index)) }
     doc_link_traits_in_scope => {
         tcx.arena.alloc_from_iter(cdata.get_doc_link_traits_in_scope(tcx, def_id.index))
@@ -723,6 +724,24 @@ impl CrateStore for CStore {
     }
 }
 
+/// Determines whether an item is directly annotated with `doc(hidden)`.
+fn is_doc_hidden_local(tcx: TyCtxt<'_>, def_id: LocalDefId) -> bool {
+    find_attr!(tcx, def_id, Doc(doc) if doc.hidden.is_some())
+}
+
+// Optimization of is_doc_hidden query in case of non-incremental build.
+// is_doc_hidden query itself renamed into is_doc_hidden_q.
+#[inline]
+fn is_doc_hidden(tcx: TyCtxt<'_>, def_id: DefId) -> bool {
+    if let Some(local) = def_id.as_local() {
+        is_doc_hidden_local(tcx, local)
+    } else {
+        let cstore = CStore::from_tcx(tcx);
+        let cdata = cstore.get_crate_data(def_id.krate);
+        cdata.get_attr_flags(def_id.index).contains(AttrFlags::IS_DOC_HIDDEN)
+    }
+}
+
 fn provide_cstore_hooks(providers: &mut Providers) {
     providers.hooks.def_path_hash_to_def_id_extern = |tcx, hash, stable_crate_id| {
         // If this is a DefPathHash from an upstream crate, let the CrateStore map
@@ -750,4 +769,6 @@ fn provide_cstore_hooks(providers: &mut Providers) {
             cdata.imported_source_file(tcx, file_index as u32);
         }
     };
+    providers.hooks.is_doc_hidden = is_doc_hidden;
+    providers.queries.is_doc_hidden_q = is_doc_hidden_local;
 }

--- a/compiler/rustc_middle/src/hooks/mod.rs
+++ b/compiler/rustc_middle/src/hooks/mod.rs
@@ -113,6 +113,9 @@ declare_hooks! {
 
     /// Serializes all eligible query return values into the on-disk cache.
     hook encode_query_values(encoder: &mut CacheEncoder<'_, 'tcx>) -> ();
+
+    /// Determines whether an item is annotated with `#[doc(hidden)]`.
+    hook is_doc_hidden(def_id: DefId) -> bool;
 }
 
 #[cold]

--- a/compiler/rustc_middle/src/queries.rs
+++ b/compiler/rustc_middle/src/queries.rs
@@ -1506,7 +1506,7 @@ rustc_queries! {
     }
 
     /// Determines whether an item is annotated with `#[doc(hidden)]`.
-    query is_doc_hidden(def_id: DefId) -> bool {
+    query is_doc_hidden_q(def_id: DefId) -> bool {
         desc { "checking whether `{}` is `doc(hidden)`", tcx.def_path_str(def_id) }
         separate_provide_extern
     }

--- a/compiler/rustc_middle/src/ty/util.rs
+++ b/compiler/rustc_middle/src/ty/util.rs
@@ -1679,11 +1679,6 @@ pub fn reveal_opaque_types_in_bounds<'tcx>(
     val.fold_with(&mut visitor)
 }
 
-/// Determines whether an item is directly annotated with `doc(hidden)`.
-fn is_doc_hidden(tcx: TyCtxt<'_>, def_id: LocalDefId) -> bool {
-    find_attr!(tcx, def_id, Doc(doc) if doc.hidden.is_some())
-}
-
 /// Determines whether an item is annotated with `doc(notable_trait)`.
 pub fn is_doc_notable_trait(tcx: TyCtxt<'_>, def_id: DefId) -> bool {
     find_attr!(tcx, def_id, Doc(doc) if doc.notable_trait.is_some())
@@ -1715,7 +1710,6 @@ pub fn intrinsic_raw(tcx: TyCtxt<'_>, def_id: LocalDefId) -> Option<ty::Intrinsi
 pub fn provide(providers: &mut Providers) {
     *providers = Providers {
         reveal_opaque_types_in_bounds,
-        is_doc_hidden,
         is_doc_notable_trait,
         intrinsic_raw,
         ..*providers

--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -386,7 +386,7 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
             .unwrap_or(target_def_id);
         item_def_id != import_def_id
             && self.cx.cache.effective_visibilities.is_directly_public(tcx, item_def_id.to_def_id())
-            && !tcx.is_doc_hidden(item_def_id)
+            && !tcx.is_doc_hidden(item_def_id.to_def_id())
             && !inherits_doc_hidden(tcx, item_def_id, None)
     }
 

--- a/src/tools/clippy/clippy_lints/src/macro_metavars_in_unsafe.rs
+++ b/src/tools/clippy/clippy_lints/src/macro_metavars_in_unsafe.rs
@@ -148,7 +148,7 @@ struct BodyVisitor<'a, 'tcx> {
 
 fn is_public_macro(cx: &LateContext<'_>, def_id: LocalDefId) -> bool {
     (cx.effective_visibilities.is_exported(def_id) || find_attr!(cx.tcx, def_id, MacroExport { .. }))
-        && !cx.tcx.is_doc_hidden(def_id)
+        && !cx.tcx.is_doc_hidden(def_id.to_def_id())
 }
 
 impl<'tcx> Visitor<'tcx> for BodyVisitor<'_, 'tcx> {

--- a/src/tools/clippy/clippy_lints/src/new_without_default.rs
+++ b/src/tools/clippy/clippy_lints/src/new_without_default.rs
@@ -84,7 +84,7 @@ impl<'tcx> LateLintPass<'tcx> for NewWithoutDefault {
                 // can't be implemented for unsafe new
                 && !sig.header.is_unsafe()
                 // shouldn't be implemented when it is hidden in docs
-                && !cx.tcx.is_doc_hidden(impl_item.owner_id.def_id)
+                && !cx.tcx.is_doc_hidden(impl_item.owner_id.def_id.to_def_id())
                 // when the result of `new()` depends on a parameter we should not require
                 // an impl of `Default`
                 && impl_item.generics.params.is_empty()


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/147511)*
<!-- homu-ignore:end -->

<!-- homu-ignore:start -->
<!--
-->
<!-- homu-ignore:end -->
Continuation of rust-lang/rust#146880, rust-lang/rust#147232 and rust-lang/rust#147387.

'is_doc_hidden' query renamed 'is_doc_hidden_q'. is_doc_hidden hook added to optimize performance in case of non-incremental build.

Optimization may be profitable for queries with low normalized average execution time (to replace cache lookup into inlined call) and be significant with good cache_hits.
| Query | cache_hits | min_ns | max_ns | avg_ns_norm |
| ------------- | ------------- | ------------- | ------------- | ------------- |
source_span | 11361 | 18 | 2991 | 66
hir_owner_parent | 5773 | 52 | 1773 | 163
**\*is_doc_hidden\*** | 3134 | 47 | 1111 | 285
lookup_deprecation_entry | 13905 | 36 | 6208 | 287
object_lifetime_default | 5840 | 63 | 4688 | 290
upvars_mentioned | 2575 | 75 | 7722 | 322
intrinsic_raw | 21235 | 73 | 3453 | 367

Draft PR to measure performance changes.