### PR TITLE
Use `bit_set::Word` in a couple more places.

### DIFF
--- a/compiler/rustc_index/src/bit_set.rs
+++ b/compiler/rustc_index/src/bit_set.rs
@@ -873,7 +873,7 @@ impl<T: Idx> BitRelations<ChunkedBitSet<T>> for ChunkedBitSet<T> {
                     let mut self_chunk_words = **other_chunk_words;
                     for word in self_chunk_words[0..num_words].iter_mut().rev() {
                         *word = !*word & tail_mask;
-                        tail_mask = u64::MAX;
+                        tail_mask = Word::MAX;
                     }
                     let self_chunk_count = chunk_domain_size - *other_chunk_count;
                     debug_assert_eq!(
@@ -888,7 +888,7 @@ impl<T: Idx> BitRelations<ChunkedBitSet<T>> for ChunkedBitSet<T> {
                 ) => {
                     // See `ChunkedBitSet::union` for details on what is happening here.
                     let num_words = num_words(chunk_domain_size as usize);
-                    let op = |a: u64, b: u64| a & !b;
+                    let op = |a: Word, b: Word| a & !b;
                     if !bitwise_changes(
                         &self_chunk_words[0..num_words],
                         &other_chunk_words[0..num_words],


### PR DESCRIPTION
It's a synonym for `u64` and there are a couple of places where we use `u64` where we should use `Word`, which this commit fixes.

I found this when I tried changing `Word` to `u128` (which made performance worse).

r? @Zalathar 