### PR TITLE
Prepare to move debugger discovery from compiletest to bootstrap

### DIFF
--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -29,6 +29,7 @@ use crate::core::builder::{
 };
 use crate::core::config::TargetSelection;
 use crate::core::config::flags::{Subcommand, get_completion, top_level_help};
+use crate::core::debuggers;
 use crate::utils::build_stamp::{self, BuildStamp};
 use crate::utils::exec::{BootstrapCommand, command};
 use crate::utils::helpers::{
@@ -37,8 +38,6 @@ use crate::utils::helpers::{
 };
 use crate::utils::render_tests::{add_flags_and_try_run_tests, try_run_tests};
 use crate::{CLang, CodegenBackendKind, DocTests, GitRepo, Mode, PathSet, envify};
-
-const ADB_TEST_DIR: &str = "/data/local/tmp/work";
 
 /// Runs `cargo test` on various internal tools used by bootstrap.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -2082,39 +2081,24 @@ Please disable assertions with `rust.debug-assertions = false`.
         // modes, even though they should only be needed in "debuginfo" mode,
         // because the GDB-discovery code in compiletest currently assumes that
         // `--android-cross-path` is always set for Android targets.
-        cmd.arg("--adb-path").arg("adb");
-        cmd.arg("--adb-test-dir").arg(ADB_TEST_DIR);
-        if target.contains("android") && !builder.config.dry_run() {
-            // Assume that cc for this target comes from the android sysroot
-            cmd.arg("--android-cross-path")
-                .arg(builder.cc(target).parent().unwrap().parent().unwrap());
-        } else {
-            cmd.arg("--android-cross-path").arg("");
+        if let Some(debuggers::Android { adb_path, adb_test_dir, android_cross_path }) =
+            debuggers::discover_android(builder, target)
+        {
+            cmd.arg("--adb-path").arg(adb_path);
+            cmd.arg("--adb-test-dir").arg(adb_test_dir);
+            cmd.arg("--android-cross-path").arg(android_cross_path);
         }
 
         if mode == "debuginfo" {
-            if let Some(ref gdb) = builder.config.gdb {
+            if let Some(debuggers::Gdb { gdb }) = debuggers::discover_gdb(builder) {
                 cmd.arg("--gdb").arg(gdb);
             }
 
-            let lldb_exe = builder.config.lldb.clone().unwrap_or_else(|| PathBuf::from("lldb"));
-            let lldb_version = command(&lldb_exe)
-                .allow_failure()
-                .arg("--version")
-                .run_capture(builder)
-                .stdout_if_ok()
-                .and_then(|v| if v.trim().is_empty() { None } else { Some(v) });
-            if let Some(ref vers) = lldb_version {
-                cmd.arg("--lldb-version").arg(vers);
-                let lldb_python_dir = command(&lldb_exe)
-                    .allow_failure()
-                    .arg("-P")
-                    .run_capture_stdout(builder)
-                    .stdout_if_ok()
-                    .map(|p| p.lines().next().expect("lldb Python dir not found").to_string());
-                if let Some(ref dir) = lldb_python_dir {
-                    cmd.arg("--lldb-python-dir").arg(dir);
-                }
+            if let Some(debuggers::Lldb { lldb_version, lldb_python_dir }) =
+                debuggers::discover_lldb(builder)
+            {
+                cmd.arg("--lldb-version").arg(lldb_version);
+                cmd.arg("--lldb-python-dir").arg(lldb_python_dir);
             }
         }
 

--- a/src/bootstrap/src/core/debuggers/android.rs
+++ b/src/bootstrap/src/core/debuggers/android.rs
@@ -1,0 +1,24 @@
+use std::path::PathBuf;
+
+use crate::core::builder::Builder;
+use crate::core::config::TargetSelection;
+
+pub(crate) struct Android {
+    pub(crate) adb_path: &'static str,
+    pub(crate) adb_test_dir: &'static str,
+    pub(crate) android_cross_path: PathBuf,
+}
+
+pub(crate) fn discover_android(builder: &Builder<'_>, target: TargetSelection) -> Option<Android> {
+    let adb_path = "adb";
+    // See <https://github.com/rust-lang/rust/pull/102755>.
+    let adb_test_dir = "/data/local/tmp/work";
+
+    let android_cross_path = if target.contains("android") && !builder.config.dry_run() {
+        builder.cc(target).parent().unwrap().parent().unwrap().to_owned()
+    } else {
+        PathBuf::new()
+    };
+
+    Some(Android { adb_path, adb_test_dir, android_cross_path })
+}

--- a/src/bootstrap/src/core/debuggers/gdb.rs
+++ b/src/bootstrap/src/core/debuggers/gdb.rs
@@ -1,0 +1,13 @@
+use std::path::Path;
+
+use crate::core::builder::Builder;
+
+pub(crate) struct Gdb<'a> {
+    pub(crate) gdb: &'a Path,
+}
+
+pub(crate) fn discover_gdb<'a>(builder: &'a Builder<'_>) -> Option<Gdb<'a>> {
+    let gdb = builder.config.gdb.as_deref()?;
+
+    Some(Gdb { gdb })
+}

--- a/src/bootstrap/src/core/debuggers/lldb.rs
+++ b/src/bootstrap/src/core/debuggers/lldb.rs
@@ -1,0 +1,32 @@
+use std::path::PathBuf;
+
+use crate::core::builder::Builder;
+use crate::utils::exec::command;
+
+pub(crate) struct Lldb {
+    pub(crate) lldb_version: String,
+    pub(crate) lldb_python_dir: String,
+}
+
+pub(crate) fn discover_lldb(builder: &Builder<'_>) -> Option<Lldb> {
+    // FIXME(#148361): We probably should not be picking up whatever arbitrary
+    // lldb happens to be in the user's path, and instead require some kind of
+    // explicit opt-in or configuration.
+    let lldb_exe = builder.config.lldb.clone().unwrap_or_else(|| PathBuf::from("lldb"));
+
+    let lldb_version = command(&lldb_exe)
+        .allow_failure()
+        .arg("--version")
+        .run_capture(builder)
+        .stdout_if_ok()
+        .and_then(|v| if v.trim().is_empty() { None } else { Some(v) })?;
+
+    let lldb_python_dir = command(&lldb_exe)
+        .allow_failure()
+        .arg("-P")
+        .run_capture_stdout(builder)
+        .stdout_if_ok()
+        .map(|p| p.lines().next().expect("lldb Python dir not found").to_string())?;
+
+    Some(Lldb { lldb_version, lldb_python_dir })
+}

--- a/src/bootstrap/src/core/debuggers/mod.rs
+++ b/src/bootstrap/src/core/debuggers/mod.rs
@@ -1,0 +1,10 @@
+//! Code for discovering debuggers and debugger-related configuration, so that
+//! it can be passed to compiletest when running debuginfo tests.
+
+pub(crate) use self::android::{Android, discover_android};
+pub(crate) use self::gdb::{Gdb, discover_gdb};
+pub(crate) use self::lldb::{Lldb, discover_lldb};
+
+mod android;
+mod gdb;
+mod lldb;

--- a/src/bootstrap/src/core/mod.rs
+++ b/src/bootstrap/src/core/mod.rs
@@ -1,6 +1,7 @@
 pub(crate) mod build_steps;
 pub(crate) mod builder;
 pub(crate) mod config;
+pub(crate) mod debuggers;
 pub(crate) mod download;
 pub(crate) mod metadata;
 pub(crate) mod sanity;

--- a/src/tools/compiletest/src/lib.rs
+++ b/src/tools/compiletest/src/lib.rs
@@ -258,10 +258,11 @@ fn parse_config(args: Vec<String>) -> Config {
     let target = opt_str2(matches.opt_str("target"));
     let android_cross_path = opt_path(matches, "android-cross-path");
     // FIXME: `cdb_version` is *derived* from cdb, but it's *not* technically a config!
-    let (cdb, cdb_version) = debuggers::analyze_cdb(matches.opt_str("cdb"), &target);
+    let cdb = debuggers::discover_cdb(matches.opt_str("cdb"), &target);
+    let cdb_version = cdb.as_deref().and_then(debuggers::query_cdb_version);
     // FIXME: `gdb_version` is *derived* from gdb, but it's *not* technically a config!
-    let (gdb, gdb_version) =
-        debuggers::analyze_gdb(matches.opt_str("gdb"), &target, &android_cross_path);
+    let gdb = debuggers::discover_gdb(matches.opt_str("gdb"), &target, &android_cross_path);
+    let gdb_version = gdb.as_deref().and_then(debuggers::query_gdb_version);
     // FIXME: `lldb_version` is *derived* from lldb, but it's *not* technically a config!
     let lldb_version =
         matches.opt_str("lldb-version").as_deref().and_then(debuggers::extract_lldb_version);


### PR DESCRIPTION
For a while I've been wanting to move debugger discovery out of compiletest and into bootstrap, so that bootstrap would be responsible for deciding which debugger to use, and compiletest would faithfully use that debugger with no extra magic (and no horrible config-duplicating hacks).

Making that change is complicated, and eventually I had so many intertwined preparatory changes that I split them off into this PR, so that it can be reviewed and tested as a smaller chunk.

---

To avoid scope creep, the changes in this PR try to move code as-is as much as possible, even if the moved code could arguably benefit from further cleanups. And in many cases, that code will need to be further overhauled anyway when discovery steps are actually moved out of compiletest.