### PR TITLE
rustdoc: fix `--emit=dep-info` on scraped examples

### DIFF
--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -896,7 +896,7 @@ fn main_args(early_dcx: &mut EarlyDiagCtxt, at_args: &[String]) {
         // Register the loaded external files in the source map so they show up in depinfo.
         // We can't load them via the source map because it gets created after we process the options.
         for external_path in &loaded_paths {
-            let _ = sess.source_map().load_file(external_path);
+            let _ = sess.source_map().load_binary_file(external_path);
         }
 
         if sess.opts.describe_lints {

--- a/src/librustdoc/scrape_examples.rs
+++ b/src/librustdoc/scrape_examples.rs
@@ -273,6 +273,7 @@ pub(crate) fn run(
     bin_crate: bool,
 ) {
     let inner = move || -> Result<(), String> {
+        let emit_dep_info = renderopts.dep_info().is_some();
         // Generates source files for examples
         renderopts.no_emit_shared = true;
         let (cx, _) = Context::init(krate, renderopts, cache, tcx, Default::default())
@@ -319,6 +320,10 @@ pub(crate) fn run(
         let mut encoder = FileEncoder::new(options.output_path).map_err(|e| e.to_string())?;
         calls.encode(&mut encoder);
         encoder.finish().map_err(|(_path, e)| e.to_string())?;
+
+        if emit_dep_info {
+            rustc_interface::passes::write_dep_info(tcx);
+        }
 
         Ok(())
     };

--- a/tests/run-make/rustdoc-scrape-examples-dep-info/examples/ex.rs
+++ b/tests/run-make/rustdoc-scrape-examples-dep-info/examples/ex.rs
@@ -1,0 +1,6 @@
+fn main() {}
+
+#[test]
+fn a_test() {
+    foobar::ok();
+}

--- a/tests/run-make/rustdoc-scrape-examples-dep-info/rmake.rs
+++ b/tests/run-make/rustdoc-scrape-examples-dep-info/rmake.rs
@@ -10,10 +10,10 @@ fn main() {
         &["--emit=dep-info,invocation-specific"],
     );
 
-    let content = rfs::read_to_string("foobar.d");
+    let content = rfs::read_to_string("foobar.d").replace(r"\", "/");
     assert_contains(&content, "lib.rs:");
     assert_contains(&content, "rustdoc/ex.calls:");
 
-    let content = rfs::read_to_string("ex.d");
+    let content = rfs::read_to_string("ex.d").replace(r"\", "/");
     assert_contains(&content, "examples/ex.rs:");
 }

--- a/tests/run-make/rustdoc-scrape-examples-dep-info/rmake.rs
+++ b/tests/run-make/rustdoc-scrape-examples-dep-info/rmake.rs
@@ -1,0 +1,19 @@
+//@ needs-target-std
+use run_make_support::{assert_contains, rfs};
+
+#[path = "../rustdoc-scrape-examples-remap/scrape.rs"]
+mod scrape;
+
+fn main() {
+    scrape::scrape(
+        &["--scrape-tests", "--emit=dep-info"],
+        &["--emit=dep-info,invocation-specific"],
+    );
+
+    let content = rfs::read_to_string("foobar.d");
+    assert_contains(&content, "lib.rs:");
+    assert_contains(&content, "rustdoc/ex.calls:");
+
+    let content = rfs::read_to_string("ex.d");
+    assert_contains(&content, "examples/ex.rs:");
+}

--- a/tests/run-make/rustdoc-scrape-examples-dep-info/src/lib.rs
+++ b/tests/run-make/rustdoc-scrape-examples-dep-info/src/lib.rs
@@ -1,0 +1,3 @@
+//@ has foobar/fn.ok.html '//*[@class="docblock scraped-example-list"]' ''
+
+pub fn ok() {}

--- a/tests/run-make/rustdoc-scrape-examples-invalid-expr/rmake.rs
+++ b/tests/run-make/rustdoc-scrape-examples-invalid-expr/rmake.rs
@@ -3,5 +3,5 @@
 mod scrape;
 
 fn main() {
-    scrape::scrape(&[]);
+    scrape::scrape(&[], &[]);
 }

--- a/tests/run-make/rustdoc-scrape-examples-multiple/rmake.rs
+++ b/tests/run-make/rustdoc-scrape-examples-multiple/rmake.rs
@@ -3,5 +3,5 @@
 mod scrape;
 
 fn main() {
-    scrape::scrape(&[]);
+    scrape::scrape(&[], &[]);
 }

--- a/tests/run-make/rustdoc-scrape-examples-ordering/rmake.rs
+++ b/tests/run-make/rustdoc-scrape-examples-ordering/rmake.rs
@@ -3,5 +3,5 @@
 mod scrape;
 
 fn main() {
-    scrape::scrape(&[]);
+    scrape::scrape(&[], &[]);
 }

--- a/tests/run-make/rustdoc-scrape-examples-remap/rmake.rs
+++ b/tests/run-make/rustdoc-scrape-examples-remap/rmake.rs
@@ -2,5 +2,5 @@
 mod scrape;
 
 fn main() {
-    scrape::scrape(&[]);
+    scrape::scrape(&[], &[]);
 }

--- a/tests/run-make/rustdoc-scrape-examples-remap/scrape.rs
+++ b/tests/run-make/rustdoc-scrape-examples-remap/scrape.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use run_make_support::{htmldocck, rfs, rustc, rustdoc};
 
-pub fn scrape(extra_args: &[&str]) {
+pub fn scrape(extra_args_scrape: &[&str], extra_args_doc: &[&str]) {
     let out_dir = Path::new("rustdoc");
     let crate_name = "foobar";
     let deps = rfs::read_dir("examples")
@@ -27,7 +27,7 @@ pub fn scrape(extra_args: &[&str]) {
             .arg(&out_example)
             .arg("--scrape-examples-target-crate")
             .arg(crate_name)
-            .args(extra_args)
+            .args(extra_args_scrape)
             .run();
         out_deps.push(out_example);
     }
@@ -42,6 +42,7 @@ pub fn scrape(extra_args: &[&str]) {
     for dep in out_deps {
         rustdoc.arg("--with-examples").arg(dep);
     }
+    rustdoc.args(extra_args_doc);
     rustdoc.run();
 
     htmldocck().arg(out_dir).arg("src/lib.rs").run();

--- a/tests/run-make/rustdoc-scrape-examples-test/rmake.rs
+++ b/tests/run-make/rustdoc-scrape-examples-test/rmake.rs
@@ -3,5 +3,5 @@
 mod scrape;
 
 fn main() {
-    scrape::scrape(&["--scrape-tests"]);
+    scrape::scrape(&["--scrape-tests"], &[]);
 }

--- a/tests/run-make/rustdoc-scrape-examples-whitespace/rmake.rs
+++ b/tests/run-make/rustdoc-scrape-examples-whitespace/rmake.rs
@@ -3,5 +3,5 @@
 mod scrape;
 
 fn main() {
-    scrape::scrape(&[]);
+    scrape::scrape(&[], &[]);
 }


### PR DESCRIPTION
Makes sure both stages (the scraping process itself, and the doc build) emit complete dependency lists.

CC https://github.com/rust-lang/rust/pull/146220
Part of https://github.com/rust-lang/rust/issues/83784