### PR TITLE
resolve: Use primitives for conditional mutability more consistently

### DIFF
--- a/compiler/rustc_resolve/src/build_reduced_graph.rs
+++ b/compiler/rustc_resolve/src/build_reduced_graph.rs
@@ -87,13 +87,12 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         // because they can be fetched by glob imports from those modules, and bring traits
         // into scope both directly and through glob imports.
         let key = BindingKey::new_disambiguated(ident, ns, || {
-            // FIXME(batched): Will be fixed in batched resolution.
             parent.underscore_disambiguator.update_unchecked(|d| d + 1);
             parent.underscore_disambiguator.get()
         });
         if self
             .resolution_or_default(parent, key)
-            .borrow_mut()
+            .borrow_mut_unchecked()
             .non_glob_binding
             .replace(binding)
             .is_some()
@@ -499,7 +498,7 @@ impl<'a, 'ra, 'tcx> BuildReducedGraphVisitor<'a, 'ra, 'tcx> {
                         if !type_ns_only || ns == TypeNS {
                             let key = BindingKey::new(target, ns);
                             this.resolution_or_default(current_module, key)
-                                .borrow_mut()
+                                .borrow_mut(this)
                                 .single_imports
                                 .insert(import);
                         }

--- a/compiler/rustc_resolve/src/check_unused.rs
+++ b/compiler/rustc_resolve/src/check_unused.rs
@@ -507,7 +507,7 @@ impl Resolver<'_, '_> {
 
         let unused_imports = visitor.unused_imports;
         let mut check_redundant_imports = FxIndexSet::default();
-        for module in self.arenas.local_modules().iter() {
+        for module in &self.local_modules {
             for (_key, resolution) in self.resolutions(*module).borrow().iter() {
                 if let Some(binding) = resolution.borrow().best_binding()
                     && let NameBindingKind::Import { import, .. } = binding.kind

--- a/compiler/rustc_resolve/src/ident.rs
+++ b/compiler/rustc_resolve/src/ident.rs
@@ -891,7 +891,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         // the exclusive access infinite recursion will crash the compiler with stack overflow.
         let resolution = &*self
             .resolution_or_default(module, key)
-            .try_borrow_mut()
+            .try_borrow_mut_unchecked()
             .map_err(|_| (Determined, Weak::No))?;
 
         // If the primary binding is unusable, search further and return the shadowed glob


### PR DESCRIPTION
No bare `(Ref)Cell`s remain in `rustc_resolve`, only `Cm(Ref)Cell`s checking that nothing is modified during speculative resolution, and `Cache(Ref)Cell` aliases for cells that need to be migrated to mutexes/atomics.

cc @LorrensP-2158466 