### PR TITLE
some `ErrorGuaranteed` cleanups

### DIFF
--- a/compiler/rustc_hir_analysis/src/check/wfcheck.rs
+++ b/compiler/rustc_hir_analysis/src/check/wfcheck.rs
@@ -1651,9 +1651,7 @@ fn check_method_receiver<'tcx>(
 
     // If the receiver already has errors reported, consider it valid to avoid
     // unnecessary errors (#58712).
-    if receiver_ty.references_error() {
-        return Ok(());
-    }
+    receiver_ty.error_reported()?;
 
     let arbitrary_self_types_level = if tcx.features().arbitrary_self_types_pointers() {
         Some(ArbitrarySelfTypesLevel::WithPointers)

--- a/compiler/rustc_hir_analysis/src/coherence/mod.rs
+++ b/compiler/rustc_hir_analysis/src/coherence/mod.rs
@@ -39,9 +39,7 @@ fn check_impl<'tcx>(
 
     // Skip impls where one of the self type is an error type.
     // This occurs with e.g., resolve failures (#30589).
-    if trait_ref.references_error() {
-        return Ok(());
-    }
+    trait_ref.error_reported()?;
 
     enforce_trait_manually_implementable(tcx, impl_def_id, trait_ref.def_id, trait_def)
         .and(enforce_empty_impls_for_marker_traits(tcx, impl_def_id, trait_ref.def_id, trait_def))
@@ -188,9 +186,9 @@ fn check_object_overlap<'tcx>(
 ) -> Result<(), ErrorGuaranteed> {
     let trait_def_id = trait_ref.def_id;
 
-    if trait_ref.references_error() {
+    if let Err(guar) = trait_ref.error_reported() {
         debug!("coherence: skipping impl {:?} with error {:?}", impl_def_id, trait_ref);
-        return Ok(());
+        return Err(guar);
     }
 
     // check for overlap with the automatic `impl Trait for dyn Trait`

--- a/compiler/rustc_hir_analysis/src/impl_wf_check.rs
+++ b/compiler/rustc_hir_analysis/src/impl_wf_check.rs
@@ -76,20 +76,10 @@ pub(crate) fn enforce_impl_lifetime_params_are_constrained(
     impl_def_id: LocalDefId,
 ) -> Result<(), ErrorGuaranteed> {
     let impl_self_ty = tcx.type_of(impl_def_id).instantiate_identity();
-    if impl_self_ty.references_error() {
-        // Don't complain about unconstrained type params when self ty isn't known due to errors.
-        // (#36836)
-        tcx.dcx().span_delayed_bug(
-            tcx.def_span(impl_def_id),
-            format!(
-                "potentially unconstrained type parameters weren't evaluated: {impl_self_ty:?}",
-            ),
-        );
-        // This is super fishy, but our current `rustc_hir_analysis::check_crate` pipeline depends on
-        // `type_of` having been called much earlier, and thus this value being read from cache.
-        // Compilation must continue in order for other important diagnostics to keep showing up.
-        return Ok(());
-    }
+
+    // Don't complain about unconstrained type params when self ty isn't known due to errors.
+    // (#36836)
+    impl_self_ty.error_reported()?;
 
     let impl_generics = tcx.generics_of(impl_def_id);
     let impl_predicates = tcx.predicates_of(impl_def_id);
@@ -174,20 +164,11 @@ pub(crate) fn enforce_impl_non_lifetime_params_are_constrained(
     impl_def_id: LocalDefId,
 ) -> Result<(), ErrorGuaranteed> {
     let impl_self_ty = tcx.type_of(impl_def_id).instantiate_identity();
-    if impl_self_ty.references_error() {
-        // Don't complain about unconstrained type params when self ty isn't known due to errors.
-        // (#36836)
-        tcx.dcx().span_delayed_bug(
-            tcx.def_span(impl_def_id),
-            format!(
-                "potentially unconstrained type parameters weren't evaluated: {impl_self_ty:?}",
-            ),
-        );
-        // This is super fishy, but our current `rustc_hir_analysis::check_crate` pipeline depends on
-        // `type_of` having been called much earlier, and thus this value being read from cache.
-        // Compilation must continue in order for other important diagnostics to keep showing up.
-        return Ok(());
-    }
+
+    // Don't complain about unconstrained type params when self ty isn't known due to errors.
+    // (#36836)
+    impl_self_ty.error_reported()?;
+
     let impl_generics = tcx.generics_of(impl_def_id);
     let impl_predicates = tcx.predicates_of(impl_def_id);
     let impl_trait_ref = tcx.impl_trait_ref(impl_def_id).map(ty::EarlyBinder::instantiate_identity);

--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -685,9 +685,11 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         });
         let ty =
             self.check_expr_with_expectation_and_needs(oprnd, hint, Needs::maybe_mut_place(mutbl));
+        if let Err(guar) = ty.error_reported() {
+            return Ty::new_error(self.tcx, guar);
+        }
 
         match kind {
-            _ if ty.references_error() => Ty::new_misc_error(self.tcx),
             hir::BorrowKind::Raw => {
                 self.check_named_place_expr(oprnd);
                 Ty::new_ptr(self.tcx, ty, mutbl)


### PR DESCRIPTION
If we've got an `ErrorGuaranteed`, use it.