### PR TITLE
[EXPERIMENT] libs: relax `Deref::Target`

### DIFF
--- a/library/core/src/ops/deref.rs
+++ b/library/core/src/ops/deref.rs
@@ -141,7 +141,7 @@ pub const trait Deref: PointeeSized {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_diagnostic_item = "deref_target"]
     #[lang = "deref_target"]
-    type Target: ?Sized;
+    type Target: PointeeSized;
 
     /// Dereferences the value.
     #[must_use]
@@ -152,7 +152,7 @@ pub const trait Deref: PointeeSized {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_const_unstable(feature = "const_convert", issue = "143773")]
-impl<T: ?Sized> const Deref for &T {
+impl<T: PointeeSized> const Deref for &T {
     type Target = T;
 
     #[rustc_diagnostic_item = "noop_method_deref"]
@@ -162,11 +162,11 @@ impl<T: ?Sized> const Deref for &T {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: ?Sized> !DerefMut for &T {}
+impl<T: PointeeSized> !DerefMut for &T {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_const_unstable(feature = "const_convert", issue = "143773")]
-impl<T: ?Sized> const Deref for &mut T {
+impl<T: PointeeSized> const Deref for &mut T {
     type Target = T;
 
     fn deref(&self) -> &T {
@@ -276,7 +276,7 @@ pub const trait DerefMut: [const] Deref + PointeeSized {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_const_unstable(feature = "const_convert", issue = "143773")]
-impl<T: ?Sized> const DerefMut for &mut T {
+impl<T: PointeeSized> const DerefMut for &mut T {
     fn deref_mut(&mut self) -> &mut T {
         self
     }
@@ -296,10 +296,10 @@ impl<T: ?Sized> const DerefMut for &mut T {
 pub unsafe trait DerefPure: PointeeSized {}
 
 #[unstable(feature = "deref_pure_trait", issue = "87121")]
-unsafe impl<T: ?Sized> DerefPure for &T {}
+unsafe impl<T: PointeeSized> DerefPure for &T {}
 
 #[unstable(feature = "deref_pure_trait", issue = "87121")]
-unsafe impl<T: ?Sized> DerefPure for &mut T {}
+unsafe impl<T: PointeeSized> DerefPure for &mut T {}
 
 /// Indicates that a struct can be used as a method receiver.
 /// That is, a type can use this type as a type of `self`, like this:
@@ -371,11 +371,11 @@ pub trait Receiver: PointeeSized {
     #[rustc_diagnostic_item = "receiver_target"]
     #[lang = "receiver_target"]
     #[unstable(feature = "arbitrary_self_types", issue = "44874")]
-    type Target: ?Sized;
+    type Target: PointeeSized;
 }
 
 #[unstable(feature = "arbitrary_self_types", issue = "44874")]
-impl<P: ?Sized, T: ?Sized> Receiver for P
+impl<P: PointeeSized, T: PointeeSized> Receiver for P
 where
     P: Deref<Target = T>,
 {

--- a/library/core/src/pin.rs
+++ b/library/core/src/pin.rs
@@ -926,7 +926,7 @@ use crate::ops::{CoerceUnsized, Deref, DerefMut, DerefPure, DispatchFromDyn, Leg
 use crate::{
     cell::{RefCell, UnsafeCell},
     future::Future,
-    marker::PhantomPinned,
+    marker::{PhantomPinned, PointeeSized},
     mem, ptr,
 };
 use crate::{cmp, fmt};
@@ -1516,7 +1516,7 @@ impl<Ptr: Deref> Pin<Ptr> {
     }
 }
 
-impl<'a, T: ?Sized> Pin<&'a T> {
+impl<'a, T: PointeeSized> Pin<&'a T> {
     /// Constructs a new pin by mapping the interior value.
     ///
     /// For example, if you wanted to get a `Pin` of a field of something,
@@ -1535,7 +1535,7 @@ impl<'a, T: ?Sized> Pin<&'a T> {
     #[stable(feature = "pin", since = "1.33.0")]
     pub unsafe fn map_unchecked<U, F>(self, func: F) -> Pin<&'a U>
     where
-        U: ?Sized,
+        U: PointeeSized,
         F: FnOnce(&T) -> &U,
     {
         let pointer = &*self.pointer;
@@ -1572,7 +1572,7 @@ impl<'a, T: ?Sized> Pin<&'a T> {
     }
 }
 
-impl<'a, T: ?Sized> Pin<&'a mut T> {
+impl<'a, T: PointeeSized> Pin<&'a mut T> {
     /// Converts this `Pin<&mut T>` into a `Pin<&T>` with the same lifetime.
     #[inline(always)]
     #[must_use = "`self` will be dropped if the result is not used"]
@@ -1639,7 +1639,7 @@ impl<'a, T: ?Sized> Pin<&'a mut T> {
     #[stable(feature = "pin", since = "1.33.0")]
     pub unsafe fn map_unchecked_mut<U, F>(self, func: F) -> Pin<&'a mut U>
     where
-        U: ?Sized,
+        U: PointeeSized,
         F: FnOnce(&mut T) -> &mut U,
     {
         // SAFETY: the caller is responsible for not moving the
@@ -1652,7 +1652,7 @@ impl<'a, T: ?Sized> Pin<&'a mut T> {
     }
 }
 
-impl<T: ?Sized> Pin<&'static T> {
+impl<T: PointeeSized> Pin<&'static T> {
     /// Gets a pinning reference from a `&'static` reference.
     ///
     /// This is safe because `T` is borrowed immutably for the `'static` lifetime, which
@@ -1666,7 +1666,7 @@ impl<T: ?Sized> Pin<&'static T> {
     }
 }
 
-impl<T: ?Sized> Pin<&'static mut T> {
+impl<T: PointeeSized> Pin<&'static mut T> {
     /// Gets a pinning mutable reference from a static mutable reference.
     ///
     /// This is safe because `T` is borrowed for the `'static` lifetime, which
@@ -1719,7 +1719,7 @@ mod helper {
     #[rustc_const_unstable(feature = "const_convert", issue = "143773")]
     #[rustc_diagnostic_item = "PinDerefMutHelper"]
     pub const trait PinDerefMutHelper {
-        type Target: ?Sized;
+        type Target: super::PointeeSized;
         fn deref_mut(&mut self) -> &mut Self::Target;
     }
 
@@ -1847,19 +1847,19 @@ where
 pub unsafe trait PinCoerceUnsized {}
 
 #[stable(feature = "pin", since = "1.33.0")]
-unsafe impl<'a, T: ?Sized> PinCoerceUnsized for &'a T {}
+unsafe impl<'a, T: PointeeSized> PinCoerceUnsized for &'a T {}
 
 #[stable(feature = "pin", since = "1.33.0")]
-unsafe impl<'a, T: ?Sized> PinCoerceUnsized for &'a mut T {}
+unsafe impl<'a, T: PointeeSized> PinCoerceUnsized for &'a mut T {}
 
 #[stable(feature = "pin", since = "1.33.0")]
 unsafe impl<T: PinCoerceUnsized> PinCoerceUnsized for Pin<T> {}
 
 #[stable(feature = "pin", since = "1.33.0")]
-unsafe impl<T: ?Sized> PinCoerceUnsized for *const T {}
+unsafe impl<T: PointeeSized> PinCoerceUnsized for *const T {}
 
 #[stable(feature = "pin", since = "1.33.0")]
-unsafe impl<T: ?Sized> PinCoerceUnsized for *mut T {}
+unsafe impl<T: PointeeSized> PinCoerceUnsized for *mut T {}
 
 /// Constructs a <code>[Pin]<[&mut] T></code>, by pinning a `value: T` locally.
 ///


### PR DESCRIPTION
Part of rust-lang/rust#144404.

As with any associated type, the default `?Sized` bound of `Deref::Target` cannot be relaxed backwards compatibly:

```rust
trait Deref {
    type Target: ?Sized;
}

fn needs_metasized<T: ?Sized>() {}
fn caller<T: Deref>() -> usize {
    needs_metasized::<<T as Deref>::Target>()
    //~^ error! the trait bound `<T as Deref>::Target: MetaSized` is not satisfied 
}
```

This is a known limitation of the proposal and for most use cases of the new sizedness traits is unlikely to be a major issue.

However, `Deref` is particularly tricky because in the limited relaxations in the standard library performed so far (because of the use of `extern type` in a couple places), plenty of code that could have been `PointeeSized` ended up being `MetaSized` only because of `Deref`. It seems unlikely enough that much code is relying solely on `Deref::Target`'s `?Sized` bound, so attempt to relax this to find out if it will break any code.

This is technically a breaking change so will need a crater run to determine whether it actually breaks anyone in practice.

r? @ghost
