### PR TITLE
Make `__cpuid_count()` a pure function

### DIFF
--- a/library/stdarch/crates/core_arch/src/x86/cpuid.rs
+++ b/library/stdarch/crates/core_arch/src/x86/cpuid.rs
@@ -67,7 +67,7 @@ pub unsafe fn __cpuid_count(leaf: u32, sub_leaf: u32) -> CpuidResult {
             inout("eax") leaf => eax,
             inout("ecx") sub_leaf => ecx,
             out("edx") edx,
-            options(nostack, preserves_flags),
+            options(nostack, nomem, pure, preserves_flags),
         );
     }
     #[cfg(target_arch = "x86_64")]
@@ -80,7 +80,7 @@ pub unsafe fn __cpuid_count(leaf: u32, sub_leaf: u32) -> CpuidResult {
             inout("eax") leaf => eax,
             inout("ecx") sub_leaf => ecx,
             out("edx") edx,
-            options(nostack, preserves_flags),
+            options(nostack, nomem, pure, preserves_flags),
         );
     }
     CpuidResult { eax, ebx, ecx, edx }


### PR DESCRIPTION
Crates like [`raw_cpuid`](https://docs.rs/raw_cpuid) use `core::arch::x86_64::__cpuid_count()` to determine x86 CPU information.  It's great that core provides such a function, instead of having to write inline assembly everywhere; but core's implementation does not use the `asm!` attributes `pure` and `nomem`.  This means that calls to `__cpuid_count()` can't be elided or deduplicated.  I'm writing some target-feature enhancement code (akin to [`multiversion`](https://docs.rs/multiversion)), and I'd like to rely on CPUID getting optimized away appropriately.

The lack of these attributes was probably an oversight; I looked through the Git history and couldn't see any discussion of the purity of the instruction.  While CPUID _can_ have some less-than-pure effects (it acts like a strong memory fence), that's not the primary use case for it -- users who explicitly rely on those effects should write inline assembly where they can be more explicit about it.

In a future where CPUID is an LLVM intrinsic, this wouldn't matter, and LLVM would presumably be able to determine the purity of the intrinsic automatically.  But until then, marking it as pure would be a nice optimization hint.

If there are concerns that users may wish to rely on the mild side effects of CPUID, or if there are genuine side effects I wasn't aware of, perhaps a `__pure_cpuid_count()` instruction could be added.  I think it's better to make `__cpuid_count()` pure, but I'll leave that decision to the reviewer.