### PR TITLE
Move even more early buffered lints to dyn lint diagnostics

### DIFF
--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -2049,22 +2049,6 @@ pub fn elided_lifetime_in_path_suggestion(
     ElidedLifetimeInPathSubdiag { expected, indicate }
 }
 
-pub fn report_ambiguity_error<'a, G: EmissionGuarantee>(
-    diag: &mut Diag<'a, G>,
-    ambiguity: rustc_lint_defs::AmbiguityErrorDiag,
-) {
-    diag.span_label(ambiguity.label_span, ambiguity.label_msg);
-    diag.note(ambiguity.note_msg);
-    diag.span_note(ambiguity.b1_span, ambiguity.b1_note_msg);
-    for help_msg in ambiguity.b1_help_msgs {
-        diag.help(help_msg);
-    }
-    diag.span_note(ambiguity.b2_span, ambiguity.b2_note_msg);
-    for help_msg in ambiguity.b2_help_msgs {
-        diag.help(help_msg);
-    }
-}
-
 /// Grammatical tool for displaying messages to end users in a nice form.
 ///
 /// Returns "an" if the given string starts with a vowel, and "a" otherwise.

--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -642,10 +642,6 @@ lint_opaque_hidden_inferred_bound = opaque type `{$ty}` does not satisfy its ass
 
 lint_opaque_hidden_inferred_bound_sugg = add this bound
 
-lint_out_of_scope_macro_calls = cannot find macro `{$path}` in the current scope when looking from {$location}
-    .label = not found from {$location}
-    .help = import `macro_rules` with `use` to make it callable above its definition
-
 lint_overflowing_bin_hex = literal out of range for `{$ty}`
     .negative_note = the literal `{$lit}` (decimal `{$dec}`) does not fit into the type `{$ty}`
     .negative_becomes_note = and the value `-{$lit}` will become `{$actually}{$ty}`
@@ -681,9 +677,6 @@ lint_pattern_in_bodiless = patterns aren't allowed in functions without bodies
 lint_pattern_in_foreign = patterns aren't allowed in foreign function declarations
     .label = pattern not allowed in foreign function
 
-lint_private_extern_crate_reexport = extern crate `{$ident}` is private and cannot be re-exported
-    .suggestion = consider making the `extern crate` item publicly accessible
-
 lint_query_instability = using `{$query}` can result in unstable query results
     .note = if you believe this case to be fine, allow this lint and add a comment explaining your rationale
 
@@ -708,10 +701,6 @@ lint_redundant_import = the item `{$ident}` is imported redundantly
     .label_defined_here = the item `{$ident}` is already defined here
     .label_imported_prelude = the item `{$ident}` is already imported by the extern prelude
     .label_defined_prelude = the item `{$ident}` is already defined by the extern prelude
