### PR TITLE
Point at inner item when it uses generic type param from outer item or `Self`

### DIFF
--- a/compiler/rustc_hir_typeck/messages.ftl
+++ b/compiler/rustc_hir_typeck/messages.ftl
@@ -262,6 +262,8 @@ hir_typeck_self_ctor_from_outer_item = can't reference `Self` constructor from o
     .label = the inner item doesn't inherit generics from this impl, so `Self` is invalid to reference
     .suggestion = replace `Self` with the actual type
 
+hir_typeck_self_ctor_from_outer_item_inner_item = `Self` used in this inner item
+
 hir_typeck_slicing_suggestion = consider slicing here
 
 hir_typeck_struct_expr_non_exhaustive =

--- a/compiler/rustc_hir_typeck/src/errors.rs
+++ b/compiler/rustc_hir_typeck/src/errors.rs
@@ -978,6 +978,15 @@ pub(crate) struct SelfCtorFromOuterItem {
     pub impl_span: Span,
     #[subdiagnostic]
     pub sugg: Option<ReplaceWithName>,
+    #[subdiagnostic]
+    pub item: Option<InnerItem>,
+}
+
+#[derive(Subdiagnostic)]
+#[label(hir_typeck_self_ctor_from_outer_item_inner_item)]
+pub(crate) struct InnerItem {
+    #[primary_span]
+    pub span: Span,
 }
 
 #[derive(LintDiagnostic)]
@@ -987,6 +996,8 @@ pub(crate) struct SelfCtorFromOuterItemLint {
     pub impl_span: Span,
     #[subdiagnostic]
     pub sugg: Option<ReplaceWithName>,
+    #[subdiagnostic]
+    pub item: Option<InnerItem>,
 }
 
 #[derive(Subdiagnostic)]

--- a/compiler/rustc_resolve/messages.ftl
+++ b/compiler/rustc_resolve/messages.ftl
@@ -180,6 +180,11 @@ resolve_generic_params_from_outer_item_const = a `const` is a separate item from
 
 resolve_generic_params_from_outer_item_const_param = const parameter from outer item
 
+resolve_generic_params_from_outer_item_inner_item = {$is_self ->
+        [true] `Self`
+        *[false] generic parameter
+    } used in this inner {$descr}
+
 resolve_generic_params_from_outer_item_self_ty_alias = `Self` type implicitly declared here, by this `impl`
 
 resolve_generic_params_from_outer_item_self_ty_param = can't use `Self` here

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -557,6 +557,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 outer_res,
                 has_generic_params,
                 def_kind,
+                item,
             ) => {
                 use errs::GenericParamsFromOuterItemLabel as Label;
                 let static_or_const = match def_kind {
@@ -575,6 +576,10 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                     sugg: None,
                     static_or_const,
                     is_self,
+                    item: item.map(|(span, descr)| errs::GenericParamsFromOuterItemInnerItem {
+                        span,
+                        descr,
+                    }),
                 };
 
                 let sm = self.tcx.sess.source_map();
@@ -2506,6 +2511,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                         None,
                         &ribs[ns_to_try],
                         ignore_binding,
+                        None,
                     ) {
                         // we found a locally-imported or available item/module
                         Some(LexicalScopeBinding::Item(binding)) => Some(binding),
@@ -2556,6 +2562,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                     None,
                     &ribs[ValueNS],
                     ignore_binding,
+                    None,
                 )
             } else {
                 None

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -553,12 +553,12 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         resolution_error: ResolutionError<'ra>,
     ) -> Diag<'_> {
         match resolution_error {
-            ResolutionError::GenericParamsFromOuterItem(
+            ResolutionError::GenericParamsFromOuterItem {
                 outer_res,
                 has_generic_params,
                 def_kind,
-                item,
-            ) => {
+                inner_item,
+            } => {
                 use errs::GenericParamsFromOuterItemLabel as Label;
                 let static_or_const = match def_kind {
                     DefKind::Static { .. } => {
@@ -576,9 +576,9 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                     sugg: None,
                     static_or_const,
                     is_self,
-                    item: item.map(|(span, descr)| errs::GenericParamsFromOuterItemInnerItem {
+                    item: inner_item.map(|(span, kind)| errs::GenericParamsFromOuterItemInnerItem {
                         span,
-                        descr,
+                        descr: kind.descr().to_string(),
                     }),
                 };
 

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -40,7 +40,7 @@ use crate::errors::{
     MaybeMissingMacroRulesName,
 };
 use crate::imports::{Import, ImportKind};
-use crate::late::{PatternSource, Rib};
+use crate::late::{DiagMetadata, PatternSource, Rib};
 use crate::{
     AmbiguityError, AmbiguityErrorMisc, AmbiguityKind, BindingError, BindingKey, Finalize,
     ForwardGenericParamBanReason, HasGenericParams, LexicalScopeBinding, MacroRulesScope, Module,
@@ -2406,6 +2406,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         module: Option<ModuleOrUniformRoot<'ra>>,
         failed_segment_idx: usize,
         ident: Ident,
+        diag_metadata: Option<&DiagMetadata<'_>>,
     ) -> (String, Option<Suggestion>) {
         let is_last = failed_segment_idx == path.len() - 1;
         let ns = if is_last { opt_ns.unwrap_or(TypeNS) } else { TypeNS };
@@ -2511,7 +2512,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                         None,
                         &ribs[ns_to_try],
                         ignore_binding,
-                        None,
+                        diag_metadata,
                     ) {
                         // we found a locally-imported or available item/module
                         Some(LexicalScopeBinding::Item(binding)) => Some(binding),
@@ -2562,7 +2563,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                     None,
                     &ribs[ValueNS],
                     ignore_binding,
-                    None,
+                    diag_metadata,
                 )
             } else {
                 None

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -576,9 +576,11 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                     sugg: None,
                     static_or_const,
                     is_self,
-                    item: inner_item.map(|(span, kind)| errs::GenericParamsFromOuterItemInnerItem {
-                        span,
-                        descr: kind.descr().to_string(),
+                    item: inner_item.as_ref().map(|(span, kind)| {
+                        errs::GenericParamsFromOuterItemInnerItem {
+                            span: *span,
+                            descr: kind.descr().to_string(),
+                        }
                     }),
                 };
 
@@ -613,7 +615,9 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                     }
                 };
 
-                if let HasGenericParams::Yes(span) = has_generic_params {
+                if let HasGenericParams::Yes(span) = has_generic_params
+                    && !matches!(inner_item, Some((_, ItemKind::Delegation(..))))
+                {
                     let name = self.tcx.item_name(def_id);
                     let (span, snippet) = if span.is_empty() {
                         let snippet = format!("<{name}>");

--- a/compiler/rustc_resolve/src/errors.rs
+++ b/compiler/rustc_resolve/src/errors.rs
@@ -24,6 +24,16 @@ pub(crate) struct GenericParamsFromOuterItem {
     #[subdiagnostic]
     pub(crate) static_or_const: Option<GenericParamsFromOuterItemStaticOrConst>,
     pub(crate) is_self: bool,
+    #[subdiagnostic]
+    pub(crate) item: Option<GenericParamsFromOuterItemInnerItem>,
+}
+
+#[derive(Subdiagnostic)]
+#[label(resolve_generic_params_from_outer_item_inner_item)]
+pub(crate) struct GenericParamsFromOuterItemInnerItem {
+    #[primary_span]
+    pub(crate) span: Span,
+    pub(crate) descr: String,
 }
 
 #[derive(Subdiagnostic)]

--- a/compiler/rustc_resolve/src/errors.rs
+++ b/compiler/rustc_resolve/src/errors.rs
@@ -47,7 +47,12 @@ pub(crate) enum GenericParamsFromOuterItemLabel {
 }
 
 #[derive(Subdiagnostic)]
-#[suggestion(resolve_suggestion, code = "{snippet}", applicability = "maybe-incorrect")]
+#[suggestion(
+    resolve_suggestion,
+    code = "{snippet}",
+    applicability = "maybe-incorrect",
+    style = "verbose"
+)]
 pub(crate) struct GenericParamsFromOuterItemSugg {
     #[primary_span]
     pub(crate) span: Span,

--- a/compiler/rustc_resolve/src/ident.rs
+++ b/compiler/rustc_resolve/src/ident.rs
@@ -1835,6 +1835,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                                 module,
                                 segment_idx,
                                 ident,
+                                diag_metadata,
                             )
                         },
                     );

--- a/compiler/rustc_resolve/src/ident.rs
+++ b/compiler/rustc_resolve/src/ident.rs
@@ -1484,13 +1484,25 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
 
                     // This was an attempt to use a const parameter outside its scope.
                     if let Some(span) = finalize {
+                        let item = if let Some(diag_metadata) = diag_metadata
+                            && let Some(current_item) = diag_metadata.current_item
+                        {
+                            let span = current_item
+                                .kind
+                                .ident()
+                                .map(|i| i.span)
+                                .unwrap_or(current_item.span);
+                            Some((span, current_item.kind.descr().to_string()))
+                        } else {
+                            None
+                        };
                         self.report_error(
                             span,
                             ResolutionError::GenericParamsFromOuterItem(
                                 res,
                                 has_generic_params,
                                 def_kind,
-                                None,
+                                item,
                             ),
                         );
                     }

--- a/compiler/rustc_resolve/src/ident.rs
+++ b/compiler/rustc_resolve/src/ident.rs
@@ -1404,18 +1404,18 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                                 .ident()
                                 .map(|i| i.span)
                                 .unwrap_or(current_item.span);
-                            Some((span, current_item.kind.descr().to_string()))
+                            Some((span, current_item.kind.clone()))
                         } else {
                             None
                         };
                         self.report_error(
                             span,
-                            ResolutionError::GenericParamsFromOuterItem(
-                                res,
+                            ResolutionError::GenericParamsFromOuterItem {
+                                outer_res: res,
                                 has_generic_params,
                                 def_kind,
-                                item,
-                            ),
+                                inner_item: item,
+                            },
                         );
                     }
                     return Res::Err;
@@ -1492,18 +1492,18 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                                 .ident()
                                 .map(|i| i.span)
                                 .unwrap_or(current_item.span);
-                            Some((span, current_item.kind.descr().to_string()))
+                            Some((span, current_item.kind.clone()))
                         } else {
                             None
                         };
                         self.report_error(
                             span,
-                            ResolutionError::GenericParamsFromOuterItem(
-                                res,
+                            ResolutionError::GenericParamsFromOuterItem {
+                                outer_res: res,
                                 has_generic_params,
                                 def_kind,
-                                item,
-                            ),
+                                inner_item: item,
+                            },
                         );
                     }
                     return Res::Err;

