### PR TITLE
Revert constification of `Borrow` and `Deref for Cow` due to inference failure

### DIFF
--- a/library/alloc/src/borrow.rs
+++ b/library/alloc/src/borrow.rs
@@ -16,12 +16,13 @@ use crate::fmt;
 #[cfg(not(no_global_oom_handling))]
 use crate::string::String;
 
+// FIXME(inference): const bounds removed due to inference regressions found by crater;
+//   see https://github.com/rust-lang/rust/issues/147964
+// #[rustc_const_unstable(feature = "const_convert", issue = "143773")]
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_const_unstable(feature = "const_convert", issue = "143773")]
-impl<'a, B: ?Sized> const Borrow<B> for Cow<'a, B>
-where
-    B: ToOwned,
-    B::Owned: [const] Borrow<B>,
+impl<'a, B: ?Sized + ToOwned> Borrow<B> for Cow<'a, B>
+// where
+//     B::Owned: [const] Borrow<B>,
 {
     fn borrow(&self) -> &B {
         &**self
@@ -327,11 +328,13 @@ impl<B: ?Sized + ToOwned> Cow<'_, B> {
     }
 }
 
+// FIXME(inference): const bounds removed due to inference regressions found by crater;
+//   see https://github.com/rust-lang/rust/issues/147964
+// #[rustc_const_unstable(feature = "const_convert", issue = "143773")]
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_const_unstable(feature = "const_convert", issue = "143773")]
-impl<B: ?Sized + ToOwned> const Deref for Cow<'_, B>
-where
-    B::Owned: [const] Borrow<B>,
+impl<B: ?Sized + ToOwned> Deref for Cow<'_, B>
+// where
+//     B::Owned: [const] Borrow<B>,
 {
     type Target = B;
 

--- a/tests/ui/traits/generic-cow-inference-regression.rs
+++ b/tests/ui/traits/generic-cow-inference-regression.rs
@@ -1,0 +1,20 @@
+//@ run-pass
+
+// regression test for #147964:
+//   constification of these traits resulted in inference errors due to additional where clauses
+
+use std::borrow::{Cow, Borrow};
+
+pub fn generic_deref<'a, T: ToOwned<Owned = U>, U>(cow: Cow<'a, T>) {
+    let _: &T = &cow;
+}
+
+pub fn generic_borrow<'a, T: ToOwned<Owned = U>, U>(cow: Cow<'a, T>) {
+    let _: &T = cow.borrow();
+}
+
+pub fn generic_as_ref<'a, T: ToOwned<Owned = U>, U>(cow: Cow<'a, T>) {
+    let _: &T = cow.as_ref();
+}
+
+fn main() {}


### PR DESCRIPTION
Reported issue: rust-lang/rust#147964 
Original PR: rust-lang/rust#145279
Previous revert: rust-lang/rust#148011
`const Borrow`/`Deref` tracking issue: rust-lang/rust#143773

Should have additional crater run to verify this fixes the issue.

Since other PR is in the queue, this will need to be rebased after that merges. Also will want a beta nomination.