### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/library/alloc/src/borrow.rs
+++ b/library/alloc/src/borrow.rs
@@ -16,12 +16,13 @@ use crate::fmt;
 #[cfg(not(no_global_oom_handling))]
 use crate::string::String;
 
+// FIXME(inference): const bounds removed due to inference regressions found by crater;
+//   see https://github.com/rust-lang/rust/issues/147964
+// #[rustc_const_unstable(feature = "const_convert", issue = "143773")]
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_const_unstable(feature = "const_convert", issue = "143773")]
-impl<'a, B: ?Sized> const Borrow<B> for Cow<'a, B>
-where
-    B: ToOwned,
-    B::Owned: [const] Borrow<B>,
+impl<'a, B: ?Sized + ToOwned> Borrow<B> for Cow<'a, B>
+// where
+//     B::Owned: [const] Borrow<B>,
 {
     fn borrow(&self) -> &B {
         &**self
@@ -327,11 +328,13 @@ impl<B: ?Sized + ToOwned> Cow<'_, B> {
     }
 }
 
+// FIXME(inference): const bounds removed due to inference regressions found by crater;
+//   see https://github.com/rust-lang/rust/issues/147964
+// #[rustc_const_unstable(feature = "const_convert", issue = "143773")]
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_const_unstable(feature = "const_convert", issue = "143773")]
-impl<B: ?Sized + ToOwned> const Deref for Cow<'_, B>
-where
-    B::Owned: [const] Borrow<B>,
+impl<B: ?Sized + ToOwned> Deref for Cow<'_, B>
+// where
+//     B::Owned: [const] Borrow<B>,
 {
     type Target = B;
 

--- a/tests/ui/frontmatter/space-in-infostring.rs
+++ b/tests/ui/frontmatter/space-in-infostring.rs
@@ -1,0 +1,9 @@
+--- cargo clippy
+//~^ ERROR: invalid infostring for frontmatter
+---
+
+// infostrings cannot have spaces
+
+#![feature(frontmatter)]
+
+fn main() {}

--- a/tests/ui/frontmatter/space-in-infostring.stderr
+++ b/tests/ui/frontmatter/space-in-infostring.stderr
@@ -1,0 +1,10 @@
+error: invalid infostring for frontmatter
+  --> $DIR/space-in-infostring.rs:1:4
+   |
+LL | --- cargo clippy
+   |    ^^^^^^^^^^^^^
+   |
+   = note: frontmatter infostrings must be a single identifier immediately following the opening
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/traits/generic-cow-inference-regression.rs
+++ b/tests/ui/traits/generic-cow-inference-regression.rs
@@ -1,0 +1,20 @@
+//@ run-pass
+
+// regression test for #147964:
+//   constification of these traits resulted in inference errors due to additional where clauses
+
+use std::borrow::{Cow, Borrow};
+
+pub fn generic_deref<'a, T: ToOwned<Owned = U>, U>(cow: Cow<'a, T>) {
+    let _: &T = &cow;
+}
+
+pub fn generic_borrow<'a, T: ToOwned<Owned = U>, U>(cow: Cow<'a, T>) {
+    let _: &T = cow.borrow();
+}
+
+pub fn generic_as_ref<'a, T: ToOwned<Owned = U>, U>(cow: Cow<'a, T>) {
+    let _: &T = cow.as_ref();
+}
+
+fn main() {}

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1370,6 +1370,7 @@ compiler = [
     "@jackh726",
     "@jieyouxu",
     "@jdonszelmann",
+    "@JonathanBrouwer",
     "@lcnr",
     "@madsmtm",
     "@Nadrieril",


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#148016 (Revert constification of `Borrow` and `Deref for Cow` due to inference failure)
 - rust-lang/rust#148039 (Add myself to the review rotation)
 - rust-lang/rust#148042 (test(frontmatter): Cover spaces between infostring parts)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=148016,148039,148042)
<!-- homu-ignore:end -->