### PR TITLE
Update typos

### DIFF
--- a/compiler/rustc_builtin_macros/messages.ftl
+++ b/compiler/rustc_builtin_macros/messages.ftl
@@ -283,7 +283,7 @@ builtin_macros_requires_cfg_pattern =
     macro requires a cfg-pattern as an argument
     .label = cfg-pattern required
 
-builtin_macros_source_uitls_expected_item = expected item, found `{$token}`
+builtin_macros_source_utils_expected_item = expected item, found `{$token}`
 
 builtin_macros_takes_no_arguments = {$name} takes no arguments
 

--- a/compiler/rustc_builtin_macros/src/errors.rs
+++ b/compiler/rustc_builtin_macros/src/errors.rs
@@ -952,7 +952,7 @@ pub(crate) struct AttributeOnlyUsableWithCrateType<'a> {
 }
 
 #[derive(Diagnostic)]
-#[diag(builtin_macros_source_uitls_expected_item)]
+#[diag(builtin_macros_source_utils_expected_item)]
 pub(crate) struct ExpectedItem<'a> {
     #[primary_span]
     pub span: Span,

--- a/compiler/rustc_codegen_llvm/src/back/write.rs
+++ b/compiler/rustc_codegen_llvm/src/back/write.rs
@@ -358,7 +358,7 @@ fn write_bitcode_to_file(module: &ModuleCodegen<ModuleLlvm>, path: &Path) {
     }
 }
 
-/// In what context is a dignostic handler being attached to a codegen unit?
+/// In what context is a diagnostic handler being attached to a codegen unit?
 pub(crate) enum CodegenDiagnosticsStage {
     /// Prelink optimization stage.
     Opt,

--- a/compiler/rustc_const_eval/src/interpret/call.rs
+++ b/compiler/rustc_const_eval/src/interpret/call.rs
@@ -127,7 +127,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         } else if all_fields_1zst(def.variant(var1))? {
             def.variant(var0)
         } else {
-            // No varant is all-1-ZST, so no NPO.
+            // No variant is all-1-ZST, so no NPO.
             return interp_ok(layout);
         };
         // The "relevant" variant must have exactly one field, and its type is the "inner" type.

--- a/compiler/rustc_const_eval/src/interpret/projection.rs
+++ b/compiler/rustc_const_eval/src/interpret/projection.rs
@@ -2,7 +2,7 @@
 //!
 //! OpTy and PlaceTy generally work by "let's see if we are actually an MPlaceTy, and do something custom if not".
 //! For PlaceTy, the custom thing is basically always to call `force_allocation` and then use the MPlaceTy logic anyway.
-//! For OpTy, the custom thing on field pojections has to be pretty clever (since `Operand::Immediate` can have fields),
+//! For OpTy, the custom thing on field projections has to be pretty clever (since `Operand::Immediate` can have fields),
 //! but for array/slice operations it only has to worry about `Operand::Uninit`. That makes the value part trivial,
 //! but we still need to do bounds checking and adjust the layout. To not duplicate that with MPlaceTy, we actually
 //! implement the logic on OpTy, and MPlaceTy calls that.

--- a/compiler/rustc_const_eval/src/interpret/util.rs
+++ b/compiler/rustc_const_eval/src/interpret/util.rs
@@ -74,7 +74,7 @@ impl EnteredTraceSpan for tracing::span::EnteredSpan {
     }
 }
 
-/// Shortand for calling [crate::interpret::Machine::enter_trace_span] on a [tracing::info_span!].
+/// Shorthand for calling [crate::interpret::Machine::enter_trace_span] on a [tracing::info_span!].
 /// This is supposed to be compiled out when [crate::interpret::Machine::enter_trace_span] has the
 /// default implementation (i.e. when it does not actually enter the span but instead returns `()`).
 /// This macro takes a type implementing the [crate::interpret::Machine] trait as its first argument

--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -479,10 +479,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     }
                 }
 
-                // If the shadowed binding has an itializer expression,
+                // If the shadowed binding has an initializer expression,
                 // use the initializer expression's ty to try to find the method again.
                 // For example like:  `let mut x = Vec::new();`,
