### PR TITLE
Improvements to attribute suggestions

### DIFF
--- a/compiler/rustc_attr_parsing/src/attributes/cfg.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/cfg.rs
@@ -326,7 +326,8 @@ pub fn parse_cfg_attr(
             }) {
                 Ok(r) => return Some(r),
                 Err(e) => {
-                    let suggestions = CFG_ATTR_TEMPLATE.suggestions(cfg_attr.style, sym::cfg_attr);
+                    let suggestions =
+                        CFG_ATTR_TEMPLATE.suggestions(Some(cfg_attr.style), sym::cfg_attr);
                     e.with_span_suggestions(
                         cfg_attr.span,
                         "must be of the form",
@@ -356,7 +357,7 @@ pub fn parse_cfg_attr(
                 template: CFG_ATTR_TEMPLATE,
                 attribute: AttrPath::from_ast(&cfg_attr.get_normal_item().path),
                 reason,
-                attr_style: cfg_attr.style,
+                suggestions: CFG_ATTR_TEMPLATE.suggestions(Some(cfg_attr.style), sym::cfg_attr),
             });
         }
     }

--- a/compiler/rustc_attr_parsing/src/attributes/cfg.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/cfg.rs
@@ -389,6 +389,7 @@ fn parse_cfg_attr_internal<'a>(
     let cfg_predicate = AttributeParser::parse_single_args(
         sess,
         attribute.span,
+        attribute.get_normal_item().span(),
         attribute.style,
         AttrPath {
             segments: attribute

--- a/compiler/rustc_attr_parsing/src/attributes/inline.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/inline.rs
@@ -56,8 +56,7 @@ impl<S: Stage> SingleAttributeParser<S> for InlineParser {
                 }
             }
             ArgParser::NameValue(_) => {
-                let suggestions = <Self as SingleAttributeParser<S>>::TEMPLATE
-                    .suggestions(cx.attr_style, "inline");
+                let suggestions = cx.suggestions();
                 let span = cx.attr_span;
                 cx.emit_lint(AttributeLintKind::IllFormedAttributeInput { suggestions }, span);
                 return None;

--- a/compiler/rustc_attr_parsing/src/attributes/link_attrs.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/link_attrs.rs
@@ -71,8 +71,7 @@ impl<S: Stage> CombineAttributeParser<S> for LinkParser {
             // Specifically `#[link = "dl"]` is accepted with a FCW
             // For more information, see https://github.com/rust-lang/rust/pull/143193
             ArgParser::NameValue(nv) if nv.value_as_str().is_some_and(|v| v == sym::dl) => {
-                let suggestions = <Self as CombineAttributeParser<S>>::TEMPLATE
-                    .suggestions(cx.attr_style, "link");
+                let suggestions = cx.suggestions();
                 let span = cx.attr_span;
                 cx.emit_lint(AttributeLintKind::IllFormedAttributeInput { suggestions }, span);
                 return None;

--- a/compiler/rustc_attr_parsing/src/attributes/must_use.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/must_use.rs
@@ -45,8 +45,7 @@ impl<S: Stage> SingleAttributeParser<S> for MustUseParser {
                     Some(value_str)
                 }
                 ArgParser::List(_) => {
-                    let suggestions = <Self as SingleAttributeParser<S>>::TEMPLATE
-                        .suggestions(cx.attr_style, "must_use");
+                    let suggestions = cx.suggestions();
                     cx.emit_err(IllFormedAttributeInputLint {
                         num_suggestions: suggestions.len(),
                         suggestions: DiagArgValue::StrListSepByAnd(

--- a/compiler/rustc_attr_parsing/src/attributes/test_attrs.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/test_attrs.rs
@@ -20,8 +20,7 @@ impl<S: Stage> SingleAttributeParser<S> for IgnoreParser {
                 ArgParser::NoArgs => None,
                 ArgParser::NameValue(name_value) => {
                     let Some(str_value) = name_value.value_as_str() else {
-                        let suggestions = <Self as SingleAttributeParser<S>>::TEMPLATE
-                            .suggestions(cx.attr_style, "ignore");
+                        let suggestions = cx.suggestions();
                         let span = cx.attr_span;
                         cx.emit_lint(
                             AttributeLintKind::IllFormedAttributeInput { suggestions },
@@ -32,8 +31,7 @@ impl<S: Stage> SingleAttributeParser<S> for IgnoreParser {
                     Some(str_value)
                 }
                 ArgParser::List(_) => {
-                    let suggestions = <Self as SingleAttributeParser<S>>::TEMPLATE
-                        .suggestions(cx.attr_style, "ignore");
+                    let suggestions = cx.suggestions();
                     let span = cx.attr_span;
                     cx.emit_lint(AttributeLintKind::IllFormedAttributeInput { suggestions }, span);
                     return None;

--- a/compiler/rustc_attr_parsing/src/context.rs
+++ b/compiler/rustc_attr_parsing/src/context.rs
@@ -427,7 +427,7 @@ impl<'f, 'sess: 'f, S: Stage> AcceptContext<'f, 'sess, S> {
                     i.kind.is_bytestr().then(|| self.sess().source_map().start_point(i.span))
                 }),
             },
-            attr_style: self.attr_style,
+            suggestions: self.suggestions(),
         })
     }
 
@@ -438,7 +438,7 @@ impl<'f, 'sess: 'f, S: Stage> AcceptContext<'f, 'sess, S> {
             template: self.template.clone(),
             attribute: self.attr_path.clone(),
             reason: AttributeParseErrorReason::ExpectedIntegerLiteral,
-            attr_style: self.attr_style,
+            suggestions: self.suggestions(),
         })
     }
 
@@ -449,7 +449,7 @@ impl<'f, 'sess: 'f, S: Stage> AcceptContext<'f, 'sess, S> {
             template: self.template.clone(),
             attribute: self.attr_path.clone(),
             reason: AttributeParseErrorReason::ExpectedList,
-            attr_style: self.attr_style,
+            suggestions: self.suggestions(),
         })
     }
 
@@ -460,7 +460,7 @@ impl<'f, 'sess: 'f, S: Stage> AcceptContext<'f, 'sess, S> {
             template: self.template.clone(),
             attribute: self.attr_path.clone(),
             reason: AttributeParseErrorReason::ExpectedNoArgs,
-            attr_style: self.attr_style,
+            suggestions: self.suggestions(),
         })
     }
 
