### PR TITLE
Fix ICE in pattern matching with generic const array length errors

### DIFF
--- a/tests/ui/const-generics/generic-const-array-pattern-ice-139815.rs
+++ b/tests/ui/const-generics/generic-const-array-pattern-ice-139815.rs
@@ -1,8 +1,10 @@
-//@ known-bug: #139815
-
+//@ compile-flags: --crate-type=lib
+#![allow(incomplete_features)]
 #![feature(generic_const_exprs)]
+
 fn is_123<const N: usize>(
     x: [u32; {
+        //~^ ERROR overly complex generic constant
         N + 1;
         5
     }],

--- a/tests/ui/const-generics/generic-const-array-pattern-ice-139815.stderr
+++ b/tests/ui/const-generics/generic-const-array-pattern-ice-139815.stderr
@@ -1,0 +1,16 @@
+error: overly complex generic constant
+  --> $DIR/generic-const-array-pattern-ice-139815.rs:6:14
+   |
+LL |       x: [u32; {
+   |  ______________^
+LL | |
+LL | |         N + 1;
+LL | |         5
+LL | |     }],
+   | |_____^ blocks are not supported in generic constants
+   |
+   = help: consider moving this anonymous constant into a `const` function
+   = note: this operation may be supported in the future
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Fixes rust-lang/rust#139815