### PR TITLE
make coerce-lub order independent

### DIFF
--- a/compiler/rustc_hir_typeck/src/coercion.rs
+++ b/compiler/rustc_hir_typeck/src/coercion.rs
@@ -1252,10 +1252,14 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
             // The signature must match.
             let (a_sig, b_sig) = self.normalize(new.span, (a_sig, b_sig));
+            let outer_universe = self.infcx.universe();
             let sig = self
                 .at(cause, self.param_env)
                 .lub(a_sig, b_sig)
                 .map(|ok| self.register_infer_ok_obligations(ok))?;
+
+            // See comment in `unify_raw` for why we leak check here
+            self.leak_check(outer_universe, None)?;
 
             // Reify both sides and return the reified fn pointer type.
             let fn_ptr = Ty::new_fn_ptr(self.tcx, sig);

--- a/tests/ui/coercion/leak_check_lub_fallback.rs
+++ b/tests/ui/coercion/leak_check_lub_fallback.rs
@@ -1,0 +1,25 @@
+macro_rules! lub {
+    ($lhs:expr, $rhs:expr) => {
+        if true { $lhs } else { $rhs }
+    };
+}
+
+struct Foo<T>(T);
+
+fn mk<T>() -> T {
+    loop {}
+}
+
+fn lub_deep_binder() {
+    // The lub should occur inside of dead code so that we
+    // can be sure we are actually testing whether we leak
+    // checked.
+    loop {}
+
+    let lhs = mk::<Foo<for<'a> fn(&'static (), &'a ())>>();
+    let rhs = mk::<Foo<for<'a> fn(&'a (), &'static ())>>();
+    lub!(lhs, rhs);
+    //~^ ERROR: `if` and `else` have incompatible types
+}
+
+fn main() {}

