### PR TITLE
fix: Only special case single line item attribute suggestions

### DIFF
--- a/compiler/rustc_errors/src/emitter.rs
+++ b/compiler/rustc_errors/src/emitter.rs
@@ -2152,6 +2152,7 @@ impl HumanEmitter {
 
             let line_start = sm.lookup_char_pos(parts[0].original_span.lo()).line;
             let mut lines = complete.lines();
+            let lines_len = lines.clone().count();
             if lines.clone().next().is_none() {
                 // Account for a suggestion to completely remove a line(s) with whitespace (#94192).
                 let line_end = sm.lookup_char_pos(parts[0].original_span.hi()).line;
@@ -2192,6 +2193,7 @@ impl HumanEmitter {
                 if highlight_parts.len() == 1
                     && line.trim().starts_with("#[")
                     && line.trim().ends_with(']')
+                    && lines_len == 1
                 {
                     is_item_attribute = true;
                 }

--- a/src/tools/clippy/tests/ui/new_without_default.stderr
+++ b/src/tools/clippy/tests/ui/new_without_default.stderr
@@ -191,7 +191,6 @@ LL +     fn default() -> Self {
 LL +         Self::new()
 LL +     }
 LL + }
-LL | impl NewWithCfg {
    |
 
 error: you should consider adding a `Default` implementation for `NewWith2Cfgs`
@@ -212,7 +211,6 @@ LL +     fn default() -> Self {
 LL +         Self::new()
 LL +     }
 LL + }
-LL | impl NewWith2Cfgs {
    |
 
 error: you should consider adding a `Default` implementation for `NewWithExtraneous`
@@ -250,7 +248,6 @@ LL +     fn default() -> Self {
 LL +         Self::new()
 LL +     }
 LL + }
-LL | impl NewWithCfgAndExtraneous {
    |
 
 error: aborting due to 13 previous errors


### PR DESCRIPTION
`rustc` currently special cases suggestions to add [`#[derive(_)]\n` and other attributes](https://github.com/rust-lang/rust/blob/dc1feabef242259d61bd930713de3250577c1c71/compiler/rustc_errors/src/emitter.rs#L2288C36-L2288C72), to add more context to the suggestions.

> // The suggestion adds an entire line of code, ending on a newline, so we'll also
> // print the *following* line, to provide context of what we're advising people to
> // do. Otherwise you would only see contextless code that can be confused for
> // already existing code, despite the colors and UI elements.
> // We special case `#[derive(_)]\n` and other attribute suggestions, because those
> // are the ones where context is most useful.


This special case is a bit broad at the moment and applies to suggestions just to add an attribute, as well as suggestions that contain an attribute and other code, i.e.
```rust
#[derive(Clone)]
```
and
```rust
#[cfg(not(test))]
impl Default for NewWithCfg {
    fn default() -> Self {
        Self::new()
    }
}
```

In the latter case, adding a line for context after the suggestion doesn't provide much benefit. Example:
![temp](https://github.com/user-attachments/assets/6859b400-aa99-4c1b-9eb0-0cd67ae35bf9)




This PR makes it so that this special case only applies to suggestions that just add an attribute and nothing else. This will also make `rustc`'s output match `annotate-snippets`.