### PR TITLE
Revert constification of `AsRef for Cow` due to inference failure 

### DIFF
--- a/library/alloc/src/borrow.rs
+++ b/library/alloc/src/borrow.rs
@@ -441,11 +441,13 @@ where
     }
 }
 
+// FIXME(inference): const bounds removed due to inference regressions found by crater;
+//   see https://github.com/rust-lang/rust/issues/147964
+// #[rustc_const_unstable(feature = "const_convert", issue = "143773")]
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_const_unstable(feature = "const_convert", issue = "143773")]
-impl<T: ?Sized + ToOwned> const AsRef<T> for Cow<'_, T>
-where
-    T::Owned: [const] Borrow<T>,
+impl<T: ?Sized + ToOwned> AsRef<T> for Cow<'_, T>
+// where
+//     T::Owned: [const] Borrow<T>,
 {
     fn as_ref(&self) -> &T {
         self


### PR DESCRIPTION
Reported issue: rust-lang/rust#147964 
Original PR: rust-lang/rust#145279
`const AsRef` tracking issue: rust-lang/rust#143773

Should have additional crater run to verify this fixes the issue.