--- a/compiler/rustc_resolve/src/ident.rs
+++ b/compiler/rustc_resolve/src/ident.rs
@@ -12,7 +12,9 @@ use tracing::{debug, instrument};
 
 use crate::errors::{ParamKindInEnumDiscriminant, ParamKindInNonTrivialAnonConst};
 use crate::imports::{Import, NameResolution};
-use crate::late::{ConstantHasGenerics, NoConstantGenericsReason, PathSource, Rib, RibKind};
+use crate::late::{
+    ConstantHasGenerics, DiagMetadata, NoConstantGenericsReason, PathSource, Rib, RibKind,
+};
 use crate::macros::{MacroRulesScope, sub_namespace_match};
 use crate::{
     AmbiguityError, AmbiguityErrorMisc, AmbiguityKind, BindingKey, CmResolver, Determinacy,
@@ -295,6 +297,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         finalize: Option<Finalize>,
         ribs: &[Rib<'ra>],
         ignore_binding: Option<NameBinding<'ra>>,
+        diag_metadata: Option<&DiagMetadata<'_>>,
     ) -> Option<LexicalScopeBinding<'ra>> {
         assert!(ns == TypeNS || ns == ValueNS);
         let orig_ident = ident;
@@ -326,6 +329,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                     finalize.map(|finalize| finalize.path_span),
                     *original_rib_ident_def,
                     ribs,
+                    diag_metadata,
                 )));
             } else if let RibKind::Block(Some(module)) = rib.kind
                 && let Ok(binding) = self.cm().resolve_ident_in_module_unadjusted(
@@ -1193,6 +1197,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         finalize: Option<Span>,
         original_rib_ident_def: Ident,
         all_ribs: &[Rib<'ra>],
+        diag_metadata: Option<&DiagMetadata<'_>>,
     ) -> Res {
         debug!("validate_res_from_ribs({:?})", res);
         let ribs = &all_ribs[rib_index + 1..];
@@ -1391,12 +1396,25 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                     };
 
                     if let Some(span) = finalize {
+                        let item = if let Some(diag_metadata) = diag_metadata
+                            && let Some(current_item) = diag_metadata.current_item
+                        {
+                            let span = current_item
+                                .kind
+                                .ident()
+                                .map(|i| i.span)
+                                .unwrap_or(current_item.span);
+                            Some((span, current_item.kind.descr().to_string()))
+                        } else {
+                            None
+                        };
                         self.report_error(
                             span,
                             ResolutionError::GenericParamsFromOuterItem(
                                 res,
                                 has_generic_params,
                                 def_kind,
+                                item,
                             ),
                         );
                     }
@@ -1472,6 +1490,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                                 res,
                                 has_generic_params,
                                 def_kind,
+                                None,
                             ),
                         );
                     }
@@ -1501,6 +1520,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             None,
             None,
             ignore_import,
