### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5261,9 +5261,9 @@ dependencies = [
 
 [[package]]
 name = "stringdex"
-version = "0.0.1-alpha10"
+version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa846a7d509d1828a4f90962dc09810e161abcada7fc6a921e92c168d0811d7"
+checksum = "18b3bd4f10d15ef859c40291769f0d85209de6b0f1c30713ff9cdf45ac43ea36"
 dependencies = [
  "stacker",
 ]

--- a/compiler/rustc_codegen_ssa/src/mir/locals.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/locals.rs
@@ -40,12 +40,12 @@ impl<'tcx, V> Locals<'tcx, V> {
 impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
     pub(super) fn initialize_locals(&mut self, values: Vec<LocalRef<'tcx, Bx::Value>>) {
         assert!(self.locals.values.is_empty());
+        self.locals.values = IndexVec::from_raw(values);
         // FIXME(#115215): After #115025 get's merged this might not be necessary
-        for (local, value) in values.into_iter().enumerate() {
+        for (local, value) in self.locals.values.iter_enumerated() {
             match value {
                 LocalRef::Place(_) | LocalRef::UnsizedPlace(_) | LocalRef::PendingOperand => (),
                 LocalRef::Operand(op) => {
-                    let local = mir::Local::from_usize(local);
                     let expected_ty = self.monomorphize(self.mir.local_decls[local].ty);
                     if expected_ty != op.layout.ty {
                         warn!(
@@ -56,7 +56,6 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                     }
                 }
             }
-            self.locals.values.push(value);
         }
     }
 

--- a/compiler/rustc_const_eval/src/check_consts/qualifs.rs
+++ b/compiler/rustc_const_eval/src/check_consts/qualifs.rs
@@ -234,7 +234,7 @@ where
 
         Rvalue::Discriminant(place) => in_place::<Q, _>(cx, in_local, place.as_ref()),
 
-        Rvalue::CopyForDeref(_) => bug!("`CopyForDeref` in runtime MIR"),
+        Rvalue::CopyForDeref(place) => in_place::<Q, _>(cx, in_local, place.as_ref()),
 
         Rvalue::Use(operand)
         | Rvalue::Repeat(operand, _)

--- a/compiler/rustc_sanitizers/src/cfi/typeid/itanium_cxx_abi/transform.rs
+++ b/compiler/rustc_sanitizers/src/cfi/typeid/itanium_cxx_abi/transform.rs
@@ -10,8 +10,8 @@ use rustc_hir as hir;
 use rustc_hir::LangItem;
 use rustc_middle::bug;
 use rustc_middle::ty::{
-    self, ExistentialPredicateStableCmpExt as _, Instance, InstanceKind, IntTy, List, TraitRef, Ty,
-    TyCtxt, TypeFoldable, TypeFolder, TypeSuperFoldable, TypeVisitableExt, UintTy,
+    self, ExistentialPredicateStableCmpExt as _, Instance, IntTy, List, TraitRef, Ty, TyCtxt,
+    TypeFoldable, TypeFolder, TypeSuperFoldable, TypeVisitableExt, UintTy,
 };
 use rustc_span::def_id::DefId;
 use rustc_span::{DUMMY_SP, sym};
@@ -458,6 +458,30 @@ pub(crate) fn transform_instance<'tcx>(
     instance
 }
 
+fn default_or_shim<'tcx>(tcx: TyCtxt<'tcx>, instance: Instance<'tcx>) -> Option<DefId> {
+    match instance.def {
+        ty::InstanceKind::Item(def_id) | ty::InstanceKind::FnPtrShim(def_id, _) => {
+            tcx.opt_associated_item(def_id).map(|item| item.def_id)
+        }
+        _ => None,
+    }
+}
+
+/// Determines if an instance represents a trait method implementation and returns the necessary
+/// information for type erasure.
+///
+/// This function handles two main cases:
+///
+/// * **Implementation in an `impl` block**: When the instance represents a concrete implementation
+///   of a trait method in an `impl` block, it extracts the trait reference, method ID, and trait
+///   ID from the implementation. The method ID is obtained from the `trait_item_def_id` field of
+///   the associated item, which points to the original trait method definition.
+///
+/// * **Provided method in a `trait` block or synthetic `shim`**: When the instance represents a
+///   default implementation provided in the trait definition itself or a synthetic shim, it uses
+///   the instance's own `def_id` as the method ID and determines the trait ID from the associated
+///   item.
+///
 fn implemented_method<'tcx>(
     tcx: TyCtxt<'tcx>,
     instance: Instance<'tcx>,
@@ -474,11 +498,9 @@ fn implemented_method<'tcx>(
         trait_method = tcx.associated_item(method_id);
         trait_id = trait_ref.skip_binder().def_id;
         impl_id
-    } else if let InstanceKind::Item(def_id) = instance.def
-        && let Some(trait_method_bound) = tcx.opt_associated_item(def_id)
-    {
-        // Provided method in a `trait` block
-        trait_method = trait_method_bound;
+    } else if let Some(trait_method_def_id) = default_or_shim(tcx, instance) {
+        // Provided method in a `trait` block or a synthetic `shim`
+        trait_method = tcx.associated_item(trait_method_def_id);
         method_id = instance.def_id();
         trait_id = tcx.trait_of_assoc(method_id)?;
         trait_ref = ty::EarlyBinder::bind(TraitRef::from_method(tcx, trait_id, instance.args));

--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -420,6 +420,9 @@ pub fn write<P: AsRef<Path>, C: AsRef<[u8]>>(path: P, contents: C) -> io::Result
 /// }
 /// ```
 #[unstable(feature = "fs_set_times", issue = "147455")]
+#[doc(alias = "utimens")]
+#[doc(alias = "utimes")]
+#[doc(alias = "utime")]
 pub fn set_times<P: AsRef<Path>>(path: P, times: FileTimes) -> io::Result<()> {
     fs_imp::set_times(path.as_ref(), times.0)
 }

--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -395,8 +395,8 @@ pub fn write<P: AsRef<Path>, C: AsRef<[u8]>>(path: P, contents: C) -> io::Result
 ///
 /// # Platform-specific behavior
 ///
-/// This function currently corresponds to the `utimensat` function on Unix platforms
-/// and the `SetFileTime` function on Windows.
+/// This function currently corresponds to the `utimensat` function on Unix platforms, the
+/// `setattrlist` function on Apple platforms, and the `SetFileTime` function on Windows.
 ///
 /// # Errors
 ///

--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -387,6 +387,80 @@ pub fn write<P: AsRef<Path>, C: AsRef<[u8]>>(path: P, contents: C) -> io::Result
     inner(path.as_ref(), contents.as_ref())
 }
 