-
-lint_redundant_import_visibility = glob import doesn't reexport anything with visibility `{$import_vis}` because no imported item is public enough
-    .note = the most public imported item is `{$max_vis}`
-    .help = reduce the glob import's visibility or increase visibility of imported items
 
 lint_redundant_semicolons =
     unnecessary trailing {$multiple ->
@@ -871,9 +860,6 @@ lint_unicode_text_flow = unicode codepoint changing visible direction of text pr
 
 lint_unit_bindings = binding has unit type `()`
     .label = this pattern is inferred to be the unit type `()`
-
-lint_unknown_diagnostic_attribute = unknown diagnostic attribute
-lint_unknown_diagnostic_attribute_typo_sugg = an attribute with a similar name exists
 
 lint_unknown_gated_lint =
     unknown lint: `{$name}`

--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -257,9 +257,6 @@ lint_expectation = this lint expectation is unfulfilled
     .note = the `unfulfilled_lint_expectations` lint can't be expected and will always produce this message
     .rationale = {$rationale}
 
-lint_extern_crate_not_idiomatic = `extern crate` is not idiomatic in the new edition
-    .suggestion = convert it to a `use`
-
 lint_for_loops_over_fallibles =
     for loop over {$article} `{$ref_prefix}{$ty}`. This is more readably written as an `if let` statement
     .suggestion = consider using `if let` to clear intent
@@ -467,9 +464,6 @@ lint_lintpass_by_hand = implementing `LintPass` by hand
 lint_macro_expr_fragment_specifier_2024_migration =
     the `expr` fragment specifier will accept more expressions in the 2024 edition
     .suggestion = to keep the existing behavior, use the `expr_2021` fragment specifier
-lint_macro_is_private = macro `{$ident}` is private
-
-lint_macro_rule_never_used = rule #{$n} of macro `{$name}` is never used
 
 lint_malformed_attribute = malformed lint attribute input
 
@@ -961,8 +955,6 @@ lint_unused_imports = {$num_snippets ->
 
 lint_unused_lifetime = lifetime parameter `{$ident}` never used
     .suggestion = elide the unused lifetime
-
-lint_unused_macro_definition = unused macro definition: `{$name}`
 
 lint_unused_op = unused {$op} that must be used
     .label = the {$op} produces a value

--- a/compiler/rustc_lint/src/early/diagnostics.rs
+++ b/compiler/rustc_lint/src/early/diagnostics.rs
@@ -311,21 +311,6 @@ pub fn decorate_builtin_lint(
             }
             .decorate_lint(diag);
         }
-        BuiltinLintDiag::RedundantImportVisibility { max_vis, span: vis_span, import_vis } => {
-            lints::RedundantImportVisibility { span: vis_span, help: (), max_vis, import_vis }
-                .decorate_lint(diag);
-        }
-        BuiltinLintDiag::UnknownDiagnosticAttribute { span: typo_span, typo_name } => {
-            let typo = typo_name.map(|typo_name| lints::UnknownDiagnosticAttributeTypoSugg {
-                span: typo_span,
-                typo_name,
-            });
-            lints::UnknownDiagnosticAttribute { typo }.decorate_lint(diag);
-        }
-        BuiltinLintDiag::PrivateExternCrateReexport { source: ident, extern_crate_span } => {
-            lints::PrivateExternCrateReexport { ident, sugg: extern_crate_span.shrink_to_lo() }
-                .decorate_lint(diag);
-        }
         BuiltinLintDiag::UnusedCrateDependency { extern_crate, local_crate } => {
             lints::UnusedCrateDependency { extern_crate, local_crate }.decorate_lint(diag)
         }
@@ -339,9 +324,6 @@ pub fn decorate_builtin_lint(
                 docs: docs.unwrap_or(""),
             }
             .decorate_lint(diag)
-        }
-        BuiltinLintDiag::OutOfScopeMacroCalls { span, path, location } => {
-            lints::OutOfScopeMacroCalls { span, path, location }.decorate_lint(diag)
         }
     }
 }

--- a/compiler/rustc_lint/src/early/diagnostics.rs
+++ b/compiler/rustc_lint/src/early/diagnostics.rs
@@ -251,9 +251,6 @@ pub fn decorate_builtin_lint(
             }
             .decorate_lint(diag);
         }
-        BuiltinLintDiag::AmbiguousGlobImports { diag: ambiguity } => {
-            lints::AmbiguousGlobImports { ambiguity }.decorate_lint(diag);
-        }
         BuiltinLintDiag::AmbiguousGlobReexports {
             name,
             namespace,

--- a/compiler/rustc_lint/src/early/diagnostics.rs
+++ b/compiler/rustc_lint/src/early/diagnostics.rs
@@ -251,12 +251,6 @@ pub fn decorate_builtin_lint(
             }
             .decorate_lint(diag);
         }
-        BuiltinLintDiag::ExternCrateNotIdiomatic { vis_span, ident_span } => {
-            let suggestion_span = vis_span.between(ident_span);
-            let code = if vis_span.is_empty() { "use " } else { " use " };
-
-            lints::ExternCrateNotIdiomatic { span: suggestion_span, code }.decorate_lint(diag);
-        }
         BuiltinLintDiag::AmbiguousGlobImports { diag: ambiguity } => {
             lints::AmbiguousGlobImports { ambiguity }.decorate_lint(diag);
         }
