### PR TITLE
motor: Use UTF-8 guarantee for OS strings

### DIFF
--- a/library/std/src/os/motor/ffi.rs
+++ b/library/std/src/os/motor/ffi.rs
@@ -9,14 +9,18 @@ use crate::sealed::Sealed;
 /// This trait is sealed: it cannot be implemented outside the standard library.
 /// This is so that future additional methods are not breaking changes.
 pub trait OsStringExt: Sealed {
-    /// Motor OS strings are utf-8, and thus just strings.
-    fn as_str(&self) -> &str;
+    /// Yields the underlying UTF-8 string of this [`OsString`].
+    fn into_string(self) -> String;
 }
 
 impl OsStringExt for OsString {
     #[inline]
-    fn as_str(&self) -> &str {
-        self.to_str().unwrap()
+    fn into_string(self) -> String {
+        // SAFETY: The platform encoding of Motor OS is UTF-8. As
+        // from_encoded_bytes_unchecked requires that the input bytes originate
+        // from OsStr::as_encoded_bytes and/or valid UTF-8, no OsString can
+        // contain invalid UTF-8.
+        unsafe { String::from_utf8_unchecked(self.into_encoded_bytes()) }
     }
 }
 
@@ -25,13 +29,14 @@ impl OsStringExt for OsString {
 /// This trait is sealed: it cannot be implemented outside the standard library.
 /// This is so that future additional methods are not breaking changes.
 pub trait OsStrExt: Sealed {
-    /// Motor OS strings are utf-8, and thus just strings.
+    /// Gets the underlying UTF-8 string view of the [`OsStr`] slice.
     fn as_str(&self) -> &str;
 }
 
 impl OsStrExt for OsStr {
     #[inline]
     fn as_str(&self) -> &str {
-        self.to_str().unwrap()
+        // SAFETY: As above.
+        unsafe { str::from_utf8_unchecked(self.as_encoded_bytes()) }
     }
 }


### PR DESCRIPTION
Motor OS (a new target added in https://github.com/rust-lang/rust/pull/147000) guarantees that strings from the OS are valid UTF-8, yet the `OsStrExt`/`OsStringExt` traits, which aim to expose the inner UTF-8 representations, use checked UTF-8 conversions.

The only way for a user to construct an `OsStr`/`OsString` from arbitrary bytes is via `from_encoded_bytes_unchecked`, which requires:

> As the encoding is unspecified, callers must pass in bytes that originated as a mixture of validated UTF-8 and bytes from `OsStr::as_encoded_bytes` from within the same Rust version built for the same target platform.

Thus, callers are required to supply bytes which originated from `OsStr::as_encoded_bytes` (i.e., guaranteed to be UTF-8) and/or are valid UTF-8, so it is library UB for an `OsStr`/`OsString` to contain invalid UTF-8 on Motor OS.

Since the standard library can make these guarantees, I think it is appropriate for these extension traits to perform unchecked conversions. As they stand, they offer no benefit over existing methods.

Also: Replace `OsStringExt::as_str` with `OsStringExt::into_string` (just use `OsStr::as_str` for the other) and mirror the Unix comments for these functions.

cc @lasiotus