+/// Changes the timestamps of the file or directory at the specified path.
+///
+/// This function will attempt to set the access and modification times
+/// to the times specified. If the path refers to a symbolic link, this function
+/// will follow the link and change the timestamps of the target file.
+///
+/// # Platform-specific behavior
+///
+/// This function currently corresponds to the `utimensat` function on Unix platforms
+/// and the `SetFileTime` function on Windows.
+///
+/// # Errors
+///
+/// This function will return an error if the user lacks permission to change timestamps on the
+/// target file or symlink. It may also return an error if the OS does not support it.
+///
+/// # Examples
+///
+/// ```no_run
+/// #![feature(fs_set_times)]
+/// use std::fs::{self, FileTimes};
+/// use std::time::SystemTime;
+///
+/// fn main() -> std::io::Result<()> {
+///     let now = SystemTime::now();
+///     let times = FileTimes::new()
+///         .set_accessed(now)
+///         .set_modified(now);
+///     fs::set_times("foo.txt", times)?;
+///     Ok(())
+/// }
+/// ```
+#[unstable(feature = "fs_set_times", issue = "147455")]
+pub fn set_times<P: AsRef<Path>>(path: P, times: FileTimes) -> io::Result<()> {
+    fs_imp::set_times(path.as_ref(), times.0)
+}
+
+/// Changes the timestamps of the file or symlink at the specified path.
+///
+/// This function will attempt to set the access and modification times
+/// to the times specified. Differ from `set_times`, if the path refers to a symbolic link,
+/// this function will change the timestamps of the symlink itself, not the target file.
+///
+/// # Platform-specific behavior
+///
+/// This function currently corresponds to the `utimensat` function with `AT_SYMLINK_NOFOLLOW`
+/// on Unix platforms and the `SetFileTime` function on Windows after opening the symlink.
+///
+/// # Errors
+///
+/// This function will return an error if the user lacks permission to change timestamps on the
+/// target file or symlink. It may also return an error if the OS does not support it.
+///
+/// # Examples
+///
+/// ```no_run
+/// #![feature(fs_set_times)]
+/// use std::fs::{self, FileTimes};
+/// use std::time::SystemTime;
+///
+/// fn main() -> std::io::Result<()> {
+///     let now = SystemTime::now();
+///     let times = FileTimes::new()
+///         .set_accessed(now)
+///         .set_modified(now);
+///     fs::set_times_nofollow("symlink.txt", times)?;
+///     Ok(())
+/// }
+/// ```
+#[unstable(feature = "fs_set_times", issue = "147455")]
+pub fn set_times_nofollow<P: AsRef<Path>>(path: P, times: FileTimes) -> io::Result<()> {
+    fs_imp::set_times_nofollow(path.as_ref(), times.0)
+}
+
 #[stable(feature = "file_lock", since = "1.89.0")]
 impl error::Error for TryLockError {}
 

