### PR TITLE
[rustdoc search] Include extern crates when filtering on `import`

### DIFF
--- a/src/librustdoc/html/static/js/search.js
+++ b/src/librustdoc/html/static/js/search.js
@@ -3906,6 +3906,8 @@ class DocSearch {
                     return name === "traitalias";
                 case "macro":
                     return name === "attr" || name === "derive";
+                case "import":
+                    return name === "externcrate";
             }
 
             // No match

--- a/tests/rustdoc-js/import-filter.js
+++ b/tests/rustdoc-js/import-filter.js
@@ -1,0 +1,20 @@
+// This test ensures that when filtering on `import`, `externcrate` items are also displayed.
+// It also ensures that the opposite is not true.
+
+const EXPECTED = [
+    {
+        'query': 'import:st',
+        'others': [
+            { 'path': 'foo', 'name': 'st', 'href': '../foo/index.html#reexport.st' },
+            // FIXME: `href` is wrong: <https://github.com/rust-lang/rust/issues/148300>
+            { 'path': 'foo', 'name': 'st2', 'href': '../st2/index.html' },
+        ],
+    },
+    {
+        'query': 'externcrate:st',
+        'others': [
+            // FIXME: `href` is wrong: <https://github.com/rust-lang/rust/issues/148300>
+            { 'path': 'foo', 'name': 'st2', 'href': '../st2/index.html' },
+        ],
+    },
+];

--- a/tests/rustdoc-js/import-filter.rs
+++ b/tests/rustdoc-js/import-filter.rs
@@ -1,0 +1,7 @@
+#![crate_name = "foo"]
+
+pub extern crate std as st2;
+
+pub use crate::Bar as st;
+
+pub struct Bar;


### PR DESCRIPTION
As discussed https://github.com/rust-lang/rust/pull/147909, some filters should have been "grouped". This PR allows extern crates to match the `import` filter.

This PR also allowed me to uncover a bug for the URL generated for renamed extern crates. Opened rust-lang/rust#148300 for it.

r? @notriddle