### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/bootstrap.example.toml
+++ b/bootstrap.example.toml
@@ -758,12 +758,8 @@
 # Currently, the only standard options supported here are `"llvm"`, `"cranelift"` and `"gcc"`.
 #rust.codegen-backends = ["llvm"]
 
-# Indicates whether LLD will be compiled and made available in the sysroot for rustc to execute, and
-# whether to set it as rustc's default linker on `x86_64-unknown-linux-gnu`. This will also only be
-# when *not* building an external LLVM (so only when using `download-ci-llvm` or building LLVM from
-# the in-tree source): setting `llvm-config` in the `[target.x86_64-unknown-linux-gnu]` section will
-# make this default to false.
-#rust.lld = false in all cases, except on `x86_64-unknown-linux-gnu` as described above, where it is true
+# Indicates whether LLD will be compiled and made available in the sysroot for rustc to execute,
+#rust.lld = false, except for targets that opt into LLD (see `target.default-linker-linux-override`)
 
 # Indicates if we should override the linker used to link Rust crates during bootstrap to be LLD.
 # If set to `true` or `"external"`, a global `lld` binary that has to be in $PATH
@@ -1067,3 +1063,17 @@
 # Link the compiler and LLVM against `jemalloc` instead of the default libc allocator.
 # This overrides the global `rust.jemalloc` option. See that option for more info.
 #jemalloc = rust.jemalloc (bool)
+
+# The linker configuration that will *override* the default linker used for Linux
+# targets in the built compiler.
+#
+# The following values are supported:
+# - `off` => do not apply any override and use the default linker. This can be used to opt out of
+#   linker overrides set by bootstrap for specific targets (see below).
+# - `self-contained-lld-cc` => override the default linker to be self-contained LLD (`rust-lld`)
+#   that is invoked through `cc`.
+#
+# Currently, the following targets automatically opt into the self-contained LLD linker, unless you
+# pass `off`:
+# - x86_64-unknown-linux-gnu
+#default-linker-linux-override = "off" (for most targets)

--- a/compiler/rustc_codegen_llvm/src/debuginfo/di_builder.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/di_builder.rs
@@ -1,0 +1,21 @@
+use crate::llvm;
+use crate::llvm::debuginfo::DIBuilder;
+
+/// Extension trait for defining safe wrappers and helper methods on
+/// `&DIBuilder<'ll>`, without requiring it to be defined in the same crate.
+pub(crate) trait DIBuilderExt<'ll> {
+    fn as_di_builder(&self) -> &DIBuilder<'ll>;
+
+    fn create_expression(&self, addr_ops: &[u64]) -> &'ll llvm::Metadata {
+        let this = self.as_di_builder();
+        unsafe { llvm::LLVMDIBuilderCreateExpression(this, addr_ops.as_ptr(), addr_ops.len()) }
+    }
+}
+
+impl<'ll> DIBuilderExt<'ll> for &DIBuilder<'ll> {
+    fn as_di_builder(&self) -> &DIBuilder<'ll> {
+        self
+    }
+
+    // All other methods have default bodies that rely on `as_di_builder`.
+}

--- a/compiler/rustc_codegen_llvm/src/debuginfo/di_builder.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/di_builder.rs
@@ -1,3 +1,7 @@
+use libc::c_uint;
+use rustc_abi::Align;
+
+use crate::common::AsCCharPtr;
 use crate::llvm;
 use crate::llvm::debuginfo::DIBuilder;
 
@@ -9,6 +13,41 @@ pub(crate) trait DIBuilderExt<'ll> {
     fn create_expression(&self, addr_ops: &[u64]) -> &'ll llvm::Metadata {
         let this = self.as_di_builder();
         unsafe { llvm::LLVMDIBuilderCreateExpression(this, addr_ops.as_ptr(), addr_ops.len()) }
+    }
+
+    fn create_static_variable(
+        &self,
+        scope: Option<&'ll llvm::Metadata>,
+        name: &str,
+        linkage_name: &str,
+        file: &'ll llvm::Metadata,
+        line_number: c_uint,
+        ty: &'ll llvm::Metadata,
+        is_local_to_unit: bool,
+        val: &'ll llvm::Value,
+        decl: Option<&'ll llvm::Metadata>,
+        align: Option<Align>,
+    ) -> &'ll llvm::Metadata {
+        let this = self.as_di_builder();
+        let align_in_bits = align.map_or(0, |align| align.bits() as u32);
+
+        unsafe {
+            llvm::LLVMRustDIBuilderCreateStaticVariable(
+                this,
+                scope,
+                name.as_c_char_ptr(),
+                name.len(),
+                linkage_name.as_c_char_ptr(),
+                linkage_name.len(),
+                file,
+                line_number,
+                ty,
+                is_local_to_unit,
+                val,
+                decl,
+                align_in_bits,
+            )
+        }
     }
 }
 

--- a/compiler/rustc_codegen_llvm/src/debuginfo/mod.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/mod.rs
@@ -28,6 +28,8 @@ use rustc_target::spec::DebuginfoKind;
 use smallvec::SmallVec;
 use tracing::debug;
 