--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -432,8 +432,9 @@ pub fn set_times<P: AsRef<Path>>(path: P, times: FileTimes) -> io::Result<()> {
 ///
 /// # Platform-specific behavior
 ///
-/// This function currently corresponds to the `utimensat` function with `AT_SYMLINK_NOFOLLOW`
-/// on Unix platforms and the `SetFileTime` function on Windows after opening the symlink.
+/// This function currently corresponds to the `utimensat` function with `AT_SYMLINK_NOFOLLOW` on
+/// Unix platforms, the `setattrlist` function with `FSOPT_NOFOLLOW` on Apple platforms, and the
+/// `SetFileTime` function on Windows.
 ///
 /// # Errors
 ///

--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -458,6 +458,9 @@ pub fn set_times<P: AsRef<Path>>(path: P, times: FileTimes) -> io::Result<()> {
 /// }
 /// ```
 #[unstable(feature = "fs_set_times", issue = "147455")]
+#[doc(alias = "utimensat")]
+#[doc(alias = "lutimens")]
+#[doc(alias = "lutimes")]
 pub fn set_times_nofollow<P: AsRef<Path>>(path: P, times: FileTimes) -> io::Result<()> {
     fs_imp::set_times_nofollow(path.as_ref(), times.0)
 }

--- a/library/std/src/fs/tests.rs
+++ b/library/std/src/fs/tests.rs
@@ -2226,3 +2226,222 @@ fn test_open_options_invalid_combinations() {
     assert_eq!(err.kind(), ErrorKind::InvalidInput);
     assert_eq!(err.to_string(), "must specify at least one of read, write, or append access");
 }
+
+#[test]
+fn test_fs_set_times() {
+    #[cfg(target_vendor = "apple")]
+    use crate::os::darwin::fs::FileTimesExt;
+    #[cfg(windows)]
+    use crate::os::windows::fs::FileTimesExt;
+
+    let tmp = tmpdir();
+    let path = tmp.join("foo");
+    File::create(&path).unwrap();
+
+    let mut times = FileTimes::new();
+    let accessed = SystemTime::UNIX_EPOCH + Duration::from_secs(12345);
+    let modified = SystemTime::UNIX_EPOCH + Duration::from_secs(54321);
+    times = times.set_accessed(accessed).set_modified(modified);
+
+    #[cfg(any(windows, target_vendor = "apple"))]
+    let created = SystemTime::UNIX_EPOCH + Duration::from_secs(32123);
+    #[cfg(any(windows, target_vendor = "apple"))]
+    {
+        times = times.set_created(created);
+    }
+
+    match fs::set_times(&path, times) {
+        // Allow unsupported errors on platforms which don't support setting times.
+        #[cfg(not(any(
+            windows,
+            all(
+                unix,
+                not(any(
+                    target_os = "android",
+                    target_os = "redox",
+                    target_os = "espidf",
+                    target_os = "horizon"
+                ))
+            )
+        )))]
+        Err(e) if e.kind() == ErrorKind::Unsupported => return,
+        Err(e) => panic!("error setting file times: {e:?}"),
+        Ok(_) => {}
+    }
+
+    let metadata = fs::metadata(&path).unwrap();
+    assert_eq!(metadata.accessed().unwrap(), accessed);
+    assert_eq!(metadata.modified().unwrap(), modified);
+    #[cfg(any(windows, target_vendor = "apple"))]
+    {
+        assert_eq!(metadata.created().unwrap(), created);
+    }
+}
+
+#[test]
+fn test_fs_set_times_follows_symlink() {
+    #[cfg(target_vendor = "apple")]
+    use crate::os::darwin::fs::FileTimesExt;
+    #[cfg(windows)]
+    use crate::os::windows::fs::FileTimesExt;
+
+    let tmp = tmpdir();
+
+    // Create a target file
+    let target = tmp.join("target");
+    File::create(&target).unwrap();
+
+    // Create a symlink to the target
+    #[cfg(unix)]
+    let link = tmp.join("link");
+    #[cfg(unix)]
+    crate::os::unix::fs::symlink(&target, &link).unwrap();
+
+    #[cfg(windows)]
+    let link = tmp.join("link.txt");
+    #[cfg(windows)]
+    crate::os::windows::fs::symlink_file(&target, &link).unwrap();
+
+    // Get the symlink's own modified time BEFORE calling set_times (to compare later)
+    // We don't check accessed time because reading metadata may update atime on some platforms.
+    let link_metadata_before = fs::symlink_metadata(&link).unwrap();
+    let link_modified_before = link_metadata_before.modified().unwrap();
+
+    let mut times = FileTimes::new();
+    let accessed = SystemTime::UNIX_EPOCH + Duration::from_secs(12345);
+    let modified = SystemTime::UNIX_EPOCH + Duration::from_secs(54321);
+    times = times.set_accessed(accessed).set_modified(modified);
+
+    #[cfg(any(windows, target_vendor = "apple"))]
+    let created = SystemTime::UNIX_EPOCH + Duration::from_secs(32123);
+    #[cfg(any(windows, target_vendor = "apple"))]
+    {
+        times = times.set_created(created);
+    }
+
+    // Call fs::set_times on the symlink - it should follow the link and modify the target
+    match fs::set_times(&link, times) {
+        // Allow unsupported errors on platforms which don't support setting times.
+        #[cfg(not(any(
+            windows,
+            all(
+                unix,
+                not(any(
+                    target_os = "android",
+                    target_os = "redox",
+                    target_os = "espidf",
+                    target_os = "horizon"
+                ))
+            )
+        )))]
+        Err(e) if e.kind() == ErrorKind::Unsupported => return,
+        Err(e) => panic!("error setting file times through symlink: {e:?}"),
+        Ok(_) => {}
+    }
+
+    // Verify that the TARGET file's times were changed (following the symlink)
+    let target_metadata = fs::metadata(&target).unwrap();
+    assert_eq!(
+        target_metadata.accessed().unwrap(),
+        accessed,
+        "target file accessed time should match"
+    );
+    assert_eq!(
+        target_metadata.modified().unwrap(),
+        modified,
+        "target file modified time should match"
+    );
+    #[cfg(any(windows, target_vendor = "apple"))]
+    {
+        assert_eq!(
+            target_metadata.created().unwrap(),
+            created,
+            "target file created time should match"
+        );
+    }
+
+    // Also verify through the symlink (fs::metadata follows symlinks)
+    let link_followed_metadata = fs::metadata(&link).unwrap();
+    assert_eq!(link_followed_metadata.accessed().unwrap(), accessed);
+    assert_eq!(link_followed_metadata.modified().unwrap(), modified);
+
+    // Verify that the SYMLINK ITSELF was NOT modified
+    // Note: We only check modified time, not accessed time, because reading the symlink
+    // metadata may update its atime on some platforms (e.g., Linux).
+    let link_metadata_after = fs::symlink_metadata(&link).unwrap();
+    assert_eq!(
+        link_metadata_after.modified().unwrap(),
+        link_modified_before,
+        "symlink's own modified time should not change"
+    );
+}
+
+#[test]
+fn test_fs_set_times_nofollow() {
+    #[cfg(target_vendor = "apple")]
+    use crate::os::darwin::fs::FileTimesExt;
+    #[cfg(windows)]
+    use crate::os::windows::fs::FileTimesExt;
+
+    let tmp = tmpdir();
+
+    // Create a target file and a symlink to it
+    let target = tmp.join("target");
+    File::create(&target).unwrap();
+
+    #[cfg(unix)]
+    let link = tmp.join("link");
+    #[cfg(unix)]
+    crate::os::unix::fs::symlink(&target, &link).unwrap();
+
+    #[cfg(windows)]
+    let link = tmp.join("link.txt");
+    #[cfg(windows)]
+    crate::os::windows::fs::symlink_file(&target, &link).unwrap();
+
+    let mut times = FileTimes::new();
+    let accessed = SystemTime::UNIX_EPOCH + Duration::from_secs(11111);
+    let modified = SystemTime::UNIX_EPOCH + Duration::from_secs(22222);
+    times = times.set_accessed(accessed).set_modified(modified);
+
+    #[cfg(any(windows, target_vendor = "apple"))]
+    let created = SystemTime::UNIX_EPOCH + Duration::from_secs(33333);
+    #[cfg(any(windows, target_vendor = "apple"))]
+    {
+        times = times.set_created(created);
+    }
+
+    // Set times on the symlink itself (not following it)
+    match fs::set_times_nofollow(&link, times) {
+        // Allow unsupported errors on platforms which don't support setting times.
+        #[cfg(not(any(
+            windows,
+            all(
+                unix,
+                not(any(
+                    target_os = "android",
+                    target_os = "redox",
+                    target_os = "espidf",
+                    target_os = "horizon"
+                ))
+            )
+        )))]
+        Err(e) if e.kind() == ErrorKind::Unsupported => return,
+        Err(e) => panic!("error setting symlink times: {e:?}"),
+        Ok(_) => {}
+    }
+
+    // Read symlink metadata (without following)
+    let metadata = fs::symlink_metadata(&link).unwrap();
+    assert_eq!(metadata.accessed().unwrap(), accessed);
+    assert_eq!(metadata.modified().unwrap(), modified);
+    #[cfg(any(windows, target_vendor = "apple"))]
+    {
+        assert_eq!(metadata.created().unwrap(), created);
+    }
+
+    // Verify that the target file's times were NOT changed
+    let target_metadata = fs::metadata(&target).unwrap();
+    assert_ne!(target_metadata.accessed().unwrap(), accessed);
+    assert_ne!(target_metadata.modified().unwrap(), modified);
+}