-                // `Vec::new()` is the itializer expression.
+                // `Vec::new()` is the initializer expression.
                 if let Some(self_ty) = self.fcx.node_ty_opt(binding.init_hir_id)
                     && self
                         .fcx

--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -2959,7 +2959,7 @@ impl<'tcx> LateLintPass<'tcx> for AsmLabels {
 
                         for c in chars {
                             // Inside a template format arg, any character is permitted for the
-                            // puproses of label detection because we assume that it can be
+                            // purposes of label detection because we assume that it can be
                             // replaced with some other valid label string later. `options(raw)`
                             // asm blocks cannot have format args, so they are excluded from this
                             // special case.

--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
@@ -993,7 +993,7 @@ where
         }
     }
 
-    /// This sohuld only be used when we're either instantiating a previously
+    /// This should only be used when we're either instantiating a previously
     /// unconstrained "return value" or when we're sure that all aliases in
     /// the types are rigid.
     #[instrument(level = "trace", skip(self, param_env), ret)]

--- a/compiler/rustc_next_trait_solver/src/solve/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/mod.rs
@@ -39,7 +39,7 @@ use crate::solve::assembly::Candidate;
 ///
 /// We previously used  `cx.recursion_limit().0.checked_ilog2().unwrap_or(0)` for this.
 /// However, it feels unlikely that uncreasing the recursion limit by a power of two
-/// to get one more itereation is every useful or desirable. We now instead used a constant
+/// to get one more iteration is every useful or desirable. We now instead used a constant
 /// here. If there ever ends up some use-cases where a bigger number of fixpoint iterations
 /// is required, we can add a new attribute for that or revert this to be dependant on the
 /// recursion limit again. However, this feels very unlikely.

--- a/compiler/rustc_public/src/mir/visit.rs
+++ b/compiler/rustc_public/src/mir/visit.rs
@@ -181,7 +181,7 @@ macro_rules! make_mir_visitor {
                         self.visit_user_type_projection(projections);
                     }
                     StatementKind::Coverage(coverage) => visit_opaque(coverage),