+            None,
         )
     }
     #[instrument(level = "debug", skip(self))]
@@ -1522,6 +1542,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             None,
             ignore_binding,
             ignore_import,
+            None,
         )
     }
 
@@ -1535,6 +1556,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         ribs: Option<&PerNS<Vec<Rib<'ra>>>>,
         ignore_binding: Option<NameBinding<'ra>>,
         ignore_import: Option<Import<'ra>>,
+        diag_metadata: Option<&DiagMetadata<'_>>,
     ) -> PathResult<'ra> {
         let mut module = None;
         let mut module_had_parse_errors = false;
@@ -1675,6 +1697,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                     finalize,
                     &ribs[ns],
                     ignore_binding,
+                    diag_metadata,
                 ) {
                     // we found a locally-imported or available item/module
                     Some(LexicalScopeBinding::Item(binding)) => Ok(binding),

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -677,7 +677,7 @@ pub(crate) struct DiagMetadata<'ast> {
     /// The current self item if inside an ADT (used for better errors).
     current_self_item: Option<NodeId>,
 
-    /// The current trait (used to suggest).
+    /// The current item being evaluated (used for suggestions and more detail in errors).
     pub(crate) current_item: Option<&'ast Item>,
 
     /// When processing generic arguments and encountering an unresolved ident not found,

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -241,7 +241,7 @@ struct BindingError {
 #[derive(Debug)]
 enum ResolutionError<'ra> {
     /// Error E0401: can't use type or const parameters from outer item.
-    GenericParamsFromOuterItem(Res, HasGenericParams, DefKind),
+    GenericParamsFromOuterItem(Res, HasGenericParams, DefKind, Option<(Span, String)>),
     /// Error E0403: the name is already used for a type or const parameter in this generic
     /// parameter list.
     NameAlreadyUsedInParameterList(Ident, Span),

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -241,7 +241,12 @@ struct BindingError {
 #[derive(Debug)]
 enum ResolutionError<'ra> {
     /// Error E0401: can't use type or const parameters from outer item.
-    GenericParamsFromOuterItem(Res, HasGenericParams, DefKind, Option<(Span, String)>),
+    GenericParamsFromOuterItem {
+        outer_res: Res,
+        has_generic_params: HasGenericParams,
+        def_kind: DefKind,
+        inner_item: Option<(Span, ast::ItemKind)>,
+    },
     /// Error E0403: the name is already used for a type or const parameter in this generic
     /// parameter list.
     NameAlreadyUsedInParameterList(Ident, Span),

--- a/tests/ui/const-generics/early/const-param-from-outer-fn.stderr
+++ b/tests/ui/const-generics/early/const-param-from-outer-fn.stderr
@@ -4,9 +4,13 @@ error[E0401]: can't use generic parameters from outer item
 LL | fn foo<const X: u32>() {
    |              - const parameter from outer item
 LL |     fn bar() -> u32 {
-   |           - help: try introducing a local generic parameter here: `<X>`
 LL |         X
    |         ^ use of generic parameter from outer item
+   |
+help: try introducing a local generic parameter here
+   |
+LL |     fn bar<X>() -> u32 {
+   |           +++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/early/const-param-from-outer-fn.stderr
+++ b/tests/ui/const-generics/early/const-param-from-outer-fn.stderr
@@ -4,6 +4,7 @@ error[E0401]: can't use generic parameters from outer item
 LL | fn foo<const X: u32>() {
    |              - const parameter from outer item
 LL |     fn bar() -> u32 {
+   |        --- generic parameter used in this inner function
 LL |         X
    |         ^ use of generic parameter from outer item
    |

--- a/tests/ui/delegation/target-expr.stderr
+++ b/tests/ui/delegation/target-expr.stderr
@@ -3,11 +3,14 @@ error[E0401]: can't use generic parameters from outer item
    |
 LL | fn bar<T: Default>(_: T) {
    |        - type parameter from outer item
-LL |     reuse Trait::static_method {
-   |                               - help: try introducing a local generic parameter here: `T,`
-LL |
+...
 LL |         let _ = T::Default();
    |                 ^^^^^^^^^^ use of generic parameter from outer item
+   |
+help: try introducing a local generic parameter here
+   |
+LL |     reuse Trait::static_methodT,  {
+   |                               ++
 
 error[E0434]: can't capture dynamic environment in a fn item
   --> $DIR/target-expr.rs:26:17

--- a/tests/ui/delegation/target-expr.stderr
+++ b/tests/ui/delegation/target-expr.stderr
@@ -3,7 +3,9 @@ error[E0401]: can't use generic parameters from outer item
    |
 LL | fn bar<T: Default>(_: T) {
    |        - type parameter from outer item
-...
+LL |     reuse Trait::static_method {
+   |                  ------------- generic parameter used in this inner delegated function
+LL |
 LL |         let _ = T::Default();
    |                 ^^^^^^^^^^ use of generic parameter from outer item
    |

--- a/tests/ui/delegation/target-expr.stderr
+++ b/tests/ui/delegation/target-expr.stderr
@@ -8,11 +8,6 @@ LL |     reuse Trait::static_method {
 LL |
 LL |         let _ = T::Default();
    |                 ^^^^^^^^^^ use of generic parameter from outer item
-   |
-help: try introducing a local generic parameter here
-   |
-LL |     reuse Trait::static_methodT,  {
-   |                               ++
 
 error[E0434]: can't capture dynamic environment in a fn item
   --> $DIR/target-expr.rs:26:17

--- a/tests/ui/error-codes/E0401.stderr
+++ b/tests/ui/error-codes/E0401.stderr
@@ -4,9 +4,12 @@ error[E0401]: can't use generic parameters from outer item
 LL | fn foo<T>(x: T) {
    |        - type parameter from outer item
 LL |     fn bfnr<U, V: Baz<U>, W: Fn()>(y: T) {
-   |             -                         ^ use of generic parameter from outer item
-   |             |
-   |             help: try introducing a local generic parameter here: `T,`
+   |                                       ^ use of generic parameter from outer item
+   |
+help: try introducing a local generic parameter here
+   |
+LL |     fn bfnr<T, U, V: Baz<U>, W: Fn()>(y: T) {
+   |             ++
 
 error[E0401]: can't use generic parameters from outer item
   --> $DIR/E0401.rs:9:16
@@ -14,11 +17,13 @@ error[E0401]: can't use generic parameters from outer item
 LL | fn foo<T>(x: T) {
    |        - type parameter from outer item
 ...
-LL |     fn baz<U,
-   |            - help: try introducing a local generic parameter here: `T,`
-...
 LL |            (y: T) {
    |                ^ use of generic parameter from outer item
+   |
+help: try introducing a local generic parameter here
+   |
+LL |     fn baz<T, U,
+   |            ++
 
 error[E0401]: can't use `Self` from outer item
   --> $DIR/E0401.rs:22:25

--- a/tests/ui/error-codes/E0401.stderr
+++ b/tests/ui/error-codes/E0401.stderr
@@ -4,7 +4,9 @@ error[E0401]: can't use generic parameters from outer item
 LL | fn foo<T>(x: T) {
    |        - type parameter from outer item
 LL |     fn bfnr<U, V: Baz<U>, W: Fn()>(y: T) {
-   |                                       ^ use of generic parameter from outer item
+   |        ----                           ^ use of generic parameter from outer item
+   |        |
+   |        generic parameter used in this inner function
    |
 help: try introducing a local generic parameter here
    |
@@ -16,6 +18,9 @@ error[E0401]: can't use generic parameters from outer item
    |
 LL | fn foo<T>(x: T) {
    |        - type parameter from outer item
+...
+LL |     fn baz<U,
+   |        --- generic parameter used in this inner function
 ...
 LL |            (y: T) {
    |                ^ use of generic parameter from outer item
@@ -32,10 +37,11 @@ LL | impl<T> Iterator for A<T> {
    | ---- `Self` type implicitly declared here, by this `impl`
 ...
 LL |         fn helper(sel: &Self) -> u8 {
-   |                         ^^^^
-   |                         |
-   |                         use of `Self` from outer item
-   |                         refer to the type directly here instead
+   |            ------       ^^^^
+   |            |            |
+   |            |            use of `Self` from outer item
+   |            |            refer to the type directly here instead
+   |            `Self` used in this inner function
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/generics/enum-definition-with-outer-generic-parameter-5997.stderr
+++ b/tests/ui/generics/enum-definition-with-outer-generic-parameter-5997.stderr
@@ -4,9 +4,12 @@ error[E0401]: can't use generic parameters from outer item
 LL | fn f<Z>() -> bool {
    |      - type parameter from outer item
 LL |     enum E { V(Z) }
-   |           -    ^ use of generic parameter from outer item
-   |           |
-   |           help: try introducing a local generic parameter here: `<Z>`
+   |                ^ use of generic parameter from outer item
+   |
+help: try introducing a local generic parameter here
+   |
+LL |     enum E<Z> { V(Z) }
+   |           +++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/generics/enum-definition-with-outer-generic-parameter-5997.stderr
+++ b/tests/ui/generics/enum-definition-with-outer-generic-parameter-5997.stderr
@@ -4,7 +4,9 @@ error[E0401]: can't use generic parameters from outer item
 LL | fn f<Z>() -> bool {
    |      - type parameter from outer item
 LL |     enum E { V(Z) }
-   |                ^ use of generic parameter from outer item
+   |          -     ^ use of generic parameter from outer item
+   |          |
+   |          generic parameter used in this inner enum
    |
 help: try introducing a local generic parameter here
    |

--- a/tests/ui/generics/generic-params-nested-fn-scope-error.stderr
+++ b/tests/ui/generics/generic-params-nested-fn-scope-error.stderr
@@ -4,7 +4,9 @@ error[E0401]: can't use generic parameters from outer item
 LL | fn foo<U>(v: Vec<U>) -> U {
    |        - type parameter from outer item
 LL |     fn bar(w: [U]) -> U {
-   |                ^ use of generic parameter from outer item
+   |        ---     ^ use of generic parameter from outer item
+   |        |
+   |        generic parameter used in this inner function
    |
 help: try introducing a local generic parameter here
    |
@@ -17,7 +19,9 @@ error[E0401]: can't use generic parameters from outer item
 LL | fn foo<U>(v: Vec<U>) -> U {
    |        - type parameter from outer item
 LL |     fn bar(w: [U]) -> U {
-   |                       ^ use of generic parameter from outer item
+   |        ---            ^ use of generic parameter from outer item
+   |        |
+   |        generic parameter used in this inner function
    |
 help: try introducing a local generic parameter here
    |

--- a/tests/ui/generics/generic-params-nested-fn-scope-error.stderr
+++ b/tests/ui/generics/generic-params-nested-fn-scope-error.stderr
@@ -4,9 +4,12 @@ error[E0401]: can't use generic parameters from outer item
 LL | fn foo<U>(v: Vec<U>) -> U {
    |        - type parameter from outer item
 LL |     fn bar(w: [U]) -> U {
-   |           -    ^ use of generic parameter from outer item
-   |           |
-   |           help: try introducing a local generic parameter here: `<U>`
+   |                ^ use of generic parameter from outer item
+   |
+help: try introducing a local generic parameter here
+   |
+LL |     fn bar<U>(w: [U]) -> U {
+   |           +++
 
 error[E0401]: can't use generic parameters from outer item
   --> $DIR/generic-params-nested-fn-scope-error.rs:5:23
@@ -14,9 +17,12 @@ error[E0401]: can't use generic parameters from outer item
 LL | fn foo<U>(v: Vec<U>) -> U {
    |        - type parameter from outer item
 LL |     fn bar(w: [U]) -> U {
-   |           -           ^ use of generic parameter from outer item
-   |           |
-   |           help: try introducing a local generic parameter here: `<U>`
+   |                       ^ use of generic parameter from outer item
+   |
+help: try introducing a local generic parameter here
+   |
+LL |     fn bar<U>(w: [U]) -> U {
+   |           +++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/generics/issue-98432.stderr
+++ b/tests/ui/generics/issue-98432.stderr
@@ -5,9 +5,12 @@ LL | impl<T> Struct<T> {
    |      - type parameter from outer item
 LL |     const CONST: fn() = || {
 LL |         struct _Obligation where T:;
-   |                           -      ^ use of generic parameter from outer item
-   |                           |
-   |                           help: try introducing a local generic parameter here: `<T>`
+   |                                  ^ use of generic parameter from outer item
+   |
+help: try introducing a local generic parameter here
+   |
+LL |         struct _Obligation<T> where T:;
+   |                           +++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/generics/issue-98432.stderr
+++ b/tests/ui/generics/issue-98432.stderr
@@ -5,7 +5,9 @@ LL | impl<T> Struct<T> {
    |      - type parameter from outer item
 LL |     const CONST: fn() = || {
 LL |         struct _Obligation where T:;
-   |                                  ^ use of generic parameter from outer item
+   |                -----------       ^ use of generic parameter from outer item
+   |                |
+   |                generic parameter used in this inner struct
    |
 help: try introducing a local generic parameter here
    |

--- a/tests/ui/malformed/do-not-ice-on-note_and_explain.stderr
+++ b/tests/ui/malformed/do-not-ice-on-note_and_explain.stderr
@@ -3,7 +3,9 @@ error[E0401]: can't reference `Self` constructor from outer item
    |
 LL | impl<B> A<B> {
    | ------------ the inner item doesn't inherit generics from this impl, so `Self` is invalid to reference
-...
+LL |     fn d() {
+LL |         fn d() {
+   |            - `Self` used in this inner item
 LL |             Self(1)
    |             ^^^^ help: replace `Self` with the actual type: `A`
 

--- a/tests/ui/resolve/bad-type-env-capture.stderr
+++ b/tests/ui/resolve/bad-type-env-capture.stderr
@@ -4,9 +4,12 @@ error[E0401]: can't use generic parameters from outer item
 LL | fn foo<T>() {
    |        - type parameter from outer item
 LL |     fn bar(b: T) { }
-   |           -   ^ use of generic parameter from outer item
-   |           |
-   |           help: try introducing a local generic parameter here: `<T>`
+   |               ^ use of generic parameter from outer item
+   |
+help: try introducing a local generic parameter here
+   |
+LL |     fn bar<T>(b: T) { }
+   |           +++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/resolve/bad-type-env-capture.stderr
+++ b/tests/ui/resolve/bad-type-env-capture.stderr
@@ -4,7 +4,9 @@ error[E0401]: can't use generic parameters from outer item
 LL | fn foo<T>() {
    |        - type parameter from outer item
 LL |     fn bar(b: T) { }
-   |               ^ use of generic parameter from outer item
+   |        ---    ^ use of generic parameter from outer item
+   |        |
+   |        generic parameter used in this inner function
    |
 help: try introducing a local generic parameter here
    |

--- a/tests/ui/resolve/generic-params-from-outer-item-in-const-item.default.stderr
+++ b/tests/ui/resolve/generic-params-from-outer-item-in-const-item.default.stderr
@@ -4,7 +4,9 @@ error[E0401]: can't use generic parameters from outer item
 LL | fn outer<T: Tr>() { // outer function
    |          - type parameter from outer item
 LL |     const K: u32 = T::C;
-   |                    ^^^^ use of generic parameter from outer item
+   |           -        ^^^^ use of generic parameter from outer item
+   |           |
+   |           generic parameter used in this inner constant item
    |
    = note: a `const` is a separate item from the item that contains it
 
@@ -15,7 +17,9 @@ LL | impl<T> Tr for T { // outer impl block
    |      - type parameter from outer item
 LL |     const C: u32 = {
 LL |         const I: u32 = T::C;
-   |                        ^^^^ use of generic parameter from outer item
+   |               -        ^^^^ use of generic parameter from outer item
+   |               |
+   |               generic parameter used in this inner constant item
    |
    = note: a `const` is a separate item from the item that contains it
 
@@ -25,7 +29,9 @@ error[E0401]: can't use generic parameters from outer item
 LL | struct S<T: Tr>(U32<{ // outer struct
    |          - type parameter from outer item
 LL |     const _: u32 = T::C;
-   |                    ^^^^ use of generic parameter from outer item
+   |           -        ^^^^ use of generic parameter from outer item
+   |           |
+   |           generic parameter used in this inner constant item
    |
    = note: a `const` is a separate item from the item that contains it
 

--- a/tests/ui/resolve/generic-params-from-outer-item-in-const-item.generic_const_items.stderr
+++ b/tests/ui/resolve/generic-params-from-outer-item-in-const-item.generic_const_items.stderr
@@ -4,11 +4,13 @@ error[E0401]: can't use generic parameters from outer item
 LL | fn outer<T: Tr>() { // outer function
    |          - type parameter from outer item
 LL |     const K: u32 = T::C;
-   |            -       ^^^^ use of generic parameter from outer item
-   |            |
-   |            help: try introducing a local generic parameter here: `<T>`
+   |                    ^^^^ use of generic parameter from outer item
    |
    = note: a `const` is a separate item from the item that contains it
+help: try introducing a local generic parameter here
+   |
+LL |     const K<T>: u32 = T::C;
+   |            +++
 
 error[E0401]: can't use generic parameters from outer item
   --> $DIR/generic-params-from-outer-item-in-const-item.rs:19:24
@@ -17,11 +19,13 @@ LL | impl<T> Tr for T { // outer impl block
    |      - type parameter from outer item
 LL |     const C: u32 = {
 LL |         const I: u32 = T::C;
-   |                -       ^^^^ use of generic parameter from outer item
-   |                |
-   |                help: try introducing a local generic parameter here: `<T>`
+   |                        ^^^^ use of generic parameter from outer item
    |
    = note: a `const` is a separate item from the item that contains it
+help: try introducing a local generic parameter here
+   |
+LL |         const I<T>: u32 = T::C;
+   |                +++
 
 error[E0401]: can't use generic parameters from outer item
   --> $DIR/generic-params-from-outer-item-in-const-item.rs:27:20
@@ -29,11 +33,13 @@ error[E0401]: can't use generic parameters from outer item
 LL | struct S<T: Tr>(U32<{ // outer struct
    |          - type parameter from outer item
 LL |     const _: u32 = T::C;
-   |            -       ^^^^ use of generic parameter from outer item
-   |            |
-   |            help: try introducing a local generic parameter here: `<T>`
+   |                    ^^^^ use of generic parameter from outer item
    |
    = note: a `const` is a separate item from the item that contains it
+help: try introducing a local generic parameter here
+   |
+LL |     const _<T>: u32 = T::C;
+   |            +++
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/resolve/generic-params-from-outer-item-in-const-item.generic_const_items.stderr
+++ b/tests/ui/resolve/generic-params-from-outer-item-in-const-item.generic_const_items.stderr
@@ -4,7 +4,9 @@ error[E0401]: can't use generic parameters from outer item
 LL | fn outer<T: Tr>() { // outer function
    |          - type parameter from outer item
 LL |     const K: u32 = T::C;
-   |                    ^^^^ use of generic parameter from outer item
+   |           -        ^^^^ use of generic parameter from outer item
+   |           |
+   |           generic parameter used in this inner constant item
    |
    = note: a `const` is a separate item from the item that contains it
 help: try introducing a local generic parameter here
@@ -19,7 +21,9 @@ LL | impl<T> Tr for T { // outer impl block
    |      - type parameter from outer item
 LL |     const C: u32 = {
 LL |         const I: u32 = T::C;
-   |                        ^^^^ use of generic parameter from outer item
+   |               -        ^^^^ use of generic parameter from outer item
+   |               |
+   |               generic parameter used in this inner constant item
    |
    = note: a `const` is a separate item from the item that contains it
 help: try introducing a local generic parameter here
@@ -33,7 +37,9 @@ error[E0401]: can't use generic parameters from outer item
 LL | struct S<T: Tr>(U32<{ // outer struct
    |          - type parameter from outer item
 LL |     const _: u32 = T::C;
-   |                    ^^^^ use of generic parameter from outer item
+   |           -        ^^^^ use of generic parameter from outer item
+   |           |
+   |           generic parameter used in this inner constant item
    |
    = note: a `const` is a separate item from the item that contains it
 help: try introducing a local generic parameter here

--- a/tests/ui/resolve/issue-12796.stderr
+++ b/tests/ui/resolve/issue-12796.stderr
@@ -2,10 +2,11 @@ error[E0401]: can't use `Self` from outer item
   --> $DIR/issue-12796.rs:3:22
    |
 LL |         fn inner(_: &Self) {
-   |                      ^^^^
-   |                      |
-   |                      use of `Self` from outer item
-   |                      can't use `Self` here
+   |            -----     ^^^^
+   |            |         |
+   |            |         use of `Self` from outer item
+   |            |         can't use `Self` here
+   |            `Self` used in this inner function
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/resolve/issue-3021-c.stderr
+++ b/tests/ui/resolve/issue-3021-c.stderr
@@ -3,22 +3,28 @@ error[E0401]: can't use generic parameters from outer item
    |
 LL | fn siphash<T>() {
    |            - type parameter from outer item
-LL |
-LL |     trait U {
-   |            - help: try introducing a local generic parameter here: `<T>`
+...
 LL |         fn g(&self, x: T) -> T;
    |                        ^ use of generic parameter from outer item
+   |
+help: try introducing a local generic parameter here
+   |
+LL |     trait U<T> {
+   |            +++
 
 error[E0401]: can't use generic parameters from outer item
   --> $DIR/issue-3021-c.rs:4:30
    |
 LL | fn siphash<T>() {
    |            - type parameter from outer item
-LL |
-LL |     trait U {
-   |            - help: try introducing a local generic parameter here: `<T>`
+...
 LL |         fn g(&self, x: T) -> T;
    |                              ^ use of generic parameter from outer item
+   |
+help: try introducing a local generic parameter here
+   |
+LL |     trait U<T> {
+   |            +++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/resolve/issue-3021-c.stderr
+++ b/tests/ui/resolve/issue-3021-c.stderr
@@ -3,7 +3,9 @@ error[E0401]: can't use generic parameters from outer item
    |
 LL | fn siphash<T>() {
    |            - type parameter from outer item
-...
+LL |
+LL |     trait U {
+   |           - generic parameter used in this inner trait
 LL |         fn g(&self, x: T) -> T;
    |                        ^ use of generic parameter from outer item
    |
@@ -17,7 +19,9 @@ error[E0401]: can't use generic parameters from outer item
    |
 LL | fn siphash<T>() {
    |            - type parameter from outer item
-...
+LL |
+LL |     trait U {
+   |           - generic parameter used in this inner trait
 LL |         fn g(&self, x: T) -> T;
    |                              ^ use of generic parameter from outer item
    |

--- a/tests/ui/resolve/issue-3214.stderr
+++ b/tests/ui/resolve/issue-3214.stderr
@@ -4,6 +4,7 @@ error[E0401]: can't use generic parameters from outer item
 LL | fn foo<T>() {
    |        - type parameter from outer item
 LL |     struct Foo {
+   |            --- generic parameter used in this inner struct
 LL |         x: T,
    |            ^ use of generic parameter from outer item
    |

--- a/tests/ui/resolve/issue-3214.stderr
+++ b/tests/ui/resolve/issue-3214.stderr
@@ -4,9 +4,13 @@ error[E0401]: can't use generic parameters from outer item
 LL | fn foo<T>() {
    |        - type parameter from outer item
 LL |     struct Foo {
-   |               - help: try introducing a local generic parameter here: `<T>`
 LL |         x: T,
    |            ^ use of generic parameter from outer item
+   |
+help: try introducing a local generic parameter here
+   |
+LL |     struct Foo<T> {
+   |               +++
 
 error[E0107]: struct takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/issue-3214.rs:6:22

--- a/tests/ui/resolve/issue-65025-extern-static-parent-generics.stderr
+++ b/tests/ui/resolve/issue-65025-extern-static-parent-generics.stderr
@@ -1,11 +1,14 @@
 error[E0401]: can't use generic parameters from outer item
   --> $DIR/issue-65025-extern-static-parent-generics.rs:3:28
    |
-LL | unsafe fn foo<A>() {
-   |               - type parameter from outer item
-LL |     extern "C" {
-LL |         static baz: *const A;
-   |                            ^ use of generic parameter from outer item
+LL |   unsafe fn foo<A>() {
+   |                 - type parameter from outer item
+LL | /     extern "C" {
+LL | |         static baz: *const A;
+   | |                            ^ use of generic parameter from outer item
+LL | |
+LL | |     }
+   | |_____- generic parameter used in this inner extern block
    |
    = note: a `static` is a separate item from the item that contains it
 

--- a/tests/ui/resolve/issue-65035-static-with-parent-generics.stderr
+++ b/tests/ui/resolve/issue-65035-static-with-parent-generics.stderr
@@ -1,11 +1,14 @@
 error[E0401]: can't use generic parameters from outer item
   --> $DIR/issue-65035-static-with-parent-generics.rs:3:26
    |
-LL | fn f<T>() {
-   |      - type parameter from outer item
-LL |     extern "C" {
-LL |         static a: *const T;
-   |                          ^ use of generic parameter from outer item
+LL |   fn f<T>() {
+   |        - type parameter from outer item
+LL | /     extern "C" {
+LL | |         static a: *const T;
+   | |                          ^ use of generic parameter from outer item
+LL | |
+LL | |     }
+   | |_____- generic parameter used in this inner extern block
    |
    = note: a `static` is a separate item from the item that contains it
 
@@ -15,7 +18,9 @@ error[E0401]: can't use generic parameters from outer item
 LL | fn g<T: Default>() {
    |      - type parameter from outer item
 LL |     static a: *const T = Default::default();
-   |                      ^ use of generic parameter from outer item
+   |            -         ^ use of generic parameter from outer item
+   |            |
+   |            generic parameter used in this inner static item
    |
    = note: a `static` is a separate item from the item that contains it
 

--- a/tests/ui/resolve/issue-65035-static-with-parent-generics.stderr
+++ b/tests/ui/resolve/issue-65035-static-with-parent-generics.stderr
@@ -27,11 +27,14 @@ LL |     static a: *const T = Default::default();
 error[E0401]: can't use generic parameters from outer item
   --> $DIR/issue-65035-static-with-parent-generics.rs:15:24
    |
-LL | fn h<const N: usize>() {
-   |            - const parameter from outer item
-LL |     extern "C" {
-LL |         static a: [u8; N];
-   |                        ^ use of generic parameter from outer item
+LL |   fn h<const N: usize>() {
+   |              - const parameter from outer item
+LL | /     extern "C" {
+LL | |         static a: [u8; N];
+   | |                        ^ use of generic parameter from outer item
+LL | |
+LL | |     }
+   | |_____- generic parameter used in this inner extern block
    |
    = note: a `static` is a separate item from the item that contains it
 
@@ -41,7 +44,9 @@ error[E0401]: can't use generic parameters from outer item
 LL | fn i<const N: usize>() {
    |            - const parameter from outer item
 LL |     static a: [u8; N] = [0; N];
-   |                    ^ use of generic parameter from outer item
+   |            -       ^ use of generic parameter from outer item
+   |            |
+   |            generic parameter used in this inner static item
    |
    = note: a `static` is a separate item from the item that contains it
 
@@ -51,7 +56,9 @@ error[E0401]: can't use generic parameters from outer item
 LL | fn i<const N: usize>() {
    |            - const parameter from outer item
 LL |     static a: [u8; N] = [0; N];
-   |                             ^ use of generic parameter from outer item
+   |            -                ^ use of generic parameter from outer item
+   |            |
+   |            generic parameter used in this inner static item
    |
    = note: a `static` is a separate item from the item that contains it
 

--- a/tests/ui/resolve/resolve-type-param-in-item-in-trait.stderr
+++ b/tests/ui/resolve/resolve-type-param-in-item-in-trait.stderr
@@ -3,11 +3,14 @@ error[E0401]: can't use generic parameters from outer item
    |
 LL | trait TraitA<A> {
    |              - type parameter from outer item
-LL |     fn outer(&self) {
-LL |         enum Foo<B> {
-   |                  - help: try introducing a local generic parameter here: `A,`
+...
 LL |             Variance(A)
    |                      ^ use of generic parameter from outer item
+   |
+help: try introducing a local generic parameter here
+   |
+LL |         enum Foo<A, B> {
+   |                  ++
 
 error[E0401]: can't use generic parameters from outer item
   --> $DIR/resolve-type-param-in-item-in-trait.rs:16:23
@@ -16,9 +19,12 @@ LL | trait TraitB<A> {
    |              - type parameter from outer item
 LL |     fn outer(&self) {
 LL |         struct Foo<B>(A);
-   |                    -  ^ use of generic parameter from outer item
-   |                    |
-   |                    help: try introducing a local generic parameter here: `A,`
+   |                       ^ use of generic parameter from outer item
+   |
+help: try introducing a local generic parameter here
+   |
+LL |         struct Foo<A, B>(A);
+   |                    ++
 
 error[E0401]: can't use generic parameters from outer item
   --> $DIR/resolve-type-param-in-item-in-trait.rs:23:28
@@ -27,9 +33,12 @@ LL | trait TraitC<A> {
    |              - type parameter from outer item
 LL |     fn outer(&self) {
 LL |         struct Foo<B> { a: A }
-   |                    -       ^ use of generic parameter from outer item
-   |                    |
-   |                    help: try introducing a local generic parameter here: `A,`
+   |                            ^ use of generic parameter from outer item
+   |
+help: try introducing a local generic parameter here
+   |
+LL |         struct Foo<A, B> { a: A }
+   |                    ++
 
 error[E0401]: can't use generic parameters from outer item
   --> $DIR/resolve-type-param-in-item-in-trait.rs:30:22
@@ -38,9 +47,12 @@ LL | trait TraitD<A> {
    |              - type parameter from outer item
 LL |     fn outer(&self) {
 LL |         fn foo<B>(a: A) { }
-   |                -     ^ use of generic parameter from outer item
-   |                |
-   |                help: try introducing a local generic parameter here: `A,`
+   |                      ^ use of generic parameter from outer item
+   |
+help: try introducing a local generic parameter here
+   |
+LL |         fn foo<A, B>(a: A) { }
+   |                ++
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/resolve/resolve-type-param-in-item-in-trait.stderr
+++ b/tests/ui/resolve/resolve-type-param-in-item-in-trait.stderr
@@ -3,7 +3,9 @@ error[E0401]: can't use generic parameters from outer item
    |
 LL | trait TraitA<A> {
    |              - type parameter from outer item
-...
+LL |     fn outer(&self) {
+LL |         enum Foo<B> {
+   |              --- generic parameter used in this inner enum
 LL |             Variance(A)
    |                      ^ use of generic parameter from outer item
    |
@@ -19,7 +21,9 @@ LL | trait TraitB<A> {
    |              - type parameter from outer item
 LL |     fn outer(&self) {
 LL |         struct Foo<B>(A);
-   |                       ^ use of generic parameter from outer item
+   |                ---    ^ use of generic parameter from outer item
+   |                |
+   |                generic parameter used in this inner struct
    |
 help: try introducing a local generic parameter here
    |
@@ -33,7 +37,9 @@ LL | trait TraitC<A> {
    |              - type parameter from outer item
 LL |     fn outer(&self) {
 LL |         struct Foo<B> { a: A }
-   |                            ^ use of generic parameter from outer item
+   |                ---         ^ use of generic parameter from outer item
+   |                |
+   |                generic parameter used in this inner struct
    |
 help: try introducing a local generic parameter here
    |
@@ -47,7 +53,9 @@ LL | trait TraitD<A> {
    |              - type parameter from outer item
 LL |     fn outer(&self) {
 LL |         fn foo<B>(a: A) { }
-   |                      ^ use of generic parameter from outer item
+   |            ---       ^ use of generic parameter from outer item
+   |            |
+   |            generic parameter used in this inner function
    |
 help: try introducing a local generic parameter here
    |

--- a/tests/ui/resolve/use-self-in-inner-fn.rs
+++ b/tests/ui/resolve/use-self-in-inner-fn.rs
@@ -6,6 +6,7 @@ impl A {
         fn peach(this: &Self) {
         //~^ ERROR can't use `Self` from outer item
         //~| NOTE use of `Self` from outer item
+        //~| NOTE `Self` used in this inner function
         //~| NOTE refer to the type directly here instead
         }
     }

--- a/tests/ui/resolve/use-self-in-inner-fn.stderr
+++ b/tests/ui/resolve/use-self-in-inner-fn.stderr
@@ -5,10 +5,11 @@ LL | impl A {
    | ---- `Self` type implicitly declared here, by this `impl`
 ...
 LL |         fn peach(this: &Self) {
-   |                         ^^^^
-   |                         |
-   |                         use of `Self` from outer item
-   |                         refer to the type directly here instead
+   |            -----        ^^^^
+   |            |            |
+   |            |            use of `Self` from outer item
+   |            |            refer to the type directly here instead
+   |            `Self` used in this inner function
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/self/self-ctor-nongeneric.stderr
+++ b/tests/ui/self/self-ctor-nongeneric.stderr
@@ -5,7 +5,9 @@ LL | impl S0 {
    | ------- the inner item doesn't inherit generics from this impl, so `Self` is invalid to reference
 LL |     fn foo() {
 LL |         const C: S0 = Self(0);
-   |                       ^^^^ help: replace `Self` with the actual type: `S0`
+   |               -       ^^^^ help: replace `Self` with the actual type: `S0`
+   |               |
+   |               `Self` used in this inner item
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #124186 <https://github.com/rust-lang/rust/issues/124186>
@@ -17,6 +19,8 @@ warning: can't reference `Self` constructor from outer item
 LL | impl S0 {
    | ------- the inner item doesn't inherit generics from this impl, so `Self` is invalid to reference
 ...
+LL |         fn bar() -> S0 {
+   |            --- `Self` used in this inner item
 LL |             Self(0)
    |             ^^^^ help: replace `Self` with the actual type: `S0`
    |

--- a/tests/ui/self/self-ctor.stderr
+++ b/tests/ui/self/self-ctor.stderr
@@ -5,7 +5,9 @@ LL | impl<T> S0<T> {
    | ------------- the inner item doesn't inherit generics from this impl, so `Self` is invalid to reference
 LL |     fn foo() {
 LL |         const C: S0<i32> = Self(0);
-   |                            ^^^^ help: replace `Self` with the actual type: `S0`
+   |               -            ^^^^ help: replace `Self` with the actual type: `S0`
+   |               |
+   |               `Self` used in this inner item
 
 error[E0401]: can't reference `Self` constructor from outer item
   --> $DIR/self-ctor.rs:8:13
@@ -13,6 +15,8 @@ error[E0401]: can't reference `Self` constructor from outer item
 LL | impl<T> S0<T> {
    | ------------- the inner item doesn't inherit generics from this impl, so `Self` is invalid to reference
 ...
+LL |         fn bar() -> S0<i32> {
+   |            --- `Self` used in this inner item
 LL |             Self(0)
    |             ^^^^ help: replace `Self` with the actual type: `S0`
 

--- a/tests/ui/statics/static-generic-param-soundness.stderr
+++ b/tests/ui/statics/static-generic-param-soundness.stderr
@@ -4,7 +4,9 @@ error[E0401]: can't use generic parameters from outer item
 LL | fn foo<T>() {
    |        - type parameter from outer item
 LL |     static a: Bar<T> = Bar::What;
-   |                   ^ use of generic parameter from outer item
+   |            -      ^ use of generic parameter from outer item
+   |            |
+   |            generic parameter used in this inner static item
    |
    = note: a `static` is a separate item from the item that contains it
 

--- a/tests/ui/traits/ice-index-out-of-bounds-issue-117446.stderr
+++ b/tests/ui/traits/ice-index-out-of-bounds-issue-117446.stderr
@@ -24,6 +24,9 @@ error[E0401]: can't reference `Self` constructor from outer item
 LL | impl<'a, T> Foo<'a> for Repeated<T> {
    | ----------------------------------- the inner item doesn't inherit generics from this impl, so `Self` is invalid to reference
 ...
+LL |         fn inner<Q>(value: Option<()>) -> Repeated<Q> {
+   |            ----- `Self` used in this inner item
+LL |             match value {
 LL |                 _ => Self(unimplemented!()),
    |                      ^^^^ help: replace `Self` with the actual type: `Repeated`
 

--- a/tests/ui/type/type-arg-out-of-scope.stderr
+++ b/tests/ui/type/type-arg-out-of-scope.stderr
@@ -4,9 +4,12 @@ error[E0401]: can't use generic parameters from outer item
 LL | fn foo<T>(x: T) {
    |        - type parameter from outer item
 LL |     fn bar(f: Box<dyn FnMut(T) -> T>) { }
-   |           -                 ^ use of generic parameter from outer item
-   |           |
-   |           help: try introducing a local generic parameter here: `<T>`
+   |                             ^ use of generic parameter from outer item
+   |
+help: try introducing a local generic parameter here
+   |
+LL |     fn bar<T>(f: Box<dyn FnMut(T) -> T>) { }
+   |           +++
 
 error[E0401]: can't use generic parameters from outer item
   --> $DIR/type-arg-out-of-scope.rs:2:35
@@ -14,9 +17,12 @@ error[E0401]: can't use generic parameters from outer item
 LL | fn foo<T>(x: T) {
    |        - type parameter from outer item
 LL |     fn bar(f: Box<dyn FnMut(T) -> T>) { }
-   |           -                       ^ use of generic parameter from outer item
-   |           |
-   |           help: try introducing a local generic parameter here: `<T>`
+   |                                   ^ use of generic parameter from outer item
+   |
+help: try introducing a local generic parameter here
+   |
+LL |     fn bar<T>(f: Box<dyn FnMut(T) -> T>) { }
+   |           +++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/type/type-arg-out-of-scope.stderr
+++ b/tests/ui/type/type-arg-out-of-scope.stderr
@@ -4,7 +4,9 @@ error[E0401]: can't use generic parameters from outer item
 LL | fn foo<T>(x: T) {
    |        - type parameter from outer item
 LL |     fn bar(f: Box<dyn FnMut(T) -> T>) { }
-   |                             ^ use of generic parameter from outer item
+   |        ---                  ^ use of generic parameter from outer item
+   |        |
+   |        generic parameter used in this inner function
    |
 help: try introducing a local generic parameter here
    |
@@ -17,7 +19,9 @@ error[E0401]: can't use generic parameters from outer item
 LL | fn foo<T>(x: T) {
    |        - type parameter from outer item
 LL |     fn bar(f: Box<dyn FnMut(T) -> T>) { }
-   |                                   ^ use of generic parameter from outer item
+   |        ---                        ^ use of generic parameter from outer item
+   |        |
+   |        generic parameter used in this inner function
    |
 help: try introducing a local generic parameter here
    |


### PR DESCRIPTION
Partially address rust-lang/rust#37892.

In E0401 generated in resolve:
```
error[E0401]: can't use generic parameters from outer item
  --> $DIR/E0401.rs:4:39
   |
LL | fn foo<T>(x: T) {
   |        - type parameter from outer item
LL |     fn bfnr<U, V: Baz<U>, W: Fn()>(y: T) {
   |        ----                           ^ use of generic parameter from outer item
   |        |
   |        generic parameter used in this inner function
   |
help: try introducing a local generic parameter here
   |
LL |     fn bfnr<T, U, V: Baz<U>, W: Fn()>(y: T) {
   |             ++
```
In E0401 generated in hir_typeck:
```
error[E0401]: can't reference `Self` constructor from outer item
  --> $DIR/do-not-ice-on-note_and_explain.rs:6:13
   |
LL | impl<B> A<B> {
   | ------------ the inner item doesn't inherit generics from this impl, so `Self` is invalid to reference
LL |     fn d() {
LL |         fn d() {
   |            - `Self` used in this inner item
LL |             Self(1)
   |             ^^^^ help: replace `Self` with the actual type: `A`
```