### PR TITLE
Reorder passes so `cfg` checks are run even on private/hidden items

### DIFF
--- a/src/librustdoc/passes/mod.rs
+++ b/src/librustdoc/passes/mod.rs
@@ -95,11 +95,11 @@ pub(crate) const DEFAULT_PASSES: &[ConditionalPass] = &[
     ConditionalPass::always(CHECK_DOC_TEST_VISIBILITY),
     ConditionalPass::always(CHECK_DOC_CFG),
     ConditionalPass::always(STRIP_ALIASED_NON_LOCAL),
+    ConditionalPass::always(PROPAGATE_DOC_CFG),
     ConditionalPass::new(STRIP_HIDDEN, WhenNotDocumentHidden),
     ConditionalPass::new(STRIP_PRIVATE, WhenNotDocumentPrivate),
     ConditionalPass::new(STRIP_PRIV_IMPORTS, WhenDocumentPrivate),
     ConditionalPass::always(COLLECT_INTRA_DOC_LINKS),
-    ConditionalPass::always(PROPAGATE_DOC_CFG),
     ConditionalPass::always(PROPAGATE_STABILITY),
     ConditionalPass::always(RUN_LINTS),
 ];

--- a/tests/rustdoc-ui/invalid-cfg.rs
+++ b/tests/rustdoc-ui/invalid-cfg.rs
@@ -1,4 +1,4 @@
 #![feature(doc_cfg)]
 #[doc(cfg = "x")] //~ ERROR not followed by parentheses
 #[doc(cfg(x, y))] //~ ERROR multiple `cfg` predicates
-pub struct S {}
+struct S {}

--- a/tests/rustdoc-ui/issues/issue-91713.stdout
+++ b/tests/rustdoc-ui/issues/issue-91713.stdout
@@ -17,11 +17,11 @@ Default passes for rustdoc:
 check_doc_test_visibility
        check-doc-cfg
 strip-aliased-non-local
+   propagate-doc-cfg
         strip-hidden  (when not --document-hidden-items)
        strip-private  (when not --document-private-items)
   strip-priv-imports  (when --document-private-items)
 collect-intra-doc-links
-   propagate-doc-cfg
  propagate-stability
            run-lints
 


### PR DESCRIPTION
Follow-up of https://github.com/rust-lang/rust/pull/147809 and of https://github.com/rust-lang/rust/pull/138907.

r? @fmease