### PR TITLE
Stabilize `const_mul_add`

### DIFF
--- a/library/core/src/intrinsics/mod.rs
+++ b/library/core/src/intrinsics/mod.rs
@@ -1310,6 +1310,7 @@ pub fn log2f128(x: f128) -> f128;
 ///
 /// The stabilized version of this intrinsic is
 /// [`f16::mul_add`](../../std/primitive.f16.html#method.mul_add)
+#[rustc_intrinsic_const_stable_indirect]
 #[rustc_intrinsic]
 #[rustc_nounwind]
 pub const fn fmaf16(a: f16, b: f16, c: f16) -> f16;
@@ -1317,6 +1318,7 @@ pub const fn fmaf16(a: f16, b: f16, c: f16) -> f16;
 ///
 /// The stabilized version of this intrinsic is
 /// [`f32::mul_add`](../../std/primitive.f32.html#method.mul_add)
+#[rustc_intrinsic_const_stable_indirect]
 #[rustc_intrinsic]
 #[rustc_nounwind]
 pub const fn fmaf32(a: f32, b: f32, c: f32) -> f32;
@@ -1324,6 +1326,7 @@ pub const fn fmaf32(a: f32, b: f32, c: f32) -> f32;
 ///
 /// The stabilized version of this intrinsic is
 /// [`f64::mul_add`](../../std/primitive.f64.html#method.mul_add)
+#[rustc_intrinsic_const_stable_indirect]
 #[rustc_intrinsic]
 #[rustc_nounwind]
 pub const fn fmaf64(a: f64, b: f64, c: f64) -> f64;
@@ -1331,6 +1334,7 @@ pub const fn fmaf64(a: f64, b: f64, c: f64) -> f64;
 ///
 /// The stabilized version of this intrinsic is
 /// [`f128::mul_add`](../../std/primitive.f128.html#method.mul_add)
+#[rustc_intrinsic_const_stable_indirect]
 #[rustc_intrinsic]
 #[rustc_nounwind]
 pub const fn fmaf128(a: f128, b: f128, c: f128) -> f128;

--- a/library/core/src/num/f128.rs
+++ b/library/core/src/num/f128.rs
@@ -1660,7 +1660,6 @@ impl f128 {
     #[doc(alias = "fmaf128", alias = "fusedMultiplyAdd")]
     #[unstable(feature = "f128", issue = "116909")]
     #[must_use = "method returns a new number and does not mutate the original value"]
-    #[rustc_const_unstable(feature = "const_mul_add", issue = "146724")]
     pub const fn mul_add(self, a: f128, b: f128) -> f128 {
         intrinsics::fmaf128(self, a, b)
     }

--- a/library/core/src/num/f16.rs
+++ b/library/core/src/num/f16.rs
@@ -1635,7 +1635,6 @@ impl f16 {
     #[unstable(feature = "f16", issue = "116909")]
     #[doc(alias = "fmaf16", alias = "fusedMultiplyAdd")]
     #[must_use = "method returns a new number and does not mutate the original value"]
-    #[rustc_const_unstable(feature = "const_mul_add", issue = "146724")]
     pub const fn mul_add(self, a: f16, b: f16) -> f16 {
         intrinsics::fmaf16(self, a, b)
     }

--- a/library/core/src/num/f32.rs
+++ b/library/core/src/num/f32.rs
@@ -1799,7 +1799,6 @@ pub mod math {
     #[doc(alias = "fmaf", alias = "fusedMultiplyAdd")]
     #[must_use = "method returns a new number and does not mutate the original value"]
     #[unstable(feature = "core_float_math", issue = "137578")]
-    #[rustc_const_unstable(feature = "const_mul_add", issue = "146724")]
     pub const fn mul_add(x: f32, y: f32, z: f32) -> f32 {
         intrinsics::fmaf32(x, y, z)
     }

--- a/library/core/src/num/f64.rs
+++ b/library/core/src/num/f64.rs
@@ -1797,7 +1797,6 @@ pub mod math {
     #[doc(alias = "fma", alias = "fusedMultiplyAdd")]
     #[unstable(feature = "core_float_math", issue = "137578")]
     #[must_use = "method returns a new number and does not mutate the original value"]
-    #[rustc_const_unstable(feature = "const_mul_add", issue = "146724")]
     pub const fn mul_add(x: f64, a: f64, b: f64) -> f64 {
         intrinsics::fmaf64(x, a, b)
     }

--- a/library/coretests/tests/lib.rs
+++ b/library/coretests/tests/lib.rs
@@ -22,7 +22,6 @@
 #![feature(const_destruct)]
 #![feature(const_drop_in_place)]
 #![feature(const_eval_select)]
-#![feature(const_mul_add)]
 #![feature(const_ops)]
 #![feature(const_option_ops)]
 #![feature(const_ref_cell)]

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -328,7 +328,6 @@
 #![feature(char_internals)]
 #![feature(clone_to_uninit)]
 #![feature(const_convert)]
-#![feature(const_mul_add)]
 #![feature(core_intrinsics)]
 #![feature(core_io_borrowed_buf)]
 #![feature(drop_guard)]

--- a/library/std/src/num/f32.rs
+++ b/library/std/src/num/f32.rs
@@ -217,7 +217,7 @@ impl f32 {
     #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
-    #[rustc_const_unstable(feature = "const_mul_add", issue = "146724")]
+    #[rustc_const_stable(feature = "const_mul_add", since = "CURRENT_RUSTC_VERSION")]
     pub const fn mul_add(self, a: f32, b: f32) -> f32 {
         core::f32::math::mul_add(self, a, b)
     }

--- a/library/std/src/num/f64.rs
+++ b/library/std/src/num/f64.rs
@@ -217,7 +217,7 @@ impl f64 {
     #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
-    #[rustc_const_unstable(feature = "const_mul_add", issue = "146724")]
+    #[rustc_const_stable(feature = "const_mul_add", since = "CURRENT_RUSTC_VERSION")]
     pub const fn mul_add(self, a: f64, b: f64) -> f64 {
         core::f64::math::mul_add(self, a, b)
     }


### PR DESCRIPTION
Newly stable API:

```rust
impl {f32, f64} {
    pub const fn mul_add(self, a: Self, b: Self) -> Self;
}
```

This includes making the intrinsics `fmaf{16,32,64,128}` const stable for indirect use, matching similar intrinsics.

Closes: https://github.com/rust-lang/rust/issues/146724