### PR TITLE
Support composing two deref coercion adjustments

### DIFF
--- a/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
@@ -337,9 +337,19 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         *entry.get_mut() = adj;
                     }
 
+                    (
+                        &mut [.., Adjustment { kind: Adjust::Borrow(AutoBorrow::Ref(..)), .. }],
+                        &[Adjustment { kind: Adjust::Deref(_), .. }, ..],
+                    ) => {
+                        // A reborrow has no effect before a dereference, so we can safely merge adjustments.
+                        // A more general version of the above case.
+                        let entry_mut = entry.get_mut();
+                        entry_mut.pop();
+                        entry_mut.extend_from_slice(&adj[1..]);
+                    }
+
                     _ => {
-                        // FIXME: currently we never try to compose autoderefs
-                        // and ReifyFnPointer/UnsafeFnPointer, but we could.
+                        // FIXME: currently we never try to compose ReifyFnPointer/UnsafeFnPointer, but we could.
                         self.dcx().span_delayed_bug(
                             expr.span,
                             format!(

--- a/tests/ui/coercion/compose_autoderefs.rs
+++ b/tests/ui/coercion/compose_autoderefs.rs
@@ -1,0 +1,32 @@
+//@ edition:2021
+//@ check-pass
+
+use core::ops::Deref;
+
+struct A;
+struct B;
+struct C;
+
+impl Deref for C {
+    type Target = B;
+    fn deref(&self) -> &Self::Target {
+        &B
+    }
+}
+
+impl Deref for B {
+    type Target = A;
+    fn deref(&self) -> &Self::Target {
+        &A
+    }
+}
+
+fn f(v: u8) {
+    let _ = match v {
+        0 => &C,
+        1 => &B,
+        _ => &A,
+    };
+}
+
+fn main() {}


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/148320)*
<!-- homu-ignore:end -->

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
Fixes rust-lang/rust#148283 

Given a deref chain like `&C -> &B -> &A`, we do can coerce `&C -> &A` directly with adjustments:
```
rustc_hir_typeck::fn_ctxt::_impl::apply_adjustments adj=[
    Deref(None) -> C,
    Deref(Some(OverloadedDeref { mutbl: Not, ..)) -> B,
    Deref(Some(OverloadedDeref { mutbl: Not, ..)) -> A,
    Borrow(Ref(Not)) -> &A
]
```
But if we coerce in two steps: `&C -> &B` and `&B -> &A`, it errs with
```
can't compose [
    Deref(None) -> C,
    Deref(Some(OverloadedDeref { mutbl: Not, ..)) -> B,
    Borrow(Ref(Not)) -> &B
] and [
    Deref(None) -> B,
    Deref(Some(OverloadedDeref { mutbl: Not, ..)) -> A,
    Borrow(Ref(Not)) -> &A
]
```
This PR bridges the gap. 

About the FIXME, I'm not familiar with unsafe fn pointer so that's not covered.

Edited: My change allows **more than** deref composition. I think restricting it to **exactly** deref composition is suitable, to avoid surprising [behavior](https://github.com/rust-lang/rust/pull/148320#issuecomment-3471975980) where coercion order affects method selection.
Other unsupported composition can be reported by proper diagnostics.