### PR TITLE
Allow check builds with binaries for the dummy codegen backend

### DIFF
--- a/compiler/rustc_interface/src/util.rs
+++ b/compiler/rustc_interface/src/util.rs
@@ -421,6 +421,7 @@ impl CodegenBackend for DummyCodegenBackend {
             .crate_types
             .iter()
             .find(|&&crate_type| crate_type != CrateType::Rlib)
+            && outputs.outputs.should_link()
         {
             #[allow(rustc::untranslatable_diagnostic)]
             #[allow(rustc::diagnostic_outside_of_impl)]


### PR DESCRIPTION
This is likely the last part necessary for https://github.com/rust-lang/miri/pull/4648. Miri needs to be able to do a regular check build for compile_fail doc tests to work.