### PR TITLE
Remove double check when decoding ExpnId to avoid races

### DIFF
--- a/compiler/rustc_metadata/src/rmeta/decoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder.rs
@@ -1560,7 +1560,6 @@ impl<'a> CrateMetadataRef<'a> {
     }
 
     fn expn_hash_to_expn_id(self, sess: &Session, index_guess: u32, hash: ExpnHash) -> ExpnId {
-        debug_assert_eq!(ExpnId::from_hash(hash), None);
         let index_guess = ExpnIndex::from_u32(index_guess);
         let old_hash = self.root.expn_hashes.get(self, index_guess).map(|lazy| lazy.decode(self));
 


### PR DESCRIPTION
Fixes debug assertion failure as described in https://github.com/rust-lang/rust/issues/141540#issuecomment-3462723909

Essentially failure happens during the race while decoding one `ExpnId` from different threads. This ICE doesn't happen with single threaded thread_pool due to early return within `decode_expn_id` with the same condition:

https://github.com/rust-lang/rust/blob/8205e6b75ec656305ac235d4726d2c7a1ddcef14/compiler/rustc_middle/src/query/on_disk_cache.rs#L605-L607

However I believe this race does not hurt because `register_expn_id` is pretty much idempotent:

https://github.com/rust-lang/rust/blob/8205e6b75ec656305ac235d4726d2c7a1ddcef14/compiler/rustc_span/src/hygiene.rs#L1397-L1413