### PR TITLE
array_chunks: remove Option wrapper from into_remainder's return type

### DIFF
--- a/library/core/src/iter/adapters/array_chunks.rs
+++ b/library/core/src/iter/adapters/array_chunks.rs
@@ -40,17 +40,17 @@ where
     /// # // Also serves as a regression test for https://github.com/rust-lang/rust/issues/123333
     /// # #![feature(iter_array_chunks)]
     /// let x = [1,2,3,4,5].into_iter().array_chunks::<2>();
-    /// let mut rem = x.into_remainder().unwrap();
+    /// let mut rem = x.into_remainder();
     /// assert_eq!(rem.next(), Some(5));
     /// assert_eq!(rem.next(), None);
     /// ```
     #[unstable(feature = "iter_array_chunks", reason = "recently added", issue = "100450")]
     #[inline]
-    pub fn into_remainder(mut self) -> Option<array::IntoIter<I::Item, N>> {
-        if self.remainder.is_none() {
-            while let Some(_) = self.next() {}
+    pub fn into_remainder(mut self) -> array::IntoIter<I::Item, N> {
+        while self.remainder.is_none() {
+            let _ = self.next();
         }
-        self.remainder
+        self.remainder.unwrap()
     }
 }
 

--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -3523,7 +3523,7 @@ pub trait Iterator {
     /// assert_eq!(iter.next(), Some(['l', 'o']));
     /// assert_eq!(iter.next(), Some(['r', 'e']));
     /// assert_eq!(iter.next(), None);
-    /// assert_eq!(iter.into_remainder().unwrap().as_slice(), &['m']);
+    /// assert_eq!(iter.into_remainder().as_slice(), &['m']);
     /// ```
     ///
     /// ```

--- a/library/coretests/tests/iter/adapters/array_chunks.rs
+++ b/library/coretests/tests/iter/adapters/array_chunks.rs
@@ -18,10 +18,10 @@ fn test_iterator_array_chunks_clone_and_drop() {
     assert_eq!(count.get(), 3);
     let mut it2 = it.clone();
     assert_eq!(count.get(), 3);
-    assert_eq!(it.into_remainder().unwrap().len(), 2);
+    assert_eq!(it.into_remainder().len(), 2);
     assert_eq!(count.get(), 5);
     assert!(it2.next().is_none());
-    assert_eq!(it2.into_remainder().unwrap().len(), 2);
+    assert_eq!(it2.into_remainder().len(), 2);
     assert_eq!(count.get(), 7);
 }
 
@@ -31,7 +31,7 @@ fn test_iterator_array_chunks_remainder() {
     assert_eq!(it.next(), Some([0, 1, 2, 3]));
     assert_eq!(it.next(), Some([4, 5, 6, 7]));
     assert_eq!(it.next(), None);
-    assert_eq!(it.into_remainder().unwrap().as_slice(), &[8, 9, 10]);
+    assert_eq!(it.into_remainder().as_slice(), &[8, 9, 10]);
 }
 
 #[test]
@@ -89,7 +89,7 @@ fn test_iterator_array_chunks_next_and_next_back() {
     assert_eq!(it.next(), None);
     assert_eq!(it.next_back(), None);
     assert_eq!(it.next(), None);
-    assert_eq!(it.into_remainder().unwrap().as_slice(), &[9, 10]);
+    assert_eq!(it.into_remainder().as_slice(), &[9, 10]);
 }
 
 #[test]
@@ -102,7 +102,7 @@ fn test_iterator_array_chunks_rev_remainder() {
         assert_eq!(it.next(), None);
         assert_eq!(it.next(), None);
     }
-    assert_eq!(it.into_remainder().unwrap().as_slice(), &[8, 9, 10]);
+    assert_eq!(it.into_remainder().as_slice(), &[8, 9, 10]);
 }
 
 #[test]


### PR DESCRIPTION
This simplifies `into_remainder`'s return type.