### PR TITLE
GVN: Bail out if the address cannot be dereferenced.

### DIFF
--- a/tests/mir-opt/gvn.dereferences.GVN.panic-abort.diff
+++ b/tests/mir-opt/gvn.dereferences.GVN.panic-abort.diff
@@ -108,7 +108,8 @@
           _18 = &(*_1);
           StorageLive(_19);
           StorageLive(_20);
-          _20 = copy (*_18);
+-         _20 = copy (*_18);
++         _20 = copy (*_1);
           _19 = opaque::<u32>(move _20) -> [return: bb7, unwind unreachable];
       }
   
@@ -117,7 +118,8 @@
           StorageDead(_19);
           StorageLive(_21);
           StorageLive(_22);
-          _22 = copy (*_18);
+-         _22 = copy (*_18);
++         _22 = copy (*_1);
           _21 = opaque::<u32>(move _22) -> [return: bb8, unwind unreachable];
       }
   

--- a/tests/mir-opt/gvn.dereferences.GVN.panic-unwind.diff
+++ b/tests/mir-opt/gvn.dereferences.GVN.panic-unwind.diff
@@ -108,7 +108,8 @@
           _18 = &(*_1);
           StorageLive(_19);
           StorageLive(_20);
-          _20 = copy (*_18);
+-         _20 = copy (*_18);
++         _20 = copy (*_1);
           _19 = opaque::<u32>(move _20) -> [return: bb7, unwind continue];
       }
   
@@ -117,7 +118,8 @@
           StorageDead(_19);
           StorageLive(_21);
           StorageLive(_22);
-          _22 = copy (*_18);
+-         _22 = copy (*_18);
++         _22 = copy (*_1);
           _21 = opaque::<u32>(move _22) -> [return: bb8, unwind continue];
       }
   

--- a/tests/mir-opt/gvn.fn_pointers.GVN.panic-abort.diff
+++ b/tests/mir-opt/gvn.fn_pointers.GVN.panic-abort.diff
@@ -8,10 +8,10 @@
       let mut _3: fn(u8) -> u8;
       let _5: ();
       let mut _6: fn(u8) -> u8;
-      let mut _9: {closure@$DIR/gvn.rs:617:19: 617:21};
+      let mut _9: {closure@$DIR/gvn.rs:616:19: 616:21};
       let _10: ();
       let mut _11: fn();
