### PR TITLE
Rollup of 10 pull requests

### DIFF
--- a/compiler/rustc_borrowck/src/region_infer/opaque_types/mod.rs
+++ b/compiler/rustc_borrowck/src/region_infer/opaque_types/mod.rs
@@ -155,13 +155,6 @@ fn add_hidden_type<'tcx>(
     }
 }
 
-fn get_hidden_type<'tcx>(
-    hidden_types: &DefinitionSiteHiddenTypes<'tcx>,
-    def_id: LocalDefId,
-) -> Option<EarlyBinder<'tcx, OpaqueHiddenType<'tcx>>> {
-    hidden_types.0.get(&def_id).map(|ty| EarlyBinder::bind(*ty))
-}
-
 #[derive(Debug)]
 struct DefiningUse<'tcx> {
     /// The opaque type using non NLL vars. This uses the actual
@@ -501,7 +494,8 @@ pub(crate) fn apply_definition_site_hidden_types<'tcx>(
     let tcx = infcx.tcx;
     let mut errors = Vec::new();
     for &(key, hidden_type) in opaque_types {
-        let Some(expected) = get_hidden_type(hidden_types, key.def_id) else {
+        let Some(expected) = hidden_types.0.get(&key.def_id).map(|ty| EarlyBinder::bind(*ty))
+        else {
             if !tcx.use_typing_mode_borrowck() {
                 if let ty::Alias(ty::Opaque, alias_ty) = hidden_type.ty.kind()
                     && alias_ty.def_id == key.def_id.to_def_id()

--- a/compiler/rustc_hir_typeck/src/lib.rs
+++ b/compiler/rustc_hir_typeck/src/lib.rs
@@ -219,6 +219,12 @@ fn typeck_with_inspect<'tcx>(
     // the future.
     fcx.check_repeat_exprs();
 
+    // We need to handle opaque types before emitting ambiguity errors as applying
+    // defining uses may guide type inference.
+    if fcx.next_trait_solver() {
+        fcx.try_handle_opaque_type_uses_next();
+    }
+
     fcx.type_inference_fallback();
 
     // Even though coercion casts provide type hints, we check casts after fallback for

--- a/compiler/rustc_hir_typeck/src/opaque_types.rs
+++ b/compiler/rustc_hir_typeck/src/opaque_types.rs
@@ -26,15 +26,15 @@ impl<'tcx> FnCtxt<'_, 'tcx> {
     /// Unlike `handle_opaque_type_uses_next`, this does not report errors.
     #[instrument(level = "debug", skip(self))]
     pub(super) fn try_handle_opaque_type_uses_next(&mut self) {
-        // We clone the opaques instead of stealing them here as they are still used for
-        // normalization in the next generation trait solver.
+        // We clone the opaques instead of stealing them here as we still need
+        // to use them after fallback.
         let mut opaque_types: Vec<_> = self.infcx.clone_opaque_types();
         for entry in &mut opaque_types {
             *entry = self.resolve_vars_if_possible(*entry);
         }
         debug!(?opaque_types);
 
-        self.compute_definition_site_hidden_types(&opaque_types, true);
+        self.compute_definition_site_hidden_types(&opaque_types, false);
     }
 
     /// This takes all the opaque type uses during HIR typeck. It first computes
@@ -58,7 +58,7 @@ impl<'tcx> FnCtxt<'_, 'tcx> {
         }
         debug!(?opaque_types);
 
-        self.compute_definition_site_hidden_types(&opaque_types, false);
+        self.compute_definition_site_hidden_types(&opaque_types, true);
     }
 }
 
@@ -97,7 +97,7 @@ impl<'tcx> FnCtxt<'_, 'tcx> {
     fn compute_definition_site_hidden_types(
         &mut self,
         opaque_types: &[(OpaqueTypeKey<'tcx>, OpaqueHiddenType<'tcx>)],
-        first_pass: bool,
+        error_on_missing_defining_use: bool,
     ) {
         let tcx = self.tcx;
         let TypingMode::Analysis { defining_opaque_types_and_generators } = self.typing_mode()
@@ -138,19 +138,16 @@ impl<'tcx> FnCtxt<'_, 'tcx> {
                     self.demand_eqtype(hidden_type.span, expected, hidden_type.ty);
                 }
 
-                let prev = self.typeck_results.borrow_mut().hidden_types.insert(def_id, ty);
-
-                // We do want to insert opaque types the first pass, because
-                // we want to equate them. So, the second pass (where we
-                // report errors) may have a hidden type inserted.
-                if first_pass {
-                    assert!(prev.is_none());
-                }
+                // Being explicit here: it may be possible that we in a
+                // previous call to this function we did an insert, but this
+                // should be just fine, since they all get equated anyways and
+                // we shouldn't ever go from `HasDefiningUse` to anyway else.
+                let _ = self.typeck_results.borrow_mut().hidden_types.insert(def_id, ty);
             }
 
             // If this the first pass (`try_handle_opaque_type_uses_next`),
             // then do not report any errors.
