### PR TITLE
tests/ui/sanitizer/hwaddress.rs: Run on aarch64 and remove cgu hack

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -24,8 +24,8 @@
 	shallow = true
 [submodule "src/llvm-project"]
 	path = src/llvm-project
-	url = https://github.com/rust-lang/llvm-project.git
-	branch = rustc/21.1-2025-08-01
+	url = https://github.com/Enselic/llvm-project.git
+	branch = rustc/21.1-2025-08-01_plus-hwasan-link-fix
 	shallow = true
 [submodule "src/doc/embedded-book"]
 	path = src/doc/embedded-book

--- a/tests/ui/sanitizer/hwaddress.rs
+++ b/tests/ui/sanitizer/hwaddress.rs
@@ -1,11 +1,7 @@
 //@ needs-sanitizer-support
 //@ needs-sanitizer-hwaddress
 //
-// FIXME(#83706): this test triggers errors on aarch64-gnu
-//@ ignore-aarch64-unknown-linux-gnu
-//
-// FIXME(#83989): codegen-units=1 triggers linker errors on aarch64-gnu
-//@ compile-flags: -Z sanitizer=hwaddress -O -g -C codegen-units=16 -C unsafe-allow-abi-mismatch=sanitizer
+//@ compile-flags: -Z sanitizer=hwaddress -O -g -C unsafe-allow-abi-mismatch=sanitizer
 //
 //@ run-fail
 //@ error-pattern: HWAddressSanitizer: tag-mismatch


### PR DESCRIPTION
Trying if https://github.com/Enselic/llvm-project/commit/7953fa5be5d6d33b0a7c648d32095f3000b714c9 helps.

If this works and the LLVM patch gets accepted upstream this will eventually:
Close https://github.com/rust-lang/rust/issues/83989

try-job: aarch64-gnu
