### PR TITLE
Allow unused `Result`s with an uninhabited error type

### DIFF
--- a/tests/ui/lint/unused/must-use-uninhabited-result-e.rs
+++ b/tests/ui/lint/unused/must-use-uninhabited-result-e.rs
@@ -1,0 +1,32 @@
+// This test checks for uninhabited error type in a result interacts with must
+// use lint. Ideally we don't want to lint on `Result<T, !>` as something that
+// must be used, because it's equivalent to `T`. However, we need to make sure
+// that if there are other reasons for the lint, we still emit it.
+//
+// See also: <https://github.com/rust-lang/rust/issues/65861>.
+//
+//@ aux-build:../../../pattern/usefulness/auxiliary/empty.rs
+//@ check-pass
+#![warn(unused)]
+#![feature(never_type)]
+
+extern crate empty;
+
+fn main() {
+    Ok::<_, std::convert::Infallible>(()); //~ warn: unused `Result` that must be used
+    Ok::<_, empty::EmptyForeignEnum>(()); //~ warn: unused `Result` that must be used
+    Ok::<_, empty::VisiblyUninhabitedForeignStruct>(()); //~ warn: unused `Result` that must be used
+    Ok::<_, empty::SecretlyUninhabitedForeignStruct>(()); //~ warn: unused `Result` that must be used
+    Ok::<_, !>(()); //~ warn: unused `Result` that must be used
+
+    Ok::<_, !>(Important); //~ warn: unused `Result` that must be used
+
+    very_important(); //~ warn: unused return value of `very_important` that must be used
+                      //~| warn: unused `Result` that must be used
+}
+
+#[must_use]
+struct Important;
+
+#[must_use]
+fn very_important() -> Result<(), !> { Ok(()) }

--- a/tests/ui/lint/unused/must-use-uninhabited-result-e.rs
+++ b/tests/ui/lint/unused/must-use-uninhabited-result-e.rs
@@ -13,16 +13,15 @@
 extern crate empty;
 
 fn main() {
-    Ok::<_, std::convert::Infallible>(()); //~ warn: unused `Result` that must be used
-    Ok::<_, empty::EmptyForeignEnum>(()); //~ warn: unused `Result` that must be used
-    Ok::<_, empty::VisiblyUninhabitedForeignStruct>(()); //~ warn: unused `Result` that must be used
+    Ok::<_, std::convert::Infallible>(());
+    Ok::<_, empty::EmptyForeignEnum>(());
+    Ok::<_, empty::VisiblyUninhabitedForeignStruct>(());
     Ok::<_, empty::SecretlyUninhabitedForeignStruct>(()); //~ warn: unused `Result` that must be used
-    Ok::<_, !>(()); //~ warn: unused `Result` that must be used
+    Ok::<_, !>(());
 
-    Ok::<_, !>(Important); //~ warn: unused `Result` that must be used
+    Ok::<_, !>(Important); //~ warn: unused `Important` that must be used
 
     very_important(); //~ warn: unused return value of `very_important` that must be used
-                      //~| warn: unused `Result` that must be used
 }
 
 #[must_use]

--- a/tests/ui/lint/unused/must-use-uninhabited-result-e.stderr
+++ b/tests/ui/lint/unused/must-use-uninhabited-result-e.stderr
@@ -1,8 +1,8 @@
 warning: unused `Result` that must be used
-  --> $DIR/must-use-uninhabited-result-e.rs:16:5
+  --> $DIR/must-use-uninhabited-result-e.rs:19:5
    |
-LL |     Ok::<_, std::convert::Infallible>(());
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     Ok::<_, empty::SecretlyUninhabitedForeignStruct>(());
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: this `Result` may be an `Err` variant, which should be handled
 note: the lint level is defined here
@@ -13,79 +13,18 @@ LL | #![warn(unused)]
    = note: `#[warn(unused_must_use)]` implied by `#[warn(unused)]`
 help: use `let _ = ...` to ignore the resulting value
    |
-LL |     let _ = Ok::<_, std::convert::Infallible>(());
-   |     +++++++
-
-warning: unused `Result` that must be used
-  --> $DIR/must-use-uninhabited-result-e.rs:17:5
-   |
-LL |     Ok::<_, empty::EmptyForeignEnum>(());
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this `Result` may be an `Err` variant, which should be handled
-help: use `let _ = ...` to ignore the resulting value
-   |
-LL |     let _ = Ok::<_, empty::EmptyForeignEnum>(());
-   |     +++++++
-
-warning: unused `Result` that must be used
-  --> $DIR/must-use-uninhabited-result-e.rs:18:5
-   |
-LL |     Ok::<_, empty::VisiblyUninhabitedForeignStruct>(());
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this `Result` may be an `Err` variant, which should be handled
-help: use `let _ = ...` to ignore the resulting value
-   |
-LL |     let _ = Ok::<_, empty::VisiblyUninhabitedForeignStruct>(());
-   |     +++++++
-
-warning: unused `Result` that must be used
-  --> $DIR/must-use-uninhabited-result-e.rs:19:5
-   |
-LL |     Ok::<_, empty::SecretlyUninhabitedForeignStruct>(());
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this `Result` may be an `Err` variant, which should be handled
-help: use `let _ = ...` to ignore the resulting value
-   |
 LL |     let _ = Ok::<_, empty::SecretlyUninhabitedForeignStruct>(());
    |     +++++++
 