--- a/library/std/src/sys/fs/hermit.rs
+++ b/library/std/src/sys/fs/hermit.rs
@@ -566,6 +566,14 @@ pub fn set_perm(_p: &Path, _perm: FilePermissions) -> io::Result<()> {
     Err(Error::from_raw_os_error(22))
 }
 
+pub fn set_times(_p: &Path, _times: FileTimes) -> io::Result<()> {
+    Err(Error::from_raw_os_error(22))
+}
+
+pub fn set_times_nofollow(_p: &Path, _times: FileTimes) -> io::Result<()> {
+    Err(Error::from_raw_os_error(22))
+}
+
 pub fn rmdir(path: &Path) -> io::Result<()> {
     run_path_with_cstr(path, &|path| cvt(unsafe { hermit_abi::rmdir(path.as_ptr()) }).map(|_| ()))
 }

--- a/library/std/src/sys/fs/mod.rs
+++ b/library/std/src/sys/fs/mod.rs
@@ -161,3 +161,11 @@ pub fn exists(path: &Path) -> io::Result<bool> {
     #[cfg(windows)]
     with_native_path(path, &imp::exists)
 }
+
+pub fn set_times(path: &Path, times: FileTimes) -> io::Result<()> {
+    with_native_path(path, &|path| imp::set_times(path, times.clone()))
+}
+
+pub fn set_times_nofollow(path: &Path, times: FileTimes) -> io::Result<()> {
+    with_native_path(path, &|path| imp::set_times_nofollow(path, times.clone()))
+}

