### PR TITLE
const `mem::drop`

### DIFF
--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -6,7 +6,7 @@
 #![stable(feature = "rust1", since = "1.0.0")]
 
 use crate::alloc::Layout;
-use crate::marker::DiscriminantKind;
+use crate::marker::{Destruct, DiscriminantKind};
 use crate::panic::const_assert;
 use crate::{clone, cmp, fmt, hash, intrinsics, ptr};
 
@@ -958,8 +958,13 @@ pub const fn replace<T>(dest: &mut T, src: T) -> T {
 /// [`RefCell`]: crate::cell::RefCell
 #[inline]
 #[stable(feature = "rust1", since = "1.0.0")]
+#[rustc_const_unstable(feature = "const_destruct", issue = "133214")]
 #[rustc_diagnostic_item = "mem_drop"]
-pub fn drop<T>(_x: T) {}
+pub const fn drop<T>(_x: T)
+where
+    T: [const] Destruct,
+{
+}
 
 /// Bitwise-copies a value.
 ///

--- a/tests/ui/traits/next-solver/alias-bound-unsound.rs
+++ b/tests/ui/traits/next-solver/alias-bound-unsound.rs
@@ -4,6 +4,10 @@
 
 #![feature(trivial_bounds)]
 
+// we use identity instead of drop because the presence of [const] Destruct means that there
+// are additional bounds on the function, which result in additional errors
+use std::convert::identity;
+
 trait Foo {
     type Item: Copy
     where
@@ -21,7 +25,7 @@ impl Foo for () {
 
 fn main() {
     let x = String::from("hello, world");
-    drop(<() as Foo>::copy_me(&x));
+    let _ = identity(<() as Foo>::copy_me(&x));
     //~^ ERROR overflow evaluating the requirement `String <: <() as Foo>::Item`
     //~| ERROR overflow evaluating the requirement `<() as Foo>::Item well-formed`
     //~| ERROR overflow evaluating the requirement `&<() as Foo>::Item well-formed`

--- a/tests/ui/traits/next-solver/alias-bound-unsound.stderr
+++ b/tests/ui/traits/next-solver/alias-bound-unsound.stderr
@@ -1,11 +1,11 @@
 error[E0275]: overflow evaluating the requirement `String: Copy`
-  --> $DIR/alias-bound-unsound.rs:18:38
+  --> $DIR/alias-bound-unsound.rs:22:38
    |
 LL |     type Item = String where String: Copy;
    |                                      ^^^^
    |
 note: the requirement `String: Copy` appears on the `impl`'s associated type `Item` but not on the corresponding trait's associated type
-  --> $DIR/alias-bound-unsound.rs:8:10
+  --> $DIR/alias-bound-unsound.rs:12:10
    |
 LL | trait Foo {
    |       --- in this trait
@@ -13,50 +13,50 @@ LL |     type Item: Copy
    |          ^^^^ this trait's associated type doesn't have the requirement `String: Copy`
 
 error[E0275]: overflow evaluating the requirement `String <: <() as Foo>::Item`
-  --> $DIR/alias-bound-unsound.rs:24:31
+  --> $DIR/alias-bound-unsound.rs:28:43
    |
-LL |     drop(<() as Foo>::copy_me(&x));
-   |                               ^^
+LL |     let _ = identity(<() as Foo>::copy_me(&x));
+   |                                           ^^
 
 error[E0275]: overflow evaluating the requirement `<() as Foo>::Item == _`
-  --> $DIR/alias-bound-unsound.rs:24:10
+  --> $DIR/alias-bound-unsound.rs:28:22
    |
-LL |     drop(<() as Foo>::copy_me(&x));
-   |          ^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     let _ = identity(<() as Foo>::copy_me(&x));
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0275]: overflow evaluating the requirement `<() as Foo>::Item == _`
-  --> $DIR/alias-bound-unsound.rs:24:10
+  --> $DIR/alias-bound-unsound.rs:28:22
    |
-LL |     drop(<() as Foo>::copy_me(&x));
-   |          ^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     let _ = identity(<() as Foo>::copy_me(&x));
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0275]: overflow evaluating the requirement `&<() as Foo>::Item well-formed`
-  --> $DIR/alias-bound-unsound.rs:24:31
+  --> $DIR/alias-bound-unsound.rs:28:43
    |
-LL |     drop(<() as Foo>::copy_me(&x));
-   |                               ^^
+LL |     let _ = identity(<() as Foo>::copy_me(&x));
+   |                                           ^^
 
 error[E0275]: overflow evaluating the requirement `<() as Foo>::Item well-formed`
-  --> $DIR/alias-bound-unsound.rs:24:10
+  --> $DIR/alias-bound-unsound.rs:28:22
    |
-LL |     drop(<() as Foo>::copy_me(&x));
-   |          ^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     let _ = identity(<() as Foo>::copy_me(&x));
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0275]: overflow evaluating the requirement `<() as Foo>::Item == _`
-  --> $DIR/alias-bound-unsound.rs:24:10
+  --> $DIR/alias-bound-unsound.rs:28:22
    |
-LL |     drop(<() as Foo>::copy_me(&x));
-   |          ^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     let _ = identity(<() as Foo>::copy_me(&x));
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0275]: overflow evaluating the requirement `<() as Foo>::Item == _`
-  --> $DIR/alias-bound-unsound.rs:24:31
+  --> $DIR/alias-bound-unsound.rs:28:43
    |
-LL |     drop(<() as Foo>::copy_me(&x));
-   |                               ^^
+LL |     let _ = identity(<() as Foo>::copy_me(&x));
+   |                                           ^^
 
 error: aborting due to 8 previous errors
 


### PR DESCRIPTION
I'm putting this under the `const Destruct` feature flag since it doesn't really feel relevant to put it elsewhere… it's just an empty function body, so, it doesn't have any particular weirdness attached to it (unlike `drop_in_place`, for example).

r? wg-const-eval