### PR TITLE
Fix deferred cast checks using the wrong body for determining constness

### DIFF
--- a/compiler/rustc_hir_typeck/src/cast.rs
+++ b/compiler/rustc_hir_typeck/src/cast.rs
@@ -32,7 +32,7 @@ use rustc_ast::util::parser::ExprPrecedence;
 use rustc_data_structures::fx::FxHashSet;
 use rustc_errors::codes::*;
 use rustc_errors::{Applicability, Diag, ErrorGuaranteed};
-use rustc_hir::def_id::DefId;
+use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_hir::{self as hir, ExprKind};
 use rustc_infer::infer::DefineOpaqueTypes;
 use rustc_macros::{TypeFoldable, TypeVisitable};
@@ -63,6 +63,7 @@ pub(crate) struct CastCheck<'tcx> {
     cast_ty: Ty<'tcx>,
     cast_span: Span,
     span: Span,
+    pub body_id: LocalDefId,
 }
 
 /// The kind of pointer and associated metadata (thin, length or vtable) - we
@@ -244,7 +245,8 @@ impl<'a, 'tcx> CastCheck<'tcx> {
         span: Span,
     ) -> Result<CastCheck<'tcx>, ErrorGuaranteed> {
         let expr_span = expr.span.find_ancestor_inside(span).unwrap_or(expr.span);
-        let check = CastCheck { expr, expr_ty, expr_span, cast_ty, cast_span, span };
+        let check =
+            CastCheck { expr, expr_ty, expr_span, cast_ty, cast_span, span, body_id: fcx.body_id };
 
         // For better error messages, check for some obviously unsized
         // cases now. We do a more thorough check at the end, once

--- a/tests/ui/traits/const-traits/issue-103677.cnst.stderr
+++ b/tests/ui/traits/const-traits/issue-103677.cnst.stderr
@@ -1,0 +1,9 @@
+error[E0277]: the trait bound `String: const Deref` is not satisfied
+  --> $DIR/issue-103677.rs:6:5
+   |
+LL |     &*s as &str;
+   |     ^^^
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/traits/const-traits/issue-103677.cnst.stderr
+++ b/tests/ui/traits/const-traits/issue-103677.cnst.stderr
@@ -1,9 +1,0 @@
-error[E0277]: the trait bound `String: const Deref` is not satisfied
-  --> $DIR/issue-103677.rs:6:5
-   |
-LL |     &*s as &str;
-   |     ^^^
-
-error: aborting due to 1 previous error
-
-For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/traits/const-traits/issue-103677.rs
+++ b/tests/ui/traits/const-traits/issue-103677.rs
@@ -1,10 +1,9 @@
-//@[stock] check-pass
+//@ check-pass
 //@ revisions: stock cnst
 #![cfg_attr(cnst, feature(const_trait_impl))]
 
 const _: fn(&String) = |s| {
     &*s as &str;
-    //[cnst]~^ ERROR: the trait bound `String: const Deref` is not satisfied
 };
 
 fn main() {}

--- a/tests/ui/traits/const-traits/issue-103677.rs
+++ b/tests/ui/traits/const-traits/issue-103677.rs
@@ -1,5 +1,10 @@
-//@ check-pass
+//@[stock] check-pass
+//@ revisions: stock cnst
+#![cfg_attr(cnst, feature(const_trait_impl))]
 
-const _: fn(&String) = |s| { &*s as &str; };
+const _: fn(&String) = |s| {
+    &*s as &str;
+    //[cnst]~^ ERROR: the trait bound `String: const Deref` is not satisfied
+};
 
 fn main() {}


### PR DESCRIPTION
re-introduces https://github.com/rust-lang/rust/pull/103683

it was lost in https://github.com/rust-lang/rust/commit/4fec845c3f971c0ec77fccf460fe981fc50a7a12

deferred checks possibly have more such issues, needs investigation.

r? @fee1-dead 