### PR TITLE
Rollup of 2 pull requests

### DIFF
--- a/compiler/rustc_codegen_ssa/src/mir/intrinsic.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/intrinsic.rs
@@ -120,8 +120,15 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                 | sym::atomic_singlethreadfence
                 | sym::caller_location => {}
                 _ => {
-                    span_bug!(span, "nullary intrinsic {name} must either be in a const block or explicitly opted out because it is inherently a runtime intrinsic
-");
+                    span_bug!(
+                        span,
+                        "Nullary intrinsic {name} must be called in a const block. \
+                        If you are seeing this message from code outside the standard library, the \
+                        unstable implementation details of the relevant intrinsic may have changed. \
+                        Consider using stable APIs instead. \
+                        If you are adding a new nullary intrinsic that is inherently a runtime \
+                        intrinsic, update this check."
+                    );
                 }
             }
         }

--- a/library/core/src/intrinsics/mod.rs
+++ b/library/core/src/intrinsics/mod.rs
@@ -2728,6 +2728,11 @@ pub unsafe fn vtable_align(ptr: *const ()) -> usize;
 /// More specifically, this is the offset in bytes between successive
 /// items of the same type, including alignment padding.
 ///
+/// Note that, unlike most intrinsics, this can only be called at compile-time
+/// as backends do not have an implementation for it. The only caller (its
+/// stable counterpart) wraps this intrinsic call in a `const` block so that
+/// backends only see an evaluated constant.
+///
 /// The stabilized version of this intrinsic is [`core::mem::size_of`].
 #[rustc_nounwind]
 #[unstable(feature = "core_intrinsics", issue = "none")]
@@ -2741,6 +2746,11 @@ pub const fn size_of<T>() -> usize;
 /// it does not require an `unsafe` block.
 /// Therefore, implementations must not require the user to uphold
 /// any safety invariants.
+///
+/// Note that, unlike most intrinsics, this can only be called at compile-time
+/// as backends do not have an implementation for it. The only caller (its
+/// stable counterpart) wraps this intrinsic call in a `const` block so that
+/// backends only see an evaluated constant.
 ///
 /// The stabilized version of this intrinsic is [`core::mem::align_of`].
 #[rustc_nounwind]

--- a/tests/debuginfo/closures.rs
+++ b/tests/debuginfo/closures.rs
@@ -17,7 +17,7 @@
 // cdb-check:     [+0x[...]] x                : [...] [Type: alloc::string::String]
 // cdb-check:     [+0x[...]] _ref__base_value : 0x[...] : 42 [Type: int *]
 // cdb-command:dx simple_closure
-// cdb-checksimple_closure   [Type: closures::main::closure_env$5]
+// cdb-check:simple_closure   [Type: closures::main::closure_env$5]
 // cdb-check:     [+0x[...]] _ref__base_value : 0x[...] : 42 [Type: int *]
 // cdb-command:g
 // cdb-command:dx first_closure


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#148097 (tests/debuginfo/closures.rs: Activate misspelled `cdb-check`)
 - rust-lang/rust#148118 (Improve the ICE message for invalid nullary intrinsic calls)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=148097,148118)
<!-- homu-ignore:end -->