### PR TITLE
Add a timeout to the `remote-test-client` connection

### DIFF
--- a/src/doc/rustc-dev-guide/src/tests/running.md
+++ b/src/doc/rustc-dev-guide/src/tests/running.md
@@ -321,6 +321,10 @@ Tests are built on the machine running `x` not on the remote machine.
 Tests which fail to build unexpectedly (or `ui` tests producing incorrect build
 output) may fail without ever running on the remote machine.
 
+There is a default timeout of 30 minutes in case the `remote-test-server`
+cannot be reached by the `x` command. This timeout can be modified by using the
+`TEST_DEVICE_CONNECT_TIMEOUT_SECONDS` environment variable.
+
 ## Testing on emulators
 
 Some platforms are tested via an emulator for architectures that aren't readily available.

--- a/src/tools/remote-test-client/src/main.rs
+++ b/src/tools/remote-test-client/src/main.rs
@@ -11,11 +11,15 @@ use std::io::{self, BufWriter};
 use std::net::TcpStream;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use std::{env, thread};
 
 const REMOTE_ADDR_ENV: &str = "TEST_DEVICE_ADDR";
 const DEFAULT_ADDR: &str = "127.0.0.1:12345";
+
+const CONNECT_TIMEOUT_ENV: &str = "TEST_DEVICE_CONNECT_TIMEOUT_SECONDS";
+/// The default timeout is high to not break slow CI or slow device starts.
+const DEFAULT_CONNECT_TIMEOUT: Duration = Duration::from_mins(30);
 
 macro_rules! t {
     ($e:expr) => {
@@ -56,6 +60,17 @@ fn main() {
     }
 }
 
+fn connect_timeout() -> Duration {
+    match env::var(CONNECT_TIMEOUT_ENV).ok() {
+        Some(timeout) => timeout.parse().map(Duration::from_secs).unwrap_or_else(|e| {
+            panic!(
+                "error: parsing `{CONNECT_TIMEOUT_ENV}` value \"{timeout}\" as seconds failed: {e}"
+            )
+        }),
+        None => DEFAULT_CONNECT_TIMEOUT,
+    }
+}
+
 fn spawn_emulator(target: &str, server: &Path, tmpdir: &Path, rootfs: Option<PathBuf>) {
     let device_address = env::var(REMOTE_ADDR_ENV).unwrap_or(DEFAULT_ADDR.to_string());
 
@@ -69,7 +84,10 @@ fn spawn_emulator(target: &str, server: &Path, tmpdir: &Path, rootfs: Option<Pat
     }
 
     // Wait for the emulator to come online
-    loop {
+    let timeout = connect_timeout();
+    let mut successful_read = false;
+    let start_time = Instant::now();
+    while start_time.elapsed() < timeout {
         let dur = Duration::from_millis(2000);
         if let Ok(mut client) = TcpStream::connect(&device_address) {
             t!(client.set_read_timeout(Some(dur)));
@@ -77,11 +95,16 @@ fn spawn_emulator(target: &str, server: &Path, tmpdir: &Path, rootfs: Option<Pat
             if client.write_all(b"ping").is_ok() {
                 let mut b = [0; 4];
                 if client.read_exact(&mut b).is_ok() {
+                    successful_read = true;
                     break;
                 }
             }
         }
         thread::sleep(dur);
+    }
+
+    if !successful_read {
+        panic!("Gave up trying to connect to test device at {device_address} after {timeout:?}");
     }
 }
 

--- a/src/tools/remote-test-client/tests/lib.rs
+++ b/src/tools/remote-test-client/tests/lib.rs
@@ -8,3 +8,18 @@ fn test_help() {
     let stdout = String::from_utf8(output.stdout.clone()).unwrap();
     assert!(stdout.trim().starts_with("Usage:"));
 }
+
+#[test]
+fn test_timeout() {
+    let mut cmd = assert_cmd::cargo::cargo_bin_cmd!();
+    cmd.env("TEST_DEVICE_CONNECT_TIMEOUT_SECONDS", "1");
+    cmd.env("TEST_DEVICE_ADDR", "127.69.69.69:6969");
+    cmd.args(["spawn-emulator", "dummy-target", "dummy-server", "dummy-tmpdir"]);
+
+    let assert = cmd.assert().failure();
+    let output = assert.get_output();
+
+    let stderr = String::from_utf8(output.stderr.clone()).unwrap();
+    let pass_msg = "Gave up trying to connect to test device";
+    assert!(stderr.contains(pass_msg), "Could not find `{pass_msg}` in `{stderr}`");
+}


### PR DESCRIPTION
Currently, the `remote-test-client` doesn't have a timeout when connecting to the `remote-test-server`. This means that running tests using it can hang indefinitely which causes issues when running tests on CI, for example.

This PR now sets a default timeout of 5 minutes, meaning that if, for example, `TEST_DEVICE_ADDR=<IP:PORT> ./x test --target riscv64gc-unknown-linux-gnu tests/ui` is run and the `remote-test-server` is not reachable by the client, the client will panic after the timeout is reached. 

Additionally, the `TEST_DEVICE_CONNECT_TIMEOUT` env variable can be used to set up the timeout to any value (in seconds).

This PR also wires up a test step for `remote-test-client`, which didn't previously have tool tests run in CI.

Edit: ~~blocked by rust-lang/rust#149071~~