### PR TITLE
Fix duplicate 'the the' typos in comments

### DIFF
--- a/compiler/rustc_hir_typeck/src/writeback.rs
+++ b/compiler/rustc_hir_typeck/src/writeback.rs
@@ -798,7 +798,7 @@ impl<'cx, 'tcx> WritebackCx<'cx, 'tcx> {
                 } else {
                     let predicate = self.tcx().erase_and_anonymize_regions(predicate);
                     if cause.has_infer() || cause.has_placeholders() {
-                        // We can't use the the obligation cause as it references
+                        // We can't use the obligation cause as it references
                         // information local to this query.
                         cause = self.fcx.misc(cause.span);
                     }

--- a/compiler/rustc_type_ir/src/search_graph/mod.rs
+++ b/compiler/rustc_type_ir/src/search_graph/mod.rs
@@ -924,7 +924,7 @@ enum RebaseReason<X: Cx> {
     ///
     /// This either happens in the first evaluation step for the cycle head.
     /// In this case the used provisional result depends on the cycle `PathKind`.
-    /// We store this path kind to check whether the the provisional cache entry
+    /// We store this path kind to check whether the provisional cache entry
     /// we're rebasing relied on the same cycles.
     ///
     /// In later iterations cycles always return `stack_entry.provisional_result`


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
Fix duplicate 'the the' typos in comments 