### PR TITLE
remove `#[rustc_inherit_overflow_checks]` from `is_multiple_of`

### DIFF
--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -3552,7 +3552,6 @@ macro_rules! uint_impl {
         #[rustc_const_stable(feature = "unsigned_is_multiple_of", since = "1.87.0")]
         #[must_use]
         #[inline]
-        #[rustc_inherit_overflow_checks]
         pub const fn is_multiple_of(self, rhs: Self) -> bool {
             match rhs {
                 0 => self == 0,


### PR DESCRIPTION
Most likely this was just a result of copy-pasting. The attribute has no effect, because `%` always uses overflow checks.

r? @Amanieu 
cc @RalfJung 