### PR TITLE
fix: std::sys::fs use_with_native_path for read_dir for windows

### DIFF
--- a/library/std/src/sys/fs/mod.rs
+++ b/library/std/src/sys/fs/mod.rs
@@ -67,7 +67,7 @@ pub use imp::{
 
 pub fn read_dir(path: &Path) -> io::Result<ReadDir> {
     #[cfg(not(windows))]
-    return imp::remove_dir_all(path);
+    return imp::readdir(path);
     #[cfg(windows)]
     with_native_path(path, &imp::readdir)
 }

--- a/library/std/src/sys/fs/mod.rs
+++ b/library/std/src/sys/fs/mod.rs
@@ -66,6 +66,7 @@ pub use imp::{
 };
 
 pub fn read_dir(path: &Path) -> io::Result<ReadDir> {
+    // FIXME: use with_native_path on all platforms
     #[cfg(not(windows))]
     return imp::readdir(path);
     #[cfg(windows)]

--- a/library/std/src/sys/fs/mod.rs
+++ b/library/std/src/sys/fs/mod.rs
@@ -66,6 +66,9 @@ pub use imp::{
 };
 
 pub fn read_dir(path: &Path) -> io::Result<ReadDir> {
+    #[cfg(not(windows))]
+    return imp::remove_dir_all(path);
+    #[cfg(windows)]
     with_native_path(path, &imp::readdir)
 }
 

--- a/library/std/src/sys/fs/mod.rs
+++ b/library/std/src/sys/fs/mod.rs
@@ -66,8 +66,7 @@ pub use imp::{
 };
 
 pub fn read_dir(path: &Path) -> io::Result<ReadDir> {
-    // FIXME: use with_native_path on all platforms
-    imp::readdir(path)
+    with_native_path(path, &imp::readdir)
 }
 
 pub fn remove_file(path: &Path) -> io::Result<()> {

--- a/library/std/src/sys/fs/windows.rs
+++ b/library/std/src/sys/fs/windows.rs
@@ -6,6 +6,7 @@ use crate::ffi::{OsStr, OsString, c_void};
 use crate::fs::TryLockError;
 use crate::io::{self, BorrowedCursor, Error, IoSlice, IoSliceMut, SeekFrom};
 use crate::mem::{self, MaybeUninit, offset_of};
+use crate::os::windows::ffi::OsStringExt;
 use crate::os::windows::io::{AsHandle, BorrowedHandle};
 use crate::os::windows::prelude::*;
 use crate::path::{Path, PathBuf};
@@ -18,7 +19,6 @@ use crate::sys::time::SystemTime;
 use crate::sys::{Align8, c, cvt};
 use crate::sys_common::{AsInner, FromInner, IntoInner};
 use crate::{fmt, ptr, slice};
-use crate::os::windows::ffi::OsStringExt;
 
 mod remove_dir_all;
 use remove_dir_all::remove_dir_all_iterative;

--- a/library/std/src/sys/fs/windows.rs
+++ b/library/std/src/sys/fs/windows.rs
@@ -1183,16 +1183,12 @@ impl DirBuilder {
 }
 
 pub fn readdir(p: &WCStr) -> io::Result<ReadDir> {
-    let mut p = p.to_wchars_with_null_unchecked().to_vec();
+    let p = p.to_wchars_with_null_unchecked().to_vec();
 
     // `p` already contains NUL, because before reading directory function,
     // it already passes `maybe_verbatim` that appending zero at the end, it
     // should be refactored.
-    if let Some(pos) = p.iter().position(|x| *x == 0) {
-        p.remove(pos);
-    }
-
-    let p_os_string = OsString::from_wide(&p);
+    let p_os_string = OsString::from_wide(&p[..p.len() - 1]);
     let p = Path::new(&p_os_string);
 
     // We push a `*` to the end of the path which cause the empty path to be

--- a/library/std/src/sys/fs/windows.rs
+++ b/library/std/src/sys/fs/windows.rs
@@ -1183,7 +1183,7 @@ impl DirBuilder {
 }
 
 pub fn readdir(p: &WCStr) -> io::Result<ReadDir> {
-    let mut p = unsafe { p.to_wchars_with_null_unchecked() }.to_vec();
+    let mut p = p.to_wchars_with_null_unchecked().to_vec();
 
     // `p` already contains NUL, because before reading directory function,
     // it already passes `maybe_verbatim` that appending zero at the end, it

--- a/library/std/src/sys/path/windows.rs
+++ b/library/std/src/sys/path/windows.rs
@@ -31,7 +31,7 @@ impl WCStr {
     }
 
     pub unsafe fn to_wchars_with_null_unchecked(&self) -> &[u16] {
-        unsafe { slice::from_raw_parts(self.as_ptr(), self.0.len()) }
+        unsafe { slice::from_raw_parts(self.0.as_ptr(), self.0.len()) }
     }
 
     pub fn as_ptr(&self) -> *const u16 {

--- a/library/std/src/sys/path/windows.rs
+++ b/library/std/src/sys/path/windows.rs
@@ -1,3 +1,4 @@
+use crate::alloc_crate::slice;
 use crate::ffi::{OsStr, OsString};
 use crate::path::{Path, PathBuf};
 use crate::sys::api::utf16;
@@ -27,6 +28,10 @@ impl WCStr {
     /// The slice must end in a null.
     pub unsafe fn from_wchars_with_null_unchecked(s: &[u16]) -> &Self {
         unsafe { &*(s as *const [u16] as *const Self) }
+    }
+
+    pub unsafe fn to_wchars_with_null_unchecked(&self) -> &[u16] {
+        unsafe { slice::from_raw_parts(self.as_ptr(), self.0.len()) }
     }
 
     pub fn as_ptr(&self) -> *const u16 {

--- a/library/std/src/sys/path/windows.rs
+++ b/library/std/src/sys/path/windows.rs
@@ -1,4 +1,3 @@
-use crate::alloc_crate::slice;
 use crate::ffi::{OsStr, OsString};
 use crate::path::{Path, PathBuf};
 use crate::sys::api::utf16;
@@ -30,8 +29,8 @@ impl WCStr {
         unsafe { &*(s as *const [u16] as *const Self) }
     }
 
-    pub unsafe fn to_wchars_with_null_unchecked(&self) -> &[u16] {
-        unsafe { slice::from_raw_parts(self.0.as_ptr(), self.0.len()) }
+    pub const fn to_wchars_with_null_unchecked(&self) -> &[u16] {
+        &self.0
     }
 
     pub fn as_ptr(&self) -> *const u16 {


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
Fix the read_dir function in windows for using with native_path

r? @ChrisDenton 