### PR TITLE
style-guide: fix typo for empty struct advice

### DIFF
--- a/src/doc/style-guide/src/items.md
+++ b/src/doc/style-guide/src/items.md
@@ -123,7 +123,7 @@ struct Foo {
 Prefer using a unit struct (e.g., `struct Foo;`) to an empty struct (e.g.,
 `struct Foo();` or `struct Foo {}`, these only exist to simplify code
 generation), but if you must use an empty struct, keep it on one line with no
-space between the braces: `struct Foo;` or `struct Foo {}`.
+space between the braces: `struct Foo();` or `struct Foo {}`.
 
 The same guidelines are used for untagged union declarations.
 


### PR DESCRIPTION
the advice appears to apply to empty structs with braces (parens/blocks), and a unit struct in the comment does not make sense. Fix the typo.
