### PR TITLE
feat(rustdoc): `--emit=depinfo` output to stdout via `-`

### DIFF
--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -1111,7 +1111,7 @@ impl Input {
     }
 }
 
-#[derive(Clone, Hash, Debug, HashStable_Generic, PartialEq, Encodable, Decodable)]
+#[derive(Clone, Hash, Debug, HashStable_Generic, PartialEq, Eq, Encodable, Decodable)]
 pub enum OutFileName {
     Real(PathBuf),
     Stdout,

--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -9,8 +9,8 @@ use rustc_data_structures::fx::FxIndexMap;
 use rustc_errors::DiagCtxtHandle;
 use rustc_session::config::{
     self, CodegenOptions, CrateType, ErrorOutputType, Externs, Input, JsonUnusedExterns,
-    OptionsTargetModifiers, Sysroot, UnstableOptions, get_cmd_lint_options, nightly_options,
-    parse_crate_types_from_list, parse_externs, parse_target_triple,
+    OptionsTargetModifiers, OutFileName, Sysroot, UnstableOptions, get_cmd_lint_options,
+    nightly_options, parse_crate_types_from_list, parse_externs, parse_target_triple,
 };
 use rustc_session::lint::Level;
 use rustc_session::search_paths::SearchPath;
@@ -320,7 +320,7 @@ pub(crate) enum EmitType {
     Unversioned,
     Toolchain,
     InvocationSpecific,
-    DepInfo(Option<PathBuf>),
+    DepInfo(Option<OutFileName>),
 }
 
 impl FromStr for EmitType {
@@ -332,13 +332,11 @@ impl FromStr for EmitType {
             "toolchain-shared-resources" => Ok(Self::Toolchain),
             "invocation-specific" => Ok(Self::InvocationSpecific),
             "dep-info" => Ok(Self::DepInfo(None)),
-            option => {
-                if let Some(file) = option.strip_prefix("dep-info=") {
-                    Ok(Self::DepInfo(Some(Path::new(file).into())))
-                } else {
-                    Err(())
-                }
-            }
+            option => match option.strip_prefix("dep-info=") {
+                Some("-") => Ok(Self::DepInfo(Some(OutFileName::Stdout))),
+                Some(f) => Ok(Self::DepInfo(Some(OutFileName::Real(f.into())))),
+                None => Err(()),
+            },
         }
     }
 }
@@ -348,10 +346,10 @@ impl RenderOptions {
         self.emit.is_empty() || self.emit.contains(&EmitType::InvocationSpecific)
     }
 
-    pub(crate) fn dep_info(&self) -> Option<Option<&Path>> {
+    pub(crate) fn dep_info(&self) -> Option<Option<&OutFileName>> {
         for emit in &self.emit {
             if let EmitType::DepInfo(file) = emit {
-                return Some(file.as_deref());
+                return Some(file.as_ref());
             }
         }
         None

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -19,7 +19,7 @@ use rustc_lint::{MissingDoc, late_lint_mod};
 use rustc_middle::hir::nested_filter;
 use rustc_middle::ty::{self, ParamEnv, Ty, TyCtxt};
 use rustc_session::config::{
-    self, CrateType, ErrorOutputType, Input, OutFileName, OutputType, OutputTypes, ResolveDocLinks,
+    self, CrateType, ErrorOutputType, Input, OutputType, OutputTypes, ResolveDocLinks,
 };
 pub(crate) use rustc_session::config::{Options, UnstableOptions};
 use rustc_session::{Session, lint};
@@ -272,10 +272,7 @@ pub(crate) fn create_config(
         test,
         remap_path_prefix,
         output_types: if let Some(file) = render_options.dep_info() {
-            OutputTypes::new(&[(
-                OutputType::DepInfo,
-                file.map(|f| OutFileName::Real(f.to_path_buf())),
-            )])
+            OutputTypes::new(&[(OutputType::DepInfo, file.cloned())])
         } else {
             OutputTypes::new(&[])
         },

--- a/tests/run-make/rustdoc-dep-info/rmake.rs
+++ b/tests/run-make/rustdoc-dep-info/rmake.rs
@@ -54,6 +54,6 @@ fn main() {
         .emit("dep-info=-")
         .run();
     assert!(!path("precedence1.d").exists());
-    assert!(path("-").exists()); // `-` be treated as a file path
-    assert!(result.stdout().is_empty()); // Nothing emitted to stdout
+    assert!(!path("-").exists()); // `-` shouldn't be treated as a file path
+    assert!(!result.stdout().is_empty()); // Something emitted to stdout
 }

--- a/tests/run-make/rustdoc-dep-info/rmake.rs
+++ b/tests/run-make/rustdoc-dep-info/rmake.rs
@@ -45,4 +45,15 @@ fn main() {
     assert!(!path("precedence1.d").exists());
     assert!(!path("precedence2.d").exists());
     assert!(path("precedence3.d").exists());
+
+    // stdout (-) also wins if being the last.
+    let result = rustdoc()
+        .input("lib.rs")
+        .arg("-Zunstable-options")
+        .emit("dep-info=precedence1.d")
+        .emit("dep-info=-")
+        .run();
+    assert!(!path("precedence1.d").exists());
+    assert!(path("-").exists()); // `-` be treated as a file path
+    assert!(result.stdout().is_empty()); // Nothing emitted to stdout
 }


### PR DESCRIPTION
rustdoc's `--emit=depinfo` flag now supports using `-` to write the output to stdout,
aligning with rustc's behavior.

This will fix <https://github.com/rust-lang/rust/issues/147649>.

### How to review

* The first commit demonstrates that `rustdoc --emit=depinfo=-` hasn't yet supported emitting to stdout.
* The second implements it and the diff shows how the behavior changes.

