### PR TITLE
Fix tests to use static linking

### DIFF
--- a/tests/ui/cross-crate/auxiliary/pub_static_array.rs
+++ b/tests/ui/cross-crate/auxiliary/pub_static_array.rs
@@ -1,1 +1,5 @@
+//@ no-prefer-dynamic
+
+#![crate_type = "lib"]
+
 pub static ARRAY: [u8; 1] = [1];

--- a/tests/ui/cross-crate/static-array-across-crate.rs
+++ b/tests/ui/cross-crate/static-array-across-crate.rs
@@ -10,4 +10,8 @@ static X: &'static u8 = &ARRAY[0];
 static Y: &'static u8 = &(&ARRAY)[0];
 static Z: u8 = (&ARRAY)[0];
 
-pub fn main() {}
+pub fn main() {
+    // Make sure to actually reference the statics.
+    assert_eq!(&X, &Y);
+    assert_eq!(&X, &&Z);
+}

--- a/tests/ui/statics/auxiliary/check_static_recursion_foreign_helper.rs
+++ b/tests/ui/statics/auxiliary/check_static_recursion_foreign_helper.rs
@@ -1,3 +1,5 @@
+//@ no-prefer-dynamic
+
 // Helper definition for test/run-pass/check-static-recursion-foreign.rs.
 
 #![feature(rustc_private)]

--- a/tests/ui/statics/check-recursion-foreign.rs
+++ b/tests/ui/statics/check-recursion-foreign.rs
@@ -15,4 +15,7 @@ extern "C" {
 
 pub static B: &'static c_int = unsafe { &test_static };
 
-pub fn main() {}
+pub fn main() {
+    // Make sure to actually reference the static.
+    unsafe { assert_eq!(test_static, 0); }
+}


### PR DESCRIPTION
Per discussion in rust-lang/rust#142742, this PR makes a couple of tests link in their helper crates statically. The `compiletest`'s default is to prefer dynamic linking, which in these cases would exercise a problematic (unsupported?) scenario.

r? @bjorn3
