### PR TITLE
Fix typos across multipe file

### DIFF
--- a/src/tools/rustfmt/tests/target/issue_4573.rs
+++ b/src/tools/rustfmt/tests/target/issue_4573.rs
@@ -2,7 +2,7 @@
 // rustmft-use_small_heuristics:Max
 // rustmft-merge_derives:false
 // These are the same rustfmt configuration options that are used
-// in the comiler as of ce39461ca75a and 8eb7c58dbb7b
+// in the compiler as of ce39461ca75a and 8eb7c58dbb7b
 // These are commits in https://github.com/rust-lang/rust
 
 #![no_std] // inner attribute comment

--- a/src/tools/test-float-parse/src/gen_/fuzz.rs
+++ b/src/tools/test-float-parse/src/gen_/fuzz.rs
@@ -37,7 +37,7 @@ impl<F: Float> Fuzz<F> {
             // to catch failures from e.g. high bit patterns before exhaustive tests would get to them.
             (F::Int::MAX >> (F::BITS / 2)).try_into().unwrap()
         } else {
-            // Eveything bigger gets a fuzz test with as many iterations as `f32` exhaustive.
+            // Everything bigger gets a fuzz test with as many iterations as `f32` exhaustive.
             u32::MAX.into()
         };
 

--- a/src/tools/test-float-parse/src/validate.rs
+++ b/src/tools/test-float-parse/src/validate.rs
@@ -309,7 +309,7 @@ fn decode<F: Float>(f: F) -> FloatRes<F> {
 
     let mut exponent = i32::try_from(exponent_biased).unwrap();
 
-    // Adjust for bias and the rnage of the mantissa
+    // Adjust for bias and the range of the mantissa
     exponent -= i32::try_from(F::EXP_BIAS + F::MAN_BITS).unwrap();
 
     if f.is_sign_negative() {

--- a/src/tools/tidy/src/diagnostics.rs
+++ b/src/tools/tidy/src/diagnostics.rs
@@ -181,7 +181,7 @@ impl RunningCheck {
         }
     }
 
-    /// Has an error already occured for this check?
+    /// Has an error already occurred for this check?
     pub fn is_bad(&self) -> bool {
         self.bad
     }

--- a/src/tools/tidy/src/lib.rs
+++ b/src/tools/tidy/src/lib.rs
@@ -105,7 +105,7 @@ pub fn git_diff<S: AsRef<OsStr>>(base_commit: &str, extra_arg: S) -> Option<Stri
 
 /// Similar to `files_modified`, but only involves a single call to `git`.
 ///
-/// removes all elements from `items` that do not cause any match when `pred` is called with the list of modifed files.
+/// removes all elements from `items` that do not cause any match when `pred` is called with the list of modified files.
 ///
 /// if in CI, no elements will be removed.
 pub fn files_modified_batch_filter<T>(

--- a/src/tools/unicode-table-generator/src/main.rs
+++ b/src/tools/unicode-table-generator/src/main.rs
@@ -411,7 +411,7 @@ fn generate_asserts(
     Ok(())
 }
 
-/// Group the elements of `set` into contigous ranges
+/// Group the elements of `set` into contiguous ranges
 fn ranges_from_set(set: &[u32]) -> Vec<Range<u32>> {
     set.chunk_by(|a, b| a + 1 == *b)
         .map(|chunk| {


### PR DESCRIPTION
Fixed several spelling typos across files — things like :
“comiler” → “compiler”, 
“Eveything” → “Everything”, 
 “rnage” → “range”,
 “occured” → “occurred”,
 “modifed” → “modified”,
 “contigous” → “contiguous”.
