### PR TITLE
remove unnecessary fudge_inference

### DIFF
--- a/tests/ui/async-await/drop-track-bad-field-in-fru.stderr
+++ b/tests/ui/async-await/drop-track-bad-field-in-fru.stderr
@@ -1,11 +1,3 @@
-error[E0559]: variant `Option<_>::None` has no field named `value`
-  --> $DIR/drop-track-bad-field-in-fru.rs:6:12
-   |
-LL |     None { value: (), ..Default::default() }.await;
-   |            ^^^^^ `Option<_>::None` does not have this field
-   |
-   = note: all struct fields are already assigned
-
 error[E0277]: `Option<_>` is not a future
   --> $DIR/drop-track-bad-field-in-fru.rs:6:46
    |
@@ -20,6 +12,14 @@ help: remove the `.await`
 LL -     None { value: (), ..Default::default() }.await;
 LL +     None { value: (), ..Default::default() };
    |
+
+error[E0559]: variant `Option<_>::None` has no field named `value`
+  --> $DIR/drop-track-bad-field-in-fru.rs:6:12
+   |
+LL |     None { value: (), ..Default::default() }.await;
+   |            ^^^^^ `Option<_>::None` does not have this field
+   |
+   = note: all struct fields are already assigned
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/async-await/issue-98634.stderr
+++ b/tests/ui/async-await/issue-98634.stderr
@@ -28,11 +28,15 @@ error[E0271]: expected `callback` to return `Pin<Box<dyn Future<Output = ()>>>`,
 LL |         StructAsync { callback }.await;
    |                                  ^^^^^ expected `Pin<Box<dyn Future<Output = ()>>>`, found future
    |
-note: required by a bound in `StructAsync`
-  --> $DIR/issue-98634.rs:9:35
+note: required for `StructAsync<fn() -> impl Future<Output = ()> {callback}>` to implement `Future`
+  --> $DIR/issue-98634.rs:13:9
    |
