### PR TITLE
`nonpoison::Condvar` should take `MutexGuard` by reference

### DIFF
--- a/library/std/src/sync/barrier.rs
+++ b/library/std/src/sync/barrier.rs
@@ -125,7 +125,7 @@ impl Barrier {
         let local_gen = lock.generation_id;
         lock.count += 1;
         if lock.count < self.num_threads {
-            let _guard = self.cvar.wait_while(lock, |state| local_gen == state.generation_id);
+            self.cvar.wait_while(&mut lock, |state| local_gen == state.generation_id);
             BarrierWaitResult(false)
         } else {
             lock.count = 0;

--- a/library/std/tests/sync/condvar.rs
+++ b/library/std/tests/sync/condvar.rs
@@ -17,256 +17,237 @@ nonpoison_and_poison_unwrap_test!(
     }
 );
 
+#[test]
 #[cfg(not(any(target_os = "emscripten", target_os = "wasi")))] // No threads.
-nonpoison_and_poison_unwrap_test!(
-    name: notify_one,
-    test_body: {
-        use locks::{Condvar, Mutex};
+fn notify_one() {
+    use std::sync::{Condvar, Mutex};
 
-        let m = Arc::new(Mutex::new(()));
-        let m2 = m.clone();
-        let c = Arc::new(Condvar::new());
+    let m = Arc::new(Mutex::new(()));
+    let m2 = m.clone();
+    let c = Arc::new(Condvar::new());
+    let c2 = c.clone();
+
+    let g = m.lock().unwrap();
+    let _t = thread::spawn(move || {
+        let _g = m2.lock().unwrap();
+        c2.notify_one();
+    });
+
+    let g = c.wait(g).unwrap();
+    drop(g);
+}
+
+#[test]
+#[cfg(not(any(target_os = "emscripten", target_os = "wasi")))] // No threads.
+fn notify_all() {
+    use std::sync::{Condvar, Mutex};
+
+    const N: usize = 10;
+
+    let data = Arc::new((Mutex::new(0), Condvar::new()));
+    let (tx, rx) = channel();
+    for _ in 0..N {
+        let data = data.clone();
+        let tx = tx.clone();
+        thread::spawn(move || {
+            let &(ref lock, ref cond) = &*data;
+            let mut cnt = lock.lock().unwrap();
+            *cnt += 1;
+            if *cnt == N {
+                tx.send(()).unwrap();
+            }
+            while *cnt != 0 {
+                cnt = cond.wait(cnt).unwrap();
+            }
+            tx.send(()).unwrap();
+        });
+    }
+    drop(tx);
+
+    let &(ref lock, ref cond) = &*data;
+    rx.recv().unwrap();
+    let mut cnt = lock.lock().unwrap();
+    *cnt = 0;
+    cond.notify_all();
+    drop(cnt);
+
+    for _ in 0..N {
+        rx.recv().unwrap();
+    }
+}
+
+#[test]
+#[cfg(not(any(target_os = "emscripten", target_os = "wasi")))] // No threads.
+fn test_mutex_arc_condvar() {
+    use std::sync::{Condvar, Mutex};
+
+    struct Packet<T>(Arc<(Mutex<T>, Condvar)>);
+
+    let packet = Packet(Arc::new((Mutex::new(false), Condvar::new())));
+    let packet2 = Packet(packet.0.clone());
+
+    let (tx, rx) = channel();
+
+    let _t = thread::spawn(move || {
+        // Wait until our parent has taken the lock.
+        rx.recv().unwrap();
+        let &(ref lock, ref cvar) = &*packet2.0;
+
+        // Set the data to `true` and wake up our parent.
+        let mut guard = lock.lock().unwrap();
+        *guard = true;
+        cvar.notify_one();
+    });
+
+    let &(ref lock, ref cvar) = &*packet.0;
+    let mut guard = lock.lock().unwrap();
+    // Wake up our child.
+    tx.send(()).unwrap();
+
+    // Wait until our child has set the data to `true`.
+    assert!(!*guard);
+    while !*guard {
+        guard = cvar.wait(guard).unwrap();
+    }
+}
+
+#[test]
+#[cfg(not(any(target_os = "emscripten", target_os = "wasi")))] // No threads.
+fn wait_while() {
+    use std::sync::{Condvar, Mutex};
+
+    let pair = Arc::new((Mutex::new(false), Condvar::new()));
+    let pair2 = pair.clone();
+
+    // Inside of our lock, spawn a new thread, and then wait for it to start.
+    thread::spawn(move || {
+        let &(ref lock, ref cvar) = &*pair2;
+        let mut started = lock.lock().unwrap();
+        *started = true;
+        // We notify the condvar that the value has changed.
+        cvar.notify_one();
+    });
+
+    // Wait for the thread to start up.
+    let &(ref lock, ref cvar) = &*pair;
+    let guard = cvar.wait_while(lock.lock().unwrap(), |started| !*started).unwrap();
+    assert!(*guard);
+}
+
+#[test]
+#[cfg(not(any(target_os = "emscripten", target_os = "wasi")))] // No threads.
+fn wait_timeout_wait() {
+    use std::sync::{Condvar, Mutex};
+
+    let m = Arc::new(Mutex::new(()));
+    let c = Arc::new(Condvar::new());
+
+    loop {
+        let g = m.lock().unwrap();
+        let (_g, no_timeout) = c.wait_timeout(g, Duration::from_millis(1)).unwrap();
+        // spurious wakeups mean this isn't necessarily true
+        // so execute test again, if not timeout
+        if !no_timeout.timed_out() {
+            continue;
+        }
+
+        break;
+    }
+}
+
+#[test]
+#[cfg(not(any(target_os = "emscripten", target_os = "wasi")))] // No threads.
+fn wait_timeout_while_wait() {
+    use std::sync::{Condvar, Mutex};
+
+    let m = Arc::new(Mutex::new(()));
+    let c = Arc::new(Condvar::new());
+
+    let g = m.lock().unwrap();
+    let (_g, wait) = c.wait_timeout_while(g, Duration::from_millis(1), |_| true).unwrap();
+    // no spurious wakeups. ensure it timed-out
+    assert!(wait.timed_out());
+}
+
+#[test]
+#[cfg(not(any(target_os = "emscripten", target_os = "wasi")))] // No threads.
+fn wait_timeout_while_instant_satisfy() {
+    use std::sync::{Condvar, Mutex};
+
+    let m = Arc::new(Mutex::new(()));
+    let c = Arc::new(Condvar::new());
+
+    let g = m.lock().unwrap();
+    let (_g, wait) = c.wait_timeout_while(g, Duration::from_millis(0), |_| false).unwrap();
+    // ensure it didn't time-out even if we were not given any time.
+    assert!(!wait.timed_out());
+}
+
+#[test]
+#[cfg(not(any(target_os = "emscripten", target_os = "wasi")))] // No threads.
+fn wait_timeout_while_wake() {
+    use std::sync::{Condvar, Mutex};
+
+    let pair = Arc::new((Mutex::new(false), Condvar::new()));
+    let pair_copy = pair.clone();
+
+    let &(ref m, ref c) = &*pair;
+    let g = m.lock().unwrap();
+    let _t = thread::spawn(move || {
+        let &(ref lock, ref cvar) = &*pair_copy;
+        let mut started = lock.lock().unwrap();
+        thread::sleep(Duration::from_millis(1));
+        *started = true;
+        cvar.notify_one();
+    });
+
+    let (g2, wait) = c
+        .wait_timeout_while(g, Duration::from_millis(u64::MAX), |&mut notified| !notified)
+        .unwrap();
+    // ensure it didn't time-out even if we were not given any time.
+    assert!(!wait.timed_out());
+    assert!(*g2);
+}
+
+#[test]
+#[cfg(not(any(target_os = "emscripten", target_os = "wasi")))] // No threads.
+fn wait_timeout_wake() {
+    use std::sync::{Condvar, Mutex};
+
+    let m = Arc::new(Mutex::new(()));
+    let c = Arc::new(Condvar::new());
+
+    loop {
+        let g = m.lock().unwrap();
+
         let c2 = c.clone();
+        let m2 = m.clone();
 
-        let g = maybe_unwrap(m.lock());
-        let _t = thread::spawn(move || {
-            let _g = maybe_unwrap(m2.lock());
+        let notified = Arc::new(AtomicBool::new(false));
+        let notified_copy = notified.clone();
+
+        let t = thread::spawn(move || {
+            let _g = m2.lock().unwrap();
+            thread::sleep(Duration::from_millis(1));
+            notified_copy.store(true, Ordering::Relaxed);
             c2.notify_one();
         });
-        let g = maybe_unwrap(c.wait(g));
-        drop(g);
-    }
-);
 
-#[cfg(not(any(target_os = "emscripten", target_os = "wasi")))] // No threads.
-nonpoison_and_poison_unwrap_test!(
-    name: notify_all,
-    test_body: {
-        use locks::{Condvar, Mutex};
-
-        const N: usize = 10;
-
-        let data = Arc::new((Mutex::new(0), Condvar::new()));
-        let (tx, rx) = channel();
-        for _ in 0..N {
-            let data = data.clone();
-            let tx = tx.clone();
-            thread::spawn(move || {
-                let &(ref lock, ref cond) = &*data;
-                let mut cnt = maybe_unwrap(lock.lock());
-                *cnt += 1;
-                if *cnt == N {
-                    tx.send(()).unwrap();
-                }
-                while *cnt != 0 {
-                    cnt = maybe_unwrap(cond.wait(cnt));
-                }
-                tx.send(()).unwrap();
-            });
-        }
-        drop(tx);
-
-        let &(ref lock, ref cond) = &*data;
-        rx.recv().unwrap();
-        let mut cnt = maybe_unwrap(lock.lock());
-        *cnt = 0;
-        cond.notify_all();
-        drop(cnt);
-
-        for _ in 0..N {
-            rx.recv().unwrap();
-        }
-    }
-);
-
-#[cfg(not(any(target_os = "emscripten", target_os = "wasi")))] // No threads.
-nonpoison_and_poison_unwrap_test!(
-    name: test_mutex_arc_condvar,
-    test_body: {
-        use locks::{Condvar, Mutex};
-
-        struct Packet<T>(Arc<(Mutex<T>, Condvar)>);
-
-        let packet = Packet(Arc::new((Mutex::new(false), Condvar::new())));
-        let packet2 = Packet(packet.0.clone());
-
-        let (tx, rx) = channel();
-
-        let _t = thread::spawn(move || {
-            // Wait until our parent has taken the lock.
-            rx.recv().unwrap();
-            let &(ref lock, ref cvar) = &*packet2.0;
-
-            // Set the data to `true` and wake up our parent.
-            let mut guard = maybe_unwrap(lock.lock());
-            *guard = true;
-            cvar.notify_one();
-        });
-
-        let &(ref lock, ref cvar) = &*packet.0;
-        let mut guard = maybe_unwrap(lock.lock());
-        // Wake up our child.
-        tx.send(()).unwrap();
-
-        // Wait until our child has set the data to `true`.
-        assert!(!*guard);
-        while !*guard {
-            guard = maybe_unwrap(cvar.wait(guard));
-        }
-    }
-);
-
-#[cfg(not(any(target_os = "emscripten", target_os = "wasi")))] // No threads.
-nonpoison_and_poison_unwrap_test!(
-    name: wait_while,
-    test_body: {
-        use locks::{Condvar, Mutex};
-
-        let pair = Arc::new((Mutex::new(false), Condvar::new()));
-        let pair2 = pair.clone();
-
-        // Inside of our lock, spawn a new thread, and then wait for it to start.
-        thread::spawn(move || {
-            let &(ref lock, ref cvar) = &*pair2;
-            let mut started = maybe_unwrap(lock.lock());
-            *started = true;
-            // We notify the condvar that the value has changed.
-            cvar.notify_one();
-        });
-
-        // Wait for the thread to start up.
-        let &(ref lock, ref cvar) = &*pair;
-        let guard = cvar.wait_while(maybe_unwrap(lock.lock()), |started| !*started);
-        assert!(*maybe_unwrap(guard));
-    }
-);
-
-#[cfg(not(any(target_os = "emscripten", target_os = "wasi")))] // No threads.
-nonpoison_and_poison_unwrap_test!(
-    name: wait_timeout_wait,
-    test_body: {
-        use locks::{Condvar, Mutex};
-
-        let m = Arc::new(Mutex::new(()));
-        let c = Arc::new(Condvar::new());
-
-        loop {
-            let g = maybe_unwrap(m.lock());
-            let (_g, no_timeout) = maybe_unwrap(c.wait_timeout(g, Duration::from_millis(1)));
-            // spurious wakeups mean this isn't necessarily true
-            // so execute test again, if not timeout
-            if !no_timeout.timed_out() {
-                continue;
-            }
-
-            break;
-        }
-    }
-);
-
-#[cfg(not(any(target_os = "emscripten", target_os = "wasi")))] // No threads.
-nonpoison_and_poison_unwrap_test!(
-    name: wait_timeout_while_wait,
-    test_body: {
-        use locks::{Condvar, Mutex};
-
-        let m = Arc::new(Mutex::new(()));
-        let c = Arc::new(Condvar::new());
-
-        let g = maybe_unwrap(m.lock());
-        let (_g, wait) = maybe_unwrap(c.wait_timeout_while(g, Duration::from_millis(1), |_| true));
-        // no spurious wakeups. ensure it timed-out
-        assert!(wait.timed_out());
-    }
-);
-
-#[cfg(not(any(target_os = "emscripten", target_os = "wasi")))] // No threads.
-nonpoison_and_poison_unwrap_test!(
-    name: wait_timeout_while_instant_satisfy,
-    test_body: {
-        use locks::{Condvar, Mutex};
-
-        let m = Arc::new(Mutex::new(()));
-        let c = Arc::new(Condvar::new());
-
-        let g = maybe_unwrap(m.lock());
-        let (_g, wait) =
-            maybe_unwrap(c.wait_timeout_while(g, Duration::from_millis(0), |_| false));
-        // ensure it didn't time-out even if we were not given any time.
-        assert!(!wait.timed_out());
-    }
-);
-
-#[cfg(not(any(target_os = "emscripten", target_os = "wasi")))] // No threads.
-nonpoison_and_poison_unwrap_test!(
-    name: wait_timeout_while_wake,
-    test_body: {
-        use locks::{Condvar, Mutex};
-
-        let pair = Arc::new((Mutex::new(false), Condvar::new()));
-        let pair_copy = pair.clone();
-
-        let &(ref m, ref c) = &*pair;
-        let g = maybe_unwrap(m.lock());
-        let _t = thread::spawn(move || {
-            let &(ref lock, ref cvar) = &*pair_copy;
-            let mut started = maybe_unwrap(lock.lock());
-            thread::sleep(Duration::from_millis(1));
-            *started = true;
-            cvar.notify_one();
-        });
-        let (g2, wait) = maybe_unwrap(c.wait_timeout_while(
-            g,
-            Duration::from_millis(u64::MAX),
-            |&mut notified| !notified
-        ));
-        // ensure it didn't time-out even if we were not given any time.
-        assert!(!wait.timed_out());
-        assert!(*g2);
-    }
-);
-
-#[cfg(not(any(target_os = "emscripten", target_os = "wasi")))] // No threads.
-nonpoison_and_poison_unwrap_test!(
-    name: wait_timeout_wake,
-    test_body: {
-        use locks::{Condvar, Mutex};
-
-        let m = Arc::new(Mutex::new(()));
-        let c = Arc::new(Condvar::new());
-
-        loop {
-            let g = maybe_unwrap(m.lock());
-
-            let c2 = c.clone();
-            let m2 = m.clone();
-
-            let notified = Arc::new(AtomicBool::new(false));
-            let notified_copy = notified.clone();
-
-            let t = thread::spawn(move || {
-                let _g = maybe_unwrap(m2.lock());
-                thread::sleep(Duration::from_millis(1));
-                notified_copy.store(true, Ordering::Relaxed);
-                c2.notify_one();
-            });
-            let (g, timeout_res) =
-                maybe_unwrap(c.wait_timeout(g, Duration::from_millis(u64::MAX)));
-            assert!(!timeout_res.timed_out());
-            // spurious wakeups mean this isn't necessarily true
-            // so execute test again, if not notified
-            if !notified.load(Ordering::Relaxed) {
-                t.join().unwrap();
-                continue;
-            }
-            drop(g);
-
+        let (g, timeout_res) = c.wait_timeout(g, Duration::from_millis(u64::MAX)).unwrap();
+        assert!(!timeout_res.timed_out());
+        // spurious wakeups mean this isn't necessarily true
+        // so execute test again, if not notified
+        if !notified.load(Ordering::Relaxed) {
             t.join().unwrap();
-
-            break;
+            continue;
         }
+        drop(g);
+
+        t.join().unwrap();
+
+        break;
     }
-);
+}
 
 // Some platforms internally cast the timeout duration into nanoseconds.
 // If they fail to consider overflow during the conversion (I'm looking
@@ -274,42 +255,41 @@ nonpoison_and_poison_unwrap_test!(
 // timeout for durations that are slightly longer than u64::MAX nanoseconds.
 // `std` should guard against this by clamping the timeout.
 // See #37440 for context.
-nonpoison_and_poison_unwrap_test!(
-    name: timeout_nanoseconds,
-    test_body: {
-        use locks::Mutex;
-        use locks::Condvar;
+#[test]
+fn timeout_nanoseconds() {
+    use std::sync::{Condvar, Mutex};
 
-        let sent = Mutex::new(false);
-        let cond = Condvar::new();
+    let sent = Mutex::new(false);
+    let cond = Condvar::new();
 
-        thread::scope(|s| {
-            s.spawn(|| {
-                // Sleep so that the other thread has a chance to encounter the
-                // timeout.
-                thread::sleep(Duration::from_secs(2));
-                maybe_unwrap(sent.set(true));
-                cond.notify_all();
-            });
+    thread::scope(|s| {
+        s.spawn(|| {
+            // Sleep so that the other thread has a chance to encounter the
+            // timeout.
+            thread::sleep(Duration::from_secs(2));
+            *sent.lock().unwrap() = true;
+            cond.notify_all();
+        });
 
-            let mut guard = maybe_unwrap(sent.lock());
-            // Loop until `sent` is set by the thread to guard against spurious
-            // wakeups. If the `wait_timeout` happens just before the signal by
-            // the other thread, such a spurious wakeup might prevent the
-            // miscalculated timeout from occurring, but this is basically just
-            // a smoke test anyway.
-            loop {
-                if *guard {
-                    break;
-                }
-
-                // If there is internal overflow, this call will return almost
-                // immediately, before the other thread has reached the `notify_all`,
-                // and indicate a timeout.
-                let (g, res) = maybe_unwrap(cond.wait_timeout(guard, Duration::from_secs(u64::MAX.div_ceil(1_000_000_000))));
-                assert!(!res.timed_out());
-                guard = g;
+        let mut guard = sent.lock().unwrap();
+        // Loop until `sent` is set by the thread to guard against spurious
+        // wakeups. If the `wait_timeout` happens just before the signal by
+        // the other thread, such a spurious wakeup might prevent the
+        // miscalculated timeout from occurring, but this is basically just
+        // a smoke test anyway.
+        loop {
+            if *guard {
+                break;
             }
-        })
-    }
-);
+
+            // If there is internal overflow, this call will return almost
+            // immediately, before the other thread has reached the `notify_all`,
+            // and indicate a timeout.
+            let (g, res) = cond
+                .wait_timeout(guard, Duration::from_secs(u64::MAX.div_ceil(1_000_000_000)))
+                .unwrap();
+            assert!(!res.timed_out());
+            guard = g;
+        }
+    })
+}

--- a/library/std/tests/sync/condvar.rs
+++ b/library/std/tests/sync/condvar.rs
@@ -19,8 +19,8 @@ nonpoison_and_poison_unwrap_test!(
 
 #[test]
 #[cfg(not(any(target_os = "emscripten", target_os = "wasi")))] // No threads.
-fn notify_one() {
-    use std::sync::{Condvar, Mutex};
+fn poison_notify_one() {
+    use std::sync::poison::{Condvar, Mutex};
 
     let m = Arc::new(Mutex::new(()));
     let m2 = m.clone();
@@ -39,8 +39,28 @@ fn notify_one() {
 
 #[test]
 #[cfg(not(any(target_os = "emscripten", target_os = "wasi")))] // No threads.
-fn notify_all() {
-    use std::sync::{Condvar, Mutex};
+fn nonpoison_notify_one() {
+    use std::sync::nonpoison::{Condvar, Mutex};
+
+    let m = Arc::new(Mutex::new(()));
+    let m2 = m.clone();
+    let c = Arc::new(Condvar::new());
+    let c2 = c.clone();
+
+    let mut g = m.lock();
+    let _t = thread::spawn(move || {
+        let _g = m2.lock();
+        c2.notify_one();
+    });
+
+    c.wait(&mut g);
+    drop(g);
+}
+
+#[test]
+#[cfg(not(any(target_os = "emscripten", target_os = "wasi")))] // No threads.
+fn poison_notify_all() {
+    use std::sync::poison::{Condvar, Mutex};
 
     const N: usize = 10;
 
@@ -78,8 +98,47 @@ fn notify_all() {
 
 #[test]
 #[cfg(not(any(target_os = "emscripten", target_os = "wasi")))] // No threads.
-fn test_mutex_arc_condvar() {
-    use std::sync::{Condvar, Mutex};
+fn nonpoison_notify_all() {
+    use std::sync::nonpoison::{Condvar, Mutex};
+
+    const N: usize = 10;
+
+    let data = Arc::new((Mutex::new(0), Condvar::new()));
+    let (tx, rx) = channel();
+    for _ in 0..N {
+        let data = data.clone();
+        let tx = tx.clone();
+        thread::spawn(move || {
+            let &(ref lock, ref cond) = &*data;
+            let mut cnt = lock.lock();
+            *cnt += 1;
+            if *cnt == N {
+                tx.send(()).unwrap();
+            }
+            while *cnt != 0 {
+                cond.wait(&mut cnt);
+            }
+            tx.send(()).unwrap();
+        });
+    }
+    drop(tx);
+
+    let &(ref lock, ref cond) = &*data;
+    rx.recv().unwrap();
+    let mut cnt = lock.lock();
+    *cnt = 0;
+    cond.notify_all();
+    drop(cnt);
+
+    for _ in 0..N {
+        rx.recv().unwrap();
+    }
+}
+
+#[test]
+#[cfg(not(any(target_os = "emscripten", target_os = "wasi")))] // No threads.
+fn poison_test_mutex_arc_condvar() {
+    use std::sync::poison::{Condvar, Mutex};
 
     struct Packet<T>(Arc<(Mutex<T>, Condvar)>);
 
@@ -113,8 +172,43 @@ fn test_mutex_arc_condvar() {
 
 #[test]
 #[cfg(not(any(target_os = "emscripten", target_os = "wasi")))] // No threads.
-fn wait_while() {
-    use std::sync::{Condvar, Mutex};
+fn nonpoison_test_mutex_arc_condvar() {
+    use std::sync::nonpoison::{Condvar, Mutex};
+
+    struct Packet<T>(Arc<(Mutex<T>, Condvar)>);
+
+    let packet = Packet(Arc::new((Mutex::new(false), Condvar::new())));
+    let packet2 = Packet(packet.0.clone());
+
+    let (tx, rx) = channel();
+
+    let _t = thread::spawn(move || {
+        // Wait until our parent has taken the lock.
+        rx.recv().unwrap();
+        let &(ref lock, ref cvar) = &*packet2.0;
+
+        // Set the data to `true` and wake up our parent.
+        let mut guard = lock.lock();
+        *guard = true;
+        cvar.notify_one();
+    });
+
+    let &(ref lock, ref cvar) = &*packet.0;
+    let mut guard = lock.lock();
+    // Wake up our child.
+    tx.send(()).unwrap();
+
+    // Wait until our child has set the data to `true`.
+    assert!(!*guard);
+    while !*guard {
+        cvar.wait(&mut guard);
+    }
+}
+
+#[test]
+#[cfg(not(any(target_os = "emscripten", target_os = "wasi")))] // No threads.
+fn poison_wait_while() {
+    use std::sync::poison::{Condvar, Mutex};
 
     let pair = Arc::new((Mutex::new(false), Condvar::new()));
     let pair2 = pair.clone();
@@ -136,8 +230,32 @@ fn wait_while() {
 
 #[test]
 #[cfg(not(any(target_os = "emscripten", target_os = "wasi")))] // No threads.
-fn wait_timeout_wait() {
-    use std::sync::{Condvar, Mutex};
+fn nonpoison_wait_while() {
+    use std::sync::nonpoison::{Condvar, Mutex};
+
+    let pair = Arc::new((Mutex::new(false), Condvar::new()));
+    let pair2 = pair.clone();
+
+    // Inside of our lock, spawn a new thread, and then wait for it to start.
+    thread::spawn(move || {
+        let &(ref lock, ref cvar) = &*pair2;
+        let mut started = lock.lock();
+        *started = true;
+        // We notify the condvar that the value has changed.
+        cvar.notify_one();
+    });
+
+    // Wait for the thread to start up.
+    let &(ref lock, ref cvar) = &*pair;
+    let mut guard = lock.lock();
+    cvar.wait_while(&mut guard, |started| !*started);
+    assert!(*guard);
+}
+
+#[test]
+#[cfg(not(any(target_os = "emscripten", target_os = "wasi")))] // No threads.
+fn poison_wait_timeout_wait() {
+    use std::sync::poison::{Condvar, Mutex};
 
     let m = Arc::new(Mutex::new(()));
     let c = Arc::new(Condvar::new());
@@ -157,8 +275,29 @@ fn wait_timeout_wait() {
 
 #[test]
 #[cfg(not(any(target_os = "emscripten", target_os = "wasi")))] // No threads.
-fn wait_timeout_while_wait() {
-    use std::sync::{Condvar, Mutex};
+fn nonpoison_wait_timeout_wait() {
+    use std::sync::nonpoison::{Condvar, Mutex};
+
+    let m = Arc::new(Mutex::new(()));
+    let c = Arc::new(Condvar::new());
+
+    loop {
+        let mut g = m.lock();
+        let no_timeout = c.wait_timeout(&mut g, Duration::from_millis(1));
+        // spurious wakeups mean this isn't necessarily true
+        // so execute test again, if not timeout
+        if !no_timeout.timed_out() {
+            continue;
+        }
+
+        break;
+    }
+}
+
+#[test]
+#[cfg(not(any(target_os = "emscripten", target_os = "wasi")))] // No threads.
+fn poison_wait_timeout_while_wait() {
+    use std::sync::poison::{Condvar, Mutex};
 
     let m = Arc::new(Mutex::new(()));
     let c = Arc::new(Condvar::new());
@@ -171,8 +310,22 @@ fn wait_timeout_while_wait() {
 
 #[test]
 #[cfg(not(any(target_os = "emscripten", target_os = "wasi")))] // No threads.
-fn wait_timeout_while_instant_satisfy() {
-    use std::sync::{Condvar, Mutex};
+fn nonpoison_wait_timeout_while_wait() {
+    use std::sync::nonpoison::{Condvar, Mutex};
+
+    let m = Arc::new(Mutex::new(()));
+    let c = Arc::new(Condvar::new());
+
+    let mut g = m.lock();
+    let wait = c.wait_timeout_while(&mut g, Duration::from_millis(1), |_| true);
+    // no spurious wakeups. ensure it timed-out
+    assert!(wait.timed_out());
+}
+
+#[test]
+#[cfg(not(any(target_os = "emscripten", target_os = "wasi")))] // No threads.
+fn poison_wait_timeout_while_instant_satisfy() {
+    use std::sync::poison::{Condvar, Mutex};
 
     let m = Arc::new(Mutex::new(()));
     let c = Arc::new(Condvar::new());
@@ -185,8 +338,22 @@ fn wait_timeout_while_instant_satisfy() {
 
 #[test]
 #[cfg(not(any(target_os = "emscripten", target_os = "wasi")))] // No threads.
-fn wait_timeout_while_wake() {
-    use std::sync::{Condvar, Mutex};
+fn nonpoison_wait_timeout_while_instant_satisfy() {
+    use std::sync::nonpoison::{Condvar, Mutex};
+
+    let m = Arc::new(Mutex::new(()));
+    let c = Arc::new(Condvar::new());
+
+    let mut g = m.lock();
+    let wait = c.wait_timeout_while(&mut g, Duration::from_millis(0), |_| false);
+    // ensure it didn't time-out even if we were not given any time.
+    assert!(!wait.timed_out());
+}
+
+#[test]
+#[cfg(not(any(target_os = "emscripten", target_os = "wasi")))] // No threads.
+fn poison_wait_timeout_while_wake() {
+    use std::sync::poison::{Condvar, Mutex};
 
     let pair = Arc::new((Mutex::new(false), Condvar::new()));
     let pair_copy = pair.clone();
@@ -211,8 +378,33 @@ fn wait_timeout_while_wake() {
 
 #[test]
 #[cfg(not(any(target_os = "emscripten", target_os = "wasi")))] // No threads.
-fn wait_timeout_wake() {
-    use std::sync::{Condvar, Mutex};
+fn nonpoison_wait_timeout_while_wake() {
+    use std::sync::nonpoison::{Condvar, Mutex};
+
+    let pair = Arc::new((Mutex::new(false), Condvar::new()));
+    let pair_copy = pair.clone();
+
+    let &(ref m, ref c) = &*pair;
+    let mut g = m.lock();
+    let _t = thread::spawn(move || {
+        let &(ref lock, ref cvar) = &*pair_copy;
+        let mut started = lock.lock();
+        thread::sleep(Duration::from_millis(1));
+        *started = true;
+        cvar.notify_one();
+    });
+
+    let wait =
+        c.wait_timeout_while(&mut g, Duration::from_millis(u64::MAX), |&mut notified| !notified);
+    // ensure it didn't time-out even if we were not given any time.
+    assert!(!wait.timed_out());
+    assert!(*g);
+}
+
+#[test]
+#[cfg(not(any(target_os = "emscripten", target_os = "wasi")))] // No threads.
+fn poison_wait_timeout_wake() {
+    use std::sync::poison::{Condvar, Mutex};
 
     let m = Arc::new(Mutex::new(()));
     let c = Arc::new(Condvar::new());
@@ -249,6 +441,46 @@ fn wait_timeout_wake() {
     }
 }
 
+#[test]
+#[cfg(not(any(target_os = "emscripten", target_os = "wasi")))] // No threads.
+fn nonpoison_wait_timeout_wake() {
+    use std::sync::nonpoison::{Condvar, Mutex};
+
+    let m = Arc::new(Mutex::new(()));
+    let c = Arc::new(Condvar::new());
+
+    loop {
+        let mut g = m.lock();
+
+        let c2 = c.clone();
+        let m2 = m.clone();
+
+        let notified = Arc::new(AtomicBool::new(false));
+        let notified_copy = notified.clone();
+
+        let t = thread::spawn(move || {
+            let _g = m2.lock();
+            thread::sleep(Duration::from_millis(1));
+            notified_copy.store(true, Ordering::Relaxed);
+            c2.notify_one();
+        });
+
+        let timeout_res = c.wait_timeout(&mut g, Duration::from_millis(u64::MAX));
+        assert!(!timeout_res.timed_out());
+        // spurious wakeups mean this isn't necessarily true
+        // so execute test again, if not notified
+        if !notified.load(Ordering::Relaxed) {
+            t.join().unwrap();
+            continue;
+        }
+        drop(g);
+
+        t.join().unwrap();
+
+        break;
+    }
+}
+
 // Some platforms internally cast the timeout duration into nanoseconds.
 // If they fail to consider overflow during the conversion (I'm looking
 // at you, macOS), `wait_timeout` will return immediately and indicate a
@@ -256,8 +488,8 @@ fn wait_timeout_wake() {
 // `std` should guard against this by clamping the timeout.
 // See #37440 for context.
 #[test]
-fn timeout_nanoseconds() {
-    use std::sync::{Condvar, Mutex};
+fn poison_timeout_nanoseconds() {
+    use std::sync::poison::{Condvar, Mutex};
 
     let sent = Mutex::new(false);
     let cond = Condvar::new();
@@ -290,6 +522,43 @@ fn timeout_nanoseconds() {
                 .unwrap();
             assert!(!res.timed_out());
             guard = g;
+        }
+    })
+}
+
+#[test]
+fn nonpoison_timeout_nanoseconds() {
+    use std::sync::nonpoison::{Condvar, Mutex};
+
+    let sent = Mutex::new(false);
+    let cond = Condvar::new();
+
+    thread::scope(|s| {
+        s.spawn(|| {
+            // Sleep so that the other thread has a chance to encounter the
+            // timeout.
+            thread::sleep(Duration::from_secs(2));
+            sent.set(true);
+            cond.notify_all();
+        });
+
+        let mut guard = sent.lock();
+        // Loop until `sent` is set by the thread to guard against spurious
+        // wakeups. If the `wait_timeout` happens just before the signal by
+        // the other thread, such a spurious wakeup might prevent the
+        // miscalculated timeout from occurring, but this is basically just
+        // a smoke test anyway.
+        loop {
+            if *guard {
+                break;
+            }
+
+            // If there is internal overflow, this call will return almost
+            // immediately, before the other thread has reached the `notify_all`,
+            // and indicate a timeout.
+            let res = cond
+                .wait_timeout(&mut guard, Duration::from_secs(u64::MAX.div_ceil(1_000_000_000)));
+            assert!(!res.timed_out());
         }
     })
 }


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Feature: `#![feature(nonpoison_condvar)]`
Tracking Issue: https://github.com/rust-lang/rust/issues/134645
Specific comment: https://github.com/rust-lang/rust/issues/134645#issuecomment-3458525913

Changes the `nonpoison::Condvar` API to take `MutexGuard` by reference instead of ownership.

I'm actually not entirely sure why the current poison variant of `Condvar` takes by ownership, is it just legacy reasons?

Additionally, the `nonpoison_and_poison_unwrap_test` macro doesn't really make sense anymore now that the APIs are completely different, so this reverts that change from a few months ago.

r? @Amanieu 