### PR TITLE
[beta] fix panic when rustc tries to reduce intermediate filenames length

### DIFF
--- a/tests/run-make/lto-long-filenames/rmake.rs
+++ b/tests/run-make/lto-long-filenames/rmake.rs
@@ -9,8 +9,6 @@
 
 //@ ignore-cross-compile
 
-use std::fs;
-
 use run_make_support::{rfs, rustc};
 
 // This test make sure we don't get such following error:

--- a/tests/run-make/lto-long-filenames_cn/rmake.rs
+++ b/tests/run-make/lto-long-filenames_cn/rmake.rs
@@ -1,0 +1,19 @@
+//@ ignore-cross-compile
+
+use run_make_support::{rfs, rustc};
+
+// This test make sure we don't crash when lto creates output files with long names.
+// cn characters can be multi-byte and thus trigger the long filename reduction code more easily.
+// we need to make sure that the code is properly generating names at char boundaries.
+// as reported in issue #147975
+fn main() {
+    let lto_flags = ["-Clto", "-Clto=yes", "-Clto=off", "-Clto=thin", "-Clto=fat"];
+    for prefix_len in 0..4 {
+        let prefix: String = std::iter::repeat("_").take(prefix_len).collect();
+        let main_file = format!("{}28_找出字符串中第一个匹配项的下标.rs", prefix);
+        rfs::write(&main_file, "fn main() {}\n");
+        for flag in lto_flags {
+            rustc().input(&main_file).arg(flag).run();
+        }
+    }
+}


### PR DESCRIPTION
with multi byte chars

The issue cannot be reproduced with the former testcase of creating external crates because rust refuses to use "external crate 28_找出字符串中第一个匹配项的下标" because it is not a valid indentifier (starts with number, and contain non ascii chars)

But still using 28_找出字符串中第一个匹配项的下标.rs as a filename is accepted by previous rustc releases So we consider it valid, and add an integration test for it to catch any regression on other code related to non ascii filenames.

This is the beta backport for this bug

rust-lang/rust#147975

r? @jieyouxu

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