--- a/tests/ui/coercion/leak_check_lub_fallback.stderr
+++ b/tests/ui/coercion/leak_check_lub_fallback.stderr
@@ -1,0 +1,14 @@
+error[E0308]: `if` and `else` have incompatible types
+  --> $DIR/leak_check_lub_fallback.rs:21:15
+   |
+LL |     lub!(lhs, rhs);
+   |          ---  ^^^ one type is more general than the other
+   |          |
+   |          expected because of this
+   |
+   = note: expected struct `Foo<for<'a> fn(&(), &'a ())>`
+              found struct `Foo<for<'a> fn(&'a (), &())>`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/coercion/leak_check_lub_to_fnptr.deadcode.stderr
+++ b/tests/ui/coercion/leak_check_lub_to_fnptr.deadcode.stderr
@@ -1,0 +1,128 @@
+error[E0308]: `if` and `else` have incompatible types
+  --> $DIR/leak_check_lub_to_fnptr.rs:21:21
+   |
+LL |     lub!(lhs_fnptr, rhs_fnptr);
+   |          ---------  ^^^^^^^^^ one type is more general than the other
+   |          |
+   |          expected because of this
+   |
+   = note: expected fn pointer `for<'a> fn(&'a (), &())`
+              found fn pointer `for<'a> fn(&(), &'a ())`
+
+error[E0308]: `if` and `else` have incompatible types
+  --> $DIR/leak_check_lub_to_fnptr.rs:27:21
+   |
+LL |     lub!(lhs_fndef, rhs_fndef);
+   |          ---------  ^^^^^^^^^ one type is more general than the other
+   |          |
+   |          expected because of this
+   |
+   = note: expected fn item `for<'a> fn(&'a (), &'static ()) {lub_to_fnptr_leak_checking::lhs_fndef}`
+              found fn item `for<'a> fn(&'static (), &'a ()) {lub_to_fnptr_leak_checking::rhs_fndef}`
+
+error[E0308]: `if` and `else` have incompatible types
+  --> $DIR/leak_check_lub_to_fnptr.rs:33:23
+   |
+LL |     let lhs_closure = |_: &(), _: &'static ()| {};
+   |                       ------------------------ the expected closure
+LL |     let rhs_closure = |_: &'static (), _: &()| {};
+   |                       ------------------------ the found closure
+LL |     lub!(lhs_closure, rhs_closure);
+   |          -----------  ^^^^^^^^^^^ one type is more general than the other
+   |          |
+   |          expected because of this
+   |
+   = note: expected closure `{closure@$DIR/leak_check_lub_to_fnptr.rs:31:23: 31:47}`
+              found closure `{closure@$DIR/leak_check_lub_to_fnptr.rs:32:23: 32:47}`
+   = note: closure has signature: `for<'a> fn(&'static (), &'a ())`
+   = note: no two closures, even if identical, have the same type
+   = help: consider boxing your closure and/or using it as a trait object
+
+error[E0308]: `if` and `else` have incompatible types
+  --> $DIR/leak_check_lub_to_fnptr.rs:42:15
+   |
+LL |     lub!(lhs, rhs_fndef);
+   |          ---  ^^^^^^^^^ one type is more general than the other
+   |          |
+   |          expected because of this
+   |
+   = note: expected fn pointer `for<'a> fn(&'a (), &())`
+                 found fn item `for<'a> fn(&'static (), &'a ()) {lub_with_fnptr_leak_checking::rhs_fndef}`
+
+error[E0308]: `if` and `else` have incompatible types
+  --> $DIR/leak_check_lub_to_fnptr.rs:47:15
+   |
+LL |     let rhs_closure = |_: &'static (), _: &()| {};
+   |                       ------------------------ the found closure
+LL |     lub!(lhs, rhs_closure);
+   |          ---  ^^^^^^^^^^^ one type is more general than the other
+   |          |
+   |          expected because of this
+   |
+   = note: expected fn pointer `for<'a> fn(&'a (), &())`
+                 found closure `{closure@$DIR/leak_check_lub_to_fnptr.rs:46:23: 46:47}`
+   = note: closure has signature: `for<'a> fn(&'static (), &'a ())`
+
+error[E0308]: `if` and `else` have incompatible types
+  --> $DIR/leak_check_lub_to_fnptr.rs:56:23
+   |
+LL |     let lhs_closure = |_: &(), _: &'static ()| {};
+   |                       ------------------------ the expected closure
+LL |     let rhs_closure = |_: &'static (), _: &'static ()| {};
+   |                       -------------------------------- the found closure
+LL |
+LL |     lub!(lhs_closure, rhs_closure);
+   |          -----------  ^^^^^^^^^^^ one type is more general than the other
+   |          |
+   |          expected because of this
+   |
+   = note: expected closure `{closure@$DIR/leak_check_lub_to_fnptr.rs:53:23: 53:47}`
+              found closure `{closure@$DIR/leak_check_lub_to_fnptr.rs:54:23: 54:55}`
+   = note: closure has signature: `fn(&'static (), &'static ())`
+   = note: no two closures, even if identical, have the same type
+   = help: consider boxing your closure and/or using it as a trait object
+
+error[E0308]: `if` and `else` have incompatible types
+  --> $DIR/leak_check_lub_to_fnptr.rs:58:23
+   |
+LL |     let lhs_closure = |_: &(), _: &'static ()| {};
+   |                       ------------------------ the found closure
+LL |     let rhs_closure = |_: &'static (), _: &'static ()| {};
+   |                       -------------------------------- the expected closure
+...
+LL |     lub!(rhs_closure, lhs_closure);
+   |          -----------  ^^^^^^^^^^^ one type is more general than the other
+   |          |
+   |          expected because of this
+   |
+   = note: expected closure `{closure@$DIR/leak_check_lub_to_fnptr.rs:54:23: 54:55}`
+              found closure `{closure@$DIR/leak_check_lub_to_fnptr.rs:53:23: 53:47}`
+   = note: closure has signature: `for<'a> fn(&'a (), &'static ())`
+   = note: no two closures, even if identical, have the same type
+   = help: consider boxing your closure and/or using it as a trait object
+
+error[E0308]: `if` and `else` have incompatible types
+  --> $DIR/leak_check_lub_to_fnptr.rs:67:21
+   |
+LL |     lub!(lhs_fndef, rhs_fndef);
+   |          ---------  ^^^^^^^^^ one type is more general than the other
+   |          |
+   |          expected because of this
+   |
+   = note: expected fn item `for<'a> fn(&'a (), &'static ()) {order_dependence_fndefs::lhs_fndef}`
+              found fn item `fn(&'static (), &'static ()) {order_dependence_fndefs::rhs_fndef}`
+
+error[E0308]: `if` and `else` have incompatible types
+  --> $DIR/leak_check_lub_to_fnptr.rs:69:21
+   |
+LL |     lub!(rhs_fndef, lhs_fndef);
+   |          ---------  ^^^^^^^^^ one type is more general than the other
+   |          |
+   |          expected because of this
+   |
+   = note: expected fn item `fn(&'static (), &'static ()) {order_dependence_fndefs::rhs_fndef}`
+              found fn item `for<'a> fn(&'a (), &'static ()) {order_dependence_fndefs::lhs_fndef}`
+
+error: aborting due to 9 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/coercion/leak_check_lub_to_fnptr.deadcode.stderr
+++ b/tests/ui/coercion/leak_check_lub_to_fnptr.deadcode.stderr
@@ -64,64 +64,64 @@ LL |     lub!(lhs, rhs_closure);
    = note: closure has signature: `for<'a> fn(&'static (), &'a ())`
 
 error[E0308]: `if` and `else` have incompatible types
-  --> $DIR/leak_check_lub_to_fnptr.rs:56:23
+  --> $DIR/leak_check_lub_to_fnptr.rs:59:23
    |
-LL |     let lhs_closure = |_: &(), _: &'static ()| {};
-   |                       ------------------------ the expected closure
-LL |     let rhs_closure = |_: &'static (), _: &'static ()| {};
-   |                       -------------------------------- the found closure
+LL |     let lhs_closure = |_: &(), _: &'static (), _: &()| {};
+   |                       -------------------------------- the expected closure
+LL |     let rhs_closure = |_: &'static (), _: &'static (), _: &()| {};
+   |                       ---------------------------------------- the found closure
 LL |
 LL |     lub!(lhs_closure, rhs_closure);
    |          -----------  ^^^^^^^^^^^ one type is more general than the other
    |          |
    |          expected because of this
    |
