### PR TITLE
Simplify rustc_public context handling

### DIFF
--- a/compiler/rustc_public/src/compiler_interface.rs
+++ b/compiler/rustc_public/src/compiler_interface.rs
@@ -3,11 +3,11 @@
 //! rustc_public users should not use any of the items in this module directly.
 //! These APIs have no stability guarantee.
 
-use std::cell::Cell;
+use std::cell::{Cell, RefCell};
 
 use rustc_hir::def::DefKind;
 use rustc_public_bridge::context::CompilerCtxt;
-use rustc_public_bridge::{Bridge, Container};
+use rustc_public_bridge::{Bridge, Tables};
 use tracing::debug;
 
 use crate::abi::{FnAbi, Layout, LayoutShape, ReprOptions};
@@ -68,256 +68,17 @@ impl Bridge for BridgeTys {
 
 /// Public API for querying compiler information.
 ///
-/// All queries are delegated to [`rustc_public_bridge::context::CompilerCtxt`] that provides
-/// similar APIs but based on internal rustc constructs.
+/// All queries are delegated to [`rustc_public_bridge::context::CompilerCtxt`]
+/// that provides similar APIs but based on internal rustc constructs.
 ///
 /// Do not use this directly. This is currently used in the macro expansion.
-pub(crate) trait CompilerInterface {
-    fn entry_fn(&self) -> Option<CrateItem>;
-    /// Retrieve all items of the local crate that have a MIR associated with them.
-    fn all_local_items(&self) -> CrateItems;
-    /// Retrieve the body of a function.
-    /// This function will panic if the body is not available.
-    fn mir_body(&self, item: DefId) -> mir::Body;
-    /// Check whether the body of a function is available.
-    fn has_body(&self, item: DefId) -> bool;
-    fn foreign_modules(&self, crate_num: CrateNum) -> Vec<ForeignModuleDef>;
-
-    /// Retrieve all functions defined in this crate.
-    fn crate_functions(&self, crate_num: CrateNum) -> Vec<FnDef>;
-
-    /// Retrieve all static items defined in this crate.
-    fn crate_statics(&self, crate_num: CrateNum) -> Vec<StaticDef>;
-    fn foreign_module(&self, mod_def: ForeignModuleDef) -> ForeignModule;
-    fn foreign_items(&self, mod_def: ForeignModuleDef) -> Vec<ForeignDef>;
-    fn all_trait_decls(&self) -> TraitDecls;
-    fn trait_decls(&self, crate_num: CrateNum) -> TraitDecls;
-    fn trait_decl(&self, trait_def: &TraitDef) -> TraitDecl;
-    fn all_trait_impls(&self) -> ImplTraitDecls;
-    fn trait_impls(&self, crate_num: CrateNum) -> ImplTraitDecls;
-    fn trait_impl(&self, trait_impl: &ImplDef) -> ImplTrait;
-    fn generics_of(&self, def_id: DefId) -> Generics;
-    fn predicates_of(&self, def_id: DefId) -> GenericPredicates;
-    fn explicit_predicates_of(&self, def_id: DefId) -> GenericPredicates;
-
-    /// Get information about the local crate.
-    fn local_crate(&self) -> Crate;
-    /// Retrieve a list of all external crates.
-    fn external_crates(&self) -> Vec<Crate>;
-
-    /// Find a crate with the given name.
-    fn find_crates(&self, name: &str) -> Vec<Crate>;
-
-    /// Returns the name of given `DefId`
-    fn def_name(&self, def_id: DefId, trimmed: bool) -> Symbol;
-
-    /// Return registered tool attributes with the given attribute name.
-    ///
-    /// FIXME(jdonszelmann): may panic on non-tool attributes. After more attribute work, non-tool
-    /// attributes will simply return an empty list.
-    ///
-    /// Single segmented name like `#[clippy]` is specified as `&["clippy".to_string()]`.
-    /// Multi-segmented name like `#[rustfmt::skip]` is specified as `&["rustfmt".to_string(), "skip".to_string()]`.
-    fn tool_attrs(&self, def_id: DefId, attr: &[Symbol]) -> Vec<Attribute>;
-
-    /// Get all tool attributes of a definition.
-    fn all_tool_attrs(&self, def_id: DefId) -> Vec<Attribute>;
-
-    /// Returns printable, human readable form of `Span`
-    fn span_to_string(&self, span: Span) -> String;
-
-    /// Return filename from given `Span`, for diagnostic purposes
-    fn get_filename(&self, span: &Span) -> Filename;
-
-    /// Return lines corresponding to this `Span`
-    fn get_lines(&self, span: &Span) -> LineInfo;
-
-    /// Returns the `kind` of given `DefId`
-    fn item_kind(&self, item: CrateItem) -> ItemKind;
-
-    /// Returns whether this is a foreign item.
-    fn is_foreign_item(&self, item: DefId) -> bool;
-
-    /// Returns the kind of a given foreign item.
-    fn foreign_item_kind(&self, def: ForeignDef) -> ForeignItemKind;
-
-    /// Returns the kind of a given algebraic data type
-    fn adt_kind(&self, def: AdtDef) -> AdtKind;
-
-    /// Returns if the ADT is a box.
-    fn adt_is_box(&self, def: AdtDef) -> bool;
-
-    /// Returns whether this ADT is simd.
-    fn adt_is_simd(&self, def: AdtDef) -> bool;
-
-    /// Returns whether this definition is a C string.
-    fn adt_is_cstr(&self, def: AdtDef) -> bool;
-
-    /// Returns the representation options for this ADT.
-    fn adt_repr(&self, def: AdtDef) -> ReprOptions;
-
-    /// Retrieve the function signature for the given generic arguments.
-    fn fn_sig(&self, def: FnDef, args: &GenericArgs) -> PolyFnSig;
-
-    /// Retrieve the intrinsic definition if the item corresponds one.
-    fn intrinsic(&self, item: DefId) -> Option<IntrinsicDef>;
-
-    /// Retrieve the plain function name of an intrinsic.
-    fn intrinsic_name(&self, def: IntrinsicDef) -> Symbol;
-
-    /// Retrieve the closure signature for the given generic arguments.
-    fn closure_sig(&self, args: &GenericArgs) -> PolyFnSig;
-
-    /// The number of variants in this ADT.
-    fn adt_variants_len(&self, def: AdtDef) -> usize;
-
-    /// Discriminant for a given variant index of AdtDef.
-    fn adt_discr_for_variant(&self, adt: AdtDef, variant: VariantIdx) -> Discr;
-
-    /// Discriminant for a given variand index and args of a coroutine.
-    fn coroutine_discr_for_variant(
-        &self,
-        coroutine: CoroutineDef,
-        args: &GenericArgs,
-        variant: VariantIdx,
-    ) -> Discr;
-
-    /// The name of a variant.
-    fn variant_name(&self, def: VariantDef) -> Symbol;
-    fn variant_fields(&self, def: VariantDef) -> Vec<FieldDef>;
-
-    /// Evaluate constant as a target usize.
-    fn eval_target_usize(&self, cnst: &MirConst) -> Result<u64, Error>;
-    fn eval_target_usize_ty(&self, cnst: &TyConst) -> Result<u64, Error>;
-
-    /// Create a new zero-sized constant.
-    fn try_new_const_zst(&self, ty: Ty) -> Result<MirConst, Error>;
-
-    /// Create a new constant that represents the given string value.
-    fn new_const_str(&self, value: &str) -> MirConst;
-
-    /// Create a new constant that represents the given boolean value.
-    fn new_const_bool(&self, value: bool) -> MirConst;
-
-    /// Create a new constant that represents the given value.
-    fn try_new_const_uint(&self, value: u128, uint_ty: UintTy) -> Result<MirConst, Error>;
-    fn try_new_ty_const_uint(&self, value: u128, uint_ty: UintTy) -> Result<TyConst, Error>;
-
-    /// Create a new type from the given kind.
-    fn new_rigid_ty(&self, kind: RigidTy) -> Ty;
-
-    /// Create a new box type, `Box<T>`, for the given inner type `T`.
-    fn new_box_ty(&self, ty: Ty) -> Ty;
-
-    /// Returns the type of given crate item.
-    fn def_ty(&self, item: DefId) -> Ty;
-
-    /// Returns the type of given definition instantiated with the given arguments.
-    fn def_ty_with_args(&self, item: DefId, args: &GenericArgs) -> Ty;
-
-    /// Returns literal value of a const as a string.
-    fn mir_const_pretty(&self, cnst: &MirConst) -> String;
-
-    /// `Span` of an item
-    fn span_of_an_item(&self, def_id: DefId) -> Span;
-
-    fn ty_const_pretty(&self, ct: TyConstId) -> String;
-
-    /// Obtain the representation of a type.
-    fn ty_pretty(&self, ty: Ty) -> String;
-
-    /// Obtain the kind of a type.
-    fn ty_kind(&self, ty: Ty) -> TyKind;
-
-    // Get the discriminant Ty for this Ty if there's one.
-    fn rigid_ty_discriminant_ty(&self, ty: &RigidTy) -> Ty;
-
-    /// Get the body of an Instance which is already monomorphized.
-    fn instance_body(&self, instance: InstanceDef) -> Option<Body>;
-
-    /// Get the instance type with generic instantiations applied and lifetimes erased.
-    fn instance_ty(&self, instance: InstanceDef) -> Ty;
-
-    /// Get the instantiation types.
-    fn instance_args(&self, def: InstanceDef) -> GenericArgs;
-
-    /// Get the instance.
-    fn instance_def_id(&self, instance: InstanceDef) -> DefId;
-
-    /// Get the instance mangled name.
-    fn instance_mangled_name(&self, instance: InstanceDef) -> Symbol;
-
-    /// Check if this is an empty DropGlue shim.
-    fn is_empty_drop_shim(&self, def: InstanceDef) -> bool;
-
-    /// Convert a non-generic crate item into an instance.
-    /// This function will panic if the item is generic.
-    fn mono_instance(&self, def_id: DefId) -> Instance;
-
-    /// Item requires monomorphization.
-    fn requires_monomorphization(&self, def_id: DefId) -> bool;
-
-    /// Resolve an instance from the given function definition and generic arguments.
-    fn resolve_instance(&self, def: FnDef, args: &GenericArgs) -> Option<Instance>;
-
-    /// Resolve an instance for drop_in_place for the given type.
-    fn resolve_drop_in_place(&self, ty: Ty) -> Instance;
-
-    /// Resolve instance for a function pointer.
-    fn resolve_for_fn_ptr(&self, def: FnDef, args: &GenericArgs) -> Option<Instance>;
-
-    /// Resolve instance for a closure with the requested type.
-    fn resolve_closure(
-        &self,
-        def: ClosureDef,
-        args: &GenericArgs,
-        kind: ClosureKind,
-    ) -> Option<Instance>;
-
-    /// Evaluate a static's initializer.
-    fn eval_static_initializer(&self, def: StaticDef) -> Result<Allocation, Error>;
-
-    /// Try to evaluate an instance into a constant.
-    fn eval_instance(&self, def: InstanceDef, const_ty: Ty) -> Result<Allocation, Error>;
-
-    /// Retrieve global allocation for the given allocation ID.
-    fn global_alloc(&self, id: AllocId) -> GlobalAlloc;
-
-    /// Retrieve the id for the virtual table.
-    fn vtable_allocation(&self, global_alloc: &GlobalAlloc) -> Option<AllocId>;
-    fn krate(&self, def_id: DefId) -> Crate;
-    fn instance_name(&self, def: InstanceDef, trimmed: bool) -> Symbol;
-
-    /// Return information about the target machine.
-    fn target_info(&self) -> MachineInfo;
-
-    /// Get an instance ABI.
-    fn instance_abi(&self, def: InstanceDef) -> Result<FnAbi, Error>;
-
-    /// Get the ABI of a function pointer.
-    fn fn_ptr_abi(&self, fn_ptr: PolyFnSig) -> Result<FnAbi, Error>;
-
-    /// Get the layout of a type.
-    fn ty_layout(&self, ty: Ty) -> Result<Layout, Error>;
-
-    /// Get the layout shape.
-    fn layout_shape(&self, id: Layout) -> LayoutShape;
-
-    /// Get a debug string representation of a place.
-    fn place_pretty(&self, place: &Place) -> String;
-
-    /// Get the resulting type of binary operation.
-    fn binop_ty(&self, bin_op: BinOp, rhs: Ty, lhs: Ty) -> Ty;
-
-    /// Get the resulting type of unary operation.
-    fn unop_ty(&self, un_op: UnOp, arg: Ty) -> Ty;
-
-    /// Get all associated items of a definition.
-    fn associated_items(&self, def_id: DefId) -> AssocItems;
+pub(crate) struct CompilerInterface<'tcx> {
+    pub tables: RefCell<Tables<'tcx, BridgeTys>>,
+    pub cx: RefCell<CompilerCtxt<'tcx, BridgeTys>>,
 }
 
-impl<'tcx> CompilerInterface for Container<'tcx, BridgeTys> {
-    fn entry_fn(&self) -> Option<CrateItem> {
+impl<'tcx> CompilerInterface<'tcx> {
+    pub(crate) fn entry_fn(&self) -> Option<CrateItem> {
         let mut tables = self.tables.borrow_mut();
         let cx = &*self.cx.borrow();
         let did = cx.entry_fn();
@@ -325,7 +86,7 @@ impl<'tcx> CompilerInterface for Container<'tcx, BridgeTys> {
     }
 
     /// Retrieve all items of the local crate that have a MIR associated with them.
-    fn all_local_items(&self) -> CrateItems {
+    pub(crate) fn all_local_items(&self) -> CrateItems {
         let mut tables = self.tables.borrow_mut();
         let cx = &*self.cx.borrow();
         cx.all_local_items().iter().map(|did| tables.crate_item(*did)).collect()
@@ -333,7 +94,7 @@ impl<'tcx> CompilerInterface for Container<'tcx, BridgeTys> {
 
     /// Retrieve the body of a function.
     /// This function will panic if the body is not available.
-    fn mir_body(&self, item: DefId) -> mir::Body {
+    pub(crate) fn mir_body(&self, item: DefId) -> mir::Body {
         let mut tables = self.tables.borrow_mut();
         let cx = &*self.cx.borrow();
         let did = tables[item];
@@ -341,14 +102,14 @@ impl<'tcx> CompilerInterface for Container<'tcx, BridgeTys> {
     }
 
     /// Check whether the body of a function is available.
-    fn has_body(&self, item: DefId) -> bool {
+    pub(crate) fn has_body(&self, item: DefId) -> bool {
         let mut tables = self.tables.borrow_mut();
         let cx = &*self.cx.borrow();
         let def = item.internal(&mut *tables, cx.tcx);
         cx.has_body(def)
     }
 
-    fn foreign_modules(&self, crate_num: CrateNum) -> Vec<ForeignModuleDef> {
+    pub(crate) fn foreign_modules(&self, crate_num: CrateNum) -> Vec<ForeignModuleDef> {
         let mut tables = self.tables.borrow_mut();
         let cx = &*self.cx.borrow();
         cx.foreign_modules(crate_num.internal(&mut *tables, cx.tcx))
@@ -358,7 +119,7 @@ impl<'tcx> CompilerInterface for Container<'tcx, BridgeTys> {
     }
 
     /// Retrieve all functions defined in this crate.
-    fn crate_functions(&self, crate_num: CrateNum) -> Vec<FnDef> {
+    pub(crate) fn crate_functions(&self, crate_num: CrateNum) -> Vec<FnDef> {
         let mut tables = self.tables.borrow_mut();
         let cx = &*self.cx.borrow();
         let krate = crate_num.internal(&mut *tables, cx.tcx);
@@ -366,75 +127,75 @@ impl<'tcx> CompilerInterface for Container<'tcx, BridgeTys> {
     }
 
     /// Retrieve all static items defined in this crate.
-    fn crate_statics(&self, crate_num: CrateNum) -> Vec<StaticDef> {
+    pub(crate) fn crate_statics(&self, crate_num: CrateNum) -> Vec<StaticDef> {
         let mut tables = self.tables.borrow_mut();
         let cx = &*self.cx.borrow();
         let krate = crate_num.internal(&mut *tables, cx.tcx);
         cx.crate_statics(krate).iter().map(|did| tables.static_def(*did)).collect()
     }
 
-    fn foreign_module(&self, mod_def: ForeignModuleDef) -> ForeignModule {
+    pub(crate) fn foreign_module(&self, mod_def: ForeignModuleDef) -> ForeignModule {
         let mut tables = self.tables.borrow_mut();
         let cx = &*self.cx.borrow();
         let did = tables[mod_def.def_id()];
         cx.foreign_module(did).stable(&mut *tables, cx)
     }
 
-    fn foreign_items(&self, mod_def: ForeignModuleDef) -> Vec<ForeignDef> {
+    pub(crate) fn foreign_items(&self, mod_def: ForeignModuleDef) -> Vec<ForeignDef> {
         let mut tables = self.tables.borrow_mut();
         let cx = &*self.cx.borrow();
         let did = tables[mod_def.def_id()];
         cx.foreign_items(did).iter().map(|did| tables.foreign_def(*did)).collect()
     }
 
-    fn all_trait_decls(&self) -> TraitDecls {
+    pub(crate) fn all_trait_decls(&self) -> TraitDecls {
         let mut tables = self.tables.borrow_mut();
         let cx = &*self.cx.borrow();
         cx.all_trait_decls().map(|did| tables.trait_def(did)).collect()
     }
 
-    fn trait_decls(&self, crate_num: CrateNum) -> TraitDecls {
+    pub(crate) fn trait_decls(&self, crate_num: CrateNum) -> TraitDecls {
         let mut tables = self.tables.borrow_mut();
         let cx = &*self.cx.borrow();
         let krate = crate_num.internal(&mut *tables, cx.tcx);
         cx.trait_decls(krate).iter().map(|did| tables.trait_def(*did)).collect()
     }
 
-    fn trait_decl(&self, trait_def: &TraitDef) -> TraitDecl {
+    pub(crate) fn trait_decl(&self, trait_def: &TraitDef) -> TraitDecl {
         let mut tables = self.tables.borrow_mut();
         let cx = &*self.cx.borrow();
         let did = tables[trait_def.0];
         cx.trait_decl(did).stable(&mut *tables, cx)
     }
 
-    fn all_trait_impls(&self) -> ImplTraitDecls {
+    pub(crate) fn all_trait_impls(&self) -> ImplTraitDecls {
         let mut tables = self.tables.borrow_mut();
         let cx = &*self.cx.borrow();
         cx.all_trait_impls().iter().map(|did| tables.impl_def(*did)).collect()
     }
 
-    fn trait_impls(&self, crate_num: CrateNum) -> ImplTraitDecls {
+    pub(crate) fn trait_impls(&self, crate_num: CrateNum) -> ImplTraitDecls {
         let mut tables = self.tables.borrow_mut();
         let cx = &*self.cx.borrow();
         let krate = crate_num.internal(&mut *tables, cx.tcx);
         cx.trait_impls(krate).iter().map(|did| tables.impl_def(*did)).collect()
     }
 
-    fn trait_impl(&self, trait_impl: &ImplDef) -> ImplTrait {
+    pub(crate) fn trait_impl(&self, trait_impl: &ImplDef) -> ImplTrait {
         let mut tables = self.tables.borrow_mut();
         let cx = &*self.cx.borrow();
         let did = tables[trait_impl.0];
         cx.trait_impl(did).stable(&mut *tables, cx)
     }
 
-    fn generics_of(&self, def_id: DefId) -> Generics {
+    pub(crate) fn generics_of(&self, def_id: DefId) -> Generics {
         let mut tables = self.tables.borrow_mut();
         let cx = &*self.cx.borrow();
         let did = tables[def_id];
         cx.generics_of(did).stable(&mut *tables, cx)
     }
 
-    fn predicates_of(&self, def_id: DefId) -> GenericPredicates {
+    pub(crate) fn predicates_of(&self, def_id: DefId) -> GenericPredicates {
         let mut tables = self.tables.borrow_mut();
         let cx = &*self.cx.borrow();
         let did = tables[def_id];
@@ -448,7 +209,7 @@ impl<'tcx> CompilerInterface for Container<'tcx, BridgeTys> {
         }
     }
 
-    fn explicit_predicates_of(&self, def_id: DefId) -> GenericPredicates {
+    pub(crate) fn explicit_predicates_of(&self, def_id: DefId) -> GenericPredicates {
         let mut tables = self.tables.borrow_mut();
         let cx = &*self.cx.borrow();
         let did = tables[def_id];
@@ -463,25 +224,25 @@ impl<'tcx> CompilerInterface for Container<'tcx, BridgeTys> {
     }
 
     /// Get information about the local crate.
-    fn local_crate(&self) -> Crate {
+    pub(crate) fn local_crate(&self) -> Crate {
         let cx = &*self.cx.borrow();
         smir_crate(cx, cx.local_crate_num())
     }
 
     /// Retrieve a list of all external crates.
-    fn external_crates(&self) -> Vec<Crate> {
+    pub(crate) fn external_crates(&self) -> Vec<Crate> {
         let cx = &*self.cx.borrow();
         cx.external_crates().iter().map(|crate_num| smir_crate(cx, *crate_num)).collect()
     }
 
     /// Find a crate with the given name.
-    fn find_crates(&self, name: &str) -> Vec<Crate> {
+    pub(crate) fn find_crates(&self, name: &str) -> Vec<Crate> {
         let cx = &*self.cx.borrow();
         cx.find_crates(name).iter().map(|crate_num| smir_crate(cx, *crate_num)).collect()
     }
 
     /// Returns the name of given `DefId`.
-    fn def_name(&self, def_id: DefId, trimmed: bool) -> Symbol {
+    pub(crate) fn def_name(&self, def_id: DefId, trimmed: bool) -> Symbol {
         let tables = self.tables.borrow();
         let cx = &*self.cx.borrow();
         let did = tables[def_id];
@@ -495,7 +256,7 @@ impl<'tcx> CompilerInterface for Container<'tcx, BridgeTys> {
     ///
     /// Single segmented name like `#[clippy]` is specified as `&["clippy".to_string()]`.
     /// Multi-segmented name like `#[rustfmt::skip]` is specified as `&["rustfmt".to_string(), "skip".to_string()]`.
-    fn tool_attrs(&self, def_id: DefId, attr: &[Symbol]) -> Vec<Attribute> {
+    pub(crate) fn tool_attrs(&self, def_id: DefId, attr: &[Symbol]) -> Vec<Attribute> {
         let mut tables = self.tables.borrow_mut();
         let cx = &*self.cx.borrow();
         let did = tables[def_id];
@@ -506,7 +267,7 @@ impl<'tcx> CompilerInterface for Container<'tcx, BridgeTys> {
     }
 
     /// Get all tool attributes of a definition.
-    fn all_tool_attrs(&self, def_id: DefId) -> Vec<Attribute> {
+    pub(crate) fn all_tool_attrs(&self, def_id: DefId) -> Vec<Attribute> {
         let mut tables = self.tables.borrow_mut();
         let cx = &*self.cx.borrow();
         let did = tables[def_id];
@@ -517,7 +278,7 @@ impl<'tcx> CompilerInterface for Container<'tcx, BridgeTys> {
     }
 
     /// Returns printable, human readable form of `Span`.
-    fn span_to_string(&self, span: Span) -> String {
+    pub(crate) fn span_to_string(&self, span: Span) -> String {
         let tables = self.tables.borrow_mut();
         let cx = &*self.cx.borrow();
         let sp = tables.spans[span];
@@ -525,7 +286,7 @@ impl<'tcx> CompilerInterface for Container<'tcx, BridgeTys> {
     }
 
     /// Return filename from given `Span`, for diagnostic purposes.
-    fn get_filename(&self, span: &Span) -> Filename {
+    pub(crate) fn get_filename(&self, span: &Span) -> Filename {
         let tables = self.tables.borrow_mut();
         let cx = &*self.cx.borrow();
         let sp = tables.spans[*span];
@@ -533,7 +294,7 @@ impl<'tcx> CompilerInterface for Container<'tcx, BridgeTys> {
     }
 
     /// Return lines corresponding to this `Span`.
-    fn get_lines(&self, span: &Span) -> LineInfo {
+    pub(crate) fn get_lines(&self, span: &Span) -> LineInfo {
         let tables = self.tables.borrow_mut();
         let cx = &*self.cx.borrow();
         let sp = tables.spans[*span];
@@ -542,7 +303,7 @@ impl<'tcx> CompilerInterface for Container<'tcx, BridgeTys> {
     }
 
     /// Returns the `kind` of given `DefId`.
-    fn item_kind(&self, item: CrateItem) -> ItemKind {
+    pub(crate) fn item_kind(&self, item: CrateItem) -> ItemKind {
         let tables = self.tables.borrow();
         let cx = &*self.cx.borrow();
         let did = tables[item.0];
@@ -550,7 +311,7 @@ impl<'tcx> CompilerInterface for Container<'tcx, BridgeTys> {
     }
 
     /// Returns whether this is a foreign item.
-    fn is_foreign_item(&self, item: DefId) -> bool {
+    pub(crate) fn is_foreign_item(&self, item: DefId) -> bool {
         let tables = self.tables.borrow();
         let cx = &*self.cx.borrow();
         let did = tables[item];
@@ -558,7 +319,7 @@ impl<'tcx> CompilerInterface for Container<'tcx, BridgeTys> {
     }
 
     /// Returns the kind of a given foreign item.
-    fn foreign_item_kind(&self, def: ForeignDef) -> ForeignItemKind {
+    pub(crate) fn foreign_item_kind(&self, def: ForeignDef) -> ForeignItemKind {
         let mut tables = self.tables.borrow_mut();
         let cx = &*self.cx.borrow();
         let def_id = tables[def.def_id()];
@@ -575,42 +336,42 @@ impl<'tcx> CompilerInterface for Container<'tcx, BridgeTys> {
     }
 
     /// Returns the kind of a given algebraic data type.
-    fn adt_kind(&self, def: AdtDef) -> AdtKind {
+    pub(crate) fn adt_kind(&self, def: AdtDef) -> AdtKind {
         let mut tables = self.tables.borrow_mut();
         let cx = &*self.cx.borrow();
         cx.adt_kind(def.internal(&mut *tables, cx.tcx)).stable(&mut *tables, cx)
     }
 
     /// Returns if the ADT is a box.
-    fn adt_is_box(&self, def: AdtDef) -> bool {
+    pub(crate) fn adt_is_box(&self, def: AdtDef) -> bool {
         let mut tables = self.tables.borrow_mut();
         let cx = &*self.cx.borrow();
         cx.adt_is_box(def.internal(&mut *tables, cx.tcx))
     }
 
     /// Returns whether this ADT is simd.
-    fn adt_is_simd(&self, def: AdtDef) -> bool {
+    pub(crate) fn adt_is_simd(&self, def: AdtDef) -> bool {
         let mut tables = self.tables.borrow_mut();
         let cx = &*self.cx.borrow();
         cx.adt_is_simd(def.internal(&mut *tables, cx.tcx))
     }
 
     /// Returns whether this definition is a C string.
-    fn adt_is_cstr(&self, def: AdtDef) -> bool {
+    pub(crate) fn adt_is_cstr(&self, def: AdtDef) -> bool {
         let mut tables = self.tables.borrow_mut();
         let cx = &*self.cx.borrow();
         cx.adt_is_cstr(def.0.internal(&mut *tables, cx.tcx))
     }
 
     /// Returns the representation options for this ADT
-    fn adt_repr(&self, def: AdtDef) -> ReprOptions {
+    pub(crate) fn adt_repr(&self, def: AdtDef) -> ReprOptions {
         let mut tables = self.tables.borrow_mut();
         let cx = &*self.cx.borrow();
         cx.adt_repr(def.internal(&mut *tables, cx.tcx)).stable(&mut *tables, cx)
     }
 
     /// Retrieve the function signature for the given generic arguments.
-    fn fn_sig(&self, def: FnDef, args: &GenericArgs) -> PolyFnSig {
+    pub(crate) fn fn_sig(&self, def: FnDef, args: &GenericArgs) -> PolyFnSig {
         let mut tables = self.tables.borrow_mut();
         let cx = &*self.cx.borrow();
         let def_id = def.0.internal(&mut *tables, cx.tcx);
@@ -619,7 +380,7 @@ impl<'tcx> CompilerInterface for Container<'tcx, BridgeTys> {
     }
 
     /// Retrieve the intrinsic definition if the item corresponds one.
-    fn intrinsic(&self, item: DefId) -> Option<IntrinsicDef> {
+    pub(crate) fn intrinsic(&self, item: DefId) -> Option<IntrinsicDef> {
         let mut tables = self.tables.borrow_mut();
         let cx = &*self.cx.borrow();
         let def_id = item.internal(&mut *tables, cx.tcx);
@@ -627,7 +388,7 @@ impl<'tcx> CompilerInterface for Container<'tcx, BridgeTys> {
     }
 
     /// Retrieve the plain function name of an intrinsic.
-    fn intrinsic_name(&self, def: IntrinsicDef) -> Symbol {
+    pub(crate) fn intrinsic_name(&self, def: IntrinsicDef) -> Symbol {
         let mut tables = self.tables.borrow_mut();
         let cx = &*self.cx.borrow();
         let def_id = def.0.internal(&mut *tables, cx.tcx);
@@ -635,7 +396,7 @@ impl<'tcx> CompilerInterface for Container<'tcx, BridgeTys> {
     }
 
     /// Retrieve the closure signature for the given generic arguments.
-    fn closure_sig(&self, args: &GenericArgs) -> PolyFnSig {
+    pub(crate) fn closure_sig(&self, args: &GenericArgs) -> PolyFnSig {
         let mut tables = self.tables.borrow_mut();
         let cx = &*self.cx.borrow();
         let args_ref = args.internal(&mut *tables, cx.tcx);
@@ -643,14 +404,14 @@ impl<'tcx> CompilerInterface for Container<'tcx, BridgeTys> {
     }
 
     /// The number of variants in this ADT.
-    fn adt_variants_len(&self, def: AdtDef) -> usize {
+    pub(crate) fn adt_variants_len(&self, def: AdtDef) -> usize {
         let mut tables = self.tables.borrow_mut();
         let cx = &*self.cx.borrow();
         cx.adt_variants_len(def.internal(&mut *tables, cx.tcx))
     }
 
     /// Discriminant for a given variant index of AdtDef.
-    fn adt_discr_for_variant(&self, adt: AdtDef, variant: VariantIdx) -> Discr {
+    pub(crate) fn adt_discr_for_variant(&self, adt: AdtDef, variant: VariantIdx) -> Discr {
         let mut tables = self.tables.borrow_mut();
         let cx = &*self.cx.borrow();
         cx.adt_discr_for_variant(
@@ -661,7 +422,7 @@ impl<'tcx> CompilerInterface for Container<'tcx, BridgeTys> {
     }
 
     /// Discriminant for a given variand index and args of a coroutine.
-    fn coroutine_discr_for_variant(
+    pub(crate) fn coroutine_discr_for_variant(
         &self,
         coroutine: CoroutineDef,
         args: &GenericArgs,
@@ -677,13 +438,13 @@ impl<'tcx> CompilerInterface for Container<'tcx, BridgeTys> {
     }
 
     /// The name of a variant.
-    fn variant_name(&self, def: VariantDef) -> Symbol {
+    pub(crate) fn variant_name(&self, def: VariantDef) -> Symbol {
         let mut tables = self.tables.borrow_mut();
         let cx = &*self.cx.borrow();
         cx.variant_name(def.internal(&mut *tables, cx.tcx))
     }
 
-    fn variant_fields(&self, def: VariantDef) -> Vec<FieldDef> {
+    pub(crate) fn variant_fields(&self, def: VariantDef) -> Vec<FieldDef> {
         let mut tables = self.tables.borrow_mut();
         let cx = &*self.cx.borrow();
         def.internal(&mut *tables, cx.tcx)
@@ -694,14 +455,14 @@ impl<'tcx> CompilerInterface for Container<'tcx, BridgeTys> {
     }
 
     /// Evaluate constant as a target usize.
-    fn eval_target_usize(&self, mir_const: &MirConst) -> Result<u64, Error> {
+    pub(crate) fn eval_target_usize(&self, mir_const: &MirConst) -> Result<u64, Error> {
         let mut tables = self.tables.borrow_mut();
         let cx = &*self.cx.borrow();
         let cnst = mir_const.internal(&mut *tables, cx.tcx);
         cx.eval_target_usize(cnst)
     }
 
-    fn eval_target_usize_ty(&self, ty_const: &TyConst) -> Result<u64, Error> {
+    pub(crate) fn eval_target_usize_ty(&self, ty_const: &TyConst) -> Result<u64, Error> {
         let mut tables = self.tables.borrow_mut();
         let cx = &*self.cx.borrow();
         let cnst = ty_const.internal(&mut *tables, cx.tcx);
@@ -709,7 +470,7 @@ impl<'tcx> CompilerInterface for Container<'tcx, BridgeTys> {
     }
 
     /// Create a new zero-sized constant.
-    fn try_new_const_zst(&self, ty: Ty) -> Result<MirConst, Error> {
+    pub(crate) fn try_new_const_zst(&self, ty: Ty) -> Result<MirConst, Error> {
         let mut tables = self.tables.borrow_mut();
         let cx = &*self.cx.borrow();
         let ty_internal = ty.internal(&mut *tables, cx.tcx);
@@ -717,28 +478,36 @@ impl<'tcx> CompilerInterface for Container<'tcx, BridgeTys> {
     }
 
     /// Create a new constant that represents the given string value.
-    fn new_const_str(&self, value: &str) -> MirConst {
+    pub(crate) fn new_const_str(&self, value: &str) -> MirConst {
         let mut tables = self.tables.borrow_mut();
         let cx = &*self.cx.borrow();
         cx.new_const_str(value).stable(&mut *tables, cx)
     }
 
     /// Create a new constant that represents the given boolean value.
-    fn new_const_bool(&self, value: bool) -> MirConst {
+    pub(crate) fn new_const_bool(&self, value: bool) -> MirConst {
         let mut tables = self.tables.borrow_mut();
         let cx = &*self.cx.borrow();
         cx.new_const_bool(value).stable(&mut *tables, cx)
     }
 
     /// Create a new constant that represents the given value.
-    fn try_new_const_uint(&self, value: u128, uint_ty: UintTy) -> Result<MirConst, Error> {
+    pub(crate) fn try_new_const_uint(
+        &self,
+        value: u128,
+        uint_ty: UintTy,
+    ) -> Result<MirConst, Error> {
         let mut tables = self.tables.borrow_mut();
         let cx = &*self.cx.borrow();
         let ty = cx.ty_new_uint(uint_ty.internal(&mut *tables, cx.tcx));
         cx.try_new_const_uint(value, ty).map(|cnst| cnst.stable(&mut *tables, cx))
     }
 
-    fn try_new_ty_const_uint(&self, value: u128, uint_ty: UintTy) -> Result<TyConst, Error> {
+    pub(crate) fn try_new_ty_const_uint(
+        &self,
+        value: u128,
+        uint_ty: UintTy,
+    ) -> Result<TyConst, Error> {
         let mut tables = self.tables.borrow_mut();
         let cx = &*self.cx.borrow();
         let ty = cx.ty_new_uint(uint_ty.internal(&mut *tables, cx.tcx));
@@ -746,7 +515,7 @@ impl<'tcx> CompilerInterface for Container<'tcx, BridgeTys> {
     }
 
     /// Create a new type from the given kind.
-    fn new_rigid_ty(&self, kind: RigidTy) -> Ty {
+    pub(crate) fn new_rigid_ty(&self, kind: RigidTy) -> Ty {
         let mut tables = self.tables.borrow_mut();
         let cx = &*self.cx.borrow();
         let internal_kind = kind.internal(&mut *tables, cx.tcx);
@@ -754,7 +523,7 @@ impl<'tcx> CompilerInterface for Container<'tcx, BridgeTys> {
     }
 
     /// Create a new box type, `Box<T>`, for the given inner type `T`.
-    fn new_box_ty(&self, ty: Ty) -> Ty {
+    pub(crate) fn new_box_ty(&self, ty: Ty) -> Ty {
         let mut tables = self.tables.borrow_mut();
         let cx = &*self.cx.borrow();
         let inner = ty.internal(&mut *tables, cx.tcx);
@@ -762,7 +531,7 @@ impl<'tcx> CompilerInterface for Container<'tcx, BridgeTys> {
     }
 
     /// Returns the type of given crate item.
-    fn def_ty(&self, item: DefId) -> Ty {
+    pub(crate) fn def_ty(&self, item: DefId) -> Ty {
         let mut tables = self.tables.borrow_mut();
         let cx = &*self.cx.borrow();
         let inner = item.internal(&mut *tables, cx.tcx);
@@ -770,7 +539,7 @@ impl<'tcx> CompilerInterface for Container<'tcx, BridgeTys> {
     }
 
     /// Returns the type of given definition instantiated with the given arguments.
-    fn def_ty_with_args(&self, item: DefId, args: &GenericArgs) -> Ty {
+    pub(crate) fn def_ty_with_args(&self, item: DefId, args: &GenericArgs) -> Ty {
         let mut tables = self.tables.borrow_mut();
         let cx = &*self.cx.borrow();
         let inner = item.internal(&mut *tables, cx.tcx);
@@ -779,42 +548,42 @@ impl<'tcx> CompilerInterface for Container<'tcx, BridgeTys> {
     }
 
     /// Returns literal value of a const as a string.
-    fn mir_const_pretty(&self, cnst: &MirConst) -> String {
+    pub(crate) fn mir_const_pretty(&self, cnst: &MirConst) -> String {
         let mut tables = self.tables.borrow_mut();
         let cx = &*self.cx.borrow();
         cnst.internal(&mut *tables, cx.tcx).to_string()
     }
 
     /// `Span` of an item.
-    fn span_of_an_item(&self, def_id: DefId) -> Span {
+    pub(crate) fn span_of_an_item(&self, def_id: DefId) -> Span {
         let mut tables = self.tables.borrow_mut();
         let cx = &*self.cx.borrow();
         let did = tables[def_id];
         cx.span_of_an_item(did).stable(&mut *tables, cx)
     }
 
-    fn ty_const_pretty(&self, ct: TyConstId) -> String {
+    pub(crate) fn ty_const_pretty(&self, ct: TyConstId) -> String {
         let tables = self.tables.borrow_mut();
         let cx = &*self.cx.borrow();
         cx.ty_const_pretty(tables.ty_consts[ct])
     }
 
     /// Obtain the representation of a type.
-    fn ty_pretty(&self, ty: Ty) -> String {
+    pub(crate) fn ty_pretty(&self, ty: Ty) -> String {
         let tables = self.tables.borrow_mut();
         let cx = &*self.cx.borrow();
         cx.ty_pretty(tables.types[ty])
     }
 
     /// Obtain the kind of a type.
-    fn ty_kind(&self, ty: Ty) -> TyKind {
+    pub(crate) fn ty_kind(&self, ty: Ty) -> TyKind {
         let mut tables = self.tables.borrow_mut();
         let cx = &*self.cx.borrow();
         cx.ty_kind(tables.types[ty]).stable(&mut *tables, cx)
     }
 
     /// Get the discriminant Ty for this Ty if there's one.
-    fn rigid_ty_discriminant_ty(&self, ty: &RigidTy) -> Ty {
+    pub(crate) fn rigid_ty_discriminant_ty(&self, ty: &RigidTy) -> Ty {
         let mut tables = self.tables.borrow_mut();
         let cx = &*self.cx.borrow();
         let internal_kind = ty.internal(&mut *tables, cx.tcx);
@@ -822,7 +591,7 @@ impl<'tcx> CompilerInterface for Container<'tcx, BridgeTys> {
     }
 
     /// Get the body of an Instance which is already monomorphized.
-    fn instance_body(&self, instance: InstanceDef) -> Option<Body> {
+    pub(crate) fn instance_body(&self, instance: InstanceDef) -> Option<Body> {
         let mut tables = self.tables.borrow_mut();
         let cx = &*self.cx.borrow();
         let instance = tables.instances[instance];
@@ -830,7 +599,7 @@ impl<'tcx> CompilerInterface for Container<'tcx, BridgeTys> {
     }
 
     /// Get the instance type with generic instantiations applied and lifetimes erased.
-    fn instance_ty(&self, instance: InstanceDef) -> Ty {
+    pub(crate) fn instance_ty(&self, instance: InstanceDef) -> Ty {
         let mut tables = self.tables.borrow_mut();
         let cx = &*self.cx.borrow();
         let instance = tables.instances[instance];
@@ -838,7 +607,7 @@ impl<'tcx> CompilerInterface for Container<'tcx, BridgeTys> {
     }
 
     /// Get the instantiation types.
-    fn instance_args(&self, def: InstanceDef) -> GenericArgs {
+    pub(crate) fn instance_args(&self, def: InstanceDef) -> GenericArgs {
         let mut tables = self.tables.borrow_mut();
         let cx = &*self.cx.borrow();
         let instance = tables.instances[def];
@@ -846,7 +615,7 @@ impl<'tcx> CompilerInterface for Container<'tcx, BridgeTys> {
     }
 
     /// Get the instance.
-    fn instance_def_id(&self, instance: InstanceDef) -> DefId {
+    pub(crate) fn instance_def_id(&self, instance: InstanceDef) -> DefId {
         let mut tables = self.tables.borrow_mut();
         let cx = &*self.cx.borrow();
         let instance = tables.instances[instance];
@@ -854,7 +623,7 @@ impl<'tcx> CompilerInterface for Container<'tcx, BridgeTys> {
     }
 
     /// Get the instance mangled name.
-    fn instance_mangled_name(&self, instance: InstanceDef) -> Symbol {
+    pub(crate) fn instance_mangled_name(&self, instance: InstanceDef) -> Symbol {
         let tables = self.tables.borrow_mut();
         let cx = &*self.cx.borrow();
         let instance = tables.instances[instance];
@@ -862,7 +631,7 @@ impl<'tcx> CompilerInterface for Container<'tcx, BridgeTys> {
     }
 
     /// Check if this is an empty DropGlue shim.
-    fn is_empty_drop_shim(&self, def: InstanceDef) -> bool {
+    pub(crate) fn is_empty_drop_shim(&self, def: InstanceDef) -> bool {
         let tables = self.tables.borrow_mut();
         let cx = &*self.cx.borrow();
         let instance = tables.instances[def];
@@ -871,7 +640,7 @@ impl<'tcx> CompilerInterface for Container<'tcx, BridgeTys> {
 
     /// Convert a non-generic crate item into an instance.
     /// This function will panic if the item is generic.
-    fn mono_instance(&self, def_id: DefId) -> Instance {
+    pub(crate) fn mono_instance(&self, def_id: DefId) -> Instance {
         let mut tables = self.tables.borrow_mut();
         let cx = &*self.cx.borrow();
         let did = tables[def_id];
@@ -879,7 +648,7 @@ impl<'tcx> CompilerInterface for Container<'tcx, BridgeTys> {
     }
 
     /// Item requires monomorphization.
-    fn requires_monomorphization(&self, def_id: DefId) -> bool {
+    pub(crate) fn requires_monomorphization(&self, def_id: DefId) -> bool {
         let tables = self.tables.borrow();
         let cx = &*self.cx.borrow();
         let did = tables[def_id];
@@ -887,7 +656,7 @@ impl<'tcx> CompilerInterface for Container<'tcx, BridgeTys> {
     }
 
     /// Resolve an instance from the given function definition and generic arguments.
-    fn resolve_instance(&self, def: FnDef, args: &GenericArgs) -> Option<Instance> {
+    pub(crate) fn resolve_instance(&self, def: FnDef, args: &GenericArgs) -> Option<Instance> {
         let mut tables = self.tables.borrow_mut();
         let cx = &*self.cx.borrow();
         let def_id = def.0.internal(&mut *tables, cx.tcx);
@@ -896,7 +665,7 @@ impl<'tcx> CompilerInterface for Container<'tcx, BridgeTys> {
     }
 
     /// Resolve an instance for drop_in_place for the given type.
-    fn resolve_drop_in_place(&self, ty: Ty) -> Instance {
+    pub(crate) fn resolve_drop_in_place(&self, ty: Ty) -> Instance {
         let mut tables = self.tables.borrow_mut();
         let cx = &*self.cx.borrow();
         let internal_ty = ty.internal(&mut *tables, cx.tcx);
@@ -905,7 +674,7 @@ impl<'tcx> CompilerInterface for Container<'tcx, BridgeTys> {
     }
 
     /// Resolve instance for a function pointer.
-    fn resolve_for_fn_ptr(&self, def: FnDef, args: &GenericArgs) -> Option<Instance> {
+    pub(crate) fn resolve_for_fn_ptr(&self, def: FnDef, args: &GenericArgs) -> Option<Instance> {
         let mut tables = self.tables.borrow_mut();
         let cx = &*self.cx.borrow();
         let def_id = def.0.internal(&mut *tables, cx.tcx);
@@ -914,7 +683,7 @@ impl<'tcx> CompilerInterface for Container<'tcx, BridgeTys> {
     }
 
     /// Resolve instance for a closure with the requested type.
-    fn resolve_closure(
+    pub(crate) fn resolve_closure(
         &self,
         def: ClosureDef,
         args: &GenericArgs,
@@ -929,7 +698,7 @@ impl<'tcx> CompilerInterface for Container<'tcx, BridgeTys> {
     }
 
     /// Evaluate a static's initializer.
-    fn eval_static_initializer(&self, def: StaticDef) -> Result<Allocation, Error> {
+    pub(crate) fn eval_static_initializer(&self, def: StaticDef) -> Result<Allocation, Error> {
         let mut tables = self.tables.borrow_mut();
         let cx = &*self.cx.borrow();
         let def_id = def.0.internal(&mut *tables, cx.tcx);
@@ -938,7 +707,11 @@ impl<'tcx> CompilerInterface for Container<'tcx, BridgeTys> {
     }
 
     /// Try to evaluate an instance into a constant.
-    fn eval_instance(&self, def: InstanceDef, const_ty: Ty) -> Result<Allocation, Error> {
+    pub(crate) fn eval_instance(
+        &self,
+        def: InstanceDef,
+        const_ty: Ty,
+    ) -> Result<Allocation, Error> {
         let mut tables = self.tables.borrow_mut();
         let instance = tables.instances[def];
         let cx = &*self.cx.borrow();
@@ -949,7 +722,7 @@ impl<'tcx> CompilerInterface for Container<'tcx, BridgeTys> {
     }
 
     /// Retrieve global allocation for the given allocation ID.
-    fn global_alloc(&self, id: AllocId) -> GlobalAlloc {
+    pub(crate) fn global_alloc(&self, id: AllocId) -> GlobalAlloc {
         let mut tables = self.tables.borrow_mut();
         let cx = &*self.cx.borrow();
         let alloc_id = id.internal(&mut *tables, cx.tcx);
@@ -957,7 +730,7 @@ impl<'tcx> CompilerInterface for Container<'tcx, BridgeTys> {
     }
 
     /// Retrieve the id for the virtual table.
-    fn vtable_allocation(&self, global_alloc: &GlobalAlloc) -> Option<AllocId> {
+    pub(crate) fn vtable_allocation(&self, global_alloc: &GlobalAlloc) -> Option<AllocId> {
         let mut tables = self.tables.borrow_mut();
         let GlobalAlloc::VTable(ty, trait_ref) = global_alloc else {
             return None;
@@ -969,13 +742,13 @@ impl<'tcx> CompilerInterface for Container<'tcx, BridgeTys> {
         Some(alloc_id.stable(&mut *tables, cx))
     }
 
-    fn krate(&self, def_id: DefId) -> Crate {
+    pub(crate) fn krate(&self, def_id: DefId) -> Crate {
         let tables = self.tables.borrow();
         let cx = &*self.cx.borrow();
         smir_crate(cx, tables[def_id].krate)
     }
 
-    fn instance_name(&self, def: InstanceDef, trimmed: bool) -> Symbol {
+    pub(crate) fn instance_name(&self, def: InstanceDef, trimmed: bool) -> Symbol {
         let tables = self.tables.borrow_mut();
         let cx = &*self.cx.borrow();
         let instance = tables.instances[def];
@@ -983,7 +756,7 @@ impl<'tcx> CompilerInterface for Container<'tcx, BridgeTys> {
     }
 
     /// Return information about the target machine.
-    fn target_info(&self) -> MachineInfo {
+    pub(crate) fn target_info(&self) -> MachineInfo {
         let mut tables = self.tables.borrow_mut();
         let cx = &*self.cx.borrow();
         MachineInfo {
@@ -993,7 +766,7 @@ impl<'tcx> CompilerInterface for Container<'tcx, BridgeTys> {
     }
 
     /// Get an instance ABI.
-    fn instance_abi(&self, def: InstanceDef) -> Result<FnAbi, Error> {
+    pub(crate) fn instance_abi(&self, def: InstanceDef) -> Result<FnAbi, Error> {
         let mut tables = self.tables.borrow_mut();
         let cx = &*self.cx.borrow();
         let instance = tables.instances[def];
@@ -1001,7 +774,7 @@ impl<'tcx> CompilerInterface for Container<'tcx, BridgeTys> {
     }
 
     /// Get the ABI of a function pointer.
-    fn fn_ptr_abi(&self, fn_ptr: PolyFnSig) -> Result<FnAbi, Error> {
+    pub(crate) fn fn_ptr_abi(&self, fn_ptr: PolyFnSig) -> Result<FnAbi, Error> {
         let mut tables = self.tables.borrow_mut();
         let cx = &*self.cx.borrow();
         let sig = fn_ptr.internal(&mut *tables, cx.tcx);
@@ -1009,7 +782,7 @@ impl<'tcx> CompilerInterface for Container<'tcx, BridgeTys> {
     }
 
     /// Get the layout of a type.
-    fn ty_layout(&self, ty: Ty) -> Result<Layout, Error> {
+    pub(crate) fn ty_layout(&self, ty: Ty) -> Result<Layout, Error> {
         let mut tables = self.tables.borrow_mut();
         let cx = &*self.cx.borrow();
         let internal_ty = ty.internal(&mut *tables, cx.tcx);
@@ -1017,14 +790,14 @@ impl<'tcx> CompilerInterface for Container<'tcx, BridgeTys> {
     }
 
     /// Get the layout shape.
-    fn layout_shape(&self, id: Layout) -> LayoutShape {
+    pub(crate) fn layout_shape(&self, id: Layout) -> LayoutShape {
         let mut tables = self.tables.borrow_mut();
         let cx = &*self.cx.borrow();
         id.internal(&mut *tables, cx.tcx).0.stable(&mut *tables, cx)
     }
 
     /// Get a debug string representation of a place.
-    fn place_pretty(&self, place: &Place) -> String {
+    pub(crate) fn place_pretty(&self, place: &Place) -> String {
         let mut tables = self.tables.borrow_mut();
         let cx = &*self.cx.borrow();
 
@@ -1032,7 +805,7 @@ impl<'tcx> CompilerInterface for Container<'tcx, BridgeTys> {
     }
 
     /// Get the resulting type of binary operation.
-    fn binop_ty(&self, bin_op: BinOp, rhs: Ty, lhs: Ty) -> Ty {
+    pub(crate) fn binop_ty(&self, bin_op: BinOp, rhs: Ty, lhs: Ty) -> Ty {
         let mut tables = self.tables.borrow_mut();
         let cx = &*self.cx.borrow();
         let rhs_internal = rhs.internal(&mut *tables, cx.tcx);
@@ -1042,7 +815,7 @@ impl<'tcx> CompilerInterface for Container<'tcx, BridgeTys> {
     }
 
     /// Get the resulting type of unary operation.
-    fn unop_ty(&self, un_op: UnOp, arg: Ty) -> Ty {
+    pub(crate) fn unop_ty(&self, un_op: UnOp, arg: Ty) -> Ty {
         let mut tables = self.tables.borrow_mut();
         let cx = &*self.cx.borrow();
         let un_op = un_op.internal(&mut *tables, cx.tcx);
@@ -1051,7 +824,7 @@ impl<'tcx> CompilerInterface for Container<'tcx, BridgeTys> {
     }
 
     /// Get all associated items of a definition.
-    fn associated_items(&self, def_id: DefId) -> AssocItems {
+    pub(crate) fn associated_items(&self, def_id: DefId) -> AssocItems {
         let mut tables = self.tables.borrow_mut();
         let cx = &*self.cx.borrow();
         let did = tables[def_id];
@@ -1062,7 +835,7 @@ impl<'tcx> CompilerInterface for Container<'tcx, BridgeTys> {
 // A thread local variable that stores a pointer to [`CompilerInterface`].
 scoped_tls::scoped_thread_local!(static TLV: Cell<*const ()>);
 
-pub(crate) fn run<F, T>(interface: &dyn CompilerInterface, f: F) -> Result<T, Error>
+pub(crate) fn run<'tcx, F, T>(interface: &CompilerInterface<'tcx>, f: F) -> Result<T, Error>
 where
     F: FnOnce() -> T,
 {
@@ -1078,12 +851,12 @@ where
 ///
 /// I.e., This function will load the current interface and calls a function with it.
 /// Do not nest these, as that will ICE.
-pub(crate) fn with<R>(f: impl FnOnce(&dyn CompilerInterface) -> R) -> R {
+pub(crate) fn with<R>(f: impl for<'tcx> FnOnce(&CompilerInterface<'tcx>) -> R) -> R {
     assert!(TLV.is_set());
     TLV.with(|tlv| {
         let ptr = tlv.get();
         assert!(!ptr.is_null());
-        f(unsafe { *(ptr as *const &dyn CompilerInterface) })
+        f(unsafe { *(ptr as *const &CompilerInterface<'_>) })
     })
 }
 

--- a/compiler/rustc_public/src/rustc_internal/mod.rs
+++ b/compiler/rustc_public/src/rustc_internal/mod.rs
@@ -3,15 +3,15 @@
 //! For that, we define APIs that will temporarily be public to 3P that exposes rustc internal APIs
 //! until rustc_public's IR is complete.
 
-use std::cell::{Cell, RefCell};
+use std::cell::RefCell;
 
 use rustc_middle::ty::TyCtxt;
+use rustc_public_bridge::Tables;
 use rustc_public_bridge::context::CompilerCtxt;
-use rustc_public_bridge::{Bridge, Container, Tables};
 use rustc_span::def_id::CrateNum;
-use scoped_tls::scoped_thread_local;
 
 use crate::Error;
+use crate::compiler_interface::{BridgeTys, CompilerInterface, with};
 use crate::unstable::{RustcInternal, Stable};
 
 pub mod pretty;
@@ -28,7 +28,7 @@ pub mod pretty;
 ///
 /// This function will panic if rustc_public has not been properly initialized.
 pub fn stable<'tcx, S: Stable<'tcx>>(item: S) -> S::T {
-    with_container(|tables, cx| item.stable(tables, cx))
+    with_bridge(|tables, cx| item.stable(tables, cx))
 }
 
 /// Convert a stable item into its internal Rust compiler counterpart, if one exists.
@@ -49,38 +49,21 @@ where
     // The tcx argument ensures that the item won't outlive the type context.
     // See https://github.com/rust-lang/rust/pull/120128/commits/9aace6723572438a94378451793ca37deb768e72
     // for more details.
-    with_container(|tables, _| item.internal(tables, tcx))
+    with_bridge(|tables, _| item.internal(tables, tcx))
 }
 
 pub fn crate_num(item: &crate::Crate) -> CrateNum {
     item.id.into()
 }
 
-// A thread local variable that stores a pointer to the tables mapping between TyCtxt
-// datastructures and rustc_public's IR datastructures
-scoped_thread_local! (static TLV: Cell<*const ()>);
-
-pub(crate) fn init<'tcx, F, T, B: Bridge>(container: &Container<'tcx, B>, f: F) -> T
-where
-    F: FnOnce() -> T,
-{
-    assert!(!TLV.is_set());
-    let ptr = container as *const _ as *const ();
-    TLV.set(&Cell::new(ptr), || f())
-}
-
 /// Loads the current context and calls a function with it.
 /// Do not nest these, as that will ICE.
-pub(crate) fn with_container<R, B: Bridge>(
-    f: impl for<'tcx> FnOnce(&mut Tables<'tcx, B>, &CompilerCtxt<'tcx, B>) -> R,
+pub(crate) fn with_bridge<R>(
+    f: impl for<'tcx> FnOnce(&mut Tables<'tcx, BridgeTys>, &CompilerCtxt<'tcx, BridgeTys>) -> R,
 ) -> R {
-    assert!(TLV.is_set());
-    TLV.with(|tlv| {
-        let ptr = tlv.get();
-        assert!(!ptr.is_null());
-        let container = ptr as *const Container<'_, B>;
-        let mut tables = unsafe { (*container).tables.borrow_mut() };
-        let cx = unsafe { (*container).cx.borrow() };
+    with(|compiler| {
+        let mut tables = compiler.tables.borrow_mut();
+        let cx = compiler.cx.borrow();
         f(&mut *tables, &*cx)
     })
 }
@@ -90,9 +73,10 @@ where
     F: FnOnce() -> T,
 {
     let compiler_cx = RefCell::new(CompilerCtxt::new(tcx));
-    let container = Container { tables: RefCell::new(Tables::default()), cx: compiler_cx };
+    let compiler_interface =
+        CompilerInterface { tables: RefCell::new(Tables::default()), cx: compiler_cx };
 
-    crate::compiler_interface::run(&container, || init(&container, f))
+    crate::compiler_interface::run(&compiler_interface, || f())
 }
 
 /// Instantiate and run the compiler with the provided arguments and callback.

--- a/compiler/rustc_public_bridge/src/lib.rs
+++ b/compiler/rustc_public_bridge/src/lib.rs
@@ -24,7 +24,6 @@
 #![feature(trait_alias)]
 // tidy-alphabetical-end
 
-use std::cell::RefCell;
 use std::fmt::Debug;
 use std::hash::Hash;
 use std::ops::Index;
@@ -48,12 +47,6 @@ pub mod rustc_internal {}
 
 /// Trait alias for types that can be cached in [`Tables`].
 pub trait Cacheable = Copy + Debug + PartialEq + IndexedVal;
-
-/// A container which is used for TLS.
-pub struct Container<'tcx, B: Bridge> {
-    pub tables: RefCell<Tables<'tcx, B>>,
-    pub cx: RefCell<CompilerCtxt<'tcx, B>>,
-}
 
 pub struct Tables<'tcx, B: Bridge> {
     pub def_ids: IndexMap<DefId, B::DefId>,


### PR DESCRIPTION
We no longer need two thread-local variables to store the context. We used to have two because the conversion logic used to live in a separate crate from the rest of the business logic.

I'm also merging the Container struct and the CompilerInterface trait as a single struct. This removes the unnecessary indirection and code duplication. Using a trait would also block us from adding any generic method to the compiler interface.

r? @oli-obk 

cc: @makai410 