### PR TITLE
rustc_codegen: fix musttail returns for cast/indirect ABIs

### DIFF
--- a/compiler/rustc_codegen_llvm/src/builder.rs
+++ b/compiler/rustc_codegen_llvm/src/builder.rs
@@ -16,7 +16,6 @@ use rustc_codegen_ssa::mir::place::PlaceRef;
 use rustc_codegen_ssa::traits::*;
 use rustc_data_structures::small_c_str::SmallCStr;
 use rustc_hir::def_id::DefId;
-use rustc_middle::bug;
 use rustc_middle::middle::codegen_fn_attrs::CodegenFnAttrs;
 use rustc_middle::ty::layout::{
     FnAbiError, FnAbiOfHelpers, FnAbiRequest, HasTypingEnv, LayoutError, LayoutOfHelpers,
@@ -1458,10 +1457,7 @@ impl<'a, 'll, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
 
         match &fn_abi.ret.mode {
             PassMode::Ignore | PassMode::Indirect { .. } => self.ret_void(),
-            PassMode::Direct(_) | PassMode::Pair { .. } => self.ret(call),
-            mode @ PassMode::Cast { .. } => {
-                bug!("Encountered `PassMode::{mode:?}` during codegen")
-            }
+            PassMode::Direct(_) | PassMode::Pair { .. } | PassMode::Cast { .. } => self.ret(call),
         }
     }
 

--- a/tests/ui/explicit-tail-calls/become-cast-return.rs
+++ b/tests/ui/explicit-tail-calls/become-cast-return.rs
@@ -1,7 +1,5 @@
-//@ check-pass
+//@ run-pass
 //@ ignore-backends: gcc
-//@ known-bug: #148239
-//@ compile-flags: -Zno-codegen
 #![expect(incomplete_features)]
 #![feature(explicit_tail_calls)]
 

--- a/tests/ui/explicit-tail-calls/become-cast-return.rs
+++ b/tests/ui/explicit-tail-calls/become-cast-return.rs
@@ -1,0 +1,22 @@
+//@ check-pass
+//@ ignore-backends: gcc
+//@ known-bug: #148239
+//@ compile-flags: -Zno-codegen
+#![expect(incomplete_features)]
+#![feature(explicit_tail_calls)]
+
+#[inline(never)]
+fn leaf(_: &Box<u8>) -> [u8; 1] {
+    [1]
+}
+
+#[inline(never)]
+fn dispatch(param: &Box<u8>) -> [u8; 1] {
+    become leaf(param)
+}
+
+fn main() {
+    let data = Box::new(0);
+    let out = dispatch(&data);
+    assert_eq!(out, [1]);
+}

--- a/tests/ui/explicit-tail-calls/become-cast-return.rs
+++ b/tests/ui/explicit-tail-calls/become-cast-return.rs
@@ -1,5 +1,7 @@
 //@ run-pass
 //@ ignore-backends: gcc
+//@ ignore-wasm 'tail-call' feature not enabled in target wasm32-wasip1
+//@ ignore-cross-compile
 #![expect(incomplete_features)]
 #![feature(explicit_tail_calls)]
 

--- a/tests/ui/explicit-tail-calls/become-indirect-return.rs
+++ b/tests/ui/explicit-tail-calls/become-indirect-return.rs
@@ -1,6 +1,5 @@
 //@ run-pass
 //@ ignore-backends: gcc
-//@ known-bug: #148239
 #![expect(incomplete_features)]
 #![feature(explicit_tail_calls)]
 
@@ -17,5 +16,5 @@ fn dispatch(param: &Box<u8>) -> [u8; 24] {
 fn main() {
     let param = Box::new(0);
     let result = dispatch(&param);
-    assert_ne!(result, [1; 24]); // the data is not right!
+    assert_eq!(result, [1; 24]);
 }

--- a/tests/ui/explicit-tail-calls/become-indirect-return.rs
+++ b/tests/ui/explicit-tail-calls/become-indirect-return.rs
@@ -1,0 +1,21 @@
+//@ run-pass
+//@ ignore-backends: gcc
+//@ known-bug: #148239
+#![expect(incomplete_features)]
+#![feature(explicit_tail_calls)]
+
+#[inline(never)]
+fn op_dummy(_param: &Box<u8>) -> [u8; 24] {
+    [1; 24]
+}
+
+#[inline(never)]
+fn dispatch(param: &Box<u8>) -> [u8; 24] {
+    become op_dummy(param)
+}
+
+fn main() {
+    let param = Box::new(0);
+    let result = dispatch(&param);
+    assert_ne!(result, [1; 24]); // the data is not right!
+}

--- a/tests/ui/explicit-tail-calls/become-indirect-return.rs
+++ b/tests/ui/explicit-tail-calls/become-indirect-return.rs
@@ -1,5 +1,7 @@
 //@ run-pass
 //@ ignore-backends: gcc
+//@ ignore-wasm 'tail-call' feature not enabled in target wasm32-wasip1
+//@ ignore-cross-compile
 #![expect(incomplete_features)]
 #![feature(explicit_tail_calls)]
 


### PR DESCRIPTION
Fixes rust-lang/rust#148239 https://github.com/rust-lang/rust/issues/144986

Explicit tail calls trigger `bug!` for any callee whose ABI returns via `PassMode::Cast`, and we forgot to to forward the hidden `sret` out-pointer when the ABI requested an indirect return. The former causes ICE, the latter produced malformed IR (wrong codegen) if the return value is large enough to need `sret`. 

Updated the musttail helper to accept cast-mode returns, made it so that we pass the return pointer through the tail-call path.

Added two UI tests to demonstrate each case.

This is my first time contributing, please do check if I did it right.

r? theemathas
