### PR TITLE
Change cfg_trace, cfg_attr_trace symbol values

### DIFF
--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -625,7 +625,7 @@ symbols! {
         cfg_accessible,
         cfg_attr,
         cfg_attr_multi,
-        cfg_attr_trace: "<cfg_attr>", // must not be a valid identifier
+        cfg_attr_trace: "<cfg_attr_trace>", // must not be a valid identifier
         cfg_boolean_literals,
         cfg_contract_checks,
         cfg_doctest,
@@ -646,7 +646,7 @@ symbols! {
         cfg_target_has_reliable_f16_f128,
         cfg_target_thread_local,
         cfg_target_vendor,
-        cfg_trace: "<cfg>", // must not be a valid identifier
+        cfg_trace: "<cfg_trace>", // must not be a valid identifier
         cfg_ub_checks,
         cfg_version,
         cfi,


### PR DESCRIPTION
For debugging - I ran into this working on `cfg` stuff in Clippy where I didn't notice the value was wrapped in `<>`, adding `_trace` makes it easier to spot