### PR TITLE
Add check for `+=` typo in let chains

### DIFF
--- a/compiler/rustc_hir_typeck/src/errors.rs
+++ b/compiler/rustc_hir_typeck/src/errors.rs
@@ -3,20 +3,21 @@
 use std::borrow::Cow;
 
 use rustc_abi::ExternAbi;
-use rustc_ast::Label;
+use rustc_ast::{AssignOpKind, Label};
 use rustc_errors::codes::*;
 use rustc_errors::{
     Applicability, Diag, DiagArgValue, DiagCtxtHandle, DiagSymbolList, Diagnostic,
-    EmissionGuarantee, IntoDiagArg, Level, MultiSpan, Subdiagnostic,
+    EmissionGuarantee, IntoDiagArg, Level, MultiSpan, Subdiagnostic, struct_span_code_err,
 };
 use rustc_hir as hir;
 use rustc_hir::ExprKind;
 use rustc_macros::{Diagnostic, LintDiagnostic, Subdiagnostic};
 use rustc_middle::ty::{self, Ty};
 use rustc_span::edition::{Edition, LATEST_STABLE_EDITION};
+use rustc_span::source_map::Spanned;
 use rustc_span::{Ident, Span, Symbol};
 
-use crate::fluent_generated as fluent;
+use crate::{FnCtxt, fluent_generated as fluent};
 
 #[derive(Diagnostic)]
 #[diag(hir_typeck_base_expression_double_dot, code = E0797)]
@@ -1131,6 +1132,39 @@ impl<G: EmissionGuarantee> Diagnostic<'_, G> for NakedFunctionsAsmBlock {
         }
         diag
     }
+}
+
+pub(crate) fn maybe_emit_plus_equals_diagnostic<'a>(
+    fnctxt: &FnCtxt<'a, '_>,
+    assign_op: Spanned<AssignOpKind>,
+    lhs_expr: &hir::Expr<'_>,
+) -> Result<(), Diag<'a>> {
+    if assign_op.node == hir::AssignOpKind::AddAssign
+        && let hir::ExprKind::Binary(bin_op, left, right) = &lhs_expr.kind
+        && bin_op.node == hir::BinOpKind::And
+        && crate::op::contains_let_in_chain(left)
+        && let hir::ExprKind::Path(hir::QPath::Resolved(_, path)) = &right.kind
+        && matches!(path.res, hir::def::Res::Local(_))
+    {
+        let mut err = struct_span_code_err!(
+            fnctxt.dcx(),
+            assign_op.span,
+            E0368,
+            "binary assignment operation `+=` cannot be used in a let chain",
+        );
+
+        err.span_label(assign_op.span, "cannot use `+=` in a let chain");
+
+        err.span_suggestion(
+            assign_op.span,
+            "you might have meant to compare with `==` instead of assigning with `+=`",
+            "==",
+            Applicability::MaybeIncorrect,
+        );
+
+        return Err(err);
+    }
+    Ok(())
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_hir_typeck/src/errors.rs
+++ b/compiler/rustc_hir_typeck/src/errors.rs
@@ -7,7 +7,7 @@ use rustc_ast::{AssignOpKind, Label};
 use rustc_errors::codes::*;
 use rustc_errors::{
     Applicability, Diag, DiagArgValue, DiagCtxtHandle, DiagSymbolList, Diagnostic,
-    EmissionGuarantee, IntoDiagArg, Level, MultiSpan, Subdiagnostic, struct_span_code_err,
+    EmissionGuarantee, IntoDiagArg, Level, MultiSpan, Subdiagnostic,
 };
 use rustc_hir as hir;
 use rustc_hir::ExprKind;
