### PR TITLE
rustc_codegen_llvm: Add debug locations to `write_operand_repeatedly()`

### DIFF
--- a/compiler/rustc_codegen_llvm/src/builder.rs
+++ b/compiler/rustc_codegen_llvm/src/builder.rs
@@ -770,6 +770,8 @@ impl<'a, 'll, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
         let zero = self.const_usize(0);
         let count = self.const_usize(count);
 
+        // Sibling blocks have the same debug location as the original block.
+        let dbg_loc = self.get_dbg_loc();
         let header_bb = self.append_sibling_block("repeat_loop_header");
         let body_bb = self.append_sibling_block("repeat_loop_body");
         let next_bb = self.append_sibling_block("repeat_loop_next");
@@ -777,12 +779,18 @@ impl<'a, 'll, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
         self.br(header_bb);
 
         let mut header_bx = Self::build(self.cx, header_bb);
+        if let Some(dbg_loc) = dbg_loc {
+            header_bx.set_dbg_loc(dbg_loc);
+        }
         let i = header_bx.phi(self.val_ty(zero), &[zero], &[self.llbb()]);
 
         let keep_going = header_bx.icmp(IntPredicate::IntULT, i, count);
         header_bx.cond_br(keep_going, body_bb, next_bb);
 
         let mut body_bx = Self::build(self.cx, body_bb);
+        if let Some(dbg_loc) = dbg_loc {
+            body_bx.set_dbg_loc(dbg_loc);
+        }
         let dest_elem = dest.project_index(&mut body_bx, i);
         cg_elem.val.store(&mut body_bx, dest_elem);
 
@@ -791,6 +799,9 @@ impl<'a, 'll, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
         header_bx.add_incoming_to_phi(i, next, body_bb);
 
         *self = Self::build(self.cx, next_bb);
+        if let Some(dbg_loc) = dbg_loc {
+            self.set_dbg_loc(dbg_loc);
+        }
     }
 
     fn range_metadata(&mut self, load: &'ll Value, range: WrappingRange) {
@@ -1825,6 +1836,7 @@ impl<'a, 'll, 'tcx> Builder<'a, 'll, 'tcx> {
                 cfi::typeid_for_fnabi(self.tcx, fn_abi, options)
             };
             let typeid_metadata = self.cx.create_metadata(typeid.as_bytes());
+            // Sibling blocks have the same debug location as the original block.
             let dbg_loc = self.get_dbg_loc();
 
             // Test whether the function pointer is associated with the type identifier using the

--- a/tests/debuginfo/basic-stepping.rs
+++ b/tests/debuginfo/basic-stepping.rs
@@ -20,8 +20,25 @@
 // FIXME(#33013): gdb-command: next
 // FIXME(#33013): gdb-check:   let g = b'9';
 // FIXME(#33013): gdb-command: next
-// FIXME(#33013): gdb-check:   let h = ["whatever"; 8];
-// FIXME(#33013): gdb-command: next
+// FIXME(#33013): Don't step 8 times. Tricky, because all emitted LLVM instructions are looped over.
+// gdb-check:   let h = ["whatever"; 8];
+// gdb-command: next
+// gdb-check:   let h = ["whatever"; 8];
+// gdb-command: next
+// gdb-check:   let h = ["whatever"; 8];
+// gdb-command: next
+// gdb-check:   let h = ["whatever"; 8];
+// gdb-command: next
+// gdb-check:   let h = ["whatever"; 8];
+// gdb-command: next
+// gdb-check:   let h = ["whatever"; 8];
+// gdb-command: next
+// gdb-check:   let h = ["whatever"; 8];
+// gdb-command: next
+// gdb-check:   let h = ["whatever"; 8];
+// gdb-command: next
+// gdb-check:   let h = ["whatever"; 8];
+// gdb-command: next
 // gdb-check:   let i = [1,2,3,4];
 // gdb-command: next
 // gdb-check:   let j = (23, "hi");


### PR DESCRIPTION
So that stepping with a debugger over lines such as:

    let h = ["whatever"; 8];

works.

Use the same technique as we already do in `cfi_type_test()`.

Since all emitted LLVM instructions are looped over, a debugger will unfortunately step as many times as we repeat. Not sure how to solve that. It can become quite annoying if you have say `1024` repetitions.

This is an alternative to https://github.com/rust-lang/rust/pull/147462.