@@ -331,18 +325,6 @@ pub fn decorate_builtin_lint(
         BuiltinLintDiag::PrivateExternCrateReexport { source: ident, extern_crate_span } => {
             lints::PrivateExternCrateReexport { ident, sugg: extern_crate_span.shrink_to_lo() }
                 .decorate_lint(diag);
-        }
-        BuiltinLintDiag::MacroIsPrivate(ident) => {
-            lints::MacroIsPrivate { ident }.decorate_lint(diag);
-        }
-        BuiltinLintDiag::UnusedMacroDefinition(name) => {
-            lints::UnusedMacroDefinition { name }.decorate_lint(diag);
-        }
-        BuiltinLintDiag::MacroRuleNeverUsed(n, name) => {
-            lints::MacroRuleNeverUsed { n: n + 1, name }.decorate_lint(diag);
-        }
-        BuiltinLintDiag::UnstableFeature(msg) => {
-            lints::UnstableFeature { msg }.decorate_lint(diag);
         }
         BuiltinLintDiag::UnusedCrateDependency { extern_crate, local_crate } => {
             lints::UnusedCrateDependency { extern_crate, local_crate }.decorate_lint(diag)

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -15,7 +15,6 @@ use rustc_macros::{LintDiagnostic, Subdiagnostic};
 use rustc_middle::ty::inhabitedness::InhabitedPredicate;
 use rustc_middle::ty::{Clause, PolyExistentialTraitRef, Ty, TyCtxt};
 use rustc_session::Session;
-use rustc_session::lint::AmbiguityErrorDiag;
 use rustc_span::edition::Edition;
 use rustc_span::{Ident, Span, Symbol, sym};
 
@@ -2834,18 +2833,6 @@ pub(crate) struct NamedArgumentUsedPositionally {
 
     pub name: String,
     pub named_arg_name: String,
-}
-
-// FIXME: make this translatable
-pub(crate) struct AmbiguousGlobImports {
-    pub ambiguity: AmbiguityErrorDiag,
-}
-
-impl<'a, G: EmissionGuarantee> LintDiagnostic<'a, G> for AmbiguousGlobImports {
-    fn decorate_lint<'b>(self, diag: &'b mut Diag<'a, G>) {
-        diag.primary_message(self.ambiguity.msg.clone());
-        rustc_errors::report_ambiguity_error(diag, self.ambiguity);
-    }
 }
 
 #[derive(LintDiagnostic)]

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -2584,35 +2584,6 @@ pub(crate) struct PrivateExternCrateReexport {
 }
 
 #[derive(LintDiagnostic)]
-#[diag(lint_macro_is_private)]
-pub(crate) struct MacroIsPrivate {
-    pub ident: Ident,
-}
-
-#[derive(LintDiagnostic)]
-#[diag(lint_unused_macro_definition)]
-pub(crate) struct UnusedMacroDefinition {
-    pub name: Symbol,
-}
-
-#[derive(LintDiagnostic)]
-#[diag(lint_macro_rule_never_used)]
-pub(crate) struct MacroRuleNeverUsed {
-    pub n: usize,
-    pub name: Symbol,
-}
-
-pub(crate) struct UnstableFeature {
-    pub msg: DiagMessage,
-}
-
-impl<'a> LintDiagnostic<'a, ()> for UnstableFeature {
-    fn decorate_lint<'b>(self, diag: &'b mut Diag<'a, ()>) {
-        diag.primary_message(self.msg);
-    }
-}
-
-#[derive(LintDiagnostic)]
 #[diag(lint_unused_crate_dependency)]
 #[help]
 pub(crate) struct UnusedCrateDependency {
@@ -2891,15 +2862,6 @@ pub(crate) struct NamedArgumentUsedPositionally {
 
     pub name: String,
     pub named_arg_name: String,
-}
-
-#[derive(LintDiagnostic)]
-#[diag(lint_extern_crate_not_idiomatic)]
-pub(crate) struct ExternCrateNotIdiomatic {
-    #[suggestion(style = "verbose", code = "{code}", applicability = "machine-applicable")]
-    pub span: Span,
-
-    pub code: &'static str,
 }
 
 // FIXME: make this translatable

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -2576,14 +2576,6 @@ pub(crate) mod unexpected_cfg_value {
 }
 
 #[derive(LintDiagnostic)]
-#[diag(lint_private_extern_crate_reexport, code = E0365)]
-pub(crate) struct PrivateExternCrateReexport {
-    pub ident: Ident,
-    #[suggestion(code = "pub ", style = "verbose", applicability = "maybe-incorrect")]
-    pub sugg: Span,
-}
-
-#[derive(LintDiagnostic)]
 #[diag(lint_unused_crate_dependency)]
 #[help]
 pub(crate) struct UnusedCrateDependency {
@@ -2600,26 +2592,6 @@ pub(crate) struct IllFormedAttributeInput {
     #[note]
     pub has_docs: bool,
     pub docs: &'static str,
-}
-
-#[derive(LintDiagnostic)]
-#[diag(lint_unknown_diagnostic_attribute)]
-pub(crate) struct UnknownDiagnosticAttribute {
-    #[subdiagnostic]
-    pub typo: Option<UnknownDiagnosticAttributeTypoSugg>,
-}
-
-#[derive(Subdiagnostic)]
-#[suggestion(
-    lint_unknown_diagnostic_attribute_typo_sugg,
-    style = "verbose",
-    code = "{typo_name}",
-    applicability = "machine-applicable"
-)]
-pub(crate) struct UnknownDiagnosticAttributeTypoSugg {
-    #[primary_span]
-    pub span: Span,
-    pub typo_name: Symbol,
 }
 
 #[derive(LintDiagnostic)]
