### PR TITLE
Modify contributor email entries in .mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -9,7 +9,7 @@ Aaron Todd <github@opprobrio.us>
 Abhishek Chanda <abhishek.becs@gmail.com> Abhishek Chanda <abhishek@cloudscaling.com>
 Abhijeet Bhagat <abhijeet.bhagat@gmx.com>
 Abroskin Alexander <arkweid@evilmartians.com>
-Adolfo Ochagavía <aochagavia92@gmail.com>
+Adolfo Ochagavía <aochagavia92@gmail.com> <github@adolfo.ochagavia.xyz>
 Adrian Heine né Lang <mail@adrianheine.de>
 Adrien Tétar <adri-from-59@hotmail.fr>
 Ahmed Charles <ahmedcharles@gmail.com> <acharles@outlook.com>
@@ -36,6 +36,7 @@ Amanda Stjerna <mail@amandastjerna.se> <albin.stjerna@gmail.com>
 Amanda Stjerna <mail@amandastjerna.se> <amanda.stjerna@it.uu.se>
 Amanieu d'Antras <amanieu@gmail.com> <amanieu.dantras@huawei.com>
 Amos Onn <amosonn@gmail.com>
+Amos Wenger <amoswenger@gmail.com> <fasterthanlime@users.noreply.github.com>
 Ana-Maria Mihalache <mihalacheana.maria@yahoo.com>
 Anatoly Ikorsky <aikorsky@gmail.com>
 Andre Bogus <bogusandre@gmail.com>
@@ -276,7 +277,8 @@ Irina Popa <irinagpopa@gmail.com>
 Ivan Ivaschenko <defuz.net@gmail.com>
 ivan tkachenko <me@ratijas.tk>
 J. J. Weber <jjweber@gmail.com>
-Jack Huey <jack.huey@umassmed.edu> <jackh726@gmail.com>
+Jack Huey <jackh726@gmail.com> <jack.huey@umassmed.edu>
+Jack Huey <jackh726@gmail.com> <31162821+jackh726@users.noreply.github.com>
 Jacob <jacob.macritchie@gmail.com>
 Jacob Hoffman-Andrews <rust@hoffman-andrews.com> <github@hoffman-andrews.com>
 Jacob Greenfield <xales@naveria.com>
@@ -292,6 +294,8 @@ Jakub Adam Wieczorek <jakub.adam.wieczorek@gmail.com>
 Jakub Adam Wieczorek <jakub.adam.wieczorek@gmail.com> <jakub.bukaj@yahoo.com>
 Jakub Adam Wieczorek <jakub.adam.wieczorek@gmail.com> <jakub@jakub.cc>
 Jakub Adam Wieczorek <jakub.adam.wieczorek@gmail.com> <jakubw@jakubw.net>
+Jakub Adam Wieczorek <jakub.adam.wieczorek@gmail.com> <ja.wieczorek@student.uw.edu.pl>
+Jakub Adam Wieczorek <jakub.adam.wieczorek@gmail.com> <software@jacobadam.net>
 Jakub Beránek <berykubik@gmail.com> <jakub.beranek@vsb.cz>
 James [Undefined] <tpzker@thepuzzlemaker.info>
 James Deng <cnjamesdeng@gmail.com> <cnJamesDeng@gmail.com>
@@ -303,6 +307,7 @@ Jamie Hill-Daniel <jamie@hill-daniel.co.uk> <clubby789@gmail.com>
 Jana Dönszelmann <jana@donsz.nl>
 Jana Dönszelmann <jana@donsz.nl> <jonathan@donsz.nl>
 Jana Dönszelmann <jana@donsz.nl> <jonabent@gmail.com>
+Jane Lusby <jlusby42@gmail.com> <jlusby@yaah.dev>
 Jan-Erik Rediger <janerik@fnordig.de> <badboy@archlinux.us>
 Jaro Fietz <jaro.fietz@gmx.de>
 Jason Fager <jfager@gmail.com>
@@ -313,6 +318,7 @@ Jason Toffaletti <toffaletti@gmail.com> Jason Toffaletti <jason@topsy.com>
 Jauhien Piatlicki <jauhien@gentoo.org> Jauhien Piatlicki <jpiatlicki@zertisa.com>
 Jay True <glacjay@gmail.com>
 Jeremy Letang <letang.jeremy@gmail.com>
+Jeremy Soller <jackpot51@gmail.com> <jeremy@system76.com>
 Jeremy Sorensen <jeremy.a.sorensen@gmail.com>
 Jeremy Stucki <dev@jeremystucki.ch> <stucki.jeremy@gmail.com>
 Jeremy Stucki <dev@jeremystucki.ch> <jeremy@myelin.ch>
@@ -336,6 +342,7 @@ John Kåre Alsaker <john.kare.alsaker@gmail.com>
 John Kåre Alsaker <john.kare.alsaker@gmail.com> <zoxc32@gmail.com>
 John Talling <inrustwetrust@users.noreply.github.com>
 John Van Enk <vanenkj@gmail.com>
