### PR TITLE
Show backtrace on allocation failures when possible

### DIFF
--- a/library/std/src/panicking.rs
+++ b/library/std/src/panicking.rs
@@ -285,7 +285,6 @@ fn default_hook(info: &PanicHookInfo<'_>) {
         static FIRST_PANIC: Atomic<bool> = AtomicBool::new(true);
 
         match backtrace {
-            // SAFETY: we took out a lock just a second ago.
             Some(BacktraceStyle::Short) => {
                 drop(lock.print(err, crate::backtrace_rs::PrintFmt::Short))
             }

--- a/src/tools/miri/tests/fail/alloc/alloc_error_handler.stderr
+++ b/src/tools/miri/tests/fail/alloc/alloc_error_handler.stderr
@@ -1,11 +1,15 @@
 memory allocation of 4 bytes failed
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+note: in Miri, you may have to set `MIRIFLAGS=-Zmiri-env-forward=RUST_BACKTRACE` for the environment variable to have an effect
 error: abnormal termination: the program aborted execution
   --> RUSTLIB/std/src/alloc.rs:LL:CC
    |
-LL |     crate::process::abort()
-   |     ^^^^^^^^^^^^^^^^^^^^^^^ abnormal termination occurred here
+LL |         crate::process::abort()
+   |         ^^^^^^^^^^^^^^^^^^^^^^^ abnormal termination occurred here
    |
    = note: BACKTRACE:
+   = note: inside closure at RUSTLIB/std/src/alloc.rs:LL:CC
+   = note: inside `std::sys::backtrace::__rust_end_short_backtrace::<{closure@std::alloc::rust_oom::{closure#0}}, !>` at RUSTLIB/std/src/sys/backtrace.rs:LL:CC
    = note: inside `std::alloc::rust_oom` at RUSTLIB/std/src/alloc.rs:LL:CC
    = note: inside `std::alloc::_::__rust_alloc_error_handler` at RUSTLIB/std/src/alloc.rs:LL:CC
    = note: inside `std::alloc::handle_alloc_error::rt_error` at RUSTLIB/alloc/src/alloc.rs:LL:CC

--- a/tests/ui/alloc-error/alloc-error-backtrace.rs
+++ b/tests/ui/alloc-error/alloc-error-backtrace.rs
@@ -1,0 +1,49 @@
+//@ run-pass
+// We disable tail merging here because it can't preserve debuginfo and thus
+// potentially breaks the backtraces. Also, subtle changes can decide whether
+// tail merging succeeds, so the test might work today but fail tomorrow due to a
+// seemingly completely unrelated change.
+// Unfortunately, LLVM has no "disable" option for this, so we have to set
+// "enable" to 0 instead.
+
+//@ compile-flags:-g -Copt-level=0 -Cllvm-args=-enable-tail-merge=0
+//@ compile-flags:-Cforce-frame-pointers=yes
+//@ compile-flags:-Cstrip=none
+//@ ignore-android FIXME #17520
+//@ needs-subprocess
+//@ ignore-fuchsia Backtrace not symbolized, trace different line alignment
+//@ ignore-ios needs the `.dSYM` files to be moved to the device
+//@ ignore-tvos needs the `.dSYM` files to be moved to the device
+//@ ignore-watchos needs the `.dSYM` files to be moved to the device
+//@ ignore-visionos needs the `.dSYM` files to be moved to the device
+
+// FIXME(#117097): backtrace (possibly unwinding mechanism) seems to be different on at least
+// `i686-mingw` (32-bit windows-gnu)? cc #128911.
+//@ ignore-windows-gnu
+//@ ignore-backends: gcc
+//@ ignore-msvc see #62897 and `backtrace-debuginfo.rs` test
+
+use std::alloc::{Layout, handle_alloc_error};
+use std::process::Command;
+use std::{env, str};
+
+fn main() {
+    if env::args().len() > 1 {
+        handle_alloc_error(Layout::new::<[u8; 42]>())
+    }
+
+    let me = env::current_exe().unwrap();
+    let output = Command::new(&me).env("RUST_BACKTRACE", "1").arg("next").output().unwrap();
+    assert!(!output.status.success(), "{:?} is a success", output.status);
+
+    let mut stderr = str::from_utf8(&output.stderr).unwrap();
+
+    // When running inside QEMU user-mode emulation, there will be an extra message printed by QEMU
+    // in the stderr whenever a core dump happens. Remove it before the check.
+    stderr = stderr
+        .strip_suffix("qemu: uncaught target signal 6 (Aborted) - core dumped\n")
+        .unwrap_or(stderr);
+
+    assert!(stderr.contains("memory allocation of 42 bytes failed"), "{}", stderr);
+    assert!(stderr.contains("alloc_error_backtrace::main"), "{}", stderr);
+}

--- a/tests/ui/alloc-error/default-alloc-error-hook.rs
+++ b/tests/ui/alloc-error/default-alloc-error-hook.rs
@@ -2,9 +2,8 @@
 //@ needs-subprocess
 
 use std::alloc::{Layout, handle_alloc_error};
-use std::env;
 use std::process::Command;
-use std::str;
+use std::{env, str};
 
 fn main() {
     if env::args().len() > 1 {
@@ -12,7 +11,7 @@ fn main() {
     }
 
     let me = env::current_exe().unwrap();
-    let output = Command::new(&me).arg("next").output().unwrap();
+    let output = Command::new(&me).env("RUST_BACKTRACE", "0").arg("next").output().unwrap();
     assert!(!output.status.success(), "{:?} is a success", output.status);
 
     let mut stderr = str::from_utf8(&output.stderr).unwrap();
@@ -23,5 +22,9 @@ fn main() {
         .strip_suffix("qemu: uncaught target signal 6 (Aborted) - core dumped\n")
         .unwrap_or(stderr);
 
-    assert_eq!(stderr, "memory allocation of 42 bytes failed\n");
+    assert_eq!(
+        stderr,
+        "memory allocation of 42 bytes failed\n\
+        note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace\n"
+    );
 }

--- a/tests/ui/backtrace/line-tables-only.rs
+++ b/tests/ui/backtrace/line-tables-only.rs
@@ -50,5 +50,5 @@ fn main() {
         assert_contains(&backtrace, "foo", "line-tables-only-helper.rs", 5);
     }
     assert_contains(&backtrace, "bar", "line-tables-only-helper.rs", 10);
-    assert_contains(&backtrace, "baz", "line-tables-only-helper.rs", 15);
+    assert_contains(&backtrace, "baz", "line-tables-only-helper.rs", 5);
 }


### PR DESCRIPTION
And if an allocation while printing the backtrace fails, don't try to print another backtrace as that will never succeed.

Split out of https://github.com/rust-lang/rust/pull/147725 to allow landing this independently of a decision whether or not to remove `-Zoom=panic`.
