### PR TITLE
rustdoc: don't ignore path distance for doc aliases

### DIFF
--- a/src/librustdoc/html/static/js/search.js
+++ b/src/librustdoc/html/static/js/search.js
@@ -3933,16 +3933,25 @@ class DocSearch {
                  * @returns {Promise<rustdoc.PlainResultObject?>}
                  */
                 const handleAlias = async(name, alias, dist, index) => {
+                    const item = nonnull(await this.getRow(alias, false));
+                    // space both is an alias for ::,
+                    // and is also allowed to appear in doc alias names
+                    const path_dist = name.includes(" ") || parsedQuery.elems.length === 0 ?
+                        0 : checkRowPath(parsedQuery.elems[0].pathWithoutLast, item);
+                    // path distance exceeds max, omit alias from results
+                    if (path_dist === null) {
+                        return null;
+                    }
                     return {
                         id: alias,
                         dist,
-                        path_dist: 0,
+                        path_dist,
                         index,
                         alias: name,
                         is_alias: true,
                         elems: [], // only used in type-based queries
                         returned: [], // only used in type-based queries
-                        item: nonnull(await this.getRow(alias, false)),
+                        item,
                     };
                 };
                 /**

--- a/tests/rustdoc-js/alias-path-distance-146214.js
+++ b/tests/rustdoc-js/alias-path-distance-146214.js
@@ -16,4 +16,17 @@ const EXPECTED = [
             { 'path': 'alias_path_distance::Foo', 'name': 'baz' },
         ],
     },
+    {
+        'query': 'Foo::zzzz',
+        'others': [
+            { 'path': 'alias_path_distance::Foo', 'name': 'baz' },
+        ],
+    },
+    {
+        'query': 'zzzz',
+        'others': [
+            { 'path': 'alias_path_distance::Foo', 'name': 'baz' },
+            { 'path': 'alias_path_distance::Bar', 'name': 'baz' },
+        ],
+    },
 ];

--- a/tests/rustdoc-js/alias-path-distance-146214.js
+++ b/tests/rustdoc-js/alias-path-distance-146214.js
@@ -3,7 +3,17 @@
 // consider path distance for doc aliases
 // regression test for <https://github.com/rust-lang/rust/issues/146214>
 
-const EXPECTED = {
-    'query': 'Foo::zzz',
-    'others': [{ 'path': 'alias_path_distance::Foo', 'name': 'baz' }],
-};
+const EXPECTED = [
+    {
+        'query': 'Foo::zzz',
+        'others': [
+            { 'path': 'alias_path_distance::Foo', 'name': 'baz' },
+        ],
+    },
+    {
+        'query': '"Foo::zzz"',
+        'others': [
+            { 'path': 'alias_path_distance::Foo', 'name': 'baz' },
+        ],
+    },
+];

--- a/tests/rustdoc-js/alias-path-distance-146214.js
+++ b/tests/rustdoc-js/alias-path-distance-146214.js
@@ -1,0 +1,9 @@
+// exact-check
+
+// consider path distance for doc aliases
+// regression test for <https://github.com/rust-lang/rust/issues/146214>
+
+const EXPECTED = {
+    'query': 'Foo::zzz',
+    'others': [{ 'path': 'alias_path_distance::Foo', 'name': 'baz' }],
+};

--- a/tests/rustdoc-js/alias-path-distance-146214.rs
+++ b/tests/rustdoc-js/alias-path-distance-146214.rs
@@ -1,0 +1,14 @@
+#![crate_name = "alias_path_distance"]
+
+pub struct Foo;
+pub struct Bar;
+
+impl Foo {
+    #[doc(alias = "zzz")]
+    pub fn baz() {}
+}
+
+impl Bar {
+    #[doc(alias = "zzz")]
+    pub fn baz() {}
+}

--- a/tests/rustdoc-js/alias-rank-lower-140968.js
+++ b/tests/rustdoc-js/alias-rank-lower-140968.js
@@ -1,0 +1,10 @@
+// rank doc aliases lower than exact matches
+// regression test for <https://github.com/rust-lang/rust/issues/140968>
+
+const EXPECTED = {
+    'query': 'Foo',
+    'others': [
+        { 'path': 'alias_rank_lower', 'name': 'Foo' },
+        { 'path': 'alias_rank_lower', 'name': 'Bar' },
+    ],
+};

--- a/tests/rustdoc-js/alias-rank-lower-140968.rs
+++ b/tests/rustdoc-js/alias-rank-lower-140968.rs
@@ -1,0 +1,6 @@
+#![crate_name = "alias_rank_lower"]
+
+pub struct Foo;
+
+#[doc(alias = "Foo")]
+pub struct Bar;


### PR DESCRIPTION
Ran into a bit of an issue due to the overloading of space (it needs to be a metachar for most searches, but not for doc aliases that have space in them).  Not sure if I need to also need to account for other whitespace chars.

<img width="1778" height="494" alt="screenshot" src="https://github.com/user-attachments/assets/041e76f1-3b29-4de5-a72b-1431021fb676" />


fixes https://github.com/rust-lang/rust/issues/146214

r? @GuillaumeGomez 

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
