### PR TITLE
Ignore test-dashboard related files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,10 @@ node_modules
 ## Rustdoc GUI tests
 tests/rustdoc-gui/src/**.lock
 
+## Test dashboard
+.citool-cache/
+test-dashboard/
+
 ## direnv
 /.envrc
 /.direnv/


### PR DESCRIPTION
After bors merge a PR, a message may be posted from the CI onto the PR comment thread directing the user to use the following commands to look at the test differences:

```
cargo run --manifest-path src/ci/citool/Cargo.toml -- \
    test-dashboard [SOMEID] --output-dir test-dashboard
open test-dashboard/index.html
```

This command creates the `.citool-cache` and `test-dashboard` directories, whose contents should not enter the repository and can be ignored by `git`.

