### PR TITLE
Rollup of 12 pull requests

### DIFF
--- a/compiler/rustc_borrowck/src/dataflow.rs
+++ b/compiler/rustc_borrowck/src/dataflow.rs
@@ -577,7 +577,6 @@ impl<'tcx> rustc_mir_dataflow::Analysis<'tcx> for Borrows<'_, 'tcx> {
 
             mir::StatementKind::FakeRead(..)
             | mir::StatementKind::SetDiscriminant { .. }
-            | mir::StatementKind::Deinit(..)
             | mir::StatementKind::StorageLive(..)
             | mir::StatementKind::Retag { .. }
             | mir::StatementKind::PlaceMention(..)

--- a/compiler/rustc_borrowck/src/def_use.rs
+++ b/compiler/rustc_borrowck/src/def_use.rs
@@ -80,7 +80,7 @@ pub(crate) fn categorize(context: PlaceContext) -> Option<DefUse> {
         // Backwards incompatible drop hint is not a use, just a marker for linting.
         PlaceContext::NonUse(NonUseContext::BackwardIncompatibleDropHint) => None,
 
-        PlaceContext::MutatingUse(MutatingUseContext::Deinit | MutatingUseContext::SetDiscriminant) => {
+        PlaceContext::MutatingUse(MutatingUseContext::SetDiscriminant) => {
             bug!("These statements are not allowed in this MIR phase")
         }
     }

--- a/compiler/rustc_borrowck/src/lib.rs
+++ b/compiler/rustc_borrowck/src/lib.rs
@@ -857,7 +857,6 @@ impl<'a, 'tcx> ResultsVisitor<'tcx, Borrowck<'a, 'tcx>> for MirBorrowckCtxt<'a, 
             }
             StatementKind::Nop
             | StatementKind::Retag { .. }
-            | StatementKind::Deinit(..)
             | StatementKind::SetDiscriminant { .. } => {
                 bug!("Statement not allowed in this MIR phase")
             }

--- a/compiler/rustc_borrowck/src/polonius/legacy/loan_invalidations.rs
+++ b/compiler/rustc_borrowck/src/polonius/legacy/loan_invalidations.rs
@@ -84,7 +84,6 @@ impl<'a, 'tcx> Visitor<'tcx> for LoanInvalidationsGenerator<'a, 'tcx> {
             StatementKind::ConstEvalCounter
             | StatementKind::Nop
             | StatementKind::Retag { .. }
-            | StatementKind::Deinit(..)
             | StatementKind::BackwardIncompatibleDropHint { .. }
             | StatementKind::SetDiscriminant { .. } => {
                 bug!("Statement not allowed in this MIR phase")

--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -748,7 +748,6 @@ impl<'a, 'tcx> Visitor<'tcx> for TypeChecker<'a, 'tcx> {
             | StatementKind::BackwardIncompatibleDropHint { .. }
             | StatementKind::Nop => {}
             StatementKind::Intrinsic(box NonDivergingIntrinsic::CopyNonOverlapping(..))
-            | StatementKind::Deinit(..)
             | StatementKind::SetDiscriminant { .. } => {
                 bug!("Statement not allowed in this MIR phase")
             }

--- a/compiler/rustc_codegen_cranelift/src/base.rs
+++ b/compiler/rustc_codegen_cranelift/src/base.rs
@@ -932,7 +932,6 @@ fn codegen_stmt<'tcx>(fx: &mut FunctionCx<'_, '_, 'tcx>, cur_block: Block, stmt:
         }
         StatementKind::StorageLive(_)
         | StatementKind::StorageDead(_)
-        | StatementKind::Deinit(_)
         | StatementKind::ConstEvalCounter
         | StatementKind::Nop
         | StatementKind::FakeRead(..)

--- a/compiler/rustc_codegen_cranelift/src/constant.rs
+++ b/compiler/rustc_codegen_cranelift/src/constant.rs
@@ -597,7 +597,6 @@ pub(crate) fn mir_operand_get_const_val<'tcx>(
                         StatementKind::Assign(_)
                         | StatementKind::FakeRead(_)
                         | StatementKind::SetDiscriminant { .. }
-                        | StatementKind::Deinit(_)
                         | StatementKind::StorageLive(_)
                         | StatementKind::StorageDead(_)
                         | StatementKind::Retag(_, _)

--- a/compiler/rustc_codegen_ssa/src/mir/analyze.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/analyze.rs
@@ -229,7 +229,6 @@ impl<'a, 'b, 'tcx, Bx: BuilderMethods<'b, 'tcx>> Visitor<'tcx> for LocalAnalyzer
 
             PlaceContext::MutatingUse(
                 MutatingUseContext::Store
-                | MutatingUseContext::Deinit
                 | MutatingUseContext::SetDiscriminant
                 | MutatingUseContext::AsmOutput
                 | MutatingUseContext::Borrow

--- a/compiler/rustc_codegen_ssa/src/mir/statement.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/statement.rs
@@ -50,11 +50,6 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
             mir::StatementKind::SetDiscriminant { box ref place, variant_index } => {
                 self.codegen_place(bx, place.as_ref()).codegen_set_discr(bx, variant_index);
             }
-            mir::StatementKind::Deinit(..) => {
-                // For now, don't codegen this to anything. In the future it may be worth
-                // experimenting with what kind of information we can emit to LLVM without hurting
-                // perf here
-            }
             mir::StatementKind::StorageLive(local) => {
                 if let LocalRef::Place(cg_place) = self.locals[local] {
                     cg_place.storage_live(bx);

--- a/compiler/rustc_const_eval/src/check_consts/check.rs
+++ b/compiler/rustc_const_eval/src/check_consts/check.rs
@@ -732,7 +732,6 @@ impl<'tcx> Visitor<'tcx> for Checker<'_, 'tcx> {
         match statement.kind {
             StatementKind::Assign(..)
             | StatementKind::SetDiscriminant { .. }
-            | StatementKind::Deinit(..)
             | StatementKind::FakeRead(..)
             | StatementKind::StorageLive(_)
             | StatementKind::StorageDead(_)

--- a/compiler/rustc_const_eval/src/interpret/step.rs
+++ b/compiler/rustc_const_eval/src/interpret/step.rs
@@ -98,11 +98,6 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                 self.write_discriminant(*variant_index, &dest)?;
             }
 
-            Deinit(place) => {
-                let dest = self.eval_place(**place)?;
-                self.write_uninit(&dest)?;
-            }
-
             // Mark locals as alive
             StorageLive(local) => {
                 self.storage_live(*local)?;

--- a/compiler/rustc_middle/src/mir/pretty.rs
+++ b/compiler/rustc_middle/src/mir/pretty.rs
@@ -818,7 +818,6 @@ impl Debug for Statement<'_> {
             SetDiscriminant { ref place, variant_index } => {
                 write!(fmt, "discriminant({place:?}) = {variant_index:?}")
             }
-            Deinit(ref place) => write!(fmt, "Deinit({place:?})"),
             PlaceMention(ref place) => {
                 write!(fmt, "PlaceMention({place:?})")
             }

--- a/compiler/rustc_middle/src/mir/statement.rs
+++ b/compiler/rustc_middle/src/mir/statement.rs
@@ -50,7 +50,6 @@ impl<'tcx> StatementKind<'tcx> {
             StatementKind::Assign(..) => "Assign",
             StatementKind::FakeRead(..) => "FakeRead",
             StatementKind::SetDiscriminant { .. } => "SetDiscriminant",
-            StatementKind::Deinit(..) => "Deinit",
             StatementKind::StorageLive(..) => "StorageLive",
             StatementKind::StorageDead(..) => "StorageDead",
             StatementKind::Retag(..) => "Retag",

--- a/compiler/rustc_middle/src/mir/syntax.rs
+++ b/compiler/rustc_middle/src/mir/syntax.rs
@@ -135,7 +135,6 @@ pub enum RuntimePhase {
     /// And the following variants are allowed:
     /// * [`StatementKind::Retag`]
     /// * [`StatementKind::SetDiscriminant`]
-    /// * [`StatementKind::Deinit`]
     ///
     /// Furthermore, `Copy` operands are allowed for non-`Copy` types.
     Initial = 0,
@@ -361,11 +360,6 @@ pub enum StatementKind<'tcx> {
     /// entire place; instead, it writes to the minimum set of bytes as required by the layout for
     /// the type.
     SetDiscriminant { place: Box<Place<'tcx>>, variant_index: VariantIdx },
-
-    /// Deinitializes the place.
-    ///
-    /// This writes `uninit` bytes to the entire place.
-    Deinit(Box<Place<'tcx>>),
 
     /// `StorageLive` and `StorageDead` statements mark the live range of a local.
     ///

--- a/compiler/rustc_middle/src/mir/visit.rs
+++ b/compiler/rustc_middle/src/mir/visit.rs
@@ -445,13 +445,6 @@ macro_rules! make_mir_visitor {
                             location
                         );
                     }
-                    StatementKind::Deinit(place) => {
-                        self.visit_place(
-                            place,
-                            PlaceContext::MutatingUse(MutatingUseContext::Deinit),
-                            location
-                        )
-                    }
                     StatementKind::StorageLive(local) => {
                         self.visit_local(
                             $(& $mutability)? *local,
@@ -1372,8 +1365,6 @@ pub enum MutatingUseContext {
     Store,
     /// Appears on `SetDiscriminant`
     SetDiscriminant,
-    /// Appears on `Deinit`
-    Deinit,
     /// Output operand of an inline assembly block.
     AsmOutput,
     /// Destination of a call.

--- a/compiler/rustc_middle/src/mir/visit.rs
+++ b/compiler/rustc_middle/src/mir/visit.rs
@@ -1098,6 +1098,10 @@ macro_rules! super_body {
             }
         }
 
+        for var_debug_info in &$($mutability)? $body.var_debug_info {
+            $self.visit_var_debug_info(var_debug_info);
+        }
+
         for (bb, data) in basic_blocks_iter!($body, $($mutability, $invalidate)?) {
             $self.visit_basic_block_data(bb, data);
         }
@@ -1125,10 +1129,6 @@ macro_rules! super_body {
             $self.visit_user_type_annotation(
                 index, annotation
             );
-        }
-
-        for var_debug_info in &$($mutability)? $body.var_debug_info {
-            $self.visit_var_debug_info(var_debug_info);
         }
 
         $self.visit_span($(& $mutability)? $body.span);

--- a/compiler/rustc_mir_build/src/builder/custom/parse/instruction.rs
+++ b/compiler/rustc_mir_build/src/builder/custom/parse/instruction.rs
@@ -24,9 +24,6 @@ impl<'a, 'tcx> ParseCtxt<'a, 'tcx> {
                 let op = self.parse_operand(args[0])?;
                 Ok(StatementKind::Intrinsic(Box::new(NonDivergingIntrinsic::Assume(op))))
             },
-            @call(mir_deinit, args) => {
-                Ok(StatementKind::Deinit(Box::new(self.parse_place(args[0])?)))
-            },
             @call(mir_retag, args) => {
                 Ok(StatementKind::Retag(RetagKind::Default, Box::new(self.parse_place(args[0])?)))
             },

--- a/compiler/rustc_mir_dataflow/src/impls/liveness.rs
+++ b/compiler/rustc_mir_dataflow/src/impls/liveness.rs
@@ -159,8 +159,7 @@ impl DefUse {
                 MutatingUseContext::Call
                 | MutatingUseContext::Yield
                 | MutatingUseContext::AsmOutput
-                | MutatingUseContext::Store
-                | MutatingUseContext::Deinit,
+                | MutatingUseContext::Store,
             ) => {
                 // Treat derefs as a use of the base local. `*p = 4` is not a def of `p` but a use.
                 if place.is_indirect() {
@@ -238,7 +237,7 @@ impl<'a> MaybeTransitiveLiveLocals<'a> {
                 && (!debuginfo_locals.contains(place.local)
                     || (place.as_local().is_some() && stmt_kind.as_debuginfo().is_some())))
             .then_some(*place),
-            StatementKind::SetDiscriminant { place, .. } | StatementKind::Deinit(place) => {
+            StatementKind::SetDiscriminant { place, .. } => {
                 (!debuginfo_locals.contains(place.local)).then_some(**place)
             }
             StatementKind::FakeRead(_)

--- a/compiler/rustc_mir_dataflow/src/impls/storage_liveness.rs
+++ b/compiler/rustc_mir_dataflow/src/impls/storage_liveness.rs
@@ -156,8 +156,7 @@ impl<'tcx> Analysis<'tcx> for MaybeRequiresStorage<'_, 'tcx> {
 
             // If a place is assigned to in a statement, it needs storage for that statement.
             StatementKind::Assign(box (place, _))
-            | StatementKind::SetDiscriminant { box place, .. }
-            | StatementKind::Deinit(box place) => {
+            | StatementKind::SetDiscriminant { box place, .. } => {
                 state.gen_(place.local);
             }
 

--- a/compiler/rustc_mir_dataflow/src/move_paths/builder.rs
+++ b/compiler/rustc_mir_dataflow/src/move_paths/builder.rs
@@ -371,7 +371,7 @@ impl<'a, 'tcx, F: Fn(Ty<'tcx>) -> bool> MoveDataBuilder<'a, 'tcx, F> {
                     self.gather_move(Place::from(*local));
                 }
             }
-            StatementKind::SetDiscriminant { .. } | StatementKind::Deinit(..) => {
+            StatementKind::SetDiscriminant { .. } => {
                 span_bug!(
                     stmt.source_info.span,
                     "SetDiscriminant/Deinit should not exist during borrowck"

--- a/compiler/rustc_mir_transform/src/coroutine.rs
+++ b/compiler/rustc_mir_transform/src/coroutine.rs
@@ -1723,7 +1723,6 @@ impl<'tcx> Visitor<'tcx> for EnsureCoroutineFieldAssignmentsNeverAlias<'_> {
 
             StatementKind::FakeRead(..)
             | StatementKind::SetDiscriminant { .. }
-            | StatementKind::Deinit(..)
             | StatementKind::StorageLive(_)
             | StatementKind::StorageDead(_)
             | StatementKind::Retag(..)

--- a/compiler/rustc_mir_transform/src/coverage/spans/from_mir.rs
+++ b/compiler/rustc_mir_transform/src/coverage/spans/from_mir.rs
@@ -91,7 +91,6 @@ fn filtered_statement_span(statement: &Statement<'_>) -> Option<Span> {
         )
         | StatementKind::Assign(_)
         | StatementKind::SetDiscriminant { .. }
-        | StatementKind::Deinit(..)
         | StatementKind::Retag(_, _)
         | StatementKind::PlaceMention(..)
         | StatementKind::AscribeUserType(_, _) => Some(statement.source_info.span),

--- a/compiler/rustc_mir_transform/src/cross_crate_inline.rs
+++ b/compiler/rustc_mir_transform/src/cross_crate_inline.rs
@@ -115,10 +115,7 @@ impl<'tcx> Visitor<'tcx> for CostChecker<'_, 'tcx> {
     fn visit_statement(&mut self, statement: &Statement<'tcx>, _: Location) {
         // Don't count StorageLive/StorageDead in the inlining cost.
         match statement.kind {
-            StatementKind::StorageLive(_)
-            | StatementKind::StorageDead(_)
-            | StatementKind::Deinit(_)
-            | StatementKind::Nop => {}
+            StatementKind::StorageLive(_) | StatementKind::StorageDead(_) | StatementKind::Nop => {}
             _ => self.statements += 1,
         }
     }

--- a/compiler/rustc_mir_transform/src/dataflow_const_prop.rs
+++ b/compiler/rustc_mir_transform/src/dataflow_const_prop.rs
@@ -178,10 +178,6 @@ impl<'a, 'tcx> ConstAnalysis<'a, 'tcx> {
                     FlatSet::<Scalar>::BOTTOM,
                 );
             }
-            StatementKind::Deinit(box place) => {
-                // Deinit makes the place uninitialized.
-                state.flood_with(place.as_ref(), &self.map, FlatSet::<Scalar>::BOTTOM);
-            }
             StatementKind::Retag(..) => {
                 // We don't track references.
             }

--- a/compiler/rustc_mir_transform/src/dest_prop.rs
+++ b/compiler/rustc_mir_transform/src/dest_prop.rs
@@ -277,7 +277,6 @@ impl<'tcx> MutVisitor<'tcx> for Merger<'tcx> {
                 if self.merged_locals.contains(*local) =>
             {
                 statement.make_nop(true);
-                return;
             }
             _ => (),
         };

--- a/compiler/rustc_mir_transform/src/jump_threading.rs
+++ b/compiler/rustc_mir_transform/src/jump_threading.rs
@@ -332,8 +332,7 @@ impl<'a, 'tcx> TOFinder<'a, 'tcx> {
         stmt: &Statement<'tcx>,
     ) -> Option<(Place<'tcx>, Option<TrackElem>)> {
         match stmt.kind {
-            StatementKind::Assign(box (place, _))
-            | StatementKind::Deinit(box place) => Some((place, None)),
+            StatementKind::Assign(box (place, _)) => Some((place, None)),
             StatementKind::SetDiscriminant { box place, variant_index: _ } => {
                 Some((place, Some(TrackElem::Discriminant)))
             }

--- a/compiler/rustc_mir_transform/src/known_panics_lint.rs
+++ b/compiler/rustc_mir_transform/src/known_panics_lint.rs
@@ -926,7 +926,6 @@ impl<'tcx> Visitor<'tcx> for CanConstProp {
             // mutations of the same local via `Store`
             | MutatingUse(MutatingUseContext::Call)
             | MutatingUse(MutatingUseContext::AsmOutput)
-            | MutatingUse(MutatingUseContext::Deinit)
             // Actual store that can possibly even propagate a value
             | MutatingUse(MutatingUseContext::Store)
             | MutatingUse(MutatingUseContext::SetDiscriminant) => {

--- a/compiler/rustc_mir_transform/src/large_enums.rs
+++ b/compiler/rustc_mir_transform/src/large_enums.rs
@@ -126,8 +126,6 @@ impl<'tcx> crate::MirPass<'tcx> for EnumSizeOpt {
                     Rvalue::Cast(CastKind::PtrToPtr, Operand::Copy(src), src_cast_ty),
                 )));
 
-                let deinit_old = StatementKind::Deinit(Box::new(dst));
-
                 let copy_bytes = StatementKind::Intrinsic(Box::new(
                     NonDivergingIntrinsic::CopyNonOverlapping(CopyNonOverlapping {
                         src: Operand::Copy(src_cast_place),
@@ -148,7 +146,6 @@ impl<'tcx> crate::MirPass<'tcx> for EnumSizeOpt {
                     dst_cast,
                     src_ptr,
                     src_cast,
-                    deinit_old,
                     copy_bytes,
                     store_dead,
                 ];

--- a/compiler/rustc_mir_transform/src/remove_noop_landing_pads.rs
+++ b/compiler/rustc_mir_transform/src/remove_noop_landing_pads.rs
@@ -113,7 +113,6 @@ impl RemoveNoopLandingPads {
 
                 StatementKind::Assign { .. }
                 | StatementKind::SetDiscriminant { .. }
-                | StatementKind::Deinit(..)
                 | StatementKind::Intrinsic(..)
                 | StatementKind::Retag { .. } => {
                     return false;

--- a/compiler/rustc_mir_transform/src/remove_zsts.rs
+++ b/compiler/rustc_mir_transform/src/remove_zsts.rs
@@ -122,8 +122,7 @@ impl<'tcx> MutVisitor<'tcx> for Replacer<'_, 'tcx> {
             StatementKind::Assign(box (place, ref rvalue)) => {
                 rvalue.is_safe_to_remove().then_some(place)
             }
-            StatementKind::Deinit(box place)
-            | StatementKind::SetDiscriminant { box place, variant_index: _ }
+            StatementKind::SetDiscriminant { box place, variant_index: _ }
             | StatementKind::AscribeUserType(box (place, _), _)
             | StatementKind::Retag(_, box place)
             | StatementKind::PlaceMention(box place)

--- a/compiler/rustc_mir_transform/src/simplify.rs
+++ b/compiler/rustc_mir_transform/src/simplify.rs
@@ -590,7 +590,6 @@ impl<'tcx> Visitor<'tcx> for UsedLocals {
             }
 
             StatementKind::SetDiscriminant { ref place, variant_index: _ }
-            | StatementKind::Deinit(ref place)
             | StatementKind::BackwardIncompatibleDropHint { ref place, reason: _ } => {
                 self.visit_lhs(place, location);
             }
@@ -630,8 +629,9 @@ fn remove_unused_definitions_helper(used_locals: &mut UsedLocals, body: &mut Bod
                     }
                     StatementKind::Assign(box (place, _))
                     | StatementKind::SetDiscriminant { box place, .. }
-                    | StatementKind::BackwardIncompatibleDropHint { box place, .. }
-                    | StatementKind::Deinit(box place) => used_locals.is_used(place.local),
+                    | StatementKind::BackwardIncompatibleDropHint { box place, .. } => {
+                        used_locals.is_used(place.local)
+                    }
                     _ => continue,
                 };
                 if keep_statement {

--- a/compiler/rustc_mir_transform/src/sroa.rs
+++ b/compiler/rustc_mir_transform/src/sroa.rs
@@ -136,9 +136,7 @@ fn escaping_locals<'tcx>(
         fn visit_statement(&mut self, statement: &Statement<'tcx>, location: Location) {
             match statement.kind {
                 // Storage statements are expanded in run_pass.
-                StatementKind::StorageLive(..)
-                | StatementKind::StorageDead(..)
-                | StatementKind::Deinit(..) => return,
+                StatementKind::StorageLive(..) | StatementKind::StorageDead(..) => return,
                 _ => self.super_statement(statement, location),
             }
         }
@@ -330,16 +328,6 @@ impl<'tcx, 'll> MutVisitor<'tcx> for ReplacementVisitor<'tcx, 'll> {
                     statement.make_nop(true);
                 }
                 return;
-            }
-            StatementKind::Deinit(box place) => {
-                if let Some(final_locals) = self.replacements.place_fragments(place) {
-                    for (_, _, fl) in final_locals {
-                        self.patch
-                            .add_statement(location, StatementKind::Deinit(Box::new(fl.into())));
-                    }
-                    statement.make_nop(true);
-                    return;
-                }
             }
 
             // We have `a = Struct { 0: x, 1: y, .. }`.

--- a/compiler/rustc_mir_transform/src/validate.rs
+++ b/compiler/rustc_mir_transform/src/validate.rs
@@ -313,11 +313,6 @@ impl<'a, 'tcx> Visitor<'tcx> for CfgChecker<'a, 'tcx> {
                     self.fail(location, "`SetDiscriminant`is not allowed until deaggregation");
                 }
             }
-            StatementKind::Deinit(..) => {
-                if self.body.phase < MirPhase::Runtime(RuntimePhase::Initial) {
-                    self.fail(location, "`Deinit`is not allowed until deaggregation");
-                }
-            }
             StatementKind::Retag(kind, _) => {
                 // FIXME(JakobDegen) The validator should check that `self.body.phase <
                 // DropsLowered`. However, this causes ICEs with generation of drop shims, which
@@ -1499,11 +1494,6 @@ impl<'a, 'tcx> Visitor<'tcx> for TypeChecker<'a, 'tcx> {
                             "`SetDiscriminant` is only allowed on ADTs and coroutines, not {pty}"
                         ),
                     );
-                }
-            }
-            StatementKind::Deinit(..) => {
-                if self.body.phase < MirPhase::Runtime(RuntimePhase::Initial) {
-                    self.fail(location, "`Deinit`is not allowed until deaggregation");
                 }
             }
             StatementKind::Retag(kind, _) => {

--- a/compiler/rustc_mir_transform/src/validate.rs
+++ b/compiler/rustc_mir_transform/src/validate.rs
@@ -17,6 +17,7 @@ use rustc_middle::ty::{
     self, CoroutineArgsExt, InstanceKind, ScalarInt, Ty, TyCtxt, TypeVisitableExt, Upcast, Variance,
 };
 use rustc_middle::{bug, span_bug};
+use rustc_mir_dataflow::debuginfo::debuginfo_locals;
 use rustc_trait_selection::traits::ObligationCtxt;
 
 use crate::util::{self, is_within_packed};
@@ -77,6 +78,11 @@ impl<'tcx> crate::MirPass<'tcx> for Validator {
 
         // Also run the TypeChecker.
         for (location, msg) in validate_types(tcx, typing_env, body, body) {
+            cfg_checker.fail(location, msg);
+        }
+
+        // Ensure that debuginfo records are not emitted for locals that are not in debuginfo.
+        for (location, msg) in validate_debuginfos(body) {
             cfg_checker.fail(location, msg);
         }
 
@@ -1593,5 +1599,32 @@ impl<'a, 'tcx> Visitor<'tcx> for TypeChecker<'a, 'tcx> {
         }
 
         self.super_terminator(terminator, location);
+    }
+}
+
+pub(super) fn validate_debuginfos<'tcx>(body: &Body<'tcx>) -> Vec<(Location, String)> {
+    let mut debuginfo_checker =
+        DebuginfoChecker { debuginfo_locals: debuginfo_locals(body), failures: Vec::new() };
+    debuginfo_checker.visit_body(body);
+    debuginfo_checker.failures
+}
+
+struct DebuginfoChecker {
+    debuginfo_locals: DenseBitSet<Local>,
+    failures: Vec<(Location, String)>,
+}
+
+impl<'tcx> Visitor<'tcx> for DebuginfoChecker {
+    fn visit_statement_debuginfo(
+        &mut self,
+        stmt_debuginfo: &StmtDebugInfo<'tcx>,
+        location: Location,
+    ) {
+        let local = match stmt_debuginfo {
+            StmtDebugInfo::AssignRef(local, _) | StmtDebugInfo::InvalidAssign(local) => *local,
+        };
+        if !self.debuginfo_locals.contains(local) {
+            self.failures.push((location, format!("{local:?} is not in debuginfo")));
+        }
     }
 }

--- a/compiler/rustc_public/src/mir/body.rs
+++ b/compiler/rustc_public/src/mir/body.rs
@@ -478,7 +478,6 @@ pub enum StatementKind {
     Assign(Place, Rvalue),
     FakeRead(FakeReadCause, Place),
     SetDiscriminant { place: Place, variant_index: VariantIdx },
-    Deinit(Place),
     StorageLive(Local),
     StorageDead(Local),
     Retag(RetagKind, Place),

--- a/compiler/rustc_public/src/mir/pretty.rs
+++ b/compiler/rustc_public/src/mir/pretty.rs
@@ -102,7 +102,6 @@ fn pretty_statement<W: Write>(writer: &mut W, statement: &StatementKind) -> io::
         StatementKind::SetDiscriminant { place, variant_index } => {
             writeln!(writer, "{INDENT}discriminant({place:?}) = {};", variant_index.to_index())
         }
-        StatementKind::Deinit(place) => writeln!(writer, "Deinit({place:?};"),
         StatementKind::StorageLive(local) => {
             writeln!(writer, "{INDENT}StorageLive(_{local});")
         }

--- a/compiler/rustc_public/src/mir/visit.rs
+++ b/compiler/rustc_public/src/mir/visit.rs
@@ -170,7 +170,6 @@ macro_rules! make_mir_visitor {
                         self.visit_place(place, PlaceContext::NON_MUTATING, location);
                     }
                     StatementKind::SetDiscriminant { place, .. }
-                    | StatementKind::Deinit(place)
                     | StatementKind::Retag(_, place) => {
                         self.visit_place(place, PlaceContext::MUTATING, location);
                     }

--- a/compiler/rustc_public/src/unstable/convert/stable/mir.rs
+++ b/compiler/rustc_public/src/unstable/convert/stable/mir.rs
@@ -149,9 +149,6 @@ impl<'tcx> Stable<'tcx> for mir::StatementKind<'tcx> {
                     variant_index: variant_index.stable(tables, cx),
                 }
             }
-            mir::StatementKind::Deinit(place) => {
-                crate::mir::StatementKind::Deinit(place.stable(tables, cx))
-            }
 
             mir::StatementKind::StorageLive(place) => {
                 crate::mir::StatementKind::StorageLive(place.stable(tables, cx))

--- a/compiler/rustc_target/src/spec/targets/armv7a_none_eabihf.rs
+++ b/compiler/rustc_target/src/spec/targets/armv7a_none_eabihf.rs
@@ -30,7 +30,7 @@ pub(crate) fn target() -> Target {
         llvm_target: "armv7a-none-eabihf".into(),
         metadata: TargetMetadata {
             description: Some("Bare Armv7-A, hardfloat".into()),
-            tier: Some(3),
+            tier: Some(2),
             host_tools: Some(false),
             std: Some(false),
         },

--- a/compiler/rustc_target/src/spec/targets/armv8r_none_eabihf.rs
+++ b/compiler/rustc_target/src/spec/targets/armv8r_none_eabihf.rs
@@ -10,7 +10,7 @@ pub(crate) fn target() -> Target {
         llvm_target: "armv8r-none-eabihf".into(),
         metadata: TargetMetadata {
             description: Some("Bare Armv8-R, hardfloat".into()),
-            tier: Some(3),
+            tier: Some(2),
             host_tools: Some(false),
             std: Some(false),
         },

--- a/library/core/src/intrinsics/mir.rs
+++ b/library/core/src/intrinsics/mir.rs
@@ -227,7 +227,7 @@
 //!
 //! #### Statements
 //!  - Assign statements work via normal Rust assignment.
-//!  - [`Retag`], [`StorageLive`], [`StorageDead`], [`Deinit`] statements have an associated function.
+//!  - [`Retag`], [`StorageLive`], [`StorageDead`] statements have an associated function.
 //!
 //! #### Rvalues
 //!
@@ -400,7 +400,6 @@ define!("mir_unwind_resume",
 define!("mir_storage_live", fn StorageLive<T>(local: T));
 define!("mir_storage_dead", fn StorageDead<T>(local: T));
 define!("mir_assume", fn Assume(operand: bool));
-define!("mir_deinit", fn Deinit<T>(place: T));
 define!("mir_checked", fn Checked<T>(binop: T) -> (T, bool));
 define!(
     "mir_ptr_metadata",

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -1373,7 +1373,6 @@ macro_rules! nonzero_integer_signedness_dependent_impls {
             /// # Examples
             ///
             /// ```
-            /// # #![feature(unsigned_nonzero_div_ceil)]
             /// # use std::num::NonZero;
             #[doc = concat!("let one = NonZero::new(1", stringify!($Int), ").unwrap();")]
             #[doc = concat!("let max = NonZero::new(", stringify!($Int), "::MAX).unwrap();")]
@@ -1383,7 +1382,11 @@ macro_rules! nonzero_integer_signedness_dependent_impls {
             #[doc = concat!("let three = NonZero::new(3", stringify!($Int), ").unwrap();")]
             /// assert_eq!(three.div_ceil(two), two);
             /// ```
-            #[unstable(feature = "unsigned_nonzero_div_ceil", issue = "132968")]
+            #[stable(feature = "unsigned_nonzero_div_ceil", since = "CURRENT_RUSTC_VERSION")]
+            #[rustc_const_stable(
+                feature = "unsigned_nonzero_div_ceil",
+                since = "CURRENT_RUSTC_VERSION"
+            )]
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
             #[inline]

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -3552,7 +3552,6 @@ macro_rules! uint_impl {
         #[rustc_const_stable(feature = "unsigned_is_multiple_of", since = "1.87.0")]
         #[must_use]
         #[inline]
-        #[rustc_inherit_overflow_checks]
         pub const fn is_multiple_of(self, rhs: Self) -> bool {
             match rhs {
                 0 => self == 0,

--- a/library/proc_macro/src/lib.rs
+++ b/library/proc_macro/src/lib.rs
@@ -383,7 +383,7 @@ macro_rules! extend_items {
             #[stable(feature = "token_stream_extend_tt_items", since = "CURRENT_RUSTC_VERSION")]
             impl Extend<$item> for TokenStream {
                 fn extend<T: IntoIterator<Item = $item>>(&mut self, iter: T) {
-                    self.extend(iter.into_iter().map(|i| TokenTree::$item(i)));
+                    self.extend(iter.into_iter().map(TokenTree::$item));
                 }
             }
         )*

--- a/library/proc_macro/src/lib.rs
+++ b/library/proc_macro/src/lib.rs
@@ -377,6 +377,21 @@ impl Extend<TokenStream> for TokenStream {
     }
 }
 
+macro_rules! extend_items {
+    ($($item:ident)*) => {
+        $(
+            #[stable(feature = "token_stream_extend_tt_items", since = "CURRENT_RUSTC_VERSION")]
+            impl Extend<$item> for TokenStream {
+                fn extend<T: IntoIterator<Item = $item>>(&mut self, iter: T) {
+                    self.extend(iter.into_iter().map(|i| TokenTree::$item(i)));
+                }
+            }
+        )*
+    };
+}
+
+extend_items!(Group Literal Punct Ident);
+
 /// Public implementation details for the `TokenStream` type, such as iterators.
 #[stable(feature = "proc_macro_lib2", since = "1.29.0")]
 pub mod token_stream {

--- a/library/std/src/sys/thread_local/native/mod.rs
+++ b/library/std/src/sys/thread_local/native/mod.rs
@@ -55,7 +55,7 @@ pub macro thread_local_inner {
 
     // Used to generate the `LocalKey` value for const-initialized thread locals.
     (@key $t:ty, $(#[$align_attr:meta])*, const $init:expr) => {{
-        const __INIT: $t = $init;
+        const __RUST_STD_INTERNAL_INIT: $t = $init;
 
         unsafe {
             $crate::thread::LocalKey::new(const {
@@ -63,16 +63,16 @@ pub macro thread_local_inner {
                     |_| {
                         #[thread_local]
                         $(#[$align_attr])*
-                        static VAL: $crate::thread::local_impl::EagerStorage<$t>
-                            = $crate::thread::local_impl::EagerStorage::new(__INIT);
-                        VAL.get()
+                        static __RUST_STD_INTERNAL_VAL: $crate::thread::local_impl::EagerStorage<$t>
+                            = $crate::thread::local_impl::EagerStorage::new(__RUST_STD_INTERNAL_INIT);
+                        __RUST_STD_INTERNAL_VAL.get()
                     }
                 } else {
                     |_| {
                         #[thread_local]
                         $(#[$align_attr])*
-                        static VAL: $t = __INIT;
-                        &VAL
+                        static __RUST_STD_INTERNAL_VAL: $t = __RUST_STD_INTERNAL_INIT;
+                        &__RUST_STD_INTERNAL_VAL
                     }
                 }
             })
@@ -82,27 +82,27 @@ pub macro thread_local_inner {
     // used to generate the `LocalKey` value for `thread_local!`
     (@key $t:ty, $(#[$align_attr:meta])*, $init:expr) => {{
         #[inline]
-        fn __init() -> $t {
+        fn __rust_std_internal_init_fn() -> $t {
             $init
         }
 
         unsafe {
             $crate::thread::LocalKey::new(const {
                 if $crate::mem::needs_drop::<$t>() {
-                    |init| {
+                    |__rust_std_internal_init| {
                         #[thread_local]
                         $(#[$align_attr])*
-                        static VAL: $crate::thread::local_impl::LazyStorage<$t, ()>
+                        static __RUST_STD_INTERNAL_VAL: $crate::thread::local_impl::LazyStorage<$t, ()>
                             = $crate::thread::local_impl::LazyStorage::new();
-                        VAL.get_or_init(init, __init)
+                        __RUST_STD_INTERNAL_VAL.get_or_init(__rust_std_internal_init, __rust_std_internal_init_fn)
                     }
                 } else {
-                    |init| {
+                    |__rust_std_internal_init| {
                         #[thread_local]
                         $(#[$align_attr])*
-                        static VAL: $crate::thread::local_impl::LazyStorage<$t, !>
+                        static __RUST_STD_INTERNAL_VAL: $crate::thread::local_impl::LazyStorage<$t, !>
                             = $crate::thread::local_impl::LazyStorage::new();
-                        VAL.get_or_init(init, __init)
+                        __RUST_STD_INTERNAL_VAL.get_or_init(__rust_std_internal_init, __rust_std_internal_init_fn)
                     }
                 }
             })

--- a/library/std/src/sys/thread_local/no_threads.rs
+++ b/library/std/src/sys/thread_local/no_threads.rs
@@ -13,15 +13,15 @@ use crate::ptr;
 pub macro thread_local_inner {
     // used to generate the `LocalKey` value for const-initialized thread locals
     (@key $t:ty, $(#[$align_attr:meta])*, const $init:expr) => {{
-        const __INIT: $t = $init;
+        const __RUST_STD_INTERNAL_INIT: $t = $init;
 
         // NOTE: Please update the shadowing test in `tests/thread.rs` if these types are renamed.
         unsafe {
             $crate::thread::LocalKey::new(|_| {
                 $(#[$align_attr])*
-                static VAL: $crate::thread::local_impl::EagerStorage<$t> =
-                    $crate::thread::local_impl::EagerStorage { value: __INIT };
-                &VAL.value
+                static __RUST_STD_INTERNAL_VAL: $crate::thread::local_impl::EagerStorage<$t> =
+                    $crate::thread::local_impl::EagerStorage { value: __RUST_STD_INTERNAL_INIT };
+                &__RUST_STD_INTERNAL_VAL.value
             })
         }
     }},
@@ -29,13 +29,13 @@ pub macro thread_local_inner {
     // used to generate the `LocalKey` value for `thread_local!`
     (@key $t:ty, $(#[$align_attr:meta])*, $init:expr) => {{
         #[inline]
-        fn __init() -> $t { $init }
+        fn __rust_std_internal_init_fn() -> $t { $init }
 
         unsafe {
-            $crate::thread::LocalKey::new(|init| {
+            $crate::thread::LocalKey::new(|__rust_std_internal_init| {
                 $(#[$align_attr])*
-                static VAL: $crate::thread::local_impl::LazyStorage<$t> = $crate::thread::local_impl::LazyStorage::new();
-                VAL.get(init, __init)
+                static __RUST_STD_INTERNAL_VAL: $crate::thread::local_impl::LazyStorage<$t> = $crate::thread::local_impl::LazyStorage::new();
+                __RUST_STD_INTERNAL_VAL.get(__rust_std_internal_init, __rust_std_internal_init_fn)
             })
         }
     }},

--- a/library/std/src/sys/thread_local/os.rs
+++ b/library/std/src/sys/thread_local/os.rs
@@ -21,14 +21,14 @@ pub macro thread_local_inner {
     // used to generate the `LocalKey` value for `thread_local!`.
     (@key $t:ty, $($(#[$($align_attr:tt)*])+)?, $init:expr) => {{
         #[inline]
-        fn __init() -> $t { $init }
+        fn __rust_std_internal_init_fn() -> $t { $init }
 
         // NOTE: this cannot import `LocalKey` or `Storage` with a `use` because that can shadow
         // user provided type or type alias with a matching name. Please update the shadowing test
         // in `tests/thread.rs` if these types are renamed.
         unsafe {
-            $crate::thread::LocalKey::new(|init| {
-                static VAL: $crate::thread::local_impl::Storage<$t, {
+            $crate::thread::LocalKey::new(|__rust_std_internal_init| {
+                static __RUST_STD_INTERNAL_VAL: $crate::thread::local_impl::Storage<$t, {
                     $({
                         // Ensure that attributes have valid syntax
                         // and that the proper feature gate is enabled
@@ -43,7 +43,7 @@ pub macro thread_local_inner {
                     final_align
                 }>
                     = $crate::thread::local_impl::Storage::new();
-                VAL.get(init, __init)
+                __RUST_STD_INTERNAL_VAL.get(__rust_std_internal_init, __rust_std_internal_init_fn)
             })
         }
     }},

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -165,6 +165,7 @@ target | std | notes
 `armv7-unknown-linux-musleabi` | ✓ | Armv7-A Linux with musl 1.2.3
 `armv7-unknown-linux-musleabihf` | ✓ | Armv7-A Linux with musl 1.2.3, hardfloat
 [`armv7a-none-eabi`](platform-support/armv7a-none-eabi.md) | * | Bare Armv7-A
+[`armv7a-none-eabihf`](platform-support/armv7a-none-eabi.md) | * |  | Bare Armv7-A, hardfloat
 [`armv7r-none-eabi`](platform-support/armv7r-none-eabi.md) | * | Bare Armv7-R
 [`armv7r-none-eabihf`](platform-support/armv7r-none-eabi.md) | * | Bare Armv7-R, hardfloat
 `i586-unknown-linux-gnu` | ✓ | 32-bit Linux (kernel 3.2+, glibc 2.17, original Pentium) [^x86_32-floats-x87]
@@ -300,7 +301,6 @@ target | std | host | notes
 [`armv7-wrs-vxworks-eabihf`](platform-support/vxworks.md) | ✓ |  | Armv7-A for VxWorks
 [`armv7a-kmc-solid_asp3-eabi`](platform-support/kmc-solid.md) | ✓ |  | ARM SOLID with TOPPERS/ASP3
 [`armv7a-kmc-solid_asp3-eabihf`](platform-support/kmc-solid.md) | ✓ |  | ARM SOLID with TOPPERS/ASP3, hardfloat
-[`armv7a-none-eabihf`](platform-support/arm-none-eabi.md) | * |  | Bare Armv7-A, hardfloat
 [`armv7a-vex-v5`](platform-support/armv7a-vex-v5.md) | ? |  | Armv7-A Cortex-A9 VEX V5 Brain, VEXos
 [`armv7k-apple-watchos`](platform-support/apple-watchos.md) | ✓ |  | Armv7-A Apple WatchOS
 [`armv7s-apple-ios`](platform-support/apple-ios.md) | ✓ |  | Armv7-A Apple-A6 Apple iOS

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -167,6 +167,7 @@ target | std | notes
 [`armv7a-none-eabi`](platform-support/armv7a-none-eabi.md) | * | Bare Armv7-A
 [`armv7r-none-eabi`](platform-support/armv7r-none-eabi.md) | * | Bare Armv7-R
 [`armv7r-none-eabihf`](platform-support/armv7r-none-eabi.md) | * | Bare Armv7-R, hardfloat
+[`armv8r-none-eabihf`](platform-support/armv8r-none-eabihf.md) | * |  | Bare Armv8-R, hardfloat
 `i586-unknown-linux-gnu` | ✓ | 32-bit Linux (kernel 3.2+, glibc 2.17, original Pentium) [^x86_32-floats-x87]
 `i586-unknown-linux-musl` | ✓ | 32-bit Linux (musl 1.2.3, original Pentium) [^x86_32-floats-x87]
 [`i686-linux-android`](platform-support/android.md) | ✓ | 32-bit x86 Android ([Pentium 4 plus various extensions](https://developer.android.com/ndk/guides/abis.html#x86)) [^x86_32-floats-return-ABI]
@@ -304,7 +305,6 @@ target | std | host | notes
 [`armv7a-vex-v5`](platform-support/armv7a-vex-v5.md) | ? |  | Armv7-A Cortex-A9 VEX V5 Brain, VEXos
 [`armv7k-apple-watchos`](platform-support/apple-watchos.md) | ✓ |  | Armv7-A Apple WatchOS
 [`armv7s-apple-ios`](platform-support/apple-ios.md) | ✓ |  | Armv7-A Apple-A6 Apple iOS
-[`armv8r-none-eabihf`](platform-support/armv8r-none-eabihf.md) | * |  | Bare Armv8-R, hardfloat
 [`armv7a-nuttx-eabi`](platform-support/nuttx.md) | ✓ |  | ARMv7-A with NuttX
 [`armv7a-nuttx-eabihf`](platform-support/nuttx.md) | ✓ |  | ARMv7-A with NuttX, hardfloat
 [`avr-none`](platform-support/avr-none.md) | * |  | AVR; requires `-Zbuild-std=core` and `-Ctarget-cpu=...`

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -198,7 +198,6 @@ target | std | notes
 [`wasm32-wasip1`](platform-support/wasm32-wasip1.md) | ✓ | WebAssembly with WASIp1
 [`wasm32-wasip1-threads`](platform-support/wasm32-wasip1-threads.md) | ✓ | WebAssembly with WASI Preview 1 and threads
 [`wasm32-wasip2`](platform-support/wasm32-wasip2.md) | ✓ | WebAssembly with WASIp2
-[`wasm32-wasip3`](platform-support/wasm32-wasip3.md) | ✓ | WebAssembly with WASIp3
 [`wasm32v1-none`](platform-support/wasm32v1-none.md) | * | WebAssembly limited to 1.0 features and no imports
 [`x86_64-apple-ios`](platform-support/apple-ios.md) | ✓ | 64-bit x86 iOS
 [`x86_64-apple-ios-macabi`](platform-support/apple-ios-macabi.md) | ✓ | Mac Catalyst on x86_64
@@ -417,6 +416,7 @@ target | std | host | notes
 [`thumbv8m.main-nuttx-eabihf`](platform-support/nuttx.md) | ✓ |  | ARMv8M Mainline with NuttX, hardfloat
 [`wasm64-unknown-unknown`](platform-support/wasm64-unknown-unknown.md) | ? |  | WebAssembly
 [`wasm32-wali-linux-musl`](platform-support/wasm32-wali-linux.md) | ? |  | WebAssembly with [WALI](https://github.com/arjunr2/WALI)
+[`wasm32-wasip3`](platform-support/wasm32-wasip3.md) | ✓ | WebAssembly with WASIp3
 [`x86_64-apple-tvos`](platform-support/apple-tvos.md) | ✓ |  | x86 64-bit tvOS
 [`x86_64-apple-watchos-sim`](platform-support/apple-watchos.md) | ✓ |  | x86 64-bit Apple WatchOS simulator
 [`x86_64-lynx-lynxos178`](platform-support/lynxos178.md) |   |  | x86_64 LynxOS-178

--- a/src/doc/rustc/src/platform-support/armv7a-none-eabi.md
+++ b/src/doc/rustc/src/platform-support/armv7a-none-eabi.md
@@ -1,7 +1,6 @@
 # `armv7a-none-eabi` and `armv7a-none-eabihf`
 
-* **Tier: 2** for `armv7a-none-eabi`
-* **Tier: 3** for `armv7a-none-eabihf`
+* **Tier: 2**
 * **Library Support:** core and alloc (bare-metal, `#![no_std]`)
 
 Bare-metal target for CPUs in the Armv7-A architecture family, supporting

--- a/src/doc/rustc/src/platform-support/armv8r-none-eabihf.md
+++ b/src/doc/rustc/src/platform-support/armv8r-none-eabihf.md
@@ -1,6 +1,6 @@
 # `armv8r-none-eabihf`
 
-* **Tier: 3**
+* **Tier: 2**
 * **Library Support:** core and alloc (bare-metal, `#![no_std]`)
 
 Bare-metal target for CPUs in the Armv8-R architecture family, supporting

--- a/src/tools/clippy/clippy_utils/src/qualify_min_const_fn.rs
+++ b/src/tools/clippy/clippy_utils/src/qualify_min_const_fn.rs
@@ -232,7 +232,7 @@ fn check_statement<'tcx>(
 
         StatementKind::FakeRead(box (_, place)) => check_place(cx, *place, span, body, msrv),
         // just an assignment
-        StatementKind::SetDiscriminant { place, .. } | StatementKind::Deinit(place) => {
+        StatementKind::SetDiscriminant { place, .. } => {
             check_place(cx, **place, span, body, msrv)
         },
 

--- a/src/tools/compiletest/src/directives/file.rs
+++ b/src/tools/compiletest/src/directives/file.rs
@@ -1,0 +1,24 @@
+use camino::Utf8Path;
+
+use crate::directives::line::{DirectiveLine, line_directive};
+
+pub(crate) struct FileDirectives<'a> {
+    pub(crate) path: &'a Utf8Path,
+    pub(crate) lines: Vec<DirectiveLine<'a>>,
+}
+
+impl<'a> FileDirectives<'a> {
+    pub(crate) fn from_file_contents(path: &'a Utf8Path, file_contents: &'a str) -> Self {
+        let mut lines = vec![];
+
+        for (line_number, ln) in (1..).zip(file_contents.lines()) {
+            let ln = ln.trim();
+
+            if let Some(directive_line) = line_directive(line_number, ln) {
+                lines.push(directive_line);
+            }
+        }
+
+        Self { path, lines }
+    }
+}

--- a/tests/crashes/147485-2.rs
+++ b/tests/crashes/147485-2.rs
@@ -1,0 +1,16 @@
+//@ known-bug: #147485
+//@ compile-flags: -g -O
+
+#![crate_type = "lib"]
+
+pub fn foo(a: bool, b: bool) -> bool {
+    let mut c = &a;
+    if false {
+        return *c;
+    }
+    let d = b && a;
+    if d {
+        c = &b;
+    }
+    b
+}

--- a/tests/crashes/147485.rs
+++ b/tests/crashes/147485.rs
@@ -1,0 +1,14 @@
+//@ known-bug: #147485
+//@ compile-flags: -g -O
+
+#![crate_type = "lib"]
+
+pub fn f(x: *const usize) -> &'static usize {
+    let mut a = unsafe { &*x };
+    a = unsafe { &*x };
+    a
+}
+
+pub fn g() {
+    f(&0);
+}

--- a/tests/mir-opt/building/custom/enums.rs
+++ b/tests/mir-opt/building/custom/enums.rs
@@ -88,7 +88,6 @@ fn switch_option_repr(option: Bool) -> bool {
 fn set_discr(option: &mut Option<()>) {
     mir! {
         {
-            Deinit(*option);
             SetDiscriminant(*option, 0);
             Return()
         }

--- a/tests/mir-opt/building/custom/enums.set_discr.built.after.mir
+++ b/tests/mir-opt/building/custom/enums.set_discr.built.after.mir
@@ -4,7 +4,6 @@ fn set_discr(_1: &mut Option<()>) -> () {
     let mut _0: ();
 
     bb0: {
-        Deinit((*_1));
         discriminant((*_1)) = 0;
         return;
     }

--- a/tests/mir-opt/debuginfo/dest_prop.remap_debuginfo_locals.DestinationPropagation.diff
+++ b/tests/mir-opt/debuginfo/dest_prop.remap_debuginfo_locals.DestinationPropagation.diff
@@ -9,11 +9,12 @@
       let mut _4: bool;
   
       bb0: {
-          // DBG: _3 = &_1;
+-         // DBG: _3 = &_1;
 -         StorageLive(_4);
 -         _4 = copy _1;
 -         _3 = copy _2;
 -         switchInt(copy _4) -> [1: bb1, otherwise: bb2];
++         // DBG: _2 = &_1;
 +         nop;
 +         nop;
 +         nop;

--- a/tests/mir-opt/debuginfo/dest_prop.remap_debuginfo_locals.DestinationPropagation.diff
+++ b/tests/mir-opt/debuginfo/dest_prop.remap_debuginfo_locals.DestinationPropagation.diff
@@ -1,0 +1,35 @@
+- // MIR for `remap_debuginfo_locals` before DestinationPropagation
++ // MIR for `remap_debuginfo_locals` after DestinationPropagation
+  
+  fn remap_debuginfo_locals(_1: bool, _2: &bool) -> &bool {
+-     debug c => _3;
++     debug c => _2;
+      let mut _0: &bool;
+      let mut _3: &bool;
+      let mut _4: bool;
+  
+      bb0: {
+          // DBG: _3 = &_1;
+-         StorageLive(_4);
+-         _4 = copy _1;
+-         _3 = copy _2;
+-         switchInt(copy _4) -> [1: bb1, otherwise: bb2];
++         nop;
++         nop;
++         nop;
++         switchInt(copy _1) -> [1: bb1, otherwise: bb2];
+      }
+  
+      bb1: {
+          goto -> bb2;
+      }
+  
+      bb2: {
+-         StorageDead(_4);
+-         _0 = copy _3;
++         nop;
++         _0 = copy _2;
+          return;
+      }
+  }
+  

--- a/tests/mir-opt/debuginfo/dest_prop.rs
+++ b/tests/mir-opt/debuginfo/dest_prop.rs
@@ -1,0 +1,36 @@
+// skip-filecheck
+//@ test-mir-pass: DestinationPropagation
+//@ compile-flags: -g -Zmir-enable-passes=+DeadStoreElimination-initial
+
+#![feature(core_intrinsics, custom_mir)]
+#![crate_type = "lib"]
+
+use std::intrinsics::mir::*;
+
+// EMIT_MIR dest_prop.remap_debuginfo_locals.DestinationPropagation.diff
+#[custom_mir(dialect = "runtime", phase = "post-cleanup")]
+pub fn remap_debuginfo_locals(a: bool, b: &bool) -> &bool {
+    mir! {
+        let _3: &bool;
+        let _4: bool;
+        debug c => _3;
+        {
+            _3 = &a;
+            StorageLive(_4);
+            _4 = a;
+            _3 = b;
+            match _4 {
+                true => bb1,
+                _ => bb2,
+            }
+        }
+        bb1 = {
+            Goto(bb2)
+        }
+        bb2 = {
+            StorageDead(_4);
+            RET = _3;
+            Return()
+        }
+    }
+}

--- a/tests/mir-opt/debuginfo/dest_prop.rs
+++ b/tests/mir-opt/debuginfo/dest_prop.rs
@@ -1,4 +1,3 @@
-// skip-filecheck
 //@ test-mir-pass: DestinationPropagation
 //@ compile-flags: -g -Zmir-enable-passes=+DeadStoreElimination-initial
 
@@ -10,6 +9,10 @@ use std::intrinsics::mir::*;
 // EMIT_MIR dest_prop.remap_debuginfo_locals.DestinationPropagation.diff
 #[custom_mir(dialect = "runtime", phase = "post-cleanup")]
 pub fn remap_debuginfo_locals(a: bool, b: &bool) -> &bool {
+    // CHECK-LABEL: fn remap_debuginfo_locals(
+    // CHECK: debug c => [[c:_.*]];
+    // CHECK: bb0:
+    // CHECK-NEXT: DBG: [[c]] = &_1;
     mir! {
         let _3: &bool;
         let _4: bool;

--- a/tests/mir-opt/debuginfo/ref_prop.remap_debuginfo_locals.ReferencePropagation.diff
+++ b/tests/mir-opt/debuginfo/ref_prop.remap_debuginfo_locals.ReferencePropagation.diff
@@ -25,7 +25,7 @@
 -         StorageDead(_2);
 -         StorageDead(_3);
 -         StorageDead(_1);
-+         // DBG: _1 = &(*_5);
++         // DBG: _5 = &(*_5);
           _0 = const ();
           return;
       }

--- a/tests/mir-opt/debuginfo/ref_prop.remap_debuginfo_locals.ReferencePropagation.diff
+++ b/tests/mir-opt/debuginfo/ref_prop.remap_debuginfo_locals.ReferencePropagation.diff
@@ -1,0 +1,33 @@
+- // MIR for `remap_debuginfo_locals` before ReferencePropagation
++ // MIR for `remap_debuginfo_locals` after ReferencePropagation
+  
+  fn remap_debuginfo_locals() -> () {
+      let mut _0: ();
+      let _1: &usize;
+      let mut _2: *const usize;
+      let _3: &usize;
+      let _4: usize;
+      let mut _5: &usize;
+      scope 1 (inlined foo) {
+-         debug a => _1;
++         debug a => _5;
+      }
+  
+      bb0: {
+-         StorageLive(_1);
+-         StorageLive(_2);
+-         StorageLive(_3);
+          _5 = const remap_debuginfo_locals::promoted[0];
+-         _3 = &(*_5);
+-         _2 = &raw const (*_3);
+-         // DBG: _1 = &(*_2);
+-         _1 = &(*_2);
+-         StorageDead(_2);
+-         StorageDead(_3);
+-         StorageDead(_1);
++         // DBG: _1 = &(*_5);
+          _0 = const ();
+          return;
+      }
+  }
+  

--- a/tests/mir-opt/debuginfo/ref_prop.rs
+++ b/tests/mir-opt/debuginfo/ref_prop.rs
@@ -1,0 +1,26 @@
+// skip-filecheck
+//@ test-mir-pass: ReferencePropagation
+//@ compile-flags: -g -Zub_checks=false -Zinline-mir -Zmir-enable-passes=+DeadStoreElimination-initial
+
+#![feature(core_intrinsics, custom_mir)]
+#![crate_type = "lib"]
+
+use std::intrinsics::mir::*;
+
+// EMIT_MIR ref_prop.remap_debuginfo_locals.ReferencePropagation.diff
+pub fn remap_debuginfo_locals() {
+    foo(&0);
+}
+
+#[custom_mir(dialect = "runtime", phase = "post-cleanup")]
+#[inline]
+fn foo(x: *const usize) -> &'static usize {
+    mir! {
+        debug a => RET;
+        {
+            RET = &*x;
+            RET = &*x;
+            Return()
+        }
+    }
+}

--- a/tests/mir-opt/debuginfo/ref_prop.rs
+++ b/tests/mir-opt/debuginfo/ref_prop.rs
@@ -1,4 +1,3 @@
-// skip-filecheck
 //@ test-mir-pass: ReferencePropagation
 //@ compile-flags: -g -Zub_checks=false -Zinline-mir -Zmir-enable-passes=+DeadStoreElimination-initial
 
@@ -9,6 +8,11 @@ use std::intrinsics::mir::*;
 
 // EMIT_MIR ref_prop.remap_debuginfo_locals.ReferencePropagation.diff
 pub fn remap_debuginfo_locals() {
+    // CHECK-LABEL: fn remap_debuginfo_locals()
+    // CHECK: debug a => [[a:_.*]];
+    // CHECK: bb0:
+    // CHECK-NEXT: [[a]] = const
+    // CHECK-NEXT: DBG: [[a]] = &(*[[a]]);
     foo(&0);
 }
 

--- a/tests/mir-opt/enum_opt.cand.EnumSizeOpt.32bit.diff
+++ b/tests/mir-opt/enum_opt.cand.EnumSizeOpt.32bit.diff
@@ -44,7 +44,6 @@
 +         _9 = copy _8 as *mut u8 (PtrToPtr);
 +         _10 = &raw const _2;
 +         _11 = copy _10 as *const u8 (PtrToPtr);
-+         Deinit(_8);
 +         copy_nonoverlapping(dst = copy _9, src = copy _11, count = copy _7);
 +         StorageDead(_4);
 +         nop;
@@ -59,7 +58,6 @@
 +         _17 = copy _16 as *mut u8 (PtrToPtr);
 +         _18 = &raw const _1;
 +         _19 = copy _18 as *const u8 (PtrToPtr);
-+         Deinit(_16);
 +         copy_nonoverlapping(dst = copy _17, src = copy _19, count = copy _15);
 +         StorageDead(_12);
 +         nop;

--- a/tests/mir-opt/enum_opt.cand.EnumSizeOpt.64bit.diff
+++ b/tests/mir-opt/enum_opt.cand.EnumSizeOpt.64bit.diff
@@ -44,7 +44,6 @@
 +         _9 = copy _8 as *mut u8 (PtrToPtr);
 +         _10 = &raw const _2;
 +         _11 = copy _10 as *const u8 (PtrToPtr);
-+         Deinit(_8);
 +         copy_nonoverlapping(dst = copy _9, src = copy _11, count = copy _7);
 +         StorageDead(_4);
 +         nop;
@@ -59,7 +58,6 @@
 +         _17 = copy _16 as *mut u8 (PtrToPtr);
 +         _18 = &raw const _1;
 +         _19 = copy _18 as *const u8 (PtrToPtr);
-+         Deinit(_16);
 +         copy_nonoverlapping(dst = copy _17, src = copy _19, count = copy _15);
 +         StorageDead(_12);
 +         nop;

--- a/tests/mir-opt/enum_opt.unin.EnumSizeOpt.32bit.diff
+++ b/tests/mir-opt/enum_opt.unin.EnumSizeOpt.32bit.diff
@@ -44,7 +44,6 @@
 +         _9 = copy _8 as *mut u8 (PtrToPtr);
 +         _10 = &raw const _2;
 +         _11 = copy _10 as *const u8 (PtrToPtr);
-+         Deinit(_8);
 +         copy_nonoverlapping(dst = copy _9, src = copy _11, count = copy _7);
 +         StorageDead(_4);
 +         nop;
@@ -59,7 +58,6 @@
 +         _17 = copy _16 as *mut u8 (PtrToPtr);
 +         _18 = &raw const _1;
 +         _19 = copy _18 as *const u8 (PtrToPtr);
-+         Deinit(_16);
 +         copy_nonoverlapping(dst = copy _17, src = copy _19, count = copy _15);
 +         StorageDead(_12);
 +         nop;

--- a/tests/mir-opt/enum_opt.unin.EnumSizeOpt.64bit.diff
+++ b/tests/mir-opt/enum_opt.unin.EnumSizeOpt.64bit.diff
@@ -44,7 +44,6 @@
 +         _9 = copy _8 as *mut u8 (PtrToPtr);
 +         _10 = &raw const _2;
 +         _11 = copy _10 as *const u8 (PtrToPtr);
-+         Deinit(_8);
 +         copy_nonoverlapping(dst = copy _9, src = copy _11, count = copy _7);
 +         StorageDead(_4);
 +         nop;
@@ -59,7 +58,6 @@
 +         _17 = copy _16 as *mut u8 (PtrToPtr);
 +         _18 = &raw const _1;
 +         _19 = copy _18 as *const u8 (PtrToPtr);
-+         Deinit(_16);
 +         copy_nonoverlapping(dst = copy _17, src = copy _19, count = copy _15);
 +         StorageDead(_12);
 +         nop;

--- a/tests/mir-opt/pre-codegen/const_promotion_option_ordering_eq.direct.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/const_promotion_option_ordering_eq.direct.PreCodegen.after.mir
@@ -1,0 +1,46 @@
+// MIR for `direct` after PreCodegen
+
+fn direct(_1: Option<std::cmp::Ordering>) -> bool {
+    debug e => _1;
+    let mut _0: bool;
+    scope 1 (inlined <Option<std::cmp::Ordering> as PartialEq>::eq) {
+        let mut _2: isize;
+        scope 2 {
+            scope 3 (inlined <std::cmp::Ordering as PartialEq>::eq) {
+                let _3: i8;
+                scope 4 {
+                    scope 5 {
+                    }
+                }
+            }
+        }
+    }
+
+    bb0: {
+        StorageLive(_2);
+        _2 = discriminant(_1);
+        switchInt(move _2) -> [0: bb1, 1: bb2, otherwise: bb4];
+    }
+
+    bb1: {
+        _0 = const false;
+        goto -> bb3;
+    }
+
+    bb2: {
+        StorageLive(_3);
+        _3 = discriminant(((_1 as Some).0: std::cmp::Ordering));
+        _0 = Eq(copy _3, const 0_i8);
+        StorageDead(_3);
+        goto -> bb3;
+    }
+
+    bb3: {
+        StorageDead(_2);
+        return;
+    }
+
+    bb4: {
+        unreachable;
+    }
+}

--- a/tests/mir-opt/pre-codegen/const_promotion_option_ordering_eq.rs
+++ b/tests/mir-opt/pre-codegen/const_promotion_option_ordering_eq.rs
@@ -1,0 +1,30 @@
+//@ compile-flags: -O -Zmir-opt-level=2 -Cdebuginfo=0
+
+// Check that comparing `Option<Ordering>` to a constant inlined `Some(...)`
+// does not produce unnecessarily complex MIR compared to using a local binding.
+//
+// Regression test for <https://github.com/rust-lang/rust/issues/139093>.
+// Originally, inlined constants like `Some(Ordering::Equal)` would get promoted,
+// leading to more MIR (and extra LLVM IR checks) than necessary.
+// Both cases should now generate identical MIR.
+
+use std::cmp::Ordering;
+
+// EMIT_MIR const_promotion_option_ordering_eq.direct.PreCodegen.after.mir
+pub fn direct(e: Option<Ordering>) -> bool {
+    // CHECK-LABEL: fn direct(
+    // CHECK-NOT: promoted[
+    // CHECK: switchInt(
+    // CHECK: return
+    e == Some(Ordering::Equal)
+}
+
+// EMIT_MIR const_promotion_option_ordering_eq.with_let.PreCodegen.after.mir
+pub fn with_let(e: Option<Ordering>) -> bool {
+    // CHECK-LABEL: fn with_let(
+    // CHECK-NOT: promoted[
+    // CHECK: switchInt(
+    // CHECK: return
+    let eq = Ordering::Equal;
+    e == Some(eq)
+}

--- a/tests/mir-opt/pre-codegen/const_promotion_option_ordering_eq.with_let.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/const_promotion_option_ordering_eq.with_let.PreCodegen.after.mir
@@ -1,0 +1,49 @@
+// MIR for `with_let` after PreCodegen
+
+fn with_let(_1: Option<std::cmp::Ordering>) -> bool {
+    debug e => _1;
+    let mut _0: bool;
+    scope 1 {
+        debug eq => const Equal;
+        scope 2 (inlined <Option<std::cmp::Ordering> as PartialEq>::eq) {
+            let mut _2: isize;
+            scope 3 {
+                scope 4 (inlined <std::cmp::Ordering as PartialEq>::eq) {
+                    let _3: i8;
+                    scope 5 {
+                        scope 6 {
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    bb0: {
+        StorageLive(_2);
+        _2 = discriminant(_1);
+        switchInt(move _2) -> [0: bb1, 1: bb2, otherwise: bb4];
+    }
+
+    bb1: {
+        _0 = const false;
+        goto -> bb3;
+    }
+
+    bb2: {
+        StorageLive(_3);
+        _3 = discriminant(((_1 as Some).0: std::cmp::Ordering));
+        _0 = Eq(copy _3, const 0_i8);
+        StorageDead(_3);
+        goto -> bb3;
+    }
+
+    bb3: {
+        StorageDead(_2);
+        return;
+    }
+
+    bb4: {
+        unreachable;
+    }
+}

--- a/tests/ui/debuginfo/dest_prop_debuginfo-147485.rs
+++ b/tests/ui/debuginfo/dest_prop_debuginfo-147485.rs
@@ -1,5 +1,7 @@
-//@ known-bug: #147485
+//@ build-pass
 //@ compile-flags: -g -O
+
+// Regression test for #147485.
 
 #![crate_type = "lib"]
 

--- a/tests/ui/debuginfo/ref_prop_debuginfo-147485.rs
+++ b/tests/ui/debuginfo/ref_prop_debuginfo-147485.rs
@@ -1,5 +1,7 @@
-//@ known-bug: #147485
+//@ build-pass
 //@ compile-flags: -g -O
+
+// Regression test for #147485.
 
 #![crate_type = "lib"]
 


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#145651 (Regression test for const promotion with Option<Ordering>)
 - rust-lang/rust#145722 (implement Extend<{Group, Literal, Punct, Ident}> for TokenStream)
 - rust-lang/rust#146520 (Promote armv8r-none-eabihf target to Tier 2)
 - rust-lang/rust#146522 (Promote armv7a-none-eabihf to Tier 2)
 - rust-lang/rust#147289 (Mitigate `thread_local!` shadowing issues)
 - rust-lang/rust#147515 (Update rustc-perf submodule)
 - rust-lang/rust#147522 (compiletest: Use the same directive lines for EarlyProps and ignore/only/needs)
 - rust-lang/rust#147525 (Replace locals in debuginfo records during ref_prop and dest_prop)
 - rust-lang/rust#147544 (Remove StatementKind::Deinit.)
 - rust-lang/rust#147551 (remove `#[rustc_inherit_overflow_checks]` from `is_multiple_of`)
 - rust-lang/rust#147553 (Move `wasm32-wasip3`  to the tier 3 table)
 - rust-lang/rust#147562 (Stabilize `NonZero<u*>::div_ceil`)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=145651,145722,146520,146522,147289,147515,147522,147525,147544,147551,147553,147562)
<!-- homu-ignore:end -->