### PR TITLE
add inline to copy_within

### DIFF
--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -3906,6 +3906,7 @@ impl<T> [T] {
     ///
     /// assert_eq!(&bytes, b"Hello, Wello!");
     /// ```
+    #[inline]
     #[stable(feature = "copy_within", since = "1.37.0")]
     #[track_caller]
     pub fn copy_within<R: RangeBounds<usize>>(&mut self, src: R, dest: usize)


### PR DESCRIPTION
In [lz4_flex](https://github.com/PSeitz/lz4_flex) a fixed size parameter is used to `copy_within` to avoid calls to libc memmove.
However, I can see in the call stack still see calls to libc. I think it's because of the missing `inline`.

It's using the equivalent of this:
[https://godbolt.org/z/cKqYYvKbT](https://godbolt.org/z/cKqYYvKbT)
(in this example `copy_within` is getting inlined)