### PR TITLE
Rollup of 11 pull requests

### DIFF
--- a/compiler/rustc_ast/src/attr/mod.rs
+++ b/compiler/rustc_ast/src/attr/mod.rs
@@ -86,10 +86,10 @@ impl AttributeExt for Attribute {
     /// Returns `true` if it is a sugared doc comment (`///` or `//!` for example).
     /// So `#[doc = "doc"]` (which is a doc comment) and `#[doc(...)]` (which is not
     /// a doc comment) will return `false`.
-    fn is_doc_comment(&self) -> bool {
+    fn is_doc_comment(&self) -> Option<Span> {
         match self.kind {
-            AttrKind::Normal(..) => false,
-            AttrKind::DocComment(..) => true,
+            AttrKind::Normal(..) => None,
+            AttrKind::DocComment(..) => Some(self.span),
         }
     }
 
@@ -776,7 +776,7 @@ pub trait AttributeExt: Debug {
     /// Returns `true` if it is a sugared doc comment (`///` or `//!` for example).
     /// So `#[doc = "doc"]` (which is a doc comment) and `#[doc(...)]` (which is not
     /// a doc comment) will return `false`.
-    fn is_doc_comment(&self) -> bool;
+    fn is_doc_comment(&self) -> Option<Span>;
 
     #[inline]
     fn has_name(&self, name: Symbol) -> bool {
@@ -863,8 +863,9 @@ impl Attribute {
         AttributeExt::path_matches(self, name)
     }
 
+    // on ast attributes we return a bool since that's what most code already expects
     pub fn is_doc_comment(&self) -> bool {
-        AttributeExt::is_doc_comment(self)
+        AttributeExt::is_doc_comment(self).is_some()
     }
 
     #[inline]

--- a/compiler/rustc_ast/src/expand/allocator.rs
+++ b/compiler/rustc_ast/src/expand/allocator.rs
@@ -31,10 +31,23 @@ pub enum AllocatorTy {
     Usize,
 }
 
+/// Some allocator methods are known to the compiler: they act more like
+/// intrinsics/language primitives than library-defined functions.
+/// FIXME: ideally this would be derived from attributes like `#[rustc_allocator]`,
+/// so we don't have two sources of truth.
+#[derive(Copy, Clone, Debug)]
+pub enum SpecialAllocatorMethod {
+    Alloc,
+    AllocZeroed,
+    Dealloc,
+    Realloc,
+}
+
 /// A method that will be codegened in the allocator shim.
 #[derive(Copy, Clone)]
 pub struct AllocatorMethod {
     pub name: Symbol,
+    pub special: Option<SpecialAllocatorMethod>,
     pub inputs: &'static [AllocatorMethodInput],
     pub output: AllocatorTy,
 }
@@ -47,11 +60,13 @@ pub struct AllocatorMethodInput {
 pub static ALLOCATOR_METHODS: &[AllocatorMethod] = &[
     AllocatorMethod {
         name: sym::alloc,
+        special: Some(SpecialAllocatorMethod::Alloc),
         inputs: &[AllocatorMethodInput { name: "layout", ty: AllocatorTy::Layout }],
         output: AllocatorTy::ResultPtr,
     },
     AllocatorMethod {
         name: sym::dealloc,
+        special: Some(SpecialAllocatorMethod::Dealloc),
         inputs: &[
             AllocatorMethodInput { name: "ptr", ty: AllocatorTy::Ptr },
             AllocatorMethodInput { name: "layout", ty: AllocatorTy::Layout },
@@ -60,6 +75,7 @@ pub static ALLOCATOR_METHODS: &[AllocatorMethod] = &[
     },
     AllocatorMethod {
         name: sym::realloc,
+        special: Some(SpecialAllocatorMethod::Realloc),
         inputs: &[
             AllocatorMethodInput { name: "ptr", ty: AllocatorTy::Ptr },
             AllocatorMethodInput { name: "layout", ty: AllocatorTy::Layout },
@@ -69,6 +85,7 @@ pub static ALLOCATOR_METHODS: &[AllocatorMethod] = &[
     },
     AllocatorMethod {
         name: sym::alloc_zeroed,
+        special: Some(SpecialAllocatorMethod::AllocZeroed),
         inputs: &[AllocatorMethodInput { name: "layout", ty: AllocatorTy::Layout }],
         output: AllocatorTy::ResultPtr,
     },

--- a/compiler/rustc_attr_parsing/src/attributes/mod.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/mod.rs
@@ -302,7 +302,7 @@ pub(crate) trait CombineAttributeParser<S: Stage>: 'static {
     type Item;
     /// A function that converts individual items (of type [`Item`](Self::Item)) into the final attribute.
     ///
-    /// For example, individual representations fomr `#[repr(...)]` attributes into an `AttributeKind::Repr(x)`,
+    /// For example, individual representations from `#[repr(...)]` attributes into an `AttributeKind::Repr(x)`,
     ///  where `x` is a vec of these individual reprs.
     const CONVERT: ConvertFn<Self::Item>;
 

--- a/compiler/rustc_attr_parsing/src/attributes/util.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/util.rs
@@ -28,7 +28,8 @@ pub fn parse_version(s: Symbol) -> Option<RustcVersion> {
 }
 
 pub fn is_builtin_attr(attr: &impl AttributeExt) -> bool {
-    attr.is_doc_comment() || attr.ident().is_some_and(|ident| is_builtin_attr_name(ident.name))
+    attr.is_doc_comment().is_some()
+        || attr.ident().is_some_and(|ident| is_builtin_attr_name(ident.name))
 }
 
 pub fn is_doc_alias_attrs_contain_symbol<'tcx, T: AttributeExt + 'tcx>(

--- a/compiler/rustc_borrowck/src/diagnostics/explain_borrow.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/explain_borrow.rs
@@ -687,7 +687,7 @@ impl<'tcx> MirBorrowckCtxt<'_, '_, 'tcx> {
                 }
             }
 
-            Some(Cause::DropVar(local, location)) => {
+            Some(Cause::DropVar(local, location)) if !is_local_boring(local) => {
                 let mut should_note_order = false;
                 if self.local_name(local).is_some()
                     && let Some((WriteKind::StorageDeadOrDrop, place)) = kind_place
@@ -705,7 +705,7 @@ impl<'tcx> MirBorrowckCtxt<'_, '_, 'tcx> {
                 }
             }
 
-            Some(Cause::LiveVar(..)) | None => {
+            Some(Cause::LiveVar(..) | Cause::DropVar(..)) | None => {
                 // Here, under NLL: no cause was found. Under polonius: no cause was found, or a
                 // boring local was found, which we ignore like NLLs do to match its diagnostics.
                 if let Some(region) = self.to_error_region_vid(borrow_region_vid) {

--- a/compiler/rustc_builtin_macros/src/contracts.rs
+++ b/compiler/rustc_builtin_macros/src/contracts.rs
@@ -71,6 +71,14 @@ fn expand_contract_clause(
             .span_err(attr_span, "contract annotations can only be used on functions"));
     }
 
+    // Contracts are not yet supported on async/gen functions
+    if new_tts.iter().any(|tt| is_kw(tt, kw::Async) || is_kw(tt, kw::Gen)) {
+        return Err(ecx.sess.dcx().span_err(
+            attr_span,
+            "contract annotations are not yet supported on async or gen functions",
+        ));
+    }
+
     // Found the `fn` keyword, now find either the `where` token or the function body.
     let next_tt = loop {
         let Some(tt) = cursor.next() else {

--- a/compiler/rustc_codegen_ssa/src/base.rs
+++ b/compiler/rustc_codegen_ssa/src/base.rs
@@ -669,6 +669,7 @@ pub fn allocator_shim_contents(tcx: TyCtxt<'_>, kind: AllocatorKind) -> Vec<Allo
     if tcx.alloc_error_handler_kind(()).unwrap() == AllocatorKind::Default {
         methods.push(AllocatorMethod {
             name: ALLOC_ERROR_HANDLER,
+            special: None,
             inputs: &[],
             output: AllocatorTy::Never,
         });

--- a/compiler/rustc_data_structures/src/graph/scc/mod.rs
+++ b/compiler/rustc_data_structures/src/graph/scc/mod.rs
@@ -289,7 +289,7 @@ enum NodeState<N, S, A: Annotation> {
 #[derive(Copy, Clone, Debug)]
 enum WalkReturn<S, A: Annotation> {
     /// The walk found a cycle, but the entire component is not known to have
-    /// been fully walked yet. We only know the minimum depth of  this
+    /// been fully walked yet. We only know the minimum depth of this
     /// component in a minimum spanning tree of the graph. This component
     /// is tentatively represented by the state of the first node of this
     /// cycle we met, which is at `min_depth`.

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -1304,8 +1304,12 @@ impl AttributeExt for Attribute {
     }
 
     #[inline]
-    fn is_doc_comment(&self) -> bool {
-        matches!(self, Attribute::Parsed(AttributeKind::DocComment { .. }))
+    fn is_doc_comment(&self) -> Option<Span> {
+        if let Attribute::Parsed(AttributeKind::DocComment { span, .. }) = self {
+            Some(*span)
+        } else {
+            None
+        }
     }
 
     #[inline]
@@ -1425,7 +1429,7 @@ impl Attribute {
     }
 
     #[inline]
-    pub fn is_doc_comment(&self) -> bool {
+    pub fn is_doc_comment(&self) -> Option<Span> {
         AttributeExt::is_doc_comment(self)
     }
 

--- a/compiler/rustc_hir_analysis/src/check/wfcheck.rs
+++ b/compiler/rustc_hir_analysis/src/check/wfcheck.rs
@@ -1651,9 +1651,7 @@ fn check_method_receiver<'tcx>(
 
     // If the receiver already has errors reported, consider it valid to avoid
     // unnecessary errors (#58712).
-    if receiver_ty.references_error() {
-        return Ok(());
-    }
+    receiver_ty.error_reported()?;
 
     let arbitrary_self_types_level = if tcx.features().arbitrary_self_types_pointers() {
         Some(ArbitrarySelfTypesLevel::WithPointers)

--- a/compiler/rustc_hir_analysis/src/coherence/mod.rs
+++ b/compiler/rustc_hir_analysis/src/coherence/mod.rs
@@ -39,9 +39,7 @@ fn check_impl<'tcx>(
 
     // Skip impls where one of the self type is an error type.
     // This occurs with e.g., resolve failures (#30589).
-    if trait_ref.references_error() {
-        return Ok(());
-    }
+    trait_ref.error_reported()?;
 
     enforce_trait_manually_implementable(tcx, impl_def_id, trait_ref.def_id, trait_def)
         .and(enforce_empty_impls_for_marker_traits(tcx, impl_def_id, trait_ref.def_id, trait_def))
@@ -188,9 +186,9 @@ fn check_object_overlap<'tcx>(
 ) -> Result<(), ErrorGuaranteed> {
     let trait_def_id = trait_ref.def_id;
 
-    if trait_ref.references_error() {
+    if let Err(guar) = trait_ref.error_reported() {
         debug!("coherence: skipping impl {:?} with error {:?}", impl_def_id, trait_ref);
-        return Ok(());
+        return Err(guar);
     }
 
     // check for overlap with the automatic `impl Trait for dyn Trait`

--- a/compiler/rustc_hir_analysis/src/impl_wf_check.rs
+++ b/compiler/rustc_hir_analysis/src/impl_wf_check.rs
@@ -76,20 +76,10 @@ pub(crate) fn enforce_impl_lifetime_params_are_constrained(
     impl_def_id: LocalDefId,
 ) -> Result<(), ErrorGuaranteed> {
     let impl_self_ty = tcx.type_of(impl_def_id).instantiate_identity();
-    if impl_self_ty.references_error() {
-        // Don't complain about unconstrained type params when self ty isn't known due to errors.
-        // (#36836)
-        tcx.dcx().span_delayed_bug(
-            tcx.def_span(impl_def_id),
-            format!(
-                "potentially unconstrained type parameters weren't evaluated: {impl_self_ty:?}",
-            ),
-        );
-        // This is super fishy, but our current `rustc_hir_analysis::check_crate` pipeline depends on
-        // `type_of` having been called much earlier, and thus this value being read from cache.
-        // Compilation must continue in order for other important diagnostics to keep showing up.
-        return Ok(());
-    }
+
+    // Don't complain about unconstrained type params when self ty isn't known due to errors.
+    // (#36836)
+    impl_self_ty.error_reported()?;
 
     let impl_generics = tcx.generics_of(impl_def_id);
     let impl_predicates = tcx.predicates_of(impl_def_id);
@@ -174,20 +164,11 @@ pub(crate) fn enforce_impl_non_lifetime_params_are_constrained(
     impl_def_id: LocalDefId,
 ) -> Result<(), ErrorGuaranteed> {
     let impl_self_ty = tcx.type_of(impl_def_id).instantiate_identity();
-    if impl_self_ty.references_error() {
-        // Don't complain about unconstrained type params when self ty isn't known due to errors.
-        // (#36836)
-        tcx.dcx().span_delayed_bug(
-            tcx.def_span(impl_def_id),
-            format!(
-                "potentially unconstrained type parameters weren't evaluated: {impl_self_ty:?}",
-            ),
-        );
-        // This is super fishy, but our current `rustc_hir_analysis::check_crate` pipeline depends on
-        // `type_of` having been called much earlier, and thus this value being read from cache.
-        // Compilation must continue in order for other important diagnostics to keep showing up.
-        return Ok(());
-    }
+
+    // Don't complain about unconstrained type params when self ty isn't known due to errors.
+    // (#36836)
+    impl_self_ty.error_reported()?;
+
     let impl_generics = tcx.generics_of(impl_def_id);
     let impl_predicates = tcx.predicates_of(impl_def_id);
     let impl_trait_ref = tcx.impl_trait_ref(impl_def_id).map(ty::EarlyBinder::instantiate_identity);

--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -685,9 +685,11 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         });
         let ty =
             self.check_expr_with_expectation_and_needs(oprnd, hint, Needs::maybe_mut_place(mutbl));
+        if let Err(guar) = ty.error_reported() {
+            return Ty::new_error(self.tcx, guar);
+        }
 
         match kind {
-            _ if ty.references_error() => Ty::new_misc_error(self.tcx),
             hir::BorrowKind::Raw => {
                 self.check_named_place_expr(oprnd);
                 Ty::new_ptr(self.tcx, ty, mutbl)

--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -391,7 +391,7 @@ pub struct MissingDoc;
 impl_lint_pass!(MissingDoc => [MISSING_DOCS]);
 
 fn has_doc(attr: &hir::Attribute) -> bool {
-    if attr.is_doc_comment() {
+    if attr.is_doc_comment().is_some() {
         return true;
     }
 

--- a/compiler/rustc_query_system/src/ich/impls_syntax.rs
+++ b/compiler/rustc_query_system/src/ich/impls_syntax.rs
@@ -22,7 +22,7 @@ impl<'a> HashStable<StableHashingContext<'a>> for [hir::Attribute] {
         let filtered: SmallVec<[&hir::Attribute; 8]> = self
             .iter()
             .filter(|attr| {
-                !attr.is_doc_comment()
+                attr.is_doc_comment().is_none()
                     // FIXME(jdonszelmann) have a better way to handle ignored attrs
                     && !attr.ident().is_some_and(|ident| hcx.is_ignored_attr(ident.name))
             })

--- a/compiler/rustc_resolve/src/rustdoc.rs
+++ b/compiler/rustc_resolve/src/rustdoc.rs
@@ -214,8 +214,7 @@ pub fn attrs_to_doc_fragments<'a, A: AttributeExt + Clone + 'a>(
     for (attr, item_id) in attrs {
         if let Some((doc_str, comment_kind)) = attr.doc_str_and_comment_kind() {
             let doc = beautify_doc_string(doc_str, comment_kind);
-            let (span, kind, from_expansion) = if attr.is_doc_comment() {
-                let span = attr.span();
+            let (span, kind, from_expansion) = if let Some(span) = attr.is_doc_comment() {
                 (span, DocFragmentKind::SugaredDoc, span.from_expansion())
             } else {
                 let attr_span = attr.span();

--- a/compiler/rustc_sanitizers/src/cfi/typeid/mod.rs
+++ b/compiler/rustc_sanitizers/src/cfi/typeid/mod.rs
@@ -21,7 +21,7 @@ bitflags! {
         const GENERALIZE_REPR_C = 2;
         /// Normalizes integers for compatibility with Clang
         /// `-fsanitize-cfi-icall-experimental-normalize-integers` option for cross-language LLVM
-        /// CFI and  KCFI support.
+        /// CFI and KCFI support.
         const NORMALIZE_INTEGERS = 4;
         /// Do not perform self type erasure for attaching a secondary type id to methods with their
         /// concrete self so they can be used as function pointers.

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/on_unimplemented.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/on_unimplemented.rs
@@ -309,7 +309,7 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
 pub struct OnUnimplementedFormatString {
     /// Symbol of the format string, i.e. `"content"`
     symbol: Symbol,
-    ///The span of the format string, i.e. `"content"`
+    /// The span of the format string, i.e. `"content"`
     span: Span,
     is_diagnostic_namespace_variant: bool,
 }

--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -6,7 +6,7 @@
 #![stable(feature = "rust1", since = "1.0.0")]
 
 use crate::alloc::Layout;
-use crate::marker::DiscriminantKind;
+use crate::marker::{Destruct, DiscriminantKind};
 use crate::panic::const_assert;
 use crate::{clone, cmp, fmt, hash, intrinsics, ptr};
 
@@ -958,8 +958,13 @@ pub const fn replace<T>(dest: &mut T, src: T) -> T {
 /// [`RefCell`]: crate::cell::RefCell
 #[inline]
 #[stable(feature = "rust1", since = "1.0.0")]
+#[rustc_const_unstable(feature = "const_destruct", issue = "133214")]
 #[rustc_diagnostic_item = "mem_drop"]
-pub fn drop<T>(_x: T) {}
+pub const fn drop<T>(_x: T)
+where
+    T: [const] Destruct,
+{
+}
 
 /// Bitwise-copies a value.
 ///

--- a/library/std/src/sync/nonpoison/rwlock.rs
+++ b/library/std/src/sync/nonpoison/rwlock.rs
@@ -638,7 +638,6 @@ impl<'rwlock, T: ?Sized> RwLockWriteGuard<'rwlock, T> {
     ///
     /// ```
     /// #![feature(nonpoison_rwlock)]
-    /// #![feature(rwlock_downgrade)]
     ///
     /// use std::sync::nonpoison::{RwLock, RwLockWriteGuard};
     ///
@@ -657,7 +656,6 @@ impl<'rwlock, T: ?Sized> RwLockWriteGuard<'rwlock, T> {
     ///
     /// ```
     /// #![feature(nonpoison_rwlock)]
-    /// #![feature(rwlock_downgrade)]
     ///
     /// use std::sync::Arc;
     /// use std::sync::nonpoison::{RwLock, RwLockWriteGuard};
@@ -690,8 +688,7 @@ impl<'rwlock, T: ?Sized> RwLockWriteGuard<'rwlock, T> {
     /// # let final_check = rw.read();
     /// # assert_eq!(*final_check, 3);
     /// ```
-    #[unstable(feature = "rwlock_downgrade", issue = "128203")]
-    // #[unstable(feature = "nonpoison_rwlock", issue = "134645")]
+    #[unstable(feature = "nonpoison_rwlock", issue = "134645")]
     pub fn downgrade(s: Self) -> RwLockReadGuard<'rwlock, T> {
         let lock = s.lock;
 

--- a/library/std/src/sync/poison/rwlock.rs
+++ b/library/std/src/sync/poison/rwlock.rs
@@ -813,8 +813,6 @@ impl<'rwlock, T: ?Sized> RwLockWriteGuard<'rwlock, T> {
     /// `downgrade` takes ownership of the `RwLockWriteGuard` and returns a [`RwLockReadGuard`].
     ///
     /// ```
-    /// #![feature(rwlock_downgrade)]
-    ///
     /// use std::sync::{RwLock, RwLockWriteGuard};
     ///
     /// let rw = RwLock::new(0);
@@ -831,8 +829,6 @@ impl<'rwlock, T: ?Sized> RwLockWriteGuard<'rwlock, T> {
     /// thread calling `downgrade` and any reads it performs after downgrading.
     ///
     /// ```
-    /// #![feature(rwlock_downgrade)]
-    ///
     /// use std::sync::{Arc, RwLock, RwLockWriteGuard};
     ///
     /// let rw = Arc::new(RwLock::new(1));
@@ -863,7 +859,7 @@ impl<'rwlock, T: ?Sized> RwLockWriteGuard<'rwlock, T> {
     /// # let final_check = rw.read().unwrap();
     /// # assert_eq!(*final_check, 3);
     /// ```
-    #[unstable(feature = "rwlock_downgrade", issue = "128203")]
+    #[stable(feature = "rwlock_downgrade", since = "CURRENT_RUSTC_VERSION")]
     pub fn downgrade(s: Self) -> RwLockReadGuard<'rwlock, T> {
         let lock = s.lock;
 

--- a/library/std/tests/sync/lib.rs
+++ b/library/std/tests/sync/lib.rs
@@ -4,7 +4,6 @@
 #![feature(once_cell_try)]
 #![feature(lock_value_accessors)]
 #![feature(reentrant_lock)]
-#![feature(rwlock_downgrade)]
 #![feature(std_internals)]
 #![feature(sync_nonpoison)]
 #![feature(nonpoison_mutex)]

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -2719,7 +2719,7 @@ fn add_without_unwanted_attributes<'hir>(
     import_parent: Option<DefId>,
 ) {
     for attr in new_attrs {
-        if attr.is_doc_comment() {
+        if attr.is_doc_comment().is_some() {
             attrs.push((Cow::Borrowed(attr), import_parent));
             continue;
         }

--- a/src/librustdoc/passes/propagate_doc_cfg.rs
+++ b/src/librustdoc/passes/propagate_doc_cfg.rs
@@ -65,7 +65,7 @@ fn filter_non_cfg_tokens_from_list(args_tokens: &TokenStream) -> Vec<TokenTree> 
 /// it and put them into `attrs`.
 fn add_only_cfg_attributes(attrs: &mut Vec<Attribute>, new_attrs: &[Attribute]) {
     for attr in new_attrs {
-        if attr.is_doc_comment() {
+        if attr.is_doc_comment().is_some() {
             continue;
         }
         let mut attr = attr.clone();

--- a/src/tools/clippy/clippy_lints/src/four_forward_slashes.rs
+++ b/src/tools/clippy/clippy_lints/src/four_forward_slashes.rs
@@ -47,7 +47,7 @@ impl<'tcx> LateLintPass<'tcx> for FourForwardSlashes {
             .tcx
             .hir_attrs(item.hir_id())
             .iter()
-            .filter(|i| i.is_doc_comment())
+            .filter(|i| i.is_doc_comment().is_some())
             .fold(item.span.shrink_to_lo(), |span, attr| span.to(attr.span()));
         let (Some(file), _, _, end_line, _) = sm.span_to_location_info(span) else {
             return;

--- a/src/tools/clippy/clippy_lints/src/undocumented_unsafe_blocks.rs
+++ b/src/tools/clippy/clippy_lints/src/undocumented_unsafe_blocks.rs
@@ -475,7 +475,7 @@ fn block_has_safety_comment(cx: &LateContext<'_>, span: Span) -> bool {
 
 fn include_attrs_in_span(cx: &LateContext<'_>, hir_id: HirId, span: Span) -> Span {
     span.to(cx.tcx.hir_attrs(hir_id).iter().fold(span, |acc, attr| {
-        if attr.is_doc_comment() {
+        if attr.is_doc_comment().is_some() {
             return acc;
         }
         acc.to(attr.span())

--- a/src/tools/miri/src/bin/log/tracing_chrome.rs
+++ b/src/tools/miri/src/bin/log/tracing_chrome.rs
@@ -523,16 +523,16 @@ where
                 }
             },
             TraceStyle::Async => Some(
-        span.scope()
-            .from_root()
-            .take(1)
-            .next()
-            .unwrap_or(span)
-            .id()
-            .into_u64()
+                span.scope()
+                    .from_root()
+                    .take(1)
+                    .next()
+                    .unwrap_or(span)
+                    .id()
+                    .into_u64()
                     .cast_signed() // the comment above explains the cast
             ),
-    }
+        }
     }
 
     fn enter_span(&self, span: SpanRef<S>, ts: f64, tid: usize, out: &Sender<Message>) {
@@ -567,11 +567,11 @@ where
                 Some(thread_data) => (thread_data, false),
                 None => {
                     let tid = self.max_tid.fetch_add(1, Ordering::SeqCst);
-                let out = self.out.lock().unwrap().clone();
+                    let out = self.out.lock().unwrap().clone();
                     let start = TracingChromeInstant::setup_for_thread_and_start(tid);
                     *thread_data = Some(ThreadData { tid, out, start });
                     (thread_data.as_mut().unwrap(), true)
-            }
+                }
             };
 
             start.with_elapsed_micros_subtracting_tracing(|ts| {
@@ -583,7 +583,7 @@ where
                     let _ignored = out.send(Message::NewThread(*tid, name));
                 }
                 f(ts, *tid, out);
-        });
+            });
         });
     }
 }
@@ -605,15 +605,15 @@ where
     fn on_record(&self, id: &span::Id, values: &span::Record<'_>, ctx: Context<'_, S>) {
         if self.include_args {
             self.with_elapsed_micros_subtracting_tracing(|_, _, _| {
-            let span = ctx.span(id).unwrap();
-            let mut exts = span.extensions_mut();
+                let span = ctx.span(id).unwrap();
+                let mut exts = span.extensions_mut();
 
-            let args = exts.get_mut::<ArgsWrapper>();
+                let args = exts.get_mut::<ArgsWrapper>();
 
-            if let Some(args) = args {
-                let args = Arc::make_mut(&mut args.args);
-                values.record(&mut JsonVisitor { object: args });
-            }
+                if let Some(args) = args {
+                    let args = Arc::make_mut(&mut args.args);
+                    values.record(&mut JsonVisitor { object: args });
+                }
             });
         }
     }
@@ -636,16 +636,16 @@ where
 
     fn on_new_span(&self, attrs: &span::Attributes<'_>, id: &span::Id, ctx: Context<'_, S>) {
         self.with_elapsed_micros_subtracting_tracing(|ts, tid, out| {
-        if self.include_args {
-            let mut args = Object::new();
-            attrs.record(&mut JsonVisitor { object: &mut args });
-            ctx.span(id).unwrap().extensions_mut().insert(ArgsWrapper {
-                args: Arc::new(args),
-            });
-        }
-        if let TraceStyle::Threaded = self.trace_style {
-            return;
-        }
+            if self.include_args {
+                let mut args = Object::new();
+                attrs.record(&mut JsonVisitor { object: &mut args });
+                ctx.span(id).unwrap().extensions_mut().insert(ArgsWrapper {
+                    args: Arc::new(args),
+                });
+            }
+            if let TraceStyle::Threaded = self.trace_style {
+                return;
+            }
 
             self.enter_span(ctx.span(id).expect("Span not found."), ts, tid, out);
         });

--- a/src/tools/miri/src/intrinsics/simd.rs
+++ b/src/tools/miri/src/intrinsics/simd.rs
@@ -38,47 +38,47 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 for i in 0..dest_len {
                     let op = this.read_immediate(&this.project_index(&op, i)?)?;
                     let dest = this.project_index(&dest, i)?;
-                            let ty::Float(float_ty) = op.layout.ty.kind() else {
-                                span_bug!(this.cur_span(), "{} operand is not a float", intrinsic_name)
-                            };
-                            // Using host floats except for sqrt (but it's fine, these operations do not
-                            // have guaranteed precision).
+                    let ty::Float(float_ty) = op.layout.ty.kind() else {
+                        span_bug!(this.cur_span(), "{} operand is not a float", intrinsic_name)
+                    };
+                    // Using host floats except for sqrt (but it's fine, these operations do not
+                    // have guaranteed precision).
                     let val = match float_ty {
-                                FloatTy::F16 => unimplemented!("f16_f128"),
-                                FloatTy::F32 => {
-                                    let f = op.to_scalar().to_f32()?;
+                        FloatTy::F16 => unimplemented!("f16_f128"),
+                        FloatTy::F32 => {
+                            let f = op.to_scalar().to_f32()?;
                             let res = match intrinsic_name {
-                                        "fsqrt" => math::sqrt(f),
-                                        "fsin" => f.to_host().sin().to_soft(),
-                                        "fcos" => f.to_host().cos().to_soft(),
-                                        "fexp" => f.to_host().exp().to_soft(),
-                                        "fexp2" => f.to_host().exp2().to_soft(),
-                                        "flog" => f.to_host().ln().to_soft(),
-                                        "flog2" => f.to_host().log2().to_soft(),
-                                        "flog10" => f.to_host().log10().to_soft(),
-                                        _ => bug!(),
-                                    };
-                                    let res = this.adjust_nan(res, &[f]);
-                                    Scalar::from(res)
-                                }
-                                FloatTy::F64 => {
-                                    let f = op.to_scalar().to_f64()?;
-                            let res = match intrinsic_name {
-                                        "fsqrt" => math::sqrt(f),
-                                        "fsin" => f.to_host().sin().to_soft(),
-                                        "fcos" => f.to_host().cos().to_soft(),
-                                        "fexp" => f.to_host().exp().to_soft(),
-                                        "fexp2" => f.to_host().exp2().to_soft(),
-                                        "flog" => f.to_host().ln().to_soft(),
-                                        "flog2" => f.to_host().log2().to_soft(),
-                                        "flog10" => f.to_host().log10().to_soft(),
-                                        _ => bug!(),
-                                    };
-                                    let res = this.adjust_nan(res, &[f]);
-                                    Scalar::from(res)
-                                }
-                                FloatTy::F128 => unimplemented!("f16_f128"),
+                                "fsqrt" => math::sqrt(f),
+                                "fsin" => f.to_host().sin().to_soft(),
+                                "fcos" => f.to_host().cos().to_soft(),
+                                "fexp" => f.to_host().exp().to_soft(),
+                                "fexp2" => f.to_host().exp2().to_soft(),
+                                "flog" => f.to_host().ln().to_soft(),
+                                "flog2" => f.to_host().log2().to_soft(),
+                                "flog10" => f.to_host().log10().to_soft(),
+                                _ => bug!(),
                             };
+                            let res = this.adjust_nan(res, &[f]);
+                            Scalar::from(res)
+                        }
+                        FloatTy::F64 => {
+                            let f = op.to_scalar().to_f64()?;
+                            let res = match intrinsic_name {
+                                "fsqrt" => math::sqrt(f),
+                                "fsin" => f.to_host().sin().to_soft(),
+                                "fcos" => f.to_host().cos().to_soft(),
+                                "fexp" => f.to_host().exp().to_soft(),
+                                "fexp2" => f.to_host().exp2().to_soft(),
+                                "flog" => f.to_host().ln().to_soft(),
+                                "flog2" => f.to_host().log2().to_soft(),
+                                "flog10" => f.to_host().log10().to_soft(),
+                                _ => bug!(),
+                            };
+                            let res = this.adjust_nan(res, &[f]);
+                            Scalar::from(res)
+                        }
+                        FloatTy::F128 => unimplemented!("f16_f128"),
+                    };
 
                     this.write_scalar(val, &dest)?;
                 }

--- a/src/tools/miri/src/lib.rs
+++ b/src/tools/miri/src/lib.rs
@@ -53,6 +53,7 @@
 extern crate rustc_abi;
 extern crate rustc_apfloat;
 extern crate rustc_ast;
+extern crate rustc_codegen_ssa;
 extern crate rustc_const_eval;
 extern crate rustc_data_structures;
 extern crate rustc_errors;

--- a/src/tools/miri/src/shims/foreign_items.rs
+++ b/src/tools/miri/src/shims/foreign_items.rs
@@ -2,8 +2,9 @@ use std::collections::hash_map::Entry;
 use std::io::Write;
 use std::path::Path;
 
-use rustc_abi::{Align, AlignFromBytesError, CanonAbi, Size};
-use rustc_ast::expand::allocator::AllocatorKind;
+use rustc_abi::{Align, CanonAbi, Size};
+use rustc_ast::expand::allocator::NO_ALLOC_SHIM_IS_UNSTABLE;
+use rustc_data_structures::either::Either;
 use rustc_hir::attrs::Linkage;
 use rustc_hir::def::DefKind;
 use rustc_hir::def_id::CrateNum;
@@ -11,6 +12,7 @@ use rustc_middle::middle::codegen_fn_attrs::CodegenFnAttrFlags;
 use rustc_middle::mir::interpret::AllocInit;
 use rustc_middle::ty::{Instance, Ty};
 use rustc_middle::{mir, ty};
+use rustc_session::config::OomStrategy;
 use rustc_span::Symbol;
 use rustc_target::callconv::FnAbi;
 
@@ -50,31 +52,21 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
     ) -> InterpResult<'tcx, Option<(&'tcx mir::Body<'tcx>, ty::Instance<'tcx>)>> {
         let this = self.eval_context_mut();
 
-        // Some shims forward to other MIR bodies.
-        match link_name.as_str() {
-            // This allocator function has forwarding shims synthesized during normal codegen
-            // (see `allocator_shim_contents`); this is where we emulate that behavior.
-            // FIXME should use global_fn_name, but mangle_internal_symbol requires a static str.
-            name if name == this.mangle_internal_symbol("__rust_alloc_error_handler") => {
-                // Forward to the right symbol that implements this function.
-                let Some(handler_kind) = this.tcx.alloc_error_handler_kind(()) else {
-                    // in real code, this symbol does not exist without an allocator
-                    throw_unsup_format!(
-                        "`__rust_alloc_error_handler` cannot be called when no alloc error handler is set"
-                    );
-                };
-                if handler_kind == AllocatorKind::Default {
-                    let name =
-                        Symbol::intern(this.mangle_internal_symbol("__rdl_alloc_error_handler"));
+        // Handle allocator shim.
+        if let Some(shim) = this.machine.allocator_shim_symbols.get(&link_name) {
+            match *shim {
+                Either::Left(other_fn) => {
                     let handler = this
-                        .lookup_exported_symbol(name)?
+                        .lookup_exported_symbol(other_fn)?
                         .expect("missing alloc error handler symbol");
                     return interp_ok(Some(handler));
                 }
-                // Fall through to the `lookup_exported_symbol` below which should find
-                // a `__rust_alloc_error_handler`.
+                Either::Right(special) => {
+                    this.rust_special_allocator_method(special, link_name, abi, args, dest)?;
+                    this.return_to_block(ret)?;
+                    return interp_ok(None);
+                }
             }
-            _ => {}
         }
 
         // FIXME: avoid allocating memory
@@ -254,33 +246,6 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
 impl<'tcx> EvalContextExtPriv<'tcx> for crate::MiriInterpCx<'tcx> {}
 trait EvalContextExtPriv<'tcx>: crate::MiriInterpCxExt<'tcx> {
-    /// Check some basic requirements for this allocation request:
-    /// non-zero size, power-of-two alignment.
-    fn check_rustc_alloc_request(&self, size: u64, align: u64) -> InterpResult<'tcx> {
-        let this = self.eval_context_ref();
-        if size == 0 {
-            throw_ub_format!("creating allocation with size 0");
-        }
-        if size > this.max_size_of_val().bytes() {
-            throw_ub_format!("creating an allocation larger than half the address space");
-        }
-        if let Err(e) = Align::from_bytes(align) {
-            match e {
-                AlignFromBytesError::TooLarge(_) => {
-                    throw_unsup_format!(
-                        "creating allocation with alignment {align} exceeding rustc's maximum \
-                         supported value"
-                    );
-                }
-                AlignFromBytesError::NotPowerOfTwo(_) => {
-                    throw_ub_format!("creating allocation with non-power-of-two alignment {align}");
-                }
-            }
-        }
-
-        interp_ok(())
-    }
-
     fn emulate_foreign_item_inner(
         &mut self,
         link_name: Symbol,
@@ -340,7 +305,51 @@ trait EvalContextExtPriv<'tcx>: crate::MiriInterpCxExt<'tcx> {
         // Here we dispatch all the shims for foreign functions. If you have a platform specific
         // shim, add it to the corresponding submodule.
         match link_name.as_str() {
+            // Magic functions Rust emits (and not as part of the allocator shim).
+            name if name == this.mangle_internal_symbol(NO_ALLOC_SHIM_IS_UNSTABLE) => {
+                // This is a no-op shim that only exists to prevent making the allocator shims
+                // instantly stable.
+                let [] = this.check_shim_sig_lenient(abi, CanonAbi::Rust, link_name, args)?;
+            }
+            name if name == this.mangle_internal_symbol(OomStrategy::SYMBOL) => {
+                // Gets the value of the `oom` option.
+                let [] = this.check_shim_sig_lenient(abi, CanonAbi::Rust, link_name, args)?;
+                let val = this.tcx.sess.opts.unstable_opts.oom.should_panic();
+                this.write_int(val, dest)?;
+            }
+
             // Miri-specific extern functions
+            "miri_alloc" => {
+                let [size, align] =
+                    this.check_shim_sig_lenient(abi, CanonAbi::Rust, link_name, args)?;
+                let size = this.read_target_usize(size)?;
+                let align = this.read_target_usize(align)?;
+
+                this.check_rust_alloc_request(size, align)?;
+
+                let ptr = this.allocate_ptr(
+                    Size::from_bytes(size),
+                    Align::from_bytes(align).unwrap(),
+                    MiriMemoryKind::Miri.into(),
+                    AllocInit::Uninit,
+                )?;
+
+                this.write_pointer(ptr, dest)?;
+            }
+            "miri_dealloc" => {
+                let [ptr, old_size, align] =
+                    this.check_shim_sig_lenient(abi, CanonAbi::Rust, link_name, args)?;
+                let ptr = this.read_pointer(ptr)?;
+                let old_size = this.read_target_usize(old_size)?;
+                let align = this.read_target_usize(align)?;
+
+                // No need to check old_size/align; we anyway check that they match the allocation.
+                this.deallocate_ptr(
+                    ptr,
+                    Some((Size::from_bytes(old_size), Align::from_bytes(align).unwrap())),
+                    MiriMemoryKind::Miri.into(),
+                )?;
+            }
             "miri_start_unwind" => {
                 let [payload] =
                     this.check_shim_sig_lenient(abi, CanonAbi::Rust, link_name, args)?;
@@ -492,7 +501,6 @@ trait EvalContextExtPriv<'tcx>: crate::MiriInterpCxExt<'tcx> {
                     }
                 }
             }
-
             // GenMC mode: Assume statements block the current thread when their condition is false.
             "miri_genmc_assume" => {
                 let [condition] =
@@ -577,133 +585,6 @@ trait EvalContextExtPriv<'tcx>: crate::MiriInterpCxExt<'tcx> {
                     }
                     this.write_null(dest)?;
                 }
-            }
-
-            // Rust allocation
-            name if name == this.mangle_internal_symbol("__rust_alloc") || name == "miri_alloc" => {
-                let default = |ecx: &mut MiriInterpCx<'tcx>| {
-                    // Only call `check_shim` when `#[global_allocator]` isn't used. When that
-                    // macro is used, we act like no shim exists, so that the exported function can run.
-                    let [size, align] =
-                        ecx.check_shim_sig_lenient(abi, CanonAbi::Rust, link_name, args)?;
-                    let size = ecx.read_target_usize(size)?;
-                    let align = ecx.read_target_usize(align)?;
-
-                    ecx.check_rustc_alloc_request(size, align)?;
-
-                    let memory_kind = match link_name.as_str() {
-                        "miri_alloc" => MiriMemoryKind::Miri,
-                        _ => MiriMemoryKind::Rust,
-                    };
-
-                    let ptr = ecx.allocate_ptr(
-                        Size::from_bytes(size),
-                        Align::from_bytes(align).unwrap(),
-                        memory_kind.into(),
-                        AllocInit::Uninit,
-                    )?;
-
-                    ecx.write_pointer(ptr, dest)
-                };
-
-                match link_name.as_str() {
-                    "miri_alloc" => {
-                        default(this)?;
-                        return interp_ok(EmulateItemResult::NeedsReturn);
-                    }
-                    _ => return this.emulate_allocator(default),
-                }
-            }
-            name if name == this.mangle_internal_symbol("__rust_alloc_zeroed") => {
-                return this.emulate_allocator(|this| {
-                    // See the comment for `__rust_alloc` why `check_shim` is only called in the
-                    // default case.
-                    let [size, align] =
-                        this.check_shim_sig_lenient(abi, CanonAbi::Rust, link_name, args)?;
-                    let size = this.read_target_usize(size)?;
-                    let align = this.read_target_usize(align)?;
-
-                    this.check_rustc_alloc_request(size, align)?;
-
-                    let ptr = this.allocate_ptr(
-                        Size::from_bytes(size),
-                        Align::from_bytes(align).unwrap(),
-                        MiriMemoryKind::Rust.into(),
-                        AllocInit::Zero,
-                    )?;
-                    this.write_pointer(ptr, dest)
-                });
-            }
-            name if name == this.mangle_internal_symbol("__rust_dealloc")
-                || name == "miri_dealloc" =>
-            {
-                let default = |ecx: &mut MiriInterpCx<'tcx>| {
-                    // See the comment for `__rust_alloc` why `check_shim` is only called in the
-                    // default case.
-                    let [ptr, old_size, align] =
-                        ecx.check_shim_sig_lenient(abi, CanonAbi::Rust, link_name, args)?;
-                    let ptr = ecx.read_pointer(ptr)?;
-                    let old_size = ecx.read_target_usize(old_size)?;
-                    let align = ecx.read_target_usize(align)?;
-
-                    let memory_kind = match link_name.as_str() {
-                        "miri_dealloc" => MiriMemoryKind::Miri,
-                        _ => MiriMemoryKind::Rust,
-                    };
-
-                    // No need to check old_size/align; we anyway check that they match the allocation.
-                    ecx.deallocate_ptr(
-                        ptr,
-                        Some((Size::from_bytes(old_size), Align::from_bytes(align).unwrap())),
-                        memory_kind.into(),
-                    )
-                };
-
-                match link_name.as_str() {
-                    "miri_dealloc" => {
-                        default(this)?;
-                        return interp_ok(EmulateItemResult::NeedsReturn);
-                    }
-                    _ => return this.emulate_allocator(default),
-                }
-            }
-            name if name == this.mangle_internal_symbol("__rust_realloc") => {
-                return this.emulate_allocator(|this| {
-                    // See the comment for `__rust_alloc` why `check_shim` is only called in the
-                    // default case.
-                    let [ptr, old_size, align, new_size] =
-                        this.check_shim_sig_lenient(abi, CanonAbi::Rust, link_name, args)?;
-                    let ptr = this.read_pointer(ptr)?;
-                    let old_size = this.read_target_usize(old_size)?;
-                    let align = this.read_target_usize(align)?;
-                    let new_size = this.read_target_usize(new_size)?;
-                    // No need to check old_size; we anyway check that they match the allocation.
-
-                    this.check_rustc_alloc_request(new_size, align)?;
-
-                    let align = Align::from_bytes(align).unwrap();
-                    let new_ptr = this.reallocate_ptr(
-                        ptr,
-                        Some((Size::from_bytes(old_size), align)),
-                        Size::from_bytes(new_size),
-                        align,
-                        MiriMemoryKind::Rust.into(),
-                        AllocInit::Uninit,
-                    )?;
-                    this.write_pointer(new_ptr, dest)
-                });
-            }
-            name if name == this.mangle_internal_symbol("__rust_no_alloc_shim_is_unstable_v2") => {
-                // This is a no-op shim that only exists to prevent making the allocator shims instantly stable.
-                let [] = this.check_shim_sig_lenient(abi, CanonAbi::Rust, link_name, args)?;
-            }
-            name if name
-                == this.mangle_internal_symbol("__rust_alloc_error_handler_should_panic_v2") =>
-            {
-                // Gets the value of the `oom` option.
-                let [] = this.check_shim_sig_lenient(abi, CanonAbi::Rust, link_name, args)?;
-                let val = this.tcx.sess.opts.unstable_opts.oom.should_panic();
-                this.write_int(val, dest)?;
             }
 
             // C memory handling functions

--- a/tests/ui/contracts/async-fn-contract-ice-145333.rs
+++ b/tests/ui/contracts/async-fn-contract-ice-145333.rs
@@ -1,0 +1,10 @@
+//@ compile-flags: --crate-type=lib
+//@ edition: 2021
+#![feature(contracts)]
+//~^ WARN the feature `contracts` is incomplete
+
+#[core::contracts::ensures(|ret| *ret)]
+//~^ ERROR contract annotations are not yet supported on async or gen functions
+async fn _always_true(b: bool) -> bool {
+    b
+}

--- a/tests/ui/contracts/async-fn-contract-ice-145333.stderr
+++ b/tests/ui/contracts/async-fn-contract-ice-145333.stderr
@@ -1,0 +1,17 @@
+error: contract annotations are not yet supported on async or gen functions
+  --> $DIR/async-fn-contract-ice-145333.rs:6:1
+   |
+LL | #[core::contracts::ensures(|ret| *ret)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: the feature `contracts` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/async-fn-contract-ice-145333.rs:3:12
+   |
+LL | #![feature(contracts)]
+   |            ^^^^^^^^^
+   |
+   = note: see issue #128044 <https://github.com/rust-lang/rust/issues/128044> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+error: aborting due to 1 previous error; 1 warning emitted
+

--- a/tests/ui/nll/polonius/lending-iterator-sanity-checks.polonius.stderr
+++ b/tests/ui/nll/polonius/lending-iterator-sanity-checks.polonius.stderr
@@ -1,13 +1,15 @@
 error[E0499]: cannot borrow `*t` as mutable more than once at a time
   --> $DIR/lending-iterator-sanity-checks.rs:19:19
    |
+LL | fn use_live<T: LendingIterator>(t: &mut T) -> Option<(T::Item<'_>, T::Item<'_>)> {
+   |                                    - let's call the lifetime of this reference `'1`
 LL |     let Some(i) = t.next() else { return None };
    |                   - first mutable borrow occurs here
 LL |     let Some(j) = t.next() else { return None };
    |                   ^ second mutable borrow occurs here
 ...
-LL | }
-   | - first borrow might be used here, when `i` is dropped and runs the destructor for type `<T as LendingIterator>::Item<'_>`
+LL |     Some((i, j))
+   |     ------------ returning this value requires that `*t` is borrowed for `'1`
 
 error[E0499]: cannot borrow `*t` as mutable more than once at a time
   --> $DIR/lending-iterator-sanity-checks.rs:31:13

--- a/tests/ui/traits/next-solver/alias-bound-unsound.rs
+++ b/tests/ui/traits/next-solver/alias-bound-unsound.rs
@@ -4,6 +4,10 @@
 
 #![feature(trivial_bounds)]
 
+// we use identity instead of drop because the presence of [const] Destruct means that there
+// are additional bounds on the function, which result in additional errors
+use std::convert::identity;
+
 trait Foo {
     type Item: Copy
     where
@@ -21,7 +25,7 @@ impl Foo for () {
 
 fn main() {
     let x = String::from("hello, world");
-    drop(<() as Foo>::copy_me(&x));
+    let _ = identity(<() as Foo>::copy_me(&x));
     //~^ ERROR overflow evaluating the requirement `String <: <() as Foo>::Item`
     //~| ERROR overflow evaluating the requirement `<() as Foo>::Item well-formed`
     //~| ERROR overflow evaluating the requirement `&<() as Foo>::Item well-formed`

--- a/tests/ui/traits/next-solver/alias-bound-unsound.stderr
+++ b/tests/ui/traits/next-solver/alias-bound-unsound.stderr
@@ -1,11 +1,11 @@
 error[E0275]: overflow evaluating the requirement `String: Copy`
-  --> $DIR/alias-bound-unsound.rs:18:38
+  --> $DIR/alias-bound-unsound.rs:22:38
    |
 LL |     type Item = String where String: Copy;
    |                                      ^^^^
    |
 note: the requirement `String: Copy` appears on the `impl`'s associated type `Item` but not on the corresponding trait's associated type
-  --> $DIR/alias-bound-unsound.rs:8:10
+  --> $DIR/alias-bound-unsound.rs:12:10
    |
 LL | trait Foo {
    |       --- in this trait
@@ -13,50 +13,50 @@ LL |     type Item: Copy
    |          ^^^^ this trait's associated type doesn't have the requirement `String: Copy`
 
 error[E0275]: overflow evaluating the requirement `String <: <() as Foo>::Item`
-  --> $DIR/alias-bound-unsound.rs:24:31
+  --> $DIR/alias-bound-unsound.rs:28:43
    |
-LL |     drop(<() as Foo>::copy_me(&x));
-   |                               ^^
+LL |     let _ = identity(<() as Foo>::copy_me(&x));
+   |                                           ^^
 
 error[E0275]: overflow evaluating the requirement `<() as Foo>::Item == _`
-  --> $DIR/alias-bound-unsound.rs:24:10
+  --> $DIR/alias-bound-unsound.rs:28:22
    |
-LL |     drop(<() as Foo>::copy_me(&x));
-   |          ^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     let _ = identity(<() as Foo>::copy_me(&x));
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0275]: overflow evaluating the requirement `<() as Foo>::Item == _`
-  --> $DIR/alias-bound-unsound.rs:24:10
+  --> $DIR/alias-bound-unsound.rs:28:22
    |
-LL |     drop(<() as Foo>::copy_me(&x));
-   |          ^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     let _ = identity(<() as Foo>::copy_me(&x));
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0275]: overflow evaluating the requirement `&<() as Foo>::Item well-formed`
-  --> $DIR/alias-bound-unsound.rs:24:31
+  --> $DIR/alias-bound-unsound.rs:28:43
    |
-LL |     drop(<() as Foo>::copy_me(&x));
-   |                               ^^
+LL |     let _ = identity(<() as Foo>::copy_me(&x));
+   |                                           ^^
 
 error[E0275]: overflow evaluating the requirement `<() as Foo>::Item well-formed`
-  --> $DIR/alias-bound-unsound.rs:24:10
+  --> $DIR/alias-bound-unsound.rs:28:22
    |
-LL |     drop(<() as Foo>::copy_me(&x));
-   |          ^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     let _ = identity(<() as Foo>::copy_me(&x));
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0275]: overflow evaluating the requirement `<() as Foo>::Item == _`
-  --> $DIR/alias-bound-unsound.rs:24:10
+  --> $DIR/alias-bound-unsound.rs:28:22
    |
-LL |     drop(<() as Foo>::copy_me(&x));
-   |          ^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     let _ = identity(<() as Foo>::copy_me(&x));
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0275]: overflow evaluating the requirement `<() as Foo>::Item == _`
-  --> $DIR/alias-bound-unsound.rs:24:31
+  --> $DIR/alias-bound-unsound.rs:28:43
    |
-LL |     drop(<() as Foo>::copy_me(&x));
-   |                               ^^
+LL |     let _ = identity(<() as Foo>::copy_me(&x));
+   |                                           ^^
 
 error: aborting due to 8 previous errors
 

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -742,13 +742,15 @@ message_on_reopen = "PR #{number} has been reopened. Pinging @*T-rustdoc*."
 [notify-zulip."beta-nominated".compiler]
 required_labels = ["T-compiler"]
 zulip_stream = 474880 # #t-compiler/backports
-topic = "#{number}: beta-nominated"
+topic = "#{number}: beta-backport nomination"
 message_on_add = [
     """\
-@**channel** PR #{number} "{title}" has been nominated for beta backport.
+PR #{number} "{title}" fixes a regression.
+{recipients}, please evaluate nominating this PR for backport.
+The following poll is a vibe-check and not binding.
 """,
     """\
-/poll Approve beta backport of #{number}?
+/poll Should #{number} be beta backported?
 approve
 decline
 don't know


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#143191 (Stabilize `rwlock_downgrade` library feature)
 - rust-lang/rust#147444 (Allow printing a fully-qualified path in `def_path_str`)
 - rust-lang/rust#147527 (Update t-compiler beta nomination Zulip msg)
 - rust-lang/rust#147670 (some `ErrorGuaranteed` cleanups)
 - rust-lang/rust#147676 (Return spans out of `is_doc_comment` to reduce reliance on `.span()` on attributes)
 - rust-lang/rust#147708 (const `mem::drop`)
 - rust-lang/rust#147710 (Fix ICE when using contracts on async functions)
 - rust-lang/rust#147716 (Fix some comments)
 - rust-lang/rust#147718 (miri: use allocator_shim_contents codegen helper)
 - rust-lang/rust#147729 (ignore boring locals when explaining why a borrow contains a point due to drop of a live local under polonius)
 - rust-lang/rust#147742 (Revert unintentional whitespace changes to rustfmt-excluded file)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=143191,147444,147527,147670,147676,147708,147710,147716,147718,147729,147742)
<!-- homu-ignore:end -->