### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -3636,49 +3636,26 @@ pub struct Trait {
     pub items: ThinVec<Box<AssocItem>>,
 }
 
-/// The location of a where clause on a `TyAlias` (`Span`) and whether there was
-/// a `where` keyword (`bool`). This is split out from `WhereClause`, since there
-/// are two locations for where clause on type aliases, but their predicates
-/// are concatenated together.
-///
-/// Take this example:
-/// ```ignore (only-for-syntax-highlight)
-/// trait Foo {
-///   type Assoc<'a, 'b> where Self: 'a, Self: 'b;
-/// }
-/// impl Foo for () {
-///   type Assoc<'a, 'b> where Self: 'a = () where Self: 'b;
-///   //                 ^^^^^^^^^^^^^^ first where clause
-///   //                                     ^^^^^^^^^^^^^^ second where clause
-/// }
-/// ```
-///
-/// If there is no where clause, then this is `false` with `DUMMY_SP`.
-#[derive(Copy, Clone, Encodable, Decodable, Debug, Default, Walkable)]
-pub struct TyAliasWhereClause {
-    pub has_where_token: bool,
-    pub span: Span,
-}
-
-/// The span information for the two where clauses on a `TyAlias`.
-#[derive(Copy, Clone, Encodable, Decodable, Debug, Default, Walkable)]
-pub struct TyAliasWhereClauses {
-    /// Before the equals sign.
-    pub before: TyAliasWhereClause,
-    /// After the equals sign.
-    pub after: TyAliasWhereClause,
-    /// The index in `TyAlias.generics.where_clause.predicates` that would split
-    /// into predicates from the where clause before the equals sign and the ones
-    /// from the where clause after the equals sign.
-    pub split: usize,
-}
-
 #[derive(Clone, Encodable, Decodable, Debug, Walkable)]
 pub struct TyAlias {
     pub defaultness: Defaultness,
     pub ident: Ident,
     pub generics: Generics,
-    pub where_clauses: TyAliasWhereClauses,
+    /// There are two locations for where clause on type aliases. This represents the second
+    /// where clause, before the semicolon. The first where clause is stored inside `generics`.
+    ///
+    /// Take this example:
+    /// ```ignore (only-for-syntax-highlight)
+    /// trait Foo {
+    ///   type Assoc<'a, 'b> where Self: 'a, Self: 'b;
+    /// }
+    /// impl Foo for () {
+    ///   type Assoc<'a, 'b> where Self: 'a = () where Self: 'b;
+    ///   //                 ^^^^^^^^^^^^^^ before where clause
+    ///   //                                     ^^^^^^^^^^^^^^ after where clause
+    /// }
+    /// ```
+    pub after_where_clause: WhereClause,
     #[visitable(extra = BoundKind::Bound)]
     pub bounds: GenericBounds,
     pub ty: Option<Box<Ty>>,

--- a/compiler/rustc_ast/src/visit.rs
+++ b/compiler/rustc_ast/src/visit.rs
@@ -471,8 +471,6 @@ macro_rules! common_visitor_and_walkers {
             TraitBoundModifiers,
             TraitObjectSyntax,
             TyAlias,
-            TyAliasWhereClause,
-            TyAliasWhereClauses,
             TyKind,
             TyPatKind,
             UnOp,

--- a/compiler/rustc_ast_pretty/src/pprust/state/item.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state/item.rs
@@ -59,14 +59,14 @@ impl<'a> State<'a> {
                 defaultness,
                 ident,
                 generics,
-                where_clauses,
+                after_where_clause,
                 bounds,
                 ty,
             }) => {
                 self.print_associated_type(
                     *ident,
                     generics,
-                    *where_clauses,
+                    after_where_clause,
                     bounds,
                     ty.as_deref(),
                     vis,
@@ -127,14 +127,12 @@ impl<'a> State<'a> {
         &mut self,
         ident: Ident,
         generics: &ast::Generics,
-        where_clauses: ast::TyAliasWhereClauses,
+        after_where_clause: &ast::WhereClause,
         bounds: &ast::GenericBounds,
         ty: Option<&ast::Ty>,
         vis: &ast::Visibility,
         defaultness: ast::Defaultness,
     ) {
-        let (before_predicates, after_predicates) =
-            generics.where_clause.predicates.split_at(where_clauses.split);
         let (cb, ib) = self.head("");
         self.print_visibility(vis);
         self.print_defaultness(defaultness);
@@ -145,13 +143,13 @@ impl<'a> State<'a> {
             self.word_nbsp(":");
             self.print_type_bounds(bounds);
         }
-        self.print_where_clause_parts(where_clauses.before.has_where_token, before_predicates);
+        self.print_where_clause(&generics.where_clause);
         if let Some(ty) = ty {
             self.space();
             self.word_space("=");
             self.print_type(ty);
         }
-        self.print_where_clause_parts(where_clauses.after.has_where_token, after_predicates);
+        self.print_where_clause(&after_where_clause);
         self.word(";");
         self.end(ib);
         self.end(cb);
@@ -283,14 +281,14 @@ impl<'a> State<'a> {
                 defaultness,
                 ident,
                 generics,
-                where_clauses,
+                after_where_clause,
                 bounds,
                 ty,
             }) => {
                 self.print_associated_type(
                     *ident,
                     generics,
-                    *where_clauses,
+                    after_where_clause,
                     bounds,
                     ty.as_deref(),
                     &item.vis,
@@ -585,14 +583,14 @@ impl<'a> State<'a> {
                 defaultness,
                 ident,
                 generics,
-                where_clauses,
+                after_where_clause,
                 bounds,
                 ty,
             }) => {
                 self.print_associated_type(
                     *ident,
                     generics,
-                    *where_clauses,
+                    after_where_clause,
                     bounds,
                     ty.as_deref(),
                     vis,
@@ -759,14 +757,7 @@ impl<'a> State<'a> {
     }
 
     fn print_where_clause(&mut self, where_clause: &ast::WhereClause) {
-        self.print_where_clause_parts(where_clause.has_where_token, &where_clause.predicates);
-    }
-
-    fn print_where_clause_parts(
-        &mut self,
-        has_where_token: bool,
-        predicates: &[ast::WherePredicate],
-    ) {
+        let ast::WhereClause { has_where_token, ref predicates, span: _ } = *where_clause;
         if predicates.is_empty() && !has_where_token {
             return;
         }

--- a/compiler/rustc_builtin_macros/src/deriving/generic/mod.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/generic/mod.rs
@@ -610,7 +610,7 @@ impl<'a> TraitDef<'a> {
                     defaultness: ast::Defaultness::Final,
                     ident,
                     generics: Generics::default(),
-                    where_clauses: ast::TyAliasWhereClauses::default(),
+                    after_where_clause: ast::WhereClause::default(),
                     bounds: Vec::new(),
                     ty: Some(type_def.to_ty(cx, self.span, type_ident, generics)),
                 })),

--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -1041,32 +1041,11 @@ impl<'a> Parser<'a> {
 
         // Parse optional colon and param bounds.
         let bounds = if self.eat(exp!(Colon)) { self.parse_generic_bounds()? } else { Vec::new() };
-        let before_where_clause = self.parse_where_clause()?;
+        generics.where_clause = self.parse_where_clause()?;
 
         let ty = if self.eat(exp!(Eq)) { Some(self.parse_ty()?) } else { None };
 
         let after_where_clause = self.parse_where_clause()?;
-
-        let where_clauses = TyAliasWhereClauses {
-            before: TyAliasWhereClause {
-                has_where_token: before_where_clause.has_where_token,
-                span: before_where_clause.span,
-            },
-            after: TyAliasWhereClause {
-                has_where_token: after_where_clause.has_where_token,
-                span: after_where_clause.span,
-            },
-            split: before_where_clause.predicates.len(),
-        };
-        let mut predicates = before_where_clause.predicates;
-        predicates.extend(after_where_clause.predicates);
-        let where_clause = WhereClause {
-            has_where_token: before_where_clause.has_where_token
-                || after_where_clause.has_where_token,
-            predicates,
-            span: DUMMY_SP,
-        };
-        generics.where_clause = where_clause;
 
         self.expect_semi()?;
 
@@ -1074,7 +1053,7 @@ impl<'a> Parser<'a> {
             defaultness,
             ident,
             generics,
-            where_clauses,
+            after_where_clause,
             bounds,
             ty,
         })))

--- a/library/alloc/src/borrow.rs
+++ b/library/alloc/src/borrow.rs
@@ -441,11 +441,13 @@ where
     }
 }
 
+// FIXME(inference): const bounds removed due to inference regressions found by crater;
+//   see https://github.com/rust-lang/rust/issues/147964
+// #[rustc_const_unstable(feature = "const_convert", issue = "143773")]
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_const_unstable(feature = "const_convert", issue = "143773")]
-impl<T: ?Sized + ToOwned> const AsRef<T> for Cow<'_, T>
-where
-    T::Owned: [const] Borrow<T>,
+impl<T: ?Sized + ToOwned> AsRef<T> for Cow<'_, T>
+// where
+//     T::Owned: [const] Borrow<T>,
 {
     fn as_ref(&self) -> &T {
         self

--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -85,6 +85,7 @@
 //
 // Library features:
 // tidy-alphabetical-start
+#![cfg_attr(not(no_global_oom_handling), feature(string_replace_in_place))]
 #![feature(alloc_layout_extra)]
 #![feature(allocator_api)]
 #![feature(array_into_iter_constructors)]

--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -2090,6 +2090,67 @@ impl String {
         unsafe { self.as_mut_vec() }.splice((start, end), replace_with.bytes());
     }
 
+    /// Replaces the leftmost occurrence of a pattern with another string, in-place.
+    ///
+    /// This method can be preferred over [`string = string.replacen(..., 1);`][replacen],
+    /// as it can use the `String`'s existing capacity to prevent a reallocation if
+    /// sufficient space is available.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// #![feature(string_replace_in_place)]
+    ///
+    /// let mut s = String::from("Test Results: ❌❌❌");
+    ///
+    /// // Replace the leftmost ❌ with a ✅
+    /// s.replace_first('❌', "✅");
+    /// assert_eq!(s, "Test Results: ✅❌❌");
+    /// ```
+    ///
+    /// [replacen]: ../../std/primitive.str.html#method.replacen
+    #[cfg(not(no_global_oom_handling))]
+    #[unstable(feature = "string_replace_in_place", issue = "147949")]
+    pub fn replace_first<P: Pattern>(&mut self, from: P, to: &str) {
+        let range = match self.match_indices(from).next() {
+            Some((start, match_str)) => start..start + match_str.len(),
+            None => return,
+        };
+
+        self.replace_range(range, to);
+    }
+
+    /// Replaces the rightmost occurrence of a pattern with another string, in-place.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// #![feature(string_replace_in_place)]
+    ///
+    /// let mut s = String::from("Test Results: ❌❌❌");
+    ///
+    /// // Replace the rightmost ❌ with a ✅
+    /// s.replace_last('❌', "✅");
+    /// assert_eq!(s, "Test Results: ❌❌✅");
+    /// ```
+    #[cfg(not(no_global_oom_handling))]
+    #[unstable(feature = "string_replace_in_place", issue = "147949")]
+    pub fn replace_last<P: Pattern>(&mut self, from: P, to: &str)
+    where
+        for<'a> P::Searcher<'a>: core::str::pattern::ReverseSearcher<'a>,
+    {
+        let range = match self.rmatch_indices(from).next() {
+            Some((start, match_str)) => start..start + match_str.len(),
+            None => return,
+        };
+
+        self.replace_range(range, to);
+    }
+
     /// Converts this `String` into a <code>[Box]<[str]></code>.
     ///
     /// Before doing the conversion, this method discards excess capacity like [`shrink_to_fit`].

--- a/library/alloctests/tests/lib.rs
+++ b/library/alloctests/tests/lib.rs
@@ -36,6 +36,7 @@
 #![feature(local_waker)]
 #![feature(str_as_str)]
 #![feature(strict_provenance_lints)]
+#![feature(string_replace_in_place)]
 #![feature(vec_deque_pop_if)]
 #![feature(vec_deque_truncate_front)]
 #![feature(unique_rc_arc)]

--- a/library/alloctests/tests/string.rs
+++ b/library/alloctests/tests/string.rs
@@ -720,6 +720,40 @@ fn test_replace_range_evil_end_bound() {
 }
 
 #[test]
+fn test_replace_first() {
+    let mut s = String::from("~ First ❌ Middle ❌ Last ❌ ~");
+    s.replace_first("❌", "✅✅");
+    assert_eq!(s, "~ First ✅✅ Middle ❌ Last ❌ ~");
+    s.replace_first("🦀", "😳");
+    assert_eq!(s, "~ First ✅✅ Middle ❌ Last ❌ ~");
+
+    let mut s = String::from("❌");
+    s.replace_first('❌', "✅✅");
+    assert_eq!(s, "✅✅");
+
+    let mut s = String::from("");
+    s.replace_first('🌌', "❌");
+    assert_eq!(s, "");
+}
+
+#[test]
+fn test_replace_last() {
+    let mut s = String::from("~ First ❌ Middle ❌ Last ❌ ~");
+    s.replace_last("❌", "✅✅");
+    assert_eq!(s, "~ First ❌ Middle ❌ Last ✅✅ ~");
+    s.replace_last("🦀", "😳");
+    assert_eq!(s, "~ First ❌ Middle ❌ Last ✅✅ ~");
+
+    let mut s = String::from("❌");
+    s.replace_last::<char>('❌', "✅✅");
+    assert_eq!(s, "✅✅");
+
+    let mut s = String::from("");
+    s.replace_last::<char>('🌌', "❌");
+    assert_eq!(s, "");
+}
+
+#[test]
 fn test_extend_ref() {
     let mut a = "foo".to_string();
     a.extend(&['b', 'a', 'r']);

--- a/src/tools/clippy/clippy_utils/src/ast_utils/mod.rs
+++ b/src/tools/clippy/clippy_utils/src/ast_utils/mod.rs
@@ -562,7 +562,7 @@ pub fn eq_foreign_item_kind(l: &ForeignItemKind, r: &ForeignItemKind) -> bool {
                 defaultness: ld,
                 ident: li,
                 generics: lg,
-                where_clauses: _,
+                after_where_clause: lw,
                 bounds: lb,
                 ty: lt,
             }),
@@ -570,7 +570,7 @@ pub fn eq_foreign_item_kind(l: &ForeignItemKind, r: &ForeignItemKind) -> bool {
                 defaultness: rd,
                 ident: ri,
                 generics: rg,
-                where_clauses: _,
+                after_where_clause: rw,
                 bounds: rb,
                 ty: rt,
             }),
@@ -578,6 +578,7 @@ pub fn eq_foreign_item_kind(l: &ForeignItemKind, r: &ForeignItemKind) -> bool {
             eq_defaultness(*ld, *rd)
                 && eq_id(*li, *ri)
                 && eq_generics(lg, rg)
+                && over(&lw.predicates, &rw.predicates, eq_where_predicate)
                 && over(lb, rb, eq_generic_bound)
                 && both(lt.as_ref(), rt.as_ref(), |l, r| eq_ty(l, r))
         },
@@ -645,7 +646,7 @@ pub fn eq_assoc_item_kind(l: &AssocItemKind, r: &AssocItemKind) -> bool {
                 defaultness: ld,
                 ident: li,
                 generics: lg,
-                where_clauses: _,
+                after_where_clause: lw,
                 bounds: lb,
                 ty: lt,
             }),
