### PR TITLE
rustdoc: Use configured target modifiers when collecting doctests

### DIFF
--- a/src/librustdoc/doctest.rs
+++ b/src/librustdoc/doctest.rs
@@ -166,6 +166,7 @@ pub(crate) fn run(dcx: DiagCtxtHandle<'_>, input: Input, options: RustdocOptions
         remap_path_prefix: options.remap_path_prefix.clone(),
         unstable_opts: options.unstable_opts.clone(),
         error_format: options.error_format.clone(),
+        target_modifiers: options.target_modifiers.clone(),
         ..config::Options::default()
     };
 

--- a/tests/run-make/rustdoc-target-modifiers/rmake.rs
+++ b/tests/run-make/rustdoc-target-modifiers/rmake.rs
@@ -25,4 +25,43 @@ fn main() {
         .target("aarch64-unknown-none-softfloat")
         .arg("-Zfixed-x18")
         .run();
+
+    rustdoc()
+        .input("c.rs")
+        .crate_type("rlib")
+        .extern_("d", "libd.rmeta")
+        .target("aarch64-unknown-none-softfloat")
+        .arg("-Zfixed-x18")
+        .arg("--test")
+        .run();
+
+    rustdoc()
+        .input("c.rs")
+        .edition("2024")
+        .crate_type("rlib")
+        .extern_("d", "libd.rmeta")
+        .target("aarch64-unknown-none-softfloat")
+        .arg("-Zfixed-x18")
+        .arg("--test")
+        .run();
+
+    // rustdoc --test detects ABI mismatch
+    rustdoc()
+        .input("c.rs")
+        .crate_type("rlib")
+        .extern_("d", "libd.rmeta")
+        .target("aarch64-unknown-none-softfloat")
+        .arg("--test")
+        .run_fail()
+        .assert_stderr_contains("mixing `-Zfixed-x18` will cause an ABI mismatch");
+
+    // rustdoc --test -Cunsafe-allow-abi-mismatch=... ignores the mismatch
+    rustdoc()
+        .input("c.rs")
+        .crate_type("rlib")
+        .extern_("d", "libd.rmeta")
+        .target("aarch64-unknown-none-softfloat")
+        .arg("--test")
+        .arg("-Cunsafe-allow-abi-mismatch=fixed-x18")
+        .run();
 }


### PR DESCRIPTION
To support loading dependencies with target modifiers and avoid ABI mismatch errors.

Fixes rust-lang/rust#146465.