### PR TITLE
Rollup of 11 pull requests

### DIFF
--- a/compiler/rustc_borrowck/src/region_infer/opaque_types/mod.rs
+++ b/compiler/rustc_borrowck/src/region_infer/opaque_types/mod.rs
@@ -155,13 +155,6 @@ fn add_hidden_type<'tcx>(
     }
 }
 
-fn get_hidden_type<'tcx>(
-    hidden_types: &DefinitionSiteHiddenTypes<'tcx>,
-    def_id: LocalDefId,
-) -> Option<EarlyBinder<'tcx, OpaqueHiddenType<'tcx>>> {
-    hidden_types.0.get(&def_id).map(|ty| EarlyBinder::bind(*ty))
-}
-
 #[derive(Debug)]
 struct DefiningUse<'tcx> {
     /// The opaque type using non NLL vars. This uses the actual
@@ -501,7 +494,8 @@ pub(crate) fn apply_definition_site_hidden_types<'tcx>(
     let tcx = infcx.tcx;
     let mut errors = Vec::new();
     for &(key, hidden_type) in opaque_types {
-        let Some(expected) = get_hidden_type(hidden_types, key.def_id) else {
+        let Some(expected) = hidden_types.0.get(&key.def_id).map(|ty| EarlyBinder::bind(*ty))
+        else {
             if !tcx.use_typing_mode_borrowck() {
                 if let ty::Alias(ty::Opaque, alias_ty) = hidden_type.ty.kind()
                     && alias_ty.def_id == key.def_id.to_def_id()

--- a/compiler/rustc_hir_typeck/src/lib.rs
+++ b/compiler/rustc_hir_typeck/src/lib.rs
@@ -219,6 +219,12 @@ fn typeck_with_inspect<'tcx>(
     // the future.
     fcx.check_repeat_exprs();
 
+    // We need to handle opaque types before emitting ambiguity errors as applying
+    // defining uses may guide type inference.
+    if fcx.next_trait_solver() {
+        fcx.try_handle_opaque_type_uses_next();
+    }
+
     fcx.type_inference_fallback();
 
     // Even though coercion casts provide type hints, we check casts after fallback for

--- a/compiler/rustc_hir_typeck/src/opaque_types.rs
+++ b/compiler/rustc_hir_typeck/src/opaque_types.rs
@@ -26,15 +26,15 @@ impl<'tcx> FnCtxt<'_, 'tcx> {
     /// Unlike `handle_opaque_type_uses_next`, this does not report errors.
     #[instrument(level = "debug", skip(self))]
     pub(super) fn try_handle_opaque_type_uses_next(&mut self) {
-        // We clone the opaques instead of stealing them here as they are still used for
-        // normalization in the next generation trait solver.
+        // We clone the opaques instead of stealing them here as we still need
+        // to use them after fallback.
         let mut opaque_types: Vec<_> = self.infcx.clone_opaque_types();
         for entry in &mut opaque_types {
             *entry = self.resolve_vars_if_possible(*entry);
         }
         debug!(?opaque_types);
 
-        self.compute_definition_site_hidden_types(&opaque_types, true);
+        self.compute_definition_site_hidden_types(&opaque_types, false);
     }
 
     /// This takes all the opaque type uses during HIR typeck. It first computes
@@ -58,7 +58,7 @@ impl<'tcx> FnCtxt<'_, 'tcx> {
         }
         debug!(?opaque_types);
 
-        self.compute_definition_site_hidden_types(&opaque_types, false);
+        self.compute_definition_site_hidden_types(&opaque_types, true);
     }
 }
 
@@ -97,7 +97,7 @@ impl<'tcx> FnCtxt<'_, 'tcx> {
     fn compute_definition_site_hidden_types(
         &mut self,
         opaque_types: &[(OpaqueTypeKey<'tcx>, OpaqueHiddenType<'tcx>)],
-        first_pass: bool,
+        error_on_missing_defining_use: bool,
     ) {
         let tcx = self.tcx;
         let TypingMode::Analysis { defining_opaque_types_and_generators } = self.typing_mode()
@@ -138,19 +138,16 @@ impl<'tcx> FnCtxt<'_, 'tcx> {
                     self.demand_eqtype(hidden_type.span, expected, hidden_type.ty);
                 }
 
-                let prev = self.typeck_results.borrow_mut().hidden_types.insert(def_id, ty);
-
-                // We do want to insert opaque types the first pass, because
-                // we want to equate them. So, the second pass (where we
-                // report errors) may have a hidden type inserted.
-                if first_pass {
-                    assert!(prev.is_none());
-                }
+                // Being explicit here: it may be possible that we in a
+                // previous call to this function we did an insert, but this
+                // should be just fine, since they all get equated anyways and
+                // we shouldn't ever go from `HasDefiningUse` to anyway else.
+                let _ = self.typeck_results.borrow_mut().hidden_types.insert(def_id, ty);
             }
 
             // If this the first pass (`try_handle_opaque_type_uses_next`),
             // then do not report any errors.
