### PR TITLE
Fix ICE for never pattern as closure parameters

### DIFF
--- a/compiler/rustc_hir_typeck/src/fn_ctxt/mod.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/mod.rs
@@ -104,8 +104,8 @@ pub(crate) struct FnCtxt<'a, 'tcx> {
     /// the diverges flag is set to something other than `Maybe`.
     pub(super) diverges: Cell<Diverges>,
 
-    /// If one of the function arguments is a never pattern, this counts as diverging code. This
-    /// affect typechecking of the function body.
+    /// If one of the function arguments is a never pattern, this counts as diverging code.
+    /// This affect typechecking of the function body.
     pub(super) function_diverges_because_of_empty_arguments: Cell<Diverges>,
 
     /// Whether the currently checked node is the whole body of the function.

--- a/tests/ui/never_type/never-pattern-as-closure-param-141592.rs
+++ b/tests/ui/never_type/never-pattern-as-closure-param-141592.rs
@@ -1,0 +1,24 @@
+#![feature(never_patterns)]
+#![allow(incomplete_features)]
+
+enum Never {}
+
+fn example(x: Never) -> [i32; 1] {
+    let ! = x;
+    [1]
+}
+
+fn function_param_never(!: Never) -> [i32; 1] {
+    [1]
+}
+
+fn generic_never<T>(!: T) -> [i32; 1] //~ ERROR mismatched types
+where
+    T: Copy,
+{
+    [1]
+}
+
+fn main() {
+    let _ = "12".lines().map(|!| [1]); //~ ERROR mismatched types
+}

--- a/tests/ui/never_type/never-pattern-as-closure-param-141592.stderr
+++ b/tests/ui/never_type/never-pattern-as-closure-param-141592.stderr
@@ -1,0 +1,18 @@
+error: mismatched types
+  --> $DIR/never-pattern-as-closure-param-141592.rs:15:21
+   |
+LL | fn generic_never<T>(!: T) -> [i32; 1]
+   |                     ^ a never pattern must be used on an uninhabited type
+   |
+   = note: the matched value is of type `T`
+
+error: mismatched types
+  --> $DIR/never-pattern-as-closure-param-141592.rs:23:31
+   |
+LL |     let _ = "12".lines().map(|!| [1]);
+   |                               ^ a never pattern must be used on an uninhabited type
+   |
+   = note: the matched value is of type `str`
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Fixes rust-lang/rust#141592 

`diverge` is set here for never pattern in parameter:
https://github.com/rust-lang/rust/blob/master/compiler/rustc_hir_typeck/src/check.rs#L87-L90

the assertion is too strict, I set it delay as bug for later error.
