### PR TITLE
resolve: Preserve ambiguous glob reexports in crate metadata

### DIFF
--- a/compiler/rustc_metadata/src/lib.rs
+++ b/compiler/rustc_metadata/src/lib.rs
@@ -9,6 +9,7 @@
 #![feature(min_specialization)]
 #![feature(never_type)]
 #![feature(proc_macro_internals)]
+#![feature(result_option_map_or_default)]
 #![feature(trusted_len)]
 // tidy-alphabetical-end
 

--- a/compiler/rustc_metadata/src/rmeta/decoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder.rs
@@ -1284,6 +1284,21 @@ impl<'a> CrateMetadataRef<'a> {
         }
     }
 
+    fn get_ambig_module_children(
+        self,
+        tcx: TyCtxt<'_>,
+        id: DefIndex,
+    ) -> impl Iterator<Item = AmbigModChild> {
+        gen move {
+            let children = self.root.tables.ambig_module_children.get((self, tcx), id);
+            if !children.is_default() {
+                for child in children.decode((self, tcx)) {
+                    yield child;
+                }
+            }
+        }
+    }
+
     fn is_ctfe_mir_available(self, tcx: TyCtxt<'_>, id: DefIndex) -> bool {
         self.root.tables.mir_for_ctfe.get((self, tcx), id).is_some()
     }

--- a/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
@@ -8,7 +8,7 @@ use rustc_hir::def_id::{CrateNum, DefId, DefIdMap, LOCAL_CRATE};
 use rustc_hir::definitions::{DefKey, DefPath, DefPathHash};
 use rustc_middle::arena::ArenaAllocatable;
 use rustc_middle::bug;
-use rustc_middle::metadata::ModChild;
+use rustc_middle::metadata::{AmbigModChild, ModChild};
 use rustc_middle::middle::exported_symbols::ExportedSymbol;
 use rustc_middle::middle::stability::DeprecationEntry;
 use rustc_middle::query::{ExternProviders, LocalCrate};
@@ -583,6 +583,14 @@ impl CStore {
 
     pub fn expn_that_defined_untracked(&self, tcx: TyCtxt<'_>, def_id: DefId) -> ExpnId {
         self.get_crate_data(def_id.krate).get_expn_that_defined(tcx, def_id.index)
+    }
+
+    pub fn ambig_module_children_untracked(
+        &self,
+        tcx: TyCtxt<'_>,
+        def_id: DefId,
+    ) -> impl Iterator<Item = AmbigModChild> {
+        self.get_crate_data(def_id.krate).get_ambig_module_children(tcx, def_id.index)
     }
 
     /// Only public-facing way to traverse all the definitions in a non-local crate.

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -1731,6 +1731,14 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
 
             record_defaulted_array!(self.tables.module_children_reexports[def_id] <-
                 module_children.iter().filter(|child| !child.reexport_chain.is_empty()));
+
+            let ambig_module_children = tcx
+                .resolutions(())
+                .ambig_module_children
+                .get(&local_def_id)
+                .map_or_default(|v| &v[..]);
+            record_defaulted_array!(self.tables.ambig_module_children[def_id] <-
+                ambig_module_children);
         }
     }
 

--- a/compiler/rustc_metadata/src/rmeta/mod.rs
+++ b/compiler/rustc_metadata/src/rmeta/mod.rs
@@ -21,7 +21,7 @@ use rustc_index::bit_set::DenseBitSet;
 use rustc_macros::{
     BlobDecodable, Decodable, Encodable, LazyDecodable, MetadataEncodable, TyDecodable, TyEncodable,
 };
-use rustc_middle::metadata::ModChild;
+use rustc_middle::metadata::{AmbigModChild, ModChild};
 use rustc_middle::middle::codegen_fn_attrs::CodegenFnAttrs;
 use rustc_middle::middle::debugger_visualizer::DebuggerVisualizerFile;
 use rustc_middle::middle::deduced_param_attrs::DeducedParamAttrs;