@@ -2922,18 +2894,6 @@ pub(crate) struct AssociatedConstElidedLifetime {
 }
 
 #[derive(LintDiagnostic)]
-#[diag(lint_redundant_import_visibility)]
-pub(crate) struct RedundantImportVisibility {
-    #[note]
-    pub span: Span,
-    #[help]
-    pub help: (),
-
-    pub import_vis: String,
-    pub max_vis: String,
-}
-
-#[derive(LintDiagnostic)]
 #[diag(lint_unsafe_attr_outside_unsafe)]
 pub(crate) struct UnsafeAttrOutsideUnsafe {
     #[label]
@@ -2952,16 +2912,6 @@ pub(crate) struct UnsafeAttrOutsideUnsafeSuggestion {
     pub left: Span,
     #[suggestion_part(code = ")")]
     pub right: Span,
-}
-
-#[derive(LintDiagnostic)]
-#[diag(lint_out_of_scope_macro_calls)]
-#[help]
-pub(crate) struct OutOfScopeMacroCalls {
-    #[label]
-    pub span: Span,
-    pub path: String,
-    pub location: String,
 }
 
 #[derive(LintDiagnostic)]

--- a/compiler/rustc_lint_defs/src/lib.rs
+++ b/compiler/rustc_lint_defs/src/lib.rs
@@ -714,19 +714,6 @@ pub enum BuiltinLintDiag {
         span: Span,
         lifetimes_in_scope: MultiSpan,
     },
-    RedundantImportVisibility {
-        span: Span,
-        max_vis: String,
-        import_vis: String,
-    },
-    UnknownDiagnosticAttribute {
-        span: Span,
-        typo_name: Option<Symbol>,
-    },
-    PrivateExternCrateReexport {
-        source: Ident,
-        extern_crate_span: Span,
-    },
     UnusedCrateDependency {
         extern_crate: Symbol,
         local_crate: Symbol,
@@ -734,11 +721,6 @@ pub enum BuiltinLintDiag {
     IllFormedAttributeInput {
         suggestions: Vec<String>,
         docs: Option<&'static str>,
-    },
-    OutOfScopeMacroCalls {
-        span: Span,
-        path: String,
-        location: String,
     },
 }
 

--- a/compiler/rustc_lint_defs/src/lib.rs
+++ b/compiler/rustc_lint_defs/src/lib.rs
@@ -593,21 +593,6 @@ impl StableCompare for LintId {
     }
 }
 
-#[derive(Debug)]
-pub struct AmbiguityErrorDiag {
-    pub msg: String,
-    pub span: Span,
-    pub label_span: Span,
-    pub label_msg: String,
-    pub note_msg: String,
-    pub b1_span: Span,
-    pub b1_note_msg: String,
-    pub b1_help_msgs: Vec<String>,
-    pub b2_span: Span,
-    pub b2_note_msg: String,
-    pub b2_help_msgs: Vec<String>,
-}
-
 #[derive(Debug, Clone)]
 pub enum DeprecatedSinceKind {
     InEffect,
@@ -677,9 +662,6 @@ pub enum BuiltinLintDiag {
         named_arg_name: String,
         /// Indicates if the named argument is used as a width/precision for formatting
         is_formatting_arg: bool,
-    },
-    AmbiguousGlobImports {
-        diag: AmbiguityErrorDiag,
     },
     AmbiguousGlobReexports {
         /// The name for which collision(s) have occurred.

--- a/compiler/rustc_lint_defs/src/lib.rs
+++ b/compiler/rustc_lint_defs/src/lib.rs
@@ -6,7 +6,7 @@ use rustc_data_structures::fx::FxIndexSet;
 use rustc_data_structures::stable_hasher::{
     HashStable, StableCompare, StableHasher, ToStableHashKey,
 };
-use rustc_error_messages::{DiagArgValue, DiagMessage, IntoDiagArg, MultiSpan};
+use rustc_error_messages::{DiagArgValue, IntoDiagArg, MultiSpan};
 use rustc_hir_id::{HashStableContext, HirId, ItemLocalId};
 use rustc_macros::{Decodable, Encodable, HashStable_Generic};
 use rustc_span::def_id::DefPathHash;
@@ -678,10 +678,6 @@ pub enum BuiltinLintDiag {
         /// Indicates if the named argument is used as a width/precision for formatting
         is_formatting_arg: bool,
     },
-    ExternCrateNotIdiomatic {
-        vis_span: Span,
-        ident_span: Span,
-    },
     AmbiguousGlobImports {
         diag: AmbiguityErrorDiag,
     },
@@ -731,10 +727,6 @@ pub enum BuiltinLintDiag {
         source: Ident,
         extern_crate_span: Span,
     },
-    MacroIsPrivate(Ident),
-    UnusedMacroDefinition(Symbol),
-    MacroRuleNeverUsed(usize, Symbol),
-    UnstableFeature(DiagMessage),
     UnusedCrateDependency {
         extern_crate: Symbol,
         local_crate: Symbol,

--- a/compiler/rustc_resolve/messages.ftl
+++ b/compiler/rustc_resolve/messages.ftl
@@ -146,6 +146,9 @@ resolve_explicit_unsafe_traits =
 resolve_extern_crate_loading_macro_not_at_crate_root =
     an `extern crate` loading macros must be at the crate root
 
+resolve_extern_crate_not_idiomatic = `extern crate` is not idiomatic in the new edition
+    .suggestion = convert it to a `use`
+
 resolve_extern_crate_self_requires_renaming =
     `extern crate self;` requires renaming
     .suggestion = rename the `self` crate to be able to import it
@@ -279,6 +282,10 @@ resolve_macro_expected_found =
 resolve_macro_extern_deprecated =
     `#[macro_escape]` is a deprecated synonym for `#[macro_use]`
     .help = try an outer attribute: `#[macro_use]`
+
+resolve_macro_is_private = macro `{$ident}` is private
+
+resolve_macro_rule_never_used = rule #{$n} of macro `{$name}` is never used
 
 resolve_macro_use_deprecated =
     applying the `#[macro_use]` attribute to an `extern crate` item is deprecated
@@ -492,6 +499,8 @@ resolve_unused_extern_crate = unused extern crate
     .suggestion = remove the unused `extern crate`
 
 resolve_unused_label = unused label
+
+resolve_unused_macro_definition = unused macro definition: `{$name}`
 
 resolve_unused_macro_use = unused `#[macro_use]` import
 

--- a/compiler/rustc_resolve/messages.ftl
+++ b/compiler/rustc_resolve/messages.ftl
@@ -342,6 +342,10 @@ resolve_note_and_refers_to_the_item_defined_here =
         }
     }
 
+resolve_out_of_scope_macro_calls = cannot find macro `{$path}` in the current scope when looking from {$location}
+    .label = not found from {$location}
+    .help = import `macro_rules` with `use` to make it callable above its definition
+
 resolve_outer_ident_is_not_publicly_reexported =
     {$outer_ident_descr} `{$outer_ident}` is not publicly re-exported
 
@@ -362,11 +366,18 @@ resolve_param_in_ty_of_const_param =
 
 resolve_pattern_doesnt_bind_name = pattern doesn't bind `{$name}`
 
+resolve_private_extern_crate_reexport = extern crate `{$ident}` is private and cannot be re-exported
+    .suggestion = consider making the `extern crate` item publicly accessible
+
 resolve_proc_macro_derive_resolution_fallback = cannot find {$ns_descr} `{$ident}` in this scope
     .label = names from parent modules are not accessible without an explicit import
 
 resolve_proc_macro_same_crate = can't use a procedural macro from the same crate that defines it
     .help = you can define integration tests in a directory named `tests`
+
+resolve_redundant_import_visibility = glob import doesn't reexport anything with visibility `{$import_vis}` because no imported item is public enough
+    .note = the most public imported item is `{$max_vis}`
+    .help = reduce the glob import's visibility or increase visibility of imported items
 
 resolve_reexport_of_crate_public =
     re-export of crate public `{$ident}`
@@ -472,6 +483,9 @@ resolve_unexpected_res_change_ty_to_const_param_sugg =
 
 resolve_unexpected_res_use_at_op_in_slice_pat_with_range_sugg =
     if you meant to collect the rest of the slice in `{$ident}`, use the at operator
+
+resolve_unknown_diagnostic_attribute = unknown diagnostic attribute
+resolve_unknown_diagnostic_attribute_typo_sugg = an attribute with a similar name exists
 
 resolve_unnamed_crate_root_import =
     crate root imports need to be explicitly named: `use crate as name;`

--- a/compiler/rustc_resolve/src/check_unused.rs
+++ b/compiler/rustc_resolve/src/check_unused.rs
@@ -228,11 +228,15 @@ impl<'a, 'ra, 'tcx> UnusedImportCheckVisitor<'a, 'ra, 'tcx> {
                 .span
                 .find_ancestor_inside(extern_crate.span)
                 .unwrap_or(extern_crate.ident.span);
+
             self.r.lint_buffer.buffer_lint(
                 UNUSED_EXTERN_CRATES,
                 extern_crate.id,
                 extern_crate.span,
-                BuiltinLintDiag::ExternCrateNotIdiomatic { vis_span, ident_span },
+                crate::errors::ExternCrateNotIdiomatic {
+                    span: vis_span.between(ident_span),
+                    code: if vis_span.is_empty() { "use " } else { " use " },
+                },
             );
         }
     }

--- a/compiler/rustc_resolve/src/errors.rs
+++ b/compiler/rustc_resolve/src/errors.rs
@@ -1,7 +1,7 @@
 use rustc_errors::codes::*;
 use rustc_errors::{
-    Applicability, Diag, ElidedLifetimeInPathSubdiag, EmissionGuarantee, IntoDiagArg, MultiSpan,
-    Subdiagnostic,
+    Applicability, Diag, DiagMessage, ElidedLifetimeInPathSubdiag, EmissionGuarantee, IntoDiagArg,
+    LintDiagnostic, MultiSpan, Subdiagnostic,
 };
 use rustc_macros::{Diagnostic, LintDiagnostic, Subdiagnostic};
 use rustc_span::{Ident, Span, Symbol};
@@ -1359,3 +1359,40 @@ pub(crate) struct UnusedMacroUse;
 #[diag(resolve_macro_use_deprecated)]
 #[help]
 pub(crate) struct MacroUseDeprecated;
+
+#[derive(LintDiagnostic)]
+#[diag(resolve_macro_is_private)]
+pub(crate) struct MacroIsPrivate {
+    pub ident: Ident,
+}
+
+#[derive(LintDiagnostic)]
+#[diag(resolve_unused_macro_definition)]
+pub(crate) struct UnusedMacroDefinition {
+    pub name: Symbol,
+}
+
+#[derive(LintDiagnostic)]
+#[diag(resolve_macro_rule_never_used)]
+pub(crate) struct MacroRuleNeverUsed {
+    pub n: usize,
+    pub name: Symbol,
+}
+
+pub(crate) struct UnstableFeature {
+    pub msg: DiagMessage,
+}
+
+impl<'a> LintDiagnostic<'a, ()> for UnstableFeature {
+    fn decorate_lint<'b>(self, diag: &'b mut Diag<'a, ()>) {
+        diag.primary_message(self.msg);
+    }
+}
+
+#[derive(LintDiagnostic)]
+#[diag(resolve_extern_crate_not_idiomatic)]
+pub(crate) struct ExternCrateNotIdiomatic {
+    #[suggestion(style = "verbose", code = "{code}", applicability = "machine-applicable")]
+    pub span: Span,
+    pub code: &'static str,
+}