@@ -653,7 +654,7 @@ pub fn eq_assoc_item_kind(l: &AssocItemKind, r: &AssocItemKind) -> bool {
                 defaultness: rd,
                 ident: ri,
                 generics: rg,
-                where_clauses: _,
+                after_where_clause: rw,
                 bounds: rb,
                 ty: rt,
             }),
@@ -661,6 +662,7 @@ pub fn eq_assoc_item_kind(l: &AssocItemKind, r: &AssocItemKind) -> bool {
             eq_defaultness(*ld, *rd)
                 && eq_id(*li, *ri)
                 && eq_generics(lg, rg)
+                && over(&lw.predicates, &rw.predicates, eq_where_predicate)
                 && over(lb, rb, eq_generic_bound)
                 && both(lt.as_ref(), rt.as_ref(), |l, r| eq_ty(l, r))
         },

--- a/tests/ui/where-clauses/cfg-attr-issue-138010-1.rs
+++ b/tests/ui/where-clauses/cfg-attr-issue-138010-1.rs
@@ -1,0 +1,14 @@
+//@ check-pass
+
+#![feature(associated_type_defaults, where_clause_attrs)]
+#![allow(deprecated_where_clause_location)]
+
+trait A {
+    type F<T>
+    where
+        #[cfg(false)]
+        T: TraitB,
+    = T;
+}
+
+fn main() {}

