### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -495,7 +495,7 @@ dependencies = [
  "iana-time-zone",
  "num-traits",
  "serde",
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -6059,9 +6059,9 @@ dependencies = [
 
 [[package]]
 name = "wasi-preview1-component-adapter-provider"
-version = "36.0.1"
+version = "37.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20689c88791776219f78c2529700d15e6a9bd57a27858c62e9ef8487956b571c"
+checksum = "8d0fcd636ad2b29a7c0490799a23ad61d1c8dedfafdb970447fddd0549502b60"
 
 [[package]]
 name = "wasm-bindgen"
@@ -6123,9 +6123,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-component-ld"
-version = "0.5.17"
+version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c9208f87cac2332fd80dcf36d54e9163d3446e28301e0c6e424984425738984"
+checksum = "11f565dfcfd9aabb10d865b608a92ce1f93051aeb56f4c89550ed9cd97d8ce0e"
 dependencies = [
  "anyhow",
  "clap",
@@ -6133,9 +6133,9 @@ dependencies = [
  "libc",
  "tempfile",
  "wasi-preview1-component-adapter-provider",
- "wasmparser 0.239.0",
+ "wasmparser 0.240.0",
  "wat",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
  "winsplit",
  "wit-component",
  "wit-parser",
@@ -6160,24 +6160,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.239.0"
+version = "0.240.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be00faa2b4950c76fe618c409d2c3ea5a3c9422013e079482d78544bb2d184c"
+checksum = "06d642d8c5ecc083aafe9ceb32809276a304547a3a6eeecceb5d8152598bc71f"
 dependencies = [
  "leb128fmt",
- "wasmparser 0.239.0",
+ "wasmparser 0.240.0",
 ]
 
 [[package]]
 name = "wasm-metadata"
-version = "0.239.0"
+version = "0.240.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20b3ec880a9ac69ccd92fbdbcf46ee833071cf09f82bb005b2327c7ae6025ae2"
+checksum = "ee093e1e1ccffa005b9b778f7a10ccfd58e25a20eccad294a1a93168d076befb"
 dependencies = [
  "anyhow",
  "indexmap",
- "wasm-encoder 0.239.0",
- "wasmparser 0.239.0",
+ "wasm-encoder 0.240.0",
+ "wasmparser 0.240.0",
 ]
 
 [[package]]
@@ -6202,9 +6202,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.239.0"
+version = "0.240.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9d90bb93e764f6beabf1d02028c70a2156a6583e63ac4218dd07ef733368b0"
+checksum = "b722dcf61e0ea47440b53ff83ccb5df8efec57a69d150e4f24882e4eba7e24a4"
 dependencies = [
  "bitflags",
  "hashbrown",
@@ -6215,22 +6215,22 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "239.0.0"
+version = "240.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9139176fe8a2590e0fb174cdcaf373b224cb93c3dde08e4297c1361d2ba1ea5d"
+checksum = "b0efe1c93db4ac562b9733e3dca19ed7fc878dba29aef22245acf84f13da4a19"
 dependencies = [
  "bumpalo",
  "leb128fmt",
  "memchr",
  "unicode-width 0.2.1",
- "wasm-encoder 0.239.0",
+ "wasm-encoder 0.240.0",
 ]
 
 [[package]]
 name = "wat"
-version = "1.239.0"
+version = "1.240.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e1c941927d34709f255558166f8901a2005f8ab4a9650432e9281b7cc6f3b75"
+checksum = "4ec9b6eab7ecd4d639d78515e9ea491c9bacf494aa5eda10823bd35992cf8c1e"
 dependencies = [
  "wast",
 ]
@@ -6295,7 +6295,7 @@ dependencies = [
  "windows-collections",
  "windows-core 0.61.2",
  "windows-future",
- "windows-link",
+ "windows-link 0.1.3",
  "windows-numerics",
 ]
 
@@ -6340,7 +6340,7 @@ checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
  "windows-implement 0.60.0",
  "windows-interface 0.59.1",
- "windows-link",
+ "windows-link 0.1.3",
  "windows-result 0.3.4",
  "windows-strings 0.4.2",
 ]
@@ -6352,7 +6352,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
  "windows-core 0.61.2",
- "windows-link",
+ "windows-link 0.1.3",
  "windows-threading",
 ]
 
@@ -6407,13 +6407,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
 name = "windows-numerics"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -6431,7 +6437,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -6450,7 +6456,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -6481,6 +6487,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6502,7 +6517,7 @@ version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",
@@ -6519,7 +6534,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -6653,9 +6668,9 @@ dependencies = [
 
 [[package]]
 name = "wit-component"
-version = "0.239.0"
+version = "0.240.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88a866b19dba2c94d706ec58c92a4c62ab63e482b4c935d2a085ac94caecb136"
+checksum = "7dc5474b078addc5fe8a72736de8da3acfb3ff324c2491133f8b59594afa1a20"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -6664,17 +6679,17 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-encoder 0.239.0",
+ "wasm-encoder 0.240.0",
  "wasm-metadata",
- "wasmparser 0.239.0",
+ "wasmparser 0.240.0",
  "wit-parser",
 ]
 
 [[package]]
 name = "wit-parser"
-version = "0.239.0"
+version = "0.240.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55c92c939d667b7bf0c6bf2d1f67196529758f99a2a45a3355cc56964fd5315d"
+checksum = "9875ea3fa272f57cc1fc50f225a7b94021a7878c484b33792bccad0d93223439"
 dependencies = [
  "anyhow",
  "id-arena",
@@ -6685,7 +6700,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-xid",
- "wasmparser 0.239.0",
+ "wasmparser 0.240.0",
 ]
 
 [[package]]

--- a/compiler/rustc_arena/src/tests.rs
+++ b/compiler/rustc_arena/src/tests.rs
@@ -19,8 +19,8 @@ impl<T> TypedArena<T> {
         unsafe {
             // Clear the last chunk, which is partially filled.
             let mut chunks_borrow = self.chunks.borrow_mut();
-            if let Some(mut last_chunk) = chunks_borrow.last_mut() {
-                self.clear_last_chunk(&mut last_chunk);
+            if let Some(last_chunk) = chunks_borrow.last_mut() {
+                self.clear_last_chunk(last_chunk);
                 let len = chunks_borrow.len();
                 // If `T` is ZST, code below has no effect.
                 for mut chunk in chunks_borrow.drain(..len - 1) {

--- a/compiler/rustc_fluent_macro/src/fluent.rs
+++ b/compiler/rustc_fluent_macro/src/fluent.rs
@@ -265,7 +265,7 @@ pub(crate) fn fluent_messages(input: proc_macro::TokenStream) -> proc_macro::Tok
                 Level::Error,
                 format!("referenced message `{mref}` does not exist (in message `{name}`)"),
             )
-            .help(&format!("you may have meant to use a variable reference (`{{${mref}}}`)"))
+            .help(format!("you may have meant to use a variable reference (`{{${mref}}}`)"))
             .emit();
         }
     }

--- a/compiler/rustc_graphviz/src/tests.rs
+++ b/compiler/rustc_graphviz/src/tests.rs
@@ -63,10 +63,10 @@ impl NodeLabels<&'static str> {
     }
 
     fn len(&self) -> usize {
-        match self {
-            &UnlabelledNodes(len) => len,
-            &AllNodesLabelled(ref lbls) => lbls.len(),
-            &SomeNodesLabelled(ref lbls) => lbls.len(),
+        match *self {
+            UnlabelledNodes(len) => len,
+            AllNodesLabelled(ref lbls) => lbls.len(),
+            SomeNodesLabelled(ref lbls) => lbls.len(),
         }
     }
 }

--- a/compiler/rustc_hashes/src/lib.rs
+++ b/compiler/rustc_hashes/src/lib.rs
@@ -54,7 +54,7 @@ impl FromStableHash for Hash64 {
     type Hash = StableHasherHash;
 
     #[inline]
-    fn from(StableHasherHash([_0, __1]): Self::Hash) -> Self {
+    fn from(StableHasherHash([_0, _]): Self::Hash) -> Self {
         Self { inner: _0 }
     }
 }

--- a/compiler/rustc_llvm/build.rs
+++ b/compiler/rustc_llvm/build.rs
@@ -197,7 +197,7 @@ fn main() {
 
         // Include path contains host directory, replace it with target
         if is_crossed && flag.starts_with("-I") {
-            cfg.flag(&flag.replace(&host, &target));
+            cfg.flag(flag.replace(&host, &target));
             continue;
         }
 

--- a/compiler/rustc_log/src/lib.rs
+++ b/compiler/rustc_log/src/lib.rs
@@ -73,7 +73,7 @@ impl LoggerConfig {
 
 /// Initialize the logger with the given values for the filter, coloring, and other options env variables.
 pub fn init_logger(cfg: LoggerConfig) -> Result<(), Error> {
-    init_logger_with_additional_layer(cfg, || Registry::default())
+    init_logger_with_additional_layer(cfg, Registry::default)
 }
 
 /// Trait alias for the complex return type of `build_subscriber` in
@@ -145,14 +145,11 @@ where
         .with_thread_ids(verbose_thread_ids)
         .with_thread_names(verbose_thread_ids);
 
-    match cfg.wraptree {
-        Ok(v) => match v.parse::<usize>() {
-            Ok(v) => {
-                layer = layer.with_wraparound(v);
-            }
+    if let Ok(v) = cfg.wraptree {
+        match v.parse::<usize>() {
+            Ok(v) => layer = layer.with_wraparound(v),
             Err(_) => return Err(Error::InvalidWraptree(v)),
-        },
-        Err(_) => {} // no wraptree
+        }
     }
 
     let subscriber = build_subscriber().with(layer.with_filter(filter));

--- a/compiler/rustc_thread_pool/src/registry.rs
+++ b/compiler/rustc_thread_pool/src/registry.rs
@@ -808,7 +808,7 @@ impl WorkerThread {
         latch: &L,
         mut all_jobs_started: impl FnMut() -> bool,
         mut is_job: impl FnMut(&JobRef) -> bool,
-        mut execute_job: impl FnMut(JobRef) -> (),
+        mut execute_job: impl FnMut(JobRef),
     ) {
         let mut jobs = SmallVec::<[JobRef; 8]>::new();
         let mut broadcast_jobs = SmallVec::<[JobRef; 8]>::new();

--- a/compiler/rustc_thread_pool/src/scope/tests.rs
+++ b/compiler/rustc_thread_pool/src/scope/tests.rs
@@ -168,7 +168,7 @@ fn the_final_countdown<'scope>(
     let top_of_stack = 0;
     let p = bottom_of_stack as *const i32 as usize;
     let q = &top_of_stack as *const i32 as usize;
-    let diff = if p > q { p - q } else { q - p };
+    let diff = p.abs_diff(q);
 
     let mut data = max.lock().unwrap();
     *data = Ord::max(diff, *data);

--- a/compiler/rustc_thread_pool/src/thread_pool/tests.rs
+++ b/compiler/rustc_thread_pool/src/thread_pool/tests.rs
@@ -97,7 +97,7 @@ fn failed_thread_stack() {
     // macOS and Windows weren't fazed, or at least didn't fail the way we want.
     // They work with `isize::MAX`, but 32-bit platforms may feasibly allocate a
     // 2GB stack, so it might not fail until the second thread.
-    let stack_size = ::std::isize::MAX as usize;
+    let stack_size = isize::MAX as usize;
 
     let (start_count, start_handler) = count_handler();
     let (exit_count, exit_handler) = count_handler();

--- a/compiler/rustc_thread_pool/src/worker_local.rs
+++ b/compiler/rustc_thread_pool/src/worker_local.rs
@@ -43,7 +43,7 @@ impl<T> WorkerLocal<T> {
         unsafe {
             let worker_thread = WorkerThread::current();
             if worker_thread.is_null()
-                || &*(*worker_thread).registry as *const _ != &*self.registry as *const _
+                || !std::ptr::eq(&*(*worker_thread).registry, &*self.registry)
             {
                 panic!("WorkerLocal can only be used on the thread pool it was created on")
             }
@@ -55,7 +55,7 @@ impl<T> WorkerLocal<T> {
 impl<T> WorkerLocal<Vec<T>> {
     /// Joins the elements of all the worker locals into one Vec
     pub fn join(self) -> Vec<T> {
-        self.into_inner().into_iter().flat_map(|v| v).collect()
+        self.into_inner().into_iter().flatten().collect()
     }
 }
 

--- a/compiler/rustc_type_ir_macros/src/lib.rs
+++ b/compiler/rustc_type_ir_macros/src/lib.rs
@@ -197,10 +197,10 @@ fn lift(mut ty: syn::Type) -> syn::Type {
     impl VisitMut for ItoJ {
         fn visit_type_path_mut(&mut self, i: &mut syn::TypePath) {
             if i.qself.is_none() {
-                if let Some(first) = i.path.segments.first_mut() {
-                    if first.ident == "I" {
-                        *first = parse_quote! { J };
-                    }
+                if let Some(first) = i.path.segments.first_mut()
+                    && first.ident == "I"
+                {
+                    *first = parse_quote! { J };
                 }
             }
             syn::visit_mut::visit_type_path_mut(self, i);

--- a/src/bootstrap/src/core/build_steps/check.rs
+++ b/src/bootstrap/src/core/build_steps/check.rs
@@ -841,3 +841,8 @@ tool_check_step!(BumpStage0 {
     mode: Mode::ToolBootstrap,
     default: false
 });
+
+// Tidy is implicitly checked when `./x test tidy` is executed
+// (if you set a pre-push hook, the command is called).
+// So this is mainly for people working on tidy.
+tool_check_step!(Tidy { path: "src/tools/tidy", mode: Mode::ToolBootstrap, default: false });

--- a/src/bootstrap/src/core/build_steps/check.rs
+++ b/src/bootstrap/src/core/build_steps/check.rs
@@ -61,6 +61,9 @@ impl Step for Std {
             return;
         }
 
+        // Explicitly pass -p for all dependencies crates -- this will force cargo
+        // to also check the tests/benches/examples for these crates, rather
+        // than just the leaf crate.
         let crates = std_crates_for_run_make(&run);
         run.builder.ensure(Std {
             build_compiler: prepare_compiler_for_check(run.builder, run.target, Mode::Std)
@@ -83,14 +86,10 @@ impl Step for Std {
             Kind::Check,
         );
 
-        std_cargo(builder, target, &mut cargo);
+        std_cargo(builder, target, &mut cargo, &self.crates);
         if matches!(builder.config.cmd, Subcommand::Fix) {
             // By default, cargo tries to fix all targets. Tell it not to fix tests until we've added `test` to the sysroot.
             cargo.arg("--lib");
-        }
-
-        for krate in &*self.crates {
-            cargo.arg("-p").arg(krate);
         }
 
         let _guard = builder.msg(
@@ -135,14 +134,7 @@ impl Step for Std {
             Kind::Check,
         );
 
-        std_cargo(builder, target, &mut cargo);
-
-        // Explicitly pass -p for all dependencies krates -- this will force cargo
-        // to also check the tests/benches/examples for these crates, rather
-        // than just the leaf crate.
-        for krate in &*self.crates {
-            cargo.arg("-p").arg(krate);
-        }
+        std_cargo(builder, target, &mut cargo, &self.crates);
 
         let stamp =
             build_stamp::libstd_stamp(builder, build_compiler, target).with_prefix("check-test");

--- a/src/bootstrap/src/core/build_steps/clippy.rs
+++ b/src/bootstrap/src/core/build_steps/clippy.rs
@@ -195,11 +195,7 @@ impl Step for Std {
             Kind::Clippy,
         );
 
-        std_cargo(builder, target, &mut cargo);
-
-        for krate in &*self.crates {
-            cargo.arg("-p").arg(krate);
-        }
+        std_cargo(builder, target, &mut cargo, &self.crates);
 
         let _guard = builder.msg(
             Kind::Clippy,

--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -266,10 +266,7 @@ impl Step for Std {
                 target,
                 Kind::Build,
             );
-            std_cargo(builder, target, &mut cargo);
-            for krate in &*self.crates {
-                cargo.arg("-p").arg(krate);
-            }
+            std_cargo(builder, target, &mut cargo, &self.crates);
             cargo
         };
 
@@ -497,7 +494,12 @@ fn compiler_rt_for_profiler(builder: &Builder<'_>) -> PathBuf {
 
 /// Configure cargo to compile the standard library, adding appropriate env vars
 /// and such.
-pub fn std_cargo(builder: &Builder<'_>, target: TargetSelection, cargo: &mut Cargo) {
+pub fn std_cargo(
+    builder: &Builder<'_>,
+    target: TargetSelection,
+    cargo: &mut Cargo,
+    crates: &[String],
+) {
     // rustc already ensures that it builds with the minimum deployment
     // target, so ideally we shouldn't need to do anything here.
     //
@@ -605,6 +607,10 @@ pub fn std_cargo(builder: &Builder<'_>, target: TargetSelection, cargo: &mut Car
         cargo.env("CFG_DISABLE_UNSTABLE_FEATURES", "1");
     }
 
+    for krate in crates {
+        cargo.args(["-p", krate]);
+    }
+
     let mut features = String::new();
 
     if builder.no_std(target) == Some(true) {
@@ -614,8 +620,10 @@ pub fn std_cargo(builder: &Builder<'_>, target: TargetSelection, cargo: &mut Car
         }
 
         // for no-std targets we only compile a few no_std crates
+        if crates.is_empty() {
+            cargo.args(["-p", "alloc"]);
+        }
         cargo
-            .args(["-p", "alloc"])
             .arg("--manifest-path")
             .arg(builder.src.join("library/alloc/Cargo.toml"))
             .arg("--features")

--- a/src/bootstrap/src/core/build_steps/doc.rs
+++ b/src/bootstrap/src/core/build_steps/doc.rs
@@ -783,7 +783,7 @@ fn doc_std(
         Kind::Doc,
     );
 
-    compile::std_cargo(builder, target, &mut cargo);
+    compile::std_cargo(builder, target, &mut cargo, requested_crates);
     cargo
         .arg("--no-deps")
         .arg("--target-dir")
@@ -801,10 +801,6 @@ fn doc_std(
 
     if builder.config.library_docs_private_items {
         cargo.rustdocflag("--document-private-items").rustdocflag("--document-hidden-items");
-    }
-
-    for krate in requested_crates {
-        cargo.arg("-p").arg(krate);
     }
 
     let description =

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -2963,7 +2963,7 @@ impl Step for Crate {
                         .arg("--manifest-path")
                         .arg(builder.src.join("library/sysroot/Cargo.toml"));
                 } else {
-                    compile::std_cargo(builder, target, &mut cargo);
+                    compile::std_cargo(builder, target, &mut cargo, &[]);
                 }
             }
             Mode::Rustc => {

--- a/src/bootstrap/src/core/builder/mod.rs
+++ b/src/bootstrap/src/core/builder/mod.rs
@@ -1076,6 +1076,7 @@ impl<'a> Builder<'a> {
                 check::CoverageDump,
                 check::Linkchecker,
                 check::BumpStage0,
+                check::Tidy,
                 // This has special staging logic, it may run on stage 1 while others run on stage 0.
                 // It takes quite some time to build stage 1, so put this at the end.
                 //

--- a/src/ci/docker/host-x86_64/pr-check-1/Dockerfile
+++ b/src/ci/docker/host-x86_64/pr-check-1/Dockerfile
@@ -50,6 +50,7 @@ ENV SCRIPT \
     linkchecker \
     run-make-support \
     rustdoc-gui-test \
+    tidy \
     && \
   /scripts/check-default-config-profiles.sh && \
   python3 ../x.py build src/tools/build-manifest && \

--- a/src/tools/wasm-component-ld/Cargo.toml
+++ b/src/tools/wasm-component-ld/Cargo.toml
@@ -10,4 +10,4 @@ name = "wasm-component-ld"
 path = "src/main.rs"
 
 [dependencies]
-wasm-component-ld = "0.5.17"
+wasm-component-ld = "0.5.18"

--- a/tests/ui/impl-trait/associated-type-fn-bound-issue-72207.rs
+++ b/tests/ui/impl-trait/associated-type-fn-bound-issue-72207.rs
@@ -1,0 +1,57 @@
+//@ check-pass
+//@ compile-flags: --crate-type=lib
+
+#![allow(dead_code)]
+
+use std::marker::PhantomData;
+
+pub struct XImpl<T, E, F2, F1>
+where
+    F2: Fn(E),
+{
+    f1: F1,
+    f2: F2,
+    _ghost: PhantomData<(T, E)>,
+}
+
+pub trait X<T>: Sized {
+    type F1;
+    type F2: Fn(Self::E);
+    type E;
+
+    fn and<NewF1, NewF1Generator>(self, f: NewF1Generator) -> XImpl<T, Self::E, Self::F2, NewF1>
+    where
+        NewF1Generator: FnOnce(Self::F1) -> NewF1;
+}
+
+impl<T, E, F2, F1> X<T> for XImpl<T, E, F2, F1>
+where
+    F2: Fn(E),
+{
+    type E = E;
+    type F2 = F2;
+    type F1 = F1;
+
+    fn and<NewF1, NewF1Generator>(self, f: NewF1Generator) -> XImpl<T, E, F2, NewF1>
+    where
+        NewF1Generator: FnOnce(F1) -> NewF1,
+    {
+        XImpl {
+            f1: f(self.f1),
+            f2: self.f2,
+            _ghost: PhantomData,
+        }
+    }
+}
+
+fn f() -> impl X<(), E = ()> {
+    XImpl {
+        f1: || (),
+        f2: |()| (),
+        _ghost: PhantomData,
+    }
+}
+
+fn f2() -> impl X<(), E = ()> {
+    f().and(|rb| rb)
+}


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#147168 (Don't unconditionally build alloc for `no-std` targets)
 - rust-lang/rust#147178 ([DebugInfo] Improve formatting of MSVC enum struct variants)
 - rust-lang/rust#147495 (Update wasm-component-ld to 0.5.18)
 - rust-lang/rust#147592 (Add tidy to the target of ./x check)
 - rust-lang/rust#147597 (Add a regression test for rust-lang/rust#72207)
 - rust-lang/rust#147604 (Some clippy cleanups in compiler)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=147168,147178,147495,147592,147597,147604)
<!-- homu-ignore:end -->