### PR TITLE
Add `coverage` scope for controlling paths in code coverage

### DIFF
--- a/compiler/rustc_codegen_llvm/src/coverageinfo/mapgen.rs
+++ b/compiler/rustc_codegen_llvm/src/coverageinfo/mapgen.rs
@@ -128,7 +128,7 @@ impl GlobalFileTable {
         for file in all_files {
             raw_file_table.entry(file.stable_id).or_insert_with(|| {
                 file.name
-                    .for_scope(tcx.sess, RemapPathScopeComponents::MACRO)
+                    .for_scope(tcx.sess, RemapPathScopeComponents::COVERAGE)
                     .to_string_lossy()
                     .into_owned()
             });
@@ -147,7 +147,7 @@ impl GlobalFileTable {
             .sess
             .opts
             .working_dir
-            .for_scope(tcx.sess, RemapPathScopeComponents::MACRO)
+            .for_scope(tcx.sess, RemapPathScopeComponents::COVERAGE)
             .to_string_lossy();
         table.push(base_dir.as_ref());
 

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -1377,10 +1377,12 @@ bitflags::bitflags! {
         const DIAGNOSTICS = 1 << 1;
         /// Apply remappings to debug information
         const DEBUGINFO = 1 << 3;
+        /// Apply remappings to coverage information
+        const COVERAGE = 1 << 4;
 
-        /// An alias for `macro` and `debuginfo`. This ensures all paths in compiled
-        /// executables or libraries are remapped but not elsewhere.
-        const OBJECT = Self::MACRO.bits() | Self::DEBUGINFO.bits();
+        /// An alias for `macro`, `debuginfo` and `coverage`. This ensures all paths in compiled
+        /// executables, libraries and objects are remapped but not elsewhere.
+        const OBJECT = Self::MACRO.bits() | Self::DEBUGINFO.bits() | Self::COVERAGE.bits();
     }
 }
 

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -869,8 +869,7 @@ mod desc {
     pub(crate) const parse_branch_protection: &str = "a `,` separated combination of `bti`, `gcs`, `pac-ret`, (optionally with `pc`, `b-key`, `leaf` if `pac-ret` is set)";
     pub(crate) const parse_proc_macro_execution_strategy: &str =
         "one of supported execution strategies (`same-thread`, or `cross-thread`)";
-    pub(crate) const parse_remap_path_scope: &str =
-        "comma separated list of scopes: `macro`, `diagnostics`, `debuginfo`, `object`, `all`";
+    pub(crate) const parse_remap_path_scope: &str = "comma separated list of scopes: `macro`, `diagnostics`, `debuginfo`, `coverage`, `object`, `all`";
     pub(crate) const parse_inlining_threshold: &str =
         "either a boolean (`yes`, `no`, `on`, `off`, etc), or a non-negative number";
     pub(crate) const parse_llvm_module_flag: &str = "<key>:<type>:<value>:<behavior>. Type must currently be `u32`. Behavior should be one of (`error`, `warning`, `require`, `override`, `append`, `appendunique`, `max`, `min`)";
@@ -1705,6 +1704,7 @@ pub mod parse {
                     "macro" => RemapPathScopeComponents::MACRO,
                     "diagnostics" => RemapPathScopeComponents::DIAGNOSTICS,
                     "debuginfo" => RemapPathScopeComponents::DEBUGINFO,
+                    "coverage" => RemapPathScopeComponents::COVERAGE,
                     "object" => RemapPathScopeComponents::OBJECT,
                     "all" => RemapPathScopeComponents::all(),
                     _ => return false,

--- a/src/doc/unstable-book/src/compiler-flags/remap-path-scope.md
+++ b/src/doc/unstable-book/src/compiler-flags/remap-path-scope.md
@@ -10,7 +10,8 @@ This flag accepts a comma-separated list of values and may be specified multiple
 
 - `macro` - apply remappings to the expansion of `std::file!()` macro. This is where paths in embedded panic messages come from
 - `diagnostics` - apply remappings to printed compiler diagnostics
-- `debuginfo` - apply remappings to debug informations
+- `debuginfo` - apply remappings to debug information
+- `coverage` - apply remappings to coverage information
 - `object` - apply remappings to all paths in compiled executables or libraries, but not elsewhere. Currently an alias for `macro,debuginfo`.
 - `all` - an alias for all of the above, also equivalent to supplying only `--remap-path-prefix` without `--remap-path-scope`.
 

--- a/tests/coverage/remap-path-prefix.rs
+++ b/tests/coverage/remap-path-prefix.rs
@@ -1,0 +1,17 @@
+// This test makes sure that the files used in the coverage are remapped by
+// `--remap-path-prefix` and the `coverage` <- `object` scopes.
+//
+// We also test the `macro` scope to make sure it does not affect coverage.
+
+// When coverage paths are remapped, the coverage-run mode can't find source files (because
+// it doesn't know about the remapping), so it produces an empty coverage report. The empty
+// report (i.e. no `.coverage` files) helps to demonstrate that remapping was indeed performed.
+
+//@ revisions: with_remap with_coverage_scope with_object_scope with_macro_scope
+//@ compile-flags: --remap-path-prefix={{src-base}}=remapped
+//
+//@[with_coverage_scope] compile-flags: -Zremap-path-scope=coverage
+//@[with_object_scope] compile-flags: -Zremap-path-scope=object
+//@[with_macro_scope] compile-flags: -Zremap-path-scope=macro
+
+fn main() {}

--- a/tests/coverage/remap-path-prefix.with_coverage_scope.cov-map
+++ b/tests/coverage/remap-path-prefix.with_coverage_scope.cov-map
@@ -1,0 +1,10 @@
+Function name: remap_path_prefix::main
+Raw bytes (14): 0x[01, 01, 00, 02, 01, 11, 01, 00, 0a, 01, 00, 0c, 00, 0d]
+Number of files: 1
+- file 0 => remapped/remap-path-prefix.rs
+Number of expressions: 0
+Number of file 0 mappings: 2
+- Code(Counter(0)) at (prev + 17, 1) to (start + 0, 10)
+- Code(Counter(0)) at (prev + 0, 12) to (start + 0, 13)
+Highest counter ID seen: c0
+

--- a/tests/coverage/remap-path-prefix.with_macro_scope.cov-map
+++ b/tests/coverage/remap-path-prefix.with_macro_scope.cov-map
@@ -1,0 +1,10 @@
+Function name: remap_path_prefix::main
+Raw bytes (14): 0x[01, 01, 00, 02, 01, 11, 01, 00, 0a, 01, 00, 0c, 00, 0d]
+Number of files: 1
+- file 0 => $DIR/remap-path-prefix.rs
+Number of expressions: 0
+Number of file 0 mappings: 2
+- Code(Counter(0)) at (prev + 17, 1) to (start + 0, 10)
+- Code(Counter(0)) at (prev + 0, 12) to (start + 0, 13)
+Highest counter ID seen: c0
+

--- a/tests/coverage/remap-path-prefix.with_macro_scope.coverage
+++ b/tests/coverage/remap-path-prefix.with_macro_scope.coverage
@@ -1,0 +1,18 @@
+   LL|       |// This test makes sure that the files used in the coverage are remapped by
+   LL|       |// `--remap-path-prefix` and the `coverage` <- `object` scopes.
+   LL|       |//
+   LL|       |// We also test the `macro` scope to make sure it does not affect coverage.
+   LL|       |
+   LL|       |// When coverage paths are remapped, the coverage-run mode can't find source files (because
+   LL|       |// it doesn't know about the remapping), so it produces an empty coverage report. The empty
+   LL|       |// report (i.e. no `.coverage` files) helps to demonstrate that remapping was indeed performed.
+   LL|       |
+   LL|       |//@ revisions: with_remap with_coverage_scope with_object_scope with_macro_scope
+   LL|       |//@ compile-flags: --remap-path-prefix={{src-base}}=remapped
+   LL|       |//
+   LL|       |//@[with_coverage_scope] compile-flags: -Zremap-path-scope=coverage
+   LL|       |//@[with_object_scope] compile-flags: -Zremap-path-scope=object
+   LL|       |//@[with_macro_scope] compile-flags: -Zremap-path-scope=macro
+   LL|       |
+   LL|      1|fn main() {}
+

--- a/tests/coverage/remap-path-prefix.with_object_scope.cov-map
+++ b/tests/coverage/remap-path-prefix.with_object_scope.cov-map
@@ -1,0 +1,10 @@
+Function name: remap_path_prefix::main
+Raw bytes (14): 0x[01, 01, 00, 02, 01, 11, 01, 00, 0a, 01, 00, 0c, 00, 0d]
+Number of files: 1
+- file 0 => remapped/remap-path-prefix.rs
+Number of expressions: 0
+Number of file 0 mappings: 2
+- Code(Counter(0)) at (prev + 17, 1) to (start + 0, 10)
+- Code(Counter(0)) at (prev + 0, 12) to (start + 0, 13)
+Highest counter ID seen: c0
+

--- a/tests/coverage/remap-path-prefix.with_remap.cov-map
+++ b/tests/coverage/remap-path-prefix.with_remap.cov-map
@@ -1,0 +1,10 @@
+Function name: remap_path_prefix::main
+Raw bytes (14): 0x[01, 01, 00, 02, 01, 11, 01, 00, 0a, 01, 00, 0c, 00, 0d]
+Number of files: 1
+- file 0 => remapped/remap-path-prefix.rs
+Number of expressions: 0
+Number of file 0 mappings: 2
+- Code(Counter(0)) at (prev + 17, 1) to (start + 0, 10)
+- Code(Counter(0)) at (prev + 0, 12) to (start + 0, 13)
+Highest counter ID seen: c0
+


### PR DESCRIPTION
This PR adds a `coverage` scope (for `-Zremap-path-scope`) for controlling if the paths that ends up in code coverage output should be remapped or not.

Currently code coverage use the `macro` scope which is not a appropriate scope for them.

Found during the stabilization of `-Zremap-path-scope` https://github.com/rust-lang/rust/pull/147611#issuecomment-3396210043 and was asked to be in a separate PR in https://github.com/rust-lang/rust/pull/147611#issuecomment-3448455252.

r? compiler
