### PR TITLE
Port the remaining SIMD intrinsics to const-eval

### DIFF
--- a/compiler/rustc_const_eval/src/interpret/intrinsics/simd.rs
+++ b/compiler/rustc_const_eval/src/interpret/intrinsics/simd.rs
@@ -134,20 +134,11 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                                     intrinsic_name
                                 )
                             };
+                            let op = op.to_scalar();
                             match float_ty {
                                 FloatTy::F16 => unimplemented!("f16_f128"),
-                                FloatTy::F32 => {
-                                    let f = op.to_scalar().to_f32()?;
-                                    let res = f.round_to_integral(rounding).value;
-                                    let res = self.adjust_nan(res, &[f]);
-                                    Scalar::from_f32(res)
-                                }
-                                FloatTy::F64 => {
-                                    let f = op.to_scalar().to_f64()?;
-                                    let res = f.round_to_integral(rounding).value;
-                                    let res = self.adjust_nan(res, &[f]);
-                                    Scalar::from_f64(res)
-                                }
+                                FloatTy::F32 => self.float_round::<Single>(op, rounding)?,
+                                FloatTy::F64 => self.float_round::<Double>(op, rounding)?,
                                 FloatTy::F128 => unimplemented!("f16_f128"),
                             }
                         }

--- a/compiler/rustc_const_eval/src/interpret/intrinsics/simd.rs
+++ b/compiler/rustc_const_eval/src/interpret/intrinsics/simd.rs
@@ -1,6 +1,6 @@
 use either::Either;
 use rustc_abi::Endian;
-use rustc_apfloat::ieee::{Double, Single};
+use rustc_apfloat::ieee::{Double, Half, Quad, Single};
 use rustc_apfloat::{Float, Round};
 use rustc_middle::mir::interpret::{InterpErrorKind, UndefinedBehaviorInfo};
 use rustc_middle::ty::FloatTy;
@@ -120,10 +120,10 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                             let op = op.to_scalar();
                             // "Bitwise" operation, no NaN adjustments
                             match float_ty {
-                                FloatTy::F16 => unimplemented!("f16_f128"),
+                                FloatTy::F16 => Scalar::from_f16(op.to_f16()?.abs()),
                                 FloatTy::F32 => Scalar::from_f32(op.to_f32()?.abs()),
                                 FloatTy::F64 => Scalar::from_f64(op.to_f64()?.abs()),
-                                FloatTy::F128 => unimplemented!("f16_f128"),
+                                FloatTy::F128 => Scalar::from_f128(op.to_f128()?.abs()),
                             }
                         }
                         Op::Round(rounding) => {
@@ -136,10 +136,10 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                             };
                             let op = op.to_scalar();
                             match float_ty {
-                                FloatTy::F16 => unimplemented!("f16_f128"),
+                                FloatTy::F16 => self.float_round::<Half>(op, rounding)?,
                                 FloatTy::F32 => self.float_round::<Single>(op, rounding)?,
                                 FloatTy::F64 => self.float_round::<Double>(op, rounding)?,
-                                FloatTy::F128 => unimplemented!("f16_f128"),
+                                FloatTy::F128 => self.float_round::<Quad>(op, rounding)?,
                             }
                         }
                         Op::Numeric(name) => {
@@ -716,10 +716,10 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                     };
 
                     let val = match float_ty {
-                        FloatTy::F16 => unimplemented!("f16_f128"),
+                        FloatTy::F16 => self.float_muladd::<Half>(a, b, c, typ)?,
                         FloatTy::F32 => self.float_muladd::<Single>(a, b, c, typ)?,
                         FloatTy::F64 => self.float_muladd::<Double>(a, b, c, typ)?,
-                        FloatTy::F128 => unimplemented!("f16_f128"),
+                        FloatTy::F128 => self.float_muladd::<Quad>(a, b, c, typ)?,
                     };
                     self.write_scalar(val, &dest)?;
                 }
@@ -747,10 +747,10 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         let left = left.to_scalar();
         let right = right.to_scalar();
         interp_ok(match float_ty {
-            FloatTy::F16 => unimplemented!("f16_f128"),
+            FloatTy::F16 => self.float_minmax::<Half>(left, right, op)?,
             FloatTy::F32 => self.float_minmax::<Single>(left, right, op)?,
             FloatTy::F64 => self.float_minmax::<Double>(left, right, op)?,
-            FloatTy::F128 => unimplemented!("f16_f128"),
+            FloatTy::F128 => self.float_minmax::<Quad>(left, right, op)?,
         })
     }
 }

--- a/compiler/rustc_const_eval/src/interpret/machine.rs
+++ b/compiler/rustc_const_eval/src/interpret/machine.rs
@@ -290,7 +290,7 @@ pub trait Machine<'tcx>: Sized {
     }
 
     /// Determines whether the `fmuladd` intrinsics fuse the multiply-add or use separate operations.
-    fn float_fuse_mul_add(_ecx: &mut InterpCx<'tcx, Self>) -> bool;
+    fn float_fuse_mul_add(_ecx: &InterpCx<'tcx, Self>) -> bool;
 
     /// Called before a basic block terminator is executed.
     #[inline]
@@ -676,7 +676,7 @@ pub macro compile_time_machine(<$tcx: lifetime>) {
     }
 
     #[inline(always)]
-    fn float_fuse_mul_add(_ecx: &mut InterpCx<$tcx, Self>) -> bool {
+    fn float_fuse_mul_add(_ecx: &InterpCx<$tcx, Self>) -> bool {
         true
     }
 

--- a/src/tools/miri/src/machine.rs
+++ b/src/tools/miri/src/machine.rs
@@ -1324,8 +1324,8 @@ impl<'tcx> Machine<'tcx> for MiriMachine<'tcx> {
     }
 
     #[inline(always)]
-    fn float_fuse_mul_add(ecx: &mut InterpCx<'tcx, Self>) -> bool {
-        ecx.machine.float_nondet && ecx.machine.rng.get_mut().random()
+    fn float_fuse_mul_add(ecx: &InterpCx<'tcx, Self>) -> bool {
+        ecx.machine.float_nondet && ecx.machine.rng.borrow_mut().random()
     }
 
     #[inline(always)]


### PR DESCRIPTION
successor to rust-lang/rust#146568, this refactors some implementations and ports the implementation of `simd_fma` and `simd_relaxed_fma`to `rustc_const_eval`

Also adds some remaining f16/f128 support in these intrinsics

r? @RalfJung