### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/compiler/rustc_hir_typeck/src/writeback.rs
+++ b/compiler/rustc_hir_typeck/src/writeback.rs
@@ -798,7 +798,7 @@ impl<'cx, 'tcx> WritebackCx<'cx, 'tcx> {
                 } else {
                     let predicate = self.tcx().erase_and_anonymize_regions(predicate);
                     if cause.has_infer() || cause.has_placeholders() {
-                        // We can't use the the obligation cause as it references
+                        // We can't use the obligation cause as it references
                         // information local to this query.
                         cause = self.fcx.misc(cause.span);
                     }

--- a/compiler/rustc_trait_selection/src/traits/effects.rs
+++ b/compiler/rustc_trait_selection/src/traits/effects.rs
@@ -8,7 +8,7 @@ use rustc_middle::span_bug;
 use rustc_middle::traits::query::NoSolution;
 use rustc_middle::ty::elaborate::elaborate;
 use rustc_middle::ty::fast_reject::DeepRejectCtxt;
-use rustc_middle::ty::{self, TypingMode};
+use rustc_middle::ty::{self, Ty, TypingMode};
 use thin_vec::{ThinVec, thin_vec};
 
 use super::SelectionContext;
@@ -303,12 +303,104 @@ fn evaluate_host_effect_from_builtin_impls<'tcx>(
     obligation: &HostEffectObligation<'tcx>,
 ) -> Result<ThinVec<PredicateObligation<'tcx>>, EvaluationFailure> {
     match selcx.tcx().as_lang_item(obligation.predicate.def_id()) {
+        Some(LangItem::Copy | LangItem::Clone) => {
+            evaluate_host_effect_for_copy_clone_goal(selcx, obligation)
+        }
         Some(LangItem::Destruct) => evaluate_host_effect_for_destruct_goal(selcx, obligation),
         Some(LangItem::Fn | LangItem::FnMut | LangItem::FnOnce) => {
             evaluate_host_effect_for_fn_goal(selcx, obligation)
         }
         _ => Err(EvaluationFailure::NoSolution),
     }
