### PR TITLE
Show packed field alignment in mir_transform_unaligned_packed_ref

### DIFF
--- a/compiler/rustc_const_eval/src/util/alignment.rs
+++ b/compiler/rustc_const_eval/src/util/alignment.rs
@@ -1,24 +1,24 @@
 use rustc_abi::Align;
 use rustc_middle::mir::*;
-use rustc_middle::ty::{self, TyCtxt};
+use rustc_middle::ty::{self, AdtDef, TyCtxt};
 use tracing::debug;
 
-/// Returns `true` if this place is allowed to be less aligned
-/// than its containing struct (because it is within a packed
-/// struct).
-pub fn is_disaligned<'tcx, L>(
+/// If the place may be less aligned than its type requires
+/// (because it is in a packed type), returns the AdtDef
+/// and packed alignment of its most-unaligned projection.
+pub fn place_unalignment<'tcx, L>(
     tcx: TyCtxt<'tcx>,
     local_decls: &L,
     typing_env: ty::TypingEnv<'tcx>,
     place: Place<'tcx>,
-) -> bool
+) -> Option<(AdtDef<'tcx>, Align)>
 where
     L: HasLocalDecls<'tcx>,
 {
-    debug!("is_disaligned({:?})", place);
-    let Some(pack) = is_within_packed(tcx, local_decls, place) else {
-        debug!("is_disaligned({:?}) - not within packed", place);
-        return false;
+    debug!("unalignment({:?})", place);
+    let Some((descr, pack)) = most_packed_projection(tcx, local_decls, place) else {
+        debug!("unalignment({:?}) - not within packed", place);
+        return None;
     };
 
     let ty = place.ty(local_decls, tcx).ty;
@@ -30,31 +30,34 @@ where
                     || matches!(unsized_tail().kind(), ty::Slice(..) | ty::Str)) =>
         {
             // If the packed alignment is greater or equal to the field alignment, the type won't be
-            // further disaligned.
+            // further unaligned.
             // However we need to ensure the field is sized; for unsized fields, `layout.align` is
             // just an approximation -- except when the unsized tail is a slice, where the alignment
             // is fully determined by the type.
             debug!(
-                "is_disaligned({:?}) - align = {}, packed = {}; not disaligned",
+                "unalignment({:?}) - align = {}, packed = {}; not unaligned",
                 place,
                 layout.align.bytes(),
                 pack.bytes()
             );
-            false
+            None
         }
         _ => {
-            // We cannot figure out the layout. Conservatively assume that this is disaligned.
-            debug!("is_disaligned({:?}) - true", place);
-            true
+            // We cannot figure out the layout. Conservatively assume that this is unaligned.
+            debug!("unalignment({:?}) - unaligned", place);
+            Some((descr, pack))
         }
     }
 }
 
-pub fn is_within_packed<'tcx, L>(
+/// If the place includes a projection from a packed struct,
+/// returns the AdtDef and packed alignment of the projection
+/// with the lowest pack
+pub fn most_packed_projection<'tcx, L>(
     tcx: TyCtxt<'tcx>,
     local_decls: &L,
     place: Place<'tcx>,
