### PR TITLE
use minicore for more tests

### DIFF
--- a/tests/ui/repr/16-bit-repr-c-enum.rs
+++ b/tests/ui/repr/16-bit-repr-c-enum.rs
@@ -7,7 +7,7 @@
 //@ [msp430] needs-llvm-components: msp430
 //@ [msp430] compile-flags: --target=msp430-none-elf --crate-type=rlib
 //@ ignore-backends: gcc
-#![feature(no_core, lang_items, intrinsics, staged_api, rustc_attrs)]
+#![feature(no_core, intrinsics, staged_api, rustc_attrs)]
 #![no_core]
 #![crate_type = "lib"]
 #![stable(feature = "intrinsics_for_test", since = "3.3.3")]

--- a/tests/ui/repr/repr-c-dead-variants.rs
+++ b/tests/ui/repr/repr-c-dead-variants.rs
@@ -1,4 +1,4 @@
-#![feature(no_core, rustc_attrs, lang_items)]
+#![feature(no_core, rustc_attrs)]
 #![allow(dead_code)]
 #![crate_type = "lib"]
 #![no_std]

--- a/tests/ui/repr/repr_align_greater_usize.rs
+++ b/tests/ui/repr/repr_align_greater_usize.rs
@@ -9,7 +9,7 @@
 // We should fail to compute alignment for types aligned higher than usize::MAX.
 // We can't handle alignments that require all 32 bits, so this only affects 16-bit.
 
-#![feature(lang_items, no_core)]
+#![feature(no_core)]
 #![no_core]
 #![crate_type = "lib"]
 

--- a/tests/ui/sanitizer/cfg-kasan.rs
+++ b/tests/ui/sanitizer/cfg-kasan.rs
@@ -16,7 +16,7 @@
 //@ ignore-backends: gcc
 
 #![crate_type = "rlib"]
-#![feature(cfg_sanitize, no_core, lang_items)]
+#![feature(cfg_sanitize, no_core)]
 #![no_core]
 
 extern crate minicore;

--- a/tests/ui/sanitizer/cfg.rs
+++ b/tests/ui/sanitizer/cfg.rs
@@ -21,7 +21,7 @@
 //@[thread]compile-flags:  -Zsanitizer=thread
 //@ ignore-backends: gcc
 
-#![feature(cfg_sanitize, no_core, lang_items)]
+#![feature(cfg_sanitize, no_core)]
 #![crate_type="lib"]
 #![no_core]
 

--- a/tests/ui/static/static_sized_requirement.rs
+++ b/tests/ui/static/static_sized_requirement.rs
@@ -1,7 +1,7 @@
 //@ add-core-stubs
 //@ check-pass
 
-#![feature(no_core, lang_items)]
+#![feature(no_core)]
 #![no_core]
 #![crate_type = "lib"]
 

--- a/tests/ui/target-feature/abi-incompatible-target-feature-attribute-fcw.rs
+++ b/tests/ui/target-feature/abi-incompatible-target-feature-attribute-fcw.rs
@@ -1,18 +1,13 @@
 //@ compile-flags: --crate-type=lib
 //@ compile-flags: --target=aarch64-unknown-none-softfloat
 //@ needs-llvm-components: aarch64
-#![feature(no_core, lang_items)]
+//@ add-core-stubs
+#![feature(no_core)]
 #![no_core]
 #![deny(aarch64_softfloat_neon)]
 
-#[lang = "pointee_sized"]
-pub trait PointeeSized {}
-
-#[lang = "meta_sized"]
-pub trait MetaSized: PointeeSized {}
-
-#[lang = "sized"]
-pub trait Sized: MetaSized {}
+extern crate minicore;
+use minicore::*;
 
 #[target_feature(enable = "neon")]
 //~^ERROR: enabling the `neon` target feature on the current target is unsound

--- a/tests/ui/target-feature/abi-incompatible-target-feature-attribute-fcw.stderr
+++ b/tests/ui/target-feature/abi-incompatible-target-feature-attribute-fcw.stderr
@@ -1,5 +1,5 @@
 error: enabling the `neon` target feature on the current target is unsound due to ABI issues
