### PR TITLE
Rework unsizing coercions in the new solver

### DIFF
--- a/compiler/rustc_hir_typeck/src/coercion.rs
+++ b/compiler/rustc_hir_typeck/src/coercion.rs
@@ -35,13 +35,13 @@
 //! // and are then unable to coerce `&7i32` to `&mut i32`.
 //! ```
 
-use std::ops::Deref;
+use std::ops::{ControlFlow, Deref};
 
 use rustc_errors::codes::*;
 use rustc_errors::{Applicability, Diag, struct_span_code_err};
-use rustc_hir as hir;
 use rustc_hir::attrs::InlineAttr;
 use rustc_hir::def_id::{DefId, LocalDefId};
+use rustc_hir::{self as hir, LangItem};
 use rustc_hir_analysis::hir_ty_lowering::HirTyLowerer;
 use rustc_infer::infer::relate::RelateResult;
 use rustc_infer::infer::{DefineOpaqueTypes, InferOk, InferResult, RegionVariableOrigin};
@@ -56,6 +56,8 @@ use rustc_middle::ty::error::TypeError;
 use rustc_middle::ty::{self, GenericArgsRef, Ty, TyCtxt, TypeVisitableExt};
 use rustc_span::{BytePos, DUMMY_SP, DesugaringKind, Span};
 use rustc_trait_selection::infer::InferCtxtExt as _;
