### PR TITLE
Add TidyFlags and merge DiagCtx

### DIFF
--- a/src/tools/tidy/src/alphabetical.rs
+++ b/src/tools/tidy/src/alphabetical.rs
@@ -24,7 +24,7 @@ use std::fmt::Display;
 use std::iter::Peekable;
 use std::path::Path;
 
-use crate::diagnostics::{CheckId, DiagCtx, RunningCheck};
+use crate::diagnostics::{CheckId, RunningCheck, TidyCtx};
 use crate::walk::{filter_dirs, walk};
 
 #[cfg(test)]
@@ -130,8 +130,8 @@ fn check_lines<'a>(
     }
 }
 
-pub fn check(path: &Path, diag_ctx: DiagCtx) {
-    let mut check = diag_ctx.start_check(CheckId::new("alphabetical").path(path));
+pub fn check(path: &Path, tidy_ctx: TidyCtx) {
+    let mut check = tidy_ctx.start_check(CheckId::new("alphabetical").path(path));
 
     let skip =
         |path: &_, _is_dir| filter_dirs(path) || path.ends_with("tidy/src/alphabetical/tests.rs");

--- a/src/tools/tidy/src/alphabetical/tests.rs
+++ b/src/tools/tidy/src/alphabetical/tests.rs
@@ -1,12 +1,12 @@
 use std::path::Path;
 
 use crate::alphabetical::check_lines;
-use crate::diagnostics::DiagCtx;
+use crate::diagnostics::{TidyCtx, TidyFlags};
 
 #[track_caller]
 fn test(lines: &str, name: &str, expected_msg: &str, expected_bad: bool) {
-    let diag_ctx = DiagCtx::new(Path::new("/"), false);
-    let mut check = diag_ctx.start_check("alphabetical-test");
+    let tidy_ctx = TidyCtx::new(Path::new("/"), false, TidyFlags::default());
+    let mut check = tidy_ctx.start_check("alphabetical-test");
     check_lines(&name, lines.lines().enumerate(), &mut check);
 
     assert_eq!(expected_bad, check.is_bad());

--- a/src/tools/tidy/src/bins.rs
+++ b/src/tools/tidy/src/bins.rs
@@ -12,13 +12,13 @@ pub use os_impl::*;
 mod os_impl {
     use std::path::Path;
 
-    use crate::diagnostics::DiagCtx;
+    use crate::diagnostics::TidyCtx;
 
     pub fn check_filesystem_support(_sources: &[&Path], _output: &Path) -> bool {
         return false;
     }
 
-    pub fn check(_path: &Path, _diag_ctx: DiagCtx) {}
+    pub fn check(_path: &Path, _tidy_ctx: TidyCtx) {}
 }
 
 #[cfg(unix)]
@@ -38,7 +38,7 @@ mod os_impl {
 
     use FilesystemSupport::*;
 
-    use crate::diagnostics::DiagCtx;
+    use crate::diagnostics::TidyCtx;
 
     fn is_executable(path: &Path) -> std::io::Result<bool> {
         Ok(path.metadata()?.mode() & 0o111 != 0)
@@ -110,8 +110,8 @@ mod os_impl {
     }
 
     #[cfg(unix)]
-    pub fn check(path: &Path, diag_ctx: DiagCtx) {
-        let mut check = diag_ctx.start_check("bins");
+    pub fn check(path: &Path, tidy_ctx: TidyCtx) {
+        let mut check = tidy_ctx.start_check("bins");
 
         use std::ffi::OsStr;
 

--- a/src/tools/tidy/src/debug_artifacts.rs
+++ b/src/tools/tidy/src/debug_artifacts.rs
@@ -2,13 +2,13 @@
 
 use std::path::Path;
 
-use crate::diagnostics::{CheckId, DiagCtx};
+use crate::diagnostics::{CheckId, TidyCtx};
 use crate::walk::{filter_dirs, filter_not_rust, walk};
 
 const GRAPHVIZ_POSTFLOW_MSG: &str = "`borrowck_graphviz_postflow` attribute in test";
 
-pub fn check(test_dir: &Path, diag_ctx: DiagCtx) {
-    let mut check = diag_ctx.start_check(CheckId::new("debug_artifacts").path(test_dir));
+pub fn check(test_dir: &Path, tidy_ctx: TidyCtx) {
+    let mut check = tidy_ctx.start_check(CheckId::new("debug_artifacts").path(test_dir));
 
     walk(
         test_dir,

--- a/src/tools/tidy/src/deps.rs
+++ b/src/tools/tidy/src/deps.rs
@@ -9,7 +9,7 @@ use build_helper::ci::CiEnv;
 use cargo_metadata::semver::Version;
 use cargo_metadata::{Metadata, Package, PackageId};
 
-use crate::diagnostics::{DiagCtx, RunningCheck};
+use crate::diagnostics::{RunningCheck, TidyCtx};
 
 #[path = "../../../bootstrap/src/utils/proc_macro_deps.rs"]
 mod proc_macro_deps;
@@ -615,8 +615,9 @@ const PERMITTED_CRANELIFT_DEPENDENCIES: &[&str] = &[
 ///
 /// `root` is path to the directory with the root `Cargo.toml` (for the workspace). `cargo` is path
 /// to the cargo executable.
-pub fn check(root: &Path, cargo: &Path, bless: bool, diag_ctx: DiagCtx) {
-    let mut check = diag_ctx.start_check("deps");
+pub fn check(root: &Path, cargo: &Path, tidy_ctx: TidyCtx) {
+    let mut check = tidy_ctx.start_check("deps");
+    let bless = tidy_ctx.is_bless_enabled();
 
     let mut checked_runtime_licenses = false;
 

--- a/src/tools/tidy/src/edition.rs
+++ b/src/tools/tidy/src/edition.rs
@@ -2,11 +2,11 @@
 
 use std::path::Path;
 
-use crate::diagnostics::{CheckId, DiagCtx};
+use crate::diagnostics::{CheckId, TidyCtx};
 use crate::walk::{filter_dirs, walk};
 
-pub fn check(path: &Path, diag_ctx: DiagCtx) {
-    let mut check = diag_ctx.start_check(CheckId::new("edition").path(path));
+pub fn check(path: &Path, tidy_ctx: TidyCtx) {
+    let mut check = tidy_ctx.start_check(CheckId::new("edition").path(path));
     walk(path, |path, _is_dir| filter_dirs(path), &mut |entry, contents| {
         let file = entry.path();
         let filename = file.file_name().unwrap();

--- a/src/tools/tidy/src/error_codes.rs
+++ b/src/tools/tidy/src/error_codes.rs
@@ -22,7 +22,7 @@ use std::path::Path;
 
 use regex::Regex;
 
-use crate::diagnostics::{DiagCtx, RunningCheck};
+use crate::diagnostics::{RunningCheck, TidyCtx};
 use crate::walk::{filter_dirs, walk, walk_many};
 
 const ERROR_CODES_PATH: &str = "compiler/rustc_error_codes/src/lib.rs";
@@ -36,8 +36,8 @@ const IGNORE_DOCTEST_CHECK: &[&str] = &["E0464", "E0570", "E0601", "E0602", "E07
 const IGNORE_UI_TEST_CHECK: &[&str] =
     &["E0461", "E0465", "E0514", "E0554", "E0640", "E0717", "E0729"];
 
-pub fn check(root_path: &Path, search_paths: &[&Path], ci_info: &crate::CiInfo, diag_ctx: DiagCtx) {
-    let mut check = diag_ctx.start_check("error_codes");
+pub fn check(root_path: &Path, search_paths: &[&Path], ci_info: &crate::CiInfo, tidy_ctx: TidyCtx) {
+    let mut check = tidy_ctx.start_check("error_codes");
 
     // Check that no error code explanation was removed.
     check_removed_error_code_explanation(ci_info, &mut check);

--- a/src/tools/tidy/src/extdeps.rs
+++ b/src/tools/tidy/src/extdeps.rs
@@ -4,7 +4,7 @@ use std::fs;
 use std::path::Path;
 
 use crate::deps::WorkspaceInfo;
-use crate::diagnostics::DiagCtx;
+use crate::diagnostics::TidyCtx;
 
 /// List of allowed sources for packages.
 const ALLOWED_SOURCES: &[&str] = &[
@@ -15,8 +15,8 @@ const ALLOWED_SOURCES: &[&str] = &[
 
 /// Checks for external package sources. `root` is the path to the directory that contains the
 /// workspace `Cargo.toml`.
-pub fn check(root: &Path, diag_ctx: DiagCtx) {
-    let mut check = diag_ctx.start_check("extdeps");
+pub fn check(root: &Path, tidy_ctx: TidyCtx) {
+    let mut check = tidy_ctx.start_check("extdeps");
 
     for &WorkspaceInfo { path, submodules, .. } in crate::deps::WORKSPACES {
         if crate::deps::has_missing_submodule(root, submodules) {

--- a/src/tools/tidy/src/extra_checks/mod.rs
+++ b/src/tools/tidy/src/extra_checks/mod.rs
@@ -24,7 +24,7 @@ use std::str::FromStr;
 use std::{fmt, fs, io};
 
 use crate::CiInfo;
-use crate::diagnostics::DiagCtx;
+use crate::diagnostics::TidyCtx;
 
 mod rustdoc_js;
 
@@ -52,12 +52,11 @@ pub fn check(
     tools_path: &Path,
     npm: &Path,
     cargo: &Path,
-    bless: bool,
     extra_checks: Option<&str>,
     pos_args: &[String],
-    diag_ctx: DiagCtx,
+    tidy_ctx: TidyCtx,
 ) {
-    let mut check = diag_ctx.start_check("extra_checks");
+    let mut check = tidy_ctx.start_check("extra_checks");
 
     if let Err(e) = check_impl(
         root_path,
@@ -67,9 +66,9 @@ pub fn check(
         tools_path,
         npm,
         cargo,
-        bless,
         extra_checks,
         pos_args,
+        &tidy_ctx,
     ) {
         check.error(e);
     }
@@ -83,12 +82,13 @@ fn check_impl(
     tools_path: &Path,
     npm: &Path,
     cargo: &Path,
-    bless: bool,
     extra_checks: Option<&str>,
     pos_args: &[String],
+    tidy_ctx: &TidyCtx,
 ) -> Result<(), Error> {
     let show_diff =
         std::env::var("TIDY_PRINT_DIFF").is_ok_and(|v| v.eq_ignore_ascii_case("true") || v == "1");
+    let bless = tidy_ctx.is_bless_enabled();
 
     // Split comma-separated args up
     let mut lint_args = match extra_checks {

--- a/src/tools/tidy/src/features.rs
+++ b/src/tools/tidy/src/features.rs
@@ -16,7 +16,7 @@ use std::num::NonZeroU32;
 use std::path::{Path, PathBuf};
 use std::{fmt, fs};
 
-use crate::diagnostics::{DiagCtx, RunningCheck};
+use crate::diagnostics::{RunningCheck, TidyCtx};
 use crate::walk::{filter_dirs, filter_not_rust, walk, walk_many};
 
 #[cfg(test)]
@@ -92,9 +92,9 @@ pub fn check(
     tests_path: &Path,
     compiler_path: &Path,
     lib_path: &Path,
-    diag_ctx: DiagCtx,
+    tidy_ctx: TidyCtx,
 ) -> CollectedFeatures {
-    let mut check = diag_ctx.start_check("features");
+    let mut check = tidy_ctx.start_check("features");
 
     let mut features = collect_lang_features(compiler_path, &mut check);
     assert!(!features.is_empty());

--- a/src/tools/tidy/src/filenames.rs
+++ b/src/tools/tidy/src/filenames.rs
@@ -10,10 +10,10 @@
 use std::path::Path;
 use std::process::Command;
 
-use crate::diagnostics::DiagCtx;
+use crate::diagnostics::TidyCtx;
 
-pub fn check(root_path: &Path, diag_ctx: DiagCtx) {
-    let mut check = diag_ctx.start_check("filenames");
+pub fn check(root_path: &Path, tidy_ctx: TidyCtx) {
+    let mut check = tidy_ctx.start_check("filenames");
     let stat_output = Command::new("git")
         .arg("-C")
         .arg(root_path)

--- a/src/tools/tidy/src/fluent_alphabetical.rs
+++ b/src/tools/tidy/src/fluent_alphabetical.rs
@@ -9,7 +9,7 @@ use fluent_syntax::ast::Entry;
 use fluent_syntax::parser;
 use regex::Regex;
 
-use crate::diagnostics::{CheckId, DiagCtx, RunningCheck};
+use crate::diagnostics::{CheckId, RunningCheck, TidyCtx};
 use crate::walk::{filter_dirs, walk};
 
 fn message() -> &'static Regex {
@@ -87,8 +87,9 @@ fn sort_messages(
     out
 }
 
-pub fn check(path: &Path, bless: bool, diag_ctx: DiagCtx) {
-    let mut check = diag_ctx.start_check(CheckId::new("fluent_alphabetical").path(path));
+pub fn check(path: &Path, tidy_ctx: TidyCtx) {
+    let mut check = tidy_ctx.start_check(CheckId::new("fluent_alphabetical").path(path));
+    let bless = tidy_ctx.is_bless_enabled();
 
     let mut all_defined_msgs = HashMap::new();
     walk(
@@ -120,5 +121,5 @@ pub fn check(path: &Path, bless: bool, diag_ctx: DiagCtx) {
 
     assert!(!all_defined_msgs.is_empty());
 
-    crate::fluent_used::check(path, all_defined_msgs, diag_ctx);
+    crate::fluent_used::check(path, all_defined_msgs, tidy_ctx);
 }

--- a/src/tools/tidy/src/fluent_lowercase.rs
+++ b/src/tools/tidy/src/fluent_lowercase.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 
 use fluent_syntax::ast::{Entry, Message, PatternElement};
 
-use crate::diagnostics::{CheckId, DiagCtx, RunningCheck};
+use crate::diagnostics::{CheckId, RunningCheck, TidyCtx};
 use crate::walk::{filter_dirs, walk};
 
 #[rustfmt::skip]
@@ -53,8 +53,8 @@ fn check_lowercase(filename: &str, contents: &str, check: &mut RunningCheck) {
     }
 }
 
-pub fn check(path: &Path, diag_ctx: DiagCtx) {
-    let mut check = diag_ctx.start_check(CheckId::new("fluent_lowercase").path(path));
+pub fn check(path: &Path, tidy_ctx: TidyCtx) {
+    let mut check = tidy_ctx.start_check(CheckId::new("fluent_lowercase").path(path));
     walk(
         path,
         |path, is_dir| filter_dirs(path) || (!is_dir && filter_fluent(path)),

--- a/src/tools/tidy/src/fluent_period.rs
+++ b/src/tools/tidy/src/fluent_period.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 
 use fluent_syntax::ast::{Entry, PatternElement};
 
-use crate::diagnostics::{CheckId, DiagCtx, RunningCheck};
+use crate::diagnostics::{CheckId, RunningCheck, TidyCtx};
 use crate::walk::{filter_dirs, walk};
 
 fn filter_fluent(path: &Path) -> bool {
@@ -75,8 +75,8 @@ fn find_line(haystack: &str, needle: &str) -> usize {
     1
 }
 
-pub fn check(path: &Path, diag_ctx: DiagCtx) {
-    let mut check = diag_ctx.start_check(CheckId::new("fluent_period").path(path));
+pub fn check(path: &Path, tidy_ctx: TidyCtx) {
+    let mut check = tidy_ctx.start_check(CheckId::new("fluent_period").path(path));
 
     walk(
         path,

--- a/src/tools/tidy/src/fluent_used.rs
+++ b/src/tools/tidy/src/fluent_used.rs
@@ -3,7 +3,7 @@
 use std::collections::HashMap;
 use std::path::Path;
 
-use crate::diagnostics::{CheckId, DiagCtx};
+use crate::diagnostics::{CheckId, TidyCtx};
 use crate::walk::{filter_dirs, walk};
 
 fn filter_used_messages(
@@ -28,8 +28,8 @@ fn filter_used_messages(
     }
 }
 
-pub fn check(path: &Path, mut all_defined_msgs: HashMap<String, String>, diag_ctx: DiagCtx) {
-    let mut check = diag_ctx.start_check(CheckId::new("fluent_used").path(path));
+pub fn check(path: &Path, mut all_defined_msgs: HashMap<String, String>, tidy_ctx: TidyCtx) {
+    let mut check = tidy_ctx.start_check(CheckId::new("fluent_used").path(path));
 
     let mut msgs_appear_only_once = HashMap::new();
     walk(path, |path, _| filter_dirs(path), &mut |_, contents| {

--- a/src/tools/tidy/src/gcc_submodule.rs
+++ b/src/tools/tidy/src/gcc_submodule.rs
@@ -4,10 +4,10 @@
 use std::path::Path;
 use std::process::Command;
 
-use crate::diagnostics::DiagCtx;
+use crate::diagnostics::TidyCtx;
 
-pub fn check(root_path: &Path, compiler_path: &Path, diag_ctx: DiagCtx) {
-    let mut check = diag_ctx.start_check("gcc_submodule");
+pub fn check(root_path: &Path, compiler_path: &Path, tidy_ctx: TidyCtx) {
+    let mut check = tidy_ctx.start_check("gcc_submodule");
 
     let cg_gcc_version_path = compiler_path.join("rustc_codegen_gcc/libgccjit.version");
     let cg_gcc_version = std::fs::read_to_string(&cg_gcc_version_path)

--- a/src/tools/tidy/src/known_bug.rs
+++ b/src/tools/tidy/src/known_bug.rs
@@ -2,11 +2,11 @@
 
 use std::path::Path;
 
-use crate::diagnostics::{CheckId, DiagCtx};
+use crate::diagnostics::{CheckId, TidyCtx};
 use crate::walk::*;
 
-pub fn check(filepath: &Path, diag_ctx: DiagCtx) {
-    let mut check = diag_ctx.start_check(CheckId::new("known_bug").path(filepath));
+pub fn check(filepath: &Path, tidy_ctx: TidyCtx) {
+    let mut check = tidy_ctx.start_check(CheckId::new("known_bug").path(filepath));
     walk(filepath, |path, _is_dir| filter_not_rust(path), &mut |entry, contents| {
         let file: &Path = entry.path();
 

--- a/src/tools/tidy/src/lib.rs
+++ b/src/tools/tidy/src/lib.rs
@@ -12,7 +12,7 @@ use build_helper::ci::CiEnv;
 use build_helper::git::{GitConfig, get_closest_upstream_commit};
 use build_helper::stage0_parser::{Stage0Config, parse_stage0_file};
 
-use crate::diagnostics::{DiagCtx, RunningCheck};
+use crate::diagnostics::{RunningCheck, TidyCtx};
 
 macro_rules! static_regex {
     ($re:literal) => {{
@@ -52,8 +52,8 @@ pub struct CiInfo {
 }
 
 impl CiInfo {
-    pub fn new(diag_ctx: DiagCtx) -> Self {
-        let mut check = diag_ctx.start_check("CI history");
+    pub fn new(tidy_ctx: TidyCtx) -> Self {
+        let mut check = tidy_ctx.start_check("CI history");
 
         let stage0 = parse_stage0_file();
         let Stage0Config { nightly_branch, git_merge_commit_email, .. } = stage0.config;

--- a/src/tools/tidy/src/mir_opt_tests.rs
+++ b/src/tools/tidy/src/mir_opt_tests.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 
 use miropt_test_tools::PanicStrategy;
 
-use crate::diagnostics::{CheckId, DiagCtx, RunningCheck};
+use crate::diagnostics::{CheckId, RunningCheck, TidyCtx};
 use crate::walk::walk_no_read;
 
 fn check_unused_files(path: &Path, bless: bool, check: &mut RunningCheck) {
@@ -74,8 +74,9 @@ fn check_dash_files(path: &Path, bless: bool, check: &mut RunningCheck) {
     }
 }
 
-pub fn check(path: &Path, bless: bool, diag_ctx: DiagCtx) {
-    let mut check = diag_ctx.start_check(CheckId::new("mir_opt_tests").path(path));
+pub fn check(path: &Path, tidy_ctx: TidyCtx) {
+    let mut check = tidy_ctx.start_check(CheckId::new("mir_opt_tests").path(path));
+    let bless = tidy_ctx.is_bless_enabled();
 
     check_unused_files(path, bless, &mut check);
     check_dash_files(path, bless, &mut check);

--- a/src/tools/tidy/src/pal.rs
+++ b/src/tools/tidy/src/pal.rs
@@ -32,7 +32,7 @@
 
 use std::path::Path;
 
-use crate::diagnostics::{CheckId, DiagCtx, RunningCheck};
+use crate::diagnostics::{CheckId, RunningCheck, TidyCtx};
 use crate::walk::{filter_dirs, walk};
 
 // Paths that may contain platform-specific code.
@@ -68,8 +68,8 @@ const EXCEPTION_PATHS: &[&str] = &[
     "library/std/src/io/error.rs", // Repr unpacked needed for UEFI
 ];
 
-pub fn check(path: &Path, diag_ctx: DiagCtx) {
-    let mut check = diag_ctx.start_check(CheckId::new("pal").path(path));
+pub fn check(path: &Path, tidy_ctx: TidyCtx) {
+    let mut check = tidy_ctx.start_check(CheckId::new("pal").path(path));
 
     // Sanity check that the complex parsing here works.
     let mut saw_target_arch = false;

--- a/src/tools/tidy/src/rustdoc_css_themes.rs
+++ b/src/tools/tidy/src/rustdoc_css_themes.rs
@@ -3,10 +3,10 @@
 
 use std::path::Path;
 
-use crate::diagnostics::{CheckId, DiagCtx, RunningCheck};
+use crate::diagnostics::{CheckId, RunningCheck, TidyCtx};
 
-pub fn check(librustdoc_path: &Path, diag_ctx: DiagCtx) {
-    let mut check = diag_ctx.start_check(CheckId::new("rustdoc_css_themes").path(librustdoc_path));
+pub fn check(librustdoc_path: &Path, tidy_ctx: TidyCtx) {
+    let mut check = tidy_ctx.start_check(CheckId::new("rustdoc_css_themes").path(librustdoc_path));
 
     let rustdoc_css = "html/static/css/rustdoc.css";
     let noscript_css = "html/static/css/noscript.css";

--- a/src/tools/tidy/src/rustdoc_gui_tests.rs
+++ b/src/tools/tidy/src/rustdoc_gui_tests.rs
@@ -2,10 +2,10 @@
 
 use std::path::Path;
 
-use crate::diagnostics::{CheckId, DiagCtx};
+use crate::diagnostics::{CheckId, TidyCtx};
 
-pub fn check(path: &Path, diag_ctx: DiagCtx) {
-    let mut check = diag_ctx.start_check(CheckId::new("rustdoc_gui_tests").path(path));
+pub fn check(path: &Path, tidy_ctx: TidyCtx) {
+    let mut check = tidy_ctx.start_check(CheckId::new("rustdoc_gui_tests").path(path));
 
     crate::walk::walk(
         &path.join("rustdoc-gui"),

--- a/src/tools/tidy/src/rustdoc_json.rs
+++ b/src/tools/tidy/src/rustdoc_json.rs
@@ -4,12 +4,12 @@
 use std::path::Path;
 use std::str::FromStr;
 
-use crate::diagnostics::{CheckId, DiagCtx};
+use crate::diagnostics::{CheckId, TidyCtx};
 
 const RUSTDOC_JSON_TYPES: &str = "src/rustdoc-json-types";
 
-pub fn check(src_path: &Path, ci_info: &crate::CiInfo, diag_ctx: DiagCtx) {
-    let mut check = diag_ctx.start_check(CheckId::new("rustdoc_json").path(src_path));
+pub fn check(src_path: &Path, ci_info: &crate::CiInfo, tidy_ctx: TidyCtx) {
+    let mut check = tidy_ctx.start_check(CheckId::new("rustdoc_json").path(src_path));
 
     let Some(base_commit) = &ci_info.base_commit else {
         check.verbose_msg("No base commit, skipping rustdoc_json check");

--- a/src/tools/tidy/src/rustdoc_templates.rs
+++ b/src/tools/tidy/src/rustdoc_templates.rs
@@ -6,14 +6,14 @@ use std::path::Path;
 
 use ignore::DirEntry;
 
-use crate::diagnostics::{CheckId, DiagCtx};
+use crate::diagnostics::{CheckId, TidyCtx};
 use crate::walk::walk;
 
 // Array containing `("beginning of tag", "end of tag")`.
 const TAGS: &[(&str, &str)] = &[("{#", "#}"), ("{%", "%}"), ("{{", "}}")];
 
-pub fn check(librustdoc_path: &Path, diag_ctx: DiagCtx) {
-    let mut check = diag_ctx.start_check(CheckId::new("rustdoc_templates").path(librustdoc_path));
+pub fn check(librustdoc_path: &Path, tidy_ctx: TidyCtx) {
+    let mut check = tidy_ctx.start_check(CheckId::new("rustdoc_templates").path(librustdoc_path));
 
     walk(
         &librustdoc_path.join("html/templates"),

--- a/src/tools/tidy/src/style.rs
+++ b/src/tools/tidy/src/style.rs
@@ -24,7 +24,7 @@ use std::sync::LazyLock;
 use regex::RegexSetBuilder;
 use rustc_hash::FxHashMap;
 
-use crate::diagnostics::{CheckId, DiagCtx};
+use crate::diagnostics::{CheckId, TidyCtx};
 use crate::walk::{filter_dirs, walk};
 
 #[cfg(test)]
@@ -339,8 +339,8 @@ fn is_unexplained_ignore(extension: &str, line: &str) -> bool {
     true
 }
 
-pub fn check(path: &Path, diag_ctx: DiagCtx) {
-    let mut check = diag_ctx.start_check(CheckId::new("style").path(path));
+pub fn check(path: &Path, tidy_ctx: TidyCtx) {
+    let mut check = tidy_ctx.start_check(CheckId::new("style").path(path));
 
     fn skip(path: &Path, is_dir: bool) -> bool {
         if path.file_name().is_some_and(|name| name.to_string_lossy().starts_with(".#")) {

--- a/src/tools/tidy/src/target_policy.rs
+++ b/src/tools/tidy/src/target_policy.rs
@@ -5,7 +5,7 @@
 use std::collections::HashSet;
 use std::path::Path;
 
-use crate::diagnostics::DiagCtx;
+use crate::diagnostics::TidyCtx;
 use crate::walk::{filter_not_rust, walk};
 
 const TARGET_DEFINITIONS_PATH: &str = "compiler/rustc_target/src/spec/targets/";
@@ -24,8 +24,8 @@ const EXCEPTIONS: &[&str] = &[
     "xtensa_esp32s3_espidf",
 ];
 
-pub fn check(root_path: &Path, diag_ctx: DiagCtx) {
-    let mut check = diag_ctx.start_check("target_policy");
+pub fn check(root_path: &Path, tidy_ctx: TidyCtx) {
+    let mut check = tidy_ctx.start_check("target_policy");
 
     let mut targets_to_find = HashSet::new();
 

--- a/src/tools/tidy/src/target_specific_tests.rs
+++ b/src/tools/tidy/src/target_specific_tests.rs
@@ -4,7 +4,7 @@
 use std::collections::BTreeMap;
 use std::path::Path;
 
-use crate::diagnostics::{CheckId, DiagCtx};
+use crate::diagnostics::{CheckId, TidyCtx};
 use crate::iter_header::{HeaderLine, iter_header};
 use crate::walk::filter_not_rust;
 
@@ -17,8 +17,8 @@ struct RevisionInfo<'a> {
     llvm_components: Option<Vec<&'a str>>,
 }
 
-pub fn check(tests_path: &Path, diag_ctx: DiagCtx) {
-    let mut check = diag_ctx.start_check(CheckId::new("target-specific-tests").path(tests_path));
+pub fn check(tests_path: &Path, tidy_ctx: TidyCtx) {
+    let mut check = tidy_ctx.start_check(CheckId::new("target-specific-tests").path(tests_path));
 
     crate::walk::walk(tests_path, |path, _is_dir| filter_not_rust(path), &mut |entry, content| {
         if content.contains("// ignore-tidy-target-specific-tests") {

--- a/src/tools/tidy/src/tests_placement.rs
+++ b/src/tools/tidy/src/tests_placement.rs
@@ -1,12 +1,12 @@
 use std::path::Path;
 
-use crate::diagnostics::DiagCtx;
+use crate::diagnostics::TidyCtx;
 
 const FORBIDDEN_PATH: &str = "src/test";
 const ALLOWED_PATH: &str = "tests";
 
-pub fn check(root_path: &Path, diag_ctx: DiagCtx) {
-    let mut check = diag_ctx.start_check("tests_placement");
+pub fn check(root_path: &Path, tidy_ctx: TidyCtx) {
+    let mut check = tidy_ctx.start_check("tests_placement");
 
     if root_path.join(FORBIDDEN_PATH).exists() {
         check.error(format!(

--- a/src/tools/tidy/src/tests_revision_unpaired_stdout_stderr.rs
+++ b/src/tools/tidy/src/tests_revision_unpaired_stdout_stderr.rs
@@ -4,7 +4,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::ffi::OsStr;
 use std::path::Path;
 
-use crate::diagnostics::{CheckId, DiagCtx};
+use crate::diagnostics::{CheckId, TidyCtx};
 use crate::iter_header::*;
 use crate::walk::*;
 
@@ -22,8 +22,8 @@ const IGNORES: &[&str] = &[
 const EXTENSIONS: &[&str] = &["stdout", "stderr"];
 const SPECIAL_TEST: &str = "tests/ui/command/need-crate-arg-ignore-tidy.x.rs";
 
-pub fn check(tests_path: &Path, diag_ctx: DiagCtx) {
-    let mut check = diag_ctx
+pub fn check(tests_path: &Path, tidy_ctx: TidyCtx) {
+    let mut check = tidy_ctx
         .start_check(CheckId::new("tests_revision_unpaired_stdout_stderr").path(tests_path));
 
     // Recurse over subdirectories under `tests/`

--- a/src/tools/tidy/src/triagebot.rs
+++ b/src/tools/tidy/src/triagebot.rs
@@ -4,10 +4,10 @@ use std::path::Path;
 
 use toml::Value;
 
-use crate::diagnostics::DiagCtx;
+use crate::diagnostics::TidyCtx;
 
-pub fn check(path: &Path, diag_ctx: DiagCtx) {
-    let mut check = diag_ctx.start_check("triagebot");
+pub fn check(path: &Path, tidy_ctx: TidyCtx) {
+    let mut check = tidy_ctx.start_check("triagebot");
     let triagebot_path = path.join("triagebot.toml");
 
     // This check is mostly to catch broken path filters *within* `triagebot.toml`, and not enforce

--- a/src/tools/tidy/src/ui_tests.rs
+++ b/src/tools/tidy/src/ui_tests.rs
@@ -7,16 +7,17 @@ use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
-use crate::diagnostics::{CheckId, DiagCtx, RunningCheck};
+use crate::diagnostics::{CheckId, RunningCheck, TidyCtx};
 
 const ISSUES_TXT_HEADER: &str = r#"============================================================
     ⚠️⚠️⚠️NOTHING SHOULD EVER BE ADDED TO THIS LIST⚠️⚠️⚠️
 ============================================================
 "#;
 
-pub fn check(root_path: &Path, bless: bool, diag_ctx: DiagCtx) {
+pub fn check(root_path: &Path, tidy_ctx: TidyCtx) {
     let path = &root_path.join("tests");
-    let mut check = diag_ctx.start_check(CheckId::new("ui_tests").path(path));
+    let mut check = tidy_ctx.start_check(CheckId::new("ui_tests").path(path));
+    let bless = tidy_ctx.is_bless_enabled();
 
     // the list of files in ui tests that are allowed to start with `issue-XXXX`
     // BTreeSet because we would like a stable ordering so --bless works

--- a/src/tools/tidy/src/unit_tests.rs
+++ b/src/tools/tidy/src/unit_tests.rs
@@ -11,11 +11,11 @@
 
 use std::path::Path;
 
-use crate::diagnostics::{CheckId, DiagCtx};
+use crate::diagnostics::{CheckId, TidyCtx};
 use crate::walk::{filter_dirs, walk};
 
-pub fn check(root_path: &Path, stdlib: bool, diag_ctx: DiagCtx) {
-    let mut check = diag_ctx.start_check(CheckId::new("unit_tests").path(root_path));
+pub fn check(root_path: &Path, stdlib: bool, tidy_ctx: TidyCtx) {
+    let mut check = tidy_ctx.start_check(CheckId::new("unit_tests").path(root_path));
 
     let skip = move |path: &Path, is_dir| {
         let file_name = path.file_name().unwrap_or_default();

--- a/src/tools/tidy/src/unknown_revision.rs
+++ b/src/tools/tidy/src/unknown_revision.rs
@@ -12,12 +12,12 @@ use std::sync::OnceLock;
 use ignore::DirEntry;
 use regex::Regex;
 
-use crate::diagnostics::{CheckId, DiagCtx, RunningCheck};
+use crate::diagnostics::{CheckId, RunningCheck, TidyCtx};
 use crate::iter_header::{HeaderLine, iter_header};
 use crate::walk::{filter_dirs, filter_not_rust, walk};
 
-pub fn check(tests_path: &Path, diag_ctx: DiagCtx) {
-    let mut check = diag_ctx.start_check(CheckId::new("unknown_revision").path(tests_path));
+pub fn check(tests_path: &Path, tidy_ctx: TidyCtx) {
+    let mut check = tidy_ctx.start_check(CheckId::new("unknown_revision").path(tests_path));
     walk(
         tests_path,
         |path, is_dir| {

--- a/src/tools/tidy/src/unstable_book.rs
+++ b/src/tools/tidy/src/unstable_book.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use crate::diagnostics::{DiagCtx, RunningCheck};
+use crate::diagnostics::{RunningCheck, TidyCtx};
 use crate::features::{CollectedFeatures, Features, Status};
 
 pub const PATH_STR: &str = "doc/unstable-book";
@@ -85,8 +85,8 @@ fn maybe_suggest_dashes(names: &BTreeSet<String>, feature_name: &str, check: &mu
     }
 }
 
-pub fn check(path: &Path, features: CollectedFeatures, diag_ctx: DiagCtx) {
-    let mut check = diag_ctx.start_check("unstable_book");
+pub fn check(path: &Path, features: CollectedFeatures, tidy_ctx: TidyCtx) {
+    let mut check = tidy_ctx.start_check("unstable_book");
 
     let lang_features = features.lang;
     let lib_features = features

--- a/src/tools/tidy/src/x_version.rs
+++ b/src/tools/tidy/src/x_version.rs
@@ -3,10 +3,10 @@ use std::process::{Command, Stdio};
 
 use semver::Version;
 
-use crate::diagnostics::{CheckId, DiagCtx};
+use crate::diagnostics::{CheckId, TidyCtx};
 
-pub fn check(root: &Path, cargo: &Path, diag_ctx: DiagCtx) {
-    let mut check = diag_ctx.start_check(CheckId::new("x_version").path(root));
+pub fn check(root: &Path, cargo: &Path, tidy_ctx: TidyCtx) {
+    let mut check = tidy_ctx.start_check(CheckId::new("x_version").path(root));
     let cargo_list = Command::new(cargo).args(["install", "--list"]).stdout(Stdio::piped()).spawn();
 
     let child = match cargo_list {


### PR DESCRIPTION
Adds a struct `TidyFlags` and merges it with `DiagCtx` into `TidyCtx`. Removes the need to pass `bless` into individual check functions in tidy.