### PR TITLE
Update t-compiler beta nomination Zulip msg

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -742,13 +742,15 @@ message_on_reopen = "PR #{number} has been reopened. Pinging @*T-rustdoc*."
 [notify-zulip."beta-nominated".compiler]
 required_labels = ["T-compiler"]
 zulip_stream = 474880 # #t-compiler/backports
-topic = "#{number}: beta-nominated"
+topic = "#{number}: beta-backport nomination"
 message_on_add = [
     """\
-@**channel** PR #{number} "{title}" has been nominated for beta backport.
+PR #{number} "{title}" fixes a regression.
+{recipients}, please evaluate nominating this PR for backport.
+The following poll is a vibe-check and not binding.
 """,
     """\
-/poll Approve beta backport of #{number}?
+/poll Should #{number} be beta backported?
 approve
 decline
 don't know


### PR DESCRIPTION
Sister patch of [triagebot#2191](https://github.com/rust-lang/triagebot/pull/2191)
Follow-up to rust-lang/rust#147263

The triagebot now triggers a different message when a PR is nominated for backport, making it look like more a suggestion to evaluate for the author/reviewers than a mandatory decision for the team to take.

The wording (as per [triagebot#2191](https://github.com/rust-lang/triagebot/pull/2191)) is open to suggestions.

Thanks