### PR TITLE
Don't highlight `let` expressions as having type `bool` in let-chain error messages

### DIFF
--- a/compiler/rustc_hir_typeck/src/demand.rs
+++ b/compiler/rustc_hir_typeck/src/demand.rs
@@ -792,7 +792,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 hir::Node::Expr(hir::Expr { kind: hir::ExprKind::Binary(_, lhs, rhs), .. }),
                 Some(TypeError::Sorts(ExpectedFound { expected, .. })),
             ) if rhs.hir_id == expr.hir_id
-                && self.typeck_results.borrow().expr_ty_adjusted_opt(lhs) == Some(expected) =>
+                && self.typeck_results.borrow().expr_ty_adjusted_opt(lhs) == Some(expected)
+                // let expressions being marked as `bool` is confusing (see issue #147665)
+                && !matches!(lhs.kind, hir::ExprKind::Let(..)) =>
             {
                 err.span_label(lhs.span, format!("expected because this is `{expected}`"));
             }

--- a/tests/ui/binop/let-chain-type-issue-147665.rs
+++ b/tests/ui/binop/let-chain-type-issue-147665.rs
@@ -1,0 +1,7 @@
+// Shouldn't highlight `let x = 1` as having type bool.
+//@ edition:2024
+
+fn main() {
+    if let x = 1 && 2 {}
+    //~^ ERROR mismatched types
+}

--- a/tests/ui/binop/let-chain-type-issue-147665.stderr
+++ b/tests/ui/binop/let-chain-type-issue-147665.stderr
@@ -1,0 +1,9 @@
+error[E0308]: mismatched types
+  --> $DIR/let-chain-type-issue-147665.rs:5:21
+   |
+LL |     if let x = 1 && 2 {}
+   |                     ^ expected `bool`, found integer
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Fixes rust-lang/rust#147665.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
