### PR TITLE
std: move check for destroyed TLS variable

### DIFF
--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -327,6 +327,7 @@
 #![feature(cfg_select)]
 #![feature(char_internals)]
 #![feature(clone_to_uninit)]
+#![feature(cold_path)]
 #![feature(const_convert)]
 #![feature(const_mul_add)]
 #![feature(core_intrinsics)]

--- a/library/std/src/sys/thread_local/native/eager.rs
+++ b/library/std/src/sys/thread_local/native/eager.rs
@@ -1,4 +1,5 @@
 use crate::cell::{Cell, UnsafeCell};
+use crate::hint;
 use crate::ptr::{self, drop_in_place};
 use crate::sys::thread_local::{abort_on_dtor_unwind, destructors};
 
@@ -34,7 +35,10 @@ impl<T> Storage<T> {
     pub unsafe fn get(&self) -> *const T {
         match self.state.get() {
             State::Alive => self.val.get(),
-            State::Destroyed => ptr::null(),
+            State::Destroyed => {
+                hint::cold_path();
+                ptr::null()
+            }
             State::Initial => unsafe { self.initialize() },
         }
     }


### PR DESCRIPTION
When accessing a TLS variable, the comparison that checks whether the variable is initialised can be inlined to the call site. The comparison that checks whether the variable has been destroyed is however performed in the `#[cold]` accessor function. Since all call-sites need to check whether the returned pointer is null, this split prevents these two checks from being merged into one. Thus moving the liveliness check into the inlineable accessor may yield more optimal codegen. This is especially true in the case where the variable does not need destruction and thus no null pointer will ever be returned, as the null-pointer check can now be optimised out.