### PR TITLE
Improve diagnose for unconditional panic when resource limit

### DIFF
--- a/compiler/rustc_interface/src/util.rs
+++ b/compiler/rustc_interface/src/util.rs
@@ -287,7 +287,15 @@ pub(crate) fn run_in_thread_pool_with_globals<
                         pool.install(|| f(current_gcx.into_inner(), proxy))
                     },
                 )
-                .unwrap()
+                .unwrap_or_else(|err| {
+                    let mut diag = thread_builder_diag.early_struct_fatal(format!(
+                        "failed to spawn compiler thread pool: could not create {threads} threads ({err})",
+                    ));
+                    diag.help(
+                        "try lowering `-Z threads` or checking the operating system's resource limits",
+                    );
+                    diag.emit();
+                })
         })
     })
 }


### PR DESCRIPTION
Improve diagnostic message for similar issue rust-lang/rust#115021.

When `parallel_compiler=true`, the Rust compiler frontend sets `-Z threads` to match the number of cores, which is reasonable and common. However, in a constrained environment or with an excessive number of cores (such as 377 mentioned below 😑), it could consume all resources and cause a panic.

Setting a default maximum for `-Z threads` in a parallel compiler is challenging. However, the panic error message can guide the user to check the system limit and explicitly lower the thread count according to their needs.

```
14:55:47 thread 'main' panicked at /rustc/f1586001ace26df7cafeb6534eaf76fb2c5513e5/compiler/rustc_interface/src/util.rs:216:18:

14:55:47 called `Result::unwrap()` on an `Err` value: ThreadPoolBuildError { kind: IOError(Os { code: 11, kind: WouldBlock, message: "Resource temporarily unavailable" }) }

...

14:55:47 note: compiler flags: --crate-type lib -C opt-level=z -C embed-bitcode=no -C linker=/cache/84996/rust-sdk/target/shim/aarch64-unknown-linux-ohos/clang -Z unstable-options -C symbol-mangling-version=v0 -Z panic-in-drop=abort -C codegen-units=1 -C debuginfo=1 -C embed-bitcode=yes -Z threads=377 -C link-arg=-Wl,--build-id=sha1 -Z binary-dep-depinfo
```