### PR TITLE
Implement create_dir_all() to operate iteratively instead of recursively

### DIFF
--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -3329,7 +3329,9 @@ impl DirBuilder {
     }
 
     fn create_dir_all(&self, path: &Path) -> io::Result<()> {
-        if path == Path::new("") {
+        // if path's parent is None, it is "/" path, which should
+        // return Ok immediately
+        if path == Path::new("") || path.parent() == None {
             return Ok(());
         }
 
@@ -3340,7 +3342,7 @@ impl DirBuilder {
             // for relative paths like "foo/bar", the parent of
             // "foo" will be "" which there's no need to invoke
             // a mkdir syscall on
-            if ancestor == Path::new("") {
+            if ancestor == Path::new("") || ancestor.parent() == None {
                 break;
             }
 

--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -3333,26 +3333,42 @@ impl DirBuilder {
             return Ok(());
         }
 
-        match self.inner.mkdir(path) {
-            Ok(()) => return Ok(()),
-            Err(ref e) if e.kind() == io::ErrorKind::NotFound => {}
-            Err(_) if path.is_dir() => return Ok(()),
-            Err(e) => return Err(e),
-        }
-        match path.parent() {
-            Some(p) => self.create_dir_all(p)?,
-            None => {
-                return Err(io::const_error!(
-                    io::ErrorKind::Uncategorized,
-                    "failed to create whole tree",
-                ));
+        let ancestors = path.ancestors();
+        let mut uncreated_dirs = 0;
+
+        for ancestor in ancestors {
+            // for relative paths like "foo/bar", the parent of
+            // "foo" will be "" which there's no need to invoke
+            // a mkdir syscall on
+            if ancestor == Path::new("") {
+                break;
+            }
+
+            match self.inner.mkdir(ancestor) {
+                Ok(()) => break,
+                Err(e) if e.kind() == io::ErrorKind::NotFound => uncreated_dirs += 1,
+                // we check if the err is AlreadyExists for two reasons
+                //    - in case the path exists as a *file*
+                //    - and to avoid calls to .is_dir() in case of other errs
+                //      (i.e. PermissionDenied)
+                Err(e) if e.kind() == io::ErrorKind::AlreadyExists && ancestor.is_dir() => break,
+                Err(e) => return Err(e),
             }
         }
-        match self.inner.mkdir(path) {
-            Ok(()) => Ok(()),
-            Err(_) if path.is_dir() => Ok(()),
-            Err(e) => Err(e),
+
+        // collect only the uncreated directories w/o letting the vec resize
+        let mut uncreated_dirs_vec = Vec::with_capacity(uncreated_dirs);
+        uncreated_dirs_vec.extend(ancestors.take(uncreated_dirs));
+
+        for uncreated_dir in uncreated_dirs_vec.iter().rev() {
+            if let Err(e) = self.inner.mkdir(uncreated_dir) {
+                if e.kind() != io::ErrorKind::AlreadyExists || !uncreated_dir.is_dir() {
+                    return Err(e);
+                }
+            }
         }
+
+        Ok(())
     }
 }
 


### PR DESCRIPTION
The current implementation of `create_dir_all(...)` in std::fs operates recursively. As mentioned in rust-lang/rust#124309, this could run into a stack overflow with big paths. To avoid this stack overflow issue, this PR implements the method in an iterative manner, preserving the documented behavior of:
```
Recursively create a directory and all of its parent components if they are missing.
This function is not atomic. If it returns an error, any parent components it was able to create will remain.
If the empty path is passed to this function, it always succeeds without creating any directories.
```

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
