### PR TITLE
Generalize configuring LLD as the default linker in bootstrap

### DIFF
--- a/bootstrap.example.toml
+++ b/bootstrap.example.toml
@@ -758,12 +758,8 @@
 # Currently, the only standard options supported here are `"llvm"`, `"cranelift"` and `"gcc"`.
 #rust.codegen-backends = ["llvm"]
 
-# Indicates whether LLD will be compiled and made available in the sysroot for rustc to execute, and
-# whether to set it as rustc's default linker on `x86_64-unknown-linux-gnu`. This will also only be
-# when *not* building an external LLVM (so only when using `download-ci-llvm` or building LLVM from
-# the in-tree source): setting `llvm-config` in the `[target.x86_64-unknown-linux-gnu]` section will
-# make this default to false.
-#rust.lld = false in all cases, except on `x86_64-unknown-linux-gnu` as described above, where it is true
+# Indicates whether LLD will be compiled and made available in the sysroot for rustc to execute,
+#rust.lld = false, except for targets that opt into LLD (see `target.default-linker-linux-override`)
 
 # Indicates if we should override the linker used to link Rust crates during bootstrap to be LLD.
 # If set to `true` or `"external"`, a global `lld` binary that has to be in $PATH
@@ -1067,3 +1063,17 @@
 # Link the compiler and LLVM against `jemalloc` instead of the default libc allocator.
 # This overrides the global `rust.jemalloc` option. See that option for more info.
 #jemalloc = rust.jemalloc (bool)
+
+# The linker configuration that will *override* the default linker used for Linux
+# targets in the built compiler.
+#
+# The following values are supported:
+# - `off` => do not apply any override and use the default linker. This can be used to opt out of
+#   linker overrides set by bootstrap for specific targets (see below).
+# - `self-contained-lld-cc` => override the default linker to be self-contained LLD (`rust-lld`)
+#   that is invoked through `cc`.
+#
+# Currently, the following targets automatically opt into the self-contained LLD linker, unless you
+# pass `off`:
+# - x86_64-unknown-linux-gnu
+#default-linker-linux-override = "off" (for most targets)

--- a/compiler/rustc_target/src/spec/base/linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/base/linux_gnu.rs
@@ -1,5 +1,14 @@
-use crate::spec::{TargetOptions, base};
+use crate::spec::{Cc, LinkerFlavor, Lld, TargetOptions, base};
 
 pub(crate) fn opts() -> TargetOptions {
-    TargetOptions { env: "gnu".into(), ..base::linux::opts() }
+    let mut base = TargetOptions { env: "gnu".into(), ..base::linux::opts() };
+
+    // When we're asked to use the `rust-lld` linker by default, set the appropriate lld-using
+    // linker flavor, and self-contained linker component.
+    if option_env!("CFG_DEFAULT_LINKER_SELF_CONTAINED_LLD_CC").is_some() {
+        base.linker_flavor = LinkerFlavor::Gnu(Cc::Yes, Lld::Yes);
+        base.link_self_contained = crate::spec::LinkSelfContainedDefault::with_linker();
+    }
+
+    base
 }

