### PR TITLE
Fix types being marked as dead when they are inferred generic arguments

### DIFF
--- a/tests/ui/lint/dead-code/inferred-generic-arg.rs
+++ b/tests/ui/lint/dead-code/inferred-generic-arg.rs
@@ -1,0 +1,16 @@
+//@ check-pass
+
+#![deny(dead_code)]
+
+#[derive(Default)]
+struct Test {
+
+}
+
+fn main() {
+    if let Some::<Test>(test) = magic::<Test>() { }
+}
+
+fn magic<T: Default>() -> Option<T> {
+    Some(T::default())
+}


### PR DESCRIPTION
Previously usages of a type in a pattern were ignored. This is incorrect, since if the type is in a pattern we're clearly producing it in the expression we're matching against. 

I think this `in_pat` check was meant to be only for variants, which we should indeed ignore since we can just remove the match arm that matches the pattern. Please double check my logic here since this is my first time touching the dead-code pass and I'm not 100% sure this is what the `self.in_pat` check was for.

Fixes https://github.com/rust-lang/rust/issues/148144


