### PR TITLE
Parse `const unsafe trait` properly

### DIFF
--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -2664,7 +2664,10 @@ impl<'a> Parser<'a> {
                         // Rule out `unsafe extern {`.
                         && !self.is_unsafe_foreign_mod()
                         // Rule out `async gen {` and `async gen move {`
-                        && !self.is_async_gen_block())
+                        && !self.is_async_gen_block()
+                        // Rule out `const unsafe auto` and `const unsafe trait`.
+                        && !self.is_keyword_ahead(2, &[kw::Auto, kw::Trait])
+                    )
                 })
             // `extern ABI fn`
             || self.check_keyword_case(exp!(Extern), case)

--- a/tests/ui/traits/const-traits/parse-const-unsafe-trait.rs
+++ b/tests/ui/traits/const-traits/parse-const-unsafe-trait.rs
@@ -1,0 +1,13 @@
+// Test that `const unsafe trait` and `const unsafe auto trait` works.
+
+//@ check-pass
+
+#![feature(const_trait_impl)]
+#![feature(auto_traits)]
+
+pub const unsafe trait Owo {}
+const unsafe trait OwO {}
+pub const unsafe auto trait UwU {}
+const unsafe auto trait Uwu {}
+
+fn main() {}


### PR DESCRIPTION
Previously, this was greedily stolen by the `fn` parsing logic.

r? project-const-traits