+use self::create_scope_map::compute_mir_scopes;
+pub(crate) use self::metadata::build_global_var_di_node;
 use self::metadata::{
     UNKNOWN_COLUMN_NUMBER, UNKNOWN_LINE_NUMBER, file_metadata, spanned_type_di_node, type_di_node,
 };
@@ -47,9 +49,6 @@ mod gdb;
 pub(crate) mod metadata;
 mod namespace;
 mod utils;
-
-use self::create_scope_map::compute_mir_scopes;
-pub(crate) use self::metadata::build_global_var_di_node;
 
 /// A context object for maintaining all state needed by the debuginfo module.
 pub(crate) struct CodegenUnitDebugContext<'ll, 'tcx> {

--- a/compiler/rustc_codegen_llvm/src/debuginfo/mod.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/mod.rs
@@ -29,6 +29,7 @@ use smallvec::SmallVec;
 use tracing::debug;
 
 use self::create_scope_map::compute_mir_scopes;
+pub(crate) use self::di_builder::DIBuilderExt;
 pub(crate) use self::metadata::build_global_var_di_node;
 use self::metadata::{
     UNKNOWN_COLUMN_NUMBER, UNKNOWN_LINE_NUMBER, file_metadata, spanned_type_di_node, type_di_node,
@@ -44,6 +45,7 @@ use crate::llvm::debuginfo::{
 use crate::llvm::{self, Value};
 
 mod create_scope_map;
+mod di_builder;
 mod dwarf_const;
 mod gdb;
 pub(crate) mod metadata;
@@ -181,9 +183,7 @@ impl<'ll> DebugInfoBuilderMethods for Builder<'_, 'll, '_> {
         }
 
         let di_builder = DIB(self.cx());
-        let addr_expr = unsafe {
-            llvm::LLVMDIBuilderCreateExpression(di_builder, addr_ops.as_ptr(), addr_ops.len())
-        };
+        let addr_expr = di_builder.create_expression(&addr_ops);
         unsafe {
             llvm::LLVMDIBuilderInsertDeclareRecordAtEnd(
                 di_builder,

--- a/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
@@ -22,9 +22,9 @@ use libc::{c_char, c_int, c_uchar, c_uint, c_ulonglong, c_void, size_t};
 
 use super::RustString;
 use super::debuginfo::{
-    DIArray, DIBuilder, DIDerivedType, DIDescriptor, DIEnumerator, DIFile, DIFlags,
-    DIGlobalVariableExpression, DILocation, DISPFlags, DIScope, DISubprogram,
-    DITemplateTypeParameter, DIType, DebugEmissionKind, DebugNameTableKind,
+    DIArray, DIBuilder, DIDerivedType, DIDescriptor, DIEnumerator, DIFile, DIFlags, DILocation,
+    DISPFlags, DIScope, DISubprogram, DITemplateTypeParameter, DIType, DebugEmissionKind,
+    DebugNameTableKind,
 };
 use crate::llvm::MetadataKindId;
 use crate::{TryFromU32, llvm};
@@ -781,7 +781,6 @@ pub(crate) mod debuginfo {
     pub(crate) type DIDerivedType = DIType;
     pub(crate) type DICompositeType = DIDerivedType;
     pub(crate) type DIVariable = DIDescriptor;
-    pub(crate) type DIGlobalVariableExpression = DIDescriptor;
     pub(crate) type DIArray = DIDescriptor;
     pub(crate) type DIEnumerator = DIDescriptor;
     pub(crate) type DITemplateTypeParameter = DIDescriptor;
@@ -1875,6 +1874,22 @@ unsafe extern "C" {
         Length: size_t,
     ) -> &'ll Metadata;
 
+    pub(crate) fn LLVMDIBuilderCreateGlobalVariableExpression<'ll>(
+        Builder: &DIBuilder<'ll>,
+        Scope: Option<&'ll Metadata>,
+        Name: *const c_uchar, // See "PTR_LEN_STR".
+        NameLen: size_t,
+        Linkage: *const c_uchar, // See "PTR_LEN_STR".
+        LinkLen: size_t,
+        File: &'ll Metadata,
+        LineNo: c_uint,
+        Ty: &'ll Metadata,
+        LocalToUnit: llvm::Bool,
+        Expr: &'ll Metadata,
+        Decl: Option<&'ll Metadata>,
+        AlignInBits: u32,
+    ) -> &'ll Metadata;
+
     pub(crate) fn LLVMDIBuilderInsertDeclareRecordAtEnd<'ll>(
         Builder: &DIBuilder<'ll>,
         Storage: &'ll Value,
@@ -2213,22 +2228,6 @@ unsafe extern "C" {
         Flags: DIFlags,
         Ty: &'a DIType,
     ) -> &'a DIType;
-
-    pub(crate) fn LLVMRustDIBuilderCreateStaticVariable<'a>(
-        Builder: &DIBuilder<'a>,
-        Context: Option<&'a DIScope>,
-        Name: *const c_char,
-        NameLen: size_t,
-        LinkageName: *const c_char,
-        LinkageNameLen: size_t,
-        File: &'a DIFile,
-        LineNo: c_uint,
-        Ty: &'a DIType,
-        isLocalToUnit: bool,
-        Val: &'a Value,
-        Decl: Option<&'a DIDescriptor>,
-        AlignInBits: u32,
-    ) -> &'a DIGlobalVariableExpression;
 
     pub(crate) fn LLVMRustDIBuilderCreateEnumerator<'a>(
         Builder: &DIBuilder<'a>,

--- a/compiler/rustc_index/src/bit_set.rs
+++ b/compiler/rustc_index/src/bit_set.rs
@@ -585,8 +585,7 @@ impl<T: Idx> ChunkedBitSet<T> {
     }
 
     pub fn clear(&mut self) {
-        let domain_size = self.domain_size();
-        *self = ChunkedBitSet::new_empty(domain_size);
+        self.chunks.fill_with(|| Chunk::Zeros);
     }
 
     #[cfg(test)]
@@ -684,9 +683,7 @@ impl<T: Idx> ChunkedBitSet<T> {
 
     /// Sets all bits to true.
     pub fn insert_all(&mut self) {
-        for chunk in self.chunks.iter_mut() {
-            *chunk = Ones;
-        }
+        self.chunks.fill_with(|| Chunk::Ones);
     }
 
     /// Returns `true` if the set has changed.

--- a/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
@@ -1044,37 +1044,6 @@ extern "C" LLVMMetadataRef LLVMRustDIBuilderCreateVariantMemberType(
       fromRust(Flags), unwrapDI<DIType>(Ty)));
 }
 
-extern "C" LLVMMetadataRef LLVMRustDIBuilderCreateStaticVariable(
-    LLVMDIBuilderRef Builder, LLVMMetadataRef Context, const char *Name,
-    size_t NameLen, const char *LinkageName, size_t LinkageNameLen,
-    LLVMMetadataRef File, unsigned LineNo, LLVMMetadataRef Ty,
-    bool IsLocalToUnit, LLVMValueRef V, LLVMMetadataRef Decl = nullptr,
-    uint32_t AlignInBits = 0) {
-  llvm::GlobalVariable *InitVal = cast<llvm::GlobalVariable>(unwrap(V));
-
-  llvm::DIExpression *InitExpr = nullptr;
-  if (llvm::ConstantInt *IntVal = llvm::dyn_cast<llvm::ConstantInt>(InitVal)) {
-    InitExpr = unwrap(Builder)->createConstantValueExpression(
-        IntVal->getValue().getSExtValue());
-  } else if (llvm::ConstantFP *FPVal =
-                 llvm::dyn_cast<llvm::ConstantFP>(InitVal)) {
-    InitExpr = unwrap(Builder)->createConstantValueExpression(
-        FPVal->getValueAPF().bitcastToAPInt().getZExtValue());
-  }
-
-  llvm::DIGlobalVariableExpression *VarExpr =
-      unwrap(Builder)->createGlobalVariableExpression(
-          unwrapDI<DIDescriptor>(Context), StringRef(Name, NameLen),
-          StringRef(LinkageName, LinkageNameLen), unwrapDI<DIFile>(File),
-          LineNo, unwrapDI<DIType>(Ty), IsLocalToUnit,
-          /* isDefined */ true, InitExpr, unwrapDIPtr<MDNode>(Decl),
-          /* templateParams */ nullptr, AlignInBits);
-
-  InitVal->setMetadata("dbg", VarExpr);
-
-  return wrap(VarExpr);
-}
-
 extern "C" LLVMMetadataRef
 LLVMRustDIBuilderCreateEnumerator(LLVMDIBuilderRef Builder, const char *Name,
                                   size_t NameLen, const uint64_t Value[2],

--- a/compiler/rustc_target/src/spec/base/linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/base/linux_gnu.rs
@@ -1,5 +1,14 @@
-use crate::spec::{TargetOptions, base};
+use crate::spec::{Cc, LinkerFlavor, Lld, TargetOptions, base};
 
 pub(crate) fn opts() -> TargetOptions {
-    TargetOptions { env: "gnu".into(), ..base::linux::opts() }
+    let mut base = TargetOptions { env: "gnu".into(), ..base::linux::opts() };
+
+    // When we're asked to use the `rust-lld` linker by default, set the appropriate lld-using
+    // linker flavor, and self-contained linker component.
+    if option_env!("CFG_DEFAULT_LINKER_SELF_CONTAINED_LLD_CC").is_some() {
+        base.linker_flavor = LinkerFlavor::Gnu(Cc::Yes, Lld::Yes);
+        base.link_self_contained = crate::spec::LinkSelfContainedDefault::with_linker();
+    }
+
+    base
 }

--- a/compiler/rustc_target/src/spec/targets/x86_64_unknown_linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/targets/x86_64_unknown_linux_gnu.rs
@@ -20,13 +20,6 @@ pub(crate) fn target() -> Target {
         | SanitizerSet::THREAD;
     base.supports_xray = true;
 
-    // When we're asked to use the `rust-lld` linker by default, set the appropriate lld-using
-    // linker flavor, and self-contained linker component.
-    if option_env!("CFG_USE_SELF_CONTAINED_LINKER").is_some() {
-        base.linker_flavor = LinkerFlavor::Gnu(Cc::Yes, Lld::Yes);
-        base.link_self_contained = crate::spec::LinkSelfContainedDefault::with_linker();
-    }
-
     Target {
         llvm_target: "x86_64-unknown-linux-gnu".into(),
         metadata: TargetMetadata {

--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -1422,6 +1422,10 @@ macro_rules! from_str_int_impl {
             /// whitespace) represent an error. Underscores (which are accepted in Rust literals)
             /// also represent an error.
             ///
+            /// # See also
+            /// For parsing numbers in other bases, such as binary or hexadecimal,
+            /// see [`from_str_radix`][Self::from_str_radix].
+            ///
             /// # Examples
             ///
             /// ```
@@ -1466,6 +1470,14 @@ macro_rules! from_str_int_impl {
             /// # Panics
             ///
             /// This function panics if `radix` is not in the range from 2 to 36.
+            ///
+            /// # See also
+            /// If the string to be parsed is in base 10 (decimal),
+            /// [`from_str`] or [`str::parse`] can also be used.
+            ///
+            // FIXME(#122566): These HTML links work around a rustdoc-json test failure.
+            /// [`from_str`]: #method.from_str
+            /// [`str::parse`]: primitive.str.html#method.parse
             ///
             /// # Examples
             ///

--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -26,6 +26,7 @@ use crate::core::builder;
 use crate::core::builder::{
     Builder, Cargo, Kind, RunConfig, ShouldRun, Step, StepMetadata, crate_description,
 };
+use crate::core::config::toml::target::DefaultLinuxLinkerOverride;
 use crate::core::config::{
     CompilerBuiltins, DebuginfoLevel, LlvmLibunwind, RustcLto, TargetSelection,
 };
@@ -1355,9 +1356,14 @@ pub fn rustc_cargo_env(builder: &Builder<'_>, cargo: &mut Cargo, target: TargetS
         cargo.env("CFG_DEFAULT_LINKER", s);
     }
 
-    // Enable rustc's env var for `rust-lld` when requested.
-    if builder.config.lld_enabled {
-        cargo.env("CFG_DEFAULT_LINKER_SELF_CONTAINED_LLD_CC", "1");
+    // Enable rustc's env var to use a linker override on Linux when requested.
+    if let Some(linker) = target_config.map(|c| c.default_linker_linux_override) {
+        match linker {
+            DefaultLinuxLinkerOverride::Off => {}
+            DefaultLinuxLinkerOverride::SelfContainedLldCc => {
+                cargo.env("CFG_DEFAULT_LINKER_SELF_CONTAINED_LLD_CC", "1");
+            }
+        }
     }
 
     if builder.config.rust_verify_llvm_ir {

--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -1357,7 +1357,7 @@ pub fn rustc_cargo_env(builder: &Builder<'_>, cargo: &mut Cargo, target: TargetS
 
     // Enable rustc's env var for `rust-lld` when requested.
     if builder.config.lld_enabled {
-        cargo.env("CFG_USE_SELF_CONTAINED_LINKER", "1");
+        cargo.env("CFG_DEFAULT_LINKER_SELF_CONTAINED_LLD_CC", "1");
     }
 
     if builder.config.rust_verify_llvm_ir {

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -1942,6 +1942,17 @@ HELP: You can add it into `bootstrap.toml` in `rust.codegen-backends = [{name:?}
                 );
                 crate::exit!(1);
             }
+
+            if let CodegenBackendKind::Gcc = codegen_backend
+                && builder.config.rustc_debug_assertions
+            {
+                eprintln!(
+                    r#"WARNING: Running tests with the GCC codegen backend while rustc debug assertions are enabled. This might lead to test failures.
+Please disable assertions with `rust.debug-assertions = false`.
+        "#
+                );
+            }
+
             // Tells compiletest that we want to use this codegen in particular and to override
             // the default one.
             cmd.arg("--override-codegen-backend").arg(codegen_backend.name());

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -844,7 +844,7 @@ impl Config {
                     ar: target_ar,
                     ranlib: target_ranlib,
                     default_linker: target_default_linker,
-                    default_linker_linux: target_default_linker_linux_override,
+                    default_linker_linux_override: target_default_linker_linux_override,
                     linker: target_linker,
                     split_debuginfo: target_split_debuginfo,
                     llvm_config: target_llvm_config,

--- a/src/bootstrap/src/core/config/toml/rust.rs
+++ b/src/bootstrap/src/core/config/toml/rust.rs
@@ -438,28 +438,3 @@ pub(crate) fn parse_codegen_backends(
     }
     found_backends
 }
-
-#[cfg(not(test))]
-pub fn default_lld_opt_in_targets() -> Vec<String> {
-    vec!["x86_64-unknown-linux-gnu".to_string()]
-}
-
-#[cfg(test)]
-thread_local! {
-    static TEST_LLD_OPT_IN_TARGETS: std::cell::RefCell<Option<Vec<String>>> = std::cell::RefCell::new(None);
-}
-
-#[cfg(test)]
-pub fn default_lld_opt_in_targets() -> Vec<String> {
-    TEST_LLD_OPT_IN_TARGETS.with(|cell| cell.borrow().clone()).unwrap_or_default()
-}
-
-#[cfg(test)]
-pub fn with_lld_opt_in_targets<R>(targets: Vec<String>, f: impl FnOnce() -> R) -> R {
-    TEST_LLD_OPT_IN_TARGETS.with(|cell| {
-        let prev = cell.replace(Some(targets));
-        let result = f();
-        cell.replace(prev);
-        result
-    })
-}

--- a/src/bootstrap/src/core/config/toml/target.rs
+++ b/src/bootstrap/src/core/config/toml/target.rs
@@ -9,6 +9,9 @@
 //! * [`Target`]: This struct represents the processed and validated configuration for a
 //!   build target, which is is stored in the main `Config` structure.
 
+use std::collections::HashMap;
+
+use serde::de::Error;
 use serde::{Deserialize, Deserializer};
 
 use crate::core::config::{
@@ -24,6 +27,7 @@ define_config! {
         ar: Option<String> = "ar",
         ranlib: Option<String> = "ranlib",
         default_linker: Option<PathBuf> = "default-linker",
+        default_linker_linux: Option<DefaultLinuxLinkerOverride> = "default-linker-linux-override",
         linker: Option<String> = "linker",
         split_debuginfo: Option<String> = "split-debuginfo",
         llvm_config: Option<String> = "llvm-config",
@@ -60,6 +64,7 @@ pub struct Target {
     pub ar: Option<PathBuf>,
     pub ranlib: Option<PathBuf>,
     pub default_linker: Option<PathBuf>,
+    pub default_linker_linux_override: DefaultLinuxLinkerOverride,
     pub linker: Option<PathBuf>,
     pub split_debuginfo: Option<SplitDebuginfo>,
     pub sanitizers: Option<bool>,
@@ -88,4 +93,61 @@ impl Target {
         }
         target
     }
+}
+
+/// Overrides the default linker used on a Linux linker.
+/// On Linux, the linker is usually invoked through `cc`, therefore this exists as a separate
+/// configuration from simply setting `default-linker`, which corresponds to `-Clinker`.
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
+pub enum DefaultLinuxLinkerOverride {
+    /// Do not apply any override and use the default linker for the given target.
+    #[default]
+    Off,
+    /// Use the self-contained `rust-lld` linker, invoked through `cc`.
+    /// Corresponds to `-Clinker-features=+lld -Clink-self-contained=+linker`.
+    SelfContainedLldCc,
+}
+
+impl<'de> Deserialize<'de> for DefaultLinuxLinkerOverride {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let name = String::deserialize(deserializer)?;
+        match name.as_str() {
+            "off" => Ok(Self::Off),
+            "self-contained-lld-cc" => Ok(Self::SelfContainedLldCc),
+            other => Err(D::Error::unknown_variant(other, &["off", "self-contained-lld-cc"])),
+        }
+    }
+}
+
+/// Set of linker overrides for selected Linux targets.
+#[cfg(not(test))]
+pub fn default_linux_linker_overrides() -> HashMap<String, DefaultLinuxLinkerOverride> {
+    [("x86_64-unknown-linux-gnu".to_string(), DefaultLinuxLinkerOverride::SelfContainedLldCc)]
+        .into()
+}
+
+#[cfg(test)]
+thread_local! {
+    static TEST_LINUX_LINKER_OVERRIDES: std::cell::RefCell<Option<HashMap<String, DefaultLinuxLinkerOverride>>> = std::cell::RefCell::new(None);
+}
+
+#[cfg(test)]
+pub fn default_linux_linker_overrides() -> HashMap<String, DefaultLinuxLinkerOverride> {
+    TEST_LINUX_LINKER_OVERRIDES.with(|cell| cell.borrow().clone()).unwrap_or_default()
+}
+
+#[cfg(test)]
+pub fn with_default_linux_linker_overrides<R>(
+    targets: HashMap<String, DefaultLinuxLinkerOverride>,
+    f: impl FnOnce() -> R,
+) -> R {
+    TEST_LINUX_LINKER_OVERRIDES.with(|cell| {
+        let prev = cell.replace(Some(targets));
+        let result = f();
+        cell.replace(prev);
+        result
+    })
 }

--- a/src/bootstrap/src/core/config/toml/target.rs
+++ b/src/bootstrap/src/core/config/toml/target.rs
@@ -27,7 +27,7 @@ define_config! {
         ar: Option<String> = "ar",
         ranlib: Option<String> = "ranlib",
         default_linker: Option<PathBuf> = "default-linker",
-        default_linker_linux: Option<DefaultLinuxLinkerOverride> = "default-linker-linux-override",
+        default_linker_linux_override: Option<DefaultLinuxLinkerOverride> = "default-linker-linux-override",
         linker: Option<String> = "linker",
         split_debuginfo: Option<String> = "split-debuginfo",
         llvm_config: Option<String> = "llvm-config",
@@ -95,7 +95,7 @@ impl Target {
     }
 }
 
-/// Overrides the default linker used on a Linux linker.
+/// Overrides the default linker used on a Linux target.
 /// On Linux, the linker is usually invoked through `cc`, therefore this exists as a separate
 /// configuration from simply setting `default-linker`, which corresponds to `-Clinker`.
 #[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]

--- a/src/bootstrap/src/utils/change_tracker.rs
+++ b/src/bootstrap/src/utils/change_tracker.rs
@@ -566,4 +566,9 @@ pub const CONFIG_CHANGE_HISTORY: &[ChangeInfo] = &[
         severity: ChangeSeverity::Info,
         summary: "`compiletest` is now always built with the stage 0 compiler, so `build.compiletest-use-stage0-libtest` has no effect.",
     },
+    ChangeInfo {
+        change_id: 147157,
+        severity: ChangeSeverity::Warning,
+        summary: "`rust.lld = true` no longer automatically causes the `x86_64-unknown-linux-gnu` target to default into using the self-contained LLD linker. This target now uses the LLD linker by default. To opt out, set `target.x86_64-unknown-linux-gnu.default-linker-linux-override = 'off'`.",
+    },
 ];

--- a/tests/debuginfo/basic-types-globals.rs
+++ b/tests/debuginfo/basic-types-globals.rs
@@ -6,6 +6,38 @@
 //@ [lto] compile-flags:-C lto
 //@ [lto] no-prefer-dynamic
 
+// lldb-command:run
+// lldb-command:v B
+// lldb-check: ::B::[...] = false
+// lldb-command:v I
+// lldb-check: ::I::[...] = -1
+// lldb-command:v --format=d C
+// lldb-check: ::C::[...] = 97
+// lldb-command:v --format=d I8
+// lldb-check: ::I8::[...] = 68
+// lldb-command:v I16
+// lldb-check: ::I16::[...] = -16
+// lldb-command:v I32
+// lldb-check: ::I32::[...] = -32
+// lldb-command:v I64
+// lldb-check: ::I64::[...] = -64
+// lldb-command:v U
+// lldb-check: ::U::[...] = 1
+// lldb-command:v --format=d U8
+// lldb-check: ::U8::[...] = 100
+// lldb-command:v U16
+// lldb-check: ::U16::[...] = 16
+// lldb-command:v U32
+// lldb-check: ::U32::[...] = 32
+// lldb-command:v U64
+// lldb-check: ::U64::[...] = 64
+// lldb-command:v F16
+// lldb-check: ::F16::[...] = 1.5
+// lldb-command:v F32
+// lldb-check: ::F32::[...] = 2.5
+// lldb-command:v F64
+// lldb-check: ::F64::[...] = 3.5
+
 // gdb-command:run
 // gdb-command:print B
 // gdb-check:$1 = false

--- a/tests/ui/repr/repr-transparent-non-exhaustive.rs
+++ b/tests/ui/repr/repr-transparent-non-exhaustive.rs
@@ -24,6 +24,13 @@ pub struct InternalIndirection<T> {
 
 pub type Sized = i32;
 
+pub trait Trait {
+    type Assoc;
+}
+impl Trait for i32 {
+    type Assoc = NonExhaustive;
+}
+
 #[repr(transparent)]
 pub struct T1(Sized, InternalPrivate);
 #[repr(transparent)]
@@ -40,6 +47,11 @@ pub struct T5(Sized, Private);
 
 #[repr(transparent)]
 pub struct T6(Sized, NonExhaustive);
+//~^ ERROR zero-sized fields in `repr(transparent)` cannot contain external non-exhaustive types
+//~| WARN this was previously accepted by the compiler
+
+#[repr(transparent)]
+pub struct T6a(Sized, <i32 as Trait>::Assoc); // normalizes to `NonExhaustive`
 //~^ ERROR zero-sized fields in `repr(transparent)` cannot contain external non-exhaustive types
 //~| WARN this was previously accepted by the compiler
 

--- a/tests/ui/repr/repr-transparent-non-exhaustive.stderr
+++ b/tests/ui/repr/repr-transparent-non-exhaustive.stderr
@@ -1,5 +1,5 @@
 error: zero-sized fields in `repr(transparent)` cannot contain external non-exhaustive types
-  --> $DIR/repr-transparent-non-exhaustive.rs:37:22
+  --> $DIR/repr-transparent-non-exhaustive.rs:44:22
    |
 LL | pub struct T5(Sized, Private);
    |                      ^^^^^^^
@@ -14,7 +14,7 @@ LL | #![deny(repr_transparent_external_private_fields)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: zero-sized fields in `repr(transparent)` cannot contain external non-exhaustive types
-  --> $DIR/repr-transparent-non-exhaustive.rs:42:22
+  --> $DIR/repr-transparent-non-exhaustive.rs:49:22
    |
 LL | pub struct T6(Sized, NonExhaustive);
    |                      ^^^^^^^^^^^^^
@@ -24,7 +24,17 @@ LL | pub struct T6(Sized, NonExhaustive);
    = note: this struct contains `NonExhaustive`, which is marked with `#[non_exhaustive]`, and makes it not a breaking change to become non-zero-sized in the future.
 
 error: zero-sized fields in `repr(transparent)` cannot contain external non-exhaustive types
-  --> $DIR/repr-transparent-non-exhaustive.rs:47:22
+  --> $DIR/repr-transparent-non-exhaustive.rs:54:23
+   |
+LL | pub struct T6a(Sized, <i32 as Trait>::Assoc); // normalizes to `NonExhaustive`
+   |                       ^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #78586 <https://github.com/rust-lang/rust/issues/78586>
+   = note: this struct contains `NonExhaustive`, which is marked with `#[non_exhaustive]`, and makes it not a breaking change to become non-zero-sized in the future.
+
+error: zero-sized fields in `repr(transparent)` cannot contain external non-exhaustive types
+  --> $DIR/repr-transparent-non-exhaustive.rs:59:22
    |
 LL | pub struct T7(Sized, NonExhaustiveEnum);
    |                      ^^^^^^^^^^^^^^^^^
@@ -34,7 +44,7 @@ LL | pub struct T7(Sized, NonExhaustiveEnum);
    = note: this enum contains `NonExhaustiveEnum`, which is marked with `#[non_exhaustive]`, and makes it not a breaking change to become non-zero-sized in the future.
 
 error: zero-sized fields in `repr(transparent)` cannot contain external non-exhaustive types
-  --> $DIR/repr-transparent-non-exhaustive.rs:52:22
+  --> $DIR/repr-transparent-non-exhaustive.rs:64:22
    |
 LL | pub struct T8(Sized, NonExhaustiveVariant);
    |                      ^^^^^^^^^^^^^^^^^^^^
@@ -44,7 +54,7 @@ LL | pub struct T8(Sized, NonExhaustiveVariant);
    = note: this enum contains `NonExhaustiveVariant`, which is marked with `#[non_exhaustive]`, and makes it not a breaking change to become non-zero-sized in the future.
 
 error: zero-sized fields in `repr(transparent)` cannot contain external non-exhaustive types
-  --> $DIR/repr-transparent-non-exhaustive.rs:57:22
+  --> $DIR/repr-transparent-non-exhaustive.rs:69:22
    |
 LL | pub struct T9(Sized, InternalIndirection<Private>);
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -54,7 +64,7 @@ LL | pub struct T9(Sized, InternalIndirection<Private>);
    = note: this struct contains `Private`, which contains private fields, and makes it not a breaking change to become non-zero-sized in the future.
 
 error: zero-sized fields in `repr(transparent)` cannot contain external non-exhaustive types
-  --> $DIR/repr-transparent-non-exhaustive.rs:62:23
+  --> $DIR/repr-transparent-non-exhaustive.rs:74:23
    |
 LL | pub struct T10(Sized, InternalIndirection<NonExhaustive>);
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -64,7 +74,7 @@ LL | pub struct T10(Sized, InternalIndirection<NonExhaustive>);
    = note: this struct contains `NonExhaustive`, which is marked with `#[non_exhaustive]`, and makes it not a breaking change to become non-zero-sized in the future.
 
 error: zero-sized fields in `repr(transparent)` cannot contain external non-exhaustive types
-  --> $DIR/repr-transparent-non-exhaustive.rs:67:23
+  --> $DIR/repr-transparent-non-exhaustive.rs:79:23
    |
 LL | pub struct T11(Sized, InternalIndirection<NonExhaustiveEnum>);
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -74,7 +84,7 @@ LL | pub struct T11(Sized, InternalIndirection<NonExhaustiveEnum>);
    = note: this enum contains `NonExhaustiveEnum`, which is marked with `#[non_exhaustive]`, and makes it not a breaking change to become non-zero-sized in the future.
 
 error: zero-sized fields in `repr(transparent)` cannot contain external non-exhaustive types
-  --> $DIR/repr-transparent-non-exhaustive.rs:72:23
+  --> $DIR/repr-transparent-non-exhaustive.rs:84:23
    |
 LL | pub struct T12(Sized, InternalIndirection<NonExhaustiveVariant>);
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -84,7 +94,7 @@ LL | pub struct T12(Sized, InternalIndirection<NonExhaustiveVariant>);
    = note: this enum contains `NonExhaustiveVariant`, which is marked with `#[non_exhaustive]`, and makes it not a breaking change to become non-zero-sized in the future.
 
 error: zero-sized fields in `repr(transparent)` cannot contain external non-exhaustive types
-  --> $DIR/repr-transparent-non-exhaustive.rs:77:23
+  --> $DIR/repr-transparent-non-exhaustive.rs:89:23
    |
 LL | pub struct T13(Sized, ExternalIndirection<Private>);
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -94,7 +104,7 @@ LL | pub struct T13(Sized, ExternalIndirection<Private>);
    = note: this struct contains `Private`, which contains private fields, and makes it not a breaking change to become non-zero-sized in the future.
 
 error: zero-sized fields in `repr(transparent)` cannot contain external non-exhaustive types
-  --> $DIR/repr-transparent-non-exhaustive.rs:82:23
+  --> $DIR/repr-transparent-non-exhaustive.rs:94:23
    |
 LL | pub struct T14(Sized, ExternalIndirection<NonExhaustive>);
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -104,7 +114,7 @@ LL | pub struct T14(Sized, ExternalIndirection<NonExhaustive>);
    = note: this struct contains `NonExhaustive`, which is marked with `#[non_exhaustive]`, and makes it not a breaking change to become non-zero-sized in the future.
 
 error: zero-sized fields in `repr(transparent)` cannot contain external non-exhaustive types
-  --> $DIR/repr-transparent-non-exhaustive.rs:87:23
+  --> $DIR/repr-transparent-non-exhaustive.rs:99:23
    |
 LL | pub struct T15(Sized, ExternalIndirection<NonExhaustiveEnum>);
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -114,7 +124,7 @@ LL | pub struct T15(Sized, ExternalIndirection<NonExhaustiveEnum>);
    = note: this enum contains `NonExhaustiveEnum`, which is marked with `#[non_exhaustive]`, and makes it not a breaking change to become non-zero-sized in the future.
 
 error: zero-sized fields in `repr(transparent)` cannot contain external non-exhaustive types
-  --> $DIR/repr-transparent-non-exhaustive.rs:92:23
+  --> $DIR/repr-transparent-non-exhaustive.rs:104:23
    |
 LL | pub struct T16(Sized, ExternalIndirection<NonExhaustiveVariant>);
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -124,7 +134,7 @@ LL | pub struct T16(Sized, ExternalIndirection<NonExhaustiveVariant>);
    = note: this enum contains `NonExhaustiveVariant`, which is marked with `#[non_exhaustive]`, and makes it not a breaking change to become non-zero-sized in the future.
 
 error: zero-sized fields in `repr(transparent)` cannot contain external non-exhaustive types
-  --> $DIR/repr-transparent-non-exhaustive.rs:97:16
+  --> $DIR/repr-transparent-non-exhaustive.rs:109:16
    |
 LL | pub struct T17(NonExhaustive, Sized);
    |                ^^^^^^^^^^^^^
@@ -134,7 +144,7 @@ LL | pub struct T17(NonExhaustive, Sized);
    = note: this struct contains `NonExhaustive`, which is marked with `#[non_exhaustive]`, and makes it not a breaking change to become non-zero-sized in the future.
 
 error: zero-sized fields in `repr(transparent)` cannot contain external non-exhaustive types
-  --> $DIR/repr-transparent-non-exhaustive.rs:102:31
+  --> $DIR/repr-transparent-non-exhaustive.rs:114:31
    |
 LL | pub struct T18(NonExhaustive, NonExhaustive);
    |                               ^^^^^^^^^^^^^
@@ -144,7 +154,7 @@ LL | pub struct T18(NonExhaustive, NonExhaustive);
    = note: this struct contains `NonExhaustive`, which is marked with `#[non_exhaustive]`, and makes it not a breaking change to become non-zero-sized in the future.
 
 error: zero-sized fields in `repr(transparent)` cannot contain external non-exhaustive types
-  --> $DIR/repr-transparent-non-exhaustive.rs:107:31
+  --> $DIR/repr-transparent-non-exhaustive.rs:119:31
    |
 LL | pub struct T19(NonExhaustive, Private);
    |                               ^^^^^^^
@@ -154,7 +164,7 @@ LL | pub struct T19(NonExhaustive, Private);
    = note: this struct contains `Private`, which contains private fields, and makes it not a breaking change to become non-zero-sized in the future.
 
 error: zero-sized fields in `repr(transparent)` cannot contain external non-exhaustive types
-  --> $DIR/repr-transparent-non-exhaustive.rs:112:32
+  --> $DIR/repr-transparent-non-exhaustive.rs:124:32
    |
 LL | pub struct T19Flipped(Private, NonExhaustive);
    |                                ^^^^^^^^^^^^^
@@ -163,5 +173,5 @@ LL | pub struct T19Flipped(Private, NonExhaustive);
    = note: for more information, see issue #78586 <https://github.com/rust-lang/rust/issues/78586>
    = note: this struct contains `NonExhaustive`, which is marked with `#[non_exhaustive]`, and makes it not a breaking change to become non-zero-sized in the future.
 
-error: aborting due to 16 previous errors
+error: aborting due to 17 previous errors
 


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#147168 (Don't unconditionally build alloc for `no-std` targets)
 - rust-lang/rust#147514 (repr_transparent_external_private_fields: normalize types during traversal)
 - rust-lang/rust#147605 (Add doc links between `{integer}::from_str_radix` and `from_str`)
 - rust-lang/rust#147608 (cg_llvm: Use `LLVMDIBuilderCreateGlobalVariableExpression`)
 - rust-lang/rust#147623 (Clear `ChunkedBitSet` without reallocating)
 - rust-lang/rust#147625 (Add a warning when running tests with the GCC backend and debug assertions are enabled)
 - rust-lang/rust#147626 (Generalize configuring LLD as the default linker in bootstrap)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=147168,147514,147605,147608,147623,147625,147626)
<!-- homu-ignore:end -->