### PR TITLE
LLBC-linker: Do not strip debug symbols for the nvptx target anymore

### DIFF
--- a/src/tools/llvm-bitcode-linker/Cargo.toml
+++ b/src/tools/llvm-bitcode-linker/Cargo.toml
@@ -3,7 +3,7 @@ name = "llvm-bitcode-linker"
 version = "0.0.1"
 description = "A self-contained linker for llvm bitcode"
 license = "MIT OR Apache-2.0"
-edition = "2021"
+edition = "2024"
 publish = false
 
 [dependencies]

--- a/src/tools/llvm-bitcode-linker/src/linker.rs
+++ b/src/tools/llvm-bitcode-linker/src/linker.rs
@@ -2,11 +2,10 @@ use std::path::PathBuf;
 
 use anyhow::Context;
 
-use crate::{Optimization, Target};
+use crate::Optimization;
 
 #[derive(Debug)]
 pub struct Session {
-    target: Target,
     cpu: Option<String>,
     feature: Option<String>,
     symbols: Vec<String>,
@@ -32,8 +31,9 @@ impl Session {
         let opt_path = out_path.with_extension("optimized.o");
         let sym_path = out_path.with_extension("symbols.txt");
 
+        tracing::debug!(%target, ?cpu, ?feature, ?out_path, "new session created");
+
         Session {
-            target,
             cpu,
             feature,
             symbols: Vec::new(),
@@ -86,14 +86,8 @@ impl Session {
     /// Optimize and compile to native format using `opt` and `llc`
     ///
     /// Before this can be called `link` needs to be called
-    fn optimize(&mut self, optimization: Optimization, mut debug: bool) -> anyhow::Result<()> {
+    fn optimize(&mut self, optimization: Optimization, debug: bool) -> anyhow::Result<()> {
         let mut passes = format!("default<{}>", optimization);
-
-        // FIXME(@kjetilkjeka) Debug symbol generation is broken for nvptx64 so we must remove them even in debug mode
-        if debug && self.target == crate::Target::Nvptx64NvidiaCuda {
-            tracing::warn!("nvptx64 target detected - stripping debug symbols");
-            debug = false;
-        }
 
         // We add an internalize pass as the rust compiler as we require exported symbols to be explicitly marked
         passes.push_str(",internalize,globaldce");

--- a/src/tools/llvm-bitcode-linker/src/target.rs
+++ b/src/tools/llvm-bitcode-linker/src/target.rs
@@ -18,3 +18,11 @@ impl std::str::FromStr for Target {
         }
     }
 }
+
+impl std::fmt::Display for Target {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Target::Nvptx64NvidiaCuda => f.write_str("nvptx64-nvidia-cuda"),
+        }
+    }
+}

--- a/tests/assembly-llvm/nvptx-debug.rs
+++ b/tests/assembly-llvm/nvptx-debug.rs
@@ -1,0 +1,24 @@
+//@ assembly-output: emit-asm
+//@ compile-flags: --crate-type cdylib -C debuginfo=2
+//@ only-nvptx64
+
+// Tests related to debug symbols for nvptx
+
+#![feature(abi_ptx)]
+#![no_std]
+
+//@ aux-build: breakpoint-panic-handler.rs
+extern crate breakpoint_panic_handler;
+
+#[no_mangle]
+pub extern "ptx-kernel" fn foo() {
+    panic!("bar");
+}
+
+// We make sure that all debug sections are available and visit them
+// CHECK: .section .debug_abbrev
+// CHECK: .section .debug_info
+
+// Issue #99248 describes a bug where `.` was used as a seperator
+// instead of `_` for `anon`s in `.debug_info`
+// CHECK-NOT: anon.


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/147672)*
<!-- homu-ignore:end -->

With LLVM >= 20 and PTX ISA version >= 7.0 the problems described in rust-lang/rust#99248 with debug symbols seems to be fixed :tada: 

Since PTX isa versions < 7.0 is unsupported on the main branch and the upcoming beta release it's possible to finally remove the hack we had where we stripped debug symbols unconditionally for the nvptx64-nvidia-cuda target.

closes: https://github.com/rust-lang/rust/issues/99248