### PR TITLE
Implement suggestion when array of 1 range used as argument of type `Range`

### DIFF
--- a/compiler/rustc_middle/src/middle/lang_items.rs
+++ b/compiler/rustc_middle/src/middle/lang_items.rs
@@ -81,6 +81,30 @@ impl<'tcx> TyCtxt<'tcx> {
     pub fn is_fn_trait(self, id: DefId) -> bool {
         self.fn_trait_kind_from_def_id(id).is_some()
     }
+
+    /// Returns `true` if `id` is a `DefId` of one of `Range` types.
+    pub fn is_range(self, id: DefId) -> bool {
+        match self.as_lang_item(id) {
+            Some(item) => match item {
+                LangItem::RangeFrom
+                | LangItem::RangeFull
+                | LangItem::RangeInclusiveStruct
+                | LangItem::RangeInclusiveNew
+                | LangItem::Range
+                | LangItem::RangeToInclusive
+                | LangItem::RangeTo
+                | LangItem::RangeMax
+                | LangItem::RangeMin
+                | LangItem::RangeSub
+                | LangItem::RangeFromCopy
+                | LangItem::RangeCopy
+                | LangItem::RangeInclusiveCopy
+                | LangItem::RangeToInclusiveCopy => true,
+                _ => false,
+            },
+            None => false,
+        }
+    }
 }
 
 /// Returns `true` if the specified `lang_item` must be present for this

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -472,6 +472,8 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                         self.suggest_remove_await(&obligation, &mut err);
                         self.suggest_derive(&obligation, &mut err, leaf_trait_predicate);
 
