### PR TITLE
fix: Don't add diff symbol to unchanged lines

### DIFF
--- a/compiler/rustc_errors/src/emitter.rs
+++ b/compiler/rustc_errors/src/emitter.rs
@@ -2698,8 +2698,7 @@ impl HumanEmitter {
                 [SubstitutionHighlight { start: 0, end }] if *end == line_to_add.len() => {
                     buffer.puts(*row_num, max_line_num_len + 1, "+ ", Style::Addition);
                 }
-                [] => {
-                    // FIXME: needed? Doesn't get exercised in any test.
+                [] | [SubstitutionHighlight { start: 0, end: 0 }] => {
                     self.draw_col_separator_no_space(buffer, *row_num, max_line_num_len + 1);
                 }
                 _ => {

--- a/src/tools/clippy/tests/ui/derivable_impls.stderr
+++ b/src/tools/clippy/tests/ui/derivable_impls.stderr
@@ -14,7 +14,7 @@ LL | | }
 help: replace the manual implementation with a derive attribute
    |
 LL + #[derive(Default)]
-LL ~ struct FooDefault<'a> {
+LL | struct FooDefault<'a> {
    |
 
 error: this `impl` can be derived
@@ -31,7 +31,7 @@ LL | | }
 help: replace the manual implementation with a derive attribute
    |
 LL + #[derive(Default)]
-LL ~ struct TupleDefault(bool, i32, u64);
+LL | struct TupleDefault(bool, i32, u64);
    |
 
 error: this `impl` can be derived
@@ -48,7 +48,7 @@ LL | | }
 help: replace the manual implementation with a derive attribute
    |
 LL + #[derive(Default)]
-LL ~ struct StrDefault<'a>(&'a str);
+LL | struct StrDefault<'a>(&'a str);
    |
 
 error: this `impl` can be derived
@@ -65,7 +65,7 @@ LL | | }
 help: replace the manual implementation with a derive attribute
    |
 LL + #[derive(Default)]
-LL ~ struct Y(u32);
+LL | struct Y(u32);
    |
 
 error: this `impl` can be derived
@@ -82,7 +82,7 @@ LL | | }
 help: replace the manual implementation with a derive attribute
    |
 LL + #[derive(Default)]
-LL ~ struct WithoutSelfCurly {
+LL | struct WithoutSelfCurly {
    |
 
 error: this `impl` can be derived
@@ -99,7 +99,7 @@ LL | | }
 help: replace the manual implementation with a derive attribute
    |
 LL + #[derive(Default)]
-LL ~ struct WithoutSelfParan(bool);
+LL | struct WithoutSelfParan(bool);
    |
 
 error: this `impl` can be derived
@@ -115,7 +115,7 @@ LL | | }
 help: replace the manual implementation with a derive attribute
    |
 LL + #[derive(Default)]
