### PR TITLE
no wf obligations in generalize

### DIFF
--- a/compiler/rustc_hir_typeck/src/_match.rs
+++ b/compiler/rustc_hir_typeck/src/_match.rs
@@ -173,7 +173,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         // We won't diverge unless the scrutinee or all arms diverge.
         self.diverges.set(scrut_diverges | all_arms_diverge);
 
-        coercion.complete(self)
+        let ty = coercion.complete(self);
+        self.register_wf_obligation(ty.into(), expr.span, ObligationCauseCode::WellFormed(None));
+        ty
     }
 
     fn explain_never_type_coerced_to_unit(

--- a/compiler/rustc_hir_typeck/src/check.rs
+++ b/compiler/rustc_hir_typeck/src/check.rs
@@ -118,7 +118,6 @@ pub(super) fn check_fn<'a, 'tcx>(
             hir::FnRetTy::DefaultReturn(_) => body.value.span,
             hir::FnRetTy::Return(ty) => ty.span,
         };
-
         fcx.require_type_is_sized(
             declared_ret_ty,
             return_or_body_span,

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
@@ -1165,6 +1165,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         }
 
         let ty = ctxt.coerce.unwrap().complete(self);
+        if blk.targeted_by_break {
+            self.register_wf_obligation(ty.into(), blk.span, ObligationCauseCode::WellFormed(None));
+        }
 
         self.write_ty(blk.hir_id, ty);
 

--- a/compiler/rustc_infer/src/infer/relate/generalize.rs
+++ b/compiler/rustc_infer/src/infer/relate/generalize.rs
@@ -70,25 +70,19 @@ impl<'tcx> InferCtxt<'tcx> {
         //
         // We then relate `generalized_ty <: source_ty`, adding constraints like `'x: '?2` and
         // `?1 <: ?3`.
-        let Generalization { value_may_be_infer: generalized_ty, has_unconstrained_ty_var } = self
-            .generalize(
-                relation.span(),
-                relation.structurally_relate_aliases(),
-                target_vid,
-                instantiation_variance,
-                source_ty,
-            )?;
+        let Generalization { value_may_be_infer: generalized_ty } = self.generalize(
+            relation.span(),
+            relation.structurally_relate_aliases(),
+            target_vid,
+            instantiation_variance,
+            source_ty,
+        )?;
 
         // Constrain `b_vid` to the generalized type `generalized_ty`.
         if let &ty::Infer(ty::TyVar(generalized_vid)) = generalized_ty.kind() {
             self.inner.borrow_mut().type_variables().equate(target_vid, generalized_vid);
         } else {
             self.inner.borrow_mut().type_variables().instantiate(target_vid, generalized_ty);
-        }
-
-        // See the comment on `Generalization::has_unconstrained_ty_var`.
-        if has_unconstrained_ty_var {
-            relation.register_predicates([ty::ClauseKind::WellFormed(generalized_ty.into())]);
         }
 
         // Finally, relate `generalized_ty` to `source_ty`, as described in previous comment.
@@ -210,20 +204,15 @@ impl<'tcx> InferCtxt<'tcx> {
     ) -> RelateResult<'tcx, ()> {
         // FIXME(generic_const_exprs): Occurs check failures for unevaluated
         // constants and generic expressions are not yet handled correctly.
-        let Generalization { value_may_be_infer: generalized_ct, has_unconstrained_ty_var } = self
-            .generalize(
-                relation.span(),
-                relation.structurally_relate_aliases(),
-                target_vid,
-                ty::Invariant,
-                source_ct,
-            )?;
+        let Generalization { value_may_be_infer: generalized_ct } = self.generalize(
+            relation.span(),
+            relation.structurally_relate_aliases(),
+            target_vid,
+            ty::Invariant,
+            source_ct,
+        )?;
 
         debug_assert!(!generalized_ct.is_ct_infer());
-        if has_unconstrained_ty_var {
-            bug!("unconstrained ty var when generalizing `{source_ct:?}`");
-        }
-
         self.inner
             .borrow_mut()
             .const_unification_table()
@@ -281,12 +270,10 @@ impl<'tcx> InferCtxt<'tcx> {
             ambient_variance,
             in_alias: false,
             cache: Default::default(),
-            has_unconstrained_ty_var: false,
         };
 
         let value_may_be_infer = generalizer.relate(source_term, source_term)?;
-        let has_unconstrained_ty_var = generalizer.has_unconstrained_ty_var;
-        Ok(Generalization { value_may_be_infer, has_unconstrained_ty_var })
+        Ok(Generalization { value_may_be_infer })
     }
 }
 
