### PR TITLE
Reword unstable fingerprints ICE to ask for reproduction

### DIFF
--- a/compiler/rustc_query_system/messages.ftl
+++ b/compiler/rustc_query_system/messages.ftl
@@ -16,10 +16,11 @@ query_system_cycle_stack_single = ...which immediately requires {$stack_bottom} 
 query_system_cycle_usage = cycle used when {$usage}
 
 query_system_increment_compilation = internal compiler error: encountered incremental compilation error with {$dep_node}
-    .help = This is a known issue with the compiler. Run {$run_cmd} to allow your project to compile
 
 query_system_increment_compilation_note1 = please follow the instructions below to create a bug report with the provided information
-query_system_increment_compilation_note2 = see <https://github.com/rust-lang/rust/issues/84970> for more information
+query_system_increment_compilation_note2 = for incremental compilation bugs, having a reproduction is vital
+query_system_increment_compilation_note3 = an ideal reproduction consists of the code before and some patch that then triggers the bug when applied and compiled again
+query_system_increment_compilation_note4 = as a workaround, you can run {$run_cmd} to allow your project to compile
 
 query_system_overflow_note = query depth increased by {$depth} when {$desc}
 

--- a/compiler/rustc_query_system/src/error.rs
+++ b/compiler/rustc_query_system/src/error.rs
@@ -69,9 +69,10 @@ pub(crate) struct Reentrant;
 
 #[derive(Diagnostic)]
 #[diag(query_system_increment_compilation)]
-#[help]
 #[note(query_system_increment_compilation_note1)]
 #[note(query_system_increment_compilation_note2)]
+#[note(query_system_increment_compilation_note3)]
+#[note(query_system_increment_compilation_note4)]
 pub(crate) struct IncrementCompilation {
     pub run_cmd: String,
     pub dep_node: String,


### PR DESCRIPTION
When the unstable fingerprints error was added, Rust was on fire, and we needed a quick way for people to sort of understand what's going on, follow the tracking issue, and leave some information without overwhelming the issue tracker and focusing on getting their code working.

This is what motivated the previous message. It called this a "known issue", provided help on how to fix it, and only secondarily asked for a bug report.

This is no longer true. These days incremental compilation is fairly solid and these issues are supposed to be rare, we expect *none* of them to exist (but obviously know that's not true). As such, it's time to reword this message.

Recently someone mentioned how they didn't bother reporting this issue because it said that it was a "known issue", and I only got awareness of their problem because they complained about all the rustc-ice files hanging around their directories (https://github.com/rust-lang/rust/issues/147825#issuecomment-3417297842). This is not at all what we want, we want reports from people, ideally with a reproduction.

To get this, I reworded the error. It now explicitly asks for a reproduction (and explaining what that means) and no longer calls it a "known issue". It also does not link to the tracking issue anymore, because I don't think this tracking issue is useful. It should probably be closed.

I still mention the workaround, but explicitly call it a "workaround". People should report a reproduction and only *then* use the workaround.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
