### PR TITLE
Warn on unused_attributes in uitests 

### DIFF
--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -1838,8 +1838,9 @@ impl<'test> TestCx<'test> {
 
         // Add `-A unused` before `config` flags and in-test (`props`) flags, so that they can
         // overwrite this.
+        // Don't allow `unused_attributes` since these are usually actual mistakes, rather than just unused code.
         if let AllowUnused::Yes = allow_unused {
-            rustc.args(&["-A", "unused"]);
+            rustc.args(&["-A", "unused", "-W", "unused_attributes"]);
         }
 
         // Allow tests to use internal features.

--- a/tests/ui/attributes/attr-mix-new.rs
+++ b/tests/ui/attributes/attr-mix-new.rs
@@ -5,6 +5,7 @@
 #[rustc_dummy(bar)]
 mod foo {
   #![feature(globs)]
+  //~^ WARN crate-level attribute should be in the root module
 }
 
 fn main() {}

--- a/tests/ui/attributes/attr-mix-new.stderr
+++ b/tests/ui/attributes/attr-mix-new.stderr
@@ -1,0 +1,10 @@
+warning: crate-level attribute should be in the root module
+  --> $DIR/attr-mix-new.rs:7:3
+   |
+LL |   #![feature(globs)]
+   |   ^^^^^^^^^^^^^^^^^^
+   |
+   = note: requested on the command line with `-W unused-attributes`
+
+warning: 1 warning emitted
+

--- a/tests/ui/attributes/crate-type-macro-empty.rs
+++ b/tests/ui/attributes/crate-type-macro-empty.rs
@@ -1,6 +1,7 @@
 // Tests for the issue in #137589
 #[crate_type = foo!()]
 //~^ ERROR cannot find macro `foo` in this scope
+//~| WARN crate-level attribute should be an inner attribute
 
 macro_rules! foo {} //~ ERROR macros must contain at least one rule
 

--- a/tests/ui/attributes/crate-type-macro-empty.stderr
+++ b/tests/ui/attributes/crate-type-macro-empty.stderr
@@ -1,5 +1,5 @@
 error: macros must contain at least one rule
-  --> $DIR/crate-type-macro-empty.rs:5:1
+  --> $DIR/crate-type-macro-empty.rs:6:1
    |
 LL | macro_rules! foo {}
    | ^^^^^^^^^^^^^^^^^^^
@@ -11,10 +11,22 @@ LL | #[crate_type = foo!()]
    |                ^^^ consider moving the definition of `foo` before this call
    |
 note: a macro with the same name exists, but it appears later
-  --> $DIR/crate-type-macro-empty.rs:5:14
+  --> $DIR/crate-type-macro-empty.rs:6:14
    |
 LL | macro_rules! foo {}
    |              ^^^
 
-error: aborting due to 2 previous errors
+warning: crate-level attribute should be an inner attribute
+  --> $DIR/crate-type-macro-empty.rs:2:1
+   |
+LL | #[crate_type = foo!()]
+   | ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: requested on the command line with `-W unused-attributes`
+help: add a `!`
+   |
+LL | #![crate_type = foo!()]
+   |  +
+
+error: aborting due to 2 previous errors; 1 warning emitted
 

--- a/tests/ui/attributes/crate-type-macro-not-found.rs
+++ b/tests/ui/attributes/crate-type-macro-not-found.rs
@@ -1,5 +1,6 @@
 // Tests for the issue in #137589
 #[crate_type = foo!()] //~ ERROR cannot find macro `foo` in this scope
+//~| WARN crate-level attribute should be an inner attribute
 
 macro_rules! foo {
     ($x:expr) => {"rlib"}

--- a/tests/ui/attributes/crate-type-macro-not-found.stderr
+++ b/tests/ui/attributes/crate-type-macro-not-found.stderr
@@ -5,10 +5,22 @@ LL | #[crate_type = foo!()]
    |                ^^^ consider moving the definition of `foo` before this call
    |
 note: a macro with the same name exists, but it appears later
-  --> $DIR/crate-type-macro-not-found.rs:4:14
+  --> $DIR/crate-type-macro-not-found.rs:5:14
    |
 LL | macro_rules! foo {
    |              ^^^
 
-error: aborting due to 1 previous error
+warning: crate-level attribute should be an inner attribute
+  --> $DIR/crate-type-macro-not-found.rs:2:1
+   |
+LL | #[crate_type = foo!()]
+   | ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: requested on the command line with `-W unused-attributes`
+help: add a `!`
+   |
+LL | #![crate_type = foo!()]
+   |  +
+
+error: aborting due to 1 previous error; 1 warning emitted
 

--- a/tests/ui/attributes/inline/attr-usage-inline.rs
+++ b/tests/ui/attributes/inline/attr-usage-inline.rs
@@ -9,16 +9,22 @@ struct S;
 
 struct I {
     #[inline]
+    //~^ WARN attribute cannot be used on
+    //~| WARN previously accepted
     i: u8,
 }
 
 #[macro_export]
 #[inline]
+//~^ WARN attribute cannot be used on
+//~| WARN previously accepted
 macro_rules! m_e {
     () => {};
 }
 
 #[inline] //~ ERROR: attribute should be applied to function or closure
+//~^ WARN attribute cannot be used on
+//~| WARN previously accepted
 macro_rules! m {
     () => {};
 }

--- a/tests/ui/attributes/inline/attr-usage-inline.stderr
+++ b/tests/ui/attributes/inline/attr-usage-inline.stderr
@@ -7,11 +7,39 @@ LL | #[inline]
    = help: `#[inline]` can only be applied to functions
 
 error[E0518]: attribute should be applied to function or closure
-  --> $DIR/attr-usage-inline.rs:21:1
+  --> $DIR/attr-usage-inline.rs:25:1
    |
 LL | #[inline]
    | ^^^^^^^^^ not a function or closure
 
-error: aborting due to 2 previous errors
+warning: `#[inline]` attribute cannot be used on struct fields
+  --> $DIR/attr-usage-inline.rs:11:5
+   |
+LL |     #[inline]
+   |     ^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = help: `#[inline]` can only be applied to functions
+   = note: requested on the command line with `-W unused-attributes`
+
+warning: `#[inline]` attribute cannot be used on macro defs
+  --> $DIR/attr-usage-inline.rs:18:1
+   |
+LL | #[inline]
+   | ^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = help: `#[inline]` can only be applied to functions
+
+warning: `#[inline]` attribute cannot be used on macro defs
+  --> $DIR/attr-usage-inline.rs:25:1
+   |
+LL | #[inline]
+   | ^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = help: `#[inline]` can only be applied to functions
+
+error: aborting due to 2 previous errors; 3 warnings emitted
 
 For more information about this error, try `rustc --explain E0518`.

--- a/tests/ui/attributes/link-dl.rs
+++ b/tests/ui/attributes/link-dl.rs
@@ -9,7 +9,7 @@
 //@ revisions: default_fcw allowed
 //@[allowed] check-pass
 
-#[cfg_attr(allowed, allow(ill_formed_attribute_input))]
+#![cfg_attr(allowed, allow(ill_formed_attribute_input))]
 
 #[link="dl"]
 //[default_fcw]~^ ERROR valid forms for the attribute are

--- a/tests/ui/attributes/malformed-attrs.rs
+++ b/tests/ui/attributes/malformed-attrs.rs
@@ -73,6 +73,7 @@
 //~| ERROR attribute cannot be used on
 #[crate_name]
 //~^ ERROR malformed
+//~| WARN crate-level attribute should be an inner attribute
 #[doc]
 //~^ ERROR valid forms for the attribute are
 //~| WARN this was previously accepted by the compiler
@@ -82,8 +83,12 @@
 //~^ ERROR malformed
 #[link]
 //~^ ERROR malformed
+//~| WARN attribute should be applied to an `extern` block with non-Rust ABI
+//~| WARN previously accepted
 #[link_name]
 //~^ ERROR malformed
+//~| WARN cannot be used on functions
+//~| WARN previously accepted
 #[link_section]
 //~^ ERROR malformed
 #[coverage]
@@ -95,6 +100,8 @@
 //~| WARN this was previously accepted by the compiler
 #[no_implicit_prelude = 23]
 //~^ ERROR malformed
+//~| WARN cannot be used on functions
+//~| WARN previously accepted
 #[proc_macro = 18]
 //~^ ERROR malformed
 //~| ERROR the `#[proc_macro]` attribute is only usable with crates of the `proc-macro` crate type
@@ -188,6 +195,8 @@ extern "C" {
 //~^ ERROR malformed `debugger_visualizer` attribute input
 #[automatically_derived = 18]
 //~^ ERROR malformed
+//~| WARN cannot be used on modules
+//~| WARN previously accepted
 mod yooo {
 
 }

--- a/tests/ui/attributes/malformed-attrs.stderr
+++ b/tests/ui/attributes/malformed-attrs.stderr
@@ -1,5 +1,5 @@
 error[E0539]: malformed `cfg` attribute input
-  --> $DIR/malformed-attrs.rs:101:1
+  --> $DIR/malformed-attrs.rs:108:1
    |
 LL | #[cfg]
    | ^^^^^^
@@ -10,7 +10,7 @@ LL | #[cfg]
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
 
 error[E0539]: malformed `cfg_attr` attribute input
-  --> $DIR/malformed-attrs.rs:103:1
+  --> $DIR/malformed-attrs.rs:110:1
    |
 LL | #[cfg_attr]
    | ^^^^^^^^^^^
@@ -21,7 +21,7 @@ LL | #[cfg_attr]
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute>
 
 error[E0463]: can't find crate for `wloop`
-  --> $DIR/malformed-attrs.rs:209:1
+  --> $DIR/malformed-attrs.rs:218:1
    |
 LL | extern crate wloop;
    | ^^^^^^^^^^^^^^^^^^^ can't find crate
@@ -41,7 +41,7 @@ LL | #![windows_subsystem = "windows"]
    |                      +++++++++++
 
 error: malformed `instruction_set` attribute input
-  --> $DIR/malformed-attrs.rs:105:1
+  --> $DIR/malformed-attrs.rs:112:1
    |
 LL | #[instruction_set]
    | ^^^^^^^^^^^^^^^^^^ help: must be of the form: `#[instruction_set(set)]`
@@ -49,13 +49,13 @@ LL | #[instruction_set]
    = note: for more information, visit <https://doc.rust-lang.org/reference/attributes/codegen.html#the-instruction_set-attribute>
 
 error: malformed `patchable_function_entry` attribute input
-  --> $DIR/malformed-attrs.rs:107:1
+  --> $DIR/malformed-attrs.rs:114:1
    |
 LL | #[patchable_function_entry]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: must be of the form: `#[patchable_function_entry(prefix_nops = m, entry_nops = n)]`
 
 error: malformed `must_not_suspend` attribute input
-  --> $DIR/malformed-attrs.rs:131:1
+  --> $DIR/malformed-attrs.rs:138:1
    |
 LL | #[must_not_suspend()]
    | ^^^^^^^^^^^^^^^^^^^^^
@@ -70,13 +70,13 @@ LL + #[must_not_suspend]
    |
 
 error: malformed `cfi_encoding` attribute input
-  --> $DIR/malformed-attrs.rs:133:1
+  --> $DIR/malformed-attrs.rs:140:1
    |
 LL | #[cfi_encoding]
    | ^^^^^^^^^^^^^^^ help: must be of the form: `#[cfi_encoding = "encoding"]`
 
 error: malformed `allow` attribute input
-  --> $DIR/malformed-attrs.rs:177:1
+  --> $DIR/malformed-attrs.rs:184:1
    |
 LL | #[allow]
    | ^^^^^^^^
@@ -92,7 +92,7 @@ LL | #[allow(lint1, lint2, lint3, reason = "...")]
    |        +++++++++++++++++++++++++++++++++++++
 
 error: malformed `expect` attribute input
-  --> $DIR/malformed-attrs.rs:179:1
+  --> $DIR/malformed-attrs.rs:186:1
    |
 LL | #[expect]
    | ^^^^^^^^^
@@ -108,7 +108,7 @@ LL | #[expect(lint1, lint2, lint3, reason = "...")]
    |         +++++++++++++++++++++++++++++++++++++
 
 error: malformed `warn` attribute input
-  --> $DIR/malformed-attrs.rs:181:1
+  --> $DIR/malformed-attrs.rs:188:1
    |
 LL | #[warn]
    | ^^^^^^^
@@ -124,7 +124,7 @@ LL | #[warn(lint1, lint2, lint3, reason = "...")]
    |       +++++++++++++++++++++++++++++++++++++
 
 error: malformed `deny` attribute input
-  --> $DIR/malformed-attrs.rs:183:1
+  --> $DIR/malformed-attrs.rs:190:1
    |
 LL | #[deny]
    | ^^^^^^^
@@ -140,7 +140,7 @@ LL | #[deny(lint1, lint2, lint3, reason = "...")]
    |       +++++++++++++++++++++++++++++++++++++
 
 error: malformed `forbid` attribute input
-  --> $DIR/malformed-attrs.rs:185:1
+  --> $DIR/malformed-attrs.rs:192:1
    |
 LL | #[forbid]
    | ^^^^^^^^^
@@ -156,13 +156,13 @@ LL | #[forbid(lint1, lint2, lint3, reason = "...")]
    |         +++++++++++++++++++++++++++++++++++++
 
 error: malformed `thread_local` attribute input
-  --> $DIR/malformed-attrs.rs:201:1
+  --> $DIR/malformed-attrs.rs:210:1
    |
 LL | #[thread_local()]
    | ^^^^^^^^^^^^^^^^^ help: must be of the form: `#[thread_local]`
 
 error: malformed `no_link` attribute input
-  --> $DIR/malformed-attrs.rs:205:1
+  --> $DIR/malformed-attrs.rs:214:1
    |
 LL | #[no_link()]
    | ^^^^^^^^^^^^ help: must be of the form: `#[no_link]`
@@ -170,25 +170,25 @@ LL | #[no_link()]
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/extern-crates.html#the-no_link-attribute>
 
 error: the `#[proc_macro]` attribute is only usable with crates of the `proc-macro` crate type
-  --> $DIR/malformed-attrs.rs:98:1
+  --> $DIR/malformed-attrs.rs:105:1
    |
 LL | #[proc_macro = 18]
    | ^^^^^^^^^^^^^^^^^^
 
 error: the `#[proc_macro_attribute]` attribute is only usable with crates of the `proc-macro` crate type
-  --> $DIR/malformed-attrs.rs:115:1
+  --> $DIR/malformed-attrs.rs:122:1
    |
 LL | #[proc_macro_attribute = 19]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: the `#[proc_macro_derive]` attribute is only usable with crates of the `proc-macro` crate type
-  --> $DIR/malformed-attrs.rs:122:1
+  --> $DIR/malformed-attrs.rs:129:1
    |
 LL | #[proc_macro_derive]
    | ^^^^^^^^^^^^^^^^^^^^
 
 error[E0658]: allow_internal_unsafe side-steps the unsafe_code lint
-  --> $DIR/malformed-attrs.rs:214:1
+  --> $DIR/malformed-attrs.rs:223:1
    |
 LL | #[allow_internal_unsafe = 1]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -208,7 +208,7 @@ LL | #[doc]
    = note: `#[deny(ill_formed_attribute_input)]` (part of `#[deny(future_incompatible)]`) on by default
 
 error: valid forms for the attribute are `#[doc(hidden)]`, `#[doc(inline)]`, and `#[doc = "string"]`
-  --> $DIR/malformed-attrs.rs:76:1
+  --> $DIR/malformed-attrs.rs:77:1
    |
 LL | #[doc]
    | ^^^^^^
@@ -432,7 +432,7 @@ LL | #[crate_name]
    | ^^^^^^^^^^^^^ help: must be of the form: `#[crate_name = "name"]`
 
 error[E0539]: malformed `target_feature` attribute input
-  --> $DIR/malformed-attrs.rs:79:1
+  --> $DIR/malformed-attrs.rs:80:1
    |
 LL | #[target_feature]
    | ^^^^^^^^^^^^^^^^^
@@ -441,7 +441,7 @@ LL | #[target_feature]
    | help: must be of the form: `#[target_feature(enable = "feat1, feat2")]`
 
 error[E0565]: malformed `export_stable` attribute input
-  --> $DIR/malformed-attrs.rs:81:1
+  --> $DIR/malformed-attrs.rs:82:1
    |
 LL | #[export_stable = 1]
    | ^^^^^^^^^^^^^^^^---^
@@ -450,7 +450,7 @@ LL | #[export_stable = 1]
    | help: must be of the form: `#[export_stable]`
 
 error[E0539]: malformed `link` attribute input
-  --> $DIR/malformed-attrs.rs:83:1
+  --> $DIR/malformed-attrs.rs:84:1
    |
 LL | #[link]
    | ^^^^^^^ expected this to be a list
@@ -469,7 +469,7 @@ LL | #[link(name = "...", kind = "dylib|static|...", wasm_import_module = "...",
    = and 1 other candidate
 
 error[E0539]: malformed `link_name` attribute input
-  --> $DIR/malformed-attrs.rs:85:1
+  --> $DIR/malformed-attrs.rs:88:1
    |
 LL | #[link_name]
    | ^^^^^^^^^^^^ help: must be of the form: `#[link_name = "name"]`
@@ -477,7 +477,7 @@ LL | #[link_name]
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link_name-attribute>
 
 error[E0539]: malformed `link_section` attribute input
-  --> $DIR/malformed-attrs.rs:87:1
+  --> $DIR/malformed-attrs.rs:92:1
    |
 LL | #[link_section]
    | ^^^^^^^^^^^^^^^ help: must be of the form: `#[link_section = "name"]`
@@ -485,7 +485,7 @@ LL | #[link_section]
    = note: for more information, visit <https://doc.rust-lang.org/reference/abi.html#the-link_section-attribute>
 
 error[E0539]: malformed `coverage` attribute input
-  --> $DIR/malformed-attrs.rs:89:1
+  --> $DIR/malformed-attrs.rs:94:1
    |
 LL | #[coverage]
    | ^^^^^^^^^^^ this attribute is only valid with either `on` or `off` as an argument
@@ -498,7 +498,7 @@ LL | #[coverage(on)]
    |           ++++
 
 error[E0539]: malformed `sanitize` attribute input
-  --> $DIR/malformed-attrs.rs:91:1
+  --> $DIR/malformed-attrs.rs:96:1
    |
 LL | #[sanitize]
    | ^^^^^^^^^^^ expected this to be a list
@@ -516,7 +516,7 @@ LL | #[sanitize(kcfi = "on|off")]
    = and 5 other candidates
 
 error[E0565]: malformed `no_implicit_prelude` attribute input
-  --> $DIR/malformed-attrs.rs:96:1
+  --> $DIR/malformed-attrs.rs:101:1
    |
 LL | #[no_implicit_prelude = 23]
    | ^^^^^^^^^^^^^^^^^^^^^^----^
@@ -525,7 +525,7 @@ LL | #[no_implicit_prelude = 23]
    | help: must be of the form: `#[no_implicit_prelude]`
 
 error[E0565]: malformed `proc_macro` attribute input
-  --> $DIR/malformed-attrs.rs:98:1
+  --> $DIR/malformed-attrs.rs:105:1
    |
 LL | #[proc_macro = 18]
    | ^^^^^^^^^^^^^----^
@@ -534,7 +534,7 @@ LL | #[proc_macro = 18]
    | help: must be of the form: `#[proc_macro]`
 
 error[E0565]: malformed `coroutine` attribute input
-  --> $DIR/malformed-attrs.rs:110:5
+  --> $DIR/malformed-attrs.rs:117:5
    |
 LL |     #[coroutine = 63] || {}
    |     ^^^^^^^^^^^^----^
@@ -543,7 +543,7 @@ LL |     #[coroutine = 63] || {}
    |     help: must be of the form: `#[coroutine]`
 
 error[E0565]: malformed `proc_macro_attribute` attribute input
-  --> $DIR/malformed-attrs.rs:115:1
+  --> $DIR/malformed-attrs.rs:122:1
    |
 LL | #[proc_macro_attribute = 19]
    | ^^^^^^^^^^^^^^^^^^^^^^^----^
@@ -552,7 +552,7 @@ LL | #[proc_macro_attribute = 19]
    | help: must be of the form: `#[proc_macro_attribute]`
 
 error[E0539]: malformed `must_use` attribute input
-  --> $DIR/malformed-attrs.rs:118:1
+  --> $DIR/malformed-attrs.rs:125:1
    |
 LL | #[must_use = 1]
    | ^^^^^^^^^^^^^-^
@@ -570,7 +570,7 @@ LL + #[must_use]
    |
 
 error[E0539]: malformed `proc_macro_derive` attribute input
-  --> $DIR/malformed-attrs.rs:122:1
+  --> $DIR/malformed-attrs.rs:129:1
    |
 LL | #[proc_macro_derive]
    | ^^^^^^^^^^^^^^^^^^^^ expected this to be a list
@@ -584,7 +584,7 @@ LL | #[proc_macro_derive(TraitName, attributes(name1, name2, ...))]
    |                    ++++++++++++++++++++++++++++++++++++++++++
 
 error[E0539]: malformed `rustc_layout_scalar_valid_range_start` attribute input
-  --> $DIR/malformed-attrs.rs:127:1
+  --> $DIR/malformed-attrs.rs:134:1
    |
 LL | #[rustc_layout_scalar_valid_range_start]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -593,7 +593,7 @@ LL | #[rustc_layout_scalar_valid_range_start]
    | help: must be of the form: `#[rustc_layout_scalar_valid_range_start(start)]`
 
 error[E0539]: malformed `rustc_layout_scalar_valid_range_end` attribute input
-  --> $DIR/malformed-attrs.rs:129:1
+  --> $DIR/malformed-attrs.rs:136:1
    |
 LL | #[rustc_layout_scalar_valid_range_end]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -602,7 +602,7 @@ LL | #[rustc_layout_scalar_valid_range_end]
    | help: must be of the form: `#[rustc_layout_scalar_valid_range_end(end)]`
 
 error[E0565]: malformed `marker` attribute input
-  --> $DIR/malformed-attrs.rs:154:1
+  --> $DIR/malformed-attrs.rs:161:1
    |
 LL | #[marker = 3]
    | ^^^^^^^^^---^
@@ -611,7 +611,7 @@ LL | #[marker = 3]
    | help: must be of the form: `#[marker]`
 
 error[E0565]: malformed `fundamental` attribute input
-  --> $DIR/malformed-attrs.rs:156:1
+  --> $DIR/malformed-attrs.rs:163:1
    |
 LL | #[fundamental()]
    | ^^^^^^^^^^^^^--^
@@ -620,7 +620,7 @@ LL | #[fundamental()]
    | help: must be of the form: `#[fundamental]`
 
 error[E0565]: malformed `ffi_pure` attribute input
-  --> $DIR/malformed-attrs.rs:164:5
+  --> $DIR/malformed-attrs.rs:171:5
    |
 LL |     #[unsafe(ffi_pure = 1)]
    |     ^^^^^^^^^^^^^^^^^^---^^
@@ -629,7 +629,7 @@ LL |     #[unsafe(ffi_pure = 1)]
    |     help: must be of the form: `#[ffi_pure]`
 
 error[E0539]: malformed `link_ordinal` attribute input
-  --> $DIR/malformed-attrs.rs:166:5
+  --> $DIR/malformed-attrs.rs:173:5
    |
 LL |     #[link_ordinal]
    |     ^^^^^^^^^^^^^^^
@@ -640,7 +640,7 @@ LL |     #[link_ordinal]
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link_ordinal-attribute>
 
 error[E0565]: malformed `ffi_const` attribute input
-  --> $DIR/malformed-attrs.rs:170:5
+  --> $DIR/malformed-attrs.rs:177:5
    |
 LL |     #[unsafe(ffi_const = 1)]
    |     ^^^^^^^^^^^^^^^^^^^---^^
@@ -649,7 +649,7 @@ LL |     #[unsafe(ffi_const = 1)]
    |     help: must be of the form: `#[ffi_const]`
 
 error[E0539]: malformed `linkage` attribute input
-  --> $DIR/malformed-attrs.rs:172:5
+  --> $DIR/malformed-attrs.rs:179:5
    |
 LL |     #[linkage]
    |     ^^^^^^^^^^ expected this to be of the form `linkage = "..."`
@@ -667,7 +667,7 @@ LL |     #[linkage = "external"]
    = and 5 other candidates
 
 error[E0539]: malformed `debugger_visualizer` attribute input
-  --> $DIR/malformed-attrs.rs:187:1
+  --> $DIR/malformed-attrs.rs:194:1
    |
 LL | #[debugger_visualizer]
    | ^^^^^^^^^^^^^^^^^^^^^^
@@ -678,7 +678,7 @@ LL | #[debugger_visualizer]
    = note: for more information, visit <https://doc.rust-lang.org/reference/attributes/debugger.html#the-debugger_visualizer-attribute>
 
 error[E0565]: malformed `automatically_derived` attribute input
-  --> $DIR/malformed-attrs.rs:189:1
+  --> $DIR/malformed-attrs.rs:196:1
    |
 LL | #[automatically_derived = 18]
    | ^^^^^^^^^^^^^^^^^^^^^^^^----^
@@ -687,7 +687,7 @@ LL | #[automatically_derived = 18]
    | help: must be of the form: `#[automatically_derived]`
 
 error[E0565]: malformed `non_exhaustive` attribute input
-  --> $DIR/malformed-attrs.rs:195:1
+  --> $DIR/malformed-attrs.rs:204:1
    |
 LL | #[non_exhaustive = 1]
    | ^^^^^^^^^^^^^^^^^---^
@@ -696,19 +696,19 @@ LL | #[non_exhaustive = 1]
    | help: must be of the form: `#[non_exhaustive]`
 
 error: valid forms for the attribute are `#[macro_use(name1, name2, ...)]` and `#[macro_use]`
-  --> $DIR/malformed-attrs.rs:207:1
+  --> $DIR/malformed-attrs.rs:216:1
    |
 LL | #[macro_use = 1]
    | ^^^^^^^^^^^^^^^^
 
 error: valid forms for the attribute are `#![macro_export(local_inner_macros)]` and `#![macro_export]`
-  --> $DIR/malformed-attrs.rs:212:1
+  --> $DIR/malformed-attrs.rs:221:1
    |
 LL | #[macro_export = 18]
    | ^^^^^^^^^^^^^^^^^^^^
 
 error[E0565]: malformed `allow_internal_unsafe` attribute input
-  --> $DIR/malformed-attrs.rs:214:1
+  --> $DIR/malformed-attrs.rs:223:1
    |
 LL | #[allow_internal_unsafe = 1]
    | ^^^^^^^^^^^^^^^^^^^^^^^^---^
@@ -717,7 +717,7 @@ LL | #[allow_internal_unsafe = 1]
    | help: must be of the form: `#[allow_internal_unsafe]`
 
 error[E0565]: malformed `type_const` attribute input
-  --> $DIR/malformed-attrs.rs:142:5
+  --> $DIR/malformed-attrs.rs:149:5
    |
 LL |     #[type_const = 1]
    |     ^^^^^^^^^^^^^---^
@@ -737,6 +737,21 @@ LL | |     #[coroutine = 63] || {}
 LL | | }
    | |_- not a `const fn`
 
+warning: attribute should be applied to an `extern` block with non-Rust ABI
+  --> $DIR/malformed-attrs.rs:84:1
+   |
+LL |   #[link]
+   |   ^^^^^^^
+...
+LL | / fn test() {
+LL | |     #[coroutine = 63] || {}
+...  |
+LL | | }
+   | |_- not an `extern` block
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: requested on the command line with `-W unused-attributes`
+
 error: `#[repr(align(...))]` is not supported on functions
   --> $DIR/malformed-attrs.rs:47:1
    |
@@ -750,7 +765,7 @@ LL | #[repr]
    | ^^^^^^^
 
 warning: `#[diagnostic::do_not_recommend]` does not expect any arguments
-  --> $DIR/malformed-attrs.rs:148:1
+  --> $DIR/malformed-attrs.rs:155:1
    |
 LL | #[diagnostic::do_not_recommend()]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -758,7 +773,7 @@ LL | #[diagnostic::do_not_recommend()]
    = note: `#[warn(malformed_diagnostic_attributes)]` (part of `#[warn(unknown_or_malformed_diagnostic_attributes)]`) on by default
 
 warning: missing options for `on_unimplemented` attribute
-  --> $DIR/malformed-attrs.rs:137:1
+  --> $DIR/malformed-attrs.rs:144:1
    |
 LL | #[diagnostic::on_unimplemented]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -766,7 +781,7 @@ LL | #[diagnostic::on_unimplemented]
    = help: at least one of the `message`, `note` and `label` options are expected
 
 warning: malformed `on_unimplemented` attribute
-  --> $DIR/malformed-attrs.rs:139:1
+  --> $DIR/malformed-attrs.rs:146:1
    |
 LL | #[diagnostic::on_unimplemented = 1]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ invalid option found here
@@ -782,8 +797,32 @@ LL | #[inline = 5]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
 
+warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![crate_name]`
+  --> $DIR/malformed-attrs.rs:74:1
+   |
+LL | #[crate_name]
+   | ^^^^^^^^^^^^^
+   |
+note: This attribute does not have an `!`, which means it is applied to this function
+  --> $DIR/malformed-attrs.rs:116:1
+   |
+LL | / fn test() {
+LL | |     #[coroutine = 63] || {}
+...  |
+LL | | }
+   | |_^
+
+warning: `#[link_name]` attribute cannot be used on functions
+  --> $DIR/malformed-attrs.rs:88:1
+   |
+LL | #[link_name]
+   | ^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = help: `#[link_name]` can be applied to foreign functions and foreign statics
+
 error: valid forms for the attribute are `#[ignore = "reason"]` and `#[ignore]`
-  --> $DIR/malformed-attrs.rs:93:1
+  --> $DIR/malformed-attrs.rs:98:1
    |
 LL | #[ignore()]
    | ^^^^^^^^^^^
@@ -791,8 +830,26 @@ LL | #[ignore()]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
 
+warning: `#[no_implicit_prelude]` attribute cannot be used on functions
+  --> $DIR/malformed-attrs.rs:101:1
+   |
+LL | #[no_implicit_prelude = 23]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = help: `#[no_implicit_prelude]` can be applied to crates and modules
+
+warning: `#[automatically_derived]` attribute cannot be used on modules
+  --> $DIR/malformed-attrs.rs:196:1
+   |
+LL | #[automatically_derived = 18]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = help: `#[automatically_derived]` can only be applied to trait impl blocks
+
 error: valid forms for the attribute are `#[ignore = "reason"]` and `#[ignore]`
-  --> $DIR/malformed-attrs.rs:221:1
+  --> $DIR/malformed-attrs.rs:230:1
    |
 LL | #[ignore = 1]
    | ^^^^^^^^^^^^^
@@ -801,7 +858,7 @@ LL | #[ignore = 1]
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
 
 error[E0308]: mismatched types
-  --> $DIR/malformed-attrs.rs:110:23
+  --> $DIR/malformed-attrs.rs:117:23
    |
 LL | fn test() {
    |          - help: a return type might be missing here: `-> _`
@@ -809,9 +866,9 @@ LL |     #[coroutine = 63] || {}
    |                       ^^^^^ expected `()`, found coroutine
    |
    = note: expected unit type `()`
-              found coroutine `{coroutine@$DIR/malformed-attrs.rs:110:23: 110:25}`
+              found coroutine `{coroutine@$DIR/malformed-attrs.rs:117:23: 117:25}`
 
-error: aborting due to 76 previous errors; 3 warnings emitted
+error: aborting due to 76 previous errors; 8 warnings emitted
 
 Some errors have detailed explanations: E0308, E0463, E0539, E0565, E0658, E0805.
 For more information about an error, try `rustc --explain E0308`.
@@ -829,7 +886,7 @@ LL | #[doc]
 
 Future breakage diagnostic:
 error: valid forms for the attribute are `#[doc(hidden)]`, `#[doc(inline)]`, and `#[doc = "string"]`
-  --> $DIR/malformed-attrs.rs:76:1
+  --> $DIR/malformed-attrs.rs:77:1
    |
 LL | #[doc]
    | ^^^^^^
@@ -852,7 +909,7 @@ LL | #[inline = 5]
 
 Future breakage diagnostic:
 error: valid forms for the attribute are `#[ignore = "reason"]` and `#[ignore]`
-  --> $DIR/malformed-attrs.rs:93:1
+  --> $DIR/malformed-attrs.rs:98:1
    |
 LL | #[ignore()]
    | ^^^^^^^^^^^
@@ -863,7 +920,7 @@ LL | #[ignore()]
 
 Future breakage diagnostic:
 error: valid forms for the attribute are `#[ignore = "reason"]` and `#[ignore]`
-  --> $DIR/malformed-attrs.rs:221:1
+  --> $DIR/malformed-attrs.rs:230:1
    |
 LL | #[ignore = 1]
    | ^^^^^^^^^^^^^

--- a/tests/ui/attributes/malformed-no-std.rs
+++ b/tests/ui/attributes/malformed-no-std.rs
@@ -4,14 +4,18 @@
 //~^ ERROR malformed `no_std` attribute input
 #![no_std("bar")]
 //~^ ERROR malformed `no_std` attribute input
+//~| WARN unused attribute
 #![no_std(foo = "bar")]
 //~^ ERROR malformed `no_std` attribute input
+//~| WARN unused attribute
 #![no_core = "foo"]
 //~^ ERROR malformed `no_core` attribute input
 #![no_core("bar")]
 //~^ ERROR malformed `no_core` attribute input
+//~| WARN unused attribute
 #![no_core(foo = "bar")]
 //~^ ERROR malformed `no_core` attribute input
+//~| WARN unused attribute
 
 #[deny(unused_attributes)]
 #[no_std]

--- a/tests/ui/attributes/malformed-no-std.stderr
+++ b/tests/ui/attributes/malformed-no-std.stderr
@@ -17,7 +17,7 @@ LL | #![no_std("bar")]
    | help: must be of the form: `#![no_std]`
 
 error[E0565]: malformed `no_std` attribute input
-  --> $DIR/malformed-no-std.rs:7:1
+  --> $DIR/malformed-no-std.rs:8:1
    |
 LL | #![no_std(foo = "bar")]
    | ^^^^^^^^^-------------^
@@ -26,7 +26,7 @@ LL | #![no_std(foo = "bar")]
    | help: must be of the form: `#![no_std]`
 
 error[E0565]: malformed `no_core` attribute input
-  --> $DIR/malformed-no-std.rs:9:1
+  --> $DIR/malformed-no-std.rs:11:1
    |
 LL | #![no_core = "foo"]
    | ^^^^^^^^^^^-------^
@@ -35,7 +35,7 @@ LL | #![no_core = "foo"]
    | help: must be of the form: `#![no_core]`
 
 error[E0565]: malformed `no_core` attribute input
-  --> $DIR/malformed-no-std.rs:11:1
+  --> $DIR/malformed-no-std.rs:13:1
    |
 LL | #![no_core("bar")]
    | ^^^^^^^^^^-------^
@@ -44,7 +44,7 @@ LL | #![no_core("bar")]
    | help: must be of the form: `#![no_core]`
 
 error[E0565]: malformed `no_core` attribute input
-  --> $DIR/malformed-no-std.rs:13:1
+  --> $DIR/malformed-no-std.rs:16:1
    |
 LL | #![no_core(foo = "bar")]
    | ^^^^^^^^^^-------------^
@@ -53,34 +53,83 @@ LL | #![no_core(foo = "bar")]
    | help: must be of the form: `#![no_core]`
 
 error: crate-level attribute should be an inner attribute: add an exclamation mark: `#![no_std]`
-  --> $DIR/malformed-no-std.rs:17:1
+  --> $DIR/malformed-no-std.rs:21:1
    |
 LL | #[no_std]
    | ^^^^^^^^^
    |
 note: This attribute does not have an `!`, which means it is applied to this extern crate
-  --> $DIR/malformed-no-std.rs:22:1
+  --> $DIR/malformed-no-std.rs:26:1
    |
 LL | extern crate core;
    | ^^^^^^^^^^^^^^^^^^
 note: the lint level is defined here
-  --> $DIR/malformed-no-std.rs:16:8
+  --> $DIR/malformed-no-std.rs:20:8
    |
 LL | #[deny(unused_attributes)]
    |        ^^^^^^^^^^^^^^^^^
 
 error: crate-level attribute should be an inner attribute: add an exclamation mark: `#![no_core]`
-  --> $DIR/malformed-no-std.rs:19:1
+  --> $DIR/malformed-no-std.rs:23:1
    |
 LL | #[no_core]
    | ^^^^^^^^^^
    |
 note: This attribute does not have an `!`, which means it is applied to this extern crate
-  --> $DIR/malformed-no-std.rs:22:1
+  --> $DIR/malformed-no-std.rs:26:1
    |
 LL | extern crate core;
    | ^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 8 previous errors
+warning: unused attribute
+  --> $DIR/malformed-no-std.rs:5:1
+   |
+LL | #![no_std("bar")]
+   | ^^^^^^^^^^^^^^^^^ help: remove this attribute
+   |
+note: attribute also specified here
+  --> $DIR/malformed-no-std.rs:3:1
+   |
+LL | #![no_std = "foo"]
+   | ^^^^^^^^^^^^^^^^^^
+   = note: requested on the command line with `-W unused-attributes`
+
+warning: unused attribute
+  --> $DIR/malformed-no-std.rs:8:1
+   |
+LL | #![no_std(foo = "bar")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^ help: remove this attribute
+   |
+note: attribute also specified here
+  --> $DIR/malformed-no-std.rs:5:1
+   |
+LL | #![no_std("bar")]
+   | ^^^^^^^^^^^^^^^^^
+
+warning: unused attribute
+  --> $DIR/malformed-no-std.rs:13:1
+   |
+LL | #![no_core("bar")]
+   | ^^^^^^^^^^^^^^^^^^ help: remove this attribute
+   |
+note: attribute also specified here
+  --> $DIR/malformed-no-std.rs:11:1
+   |
+LL | #![no_core = "foo"]
+   | ^^^^^^^^^^^^^^^^^^^
+
+warning: unused attribute
+  --> $DIR/malformed-no-std.rs:16:1
+   |
+LL | #![no_core(foo = "bar")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^ help: remove this attribute
+   |
+note: attribute also specified here
+  --> $DIR/malformed-no-std.rs:13:1
+   |
+LL | #![no_core("bar")]
+   | ^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 8 previous errors; 4 warnings emitted
 
 For more information about this error, try `rustc --explain E0565`.

--- a/tests/ui/conditional-compilation/cfg-attr-parse.rs
+++ b/tests/ui/conditional-compilation/cfg-attr-parse.rs
@@ -9,7 +9,8 @@ struct NoConfigurationPredicate;
 struct A0C0;
 
 // Zero attributes, one trailing comma
-#[cfg_attr(all(),)] // Ok
+#[cfg_attr(all(),)]
+//~^ WARN `#[cfg_attr]` does not expand to any attributes
 struct A0C1;
 
 // Zero attributes, two trailing commas

--- a/tests/ui/conditional-compilation/cfg-attr-parse.stderr
+++ b/tests/ui/conditional-compilation/cfg-attr-parse.stderr
@@ -21,7 +21,7 @@ LL | #[cfg_attr(all())]
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute>
 
 error: expected identifier, found `,`
-  --> $DIR/cfg-attr-parse.rs:16:18
+  --> $DIR/cfg-attr-parse.rs:17:18
    |
 LL | #[cfg_attr(all(),,)]
    | -----------------^--
@@ -32,7 +32,7 @@ LL | #[cfg_attr(all(),,)]
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute>
 
 error: expected identifier, found `,`
-  --> $DIR/cfg-attr-parse.rs:28:28
+  --> $DIR/cfg-attr-parse.rs:29:28
    |
 LL | #[cfg_attr(all(), must_use,,)]
    | ---------------------------^--
@@ -43,7 +43,7 @@ LL | #[cfg_attr(all(), must_use,,)]
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute>
 
 error: expected identifier, found `,`
-  --> $DIR/cfg-attr-parse.rs:40:40
+  --> $DIR/cfg-attr-parse.rs:41:40
    |
 LL | #[cfg_attr(all(), must_use, deprecated,,)]
    | ---------------------------------------^--
@@ -54,7 +54,7 @@ LL | #[cfg_attr(all(), must_use, deprecated,,)]
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute>
 
 error: wrong `cfg_attr` delimiters
-  --> $DIR/cfg-attr-parse.rs:44:11
+  --> $DIR/cfg-attr-parse.rs:45:11
    |
 LL | #[cfg_attr[all(),,]]
    |           ^^^^^^^^^
@@ -66,7 +66,7 @@ LL + #[cfg_attr(all(),,)]
    |
 
 error: expected identifier, found `,`
-  --> $DIR/cfg-attr-parse.rs:44:18
+  --> $DIR/cfg-attr-parse.rs:45:18
    |
 LL | #[cfg_attr[all(),,]]
    | -----------------^--
@@ -77,7 +77,7 @@ LL | #[cfg_attr[all(),,]]
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute>
 
 error: wrong `cfg_attr` delimiters
-  --> $DIR/cfg-attr-parse.rs:50:11
+  --> $DIR/cfg-attr-parse.rs:51:11
    |
 LL | #[cfg_attr{all(),,}]
    |           ^^^^^^^^^
@@ -89,7 +89,7 @@ LL + #[cfg_attr(all(),,)]
    |
 
 error: expected identifier, found `,`
-  --> $DIR/cfg-attr-parse.rs:50:18
+  --> $DIR/cfg-attr-parse.rs:51:18
    |
 LL | #[cfg_attr{all(),,}]
    | -----------------^--
@@ -99,6 +99,14 @@ LL | #[cfg_attr{all(),,}]
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute>
 
-error: aborting due to 9 previous errors
+warning: `#[cfg_attr]` does not expand to any attributes
+  --> $DIR/cfg-attr-parse.rs:12:1
+   |
+LL | #[cfg_attr(all(),)]
+   | ^^^^^^^^^^^^^^^^^^^
+   |
+   = note: requested on the command line with `-W unused-attributes`
+
+error: aborting due to 9 previous errors; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0539`.

--- a/tests/ui/conditional-compilation/cfg_attr-attr-syntax-validation.rs
+++ b/tests/ui/conditional-compilation/cfg_attr-attr-syntax-validation.rs
@@ -42,6 +42,8 @@ struct S11;
 struct S12;
 
 #[cfg_attr(true, link_section)] //~ ERROR malformed `link_section` attribute input
+//~^ WARN attribute cannot be used on
+//~| WARN previously accepted
 struct S13;
 
 #[cfg_attr(true, inline())] //~ ERROR malformed `inline` attribute input

--- a/tests/ui/conditional-compilation/cfg_attr-attr-syntax-validation.stderr
+++ b/tests/ui/conditional-compilation/cfg_attr-attr-syntax-validation.stderr
@@ -118,7 +118,7 @@ LL | #[cfg_attr(true, link_section)]
    = note: for more information, visit <https://doc.rust-lang.org/reference/abi.html#the-link_section-attribute>
 
 error[E0805]: malformed `inline` attribute input
-  --> $DIR/cfg_attr-attr-syntax-validation.rs:47:18
+  --> $DIR/cfg_attr-attr-syntax-validation.rs:49:18
    |
 LL | #[cfg_attr(true, inline())]
    |                  ^^^^^^--
@@ -138,7 +138,17 @@ LL - #[cfg_attr(true, inline())]
 LL + #[cfg_attr(true, #[inline])]
    |
 
-error: aborting due to 13 previous errors
+warning: `#[link_section]` attribute cannot be used on structs
+  --> $DIR/cfg_attr-attr-syntax-validation.rs:44:18
+   |
+LL | #[cfg_attr(true, link_section)]
+   |                  ^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = help: `#[link_section]` can be applied to functions and statics
+   = note: requested on the command line with `-W unused-attributes`
+
+error: aborting due to 13 previous errors; 1 warning emitted
 
 Some errors have detailed explanations: E0537, E0539, E0805.
 For more information about an error, try `rustc --explain E0537`.

--- a/tests/ui/cross/cross-file-errors/main.stderr
+++ b/tests/ui/cross/cross-file-errors/main.stderr
@@ -1,5 +1,5 @@
 error: in expressions, `_` can only be used on the left-hand side of an assignment
-  --> $DIR/underscore.rs:6:9
+  --> $DIR/underscore.rs:5:9
    |
 LL |         _
    |         ^ `_` not allowed here

--- a/tests/ui/cross/cross-file-errors/underscore.rs
+++ b/tests/ui/cross/cross-file-errors/underscore.rs
@@ -1,5 +1,4 @@
 //@ ignore-auxiliary (used by `./main.rs`)
-#![crate_type = "lib"]
 
 macro_rules! underscore {
     () => (

--- a/tests/ui/deprecation/deprecated-expr-precedence.rs
+++ b/tests/ui/deprecation/deprecated-expr-precedence.rs
@@ -5,4 +5,6 @@
 pub fn public() {
     #[deprecated] 0
     //~^ ERROR mismatched types
+    //~| WARN attribute cannot be used on expressions
+    //~| WARN previously accepted
 }

--- a/tests/ui/deprecation/deprecated-expr-precedence.stderr
+++ b/tests/ui/deprecation/deprecated-expr-precedence.stderr
@@ -1,3 +1,13 @@
+warning: `#[deprecated]` attribute cannot be used on expressions
+  --> $DIR/deprecated-expr-precedence.rs:6:5
+   |
+LL |     #[deprecated] 0
+   |     ^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = help: `#[deprecated]` can be applied to associated consts, associated types, constants, crates, data types, enum variants, foreign statics, functions, inherent impl blocks, macro defs, modules, statics, struct fields, traits, type aliases, unions, and use statements
+   = note: requested on the command line with `-W unused-attributes`
+
 error[E0308]: mismatched types
   --> $DIR/deprecated-expr-precedence.rs:6:19
    |
@@ -6,6 +16,6 @@ LL | pub fn public() {
 LL |     #[deprecated] 0
    |                   ^ expected `()`, found integer
 
-error: aborting due to 1 previous error
+error: aborting due to 1 previous error; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/empty/empty-macro-use.rs
+++ b/tests/ui/empty/empty-macro-use.rs
@@ -1,6 +1,7 @@
 //@ aux-build:two_macros.rs
 
 #[macro_use()]
+//~^ WARN unused attribute
 extern crate two_macros;
 
 pub fn main() {

--- a/tests/ui/empty/empty-macro-use.stderr
+++ b/tests/ui/empty/empty-macro-use.stderr
@@ -1,5 +1,5 @@
 error: cannot find macro `macro_two` in this scope
-  --> $DIR/empty-macro-use.rs:7:5
+  --> $DIR/empty-macro-use.rs:8:5
    |
 LL |     macro_two!();
    |     ^^^^^^^^^
@@ -9,5 +9,14 @@ help: consider importing this macro
 LL + use two_macros::macro_two;
    |
 
-error: aborting due to 1 previous error
+warning: unused attribute
+  --> $DIR/empty-macro-use.rs:3:12
+   |
+LL | #[macro_use()]
+   |            ^^ help: remove these parentheses
+   |
+   = note: using `macro_use` with an empty list is equivalent to not using a list at all
+   = note: requested on the command line with `-W unused-attributes`
+
+error: aborting due to 1 previous error; 1 warning emitted
 

--- a/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs-error.rs
+++ b/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs-error.rs
@@ -16,15 +16,23 @@
 //~| NOTE: the `#[rustc_main]` attribute is used internally to specify test entry point function
 #![repr()]
 //~^ ERROR: `repr` attribute cannot be used at crate level
+//~| WARN unused attribute
+//~| NOTE empty list has no effect
 #![path = "3800"]
 //~^ ERROR: attribute cannot be used on
 #![automatically_derived]
 //~^ ERROR: attribute cannot be used on
 #![no_mangle]
+//~^ WARN may not be used in combination with `#[export_name]`
+//~| NOTE is ignored
+//~| NOTE requested on the command line
+//~| WARN cannot be used on crates
+//~| WARN previously accepted
 #![no_link]
 //~^ ERROR: attribute should be applied to an `extern crate` item
 #![export_name = "2200"]
 //~^ ERROR: attribute cannot be used on
+//~| NOTE takes precedence
 #![inline]
 //~^ ERROR: attribute cannot be used on
 #[inline]

--- a/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs-error.stderr
+++ b/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs-error.stderr
@@ -25,7 +25,7 @@ LL | #![rustc_main]
    = help: `#[rustc_main]` can only be applied to functions
 
 error: `#[path]` attribute cannot be used on crates
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:19:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:21:1
    |
 LL | #![path = "3800"]
    | ^^^^^^^^^^^^^^^^^
@@ -33,7 +33,7 @@ LL | #![path = "3800"]
    = help: `#[path]` can only be applied to modules
 
 error: `#[automatically_derived]` attribute cannot be used on crates
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:21:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:23:1
    |
 LL | #![automatically_derived]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -41,7 +41,7 @@ LL | #![automatically_derived]
    = help: `#[automatically_derived]` can only be applied to trait impl blocks
 
 error: `#[export_name]` attribute cannot be used on crates
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:26:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:33:1
    |
 LL | #![export_name = "2200"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -49,7 +49,7 @@ LL | #![export_name = "2200"]
    = help: `#[export_name]` can be applied to functions and statics
 
 error: `#[inline]` attribute cannot be used on crates
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:28:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:36:1
    |
 LL | #![inline]
    | ^^^^^^^^^^
@@ -57,7 +57,7 @@ LL | #![inline]
    = help: `#[inline]` can only be applied to functions
 
 error: `#[inline]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:30:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:38:1
    |
 LL | #[inline]
    | ^^^^^^^^^
@@ -65,7 +65,7 @@ LL | #[inline]
    = help: `#[inline]` can only be applied to functions
 
 error: `#[inline]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:35:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:43:17
    |
 LL |     mod inner { #![inline] }
    |                 ^^^^^^^^^^
@@ -73,7 +73,7 @@ LL |     mod inner { #![inline] }
    = help: `#[inline]` can only be applied to functions
 
 error: `#[inline]` attribute cannot be used on structs
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:44:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:52:5
    |
 LL |     #[inline] struct S;
    |     ^^^^^^^^^
@@ -81,7 +81,7 @@ LL |     #[inline] struct S;
    = help: `#[inline]` can only be applied to functions
 
 error: `#[inline]` attribute cannot be used on type aliases
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:47:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:55:5
    |
 LL |     #[inline] type T = S;
    |     ^^^^^^^^^
@@ -89,7 +89,7 @@ LL |     #[inline] type T = S;
    = help: `#[inline]` can only be applied to functions
 
 error: `#[inline]` attribute cannot be used on inherent impl blocks
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:50:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:58:5
    |
 LL |     #[inline] impl S { }
    |     ^^^^^^^^^
@@ -97,7 +97,7 @@ LL |     #[inline] impl S { }
    = help: `#[inline]` can only be applied to functions
 
 error: `#[export_name]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:80:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:88:1
    |
 LL | #[export_name = "2200"]
    | ^^^^^^^^^^^^^^^^^^^^^^^
@@ -105,7 +105,7 @@ LL | #[export_name = "2200"]
    = help: `#[export_name]` can be applied to functions and statics
 
 error: `#[export_name]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:83:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:91:17
    |
 LL |     mod inner { #![export_name="2200"] }
    |                 ^^^^^^^^^^^^^^^^^^^^^^
@@ -113,7 +113,7 @@ LL |     mod inner { #![export_name="2200"] }
    = help: `#[export_name]` can be applied to functions and statics
 
 error: `#[export_name]` attribute cannot be used on structs
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:88:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:96:5
    |
 LL |     #[export_name = "2200"] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^
@@ -121,7 +121,7 @@ LL |     #[export_name = "2200"] struct S;
    = help: `#[export_name]` can be applied to functions and statics
 
 error: `#[export_name]` attribute cannot be used on type aliases
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:91:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:99:5
    |
 LL |     #[export_name = "2200"] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^
@@ -129,7 +129,7 @@ LL |     #[export_name = "2200"] type T = S;
    = help: `#[export_name]` can be applied to functions and statics
 
 error: `#[export_name]` attribute cannot be used on inherent impl blocks
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:94:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:102:5
    |
 LL |     #[export_name = "2200"] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^
@@ -137,7 +137,7 @@ LL |     #[export_name = "2200"] impl S { }
    = help: `#[export_name]` can be applied to functions and statics
 
 error: `#[export_name]` attribute cannot be used on required trait methods
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:98:9
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:106:9
    |
 LL |         #[export_name = "2200"] fn foo();
    |         ^^^^^^^^^^^^^^^^^^^^^^^
@@ -145,7 +145,7 @@ LL |         #[export_name = "2200"] fn foo();
    = help: `#[export_name]` can be applied to functions, inherent methods, provided trait methods, statics, and trait methods in impl blocks
 
 error: attribute should be applied to an `extern crate` item
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:54:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:62:1
    |
 LL |   #[no_link]
    |   ^^^^^^^^^^
@@ -159,7 +159,7 @@ LL | | }
    | |_- not an `extern crate` item
 
 error[E0517]: attribute should be applied to a struct, enum, or union
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:105:8
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:113:8
    |
 LL |   #[repr(C)]
    |          ^
@@ -172,7 +172,7 @@ LL | | }
    | |_- not a struct, enum, or union
 
 error[E0517]: attribute should be applied to a struct, enum, or union
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:129:8
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:137:8
    |
 LL |   #[repr(Rust)]
    |          ^^^^
@@ -185,10 +185,27 @@ LL | | }
    | |_- not a struct, enum, or union
 
 error: attribute should be applied to an `extern crate` item
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:24:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:31:1
    |
 LL | #![no_link]
    | ^^^^^^^^^^^ not an `extern crate` item
+
+warning: `#[no_mangle]` attribute may not be used in combination with `#[export_name]`
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:25:1
+   |
+LL | #![no_mangle]
+   | ^^^^^^^^^^^^^ `#[no_mangle]` is ignored
+   |
+note: `#[export_name]` takes precedence
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:33:1
+   |
+LL | #![export_name = "2200"]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: requested on the command line with `-W unused-attributes`
+help: remove the `#[no_mangle]` attribute
+   |
+LL - #![no_mangle]
+   |
 
 error: `repr` attribute cannot be used at crate level
   --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:17:1
@@ -206,85 +223,85 @@ LL + #[repr()]
    |
 
 error: attribute should be applied to an `extern crate` item
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:59:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:67:17
    |
 LL |     mod inner { #![no_link] }
    |     ------------^^^^^^^^^^^-- not an `extern crate` item
 
 error: attribute should be applied to an `extern crate` item
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:63:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:71:5
    |
 LL |     #[no_link] fn f() { }
    |     ^^^^^^^^^^ ---------- not an `extern crate` item
 
 error: attribute should be applied to an `extern crate` item
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:67:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:75:5
    |
 LL |     #[no_link] struct S;
    |     ^^^^^^^^^^ --------- not an `extern crate` item
 
 error: attribute should be applied to an `extern crate` item
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:71:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:79:5
    |
 LL |     #[no_link]type T = S;
    |     ^^^^^^^^^^----------- not an `extern crate` item
 
 error: attribute should be applied to an `extern crate` item
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:75:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:83:5
    |
 LL |     #[no_link] impl S { }
    |     ^^^^^^^^^^ ---------- not an `extern crate` item
 
 error[E0517]: attribute should be applied to a struct, enum, or union
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:109:25
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:117:25
    |
 LL |     mod inner { #![repr(C)] }
    |     --------------------^---- not a struct, enum, or union
 
 error[E0517]: attribute should be applied to a struct, enum, or union
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:113:12
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:121:12
    |
 LL |     #[repr(C)] fn f() { }
    |            ^   ---------- not a struct, enum, or union
 
 error[E0517]: attribute should be applied to a struct, enum, or union
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:119:12
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:127:12
    |
 LL |     #[repr(C)] type T = S;
    |            ^   ----------- not a struct, enum, or union
 
 error[E0517]: attribute should be applied to a struct, enum, or union
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:123:12
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:131:12
    |
 LL |     #[repr(C)] impl S { }
    |            ^   ---------- not a struct, enum, or union
 
 error[E0517]: attribute should be applied to a struct, enum, or union
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:133:25
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:141:25
    |
 LL |     mod inner { #![repr(Rust)] }
    |     --------------------^^^^---- not a struct, enum, or union
 
 error[E0517]: attribute should be applied to a struct, enum, or union
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:137:12
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:145:12
    |
 LL |     #[repr(Rust)] fn f() { }
    |            ^^^^   ---------- not a struct, enum, or union
 
 error[E0517]: attribute should be applied to a struct, enum, or union
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:143:12
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:151:12
    |
 LL |     #[repr(Rust)] type T = S;
    |            ^^^^   ----------- not a struct, enum, or union
 
 error[E0517]: attribute should be applied to a struct, enum, or union
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:147:12
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:155:12
    |
 LL |     #[repr(Rust)] impl S { }
    |            ^^^^   ---------- not a struct, enum, or union
 
 error: valid forms for the attribute are `#[inline(always)]`, `#[inline(never)]`, and `#[inline]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:38:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:46:5
    |
 LL |     #[inline = "2100"] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^
@@ -293,13 +310,30 @@ LL |     #[inline = "2100"] fn f() { }
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
    = note: `#[deny(ill_formed_attribute_input)]` (part of `#[deny(future_incompatible)]`) on by default
 
-error: aborting due to 37 previous errors
+warning: unused attribute
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:17:1
+   |
+LL | #![repr()]
+   | ^^^^^^^^^^ help: remove this attribute
+   |
+   = note: using `repr` with an empty list has no effect
+
+warning: `#[no_mangle]` attribute cannot be used on crates
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:25:1
+   |
+LL | #![no_mangle]
+   | ^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = help: `#[no_mangle]` can be applied to functions and statics
+
+error: aborting due to 37 previous errors; 3 warnings emitted
 
 Some errors have detailed explanations: E0517, E0658.
 For more information about an error, try `rustc --explain E0517`.
 Future incompatibility report: Future breakage diagnostic:
 error: valid forms for the attribute are `#[inline(always)]`, `#[inline(never)]`, and `#[inline]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:38:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:46:5
    |
 LL |     #[inline = "2100"] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^

--- a/tests/ui/feature-gates/issue-43106-gating-of-macro_use.rs
+++ b/tests/ui/feature-gates/issue-43106-gating-of-macro_use.rs
@@ -14,12 +14,20 @@ mod macro_escape {
 
     #[macro_use = "2700"] struct S;
     //~^ ERROR valid forms for the attribute are `#[macro_use(name1, name2, ...)]` and `#[macro_use]`
+    //~| WARN cannot be used on
+    //~| WARN previously accepted
 
     #[macro_use] fn f() { }
+    //~^ WARN cannot be used on
+    //~| WARN previously accepted
 
     #[macro_use] type T = S;
+    //~^ WARN cannot be used on
+    //~| WARN previously accepted
 
     #[macro_use] impl S { }
+    //~^ WARN cannot be used on
+    //~| WARN previously accepted
 }
 
 fn main() { }

--- a/tests/ui/feature-gates/issue-43106-gating-of-macro_use.stderr
+++ b/tests/ui/feature-gates/issue-43106-gating-of-macro_use.stderr
@@ -22,5 +22,42 @@ error: valid forms for the attribute are `#[macro_use(name1, name2, ...)]` and `
 LL |     #[macro_use = "2700"] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 4 previous errors
+warning: `#[macro_use]` attribute cannot be used on structs
+  --> $DIR/issue-43106-gating-of-macro_use.rs:15:5
+   |
+LL |     #[macro_use = "2700"] struct S;
+   |     ^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = help: `#[macro_use]` can be applied to crates, extern crates, and modules
+   = note: requested on the command line with `-W unused-attributes`
+
+warning: `#[macro_use]` attribute cannot be used on functions
+  --> $DIR/issue-43106-gating-of-macro_use.rs:20:5
+   |
+LL |     #[macro_use] fn f() { }
+   |     ^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = help: `#[macro_use]` can be applied to crates, extern crates, and modules
+
+warning: `#[macro_use]` attribute cannot be used on type aliases
+  --> $DIR/issue-43106-gating-of-macro_use.rs:24:5
+   |
+LL |     #[macro_use] type T = S;
+   |     ^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = help: `#[macro_use]` can be applied to crates, extern crates, and modules
+
+warning: `#[macro_use]` attribute cannot be used on inherent impl blocks
+  --> $DIR/issue-43106-gating-of-macro_use.rs:28:5
+   |
+LL |     #[macro_use] impl S { }
+   |     ^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = help: `#[macro_use]` can be applied to crates, extern crates, and modules
+
+error: aborting due to 4 previous errors; 4 warnings emitted
 

--- a/tests/ui/internal/internal-unstable.rs
+++ b/tests/ui/internal/internal-unstable.rs
@@ -8,6 +8,8 @@ extern crate internal_unstable;
 
 struct Baz {
     #[allow_internal_unstable] //~ ERROR `allow_internal_unstable` expects a list of feature names
+    //~^ WARN cannot be used on
+    //~| WARN previously accepted
     baz: u8,
 }
 
@@ -57,6 +59,8 @@ fn main() {
 
     match true {
         #[allow_internal_unstable] //~ ERROR `allow_internal_unstable` expects a list of feature names
+        //~^ WARN cannot be used on
+        //~| WARN previously accepted
         _ => {}
     }
 

--- a/tests/ui/internal/internal-unstable.stderr
+++ b/tests/ui/internal/internal-unstable.stderr
@@ -5,13 +5,13 @@ LL |     #[allow_internal_unstable]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `allow_internal_unstable` expects a list of feature names
-  --> $DIR/internal-unstable.rs:59:9
+  --> $DIR/internal-unstable.rs:61:9
    |
 LL |         #[allow_internal_unstable]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0658]: use of unstable library feature `function`
-  --> $DIR/internal-unstable.rs:48:25
+  --> $DIR/internal-unstable.rs:50:25
    |
 LL |     pass_through_allow!(internal_unstable::unstable());
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -20,7 +20,7 @@ LL |     pass_through_allow!(internal_unstable::unstable());
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature `function`
-  --> $DIR/internal-unstable.rs:50:27
+  --> $DIR/internal-unstable.rs:52:27
    |
 LL |     pass_through_noallow!(internal_unstable::unstable());
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -29,7 +29,7 @@ LL |     pass_through_noallow!(internal_unstable::unstable());
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature `function`
-  --> $DIR/internal-unstable.rs:54:22
+  --> $DIR/internal-unstable.rs:56:22
    |
 LL |     println!("{:?}", internal_unstable::unstable());
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -38,7 +38,7 @@ LL |     println!("{:?}", internal_unstable::unstable());
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature `function`
-  --> $DIR/internal-unstable.rs:56:10
+  --> $DIR/internal-unstable.rs:58:10
    |
 LL |     bar!(internal_unstable::unstable());
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -47,7 +47,7 @@ LL |     bar!(internal_unstable::unstable());
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature `function`
-  --> $DIR/internal-unstable.rs:18:9
+  --> $DIR/internal-unstable.rs:20:9
    |
 LL |         internal_unstable::unstable();
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -59,6 +59,25 @@ LL |     bar!(internal_unstable::unstable());
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = note: this error originates in the macro `foo` which comes from the expansion of the macro `bar` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 7 previous errors
+warning: `#[allow_internal_unstable]` attribute cannot be used on struct fields
+  --> $DIR/internal-unstable.rs:10:5
+   |
+LL |     #[allow_internal_unstable]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = help: `#[allow_internal_unstable]` can be applied to functions and macro defs
+   = note: requested on the command line with `-W unused-attributes`
+
+warning: `#[allow_internal_unstable]` attribute cannot be used on match arms
+  --> $DIR/internal-unstable.rs:61:9
+   |
+LL |         #[allow_internal_unstable]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = help: `#[allow_internal_unstable]` can be applied to functions and macro defs
+
+error: aborting due to 7 previous errors; 2 warnings emitted
 
 For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/lint/empty-lint-attributes.rs
+++ b/tests/ui/lint/empty-lint-attributes.rs
@@ -3,13 +3,13 @@
 // Empty (and reason-only) lint attributes are legal—although we may want to
 // lint them in the future (Issue #55112).
 
-#![allow()]
-#![warn(reason = "observationalism")]
+#![allow()] //~ WARN unused attribute
+#![warn(reason = "observationalism")] //~ WARN unused attribute
 
-#[forbid()]
+#[forbid()] //~ WARN unused attribute
 fn devoir() {}
 
-#[deny(reason = "ultion")]
+#[deny(reason = "ultion")] //~ WARN unused attribute
 fn waldgrave() {}
 
 fn main() {}

--- a/tests/ui/lint/empty-lint-attributes.stderr
+++ b/tests/ui/lint/empty-lint-attributes.stderr
@@ -1,0 +1,35 @@
+warning: unused attribute
+  --> $DIR/empty-lint-attributes.rs:9:1
+   |
+LL | #[forbid()]
+   | ^^^^^^^^^^^ help: remove this attribute
+   |
+   = note: attribute `forbid` with an empty list has no effect
+   = note: requested on the command line with `-W unused-attributes`
+
+warning: unused attribute
+  --> $DIR/empty-lint-attributes.rs:12:1
+   |
+LL | #[deny(reason = "ultion")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove this attribute
+   |
+   = note: attribute `deny` without any lints has no effect
+
+warning: unused attribute
+  --> $DIR/empty-lint-attributes.rs:6:1
+   |
+LL | #![allow()]
+   | ^^^^^^^^^^^ help: remove this attribute
+   |
+   = note: attribute `allow` with an empty list has no effect
+
+warning: unused attribute
+  --> $DIR/empty-lint-attributes.rs:7:1
+   |
+LL | #![warn(reason = "observationalism")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove this attribute
+   |
+   = note: attribute `warn` without any lints has no effect
+
+warning: 4 warnings emitted
+

--- a/tests/ui/lint/fn_must_use.rs
+++ b/tests/ui/lint/fn_must_use.rs
@@ -39,6 +39,8 @@ impl Replaceable for MyStruct {
     // method won't work; the attribute should be on the method signature in
     // the trait's definition.
     #[must_use]
+    //~^ WARN attribute cannot be used on trait methods in impl blocks
+    //~| WARN previously accepted
     fn replace(&mut self, substitute: usize) -> usize {
         let previously = self.n;
         self.n = substitute;

--- a/tests/ui/lint/fn_must_use.stderr
+++ b/tests/ui/lint/fn_must_use.stderr
@@ -1,5 +1,15 @@
+warning: `#[must_use]` attribute cannot be used on trait methods in impl blocks
+  --> $DIR/fn_must_use.rs:41:5
+   |
+LL |     #[must_use]
+   |     ^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = help: `#[must_use]` can be applied to data types, foreign functions, functions, inherent methods, provided trait methods, required trait methods, traits, and unions
+   = note: requested on the command line with `-W unused-attributes`
+
 warning: unused return value of `need_to_use_this_value` that must be used
-  --> $DIR/fn_must_use.rs:55:5
+  --> $DIR/fn_must_use.rs:57:5
    |
 LL |     need_to_use_this_value();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -16,7 +26,7 @@ LL |     let _ = need_to_use_this_value();
    |     +++++++
 
 warning: unused return value of `MyStruct::need_to_use_this_method_value` that must be used
-  --> $DIR/fn_must_use.rs:60:5
+  --> $DIR/fn_must_use.rs:62:5
    |
 LL |     m.need_to_use_this_method_value();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -27,7 +37,7 @@ LL |     let _ = m.need_to_use_this_method_value();
    |     +++++++
 
 warning: unused return value of `EvenNature::is_even` that must be used
-  --> $DIR/fn_must_use.rs:61:5
+  --> $DIR/fn_must_use.rs:63:5
    |
 LL |     m.is_even(); // trait method!
    |     ^^^^^^^^^^^
@@ -39,7 +49,7 @@ LL |     let _ = m.is_even(); // trait method!
    |     +++++++
 
 warning: unused return value of `MyStruct::need_to_use_this_associated_function_value` that must be used
-  --> $DIR/fn_must_use.rs:64:5
+  --> $DIR/fn_must_use.rs:66:5
    |
 LL |     MyStruct::need_to_use_this_associated_function_value();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -50,7 +60,7 @@ LL |     let _ = MyStruct::need_to_use_this_associated_function_value();
    |     +++++++
 
 warning: unused return value of `std::cmp::PartialEq::eq` that must be used
-  --> $DIR/fn_must_use.rs:70:5
+  --> $DIR/fn_must_use.rs:72:5
    |
 LL |     2.eq(&3);
    |     ^^^^^^^^
@@ -61,7 +71,7 @@ LL |     let _ = 2.eq(&3);
    |     +++++++
 
 warning: unused return value of `std::cmp::PartialEq::eq` that must be used
-  --> $DIR/fn_must_use.rs:71:5
+  --> $DIR/fn_must_use.rs:73:5
    |
 LL |     m.eq(&n);
    |     ^^^^^^^^
@@ -72,7 +82,7 @@ LL |     let _ = m.eq(&n);
    |     +++++++
 
 warning: unused comparison that must be used
-  --> $DIR/fn_must_use.rs:74:5
+  --> $DIR/fn_must_use.rs:76:5
    |
 LL |     2 == 3;
    |     ^^^^^^ the comparison produces a value
@@ -83,7 +93,7 @@ LL |     let _ = 2 == 3;
    |     +++++++
 
 warning: unused comparison that must be used
-  --> $DIR/fn_must_use.rs:75:5
+  --> $DIR/fn_must_use.rs:77:5
    |
 LL |     m == n;
    |     ^^^^^^ the comparison produces a value
@@ -93,5 +103,5 @@ help: use `let _ = ...` to ignore the resulting value
 LL |     let _ = m == n;
    |     +++++++
 
-warning: 8 warnings emitted
+warning: 9 warnings emitted
 

--- a/tests/ui/lint/forbid-error-capped.rs
+++ b/tests/ui/lint/forbid-error-capped.rs
@@ -6,6 +6,8 @@
 
 #![forbid(warnings)]
 #![allow(unused)]
+//~^ WARN allow(unused) incompatible with previous forbid
+//~| WARN previously accepted
 
 #[allow(unused)]
 mod bar {

--- a/tests/ui/lint/forbid-error-capped.stderr
+++ b/tests/ui/lint/forbid-error-capped.stderr
@@ -1,0 +1,27 @@
+warning: allow(unused) incompatible with previous forbid
+  --> $DIR/forbid-error-capped.rs:8:10
+   |
+LL | #![forbid(warnings)]
+   |           -------- `forbid` level set here
+LL | #![allow(unused)]
+   |          ^^^^^^ overruled by previous forbid
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #81670 <https://github.com/rust-lang/rust/issues/81670>
+   = note: `#[warn(forbidden_lint_groups)]` (part of `#[warn(future_incompatible)]`) on by default
+
+warning: 1 warning emitted
+
+Future incompatibility report: Future breakage diagnostic:
+warning: allow(unused) incompatible with previous forbid
+  --> $DIR/forbid-error-capped.rs:8:10
+   |
+LL | #![forbid(warnings)]
+   |           -------- `forbid` level set here
+LL | #![allow(unused)]
+   |          ^^^^^^ overruled by previous forbid
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #81670 <https://github.com/rust-lang/rust/issues/81670>
+   = note: `#[warn(forbidden_lint_groups)]` (part of `#[warn(future_incompatible)]`) on by default
+

--- a/tests/ui/lint/rfc-2383-lint-reason/expect_lint_from_macro.rs
+++ b/tests/ui/lint/rfc-2383-lint-reason/expect_lint_from_macro.rs
@@ -23,7 +23,7 @@ pub fn check_expect_on_item() {
 
 pub fn check_expect_on_macro() {
     // This should be fulfilled by the macro
-    #[expect(unused_variables)]
+    #[expect(unused_variables)] //~ WARN unused attribute
     trigger_unused_variables_macro!();
 
     // FIXME: Lint attributes currently don't work directly on macros, and

--- a/tests/ui/lint/rfc-2383-lint-reason/expect_lint_from_macro.stderr
+++ b/tests/ui/lint/rfc-2383-lint-reason/expect_lint_from_macro.stderr
@@ -1,3 +1,16 @@
+warning: unused attribute `expect`
+  --> $DIR/expect_lint_from_macro.rs:26:5
+   |
+LL |     #[expect(unused_variables)]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: the built-in attribute `expect` will be ignored, since it's applied to the macro invocation `trigger_unused_variables_macro`
+  --> $DIR/expect_lint_from_macro.rs:27:5
+   |
+LL |     trigger_unused_variables_macro!();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: requested on the command line with `-W unused-attributes`
+
 warning: unused variable: `x`
   --> $DIR/expect_lint_from_macro.rs:7:13
    |
@@ -41,5 +54,5 @@ LL |     trigger_unused_variables_macro!();
    |     --------------------------------- in this macro invocation
    = note: this warning originates in the macro `trigger_unused_variables_macro` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-warning: 2 warnings emitted
+warning: 3 warnings emitted
 

--- a/tests/ui/lint/semicolon-in-expressions-from-macros/semicolon-in-expressions-from-macros.rs
+++ b/tests/ui/lint/semicolon-in-expressions-from-macros/semicolon-in-expressions-from-macros.rs
@@ -48,4 +48,5 @@ fn main() {
     // This `#[allow]` does not work, since the attribute gets dropped
     // when we expand the macro
     let _ = #[allow(semicolon_in_expressions_from_macros)] foo!(allow_does_not_work);
+    //~^ WARN unused attribute
 }

--- a/tests/ui/lint/semicolon-in-expressions-from-macros/semicolon-in-expressions-from-macros.stderr
+++ b/tests/ui/lint/semicolon-in-expressions-from-macros/semicolon-in-expressions-from-macros.stderr
@@ -31,6 +31,19 @@ LL |     let _ = foo!(warn_in_expr);
    = note: for more information, see issue #79813 <https://github.com/rust-lang/rust/issues/79813>
    = note: this warning originates in the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)
 
+warning: unused attribute `allow`
+  --> $DIR/semicolon-in-expressions-from-macros.rs:50:13
+   |
+LL |     let _ = #[allow(semicolon_in_expressions_from_macros)] foo!(allow_does_not_work);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: the built-in attribute `allow` will be ignored, since it's applied to the macro invocation `foo`
+  --> $DIR/semicolon-in-expressions-from-macros.rs:50:60
+   |
+LL |     let _ = #[allow(semicolon_in_expressions_from_macros)] foo!(allow_does_not_work);
+   |                                                            ^^^
+   = note: requested on the command line with `-W unused-attributes`
+
 warning: trailing semicolon in macro used in expression position
   --> $DIR/semicolon-in-expressions-from-macros.rs:9:13
    |
@@ -44,7 +57,7 @@ LL |     let _ = #[allow(semicolon_in_expressions_from_macros)] foo!(allow_does_
    = note: for more information, see issue #79813 <https://github.com/rust-lang/rust/issues/79813>
    = note: this warning originates in the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-warning: 3 warnings emitted
+warning: 4 warnings emitted
 
 Future incompatibility report: Future breakage diagnostic:
 warning: trailing semicolon in macro used in expression position

--- a/tests/ui/malformed/malformed-regressions.rs
+++ b/tests/ui/malformed/malformed-regressions.rs
@@ -5,6 +5,8 @@
 #[inline = ""] //~ ERROR valid forms for the attribute are
 //~^ WARN this was previously accepted
 #[link] //~ ERROR malformed
+//~^ WARN attribute should be applied to an `extern` block with non-Rust ABI
+//~| WARN previously accepted
 #[link = ""] //~ ERROR malformed
 
 fn main() {}

--- a/tests/ui/malformed/malformed-regressions.stderr
+++ b/tests/ui/malformed/malformed-regressions.stderr
@@ -29,7 +29,7 @@ LL | #[link(name = "...", kind = "dylib|static|...", wasm_import_module = "...",
    = and 1 other candidate
 
 error[E0539]: malformed `link` attribute input
-  --> $DIR/malformed-regressions.rs:8:1
+  --> $DIR/malformed-regressions.rs:10:1
    |
 LL | #[link = ""]
    | ^^^^^^^^^^^^ expected this to be a list
@@ -51,6 +51,18 @@ LL + #[link(name = "...", kind = "dylib|static|...", wasm_import_module = "...",
    |
    = and 1 other candidate
 
+warning: attribute should be applied to an `extern` block with non-Rust ABI
+  --> $DIR/malformed-regressions.rs:7:1
+   |
+LL | #[link]
+   | ^^^^^^^
+...
+LL | fn main() {}
+   | ------------ not an `extern` block
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: requested on the command line with `-W unused-attributes`
+
 error: valid forms for the attribute are `#[ignore = "reason"]` and `#[ignore]`
   --> $DIR/malformed-regressions.rs:3:1
    |
@@ -69,7 +81,7 @@ LL | #[inline = ""]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
 
-error: aborting due to 5 previous errors
+error: aborting due to 5 previous errors; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0539`.
 Future incompatibility report: Future breakage diagnostic:

--- a/tests/ui/parser/inner-attr.rs
+++ b/tests/ui/parser/inner-attr.rs
@@ -1,4 +1,4 @@
-#[feature(lang_items)]
+#[feature(lang_items)] //~ WARN crate-level attribute should be an inner attribute
 
 #![recursion_limit="100"] //~ ERROR an inner attribute is not permitted following an outer attribute
 fn main() {}

--- a/tests/ui/parser/inner-attr.stderr
+++ b/tests/ui/parser/inner-attr.stderr
@@ -11,5 +11,17 @@ LL | fn main() {}
    |
    = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files
 
-error: aborting due to 1 previous error
+warning: crate-level attribute should be an inner attribute
+  --> $DIR/inner-attr.rs:1:1
+   |
+LL | #[feature(lang_items)]
+   | ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: requested on the command line with `-W unused-attributes`
+help: add a `!`
+   |
+LL | #![feature(lang_items)]
+   |  +
+
+error: aborting due to 1 previous error; 1 warning emitted
 

--- a/tests/ui/proc-macro/cfg-eval.rs
+++ b/tests/ui/proc-macro/cfg-eval.rs
@@ -19,7 +19,7 @@ struct S1 {
     field_false: u8,
     #[cfg(all(/*true*/))]
     #[cfg_attr(FALSE, unknown_attr)]
-    #[cfg_attr(all(/*true*/), allow())]
+    #[cfg_attr(all(/*true*/), allow())] //~ WARN unused attribute
     field_true: u8,
 }
 

--- a/tests/ui/proc-macro/cfg-eval.stderr
+++ b/tests/ui/proc-macro/cfg-eval.stderr
@@ -1,0 +1,11 @@
+warning: unused attribute
+  --> $DIR/cfg-eval.rs:22:5
+   |
+LL |     #[cfg_attr(all(/*true*/), allow())]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove this attribute
+   |
+   = note: attribute `allow` with an empty list has no effect
+   = note: requested on the command line with `-W unused-attributes`
+
+warning: 1 warning emitted
+

--- a/tests/ui/repr/attr-usage-repr.rs
+++ b/tests/ui/repr/attr-usage-repr.rs
@@ -46,9 +46,11 @@ enum EInt {
 }
 
 #[repr()] //~ ERROR attribute should be applied to a struct, enum, or union [E0517]
+//~^ WARN unused attribute
 type SirThisIsAType = i32;
 
 #[repr()]
+//~^ WARN unused attribute
 struct EmptyReprArgumentList(i32);
 
 fn main() {}

--- a/tests/ui/repr/attr-usage-repr.stderr
+++ b/tests/ui/repr/attr-usage-repr.stderr
@@ -41,9 +41,27 @@ error[E0517]: attribute should be applied to a struct, enum, or union
    |
 LL | #[repr()]
    | ^^^^^^^^^
+LL |
 LL | type SirThisIsAType = i32;
    | -------------------------- not a struct, enum, or union
 
-error: aborting due to 5 previous errors
+warning: unused attribute
+  --> $DIR/attr-usage-repr.rs:48:1
+   |
+LL | #[repr()]
+   | ^^^^^^^^^ help: remove this attribute
+   |
+   = note: using `repr` with an empty list has no effect
+   = note: requested on the command line with `-W unused-attributes`
+
+warning: unused attribute
+  --> $DIR/attr-usage-repr.rs:52:1
+   |
+LL | #[repr()]
+   | ^^^^^^^^^ help: remove this attribute
+   |
+   = note: using `repr` with an empty list has no effect
+
+error: aborting due to 5 previous errors; 2 warnings emitted
 
 For more information about this error, try `rustc --explain E0517`.

--- a/tests/ui/rfcs/rfc-2091-track-caller/macro-declaration.rs
+++ b/tests/ui/rfcs/rfc-2091-track-caller/macro-declaration.rs
@@ -2,6 +2,8 @@
 
 // See https://github.com/rust-lang/rust/issues/95151
 #[track_caller]
+//~^ WARN attribute cannot be used on macro defs
+//~| WARN previously accepted
 macro_rules! _foo {
     () => {};
 }

--- a/tests/ui/rfcs/rfc-2091-track-caller/macro-declaration.stderr
+++ b/tests/ui/rfcs/rfc-2091-track-caller/macro-declaration.stderr
@@ -1,0 +1,12 @@
+warning: `#[track_caller]` attribute cannot be used on macro defs
+  --> $DIR/macro-declaration.rs:4:1
+   |
+LL | #[track_caller]
+   | ^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = help: `#[track_caller]` can only be applied to functions
+   = note: requested on the command line with `-W unused-attributes`
+
+warning: 1 warning emitted
+

--- a/tests/ui/rfcs/rfc-2565-param-attrs/param-attrs-builtin-attrs.rs
+++ b/tests/ui/rfcs/rfc-2565-param-attrs/param-attrs-builtin-attrs.rs
@@ -39,10 +39,14 @@ pub fn foo(
     //~^ ERROR documentation comments cannot be applied to function
     #[must_use]
     //~^ ERROR allow, cfg, cfg_attr, deny, expect, forbid, and warn are the only allowed built-in attributes in function parameters
+    //~| WARN attribute cannot be used on
+    //~| WARN previously accepted
     /// Baz
     //~^ ERROR documentation comments cannot be applied to function
     #[no_mangle] b: i32,
     //~^ ERROR allow, cfg, cfg_attr, deny, expect, forbid, and warn are the only allowed built-in attributes in function parameters
+    //~| WARN attribute cannot be used on
+    //~| WARN previously accepted
 ) {}
 
 struct SelfStruct {}
@@ -59,10 +63,14 @@ impl SelfStruct {
         //~^ ERROR documentation comments cannot be applied to function
         #[must_use]
         //~^ ERROR allow, cfg, cfg_attr, deny, expect, forbid, and warn are the only allowed built-in attributes in function parameters
+        //~| WARN attribute cannot be used on
+        //~| WARN previously accepted
         /// Qux
         //~^ ERROR documentation comments cannot be applied to function
         #[no_mangle] b: i32,
         //~^ ERROR allow, cfg, cfg_attr, deny, expect, forbid, and warn are the only allowed built-in attributes in function parameters
+        //~| WARN attribute cannot be used on
+        //~| WARN previously accepted
     ) {}
 
     fn issue_64682_associated_fn(
@@ -74,10 +82,14 @@ impl SelfStruct {
         //~^ ERROR documentation comments cannot be applied to function
         #[must_use]
         //~^ ERROR allow, cfg, cfg_attr, deny, expect, forbid, and warn are the only allowed built-in attributes in function parameters
+        //~| WARN attribute cannot be used on
+        //~| WARN previously accepted
         /// Qux
         //~^ ERROR documentation comments cannot be applied to function
         #[no_mangle] b: i32,
         //~^ ERROR allow, cfg, cfg_attr, deny, expect, forbid, and warn are the only allowed built-in attributes in function parameters
+        //~| WARN attribute cannot be used on
+        //~| WARN previously accepted
     ) {}
 }
 
@@ -95,10 +107,14 @@ impl RefStruct {
         //~^ ERROR documentation comments cannot be applied to function
         #[must_use]
         //~^ ERROR allow, cfg, cfg_attr, deny, expect, forbid, and warn are the only allowed built-in attributes in function parameters
+        //~| WARN attribute cannot be used on
+        //~| WARN previously accepted
         /// Qux
         //~^ ERROR documentation comments cannot be applied to function
         #[no_mangle] b: i32,
         //~^ ERROR allow, cfg, cfg_attr, deny, expect, forbid, and warn are the only allowed built-in attributes in function parameters
+        //~| WARN attribute cannot be used on
+        //~| WARN previously accepted
     ) {}
 }
 trait RefTrait {
@@ -114,10 +130,14 @@ trait RefTrait {
         //~^ ERROR documentation comments cannot be applied to function
         #[must_use]
         //~^ ERROR allow, cfg, cfg_attr, deny, expect, forbid, and warn are the only allowed built-in attributes in function parameters
+        //~| WARN attribute cannot be used on
+        //~| WARN previously accepted
         /// Qux
         //~^ ERROR documentation comments cannot be applied to function
         #[no_mangle] b: i32,
         //~^ ERROR allow, cfg, cfg_attr, deny, expect, forbid, and warn are the only allowed built-in attributes in function parameters
+        //~| WARN attribute cannot be used on
+        //~| WARN previously accepted
     ) {}
 
     fn issue_64682_associated_fn(
@@ -129,10 +149,14 @@ trait RefTrait {
         //~^ ERROR documentation comments cannot be applied to function
         #[must_use]
         //~^ ERROR allow, cfg, cfg_attr, deny, expect, forbid, and warn are the only allowed built-in attributes in function parameters
+        //~| WARN attribute cannot be used on
+        //~| WARN previously accepted
         /// Qux
         //~^ ERROR documentation comments cannot be applied to function
         #[no_mangle] b: i32,
         //~^ ERROR allow, cfg, cfg_attr, deny, expect, forbid, and warn are the only allowed built-in attributes in function parameters
+        //~| WARN attribute cannot be used on
+        //~| WARN previously accepted
     ) {}
 }
 
@@ -149,10 +173,14 @@ impl RefTrait for RefStruct {
         //~^ ERROR documentation comments cannot be applied to function
         #[must_use]
         //~^ ERROR allow, cfg, cfg_attr, deny, expect, forbid, and warn are the only allowed built-in attributes in function parameters
+        //~| WARN attribute cannot be used on
+        //~| WARN previously accepted
         /// Qux
         //~^ ERROR documentation comments cannot be applied to function
         #[no_mangle] b: i32,
         //~^ ERROR allow, cfg, cfg_attr, deny, expect, forbid, and warn are the only allowed built-in attributes in function parameters
+        //~| WARN attribute cannot be used on
+        //~| WARN previously accepted
     ) {}
 }
 
@@ -166,9 +194,13 @@ fn main() {
         //~^ ERROR documentation comments cannot be applied to function
         #[must_use]
         //~^ ERROR allow, cfg, cfg_attr, deny, expect, forbid, and warn are the only allowed built-in attributes in function parameters
+        //~| WARN attribute cannot be used on
+        //~| WARN previously accepted
         /// Baz
         //~^ ERROR documentation comments cannot be applied to function
         #[no_mangle] b: i32
         //~^ ERROR allow, cfg, cfg_attr, deny, expect, forbid, and warn are the only allowed built-in attributes in function parameters
+        //~| WARN attribute cannot be used on
+        //~| WARN previously accepted
     | {};
 }

--- a/tests/ui/rfcs/rfc-2565-param-attrs/param-attrs-builtin-attrs.stderr
+++ b/tests/ui/rfcs/rfc-2565-param-attrs/param-attrs-builtin-attrs.stderr
@@ -17,31 +17,25 @@ LL |     #[test] a: u32,
    |       ^^^^ not a non-macro attribute
 
 error: expected non-macro attribute, found attribute macro `test`
-  --> $DIR/param-attrs-builtin-attrs.rs:56:11
+  --> $DIR/param-attrs-builtin-attrs.rs:60:11
    |
 LL |         #[test] a: i32,
    |           ^^^^ not a non-macro attribute
 
 error: expected non-macro attribute, found attribute macro `test`
-  --> $DIR/param-attrs-builtin-attrs.rs:71:11
+  --> $DIR/param-attrs-builtin-attrs.rs:79:11
    |
 LL |         #[test] a: i32,
    |           ^^^^ not a non-macro attribute
 
 error: expected non-macro attribute, found attribute macro `test`
-  --> $DIR/param-attrs-builtin-attrs.rs:92:11
+  --> $DIR/param-attrs-builtin-attrs.rs:104:11
    |
 LL |         #[test] a: i32,
    |           ^^^^ not a non-macro attribute
 
 error: expected non-macro attribute, found attribute macro `test`
-  --> $DIR/param-attrs-builtin-attrs.rs:111:11
-   |
-LL |         #[test] a: i32,
-   |           ^^^^ not a non-macro attribute
-
-error: expected non-macro attribute, found attribute macro `test`
-  --> $DIR/param-attrs-builtin-attrs.rs:126:11
+  --> $DIR/param-attrs-builtin-attrs.rs:127:11
    |
 LL |         #[test] a: i32,
    |           ^^^^ not a non-macro attribute
@@ -53,7 +47,13 @@ LL |         #[test] a: i32,
    |           ^^^^ not a non-macro attribute
 
 error: expected non-macro attribute, found attribute macro `test`
-  --> $DIR/param-attrs-builtin-attrs.rs:163:11
+  --> $DIR/param-attrs-builtin-attrs.rs:170:11
+   |
+LL |         #[test] a: i32,
+   |           ^^^^ not a non-macro attribute
+
+error: expected non-macro attribute, found attribute macro `test`
+  --> $DIR/param-attrs-builtin-attrs.rs:191:11
    |
 LL |         #[test] a: u32,
    |           ^^^^ not a non-macro attribute
@@ -137,195 +137,159 @@ LL |     #[must_use]
    |     ^^^^^^^^^^^
 
 error: documentation comments cannot be applied to function parameters
-  --> $DIR/param-attrs-builtin-attrs.rs:42:5
+  --> $DIR/param-attrs-builtin-attrs.rs:44:5
    |
 LL |     /// Baz
    |     ^^^^^^^ doc comments are not allowed here
 
 error: allow, cfg, cfg_attr, deny, expect, forbid, and warn are the only allowed built-in attributes in function parameters
-  --> $DIR/param-attrs-builtin-attrs.rs:44:5
+  --> $DIR/param-attrs-builtin-attrs.rs:46:5
    |
 LL |     #[no_mangle] b: i32,
    |     ^^^^^^^^^^^^
 
 error: documentation comments cannot be applied to function parameters
-  --> $DIR/param-attrs-builtin-attrs.rs:51:9
+  --> $DIR/param-attrs-builtin-attrs.rs:55:9
    |
 LL |         /// Foo
-   |         ^^^^^^^ doc comments are not allowed here
-
-error: documentation comments cannot be applied to function parameters
-  --> $DIR/param-attrs-builtin-attrs.rs:54:9
-   |
-LL |         /// Bar
    |         ^^^^^^^ doc comments are not allowed here
 
 error: documentation comments cannot be applied to function parameters
   --> $DIR/param-attrs-builtin-attrs.rs:58:9
    |
-LL |         /// Baz
+LL |         /// Bar
    |         ^^^^^^^ doc comments are not allowed here
-
-error: allow, cfg, cfg_attr, deny, expect, forbid, and warn are the only allowed built-in attributes in function parameters
-  --> $DIR/param-attrs-builtin-attrs.rs:60:9
-   |
-LL |         #[must_use]
-   |         ^^^^^^^^^^^
 
 error: documentation comments cannot be applied to function parameters
   --> $DIR/param-attrs-builtin-attrs.rs:62:9
    |
-LL |         /// Qux
+LL |         /// Baz
    |         ^^^^^^^ doc comments are not allowed here
 
 error: allow, cfg, cfg_attr, deny, expect, forbid, and warn are the only allowed built-in attributes in function parameters
   --> $DIR/param-attrs-builtin-attrs.rs:64:9
    |
-LL |         #[no_mangle] b: i32,
-   |         ^^^^^^^^^^^^
+LL |         #[must_use]
+   |         ^^^^^^^^^^^
 
 error: documentation comments cannot be applied to function parameters
-  --> $DIR/param-attrs-builtin-attrs.rs:69:9
+  --> $DIR/param-attrs-builtin-attrs.rs:68:9
    |
-LL |         /// Foo
-   |         ^^^^^^^ doc comments are not allowed here
-
-error: documentation comments cannot be applied to function parameters
-  --> $DIR/param-attrs-builtin-attrs.rs:73:9
-   |
-LL |         /// Baz
+LL |         /// Qux
    |         ^^^^^^^ doc comments are not allowed here
 
 error: allow, cfg, cfg_attr, deny, expect, forbid, and warn are the only allowed built-in attributes in function parameters
-  --> $DIR/param-attrs-builtin-attrs.rs:75:9
+  --> $DIR/param-attrs-builtin-attrs.rs:70:9
    |
-LL |         #[must_use]
-   |         ^^^^^^^^^^^
+LL |         #[no_mangle] b: i32,
+   |         ^^^^^^^^^^^^
 
 error: documentation comments cannot be applied to function parameters
   --> $DIR/param-attrs-builtin-attrs.rs:77:9
    |
-LL |         /// Qux
+LL |         /// Foo
+   |         ^^^^^^^ doc comments are not allowed here
+
+error: documentation comments cannot be applied to function parameters
+  --> $DIR/param-attrs-builtin-attrs.rs:81:9
+   |
+LL |         /// Baz
    |         ^^^^^^^ doc comments are not allowed here
 
 error: allow, cfg, cfg_attr, deny, expect, forbid, and warn are the only allowed built-in attributes in function parameters
-  --> $DIR/param-attrs-builtin-attrs.rs:79:9
+  --> $DIR/param-attrs-builtin-attrs.rs:83:9
    |
-LL |         #[no_mangle] b: i32,
-   |         ^^^^^^^^^^^^
+LL |         #[must_use]
+   |         ^^^^^^^^^^^
 
 error: documentation comments cannot be applied to function parameters
   --> $DIR/param-attrs-builtin-attrs.rs:87:9
    |
-LL |         /// Foo
-   |         ^^^^^^^ doc comments are not allowed here
-
-error: documentation comments cannot be applied to function parameters
-  --> $DIR/param-attrs-builtin-attrs.rs:90:9
-   |
-LL |         /// Bar
-   |         ^^^^^^^ doc comments are not allowed here
-
-error: documentation comments cannot be applied to function parameters
-  --> $DIR/param-attrs-builtin-attrs.rs:94:9
-   |
-LL |         /// Baz
-   |         ^^^^^^^ doc comments are not allowed here
-
-error: allow, cfg, cfg_attr, deny, expect, forbid, and warn are the only allowed built-in attributes in function parameters
-  --> $DIR/param-attrs-builtin-attrs.rs:96:9
-   |
-LL |         #[must_use]
-   |         ^^^^^^^^^^^
-
-error: documentation comments cannot be applied to function parameters
-  --> $DIR/param-attrs-builtin-attrs.rs:98:9
-   |
 LL |         /// Qux
    |         ^^^^^^^ doc comments are not allowed here
 
 error: allow, cfg, cfg_attr, deny, expect, forbid, and warn are the only allowed built-in attributes in function parameters
-  --> $DIR/param-attrs-builtin-attrs.rs:100:9
+  --> $DIR/param-attrs-builtin-attrs.rs:89:9
    |
 LL |         #[no_mangle] b: i32,
    |         ^^^^^^^^^^^^
+
+error: documentation comments cannot be applied to function parameters
+  --> $DIR/param-attrs-builtin-attrs.rs:99:9
+   |
+LL |         /// Foo
+   |         ^^^^^^^ doc comments are not allowed here
+
+error: documentation comments cannot be applied to function parameters
+  --> $DIR/param-attrs-builtin-attrs.rs:102:9
+   |
+LL |         /// Bar
+   |         ^^^^^^^ doc comments are not allowed here
 
 error: documentation comments cannot be applied to function parameters
   --> $DIR/param-attrs-builtin-attrs.rs:106:9
    |
+LL |         /// Baz
+   |         ^^^^^^^ doc comments are not allowed here
+
+error: allow, cfg, cfg_attr, deny, expect, forbid, and warn are the only allowed built-in attributes in function parameters
+  --> $DIR/param-attrs-builtin-attrs.rs:108:9
+   |
+LL |         #[must_use]
+   |         ^^^^^^^^^^^
+
+error: documentation comments cannot be applied to function parameters
+  --> $DIR/param-attrs-builtin-attrs.rs:112:9
+   |
+LL |         /// Qux
+   |         ^^^^^^^ doc comments are not allowed here
+
+error: allow, cfg, cfg_attr, deny, expect, forbid, and warn are the only allowed built-in attributes in function parameters
+  --> $DIR/param-attrs-builtin-attrs.rs:114:9
+   |
+LL |         #[no_mangle] b: i32,
+   |         ^^^^^^^^^^^^
+
+error: documentation comments cannot be applied to function parameters
+  --> $DIR/param-attrs-builtin-attrs.rs:122:9
+   |
 LL |         /// Foo
    |         ^^^^^^^ doc comments are not allowed here
 
 error: documentation comments cannot be applied to function parameters
-  --> $DIR/param-attrs-builtin-attrs.rs:109:9
+  --> $DIR/param-attrs-builtin-attrs.rs:125:9
    |
 LL |         /// Bar
    |         ^^^^^^^ doc comments are not allowed here
 
 error: documentation comments cannot be applied to function parameters
-  --> $DIR/param-attrs-builtin-attrs.rs:113:9
+  --> $DIR/param-attrs-builtin-attrs.rs:129:9
    |
 LL |         /// Baz
    |         ^^^^^^^ doc comments are not allowed here
 
 error: allow, cfg, cfg_attr, deny, expect, forbid, and warn are the only allowed built-in attributes in function parameters
-  --> $DIR/param-attrs-builtin-attrs.rs:115:9
+  --> $DIR/param-attrs-builtin-attrs.rs:131:9
    |
 LL |         #[must_use]
    |         ^^^^^^^^^^^
 
 error: documentation comments cannot be applied to function parameters
-  --> $DIR/param-attrs-builtin-attrs.rs:117:9
+  --> $DIR/param-attrs-builtin-attrs.rs:135:9
    |
 LL |         /// Qux
    |         ^^^^^^^ doc comments are not allowed here
 
 error: allow, cfg, cfg_attr, deny, expect, forbid, and warn are the only allowed built-in attributes in function parameters
-  --> $DIR/param-attrs-builtin-attrs.rs:119:9
+  --> $DIR/param-attrs-builtin-attrs.rs:137:9
    |
 LL |         #[no_mangle] b: i32,
    |         ^^^^^^^^^^^^
-
-error: documentation comments cannot be applied to function parameters
-  --> $DIR/param-attrs-builtin-attrs.rs:124:9
-   |
-LL |         /// Foo
-   |         ^^^^^^^ doc comments are not allowed here
-
-error: documentation comments cannot be applied to function parameters
-  --> $DIR/param-attrs-builtin-attrs.rs:128:9
-   |
-LL |         /// Baz
-   |         ^^^^^^^ doc comments are not allowed here
-
-error: allow, cfg, cfg_attr, deny, expect, forbid, and warn are the only allowed built-in attributes in function parameters
-  --> $DIR/param-attrs-builtin-attrs.rs:130:9
-   |
-LL |         #[must_use]
-   |         ^^^^^^^^^^^
-
-error: documentation comments cannot be applied to function parameters
-  --> $DIR/param-attrs-builtin-attrs.rs:132:9
-   |
-LL |         /// Qux
-   |         ^^^^^^^ doc comments are not allowed here
-
-error: allow, cfg, cfg_attr, deny, expect, forbid, and warn are the only allowed built-in attributes in function parameters
-  --> $DIR/param-attrs-builtin-attrs.rs:134:9
-   |
-LL |         #[no_mangle] b: i32,
-   |         ^^^^^^^^^^^^
-
-error: documentation comments cannot be applied to function parameters
-  --> $DIR/param-attrs-builtin-attrs.rs:141:9
-   |
-LL |         /// Foo
-   |         ^^^^^^^ doc comments are not allowed here
 
 error: documentation comments cannot be applied to function parameters
   --> $DIR/param-attrs-builtin-attrs.rs:144:9
    |
-LL |         /// Bar
+LL |         /// Foo
    |         ^^^^^^^ doc comments are not allowed here
 
 error: documentation comments cannot be applied to function parameters
@@ -341,46 +305,227 @@ LL |         #[must_use]
    |         ^^^^^^^^^^^
 
 error: documentation comments cannot be applied to function parameters
-  --> $DIR/param-attrs-builtin-attrs.rs:152:9
+  --> $DIR/param-attrs-builtin-attrs.rs:154:9
    |
 LL |         /// Qux
    |         ^^^^^^^ doc comments are not allowed here
 
 error: allow, cfg, cfg_attr, deny, expect, forbid, and warn are the only allowed built-in attributes in function parameters
-  --> $DIR/param-attrs-builtin-attrs.rs:154:9
+  --> $DIR/param-attrs-builtin-attrs.rs:156:9
    |
 LL |         #[no_mangle] b: i32,
    |         ^^^^^^^^^^^^
 
 error: documentation comments cannot be applied to function parameters
-  --> $DIR/param-attrs-builtin-attrs.rs:161:9
+  --> $DIR/param-attrs-builtin-attrs.rs:165:9
    |
 LL |         /// Foo
    |         ^^^^^^^ doc comments are not allowed here
 
 error: documentation comments cannot be applied to function parameters
-  --> $DIR/param-attrs-builtin-attrs.rs:165:9
+  --> $DIR/param-attrs-builtin-attrs.rs:168:9
    |
 LL |         /// Bar
    |         ^^^^^^^ doc comments are not allowed here
 
-error: allow, cfg, cfg_attr, deny, expect, forbid, and warn are the only allowed built-in attributes in function parameters
-  --> $DIR/param-attrs-builtin-attrs.rs:167:9
-   |
-LL |         #[must_use]
-   |         ^^^^^^^^^^^
-
 error: documentation comments cannot be applied to function parameters
-  --> $DIR/param-attrs-builtin-attrs.rs:169:9
+  --> $DIR/param-attrs-builtin-attrs.rs:172:9
    |
 LL |         /// Baz
    |         ^^^^^^^ doc comments are not allowed here
 
 error: allow, cfg, cfg_attr, deny, expect, forbid, and warn are the only allowed built-in attributes in function parameters
-  --> $DIR/param-attrs-builtin-attrs.rs:171:9
+  --> $DIR/param-attrs-builtin-attrs.rs:174:9
+   |
+LL |         #[must_use]
+   |         ^^^^^^^^^^^
+
+error: documentation comments cannot be applied to function parameters
+  --> $DIR/param-attrs-builtin-attrs.rs:178:9
+   |
+LL |         /// Qux
+   |         ^^^^^^^ doc comments are not allowed here
+
+error: allow, cfg, cfg_attr, deny, expect, forbid, and warn are the only allowed built-in attributes in function parameters
+  --> $DIR/param-attrs-builtin-attrs.rs:180:9
+   |
+LL |         #[no_mangle] b: i32,
+   |         ^^^^^^^^^^^^
+
+error: documentation comments cannot be applied to function parameters
+  --> $DIR/param-attrs-builtin-attrs.rs:189:9
+   |
+LL |         /// Foo
+   |         ^^^^^^^ doc comments are not allowed here
+
+error: documentation comments cannot be applied to function parameters
+  --> $DIR/param-attrs-builtin-attrs.rs:193:9
+   |
+LL |         /// Bar
+   |         ^^^^^^^ doc comments are not allowed here
+
+error: allow, cfg, cfg_attr, deny, expect, forbid, and warn are the only allowed built-in attributes in function parameters
+  --> $DIR/param-attrs-builtin-attrs.rs:195:9
+   |
+LL |         #[must_use]
+   |         ^^^^^^^^^^^
+
+error: documentation comments cannot be applied to function parameters
+  --> $DIR/param-attrs-builtin-attrs.rs:199:9
+   |
+LL |         /// Baz
+   |         ^^^^^^^ doc comments are not allowed here
+
+error: allow, cfg, cfg_attr, deny, expect, forbid, and warn are the only allowed built-in attributes in function parameters
+  --> $DIR/param-attrs-builtin-attrs.rs:201:9
    |
 LL |         #[no_mangle] b: i32
    |         ^^^^^^^^^^^^
 
-error: aborting due to 64 previous errors
+warning: `#[must_use]` attribute cannot be used on function params
+  --> $DIR/param-attrs-builtin-attrs.rs:40:5
+   |
+LL |     #[must_use]
+   |     ^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
+   = note: requested on the command line with `-W unused-attributes`
+
+warning: `#[no_mangle]` attribute cannot be used on function params
+  --> $DIR/param-attrs-builtin-attrs.rs:46:5
+   |
+LL |     #[no_mangle] b: i32,
+   |     ^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = help: `#[no_mangle]` can be applied to functions and statics
+
+warning: `#[must_use]` attribute cannot be used on function params
+  --> $DIR/param-attrs-builtin-attrs.rs:64:9
+   |
+LL |         #[must_use]
+   |         ^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
+
+warning: `#[no_mangle]` attribute cannot be used on function params
+  --> $DIR/param-attrs-builtin-attrs.rs:70:9
+   |
+LL |         #[no_mangle] b: i32,
+   |         ^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = help: `#[no_mangle]` can be applied to functions and statics
+
+warning: `#[must_use]` attribute cannot be used on function params
+  --> $DIR/param-attrs-builtin-attrs.rs:83:9
+   |
+LL |         #[must_use]
+   |         ^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
+
+warning: `#[no_mangle]` attribute cannot be used on function params
+  --> $DIR/param-attrs-builtin-attrs.rs:89:9
+   |
+LL |         #[no_mangle] b: i32,
+   |         ^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = help: `#[no_mangle]` can be applied to functions and statics
+
+warning: `#[must_use]` attribute cannot be used on function params
+  --> $DIR/param-attrs-builtin-attrs.rs:108:9
+   |
+LL |         #[must_use]
+   |         ^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
+
+warning: `#[no_mangle]` attribute cannot be used on function params
+  --> $DIR/param-attrs-builtin-attrs.rs:114:9
+   |
+LL |         #[no_mangle] b: i32,
+   |         ^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = help: `#[no_mangle]` can be applied to functions and statics
+
+warning: `#[must_use]` attribute cannot be used on function params
+  --> $DIR/param-attrs-builtin-attrs.rs:131:9
+   |
+LL |         #[must_use]
+   |         ^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
+
+warning: `#[no_mangle]` attribute cannot be used on function params
+  --> $DIR/param-attrs-builtin-attrs.rs:137:9
+   |
+LL |         #[no_mangle] b: i32,
+   |         ^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = help: `#[no_mangle]` can be applied to functions and statics
+
+warning: `#[must_use]` attribute cannot be used on function params
+  --> $DIR/param-attrs-builtin-attrs.rs:150:9
+   |
+LL |         #[must_use]
+   |         ^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
+
+warning: `#[no_mangle]` attribute cannot be used on function params
+  --> $DIR/param-attrs-builtin-attrs.rs:156:9
+   |
+LL |         #[no_mangle] b: i32,
+   |         ^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = help: `#[no_mangle]` can be applied to functions and statics
+
+warning: `#[must_use]` attribute cannot be used on function params
+  --> $DIR/param-attrs-builtin-attrs.rs:174:9
+   |
+LL |         #[must_use]
+   |         ^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
+
+warning: `#[no_mangle]` attribute cannot be used on function params
+  --> $DIR/param-attrs-builtin-attrs.rs:180:9
+   |
+LL |         #[no_mangle] b: i32,
+   |         ^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = help: `#[no_mangle]` can be applied to functions and statics
+
+warning: `#[must_use]` attribute cannot be used on function params
+  --> $DIR/param-attrs-builtin-attrs.rs:195:9
+   |
+LL |         #[must_use]
+   |         ^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
+
+warning: `#[no_mangle]` attribute cannot be used on function params
+  --> $DIR/param-attrs-builtin-attrs.rs:201:9
+   |
+LL |         #[no_mangle] b: i32
+   |         ^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = help: `#[no_mangle]` can be applied to functions and statics
+
+error: aborting due to 64 previous errors; 16 warnings emitted
 


### PR DESCRIPTION
r? @jdonszelmann 

Because:
- unused_attributes warnings are usually actual mistakes, rather than just unused code, and we want to notify test writers they may be accidentally making a mistake
- Because the lint was allowed by default previously, we missed real bugs, because the test coverage is worse
  1. https://github.com/rust-lang/rust/issues/147417
  2. https://github.com/rust-lang/rust/issues/147411