### PR TITLE
Make deref_nullptr deny by default instead of warn

### DIFF
--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -2699,6 +2699,7 @@ declare_lint! {
     ///
     /// ```rust,compile_fail
     /// # #![allow(unused)]
+    /// # #![cfg_attr(bootstrap, deny(deref_nullptr))]
     /// use std::ptr;
     /// unsafe {
     ///     let x = &*ptr::null::<i32>();

--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -2697,7 +2697,7 @@ declare_lint! {
     ///
     /// ### Example
     ///
-    /// ```rust,no_run
+    /// ```rust,compile_fail
     /// # #![allow(unused)]
     /// use std::ptr;
     /// unsafe {
@@ -2716,7 +2716,7 @@ declare_lint! {
     ///
     /// [undefined behavior]: https://doc.rust-lang.org/reference/behavior-considered-undefined.html
     pub DEREF_NULLPTR,
-    Warn,
+    Deny,
     "detects when an null pointer is dereferenced"
 }
 

--- a/tests/ui/lint/lint-deref-nullptr.rs
+++ b/tests/ui/lint/lint-deref-nullptr.rs
@@ -1,12 +1,13 @@
 // test the deref_nullptr lint
 
-#![deny(deref_nullptr)]
-
 use std::ptr;
 
 struct Struct {
     field: u8,
 }
+
+#[derive(Clone, Copy)]
+struct Zst;
 
 fn f() {
     unsafe {
@@ -32,6 +33,11 @@ fn f() {
         // ^^ OKAY
         let offset = ptr::addr_of!((*ptr::null::<Struct>()).field);
         //~^ ERROR dereferencing a null pointer
+
+        // Make sure the lint permits derefs of null pointers to ZSTs
+        let ok: Zst = *ptr::null();
+        let ok: Zst = *ptr::null_mut();
+        let ok: Zst = *(0 as *const Zst);
     }
 }
 

--- a/tests/ui/lint/lint-deref-nullptr.stderr
+++ b/tests/ui/lint/lint-deref-nullptr.stderr
@@ -1,53 +1,49 @@
 error: dereferencing a null pointer
-  --> $DIR/lint-deref-nullptr.rs:15:18
+  --> $DIR/lint-deref-nullptr.rs:16:18
    |
 LL |         let ub = *(0 as *const i32);
    |                  ^^^^^^^^^^^^^^^^^^ this code causes undefined behavior when executed
    |
-note: the lint level is defined here
-  --> $DIR/lint-deref-nullptr.rs:3:9
-   |
-LL | #![deny(deref_nullptr)]
-   |         ^^^^^^^^^^^^^
+   = note: `#[deny(deref_nullptr)]` on by default
 
 error: dereferencing a null pointer
-  --> $DIR/lint-deref-nullptr.rs:17:18
+  --> $DIR/lint-deref-nullptr.rs:18:18
    |
 LL |         let ub = *ptr::null::<i32>();
    |                  ^^^^^^^^^^^^^^^^^^^ this code causes undefined behavior when executed
 
 error: dereferencing a null pointer
-  --> $DIR/lint-deref-nullptr.rs:19:18
+  --> $DIR/lint-deref-nullptr.rs:20:18
    |
 LL |         let ub = *ptr::null_mut::<i32>();
    |                  ^^^^^^^^^^^^^^^^^^^^^^^ this code causes undefined behavior when executed
 
 error: dereferencing a null pointer
-  --> $DIR/lint-deref-nullptr.rs:21:18
+  --> $DIR/lint-deref-nullptr.rs:22:18
    |
 LL |         let ub = *(ptr::null::<i16>() as *const i32);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this code causes undefined behavior when executed
 
 error: dereferencing a null pointer
-  --> $DIR/lint-deref-nullptr.rs:23:18
+  --> $DIR/lint-deref-nullptr.rs:24:18
    |
 LL |         let ub = *(ptr::null::<i16>() as *mut i32 as *mut usize as *const u8);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this code causes undefined behavior when executed
 
 error: dereferencing a null pointer
-  --> $DIR/lint-deref-nullptr.rs:25:19
+  --> $DIR/lint-deref-nullptr.rs:26:19
    |
 LL |         let ub = &*ptr::null::<i32>();
    |                   ^^^^^^^^^^^^^^^^^^^ this code causes undefined behavior when executed
 
 error: dereferencing a null pointer
-  --> $DIR/lint-deref-nullptr.rs:27:19
+  --> $DIR/lint-deref-nullptr.rs:28:19
    |
 LL |         let ub = &*ptr::null_mut::<i32>();
    |                   ^^^^^^^^^^^^^^^^^^^^^^^ this code causes undefined behavior when executed
 
 error: dereferencing a null pointer
-  --> $DIR/lint-deref-nullptr.rs:33:36
+  --> $DIR/lint-deref-nullptr.rs:34:36
    |
 LL |         let offset = ptr::addr_of!((*ptr::null::<Struct>()).field);
    |                                    ^^^^^^^^^^^^^^^^^^^^^^^^ this code causes undefined behavior when executed

--- a/tests/ui/lint/lint-forbid-internal-unsafe.rs
+++ b/tests/ui/lint/lint-forbid-internal-unsafe.rs
@@ -13,5 +13,5 @@ macro_rules! evil {
 
 fn main() {
     println!("{}", evil!(*(0 as *const u8)));
-    //~^ WARNING dereferencing a null pointer
+    //~^ ERROR dereferencing a null pointer
 }

--- a/tests/ui/lint/lint-forbid-internal-unsafe.stderr
+++ b/tests/ui/lint/lint-forbid-internal-unsafe.stderr
@@ -10,13 +10,13 @@ note: the lint level is defined here
 LL | #![forbid(unsafe_code)]
    |           ^^^^^^^^^^^
 
-warning: dereferencing a null pointer
+error: dereferencing a null pointer
   --> $DIR/lint-forbid-internal-unsafe.rs:15:26
    |
 LL |     println!("{}", evil!(*(0 as *const u8)));
    |                          ^^^^^^^^^^^^^^^^^ this code causes undefined behavior when executed
    |
-   = note: `#[warn(deref_nullptr)]` on by default
+   = note: `#[deny(deref_nullptr)]` on by default
 
-error: aborting due to 1 previous error; 1 warning emitted
+error: aborting due to 2 previous errors
 

--- a/tests/ui/unreachable-code/unreachable-bool-read-7246.rs
+++ b/tests/ui/unreachable-code/unreachable-bool-read-7246.rs
@@ -5,7 +5,7 @@ use std::ptr;
 pub unsafe fn g() {
     return;
     if *ptr::null() {}; //~ ERROR unreachable
-    //~| WARNING dereferencing a null pointer
+    //~| ERROR dereferencing a null pointer
 }
 
 pub fn main() {}

--- a/tests/ui/unreachable-code/unreachable-bool-read-7246.stderr
+++ b/tests/ui/unreachable-code/unreachable-bool-read-7246.stderr
@@ -12,13 +12,13 @@ note: the lint level is defined here
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
 
-warning: dereferencing a null pointer
+error: dereferencing a null pointer
   --> $DIR/unreachable-bool-read-7246.rs:7:8
    |
 LL |     if *ptr::null() {};
    |        ^^^^^^^^^^^^ this code causes undefined behavior when executed
    |
-   = note: `#[warn(deref_nullptr)]` on by default
+   = note: `#[deny(deref_nullptr)]` on by default
 
-error: aborting due to 1 previous error; 1 warning emitted
+error: aborting due to 2 previous errors
 


### PR DESCRIPTION
This lint was added 4 years ago in https://github.com/rust-lang/rust/pull/83948 and I cannot find any discussion on that PR or its issue about whether it should be warn or deny by default.

I think keeping this lint to warn was at one point in the past justifiable because of the old bindgen behavior of generating tests that do null pointer derefs. I've certainly heard that argument. I don't think it holds up now, so I think we should be more firm about code that is definitely UB.

We merged https://github.com/rust-lang/rust/pull/134424 which adds a runtime check for null pointer reads/writes, with very little fanfare. So now we know things like: This lint warns on 111 crates in crater, but 106 crates are encountering the runtime UB check. 65 crates hit both the lint and a runtime check. Of the 46 crates that only hit the lint, 25 look to me like machine-generated bindings, and all hits except https://github.com/Plecra/asm-w-ownership/blob/3a0eff4bd151d8a0ccc076d6b8dea0bbc051e8e8/src/main.rs#L454 are trying to compute a field offset, and should use `offset_of!`.

Based on the contents of the crater runs for 1.91, I'd expect these crates to go from test-fail to build-fail as a result of this change:
```
gh/bernardjason/rust-invaders
gh/Leinnan/doppler
gh/Max-E/rust-gl-python-gtk
gh/nslebruh/rust-opengl-glfw
gh/nslebruh/rust_physics_gl_test
gh/oraoto/php-stacktrace
gh/playXE/jsrs
gh/Plecra/asm-w-ownership
gh/TateKennington/ROpenGL
gh/WillFarris/voxel-game
reg/ochre
```
Most of the crates where the lint fires already don't build for other reasons (note there are a lot of C bindings wrapper crates in the set).