### PR TITLE
bootstrap: `ensure(doc::Std)` no longer opens a browser

### DIFF
--- a/src/bootstrap/src/core/build_steps/doc.rs
+++ b/src/bootstrap/src/core/build_steps/doc.rs
@@ -709,12 +709,12 @@ impl Step for Std {
             if builder.paths.iter().any(|path| path.ends_with("library")) {
                 // For `x.py doc library --open`, open `std` by default.
                 let index = out.join("std").join("index.html");
-                builder.open_in_browser(index);
+                builder.maybe_open_in_browser::<Self>(index);
             } else {
                 for requested_crate in crates {
                     if STD_PUBLIC_CRATES.iter().any(|&k| k == requested_crate) {
                         let index = out.join(requested_crate).join("index.html");
-                        builder.open_in_browser(index);
+                        builder.maybe_open_in_browser::<Self>(index);
                         break;
                     }
                 }


### PR DESCRIPTION
In general, the rationale for `--open` is to only open HTML files if they were "explicitly" invoked from the CLI (e.g. `x doc --open library/core`). The existing logic did not do that. Instead it opened the docs unconditionally when a subset of the crates was requested. This is unfortunate for other Steps in bootstrap, which may wish to `ensure()` the standard library docs without opening them.

Change `Std` to check if it was explicitly invoked, rather than assuming it's the case.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
