### PR TITLE
bootstrap: PathSet::check only considers starts_with for `--skip` flag

### DIFF
--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -3636,7 +3636,7 @@ impl Step for CodegenCranelift {
     const IS_HOST: bool = true;
 
     fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
-        run.paths(&["compiler/rustc_codegen_cranelift"])
+        run.paths(&["compiler/rustc_codegen_cranelift"]).path("compiler")
     }
 
     fn make_run(run: RunConfig<'_>) {
@@ -3754,7 +3754,7 @@ impl Step for CodegenGCC {
     const IS_HOST: bool = true;
 
     fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
-        run.paths(&["compiler/rustc_codegen_gcc"])
+        run.paths(&["compiler/rustc_codegen_gcc"]).path("compiler")
     }
 
     fn make_run(run: RunConfig<'_>) {

--- a/src/bootstrap/src/core/builder/mod.rs
+++ b/src/bootstrap/src/core/builder/mod.rs
@@ -363,18 +363,18 @@ impl PathSet {
         PathSet::Set(set)
     }
 
-    fn has(&self, needle: &Path, module: Kind) -> bool {
+    fn has(&self, needle: &Path, module: Kind, filter_start: bool) -> bool {
         match self {
-            PathSet::Set(set) => set.iter().any(|p| Self::check(p, needle, module)),
-            PathSet::Suite(suite) => Self::check(suite, needle, module),
+            PathSet::Set(set) => set.iter().any(|p| Self::check(p, needle, module, filter_start)),
+            PathSet::Suite(suite) => Self::check(suite, needle, module, filter_start),
         }
     }
 
     // internal use only
-    fn check(p: &TaskPath, needle: &Path, module: Kind) -> bool {
+    fn check(p: &TaskPath, needle: &Path, module: Kind, filter_start: bool) -> bool {
         let check_path = || {
             // This order is important for retro-compatibility, as `starts_with` was introduced later.
-            p.path.ends_with(needle) || p.path.starts_with(needle)
+            p.path.ends_with(needle) || (filter_start && p.path.starts_with(needle))
         };
         if let Some(p_kind) = &p.kind { check_path() && *p_kind == module } else { check_path() }
     }
@@ -389,7 +389,7 @@ impl PathSet {
         let mut check = |p| {
             let mut result = false;
             for n in needles.iter_mut() {
-                let matched = Self::check(p, &n.path, module);
+                let matched = Self::check(p, &n.path, module, false);
                 if matched {
                     n.will_be_executed = true;
                     result = true;
@@ -535,7 +535,7 @@ impl StepDescription {
     }
 
     fn is_excluded(&self, builder: &Builder<'_>, pathset: &PathSet) -> bool {
-        if builder.config.skip.iter().any(|e| pathset.has(e, builder.kind)) {
+        if builder.config.skip.iter().any(|e| pathset.has(e, builder.kind, true)) {
             if !matches!(builder.config.get_dry_run(), DryRun::SelfCheck) {
                 println!("Skipping {pathset:?} because it is excluded");
             }
@@ -1861,7 +1861,7 @@ Alternatively, you can set `build.local-rebuild=true` and use a stage0 compiler 
         let should_run = (desc.should_run)(ShouldRun::new(self, desc.kind));
 
         for path in &self.paths {
-            if should_run.paths.iter().any(|s| s.has(path, desc.kind))
+            if should_run.paths.iter().any(|s| s.has(path, desc.kind, false))
                 && !desc.is_excluded(
                     self,
                     &PathSet::Suite(TaskPath { path: path.clone(), kind: Some(desc.kind) }),


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

The original motivation for adding this `path.starts_with` check was to allow things like `--skip=src/etc`: https://github.com/rust-lang/rust/pull/133492. But it affects quite a lot more things than just `--skip`; bootstrap is really not designed for the case when multiple Steps match the same filter (https://github.com/rust-lang/rust/pull/134919#issuecomment-2565445761). For example, `x test src` does ... something! Not sure what, but something!

This has already caused several issues; see https://github.com/rust-lang/rust/issues/135022, https://github.com/rust-lang/rust/issues/135022, probably others I am forgetting.

Change `starts_with` to only affect `--skip`, not anything else.

The immediate motivation for this change was to prevent `x doc --open src/doc` from opening a dozen different pages (see `was_explicitly_invoked` for how this is related).

r? bootstrap cc @marcoieni @onur-ozkan @jieyouxu @Zalathar 