### PR TITLE
Fix ICE when late-bound lifetimes don't appear in fn signature

### DIFF
--- a/tests/crashes/135845.rs
+++ b/tests/crashes/135845.rs
@@ -1,6 +1,0 @@
-//@ known-bug: #135845
-struct S<'a, T: ?Sized>(&'a T);
-
-fn b<'a>() -> S<'static, _> {
-    S::<'a>(&0)
-}

--- a/tests/ui/lifetimes/late-bound-misuse-issue-135845.rs
+++ b/tests/ui/lifetimes/late-bound-misuse-issue-135845.rs
@@ -1,0 +1,29 @@
+// Regression test for issue #135845
+// Ensure we don't ICE when a lifetime parameter from a function
+// is incorrectly used in an expression.
+
+struct S<'a, T: ?Sized>(&'a T);
+
+fn b<'a>() -> S<'static, _> {
+    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for return types
+    S::<'a>(&0)
+}
+
+fn static_to_a_to_static_through_ref_in_tuple<'a>(x: &'a u32) -> &'a _ {
+    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for return types
+    let (ref y, _z): (&'a u32, u32) = (&22, 44);
+    *y
+}
+
+fn opt_str2<'a>(maybestr: &'a Option<String>) -> &'a _ {
+    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for return types
+    match *maybestr {
+        None => "(none)",
+        Some(ref s) => {
+            let s: &'a str = s;
+            s
+        }
+    }
+}
+
+fn main() {}

--- a/tests/ui/lifetimes/late-bound-misuse-issue-135845.stderr
+++ b/tests/ui/lifetimes/late-bound-misuse-issue-135845.stderr
@@ -1,0 +1,39 @@
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
+  --> $DIR/late-bound-misuse-issue-135845.rs:7:26
+   |
+LL | fn b<'a>() -> S<'static, _> {
+   |                          ^ not allowed in type signatures
+   |
+help: replace with the correct return type
+   |
+LL - fn b<'a>() -> S<'static, _> {
+LL + fn b<'a>() -> S<'_, i32> {
+   |
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
+  --> $DIR/late-bound-misuse-issue-135845.rs:12:70
+   |
+LL | fn static_to_a_to_static_through_ref_in_tuple<'a>(x: &'a u32) -> &'a _ {
+   |                                                                      ^ not allowed in type signatures
+   |
+help: replace with the correct return type
+   |
+LL - fn static_to_a_to_static_through_ref_in_tuple<'a>(x: &'a u32) -> &'a _ {
+LL + fn static_to_a_to_static_through_ref_in_tuple<'a>(x: &'a u32) -> &u32 {
+   |
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
+  --> $DIR/late-bound-misuse-issue-135845.rs:18:54
+   |
+LL | fn opt_str2<'a>(maybestr: &'a Option<String>) -> &'a _ {
+   |                                                      ^ not allowed in type signatures
+   |
+help: replace with the correct return type
+   |
+LL - fn opt_str2<'a>(maybestr: &'a Option<String>) -> &'a _ {
+LL + fn opt_str2<'a>(maybestr: &'a Option<String>) -> &str {
+   |
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0121`.


### PR DESCRIPTION
PR rust-lang/rust#135479 changed how late-bound regions are registered for MIR borrowck, switching from `for_each_late_bound_region_in_item` to iterating over `bound_inputs_and_output.bound_vars()`. However, for regular functions, the latter only includes late-bound lifetimes that appear in the function's inputs or output, missing unused lifetime parameters.

This caused an ICE when `replace_bound_regions_with_nll_infer_vars` tried to look up these unregistered regions.

This ensures all late-bound regions are properly registered in the universal regions map before they're needed during region substitution.

Fixes https://github.com/rust-lang/rust/issues/135845