--- a/compiler/rustc_target/src/spec/targets/x86_64_unknown_linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/targets/x86_64_unknown_linux_gnu.rs
@@ -20,13 +20,6 @@ pub(crate) fn target() -> Target {
         | SanitizerSet::THREAD;
     base.supports_xray = true;
 
-    // When we're asked to use the `rust-lld` linker by default, set the appropriate lld-using
-    // linker flavor, and self-contained linker component.
-    if option_env!("CFG_USE_SELF_CONTAINED_LINKER").is_some() {
-        base.linker_flavor = LinkerFlavor::Gnu(Cc::Yes, Lld::Yes);
-        base.link_self_contained = crate::spec::LinkSelfContainedDefault::with_linker();
-    }
-
     Target {
         llvm_target: "x86_64-unknown-linux-gnu".into(),
         metadata: TargetMetadata {

--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -26,6 +26,7 @@ use crate::core::builder;
 use crate::core::builder::{
     Builder, Cargo, Kind, RunConfig, ShouldRun, Step, StepMetadata, crate_description,
 };
+use crate::core::config::toml::target::DefaultLinuxLinkerOverride;
 use crate::core::config::{
     CompilerBuiltins, DebuginfoLevel, LlvmLibunwind, RustcLto, TargetSelection,
 };
@@ -1355,9 +1356,14 @@ pub fn rustc_cargo_env(builder: &Builder<'_>, cargo: &mut Cargo, target: TargetS
         cargo.env("CFG_DEFAULT_LINKER", s);
     }
 
-    // Enable rustc's env var for `rust-lld` when requested.
-    if builder.config.lld_enabled {
-        cargo.env("CFG_DEFAULT_LINKER_SELF_CONTAINED_LLD_CC", "1");
+    // Enable rustc's env var to use a linker override on Linux when requested.
+    if let Some(linker) = target_config.map(|c| c.default_linker_linux_override) {
+        match linker {
+            DefaultLinuxLinkerOverride::Off => {}
+            DefaultLinuxLinkerOverride::SelfContainedLldCc => {
+                cargo.env("CFG_DEFAULT_LINKER_SELF_CONTAINED_LLD_CC", "1");
+            }
+        }
     }
 
     if builder.config.rust_verify_llvm_ir {

--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -1357,7 +1357,7 @@ pub fn rustc_cargo_env(builder: &Builder<'_>, cargo: &mut Cargo, target: TargetS
 
     // Enable rustc's env var for `rust-lld` when requested.
     if builder.config.lld_enabled {
-        cargo.env("CFG_USE_SELF_CONTAINED_LINKER", "1");
+        cargo.env("CFG_DEFAULT_LINKER_SELF_CONTAINED_LLD_CC", "1");
     }
 
     if builder.config.rust_verify_llvm_ir {

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -844,7 +844,7 @@ impl Config {
                     ar: target_ar,
                     ranlib: target_ranlib,
                     default_linker: target_default_linker,
-                    default_linker_linux: target_default_linker_linux_override,
+                    default_linker_linux_override: target_default_linker_linux_override,
                     linker: target_linker,
                     split_debuginfo: target_split_debuginfo,
                     llvm_config: target_llvm_config,

--- a/src/bootstrap/src/core/config/toml/rust.rs
+++ b/src/bootstrap/src/core/config/toml/rust.rs
@@ -438,28 +438,3 @@ pub(crate) fn parse_codegen_backends(
     }
     found_backends
 }
-
-#[cfg(not(test))]
-pub fn default_lld_opt_in_targets() -> Vec<String> {
-    vec!["x86_64-unknown-linux-gnu".to_string()]
-}
-
-#[cfg(test)]
-thread_local! {
-    static TEST_LLD_OPT_IN_TARGETS: std::cell::RefCell<Option<Vec<String>>> = std::cell::RefCell::new(None);
-}
-
-#[cfg(test)]
-pub fn default_lld_opt_in_targets() -> Vec<String> {
-    TEST_LLD_OPT_IN_TARGETS.with(|cell| cell.borrow().clone()).unwrap_or_default()
-}
-
-#[cfg(test)]
-pub fn with_lld_opt_in_targets<R>(targets: Vec<String>, f: impl FnOnce() -> R) -> R {
-    TEST_LLD_OPT_IN_TARGETS.with(|cell| {
-        let prev = cell.replace(Some(targets));
-        let result = f();
-        cell.replace(prev);
-        result
-    })
-}

--- a/src/bootstrap/src/core/config/toml/target.rs
+++ b/src/bootstrap/src/core/config/toml/target.rs
@@ -9,6 +9,9 @@
 //! * [`Target`]: This struct represents the processed and validated configuration for a
 //!   build target, which is is stored in the main `Config` structure.
 
+use std::collections::HashMap;
+
+use serde::de::Error;
 use serde::{Deserialize, Deserializer};
 
 use crate::core::config::{
@@ -24,6 +27,7 @@ define_config! {
         ar: Option<String> = "ar",
         ranlib: Option<String> = "ranlib",
         default_linker: Option<PathBuf> = "default-linker",
+        default_linker_linux: Option<DefaultLinuxLinkerOverride> = "default-linker-linux-override",
         linker: Option<String> = "linker",
         split_debuginfo: Option<String> = "split-debuginfo",
         llvm_config: Option<String> = "llvm-config",
@@ -60,6 +64,7 @@ pub struct Target {
     pub ar: Option<PathBuf>,
     pub ranlib: Option<PathBuf>,
     pub default_linker: Option<PathBuf>,
+    pub default_linker_linux_override: DefaultLinuxLinkerOverride,
     pub linker: Option<PathBuf>,
     pub split_debuginfo: Option<SplitDebuginfo>,
     pub sanitizers: Option<bool>,
@@ -88,4 +93,61 @@ impl Target {
         }
         target
     }
+}
+
+/// Overrides the default linker used on a Linux linker.
+/// On Linux, the linker is usually invoked through `cc`, therefore this exists as a separate
+/// configuration from simply setting `default-linker`, which corresponds to `-Clinker`.
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
+pub enum DefaultLinuxLinkerOverride {
+    /// Do not apply any override and use the default linker for the given target.
+    #[default]
+    Off,
+    /// Use the self-contained `rust-lld` linker, invoked through `cc`.
+    /// Corresponds to `-Clinker-features=+lld -Clink-self-contained=+linker`.
+    SelfContainedLldCc,
+}
+
+impl<'de> Deserialize<'de> for DefaultLinuxLinkerOverride {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let name = String::deserialize(deserializer)?;
+        match name.as_str() {
+            "off" => Ok(Self::Off),
+            "self-contained-lld-cc" => Ok(Self::SelfContainedLldCc),
+            other => Err(D::Error::unknown_variant(other, &["off", "self-contained-lld-cc"])),
+        }
+    }
+}
+
+/// Set of linker overrides for selected Linux targets.
+#[cfg(not(test))]
+pub fn default_linux_linker_overrides() -> HashMap<String, DefaultLinuxLinkerOverride> {
+    [("x86_64-unknown-linux-gnu".to_string(), DefaultLinuxLinkerOverride::SelfContainedLldCc)]
+        .into()
+}
+
+#[cfg(test)]
+thread_local! {
+    static TEST_LINUX_LINKER_OVERRIDES: std::cell::RefCell<Option<HashMap<String, DefaultLinuxLinkerOverride>>> = std::cell::RefCell::new(None);
+}
+
+#[cfg(test)]
+pub fn default_linux_linker_overrides() -> HashMap<String, DefaultLinuxLinkerOverride> {
+    TEST_LINUX_LINKER_OVERRIDES.with(|cell| cell.borrow().clone()).unwrap_or_default()
+}
+
+#[cfg(test)]
+pub fn with_default_linux_linker_overrides<R>(
+    targets: HashMap<String, DefaultLinuxLinkerOverride>,
+    f: impl FnOnce() -> R,
+) -> R {
+    TEST_LINUX_LINKER_OVERRIDES.with(|cell| {
+        let prev = cell.replace(Some(targets));
+        let result = f();
+        cell.replace(prev);
+        result
+    })
 }

--- a/src/bootstrap/src/core/config/toml/target.rs
+++ b/src/bootstrap/src/core/config/toml/target.rs
@@ -27,7 +27,7 @@ define_config! {
         ar: Option<String> = "ar",
         ranlib: Option<String> = "ranlib",
         default_linker: Option<PathBuf> = "default-linker",
-        default_linker_linux: Option<DefaultLinuxLinkerOverride> = "default-linker-linux-override",
+        default_linker_linux_override: Option<DefaultLinuxLinkerOverride> = "default-linker-linux-override",
         linker: Option<String> = "linker",
         split_debuginfo: Option<String> = "split-debuginfo",
         llvm_config: Option<String> = "llvm-config",
@@ -95,7 +95,7 @@ impl Target {
     }
 }
 
-/// Overrides the default linker used on a Linux linker.
+/// Overrides the default linker used on a Linux target.
 /// On Linux, the linker is usually invoked through `cc`, therefore this exists as a separate
 /// configuration from simply setting `default-linker`, which corresponds to `-Clinker`.
 #[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]

--- a/src/bootstrap/src/utils/change_tracker.rs
+++ b/src/bootstrap/src/utils/change_tracker.rs
@@ -566,4 +566,9 @@ pub const CONFIG_CHANGE_HISTORY: &[ChangeInfo] = &[
         severity: ChangeSeverity::Info,
         summary: "`compiletest` is now always built with the stage 0 compiler, so `build.compiletest-use-stage0-libtest` has no effect.",
     },
+    ChangeInfo {
+        change_id: 147157,
+        severity: ChangeSeverity::Warning,
+        summary: "`rust.lld = true` no longer automatically causes the `x86_64-unknown-linux-gnu` target to default into using the self-contained LLD linker. This target now uses the LLD linker by default. To opt out, set `target.x86_64-unknown-linux-gnu.default-linker-linux-override = 'off'`.",
+    },
 ];


### PR DESCRIPTION
Reopen of https://github.com/rust-lang/rust/pull/147157, because apparently bors can't deal with it for some reason.

---

This PR generalizes the previous hardcoded logic for setting self-contained LLD to be used as the default Linker on Linux GNU targets. The changes made:

1) `rust.lld` now only controls whether LLD is built and included in the sysroot. If `rust.lld` is set to `false`, it will disable the default opt into LLD on x64 Linux.
2) The linker override for using `rust-lld` through `cc` can now be applied to all Linux targets. It is configured through `target.<target>.default-linker-linux-override = "self-contained-lld-cc"/"off"`

Here is how it behaves:
1) If you don't set any options, x64 Linux will default into `default-linker-linux-override = "self-contained-lld-cc"` and also `rust.lld = true`.
2) If you set `rust.lld = false`, you disable this override
3) If you set `target.x86_64-unknown-linux-gnu.default-linux-linker-override = "off"`, you disable this override
4) If you set `target.x86_64-unknown-linux-gnu.llvm-config = ...`, you disable this override

Note that in contrast to what I described in https://github.com/rust-lang/rust/issues/146640, I didn't bother moving `rust.lld` to `llvm.lld`. We can do that separately later, but I don't think it's worth the churn. I realized that `rust` is perhaps a better place for this, because it not only controls whether LLD is built, but also if it is included in the compiler sysroot. So to truly distinguish these two, we'd need both `llvm.lld` and `rust.lld`, which doesn't seem worth it. Note that `rust.codegen-backends = ["llvm"]` works in the same way, it tells bootstrap to build LLVM and include it in the sysroot. So it is consistent with `rust.lld`

Related to: https://github.com/rust-lang/rust/issues/146640

---

r? @ghost