### PR TITLE
Skip parameter attribute deduction for MIR with `spread_arg`

### DIFF
--- a/compiler/rustc_mir_transform/src/deduce_param_attrs.rs
+++ b/compiler/rustc_mir_transform/src/deduce_param_attrs.rs
@@ -195,6 +195,11 @@ pub(super) fn deduced_param_attrs<'tcx>(
 
     // Grab the optimized MIR. Analyze it to determine which arguments have been mutated.
     let body: &Body<'tcx> = tcx.optimized_mir(def_id);
+    // Arguments spread at ABI level are currently unsupported.
+    if body.spread_arg.is_some() {
+        return &[];
+    }
+
     let mut deduce = DeduceParamAttrs::new(body);
     deduce.visit_body(body);
     tracing::trace!(?deduce.usage);

--- a/tests/codegen-llvm/deduced-param-attrs.rs
+++ b/tests/codegen-llvm/deduced-param-attrs.rs
@@ -3,7 +3,7 @@
 //@ revisions: LLVM21 LLVM20
 //@ [LLVM21] min-llvm-version: 21
 //@ [LLVM20] max-llvm-major-version: 20
-#![feature(custom_mir, core_intrinsics)]
+#![feature(custom_mir, core_intrinsics, unboxed_closures)]
 #![crate_type = "lib"]
 extern crate core;
 use core::intrinsics::mir::*;
@@ -170,3 +170,11 @@ pub fn not_captured_return_place() -> [u8; 80] {
 pub fn captured_return_place() -> [u8; 80] {
     black_box([0u8; 80])
 }
+
+// Arguments spread at ABI level are unsupported.
+//
+// CHECK-LABEL: @spread_arg(
+// CHECK-NOT: readonly
+// CHECK-SAME: )
+#[no_mangle]
+pub extern "rust-call" fn spread_arg(_: (Big, Big, Big)) {}


### PR DESCRIPTION
When a MIR argument is spread at ABI level, deduced attributes are potentially misapplied, since a spread argument can correspond to zero or more arguments at ABI level.

Disable deduction for MIR using spread argument for the time being.