--- a/compiler/rustc_resolve/src/errors.rs
+++ b/compiler/rustc_resolve/src/errors.rs
@@ -812,6 +812,14 @@ pub(crate) struct CannotBeReexportedCratePublicNS {
     pub(crate) ident: Ident,
 }
 
+#[derive(LintDiagnostic)]
+#[diag(resolve_private_extern_crate_reexport, code = E0365)]
+pub(crate) struct PrivateExternCrateReexport {
+    pub ident: Ident,
+    #[suggestion(code = "pub ", style = "verbose", applicability = "maybe-incorrect")]
+    pub sugg: Span,
+}
+
 #[derive(Subdiagnostic)]
 #[help(resolve_consider_adding_macro_export)]
 pub(crate) struct ConsiderAddingMacroExport {
@@ -1395,4 +1403,45 @@ pub(crate) struct ExternCrateNotIdiomatic {
     #[suggestion(style = "verbose", code = "{code}", applicability = "machine-applicable")]
     pub span: Span,
     pub code: &'static str,
+}
+
+#[derive(LintDiagnostic)]
+#[diag(resolve_out_of_scope_macro_calls)]
+#[help]
+pub(crate) struct OutOfScopeMacroCalls {
+    #[label]
+    pub span: Span,
+    pub path: String,
+    pub location: String,
+}
+
+#[derive(LintDiagnostic)]
+#[diag(resolve_redundant_import_visibility)]
+pub(crate) struct RedundantImportVisibility {
+    #[note]
+    pub span: Span,
+    #[help]
+    pub help: (),
+    pub import_vis: String,
+    pub max_vis: String,
+}
+
+#[derive(LintDiagnostic)]
+#[diag(resolve_unknown_diagnostic_attribute)]
+pub(crate) struct UnknownDiagnosticAttribute {
+    #[subdiagnostic]
+    pub typo: Option<UnknownDiagnosticAttributeTypoSugg>,
+}
+
+#[derive(Subdiagnostic)]
+#[suggestion(
+    resolve_unknown_diagnostic_attribute_typo_sugg,
+    style = "verbose",
+    code = "{typo_name}",
+    applicability = "machine-applicable"
+)]
+pub(crate) struct UnknownDiagnosticAttributeTypoSugg {
+    #[primary_span]
+    pub span: Span,
+    pub typo_name: Symbol,
 }