-warning: unused `Result` that must be used
-  --> $DIR/must-use-uninhabited-result-e.rs:20:5
-   |
-LL |     Ok::<_, !>(());
-   |     ^^^^^^^^^^^^^^
-   |
-   = note: this `Result` may be an `Err` variant, which should be handled
-help: use `let _ = ...` to ignore the resulting value
-   |
-LL |     let _ = Ok::<_, !>(());
-   |     +++++++
-
-warning: unused `Result` that must be used
+warning: unused `Important` that must be used
   --> $DIR/must-use-uninhabited-result-e.rs:22:5
    |
 LL |     Ok::<_, !>(Important);
    |     ^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: this `Result` may be an `Err` variant, which should be handled
 help: use `let _ = ...` to ignore the resulting value
    |
 LL |     let _ = Ok::<_, !>(Important);
-   |     +++++++
-
-warning: unused `Result` that must be used
-  --> $DIR/must-use-uninhabited-result-e.rs:24:5
-   |
-LL |     very_important();
-   |     ^^^^^^^^^^^^^^^^
-   |
-   = note: this `Result` may be an `Err` variant, which should be handled
-help: use `let _ = ...` to ignore the resulting value
-   |
-LL |     let _ = very_important();
    |     +++++++
 
 warning: unused return value of `very_important` that must be used
@@ -99,5 +38,5 @@ help: use `let _ = ...` to ignore the resulting value
 LL |     let _ = very_important();
    |     +++++++
 
-warning: 8 warnings emitted
+warning: 3 warnings emitted
 

--- a/tests/ui/lint/unused/must-use-uninhabited-result-e.stderr
+++ b/tests/ui/lint/unused/must-use-uninhabited-result-e.stderr
@@ -1,0 +1,103 @@
+warning: unused `Result` that must be used
+  --> $DIR/must-use-uninhabited-result-e.rs:16:5
+   |
+LL |     Ok::<_, std::convert::Infallible>(());
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this `Result` may be an `Err` variant, which should be handled
+note: the lint level is defined here
+  --> $DIR/must-use-uninhabited-result-e.rs:10:9
+   |
+LL | #![warn(unused)]
+   |         ^^^^^^
+   = note: `#[warn(unused_must_use)]` implied by `#[warn(unused)]`
+help: use `let _ = ...` to ignore the resulting value
+   |
+LL |     let _ = Ok::<_, std::convert::Infallible>(());
+   |     +++++++
+
+warning: unused `Result` that must be used
+  --> $DIR/must-use-uninhabited-result-e.rs:17:5
+   |
+LL |     Ok::<_, empty::EmptyForeignEnum>(());
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this `Result` may be an `Err` variant, which should be handled
+help: use `let _ = ...` to ignore the resulting value
+   |
+LL |     let _ = Ok::<_, empty::EmptyForeignEnum>(());
+   |     +++++++
+
+warning: unused `Result` that must be used
+  --> $DIR/must-use-uninhabited-result-e.rs:18:5
+   |
+LL |     Ok::<_, empty::VisiblyUninhabitedForeignStruct>(());
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this `Result` may be an `Err` variant, which should be handled
+help: use `let _ = ...` to ignore the resulting value
+   |
+LL |     let _ = Ok::<_, empty::VisiblyUninhabitedForeignStruct>(());
+   |     +++++++
+
+warning: unused `Result` that must be used
+  --> $DIR/must-use-uninhabited-result-e.rs:19:5
+   |
+LL |     Ok::<_, empty::SecretlyUninhabitedForeignStruct>(());
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this `Result` may be an `Err` variant, which should be handled
+help: use `let _ = ...` to ignore the resulting value
+   |
+LL |     let _ = Ok::<_, empty::SecretlyUninhabitedForeignStruct>(());
+   |     +++++++
+
+warning: unused `Result` that must be used
+  --> $DIR/must-use-uninhabited-result-e.rs:20:5
+   |
+LL |     Ok::<_, !>(());
+   |     ^^^^^^^^^^^^^^
+   |
+   = note: this `Result` may be an `Err` variant, which should be handled
+help: use `let _ = ...` to ignore the resulting value
+   |
+LL |     let _ = Ok::<_, !>(());
+   |     +++++++
+
+warning: unused `Result` that must be used
+  --> $DIR/must-use-uninhabited-result-e.rs:22:5
+   |
+LL |     Ok::<_, !>(Important);
+   |     ^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this `Result` may be an `Err` variant, which should be handled
+help: use `let _ = ...` to ignore the resulting value
+   |
+LL |     let _ = Ok::<_, !>(Important);
+   |     +++++++
+
+warning: unused `Result` that must be used
+  --> $DIR/must-use-uninhabited-result-e.rs:24:5
+   |
+LL |     very_important();
+   |     ^^^^^^^^^^^^^^^^
+   |
+   = note: this `Result` may be an `Err` variant, which should be handled
+help: use `let _ = ...` to ignore the resulting value
+   |
+LL |     let _ = very_important();
+   |     +++++++
+
+warning: unused return value of `very_important` that must be used
+  --> $DIR/must-use-uninhabited-result-e.rs:24:5
+   |
+LL |     very_important();
+   |     ^^^^^^^^^^^^^^^^
+   |
+help: use `let _ = ...` to ignore the resulting value
+   |
+LL |     let _ = very_important();
+   |     +++++++
+
+warning: 8 warnings emitted
+


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Fixes rust-lang/rust#65861

r? Nadrieril 