### PR TITLE
Fix some issues around `rustc_public`

### DIFF
--- a/compiler/rustc_public/src/compiler_interface.rs
+++ b/compiler/rustc_public/src/compiler_interface.rs
@@ -835,6 +835,8 @@ impl<'tcx> CompilerInterface<'tcx> {
 // A thread local variable that stores a pointer to [`CompilerInterface`].
 scoped_tls::scoped_thread_local!(static TLV: Cell<*const ()>);
 
+// remove this cfg when we have a stable driver.
+#[cfg(feature = "rustc_internal")]
 pub(crate) fn run<'tcx, F, T>(interface: &CompilerInterface<'tcx>, f: F) -> Result<T, Error>
 where
     F: FnOnce() -> T,

--- a/compiler/rustc_public/src/unstable/mod.rs
+++ b/compiler/rustc_public/src/unstable/mod.rs
@@ -22,6 +22,7 @@ mod internal_cx;
 ///
 /// This trait is only for [`RustcInternal`]. Any other other access to rustc's internals
 /// should go through [`rustc_public_bridge::context::CompilerCtxt`].
+#[cfg_attr(not(feature = "rustc_internal"), allow(unreachable_pub))]
 pub trait InternalCx<'tcx>: Copy + Clone {
     fn tcx(self) -> TyCtxt<'tcx>;
 
@@ -59,6 +60,7 @@ pub trait InternalCx<'tcx>: Copy + Clone {
 /// between internal MIR and rustc_public's IR constructs.
 /// However, they should be used seldom and they have no influence in this crate semver.
 #[doc(hidden)]
+#[cfg_attr(not(feature = "rustc_internal"), allow(unreachable_pub))]
 pub trait Stable<'tcx>: PointeeSized {
     /// The stable representation of the type implementing Stable.
     type T;
@@ -78,6 +80,7 @@ pub trait Stable<'tcx>: PointeeSized {
 /// between internal MIR and rustc_public's IR constructs.
 /// They should be used seldom as they have no stability guarantees.
 #[doc(hidden)]
+#[cfg_attr(not(feature = "rustc_internal"), allow(unreachable_pub))]
 pub trait RustcInternal {
     type T<'tcx>;
     fn internal<'tcx>(


### PR DESCRIPTION
cc rust-lang/rust#148266 .
follow-up of rust-lang/rust#148341 .

This fixes the issues that can be reproduced by `x test compiler/rustc_public`:

```
error: function `run` is never used
   --> compiler/rustc_public/src/compiler_interface.rs:838:15
    |
838 | pub(crate) fn run<'tcx, F, T>(interface: &CompilerInterface<'tcx>, f: F) -> Result<T, Error>
    |               ^^^
    |
    = note: `-D dead-code` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(dead_code)]`

error: unreachable `pub` item
  --> compiler/rustc_public/src/unstable/mod.rs:25:1
   |
25 | pub trait InternalCx<'tcx>: Copy + Clone {
   | ---^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   | |
   | help: consider restricting its visibility: `pub(crate)`
   |
   = help: or consider exporting it for use by other crates
   = note: `-D unreachable-pub` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(unreachable_pub)]`

error: unreachable `pub` item
  --> compiler/rustc_public/src/unstable/mod.rs:62:1
   |
62 | pub trait Stable<'tcx>: PointeeSized {
   | ---^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   | |
   | help: consider restricting its visibility: `pub(crate)`
   |
   = help: or consider exporting it for use by other crates

error: unreachable `pub` item
  --> compiler/rustc_public/src/unstable/mod.rs:81:1
   |
81 | pub trait RustcInternal {
   | ---^^^^^^^^^^^^^^^^^^^^
   | |
   | help: consider restricting its visibility: `pub(crate)`
   |
   = help: or consider exporting it for use by other crates

error: could not compile `rustc_public` (lib) due to 4 previous errors
```