-  --> $DIR/abi-incompatible-target-feature-attribute-fcw.rs:17:18
+  --> $DIR/abi-incompatible-target-feature-attribute-fcw.rs:12:18
    |
 LL | #[target_feature(enable = "neon")]
    |                  ^^^^^^^^^^^^^^^
@@ -7,7 +7,7 @@ LL | #[target_feature(enable = "neon")]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #134375 <https://github.com/rust-lang/rust/issues/134375>
 note: the lint level is defined here
-  --> $DIR/abi-incompatible-target-feature-attribute-fcw.rs:6:9
+  --> $DIR/abi-incompatible-target-feature-attribute-fcw.rs:7:9
    |
 LL | #![deny(aarch64_softfloat_neon)]
    |         ^^^^^^^^^^^^^^^^^^^^^^
@@ -16,7 +16,7 @@ error: aborting due to 1 previous error
 
 Future incompatibility report: Future breakage diagnostic:
 error: enabling the `neon` target feature on the current target is unsound due to ABI issues
-  --> $DIR/abi-incompatible-target-feature-attribute-fcw.rs:17:18
+  --> $DIR/abi-incompatible-target-feature-attribute-fcw.rs:12:18
    |
 LL | #[target_feature(enable = "neon")]
    |                  ^^^^^^^^^^^^^^^
@@ -24,7 +24,7 @@ LL | #[target_feature(enable = "neon")]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #134375 <https://github.com/rust-lang/rust/issues/134375>
 note: the lint level is defined here
-  --> $DIR/abi-incompatible-target-feature-attribute-fcw.rs:6:9
+  --> $DIR/abi-incompatible-target-feature-attribute-fcw.rs:7:9
    |
 LL | #![deny(aarch64_softfloat_neon)]
    |         ^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/target-feature/abi-incompatible-target-feature-attribute.riscv.stderr
+++ b/tests/ui/target-feature/abi-incompatible-target-feature-attribute.riscv.stderr
@@ -1,5 +1,5 @@
 error: target feature `d` cannot be enabled with `#[target_feature]`: this feature is incompatible with the target ABI
-  --> $DIR/abi-incompatible-target-feature-attribute.rs:22:90
+  --> $DIR/abi-incompatible-target-feature-attribute.rs:17:90
    |
 LL | #[cfg_attr(x86, target_feature(enable = "soft-float"))] #[cfg_attr(riscv, target_feature(enable = "d"))]
    |                                                                                          ^^^^^^^^^^^^

--- a/tests/ui/target-feature/abi-incompatible-target-feature-attribute.rs
+++ b/tests/ui/target-feature/abi-incompatible-target-feature-attribute.rs
@@ -7,17 +7,12 @@
 //@[riscv] compile-flags: --target=riscv32e-unknown-none-elf
 //@[riscv] needs-llvm-components: riscv
 //@ ignore-backends: gcc
-#![feature(no_core, lang_items, riscv_target_feature, x87_target_feature)]
+//@ add-core-stubs
+#![feature(no_core, riscv_target_feature, x87_target_feature)]
 #![no_core]
 
-#[lang = "pointee_sized"]
-pub trait PointeeSized {}
-
-#[lang = "meta_sized"]
-pub trait MetaSized: PointeeSized {}
-
-#[lang = "sized"]
-pub trait Sized {}
+extern crate minicore;
+use minicore::*;
 
 #[cfg_attr(x86, target_feature(enable = "soft-float"))] #[cfg_attr(riscv, target_feature(enable = "d"))]
 //~^ERROR: cannot be enabled with

--- a/tests/ui/target-feature/abi-incompatible-target-feature-attribute.x86.stderr
+++ b/tests/ui/target-feature/abi-incompatible-target-feature-attribute.x86.stderr
@@ -1,5 +1,5 @@
 error: target feature `soft-float` cannot be enabled with `#[target_feature]`: this feature is incompatible with the target ABI