+}
+
+fn evaluate_host_effect_for_copy_clone_goal<'tcx>(
+    selcx: &mut SelectionContext<'_, 'tcx>,
+    obligation: &HostEffectObligation<'tcx>,
+) -> Result<ThinVec<PredicateObligation<'tcx>>, EvaluationFailure> {
+    let tcx = selcx.tcx();
+    let self_ty = obligation.predicate.self_ty();
+    let constituent_tys = match *self_ty.kind() {
+        // impl Copy/Clone for FnDef, FnPtr
+        ty::FnDef(..) | ty::FnPtr(..) | ty::Error(_) => Ok(ty::Binder::dummy(vec![])),
+
+        // Implementations are provided in core
+        ty::Uint(_)
+        | ty::Int(_)
+        | ty::Infer(ty::IntVar(_) | ty::FloatVar(_))
+        | ty::Bool
+        | ty::Float(_)
+        | ty::Char
+        | ty::RawPtr(..)
+        | ty::Never
+        | ty::Ref(_, _, ty::Mutability::Not)
+        | ty::Array(..) => Err(EvaluationFailure::NoSolution),
+
+        // Cannot implement in core, as we can't be generic over patterns yet,
+        // so we'd have to list all patterns and type combinations.
+        ty::Pat(ty, ..) => Ok(ty::Binder::dummy(vec![ty])),
+
+        ty::Dynamic(..)
+        | ty::Str
+        | ty::Slice(_)
+        | ty::Foreign(..)
+        | ty::Ref(_, _, ty::Mutability::Mut)
+        | ty::Adt(_, _)
+        | ty::Alias(_, _)
+        | ty::Param(_)
+        | ty::Placeholder(..) => Err(EvaluationFailure::NoSolution),
+
+        ty::Bound(..)
+        | ty::Infer(ty::TyVar(_) | ty::FreshTy(_) | ty::FreshIntTy(_) | ty::FreshFloatTy(_)) => {
+            panic!("unexpected type `{self_ty:?}`")
+        }
+
+        // impl Copy/Clone for (T1, T2, .., Tn) where T1: Copy/Clone, T2: Copy/Clone, .. Tn: Copy/Clone
+        ty::Tuple(tys) => Ok(ty::Binder::dummy(tys.to_vec())),
+
+        // impl Copy/Clone for Closure where Self::TupledUpvars: Copy/Clone
+        ty::Closure(_, args) => Ok(ty::Binder::dummy(vec![args.as_closure().tupled_upvars_ty()])),
+
+        // impl Copy/Clone for CoroutineClosure where Self::TupledUpvars: Copy/Clone
+        ty::CoroutineClosure(_, args) => {
+            Ok(ty::Binder::dummy(vec![args.as_coroutine_closure().tupled_upvars_ty()]))
+        }
+
+        // only when `coroutine_clone` is enabled and the coroutine is movable
+        // impl Copy/Clone for Coroutine where T: Copy/Clone forall T in (upvars, witnesses)
+        ty::Coroutine(def_id, args) => match tcx.coroutine_movability(def_id) {
+            ty::Movability::Static => Err(EvaluationFailure::NoSolution),
+            ty::Movability::Movable => {
+                if tcx.features().coroutine_clone() {
+                    Ok(ty::Binder::dummy(vec![
+                        args.as_coroutine().tupled_upvars_ty(),
+                        Ty::new_coroutine_witness_for_coroutine(tcx, def_id, args),
+                    ]))
+                } else {
+                    Err(EvaluationFailure::NoSolution)
+                }
+            }
+        },
+
+        ty::UnsafeBinder(_) => Err(EvaluationFailure::NoSolution),
+
+        // impl Copy/Clone for CoroutineWitness where T: Copy/Clone forall T in coroutine_hidden_types
+        ty::CoroutineWitness(def_id, args) => Ok(tcx
+            .coroutine_hidden_types(def_id)
+            .instantiate(tcx, args)
+            .map_bound(|bound| bound.types.to_vec())),
+    }?;
+
+    Ok(constituent_tys
+        .iter()
+        .map(|ty| {
+            obligation.with(
+                tcx,
+                ty.map_bound(|ty| ty::TraitRef::new(tcx, obligation.predicate.def_id(), [ty]))
+                    .to_host_effect_clause(tcx, obligation.predicate.constness),
+            )
+        })
+        .collect())
 }
 
 // NOTE: Keep this in sync with `const_conditions_for_destruct` in the new solver.

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -2877,7 +2877,7 @@ impl<'tcx> SelectionContext<'_, 'tcx> {
         obligations
     }
 
