### PR TITLE
ignore boring locals when explaining why a borrow contains a point due to drop of a live local under polonius

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/explain_borrow.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/explain_borrow.rs
@@ -687,7 +687,7 @@ impl<'tcx> MirBorrowckCtxt<'_, '_, 'tcx> {
                 }
             }
 
-            Some(Cause::DropVar(local, location)) => {
+            Some(Cause::DropVar(local, location)) if !is_local_boring(local) => {
                 let mut should_note_order = false;
                 if self.local_name(local).is_some()
                     && let Some((WriteKind::StorageDeadOrDrop, place)) = kind_place
@@ -705,7 +705,7 @@ impl<'tcx> MirBorrowckCtxt<'_, '_, 'tcx> {
                 }
             }
 
-            Some(Cause::LiveVar(..)) | None => {
+            Some(Cause::LiveVar(..) | Cause::DropVar(..)) | None => {
                 // Here, under NLL: no cause was found. Under polonius: no cause was found, or a
                 // boring local was found, which we ignore like NLLs do to match its diagnostics.
                 if let Some(region) = self.to_error_region_vid(borrow_region_vid) {

--- a/tests/ui/nll/polonius/lending-iterator-sanity-checks.polonius.stderr
+++ b/tests/ui/nll/polonius/lending-iterator-sanity-checks.polonius.stderr
@@ -1,13 +1,15 @@
 error[E0499]: cannot borrow `*t` as mutable more than once at a time
   --> $DIR/lending-iterator-sanity-checks.rs:19:19
    |
+LL | fn use_live<T: LendingIterator>(t: &mut T) -> Option<(T::Item<'_>, T::Item<'_>)> {
+   |                                    - let's call the lifetime of this reference `'1`
 LL |     let Some(i) = t.next() else { return None };
    |                   - first mutable borrow occurs here
 LL |     let Some(j) = t.next() else { return None };
    |                   ^ second mutable borrow occurs here
 ...
-LL | }
-   | - first borrow might be used here, when `i` is dropped and runs the destructor for type `<T as LendingIterator>::Item<'_>`
+LL |     Some((i, j))
+   |     ------------ returning this value requires that `*t` is borrowed for `'1`
 
 error[E0499]: cannot borrow `*t` as mutable more than once at a time
   --> $DIR/lending-iterator-sanity-checks.rs:31:13


### PR DESCRIPTION
Polonius liveness has to contain boring locals, and we ignore them in diagnostics, to match NLL diagnostics that never involve any boring locals. When explaining why a borrow contains a point, I ignored these boring locals when it was due to a use of a live var, but forgot to do so when the cause was because of a drop of a live var. 

This is what was causing the last two (known) diagnostics differences under the polonius compare-mode:
- `tests/ui/dropck/dropck_trait_cycle_checked.rs` 
- `tests/ui/unboxed-closures/unboxed-closures-failed-recursive-fn-1.rs`

r? @jackh726 