### PR TITLE
rustdoc: Properly highlight shebang, frontmatter & weak keywords in source code pages and code blocks

### DIFF
--- a/tests/rustdoc/jump-to-def/shebang.rs
+++ b/tests/rustdoc/jump-to-def/shebang.rs
@@ -1,0 +1,15 @@
+#!/path/to/my/interpreter
+//@ compile-flags: -Zunstable-options --generate-link-to-definition
+
+// Ensure that we can successfully generate links to definitions in the presence of shebang.
+// Implementation-wise, shebang is not a token that's emitted by the lexer. Instead, we need
+// to offset the actual lexing which is tricky due to all the byte index and span calculations
+// in the Classifier.
+
+fn scope() {
+//@ has 'src/shebang/shebang.rs.html'
+//@ has - '//a[@href="#15"]' 'function'
+    function();
+}
+
+fn function() {}

--- a/tests/rustdoc/source-code-pages/frontmatter.rs
+++ b/tests/rustdoc/source-code-pages/frontmatter.rs
@@ -1,0 +1,10 @@
+--- json
+{"edition": "2024"}
+---
+#![feature(frontmatter)]
+
+// Test that we highlight frontmatter as comments on source code pages.
+
+//@ has 'src/frontmatter/frontmatter.rs.html'
+//@ has - '//pre[@class="rust"]//span[@class="comment"]' \
+//        '--- json {"edition": "2024"} ---'

--- a/tests/rustdoc/source-code-pages/shebang.rs
+++ b/tests/rustdoc/source-code-pages/shebang.rs
@@ -1,0 +1,6 @@
+#!/path/to/somewhere 0 if false ""
+
+// Test that we highlight shebang as comments on source code pages.
+
+//@ has 'src/shebang/shebang.rs.html'
+//@ has - '//pre[@class="rust"]//span[@class="comment"]' '#!/path/to/somewhere 0 if false ""'


### PR DESCRIPTION
Before | After
---|---
<img width="517" height="532" alt="Screenshot 2025-10-28 at 23-21-02 pre rs - source" src="https://github.com/user-attachments/assets/5026761f-c604-4bcc-a699-9e75eb73dff6" /> | <img width="499" height="531" alt="Screenshot 2025-10-28 at 23-21-51 pre rs - source" src="https://github.com/user-attachments/assets/cc8c65e7-e3ad-4e20-a2c3-2623cf799093" />