-   = note: expected closure `{closure@$DIR/leak_check_lub_to_fnptr.rs:53:23: 53:47}`
-              found closure `{closure@$DIR/leak_check_lub_to_fnptr.rs:54:23: 54:55}`
-   = note: closure has signature: `fn(&'static (), &'static ())`
+   = note: expected closure `{closure@$DIR/leak_check_lub_to_fnptr.rs:56:23: 56:55}`
+              found closure `{closure@$DIR/leak_check_lub_to_fnptr.rs:57:23: 57:63}`
+   = note: closure has signature: `for<'a> fn(&'static (), &'static (), &'a ())`
    = note: no two closures, even if identical, have the same type
    = help: consider boxing your closure and/or using it as a trait object
 
 error[E0308]: `if` and `else` have incompatible types
-  --> $DIR/leak_check_lub_to_fnptr.rs:58:23
+  --> $DIR/leak_check_lub_to_fnptr.rs:61:23
    |
-LL |     let lhs_closure = |_: &(), _: &'static ()| {};
-   |                       ------------------------ the found closure
-LL |     let rhs_closure = |_: &'static (), _: &'static ()| {};
-   |                       -------------------------------- the expected closure
+LL |     let lhs_closure = |_: &(), _: &'static (), _: &()| {};
+   |                       -------------------------------- the found closure
+LL |     let rhs_closure = |_: &'static (), _: &'static (), _: &()| {};
+   |                       ---------------------------------------- the expected closure
 ...
 LL |     lub!(rhs_closure, lhs_closure);
    |          -----------  ^^^^^^^^^^^ one type is more general than the other
    |          |
    |          expected because of this
    |
-   = note: expected closure `{closure@$DIR/leak_check_lub_to_fnptr.rs:54:23: 54:55}`
-              found closure `{closure@$DIR/leak_check_lub_to_fnptr.rs:53:23: 53:47}`
-   = note: closure has signature: `for<'a> fn(&'a (), &'static ())`
+   = note: expected closure `{closure@$DIR/leak_check_lub_to_fnptr.rs:57:23: 57:63}`
+              found closure `{closure@$DIR/leak_check_lub_to_fnptr.rs:56:23: 56:55}`
+   = note: closure has signature: `for<'a, 'b> fn(&'a (), &'static (), &'b ())`
    = note: no two closures, even if identical, have the same type
    = help: consider boxing your closure and/or using it as a trait object
 
 error[E0308]: `if` and `else` have incompatible types
-  --> $DIR/leak_check_lub_to_fnptr.rs:67:21
+  --> $DIR/leak_check_lub_to_fnptr.rs:73:21
    |
 LL |     lub!(lhs_fndef, rhs_fndef);
    |          ---------  ^^^^^^^^^ one type is more general than the other
    |          |
    |          expected because of this
    |
-   = note: expected fn item `for<'a> fn(&'a (), &'static ()) {order_dependence_fndefs::lhs_fndef}`
-              found fn item `fn(&'static (), &'static ()) {order_dependence_fndefs::rhs_fndef}`
+   = note: expected fn item `for<'a, 'b> fn(&'a (), &'static (), &'b ()) {order_dependence_fndefs::lhs_fndef}`
+              found fn item `for<'a> fn(&'static (), &'static (), &'a ()) {order_dependence_fndefs::rhs_fndef}`
 
 error[E0308]: `if` and `else` have incompatible types
-  --> $DIR/leak_check_lub_to_fnptr.rs:69:21
+  --> $DIR/leak_check_lub_to_fnptr.rs:75:21
    |
 LL |     lub!(rhs_fndef, lhs_fndef);
    |          ---------  ^^^^^^^^^ one type is more general than the other
    |          |
    |          expected because of this
    |
-   = note: expected fn item `fn(&'static (), &'static ()) {order_dependence_fndefs::rhs_fndef}`
-              found fn item `for<'a> fn(&'a (), &'static ()) {order_dependence_fndefs::lhs_fndef}`
+   = note: expected fn item `for<'a> fn(&'static (), &'static (), &'a ()) {order_dependence_fndefs::rhs_fndef}`
+              found fn item `for<'a, 'b> fn(&'a (), &'static (), &'b ()) {order_dependence_fndefs::lhs_fndef}`
 
 error: aborting due to 9 previous errors
 

