### PR TITLE
docs(core): clarify that signed integers use two's complement

### DIFF
--- a/library/core/src/primitive_docs.rs
+++ b/library/core/src/primitive_docs.rs
@@ -1405,31 +1405,31 @@ mod prim_f128 {}
 
 #[rustc_doc_primitive = "i8"]
 //
-/// The 8-bit signed integer type.
+/// The 8-bit signed integer type (represented using two's complement).
 #[stable(feature = "rust1", since = "1.0.0")]
 mod prim_i8 {}
 
 #[rustc_doc_primitive = "i16"]
 //
-/// The 16-bit signed integer type.
+/// The 16-bit signed integer type (represented using two's complement).
 #[stable(feature = "rust1", since = "1.0.0")]
 mod prim_i16 {}
 
 #[rustc_doc_primitive = "i32"]
 //
-/// The 32-bit signed integer type.
+/// The 32-bit signed integer type (represented using two's complement).
 #[stable(feature = "rust1", since = "1.0.0")]
 mod prim_i32 {}
 
 #[rustc_doc_primitive = "i64"]
 //
-/// The 64-bit signed integer type.
+/// The 64-bit signed integer type (represented using two's complement).
 #[stable(feature = "rust1", since = "1.0.0")]
 mod prim_i64 {}
 
 #[rustc_doc_primitive = "i128"]
 //
-/// The 128-bit signed integer type.
+/// The 128-bit signed integer type (represented using two's complement).
 ///
 /// # ABI compatibility
 ///
@@ -1479,7 +1479,7 @@ mod prim_u128 {}
 
 #[rustc_doc_primitive = "isize"]
 //
-/// The pointer-sized signed integer type.
+/// The pointer-sized signed integer type (represented using two's complement).
 ///
 /// The size of this primitive is how many bytes it takes to reference any
 /// location in memory. For example, on a 32 bit target, this is 4 bytes

--- a/library/core/src/primitive_docs.rs
+++ b/library/core/src/primitive_docs.rs
@@ -1405,31 +1405,51 @@ mod prim_f128 {}
 
 #[rustc_doc_primitive = "i8"]
 //
-/// The 8-bit signed integer type (represented using two's complement).
+/// The 8-bit signed integer type.
+///
+/// # Binary representation
+///
+/// Signed integers are represented using two's complement.
 #[stable(feature = "rust1", since = "1.0.0")]
 mod prim_i8 {}
 
 #[rustc_doc_primitive = "i16"]
 //
-/// The 16-bit signed integer type (represented using two's complement).
+/// The 16-bit signed integer type.
+///
+/// # Binary representation
+///
+/// Signed integers are represented using two's complement.
 #[stable(feature = "rust1", since = "1.0.0")]
 mod prim_i16 {}
 
 #[rustc_doc_primitive = "i32"]
 //
-/// The 32-bit signed integer type (represented using two's complement).
+/// The 32-bit signed integer type.
+///
+/// # Binary representation
+///
+/// Signed integers are represented using two's complement.
 #[stable(feature = "rust1", since = "1.0.0")]
 mod prim_i32 {}
 
 #[rustc_doc_primitive = "i64"]
 //
-/// The 64-bit signed integer type (represented using two's complement).
+/// The 64-bit signed integer type.
+///
+/// # Binary representation
+///
+/// Signed integers are represented using two's complement.
 #[stable(feature = "rust1", since = "1.0.0")]
 mod prim_i64 {}
 
 #[rustc_doc_primitive = "i128"]
 //
-/// The 128-bit signed integer type (represented using two's complement).
+/// The 128-bit signed integer type.
+///
+/// # Binary representation
+///
+/// Signed integers are represented using two's complement.
 ///
 /// # ABI compatibility
 ///
@@ -1479,11 +1499,15 @@ mod prim_u128 {}
 
 #[rustc_doc_primitive = "isize"]
 //
-/// The pointer-sized signed integer type (represented using two's complement).
+/// The pointer-sized signed integer type.
 ///
 /// The size of this primitive is how many bytes it takes to reference any
 /// location in memory. For example, on a 32 bit target, this is 4 bytes
 /// and on a 64 bit target, this is 8 bytes.
+///
+/// # Binary representation
+///
+/// Signed integers are represented using two's complement.
 #[stable(feature = "rust1", since = "1.0.0")]
 mod prim_isize {}
 


### PR DESCRIPTION
## Description

This attempts to clarify in the std documentation how signed integers (`i8`–`i128` and `isize`) are encoded. I do not mean this to introduce a *new* stability guarantee, but only to document an already obvious (?) property, which is already documented elsewhere (mostly).

## Motivation

My understanding is that signed integers are already *guaranteed* to be encoded in two's complement. The [Reference does state this for `i8`–`i128`][reference-signed] (but technically [does not for `isize`][reference-signed], at least not in the same place), and in documenting [numeric casts][reference-numeric-casts] and [negation operators][reference-negate]:

> Remember that signed integers are always represented using two’s complement.

This therefore does not seem architecture or platform-dependent. However it is also not [specified explicitly in the FLS][fls-signed].

In addition, I could not find this in the std documentation, while this seems required to understand the behavior of shr operations and of [`as` casts][reference-numeric-casts] in particular.

If this is something you think is worth documenting explicitly, the exact phrasing can likely be refined (it is currently modeled on floats'). If not, feel free to close this PR.

[reference-signed]: https://doc.rust-lang.org/reference/types/numeric.html#r-type.numeric.int.signed
[reference-isize]: https://doc.rust-lang.org/reference/types/numeric.html#r-type.numeric.int.size.isize
[reference-numeric-casts]: https://doc.rust-lang.org/reference/expressions/operator-expr.html#r-expr.as.numeric.int-same-size
[reference-negate]: https://doc.rust-lang.org/reference/expressions/operator-expr.html#r-expr.negate.results
[fls-signed]: https://rust-lang.github.io/fls/glossary.html#signed-integer-type