### PR TITLE
Make `const BorrowMut` require `const Borrow` and make `const Fn` require `const FnMut`

### DIFF
--- a/library/core/src/borrow.rs
+++ b/library/core/src/borrow.rs
@@ -187,7 +187,7 @@ pub const trait Borrow<Borrowed: ?Sized> {
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_diagnostic_item = "BorrowMut"]
 #[rustc_const_unstable(feature = "const_convert", issue = "143773")]
-pub const trait BorrowMut<Borrowed: ?Sized>: Borrow<Borrowed> {
+pub const trait BorrowMut<Borrowed: ?Sized>: [const] Borrow<Borrowed> {
     /// Mutably borrows from an owned value.
     ///
     /// # Examples

--- a/library/core/src/ops/function.rs
+++ b/library/core/src/ops/function.rs
@@ -73,7 +73,7 @@ use crate::marker::Tuple;
 #[fundamental] // so that regex can rely that `&str: !FnMut`
 #[must_use = "closures are lazy and do nothing unless called"]
 #[rustc_const_unstable(feature = "const_trait_impl", issue = "143874")]
-pub const trait Fn<Args: Tuple>: FnMut<Args> {
+pub const trait Fn<Args: Tuple>: [const] FnMut<Args> {
     /// Performs the call operation.
     #[unstable(feature = "fn_traits", issue = "29625")]
     extern "rust-call" fn call(&self, args: Args) -> Self::Output;

--- a/tests/ui/traits/const-traits/call.rs
+++ b/tests/ui/traits/const-traits/call.rs
@@ -6,6 +6,7 @@
 pub const _: () = {
     assert!((const || true)());
     //~^ ERROR }: [const] Fn()` is not satisfied
+    //~| ERROR }: [const] FnMut()` is not satisfied
 };
 
 fn main() {}

--- a/tests/ui/traits/const-traits/call.stderr
+++ b/tests/ui/traits/const-traits/call.stderr
@@ -4,6 +4,15 @@ error[E0277]: the trait bound `{closure@$DIR/call.rs:7:14: 7:22}: [const] Fn()` 
 LL |     assert!((const || true)());
    |             ^^^^^^^^^^^^^^^^^
 
-error: aborting due to 1 previous error
+error[E0277]: the trait bound `{closure@$DIR/call.rs:7:14: 7:22}: [const] FnMut()` is not satisfied
+  --> $DIR/call.rs:7:13
+   |
+LL |     assert!((const || true)());
+   |             ^^^^^^^^^^^^^^^^^
+   |
+note: required by a bound in `call`
+  --> $SRC_DIR/core/src/ops/function.rs:LL:COL
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/traits/const-traits/const_closure-const_trait_impl-ice-113381.rs
+++ b/tests/ui/traits/const-traits/const_closure-const_trait_impl-ice-113381.rs
@@ -13,6 +13,4 @@ impl Foo for () {
 
 fn main() {
     (const || (()).foo())();
-    // ^ ERROR: cannot call non-const method `<() as Foo>::foo` in constant functions
-    // FIXME(const_trait_impl) this should probably say constant closures
 }

--- a/tests/ui/traits/const-traits/const_closure-const_trait_impl-ice-113381.stderr
+++ b/tests/ui/traits/const-traits/const_closure-const_trait_impl-ice-113381.stderr
@@ -4,6 +4,15 @@ error[E0277]: the trait bound `{closure@$DIR/const_closure-const_trait_impl-ice-
 LL |     (const || (()).foo())();
    |     ^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 1 previous error
+error[E0277]: the trait bound `{closure@$DIR/const_closure-const_trait_impl-ice-113381.rs:15:6: 15:14}: [const] FnMut()` is not satisfied
+  --> $DIR/const_closure-const_trait_impl-ice-113381.rs:15:5
+   |
+LL |     (const || (()).foo())();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: required by a bound in `call`
+  --> $SRC_DIR/core/src/ops/function.rs:LL:COL
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/traits/const-traits/non-const-op-const-closure-non-const-outer.rs
+++ b/tests/ui/traits/const-traits/non-const-op-const-closure-non-const-outer.rs
@@ -12,4 +12,5 @@ impl Foo for () {
 fn main() {
     (const || { (()).foo() })();
     //~^ ERROR: }: [const] Fn()` is not satisfied
+    //~| ERROR: }: [const] FnMut()` is not satisfied
 }

--- a/tests/ui/traits/const-traits/non-const-op-const-closure-non-const-outer.stderr
+++ b/tests/ui/traits/const-traits/non-const-op-const-closure-non-const-outer.stderr
@@ -4,6 +4,15 @@ error[E0277]: the trait bound `{closure@$DIR/non-const-op-const-closure-non-cons
 LL |     (const || { (()).foo() })();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 1 previous error
+error[E0277]: the trait bound `{closure@$DIR/non-const-op-const-closure-non-const-outer.rs:13:6: 13:14}: [const] FnMut()` is not satisfied
+  --> $DIR/non-const-op-const-closure-non-const-outer.rs:13:5
+   |
+LL |     (const || { (()).foo() })();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: required by a bound in `call`
+  --> $SRC_DIR/core/src/ops/function.rs:LL:COL
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
This makes it consistent with other const traits in the standard library with supertraits.

I am currently unsure if `const FnMut` should require `const FnOnce` or not. See [zulip discussion](https://rust-lang.zulipchat.com/#narrow/channel/146212-t-compiler.2Fconst-eval/topic/.5Bconst.5D.20implied.20bounds.20for.20implicit.20trait.20bounds/near/546152748).

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
