### PR TITLE
fix: std::sys::fs use_with_native_path for read_dir for windows

### DIFF
--- a/library/std/src/sys/fs/mod.rs
+++ b/library/std/src/sys/fs/mod.rs
@@ -67,7 +67,7 @@ pub use imp::{
 
 pub fn read_dir(path: &Path) -> io::Result<ReadDir> {
     #[cfg(not(windows))]
-    return imp::remove_dir_all(path);
+    return imp::readdir(path);
     #[cfg(windows)]
     with_native_path(path, &imp::readdir)
 }

--- a/library/std/src/sys/fs/mod.rs
+++ b/library/std/src/sys/fs/mod.rs
@@ -66,6 +66,9 @@ pub use imp::{
 };
 
 pub fn read_dir(path: &Path) -> io::Result<ReadDir> {
+    #[cfg(not(windows))]
+    return imp::remove_dir_all(path);
+    #[cfg(windows)]
     with_native_path(path, &imp::readdir)
 }
 

--- a/library/std/src/sys/fs/mod.rs
+++ b/library/std/src/sys/fs/mod.rs
@@ -66,8 +66,7 @@ pub use imp::{
 };
 
 pub fn read_dir(path: &Path) -> io::Result<ReadDir> {
-    // FIXME: use with_native_path on all platforms
-    imp::readdir(path)
+    with_native_path(path, &imp::readdir)
 }
 
 pub fn remove_file(path: &Path) -> io::Result<()> {

--- a/library/std/src/sys/path/windows.rs
+++ b/library/std/src/sys/path/windows.rs
@@ -1,3 +1,4 @@
+use crate::alloc_crate::slice;
 use crate::ffi::{OsStr, OsString};
 use crate::path::{Path, PathBuf};
 use crate::sys::api::utf16;
@@ -27,6 +28,10 @@ impl WCStr {
     /// The slice must end in a null.
     pub unsafe fn from_wchars_with_null_unchecked(s: &[u16]) -> &Self {
         unsafe { &*(s as *const [u16] as *const Self) }
+    }
+
+    pub unsafe fn to_wchars_with_null_unchecked(&self) -> &[u16] {
+        unsafe { slice::from_raw_parts(self.as_ptr(), self.0.len()) }
     }
 
     pub fn as_ptr(&self) -> *const u16 {


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Fix the read_dir function in windows for using with native_path