### PR TITLE
x86: Correctly pass larger structs/types in registers with -Zregparm

### DIFF
--- a/compiler/rustc_target/src/callconv/x86.rs
+++ b/compiler/rustc_target/src/callconv/x86.rs
@@ -183,7 +183,9 @@ pub(crate) fn fill_inregs<'a, Ty, C>(
 
         free_regs -= size_in_regs;
 
-        if arg.layout.size.bits() <= 32 && unit.kind == RegKind::Integer {
+        if opts.flavor != Flavor::FastcallOrVectorcall
+            || arg.layout.size.bits() <= 32 && unit.kind == RegKind::Integer
+        {
             attrs.set(ArgAttribute::InReg);
         }
 

--- a/tests/assembly-llvm/regparm-module-flag.rs
+++ b/tests/assembly-llvm/regparm-module-flag.rs
@@ -19,6 +19,26 @@ use minicore::*;
 unsafe extern "C" {
     fn memset(p: *mut c_void, val: i32, len: usize) -> *mut c_void;
     fn non_builtin_memset(p: *mut c_void, val: i32, len: usize) -> *mut c_void;
+    fn test_i64_arg(s: i64) -> i64;
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn test_i64() -> i64 {
+    // REGPARM1-LABEL: test_i64
+    // REGPARM1: pushl
+    // REGPARM1: pushl
+    // REGPARM1: calll test_i64_arg
+
+    // REGPARM2-LABEL: test_i64
+    // REGPARM2: movl $42, %eax
+    // REGPARM2: xorl %edx, %edx
+    // REGPARM2: jmp test_i64_arg
+
+    // REGPARM3-LABEL: test_i64
+    // REGPARM3: movl $42, %eax
+    // REGPARM3: xorl %edx, %edx
+    // REGPARM3: jmp test_i64_arg
+    unsafe { test_i64_arg(42) }
 }
 
 #[unsafe(no_mangle)]


### PR DESCRIPTION
Fixes rust-lang/rust#145694. I think this should be the last compiler fix needed to unblock 32-bit x86 support for Rust-for-linux (https://github.com/Rust-for-Linux/linux/issues/78)

Tracking issue for -Zregparm: https://github.com/rust-lang/rust/issues/131749

The -Zregparm option for 32-bit x86 modifies the calling convention to pass a number of arguments in registers instead of on the stack. (This is primarily used by the Linux kernel.)

Currently, rustc will only pass primitive integer types in registers, which seems to match the gcc documentation[1], which says that arguments "of integral type" are passed as registers. This also matches the fastcall and vectorcall conventions on windows.

However, it seems that _any_ type — most particularly structs — should be passed as a register if possible. This matches what clang and gcc do, and so avoids an ABI mismatch when linking with C code (which, after all, is the whole point of supporting -Zregparm).


Note that I haven't tested this particularly thoroughly outside the Linux kernel usecase, and in particular haven't tried to implement any 'assembly-llvm' tests, nor test for regressions against fastcall/vectorcall.