--- a/tests/ui/coercion/leak_check_lub_to_fnptr.livecode.stderr
+++ b/tests/ui/coercion/leak_check_lub_to_fnptr.livecode.stderr
@@ -1,0 +1,128 @@
+error[E0308]: `if` and `else` have incompatible types
+  --> $DIR/leak_check_lub_to_fnptr.rs:21:21
+   |
+LL |     lub!(lhs_fnptr, rhs_fnptr);
+   |          ---------  ^^^^^^^^^ one type is more general than the other
+   |          |
+   |          expected because of this
+   |
+   = note: expected fn pointer `for<'a> fn(&'a (), &())`
+              found fn pointer `for<'a> fn(&(), &'a ())`
+
+error[E0308]: `if` and `else` have incompatible types
+  --> $DIR/leak_check_lub_to_fnptr.rs:27:21
+   |
+LL |     lub!(lhs_fndef, rhs_fndef);
+   |          ---------  ^^^^^^^^^ one type is more general than the other
+   |          |
+   |          expected because of this
+   |
+   = note: expected fn item `for<'a> fn(&'a (), &'static ()) {lub_to_fnptr_leak_checking::lhs_fndef}`
+              found fn item `for<'a> fn(&'static (), &'a ()) {lub_to_fnptr_leak_checking::rhs_fndef}`
+
+error[E0308]: `if` and `else` have incompatible types
+  --> $DIR/leak_check_lub_to_fnptr.rs:33:23
+   |
+LL |     let lhs_closure = |_: &(), _: &'static ()| {};
+   |                       ------------------------ the expected closure
+LL |     let rhs_closure = |_: &'static (), _: &()| {};
+   |                       ------------------------ the found closure
+LL |     lub!(lhs_closure, rhs_closure);
+   |          -----------  ^^^^^^^^^^^ one type is more general than the other
+   |          |
+   |          expected because of this
+   |
+   = note: expected closure `{closure@$DIR/leak_check_lub_to_fnptr.rs:31:23: 31:47}`
+              found closure `{closure@$DIR/leak_check_lub_to_fnptr.rs:32:23: 32:47}`
+   = note: closure has signature: `for<'a> fn(&'static (), &'a ())`
+   = note: no two closures, even if identical, have the same type
+   = help: consider boxing your closure and/or using it as a trait object
+
+error[E0308]: `if` and `else` have incompatible types
+  --> $DIR/leak_check_lub_to_fnptr.rs:42:15
+   |
+LL |     lub!(lhs, rhs_fndef);
+   |          ---  ^^^^^^^^^ one type is more general than the other
+   |          |
+   |          expected because of this
+   |
+   = note: expected fn pointer `for<'a> fn(&'a (), &())`
+                 found fn item `for<'a> fn(&'static (), &'a ()) {lub_with_fnptr_leak_checking::rhs_fndef}`
+
+error[E0308]: `if` and `else` have incompatible types
+  --> $DIR/leak_check_lub_to_fnptr.rs:47:15
+   |
+LL |     let rhs_closure = |_: &'static (), _: &()| {};
+   |                       ------------------------ the found closure
+LL |     lub!(lhs, rhs_closure);
+   |          ---  ^^^^^^^^^^^ one type is more general than the other
+   |          |
+   |          expected because of this
+   |
+   = note: expected fn pointer `for<'a> fn(&'a (), &())`
+                 found closure `{closure@$DIR/leak_check_lub_to_fnptr.rs:46:23: 46:47}`
+   = note: closure has signature: `for<'a> fn(&'static (), &'a ())`
+
+error[E0308]: `if` and `else` have incompatible types
+  --> $DIR/leak_check_lub_to_fnptr.rs:56:23
+   |
+LL |     let lhs_closure = |_: &(), _: &'static ()| {};
+   |                       ------------------------ the expected closure
+LL |     let rhs_closure = |_: &'static (), _: &'static ()| {};
+   |                       -------------------------------- the found closure
+LL |
+LL |     lub!(lhs_closure, rhs_closure);
+   |          -----------  ^^^^^^^^^^^ one type is more general than the other
+   |          |
+   |          expected because of this
+   |
+   = note: expected closure `{closure@$DIR/leak_check_lub_to_fnptr.rs:53:23: 53:47}`
+              found closure `{closure@$DIR/leak_check_lub_to_fnptr.rs:54:23: 54:55}`
+   = note: closure has signature: `fn(&'static (), &'static ())`
+   = note: no two closures, even if identical, have the same type
+   = help: consider boxing your closure and/or using it as a trait object
+
+error[E0308]: `if` and `else` have incompatible types
+  --> $DIR/leak_check_lub_to_fnptr.rs:58:23
+   |
+LL |     let lhs_closure = |_: &(), _: &'static ()| {};
+   |                       ------------------------ the found closure
+LL |     let rhs_closure = |_: &'static (), _: &'static ()| {};
+   |                       -------------------------------- the expected closure
+...
+LL |     lub!(rhs_closure, lhs_closure);
+   |          -----------  ^^^^^^^^^^^ one type is more general than the other
+   |          |
+   |          expected because of this
+   |
+   = note: expected closure `{closure@$DIR/leak_check_lub_to_fnptr.rs:54:23: 54:55}`
+              found closure `{closure@$DIR/leak_check_lub_to_fnptr.rs:53:23: 53:47}`
+   = note: closure has signature: `for<'a> fn(&'a (), &'static ())`
+   = note: no two closures, even if identical, have the same type
+   = help: consider boxing your closure and/or using it as a trait object
+
+error[E0308]: `if` and `else` have incompatible types
+  --> $DIR/leak_check_lub_to_fnptr.rs:67:21
+   |
+LL |     lub!(lhs_fndef, rhs_fndef);
+   |          ---------  ^^^^^^^^^ one type is more general than the other
+   |          |
+   |          expected because of this
+   |
+   = note: expected fn item `for<'a> fn(&'a (), &'static ()) {order_dependence_fndefs::lhs_fndef}`
+              found fn item `fn(&'static (), &'static ()) {order_dependence_fndefs::rhs_fndef}`
+
+error[E0308]: `if` and `else` have incompatible types
+  --> $DIR/leak_check_lub_to_fnptr.rs:69:21
+   |
+LL |     lub!(rhs_fndef, lhs_fndef);
+   |          ---------  ^^^^^^^^^ one type is more general than the other
+   |          |
+   |          expected because of this
+   |
+   = note: expected fn item `fn(&'static (), &'static ()) {order_dependence_fndefs::rhs_fndef}`
+              found fn item `for<'a> fn(&'a (), &'static ()) {order_dependence_fndefs::lhs_fndef}`
+
+error: aborting due to 9 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/coercion/leak_check_lub_to_fnptr.livecode.stderr
+++ b/tests/ui/coercion/leak_check_lub_to_fnptr.livecode.stderr
@@ -64,64 +64,64 @@ LL |     lub!(lhs, rhs_closure);
    = note: closure has signature: `for<'a> fn(&'static (), &'a ())`
 
 error[E0308]: `if` and `else` have incompatible types