-  --> $DIR/abi-incompatible-target-feature-attribute.rs:22:32
+  --> $DIR/abi-incompatible-target-feature-attribute.rs:17:32
    |
 LL | #[cfg_attr(x86, target_feature(enable = "soft-float"))] #[cfg_attr(riscv, target_feature(enable = "d"))]
    |                                ^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/target-feature/abi-incompatible-target-feature-flag-enable.rs
+++ b/tests/ui/target-feature/abi-incompatible-target-feature-flag-enable.rs
@@ -8,20 +8,13 @@
 //@[riscv] compile-flags: --target=riscv32e-unknown-none-elf -Ctarget-feature=+d
 //@[riscv] needs-llvm-components: riscv
 //@ ignore-backends: gcc
+//@ add-core-stubs
 
-#![feature(no_core, lang_items, riscv_target_feature)]
+#![feature(no_core, riscv_target_feature)]
 #![no_core]
 
-#[lang = "pointee_sized"]
-pub trait PointeeSized {}
-
-#[lang = "meta_sized"]
-pub trait MetaSized: PointeeSized {}
-
-#[lang = "sized"]
-pub trait Sized {}
-#[lang = "freeze"]
-pub trait Freeze {}
+extern crate minicore;
+use minicore::*;
 
 //~? WARN must be disabled to ensure that the ABI of the current target can be implemented correctly
 //~? WARN unstable feature specified for `-Ctarget-feature`

--- a/tests/ui/target-feature/abi-incompatible-target-feature-flag-enable.rs
+++ b/tests/ui/target-feature/abi-incompatible-target-feature-flag-enable.rs
@@ -6,6 +6,8 @@
 //@[x86] compile-flags: --target=x86_64-unknown-linux-gnu -Ctarget-feature=+soft-float
 //@[x86] needs-llvm-components: x86
 //@[riscv] compile-flags: --target=riscv32e-unknown-none-elf -Ctarget-feature=+d
+// FIXME(#147881): *disable* the feature again for minicore as otherwise that will fail to build.
+//@[riscv] core-stubs-compile-flags: -Ctarget-feature=-d
 //@[riscv] needs-llvm-components: riscv
 //@ ignore-backends: gcc
 //@ add-core-stubs

--- a/tests/ui/target-feature/abi-irrelevant-target-feature-flag-disable.rs
+++ b/tests/ui/target-feature/abi-irrelevant-target-feature-flag-disable.rs
@@ -6,16 +6,11 @@
 //@ compile-flags: -Ctarget-feature=-x87
 //@ build-pass
 //@ ignore-backends: gcc
-#![feature(no_core, lang_items)]
+//@ add-core-stubs
+#![feature(no_core)]
 #![no_core]
 
-#[lang = "pointee_sized"]
-pub trait PointeeSized {}
-
-#[lang = "meta_sized"]
-pub trait MetaSized: PointeeSized {}
-
-#[lang = "sized"]
-pub trait Sized: MetaSized {}
+extern crate minicore;
+use minicore::*;
 
 //~? WARN unstable feature specified for `-Ctarget-feature`: `x87`

--- a/tests/ui/target-feature/abi-required-target-feature-attribute.rs
+++ b/tests/ui/target-feature/abi-required-target-feature-attribute.rs
@@ -4,17 +4,12 @@
 //@ needs-llvm-components: x86
 //@ build-pass
 //@ ignore-backends: gcc
-#![feature(no_core, lang_items, x87_target_feature)]
+//@ add-core-stubs
+#![feature(no_core, x87_target_feature)]
 #![no_core]
 
-#[lang = "pointee_sized"]
-pub trait PointeeSized {}
-
-#[lang = "meta_sized"]
-pub trait MetaSized: PointeeSized {}
-
-#[lang = "sized"]
-pub trait Sized: MetaSized {}
+extern crate minicore;
+use minicore::*;
 
 #[target_feature(enable = "x87")]
 pub unsafe fn my_fun() {}