+Jon Gjengset <jon@thesquareplanet.com> <jongje@amazon.com>
 Jonas Tepe <jonasprogrammer@gmail.com>
 Jonathan Bailey <jbailey@mozilla.com> <jbailey@jbailey-20809.local>
 Jonathan Chan Kwan Yin <sofe2038@gmail.com>
@@ -424,7 +431,7 @@ Malo Jaffré <jaffre.malo@gmail.com>
 Manish Goregaokar <manishsmail@gmail.com>
 Mara Bos <m-ou.se@m-ou.se>
 Marcell Pardavi <marcell.pardavi@gmail.com>
-Marco Ieni <11428655+MarcoIeni@users.noreply.github.com>
+Marco Ieni <marcoieni@rustfoundation.org> <11428655+MarcoIeni@users.noreply.github.com>
 Marcus Klaas de Vries <mail@marcusklaas.nl>
 Margaret Meyerhofer <mmeyerho@andrew.cmu.edu> <mmeyerho@andrew>
 Marijn Schouten <mhkbst@gmail.com> <hkBst@users.noreply.github.com>
@@ -531,6 +538,7 @@ Oliver Scherer <oli-obk@users.noreply.github.com> <oliver.schneider@kit.edu>
 Oliver Scherer <oli-obk@users.noreply.github.com> <obk8176014uqher834@olio-obk.de>
 Oliver Scherer <oli-obk@users.noreply.github.com> <rustc-contact@oli-obk.de>
 Oliver Scherer <oli-obk@users.noreply.github.com>
+Onur Özkan <onurozkan.dev@outlook.com> <contact@onurozkan.dev>
 Onur Özkan <onurozkan.dev@outlook.com> <work@onurozkan.dev>
 Onur Özkan <onurozkan.dev@outlook.com>
 Ömer Sinan Ağacan <omeragacan@gmail.com>
@@ -591,6 +599,7 @@ Rusty Blitzerr <rusty.blitzerr@gmail.com>
 RustyYato <krishna.sd.2012@gmail.com>
 Ruud van Asseldonk <dev@veniogames.com> Ruud van Asseldonk <ruuda@google.com>
 Ryan Leung <rleungx@gmail.com>
+Ryan Levick <me@ryanlevick.com> <rylev@users.noreply.github.com>
 Ryan Scheel <ryan.havvy@gmail.com>
 Ryan Sullivant <rsulli55@gmail.com>
 Ryan Wiedemann <Ryan1729@gmail.com>
@@ -685,6 +694,8 @@ Weihang Lo <me@weihanglo.tw>
 Weihang Lo <me@weihanglo.tw> <weihanglo@users.noreply.github.com>
 Wesley Wiser <wwiser@gmail.com> <wesleywiser@microsoft.com>
 whitequark <whitequark@whitequark.org>
+Will Crichton <crichton.will@gmail.com> <wcrichto@stanford.edu>
+Will Crichton <crichton.will@gmail.com> <wcrichto@cs.stanford.edu>
 William Ting <io@williamting.com> <william.h.ting@gmail.com>
 Wim Looman <wim@nemo157.com> <rust-lang@nemo157.com>
 Wim Looman <wim@nemo157.com> <git@nemo157.com>
@@ -694,6 +705,8 @@ Xinye Tao <xy.tao@outlook.com>
 Xuefeng Wu <benewu@gmail.com> Xuefeng Wu <xfwu@thoughtworks.com>
 Xuefeng Wu <benewu@gmail.com> XuefengWu <benewu@gmail.com>
 York Xiang <bombless@126.com>
+Yoshua Wuyts <yoshuawuyts@gmail.com> <yoshuawuyts+github@gmail.com>
+Yoshua Wuyts <yoshuawuyts@gmail.com> <2467194+yoshuawuyts@users.noreply.github.com>
 Yotam Ofek <yotam.ofek@gmail.com> <yotamofek@microsoft.com>
 Youngsoo Son <ysson83@gmail.com> <ysoo.son@samsung.com>
 Youngsuk Kim <joseph942010@gmail.com>


### PR DESCRIPTION
This adds mailmap entries for duplicates I found in https://thanks.rust-lang.org/rust/all-time/

If I added an entry for you and it is not correct, then please let me know! See the comments at the start of https://github.com/rust-lang/thanks/blob/master/mailmap/src/lib.rs for understanding these entries.

After this gets into the repo, the thanks page will be regenerated within a day, and your double entries will be merged.

cc @aochagavia 
cc @fasterthanlime 
cc @jackh726 
cc @jakubadamw 
cc @yaahc 
cc @jackpot51 
cc @jonhoo 
cc @marcoieni 
cc @onur-ozkan 
cc @rylev 
cc @willcrichton 
cc @yoshuawuyts 