### PR TITLE
fix missing link to `std::char` in `std` docs

### DIFF
--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -65,7 +65,7 @@
 //! So for example there is a [page for the primitive type
 //! `char`](primitive::char) that lists all the methods that can be called on
 //! characters (very useful), and there is a [page for the module
-//! `std::char`] that documents iterator and error types created by these methods
+//! `std::char`](crate::char) that documents iterator and error types created by these methods
 //! (rarely useful).
 //!
 //! Note the documentation for the primitives [`str`] and [`[T]`][prim@slice] (also
@@ -180,9 +180,6 @@
 //!
 //!
 //! [I/O]: io
-//! [`MIN`]: i32::MIN
-//! [`MAX`]: i32::MAX
-//! [page for the module `std::i32`]: crate::i32
 //! [TCP]: net::TcpStream
 //! [The Rust Prelude]: prelude
 //! [UDP]: net::UdpSocket


### PR DESCRIPTION
Missed this in rust-lang/rust#147373.