### PR TITLE
[stable] Further revert `Deref for Cow` to its 1.90.0 state

### DIFF
--- a/library/alloc/src/borrow.rs
+++ b/library/alloc/src/borrow.rs
@@ -333,7 +333,8 @@ impl<B: ?Sized + ToOwned> Cow<'_, B> {
 // #[rustc_const_unstable(feature = "const_convert", issue = "143773")]
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<B: ?Sized + ToOwned> Deref for Cow<'_, B>
-// where
+where
+    B::Owned: Borrow<B>,
 //     B::Owned: [const] Borrow<B>,
 {
     type Target = B;

--- a/tests/ui/traits/generic-cow-inference-regression.rs
+++ b/tests/ui/traits/generic-cow-inference-regression.rs
@@ -5,9 +5,12 @@
 
 use std::borrow::{Cow, Borrow};
 
-pub fn generic_deref<'a, T: ToOwned<Owned = U>, U>(cow: Cow<'a, T>) {
-    let _: &T = &cow;
-}
+// This won't work even with the non-const bound on `Deref` like 1.90.0, although note
+// as well that no such bound existed until 1.57 started `~const` experiments.
+//
+// pub fn generic_deref<'a, T: ToOwned<Owned = U>, U>(cow: Cow<'a, T>) {
+//     let _: &T = &cow;
+// }
 
 pub fn generic_borrow<'a, T: ToOwned<Owned = U>, U>(cow: Cow<'a, T>) {
     let _: &T = cow.borrow();


### PR DESCRIPTION
It's not clear whether it breaks anything to *not* have this bound,
but the conservative choice is to match the state as of 1.90.0.

See also:
https://github.com/rust-lang/rust/issues/147964#issuecomment-3446420995
https://rust-lang.zulipchat.com/#narrow/channel/144729-t-types/topic/Can.20this.20change.20break.20code.20in.201.2E91.3F/with/547528362