@@ -472,7 +472,7 @@ impl<'f, 'sess: 'f, S: Stage> AcceptContext<'f, 'sess, S> {
             template: self.template.clone(),
             attribute: self.attr_path.clone(),
             reason: AttributeParseErrorReason::ExpectedIdentifier,
-            attr_style: self.attr_style,
+            suggestions: self.suggestions(),
         })
     }
 
@@ -485,7 +485,7 @@ impl<'f, 'sess: 'f, S: Stage> AcceptContext<'f, 'sess, S> {
             template: self.template.clone(),
             attribute: self.attr_path.clone(),
             reason: AttributeParseErrorReason::ExpectedNameValue(name),
-            attr_style: self.attr_style,
+            suggestions: self.suggestions(),
         })
     }
 
@@ -497,7 +497,7 @@ impl<'f, 'sess: 'f, S: Stage> AcceptContext<'f, 'sess, S> {
             template: self.template.clone(),
             attribute: self.attr_path.clone(),
             reason: AttributeParseErrorReason::DuplicateKey(key),
-            attr_style: self.attr_style,
+            suggestions: self.suggestions(),
         })
     }
 
@@ -510,7 +510,7 @@ impl<'f, 'sess: 'f, S: Stage> AcceptContext<'f, 'sess, S> {
             template: self.template.clone(),
             attribute: self.attr_path.clone(),
             reason: AttributeParseErrorReason::UnexpectedLiteral,
-            attr_style: self.attr_style,
+            suggestions: self.suggestions(),
         })
     }
 
@@ -521,7 +521,7 @@ impl<'f, 'sess: 'f, S: Stage> AcceptContext<'f, 'sess, S> {
             template: self.template.clone(),
             attribute: self.attr_path.clone(),
             reason: AttributeParseErrorReason::ExpectedSingleArgument,
-            attr_style: self.attr_style,
+            suggestions: self.suggestions(),
         })
     }
 
@@ -532,7 +532,7 @@ impl<'f, 'sess: 'f, S: Stage> AcceptContext<'f, 'sess, S> {
             template: self.template.clone(),
             attribute: self.attr_path.clone(),
             reason: AttributeParseErrorReason::ExpectedAtLeastOneArgument,
-            attr_style: self.attr_style,
+            suggestions: self.suggestions(),
         })
     }
 
@@ -552,7 +552,7 @@ impl<'f, 'sess: 'f, S: Stage> AcceptContext<'f, 'sess, S> {
                 strings: false,
                 list: false,
             },
