### PR TITLE
Fix ICE when using contracts on async functions

### DIFF
--- a/compiler/rustc_builtin_macros/src/contracts.rs
+++ b/compiler/rustc_builtin_macros/src/contracts.rs
@@ -71,6 +71,14 @@ fn expand_contract_clause(
             .span_err(attr_span, "contract annotations can only be used on functions"));
     }
 
+    // Contracts are not yet supported on async/gen functions
+    if new_tts.iter().any(|tt| is_kw(tt, kw::Async) || is_kw(tt, kw::Gen)) {
+        return Err(ecx.sess.dcx().span_err(
+            attr_span,
+            "contract annotations are not yet supported on async or gen functions",
+        ));
+    }
+
     // Found the `fn` keyword, now find either the `where` token or the function body.
     let next_tt = loop {
         let Some(tt) = cursor.next() else {

--- a/tests/ui/contracts/async-fn-contract-ice-145333.rs
+++ b/tests/ui/contracts/async-fn-contract-ice-145333.rs
@@ -1,0 +1,10 @@
+//@ compile-flags: --crate-type=lib
+//@ edition: 2021
+#![feature(contracts)]
+//~^ WARN the feature `contracts` is incomplete
+
+#[core::contracts::ensures(|ret| *ret)]
+//~^ ERROR contract annotations are not yet supported on async or gen functions
+async fn _always_true(b: bool) -> bool {
+    b
+}

--- a/tests/ui/contracts/async-fn-contract-ice-145333.stderr
+++ b/tests/ui/contracts/async-fn-contract-ice-145333.stderr
@@ -1,0 +1,17 @@
+error: contract annotations are not yet supported on async or gen functions
+  --> $DIR/async-fn-contract-ice-145333.rs:6:1
+   |
+LL | #[core::contracts::ensures(|ret| *ret)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: the feature `contracts` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/async-fn-contract-ice-145333.rs:3:12
+   |
+LL | #![feature(contracts)]
+   |            ^^^^^^^^^
+   |
+   = note: see issue #128044 <https://github.com/rust-lang/rust/issues/128044> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+error: aborting due to 1 previous error; 1 warning emitted
+


### PR DESCRIPTION
Fixes rust-lang/rust#145333

contract is not supported for async functions right now, it's not properly lowered and getting HirId will ICE.

This PR adds checking for async function in expanding AST phase, it's better until we want to fully support async for contracts feature.
