### PR TITLE
docs: makes a note about possible building  `rustc 1.91.0 + host tools` for win7

### DIFF
--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -439,7 +439,7 @@ target | std | host | notes
 `x86_64-uwp-windows-gnu` | ✓ |  |
 [`x86_64-uwp-windows-msvc`](platform-support/uwp-windows-msvc.md) | ✓ |  |
 [`x86_64-win7-windows-gnu`](platform-support/win7-windows-gnu.md) | ✓ |   | 64-bit Windows 7 support
-[`x86_64-win7-windows-msvc`](platform-support/win7-windows-msvc.md) | ✓ |   | 64-bit Windows 7 support
+[`x86_64-win7-windows-msvc`](platform-support/win7-windows-msvc.md) | ✓ | ✓ | 64-bit Windows 7 support
 [`x86_64-wrs-vxworks`](platform-support/vxworks.md) | ✓ |  |
 [`x86_64h-apple-darwin`](platform-support/x86_64h-apple-darwin.md) | ✓ | ✓ | macOS with late-gen Intel (at least Haswell)
 [`xtensa-esp32-espidf`](platform-support/esp-idf.md) | ✓ |  | Xtensa ESP32

--- a/src/doc/rustc/src/platform-support/win7-windows-msvc.md
+++ b/src/doc/rustc/src/platform-support/win7-windows-msvc.md
@@ -16,7 +16,8 @@ Target triples:
 
 This target supports all of core, alloc, std and test. This is automatically
 tested every night on private infrastructure hosted by the maintainer. Host
-tools may also work, though those are not currently tested.
+tools may also work, though it is not guaranteed. Last known success built
+version of rustc with host tools (x86_64) is 1.91.0.
 
 Those targets follow Windows calling convention for extern "C".
 


### PR DESCRIPTION
I have make notes in docs that there is possible to build host tools for target `x86_64-win7-windows-msvc`.

<img width="668" height="331" alt="image" src="https://github.com/user-attachments/assets/0335bc72-963c-4bfd-9910-61963dbf7dd7" />

r? @roblabla 

@rustbot label A-docs  O-windows-7 

P.S. prebuilt binaries can be found [here](https://github.com/Fenex/rust-win7/releases).