### PR TITLE
Rollup of 2 pull requests

### DIFF
--- a/compiler/rustc_codegen_ssa/src/mir/intrinsic.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/intrinsic.rs
@@ -120,8 +120,15 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                 | sym::atomic_singlethreadfence
                 | sym::caller_location => {}
                 _ => {
-                    span_bug!(span, "nullary intrinsic {name} must either be in a const block or explicitly opted out because it is inherently a runtime intrinsic
-");
+                    span_bug!(
+                        span,
+                        "Nullary intrinsic {name} must be called in a const block. \
+                        If you are seeing this message from code outside the standard library, the \
+                        unstable implementation details of the relevant intrinsic may have changed. \
+                        Consider using stable APIs instead. \
+                        If you are adding a new nullary intrinsic that is inherently a runtime \
+                        intrinsic, update this check."
+                    );
                 }
             }
         }

--- a/library/core/src/intrinsics/mod.rs
+++ b/library/core/src/intrinsics/mod.rs
@@ -2728,6 +2728,11 @@ pub unsafe fn vtable_align(ptr: *const ()) -> usize;
 /// More specifically, this is the offset in bytes between successive
 /// items of the same type, including alignment padding.
 ///
+/// Note that, unlike most intrinsics, this can only be called at compile-time
+/// as backends do not have an implementation for it. The only caller (its
+/// stable counterpart) wraps this intrinsic call in a `const` block so that
+/// backends only see an evaluated constant.
+///
 /// The stabilized version of this intrinsic is [`core::mem::size_of`].
 #[rustc_nounwind]
 #[unstable(feature = "core_intrinsics", issue = "none")]
@@ -2741,6 +2746,11 @@ pub const fn size_of<T>() -> usize;
 /// it does not require an `unsafe` block.
 /// Therefore, implementations must not require the user to uphold
 /// any safety invariants.
+///
+/// Note that, unlike most intrinsics, this can only be called at compile-time
+/// as backends do not have an implementation for it. The only caller (its
+/// stable counterpart) wraps this intrinsic call in a `const` block so that
+/// backends only see an evaluated constant.
 ///
 /// The stabilized version of this intrinsic is [`core::mem::align_of`].
 #[rustc_nounwind]

--- a/src/doc/rustc/src/platform-support/windows-msvc.md
+++ b/src/doc/rustc/src/platform-support/windows-msvc.md
@@ -12,6 +12,7 @@ Windows MSVC targets.
 
 [@ChrisDenton](https://github.com/ChrisDenton)
 [@dpaoliello](https://github.com/dpaoliello)
+[@Fulgen301](https://github.com/Fulgen301)
 [@lambdageek](https://github.com/lambdageek)
 [@sivadeilra](https://github.com/sivadeilra)
 [@wesleywiser](https://github.com/wesleywiser)


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#148118 (Improve the ICE message for invalid nullary intrinsic calls)
 - rust-lang/rust#148134 (Add myself as a windows-msvc maintainer)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=148118,148134)
<!-- homu-ignore:end -->