### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_attr_parsing/src/attributes/crate_level.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/crate_level.rs
@@ -20,12 +20,7 @@ impl<S: Stage> SingleAttributeParser<S> for CrateNameParser {
             return None;
         };
 
-        Some(AttributeKind::CrateName {
-            name,
-            name_span: n.value_span,
-            attr_span: cx.attr_span,
-            style: cx.attr_style,
-        })
+        Some(AttributeKind::CrateName { name, name_span: n.value_span, attr_span: cx.attr_span })
     }
 }
 

--- a/compiler/rustc_hir/src/attrs/data_structures.rs
+++ b/compiler/rustc_hir/src/attrs/data_structures.rs
@@ -499,7 +499,7 @@ pub enum AttributeKind {
     Coverage(Span, CoverageAttrKind),
 
     /// Represents `#[crate_name = ...]`
-    CrateName { name: Symbol, name_span: Span, attr_span: Span, style: AttrStyle },
+    CrateName { name: Symbol, name_span: Span, attr_span: Span },
 
     /// Represents `#[custom_mir]`.
     CustomMir(Option<(MirDialect, Span)>, Option<(MirPhase, Span)>, Span),

--- a/compiler/rustc_query_system/messages.ftl
+++ b/compiler/rustc_query_system/messages.ftl
@@ -16,10 +16,11 @@ query_system_cycle_stack_single = ...which immediately requires {$stack_bottom} 
 query_system_cycle_usage = cycle used when {$usage}
 
 query_system_increment_compilation = internal compiler error: encountered incremental compilation error with {$dep_node}
-    .help = This is a known issue with the compiler. Run {$run_cmd} to allow your project to compile
 
 query_system_increment_compilation_note1 = please follow the instructions below to create a bug report with the provided information
-query_system_increment_compilation_note2 = see <https://github.com/rust-lang/rust/issues/84970> for more information
+query_system_increment_compilation_note2 = for incremental compilation bugs, having a reproduction is vital
+query_system_increment_compilation_note3 = an ideal reproduction consists of the code before and some patch that then triggers the bug when applied and compiled again
+query_system_increment_compilation_note4 = as a workaround, you can run {$run_cmd} to allow your project to compile
 
 query_system_overflow_note = query depth increased by {$depth} when {$desc}
 

--- a/compiler/rustc_query_system/src/error.rs
+++ b/compiler/rustc_query_system/src/error.rs
@@ -69,9 +69,10 @@ pub(crate) struct Reentrant;
 
 #[derive(Diagnostic)]
 #[diag(query_system_increment_compilation)]
-#[help]
 #[note(query_system_increment_compilation_note1)]
 #[note(query_system_increment_compilation_note2)]
+#[note(query_system_increment_compilation_note3)]
+#[note(query_system_increment_compilation_note4)]
 pub(crate) struct IncrementCompilation {
     pub run_cmd: String,
     pub dep_node: String,

--- a/src/doc/style-guide/src/nightly.md
+++ b/src/doc/style-guide/src/nightly.md
@@ -5,3 +5,29 @@ This chapter documents style and formatting for nightly-only syntax. The rest of
 Style and formatting for nightly-only syntax should be removed from this chapter and integrated into the appropriate sections of the style guide at the time of stabilization.
 
 There is no guarantee of the stability of this chapter in contrast to the rest of the style guide. Refer to the style team policy for nightly formatting procedure regarding breaking changes to this chapter.
+
+### Frontmatter
+
+*Location: Placed before comments and attributes in the [root](index.html).*
+
+*Tracking issue: [#136889](https://github.com/rust-lang/rust/issues/136889)*
+
+*Feature gate: `frontmatter`*
+
+There should be no blank lines between the frontmatter and either the start of the file or a shebang.
+There can be zero or one line between the frontmatter and any following content.
+
+The frontmatter fences should use the minimum number of dashes necessary for the contained content (one more than the longest series of initial dashes in the
+content, with a minimum of 3 to be recognized as frontmatter delimiters).
+If an infostring is present after the opening fence, there should be one space separating them.
+The frontmatter fence lines should not have trailing whitespace.
+
+```rust
+#!/usr/bin/env cargo
+--- cargo
+[dependencies]
+regex = "1"
+---
+
+fn main() {}
+```

--- a/src/librustdoc/html/render/span_map.rs
+++ b/src/librustdoc/html/render/span_map.rs
@@ -7,7 +7,6 @@ use rustc_hir::intravisit::{self, Visitor, VisitorExt};
 use rustc_hir::{ExprKind, HirId, Item, ItemKind, Mod, Node, QPath};
 use rustc_middle::hir::nested_filter;
 use rustc_middle::ty::TyCtxt;
-use rustc_span::hygiene::MacroKind;
 use rustc_span::{BytePos, ExpnKind};
 
 use crate::clean::{self, PrimitiveType, rustc_span};
@@ -194,7 +193,7 @@ impl SpanMapVisitor<'_> {
         }
 
         let macro_name = match data.kind {
-            ExpnKind::Macro(MacroKind::Bang, macro_name) => macro_name,
+            ExpnKind::Macro(_, macro_name) => macro_name,
             // Even though we don't handle this kind of macro, this `data` still comes from
             // expansion so we return `true` so we don't go any deeper in this code.
             _ => return true,

--- a/src/librustdoc/passes/mod.rs
+++ b/src/librustdoc/passes/mod.rs
@@ -95,11 +95,11 @@ pub(crate) const DEFAULT_PASSES: &[ConditionalPass] = &[
     ConditionalPass::always(CHECK_DOC_TEST_VISIBILITY),
     ConditionalPass::always(CHECK_DOC_CFG),
     ConditionalPass::always(STRIP_ALIASED_NON_LOCAL),
+    ConditionalPass::always(PROPAGATE_DOC_CFG),
     ConditionalPass::new(STRIP_HIDDEN, WhenNotDocumentHidden),
     ConditionalPass::new(STRIP_PRIVATE, WhenNotDocumentPrivate),
     ConditionalPass::new(STRIP_PRIV_IMPORTS, WhenDocumentPrivate),
     ConditionalPass::always(COLLECT_INTRA_DOC_LINKS),
-    ConditionalPass::always(PROPAGATE_DOC_CFG),
     ConditionalPass::always(PROPAGATE_STABILITY),
     ConditionalPass::always(RUN_LINTS),
 ];

--- a/tests/rustdoc-ui/invalid-cfg.rs
+++ b/tests/rustdoc-ui/invalid-cfg.rs
@@ -2,3 +2,20 @@
 #[doc(cfg = "x")] //~ ERROR not followed by parentheses
 #[doc(cfg(x, y))] //~ ERROR multiple `cfg` predicates
 pub struct S {}
+
+// We check it also fails on private items.
+#[doc(cfg = "x")] //~ ERROR not followed by parentheses
+#[doc(cfg(x, y))] //~ ERROR multiple `cfg` predicates
+struct X {}
+
+// We check it also fails on hidden items.
+#[doc(cfg = "x")] //~ ERROR not followed by parentheses
+#[doc(cfg(x, y))] //~ ERROR multiple `cfg` predicates
+#[doc(hidden)]
+pub struct Y {}
+
+// We check it also fails on hidden AND private items.
+#[doc(cfg = "x")] //~ ERROR not followed by parentheses
+#[doc(cfg(x, y))] //~ ERROR multiple `cfg` predicates
+#[doc(hidden)]
+struct Z {}

--- a/tests/rustdoc-ui/invalid-cfg.stderr
+++ b/tests/rustdoc-ui/invalid-cfg.stderr
@@ -10,5 +10,41 @@ error: multiple `cfg` predicates are specified
 LL | #[doc(cfg(x, y))]
    |              ^
 
-error: aborting due to 2 previous errors
+error: `cfg` is not followed by parentheses
+  --> $DIR/invalid-cfg.rs:7:7
+   |
+LL | #[doc(cfg = "x")]
+   |       ^^^^^^^^^ help: expected syntax is: `cfg(/* predicate */)`
+
+error: multiple `cfg` predicates are specified
+  --> $DIR/invalid-cfg.rs:8:14
+   |
+LL | #[doc(cfg(x, y))]
+   |              ^
+
+error: `cfg` is not followed by parentheses
+  --> $DIR/invalid-cfg.rs:12:7
+   |
+LL | #[doc(cfg = "x")]
+   |       ^^^^^^^^^ help: expected syntax is: `cfg(/* predicate */)`
+
+error: multiple `cfg` predicates are specified
+  --> $DIR/invalid-cfg.rs:13:14
+   |
+LL | #[doc(cfg(x, y))]
+   |              ^
+
+error: `cfg` is not followed by parentheses
+  --> $DIR/invalid-cfg.rs:18:7
+   |
+LL | #[doc(cfg = "x")]
+   |       ^^^^^^^^^ help: expected syntax is: `cfg(/* predicate */)`
+
+error: multiple `cfg` predicates are specified
+  --> $DIR/invalid-cfg.rs:19:14
+   |
+LL | #[doc(cfg(x, y))]
+   |              ^
+
+error: aborting due to 8 previous errors
 

--- a/tests/rustdoc-ui/issues/issue-91713.stdout
+++ b/tests/rustdoc-ui/issues/issue-91713.stdout
@@ -17,11 +17,11 @@ Default passes for rustdoc:
 check_doc_test_visibility
        check-doc-cfg
 strip-aliased-non-local
+   propagate-doc-cfg
         strip-hidden  (when not --document-hidden-items)
        strip-private  (when not --document-private-items)
   strip-priv-imports  (when --document-private-items)
 collect-intra-doc-links
-   propagate-doc-cfg
  propagate-stability
            run-lints
 

--- a/tests/rustdoc/jump-to-def-assoc-items.rs
+++ b/tests/rustdoc/jump-to-def-assoc-items.rs
@@ -26,6 +26,9 @@ impl C {
     pub fn wat() {}
 }
 
+//@ has - '//a[@href="{{channel}}/core/fmt/macros/macro.Debug.html"]' 'Debug'
+//@ has - '//a[@href="{{channel}}/core/cmp/macro.PartialEq.html"]' 'PartialEq'
+#[derive(Debug, PartialEq)]
 pub struct Bar;
 impl Trait for Bar {
     type T = Foo;


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#145617 (docs(style): Specify the frontmatter style)
 - rust-lang/rust#147830 (Reword unstable fingerprints ICE to ask for reproduction)
 - rust-lang/rust#147988 (Remove unused field `style` from `AttributeKind::CrateName`)
 - rust-lang/rust#147990 (Fix invalid jump to def link generated on derive attributes)
 - rust-lang/rust#147991 ([rustdoc] Check `doc(cfg())` even of private/hidden items)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=145617,147830,147988,147990,147991)
<!-- homu-ignore:end -->