### PR TITLE
Use fstatat() in DirEntry::metadata on Apple platforms

### DIFF
--- a/library/std/src/sys/fs/unix.rs
+++ b/library/std/src/sys/fs/unix.rs
@@ -17,7 +17,7 @@ use libc::c_char;
     target_vendor = "apple",
 ))]
 use libc::dirfd;
-#[cfg(any(target_os = "fuchsia", target_os = "illumos", target_vendor = "apple")]
+#[cfg(any(target_os = "fuchsia", target_os = "illumos", target_vendor = "apple"))]
 use libc::fstatat as fstatat64;
 #[cfg(any(all(target_os = "linux", not(target_env = "musl")), target_os = "hurd"))]
 use libc::fstatat64;

--- a/library/std/src/sys/fs/unix.rs
+++ b/library/std/src/sys/fs/unix.rs
@@ -14,9 +14,10 @@ use libc::c_char;
     target_os = "fuchsia",
     target_os = "hurd",
     target_os = "illumos",
+    target_vendor = "apple",
 ))]
 use libc::dirfd;
-#[cfg(any(target_os = "fuchsia", target_os = "illumos"))]
+#[cfg(any(target_os = "fuchsia", target_os = "illumos", target_vendor = "apple")]
 use libc::fstatat as fstatat64;
 #[cfg(any(all(target_os = "linux", not(target_env = "musl")), target_os = "hurd"))]
 use libc::fstatat64;
@@ -907,6 +908,7 @@ impl DirEntry {
             target_os = "fuchsia",
             target_os = "hurd",
             target_os = "illumos",
+            target_vendor = "apple",
         ),
         not(miri) // no dirfd on Miri
     ))]
@@ -937,6 +939,7 @@ impl DirEntry {
             target_os = "fuchsia",
             target_os = "hurd",
             target_os = "illumos",
+            target_vendor = "apple",
         )),
         miri
     ))]


### PR DESCRIPTION
Apple supports `fstatat` on macOS >=10.10 ([source](https://gitlab.gnome.org/GNOME/glib/-/issues/2203)), and according to [Platform Support](https://doc.rust-lang.org/beta/rustc/platform-support.html) the oldest supported version is 10.12.

Google says iOS >=10 supports `fstatat` but doesn't provide a source. [*-apple-ios](https://doc.rust-lang.org/beta/rustc/platform-support/apple-ios.html#os-version) says the minimum supported iOS version is 10.0.

Unsure about tvOS, watchOS and visionOS, hoping CI can confirm this.

I am testing with [fastdu](https://github.com/jesseschalken/fastdu) which is effectively a stress test for `DirEntry::metadata`. In one test this provides a **1.13x** speedup.

```
$ hyperfine --warmup 1 'target/release/fastdu testdir' 'fastdu testdir'
Benchmark 1: target/release/fastdu testdir
  Time (mean ± σ):     154.6 ms ±  17.4 ms    [User: 31.7 ms, System: 187.6 ms]
  Range (min … max):   148.4 ms … 225.5 ms    19 runs
 
Benchmark 2: fastdu testdir
  Time (mean ± σ):     175.3 ms ±  15.8 ms    [User: 50.0 ms, System: 196.2 ms]
  Range (min … max):   165.4 ms … 211.7 ms    17 runs
 
Summary
  target/release/fastdu testdir ran
    1.13 ± 0.16 times faster than fastdu testdir
```

You can also reproduce a speedup with a program like this (providing a directory with many entries):

```rust
fn main() {
    let args: Vec<_> = std::env::args_os().collect();
    let dir: PathBuf = args[1].clone().into();

    for entry in dir.read_dir().as_mut().unwrap() {
        let entry = entry.as_ref().unwrap();
        let metadata = entry.metadata();
        let metadata = metadata.as_ref().unwrap();
        println!("{} {}", metadata.len(), entry.file_name().display());
    }
}
```

```
$ hyperfine './target/release/main testdir' './main testdir'
Benchmark 1: ./target/release/main testdir
  Time (mean ± σ):     148.3 ms ±   5.2 ms    [User: 23.1 ms, System: 122.9 ms]
  Range (min … max):   145.2 ms … 167.2 ms    19 runs
 
Benchmark 2: ./main testdir
  Time (mean ± σ):     164.4 ms ±   9.5 ms    [User: 32.6 ms, System: 128.8 ms]
  Range (min … max):   158.5 ms … 199.5 ms    17 runs
 
Summary
  ./target/release/main testdir ran
    1.11 ± 0.07 times faster than ./main testdir
```