### PR TITLE
Align VEX V5 boot routine to 4 bytes

### DIFF
--- a/compiler/rustc_target/src/spec/targets/armv7a_vex_v5_linker_script.ld
+++ b/compiler/rustc_target/src/spec/targets/armv7a_vex_v5_linker_script.ld
@@ -60,7 +60,7 @@ SECTIONS {
     /*
      * Executable program instructions.
      */
-    .text : {
+    .text ALIGN(4) : {
         /* _boot routine (entry point from VEXos, must be at 0x03800020) */
         *(.boot)
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

This PR fixes an alignment issue with the initialization routine on the VEX V5 target.

Previously, if the `.text` output section contained any functions aligned to more than four bytes, the linker would add padding bytes before the beginning of `.text` rather than changing the position of the aligned function inside the section itself. This is an issue because the entry point for the program needs to be located at `0x3800_0020` on this platform and the addition of padding could cause it to be moved.

To fix this, I've forced the start address of the `.text` section to be aligned to 4 bytes so that the entry point is placed consistently. Items inside the section can still be aligned to values larger than this.