--- a/compiler/rustc_resolve/src/imports.rs
+++ b/compiler/rustc_resolve/src/imports.rs
@@ -1095,10 +1095,11 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                         UNUSED_IMPORTS,
                         id,
                         import.span,
-                        BuiltinLintDiag::RedundantImportVisibility {
+                        crate::errors::RedundantImportVisibility {
+                            span: import.span,
+                            help: (),
                             max_vis: max_vis.to_string(def_id, self.tcx),
                             import_vis: import.vis.to_string(def_id, self.tcx),
-                            span: import.span,
                         },
                     );
                 }
@@ -1330,13 +1331,14 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         if !any_successful_reexport {
             let (ns, binding) = reexport_error.unwrap();
             if let Some(extern_crate_id) = pub_use_of_private_extern_crate_hack(import, binding) {
+                let extern_crate_sp = self.tcx.source_span(self.local_def_id(extern_crate_id));
                 self.lint_buffer.buffer_lint(
                     PUB_USE_OF_PRIVATE_EXTERN_CRATE,
                     import_id,
                     import.span,
-                    BuiltinLintDiag::PrivateExternCrateReexport {
-                        source: ident,
-                        extern_crate_span: self.tcx.source_span(self.local_def_id(extern_crate_id)),
+                    crate::errors::PrivateExternCrateReexport {
+                        ident,
+                        sugg: extern_crate_sp.shrink_to_lo(),
                     },
                 );
             } else if ns == TypeNS {

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -73,7 +73,6 @@ use rustc_middle::ty::{
     ResolverGlobalCtxt, TyCtxt, TyCtxtFeed, Visibility,
 };
 use rustc_query_system::ich::StableHashingContext;
-use rustc_session::lint::BuiltinLintDiag;
 use rustc_session::lint::builtin::PRIVATE_MACRO_USE;
 use rustc_span::hygiene::{ExpnId, LocalExpnId, MacroKind, SyntaxContext, Transparency};
 use rustc_span::{DUMMY_SP, Ident, Macros20NormalizedIdent, Span, Symbol, kw, sym};
@@ -2067,7 +2066,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                         PRIVATE_MACRO_USE,
                         import.root_id,
                         ident.span,
-                        BuiltinLintDiag::MacroIsPrivate(ident),
+                        errors::MacroIsPrivate { ident },
                     );
                 }
             }