--- a/tests/ui/target-feature/abi-required-target-feature-flag-disable.rs
+++ b/tests/ui/target-feature/abi-required-target-feature-flag-disable.rs
@@ -17,18 +17,13 @@
 // Remove some LLVM warnings that only show up sometimes.
 //@ normalize-stderr: "\n[^\n]*(target-abi|lp64f)[^\n]*" -> ""
 //@ ignore-backends: gcc
+//@ add-core-stubs
 
-#![feature(no_core, lang_items)]
+#![feature(no_core)]
 #![no_core]
 
-#[lang = "pointee_sized"]
-pub trait PointeeSized {}
-
-#[lang = "meta_sized"]
-pub trait MetaSized: PointeeSized {}
-
-#[lang = "sized"]
-pub trait Sized {}
+extern crate minicore;
+use minicore::*;
 
 //~? WARN must be enabled to ensure that the ABI of the current target can be implemented correctly
 //[x86,riscv]~? WARN unstable feature specified for `-Ctarget-feature`

--- a/tests/ui/target-feature/feature-hierarchy.rs
+++ b/tests/ui/target-feature/feature-hierarchy.rs
@@ -4,27 +4,16 @@
 //@ [aarch64-sve2] compile-flags: -Ctarget-feature=-neon,+sve2 --target=aarch64-unknown-linux-gnu
 //@ [aarch64-sve2] needs-llvm-components: aarch64
 //@ build-pass
+//@ add-core-stubs
 #![no_core]
 #![crate_type = "rlib"]
-#![feature(intrinsics, rustc_attrs, no_core, lang_items, staged_api)]
+#![feature(intrinsics, rustc_attrs, no_core, staged_api)]
 #![stable(feature = "test", since = "1.0.0")]
 
 // Tests vetting "feature hierarchies" in the cases where we impose them.
 
-// Supporting minimal rust core code
-#[lang = "pointee_sized"]
-trait PointeeSized {}
-
-#[lang = "meta_sized"]
-trait MetaSized: PointeeSized {}
-
-#[lang = "sized"]
-trait Sized: MetaSized {}
-
-#[lang = "copy"]
-trait Copy {}
-
-impl Copy for bool {}
+extern crate minicore;
+use minicore::*;
 
 #[stable(feature = "test", since = "1.0.0")]
 #[rustc_const_stable(feature = "test", since = "1.0.0")]

--- a/tests/ui/target-feature/forbidden-hardfloat-target-feature-attribute-e-d.rs
+++ b/tests/ui/target-feature/forbidden-hardfloat-target-feature-attribute-e-d.rs
@@ -2,17 +2,12 @@
 //@ compile-flags: --target=riscv32e-unknown-none-elf --crate-type=lib
 //@ needs-llvm-components: riscv
 //@ ignore-backends: gcc
-#![feature(no_core, lang_items, riscv_target_feature)]
+//@ add-core-stubs
+#![feature(no_core, riscv_target_feature)]
 #![no_core]
 
-#[lang = "pointee_sized"]
-pub trait PointeeSized {}
-
-#[lang = "meta_sized"]
-pub trait MetaSized: PointeeSized {}
-
-#[lang = "sized"]
-pub trait Sized: MetaSized {}
+extern crate minicore;
+use minicore::*;
 
 #[target_feature(enable = "d")]
 //~^ERROR: cannot be enabled with

--- a/tests/ui/target-feature/forbidden-hardfloat-target-feature-attribute-e-d.stderr
+++ b/tests/ui/target-feature/forbidden-hardfloat-target-feature-attribute-e-d.stderr
@@ -1,5 +1,5 @@
 error: target feature `d` cannot be enabled with `#[target_feature]`: this feature is incompatible with the target ABI
-  --> $DIR/forbidden-hardfloat-target-feature-attribute-e-d.rs:17:18
+  --> $DIR/forbidden-hardfloat-target-feature-attribute-e-d.rs:12:18
    |
 LL | #[target_feature(enable = "d")]
    |                  ^^^^^^^^^^^^

--- a/tests/ui/target-feature/forbidden-hardfloat-target-feature-attribute-f-zfinx.rs
+++ b/tests/ui/target-feature/forbidden-hardfloat-target-feature-attribute-f-zfinx.rs
@@ -2,17 +2,12 @@
 //@ compile-flags: --target=riscv64gc-unknown-linux-gnu --crate-type=lib
 //@ needs-llvm-components: riscv
 //@ ignore-backends: gcc
