### PR TITLE
rustdoc: remove `--emit=unversioned-shared-resources`

### DIFF
--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -311,7 +311,6 @@ pub(crate) enum ModuleSorting {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) enum EmitType {
-    Unversioned,
     Toolchain,
     InvocationSpecific,
     DepInfo(Option<OutFileName>),
@@ -322,7 +321,6 @@ impl FromStr for EmitType {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "unversioned-shared-resources" => Ok(Self::Unversioned),
             "toolchain-shared-resources" => Ok(Self::Toolchain),
             "invocation-specific" => Ok(Self::InvocationSpecific),
             "dep-info" => Ok(Self::DepInfo(None)),

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -567,7 +567,7 @@ fn opts() -> Vec<RustcOptGroup> {
             "",
             "emit",
             "Comma separated list of types of output for rustdoc to emit",
-            "[unversioned-shared-resources,toolchain-shared-resources,invocation-specific,dep-info]",
+            "[toolchain-shared-resources,invocation-specific,dep-info]",
         ),
         opt(Unstable, FlagMulti, "", "no-run", "Compile doctests without running them", ""),
         opt(

--- a/tests/run-make/emit-shared-files/rmake.rs
+++ b/tests/run-make/emit-shared-files/rmake.rs
@@ -68,7 +68,7 @@ fn main() {
 
     rustdoc()
         .arg("-Zunstable-options")
-        .arg("--emit=toolchain-shared-resources,unversioned-shared-resources")
+        .arg("--emit=toolchain-shared-resources")
         .out_dir("all-shared")
         .arg("--resource-suffix=-xxx")
         .args(&["--extend-css", "z.css"])

--- a/tests/run-make/rustdoc-default-output/output-default.stdout
+++ b/tests/run-make/rustdoc-default-output/output-default.stdout
@@ -150,7 +150,7 @@ Options:
         --generate-redirect-map 
                         Generate JSON file at the top level instead of
                         generating HTML redirection files
-        --emit [unversioned-shared-resources,toolchain-shared-resources,invocation-specific,dep-info]
+        --emit [toolchain-shared-resources,invocation-specific,dep-info]
                         Comma separated list of types of output for rustdoc to
                         emit
         --no-run        Compile doctests without running them


### PR DESCRIPTION
This option hasn't done anything for a long time, and can be removed. ~~I've kept a shim in place to avoid breaking docs.rs, but the option no longer does anything.~~

Using git-blame, I tracked this option down to
f77ebd4ffaea7fc5af49425cafefe141e7458cc3, the commit that introduced EmitType in the first place. It was used with SharedResource::Unversioned, which no longer exists since f9e1f6ffdf03ec33cb29e20c88fc7bcc938c7f42 removed them.

CC https://github.com/rust-lang/rust/pull/146220
Part of https://github.com/rust-lang/rust/issues/83784