### PR TITLE
impl TrustedLen for all RangeFrom<A>, IterRangeFrom<A>

### DIFF
--- a/library/core/src/iter/range.rs
+++ b/library/core/src/iter/range.rs
@@ -1031,9 +1031,9 @@ impl<A: Step> Iterator for ops::RangeFrom<A> {
     }
 }
 
-// Safety: See above implementation for `ops::Range<A>`
+// Safety: RangeFrom::next() cannot return None
 #[unstable(feature = "trusted_len", issue = "37572")]
-unsafe impl<A: TrustedStep> TrustedLen for ops::RangeFrom<A> {}
+unsafe impl<A: Step> TrustedLen for ops::RangeFrom<A> {}
 
 #[stable(feature = "fused", since = "1.26.0")]
 impl<A: Step> FusedIterator for ops::RangeFrom<A> {}

--- a/library/core/src/range/iter.rs
+++ b/library/core/src/range/iter.rs
@@ -322,8 +322,9 @@ impl<A: Step> Iterator for IterRangeFrom<A> {
     }
 }
 
+// Safety: RangeFrom::next() cannot return None
 #[unstable(feature = "trusted_len", issue = "37572")]
-unsafe impl<A: TrustedStep> TrustedLen for IterRangeFrom<A> {}
+unsafe impl<A: Step> TrustedLen for IterRangeFrom<A> {}
 
 #[unstable(feature = "new_range_api", issue = "125687")]
 impl<A: Step> FusedIterator for IterRangeFrom<A> {}


### PR DESCRIPTION
Remove the `A: TrustedStep` requirement for `std::ops::RangeFrom<A>` and `std::range::IterRangeFrom<A>` to implement `TrustedLen`.

These iterators cannot return `None`, so returning `(usize::MAX, None)` from `size_hint()` is always correct