### PR TITLE
tests: activate misspelled `gdb-check` in `function-arg-initialization.rs`

### DIFF
--- a/tests/debuginfo/function-arg-initialization.rs
+++ b/tests/debuginfo/function-arg-initialization.rs
@@ -26,9 +26,9 @@
 
 // NON IMMEDIATE ARGS
 // gdb-command:print a
-// gdbt-check:$4 = function_arg_initialization::BigStruct {a: 3, b: 4, c: 5, d: 6, e: 7, f: 8, g: 9, h: 10}
+// gdb-check:$4 = function_arg_initialization::BigStruct {a: 3, b: 4, c: 5, d: 6, e: 7, f: 8, g: 9, h: 10}
 // gdb-command:print b
-// gdbt-check:$5 = function_arg_initialization::BigStruct {a: 11, b: 12, c: 13, d: 14, e: 15, f: 16, g: 17, h: 18}
+// gdb-check:$5 = function_arg_initialization::BigStruct {a: 11, b: 12, c: 13, d: 14, e: 15, f: 16, g: 17, h: 18}
 // gdb-command:continue
 
 // BINDING
@@ -234,6 +234,9 @@ struct BigStruct {
 
 fn non_immediate_args(a: BigStruct, b: BigStruct) {
     zzz(); // #break
+
+    // FIXME(#128973): Needed to avoid `<optimized out>` prints before #128973 has been fixed.
+    std::hint::black_box(|| { let _ = (a, b);});
 }
 
 fn binding(a: i64, b: u64, c: f64) {


### PR DESCRIPTION
In 9253e1206e91f5bd7 a bunch of `gdbr-check` (for `rust-gdb`) directives and `gdbg-check` (for plain `gdb`) directives were added. But in two places the author accidentally wrote `gdbt-check` instead (`t` is next to `r` on the keyboard). This commit fixes that typo.

rust-lang/rust#129218 later renamed `gdbr-check` to just `gdb-check` which is why we rename to `gdb-check` directly.

The test still passes locally for me after the change, but fails if I change the `gdb-check` checks to check for some other string, so the check seems to still perform its intended function.

Note that we need to add a `std::hint::black_box()` to avoid

    $4 = <optimized out>

prints on at least `aarch64-gnu-llvm-20-1`.

After this there are no more instances of the string `gdbt` in the code base:
```console
$ git grep gdbt
```

try-job: dist-i586-gnu-i586-i686-musl