### PR TITLE
tests/ui/sanitizer/hwaddress.rs: Run on aarch64 and remove cgu hack

### DIFF
--- a/tests/ui/sanitizer/hwaddress.rs
+++ b/tests/ui/sanitizer/hwaddress.rs
@@ -1,11 +1,7 @@
 //@ needs-sanitizer-support
 //@ needs-sanitizer-hwaddress
 //
-// FIXME(#83706): this test triggers errors on aarch64-gnu
-//@ ignore-aarch64-unknown-linux-gnu
-//
-// FIXME(#83989): codegen-units=1 triggers linker errors on aarch64-gnu
-//@ compile-flags: -Z sanitizer=hwaddress -O -g -C codegen-units=16 -C unsafe-allow-abi-mismatch=sanitizer
+//@ compile-flags: -Z sanitizer=hwaddress -O -g -C target-feature=+tagged-globals -C unsafe-allow-abi-mismatch=sanitizer
 //
 //@ run-fail
 //@ error-pattern: HWAddressSanitizer: tag-mismatch
@@ -19,3 +15,5 @@ fn main() {
     let code = unsafe { *xs.offset(4) };
     std::process::exit(code);
 }
+
+//~? WARN unknown and unstable feature specified for `-Ctarget-feature`: `tagged-globals`

--- a/tests/ui/sanitizer/hwaddress.stderr
+++ b/tests/ui/sanitizer/hwaddress.stderr
@@ -1,0 +1,7 @@
+warning: unknown and unstable feature specified for `-Ctarget-feature`: `tagged-globals`
+   |
+   = note: it is still passed through to the codegen backend, but use of this feature might be unsound and the behavior of this feature can change in the future
+   = help: consider filing a feature request
+
+warning: 1 warning emitted
+


### PR DESCRIPTION
To avoid linker errors like

    relocation truncated to fit: R_AARCH64_ADR_PREL_PG_HI21 against `.data.rel.ro..L.hwasan'

we need to have `-C target-feature=+tagged-globals`, which is documented [here](https://doc.rust-lang.org/beta/unstable-book/compiler-flags/sanitizer.html#hwaddresssanitizer).  I learned that [here](https://github.com/llvm/llvm-project/pull/164876#issuecomment-3439034858).

Closes rust-lang/rust#83989

try-job: aarch64-gnu