### PR TITLE
Stabilize `rwlock_downgrade` feature

### DIFF
--- a/library/std/src/sync/nonpoison/rwlock.rs
+++ b/library/std/src/sync/nonpoison/rwlock.rs
@@ -700,7 +700,6 @@ impl<'rwlock, T: ?Sized> RwLockWriteGuard<'rwlock, T> {
     ///
     /// ```
     /// #![feature(nonpoison_rwlock)]
-    /// #![feature(rwlock_downgrade)]
     ///
     /// use std::sync::nonpoison::{RwLock, RwLockWriteGuard};
     ///
@@ -719,7 +718,6 @@ impl<'rwlock, T: ?Sized> RwLockWriteGuard<'rwlock, T> {
     ///
     /// ```
     /// #![feature(nonpoison_rwlock)]
-    /// #![feature(rwlock_downgrade)]
     ///
     /// use std::sync::Arc;
     /// use std::sync::nonpoison::{RwLock, RwLockWriteGuard};
@@ -752,8 +750,7 @@ impl<'rwlock, T: ?Sized> RwLockWriteGuard<'rwlock, T> {
     /// # let final_check = rw.read();
     /// # assert_eq!(*final_check, 3);
     /// ```
-    #[unstable(feature = "rwlock_downgrade", issue = "128203")]
-    // #[unstable(feature = "nonpoison_rwlock", issue = "134645")]
+    #[stable(feature = "rwlock_downgrade", since = "CURRENT_RUSTC_VERSION")]
     pub fn downgrade(s: Self) -> RwLockReadGuard<'rwlock, T> {
         let lock = s.lock;
 

--- a/library/std/src/sync/poison/rwlock.rs
+++ b/library/std/src/sync/poison/rwlock.rs
@@ -813,8 +813,6 @@ impl<'rwlock, T: ?Sized> RwLockWriteGuard<'rwlock, T> {
     /// `downgrade` takes ownership of the `RwLockWriteGuard` and returns a [`RwLockReadGuard`].
     ///
     /// ```
-    /// #![feature(rwlock_downgrade)]
-    ///
     /// use std::sync::{RwLock, RwLockWriteGuard};
     ///
     /// let rw = RwLock::new(0);
@@ -831,8 +829,6 @@ impl<'rwlock, T: ?Sized> RwLockWriteGuard<'rwlock, T> {
     /// thread calling `downgrade` and any reads it performs after downgrading.
     ///
     /// ```
-    /// #![feature(rwlock_downgrade)]
-    ///
     /// use std::sync::{Arc, RwLock, RwLockWriteGuard};
     ///
     /// let rw = Arc::new(RwLock::new(1));
@@ -863,7 +859,7 @@ impl<'rwlock, T: ?Sized> RwLockWriteGuard<'rwlock, T> {
     /// # let final_check = rw.read().unwrap();
     /// # assert_eq!(*final_check, 3);
     /// ```
-    #[unstable(feature = "rwlock_downgrade", issue = "128203")]
+    #[stable(feature = "rwlock_downgrade", since = "CURRENT_RUSTC_VERSION")]
     pub fn downgrade(s: Self) -> RwLockReadGuard<'rwlock, T> {
         let lock = s.lock;
 

--- a/library/std/tests/sync/lib.rs
+++ b/library/std/tests/sync/lib.rs
@@ -4,7 +4,6 @@
 #![feature(once_cell_try)]
 #![feature(lock_value_accessors)]
 #![feature(reentrant_lock)]
-#![feature(rwlock_downgrade)]
 #![feature(std_internals)]
 #![feature(sync_nonpoison)]
 #![feature(nonpoison_condvar)]


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

This stabilises `RwLockWriter::downgrade` and `RwLockWriteGuard::downgrade`, following the FCP in [tracking issue](https://github.com/rust-lang/rust/issues/128203)

Closes https://github.com/rust-lang/rust/issues/128203