### PR TITLE
Update substring match for substitutions

### DIFF
--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -318,7 +318,7 @@ fn as_substr<'a>(original: &'a str, suggestion: &'a str) -> Option<(usize, &'a s
     {
         return Some((0, prefix, original.len()));
     }
-    
+
     let common_prefix = original
         .chars()
         .zip(suggestion.chars())

--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -312,13 +312,13 @@ fn as_substr<'a>(original: &'a str, suggestion: &'a str) -> Option<(usize, &'a s
     if suggestion.contains("::")
         && suggestion.ends_with(original)
         && suggestion.len() > original.len()
+        && let prefix = &suggestion[..suggestion.len() - original.len()]
+        && prefix.ends_with("::")
+        && suggestion.chars().next() == original.chars().next()
     {
-        let prefix = &suggestion[..suggestion.len() - original.len()];
-        if prefix.ends_with("::") && suggestion.chars().next() == original.chars().next() {
-            return Some((0, prefix, original.len()));
-        }
+        return Some((0, prefix, original.len()));
     }
-
+    
     let common_prefix = original
         .chars()
         .zip(suggestion.chars())

--- a/tests/ui/imports/same-prefix-unresolved-import-148070.rs
+++ b/tests/ui/imports/same-prefix-unresolved-import-148070.rs
@@ -1,0 +1,5 @@
+// https://github.com/rust-lang/rust/issues/148070
+#![no_main]
+use stat; //~ ERROR unresolved import `stat`
+use str; //~ ERROR unresolved import `str`
+use sync; //~ ERROR unresolved import `sync`

--- a/tests/ui/imports/same-prefix-unresolved-import-148070.stderr
+++ b/tests/ui/imports/same-prefix-unresolved-import-148070.stderr
@@ -1,0 +1,43 @@
+error[E0432]: unresolved import `stat`
+  --> $DIR/same-prefix-unresolved-import-148070.rs:3:5
+   |
+LL | use stat;
+   |     ^^^^ no `stat` in the root
+   |
+help: consider importing this struct instead
+   |
+LL | use std::os::linux::raw::stat;
+   |     +++++++++++++++++++++
+
+error[E0432]: unresolved import `str`
+  --> $DIR/same-prefix-unresolved-import-148070.rs:4:5
+   |
+LL | use str;
+   |     ^^^ no `str` in the root
+   |
+help: a similar name exists in the module
+   |
+LL - use str;
+LL + use std;
+   |
+help: consider importing one of these items instead
+   |
+LL | use std::primitive::str;
+   |     ++++++++++++++++
+LL | use std::str;
+   |     +++++
+
+error[E0432]: unresolved import `sync`
+  --> $DIR/same-prefix-unresolved-import-148070.rs:5:5
+   |
+LL | use sync;
+   |     ^^^^ no `sync` in the root
+   |
+help: consider importing this module instead
+   |
+LL | use std::sync;
+   |     +++++
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0432`.

--- a/tests/ui/test-attrs/inaccessible-test-modules.stderr
+++ b/tests/ui/test-attrs/inaccessible-test-modules.stderr
@@ -13,7 +13,7 @@ LL | use test as y;
 help: consider importing this module instead
    |
 LL | use test::test as y;
-   |         ++++++
+   |     ++++++
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/148061)*
<!-- homu-ignore:end -->

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Fixed `as_substr` function to check for matching prefixes too. This fixes this issue where `td::s` is matched instead of `std::`. This same behaviour can be seen with `time` and `tokio::time` and similar cases where the error import starts with the same prefix as the suggestion.

```rust
use sync;
fn main() {}
```


```
error[E0432]: unresolved import `sync`
 --> /tmp/test_import.rs:1:5
  |
1 | use sync;
  |     ^^^^ no `sync` in the root
  |
help: consider importing this module instead
  |
1 | use std::sync;
  |      +++++
```

After the changes:

```
error[E0432]: unresolved import `sync`
 --> /tmp/test_import.rs:1:5
  |
1 | use sync;
  |     ^^^^ no `sync` in the root
  |
help: consider importing this module instead
  |
1 | use std::sync;
  |     +++++
```



