### PR TITLE
ci: Use GNU coreutils to work around a libffi-sys build failure

### DIFF
--- a/src/ci/docker/host-aarch64/aarch64-gnu-debug/Dockerfile
+++ b/src/ci/docker/host-aarch64/aarch64-gnu-debug/Dockerfile
@@ -2,6 +2,8 @@ FROM ubuntu:25.10
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
+  # FIXME(#147556): Use GNU coreutils to work around a libffi-sys build failure.
+  coreutils-from-gnu coreutils-from-uutils- --allow-remove-essential \
   g++ \
   make \
   ninja-build \

--- a/src/ci/docker/host-aarch64/aarch64-gnu-llvm-20/Dockerfile
+++ b/src/ci/docker/host-aarch64/aarch64-gnu-llvm-20/Dockerfile
@@ -3,6 +3,8 @@ FROM ubuntu:25.10
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
+  # FIXME(#147556): Use GNU coreutils to work around a libffi-sys build failure.
+  coreutils-from-gnu coreutils-from-uutils- --allow-remove-essential \
   bzip2 \
   g++ \
   make \

--- a/src/ci/docker/host-aarch64/aarch64-gnu/Dockerfile
+++ b/src/ci/docker/host-aarch64/aarch64-gnu/Dockerfile
@@ -2,6 +2,8 @@ FROM ubuntu:25.10
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
+  # FIXME(#147556): Use GNU coreutils to work around a libffi-sys build failure.
+  coreutils-from-gnu coreutils-from-uutils- --allow-remove-essential \
   g++ \
   make \
   ninja-build \


### PR DESCRIPTION
This is an attempt to work around the CI failures at https://github.com/rust-lang/rust/issues/147556, by switching back to GNU coreutils (instead of uutils) on the Ubuntu 25.10 jobs.

- [Zulip thread](https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/Treeclosed.3A.20libffi.20failures/with/544301779)