### PR TITLE
compiler/middle/lint: Suggest `#[expect(dead_code)]` instead of `#[allow(dead_code)]`

### DIFF
--- a/compiler/rustc_middle/src/lint.rs
+++ b/compiler/rustc_middle/src/lint.rs
@@ -265,9 +265,16 @@ fn explain_lint_level_source(
                     "`{flag} {hyphen_case_lint_name}` implied by `{flag} {hyphen_case_flag_val}`"
                 ));
                 if matches!(orig_level, Level::Warn | Level::Deny) {
-                    err.help_once(format!(
-                        "to override `{flag} {hyphen_case_flag_val}` add `#[allow({name})]`"
-                    ));
+                    let help = if name == "dead_code" {
+                        format!(
+                            "to override `{flag} {hyphen_case_flag_val}` add `#[expect({name})]` or `#[allow({name})]`"
+                        )
+                    } else {
+                        format!(
+                            "to override `{flag} {hyphen_case_flag_val}` add `#[allow({name})]`"
+                        )
+                    };
+                    err.help_once(help);
                 }
             }
         }

--- a/tests/ui/derives/derive-debug-uninhabited-enum.stderr
+++ b/tests/ui/derives/derive-debug-uninhabited-enum.stderr
@@ -9,7 +9,7 @@ LL |     Void(Void),
    |
    = note: `Foo` has a derived impl for the trait `Debug`, but this is intentionally ignored during dead code analysis
    = note: `-W dead-code` implied by `-W unused`
-   = help: to override `-W unused` add `#[allow(dead_code)]`
+   = help: to override `-W unused` add `#[expect(dead_code)]` or `#[allow(dead_code)]`
 
 warning: 1 warning emitted
 

--- a/tests/ui/lint/dead-code/unused-fn-with-check-pass.rs
+++ b/tests/ui/lint/dead-code/unused-fn-with-check-pass.rs
@@ -1,0 +1,8 @@
+//@ check-pass
+//@ compile-flags: -Wunused
+
+fn foo() -> &'static str { //~ WARN function `foo` is never used
+    "hello"
+}
+
+fn main() {}

--- a/tests/ui/lint/dead-code/unused-fn-with-check-pass.stderr
+++ b/tests/ui/lint/dead-code/unused-fn-with-check-pass.stderr
@@ -5,7 +5,7 @@ LL | fn foo() -> &'static str {
    |    ^^^
    |
    = note: `-W dead-code` implied by `-W unused`
-   = help: to override `-W unused` add `#[allow(dead_code)]`
+   = help: to override `-W unused` add `#[expect(dead_code)]` or `#[allow(dead_code)]`
 
 warning: 1 warning emitted
 

--- a/tests/ui/lint/dead-code/unused-fn-with-check-pass.stderr
+++ b/tests/ui/lint/dead-code/unused-fn-with-check-pass.stderr
@@ -1,0 +1,11 @@
+warning: function `foo` is never used
+  --> $DIR/unused-fn-with-check-pass.rs:4:4
+   |
+LL | fn foo() -> &'static str {
+   |    ^^^
+   |
+   = note: `-W dead-code` implied by `-W unused`
+   = help: to override `-W unused` add `#[allow(dead_code)]`
+
+warning: 1 warning emitted
+


### PR DESCRIPTION
Until now the compiler suggested

> help: to override `-W unused` add `#[allow(dead_code)]`

when encountering e.g. an unused function in the codebase.

This PR changes the suggestion to `#[expect(dead_code)]`, which will warn again once the code is being used somewhere. This is helpful because it lets the developer know that the attribute can now be removed again. Without this the codebase will eventually be littered with stray `#[allow(dead_code)]` attributes that are no longer serving any purpose.

This was suggested in https://bsky.app/profile/steveklabnik.com/post/3m2uh7pf6e225 and I agreed strongly enough to take a look and implement it 😆