### PR TITLE
Suppress unused_parens for labeled break

### DIFF
--- a/tests/ui/lint/unused/break-label-with-parens-147542.rs
+++ b/tests/ui/lint/unused/break-label-with-parens-147542.rs
@@ -1,0 +1,22 @@
+//@ check-pass
+
+// Regression test for #147542
+// Ensures that we don't suggest removing parens in a break with label and loop
+// when the parens are necessary for correct parsing.
+
+#![warn(unused_parens)]
+#![warn(break_with_label_and_loop)]
+
+fn xyz() -> usize {
+    'foo: {
+        // parens bellow are necessary break of break with label and loop
+        break 'foo ({
+            println!("Hello!");
+            123
+        });
+    }
+}
+
+fn main() {
+    xyz();
+}


### PR DESCRIPTION
Fixes rust-lang/rust#147542
