### PR TITLE
motor: Add new `set_times` stubs

### DIFF
--- a/library/std/src/sys/fs/motor.rs
+++ b/library/std/src/sys/fs/motor.rs
@@ -324,6 +324,14 @@ pub fn set_perm(path: &Path, perm: FilePermissions) -> io::Result<()> {
     moto_rt::fs::set_perm(path, perm.rt_perm).map_err(map_motor_error)
 }
 
+pub fn set_times(_p: &Path, _times: FileTimes) -> io::Result<()> {
+    unsupported()
+}
+
+pub fn set_times_nofollow(_p: &Path, _times: FileTimes) -> io::Result<()> {
+    unsupported()
+}
+
 pub fn readlink(_p: &Path) -> io::Result<PathBuf> {
     unsupported()
 }


### PR DESCRIPTION
Motor OS `std` support (https://github.com/rust-lang/rust/pull/147000) and `set_times`/`set_times_nofollow` (https://github.com/rust-lang/rust/pull/147468) were merged around the same time, so Motor OS is missing this API and currently fails to build.

cc @lasiotus