### PR TITLE
perf: removed unnecessary let for return only in layout.rs

### DIFF
--- a/library/core/src/alloc/layout.rs
+++ b/library/core/src/alloc/layout.rs
@@ -316,8 +316,7 @@ impl Layout {
         // Size 1 Align MAX or Size isize::MAX Align 2 round up to `isize::MAX + 1`.)
         unsafe {
             let align_m1 = unchecked_sub(align.as_usize(), 1);
-            let size_rounded_up = unchecked_add(self.size, align_m1) & !align_m1;
-            size_rounded_up
+            unchecked_add(self.size, align_m1) & !align_m1
         }
     }
 


### PR DESCRIPTION
perf: removed unnecessary let for return only

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
