### PR TITLE
Deduplicate higher-ranked lifetime capture errors in impl Trait

### DIFF
--- a/compiler/rustc_hir_analysis/src/errors.rs
+++ b/compiler/rustc_hir_analysis/src/errors.rs
@@ -1562,11 +1562,11 @@ pub(crate) struct UnconstrainedGenericParameter {
 #[diag(hir_analysis_opaque_captures_higher_ranked_lifetime, code = E0657)]
 pub(crate) struct OpaqueCapturesHigherRankedLifetime {
     #[primary_span]
-    pub span: Span,
+    pub span: MultiSpan,
     #[label]
     pub label: Option<Span>,
     #[note]
-    pub decl_span: Span,
+    pub decl_span: MultiSpan,
     pub bad_place: &'static str,
 }
 

--- a/tests/ui/error-codes/E0657.stderr
+++ b/tests/ui/error-codes/E0657.stderr
@@ -1,8 +1,8 @@
 error[E0657]: `impl Trait` cannot capture higher-ranked lifetime from `dyn` type
-  --> $DIR/E0657.rs:10:35
+  --> $DIR/E0657.rs:10:27
    |
 LL |     -> Box<dyn for<'a> Id<impl Lt<'a>>>
-   |                                   ^^
+   |                           ^^^^^^^^--^ `impl Trait` implicitly captures all lifetimes in scope
    |
 note: lifetime declared here
   --> $DIR/E0657.rs:10:20
@@ -11,10 +11,10 @@ LL |     -> Box<dyn for<'a> Id<impl Lt<'a>>>
    |                    ^^
 
 error[E0657]: `impl Trait` cannot capture higher-ranked lifetime from `dyn` type
-  --> $DIR/E0657.rs:19:39
+  --> $DIR/E0657.rs:19:31
    |
 LL |         -> Box<dyn for<'a> Id<impl Lt<'a>>>
-   |                                       ^^
+   |                               ^^^^^^^^--^ `impl Trait` implicitly captures all lifetimes in scope
    |
 note: lifetime declared here
   --> $DIR/E0657.rs:19:24

--- a/tests/ui/impl-trait/higher-ranked-lifetime-capture-deduplication.edition2015.stderr
+++ b/tests/ui/impl-trait/higher-ranked-lifetime-capture-deduplication.edition2015.stderr
@@ -1,0 +1,17 @@
+error[E0657]: `impl Trait` cannot capture higher-ranked lifetime from outer `impl Trait`
+  --> $DIR/higher-ranked-lifetime-capture-deduplication.rs:19:44
+   |
+LL | fn f() -> impl for<'a, 'b> Trait<'a, Out = impl Sized + 'a + 'b> {
+   |                                            ^^^^^^^^^^^^^--^^^--
+   |                                            |
+   |                                            `impl Trait` implicitly captures all lifetimes in scope
+   |
+note: lifetime declared here
+  --> $DIR/higher-ranked-lifetime-capture-deduplication.rs:19:20
+   |
+LL | fn f() -> impl for<'a, 'b> Trait<'a, Out = impl Sized + 'a + 'b> {
+   |                    ^^  ^^
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0657`.

--- a/tests/ui/impl-trait/higher-ranked-lifetime-capture-deduplication.edition2024.stderr
+++ b/tests/ui/impl-trait/higher-ranked-lifetime-capture-deduplication.edition2024.stderr
@@ -1,0 +1,17 @@
+error[E0657]: `impl Trait` cannot capture higher-ranked lifetime from outer `impl Trait`
+  --> $DIR/higher-ranked-lifetime-capture-deduplication.rs:19:44
+   |
+LL | fn f() -> impl for<'a, 'b> Trait<'a, Out = impl Sized + 'a + 'b> {
+   |                                            ^^^^^^^^^^^^^--^^^--
+   |                                            |
+   |                                            `impl Trait` implicitly captures all lifetimes in scope
+   |
+note: lifetime declared here
+  --> $DIR/higher-ranked-lifetime-capture-deduplication.rs:19:20
+   |
+LL | fn f() -> impl for<'a, 'b> Trait<'a, Out = impl Sized + 'a + 'b> {
+   |                    ^^  ^^
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0657`.

--- a/tests/ui/impl-trait/higher-ranked-lifetime-capture-deduplication.rs
+++ b/tests/ui/impl-trait/higher-ranked-lifetime-capture-deduplication.rs
@@ -1,6 +1,7 @@
 //@revisions: edition2015 edition2024
 //@[edition2015] edition:2015
 //@[edition2024] edition:2024
+
 trait Trait<'a> {
     type Out;
     fn call(&'a self) -> Self::Out;
@@ -15,7 +16,7 @@ impl<'a> Trait<'a> for X {
     }
 }
 
-fn f() -> impl for<'a> Trait<'a, Out = impl Sized + 'a> {
+fn f() -> impl for<'a, 'b> Trait<'a, Out = impl Sized + 'a + 'b> {
     //~^ ERROR `impl Trait` cannot capture higher-ranked lifetime from outer `impl Trait`
     X(())
 }

