### PR TITLE
compiletest: Use the same directive lines for EarlyProps and ignore/only/needs

### DIFF
--- a/src/tools/compiletest/src/directives/file.rs
+++ b/src/tools/compiletest/src/directives/file.rs
@@ -1,0 +1,24 @@
+use camino::Utf8Path;
+
+use crate::directives::line::{DirectiveLine, line_directive};
+
+pub(crate) struct FileDirectives<'a> {
+    pub(crate) path: &'a Utf8Path,
+    pub(crate) lines: Vec<DirectiveLine<'a>>,
+}
+
+impl<'a> FileDirectives<'a> {
+    pub(crate) fn from_file_contents(path: &'a Utf8Path, file_contents: &'a str) -> Self {
+        let mut lines = vec![];
+
+        for (line_number, ln) in (1..).zip(file_contents.lines()) {
+            let ln = ln.trim();
+
+            if let Some(directive_line) = line_directive(line_number, ln) {
+                lines.push(directive_line);
+            }
+        }
+
+        Self { path, lines }
+    }
+}


### PR DESCRIPTION
Currently we load each discovered test file to scan it for directives once for EarlyProps parsing, then reload and scan it once *per revision* for ignore processing. If a revision is not ignored, we then reload and scan it again during actual execution.

That's a bit silly, so this PR tries to reduce the number of unnecessary file loads and line scans for directive parsing, by reusing the same collection of `DirectiveLine` values for EarlyProps and for each revision's ignores.

Each individual directive still needs to be re-parsed a bunch of times, but those steps can at least avoid scanning the whole file, or having to split out names from values.

---

There's more that could be done after this, such as only doing known-directive checks once per file, or embedding file paths in each `DirectiveLine`, but I decided to stop here to allow review in modest chunks.

r? jieyouxu