@@ -1146,11 +1146,14 @@ pub(crate) fn maybe_emit_plus_equals_diagnostic<'a>(
         && let hir::ExprKind::Path(hir::QPath::Resolved(_, path)) = &right.kind
         && matches!(path.res, hir::def::Res::Local(_))
     {
-        let mut err = struct_span_code_err!(
-            fnctxt.dcx(),
+        let mut err = fnctxt.dcx().struct_span_err(
             assign_op.span,
-            E0368,
             "binary assignment operation `+=` cannot be used in a let chain",
+        );
+
+        err.span_label(
+            lhs_expr.span,
+            "you are add-assigning the right-hand side expression to the result of this let-chain",
         );
 
         err.span_label(assign_op.span, "cannot use `+=` in a let chain");

--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -1249,6 +1249,12 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             return;
         }
 
+        // Skip suggestion if LHS contains a let-chain at this would likely be spurious
+        // cc: https://github.com/rust-lang/rust/issues/147664
+        if crate::op::contains_let_in_chain(lhs) {
+            return;
+        }
+
         let mut err = self.dcx().struct_span_err(op_span, "invalid left-hand side of assignment");
         err.code(code);
         err.span_label(lhs.span, "cannot assign to this expression");

--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -48,6 +48,7 @@ use crate::errors::{
     NoFieldOnVariant, ReturnLikeStatementKind, ReturnStmtOutsideOfFnBody, StructExprNonExhaustive,
     TypeMismatchFruTypo, YieldExprOutsideOfCoroutine,
 };
+use crate::op::contains_let_in_chain;
 use crate::{
     BreakableCtxt, CoroutineTypes, Diverges, FnCtxt, GatherLocalsVisitor, Needs,
     TupleArgumentsFlag, cast, fatally_break_rust, report_unexpected_variant_res, type_error_struct,
@@ -1251,7 +1252,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         // Skip suggestion if LHS contains a let-chain at this would likely be spurious
         // cc: https://github.com/rust-lang/rust/issues/147664
-        if crate::op::contains_let_in_chain(lhs) {
+        if contains_let_in_chain(lhs) {
             return;
         }
 

--- a/tests/ui/parser/let-chains-assign-add-incorrect.fixed
+++ b/tests/ui/parser/let-chains-assign-add-incorrect.fixed
@@ -5,7 +5,7 @@
 
 fn test_where_left_is_not_let() {
     let y = 2;
-    if let _ = 1 && true && y += 2 {};
+    if let _ = 1 && true && y == 2 {};
     //~^ ERROR expected expression, found `let` statement
     //~| NOTE only supported directly in conditions of `if` and `while` expressions
     //~| ERROR mismatched types
@@ -19,7 +19,7 @@ fn test_where_left_is_not_let() {
 
 fn test_where_left_is_let() {
     let y = 2;
-    if let _ = 1 && y += 2 {};
+    if let _ = 1 && y == 2 {};
     //~^ ERROR expected expression, found `let` statement
     //~| NOTE only supported directly in conditions of `if` and `while` expressions
     //~| ERROR mismatched types

--- a/tests/ui/parser/let-chains-assign-add-incorrect.rs
+++ b/tests/ui/parser/let-chains-assign-add-incorrect.rs
@@ -1,0 +1,28 @@
+//@ edition:2024
+
+fn test_where_left_is_not_let() {
+    let mut y = 2;
+    if let x = 1 && true && y += 2 {};
+    //~^ ERROR expected expression, found `let` statement
+    //~| NOTE only supported directly in conditions of `if` and `while` expressions
+    //~| ERROR mismatched types
+    //~| NOTE expected `bool`, found integer
+    //~| NOTE expected because this is `bool`
+    //~| ERROR binary assignment operation `+=` cannot be used in a let chain
+    //~| NOTE cannot use `+=` in a let chain
+    //~| HELP you might have meant to compare with `==` instead of assigning with `+=`
+}
+
+fn test_where_left_is_let() {
+    let mut y = 2;
+    if let x = 1 && y += 2 {};
+    //~^ ERROR expected expression, found `let` statement
+    //~| NOTE only supported directly in conditions of `if` and `while` expressions
+    //~| ERROR mismatched types
+    //~| NOTE expected `bool`, found integer
+    //~| ERROR binary assignment operation `+=` cannot be used in a let chain
+    //~| NOTE cannot use `+=` in a let chain
+    //~| HELP you might have meant to compare with `==` instead of assigning with `+=`
+}
+
+fn main() {}

--- a/tests/ui/parser/let-chains-assign-add-incorrect.stderr
+++ b/tests/ui/parser/let-chains-assign-add-incorrect.stderr
@@ -1,0 +1,58 @@
+error: expected expression, found `let` statement
+  --> $DIR/let-chains-assign-add-incorrect.rs:5:8
+   |
+LL |     if let x = 1 && true && y += 2 {};
+   |        ^^^^^^^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
+
+error: expected expression, found `let` statement
+  --> $DIR/let-chains-assign-add-incorrect.rs:18:8
+   |
+LL |     if let x = 1 && y += 2 {};
+   |        ^^^^^^^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
+
+error[E0308]: mismatched types
+  --> $DIR/let-chains-assign-add-incorrect.rs:5:29
+   |
+LL |     if let x = 1 && true && y += 2 {};
+   |        -----------------    ^ expected `bool`, found integer
+   |        |
+   |        expected because this is `bool`
+
+error[E0368]: binary assignment operation `+=` cannot be used in a let chain
+  --> $DIR/let-chains-assign-add-incorrect.rs:5:31
+   |
+LL |     if let x = 1 && true && y += 2 {};
+   |                               ^^ cannot use `+=` in a let chain
+   |
+help: you might have meant to compare with `==` instead of assigning with `+=`
+   |
+LL -     if let x = 1 && true && y += 2 {};
+LL +     if let x = 1 && true && y == 2 {};
+   |
+
+error[E0308]: mismatched types
+  --> $DIR/let-chains-assign-add-incorrect.rs:18:21
+   |
+LL |     if let x = 1 && y += 2 {};
+   |                     ^ expected `bool`, found integer
+
+error[E0368]: binary assignment operation `+=` cannot be used in a let chain
+  --> $DIR/let-chains-assign-add-incorrect.rs:18:23
+   |
+LL |     if let x = 1 && y += 2 {};
+   |                       ^^ cannot use `+=` in a let chain
+   |
+help: you might have meant to compare with `==` instead of assigning with `+=`
+   |
+LL -     if let x = 1 && y += 2 {};
+LL +     if let x = 1 && y == 2 {};
+   |
+
+error: aborting due to 6 previous errors
+
+Some errors have detailed explanations: E0308, E0368.
+For more information about an error, try `rustc --explain E0308`.

--- a/tests/ui/parser/let-chains-assign-add-incorrect.stderr
+++ b/tests/ui/parser/let-chains-assign-add-incorrect.stderr
@@ -1,58 +1,61 @@
 error: expected expression, found `let` statement
-  --> $DIR/let-chains-assign-add-incorrect.rs:5:8
+  --> $DIR/let-chains-assign-add-incorrect.rs:8:8
    |
-LL |     if let x = 1 && true && y += 2 {};
+LL |     if let _ = 1 && true && y += 2 {};
    |        ^^^^^^^^^
    |
    = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
-  --> $DIR/let-chains-assign-add-incorrect.rs:18:8
+  --> $DIR/let-chains-assign-add-incorrect.rs:22:8
    |
-LL |     if let x = 1 && y += 2 {};
+LL |     if let _ = 1 && y += 2 {};
    |        ^^^^^^^^^
    |
    = note: only supported directly in conditions of `if` and `while` expressions
 
 error[E0308]: mismatched types
-  --> $DIR/let-chains-assign-add-incorrect.rs:5:29
+  --> $DIR/let-chains-assign-add-incorrect.rs:8:29
    |
-LL |     if let x = 1 && true && y += 2 {};
+LL |     if let _ = 1 && true && y += 2 {};
    |        -----------------    ^ expected `bool`, found integer
    |        |
    |        expected because this is `bool`
 
-error[E0368]: binary assignment operation `+=` cannot be used in a let chain
-  --> $DIR/let-chains-assign-add-incorrect.rs:5:31
+error: binary assignment operation `+=` cannot be used in a let chain
+  --> $DIR/let-chains-assign-add-incorrect.rs:8:31
    |
-LL |     if let x = 1 && true && y += 2 {};
-   |                               ^^ cannot use `+=` in a let chain
+LL |     if let _ = 1 && true && y += 2 {};
+   |        ---------------------- ^^ cannot use `+=` in a let chain
+   |        |
+   |        you are add-assigning the right-hand side expression to the result of this let-chain
    |
 help: you might have meant to compare with `==` instead of assigning with `+=`
    |
-LL -     if let x = 1 && true && y += 2 {};
-LL +     if let x = 1 && true && y == 2 {};
+LL -     if let _ = 1 && true && y += 2 {};
+LL +     if let _ = 1 && true && y == 2 {};
    |
 
 error[E0308]: mismatched types
-  --> $DIR/let-chains-assign-add-incorrect.rs:18:21
+  --> $DIR/let-chains-assign-add-incorrect.rs:22:21
    |
-LL |     if let x = 1 && y += 2 {};
+LL |     if let _ = 1 && y += 2 {};
    |                     ^ expected `bool`, found integer
 
-error[E0368]: binary assignment operation `+=` cannot be used in a let chain
-  --> $DIR/let-chains-assign-add-incorrect.rs:18:23
+error: binary assignment operation `+=` cannot be used in a let chain
+  --> $DIR/let-chains-assign-add-incorrect.rs:22:23
    |
-LL |     if let x = 1 && y += 2 {};
-   |                       ^^ cannot use `+=` in a let chain
+LL |     if let _ = 1 && y += 2 {};
+   |        -------------- ^^ cannot use `+=` in a let chain
+   |        |
+   |        you are add-assigning the right-hand side expression to the result of this let-chain
    |
 help: you might have meant to compare with `==` instead of assigning with `+=`
    |
-LL -     if let x = 1 && y += 2 {};
-LL +     if let x = 1 && y == 2 {};
+LL -     if let _ = 1 && y += 2 {};
+LL +     if let _ = 1 && y == 2 {};
    |
 
 error: aborting due to 6 previous errors
 
-Some errors have detailed explanations: E0308, E0368.
-For more information about an error, try `rustc --explain E0308`.
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Fixes https://github.com/rust-lang/rust/issues/147664

it does affect only cases where variable exist in scope, because if the variable is not exist in scope, the suggestion will not make any sense

I wanted to add suggestion for case where variable does not in scope to fix `y += 1` to `let y = 1` but I guess it's too much (not too much work, but too much wild predict of what user wants)? if it's good addition in your opinion I can add this in follow up

in other things I guess impl is pretty much self-explanatory, if you see there is some possibilities to improve code or/and some _edge-cases_ that I could overlooked feel free to tell about it

ah, also about why I think this change is good and why I originally took it, so it seems to me that this is possible to make this typo (I explained this in comment a little), like, both `+` and `=` is the same button (in most of layouts) and for this reasons I didn't added something like `-=` it seems more harder to make this typo

r? diagnostics