-) -> Option<Align>
+) -> Option<(AdtDef<'tcx>, Align)>
 where
     L: HasLocalDecls<'tcx>,
 {
@@ -65,9 +68,11 @@ where
         .take_while(|(_base, elem)| !matches!(elem, ProjectionElem::Deref))
         // Consider the packed alignments at play here...
         .filter_map(|(base, _elem)| {
-            base.ty(local_decls, tcx).ty.ty_adt_def().and_then(|adt| adt.repr().pack)
+            let adt = base.ty(local_decls, tcx).ty.ty_adt_def()?;
+            let pack = adt.repr().pack?;
+            Some((adt, pack))
         })
         // ... and compute their minimum.
         // The overall smallest alignment is what matters.
-        .min()
+        .min_by_key(|(_, align)| *align)
 }

--- a/compiler/rustc_const_eval/src/util/mod.rs
+++ b/compiler/rustc_const_eval/src/util/mod.rs
@@ -6,7 +6,7 @@ mod check_validity_requirement;
 mod compare_types;
 mod type_name;
 
-pub use self::alignment::{is_disaligned, is_within_packed};
+pub use self::alignment::{most_packed_projection, place_unalignment};
 pub use self::check_validity_requirement::check_validity_requirement;
 pub(crate) use self::check_validity_requirement::validate_scalar_in_layout;
 pub use self::compare_types::{relate_types, sub_types};

--- a/compiler/rustc_mir_transform/messages.ftl
+++ b/compiler/rustc_mir_transform/messages.ftl
@@ -69,8 +69,11 @@ mir_transform_tail_expr_local = {$is_generated_name ->
         *[false] `{$name}` calls a custom destructor
     }
 
-mir_transform_unaligned_packed_ref = reference to packed field is unaligned
-    .note = packed structs are only aligned by one byte, and many modern architectures penalize unaligned field accesses
+mir_transform_unaligned_packed_ref = reference to field of packed {$ty_descr} is unaligned
+    .note = this {$ty_descr} is {$align ->
+        [one] {""}
+        *[other] {"at most "}
+    }{$align}-byte aligned, but the type of this field may require higher alignment
     .note_ub = creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
     .help = copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
 

--- a/compiler/rustc_mir_transform/src/add_moves_for_packed_drops.rs
+++ b/compiler/rustc_mir_transform/src/add_moves_for_packed_drops.rs
@@ -51,7 +51,7 @@ impl<'tcx> crate::MirPass<'tcx> for AddMovesForPackedDrops {
 
             match terminator.kind {
                 TerminatorKind::Drop { place, .. }
-                    if util::is_disaligned(tcx, body, typing_env, place) =>
+                    if util::place_unalignment(tcx, body, typing_env, place).is_some() =>
                 {
                     add_move_for_packed_drop(
                         tcx,

--- a/compiler/rustc_mir_transform/src/check_packed_ref.rs
+++ b/compiler/rustc_mir_transform/src/check_packed_ref.rs
@@ -37,7 +37,9 @@ impl<'tcx> Visitor<'tcx> for PackedRefChecker<'_, 'tcx> {
     }
 
     fn visit_place(&mut self, place: &Place<'tcx>, context: PlaceContext, _location: Location) {
-        if context.is_borrow() && util::is_disaligned(self.tcx, self.body, self.typing_env, *place)
+        if context.is_borrow()
+            && let Some((adt, pack)) =
+                util::place_unalignment(self.tcx, self.body, self.typing_env, *place)
         {
             let def_id = self.body.source.instance.def_id();
             if let Some(impl_def_id) = self.tcx.trait_impl_of_assoc(def_id)
@@ -48,7 +50,11 @@ impl<'tcx> Visitor<'tcx> for PackedRefChecker<'_, 'tcx> {
                 // shouldn't do.
                 span_bug!(self.source_info.span, "builtin derive created an unaligned reference");
             } else {
-                self.tcx.dcx().emit_err(errors::UnalignedPackedRef { span: self.source_info.span });
+                self.tcx.dcx().emit_err(errors::UnalignedPackedRef {
+                    span: self.source_info.span,
+                    ty_descr: adt.descr(),
+                    align: pack.bytes(),
+                });
             }
         }
     }

--- a/compiler/rustc_mir_transform/src/dead_store_elimination.rs
+++ b/compiler/rustc_mir_transform/src/dead_store_elimination.rs
@@ -23,7 +23,7 @@ use rustc_mir_dataflow::impls::{
 };
 
 use crate::simplify::UsedInStmtLocals;
-use crate::util::is_within_packed;
+use crate::util::most_packed_projection;
 
 /// Performs the optimization on the body
 ///
@@ -65,7 +65,7 @@ fn eliminate<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) -> bool {
                     // the move may be codegened as a pointer to that field.
                     // Using that disaligned pointer may trigger UB in the callee,
                     // so do nothing.
-                    && is_within_packed(tcx, body, place).is_none()
+                    && most_packed_projection(tcx, body, place).is_none()
                 {
                     call_operands_to_move.push((bb, index));
                 }

--- a/compiler/rustc_mir_transform/src/errors.rs
+++ b/compiler/rustc_mir_transform/src/errors.rs
@@ -99,6 +99,8 @@ pub(crate) enum ConstMutate {
 pub(crate) struct UnalignedPackedRef {
     #[primary_span]
     pub span: Span,
+    pub ty_descr: &'static str,
+    pub align: u64,
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_mir_transform/src/validate.rs
+++ b/compiler/rustc_mir_transform/src/validate.rs
@@ -20,7 +20,7 @@ use rustc_middle::{bug, span_bug};
 use rustc_mir_dataflow::debuginfo::debuginfo_locals;
 use rustc_trait_selection::traits::ObligationCtxt;
 
-use crate::util::{self, is_within_packed};
+use crate::util::{self, most_packed_projection};
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 enum EdgeKind {
@@ -409,7 +409,9 @@ impl<'a, 'tcx> Visitor<'tcx> for CfgChecker<'a, 'tcx> {
 
                     // The call destination place and Operand::Move place used as an argument might
                     // be passed by a reference to the callee. Consequently they cannot be packed.
-                    if is_within_packed(self.tcx, &self.body.local_decls, destination).is_some() {
+                    if most_packed_projection(self.tcx, &self.body.local_decls, destination)
+                        .is_some()
+                    {
                         // This is bad! The callee will expect the memory to be aligned.
                         self.fail(
                             location,
@@ -423,7 +425,9 @@ impl<'a, 'tcx> Visitor<'tcx> for CfgChecker<'a, 'tcx> {
 
                 for arg in args {
                     if let Operand::Move(place) = &arg.node {
-                        if is_within_packed(self.tcx, &self.body.local_decls, *place).is_some() {
+                        if most_packed_projection(self.tcx, &self.body.local_decls, *place)
+                            .is_some()
+                        {
                             // This is bad! The callee will expect the memory to be aligned.
                             self.fail(
                                 location,

--- a/tests/ui/binding/issue-53114-safety-checks.rs
+++ b/tests/ui/binding/issue-53114-safety-checks.rs
@@ -20,12 +20,12 @@ fn let_wild_gets_unsafe_field() {
     let u1 = U { a: I(0) };
     let u2 = U { a: I(1) };
     let p = P { a: &2, b: &3 };
-    let _ = &p.b;  //~ ERROR    reference to packed field
+    let _ = &p.b;  //~ ERROR    reference to field of packed struct
     let _ = u1.a;  //~ ERROR  [E0133]
     let _ = &u2.a; //~ ERROR  [E0133]
 
     // variation on above with `_` in substructure
-    let (_,) = (&p.b,);  //~ ERROR     reference to packed field
+    let (_,) = (&p.b,);  //~ ERROR     reference to field of packed struct
     let (_,) = (u1.a,);  //~ ERROR   [E0133]
     let (_,) = (&u2.a,); //~ ERROR   [E0133]
 }
@@ -34,12 +34,12 @@ fn let_ascribe_gets_unsafe_field() {
     let u1 = U { a: I(0) };
     let u2 = U { a: I(1) };
     let p = P { a: &2, b: &3 };
-    let _: _ = &p.b;  //~ ERROR    reference to packed field
+    let _: _ = &p.b;  //~ ERROR    reference to field of packed struct
     let _: _ = u1.a;  //~ ERROR  [E0133]
     let _: _ = &u2.a; //~ ERROR  [E0133]
 
     // variation on above with `_` in substructure
-    let (_,): _ = (&p.b,);  //~ ERROR     reference to packed field
+    let (_,): _ = (&p.b,);  //~ ERROR     reference to field of packed struct
     let (_,): _ = (u1.a,);  //~ ERROR   [E0133]
     let (_,): _ = (&u2.a,); //~ ERROR   [E0133]
 }
@@ -48,12 +48,12 @@ fn match_unsafe_field_to_wild() {
     let u1 = U { a: I(0) };
     let u2 = U { a: I(1) };
     let p = P { a: &2, b: &3 };
-    match &p.b  { _ => { } } //~ ERROR     reference to packed field
+    match &p.b  { _ => { } } //~ ERROR     reference to field of packed struct
     match u1.a  { _ => { } } //~ ERROR   [E0133]
     match &u2.a { _ => { } } //~ ERROR   [E0133]
 
     // variation on above with `_` in substructure
-    match (&p.b,)  { (_,) => { } } //~ ERROR     reference to packed field
+    match (&p.b,)  { (_,) => { } } //~ ERROR     reference to field of packed struct
     match (u1.a,)  { (_,) => { } } //~ ERROR   [E0133]
     match (&u2.a,) { (_,) => { } } //~ ERROR   [E0133]
 }

--- a/tests/ui/binding/issue-53114-safety-checks.stderr
+++ b/tests/ui/binding/issue-53114-safety-checks.stderr
@@ -1,20 +1,20 @@
-error[E0793]: reference to packed field is unaligned
+error[E0793]: reference to field of packed struct is unaligned
   --> $DIR/issue-53114-safety-checks.rs:23:13
    |
 LL |     let _ = &p.b;
    |             ^^^^
    |
-   = note: packed structs are only aligned by one byte, and many modern architectures penalize unaligned field accesses
+   = note: this struct is 1-byte aligned, but the type of this field may require higher alignment
    = note: creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
    = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
 
-error[E0793]: reference to packed field is unaligned
+error[E0793]: reference to field of packed struct is unaligned
   --> $DIR/issue-53114-safety-checks.rs:28:17
    |
 LL |     let (_,) = (&p.b,);
    |                 ^^^^
    |
-   = note: packed structs are only aligned by one byte, and many modern architectures penalize unaligned field accesses
+   = note: this struct is 1-byte aligned, but the type of this field may require higher alignment
    = note: creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
    = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
 
@@ -50,23 +50,23 @@ LL |     let (_,) = (&u2.a,);
    |
    = note: the field may not be properly initialized: using uninitialized data will cause undefined behavior
 
-error[E0793]: reference to packed field is unaligned
+error[E0793]: reference to field of packed struct is unaligned
   --> $DIR/issue-53114-safety-checks.rs:37:16
    |
 LL |     let _: _ = &p.b;
    |                ^^^^
    |
-   = note: packed structs are only aligned by one byte, and many modern architectures penalize unaligned field accesses
+   = note: this struct is 1-byte aligned, but the type of this field may require higher alignment
    = note: creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
    = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
 
-error[E0793]: reference to packed field is unaligned
+error[E0793]: reference to field of packed struct is unaligned
   --> $DIR/issue-53114-safety-checks.rs:42:20
    |
 LL |     let (_,): _ = (&p.b,);
    |                    ^^^^
    |
-   = note: packed structs are only aligned by one byte, and many modern architectures penalize unaligned field accesses
+   = note: this struct is 1-byte aligned, but the type of this field may require higher alignment
    = note: creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
    = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
 
@@ -102,23 +102,23 @@ LL |     let (_,): _ = (&u2.a,);
    |
    = note: the field may not be properly initialized: using uninitialized data will cause undefined behavior
 
-error[E0793]: reference to packed field is unaligned
+error[E0793]: reference to field of packed struct is unaligned
   --> $DIR/issue-53114-safety-checks.rs:51:11
    |
 LL |     match &p.b  { _ => { } }
    |           ^^^^
    |
-   = note: packed structs are only aligned by one byte, and many modern architectures penalize unaligned field accesses
+   = note: this struct is 1-byte aligned, but the type of this field may require higher alignment
    = note: creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
    = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
 
-error[E0793]: reference to packed field is unaligned
+error[E0793]: reference to field of packed struct is unaligned
   --> $DIR/issue-53114-safety-checks.rs:56:12
    |
 LL |     match (&p.b,)  { (_,) => { } }
    |            ^^^^
    |
-   = note: packed structs are only aligned by one byte, and many modern architectures penalize unaligned field accesses
+   = note: this struct is 1-byte aligned, but the type of this field may require higher alignment
    = note: creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
    = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
 

--- a/tests/ui/closures/2229_closure_analysis/diagnostics/repr_packed.rs
+++ b/tests/ui/closures/2229_closure_analysis/diagnostics/repr_packed.rs
@@ -19,7 +19,7 @@ fn test_missing_unsafe_warning_on_repr_packed() {
 
     let c = || {
         println!("{}", foo.x);
-        //~^ ERROR: reference to packed field is unaligned
+        //~^ ERROR: reference to field of packed struct is unaligned
         let _z = foo.x;
     };
 

--- a/tests/ui/closures/2229_closure_analysis/diagnostics/repr_packed.stderr
+++ b/tests/ui/closures/2229_closure_analysis/diagnostics/repr_packed.stderr
@@ -1,10 +1,10 @@
-error[E0793]: reference to packed field is unaligned
+error[E0793]: reference to field of packed struct is unaligned
   --> $DIR/repr_packed.rs:21:24
    |
 LL |         println!("{}", foo.x);
    |                        ^^^^^
    |
-   = note: packed structs are only aligned by one byte, and many modern architectures penalize unaligned field accesses
+   = note: this struct is 1-byte aligned, but the type of this field may require higher alignment
    = note: creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
    = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
    = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/lint/unaligned_references.current.stderr
+++ b/tests/ui/lint/unaligned_references.current.stderr
@@ -1,130 +1,130 @@
-error[E0793]: reference to packed field is unaligned
+error[E0793]: reference to field of packed struct is unaligned
   --> $DIR/unaligned_references.rs:32:13
    |
 LL |             &self.x;
    |             ^^^^^^^
    |
-   = note: packed structs are only aligned by one byte, and many modern architectures penalize unaligned field accesses
+   = note: this struct is at most 2-byte aligned, but the type of this field may require higher alignment
    = note: creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
    = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
 
-error[E0793]: reference to packed field is unaligned
+error[E0793]: reference to field of packed struct is unaligned
   --> $DIR/unaligned_references.rs:44:24
    |
 LL |     println!("{:?}", &*foo.0);
    |                        ^^^^^
    |
-   = note: packed structs are only aligned by one byte, and many modern architectures penalize unaligned field accesses
+   = note: this struct is 1-byte aligned, but the type of this field may require higher alignment
    = note: creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
    = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
 
-error[E0793]: reference to packed field is unaligned
+error[E0793]: reference to field of packed struct is unaligned
   --> $DIR/unaligned_references.rs:46:24
    |
 LL |     println!("{:?}", &*foo.0);
    |                        ^^^^^
    |
-   = note: packed structs are only aligned by one byte, and many modern architectures penalize unaligned field accesses
+   = note: this struct is 1-byte aligned, but the type of this field may require higher alignment
    = note: creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
    = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
 
-error[E0793]: reference to packed field is unaligned
+error[E0793]: reference to field of packed struct is unaligned
   --> $DIR/unaligned_references.rs:51:24
    |
 LL |     println!("{:?}", &*foo.0);
    |                        ^^^^^
    |
-   = note: packed structs are only aligned by one byte, and many modern architectures penalize unaligned field accesses
+   = note: this struct is 1-byte aligned, but the type of this field may require higher alignment
    = note: creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
    = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
 
-error[E0793]: reference to packed field is unaligned
+error[E0793]: reference to field of packed struct is unaligned
   --> $DIR/unaligned_references.rs:81:17
    |
 LL |         let _ = &good.ptr;
    |                 ^^^^^^^^^
    |
-   = note: packed structs are only aligned by one byte, and many modern architectures penalize unaligned field accesses
+   = note: this struct is 1-byte aligned, but the type of this field may require higher alignment
    = note: creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
    = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
 
-error[E0793]: reference to packed field is unaligned
+error[E0793]: reference to field of packed struct is unaligned
   --> $DIR/unaligned_references.rs:82:17
    |
 LL |         let _ = &good.data;
    |                 ^^^^^^^^^^
    |
-   = note: packed structs are only aligned by one byte, and many modern architectures penalize unaligned field accesses
+   = note: this struct is 1-byte aligned, but the type of this field may require higher alignment
    = note: creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
    = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
 
-error[E0793]: reference to packed field is unaligned
+error[E0793]: reference to field of packed struct is unaligned
   --> $DIR/unaligned_references.rs:84:17
    |
 LL |         let _ = &good.data as *const _;
    |                 ^^^^^^^^^^
    |
-   = note: packed structs are only aligned by one byte, and many modern architectures penalize unaligned field accesses
+   = note: this struct is 1-byte aligned, but the type of this field may require higher alignment
    = note: creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
    = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
 
-error[E0793]: reference to packed field is unaligned
+error[E0793]: reference to field of packed struct is unaligned
   --> $DIR/unaligned_references.rs:85:27
    |
 LL |         let _: *const _ = &good.data;
    |                           ^^^^^^^^^^
    |
-   = note: packed structs are only aligned by one byte, and many modern architectures penalize unaligned field accesses
+   = note: this struct is 1-byte aligned, but the type of this field may require higher alignment
    = note: creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
    = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
 
-error[E0793]: reference to packed field is unaligned
+error[E0793]: reference to field of packed struct is unaligned
   --> $DIR/unaligned_references.rs:87:17
    |
 LL |         let _ = good.data.clone();
    |                 ^^^^^^^^^
    |
-   = note: packed structs are only aligned by one byte, and many modern architectures penalize unaligned field accesses
+   = note: this struct is 1-byte aligned, but the type of this field may require higher alignment
    = note: creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
    = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
 
-error[E0793]: reference to packed field is unaligned
+error[E0793]: reference to field of packed struct is unaligned
   --> $DIR/unaligned_references.rs:89:17
    |
 LL |         let _ = &good.data2[0];
    |                 ^^^^^^^^^^^^^^
    |
-   = note: packed structs are only aligned by one byte, and many modern architectures penalize unaligned field accesses
+   = note: this struct is 1-byte aligned, but the type of this field may require higher alignment
    = note: creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
    = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
 
-error[E0793]: reference to packed field is unaligned
+error[E0793]: reference to field of packed struct is unaligned
   --> $DIR/unaligned_references.rs:98:17
    |
 LL |         let _ = &packed2.x;
    |                 ^^^^^^^^^^
    |
-   = note: packed structs are only aligned by one byte, and many modern architectures penalize unaligned field accesses
+   = note: this struct is at most 2-byte aligned, but the type of this field may require higher alignment
    = note: creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
    = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
 
-error[E0793]: reference to packed field is unaligned
+error[E0793]: reference to field of packed struct is unaligned
   --> $DIR/unaligned_references.rs:137:20
    |
 LL |         let _ref = &m1.1.a;
    |                    ^^^^^^^
    |
-   = note: packed structs are only aligned by one byte, and many modern architectures penalize unaligned field accesses
+   = note: this struct is 1-byte aligned, but the type of this field may require higher alignment
    = note: creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
    = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
 
-error[E0793]: reference to packed field is unaligned
+error[E0793]: reference to field of packed struct is unaligned
   --> $DIR/unaligned_references.rs:140:20
    |
 LL |         let _ref = &m2.1.a;
    |                    ^^^^^^^
    |
-   = note: packed structs are only aligned by one byte, and many modern architectures penalize unaligned field accesses
+   = note: this struct is 1-byte aligned, but the type of this field may require higher alignment
    = note: creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
    = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
 

--- a/tests/ui/lint/unaligned_references.next.stderr
+++ b/tests/ui/lint/unaligned_references.next.stderr
@@ -1,130 +1,130 @@
-error[E0793]: reference to packed field is unaligned
+error[E0793]: reference to field of packed struct is unaligned
   --> $DIR/unaligned_references.rs:32:13
    |
 LL |             &self.x;
    |             ^^^^^^^
    |
-   = note: packed structs are only aligned by one byte, and many modern architectures penalize unaligned field accesses
+   = note: this struct is at most 2-byte aligned, but the type of this field may require higher alignment
    = note: creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
    = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
 
-error[E0793]: reference to packed field is unaligned
+error[E0793]: reference to field of packed struct is unaligned
   --> $DIR/unaligned_references.rs:44:24
    |
 LL |     println!("{:?}", &*foo.0);
    |                        ^^^^^
    |
-   = note: packed structs are only aligned by one byte, and many modern architectures penalize unaligned field accesses
+   = note: this struct is 1-byte aligned, but the type of this field may require higher alignment
    = note: creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
    = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
 
-error[E0793]: reference to packed field is unaligned
+error[E0793]: reference to field of packed struct is unaligned
   --> $DIR/unaligned_references.rs:46:24
    |
 LL |     println!("{:?}", &*foo.0);
    |                        ^^^^^
    |
-   = note: packed structs are only aligned by one byte, and many modern architectures penalize unaligned field accesses
+   = note: this struct is 1-byte aligned, but the type of this field may require higher alignment
    = note: creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
    = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
 
-error[E0793]: reference to packed field is unaligned
+error[E0793]: reference to field of packed struct is unaligned
   --> $DIR/unaligned_references.rs:51:24
    |
 LL |     println!("{:?}", &*foo.0);
    |                        ^^^^^
    |
-   = note: packed structs are only aligned by one byte, and many modern architectures penalize unaligned field accesses
+   = note: this struct is 1-byte aligned, but the type of this field may require higher alignment
    = note: creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
    = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
 
-error[E0793]: reference to packed field is unaligned
+error[E0793]: reference to field of packed struct is unaligned
   --> $DIR/unaligned_references.rs:81:17
    |
 LL |         let _ = &good.ptr;
    |                 ^^^^^^^^^
    |
-   = note: packed structs are only aligned by one byte, and many modern architectures penalize unaligned field accesses
+   = note: this struct is 1-byte aligned, but the type of this field may require higher alignment
    = note: creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
    = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
 
-error[E0793]: reference to packed field is unaligned
+error[E0793]: reference to field of packed struct is unaligned
   --> $DIR/unaligned_references.rs:82:17
    |
 LL |         let _ = &good.data;
    |                 ^^^^^^^^^^
    |
-   = note: packed structs are only aligned by one byte, and many modern architectures penalize unaligned field accesses
+   = note: this struct is 1-byte aligned, but the type of this field may require higher alignment
    = note: creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
    = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
 
-error[E0793]: reference to packed field is unaligned
+error[E0793]: reference to field of packed struct is unaligned
   --> $DIR/unaligned_references.rs:84:17
    |
 LL |         let _ = &good.data as *const _;
    |                 ^^^^^^^^^^
    |
-   = note: packed structs are only aligned by one byte, and many modern architectures penalize unaligned field accesses
+   = note: this struct is 1-byte aligned, but the type of this field may require higher alignment
    = note: creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
    = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
 
-error[E0793]: reference to packed field is unaligned
+error[E0793]: reference to field of packed struct is unaligned
   --> $DIR/unaligned_references.rs:85:27
    |
 LL |         let _: *const _ = &good.data;
    |                           ^^^^^^^^^^
    |
-   = note: packed structs are only aligned by one byte, and many modern architectures penalize unaligned field accesses
+   = note: this struct is 1-byte aligned, but the type of this field may require higher alignment
    = note: creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
    = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
 
-error[E0793]: reference to packed field is unaligned
+error[E0793]: reference to field of packed struct is unaligned
   --> $DIR/unaligned_references.rs:87:17
    |
 LL |         let _ = good.data.clone();
    |                 ^^^^^^^^^
    |
-   = note: packed structs are only aligned by one byte, and many modern architectures penalize unaligned field accesses
+   = note: this struct is 1-byte aligned, but the type of this field may require higher alignment
    = note: creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
    = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
 
-error[E0793]: reference to packed field is unaligned
+error[E0793]: reference to field of packed struct is unaligned
   --> $DIR/unaligned_references.rs:89:17
    |
 LL |         let _ = &good.data2[0];
    |                 ^^^^^^^^^^^^^^
    |
-   = note: packed structs are only aligned by one byte, and many modern architectures penalize unaligned field accesses
+   = note: this struct is 1-byte aligned, but the type of this field may require higher alignment
    = note: creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
    = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
 
-error[E0793]: reference to packed field is unaligned
+error[E0793]: reference to field of packed struct is unaligned
   --> $DIR/unaligned_references.rs:98:17
    |
 LL |         let _ = &packed2.x;
    |                 ^^^^^^^^^^
    |
-   = note: packed structs are only aligned by one byte, and many modern architectures penalize unaligned field accesses
+   = note: this struct is at most 2-byte aligned, but the type of this field may require higher alignment
    = note: creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
    = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
 
-error[E0793]: reference to packed field is unaligned
+error[E0793]: reference to field of packed struct is unaligned
   --> $DIR/unaligned_references.rs:137:20
    |
 LL |         let _ref = &m1.1.a;
    |                    ^^^^^^^
    |
-   = note: packed structs are only aligned by one byte, and many modern architectures penalize unaligned field accesses
+   = note: this struct is 1-byte aligned, but the type of this field may require higher alignment
    = note: creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
    = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
 
-error[E0793]: reference to packed field is unaligned
+error[E0793]: reference to field of packed struct is unaligned
   --> $DIR/unaligned_references.rs:140:20
    |
 LL |         let _ref = &m2.1.a;
    |                    ^^^^^^^
    |
-   = note: packed structs are only aligned by one byte, and many modern architectures penalize unaligned field accesses
+   = note: this struct is 1-byte aligned, but the type of this field may require higher alignment
    = note: creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
    = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
 

--- a/tests/ui/lint/unaligned_references.rs
+++ b/tests/ui/lint/unaligned_references.rs
@@ -29,7 +29,7 @@ trait Foo {
 impl Foo for Packed2 {
     fn evil(&self) {
         unsafe {
-            &self.x; //~ ERROR reference to packed field
+            &self.x; //~ ERROR reference to field of packed struct
         }
     }
 }
@@ -41,14 +41,14 @@ fn packed_dyn() {
 
     let ref local = Unaligned(ManuallyDrop::new([3, 5, 8u64]));
     let foo: &Unaligned<dyn Debug> = &*local;
-    println!("{:?}", &*foo.0); //~ ERROR reference to packed field
+    println!("{:?}", &*foo.0); //~ ERROR reference to field of packed struct
     let foo: &Unaligned<[u64]> = &*local;
-    println!("{:?}", &*foo.0); //~ ERROR reference to packed field
+    println!("{:?}", &*foo.0); //~ ERROR reference to field of packed struct
 
     // Even if the actual alignment is 1, we cannot know that when looking at `dyn Debug.`
     let ref local = Unaligned(ManuallyDrop::new([3, 5, 8u8]));
     let foo: &Unaligned<dyn Debug> = &*local;
-    println!("{:?}", &*foo.0); //~ ERROR reference to packed field
+    println!("{:?}", &*foo.0); //~ ERROR reference to field of packed struct
     // However, we *can* know the alignment when looking at a slice.
     let foo: &Unaligned<[u8]> = &*local;
     println!("{:?}", &*foo.0); // no error!
@@ -78,15 +78,15 @@ fn main() {
     unsafe {
         let good = Good { data: 0, ptr: &0, data2: [0, 0], aligned: [0; 32] };
 
-        let _ = &good.ptr; //~ ERROR reference to packed field
-        let _ = &good.data; //~ ERROR reference to packed field
+        let _ = &good.ptr; //~ ERROR reference to field of packed struct
+        let _ = &good.data; //~ ERROR reference to field of packed struct
         // Error even when turned into raw pointer immediately.
-        let _ = &good.data as *const _; //~ ERROR reference to packed field
-        let _: *const _ = &good.data; //~ ERROR reference to packed field
+        let _ = &good.data as *const _; //~ ERROR reference to field of packed struct
+        let _: *const _ = &good.data; //~ ERROR reference to field of packed struct
         // Error on method call.
-        let _ = good.data.clone(); //~ ERROR reference to packed field
+        let _ = good.data.clone(); //~ ERROR reference to field of packed struct
         // Error for nested fields.
-        let _ = &good.data2[0]; //~ ERROR reference to packed field
+        let _ = &good.data2[0]; //~ ERROR reference to field of packed struct
 
         let _ = &*good.ptr; // ok, behind a pointer
         let _ = &good.aligned; // ok, has align 1
@@ -95,7 +95,7 @@ fn main() {
 
     unsafe {
         let packed2 = Packed2 { x: 0, y: 0, z: 0 };
-        let _ = &packed2.x; //~ ERROR reference to packed field
+        let _ = &packed2.x; //~ ERROR reference to field of packed struct
         let _ = &packed2.y; // ok, has align 2 in packed(2) struct
         let _ = &packed2.z; // ok, has align 1
         packed2.evil();
@@ -134,9 +134,9 @@ fn main() {
         struct Misalign<T>(u8, T);
 
         let m1 = Misalign(0, Wrapper { a: U16(10), b: HasDrop });
-        let _ref = &m1.1.a; //~ ERROR reference to packed field
+        let _ref = &m1.1.a; //~ ERROR reference to field of packed struct
 
         let m2 = Misalign(0, Wrapper2 { a: U16(10), b: HasDrop });
-        let _ref = &m2.1.a; //~ ERROR reference to packed field
+        let _ref = &m2.1.a; //~ ERROR reference to field of packed struct
     }
 }

--- a/tests/ui/lint/unaligned_references_external_macro.rs
+++ b/tests/ui/lint/unaligned_references_external_macro.rs
@@ -2,7 +2,7 @@
 
 extern crate unaligned_references_external_crate;
 
-unaligned_references_external_crate::mac! { //~ERROR reference to packed field is unaligned
+unaligned_references_external_crate::mac! { //~ERROR reference to field of packed struct is unaligned
     #[repr(packed)]
     pub struct X {
         pub field: u16

--- a/tests/ui/lint/unaligned_references_external_macro.stderr
+++ b/tests/ui/lint/unaligned_references_external_macro.stderr
@@ -1,4 +1,4 @@
-error[E0793]: reference to packed field is unaligned
+error[E0793]: reference to field of packed struct is unaligned
   --> $DIR/unaligned_references_external_macro.rs:5:1
    |
 LL | / unaligned_references_external_crate::mac! {
@@ -9,7 +9,7 @@ LL | |     }
 LL | | }
    | |_^
    |
-   = note: packed structs are only aligned by one byte, and many modern architectures penalize unaligned field accesses
+   = note: this struct is 1-byte aligned, but the type of this field may require higher alignment
    = note: creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
    = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
    = note: this error originates in the macro `unaligned_references_external_crate::mac` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/packed/issue-27060.rs
+++ b/tests/ui/packed/issue-27060.rs
@@ -12,11 +12,11 @@ fn main() {
         aligned: [0; 32]
     };
 
-    let _ = &good.data; //~ ERROR reference to packed field
-    let _ = &good.data2[0]; //~ ERROR reference to packed field
+    let _ = &good.data; //~ ERROR reference to field of packed struct
+    let _ = &good.data2[0]; //~ ERROR reference to field of packed struct
 
-    let _ = &good.data; //~ ERROR reference to packed field
-    let _ = &good.data2[0]; //~ ERROR reference to packed field
+    let _ = &good.data; //~ ERROR reference to field of packed struct
+    let _ = &good.data2[0]; //~ ERROR reference to field of packed struct
     let _ = &*good.data; // ok, behind a pointer
     let _ = &good.aligned; // ok, has align 1
     let _ = &good.aligned[2]; // ok, has align 1

--- a/tests/ui/packed/issue-27060.stderr
+++ b/tests/ui/packed/issue-27060.stderr
@@ -1,40 +1,40 @@
-error[E0793]: reference to packed field is unaligned
+error[E0793]: reference to field of packed struct is unaligned
   --> $DIR/issue-27060.rs:15:13
    |
 LL |     let _ = &good.data;
    |             ^^^^^^^^^^
    |
-   = note: packed structs are only aligned by one byte, and many modern architectures penalize unaligned field accesses
+   = note: this struct is 1-byte aligned, but the type of this field may require higher alignment
    = note: creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
    = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
 
-error[E0793]: reference to packed field is unaligned
+error[E0793]: reference to field of packed struct is unaligned
   --> $DIR/issue-27060.rs:16:13
    |
 LL |     let _ = &good.data2[0];
    |             ^^^^^^^^^^^^^^
    |
-   = note: packed structs are only aligned by one byte, and many modern architectures penalize unaligned field accesses
+   = note: this struct is 1-byte aligned, but the type of this field may require higher alignment
    = note: creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
    = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
 
-error[E0793]: reference to packed field is unaligned
+error[E0793]: reference to field of packed struct is unaligned
   --> $DIR/issue-27060.rs:18:13
    |
 LL |     let _ = &good.data;
    |             ^^^^^^^^^^
    |
-   = note: packed structs are only aligned by one byte, and many modern architectures penalize unaligned field accesses
+   = note: this struct is 1-byte aligned, but the type of this field may require higher alignment
    = note: creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
    = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
 
-error[E0793]: reference to packed field is unaligned
+error[E0793]: reference to field of packed struct is unaligned
   --> $DIR/issue-27060.rs:19:13
    |
 LL |     let _ = &good.data2[0];
    |             ^^^^^^^^^^^^^^
    |
-   = note: packed structs are only aligned by one byte, and many modern architectures penalize unaligned field accesses
+   = note: this struct is 1-byte aligned, but the type of this field may require higher alignment
    = note: creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
    = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
 

--- a/tests/ui/packed/packed-struct-borrow-element-64bit.rs
+++ b/tests/ui/packed/packed-struct-borrow-element-64bit.rs
@@ -10,6 +10,6 @@ struct Foo4C {
 
 pub fn main() {
     let foo = Foo4C { bar: 1, baz: 2 };
-    let brw = &foo.baz; //~ERROR reference to packed field is unaligned
+    let brw = &foo.baz; //~ERROR reference to field of packed struct is unaligned
     assert_eq!(*brw, 2);
 }

--- a/tests/ui/packed/packed-struct-borrow-element-64bit.stderr
+++ b/tests/ui/packed/packed-struct-borrow-element-64bit.stderr
@@ -1,10 +1,10 @@
-error[E0793]: reference to packed field is unaligned
+error[E0793]: reference to field of packed struct is unaligned
   --> $DIR/packed-struct-borrow-element-64bit.rs:13:15
    |
 LL |     let brw = &foo.baz;
    |               ^^^^^^^^
    |
-   = note: packed structs are only aligned by one byte, and many modern architectures penalize unaligned field accesses
+   = note: this struct is at most 4-byte aligned, but the type of this field may require higher alignment
    = note: creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
    = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
 

--- a/tests/ui/packed/packed-struct-borrow-element.rs
+++ b/tests/ui/packed/packed-struct-borrow-element.rs
@@ -21,10 +21,10 @@ struct Foo4C {
 
 pub fn main() {
     let foo = Foo1 { bar: 1, baz: 2 };
-    let brw = &foo.baz; //~ERROR reference to packed field is unaligned
+    let brw = &foo.baz; //~ERROR reference to field of packed struct is unaligned
     assert_eq!(*brw, 2);
 
     let foo = Foo2 { bar: 1, baz: 2 };
-    let brw = &foo.baz; //~ERROR reference to packed field is unaligned
+    let brw = &foo.baz; //~ERROR reference to field of packed struct is unaligned
     assert_eq!(*brw, 2);
 }

--- a/tests/ui/packed/packed-union-borrow-element.rs
+++ b/tests/ui/packed/packed-union-borrow-element.rs
@@ -1,0 +1,26 @@
+#![allow(dead_code)]
+//@ ignore-emscripten weird assertion?
+
+#[repr(packed)]
+#[derive(Clone, Copy)]
+struct Foo1(usize);
+
+#[repr(packed(4))]
+#[derive(Clone, Copy)]
+struct Foo4(usize);
+
+#[repr(packed(2))]
+union Bar2 {
+    foo1: Foo1,
+    foo4: Foo4,
+}
+
+pub fn main() {
+    let bar = Bar2 { foo1: Foo1(2) };
+    let brw = unsafe { &bar.foo1.0 }; //~ERROR reference to field of packed struct is unaligned
+    assert_eq!(*brw, 2);
+
+    let bar = Bar2 { foo4: Foo4(2) };
+    let brw = unsafe { &bar.foo4.0 }; //~ERROR reference to field of packed union is unaligned
+    assert_eq!(*brw, 2);
+}

--- a/tests/ui/packed/packed-union-borrow-element.stderr
+++ b/tests/ui/packed/packed-union-borrow-element.stderr
@@ -1,20 +1,20 @@
 error[E0793]: reference to field of packed struct is unaligned
-  --> $DIR/packed-struct-borrow-element.rs:24:15
+  --> $DIR/packed-union-borrow-element.rs:20:24
    |
-LL |     let brw = &foo.baz;
-   |               ^^^^^^^^
+LL |     let brw = unsafe { &bar.foo1.0 };
+   |                        ^^^^^^^^^^^
    |
    = note: this struct is 1-byte aligned, but the type of this field may require higher alignment
    = note: creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
    = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
 
-error[E0793]: reference to field of packed struct is unaligned
-  --> $DIR/packed-struct-borrow-element.rs:28:15
+error[E0793]: reference to field of packed union is unaligned
+  --> $DIR/packed-union-borrow-element.rs:24:24
    |
-LL |     let brw = &foo.baz;
-   |               ^^^^^^^^
+LL |     let brw = unsafe { &bar.foo4.0 };
+   |                        ^^^^^^^^^^^
    |
-   = note: this struct is at most 2-byte aligned, but the type of this field may require higher alignment
+   = note: this union is at most 2-byte aligned, but the type of this field may require higher alignment
    = note: creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
    = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
 


### PR DESCRIPTION
Fixes rust-lang/rust#147528

I left the expected padding for the field out of the error message so the message would be the same on all platforms. It also isn't always possible to know the expected alignment, so this makes the message simpler.