### PR TITLE
rustdoc: Properly detect syntactically invalid doctests (to fix a regression)

### DIFF
--- a/compiler/rustc_attr_parsing/src/attributes/mod.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/mod.rs
@@ -241,7 +241,7 @@ pub(crate) enum AttributeOrder {
     ///
     /// Attributes are processed from bottom to top, so this raises a warning/error on all the attributes
     /// further above the lowest one:
-    /// ```
+    /// ```ignore (illustrative)
     /// #[stable(since="1.0")] //~ WARNING duplicated attribute
     /// #[stable(since="2.0")]
     /// ```
@@ -252,7 +252,7 @@ pub(crate) enum AttributeOrder {
     ///
     /// Attributes are processed from bottom to top, so this raises a warning/error on all the attributes
     /// below the highest one:
-    /// ```
+    /// ```ignore (illustrative)
     /// #[path="foo.rs"]
     /// #[path="bar.rs"] //~ WARNING duplicated attribute
     /// ```

--- a/compiler/rustc_errors/src/annotate_snippet_emitter_writer.rs
+++ b/compiler/rustc_errors/src/annotate_snippet_emitter_writer.rs
@@ -112,10 +112,6 @@ impl Emitter for AnnotateSnippetEmitter {
     fn translator(&self) -> &Translator {
         &self.translator
     }
-
-    fn supports_color(&self) -> bool {
-        false
-    }
 }
 
 fn annotation_level_for_level(level: Level) -> annotate_snippets::level::Level<'static> {

--- a/compiler/rustc_errors/src/emitter.rs
+++ b/compiler/rustc_errors/src/emitter.rs
@@ -203,11 +203,6 @@ pub trait Emitter {
         true
     }
 
-    /// Checks if we can use colors in the current output stream.
-    fn supports_color(&self) -> bool {
-        false
-    }
-
     fn source_map(&self) -> Option<&SourceMap>;
 
     fn translator(&self) -> &Translator;

--- a/tests/rustdoc-ui/doctest/doctest-output-include-fail.stdout
+++ b/tests/rustdoc-ui/doctest/doctest-output-include-fail.stdout
@@ -13,7 +13,15 @@ LL |     let x = 234 // no semicolon here! oh no!
 LL | }
    | - unexpected token
 
-error: aborting due to 1 previous error
+warning: unused variable: `x`
+  --> $DIR/doctest-output-include-fail.md:5:9
+   |
+LL |     let x = 234 // no semicolon here! oh no!
+   |         ^ help: if this is intentional, prefix it with an underscore: `_x`
+   |
+   = note: `#[warn(unused_variables)]` (part of `#[warn(unused)]`) on by default
+
+error: aborting due to 1 previous error; 1 warning emitted
 
 Couldn't compile the test.
 
@@ -22,4 +30,3 @@ failures:
 
 test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
 
-all doctests ran in $TIME; merged doctests compilation took $TIME

--- a/tests/rustdoc-ui/doctest/no-capture-fail.stderr
+++ b/tests/rustdoc-ui/doctest/no-capture-fail.stderr
@@ -14,5 +14,12 @@ LL |     Input: 123
 LL ~ } }
    |
 
-error: aborting due to 1 previous error
+error[E0601]: `main` function not found in crate `rust_out`
+  --> $DIR/nocapture-fail.rs:10:2
+   |
+LL | }
+   |  ^ consider adding a `main` function to `$DIR/nocapture-fail.rs`
 
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0601`.

--- a/tests/rustdoc-ui/doctest/recovered-syntax-error.rs
+++ b/tests/rustdoc-ui/doctest/recovered-syntax-error.rs
@@ -1,0 +1,9 @@
+// issue: <https://github.com/rust-lang/rust/issues/147999>
+//@ compile-flags: --test
+//@ normalize-stdout: "tests/rustdoc-ui/doctest" -> "$$DIR"
+//@ normalize-stdout: "finished in \d+\.\d+s" -> "finished in $$TIME"
+//@ failure-status: 101
+
+//! ```
+//! #[derive(Clone)]
+//! ```

--- a/tests/rustdoc-ui/doctest/recovered-syntax-error.stdout
+++ b/tests/rustdoc-ui/doctest/recovered-syntax-error.stdout
@@ -1,0 +1,22 @@
+
+running 1 test
+test $DIR/recovered-syntax-error.rs - (line 7) ... FAILED
+
+failures:
+
+---- $DIR/recovered-syntax-error.rs - (line 7) stdout ----
+error: expected item after attributes
+  --> $DIR/recovered-syntax-error.rs:8:1
+   |
+LL | #[derive(Clone)]
+   | ^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+
+Couldn't compile the test.
+
+failures:
+    $DIR/recovered-syntax-error.rs - (line 7)
+
+test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
+


### PR DESCRIPTION
Previously, we would only consider doctests to be syntactically invalid (for our crude static analysis pass) if (we failed to lex it or if) the parser returned an `Err(_)`[^1].

However, since the parser can actually recover from a slew of invalid forms, it may return `Ok(node)` even in the presence of syntax errors. E.g., stray outer attrs may just get jettisoned. Combine that with the fact that we (send all diagnostics into the ether and) only forward selected spans of the original source to the final runnable doctest, it led to issues like rust-lang/rust#147999.

To remedy that, check if `dcx.has_errors()`.

Fixes https://github.com/rust-lang/rust/issues/147999 (regressed in https://github.com/rust-lang/rust/pull/138104).

**FIXME**: Okay, due to the existence of error code checks like `compile_fail,E0726` I actually have to preserve some existing behavior here and continue wrapping certain classes of syntactically invalid doctests in functions, sigh.

[^1]: Or if the one of the expr stmts was an `ExprKind::Err(_)` (a special case / hack to paper over things).