### PR TITLE
cg_llvm: Pass `debuginfo_compression` through FFI as an enum

### DIFF
--- a/compiler/rustc_codegen_llvm/src/back/owned_target_machine.rs
+++ b/compiler/rustc_codegen_llvm/src/back/owned_target_machine.rs
@@ -36,7 +36,7 @@ impl OwnedTargetMachine {
         use_init_array: bool,
         split_dwarf_file: &CStr,
         output_obj_file: &CStr,
-        debug_info_compression: &CStr,
+        debug_info_compression: llvm::CompressionKind,
         use_emulated_tls: bool,
         use_wasm_eh: bool,
     ) -> Result<Self, LlvmError<'static>> {
@@ -62,7 +62,7 @@ impl OwnedTargetMachine {
                 use_init_array,
                 split_dwarf_file.as_ptr(),
                 output_obj_file.as_ptr(),
-                debug_info_compression.as_ptr(),
+                debug_info_compression,
                 use_emulated_tls,
                 use_wasm_eh,
             )

--- a/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
@@ -677,6 +677,15 @@ pub(crate) enum Opcode {
     CatchSwitch = 65,
 }
 
+/// Must match the layout of `LLVMRustCompressionKind`.
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub(crate) enum CompressionKind {
+    None = 0,
+    Zlib = 1,
+    Zstd = 2,
+}
+
 unsafe extern "C" {
     type Opaque;
 }
@@ -2328,7 +2337,7 @@ unsafe extern "C" {
         UseInitArray: bool,
         SplitDwarfFile: *const c_char,
         OutputObjFile: *const c_char,
-        DebugInfoCompression: *const c_char,
+        DebugInfoCompression: CompressionKind,
         UseEmulatedTls: bool,
         UseWasmEH: bool,
     ) -> *mut TargetMachine;
@@ -2516,9 +2525,8 @@ unsafe extern "C" {
 
     pub(crate) fn LLVMRustGetElementTypeArgIndex(CallSite: &Value) -> i32;
 
-    pub(crate) fn LLVMRustLLVMHasZlibCompressionForDebugSymbols() -> bool;
-
-    pub(crate) fn LLVMRustLLVMHasZstdCompressionForDebugSymbols() -> bool;
+    pub(crate) safe fn LLVMRustLLVMHasZlibCompression() -> bool;
+    pub(crate) safe fn LLVMRustLLVMHasZstdCompression() -> bool;
 
     pub(crate) fn LLVMRustGetSymbols(
         buf_ptr: *const u8,

--- a/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
@@ -1640,11 +1640,11 @@ extern "C" bool LLVMRustIsNonGVFunctionPointerTy(LLVMValueRef V) {
   return false;
 }
 
-extern "C" bool LLVMRustLLVMHasZlibCompressionForDebugSymbols() {
+extern "C" bool LLVMRustLLVMHasZlibCompression() {
   return llvm::compression::zlib::isAvailable();
 }
 
-extern "C" bool LLVMRustLLVMHasZstdCompressionForDebugSymbols() {
+extern "C" bool LLVMRustLLVMHasZstdCompression() {
   return llvm::compression::zstd::isAvailable();
 }
 

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -583,17 +583,6 @@ pub enum DebugInfoCompression {
     Zstd,
 }
 
-impl ToString for DebugInfoCompression {
-    fn to_string(&self) -> String {
-        match self {
-            DebugInfoCompression::None => "none",
-            DebugInfoCompression::Zlib => "zlib",
-            DebugInfoCompression::Zstd => "zstd",
-        }
-        .to_owned()
-    }
-}
-
 #[derive(Clone, Copy, Debug, PartialEq, Hash)]
 pub enum MirStripDebugInfo {
     None,


### PR DESCRIPTION
There are only three possible values, making an enum more appropriate.

This avoids string allocation on the Rust side, and avoids ad-hoc `!strcmp` to convert back to an enum on the C++ side.