### PR TITLE
Improve error message for std integer clamp() if min > max

### DIFF
--- a/library/core/src/cmp.rs
+++ b/library/core/src/cmp.rs
@@ -1997,6 +1997,19 @@ mod impls {
                 fn cmp(&self, other: &Self) -> Ordering {
                     crate::intrinsics::three_way_compare(*self, *other)
                 }
+
+                #[inline]
+                fn clamp(self, min: Self, max: Self) -> Self
+                {
+                    assert!(min <= max, "min > max. min = {min}, max = {max}");
+                    if self < min {
+                        min
+                    } else if self > max {
+                        max
+                    } else {
+                        self
+                    }
+                }
             }
         )*)
     }

--- a/library/core/src/cmp.rs
+++ b/library/core/src/cmp.rs
@@ -1855,6 +1855,7 @@ mod impls {
     use crate::hint::unreachable_unchecked;
     use crate::marker::PointeeSized;
     use crate::ops::ControlFlow::{self, Break, Continue};
+    use crate::panic::const_assert;
 
     macro_rules! partial_eq_impl {
         ($($t:ty)*) => ($(
@@ -2002,7 +2003,13 @@ mod impls {
                 #[track_caller]
                 fn clamp(self, min: Self, max: Self) -> Self
                 {
-                    assert!(min <= max, "min > max. min = {min}, max = {max}");
+                    const_assert!(
+                        min <= max,
+                        "min > max",
+                        "min > max. min = {min:?}, max = {max:?}",
+                        min: $t,
+                        max: $t,
+                    );
                     if self < min {
                         min
                     } else if self > max {

--- a/library/core/src/cmp.rs
+++ b/library/core/src/cmp.rs
@@ -1999,6 +1999,7 @@ mod impls {
                 }
 
                 #[inline]
+                #[track_caller]
                 fn clamp(self, min: Self, max: Self) -> Self
                 {
                     assert!(min <= max, "min > max. min = {min}, max = {max}");


### PR DESCRIPTION
For rust-lang/rust#142309: change the error message for `Ord::clamp()` for std integer types if min > max to be more useful.

Message is now `min > max. min = {min:?}, max = {max:?}`

Also add `#[track_caller]` to `clamp()`