### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/compiler/rustc_codegen_ssa/src/mir/intrinsic.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/intrinsic.rs
@@ -120,8 +120,15 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                 | sym::atomic_singlethreadfence
                 | sym::caller_location => {}
                 _ => {
-                    span_bug!(span, "nullary intrinsic {name} must either be in a const block or explicitly opted out because it is inherently a runtime intrinsic
-");
+                    span_bug!(
+                        span,
+                        "Nullary intrinsic {name} must be called in a const block. \
+                        If you are seeing this message from code outside the standard library, the \
+                        unstable implementation details of the relevant intrinsic may have changed. \
+                        Consider using stable APIs instead. \
+                        If you are adding a new nullary intrinsic that is inherently a runtime \
+                        intrinsic, update this check."
+                    );
                 }
             }
         }

--- a/library/alloc/src/vec/into_iter.rs
+++ b/library/alloc/src/vec/into_iter.rs
@@ -7,6 +7,7 @@ use core::mem::{ManuallyDrop, MaybeUninit, SizedTypeProperties};
 use core::num::NonZero;
 #[cfg(not(no_global_oom_handling))]
 use core::ops::Deref;
+use core::panic::UnwindSafe;
 use core::ptr::{self, NonNull};
 use core::slice::{self};
 use core::{array, fmt};
@@ -59,6 +60,11 @@ pub struct IntoIter<
     /// For non-ZSTs the pointer is treated as `NonNull<T>`
     pub(super) end: *const T,
 }
+
+// Manually mirroring what `Vec` has,
+// because otherwise we get `T: RefUnwindSafe` from `NonNull`.
+#[stable(feature = "catch_unwind", since = "1.9.0")]
+impl<T: UnwindSafe, A: Allocator + UnwindSafe> UnwindSafe for IntoIter<T, A> {}
 
 #[stable(feature = "vec_intoiter_debug", since = "1.13.0")]
 impl<T: fmt::Debug, A: Allocator> fmt::Debug for IntoIter<T, A> {

--- a/library/core/src/intrinsics/mod.rs
+++ b/library/core/src/intrinsics/mod.rs
@@ -2728,6 +2728,11 @@ pub unsafe fn vtable_align(ptr: *const ()) -> usize;
 /// More specifically, this is the offset in bytes between successive
 /// items of the same type, including alignment padding.
 ///
+/// Note that, unlike most intrinsics, this can only be called at compile-time
+/// as backends do not have an implementation for it. The only caller (its
+/// stable counterpart) wraps this intrinsic call in a `const` block so that
+/// backends only see an evaluated constant.
+///
 /// The stabilized version of this intrinsic is [`core::mem::size_of`].
 #[rustc_nounwind]
 #[unstable(feature = "core_intrinsics", issue = "none")]
@@ -2741,6 +2746,11 @@ pub const fn size_of<T>() -> usize;
 /// it does not require an `unsafe` block.
 /// Therefore, implementations must not require the user to uphold
 /// any safety invariants.
+///
+/// Note that, unlike most intrinsics, this can only be called at compile-time
+/// as backends do not have an implementation for it. The only caller (its
+/// stable counterpart) wraps this intrinsic call in a `const` block so that
+/// backends only see an evaluated constant.
 ///
 /// The stabilized version of this intrinsic is [`core::mem::align_of`].
 #[rustc_nounwind]

--- a/tests/debuginfo/closures.rs
+++ b/tests/debuginfo/closures.rs
@@ -17,7 +17,7 @@
 // cdb-check:     [+0x[...]] x                : [...] [Type: alloc::string::String]
 // cdb-check:     [+0x[...]] _ref__base_value : 0x[...] : 42 [Type: int *]
 // cdb-command:dx simple_closure
-// cdb-checksimple_closure   [Type: closures::main::closure_env$5]
+// cdb-check:simple_closure   [Type: closures::main::closure_env$5]
 // cdb-check:     [+0x[...]] _ref__base_value : 0x[...] : 42 [Type: int *]
 // cdb-command:g
 // cdb-command:dx first_closure

--- a/tests/debuginfo/function-arg-initialization.rs
+++ b/tests/debuginfo/function-arg-initialization.rs
@@ -26,9 +26,9 @@
 
 // NON IMMEDIATE ARGS
 // gdb-command:print a
-// gdbt-check:$4 = function_arg_initialization::BigStruct {a: 3, b: 4, c: 5, d: 6, e: 7, f: 8, g: 9, h: 10}
+// gdb-check:$4 = function_arg_initialization::BigStruct {a: 3, b: 4, c: 5, d: 6, e: 7, f: 8, g: 9, h: 10}
 // gdb-command:print b
-// gdbt-check:$5 = function_arg_initialization::BigStruct {a: 11, b: 12, c: 13, d: 14, e: 15, f: 16, g: 17, h: 18}
+// gdb-check:$5 = function_arg_initialization::BigStruct {a: 11, b: 12, c: 13, d: 14, e: 15, f: 16, g: 17, h: 18}
 // gdb-command:continue
 
 // BINDING
@@ -234,6 +234,10 @@ struct BigStruct {
 
 fn non_immediate_args(a: BigStruct, b: BigStruct) {
     zzz(); // #break
+
+    // FIXME(#128973): Needed to avoid `<optimized out>` prints before #128973 has been fixed.
+    #[cfg(target_arch = "aarch64")]
+    std::hint::black_box(|| { let _ = (a, b);});
 }
 
 fn binding(a: i64, b: u64, c: f64) {


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#145665 (Don't require `T: RefUnwindSafe` for `vec::IntoIter<T>: UnwindSafe`)
 - rust-lang/rust#147728 (tests: activate misspelled `gdb-check` in `function-arg-initialization.rs`)
 - rust-lang/rust#148097 (tests/debuginfo/closures.rs: Activate misspelled `cdb-check`)
 - rust-lang/rust#148118 (Improve the ICE message for invalid nullary intrinsic calls)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=145665,147728,148097,148118)
<!-- homu-ignore:end -->