### PR TITLE
docs: update Motor OS target docs

### DIFF
--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -432,7 +432,7 @@ target | std | host | notes
 `x86_64-unknown-l4re-uclibc` | ? |  |
 [`x86_64-unknown-linux-none`](platform-support/x86_64-unknown-linux-none.md) | * |  | 64-bit Linux with no libc
 [`x86_64-unknown-managarm-mlibc`](platform-support/managarm.md) | ? |   | x86_64 Managarm
-[`x86_64-unknown-motor`](platform-support/motor.md) | ? |  | x86_64 Motor OS
+[`x86_64-unknown-motor`](platform-support/motor.md) | ✓ |  | x86_64 Motor OS
 [`x86_64-unknown-openbsd`](platform-support/openbsd.md) | ✓ | ✓ | 64-bit OpenBSD
 [`x86_64-unknown-trusty`](platform-support/trusty.md) | ✓ |  |
 `x86_64-uwp-windows-gnu` | ✓ |  |

--- a/src/doc/rustc/src/platform-support/motor.md
+++ b/src/doc/rustc/src/platform-support/motor.md
@@ -15,27 +15,35 @@ This target is cross-compiled. There are no special requirements for the host.
 
 Motor OS uses the ELF file format.
 
-## Building the target
+## Building the target toolchain
 
-The target can be built by enabling it for a `rustc` build, for example:
+Motor OS target toolchain can be
+[built using `x.py`](https://rustc-dev-guide.rust-lang.org/building/how-to-build-and-run.html):
+
+The bootstrap file:
 
 ```toml
 [build]
-build-stage = 2
-target = ["x86_64-unknown-motor"]
+host = ["x86_64-unknown-linux-gnu"]
+target = ["x86_64-unknown-linux-gnu", "x86_64-unknown-motor"]
+```
+
+The build command:
+
+```sh
+./x.py build --stage 2 clippy library
 ```
 
 ## Building Rust programs
 
-Rust standard library is fully supported/implemented, but is not yet part of
-the official Rust repo, so an out-of-tree building process should be
-followed, as described in the
-[build doc](https://github.com/moturus/motor-os/blob/main/docs/build.md).
+See the [Hello Motor OS](https://github.com/moturus/motor-os/blob/main/docs/recipes/hello-motor-os.md)
+example.
 
 ## Testing
 
 Cross-compiled Rust binaries and test artifacts can be executed in Motor OS VMs,
-as described in e.g.
+as described in the [build doc](https://github.com/moturus/motor-os/blob/main/docs/build.md)
+and the
 [Hello Motor OS](https://github.com/moturus/motor-os/blob/main/docs/recipes/hello-motor-os.md)
 example.
 


### PR DESCRIPTION
Update the docs to reflect that [Motor OS std library PR](https://github.com/rust-lang/rust/pull/147000) has been merged.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
