### PR TITLE
tests/ui/sanitizer/hwaddress.rs: Enable for aarch64-unknown-linux-gnu again

### DIFF
--- a/tests/ui/sanitizer/hwaddress.rs
+++ b/tests/ui/sanitizer/hwaddress.rs
@@ -1,9 +1,6 @@
 //@ needs-sanitizer-support
 //@ needs-sanitizer-hwaddress
 //
-// FIXME(#83706): this test triggers errors on aarch64-gnu
-//@ ignore-aarch64-unknown-linux-gnu
-//
 // FIXME(#83989): codegen-units=1 triggers linker errors on aarch64-gnu
 //@ compile-flags: -Z sanitizer=hwaddress -O -g -C codegen-units=16 -C unsafe-allow-abi-mismatch=sanitizer
 //


### PR DESCRIPTION
Let's see if this is still needed. https://github.com/rust-lang/rust/issues/83838#issuecomment-3417915478 makes me think it might not be needed any longer.

Closes rust-lang/rust#83989

try-job: aarch64-gnu