### PR TITLE
Renumber return local after state transform

### DIFF
--- a/tests/mir-opt/async_drop_live_dead.a-{closure#0}.coroutine_drop_async.0.panic-abort.mir
+++ b/tests/mir-opt/async_drop_live_dead.a-{closure#0}.coroutine_drop_async.0.panic-abort.mir
@@ -10,16 +10,16 @@ fn a::{closure#0}(_1: Pin<&mut {async fn body of a<T>()}>, _2: &mut Context<'_>)
     let mut _6: std::pin::Pin<&mut T>;
     let mut _7: &mut T;
     let mut _8: *mut T;
-    let mut _9: ();
-    let mut _10: std::task::Poll<()>;
-    let mut _11: &mut std::task::Context<'_>;
-    let mut _12: &mut impl std::future::Future<Output = ()>;
-    let mut _13: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
-    let mut _14: isize;
-    let mut _15: &mut std::task::Context<'_>;
-    let mut _16: &mut impl std::future::Future<Output = ()>;
-    let mut _17: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
-    let mut _18: isize;
+    let mut _9: std::task::Poll<()>;
+    let mut _10: &mut std::task::Context<'_>;
+    let mut _11: &mut impl std::future::Future<Output = ()>;
+    let mut _12: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
+    let mut _13: isize;
+    let mut _14: &mut std::task::Context<'_>;
+    let mut _15: &mut impl std::future::Future<Output = ()>;
+    let mut _16: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
+    let mut _17: isize;
+    let mut _18: ();
     let mut _19: u32;
     scope 1 {
         debug x => (((*(_1.0: &mut {async fn body of a<T>()})) as variant#4).0: T);
@@ -48,9 +48,9 @@ fn a::{closure#0}(_1: Pin<&mut {async fn body of a<T>()}>, _2: &mut Context<'_>)
     }
 
     bb4: {
-        StorageLive(_17);
-        _16 = &mut (((*(_1.0: &mut {async fn body of a<T>()})) as variant#4).1: impl std::future::Future<Output = ()>);
-        _17 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _16) -> [return: bb7, unwind unreachable];
+        StorageLive(_16);
+        _15 = &mut (((*(_1.0: &mut {async fn body of a<T>()})) as variant#4).1: impl std::future::Future<Output = ()>);
+        _16 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _15) -> [return: bb7, unwind unreachable];
     }
 
     bb5: {
@@ -58,13 +58,13 @@ fn a::{closure#0}(_1: Pin<&mut {async fn body of a<T>()}>, _2: &mut Context<'_>)
     }
 
     bb6: {
-        StorageDead(_17);
-        _18 = discriminant(_10);
-        switchInt(move _18) -> [0: bb1, 1: bb3, otherwise: bb5];
+        StorageDead(_16);
+        _17 = discriminant(_9);
+        switchInt(move _17) -> [0: bb1, 1: bb3, otherwise: bb5];
     }
 
     bb7: {
-        _10 = <impl Future<Output = ()> as Future>::poll(move _17, move _15) -> [return: bb6, unwind unreachable];
+        _9 = <impl Future<Output = ()> as Future>::poll(move _16, move _14) -> [return: bb6, unwind unreachable];
     }
 
     bb8: {

--- a/tests/mir-opt/async_drop_live_dead.a-{closure#0}.coroutine_drop_async.0.panic-unwind.mir
+++ b/tests/mir-opt/async_drop_live_dead.a-{closure#0}.coroutine_drop_async.0.panic-unwind.mir
@@ -10,16 +10,16 @@ fn a::{closure#0}(_1: Pin<&mut {async fn body of a<T>()}>, _2: &mut Context<'_>)
     let mut _6: std::pin::Pin<&mut T>;
     let mut _7: &mut T;
     let mut _8: *mut T;
-    let mut _9: ();
-    let mut _10: std::task::Poll<()>;
-    let mut _11: &mut std::task::Context<'_>;
-    let mut _12: &mut impl std::future::Future<Output = ()>;
-    let mut _13: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
-    let mut _14: isize;
-    let mut _15: &mut std::task::Context<'_>;
-    let mut _16: &mut impl std::future::Future<Output = ()>;
-    let mut _17: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
-    let mut _18: isize;
+    let mut _9: std::task::Poll<()>;
+    let mut _10: &mut std::task::Context<'_>;
+    let mut _11: &mut impl std::future::Future<Output = ()>;
+    let mut _12: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
+    let mut _13: isize;
+    let mut _14: &mut std::task::Context<'_>;
+    let mut _15: &mut impl std::future::Future<Output = ()>;
+    let mut _16: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
+    let mut _17: isize;
+    let mut _18: ();
     let mut _19: u32;
     scope 1 {
         debug x => (((*(_1.0: &mut {async fn body of a<T>()})) as variant#4).0: T);
@@ -62,9 +62,9 @@ fn a::{closure#0}(_1: Pin<&mut {async fn body of a<T>()}>, _2: &mut Context<'_>)
     }
 
     bb7: {
-        StorageLive(_17);
-        _16 = &mut (((*(_1.0: &mut {async fn body of a<T>()})) as variant#4).1: impl std::future::Future<Output = ()>);
-        _17 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _16) -> [return: bb10, unwind: bb15];
+        StorageLive(_16);
+        _15 = &mut (((*(_1.0: &mut {async fn body of a<T>()})) as variant#4).1: impl std::future::Future<Output = ()>);
+        _16 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _15) -> [return: bb10, unwind: bb15];
     }
 
     bb8: {
@@ -72,13 +72,13 @@ fn a::{closure#0}(_1: Pin<&mut {async fn body of a<T>()}>, _2: &mut Context<'_>)
     }
 
     bb9: {
-        StorageDead(_17);
-        _18 = discriminant(_10);
-        switchInt(move _18) -> [0: bb1, 1: bb6, otherwise: bb8];
+        StorageDead(_16);
+        _17 = discriminant(_9);
+        switchInt(move _17) -> [0: bb1, 1: bb6, otherwise: bb8];
     }
 
     bb10: {
-        _10 = <impl Future<Output = ()> as Future>::poll(move _17, move _15) -> [return: bb9, unwind: bb3];
+        _9 = <impl Future<Output = ()> as Future>::poll(move _16, move _14) -> [return: bb9, unwind: bb3];
     }
 
     bb11: {


### PR DESCRIPTION
The current implementation of `StateTransform` renames `_0` before analyzing liveness. This is inconsistent, as a `return` terminator hardcodes a read of `_0`.

This PR proposes to perform such rename *after* analyzing the body, in fact after the whole transform. The implementation is not much more complicated.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
