### PR TITLE
Clarify that UB will occur, not can/may in GlobalAlloc docs

### DIFF
--- a/library/core/src/alloc/global.rs
+++ b/library/core/src/alloc/global.rs
@@ -124,7 +124,7 @@ pub unsafe trait GlobalAlloc {
     ///
     /// # Safety
     ///
-    /// `layout` must have non-zero size. Attempting to allocate for a zero-sized `layout` may
+    /// `layout` must have non-zero size. Attempting to allocate for a zero-sized `layout` will
     /// result in undefined behavior.
     ///
     /// (Extension subtraits might provide more specific bounds on
@@ -163,7 +163,7 @@ pub unsafe trait GlobalAlloc {
     /// * `layout` is the same layout that was used to allocate that block of
     ///   memory.
     ///
-    /// Otherwise undefined behavior can result.
+    /// Otherwise the behavior is undefined.
     #[stable(feature = "global_alloc", since = "1.28.0")]
     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout);
 
@@ -173,7 +173,7 @@ pub unsafe trait GlobalAlloc {
     /// # Safety
     ///
     /// The caller has to ensure that `layout` has non-zero size. Like `alloc`
-    /// zero sized `layout` can result in undefined behavior.
+    /// zero sized `layout` will result in undefined behavior.
     /// However the allocated block of memory is guaranteed to be initialized.
     ///
     /// # Errors
@@ -234,7 +234,7 @@ pub unsafe trait GlobalAlloc {
     ///   does not overflow `isize` (i.e., the rounded value must be less than or
     ///   equal to `isize::MAX`).
     ///
-    /// If these are not followed, undefined behavior can result.
+    /// If these are not followed, the behavior is undefined.
     ///
     /// (Extension subtraits might provide more specific bounds on
     /// behavior, e.g., guarantee a sentinel address or a null pointer


### PR DESCRIPTION
These doc comments start out very clear by saying the caller "must" or "has to" ensure something, but the end with some form of "otherwise undefined behavior may result" which sounds like it is implementation-defined and seems to conflict with the way the paragraph starts. Consistent phrasing makes it clearer that when the safety precondition is violated, UB is encountered.

Some of the phrasing here is a bit awkward to me, I don't think we usually say "the behavior is undefined" @RalfJung right? But in either case I'm trying to be surgical in my edit here.

r? Amanieu