### PR TITLE
Make `ops::DerefMut` a diagnostic item

### DIFF
--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -219,6 +219,7 @@ symbols! {
         Decoder,
         Default,
         Deref,
+        DerefMut,
         DiagMessage,
         Diagnostic,
         DirBuilder,

--- a/library/core/src/ops/deref.rs
+++ b/library/core/src/ops/deref.rs
@@ -266,6 +266,7 @@ impl<T: ?Sized> const Deref for &mut T {
 #[lang = "deref_mut"]
 #[doc(alias = "*")]
 #[stable(feature = "rust1", since = "1.0.0")]
+#[rustc_diagnostic_item = "DerefMut"]
 #[rustc_const_unstable(feature = "const_convert", issue = "143773")]
 pub const trait DerefMut: [const] Deref + PointeeSized {
     /// Mutably dereferences the value.


### PR DESCRIPTION
I'm working on an enhancement to [clippy::explicit_deref_methods](https://rust-lang.github.io/rust-clippy/master/index.html#explicit_deref_methods), which would allow explicit `deref` or `deref_mut` method calls in implementation of the the `Deref` or `DerefMut` trait, so I need a `DerefMut` diagnostic item to check if we are already in the impl of `DerefMut` trait.