### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/compiler/rustc_lint/src/unused.rs
+++ b/compiler/rustc_lint/src/unused.rs
@@ -273,13 +273,11 @@ impl<'tcx> LateLintPass<'tcx> for UnusedResults {
             expr: &hir::Expr<'_>,
             span: Span,
         ) -> Option<MustUsePath> {
-            if ty.is_unit()
-                || !ty.is_inhabited_from(
-                    cx.tcx,
-                    cx.tcx.parent_module(expr.hir_id).to_def_id(),
-                    cx.typing_env(),
-                )
-            {
+            if ty.is_unit() {
+                return Some(MustUsePath::Suppressed);
+            }
+            let parent_mod_did = cx.tcx.parent_module(expr.hir_id).to_def_id();
+            if !ty.is_inhabited_from(cx.tcx, parent_mod_did, cx.typing_env()) {
                 return Some(MustUsePath::Suppressed);
             }
 

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -4065,7 +4065,6 @@ declare_lint! {
     /// ### Example
     ///
     /// ```rust,compile_fail
-    /// #![deny(never_type_fallback_flowing_into_unsafe)]
     /// fn main() {
     ///     if true {
     ///         // return has type `!` which, is some cases, causes never type fallback
@@ -4122,7 +4121,7 @@ declare_lint! {
     /// ### Example
     ///
     /// ```rust,compile_fail,edition2021
-    /// #![deny(dependency_on_unit_never_type_fallback)]
+    /// # #![deny(dependency_on_unit_never_type_fallback)]
     /// fn main() {
     ///     if true {
     ///         // return has type `!` which, is some cases, causes never type fallback

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -4100,7 +4100,7 @@ declare_lint! {
     /// [`!`]: https://doc.rust-lang.org/core/primitive.never.html
     /// [`()`]: https://doc.rust-lang.org/core/primitive.unit.html
     pub NEVER_TYPE_FALLBACK_FLOWING_INTO_UNSAFE,
-    Warn,
+    Deny,
     "never type fallback affecting unsafe function calls",
     @future_incompatible = FutureIncompatibleInfo {
         reason: FutureIncompatibilityReason::EditionAndFutureReleaseSemanticsChange(Edition::Edition2024),
@@ -4155,7 +4155,7 @@ declare_lint! {
     ///
     /// See [Tracking Issue for making `!` fall back to `!`](https://github.com/rust-lang/rust/issues/123748).
     pub DEPENDENCY_ON_UNIT_NEVER_TYPE_FALLBACK,
-    Warn,
+    Deny,
     "never type fallback affecting unsafe function calls",
     @future_incompatible = FutureIncompatibleInfo {
         reason: FutureIncompatibilityReason::EditionAndFutureReleaseError(Edition::Edition2024),

--- a/tests/ui/editions/never-type-fallback-breaking.e2021.fixed
+++ b/tests/ui/editions/never-type-fallback-breaking.e2021.fixed
@@ -3,9 +3,7 @@
 //@[e2021] edition: 2021
 //@[e2024] edition: 2024
 //
-//@[e2021] run-pass
 //@[e2021] run-rustfix
-//@[e2024] check-fail
 
 fn main() {
     m();
@@ -16,8 +14,8 @@ fn main() {
 }
 
 fn m() {
-    //[e2021]~^ WARN this function depends on never type fallback being `()`
-    //[e2021]~| WARN this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
+    //[e2021]~^ error: this function depends on never type fallback being `()`
+    //[e2021]~| warn: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
     let x: () = match true {
         true => Default::default(),
         //[e2024]~^ error: the trait bound `!: Default` is not satisfied
@@ -28,8 +26,8 @@ fn m() {
 }
 
 fn q() -> Option<()> {
-    //[e2021]~^ WARN this function depends on never type fallback being `()`
-    //[e2021]~| WARN this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
+    //[e2021]~^ error: this function depends on never type fallback being `()`
+    //[e2021]~| warn: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
     fn deserialize<T: Default>() -> Option<T> {
         Some(T::default())
     }
@@ -45,8 +43,8 @@ fn help<'a: 'a, T: Into<()>, U>(_: U) -> Result<T, ()> {
     Err(())
 }
 fn meow() -> Result<(), ()> {
-    //[e2021]~^ WARN this function depends on never type fallback being `()`
-    //[e2021]~| WARN this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
+    //[e2021]~^ error: this function depends on never type fallback being `()`
+    //[e2021]~| warn: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
     help::<(), _>(1)?;
     //[e2024]~^ error: the trait bound `(): From<!>` is not satisfied
     Ok(())
@@ -57,8 +55,8 @@ pub fn takes_apit<T>(_y: impl Fn() -> T) -> Result<T, ()> {
 }
 
 pub fn fallback_return() -> Result<(), ()> {
-    //[e2021]~^ WARN this function depends on never type fallback being `()`
-    //[e2021]~| WARN this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
+    //[e2021]~^ error: this function depends on never type fallback being `()`
+    //[e2021]~| warn: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
     takes_apit::<()>(|| Default::default())?;
     //[e2024]~^ error: the trait bound `!: Default` is not satisfied
     Ok(())
@@ -71,8 +69,8 @@ fn mk<T>() -> Result<T, ()> {
 fn takes_apit2(_x: impl Default) {}
 
 fn fully_apit() -> Result<(), ()> {
-    //[e2021]~^ WARN this function depends on never type fallback being `()`
-    //[e2021]~| WARN this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
+    //[e2021]~^ error: this function depends on never type fallback being `()`
+    //[e2021]~| warn: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
     takes_apit2(mk::<()>()?);
     //[e2024]~^ error: the trait bound `!: Default` is not satisfied
     Ok(())

--- a/tests/ui/editions/never-type-fallback-breaking.e2021.stderr
+++ b/tests/ui/editions/never-type-fallback-breaking.e2021.stderr
@@ -1,5 +1,5 @@
-warning: this function depends on never type fallback being `()`
-  --> $DIR/never-type-fallback-breaking.rs:18:1
+error: this function depends on never type fallback being `()`
+  --> $DIR/never-type-fallback-breaking.rs:16:1
    |
 LL | fn m() {
    | ^^^^^^
@@ -8,18 +8,18 @@ LL | fn m() {
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: Default` will fail
-  --> $DIR/never-type-fallback-breaking.rs:22:17
+  --> $DIR/never-type-fallback-breaking.rs:20:17
    |
 LL |         true => Default::default(),
    |                 ^^^^^^^^^^^^^^^^^^
-   = note: `#[warn(dependency_on_unit_never_type_fallback)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
+   = note: `#[deny(dependency_on_unit_never_type_fallback)]` (part of `#[deny(rust_2024_compatibility)]`) on by default
 help: use `()` annotations to avoid fallback changes
    |
 LL |     let x: () = match true {
    |          ++++
 
-warning: this function depends on never type fallback being `()`
-  --> $DIR/never-type-fallback-breaking.rs:30:1
+error: this function depends on never type fallback being `()`
+  --> $DIR/never-type-fallback-breaking.rs:28:1
    |
 LL | fn q() -> Option<()> {
    | ^^^^^^^^^^^^^^^^^^^^
@@ -28,7 +28,7 @@ LL | fn q() -> Option<()> {
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: Default` will fail
-  --> $DIR/never-type-fallback-breaking.rs:37:5
+  --> $DIR/never-type-fallback-breaking.rs:35:5
    |
 LL |     deserialize()?;
    |     ^^^^^^^^^^^^^
@@ -37,8 +37,8 @@ help: use `()` annotations to avoid fallback changes
 LL |     deserialize::<()>()?;
    |                ++++++
 
-warning: this function depends on never type fallback being `()`
-  --> $DIR/never-type-fallback-breaking.rs:47:1
+error: this function depends on never type fallback being `()`
+  --> $DIR/never-type-fallback-breaking.rs:45:1
    |
 LL | fn meow() -> Result<(), ()> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -47,7 +47,7 @@ LL | fn meow() -> Result<(), ()> {
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `(): From<!>` will fail
-  --> $DIR/never-type-fallback-breaking.rs:50:5
+  --> $DIR/never-type-fallback-breaking.rs:48:5
    |
 LL |     help(1)?;
    |     ^^^^^^^
@@ -56,8 +56,8 @@ help: use `()` annotations to avoid fallback changes
 LL |     help::<(), _>(1)?;
    |         +++++++++
 
-warning: this function depends on never type fallback being `()`
-  --> $DIR/never-type-fallback-breaking.rs:59:1
+error: this function depends on never type fallback being `()`
+  --> $DIR/never-type-fallback-breaking.rs:57:1
    |
 LL | pub fn fallback_return() -> Result<(), ()> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -66,7 +66,7 @@ LL | pub fn fallback_return() -> Result<(), ()> {
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: Default` will fail
-  --> $DIR/never-type-fallback-breaking.rs:62:19
+  --> $DIR/never-type-fallback-breaking.rs:60:19
    |
 LL |     takes_apit(|| Default::default())?;
    |                   ^^^^^^^^^^^^^^^^^^
@@ -75,8 +75,8 @@ help: use `()` annotations to avoid fallback changes
 LL |     takes_apit::<()>(|| Default::default())?;
    |               ++++++
 
-warning: this function depends on never type fallback being `()`
-  --> $DIR/never-type-fallback-breaking.rs:73:1
+error: this function depends on never type fallback being `()`
+  --> $DIR/never-type-fallback-breaking.rs:71:1
    |
 LL | fn fully_apit() -> Result<(), ()> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -85,7 +85,7 @@ LL | fn fully_apit() -> Result<(), ()> {
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: Default` will fail
-  --> $DIR/never-type-fallback-breaking.rs:76:17
+  --> $DIR/never-type-fallback-breaking.rs:74:17
    |
 LL |     takes_apit2(mk()?);
    |                 ^^^^^
@@ -94,11 +94,11 @@ help: use `()` annotations to avoid fallback changes
 LL |     takes_apit2(mk::<()>()?);
    |                   ++++++
 
-warning: 5 warnings emitted
+error: aborting due to 5 previous errors
 
 Future incompatibility report: Future breakage diagnostic:
-warning: this function depends on never type fallback being `()`
-  --> $DIR/never-type-fallback-breaking.rs:18:1
+error: this function depends on never type fallback being `()`
+  --> $DIR/never-type-fallback-breaking.rs:16:1
    |
 LL | fn m() {
    | ^^^^^^
@@ -107,19 +107,19 @@ LL | fn m() {
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: Default` will fail
-  --> $DIR/never-type-fallback-breaking.rs:22:17
+  --> $DIR/never-type-fallback-breaking.rs:20:17
    |
 LL |         true => Default::default(),
    |                 ^^^^^^^^^^^^^^^^^^
-   = note: `#[warn(dependency_on_unit_never_type_fallback)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
+   = note: `#[deny(dependency_on_unit_never_type_fallback)]` (part of `#[deny(rust_2024_compatibility)]`) on by default
 help: use `()` annotations to avoid fallback changes
    |
 LL |     let x: () = match true {
    |          ++++
 
 Future breakage diagnostic:
-warning: this function depends on never type fallback being `()`
-  --> $DIR/never-type-fallback-breaking.rs:30:1
+error: this function depends on never type fallback being `()`
+  --> $DIR/never-type-fallback-breaking.rs:28:1
    |
 LL | fn q() -> Option<()> {
    | ^^^^^^^^^^^^^^^^^^^^
@@ -128,19 +128,19 @@ LL | fn q() -> Option<()> {
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: Default` will fail
-  --> $DIR/never-type-fallback-breaking.rs:37:5
+  --> $DIR/never-type-fallback-breaking.rs:35:5
    |
 LL |     deserialize()?;
    |     ^^^^^^^^^^^^^
-   = note: `#[warn(dependency_on_unit_never_type_fallback)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
+   = note: `#[deny(dependency_on_unit_never_type_fallback)]` (part of `#[deny(rust_2024_compatibility)]`) on by default
 help: use `()` annotations to avoid fallback changes
    |
 LL |     deserialize::<()>()?;
    |                ++++++
 
 Future breakage diagnostic:
-warning: this function depends on never type fallback being `()`
-  --> $DIR/never-type-fallback-breaking.rs:47:1
+error: this function depends on never type fallback being `()`
+  --> $DIR/never-type-fallback-breaking.rs:45:1
    |
 LL | fn meow() -> Result<(), ()> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -149,19 +149,19 @@ LL | fn meow() -> Result<(), ()> {
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `(): From<!>` will fail
-  --> $DIR/never-type-fallback-breaking.rs:50:5
+  --> $DIR/never-type-fallback-breaking.rs:48:5
    |
 LL |     help(1)?;
    |     ^^^^^^^
-   = note: `#[warn(dependency_on_unit_never_type_fallback)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
+   = note: `#[deny(dependency_on_unit_never_type_fallback)]` (part of `#[deny(rust_2024_compatibility)]`) on by default
 help: use `()` annotations to avoid fallback changes
    |
 LL |     help::<(), _>(1)?;
    |         +++++++++
 
 Future breakage diagnostic:
-warning: this function depends on never type fallback being `()`
-  --> $DIR/never-type-fallback-breaking.rs:59:1
+error: this function depends on never type fallback being `()`
+  --> $DIR/never-type-fallback-breaking.rs:57:1
    |
 LL | pub fn fallback_return() -> Result<(), ()> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -170,19 +170,19 @@ LL | pub fn fallback_return() -> Result<(), ()> {
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: Default` will fail
-  --> $DIR/never-type-fallback-breaking.rs:62:19
+  --> $DIR/never-type-fallback-breaking.rs:60:19
    |
 LL |     takes_apit(|| Default::default())?;
    |                   ^^^^^^^^^^^^^^^^^^
-   = note: `#[warn(dependency_on_unit_never_type_fallback)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
+   = note: `#[deny(dependency_on_unit_never_type_fallback)]` (part of `#[deny(rust_2024_compatibility)]`) on by default
 help: use `()` annotations to avoid fallback changes
    |
 LL |     takes_apit::<()>(|| Default::default())?;
    |               ++++++
 
 Future breakage diagnostic:
-warning: this function depends on never type fallback being `()`
-  --> $DIR/never-type-fallback-breaking.rs:73:1
+error: this function depends on never type fallback being `()`
+  --> $DIR/never-type-fallback-breaking.rs:71:1
    |
 LL | fn fully_apit() -> Result<(), ()> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -191,11 +191,11 @@ LL | fn fully_apit() -> Result<(), ()> {
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: Default` will fail
-  --> $DIR/never-type-fallback-breaking.rs:76:17
+  --> $DIR/never-type-fallback-breaking.rs:74:17
    |
 LL |     takes_apit2(mk()?);
    |                 ^^^^^
-   = note: `#[warn(dependency_on_unit_never_type_fallback)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
+   = note: `#[deny(dependency_on_unit_never_type_fallback)]` (part of `#[deny(rust_2024_compatibility)]`) on by default
 help: use `()` annotations to avoid fallback changes
    |
 LL |     takes_apit2(mk::<()>()?);

--- a/tests/ui/editions/never-type-fallback-breaking.e2024.stderr
+++ b/tests/ui/editions/never-type-fallback-breaking.e2024.stderr
@@ -1,5 +1,5 @@
 error[E0277]: the trait bound `!: Default` is not satisfied
-  --> $DIR/never-type-fallback-breaking.rs:22:17
+  --> $DIR/never-type-fallback-breaking.rs:20:17
    |
 LL |         true => Default::default(),
    |                 ^^^^^^^^^^^^^^^^^^ the trait `Default` is not implemented for `!`
@@ -8,7 +8,7 @@ LL |         true => Default::default(),
    = help: you might have intended to use the type `()` here instead
 
 error[E0277]: the trait bound `!: Default` is not satisfied
-  --> $DIR/never-type-fallback-breaking.rs:37:5
+  --> $DIR/never-type-fallback-breaking.rs:35:5
    |
 LL |     deserialize()?;
    |     ^^^^^^^^^^^^^ the trait `Default` is not implemented for `!`
@@ -16,13 +16,13 @@ LL |     deserialize()?;
    = note: this error might have been caused by changes to Rust's type-inference algorithm (see issue #48950 <https://github.com/rust-lang/rust/issues/48950> for more information)
    = help: you might have intended to use the type `()` here instead
 note: required by a bound in `deserialize`
-  --> $DIR/never-type-fallback-breaking.rs:33:23
+  --> $DIR/never-type-fallback-breaking.rs:31:23
    |
 LL |     fn deserialize<T: Default>() -> Option<T> {
    |                       ^^^^^^^ required by this bound in `deserialize`
 
 error[E0277]: the trait bound `(): From<!>` is not satisfied
-  --> $DIR/never-type-fallback-breaking.rs:50:5
+  --> $DIR/never-type-fallback-breaking.rs:48:5
    |
 LL |     help(1)?;
    |     ^^^^^^^ the trait `From<!>` is not implemented for `()`
@@ -39,13 +39,13 @@ LL |     help(1)?;
            and 4 others
    = note: required for `!` to implement `Into<()>`
 note: required by a bound in `help`
-  --> $DIR/never-type-fallback-breaking.rs:44:20
+  --> $DIR/never-type-fallback-breaking.rs:42:20
    |
 LL | fn help<'a: 'a, T: Into<()>, U>(_: U) -> Result<T, ()> {
    |                    ^^^^^^^^ required by this bound in `help`
 
 error[E0277]: the trait bound `!: Default` is not satisfied
-  --> $DIR/never-type-fallback-breaking.rs:62:19
+  --> $DIR/never-type-fallback-breaking.rs:60:19
    |
 LL |     takes_apit(|| Default::default())?;
    |                   ^^^^^^^^^^^^^^^^^^ the trait `Default` is not implemented for `!`
@@ -54,7 +54,7 @@ LL |     takes_apit(|| Default::default())?;
    = help: you might have intended to use the type `()` here instead
 
 error[E0277]: the trait bound `!: Default` is not satisfied
-  --> $DIR/never-type-fallback-breaking.rs:76:17
+  --> $DIR/never-type-fallback-breaking.rs:74:17
    |
 LL |     takes_apit2(mk()?);
    |     ----------- ^^^^^ the trait `Default` is not implemented for `!`
@@ -64,7 +64,7 @@ LL |     takes_apit2(mk()?);
    = note: this error might have been caused by changes to Rust's type-inference algorithm (see issue #48950 <https://github.com/rust-lang/rust/issues/48950> for more information)
    = help: you might have intended to use the type `()` here instead
 note: required by a bound in `takes_apit2`
-  --> $DIR/never-type-fallback-breaking.rs:71:25
+  --> $DIR/never-type-fallback-breaking.rs:69:25
    |
 LL | fn takes_apit2(_x: impl Default) {}
    |                         ^^^^^^^ required by this bound in `takes_apit2`

--- a/tests/ui/editions/never-type-fallback-breaking.rs
+++ b/tests/ui/editions/never-type-fallback-breaking.rs
@@ -3,9 +3,7 @@
 //@[e2021] edition: 2021
 //@[e2024] edition: 2024
 //
-//@[e2021] run-pass
 //@[e2021] run-rustfix
-//@[e2024] check-fail
 
 fn main() {
     m();
@@ -16,8 +14,8 @@ fn main() {
 }
 
 fn m() {
-    //[e2021]~^ WARN this function depends on never type fallback being `()`
-    //[e2021]~| WARN this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
+    //[e2021]~^ error: this function depends on never type fallback being `()`
+    //[e2021]~| warn: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
     let x = match true {
         true => Default::default(),
         //[e2024]~^ error: the trait bound `!: Default` is not satisfied
@@ -28,8 +26,8 @@ fn m() {
 }
 
 fn q() -> Option<()> {
-    //[e2021]~^ WARN this function depends on never type fallback being `()`
-    //[e2021]~| WARN this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
+    //[e2021]~^ error: this function depends on never type fallback being `()`
+    //[e2021]~| warn: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
     fn deserialize<T: Default>() -> Option<T> {
         Some(T::default())
     }
@@ -45,8 +43,8 @@ fn help<'a: 'a, T: Into<()>, U>(_: U) -> Result<T, ()> {
     Err(())
 }
 fn meow() -> Result<(), ()> {
-    //[e2021]~^ WARN this function depends on never type fallback being `()`
-    //[e2021]~| WARN this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
+    //[e2021]~^ error: this function depends on never type fallback being `()`
+    //[e2021]~| warn: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
     help(1)?;
     //[e2024]~^ error: the trait bound `(): From<!>` is not satisfied
     Ok(())
@@ -57,8 +55,8 @@ pub fn takes_apit<T>(_y: impl Fn() -> T) -> Result<T, ()> {
 }
 
 pub fn fallback_return() -> Result<(), ()> {
-    //[e2021]~^ WARN this function depends on never type fallback being `()`
-    //[e2021]~| WARN this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
+    //[e2021]~^ error: this function depends on never type fallback being `()`
+    //[e2021]~| warn: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
     takes_apit(|| Default::default())?;
     //[e2024]~^ error: the trait bound `!: Default` is not satisfied
     Ok(())
@@ -71,8 +69,8 @@ fn mk<T>() -> Result<T, ()> {
 fn takes_apit2(_x: impl Default) {}
 
 fn fully_apit() -> Result<(), ()> {
-    //[e2021]~^ WARN this function depends on never type fallback being `()`
-    //[e2021]~| WARN this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
+    //[e2021]~^ error: this function depends on never type fallback being `()`
+    //[e2021]~| warn: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
     takes_apit2(mk()?);
     //[e2024]~^ error: the trait bound `!: Default` is not satisfied
     Ok(())

--- a/tests/ui/lint/unused/auxiliary/must_use_result_unit_uninhabited_extern_crate.rs
+++ b/tests/ui/lint/unused/auxiliary/must_use_result_unit_uninhabited_extern_crate.rs
@@ -1,0 +1,4 @@
+pub enum MyUninhabited {}
+
+#[non_exhaustive]
+pub enum MyUninhabitedNonexhaustive {}

--- a/tests/ui/lint/unused/must_use-result-unit-uninhabited.rs
+++ b/tests/ui/lint/unused/must_use-result-unit-uninhabited.rs
@@ -1,0 +1,55 @@
+//@ edition: 2024
+//@ aux-crate:dep=must_use_result_unit_uninhabited_extern_crate.rs
+
+#![deny(unused_must_use)]
+#![feature(never_type)]
+
+use dep::{MyUninhabited, MyUninhabitedNonexhaustive};
+
+fn f1() -> Result<(), ()> {
+    Ok(())
+}
+
+fn f2() -> Result<(), core::convert::Infallible> {
+    Ok(())
+}
+
+fn f3() -> Result<(), !> {
+    Ok(())
+}
+
+fn f4() -> Result<(), MyUninhabited> {
+    Ok(())
+}
+
+fn f5() -> Result<(), MyUninhabitedNonexhaustive> {
+    Ok(())
+}
+
+trait AssocType {
+    type Error;
+}
+
+struct S1;
+impl AssocType for S1 {
+    type Error = !;
+}
+
+struct S2;
+impl AssocType for S2 {
+    type Error = ();
+}
+
+fn f6<AT: AssocType>(_: AT) -> Result<(), AT::Error> {
+    Ok(())
+}
+
+fn main() {
+    f1(); //~ ERROR: unused `Result` that must be used
+    f2();
+    f3();
+    f4();
+    f5(); //~ ERROR: unused `Result` that must be used
+    f6(S1);
+    f6(S2); //~ ERROR: unused `Result` that must be used
+}

--- a/tests/ui/lint/unused/must_use-result-unit-uninhabited.rs
+++ b/tests/ui/lint/unused/must_use-result-unit-uninhabited.rs
@@ -7,23 +7,23 @@
 use core::ops::{ControlFlow, ControlFlow::Continue};
 use dep::{MyUninhabited, MyUninhabitedNonexhaustive};
 
-fn f1() -> Result<(), ()> {
+fn result_unit_unit() -> Result<(), ()> {
     Ok(())
 }
 
-fn f2() -> Result<(), core::convert::Infallible> {
+fn result_unit_infallible() -> Result<(), core::convert::Infallible> {
     Ok(())
 }
 
-fn f3() -> Result<(), !> {
+fn result_unit_never() -> Result<(), !> {
     Ok(())
 }
 
-fn f4() -> Result<(), MyUninhabited> {
+fn result_unit_myuninhabited() -> Result<(), MyUninhabited> {
     Ok(())
 }
 
-fn f5() -> Result<(), MyUninhabitedNonexhaustive> {
+fn result_unit_myuninhabited_nonexhaustive() -> Result<(), MyUninhabitedNonexhaustive> {
     Ok(())
 }
 
@@ -41,53 +41,53 @@ impl AssocType for S2 {
     type Error = ();
 }
 
-fn f6<AT: AssocType>(_: AT) -> Result<(), AT::Error> {
+fn result_unit_assoctype<AT: AssocType>(_: AT) -> Result<(), AT::Error> {
     Ok(())
 }
 
 trait UsesAssocType {
     type Error;
-    fn method(&self) -> Result<(), Self::Error>;
+    fn method_use_assoc_type(&self) -> Result<(), Self::Error>;
 }
 
 impl UsesAssocType for S1 {
     type Error = !;
-    fn method(&self) -> Result<(), Self::Error> {
+    fn method_use_assoc_type(&self) -> Result<(), Self::Error> {
         Ok(())
     }
 }
 
 impl UsesAssocType for S2 {
     type Error = ();
-    fn method(&self) -> Result<(), Self::Error> {
+    fn method_use_assoc_type(&self) -> Result<(), Self::Error> {
         Err(())
     }
 }
 
-fn c1() -> ControlFlow<()> {
+fn controlflow_unit() -> ControlFlow<()> {
     Continue(())
 }
 
-fn c2() -> ControlFlow<core::convert::Infallible, ()> {
+fn controlflow_infallible_unit() -> ControlFlow<core::convert::Infallible, ()> {
     Continue(())
 }
 
-fn c3() -> ControlFlow<!> {
+fn controlflow_never() -> ControlFlow<!> {
     Continue(())
 }
 
 fn main() {
-    f1(); //~ ERROR: unused `Result` that must be used
-    f2();
-    f3();
-    f4();
-    f5(); //~ ERROR: unused `Result` that must be used
-    f6(S1);
-    f6(S2); //~ ERROR: unused `Result` that must be used
-    S1.method();
-    S2.method(); //~ ERROR: unused `Result` that must be used
+    result_unit_unit(); //~ ERROR: unused `Result` that must be used
+    result_unit_infallible();
+    result_unit_never();
+    result_unit_myuninhabited();
+    result_unit_myuninhabited_nonexhaustive(); //~ ERROR: unused `Result` that must be used
+    result_unit_assoctype(S1);
+    result_unit_assoctype(S2); //~ ERROR: unused `Result` that must be used
+    S1.method_use_assoc_type();
+    S2.method_use_assoc_type(); //~ ERROR: unused `Result` that must be used
 
-    c1(); //~ ERROR: unused `ControlFlow` that must be used
-    c2();
-    c3();
+    controlflow_unit(); //~ ERROR: unused `ControlFlow` that must be used
+    controlflow_infallible_unit();
+    controlflow_never();
 }

--- a/tests/ui/lint/unused/must_use-result-unit-uninhabited.rs
+++ b/tests/ui/lint/unused/must_use-result-unit-uninhabited.rs
@@ -44,6 +44,25 @@ fn f6<AT: AssocType>(_: AT) -> Result<(), AT::Error> {
     Ok(())
 }
 
+trait UsesAssocType {
+    type Error;
+    fn method(&self) -> Result<(), Self::Error>;
+}
+
+impl UsesAssocType for S1 {
+    type Error = !;
+    fn method(&self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+}
+
+impl UsesAssocType for S2 {
+    type Error = ();
+    fn method(&self) -> Result<(), Self::Error> {
+        Err(())
+    }
+}
+
 fn main() {
     f1(); //~ ERROR: unused `Result` that must be used
     f2();
@@ -52,4 +71,6 @@ fn main() {
     f5(); //~ ERROR: unused `Result` that must be used
     f6(S1);
     f6(S2); //~ ERROR: unused `Result` that must be used
+    S1.method();
+    S2.method(); //~ ERROR: unused `Result` that must be used
 }

--- a/tests/ui/lint/unused/must_use-result-unit-uninhabited.rs
+++ b/tests/ui/lint/unused/must_use-result-unit-uninhabited.rs
@@ -91,3 +91,11 @@ fn main() {
     controlflow_infallible_unit();
     controlflow_never();
 }
+
+trait AssocTypeBeforeMonomorphisation {
+    type Error;
+    fn generate(&self) -> Result<(), Self::Error>;
+    fn process(&self) {
+        self.generate(); //~ ERROR: unused `Result` that must be used
+    }
+}

--- a/tests/ui/lint/unused/must_use-result-unit-uninhabited.rs
+++ b/tests/ui/lint/unused/must_use-result-unit-uninhabited.rs
@@ -4,6 +4,7 @@
 #![deny(unused_must_use)]
 #![feature(never_type)]
 
+use core::ops::{ControlFlow, ControlFlow::Continue};
 use dep::{MyUninhabited, MyUninhabitedNonexhaustive};
 
 fn f1() -> Result<(), ()> {
@@ -63,6 +64,18 @@ impl UsesAssocType for S2 {
     }
 }
 
+fn c1() -> ControlFlow<()> {
+    Continue(())
+}
+
+fn c2() -> ControlFlow<core::convert::Infallible, ()> {
+    Continue(())
+}
+
+fn c3() -> ControlFlow<!> {
+    Continue(())
+}
+
 fn main() {
     f1(); //~ ERROR: unused `Result` that must be used
     f2();
@@ -73,4 +86,8 @@ fn main() {
     f6(S2); //~ ERROR: unused `Result` that must be used
     S1.method();
     S2.method(); //~ ERROR: unused `Result` that must be used
+
+    c1(); //~ ERROR: unused `ControlFlow` that must be used
+    c2();
+    c3();
 }

--- a/tests/ui/lint/unused/must_use-result-unit-uninhabited.stderr
+++ b/tests/ui/lint/unused/must_use-result-unit-uninhabited.stderr
@@ -1,8 +1,8 @@
 error: unused `Result` that must be used
   --> $DIR/must_use-result-unit-uninhabited.rs:80:5
    |
-LL |     f1();
-   |     ^^^^
+LL |     result_unit_unit();
+   |     ^^^^^^^^^^^^^^^^^^
    |
    = note: this `Result` may be an `Err` variant, which should be handled
 note: the lint level is defined here
@@ -12,54 +12,54 @@ LL | #![deny(unused_must_use)]
    |         ^^^^^^^^^^^^^^^
 help: use `let _ = ...` to ignore the resulting value
    |
-LL |     let _ = f1();
+LL |     let _ = result_unit_unit();
    |     +++++++
 
 error: unused `Result` that must be used
   --> $DIR/must_use-result-unit-uninhabited.rs:84:5
    |
-LL |     f5();
-   |     ^^^^
+LL |     result_unit_myuninhabited_nonexhaustive();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: this `Result` may be an `Err` variant, which should be handled
 help: use `let _ = ...` to ignore the resulting value
    |
-LL |     let _ = f5();
+LL |     let _ = result_unit_myuninhabited_nonexhaustive();
    |     +++++++
 
 error: unused `Result` that must be used
   --> $DIR/must_use-result-unit-uninhabited.rs:86:5
    |
-LL |     f6(S2);
-   |     ^^^^^^
+LL |     result_unit_assoctype(S2);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: this `Result` may be an `Err` variant, which should be handled
 help: use `let _ = ...` to ignore the resulting value
    |
-LL |     let _ = f6(S2);
+LL |     let _ = result_unit_assoctype(S2);
    |     +++++++
 
 error: unused `Result` that must be used
   --> $DIR/must_use-result-unit-uninhabited.rs:88:5
    |
-LL |     S2.method();
-   |     ^^^^^^^^^^^
+LL |     S2.method_use_assoc_type();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: this `Result` may be an `Err` variant, which should be handled
 help: use `let _ = ...` to ignore the resulting value
    |
-LL |     let _ = S2.method();
+LL |     let _ = S2.method_use_assoc_type();
    |     +++++++
 
 error: unused `ControlFlow` that must be used
   --> $DIR/must_use-result-unit-uninhabited.rs:90:5
    |
-LL |     c1();
-   |     ^^^^
+LL |     controlflow_unit();
+   |     ^^^^^^^^^^^^^^^^^^
    |
 help: use `let _ = ...` to ignore the resulting value
    |
-LL |     let _ = c1();
+LL |     let _ = controlflow_unit();
    |     +++++++
 
 error: aborting due to 5 previous errors

--- a/tests/ui/lint/unused/must_use-result-unit-uninhabited.stderr
+++ b/tests/ui/lint/unused/must_use-result-unit-uninhabited.stderr
@@ -62,5 +62,17 @@ help: use `let _ = ...` to ignore the resulting value
 LL |     let _ = controlflow_unit();
    |     +++++++
 
-error: aborting due to 5 previous errors
+error: unused `Result` that must be used
+  --> $DIR/must_use-result-unit-uninhabited.rs:99:9
+   |
+LL |         self.generate();
+   |         ^^^^^^^^^^^^^^^
+   |
+   = note: this `Result` may be an `Err` variant, which should be handled
+help: use `let _ = ...` to ignore the resulting value
+   |
+LL |         let _ = self.generate();
+   |         +++++++
+
+error: aborting due to 6 previous errors
 

--- a/tests/ui/lint/unused/must_use-result-unit-uninhabited.stderr
+++ b/tests/ui/lint/unused/must_use-result-unit-uninhabited.stderr
@@ -1,5 +1,5 @@
 error: unused `Result` that must be used
-  --> $DIR/must_use-result-unit-uninhabited.rs:48:5
+  --> $DIR/must_use-result-unit-uninhabited.rs:67:5
    |
 LL |     f1();
    |     ^^^^
@@ -16,7 +16,7 @@ LL |     let _ = f1();
    |     +++++++
 
 error: unused `Result` that must be used
-  --> $DIR/must_use-result-unit-uninhabited.rs:52:5
+  --> $DIR/must_use-result-unit-uninhabited.rs:71:5
    |
 LL |     f5();
    |     ^^^^
@@ -28,7 +28,7 @@ LL |     let _ = f5();
    |     +++++++
 
 error: unused `Result` that must be used
-  --> $DIR/must_use-result-unit-uninhabited.rs:54:5
+  --> $DIR/must_use-result-unit-uninhabited.rs:73:5
    |
 LL |     f6(S2);
    |     ^^^^^^
@@ -39,5 +39,17 @@ help: use `let _ = ...` to ignore the resulting value
 LL |     let _ = f6(S2);
    |     +++++++
 
-error: aborting due to 3 previous errors
+error: unused `Result` that must be used
+  --> $DIR/must_use-result-unit-uninhabited.rs:75:5
+   |
+LL |     S2.method();
+   |     ^^^^^^^^^^^
+   |
+   = note: this `Result` may be an `Err` variant, which should be handled
+help: use `let _ = ...` to ignore the resulting value
+   |
+LL |     let _ = S2.method();
+   |     +++++++
+
+error: aborting due to 4 previous errors
 

--- a/tests/ui/lint/unused/must_use-result-unit-uninhabited.stderr
+++ b/tests/ui/lint/unused/must_use-result-unit-uninhabited.stderr
@@ -1,0 +1,43 @@
+error: unused `Result` that must be used
+  --> $DIR/must_use-result-unit-uninhabited.rs:48:5
+   |
+LL |     f1();
+   |     ^^^^
+   |
+   = note: this `Result` may be an `Err` variant, which should be handled
+note: the lint level is defined here
+  --> $DIR/must_use-result-unit-uninhabited.rs:4:9
+   |
+LL | #![deny(unused_must_use)]
+   |         ^^^^^^^^^^^^^^^
+help: use `let _ = ...` to ignore the resulting value
+   |
+LL |     let _ = f1();
+   |     +++++++
+
+error: unused `Result` that must be used
+  --> $DIR/must_use-result-unit-uninhabited.rs:52:5
+   |
+LL |     f5();
+   |     ^^^^
+   |
+   = note: this `Result` may be an `Err` variant, which should be handled
+help: use `let _ = ...` to ignore the resulting value
+   |
+LL |     let _ = f5();
+   |     +++++++
+
+error: unused `Result` that must be used
+  --> $DIR/must_use-result-unit-uninhabited.rs:54:5
+   |
+LL |     f6(S2);
+   |     ^^^^^^
+   |
+   = note: this `Result` may be an `Err` variant, which should be handled
+help: use `let _ = ...` to ignore the resulting value
+   |
+LL |     let _ = f6(S2);
+   |     +++++++
+
+error: aborting due to 3 previous errors
+

--- a/tests/ui/lint/unused/must_use-result-unit-uninhabited.stderr
+++ b/tests/ui/lint/unused/must_use-result-unit-uninhabited.stderr
@@ -1,5 +1,5 @@
 error: unused `Result` that must be used
-  --> $DIR/must_use-result-unit-uninhabited.rs:67:5
+  --> $DIR/must_use-result-unit-uninhabited.rs:80:5
    |
 LL |     f1();
    |     ^^^^
@@ -16,7 +16,7 @@ LL |     let _ = f1();
    |     +++++++
 
 error: unused `Result` that must be used
-  --> $DIR/must_use-result-unit-uninhabited.rs:71:5
+  --> $DIR/must_use-result-unit-uninhabited.rs:84:5
    |
 LL |     f5();
    |     ^^^^
@@ -28,7 +28,7 @@ LL |     let _ = f5();
    |     +++++++
 
 error: unused `Result` that must be used
-  --> $DIR/must_use-result-unit-uninhabited.rs:73:5
+  --> $DIR/must_use-result-unit-uninhabited.rs:86:5
    |
 LL |     f6(S2);
    |     ^^^^^^
@@ -40,7 +40,7 @@ LL |     let _ = f6(S2);
    |     +++++++
 
 error: unused `Result` that must be used
-  --> $DIR/must_use-result-unit-uninhabited.rs:75:5
+  --> $DIR/must_use-result-unit-uninhabited.rs:88:5
    |
 LL |     S2.method();
    |     ^^^^^^^^^^^
@@ -51,5 +51,16 @@ help: use `let _ = ...` to ignore the resulting value
 LL |     let _ = S2.method();
    |     +++++++
 
-error: aborting due to 4 previous errors
+error: unused `ControlFlow` that must be used
+  --> $DIR/must_use-result-unit-uninhabited.rs:90:5
+   |
+LL |     c1();
+   |     ^^^^
+   |
+help: use `let _ = ...` to ignore the resulting value
+   |
+LL |     let _ = c1();
+   |     +++++++
+
+error: aborting due to 5 previous errors
 

--- a/tests/ui/never_type/defaulted-never-note.fallback.stderr
+++ b/tests/ui/never_type/defaulted-never-note.fallback.stderr
@@ -1,5 +1,5 @@
 error[E0277]: the trait bound `!: ImplementedForUnitButNotNever` is not satisfied
-  --> $DIR/defaulted-never-note.rs:30:9
+  --> $DIR/defaulted-never-note.rs:31:9
    |
 LL |     foo(_x);
    |     --- ^^ the trait `ImplementedForUnitButNotNever` is not implemented for `!`
@@ -10,7 +10,7 @@ LL |     foo(_x);
    = note: this error might have been caused by changes to Rust's type-inference algorithm (see issue #48950 <https://github.com/rust-lang/rust/issues/48950> for more information)
    = help: you might have intended to use the type `()` here instead
 note: required by a bound in `foo`
-  --> $DIR/defaulted-never-note.rs:23:11
+  --> $DIR/defaulted-never-note.rs:26:11
    |
 LL | fn foo<T: ImplementedForUnitButNotNever>(_t: T) {}
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `foo`

--- a/tests/ui/never_type/defaulted-never-note.fallback.stderr
+++ b/tests/ui/never_type/defaulted-never-note.fallback.stderr
@@ -1,5 +1,5 @@
 error[E0277]: the trait bound `!: ImplementedForUnitButNotNever` is not satisfied
-  --> $DIR/defaulted-never-note.rs:32:9
+  --> $DIR/defaulted-never-note.rs:30:9
    |
 LL |     foo(_x);
    |     --- ^^ the trait `ImplementedForUnitButNotNever` is not implemented for `!`
@@ -10,7 +10,7 @@ LL |     foo(_x);
    = note: this error might have been caused by changes to Rust's type-inference algorithm (see issue #48950 <https://github.com/rust-lang/rust/issues/48950> for more information)
    = help: you might have intended to use the type `()` here instead
 note: required by a bound in `foo`
-  --> $DIR/defaulted-never-note.rs:25:11
+  --> $DIR/defaulted-never-note.rs:23:11
    |
 LL | fn foo<T: ImplementedForUnitButNotNever>(_t: T) {}
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `foo`

--- a/tests/ui/never_type/defaulted-never-note.nofallback.stderr
+++ b/tests/ui/never_type/defaulted-never-note.nofallback.stderr
@@ -1,5 +1,5 @@
-warning: this function depends on never type fallback being `()`
-  --> $DIR/defaulted-never-note.rs:28:1
+error: this function depends on never type fallback being `()`
+  --> $DIR/defaulted-never-note.rs:26:1
    |
 LL | fn smeg() {
    | ^^^^^^^^^
@@ -8,21 +8,21 @@ LL | fn smeg() {
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: ImplementedForUnitButNotNever` will fail
-  --> $DIR/defaulted-never-note.rs:32:9
+  --> $DIR/defaulted-never-note.rs:30:9
    |
 LL |     foo(_x);
    |         ^^
-   = note: `#[warn(dependency_on_unit_never_type_fallback)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
+   = note: `#[deny(dependency_on_unit_never_type_fallback)]` (part of `#[deny(rust_2024_compatibility)]`) on by default
 help: use `()` annotations to avoid fallback changes
    |
 LL |     let _x: () = return;
    |           ++++
 
-warning: 1 warning emitted
+error: aborting due to 1 previous error
 
 Future incompatibility report: Future breakage diagnostic:
-warning: this function depends on never type fallback being `()`
-  --> $DIR/defaulted-never-note.rs:28:1
+error: this function depends on never type fallback being `()`
+  --> $DIR/defaulted-never-note.rs:26:1
    |
 LL | fn smeg() {
    | ^^^^^^^^^
@@ -31,11 +31,11 @@ LL | fn smeg() {
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: ImplementedForUnitButNotNever` will fail
-  --> $DIR/defaulted-never-note.rs:32:9
+  --> $DIR/defaulted-never-note.rs:30:9
    |
 LL |     foo(_x);
    |         ^^
-   = note: `#[warn(dependency_on_unit_never_type_fallback)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
+   = note: `#[deny(dependency_on_unit_never_type_fallback)]` (part of `#[deny(rust_2024_compatibility)]`) on by default
 help: use `()` annotations to avoid fallback changes
    |
 LL |     let _x: () = return;

--- a/tests/ui/never_type/defaulted-never-note.nofallback.stderr
+++ b/tests/ui/never_type/defaulted-never-note.nofallback.stderr
@@ -1,41 +1,16 @@
-error: this function depends on never type fallback being `()`
-  --> $DIR/defaulted-never-note.rs:26:1
-   |
-LL | fn smeg() {
-   | ^^^^^^^^^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
-   = help: specify the types explicitly
-note: in edition 2024, the requirement `!: ImplementedForUnitButNotNever` will fail
-  --> $DIR/defaulted-never-note.rs:30:9
-   |
-LL |     foo(_x);
-   |         ^^
-   = note: `#[deny(dependency_on_unit_never_type_fallback)]` (part of `#[deny(rust_2024_compatibility)]`) on by default
-help: use `()` annotations to avoid fallback changes
-   |
-LL |     let _x: () = return;
-   |           ++++
-
-error: aborting due to 1 previous error
-
 Future incompatibility report: Future breakage diagnostic:
-error: this function depends on never type fallback being `()`
-  --> $DIR/defaulted-never-note.rs:26:1
+warning: this function depends on never type fallback being `()`
+  --> $DIR/defaulted-never-note.rs:29:1
    |
 LL | fn smeg() {
    | ^^^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: ImplementedForUnitButNotNever` will fail
-  --> $DIR/defaulted-never-note.rs:30:9
+  --> $DIR/defaulted-never-note.rs:31:9
    |
 LL |     foo(_x);
    |         ^^
-   = note: `#[deny(dependency_on_unit_never_type_fallback)]` (part of `#[deny(rust_2024_compatibility)]`) on by default
 help: use `()` annotations to avoid fallback changes
    |
 LL |     let _x: () = return;

--- a/tests/ui/never_type/defaulted-never-note.rs
+++ b/tests/ui/never_type/defaulted-never-note.rs
@@ -1,6 +1,4 @@
 //@ revisions: nofallback fallback
-//@[nofallback] run-pass
-//@[fallback] check-fail
 
 // We need to opt into the `never_type_fallback` feature
 // to trigger the requirement that this is testing.
@@ -23,19 +21,19 @@ trait ImplementedForUnitButNotNever {}
 impl ImplementedForUnitButNotNever for () {}
 
 fn foo<T: ImplementedForUnitButNotNever>(_t: T) {}
-//[fallback]~^ NOTE required by this bound in `foo`
-//[fallback]~| NOTE required by a bound in `foo`
+//[fallback]~^ note: required by this bound in `foo`
+//[fallback]~| note: required by a bound in `foo`
 fn smeg() {
-    //[nofallback]~^ warn: this function depends on never type fallback being `()`
+    //[nofallback]~^ error: this function depends on never type fallback being `()`
     //[nofallback]~| warn: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
     let _x = return;
     foo(_x);
-    //[fallback]~^ ERROR the trait bound
-    //[fallback]~| NOTE the trait `ImplementedForUnitButNotNever` is not implemented
-    //[fallback]~| HELP trait `ImplementedForUnitButNotNever` is implemented for `()`
-    //[fallback]~| NOTE this error might have been caused
-    //[fallback]~| NOTE required by a bound introduced by this call
-    //[fallback]~| HELP you might have intended to use the type `()`
+    //[fallback]~^ error: the trait bound
+    //[fallback]~| note: the trait `ImplementedForUnitButNotNever` is not implemented
+    //[fallback]~| help: trait `ImplementedForUnitButNotNever` is implemented for `()`
+    //[fallback]~| note: this error might have been caused
+    //[fallback]~| note: required by a bound introduced by this call
+    //[fallback]~| help: you might have intended to use the type `()`
 }
 
 fn main() {

--- a/tests/ui/never_type/defaulted-never-note.rs
+++ b/tests/ui/never_type/defaulted-never-note.rs
@@ -1,10 +1,13 @@
 //@ revisions: nofallback fallback
+//@[nofallback] run-pass
+//@[fallback] check-fail
 
 // We need to opt into the `never_type_fallback` feature
 // to trigger the requirement that this is testing.
 #![cfg_attr(fallback, feature(never_type, never_type_fallback))]
 
 #![allow(unused)]
+#![expect(dependency_on_unit_never_type_fallback)]
 
 trait Deserialize: Sized {
     fn deserialize() -> Result<Self, String>;
@@ -24,8 +27,6 @@ fn foo<T: ImplementedForUnitButNotNever>(_t: T) {}
 //[fallback]~^ note: required by this bound in `foo`
 //[fallback]~| note: required by a bound in `foo`
 fn smeg() {
-    //[nofallback]~^ error: this function depends on never type fallback being `()`
-    //[nofallback]~| warn: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
     let _x = return;
     foo(_x);
     //[fallback]~^ error: the trait bound

--- a/tests/ui/never_type/dependency-on-fallback-to-unit.rs
+++ b/tests/ui/never_type/dependency-on-fallback-to-unit.rs
@@ -1,12 +1,10 @@
-//@ check-pass
-
 fn main() {
     def();
     _ = question_mark();
 }
 
 fn def() {
-    //~^ warn: this function depends on never type fallback being `()`
+    //~^ error: this function depends on never type fallback being `()`
     //~| warn: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
     match true {
         false => <_>::default(),
@@ -17,7 +15,7 @@ fn def() {
 // <https://github.com/rust-lang/rust/issues/51125>
 // <https://github.com/rust-lang/rust/issues/39216>
 fn question_mark() -> Result<(), ()> {
-    //~^ warn: this function depends on never type fallback being `()`
+    //~^ error: this function depends on never type fallback being `()`
     //~| warn: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
     deserialize()?;
     Ok(())

--- a/tests/ui/never_type/dependency-on-fallback-to-unit.stderr
+++ b/tests/ui/never_type/dependency-on-fallback-to-unit.stderr
@@ -1,5 +1,5 @@
-warning: this function depends on never type fallback being `()`
-  --> $DIR/dependency-on-fallback-to-unit.rs:8:1
+error: this function depends on never type fallback being `()`
+  --> $DIR/dependency-on-fallback-to-unit.rs:6:1
    |
 LL | fn def() {
    | ^^^^^^^^
@@ -8,19 +8,19 @@ LL | fn def() {
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: Default` will fail
-  --> $DIR/dependency-on-fallback-to-unit.rs:12:19
+  --> $DIR/dependency-on-fallback-to-unit.rs:10:19
    |
 LL |         false => <_>::default(),
    |                   ^
-   = note: `#[warn(dependency_on_unit_never_type_fallback)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
+   = note: `#[deny(dependency_on_unit_never_type_fallback)]` (part of `#[deny(rust_2024_compatibility)]`) on by default
 help: use `()` annotations to avoid fallback changes
    |
 LL -         false => <_>::default(),
 LL +         false => <()>::default(),
    |
 
-warning: this function depends on never type fallback being `()`
-  --> $DIR/dependency-on-fallback-to-unit.rs:19:1
+error: this function depends on never type fallback being `()`
+  --> $DIR/dependency-on-fallback-to-unit.rs:17:1
    |
 LL | fn question_mark() -> Result<(), ()> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -29,7 +29,7 @@ LL | fn question_mark() -> Result<(), ()> {
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: Default` will fail
-  --> $DIR/dependency-on-fallback-to-unit.rs:22:5
+  --> $DIR/dependency-on-fallback-to-unit.rs:20:5
    |
 LL |     deserialize()?;
    |     ^^^^^^^^^^^^^
@@ -38,11 +38,11 @@ help: use `()` annotations to avoid fallback changes
 LL |     deserialize::<()>()?;
    |                ++++++
 
-warning: 2 warnings emitted
+error: aborting due to 2 previous errors
 
 Future incompatibility report: Future breakage diagnostic:
-warning: this function depends on never type fallback being `()`
-  --> $DIR/dependency-on-fallback-to-unit.rs:8:1
+error: this function depends on never type fallback being `()`
+  --> $DIR/dependency-on-fallback-to-unit.rs:6:1
    |
 LL | fn def() {
    | ^^^^^^^^
@@ -51,11 +51,11 @@ LL | fn def() {
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: Default` will fail
-  --> $DIR/dependency-on-fallback-to-unit.rs:12:19
+  --> $DIR/dependency-on-fallback-to-unit.rs:10:19
    |
 LL |         false => <_>::default(),
    |                   ^
-   = note: `#[warn(dependency_on_unit_never_type_fallback)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
+   = note: `#[deny(dependency_on_unit_never_type_fallback)]` (part of `#[deny(rust_2024_compatibility)]`) on by default
 help: use `()` annotations to avoid fallback changes
    |
 LL -         false => <_>::default(),
@@ -63,8 +63,8 @@ LL +         false => <()>::default(),
    |
 
 Future breakage diagnostic:
-warning: this function depends on never type fallback being `()`
-  --> $DIR/dependency-on-fallback-to-unit.rs:19:1
+error: this function depends on never type fallback being `()`
+  --> $DIR/dependency-on-fallback-to-unit.rs:17:1
    |
 LL | fn question_mark() -> Result<(), ()> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -73,11 +73,11 @@ LL | fn question_mark() -> Result<(), ()> {
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: Default` will fail
-  --> $DIR/dependency-on-fallback-to-unit.rs:22:5
+  --> $DIR/dependency-on-fallback-to-unit.rs:20:5
    |
 LL |     deserialize()?;
    |     ^^^^^^^^^^^^^
-   = note: `#[warn(dependency_on_unit_never_type_fallback)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
+   = note: `#[deny(dependency_on_unit_never_type_fallback)]` (part of `#[deny(rust_2024_compatibility)]`) on by default
 help: use `()` annotations to avoid fallback changes
    |
 LL |     deserialize::<()>()?;

--- a/tests/ui/never_type/diverging-fallback-control-flow.nofallback.stderr
+++ b/tests/ui/never_type/diverging-fallback-control-flow.nofallback.stderr
@@ -1,81 +1,34 @@
-error: this function depends on never type fallback being `()`
-  --> $DIR/diverging-fallback-control-flow.rs:30:1
-   |
-LL | fn assignment() {
-   | ^^^^^^^^^^^^^^^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
-   = help: specify the types explicitly
-note: in edition 2024, the requirement `!: UnitDefault` will fail
-  --> $DIR/diverging-fallback-control-flow.rs:36:13
-   |
-LL |         x = UnitDefault::default();
-   |             ^^^^^^^^^^^^^^^^^^^^^^
-   = note: `#[deny(dependency_on_unit_never_type_fallback)]` (part of `#[deny(rust_2024_compatibility)]`) on by default
-help: use `()` annotations to avoid fallback changes
-   |
-LL |     let x: ();
-   |          ++++
-
-error: this function depends on never type fallback being `()`
-  --> $DIR/diverging-fallback-control-flow.rs:42:1
-   |
-LL | fn assignment_rev() {
-   | ^^^^^^^^^^^^^^^^^^^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
-   = help: specify the types explicitly
-note: in edition 2024, the requirement `!: UnitDefault` will fail
-  --> $DIR/diverging-fallback-control-flow.rs:50:13
-   |
-LL |         x = UnitDefault::default();
-   |             ^^^^^^^^^^^^^^^^^^^^^^
-help: use `()` annotations to avoid fallback changes
-   |
-LL |     let x: ();
-   |          ++++
-
-error: aborting due to 2 previous errors
-
 Future incompatibility report: Future breakage diagnostic:
-error: this function depends on never type fallback being `()`
-  --> $DIR/diverging-fallback-control-flow.rs:30:1
+warning: this function depends on never type fallback being `()`
+  --> $DIR/diverging-fallback-control-flow.rs:32:1
    |
 LL | fn assignment() {
    | ^^^^^^^^^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: UnitDefault` will fail
   --> $DIR/diverging-fallback-control-flow.rs:36:13
    |
 LL |         x = UnitDefault::default();
    |             ^^^^^^^^^^^^^^^^^^^^^^
-   = note: `#[deny(dependency_on_unit_never_type_fallback)]` (part of `#[deny(rust_2024_compatibility)]`) on by default
 help: use `()` annotations to avoid fallback changes
    |
 LL |     let x: ();
    |          ++++
 
 Future breakage diagnostic:
-error: this function depends on never type fallback being `()`
+warning: this function depends on never type fallback being `()`
   --> $DIR/diverging-fallback-control-flow.rs:42:1
    |
 LL | fn assignment_rev() {
    | ^^^^^^^^^^^^^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: UnitDefault` will fail
-  --> $DIR/diverging-fallback-control-flow.rs:50:13
+  --> $DIR/diverging-fallback-control-flow.rs:48:13
    |
 LL |         x = UnitDefault::default();
    |             ^^^^^^^^^^^^^^^^^^^^^^
-   = note: `#[deny(dependency_on_unit_never_type_fallback)]` (part of `#[deny(rust_2024_compatibility)]`) on by default
 help: use `()` annotations to avoid fallback changes
    |
 LL |     let x: ();

--- a/tests/ui/never_type/diverging-fallback-control-flow.nofallback.stderr
+++ b/tests/ui/never_type/diverging-fallback-control-flow.nofallback.stderr
@@ -1,4 +1,4 @@
-warning: this function depends on never type fallback being `()`
+error: this function depends on never type fallback being `()`
   --> $DIR/diverging-fallback-control-flow.rs:30:1
    |
 LL | fn assignment() {
@@ -12,13 +12,13 @@ note: in edition 2024, the requirement `!: UnitDefault` will fail
    |
 LL |         x = UnitDefault::default();
    |             ^^^^^^^^^^^^^^^^^^^^^^
-   = note: `#[warn(dependency_on_unit_never_type_fallback)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
+   = note: `#[deny(dependency_on_unit_never_type_fallback)]` (part of `#[deny(rust_2024_compatibility)]`) on by default
 help: use `()` annotations to avoid fallback changes
    |
 LL |     let x: ();
    |          ++++
 
-warning: this function depends on never type fallback being `()`
+error: this function depends on never type fallback being `()`
   --> $DIR/diverging-fallback-control-flow.rs:42:1
    |
 LL | fn assignment_rev() {
@@ -37,10 +37,10 @@ help: use `()` annotations to avoid fallback changes
 LL |     let x: ();
    |          ++++
 
-warning: 2 warnings emitted
+error: aborting due to 2 previous errors
 
 Future incompatibility report: Future breakage diagnostic:
-warning: this function depends on never type fallback being `()`
+error: this function depends on never type fallback being `()`
   --> $DIR/diverging-fallback-control-flow.rs:30:1
    |
 LL | fn assignment() {
@@ -54,14 +54,14 @@ note: in edition 2024, the requirement `!: UnitDefault` will fail
    |
 LL |         x = UnitDefault::default();
    |             ^^^^^^^^^^^^^^^^^^^^^^
-   = note: `#[warn(dependency_on_unit_never_type_fallback)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
+   = note: `#[deny(dependency_on_unit_never_type_fallback)]` (part of `#[deny(rust_2024_compatibility)]`) on by default
 help: use `()` annotations to avoid fallback changes
    |
 LL |     let x: ();
    |          ++++
 
 Future breakage diagnostic:
-warning: this function depends on never type fallback being `()`
+error: this function depends on never type fallback being `()`
   --> $DIR/diverging-fallback-control-flow.rs:42:1
    |
 LL | fn assignment_rev() {
@@ -75,7 +75,7 @@ note: in edition 2024, the requirement `!: UnitDefault` will fail
    |
 LL |         x = UnitDefault::default();
    |             ^^^^^^^^^^^^^^^^^^^^^^
-   = note: `#[warn(dependency_on_unit_never_type_fallback)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
+   = note: `#[deny(dependency_on_unit_never_type_fallback)]` (part of `#[deny(rust_2024_compatibility)]`) on by default
 help: use `()` annotations to avoid fallback changes
    |
 LL |     let x: ();

--- a/tests/ui/never_type/diverging-fallback-control-flow.rs
+++ b/tests/ui/never_type/diverging-fallback-control-flow.rs
@@ -1,10 +1,12 @@
 //@ revisions: nofallback fallback
-//@[fallback] check-pass
+//@ check-pass
 
 #![allow(dead_code)]
 #![allow(unused_assignments)]
 #![allow(unused_variables)]
 #![allow(unreachable_code)]
+#![cfg_attr(nofallback, expect(dependency_on_unit_never_type_fallback))]
+
 // Test various cases where we permit an unconstrained variable
 // to fallback based on control-flow. In all of these cases,
 // the type variable winds up being the target of both a `!` coercion
@@ -28,8 +30,6 @@ impl UnitDefault for () {
 }
 
 fn assignment() {
-    //[nofallback]~^ error: this function depends on never type fallback being `()`
-    //[nofallback]~| warn: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
     let x;
 
     if true {
@@ -40,8 +40,6 @@ fn assignment() {
 }
 
 fn assignment_rev() {
-    //[nofallback]~^ error: this function depends on never type fallback being `()`
-    //[nofallback]~| warn: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
     let x;
 
     if true {

--- a/tests/ui/never_type/diverging-fallback-control-flow.rs
+++ b/tests/ui/never_type/diverging-fallback-control-flow.rs
@@ -1,5 +1,5 @@
 //@ revisions: nofallback fallback
-//@ run-pass
+//@[fallback] check-pass
 
 #![allow(dead_code)]
 #![allow(unused_assignments)]
@@ -28,7 +28,7 @@ impl UnitDefault for () {
 }
 
 fn assignment() {
-    //[nofallback]~^ warn: this function depends on never type fallback being `()`
+    //[nofallback]~^ error: this function depends on never type fallback being `()`
     //[nofallback]~| warn: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
     let x;
 
@@ -40,7 +40,7 @@ fn assignment() {
 }
 
 fn assignment_rev() {
-    //[nofallback]~^ warn: this function depends on never type fallback being `()`
+    //[nofallback]~^ error: this function depends on never type fallback being `()`
     //[nofallback]~| warn: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
     let x;
 

--- a/tests/ui/never_type/diverging-fallback-no-leak.fallback.stderr
+++ b/tests/ui/never_type/diverging-fallback-no-leak.fallback.stderr
@@ -1,5 +1,5 @@
 error[E0277]: the trait bound `!: Test` is not satisfied
-  --> $DIR/diverging-fallback-no-leak.rs:20:23
+  --> $DIR/diverging-fallback-no-leak.rs:19:23
    |
 LL |     unconstrained_arg(return);
    |     ----------------- ^^^^^^ the trait `Test` is not implemented for `!`
@@ -12,7 +12,7 @@ LL |     unconstrained_arg(return);
    = note: this error might have been caused by changes to Rust's type-inference algorithm (see issue #48950 <https://github.com/rust-lang/rust/issues/48950> for more information)
    = help: you might have intended to use the type `()` here instead
 note: required by a bound in `unconstrained_arg`
-  --> $DIR/diverging-fallback-no-leak.rs:12:25
+  --> $DIR/diverging-fallback-no-leak.rs:11:25
    |
 LL | fn unconstrained_arg<T: Test>(_: T) {}
    |                         ^^^^ required by this bound in `unconstrained_arg`

--- a/tests/ui/never_type/diverging-fallback-no-leak.fallback.stderr
+++ b/tests/ui/never_type/diverging-fallback-no-leak.fallback.stderr
@@ -1,5 +1,5 @@
 error[E0277]: the trait bound `!: Test` is not satisfied
-  --> $DIR/diverging-fallback-no-leak.rs:19:23
+  --> $DIR/diverging-fallback-no-leak.rs:18:23
    |
 LL |     unconstrained_arg(return);
    |     ----------------- ^^^^^^ the trait `Test` is not implemented for `!`
@@ -12,7 +12,7 @@ LL |     unconstrained_arg(return);
    = note: this error might have been caused by changes to Rust's type-inference algorithm (see issue #48950 <https://github.com/rust-lang/rust/issues/48950> for more information)
    = help: you might have intended to use the type `()` here instead
 note: required by a bound in `unconstrained_arg`
-  --> $DIR/diverging-fallback-no-leak.rs:11:25
+  --> $DIR/diverging-fallback-no-leak.rs:13:25
    |
 LL | fn unconstrained_arg<T: Test>(_: T) {}
    |                         ^^^^ required by this bound in `unconstrained_arg`

--- a/tests/ui/never_type/diverging-fallback-no-leak.nofallback.stderr
+++ b/tests/ui/never_type/diverging-fallback-no-leak.nofallback.stderr
@@ -1,5 +1,5 @@
-warning: this function depends on never type fallback being `()`
-  --> $DIR/diverging-fallback-no-leak.rs:14:1
+error: this function depends on never type fallback being `()`
+  --> $DIR/diverging-fallback-no-leak.rs:13:1
    |
 LL | fn main() {
    | ^^^^^^^^^
@@ -8,21 +8,21 @@ LL | fn main() {
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: Test` will fail
-  --> $DIR/diverging-fallback-no-leak.rs:20:23
+  --> $DIR/diverging-fallback-no-leak.rs:19:23
    |
 LL |     unconstrained_arg(return);
    |                       ^^^^^^
-   = note: `#[warn(dependency_on_unit_never_type_fallback)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
+   = note: `#[deny(dependency_on_unit_never_type_fallback)]` (part of `#[deny(rust_2024_compatibility)]`) on by default
 help: use `()` annotations to avoid fallback changes
    |
 LL |     unconstrained_arg::<()>(return);
    |                      ++++++
 
-warning: 1 warning emitted
+error: aborting due to 1 previous error
 
 Future incompatibility report: Future breakage diagnostic:
-warning: this function depends on never type fallback being `()`
-  --> $DIR/diverging-fallback-no-leak.rs:14:1
+error: this function depends on never type fallback being `()`
+  --> $DIR/diverging-fallback-no-leak.rs:13:1
    |
 LL | fn main() {
    | ^^^^^^^^^
@@ -31,11 +31,11 @@ LL | fn main() {
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: Test` will fail
-  --> $DIR/diverging-fallback-no-leak.rs:20:23
+  --> $DIR/diverging-fallback-no-leak.rs:19:23
    |
 LL |     unconstrained_arg(return);
    |                       ^^^^^^
-   = note: `#[warn(dependency_on_unit_never_type_fallback)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
+   = note: `#[deny(dependency_on_unit_never_type_fallback)]` (part of `#[deny(rust_2024_compatibility)]`) on by default
 help: use `()` annotations to avoid fallback changes
    |
 LL |     unconstrained_arg::<()>(return);

--- a/tests/ui/never_type/diverging-fallback-no-leak.nofallback.stderr
+++ b/tests/ui/never_type/diverging-fallback-no-leak.nofallback.stderr
@@ -1,41 +1,16 @@
-error: this function depends on never type fallback being `()`
-  --> $DIR/diverging-fallback-no-leak.rs:13:1
-   |
-LL | fn main() {
-   | ^^^^^^^^^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
-   = help: specify the types explicitly
-note: in edition 2024, the requirement `!: Test` will fail
-  --> $DIR/diverging-fallback-no-leak.rs:19:23
-   |
-LL |     unconstrained_arg(return);
-   |                       ^^^^^^
-   = note: `#[deny(dependency_on_unit_never_type_fallback)]` (part of `#[deny(rust_2024_compatibility)]`) on by default
-help: use `()` annotations to avoid fallback changes
-   |
-LL |     unconstrained_arg::<()>(return);
-   |                      ++++++
-
-error: aborting due to 1 previous error
-
 Future incompatibility report: Future breakage diagnostic:
-error: this function depends on never type fallback being `()`
-  --> $DIR/diverging-fallback-no-leak.rs:13:1
+warning: this function depends on never type fallback being `()`
+  --> $DIR/diverging-fallback-no-leak.rs:15:1
    |
 LL | fn main() {
    | ^^^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: Test` will fail
-  --> $DIR/diverging-fallback-no-leak.rs:19:23
+  --> $DIR/diverging-fallback-no-leak.rs:18:23
    |
 LL |     unconstrained_arg(return);
    |                       ^^^^^^
-   = note: `#[deny(dependency_on_unit_never_type_fallback)]` (part of `#[deny(rust_2024_compatibility)]`) on by default
 help: use `()` annotations to avoid fallback changes
    |
 LL |     unconstrained_arg::<()>(return);

--- a/tests/ui/never_type/diverging-fallback-no-leak.rs
+++ b/tests/ui/never_type/diverging-fallback-no-leak.rs
@@ -1,5 +1,4 @@
 //@ revisions: nofallback fallback
-//@[nofallback] check-pass
 
 #![cfg_attr(fallback, feature(never_type, never_type_fallback))]
 
@@ -12,11 +11,11 @@ impl Test for () {}
 fn unconstrained_arg<T: Test>(_: T) {}
 
 fn main() {
-    //[nofallback]~^ warn: this function depends on never type fallback being `()`
+    //[nofallback]~^ error: this function depends on never type fallback being `()`
     //[nofallback]~| warn: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
 
     // Here the type variable falls back to `!`,
     // and hence we get a type error.
     unconstrained_arg(return);
-    //[fallback]~^ ERROR trait bound `!: Test` is not satisfied
+    //[fallback]~^ error: trait bound `!: Test` is not satisfied
 }

--- a/tests/ui/never_type/diverging-fallback-no-leak.rs
+++ b/tests/ui/never_type/diverging-fallback-no-leak.rs
@@ -1,6 +1,8 @@
 //@ revisions: nofallback fallback
+//@[nofallback] check-pass
 
 #![cfg_attr(fallback, feature(never_type, never_type_fallback))]
+#![cfg_attr(nofallback, expect(dependency_on_unit_never_type_fallback))]
 
 fn make_unit() {}
 
@@ -11,9 +13,6 @@ impl Test for () {}
 fn unconstrained_arg<T: Test>(_: T) {}
 
 fn main() {
-    //[nofallback]~^ error: this function depends on never type fallback being `()`
-    //[nofallback]~| warn: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-
     // Here the type variable falls back to `!`,
     // and hence we get a type error.
     unconstrained_arg(return);

--- a/tests/ui/never_type/diverging-fallback-unconstrained-return.nofallback.stderr
+++ b/tests/ui/never_type/diverging-fallback-unconstrained-return.nofallback.stderr
@@ -1,4 +1,4 @@
-warning: this function depends on never type fallback being `()`
+error: this function depends on never type fallback being `()`
   --> $DIR/diverging-fallback-unconstrained-return.rs:28:1
    |
 LL | fn main() {
@@ -12,16 +12,16 @@ note: in edition 2024, the requirement `!: UnitReturn` will fail
    |
 LL |     let _ = if true { unconstrained_return() } else { panic!() };
    |                       ^^^^^^^^^^^^^^^^^^^^^^
-   = note: `#[warn(dependency_on_unit_never_type_fallback)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
+   = note: `#[deny(dependency_on_unit_never_type_fallback)]` (part of `#[deny(rust_2024_compatibility)]`) on by default
 help: use `()` annotations to avoid fallback changes
    |
 LL |     let _: () = if true { unconstrained_return() } else { panic!() };
    |          ++++
 
-warning: 1 warning emitted
+error: aborting due to 1 previous error
 
 Future incompatibility report: Future breakage diagnostic:
-warning: this function depends on never type fallback being `()`
+error: this function depends on never type fallback being `()`
   --> $DIR/diverging-fallback-unconstrained-return.rs:28:1
    |
 LL | fn main() {
@@ -35,7 +35,7 @@ note: in edition 2024, the requirement `!: UnitReturn` will fail
    |
 LL |     let _ = if true { unconstrained_return() } else { panic!() };
    |                       ^^^^^^^^^^^^^^^^^^^^^^
-   = note: `#[warn(dependency_on_unit_never_type_fallback)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
+   = note: `#[deny(dependency_on_unit_never_type_fallback)]` (part of `#[deny(rust_2024_compatibility)]`) on by default
 help: use `()` annotations to avoid fallback changes
    |
 LL |     let _: () = if true { unconstrained_return() } else { panic!() };

--- a/tests/ui/never_type/diverging-fallback-unconstrained-return.rs
+++ b/tests/ui/never_type/diverging-fallback-unconstrained-return.rs
@@ -4,7 +4,7 @@
 // in the objc crate, where changing the fallback from `!` to `()`
 // resulted in unsoundness.
 //
-//@ check-pass
+//@[fallback] check-pass
 
 //@ revisions: nofallback fallback
 
@@ -26,7 +26,7 @@ fn unconstrained_return<T: UnitReturn>() -> T {
 }
 
 fn main() {
-    //[nofallback]~^ warn: this function depends on never type fallback being `()`
+    //[nofallback]~^ error: this function depends on never type fallback being `()`
     //[nofallback]~| warn: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
 
     // In Ye Olde Days, the `T` parameter of `unconstrained_return`

--- a/tests/ui/never_type/dont-suggest-turbofish-from-expansion.rs
+++ b/tests/ui/never_type/dont-suggest-turbofish-from-expansion.rs
@@ -1,5 +1,3 @@
-#![deny(dependency_on_unit_never_type_fallback)]
-
 fn create_ok_default<C>() -> Result<C, ()>
 where
     C: Default,

--- a/tests/ui/never_type/dont-suggest-turbofish-from-expansion.stderr
+++ b/tests/ui/never_type/dont-suggest-turbofish-from-expansion.stderr
@@ -1,5 +1,5 @@
 error: this function depends on never type fallback being `()`
-  --> $DIR/dont-suggest-turbofish-from-expansion.rs:10:1
+  --> $DIR/dont-suggest-turbofish-from-expansion.rs:8:1
    |
 LL | fn main() -> Result<(), ()> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -8,15 +8,11 @@ LL | fn main() -> Result<(), ()> {
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: Default` will fail
-  --> $DIR/dont-suggest-turbofish-from-expansion.rs:14:23
+  --> $DIR/dont-suggest-turbofish-from-expansion.rs:12:23
    |
 LL |         let created = create_ok_default()?;
    |                       ^^^^^^^^^^^^^^^^^^^
-note: the lint level is defined here
-  --> $DIR/dont-suggest-turbofish-from-expansion.rs:1:9
-   |
-LL | #![deny(dependency_on_unit_never_type_fallback)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: `#[deny(dependency_on_unit_never_type_fallback)]` (part of `#[deny(rust_2024_compatibility)]`) on by default
 help: use `()` annotations to avoid fallback changes
    |
 LL |         let created: () = create_ok_default()?;
@@ -26,7 +22,7 @@ error: aborting due to 1 previous error
 
 Future incompatibility report: Future breakage diagnostic:
 error: this function depends on never type fallback being `()`
-  --> $DIR/dont-suggest-turbofish-from-expansion.rs:10:1
+  --> $DIR/dont-suggest-turbofish-from-expansion.rs:8:1
    |
 LL | fn main() -> Result<(), ()> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -35,15 +31,11 @@ LL | fn main() -> Result<(), ()> {
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: Default` will fail
-  --> $DIR/dont-suggest-turbofish-from-expansion.rs:14:23
+  --> $DIR/dont-suggest-turbofish-from-expansion.rs:12:23
    |
 LL |         let created = create_ok_default()?;
    |                       ^^^^^^^^^^^^^^^^^^^
-note: the lint level is defined here
-  --> $DIR/dont-suggest-turbofish-from-expansion.rs:1:9
-   |
-LL | #![deny(dependency_on_unit_never_type_fallback)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: `#[deny(dependency_on_unit_never_type_fallback)]` (part of `#[deny(rust_2024_compatibility)]`) on by default
 help: use `()` annotations to avoid fallback changes
    |
 LL |         let created: () = create_ok_default()?;

--- a/tests/ui/never_type/fallback-closure-ret.nofallback.stderr
+++ b/tests/ui/never_type/fallback-closure-ret.nofallback.stderr
@@ -1,4 +1,4 @@
-warning: this function depends on never type fallback being `()`
+error: this function depends on never type fallback being `()`
   --> $DIR/fallback-closure-ret.rs:21:1
    |
 LL | fn main() {
@@ -12,16 +12,16 @@ note: in edition 2024, the requirement `!: Bar` will fail
    |
 LL |     foo(|| panic!());
    |     ^^^^^^^^^^^^^^^^
-   = note: `#[warn(dependency_on_unit_never_type_fallback)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
+   = note: `#[deny(dependency_on_unit_never_type_fallback)]` (part of `#[deny(rust_2024_compatibility)]`) on by default
 help: use `()` annotations to avoid fallback changes
    |
 LL |     foo::<()>(|| panic!());
    |        ++++++
 
-warning: 1 warning emitted
+error: aborting due to 1 previous error
 
 Future incompatibility report: Future breakage diagnostic:
-warning: this function depends on never type fallback being `()`
+error: this function depends on never type fallback being `()`
   --> $DIR/fallback-closure-ret.rs:21:1
    |
 LL | fn main() {
@@ -35,7 +35,7 @@ note: in edition 2024, the requirement `!: Bar` will fail
    |
 LL |     foo(|| panic!());
    |     ^^^^^^^^^^^^^^^^
-   = note: `#[warn(dependency_on_unit_never_type_fallback)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
+   = note: `#[deny(dependency_on_unit_never_type_fallback)]` (part of `#[deny(rust_2024_compatibility)]`) on by default
 help: use `()` annotations to avoid fallback changes
    |
 LL |     foo::<()>(|| panic!());

--- a/tests/ui/never_type/fallback-closure-ret.nofallback.stderr
+++ b/tests/ui/never_type/fallback-closure-ret.nofallback.stderr
@@ -1,41 +1,16 @@
-error: this function depends on never type fallback being `()`
-  --> $DIR/fallback-closure-ret.rs:21:1
-   |
-LL | fn main() {
-   | ^^^^^^^^^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
-   = help: specify the types explicitly
-note: in edition 2024, the requirement `!: Bar` will fail
-  --> $DIR/fallback-closure-ret.rs:24:5
-   |
-LL |     foo(|| panic!());
-   |     ^^^^^^^^^^^^^^^^
-   = note: `#[deny(dependency_on_unit_never_type_fallback)]` (part of `#[deny(rust_2024_compatibility)]`) on by default
-help: use `()` annotations to avoid fallback changes
-   |
-LL |     foo::<()>(|| panic!());
-   |        ++++++
-
-error: aborting due to 1 previous error
-
 Future incompatibility report: Future breakage diagnostic:
-error: this function depends on never type fallback being `()`
-  --> $DIR/fallback-closure-ret.rs:21:1
+warning: this function depends on never type fallback being `()`
+  --> $DIR/fallback-closure-ret.rs:22:1
    |
 LL | fn main() {
    | ^^^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: Bar` will fail
-  --> $DIR/fallback-closure-ret.rs:24:5
+  --> $DIR/fallback-closure-ret.rs:23:5
    |
 LL |     foo(|| panic!());
    |     ^^^^^^^^^^^^^^^^
-   = note: `#[deny(dependency_on_unit_never_type_fallback)]` (part of `#[deny(rust_2024_compatibility)]`) on by default
 help: use `()` annotations to avoid fallback changes
    |
 LL |     foo::<()>(|| panic!());

--- a/tests/ui/never_type/fallback-closure-ret.rs
+++ b/tests/ui/never_type/fallback-closure-ret.rs
@@ -8,9 +8,10 @@
 // ?T`. In the code below, these are `R: Bar` and `Fn::Output = R`.
 //
 //@ revisions: nofallback fallback
-//@[fallback] check-pass
+//@ check-pass
 
 #![cfg_attr(fallback, feature(never_type_fallback))]
+#![cfg_attr(nofallback, expect(dependency_on_unit_never_type_fallback))]
 
 trait Bar {}
 impl Bar for () {}
@@ -19,7 +20,5 @@ impl Bar for u32 {}
 fn foo<R: Bar>(_: impl Fn() -> R) {}
 
 fn main() {
-    //[nofallback]~^ error: this function depends on never type fallback being `()`
-    //[nofallback]~| warn: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
     foo(|| panic!());
 }

--- a/tests/ui/never_type/fallback-closure-ret.rs
+++ b/tests/ui/never_type/fallback-closure-ret.rs
@@ -8,7 +8,7 @@
 // ?T`. In the code below, these are `R: Bar` and `Fn::Output = R`.
 //
 //@ revisions: nofallback fallback
-//@ check-pass
+//@[fallback] check-pass
 
 #![cfg_attr(fallback, feature(never_type_fallback))]
 
@@ -19,7 +19,7 @@ impl Bar for u32 {}
 fn foo<R: Bar>(_: impl Fn() -> R) {}
 
 fn main() {
-    //[nofallback]~^ warn: this function depends on never type fallback being `()`
+    //[nofallback]~^ error: this function depends on never type fallback being `()`
     //[nofallback]~| warn: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
     foo(|| panic!());
 }

--- a/tests/ui/never_type/impl_trait_fallback.rs
+++ b/tests/ui/never_type/impl_trait_fallback.rs
@@ -1,12 +1,10 @@
-//@ check-pass
-
 fn main() {}
 
 trait T {}
 impl T for () {}
 
 fn should_ret_unit() -> impl T {
-    //~^ warn: this function depends on never type fallback being `()`
+    //~^ error: this function depends on never type fallback being `()`
     //~| warn: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
     panic!()
 }

--- a/tests/ui/never_type/impl_trait_fallback.rs
+++ b/tests/ui/never_type/impl_trait_fallback.rs
@@ -1,10 +1,11 @@
+//@ check-pass
+#![expect(dependency_on_unit_never_type_fallback)]
+
 fn main() {}
 
 trait T {}
 impl T for () {}
 
 fn should_ret_unit() -> impl T {
-    //~^ error: this function depends on never type fallback being `()`
-    //~| warn: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
     panic!()
 }

--- a/tests/ui/never_type/impl_trait_fallback.stderr
+++ b/tests/ui/never_type/impl_trait_fallback.stderr
@@ -1,5 +1,5 @@
-warning: this function depends on never type fallback being `()`
-  --> $DIR/impl_trait_fallback.rs:8:1
+error: this function depends on never type fallback being `()`
+  --> $DIR/impl_trait_fallback.rs:6:1
    |
 LL | fn should_ret_unit() -> impl T {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -8,17 +8,17 @@ LL | fn should_ret_unit() -> impl T {
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: T` will fail
-  --> $DIR/impl_trait_fallback.rs:8:25
+  --> $DIR/impl_trait_fallback.rs:6:25
    |
 LL | fn should_ret_unit() -> impl T {
    |                         ^^^^^^
-   = note: `#[warn(dependency_on_unit_never_type_fallback)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
+   = note: `#[deny(dependency_on_unit_never_type_fallback)]` (part of `#[deny(rust_2024_compatibility)]`) on by default
 
-warning: 1 warning emitted
+error: aborting due to 1 previous error
 
 Future incompatibility report: Future breakage diagnostic:
-warning: this function depends on never type fallback being `()`
-  --> $DIR/impl_trait_fallback.rs:8:1
+error: this function depends on never type fallback being `()`
+  --> $DIR/impl_trait_fallback.rs:6:1
    |
 LL | fn should_ret_unit() -> impl T {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -27,9 +27,9 @@ LL | fn should_ret_unit() -> impl T {
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: T` will fail
-  --> $DIR/impl_trait_fallback.rs:8:25
+  --> $DIR/impl_trait_fallback.rs:6:25
    |
 LL | fn should_ret_unit() -> impl T {
    |                         ^^^^^^
-   = note: `#[warn(dependency_on_unit_never_type_fallback)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
+   = note: `#[deny(dependency_on_unit_never_type_fallback)]` (part of `#[deny(rust_2024_compatibility)]`) on by default
 

--- a/tests/ui/never_type/impl_trait_fallback.stderr
+++ b/tests/ui/never_type/impl_trait_fallback.stderr
@@ -1,35 +1,14 @@
-error: this function depends on never type fallback being `()`
-  --> $DIR/impl_trait_fallback.rs:6:1
-   |
-LL | fn should_ret_unit() -> impl T {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
-   = help: specify the types explicitly
-note: in edition 2024, the requirement `!: T` will fail
-  --> $DIR/impl_trait_fallback.rs:6:25
-   |
-LL | fn should_ret_unit() -> impl T {
-   |                         ^^^^^^
-   = note: `#[deny(dependency_on_unit_never_type_fallback)]` (part of `#[deny(rust_2024_compatibility)]`) on by default
-
-error: aborting due to 1 previous error
-
 Future incompatibility report: Future breakage diagnostic:
-error: this function depends on never type fallback being `()`
-  --> $DIR/impl_trait_fallback.rs:6:1
+warning: this function depends on never type fallback being `()`
+  --> $DIR/impl_trait_fallback.rs:9:1
    |
 LL | fn should_ret_unit() -> impl T {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: T` will fail
-  --> $DIR/impl_trait_fallback.rs:6:25
+  --> $DIR/impl_trait_fallback.rs:9:25
    |
 LL | fn should_ret_unit() -> impl T {
    |                         ^^^^^^
-   = note: `#[deny(dependency_on_unit_never_type_fallback)]` (part of `#[deny(rust_2024_compatibility)]`) on by default
 

--- a/tests/ui/never_type/lint-breaking-2024-assign-underscore.fixed
+++ b/tests/ui/never_type/lint-breaking-2024-assign-underscore.fixed
@@ -1,7 +1,5 @@
 //@ run-rustfix
-
 #![allow(unused)]
-#![deny(dependency_on_unit_never_type_fallback)]
 
 fn foo<T: Default>() -> Result<T, ()> {
     Err(())

--- a/tests/ui/never_type/lint-breaking-2024-assign-underscore.rs
+++ b/tests/ui/never_type/lint-breaking-2024-assign-underscore.rs
@@ -1,7 +1,5 @@
 //@ run-rustfix
-
 #![allow(unused)]
-#![deny(dependency_on_unit_never_type_fallback)]
 
 fn foo<T: Default>() -> Result<T, ()> {
     Err(())

--- a/tests/ui/never_type/lint-breaking-2024-assign-underscore.stderr
+++ b/tests/ui/never_type/lint-breaking-2024-assign-underscore.stderr
@@ -1,5 +1,5 @@
 error: this function depends on never type fallback being `()`
-  --> $DIR/lint-breaking-2024-assign-underscore.rs:10:1
+  --> $DIR/lint-breaking-2024-assign-underscore.rs:8:1
    |
 LL | fn test() -> Result<(), ()> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -8,15 +8,11 @@ LL | fn test() -> Result<(), ()> {
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: Default` will fail
-  --> $DIR/lint-breaking-2024-assign-underscore.rs:13:9
+  --> $DIR/lint-breaking-2024-assign-underscore.rs:11:9
    |
 LL |     _ = foo()?;
    |         ^^^^^
-note: the lint level is defined here
-  --> $DIR/lint-breaking-2024-assign-underscore.rs:4:9
-   |
-LL | #![deny(dependency_on_unit_never_type_fallback)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: `#[deny(dependency_on_unit_never_type_fallback)]` (part of `#[deny(rust_2024_compatibility)]`) on by default
 help: use `()` annotations to avoid fallback changes
    |
 LL |     _ = foo::<()>()?;
@@ -26,7 +22,7 @@ error: aborting due to 1 previous error
 
 Future incompatibility report: Future breakage diagnostic:
 error: this function depends on never type fallback being `()`
-  --> $DIR/lint-breaking-2024-assign-underscore.rs:10:1
+  --> $DIR/lint-breaking-2024-assign-underscore.rs:8:1
    |
 LL | fn test() -> Result<(), ()> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -35,15 +31,11 @@ LL | fn test() -> Result<(), ()> {
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: Default` will fail
-  --> $DIR/lint-breaking-2024-assign-underscore.rs:13:9
+  --> $DIR/lint-breaking-2024-assign-underscore.rs:11:9
    |
 LL |     _ = foo()?;
    |         ^^^^^
-note: the lint level is defined here
-  --> $DIR/lint-breaking-2024-assign-underscore.rs:4:9
-   |
-LL | #![deny(dependency_on_unit_never_type_fallback)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: `#[deny(dependency_on_unit_never_type_fallback)]` (part of `#[deny(rust_2024_compatibility)]`) on by default
 help: use `()` annotations to avoid fallback changes
    |
 LL |     _ = foo::<()>()?;

--- a/tests/ui/never_type/lint-never-type-fallback-flowing-into-unsafe.e2015.stderr
+++ b/tests/ui/never_type/lint-never-type-fallback-flowing-into-unsafe.e2015.stderr
@@ -1,5 +1,5 @@
-warning: never type fallback affects this call to an `unsafe` function
-  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:12:18
+error: never type fallback affects this call to an `unsafe` function
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:10:18
    |
 LL |         unsafe { mem::zeroed() }
    |                  ^^^^^^^^^^^^^
@@ -7,14 +7,14 @@ LL |         unsafe { mem::zeroed() }
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
-   = note: `#[warn(never_type_fallback_flowing_into_unsafe)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
+   = note: `#[deny(never_type_fallback_flowing_into_unsafe)]` (part of `#[deny(rust_2024_compatibility)]`) on by default
 help: use `()` annotations to avoid fallback changes
    |
 LL |         unsafe { mem::zeroed::<()>() }
    |                             ++++++
 
-warning: never type fallback affects this call to an `unsafe` function
-  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:29:13
+error: never type fallback affects this call to an `unsafe` function
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:27:13
    |
 LL |             core::mem::transmute(Zst)
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -27,8 +27,8 @@ help: use `()` annotations to avoid fallback changes
 LL |             core::mem::transmute::<_, ()>(Zst)
    |                                 +++++++++
 
-warning: never type fallback affects this union access
-  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:46:18
+error: never type fallback affects this union access
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:44:18
    |
 LL |         unsafe { Union { a: () }.b }
    |                  ^^^^^^^^^^^^^^^^^
@@ -37,8 +37,8 @@ LL |         unsafe { Union { a: () }.b }
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
 
-warning: never type fallback affects this raw pointer dereference
-  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:57:18
+error: never type fallback affects this raw pointer dereference
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:55:18
    |
 LL |         unsafe { *ptr::from_ref(&()).cast() }
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -51,8 +51,8 @@ help: use `()` annotations to avoid fallback changes
 LL |         unsafe { *ptr::from_ref(&()).cast::<()>() }
    |                                          ++++++
 
-warning: never type fallback affects this call to an `unsafe` function
-  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:78:18
+error: never type fallback affects this call to an `unsafe` function
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:76:18
    |
 LL |         unsafe { internally_create(x) }
    |                  ^^^^^^^^^^^^^^^^^^^^
@@ -65,8 +65,8 @@ help: use `()` annotations to avoid fallback changes
 LL |         unsafe { internally_create::<()>(x) }
    |                                   ++++++
 
-warning: never type fallback affects this call to an `unsafe` function
-  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:96:18
+error: never type fallback affects this call to an `unsafe` function
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:94:18
    |
 LL |         unsafe { zeroed() }
    |                  ^^^^^^^^
@@ -79,8 +79,8 @@ help: use `()` annotations to avoid fallback changes
 LL |         let zeroed = mem::zeroed::<()>;
    |                                 ++++++
 
-warning: never type fallback affects this `unsafe` function
-  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:91:22
+error: never type fallback affects this `unsafe` function
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:89:22
    |
 LL |         let zeroed = mem::zeroed;
    |                      ^^^^^^^^^^^
@@ -93,8 +93,8 @@ help: use `()` annotations to avoid fallback changes
 LL |         let zeroed = mem::zeroed::<()>;
    |                                 ++++++
 
-warning: never type fallback affects this `unsafe` function
-  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:114:17
+error: never type fallback affects this `unsafe` function
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:112:17
    |
 LL |         let f = internally_create;
    |                 ^^^^^^^^^^^^^^^^^
@@ -107,8 +107,8 @@ help: use `()` annotations to avoid fallback changes
 LL |         let f = internally_create::<()>;
    |                                  ++++++
 
-warning: never type fallback affects this call to an `unsafe` method
-  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:139:13
+error: never type fallback affects this call to an `unsafe` method
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:137:13
    |
 LL |             S(marker::PhantomData).create_out_of_thin_air()
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -117,8 +117,8 @@ LL |             S(marker::PhantomData).create_out_of_thin_air()
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
 
-warning: never type fallback affects this call to an `unsafe` function
-  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:157:19
+error: never type fallback affects this call to an `unsafe` function
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:155:19
    |
 LL |             match send_message::<_ /* ?0 */>() {
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -129,13 +129,13 @@ LL |         msg_send!();
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
-   = note: this warning originates in the macro `msg_send` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `msg_send` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-warning: 10 warnings emitted
+error: aborting due to 10 previous errors
 
 Future incompatibility report: Future breakage diagnostic:
-warning: never type fallback affects this call to an `unsafe` function
-  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:12:18
+error: never type fallback affects this call to an `unsafe` function
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:10:18
    |
 LL |         unsafe { mem::zeroed() }
    |                  ^^^^^^^^^^^^^
@@ -143,15 +143,15 @@ LL |         unsafe { mem::zeroed() }
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
-   = note: `#[warn(never_type_fallback_flowing_into_unsafe)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
+   = note: `#[deny(never_type_fallback_flowing_into_unsafe)]` (part of `#[deny(rust_2024_compatibility)]`) on by default
 help: use `()` annotations to avoid fallback changes
    |
 LL |         unsafe { mem::zeroed::<()>() }
    |                             ++++++
 
 Future breakage diagnostic:
-warning: never type fallback affects this call to an `unsafe` function
-  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:29:13
+error: never type fallback affects this call to an `unsafe` function
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:27:13
    |
 LL |             core::mem::transmute(Zst)
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -159,15 +159,15 @@ LL |             core::mem::transmute(Zst)
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
-   = note: `#[warn(never_type_fallback_flowing_into_unsafe)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
+   = note: `#[deny(never_type_fallback_flowing_into_unsafe)]` (part of `#[deny(rust_2024_compatibility)]`) on by default
 help: use `()` annotations to avoid fallback changes
    |
 LL |             core::mem::transmute::<_, ()>(Zst)
    |                                 +++++++++
 
 Future breakage diagnostic:
-warning: never type fallback affects this union access
-  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:46:18
+error: never type fallback affects this union access
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:44:18
    |
 LL |         unsafe { Union { a: () }.b }
    |                  ^^^^^^^^^^^^^^^^^
@@ -175,11 +175,11 @@ LL |         unsafe { Union { a: () }.b }
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
-   = note: `#[warn(never_type_fallback_flowing_into_unsafe)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
+   = note: `#[deny(never_type_fallback_flowing_into_unsafe)]` (part of `#[deny(rust_2024_compatibility)]`) on by default
 
 Future breakage diagnostic:
-warning: never type fallback affects this raw pointer dereference
-  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:57:18
+error: never type fallback affects this raw pointer dereference
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:55:18
    |
 LL |         unsafe { *ptr::from_ref(&()).cast() }
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -187,15 +187,15 @@ LL |         unsafe { *ptr::from_ref(&()).cast() }
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
-   = note: `#[warn(never_type_fallback_flowing_into_unsafe)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
+   = note: `#[deny(never_type_fallback_flowing_into_unsafe)]` (part of `#[deny(rust_2024_compatibility)]`) on by default
 help: use `()` annotations to avoid fallback changes
    |
 LL |         unsafe { *ptr::from_ref(&()).cast::<()>() }
    |                                          ++++++
 
 Future breakage diagnostic:
-warning: never type fallback affects this call to an `unsafe` function
-  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:78:18
+error: never type fallback affects this call to an `unsafe` function
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:76:18
    |
 LL |         unsafe { internally_create(x) }
    |                  ^^^^^^^^^^^^^^^^^^^^
@@ -203,15 +203,15 @@ LL |         unsafe { internally_create(x) }
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
-   = note: `#[warn(never_type_fallback_flowing_into_unsafe)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
+   = note: `#[deny(never_type_fallback_flowing_into_unsafe)]` (part of `#[deny(rust_2024_compatibility)]`) on by default
 help: use `()` annotations to avoid fallback changes
    |
 LL |         unsafe { internally_create::<()>(x) }
    |                                   ++++++
 
 Future breakage diagnostic:
-warning: never type fallback affects this call to an `unsafe` function
-  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:96:18
+error: never type fallback affects this call to an `unsafe` function
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:94:18
    |
 LL |         unsafe { zeroed() }
    |                  ^^^^^^^^
@@ -219,15 +219,15 @@ LL |         unsafe { zeroed() }
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
-   = note: `#[warn(never_type_fallback_flowing_into_unsafe)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
+   = note: `#[deny(never_type_fallback_flowing_into_unsafe)]` (part of `#[deny(rust_2024_compatibility)]`) on by default
 help: use `()` annotations to avoid fallback changes
    |
 LL |         let zeroed = mem::zeroed::<()>;
    |                                 ++++++
 
 Future breakage diagnostic:
-warning: never type fallback affects this `unsafe` function
-  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:91:22
+error: never type fallback affects this `unsafe` function
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:89:22
    |
 LL |         let zeroed = mem::zeroed;
    |                      ^^^^^^^^^^^
@@ -235,15 +235,15 @@ LL |         let zeroed = mem::zeroed;
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
-   = note: `#[warn(never_type_fallback_flowing_into_unsafe)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
+   = note: `#[deny(never_type_fallback_flowing_into_unsafe)]` (part of `#[deny(rust_2024_compatibility)]`) on by default
 help: use `()` annotations to avoid fallback changes
    |
 LL |         let zeroed = mem::zeroed::<()>;
    |                                 ++++++
 
 Future breakage diagnostic:
-warning: never type fallback affects this `unsafe` function
-  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:114:17
+error: never type fallback affects this `unsafe` function
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:112:17
    |
 LL |         let f = internally_create;
    |                 ^^^^^^^^^^^^^^^^^
@@ -251,15 +251,15 @@ LL |         let f = internally_create;
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
-   = note: `#[warn(never_type_fallback_flowing_into_unsafe)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
+   = note: `#[deny(never_type_fallback_flowing_into_unsafe)]` (part of `#[deny(rust_2024_compatibility)]`) on by default
 help: use `()` annotations to avoid fallback changes
    |
 LL |         let f = internally_create::<()>;
    |                                  ++++++
 
 Future breakage diagnostic:
-warning: never type fallback affects this call to an `unsafe` method
-  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:139:13
+error: never type fallback affects this call to an `unsafe` method
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:137:13
    |
 LL |             S(marker::PhantomData).create_out_of_thin_air()
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -267,11 +267,11 @@ LL |             S(marker::PhantomData).create_out_of_thin_air()
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
-   = note: `#[warn(never_type_fallback_flowing_into_unsafe)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
+   = note: `#[deny(never_type_fallback_flowing_into_unsafe)]` (part of `#[deny(rust_2024_compatibility)]`) on by default
 
 Future breakage diagnostic:
-warning: never type fallback affects this call to an `unsafe` function
-  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:157:19
+error: never type fallback affects this call to an `unsafe` function
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:155:19
    |
 LL |             match send_message::<_ /* ?0 */>() {
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -282,6 +282,6 @@ LL |         msg_send!();
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
-   = note: `#[warn(never_type_fallback_flowing_into_unsafe)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
-   = note: this warning originates in the macro `msg_send` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: `#[deny(never_type_fallback_flowing_into_unsafe)]` (part of `#[deny(rust_2024_compatibility)]`) on by default
+   = note: this error originates in the macro `msg_send` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/never_type/lint-never-type-fallback-flowing-into-unsafe.e2024.stderr
+++ b/tests/ui/never_type/lint-never-type-fallback-flowing-into-unsafe.e2024.stderr
@@ -1,5 +1,5 @@
 error: never type fallback affects this call to an `unsafe` function
-  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:12:18
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:10:18
    |
 LL |         unsafe { mem::zeroed() }
    |                  ^^^^^^^^^^^^^
@@ -14,7 +14,7 @@ LL |         unsafe { mem::zeroed::<()>() }
    |                             ++++++
 
 error: never type fallback affects this call to an `unsafe` function
-  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:29:13
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:27:13
    |
 LL |             core::mem::transmute(Zst)
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -28,7 +28,7 @@ LL |             core::mem::transmute::<_, ()>(Zst)
    |                                 +++++++++
 
 error: never type fallback affects this union access
-  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:46:18
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:44:18
    |
 LL |         unsafe { Union { a: () }.b }
    |                  ^^^^^^^^^^^^^^^^^
@@ -38,7 +38,7 @@ LL |         unsafe { Union { a: () }.b }
    = help: specify the type explicitly
 
 error: never type fallback affects this raw pointer dereference
-  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:57:18
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:55:18
    |
 LL |         unsafe { *ptr::from_ref(&()).cast() }
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -52,7 +52,7 @@ LL |         unsafe { *ptr::from_ref(&()).cast::<()>() }
    |                                          ++++++
 
 error: never type fallback affects this call to an `unsafe` function
-  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:78:18
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:76:18
    |
 LL |         unsafe { internally_create(x) }
    |                  ^^^^^^^^^^^^^^^^^^^^
@@ -66,7 +66,7 @@ LL |         unsafe { internally_create::<()>(x) }
    |                                   ++++++
 
 error: never type fallback affects this call to an `unsafe` function
-  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:96:18
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:94:18
    |
 LL |         unsafe { zeroed() }
    |                  ^^^^^^^^
@@ -80,7 +80,7 @@ LL |         let zeroed = mem::zeroed::<()>;
    |                                 ++++++
 
 error: never type fallback affects this `unsafe` function
-  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:91:22
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:89:22
    |
 LL |         let zeroed = mem::zeroed;
    |                      ^^^^^^^^^^^
@@ -94,7 +94,7 @@ LL |         let zeroed = mem::zeroed::<()>;
    |                                 ++++++
 
 error: never type fallback affects this `unsafe` function
-  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:114:17
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:112:17
    |
 LL |         let f = internally_create;
    |                 ^^^^^^^^^^^^^^^^^
@@ -108,7 +108,7 @@ LL |         let f = internally_create::<()>;
    |                                  ++++++
 
 error: never type fallback affects this call to an `unsafe` method
-  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:139:13
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:137:13
    |
 LL |             S(marker::PhantomData).create_out_of_thin_air()
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -118,7 +118,7 @@ LL |             S(marker::PhantomData).create_out_of_thin_air()
    = help: specify the type explicitly
 
 error: never type fallback affects this call to an `unsafe` function
-  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:157:19
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:155:19
    |
 LL |             match send_message::<_ /* ?0 */>() {
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -132,7 +132,7 @@ LL |         msg_send!();
    = note: this error originates in the macro `msg_send` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: the type `!` does not permit zero-initialization
-  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:12:18
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:10:18
    |
 LL |         unsafe { mem::zeroed() }
    |                  ^^^^^^^^^^^^^ this code causes undefined behavior when executed
@@ -144,7 +144,7 @@ error: aborting due to 10 previous errors; 1 warning emitted
 
 Future incompatibility report: Future breakage diagnostic:
 error: never type fallback affects this call to an `unsafe` function
-  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:12:18
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:10:18
    |
 LL |         unsafe { mem::zeroed() }
    |                  ^^^^^^^^^^^^^
@@ -160,7 +160,7 @@ LL |         unsafe { mem::zeroed::<()>() }
 
 Future breakage diagnostic:
 error: never type fallback affects this call to an `unsafe` function
-  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:29:13
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:27:13
    |
 LL |             core::mem::transmute(Zst)
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -176,7 +176,7 @@ LL |             core::mem::transmute::<_, ()>(Zst)
 
 Future breakage diagnostic:
 error: never type fallback affects this union access
-  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:46:18
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:44:18
    |
 LL |         unsafe { Union { a: () }.b }
    |                  ^^^^^^^^^^^^^^^^^
@@ -188,7 +188,7 @@ LL |         unsafe { Union { a: () }.b }
 
 Future breakage diagnostic:
 error: never type fallback affects this raw pointer dereference
-  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:57:18
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:55:18
    |
 LL |         unsafe { *ptr::from_ref(&()).cast() }
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -204,7 +204,7 @@ LL |         unsafe { *ptr::from_ref(&()).cast::<()>() }
 
 Future breakage diagnostic:
 error: never type fallback affects this call to an `unsafe` function
-  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:78:18
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:76:18
    |
 LL |         unsafe { internally_create(x) }
    |                  ^^^^^^^^^^^^^^^^^^^^
@@ -220,7 +220,7 @@ LL |         unsafe { internally_create::<()>(x) }
 
 Future breakage diagnostic:
 error: never type fallback affects this call to an `unsafe` function
-  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:96:18
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:94:18
    |
 LL |         unsafe { zeroed() }
    |                  ^^^^^^^^
@@ -236,7 +236,7 @@ LL |         let zeroed = mem::zeroed::<()>;
 
 Future breakage diagnostic:
 error: never type fallback affects this `unsafe` function
-  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:91:22
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:89:22
    |
 LL |         let zeroed = mem::zeroed;
    |                      ^^^^^^^^^^^
@@ -252,7 +252,7 @@ LL |         let zeroed = mem::zeroed::<()>;
 
 Future breakage diagnostic:
 error: never type fallback affects this `unsafe` function
-  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:114:17
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:112:17
    |
 LL |         let f = internally_create;
    |                 ^^^^^^^^^^^^^^^^^
@@ -268,7 +268,7 @@ LL |         let f = internally_create::<()>;
 
 Future breakage diagnostic:
 error: never type fallback affects this call to an `unsafe` method
-  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:139:13
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:137:13
    |
 LL |             S(marker::PhantomData).create_out_of_thin_air()
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -280,7 +280,7 @@ LL |             S(marker::PhantomData).create_out_of_thin_air()
 
 Future breakage diagnostic:
 error: never type fallback affects this call to an `unsafe` function
-  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:157:19
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:155:19
    |
 LL |             match send_message::<_ /* ?0 */>() {
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/never_type/lint-never-type-fallback-flowing-into-unsafe.rs
+++ b/tests/ui/never_type/lint-never-type-fallback-flowing-into-unsafe.rs
@@ -1,6 +1,4 @@
 //@ revisions: e2015 e2024
-//@[e2015] check-pass
-//@[e2024] check-fail
 //@[e2024] edition:2024
 
 use std::{marker, mem, ptr};
@@ -10,10 +8,10 @@ fn main() {}
 fn _zero() {
     if false {
         unsafe { mem::zeroed() }
-        //[e2015]~^ warn: never type fallback affects this call to an `unsafe` function
+        //[e2015]~^ error: never type fallback affects this call to an `unsafe` function
         //[e2024]~^^ error: never type fallback affects this call to an `unsafe` function
         //~| warn: this changes meaning in Rust 2024 and in a future release in all editions!
-        //[e2024]~| warning: the type `!` does not permit zero-initialization
+        //[e2024]~| warn: the type `!` does not permit zero-initialization
     } else {
         return;
     };
@@ -27,7 +25,7 @@ fn _trans() {
         unsafe {
             struct Zst;
             core::mem::transmute(Zst)
-            //[e2015]~^ warn: never type fallback affects this call to an `unsafe` function
+            //[e2015]~^ error: never type fallback affects this call to an `unsafe` function
             //[e2024]~^^ error: never type fallback affects this call to an `unsafe` function
             //~| warn: this changes meaning in Rust 2024 and in a future release in all editions!
         }
@@ -44,7 +42,7 @@ fn _union() {
         }
 
         unsafe { Union { a: () }.b }
-        //[e2015]~^ warn: never type fallback affects this union access
+        //[e2015]~^ error: never type fallback affects this union access
         //[e2024]~^^ error: never type fallback affects this union access
         //~| warn: this changes meaning in Rust 2024 and in a future release in all editions!
     } else {
@@ -55,7 +53,7 @@ fn _union() {
 fn _deref() {
     if false {
         unsafe { *ptr::from_ref(&()).cast() }
-        //[e2015]~^ warn: never type fallback affects this raw pointer dereference
+        //[e2015]~^ error: never type fallback affects this raw pointer dereference
         //[e2024]~^^ error: never type fallback affects this raw pointer dereference
         //~| warn: this changes meaning in Rust 2024 and in a future release in all editions!
     } else {
@@ -76,7 +74,7 @@ fn _only_generics() {
         let x = None;
 
         unsafe { internally_create(x) }
-        //[e2015]~^ warn: never type fallback affects this call to an `unsafe` function
+        //[e2015]~^ error: never type fallback affects this call to an `unsafe` function
         //[e2024]~^^ error: never type fallback affects this call to an `unsafe` function
         //~| warn: this changes meaning in Rust 2024 and in a future release in all editions!
 
@@ -89,12 +87,12 @@ fn _only_generics() {
 fn _stored_function() {
     if false {
         let zeroed = mem::zeroed;
-        //[e2015]~^ warn: never type fallback affects this `unsafe` function
+        //[e2015]~^ error: never type fallback affects this `unsafe` function
         //[e2024]~^^ error: never type fallback affects this `unsafe` function
         //~| warn: this changes meaning in Rust 2024 and in a future release in all editions!
 
         unsafe { zeroed() }
-        //[e2015]~^ warn: never type fallback affects this call to an `unsafe` function
+        //[e2015]~^ error: never type fallback affects this call to an `unsafe` function
         //[e2024]~^^ error: never type fallback affects this call to an `unsafe` function
         //~| warn: this changes meaning in Rust 2024 and in a future release in all editions!
     } else {
@@ -112,7 +110,7 @@ fn _only_generics_stored_function() {
 
         let x = None;
         let f = internally_create;
-        //[e2015]~^ warn: never type fallback affects this `unsafe` function
+        //[e2015]~^ error: never type fallback affects this `unsafe` function
         //[e2024]~^^ error: never type fallback affects this `unsafe` function
         //~| warn: this changes meaning in Rust 2024 and in a future release in all editions!
 
@@ -137,7 +135,7 @@ fn _method() {
     if false {
         unsafe {
             S(marker::PhantomData).create_out_of_thin_air()
-            //[e2015]~^ warn: never type fallback affects this call to an `unsafe` method
+            //[e2015]~^ error: never type fallback affects this call to an `unsafe` method
             //[e2024]~^^ error: never type fallback affects this call to an `unsafe` method
             //~| warn: this changes meaning in Rust 2024 and in a future release in all editions!
         }
@@ -155,7 +153,7 @@ fn _objc() {
     macro_rules! msg_send {
         () => {
             match send_message::<_ /* ?0 */>() {
-                //[e2015]~^ warn: never type fallback affects this call to an `unsafe` function
+                //[e2015]~^ error: never type fallback affects this call to an `unsafe` function
                 //[e2024]~^^ error: never type fallback affects this call to an `unsafe` function
                 //~| warn: this changes meaning in Rust 2024 and in a future release in all editions!
                 Ok(x) => x,


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#146167 (Deny-by-default never type lints)
 - rust-lang/rust#147382 (unused_must_use: Don't warn on `Result<(), Uninhabited>` or `ControlFlow<Uninhabited, ()>`)
 - rust-lang/rust#147821 (Do not GC the current active incremental session directory)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=146167,147382,147821)
<!-- homu-ignore:end -->