-    fn should_stall_coroutine(&self, def_id: DefId) -> bool {
+    pub(super) fn should_stall_coroutine(&self, def_id: DefId) -> bool {
         match self.infcx.typing_mode() {
             TypingMode::Analysis { defining_opaque_types_and_generators: stalled_generators } => {
                 def_id.as_local().is_some_and(|def_id| stalled_generators.contains(&def_id))

--- a/compiler/rustc_type_ir/src/predicate.rs
+++ b/compiler/rustc_type_ir/src/predicate.rs
@@ -121,7 +121,7 @@ impl<I: Interner> ty::Binder<I, TraitRef<I>> {
     }
 
     pub fn to_host_effect_clause(self, cx: I, constness: BoundConstness) -> I::Clause {
-        self.map_bound(|trait_ref: TraitRef<I>| {
+        self.map_bound(|trait_ref| {
             ty::ClauseKind::HostEffect(HostEffectPredicate { trait_ref, constness })
         })
         .upcast(cx)

--- a/compiler/rustc_type_ir/src/predicate.rs
+++ b/compiler/rustc_type_ir/src/predicate.rs
@@ -121,7 +121,7 @@ impl<I: Interner> ty::Binder<I, TraitRef<I>> {
     }
 
     pub fn to_host_effect_clause(self, cx: I, constness: BoundConstness) -> I::Clause {
-        self.map_bound(|trait_ref| {
+        self.map_bound(|trait_ref: TraitRef<I>| {
             ty::ClauseKind::HostEffect(HostEffectPredicate { trait_ref, constness })
         })
         .upcast(cx)

--- a/compiler/rustc_type_ir/src/search_graph/mod.rs
+++ b/compiler/rustc_type_ir/src/search_graph/mod.rs
@@ -924,7 +924,7 @@ enum RebaseReason<X: Cx> {
     ///
     /// This either happens in the first evaluation step for the cycle head.
     /// In this case the used provisional result depends on the cycle `PathKind`.
-    /// We store this path kind to check whether the the provisional cache entry
+    /// We store this path kind to check whether the provisional cache entry
     /// we're rebasing relied on the same cycles.
     ///
     /// In later iterations cycles always return `stack_entry.provisional_result`

--- a/library/core/src/hint.rs
+++ b/library/core/src/hint.rs
@@ -4,6 +4,7 @@
 //!
 //! Hints may be compile time or runtime.
 
+use crate::marker::Destruct;
 use crate::mem::MaybeUninit;
 use crate::{intrinsics, ub_checks};
 
@@ -771,7 +772,11 @@ pub const fn cold_path() {
 /// ```
 #[inline(always)]
 #[stable(feature = "select_unpredictable", since = "1.88.0")]
-pub fn select_unpredictable<T>(condition: bool, true_val: T, false_val: T) -> T {
+#[rustc_const_unstable(feature = "const_select_unpredictable", issue = "145938")]
+pub const fn select_unpredictable<T>(condition: bool, true_val: T, false_val: T) -> T
+where
+    T: [const] Destruct,
+{
     // FIXME(https://github.com/rust-lang/unsafe-code-guidelines/issues/245):
     // Change this to use ManuallyDrop instead.
     let mut true_val = MaybeUninit::new(true_val);

--- a/library/core/src/intrinsics/mod.rs
+++ b/library/core/src/intrinsics/mod.rs
@@ -55,7 +55,7 @@
 #![allow(missing_docs)]
 
 use crate::ffi::va_list::{VaArgSafe, VaListImpl};
-use crate::marker::{ConstParamTy, DiscriminantKind, PointeeSized, Tuple};
+use crate::marker::{ConstParamTy, Destruct, DiscriminantKind, PointeeSized, Tuple};
 use crate::ptr;
 
 mod bounds;
@@ -477,11 +477,15 @@ pub const fn unlikely(b: bool) -> bool {
 /// However unlike the public form, the intrinsic will not drop the value that
 /// is not selected.
 #[unstable(feature = "core_intrinsics", issue = "none")]
+#[rustc_const_unstable(feature = "const_select_unpredictable", issue = "145938")]
 #[rustc_intrinsic]
 #[rustc_nounwind]
 #[miri::intrinsic_fallback_is_spec]
 #[inline]
-pub fn select_unpredictable<T>(b: bool, true_val: T, false_val: T) -> T {
+pub const fn select_unpredictable<T>(b: bool, true_val: T, false_val: T) -> T
+where
+    T: [const] Destruct,
+{
     if b { true_val } else { false_val }
 }
 

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -106,6 +106,7 @@
 #![feature(const_cmp)]
 #![feature(const_destruct)]
 #![feature(const_eval_select)]
+#![feature(const_select_unpredictable)]
 #![feature(core_intrinsics)]
 #![feature(coverage_attribute)]
 #![feature(disjoint_bitor)]

--- a/library/coretests/tests/hint.rs
+++ b/library/coretests/tests/hint.rs
@@ -1,25 +1,33 @@
 #[test]
 fn select_unpredictable_drop() {
     use core::cell::Cell;
+
     struct X<'a>(&'a Cell<bool>);
-    impl Drop for X<'_> {
+    impl const Drop for X<'_> {
         fn drop(&mut self) {
             self.0.set(true);
         }
     }
 
-    let a_dropped = Cell::new(false);
-    let b_dropped = Cell::new(false);
-    let a = X(&a_dropped);
-    let b = X(&b_dropped);
-    assert!(!a_dropped.get());
-    assert!(!b_dropped.get());
-    let selected = core::hint::select_unpredictable(core::hint::black_box(true), a, b);
-    assert!(!a_dropped.get());
-    assert!(b_dropped.get());
-    drop(selected);
-    assert!(a_dropped.get());
-    assert!(b_dropped.get());
+    const fn do_test() {
+        let a_dropped = Cell::new(false);
+        let b_dropped = Cell::new(false);
+        let a = X(&a_dropped);
+        let b = X(&b_dropped);
+        assert!(!a_dropped.get());
+        assert!(!b_dropped.get());
+        let selected = core::hint::select_unpredictable(core::hint::black_box(true), a, b);
+        assert!(!a_dropped.get());
+        assert!(b_dropped.get());
+        drop(selected);
+        assert!(a_dropped.get());
+        assert!(b_dropped.get());
+    }
+
+    do_test();
+    const {
+        do_test();
+    }
 }
 
 #[test]

--- a/library/coretests/tests/lib.rs
+++ b/library/coretests/tests/lib.rs
@@ -27,6 +27,7 @@
 #![feature(const_option_ops)]
 #![feature(const_ref_cell)]
 #![feature(const_result_trait_fn)]
+#![feature(const_select_unpredictable)]
 #![feature(const_trait_impl)]
 #![feature(control_flow_ok)]
 #![feature(core_float_math)]

--- a/tests/ui/resolve/private-constructor-self-issue-147343.rs
+++ b/tests/ui/resolve/private-constructor-self-issue-147343.rs
@@ -1,0 +1,16 @@
+mod m {
+    pub struct S(crate::P);
+}
+
+use m::S;
+
+struct P;
+
+impl P {
+    fn foo(self) {
+        S(self);
+        //~^ ERROR cannot initialize a tuple struct which contains private fields [E0423]
+    }
+}
+
+fn main() {}

--- a/tests/ui/resolve/private-constructor-self-issue-147343.stderr
+++ b/tests/ui/resolve/private-constructor-self-issue-147343.stderr
@@ -1,0 +1,11 @@
+error[E0423]: cannot initialize a tuple struct which contains private fields
+  --> $DIR/private-constructor-self-issue-147343.rs:11:9
+   |
+LL |         S(self);
+   |         ^
+   |
+   = note: constructor is not visible here due to private fields
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0423`.

--- a/tests/ui/traits/const-traits/const-traits-alloc.rs
+++ b/tests/ui/traits/const-traits/const-traits-alloc.rs
@@ -1,4 +1,4 @@
-//@ run-pass
+//@ check-pass
 #![feature(const_trait_impl, const_default)]
 #![allow(dead_code)]
 // alloc::string

--- a/tests/ui/traits/const-traits/const-traits-core.rs
+++ b/tests/ui/traits/const-traits/const-traits-core.rs
@@ -1,6 +1,13 @@
-//@ run-pass
+//@ check-pass
 #![feature(
-    const_trait_impl, const_default, ptr_alignment_type, ascii_char, f16, f128, sync_unsafe_cell,
+    const_clone,
+    const_default,
+    const_trait_impl,
+    ptr_alignment_type,
+    ascii_char,
+    f16,
+    f128,
+    sync_unsafe_cell,
 )]
 #![allow(dead_code)]
 // core::default
@@ -42,5 +49,9 @@ const CELL: std::cell::Cell<()> = Default::default();
 const REF_CELL: std::cell::RefCell<()> = Default::default();
 const UNSAFE_CELL: std::cell::UnsafeCell<()> = Default::default();
 const SYNC_UNSAFE_CELL: std::cell::SyncUnsafeCell<()> = Default::default();
+
+// `Clone` for tuples
+const BUILTIN_CLONE: () = ().clone();
+const BUILTIN_CLONE_2: (u32, i32) = (42, 100).clone();
 
 fn main() {}


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#145939 (const `select_unpredictable`)
 - rust-lang/rust#147478 (More intuitive error when using self to instantiate tuple struct with private field)
 - rust-lang/rust#147866 (Add built-in `const` impls for `Clone` and `Copy`)
 - rust-lang/rust#148153 (Fix duplicate 'the the' typos in comments)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=145939,147478,147866,148153)
<!-- homu-ignore:end -->