--- a/tests/ui/where-clauses/cfg-attr-issue-138010-2.rs
+++ b/tests/ui/where-clauses/cfg-attr-issue-138010-2.rs
@@ -1,0 +1,27 @@
+#![feature(where_clause_attrs, lazy_type_alias)]
+#![expect(incomplete_features)]
+
+struct Foo;
+trait Trait {}
+
+impl Trait for Foo {}
+
+type MixedWhereBounds1
+where
+    //~^ ERROR: where clauses are not allowed before the type for type aliases
+    #[cfg(true)]
+    Foo: Trait,
+= Foo
+where
+    (): Sized;
+
+type MixedWhereBounds2
+where
+    //~^ ERROR: where clauses are not allowed before the type for type aliases
+    #[cfg(false)]
+    Foo: Trait,
+= Foo
+where
+    (): Sized;
+
+fn main() {}

--- a/tests/ui/where-clauses/cfg-attr-issue-138010-2.stderr
+++ b/tests/ui/where-clauses/cfg-attr-issue-138010-2.stderr
@@ -1,0 +1,31 @@
+error: where clauses are not allowed before the type for type aliases
+  --> $DIR/cfg-attr-issue-138010-2.rs:10:1
+   |
+LL | / where
+LL | |
+LL | |     #[cfg(true)]
+LL | |     Foo: Trait,
+   | |_______________^
+   |
+   = note: see issue #89122 <https://github.com/rust-lang/rust/issues/89122> for more information
+help: move it to the end of the type declaration
+   |
+LL + 
+LL | = Foo
+LL | where
+LL ~     (): Sized, Foo: Trait;
+   |
+
+error: where clauses are not allowed before the type for type aliases
+  --> $DIR/cfg-attr-issue-138010-2.rs:19:1
+   |
+LL | / where
+LL | |
+LL | |     #[cfg(false)]
+LL | |     Foo: Trait,
+   | |_______________^ help: remove this `where`
+   |
+   = note: see issue #89122 <https://github.com/rust-lang/rust/issues/89122> for more information
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#134316 (Add `String::replace_first` and `String::replace_last`)
 - rust-lang/rust#147713 (Retire ast::TyAliasWhereClauses.)
 - rust-lang/rust#148011 (Revert constification of `AsRef for Cow` due to inference failure )

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=134316,147713,148011)
<!-- homu-ignore:end -->