### PR TITLE
Fix typos: duplicate words in comments

### DIFF
--- a/compiler/rustc_ast_pretty/src/pp.rs
+++ b/compiler/rustc_ast_pretty/src/pp.rs
@@ -298,7 +298,7 @@ impl Printer {
         }
     }
 
-    // This is is where `BoxMarker`s are produced.
+    // This is where `BoxMarker`s are produced.
     fn scan_begin(&mut self, token: BeginToken) -> BoxMarker {
         if self.scan_stack.is_empty() {
             self.left_total = 1;
@@ -310,7 +310,7 @@ impl Printer {
         BoxMarker
     }
 
-    // This is is where `BoxMarker`s are consumed.
+    // This is where `BoxMarker`s are consumed.
     fn scan_end(&mut self, b: BoxMarker) {
         if self.scan_stack.is_empty() {
             self.print_end();

--- a/compiler/rustc_const_eval/src/interpret/util.rs
+++ b/compiler/rustc_const_eval/src/interpret/util.rs
@@ -121,7 +121,7 @@ impl EnteredTraceSpan for tracing::span::EnteredSpan {
 /// ### `tracing_separate_thread` parameter
 ///
 /// This macro was introduced to obtain better traces of Miri without impacting release performance.
-/// Miri saves traces using the the `tracing_chrome` `tracing::Layer` so that they can be visualized
+/// Miri saves traces using the `tracing_chrome` `tracing::Layer` so that they can be visualized
 /// in <https://ui.perfetto.dev>. To instruct `tracing_chrome` to put some spans on a separate trace
 /// thread/line than other spans when viewed in <https://ui.perfetto.dev>, you can pass
 /// `tracing_separate_thread = tracing::field::Empty` to the tracing macros. This is useful to

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -3006,7 +3006,7 @@ impl<'test> TestCx<'test> {
                         self.delete_file(&examined_path);
                     }
                     // If we want them to be the same, but they are different, then error.
-                    // We do this wether we bless or not
+                    // We do this whether we bless or not
                     (_, true, false) => {
                         self.fatal_proc_rec(
                             &format!("`{}` should not have different output from base test!", kind),


### PR DESCRIPTION
- Fix 'the the' → 'the' in rustc_const_eval
- Fix 'wether' → 'whether' in compiletest
- Fix 'is is' → 'is' in rustc_ast_pretty (2 instances)

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
