### PR TITLE
Un-shadow object bound candidate in `NormalizesTo` goal if self_ty is trait object

### DIFF
--- a/compiler/rustc_next_trait_solver/src/solve/assembly/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/assembly/mod.rs
@@ -1143,6 +1143,12 @@ where
                 // See `tests/ui/winnowing/norm-where-bound-gt-alias-bound.rs`.
                 if candidates.iter().any(|c| matches!(c.source, CandidateSource::ParamEnv(_))) {
                     candidates.retain(|c| matches!(c.source, CandidateSource::ParamEnv(_)));
+                } else if matches!(goal.predicate.self_ty().kind(), ty::Dynamic(..)) {
+                    // Object candidate may be shadowed by where-bound for the trait goal, see
+                    // `tests/ui/traits/next-solver/normalization-shadowing/use_object_if_empty_env.rs`.
+                    // Trait objects always have their associated types specified so `candidates`
+                    // won't be empty.
+                    self.assemble_object_bound_candidates(goal, &mut candidates);
                 } else if candidates.is_empty() {
                     // If the trait goal has been proven by using the environment, we want to treat
                     // aliases as rigid if there are no applicable projection bounds in the environment.

--- a/compiler/rustc_next_trait_solver/src/solve/assembly/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/assembly/mod.rs
@@ -454,7 +454,16 @@ where
                     self.assemble_object_bound_candidates(goal, &mut candidates);
                 }
             }
-            AssembleCandidatesFrom::EnvAndBounds => {}
+            AssembleCandidatesFrom::EnvAndBounds => {
+                // This is somewhat inconsistent and may make #57893 slightly easier to exploit.
+                // However, it matches the behavior of the old solver. See
+                // `tests/ui/traits/next-solver/normalization-shadowing/use_object_if_empty_env.rs`.
+                if matches!(normalized_self_ty.kind(), ty::Dynamic(..))
+                    && !candidates.iter().any(|c| matches!(c.source, CandidateSource::ParamEnv(_)))
+                {
+                    self.assemble_object_bound_candidates(goal, &mut candidates);
+                }
+            }
         }
 
         (candidates, failed_candidate_info)
@@ -1143,12 +1152,6 @@ where
                 // See `tests/ui/winnowing/norm-where-bound-gt-alias-bound.rs`.
                 if candidates.iter().any(|c| matches!(c.source, CandidateSource::ParamEnv(_))) {
                     candidates.retain(|c| matches!(c.source, CandidateSource::ParamEnv(_)));
-                } else if matches!(goal.predicate.self_ty().kind(), ty::Dynamic(..)) {
-                    // Object candidate may be shadowed by where-bound for the trait goal, see
-                    // `tests/ui/traits/next-solver/normalization-shadowing/use_object_if_empty_env.rs`.
-                    // Trait objects always have their associated types specified so `candidates`
-                    // won't be empty.
-                    self.assemble_object_bound_candidates(goal, &mut candidates);
                 } else if candidates.is_empty() {
                     // If the trait goal has been proven by using the environment, we want to treat
                     // aliases as rigid if there are no applicable projection bounds in the environment.

--- a/tests/ui/traits/next-solver/normalization-shadowing/use_object_if_empty_env.rs
+++ b/tests/ui/traits/next-solver/normalization-shadowing/use_object_if_empty_env.rs
@@ -1,6 +1,8 @@
 //@ compile-flags: -Znext-solver
 //@ check-pass
 
+// Regression test for trait-system-refactor-initiative#244
+
 trait Trait {
     type Assoc;
 }

--- a/tests/ui/traits/next-solver/normalization-shadowing/use_object_if_empty_env.rs
+++ b/tests/ui/traits/next-solver/normalization-shadowing/use_object_if_empty_env.rs
@@ -1,0 +1,17 @@
+//@ compile-flags: -Znext-solver
+//@ check-pass
+
+trait Trait {
+    type Assoc;
+}
+
+// We have param env candidate for the trait goal but not the projection.
+// Under such circumstance, consider object candidate if the self_ty is trait object.
+fn foo<T>(x: <dyn Trait<Assoc = T> as Trait>::Assoc) -> T
+where
+    dyn Trait<Assoc = T>: Trait,
+{
+    x
+}
+
+fn main() {}

--- a/tests/ui/traits/next-solver/normalization-shadowing/use_object_if_empty_env.rs
+++ b/tests/ui/traits/next-solver/normalization-shadowing/use_object_if_empty_env.rs
@@ -16,4 +16,21 @@ where
     x
 }
 
+trait Id<'a> {
+    type This: ?Sized;
+}
+impl<T: ?Sized> Id<'_> for T {
+    type This = T;
+}
+
+// Ensure that we properly normalize alias self_ty before evaluating the goal.
+fn alias_foo<T>(x: for<'a> fn(
+    <<dyn Trait<Assoc = T> as Id<'a>>::This as Trait>::Assoc
+)) -> fn(T)
+where
+    dyn Trait<Assoc = T>: Trait,
+{
+    x
+}
+
 fn main() {}


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
Fixes https://github.com/rust-lang/trait-system-refactor-initiative/issues/244

r? lcnr