@@ -399,6 +399,7 @@ define_tables! {
     // That's why the encoded list needs to contain `ModChild` structures describing all the names
     // individually instead of `DefId`s.
     module_children_reexports: Table<DefIndex, LazyArray<ModChild>>,
+    ambig_module_children: Table<DefIndex, LazyArray<AmbigModChild>>,
     cross_crate_inlinable: Table<DefIndex, bool>,
     asyncness: Table<DefIndex, ty::Asyncness>,
     constness: Table<DefIndex, hir::Constness>,

--- a/compiler/rustc_metadata/src/rmeta/parameterized.rs
+++ b/compiler/rustc_metadata/src/rmeta/parameterized.rs
@@ -94,6 +94,7 @@ trivially_parameterized_over_tcx! {
     rustc_hir::def_id::DefIndex,
     rustc_hir::definitions::DefKey,
     rustc_index::bit_set::DenseBitSet<u32>,
+    rustc_middle::metadata::AmbigModChild,
     rustc_middle::metadata::ModChild,
     rustc_middle::middle::codegen_fn_attrs::CodegenFnAttrs,
     rustc_middle::middle::debugger_visualizer::DebuggerVisualizerFile,

--- a/compiler/rustc_middle/src/metadata.rs
+++ b/compiler/rustc_middle/src/metadata.rs
@@ -44,3 +44,17 @@ pub struct ModChild {
     /// Empty if the module child is a proper item.
     pub reexport_chain: SmallVec<[Reexport; 2]>,
 }
+
+#[derive(Debug, TyEncodable, TyDecodable, HashStable)]
+pub enum AmbigModChildKind {
+    GlobVsGlob,
+    GlobVsExpanded,
+}
+
+/// Same as `ModChild`, however, it includes ambiguity error.
+#[derive(Debug, TyEncodable, TyDecodable, HashStable)]
+pub struct AmbigModChild {
+    pub main: ModChild,
+    pub second: ModChild,
+    pub kind: AmbigModChildKind,
+}

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -108,7 +108,7 @@ pub use self::typeck_results::{
     Rust2024IncompatiblePatInfo, TypeckResults, UserType, UserTypeAnnotationIndex, UserTypeKind,
 };
 use crate::error::{OpaqueHiddenTypeMismatch, TypeMismatchReason};
-use crate::metadata::ModChild;
+use crate::metadata::{AmbigModChild, ModChild};
 use crate::middle::privacy::EffectiveVisibilities;
 use crate::mir::{Body, CoroutineLayout, CoroutineSavedLocal, SourceInfo};
 use crate::query::{IntoQueryParam, Providers};
@@ -173,6 +173,7 @@ pub struct ResolverGlobalCtxt {
     pub extern_crate_map: UnordMap<LocalDefId, CrateNum>,
     pub maybe_unused_trait_imports: FxIndexSet<LocalDefId>,
     pub module_children: LocalDefIdMap<Vec<ModChild>>,
+    pub ambig_module_children: LocalDefIdMap<Vec<AmbigModChild>>,
     pub glob_map: FxIndexMap<LocalDefId, FxIndexSet<Symbol>>,
     pub main_def: Option<MainDefinition>,
     pub trait_impls: FxIndexMap<DefId, Vec<LocalDefId>>,

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -148,12 +148,13 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             let diag = self.ambiguity_diagnostic(ambiguity_error);
 
             if ambiguity_error.warning {
-                let NameBindingKind::Import { import, .. } = ambiguity_error.b1.0.kind else {
-                    unreachable!()
+                let node_id = match ambiguity_error.b1.0.kind {
+                    NameBindingKind::Import { import, .. } => import.root_id,
+                    NameBindingKind::Res(_) => CRATE_NODE_ID,
                 };
                 self.lint_buffer.buffer_lint(
                     AMBIGUOUS_GLOB_IMPORTS,
-                    import.root_id,
+                    node_id,
                     diag.ident.span,
                     diag,
                 );

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -64,7 +64,7 @@ use rustc_hir::definitions::DisambiguatorState;
 use rustc_hir::{PrimTy, TraitCandidate};
 use rustc_index::bit_set::DenseBitSet;
 use rustc_metadata::creader::CStore;
-use rustc_middle::metadata::ModChild;
+use rustc_middle::metadata::{AmbigModChild, ModChild, Reexport};
 use rustc_middle::middle::privacy::EffectiveVisibilities;
 use rustc_middle::query::Providers;
 use rustc_middle::span_bug;
@@ -927,6 +927,18 @@ impl<'ra> NameBindingData<'ra> {
         }
     }
 
+    fn descent_to_ambiguity(
+        self: NameBinding<'ra>,
+    ) -> Option<(NameBinding<'ra>, NameBinding<'ra>, AmbiguityKind)> {
+        match self.ambiguity {
+            Some((ambig_binding, ambig_kind)) => Some((self, ambig_binding, ambig_kind)),
+            None => match self.kind {
+                NameBindingKind::Import { binding, .. } => binding.descent_to_ambiguity(),
+                _ => None,
+            },
+        }
+    }
+
     fn is_ambiguity_recursive(&self) -> bool {
         self.ambiguity.is_some()
             || match self.kind {
@@ -988,6 +1000,16 @@ impl<'ra> NameBindingData<'ra> {
 
     fn macro_kinds(&self) -> Option<MacroKinds> {
         self.res().macro_kinds()
+    }
+
+    fn reexport_chain(self: NameBinding<'ra>, r: &Resolver<'_, '_>) -> SmallVec<[Reexport; 2]> {
+        let mut reexport_chain = SmallVec::new();
+        let mut next_binding = self;
+        while let NameBindingKind::Import { binding, import, .. } = next_binding.kind {
+            reexport_chain.push(import.simplify(r));
+            next_binding = binding;
+        }
+        reexport_chain
     }
 
     // Suppose that we resolved macro invocation with `invoc_parent_expansion` to binding `binding`
@@ -1123,6 +1145,7 @@ pub struct Resolver<'ra, 'tcx> {
     /// `CrateNum` resolutions of `extern crate` items.
     extern_crate_map: UnordMap<LocalDefId, CrateNum>,
     module_children: LocalDefIdMap<Vec<ModChild>>,
+    ambig_module_children: LocalDefIdMap<Vec<AmbigModChild>>,
     trait_map: NodeMap<Vec<TraitCandidate>>,
 
     /// A map from nodes to anonymous modules.
@@ -1580,6 +1603,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             extra_lifetime_params_map: Default::default(),
             extern_crate_map: Default::default(),
             module_children: Default::default(),
+            ambig_module_children: Default::default(),
             trait_map: NodeMap::default(),
             empty_module,
             local_modules,
@@ -1766,6 +1790,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             effective_visibilities,
             extern_crate_map,
             module_children: self.module_children,
+            ambig_module_children: self.ambig_module_children,
             glob_map,
             maybe_unused_trait_imports,
             main_def,

--- a/tests/ui/imports/ambiguous-2.rs
+++ b/tests/ui/imports/ambiguous-2.rs
@@ -1,10 +1,9 @@
-//@ check-pass
 //@ aux-build: ../ambiguous-1.rs
 // https://github.com/rust-lang/rust/pull/113099#issuecomment-1633574396
 
 extern crate ambiguous_1;
 
 fn main() {
-    ambiguous_1::id();
-    //^ FIXME: `id` should be identified as an ambiguous item.
+    ambiguous_1::id(); //~ ERROR `id` is ambiguous
+                       //~| WARN this was previously accepted
 }

--- a/tests/ui/imports/ambiguous-2.stderr
+++ b/tests/ui/imports/ambiguous-2.stderr
@@ -1,45 +1,45 @@
-error: `C` is ambiguous
-  --> $DIR/glob-conflict-cross-crate-2.rs:8:13
+error: `id` is ambiguous
+  --> $DIR/ambiguous-2.rs:7:18
    |
-LL |     let _a: C = 1;
-   |             ^ ambiguous name
+LL |     ambiguous_1::id();
+   |                  ^^ ambiguous name
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
-note: `C` could refer to the type alias defined here
-  --> $DIR/auxiliary/glob-conflict-cross-crate-2-extern.rs:9:9
+note: `id` could refer to the function defined here
+  --> $DIR/auxiliary/../ambiguous-1.rs:13:13
    |
-LL | pub use a::*;
-   |         ^
-note: `C` could also refer to the type alias defined here
-  --> $DIR/auxiliary/glob-conflict-cross-crate-2-extern.rs:10:9
+LL |     pub use self::evp::*;
+   |             ^^^^^^^^^
+note: `id` could also refer to the function defined here
+  --> $DIR/auxiliary/../ambiguous-1.rs:15:13
    |
-LL | pub use b::*;
-   |         ^
+LL |     pub use self::handwritten::*;
+   |             ^^^^^^^^^^^^^^^^^
    = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
 error: aborting due to 1 previous error
 
 Future incompatibility report: Future breakage diagnostic:
-error: `C` is ambiguous
-  --> $DIR/glob-conflict-cross-crate-2.rs:8:13
+error: `id` is ambiguous
+  --> $DIR/ambiguous-2.rs:7:18
    |
-LL |     let _a: C = 1;
-   |             ^ ambiguous name
+LL |     ambiguous_1::id();
+   |                  ^^ ambiguous name
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
-note: `C` could refer to the type alias defined here
-  --> $DIR/auxiliary/glob-conflict-cross-crate-2-extern.rs:9:9
+note: `id` could refer to the function defined here
+  --> $DIR/auxiliary/../ambiguous-1.rs:13:13
    |
-LL | pub use a::*;
-   |         ^
-note: `C` could also refer to the type alias defined here
-  --> $DIR/auxiliary/glob-conflict-cross-crate-2-extern.rs:10:9
+LL |     pub use self::evp::*;
+   |             ^^^^^^^^^
+note: `id` could also refer to the function defined here
+  --> $DIR/auxiliary/../ambiguous-1.rs:15:13
    |
-LL | pub use b::*;
-   |         ^
+LL |     pub use self::handwritten::*;
+   |             ^^^^^^^^^^^^^^^^^
    = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/ambiguous-4.rs
+++ b/tests/ui/imports/ambiguous-4.rs
@@ -1,10 +1,9 @@
 //@ edition:2015
-//@ check-pass
 //@ aux-build: ../ambiguous-4-extern.rs
 
 extern crate ambiguous_4_extern;
 
 fn main() {
-    ambiguous_4_extern::id();
-    //^ FIXME: `id` should be identified as an ambiguous item.
+    ambiguous_4_extern::id(); //~ ERROR `id` is ambiguous
+                              //~| WARN this was previously accepted
 }

--- a/tests/ui/imports/ambiguous-4.stderr
+++ b/tests/ui/imports/ambiguous-4.stderr
@@ -1,45 +1,45 @@
-error: `C` is ambiguous
-  --> $DIR/glob-conflict-cross-crate-2.rs:8:13
+error: `id` is ambiguous
+  --> $DIR/ambiguous-4.rs:7:25
    |
-LL |     let _a: C = 1;
-   |             ^ ambiguous name
+LL |     ambiguous_4_extern::id();
+   |                         ^^ ambiguous name
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
-note: `C` could refer to the type alias defined here
-  --> $DIR/auxiliary/glob-conflict-cross-crate-2-extern.rs:9:9
+note: `id` could refer to the function defined here
+  --> $DIR/auxiliary/../ambiguous-4-extern.rs:13:9
    |
-LL | pub use a::*;
-   |         ^
-note: `C` could also refer to the type alias defined here
-  --> $DIR/auxiliary/glob-conflict-cross-crate-2-extern.rs:10:9
+LL | pub use evp::*;
+   |         ^^^
+note: `id` could also refer to the function defined here
+  --> $DIR/auxiliary/../ambiguous-4-extern.rs:14:9
    |
-LL | pub use b::*;
-   |         ^
+LL | pub use handwritten::*;
+   |         ^^^^^^^^^^^
    = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
 error: aborting due to 1 previous error
 
 Future incompatibility report: Future breakage diagnostic:
-error: `C` is ambiguous
-  --> $DIR/glob-conflict-cross-crate-2.rs:8:13
+error: `id` is ambiguous
+  --> $DIR/ambiguous-4.rs:7:25
    |
-LL |     let _a: C = 1;
-   |             ^ ambiguous name
+LL |     ambiguous_4_extern::id();
+   |                         ^^ ambiguous name
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
-note: `C` could refer to the type alias defined here
-  --> $DIR/auxiliary/glob-conflict-cross-crate-2-extern.rs:9:9
+note: `id` could refer to the function defined here
+  --> $DIR/auxiliary/../ambiguous-4-extern.rs:13:9
    |
-LL | pub use a::*;
-   |         ^
-note: `C` could also refer to the type alias defined here
-  --> $DIR/auxiliary/glob-conflict-cross-crate-2-extern.rs:10:9
+LL | pub use evp::*;
+   |         ^^^
+note: `id` could also refer to the function defined here
+  --> $DIR/auxiliary/../ambiguous-4-extern.rs:14:9
    |
-LL | pub use b::*;
-   |         ^
+LL | pub use handwritten::*;
+   |         ^^^^^^^^^^^
    = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/ambiguous-glob-vs-expanded-extern.rs
+++ b/tests/ui/imports/ambiguous-glob-vs-expanded-extern.rs
@@ -1,0 +1,6 @@
+//@ aux-crate: glob_vs_expanded=glob-vs-expanded.rs
+
+fn main() {
+    glob_vs_expanded::mac!(); //~ ERROR `mac` is ambiguous
+                              //~| WARN this was previously accepted
+}

--- a/tests/ui/imports/ambiguous-glob-vs-expanded-extern.stderr
+++ b/tests/ui/imports/ambiguous-glob-vs-expanded-extern.stderr
@@ -1,0 +1,47 @@
+error: `mac` is ambiguous
+  --> $DIR/ambiguous-glob-vs-expanded-extern.rs:4:23
+   |
+LL |     glob_vs_expanded::mac!();
+   |                       ^^^ ambiguous name
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
+   = note: ambiguous because of a conflict between a name from a glob import and a macro-expanded name in the same module during import or macro resolution
+note: `mac` could refer to the macro defined here
+  --> $DIR/auxiliary/glob-vs-expanded.rs:11:1
+   |
+LL | define_mac!();
+   | ^^^^^^^^^^^^^
+note: `mac` could also refer to the macro defined here
+  --> $DIR/auxiliary/glob-vs-expanded.rs:5:9
+   |
+LL | pub use inner::*;
+   |         ^^^^^
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
+   = note: this error originates in the macro `define_mac` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 1 previous error
+
+Future incompatibility report: Future breakage diagnostic:
+error: `mac` is ambiguous
+  --> $DIR/ambiguous-glob-vs-expanded-extern.rs:4:23
+   |
+LL |     glob_vs_expanded::mac!();
+   |                       ^^^ ambiguous name
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
+   = note: ambiguous because of a conflict between a name from a glob import and a macro-expanded name in the same module during import or macro resolution
+note: `mac` could refer to the macro defined here
+  --> $DIR/auxiliary/glob-vs-expanded.rs:11:1
+   |
+LL | define_mac!();
+   | ^^^^^^^^^^^^^
+note: `mac` could also refer to the macro defined here
+  --> $DIR/auxiliary/glob-vs-expanded.rs:5:9
+   |
+LL | pub use inner::*;
+   |         ^^^^^
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
+   = note: this error originates in the macro `define_mac` (in Nightly builds, run with -Z macro-backtrace for more info)
+

--- a/tests/ui/imports/auxiliary/glob-vs-expanded.rs
+++ b/tests/ui/imports/auxiliary/glob-vs-expanded.rs
@@ -1,0 +1,11 @@
+#![feature(decl_macro)]
+
+// Glob import in macro namespace
+mod inner { pub macro mac() {} }
+pub use inner::*;
+
+// Macro-expanded single import in macro namespace
+macro_rules! define_mac {
+    () => { pub macro mac() {} }
+}
+define_mac!();

--- a/tests/ui/imports/extern-with-ambiguous-2.rs
+++ b/tests/ui/imports/extern-with-ambiguous-2.rs
@@ -1,4 +1,3 @@
-//@ check-pass
 //@ edition: 2021
 //@ aux-build: extern-with-ambiguous-2-extern.rs
 
@@ -11,8 +10,6 @@ mod s {
 }
 use s::*;
 use extern_with_ambiguous_2_extern::*;
-use error::*;
-//^ FIXME: An ambiguity error should be thrown for `error`,
-// as there is ambiguity present within `extern-with-ambiguous-2-extern.rs`.
+use error::*; //~ ERROR `error` is ambiguous
 
 fn main() {}

--- a/tests/ui/imports/extern-with-ambiguous-2.stderr
+++ b/tests/ui/imports/extern-with-ambiguous-2.stderr
@@ -1,0 +1,23 @@
+error[E0659]: `error` is ambiguous
+  --> $DIR/extern-with-ambiguous-2.rs:13:5
+   |
+LL | use error::*;
+   |     ^^^^^ ambiguous name
+   |
+   = note: ambiguous because of multiple glob imports of a name in the same module
+note: `error` could refer to the module imported here
+  --> $DIR/extern-with-ambiguous-2.rs:11:5
+   |
+LL | use s::*;
+   |     ^^^^
+   = help: consider adding an explicit import of `error` to disambiguate
+note: `error` could also refer to the module imported here
+  --> $DIR/extern-with-ambiguous-2.rs:12:5
+   |
+LL | use extern_with_ambiguous_2_extern::*;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = help: consider adding an explicit import of `error` to disambiguate
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0659`.

--- a/tests/ui/imports/extern-with-ambiguous-3.rs
+++ b/tests/ui/imports/extern-with-ambiguous-3.rs
@@ -1,4 +1,3 @@
-//@ check-pass
 //@ edition: 2021
 //@ aux-build: extern-with-ambiguous-3-extern.rs
 // https://github.com/rust-lang/rust/pull/113099#issuecomment-1643974121
@@ -12,8 +11,6 @@ mod s {
 }
 use s::*;
 use extern_with_ambiguous_3_extern::*;
-use error::*;
-//^ FIXME: An ambiguity error should be thrown for `error`,
-// as there is ambiguity present within `extern-with-ambiguous-3-extern.rs`.
+use error::*; //~ ERROR `error` is ambiguous
 
 fn main() {}

--- a/tests/ui/imports/extern-with-ambiguous-3.stderr
+++ b/tests/ui/imports/extern-with-ambiguous-3.stderr
@@ -1,0 +1,23 @@
+error[E0659]: `error` is ambiguous
+  --> $DIR/extern-with-ambiguous-3.rs:14:5
+   |
+LL | use error::*;
+   |     ^^^^^ ambiguous name
+   |
+   = note: ambiguous because of multiple glob imports of a name in the same module
+note: `error` could refer to the module imported here
+  --> $DIR/extern-with-ambiguous-3.rs:12:5
+   |
+LL | use s::*;
+   |     ^^^^
+   = help: consider adding an explicit import of `error` to disambiguate
+note: `error` could also refer to the module imported here
+  --> $DIR/extern-with-ambiguous-3.rs:13:5
+   |
+LL | use extern_with_ambiguous_3_extern::*;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = help: consider adding an explicit import of `error` to disambiguate
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0659`.

--- a/tests/ui/imports/glob-conflict-cross-crate-1.rs
+++ b/tests/ui/imports/glob-conflict-cross-crate-1.rs
@@ -4,10 +4,8 @@
 extern crate glob_conflict;
 
 fn main() {
-    glob_conflict::f(); //~ ERROR cannot find function `f` in crate `glob_conflict`
-    //^ FIXME: `glob_conflict::f` should raise an
-    // ambiguity error instead of a not found error.
-    glob_conflict::glob::f(); //~ ERROR cannot find function `f` in module `glob_conflict::glob`
-    //^ FIXME: `glob_conflict::glob::f` should raise an
-    // ambiguity error instead of a not found error.
+    glob_conflict::f(); //~ ERROR `f` is ambiguous
+                        //~| WARN this was previously accepted
+    glob_conflict::glob::f(); //~ ERROR `f` is ambiguous
+                              //~| WARN this was previously accepted
 }

--- a/tests/ui/imports/glob-conflict-cross-crate-1.stderr
+++ b/tests/ui/imports/glob-conflict-cross-crate-1.stderr
@@ -1,15 +1,87 @@
-error[E0425]: cannot find function `f` in crate `glob_conflict`
+error: `f` is ambiguous
   --> $DIR/glob-conflict-cross-crate-1.rs:7:20
    |
 LL |     glob_conflict::f();
-   |                    ^ not found in `glob_conflict`
+   |                    ^ ambiguous name
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
+   = note: ambiguous because of multiple glob imports of a name in the same module
+note: `f` could refer to the function defined here
+  --> $DIR/auxiliary/glob-conflict.rs:12:9
+   |
+LL | pub use m1::*;
+   |         ^^
+note: `f` could also refer to the function defined here
+  --> $DIR/auxiliary/glob-conflict.rs:13:9
+   |
+LL | pub use m2::*;
+   |         ^^
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
-error[E0425]: cannot find function `f` in module `glob_conflict::glob`
-  --> $DIR/glob-conflict-cross-crate-1.rs:10:26
+error: `f` is ambiguous
+  --> $DIR/glob-conflict-cross-crate-1.rs:9:26
    |
 LL |     glob_conflict::glob::f();
-   |                          ^ not found in `glob_conflict::glob`
+   |                          ^ ambiguous name
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
+   = note: ambiguous because of multiple glob imports of a name in the same module
+note: `f` could refer to the function defined here
+  --> $DIR/auxiliary/glob-conflict.rs:12:9
+   |
+LL | pub use m1::*;
+   |         ^^
+note: `f` could also refer to the function defined here
+  --> $DIR/auxiliary/glob-conflict.rs:13:9
+   |
+LL | pub use m2::*;
+   |         ^^
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0425`.
+Future incompatibility report: Future breakage diagnostic:
+error: `f` is ambiguous
+  --> $DIR/glob-conflict-cross-crate-1.rs:7:20
+   |
+LL |     glob_conflict::f();
+   |                    ^ ambiguous name
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
+   = note: ambiguous because of multiple glob imports of a name in the same module
+note: `f` could refer to the function defined here
+  --> $DIR/auxiliary/glob-conflict.rs:12:9
+   |
+LL | pub use m1::*;
+   |         ^^
+note: `f` could also refer to the function defined here
+  --> $DIR/auxiliary/glob-conflict.rs:13:9
+   |
+LL | pub use m2::*;
+   |         ^^
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
+
+Future breakage diagnostic:
+error: `f` is ambiguous
+  --> $DIR/glob-conflict-cross-crate-1.rs:9:26
+   |
+LL |     glob_conflict::glob::f();
+   |                          ^ ambiguous name
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
+   = note: ambiguous because of multiple glob imports of a name in the same module
+note: `f` could refer to the function defined here
+  --> $DIR/auxiliary/glob-conflict.rs:12:9
+   |
+LL | pub use m1::*;
+   |         ^^
+note: `f` could also refer to the function defined here
+  --> $DIR/auxiliary/glob-conflict.rs:13:9
+   |
+LL | pub use m2::*;
+   |         ^^
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
+

--- a/tests/ui/imports/glob-conflict-cross-crate-2.rs
+++ b/tests/ui/imports/glob-conflict-cross-crate-2.rs
@@ -5,6 +5,6 @@ extern crate glob_conflict_cross_crate_2_extern;
 use glob_conflict_cross_crate_2_extern::*;
 
 fn main() {
-    let _a: C = 1; //~ ERROR cannot find type `C` in this scope
-    //^ FIXME: `C` should be identified as an ambiguous item.
+    let _a: C = 1; //~ ERROR `C` is ambiguous
+                   //~| WARN this was previously accepted
 }

--- a/tests/ui/imports/glob-conflict-cross-crate-3.rs
+++ b/tests/ui/imports/glob-conflict-cross-crate-3.rs
@@ -1,4 +1,3 @@
-//@ check-pass
 //@ aux-build:glob-conflict-cross-crate-2-extern.rs
 
 extern crate glob_conflict_cross_crate_2_extern;
@@ -12,5 +11,8 @@ use a::*;
 
 fn main() {
     let _a: C = 1;
-    //^ FIXME: `C` should be identified as an ambiguous item.
+    //~^ ERROR `C` is ambiguous
+    //~| ERROR `C` is ambiguous
+    //~| WARN this was previously accepted
+    //~| WARN this was previously accepted
 }

--- a/tests/ui/imports/glob-conflict-cross-crate-3.stderr
+++ b/tests/ui/imports/glob-conflict-cross-crate-3.stderr
@@ -1,0 +1,91 @@
+error: `C` is ambiguous
+  --> $DIR/glob-conflict-cross-crate-3.rs:13:13
+   |
+LL |     let _a: C = 1;
+   |             ^ ambiguous name
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
+   = note: ambiguous because of multiple glob imports of a name in the same module
+note: `C` could refer to the type alias defined here
+  --> $DIR/auxiliary/glob-conflict-cross-crate-2-extern.rs:9:9
+   |
+LL | pub use a::*;
+   |         ^
+note: `C` could also refer to the type alias defined here
+  --> $DIR/auxiliary/glob-conflict-cross-crate-2-extern.rs:10:9
+   |
+LL | pub use b::*;
+   |         ^
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
+
+error: `C` is ambiguous
+  --> $DIR/glob-conflict-cross-crate-3.rs:13:13
+   |
+LL |     let _a: C = 1;
+   |             ^ ambiguous name
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
+   = note: ambiguous because of multiple glob imports of a name in the same module
+note: `C` could refer to the type alias imported here
+  --> $DIR/glob-conflict-cross-crate-3.rs:9:5
+   |
+LL | use glob_conflict_cross_crate_2_extern::*;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = help: consider adding an explicit import of `C` to disambiguate
+note: `C` could also refer to the type alias imported here
+  --> $DIR/glob-conflict-cross-crate-3.rs:10:5
+   |
+LL | use a::*;
+   |     ^^^^
+   = help: consider adding an explicit import of `C` to disambiguate
+
+error: aborting due to 2 previous errors
+
+Future incompatibility report: Future breakage diagnostic:
+error: `C` is ambiguous
+  --> $DIR/glob-conflict-cross-crate-3.rs:13:13
+   |
+LL |     let _a: C = 1;
+   |             ^ ambiguous name
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
+   = note: ambiguous because of multiple glob imports of a name in the same module
+note: `C` could refer to the type alias defined here
+  --> $DIR/auxiliary/glob-conflict-cross-crate-2-extern.rs:9:9
+   |
+LL | pub use a::*;
+   |         ^
+note: `C` could also refer to the type alias defined here
+  --> $DIR/auxiliary/glob-conflict-cross-crate-2-extern.rs:10:9
+   |
+LL | pub use b::*;
+   |         ^
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
+
+Future breakage diagnostic:
+error: `C` is ambiguous
+  --> $DIR/glob-conflict-cross-crate-3.rs:13:13
+   |
+LL |     let _a: C = 1;
+   |             ^ ambiguous name
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
+   = note: ambiguous because of multiple glob imports of a name in the same module
+note: `C` could refer to the type alias imported here
+  --> $DIR/glob-conflict-cross-crate-3.rs:9:5
+   |
+LL | use glob_conflict_cross_crate_2_extern::*;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = help: consider adding an explicit import of `C` to disambiguate
+note: `C` could also refer to the type alias imported here
+  --> $DIR/glob-conflict-cross-crate-3.rs:10:5
+   |
+LL | use a::*;
+   |     ^^^^
+   = help: consider adding an explicit import of `C` to disambiguate
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
+

--- a/tests/ui/imports/issue-114682-2.rs
+++ b/tests/ui/imports/issue-114682-2.rs
@@ -3,17 +3,10 @@
 
 extern crate issue_114682_2_extern;
 
-use issue_114682_2_extern::max;
+use issue_114682_2_extern::max; //~ ERROR `max` is ambiguous
+                                //~| WARN this was previously accepted
 
-type A = issue_114682_2_extern::max;
-//~^ ERROR: expected type, found function `issue_114682_2_extern::max`
-// FIXME:
-// The above error was emitted due to `(Mod(issue_114682_2_extern), Namespace(Type), Ident(max))`
-// being identified as an ambiguous item.
-// However, there are two points worth discussing:
-// First, should this ambiguous item be omitted considering the maximum visibility
-// of `issue_114682_2_extern::m::max` in the type namespace is only within the extern crate.
-// Second, if we retain the ambiguous item of the extern crate, should it be treated
-// as an ambiguous item within the local crate for the same reasoning?
+type A = issue_114682_2_extern::max; //~ ERROR `max` is ambiguous
+                                     //~| WARN this was previously accepted
 
 fn main() {}

--- a/tests/ui/imports/issue-114682-2.stderr
+++ b/tests/ui/imports/issue-114682-2.stderr
@@ -1,9 +1,87 @@
-error[E0573]: expected type, found function `issue_114682_2_extern::max`
-  --> $DIR/issue-114682-2.rs:8:10
+error: `max` is ambiguous
+  --> $DIR/issue-114682-2.rs:6:28
+   |
+LL | use issue_114682_2_extern::max;
+   |                            ^^^ ambiguous name
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
+   = note: ambiguous because of multiple glob imports of a name in the same module
+note: `max` could refer to the type alias defined here
+  --> $DIR/auxiliary/issue-114682-2-extern.rs:17:9
+   |
+LL | pub use self::e::*;
+   |         ^^^^^^^
+note: `max` could also refer to the module defined here
+  --> $DIR/auxiliary/issue-114682-2-extern.rs:16:9
+   |
+LL | pub use self::d::*;
+   |         ^^^^^^^
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
+
+error: `max` is ambiguous
+  --> $DIR/issue-114682-2.rs:9:33
    |
 LL | type A = issue_114682_2_extern::max;
-   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^ not a type
+   |                                 ^^^ ambiguous name
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
+   = note: ambiguous because of multiple glob imports of a name in the same module
+note: `max` could refer to the type alias defined here
+  --> $DIR/auxiliary/issue-114682-2-extern.rs:17:9
+   |
+LL | pub use self::e::*;
+   |         ^^^^^^^
+note: `max` could also refer to the module defined here
+  --> $DIR/auxiliary/issue-114682-2-extern.rs:16:9
+   |
+LL | pub use self::d::*;
+   |         ^^^^^^^
 
-error: aborting due to 1 previous error
+error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0573`.
+Future incompatibility report: Future breakage diagnostic:
+error: `max` is ambiguous
+  --> $DIR/issue-114682-2.rs:6:28
+   |
+LL | use issue_114682_2_extern::max;
+   |                            ^^^ ambiguous name
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
+   = note: ambiguous because of multiple glob imports of a name in the same module
+note: `max` could refer to the type alias defined here
+  --> $DIR/auxiliary/issue-114682-2-extern.rs:17:9
+   |
+LL | pub use self::e::*;
+   |         ^^^^^^^
+note: `max` could also refer to the module defined here
+  --> $DIR/auxiliary/issue-114682-2-extern.rs:16:9
+   |
+LL | pub use self::d::*;
+   |         ^^^^^^^
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
+
+Future breakage diagnostic:
+error: `max` is ambiguous
+  --> $DIR/issue-114682-2.rs:9:33
+   |
+LL | type A = issue_114682_2_extern::max;
+   |                                 ^^^ ambiguous name
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
+   = note: ambiguous because of multiple glob imports of a name in the same module
+note: `max` could refer to the type alias defined here
+  --> $DIR/auxiliary/issue-114682-2-extern.rs:17:9
+   |
+LL | pub use self::e::*;
+   |         ^^^^^^^
+note: `max` could also refer to the module defined here
+  --> $DIR/auxiliary/issue-114682-2-extern.rs:16:9
+   |
+LL | pub use self::d::*;
+   |         ^^^^^^^
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
+

--- a/tests/ui/imports/issue-114682-3.rs
+++ b/tests/ui/imports/issue-114682-3.rs
@@ -1,4 +1,3 @@
-//@ check-pass
 //@ aux-build: issue-114682-3-extern.rs
 // https://github.com/rust-lang/rust/pull/114682#issuecomment-1880625909
 
@@ -19,6 +18,5 @@ pub use self::auto::*;
 fn main() {
     let a: u8 = 1;
     a.ext();
-    //^ FIXME: it should report `ext` not found because `SettingsExt`
-    // is an ambiguous item in `issue-114682-3-extern.rs`.
+    //~^ ERROR no method named `ext` found for type `u8` in the current scope
 }

--- a/tests/ui/imports/issue-114682-3.stderr
+++ b/tests/ui/imports/issue-114682-3.stderr
@@ -1,0 +1,18 @@
+error[E0599]: no method named `ext` found for type `u8` in the current scope
+  --> $DIR/issue-114682-3.rs:20:7
+   |
+LL |         fn ext(&self) {}
+   |            --- the method is available for `u8` here
+...
+LL |     a.ext();
+   |       ^^^ method not found in `u8`
+   |
+   = help: items from traits can only be used if the trait is in scope
+help: trait `SettingsExt` which provides `ext` is implemented but not in scope; perhaps you want to import it
+   |
+LL + use auto::SettingsExt;
+   |
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0599`.

--- a/tests/ui/imports/issue-114682-4.rs
+++ b/tests/ui/imports/issue-114682-4.rs
@@ -1,4 +1,3 @@
-//@ check-pass
 //@ aux-build: issue-114682-4-extern.rs
 // https://github.com/rust-lang/rust/pull/114682#issuecomment-1880755441
 
@@ -6,7 +5,9 @@ extern crate issue_114682_4_extern;
 
 use issue_114682_4_extern::*;
 
-fn a() -> Result<i32, ()> { // FIXME: `Result` should be identified as an ambiguous item.
+//~v ERROR type alias takes 1 generic argument but 2 generic arguments were supplied
+fn a() -> Result<i32, ()> { //~ ERROR `Result` is ambiguous
+                            //~| WARN this was previously accepted
     Ok(1)
 }
 

--- a/tests/ui/imports/issue-114682-4.stderr
+++ b/tests/ui/imports/issue-114682-4.stderr
@@ -1,0 +1,60 @@
+error: `Result` is ambiguous
+  --> $DIR/issue-114682-4.rs:9:11
+   |
+LL | fn a() -> Result<i32, ()> {
+   |           ^^^^^^ ambiguous name
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
+   = note: ambiguous because of multiple glob imports of a name in the same module
+note: `Result` could refer to the type alias defined here
+  --> $DIR/auxiliary/issue-114682-4-extern.rs:9:9
+   |
+LL | pub use a::*;
+   |         ^
+note: `Result` could also refer to the type alias defined here
+  --> $DIR/auxiliary/issue-114682-4-extern.rs:10:9
+   |
+LL | pub use b::*;
+   |         ^
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
+
+error[E0107]: type alias takes 1 generic argument but 2 generic arguments were supplied
+  --> $DIR/issue-114682-4.rs:9:11
+   |
+LL | fn a() -> Result<i32, ()> {
+   |           ^^^^^^    ---- help: remove the unnecessary generic argument
+   |           |
+   |           expected 1 generic argument
+   |
+note: type alias defined here, with 1 generic parameter: `T`
+  --> $DIR/auxiliary/issue-114682-4-extern.rs:2:14
+   |
+LL |     pub type Result<T> = std::result::Result<T, ()>;
+   |              ^^^^^^ -
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0107`.
+Future incompatibility report: Future breakage diagnostic:
+error: `Result` is ambiguous
+  --> $DIR/issue-114682-4.rs:9:11
+   |
+LL | fn a() -> Result<i32, ()> {
+   |           ^^^^^^ ambiguous name
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
+   = note: ambiguous because of multiple glob imports of a name in the same module
+note: `Result` could refer to the type alias defined here
+  --> $DIR/auxiliary/issue-114682-4-extern.rs:9:9
+   |
+LL | pub use a::*;
+   |         ^
+note: `Result` could also refer to the type alias defined here
+  --> $DIR/auxiliary/issue-114682-4-extern.rs:10:9
+   |
+LL | pub use b::*;
+   |         ^
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
+

--- a/tests/ui/imports/issue-114682-5.rs
+++ b/tests/ui/imports/issue-114682-5.rs
@@ -1,4 +1,3 @@
-//@ check-pass
 //@ edition: 2018
 //@ aux-build: issue-114682-5-extern-1.rs
 //@ aux-build: issue-114682-5-extern-2.rs
@@ -9,7 +8,9 @@ extern crate issue_114682_5_extern_2;
 
 use issue_114682_5_extern_2::p::*;
 use issue_114682_5_extern_1::Url;
-// FIXME: The `issue_114682_5_extern_1` should be considered an ambiguous item,
-// as it has already been recognized as ambiguous in `issue_114682_5_extern_2`.
+//~^ ERROR `issue_114682_5_extern_1` is ambiguous
+//~| ERROR `issue_114682_5_extern_1` is ambiguous
+//~| ERROR unresolved import `issue_114682_5_extern_1::Url`
+//~| WARN this was previously accepted
 
 fn main() {}

--- a/tests/ui/imports/issue-114682-5.stderr
+++ b/tests/ui/imports/issue-114682-5.stderr
@@ -1,0 +1,77 @@
+error[E0432]: unresolved import `issue_114682_5_extern_1::Url`
+  --> $DIR/issue-114682-5.rs:10:5
+   |
+LL | use issue_114682_5_extern_1::Url;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `Url` in `types::issue_114682_5_extern_1`
+   |
+help: consider importing this struct instead
+   |
+LL | use ::issue_114682_5_extern_1::Url;
+   |     ++
+
+error[E0659]: `issue_114682_5_extern_1` is ambiguous
+  --> $DIR/issue-114682-5.rs:10:5
+   |
+LL | use issue_114682_5_extern_1::Url;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^ ambiguous name
+   |
+   = note: ambiguous because of a conflict between a name from a glob import and an outer scope during import or macro resolution
+   = note: `issue_114682_5_extern_1` could refer to a crate passed with `--extern`
+   = help: use `::issue_114682_5_extern_1` to refer to this crate unambiguously
+note: `issue_114682_5_extern_1` could also refer to the module imported here
+  --> $DIR/issue-114682-5.rs:9:5
+   |
+LL | use issue_114682_5_extern_2::p::*;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = help: consider adding an explicit import of `issue_114682_5_extern_1` to disambiguate
+   = help: or use `crate::issue_114682_5_extern_1` to refer to this module unambiguously
+
+error: `issue_114682_5_extern_1` is ambiguous
+  --> $DIR/issue-114682-5.rs:10:5
+   |
+LL | use issue_114682_5_extern_1::Url;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^ ambiguous name
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
+   = note: ambiguous because of multiple glob imports of a name in the same module
+note: `issue_114682_5_extern_1` could refer to the module defined here
+  --> $DIR/auxiliary/issue-114682-5-extern-2.rs:6:13
+   |
+LL |     pub use crate::types::*;
+   |             ^^^^^^^^^^^^
+note: `issue_114682_5_extern_1` could also refer to the crate defined here
+  --> $DIR/auxiliary/issue-114682-5-extern-2.rs:7:13
+   |
+LL |     pub use crate::*;
+   |             ^^^^^
+   = help: use `::issue_114682_5_extern_1` to refer to this crate unambiguously
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0432, E0659.
+For more information about an error, try `rustc --explain E0432`.
+Future incompatibility report: Future breakage diagnostic:
+error: `issue_114682_5_extern_1` is ambiguous
+  --> $DIR/issue-114682-5.rs:10:5
+   |
+LL | use issue_114682_5_extern_1::Url;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^ ambiguous name
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
+   = note: ambiguous because of multiple glob imports of a name in the same module
+note: `issue_114682_5_extern_1` could refer to the module defined here
+  --> $DIR/auxiliary/issue-114682-5-extern-2.rs:6:13
+   |
+LL |     pub use crate::types::*;
+   |             ^^^^^^^^^^^^
+note: `issue_114682_5_extern_1` could also refer to the crate defined here
+  --> $DIR/auxiliary/issue-114682-5-extern-2.rs:7:13
+   |
+LL |     pub use crate::*;
+   |             ^^^^^
+   = help: use `::issue_114682_5_extern_1` to refer to this crate unambiguously
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
+

--- a/tests/ui/imports/issue-114682-6.rs
+++ b/tests/ui/imports/issue-114682-6.rs
@@ -1,4 +1,3 @@
-//@ check-pass
 //@ aux-build: issue-114682-6-extern.rs
 // https://github.com/rust-lang/rust/pull/114682#issuecomment-1880755441
 
@@ -7,7 +6,7 @@ extern crate issue_114682_6_extern;
 use issue_114682_6_extern::*;
 
 fn main() {
-    let log = 2;
-    //^ `log` should be identified as an ambiguous item.
+    let log = 2; //~ ERROR `log` is ambiguous
+                 //~| WARN this was previously accepted
     let _ = log;
 }

--- a/tests/ui/imports/issue-114682-6.stderr
+++ b/tests/ui/imports/issue-114682-6.stderr
@@ -1,45 +1,45 @@
-error: `C` is ambiguous
-  --> $DIR/glob-conflict-cross-crate-2.rs:8:13
+error: `log` is ambiguous
+  --> $DIR/issue-114682-6.rs:9:9
    |
-LL |     let _a: C = 1;
-   |             ^ ambiguous name
+LL |     let log = 2;
+   |         ^^^ ambiguous name
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
-note: `C` could refer to the type alias defined here
-  --> $DIR/auxiliary/glob-conflict-cross-crate-2-extern.rs:9:9
+note: `log` could refer to the function defined here
+  --> $DIR/auxiliary/issue-114682-6-extern.rs:8:9
    |
-LL | pub use a::*;
-   |         ^
-note: `C` could also refer to the type alias defined here
-  --> $DIR/auxiliary/glob-conflict-cross-crate-2-extern.rs:10:9
+LL | pub use self::a::*;
+   |         ^^^^^^^
+note: `log` could also refer to the function defined here
+  --> $DIR/auxiliary/issue-114682-6-extern.rs:9:9
    |
-LL | pub use b::*;
-   |         ^
+LL | pub use self::b::*;
+   |         ^^^^^^^
    = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
 error: aborting due to 1 previous error
 
 Future incompatibility report: Future breakage diagnostic:
-error: `C` is ambiguous
-  --> $DIR/glob-conflict-cross-crate-2.rs:8:13
+error: `log` is ambiguous
+  --> $DIR/issue-114682-6.rs:9:9
    |
-LL |     let _a: C = 1;
-   |             ^ ambiguous name
+LL |     let log = 2;
+   |         ^^^ ambiguous name
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
-note: `C` could refer to the type alias defined here
-  --> $DIR/auxiliary/glob-conflict-cross-crate-2-extern.rs:9:9
+note: `log` could refer to the function defined here
+  --> $DIR/auxiliary/issue-114682-6-extern.rs:8:9
    |
-LL | pub use a::*;
-   |         ^
-note: `C` could also refer to the type alias defined here
-  --> $DIR/auxiliary/glob-conflict-cross-crate-2-extern.rs:10:9
+LL | pub use self::a::*;
+   |         ^^^^^^^
+note: `log` could also refer to the function defined here
+  --> $DIR/auxiliary/issue-114682-6-extern.rs:9:9
    |
-LL | pub use b::*;
-   |         ^
+LL | pub use self::b::*;
+   |         ^^^^^^^
    = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 


### PR DESCRIPTION
So in cross-crate scenarios they can work in the same way as in crate-local scenarios.

Change Description: https://github.com/rust-lang/rust/pull/147984#issuecomment-3455514826

Resurrection of https://github.com/rust-lang/rust/pull/114682.
One of unblocking steps for https://github.com/rust-lang/rust/pull/145108.
Fixes https://github.com/rust-lang/rust/issues/36837.