-  --> $DIR/leak_check_lub_to_fnptr.rs:56:23
+  --> $DIR/leak_check_lub_to_fnptr.rs:59:23
    |
-LL |     let lhs_closure = |_: &(), _: &'static ()| {};
-   |                       ------------------------ the expected closure
-LL |     let rhs_closure = |_: &'static (), _: &'static ()| {};
-   |                       -------------------------------- the found closure
+LL |     let lhs_closure = |_: &(), _: &'static (), _: &()| {};
+   |                       -------------------------------- the expected closure
+LL |     let rhs_closure = |_: &'static (), _: &'static (), _: &()| {};
+   |                       ---------------------------------------- the found closure
 LL |
 LL |     lub!(lhs_closure, rhs_closure);
    |          -----------  ^^^^^^^^^^^ one type is more general than the other
    |          |
    |          expected because of this
    |
-   = note: expected closure `{closure@$DIR/leak_check_lub_to_fnptr.rs:53:23: 53:47}`
-              found closure `{closure@$DIR/leak_check_lub_to_fnptr.rs:54:23: 54:55}`
-   = note: closure has signature: `fn(&'static (), &'static ())`
+   = note: expected closure `{closure@$DIR/leak_check_lub_to_fnptr.rs:56:23: 56:55}`
+              found closure `{closure@$DIR/leak_check_lub_to_fnptr.rs:57:23: 57:63}`
+   = note: closure has signature: `for<'a> fn(&'static (), &'static (), &'a ())`
    = note: no two closures, even if identical, have the same type
    = help: consider boxing your closure and/or using it as a trait object
 
 error[E0308]: `if` and `else` have incompatible types
-  --> $DIR/leak_check_lub_to_fnptr.rs:58:23
+  --> $DIR/leak_check_lub_to_fnptr.rs:61:23
    |
-LL |     let lhs_closure = |_: &(), _: &'static ()| {};
-   |                       ------------------------ the found closure
-LL |     let rhs_closure = |_: &'static (), _: &'static ()| {};
-   |                       -------------------------------- the expected closure
+LL |     let lhs_closure = |_: &(), _: &'static (), _: &()| {};
+   |                       -------------------------------- the found closure
+LL |     let rhs_closure = |_: &'static (), _: &'static (), _: &()| {};
+   |                       ---------------------------------------- the expected closure
 ...
 LL |     lub!(rhs_closure, lhs_closure);
    |          -----------  ^^^^^^^^^^^ one type is more general than the other
    |          |
    |          expected because of this
    |
-   = note: expected closure `{closure@$DIR/leak_check_lub_to_fnptr.rs:54:23: 54:55}`
-              found closure `{closure@$DIR/leak_check_lub_to_fnptr.rs:53:23: 53:47}`
-   = note: closure has signature: `for<'a> fn(&'a (), &'static ())`
+   = note: expected closure `{closure@$DIR/leak_check_lub_to_fnptr.rs:57:23: 57:63}`
+              found closure `{closure@$DIR/leak_check_lub_to_fnptr.rs:56:23: 56:55}`
+   = note: closure has signature: `for<'a, 'b> fn(&'a (), &'static (), &'b ())`
    = note: no two closures, even if identical, have the same type
    = help: consider boxing your closure and/or using it as a trait object
 
 error[E0308]: `if` and `else` have incompatible types
