### PR TITLE
ci: loongarch64: use medium code model to avoid relocation overflows

### DIFF
--- a/src/ci/docker/host-x86_64/dist-loongarch64-linux/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-loongarch64-linux/Dockerfile
@@ -21,7 +21,9 @@ ENV PATH=$PATH:/x-tools/loongarch64-unknown-linux-gnu/bin
 
 ENV CC_loongarch64_unknown_linux_gnu=loongarch64-unknown-linux-gnu-gcc \
     AR_loongarch64_unknown_linux_gnu=loongarch64-unknown-linux-gnu-ar \
-    CXX_loongarch64_unknown_linux_gnu=loongarch64-unknown-linux-gnu-g++
+    CXX_loongarch64_unknown_linux_gnu=loongarch64-unknown-linux-gnu-g++ \
+    CFLAGS_loongarch64_unknown_linux_gnu="-mcmodel=medium" \
+    CXXFLAGS_loongarch64_unknown_linux_gnu="-mcmodel=medium"
 
 # We re-use the Linux toolchain for bare-metal, because upstream bare-metal
 # target support for LoongArch is only available from GCC 14+.

--- a/src/ci/docker/host-x86_64/dist-loongarch64-musl/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-loongarch64-musl/Dockerfile
@@ -21,7 +21,9 @@ ENV PATH=$PATH:/x-tools/loongarch64-unknown-linux-musl/bin
 
 ENV CC_loongarch64_unknown_linux_musl=loongarch64-unknown-linux-musl-gcc \
     AR_loongarch64_unknown_linux_musl=loongarch64-unknown-linux-musl-ar \
-    CXX_loongarch64_unknown_linux_musl=loongarch64-unknown-linux-musl-g++
+    CXX_loongarch64_unknown_linux_musl=loongarch64-unknown-linux-musl-g++ \
+    CFLAGS_loongarch64_unknown_linux_musl="-mcmodel=medium" \
+    CXXFLAGS_loongarch64_unknown_linux_musl="-mcmodel=medium"
 
 ENV HOSTS=loongarch64-unknown-linux-musl
 


### PR DESCRIPTION
The LoongArch C/C++ cross toolchain defaults to the `normal` code model, which can cause relocation overflows when linking LLVM after upgrading to verion 22. This change uses the `medium`code model for `loongarch64-linux-gnu` and `loongarch64-linux-musl` builds to avoid these linking errors.
