### PR TITLE
Update LLVM to 21.1.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,6 +246,8 @@ jobs:
         run: src/ci/scripts/create-doc-artifacts.sh
 
       - name: print disk usage
+        # We also want to know the disk usage when the job fails.
+        if: always()
         run: |
           echo "disk usage:"
           df -h

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -3262,6 +3262,8 @@ fn distcheck_plain_source_tarball(builder: &Builder<'_>, plain_src_dir: &Path) {
         .env("GITHUB_ACTIONS", "0")
         .current_dir(plain_src_dir)
         .run(builder);
+    // Mitigate pressure on small-capacity disks.
+    builder.remove_dir(plain_src_dir);
 }
 
 /// Check that rust-src has all of libstd's dependencies
@@ -3287,6 +3289,8 @@ fn distcheck_rust_src(builder: &Builder<'_>, src_dir: &Path) {
         .arg(&toml)
         .current_dir(src_dir)
         .run(builder);
+    // Mitigate pressure on small-capacity disks.
+    builder.remove_dir(src_dir);
 }
 
 /// Check that rustc-dev's compiler crate source code can be loaded with `cargo metadata`
@@ -3311,6 +3315,8 @@ fn distcheck_rustc_dev(builder: &Builder<'_>, dir: &Path) {
         .env("RUSTC", &builder.initial_rustc)
         .current_dir(dir)
         .run(builder);
+    // Mitigate pressure on small-capacity disks.
+    builder.remove_dir(dir);
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/146742.

After rust-lang/rust#146124, we need more space to run x86_64-gnu-distcheck if building LLVM from source. According to the building log, the space freed by `free-disk-space-linux.sh` is not entirely available.

```
You are running out of disk space. 
The runner will stop working when the machine runs out of disk space. 
Free space left: 98 MB

disk usage:
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        72G   43G   29G  60% /
tmpfs           7.9G   84K  7.9G   1% /dev/shm
tmpfs           3.2G  1.2M  3.2G   1% /run
tmpfs           5.0M     0  5.0M   0% /run/lock
/dev/sda16      881M   60M  760M   8% /boot
/dev/sda15      105M  6.2M   99M   6% /boot/efi
/dev/sdb1        74G   28K   70G   1% /mnt
tmpfs           1.6G   12K  1.6G   1% /run/user/1001
```