### PR TITLE
std: implement `pal::os::exit` for VEXos

### DIFF
--- a/library/std/src/sys/pal/vexos/mod.rs
+++ b/library/std/src/sys/pal/vexos/mod.rs
@@ -1,4 +1,3 @@
-#[path = "../unsupported/os.rs"]
 pub mod os;
 #[path = "../unsupported/pipe.rs"]
 pub mod pipe;

--- a/library/std/src/sys/pal/vexos/os.rs
+++ b/library/std/src/sys/pal/vexos/os.rs
@@ -1,0 +1,19 @@
+#[expect(dead_code)]
+#[path = "../unsupported/os.rs"]
+mod unsupported_os;
+pub use unsupported_os::{
+    JoinPathsError, SplitPaths, chdir, current_exe, errno, error_string, getcwd, getpid, home_dir,
+    join_paths, split_paths, temp_dir,
+};
+
+pub use super::unsupported;
+
+pub fn exit(_code: i32) -> ! {
+    unsafe {
+        vex_sdk::vexSystemExitRequest();
+
+        loop {
+            vex_sdk::vexTasksRun();
+        }
+    }
+}


### PR DESCRIPTION
This PR provides a more "proper" implementation of process exiting in VEXos programs by going through `vexSystemExitRequest` rather than calling `intrinsics::abort`, which exits using an undefined instruction trap. This matches the existing implementation of `rt::abort_internal` and therefore makes `std::process::exit` have the same behavior as returning from main on VEXos targets.