### PR TITLE
stdio: make stdout block-buffered when not associated to a terminal

### DIFF
--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -346,7 +346,7 @@ mod util;
 
 const DEFAULT_BUF_SIZE: usize = crate::sys::io::DEFAULT_BUF_SIZE;
 
-pub(crate) use stdio::cleanup;
+pub(crate) use stdio::{StderrRaw, StdinRaw, StdoutRaw, cleanup};
 
 struct Guard<'a> {
     buf: &'a mut Vec<u8>,

--- a/library/std/src/os/fd/owned.rs
+++ b/library/std/src/os/fd/owned.rs
@@ -489,6 +489,13 @@ impl<'a> AsFd for io::StdinLock<'a> {
     }
 }
 
+impl AsFd for io::StdinRaw {
+    #[inline]
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        unsafe { BorrowedFd::borrow_raw(0) }
+    }
+}
+
 #[stable(feature = "io_safety", since = "1.63.0")]
 impl AsFd for io::Stdout {
     #[inline]
@@ -506,6 +513,13 @@ impl<'a> AsFd for io::StdoutLock<'a> {
     }
 }
 
+impl AsFd for io::StdoutRaw {
+    #[inline]
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        unsafe { BorrowedFd::borrow_raw(1) }
+    }
+}
+
 #[stable(feature = "io_safety", since = "1.63.0")]
 impl AsFd for io::Stderr {
     #[inline]
@@ -519,6 +533,13 @@ impl<'a> AsFd for io::StderrLock<'a> {
     #[inline]
     fn as_fd(&self) -> BorrowedFd<'_> {
         // SAFETY: user code should not close stderr out from under the standard library
+        unsafe { BorrowedFd::borrow_raw(2) }
+    }
+}
+
+impl AsFd for io::StderrRaw {
+    #[inline]
+    fn as_fd(&self) -> BorrowedFd<'_> {
         unsafe { BorrowedFd::borrow_raw(2) }
     }
 }

--- a/library/std/src/os/windows/io/handle.rs
+++ b/library/std/src/os/windows/io/handle.rs
@@ -562,6 +562,13 @@ impl<'a> AsHandle for crate::io::StdinLock<'a> {
     }
 }
 
+impl AsHandle for crate::io::StdinRaw {
+    #[inline]
+    fn as_handle(&self) -> BorrowedHandle<'_> {
+        unsafe { BorrowedHandle::borrow_raw(self.as_raw_handle()) }
+    }
+}
+
 #[stable(feature = "io_safety", since = "1.63.0")]
 impl AsHandle for crate::io::Stdout {
     #[inline]
@@ -578,6 +585,13 @@ impl<'a> AsHandle for crate::io::StdoutLock<'a> {
     }
 }
 
+impl AsHandle for crate::io::StdoutRaw {
+    #[inline]
+    fn as_handle(&self) -> BorrowedHandle<'_> {
+        unsafe { BorrowedHandle::borrow_raw(self.as_raw_handle()) }
+    }
+}
+
 #[stable(feature = "io_safety", since = "1.63.0")]
 impl AsHandle for crate::io::Stderr {
     #[inline]
@@ -588,6 +602,13 @@ impl AsHandle for crate::io::Stderr {
 
 #[stable(feature = "io_safety", since = "1.63.0")]
 impl<'a> AsHandle for crate::io::StderrLock<'a> {
+    #[inline]
+    fn as_handle(&self) -> BorrowedHandle<'_> {
+        unsafe { BorrowedHandle::borrow_raw(self.as_raw_handle()) }
+    }
+}
+
+impl AsHandle for crate::io::StderrRaw {
     #[inline]
     fn as_handle(&self) -> BorrowedHandle<'_> {
         unsafe { BorrowedHandle::borrow_raw(self.as_raw_handle()) }

--- a/library/std/src/os/windows/io/raw.rs
+++ b/library/std/src/os/windows/io/raw.rs
@@ -140,6 +140,24 @@ impl<'a> AsRawHandle for io::StderrLock<'a> {
     }
 }
 
+impl AsRawHandle for io::StdinRaw {
+    fn as_raw_handle(&self) -> RawHandle {
+        stdio_handle(unsafe { sys::c::GetStdHandle(sys::c::STD_INPUT_HANDLE) as RawHandle })
+    }
+}
+
+impl AsRawHandle for io::StdoutRaw {
+    fn as_raw_handle(&self) -> RawHandle {
+        stdio_handle(unsafe { sys::c::GetStdHandle(sys::c::STD_OUTPUT_HANDLE) as RawHandle })
+    }
+}
+
+impl AsRawHandle for io::StderrRaw {
+    fn as_raw_handle(&self) -> RawHandle {
+        stdio_handle(unsafe { sys::c::GetStdHandle(sys::c::STD_ERROR_HANDLE) as RawHandle })
+    }
+}
+
 // Translate a handle returned from `GetStdHandle` into a handle to return to
 // the user.
 fn stdio_handle(raw: RawHandle) -> RawHandle {


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

This changes `std::io::Stdout` so that:

- it is line-buffered when connected to a terminal
- it is block-buffered otherwise

This matches the behavior of standard library implementations from other popular languages (C/C++/Python just to name a few).