### PR TITLE
Fix tests for big-endian

### DIFF
--- a/tests/mir-opt/const_prop/invalid_constant.main.GVN.diff
+++ b/tests/mir-opt/const_prop/invalid_constant.main.GVN.diff
@@ -61,17 +61,11 @@
           StorageDead(_1);
           return;
       }
-+ }
-+ 
-+ ALLOC0 (size: 4, align: 4) {
-+     00 00 00 00                                     │ ....
-+ }
-+ 
-+ ALLOC1 (size: 4, align: 4) {
-+     04 00 00 00                                     │ ....
-+ }
-+ 
-+ ALLOC2 (size: 4, align: 4) {
-+     01 00 11 00                                     │ ....
   }
++ 
++ ALLOC0 (size: 4, align: 4) { .. }
++ 
++ ALLOC1 (size: 4, align: 4) { .. }
++ 
++ ALLOC2 (size: 4, align: 4) { .. }
   

--- a/tests/mir-opt/const_prop/invalid_constant.rs
+++ b/tests/mir-opt/const_prop/invalid_constant.rs
@@ -1,6 +1,6 @@
 // skip-filecheck
 //@ test-mir-pass: GVN
-//@ compile-flags: -Zmir-enable-passes=+RemoveZsts
+//@ compile-flags: -Zmir-enable-passes=+RemoveZsts -Zdump-mir-exclude-alloc-bytes
 // Verify that we can pretty print invalid constants.
 
 #![feature(adt_const_params, unsized_const_params)]

--- a/tests/mir-opt/const_prop/union.main.GVN.diff
+++ b/tests/mir-opt/const_prop/union.main.GVN.diff
@@ -34,9 +34,7 @@
           StorageDead(_1);
           return;
       }
-+ }
-+ 
-+ ALLOC0 (size: 4, align: 4) {
-+     01 00 00 00                                     │ ....
   }
++ 
++ ALLOC0 (size: 4, align: 4) { .. }
   

--- a/tests/mir-opt/const_prop/union.rs
+++ b/tests/mir-opt/const_prop/union.rs
@@ -1,6 +1,6 @@
 //! Tests that we can propagate into places that are projections into unions
 //@ test-mir-pass: GVN
-//@ compile-flags: -Zinline-mir
+//@ compile-flags: -Zinline-mir -Zdump-mir-exclude-alloc-bytes
 
 fn val() -> u32 {
     1

--- a/tests/mir-opt/gvn_loop.loop_deref_mut.GVN.diff
+++ b/tests/mir-opt/gvn_loop.loop_deref_mut.GVN.diff
@@ -107,9 +107,7 @@
           StorageDead(_11);
           goto -> bb4;
       }
-+ }
-+ 
-+ ALLOC0 (size: 8, align: 4) {
-+     01 00 00 00 __ __ __ __                         │ ....░░░░
   }
++ 
++ ALLOC0 (size: 8, align: 4) { .. }
   

--- a/tests/mir-opt/gvn_loop.rs
+++ b/tests/mir-opt/gvn_loop.rs
@@ -1,4 +1,5 @@
 //@ test-mir-pass: GVN
+//@ compile-flags: -Zdump-mir-exclude-alloc-bytes
 
 #![crate_type = "lib"]
 #![feature(core_intrinsics, rustc_attrs)]


### PR DESCRIPTION
The tests fail on s390x and presumably other big-endian systems, due to check of raw alloc values in the MIR output.

To fix the tests remove the raw bytes from the MIR output (via: compile-flags: -Zdump-mir-exclude-alloc-bytes) and update the matching diffs.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
