### PR TITLE
resolve: When suppressing `out_of_scope_macro_calls` suppress `unused_imports` as well

### DIFF
--- a/tests/ui/attributes/key-value-expansion-scope-pass.rs
+++ b/tests/ui/attributes/key-value-expansion-scope-pass.rs
@@ -3,6 +3,7 @@
 //@ check-pass
 //@ edition:2018
 
+#![warn(unused_imports)]
 #![doc = in_root!()]
 
 macro_rules! in_root { () => { "" } }


### PR DESCRIPTION
Fixes the example from this comment - https://github.com/rust-lang/rust/issues/147823#issuecomment-3421770900.
Fixes https://github.com/rust-lang/rust/issues/148143.