### PR TITLE
[rustdoc] Include attribute and derive macros when filtering on "macros"

### DIFF
--- a/src/librustdoc/html/static/js/search.js
+++ b/src/librustdoc/html/static/js/search.js
@@ -3904,6 +3904,8 @@ class DocSearch {
                     return name === "primitive" || name === "associatedtype";
                 case "trait":
                     return name === "traitalias";
+                case "macro":
+                    return name === "attr" || name === "derive";
             }
 
             // No match

--- a/tests/rustdoc-js-std/filter-macro-attr-derive.js
+++ b/tests/rustdoc-js-std/filter-macro-attr-derive.js
@@ -1,0 +1,9 @@
+// This test ensures that filtering on "macro" will also include attribute and derive
+// macros.
+
+const EXPECTED = {
+    'query': 'macro:debug',
+    'others': [
+        { 'path': 'std::fmt', 'name': 'Debug', 'href': '../std/fmt/derive.Debug.html' },
+    ],
+};


### PR DESCRIPTION
As discussed [here](https://github.com/rust-lang/rust/pull/147909), some filters should have been "grouped". This PR allows attribute and derive macros to match the `macro` filter.

I'll wait for https://github.com/rust-lang/rust/pull/148005 to add more tests as it would require a proc-macro library for now.

r? @notriddle 