### PR TITLE
feat(option): add Option::clear method

### DIFF
--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -1842,6 +1842,20 @@ impl<T> Option<T> {
         mem::replace(self, None)
     }
 
+    /// Clear the value of the option.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let mut x = Some(2);
+    /// x.clear();
+    /// assert_eq!(x, None);
+    /// ```
+    #[inline(always)]
+    pub fn clear(&mut self) {
+        *self = None;
+    }
+
     /// Takes the value out of the option, but only if the predicate evaluates to
     /// `true` on a mutable reference to the value.
     ///


### PR DESCRIPTION
Add Option::clear. This makes Option more like a container.

Although this can also be achieved by using `let _ = Option::take()`, considering that Option provides insert method (somewhat similar to a container), it seems reasonable to add a clear method to it.