### PR TITLE
Undo CopyForDeref assertion in const qualif

### DIFF
--- a/compiler/rustc_const_eval/src/check_consts/qualifs.rs
+++ b/compiler/rustc_const_eval/src/check_consts/qualifs.rs
@@ -234,7 +234,7 @@ where
 
         Rvalue::Discriminant(place) => in_place::<Q, _>(cx, in_local, place.as_ref()),
 
-        Rvalue::CopyForDeref(_) => bug!("`CopyForDeref` in runtime MIR"),
+        Rvalue::CopyForDeref(place) => in_place::<Q, _>(cx, in_local, place.as_ref()),
 
         Rvalue::Use(operand)
         | Rvalue::Repeat(operand, _)

--- a/tests/ui/consts/precise-drop-nested-deref-ice.rs
+++ b/tests/ui/consts/precise-drop-nested-deref-ice.rs
@@ -1,0 +1,15 @@
+//! Tests that multiple derefs in a projection does not cause an ICE
+//! when checking const precise drops.
+//!
+//! Regression test for <https://github.com/rust-lang/rust/issues/147733>
+
+#![feature(const_precise_live_drops)]
+struct Foo(u32);
+impl Foo {
+    const fn get(self: Box<&Self>, f: &u32) -> u32 {
+        //~^ ERROR destructor of `Box<&Foo>` cannot be evaluated at compile-time
+        self.0
+    }
+}
+
+fn main() {}

--- a/tests/ui/consts/precise-drop-nested-deref-ice.stderr
+++ b/tests/ui/consts/precise-drop-nested-deref-ice.stderr
@@ -1,0 +1,12 @@
+error[E0493]: destructor of `Box<&Foo>` cannot be evaluated at compile-time
+  --> $DIR/precise-drop-nested-deref-ice.rs:9:18
+   |
+LL |     const fn get(self: Box<&Self>, f: &u32) -> u32 {
+   |                  ^^^^ the destructor for this type cannot be evaluated in constant functions
+...
+LL |     }
+   |     - value is dropped here
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0493`.


### PR DESCRIPTION
Fixes rust-lang/rust#147733 caused by rust-lang/rust#145513

This code in fact does not run only on runtime MIR.