### PR TITLE
Enable regression labeling aliases

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -38,6 +38,14 @@ allow-unauthenticated = [
     "has-merge-commits",
 ]
 
+[relabel.to-stable]
+add-labels = ["regression-from-stable-to-stable"]
+rem-labels = ["regression-from-stable-to-beta", "regression-from-stable-to-nightly"]
+
+[relabel.to-beta]
+add-labels = ["regression-from-stable-to-beta"]
+rem-labels = ["regression-from-stable-to-stable", "regression-from-stable-to-nightly"]
+
 [review-submitted]
 # This label is added when a "request changes" review is submitted.
 reviewed_label = "S-waiting-on-author"


### PR DESCRIPTION
Enabling label aliases when regressions bleed into the next release channel (nightly -> beta, beta -> stable).

This configuration enables these two aliases:
- `@rustbot label to-beta` (switch regression label <anything> -> beta)
- `@rustbot label to-stable` (switch regression label <anything> -> beta)

Pending merge of [triagebot#2172](https://github.com/rust-lang/triagebot/pull/2172)