### PR TITLE
fix incorrect line number when building trimmed multi-line suggestions

### DIFF
--- a/compiler/rustc_errors/src/emitter.rs
+++ b/compiler/rustc_errors/src/emitter.rs
@@ -2154,11 +2154,11 @@ impl HumanEmitter {
 
             assert!(!file_lines.lines.is_empty() || parts[0].span.is_dummy());
 
-            let line_start = sm.lookup_char_pos(parts[0].span.lo()).line;
+            let line_start = sm.lookup_char_pos(parts[0].original_span.lo()).line;
             let mut lines = complete.lines();
             if lines.clone().next().is_none() {
                 // Account for a suggestion to completely remove a line(s) with whitespace (#94192).
-                let line_end = sm.lookup_char_pos(parts[0].span.hi()).line;
+                let line_end = sm.lookup_char_pos(parts[0].original_span.hi()).line;
                 for line in line_start..=line_end {
                     self.draw_line_num(
                         &mut buffer,

--- a/tests/ui/error-emitter/trimmed_multiline_suggestion.rs
+++ b/tests/ui/error-emitter/trimmed_multiline_suggestion.rs
@@ -1,0 +1,14 @@
+//@ compile-flags: -Z ui-testing=no
+fn function_with_lots_of_arguments(a: i32, b: char, c: i32, d: i32, e: i32, f: i32) {}
+
+fn main() {
+    let variable_name = 42;
+    function_with_lots_of_arguments(
+        variable_name,
+        variable_name,
+        variable_name,
+        variable_name,
+        variable_name,
+    );
+    //~^^^^^^^ ERROR this function takes 6 arguments but 5 arguments were supplied [E0061]
+}

--- a/tests/ui/error-emitter/trimmed_multiline_suggestion.stderr
+++ b/tests/ui/error-emitter/trimmed_multiline_suggestion.stderr
@@ -1,0 +1,25 @@
+error[E0061]: this function takes 6 arguments but 5 arguments were supplied
+ --> $DIR/trimmed_multiline_suggestion.rs:6:5
+  |
+6 |     function_with_lots_of_arguments(
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+7 |         variable_name,
+8 |         variable_name,
+  |         ------------- argument #2 of type `char` is missing
+  |
+note: function defined here
+ --> $DIR/trimmed_multiline_suggestion.rs:2:4
+  |
+2 | fn function_with_lots_of_arguments(a: i32, b: char, c: i32, d: i32, e: i32, f: i32) {}
+  |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^         -------
+help: provide the argument
+  |
+6 |     function_with_lots_of_arguments(
+7 |         variable_name,
+8 ~         /* char */,
+9 ~         variable_name,
+  |
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0061`.


### PR DESCRIPTION
While fixing the issue https://github.com/rust-lang/rust-clippy/issues/15883 from `rust-clippy`, I tracked it down to a problem in `rustc` where line numbers were incorrect when building trimmed multi-line suggestions.