### PR TITLE
compiletest: Store the selected edition in `TestProps`

### DIFF
--- a/src/tools/compiletest/src/directives/tests.rs
+++ b/src/tools/compiletest/src/directives/tests.rs
@@ -962,6 +962,18 @@ fn parse_edition_range(line: &str) -> Option<EditionRange> {
 }
 
 #[test]
+fn edition_order() {
+    let editions = &[
+        Edition::Year(2015),
+        Edition::Year(2018),
+        Edition::Year(2021),
+        Edition::Year(2024),
+        Edition::Future,
+    ];
+    assert!(editions.is_sorted(), "{editions:#?}");
+}
+
+#[test]
 fn test_parse_edition_range() {
     assert_eq!(None, parse_edition_range("hello-world"));
     assert_eq!(None, parse_edition_range("edition"));


### PR DESCRIPTION
While working on a larger overhaul of directive processing, I ran into difficulty with the `has_edition` local variable.

Storing the selected edition in `TestProps` should make it easier to extract parts of directive processing into independent handler functions, because the `//@ edition` handler won't need access to additional mutable state outside of `TestProps`.

We still automatically add the edition to `compile_flags`, because there is too much existing compiletest code relying on that behaviour.

r? jieyouxu