-                    StatementKind::Intrinsic(intrisic) => match intrisic {
+                    StatementKind::Intrinsic(intrinsic) => match intrinsic {
                         NonDivergingIntrinsic::Assume(operand) => {
                             self.visit_operand(operand, location);
                         }

--- a/compiler/rustc_query_system/src/dep_graph/graph.rs
+++ b/compiler/rustc_query_system/src/dep_graph/graph.rs
@@ -507,7 +507,7 @@ impl<D: Deps> DepGraph<D> {
         }
     }
 
-    /// This encodes a diagnostic by creating a node with an unique index and assoicating
+    /// This encodes a diagnostic by creating a node with an unique index and associating
     /// `diagnostic` with it, for use in the next session.
     #[inline]
     pub fn record_diagnostic<Qcx: QueryContext>(&self, qcx: Qcx, diagnostic: &DiagInner) {
@@ -657,7 +657,7 @@ impl<D: Deps> DepGraphData<D> {
         self.debug_loaded_from_disk.lock().insert(dep_node);
     }
 
-    /// This encodes a diagnostic by creating a node with an unique index and assoicating
+    /// This encodes a diagnostic by creating a node with an unique index and associating
     /// `diagnostic` with it, for use in the next session.
     #[inline]
     fn encode_diagnostic<Qcx: QueryContext>(

--- a/library/alloc/src/collections/vec_deque/tests.rs
+++ b/library/alloc/src/collections/vec_deque/tests.rs
@@ -367,7 +367,7 @@ fn test_rotate_right_panic() {
 
 #[test]
 fn test_binary_search() {
-    // If the givin VecDeque is not sorted, the returned result is unspecified and meaningless,
+    // If the given VecDeque is not sorted, the returned result is unspecified and meaningless,
     // as this method performs a binary search.
 
     let tester: VecDeque<_> = [0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55].into();
@@ -391,7 +391,7 @@ fn test_binary_search() {
 
 #[test]
 fn test_binary_search_by() {
-    // If the givin VecDeque is not sorted, the returned result is unspecified and meaningless,
+    // If the given VecDeque is not sorted, the returned result is unspecified and meaningless,
     // as this method performs a binary search.
 
     let tester: VecDeque<_> = [0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55].into();
@@ -406,7 +406,7 @@ fn test_binary_search_by() {
 
 #[test]
 fn test_binary_search_key() {
-    // If the givin VecDeque is not sorted, the returned result is unspecified and meaningless,
+    // If the given VecDeque is not sorted, the returned result is unspecified and meaningless,
     // as this method performs a binary search.
 
     let tester: VecDeque<_> = [

--- a/library/core/src/asserting.rs
+++ b/library/core/src/asserting.rs
@@ -73,12 +73,14 @@ where
 
 // ***** Others *****
 
+//spellchecker:off
 /// All possible captured `assert!` elements
 ///
 /// # Types
 ///
 /// * `E`: **E**lement that is going to be displayed.
 /// * `M`: **M**arker used to differentiate [Capture]s in regards to [Debug].
+//spellchecker:on
 #[unstable(feature = "generic_assert_internals", issue = "44838")]
 pub struct Capture<E, M> {
     // If None, then `E` does not implements [Printable] or `E` wasn't evaluated (`assert!( ... )`

--- a/library/core/src/panic/unwind_safe.rs
+++ b/library/core/src/panic/unwind_safe.rs
@@ -101,9 +101,9 @@ pub auto trait UnwindSafe {}
 #[rustc_diagnostic_item = "ref_unwind_safe_trait"]
 #[diagnostic::on_unimplemented(
     message = "the type `{Self}` may contain interior mutability and a reference may not be safely \
-               transferrable across a catch_unwind boundary",
+               transferable across a catch_unwind boundary",
     label = "`{Self}` may contain interior mutability and a reference may not be safely \
-             transferrable across a catch_unwind boundary"
+             transferable across a catch_unwind boundary"
 )]
 pub auto trait RefUnwindSafe {}
 

--- a/library/std/src/sys/fs/vexos.rs
+++ b/library/std/src/sys/fs/vexos.rs
@@ -106,7 +106,7 @@ impl FilePermissions {
     }
 
     pub fn set_readonly(&mut self, _readonly: bool) {
-        panic!("Perimissions do not exist")
+        panic!("Permissions do not exist")
     }
 }
 

--- a/library/std/src/sys/pal/uefi/time.rs
+++ b/library/std/src/sys/pal/uefi/time.rs
@@ -181,7 +181,7 @@ pub(crate) mod system_time_internal {
     /// The changes are to use 1900-01-01-00:00:00 with timezone -1440 as anchor instead of UNIX
     /// epoch used in the original algorithm.
     pub(crate) const fn to_uefi(dur: &Duration, timezone: i16, daylight: u8) -> Option<Time> {
-        // Check timzone validity
+        // Check timezone validity
         assert!(timezone <= 1440 && timezone >= -1440);
 
         // FIXME(#126043): use checked_sub_signed once stabilized

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -1758,7 +1758,7 @@ impl Config {
         // We do not assume that the sources would change during bootstrap's execution,
         // so we can cache the results here.
         // Note that we do not use a static variable for the cache, because it would cause problems
-        // in tests that create separate `Config` instsances.
+        // in tests that create separate `Config` instances.
         self.path_modification_cache
             .lock()
             .unwrap()
@@ -2226,7 +2226,7 @@ pub fn check_path_modifications_<'a>(
     // We do not assume that the sources would change during bootstrap's execution,
     // so we can cache the results here.
     // Note that we do not use a static variable for the cache, because it would cause problems
-    // in tests that create separate `Config` instsances.
+    // in tests that create separate `Config` instances.
     dwn_ctx
         .path_modification_cache
         .lock()

--- a/src/librustdoc/html/render/search_index.rs
+++ b/src/librustdoc/html/render/search_index.rs
@@ -2043,7 +2043,7 @@ enum SimplifiedParam {
 /// frontend search engine can use.
 ///
 /// For example, `[T, U, i32]]` where you have the bounds: `T: Display, U: Option<T>` will return
-/// `[-1, -2, i32] where -1: Display, -2: Option<-1>`. If a type parameter has no traid bound, it
+/// `[-1, -2, i32] where -1: Display, -2: Option<-1>`. If a type parameter has no trait bound, it
 /// will still get a number. If a constraint is present but not used in the actual types, it will
 /// not be added to the map.
 ///

--- a/src/tools/tidy/src/extra_checks/mod.rs
+++ b/src/tools/tidy/src/extra_checks/mod.rs
@@ -621,7 +621,7 @@ fn spellcheck_runner(
     args: &[&str],
 ) -> Result<(), Error> {
     let bin_path =
-        crate::ensure_version_or_cargo_install(outdir, cargo, "typos-cli", "typos", "1.34.0")?;
+        crate::ensure_version_or_cargo_install(outdir, cargo, "typos-cli", "typos", "1.38.1")?;
     match Command::new(bin_path).current_dir(src_root).args(args).status() {
         Ok(status) => {
             if status.success() {

--- a/tests/ui/interior-mutability/interior-mutability.stderr
+++ b/tests/ui/interior-mutability/interior-mutability.stderr
@@ -1,8 +1,8 @@
-error[E0277]: the type `UnsafeCell<i32>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
+error[E0277]: the type `UnsafeCell<i32>` may contain interior mutability and a reference may not be safely transferable across a catch_unwind boundary
   --> $DIR/interior-mutability.rs:6:18
    |
 LL |     catch_unwind(|| { x.set(23); });
-   |     ------------ ^^^^^^^^^^^^^^^^^ `UnsafeCell<i32>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
+   |     ------------ ^^^^^^^^^^^^^^^^^ `UnsafeCell<i32>` may contain interior mutability and a reference may not be safely transferable across a catch_unwind boundary
    |     |
    |     required by a bound introduced by this call
    |

--- a/tests/ui/not-panic/not-panic-safe-2.stderr
+++ b/tests/ui/not-panic/not-panic-safe-2.stderr
@@ -1,8 +1,8 @@
-error[E0277]: the type `UnsafeCell<i32>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
+error[E0277]: the type `UnsafeCell<i32>` may contain interior mutability and a reference may not be safely transferable across a catch_unwind boundary
   --> $DIR/not-panic-safe-2.rs:10:14
    |
 LL |     assert::<Rc<RefCell<i32>>>();
-   |              ^^^^^^^^^^^^^^^^ `UnsafeCell<i32>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
+   |              ^^^^^^^^^^^^^^^^ `UnsafeCell<i32>` may contain interior mutability and a reference may not be safely transferable across a catch_unwind boundary
    |
    = help: within `RefCell<i32>`, the trait `RefUnwindSafe` is not implemented for `UnsafeCell<i32>`
 note: required because it appears within the type `RefCell<i32>`
@@ -14,11 +14,11 @@ note: required by a bound in `assert`
 LL | fn assert<T: UnwindSafe + ?Sized>() {}
    |              ^^^^^^^^^^ required by this bound in `assert`
 
-error[E0277]: the type `UnsafeCell<isize>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
+error[E0277]: the type `UnsafeCell<isize>` may contain interior mutability and a reference may not be safely transferable across a catch_unwind boundary
   --> $DIR/not-panic-safe-2.rs:10:14
    |
 LL |     assert::<Rc<RefCell<i32>>>();
-   |              ^^^^^^^^^^^^^^^^ `UnsafeCell<isize>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
+   |              ^^^^^^^^^^^^^^^^ `UnsafeCell<isize>` may contain interior mutability and a reference may not be safely transferable across a catch_unwind boundary
    |
    = help: within `RefCell<i32>`, the trait `RefUnwindSafe` is not implemented for `UnsafeCell<isize>`
 note: required because it appears within the type `Cell<isize>`

--- a/tests/ui/not-panic/not-panic-safe-3.stderr
+++ b/tests/ui/not-panic/not-panic-safe-3.stderr
@@ -1,8 +1,8 @@
-error[E0277]: the type `UnsafeCell<i32>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
+error[E0277]: the type `UnsafeCell<i32>` may contain interior mutability and a reference may not be safely transferable across a catch_unwind boundary
   --> $DIR/not-panic-safe-3.rs:10:14
    |
 LL |     assert::<Arc<RefCell<i32>>>();
-   |              ^^^^^^^^^^^^^^^^^ `UnsafeCell<i32>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
+   |              ^^^^^^^^^^^^^^^^^ `UnsafeCell<i32>` may contain interior mutability and a reference may not be safely transferable across a catch_unwind boundary
    |
    = help: within `RefCell<i32>`, the trait `RefUnwindSafe` is not implemented for `UnsafeCell<i32>`
 note: required because it appears within the type `RefCell<i32>`
@@ -14,11 +14,11 @@ note: required by a bound in `assert`
 LL | fn assert<T: UnwindSafe + ?Sized>() {}
    |              ^^^^^^^^^^ required by this bound in `assert`
 
-error[E0277]: the type `UnsafeCell<isize>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
+error[E0277]: the type `UnsafeCell<isize>` may contain interior mutability and a reference may not be safely transferable across a catch_unwind boundary
   --> $DIR/not-panic-safe-3.rs:10:14
    |
 LL |     assert::<Arc<RefCell<i32>>>();
-   |              ^^^^^^^^^^^^^^^^^ `UnsafeCell<isize>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
+   |              ^^^^^^^^^^^^^^^^^ `UnsafeCell<isize>` may contain interior mutability and a reference may not be safely transferable across a catch_unwind boundary
    |
    = help: within `RefCell<i32>`, the trait `RefUnwindSafe` is not implemented for `UnsafeCell<isize>`
 note: required because it appears within the type `Cell<isize>`

--- a/tests/ui/not-panic/not-panic-safe-4.stderr
+++ b/tests/ui/not-panic/not-panic-safe-4.stderr
@@ -1,8 +1,8 @@
-error[E0277]: the type `UnsafeCell<i32>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
+error[E0277]: the type `UnsafeCell<i32>` may contain interior mutability and a reference may not be safely transferable across a catch_unwind boundary
   --> $DIR/not-panic-safe-4.rs:9:14
    |
 LL |     assert::<&RefCell<i32>>();
-   |              ^^^^^^^^^^^^^ `UnsafeCell<i32>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
+   |              ^^^^^^^^^^^^^ `UnsafeCell<i32>` may contain interior mutability and a reference may not be safely transferable across a catch_unwind boundary
    |
    = help: within `RefCell<i32>`, the trait `RefUnwindSafe` is not implemented for `UnsafeCell<i32>`
 note: required because it appears within the type `RefCell<i32>`
@@ -19,11 +19,11 @@ LL -     assert::<&RefCell<i32>>();
 LL +     assert::<RefCell<i32>>();
    |
 
-error[E0277]: the type `UnsafeCell<isize>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
+error[E0277]: the type `UnsafeCell<isize>` may contain interior mutability and a reference may not be safely transferable across a catch_unwind boundary
   --> $DIR/not-panic-safe-4.rs:9:14
    |
 LL |     assert::<&RefCell<i32>>();
-   |              ^^^^^^^^^^^^^ `UnsafeCell<isize>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
+   |              ^^^^^^^^^^^^^ `UnsafeCell<isize>` may contain interior mutability and a reference may not be safely transferable across a catch_unwind boundary
    |
    = help: within `RefCell<i32>`, the trait `RefUnwindSafe` is not implemented for `UnsafeCell<isize>`
 note: required because it appears within the type `Cell<isize>`

--- a/tests/ui/not-panic/not-panic-safe-5.stderr
+++ b/tests/ui/not-panic/not-panic-safe-5.stderr
@@ -1,8 +1,8 @@
-error[E0277]: the type `UnsafeCell<i32>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
+error[E0277]: the type `UnsafeCell<i32>` may contain interior mutability and a reference may not be safely transferable across a catch_unwind boundary
   --> $DIR/not-panic-safe-5.rs:9:14
    |
 LL |     assert::<*const UnsafeCell<i32>>();
-   |              ^^^^^^^^^^^^^^^^^^^^^^ `UnsafeCell<i32>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
+   |              ^^^^^^^^^^^^^^^^^^^^^^ `UnsafeCell<i32>` may contain interior mutability and a reference may not be safely transferable across a catch_unwind boundary
    |
    = help: the trait `RefUnwindSafe` is not implemented for `UnsafeCell<i32>`
    = note: required for `*const UnsafeCell<i32>` to implement `UnwindSafe`

--- a/tests/ui/not-panic/not-panic-safe-6.stderr
+++ b/tests/ui/not-panic/not-panic-safe-6.stderr
@@ -1,8 +1,8 @@
-error[E0277]: the type `UnsafeCell<i32>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
+error[E0277]: the type `UnsafeCell<i32>` may contain interior mutability and a reference may not be safely transferable across a catch_unwind boundary
   --> $DIR/not-panic-safe-6.rs:9:14
    |
 LL |     assert::<*mut RefCell<i32>>();
-   |              ^^^^^^^^^^^^^^^^^ `UnsafeCell<i32>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
+   |              ^^^^^^^^^^^^^^^^^ `UnsafeCell<i32>` may contain interior mutability and a reference may not be safely transferable across a catch_unwind boundary
    |
    = help: within `RefCell<i32>`, the trait `RefUnwindSafe` is not implemented for `UnsafeCell<i32>`
 note: required because it appears within the type `RefCell<i32>`
@@ -14,11 +14,11 @@ note: required by a bound in `assert`
 LL | fn assert<T: UnwindSafe + ?Sized>() {}
    |              ^^^^^^^^^^ required by this bound in `assert`
 
-error[E0277]: the type `UnsafeCell<isize>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
+error[E0277]: the type `UnsafeCell<isize>` may contain interior mutability and a reference may not be safely transferable across a catch_unwind boundary
   --> $DIR/not-panic-safe-6.rs:9:14
    |
 LL |     assert::<*mut RefCell<i32>>();
-   |              ^^^^^^^^^^^^^^^^^ `UnsafeCell<isize>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
+   |              ^^^^^^^^^^^^^^^^^ `UnsafeCell<isize>` may contain interior mutability and a reference may not be safely transferable across a catch_unwind boundary
    |
    = help: within `RefCell<i32>`, the trait `RefUnwindSafe` is not implemented for `UnsafeCell<isize>`
 note: required because it appears within the type `Cell<isize>`

--- a/typos.toml
+++ b/typos.toml
@@ -1,11 +1,11 @@
 [files]
 extend-exclude = [
     # exclude git (sub)modules and generated content
-    "compiler/rustc_codegen_gcc",
-    "compiler/rustc_codegen_cranelift",
     "compiler/rustc_baked_icu_data",
-    "library/compiler-builtins",
+    "compiler/rustc_codegen_cranelift",
+    "compiler/rustc_codegen_gcc",
     "library/backtrace",
+    "library/compiler-builtins",
     "library/stdarch",
     # generated lorem ipsum texts
     "library/alloctests/benches/str.rs",
@@ -16,24 +16,24 @@ extend-exclude = [
 # Add exclusions here, lines should be like `x = "x"`, where `x` is excluded word.
 #
 # Also see docs: https://github.com/crate-ci/typos/blob/v1.28.2/docs/reference.md
-rplace = "rplace"
 arange = "arange"
-unstalled = "unstalled"
-taits = "taits"
+childs = "childs"
+clonable = "clonable"
 Datas = "Datas"
-splitted = "splitted"
+filetimes = "filetimes"
 leafs = "leafs"
 makro = "makro"
-optin = "optin"
-unparseable = "unparseable"
-smove = "smove"
-childs = "childs"
-filetimes = "filetimes"
 misformed = "misformed"
-targetting = "targetting"
-publically = "publically"
-clonable = "clonable"
 moreso = "moreso"
+optin = "optin"
+publically = "publically"
+rplace = "rplace"
+smove = "smove"
+splitted = "splitted"
+taits = "taits"
+targetting = "targetting"
+unparseable = "unparseable"
+unstalled = "unstalled"
 
 # this can be valid word, depends on dictionary edition
 #matcheable = "matcheable"
@@ -46,14 +46,14 @@ moreso = "moreso"
 # I.e. you don't want (or can't) fix some constant name, like
 # `DNS_ERROR_INVAILD_VIRTUALIZATION_INSTANCE_NAME` but actually
 # want to see `INVAILD` typo fixed in other places.
-ERROR_FILENAME_EXCED_RANGE = "ERROR_FILENAME_EXCED_RANGE"
 DNS_ERROR_INVAILD_VIRTUALIZATION_INSTANCE_NAME = "DNS_ERROR_INVAILD_VIRTUALIZATION_INSTANCE_NAME"
+EnzymeTypeTreeShiftIndiciesEq = "EnzymeTypeTreeShiftIndiciesEq"
+ERRNO_ACCES = "ERRNO_ACCES"
 ERROR_DS_FILTER_USES_CONTRUCTED_ATTRS = "ERROR_DS_FILTER_USES_CONTRUCTED_ATTRS"
 ERROR_DS_NOT_AUTHORITIVE_FOR_DST_NC = "ERROR_DS_NOT_AUTHORITIVE_FOR_DST_NC"
+ERROR_FILENAME_EXCED_RANGE = "ERROR_FILENAME_EXCED_RANGE"
 ERROR_MCA_OCCURED = "ERROR_MCA_OCCURED"
-ERRNO_ACCES = "ERRNO_ACCES"
 tolen = "tolen"
-EnzymeTypeTreeShiftIndiciesEq = "EnzymeTypeTreeShiftIndiciesEq"
 
 [default]
 extend-ignore-words-re = [

--- a/typos.toml
+++ b/typos.toml
@@ -33,6 +33,7 @@ splitted = "splitted"
 taits = "taits"
 targetting = "targetting"
 unparseable = "unparseable"
+unstability = "unstability"
 unstalled = "unstalled"
 
 # this can be valid word, depends on dictionary edition
@@ -46,6 +47,7 @@ unstalled = "unstalled"
 # I.e. you don't want (or can't) fix some constant name, like
 # `DNS_ERROR_INVAILD_VIRTUALIZATION_INSTANCE_NAME` but actually
 # want to see `INVAILD` typo fixed in other places.
+debug_aranges = "debug_aranges"
 DNS_ERROR_INVAILD_VIRTUALIZATION_INSTANCE_NAME = "DNS_ERROR_INVAILD_VIRTUALIZATION_INSTANCE_NAME"
 EnzymeTypeTreeShiftIndiciesEq = "EnzymeTypeTreeShiftIndiciesEq"
 ERRNO_ACCES = "ERRNO_ACCES"
@@ -53,6 +55,11 @@ ERROR_DS_FILTER_USES_CONTRUCTED_ATTRS = "ERROR_DS_FILTER_USES_CONTRUCTED_ATTRS"
 ERROR_DS_NOT_AUTHORITIVE_FOR_DST_NC = "ERROR_DS_NOT_AUTHORITIVE_FOR_DST_NC"
 ERROR_FILENAME_EXCED_RANGE = "ERROR_FILENAME_EXCED_RANGE"
 ERROR_MCA_OCCURED = "ERROR_MCA_OCCURED"
+ERROR_REQ_NOT_ACCEP = "ERROR_REQ_NOT_ACCEP"
+Oppen = "Oppen"
+# typos treats this as two different camelcase words (`SETTIN` and `Gs`)
+# Tracked in: https://github.com/crate-ci/typos/issues/745
+SETTINGs = "SETTINGs"
 tolen = "tolen"
 
 [default]
@@ -62,6 +69,8 @@ extend-ignore-words-re = [
 ]
 
 extend-ignore-re = [
+    # allow turning off spell checking
+    "(?s)(#|//)\\s*spellchecker:off.*?\\n\\s*(#|//)\\s*spellchecker:on",
     # ignore these intentional typo examples
     "/// 1 \\| #\\[cfg\\(widnows\\)\\]",
     "/// warning: unexpected `cfg` condition name: `widnows`",
@@ -71,5 +80,5 @@ extend-ignore-re = [
     "\"core::iter::adapters::Copie\"",
     "-Ccontrol-flow-guard",
     "concat!\\(\"CURRENT_RUSTC_VERSIO\", \"N\"\\)",
-    "\\*\\*v\\*\\*ariable"
+    "\\*\\*v\\*\\*ariable",
 ]


### PR DESCRIPTION
I saw that `typos` was a few versions out of date and figured it would be a good idea to update it. Upgrading to `1.38.1` adds the [July](https://github.com/crate-ci/typos/issues/1331), [August](https://github.com/crate-ci/typos/issues/1345), and [September](https://github.com/crate-ci/typos/issues/1370) dictionary updates. As part of this change, I also sorted the configuration file.