### PR TITLE
Fix autodiff incorrectly applying fat-lto to proc-macro crates 

### DIFF
--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -603,7 +603,8 @@ impl Session {
         // Autodiff currently requires fat-lto to have access to the llvm-ir of all (indirectly) used functions and types.
         // fat-lto is the easiest solution to this requirement, but quite expensive.
         // FIXME(autodiff): Make autodiff also work with embed-bc instead of fat-lto.
-        if self.opts.autodiff_enabled() {
+        // Don't apply fat-lto to proc-macro crates as they cannot use fat-lto without -Zdylib-lto
+        if self.opts.autodiff_enabled() && !self.opts.crate_types.contains(&CrateType::ProcMacro) {
             return config::Lto::Fat;
         }
 


### PR DESCRIPTION
Fixes rust-lang/rust#147487

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