-      let mut _13: {closure@$DIR/gvn.rs:617:19: 617:21};
+      let mut _13: {closure@$DIR/gvn.rs:616:19: 616:21};
       let _14: ();
       let mut _15: fn();
       scope 1 {
@@ -19,7 +19,7 @@
           let _4: fn(u8) -> u8;
           scope 2 {
               debug g => _4;
-              let _7: {closure@$DIR/gvn.rs:617:19: 617:21};
+              let _7: {closure@$DIR/gvn.rs:616:19: 616:21};
               scope 3 {
                   debug closure => _7;
                   let _8: fn();
@@ -62,16 +62,16 @@
           StorageDead(_6);
           StorageDead(_5);
 -         StorageLive(_7);
--         _7 = {closure@$DIR/gvn.rs:617:19: 617:21};
+-         _7 = {closure@$DIR/gvn.rs:616:19: 616:21};
 -         StorageLive(_8);
 +         nop;
-+         _7 = const ZeroSized: {closure@$DIR/gvn.rs:617:19: 617:21};
++         _7 = const ZeroSized: {closure@$DIR/gvn.rs:616:19: 616:21};
 +         nop;
           StorageLive(_9);
 -         _9 = copy _7;
 -         _8 = move _9 as fn() (PointerCoercion(ClosureFnPointer(Safe), AsCast));
-+         _9 = const ZeroSized: {closure@$DIR/gvn.rs:617:19: 617:21};
-+         _8 = const ZeroSized: {closure@$DIR/gvn.rs:617:19: 617:21} as fn() (PointerCoercion(ClosureFnPointer(Safe), AsCast));
++         _9 = const ZeroSized: {closure@$DIR/gvn.rs:616:19: 616:21};
++         _8 = const ZeroSized: {closure@$DIR/gvn.rs:616:19: 616:21} as fn() (PointerCoercion(ClosureFnPointer(Safe), AsCast));
           StorageDead(_9);
           StorageLive(_10);
           StorageLive(_11);
@@ -88,8 +88,8 @@
           StorageLive(_13);
 -         _13 = copy _7;
 -         _12 = move _13 as fn() (PointerCoercion(ClosureFnPointer(Safe), AsCast));
-+         _13 = const ZeroSized: {closure@$DIR/gvn.rs:617:19: 617:21};
-+         _12 = const ZeroSized: {closure@$DIR/gvn.rs:617:19: 617:21} as fn() (PointerCoercion(ClosureFnPointer(Safe), AsCast));
++         _13 = const ZeroSized: {closure@$DIR/gvn.rs:616:19: 616:21};
++         _12 = const ZeroSized: {closure@$DIR/gvn.rs:616:19: 616:21} as fn() (PointerCoercion(ClosureFnPointer(Safe), AsCast));
           StorageDead(_13);
           StorageLive(_14);
           StorageLive(_15);

--- a/tests/mir-opt/gvn.fn_pointers.GVN.panic-unwind.diff
+++ b/tests/mir-opt/gvn.fn_pointers.GVN.panic-unwind.diff
@@ -8,10 +8,10 @@
       let mut _3: fn(u8) -> u8;
       let _5: ();
       let mut _6: fn(u8) -> u8;
-      let mut _9: {closure@$DIR/gvn.rs:617:19: 617:21};
+      let mut _9: {closure@$DIR/gvn.rs:616:19: 616:21};
       let _10: ();
       let mut _11: fn();
-      let mut _13: {closure@$DIR/gvn.rs:617:19: 617:21};
+      let mut _13: {closure@$DIR/gvn.rs:616:19: 616:21};
       let _14: ();
       let mut _15: fn();
       scope 1 {
@@ -19,7 +19,7 @@
           let _4: fn(u8) -> u8;
           scope 2 {
               debug g => _4;
-              let _7: {closure@$DIR/gvn.rs:617:19: 617:21};
+              let _7: {closure@$DIR/gvn.rs:616:19: 616:21};
               scope 3 {
                   debug closure => _7;
                   let _8: fn();
@@ -62,16 +62,16 @@
           StorageDead(_6);
           StorageDead(_5);
 -         StorageLive(_7);
--         _7 = {closure@$DIR/gvn.rs:617:19: 617:21};
+-         _7 = {closure@$DIR/gvn.rs:616:19: 616:21};
 -         StorageLive(_8);
 +         nop;
-+         _7 = const ZeroSized: {closure@$DIR/gvn.rs:617:19: 617:21};
++         _7 = const ZeroSized: {closure@$DIR/gvn.rs:616:19: 616:21};
 +         nop;
           StorageLive(_9);
 -         _9 = copy _7;
 -         _8 = move _9 as fn() (PointerCoercion(ClosureFnPointer(Safe), AsCast));
-+         _9 = const ZeroSized: {closure@$DIR/gvn.rs:617:19: 617:21};
-+         _8 = const ZeroSized: {closure@$DIR/gvn.rs:617:19: 617:21} as fn() (PointerCoercion(ClosureFnPointer(Safe), AsCast));
++         _9 = const ZeroSized: {closure@$DIR/gvn.rs:616:19: 616:21};
++         _8 = const ZeroSized: {closure@$DIR/gvn.rs:616:19: 616:21} as fn() (PointerCoercion(ClosureFnPointer(Safe), AsCast));
           StorageDead(_9);
           StorageLive(_10);
           StorageLive(_11);
@@ -88,8 +88,8 @@
           StorageLive(_13);
 -         _13 = copy _7;
 -         _12 = move _13 as fn() (PointerCoercion(ClosureFnPointer(Safe), AsCast));
-+         _13 = const ZeroSized: {closure@$DIR/gvn.rs:617:19: 617:21};
-+         _12 = const ZeroSized: {closure@$DIR/gvn.rs:617:19: 617:21} as fn() (PointerCoercion(ClosureFnPointer(Safe), AsCast));
++         _13 = const ZeroSized: {closure@$DIR/gvn.rs:616:19: 616:21};
++         _12 = const ZeroSized: {closure@$DIR/gvn.rs:616:19: 616:21} as fn() (PointerCoercion(ClosureFnPointer(Safe), AsCast));
           StorageDead(_13);
           StorageLive(_14);
           StorageLive(_15);

--- a/tests/mir-opt/gvn.rs
+++ b/tests/mir-opt/gvn.rs
@@ -499,11 +499,10 @@ fn dereferences(t: &mut u32, u: &impl Copy, s: &S<u32>) {
     unsafe { opaque(*z) };
     unsafe { opaque(*z) };
 
-    // Do not reuse dereferences of `&Freeze`.
     // CHECK: [[ref:_.*]] = &(*_1);
-    // CHECK: [[st7:_.*]] = copy (*[[ref]]);
+    // CHECK: [[st7:_.*]] = copy (*_1);
     // CHECK: opaque::<u32>(move [[st7]])
-    // CHECK: [[st8:_.*]] = copy (*[[ref]]);
+    // CHECK: [[st8:_.*]] = copy (*_1);
     // CHECK: opaque::<u32>(move [[st8]])
     let z = &*t;
     opaque(*z);

--- a/tests/mir-opt/gvn_copy_aggregate.deref_nonssa.GVN.diff
+++ b/tests/mir-opt/gvn_copy_aggregate.deref_nonssa.GVN.diff
@@ -21,9 +21,8 @@
       bb0: {
           StorageLive(_1);
 -         _1 = Single(const 0_u8);
--         StorageLive(_2);
 +         _1 = const Single(0_u8);
-+         nop;
+          StorageLive(_2);
           _2 = &_1;
 -         StorageLive(_3);
 +         nop;
@@ -37,12 +36,11 @@
           StorageLive(_5);
           _5 = copy _3;
 -         _0 = Single(move _5);
-+         _0 = copy (*_2);
++         _0 = Single(copy _3);
           StorageDead(_5);
 -         StorageDead(_3);
--         StorageDead(_2);
 +         nop;
-+         nop;
+          StorageDead(_2);
           StorageDead(_1);
           return;
       }

--- a/tests/mir-opt/gvn_copy_aggregate.deref_nonssa.GVN.diff
+++ b/tests/mir-opt/gvn_copy_aggregate.deref_nonssa.GVN.diff
@@ -1,0 +1,50 @@
+- // MIR for `deref_nonssa` before GVN
++ // MIR for `deref_nonssa` after GVN
+  
+  fn deref_nonssa() -> Single {
+      let mut _0: Single;
+      let mut _1: Single;
+      let mut _4: Single;
+      let mut _5: u8;
+      scope 1 {
+          debug a => _1;
+          let _2: &Single;
+          scope 2 {
+              debug b => _2;
+              let _3: u8;
+              scope 3 {
+                  debug c => _3;
+              }
+          }
+      }
+  
+      bb0: {
+          StorageLive(_1);
+-         _1 = Single(const 0_u8);
+-         StorageLive(_2);
++         _1 = const Single(0_u8);
++         nop;
+          _2 = &_1;
+-         StorageLive(_3);
++         nop;
+          _3 = copy ((*_2).0: u8);
+          StorageLive(_4);
+-         _4 = Single(const 1_u8);
+-         _1 = move _4;
++         _4 = const Single(1_u8);
++         _1 = const Single(1_u8);
+          StorageDead(_4);
+          StorageLive(_5);
+          _5 = copy _3;
+-         _0 = Single(move _5);
++         _0 = copy (*_2);
+          StorageDead(_5);
+-         StorageDead(_3);
+-         StorageDead(_2);
++         nop;
++         nop;
+          StorageDead(_1);
+          return;
+      }
+  }
+  

--- a/tests/mir-opt/gvn_copy_aggregate.rs
+++ b/tests/mir-opt/gvn_copy_aggregate.rs
@@ -259,3 +259,15 @@ fn remove_storage_dead_from_index(f: fn() -> usize, v: [SameType; 5]) -> SameTyp
         }
     }
 }
+
+pub struct Single(u8);
+
+// EMIT_MIR gvn_copy_aggregate.deref_nonssa.GVN.diff
+fn deref_nonssa() -> Single {
+    let mut a = Single(0);
+    let b = &a;
+    let c = (*b).0;
+    a = Single(1);
+    // GVN shouldn't replace `Single(c)` with `*b`.
+    Single(c)
+}

--- a/tests/mir-opt/gvn_copy_aggregate.rs
+++ b/tests/mir-opt/gvn_copy_aggregate.rs
@@ -264,6 +264,10 @@ pub struct Single(u8);
 
 // EMIT_MIR gvn_copy_aggregate.deref_nonssa.GVN.diff
 fn deref_nonssa() -> Single {
+    // CHECK-LABEL: fn deref_nonssa(
+    // CHECK: debug c => [[C:_.*]];
+    // CHECK-NOT: _0 = copy (*_{{.*}});
+    // CHECK: _0 = Single(copy [[C]]);
     let mut a = Single(0);
     let b = &a;
     let c = (*b).0;

--- a/tests/mir-opt/gvn_overlapping.copy_overlapping.GVN.diff
+++ b/tests/mir-opt/gvn_overlapping.copy_overlapping.GVN.diff
@@ -1,0 +1,19 @@
+- // MIR for `copy_overlapping` before GVN
++ // MIR for `copy_overlapping` after GVN
+  
+  fn copy_overlapping() -> () {
+      let mut _0: ();
+      let mut _1: Adt;
+      let mut _2: u32;
+      let mut _3: &Adt;
+  
+      bb0: {
+          ((_1 as variant#1).0: u32) = const 0_u32;
+          _3 = &_1;
+          _2 = copy (((*_3) as variant#1).0: u32);
+-         _1 = Adt::Some(copy _2);
++         _1 = copy (*_3);
+          return;
+      }
+  }
+  

--- a/tests/mir-opt/gvn_overlapping.copy_overlapping.GVN.diff
+++ b/tests/mir-opt/gvn_overlapping.copy_overlapping.GVN.diff
@@ -11,8 +11,7 @@
           ((_1 as variant#1).0: u32) = const 0_u32;
           _3 = &_1;
           _2 = copy (((*_3) as variant#1).0: u32);
--         _1 = Adt::Some(copy _2);
-+         _1 = copy (*_3);
+          _1 = Adt::Some(copy _2);
           return;
       }
   }

--- a/tests/mir-opt/gvn_overlapping.overlapping.GVN.diff
+++ b/tests/mir-opt/gvn_overlapping.overlapping.GVN.diff
@@ -10,7 +10,8 @@
       bb0: {
           _2 = &raw mut _1;
           _4 = &(*_2);
-          _3 = copy (((*_4) as variant#1).0: u32);
+-         _3 = copy (((*_4) as variant#1).0: u32);
++         _3 = copy (((*_2) as variant#1).0: u32);
           (*_2) = Adt::Some(copy _3);
           return;
       }

--- a/tests/mir-opt/gvn_overlapping.rs
+++ b/tests/mir-opt/gvn_overlapping.rs
@@ -64,6 +64,23 @@ fn fields(_1: (Adt, Adt)) {
     }
 }
 
+// EMIT_MIR gvn_overlapping.copy_overlapping.GVN.diff
+#[custom_mir(dialect = "runtime")]
+fn copy_overlapping() {
+    mir! {
+        let _1;
+        let _2;
+        let _3;
+        {
+            place!(Field(Variant(_1, 1), 0)) = 0u32;
+            _3 = &_1;
+            _2 = Field(Variant(*_3, 1), 0);
+            _1 = Adt::Some(_2);
+            Return()
+        }
+    }
+}
+
 fn main() {
     overlapping(Adt::Some(0));
 }

--- a/tests/mir-opt/gvn_overlapping.rs
+++ b/tests/mir-opt/gvn_overlapping.rs
@@ -32,7 +32,7 @@ fn stable_projection(_1: (Adt,)) {
     // CHECK-LABEL: fn stable_projection(
     // CHECK: let mut _2: *mut Adt;
     // CHECK: let mut _4: &Adt;
-    // CHECK: (_1.0: Adt) = copy (*_4);
+    // CHECK: (_1.0: Adt) = copy (*_2);
     mir! {
         let _2: *mut Adt;
         let _3: u32;
@@ -67,6 +67,9 @@ fn fields(_1: (Adt, Adt)) {
 // EMIT_MIR gvn_overlapping.copy_overlapping.GVN.diff
 #[custom_mir(dialect = "runtime")]
 fn copy_overlapping() {
+    // CHECK-LABEL: fn copy_overlapping(
+    // CHECK-NOT: _1 = copy (*_{{.*}});
+    // CHECK: _1 = Adt::Some(copy _2);
     mir! {
         let _1;
         let _2;

--- a/tests/mir-opt/gvn_overlapping.stable_projection.GVN.diff
+++ b/tests/mir-opt/gvn_overlapping.stable_projection.GVN.diff
@@ -10,9 +10,10 @@
       bb0: {
           _2 = &raw mut (_1.0: Adt);
           _4 = &(*_2);
-          _3 = copy (((*_4) as variant#1).0: u32);
+-         _3 = copy (((*_4) as variant#1).0: u32);
 -         (_1.0: Adt) = Adt::Some(copy _3);
-+         (_1.0: Adt) = copy (*_4);
++         _3 = copy (((*_2) as variant#1).0: u32);
++         (_1.0: Adt) = copy (*_2);
           return;
       }
   }


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/141313 and https://github.com/rust-lang/rust/issues/141313#issuecomment-3417917156.

We should always use VnIndex when dereferencing an address in GVN.

r? cjgillot
r? tmiasko (since you found that)