### PR TITLE
Fix ICE in rustdoc when impl is nested in a func

### DIFF
--- a/src/librustdoc/html/render/span_map.rs
+++ b/src/librustdoc/html/render/span_map.rs
@@ -251,6 +251,13 @@ fn hir_enclosing_body_owner(tcx: TyCtxt<'_>, hir_id: HirId) -> Option<LocalDefId
             return None;
         } else if let Some((def_id, _)) = node.associated_body() {
             return Some(def_id);
+        // Items don't have enclosing bodies.
+        // If we go any further, we might encounter an enclosing function
+        // (e.g. if we're inside an impl that's inside of a function).
+        // This would cause us to erroneously consider this function to be the owner
+        // of the node and produce invalid `HirId`s later.
+        } else if matches!(node, Node::Item(_)) {
+            return None;
         }
     }
     None

--- a/tests/rustdoc/nested-fn-impl-147882.rs
+++ b/tests/rustdoc/nested-fn-impl-147882.rs
@@ -1,0 +1,22 @@
+//@ compile-flags: -Zunstable-options --generate-link-to-definition
+
+// See: https://github.com/rust-lang/rust/issues/147882
+
+#![crate_name = "foo"]
+
+trait Fun {
+    fn fun();
+}
+
+trait Other {}
+
+impl Fun for () {
+    fn fun() {
+        impl<E> Other for E
+        where
+            E: std::str::FromStr,
+            E::Err: Send,
+        {
+        }
+    }
+}


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

For cases like

```rust
fn foo() {
    impl<E> Trait for Bar<E>
    where E: Baz {}
}
```

`hir_enclosing_body_owner()` in rustdoc considered `fn foo()` to be the “enclosing body” of `E`, which caused to to produce `HirId`s for `E` with owner set to `fn foo()` instead of the impl. This instead treats `E` as having no enclosing body.

r? @GuillaumeGomez as the author of this logic, I’m not 100% I understood it correctly.

Fixes rust-lang/rust#147882.
Fixes rust-lang/rust#147057.