### PR TITLE
Correct non-ZST too-large-array-size check in MapWindows::new

### DIFF
--- a/library/core/src/iter/adapters/map_windows.rs
+++ b/library/core/src/iter/adapters/map_windows.rs
@@ -50,7 +50,7 @@ impl<I: Iterator, F, const N: usize> MapWindows<I, F, N> {
         assert!(N != 0, "array in `Iterator::map_windows` must contain more than 0 elements");
 
         // Only ZST arrays' length can be so large.
-        if size_of::<I::Item>() == 0 {
+        if size_of::<I::Item>() != 0 {
             assert!(
                 N.checked_mul(2).is_some(),
                 "array size of `Iterator::map_windows` is too large"


### PR DESCRIPTION
Happened to look through the source code and found what seems to be a logical error in the check in `MapWindows::new`. There's supposed to be a check to prevent too large arrays for non-zero-sized types, but it seems to be wrong. Isn't this supposed to be `!=` instead of `==`?

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
Feature `iter_map_windows` issue rust-lang/rust#87155 
<!-- homu-ignore:end -->
