### PR TITLE
Use --print host-tuple to get the host

### DIFF
--- a/src/etc/rust-lldb
+++ b/src/etc/rust-lldb
@@ -4,7 +4,7 @@
 set -e
 
 # Find the host triple so we can find lldb in rustlib.
-host=$(rustc -vV | sed -n -e 's/^host: //p')
+host=$(rustc --print host-tuple)
 
 # Find out where to look for the pretty printer Python module
 RUSTC_SYSROOT=$(rustc --print sysroot)


### PR DESCRIPTION
`--print host-tuple` has been available since 1.84 so there's no longer a need to parse the output of `-vV`. Especially since this script is shipped with the toolchain.