+use rustc_trait_selection::solve::inspect::{self, InferCtxtProofTreeExt, ProofTreeVisitor};
+use rustc_trait_selection::solve::{Certainty, Goal, NoSolution};
 use rustc_trait_selection::traits::query::evaluate_obligation::InferCtxtExt;
 use rustc_trait_selection::traits::{
     self, ImplSource, NormalizeExt, ObligationCause, ObligationCauseCode, ObligationCtxt,
@@ -639,131 +641,140 @@ impl<'f, 'tcx> Coerce<'f, 'tcx> {
             Adjust::Pointer(PointerCoercion::Unsize),
         )?;
 
-        let mut selcx = traits::SelectionContext::new(self);
-
         // Create an obligation for `Source: CoerceUnsized<Target>`.
         let cause = self.cause(self.cause.span, ObligationCauseCode::Coercion { source, target });
+        let pred = ty::TraitRef::new(self.tcx, coerce_unsized_did, [coerce_source, coerce_target]);
+        let obligation = Obligation::new(self.tcx, cause, self.fcx.param_env, pred);
 
-        // Use a FIFO queue for this custom fulfillment procedure.
-        //
-        // A Vec (or SmallVec) is not a natural choice for a queue. However,
-        // this code path is hot, and this queue usually has a max length of 1
-        // and almost never more than 3. By using a SmallVec we avoid an
-        // allocation, at the (very small) cost of (occasionally) having to
-        // shift subsequent elements down when removing the front element.
-        let mut queue: SmallVec<[PredicateObligation<'tcx>; 4]> = smallvec![Obligation::new(
-            self.tcx,
-            cause,
-            self.fcx.param_env,
-            ty::TraitRef::new(self.tcx, coerce_unsized_did, [coerce_source, coerce_target])
-        )];
+        if self.next_trait_solver() {
+            coercion.obligations.push(obligation);
 
-        // Keep resolving `CoerceUnsized` and `Unsize` predicates to avoid
-        // emitting a coercion in cases like `Foo<$1>` -> `Foo<$2>`, where
-        // inference might unify those two inner type variables later.
-        let traits = [coerce_unsized_did, unsize_did];
-        while !queue.is_empty() {
-            let obligation = queue.remove(0);
-            let trait_pred = match obligation.predicate.kind().no_bound_vars() {
-                Some(ty::PredicateKind::Clause(ty::ClauseKind::Trait(trait_pred)))
-                    if traits.contains(&trait_pred.def_id()) =>
-                {
-                    self.resolve_vars_if_possible(trait_pred)
-                }
-                // Eagerly process alias-relate obligations in new trait solver,
-                // since these can be emitted in the process of solving trait goals,
-                // but we need to constrain vars before processing goals mentioning
-                // them.
-                Some(ty::PredicateKind::AliasRelate(..)) => {
-                    let ocx = ObligationCtxt::new(self);
-                    ocx.register_obligation(obligation);
-                    if !ocx.try_evaluate_obligations().is_empty() {
-                        return Err(TypeError::Mismatch);
-                    }
-                    coercion.obligations.extend(ocx.into_pending_obligations());
-                    continue;
-                }
-                _ => {
-                    coercion.obligations.push(obligation);
-                    continue;
-                }
-            };
-            debug!("coerce_unsized resolve step: {:?}", trait_pred);
-            match selcx.select(&obligation.with(selcx.tcx(), trait_pred)) {
-                // Uncertain or unimplemented.
-                Ok(None) => {
-                    if trait_pred.def_id() == unsize_did {
-                        let self_ty = trait_pred.self_ty();
-                        let unsize_ty = trait_pred.trait_ref.args[1].expect_ty();
-                        debug!("coerce_unsized: ambiguous unsize case for {:?}", trait_pred);
-                        match (self_ty.kind(), unsize_ty.kind()) {
-                            (&ty::Infer(ty::TyVar(v)), ty::Dynamic(..))
-                                if self.type_var_is_sized(v) =>
-                            {
-                                debug!("coerce_unsized: have sized infer {:?}", v);
-                                coercion.obligations.push(obligation);
-                                // `$0: Unsize<dyn Trait>` where we know that `$0: Sized`, try going
-                                // for unsizing.
-                            }
-                            _ => {
-                                // Some other case for `$0: Unsize<Something>`. Note that we
-                                // hit this case even if `Something` is a sized type, so just
-                                // don't do the coercion.
-                                debug!("coerce_unsized: ambiguous unsize");
-                                return Err(TypeError::Mismatch);
-                            }
-                        }
-                    } else {
-                        debug!("coerce_unsized: early return - ambiguous");
-                        return Err(TypeError::Mismatch);
-                    }
-                }
-                Err(SelectionError::Unimplemented) => {
-                    debug!("coerce_unsized: early return - can't prove obligation");
-                    return Err(TypeError::Mismatch);
-                }
+            if self
+                .infcx
+                .visit_proof_tree(
+                    Goal::new(self.tcx, self.param_env, pred),
+                    &mut CoerceVisitor { fcx: self.fcx, span: self.cause.span },
+                )
+                .is_break()
+            {
+                return Err(TypeError::Mismatch);
+            }
+        } else {
+            let mut selcx = traits::SelectionContext::new(self);
+            // Use a FIFO queue for this custom fulfillment procedure.
+            //
+            // A Vec (or SmallVec) is not a natural choice for a queue. However,
+            // this code path is hot, and this queue usually has a max length of 1
+            // and almost never more than 3. By using a SmallVec we avoid an
+            // allocation, at the (very small) cost of (occasionally) having to
+            // shift subsequent elements down when removing the front element.
+            let mut queue: SmallVec<[PredicateObligation<'tcx>; 4]> = smallvec![obligation];
 
-                Err(SelectionError::TraitDynIncompatible(_)) => {
-                    // Dyn compatibility errors in coercion will *always* be due to the
-                    // fact that the RHS of the coercion is a non-dyn compatible `dyn Trait`
-                    // written in source somewhere (otherwise we will never have lowered
-                    // the dyn trait from HIR to middle).
-                    //
-                    // There's no reason to emit yet another dyn compatibility error,
-                    // especially since the span will differ slightly and thus not be
-                    // deduplicated at all!
-                    self.fcx.set_tainted_by_errors(
-                        self.fcx
-                            .dcx()
-                            .span_delayed_bug(self.cause.span, "dyn compatibility during coercion"),
-                    );
-                }
-                Err(err) => {
-                    let guar = self.err_ctxt().report_selection_error(
-                        obligation.clone(),
-                        &obligation,
-                        &err,
-                    );
-                    self.fcx.set_tainted_by_errors(guar);
-                    // Treat this like an obligation and follow through
-                    // with the unsizing - the lack of a coercion should
-                    // be silent, as it causes a type mismatch later.
-                }
-
-                Ok(Some(ImplSource::UserDefined(impl_source))) => {
-                    queue.extend(impl_source.nested);
-                    // Certain incoherent `CoerceUnsized` implementations may cause ICEs,
-                    // so check the impl's validity. Taint the body so that we don't try
-                    // to evaluate these invalid coercions in CTFE. We only need to do this
-                    // for local impls, since upstream impls should be valid.
-                    if impl_source.impl_def_id.is_local()
-                        && let Err(guar) =
-                            self.tcx.ensure_ok().coerce_unsized_info(impl_source.impl_def_id)
+            // Keep resolving `CoerceUnsized` and `Unsize` predicates to avoid
+            // emitting a coercion in cases like `Foo<$1>` -> `Foo<$2>`, where
+            // inference might unify those two inner type variables later.
+            let traits = [coerce_unsized_did, unsize_did];
+            while !queue.is_empty() {
+                let obligation = queue.remove(0);
+                let trait_pred = match obligation.predicate.kind().no_bound_vars() {
+                    Some(ty::PredicateKind::Clause(ty::ClauseKind::Trait(trait_pred)))
+                        if traits.contains(&trait_pred.def_id()) =>
                     {
-                        self.fcx.set_tainted_by_errors(guar);
+                        self.resolve_vars_if_possible(trait_pred)
                     }
+                    // Eagerly process alias-relate obligations in new trait solver,
+                    // since these can be emitted in the process of solving trait goals,
+                    // but we need to constrain vars before processing goals mentioning
+                    // them.
+                    Some(ty::PredicateKind::AliasRelate(..)) => {
+                        let ocx = ObligationCtxt::new(self);
+                        ocx.register_obligation(obligation);
+                        if !ocx.try_evaluate_obligations().is_empty() {
+                            return Err(TypeError::Mismatch);
+                        }
+                        coercion.obligations.extend(ocx.into_pending_obligations());
+                        continue;
+                    }
+                    _ => {
+                        coercion.obligations.push(obligation);
+                        continue;
+                    }
+                };
+                debug!("coerce_unsized resolve step: {:?}", trait_pred);
+                match selcx.select(&obligation.with(selcx.tcx(), trait_pred)) {
+                    // Uncertain or unimplemented.
+                    Ok(None) => {
+                        if trait_pred.def_id() == unsize_did {
+                            let self_ty = trait_pred.self_ty();
+                            let unsize_ty = trait_pred.trait_ref.args[1].expect_ty();
+                            debug!("coerce_unsized: ambiguous unsize case for {:?}", trait_pred);
+                            match (self_ty.kind(), unsize_ty.kind()) {
+                                (&ty::Infer(ty::TyVar(v)), ty::Dynamic(..))
+                                    if self.type_var_is_sized(v) =>
+                                {
+                                    debug!("coerce_unsized: have sized infer {:?}", v);
+                                    coercion.obligations.push(obligation);
+                                    // `$0: Unsize<dyn Trait>` where we know that `$0: Sized`, try going
+                                    // for unsizing.
+                                }
+                                _ => {
+                                    // Some other case for `$0: Unsize<Something>`. Note that we
+                                    // hit this case even if `Something` is a sized type, so just
+                                    // don't do the coercion.
+                                    debug!("coerce_unsized: ambiguous unsize");
+                                    return Err(TypeError::Mismatch);
+                                }
+                            }
+                        } else {
+                            debug!("coerce_unsized: early return - ambiguous");
+                            return Err(TypeError::Mismatch);
+                        }
+                    }
+                    Err(SelectionError::Unimplemented) => {
+                        debug!("coerce_unsized: early return - can't prove obligation");
+                        return Err(TypeError::Mismatch);
+                    }
+
+                    Err(SelectionError::TraitDynIncompatible(_)) => {
+                        // Dyn compatibility errors in coercion will *always* be due to the
+                        // fact that the RHS of the coercion is a non-dyn compatible `dyn Trait`
+                        // writen in source somewhere (otherwise we will never have lowered
+                        // the dyn trait from HIR to middle).
+                        //
+                        // There's no reason to emit yet another dyn compatibility error,
+                        // especially since the span will differ slightly and thus not be
+                        // deduplicated at all!
+                        self.fcx.set_tainted_by_errors(self.fcx.dcx().span_delayed_bug(
+                            self.cause.span,
+                            "dyn compatibility during coercion",
+                        ));
+                    }
+                    Err(err) => {
+                        let guar = self.err_ctxt().report_selection_error(
+                            obligation.clone(),
+                            &obligation,
+                            &err,
+                        );
+                        self.fcx.set_tainted_by_errors(guar);
+                        // Treat this like an obligation and follow through
+                        // with the unsizing - the lack of a coercion should
+                        // be silent, as it causes a type mismatch later.
+                    }
+                    Ok(Some(ImplSource::UserDefined(impl_source))) => {
+                        queue.extend(impl_source.nested);
+                        // Certain incoherent `CoerceUnsized` implementations may cause ICEs,
+                        // so check the impl's validity. Taint the body so that we don't try
+                        // to evaluate these invalid coercions in CTFE. We only need to do this
+                        // for local impls, since upstream impls should be valid.
+                        if impl_source.impl_def_id.is_local()
+                            && let Err(guar) =
+                                self.tcx.ensure_ok().coerce_unsized_info(impl_source.impl_def_id)
+                        {
+                            self.fcx.set_tainted_by_errors(guar);
+                        }
+                    }
+                    Ok(Some(impl_source)) => queue.extend(impl_source.nested_obligations()),
                 }
-                Ok(Some(impl_source)) => queue.extend(impl_source.nested_obligations()),
             }
         }
 
@@ -2003,5 +2014,54 @@ impl AsCoercionSite for ! {
 impl AsCoercionSite for hir::Arm<'_> {
     fn as_coercion_site(&self) -> &hir::Expr<'_> {
         self.body
+    }
+}
+
+/// Recursively visit goals to decide whether an unsizing is possible.
+/// `Break`s when it isn't, and an error should be raised.
+/// `Continue`s when an unsizing ok based on an implementation of the `Unsize` trait / lang item.
+struct CoerceVisitor<'a, 'tcx> {
+    fcx: &'a FnCtxt<'a, 'tcx>,
+    span: Span,
+}
+
+impl<'tcx> ProofTreeVisitor<'tcx> for CoerceVisitor<'_, 'tcx> {
+    type Result = ControlFlow<()>;
+
+    fn span(&self) -> Span {
+        self.span
+    }
+
+    fn visit_goal(&mut self, goal: &inspect::InspectGoal<'_, 'tcx>) -> Self::Result {
+        let Some(pred) = goal.goal().predicate.as_trait_clause() else {
+            return ControlFlow::Continue(());
+        };
+
+        if !self.fcx.tcx.is_lang_item(pred.def_id(), LangItem::Unsize)
+            && !self.fcx.tcx.is_lang_item(pred.def_id(), LangItem::CoerceUnsized)
+        {
+            return ControlFlow::Continue(());
+        }
+
+        match goal.result() {
+            Ok(Certainty::Yes) => ControlFlow::Continue(()),
+            Err(NoSolution) => ControlFlow::Break(()),
+            Ok(Certainty::Maybe { .. }) => {
+                // FIXME: structurally normalize?
+                if self.fcx.tcx.is_lang_item(pred.def_id(), LangItem::Unsize)
+                    && let ty::Dynamic(..) = pred.skip_binder().trait_ref.args.type_at(1).kind()
+                    && let ty::Infer(ty::TyVar(vid)) = *pred.self_ty().skip_binder().kind()
+                    && self.fcx.type_var_is_sized(vid)
+                {
+                    ControlFlow::Continue(())
+                } else if let Some(cand) = goal.unique_applicable_candidate()
+                    && cand.shallow_certainty() == Certainty::Yes
+                {
+                    cand.visit_nested_no_probe(self)
+                } else {
+                    ControlFlow::Break(())
+                }
+            }
+        }
     }
 }

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/inspect_obligations.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/inspect_obligations.rs
@@ -6,7 +6,7 @@ use rustc_middle::ty::{self, Ty, TypeVisitableExt};
 use rustc_span::Span;
 use rustc_trait_selection::solve::Certainty;
 use rustc_trait_selection::solve::inspect::{
-    InspectConfig, InspectGoal, InferCtxtProofTreeExt, ProofTreeVisitor,
+    InferCtxtProofTreeExt, InspectConfig, InspectGoal, ProofTreeVisitor,
 };
 use tracing::{debug, instrument, trace};
 

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/inspect_obligations.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/inspect_obligations.rs
@@ -6,7 +6,7 @@ use rustc_middle::ty::{self, Ty, TypeVisitableExt};
 use rustc_span::Span;
 use rustc_trait_selection::solve::Certainty;
 use rustc_trait_selection::solve::inspect::{
-    InspectConfig, InspectGoal, ProofTreeInferCtxtExt, ProofTreeVisitor,
+    InspectConfig, InspectGoal, InferCtxtProofTreeExt, ProofTreeVisitor,
 };
 use tracing::{debug, instrument, trace};
 

--- a/compiler/rustc_trait_selection/src/solve/fulfill.rs
+++ b/compiler/rustc_trait_selection/src/solve/fulfill.rs
@@ -24,7 +24,7 @@ use tracing::instrument;
 use self::derive_errors::*;
 use super::Certainty;
 use super::delegate::SolverDelegate;
-use super::inspect::{self, ProofTreeInferCtxtExt};
+use super::inspect::{self, InferCtxtProofTreeExt};
 use crate::traits::{FulfillmentError, ScrubbedTraitError};
 
 mod derive_errors;

--- a/compiler/rustc_trait_selection/src/solve/fulfill/derive_errors.rs
+++ b/compiler/rustc_trait_selection/src/solve/fulfill/derive_errors.rs
@@ -15,7 +15,7 @@ use rustc_next_trait_solver::solve::{GoalEvaluation, SolverDelegateEvalExt as _}
 use tracing::{instrument, trace};
 
 use crate::solve::delegate::SolverDelegate;
-use crate::solve::inspect::{self, ProofTreeInferCtxtExt, ProofTreeVisitor};
+use crate::solve::inspect::{self, InferCtxtProofTreeExt, ProofTreeVisitor};
 use crate::solve::{Certainty, deeply_normalize_for_diagnostics};
 use crate::traits::{FulfillmentError, FulfillmentErrorCode, wf};
 

--- a/compiler/rustc_trait_selection/src/solve/inspect/analyse.rs
+++ b/compiler/rustc_trait_selection/src/solve/inspect/analyse.rs
@@ -463,7 +463,7 @@ pub trait ProofTreeVisitor<'tcx> {
     fn visit_goal(&mut self, goal: &InspectGoal<'_, 'tcx>) -> Self::Result;
 }
 
-#[extension(pub trait ProofTreeInferCtxtExt<'tcx>)]
+#[extension(pub trait InferCtxtProofTreeExt<'tcx>)]
 impl<'tcx> InferCtxt<'tcx> {
     fn visit_proof_tree<V: ProofTreeVisitor<'tcx>>(
         &self,

--- a/compiler/rustc_trait_selection/src/solve/select.rs
+++ b/compiler/rustc_trait_selection/src/solve/select.rs
@@ -12,7 +12,7 @@ use rustc_middle::{bug, span_bug};
 use rustc_span::Span;
 use thin_vec::thin_vec;
 
-use crate::solve::inspect::{self, ProofTreeInferCtxtExt};
+use crate::solve::inspect::{self, InferCtxtProofTreeExt};
 
 #[extension(pub trait InferCtxtSelectExt<'tcx>)]
 impl<'tcx> InferCtxt<'tcx> {

--- a/compiler/rustc_trait_selection/src/traits/coherence.rs
+++ b/compiler/rustc_trait_selection/src/traits/coherence.rs
@@ -29,7 +29,7 @@ use tracing::{debug, instrument, warn};
 use super::ObligationCtxt;
 use crate::error_reporting::traits::suggest_new_overflow_limit;
 use crate::infer::InferOk;
-use crate::solve::inspect::{InspectGoal, InferCtxtProofTreeExt, ProofTreeVisitor};
+use crate::solve::inspect::{InferCtxtProofTreeExt, InspectGoal, ProofTreeVisitor};
 use crate::solve::{SolverDelegate, deeply_normalize_for_diagnostics, inspect};
 use crate::traits::query::evaluate_obligation::InferCtxtExt;
 use crate::traits::select::IntercrateAmbiguityCause;

--- a/compiler/rustc_trait_selection/src/traits/coherence.rs
+++ b/compiler/rustc_trait_selection/src/traits/coherence.rs
@@ -29,7 +29,7 @@ use tracing::{debug, instrument, warn};
 use super::ObligationCtxt;
 use crate::error_reporting::traits::suggest_new_overflow_limit;
 use crate::infer::InferOk;
-use crate::solve::inspect::{InspectGoal, ProofTreeInferCtxtExt, ProofTreeVisitor};
+use crate::solve::inspect::{InspectGoal, InferCtxtProofTreeExt, ProofTreeVisitor};
 use crate::solve::{SolverDelegate, deeply_normalize_for_diagnostics, inspect};
 use crate::traits::query::evaluate_obligation::InferCtxtExt;
 use crate::traits::select::IntercrateAmbiguityCause;

--- a/tests/ui/dst/dst-object-from-unsized-type.current.stderr
+++ b/tests/ui/dst/dst-object-from-unsized-type.current.stderr
@@ -14,7 +14,7 @@ LL + fn test1<T: Foo>(t: &T) {
    |
 
 error[E0277]: the size for values of type `T` cannot be known at compilation time
-  --> $DIR/dst-object-from-unsized-type.rs:16:23
+  --> $DIR/dst-object-from-unsized-type.rs:17:23
    |
 LL | fn test2<T: ?Sized + Foo>(t: &T) {
    |          - this type parameter needs to be `Sized`
@@ -29,7 +29,7 @@ LL + fn test2<T: Foo>(t: &T) {
    |
 
 error[E0277]: the size for values of type `str` cannot be known at compilation time
-  --> $DIR/dst-object-from-unsized-type.rs:21:28
+  --> $DIR/dst-object-from-unsized-type.rs:23:28
    |
 LL |     let _: &[&dyn Foo] = &["hi"];
    |                            ^^^^ doesn't have a size known at compile-time
@@ -38,7 +38,7 @@ LL |     let _: &[&dyn Foo] = &["hi"];
    = note: required for the cast from `&'static str` to `&dyn Foo`
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> $DIR/dst-object-from-unsized-type.rs:26:23
+  --> $DIR/dst-object-from-unsized-type.rs:29:23
    |
 LL |     let _: &dyn Foo = x as &dyn Foo;
    |                       ^ doesn't have a size known at compile-time

--- a/tests/ui/dst/dst-object-from-unsized-type.current.stderr
+++ b/tests/ui/dst/dst-object-from-unsized-type.current.stderr
@@ -1,5 +1,5 @@
 error[E0277]: the size for values of type `T` cannot be known at compilation time
-  --> $DIR/dst-object-from-unsized-type.rs:8:23
+  --> $DIR/dst-object-from-unsized-type.rs:11:23
    |
 LL | fn test1<T: ?Sized + Foo>(t: &T) {
    |          - this type parameter needs to be `Sized`
@@ -14,7 +14,7 @@ LL + fn test1<T: Foo>(t: &T) {
    |
 
 error[E0277]: the size for values of type `T` cannot be known at compilation time
-  --> $DIR/dst-object-from-unsized-type.rs:13:23
+  --> $DIR/dst-object-from-unsized-type.rs:16:23
    |
 LL | fn test2<T: ?Sized + Foo>(t: &T) {
    |          - this type parameter needs to be `Sized`
@@ -29,7 +29,7 @@ LL + fn test2<T: Foo>(t: &T) {
    |
 
 error[E0277]: the size for values of type `str` cannot be known at compilation time
-  --> $DIR/dst-object-from-unsized-type.rs:18:28
+  --> $DIR/dst-object-from-unsized-type.rs:21:28
    |
 LL |     let _: &[&dyn Foo] = &["hi"];
    |                            ^^^^ doesn't have a size known at compile-time
@@ -38,7 +38,7 @@ LL |     let _: &[&dyn Foo] = &["hi"];
    = note: required for the cast from `&'static str` to `&dyn Foo`
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> $DIR/dst-object-from-unsized-type.rs:23:23
+  --> $DIR/dst-object-from-unsized-type.rs:26:23
    |
 LL |     let _: &dyn Foo = x as &dyn Foo;
    |                       ^ doesn't have a size known at compile-time

--- a/tests/ui/dst/dst-object-from-unsized-type.next.stderr
+++ b/tests/ui/dst/dst-object-from-unsized-type.next.stderr
@@ -1,41 +1,57 @@
-error[E0308]: mismatched types
+error[E0277]: the trait bound `&T: CoerceUnsized<&dyn Foo>` is not satisfied in `T`
   --> $DIR/dst-object-from-unsized-type.rs:11:23
    |
 LL | fn test1<T: ?Sized + Foo>(t: &T) {
-   |          - found this type parameter
+   |          - this type parameter needs to be `Sized`
 LL |     let u: &dyn Foo = t;
-   |            --------   ^ expected `&dyn Foo`, found `&T`
-   |            |
-   |            expected due to this
+   |                       ^ within `T`, the trait `Sized` is not implemented for `T`
    |
-   = note: expected reference `&dyn Foo`
-              found reference `&T`
-   = help: type parameters must be constrained to match other types
-   = note: for more information, visit https://doc.rust-lang.org/book/ch10-02-traits.html#traits-as-parameters
+   = note: required because it appears within the type `T`
+   = note: required for `&T` to implement `CoerceUnsized<&dyn Foo>`
+   = note: required for the cast from `&T` to `&dyn Foo`
+help: consider removing the `?Sized` bound to make the type parameter `Sized`
+   |
+LL - fn test1<T: ?Sized + Foo>(t: &T) {
+LL + fn test1<T: Foo>(t: &T) {
+   |
 
-error[E0605]: non-primitive cast: `&T` as `&dyn Foo`
-  --> $DIR/dst-object-from-unsized-type.rs:16:23
+error[E0277]: the trait bound `&T: CoerceUnsized<&dyn Foo>` is not satisfied in `T`
+  --> $DIR/dst-object-from-unsized-type.rs:17:23
    |
+LL | fn test2<T: ?Sized + Foo>(t: &T) {
+   |          - this type parameter needs to be `Sized`
 LL |     let v: &dyn Foo = t as &dyn Foo;
-   |                       ^^^^^^^^^^^^^ an `as` expression can only be used to convert between primitive types or to coerce to a specific trait object
+   |                       ^ within `T`, the trait `Sized` is not implemented for `T`
+   |
+   = note: required because it appears within the type `T`
+   = note: required for `&T` to implement `CoerceUnsized<&dyn Foo>`
+   = note: required for the cast from `&T` to `&dyn Foo`
+help: consider removing the `?Sized` bound to make the type parameter `Sized`
+   |
+LL - fn test2<T: ?Sized + Foo>(t: &T) {
+LL + fn test2<T: Foo>(t: &T) {
+   |
 
-error[E0308]: mismatched types
-  --> $DIR/dst-object-from-unsized-type.rs:21:28
+error[E0277]: the trait bound `&str: CoerceUnsized<&dyn Foo>` is not satisfied in `str`
+  --> $DIR/dst-object-from-unsized-type.rs:23:28
    |
 LL |     let _: &[&dyn Foo] = &["hi"];
-   |                            ^^^^ expected `&dyn Foo`, found `&str`
+   |                            ^^^^ within `str`, the trait `Sized` is not implemented for `str`
    |
-   = note: expected reference `&dyn Foo`
-              found reference `&'static str`
-   = help: `str` implements `Foo` so you could box the found value and coerce it to the trait object `Box<dyn Foo>`, you will have to change the expected type as well
+   = note: `str` is considered to contain a `[u8]` slice for auto trait purposes
+   = note: required for `&str` to implement `CoerceUnsized<&dyn Foo>`
+   = note: required for the cast from `&'static str` to `&dyn Foo`
 
-error[E0605]: non-primitive cast: `&[u8]` as `&dyn Foo`
-  --> $DIR/dst-object-from-unsized-type.rs:26:23
+error[E0277]: the trait bound `&[u8]: CoerceUnsized<&dyn Foo>` is not satisfied in `[u8]`
+  --> $DIR/dst-object-from-unsized-type.rs:29:23
    |
 LL |     let _: &dyn Foo = x as &dyn Foo;
-   |                       ^^^^^^^^^^^^^ an `as` expression can only be used to convert between primitive types or to coerce to a specific trait object
+   |                       ^ within `[u8]`, the trait `Sized` is not implemented for `[u8]`
+   |
+   = note: required because it appears within the type `[u8]`
+   = note: required for `&[u8]` to implement `CoerceUnsized<&dyn Foo>`
+   = note: required for the cast from `&[u8]` to `&dyn Foo`
 
 error: aborting due to 4 previous errors
 
-Some errors have detailed explanations: E0308, E0605.
-For more information about an error, try `rustc --explain E0308`.
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/dst/dst-object-from-unsized-type.next.stderr
+++ b/tests/ui/dst/dst-object-from-unsized-type.next.stderr
@@ -1,0 +1,41 @@
+error[E0308]: mismatched types
+  --> $DIR/dst-object-from-unsized-type.rs:11:23
+   |
+LL | fn test1<T: ?Sized + Foo>(t: &T) {
+   |          - found this type parameter
+LL |     let u: &dyn Foo = t;
+   |            --------   ^ expected `&dyn Foo`, found `&T`
+   |            |
+   |            expected due to this
+   |
+   = note: expected reference `&dyn Foo`
+              found reference `&T`
+   = help: type parameters must be constrained to match other types
+   = note: for more information, visit https://doc.rust-lang.org/book/ch10-02-traits.html#traits-as-parameters
+
+error[E0605]: non-primitive cast: `&T` as `&dyn Foo`
+  --> $DIR/dst-object-from-unsized-type.rs:16:23
+   |
+LL |     let v: &dyn Foo = t as &dyn Foo;
+   |                       ^^^^^^^^^^^^^ an `as` expression can only be used to convert between primitive types or to coerce to a specific trait object
+
+error[E0308]: mismatched types
+  --> $DIR/dst-object-from-unsized-type.rs:21:28
+   |
+LL |     let _: &[&dyn Foo] = &["hi"];
+   |                            ^^^^ expected `&dyn Foo`, found `&str`
+   |
+   = note: expected reference `&dyn Foo`
+              found reference `&'static str`
+   = help: `str` implements `Foo` so you could box the found value and coerce it to the trait object `Box<dyn Foo>`, you will have to change the expected type as well
+
+error[E0605]: non-primitive cast: `&[u8]` as `&dyn Foo`
+  --> $DIR/dst-object-from-unsized-type.rs:26:23
+   |
+LL |     let _: &dyn Foo = x as &dyn Foo;
+   |                       ^^^^^^^^^^^^^ an `as` expression can only be used to convert between primitive types or to coerce to a specific trait object
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0308, E0605.
+For more information about an error, try `rustc --explain E0308`.

--- a/tests/ui/dst/dst-object-from-unsized-type.rs
+++ b/tests/ui/dst/dst-object-from-unsized-type.rs
@@ -9,22 +9,26 @@ impl Foo for [u8] {}
 
 fn test1<T: ?Sized + Foo>(t: &T) {
     let u: &dyn Foo = t;
-    //~^ ERROR the size for values of type
+    //[current]~^ ERROR the size for values of type
+    //[next]~^^ ERROR the trait bound `&T: CoerceUnsized<&dyn Foo>` is not satisfied in `T`
 }
 
 fn test2<T: ?Sized + Foo>(t: &T) {
     let v: &dyn Foo = t as &dyn Foo;
-    //~^ ERROR the size for values of type
+    //[current]~^ ERROR the size for values of type
+    //[next]~^^ ERROR the trait bound `&T: CoerceUnsized<&dyn Foo>` is not satisfied in `T`
 }
 
 fn test3() {
     let _: &[&dyn Foo] = &["hi"];
-    //~^ ERROR the size for values of type
+    //[current]~^ ERROR the size for values of type
+    //[next]~^^ ERROR the trait bound `&str: CoerceUnsized<&dyn Foo>` is not satisfied in `str`
 }
 
 fn test4(x: &[u8]) {
     let _: &dyn Foo = x as &dyn Foo;
-    //~^ ERROR the size for values of type
+    //[current]~^ ERROR the size for values of type
+    //[next]~^^ ERROR the trait bound `&[u8]: CoerceUnsized<&dyn Foo>` is not satisfied in `[u8]`
 }
 
 fn main() { }

--- a/tests/ui/dst/dst-object-from-unsized-type.rs
+++ b/tests/ui/dst/dst-object-from-unsized-type.rs
@@ -1,4 +1,7 @@
 // Test that we cannot create objects from unsized types.
+//@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@[next] compile-flags: -Znext-solver
 
 trait Foo { fn foo(&self) {} }
 impl Foo for str {}

--- a/tests/ui/traits/next-solver/unsize-goal-mismatch-2.next.stderr
+++ b/tests/ui/traits/next-solver/unsize-goal-mismatch-2.next.stderr
@@ -1,0 +1,13 @@
+error[E0283]: type annotations needed: cannot satisfy `dyn Trait<&()>: Unsize<dyn Super<&()>>`
+  --> $DIR/unsize-goal-mismatch-2.rs:15:5
+   |
+LL |     x
+   |     ^
+   |
+   = note: cannot satisfy `dyn Trait<&()>: Unsize<dyn Super<&()>>`
+   = note: required for `Box<dyn Trait<&()>>` to implement `CoerceUnsized<Box<dyn Super<&()>>>`
+   = note: required for the cast from `Box<(dyn Trait<&'a ()> + 'static)>` to `Box<(dyn Super<&'a ()> + 'static)>`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0283`.

--- a/tests/ui/traits/next-solver/unsize-goal-mismatch-2.rs
+++ b/tests/ui/traits/next-solver/unsize-goal-mismatch-2.rs
@@ -1,0 +1,18 @@
+//@ check-pass
+//@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@[next] compile-flags: -Znext-solver
+// Test from trait-system-refactor-initiative#241:
+// Used to ICE in mir typeck because of ambiguity in the new solver.
+// The wrong (first) trait bound was selected.
+// This is fixed with new logic for unsizing coercions
+// that's independent from that of the old solver, which this test verifies.
+
+trait Super<T> {}
+trait Trait<T>: Super<T> + for<'hr> Super<&'hr ()> {}
+
+fn foo<'a>(x: Box<dyn Trait<&'a ()>>) -> Box<dyn Super<&'a ()>> {
+    x
+}
+
+fn main() {}

--- a/tests/ui/traits/next-solver/unsize-goal-mismatch-2.rs
+++ b/tests/ui/traits/next-solver/unsize-goal-mismatch-2.rs
@@ -1,7 +1,7 @@
-//@ check-pass
 //@ revisions: current next
 //@ ignore-compare-mode-next-solver (explicit revisions)
 //@[next] compile-flags: -Znext-solver
+//@[current] check-pass
 // Test from trait-system-refactor-initiative#241:
 // Used to ICE in mir typeck because of ambiguity in the new solver.
 // The wrong (first) trait bound was selected.
@@ -13,6 +13,7 @@ trait Trait<T>: Super<T> + for<'hr> Super<&'hr ()> {}
 
 fn foo<'a>(x: Box<dyn Trait<&'a ()>>) -> Box<dyn Super<&'a ()>> {
     x
+    //[next]~^ ERROR type annotations needed: cannot satisfy `dyn Trait<&()>: Unsize<dyn Super<&()>>`
 }
 
 fn main() {}

--- a/tests/ui/traits/next-solver/unsize-goal-mismatch.current.stderr
+++ b/tests/ui/traits/next-solver/unsize-goal-mismatch.current.stderr
@@ -1,0 +1,17 @@
+error[E0283]: type annotations needed: cannot satisfy `Self: Super<'a>`
+  --> $DIR/unsize-goal-mismatch.rs:11:18
+   |
+LL | trait Trait<'a>: Super<'a> + for<'hr> Super<'hr> {}
+   |                  ^^^^^^^^^
+   |
+note: multiple `impl`s or `where` clauses satisfying `Self: Super<'a>` found
+  --> $DIR/unsize-goal-mismatch.rs:10:1
+   |
+LL | trait Super<'a> {}
+   | ^^^^^^^^^^^^^^^
+LL | trait Trait<'a>: Super<'a> + for<'hr> Super<'hr> {}
+   |                              ^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0283`.

--- a/tests/ui/traits/next-solver/unsize-goal-mismatch.next.stderr
+++ b/tests/ui/traits/next-solver/unsize-goal-mismatch.next.stderr
@@ -1,0 +1,13 @@
+error[E0283]: type annotations needed: cannot satisfy `dyn Trait<'_>: Unsize<dyn Super<'_>>`
+  --> $DIR/unsize-goal-mismatch.rs:15:5
+   |
+LL |     x
+   |     ^
+   |
+   = note: cannot satisfy `dyn Trait<'_>: Unsize<dyn Super<'_>>`
+   = note: required for `Box<dyn Trait<'_>>` to implement `CoerceUnsized<Box<dyn Super<'_>>>`
+   = note: required for the cast from `Box<(dyn Trait<'a> + 'static)>` to `Box<(dyn Super<'a> + 'static)>`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0283`.

--- a/tests/ui/traits/next-solver/unsize-goal-mismatch.rs
+++ b/tests/ui/traits/next-solver/unsize-goal-mismatch.rs
@@ -1,0 +1,19 @@
+//@ check-pass
+//@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@[next] compile-flags: -Znext-solver
+// Test from trait-system-refactor-initiative#241:
+// Used to ICE in mir typeck because of ambiguity in the new solver.
+// The wrong (first) trait bound was selected.
+// This is fixed with new logic for unsizing coercions
+// that's independent from that of the old solver, which this test verifies.
+
+trait Super<'a> {}
+trait Trait<'a>: Super<'a> + for<'hr> Super<'hr> {}
+
+fn foo<'a>(x: Box<dyn Trait<'a>>) -> Box<dyn Super<'a>> {
+    x
+    //~^ ERROR type annotations needed: cannot satisfy `dyn Trait<'_>: Unsize<dyn Super<'_>>
+}
+
+fn main() {}

--- a/tests/ui/traits/next-solver/unsize-goal-mismatch.rs
+++ b/tests/ui/traits/next-solver/unsize-goal-mismatch.rs
@@ -1,4 +1,3 @@
-//@ check-pass
 //@ revisions: current next
 //@ ignore-compare-mode-next-solver (explicit revisions)
 //@[next] compile-flags: -Znext-solver
@@ -10,10 +9,11 @@
 
 trait Super<'a> {}
 trait Trait<'a>: Super<'a> + for<'hr> Super<'hr> {}
+//[current]~^ ERROR type annotations needed: cannot satisfy `Self: Super<'a>`
 
 fn foo<'a>(x: Box<dyn Trait<'a>>) -> Box<dyn Super<'a>> {
     x
-    //~^ ERROR type annotations needed: cannot satisfy `dyn Trait<'_>: Unsize<dyn Super<'_>>
+    //[next]~^ ERROR type annotations needed: cannot satisfy `dyn Trait<'_>: Unsize<dyn Super<'_>>
 }
 
 fn main() {}

--- a/tests/ui/traits/next-solver/unsize-overflow.rs
+++ b/tests/ui/traits/next-solver/unsize-overflow.rs
@@ -1,0 +1,7 @@
+//@ compile-flags: -Znext-solver
+#![recursion_limit = "8"]
+
+fn main() {
+    let _: Box<dyn Send> = Box::new(&&&&&&&1);
+    //~^ ERROR overflow evaluating the requirement `Box<&&&&&&&i32>: CoerceUnsized<Box<dyn Send>>
+}

--- a/tests/ui/traits/next-solver/unsize-overflow.stderr
+++ b/tests/ui/traits/next-solver/unsize-overflow.stderr
@@ -1,0 +1,12 @@
+error[E0275]: overflow evaluating the requirement `Box<&&&&&&&i32>: CoerceUnsized<Box<dyn Send>>`
+  --> $DIR/unsize-overflow.rs:5:28
+   |
+LL |     let _: Box<dyn Send> = Box::new(&&&&&&&1);
+   |                            ^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider increasing the recursion limit by adding a `#![recursion_limit = "16"]` attribute to your crate (`unsize_overflow`)
+   = note: required for the cast from `Box<&&&&&&&i32>` to `Box<dyn Send>`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0275`.

--- a/tests/ui/traits/trait-upcasting/higher-ranked-upcasting-ub.next.stderr
+++ b/tests/ui/traits/trait-upcasting/higher-ranked-upcasting-ub.next.stderr
@@ -1,14 +1,13 @@
-error[E0308]: mismatched types
+error[E0277]: the trait bound `&dyn for<'a> Subtrait<'a, 'a>: CoerceUnsized<&dyn for<'a, 'b> Supertrait<'a, 'b>>` is not satisfied
   --> $DIR/higher-ranked-upcasting-ub.rs:22:5
    |
-LL | fn unsound(x: &dyn for<'a> Subtrait<'a, 'a>) -> &dyn for<'a, 'b> Supertrait<'a, 'b> {
-   |                                                 ----------------------------------- expected `&dyn for<'a, 'b> Supertrait<'a, 'b>` because of return type
 LL |     x
-   |     ^ expected trait `Supertrait`, found trait `Subtrait`
+   |     ^ the trait `Unsize<dyn for<'a, 'b> Supertrait<'a, 'b>>` is not implemented for `dyn for<'a> Subtrait<'a, 'a>`
    |
-   = note: expected reference `&dyn for<'a, 'b> Supertrait<'a, 'b>`
-              found reference `&dyn for<'a> Subtrait<'a, 'a>`
+   = note: all implementations of `Unsize` are provided automatically by the compiler, see <https://doc.rust-lang.org/stable/std/marker/trait.Unsize.html> for more information
+   = note: required for `&dyn for<'a> Subtrait<'a, 'a>` to implement `CoerceUnsized<&dyn for<'a, 'b> Supertrait<'a, 'b>>`
+   = note: required for the cast from `&dyn for<'a> Subtrait<'a, 'a>` to `&dyn for<'a, 'b> Supertrait<'a, 'b>`
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0308`.
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/traits/trait-upcasting/higher-ranked-upcasting-ub.rs
+++ b/tests/ui/traits/trait-upcasting/higher-ranked-upcasting-ub.rs
@@ -19,8 +19,10 @@ impl<'a> Supertrait<'a, 'a> for () {
 }
 impl<'a> Subtrait<'a, 'a> for () {}
 fn unsound(x: &dyn for<'a> Subtrait<'a, 'a>) -> &dyn for<'a, 'b> Supertrait<'a, 'b> {
-    x //~ ERROR mismatched types
+    x
     //[current]~^ ERROR mismatched types
+    //[current]~| ERROR mismatched types
+    //[next]~^^^ ERROR the trait bound `&dyn for<'a> Subtrait<'a, 'a>: CoerceUnsized<&dyn for<'a, 'b> Supertrait<'a, 'b>>` is not satisfied
 }
 
 fn transmute<'a, 'b>(x: &'a str) -> &'b str {


### PR DESCRIPTION
Replaces https://github.com/rust-lang/rust/pull/141926, contains:
 
- a commit adding tests that fail before this work
- the two commits from the previous PR
- a commit in which these tests are fixed
- finally, a fixup for an in my opinion rather large regression in diagnostics. It's still not perfect, but better?

I hope this is roughly what you had in mind

Fixes https://github.com/rust-lang/trait-system-refactor-initiative/issues/241 and https://github.com/rust-lang/trait-system-refactor-initiative/issues/238, adding tests for both

r? @lcnr