### PR TITLE
Enable file locking support in illumos

### DIFF
--- a/library/std/src/fs/tests.rs
+++ b/library/std/src/fs/tests.rs
@@ -5,6 +5,7 @@ use rand::RngCore;
     target_os = "freebsd",
     target_os = "linux",
     target_os = "netbsd",
+    target_os = "illumos",
     target_vendor = "apple",
 ))]
 use crate::assert_matches::assert_matches;
@@ -14,6 +15,7 @@ use crate::char::MAX_LEN_UTF8;
     target_os = "freebsd",
     target_os = "linux",
     target_os = "netbsd",
+    target_os = "illumos",
     target_vendor = "apple",
 ))]
 use crate::fs::TryLockError;
@@ -227,6 +229,7 @@ fn file_test_io_seek_and_write() {
     target_os = "linux",
     target_os = "netbsd",
     target_os = "solaris",
+    target_os = "illumos",
     target_vendor = "apple",
 ))]
 fn file_lock_multiple_shared() {
@@ -251,6 +254,7 @@ fn file_lock_multiple_shared() {
     target_os = "linux",
     target_os = "netbsd",
     target_os = "solaris",
+    target_os = "illumos",
     target_vendor = "apple",
 ))]
 fn file_lock_blocking() {
@@ -276,6 +280,7 @@ fn file_lock_blocking() {
     target_os = "linux",
     target_os = "netbsd",
     target_os = "solaris",
+    target_os = "illumos",
     target_vendor = "apple",
 ))]
 fn file_lock_drop() {
@@ -298,6 +303,7 @@ fn file_lock_drop() {
     target_os = "linux",
     target_os = "netbsd",
     target_os = "solaris",
+    target_os = "illumos",
     target_vendor = "apple",
 ))]
 fn file_lock_dup() {

--- a/library/std/src/sys/fs/unix.rs
+++ b/library/std/src/sys/fs/unix.rs
@@ -1292,6 +1292,7 @@ impl File {
         target_os = "netbsd",
         target_os = "openbsd",
         target_os = "cygwin",
+        target_os = "illumos",
         target_vendor = "apple",
     ))]
     pub fn lock(&self) -> io::Result<()> {
@@ -1316,6 +1317,7 @@ impl File {
         target_os = "openbsd",
         target_os = "cygwin",
         target_os = "solaris",
+        target_os = "illumos",
         target_vendor = "apple",
     )))]
     pub fn lock(&self) -> io::Result<()> {
@@ -1329,6 +1331,7 @@ impl File {
         target_os = "netbsd",
         target_os = "openbsd",
         target_os = "cygwin",
+        target_os = "illumos",
         target_vendor = "apple",
     ))]
     pub fn lock_shared(&self) -> io::Result<()> {
@@ -1353,6 +1356,7 @@ impl File {
         target_os = "openbsd",
         target_os = "cygwin",
         target_os = "solaris",
+        target_os = "illumos",
         target_vendor = "apple",
     )))]
     pub fn lock_shared(&self) -> io::Result<()> {
@@ -1366,6 +1370,7 @@ impl File {
         target_os = "netbsd",
         target_os = "openbsd",
         target_os = "cygwin",
+        target_os = "illumos",
         target_vendor = "apple",
     ))]
     pub fn try_lock(&self) -> Result<(), TryLockError> {
@@ -1406,6 +1411,7 @@ impl File {
         target_os = "openbsd",
         target_os = "cygwin",
         target_os = "solaris",
+        target_os = "illumos",
         target_vendor = "apple",
     )))]
     pub fn try_lock(&self) -> Result<(), TryLockError> {
@@ -1422,6 +1428,7 @@ impl File {
         target_os = "netbsd",
         target_os = "openbsd",
         target_os = "cygwin",
+        target_os = "illumos",
         target_vendor = "apple",
     ))]
     pub fn try_lock_shared(&self) -> Result<(), TryLockError> {
@@ -1462,6 +1469,7 @@ impl File {
         target_os = "openbsd",
         target_os = "cygwin",
         target_os = "solaris",
+        target_os = "illumos",
         target_vendor = "apple",
     )))]
     pub fn try_lock_shared(&self) -> Result<(), TryLockError> {
@@ -1478,6 +1486,7 @@ impl File {
         target_os = "netbsd",
         target_os = "openbsd",
         target_os = "cygwin",
+        target_os = "illumos",
         target_vendor = "apple",
     ))]
     pub fn unlock(&self) -> io::Result<()> {
@@ -1502,6 +1511,7 @@ impl File {
         target_os = "openbsd",
         target_os = "cygwin",
         target_os = "solaris",
+        target_os = "illumos",
         target_vendor = "apple",
     )))]
     pub fn unlock(&self) -> io::Result<()> {


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/132977 introduced an allow-list of targets supporting file locking, but forgot to add illumos to it (which introduced support for it in ~2015). `File::lock` and friends are now stable, and the ecosystem is slowly replacing custom libc calls with the standard library. Crucially, in 1.91 both Cargo and bootstrap switched to `File::lock`, both breaking build directory locking.

This PR enables file locking on illumos. Fixes https://github.com/rust-lang/rust/issues/146312.