-#![feature(no_core, lang_items, riscv_target_feature)]
+//@ add-core-stubs
+#![feature(no_core, riscv_target_feature)]
 #![no_core]
 
-#[lang = "pointee_sized"]
-pub trait PointeeSized {}
-
-#[lang = "meta_sized"]
-pub trait MetaSized: PointeeSized {}
-
-#[lang = "sized"]
-pub trait Sized {}
+extern crate minicore;
+use minicore::*;
 
 #[target_feature(enable = "zdinx")]
 //~^ERROR: cannot be enabled with

--- a/tests/ui/target-feature/forbidden-hardfloat-target-feature-attribute-f-zfinx.stderr
+++ b/tests/ui/target-feature/forbidden-hardfloat-target-feature-attribute-f-zfinx.stderr
@@ -1,5 +1,5 @@
 error: target feature `zfinx` cannot be enabled with `#[target_feature]`: this feature is incompatible with the target ABI
-  --> $DIR/forbidden-hardfloat-target-feature-attribute-f-zfinx.rs:17:18
+  --> $DIR/forbidden-hardfloat-target-feature-attribute-f-zfinx.rs:12:18
    |
 LL | #[target_feature(enable = "zdinx")]
    |                  ^^^^^^^^^^^^^^^^

--- a/tests/ui/target-feature/forbidden-hardfloat-target-feature-cfg.rs
+++ b/tests/ui/target-feature/forbidden-hardfloat-target-feature-cfg.rs
@@ -1,18 +1,13 @@
 //@ compile-flags: --target=x86_64-unknown-linux-gnu --crate-type=lib
 //@ needs-llvm-components: x86
 //@ check-pass
-#![feature(no_core, lang_items)]
+//@ add-core-stubs
+#![feature(no_core)]
 #![no_core]
 #![allow(unexpected_cfgs)]
 
-#[lang = "pointee_sized"]
-pub trait PointeeSized {}
-
-#[lang = "meta_sized"]
-pub trait MetaSized: PointeeSized {}
-
-#[lang = "sized"]
-pub trait Sized: MetaSized {}
+extern crate minicore;
+use minicore::*;
 
 // The compile_error macro does not exist, so if the `cfg` evaluates to `true` this
 // complains about the missing macro rather than showing the error... but that's good enough.

--- a/tests/ui/target-feature/forbidden-target-feature-attribute.rs
+++ b/tests/ui/target-feature/forbidden-target-feature-attribute.rs
@@ -2,17 +2,12 @@
 //@ compile-flags: --target=riscv32e-unknown-none-elf --crate-type=lib
 //@ needs-llvm-components: riscv
 //@ ignore-backends: gcc
-#![feature(no_core, lang_items)]
+//@ add-core-stubs
+#![feature(no_core)]
 #![no_core]
 
-#[lang = "pointee_sized"]
-pub trait PointeeSized {}
-
-#[lang = "meta_sized"]
-pub trait MetaSized: PointeeSized {}
-
-#[lang = "sized"]
-pub trait Sized: MetaSized {}
+extern crate minicore;
+use minicore::*;
 
 #[target_feature(enable = "forced-atomics")]
 //~^ERROR: cannot be enabled with

--- a/tests/ui/target-feature/forbidden-target-feature-attribute.stderr
+++ b/tests/ui/target-feature/forbidden-target-feature-attribute.stderr
@@ -1,5 +1,5 @@
 error: target feature `forced-atomics` cannot be enabled with `#[target_feature]`: unsound because it changes the ABI of atomic operations
-  --> $DIR/forbidden-target-feature-attribute.rs:17:18
+  --> $DIR/forbidden-target-feature-attribute.rs:12:18
    |
 LL | #[target_feature(enable = "forced-atomics")]
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/target-feature/forbidden-target-feature-cfg.rs
+++ b/tests/ui/target-feature/forbidden-target-feature-cfg.rs
@@ -3,18 +3,13 @@
 //@ needs-llvm-components: riscv
 //@ check-pass
 //@ ignore-backends: gcc
