### PR TITLE
Fix documentation for std::panic::update_hook

### DIFF
--- a/library/std/src/panicking.rs
+++ b/library/std/src/panicking.rs
@@ -215,10 +215,10 @@ pub fn take_hook() -> Box<dyn Fn(&PanicHookInfo<'_>) + 'static + Sync + Send> {
 ///
 /// // Equivalent to
 /// // let prev = panic::take_hook();
-/// // panic::set_hook(move |info| {
+/// // panic::set_hook(Box::new(move |info| {
 /// //     println!("...");
 /// //     prev(info);
-/// // );
+/// // }));
 /// panic::update_hook(move |prev, info| {
 ///     println!("Print custom message and execute panic handler as usual");
 ///     prev(info);


### PR DESCRIPTION
The equivalent code given in the documentation of `std::panic::update_hook`[^1] does not compile:

* `set_hook` expects a boxed function
* Missing closing delimiter for the closure

[^1]: rust-lang/rust#92649

