### PR TITLE
x86_64-bigint-helpers test: update test assertion to cover registers r8 and r9

### DIFF
--- a/tests/assembly-llvm/x86_64-bigint-helpers.rs
+++ b/tests/assembly-llvm/x86_64-bigint-helpers.rs
@@ -44,7 +44,7 @@ pub unsafe extern "sysv64" fn bigint_chain_borrowing_sub(
     n: usize,
     mut carry: bool,
 ) -> bool {
-    // CHECK: mov [[TEMP:r..]], qword ptr [rsi + 8*[[IND:r..]] + 8]
+    // CHECK: mov [[TEMP:r.+]], qword ptr [rsi + 8*[[IND:r.+]] + 8]
     // CHECK: sbb [[TEMP]], qword ptr [rdx + 8*[[IND]] + 8]
     // CHECK: mov qword ptr [rdi + 8*[[IND]] + 8], [[TEMP]]
     // CHECK: mov [[TEMP]], qword ptr [rsi + 8*[[IND]] + 16]


### PR DESCRIPTION
Adapts the test expectation to cover the case where a register like `r9` is chosen. Update is similar to the other such expectation in the previous function in the same test file.

Found by our experimental rust + LLVM @ HEAD bot:
https://buildkite.com/llvm-project/rust-llvm-integrate-prototype/builds/40528/steps/canvas?sid=0199c8d7-f65a-4bbc-8d7f-e62d4ddcc65e#0199c8d7-f7ab-464d-a0fd-b4b8862a11d3/1047-1175




r? durin42
@rustbot label: +llvm-main