-            if first_pass {
+            if !error_on_missing_defining_use {
                 continue;
             }
 
@@ -204,7 +201,7 @@ impl<'tcx> FnCtxt<'_, 'tcx> {
 
     #[tracing::instrument(skip(self), ret)]
     fn consider_opaque_type_use(
-        &mut self,
+        &self,
         opaque_type_key: OpaqueTypeKey<'tcx>,
         hidden_type: OpaqueHiddenType<'tcx>,
     ) -> UsageKind<'tcx> {

--- a/compiler/rustc_middle/src/mir/loops.rs
+++ b/compiler/rustc_middle/src/mir/loops.rs
@@ -1,0 +1,29 @@
+use rustc_index::bit_set::DenseBitSet;
+
+use super::*;
+
+/// Compute the set of loop headers in the given body. A loop header is usually defined as a block
+/// which dominates one of its predecessors. This definition is only correct for reducible CFGs.
+/// However, computing dominators is expensive, so we approximate according to the post-order
+/// traversal order. A loop header for us is a block which is visited after its predecessor in
+/// post-order. This is ok as we mostly need a heuristic.
+pub fn maybe_loop_headers(body: &Body<'_>) -> DenseBitSet<BasicBlock> {
+    let mut maybe_loop_headers = DenseBitSet::new_empty(body.basic_blocks.len());
+    let mut visited = DenseBitSet::new_empty(body.basic_blocks.len());
+    for (bb, bbdata) in traversal::postorder(body) {
+        // Post-order means we visit successors before the block for acyclic CFGs.
+        // If the successor is not visited yet, consider it a loop header.
+        for succ in bbdata.terminator().successors() {
+            if !visited.contains(succ) {
+                maybe_loop_headers.insert(succ);
+            }
+        }
+
+        // Only mark `bb` as visited after we checked the successors, in case we have a self-loop.
+        //     bb1: goto -> bb1;
+        let _new = visited.insert(bb);
+        debug_assert!(_new);
+    }
+
+    maybe_loop_headers
+}

--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -51,6 +51,7 @@ mod statement;
 mod syntax;
 mod terminator;
 
+pub mod loops;
 pub mod traversal;
 pub mod visit;
 

--- a/compiler/rustc_mir_transform/src/gvn.rs
+++ b/compiler/rustc_mir_transform/src/gvn.rs
@@ -129,6 +129,7 @@ impl<'tcx> crate::MirPass<'tcx> for GVN {
         let ssa = SsaLocals::new(tcx, body, typing_env);
         // Clone dominators because we need them while mutating the body.
         let dominators = body.basic_blocks.dominators().clone();
+        let maybe_loop_headers = loops::maybe_loop_headers(body);
 
         let arena = DroplessArena::default();
         let mut state =
@@ -141,6 +142,11 @@ impl<'tcx> crate::MirPass<'tcx> for GVN {
 
         let reverse_postorder = body.basic_blocks.reverse_postorder().to_vec();
         for bb in reverse_postorder {
+            // N.B. With loops, reverse postorder cannot produce a valid topological order.
+            // A statement or terminator from inside the loop, that is not processed yet, may have performed an indirect write.
+            if maybe_loop_headers.contains(bb) {
+                state.invalidate_derefs();
+            }
             let data = &mut body.basic_blocks.as_mut_preserves_cfg()[bb];
             state.visit_basic_block_data(bb, data);
         }

--- a/compiler/rustc_mir_transform/src/jump_threading.rs
+++ b/compiler/rustc_mir_transform/src/jump_threading.rs
@@ -84,7 +84,7 @@ impl<'tcx> crate::MirPass<'tcx> for JumpThreading {
             body,
             arena,
             map: Map::new(tcx, body, Some(MAX_PLACES)),
-            maybe_loop_headers: maybe_loop_headers(body),
+            maybe_loop_headers: loops::maybe_loop_headers(body),
             opportunities: Vec::new(),
         };
 
@@ -829,30 +829,4 @@ fn predecessor_count(body: &Body<'_>) -> IndexVec<BasicBlock, usize> {
 enum Update {
     Incr,
     Decr,
-}
-
-/// Compute the set of loop headers in the given body. A loop header is usually defined as a block
-/// which dominates one of its predecessors. This definition is only correct for reducible CFGs.
-/// However, computing dominators is expensive, so we approximate according to the post-order
-/// traversal order. A loop header for us is a block which is visited after its predecessor in
-/// post-order. This is ok as we mostly need a heuristic.
-fn maybe_loop_headers(body: &Body<'_>) -> DenseBitSet<BasicBlock> {
-    let mut maybe_loop_headers = DenseBitSet::new_empty(body.basic_blocks.len());
-    let mut visited = DenseBitSet::new_empty(body.basic_blocks.len());
-    for (bb, bbdata) in traversal::postorder(body) {
-        // Post-order means we visit successors before the block for acyclic CFGs.
-        // If the successor is not visited yet, consider it a loop header.
-        for succ in bbdata.terminator().successors() {
-            if !visited.contains(succ) {
-                maybe_loop_headers.insert(succ);
-            }
-        }
-
-        // Only mark `bb` as visited after we checked the successors, in case we have a self-loop.
-        //     bb1: goto -> bb1;
-        let _new = visited.insert(bb);
-        debug_assert!(_new);
-    }
-
-    maybe_loop_headers
 }

--- a/compiler/rustc_next_trait_solver/src/solve/search_graph.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/search_graph.rs
@@ -99,19 +99,23 @@ where
         response_no_constraints(cx, input, Certainty::overflow(false))
     }
 
-    fn is_ambiguous_result(result: QueryResult<I>) -> bool {
-        result.is_ok_and(|response| {
-            has_no_inference_or_external_constraints(response)
+    fn is_ambiguous_result(result: QueryResult<I>) -> Option<Certainty> {
+        result.ok().and_then(|response| {
+            if has_no_inference_or_external_constraints(response)
                 && matches!(response.value.certainty, Certainty::Maybe { .. })
+            {
+                Some(response.value.certainty)
+            } else {
+                None
+            }
         })
     }
 
     fn propagate_ambiguity(
         cx: I,
         for_input: CanonicalInput<I>,
-        from_result: QueryResult<I>,
+        certainty: Certainty,
     ) -> QueryResult<I> {
-        let certainty = from_result.unwrap().value.certainty;
         response_no_constraints(cx, for_input, certainty)
     }
 

--- a/compiler/rustc_type_ir/src/interner.rs
+++ b/compiler/rustc_type_ir/src/interner.rs
@@ -11,7 +11,7 @@ use crate::inherent::*;
 use crate::ir_print::IrPrint;
 use crate::lang_items::{SolverAdtLangItem, SolverLangItem, SolverTraitLangItem};
 use crate::relate::Relate;
-use crate::solve::{CanonicalInput, ExternalConstraintsData, QueryResult, inspect};
+use crate::solve::{CanonicalInput, Certainty, ExternalConstraintsData, QueryResult, inspect};
 use crate::visit::{Flags, TypeVisitable};
 use crate::{self as ty, CanonicalParamEnvCacheEntry, search_graph};
 
@@ -548,6 +548,7 @@ impl<T, R, E> CollectAndApply<T, R> for Result<T, E> {
 impl<I: Interner> search_graph::Cx for I {
     type Input = CanonicalInput<I>;
     type Result = QueryResult<I>;
+    type AmbiguityInfo = Certainty;
 
     type DepNodeIndex = I::DepNodeIndex;
     type Tracked<T: Debug + Clone> = I::Tracked<T>;

--- a/compiler/rustc_type_ir/src/search_graph/mod.rs
+++ b/compiler/rustc_type_ir/src/search_graph/mod.rs
@@ -40,6 +40,7 @@ pub use global_cache::GlobalCache;
 pub trait Cx: Copy {
     type Input: Debug + Eq + Hash + Copy;
     type Result: Debug + Eq + Hash + Copy;
+    type AmbiguityInfo: Debug + Eq + Hash + Copy;
 
     type DepNodeIndex;
     type Tracked<T: Debug + Clone>: Debug;
@@ -96,11 +97,13 @@ pub trait Delegate: Sized {
         input: <Self::Cx as Cx>::Input,
     ) -> <Self::Cx as Cx>::Result;
 
-    fn is_ambiguous_result(result: <Self::Cx as Cx>::Result) -> bool;
+    fn is_ambiguous_result(
+        result: <Self::Cx as Cx>::Result,
+    ) -> Option<<Self::Cx as Cx>::AmbiguityInfo>;
     fn propagate_ambiguity(
         cx: Self::Cx,
         for_input: <Self::Cx as Cx>::Input,
-        from_result: <Self::Cx as Cx>::Result,
+        ambiguity_info: <Self::Cx as Cx>::AmbiguityInfo,
     ) -> <Self::Cx as Cx>::Result;
 
     fn compute_goal(
@@ -913,9 +916,9 @@ impl<D: Delegate<Cx = X>, X: Cx> SearchGraph<D> {
 /// heads from the stack. This may not necessarily mean that we've actually
 /// reached a fixpoint for that cycle head, which impacts the way we rebase
 /// provisional cache entries.
-enum RebaseReason {
+enum RebaseReason<X: Cx> {
     NoCycleUsages,
-    Ambiguity,
+    Ambiguity(X::AmbiguityInfo),
     Overflow,
     /// We've actually reached a fixpoint.
     ///
@@ -951,7 +954,7 @@ impl<D: Delegate<Cx = X>, X: Cx> SearchGraph<D, X> {
         &mut self,
         cx: X,
         stack_entry: &StackEntry<X>,
-        rebase_reason: RebaseReason,
+        rebase_reason: RebaseReason<X>,
     ) {
         let popped_head_index = self.stack.next_index();
         #[allow(rustc::potential_query_instability)]
@@ -1029,8 +1032,8 @@ impl<D: Delegate<Cx = X>, X: Cx> SearchGraph<D, X> {
                         // is not actually equal to the final provisional result. We
                         // need to discard the provisional cache entry in this case.
                         RebaseReason::NoCycleUsages => return false,
-                        RebaseReason::Ambiguity => {
-                            *result = D::propagate_ambiguity(cx, input, *result);
+                        RebaseReason::Ambiguity(info) => {
+                            *result = D::propagate_ambiguity(cx, input, info);
                         }
                         RebaseReason::Overflow => *result = D::fixpoint_overflow_result(cx, input),
                         RebaseReason::ReachedFixpoint(None) => {}
@@ -1268,6 +1271,7 @@ impl<D: Delegate<Cx = X>, X: Cx> SearchGraph<D, X> {
     }
 
     /// Whether we've reached a fixpoint when evaluating a cycle head.
+    #[instrument(level = "trace", skip(self, stack_entry), ret)]
     fn reached_fixpoint(
         &mut self,
         stack_entry: &StackEntry<X>,
@@ -1355,8 +1359,12 @@ impl<D: Delegate<Cx = X>, X: Cx> SearchGraph<D, X> {
             // As we only get to this branch if we haven't yet reached a fixpoint,
             // we also taint all provisional cache entries which depend on the
             // current goal.
-            if D::is_ambiguous_result(result) {
-                self.rebase_provisional_cache_entries(cx, &stack_entry, RebaseReason::Ambiguity);
+            if let Some(info) = D::is_ambiguous_result(result) {
+                self.rebase_provisional_cache_entries(
+                    cx,
+                    &stack_entry,
+                    RebaseReason::Ambiguity(info),
+                );
                 return EvaluationResult::finalize(stack_entry, encountered_overflow, result);
             };
 

--- a/compiler/rustc_type_ir/src/search_graph/mod.rs
+++ b/compiler/rustc_type_ir/src/search_graph/mod.rs
@@ -969,10 +969,6 @@ impl<D: Delegate<Cx = X>, X: Cx> SearchGraph<D, X> {
                     return true;
                 };
 
-                let Some(new_highest_head_index) = heads.opt_highest_cycle_head_index() else {
-                    return false;
-                };
-
                 // We're rebasing an entry `e` over a head `p`. This head
                 // has a number of own heads `h` it depends on.
                 //
@@ -1045,6 +1041,10 @@ impl<D: Delegate<Cx = X>, X: Cx> SearchGraph<D, X> {
                         }
                     };
                 }
+
+                let Some(new_highest_head_index) = heads.opt_highest_cycle_head_index() else {
+                    return false;
+                };
 
                 // We now care about the path from the next highest cycle head to the
                 // provisional cache entry.

--- a/library/core/src/clone.rs
+++ b/library/core/src/clone.rs
@@ -575,7 +575,8 @@ mod impls {
         ($($t:ty)*) => {
             $(
                 #[stable(feature = "rust1", since = "1.0.0")]
-                impl Clone for $t {
+                #[rustc_const_unstable(feature = "const_clone", issue = "142757")]
+                impl const Clone for $t {
                     #[inline(always)]
                     fn clone(&self) -> Self {
                         *self
@@ -593,7 +594,8 @@ mod impls {
     }
 
     #[unstable(feature = "never_type", issue = "35121")]
-    impl Clone for ! {
+    #[rustc_const_unstable(feature = "const_clone", issue = "142757")]
+    impl const Clone for ! {
         #[inline]
         fn clone(&self) -> Self {
             *self
@@ -601,7 +603,8 @@ mod impls {
     }
 
     #[stable(feature = "rust1", since = "1.0.0")]
-    impl<T: PointeeSized> Clone for *const T {
+    #[rustc_const_unstable(feature = "const_clone", issue = "142757")]
+    impl<T: PointeeSized> const Clone for *const T {
         #[inline(always)]
         fn clone(&self) -> Self {
             *self
@@ -609,7 +612,8 @@ mod impls {
     }
 
     #[stable(feature = "rust1", since = "1.0.0")]
-    impl<T: PointeeSized> Clone for *mut T {
+    #[rustc_const_unstable(feature = "const_clone", issue = "142757")]
+    impl<T: PointeeSized> const Clone for *mut T {
         #[inline(always)]
         fn clone(&self) -> Self {
             *self
@@ -618,7 +622,8 @@ mod impls {
 
     /// Shared references can be cloned, but mutable references *cannot*!
     #[stable(feature = "rust1", since = "1.0.0")]
-    impl<T: PointeeSized> Clone for &T {
+    #[rustc_const_unstable(feature = "const_clone", issue = "142757")]
+    impl<T: PointeeSized> const Clone for &T {
         #[inline(always)]
         #[rustc_diagnostic_item = "noop_method_clone"]
         fn clone(&self) -> Self {

--- a/library/core/src/num/bignum.rs
+++ b/library/core/src/num/bignum.rs
@@ -59,8 +59,7 @@ impl_full_ops! {
     u8:  add(intrinsics::u8_add_with_overflow),  mul/div(u16);
     u16: add(intrinsics::u16_add_with_overflow), mul/div(u32);
     u32: add(intrinsics::u32_add_with_overflow), mul/div(u64);
-    // See RFC #521 for enabling this.
-    // u64: add(intrinsics::u64_add_with_overflow), mul/div(u128);
+    u64: add(intrinsics::u64_add_with_overflow), mul/div(u128);
 }
 
 /// Table of powers of 5 representable in digits. Specifically, the largest {u8, u16, u32} value

--- a/library/core/src/slice/index.rs
+++ b/library/core/src/slice/index.rs
@@ -564,7 +564,10 @@ unsafe impl<T> const SliceIndex<[T]> for ops::RangeFrom<usize> {
             slice_index_fail(self.start, slice.len(), slice.len())
         }
         // SAFETY: `self` is checked to be valid and in bounds above.
-        unsafe { &*self.get_unchecked(slice) }
+        unsafe {
+            let new_len = crate::intrinsics::unchecked_sub(slice.len(), self.start);
+            &*get_offset_len_noubcheck(slice, self.start, new_len)
+        }
     }
 
     #[inline]
@@ -573,7 +576,10 @@ unsafe impl<T> const SliceIndex<[T]> for ops::RangeFrom<usize> {
             slice_index_fail(self.start, slice.len(), slice.len())
         }
         // SAFETY: `self` is checked to be valid and in bounds above.
-        unsafe { &mut *self.get_unchecked_mut(slice) }
+        unsafe {
+            let new_len = crate::intrinsics::unchecked_sub(slice.len(), self.start);
+            &mut *get_offset_len_mut_noubcheck(slice, self.start, new_len)
+        }
     }
 }
 

--- a/library/proc_macro/src/bridge/client.rs
+++ b/library/proc_macro/src/bridge/client.rs
@@ -58,7 +58,7 @@ macro_rules! define_client_handles {
                 }
             }
 
-            impl<S> DecodeMut<'_, '_, S> for $oty {
+            impl<S> Decode<'_, '_, S> for $oty {
                 fn decode(r: &mut Reader<'_>, s: &mut S) -> Self {
                     $oty {
                         handle: handle::Handle::decode(r, s),
@@ -82,7 +82,7 @@ macro_rules! define_client_handles {
                 }
             }
 
-            impl<S> DecodeMut<'_, '_, S> for $ity {
+            impl<S> Decode<'_, '_, S> for $ity {
                 fn decode(r: &mut Reader<'_>, s: &mut S) -> Self {
                     $ity {
                         handle: handle::Handle::decode(r, s),
@@ -276,7 +276,7 @@ fn maybe_install_panic_hook(force_show_panics: bool) {
 /// Client-side helper for handling client panics, entering the bridge,
 /// deserializing input and serializing output.
 // FIXME(eddyb) maybe replace `Bridge::enter` with this?
-fn run_client<A: for<'a, 's> DecodeMut<'a, 's, ()>, R: Encode<()>>(
+fn run_client<A: for<'a, 's> Decode<'a, 's, ()>, R: Encode<()>>(
     config: BridgeConfig<'_>,
     f: impl FnOnce(A) -> R,
 ) -> Buffer {

--- a/library/proc_macro/src/bridge/mod.rs
+++ b/library/proc_macro/src/bridge/mod.rs
@@ -143,7 +143,7 @@ mod symbol;
 
 use buffer::Buffer;
 pub use rpc::PanicMessage;
-use rpc::{DecodeMut, Encode, Reader, Writer};
+use rpc::{Decode, Encode, Reader, Writer};
 
 /// Configuration for establishing an active connection between a server and a
 /// client.  The server creates the bridge config (`run_server` in `server.rs`),
@@ -168,7 +168,7 @@ impl !Sync for BridgeConfig<'_> {}
 #[forbid(unsafe_code)]
 #[allow(non_camel_case_types)]
 mod api_tags {
-    use super::rpc::{DecodeMut, Encode, Reader, Writer};
+    use super::rpc::{Decode, Encode, Reader, Writer};
 
     macro_rules! declare_tags {
         ($($name:ident {

--- a/library/proc_macro/src/bridge/rpc.rs
+++ b/library/proc_macro/src/bridge/rpc.rs
@@ -58,16 +58,11 @@ macro_rules! rpc_encode_decode {
             fn encode(self, w: &mut Writer, s: &mut S) {
                 // HACK(eddyb): `Tag` enum duplicated between the
                 // two impls as there's no other place to stash it.
-                #[allow(non_upper_case_globals)]
-                mod tag {
-                    #[repr(u8)] enum Tag { $($variant),* }
-
-                    $(pub(crate) const $variant: u8 = Tag::$variant as u8;)*
-                }
+                #[repr(u8)] enum Tag { $($variant),* }
 
                 match self {
                     $($name::$variant $(($field))* => {
-                        tag::$variant.encode(w, s);
+                        (Tag::$variant as u8).encode(w, s);
                         $($field.encode(w, s);)*
                     })*
                 }

--- a/library/proc_macro/src/bridge/rpc.rs
+++ b/library/proc_macro/src/bridge/rpc.rs
@@ -12,7 +12,7 @@ pub(super) trait Encode<S>: Sized {
 
 pub(super) type Reader<'a> = &'a [u8];
 
-pub(super) trait DecodeMut<'a, 's, S>: Sized {
+pub(super) trait Decode<'a, 's, S>: Sized {
     fn decode(r: &mut Reader<'a>, s: &'s mut S) -> Self;
 }
 
@@ -24,7 +24,7 @@ macro_rules! rpc_encode_decode {
             }
         }
 
-        impl<S> DecodeMut<'_, '_, S> for $ty {
+        impl<S> Decode<'_, '_, S> for $ty {
             fn decode(r: &mut Reader<'_>, _: &mut S) -> Self {
                 const N: usize = size_of::<$ty>();
 
@@ -43,12 +43,12 @@ macro_rules! rpc_encode_decode {
             }
         }
 
-        impl<'a, S, $($($T: for<'s> DecodeMut<'a, 's, S>),+)?> DecodeMut<'a, '_, S>
+        impl<'a, S, $($($T: for<'s> Decode<'a, 's, S>),+)?> Decode<'a, '_, S>
             for $name $(<$($T),+>)?
         {
             fn decode(r: &mut Reader<'a>, s: &mut S) -> Self {
                 $name {
-                    $($field: DecodeMut::decode(r, s)),*
+                    $($field: Decode::decode(r, s)),*
                 }
             }
         }
@@ -69,7 +69,7 @@ macro_rules! rpc_encode_decode {
             }
         }
 
-        impl<'a, S, $($($T: for<'s> DecodeMut<'a, 's, S>),+)?> DecodeMut<'a, '_, S>
+        impl<'a, S, $($($T: for<'s> Decode<'a, 's, S>),+)?> Decode<'a, '_, S>
             for $name $(<$($T),+>)?
         {
             fn decode(r: &mut Reader<'a>, s: &mut S) -> Self {
@@ -84,7 +84,7 @@ macro_rules! rpc_encode_decode {
 
                 match u8::decode(r, s) {
                     $(tag::$variant => {
-                        $(let $field = DecodeMut::decode(r, s);)*
+                        $(let $field = Decode::decode(r, s);)*
                         $name::$variant $(($field))*
                     })*
                     _ => unreachable!(),
@@ -98,7 +98,7 @@ impl<S> Encode<S> for () {
     fn encode(self, _: &mut Writer, _: &mut S) {}
 }
 
-impl<S> DecodeMut<'_, '_, S> for () {
+impl<S> Decode<'_, '_, S> for () {
     fn decode(_: &mut Reader<'_>, _: &mut S) -> Self {}
 }
 
@@ -108,7 +108,7 @@ impl<S> Encode<S> for u8 {
     }
 }
 
-impl<S> DecodeMut<'_, '_, S> for u8 {
+impl<S> Decode<'_, '_, S> for u8 {
     fn decode(r: &mut Reader<'_>, _: &mut S) -> Self {
         let x = r[0];
         *r = &r[1..];
@@ -125,7 +125,7 @@ impl<S> Encode<S> for bool {
     }
 }
 
-impl<S> DecodeMut<'_, '_, S> for bool {
+impl<S> Decode<'_, '_, S> for bool {
     fn decode(r: &mut Reader<'_>, s: &mut S) -> Self {
         match u8::decode(r, s) {
             0 => false,
@@ -141,7 +141,7 @@ impl<S> Encode<S> for char {
     }
 }
 
-impl<S> DecodeMut<'_, '_, S> for char {
+impl<S> Decode<'_, '_, S> for char {
     fn decode(r: &mut Reader<'_>, s: &mut S) -> Self {
         char::from_u32(u32::decode(r, s)).unwrap()
     }
@@ -153,7 +153,7 @@ impl<S> Encode<S> for NonZero<u32> {
     }
 }
 
-impl<S> DecodeMut<'_, '_, S> for NonZero<u32> {
+impl<S> Decode<'_, '_, S> for NonZero<u32> {
     fn decode(r: &mut Reader<'_>, s: &mut S) -> Self {
         Self::new(u32::decode(r, s)).unwrap()
     }
@@ -166,11 +166,11 @@ impl<S, A: Encode<S>, B: Encode<S>> Encode<S> for (A, B) {
     }
 }
 
-impl<'a, S, A: for<'s> DecodeMut<'a, 's, S>, B: for<'s> DecodeMut<'a, 's, S>> DecodeMut<'a, '_, S>
+impl<'a, S, A: for<'s> Decode<'a, 's, S>, B: for<'s> Decode<'a, 's, S>> Decode<'a, '_, S>
     for (A, B)
 {
     fn decode(r: &mut Reader<'a>, s: &mut S) -> Self {
-        (DecodeMut::decode(r, s), DecodeMut::decode(r, s))
+        (Decode::decode(r, s), Decode::decode(r, s))
     }
 }
 
@@ -181,7 +181,7 @@ impl<S> Encode<S> for &[u8] {
     }
 }
 
-impl<'a, S> DecodeMut<'a, '_, S> for &'a [u8] {
+impl<'a, S> Decode<'a, '_, S> for &'a [u8] {
     fn decode(r: &mut Reader<'a>, s: &mut S) -> Self {
         let len = usize::decode(r, s);
         let xs = &r[..len];
@@ -196,7 +196,7 @@ impl<S> Encode<S> for &str {
     }
 }
 
-impl<'a, S> DecodeMut<'a, '_, S> for &'a str {
+impl<'a, S> Decode<'a, '_, S> for &'a str {
     fn decode(r: &mut Reader<'a>, s: &mut S) -> Self {
         str::from_utf8(<&[u8]>::decode(r, s)).unwrap()
     }
@@ -208,7 +208,7 @@ impl<S> Encode<S> for String {
     }
 }
 
-impl<S> DecodeMut<'_, '_, S> for String {
+impl<S> Decode<'_, '_, S> for String {
     fn decode(r: &mut Reader<'_>, s: &mut S) -> Self {
         <&str>::decode(r, s).to_string()
     }
@@ -223,7 +223,7 @@ impl<S, T: Encode<S>> Encode<S> for Vec<T> {
     }
 }
 
-impl<'a, S, T: for<'s> DecodeMut<'a, 's, S>> DecodeMut<'a, '_, S> for Vec<T> {
+impl<'a, S, T: for<'s> Decode<'a, 's, S>> Decode<'a, '_, S> for Vec<T> {
     fn decode(r: &mut Reader<'a>, s: &mut S) -> Self {
         let len = usize::decode(r, s);
         let mut vec = Vec::with_capacity(len);
@@ -283,7 +283,7 @@ impl<S> Encode<S> for PanicMessage {
     }
 }
 
-impl<S> DecodeMut<'_, '_, S> for PanicMessage {
+impl<S> Decode<'_, '_, S> for PanicMessage {
     fn decode(r: &mut Reader<'_>, s: &mut S) -> Self {
         match Option::<String>::decode(r, s) {
             Some(s) => PanicMessage::String(s),

--- a/library/proc_macro/src/bridge/selfless_reify.rs
+++ b/library/proc_macro/src/bridge/selfless_reify.rs
@@ -50,7 +50,7 @@ macro_rules! define_reify_functions {
         >(f: F) -> $(extern $abi)? fn($($arg_ty),*) -> $ret_ty {
             // FIXME(eddyb) describe the `F` type (e.g. via `type_name::<F>`) once panic
             // formatting becomes possible in `const fn`.
-            assert!(size_of::<F>() == 0, "selfless_reify: closure must be zero-sized");
+            const { assert!(size_of::<F>() == 0, "selfless_reify: closure must be zero-sized"); }
 
             $(extern $abi)? fn wrapper<
                 $($($param,)*)?

--- a/library/proc_macro/src/bridge/server.rs
+++ b/library/proc_macro/src/bridge/server.rs
@@ -32,7 +32,7 @@ macro_rules! define_server_handles {
                 }
             }
 
-            impl<S: Types> DecodeMut<'_, '_, HandleStore<MarkedTypes<S>>>
+            impl<S: Types> Decode<'_, '_, HandleStore<MarkedTypes<S>>>
                 for Marked<S::$oty, client::$oty>
             {
                 fn decode(r: &mut Reader<'_>, s: &mut HandleStore<MarkedTypes<S>>) -> Self {
@@ -40,7 +40,7 @@ macro_rules! define_server_handles {
                 }
             }
 
-            impl<'s, S: Types> DecodeMut<'_, 's, HandleStore<MarkedTypes<S>>>
+            impl<'s, S: Types> Decode<'_, 's, HandleStore<MarkedTypes<S>>>
                 for &'s Marked<S::$oty, client::$oty>
             {
                 fn decode(r: &mut Reader<'_>, s: &'s mut HandleStore<MarkedTypes<S>>) -> Self {
@@ -48,7 +48,7 @@ macro_rules! define_server_handles {
                 }
             }
 
-            impl<'s, S: Types> DecodeMut<'_, 's, HandleStore<MarkedTypes<S>>>
+            impl<'s, S: Types> Decode<'_, 's, HandleStore<MarkedTypes<S>>>
                 for &'s mut Marked<S::$oty, client::$oty>
             {
                 fn decode(
@@ -67,7 +67,7 @@ macro_rules! define_server_handles {
                 }
             }
 
-            impl<S: Types> DecodeMut<'_, '_, HandleStore<MarkedTypes<S>>>
+            impl<S: Types> Decode<'_, '_, HandleStore<MarkedTypes<S>>>
                 for Marked<S::$ity, client::$ity>
             {
                 fn decode(r: &mut Reader<'_>, s: &mut HandleStore<MarkedTypes<S>>) -> Self {
@@ -355,7 +355,7 @@ pub trait MessagePipe<T>: Sized {
 fn run_server<
     S: Server,
     I: Encode<HandleStore<MarkedTypes<S>>>,
-    O: for<'a, 's> DecodeMut<'a, 's, HandleStore<MarkedTypes<S>>>,
+    O: for<'a, 's> Decode<'a, 's, HandleStore<MarkedTypes<S>>>,
 >(
     strategy: &impl ExecutionStrategy,
     handle_counters: &'static client::HandleCounters,

--- a/library/proc_macro/src/bridge/symbol.rs
+++ b/library/proc_macro/src/bridge/symbol.rs
@@ -102,7 +102,7 @@ impl<S> Encode<S> for Symbol {
     }
 }
 
-impl<S: server::Server> DecodeMut<'_, '_, server::HandleStore<server::MarkedTypes<S>>>
+impl<S: server::Server> Decode<'_, '_, server::HandleStore<server::MarkedTypes<S>>>
     for Marked<S::Symbol, Symbol>
 {
     fn decode(r: &mut Reader<'_>, s: &mut server::HandleStore<server::MarkedTypes<S>>) -> Self {
@@ -118,7 +118,7 @@ impl<S: server::Server> Encode<server::HandleStore<server::MarkedTypes<S>>>
     }
 }
 
-impl<S> DecodeMut<'_, '_, S> for Symbol {
+impl<S> Decode<'_, '_, S> for Symbol {
     fn decode(r: &mut Reader<'_>, s: &mut S) -> Self {
         Symbol::new(<&str>::decode(r, s))
     }

--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -420,6 +420,9 @@ pub fn write<P: AsRef<Path>, C: AsRef<[u8]>>(path: P, contents: C) -> io::Result
 /// }
 /// ```
 #[unstable(feature = "fs_set_times", issue = "147455")]
+#[doc(alias = "utimens")]
+#[doc(alias = "utimes")]
+#[doc(alias = "utime")]
 pub fn set_times<P: AsRef<Path>>(path: P, times: FileTimes) -> io::Result<()> {
     fs_imp::set_times(path.as_ref(), times.0)
 }

--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -395,8 +395,8 @@ pub fn write<P: AsRef<Path>, C: AsRef<[u8]>>(path: P, contents: C) -> io::Result
 ///
 /// # Platform-specific behavior
 ///
-/// This function currently corresponds to the `utimensat` function on Unix platforms
-/// and the `SetFileTime` function on Windows.
+/// This function currently corresponds to the `utimensat` function on Unix platforms, the
+/// `setattrlist` function on Apple platforms, and the `SetFileTime` function on Windows.
 ///
 /// # Errors
 ///

--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -387,6 +387,80 @@ pub fn write<P: AsRef<Path>, C: AsRef<[u8]>>(path: P, contents: C) -> io::Result
     inner(path.as_ref(), contents.as_ref())
 }
 
+/// Changes the timestamps of the file or directory at the specified path.
+///
+/// This function will attempt to set the access and modification times
+/// to the times specified. If the path refers to a symbolic link, this function
+/// will follow the link and change the timestamps of the target file.
+///
+/// # Platform-specific behavior
+///
+/// This function currently corresponds to the `utimensat` function on Unix platforms
+/// and the `SetFileTime` function on Windows.
+///
+/// # Errors
+///
+/// This function will return an error if the user lacks permission to change timestamps on the
+/// target file or symlink. It may also return an error if the OS does not support it.
+///
+/// # Examples
+///
+/// ```no_run
+/// #![feature(fs_set_times)]
+/// use std::fs::{self, FileTimes};
+/// use std::time::SystemTime;
+///
+/// fn main() -> std::io::Result<()> {
+///     let now = SystemTime::now();
+///     let times = FileTimes::new()
+///         .set_accessed(now)
+///         .set_modified(now);
+///     fs::set_times("foo.txt", times)?;
+///     Ok(())
+/// }
+/// ```
+#[unstable(feature = "fs_set_times", issue = "147455")]
+pub fn set_times<P: AsRef<Path>>(path: P, times: FileTimes) -> io::Result<()> {
+    fs_imp::set_times(path.as_ref(), times.0)
+}
+
+/// Changes the timestamps of the file or symlink at the specified path.
+///
+/// This function will attempt to set the access and modification times
+/// to the times specified. Differ from `set_times`, if the path refers to a symbolic link,
+/// this function will change the timestamps of the symlink itself, not the target file.
+///
+/// # Platform-specific behavior
+///
+/// This function currently corresponds to the `utimensat` function with `AT_SYMLINK_NOFOLLOW`
+/// on Unix platforms and the `SetFileTime` function on Windows after opening the symlink.
+///
+/// # Errors
+///
+/// This function will return an error if the user lacks permission to change timestamps on the
+/// target file or symlink. It may also return an error if the OS does not support it.
+///
+/// # Examples
+///
+/// ```no_run
+/// #![feature(fs_set_times)]
+/// use std::fs::{self, FileTimes};
+/// use std::time::SystemTime;
+///
+/// fn main() -> std::io::Result<()> {
+///     let now = SystemTime::now();
+///     let times = FileTimes::new()
+///         .set_accessed(now)
+///         .set_modified(now);
+///     fs::set_times_nofollow("symlink.txt", times)?;
+///     Ok(())
+/// }
+/// ```
+#[unstable(feature = "fs_set_times", issue = "147455")]
+pub fn set_times_nofollow<P: AsRef<Path>>(path: P, times: FileTimes) -> io::Result<()> {
+    fs_imp::set_times_nofollow(path.as_ref(), times.0)
+}
+
 #[stable(feature = "file_lock", since = "1.89.0")]
 impl error::Error for TryLockError {}
 

--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -432,8 +432,9 @@ pub fn set_times<P: AsRef<Path>>(path: P, times: FileTimes) -> io::Result<()> {
 ///
 /// # Platform-specific behavior
 ///
-/// This function currently corresponds to the `utimensat` function with `AT_SYMLINK_NOFOLLOW`
-/// on Unix platforms and the `SetFileTime` function on Windows after opening the symlink.
+/// This function currently corresponds to the `utimensat` function with `AT_SYMLINK_NOFOLLOW` on
+/// Unix platforms, the `setattrlist` function with `FSOPT_NOFOLLOW` on Apple platforms, and the
+/// `SetFileTime` function on Windows.
 ///
 /// # Errors
 ///

--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -458,6 +458,9 @@ pub fn set_times<P: AsRef<Path>>(path: P, times: FileTimes) -> io::Result<()> {
 /// }
 /// ```
 #[unstable(feature = "fs_set_times", issue = "147455")]
+#[doc(alias = "utimensat")]
+#[doc(alias = "lutimens")]
+#[doc(alias = "lutimes")]
 pub fn set_times_nofollow<P: AsRef<Path>>(path: P, times: FileTimes) -> io::Result<()> {
     fs_imp::set_times_nofollow(path.as_ref(), times.0)
 }

--- a/library/std/src/fs/tests.rs
+++ b/library/std/src/fs/tests.rs
@@ -2226,3 +2226,222 @@ fn test_open_options_invalid_combinations() {
     assert_eq!(err.kind(), ErrorKind::InvalidInput);
     assert_eq!(err.to_string(), "must specify at least one of read, write, or append access");
 }
+
+#[test]
+fn test_fs_set_times() {
+    #[cfg(target_vendor = "apple")]
+    use crate::os::darwin::fs::FileTimesExt;
+    #[cfg(windows)]
+    use crate::os::windows::fs::FileTimesExt;
+
+    let tmp = tmpdir();
+    let path = tmp.join("foo");
+    File::create(&path).unwrap();
+
+    let mut times = FileTimes::new();
+    let accessed = SystemTime::UNIX_EPOCH + Duration::from_secs(12345);
+    let modified = SystemTime::UNIX_EPOCH + Duration::from_secs(54321);
+    times = times.set_accessed(accessed).set_modified(modified);
+
+    #[cfg(any(windows, target_vendor = "apple"))]
+    let created = SystemTime::UNIX_EPOCH + Duration::from_secs(32123);
+    #[cfg(any(windows, target_vendor = "apple"))]
+    {
+        times = times.set_created(created);
+    }
+
+    match fs::set_times(&path, times) {
+        // Allow unsupported errors on platforms which don't support setting times.
+        #[cfg(not(any(
+            windows,
+            all(
+                unix,
+                not(any(
+                    target_os = "android",
+                    target_os = "redox",
+                    target_os = "espidf",
+                    target_os = "horizon"
+                ))
+            )
+        )))]
+        Err(e) if e.kind() == ErrorKind::Unsupported => return,
+        Err(e) => panic!("error setting file times: {e:?}"),
+        Ok(_) => {}
+    }
+
+    let metadata = fs::metadata(&path).unwrap();
+    assert_eq!(metadata.accessed().unwrap(), accessed);
+    assert_eq!(metadata.modified().unwrap(), modified);
+    #[cfg(any(windows, target_vendor = "apple"))]
+    {
+        assert_eq!(metadata.created().unwrap(), created);
+    }
+}
+
+#[test]
+fn test_fs_set_times_follows_symlink() {
+    #[cfg(target_vendor = "apple")]
+    use crate::os::darwin::fs::FileTimesExt;
+    #[cfg(windows)]
+    use crate::os::windows::fs::FileTimesExt;
+
+    let tmp = tmpdir();
+
+    // Create a target file
+    let target = tmp.join("target");
+    File::create(&target).unwrap();
+
+    // Create a symlink to the target
+    #[cfg(unix)]
+    let link = tmp.join("link");
+    #[cfg(unix)]
+    crate::os::unix::fs::symlink(&target, &link).unwrap();
+
+    #[cfg(windows)]
+    let link = tmp.join("link.txt");
+    #[cfg(windows)]
+    crate::os::windows::fs::symlink_file(&target, &link).unwrap();
+
+    // Get the symlink's own modified time BEFORE calling set_times (to compare later)
+    // We don't check accessed time because reading metadata may update atime on some platforms.
+    let link_metadata_before = fs::symlink_metadata(&link).unwrap();
+    let link_modified_before = link_metadata_before.modified().unwrap();
+
+    let mut times = FileTimes::new();
+    let accessed = SystemTime::UNIX_EPOCH + Duration::from_secs(12345);
+    let modified = SystemTime::UNIX_EPOCH + Duration::from_secs(54321);
+    times = times.set_accessed(accessed).set_modified(modified);
+
+    #[cfg(any(windows, target_vendor = "apple"))]
+    let created = SystemTime::UNIX_EPOCH + Duration::from_secs(32123);
+    #[cfg(any(windows, target_vendor = "apple"))]
+    {
+        times = times.set_created(created);
+    }
+
+    // Call fs::set_times on the symlink - it should follow the link and modify the target
+    match fs::set_times(&link, times) {
+        // Allow unsupported errors on platforms which don't support setting times.
+        #[cfg(not(any(
+            windows,
+            all(
+                unix,
+                not(any(
+                    target_os = "android",
+                    target_os = "redox",
+                    target_os = "espidf",
+                    target_os = "horizon"
+                ))
+            )
+        )))]
+        Err(e) if e.kind() == ErrorKind::Unsupported => return,
+        Err(e) => panic!("error setting file times through symlink: {e:?}"),
+        Ok(_) => {}
+    }
+
+    // Verify that the TARGET file's times were changed (following the symlink)
+    let target_metadata = fs::metadata(&target).unwrap();
+    assert_eq!(
+        target_metadata.accessed().unwrap(),
+        accessed,
+        "target file accessed time should match"
+    );
+    assert_eq!(
+        target_metadata.modified().unwrap(),
+        modified,
+        "target file modified time should match"
+    );
+    #[cfg(any(windows, target_vendor = "apple"))]
+    {
+        assert_eq!(
+            target_metadata.created().unwrap(),
+            created,
+            "target file created time should match"
+        );
+    }
+
+    // Also verify through the symlink (fs::metadata follows symlinks)
+    let link_followed_metadata = fs::metadata(&link).unwrap();
+    assert_eq!(link_followed_metadata.accessed().unwrap(), accessed);
+    assert_eq!(link_followed_metadata.modified().unwrap(), modified);
+
+    // Verify that the SYMLINK ITSELF was NOT modified
+    // Note: We only check modified time, not accessed time, because reading the symlink
+    // metadata may update its atime on some platforms (e.g., Linux).
+    let link_metadata_after = fs::symlink_metadata(&link).unwrap();
+    assert_eq!(
+        link_metadata_after.modified().unwrap(),
+        link_modified_before,
+        "symlink's own modified time should not change"
+    );
+}
+
+#[test]
+fn test_fs_set_times_nofollow() {
+    #[cfg(target_vendor = "apple")]
+    use crate::os::darwin::fs::FileTimesExt;
+    #[cfg(windows)]
+    use crate::os::windows::fs::FileTimesExt;
+
+    let tmp = tmpdir();
+
+    // Create a target file and a symlink to it
+    let target = tmp.join("target");
+    File::create(&target).unwrap();
+
+    #[cfg(unix)]
+    let link = tmp.join("link");
+    #[cfg(unix)]
+    crate::os::unix::fs::symlink(&target, &link).unwrap();
+
+    #[cfg(windows)]
+    let link = tmp.join("link.txt");
+    #[cfg(windows)]
+    crate::os::windows::fs::symlink_file(&target, &link).unwrap();
+
+    let mut times = FileTimes::new();
+    let accessed = SystemTime::UNIX_EPOCH + Duration::from_secs(11111);
+    let modified = SystemTime::UNIX_EPOCH + Duration::from_secs(22222);
+    times = times.set_accessed(accessed).set_modified(modified);
+
+    #[cfg(any(windows, target_vendor = "apple"))]
+    let created = SystemTime::UNIX_EPOCH + Duration::from_secs(33333);
+    #[cfg(any(windows, target_vendor = "apple"))]
+    {
+        times = times.set_created(created);
+    }
+
+    // Set times on the symlink itself (not following it)
+    match fs::set_times_nofollow(&link, times) {
+        // Allow unsupported errors on platforms which don't support setting times.
+        #[cfg(not(any(
+            windows,
+            all(
+                unix,
+                not(any(
+                    target_os = "android",
+                    target_os = "redox",
+                    target_os = "espidf",
+                    target_os = "horizon"
+                ))
+            )
+        )))]
+        Err(e) if e.kind() == ErrorKind::Unsupported => return,
+        Err(e) => panic!("error setting symlink times: {e:?}"),
+        Ok(_) => {}
+    }
+
+    // Read symlink metadata (without following)
+    let metadata = fs::symlink_metadata(&link).unwrap();
+    assert_eq!(metadata.accessed().unwrap(), accessed);
+    assert_eq!(metadata.modified().unwrap(), modified);
+    #[cfg(any(windows, target_vendor = "apple"))]
+    {
+        assert_eq!(metadata.created().unwrap(), created);
+    }
+
+    // Verify that the target file's times were NOT changed
+    let target_metadata = fs::metadata(&target).unwrap();
+    assert_ne!(target_metadata.accessed().unwrap(), accessed);
+    assert_ne!(target_metadata.modified().unwrap(), modified);
+}

--- a/library/std/src/sys/fs/hermit.rs
+++ b/library/std/src/sys/fs/hermit.rs
@@ -566,6 +566,14 @@ pub fn set_perm(_p: &Path, _perm: FilePermissions) -> io::Result<()> {
     Err(Error::from_raw_os_error(22))
 }
 
+pub fn set_times(_p: &Path, _times: FileTimes) -> io::Result<()> {
+    Err(Error::from_raw_os_error(22))
+}
+
+pub fn set_times_nofollow(_p: &Path, _times: FileTimes) -> io::Result<()> {
+    Err(Error::from_raw_os_error(22))
+}
+
 pub fn rmdir(path: &Path) -> io::Result<()> {
     run_path_with_cstr(path, &|path| cvt(unsafe { hermit_abi::rmdir(path.as_ptr()) }).map(|_| ()))
 }

--- a/library/std/src/sys/fs/mod.rs
+++ b/library/std/src/sys/fs/mod.rs
@@ -161,3 +161,11 @@ pub fn exists(path: &Path) -> io::Result<bool> {
     #[cfg(windows)]
     with_native_path(path, &imp::exists)
 }
+
+pub fn set_times(path: &Path, times: FileTimes) -> io::Result<()> {
+    with_native_path(path, &|path| imp::set_times(path, times.clone()))
+}
+
+pub fn set_times_nofollow(path: &Path, times: FileTimes) -> io::Result<()> {
+    with_native_path(path, &|path| imp::set_times_nofollow(path, times.clone()))
+}

--- a/library/std/src/sys/fs/solid.rs
+++ b/library/std/src/sys/fs/solid.rs
@@ -538,6 +538,17 @@ pub fn set_perm(p: &Path, perm: FilePermissions) -> io::Result<()> {
     Ok(())
 }
 
+pub fn set_times(_p: &Path, _times: FileTimes) -> io::Result<()> {
+    Err(io::const_error!(io::ErrorKind::Unsupported, "setting file times not supported",))
+}
+
+pub fn set_times_nofollow(_p: &Path, _times: FileTimes) -> io::Result<()> {
+    Err(io::const_error!(
+        io::ErrorKind::Unsupported,
+        "setting file times on symlinks not supported",
+    ))
+}
+
 pub fn rmdir(p: &Path) -> io::Result<()> {
     if stat(p)?.file_type().is_dir() {
         error::SolidError::err_if_negative(unsafe { abi::SOLID_FS_Unlink(cstr(p)?.as_ptr()) })

--- a/library/std/src/sys/fs/solid.rs
+++ b/library/std/src/sys/fs/solid.rs
@@ -539,14 +539,11 @@ pub fn set_perm(p: &Path, perm: FilePermissions) -> io::Result<()> {
 }
 
 pub fn set_times(_p: &Path, _times: FileTimes) -> io::Result<()> {
-    Err(io::const_error!(io::ErrorKind::Unsupported, "setting file times not supported",))
+    unsupported()
 }
 
 pub fn set_times_nofollow(_p: &Path, _times: FileTimes) -> io::Result<()> {
-    Err(io::const_error!(
-        io::ErrorKind::Unsupported,
-        "setting file times on symlinks not supported",
-    ))
+    unsupported()
 }
 
 pub fn rmdir(p: &Path) -> io::Result<()> {

--- a/library/std/src/sys/fs/uefi.rs
+++ b/library/std/src/sys/fs/uefi.rs
@@ -333,6 +333,14 @@ pub fn set_perm(_p: &Path, _perm: FilePermissions) -> io::Result<()> {
     unsupported()
 }
 
+pub fn set_times(_p: &Path, _times: FileTimes) -> io::Result<()> {
+    unsupported()
+}
+
+pub fn set_times_nofollow(_p: &Path, _times: FileTimes) -> io::Result<()> {
+    unsupported()
+}
+
 pub fn rmdir(_p: &Path) -> io::Result<()> {
     unsupported()
 }

--- a/library/std/src/sys/fs/unix.rs
+++ b/library/std/src/sys/fs/unix.rs
@@ -2146,7 +2146,7 @@ fn set_times_impl(p: &CStr, times: FileTimes, flags: c_int) -> io::Result<()> {
             // utimensat requires Android API level 19
             cvt(unsafe {
                 weak!(
-                    fn utimensat(dirfd: c_int, path: *const c_char, times: *const libc::timespec, flags: c_int) -> c_int;
+                    fn utimensat(dirfd: c_int, path: *const libc::c_char, times: *const libc::timespec, flags: c_int) -> c_int;
                 );
                 match utimensat.get() {
                     Some(utimensat) => utimensat(libc::AT_FDCWD, p.as_ptr(), times.as_ptr(), flags),

--- a/library/std/src/sys/fs/unix.rs
+++ b/library/std/src/sys/fs/unix.rs
@@ -1201,6 +1201,7 @@ impl fmt::Debug for OpenOptions {
     target_os = "horizon",
     target_os = "nuttx",
 )))]
+#[inline(always)]
 fn to_timespec(time: Option<SystemTime>) -> io::Result<libc::timespec> {
     match time {
         Some(time) if let Some(ts) = time.t.to_timespec() => Ok(ts),
@@ -1217,6 +1218,7 @@ fn to_timespec(time: Option<SystemTime>) -> io::Result<libc::timespec> {
 }
 
 #[cfg(target_vendor = "apple")]
+#[inline(always)]
 fn set_attrlist_with_times(
     times: &FileTimes,
 ) -> io::Result<(libc::attrlist, [mem::MaybeUninit<libc::timespec>; 3], usize)> {

--- a/library/std/src/sys/fs/unsupported.rs
+++ b/library/std/src/sys/fs/unsupported.rs
@@ -316,8 +316,8 @@ pub fn set_times(_p: &Path, _times: FileTimes) -> io::Result<()> {
     unsupported()
 }
 
-pub fn set_times_nofollow(_p: &Path, times: FileTimes) -> io::Result<()> {
-    match times {}
+pub fn set_times_nofollow(_p: &Path, _times: FileTimes) -> io::Result<()> {
+    unsupported()
 }
 
 pub fn rmdir(_p: &Path) -> io::Result<()> {

--- a/library/std/src/sys/fs/unsupported.rs
+++ b/library/std/src/sys/fs/unsupported.rs
@@ -312,6 +312,14 @@ pub fn set_perm(_p: &Path, perm: FilePermissions) -> io::Result<()> {
     match perm.0 {}
 }
 
+pub fn set_times(_p: &Path, times: FileTimes) -> io::Result<()> {
+    match times {}
+}
+
+pub fn set_times_nofollow(_p: &Path, times: FileTimes) -> io::Result<()> {
+    match times {}
+}
+
 pub fn rmdir(_p: &Path) -> io::Result<()> {
     unsupported()
 }

--- a/library/std/src/sys/fs/unsupported.rs
+++ b/library/std/src/sys/fs/unsupported.rs
@@ -312,8 +312,8 @@ pub fn set_perm(_p: &Path, perm: FilePermissions) -> io::Result<()> {
     match perm.0 {}
 }
 
-pub fn set_times(_p: &Path, times: FileTimes) -> io::Result<()> {
-    match times {}
+pub fn set_times(_p: &Path, _times: FileTimes) -> io::Result<()> {
+    unsupported()
 }
 
 pub fn set_times_nofollow(_p: &Path, times: FileTimes) -> io::Result<()> {

--- a/library/std/src/sys/fs/vexos.rs
+++ b/library/std/src/sys/fs/vexos.rs
@@ -492,6 +492,14 @@ pub fn set_perm(_p: &Path, _perm: FilePermissions) -> io::Result<()> {
     unsupported()
 }
 
+pub fn set_times(_p: &Path, _times: FileTimes) -> io::Result<()> {
+    unsupported()
+}
+
+pub fn set_times_nofollow(_p: &Path, _times: FileTimes) -> io::Result<()> {
+    unsupported()
+}
+
 pub fn exists(path: &Path) -> io::Result<bool> {
     run_path_with_cstr(path, &|path| Ok(unsafe { vex_sdk::vexFileStatus(path.as_ptr()) } != 0))
 }

--- a/library/std/src/sys/fs/wasi.rs
+++ b/library/std/src/sys/fs/wasi.rs
@@ -643,6 +643,18 @@ pub fn set_perm(_p: &Path, _perm: FilePermissions) -> io::Result<()> {
     unsupported()
 }
 
+pub fn set_times(_p: &Path, _times: FileTimes) -> io::Result<()> {
+    // File times haven't been fully figured out in wasi yet, so this is
+    // likely temporary
+    unsupported()
+}
+
+pub fn set_times_nofollow(_p: &Path, _times: FileTimes) -> io::Result<()> {
+    // File times haven't been fully figured out in wasi yet, so this is
+    // likely temporary
+    unsupported()
+}
+
 pub fn rmdir(p: &Path) -> io::Result<()> {
     let (dir, file) = open_parent(p)?;
     dir.remove_directory(osstr2str(file.as_ref())?)

--- a/library/std/src/sys/fs/wasi.rs
+++ b/library/std/src/sys/fs/wasi.rs
@@ -536,17 +536,9 @@ impl File {
     }
 
     pub fn set_times(&self, times: FileTimes) -> io::Result<()> {
-        let to_timestamp = |time: Option<SystemTime>| match time {
-            Some(time) if let Some(ts) = time.to_wasi_timestamp() => Ok(ts),
-            Some(_) => Err(io::const_error!(
-                io::ErrorKind::InvalidInput,
-                "timestamp is too large to set as a file time",
-            )),
-            None => Ok(0),
-        };
         self.fd.filestat_set_times(
-            to_timestamp(times.accessed)?,
-            to_timestamp(times.modified)?,
+            to_wasi_timestamp_or_now(times.accessed)?,
+            to_wasi_timestamp_or_now(times.modified)?,
             times.accessed.map_or(0, |_| wasi::FSTFLAGS_ATIM)
                 | times.modified.map_or(0, |_| wasi::FSTFLAGS_MTIM),
         )
@@ -643,16 +635,43 @@ pub fn set_perm(_p: &Path, _perm: FilePermissions) -> io::Result<()> {
     unsupported()
 }
 
-pub fn set_times(_p: &Path, _times: FileTimes) -> io::Result<()> {
-    // File times haven't been fully figured out in wasi yet, so this is
-    // likely temporary
-    unsupported()
+#[inline(always)]
+pub fn set_times(p: &Path, times: FileTimes) -> io::Result<()> {
+    let (dir, file) = open_parent(p)?;
+    set_times_impl(&dir, &file, times, wasi::LOOKUPFLAGS_SYMLINK_FOLLOW)
 }
 
-pub fn set_times_nofollow(_p: &Path, _times: FileTimes) -> io::Result<()> {
-    // File times haven't been fully figured out in wasi yet, so this is
-    // likely temporary
-    unsupported()
+#[inline(always)]
+pub fn set_times_nofollow(p: &Path, times: FileTimes) -> io::Result<()> {
+    let (dir, file) = open_parent(p)?;
+    set_times_impl(&dir, &file, times, 0)
+}
+
+fn to_wasi_timestamp_or_now(time: Option<SystemTime>) -> io::Result<wasi::Timestamp> {
+    match time {
+        Some(time) if let Some(ts) = time.to_wasi_timestamp() => Ok(ts),
+        Some(_) => Err(io::const_error!(
+            io::ErrorKind::InvalidInput,
+            "timestamp is too large to set as a file time",
+        )),
+        None => Ok(0),
+    }
+}
+
+fn set_times_impl(
+    fd: &WasiFd,
+    path: &Path,
+    times: FileTimes,
+    flags: wasi::Lookupflags,
+) -> io::Result<()> {
+    fd.path_filestat_set_times(
+        flags,
+        osstr2str(path.as_ref())?,
+        to_wasi_timestamp_or_now(times.accessed)?,
+        to_wasi_timestamp_or_now(times.modified)?,
+        times.accessed.map_or(0, |_| wasi::FSTFLAGS_ATIM)
+            | times.modified.map_or(0, |_| wasi::FSTFLAGS_MTIM),
+    )
 }
 
 pub fn rmdir(p: &Path) -> io::Result<()> {

--- a/library/std/src/sys/fs/windows.rs
+++ b/library/std/src/sys/fs/windows.rs
@@ -1514,6 +1514,23 @@ pub fn set_perm(p: &WCStr, perm: FilePermissions) -> io::Result<()> {
     }
 }
 
+pub fn set_times(p: &WCStr, times: FileTimes) -> io::Result<()> {
+    let mut opts = OpenOptions::new();
+    opts.write(true);
+    opts.custom_flags(c::FILE_FLAG_BACKUP_SEMANTICS);
+    let file = File::open_native(p, &opts)?;
+    file.set_times(times)
+}
+
+pub fn set_times_nofollow(p: &WCStr, times: FileTimes) -> io::Result<()> {
+    let mut opts = OpenOptions::new();
+    opts.write(true);
+    // `FILE_FLAG_OPEN_REPARSE_POINT` for no_follow behavior
+    opts.custom_flags(c::FILE_FLAG_BACKUP_SEMANTICS | c::FILE_FLAG_OPEN_REPARSE_POINT);
+    let file = File::open_native(p, &opts)?;
+    file.set_times(times)
+}
+
 fn get_path(f: &File) -> io::Result<PathBuf> {
     fill_utf16_buf(
         |buf, sz| unsafe {

--- a/library/std/src/sys/pal/vexos/mod.rs
+++ b/library/std/src/sys/pal/vexos/mod.rs
@@ -1,4 +1,3 @@
-#[path = "../unsupported/os.rs"]
 pub mod os;
 #[path = "../unsupported/pipe.rs"]
 pub mod pipe;

--- a/library/std/src/sys/pal/vexos/os.rs
+++ b/library/std/src/sys/pal/vexos/os.rs
@@ -1,0 +1,19 @@
+#[expect(dead_code)]
+#[path = "../unsupported/os.rs"]
+mod unsupported_os;
+pub use unsupported_os::{
+    JoinPathsError, SplitPaths, chdir, current_exe, errno, error_string, getcwd, getpid, home_dir,
+    join_paths, split_paths, temp_dir,
+};
+
+pub use super::unsupported;
+
+pub fn exit(_code: i32) -> ! {
+    unsafe {
+        vex_sdk::vexSystemExitRequest();
+
+        loop {
+            vex_sdk::vexTasksRun();
+        }
+    }
+}

--- a/src/bootstrap/src/core/build_steps/run.rs
+++ b/src/bootstrap/src/core/build_steps/run.rs
@@ -263,6 +263,8 @@ impl Step for GenerateCopyright {
             cache_dir
         };
 
+        let _guard = builder.group("generate-copyright");
+
         let mut cmd = builder.tool_cmd(Tool::GenerateCopyright);
         cmd.env("CARGO_MANIFESTS", &cargo_manifests);
         cmd.env("LICENSE_METADATA", &license_metadata);

--- a/src/bootstrap/src/core/build_steps/vendor.rs
+++ b/src/bootstrap/src/core/build_steps/vendor.rs
@@ -74,7 +74,7 @@ impl Step for Vendor {
     /// This function runs `cargo vendor` and ensures all required submodules
     /// are initialized before vendoring begins.
     fn run(self, builder: &Builder<'_>) -> Self::Output {
-        builder.info(&format!("Vendoring sources to {:?}", self.root_dir));
+        let _guard = builder.group(&format!("Vendoring sources to {:?}", self.root_dir));
 
         let mut cmd = command(&builder.initial_cargo);
         cmd.arg("vendor");

--- a/src/ci/docker/host-x86_64/dist-various-1/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-various-1/Dockerfile
@@ -111,12 +111,12 @@ ENV TARGETS=$TARGETS,riscv32imac-unknown-none-elf
 ENV TARGETS=$TARGETS,riscv32imafc-unknown-none-elf
 ENV TARGETS=$TARGETS,riscv64imac-unknown-none-elf
 ENV TARGETS=$TARGETS,riscv64gc-unknown-none-elf
-ENV TARGETS=$TARGETS,armebv7r-none-eabi
-ENV TARGETS=$TARGETS,armebv7r-none-eabihf
 ENV TARGETS=$TARGETS,armv7r-none-eabi
 ENV TARGETS=$TARGETS,armv7r-none-eabihf
+ENV TARGETS=$TARGETS,armv8r-none-eabihf
 ENV TARGETS=$TARGETS,thumbv7neon-unknown-linux-gnueabihf
 ENV TARGETS=$TARGETS,armv7a-none-eabi
+ENV TARGETS=$TARGETS,armv7a-none-eabihf
 
 ENV CFLAGS_armv5te_unknown_linux_musleabi="-march=armv5te -marm -mfloat-abi=soft" \
     CFLAGS_arm_unknown_linux_musleabi="-march=armv6 -marm" \

--- a/src/ci/docker/host-x86_64/dist-various-1/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-various-1/Dockerfile
@@ -131,6 +131,8 @@ ENV CFLAGS_armv5te_unknown_linux_musleabi="-march=armv5te -marm -mfloat-abi=soft
     CC_armv7a_none_eabihf=arm-none-eabi-gcc \
     CFLAGS_armv7a_none_eabi=-march=armv7-a \
     CFLAGS_armv7a_none_eabihf=-march=armv7-a+vfpv3 \
+    CC_armv8r_none_eabihf=arm-none-eabi-gcc \
+    CFLAGS_armv8r_none_eabihf="-march=armv8-r+fp.sp -mfpu=fp-armv8" \
     CC_aarch64_unknown_none_softfloat=aarch64-none-elf-gcc \
     CFLAGS_aarch64_unknown_none_softfloat=-mstrict-align -march=armv8-a+nofp+nosimd \
     CC_aarch64_unknown_none=aarch64-none-elf-gcc \

--- a/src/ci/docker/host-x86_64/dist-various-1/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-various-1/Dockerfile
@@ -130,7 +130,7 @@ ENV CFLAGS_armv5te_unknown_linux_musleabi="-march=armv5te -marm -mfloat-abi=soft
     CC_armv7a_none_eabi=arm-none-eabi-gcc \
     CC_armv7a_none_eabihf=arm-none-eabi-gcc \
     CFLAGS_armv7a_none_eabi=-march=armv7-a \
-    CFLAGS_armv7a_none_eabihf=-march=armv7-a+vfpv3 \
+    CFLAGS_armv7a_none_eabihf=-march=armv7-a+fp \
     CC_armv8r_none_eabihf=arm-none-eabi-gcc \
     CFLAGS_armv8r_none_eabihf="-march=armv8-r+fp.sp -mfpu=fp-armv8" \
     CC_aarch64_unknown_none_softfloat=aarch64-none-elf-gcc \

--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -89,6 +89,7 @@ static TARGETS: &[&str] = &[
     "armv7-unknown-linux-gnueabi",
     "armv7-unknown-linux-gnueabihf",
     "armv7a-none-eabi",
+    "armv7a-none-eabihf",
     "thumbv7neon-unknown-linux-gnueabihf",
     "armv7-unknown-linux-musleabi",
     "armv7-unknown-linux-musleabihf",

--- a/tests/mir-opt/gvn_loop.loop_deref_mut.GVN.diff
+++ b/tests/mir-opt/gvn_loop.loop_deref_mut.GVN.diff
@@ -71,7 +71,7 @@
           StorageLive(_12);
           _12 = copy _7;
 -         _11 = Value::V0(move _12);
-+         _11 = copy (*_3);
++         _11 = Value::V0(copy _7);
           StorageDead(_12);
           StorageLive(_13);
           StorageLive(_14);

--- a/tests/mir-opt/gvn_loop.loop_deref_mut.GVN.diff
+++ b/tests/mir-opt/gvn_loop.loop_deref_mut.GVN.diff
@@ -1,0 +1,115 @@
+- // MIR for `loop_deref_mut` before GVN
++ // MIR for `loop_deref_mut` after GVN
+  
+  fn loop_deref_mut(_1: &mut Value) -> Value {
+      debug val => _1;
+      let mut _0: Value;
+      let _2: &Value;
+      let _3: &Value;
+      let mut _4: &Value;
+      let mut _6: !;
+      let mut _8: isize;
+      let mut _9: !;
+      let mut _10: ();
+      let mut _12: i32;
+      let _13: ();
+      let mut _14: bool;
+      let mut _15: !;
+      let mut _16: Value;
+      scope 1 {
+          debug val_alias => _2;
+          let mut _5: bool;
+          scope 2 {
+              debug stop => _5;
+              let _7: i32;
+              scope 3 {
+                  debug v => _7;
+                  let _11: Value;
+                  scope 4 {
+                      debug v => _11;
+                  }
+              }
+          }
+      }
+  
+      bb0: {
+          StorageLive(_2);
+-         StorageLive(_3);
++         nop;
+          StorageLive(_4);
+          _4 = &(*_1);
+          _3 = get::<Value>(move _4) -> [return: bb1, unwind unreachable];
+      }
+  
+      bb1: {
+          _2 = &(*_3);
+          StorageDead(_4);
+-         StorageDead(_3);
++         nop;
+          StorageLive(_5);
+          _5 = const false;
+-         _8 = discriminant((*_2));
++         _8 = discriminant((*_3));
+          switchInt(move _8) -> [0: bb3, otherwise: bb2];
+      }
+  
+      bb2: {
+          unreachable;
+      }
+  
+      bb3: {
+-         StorageLive(_7);
+-         _7 = copy (((*_2) as V0).0: i32);
++         nop;
++         _7 = copy (((*_3) as V0).0: i32);
+          StorageLive(_9);
+          goto -> bb4;
+      }
+  
+      bb4: {
+          StorageLive(_11);
+          StorageLive(_12);
+          _12 = copy _7;
+-         _11 = Value::V0(move _12);
++         _11 = copy (*_3);
+          StorageDead(_12);
+          StorageLive(_13);
+          StorageLive(_14);
+          _14 = copy _5;
+          switchInt(move _14) -> [0: bb6, otherwise: bb5];
+      }
+  
+      bb5: {
+          _0 = move _11;
+          StorageDead(_14);
+          StorageDead(_13);
+          StorageDead(_11);
+          StorageDead(_9);
+-         StorageDead(_7);
++         nop;
+          StorageDead(_5);
+          StorageDead(_2);
+          return;
+      }
+  
+      bb6: {
+          _13 = const ();
+          StorageDead(_14);
+          StorageDead(_13);
+          _5 = const true;
+          StorageLive(_16);
+-         _16 = Value::V1;
+-         (*_1) = move _16;
++         _16 = const Value::V1;
++         (*_1) = const Value::V1;
+          StorageDead(_16);
+          _10 = const ();
+          StorageDead(_11);
+          goto -> bb4;
+      }
++ }
++ 
++ ALLOC0 (size: 8, align: 4) {
++     01 00 00 00 __ __ __ __                         │ ....░░░░
+  }
+  

--- a/tests/mir-opt/gvn_loop.rs
+++ b/tests/mir-opt/gvn_loop.rs
@@ -1,0 +1,31 @@
+// skip-filecheck
+//@ test-mir-pass: GVN
+
+#![crate_type = "lib"]
+#![feature(core_intrinsics, rustc_attrs)]
+
+pub enum Value {
+    V0(i32),
+    V1,
+}
+
+// EMIT_MIR gvn_loop.loop_deref_mut.GVN.diff
+fn loop_deref_mut(val: &mut Value) -> Value {
+    let val_alias: &Value = get(val);
+    let mut stop = false;
+    let Value::V0(v) = *val_alias else { unsafe { core::intrinsics::unreachable() } };
+    loop {
+        let v = Value::V0(v);
+        if stop {
+            return v;
+        }
+        stop = true;
+        *val = Value::V1;
+    }
+}
+
+#[inline(never)]
+#[rustc_nounwind]
+fn get<T>(v: &T) -> &T {
+    v
+}

--- a/tests/ui/mir/gvn-loop-miscompile.rs
+++ b/tests/ui/mir/gvn-loop-miscompile.rs
@@ -1,5 +1,5 @@
 //@ compile-flags: -O
-//@ run-fail
+//@ run-pass
 
 pub enum Value {
     V0(i32),

--- a/tests/ui/mir/gvn-loop-miscompile.rs
+++ b/tests/ui/mir/gvn-loop-miscompile.rs
@@ -1,0 +1,34 @@
+//@ compile-flags: -O
+//@ run-fail
+
+pub enum Value {
+    V0(i32),
+    V1,
+}
+
+fn set_discriminant(val: &mut Value) -> Value {
+    let val_alias: &Value = get(val);
+    let mut stop = false;
+    let Value::V0(v) = *val_alias else {
+        unreachable!();
+    };
+    loop {
+        let v = Value::V0(v);
+        if stop {
+            return v;
+        }
+        stop = true;
+        *val = Value::V1;
+    }
+}
+
+fn main() {
+    let mut v = Value::V0(1);
+    let v = set_discriminant(&mut v);
+    assert!(matches!(v, Value::V0(1)));
+}
+
+#[inline(never)]
+fn get<T>(v: &T) -> &T {
+    v
+}

--- a/tests/ui/traits/next-solver/cycles/forced_ambiguity-use-head-maybe-cause.rs
+++ b/tests/ui/traits/next-solver/cycles/forced_ambiguity-use-head-maybe-cause.rs
@@ -1,0 +1,44 @@
+//@ compile-flags: -Znext-solver
+#![feature(rustc_attrs)]
+#![rustc_no_implicit_bounds]
+
+// A regression test making sure that when forcing dependent
+// provisional cache entries to ambiguous, we use the `MaybeCause`
+// of the cycle head. We ended up trying to use the current result
+// of the provisional cache entry, which is incorrect and caused an
+// ICE when trying to unwrap it.
+
+struct Root<T>(T);
+struct Head<T>(T);
+struct Error<T>(T);
+struct NotImplemented<T>(T);
+
+#[rustc_coinductive]
+trait Trait {}
+impl<T> Trait for Root<T>
+where
+    Head<T>: Trait,
+{}
+
+impl<T> Trait for Head<T>
+where
+    Root<T>: Trait,
+    T: Trait, // ambiguous
+{}
+
+impl<T> Trait for Head<T>
+where
+    Error<T>: Trait,
+    NotImplemented<T>: Trait,
+{}
+
+impl<T> Trait for Error<T>
+where
+    Head<T>: Trait,
+    NotImplemented<T>: Trait,
+{}
+
+fn impls_trait<T: Trait>() {}
+fn main() {
+    impls_trait::<Root<_>>() //~ ERROR type annotations needed
+}

--- a/tests/ui/traits/next-solver/cycles/forced_ambiguity-use-head-maybe-cause.stderr
+++ b/tests/ui/traits/next-solver/cycles/forced_ambiguity-use-head-maybe-cause.stderr
@@ -1,0 +1,27 @@
+error[E0283]: type annotations needed
+  --> $DIR/forced_ambiguity-use-head-maybe-cause.rs:43:19
+   |
+LL |     impls_trait::<Root<_>>()
+   |                   ^^^^^^^ cannot infer type for struct `Head<_>`
+   |
+   = note: cannot satisfy `Head<_>: Trait`
+   = help: the trait `Trait` is implemented for `Head<T>`
+note: required for `Root<_>` to implement `Trait`
+  --> $DIR/forced_ambiguity-use-head-maybe-cause.rs:18:9
+   |
+LL | impl<T> Trait for Root<T>
+   |         ^^^^^     ^^^^^^^
+LL | where
+LL |     Head<T>: Trait,
+   |              ----- unsatisfied trait bound introduced here
+   = note: 8 redundant requirements hidden
+   = note: required for `Root<_>` to implement `Trait`
+note: required by a bound in `impls_trait`
+  --> $DIR/forced_ambiguity-use-head-maybe-cause.rs:41:19
+   |
+LL | fn impls_trait<T: Trait>() {}
+   |                   ^^^^^ required by this bound in `impls_trait`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0283`.

--- a/tests/ui/traits/next-solver/opaques/hidden-types-equate-before-fallback.rs
+++ b/tests/ui/traits/next-solver/opaques/hidden-types-equate-before-fallback.rs
@@ -6,7 +6,6 @@
 // Regression test for trait-system-refactor-initiative#240. Hidden types should
 // equate *before* inference var fallback, otherwise we can get mismatched types.
 
-
 #[derive(Clone, Copy)]
 struct FileSystem;
 impl FileSystem {

--- a/tests/ui/traits/next-solver/opaques/hidden-types-equate-before-fallback.rs
+++ b/tests/ui/traits/next-solver/opaques/hidden-types-equate-before-fallback.rs
@@ -1,0 +1,27 @@
+//@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@[next] compile-flags: -Znext-solver
+//@ check-pass
+
+// Regression test for trait-system-refactor-initiative#240. Hidden types should
+// equate *before* inference var fallback, otherwise we can get mismatched types.
+
+
+#[derive(Clone, Copy)]
+struct FileSystem;
+impl FileSystem {
+    fn build<T>(self, commands: T) -> Option<impl Sized> {
+        match false {
+            true => Some(commands),
+            false => {
+                drop(match self.build::<_>(commands) {
+                    Some(x) => x,
+                    None => return None,
+                });
+                panic!()
+            },
+        }
+    }
+}
+
+fn main() {}

--- a/tests/ui/traits/next-solver/opaques/hidden-types-equate-before-fallback.rs
+++ b/tests/ui/traits/next-solver/opaques/hidden-types-equate-before-fallback.rs
@@ -23,4 +23,22 @@ impl FileSystem {
     }
 }
 
+fn build2<T, U>() -> impl Sized {
+    if false {
+        build2::<U, T>()
+    } else {
+        loop {}
+    };
+    1u32
+}
+
+fn build3<'a>() -> impl Sized + use<'a> {
+    if false {
+        build3()
+    } else {
+        loop {}
+    };
+    1u32
+}
+
 fn main() {}


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#146277 (Enable `u64` limbs in `core::num::bignum`)
 - rust-lang/rust#146976 (constify basic Clone impls)
 - rust-lang/rust#147249 (Do two passes of `handle_opaque_type_uses_next`)
 - rust-lang/rust#147266 (fix 2 search graph bugs)
 - rust-lang/rust#147468 (Implement fs api set_times and set_times_nofollow)
 - rust-lang/rust#147497 (`proc_macro` cleanups (3/N))
 - rust-lang/rust#147594 (std: implement `pal::os::exit` for VEXos)
 - rust-lang/rust#147596 (Adjust the Arm targets in CI to reflect latest changes)
 - rust-lang/rust#147607 (GVN: Invalidate derefs at loop headers)
 - rust-lang/rust#147620 (Avoid redundant UB check in RangeFrom slice indexing)
 - rust-lang/rust#147647 (Hide vendoring and copyright in GHA group)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=146277,146976,147249,147266,147468,147497,147594,147596,147607,147620,147647)
<!-- homu-ignore:end -->