### PR TITLE
Uplift module inception from clippy

### DIFF
--- a/compiler/rustc_hir_analysis/src/check/mod.rs
+++ b/compiler/rustc_hir_analysis/src/check/mod.rs
@@ -63,6 +63,8 @@ a type parameter).
 */
 
 pub mod always_applicable;
+#[cfg_attr(bootstrap, allow(unknown_lints))]
+#[allow(module_inception)]
 mod check;
 mod compare_impl_item;
 mod entry;

--- a/compiler/rustc_lint/src/lib.rs
+++ b/compiler/rustc_lint/src/lib.rs
@@ -59,6 +59,7 @@ pub mod lifetime_syntax;
 mod lints;
 mod macro_expr_fragment_specifier_2024_migration;
 mod map_unit_fn;
+mod module_inception;
 mod multiple_supertrait_upcastable;
 mod non_ascii_idents;
 mod non_fmt_panic;
@@ -100,6 +101,7 @@ use let_underscore::*;
 use lifetime_syntax::*;
 use macro_expr_fragment_specifier_2024_migration::*;
 use map_unit_fn::*;
+use module_inception::*;
 use multiple_supertrait_upcastable::*;
 use non_ascii_idents::*;
 use non_fmt_panic::NonPanicFmt;
@@ -181,6 +183,16 @@ early_lint_methods!(
             Expr2024: Expr2024,
             Precedence: Precedence,
             DoubleNegations: DoubleNegations,
+        ]
+    ]
+);
+
+late_lint_methods!(
+    declare_combined_late_lint_pass,
+    [
+        BuiltinCombinedLateLintPass,
+        [
+            ModuleInception: ModuleInception::new(),
         ]
     ]
 );
