### PR TITLE
Run regression test for #147964 on next solver too

### DIFF
--- a/tests/ui/traits/generic-cow-inference-regression.rs
+++ b/tests/ui/traits/generic-cow-inference-regression.rs
@@ -1,3 +1,5 @@
+//@[new] compile-flags: -Znext-solver
+//@ revisions: old new
 //@ run-pass
 
 // regression test for #147964:


### PR DESCRIPTION
Original regression: rust-lang/rust#147964
Longer-term tracking of issue: rust-lang/rust#148028

For now, this just makes sure that whatever tests we keep are working the same under both the current solver and the next solver, until we decide what to do with them.