-            attr_style: self.attr_style,
+            suggestions: self.suggestions(),
         })
     }
 
@@ -573,7 +573,7 @@ impl<'f, 'sess: 'f, S: Stage> AcceptContext<'f, 'sess, S> {
                 strings: false,
                 list: true,
             },
-            attr_style: self.attr_style,
+            suggestions: self.suggestions(),
         })
     }
 
@@ -593,7 +593,7 @@ impl<'f, 'sess: 'f, S: Stage> AcceptContext<'f, 'sess, S> {
                 strings: true,
                 list: false,
             },
-            attr_style: self.attr_style,
+            suggestions: self.suggestions(),
         })
     }
 
@@ -604,6 +604,10 @@ impl<'f, 'sess: 'f, S: Stage> AcceptContext<'f, 'sess, S> {
             AttributeLintKind::EmptyAttribute { first_span: span, attr_path, valid_without_list },
             span,
         );
+    }
+
+    pub(crate) fn suggestions(&self) -> Vec<String> {
+        self.template.suggestions(Some(self.attr_style), &self.attr_path)
     }
 }
 

--- a/compiler/rustc_attr_parsing/src/interface.rs
+++ b/compiler/rustc_attr_parsing/src/interface.rs
@@ -142,6 +142,7 @@ impl<'sess> AttributeParser<'sess, Early> {
         Self::parse_single_args(
             sess,
             attr.span,
+            normal_attr.item.span(),
             attr.style,
             path.get_attribute_path(),
             target_span,
@@ -159,6 +160,7 @@ impl<'sess> AttributeParser<'sess, Early> {
     pub fn parse_single_args<T, I>(
         sess: &'sess Session,
         attr_span: Span,
+        inner_span: Span,
         attr_style: AttrStyle,
         attr_path: AttrPath,
         target_span: Span,
@@ -186,6 +188,7 @@ impl<'sess> AttributeParser<'sess, Early> {
                 },
             },
             attr_span,
+            inner_span,
             attr_style,
             template,
             attr_path,
@@ -305,6 +308,7 @@ impl<'sess, S: Stage> AttributeParser<'sess, S> {
                                     emit_lint: &mut emit_lint,
                                 },
                                 attr_span: lower_span(attr.span),
+                                inner_span: lower_span(attr.get_normal_item().span()),
                                 attr_style: attr.style,
                                 template: &accept.template,
                                 attr_path: path.get_attribute_path(),

--- a/compiler/rustc_attr_parsing/src/session_diagnostics.rs
+++ b/compiler/rustc_attr_parsing/src/session_diagnostics.rs
@@ -1,6 +1,6 @@
 use std::num::IntErrorKind;
 
-use rustc_ast::{self as ast, AttrStyle, Path};
+use rustc_ast::{self as ast, Path};
 use rustc_errors::codes::*;
 use rustc_errors::{
     Applicability, Diag, DiagArgValue, DiagCtxtHandle, Diagnostic, EmissionGuarantee, Level,
@@ -613,10 +613,10 @@ pub(crate) enum AttributeParseErrorReason<'a> {
 pub(crate) struct AttributeParseError<'a> {
     pub(crate) span: Span,
     pub(crate) attr_span: Span,
-    pub(crate) attr_style: AttrStyle,
     pub(crate) template: AttributeTemplate,
     pub(crate) attribute: AttrPath,
     pub(crate) reason: AttributeParseErrorReason<'a>,
+    pub(crate) suggestions: Vec<String>,
 }
 
 impl<'a, G: EmissionGuarantee> Diagnostic<'a, G> for AttributeParseError<'_> {
@@ -752,16 +752,15 @@ impl<'a, G: EmissionGuarantee> Diagnostic<'a, G> for AttributeParseError<'_> {
         if let Some(link) = self.template.docs {
             diag.note(format!("for more information, visit <{link}>"));
         }
-        let suggestions = self.template.suggestions(self.attr_style, &name);
 
         diag.span_suggestions(
             self.attr_span,
-            if suggestions.len() == 1 {
+            if self.suggestions.len() == 1 {
                 "must be of the form"
             } else {
                 "try changing it to one of the following valid forms of the attribute"
             },
-            suggestions,
+            self.suggestions,
             Applicability::HasPlaceholders,
         );
 

--- a/compiler/rustc_feature/src/builtin_attrs.rs
+++ b/compiler/rustc_feature/src/builtin_attrs.rs
@@ -133,24 +133,29 @@ pub struct AttributeTemplate {
 }
 
 impl AttributeTemplate {
-    pub fn suggestions(&self, style: AttrStyle, name: impl std::fmt::Display) -> Vec<String> {
+    pub fn suggestions(
+        &self,
+        style: Option<AttrStyle>,
+        name: impl std::fmt::Display,
+    ) -> Vec<String> {
         let mut suggestions = vec![];
-        let inner = match style {
-            AttrStyle::Outer => "",
-            AttrStyle::Inner => "!",
+        let (start, end) = match style {
+            Some(AttrStyle::Outer) => ("#[", "]"),
+            Some(AttrStyle::Inner) => ("#![", "]"),
+            None => ("", ""),
         };
         if self.word {
-            suggestions.push(format!("#{inner}[{name}]"));
+            suggestions.push(format!("{start}{name}{end}"));
         }
         if let Some(descr) = self.list {
             for descr in descr {
-                suggestions.push(format!("#{inner}[{name}({descr})]"));
+                suggestions.push(format!("{start}{name}({descr}){end}"));
             }
         }
-        suggestions.extend(self.one_of.iter().map(|&word| format!("#{inner}[{name}({word})]")));
+        suggestions.extend(self.one_of.iter().map(|&word| format!("{start}{name}({word}){end}")));
         if let Some(descr) = self.name_value_str {
             for descr in descr {
-                suggestions.push(format!("#{inner}[{name} = \"{descr}\"]"));
+                suggestions.push(format!("{start}{name} = \"{descr}\"{end}"));
             }
         }
         suggestions.sort();

--- a/tests/ui/attributes/invalid_macro_export_argument.allow.stderr
+++ b/tests/ui/attributes/invalid_macro_export_argument.allow.stderr
@@ -1,5 +1,5 @@
 Future incompatibility report: Future breakage diagnostic:
-warning: valid forms for the attribute are `#![macro_export(local_inner_macros)]` and `#![macro_export]`
+warning: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
   --> $DIR/invalid_macro_export_argument.rs:7:1
    |
 LL | #[macro_export(hello, world)]
@@ -9,7 +9,7 @@ LL | #[macro_export(hello, world)]
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
 
 Future breakage diagnostic:
-warning: valid forms for the attribute are `#![macro_export(local_inner_macros)]` and `#![macro_export]`
+warning: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
   --> $DIR/invalid_macro_export_argument.rs:14:1
    |
 LL | #[macro_export(not_local_inner_macros)]
@@ -19,7 +19,7 @@ LL | #[macro_export(not_local_inner_macros)]
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
 
 Future breakage diagnostic:
-warning: valid forms for the attribute are `#![macro_export(local_inner_macros)]` and `#![macro_export]`
+warning: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
   --> $DIR/invalid_macro_export_argument.rs:31:1
    |
 LL | #[macro_export()]
@@ -29,7 +29,7 @@ LL | #[macro_export()]
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
 
 Future breakage diagnostic:
-warning: valid forms for the attribute are `#![macro_export(local_inner_macros)]` and `#![macro_export]`
+warning: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
   --> $DIR/invalid_macro_export_argument.rs:38:1
    |
 LL | #[macro_export("blah")]

--- a/tests/ui/attributes/invalid_macro_export_argument.deny.stderr
+++ b/tests/ui/attributes/invalid_macro_export_argument.deny.stderr
@@ -1,4 +1,4 @@
-error: valid forms for the attribute are `#![macro_export(local_inner_macros)]` and `#![macro_export]`
+error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
   --> $DIR/invalid_macro_export_argument.rs:7:1
    |
 LL | #[macro_export(hello, world)]
@@ -12,7 +12,7 @@ note: the lint level is defined here
 LL | #![cfg_attr(deny, deny(invalid_macro_export_arguments))]
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: valid forms for the attribute are `#![macro_export(local_inner_macros)]` and `#![macro_export]`
+error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
   --> $DIR/invalid_macro_export_argument.rs:14:1
    |
 LL | #[macro_export(not_local_inner_macros)]
@@ -21,7 +21,7 @@ LL | #[macro_export(not_local_inner_macros)]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
 
-error: valid forms for the attribute are `#![macro_export(local_inner_macros)]` and `#![macro_export]`
+error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
   --> $DIR/invalid_macro_export_argument.rs:31:1
    |
 LL | #[macro_export()]
@@ -30,7 +30,7 @@ LL | #[macro_export()]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
 
-error: valid forms for the attribute are `#![macro_export(local_inner_macros)]` and `#![macro_export]`
+error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
   --> $DIR/invalid_macro_export_argument.rs:38:1
    |
 LL | #[macro_export("blah")]
@@ -42,7 +42,7 @@ LL | #[macro_export("blah")]
 error: aborting due to 4 previous errors
 
 Future incompatibility report: Future breakage diagnostic:
-error: valid forms for the attribute are `#![macro_export(local_inner_macros)]` and `#![macro_export]`
+error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
   --> $DIR/invalid_macro_export_argument.rs:7:1
    |
 LL | #[macro_export(hello, world)]
@@ -57,7 +57,7 @@ LL | #![cfg_attr(deny, deny(invalid_macro_export_arguments))]
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Future breakage diagnostic:
-error: valid forms for the attribute are `#![macro_export(local_inner_macros)]` and `#![macro_export]`
+error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
   --> $DIR/invalid_macro_export_argument.rs:14:1
    |
 LL | #[macro_export(not_local_inner_macros)]
@@ -72,7 +72,7 @@ LL | #![cfg_attr(deny, deny(invalid_macro_export_arguments))]
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Future breakage diagnostic:
-error: valid forms for the attribute are `#![macro_export(local_inner_macros)]` and `#![macro_export]`
+error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
   --> $DIR/invalid_macro_export_argument.rs:31:1
    |
 LL | #[macro_export()]
@@ -87,7 +87,7 @@ LL | #![cfg_attr(deny, deny(invalid_macro_export_arguments))]
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Future breakage diagnostic:
-error: valid forms for the attribute are `#![macro_export(local_inner_macros)]` and `#![macro_export]`
+error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
   --> $DIR/invalid_macro_export_argument.rs:38:1
    |
 LL | #[macro_export("blah")]

--- a/tests/ui/attributes/malformed-attrs.stderr
+++ b/tests/ui/attributes/malformed-attrs.stderr
@@ -701,7 +701,7 @@ error: valid forms for the attribute are `#[macro_use(name1, name2, ...)]` and `
 LL | #[macro_use = 1]
    | ^^^^^^^^^^^^^^^^
 
-error: valid forms for the attribute are `#![macro_export(local_inner_macros)]` and `#![macro_export]`
+error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
   --> $DIR/malformed-attrs.rs:221:1
    |
 LL | #[macro_export = 18]

--- a/tests/ui/conditional-compilation/cfg_attr-attr-syntax-validation.stderr
+++ b/tests/ui/conditional-compilation/cfg_attr-attr-syntax-validation.stderr
@@ -113,7 +113,7 @@ error[E0539]: malformed `link_section` attribute input
   --> $DIR/cfg_attr-attr-syntax-validation.rs:44:18
    |
 LL | #[cfg_attr(true, link_section)]
-   |                  ^^^^^^^^^^^^ help: must be of the form: `#[link_section = "name"]`
+   |                  ^^^^^^^^^^^^ help: must be of the form: `link_section = "name"`
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/abi.html#the-link_section-attribute>
 
@@ -129,14 +129,12 @@ LL | #[cfg_attr(true, inline())]
 help: try changing it to one of the following valid forms of the attribute
    |
 LL - #[cfg_attr(true, inline())]
-LL + #[cfg_attr(true, #[inline(always)])]
+LL + #[cfg_attr(true, inline)]
    |
-LL - #[cfg_attr(true, inline())]
-LL + #[cfg_attr(true, #[inline(never)])]
-   |
-LL - #[cfg_attr(true, inline())]
-LL + #[cfg_attr(true, #[inline])]
-   |
+LL | #[cfg_attr(true, inline(always))]
+   |                         ++++++
+LL | #[cfg_attr(true, inline(never))]
+   |                         +++++
 
 warning: `#[link_section]` attribute cannot be used on structs
   --> $DIR/cfg_attr-attr-syntax-validation.rs:44:18


### PR DESCRIPTION
Changes in commit 1:
- Add `AcceptContext::suggestions`, which retrieves the suggestions for the currently parsing attribute
- This happens to fix a bug in the way `#[macro_export`]. Closes https://github.com/rust-lang/rust/pull/147987

Changes in commit 2:
- Add a check to the suggestions function so the suggestions for attributes in cfg_attr are nicer. Fixes https://github.com/rust-lang/rust/issues/147693

This is also part (but not all) of the changes needed to unblock https://github.com/rust-lang/rust/pull/147945

r? @jdonszelmann 