-#![feature(no_core, lang_items)]
+//@ add-core-stubs
+#![feature(no_core)]
 #![no_core]
 #![allow(unexpected_cfgs)]
 
-#[lang = "pointee_sized"]
-pub trait PointeeSized {}
-
-#[lang = "meta_sized"]
-pub trait MetaSized: PointeeSized {}
-
-#[lang = "sized"]
-pub trait Sized: MetaSized {}
+extern crate minicore;
+use minicore::*;
 
 // The compile_error macro does not exist, so if the `cfg` evaluates to `true` this
 // complains about the missing macro rather than showing the error... but that's good enough.

--- a/tests/ui/target-feature/forbidden-target-feature-flag-disable.rs
+++ b/tests/ui/target-feature/forbidden-target-feature-flag-disable.rs
@@ -5,17 +5,12 @@
 // For now this is just a warning.
 //@ build-pass
 //@ ignore-backends: gcc
+//@ add-core-stubs
 
-#![feature(no_core, lang_items)]
+#![feature(no_core)]
 #![no_core]
 
-#[lang = "pointee_sized"]
-pub trait PointeeSized {}
-
-#[lang = "meta_sized"]
-pub trait MetaSized: PointeeSized {}
-
-#[lang = "sized"]
-pub trait Sized: MetaSized {}
+extern crate minicore;
+use minicore::*;
 
 //~? WARN target feature `forced-atomics` cannot be disabled with `-Ctarget-feature`: unsound because it changes the ABI of atomic operations

--- a/tests/ui/target-feature/forbidden-target-feature-flag.rs
+++ b/tests/ui/target-feature/forbidden-target-feature-flag.rs
@@ -5,17 +5,12 @@
 // For now this is just a warning.
 //@ build-pass
 //@ ignore-backends: gcc
+//@ add-core-stubs
 
-#![feature(no_core, lang_items)]
+#![feature(no_core)]
 #![no_core]
 
-#[lang = "pointee_sized"]
-pub trait PointeeSized {}
-
-#[lang = "meta_sized"]
-pub trait MetaSized: PointeeSized {}
-
-#[lang = "sized"]
-pub trait Sized: MetaSized {}
+extern crate minicore;
+use minicore::*;
 
 //~? WARN target feature `forced-atomics` cannot be enabled with `-Ctarget-feature`: unsound because it changes the ABI of atomic operations

--- a/tests/ui/target-feature/no-llvm-leaks.rs
+++ b/tests/ui/target-feature/no-llvm-leaks.rs
@@ -7,7 +7,7 @@
 //@ build-pass
 #![no_core]
 #![crate_type = "rlib"]
-#![feature(intrinsics, rustc_attrs, no_core, lang_items, staged_api)]
+#![feature(intrinsics, rustc_attrs, no_core, staged_api)]
 #![stable(feature = "test", since = "1.0.0")]
 
 extern crate minicore;

--- a/tests/ui/target-feature/target-cpu-lacks-required-target-feature.rs
+++ b/tests/ui/target-feature/target-cpu-lacks-required-target-feature.rs
@@ -4,17 +4,12 @@
 // For now this is just a warning.
 //@ build-pass
 //@ ignore-backends: gcc
+//@ add-core-stubs
 
-#![feature(no_core, lang_items)]
+#![feature(no_core)]
 #![no_core]
 
-#[lang = "pointee_sized"]
-pub trait PointeeSized {}
-
-#[lang = "meta_sized"]
-pub trait MetaSized: PointeeSized {}
-
-#[lang = "sized"]
-pub trait Sized: MetaSized {}
+extern crate minicore;
+use minicore::*;
 
 //~? WARN target feature `sse2` must be enabled to ensure that the ABI of the current target can be implemented correctly

