### PR TITLE
Add tidy to the target of ./x check

### DIFF
--- a/src/bootstrap/src/core/build_steps/check.rs
+++ b/src/bootstrap/src/core/build_steps/check.rs
@@ -841,3 +841,8 @@ tool_check_step!(BumpStage0 {
     mode: Mode::ToolBootstrap,
     default: false
 });
+
+// Tidy is implicitly checked when `./x test tidy` is executed
+// (if you set a pre-push hook, the command is called).
+// So this is mainly for people working on tidy.
+tool_check_step!(Tidy { path: "src/tools/tidy", mode: Mode::ToolBootstrap, default: false });

--- a/src/bootstrap/src/core/builder/mod.rs
+++ b/src/bootstrap/src/core/builder/mod.rs
@@ -1076,6 +1076,7 @@ impl<'a> Builder<'a> {
                 check::CoverageDump,
                 check::Linkchecker,
                 check::BumpStage0,
+                check::Tidy,
                 // This has special staging logic, it may run on stage 1 while others run on stage 0.
                 // It takes quite some time to build stage 1, so put this at the end.
                 //

--- a/src/ci/docker/host-x86_64/pr-check-1/Dockerfile
+++ b/src/ci/docker/host-x86_64/pr-check-1/Dockerfile
@@ -50,6 +50,7 @@ ENV SCRIPT \
     linkchecker \
     run-make-support \
     rustdoc-gui-test \
+    tidy \
     && \
   /scripts/check-default-config-profiles.sh && \
   python3 ../x.py build src/tools/build-manifest && \


### PR DESCRIPTION
## Context
Discussion: https://rust-lang.zulipchat.com/#narrow/channel/326414-t-infra.2Fbootstrap/topic/tidy.20isn't.20in.20.2E.2Fx.20check/with/544323712

Currently `tidy` (src/tools/tidy) is not included in the list of `./x check`. It means that rust-analyzer doesn't work for codes in the directory if you use `./x check` as the analyzer on your IDE.

## Change

This PR adds src/tools/tidy into the target of `./x check`. It enables rust-analyzer highlight errors/warns on all codes in the directory. 

Note that since tidy is implicitly checked by `./x test tidy`, this new check is off by default.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
