### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/compiler/rustc_errors/src/emitter.rs
+++ b/compiler/rustc_errors/src/emitter.rs
@@ -2154,11 +2154,11 @@ impl HumanEmitter {
 
             assert!(!file_lines.lines.is_empty() || parts[0].span.is_dummy());
 
-            let line_start = sm.lookup_char_pos(parts[0].span.lo()).line;
+            let line_start = sm.lookup_char_pos(parts[0].original_span.lo()).line;
             let mut lines = complete.lines();
             if lines.clone().next().is_none() {
                 // Account for a suggestion to completely remove a line(s) with whitespace (#94192).
-                let line_end = sm.lookup_char_pos(parts[0].span.hi()).line;
+                let line_end = sm.lookup_char_pos(parts[0].original_span.hi()).line;
                 for line in line_start..=line_end {
                     self.draw_line_num(
                         &mut buffer,

--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -2547,6 +2547,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             "you must specify a type for this binding, like `{concrete_type}`",
                         );
 
+                        // FIXME: Maybe FileName::Anon should also be handled,
+                        // otherwise there would be no suggestion if the source is STDIN for example.
                         match (filename, parent_node) {
                             (
                                 FileName::Real(_),

--- a/library/alloc/src/collections/btree/node.rs
+++ b/library/alloc/src/collections/btree/node.rs
@@ -33,6 +33,7 @@
 
 use core::marker::PhantomData;
 use core::mem::{self, MaybeUninit};
+use core::num::NonZero;
 use core::ptr::{self, NonNull};
 use core::slice::SliceIndex;
 
@@ -143,7 +144,7 @@ type BoxedNode<K, V> = NonNull<LeafNode<K, V>>;
 ///
 /// A reference to a node.
 ///
-/// This type has a number of parameters that controls how it acts:
+/// This type has a number of parameters that control how it acts:
 /// - `BorrowType`: A dummy type that describes the kind of borrow and carries a lifetime.
 ///    - When this is `Immut<'a>`, the `NodeRef` acts roughly like `&'a Node`.
 ///    - When this is `ValMut<'a>`, the `NodeRef` acts roughly like `&'a Node`
@@ -226,33 +227,27 @@ impl<K, V> NodeRef<marker::Owned, K, V, marker::Leaf> {
 
     fn from_new_leaf<A: Allocator + Clone>(leaf: Box<LeafNode<K, V>, A>) -> Self {
         // The allocator must be dropped, not leaked.  See also `BTreeMap::alloc`.
-        let (leaf, _alloc) = Box::into_raw_with_allocator(leaf);
-        // SAFETY: the node was just allocated.
-        let node = unsafe { NonNull::new_unchecked(leaf) };
+        let (node, _alloc) = Box::into_non_null_with_allocator(leaf);
         NodeRef { height: 0, node, _marker: PhantomData }
     }
 }
 
 impl<K, V> NodeRef<marker::Owned, K, V, marker::Internal> {
+    /// Creates a new internal (height > 0) `NodeRef`
     fn new_internal<A: Allocator + Clone>(child: Root<K, V>, alloc: A) -> Self {
         let mut new_node = unsafe { InternalNode::new(alloc) };
         new_node.edges[0].write(child.node);
-        unsafe { NodeRef::from_new_internal(new_node, child.height + 1) }
+        NodeRef::from_new_internal(new_node, NonZero::new(child.height + 1).unwrap())
     }
 
-    /// # Safety
-    /// `height` must not be zero.
-    unsafe fn from_new_internal<A: Allocator + Clone>(
+    /// Creates a new internal (height > 0) `NodeRef` from an existing internal node
+    fn from_new_internal<A: Allocator + Clone>(
         internal: Box<InternalNode<K, V>, A>,
-        height: usize,
+        height: NonZero<usize>,
     ) -> Self {
-        debug_assert!(height > 0);
         // The allocator must be dropped, not leaked.  See also `BTreeMap::alloc`.
-        let (internal, _alloc) = Box::into_raw_with_allocator(internal);
-        // SAFETY: the node was just allocated.
-        let internal = unsafe { NonNull::new_unchecked(internal) };
-        let node = internal.cast();
-        let mut this = NodeRef { height, node, _marker: PhantomData };
+        let (node, _alloc) = Box::into_non_null_with_allocator(internal);
+        let mut this = NodeRef { height: height.into(), node: node.cast(), _marker: PhantomData };
         this.borrow_mut().correct_all_childrens_parent_links();
         this
     }
@@ -625,9 +620,8 @@ impl<K, V> NodeRef<marker::Owned, K, V, marker::LeafOrInternal> {
         let top = self.node;
 
         // SAFETY: we asserted to be internal.
-        let internal_self = unsafe { self.borrow_mut().cast_to_internal_unchecked() };
-        // SAFETY: we borrowed `self` exclusively and its borrow type is exclusive.
-        let internal_node = unsafe { &mut *NodeRef::as_internal_ptr(&internal_self) };
+        let mut internal_self = unsafe { self.borrow_mut().cast_to_internal_unchecked() };
+        let internal_node = internal_self.as_internal_mut();
         // SAFETY: the first edge is always initialized.
         self.node = unsafe { internal_node.edges[0].assume_init_read() };
         self.height -= 1;
@@ -1305,7 +1299,8 @@ impl<'a, K: 'a, V: 'a> Handle<NodeRef<marker::Mut<'a>, K, V, marker::Internal>, 
                 &mut new_node.edges[..new_len + 1],
             );
 
-            let height = self.node.height;
+            // SAFETY: self is `marker::Internal`, so `self.node.height` is positive
+            let height = NonZero::new_unchecked(self.node.height);
             let right = NodeRef::from_new_internal(new_node, height);
 
             SplitResult { left: self.node, kv, right }

--- a/src/tools/tidy/src/deps.rs
+++ b/src/tools/tidy/src/deps.rs
@@ -109,17 +109,15 @@ pub(crate) const WORKSPACES: &[WorkspaceInfo<'static>] = &[
         )),
         submodules: &[],
     },
-    {
-        WorkspaceInfo {
-            path: "compiler/rustc_codegen_cranelift",
-            exceptions: EXCEPTIONS_CRANELIFT,
-            crates_and_deps: Some((
-                &["rustc_codegen_cranelift"],
-                PERMITTED_CRANELIFT_DEPENDENCIES,
-                PERMITTED_CRANELIFT_DEPS_LOCATION,
-            )),
-            submodules: &[],
-        }
+    WorkspaceInfo {
+        path: "compiler/rustc_codegen_cranelift",
+        exceptions: EXCEPTIONS_CRANELIFT,
+        crates_and_deps: Some((
+            &["rustc_codegen_cranelift"],
+            PERMITTED_CRANELIFT_DEPENDENCIES,
+            PERMITTED_CRANELIFT_DEPS_LOCATION,
+        )),
+        submodules: &[],
     },
     WorkspaceInfo {
         path: "compiler/rustc_codegen_gcc",

--- a/src/tools/tidy/src/deps.rs
+++ b/src/tools/tidy/src/deps.rs
@@ -54,6 +54,20 @@ const LICENSES: &[&str] = &[
     // tidy-alphabetical-end
 ];
 
+/// These are licenses that are allowed for rustc, tools, etc. But not for the runtime!
+#[rustfmt::skip]
+const LICENSES_TOOLS: &[&str] = &[
+    // tidy-alphabetical-start
+    "(Apache-2.0 OR MIT) AND BSD-3-Clause",
+    "Apache-2.0 AND ISC",
+    "Apache-2.0 OR BSL-1.0",  // BSL is not acceptble, but we use it under Apache-2.0
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "CC0-1.0",
+    "Zlib",
+    // tidy-alphabetical-end
+];
+
 type ExceptionList = &'static [(&'static str, &'static str)];
 
 #[derive(Clone, Copy)]
@@ -175,11 +189,8 @@ pub(crate) const WORKSPACES: &[WorkspaceInfo<'static>] = &[
 #[rustfmt::skip]
 const EXCEPTIONS: ExceptionList = &[
     // tidy-alphabetical-start
-    ("arrayref", "BSD-2-Clause"),                            // rustc
     ("colored", "MPL-2.0"),                                  // rustfmt
-    ("foldhash", "Zlib"),                                    // rustc
     ("option-ext", "MPL-2.0"),                               // cargo-miri (via `directories`)
-    ("ryu", "Apache-2.0 OR BSL-1.0"), // BSL is not acceptble, but we use it under Apache-2.0                       // cargo/... (because of serde)
     // tidy-alphabetical-end
 ];
 
@@ -196,39 +207,22 @@ const EXCEPTIONS_STDLIB: ExceptionList = &[
 
 const EXCEPTIONS_CARGO: ExceptionList = &[
     // tidy-alphabetical-start
-    ("arrayref", "BSD-2-Clause"),
     ("bitmaps", "MPL-2.0+"),
-    ("encoding_rs", "(Apache-2.0 OR MIT) AND BSD-3-Clause"),
-    ("foldhash", "Zlib"),
     ("im-rc", "MPL-2.0+"),
-    ("libz-rs-sys", "Zlib"),
-    ("ring", "Apache-2.0 AND ISC"),
-    ("ryu", "Apache-2.0 OR BSL-1.0"), // BSL is not acceptble, but we use it under Apache-2.0
     ("sized-chunks", "MPL-2.0+"),
-    ("subtle", "BSD-3-Clause"),
-    ("zlib-rs", "Zlib"),
     // tidy-alphabetical-end
 ];
 
 const EXCEPTIONS_RUST_ANALYZER: ExceptionList = &[
     // tidy-alphabetical-start
-    ("foldhash", "Zlib"),
-    ("notify", "CC0-1.0"),
     ("option-ext", "MPL-2.0"),
-    ("ryu", "Apache-2.0 OR BSL-1.0"), // BSL is not acceptble, but we use it under Apache-2.0
-                                      // tidy-alphabetical-end
+    // tidy-alphabetical-end
 ];
 
 const EXCEPTIONS_RUSTC_PERF: ExceptionList = &[
     // tidy-alphabetical-start
-    ("alloc-no-stdlib", "BSD-3-Clause"),
-    ("alloc-stdlib", "BSD-3-Clause"),
-    ("encoding_rs", "(Apache-2.0 OR MIT) AND BSD-3-Clause"),
     ("inferno", "CDDL-1.0"),
     ("option-ext", "MPL-2.0"),
-    ("ryu", "Apache-2.0 OR BSL-1.0"),
-    ("snap", "BSD-3-Clause"),
-    ("subtle", "BSD-3-Clause"),
     // tidy-alphabetical-end
 ];
 
@@ -238,15 +232,10 @@ const EXCEPTIONS_RUSTBOOK: ExceptionList = &[
     ("cssparser-macros", "MPL-2.0"),
     ("dtoa-short", "MPL-2.0"),
     ("mdbook", "MPL-2.0"),
-    ("ryu", "Apache-2.0 OR BSL-1.0"),
     // tidy-alphabetical-end
 ];
 
-const EXCEPTIONS_CRANELIFT: ExceptionList = &[
-    // tidy-alphabetical-start
-    ("foldhash", "Zlib"),
-    // tidy-alphabetical-end
-];
+const EXCEPTIONS_CRANELIFT: ExceptionList = &[];
 
 const EXCEPTIONS_GCC: ExceptionList = &[
     // tidy-alphabetical-start
@@ -255,9 +244,7 @@ const EXCEPTIONS_GCC: ExceptionList = &[
     // tidy-alphabetical-end
 ];
 
-const EXCEPTIONS_BOOTSTRAP: ExceptionList = &[
-    ("ryu", "Apache-2.0 OR BSL-1.0"), // through serde. BSL is not acceptble, but we use it under Apache-2.0
-];
+const EXCEPTIONS_BOOTSTRAP: ExceptionList = &[];
 
 const EXCEPTIONS_UEFI_QEMU_TEST: ExceptionList = &[];
 
@@ -824,7 +811,7 @@ fn check_license_exceptions(
                 }
             }
         }
-        if LICENSES.contains(license) {
+        if LICENSES.contains(license) || LICENSES_TOOLS.contains(license) {
             check.error(format!(
                 "dependency exception `{name}` is not necessary. `{license}` is an allowed license"
             ));
@@ -852,7 +839,7 @@ fn check_license_exceptions(
                 continue;
             }
         };
-        if !LICENSES.contains(&license.as_str()) {
+        if !LICENSES.contains(&license.as_str()) && !LICENSES_TOOLS.contains(&license.as_str()) {
             check.error(format!(
                 "invalid license `{}` for package `{}` in workspace `{workspace}`",
                 license, pkg.id

--- a/src/tools/tidy/src/deps.rs
+++ b/src/tools/tidy/src/deps.rs
@@ -31,10 +31,15 @@ const LICENSES: &[&str] = &[
     "Apache-2.0",
     "Apache-2.0/MIT",
     "BSD-2-Clause OR Apache-2.0 OR MIT",                   // zerocopy
+    "BSD-2-Clause OR MIT OR Apache-2.0",
+    "BSD-3-Clause/MIT",
+    "CC0-1.0 OR Apache-2.0 OR Apache-2.0 WITH LLVM-exception",
+    "CC0-1.0 OR MIT-0 OR Apache-2.0",
     "ISC",
     "MIT / Apache-2.0",
     "MIT AND (MIT OR Apache-2.0)",
     "MIT AND Apache-2.0 WITH LLVM-exception AND (MIT OR Apache-2.0)", // compiler-builtins
+    "MIT OR Apache-2.0 OR BSD-1-Clause",
     "MIT OR Apache-2.0 OR LGPL-2.1-or-later",              // r-efi, r-efi-alloc; LGPL is not acceptable, but we use it under MIT OR Apache-2.0
     "MIT OR Apache-2.0 OR Zlib",                           // tinyvec_macros
     "MIT OR Apache-2.0",
@@ -171,9 +176,7 @@ pub(crate) const WORKSPACES: &[WorkspaceInfo<'static>] = &[
 const EXCEPTIONS: ExceptionList = &[
     // tidy-alphabetical-start
     ("arrayref", "BSD-2-Clause"),                            // rustc
-    ("blake3", "CC0-1.0 OR Apache-2.0 OR Apache-2.0 WITH LLVM-exception"),  // rustc
     ("colored", "MPL-2.0"),                                  // rustfmt
-    ("constant_time_eq", "CC0-1.0 OR MIT-0 OR Apache-2.0"),  // rustc
     ("foldhash", "Zlib"),                                    // rustc
     ("option-ext", "MPL-2.0"),                               // cargo-miri (via `directories`)
     ("ryu", "Apache-2.0 OR BSL-1.0"), // BSL is not acceptble, but we use it under Apache-2.0                       // cargo/... (because of serde)
@@ -195,11 +198,7 @@ const EXCEPTIONS_CARGO: ExceptionList = &[
     // tidy-alphabetical-start
     ("arrayref", "BSD-2-Clause"),
     ("bitmaps", "MPL-2.0+"),
-    ("blake3", "CC0-1.0 OR Apache-2.0 OR Apache-2.0 WITH LLVM-exception"),
-    ("constant_time_eq", "CC0-1.0 OR MIT-0 OR Apache-2.0"),
-    ("dunce", "CC0-1.0 OR MIT-0 OR Apache-2.0"),
     ("encoding_rs", "(Apache-2.0 OR MIT) AND BSD-3-Clause"),
-    ("fiat-crypto", "MIT OR Apache-2.0 OR BSD-1-Clause"),
     ("foldhash", "Zlib"),
     ("im-rc", "MPL-2.0+"),
     ("libz-rs-sys", "Zlib"),
@@ -224,8 +223,6 @@ const EXCEPTIONS_RUSTC_PERF: ExceptionList = &[
     // tidy-alphabetical-start
     ("alloc-no-stdlib", "BSD-3-Clause"),
     ("alloc-stdlib", "BSD-3-Clause"),
-    ("brotli", "BSD-3-Clause/MIT"),
-    ("brotli-decompressor", "BSD-3-Clause/MIT"),
     ("encoding_rs", "(Apache-2.0 OR MIT) AND BSD-3-Clause"),
     ("inferno", "CDDL-1.0"),
     ("option-ext", "MPL-2.0"),
@@ -248,7 +245,6 @@ const EXCEPTIONS_RUSTBOOK: ExceptionList = &[
 const EXCEPTIONS_CRANELIFT: ExceptionList = &[
     // tidy-alphabetical-start
     ("foldhash", "Zlib"),
-    ("mach2", "BSD-2-Clause OR MIT OR Apache-2.0"),
     // tidy-alphabetical-end
 ];
 

--- a/src/tools/tidy/src/deps.rs
+++ b/src/tools/tidy/src/deps.rs
@@ -19,21 +19,15 @@ mod proc_macro_deps;
 #[rustfmt::skip]
 const LICENSES: &[&str] = &[
     // tidy-alphabetical-start
-    "(MIT OR Apache-2.0) AND Unicode-3.0",                 // unicode_ident (1.0.14)
-    "(MIT OR Apache-2.0) AND Unicode-DFS-2016",            // unicode_ident (1.0.12)
     "0BSD OR MIT OR Apache-2.0",                           // adler2 license
-    "0BSD",
     "Apache-2.0 / MIT",
     "Apache-2.0 OR ISC OR MIT",
     "Apache-2.0 OR MIT",
     "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT", // wasi license
-    "Apache-2.0 WITH LLVM-exception",
-    "Apache-2.0",
     "Apache-2.0/MIT",
     "BSD-2-Clause OR Apache-2.0 OR MIT",                   // zerocopy
     "BSD-2-Clause OR MIT OR Apache-2.0",
     "BSD-3-Clause/MIT",
-    "CC0-1.0 OR Apache-2.0 OR Apache-2.0 WITH LLVM-exception",
     "CC0-1.0 OR MIT-0 OR Apache-2.0",
     "ISC",
     "MIT / Apache-2.0",
@@ -46,11 +40,8 @@ const LICENSES: &[&str] = &[
     "MIT OR Zlib OR Apache-2.0",                           // miniz_oxide
     "MIT",
     "MIT/Apache-2.0",
-    "Unicode-3.0",                                         // icu4x
-    "Unicode-DFS-2016",                                    // tinystr
     "Unlicense OR MIT",
     "Unlicense/MIT",
-    "Zlib OR Apache-2.0 OR MIT",                           // tinyvec
     // tidy-alphabetical-end
 ];
 
@@ -59,11 +50,20 @@ const LICENSES: &[&str] = &[
 const LICENSES_TOOLS: &[&str] = &[
     // tidy-alphabetical-start
     "(Apache-2.0 OR MIT) AND BSD-3-Clause",
+    "(MIT OR Apache-2.0) AND Unicode-3.0",                 // unicode_ident (1.0.14)
+    "(MIT OR Apache-2.0) AND Unicode-DFS-2016",            // unicode_ident (1.0.12)
+    "0BSD",
     "Apache-2.0 AND ISC",
     "Apache-2.0 OR BSL-1.0",  // BSL is not acceptable, but we use it under Apache-2.0
+    "Apache-2.0 WITH LLVM-exception",
+    "Apache-2.0",
     "BSD-2-Clause",
     "BSD-3-Clause",
+    "CC0-1.0 OR Apache-2.0 OR Apache-2.0 WITH LLVM-exception",
     "CC0-1.0",
+    "Unicode-3.0",                                         // icu4x
+    "Unicode-DFS-2016",                                    // tinystr
+    "Zlib OR Apache-2.0 OR MIT",                           // tinyvec
     "Zlib",
     // tidy-alphabetical-end
 ];

--- a/src/tools/tidy/src/deps.rs
+++ b/src/tools/tidy/src/deps.rs
@@ -34,7 +34,7 @@ const LICENSES: &[&str] = &[
     "MIT / Apache-2.0",
     "MIT AND (MIT OR Apache-2.0)",
     "MIT AND Apache-2.0 WITH LLVM-exception AND (MIT OR Apache-2.0)", // compiler-builtins
-    "MIT OR Apache-2.0 OR LGPL-2.1-or-later",              // r-efi, r-efi-alloc
+    "MIT OR Apache-2.0 OR LGPL-2.1-or-later",              // r-efi, r-efi-alloc; LGPL is not acceptable, but we use it under MIT OR Apache-2.0
     "MIT OR Apache-2.0 OR Zlib",                           // tinyvec_macros
     "MIT OR Apache-2.0",
     "MIT OR Zlib OR Apache-2.0",                           // miniz_oxide
@@ -174,13 +174,10 @@ const EXCEPTIONS: ExceptionList = &[
     ("blake3", "CC0-1.0 OR Apache-2.0 OR Apache-2.0 WITH LLVM-exception"),  // rustc
     ("colored", "MPL-2.0"),                                  // rustfmt
     ("constant_time_eq", "CC0-1.0 OR MIT-0 OR Apache-2.0"),  // rustc
-    ("dissimilar", "Apache-2.0"),                            // rustdoc, rustc_lexer (few tests) via expect-test, (dev deps)
-    ("fluent-langneg", "Apache-2.0"),                        // rustc (fluent translations)
     ("foldhash", "Zlib"),                                    // rustc
     ("option-ext", "MPL-2.0"),                               // cargo-miri (via `directories`)
     ("rustc_apfloat", "Apache-2.0 WITH LLVM-exception"),     // rustc (license is the same as LLVM uses)
     ("ryu", "Apache-2.0 OR BSL-1.0"), // BSL is not acceptble, but we use it under Apache-2.0                       // cargo/... (because of serde)
-    ("self_cell", "Apache-2.0"),                             // rustc (fluent translations)
     ("wasi-preview1-component-adapter-provider", "Apache-2.0 WITH LLVM-exception"), // rustc
     // tidy-alphabetical-end
 ];
@@ -201,9 +198,6 @@ const EXCEPTIONS_CARGO: ExceptionList = &[
     ("arrayref", "BSD-2-Clause"),
     ("bitmaps", "MPL-2.0+"),
     ("blake3", "CC0-1.0 OR Apache-2.0 OR Apache-2.0 WITH LLVM-exception"),
-    ("ciborium", "Apache-2.0"),
-    ("ciborium-io", "Apache-2.0"),
-    ("ciborium-ll", "Apache-2.0"),
     ("constant_time_eq", "CC0-1.0 OR MIT-0 OR Apache-2.0"),
     ("dunce", "CC0-1.0 OR MIT-0 OR Apache-2.0"),
     ("encoding_rs", "(Apache-2.0 OR MIT) AND BSD-3-Clause"),
@@ -211,30 +205,22 @@ const EXCEPTIONS_CARGO: ExceptionList = &[
     ("foldhash", "Zlib"),
     ("im-rc", "MPL-2.0+"),
     ("libz-rs-sys", "Zlib"),
-    ("normalize-line-endings", "Apache-2.0"),
-    ("openssl", "Apache-2.0"),
     ("ring", "Apache-2.0 AND ISC"),
     ("ryu", "Apache-2.0 OR BSL-1.0"), // BSL is not acceptble, but we use it under Apache-2.0
-    ("similar", "Apache-2.0"),
     ("sized-chunks", "MPL-2.0+"),
     ("subtle", "BSD-3-Clause"),
-    ("supports-hyperlinks", "Apache-2.0"),
-    ("unicode-bom", "Apache-2.0"),
     ("zlib-rs", "Zlib"),
     // tidy-alphabetical-end
 ];
 
 const EXCEPTIONS_RUST_ANALYZER: ExceptionList = &[
     // tidy-alphabetical-start
-    ("dissimilar", "Apache-2.0"),
     ("foldhash", "Zlib"),
     ("notify", "CC0-1.0"),
     ("option-ext", "MPL-2.0"),
-    ("pulldown-cmark-to-cmark", "Apache-2.0"),
     ("rustc_apfloat", "Apache-2.0 WITH LLVM-exception"),
     ("ryu", "Apache-2.0 OR BSL-1.0"), // BSL is not acceptble, but we use it under Apache-2.0
-    ("scip", "Apache-2.0"),
-    // tidy-alphabetical-end
+                                      // tidy-alphabetical-end
 ];
 
 const EXCEPTIONS_RUSTC_PERF: ExceptionList = &[
@@ -300,9 +286,7 @@ const EXCEPTIONS_BOOTSTRAP: ExceptionList = &[
     ("ryu", "Apache-2.0 OR BSL-1.0"), // through serde. BSL is not acceptble, but we use it under Apache-2.0
 ];
 
-const EXCEPTIONS_UEFI_QEMU_TEST: ExceptionList = &[
-    ("r-efi", "MIT OR Apache-2.0 OR LGPL-2.1-or-later"), // LGPL is not acceptable, but we use it under MIT OR Apache-2.0
-];
+const EXCEPTIONS_UEFI_QEMU_TEST: ExceptionList = &[];
 
 #[derive(Clone, Copy)]
 struct ListLocation {
@@ -866,6 +850,11 @@ fn check_license_exceptions(
                     }
                 }
             }
+        }
+        if LICENSES.contains(license) {
+            check.error(format!(
+                "dependency exception `{name}` is not necessary. `{license}` is an allowed license"
+            ));
         }
     }
 

--- a/src/tools/tidy/src/deps.rs
+++ b/src/tools/tidy/src/deps.rs
@@ -27,6 +27,7 @@ const LICENSES: &[&str] = &[
     "Apache-2.0 OR ISC OR MIT",
     "Apache-2.0 OR MIT",
     "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT", // wasi license
+    "Apache-2.0 WITH LLVM-exception",
     "Apache-2.0",
     "Apache-2.0/MIT",
     "BSD-2-Clause OR Apache-2.0 OR MIT",                   // zerocopy
@@ -169,16 +170,13 @@ pub(crate) const WORKSPACES: &[WorkspaceInfo<'static>] = &[
 #[rustfmt::skip]
 const EXCEPTIONS: ExceptionList = &[
     // tidy-alphabetical-start
-    ("ar_archive_writer", "Apache-2.0 WITH LLVM-exception"), // rustc
     ("arrayref", "BSD-2-Clause"),                            // rustc
     ("blake3", "CC0-1.0 OR Apache-2.0 OR Apache-2.0 WITH LLVM-exception"),  // rustc
     ("colored", "MPL-2.0"),                                  // rustfmt
     ("constant_time_eq", "CC0-1.0 OR MIT-0 OR Apache-2.0"),  // rustc
     ("foldhash", "Zlib"),                                    // rustc
     ("option-ext", "MPL-2.0"),                               // cargo-miri (via `directories`)
-    ("rustc_apfloat", "Apache-2.0 WITH LLVM-exception"),     // rustc (license is the same as LLVM uses)
     ("ryu", "Apache-2.0 OR BSL-1.0"), // BSL is not acceptble, but we use it under Apache-2.0                       // cargo/... (because of serde)
-    ("wasi-preview1-component-adapter-provider", "Apache-2.0 WITH LLVM-exception"), // rustc
     // tidy-alphabetical-end
 ];
 
@@ -218,7 +216,6 @@ const EXCEPTIONS_RUST_ANALYZER: ExceptionList = &[
     ("foldhash", "Zlib"),
     ("notify", "CC0-1.0"),
     ("option-ext", "MPL-2.0"),
-    ("rustc_apfloat", "Apache-2.0 WITH LLVM-exception"),
     ("ryu", "Apache-2.0 OR BSL-1.0"), // BSL is not acceptble, but we use it under Apache-2.0
                                       // tidy-alphabetical-end
 ];
@@ -250,28 +247,8 @@ const EXCEPTIONS_RUSTBOOK: ExceptionList = &[
 
 const EXCEPTIONS_CRANELIFT: ExceptionList = &[
     // tidy-alphabetical-start
-    ("cranelift-assembler-x64", "Apache-2.0 WITH LLVM-exception"),
-    ("cranelift-assembler-x64-meta", "Apache-2.0 WITH LLVM-exception"),
-    ("cranelift-bforest", "Apache-2.0 WITH LLVM-exception"),
-    ("cranelift-bitset", "Apache-2.0 WITH LLVM-exception"),
-    ("cranelift-codegen", "Apache-2.0 WITH LLVM-exception"),
-    ("cranelift-codegen-meta", "Apache-2.0 WITH LLVM-exception"),
-    ("cranelift-codegen-shared", "Apache-2.0 WITH LLVM-exception"),
-    ("cranelift-control", "Apache-2.0 WITH LLVM-exception"),
-    ("cranelift-entity", "Apache-2.0 WITH LLVM-exception"),
-    ("cranelift-frontend", "Apache-2.0 WITH LLVM-exception"),
-    ("cranelift-isle", "Apache-2.0 WITH LLVM-exception"),
-    ("cranelift-jit", "Apache-2.0 WITH LLVM-exception"),
-    ("cranelift-module", "Apache-2.0 WITH LLVM-exception"),
-    ("cranelift-native", "Apache-2.0 WITH LLVM-exception"),
-    ("cranelift-object", "Apache-2.0 WITH LLVM-exception"),
-    ("cranelift-srcgen", "Apache-2.0 WITH LLVM-exception"),
     ("foldhash", "Zlib"),
     ("mach2", "BSD-2-Clause OR MIT OR Apache-2.0"),
-    ("regalloc2", "Apache-2.0 WITH LLVM-exception"),
-    ("target-lexicon", "Apache-2.0 WITH LLVM-exception"),
-    ("wasmtime-jit-icache-coherence", "Apache-2.0 WITH LLVM-exception"),
-    ("wasmtime-math", "Apache-2.0 WITH LLVM-exception"),
     // tidy-alphabetical-end
 ];
 

--- a/src/tools/tidy/src/deps.rs
+++ b/src/tools/tidy/src/deps.rs
@@ -60,7 +60,7 @@ const LICENSES_TOOLS: &[&str] = &[
     // tidy-alphabetical-start
     "(Apache-2.0 OR MIT) AND BSD-3-Clause",
     "Apache-2.0 AND ISC",
-    "Apache-2.0 OR BSL-1.0",  // BSL is not acceptble, but we use it under Apache-2.0
+    "Apache-2.0 OR BSL-1.0",  // BSL is not acceptable, but we use it under Apache-2.0
     "BSD-2-Clause",
     "BSD-3-Clause",
     "CC0-1.0",

--- a/tests/ui/error-emitter/trimmed_multiline_suggestion.rs
+++ b/tests/ui/error-emitter/trimmed_multiline_suggestion.rs
@@ -1,0 +1,14 @@
+//@ compile-flags: -Z ui-testing=no
+fn function_with_lots_of_arguments(a: i32, b: char, c: i32, d: i32, e: i32, f: i32) {}
+
+fn main() {
+    let variable_name = 42;
+    function_with_lots_of_arguments(
+        variable_name,
+        variable_name,
+        variable_name,
+        variable_name,
+        variable_name,
+    );
+    //~^^^^^^^ ERROR this function takes 6 arguments but 5 arguments were supplied [E0061]
+}

--- a/tests/ui/error-emitter/trimmed_multiline_suggestion.stderr
+++ b/tests/ui/error-emitter/trimmed_multiline_suggestion.stderr
@@ -1,0 +1,25 @@
+error[E0061]: this function takes 6 arguments but 5 arguments were supplied
+ --> $DIR/trimmed_multiline_suggestion.rs:6:5
+  |
+6 |     function_with_lots_of_arguments(
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+7 |         variable_name,
+8 |         variable_name,
+  |         ------------- argument #2 of type `char` is missing
+  |
+note: function defined here
+ --> $DIR/trimmed_multiline_suggestion.rs:2:4
+  |
+2 | fn function_with_lots_of_arguments(a: i32, b: char, c: i32, d: i32, e: i32, f: i32) {}
+  |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^         -------
+help: provide the argument
+  |
+6 |     function_with_lots_of_arguments(
+7 |         variable_name,
+8 ~         /* char */,
+9 ~         variable_name,
+  |
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0061`.

--- a/tests/ui/inference/ambiguous-numeric-in-closure-ref.fixed
+++ b/tests/ui/inference/ambiguous-numeric-in-closure-ref.fixed
@@ -1,0 +1,9 @@
+// Test for better error message when numeric type is ambiguous in closure parameter with reference
+
+//@ run-rustfix
+
+fn main() {
+    let _ = (0..10).filter(|&v: &i32| v.pow(2) > 0);
+    //~^ ERROR can't call method `pow` on ambiguous numeric type `{integer}`
+    //~| SUGGESTION &i32
+}

--- a/tests/ui/inference/ambiguous-numeric-in-closure-ref.fixed
+++ b/tests/ui/inference/ambiguous-numeric-in-closure-ref.fixed
@@ -6,4 +6,9 @@ fn main() {
     let _ = (0..10).filter(|&v: &i32| v.pow(2) > 0);
     //~^ ERROR can't call method `pow` on ambiguous numeric type `{integer}`
     //~| SUGGESTION &i32
+
+    let v = vec![0, 1, 2];
+    let _ = v.iter().filter(|&&v: &&i32| v.pow(2) > 0);
+    //~^ ERROR can't call method `pow` on ambiguous numeric type `{integer}`
+    //~| SUGGESTION &&i32
 }

--- a/tests/ui/inference/ambiguous-numeric-in-closure-ref.rs
+++ b/tests/ui/inference/ambiguous-numeric-in-closure-ref.rs
@@ -1,0 +1,9 @@
+// Test for better error message when numeric type is ambiguous in closure parameter with reference
+
+//@ run-rustfix
+
+fn main() {
+    let _ = (0..10).filter(|&v| v.pow(2) > 0);
+    //~^ ERROR can't call method `pow` on ambiguous numeric type `{integer}`
+    //~| SUGGESTION &i32
+}

--- a/tests/ui/inference/ambiguous-numeric-in-closure-ref.rs
+++ b/tests/ui/inference/ambiguous-numeric-in-closure-ref.rs
@@ -6,4 +6,9 @@ fn main() {
     let _ = (0..10).filter(|&v| v.pow(2) > 0);
     //~^ ERROR can't call method `pow` on ambiguous numeric type `{integer}`
     //~| SUGGESTION &i32
+
+    let v = vec![0, 1, 2];
+    let _ = v.iter().filter(|&&v| v.pow(2) > 0);
+    //~^ ERROR can't call method `pow` on ambiguous numeric type `{integer}`
+    //~| SUGGESTION &&i32
 }

--- a/tests/ui/inference/ambiguous-numeric-in-closure-ref.stderr
+++ b/tests/ui/inference/ambiguous-numeric-in-closure-ref.stderr
@@ -1,0 +1,16 @@
+error[E0689]: can't call method `pow` on ambiguous numeric type `{integer}`
+  --> $DIR/ambiguous-numeric-in-closure-ref.rs:6:35
+   |
+LL |     let _ = (0..10).filter(|&v| v.pow(2) > 0);
+   |                              -    ^^^
+   |                              |
+   |                              you must specify a type for this binding
+   |
+help: specify the type in the closure argument list
+   |
+LL |     let _ = (0..10).filter(|&v: &i32| v.pow(2) > 0);
+   |                               ++++++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0689`.

--- a/tests/ui/inference/ambiguous-numeric-in-closure-ref.stderr
+++ b/tests/ui/inference/ambiguous-numeric-in-closure-ref.stderr
@@ -11,6 +11,19 @@ help: specify the type in the closure argument list
 LL |     let _ = (0..10).filter(|&v: &i32| v.pow(2) > 0);
    |                               ++++++
 
-error: aborting due to 1 previous error
+error[E0689]: can't call method `pow` on ambiguous numeric type `{integer}`
+  --> $DIR/ambiguous-numeric-in-closure-ref.rs:11:37
+   |
+LL |     let _ = v.iter().filter(|&&v| v.pow(2) > 0);
+   |                                -    ^^^
+   |                                |
+   |                                you must specify a type for this binding
+   |
+help: specify the type in the closure argument list
+   |
+LL |     let _ = v.iter().filter(|&&v: &&i32| v.pow(2) > 0);
+   |                                 +++++++
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0689`.


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#147577 (Improve error message for ambiguous numeric types in closure parameters)
 - rust-lang/rust#147785 (fix incorrect line number when building trimmed multi-line suggestions)
 - rust-lang/rust#147814 (btree: some cleanup with less unsafe)
 - rust-lang/rust#147843 (Change the tidy license checker)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=147577,147785,147814,147843)
<!-- homu-ignore:end -->