--- a/tests/ui/target-feature/tied-features-cli.rs
+++ b/tests/ui/target-feature/tied-features-cli.rs
@@ -12,17 +12,12 @@
 //@ [four] build-pass
 //@ [four] compile-flags: -C target-feature=-paca,+pacg -C target-feature=+paca
 //@ ignore-backends: gcc
-#![feature(no_core, lang_items)]
+//@ add-core-stubs
+#![feature(no_core)]
 #![no_core]
 
-#[lang = "pointee_sized"]
-pub trait PointeeSized {}
-
-#[lang = "meta_sized"]
-pub trait MetaSized: PointeeSized {}
-
-#[lang = "sized"]
-pub trait Sized: MetaSized {}
+extern crate minicore;
+use minicore::*;
 
 fn main() {}
 

--- a/tests/ui/target-feature/tied-features-cli.rs
+++ b/tests/ui/target-feature/tied-features-cli.rs
@@ -13,6 +13,8 @@
 //@ [four] compile-flags: -C target-feature=-paca,+pacg -C target-feature=+paca
 //@ ignore-backends: gcc
 //@ add-core-stubs
+// FIXME(#147881): *disable* the features again for minicore as otherwise that will fail to build.
+//@ core-stubs-compile-flags: -C target-feature=-pacg,-paca
 #![feature(no_core)]
 #![no_core]
 

--- a/tests/ui/target-feature/tied-features-no-implication-1.rs
+++ b/tests/ui/target-feature/tied-features-no-implication-1.rs
@@ -5,6 +5,8 @@
 //@[pacg] compile-flags: -Ctarget-feature=+pacg
 //@ ignore-backends: gcc
 //@ add-core-stubs
+// FIXME(#147881): *disable* the features again for minicore as otherwise that will fail to build.
+//@ core-stubs-compile-flags: -C target-feature=-pacg,-paca
 #![feature(no_core)]
 #![no_core]
 

--- a/tests/ui/target-feature/tied-features-no-implication-1.rs
+++ b/tests/ui/target-feature/tied-features-no-implication-1.rs
@@ -4,17 +4,12 @@
 //@[paca] compile-flags: -Ctarget-feature=+paca
 //@[pacg] compile-flags: -Ctarget-feature=+pacg
 //@ ignore-backends: gcc
-#![feature(no_core, lang_items)]
+//@ add-core-stubs
+#![feature(no_core)]
 #![no_core]
 
-#[lang = "pointee_sized"]
-pub trait PointeeSized {}
-
-#[lang = "meta_sized"]
-pub trait MetaSized: PointeeSized {}
-
-#[lang = "sized"]
-pub trait Sized: MetaSized {}
+extern crate minicore;
+use minicore::*;
 
 // In this test, demonstrate that +paca and +pacg both result in the tied feature error if there
 // isn't something causing an error.

--- a/tests/ui/target-feature/tied-features-no-implication.pacg.stderr
+++ b/tests/ui/target-feature/tied-features-no-implication.pacg.stderr
@@ -1,5 +1,5 @@
 error[E0428]: the name `foo` is defined multiple times
-  --> $DIR/tied-features-no-implication.rs:34:1
+  --> $DIR/tied-features-no-implication.rs:31:1
    |
 LL | fn foo() {}
    | -------- previous definition of the value `foo` here

--- a/tests/ui/target-feature/tied-features-no-implication.rs
+++ b/tests/ui/target-feature/tied-features-no-implication.rs
@@ -5,6 +5,8 @@
 //@[pacg] compile-flags: -Ctarget-feature=+pacg
 //@ ignore-backends: gcc
 //@ add-core-stubs
+// FIXME(#147881): *disable* the features again for minicore as otherwise that will fail to build.
+//@ core-stubs-compile-flags: -C target-feature=-pacg,-paca
 
 #![feature(no_core)]
 #![no_core]

--- a/tests/ui/target-feature/tied-features-no-implication.rs
+++ b/tests/ui/target-feature/tied-features-no-implication.rs
@@ -4,18 +4,13 @@
 //@[paca] compile-flags: -Ctarget-feature=+paca
 //@[pacg] compile-flags: -Ctarget-feature=+pacg
 //@ ignore-backends: gcc
