### PR TITLE
tests/debuginfo/closures.rs: Activate misspelled `cdb-check`

### DIFF
--- a/tests/debuginfo/closures.rs
+++ b/tests/debuginfo/closures.rs
@@ -17,7 +17,7 @@
 // cdb-check:     [+0x[...]] x                : [...] [Type: alloc::string::String]
 // cdb-check:     [+0x[...]] _ref__base_value : 0x[...] : 42 [Type: int *]
 // cdb-command:dx simple_closure
-// cdb-checksimple_closure   [Type: closures::main::closure_env$5]
+// cdb-check:simple_closure   [Type: closures::main::closure_env$5]
 // cdb-check:     [+0x[...]] _ref__base_value : 0x[...] : 42 [Type: int *]
 // cdb-command:g
 // cdb-command:dx first_closure


### PR DESCRIPTION
Split out from https://github.com/rust-lang/rust/pull/147799 because these seemingly simple corrections can turn out to be non-trivial. See https://github.com/rust-lang/rust/pull/147728 for example.
