### PR TITLE
Implement `bit` and `set_bit` for integral types.

### DIFF
--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -56,6 +56,81 @@ macro_rules! int_impl {
         #[stable(feature = "int_bits_const", since = "1.53.0")]
         pub const BITS: u32 = <$UnsignedT>::BITS;
 
+        /// Tests the value of a specific bit.
+        ///
+        /// # Panics
+        ///
+        /// If overflow checks are enabled, this method will panic if the provided index is
+        /// greater than or equal to [`BITS`].
+        ///
+        /// [`BITS`]: Self::BITS
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// #![feature(get_set_bit)]
+        ///
+        #[doc = concat!("let n = 0b111_1001", stringify!($SelfT), ";")]
+        ///
+        /// assert!(n.bit(0));
+        /// assert!(!n.bit(1));
+        /// assert!(!n.bit(2));
+        /// assert!(n.bit(3));
+        /// assert!(n.bit(4));
+        /// assert!(n.bit(5));
+        /// assert!(n.bit(6));
+        /// ```
+        #[unstable(feature = "get_set_bit", issue = "147702")]
+        #[rustc_const_unstable(feature = "get_set_bit", issue = "147702")]
+        #[rustc_inherit_overflow_checks]
+        #[inline]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[track_caller]
+        pub const fn bit(self, index: u32) -> bool {
+            self & (1 as $SelfT) << index != (0 as $SelfT)
+        }
+
+        /// Sets the value of a specific bit.
+        ///
+        /// # Panics
+        ///
+        /// If overflow checks are enabled, this method will panic if the provided index is
+        /// greater than or equal to [`BITS`].
+        ///
+        /// [`BITS`]: Self::BITS
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// #![feature(get_set_bit)]
+        ///
+        #[doc = concat!("let mut n = 0b101_0101", stringify!($SelfT), ";")]
+        ///
+        /// n = n.set_bit(0, false);
+        /// n = n.set_bit(1, true);
+        /// n = n.set_bit(2, false);
+        /// n = n.set_bit(3, true);
+        /// n = n.set_bit(4, false);
+        /// n = n.set_bit(5, true);
+        /// n = n.set_bit(6, false);
+        ///
+        /// assert_eq!(n, 0b010_1010);
+        /// ```
+        #[unstable(feature = "get_set_bit", issue = "147702")]
+        #[rustc_const_unstable(feature = "get_set_bit", issue = "147702")]
+        #[rustc_inherit_overflow_checks]
+        #[inline]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[track_caller]
+        pub const fn set_bit(mut self, index: u32, value: bool) -> Self {
+            self &= !((1 as $SelfT) << index);
+            self |= (value as $SelfT) << index;
+
+            self
+        }
+
         /// Returns the number of ones in the binary representation of `self`.
         ///
         /// # Examples

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -60,6 +60,83 @@ macro_rules! uint_impl {
         #[stable(feature = "int_bits_const", since = "1.53.0")]
         pub const BITS: u32 = Self::MAX.count_ones();
 
+        /// Tests the value of a specific bit.
+        ///
+        /// # Panics
+        ///
+        /// If overflow checks are enabled, this method will panic if the provided index is
+        /// greater than or equal to [`BITS`].
+        ///
+        /// [`BITS`]: Self::BITS
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// #![feature(get_set_bit)]
+        ///
+        #[doc = concat!("let n = 0b0111_1001", stringify!($SelfT), ";")]
+        ///
+        /// assert!(n.bit(0));
+        /// assert!(!n.bit(1));
+        /// assert!(!n.bit(2));
+        /// assert!(n.bit(3));
+        /// assert!(n.bit(4));
+        /// assert!(n.bit(5));
+        /// assert!(n.bit(6));
+        /// assert!(!n.bit(7));
+        /// ```
+        #[unstable(feature = "get_set_bit", issue = "147702")]
+        #[rustc_const_unstable(feature = "get_set_bit", issue = "147702")]
+        #[rustc_inherit_overflow_checks]
+        #[inline]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[track_caller]
+        pub const fn bit(self, index: u32) -> bool {
+            self & (1 as $SelfT) << index != (0 as $SelfT)
+        }
+
+        /// Sets the value of a specific bit.
+        ///
+        /// # Panics
+        ///
+        /// If overflow checks are enabled, this method will panic if the provided index is
+        /// greater than or equal [`BITS`].
+        ///
+        /// [`BITS`]: Self::BITS
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// #![feature(get_set_bit)]
+        ///
+        #[doc = concat!("let mut n = 0b0101_0101", stringify!($SelfT), ";")]
+        ///
+        /// n = n.set_bit(0, false);
+        /// n = n.set_bit(1, true);
+        /// n = n.set_bit(2, false);
+        /// n = n.set_bit(3, true);
+        /// n = n.set_bit(4, false);
+        /// n = n.set_bit(5, true);
+        /// n = n.set_bit(6, false);
+        /// n = n.set_bit(7, true);
+        ///
+        /// assert_eq!(n, 0b1010_1010);
+        /// ```
+        #[unstable(feature = "get_set_bit", issue = "147702")]
+        #[rustc_const_unstable(feature = "get_set_bit", issue = "147702")]
+        #[rustc_inherit_overflow_checks]
+        #[inline]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[track_caller]
+        pub const fn set_bit(mut self, index: u32, value: bool) -> Self {
+            self &= !((1 as $SelfT) << index);
+            self |= (value as $SelfT) << index;
+
+            self
+        }
+
         /// Returns the number of ones in the binary representation of `self`.
         ///
         /// # Examples

--- a/library/coretests/tests/lib.rs
+++ b/library/coretests/tests/lib.rs
@@ -64,6 +64,7 @@
 #![feature(funnel_shifts)]
 #![feature(future_join)]
 #![feature(generic_assert_internals)]
+#![feature(get_set_bit)]
 #![feature(hasher_prefixfree_extras)]
 #![feature(hashmap_internals)]
 #![feature(int_from_ascii)]

--- a/library/coretests/tests/num/int_macros.rs
+++ b/library/coretests/tests/num/int_macros.rs
@@ -32,7 +32,6 @@ macro_rules! int_module {
         }
 
         test_runtime_and_compiletime! {
-
             fn test_rem_euclid() {
                 assert_eq_const_safe!($T: (-1 as $T).rem_euclid(MIN), MAX);
             }
@@ -73,6 +72,58 @@ macro_rules! int_module {
         const _1: $T = !0;
 
         test_runtime_and_compiletime! {
+            fn test_bit() {
+                assert!(!A.bit(0));
+                assert!(!A.bit(1));
+                assert!(A.bit(2));
+                assert!(A.bit(3));
+                assert!(!A.bit(4));
+                assert!(A.bit(5));
+                assert!(!A.bit(6));
+
+                assert!(B.bit(0));
+                assert!(!B.bit(1));
+                assert!(!B.bit(2));
+                assert!(!B.bit(3));
+                assert!(!B.bit(4));
+                assert!(B.bit(5));
+                assert!(!B.bit(6));
+
+                assert!(C.bit(0));
+                assert!(!C.bit(1));
+                assert!(!C.bit(2));
+                assert!(C.bit(3));
+                assert!(C.bit(4));
+                assert!(C.bit(5));
+                assert!(C.bit(6));
+            }
+
+            fn test_set_bit() {
+                assert_eq_const_safe!($T: A.set_bit(0, true), 0b0101101);
+                assert_eq_const_safe!($T: A.set_bit(1, true), 0b0101110);
+                assert_eq_const_safe!($T: A.set_bit(2, false), 0b0101000);
+                assert_eq_const_safe!($T: A.set_bit(3, false), 0b0100100);
+                assert_eq_const_safe!($T: A.set_bit(4, true), 0b0111100);
+                assert_eq_const_safe!($T: A.set_bit(5, false), 0b0001100);
+                assert_eq_const_safe!($T: A.set_bit(6, true), 0b1101100);
+
+                assert_eq_const_safe!($T: B.set_bit(0, false), 0b0100000);
+                assert_eq_const_safe!($T: B.set_bit(1, true), 0b0100011);
+                assert_eq_const_safe!($T: B.set_bit(2, true), 0b0100101);
+                assert_eq_const_safe!($T: B.set_bit(3, true), 0b0101001);
+                assert_eq_const_safe!($T: B.set_bit(4, true), 0b0110001);
+                assert_eq_const_safe!($T: B.set_bit(5, false), 0b0000001);
+                assert_eq_const_safe!($T: B.set_bit(6, true), 0b1100001);
+
+                assert_eq_const_safe!($T: C.set_bit(0, false), 0b1111000);
+                assert_eq_const_safe!($T: C.set_bit(1, true), 0b1111011);
+                assert_eq_const_safe!($T: C.set_bit(2, true), 0b1111101);
+                assert_eq_const_safe!($T: C.set_bit(3, false), 0b1110001);
+                assert_eq_const_safe!($T: C.set_bit(4, false), 0b1101001);
+                assert_eq_const_safe!($T: C.set_bit(5, false), 0b1011001);
+                assert_eq_const_safe!($T: C.set_bit(6, false), 0b0111001);
+            }
+
             fn test_count_ones() {
                 assert_eq_const_safe!(u32: A.count_ones(), 3);
                 assert_eq_const_safe!(u32: B.count_ones(), 2);

--- a/library/coretests/tests/num/uint_macros.rs
+++ b/library/coretests/tests/num/uint_macros.rs
@@ -35,6 +35,58 @@ macro_rules! uint_module {
         const _1: $T = !0;
 
         test_runtime_and_compiletime! {
+            fn test_bit() {
+                assert!(!A.bit(0));
+                assert!(!A.bit(1));
+                assert!(A.bit(2));
+                assert!(A.bit(3));
+                assert!(!A.bit(4));
+                assert!(A.bit(5));
+                assert!(!A.bit(6));
+
+                assert!(B.bit(0));
+                assert!(!B.bit(1));
+                assert!(!B.bit(2));
+                assert!(!B.bit(3));
+                assert!(!B.bit(4));
+                assert!(B.bit(5));
+                assert!(!B.bit(6));
+
+                assert!(C.bit(0));
+                assert!(!C.bit(1));
+                assert!(!C.bit(2));
+                assert!(C.bit(3));
+                assert!(C.bit(4));
+                assert!(C.bit(5));
+                assert!(C.bit(6));
+            }
+
+            fn test_set_bit() {
+                assert_eq_const_safe!($T: A.set_bit(0, true), 0b0101101);
+                assert_eq_const_safe!($T: A.set_bit(1, true), 0b0101110);
+                assert_eq_const_safe!($T: A.set_bit(2, false), 0b0101000);
+                assert_eq_const_safe!($T: A.set_bit(3, false), 0b0100100);
+                assert_eq_const_safe!($T: A.set_bit(4, true), 0b0111100);
+                assert_eq_const_safe!($T: A.set_bit(5, false), 0b0001100);
+                assert_eq_const_safe!($T: A.set_bit(6, true), 0b1101100);
+
+                assert_eq_const_safe!($T: B.set_bit(0, false), 0b0100000);
+                assert_eq_const_safe!($T: B.set_bit(1, true), 0b0100011);
+                assert_eq_const_safe!($T: B.set_bit(2, true), 0b0100101);
+                assert_eq_const_safe!($T: B.set_bit(3, true), 0b0101001);
+                assert_eq_const_safe!($T: B.set_bit(4, true), 0b0110001);
+                assert_eq_const_safe!($T: B.set_bit(5, false), 0b0000001);
+                assert_eq_const_safe!($T: B.set_bit(6, true), 0b1100001);
+
+                assert_eq_const_safe!($T: C.set_bit(0, false), 0b1111000);
+                assert_eq_const_safe!($T: C.set_bit(1, true), 0b1111011);
+                assert_eq_const_safe!($T: C.set_bit(2, true), 0b1111101);
+                assert_eq_const_safe!($T: C.set_bit(3, false), 0b1110001);
+                assert_eq_const_safe!($T: C.set_bit(4, false), 0b1101001);
+                assert_eq_const_safe!($T: C.set_bit(5, false), 0b1011001);
+                assert_eq_const_safe!($T: C.set_bit(6, false), 0b0111001);
+            }
+
             fn test_count_ones() {
                 assert!(A.count_ones() == 3);
                 assert!(B.count_ones() == 2);

--- a/tests/ui/const-generics/issues/issue-86820.rs
+++ b/tests/ui/const-generics/issues/issue-86820.rs
@@ -5,7 +5,7 @@ use std::ops::BitAnd;
 
 const C: fn() = || is_set();
 fn is_set() {
-    0xffu8.bit::<0>();
+    Bits::bit::<0>(0xffu8);
 }
 
 trait Bits {


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/147696)*
<!-- homu-ignore:end -->

Tracking issue: rust-lang/rust#147702

This PR implements the `bit` and `set_bit` methods for integral types:

```rust
impl u8 {
    pub const fn bit(self, index: u32) -> bool;

    pub const fn set_bit(self, index: u32, value: bool) -> Self;
}

impl u16 {
    pub const fn bit(self, index: u32) -> bool;

    pub const fn set_bit(self, index: u32, value: bool) -> Self;
}

impl u32 {
    pub const fn bit(self, index: u32) -> bool;

    pub const fn set_bit(self, index: u32, value: bool) -> Self;
}

impl u64 {
    pub const fn bit(self, index: u32) -> bool;

    pub const fn set_bit(self, index: u32, value: bool) -> Self;
}

impl u128 {
    pub const fn bit(self, index: u32) -> bool;

    pub const fn set_bit(self, index: u32, value: bool) -> Self;
}

impl usize {
    pub const fn bit(self, index: u32) -> bool;

    pub const fn set_bit(self, index: u32, value: bool) -> Self;
}

impl i8 {
    pub const fn bit(self, index: u32) -> bool;

    pub const fn set_bit(self, index: u32, value: bool) -> Self;
}

impl i16 {
    pub const fn bit(self, index: u32) -> bool;

    pub const fn set_bit(self, index: u32, value: bool) -> Self;
}

impl i32 {
    pub const fn bit(self, index: u32) -> bool;

    pub const fn set_bit(self, index: u32, value: bool) -> Self;
}

impl i64 {
    pub const fn bit(self, index: u32) -> bool;

    pub const fn set_bit(self, index: u32, value: bool) -> Self;
}

impl i128 {
    pub const fn bit(self, index: u32) -> bool;

    pub const fn set_bit(self, index: u32, value: bool) -> Self;
}

impl isize {
    pub const fn bit(self, index: u32) -> bool;

    pub const fn set_bit(self, index: u32, value: bool) -> Self;
}
```