### PR TITLE
Rollup of 12 pull requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/library_tracking_issue.md
+++ b/.github/ISSUE_TEMPLATE/library_tracking_issue.md
@@ -51,6 +51,7 @@ If the feature is changed later, please add those PRs here as well.
 
 (Remember to update the `S-tracking-*` label when checking boxes.)
 
+- [ ] ACP: rust-lang/libs-team#...
 - [ ] Implementation: #...
 - [ ] Final comment period (FCP)[^1]
 - [ ] Stabilization PR

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -495,7 +495,7 @@ dependencies = [
  "iana-time-zone",
  "num-traits",
  "serde",
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -6059,9 +6059,9 @@ dependencies = [
 
 [[package]]
 name = "wasi-preview1-component-adapter-provider"
-version = "36.0.1"
+version = "37.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20689c88791776219f78c2529700d15e6a9bd57a27858c62e9ef8487956b571c"
+checksum = "8d0fcd636ad2b29a7c0490799a23ad61d1c8dedfafdb970447fddd0549502b60"
 
 [[package]]
 name = "wasm-bindgen"
@@ -6123,9 +6123,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-component-ld"
-version = "0.5.17"
+version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c9208f87cac2332fd80dcf36d54e9163d3446e28301e0c6e424984425738984"
+checksum = "11f565dfcfd9aabb10d865b608a92ce1f93051aeb56f4c89550ed9cd97d8ce0e"
 dependencies = [
  "anyhow",
  "clap",
@@ -6133,9 +6133,9 @@ dependencies = [
  "libc",
  "tempfile",
  "wasi-preview1-component-adapter-provider",
- "wasmparser 0.239.0",
+ "wasmparser 0.240.0",
  "wat",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
  "winsplit",
  "wit-component",
  "wit-parser",
@@ -6160,24 +6160,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.239.0"
+version = "0.240.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be00faa2b4950c76fe618c409d2c3ea5a3c9422013e079482d78544bb2d184c"
+checksum = "06d642d8c5ecc083aafe9ceb32809276a304547a3a6eeecceb5d8152598bc71f"
 dependencies = [
  "leb128fmt",
- "wasmparser 0.239.0",
+ "wasmparser 0.240.0",
 ]
 
 [[package]]
 name = "wasm-metadata"
-version = "0.239.0"
+version = "0.240.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20b3ec880a9ac69ccd92fbdbcf46ee833071cf09f82bb005b2327c7ae6025ae2"
+checksum = "ee093e1e1ccffa005b9b778f7a10ccfd58e25a20eccad294a1a93168d076befb"
 dependencies = [
  "anyhow",
  "indexmap",
- "wasm-encoder 0.239.0",
- "wasmparser 0.239.0",
+ "wasm-encoder 0.240.0",
+ "wasmparser 0.240.0",
 ]
 
 [[package]]
@@ -6202,9 +6202,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.239.0"
+version = "0.240.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9d90bb93e764f6beabf1d02028c70a2156a6583e63ac4218dd07ef733368b0"
+checksum = "b722dcf61e0ea47440b53ff83ccb5df8efec57a69d150e4f24882e4eba7e24a4"
 dependencies = [
  "bitflags",
  "hashbrown",
@@ -6215,22 +6215,22 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "239.0.0"
+version = "240.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9139176fe8a2590e0fb174cdcaf373b224cb93c3dde08e4297c1361d2ba1ea5d"
+checksum = "b0efe1c93db4ac562b9733e3dca19ed7fc878dba29aef22245acf84f13da4a19"
 dependencies = [
  "bumpalo",
  "leb128fmt",
  "memchr",
  "unicode-width 0.2.1",
- "wasm-encoder 0.239.0",
+ "wasm-encoder 0.240.0",
 ]
 
 [[package]]
 name = "wat"
-version = "1.239.0"
+version = "1.240.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e1c941927d34709f255558166f8901a2005f8ab4a9650432e9281b7cc6f3b75"
+checksum = "4ec9b6eab7ecd4d639d78515e9ea491c9bacf494aa5eda10823bd35992cf8c1e"
 dependencies = [
  "wast",
 ]
@@ -6295,7 +6295,7 @@ dependencies = [
  "windows-collections",
  "windows-core 0.61.2",
  "windows-future",
- "windows-link",
+ "windows-link 0.1.3",
  "windows-numerics",
 ]
 
@@ -6340,7 +6340,7 @@ checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
  "windows-implement 0.60.0",
  "windows-interface 0.59.1",
- "windows-link",
+ "windows-link 0.1.3",
  "windows-result 0.3.4",
  "windows-strings 0.4.2",
 ]
@@ -6352,7 +6352,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
  "windows-core 0.61.2",
- "windows-link",
+ "windows-link 0.1.3",
  "windows-threading",
 ]
 
@@ -6407,13 +6407,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
 name = "windows-numerics"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -6431,7 +6437,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -6450,7 +6456,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -6481,6 +6487,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6502,7 +6517,7 @@ version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",
@@ -6519,7 +6534,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -6653,9 +6668,9 @@ dependencies = [
 
 [[package]]
 name = "wit-component"
-version = "0.239.0"
+version = "0.240.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88a866b19dba2c94d706ec58c92a4c62ab63e482b4c935d2a085ac94caecb136"
+checksum = "7dc5474b078addc5fe8a72736de8da3acfb3ff324c2491133f8b59594afa1a20"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -6664,17 +6679,17 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-encoder 0.239.0",
+ "wasm-encoder 0.240.0",
  "wasm-metadata",
- "wasmparser 0.239.0",
+ "wasmparser 0.240.0",
  "wit-parser",
 ]
 
 [[package]]
 name = "wit-parser"
-version = "0.239.0"
+version = "0.240.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55c92c939d667b7bf0c6bf2d1f67196529758f99a2a45a3355cc56964fd5315d"
+checksum = "9875ea3fa272f57cc1fc50f225a7b94021a7878c484b33792bccad0d93223439"
 dependencies = [
  "anyhow",
  "id-arena",
@@ -6685,7 +6700,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-xid",
- "wasmparser 0.239.0",
+ "wasmparser 0.240.0",
 ]
 
 [[package]]

--- a/compiler/rustc_codegen_llvm/src/lib.rs
+++ b/compiler/rustc_codegen_llvm/src/lib.rs
@@ -48,6 +48,8 @@ use rustc_session::config::{OptLevel, OutputFilenames, PrintKind, PrintRequest};
 use rustc_span::Symbol;
 use rustc_target::spec::{RelocModel, TlsModel};
 
+use crate::llvm::ToLlvmBool;
+
 mod abi;
 mod allocator;
 mod asm;
@@ -384,7 +386,8 @@ unsafe impl Sync for ModuleLlvm {}
 impl ModuleLlvm {
     fn new(tcx: TyCtxt<'_>, mod_name: &str) -> Self {
         unsafe {
-            let llcx = llvm::LLVMRustContextCreate(tcx.sess.fewer_names());
+            let llcx = llvm::LLVMContextCreate();
+            llvm::LLVMContextSetDiscardValueNames(llcx, tcx.sess.fewer_names().to_llvm_bool());
             let llmod_raw = context::create_module(tcx, llcx, mod_name) as *const _;
             ModuleLlvm {
                 llmod_raw,
@@ -396,7 +399,8 @@ impl ModuleLlvm {
 
     fn new_metadata(tcx: TyCtxt<'_>, mod_name: &str) -> Self {
         unsafe {
-            let llcx = llvm::LLVMRustContextCreate(tcx.sess.fewer_names());
+            let llcx = llvm::LLVMContextCreate();
+            llvm::LLVMContextSetDiscardValueNames(llcx, tcx.sess.fewer_names().to_llvm_bool());
             let llmod_raw = context::create_module(tcx, llcx, mod_name) as *const _;
             ModuleLlvm {
                 llmod_raw,
@@ -427,7 +431,8 @@ impl ModuleLlvm {
         dcx: DiagCtxtHandle<'_>,
     ) -> Self {
         unsafe {
-            let llcx = llvm::LLVMRustContextCreate(cgcx.fewer_names);
+            let llcx = llvm::LLVMContextCreate();
+            llvm::LLVMContextSetDiscardValueNames(llcx, cgcx.fewer_names.to_llvm_bool());
             let llmod_raw = back::lto::parse_module(llcx, name, buffer, dcx);
             let tm = ModuleLlvm::tm_from_cgcx(cgcx, name.to_str().unwrap(), dcx);
 

--- a/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
@@ -905,7 +905,9 @@ pub(crate) type GetSymbolsErrorCallback = unsafe extern "C" fn(*const c_char) ->
 
 unsafe extern "C" {
     // Create and destroy contexts.
+    pub(crate) fn LLVMContextCreate() -> &'static mut Context;
     pub(crate) fn LLVMContextDispose(C: &'static mut Context);
+    pub(crate) fn LLVMContextSetDiscardValueNames(C: &Context, Discard: Bool);
     pub(crate) fn LLVMGetMDKindIDInContext(
         C: &Context,
         Name: *const c_char,
@@ -1924,9 +1926,6 @@ unsafe extern "C" {
 unsafe extern "C" {
     pub(crate) fn LLVMRustInstallErrorHandlers();
     pub(crate) fn LLVMRustDisableSystemDialogsOnCrash();
-
-    // Create and destroy contexts.
-    pub(crate) fn LLVMRustContextCreate(shouldDiscardNames: bool) -> &'static mut Context;
 
     // Operations on all values
     pub(crate) fn LLVMRustGlobalAddMetadata<'a>(

--- a/compiler/rustc_codegen_ssa/src/mir/rvalue.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/rvalue.rs
@@ -1010,14 +1010,14 @@ pub(super) fn transmute_scalar<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
     imm = match (from_scalar.primitive(), to_scalar.primitive()) {
         (Int(..) | Float(_), Int(..) | Float(_)) => bx.bitcast(imm, to_backend_ty),
         (Pointer(..), Pointer(..)) => bx.pointercast(imm, to_backend_ty),
-        (Int(..), Pointer(..)) => bx.ptradd(bx.const_null(bx.type_ptr()), imm),
+        (Int(..), Pointer(..)) => bx.inttoptr(imm, to_backend_ty),
         (Pointer(..), Int(..)) => {
             // FIXME: this exposes the provenance, which shouldn't be necessary.
             bx.ptrtoint(imm, to_backend_ty)
         }
         (Float(_), Pointer(..)) => {
             let int_imm = bx.bitcast(imm, bx.cx().type_isize());
-            bx.ptradd(bx.const_null(bx.type_ptr()), int_imm)
+            bx.inttoptr(int_imm, to_backend_ty)
         }
         (Pointer(..), Float(_)) => {
             // FIXME: this exposes the provenance, which shouldn't be necessary.

--- a/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
@@ -123,12 +123,6 @@ extern "C" void LLVMRustSetLastError(const char *Err) {
   LastError = strdup(Err);
 }
 
-extern "C" LLVMContextRef LLVMRustContextCreate(bool shouldDiscardNames) {
-  auto ctx = new LLVMContext();
-  ctx->setDiscardValueNames(shouldDiscardNames);
-  return wrap(ctx);
-}
-
 extern "C" void LLVMRustSetNormalizedTarget(LLVMModuleRef M,
                                             const char *Target) {
 #if LLVM_VERSION_GE(21, 0)

--- a/compiler/rustc_middle/src/query/inner.rs
+++ b/compiler/rustc_middle/src/query/inner.rs
@@ -1,9 +1,15 @@
 //! Helper functions that serve as the immediate implementation of
 //! `tcx.$query(..)` and its variations.
 
+use std::fmt::Debug;
+
+use rustc_data_structures::fingerprint::Fingerprint;
+use rustc_query_system::dep_graph::{DepKind, DepNodeParams};
+use rustc_query_system::ich::StableHashingContext;
 use rustc_query_system::query::{QueryCache, QueryMode, try_get_cached};
 use rustc_span::{DUMMY_SP, ErrorGuaranteed, Span};
 
+use crate::dep_graph;
 use crate::query::IntoQueryParam;
 use crate::query::erase::{self, Erase, EraseType};
 use crate::ty::TyCtxt;
@@ -74,5 +80,55 @@ where
             // possible if the cache entry was `Ok(())`, so we emit that here, without
             // actually encoding the `Result` in the cache or loading it from there.
             .unwrap_or(Ok(()))
+    }
+}
+
+/// Common implementation of query feeding, used by `define_feedable!`.
+pub(crate) fn query_feed<'tcx, Cache, Value>(
+    tcx: TyCtxt<'tcx>,
+    dep_kind: DepKind,
+    hasher: Option<fn(&mut StableHashingContext<'_>, &Value) -> Fingerprint>,
+    cache: &Cache,
+    key: Cache::Key,
+    erased: Erase<Value>,
+) where
+    Cache: QueryCache<Value = Erase<Value>>,
+    Cache::Key: DepNodeParams<TyCtxt<'tcx>>,
+    Value: EraseType + Debug,
+{
+    let value = erase::restore::<Value>(erased);
+
+    match try_get_cached(tcx, cache, &key) {
+        Some(old) => {
+            let old = erase::restore::<Value>(old);
+            if let Some(hasher) = hasher {
+                let (value_hash, old_hash): (Fingerprint, Fingerprint) = tcx
+                    .with_stable_hashing_context(|mut hcx| {
+                        (hasher(&mut hcx, &value), hasher(&mut hcx, &old))
+                    });
+                if old_hash != value_hash {
+                    // We have an inconsistency. This can happen if one of the two
+                    // results is tainted by errors. In this case, delay a bug to
+                    // ensure compilation is doomed, and keep the `old` value.
+                    tcx.dcx().delayed_bug(format!(
+                        "Trying to feed an already recorded value for query {dep_kind:?} key={key:?}:\n\
+                        old value: {old:?}\nnew value: {value:?}",
+                    ));
+                }
+            } else {
+                // The query is `no_hash`, so we have no way to perform a sanity check.
+                // If feeding the same value multiple times needs to be supported,
+                // the query should not be marked `no_hash`.
+                bug!(
+                    "Trying to feed an already recorded value for query {dep_kind:?} key={key:?}:\n\
+                    old value: {old:?}\nnew value: {value:?}",
+                )
+            }
+        }
+        None => {
+            let dep_node = dep_graph::DepNode::construct(tcx, dep_kind, &key);
+            let dep_node_index = tcx.dep_graph.with_feed_task(dep_node, tcx, &value, hasher);
+            cache.complete(key, erased, dep_node_index);
+        }
     }
 }

--- a/compiler/rustc_middle/src/query/inner.rs
+++ b/compiler/rustc_middle/src/query/inner.rs
@@ -1,0 +1,78 @@
+//! Helper functions that serve as the immediate implementation of
+//! `tcx.$query(..)` and its variations.
+
+use rustc_query_system::query::{QueryCache, QueryMode, try_get_cached};
+use rustc_span::{DUMMY_SP, ErrorGuaranteed, Span};
+
+use crate::query::IntoQueryParam;
+use crate::query::erase::{self, Erase, EraseType};
+use crate::ty::TyCtxt;
+
+/// Shared implementation of `tcx.$query(..)` and `tcx.at(span).$query(..)`
+/// for all queries.
+#[inline(always)]
+pub(crate) fn query_get_at<'tcx, Cache>(
+    tcx: TyCtxt<'tcx>,
+    execute_query: fn(TyCtxt<'tcx>, Span, Cache::Key, QueryMode) -> Option<Cache::Value>,
+    query_cache: &Cache,
+    span: Span,
+    key: Cache::Key,
+) -> Cache::Value
+where
+    Cache: QueryCache,
+{
+    let key = key.into_query_param();
+    match try_get_cached(tcx, query_cache, &key) {
+        Some(value) => value,
+        None => execute_query(tcx, span, key, QueryMode::Get).unwrap(),
+    }
+}
+
+/// Shared implementation of `tcx.ensure_ok().$query(..)` for most queries,
+/// and `tcx.ensure_done().$query(..)` for all queries.
+#[inline]
+pub(crate) fn query_ensure<'tcx, Cache>(
+    tcx: TyCtxt<'tcx>,
+    execute_query: fn(TyCtxt<'tcx>, Span, Cache::Key, QueryMode) -> Option<Cache::Value>,
+    query_cache: &Cache,
+    key: Cache::Key,
+    check_cache: bool,
+) where
+    Cache: QueryCache,
+{
+    let key = key.into_query_param();
+    if try_get_cached(tcx, query_cache, &key).is_none() {
+        execute_query(tcx, DUMMY_SP, key, QueryMode::Ensure { check_cache });
+    }
+}
+
+/// Shared implementation of `tcx.ensure_ok().$query(..)` for queries that
+/// have the `return_result_from_ensure_ok` modifier.
+#[inline]
+pub(crate) fn query_ensure_error_guaranteed<'tcx, Cache, T>(
+    tcx: TyCtxt<'tcx>,
+    execute_query: fn(TyCtxt<'tcx>, Span, Cache::Key, QueryMode) -> Option<Cache::Value>,
+    query_cache: &Cache,
+    key: Cache::Key,
+    check_cache: bool,
+) -> Result<(), ErrorGuaranteed>
+where
+    Cache: QueryCache<Value = Erase<Result<T, ErrorGuaranteed>>>,
+    Result<T, ErrorGuaranteed>: EraseType,
+{
+    let key = key.into_query_param();
+    if let Some(res) = try_get_cached(tcx, query_cache, &key) {
+        erase::restore(res).map(drop)
+    } else {
+        execute_query(tcx, DUMMY_SP, key, QueryMode::Ensure { check_cache })
+            .map(erase::restore)
+            .map(|res| res.map(drop))
+            // Either we actually executed the query, which means we got a full `Result`,
+            // or we can just assume the query succeeded, because it was green in the
+            // incremental cache. If it is green, that means that the previous compilation
+            // that wrote to the incremental cache compiles successfully. That is only
+            // possible if the cache entry was `Ok(())`, so we emit that here, without
+            // actually encoding the `Result` in the cache or loading it from there.
+            .unwrap_or(Ok(()))
+    }
+}

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -121,9 +121,7 @@ use crate::mir::interpret::{
 };
 use crate::mir::mono::{CodegenUnit, CollectionMode, MonoItem, MonoItemPartitions};
 use crate::query::erase::{Erase, erase, restore};
-use crate::query::plumbing::{
-    CyclePlaceholder, DynamicQuery, query_ensure, query_ensure_error_guaranteed, query_get_at,
-};
+use crate::query::plumbing::{CyclePlaceholder, DynamicQuery};
 use crate::traits::query::{
     CanonicalAliasGoal, CanonicalDropckOutlivesGoal, CanonicalImpliedOutlivesBoundsGoal,
     CanonicalMethodAutoderefStepsGoal, CanonicalPredicateGoal, CanonicalTypeOpAscribeUserTypeGoal,
@@ -147,6 +145,7 @@ use crate::{dep_graph, mir, thir};
 
 mod arena_cached;
 pub mod erase;
+pub(crate) mod inner;
 mod keys;
 pub mod on_disk_cache;
 #[macro_use]

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -70,7 +70,6 @@ use std::sync::Arc;
 use rustc_abi::Align;
 use rustc_arena::TypedArena;
 use rustc_ast::expand::allocator::AllocatorKind;
-use rustc_data_structures::fingerprint::Fingerprint;
 use rustc_data_structures::fx::{FxIndexMap, FxIndexSet};
 use rustc_data_structures::sorted_map::SortedMap;
 use rustc_data_structures::steal::Steal;
@@ -88,9 +87,7 @@ use rustc_index::IndexVec;
 use rustc_lint_defs::LintId;
 use rustc_macros::rustc_queries;
 use rustc_query_system::ich::StableHashingContext;
-use rustc_query_system::query::{
-    QueryCache, QueryMode, QueryStackDeferred, QueryState, try_get_cached,
-};
+use rustc_query_system::query::{QueryMode, QueryStackDeferred, QueryState};
 use rustc_session::Limits;
 use rustc_session::config::{EntryFnType, OptLevel, OutputFilenames, SymbolManglingVersion};
 use rustc_session::cstore::{

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -103,6 +103,8 @@ use rustc_span::{DUMMY_SP, Span, Symbol};
 use rustc_target::spec::{PanicStrategy, SanitizerSet};
 use {rustc_abi as abi, rustc_ast as ast, rustc_hir as hir};
 
+pub use self::keys::{AsLocalKey, Key, LocalCrate};
+pub use self::plumbing::{IntoQueryParam, TyCtxtAt, TyCtxtEnsureDone, TyCtxtEnsureOk};
 use crate::infer::canonical::{self, Canonical};
 use crate::lint::LintExpectation;
 use crate::metadata::ModChild;
@@ -146,11 +148,9 @@ use crate::{dep_graph, mir, thir};
 mod arena_cached;
 pub mod erase;
 mod keys;
-pub use keys::{AsLocalKey, Key, LocalCrate};
 pub mod on_disk_cache;
 #[macro_use]
 pub mod plumbing;
-pub use plumbing::{IntoQueryParam, TyCtxtAt, TyCtxtEnsureDone, TyCtxtEnsureOk};
 
 // Each of these queries corresponds to a function pointer field in the
 // `Providers` struct for requesting a value of that type, and a method

--- a/compiler/rustc_middle/src/query/plumbing.rs
+++ b/compiler/rustc_middle/src/query/plumbing.rs
@@ -9,7 +9,9 @@ use rustc_query_system::dep_graph::{DepNodeIndex, SerializedDepNodeIndex};
 pub(crate) use rustc_query_system::query::QueryJobId;
 use rustc_query_system::query::*;
 use rustc_span::{DUMMY_SP, ErrorGuaranteed, Span};
+pub use sealed::IntoQueryParam;
 
+use super::erase::EraseType;
 use crate::dep_graph;
 use crate::dep_graph::DepKind;
 use crate::query::on_disk_cache::{CacheEncoder, EncodedDepNodeIndex, OnDiskCache};
@@ -693,10 +695,6 @@ mod sealed {
         }
     }
 }
-
-pub use sealed::IntoQueryParam;
-
-use super::erase::EraseType;
 
 #[derive(Copy, Clone, Debug, HashStable)]
 pub struct CyclePlaceholder(pub ErrorGuaranteed);

--- a/compiler/rustc_middle/src/query/plumbing.rs
+++ b/compiler/rustc_middle/src/query/plumbing.rs
@@ -501,56 +501,23 @@ macro_rules! define_feedable {
             $(#[$attr])*
             #[inline(always)]
             pub fn $name(self, value: queries::$name::ProvidedValue<'tcx>) {
-                #![allow(unused_imports)] // Removed later in this PR.
-                use rustc_data_structures::fingerprint::Fingerprint;
-                use rustc_query_system::query::{QueryCache, try_get_cached};
-
                 let key = self.key().into_query_param();
 
                 let tcx = self.tcx;
                 let erased = queries::$name::provided_to_erased(tcx, value);
-                let value = erase::restore::<$V>(erased);
                 let cache = &tcx.query_system.caches.$name;
 
                 let dep_kind: dep_graph::DepKind = dep_graph::dep_kinds::$name;
                 let hasher: Option<fn(&mut StableHashingContext<'_>, &_) -> _> = hash_result!([$($modifiers)*]);
-                match try_get_cached(tcx, cache, &key) {
-                    Some(old) => {
-                        let old = erase::restore::<$V>(old);
-                        if let Some(hasher) = hasher {
-                            let (value_hash, old_hash): (Fingerprint, Fingerprint) = tcx.with_stable_hashing_context(|mut hcx|
-                                (hasher(&mut hcx, &value), hasher(&mut hcx, &old))
-                            );
-                            if old_hash != value_hash {
-                                // We have an inconsistency. This can happen if one of the two
-                                // results is tainted by errors. In this case, delay a bug to
-                                // ensure compilation is doomed, and keep the `old` value.
-                                tcx.dcx().delayed_bug(format!(
-                                    "Trying to feed an already recorded value for query {dep_kind:?} key={key:?}:\n\
-                                    old value: {old:?}\nnew value: {value:?}",
-                                ));
-                            }
-                        } else {
-                            // The query is `no_hash`, so we have no way to perform a sanity check.
-                            // If feeding the same value multiple times needs to be supported,
-                            // the query should not be marked `no_hash`.
-                            bug!(
-                                "Trying to feed an already recorded value for query {dep_kind:?} key={key:?}:\n\
-                                old value: {old:?}\nnew value: {value:?}",
-                            )
-                        }
-                    }
-                    None => {
-                        let dep_node = dep_graph::DepNode::construct(tcx, dep_kind, &key);
-                        let dep_node_index = tcx.dep_graph.with_feed_task(
-                            dep_node,
-                            tcx,
-                            &value,
-                            hasher,
-                        );
-                        cache.complete(key, erased, dep_node_index);
-                    }
-                }
+
+                $crate::query::inner::query_feed(
+                    tcx,
+                    dep_kind,
+                    hasher,
+                    cache,
+                    key,
+                    erased,
+                );
             }
         })*
     }

--- a/compiler/rustc_middle/src/query/plumbing.rs
+++ b/compiler/rustc_middle/src/query/plumbing.rs
@@ -8,10 +8,9 @@ use rustc_query_system::HandleCycleError;
 use rustc_query_system::dep_graph::{DepNodeIndex, SerializedDepNodeIndex};
 pub(crate) use rustc_query_system::query::QueryJobId;
 use rustc_query_system::query::*;
-use rustc_span::{DUMMY_SP, ErrorGuaranteed, Span};
+use rustc_span::{ErrorGuaranteed, Span};
 pub use sealed::IntoQueryParam;
 
-use super::erase::EraseType;
 use crate::dep_graph;
 use crate::dep_graph::DepKind;
 use crate::query::on_disk_cache::{CacheEncoder, EncodedDepNodeIndex, OnDiskCache};
@@ -167,78 +166,17 @@ impl<'tcx> TyCtxt<'tcx> {
     }
 }
 
-#[inline(always)]
-pub fn query_get_at<'tcx, Cache>(
-    tcx: TyCtxt<'tcx>,
-    execute_query: fn(TyCtxt<'tcx>, Span, Cache::Key, QueryMode) -> Option<Cache::Value>,
-    query_cache: &Cache,
-    span: Span,
-    key: Cache::Key,
-) -> Cache::Value
-where
-    Cache: QueryCache,
-{
-    let key = key.into_query_param();
-    match try_get_cached(tcx, query_cache, &key) {
-        Some(value) => value,
-        None => execute_query(tcx, span, key, QueryMode::Get).unwrap(),
-    }
-}
-
-#[inline]
-pub fn query_ensure<'tcx, Cache>(
-    tcx: TyCtxt<'tcx>,
-    execute_query: fn(TyCtxt<'tcx>, Span, Cache::Key, QueryMode) -> Option<Cache::Value>,
-    query_cache: &Cache,
-    key: Cache::Key,
-    check_cache: bool,
-) where
-    Cache: QueryCache,
-{
-    let key = key.into_query_param();
-    if try_get_cached(tcx, query_cache, &key).is_none() {
-        execute_query(tcx, DUMMY_SP, key, QueryMode::Ensure { check_cache });
-    }
-}
-
-#[inline]
-pub fn query_ensure_error_guaranteed<'tcx, Cache, T>(
-    tcx: TyCtxt<'tcx>,
-    execute_query: fn(TyCtxt<'tcx>, Span, Cache::Key, QueryMode) -> Option<Cache::Value>,
-    query_cache: &Cache,
-    key: Cache::Key,
-    check_cache: bool,
-) -> Result<(), ErrorGuaranteed>
-where
-    Cache: QueryCache<Value = super::erase::Erase<Result<T, ErrorGuaranteed>>>,
-    Result<T, ErrorGuaranteed>: EraseType,
-{
-    let key = key.into_query_param();
-    if let Some(res) = try_get_cached(tcx, query_cache, &key) {
-        super::erase::restore(res).map(drop)
-    } else {
-        execute_query(tcx, DUMMY_SP, key, QueryMode::Ensure { check_cache })
-            .map(super::erase::restore)
-            .map(|res| res.map(drop))
-            // Either we actually executed the query, which means we got a full `Result`,
-            // or we can just assume the query succeeded, because it was green in the
-            // incremental cache. If it is green, that means that the previous compilation
-            // that wrote to the incremental cache compiles successfully. That is only
-            // possible if the cache entry was `Ok(())`, so we emit that here, without
-            // actually encoding the `Result` in the cache or loading it from there.
-            .unwrap_or(Ok(()))
-    }
-}
-
-macro_rules! query_ensure {
+/// Calls either `query_ensure` or `query_ensure_error_guaranteed`, depending
+/// on whether the list of modifiers contains `return_result_from_ensure_ok`.
+macro_rules! query_ensure_select {
     ([]$($args:tt)*) => {
-        query_ensure($($args)*)
+        crate::query::inner::query_ensure($($args)*)
     };
     ([(return_result_from_ensure_ok) $($rest:tt)*]$($args:tt)*) => {
-        query_ensure_error_guaranteed($($args)*).map(|_| ())
+        crate::query::inner::query_ensure_error_guaranteed($($args)*)
     };
     ([$other:tt $($modifiers:tt)*]$($args:tt)*) => {
-        query_ensure!([$($modifiers)*]$($args)*)
+        query_ensure_select!([$($modifiers)*]$($args)*)
     };
 }
 
@@ -434,7 +372,7 @@ macro_rules! define_callbacks {
                 self,
                 key: query_helper_param_ty!($($K)*),
             ) -> ensure_ok_result!([$($modifiers)*]) {
-                query_ensure!(
+                query_ensure_select!(
                     [$($modifiers)*]
                     self.tcx,
                     self.tcx.query_system.fns.engine.$name,
@@ -449,7 +387,7 @@ macro_rules! define_callbacks {
             $($(#[$attr])*
             #[inline(always)]
             pub fn $name(self, key: query_helper_param_ty!($($K)*)) {
-                query_ensure(
+                crate::query::inner::query_ensure(
                     self.tcx,
                     self.tcx.query_system.fns.engine.$name,
                     &self.tcx.query_system.caches.$name,
@@ -474,7 +412,7 @@ macro_rules! define_callbacks {
             #[inline(always)]
             pub fn $name(self, key: query_helper_param_ty!($($K)*)) -> $V
             {
-                restore::<$V>(query_get_at(
+                restore::<$V>(crate::query::inner::query_get_at(
                     self.tcx,
                     self.tcx.query_system.fns.engine.$name,
                     &self.tcx.query_system.caches.$name,

--- a/library/alloc/src/collections/btree/map.rs
+++ b/library/alloc/src/collections/btree/map.rs
@@ -1368,7 +1368,8 @@ impl<K, V, A: Allocator + Clone> BTreeMap<K, V, A> {
     }
 
     /// Splits the collection into two at the given key. Returns everything after the given key,
-    /// including the key.
+    /// including the key. If the key is not present, the split will occur at the nearest
+    /// greater key, or return an empty map if no such key exists.
     ///
     /// # Examples
     ///

--- a/library/core/src/iter/traits/collect.rs
+++ b/library/core/src/iter/traits/collect.rs
@@ -459,234 +459,274 @@ impl Extend<()> for () {
     fn extend_one(&mut self, _item: ()) {}
 }
 
-macro_rules! spec_tuple_impl {
-    (
-        (
-            $ty_name:ident, $var_name:ident, $extend_ty_name: ident,
-            $trait_name:ident, $default_fn_name:ident, $cnt:tt
-        ),
-    ) => {
-        spec_tuple_impl!(
-            $trait_name,
-            $default_fn_name,
-            #[doc(fake_variadic)]
-            #[doc = "This trait is implemented for tuples up to twelve items long. The `impl`s for \
-                     1- and 3- through 12-ary tuples were stabilized after 2-tuples, in \
-                     1.85.0."]
-            => ($ty_name, $var_name, $extend_ty_name, $cnt),
-        );
-    };
-    (
-        (
-            $ty_name:ident, $var_name:ident, $extend_ty_name: ident,
-            $trait_name:ident, $default_fn_name:ident, $cnt:tt
-        ),
-        $(
-            (
-                $ty_names:ident, $var_names:ident,  $extend_ty_names:ident,
-                $trait_names:ident, $default_fn_names:ident, $cnts:tt
-            ),
-        )*
-    ) => {
-        spec_tuple_impl!(
-            $(
-                (
-                    $ty_names, $var_names, $extend_ty_names,
-                    $trait_names, $default_fn_names, $cnts
-                ),
-            )*
-        );
-        spec_tuple_impl!(
-            $trait_name,
-            $default_fn_name,
-            #[doc(hidden)]
-            => (
-                $ty_name, $var_name, $extend_ty_name, $cnt
-            ),
-            $(
-                (
-                    $ty_names, $var_names, $extend_ty_names, $cnts
-                ),
-            )*
-        );
-    };
-    (
-        $trait_name:ident, $default_fn_name:ident, #[$meta:meta]
-        $(#[$doctext:meta])? => $(
-            (
-                $ty_names:ident, $var_names:ident, $extend_ty_names:ident, $cnts:tt
-            ),
-        )*
-    ) => {
-        #[$meta]
-        $(#[$doctext])?
-        #[stable(feature = "extend_for_tuple", since = "1.56.0")]
-        impl<$($ty_names,)* $($extend_ty_names,)*> Extend<($($ty_names,)*)> for ($($extend_ty_names,)*)
-        where
-            $($extend_ty_names: Extend<$ty_names>,)*
-        {
-            /// Allows to `extend` a tuple of collections that also implement `Extend`.
-            ///
-            /// See also: [`Iterator::unzip`]
-            ///
-            /// # Examples
-            /// ```
-            /// // Example given for a 2-tuple, but 1- through 12-tuples are supported
-            /// let mut tuple = (vec![0], vec![1]);
-            /// tuple.extend([(2, 3), (4, 5), (6, 7)]);
-            /// assert_eq!(tuple.0, [0, 2, 4, 6]);
-            /// assert_eq!(tuple.1, [1, 3, 5, 7]);
-            ///
-            /// // also allows for arbitrarily nested tuples as elements
-            /// let mut nested_tuple = (vec![1], (vec![2], vec![3]));
-            /// nested_tuple.extend([(4, (5, 6)), (7, (8, 9))]);
-            ///
-            /// let (a, (b, c)) = nested_tuple;
-            /// assert_eq!(a, [1, 4, 7]);
-            /// assert_eq!(b, [2, 5, 8]);
-            /// assert_eq!(c, [3, 6, 9]);
-            /// ```
-            fn extend<T: IntoIterator<Item = ($($ty_names,)*)>>(&mut self, into_iter: T) {
-                let ($($var_names,)*) = self;
-                let iter = into_iter.into_iter();
-                $trait_name::extend(iter, $($var_names,)*);
+/// This trait is implemented for tuples up to twelve items long. The `impl`s for
+/// 1- and 3- through 12-ary tuples were stabilized after 2-tuples, in 1.85.0.
+#[doc(fake_variadic)] // the other implementations are below.
+#[stable(feature = "extend_for_tuple", since = "1.56.0")]
+impl<T, ExtendT> Extend<(T,)> for (ExtendT,)
+where
+    ExtendT: Extend<T>,
+{
+    /// Allows to `extend` a tuple of collections that also implement `Extend`.
+    ///
+    /// See also: [`Iterator::unzip`]
+    ///
+    /// # Examples
+    /// ```
+    /// // Example given for a 2-tuple, but 1- through 12-tuples are supported
+    /// let mut tuple = (vec![0], vec![1]);
+    /// tuple.extend([(2, 3), (4, 5), (6, 7)]);
+    /// assert_eq!(tuple.0, [0, 2, 4, 6]);
+    /// assert_eq!(tuple.1, [1, 3, 5, 7]);
+    ///
+    /// // also allows for arbitrarily nested tuples as elements
+    /// let mut nested_tuple = (vec![1], (vec![2], vec![3]));
+    /// nested_tuple.extend([(4, (5, 6)), (7, (8, 9))]);
+    ///
+    /// let (a, (b, c)) = nested_tuple;
+    /// assert_eq!(a, [1, 4, 7]);
+    /// assert_eq!(b, [2, 5, 8]);
+    /// assert_eq!(c, [3, 6, 9]);
+    /// ```
+    fn extend<I: IntoIterator<Item = (T,)>>(&mut self, iter: I) {
+        self.0.extend(iter.into_iter().map(|t| t.0));
+    }
+
+    fn extend_one(&mut self, item: (T,)) {
+        self.0.extend_one(item.0)
+    }
+
+    fn extend_reserve(&mut self, additional: usize) {
+        self.0.extend_reserve(additional)
+    }
+
+    unsafe fn extend_one_unchecked(&mut self, item: (T,)) {
+        // SAFETY: the caller guarantees all preconditions.
+        unsafe { self.0.extend_one_unchecked(item.0) }
+    }
+}
+
+/// This implementation turns an iterator of tuples into a tuple of types which implement
+/// [`Default`] and [`Extend`].
+///
+/// This is similar to [`Iterator::unzip`], but is also composable with other [`FromIterator`]
+/// implementations:
+///
+/// ```rust
+/// # fn main() -> Result<(), core::num::ParseIntError> {
+/// let string = "1,2,123,4";
+///
+/// // Example given for a 2-tuple, but 1- through 12-tuples are supported
+/// let (numbers, lengths): (Vec<_>, Vec<_>) = string
+///     .split(',')
+///     .map(|s| s.parse().map(|n: u32| (n, s.len())))
+///     .collect::<Result<_, _>>()?;
+///
+/// assert_eq!(numbers, [1, 2, 123, 4]);
+/// assert_eq!(lengths, [1, 1, 3, 1]);
+/// # Ok(()) }
+/// ```
+#[doc(fake_variadic)] // the other implementations are below.
+#[stable(feature = "from_iterator_for_tuple", since = "1.79.0")]
+impl<T, ExtendT> FromIterator<(T,)> for (ExtendT,)
+where
+    ExtendT: Default + Extend<T>,
+{
+    fn from_iter<Iter: IntoIterator<Item = (T,)>>(iter: Iter) -> Self {
+        let mut res = ExtendT::default();
+        res.extend(iter.into_iter().map(|t| t.0));
+        (res,)
+    }
+}
+
+/// An implementation of [`extend`](Extend::extend) that calls `extend_one` or
+/// `extend_one_unchecked` for each element of the iterator.
+fn default_extend<ExtendT, I, T>(collection: &mut ExtendT, iter: I)
+where
+    ExtendT: Extend<T>,
+    I: IntoIterator<Item = T>,
+{
+    // Specialize on `TrustedLen` and call `extend_one_unchecked` where
+    // applicable.
+    trait SpecExtend<I> {
+        fn extend(&mut self, iter: I);
+    }
+
+    // Extracting these to separate functions avoid monomorphising the closures
+    // for every iterator type.
+    fn extender<ExtendT, T>(collection: &mut ExtendT) -> impl FnMut(T) + use<'_, ExtendT, T>
+    where
+        ExtendT: Extend<T>,
+    {
+        move |item| collection.extend_one(item)
+    }
+
+    unsafe fn unchecked_extender<ExtendT, T>(
+        collection: &mut ExtendT,
+    ) -> impl FnMut(T) + use<'_, ExtendT, T>
+    where
+        ExtendT: Extend<T>,
+    {
+        // SAFETY: we make sure that there is enough space at the callsite of
+        // this function.
+        move |item| unsafe { collection.extend_one_unchecked(item) }
+    }
+
+    impl<ExtendT, I, T> SpecExtend<I> for ExtendT
+    where
+        ExtendT: Extend<T>,
+        I: Iterator<Item = T>,
+    {
+        default fn extend(&mut self, iter: I) {
+            let (lower_bound, _) = iter.size_hint();
+            if lower_bound > 0 {
+                self.extend_reserve(lower_bound);
             }
 
-            fn extend_one(&mut self, item: ($($ty_names,)*)) {
-                $(self.$cnts.extend_one(item.$cnts);)*
+            iter.for_each(extender(self))
+        }
+    }
+
+    impl<ExtendT, I, T> SpecExtend<I> for ExtendT
+    where
+        ExtendT: Extend<T>,
+        I: TrustedLen<Item = T>,
+    {
+        fn extend(&mut self, iter: I) {
+            let (lower_bound, upper_bound) = iter.size_hint();
+            if lower_bound > 0 {
+                self.extend_reserve(lower_bound);
+            }
+
+            if upper_bound.is_none() {
+                // We cannot reserve more than `usize::MAX` items, and this is likely to go out of memory anyway.
+                iter.for_each(extender(self))
+            } else {
+                // SAFETY: We reserve enough space for the `size_hint`, and the iterator is
+                // `TrustedLen` so its `size_hint` is exact.
+                iter.for_each(unsafe { unchecked_extender(self) })
+            }
+        }
+    }
+
+    SpecExtend::extend(collection, iter.into_iter());
+}
+
+// Implements `Extend` and `FromIterator` for tuples with length larger than one.
+macro_rules! impl_extend_tuple {
+    ($(($ty:tt, $extend_ty:tt, $index:tt)),+) => {
+        #[doc(hidden)]
+        #[stable(feature = "extend_for_tuple", since = "1.56.0")]
+        impl<$($ty,)+ $($extend_ty,)+> Extend<($($ty,)+)> for ($($extend_ty,)+)
+        where
+            $($extend_ty: Extend<$ty>,)+
+        {
+            fn extend<T: IntoIterator<Item = ($($ty,)+)>>(&mut self, iter: T) {
+                default_extend(self, iter)
+            }
+
+            fn extend_one(&mut self, item: ($($ty,)+)) {
+                $(self.$index.extend_one(item.$index);)+
             }
 
             fn extend_reserve(&mut self, additional: usize) {
-                $(self.$cnts.extend_reserve(additional);)*
+                $(self.$index.extend_reserve(additional);)+
             }
 
-            unsafe fn extend_one_unchecked(&mut self, item: ($($ty_names,)*)) {
+            unsafe fn extend_one_unchecked(&mut self, item: ($($ty,)+)) {
                 // SAFETY: Those are our safety preconditions, and we correctly forward `extend_reserve`.
                 unsafe {
-                     $(self.$cnts.extend_one_unchecked(item.$cnts);)*
+                    $(self.$index.extend_one_unchecked(item.$index);)+
                 }
             }
         }
 
-        trait $trait_name<$($ty_names),*> {
-            fn extend(self, $($var_names: &mut $ty_names,)*);
-        }
-
-        fn $default_fn_name<$($ty_names,)* $($extend_ty_names,)*>(
-            iter: impl Iterator<Item = ($($ty_names,)*)>,
-            $($var_names: &mut $extend_ty_names,)*
-        ) where
-            $($extend_ty_names: Extend<$ty_names>,)*
-        {
-            fn extend<'a, $($ty_names,)*>(
-                $($var_names: &'a mut impl Extend<$ty_names>,)*
-            ) -> impl FnMut((), ($($ty_names,)*)) + 'a {
-                #[allow(non_snake_case)]
-                move |(), ($($extend_ty_names,)*)| {
-                    $($var_names.extend_one($extend_ty_names);)*
-                }
-            }
-
-            let (lower_bound, _) = iter.size_hint();
-            if lower_bound > 0 {
-                $($var_names.extend_reserve(lower_bound);)*
-            }
-
-            iter.fold((), extend($($var_names,)*));
-        }
-
-        impl<$($ty_names,)* $($extend_ty_names,)* Iter> $trait_name<$($extend_ty_names),*> for Iter
-        where
-            $($extend_ty_names: Extend<$ty_names>,)*
-            Iter: Iterator<Item = ($($ty_names,)*)>,
-        {
-            default fn extend(self, $($var_names: &mut $extend_ty_names),*) {
-                $default_fn_name(self, $($var_names),*);
-            }
-        }
-
-        impl<$($ty_names,)* $($extend_ty_names,)* Iter> $trait_name<$($extend_ty_names),*> for Iter
-        where
-            $($extend_ty_names: Extend<$ty_names>,)*
-            Iter: TrustedLen<Item = ($($ty_names,)*)>,
-        {
-            fn extend(self, $($var_names: &mut $extend_ty_names,)*) {
-                fn extend<'a, $($ty_names,)*>(
-                    $($var_names: &'a mut impl Extend<$ty_names>,)*
-                ) -> impl FnMut((), ($($ty_names,)*)) + 'a {
-                    #[allow(non_snake_case)]
-                    // SAFETY: We reserve enough space for the `size_hint`, and the iterator is
-                    // `TrustedLen` so its `size_hint` is exact.
-                    move |(), ($($extend_ty_names,)*)| unsafe {
-                        $($var_names.extend_one_unchecked($extend_ty_names);)*
-                    }
-                }
-
-                let (lower_bound, upper_bound) = self.size_hint();
-
-                if upper_bound.is_none() {
-                    // We cannot reserve more than `usize::MAX` items, and this is likely to go out of memory anyway.
-                    $default_fn_name(self, $($var_names,)*);
-                    return;
-                }
-
-                if lower_bound > 0 {
-                    $($var_names.extend_reserve(lower_bound);)*
-                }
-
-                self.fold((), extend($($var_names,)*));
-            }
-        }
-
-        /// This implementation turns an iterator of tuples into a tuple of types which implement
-        /// [`Default`] and [`Extend`].
-        ///
-        /// This is similar to [`Iterator::unzip`], but is also composable with other [`FromIterator`]
-        /// implementations:
-        ///
-        /// ```rust
-        /// # fn main() -> Result<(), core::num::ParseIntError> {
-        /// let string = "1,2,123,4";
-        ///
-        /// // Example given for a 2-tuple, but 1- through 12-tuples are supported
-        /// let (numbers, lengths): (Vec<_>, Vec<_>) = string
-        ///     .split(',')
-        ///     .map(|s| s.parse().map(|n: u32| (n, s.len())))
-        ///     .collect::<Result<_, _>>()?;
-        ///
-        /// assert_eq!(numbers, [1, 2, 123, 4]);
-        /// assert_eq!(lengths, [1, 1, 3, 1]);
-        /// # Ok(()) }
-        /// ```
-        #[$meta]
-        $(#[$doctext])?
+        #[doc(hidden)]
         #[stable(feature = "from_iterator_for_tuple", since = "1.79.0")]
-        impl<$($ty_names,)* $($extend_ty_names,)*> FromIterator<($($extend_ty_names,)*)> for ($($ty_names,)*)
+        impl<$($ty,)+ $($extend_ty,)+> FromIterator<($($ty,)+)> for ($($extend_ty,)+)
         where
-            $($ty_names: Default + Extend<$extend_ty_names>,)*
+            $($extend_ty: Default + Extend<$ty>,)+
         {
-            fn from_iter<Iter: IntoIterator<Item = ($($extend_ty_names,)*)>>(iter: Iter) -> Self {
-                let mut res = <($($ty_names,)*)>::default();
+            fn from_iter<Iter: IntoIterator<Item = ($($ty,)+)>>(iter: Iter) -> Self {
+                let mut res = Self::default();
                 res.extend(iter);
-
                 res
             }
         }
-
     };
 }
 
-spec_tuple_impl!(
-    (L, l, EL, TraitL, default_extend_tuple_l, 11),
-    (K, k, EK, TraitK, default_extend_tuple_k, 10),
-    (J, j, EJ, TraitJ, default_extend_tuple_j, 9),
-    (I, i, EI, TraitI, default_extend_tuple_i, 8),
-    (H, h, EH, TraitH, default_extend_tuple_h, 7),
-    (G, g, EG, TraitG, default_extend_tuple_g, 6),
-    (F, f, EF, TraitF, default_extend_tuple_f, 5),
-    (E, e, EE, TraitE, default_extend_tuple_e, 4),
-    (D, d, ED, TraitD, default_extend_tuple_d, 3),
-    (C, c, EC, TraitC, default_extend_tuple_c, 2),
-    (B, b, EB, TraitB, default_extend_tuple_b, 1),
-    (A, a, EA, TraitA, default_extend_tuple_a, 0),
+impl_extend_tuple!((A, ExA, 0), (B, ExB, 1));
+impl_extend_tuple!((A, ExA, 0), (B, ExB, 1), (C, ExC, 2));
+impl_extend_tuple!((A, ExA, 0), (B, ExB, 1), (C, ExC, 2), (D, ExD, 3));
+impl_extend_tuple!((A, ExA, 0), (B, ExB, 1), (C, ExC, 2), (D, ExD, 3), (E, ExE, 4));
+impl_extend_tuple!((A, ExA, 0), (B, ExB, 1), (C, ExC, 2), (D, ExD, 3), (E, ExE, 4), (F, ExF, 5));
+impl_extend_tuple!(
+    (A, ExA, 0),
+    (B, ExB, 1),
+    (C, ExC, 2),
+    (D, ExD, 3),
+    (E, ExE, 4),
+    (F, ExF, 5),
+    (G, ExG, 6)
+);
+impl_extend_tuple!(
+    (A, ExA, 0),
+    (B, ExB, 1),
+    (C, ExC, 2),
+    (D, ExD, 3),
+    (E, ExE, 4),
+    (F, ExF, 5),
+    (G, ExG, 6),
+    (H, ExH, 7)
+);
+impl_extend_tuple!(
+    (A, ExA, 0),
+    (B, ExB, 1),
+    (C, ExC, 2),
+    (D, ExD, 3),
+    (E, ExE, 4),
+    (F, ExF, 5),
+    (G, ExG, 6),
+    (H, ExH, 7),
+    (I, ExI, 8)
+);
+impl_extend_tuple!(
+    (A, ExA, 0),
+    (B, ExB, 1),
+    (C, ExC, 2),
+    (D, ExD, 3),
+    (E, ExE, 4),
+    (F, ExF, 5),
+    (G, ExG, 6),
+    (H, ExH, 7),
+    (I, ExI, 8),
+    (J, ExJ, 9)
+);
+impl_extend_tuple!(
+    (A, ExA, 0),
+    (B, ExB, 1),
+    (C, ExC, 2),
+    (D, ExD, 3),
+    (E, ExE, 4),
+    (F, ExF, 5),
+    (G, ExG, 6),
+    (H, ExH, 7),
+    (I, ExI, 8),
+    (J, ExJ, 9),
+    (K, ExK, 10)
+);
+impl_extend_tuple!(
+    (A, ExA, 0),
+    (B, ExB, 1),
+    (C, ExC, 2),
+    (D, ExD, 3),
+    (E, ExE, 4),
+    (F, ExF, 5),
+    (G, ExG, 6),
+    (H, ExH, 7),
+    (I, ExI, 8),
+    (J, ExJ, 9),
+    (K, ExK, 10),
+    (L, ExL, 11)
 );

--- a/library/std/src/time.rs
+++ b/library/std/src/time.rs
@@ -112,19 +112,19 @@ use crate::sys_common::{FromInner, IntoInner};
 /// |  Platform |               System call                                            |
 /// |-----------|----------------------------------------------------------------------|
 /// | SGX       | [`insecure_time` usercall]. More information on [timekeeping in SGX] |
-/// | UNIX      | [clock_gettime (Monotonic Clock)]                                    |
-/// | Darwin    | [clock_gettime (Monotonic Clock)]                                    |
-/// | VXWorks   | [clock_gettime (Monotonic Clock)]                                    |
+/// | UNIX      | [clock_gettime] with `CLOCK_MONOTONIC`                               |
+/// | Darwin    | [clock_gettime] with `CLOCK_UPTIME_RAW`                              |
+/// | VXWorks   | [clock_gettime] with `CLOCK_MONOTONIC`                               |
 /// | SOLID     | `get_tim`                                                            |
-/// | WASI      | [__wasi_clock_time_get (Monotonic Clock)]                            |
+/// | WASI      | [__wasi_clock_time_get] with `monotonic`                             |
 /// | Windows   | [QueryPerformanceCounter]                                            |
 ///
 /// [currently]: crate::io#platform-specific-behavior
 /// [QueryPerformanceCounter]: https://docs.microsoft.com/en-us/windows/win32/api/profileapi/nf-profileapi-queryperformancecounter
 /// [`insecure_time` usercall]: https://edp.fortanix.com/docs/api/fortanix_sgx_abi/struct.Usercalls.html#method.insecure_time
 /// [timekeeping in SGX]: https://edp.fortanix.com/docs/concepts/rust-std/#codestdtimecode
-/// [__wasi_clock_time_get (Monotonic Clock)]: https://github.com/WebAssembly/WASI/blob/main/legacy/preview1/docs.md#clock_time_get
-/// [clock_gettime (Monotonic Clock)]: https://linux.die.net/man/3/clock_gettime
+/// [__wasi_clock_time_get]: https://github.com/WebAssembly/WASI/blob/main/legacy/preview1/docs.md#clock_time_get
+/// [clock_gettime]: https://linux.die.net/man/3/clock_gettime
 ///
 /// **Disclaimer:** These system calls might change over time.
 ///

--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -1379,11 +1379,26 @@ def main():
         sys.argv[1] = "-h"
 
     args = parse_args(sys.argv)
-    help_triggered = args.help or len(sys.argv) == 1
 
-    # If the user is asking for help, let them know that the whole download-and-build
+    # Root help (e.g., x.py --help) prints help from the saved file to save the time
+    if len(sys.argv) == 1 or sys.argv[1] in ["-h", "--help"]:
+        try:
+            with open(
+                os.path.join(os.path.dirname(__file__), "../etc/xhelp"), "r"
+            ) as f:
+                # The file from bootstrap func already has newline.
+                print(f.read(), end="")
+                sys.exit(0)
+        except Exception as error:
+            eprint(
+                f"ERROR: unable to run help: {error}\n",
+                "x.py run generate-help may solve the problem.",
+            )
+            sys.exit(1)
+
+    # If the user is asking for other helps, let them know that the whole download-and-build
     # process has to happen before anything is printed out.
-    if help_triggered:
+    if args.help:
         eprint(
             "INFO: Downloading and building bootstrap before processing --help command.\n"
             "      See src/bootstrap/README.md for help with common commands."
@@ -1401,13 +1416,14 @@ def main():
             eprint(error)
         success_word = "unsuccessfully"
 
-    if not help_triggered:
+    if not args.help:
         eprint(
             "Build completed",
             success_word,
             "in",
             format_build_time(time() - start_time),
         )
+
     sys.exit(exit_code)
 
 

--- a/src/bootstrap/src/core/build_steps/check.rs
+++ b/src/bootstrap/src/core/build_steps/check.rs
@@ -61,6 +61,9 @@ impl Step for Std {
             return;
         }
 
+        // Explicitly pass -p for all dependencies crates -- this will force cargo
+        // to also check the tests/benches/examples for these crates, rather
+        // than just the leaf crate.
         let crates = std_crates_for_run_make(&run);
         run.builder.ensure(Std {
             build_compiler: prepare_compiler_for_check(run.builder, run.target, Mode::Std)
@@ -83,14 +86,10 @@ impl Step for Std {
             Kind::Check,
         );
 
-        std_cargo(builder, target, &mut cargo);
+        std_cargo(builder, target, &mut cargo, &self.crates);
         if matches!(builder.config.cmd, Subcommand::Fix) {
             // By default, cargo tries to fix all targets. Tell it not to fix tests until we've added `test` to the sysroot.
             cargo.arg("--lib");
-        }
-
-        for krate in &*self.crates {
-            cargo.arg("-p").arg(krate);
         }
 
         let _guard = builder.msg(
@@ -135,14 +134,7 @@ impl Step for Std {
             Kind::Check,
         );
 
-        std_cargo(builder, target, &mut cargo);
-
-        // Explicitly pass -p for all dependencies krates -- this will force cargo
-        // to also check the tests/benches/examples for these crates, rather
-        // than just the leaf crate.
-        for krate in &*self.crates {
-            cargo.arg("-p").arg(krate);
-        }
+        std_cargo(builder, target, &mut cargo, &self.crates);
 
         let stamp =
             build_stamp::libstd_stamp(builder, build_compiler, target).with_prefix("check-test");

--- a/src/bootstrap/src/core/build_steps/clippy.rs
+++ b/src/bootstrap/src/core/build_steps/clippy.rs
@@ -195,11 +195,7 @@ impl Step for Std {
             Kind::Clippy,
         );
 
-        std_cargo(builder, target, &mut cargo);
-
-        for krate in &*self.crates {
-            cargo.arg("-p").arg(krate);
-        }
+        std_cargo(builder, target, &mut cargo, &self.crates);
 
         let _guard = builder.msg(
             Kind::Clippy,

--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -266,10 +266,7 @@ impl Step for Std {
                 target,
                 Kind::Build,
             );
-            std_cargo(builder, target, &mut cargo);
-            for krate in &*self.crates {
-                cargo.arg("-p").arg(krate);
-            }
+            std_cargo(builder, target, &mut cargo, &self.crates);
             cargo
         };
 
@@ -497,7 +494,12 @@ fn compiler_rt_for_profiler(builder: &Builder<'_>) -> PathBuf {
 
 /// Configure cargo to compile the standard library, adding appropriate env vars
 /// and such.
-pub fn std_cargo(builder: &Builder<'_>, target: TargetSelection, cargo: &mut Cargo) {
+pub fn std_cargo(
+    builder: &Builder<'_>,
+    target: TargetSelection,
+    cargo: &mut Cargo,
+    crates: &[String],
+) {
     // rustc already ensures that it builds with the minimum deployment
     // target, so ideally we shouldn't need to do anything here.
     //
@@ -605,6 +607,10 @@ pub fn std_cargo(builder: &Builder<'_>, target: TargetSelection, cargo: &mut Car
         cargo.env("CFG_DISABLE_UNSTABLE_FEATURES", "1");
     }
 
+    for krate in crates {
+        cargo.args(["-p", krate]);
+    }
+
     let mut features = String::new();
 
     if builder.no_std(target) == Some(true) {
@@ -614,8 +620,10 @@ pub fn std_cargo(builder: &Builder<'_>, target: TargetSelection, cargo: &mut Car
         }
 
         // for no-std targets we only compile a few no_std crates
+        if crates.is_empty() {
+            cargo.args(["-p", "alloc"]);
+        }
         cargo
-            .args(["-p", "alloc"])
             .arg("--manifest-path")
             .arg(builder.src.join("library/alloc/Cargo.toml"))
             .arg("--features")

--- a/src/bootstrap/src/core/build_steps/doc.rs
+++ b/src/bootstrap/src/core/build_steps/doc.rs
@@ -783,7 +783,7 @@ fn doc_std(
         Kind::Doc,
     );
 
-    compile::std_cargo(builder, target, &mut cargo);
+    compile::std_cargo(builder, target, &mut cargo, requested_crates);
     cargo
         .arg("--no-deps")
         .arg("--target-dir")
@@ -801,10 +801,6 @@ fn doc_std(
 
     if builder.config.library_docs_private_items {
         cargo.rustdocflag("--document-private-items").rustdocflag("--document-hidden-items");
-    }
-
-    for krate in requested_crates {
-        cargo.arg("-p").arg(krate);
     }
 
     let description =

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -15,7 +15,7 @@ use crate::core::build_steps::compile::{Std, run_cargo};
 use crate::core::build_steps::doc::{DocumentationFormat, prepare_doc_compiler};
 use crate::core::build_steps::gcc::{Gcc, add_cg_gcc_cargo_flags};
 use crate::core::build_steps::llvm::get_llvm_version;
-use crate::core::build_steps::run::get_completion_paths;
+use crate::core::build_steps::run::{get_completion_paths, get_help_path};
 use crate::core::build_steps::synthetic_targets::MirOptPanicAbortSyntheticTarget;
 use crate::core::build_steps::tool::{
     self, RustcPrivateCompilers, SourceType, TEST_FLOAT_PARSE_ALLOW_FEATURES, Tool,
@@ -28,7 +28,7 @@ use crate::core::builder::{
     crate_description,
 };
 use crate::core::config::TargetSelection;
-use crate::core::config::flags::{Subcommand, get_completion};
+use crate::core::config::flags::{Subcommand, get_completion, top_level_help};
 use crate::utils::build_stamp::{self, BuildStamp};
 use crate::utils::exec::{BootstrapCommand, command};
 use crate::utils::helpers::{
@@ -1291,6 +1291,23 @@ HELP: to skip test's attempt to check tidiness, pass `--skip src/tools/tidy` to 
                 "x.py completions were changed; run `x.py run generate-completions` to update them"
             );
             crate::exit!(1);
+        }
+
+        builder.info("x.py help check");
+        if builder.config.cmd.bless() {
+            builder.ensure(crate::core::build_steps::run::GenerateHelp);
+        } else {
+            let help_path = get_help_path(builder);
+            let cur_help = std::fs::read_to_string(&help_path).unwrap_or_else(|err| {
+                eprintln!("couldn't read {}: {}", help_path.display(), err);
+                crate::exit!(1);
+            });
+            let new_help = top_level_help();
+
+            if new_help != cur_help {
+                eprintln!("x.py help was changed; run `x.py run generate-help` to update it");
+                crate::exit!(1);
+            }
         }
     }
 

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -2963,7 +2963,7 @@ impl Step for Crate {
                         .arg("--manifest-path")
                         .arg(builder.src.join("library/sysroot/Cargo.toml"));
                 } else {
-                    compile::std_cargo(builder, target, &mut cargo);
+                    compile::std_cargo(builder, target, &mut cargo, &[]);
                 }
             }
             Mode::Rustc => {

--- a/src/bootstrap/src/core/builder/mod.rs
+++ b/src/bootstrap/src/core/builder/mod.rs
@@ -1239,6 +1239,7 @@ impl<'a> Builder<'a> {
                 run::CyclicStep,
                 run::CoverageDump,
                 run::Rustfmt,
+                run::GenerateHelp,
             ),
             Kind::Setup => {
                 describe!(setup::Profile, setup::Hook, setup::Link, setup::Editor)

--- a/src/bootstrap/src/core/config/flags.rs
+++ b/src/bootstrap/src/core/config/flags.rs
@@ -701,3 +701,9 @@ pub fn get_completion(shell: &dyn Generator, path: &Path) -> Option<String> {
     }
     Some(String::from_utf8(buf).expect("completion script should be UTF-8"))
 }
+
+/// Return the top level help of the bootstrap.
+pub fn top_level_help() -> String {
+    let mut cmd = Flags::command();
+    cmd.render_help().to_string()
+}

--- a/src/ci/docker/host-x86_64/dist-various-1/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-various-1/Dockerfile
@@ -111,12 +111,12 @@ ENV TARGETS=$TARGETS,riscv32imac-unknown-none-elf
 ENV TARGETS=$TARGETS,riscv32imafc-unknown-none-elf
 ENV TARGETS=$TARGETS,riscv64imac-unknown-none-elf
 ENV TARGETS=$TARGETS,riscv64gc-unknown-none-elf
-ENV TARGETS=$TARGETS,armebv7r-none-eabi
-ENV TARGETS=$TARGETS,armebv7r-none-eabihf
 ENV TARGETS=$TARGETS,armv7r-none-eabi
 ENV TARGETS=$TARGETS,armv7r-none-eabihf
+ENV TARGETS=$TARGETS,armv8r-none-eabihf
 ENV TARGETS=$TARGETS,thumbv7neon-unknown-linux-gnueabihf
 ENV TARGETS=$TARGETS,armv7a-none-eabi
+ENV TARGETS=$TARGETS,armv7a-none-eabihf
 
 ENV CFLAGS_armv5te_unknown_linux_musleabi="-march=armv5te -marm -mfloat-abi=soft" \
     CFLAGS_arm_unknown_linux_musleabi="-march=armv6 -marm" \

--- a/src/etc/xhelp
+++ b/src/etc/xhelp
@@ -1,0 +1,96 @@
+
+Usage: x.py <subcommand> [options] [<paths>...]
+
+Commands:
+  build    Compile either the compiler or libraries
+  check    Compile either the compiler or libraries, using cargo check
+  clippy   Run Clippy (uses rustup/cargo-installed clippy binary)
+  fix      Run cargo fix
+  fmt      Run rustfmt
+  doc      Build documentation
+  test     Build and run some test suites
+  miri     Build and run some test suites *in Miri*
+  bench    Build and run some benchmarks
+  clean    Clean out build directories
+  dist     Build distribution artifacts
+  install  Install distribution artifacts
+  run      Run tools contained in this repository
+  setup    Set up the environment for development
+  vendor   Vendor dependencies
+  perf     Perform profiling and benchmarking of the compiler using `rustc-perf`
+
+Arguments:
+  [PATHS]...  paths for the subcommand
+  [ARGS]...   arguments passed to subcommands
+
+Options:
+  -v, --verbose...
+          use verbose output (-vv for very verbose)
+  -i, --incremental
+          use incremental compilation
+      --config <FILE>
+          TOML configuration file for build
+      --build-dir <DIR>
+          Build directory, overrides `build.build-dir` in `bootstrap.toml`
+      --build <BUILD>
+          host target of the stage0 compiler
+      --host <HOST>
+          host targets to build
+      --target <TARGET>
+          target targets to build
+      --exclude <PATH>
+          build paths to exclude
+      --skip <PATH>
+          build paths to skip
+      --include-default-paths
+          include default paths in addition to the provided ones
+      --rustc-error-format <RUSTC_ERROR_FORMAT>
+          rustc error format
+      --on-fail <CMD>
+          command to run on failure
+      --dry-run
+          dry run; don't build anything
+      --dump-bootstrap-shims
+          Indicates whether to dump the work done from bootstrap shims
+      --stage <N>
+          stage to build (indicates compiler to use/test, e.g., stage 0 uses the bootstrap compiler, stage 1 the stage 0 rustc artifacts, etc.)
+      --keep-stage <N>
+          stage(s) to keep without recompiling (pass multiple times to keep e.g., both stages 0 and 1)
+      --keep-stage-std <N>
+          stage(s) of the standard library to keep without recompiling (pass multiple times to keep e.g., both stages 0 and 1)
+      --src <DIR>
+          path to the root of the rust checkout
+  -j, --jobs <JOBS>
+          number of jobs to run in parallel
+      --warnings <deny|warn>
+          if value is deny, will deny warnings if value is warn, will emit warnings otherwise, use the default configured behaviour [default: default] [possible values: deny, warn, default]
+      --json-output
+          use message-format=json
+      --compile-time-deps
+          only build proc-macros and build scripts (for rust-analyzer)
+      --color <STYLE>
+          whether to use color in cargo and rustc output [default: auto] [possible values: always, never, auto]
+      --bypass-bootstrap-lock
+          Bootstrap uses this value to decide whether it should bypass locking the build process. This is rarely needed (e.g., compiling the std library for different targets in parallel)
+      --rust-profile-generate <PROFILE>
+          generate PGO profile with rustc build
+      --rust-profile-use <PROFILE>
+          use PGO profile for rustc build
+      --llvm-profile-use <PROFILE>
+          use PGO profile for LLVM build
+      --llvm-profile-generate
+          generate PGO profile with llvm built for rustc
+      --enable-bolt-settings
+          Enable BOLT link flags
+      --skip-stage0-validation
+          Skip stage0 compiler validation
+      --reproducible-artifact <REPRODUCIBLE_ARTIFACT>
+          Additional reproducible artifacts that should be added to the reproducible artifacts archive
+      --set <section.option=value>
+          override options in bootstrap.toml
+      --ci <bool>
+          Make bootstrap to behave as it's running on the CI environment or not [possible values: true, false]
+      --skip-std-check-if-no-download-rustc
+          Skip checking the standard library if `rust.download-rustc` isn't available. This is mostly for RA as building the stage1 compiler to check the library tree on each code change might be too much for some computers
+  -h, --help
+          Print help (see more with '--help')

--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -89,6 +89,7 @@ static TARGETS: &[&str] = &[
     "armv7-unknown-linux-gnueabi",
     "armv7-unknown-linux-gnueabihf",
     "armv7a-none-eabi",
+    "armv7a-none-eabihf",
     "thumbv7neon-unknown-linux-gnueabihf",
     "armv7-unknown-linux-musleabi",
     "armv7-unknown-linux-musleabihf",

--- a/src/tools/wasm-component-ld/Cargo.toml
+++ b/src/tools/wasm-component-ld/Cargo.toml
@@ -10,4 +10,4 @@ name = "wasm-component-ld"
 path = "src/main.rs"
 
 [dependencies]
-wasm-component-ld = "0.5.17"
+wasm-component-ld = "0.5.18"

--- a/tests/codegen-llvm/common_prim_int_ptr.rs
+++ b/tests/codegen-llvm/common_prim_int_ptr.rs
@@ -11,7 +11,7 @@
 #[no_mangle]
 pub fn insert_int(x: usize) -> Result<usize, Box<()>> {
     // CHECK: start:
-    // CHECK-NEXT: %[[WO_PROV:.+]] = getelementptr i8, ptr null, [[USIZE:i[0-9]+]] %x
+    // CHECK-NEXT: %[[WO_PROV:.+]] = inttoptr [[USIZE:i[0-9]+]] %x to ptr
     // CHECK-NEXT: %[[R:.+]] = insertvalue { [[USIZE]], ptr } { [[USIZE]] 0, ptr poison }, ptr %[[WO_PROV]], 1
     // CHECK-NEXT: ret { [[USIZE]], ptr } %[[R]]
     Ok(x)

--- a/tests/codegen-llvm/enum/enum-aggregate.rs
+++ b/tests/codegen-llvm/enum/enum-aggregate.rs
@@ -70,7 +70,7 @@ fn make_ok_ptr(x: NonNull<u16>) -> Result<NonNull<u16>, usize> {
 fn make_ok_int(x: usize) -> Result<usize, NonNull<u16>> {
     // CHECK-LABEL: { i64, ptr } @make_ok_int(i64 %x)
     // CHECK-NEXT: start:
-    // CHECK-NEXT: %[[NOPROV:.+]] = getelementptr i8, ptr null, i64 %x
+    // CHECK-NEXT: %[[NOPROV:.+]] = inttoptr i64 %x to ptr
     // CHECK-NEXT: %[[R:.+]] = insertvalue { i64, ptr } { i64 0, ptr poison }, ptr %[[NOPROV]], 1
     // CHECK-NEXT: ret { i64, ptr } %[[R]]
     Ok(x)

--- a/tests/codegen-llvm/int-ptr-int-enum-miscompile.rs
+++ b/tests/codegen-llvm/int-ptr-int-enum-miscompile.rs
@@ -1,0 +1,22 @@
+// This is a regression test for https://github.com/rust-lang/rust/issues/147265.
+
+//@ compile-flags: -Copt-level=3
+
+#![crate_type = "lib"]
+
+#[no_mangle]
+pub fn mk_result(a: usize) -> Result<u8, *const u8> {
+    // CHECK-LABEL: @mk_result
+    // CHECK-NOT: unreachable
+    // CHECK: load i8,
+    // CHECK-NOT: unreachable
+    match g(a) {
+        Ok(b) => Ok(unsafe { *(b as *const u8) }),
+        Err(c) => Err(c),
+    }
+}
+
+#[cold]
+fn g(a: usize) -> Result<usize, *const u8> {
+    Ok(a)
+}

--- a/tests/codegen-llvm/intrinsics/transmute-niched.rs
+++ b/tests/codegen-llvm/intrinsics/transmute-niched.rs
@@ -249,7 +249,7 @@ pub unsafe fn check_four_or_eight_to_nonnull(x: FourOrEight) -> NonNull<u8> {
     // OPT: call void @llvm.assume(i1 %1)
     // CHECK-NOT: icmp
     // CHECK-NOT: assume
-    // CHECK: %[[RET:.+]] = getelementptr i8, ptr null, i64 %x
+    // CHECK: %[[RET:.+]] = inttoptr i64 %x to ptr
     // CHECK-NEXT: ret ptr %[[RET]]
 
     transmute(x)

--- a/tests/codegen-llvm/intrinsics/transmute.rs
+++ b/tests/codegen-llvm/intrinsics/transmute.rs
@@ -303,7 +303,7 @@ pub unsafe fn check_pair_with_bool(x: (u8, bool)) -> (bool, i8) {
 pub unsafe fn check_float_to_pointer(x: f64) -> *const () {
     // CHECK-NOT: alloca
     // CHECK: %0 = bitcast double %x to i64
-    // CHECK: %_0 = getelementptr i8, ptr null, i64 %0
+    // CHECK: %_0 = inttoptr i64 %0 to ptr
     // CHECK: ret ptr %_0
     transmute(x)
 }
@@ -378,7 +378,7 @@ pub unsafe fn check_issue_110005(x: (usize, bool)) -> Option<Box<[u8]>> {
 // CHECK-LABEL: @check_pair_to_dst_ref(
 #[no_mangle]
 pub unsafe fn check_pair_to_dst_ref<'a>(x: (usize, usize)) -> &'a [u8] {
-    // CHECK: %_0.0 = getelementptr i8, ptr null, i64 %x.0
+    // CHECK: %_0.0 = inttoptr i64 %x.0 to ptr
     // CHECK: %0 = icmp ne ptr %_0.0, null
     // CHECK: call void @llvm.assume(i1 %0)
     // CHECK: %1 = insertvalue { ptr, i64 } poison, ptr %_0.0, 0

--- a/tests/codegen-llvm/transmute-scalar.rs
+++ b/tests/codegen-llvm/transmute-scalar.rs
@@ -56,7 +56,7 @@ pub fn ptr_to_int(p: *mut u16) -> usize {
 }
 
 // CHECK: define{{.*}}ptr @int_to_ptr([[USIZE]] %i)
-// CHECK: %_0 = getelementptr i8, ptr null, [[USIZE]] %i
+// CHECK: %_0 = inttoptr [[USIZE]] %i to ptr
 // CHECK-NEXT: ret ptr %_0
 #[no_mangle]
 pub fn int_to_ptr(i: usize) -> *mut u16 {


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#138799 (core: simplify `Extend` for tuples)
 - rust-lang/rust#146692 (Save x.py's help text for saving output time)
 - rust-lang/rust#147168 (Don't unconditionally build alloc for `no-std` targets)
 - rust-lang/rust#147178 ([DebugInfo] Improve formatting of MSVC enum struct variants)
 - rust-lang/rust#147240 (Add an ACP list item to the library tracking issue template)
 - rust-lang/rust#147246 (Explain not existed key in BTreeMap::split_off)
 - rust-lang/rust#147393 (Extract most code from `define_feedable!`)
 - rust-lang/rust#147495 (Update wasm-component-ld to 0.5.18)
 - rust-lang/rust#147503 (Fix documentation of Instant::now on mac)
 - rust-lang/rust#147541 (Change int-to-ptr transmute lowering back to inttoptr)
 - rust-lang/rust#147549 (Replace `LLVMRustContextCreate` with normal LLVM-C API calls)
 - rust-lang/rust#147596 (Adjust the Arm targets in CI to reflect latest changes)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=138799,146692,147168,147178,147240,147246,147393,147495,147503,147541,147549,147596)
<!-- homu-ignore:end -->