### PR TITLE
tidy extdeps: don't read whole lockfile into memory

### DIFF
--- a/src/tools/tidy/src/extdeps.rs
+++ b/src/tools/tidy/src/extdeps.rs
@@ -1,6 +1,7 @@
 //! Check for external package sources. Allow only vendorable packages.
 
 use std::fs;
+use std::io::{BufRead as _, BufReader};
 use std::path::Path;
 
 use crate::deps::WorkspaceInfo;
@@ -8,9 +9,9 @@ use crate::diagnostics::DiagCtx;
 
 /// List of allowed sources for packages.
 const ALLOWED_SOURCES: &[&str] = &[
-    r#""registry+https://github.com/rust-lang/crates.io-index""#,
+    "registry+https://github.com/rust-lang/crates.io-index",
     // This is `rust_team_data` used by `site` in src/tools/rustc-perf,
-    r#""git+https://github.com/rust-lang/team#a5260e76d3aa894c64c56e6ddc8545b9a98043ec""#,
+    "git+https://github.com/rust-lang/team#a5260e76d3aa894c64c56e6ddc8545b9a98043ec",
 ];
 
 /// Checks for external package sources. `root` is the path to the directory that contains the
@@ -23,8 +24,6 @@ pub fn check(root: &Path, diag_ctx: DiagCtx) {
             continue;
         }
 
-        // FIXME check other workspaces too
-        // `Cargo.lock` of rust.
         let lockfile = root.join(path).join("Cargo.lock");
 
         if !lockfile.exists() {
@@ -32,21 +31,16 @@ pub fn check(root: &Path, diag_ctx: DiagCtx) {
             continue;
         }
 
-        // Open and read the whole file.
-        let cargo_lock = t!(fs::read_to_string(&lockfile));
+        // At the time of writing, longest line in lockfile is 82 bytes.
+        let cargo_lock = BufReader::with_capacity(128, t!(fs::File::open(&lockfile)));
+        let mut lines = cargo_lock.lines();
 
         // Process each line.
-        for line in cargo_lock.lines() {
-            // Consider only source entries.
-            if !line.starts_with("source = ") {
-                continue;
-            }
-
-            // Extract source value.
-            let source = line.split_once('=').unwrap().1.trim();
-
-            // Ensure source is allowed.
-            if !ALLOWED_SOURCES.contains(&source) {
+        while let Some(line) = t!(lines.next().transpose()) {
+            if let Some(source) = line.strip_prefix(r#"source = ""#)
+                && let Some(source) = source.strip_suffix(r#"""#)
+                && !ALLOWED_SOURCES.contains(&source)
+            {
                 check.error(format!("invalid source: {}", source));
             }
         }


### PR DESCRIPTION
also, remove outdated FIXME, and simplify bespoke toml parsing

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
Might improve tidy's memory consumption by a tiny bit 😅