### PR TITLE
Add missing `impl Fn for &mut F where F: Fn`

### DIFF
--- a/library/core/src/ops/async_function.rs
+++ b/library/core/src/ops/async_function.rs
@@ -126,6 +126,16 @@ mod impls {
             F::async_call_mut(self, args)
         }
     }
+
+    #[stable(feature = "async_closure", since = "1.85.0")]
+    impl<'a, A: Tuple, F: ?Sized> AsyncFn<A> for &'a mut F
+    where
+        F: AsyncFn<A>,
+    {
+        extern "rust-call" fn async_call(&self, args: A) -> Self::CallRefFuture<'_> {
+            F::async_call(*self, args)
+        }
+    }
 }
 
 mod internal_implementation_detail {

--- a/library/core/src/ops/function.rs
+++ b/library/core/src/ops/function.rs
@@ -310,4 +310,15 @@ mod impls {
             (*self).call_mut(args)
         }
     }
+
+    #[stable(feature = "rust1", since = "1.0.0")]
+    #[rustc_const_unstable(feature = "const_trait_impl", issue = "143874")]
+    impl<A: Tuple, F: ?Sized> const Fn<A> for &mut F
+    where
+        F: [const] Fn<A>,
+    {
+        extern "rust-call" fn call(&self, args: A) -> F::Output {
+            (**self).call(args)
+        }
+    }
 }

--- a/tests/ui/const-generics/adt_const_params/non_valtreeable_const_arg-2.stderr
+++ b/tests/ui/const-generics/adt_const_params/non_valtreeable_const_arg-2.stderr
@@ -29,6 +29,8 @@ LL |     Wrapper::<function>::call;
    = note: the following trait bounds were not satisfied:
            `Wrapper<function>: Fn<_>`
            which is required by `&Wrapper<function>: Fn<_>`
+           `Wrapper<function>: Fn<_>`
+           which is required by `&mut Wrapper<function>: Fn<_>`
 note: the trait `Fn` must be implemented
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
    = help: items from traits can only be used if the trait is implemented and in scope

--- a/tests/ui/impl-trait/where-allowed.stderr
+++ b/tests/ui/impl-trait/where-allowed.stderr
@@ -385,6 +385,8 @@ LL | fn in_impl_Fn_return_in_return() -> &'static impl Fn() -> impl Debug { pani
    = note: multiple `impl`s satisfying `_: Fn()` found in the following crates: `alloc`, `core`:
            - impl<A, F> Fn<A> for &F
              where A: Tuple, F: Fn<A>, F: ?Sized;
+           - impl<A, F> Fn<A> for &mut F
+             where A: Tuple, F: Fn<A>, F: ?Sized;
            - impl<Args, F, A> Fn<Args> for Box<F, A>
              where Args: Tuple, F: Fn<Args>, A: Allocator, F: ?Sized;
            - impl<F, Args> Fn<Args> for Exclusive<F>

--- a/tests/ui/traits/next-solver/well-formed-in-relate.stderr
+++ b/tests/ui/traits/next-solver/well-formed-in-relate.stderr
@@ -10,6 +10,8 @@ LL |     x = unconstrained_map();
    = note: multiple `impl`s satisfying `_: Fn()` found in the following crates: `alloc`, `core`:
            - impl<A, F> Fn<A> for &F
              where A: Tuple, F: Fn<A>, F: ?Sized;
+           - impl<A, F> Fn<A> for &mut F
+             where A: Tuple, F: Fn<A>, F: ?Sized;
            - impl<Args, F, A> Fn<Args> for Box<F, A>
              where Args: Tuple, F: Fn<Args>, A: Allocator, F: ?Sized;
            - impl<F, Args> Fn<Args> for Exclusive<F>


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/148271)*
<!-- homu-ignore:end -->

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Currently, there are blanket implementations for `&F` and `&mut F` for `FnMut` and `FnOnce`, but not for `Fn`, as a result, `&mut F` implements fewer of the `Fn` traits than `&F`, which is inconsistent and this PR fills that coherence hole

Technically, this is a breaking change because Fn is a fundamental trait, however, practical breakage is expected to be minimal, as such overlapping impl patterns are extremely rare

```rust
pub trait Trait {}
impl<F: Fn()> Trait for F {}
impl Trait for &fn() {}     // not allowed
impl Trait for &mut fn() {} // allowed
```

Because of this, second `impl` for `&mut fn()` works fine but shouldn't

Fixes https://github.com/rust-lang/rust/issues/147931
