### PR TITLE
Remove the `sym::Deref` diagnostic item

### DIFF
--- a/compiler/rustc_lint/src/noop_method_call.rs
+++ b/compiler/rustc_lint/src/noop_method_call.rs
@@ -1,5 +1,5 @@
 use rustc_hir::def::DefKind;
-use rustc_hir::{Expr, ExprKind};
+use rustc_hir::{Expr, ExprKind, LangItem};
 use rustc_middle::ty;
 use rustc_middle::ty::adjustment::Adjust;
 use rustc_session::{declare_lint, declare_lint_pass};
@@ -86,10 +86,10 @@ impl<'tcx> LateLintPass<'tcx> for NoopMethodCall {
 
         let Some(trait_id) = cx.tcx.trait_of_assoc(did) else { return };
 
-        let Some(trait_) = cx.tcx.get_diagnostic_name(trait_id) else { return };
-
-        if !matches!(trait_, sym::Borrow | sym::Clone | sym::Deref) {
-            return;
+        let trait_ = match cx.tcx.get_diagnostic_name(trait_id) {
+            Some(trait_ @ (sym::Borrow | sym::Clone)) => trait_,
+            None if cx.tcx.is_lang_item(trait_id, LangItem::Deref) => sym::Deref,
+            _ => return,
         };
 
         let args = cx

--- a/library/core/src/ops/deref.rs
+++ b/library/core/src/ops/deref.rs
@@ -134,7 +134,6 @@ use crate::marker::PointeeSized;
 #[doc(alias = "*")]
 #[doc(alias = "&*")]
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_diagnostic_item = "Deref"]
 #[rustc_const_unstable(feature = "const_convert", issue = "143773")]
 pub const trait Deref: PointeeSized {
     /// The resulting type after dereferencing.

--- a/src/tools/clippy/clippy_lints/src/len_zero.rs
+++ b/src/tools/clippy/clippy_lints/src/len_zero.rs
@@ -634,7 +634,7 @@ fn has_is_empty(cx: &LateContext<'_>, expr: &Expr<'_>) -> bool {
             ty::Adt(id, _) => {
                 has_is_empty_impl(cx, id.did())
                     || (cx.tcx.recursion_limit().value_within_limit(depth)
-                        && cx.tcx.get_diagnostic_item(sym::Deref).is_some_and(|deref_id| {
+                        && cx.tcx.lang_items().deref_trait().is_some_and(|deref_id| {
                             implements_trait(cx, ty, deref_id, &[])
                                 && cx
                                     .get_associated_type(ty, deref_id, sym::Target)

--- a/src/tools/clippy/clippy_lints/src/methods/unnecessary_to_owned.rs
+++ b/src/tools/clippy/clippy_lints/src/methods/unnecessary_to_owned.rs
@@ -149,7 +149,7 @@ fn check_addr_of_expr(
             );
             return true;
         }
-        if let Some(deref_trait_id) = cx.tcx.get_diagnostic_item(sym::Deref)
+        if let Some(deref_trait_id) = cx.tcx.lang_items().deref_trait()
             && implements_trait(cx, receiver_ty, deref_trait_id, &[])
             && cx.get_associated_type(receiver_ty, deref_trait_id, sym::Target) == Some(target_ty)
             // Make sure that it's actually calling the right `.to_string()`, (#10033)
@@ -318,7 +318,7 @@ fn check_split_call_arg(cx: &LateContext<'_>, expr: &Expr<'_>, method_name: Symb
         // implements `AsRef<str>` but does not implement `Deref<Target = str>`. In this case, we have to
         // add `.as_ref()` to the suggestion.
         let as_ref = if cx.typeck_results().expr_ty(expr).is_lang_item(cx, LangItem::String)
-            && let Some(deref_trait_id) = cx.tcx.get_diagnostic_item(sym::Deref)
+            && let Some(deref_trait_id) = cx.tcx.lang_items().deref_trait()
             && cx.get_associated_type(cx.typeck_results().expr_ty(receiver), deref_trait_id, sym::Target)
                 != Some(cx.tcx.types.str_)
         {
@@ -392,7 +392,7 @@ fn check_other_call_arg<'tcx>(
             .filter(|trait_predicate| trait_predicate.def_id() != sized_def_id)
             .filter(|trait_predicate| trait_predicate.def_id() != meta_sized_def_id)
             .collect::<Vec<_>>()[..]
-        && let Some(deref_trait_id) = cx.tcx.get_diagnostic_item(sym::Deref)
+        && let Some(deref_trait_id) = cx.tcx.lang_items().deref_trait()
         && let Some(as_ref_trait_id) = cx.tcx.get_diagnostic_item(sym::AsRef)
         && (trait_predicate.def_id() == deref_trait_id || trait_predicate.def_id() == as_ref_trait_id)
         && let receiver_ty = cx.typeck_results().expr_ty(receiver)
@@ -649,7 +649,7 @@ fn is_to_string_on_string_like<'a>(
     if let Some(args) = cx.typeck_results().node_args_opt(call_expr.hir_id)
         && let [generic_arg] = args.as_slice()
         && let GenericArgKind::Type(ty) = generic_arg.kind()
-        && let Some(deref_trait_id) = cx.tcx.get_diagnostic_item(sym::Deref)
+        && let Some(deref_trait_id) = cx.tcx.lang_items().deref_trait()
         && let Some(as_ref_trait_id) = cx.tcx.get_diagnostic_item(sym::AsRef)
         && (cx.get_associated_type(ty, deref_trait_id, sym::Target) == Some(cx.tcx.types.str_)
             || implements_trait(cx, ty, as_ref_trait_id, &[cx.tcx.types.str_.into()]))


### PR DESCRIPTION
The `Deref` trait is already as lang item, there is no need for it to be a diagnostic item as well.

r? lcnr