### PR TITLE
compiletest: show output in debug logging

### DIFF
--- a/src/tools/compiletest/src/runtest/ui.rs
+++ b/src/tools/compiletest/src/runtest/ui.rs
@@ -207,8 +207,12 @@ impl TestCx<'_> {
 
         debug!(
             "run_ui_test: explicit={:?} config.compare_mode={:?} \
-               proc_res.status={:?} props.error_patterns={:?}",
-            explicit, self.config.compare_mode, proc_res.status, self.props.error_patterns
+               proc_res.status={:?} props.error_patterns={:?} output_to_check={:?}",
+            explicit,
+            self.config.compare_mode,
+            proc_res.status,
+            self.props.error_patterns,
+            output_to_check,
         );
 
         // Compiler diagnostics (expected errors) are always tied to the compile-time ProcRes.


### PR DESCRIPTION
I had a test I was confused by; the root issue is that `error-pattern` runs before normalization, even though `//~ ERROR` runs after normalization. This logging caught the issue immediately.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