-  --> $DIR/leak_check_lub_to_fnptr.rs:67:21
+  --> $DIR/leak_check_lub_to_fnptr.rs:73:21
    |
 LL |     lub!(lhs_fndef, rhs_fndef);
    |          ---------  ^^^^^^^^^ one type is more general than the other
    |          |
    |          expected because of this
    |
-   = note: expected fn item `for<'a> fn(&'a (), &'static ()) {order_dependence_fndefs::lhs_fndef}`
-              found fn item `fn(&'static (), &'static ()) {order_dependence_fndefs::rhs_fndef}`
+   = note: expected fn item `for<'a, 'b> fn(&'a (), &'static (), &'b ()) {order_dependence_fndefs::lhs_fndef}`
+              found fn item `for<'a> fn(&'static (), &'static (), &'a ()) {order_dependence_fndefs::rhs_fndef}`
 
 error[E0308]: `if` and `else` have incompatible types
-  --> $DIR/leak_check_lub_to_fnptr.rs:69:21
+  --> $DIR/leak_check_lub_to_fnptr.rs:75:21
    |
 LL |     lub!(rhs_fndef, lhs_fndef);
    |          ---------  ^^^^^^^^^ one type is more general than the other
    |          |
    |          expected because of this
    |
-   = note: expected fn item `fn(&'static (), &'static ()) {order_dependence_fndefs::rhs_fndef}`
-              found fn item `for<'a> fn(&'a (), &'static ()) {order_dependence_fndefs::lhs_fndef}`
+   = note: expected fn item `for<'a> fn(&'static (), &'static (), &'a ()) {order_dependence_fndefs::rhs_fndef}`
+              found fn item `for<'a, 'b> fn(&'a (), &'static (), &'b ()) {order_dependence_fndefs::lhs_fndef}`
 
 error: aborting due to 9 previous errors
 