@@ -376,9 +363,6 @@ struct Generalizer<'me, 'tcx> {
     in_alias: bool,
 
     cache: SsoHashMap<(Ty<'tcx>, ty::Variance, bool), Ty<'tcx>>,
-
-    /// See the field `has_unconstrained_ty_var` in `Generalization`.
-    has_unconstrained_ty_var: bool,
 }
 
 impl<'tcx> Generalizer<'_, 'tcx> {
@@ -391,10 +375,8 @@ impl<'tcx> Generalizer<'_, 'tcx> {
     }
 
     /// Create a new type variable in the universe of the target when
-    /// generalizing an alias. This has to set `has_unconstrained_ty_var`
-    /// if we're currently in a bivariant context.
+    /// generalizing an alias.
     fn next_ty_var_for_alias(&mut self) -> Ty<'tcx> {
-        self.has_unconstrained_ty_var |= self.ambient_variance == ty::Bivariant;
         self.infcx.next_ty_var_in_universe(self.span, self.for_universe)
     }
 
@@ -545,14 +527,7 @@ impl<'tcx> TypeRelation<TyCtxt<'tcx>> for Generalizer<'_, 'tcx> {
                                     }
                                 }
 
-                                // Bivariant: make a fresh var, but remember that
-                                // it is unconstrained. See the comment in
-                                // `Generalization`.
-                                ty::Bivariant => self.has_unconstrained_ty_var = true,
-
-                                // Co/contravariant: this will be
-                                // sufficiently constrained later on.
-                                ty::Covariant | ty::Contravariant => (),
+                                ty::Bivariant | ty::Covariant | ty::Contravariant => (),
                             }
 
                             let origin = inner.type_variables().var_origin(vid);
@@ -775,28 +750,4 @@ struct Generalization<T> {
     /// otherwise very easily result in infinite
     /// recursion.
     pub value_may_be_infer: T,
-
-    /// In general, we do not check whether all types which occur during
-    /// type checking are well-formed. We only check wf of user-provided types
-    /// and when actually using a type, e.g. for method calls.
-    ///
-    /// This means that when subtyping, we may end up with unconstrained
-    /// inference variables if a generalized type has bivariant parameters.
-    /// A parameter may only be bivariant if it is constrained by a projection
-    /// bound in a where-clause. As an example, imagine a type:
-    ///
-    ///     struct Foo<A, B> where A: Iterator<Item = B> {
-    ///         data: A
-    ///     }
-    ///
-    /// here, `A` will be covariant, but `B` is unconstrained.
-    ///
-    /// However, whatever it is, for `Foo` to be WF, it must be equal to `A::Item`.
-    /// If we have an input `Foo<?A, ?B>`, then after generalization we will wind
-    /// up with a type like `Foo<?C, ?D>`. When we enforce `Foo<?A, ?B> <: Foo<?C, ?D>`,
-    /// we will wind up with the requirement that `?A <: ?C`, but no particular
-    /// relationship between `?B` and `?D` (after all, these types may be completely
-    /// different). If we do nothing else, this may mean that `?D` goes unconstrained
-    /// (as in #41677). To avoid this we emit a `WellFormed` obligation in these cases.
-    pub has_unconstrained_ty_var: bool,
 }

--- a/compiler/rustc_type_ir/src/relate/solver_relating.rs
+++ b/compiler/rustc_type_ir/src/relate/solver_relating.rs
@@ -111,7 +111,7 @@ where
     Infcx: InferCtxtLike<Interner = I>,
     I: Interner,
 {
-    pub fn new(
+    fn new(
         infcx: &'infcx Infcx,
         structurally_relate_aliases: StructurallyRelateAliases,
         ambient_variance: ty::Variance,


### PR DESCRIPTION
We currently rely on generalize to emit WF obligations to constrain bivariant arguments.
This causes issues in the new solver and fixing it is annoying https://github.com/rust-lang/trait-system-refactor-initiative/issues/250. It seems a lot nicer to simply require all used "root types" to be well-formed.

This requires to following additions:
- locals currently only get checked for WF if they have an explicit type annotation
- coercions need to require the individual lubs to be wf as otherwise (a lub b) lub c) never checks that `(a lub b)` by itself is WF

r? @ghost