### PR TITLE
`is_ascii` on an empty string or slice returns true

### DIFF
--- a/library/core/src/slice/ascii.rs
+++ b/library/core/src/slice/ascii.rs
@@ -9,6 +9,8 @@ use crate::{ascii, iter, ops};
 
 impl [u8] {
     /// Checks if all bytes in this slice are within the ASCII range.
+    ///
+    /// An empty slice returns `true`.
     #[stable(feature = "ascii_methods_on_intrinsics", since = "1.23.0")]
     #[rustc_const_stable(feature = "const_slice_is_ascii", since = "1.74.0")]
     #[must_use]

--- a/library/core/src/str/mod.rs
+++ b/library/core/src/str/mod.rs
@@ -2704,6 +2704,8 @@ impl str {
 
     /// Checks if all characters in this string are within the ASCII range.
     ///
+    /// An empty string returns `true`.
+    ///
     /// # Examples
     ///
     /// ```

--- a/library/std/src/ffi/os_str.rs
+++ b/library/std/src/ffi/os_str.rs
@@ -1215,6 +1215,8 @@ impl OsStr {
 
     /// Checks if all characters in this string are within the ASCII range.
     ///
+    /// An empty string returns `true`.
+    ///
     /// # Examples
     ///
     /// ```


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Update the description of the [`is_ascii`](https://doc.rust-lang.org/std/primitive.str.html#method.is_ascii) functions - an empty string or slice also returns `true`.

This follows the pattern of [`all()`](https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.all). Clippy currently suggests to change `string.chars().all(|c| c.is_ascii())` into `string.is_ascii()`. This suggestion therefore seems fitting.

I've already questioned the behavior for this multiple times. I've always had to check the internals to conclude how it works. That's why I'm opening this PR to add it directly in the documentation.