### PR TITLE
Allow codegen backends to indicate which crate types they support

### DIFF
--- a/compiler/rustc_codegen_ssa/src/traits/backend.rs
+++ b/compiler/rustc_codegen_ssa/src/traits/backend.rs
@@ -10,7 +10,7 @@ use rustc_middle::dep_graph::{WorkProduct, WorkProductId};
 use rustc_middle::ty::TyCtxt;
 use rustc_middle::util::Providers;
 use rustc_session::Session;
-use rustc_session::config::{self, OutputFilenames, PrintRequest};
+use rustc_session::config::{self, CrateType, OutputFilenames, PrintRequest};
 use rustc_span::Symbol;
 
 use super::CodegenObject;
@@ -60,6 +60,18 @@ pub trait CodegenBackend {
             has_reliable_f128: true,
             has_reliable_f128_math: true,
         }
+    }
+
+    fn supported_crate_types(&self, _sess: &Session) -> Vec<CrateType> {
+        vec![
+            CrateType::Executable,
+            CrateType::Dylib,
+            CrateType::Rlib,
+            CrateType::Staticlib,
+            CrateType::Cdylib,
+            CrateType::ProcMacro,
+            CrateType::Sdylib,
+        ]
     }
 
     fn print_passes(&self) {}

--- a/compiler/rustc_driver_impl/src/lib.rs
+++ b/compiler/rustc_driver_impl/src/lib.rs
@@ -686,7 +686,8 @@ fn print_crate_info(
                 };
                 let t_outputs = rustc_interface::util::build_output_filenames(attrs, sess);
                 let crate_name = passes::get_crate_name(sess, attrs);
-                let crate_types = collect_crate_types(sess, attrs);
+                let crate_types =
+                    collect_crate_types(sess, &codegen_backend.supported_crate_types(sess), attrs);
                 for &style in &crate_types {
                     let fname = rustc_session::output::filename_for_input(
                         sess, style, crate_name, &t_outputs,

--- a/compiler/rustc_incremental/src/persist/load.rs
+++ b/compiler/rustc_incremental/src/persist/load.rs
@@ -10,8 +10,8 @@ use rustc_middle::dep_graph::{DepGraph, DepsType, SerializedDepGraph, WorkProduc
 use rustc_middle::query::on_disk_cache::OnDiskCache;
 use rustc_serialize::Decodable;
 use rustc_serialize::opaque::MemDecoder;
-use rustc_session::Session;
 use rustc_session::config::IncrementalStateAssertion;
+use rustc_session::{Session, StableCrateId};
 use rustc_span::Symbol;
 use tracing::{debug, warn};
 
@@ -208,9 +208,14 @@ pub fn load_query_result_cache(sess: &Session) -> Option<OnDiskCache> {
 
 /// Setups the dependency graph by loading an existing graph from disk and set up streaming of a
 /// new graph to an incremental session directory.
-pub fn setup_dep_graph(sess: &Session, crate_name: Symbol, deps: &DepsType) -> DepGraph {
+pub fn setup_dep_graph(
+    sess: &Session,
+    crate_name: Symbol,
+    stable_crate_id: StableCrateId,
+    deps: &DepsType,
+) -> DepGraph {
     // `load_dep_graph` can only be called after `prepare_session_directory`.
-    prepare_session_directory(sess, crate_name);
+    prepare_session_directory(sess, crate_name, stable_crate_id);
 
     let res = sess.opts.build_dep_graph().then(|| load_dep_graph(sess, deps));
 

--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -936,7 +936,7 @@ pub fn create_and_enter_global_ctxt<T, F: for<'tcx> FnOnce(TyCtxt<'tcx>) -> T>(
     let outputs = util::build_output_filenames(&pre_configured_attrs, sess);
 
     let dep_type = DepsType { dep_names: rustc_query_impl::dep_kind_names() };
-    let dep_graph = setup_dep_graph(sess, crate_name, &dep_type);
+    let dep_graph = setup_dep_graph(sess, crate_name, stable_crate_id, &dep_type);
 
     let cstore =
         FreezeLock::new(Box::new(CStore::new(compiler.codegen_backend.metadata_loader())) as _);

--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -925,7 +925,11 @@ pub fn create_and_enter_global_ctxt<T, F: for<'tcx> FnOnce(TyCtxt<'tcx>) -> T>(
     let pre_configured_attrs = rustc_expand::config::pre_configure_attrs(sess, &krate.attrs);
 
     let crate_name = get_crate_name(sess, &pre_configured_attrs);
-    let crate_types = collect_crate_types(sess, &pre_configured_attrs);
+    let crate_types = collect_crate_types(
+        sess,
+        &compiler.codegen_backend.supported_crate_types(sess),
+        &pre_configured_attrs,
+    );
     let stable_crate_id = StableCrateId::new(
         crate_name,
         crate_types.contains(&CrateType::Executable),

--- a/compiler/rustc_interface/src/util.rs
+++ b/compiler/rustc_interface/src/util.rs
@@ -388,17 +388,16 @@ impl CodegenBackend for DummyCodegenBackend {
     ) {
         // JUSTIFICATION: TyCtxt no longer available here
         #[allow(rustc::bad_opt_access)]
-        if codegen_results
+        if let Some(&crate_type) = codegen_results
             .crate_info
             .crate_types
             .iter()
-            .any(|&crate_type| crate_type != CrateType::Rlib)
+            .find(|&&crate_type| crate_type != CrateType::Rlib)
         {
             #[allow(rustc::untranslatable_diagnostic)]
             #[allow(rustc::diagnostic_outside_of_impl)]
             sess.dcx().fatal(format!(
-                "crate type {} not supported by the dummy codegen backend",
-                codegen_results.crate_info.crate_types[0],
+                "crate type {crate_type} not supported by the dummy codegen backend"
             ));
         }
 

--- a/compiler/rustc_interface/src/util.rs
+++ b/compiler/rustc_interface/src/util.rs
@@ -354,6 +354,14 @@ impl CodegenBackend for DummyCodegenBackend {
         "dummy"
     }
 
+    fn supported_crate_types(&self, _sess: &Session) -> Vec<CrateType> {
+        // This includes bin despite failing on the link step to ensure that you
+        // can still get the frontend handling for binaries. For all library
+        // like crate types cargo will fallback to rlib unless you specifically
+        // say that only a different crate type must be used.
+        vec![CrateType::Rlib, CrateType::Executable]
+    }
+
     fn codegen_crate<'tcx>(&self, tcx: TyCtxt<'tcx>) -> Box<dyn Any> {
         Box::new(CodegenResults {
             modules: vec![],
@@ -380,12 +388,17 @@ impl CodegenBackend for DummyCodegenBackend {
     ) {
         // JUSTIFICATION: TyCtxt no longer available here
         #[allow(rustc::bad_opt_access)]
-        if sess.opts.crate_types.iter().any(|&crate_type| crate_type != CrateType::Rlib) {
+        if codegen_results
+            .crate_info
+            .crate_types
+            .iter()
+            .any(|&crate_type| crate_type != CrateType::Rlib)
+        {
             #[allow(rustc::untranslatable_diagnostic)]
             #[allow(rustc::diagnostic_outside_of_impl)]
             sess.dcx().fatal(format!(
                 "crate type {} not supported by the dummy codegen backend",
-                sess.opts.crate_types[0],
+                codegen_results.crate_info.crate_types[0],
             ));
         }
 


### PR DESCRIPTION
This way cargo will drop the unsupported crate types for crates that
specify multiple crate types.

This is a prerequisite for https://github.com/rust-lang/miri/pull/4648.