### PR TITLE
Update list of available search filters in help menu

### DIFF
--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -1634,14 +1634,23 @@ function preLoadCss(cssUrl) {
         addClass(div_shortcuts, "shortcuts");
         div_shortcuts.innerHTML = "<h2>Keyboard Shortcuts</h2><dl>" + shortcuts + "</dl></div>";
 
+        // FIXME: Find a better way to keep this list up-to-date with search.js `itemTypes` and
+        // `rustdoc::formats::item_type::ItemType`.
+        let filters = [
+            "keyword", "primitive", "mod", "externcrate", "import", "struct", "enum", "fn", "type",
+            "static", "trait", "impl", "tymethod", "method", "structfield", "variant", "macro",
+            "associatedtype", "constant", "associatedconstant", "union", "foreigntype",
+            "existential", "attr", "derive", "traitalias", "generic", "attribute",
+        ];
+        filters.sort();
+        filters = filters.map(f => `<code>${f}</code>`);
+        const last = filters.pop();
         const infos = [
             `For a full list of all search features, take a look \
              <a href="${drloChannel}/rustdoc/read-documentation/search.html">here</a>.`,
             "Prefix searches with a type followed by a colon (e.g., <code>fn:</code>) to \
              restrict the search to a given item kind.",
-            "Accepted kinds are: <code>fn</code>, <code>mod</code>, <code>struct</code>, \
-             <code>enum</code>, <code>trait</code>, <code>type</code>, <code>macro</code>, \
-             and <code>const</code>.",
+            `Accepted kinds are: ${filters.join(", ")} and ${last}.`,
             "Search functions by type signature (e.g., <code>vec -&gt; usize</code> or \
              <code>-&gt; vec</code> or <code>String, enum:Cow -&gt; bool</code>)",
             "You can look for items with an exact name by putting double quotes around \


### PR DESCRIPTION
Just realized that the help menu mentions the list of available search item type filters... but it's also very incomplete and the book says the full list is provided there.

Considering that `search.js` is supposed to be self-contained (for our testsuite mostly) and that we don't want to add an extra step to generate JS (so we can copy-paste it around and just test it), I'm not too sure what would be the best solution here.

Anyway, question for future us, in the meantime, this adds the missing entries in the help menu:

<img width="386" height="536" alt="image" src="https://github.com/user-attachments/assets/28626fbb-f14d-44d3-9f6c-4da5b14f79b3" />

r? @lolbinarycat 