--- a/compiler/rustc_resolve/src/macros.rs
+++ b/compiler/rustc_resolve/src/macros.rs
@@ -340,7 +340,7 @@ impl<'ra, 'tcx> ResolverExpand for Resolver<'ra, 'tcx> {
                 UNUSED_MACROS,
                 node_id,
                 ident.span,
-                BuiltinLintDiag::UnusedMacroDefinition(ident.name),
+                errors::UnusedMacroDefinition { name: ident.name },
             );
             // Do not report unused individual rules if the entire macro is unused
             self.unused_macro_rules.swap_remove(&node_id);
@@ -361,7 +361,7 @@ impl<'ra, 'tcx> ResolverExpand for Resolver<'ra, 'tcx> {
                         UNUSED_MACRO_RULES,
                         node_id,
                         rule_span,
-                        BuiltinLintDiag::MacroRuleNeverUsed(arm_i, ident.name),
+                        errors::MacroRuleNeverUsed { n: arm_i + 1, name: ident.name },
                     );
                 }
             }
@@ -1031,10 +1031,8 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                         lint,
                         node_id,
                         span,
-                        BuiltinLintDiag::UnstableFeature(
-                            // FIXME make this translatable
-                            msg.into(),
-                        ),
+                        // FIXME make this translatable
+                        errors::UnstableFeature { msg: msg.into() },
                     )
                 };
                 stability::report_unstable(


### PR DESCRIPTION
Follow-up to https://github.com/rust-lang/rust/pull/145881 and https://github.com/rust-lang/rust/pull/145747.

I originally wanted to migrate most if not the entire rest of the early buffered lints. However, when trying to migrate the buffered lints used by check-cfg I encountered a roadblock. Namely, it depends on `TyCtxt` (well, `Option<TyCtxt>`) which makes it quite hard to migrate (see also https://github.com/rust-lang/rust/pull/147634#issuecomment-3398174584, https://github.com/rust-lang/rust/pull/147634#issuecomment-3398207128 & rust-lang/rust#149215).

So for now, I won't migrate it (maybe rust-lang/rust#149215 will find a solution), nor will I migrate the rest since it's quite tedious to migrate these. I'll leave them for future me.