### PR TITLE
ci: Switch back to default coreutils (uutils) after libffi-sys bump

### DIFF
--- a/src/ci/docker/host-aarch64/aarch64-gnu-debug/Dockerfile
+++ b/src/ci/docker/host-aarch64/aarch64-gnu-debug/Dockerfile
@@ -2,8 +2,6 @@ FROM ubuntu:25.10
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
-  # FIXME(#147556): Use GNU coreutils to work around a libffi-sys build failure.
-  coreutils-from-gnu coreutils-from-uutils- --allow-remove-essential \
   g++ \
   make \
   ninja-build \

--- a/src/ci/docker/host-aarch64/aarch64-gnu-llvm-20/Dockerfile
+++ b/src/ci/docker/host-aarch64/aarch64-gnu-llvm-20/Dockerfile
@@ -3,8 +3,6 @@ FROM ubuntu:25.10
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-  # FIXME(#147556): Use GNU coreutils to work around a libffi-sys build failure.
-  coreutils-from-gnu coreutils-from-uutils- --allow-remove-essential \
   bzip2 \
   g++ \
   make \

--- a/src/ci/docker/host-aarch64/aarch64-gnu/Dockerfile
+++ b/src/ci/docker/host-aarch64/aarch64-gnu/Dockerfile
@@ -2,8 +2,6 @@ FROM ubuntu:25.10
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
-  # FIXME(#147556): Use GNU coreutils to work around a libffi-sys build failure.
-  coreutils-from-gnu coreutils-from-uutils- --allow-remove-essential \
   g++ \
   make \
   ninja-build \


### PR DESCRIPTION
Now that Miri has updated to the latest `libffi-sys`, we should be able to remove the GNU coreutils workaround, and switch back to the default coreutils (uutils) in the runners using Ubuntu 25.10 images.

If we encounter any other uutils compatibility problems in the future, they should hopefully be easier to trace back to specific changes.

- https://github.com/rust-lang/rust/pull/147581
- https://github.com/rust-lang/miri/pull/4634
- https://github.com/rust-lang/rust/pull/147744

Closes rust-lang/rust#147556.