### PR TITLE
rustdoc-search: stringdex 0.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5261,9 +5261,9 @@ dependencies = [
 
 [[package]]
 name = "stringdex"
-version = "0.0.1-alpha10"
+version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa846a7d509d1828a4f90962dc09810e161abcada7fc6a921e92c168d0811d7"
+checksum = "18b3bd4f10d15ef859c40291769f0d85209de6b0f1c30713ff9cdf45ac43ea36"
 dependencies = [
  "stacker",
 ]

--- a/src/librustdoc/Cargo.toml
+++ b/src/librustdoc/Cargo.toml
@@ -21,7 +21,7 @@ rustdoc-json-types = { path = "../rustdoc-json-types" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 smallvec = "1.8.1"
-stringdex = { version = "0.0.1-alpha10" }
+stringdex = "=0.0.2"
 tempfile = "3"
 threadpool = "1.8.1"
 tracing = "0.1"


### PR DESCRIPTION
Two index format tweaks that reduce the size of the standard library, compiler, and wordnet dictionary when I test it.

CC rust-lang/rust#146048 

FF Profiler output: https://share.firefox.dev/4onH5xP

Preview: https://notriddle.com/rustdoc-html-demo-12/stringdex-002/std/index.html