### PR TITLE
Clear `ChunkedBitSet` without reallocating

### DIFF
--- a/compiler/rustc_index/src/bit_set.rs
+++ b/compiler/rustc_index/src/bit_set.rs
@@ -585,8 +585,7 @@ impl<T: Idx> ChunkedBitSet<T> {
     }
 
     pub fn clear(&mut self) {
-        let domain_size = self.domain_size();
-        *self = ChunkedBitSet::new_empty(domain_size);
+        self.chunks.fill_with(|| Chunk::Zeros);
     }
 
     #[cfg(test)]
@@ -684,9 +683,7 @@ impl<T: Idx> ChunkedBitSet<T> {
 
     /// Sets all bits to true.
     pub fn insert_all(&mut self) {
-        for chunk in self.chunks.iter_mut() {
-            *chunk = Ones;
-        }
+        self.chunks.fill_with(|| Chunk::Ones);
     }
 
     /// Returns `true` if the set has changed.


### PR DESCRIPTION
There doesn't appear to be any reason to clear a ChunkedBitSet via its constructor (which allocates a new list of chunks), when we could just fill the existing allocation with `Chunk::Zeros` instead.

For comparison, the `insert_all` impl added by the same PR (rust-lang/rust#93984) does the simple thing here and just overwrites every chunk with `Chunk::Ones`.

(That fill was then made somewhat easier by rust-lang/rust#145480, which removes the chunk size from all-zero/all-one chunks.)

r? nnethercote (or compiler)