### PR TITLE
Improve the ICE message for invalid nullary intrinsic calls

### DIFF
--- a/compiler/rustc_codegen_ssa/src/mir/intrinsic.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/intrinsic.rs
@@ -120,8 +120,15 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                 | sym::atomic_singlethreadfence
                 | sym::caller_location => {}
                 _ => {
-                    span_bug!(span, "nullary intrinsic {name} must either be in a const block or explicitly opted out because it is inherently a runtime intrinsic
-");
+                    span_bug!(
+                        span,
+                        "Nullary intrinsic {name} must be called in a const block. \
+                        If you are seeing this message from code outside the standard library, the \
+                        unstable implementation details of the relevant intrinsic may have changed. \
+                        Consider using stable APIs instead. \
+                        If you are adding a new nullary intrinsic that is inherently a runtime \
+                        intrinsic, update this check."
+                    );
                 }
             }
         }

--- a/library/core/src/intrinsics/mod.rs
+++ b/library/core/src/intrinsics/mod.rs
@@ -2728,6 +2728,11 @@ pub unsafe fn vtable_align(ptr: *const ()) -> usize;
 /// More specifically, this is the offset in bytes between successive
 /// items of the same type, including alignment padding.
 ///
+/// Note that, unlike most intrinsics, this can only be called at compile-time
+/// as backends do not have an implementation for it. The only caller (its
+/// stable counterpart) wraps this intrinsic call in a `const` block so that
+/// backends only see an evaluated constant.
+///
 /// The stabilized version of this intrinsic is [`core::mem::size_of`].
 #[rustc_nounwind]
 #[unstable(feature = "core_intrinsics", issue = "none")]
@@ -2741,6 +2746,11 @@ pub const fn size_of<T>() -> usize;
 /// it does not require an `unsafe` block.
 /// Therefore, implementations must not require the user to uphold
 /// any safety invariants.
+///
+/// Note that, unlike most intrinsics, this can only be called at compile-time
+/// as backends do not have an implementation for it. The only caller (its
+/// stable counterpart) wraps this intrinsic call in a `const` block so that
+/// backends only see an evaluated constant.
 ///
 /// The stabilized version of this intrinsic is [`core::mem::align_of`].
 #[rustc_nounwind]


### PR DESCRIPTION
In https://github.com/rust-lang/rust/issues/148104, we found the panic message here rather confusing, and (if I'm reading the tea leaves right) that's because the intended audience for either side of the phrase is very different. I think this is more clear if/when this is encountered by users.

I expect this ICE to be hit in practice by people calling the `size_of` and `align_of` intrinsics, so it's now _kind of_ helpful for those users too.

The original effort to stop backends from needing to support nullary intrinsics added a note to all these const-only intrinsics, but when https://github.com/rust-lang/rust/pull/147793 ported two more the paragraph wasn't added. I've added it.