### PR TITLE
test(frontmatter): Cover spaces between infostring parts

### DIFF
--- a/tests/ui/frontmatter/space-in-infostring.rs
+++ b/tests/ui/frontmatter/space-in-infostring.rs
@@ -1,0 +1,9 @@
+--- cargo clippy
+//~^ ERROR: invalid infostring for frontmatter
+---
+
+// infostrings cannot have spaces
+
+#![feature(frontmatter)]
+
+fn main() {}

--- a/tests/ui/frontmatter/space-in-infostring.stderr
+++ b/tests/ui/frontmatter/space-in-infostring.stderr
@@ -1,0 +1,10 @@
+error: invalid infostring for frontmatter
+  --> $DIR/space-in-infostring.rs:1:4
+   |
+LL | --- cargo clippy
+   |    ^^^^^^^^^^^^^
+   |
+   = note: frontmatter infostrings must be a single identifier immediately following the opening
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
As these characters are specifically called out in the RFC, I felt it would be important to have a test to cover them.

Tracking issue: rust-lang/rust#136889