### PR TITLE
Fix attribute style for `#[macro_export]`

### DIFF
--- a/compiler/rustc_attr_parsing/src/attributes/macro_attrs.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/macro_attrs.rs
@@ -1,4 +1,3 @@
-use rustc_ast::AttrStyle;
 use rustc_errors::DiagArgValue;
 use rustc_hir::attrs::MacroUseArgs;
 
@@ -149,10 +148,9 @@ impl<S: Stage> SingleAttributeParser<S> for MacroExportParser {
     ]);
 
     fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser<'_>) -> Option<AttributeKind> {
-        let suggestions = || {
-            <Self as SingleAttributeParser<S>>::TEMPLATE
-                .suggestions(AttrStyle::Inner, "macro_export")
-        };
+        let attr_style = cx.attr_style;
+        let suggestions =
+            || <Self as SingleAttributeParser<S>>::TEMPLATE.suggestions(attr_style, "macro_export");
         let local_inner_macros = match args {
             ArgParser::NoArgs => false,
             ArgParser::List(list) => {

--- a/tests/ui/attributes/invalid_macro_export_argument.allow.stderr
+++ b/tests/ui/attributes/invalid_macro_export_argument.allow.stderr
@@ -1,5 +1,5 @@
 Future incompatibility report: Future breakage diagnostic:
-warning: valid forms for the attribute are `#![macro_export(local_inner_macros)]` and `#![macro_export]`
+warning: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
   --> $DIR/invalid_macro_export_argument.rs:7:1
    |
 LL | #[macro_export(hello, world)]
@@ -9,7 +9,7 @@ LL | #[macro_export(hello, world)]
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
 
 Future breakage diagnostic:
-warning: valid forms for the attribute are `#![macro_export(local_inner_macros)]` and `#![macro_export]`
+warning: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
   --> $DIR/invalid_macro_export_argument.rs:14:1
    |
 LL | #[macro_export(not_local_inner_macros)]
@@ -19,7 +19,7 @@ LL | #[macro_export(not_local_inner_macros)]
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
 
 Future breakage diagnostic:
-warning: valid forms for the attribute are `#![macro_export(local_inner_macros)]` and `#![macro_export]`
+warning: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
   --> $DIR/invalid_macro_export_argument.rs:31:1
    |
 LL | #[macro_export()]
@@ -29,7 +29,7 @@ LL | #[macro_export()]
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
 
 Future breakage diagnostic:
-warning: valid forms for the attribute are `#![macro_export(local_inner_macros)]` and `#![macro_export]`
+warning: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
   --> $DIR/invalid_macro_export_argument.rs:38:1
    |
 LL | #[macro_export("blah")]

--- a/tests/ui/attributes/invalid_macro_export_argument.deny.stderr
+++ b/tests/ui/attributes/invalid_macro_export_argument.deny.stderr
@@ -1,4 +1,4 @@
-error: valid forms for the attribute are `#![macro_export(local_inner_macros)]` and `#![macro_export]`
+error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
   --> $DIR/invalid_macro_export_argument.rs:7:1
    |
 LL | #[macro_export(hello, world)]
@@ -12,7 +12,7 @@ note: the lint level is defined here
 LL | #![cfg_attr(deny, deny(invalid_macro_export_arguments))]
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: valid forms for the attribute are `#![macro_export(local_inner_macros)]` and `#![macro_export]`
+error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
   --> $DIR/invalid_macro_export_argument.rs:14:1
    |
 LL | #[macro_export(not_local_inner_macros)]
@@ -21,7 +21,7 @@ LL | #[macro_export(not_local_inner_macros)]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
 
-error: valid forms for the attribute are `#![macro_export(local_inner_macros)]` and `#![macro_export]`
+error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
   --> $DIR/invalid_macro_export_argument.rs:31:1
    |
 LL | #[macro_export()]
@@ -30,7 +30,7 @@ LL | #[macro_export()]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
 
-error: valid forms for the attribute are `#![macro_export(local_inner_macros)]` and `#![macro_export]`
+error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
   --> $DIR/invalid_macro_export_argument.rs:38:1
    |
 LL | #[macro_export("blah")]
@@ -42,7 +42,7 @@ LL | #[macro_export("blah")]
 error: aborting due to 4 previous errors
 
 Future incompatibility report: Future breakage diagnostic:
-error: valid forms for the attribute are `#![macro_export(local_inner_macros)]` and `#![macro_export]`
+error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
   --> $DIR/invalid_macro_export_argument.rs:7:1
    |
 LL | #[macro_export(hello, world)]
@@ -57,7 +57,7 @@ LL | #![cfg_attr(deny, deny(invalid_macro_export_arguments))]
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Future breakage diagnostic:
-error: valid forms for the attribute are `#![macro_export(local_inner_macros)]` and `#![macro_export]`
+error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
   --> $DIR/invalid_macro_export_argument.rs:14:1
    |
 LL | #[macro_export(not_local_inner_macros)]
@@ -72,7 +72,7 @@ LL | #![cfg_attr(deny, deny(invalid_macro_export_arguments))]
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Future breakage diagnostic:
-error: valid forms for the attribute are `#![macro_export(local_inner_macros)]` and `#![macro_export]`
+error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
   --> $DIR/invalid_macro_export_argument.rs:31:1
    |
 LL | #[macro_export()]
@@ -87,7 +87,7 @@ LL | #![cfg_attr(deny, deny(invalid_macro_export_arguments))]
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Future breakage diagnostic:
-error: valid forms for the attribute are `#![macro_export(local_inner_macros)]` and `#![macro_export]`
+error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
   --> $DIR/invalid_macro_export_argument.rs:38:1
    |
 LL | #[macro_export("blah")]

--- a/tests/ui/attributes/malformed-attrs.stderr
+++ b/tests/ui/attributes/malformed-attrs.stderr
@@ -701,7 +701,7 @@ error: valid forms for the attribute are `#[macro_use(name1, name2, ...)]` and `
 LL | #[macro_use = 1]
    | ^^^^^^^^^^^^^^^^
 
-error: valid forms for the attribute are `#![macro_export(local_inner_macros)]` and `#![macro_export]`
+error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
   --> $DIR/malformed-attrs.rs:221:1
    |
 LL | #[macro_export = 18]


### PR DESCRIPTION
r? @jdonszelmann 