### PR TITLE
Rollup of 10 pull requests

### DIFF
--- a/compiler/rustc_ast/src/entry.rs
+++ b/compiler/rustc_ast/src/entry.rs
@@ -1,7 +1,5 @@
 use rustc_span::{Symbol, sym};
 
-use crate::attr::{self, AttributeExt};
-
 #[derive(Debug)]
 pub enum EntryPointType {
     /// This function is not an entrypoint.
@@ -30,11 +28,11 @@ pub enum EntryPointType {
 }
 
 pub fn entry_point_type(
-    attrs: &[impl AttributeExt],
+    has_rustc_main: bool,
     at_root: bool,
     name: Option<Symbol>,
 ) -> EntryPointType {
-    if attr::contains_name(attrs, sym::rustc_main) {
+    if has_rustc_main {
         EntryPointType::RustcMainAttr
     } else if let Some(name) = name
         && name == sym::main

--- a/compiler/rustc_attr_parsing/src/attributes/rustc_internal.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/rustc_internal.rs
@@ -1,9 +1,18 @@
 use super::prelude::*;
 use super::util::parse_single_integer;
 
-pub(crate) struct RustcLayoutScalarValidRangeStart;
+pub(crate) struct RustcMainParser;
 
-impl<S: Stage> SingleAttributeParser<S> for RustcLayoutScalarValidRangeStart {
+impl<S: Stage> NoArgsAttributeParser<S> for RustcMainParser {
+    const PATH: &'static [Symbol] = &[sym::rustc_main];
+    const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Error;
+    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Fn)]);
+    const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcMain;
+}
+
+pub(crate) struct RustcLayoutScalarValidRangeStartParser;
+
+impl<S: Stage> SingleAttributeParser<S> for RustcLayoutScalarValidRangeStartParser {
     const PATH: &'static [Symbol] = &[sym::rustc_layout_scalar_valid_range_start];
     const ATTRIBUTE_ORDER: AttributeOrder = AttributeOrder::KeepInnermost;
     const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Error;
@@ -16,9 +25,9 @@ impl<S: Stage> SingleAttributeParser<S> for RustcLayoutScalarValidRangeStart {
     }
 }
 
-pub(crate) struct RustcLayoutScalarValidRangeEnd;
+pub(crate) struct RustcLayoutScalarValidRangeEndParser;
 
-impl<S: Stage> SingleAttributeParser<S> for RustcLayoutScalarValidRangeEnd {
+impl<S: Stage> SingleAttributeParser<S> for RustcLayoutScalarValidRangeEndParser {
     const PATH: &'static [Symbol] = &[sym::rustc_layout_scalar_valid_range_end];
     const ATTRIBUTE_ORDER: AttributeOrder = AttributeOrder::KeepInnermost;
     const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Error;

--- a/compiler/rustc_attr_parsing/src/context.rs
+++ b/compiler/rustc_attr_parsing/src/context.rs
@@ -53,7 +53,7 @@ use crate::attributes::proc_macro_attrs::{
 use crate::attributes::prototype::CustomMirParser;
 use crate::attributes::repr::{AlignParser, AlignStaticParser, ReprParser};
 use crate::attributes::rustc_internal::{
-    RustcLayoutScalarValidRangeEnd, RustcLayoutScalarValidRangeStart,
+    RustcLayoutScalarValidRangeEndParser, RustcLayoutScalarValidRangeStartParser, RustcMainParser,
     RustcObjectLifetimeDefaultParser, RustcSimdMonomorphizeLaneLimitParser,
 };
 use crate::attributes::semantics::MayDangleParser;
@@ -197,8 +197,8 @@ attribute_parsers!(
         Single<RecursionLimitParser>,
         Single<RustcBuiltinMacroParser>,
         Single<RustcForceInlineParser>,
-        Single<RustcLayoutScalarValidRangeEnd>,
-        Single<RustcLayoutScalarValidRangeStart>,
+        Single<RustcLayoutScalarValidRangeEndParser>,
+        Single<RustcLayoutScalarValidRangeStartParser>,
         Single<RustcObjectLifetimeDefaultParser>,
         Single<RustcSimdMonomorphizeLaneLimitParser>,
         Single<SanitizeParser>,
@@ -238,6 +238,7 @@ attribute_parsers!(
         Single<WithoutArgs<ProcMacroParser>>,
         Single<WithoutArgs<PubTransparentParser>>,
         Single<WithoutArgs<RustcCoherenceIsCoreParser>>,
+        Single<WithoutArgs<RustcMainParser>>,
         Single<WithoutArgs<SpecializationTraitParser>>,
         Single<WithoutArgs<StdInternalSymbolParser>>,
         Single<WithoutArgs<TrackCallerParser>>,

--- a/compiler/rustc_builtin_macros/src/test_harness.rs
+++ b/compiler/rustc_builtin_macros/src/test_harness.rs
@@ -3,6 +3,7 @@
 use std::mem;
 
 use rustc_ast as ast;
+use rustc_ast::attr::contains_name;
 use rustc_ast::entry::EntryPointType;
 use rustc_ast::mut_visit::*;
 use rustc_ast::visit::Visitor;
@@ -172,9 +173,11 @@ impl<'a> Visitor<'a> for InnerItemLinter<'_> {
 
 fn entry_point_type(item: &ast::Item, at_root: bool) -> EntryPointType {
     match &item.kind {
-        ast::ItemKind::Fn(fn_) => {
-            rustc_ast::entry::entry_point_type(&item.attrs, at_root, Some(fn_.ident.name))
-        }
+        ast::ItemKind::Fn(fn_) => rustc_ast::entry::entry_point_type(
+            contains_name(&item.attrs, sym::rustc_main),
+            at_root,
+            Some(fn_.ident.name),
+        ),
         _ => EntryPointType::None,
     }
 }

--- a/compiler/rustc_codegen_ssa/src/codegen_attrs.rs
+++ b/compiler/rustc_codegen_ssa/src/codegen_attrs.rs
@@ -279,7 +279,7 @@ fn process_builtin_attrs(
                 AttributeKind::StdInternalSymbol(_) => {
                     codegen_fn_attrs.flags |= CodegenFnAttrFlags::RUSTC_STD_INTERNAL_SYMBOL
                 }
-                AttributeKind::Linkage(linkage, _) => {
+                AttributeKind::Linkage(linkage, span) => {
                     let linkage = Some(*linkage);
 
                     if tcx.is_foreign_item(did) {
@@ -287,7 +287,7 @@ fn process_builtin_attrs(
 
                         if tcx.is_mutable_static(did.into()) {
                             let mut diag = tcx.dcx().struct_span_err(
-                                attr.span(),
+                                *span,
                                 "extern mutable statics are not allowed with `#[linkage]`",
                             );
                             diag.note(

--- a/compiler/rustc_hir/src/attrs/data_structures.rs
+++ b/compiler/rustc_hir/src/attrs/data_structures.rs
@@ -670,6 +670,9 @@ pub enum AttributeKind {
     /// Represents `#[rustc_layout_scalar_valid_range_start]`.
     RustcLayoutScalarValidRangeStart(Box<u128>, Span),
 
+    /// Represents `#[rustc_main]`.
+    RustcMain,
+
     /// Represents `#[rustc_object_lifetime_default]`.
     RustcObjectLifetimeDefault,
 

--- a/compiler/rustc_hir/src/attrs/encode_cross_crate.rs
+++ b/compiler/rustc_hir/src/attrs/encode_cross_crate.rs
@@ -88,6 +88,7 @@ impl AttributeKind {
             RustcCoherenceIsCore(..) => No,
             RustcLayoutScalarValidRangeEnd(..) => Yes,
             RustcLayoutScalarValidRangeStart(..) => Yes,
+            RustcMain => No,
             RustcObjectLifetimeDefault => No,
             RustcSimdMonomorphizeLaneLimit(..) => Yes, // Affects layout computation, which needs to work cross-crate
             Sanitize { .. } => No,

--- a/compiler/rustc_hir/src/attrs/pretty_printing.rs
+++ b/compiler/rustc_hir/src/attrs/pretty_printing.rs
@@ -26,16 +26,6 @@ pub trait PrintAttribute {
     fn print_attribute(&self, p: &mut Printer);
 }
 
-impl PrintAttribute for u128 {
-    fn should_render(&self) -> bool {
-        true
-    }
-
-    fn print_attribute(&self, p: &mut Printer) {
-        p.word(self.to_string())
-    }
-}
-
 impl<T: PrintAttribute> PrintAttribute for &T {
     fn should_render(&self) -> bool {
         T::should_render(self)
@@ -148,7 +138,7 @@ macro_rules! print_tup {
 
 print_tup!(A B C D E F G H);
 print_skip!(Span, (), ErrorGuaranteed);
-print_disp!(u16, bool, NonZero<u32>, Limit);
+print_disp!(u16, u128, bool, NonZero<u32>, Limit);
 print_debug!(
     Symbol,
     Ident,

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -1315,8 +1315,6 @@ impl AttributeExt for Attribute {
             // FIXME: should not be needed anymore when all attrs are parsed
             Attribute::Parsed(AttributeKind::DocComment { span, .. }) => *span,
             Attribute::Parsed(AttributeKind::Deprecation { span, .. }) => *span,
-            Attribute::Parsed(AttributeKind::AllowInternalUnsafe(span)) => *span,
-            Attribute::Parsed(AttributeKind::Linkage(_, span)) => *span,
             a => panic!("can't get the span of an arbitrary parsed attribute: {a:?}"),
         }
     }

--- a/compiler/rustc_index/src/bit_set.rs
+++ b/compiler/rustc_index/src/bit_set.rs
@@ -789,7 +789,7 @@ impl<T: Idx> BitRelations<ChunkedBitSet<T>> for ChunkedBitSet<T> {
 
             match (&mut self_chunk, &other_chunk) {
                 (_, Zeros) | (Ones, _) => {}
-                (Zeros, Ones) | (Mixed(..), Ones) | (Zeros, Mixed(..)) => {
+                (Zeros, _) | (Mixed(..), Ones) => {
                     // `other_chunk` fully overwrites `self_chunk`
                     *self_chunk = other_chunk.clone();
                     changed = true;
@@ -853,7 +853,7 @@ impl<T: Idx> BitRelations<ChunkedBitSet<T>> for ChunkedBitSet<T> {
 
             match (&mut self_chunk, &other_chunk) {
                 (Zeros, _) | (_, Zeros) => {}
-                (Ones | Mixed(_, _), Ones) => {
+                (Ones | Mixed(..), Ones) => {
                     changed = true;
                     *self_chunk = Zeros;
                 }

--- a/compiler/rustc_index/src/bit_set/tests.rs
+++ b/compiler/rustc_index/src/bit_set/tests.rs
@@ -306,34 +306,6 @@ fn with_elements_chunked(elements: &[usize], domain_size: usize) -> ChunkedBitSe
     s
 }
 
-fn with_elements_standard(elements: &[usize], domain_size: usize) -> DenseBitSet<usize> {
-    let mut s = DenseBitSet::new_empty(domain_size);
-    for &e in elements {
-        assert!(s.insert(e));
-    }
-    s
-}
-
-#[test]
-fn chunked_bitset_into_bitset_operations() {
-    let a = vec![1, 5, 7, 11, 15, 2000, 3000];
-    let b = vec![3, 4, 11, 3000, 4000];
-    let aub = vec![1, 3, 4, 5, 7, 11, 15, 2000, 3000, 4000];
-    let aib = vec![11, 3000];
-
-    let b = with_elements_chunked(&b, 9876);
-
-    let mut union = with_elements_standard(&a, 9876);
-    assert!(union.union(&b));
-    assert!(!union.union(&b));
-    assert!(union.iter().eq(aub.iter().copied()));
-
-    let mut intersection = with_elements_standard(&a, 9876);
-    assert!(intersection.intersect(&b));
-    assert!(!intersection.intersect(&b));
-    assert!(intersection.iter().eq(aib.iter().copied()));
-}
-
 #[test]
 fn chunked_bitset_iter() {
     fn check_iter(bit: &ChunkedBitSet<usize>, vec: &Vec<usize>) {

--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -310,15 +310,17 @@ impl EarlyLintPass for UnsafeCode {
             }
 
             ast::ItemKind::MacroDef(..) => {
-                if let Some(attr) = AttributeParser::parse_limited(
-                    cx.builder.sess(),
-                    &it.attrs,
-                    sym::allow_internal_unsafe,
-                    it.span,
-                    DUMMY_NODE_ID,
-                    Some(cx.builder.features()),
-                ) {
-                    self.report_unsafe(cx, attr.span(), BuiltinUnsafe::AllowInternalUnsafe);
+                if let Some(hir::Attribute::Parsed(AttributeKind::AllowInternalUnsafe(span))) =
+                    AttributeParser::parse_limited(
+                        cx.builder.sess(),
+                        &it.attrs,
+                        sym::allow_internal_unsafe,
+                        it.span,
+                        DUMMY_NODE_ID,
+                        Some(cx.builder.features()),
+                    )
+                {
+                    self.report_unsafe(cx, span, BuiltinUnsafe::AllowInternalUnsafe);
                 }
             }
 

--- a/compiler/rustc_passes/messages.ftl
+++ b/compiler/rustc_passes/messages.ftl
@@ -34,9 +34,6 @@ passes_attr_crate_level =
     .suggestion = to apply to the crate, use an inner attribute
     .note = read <https://doc.rust-lang.org/nightly/rustdoc/the-doc-attribute.html#at-the-crate-level> for more information
 
-passes_attr_only_in_functions =
-    `{$attr}` attribute can only be used on functions
-
 passes_autodiff_attr =
     `#[autodiff]` should be applied to a function
     .label = not a function

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -283,6 +283,7 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                     | AttributeKind::ObjcSelector { .. }
                     | AttributeKind::RustcCoherenceIsCore(..)
                     | AttributeKind::DebuggerVisualizer(..)
+                    | AttributeKind::RustcMain,
                 ) => { /* do nothing  */ }
                 Attribute::Unparsed(attr_item) => {
                     style = Some(attr_item.style);
@@ -2395,14 +2396,8 @@ fn check_invalid_crate_level_attr(tcx: TyCtxt<'_>, attrs: &[Attribute]) {
     // Check for builtin attributes at the crate level
     // which were unsuccessfully resolved due to cannot determine
     // resolution for the attribute macro error.
-    const ATTRS_TO_CHECK: &[Symbol] = &[
-        sym::rustc_main,
-        sym::derive,
-        sym::test,
-        sym::test_case,
-        sym::global_allocator,
-        sym::bench,
-    ];
+    const ATTRS_TO_CHECK: &[Symbol] =
+        &[sym::derive, sym::test, sym::test_case, sym::global_allocator, sym::bench];
 
     for attr in attrs {
         // FIXME(jdonszelmann): all attrs should be combined here cleaning this up some day.

--- a/compiler/rustc_passes/src/errors.rs
+++ b/compiler/rustc_passes/src/errors.rs
@@ -844,14 +844,6 @@ pub(crate) struct FeaturePreviouslyDeclared<'a> {
 }
 
 #[derive(Diagnostic)]
-#[diag(passes_attr_only_in_functions)]
-pub(crate) struct AttrOnlyInFunctions {
-    #[primary_span]
-    pub span: Span,
-    pub attr: Symbol,
-}
-
-#[derive(Diagnostic)]
 #[diag(passes_multiple_rustc_main, code = E0137)]
 pub(crate) struct MultipleRustcMain {
     #[primary_span]

--- a/compiler/rustc_target/src/callconv/bpf.rs
+++ b/compiler/rustc_target/src/callconv/bpf.rs
@@ -29,3 +29,9 @@ pub(crate) fn compute_abi_info<Ty>(fn_abi: &mut FnAbi<'_, Ty>) {
         classify_arg(arg);
     }
 }
+
+pub(crate) fn compute_rust_abi_info<Ty>(fn_abi: &mut FnAbi<'_, Ty>) {
+    if !fn_abi.ret.is_ignore() {
+        classify_ret(&mut fn_abi.ret);
+    }
+}

--- a/compiler/rustc_target/src/callconv/mod.rs
+++ b/compiler/rustc_target/src/callconv/mod.rs
@@ -715,6 +715,7 @@ impl<'a, Ty> FnAbi<'a, Ty> {
             "riscv32" | "riscv64" => riscv::compute_rust_abi_info(cx, self),
             "loongarch32" | "loongarch64" => loongarch::compute_rust_abi_info(cx, self),
             "aarch64" => aarch64::compute_rust_abi_info(cx, self),
+            "bpf" => bpf::compute_rust_abi_info(self),
             _ => {}
         };
 

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -65,7 +65,7 @@
 //! So for example there is a [page for the primitive type
 //! `char`](primitive::char) that lists all the methods that can be called on
 //! characters (very useful), and there is a [page for the module
-//! `std::char`] that documents iterator and error types created by these methods
+//! `std::char`](crate::char) that documents iterator and error types created by these methods
 //! (rarely useful).
 //!
 //! Note the documentation for the primitives [`str`] and [`[T]`][prim@slice] (also
@@ -180,9 +180,6 @@
 //!
 //!
 //! [I/O]: io
-//! [`MIN`]: i32::MIN
-//! [`MAX`]: i32::MAX
-//! [page for the module `std::i32`]: crate::i32
 //! [TCP]: net::TcpStream
 //! [The Rust Prelude]: prelude
 //! [UDP]: net::UdpSocket

--- a/tests/codegen-llvm/bpf-abi-indirect-return.rs
+++ b/tests/codegen-llvm/bpf-abi-indirect-return.rs
@@ -1,0 +1,43 @@
+// Checks that results larger than one register are returned indirectly
+//@ only-bpf
+//@ needs-llvm-components: bpf
+//@ compile-flags: --target bpfel-unknown-none
+
+#![no_std]
+#![no_main]
+
+#[no_mangle]
+fn outer(a: u64) -> u64 {
+    let v = match inner_res(a) {
+        Ok(v) => v,
+        Err(()) => 0,
+    };
+
+    inner_big(v).a[0] as u64
+}
+
+// CHECK-LABEL: define {{.*}} @_ZN{{.*}}inner_res{{.*}}E(
+// CHECK-SAME:   ptr{{[^,]*}},
+// CHECK-SAME:   i64{{[^)]*}}
+#[inline(never)]
+fn inner_res(a: u64) -> Result<u64, ()> {
+    if a == 0 { Err(()) } else { Ok(a + 1) }
+}
+
+struct Big {
+    a: [u16; 32],
+    b: u64,
+}
+
+// CHECK-LABEL: define {{.*}} @_ZN{{.*}}inner_big{{.*}}E(
+// CHECK-SAME:   ptr{{[^,]*}},
+// CHECK-SAME:   i64{{[^)]*}}
+#[inline(never)]
+fn inner_big(a: u64) -> Big {
+    Big { a: [a as u16; 32], b: 42 }
+}
+
+#[panic_handler]
+fn panic(_info: &core::panic::PanicInfo) -> ! {
+    loop {}
+}

--- a/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs-error.rs
+++ b/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs-error.rs
@@ -10,7 +10,7 @@
 #![macro_export]
 //~^ ERROR:  `#[macro_export]` attribute cannot be used on crates
 #![rustc_main]
-//~^ ERROR: `rustc_main` attribute cannot be used at crate level
+//~^ ERROR: `#[rustc_main]` attribute cannot be used on crates
 //~| ERROR: use of an internal attribute [E0658]
 //~| NOTE: the `#[rustc_main]` attribute is an internal implementation detail that will never be stable
 //~| NOTE: the `#[rustc_main]` attribute is used internally to specify test entry point function
@@ -31,7 +31,6 @@
 //~^ ERROR attribute cannot be used on
 mod inline {
     //~^ NOTE the inner attribute doesn't annotate this module
-    //~| NOTE the inner attribute doesn't annotate this module
 
     mod inner { #![inline] }
     //~^ ERROR attribute cannot be used on

--- a/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs-error.stderr
+++ b/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs-error.stderr
@@ -16,6 +16,14 @@ LL | #![macro_export]
    |
    = help: `#[macro_export]` can only be applied to macro defs
 
+error: `#[rustc_main]` attribute cannot be used on crates
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:12:1
+   |
+LL | #![rustc_main]
+   | ^^^^^^^^^^^^^^
+   |
+   = help: `#[rustc_main]` can only be applied to functions
+
 error: `#[path]` attribute cannot be used on crates
   --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:19:1
    |
@@ -57,7 +65,7 @@ LL | #[inline]
    = help: `#[inline]` can only be applied to functions
 
 error: `#[inline]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:36:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:35:17
    |
 LL |     mod inner { #![inline] }
    |                 ^^^^^^^^^^
@@ -65,7 +73,7 @@ LL |     mod inner { #![inline] }
    = help: `#[inline]` can only be applied to functions
 
 error: `#[inline]` attribute cannot be used on structs
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:45:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:44:5
    |
 LL |     #[inline] struct S;
    |     ^^^^^^^^^
@@ -73,7 +81,7 @@ LL |     #[inline] struct S;
    = help: `#[inline]` can only be applied to functions
 
 error: `#[inline]` attribute cannot be used on type aliases
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:48:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:47:5
    |
 LL |     #[inline] type T = S;
    |     ^^^^^^^^^
@@ -81,7 +89,7 @@ LL |     #[inline] type T = S;
    = help: `#[inline]` can only be applied to functions
 
 error: `#[inline]` attribute cannot be used on inherent impl blocks
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:51:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:50:5
    |
 LL |     #[inline] impl S { }
    |     ^^^^^^^^^
@@ -89,7 +97,7 @@ LL |     #[inline] impl S { }
    = help: `#[inline]` can only be applied to functions
 
 error: `#[export_name]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:81:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:80:1
    |
 LL | #[export_name = "2200"]
    | ^^^^^^^^^^^^^^^^^^^^^^^
@@ -97,7 +105,7 @@ LL | #[export_name = "2200"]
    = help: `#[export_name]` can be applied to functions and statics
 
 error: `#[export_name]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:84:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:83:17
    |
 LL |     mod inner { #![export_name="2200"] }
    |                 ^^^^^^^^^^^^^^^^^^^^^^
@@ -105,7 +113,7 @@ LL |     mod inner { #![export_name="2200"] }
    = help: `#[export_name]` can be applied to functions and statics
 
 error: `#[export_name]` attribute cannot be used on structs
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:89:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:88:5
    |
 LL |     #[export_name = "2200"] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^
@@ -113,7 +121,7 @@ LL |     #[export_name = "2200"] struct S;
    = help: `#[export_name]` can be applied to functions and statics
 
 error: `#[export_name]` attribute cannot be used on type aliases
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:92:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:91:5
    |
 LL |     #[export_name = "2200"] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^
@@ -121,7 +129,7 @@ LL |     #[export_name = "2200"] type T = S;
    = help: `#[export_name]` can be applied to functions and statics
 
 error: `#[export_name]` attribute cannot be used on inherent impl blocks
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:95:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:94:5
    |
 LL |     #[export_name = "2200"] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^
@@ -129,7 +137,7 @@ LL |     #[export_name = "2200"] impl S { }
    = help: `#[export_name]` can be applied to functions and statics
 
 error: `#[export_name]` attribute cannot be used on required trait methods
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:99:9
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:98:9
    |
 LL |         #[export_name = "2200"] fn foo();
    |         ^^^^^^^^^^^^^^^^^^^^^^^
@@ -137,7 +145,7 @@ LL |         #[export_name = "2200"] fn foo();
    = help: `#[export_name]` can be applied to functions, inherent methods, provided trait methods, statics, and trait methods in impl blocks
 
 error: attribute should be applied to an `extern crate` item
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:55:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:54:1
    |
 LL |   #[no_link]
    |   ^^^^^^^^^^
@@ -151,7 +159,7 @@ LL | | }
    | |_- not an `extern crate` item
 
 error[E0517]: attribute should be applied to a struct, enum, or union
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:106:8
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:105:8
    |
 LL |   #[repr(C)]
    |          ^
@@ -164,7 +172,7 @@ LL | | }
    | |_- not a struct, enum, or union
 
 error[E0517]: attribute should be applied to a struct, enum, or union
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:130:8
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:129:8
    |
 LL |   #[repr(Rust)]
    |          ^^^^
@@ -182,21 +190,6 @@ error: attribute should be applied to an `extern crate` item
 LL | #![no_link]
    | ^^^^^^^^^^^ not an `extern crate` item
 
-error: `rustc_main` attribute cannot be used at crate level
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:12:1
-   |
-LL | #![rustc_main]
-   | ^^^^^^^^^^^^^^
-...
-LL | mod inline {
-   |     ------ the inner attribute doesn't annotate this module
-   |
-help: perhaps you meant to use an outer attribute
-   |
-LL - #![rustc_main]
-LL + #[rustc_main]
-   |
-
 error: `repr` attribute cannot be used at crate level
   --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:17:1
    |
@@ -213,85 +206,85 @@ LL + #[repr()]
    |
 
 error: attribute should be applied to an `extern crate` item
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:60:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:59:17
    |
 LL |     mod inner { #![no_link] }
    |     ------------^^^^^^^^^^^-- not an `extern crate` item
 
 error: attribute should be applied to an `extern crate` item
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:64:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:63:5
    |
 LL |     #[no_link] fn f() { }
    |     ^^^^^^^^^^ ---------- not an `extern crate` item
 
 error: attribute should be applied to an `extern crate` item
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:68:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:67:5
    |
 LL |     #[no_link] struct S;
    |     ^^^^^^^^^^ --------- not an `extern crate` item
 
 error: attribute should be applied to an `extern crate` item
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:72:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:71:5
    |
 LL |     #[no_link]type T = S;
    |     ^^^^^^^^^^----------- not an `extern crate` item
 
 error: attribute should be applied to an `extern crate` item
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:76:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:75:5
    |
 LL |     #[no_link] impl S { }
    |     ^^^^^^^^^^ ---------- not an `extern crate` item
 
 error[E0517]: attribute should be applied to a struct, enum, or union
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:110:25
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:109:25
    |
 LL |     mod inner { #![repr(C)] }
    |     --------------------^---- not a struct, enum, or union
 
 error[E0517]: attribute should be applied to a struct, enum, or union
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:114:12
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:113:12
    |
 LL |     #[repr(C)] fn f() { }
    |            ^   ---------- not a struct, enum, or union
 
 error[E0517]: attribute should be applied to a struct, enum, or union
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:120:12
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:119:12
    |
 LL |     #[repr(C)] type T = S;
    |            ^   ----------- not a struct, enum, or union
 
 error[E0517]: attribute should be applied to a struct, enum, or union
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:124:12
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:123:12
    |
 LL |     #[repr(C)] impl S { }
    |            ^   ---------- not a struct, enum, or union
 
 error[E0517]: attribute should be applied to a struct, enum, or union
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:134:25
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:133:25
    |
 LL |     mod inner { #![repr(Rust)] }
    |     --------------------^^^^---- not a struct, enum, or union
 
 error[E0517]: attribute should be applied to a struct, enum, or union
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:138:12
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:137:12
    |
 LL |     #[repr(Rust)] fn f() { }
    |            ^^^^   ---------- not a struct, enum, or union
 
 error[E0517]: attribute should be applied to a struct, enum, or union
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:144:12
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:143:12
    |
 LL |     #[repr(Rust)] type T = S;
    |            ^^^^   ----------- not a struct, enum, or union
 
 error[E0517]: attribute should be applied to a struct, enum, or union
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:148:12
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:147:12
    |
 LL |     #[repr(Rust)] impl S { }
    |            ^^^^   ---------- not a struct, enum, or union
 
 error: valid forms for the attribute are `#[inline(always)]`, `#[inline(never)]`, and `#[inline]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:39:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:38:5
    |
 LL |     #[inline = "2100"] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^
@@ -306,7 +299,7 @@ Some errors have detailed explanations: E0517, E0658.
 For more information about an error, try `rustc --explain E0517`.
 Future incompatibility report: Future breakage diagnostic:
 error: valid forms for the attribute are `#[inline(always)]`, `#[inline(never)]`, and `#[inline]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:39:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:38:5
    |
 LL |     #[inline = "2100"] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#146277 (Enable `u64` limbs in `core::num::bignum`)
 - rust-lang/rust#146976 (constify basic Clone impls)
 - rust-lang/rust#147266 (fix 2 search graph bugs)
 - rust-lang/rust#147630 (Bitset cleanups)
 - rust-lang/rust#147638 (bpf: return results larger than one register indirectly)
 - rust-lang/rust#147647 (Hide vendoring and copyright in GHA group)
 - rust-lang/rust#147669 (fix missing link to `std::char` in `std` docs)
 - rust-lang/rust#147673 (pretty print u128 with display)
 - rust-lang/rust#147677 (Fewer exceptions in `span()` on parsed attributes)
 - rust-lang/rust#147682 (convert `rustc_main` to the new attribute parsing infrastructure)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=146277,146976,147266,147630,147638,147647,147669,147673,147677,147682)
<!-- homu-ignore:end -->