### PR TITLE
Revert "Update cc-rs to 1.2.39 #146186"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -474,11 +474,10 @@ version = "0.1.0"
 
 [[package]]
 name = "cc"
-version = "1.2.39"
+version = "1.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1354349954c6fc9cb0deab020f27f783cf0b604e8bb754dc4658ecf0d29c35f"
+checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
 dependencies = [
- "find-msvc-tools",
  "jobserver",
  "libc",
  "shlex",

--- a/compiler/rustc_llvm/Cargo.toml
+++ b/compiler/rustc_llvm/Cargo.toml
@@ -11,7 +11,7 @@ libc = "0.2.73"
 [build-dependencies]
 # tidy-alphabetical-start
 # `cc` updates often break things, so we pin it here.
-cc = "=1.2.39"
+cc = "=1.2.16"
 # tidy-alphabetical-end
 
 [features]


### PR DESCRIPTION
This reverts https://github.com/rust-lang/rust/pull/146186. This will mean regressing whichever `cc` fixes were needed for

> fixes when compiling the Rust compiler for Arm64EC.

It's not clear which `cc` change causes the across-the-board perf regression, I suspect it's a change in how certain compiler flags are handed. But I can immediately tell this is a rabbit hole to investigate, so let's revert for now to return-to-baseline and alleviate time pressure.