-LL | pub struct StructAsync<F: Fn() -> Pin<Box<dyn Future<Output = ()>>>> {
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `StructAsync`
+LL | impl<F> Future for StructAsync<F>
+   |         ^^^^^^     ^^^^^^^^^^^^^^
+LL | where
+LL |     F: Fn() -> Pin<Box<dyn Future<Output = ()>>>,
+   |                --------------------------------- unsatisfied trait bound introduced here
+   = note: required for `StructAsync<fn() -> impl Future<Output = ()> {callback}>` to implement `IntoFuture`
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/const-generics/generic_const_exprs/issue-72819-generic-in-const-eval.full.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/issue-72819-generic-in-const-eval.full.stderr
@@ -1,20 +1,4 @@
 error[E0308]: mismatched types
-  --> $DIR/issue-72819-generic-in-const-eval.rs:20:12
-   |
-LL |     let x: Arr<{usize::MAX}> = Arr {};
-   |            ^^^^^^^^^^^^^^^^^ expected `false`, found `true`
-   |
-   = note: expected constant `false`
-              found constant `true`
-note: required by a bound in `Arr`
-  --> $DIR/issue-72819-generic-in-const-eval.rs:8:39
-   |
-LL | struct Arr<const N: usize>
-   |        --- required by a bound in this struct
-LL | where Assert::<{N < usize::MAX / 2}>: IsTrue,
-   |                                       ^^^^^^ required by this bound in `Arr`
-
-error[E0308]: mismatched types
   --> $DIR/issue-72819-generic-in-const-eval.rs:20:32
    |
 LL |     let x: Arr<{usize::MAX}> = Arr {};
@@ -30,6 +14,6 @@ LL | struct Arr<const N: usize>
 LL | where Assert::<{N < usize::MAX / 2}>: IsTrue,
    |                                       ^^^^^^ required by this bound in `Arr`
 
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/const-generics/generic_const_exprs/issue-72819-generic-in-const-eval.rs
+++ b/tests/ui/const-generics/generic_const_exprs/issue-72819-generic-in-const-eval.rs
@@ -19,5 +19,4 @@ impl IsTrue for Assert<true> {}
 fn main() {
     let x: Arr<{usize::MAX}> = Arr {};
     //[full]~^ ERROR mismatched types
-    //[full]~| ERROR mismatched types
 }

--- a/tests/ui/const-generics/issues/issue-73260.rs
+++ b/tests/ui/const-generics/issues/issue-73260.rs
@@ -14,5 +14,4 @@ impl IsTrue for Assert<true> {}
 fn main() {
     let x: Arr<{usize::MAX}> = Arr {};
     //~^ ERROR mismatched types
-    //~| ERROR mismatched types
 }

--- a/tests/ui/const-generics/issues/issue-73260.stderr
+++ b/tests/ui/const-generics/issues/issue-73260.stderr
@@ -1,21 +1,4 @@
 error[E0308]: mismatched types
-  --> $DIR/issue-73260.rs:15:12
-   |
-LL |     let x: Arr<{usize::MAX}> = Arr {};
-   |            ^^^^^^^^^^^^^^^^^ expected `false`, found `true`
-   |
-   = note: expected constant `false`
-              found constant `true`
-note: required by a bound in `Arr`
-  --> $DIR/issue-73260.rs:5:37
-   |
-LL | struct Arr<const N: usize>
-   |        --- required by a bound in this struct
-LL | where
-LL |     Assert::<{N < usize::MAX / 2}>: IsTrue,
-   |                                     ^^^^^^ required by this bound in `Arr`
-
-error[E0308]: mismatched types
   --> $DIR/issue-73260.rs:15:32
    |
 LL |     let x: Arr<{usize::MAX}> = Arr {};
@@ -32,6 +15,6 @@ LL | where
 LL |     Assert::<{N < usize::MAX / 2}>: IsTrue,
    |                                     ^^^^^^ required by this bound in `Arr`
 
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/derives/deriving-copyclone.stderr
+++ b/tests/ui/derives/deriving-copyclone.stderr
@@ -1,8 +1,8 @@
-error[E0277]: the trait bound `B<C>: Copy` is not satisfied
+error[E0277]: the trait bound `B<_>: Copy` is not satisfied
   --> $DIR/deriving-copyclone.rs:31:26
    |
 LL |     is_copy(B { a: 1, b: C });
-   |     -------              ^ the trait `Copy` is not implemented for `B<C>`
+   |     -------              ^ the trait `Copy` is not implemented for `B<_>`
    |     |
    |     required by a bound introduced by this call
    |
@@ -21,11 +21,11 @@ help: consider borrowing here
 LL |     is_copy(B { a: 1, b: &C });
    |                          +
 
-error[E0277]: the trait bound `B<C>: Clone` is not satisfied
+error[E0277]: the trait bound `B<_>: Clone` is not satisfied
   --> $DIR/deriving-copyclone.rs:32:27
    |
 LL |     is_clone(B { a: 1, b: C });
-   |     --------              ^ the trait `Clone` is not implemented for `B<C>`
+   |     --------              ^ the trait `Clone` is not implemented for `B<_>`
    |     |
    |     required by a bound introduced by this call
    |
@@ -44,11 +44,11 @@ help: consider borrowing here
 LL |     is_clone(B { a: 1, b: &C });
    |                           +
 
-error[E0277]: the trait bound `B<D>: Copy` is not satisfied
+error[E0277]: the trait bound `B<_>: Copy` is not satisfied
   --> $DIR/deriving-copyclone.rs:35:26
    |
 LL |     is_copy(B { a: 1, b: D });
-   |     -------              ^ the trait `Copy` is not implemented for `B<D>`
+   |     -------              ^ the trait `Copy` is not implemented for `B<_>`
    |     |
    |     required by a bound introduced by this call
    |

--- a/tests/ui/higher-ranked/trait-bounds/issue-62203-hrtb-ice.rs
+++ b/tests/ui/higher-ranked/trait-bounds/issue-62203-hrtb-ice.rs
@@ -36,7 +36,7 @@ trait Ty<'a> {
 
 fn main() {
     let v = Unit2.m(
-        L { //~ ERROR type mismatch
+        L {
             f: |x| {
                 drop(x);
                 Unit4 //~ ERROR to return `Unit3`, but it returns `Unit4`

--- a/tests/ui/higher-ranked/trait-bounds/issue-62203-hrtb-ice.stderr
+++ b/tests/ui/higher-ranked/trait-bounds/issue-62203-hrtb-ice.stderr
@@ -1,34 +1,3 @@
-error[E0271]: type mismatch resolving `<L<{closure@issue-62203-hrtb-ice.rs:40:16}> as T0<'r, (&u8,)>>::O == <_ as Ty<'r>>::V`
-  --> $DIR/issue-62203-hrtb-ice.rs:39:9
-   |
-LL |       let v = Unit2.m(
-   |                     - required by a bound introduced by this call
-LL | /         L {
-LL | |             f: |x| {
-LL | |                 drop(x);
-LL | |                 Unit4
-LL | |             },
-LL | |         },
-   | |_________^ type mismatch resolving `<L<{closure@issue-62203-hrtb-ice.rs:40:16}> as T0<'r, (&u8,)>>::O == <_ as Ty<'r>>::V`
-   |
-note: expected this to be `<_ as Ty<'_>>::V`
-  --> $DIR/issue-62203-hrtb-ice.rs:21:14
-   |
-LL |     type O = T::Output;
-   |              ^^^^^^^^^
-   = note: expected associated type `<_ as Ty<'_>>::V`
-                       found struct `Unit4`
-   = help: consider constraining the associated type `<_ as Ty<'_>>::V` to `Unit4` or calling a method that returns `<_ as Ty<'_>>::V`
-   = note: for more information, visit https://doc.rust-lang.org/book/ch19-03-advanced-traits.html
-note: required by a bound in `T1::m`
-  --> $DIR/issue-62203-hrtb-ice.rs:27:51
-   |
-LL |     fn m<'a, B: Ty<'a>, F>(&self, f: F) -> Unit1
-   |        - required by a bound in this associated function
-LL |     where
-LL |         F: for<'r> T0<'r, (<Self as Ty<'r>>::V,), O = <B as Ty<'r>>::V>,
-   |                                                   ^^^^^^^^^^^^^^^^^^^^ required by this bound in `T1::m`
-
 error[E0271]: expected `{closure@issue-62203-hrtb-ice.rs:40:16}` to return `Unit3`, but it returns `Unit4`
   --> $DIR/issue-62203-hrtb-ice.rs:42:17
    |
@@ -58,6 +27,6 @@ LL |     where
 LL |         F: for<'r> T0<'r, (<Self as Ty<'r>>::V,), O = <B as Ty<'r>>::V>,
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `T1::m`
 
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0271`.

--- a/tests/ui/iterators/ranges.stderr
+++ b/tests/ui/iterators/ranges.stderr
@@ -1,22 +1,22 @@
-error[E0277]: `RangeTo<{integer}>` is not an iterator
+error[E0277]: `RangeTo<_>` is not an iterator
   --> $DIR/ranges.rs:2:14
    |
 LL |     for _ in ..10 {}
    |              ^^^^ if you meant to iterate until a value, add a starting value
    |
-   = help: the trait `Iterator` is not implemented for `RangeTo<{integer}>`
+   = help: the trait `Iterator` is not implemented for `RangeTo<_>`
    = note: `..end` is a `RangeTo`, which cannot be iterated on; you might have meant to have a bounded `Range`: `0..end`
-   = note: required for `RangeTo<{integer}>` to implement `IntoIterator`
+   = note: required for `RangeTo<_>` to implement `IntoIterator`
 
-error[E0277]: `std::ops::RangeToInclusive<{integer}>` is not an iterator
+error[E0277]: `std::ops::RangeToInclusive<_>` is not an iterator
   --> $DIR/ranges.rs:4:14
    |
 LL |     for _ in ..=10 {}
    |              ^^^^^ if you meant to iterate until a value (including it), add a starting value
    |
-   = help: the trait `Iterator` is not implemented for `std::ops::RangeToInclusive<{integer}>`
+   = help: the trait `Iterator` is not implemented for `std::ops::RangeToInclusive<_>`
    = note: `..=end` is a `RangeToInclusive`, which cannot be iterated on; you might have meant to have a bounded `RangeInclusive`: `0..=end`
-   = note: required for `std::ops::RangeToInclusive<{integer}>` to implement `IntoIterator`
+   = note: required for `std::ops::RangeToInclusive<_>` to implement `IntoIterator`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/wf/wf-const-type.rs
+++ b/tests/ui/wf/wf-const-type.rs
@@ -10,7 +10,6 @@ struct NotCopy;
 const FOO: IsCopy<Option<NotCopy>> = IsCopy { t: None };
 //~^ ERROR E0277
 //~| ERROR E0277
-//~| ERROR E0277
 
 
 fn main() { }

--- a/tests/ui/wf/wf-const-type.stderr
+++ b/tests/ui/wf/wf-const-type.stderr
@@ -17,25 +17,6 @@ LL | struct NotCopy;
    |
 
 error[E0277]: the trait bound `NotCopy: Copy` is not satisfied
-  --> $DIR/wf-const-type.rs:10:12
-   |
-LL | const FOO: IsCopy<Option<NotCopy>> = IsCopy { t: None };
-   |            ^^^^^^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `NotCopy`
-   |
-   = note: required for `Option<NotCopy>` to implement `Copy`
-note: required by a bound in `IsCopy`
-  --> $DIR/wf-const-type.rs:7:17
-   |
-LL | struct IsCopy<T:Copy> { t: T }
-   |                 ^^^^ required by this bound in `IsCopy`
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-help: consider annotating `NotCopy` with `#[derive(Copy)]`
-   |
-LL + #[derive(Copy)]
-LL | struct NotCopy;
-   |
-
-error[E0277]: the trait bound `NotCopy: Copy` is not satisfied
   --> $DIR/wf-const-type.rs:10:50
    |
 LL | const FOO: IsCopy<Option<NotCopy>> = IsCopy { t: None };
@@ -53,6 +34,6 @@ LL + #[derive(Copy)]
 LL | struct NotCopy;
    |
 
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Previously hidden inside of `fn expected_inputs_for_expected_output` and duplicated into this function in rust-lang/rust#129317, see https://github.com/rust-lang/rust/pull/129317/files#r1732525824.

I don't think this is necessary, see inline comment.

r? @BoxyUwU 
