### PR TITLE
Fix ICE from invalid delimeter in attrs parsing

### DIFF
--- a/compiler/rustc_attr_parsing/src/session_diagnostics.rs
+++ b/compiler/rustc_attr_parsing/src/session_diagnostics.rs
@@ -823,6 +823,19 @@ pub(crate) struct MetaBadDelimSugg {
 }
 
 #[derive(Diagnostic)]
+#[diag(attr_parsing_meta_bad_delim)]
+pub(crate) struct MetaBadDelimSingle {
+    #[primary_span]
+    pub span: Span,
+    #[suggestion(
+        attr_parsing_meta_bad_delim_suggestion,
+        code = "(...)",
+        applicability = "machine-applicable"
+    )]
+    pub sugg_span: Span,
+}
+
+#[derive(Diagnostic)]
 #[diag(attr_parsing_invalid_meta_item)]
 pub(crate) struct InvalidMetaItem {
     #[primary_span]

--- a/compiler/rustc_attr_parsing/src/validate_attr.rs
+++ b/compiler/rustc_attr_parsing/src/validate_attr.rs
@@ -130,10 +130,15 @@ fn check_meta_bad_delim(psess: &ParseSess, span: DelimSpan, delim: Delimiter) {
     if let Delimiter::Parenthesis = delim {
         return;
     }
-    psess.dcx().emit_err(errors::MetaBadDelim {
-        span: span.entire(),
-        sugg: errors::MetaBadDelimSugg { open: span.open, close: span.close },
-    });
+
+    if span.open == span.close {
+        psess.dcx().emit_err(errors::MetaBadDelimSingle { span: span.open, sugg_span: span.open });
+    } else {
+        psess.dcx().emit_err(errors::MetaBadDelim {
+            span: span.entire(),
+            sugg: errors::MetaBadDelimSugg { open: span.open, close: span.close },
+        });
+    }
 }
 
 /// Checks that the given meta-item is compatible with this `AttributeTemplate`.

--- a/tests/ui/parser/attribute/invalid-delimeter-ice-146808.rs
+++ b/tests/ui/parser/attribute/invalid-delimeter-ice-146808.rs
@@ -1,0 +1,8 @@
+#![core::contracts::requires]
+//~^ ERROR use of unstable library feature `contracts`
+//~| ERROR inner macro attributes are unstable
+//~| ERROR wrong meta list delimiters
+//~| ERROR `#[prelude_import]` is for use by rustc only
+//~| ERROR mismatched types
+#[allow{}]
+fn main() {}

--- a/tests/ui/parser/attribute/invalid-delimeter-ice-146808.stderr
+++ b/tests/ui/parser/attribute/invalid-delimeter-ice-146808.stderr
@@ -1,0 +1,51 @@
+error[E0658]: use of unstable library feature `contracts`
+  --> $DIR/invalid-delimeter-ice-146808.rs:1:4
+   |
+LL | #![core::contracts::requires]
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #128044 <https://github.com/rust-lang/rust/issues/128044> for more information
+   = help: add `#![feature(contracts)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: inner macro attributes are unstable
+  --> $DIR/invalid-delimeter-ice-146808.rs:1:4
+   |
+LL | #![core::contracts::requires]
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #54726 <https://github.com/rust-lang/rust/issues/54726> for more information
+   = help: add `#![feature(custom_inner_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: wrong meta list delimiters
+  --> $DIR/invalid-delimeter-ice-146808.rs:1:1
+   |
+LL | / #![core::contracts::requires]
+...  |
+LL | | #[allow{}]
+LL | | fn main() {}
+   | |____________^ help: the delimiters should be `(` and `)`: `(...)`
+
+error[E0658]: `#[prelude_import]` is for use by rustc only
+  --> $DIR/invalid-delimeter-ice-146808.rs:1:1
+   |
+LL | / #![core::contracts::requires]
+...  |
+LL | | #[allow{}]
+LL | | fn main() {}
+   | |____________^
+   |
+   = help: add `#![feature(prelude_import)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0308]: mismatched types
+  --> $DIR/invalid-delimeter-ice-146808.rs:1:1
+   |
+LL | #![core::contracts::requires]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `bool`, found `()`
+
+error: aborting due to 5 previous errors
+
+Some errors have detailed explanations: E0308, E0658.
+For more information about an error, try `rustc --explain E0308`.


### PR DESCRIPTION
Fixes rust-lang/rust#146808

I tried hard to get the correct span, but didn't come out with a great result. I think maybe it's better to report an error when expand macro failing for contract:

https://github.com/rust-lang/rust/blob/f5242367f4acf0130c9b68e6956531b2cb73bd38/compiler/rustc_builtin_macros/src/contracts.rs#L50
