### PR TITLE
(DO NOT MERGE) ci: Set `MKDIR_P` to work around a libffi-sys build failure

### DIFF
--- a/src/ci/docker/host-aarch64/aarch64-gnu-debug/Dockerfile
+++ b/src/ci/docker/host-aarch64/aarch64-gnu-debug/Dockerfile
@@ -34,6 +34,10 @@ ENV RUSTBUILD_FORCE_CLANG_BASED_TESTS 1
 # llvm.use-linker conflicts with downloading CI LLVM
 ENV NO_DOWNLOAD_CI_LLVM 1
 
+# FIXME(#147556): Work around a libffi-sys build failure by telling `configure`
+# that it can use `mkdir -p`.
+ENV MKDIR_P mkdir -p
+
 ENV RUST_CONFIGURE_ARGS \
       --build=aarch64-unknown-linux-gnu \
       --enable-debug \

--- a/src/ci/docker/host-aarch64/aarch64-gnu-llvm-20/Dockerfile
+++ b/src/ci/docker/host-aarch64/aarch64-gnu-llvm-20/Dockerfile
@@ -40,6 +40,10 @@ RUN sh /scripts/sccache.sh
 ENV NO_DOWNLOAD_CI_LLVM 1
 ENV EXTERNAL_LLVM 1
 
+# FIXME(#147556): Work around a libffi-sys build failure by telling `configure`
+# that it can use `mkdir -p`.
+ENV MKDIR_P mkdir -p
+
 # Using llvm-link-shared due to libffi issues -- see #34486
 ENV RUST_CONFIGURE_ARGS \
       --build=aarch64-unknown-linux-gnu \

--- a/src/ci/docker/host-aarch64/aarch64-gnu/Dockerfile
+++ b/src/ci/docker/host-aarch64/aarch64-gnu/Dockerfile
@@ -21,6 +21,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
+# FIXME(#147556): Work around a libffi-sys build failure by telling `configure`
+# that it can use `mkdir -p`.
+ENV MKDIR_P mkdir -p
+
 ENV RUST_CONFIGURE_ARGS \
  --build=aarch64-unknown-linux-gnu \
  --enable-sanitizers \


### PR DESCRIPTION
This probably won't be needed, but I'm curious to see if we could instead have worked around https://github.com/rust-lang/rust/issues/147556 by setting `MKDIR_P`.

r? ghost