--- a/library/std/src/sys/fs/solid.rs
+++ b/library/std/src/sys/fs/solid.rs
@@ -538,6 +538,17 @@ pub fn set_perm(p: &Path, perm: FilePermissions) -> io::Result<()> {
     Ok(())
 }
 
+pub fn set_times(_p: &Path, _times: FileTimes) -> io::Result<()> {
+    Err(io::const_error!(io::ErrorKind::Unsupported, "setting file times not supported",))
+}
+
+pub fn set_times_nofollow(_p: &Path, _times: FileTimes) -> io::Result<()> {
+    Err(io::const_error!(
+        io::ErrorKind::Unsupported,
+        "setting file times on symlinks not supported",
+    ))
+}
+
 pub fn rmdir(p: &Path) -> io::Result<()> {
     if stat(p)?.file_type().is_dir() {
         error::SolidError::err_if_negative(unsafe { abi::SOLID_FS_Unlink(cstr(p)?.as_ptr()) })

--- a/library/std/src/sys/fs/solid.rs
+++ b/library/std/src/sys/fs/solid.rs
@@ -539,14 +539,11 @@ pub fn set_perm(p: &Path, perm: FilePermissions) -> io::Result<()> {
 }
 
 pub fn set_times(_p: &Path, _times: FileTimes) -> io::Result<()> {
-    Err(io::const_error!(io::ErrorKind::Unsupported, "setting file times not supported",))
+    unsupported()
 }
 
 pub fn set_times_nofollow(_p: &Path, _times: FileTimes) -> io::Result<()> {
-    Err(io::const_error!(
-        io::ErrorKind::Unsupported,
-        "setting file times on symlinks not supported",
-    ))
+    unsupported()
 }
 
 pub fn rmdir(p: &Path) -> io::Result<()> {

--- a/library/std/src/sys/fs/uefi.rs
+++ b/library/std/src/sys/fs/uefi.rs
@@ -333,6 +333,14 @@ pub fn set_perm(_p: &Path, _perm: FilePermissions) -> io::Result<()> {
     unsupported()
 }
 
+pub fn set_times(_p: &Path, _times: FileTimes) -> io::Result<()> {
+    unsupported()
+}
+
+pub fn set_times_nofollow(_p: &Path, _times: FileTimes) -> io::Result<()> {
+    unsupported()
+}
+
 pub fn rmdir(_p: &Path) -> io::Result<()> {
     unsupported()
 }

--- a/library/std/src/sys/fs/unix.rs
+++ b/library/std/src/sys/fs/unix.rs
@@ -2146,7 +2146,7 @@ fn set_times_impl(p: &CStr, times: FileTimes, flags: c_int) -> io::Result<()> {
             // utimensat requires Android API level 19
             cvt(unsafe {
                 weak!(
-                    fn utimensat(dirfd: c_int, path: *const c_char, times: *const libc::timespec, flags: c_int) -> c_int;
+                    fn utimensat(dirfd: c_int, path: *const libc::c_char, times: *const libc::timespec, flags: c_int) -> c_int;
                 );
                 match utimensat.get() {
                     Some(utimensat) => utimensat(libc::AT_FDCWD, p.as_ptr(), times.as_ptr(), flags),

--- a/library/std/src/sys/fs/unix.rs
+++ b/library/std/src/sys/fs/unix.rs
@@ -1201,6 +1201,7 @@ impl fmt::Debug for OpenOptions {
     target_os = "horizon",
     target_os = "nuttx",
 )))]
+#[inline(always)]
 fn to_timespec(time: Option<SystemTime>) -> io::Result<libc::timespec> {
     match time {
         Some(time) if let Some(ts) = time.t.to_timespec() => Ok(ts),
@@ -1217,6 +1218,7 @@ fn to_timespec(time: Option<SystemTime>) -> io::Result<libc::timespec> {
 }
 
 #[cfg(target_vendor = "apple")]
+#[inline(always)]
 fn set_attrlist_with_times(
     times: &FileTimes,
 ) -> io::Result<(libc::attrlist, [mem::MaybeUninit<libc::timespec>; 3], usize)> {

--- a/library/std/src/sys/fs/unsupported.rs
+++ b/library/std/src/sys/fs/unsupported.rs
@@ -316,8 +316,8 @@ pub fn set_times(_p: &Path, _times: FileTimes) -> io::Result<()> {
     unsupported()
 }
 
-pub fn set_times_nofollow(_p: &Path, times: FileTimes) -> io::Result<()> {
-    match times {}
+pub fn set_times_nofollow(_p: &Path, _times: FileTimes) -> io::Result<()> {
+    unsupported()
 }
 
 pub fn rmdir(_p: &Path) -> io::Result<()> {

--- a/library/std/src/sys/fs/unsupported.rs
+++ b/library/std/src/sys/fs/unsupported.rs
@@ -312,6 +312,14 @@ pub fn set_perm(_p: &Path, perm: FilePermissions) -> io::Result<()> {
     match perm.0 {}
 }
 
+pub fn set_times(_p: &Path, times: FileTimes) -> io::Result<()> {
+    match times {}
+}
+
+pub fn set_times_nofollow(_p: &Path, times: FileTimes) -> io::Result<()> {
+    match times {}
+}
+
 pub fn rmdir(_p: &Path) -> io::Result<()> {
     unsupported()
 }

--- a/library/std/src/sys/fs/unsupported.rs
+++ b/library/std/src/sys/fs/unsupported.rs
@@ -312,8 +312,8 @@ pub fn set_perm(_p: &Path, perm: FilePermissions) -> io::Result<()> {
     match perm.0 {}
 }
 
-pub fn set_times(_p: &Path, times: FileTimes) -> io::Result<()> {
-    match times {}
+pub fn set_times(_p: &Path, _times: FileTimes) -> io::Result<()> {
+    unsupported()
 }
 
 pub fn set_times_nofollow(_p: &Path, times: FileTimes) -> io::Result<()> {

--- a/library/std/src/sys/fs/vexos.rs
+++ b/library/std/src/sys/fs/vexos.rs
@@ -492,6 +492,14 @@ pub fn set_perm(_p: &Path, _perm: FilePermissions) -> io::Result<()> {
     unsupported()
 }
 
+pub fn set_times(_p: &Path, _times: FileTimes) -> io::Result<()> {
+    unsupported()
+}
+
+pub fn set_times_nofollow(_p: &Path, _times: FileTimes) -> io::Result<()> {
+    unsupported()
+}
+
 pub fn exists(path: &Path) -> io::Result<bool> {
     run_path_with_cstr(path, &|path| Ok(unsafe { vex_sdk::vexFileStatus(path.as_ptr()) } != 0))
 }

--- a/library/std/src/sys/fs/wasi.rs
+++ b/library/std/src/sys/fs/wasi.rs
@@ -643,6 +643,18 @@ pub fn set_perm(_p: &Path, _perm: FilePermissions) -> io::Result<()> {
     unsupported()
 }
 
+pub fn set_times(_p: &Path, _times: FileTimes) -> io::Result<()> {
+    // File times haven't been fully figured out in wasi yet, so this is
+    // likely temporary
+    unsupported()
+}
+
+pub fn set_times_nofollow(_p: &Path, _times: FileTimes) -> io::Result<()> {
+    // File times haven't been fully figured out in wasi yet, so this is
+    // likely temporary
+    unsupported()
+}
+
 pub fn rmdir(p: &Path) -> io::Result<()> {
     let (dir, file) = open_parent(p)?;
     dir.remove_directory(osstr2str(file.as_ref())?)

--- a/library/std/src/sys/fs/wasi.rs
+++ b/library/std/src/sys/fs/wasi.rs
@@ -536,17 +536,9 @@ impl File {
     }
 
     pub fn set_times(&self, times: FileTimes) -> io::Result<()> {
-        let to_timestamp = |time: Option<SystemTime>| match time {
-            Some(time) if let Some(ts) = time.to_wasi_timestamp() => Ok(ts),
-            Some(_) => Err(io::const_error!(
-                io::ErrorKind::InvalidInput,
-                "timestamp is too large to set as a file time",
-            )),
-            None => Ok(0),
-        };
         self.fd.filestat_set_times(
-            to_timestamp(times.accessed)?,
-            to_timestamp(times.modified)?,
+            to_wasi_timestamp_or_now(times.accessed)?,
+            to_wasi_timestamp_or_now(times.modified)?,
             times.accessed.map_or(0, |_| wasi::FSTFLAGS_ATIM)
                 | times.modified.map_or(0, |_| wasi::FSTFLAGS_MTIM),
         )
@@ -643,16 +635,43 @@ pub fn set_perm(_p: &Path, _perm: FilePermissions) -> io::Result<()> {
     unsupported()
 }
 
-pub fn set_times(_p: &Path, _times: FileTimes) -> io::Result<()> {
-    // File times haven't been fully figured out in wasi yet, so this is
-    // likely temporary
-    unsupported()
+#[inline(always)]
+pub fn set_times(p: &Path, times: FileTimes) -> io::Result<()> {
+    let (dir, file) = open_parent(p)?;
+    set_times_impl(&dir, &file, times, wasi::LOOKUPFLAGS_SYMLINK_FOLLOW)
 }
 
-pub fn set_times_nofollow(_p: &Path, _times: FileTimes) -> io::Result<()> {
-    // File times haven't been fully figured out in wasi yet, so this is
-    // likely temporary
-    unsupported()
+#[inline(always)]
+pub fn set_times_nofollow(p: &Path, times: FileTimes) -> io::Result<()> {
+    let (dir, file) = open_parent(p)?;
+    set_times_impl(&dir, &file, times, 0)
+}
+
+fn to_wasi_timestamp_or_now(time: Option<SystemTime>) -> io::Result<wasi::Timestamp> {
+    match time {
+        Some(time) if let Some(ts) = time.to_wasi_timestamp() => Ok(ts),
+        Some(_) => Err(io::const_error!(
+            io::ErrorKind::InvalidInput,
+            "timestamp is too large to set as a file time",
+        )),
+        None => Ok(0),
+    }
+}
+
+fn set_times_impl(
+    fd: &WasiFd,
+    path: &Path,
+    times: FileTimes,
+    flags: wasi::Lookupflags,
+) -> io::Result<()> {
+    fd.path_filestat_set_times(
+        flags,
+        osstr2str(path.as_ref())?,
+        to_wasi_timestamp_or_now(times.accessed)?,
+        to_wasi_timestamp_or_now(times.modified)?,
+        times.accessed.map_or(0, |_| wasi::FSTFLAGS_ATIM)
+            | times.modified.map_or(0, |_| wasi::FSTFLAGS_MTIM),
+    )
 }
 
 pub fn rmdir(p: &Path) -> io::Result<()> {

--- a/library/std/src/sys/fs/windows.rs
+++ b/library/std/src/sys/fs/windows.rs
@@ -1514,6 +1514,23 @@ pub fn set_perm(p: &WCStr, perm: FilePermissions) -> io::Result<()> {
     }
 }
 
+pub fn set_times(p: &WCStr, times: FileTimes) -> io::Result<()> {
+    let mut opts = OpenOptions::new();
+    opts.write(true);
+    opts.custom_flags(c::FILE_FLAG_BACKUP_SEMANTICS);
+    let file = File::open_native(p, &opts)?;
+    file.set_times(times)
+}
+
+pub fn set_times_nofollow(p: &WCStr, times: FileTimes) -> io::Result<()> {
+    let mut opts = OpenOptions::new();
+    opts.write(true);
+    // `FILE_FLAG_OPEN_REPARSE_POINT` for no_follow behavior
+    opts.custom_flags(c::FILE_FLAG_BACKUP_SEMANTICS | c::FILE_FLAG_OPEN_REPARSE_POINT);
+    let file = File::open_native(p, &opts)?;
+    file.set_times(times)
+}
+
 fn get_path(f: &File) -> io::Result<PathBuf> {
     fill_utf16_buf(
         |buf, sz| unsafe {

--- a/src/bootstrap/Cargo.lock
+++ b/src/bootstrap/Cargo.lock
@@ -491,9 +491,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.5"
+version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
  "memchr",
 ]

--- a/src/bootstrap/Cargo.toml
+++ b/src/bootstrap/Cargo.toml
@@ -41,7 +41,7 @@ clap_complete = "4.4"
 home = "0.5"
 ignore = "0.4"
 libc = "0.2"
-object = { version = "0.36.3", default-features = false, features = ["archive", "coff", "read_core", "std", "unaligned"] }
+object = { version = "0.37", default-features = false, features = ["archive", "coff", "read_core", "std", "unaligned"] }
 opener = "0.8"
 semver = "1.0"
 serde = "1.0"

--- a/src/librustdoc/Cargo.toml
+++ b/src/librustdoc/Cargo.toml
@@ -21,7 +21,7 @@ rustdoc-json-types = { path = "../rustdoc-json-types" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 smallvec = "1.8.1"
-stringdex = { version = "0.0.1-alpha10" }
+stringdex = "=0.0.2"
 tempfile = "3"
 threadpool = "1.8.1"
 tracing = "0.1"

--- a/tests/ui/consts/precise-drop-nested-deref-ice.rs
+++ b/tests/ui/consts/precise-drop-nested-deref-ice.rs
@@ -1,0 +1,15 @@
+//! Tests that multiple derefs in a projection does not cause an ICE
+//! when checking const precise drops.
+//!
+//! Regression test for <https://github.com/rust-lang/rust/issues/147733>
+
+#![feature(const_precise_live_drops)]
+struct Foo(u32);
+impl Foo {
+    const fn get(self: Box<&Self>, f: &u32) -> u32 {
+        //~^ ERROR destructor of `Box<&Foo>` cannot be evaluated at compile-time
+        self.0
+    }
+}
+
+fn main() {}

--- a/tests/ui/consts/precise-drop-nested-deref-ice.stderr
+++ b/tests/ui/consts/precise-drop-nested-deref-ice.stderr
@@ -1,0 +1,12 @@
+error[E0493]: destructor of `Box<&Foo>` cannot be evaluated at compile-time
+  --> $DIR/precise-drop-nested-deref-ice.rs:9:18
+   |
+LL |     const fn get(self: Box<&Self>, f: &u32) -> u32 {
+   |                  ^^^^ the destructor for this type cannot be evaluated in constant functions
+...
+LL |     }
+   |     - value is dropped here
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0493`.

--- a/tests/ui/sanitizer/cfi/fn-trait-objects.rs
+++ b/tests/ui/sanitizer/cfi/fn-trait-objects.rs
@@ -1,0 +1,32 @@
+// Verifies that types that implement the Fn, FnMut, or FnOnce traits can be
+// called through their trait methods.
+//
+//@ needs-sanitizer-cfi
+//@ only-linux
+//@ ignore-backends: gcc
+//@ compile-flags: -Ctarget-feature=-crt-static -Ccodegen-units=1 -Clto -Cprefer-dynamic=off -Copt-level=0 -Zsanitizer=cfi -Cunsafe-allow-abi-mismatch=sanitizer --test
+//@ run-pass
+
+#![feature(fn_traits)]
+#![feature(unboxed_closures)]
+
+fn foo(_a: u32) {}
+
+#[test]
+fn test_fn_trait() {
+    let f: Box<dyn Fn(u32)> = Box::new(foo);
+    Fn::call(&f, (0,));
+}
+
+#[test]
+fn test_fnmut_trait() {
+    let mut a = 0;
+    let mut f: Box<dyn FnMut(u32)> = Box::new(|x| a += x);
+    FnMut::call_mut(&mut f, (1,));
+}
+
+#[test]
+fn test_fnonce_trait() {
+    let f: Box<dyn FnOnce(u32)> = Box::new(foo);
+    FnOnce::call_once(f, (2,));
+}

--- a/tests/ui/sanitizer/kcfi/fn-trait-objects.rs
+++ b/tests/ui/sanitizer/kcfi/fn-trait-objects.rs
@@ -1,0 +1,32 @@
+// Verifies that types that implement the Fn, FnMut, or FnOnce traits can be
+// called through their trait methods.
+//
+//@ needs-sanitizer-cfi
+//@ only-linux
+//@ ignore-backends: gcc
+//@ compile-flags: -Ctarget-feature=-crt-static -Zpanic_abort_tests -Cpanic=abort -Cprefer-dynamic=off -Copt-level=0 -Zsanitizer=kcfi -Cunsafe-allow-abi-mismatch=sanitizer --test
+//@ run-pass
+
+#![feature(fn_traits)]
+#![feature(unboxed_closures)]
+
+fn foo(_a: u32) {}
+
+#[test]
+fn test_fn_trait() {
+    let f: Box<dyn Fn(u32)> = Box::new(foo);
+    Fn::call(&f, (0,));
+}
+
+#[test]
+fn test_fnmut_trait() {
+    let mut a = 0;
+    let mut f: Box<dyn FnMut(u32)> = Box::new(|x| a += x);
+    FnMut::call_mut(&mut f, (1,));
+}
+
+#[test]
+fn test_fnonce_trait() {
+    let f: Box<dyn FnOnce(u32)> = Box::new(foo);
+    FnOnce::call_once(f, (2,));
+}


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#144936 (CFI: Fix types that implement Fn, FnMut, or FnOnce)
 - rust-lang/rust#147468 (Implement fs api set_times and set_times_nofollow)
 - rust-lang/rust#147660 (rustdoc-search: stringdex 0.0.2)
 - rust-lang/rust#147735 (Micro-optimization in `FunctionCx::initialize_locals`)
 - rust-lang/rust#147764 (Undo CopyForDeref assertion in const qualif)
 - rust-lang/rust#147783 (bootstrap: migrate to object 0.37)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=144936,147468,147660,147735,147764,147783)
<!-- homu-ignore:end -->