--- a/tests/ui/coercion/leak_check_lub_to_fnptr.rs
+++ b/tests/ui/coercion/leak_check_lub_to_fnptr.rs
@@ -50,8 +50,11 @@ fn lub_with_fnptr_leak_checking() {
 }
 
 fn order_dependence_closures() {
-    let lhs_closure = |_: &(), _: &'static ()| {};
-    let rhs_closure = |_: &'static (), _: &'static ()| {};
+    // We use a third parameter referencing bound vars so that
+    // lubbing is forced to equate binders instead of choosing
+    // the non-hr sig
+    let lhs_closure = |_: &(), _: &'static (), _: &()| {};
+    let rhs_closure = |_: &'static (), _: &'static (), _: &()| {};
 
     lub!(lhs_closure, rhs_closure);
     //~^ ERROR: `if` and `else` have incompatible types
@@ -61,8 +64,11 @@ fn order_dependence_closures() {
 }
 
 fn order_dependence_fndefs() {
-    fn lhs_fndef(_: &(), _: &'static ()) {}
-    fn rhs_fndef(_: &'static (), _: &'static ()) {}
+    // We use a third parameter referencing bound vars so that
+    // lubbing is forced to equate binders instead of choosing
+    // the non-hr sig
+    fn lhs_fndef(_: &(), _: &'static (), _: &()) {}
+    fn rhs_fndef(_: &'static (), _: &'static (), _: &()) {}
 
     lub!(lhs_fndef, rhs_fndef);
     //~^ ERROR: `if` and `else` have incompatible types

--- a/tests/ui/coercion/leak_check_lub_to_fnptr.rs
+++ b/tests/ui/coercion/leak_check_lub_to_fnptr.rs
@@ -1,0 +1,73 @@
+//@ revisions: livecode deadcode
+
+#![allow(unreachable_code)]
+
+fn mk<T>() -> T {
+    loop {}
+}
+
+macro_rules! lub {
+    ($lhs:expr, $rhs:expr) => {
+        if true { $lhs } else { $rhs }
+    };
+}
+
+fn lub_to_fnptr_leak_checking() {
+    #[cfg(deadcode)]
+    loop {}
+
+    let lhs_fnptr = mk::<fn(&(), &'static ())>();
+    let rhs_fnptr = mk::<fn(&'static (), &())>();
+    lub!(lhs_fnptr, rhs_fnptr);
+    //[livecode]~^ ERROR: `if` and `else` have incompatible types
+    //[deadcode]~^^ ERROR: `if` and `else` have incompatible types
+
+    fn lhs_fndef(_: &(), _: &'static ()) {};
+    fn rhs_fndef(_: &'static (), _: &()) {};
+    lub!(lhs_fndef, rhs_fndef);
+    //[livecode]~^ ERROR: `if` and `else` have incompatible types
+    //[deadcode]~^^ ERROR: `if` and `else` have incompatible types
+
+    let lhs_closure = |_: &(), _: &'static ()| {};
+    let rhs_closure = |_: &'static (), _: &()| {};
+    lub!(lhs_closure, rhs_closure);
+    //[livecode]~^ ERROR: `if` and `else` have incompatible types
+    //[deadcode]~^^ ERROR: `if` and `else` have incompatible types
+}
+
+fn lub_with_fnptr_leak_checking() {
+    let lhs = mk::<fn(&(), &'static ())>();
+
+    fn rhs_fndef(_: &'static (), _: &()) {};
+    lub!(lhs, rhs_fndef);
+    //[livecode]~^ ERROR: `if` and `else` have incompatible types
+    //[deadcode]~^^ ERROR: `if` and `else` have incompatible types
+
+    let rhs_closure = |_: &'static (), _: &()| {};
+    lub!(lhs, rhs_closure);
+    //[livecode]~^ ERROR: `if` and `else` have incompatible types
+    //[deadcode]~^^ ERROR: `if` and `else` have incompatible types
+}
+
+fn order_dependence_closures() {
+    let lhs_closure = |_: &(), _: &'static ()| {};
+    let rhs_closure = |_: &'static (), _: &'static ()| {};
+
+    lub!(lhs_closure, rhs_closure);
+    //~^ ERROR: `if` and `else` have incompatible types
+    lub!(rhs_closure, lhs_closure);
+    //~^ ERROR: `if` and `else` have incompatible types
+
+}
+
+fn order_dependence_fndefs() {
+    fn lhs_fndef(_: &(), _: &'static ()) {}
+    fn rhs_fndef(_: &'static (), _: &'static ()) {}
+
+    lub!(lhs_fndef, rhs_fndef);
+    //~^ ERROR: `if` and `else` have incompatible types
+    lub!(rhs_fndef, lhs_fndef);
+    //~^ ERROR: `if` and `else` have incompatible types
+}
+
+fn main() {}

--- a/tests/ui/coercion/leak_check_single_to_fnptr.deadcode.stderr
+++ b/tests/ui/coercion/leak_check_single_to_fnptr.deadcode.stderr
@@ -1,0 +1,25 @@
+error[E0308]: mismatched types
+  --> $DIR/leak_check_single_to_fnptr.rs:25:39
+   |
+LL |     let _target: for<'a> fn(&'a ()) = a_fndef;
+   |                  ------------------   ^^^^^^^ one type is more general than the other
+   |                  |
+   |                  expected due to this
+   |
+   = note: expected fn pointer `for<'a> fn(&'a ())`
+                 found fn item `fn(&'static ()) {static_fndef}`
+
+error[E0308]: mismatched types
+  --> $DIR/leak_check_single_to_fnptr.rs:28:39
+   |
+LL |     let _target: for<'a> fn(&'a ()) = a_fnptr;
+   |                  ------------------   ^^^^^^^ one type is more general than the other
+   |                  |
+   |                  expected due to this
+   |
+   = note: expected fn pointer `for<'a> fn(&'a ())`
+              found fn pointer `fn(&())`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/coercion/leak_check_single_to_fnptr.livecode.stderr
+++ b/tests/ui/coercion/leak_check_single_to_fnptr.livecode.stderr
@@ -1,0 +1,34 @@
+error[E0308]: mismatched types
+  --> $DIR/leak_check_single_to_fnptr.rs:25:39
+   |
+LL |     let _target: for<'a> fn(&'a ()) = a_fndef;
+   |                  ------------------   ^^^^^^^ one type is more general than the other
+   |                  |
+   |                  expected due to this
+   |
+   = note: expected fn pointer `for<'a> fn(&'a ())`
+                 found fn item `fn(&'static ()) {static_fndef}`
+
+error[E0308]: mismatched types
+  --> $DIR/leak_check_single_to_fnptr.rs:28:39
+   |
+LL |     let _target: for<'a> fn(&'a ()) = a_fnptr;
+   |                  ------------------   ^^^^^^^ one type is more general than the other
+   |                  |
+   |                  expected due to this
+   |
+   = note: expected fn pointer `for<'a> fn(&'a ())`
+              found fn pointer `fn(&())`
+
+error[E0308]: mismatched types
+  --> $DIR/leak_check_single_to_fnptr.rs:39:39
+   |
+LL |     let _target: for<'a> fn(&'a ()) = a_closure;
+   |                                       ^^^^^^^^^ one type is more general than the other
+   |
+   = note: expected fn pointer `for<'a> fn(&'a ())`
+              found fn pointer `fn(&())`
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/coercion/leak_check_single_to_fnptr.rs
+++ b/tests/ui/coercion/leak_check_single_to_fnptr.rs
@@ -1,0 +1,44 @@
+//@ revisions: livecode deadcode
+
+// When coercing to a fnptr check that we leak check when relating
+// the signatures. Previously we would leak checked for fnptr/fndef
+// to fnptr coercions, but not closure to fnptr coercions. This
+// resulted in closure to fnptr coercions not erroring in dead code
+// when equivalent code with fndefs/fnptrs would error.
+//
+// We now never leak check during normal subtyping operations only
+// during lub operations. Outside of dead code all cases wind up
+// erroring in borrowck so this is not a soundness concern.
+
+fn mk<T>() -> T {
+    loop {}
+}
+
+fn static_fndef(_: &'static ()) {}
+
+fn one_way_coerce() {
+    let a_fndef = static_fndef;
+    let a_fnptr = mk::<fn(&'static ())>();
+
+    #[cfg(deadcode)]
+    loop {}
+    let _target: for<'a> fn(&'a ()) = a_fndef;
+    //[livecode]~^ ERROR: mismatched types
+    //[deadcode]~^^ ERROR: mismatched types
+    let _target: for<'a> fn(&'a ()) = a_fnptr;
+    //[livecode]~^ ERROR: mismatched types
+    //[deadcode]~^^ ERROR: mismatched types
+}
+
+fn one_way_coerce_2() {
+    let a_closure = |_: &'static ()| {};
+
+    #[cfg(deadcode)]
+    loop {}
+
+    let _target: for<'a> fn(&'a ()) = a_closure;
+    //[livecode]~^ ERROR: mismatched types
+
+}
+
+fn main() {}

--- a/tests/ui/function-pointer/signature-mismatch.rs
+++ b/tests/ui/function-pointer/signature-mismatch.rs
@@ -2,5 +2,5 @@
 
 fn main() {
     let _ = [std::ops::Add::add, std::ops::Mul::mul, std::ops::Mul::mul as fn(_, &_)];
-    //~^ ERROR: mismatched types
+    //~^ ERROR: non-primitive cast
 }

--- a/tests/ui/function-pointer/signature-mismatch.stderr
+++ b/tests/ui/function-pointer/signature-mismatch.stderr
@@ -1,12 +1,9 @@
-error[E0308]: mismatched types
+error[E0605]: non-primitive cast: `fn(_, _) -> <_ as Mul<_>>::Output {<_ as Mul<_>>::mul}` as `for<'a> fn(_, &'a _)`
   --> $DIR/signature-mismatch.rs:4:54
    |
 LL |     let _ = [std::ops::Add::add, std::ops::Mul::mul, std::ops::Mul::mul as fn(_, &_)];
-   |                                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ one type is more general than the other
-   |
-   = note: expected fn pointer `fn(_, _) -> _`
-              found fn pointer `for<'a> fn(_, &'a _) -> ()`
+   |                                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ invalid cast
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0308`.
+For more information about this error, try `rustc --explain E0605`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/147565)*
<!-- homu-ignore:end -->

### make coerce-lubs order independent

cc rust-lang/rust#73154 rust-lang/rust#97206

`lub` currently equates binders and then just returns the lhs without ever leak checking to ensure the binders are actually equal. this can lead to coerce-lub operations being order dependent, i.e. that `a coerce-lub b` has differing behaviour to `b coerce-lub a`.

we also cannot rely on borrow checking actually checking the constraints from equating the binders as `lub` is a hir-typeck coercion concept that is not relevant once MIR has been built. In the MIR we can simply subtype all the types of match arms with the final type of the match.

it is a forwards compatibility hazard to have coerce-lub be order dependent as it results in an effectively arbitrary inference choice which may or may not actually be correct or compatible with hypothetical future behaviours of `lub` that actually try to compute a proper lub'd type.

on stable we attempt to make coerce-lubs order independent with two checks:
- Leak check for `fndef->fnptr` coercions
- Leak check for `fnptr->fnptr` coercions

on stable we do this regardless of whether the coercion is occuring as part of a `coerce-lub` or not.

under this PR we have the following checks:
- Leak check for `fnptr/fndef->fnptr` coercions
- Leak check for `closure->fnptr` coercions performed as part of a coerce-lub
- Leak check `closure/fndef<->closure/fndef` coerce-lubs that coerce both sides to fnptrs
- Leak check the fallback `lub` operation when a coerce-lub does not actually coerce

this is theoretically breaking in two cases:
1. the new leak checks are in dead code where borrowck doesn't emit any errors
2. people have written matches/if-elses/array-exprs that rely on the arbitrary inference choice of the first signature encountered

the second case actually is encountered by a few crates in practice which has been somewhat mitigated by the next change.

### improving binder lub

this PR also implements a slight improvement to `lub` operations on higher ranked types to avoid some regressions: https://github.com/rust-lang/rust/pull/147565#issuecomment-3486416652

when lubbing two higher ranked types, if one of the binders is empty then we now instantiate the other binder with inference variables and lub the instantiated type with the empty-binder type.

concretely:
- `for<'a> fn(&'a ()) lub fn(&'static ())`
- only the lhs has bound vars so: `fn(&'?a ()) lub fn(&'static ())`
- `'?a eq 'static` passes leak check

whereas the previous behaviour was:
- `for<'a> fn(&'a ()) lub fn(&'static ())`
- lubbing binders is hard so just equate with invariance: `fn(&'!a ()) eq fn(&'static ())`
- `'!a eq 'static`  fails leak check

this change is just theoretically incorrect as contravariance can allow for types with empty binders to gain a binder. e.g. `fn(fn(&'static ()) <: for<'a> fn(fn(&'a ()))`