### PR TITLE
[rustdoc] Fix invalid jump to def macro link generation

### DIFF
--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -227,6 +227,10 @@ pub(crate) fn item_relative_path(tcx: TyCtxt<'_>, def_id: DefId) -> Vec<Symbol> 
     tcx.def_path(def_id).data.into_iter().filter_map(|elem| elem.data.get_opt_name()).collect()
 }
 
+/// Get the path to an item in a URL sense: we use it to generate the URL to the actual item.
+///
+/// In particular: we handle macro differently: if it's not a macro 2.0 oe a built-in macro, then
+/// it is generated at the top-level of the crate and its path will be `[crate_name, macro_name]`.
 pub(crate) fn get_item_path(tcx: TyCtxt<'_>, def_id: DefId, kind: ItemType) -> Vec<Symbol> {
     let crate_name = tcx.crate_name(def_id.krate);
     let relative = item_relative_path(tcx, def_id);

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -227,7 +227,7 @@ pub(crate) fn item_relative_path(tcx: TyCtxt<'_>, def_id: DefId) -> Vec<Symbol> 
     tcx.def_path(def_id).data.into_iter().filter_map(|elem| elem.data.get_opt_name()).collect()
 }
 
-/// Get the path to an item in a URL sense: we use it to generate the URL to the actual item.
+/// Get the public Rust path to an item. This is used to generate the URL to the item's page.
 ///
 /// In particular: we handle macro differently: if it's not a macro 2.0 oe a built-in macro, then
 /// it is generated at the top-level of the crate and its path will be `[crate_name, macro_name]`.

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -40,6 +40,7 @@ use crate::clean::utils::{is_literal_expr, print_evaluated_const};
 use crate::core::DocContext;
 use crate::formats::cache::Cache;
 use crate::formats::item_type::ItemType;
+use crate::html::format::HrefInfo;
 use crate::html::render::Context;
 use crate::passes::collect_intra_doc_links::UrlFragment;
 
@@ -519,16 +520,16 @@ impl Item {
             .iter()
             .filter_map(|ItemLink { link: s, link_text, page_id: id, fragment }| {
                 debug!(?id);
-                if let Ok((mut href, ..)) = href(*id, cx) {
-                    debug!(?href);
+                if let Ok(HrefInfo { mut url, .. }) = href(*id, cx) {
+                    debug!(?url);
                     if let Some(ref fragment) = *fragment {
-                        fragment.render(&mut href, cx.tcx())
+                        fragment.render(&mut url, cx.tcx())
                     }
                     Some(RenderedLink {
                         original_text: s.clone(),
                         new_text: link_text.clone(),
                         tooltip: link_tooltip(*id, fragment, cx).to_string(),
-                        href,
+                        href: url,
                     })
                 } else {
                     None

--- a/src/librustdoc/display.rs
+++ b/src/librustdoc/display.rs
@@ -10,19 +10,18 @@ pub(crate) trait Joined: IntoIterator {
     ///
     /// The performance of `joined` is slightly better than `format`, since it doesn't need to use a `Cell` to keep track of whether [`fmt`](Display::fmt)
     /// was already called (`joined`'s API doesn't allow it be called more than once).
-    fn joined(self, sep: impl Display, f: &mut Formatter<'_>) -> fmt::Result;
+    fn joined(&mut self, sep: impl Display, f: &mut Formatter<'_>) -> fmt::Result;
 }
 
 impl<I, T> Joined for I
 where
-    I: IntoIterator<Item = T>,
+    I: Iterator<Item = T>,
     T: Display,
 {
-    fn joined(self, sep: impl Display, f: &mut Formatter<'_>) -> fmt::Result {
-        let mut iter = self.into_iter();
-        let Some(first) = iter.next() else { return Ok(()) };
+    fn joined(&mut self, sep: impl Display, f: &mut Formatter<'_>) -> fmt::Result {
+        let Some(first) = self.next() else { return Ok(()) };
         first.fmt(f)?;
-        for item in iter {
+        for item in self {
             sep.fmt(f)?;
             item.fmt(f)?;
         }

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -410,6 +410,8 @@ fn generate_macro_def_id_path(
     Ok((url, item_type, fqp))
 }
 
+/// If the function succeeded, it will return the full URL to the item, its type and a `Vec`
+/// representing its `use` path.
 fn generate_item_def_id_path(
     mut def_id: DefId,
     original_def_id: DefId,

--- a/src/librustdoc/html/highlight.rs
+++ b/src/librustdoc/html/highlight.rs
@@ -21,6 +21,7 @@ use super::format;
 use crate::clean::PrimitiveType;
 use crate::display::Joined as _;
 use crate::html::escape::EscapeBodyText;
+use crate::html::format::HrefInfo;
 use crate::html::macro_expansion::ExpandedCode;
 use crate::html::render::span_map::{DUMMY_SP, Span};
 use crate::html::render::{Context, LinkFromSrc};
@@ -1357,7 +1358,7 @@ fn generate_link_to_def(
                     LinkFromSrc::External(def_id) => {
                         format::href_with_root_path(*def_id, context, Some(href_context.root_path))
                             .ok()
-                            .map(|(url, _, _)| url)
+                            .map(|HrefInfo { url, .. }| url)
                     }
                     LinkFromSrc::Primitive(prim) => format::href_with_root_path(
                         PrimitiveType::primitive_locations(context.tcx())[prim],
@@ -1365,11 +1366,11 @@ fn generate_link_to_def(
                         Some(href_context.root_path),
                     )
                     .ok()
-                    .map(|(url, _, _)| url),
+                    .map(|HrefInfo { url, .. }| url),
                     LinkFromSrc::Doc(def_id) => {
                         format::href_with_root_path(*def_id, context, Some(href_context.root_path))
                             .ok()
-                            .map(|(doc_link, _, _)| doc_link)
+                            .map(|HrefInfo { url, .. }| url)
                     }
                 }
             })

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -74,7 +74,7 @@ use crate::formats::cache::Cache;
 use crate::formats::item_type::ItemType;
 use crate::html::escape::Escape;
 use crate::html::format::{
-    Ending, HrefError, PrintWithSpace, full_print_fn_decl, href, print_abi_with_space,
+    Ending, HrefError, HrefInfo, PrintWithSpace, full_print_fn_decl, href, print_abi_with_space,
     print_constness_with_space, print_default_space, print_generic_bounds, print_generics,
     print_impl, print_path, print_type, print_where_clause, visibility_print_with_space,
 };
@@ -982,7 +982,7 @@ fn assoc_href_attr(
             };
 
             match href(did.expect_def_id(), cx) {
-                Ok((url, ..)) => Href::Url(url, item_type),
+                Ok(HrefInfo { url, .. }) => Href::Url(url, item_type),
                 // The link is broken since it points to an external crate that wasn't documented.
                 // Do not create any link in such case. This is better than falling back to a
                 // dummy anchor like `#{item_type}.{name}` representing the `id` of *this* impl item

--- a/tests/rustdoc/jump-to-def/assoc-items.rs
+++ b/tests/rustdoc/jump-to-def/assoc-items.rs
@@ -26,8 +26,9 @@ impl C {
     pub fn wat() {}
 }
 
-//@ has - '//a[@href="{{channel}}/core/fmt/macros/macro.Debug.html"]' 'Debug'
-//@ has - '//a[@href="{{channel}}/core/cmp/macro.PartialEq.html"]' 'PartialEq'
+// These two links must not change and in particular must contain `/derive.`!
+//@ has - '//a[@href="{{channel}}/core/fmt/macros/derive.Debug.html"]' 'Debug'
+//@ has - '//a[@href="{{channel}}/core/cmp/derive.PartialEq.html"]' 'PartialEq'
 #[derive(Debug, PartialEq)]
 pub struct Bar;
 impl Trait for Bar {

--- a/tests/rustdoc/jump-to-def/derive-macro.rs
+++ b/tests/rustdoc/jump-to-def/derive-macro.rs
@@ -1,0 +1,24 @@
+// This test ensures that the same link is generated in both intra-doc links
+// and in jump to def links.
+
+//@ compile-flags: -Zunstable-options --generate-link-to-definition
+
+#![crate_name = "foo"]
+
+// First we check intra-doc links.
+//@ has 'foo/struct.Bar.html'
+//@ has - '//a[@href="{{channel}}/core/fmt/macros/derive.Debug.html"]' 'Debug'
+//@ has - '//a[@href="{{channel}}/core/cmp/derive.PartialEq.html"]' 'PartialEq'
+
+// We also check the "title" attributes.
+//@ has - '//a[@href="{{channel}}/core/fmt/macros/derive.Debug.html"]/@title' 'derive core::fmt::macros::Debug'
+//@ has - '//a[@href="{{channel}}/core/cmp/derive.PartialEq.html"]/@title' 'derive core::cmp::PartialEq'
+
+// Then we check that they are the same in jump to def.
+
+/// [Debug][derive@Debug] and [PartialEq][derive@PartialEq]
+//@ has 'src/foo/derive-macro.rs.html'
+//@ has - '//a[@href="{{channel}}/core/fmt/macros/derive.Debug.html"]' 'Debug'
+//@ has - '//a[@href="{{channel}}/core/cmp/derive.PartialEq.html"]' 'PartialEq'
+#[derive(Debug, PartialEq)]
+pub struct Bar;


### PR DESCRIPTION
Follow-up of https://github.com/rust-lang/rust/issues/147820.

I realized that when there was no intra-doc link linking to the same item, then the generated link for macros in jump to def would be invalid.

To make the code less redundant, I merged the "registering" of items and the href generation use the same code for macros.

r? @notriddle 