### PR TITLE
citool: Always print a signed percentage in job duration changes

### DIFF
--- a/src/ci/citool/src/analysis.rs
+++ b/src/ci/citool/src/analysis.rs
@@ -237,7 +237,7 @@ pub fn output_largest_duration_changes(
     println!("# Job duration changes");
     for (index, entry) in changes.into_iter().take(10).enumerate() {
         println!(
-            "{}. {}: {:.1}s -> {:.1}s ({:.1}%)",
+            "{}. {}: {:.1}s -> {:.1}s ({:+.1}%)",
             index + 1,
             format_job_link(job_info_resolver, job_metrics, entry.job),
             entry.before.as_secs_f64(),


### PR DESCRIPTION
I found myself confused by these percentage deltas, because it's not immediately obvious whether a change of 110% means “a little bit worse” (+10%, 110% overall) or ”more than twice as long” (+110%, 210% overall). The correct interpretation is “more than twice as long”.

Including a sign for positive percentages should hopefully make it clearer that they are relative to a baseline of ±0%, not a baseline of 100%.

Manually tested with:
```text
cargo run --manifest-path src/ci/citool/Cargo.toml post-merge-report df984edf44203c862e01b5a20c8092d5614d872e c9537a94a6300a8292804829801f7724fb8a33f6
```

r? Kobzol