+//@ add-core-stubs
 
-#![feature(no_core, lang_items)]
+#![feature(no_core)]
 #![no_core]
 
-#[lang = "pointee_sized"]
-pub trait PointeeSized {}
-
-#[lang = "meta_sized"]
-pub trait MetaSized: PointeeSized {}
-
-#[lang = "sized"]
-pub trait Sized: MetaSized {}
+extern crate minicore;
+use minicore::*;
 
 // Can't use `compile_error!` here without `core`/`std` but requiring these makes this test only
 // work if you have libcore built in the sysroot for `aarch64-unknown-linux-gnu`. Can't run this

--- a/tests/ui/target-feature/tied-features.rs
+++ b/tests/ui/target-feature/tied-features.rs
@@ -2,7 +2,8 @@
 //@ compile-flags: --crate-type=rlib --target=aarch64-unknown-linux-gnu
 //@ needs-llvm-components: aarch64
 //@ ignore-backends: gcc
-#![feature(no_core, lang_items)]
+//@ add-core-stubs
+#![feature(no_core)]
 #![no_core]
 
 extern crate minicore;

--- a/tests/ui/target-feature/tied-features.stderr
+++ b/tests/ui/target-feature/tied-features.stderr
@@ -1,5 +1,5 @@
 error: the target features paca, pacg must all be either enabled or disabled together
-  --> $DIR/tied-features.rs:12:5
+  --> $DIR/tied-features.rs:13:5
    |
 LL |     #[target_feature(enable = "pacg")]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -7,7 +7,7 @@ LL |     #[target_feature(enable = "pacg")]
    = help: add the missing features in a `target_feature` attribute
 
 error: the target features paca, pacg must all be either enabled or disabled together
-  --> $DIR/tied-features.rs:24:1
+  --> $DIR/tied-features.rs:25:1
    |
 LL | #[target_feature(enable = "paca")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -15,7 +15,7 @@ LL | #[target_feature(enable = "paca")]
    = help: add the missing features in a `target_feature` attribute
 
 error: the target features paca, pacg must all be either enabled or disabled together
-  --> $DIR/tied-features.rs:37:1
+  --> $DIR/tied-features.rs:38:1
    |
 LL | #[target_feature(enable = "paca")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/unboxed-closures/unboxed-closures-all-traits.rs
+++ b/tests/ui/unboxed-closures/unboxed-closures-all-traits.rs
@@ -1,5 +1,4 @@
 //@ run-pass
-#![feature(lang_items)]
 
 fn a<F:Fn(isize, isize) -> isize>(f: F) -> isize {
     f(1, 2)

--- a/tests/ui/unboxed-closures/unboxed-closures-blanket-fn-mut.rs
+++ b/tests/ui/unboxed-closures/unboxed-closures-blanket-fn-mut.rs
@@ -2,8 +2,6 @@
 #![allow(unused_variables)]
 // Test that you can supply `&F` where `F: FnMut()`.
 
-#![feature(lang_items)]
-
 fn a<F:FnMut() -> i32>(mut f: F) -> i32 {
     f()
 }

--- a/tests/ui/unboxed-closures/unboxed-closures-blanket-fn.rs
+++ b/tests/ui/unboxed-closures/unboxed-closures-blanket-fn.rs
@@ -2,8 +2,6 @@
 #![allow(unused_variables)]
 // Test that you can supply `&F` where `F: Fn()`.
 
-#![feature(lang_items)]
-
 fn a<F:Fn() -> i32>(f: F) -> i32 {
     f()
 }


### PR DESCRIPTION
r? @jieyouxu 

Unfortunately this doesn't work for all tests; minicore sometimes fails to build with errors like
```
rustc-LLVM ERROR: ILP32E cannot be used with the D ISA extension
```
and
```
error: the target features paca, pacg must all be either enabled or disabled together
```
These errors are meant to be triggered in the tests, but not in minicore.

It seems like all `@compile-flags` are forwarded to minicore. Maybe we should exclude `-Ctarget-feature` from that? Or provide some way to set flags only for the current file, not minicore?