### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/compiler/rustc_codegen_ssa/src/traits/backend.rs
+++ b/compiler/rustc_codegen_ssa/src/traits/backend.rs
@@ -10,7 +10,7 @@ use rustc_middle::dep_graph::{WorkProduct, WorkProductId};
 use rustc_middle::ty::TyCtxt;
 use rustc_middle::util::Providers;
 use rustc_session::Session;
-use rustc_session::config::{self, OutputFilenames, PrintRequest};
+use rustc_session::config::{self, CrateType, OutputFilenames, PrintRequest};
 use rustc_span::Symbol;
 
 use super::CodegenObject;
@@ -60,6 +60,18 @@ pub trait CodegenBackend {
             has_reliable_f128: true,
             has_reliable_f128_math: true,
         }
+    }
+
+    fn supported_crate_types(&self, _sess: &Session) -> Vec<CrateType> {
+        vec![
+            CrateType::Executable,
+            CrateType::Dylib,
+            CrateType::Rlib,
+            CrateType::Staticlib,
+            CrateType::Cdylib,
+            CrateType::ProcMacro,
+            CrateType::Sdylib,
+        ]
     }
 
     fn print_passes(&self) {}

--- a/compiler/rustc_driver_impl/src/lib.rs
+++ b/compiler/rustc_driver_impl/src/lib.rs
@@ -686,7 +686,8 @@ fn print_crate_info(
                 };
                 let t_outputs = rustc_interface::util::build_output_filenames(attrs, sess);
                 let crate_name = passes::get_crate_name(sess, attrs);
