### PR TITLE
[rustdoc] Check `doc(cfg())` even of private/hidden items

### DIFF
--- a/src/librustdoc/passes/mod.rs
+++ b/src/librustdoc/passes/mod.rs
@@ -95,11 +95,11 @@ pub(crate) const DEFAULT_PASSES: &[ConditionalPass] = &[
     ConditionalPass::always(CHECK_DOC_TEST_VISIBILITY),
     ConditionalPass::always(CHECK_DOC_CFG),
     ConditionalPass::always(STRIP_ALIASED_NON_LOCAL),
+    ConditionalPass::always(PROPAGATE_DOC_CFG),
     ConditionalPass::new(STRIP_HIDDEN, WhenNotDocumentHidden),
     ConditionalPass::new(STRIP_PRIVATE, WhenNotDocumentPrivate),
     ConditionalPass::new(STRIP_PRIV_IMPORTS, WhenDocumentPrivate),
     ConditionalPass::always(COLLECT_INTRA_DOC_LINKS),
-    ConditionalPass::always(PROPAGATE_DOC_CFG),
     ConditionalPass::always(PROPAGATE_STABILITY),
     ConditionalPass::always(RUN_LINTS),
 ];

--- a/tests/rustdoc-ui/invalid-cfg.rs
+++ b/tests/rustdoc-ui/invalid-cfg.rs
@@ -2,3 +2,20 @@
 #[doc(cfg = "x")] //~ ERROR not followed by parentheses
 #[doc(cfg(x, y))] //~ ERROR multiple `cfg` predicates
 pub struct S {}
+
+// We check it also fails on private items.
+#[doc(cfg = "x")] //~ ERROR not followed by parentheses
+#[doc(cfg(x, y))] //~ ERROR multiple `cfg` predicates
+struct X {}
+
+// We check it also fails on hidden items.
+#[doc(cfg = "x")] //~ ERROR not followed by parentheses
+#[doc(cfg(x, y))] //~ ERROR multiple `cfg` predicates
+#[doc(hidden)]
+pub struct Y {}
+
+// We check it also fails on hidden AND private items.
+#[doc(cfg = "x")] //~ ERROR not followed by parentheses
+#[doc(cfg(x, y))] //~ ERROR multiple `cfg` predicates
+#[doc(hidden)]
+struct Z {}

--- a/tests/rustdoc-ui/invalid-cfg.stderr
+++ b/tests/rustdoc-ui/invalid-cfg.stderr
@@ -10,5 +10,41 @@ error: multiple `cfg` predicates are specified
 LL | #[doc(cfg(x, y))]
    |              ^
 
-error: aborting due to 2 previous errors
+error: `cfg` is not followed by parentheses
+  --> $DIR/invalid-cfg.rs:7:7
+   |
+LL | #[doc(cfg = "x")]
+   |       ^^^^^^^^^ help: expected syntax is: `cfg(/* predicate */)`
+
+error: multiple `cfg` predicates are specified
+  --> $DIR/invalid-cfg.rs:8:14
+   |
+LL | #[doc(cfg(x, y))]
+   |              ^
+
+error: `cfg` is not followed by parentheses
+  --> $DIR/invalid-cfg.rs:12:7
+   |
+LL | #[doc(cfg = "x")]
+   |       ^^^^^^^^^ help: expected syntax is: `cfg(/* predicate */)`
+
+error: multiple `cfg` predicates are specified
+  --> $DIR/invalid-cfg.rs:13:14
+   |
+LL | #[doc(cfg(x, y))]
+   |              ^
+
+error: `cfg` is not followed by parentheses
+  --> $DIR/invalid-cfg.rs:18:7
+   |
+LL | #[doc(cfg = "x")]
+   |       ^^^^^^^^^ help: expected syntax is: `cfg(/* predicate */)`
+
+error: multiple `cfg` predicates are specified
+  --> $DIR/invalid-cfg.rs:19:14
+   |
+LL | #[doc(cfg(x, y))]
+   |              ^
+
+error: aborting due to 8 previous errors
 

--- a/tests/rustdoc-ui/issues/issue-91713.stdout
+++ b/tests/rustdoc-ui/issues/issue-91713.stdout
@@ -17,11 +17,11 @@ Default passes for rustdoc:
 check_doc_test_visibility
        check-doc-cfg
 strip-aliased-non-local
+   propagate-doc-cfg
         strip-hidden  (when not --document-hidden-items)
        strip-private  (when not --document-private-items)
   strip-priv-imports  (when --document-private-items)
 collect-intra-doc-links
-   propagate-doc-cfg
  propagate-stability
            run-lints
 


### PR DESCRIPTION
Fixes regression found out by @fmease [here](https://github.com/rust-lang/rust/pull/138907#discussion_r2382597615).

In short: the pass which checks the `doc(cfg())` attributes needed to be moved before the private/hidden stripping items passes.