@@ -273,6 +285,7 @@ fn register_builtins(store: &mut LintStore) {
 
     store.register_lints(&BuiltinCombinedPreExpansionLintPass::get_lints());
     store.register_lints(&BuiltinCombinedEarlyLintPass::get_lints());
+    store.register_lints(&BuiltinCombinedLateLintPass::get_lints());
     store.register_lints(&BuiltinCombinedModuleLateLintPass::get_lints());
     store.register_lints(&foreign_modules::get_lints());
     store.register_lints(&HardwiredLints::lint_vec());

--- a/compiler/rustc_lint/src/module_inception.rs
+++ b/compiler/rustc_lint/src/module_inception.rs
@@ -1,0 +1,92 @@
+//! Lint for detecting modules that have the same name as their parent module.
+
+use rustc_hir::{Body, Item, ItemKind};
+use rustc_session::{declare_lint, impl_lint_pass};
+use rustc_span::Symbol;
+
+use crate::{LateContext, LateLintPass, LintContext};
+
+declare_lint! {
+    /// The `module_inception` lint detects modules that have the same name as their parent module.
+    ///
+    /// ### Example
+    ///
+    /// ```rust,compile_fail
+    /// mod foo {
+    ///     mod foo {
+    ///         pub fn bar() {}
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// {{produces}}
+    ///
+    /// ### Explanation
+    ///
+    /// A typical beginner mistake is to have `mod foo;` and again `mod foo { .. }`
+    /// in `foo.rs`. The expectation is that items inside the inner `mod foo { .. }`
+    /// are then available through `foo::x`, but they are only available through
+    /// `foo::foo::x`. If this is done on purpose, it would be better to choose a
+    /// more representative module name.
+    pub MODULE_INCEPTION,
+    Warn,
+    "modules that have the same name as their parent module"
+}
+
+struct ModInfo {
+    name: Symbol,
+    /// How many bodies are between this module and the current lint pass position.
+    ///
+    /// Only the most recently seen module is updated when entering/exiting a body.
+    in_body_count: u32,
+}
+
+pub(crate) struct ModuleInception {
+    /// The module path the lint pass is in.
+    modules: Vec<ModInfo>,
+}
+
+impl ModuleInception {
+    pub(crate) fn new() -> Self {
+        Self { modules: Vec::new() }
+    }
+}
+
+impl_lint_pass!(ModuleInception => [MODULE_INCEPTION]);
+
+impl<'tcx> LateLintPass<'tcx> for ModuleInception {
+    fn check_item(&mut self, cx: &LateContext<'tcx>, item: &'tcx Item<'tcx>) {
+        if let ItemKind::Mod(ident, _) = item.kind {
+            // Check if this module has the same name as its parent module
+            if let [.., prev] = &*self.modules
+                && prev.name == ident.name
+                && prev.in_body_count == 0
+                && !item.span.from_expansion()
+            {
+                cx.span_lint(MODULE_INCEPTION, item.span, |lint| {
+                    lint.primary_message("module has the same name as its containing module");
+                });
+            }
+
+            self.modules.push(ModInfo { name: ident.name, in_body_count: 0 });
+        }
+    }
+
+    fn check_item_post(&mut self, _cx: &LateContext<'tcx>, item: &'tcx Item<'tcx>) {
+        if matches!(item.kind, ItemKind::Mod(..)) {
+            self.modules.pop();
+        }
+    }
+
+    fn check_body(&mut self, _: &LateContext<'tcx>, _: &Body<'tcx>) {
+        if let [.., last] = &mut *self.modules {
+            last.in_body_count += 1;
+        }
+    }
+
+    fn check_body_post(&mut self, _: &LateContext<'tcx>, _: &Body<'tcx>) {
+        if let [.., last] = &mut *self.modules {
+            last.in_body_count -= 1;
+        }
+    }
+}

--- a/library/core/src/async_iter/mod.rs
+++ b/library/core/src/async_iter/mod.rs
@@ -121,6 +121,7 @@
 //! warning: unused result that must be used: async iterators do nothing unless polled
 //! ```
 
+#[allow(module_inception)]
 mod async_iter;
 mod from_iter;
 

--- a/library/core/src/future/mod.rs
+++ b/library/core/src/future/mod.rs
@@ -13,6 +13,7 @@ use crate::ptr::NonNull;
 use crate::task::Context;
 
 mod async_drop;
+#[allow(module_inception)]
 mod future;
 mod into_future;
 mod join;

--- a/library/std/src/sys/process/unix/mod.rs
+++ b/library/std/src/sys/process/unix/mod.rs
@@ -16,6 +16,7 @@ cfg_select! {
         pub use unsupported::output;
     }
     _ => {
+        #[allow(module_inception)]
         mod unix;
         use unix as imp;
     }

--- a/library/test/src/lib.rs
+++ b/library/test/src/lib.rs
@@ -40,6 +40,7 @@ pub use self::types::TestName::*;
 pub use self::types::*;
 
 // Module to be used by rustc to compile tests in libtest
+#[allow(module_inception)]
 pub mod test {
     pub use crate::bench::Bencher;
     pub use crate::cli::{TestOpts, parse_opts};

--- a/src/bootstrap/src/core/config/mod.rs
+++ b/src/bootstrap/src/core/config/mod.rs
@@ -19,7 +19,7 @@
 //! - Utility enums for specific configuration options.
 //! - Helper functions for managing configuration values.
 
-#[expect(clippy::module_inception)]
+#[allow(unknown_lints, module_inception)]
 mod config;
 pub mod flags;
 pub mod target_selection;

--- a/src/bootstrap/src/lib.rs
+++ b/src/bootstrap/src/lib.rs
@@ -81,7 +81,6 @@ const LLD_FILE_NAMES: &[&str] = &["ld.lld", "ld64.lld", "lld-link", "wasm-ld"];
 
 /// Extra `--check-cfg` to add when building the compiler or tools
 /// (Mode restriction, config name, config values (if any))
-#[expect(clippy::type_complexity)] // It's fine for hard-coded list and type is explained above.
 const EXTRA_CHECK_CFGS: &[(Option<Mode>, &str, Option<&[&'static str]>)] = &[
     (Some(Mode::Rustc), "bootstrap", None),
     (Some(Mode::Codegen), "bootstrap", None),

--- a/tests/ui/expr/weird-exprs.rs
+++ b/tests/ui/expr/weird-exprs.rs
@@ -10,6 +10,7 @@
 #![allow(uncommon_codepoints, confusable_idents)]
 #![allow(unused_imports)]
 #![allow(unreachable_patterns)]
+#![allow(module_inception)]
 
 #![recursion_limit = "256"]
 

--- a/tests/ui/imports/issue-62767.rs
+++ b/tests/ui/imports/issue-62767.rs
@@ -1,4 +1,5 @@
 //@ check-pass
+#![allow(module_inception)]
 
 // Minimized case from #62767.
 mod m {

--- a/tests/ui/lint/module-inception-allow.rs
+++ b/tests/ui/lint/module-inception-allow.rs
@@ -1,0 +1,24 @@
+#![allow(module_inception)]
+
+pub mod foo {
+    pub mod foo {
+        pub fn bar() {}
+    }
+}
+
+pub mod baz {
+    // This is fine - different name
+    pub fn qux() {}
+}
+
+pub mod outer {
+    pub mod outer {
+        pub fn inner() {}
+    }
+
+    pub mod different {
+        pub fn func() {}
+    }
+}
+
+fn main() {}

--- a/tests/ui/lint/non-local-defs/convoluted-locals-131474-with-mods.rs
+++ b/tests/ui/lint/non-local-defs/convoluted-locals-131474-with-mods.rs
@@ -4,6 +4,7 @@
 // Similar to https://github.com/rust-lang/rust/issues/131474
 
 //@ check-pass
+#![allow(module_inception)]
 
 pub mod tmp {
     pub mod tmp {

--- a/tests/ui/lint/non-local-defs/module_as_local.rs
+++ b/tests/ui/lint/non-local-defs/module_as_local.rs
@@ -17,6 +17,7 @@ fn simple_one() {
 
 fn simple_two() {
     mod posts {
+        #[allow(module_inception)]
         pub mod posts {
             #[allow(non_camel_case_types)]
             pub struct table {}

--- a/tests/ui/structs-enums/rec-align-u64.rs
+++ b/tests/ui/structs-enums/rec-align-u64.rs
@@ -1,6 +1,8 @@
 //@ run-pass
 #![allow(dead_code)]
 #![allow(unused_unsafe)]
+#![allow(module_inception)]
+
 
 // Issue #2303
 


### PR DESCRIPTION
Fixes rust-lang/rust#141385

r? @estebank 

I added a group `BuiltinCombinedLateLintPass` is because `module_lints` is run per-module:
https://github.com/chenyukang/rust/blob/e7391b2f97ecb889cf48a1e83732bef64db0a575/compiler/rustc_lint/src/late.rs#L468-L471
but this check needs a recursive way so it's in crate_lints.

I'd like to make sure everything is OK in rustc lint before we remove it from clippy.

One thing I'm worried is this may report warning for those project without clippy checking, since now it's a builtin check and default is `warn`.

It's better to keep the same behavior with clippy, so how do we handle `allow_private_module_inception` option in clippy..

