### PR TITLE
Remove redundant .to_string().as_str() calls

### DIFF
--- a/compiler/rustc_builtin_macros/src/autodiff.rs
+++ b/compiler/rustc_builtin_macros/src/autodiff.rs
@@ -49,7 +49,7 @@ mod llvm_enzyme {
             match l.kind {
                 ast::LitKind::Int(val, _) => {
                     // get an Ident from a lit
-                    return rustc_span::Ident::from_str(val.get().to_string().as_str());
+                    return rustc_span::Ident::from_str(&val.get().to_string());
                 }
                 _ => {}
             }

--- a/compiler/rustc_codegen_llvm/src/context.rs
+++ b/compiler/rustc_codegen_llvm/src/context.rs
@@ -216,7 +216,7 @@ pub(crate) unsafe fn create_module<'ll>(
 
         if target_data_layout != llvm_data_layout {
             tcx.dcx().emit_err(crate::errors::MismatchedDataLayout {
-                rustc_target: sess.opts.target_triple.to_string().as_str(),
+                rustc_target: &sess.opts.target_triple.to_string(),
                 rustc_layout: target_data_layout.as_str(),
                 llvm_target: sess.target.llvm_target.borrow(),
                 llvm_layout: llvm_data_layout,


### PR DESCRIPTION
The pattern .to_string().as_str() creates a temporary String that is immediately borrowed and then dropped, which is inefficient. Replace with &.to_string() for cleaner, more idiomatic code.

Changes:
- compiler/rustc_builtin_macros/src/autodiff.rs: Simplify identifier creation
- compiler/rustc_codegen_llvm/src/context.rs: Simplify error message formatting

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