+                        self.suggest_remove_brackets_from_range(main_trait_predicate, span, &mut err);
+
                         if tcx.is_lang_item(leaf_trait_predicate.def_id(), LangItem::Try) {
                             self.suggest_await_before_try(
                                 &mut err,

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -471,8 +471,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                         self.note_adt_version_mismatch(&mut err, leaf_trait_predicate);
                         self.suggest_remove_await(&obligation, &mut err);
                         self.suggest_derive(&obligation, &mut err, leaf_trait_predicate);
-
-                        self.suggest_remove_brackets_from_range(main_trait_predicate, leaf_trait_predicate, span, &mut err);
+                        self.suggest_remove_brackets_from_range(&mut err, main_trait_predicate, leaf_trait_predicate, span);
 
                         if tcx.is_lang_item(leaf_trait_predicate.def_id(), LangItem::Try) {
                             self.suggest_await_before_try(

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -472,7 +472,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                         self.suggest_remove_await(&obligation, &mut err);
                         self.suggest_derive(&obligation, &mut err, leaf_trait_predicate);
 
-                        self.suggest_remove_brackets_from_range(main_trait_predicate, span, &mut err);
+                        self.suggest_remove_brackets_from_range(main_trait_predicate, leaf_trait_predicate, span, &mut err);
 
                         if tcx.is_lang_item(leaf_trait_predicate.def_id(), LangItem::Try) {
                             self.suggest_await_before_try(

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
@@ -5182,9 +5182,18 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
     pub fn suggest_remove_brackets_from_range(
         &self,
         main_trait_predicate: ty::PolyTraitPredicate<'tcx>,
+        leaf_trait_predicate: ty::PolyTraitPredicate<'tcx>,
         span: Span,
         err: &mut Diag<'_>,
     ) {
+        let is_trait_range_bounds =
+            match self.tcx.get_diagnostic_name(leaf_trait_predicate.def_id()) {
+                Some(trait_name) if trait_name == sym::RangeBounds => true,
+                _ => false,
+            };
+        if !is_trait_range_bounds {
+            return;
+        }
         if let ty::Array(inner_type, size_value) =
             main_trait_predicate.self_ty().skip_binder().kind()
         {

--- a/tests/ui/suggestions/remove-brackets-range-issue-147944-rustfix.fixed
+++ b/tests/ui/suggestions/remove-brackets-range-issue-147944-rustfix.fixed
@@ -1,0 +1,29 @@
+//@ run-rustfix
+
+fn main() {
+    let mut vec = vec![1, 2, 3, 4, 5];
+
+    vec.drain(..3);
+    //~^ ERROR: the trait bound `[RangeTo<{integer}>; 1]: RangeBounds<usize>` is not satisfied [E0277]
+    //~| SUGGESTION: ..3
+
+    vec.drain(..=3);
+    //~^ ERROR: the trait bound `[std::ops::RangeToInclusive<{integer}>; 1]: RangeBounds<usize>` is not satisfied [E0277]
+    //~| SUGGESTION: ..=3
+    
+    vec.drain(1..3);
+    //~^ ERROR: the trait bound `[std::ops::Range<{integer}>; 1]: RangeBounds<usize>` is not satisfied [E0277]
+    //~| SUGGESTION: 1..3
+
+    vec.drain(1..=3);
+    //~^ ERROR: the trait bound `[std::ops::RangeInclusive<{integer}>; 1]: RangeBounds<usize>` is not satisfied [E0277]
+    //~| SUGGESTION: 1..=3
+
+    vec.drain(1..);
+    //~^ ERROR: the trait bound `[std::ops::RangeFrom<{integer}>; 1]: RangeBounds<usize>` is not satisfied [E0277]
+    //~| SUGGESTION: 1..
+
+    vec.drain(..);
+    //~^ ERROR: the trait bound `[RangeFull; 1]: RangeBounds<usize>` is not satisfied [E0277]
+    //~| SUGGESTION: ..
+}

--- a/tests/ui/suggestions/remove-brackets-range-issue-147944-rustfix.fixed
+++ b/tests/ui/suggestions/remove-brackets-range-issue-147944-rustfix.fixed
@@ -10,7 +10,7 @@ fn main() {
     vec.drain(..=3);
     //~^ ERROR: the trait bound `[std::ops::RangeToInclusive<{integer}>; 1]: RangeBounds<usize>` is not satisfied [E0277]
     //~| SUGGESTION: ..=3
-    
+
     vec.drain(1..3);
     //~^ ERROR: the trait bound `[std::ops::Range<{integer}>; 1]: RangeBounds<usize>` is not satisfied [E0277]
     //~| SUGGESTION: 1..3

--- a/tests/ui/suggestions/remove-brackets-range-issue-147944-rustfix.rs
+++ b/tests/ui/suggestions/remove-brackets-range-issue-147944-rustfix.rs
@@ -1,0 +1,29 @@
+//@ run-rustfix
+
+fn main() {
+    let mut vec = vec![1, 2, 3, 4, 5];
+
+    vec.drain([..3]);
+    //~^ ERROR: the trait bound `[RangeTo<{integer}>; 1]: RangeBounds<usize>` is not satisfied [E0277]
+    //~| SUGGESTION: ..3
+
+    vec.drain([..=3]);
+    //~^ ERROR: the trait bound `[std::ops::RangeToInclusive<{integer}>; 1]: RangeBounds<usize>` is not satisfied [E0277]
+    //~| SUGGESTION: ..=3
+
+    vec.drain([1..3]);
+    //~^ ERROR: the trait bound `[std::ops::Range<{integer}>; 1]: RangeBounds<usize>` is not satisfied [E0277]
+    //~| SUGGESTION: 1..3
+
+    vec.drain([1..=3]);
+    //~^ ERROR: the trait bound `[std::ops::RangeInclusive<{integer}>; 1]: RangeBounds<usize>` is not satisfied [E0277]
+    //~| SUGGESTION: 1..=3
+
+    vec.drain([1..]);
+    //~^ ERROR: the trait bound `[std::ops::RangeFrom<{integer}>; 1]: RangeBounds<usize>` is not satisfied [E0277]
+    //~| SUGGESTION: 1..
+
+    vec.drain([..]);
+    //~^ ERROR: the trait bound `[RangeFull; 1]: RangeBounds<usize>` is not satisfied [E0277]
+    //~| SUGGESTION: ..
+}

--- a/tests/ui/suggestions/remove-brackets-range-issue-147944-rustfix.stderr
+++ b/tests/ui/suggestions/remove-brackets-range-issue-147944-rustfix.stderr
@@ -1,0 +1,99 @@
+error[E0277]: the trait bound `[RangeTo<{integer}>; 1]: RangeBounds<usize>` is not satisfied
+  --> $DIR/remove-brackets-range-issue-147944-rustfix.rs:6:15
+   |
+LL |     vec.drain([..3]);
+   |         ----- ^^^^^ the trait `RangeBounds<usize>` is not implemented for `[RangeTo<{integer}>; 1]`
+   |         |
+   |         required by a bound introduced by this call
+   |
+note: required by a bound in `Vec::<T, A>::drain`
+  --> $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
+help: consider removing `[]`
+   |
+LL -     vec.drain([..3]);
+LL +     vec.drain(..3);
+   |
+
+error[E0277]: the trait bound `[std::ops::RangeToInclusive<{integer}>; 1]: RangeBounds<usize>` is not satisfied
+  --> $DIR/remove-brackets-range-issue-147944-rustfix.rs:10:15
+   |
+LL |     vec.drain([..=3]);
+   |         ----- ^^^^^^ the trait `RangeBounds<usize>` is not implemented for `[std::ops::RangeToInclusive<{integer}>; 1]`
+   |         |
+   |         required by a bound introduced by this call
+   |
+note: required by a bound in `Vec::<T, A>::drain`
+  --> $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
+help: consider removing `[]`
+   |
+LL -     vec.drain([..=3]);
+LL +     vec.drain(..=3);
+   |
+
+error[E0277]: the trait bound `[std::ops::Range<{integer}>; 1]: RangeBounds<usize>` is not satisfied
+  --> $DIR/remove-brackets-range-issue-147944-rustfix.rs:14:15
+   |
+LL |     vec.drain([1..3]);
+   |         ----- ^^^^^^ the trait `RangeBounds<usize>` is not implemented for `[std::ops::Range<{integer}>; 1]`
+   |         |
+   |         required by a bound introduced by this call
+   |
+note: required by a bound in `Vec::<T, A>::drain`
+  --> $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
+help: consider removing `[]`
+   |
+LL -     vec.drain([1..3]);
+LL +     vec.drain(1..3);
+   |
+
+error[E0277]: the trait bound `[std::ops::RangeInclusive<{integer}>; 1]: RangeBounds<usize>` is not satisfied
+  --> $DIR/remove-brackets-range-issue-147944-rustfix.rs:18:15
+   |
+LL |     vec.drain([1..=3]);
+   |         ----- ^^^^^^^ the trait `RangeBounds<usize>` is not implemented for `[std::ops::RangeInclusive<{integer}>; 1]`
+   |         |
+   |         required by a bound introduced by this call
+   |
+note: required by a bound in `Vec::<T, A>::drain`
+  --> $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
+help: consider removing `[]`
+   |
+LL -     vec.drain([1..=3]);
+LL +     vec.drain(1..=3);
+   |
+
+error[E0277]: the trait bound `[std::ops::RangeFrom<{integer}>; 1]: RangeBounds<usize>` is not satisfied
+  --> $DIR/remove-brackets-range-issue-147944-rustfix.rs:22:15
+   |
+LL |     vec.drain([1..]);
+   |         ----- ^^^^^ the trait `RangeBounds<usize>` is not implemented for `[std::ops::RangeFrom<{integer}>; 1]`
+   |         |
+   |         required by a bound introduced by this call
+   |
+note: required by a bound in `Vec::<T, A>::drain`
+  --> $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
+help: consider removing `[]`
+   |
+LL -     vec.drain([1..]);
+LL +     vec.drain(1..);
+   |
+
+error[E0277]: the trait bound `[RangeFull; 1]: RangeBounds<usize>` is not satisfied
+  --> $DIR/remove-brackets-range-issue-147944-rustfix.rs:26:15
+   |
+LL |     vec.drain([..]);
+   |         ----- ^^^^ the trait `RangeBounds<usize>` is not implemented for `[RangeFull; 1]`
+   |         |
+   |         required by a bound introduced by this call
+   |
+note: required by a bound in `Vec::<T, A>::drain`
+  --> $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
+help: consider removing `[]`
+   |
+LL -     vec.drain([..]);
+LL +     vec.drain(..);
+   |
+
+error: aborting due to 6 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/suggestions/remove-brackets-range-issue-147944.rs
+++ b/tests/ui/suggestions/remove-brackets-range-issue-147944.rs
@@ -6,4 +6,30 @@ fn main() {
     //~| NOTE: required by a bound introduced by this call
     //~| NOTE: required by a bound in `Vec::<T, A>::drain`
     //~| HELP: consider removing `[]`
+
+    // Should not produce this  suggestion:
+
+    take_array_of_one_range_bounds([..3]);
+
+    take_array_of_one_different_trait([5..10]);
+    //~^ ERROR: no implementation for `std::ops::Range<{integer}> << usize` [E0277]
+    //~| NOTE: no implementation for `std::ops::Range<{integer}> << usize`
+    //~| NOTE: required by a bound introduced by this call
+    //~| HELP: the trait `Shl<usize>` is not implemented for `std::ops::Range<{integer}>`
+
+    take_different_trait([5..10]);
+    //~^ ERROR: no implementation for `[std::ops::Range<{integer}>; 1] << usize` [E0277]
+    //~| NOTE: no implementation for `[std::ops::Range<{integer}>; 1] << usize`
+    //~| NOTE: required by a bound introduced by this call
+    //~| HELP: the trait `Shl<usize>` is not implemented for `[std::ops::Range<{integer}>; 1]`
 }
+
+fn take_array_of_one_range_bounds<T: std::ops::RangeBounds<usize>>(_arr: [T; 1]) {}
+
+fn take_array_of_one_different_trait<T: std::ops::Shl<usize>>(_arr: [T; 1]) {}
+//~^ NOTE: required by a bound in `take_array_of_one_different_trait`
+//~| NOTE: required by this bound in `take_array_of_one_different_trait`
+
+fn take_different_trait<T: std::ops::Shl<usize>>(_ty: T) {}
+//~^ NOTE: required by a bound in `take_different_trait`
+//~| NOTE: required by this bound in `take_different_trait`

--- a/tests/ui/suggestions/remove-brackets-range-issue-147944.rs
+++ b/tests/ui/suggestions/remove-brackets-range-issue-147944.rs
@@ -2,34 +2,26 @@ fn main() {
     let mut vec = vec![1, 2, 3, 4, 5];
     vec.drain([..3]);
     //~^ ERROR: the trait bound `[RangeTo<{integer}>; 1]: RangeBounds<usize>` is not satisfied [E0277]
-    //~| NOTE: the trait `RangeBounds<usize>` is not implemented for `[RangeTo<{integer}>; 1]`
-    //~| NOTE: required by a bound introduced by this call
-    //~| NOTE: required by a bound in `Vec::<T, A>::drain`
-    //~| HELP: consider removing `[]`
+    //~| SUGGESTION: ..3
 
-    // Should not produce this  suggestion:
+    // Should not produce this suggestion:
+
+    let range = [1..5];
+    let mut vec = vec![1, 2, 3, 4, 5];
+    vec.drain(range);
+    //~^ ERROR: the trait bound `[std::ops::Range<{integer}>; 1]: RangeBounds<usize>` is not satisfied [E0277]
 
     take_array_of_one_range_bounds([..3]);
 
     take_array_of_one_different_trait([5..10]);
     //~^ ERROR: no implementation for `std::ops::Range<{integer}> << usize` [E0277]
-    //~| NOTE: no implementation for `std::ops::Range<{integer}> << usize`
-    //~| NOTE: required by a bound introduced by this call
-    //~| HELP: the trait `Shl<usize>` is not implemented for `std::ops::Range<{integer}>`
 
     take_different_trait([5..10]);
     //~^ ERROR: no implementation for `[std::ops::Range<{integer}>; 1] << usize` [E0277]
-    //~| NOTE: no implementation for `[std::ops::Range<{integer}>; 1] << usize`
-    //~| NOTE: required by a bound introduced by this call
-    //~| HELP: the trait `Shl<usize>` is not implemented for `[std::ops::Range<{integer}>; 1]`
 }
 
 fn take_array_of_one_range_bounds<T: std::ops::RangeBounds<usize>>(_arr: [T; 1]) {}
 
 fn take_array_of_one_different_trait<T: std::ops::Shl<usize>>(_arr: [T; 1]) {}
-//~^ NOTE: required by a bound in `take_array_of_one_different_trait`
-//~| NOTE: required by this bound in `take_array_of_one_different_trait`
 
 fn take_different_trait<T: std::ops::Shl<usize>>(_ty: T) {}
-//~^ NOTE: required by a bound in `take_different_trait`
-//~| NOTE: required by this bound in `take_different_trait`

--- a/tests/ui/suggestions/remove-brackets-range-issue-147944.rs
+++ b/tests/ui/suggestions/remove-brackets-range-issue-147944.rs
@@ -1,0 +1,9 @@
+fn main() {
+    let mut vec = vec![1, 2, 3, 4, 5];
+    vec.drain([..3]);
+    //~^ ERROR: the trait bound `[RangeTo<{integer}>; 1]: RangeBounds<usize>` is not satisfied [E0277]
+    //~| NOTE: the trait `RangeBounds<usize>` is not implemented for `[RangeTo<{integer}>; 1]`
+    //~| NOTE: required by a bound introduced by this call
+    //~| NOTE: required by a bound in `Vec::<T, A>::drain`
+    //~| HELP: consider removing `[]`
+}

--- a/tests/ui/suggestions/remove-brackets-range-issue-147944.stderr
+++ b/tests/ui/suggestions/remove-brackets-range-issue-147944.stderr
@@ -1,0 +1,19 @@
+error[E0277]: the trait bound `[RangeTo<{integer}>; 1]: RangeBounds<usize>` is not satisfied
+  --> $DIR/remove-brackets-range-issue-147944.rs:3:15
+   |
+LL |     vec.drain([..3]);
+   |         ----- ^^^^^ the trait `RangeBounds<usize>` is not implemented for `[RangeTo<{integer}>; 1]`
+   |         |
+   |         required by a bound introduced by this call
+   |
+note: required by a bound in `Vec::<T, A>::drain`
+  --> $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
+help: consider removing `[]`
+   |
+LL -     vec.drain([..3]);
+LL +     vec.drain(..3);
+   |
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/suggestions/remove-brackets-range-issue-147944.stderr
+++ b/tests/ui/suggestions/remove-brackets-range-issue-147944.stderr
@@ -14,8 +14,19 @@ LL -     vec.drain([..3]);
 LL +     vec.drain(..3);
    |
 
+error[E0277]: the trait bound `[std::ops::Range<{integer}>; 1]: RangeBounds<usize>` is not satisfied
+  --> $DIR/remove-brackets-range-issue-147944.rs:11:15
+   |
+LL |     vec.drain(range);
+   |         ----- ^^^^^ the trait `RangeBounds<usize>` is not implemented for `[std::ops::Range<{integer}>; 1]`
+   |         |
+   |         required by a bound introduced by this call
+   |
+note: required by a bound in `Vec::<T, A>::drain`
+  --> $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
+
 error[E0277]: no implementation for `std::ops::Range<{integer}> << usize`
-  --> $DIR/remove-brackets-range-issue-147944.rs:14:39
+  --> $DIR/remove-brackets-range-issue-147944.rs:16:39
    |
 LL |     take_array_of_one_different_trait([5..10]);
    |     --------------------------------- ^^^^^^^ no implementation for `std::ops::Range<{integer}> << usize`
@@ -24,13 +35,13 @@ LL |     take_array_of_one_different_trait([5..10]);
    |
    = help: the trait `Shl<usize>` is not implemented for `std::ops::Range<{integer}>`
 note: required by a bound in `take_array_of_one_different_trait`
-  --> $DIR/remove-brackets-range-issue-147944.rs:29:41
+  --> $DIR/remove-brackets-range-issue-147944.rs:25:41
    |
 LL | fn take_array_of_one_different_trait<T: std::ops::Shl<usize>>(_arr: [T; 1]) {}
    |                                         ^^^^^^^^^^^^^^^^^^^^ required by this bound in `take_array_of_one_different_trait`
 
 error[E0277]: no implementation for `[std::ops::Range<{integer}>; 1] << usize`
-  --> $DIR/remove-brackets-range-issue-147944.rs:20:26
+  --> $DIR/remove-brackets-range-issue-147944.rs:19:26
    |
 LL |     take_different_trait([5..10]);
    |     -------------------- ^^^^^^^ no implementation for `[std::ops::Range<{integer}>; 1] << usize`
@@ -39,11 +50,11 @@ LL |     take_different_trait([5..10]);
    |
    = help: the trait `Shl<usize>` is not implemented for `[std::ops::Range<{integer}>; 1]`
 note: required by a bound in `take_different_trait`
-  --> $DIR/remove-brackets-range-issue-147944.rs:33:28
+  --> $DIR/remove-brackets-range-issue-147944.rs:27:28
    |
 LL | fn take_different_trait<T: std::ops::Shl<usize>>(_ty: T) {}
    |                            ^^^^^^^^^^^^^^^^^^^^ required by this bound in `take_different_trait`
 
-error: aborting due to 3 previous errors
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/suggestions/remove-brackets-range-issue-147944.stderr
+++ b/tests/ui/suggestions/remove-brackets-range-issue-147944.stderr
@@ -14,6 +14,36 @@ LL -     vec.drain([..3]);
 LL +     vec.drain(..3);
    |
 
-error: aborting due to 1 previous error
+error[E0277]: no implementation for `std::ops::Range<{integer}> << usize`
+  --> $DIR/remove-brackets-range-issue-147944.rs:14:39
+   |
+LL |     take_array_of_one_different_trait([5..10]);
+   |     --------------------------------- ^^^^^^^ no implementation for `std::ops::Range<{integer}> << usize`
+   |     |
+   |     required by a bound introduced by this call
+   |
+   = help: the trait `Shl<usize>` is not implemented for `std::ops::Range<{integer}>`
+note: required by a bound in `take_array_of_one_different_trait`
+  --> $DIR/remove-brackets-range-issue-147944.rs:29:41
+   |
+LL | fn take_array_of_one_different_trait<T: std::ops::Shl<usize>>(_arr: [T; 1]) {}
+   |                                         ^^^^^^^^^^^^^^^^^^^^ required by this bound in `take_array_of_one_different_trait`
+
+error[E0277]: no implementation for `[std::ops::Range<{integer}>; 1] << usize`
+  --> $DIR/remove-brackets-range-issue-147944.rs:20:26
+   |
+LL |     take_different_trait([5..10]);
+   |     -------------------- ^^^^^^^ no implementation for `[std::ops::Range<{integer}>; 1] << usize`
+   |     |
+   |     required by a bound introduced by this call
+   |
+   = help: the trait `Shl<usize>` is not implemented for `[std::ops::Range<{integer}>; 1]`
+note: required by a bound in `take_different_trait`
+  --> $DIR/remove-brackets-range-issue-147944.rs:33:28
+   |
+LL | fn take_different_trait<T: std::ops::Shl<usize>>(_ty: T) {}
+   |                            ^^^^^^^^^^^^^^^^^^^^ required by this bound in `take_different_trait`
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Fixes: rust-lang/rust#147944 

```rust
fn main() {
    let mut vec = vec![1, 2, 3, 4, 5];
    vec.drain([..3]);
}
```
Using array of 1 range instead of range itself as argument of `impl RangeBounds` now additionally produces this suggestion:
```
help: consider removing `[]`
   |
LL -     vec.drain([..3]);
LL +     vec.drain(..3);
   |
```
