### PR TITLE
Deduce captures(none) for a return place and parameters

### DIFF
--- a/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
@@ -289,6 +289,7 @@ pub(crate) enum AttributeKind {
     DeadOnUnwind = 43,
     DeadOnReturn = 44,
     CapturesReadOnly = 45,
+    CapturesNone = 46,
 }
 
 /// LLVMIntPredicate

--- a/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
@@ -245,6 +245,7 @@ enum class LLVMRustAttributeKind {
   DeadOnUnwind = 43,
   DeadOnReturn = 44,
   CapturesReadOnly = 45,
+  CapturesNone = 46,
 };
 
 static Attribute::AttrKind fromRust(LLVMRustAttributeKind Kind) {
@@ -339,6 +340,7 @@ static Attribute::AttrKind fromRust(LLVMRustAttributeKind Kind) {
 #endif
   case LLVMRustAttributeKind::CapturesAddress:
   case LLVMRustAttributeKind::CapturesReadOnly:
+  case LLVMRustAttributeKind::CapturesNone:
     report_fatal_error("Should be handled separately");
   }
   report_fatal_error("bad LLVMRustAttributeKind");
@@ -390,6 +392,9 @@ extern "C" void LLVMRustEraseInstFromParent(LLVMValueRef Instr) {
 extern "C" LLVMAttributeRef
 LLVMRustCreateAttrNoValue(LLVMContextRef C, LLVMRustAttributeKind RustAttr) {
 #if LLVM_VERSION_GE(21, 0)
+  if (RustAttr == LLVMRustAttributeKind::CapturesNone) {
+    return wrap(Attribute::getWithCaptureInfo(*unwrap(C), CaptureInfo::none()));
+  }
   if (RustAttr == LLVMRustAttributeKind::CapturesAddress) {
     return wrap(Attribute::getWithCaptureInfo(
         *unwrap(C), CaptureInfo(CaptureComponents::Address)));

--- a/compiler/rustc_target/src/callconv/mod.rs
+++ b/compiler/rustc_target/src/callconv/mod.rs
@@ -113,13 +113,14 @@ mod attr_impl {
     pub struct ArgAttribute(u8);
     bitflags::bitflags! {
         impl ArgAttribute: u8 {
-            const NoAlias   = 1 << 1;
-            const CapturesAddress = 1 << 2;
-            const NonNull   = 1 << 3;
-            const ReadOnly  = 1 << 4;
-            const InReg     = 1 << 5;
-            const NoUndef = 1 << 6;
-            const CapturesReadOnly = 1 << 7;
+            const CapturesNone     = 0b111;
+            const CapturesAddress  = 0b110;
+            const CapturesReadOnly = 0b100;
+            const NoAlias  = 1 << 3;
+            const NonNull  = 1 << 4;
+            const ReadOnly = 1 << 5;
+            const InReg    = 1 << 6;
+            const NoUndef  = 1 << 7;
         }
     }
     rustc_data_structures::external_bitflags_debug! { ArgAttribute }

--- a/tests/codegen-llvm/addr-of-mutate.rs
+++ b/tests/codegen-llvm/addr-of-mutate.rs
@@ -24,7 +24,7 @@ pub unsafe fn second(a_ptr_and_b: (*mut (i32, bool), (i64, bool))) -> bool {
 }
 
 // If going through a deref (and there are no other mutating accesses), then `readonly` is fine.
-// CHECK: i1 @third(ptr{{( dead_on_return)?}} noalias noundef readonly align {{[0-9]+}}{{( captures\(address\))?}} dereferenceable({{[0-9]+}}) %a_ptr_and_b)
+// CHECK: i1 @third(ptr{{( dead_on_return)?}} noalias noundef readonly align {{[0-9]+}}{{( captures\(none\))?}} dereferenceable({{[0-9]+}}) %a_ptr_and_b)
 #[no_mangle]
 pub unsafe fn third(a_ptr_and_b: (*mut (i32, bool), (i64, bool))) -> bool {
     let b_bool_ptr = core::ptr::addr_of!((*a_ptr_and_b.0).1).cast_mut();

--- a/tests/codegen-llvm/deduced-param-attrs.rs
+++ b/tests/codegen-llvm/deduced-param-attrs.rs
@@ -1,81 +1,172 @@
 //@ compile-flags: -Copt-level=3 -Cno-prepopulate-passes
-
+//@ compile-flags: -Cpanic=abort -Csymbol-mangling-version=v0
+//@ revisions: LLVM21 LLVM20
+//@ [LLVM21] min-llvm-version: 21
+//@ [LLVM20] max-llvm-major-version: 20
+#![feature(custom_mir, core_intrinsics)]
 #![crate_type = "lib"]
-#![allow(internal_features)]
-#![feature(unsized_fn_params)]
-
+extern crate core;
+use core::intrinsics::mir::*;
 use std::cell::Cell;
-use std::hint;
+use std::hint::black_box;
+use std::mem::ManuallyDrop;
 
-// Check to make sure that we can deduce the `readonly` attribute from function bodies for
-// parameters passed indirectly.
-
-pub struct BigStruct {
-    blah: [i32; 1024],
+pub struct Big {
+    pub blah: [i32; 1024],
 }
 
-pub struct BigCellContainer {
-    blah: [Cell<i32>; 1024],
+pub struct BigCell {
+    pub blah: [Cell<i32>; 1024],
 }
 
-// The by-value parameter for this big struct can be marked readonly.
-//
-// CHECK: @use_big_struct_immutably({{.*}} readonly {{.*}} %big_struct)
-#[no_mangle]
-pub fn use_big_struct_immutably(big_struct: BigStruct) {
-    hint::black_box(&big_struct);
+pub struct BigDrop {
+    pub blah: [u8; 1024],
 }
 
-// The by-value parameter for this big struct can't be marked readonly, because we mutate it.
-//
-// CHECK: @use_big_struct_mutably(
+impl Drop for BigDrop {
+    #[inline(never)]
+    fn drop(&mut self) {}
+}
+
+// CHECK-LABEL: @mutate(
 // CHECK-NOT: readonly
-// CHECK-SAME: %big_struct)
-#[no_mangle]
-pub fn use_big_struct_mutably(mut big_struct: BigStruct) {
-    big_struct.blah[987] = 654;
-    hint::black_box(&big_struct);
+// CHECK-SAME: %b)
+#[unsafe(no_mangle)]
+pub fn mutate(mut b: Big) {
+    b.blah[987] = 654;
+    black_box(&b);
 }
 
-// The by-value parameter for this big struct can't be marked readonly, because it contains
-// UnsafeCell.
-//
-// CHECK: @use_big_cell_container(
-// CHECK-NOT: readonly
-// CHECK-SAME: %big_cell_container)
-#[no_mangle]
-pub fn use_big_cell_container(big_cell_container: BigCellContainer) {
-    hint::black_box(&big_cell_container);
+// LLVM21-LABEL: @deref_mut({{.*}}readonly {{.*}}captures(none) {{.*}}%c)
+// LLVM20-LABEL: @deref_mut({{.*}}readonly                      {{.*}}%c)
+#[unsafe(no_mangle)]
+pub fn deref_mut(c: (BigCell, &mut usize)) {
+    *c.1 = 42;
 }
 
-// Make sure that we don't mistakenly mark a big struct as `readonly` when passed through a generic
-// type parameter if it contains UnsafeCell.
+// LLVM21-LABEL: @call_copy_arg(ptr {{.*}}readonly {{.*}}captures(none){{.*}})
+// LLVM20-LABEL: @call_copy_arg(ptr {{.*}}readonly                     {{.*}})
+#[unsafe(no_mangle)]
+#[custom_mir(dialect = "runtime", phase = "optimized")]
+pub fn call_copy_arg(a: Big) {
+    mir! {
+        {
+            Call(RET = call_copy_arg(a), ReturnTo(bb1), UnwindUnreachable())
+        }
+        bb1 = {
+            Return()
+        }
+    }
+}
+
+// CHECK-LABEL: @call_move_arg(
+// CHECK-NOT:   readonly
+// LLVM21-SAME: captures(address)
+// CHECK-SAME:  )
+#[unsafe(no_mangle)]
+#[custom_mir(dialect = "runtime", phase = "optimized")]
+pub fn call_move_arg(a: Big) {
+    mir! {
+        {
+            Call(RET = call_move_arg(Move(a)), ReturnTo(bb1), UnwindUnreachable())
+        }
+        bb1 = {
+            Return()
+        }
+    }
+}
+
+fn shared_borrow<T>(a: T) {
+    black_box(&a);
+}
+
+// Freeze parameter cannot be mutated through a shared borrow.
 //
-// CHECK: @use_something(
-// CHECK-NOT: readonly
-// CHECK-SAME: %something)
-#[no_mangle]
+// CHECK-LABEL: ; deduced_param_attrs::shared_borrow::<deduced_param_attrs::Big>
+// CHECK-NEXT:  ;
+// LLVM21-NEXT: (ptr {{.*}}readonly {{.*}}captures(address) {{.*}}%a)
+// LLVM20-NEXT: (ptr {{.*}}readonly                         {{.*}}%a)
+pub static A0: fn(Big) = shared_borrow;
+
+// !Freeze parameter can be mutated through a shared borrow.
+//
+// CHECK-LABEL: ; deduced_param_attrs::shared_borrow::<deduced_param_attrs::BigCell>
+// CHECK-NEXT:  ;
+// CHECK-NOT:   readonly
+// CHECK-NEXT:  %a)
+pub static A1: fn(BigCell) = shared_borrow;
+
+// The parameter can be mutated through a raw const borrow.
+//
+// CHECK-LABEL: ; deduced_param_attrs::raw_const_borrow
+// CHECK-NOT:   readonly
+// CHECK-NEXT : %a)
 #[inline(never)]
-pub fn use_something<T>(something: T) {
-    hint::black_box(&something);
+pub fn raw_const_borrow(a: Big) {
+    black_box(&raw const a);
 }
 
-// Make sure that we still mark a big `Freeze` struct as `readonly` when passed through a generic
-// type parameter.
+fn consume<T>(_: T) {}
+
+// The parameter doesn't need to be dropped.
 //
-// CHECK: @use_something_freeze(
-// CHECK-SAME: readonly
-// CHECK-SAME: %x)
-#[no_mangle]
-#[inline(never)]
-pub fn use_something_freeze<T>(x: T) {}
+// CHECK-LABEL: ; deduced_param_attrs::consume::<deduced_param_attrs::BigCell>
+// CHECK-NEXT:  ;
+// LLVM21-NEXT: (ptr {{.*}}readonly {{.*}}captures(none) {{.*}})
+// LLVM20-NEXT: (ptr {{.*}}readonly                      {{.*}})
+pub static B0: fn(BigCell) = consume;
 
-#[no_mangle]
-pub fn forward_big_cell_container(big_cell_container: BigCellContainer) {
-    use_something(big_cell_container)
+// The parameter needs to be dropped.
+//
+// CHECK-LABEL: ; deduced_param_attrs::consume::<deduced_param_attrs::BigDrop>
+// CHECK-NEXT:  ;
+// LLVM21-NEXT: (ptr {{.*}}captures(address) {{.*}})
+// LLVM20-NEXT: (ptr                         {{.*}})
+pub static B1: fn(BigDrop) = consume;
+
+fn consume_parts<T>(t: (T, T)) {
+    let (_t0, ..) = t;
 }
 
-#[no_mangle]
-pub fn forward_big_container(big_struct: BigStruct) {
-    use_something_freeze(big_struct)
+// In principle it would be possible to deduce readonly here.
+//
+// CHECK-LABEL: ; deduced_param_attrs::consume_parts::<[u8; 40]>
+// CHECK-NEXT:  ;
+// CHECK-NOT:   readonly
+// CHECK-NEXT:  %t)
+pub static C1: fn(([u8; 40], [u8; 40])) = consume_parts;
+
+// The inner field of ManuallyDrop<BigDrop> needs to be dropped.
+//
+// CHECK-LABEL: @manually_drop_field(
+// CHECK-NOT:   readonly
+// CHECK-SAME:  %b)
+#[unsafe(no_mangle)]
+pub fn manually_drop_field(a: fn() -> BigDrop, mut b: ManuallyDrop<BigDrop>) {
+    // FIXME(tmiasko) replace with custom MIR, instead of expecting MIR optimizations to turn this
+    // into: drop((_2.0: BigDrop))
+    *b = a();
+    unsafe { core::intrinsics::unreachable() }
+}
+
+// `readonly` is omitted from the return place, even when applicable.
+//
+// CHECK-LABEL: @never_returns(
+// CHECK-NOT:   readonly
+// CHECK-SAME:  %_0)
+#[unsafe(no_mangle)]
+pub fn never_returns() -> [u8; 80] {
+    loop {}
+}
+
+// LLVM21-LABEL: @not_captured_return_place(ptr{{.*}} captures(none) {{.*}}%_0)
+#[unsafe(no_mangle)]
+pub fn not_captured_return_place() -> [u8; 80] {
+    [0u8; 80]
+}
+
+// LLVM21-LABEL: @captured_return_place(ptr{{.*}} captures(address) {{.*}}%_0)
+#[unsafe(no_mangle)]
+pub fn captured_return_place() -> [u8; 80] {
+    black_box([0u8; 80])
 }

--- a/tests/codegen-llvm/function-arguments.rs
+++ b/tests/codegen-llvm/function-arguments.rs
@@ -134,7 +134,7 @@ pub fn mutable_notunpin_borrow(_: &mut NotUnpin) {}
 #[no_mangle]
 pub fn notunpin_borrow(_: &NotUnpin) {}
 
-// CHECK: @indirect_struct(ptr{{( dead_on_return)?}} noalias noundef readonly align 4{{( captures\(address\))?}} dereferenceable(32) %_1)
+// CHECK: @indirect_struct(ptr{{( dead_on_return)?}} noalias noundef readonly align 4{{( captures\(none\))?}} dereferenceable(32) %_1)
 #[no_mangle]
 pub fn indirect_struct(_: S) {}
 
@@ -197,7 +197,7 @@ pub fn notunpin_box(x: Box<NotUnpin>) -> Box<NotUnpin> {
     x
 }
 
-// CHECK: @struct_return(ptr{{( dead_on_unwind)?}} noalias noundef{{( writable)?}} sret([32 x i8]) align 4{{( captures\(address\))?}} dereferenceable(32){{( %_0)?}})
+// CHECK: @struct_return(ptr{{( dead_on_unwind)?}} noalias noundef{{( writable)?}} sret([32 x i8]) align 4{{( captures\(none\))?}} dereferenceable(32){{( %_0)?}})
 #[no_mangle]
 pub fn struct_return() -> S {
     S { _field: [0, 0, 0, 0, 0, 0, 0, 0] }

--- a/tests/ui/abi/c-zst.powerpc-linux.stderr
+++ b/tests/ui/abi/c-zst.powerpc-linux.stderr
@@ -27,7 +27,7 @@ error: fn_abi_of(pass_zst) = FnAbi {
                    },
                    mode: Indirect {
                        attrs: ArgAttributes {
-                           regular: NoAlias | CapturesAddress | NonNull | NoUndef,
+                           regular: CapturesAddress | NoAlias | NonNull | NoUndef,
                            arg_ext: None,
                            pointee_size: Size(0 bytes),
                            pointee_align: Some(

--- a/tests/ui/abi/c-zst.s390x-linux.stderr
+++ b/tests/ui/abi/c-zst.s390x-linux.stderr
@@ -27,7 +27,7 @@ error: fn_abi_of(pass_zst) = FnAbi {
                    },
                    mode: Indirect {
                        attrs: ArgAttributes {
-                           regular: NoAlias | CapturesAddress | NonNull | NoUndef,
+                           regular: CapturesAddress | NoAlias | NonNull | NoUndef,
                            arg_ext: None,
                            pointee_size: Size(0 bytes),
                            pointee_align: Some(

--- a/tests/ui/abi/c-zst.sparc64-linux.stderr
+++ b/tests/ui/abi/c-zst.sparc64-linux.stderr
@@ -27,7 +27,7 @@ error: fn_abi_of(pass_zst) = FnAbi {
                    },
                    mode: Indirect {
                        attrs: ArgAttributes {
-                           regular: NoAlias | CapturesAddress | NonNull | NoUndef,
+                           regular: CapturesAddress | NoAlias | NonNull | NoUndef,
                            arg_ext: None,
                            pointee_size: Size(0 bytes),
                            pointee_align: Some(

--- a/tests/ui/abi/c-zst.x86_64-pc-windows-gnu.stderr
+++ b/tests/ui/abi/c-zst.x86_64-pc-windows-gnu.stderr
@@ -27,7 +27,7 @@ error: fn_abi_of(pass_zst) = FnAbi {
                    },
                    mode: Indirect {
                        attrs: ArgAttributes {
-                           regular: NoAlias | CapturesAddress | NonNull | NoUndef,
+                           regular: CapturesAddress | NoAlias | NonNull | NoUndef,
                            arg_ext: None,
                            pointee_size: Size(0 bytes),
                            pointee_align: Some(

--- a/tests/ui/abi/debug.generic.stderr
+++ b/tests/ui/abi/debug.generic.stderr
@@ -454,7 +454,7 @@ error: ABIs are not compatible
                    },
                    mode: Indirect {
                        attrs: ArgAttributes {
-                           regular: NoAlias | CapturesAddress | NonNull | NoUndef,
+                           regular: CapturesAddress | NoAlias | NonNull | NoUndef,
                            arg_ext: None,
                            pointee_size: Size(32 bytes),
                            pointee_align: Some(
@@ -527,7 +527,7 @@ error: ABIs are not compatible
                    },
                    mode: Indirect {
                        attrs: ArgAttributes {
-                           regular: NoAlias | CapturesAddress | NonNull | NoUndef,
+                           regular: CapturesAddress | NoAlias | NonNull | NoUndef,
                            arg_ext: None,
                            pointee_size: Size(128 bytes),
                            pointee_align: Some(
@@ -939,7 +939,7 @@ error: fn_abi_of(assoc_test) = FnAbi {
                    },
                    mode: Direct(
                        ArgAttributes {
-                           regular: NoAlias | NonNull | ReadOnly | NoUndef | CapturesReadOnly,
+                           regular: CapturesReadOnly | NoAlias | NonNull | ReadOnly | NoUndef,
                            arg_ext: None,
                            pointee_size: Size(2 bytes),
                            pointee_align: Some(

--- a/tests/ui/abi/debug.loongarch64.stderr
+++ b/tests/ui/abi/debug.loongarch64.stderr
@@ -454,7 +454,7 @@ error: ABIs are not compatible
                    },
                    mode: Indirect {
                        attrs: ArgAttributes {
-                           regular: NoAlias | CapturesAddress | NonNull | NoUndef,
+                           regular: CapturesAddress | NoAlias | NonNull | NoUndef,
                            arg_ext: None,
                            pointee_size: Size(32 bytes),
                            pointee_align: Some(
@@ -527,7 +527,7 @@ error: ABIs are not compatible
                    },
                    mode: Indirect {
                        attrs: ArgAttributes {
-                           regular: NoAlias | CapturesAddress | NonNull | NoUndef,
+                           regular: CapturesAddress | NoAlias | NonNull | NoUndef,
                            arg_ext: None,
                            pointee_size: Size(128 bytes),
                            pointee_align: Some(
@@ -939,7 +939,7 @@ error: fn_abi_of(assoc_test) = FnAbi {
                    },
                    mode: Direct(
                        ArgAttributes {
-                           regular: NoAlias | NonNull | ReadOnly | NoUndef | CapturesReadOnly,
+                           regular: CapturesReadOnly | NoAlias | NonNull | ReadOnly | NoUndef,
                            arg_ext: None,
                            pointee_size: Size(2 bytes),
                            pointee_align: Some(

--- a/tests/ui/abi/debug.riscv64.stderr
+++ b/tests/ui/abi/debug.riscv64.stderr
@@ -454,7 +454,7 @@ error: ABIs are not compatible
                    },
                    mode: Indirect {
                        attrs: ArgAttributes {
-                           regular: NoAlias | CapturesAddress | NonNull | NoUndef,
+                           regular: CapturesAddress | NoAlias | NonNull | NoUndef,
                            arg_ext: None,
                            pointee_size: Size(32 bytes),
                            pointee_align: Some(
@@ -527,7 +527,7 @@ error: ABIs are not compatible
                    },
                    mode: Indirect {
                        attrs: ArgAttributes {
-                           regular: NoAlias | CapturesAddress | NonNull | NoUndef,
+                           regular: CapturesAddress | NoAlias | NonNull | NoUndef,
                            arg_ext: None,
                            pointee_size: Size(128 bytes),
                            pointee_align: Some(
@@ -939,7 +939,7 @@ error: fn_abi_of(assoc_test) = FnAbi {
                    },
                    mode: Direct(
                        ArgAttributes {
-                           regular: NoAlias | NonNull | ReadOnly | NoUndef | CapturesReadOnly,
+                           regular: CapturesReadOnly | NoAlias | NonNull | ReadOnly | NoUndef,
                            arg_ext: None,
                            pointee_size: Size(2 bytes),
                            pointee_align: Some(


### PR DESCRIPTION
Extend attribute deduction to determine whether parameters using
indirect pass mode might have their address captured. Similarly to
the deduction of `readonly` attribute this information facilitates
memcpy optimizations.