-LL ~ pub struct DirectDefaultDefaultCall {
+LL | pub struct DirectDefaultDefaultCall {
    |
 
 error: this `impl` can be derived
@@ -131,7 +131,7 @@ LL | | }
 help: replace the manual implementation with a derive attribute
    |
 LL + #[derive(Default)]
-LL ~ pub struct EquivalentToDefaultDefaultCallVec {
+LL | pub struct EquivalentToDefaultDefaultCallVec {
    |
 
 error: this `impl` can be derived
@@ -147,7 +147,7 @@ LL | | }
 help: replace the manual implementation with a derive attribute
    |
 LL + #[derive(Default)]
-LL ~ pub struct EquivalentToDefaultDefaultCallLocal {
+LL | pub struct EquivalentToDefaultDefaultCallLocal {
    |
 
 error: this `impl` can be derived
@@ -164,7 +164,7 @@ LL | | }
 help: replace the manual implementation with a derive attribute
    |
 LL + #[derive(Default)]
-LL ~ pub struct RepeatDefault1 {
+LL | pub struct RepeatDefault1 {
    |
 
 error: this `impl` can be derived
@@ -181,7 +181,7 @@ LL | | }
 help: replace the manual implementation with a derive attribute and mark the default variant
    |
 LL + #[derive(Default)]
-LL ~ pub enum SimpleEnum {
+LL | pub enum SimpleEnum {
 LL |     Foo,
 LL ~     #[default]
 LL ~     Bar,

--- a/tests/ui/half-open-range-patterns/range_pat_interactions1.stderr
+++ b/tests/ui/half-open-range-patterns/range_pat_interactions1.stderr
@@ -8,7 +8,7 @@ LL |             0..5+1 => errors_only.push(x),
 help: consider extracting the expression into a `const`
    |
 LL +         const VAL: /* Type */ = 5+1;
-LL ~         match x as i32 {
+LL |         match x as i32 {
 LL ~             0..VAL => errors_only.push(x),
    |
 

--- a/tests/ui/parser/issues/issue-24375.stderr
+++ b/tests/ui/parser/issues/issue-24375.stderr
@@ -13,7 +13,7 @@ LL +         val if val == tmp[0] => {}
 help: consider extracting the expression into a `const`
    |
 LL +     const VAL: /* Type */ = tmp[0];
-LL ~     match z {
+LL |     match z {
 LL ~         VAL => {}
    |
 

--- a/tests/ui/parser/recover/recover-pat-exprs.stderr
+++ b/tests/ui/parser/recover/recover-pat-exprs.stderr
@@ -13,7 +13,7 @@ LL +         val if val == x.y => (),
 help: consider extracting the expression into a `const`
    |
 LL +     const VAL: /* Type */ = x.y;
-LL ~     match 0 {
+LL |     match 0 {
 LL |         x => (),
 LL ~         VAL => (),
    |
@@ -33,7 +33,7 @@ LL +         val if val == x.0 => (),
 help: consider extracting the expression into a `const`
    |
 LL +     const VAL: /* Type */ = x.0;
-LL ~     match 0 {
+LL |     match 0 {
 LL |         x => (),
 LL |         x.y => (),
 LL ~         VAL => (),
@@ -54,7 +54,7 @@ LL +         val if val == x._0 => (),
 help: consider extracting the expression into a `const`
    |
 LL +     const VAL: /* Type */ = x._0;
-LL ~     match 0 {
+LL |     match 0 {
 LL |         x => (),
 LL |         x.y => (),
 LL |         x.0 => (),
@@ -76,7 +76,7 @@ LL +         val if val == x.0.1 => (),
 help: consider extracting the expression into a `const`
    |
 LL +     const VAL: /* Type */ = x.0.1;
-LL ~     match 0 {
+LL |     match 0 {
 LL |         x => (),
 ...
 LL |         x._0 => (),
@@ -98,7 +98,7 @@ LL +         val if val == x.4.y.17.__z => (),
 help: consider extracting the expression into a `const`
    |
 LL +     const VAL: /* Type */ = x.4.y.17.__z;
-LL ~     match 0 {
+LL |     match 0 {
 LL |         x => (),
 ...
 LL |         x.0.1 => (),
@@ -150,7 +150,7 @@ LL +         val if val == x[0] => (),
 help: consider extracting the expression into a `const`
    |
 LL +     const VAL: /* Type */ = x[0];
-LL ~     match 0 {
+LL |     match 0 {
 LL ~         VAL => (),
    |
 
@@ -169,7 +169,7 @@ LL +         val if val == x[..] => (),
 help: consider extracting the expression into a `const`
    |
 LL +     const VAL: /* Type */ = x[..];
-LL ~     match 0 {
+LL |     match 0 {
 LL |         x[0] => (),
 LL ~         VAL => (),
    |
@@ -216,7 +216,7 @@ LL +         val if val == x.f() => (),
 help: consider extracting the expression into a `const`
    |
 LL +     const VAL: /* Type */ = x.f();
-LL ~     match 0 {
+LL |     match 0 {
 LL ~         VAL => (),
    |
 
@@ -235,7 +235,7 @@ LL +         val if val == x._f() => (),
 help: consider extracting the expression into a `const`
    |
 LL +     const VAL: /* Type */ = x._f();
-LL ~     match 0 {
+LL |     match 0 {
 LL |         x.f() => (),
 LL ~         VAL => (),
    |
@@ -255,7 +255,7 @@ LL +         val if val == x? => (),
 help: consider extracting the expression into a `const`
    |
 LL +     const VAL: /* Type */ = x?;
-LL ~     match 0 {
+LL |     match 0 {
 LL |         x.f() => (),
 LL |         x._f() => (),
 LL ~         VAL => (),
@@ -276,7 +276,7 @@ LL +         val if val == ().f() => (),
 help: consider extracting the expression into a `const`
    |
 LL +     const VAL: /* Type */ = ().f();
-LL ~     match 0 {
+LL |     match 0 {
 LL |         x.f() => (),
 LL |         x._f() => (),
 LL |         x? => (),
@@ -298,7 +298,7 @@ LL +         val if val == (0, x)?.f() => (),
 help: consider extracting the expression into a `const`
    |
 LL +     const VAL: /* Type */ = (0, x)?.f();
-LL ~     match 0 {
+LL |     match 0 {
 LL |         x.f() => (),
 ...
 LL |         ().f() => (),
@@ -320,7 +320,7 @@ LL +         val if val == x.f().g() => (),
 help: consider extracting the expression into a `const`
    |
 LL +     const VAL: /* Type */ = x.f().g();
-LL ~     match 0 {
+LL |     match 0 {
 LL |         x.f() => (),
 ...
 LL |         (0, x)?.f() => (),
@@ -342,7 +342,7 @@ LL +         val if val == 0.f()?.g()?? => (),
 help: consider extracting the expression into a `const`
    |
 LL +     const VAL: /* Type */ = 0.f()?.g()??;
-LL ~     match 0 {
+LL |     match 0 {
 LL |         x.f() => (),
 ...
 LL |         x.f().g() => (),
@@ -364,7 +364,7 @@ LL +         val if val == x as usize => (),
 help: consider extracting the expression into a `const`
    |
 LL +     const VAL: /* Type */ = x as usize;
-LL ~     match 0 {
+LL |     match 0 {
 LL ~         VAL => (),
    |
 
@@ -383,7 +383,7 @@ LL +         val if val == 0 as usize => (),
 help: consider extracting the expression into a `const`
    |
 LL +     const VAL: /* Type */ = 0 as usize;
-LL ~     match 0 {
+LL |     match 0 {
 LL |         x as usize => (),
 LL ~         VAL => (),
    |
@@ -403,7 +403,7 @@ LL +         val if val == x.f().0.4 as f32 => (),
 help: consider extracting the expression into a `const`
    |
 LL +     const VAL: /* Type */ = x.f().0.4 as f32;
-LL ~     match 0 {
+LL |     match 0 {
 LL |         x as usize => (),
 LL |         0 as usize => (),
 LL ~         VAL => (),
@@ -424,7 +424,7 @@ LL +         val if val == 1 + 1 => (),
 help: consider extracting the expression into a `const`
    |
 LL +     const VAL: /* Type */ = 1 + 1;
-LL ~     match 0 {
+LL |     match 0 {
 LL ~         VAL => (),
    |
 
@@ -443,7 +443,7 @@ LL +         val if val == (1 + 2) * 3 => (),
 help: consider extracting the expression into a `const`
    |
 LL +     const VAL: /* Type */ = (1 + 2) * 3;
-LL ~     match 0 {
+LL |     match 0 {
 LL |         1 + 1 => (),
 LL ~         VAL => (),
    |
@@ -463,7 +463,7 @@ LL +         val if val == (x.0 > 2) => (),
 help: consider extracting the expression into a `const`
    |
 LL +     const VAL: /* Type */ = x.0 > 2;
-LL ~     match 0 {
+LL |     match 0 {
 LL |         1 + 1 => (),
 ...
 LL |
@@ -485,7 +485,7 @@ LL +         val if val == (x.0 == 2) => (),
 help: consider extracting the expression into a `const`
    |
 LL +     const VAL: /* Type */ = x.0 == 2;
-LL ~     match 0 {
+LL |     match 0 {
 LL |         1 + 1 => (),
 ...
 LL |         x.0 > 2 => (),
@@ -507,7 +507,7 @@ LL +         (x, val) if x != 0 && val == (y.0 > 2) => (),
 help: consider extracting the expression into a `const`
    |
 LL +     const VAL: /* Type */ = y.0 > 2;
-LL ~     match (0, 0) {
+LL |     match (0, 0) {
 LL ~         (x, VAL) if x != 0 => (),
    |
 
@@ -526,7 +526,7 @@ LL +         (x, val) if (x != 0 || x != 1) && val == (y.0 > 2) => (),
 help: consider extracting the expression into a `const`
    |
 LL +     const VAL: /* Type */ = y.0 > 2;
-LL ~     match (0, 0) {
+LL |     match (0, 0) {
 LL |         (x, y.0 > 2) if x != 0 => (),
 LL ~         (x, VAL) if x != 0 || x != 1 => (),
    |
@@ -563,7 +563,7 @@ LL +         val if val == u8::MAX.abs() => (),
 help: consider extracting the expression into a `const`
    |
 LL +     const VAL: /* Type */ = u8::MAX.abs();
-LL ~     match u8::MAX {
+LL |     match u8::MAX {
 LL ~         VAL => (),
    |
 
@@ -582,7 +582,7 @@ LL +         z @ w @ val if val == v.u() => (),
 help: consider extracting the expression into a `const`
    |
 LL +     const VAL: /* Type */ = v.u();
-LL ~     match u8::MAX {
+LL |     match u8::MAX {
 LL |         u8::MAX.abs() => (),
 ...
 LL |
@@ -604,7 +604,7 @@ LL +         val if val == y.ilog(3) => (),
 help: consider extracting the expression into a `const`
    |
 LL +     const VAL: /* Type */ = y.ilog(3);
-LL ~     match u8::MAX {
+LL |     match u8::MAX {
 LL |         u8::MAX.abs() => (),
 ...
 LL |
@@ -626,7 +626,7 @@ LL +         val if val == n + 1 => (),
 help: consider extracting the expression into a `const`
    |
 LL +     const VAL: /* Type */ = n + 1;
-LL ~     match u8::MAX {
+LL |     match u8::MAX {
 LL |         u8::MAX.abs() => (),
 ...
 LL |
@@ -648,7 +648,7 @@ LL +         (val) if val == "".f() + 14 * 8 => (),
 help: consider extracting the expression into a `const`
    |
 LL +     const VAL: /* Type */ = "".f() + 14 * 8;
-LL ~     match u8::MAX {
+LL |     match u8::MAX {
 LL |         u8::MAX.abs() => (),
 ...
 LL |
@@ -670,7 +670,7 @@ LL +         val if val == f?() => (),
 help: consider extracting the expression into a `const`
    |
 LL +     const VAL: /* Type */ = f?();
-LL ~     match u8::MAX {
+LL |     match u8::MAX {
 LL |         u8::MAX.abs() => (),
 ...
 LL |         0 | ((1) | 2) | 3 => (),

--- a/tests/ui/parser/recover/recover-pat-issues.stderr
+++ b/tests/ui/parser/recover/recover-pat-issues.stderr
@@ -13,7 +13,7 @@ LL +         Foo(val) if val == "hi".to_owned() => true,
 help: consider extracting the expression into a `const`
    |
 LL +     const VAL: /* Type */ = "hi".to_owned();
-LL ~     match foo {
+LL |     match foo {
 LL ~         Foo(VAL) => true,
    |
 
@@ -32,7 +32,7 @@ LL +         Bar { baz } if baz == "hi".to_owned() => true,
 help: consider extracting the expression into a `const`
    |
 LL +     const BAZ: /* Type */ = "hi".to_owned();
-LL ~     match bar {
+LL |     match bar {
 LL ~         Bar { baz: BAZ } => true,
    |
 
@@ -51,7 +51,7 @@ LL +         &[val] if val == "foo".to_string() => {}
 help: consider extracting the expression into a `const`
    |
 LL +     const VAL: /* Type */ = "foo".to_string();
-LL ~     match foo.as_slice() {
+LL |     match foo.as_slice() {
 LL ~         &[VAL] => {}
    |
 

--- a/tests/ui/parser/recover/recover-pat-ranges.stderr
+++ b/tests/ui/parser/recover/recover-pat-ranges.stderr
@@ -92,7 +92,7 @@ LL |         ..=1 + 2 => (),
 help: consider extracting the expression into a `const`
    |
 LL +     const VAL: /* Type */ = 1 + 2;
-LL ~     match -1 {
+LL |     match -1 {
 LL |         0..=1 => (),
 ...
 LL |
@@ -109,7 +109,7 @@ LL |         (-4 + 0).. => (),
 help: consider extracting the expression into a `const`
    |
 LL +     const VAL: /* Type */ = -4 + 0;
-LL ~     match -1 {
+LL |     match -1 {
 LL |         0..=1 => (),
 ...
 LL |
@@ -126,7 +126,7 @@ LL |         (1 + 4)...1 * 2 => (),
 help: consider extracting the expression into a `const`
    |
 LL +     const VAL: /* Type */ = 1 + 4;
-LL ~     match -1 {
+LL |     match -1 {
 LL |         0..=1 => (),
 ...
 LL |
@@ -143,7 +143,7 @@ LL |         (1 + 4)...1 * 2 => (),
 help: consider extracting the expression into a `const`
    |
 LL +     const VAL: /* Type */ = 1 * 2;
-LL ~     match -1 {
+LL |     match -1 {
 LL |         0..=1 => (),
 ...
 LL |
@@ -160,7 +160,7 @@ LL |         0.x()..="y".z() => (),
 help: consider extracting the expression into a `const`
    |
 LL +     const VAL: /* Type */ = 0.x();
-LL ~     match -1 {
+LL |     match -1 {
 LL |         0..=1 => (),
 ...
 LL |
@@ -177,7 +177,7 @@ LL |         0.x()..="y".z() => (),
 help: consider extracting the expression into a `const`
    |
 LL +     const VAL: /* Type */ = "y".z();
-LL ~     match -1 {
+LL |     match -1 {
 LL |         0..=1 => (),
 ...
 LL |

--- a/tests/ui/parser/recover/recover-pat-wildcards.stderr
+++ b/tests/ui/parser/recover/recover-pat-wildcards.stderr
@@ -81,7 +81,7 @@ LL |         4..=(2 + _) => ()
 help: consider extracting the expression into a `const`
    |
 LL +     const VAL: /* Type */ = 2 + _;
-LL ~     match 9 {
+LL |     match 9 {
 LL ~         4..=(VAL) => ()
    |
 


### PR DESCRIPTION
When rendering a "multi-line" suggestion with the [`Diff`](https://github.com/rust-lang/rust/blob/dc1feabef242259d61bd930713de3250577c1c71/compiler/rustc_errors/src/emitter.rs#L3078) format, `rustc` uses a [diff symbol](https://github.com/rust-lang/rust/blob/dc1feabef242259d61bd930713de3250577c1c71/compiler/rustc_errors/src/emitter.rs#L3017-L3022) for 
[any line that has a highlight part](https://github.com/rust-lang/rust/blob/dc1feabef242259d61bd930713de3250577c1c71/compiler/rustc_errors/src/emitter.rs#L2705-L2713). This includes highlight parts that are highlighting nothing, i.e., a span of `0..0`. This leads `rustc` to add a diff symbol unnecessarily to lines that have no changes and are not highlighted. This PR makes it so that `rustc` will not add a diff symbol to lines that contain no changes/highlights.

Note: This PR is part of my ongoing effort to have `rustc` use `annotate-snippets` for rendering. This change will make it so that `rustc` and `annotate-snippets` will match in this case.