--- a/tests/ui/impl-trait/impl-fn-hrtb-bounds.stderr
+++ b/tests/ui/impl-trait/impl-fn-hrtb-bounds.stderr
@@ -12,10 +12,12 @@ LL + fn d() -> impl Fn() -> (impl Debug + 'static) {
    |
 
 error[E0657]: `impl Trait` cannot capture higher-ranked lifetime from outer `impl Trait`
-  --> $DIR/impl-fn-hrtb-bounds.rs:4:41
+  --> $DIR/impl-fn-hrtb-bounds.rs:4:28
    |
 LL | fn a() -> impl Fn(&u8) -> (impl Debug + '_) {
-   |                                         ^^
+   |                            ^^^^^^^^^^^^^--
+   |                            |
+   |                            `impl Trait` implicitly captures all lifetimes in scope
    |
 note: lifetime declared here
   --> $DIR/impl-fn-hrtb-bounds.rs:4:19
@@ -24,10 +26,12 @@ LL | fn a() -> impl Fn(&u8) -> (impl Debug + '_) {
    |                   ^
 
 error[E0657]: `impl Trait` cannot capture higher-ranked lifetime from outer `impl Trait`
-  --> $DIR/impl-fn-hrtb-bounds.rs:9:52
+  --> $DIR/impl-fn-hrtb-bounds.rs:9:39
    |
 LL | fn b() -> impl for<'a> Fn(&'a u8) -> (impl Debug + 'a) {
-   |                                                    ^^
+   |                                       ^^^^^^^^^^^^^--
+   |                                       |
+   |                                       `impl Trait` implicitly captures all lifetimes in scope
    |
 note: lifetime declared here
   --> $DIR/impl-fn-hrtb-bounds.rs:9:20
@@ -36,10 +40,12 @@ LL | fn b() -> impl for<'a> Fn(&'a u8) -> (impl Debug + 'a) {
    |                    ^^
 
 error[E0657]: `impl Trait` cannot capture higher-ranked lifetime from outer `impl Trait`
-  --> $DIR/impl-fn-hrtb-bounds.rs:14:52
+  --> $DIR/impl-fn-hrtb-bounds.rs:14:39
    |
 LL | fn c() -> impl for<'a> Fn(&'a u8) -> (impl Debug + '_) {
-   |                                                    ^^
+   |                                       ^^^^^^^^^^^^^--
+   |                                       |
+   |                                       `impl Trait` implicitly captures all lifetimes in scope
    |
 note: lifetime declared here
   --> $DIR/impl-fn-hrtb-bounds.rs:14:20

--- a/tests/ui/impl-trait/impl-fn-parsing-ambiguities.stderr
+++ b/tests/ui/impl-trait/impl-fn-parsing-ambiguities.stderr
@@ -21,10 +21,12 @@ LL | fn b() -> impl Fn() -> (impl Debug + Send) {
    |                        +                 +
 
 error[E0657]: `impl Trait` cannot capture higher-ranked lifetime from outer `impl Trait`
-  --> $DIR/impl-fn-parsing-ambiguities.rs:4:40
+  --> $DIR/impl-fn-parsing-ambiguities.rs:4:27
    |
 LL | fn a() -> impl Fn(&u8) -> impl Debug + '_ {
-   |                                        ^^
+   |                           ^^^^^^^^^^^^^--
+   |                           |
+   |                           `impl Trait` implicitly captures all lifetimes in scope
    |
 note: lifetime declared here
   --> $DIR/impl-fn-parsing-ambiguities.rs:4:19

--- a/tests/ui/impl-trait/issues/issue-54895.edition2015.stderr
+++ b/tests/ui/impl-trait/issues/issue-54895.edition2015.stderr
@@ -1,8 +1,10 @@
 error[E0657]: `impl Trait` cannot capture higher-ranked lifetime from outer `impl Trait`
-  --> $DIR/issue-54895.rs:18:53
+  --> $DIR/issue-54895.rs:18:40
    |
 LL | fn f() -> impl for<'a> Trait<'a, Out = impl Sized + 'a> {
-   |                                                     ^^
+   |                                        ^^^^^^^^^^^^^--
+   |                                        |
+   |                                        `impl Trait` implicitly captures all lifetimes in scope
    |
 note: lifetime declared here
   --> $DIR/issue-54895.rs:18:20

--- a/tests/ui/impl-trait/issues/issue-54895.edition2024.stderr
+++ b/tests/ui/impl-trait/issues/issue-54895.edition2024.stderr
@@ -2,7 +2,9 @@ error[E0657]: `impl Trait` cannot capture higher-ranked lifetime from outer `imp
   --> $DIR/issue-54895.rs:18:40
    |
 LL | fn f() -> impl for<'a> Trait<'a, Out = impl Sized + 'a> {
-   |                                        ^^^^^^^^^^^^^^^ `impl Trait` implicitly captures all lifetimes in scope
+   |                                        ^^^^^^^^^^^^^--
+   |                                        |
+   |                                        `impl Trait` implicitly captures all lifetimes in scope
    |
 note: lifetime declared here
   --> $DIR/issue-54895.rs:18:20
@@ -10,18 +12,6 @@ note: lifetime declared here
 LL | fn f() -> impl for<'a> Trait<'a, Out = impl Sized + 'a> {
    |                    ^^
 
-error[E0657]: `impl Trait` cannot capture higher-ranked lifetime from outer `impl Trait`
-  --> $DIR/issue-54895.rs:18:53
-   |
-LL | fn f() -> impl for<'a> Trait<'a, Out = impl Sized + 'a> {
-   |                                                     ^^
-   |
-note: lifetime declared here
-  --> $DIR/issue-54895.rs:18:20
-   |
-LL | fn f() -> impl for<'a> Trait<'a, Out = impl Sized + 'a> {
-   |                    ^^
-
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0657`.

--- a/tests/ui/impl-trait/issues/issue-67830.stderr
+++ b/tests/ui/impl-trait/issues/issue-67830.stderr
@@ -1,8 +1,10 @@
 error[E0657]: `impl Trait` cannot capture higher-ranked lifetime from outer `impl Trait`
-  --> $DIR/issue-67830.rs:20:64
+  --> $DIR/issue-67830.rs:20:48
    |
 LL | fn test() -> impl for<'a> MyFn<&'a A, Output = impl Iterator + 'a> {
-   |                                                                ^^
+   |                                                ^^^^^^^^^^^^^^^^--
+   |                                                |
+   |                                                `impl Trait` implicitly captures all lifetimes in scope
    |
 note: lifetime declared here
   --> $DIR/issue-67830.rs:20:23

--- a/tests/ui/impl-trait/issues/issue-88236-2.stderr
+++ b/tests/ui/impl-trait/issues/issue-88236-2.stderr
@@ -1,8 +1,10 @@
 error[E0657]: `impl Trait` cannot capture higher-ranked lifetime from outer `impl Trait`
-  --> $DIR/issue-88236-2.rs:15:61
+  --> $DIR/issue-88236-2.rs:15:49
    |
 LL | fn make_impl() -> impl for<'a> Hrtb<'a, Assoc = impl Send + 'a> {}
-   |                                                             ^^
+   |                                                 ^^^^^^^^^^^^--
+   |                                                 |
+   |                                                 `impl Trait` implicitly captures all lifetimes in scope
    |
 note: lifetime declared here
   --> $DIR/issue-88236-2.rs:15:28
@@ -11,10 +13,12 @@ LL | fn make_impl() -> impl for<'a> Hrtb<'a, Assoc = impl Send + 'a> {}
    |                            ^^
 
 error[E0657]: `impl Trait` cannot capture higher-ranked lifetime from outer `impl Trait`
-  --> $DIR/issue-88236-2.rs:18:80
+  --> $DIR/issue-88236-2.rs:18:68
    |
 LL | fn make_weird_impl<'b>(x: &'b ()) -> impl for<'a> Hrtb<'a, Assoc = impl Send + 'a> {
-   |                                                                                ^^
+   |                                                                    ^^^^^^^^^^^^--
+   |                                                                    |
+   |                                                                    `impl Trait` implicitly captures all lifetimes in scope
    |
 note: lifetime declared here
   --> $DIR/issue-88236-2.rs:18:47
@@ -23,10 +27,12 @@ LL | fn make_weird_impl<'b>(x: &'b ()) -> impl for<'a> Hrtb<'a, Assoc = impl Sen
    |                                               ^^
 
 error[E0657]: `impl Trait` cannot capture higher-ranked lifetime from outer `impl Trait`
-  --> $DIR/issue-88236-2.rs:23:78
+  --> $DIR/issue-88236-2.rs:23:66
    |
 LL | fn make_bad_impl<'b>(x: &'b ()) -> impl for<'a> Hrtb<'a, Assoc = impl Send + 'a> {
-   |                                                                              ^^
+   |                                                                  ^^^^^^^^^^^^--
+   |                                                                  |
+   |                                                                  `impl Trait` implicitly captures all lifetimes in scope
    |
 note: lifetime declared here
   --> $DIR/issue-88236-2.rs:23:45

--- a/tests/ui/impl-trait/issues/issue-88236.stderr
+++ b/tests/ui/impl-trait/issues/issue-88236.stderr
@@ -1,8 +1,10 @@
 error[E0657]: `impl Trait` cannot capture higher-ranked lifetime from outer `impl Trait`
-  --> $DIR/issue-88236.rs:15:61
+  --> $DIR/issue-88236.rs:15:49
    |
 LL | fn make_impl() -> impl for<'a> Hrtb<'a, Assoc = impl Send + 'a> {}
-   |                                                             ^^
+   |                                                 ^^^^^^^^^^^^--
+   |                                                 |
+   |                                                 `impl Trait` implicitly captures all lifetimes in scope
    |
 note: lifetime declared here
   --> $DIR/issue-88236.rs:15:28

--- a/tests/ui/impl-trait/nested-rpit-hrtb.stderr
+++ b/tests/ui/impl-trait/nested-rpit-hrtb.stderr
@@ -30,10 +30,12 @@ LL | fn two_htrb_outlives_uses<'b>() -> impl for<'a> Bar<'a, Assoc = impl for<'b
    |                          ++++
 
 error[E0657]: `impl Trait` cannot capture higher-ranked lifetime from outer `impl Trait`
-  --> $DIR/nested-rpit-hrtb.rs:25:69
+  --> $DIR/nested-rpit-hrtb.rs:25:56
    |
 LL | fn one_hrtb_outlives() -> impl for<'a> Foo<'a, Assoc = impl Sized + 'a> {}
-   |                                                                     ^^
+   |                                                        ^^^^^^^^^^^^^--
+   |                                                        |
+   |                                                        `impl Trait` implicitly captures all lifetimes in scope
    |
 note: lifetime declared here
   --> $DIR/nested-rpit-hrtb.rs:25:36
@@ -42,10 +44,10 @@ LL | fn one_hrtb_outlives() -> impl for<'a> Foo<'a, Assoc = impl Sized + 'a> {}
    |                                    ^^
 
 error[E0657]: `impl Trait` cannot capture higher-ranked lifetime from outer `impl Trait`
-  --> $DIR/nested-rpit-hrtb.rs:29:68
+  --> $DIR/nested-rpit-hrtb.rs:29:59
    |
 LL | fn one_hrtb_trait_param() -> impl for<'a> Foo<'a, Assoc = impl Qux<'a>> {}
-   |                                                                    ^^
+   |                                                           ^^^^^^^^^--^ `impl Trait` implicitly captures all lifetimes in scope
    |
 note: lifetime declared here
   --> $DIR/nested-rpit-hrtb.rs:29:39
@@ -54,10 +56,12 @@ LL | fn one_hrtb_trait_param() -> impl for<'a> Foo<'a, Assoc = impl Qux<'a>> {}
    |                                       ^^
 
 error[E0657]: `impl Trait` cannot capture higher-ranked lifetime from outer `impl Trait`
-  --> $DIR/nested-rpit-hrtb.rs:32:74
+  --> $DIR/nested-rpit-hrtb.rs:32:61
    |
 LL | fn one_hrtb_outlives_uses() -> impl for<'a> Bar<'a, Assoc = impl Sized + 'a> {}
-   |                                                                          ^^
+   |                                                             ^^^^^^^^^^^^^--
+   |                                                             |
+   |                                                             `impl Trait` implicitly captures all lifetimes in scope
    |
 note: lifetime declared here
   --> $DIR/nested-rpit-hrtb.rs:32:41
@@ -66,10 +70,10 @@ LL | fn one_hrtb_outlives_uses() -> impl for<'a> Bar<'a, Assoc = impl Sized + 'a
    |                                         ^^
 
 error[E0657]: `impl Trait` cannot capture higher-ranked lifetime from outer `impl Trait`
-  --> $DIR/nested-rpit-hrtb.rs:35:73
+  --> $DIR/nested-rpit-hrtb.rs:35:64
    |
 LL | fn one_hrtb_trait_param_uses() -> impl for<'a> Bar<'a, Assoc = impl Qux<'a>> {}
-   |                                                                         ^^
+   |                                                                ^^^^^^^^^--^ `impl Trait` implicitly captures all lifetimes in scope
    |
 note: lifetime declared here
   --> $DIR/nested-rpit-hrtb.rs:35:44

--- a/tests/ui/type-alias-impl-trait/bound-lifetime-through-dyn-trait.stderr
+++ b/tests/ui/type-alias-impl-trait/bound-lifetime-through-dyn-trait.stderr
@@ -1,8 +1,8 @@
 error[E0657]: `impl Trait` cannot capture higher-ranked lifetime from `dyn` type
-  --> $DIR/bound-lifetime-through-dyn-trait.rs:6:71
+  --> $DIR/bound-lifetime-through-dyn-trait.rs:6:57
    |
 LL | fn dyn_hoops<T: Sized>() -> dyn for<'a> Iterator<Item = impl Captures<'a>> {
-   |                                                                       ^^
+   |                                                         ^^^^^^^^^^^^^^--^ `impl Trait` implicitly captures all lifetimes in scope
    |
 note: lifetime declared here
   --> $DIR/bound-lifetime-through-dyn-trait.rs:6:37

--- a/tests/ui/type-alias-impl-trait/escaping-bound-var.rs
+++ b/tests/ui/type-alias-impl-trait/escaping-bound-var.rs
@@ -8,7 +8,6 @@ trait Test<'a> {}
 
 pub type Foo = impl for<'a> Trait<'a, Assoc = impl Test<'a>>;
 //~^ ERROR `impl Trait` cannot capture higher-ranked lifetime from outer `impl Trait`
-//~| ERROR `impl Trait` cannot capture higher-ranked lifetime from outer `impl Trait`
 
 impl Trait<'_> for () {
     type Assoc = ();

--- a/tests/ui/type-alias-impl-trait/escaping-bound-var.stderr
+++ b/tests/ui/type-alias-impl-trait/escaping-bound-var.stderr
@@ -2,7 +2,7 @@ error[E0657]: `impl Trait` cannot capture higher-ranked lifetime from outer `imp
   --> $DIR/escaping-bound-var.rs:9:47
    |
 LL | pub type Foo = impl for<'a> Trait<'a, Assoc = impl Test<'a>>;
-   |                                               ^^^^^^^^^^^^^ `impl Trait` implicitly captures all lifetimes in scope
+   |                                               ^^^^^^^^^^--^ `impl Trait` implicitly captures all lifetimes in scope
    |
 note: lifetime declared here
   --> $DIR/escaping-bound-var.rs:9:25
@@ -10,18 +10,6 @@ note: lifetime declared here
 LL | pub type Foo = impl for<'a> Trait<'a, Assoc = impl Test<'a>>;
    |                         ^^
 
-error[E0657]: `impl Trait` cannot capture higher-ranked lifetime from outer `impl Trait`
-  --> $DIR/escaping-bound-var.rs:9:57
-   |
-LL | pub type Foo = impl for<'a> Trait<'a, Assoc = impl Test<'a>>;
-   |                                                         ^^
-   |
-note: lifetime declared here
-  --> $DIR/escaping-bound-var.rs:9:25
-   |
-LL | pub type Foo = impl for<'a> Trait<'a, Assoc = impl Test<'a>>;
-   |                         ^^
-
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0657`.


### PR DESCRIPTION
  Previously, when an `impl Trait` captured multiple higher-ranked
  lifetimes from an outer `impl Trait`, the compiler would emit a
  separate error for each captured lifetime. This resulted in verbose
  and confusing diagnostics, especially in edition 2024 where implicit
  captures caused duplicate errors.

  This commit introduces error accumulation that collects all capture
  spans and lifetime declaration spans, then emits a single consolidated
  diagnostic using MultiSpan. The new error shows all captured lifetimes
  with visual indicators and lists all declarations in a single note.

r? @estebank 
Fixes https://github.com/rust-lang/rust/issues/143022