-            if first_pass {
+            if !error_on_missing_defining_use {
                 continue;
             }
 
@@ -204,7 +201,7 @@ impl<'tcx> FnCtxt<'_, 'tcx> {
 
     #[tracing::instrument(skip(self), ret)]
     fn consider_opaque_type_use(
-        &mut self,
+        &self,
         opaque_type_key: OpaqueTypeKey<'tcx>,
         hidden_type: OpaqueHiddenType<'tcx>,
     ) -> UsageKind<'tcx> {

--- a/compiler/rustc_next_trait_solver/src/solve/search_graph.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/search_graph.rs
@@ -99,19 +99,23 @@ where
         response_no_constraints(cx, input, Certainty::overflow(false))
     }
 
-    fn is_ambiguous_result(result: QueryResult<I>) -> bool {
-        result.is_ok_and(|response| {
-            has_no_inference_or_external_constraints(response)
+    fn is_ambiguous_result(result: QueryResult<I>) -> Option<Certainty> {
+        result.ok().and_then(|response| {
+            if has_no_inference_or_external_constraints(response)
                 && matches!(response.value.certainty, Certainty::Maybe { .. })
+            {
+                Some(response.value.certainty)
+            } else {
+                None
+            }
         })
     }
 
     fn propagate_ambiguity(
         cx: I,
         for_input: CanonicalInput<I>,
-        from_result: QueryResult<I>,
+        certainty: Certainty,
     ) -> QueryResult<I> {
-        let certainty = from_result.unwrap().value.certainty;
         response_no_constraints(cx, for_input, certainty)
     }
 

--- a/compiler/rustc_type_ir/src/interner.rs
+++ b/compiler/rustc_type_ir/src/interner.rs
@@ -11,7 +11,7 @@ use crate::inherent::*;
 use crate::ir_print::IrPrint;
 use crate::lang_items::{SolverAdtLangItem, SolverLangItem, SolverTraitLangItem};
 use crate::relate::Relate;
-use crate::solve::{CanonicalInput, ExternalConstraintsData, QueryResult, inspect};
+use crate::solve::{CanonicalInput, Certainty, ExternalConstraintsData, QueryResult, inspect};
 use crate::visit::{Flags, TypeVisitable};
 use crate::{self as ty, CanonicalParamEnvCacheEntry, search_graph};
 
@@ -548,6 +548,7 @@ impl<T, R, E> CollectAndApply<T, R> for Result<T, E> {
 impl<I: Interner> search_graph::Cx for I {
     type Input = CanonicalInput<I>;
     type Result = QueryResult<I>;
+    type AmbiguityInfo = Certainty;
 
     type DepNodeIndex = I::DepNodeIndex;
     type Tracked<T: Debug + Clone> = I::Tracked<T>;

--- a/compiler/rustc_type_ir/src/search_graph/mod.rs
+++ b/compiler/rustc_type_ir/src/search_graph/mod.rs
@@ -40,6 +40,7 @@ pub use global_cache::GlobalCache;
 pub trait Cx: Copy {
     type Input: Debug + Eq + Hash + Copy;
     type Result: Debug + Eq + Hash + Copy;
+    type AmbiguityInfo: Debug + Eq + Hash + Copy;
 
     type DepNodeIndex;
     type Tracked<T: Debug + Clone>: Debug;
@@ -96,11 +97,13 @@ pub trait Delegate: Sized {
         input: <Self::Cx as Cx>::Input,
     ) -> <Self::Cx as Cx>::Result;
 
-    fn is_ambiguous_result(result: <Self::Cx as Cx>::Result) -> bool;
+    fn is_ambiguous_result(
+        result: <Self::Cx as Cx>::Result,
+    ) -> Option<<Self::Cx as Cx>::AmbiguityInfo>;
     fn propagate_ambiguity(
         cx: Self::Cx,
         for_input: <Self::Cx as Cx>::Input,
-        from_result: <Self::Cx as Cx>::Result,
+        ambiguity_info: <Self::Cx as Cx>::AmbiguityInfo,
     ) -> <Self::Cx as Cx>::Result;
 
     fn compute_goal(
@@ -913,9 +916,9 @@ impl<D: Delegate<Cx = X>, X: Cx> SearchGraph<D> {
 /// heads from the stack. This may not necessarily mean that we've actually
 /// reached a fixpoint for that cycle head, which impacts the way we rebase
 /// provisional cache entries.
-enum RebaseReason {
+enum RebaseReason<X: Cx> {
     NoCycleUsages,
-    Ambiguity,
+    Ambiguity(X::AmbiguityInfo),
     Overflow,
     /// We've actually reached a fixpoint.
     ///
@@ -951,7 +954,7 @@ impl<D: Delegate<Cx = X>, X: Cx> SearchGraph<D, X> {
         &mut self,
         cx: X,
         stack_entry: &StackEntry<X>,
-        rebase_reason: RebaseReason,
+        rebase_reason: RebaseReason<X>,
     ) {
         let popped_head_index = self.stack.next_index();
         #[allow(rustc::potential_query_instability)]
@@ -1029,8 +1032,8 @@ impl<D: Delegate<Cx = X>, X: Cx> SearchGraph<D, X> {
                         // is not actually equal to the final provisional result. We
                         // need to discard the provisional cache entry in this case.
                         RebaseReason::NoCycleUsages => return false,
-                        RebaseReason::Ambiguity => {
-                            *result = D::propagate_ambiguity(cx, input, *result);
+                        RebaseReason::Ambiguity(info) => {
+                            *result = D::propagate_ambiguity(cx, input, info);
                         }
                         RebaseReason::Overflow => *result = D::fixpoint_overflow_result(cx, input),
                         RebaseReason::ReachedFixpoint(None) => {}
@@ -1268,6 +1271,7 @@ impl<D: Delegate<Cx = X>, X: Cx> SearchGraph<D, X> {
     }
 
     /// Whether we've reached a fixpoint when evaluating a cycle head.
+    #[instrument(level = "trace", skip(self, stack_entry), ret)]
     fn reached_fixpoint(
         &mut self,
         stack_entry: &StackEntry<X>,
@@ -1355,8 +1359,12 @@ impl<D: Delegate<Cx = X>, X: Cx> SearchGraph<D, X> {
             // As we only get to this branch if we haven't yet reached a fixpoint,
             // we also taint all provisional cache entries which depend on the
             // current goal.
-            if D::is_ambiguous_result(result) {
-                self.rebase_provisional_cache_entries(cx, &stack_entry, RebaseReason::Ambiguity);
+            if let Some(info) = D::is_ambiguous_result(result) {
+                self.rebase_provisional_cache_entries(
+                    cx,
+                    &stack_entry,
+                    RebaseReason::Ambiguity(info),
+                );
                 return EvaluationResult::finalize(stack_entry, encountered_overflow, result);
             };
 

--- a/compiler/rustc_type_ir/src/search_graph/mod.rs
+++ b/compiler/rustc_type_ir/src/search_graph/mod.rs
@@ -969,10 +969,6 @@ impl<D: Delegate<Cx = X>, X: Cx> SearchGraph<D, X> {
                     return true;
                 };
 
-                let Some(new_highest_head_index) = heads.opt_highest_cycle_head_index() else {
-                    return false;
-                };
-
                 // We're rebasing an entry `e` over a head `p`. This head
                 // has a number of own heads `h` it depends on.
                 //
@@ -1045,6 +1041,10 @@ impl<D: Delegate<Cx = X>, X: Cx> SearchGraph<D, X> {
                         }
                     };
                 }
+
+                let Some(new_highest_head_index) = heads.opt_highest_cycle_head_index() else {
+                    return false;
+                };
 
                 // We now care about the path from the next highest cycle head to the
                 // provisional cache entry.

--- a/library/core/src/clone.rs
+++ b/library/core/src/clone.rs
@@ -575,7 +575,8 @@ mod impls {
         ($($t:ty)*) => {
             $(
                 #[stable(feature = "rust1", since = "1.0.0")]
-                impl Clone for $t {
+                #[rustc_const_unstable(feature = "const_clone", issue = "142757")]
+                impl const Clone for $t {
                     #[inline(always)]
                     fn clone(&self) -> Self {
                         *self
@@ -593,7 +594,8 @@ mod impls {
     }
 
     #[unstable(feature = "never_type", issue = "35121")]
-    impl Clone for ! {
+    #[rustc_const_unstable(feature = "const_clone", issue = "142757")]
+    impl const Clone for ! {
         #[inline]
         fn clone(&self) -> Self {
             *self
@@ -601,7 +603,8 @@ mod impls {
     }
 
     #[stable(feature = "rust1", since = "1.0.0")]
-    impl<T: PointeeSized> Clone for *const T {
+    #[rustc_const_unstable(feature = "const_clone", issue = "142757")]
+    impl<T: PointeeSized> const Clone for *const T {
         #[inline(always)]
         fn clone(&self) -> Self {
             *self
@@ -609,7 +612,8 @@ mod impls {
     }
 
     #[stable(feature = "rust1", since = "1.0.0")]
-    impl<T: PointeeSized> Clone for *mut T {
+    #[rustc_const_unstable(feature = "const_clone", issue = "142757")]
+    impl<T: PointeeSized> const Clone for *mut T {
         #[inline(always)]
         fn clone(&self) -> Self {
             *self
@@ -618,7 +622,8 @@ mod impls {
 
     /// Shared references can be cloned, but mutable references *cannot*!
     #[stable(feature = "rust1", since = "1.0.0")]
-    impl<T: PointeeSized> Clone for &T {
+    #[rustc_const_unstable(feature = "const_clone", issue = "142757")]
+    impl<T: PointeeSized> const Clone for &T {
         #[inline(always)]
         #[rustc_diagnostic_item = "noop_method_clone"]
         fn clone(&self) -> Self {

--- a/library/core/src/num/bignum.rs
+++ b/library/core/src/num/bignum.rs
@@ -59,8 +59,7 @@ impl_full_ops! {
     u8:  add(intrinsics::u8_add_with_overflow),  mul/div(u16);
     u16: add(intrinsics::u16_add_with_overflow), mul/div(u32);
     u32: add(intrinsics::u32_add_with_overflow), mul/div(u64);
-    // See RFC #521 for enabling this.
-    // u64: add(intrinsics::u64_add_with_overflow), mul/div(u128);
+    u64: add(intrinsics::u64_add_with_overflow), mul/div(u128);
 }
 
 /// Table of powers of 5 representable in digits. Specifically, the largest {u8, u16, u32} value

--- a/library/proc_macro/src/bridge/client.rs
+++ b/library/proc_macro/src/bridge/client.rs
@@ -58,7 +58,7 @@ macro_rules! define_client_handles {
                 }
             }
 
-            impl<S> DecodeMut<'_, '_, S> for $oty {
+            impl<S> Decode<'_, '_, S> for $oty {
                 fn decode(r: &mut Reader<'_>, s: &mut S) -> Self {
                     $oty {
                         handle: handle::Handle::decode(r, s),
@@ -82,7 +82,7 @@ macro_rules! define_client_handles {
                 }
             }
 
-            impl<S> DecodeMut<'_, '_, S> for $ity {
+            impl<S> Decode<'_, '_, S> for $ity {
                 fn decode(r: &mut Reader<'_>, s: &mut S) -> Self {
                     $ity {
                         handle: handle::Handle::decode(r, s),
@@ -276,7 +276,7 @@ fn maybe_install_panic_hook(force_show_panics: bool) {
 /// Client-side helper for handling client panics, entering the bridge,
 /// deserializing input and serializing output.
 // FIXME(eddyb) maybe replace `Bridge::enter` with this?
-fn run_client<A: for<'a, 's> DecodeMut<'a, 's, ()>, R: Encode<()>>(
+fn run_client<A: for<'a, 's> Decode<'a, 's, ()>, R: Encode<()>>(
     config: BridgeConfig<'_>,
     f: impl FnOnce(A) -> R,
 ) -> Buffer {

--- a/library/proc_macro/src/bridge/mod.rs
+++ b/library/proc_macro/src/bridge/mod.rs
@@ -143,7 +143,7 @@ mod symbol;
 
 use buffer::Buffer;
 pub use rpc::PanicMessage;
-use rpc::{DecodeMut, Encode, Reader, Writer};
+use rpc::{Decode, Encode, Reader, Writer};
 
 /// Configuration for establishing an active connection between a server and a
 /// client.  The server creates the bridge config (`run_server` in `server.rs`),
@@ -168,7 +168,7 @@ impl !Sync for BridgeConfig<'_> {}
 #[forbid(unsafe_code)]
 #[allow(non_camel_case_types)]
 mod api_tags {
-    use super::rpc::{DecodeMut, Encode, Reader, Writer};
+    use super::rpc::{Decode, Encode, Reader, Writer};
 
     macro_rules! declare_tags {
         ($($name:ident {

--- a/library/proc_macro/src/bridge/rpc.rs
+++ b/library/proc_macro/src/bridge/rpc.rs
@@ -58,16 +58,11 @@ macro_rules! rpc_encode_decode {
             fn encode(self, w: &mut Writer, s: &mut S) {
                 // HACK(eddyb): `Tag` enum duplicated between the
                 // two impls as there's no other place to stash it.
-                #[allow(non_upper_case_globals)]
-                mod tag {
-                    #[repr(u8)] enum Tag { $($variant),* }
-
-                    $(pub(crate) const $variant: u8 = Tag::$variant as u8;)*
-                }
+                #[repr(u8)] enum Tag { $($variant),* }
 
                 match self {
                     $($name::$variant $(($field))* => {
-                        tag::$variant.encode(w, s);
+                        (Tag::$variant as u8).encode(w, s);
                         $($field.encode(w, s);)*
                     })*
                 }

--- a/library/proc_macro/src/bridge/rpc.rs
+++ b/library/proc_macro/src/bridge/rpc.rs
@@ -12,7 +12,7 @@ pub(super) trait Encode<S>: Sized {
 
 pub(super) type Reader<'a> = &'a [u8];
 
-pub(super) trait DecodeMut<'a, 's, S>: Sized {
+pub(super) trait Decode<'a, 's, S>: Sized {
     fn decode(r: &mut Reader<'a>, s: &'s mut S) -> Self;
 }
 
@@ -24,7 +24,7 @@ macro_rules! rpc_encode_decode {
             }
         }
 
-        impl<S> DecodeMut<'_, '_, S> for $ty {
+        impl<S> Decode<'_, '_, S> for $ty {
             fn decode(r: &mut Reader<'_>, _: &mut S) -> Self {
                 const N: usize = size_of::<$ty>();
 
@@ -43,12 +43,12 @@ macro_rules! rpc_encode_decode {
             }
         }
 
-        impl<'a, S, $($($T: for<'s> DecodeMut<'a, 's, S>),+)?> DecodeMut<'a, '_, S>
+        impl<'a, S, $($($T: for<'s> Decode<'a, 's, S>),+)?> Decode<'a, '_, S>
             for $name $(<$($T),+>)?
         {
             fn decode(r: &mut Reader<'a>, s: &mut S) -> Self {
                 $name {
-                    $($field: DecodeMut::decode(r, s)),*
+                    $($field: Decode::decode(r, s)),*
                 }
             }
         }
@@ -69,7 +69,7 @@ macro_rules! rpc_encode_decode {
             }
         }
 
-        impl<'a, S, $($($T: for<'s> DecodeMut<'a, 's, S>),+)?> DecodeMut<'a, '_, S>
+        impl<'a, S, $($($T: for<'s> Decode<'a, 's, S>),+)?> Decode<'a, '_, S>
             for $name $(<$($T),+>)?
         {
             fn decode(r: &mut Reader<'a>, s: &mut S) -> Self {
@@ -84,7 +84,7 @@ macro_rules! rpc_encode_decode {
 
                 match u8::decode(r, s) {
                     $(tag::$variant => {
-                        $(let $field = DecodeMut::decode(r, s);)*
+                        $(let $field = Decode::decode(r, s);)*
                         $name::$variant $(($field))*
                     })*
                     _ => unreachable!(),
@@ -98,7 +98,7 @@ impl<S> Encode<S> for () {
     fn encode(self, _: &mut Writer, _: &mut S) {}
 }
 
-impl<S> DecodeMut<'_, '_, S> for () {
+impl<S> Decode<'_, '_, S> for () {
     fn decode(_: &mut Reader<'_>, _: &mut S) -> Self {}
 }
 
@@ -108,7 +108,7 @@ impl<S> Encode<S> for u8 {
     }
 }
 
-impl<S> DecodeMut<'_, '_, S> for u8 {
+impl<S> Decode<'_, '_, S> for u8 {
     fn decode(r: &mut Reader<'_>, _: &mut S) -> Self {
         let x = r[0];
         *r = &r[1..];
@@ -125,7 +125,7 @@ impl<S> Encode<S> for bool {
     }
 }
 
-impl<S> DecodeMut<'_, '_, S> for bool {
+impl<S> Decode<'_, '_, S> for bool {
     fn decode(r: &mut Reader<'_>, s: &mut S) -> Self {
         match u8::decode(r, s) {
             0 => false,
@@ -141,7 +141,7 @@ impl<S> Encode<S> for char {
     }
 }
 
-impl<S> DecodeMut<'_, '_, S> for char {
+impl<S> Decode<'_, '_, S> for char {
     fn decode(r: &mut Reader<'_>, s: &mut S) -> Self {
         char::from_u32(u32::decode(r, s)).unwrap()
     }
@@ -153,7 +153,7 @@ impl<S> Encode<S> for NonZero<u32> {
     }
 }
 
-impl<S> DecodeMut<'_, '_, S> for NonZero<u32> {
+impl<S> Decode<'_, '_, S> for NonZero<u32> {
     fn decode(r: &mut Reader<'_>, s: &mut S) -> Self {
         Self::new(u32::decode(r, s)).unwrap()
     }
@@ -166,11 +166,11 @@ impl<S, A: Encode<S>, B: Encode<S>> Encode<S> for (A, B) {
     }
 }
 
-impl<'a, S, A: for<'s> DecodeMut<'a, 's, S>, B: for<'s> DecodeMut<'a, 's, S>> DecodeMut<'a, '_, S>
+impl<'a, S, A: for<'s> Decode<'a, 's, S>, B: for<'s> Decode<'a, 's, S>> Decode<'a, '_, S>
     for (A, B)
 {
     fn decode(r: &mut Reader<'a>, s: &mut S) -> Self {
-        (DecodeMut::decode(r, s), DecodeMut::decode(r, s))
+        (Decode::decode(r, s), Decode::decode(r, s))
     }
 }
 
@@ -181,7 +181,7 @@ impl<S> Encode<S> for &[u8] {
     }
 }
 
-impl<'a, S> DecodeMut<'a, '_, S> for &'a [u8] {
+impl<'a, S> Decode<'a, '_, S> for &'a [u8] {
     fn decode(r: &mut Reader<'a>, s: &mut S) -> Self {
         let len = usize::decode(r, s);
         let xs = &r[..len];
@@ -196,7 +196,7 @@ impl<S> Encode<S> for &str {
     }
 }
 
-impl<'a, S> DecodeMut<'a, '_, S> for &'a str {
+impl<'a, S> Decode<'a, '_, S> for &'a str {
     fn decode(r: &mut Reader<'a>, s: &mut S) -> Self {
         str::from_utf8(<&[u8]>::decode(r, s)).unwrap()
     }
@@ -208,7 +208,7 @@ impl<S> Encode<S> for String {
     }
 }
 
-impl<S> DecodeMut<'_, '_, S> for String {
+impl<S> Decode<'_, '_, S> for String {
     fn decode(r: &mut Reader<'_>, s: &mut S) -> Self {
         <&str>::decode(r, s).to_string()
     }
@@ -223,7 +223,7 @@ impl<S, T: Encode<S>> Encode<S> for Vec<T> {
     }
 }
 
-impl<'a, S, T: for<'s> DecodeMut<'a, 's, S>> DecodeMut<'a, '_, S> for Vec<T> {
+impl<'a, S, T: for<'s> Decode<'a, 's, S>> Decode<'a, '_, S> for Vec<T> {
     fn decode(r: &mut Reader<'a>, s: &mut S) -> Self {
         let len = usize::decode(r, s);
         let mut vec = Vec::with_capacity(len);
@@ -283,7 +283,7 @@ impl<S> Encode<S> for PanicMessage {
     }
 }
 
-impl<S> DecodeMut<'_, '_, S> for PanicMessage {
+impl<S> Decode<'_, '_, S> for PanicMessage {
     fn decode(r: &mut Reader<'_>, s: &mut S) -> Self {
         match Option::<String>::decode(r, s) {
             Some(s) => PanicMessage::String(s),

--- a/library/proc_macro/src/bridge/selfless_reify.rs
+++ b/library/proc_macro/src/bridge/selfless_reify.rs
@@ -50,7 +50,7 @@ macro_rules! define_reify_functions {
         >(f: F) -> $(extern $abi)? fn($($arg_ty),*) -> $ret_ty {
             // FIXME(eddyb) describe the `F` type (e.g. via `type_name::<F>`) once panic
             // formatting becomes possible in `const fn`.
-            assert!(size_of::<F>() == 0, "selfless_reify: closure must be zero-sized");
+            const { assert!(size_of::<F>() == 0, "selfless_reify: closure must be zero-sized"); }
 
             $(extern $abi)? fn wrapper<
                 $($($param,)*)?

--- a/library/proc_macro/src/bridge/server.rs
+++ b/library/proc_macro/src/bridge/server.rs
@@ -32,7 +32,7 @@ macro_rules! define_server_handles {
                 }
             }
 
-            impl<S: Types> DecodeMut<'_, '_, HandleStore<MarkedTypes<S>>>
+            impl<S: Types> Decode<'_, '_, HandleStore<MarkedTypes<S>>>
                 for Marked<S::$oty, client::$oty>
             {
                 fn decode(r: &mut Reader<'_>, s: &mut HandleStore<MarkedTypes<S>>) -> Self {
@@ -40,7 +40,7 @@ macro_rules! define_server_handles {
                 }
             }
 
-            impl<'s, S: Types> DecodeMut<'_, 's, HandleStore<MarkedTypes<S>>>
+            impl<'s, S: Types> Decode<'_, 's, HandleStore<MarkedTypes<S>>>
                 for &'s Marked<S::$oty, client::$oty>
             {
                 fn decode(r: &mut Reader<'_>, s: &'s mut HandleStore<MarkedTypes<S>>) -> Self {
@@ -48,7 +48,7 @@ macro_rules! define_server_handles {
                 }
             }
 
-            impl<'s, S: Types> DecodeMut<'_, 's, HandleStore<MarkedTypes<S>>>
+            impl<'s, S: Types> Decode<'_, 's, HandleStore<MarkedTypes<S>>>
                 for &'s mut Marked<S::$oty, client::$oty>
             {
                 fn decode(
@@ -67,7 +67,7 @@ macro_rules! define_server_handles {
                 }
             }
 
-            impl<S: Types> DecodeMut<'_, '_, HandleStore<MarkedTypes<S>>>
+            impl<S: Types> Decode<'_, '_, HandleStore<MarkedTypes<S>>>
                 for Marked<S::$ity, client::$ity>
             {
                 fn decode(r: &mut Reader<'_>, s: &mut HandleStore<MarkedTypes<S>>) -> Self {
@@ -355,7 +355,7 @@ pub trait MessagePipe<T>: Sized {
 fn run_server<
     S: Server,
     I: Encode<HandleStore<MarkedTypes<S>>>,
-    O: for<'a, 's> DecodeMut<'a, 's, HandleStore<MarkedTypes<S>>>,
+    O: for<'a, 's> Decode<'a, 's, HandleStore<MarkedTypes<S>>>,
 >(
     strategy: &impl ExecutionStrategy,
     handle_counters: &'static client::HandleCounters,

--- a/library/proc_macro/src/bridge/symbol.rs
+++ b/library/proc_macro/src/bridge/symbol.rs
@@ -102,7 +102,7 @@ impl<S> Encode<S> for Symbol {
     }
 }
 
-impl<S: server::Server> DecodeMut<'_, '_, server::HandleStore<server::MarkedTypes<S>>>
+impl<S: server::Server> Decode<'_, '_, server::HandleStore<server::MarkedTypes<S>>>
     for Marked<S::Symbol, Symbol>
 {
     fn decode(r: &mut Reader<'_>, s: &mut server::HandleStore<server::MarkedTypes<S>>) -> Self {
@@ -118,7 +118,7 @@ impl<S: server::Server> Encode<server::HandleStore<server::MarkedTypes<S>>>
     }
 }
 
-impl<S> DecodeMut<'_, '_, S> for Symbol {
+impl<S> Decode<'_, '_, S> for Symbol {
     fn decode(r: &mut Reader<'_>, s: &mut S) -> Self {
         Symbol::new(<&str>::decode(r, s))
     }

--- a/tests/ui/traits/next-solver/cycles/forced_ambiguity-use-head-maybe-cause.rs
+++ b/tests/ui/traits/next-solver/cycles/forced_ambiguity-use-head-maybe-cause.rs
@@ -1,0 +1,44 @@
+//@ compile-flags: -Znext-solver
+#![feature(rustc_attrs)]
+#![rustc_no_implicit_bounds]
+
+// A regression test making sure that when forcing dependent
+// provisional cache entries to ambiguous, we use the `MaybeCause`
+// of the cycle head. We ended up trying to use the current result
+// of the provisional cache entry, which is incorrect and caused an
+// ICE when trying to unwrap it.
+
+struct Root<T>(T);
+struct Head<T>(T);
+struct Error<T>(T);
+struct NotImplemented<T>(T);
+
+#[rustc_coinductive]
+trait Trait {}
+impl<T> Trait for Root<T>
+where
+    Head<T>: Trait,
+{}
+
+impl<T> Trait for Head<T>
+where
+    Root<T>: Trait,
+    T: Trait, // ambiguous
+{}
+
+impl<T> Trait for Head<T>
+where
+    Error<T>: Trait,
+    NotImplemented<T>: Trait,
+{}
+
+impl<T> Trait for Error<T>
+where
+    Head<T>: Trait,
+    NotImplemented<T>: Trait,
+{}
+
+fn impls_trait<T: Trait>() {}
+fn main() {
+    impls_trait::<Root<_>>() //~ ERROR type annotations needed
+}

--- a/tests/ui/traits/next-solver/cycles/forced_ambiguity-use-head-maybe-cause.stderr
+++ b/tests/ui/traits/next-solver/cycles/forced_ambiguity-use-head-maybe-cause.stderr
@@ -1,0 +1,27 @@
+error[E0283]: type annotations needed
+  --> $DIR/forced_ambiguity-use-head-maybe-cause.rs:43:19
+   |
+LL |     impls_trait::<Root<_>>()
+   |                   ^^^^^^^ cannot infer type for struct `Head<_>`
+   |
+   = note: cannot satisfy `Head<_>: Trait`
+   = help: the trait `Trait` is implemented for `Head<T>`
+note: required for `Root<_>` to implement `Trait`
+  --> $DIR/forced_ambiguity-use-head-maybe-cause.rs:18:9
+   |
+LL | impl<T> Trait for Root<T>
+   |         ^^^^^     ^^^^^^^
+LL | where
+LL |     Head<T>: Trait,
+   |              ----- unsatisfied trait bound introduced here
+   = note: 8 redundant requirements hidden
+   = note: required for `Root<_>` to implement `Trait`
+note: required by a bound in `impls_trait`
+  --> $DIR/forced_ambiguity-use-head-maybe-cause.rs:41:19
+   |
+LL | fn impls_trait<T: Trait>() {}
+   |                   ^^^^^ required by this bound in `impls_trait`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0283`.

--- a/tests/ui/traits/next-solver/opaques/hidden-types-equate-before-fallback.rs
+++ b/tests/ui/traits/next-solver/opaques/hidden-types-equate-before-fallback.rs
@@ -6,7 +6,6 @@
 // Regression test for trait-system-refactor-initiative#240. Hidden types should
 // equate *before* inference var fallback, otherwise we can get mismatched types.
 
-
 #[derive(Clone, Copy)]
 struct FileSystem;
 impl FileSystem {

--- a/tests/ui/traits/next-solver/opaques/hidden-types-equate-before-fallback.rs
+++ b/tests/ui/traits/next-solver/opaques/hidden-types-equate-before-fallback.rs
@@ -1,0 +1,27 @@
+//@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@[next] compile-flags: -Znext-solver
+//@ check-pass
+
+// Regression test for trait-system-refactor-initiative#240. Hidden types should
+// equate *before* inference var fallback, otherwise we can get mismatched types.
+
+
+#[derive(Clone, Copy)]
+struct FileSystem;
+impl FileSystem {
+    fn build<T>(self, commands: T) -> Option<impl Sized> {
+        match false {
+            true => Some(commands),
+            false => {
+                drop(match self.build::<_>(commands) {
+                    Some(x) => x,
+                    None => return None,
+                });
+                panic!()
+            },
+        }
+    }
+}
+
+fn main() {}

--- a/tests/ui/traits/next-solver/opaques/hidden-types-equate-before-fallback.rs
+++ b/tests/ui/traits/next-solver/opaques/hidden-types-equate-before-fallback.rs
@@ -23,4 +23,22 @@ impl FileSystem {
     }
 }
 
+fn build2<T, U>() -> impl Sized {
+    if false {
+        build2::<U, T>()
+    } else {
+        loop {}
+    };
+    1u32
+}
+
+fn build3<'a>() -> impl Sized + use<'a> {
+    if false {
+        build3()
+    } else {
+        loop {}
+    };
+    1u32
+}
+
 fn main() {}


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#146277 (Enable `u64` limbs in `core::num::bignum`)
 - rust-lang/rust#146976 (constify basic Clone impls)
 - rust-lang/rust#147249 (Do two passes of `handle_opaque_type_uses_next`)
 - rust-lang/rust#147266 (fix 2 search graph bugs)
 - rust-lang/rust#147497 (`proc_macro` cleanups (3/N))
 - rust-lang/rust#147548 (Fix ICE for never pattern as closure parameters)
 - rust-lang/rust#147594 (std: implement `pal::os::exit` for VEXos)
 - rust-lang/rust#147607 (GVN: Invalidate derefs at loop headers)
 - rust-lang/rust#147620 (Avoid redundant UB check in RangeFrom slice indexing)
 - rust-lang/rust#147647 (Hide vendoring and copyright in GHA group)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=146277,146976,147249,147266,147497,147548,147594,147607,147620,147647)
<!-- homu-ignore:end -->