### PR TITLE
experimental shipping of more CMake files for Enzyme

### DIFF
--- a/src/bootstrap/download-ci-llvm-stamp
+++ b/src/bootstrap/download-ci-llvm-stamp
@@ -1,4 +1,4 @@
 Change this file to make users of the `download-ci-llvm` configuration download
 a new version of LLVM from CI, even if the LLVM submodule hasn’t changed.
 
-Last change is for: https://github.com/rust-lang/rust/pull/139931
+Last change is for: https://github.com/rust-lang/rust/pull/148027

--- a/src/bootstrap/src/core/build_steps/dist.rs
+++ b/src/bootstrap/src/core/build_steps/dist.rs
@@ -2582,6 +2582,14 @@ impl Step for RustDev {
                 }
             }
         }
+        // The Enzyme(autodiff) cmake requires the LLVMConfig.cmake file to find tablegen
+        // and other utilities. We therefore also add all cmake files
+        // so that you can use the downloadable LLVM as if you’ve just run a full source build.
+        let cmake_dir = PathBuf::new().join("lib").join("cmake").join("llvm");
+        let cmake_src_dir = builder.llvm_out(target).join(&cmake_dir);
+        if cmake_src_dir.exists() {
+            tarball.add_dir(cmake_src_dir, cmake_dir);
+        }
 
         if builder.config.lld_enabled {
             // We want to package `lld` to use it with `download-ci-llvm`.


### PR DESCRIPTION
For testing I just added the whole cmake folder for now, we might want to reduce it just to the LLVMconfig.cmake file later.
Based on some local comparisons between a `x.py dist rust-dev` folder structure and the ci-llvm folder structure (and where enzyme is looking) I think this should end up at the right location.

What would be the best way without merging to test that locally or in CI to verify that Enzyme now works? Or shall we just give it a try? Maybe

1. Do a local x.py dist rust-dev build
2. Build rust+enzyme with download-ci-llvm, wait till it fails.
3. Delete the ci-llvm folder and replace it with the component from 1., which now includes the cmake files?

r? @Kobzol 

try-job: dist-x86_64-linux