### PR TITLE
compiler: Fix a couple issues around cargo feature unification

### DIFF
--- a/compiler/rustc_index/Cargo.toml
+++ b/compiler/rustc_index/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2024"
 rustc_index_macros = { path = "../rustc_index_macros" }
 rustc_macros = { path = "../rustc_macros", optional = true }
 rustc_serialize = { path = "../rustc_serialize", optional = true }
-smallvec = "1.8.1"
+smallvec = { version = "1.8.1", optional = true }
 # tidy-alphabetical-end
 
 [features]
@@ -17,6 +17,7 @@ default = ["nightly"]
 nightly = [
     "dep:rustc_macros",
     "dep:rustc_serialize",
+    "dep:smallvec",
     "rustc_index_macros/nightly",
 ]
 rustc_randomized_layouts = []

--- a/compiler/rustc_type_ir_macros/Cargo.toml
+++ b/compiler/rustc_type_ir_macros/Cargo.toml
@@ -10,6 +10,6 @@ proc-macro = true
 # tidy-alphabetical-start
 proc-macro2 = "1"
 quote = "1"
-syn = { version = "2.0.9", features = ["full"] }
+syn = { version = "2.0.9", features = ["full", "visit-mut"] }
 synstructure = "0.13.0"
 # tidy-alphabetical-end


### PR DESCRIPTION
cc https://github.com/rust-lang/rust/issues/148266. this doesn't fix all the issues (`rustc_public` and `rustc_transmute` still emit warnings when tested individually), but it fixes all the simple ones.

To fix rustc_public I will probably need help from @AlexanderPortland or @makai410 to make sure I am not accidentally cfg-ing out items that are meant to be public. To fix `rustc_transmute`, I will need to know (from @jswrenn ?) in what context the `rustc` cargo feature is disapled. To reproduce the issues, you can run `x test rustc_{transmute,public}` locally.

---

The first issue I fixed was a warning in `rustc_index`:
```
Testing stage2 {rustc_parse_format} (aarch64-apple-darwin)
   Compiling rustc_index v0.0.0 (/Users/ci/project/compiler/rustc_index)
error: extern crate `smallvec` is unused in crate `rustc_index`
 --> compiler/rustc_index/src/lib.rs:2:1
  |
2 | #![cfg_attr(all(feature = "nightly", test), feature(stmt_expr_attributes))]
  | ^
  |
  = help: remove the dependency or add `use smallvec as _;` to the crate root
  = note: `-D unused-crate-dependencies` implied by `-D warnings`
  = help: to override `-D warnings` add `#[allow(unused_crate_dependencies)]`

error: could not compile `rustc_index` (lib) due to 1 previous error
```

The second was that `type_ir_macros` didn't fully specify its dependencies:
```
Testing stage1 {rustc_type_ir_macros} (aarch64-apple-darwin)
   Compiling rustc_type_ir_macros v0.0.0 (/Users/jyn/src/ferrocene3/compiler/rustc_type_ir_macros)
error[E0432]: unresolved import `syn::visit_mut`
   --> compiler/rustc_type_ir_macros/src/lib.rs:2:10
    |
  2 | use syn::visit_mut::VisitMut;
    |          ^^^^^^^^^ could not find `visit_mut` in `syn`
    |
note: found an item that was configured out
   --> /Users/jyn/.local/lib/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/syn-2.0.106/src/lib.rs:880:21
    |
878 | #[cfg(feature = "visit-mut")]
    |       --------------------- the item is gated behind the `visit-mut` feature
879 | #[cfg_attr(docsrs, doc(cfg(feature = "visit-mut")))]
880 | pub use crate::gen::visit_mut;
    |                     ^^^^^^^^^

error[E0433]: failed to resolve: could not find `visit_mut` in `syn`
   --> compiler/rustc_type_ir_macros/src/lib.rs:206:18
    |
206 |             syn::visit_mut::visit_type_path_mut(self, i);
    |                  ^^^^^^^^^ could not find `visit_mut` in `syn`
    |
note: found an item that was configured out
   --> /Users/jyn/.local/lib/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/syn-2.0.106/src/lib.rs:880:21
    |
878 | #[cfg(feature = "visit-mut")]
    |       --------------------- the item is gated behind the `visit-mut` feature
879 | #[cfg_attr(docsrs, doc(cfg(feature = "visit-mut")))]
880 | pub use crate::gen::visit_mut;
    |                     ^^^^^^^^^
```

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