-                let crate_types = collect_crate_types(sess, attrs);
+                let crate_types =
+                    collect_crate_types(sess, &codegen_backend.supported_crate_types(sess), attrs);
                 for &style in &crate_types {
                     let fname = rustc_session::output::filename_for_input(
                         sess, style, crate_name, &t_outputs,

--- a/compiler/rustc_hir_analysis/src/collect/type_of/opaque.rs
+++ b/compiler/rustc_hir_analysis/src/collect/type_of/opaque.rs
@@ -242,6 +242,16 @@ pub(super) fn find_opaque_ty_constraints_for_rpit<'tcx>(
     owner_def_id: LocalDefId,
     opaque_types_from: DefiningScopeKind,
 ) -> Ty<'tcx> {
+    // When an opaque type is stranded, its hidden type cannot be inferred
+    // so we should not continue.
+    if !tcx.opaque_types_defined_by(owner_def_id).contains(&def_id) {
+        let opaque_type_span = tcx.def_span(def_id);
+        let guar = tcx
+            .dcx()
+            .span_delayed_bug(opaque_type_span, "cannot infer type for stranded opaque type");
+        return Ty::new_error(tcx, guar);
+    }
+
     match opaque_types_from {
         DefiningScopeKind::HirTypeck => {
             let tables = tcx.typeck(owner_def_id);

--- a/compiler/rustc_incremental/src/persist/load.rs
+++ b/compiler/rustc_incremental/src/persist/load.rs
@@ -10,8 +10,8 @@ use rustc_middle::dep_graph::{DepGraph, DepsType, SerializedDepGraph, WorkProduc
 use rustc_middle::query::on_disk_cache::OnDiskCache;
 use rustc_serialize::Decodable;
 use rustc_serialize::opaque::MemDecoder;
-use rustc_session::Session;
 use rustc_session::config::IncrementalStateAssertion;
+use rustc_session::{Session, StableCrateId};
 use rustc_span::Symbol;
 use tracing::{debug, warn};
 
@@ -208,9 +208,14 @@ pub fn load_query_result_cache(sess: &Session) -> Option<OnDiskCache> {
 
 /// Setups the dependency graph by loading an existing graph from disk and set up streaming of a
 /// new graph to an incremental session directory.
-pub fn setup_dep_graph(sess: &Session, crate_name: Symbol, deps: &DepsType) -> DepGraph {
+pub fn setup_dep_graph(
+    sess: &Session,
+    crate_name: Symbol,
+    stable_crate_id: StableCrateId,
+    deps: &DepsType,
+) -> DepGraph {
     // `load_dep_graph` can only be called after `prepare_session_directory`.
-    prepare_session_directory(sess, crate_name);
+    prepare_session_directory(sess, crate_name, stable_crate_id);
 
     let res = sess.opts.build_dep_graph().then(|| load_dep_graph(sess, deps));
 

--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -936,7 +936,7 @@ pub fn create_and_enter_global_ctxt<T, F: for<'tcx> FnOnce(TyCtxt<'tcx>) -> T>(
     let outputs = util::build_output_filenames(&pre_configured_attrs, sess);
 
     let dep_type = DepsType { dep_names: rustc_query_impl::dep_kind_names() };
-    let dep_graph = setup_dep_graph(sess, crate_name, &dep_type);
+    let dep_graph = setup_dep_graph(sess, crate_name, stable_crate_id, &dep_type);
 
     let cstore =
         FreezeLock::new(Box::new(CStore::new(compiler.codegen_backend.metadata_loader())) as _);

--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -925,7 +925,11 @@ pub fn create_and_enter_global_ctxt<T, F: for<'tcx> FnOnce(TyCtxt<'tcx>) -> T>(
     let pre_configured_attrs = rustc_expand::config::pre_configure_attrs(sess, &krate.attrs);
 
     let crate_name = get_crate_name(sess, &pre_configured_attrs);
-    let crate_types = collect_crate_types(sess, &pre_configured_attrs);
+    let crate_types = collect_crate_types(
+        sess,
+        &compiler.codegen_backend.supported_crate_types(sess),
+        &pre_configured_attrs,
+    );
     let stable_crate_id = StableCrateId::new(
         crate_name,
         crate_types.contains(&CrateType::Executable),

--- a/compiler/rustc_interface/src/util.rs
+++ b/compiler/rustc_interface/src/util.rs
@@ -388,17 +388,16 @@ impl CodegenBackend for DummyCodegenBackend {
     ) {
         // JUSTIFICATION: TyCtxt no longer available here
         #[allow(rustc::bad_opt_access)]
-        if codegen_results
+        if let Some(&crate_type) = codegen_results
             .crate_info
             .crate_types
             .iter()
-            .any(|&crate_type| crate_type != CrateType::Rlib)
+            .find(|&&crate_type| crate_type != CrateType::Rlib)
         {
             #[allow(rustc::untranslatable_diagnostic)]
             #[allow(rustc::diagnostic_outside_of_impl)]
             sess.dcx().fatal(format!(
-                "crate type {} not supported by the dummy codegen backend",
-                codegen_results.crate_info.crate_types[0],
+                "crate type {crate_type} not supported by the dummy codegen backend"
             ));
         }
 

--- a/compiler/rustc_interface/src/util.rs
+++ b/compiler/rustc_interface/src/util.rs
@@ -354,6 +354,14 @@ impl CodegenBackend for DummyCodegenBackend {
         "dummy"
     }
 
+    fn supported_crate_types(&self, _sess: &Session) -> Vec<CrateType> {
+        // This includes bin despite failing on the link step to ensure that you
+        // can still get the frontend handling for binaries. For all library
+        // like crate types cargo will fallback to rlib unless you specifically
+        // say that only a different crate type must be used.
+        vec![CrateType::Rlib, CrateType::Executable]
+    }
+
     fn codegen_crate<'tcx>(&self, tcx: TyCtxt<'tcx>) -> Box<dyn Any> {
         Box::new(CodegenResults {
             modules: vec![],
@@ -380,12 +388,17 @@ impl CodegenBackend for DummyCodegenBackend {
     ) {
         // JUSTIFICATION: TyCtxt no longer available here
         #[allow(rustc::bad_opt_access)]
-        if sess.opts.crate_types.iter().any(|&crate_type| crate_type != CrateType::Rlib) {
+        if codegen_results
+            .crate_info
+            .crate_types
+            .iter()
+            .any(|&crate_type| crate_type != CrateType::Rlib)
+        {
             #[allow(rustc::untranslatable_diagnostic)]
             #[allow(rustc::diagnostic_outside_of_impl)]
             sess.dcx().fatal(format!(
                 "crate type {} not supported by the dummy codegen backend",
-                sess.opts.crate_types[0],
+                codegen_results.crate_info.crate_types[0],
             ));
         }
 

--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -311,7 +311,6 @@ pub(crate) enum ModuleSorting {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) enum EmitType {
-    Unversioned,
     Toolchain,
     InvocationSpecific,
     DepInfo(Option<OutFileName>),
@@ -322,7 +321,6 @@ impl FromStr for EmitType {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "unversioned-shared-resources" => Ok(Self::Unversioned),
             "toolchain-shared-resources" => Ok(Self::Toolchain),
             "invocation-specific" => Ok(Self::InvocationSpecific),
             "dep-info" => Ok(Self::DepInfo(None)),

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -567,7 +567,7 @@ fn opts() -> Vec<RustcOptGroup> {
             "",
             "emit",
             "Comma separated list of types of output for rustdoc to emit",
-            "[unversioned-shared-resources,toolchain-shared-resources,invocation-specific,dep-info]",
+            "[toolchain-shared-resources,invocation-specific,dep-info]",
         ),
         opt(Unstable, FlagMulti, "", "no-run", "Compile doctests without running them", ""),
         opt(

--- a/tests/run-make/emit-shared-files/rmake.rs
+++ b/tests/run-make/emit-shared-files/rmake.rs
@@ -68,7 +68,7 @@ fn main() {
 
     rustdoc()
         .arg("-Zunstable-options")
-        .arg("--emit=toolchain-shared-resources,unversioned-shared-resources")
+        .arg("--emit=toolchain-shared-resources")
         .out_dir("all-shared")
         .arg("--resource-suffix=-xxx")
         .args(&["--extend-css", "z.css"])

--- a/tests/run-make/rustdoc-default-output/output-default.stdout
+++ b/tests/run-make/rustdoc-default-output/output-default.stdout
@@ -150,7 +150,7 @@ Options:
         --generate-redirect-map 
                         Generate JSON file at the top level instead of
                         generating HTML redirection files
-        --emit [unversioned-shared-resources,toolchain-shared-resources,invocation-specific,dep-info]
+        --emit [toolchain-shared-resources,invocation-specific,dep-info]
                         Comma separated list of types of output for rustdoc to
                         emit
         --no-run        Compile doctests without running them

--- a/tests/ui/traits/next-solver/opaques/stranded_opaque.rs
+++ b/tests/ui/traits/next-solver/opaques/stranded_opaque.rs
@@ -1,0 +1,50 @@
+//@ compile-flags: -Znext-solver
+#![feature(type_alias_impl_trait)]
+use std::future::Future;
+
+// Test for https://github.com/rust-lang/trait-system-refactor-initiative/issues/235
+
+// These are cases where an opaque types become "stranded" due to
+// some errors. Make sure we don't ICE in either case.
+
+// Case 1: `impl Send` is stranded
+fn foo() -> impl ?Future<Output = impl Send> {
+    //~^ ERROR bound modifier `?` can only be applied to `Sized`
+    //~| ERROR bound modifier `?` can only be applied to `Sized`
+    ()
+}
+
+// Case 2: `Assoc = impl Trait` is stranded
+trait Trait {}
+impl Trait for i32 {}
+
+fn produce() -> impl Trait<Assoc = impl Trait> {
+    //~^ ERROR associated type `Assoc` not found for `Trait`
+    //~| ERROR associated type `Assoc` not found for `Trait`
+    16
+}
+
+// Case 3: `impl Trait` is stranded
+fn ill_formed_string() -> String<impl Trait> {
+    //~^ ERROR struct takes 0 generic arguments but 1 generic argument was supplied
+   String::from("a string")
+}
+
+// Case 4: TAIT variant of Case 1 to 3
+type Foo = impl ?Future<Output = impl Send>;
+//~^ ERROR unconstrained opaque type
+//~| ERROR unconstrained opaque type
+//~| ERROR bound modifier `?` can only be applied to `Sized`
+//~| ERROR bound modifier `?` can only be applied to `Sized`
+
+type Produce =  impl Trait<Assoc = impl Trait>;
+//~^ ERROR unconstrained opaque type
+//~| ERROR unconstrained opaque type
+//~| ERROR associated type `Assoc` not found for `Trait`
+//~| ERROR associated type `Assoc` not found for `Trait`
+
+type IllFormedString =  String<impl Trait>;
+//~^ ERROR unconstrained opaque type
+//~| ERROR struct takes 0 generic arguments but 1 generic argument was supplied
+
+fn main() {}

--- a/tests/ui/traits/next-solver/opaques/stranded_opaque.stderr
+++ b/tests/ui/traits/next-solver/opaques/stranded_opaque.stderr
@@ -1,0 +1,116 @@
+error: bound modifier `?` can only be applied to `Sized`
+  --> $DIR/stranded_opaque.rs:11:18
+   |
+LL | fn foo() -> impl ?Future<Output = impl Send> {
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0220]: associated type `Assoc` not found for `Trait`
+  --> $DIR/stranded_opaque.rs:21:28
+   |
+LL | fn produce() -> impl Trait<Assoc = impl Trait> {
+   |                            ^^^^^ associated type `Assoc` not found
+
+error[E0107]: struct takes 0 generic arguments but 1 generic argument was supplied
+  --> $DIR/stranded_opaque.rs:28:27
+   |
+LL | fn ill_formed_string() -> String<impl Trait> {
+   |                           ^^^^^^------------ help: remove the unnecessary generics
+   |                           |
+   |                           expected 0 generic arguments
+
+error[E0107]: struct takes 0 generic arguments but 1 generic argument was supplied
+  --> $DIR/stranded_opaque.rs:46:25
+   |
+LL | type IllFormedString =  String<impl Trait>;
+   |                         ^^^^^^------------ help: remove the unnecessary generics
+   |                         |
+   |                         expected 0 generic arguments
+
+error: bound modifier `?` can only be applied to `Sized`
+  --> $DIR/stranded_opaque.rs:11:18
+   |
+LL | fn foo() -> impl ?Future<Output = impl Send> {
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0220]: associated type `Assoc` not found for `Trait`
+  --> $DIR/stranded_opaque.rs:21:28
+   |
+LL | fn produce() -> impl Trait<Assoc = impl Trait> {
+   |                            ^^^^^ associated type `Assoc` not found
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: unconstrained opaque type
+  --> $DIR/stranded_opaque.rs:34:12
+   |
+LL | type Foo = impl ?Future<Output = impl Send>;
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `Foo` must be used in combination with a concrete type within the same crate
+
+error: bound modifier `?` can only be applied to `Sized`
+  --> $DIR/stranded_opaque.rs:34:17
+   |
+LL | type Foo = impl ?Future<Output = impl Send>;
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: bound modifier `?` can only be applied to `Sized`
+  --> $DIR/stranded_opaque.rs:34:17
+   |
+LL | type Foo = impl ?Future<Output = impl Send>;
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: unconstrained opaque type
+  --> $DIR/stranded_opaque.rs:34:34
+   |
+LL | type Foo = impl ?Future<Output = impl Send>;
+   |                                  ^^^^^^^^^
+   |
+   = note: `Foo` must be used in combination with a concrete type within the same crate
+
+error: unconstrained opaque type
+  --> $DIR/stranded_opaque.rs:40:17
+   |
+LL | type Produce =  impl Trait<Assoc = impl Trait>;
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `Produce` must be used in combination with a concrete type within the same crate
+
+error[E0220]: associated type `Assoc` not found for `Trait`
+  --> $DIR/stranded_opaque.rs:40:28
+   |
+LL | type Produce =  impl Trait<Assoc = impl Trait>;
+   |                            ^^^^^ associated type `Assoc` not found
+
+error[E0220]: associated type `Assoc` not found for `Trait`
+  --> $DIR/stranded_opaque.rs:40:28
+   |
+LL | type Produce =  impl Trait<Assoc = impl Trait>;
+   |                            ^^^^^ associated type `Assoc` not found
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: unconstrained opaque type
+  --> $DIR/stranded_opaque.rs:40:36
+   |
+LL | type Produce =  impl Trait<Assoc = impl Trait>;
+   |                                    ^^^^^^^^^^
+   |
+   = note: `Produce` must be used in combination with a concrete type within the same crate
+
+error: unconstrained opaque type
+  --> $DIR/stranded_opaque.rs:46:32
+   |
+LL | type IllFormedString =  String<impl Trait>;
+   |                                ^^^^^^^^^^
+   |
+   = note: `IllFormedString` must be used in combination with a concrete type within the same crate
+
+error: aborting due to 15 previous errors
+
+Some errors have detailed explanations: E0107, E0220.
+For more information about an error, try `rustc --explain E0107`.


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#148173 (Emit delayed bug during wfck for stranded opaque)
 - rust-lang/rust#148177 (Allow codegen backends to indicate which crate types they support)
 - rust-lang/rust#148180 (rustdoc: remove `--emit=unversioned-shared-resources`)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=148173,148177,148180)
<!-- homu-ignore:end -->