### PR TITLE
Constify `ControlFlow` methods without unstable bounds

### DIFF
--- a/library/core/src/ops/control_flow.rs
+++ b/library/core/src/ops/control_flow.rs
@@ -150,7 +150,8 @@ impl<B, C> ControlFlow<B, C> {
     /// ```
     #[inline]
     #[stable(feature = "control_flow_enum_is", since = "1.59.0")]
-    pub fn is_break(&self) -> bool {
+    #[rustc_const_unstable(feature = "const_control_flow", issue = "none")]
+    pub const fn is_break(&self) -> bool {
         matches!(*self, ControlFlow::Break(_))
     }
 
@@ -166,7 +167,8 @@ impl<B, C> ControlFlow<B, C> {
     /// ```
     #[inline]
     #[stable(feature = "control_flow_enum_is", since = "1.59.0")]
-    pub fn is_continue(&self) -> bool {
+    #[rustc_const_unstable(feature = "const_control_flow", issue = "none")]
+    pub const fn is_continue(&self) -> bool {
         matches!(*self, ControlFlow::Continue(_))
     }
 
@@ -257,7 +259,8 @@ impl<B, C> ControlFlow<B, C> {
     /// ```
     #[inline]
     #[unstable(feature = "control_flow_ok", issue = "140266")]
-    pub fn break_ok(self) -> Result<B, C> {
+    #[rustc_const_unstable(feature = "const_control_flow", issue = "none")]
+    pub const fn break_ok(self) -> Result<B, C> {
         match self {
             ControlFlow::Continue(c) => Err(c),
             ControlFlow::Break(b) => Ok(b),
@@ -361,7 +364,8 @@ impl<B, C> ControlFlow<B, C> {
     /// ```
     #[inline]
     #[unstable(feature = "control_flow_ok", issue = "140266")]
-    pub fn continue_ok(self) -> Result<C, B> {
+    #[rustc_const_unstable(feature = "const_control_flow", issue = "none")]
+    pub const fn continue_ok(self) -> Result<C, B> {
         match self {
             ControlFlow::Continue(c) => Ok(c),
             ControlFlow::Break(b) => Err(b),

--- a/library/core/src/ops/control_flow.rs
+++ b/library/core/src/ops/control_flow.rs
@@ -150,7 +150,7 @@ impl<B, C> ControlFlow<B, C> {
     /// ```
     #[inline]
     #[stable(feature = "control_flow_enum_is", since = "1.59.0")]
-    #[rustc_const_unstable(feature = "const_control_flow", issue = "none")]
+    #[rustc_const_unstable(feature = "min_const_control_flow", issue = "148738")]
     pub const fn is_break(&self) -> bool {
         matches!(*self, ControlFlow::Break(_))
     }
@@ -167,7 +167,7 @@ impl<B, C> ControlFlow<B, C> {
     /// ```
     #[inline]
     #[stable(feature = "control_flow_enum_is", since = "1.59.0")]
-    #[rustc_const_unstable(feature = "const_control_flow", issue = "none")]
+    #[rustc_const_unstable(feature = "min_const_control_flow", issue = "148738")]
     pub const fn is_continue(&self) -> bool {
         matches!(*self, ControlFlow::Continue(_))
     }
@@ -259,7 +259,7 @@ impl<B, C> ControlFlow<B, C> {
     /// ```
     #[inline]
     #[unstable(feature = "control_flow_ok", issue = "140266")]
-    #[rustc_const_unstable(feature = "const_control_flow", issue = "none")]
+    #[rustc_const_unstable(feature = "min_const_control_flow", issue = "148738")]
     pub const fn break_ok(self) -> Result<B, C> {
         match self {
             ControlFlow::Continue(c) => Err(c),
@@ -364,7 +364,7 @@ impl<B, C> ControlFlow<B, C> {
     /// ```
     #[inline]
     #[unstable(feature = "control_flow_ok", issue = "140266")]
-    #[rustc_const_unstable(feature = "const_control_flow", issue = "none")]
+    #[rustc_const_unstable(feature = "min_const_control_flow", issue = "148738")]
     pub const fn continue_ok(self) -> Result<C, B> {
         match self {
             ControlFlow::Continue(c) => Ok(c),


### PR DESCRIPTION
Feature: `min_const_control_flow`
Tracking issue: rust-lang/rust#148738

This PR constifies some of the methods on `ControlFlow`.