### PR TITLE
Implement `&pin` patterns and `ref pin` binding modes

### DIFF
--- a/compiler/rustc_ast_ir/src/lib.rs
+++ b/compiler/rustc_ast_ir/src/lib.rs
@@ -317,4 +317,15 @@ impl Pinnedness {
     pub fn is_pinned(self) -> bool {
         matches!(self, Self::Pinned)
     }
+
+    /// Returns `""` (empty string), "mut", `"pin mut "` or `"pin const "` depending
+    /// on the pinnedness and mutability.
+    pub fn prefix_str(self, mutbl: Mutability) -> &'static str {
+        match (self, mutbl) {
+            (Pinnedness::Pinned, Mutability::Mut) => "pin mut ",
+            (Pinnedness::Pinned, Mutability::Not) => "pin const ",
+            (Pinnedness::Not, Mutability::Mut) => "mut ",
+            (Pinnedness::Not, Mutability::Not) => "",
+        }
+    }
 }

--- a/compiler/rustc_ast_lowering/src/pat.rs
+++ b/compiler/rustc_ast_lowering/src/pat.rs
@@ -124,8 +124,8 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                     PatKind::Deref(inner) => {
                         break hir::PatKind::Deref(self.lower_pat(inner));
                     }
-                    PatKind::Ref(inner, mutbl) => {
-                        break hir::PatKind::Ref(self.lower_pat(inner), *mutbl);
+                    PatKind::Ref(inner, pinned, mutbl) => {
+                        break hir::PatKind::Ref(self.lower_pat(inner), *pinned, *mutbl);
                     }
                     PatKind::Range(e1, e2, Spanned { node: end, .. }) => {
                         break hir::PatKind::Range(

--- a/compiler/rustc_ast_pretty/src/pprust/state.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state.rs
@@ -1807,8 +1807,14 @@ impl<'a> State<'a> {
                 self.print_pat(inner);
                 self.pclose();
             }
-            PatKind::Ref(inner, mutbl) => {
+            PatKind::Ref(inner, pinned, mutbl) => {
                 self.word("&");
+                if pinned.is_pinned() {
+                    self.word("pin ");
+                    if mutbl.is_not() {
+                        self.word("const ");
+                    }
+                }
                 if mutbl.is_mut() {
                     self.word("mut ");
                 }

--- a/compiler/rustc_borrowck/src/diagnostics/move_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/move_errors.rs
@@ -867,11 +867,12 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
         for (binding_span, opt_ref_pat) in finder.ref_pat_for_binding {
             if let Some(ref_pat) = opt_ref_pat
                 && !finder.cannot_remove.contains(&ref_pat.hir_id)
-                && let hir::PatKind::Ref(subpat, mutbl) = ref_pat.kind
+                && let hir::PatKind::Ref(subpat, pinned, mutbl) = ref_pat.kind
                 && let Some(ref_span) = ref_pat.span.trim_end(subpat.span)
             {
+                let pinned_str = if pinned.is_pinned() { "pinned " } else { "" };
                 let mutable_str = if mutbl.is_mut() { "mutable " } else { "" };
-                let msg = format!("consider removing the {mutable_str}borrow");
+                let msg = format!("consider removing the {pinned_str}{mutable_str}borrow");
                 suggestions.push((ref_span, msg, "".to_string()));
             } else {
                 let msg = "consider borrowing the pattern binding".to_string();

--- a/compiler/rustc_borrowck/src/diagnostics/mutability_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/mutability_errors.rs
@@ -772,11 +772,11 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
             && let Some(hir_id) = (BindingFinder { span: pat_span }).visit_body(&body).break_value()
             && let node = self.infcx.tcx.hir_node(hir_id)
             && let hir::Node::LetStmt(hir::LetStmt {
-                pat: hir::Pat { kind: hir::PatKind::Ref(_, _), .. },
+                pat: hir::Pat { kind: hir::PatKind::Ref(_, _, _), .. },
                 ..
             })
             | hir::Node::Param(Param {
-                pat: hir::Pat { kind: hir::PatKind::Ref(_, _), .. },
+                pat: hir::Pat { kind: hir::PatKind::Ref(_, _, _), .. },
                 ..
             }) = node
         {
@@ -1494,7 +1494,7 @@ impl<'tcx> Visitor<'tcx> for BindingFinder {
     }
 
     fn visit_param(&mut self, param: &'tcx hir::Param<'tcx>) -> Self::Result {
-        if let hir::Pat { kind: hir::PatKind::Ref(_, _), span, .. } = param.pat
+        if let hir::Pat { kind: hir::PatKind::Ref(_, _, _), span, .. } = param.pat
             && *span == self.span
         {
             ControlFlow::Break(param.hir_id)

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -1722,7 +1722,9 @@ impl<'hir> Pat<'hir> {
         match self.kind {
             Missing => unreachable!(),
             Wild | Never | Expr(_) | Range(..) | Binding(.., None) | Err(_) => true,
-            Box(s) | Deref(s) | Ref(s, _) | Binding(.., Some(s)) | Guard(s, _) => s.walk_short_(it),
+            Box(s) | Deref(s) | Ref(s, _, _) | Binding(.., Some(s)) | Guard(s, _) => {
+                s.walk_short_(it)
+            }
             Struct(_, fields, _) => fields.iter().all(|field| field.pat.walk_short_(it)),
             TupleStruct(_, s, _) | Tuple(s, _) | Or(s) => s.iter().all(|p| p.walk_short_(it)),
             Slice(before, slice, after) => {
@@ -1749,7 +1751,7 @@ impl<'hir> Pat<'hir> {
         use PatKind::*;
         match self.kind {
             Missing | Wild | Never | Expr(_) | Range(..) | Binding(.., None) | Err(_) => {}
-            Box(s) | Deref(s) | Ref(s, _) | Binding(.., Some(s)) | Guard(s, _) => s.walk_(it),
+            Box(s) | Deref(s) | Ref(s, _, _) | Binding(.., Some(s)) | Guard(s, _) => s.walk_(it),
             Struct(_, fields, _) => fields.iter().for_each(|field| field.pat.walk_(it)),
             TupleStruct(_, s, _) | Tuple(s, _) | Or(s) => s.iter().for_each(|p| p.walk_(it)),
             Slice(before, slice, after) => {
@@ -1938,7 +1940,7 @@ pub enum PatKind<'hir> {
     Deref(&'hir Pat<'hir>),
 
     /// A reference pattern (e.g., `&mut (a, b)`).
-    Ref(&'hir Pat<'hir>, Mutability),
+    Ref(&'hir Pat<'hir>, Pinnedness, Mutability),
 
     /// A literal, const block or path.
     Expr(&'hir PatExpr<'hir>),

--- a/compiler/rustc_hir/src/intravisit.rs
+++ b/compiler/rustc_hir/src/intravisit.rs
@@ -752,7 +752,7 @@ pub fn walk_pat<'v, V: Visitor<'v>>(visitor: &mut V, pattern: &'v Pat<'v>) -> V:
         }
         PatKind::Box(ref subpattern)
         | PatKind::Deref(ref subpattern)
-        | PatKind::Ref(ref subpattern, _) => {
+        | PatKind::Ref(ref subpattern, _, _) => {
             try_visit!(visitor.visit_pat(subpattern));
         }
         PatKind::Binding(_, _hir_id, ident, ref optional_subpattern) => {

--- a/compiler/rustc_hir_analysis/src/check/region.rs
+++ b/compiler/rustc_hir_analysis/src/check/region.rs
@@ -593,7 +593,7 @@ fn resolve_local<'tcx>(
                 is_binding_pat(subpat)
             }
 
-            PatKind::Ref(_, _)
+            PatKind::Ref(_, _, _)
             | PatKind::Binding(hir::BindingMode(hir::ByRef::No, _), ..)
             | PatKind::Missing
             | PatKind::Wild

--- a/compiler/rustc_hir_pretty/src/lib.rs
+++ b/compiler/rustc_hir_pretty/src/lib.rs
@@ -2028,9 +2028,15 @@ impl<'a> State<'a> {
                 self.print_pat(inner);
                 self.pclose();
             }
-            PatKind::Ref(inner, mutbl) => {
+            PatKind::Ref(inner, pinned, mutbl) => {
                 let is_range_inner = matches!(inner.kind, PatKind::Range(..));
                 self.word("&");
+                if pinned.is_pinned() {
+                    self.word("pin ");
+                    if mutbl.is_not() {
+                        self.word("const ");
+                    }
+                }
                 self.word(mutbl.prefix_str());
                 if is_range_inner {
                     self.popen();

--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -523,7 +523,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             | hir::PatKind::TupleStruct(_, _, _)
             | hir::PatKind::Tuple(_, _)
             | hir::PatKind::Box(_)
-            | hir::PatKind::Ref(_, _)
+            | hir::PatKind::Ref(_, _, _)
             | hir::PatKind::Deref(_)
             | hir::PatKind::Expr(_)
             | hir::PatKind::Range(_, _, _)

--- a/compiler/rustc_hir_typeck/src/expr_use_visitor.rs
+++ b/compiler/rustc_hir_typeck/src/expr_use_visitor.rs
@@ -1231,7 +1231,7 @@ impl<'tcx, Cx: TypeInformationCtxt<'tcx>, D: Delegate<'tcx>> ExprUseVisitor<'tcx
                 debug!("pat_ty(pat={:?}) found adjustment `{:?}`", pat, first_adjust);
                 return Ok(first_adjust.source);
             }
-        } else if let PatKind::Ref(subpat, _) = pat.kind
+        } else if let PatKind::Ref(subpat, _, _) = pat.kind
             && self.cx.typeck_results().skipped_ref_pats().contains(pat.hir_id)
         {
             return self.pat_ty_adjusted(subpat);
@@ -1817,13 +1817,13 @@ impl<'tcx, Cx: TypeInformationCtxt<'tcx>, D: Delegate<'tcx>> ExprUseVisitor<'tcx
                 self.cat_pattern(place_with_id, subpat, op)?;
             }
 
-            PatKind::Ref(subpat, _)
+            PatKind::Ref(subpat, _, _)
                 if self.cx.typeck_results().skipped_ref_pats().contains(pat.hir_id) =>
             {
                 self.cat_pattern(place_with_id, subpat, op)?;
             }
 
-            PatKind::Box(subpat) | PatKind::Ref(subpat, _) => {
+            PatKind::Box(subpat) | PatKind::Ref(subpat, _, _) => {
                 // box p1, &p1, &mut p1. we can ignore the mutability of
                 // PatKind::Ref since that information is already contained
                 // in the type.

--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -2610,7 +2610,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                                 let mut current_node = parent_node;
 
                                 while let Node::Pat(parent_pat) = current_node {
-                                    if let hir::PatKind::Ref(_, mutability) = parent_pat.kind {
+                                    if let hir::PatKind::Ref(_, _, mutability) = parent_pat.kind {
                                         ref_muts.push(mutability);
                                         current_node = self.tcx.parent_hir_node(parent_pat.hir_id);
                                     } else {

--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -1705,7 +1705,7 @@ impl EarlyLintPass for EllipsisInclusiveRangePatterns {
         }
 
         let (parentheses, endpoints) = match &pat.kind {
-            PatKind::Ref(subpat, _) => (true, matches_ellipsis_pat(subpat)),
+            PatKind::Ref(subpat, _, _) => (true, matches_ellipsis_pat(subpat)),
             _ => (false, matches_ellipsis_pat(pat)),
         };
 

--- a/compiler/rustc_lint/src/unused.rs
+++ b/compiler/rustc_lint/src/unused.rs
@@ -1307,7 +1307,8 @@ impl EarlyLintPass for UnusedParens {
             Ident(.., Some(p)) | Box(p) | Deref(p) | Guard(p, _) => self.check_unused_parens_pat(cx, p, true, false, keep_space),
             // Avoid linting on `&(mut x)` as `&mut x` has a different meaning, #55342.
             // Also avoid linting on `& mut? (p0 | .. | pn)`, #64106.
-            Ref(p, m) => self.check_unused_parens_pat(cx, p, true, *m == Mutability::Not, keep_space),
+            // FIXME(pin_ergonomics): check pinned patterns
+            Ref(p, _, m) => self.check_unused_parens_pat(cx, p, true, *m == Mutability::Not, keep_space),
         }
     }
 

--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -11,7 +11,7 @@ pub use basic_blocks::{BasicBlocks, SwitchTargetValue};
 use either::Either;
 use polonius_engine::Atom;
 use rustc_abi::{FieldIdx, VariantIdx};
-pub use rustc_ast::Mutability;
+pub use rustc_ast::{Mutability, Pinnedness};
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_data_structures::graph::dominators::Dominators;
 use rustc_errors::{DiagArgName, DiagArgValue, DiagMessage, ErrorGuaranteed, IntoDiagArg};

--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -1366,6 +1366,19 @@ impl<'tcx> Ty<'tcx> {
         None
     }
 
+    pub fn maybe_pinned_ref(self) -> Option<(Ty<'tcx>, ty::Pinnedness, ty::Mutability)> {
+        match *self.kind() {
+            Adt(def, args)
+                if def.is_pin()
+                    && let ty::Ref(_, ty, mutbl) = *args.type_at(0).kind() =>
+            {
+                Some((ty, ty::Pinnedness::Pinned, mutbl))
+            }
+            ty::Ref(_, ty, mutbl) => Some((ty, ty::Pinnedness::Not, mutbl)),
+            _ => None,
+        }
+    }
+
     /// Panics if called on any type other than `Box<T>`.
     pub fn expect_boxed_ty(self) -> Ty<'tcx> {
         self.boxed_ty()

--- a/compiler/rustc_mir_build/src/thir/pattern/mod.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/mod.rs
@@ -97,7 +97,7 @@ impl<'a, 'tcx> PatCtxt<'a, 'tcx> {
         // adjustments in *reverse order* (last-in-first-out, so that the last `Deref` inserted
         // gets the least-dereferenced type).
         let unadjusted_pat = match pat.kind {
-            hir::PatKind::Ref(inner, _)
+            hir::PatKind::Ref(inner, _, _)
                 if self.typeck_results.skipped_ref_pats().contains(pat.hir_id) =>
             {
                 self.lower_pattern(inner)
@@ -319,7 +319,7 @@ impl<'a, 'tcx> PatCtxt<'a, 'tcx> {
                 let borrow = self.typeck_results.deref_pat_borrow_mode(ty, subpattern);
                 PatKind::DerefPattern { subpattern: self.lower_pattern(subpattern), borrow }
             }
-            hir::PatKind::Ref(subpattern, _) => {
+            hir::PatKind::Ref(subpattern, _, _) => {
                 // Track the default binding mode for the Rust 2024 migration suggestion.
                 let opt_old_mode_span =
                     self.rust_2024_migration.as_mut().and_then(|s| s.visit_explicit_deref());
@@ -370,10 +370,6 @@ impl<'a, 'tcx> PatCtxt<'a, 'tcx> {
                             if let Some(pty) = ty.pinned_ty()
                                 && let &ty::Ref(_, rty, _) = pty.kind() =>
                         {
-                            debug_assert!(
-                                self.tcx.features().pin_ergonomics(),
-                                "`pin_ergonomics` must be enabled to have a by-pin-ref binding"
-                            );
                             ty = rty;
                         }
                         hir::Pinnedness::Not if let &ty::Ref(_, rty, _) = ty.kind() => {

--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -2301,10 +2301,10 @@ impl<'a> Parser<'a> {
                         pat.span.shrink_to_hi(),
                         pat.span.shrink_to_lo(),
                     ),
-                    PatKind::Ref(ref inner_pat, _)
+                    PatKind::Ref(ref inner_pat, _, _)
                     // Fix suggestions for multi-reference `self` parameters (e.g. `&&&self`)
                     // cc: https://github.com/rust-lang/rust/pull/146305
-                        if let PatKind::Ref(_, _) = &inner_pat.kind
+                        if let PatKind::Ref(_, _, _) = &inner_pat.kind
                             && let PatKind::Path(_, path) = &pat.peel_refs().kind
                             && let [a, ..] = path.segments.as_slice()
                             && a.ident.name == kw::SelfLower =>
@@ -2312,7 +2312,7 @@ impl<'a> Parser<'a> {
                         let mut inner = inner_pat;
                         let mut span_vec = vec![pat.span];
 
-                        while let PatKind::Ref(ref inner_type, _) = inner.kind {
+                        while let PatKind::Ref(ref inner_type, _, _) = inner.kind {
                             inner = inner_type;
                             span_vec.push(inner.span.shrink_to_lo());
                         }
@@ -2334,10 +2334,10 @@ impl<'a> Parser<'a> {
                         return None;
                     }
                     // Also catches `fn foo(&a)`.
-                    PatKind::Ref(ref inner_pat, mutab)
+                    PatKind::Ref(ref inner_pat, pinned, mutab)
                         if let PatKind::Ident(_, ident, _) = inner_pat.clone().kind =>
                     {
-                        let mutab = mutab.prefix_str();
+                        let mutab = pinned.prefix_str(mutab);
                         (
                             ident,
                             "self: ",

--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -863,14 +863,15 @@ impl<'a> Parser<'a> {
             assert!(found_raw);
             let mutability = self.parse_const_or_mut().unwrap();
             (ast::BorrowKind::Raw, mutability)
-        } else if let Some((ast::Pinnedness::Pinned, mutbl)) = self.parse_pin_and_mut() {
-            // `pin [ const | mut ]`.
-            // `pin` has been gated in `self.parse_pin_and_mut()` so we don't
-            // need to gate it here.
-            (ast::BorrowKind::Pin, mutbl)
         } else {
-            // `mut?`
-            (ast::BorrowKind::Ref, self.parse_mutability())
+            match self.parse_pin_and_mut() {
+                // `mut?`
+                (ast::Pinnedness::Not, mutbl) => (ast::BorrowKind::Ref, mutbl),
+                // `pin [ const | mut ]`.
+                // `pin` has been gated in `self.parse_pin_and_mut()` so we don't
+                // need to gate it here.
+                (ast::Pinnedness::Pinned, mutbl) => (ast::BorrowKind::Pin, mutbl),
+            }
         }
     }
 

--- a/compiler/rustc_parse/src/parser/mod.rs
+++ b/compiler/rustc_parse/src/parser/mod.rs
@@ -36,8 +36,8 @@ use rustc_ast::tokenstream::{
 use rustc_ast::util::case::Case;
 use rustc_ast::{
     self as ast, AnonConst, AttrArgs, AttrId, ByRef, Const, CoroutineKind, DUMMY_NODE_ID,
-    DelimArgs, Expr, ExprKind, Extern, HasAttrs, HasTokens, Mutability, Pinnedness, Recovered,
-    Safety, StrLit, Visibility, VisibilityKind,
+    DelimArgs, Expr, ExprKind, Extern, HasAttrs, HasTokens, Mutability, Recovered, Safety, StrLit,
+    Visibility, VisibilityKind,
 };
 use rustc_ast_pretty::pprust;
 use rustc_data_structures::fx::FxHashMap;
@@ -1315,11 +1315,11 @@ impl<'a> Parser<'a> {
         if self.eat_keyword(exp!(Mut)) { Mutability::Mut } else { Mutability::Not }
     }
 
-    /// Parses reference binding mode (`ref`, `ref mut`, or nothing).
+    /// Parses reference binding mode (`ref`, `ref mut`, `ref pin const`, `ref pin mut`, or nothing).
     fn parse_byref(&mut self) -> ByRef {
         if self.eat_keyword(exp!(Ref)) {
-            // FIXME(pin_ergonomics): support `ref pin const|mut` bindings
-            ByRef::Yes(Pinnedness::Not, self.parse_mutability())
+            let (pinnedness, mutability) = self.parse_pin_and_mut();
+            ByRef::Yes(pinnedness, mutability)
         } else {
             ByRef::No
         }

--- a/compiler/rustc_parse/src/parser/token_type.rs
+++ b/compiler/rustc_parse/src/parser/token_type.rs
@@ -142,6 +142,7 @@ pub enum TokenType {
     SymNull,
     SymOptions,
     SymOut,
+    SymPin,
     SymPreservesFlags,
     SymPure,
     SymReadonly,
@@ -568,6 +569,7 @@ macro_rules! exp {
     (Null)           => { exp!(@sym, null,            SymNull) };
     (Options)        => { exp!(@sym, options,         SymOptions) };
     (Out)            => { exp!(@sym, out,             SymOut) };
+    (Pin)            => { exp!(@sym, pin,             SymPin) };
     (PreservesFlags) => { exp!(@sym, preserves_flags, SymPreservesFlags) };
     (Pure)           => { exp!(@sym, pure,            SymPure) };
     (Readonly)       => { exp!(@sym, readonly,        SymReadonly) };

--- a/compiler/rustc_parse/src/parser/ty.rs
+++ b/compiler/rustc_parse/src/parser/ty.rs
@@ -728,10 +728,7 @@ impl<'a> Parser<'a> {
     fn parse_borrowed_pointee(&mut self) -> PResult<'a, TyKind> {
         let and_span = self.prev_token.span;
         let mut opt_lifetime = self.check_lifetime().then(|| self.expect_lifetime());
-        let (pinned, mut mutbl) = match self.parse_pin_and_mut() {
-            Some(pin_mut) => pin_mut,
-            None => (Pinnedness::Not, self.parse_mutability()),
-        };
+        let (pinned, mut mutbl) = self.parse_pin_and_mut();
         if self.token.is_lifetime() && mutbl == Mutability::Mut && opt_lifetime.is_none() {
             // A lifetime is invalid here: it would be part of a bare trait bound, which requires
             // it to be followed by a plus, but we disallow plus in the pointee type.
@@ -773,28 +770,17 @@ impl<'a> Parser<'a> {
         })
     }
 
-    /// Parses `pin` and `mut` annotations on references.
+    /// Parses `pin` and `mut` annotations on references, patterns, or borrow modifiers.
     ///
-    /// It must be either `pin const` or `pin mut`.
-    pub(crate) fn parse_pin_and_mut(&mut self) -> Option<(Pinnedness, Mutability)> {
-        if self.token.is_ident_named(sym::pin) {
-            let result = self.look_ahead(1, |token| {
-                if token.is_keyword(kw::Const) {
-                    Some((Pinnedness::Pinned, Mutability::Not))
-                } else if token.is_keyword(kw::Mut) {
-                    Some((Pinnedness::Pinned, Mutability::Mut))
-                } else {
-                    None
-                }
-            });
-            if result.is_some() {
-                self.psess.gated_spans.gate(sym::pin_ergonomics, self.token.span);
-                self.bump();
-                self.bump();
-            }
-            result
+    /// It must be either `pin const`, `pin mut`, `mut`, or nothing (immutable).
+    pub(crate) fn parse_pin_and_mut(&mut self) -> (Pinnedness, Mutability) {
+        if self.token.is_ident_named(sym::pin) && self.look_ahead(1, Token::is_mutability) {
+            self.psess.gated_spans.gate(sym::pin_ergonomics, self.token.span);
+            assert!(self.eat_keyword(exp!(Pin)));
+            let mutbl = self.parse_const_or_mut().unwrap();
+            (Pinnedness::Pinned, mutbl)
         } else {
-            None
+            (Pinnedness::Not, self.parse_mutability())
         }
     }
 

--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -303,7 +303,7 @@ pub(crate) fn name_from_pat(p: &hir::Pat<'_>) -> Symbol {
             return kw::Underscore;
         }
         PatKind::Binding(_, _, ident, _) => return ident.name,
-        PatKind::Box(p) | PatKind::Ref(p, _) | PatKind::Guard(p, _) => return name_from_pat(p),
+        PatKind::Box(p) | PatKind::Ref(p, _, _) | PatKind::Guard(p, _) => return name_from_pat(p),
         PatKind::TupleStruct(p, ..) | PatKind::Expr(PatExpr { kind: PatExprKind::Path(p), .. }) => {
             qpath_to_string(p)
         }

--- a/src/tools/clippy/clippy_lints/src/equatable_if_let.rs
+++ b/src/tools/clippy/clippy_lints/src/equatable_if_let.rs
@@ -55,7 +55,7 @@ fn unary_pattern(pat: &Pat<'_>) -> bool {
         | PatKind::Err(_) => false,
         PatKind::Struct(_, a, etc) => etc.is_none() && a.iter().all(|x| unary_pattern(x.pat)),
         PatKind::Tuple(a, etc) | PatKind::TupleStruct(_, a, etc) => etc.as_opt_usize().is_none() && array_rec(a),
-        PatKind::Ref(x, _) | PatKind::Box(x) | PatKind::Deref(x) | PatKind::Guard(x, _) => unary_pattern(x),
+        PatKind::Ref(x, _, _) | PatKind::Box(x) | PatKind::Deref(x) | PatKind::Guard(x, _) => unary_pattern(x),
         PatKind::Expr(_) => true,
     }
 }

--- a/src/tools/clippy/clippy_lints/src/loops/manual_find.rs
+++ b/src/tools/clippy/clippy_lints/src/loops/manual_find.rs
@@ -43,7 +43,7 @@ pub(super) fn check<'tcx>(
         let mut snippet = make_iterator_snippet(cx, arg, &mut applicability);
         // Checks if `pat` is a single reference to a binding (`&x`)
         let is_ref_to_binding =
-            matches!(pat.kind, PatKind::Ref(inner, _) if matches!(inner.kind, PatKind::Binding(..)));
+            matches!(pat.kind, PatKind::Ref(inner, _, _) if matches!(inner.kind, PatKind::Binding(..)));
         // If `pat` is not a binding or a reference to a binding (`x` or `&x`)
         // we need to map it to the binding returned by the function (i.e. `.map(|(x, _)| x)`)
         if !(matches!(pat.kind, PatKind::Binding(..)) || is_ref_to_binding) {

--- a/src/tools/clippy/clippy_lints/src/manual_retain.rs
+++ b/src/tools/clippy/clippy_lints/src/manual_retain.rs
@@ -157,7 +157,7 @@ fn check_iter(
                     ),
                 );
             },
-            hir::PatKind::Ref(pat, _) => make_span_lint_and_sugg(
+            hir::PatKind::Ref(pat, _, _) => make_span_lint_and_sugg(
                 cx,
                 parent_expr_span,
                 format!(
@@ -196,7 +196,7 @@ fn check_to_owned(
         && let filter_body = cx.tcx.hir_body(closure.body)
         && let [filter_params] = filter_body.params
         && msrv.meets(cx, msrvs::STRING_RETAIN)
-        && let hir::PatKind::Ref(pat, _) = filter_params.pat.kind
+        && let hir::PatKind::Ref(pat, _, _) = filter_params.pat.kind
     {
         make_span_lint_and_sugg(
             cx,

--- a/src/tools/clippy/clippy_lints/src/matches/manual_ok_err.rs
+++ b/src/tools/clippy/clippy_lints/src/matches/manual_ok_err.rs
@@ -78,7 +78,7 @@ fn is_variant_or_wildcard(cx: &LateContext<'_>, pat: &Pat<'_>, can_be_wild: bool
                 .is_lang_item(cx, ResultErr)
                 == must_match_err
         },
-        PatKind::Binding(_, _, _, Some(pat)) | PatKind::Ref(pat, _) => {
+        PatKind::Binding(_, _, _, Some(pat)) | PatKind::Ref(pat, _, _) => {
             is_variant_or_wildcard(cx, pat, can_be_wild, must_match_err)
         },
         _ => false,

--- a/src/tools/clippy/clippy_lints/src/matches/manual_utils.rs
+++ b/src/tools/clippy/clippy_lints/src/matches/manual_utils.rs
@@ -254,7 +254,7 @@ pub(super) fn try_parse_pattern<'tcx>(
     ) -> Option<OptionPat<'tcx>> {
         match pat.kind {
             PatKind::Wild => Some(OptionPat::Wild),
-            PatKind::Ref(pat, _) => f(cx, pat, ref_count + 1, ctxt),
+            PatKind::Ref(pat, _, _) => f(cx, pat, ref_count + 1, ctxt),
             PatKind::Expr(PatExpr {
                 kind: PatExprKind::Path(qpath),
                 hir_id,

--- a/src/tools/clippy/clippy_lints/src/matches/match_ref_pats.rs
+++ b/src/tools/clippy/clippy_lints/src/matches/match_ref_pats.rs
@@ -50,7 +50,7 @@ where
     }
 
     let remaining_suggs = pats.filter_map(|pat| {
-        if let PatKind::Ref(refp, _) = pat.kind {
+        if let PatKind::Ref(refp, _, _) = pat.kind {
             Some((pat.span, snippet(cx, refp.span, "..").to_string()))
         } else {
             None

--- a/src/tools/clippy/clippy_lints/src/matches/match_same_arms.rs
+++ b/src/tools/clippy/clippy_lints/src/matches/match_same_arms.rs
@@ -264,7 +264,7 @@ impl<'a> NormalizedPat<'a> {
             PatKind::Binding(.., Some(pat))
             | PatKind::Box(pat)
             | PatKind::Deref(pat)
-            | PatKind::Ref(pat, _)
+            | PatKind::Ref(pat, _, _)
             | PatKind::Guard(pat, _) => Self::from_pat(cx, arena, pat),
             PatKind::Never => Self::Never,
             PatKind::Struct(ref path, fields, _) => {

--- a/src/tools/clippy/clippy_lints/src/matches/redundant_guards.rs
+++ b/src/tools/clippy/clippy_lints/src/matches/redundant_guards.rs
@@ -30,7 +30,7 @@ pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, arms: &'tcx [Arm<'tcx>], msrv:
             && !pat_contains_disallowed_or(cx, arm.pat, msrv)
         {
             let pat_span = match (arm.pat.kind, binding.byref_ident) {
-                (PatKind::Ref(pat, _), Some(_)) => pat.span,
+                (PatKind::Ref(pat, _, _), Some(_)) => pat.span,
                 (PatKind::Ref(..), None) | (_, Some(_)) => continue,
                 _ => arm.pat.span,
             };
@@ -49,7 +49,7 @@ pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, arms: &'tcx [Arm<'tcx>], msrv:
             && !pat_contains_disallowed_or(cx, let_expr.pat, msrv)
         {
             let pat_span = match (let_expr.pat.kind, binding.byref_ident) {
-                (PatKind::Ref(pat, _), Some(_)) => pat.span,
+                (PatKind::Ref(pat, _, _), Some(_)) => pat.span,
                 (PatKind::Ref(..), None) | (_, Some(_)) => continue,
                 _ => let_expr.pat.span,
             };

--- a/src/tools/clippy/clippy_lints/src/matches/redundant_pattern_match.rs
+++ b/src/tools/clippy/clippy_lints/src/matches/redundant_pattern_match.rs
@@ -186,7 +186,7 @@ fn find_method_sugg_for_if_let<'tcx>(
     // also look inside refs
     // if we have &None for example, peel it so we can detect "if let None = x"
     let check_pat = match let_pat.kind {
-        PatKind::Ref(inner, _mutability) => inner,
+        PatKind::Ref(inner, _pinnedness, _mutability) => inner,
         _ => let_pat,
     };
     let op_ty = cx.typeck_results().expr_ty(let_expr);

--- a/src/tools/clippy/clippy_lints/src/matches/single_match.rs
+++ b/src/tools/clippy/clippy_lints/src/matches/single_match.rs
@@ -373,7 +373,7 @@ impl<'a> PatState<'a> {
             },
 
             // Patterns for things which can only contain a single sub-pattern.
-            PatKind::Binding(_, _, _, Some(pat)) | PatKind::Ref(pat, _) | PatKind::Box(pat) | PatKind::Deref(pat) => {
+            PatKind::Binding(_, _, _, Some(pat)) | PatKind::Ref(pat, _, _) | PatKind::Box(pat) | PatKind::Deref(pat) => {
                 self.add_pat(cx, pat)
             },
             PatKind::Tuple([sub_pat], pos)

--- a/src/tools/clippy/clippy_lints/src/methods/filter_map.rs
+++ b/src/tools/clippy/clippy_lints/src/methods/filter_map.rs
@@ -404,7 +404,7 @@ fn is_find_or_filter<'a>(
         && let filter_body = cx.tcx.hir_body(filter_body_id)
         && let [filter_param] = filter_body.params
         // optional ref pattern: `filter(|&x| ..)`
-        && let (filter_pat, is_filter_param_ref) = if let PatKind::Ref(ref_pat, _) = filter_param.pat.kind {
+        && let (filter_pat, is_filter_param_ref) = if let PatKind::Ref(ref_pat, _, _) = filter_param.pat.kind {
             (ref_pat, true)
         } else {
             (filter_param.pat, false)

--- a/src/tools/clippy/clippy_lints/src/methods/iter_filter.rs
+++ b/src/tools/clippy/clippy_lints/src/methods/iter_filter.rs
@@ -50,7 +50,7 @@ fn is_method(
     fn pat_is_recv(ident: Ident, param: &hir::Pat<'_>) -> bool {
         match param.kind {
             hir::PatKind::Binding(_, _, other, _) => ident == other,
-            hir::PatKind::Ref(pat, _) => pat_is_recv(ident, pat),
+            hir::PatKind::Ref(pat, _, _) => pat_is_recv(ident, pat),
             _ => false,
         }
     }

--- a/src/tools/clippy/clippy_lints/src/methods/iter_overeager_cloned.rs
+++ b/src/tools/clippy/clippy_lints/src/methods/iter_overeager_cloned.rs
@@ -81,7 +81,7 @@ pub(super) fn check<'tcx>(
                 }
 
                 match it.kind {
-                    PatKind::Binding(BindingMode(_, Mutability::Mut), _, _, _) | PatKind::Ref(_, Mutability::Mut) => {
+                    PatKind::Binding(BindingMode(_, Mutability::Mut), _, _, _) | PatKind::Ref(_, _, Mutability::Mut) => {
                         to_be_discarded = true;
                         false
                     },

--- a/src/tools/clippy/clippy_lints/src/methods/map_clone.rs
+++ b/src/tools/clippy/clippy_lints/src/methods/map_clone.rs
@@ -8,7 +8,7 @@ use rustc_errors::Applicability;
 use rustc_hir::def_id::DefId;
 use rustc_hir::{self as hir, LangItem};
 use rustc_lint::LateContext;
-use rustc_middle::mir::Mutability;
+use rustc_middle::mir::{Mutability, Pinnedness};
 use rustc_middle::ty;
 use rustc_middle::ty::adjustment::Adjust;
 use rustc_span::symbol::Ident;
@@ -50,7 +50,7 @@ pub(super) fn check(cx: &LateContext<'_>, e: &hir::Expr<'_>, recv: &hir::Expr<'_
                 let closure_body = cx.tcx.hir_body(body);
                 let closure_expr = peel_blocks(closure_body.value);
                 match closure_body.params[0].pat.kind {
-                    hir::PatKind::Ref(inner, Mutability::Not) => {
+                    hir::PatKind::Ref(inner, Pinnedness::Not, Mutability::Not) => {
                         if let hir::PatKind::Binding(hir::BindingMode::NONE, .., name, None) = inner.kind
                             && ident_eq(name, closure_expr)
                         {

--- a/src/tools/clippy/clippy_lints/src/needless_borrowed_ref.rs
+++ b/src/tools/clippy/clippy_lints/src/needless_borrowed_ref.rs
@@ -1,6 +1,6 @@
 use clippy_utils::diagnostics::span_lint_and_then;
 use rustc_errors::Applicability;
-use rustc_hir::{BindingMode, Mutability, Node, Pat, PatKind};
+use rustc_hir::{BindingMode, Mutability, Node, Pat, PatKind, Pinnedness};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_session::declare_lint_pass;
 
@@ -37,7 +37,7 @@ declare_lint_pass!(NeedlessBorrowedRef => [NEEDLESS_BORROWED_REFERENCE]);
 
 impl<'tcx> LateLintPass<'tcx> for NeedlessBorrowedRef {
     fn check_pat(&mut self, cx: &LateContext<'tcx>, ref_pat: &'tcx Pat<'_>) {
-        if let PatKind::Ref(pat, Mutability::Not) = ref_pat.kind
+        if let PatKind::Ref(pat, Pinnedness::Not, Mutability::Not) = ref_pat.kind
             && !ref_pat.span.from_expansion()
             && cx
                 .tcx

--- a/src/tools/clippy/clippy_lints/src/unnested_or_patterns.rs
+++ b/src/tools/clippy/clippy_lints/src/unnested_or_patterns.rs
@@ -7,7 +7,7 @@ use clippy_utils::msrvs::{self, MsrvStack};
 use clippy_utils::over;
 use rustc_ast::PatKind::*;
 use rustc_ast::mut_visit::*;
-use rustc_ast::{self as ast, DUMMY_NODE_ID, Mutability, Pat, PatKind};
+use rustc_ast::{self as ast, DUMMY_NODE_ID, Mutability, Pat, PatKind, Pinnedness};
 use rustc_ast_pretty::pprust;
 use rustc_data_structures::thin_vec::{ThinVec, thin_vec};
 use rustc_errors::Applicability;
@@ -151,8 +151,8 @@ fn insert_necessary_parens(pat: &mut Box<Pat>) {
             walk_pat(self, pat);
             let target = match &mut pat.kind {
                 // `i @ a | b`, `box a | b`, and `& mut? a | b`.
-                Ident(.., Some(p)) | Box(p) | Ref(p, _) if matches!(&p.kind, Or(ps) if ps.len() > 1) => p,
-                Ref(p, Mutability::Not) if matches!(p.kind, Ident(BindingMode::MUT, ..)) => p, // `&(mut x)`
+                Ident(.., Some(p)) | Box(p) | Ref(p, _, _) if matches!(&p.kind, Or(ps) if ps.len() > 1) => p,
+                Ref(p, Pinnedness::Not, Mutability::Not) if matches!(p.kind, Ident(BindingMode::MUT, ..)) => p, // `&(mut x)`
                 _ => return,
             };
             target.kind = Paren(Box::new(take_pat(target)));
@@ -241,7 +241,8 @@ fn transform_with_focus_on_idx(alternatives: &mut ThinVec<Pat>, focus_idx: usize
         // Skip immutable refs, as grouping them saves few characters,
         // and almost always requires adding parens (increasing noisiness).
         // In the case of only two patterns, replacement adds net characters.
-        | Ref(_, Mutability::Not)
+        // FIXME(pin_ergonomics): handle pinned patterns
+        | Ref(_, _, Mutability::Not)
         // Dealt with elsewhere.
         | Or(_) | Paren(_) | Deref(_) | Guard(..) => false,
         // Transform `box x | ... | box y` into `box (x | y)`.
@@ -254,10 +255,10 @@ fn transform_with_focus_on_idx(alternatives: &mut ThinVec<Pat>, focus_idx: usize
             |k| always_pat!(k, Box(p) => *p),
         ),
         // Transform `&mut x | ... | &mut y` into `&mut (x | y)`.
-        Ref(target, Mutability::Mut) => extend_with_matching(
+        Ref(target, _, Mutability::Mut) => extend_with_matching(
             target, start, alternatives,
-            |k| matches!(k, Ref(_, Mutability::Mut)),
-            |k| always_pat!(k, Ref(p, _) => *p),
+            |k| matches!(k, Ref(_, _, Mutability::Mut)),
+            |k| always_pat!(k, Ref(p, _, _) => *p),
         ),
         // Transform `b @ p0 | ... b @ p1` into `b @ (p0 | p1)`.
         Ident(b1, i1, Some(target)) => extend_with_matching(

--- a/src/tools/clippy/clippy_lints/src/utils/author.rs
+++ b/src/tools/clippy/clippy_lints/src/utils/author.rs
@@ -793,9 +793,9 @@ impl<'a, 'tcx> PrintVisitor<'a, 'tcx> {
                 kind!("Deref({pat})");
                 self.pat(pat);
             },
-            PatKind::Ref(pat, muta) => {
+            PatKind::Ref(pat, pinn, muta) => {
                 bind!(self, pat);
-                kind!("Ref({pat}, Mutability::{muta:?})");
+                kind!("Ref({pat}, Pinning::{pinn:?}, Mutability::{muta:?})");
                 self.pat(pat);
             },
             PatKind::Guard(pat, cond) => {

--- a/src/tools/clippy/clippy_utils/src/ast_utils/mod.rs
+++ b/src/tools/clippy/clippy_utils/src/ast_utils/mod.rs
@@ -45,9 +45,8 @@ pub fn eq_pat(l: &Pat, r: &Pat) -> bool {
                 && eq_expr_opt(lt.as_deref(), rt.as_deref())
                 && eq_range_end(&le.node, &re.node)
         },
-        (Box(l), Box(r))
-        | (Ref(l, Mutability::Not), Ref(r, Mutability::Not))
-        | (Ref(l, Mutability::Mut), Ref(r, Mutability::Mut)) => eq_pat(l, r),
+        (Box(l), Box(r)) => eq_pat(l, r),
+        (Ref(l, l_pin, l_mut), Ref(r, r_pin, r_mut)) => l_pin == r_pin && l_mut == r_mut && eq_pat(l, r),
         (Tuple(l), Tuple(r)) | (Slice(l), Slice(r)) => over(l, r, eq_pat),
         (Path(lq, lp), Path(rq, rp)) => both(lq.as_deref(), rq.as_deref(), eq_qself) && eq_path(lp, rp),
         (TupleStruct(lqself, lp, lfs), TupleStruct(rqself, rp, rfs)) => {

--- a/src/tools/clippy/clippy_utils/src/lib.rs
+++ b/src/tools/clippy/clippy_utils/src/lib.rs
@@ -1462,7 +1462,7 @@ pub fn is_refutable(cx: &LateContext<'_>, pat: &Pat<'_>) -> bool {
         PatKind::Missing => unreachable!(),
         PatKind::Wild | PatKind::Never => false, // If `!` typechecked then the type is empty, so not refutable.
         PatKind::Binding(_, _, _, pat) => pat.is_some_and(|pat| is_refutable(cx, pat)),
-        PatKind::Box(pat) | PatKind::Ref(pat, _) => is_refutable(cx, pat),
+        PatKind::Box(pat) | PatKind::Ref(pat, _, _) => is_refutable(cx, pat),
         PatKind::Expr(PatExpr {
             kind: PatExprKind::Path(qpath),
             hir_id,
@@ -1612,7 +1612,7 @@ pub fn is_lint_allowed(cx: &LateContext<'_>, lint: &'static Lint, id: HirId) -> 
 }
 
 pub fn strip_pat_refs<'hir>(mut pat: &'hir Pat<'hir>) -> &'hir Pat<'hir> {
-    while let PatKind::Ref(subpat, _) = pat.kind {
+    while let PatKind::Ref(subpat, _, _) = pat.kind {
         pat = subpat;
     }
     pat
@@ -2157,7 +2157,7 @@ where
 /// references removed.
 pub fn peel_hir_pat_refs<'a>(pat: &'a Pat<'a>) -> (&'a Pat<'a>, usize) {
     fn peel<'a>(pat: &'a Pat<'a>, count: usize) -> (&'a Pat<'a>, usize) {
-        if let PatKind::Ref(pat, _) = pat.kind {
+        if let PatKind::Ref(pat, _, _) = pat.kind {
             peel(pat, count + 1)
         } else {
             (pat, count)

--- a/src/tools/rustfmt/src/utils.rs
+++ b/src/tools/rustfmt/src/utils.rs
@@ -133,6 +133,19 @@ pub(crate) fn format_mutability(mutability: ast::Mutability) -> &'static str {
 }
 
 #[inline]
+pub(crate) fn format_pinnedness_and_mutability(
+    pinnedness: ast::Pinnedness,
+    mutability: ast::Mutability,
+) -> (&'static str, &'static str) {
+    match (pinnedness, mutability) {
+        (ast::Pinnedness::Pinned, ast::Mutability::Mut) => ("pin ", "mut "),
+        (ast::Pinnedness::Pinned, ast::Mutability::Not) => ("pin ", "const "),
+        (ast::Pinnedness::Not, ast::Mutability::Mut) => ("", "mut "),
+        (ast::Pinnedness::Not, ast::Mutability::Not) => ("", ""),
+    }
+}
+
+#[inline]
 pub(crate) fn format_extern(ext: ast::Extern, explicit_abi: bool) -> Cow<'static, str> {
     match ext {
         ast::Extern::None => Cow::from(""),

--- a/src/tools/rustfmt/tests/source/pin_sugar.rs
+++ b/src/tools/rustfmt/tests/source/pin_sugar.rs
@@ -28,3 +28,22 @@ fn borrows() {
     pin                const 
     foo;
 }
+
+fn patterns<'a>(
+    &pin         mut     x: &pin 
+    mut 
+    i32,
+    &
+    pin         
+         const
+         y: &
+    'a pin 
+    const 
+    i32,
+    ref      pin      mut      z: i32,
+    mut 
+    ref      
+       pin     
+    const
+          w: i32,
+) {}

--- a/src/tools/rustfmt/tests/target/pin_sugar.rs
+++ b/src/tools/rustfmt/tests/target/pin_sugar.rs
@@ -23,3 +23,11 @@ fn borrows() {
 
     let x: Pin<&_> = &pin const foo;
 }
+
+fn patterns<'a>(
+    &pin mut x: &pin mut i32,
+    &pin const y: &'a pin const i32,
+    ref pin mut z: i32,
+    mut ref pin const w: i32,
+) {
+}

--- a/tests/pretty/pin-ergonomics-hir.pp
+++ b/tests/pretty/pin-ergonomics-hir.pp
@@ -41,4 +41,7 @@ fn bar() {
     foo_const(x);
 }
 
+fn patterns<'a>(&pin mut x: Pin<&'_ mut i32>, &pin const y: Pin<&'a i32>,
+    ref pin mut z: i32, ref pin const w: i32) { }
+
 fn main() { }

--- a/tests/pretty/pin-ergonomics-hir.rs
+++ b/tests/pretty/pin-ergonomics-hir.rs
@@ -37,4 +37,11 @@ fn bar() {
     foo_const(x);
 }
 
+fn patterns<'a>(
+    &pin mut x: Pin<&mut i32>,
+    &pin const y: Pin<&'a i32>,
+    ref pin mut z: i32,
+    ref pin const w: i32,
+) {}
+
 fn main() { }

--- a/tests/pretty/pin-ergonomics.rs
+++ b/tests/pretty/pin-ergonomics.rs
@@ -34,4 +34,7 @@ fn bar() {
     foo_const(x);
 }
 
+fn patterns<'a>(&pin mut x: &pin mut i32, &pin const y: &'a pin const i32,
+    ref pin mut z: i32, ref pin const w: i32) {}
+
 fn main() {}

--- a/tests/ui/feature-gates/feature-gate-pin_ergonomics.rs
+++ b/tests/ui/feature-gates/feature-gate-pin_ergonomics.rs
@@ -47,6 +47,17 @@ fn borrows() {
     foo_const(x);
 }
 
+fn patterns<'a>(
+    &pin mut x: &pin mut i32,
+    //~^ ERROR pinned reference syntax is experimental
+    //~| ERROR pinned reference syntax is experimental
+    &pin const y: &'a pin const i32,
+    //~^ ERROR pinned reference syntax is experimental
+    //~| ERROR pinned reference syntax is experimental
+    ref pin mut z: i32, //~ ERROR pinned reference syntax is experimental
+    ref pin const w: i32, //~ ERROR pinned reference syntax is experimental
+) {}
+
 #[cfg(any())]
 mod not_compiled {
     use std::pin::Pin;
@@ -91,6 +102,17 @@ mod not_compiled {
         foo_const(x);
         foo_const(x);
     }
+
+    fn patterns<'a>(
+        &pin mut x: &pin mut i32,
+        //~^ ERROR pinned reference syntax is experimental
+        //~| ERROR pinned reference syntax is experimental
+        &pin const y: &'a pin const i32,
+        //~^ ERROR pinned reference syntax is experimental
+        //~| ERROR pinned reference syntax is experimental
+        ref pin mut z: i32, //~ ERROR pinned reference syntax is experimental
+        ref pin const w: i32, //~ ERROR pinned reference syntax is experimental
+    ) {}
 }
 
 fn main() {}

--- a/tests/ui/feature-gates/feature-gate-pin_ergonomics.stderr
+++ b/tests/ui/feature-gates/feature-gate-pin_ergonomics.stderr
@@ -79,7 +79,67 @@ LL |     let x: Pin<&_> = &pin const Foo;
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:59:23
+  --> $DIR/feature-gate-pin_ergonomics.rs:51:6
+   |
+LL |     &pin mut x: &pin mut i32,
+   |      ^^^
+   |
+   = note: see issue #130494 <https://github.com/rust-lang/rust/issues/130494> for more information
+   = help: add `#![feature(pin_ergonomics)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: pinned reference syntax is experimental
+  --> $DIR/feature-gate-pin_ergonomics.rs:51:18
+   |
+LL |     &pin mut x: &pin mut i32,
+   |                  ^^^
+   |
+   = note: see issue #130494 <https://github.com/rust-lang/rust/issues/130494> for more information
+   = help: add `#![feature(pin_ergonomics)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: pinned reference syntax is experimental
+  --> $DIR/feature-gate-pin_ergonomics.rs:54:6
+   |
+LL |     &pin const y: &'a pin const i32,
+   |      ^^^
+   |
+   = note: see issue #130494 <https://github.com/rust-lang/rust/issues/130494> for more information
+   = help: add `#![feature(pin_ergonomics)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: pinned reference syntax is experimental
+  --> $DIR/feature-gate-pin_ergonomics.rs:54:23
+   |
+LL |     &pin const y: &'a pin const i32,
+   |                       ^^^
+   |
+   = note: see issue #130494 <https://github.com/rust-lang/rust/issues/130494> for more information
+   = help: add `#![feature(pin_ergonomics)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: pinned reference syntax is experimental
+  --> $DIR/feature-gate-pin_ergonomics.rs:57:9
+   |
+LL |     ref pin mut z: i32,
+   |         ^^^
+   |
+   = note: see issue #130494 <https://github.com/rust-lang/rust/issues/130494> for more information
+   = help: add `#![feature(pin_ergonomics)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: pinned reference syntax is experimental
+  --> $DIR/feature-gate-pin_ergonomics.rs:58:9
+   |
+LL |     ref pin const w: i32,
+   |         ^^^
+   |
+   = note: see issue #130494 <https://github.com/rust-lang/rust/issues/130494> for more information
+   = help: add `#![feature(pin_ergonomics)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: pinned reference syntax is experimental
+  --> $DIR/feature-gate-pin_ergonomics.rs:70:23
    |
 LL |         fn foo_sugar(&pin mut self) {}
    |                       ^^^
@@ -89,7 +149,7 @@ LL |         fn foo_sugar(&pin mut self) {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:60:29
+  --> $DIR/feature-gate-pin_ergonomics.rs:71:29
    |
 LL |         fn foo_sugar_const(&pin const self) {}
    |                             ^^^
@@ -99,7 +159,7 @@ LL |         fn foo_sugar_const(&pin const self) {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:66:18
+  --> $DIR/feature-gate-pin_ergonomics.rs:77:18
    |
 LL |         let _y: &pin mut Foo = x;
    |                  ^^^
@@ -109,7 +169,7 @@ LL |         let _y: &pin mut Foo = x;
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:69:22
+  --> $DIR/feature-gate-pin_ergonomics.rs:80:22
    |
 LL |     fn foo_sugar(_: &pin mut Foo) {}
    |                      ^^^
@@ -119,7 +179,7 @@ LL |     fn foo_sugar(_: &pin mut Foo) {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:81:22
+  --> $DIR/feature-gate-pin_ergonomics.rs:92:22
    |
 LL |     fn baz_sugar(_: &pin const Foo) {}
    |                      ^^^
@@ -129,7 +189,7 @@ LL |     fn baz_sugar(_: &pin const Foo) {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:84:35
+  --> $DIR/feature-gate-pin_ergonomics.rs:95:35
    |
 LL |         let mut x: Pin<&mut _> = &pin mut Foo;
    |                                   ^^^
@@ -139,10 +199,70 @@ LL |         let mut x: Pin<&mut _> = &pin mut Foo;
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:89:27
+  --> $DIR/feature-gate-pin_ergonomics.rs:100:27
    |
 LL |         let x: Pin<&_> = &pin const Foo;
    |                           ^^^
+   |
+   = note: see issue #130494 <https://github.com/rust-lang/rust/issues/130494> for more information
+   = help: add `#![feature(pin_ergonomics)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: pinned reference syntax is experimental
+  --> $DIR/feature-gate-pin_ergonomics.rs:107:10
+   |
+LL |         &pin mut x: &pin mut i32,
+   |          ^^^
+   |
+   = note: see issue #130494 <https://github.com/rust-lang/rust/issues/130494> for more information
+   = help: add `#![feature(pin_ergonomics)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: pinned reference syntax is experimental
+  --> $DIR/feature-gate-pin_ergonomics.rs:107:22
+   |
+LL |         &pin mut x: &pin mut i32,
+   |                      ^^^
+   |
+   = note: see issue #130494 <https://github.com/rust-lang/rust/issues/130494> for more information
+   = help: add `#![feature(pin_ergonomics)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: pinned reference syntax is experimental
+  --> $DIR/feature-gate-pin_ergonomics.rs:110:10
+   |
+LL |         &pin const y: &'a pin const i32,
+   |          ^^^
+   |
+   = note: see issue #130494 <https://github.com/rust-lang/rust/issues/130494> for more information
+   = help: add `#![feature(pin_ergonomics)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: pinned reference syntax is experimental
+  --> $DIR/feature-gate-pin_ergonomics.rs:110:27
+   |
+LL |         &pin const y: &'a pin const i32,
+   |                           ^^^
+   |
+   = note: see issue #130494 <https://github.com/rust-lang/rust/issues/130494> for more information
+   = help: add `#![feature(pin_ergonomics)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: pinned reference syntax is experimental
+  --> $DIR/feature-gate-pin_ergonomics.rs:113:13
+   |
+LL |         ref pin mut z: i32,
+   |             ^^^
+   |
+   = note: see issue #130494 <https://github.com/rust-lang/rust/issues/130494> for more information
+   = help: add `#![feature(pin_ergonomics)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: pinned reference syntax is experimental
+  --> $DIR/feature-gate-pin_ergonomics.rs:114:13
+   |
+LL |         ref pin const w: i32,
+   |             ^^^
    |
    = note: see issue #130494 <https://github.com/rust-lang/rust/issues/130494> for more information
    = help: add `#![feature(pin_ergonomics)]` to the crate attributes to enable
@@ -196,7 +316,7 @@ help: consider reborrowing the `Pin` instead of moving it
 LL |     x.as_mut().foo();
    |      +++++++++
 
-error: aborting due to 18 previous errors
+error: aborting due to 30 previous errors
 
 Some errors have detailed explanations: E0382, E0658.
 For more information about an error, try `rustc --explain E0382`.

--- a/tests/ui/pin-ergonomics/pin-pattern.rs
+++ b/tests/ui/pin-ergonomics/pin-pattern.rs
@@ -1,0 +1,114 @@
+//@ edition:2024
+#![feature(pin_ergonomics)]
+#![allow(incomplete_features)]
+
+// This test verifies:
+// - a `&pin mut $pat` can be used to match on a pinned reference type `&pin mut T`;
+// - the subpattern can only convert the binding mode `&pin mut` to `&mut` when `T: Unpin`;
+// - the subpattern can only remove the binding mode `&pin mut` when `T: Copy`;
+
+#[pin_v2]
+struct Foo<T>(T);
+
+trait IsPinMut {}
+trait IsPinConst {}
+trait IsMut {}
+trait IsRef {}
+impl<T: ?Sized> IsPinMut for &pin mut T {}
+impl<T: ?Sized> IsPinConst for &pin const T {}
+impl<T: ?Sized> IsMut for &mut T {}
+impl<T: ?Sized> IsRef for &T {}
+
+fn assert_pin_mut<T: IsPinMut>(_: T) {}
+fn assert_pin_const<T: IsPinConst>(_: T) {}
+fn assert_mut<T: IsMut>(_: T) {}
+fn assert_ref<T: IsRef>(_: T) {}
+fn assert_ty<T>(_: T) {}
+
+fn normal<T>(foo_mut: &pin mut Foo<T>, foo_const: &pin const Foo<T>) {
+    let &pin mut Foo(ref pin mut x) = foo_mut; // ok
+    assert_pin_mut(x);
+
+    let &pin const Foo(ref pin const x) = foo_const; // ok
+    assert_pin_const(x);
+}
+
+fn by_value_copy<T: Copy>(foo_mut: &pin mut Foo<T>, foo_const: &pin const Foo<T>) {
+    let &pin mut Foo(x) = foo_mut;
+    assert_ty::<T>(x);
+
+    let &pin const Foo(x) = foo_const;
+    assert_ty::<T>(x);
+}
+
+fn by_value_non_copy<T>(foo_mut: &pin mut Foo<T>, foo_const: &pin const Foo<T>) {
+    let &pin mut Foo(x) = foo_mut;
+    //~^ ERROR cannot move out of `foo_mut.pointer` which is behind a mutable reference
+    assert_ty::<T>(x);
+
+    let &pin const Foo(x) = foo_const;
+    //~^ ERROR cannot move out of `foo_const.pointer` which is behind a shared reference
+    assert_ty::<T>(x);
+}
+
+fn by_ref_non_pinned_unpin<T: Unpin>(foo_mut: &pin mut Foo<T>, foo_const: &pin const Foo<T>) {
+    let &pin mut Foo(ref mut x) = foo_mut;
+    assert_mut(x);
+
+    let &pin const Foo(ref x) = foo_const;
+    assert_ref(x);
+}
+
+fn by_ref_non_pinned_non_unpin<T>(foo_mut: &pin mut Foo<T>, foo_const: &pin const Foo<T>) {
+    let &pin mut Foo(ref mut x) = foo_mut;
+    //~^ ERROR `T` cannot be unpinned
+    assert_mut(x);
+
+    let &pin const Foo(ref x) = foo_const;
+    //~^ ERROR `T` cannot be unpinned
+    assert_ref(x);
+}
+
+// Makes sure that `ref pin` binding mode cannot be changed to a `ref` binding mode.
+//
+// This mimics the following code:
+// ```
+// fn f<'a, T>(
+//     ((&x,),): &'a (&'a mut (&'a T,),),
+// ) -> T {
+//     x
+// }
+// ```
+fn tuple_tuple_ref_pin_mut_pat_and_pin_mut_of_tuple_mut_of_tuple_pin_mut_ty<'a, T>(
+    ((&pin mut x,),): &'a pin mut (&'a mut (&'a pin mut Foo<T>,),),
+    //~^ ERROR cannot explicitly dereference within an implicitly-borrowing pattern
+    //~| ERROR cannot move out of a mutable reference
+) -> Foo<T> {
+    x
+}
+
+fn tuple_ref_pin_mut_pat_and_mut_of_tuple_pin_mut_ty<'a, T>(
+    (&pin mut x,): &'a mut (&'a pin mut Foo<T>,), //~ ERROR `T` cannot be unpinned
+) -> &'a mut Foo<T> {
+    x
+}
+
+fn tuple_ref_pin_mut_pat_and_mut_of_mut_tuple_pin_mut_ty<'a, T>(
+    (&pin mut x,): &'a mut &'a pin mut (Foo<T>,), //~ ERROR mismatched type
+) -> &'a mut Foo<T> {
+    x
+}
+
+fn ref_pin_mut_tuple_pat_and_mut_of_tuple_pin_mut_ty<'a, T>(
+    &pin mut (x,): &'a mut (&'a pin mut Foo<T>,), //~ ERROR mismatched type
+) -> &'a mut Foo<T> {
+    x
+}
+
+fn ref_pin_mut_tuple_pat_and_mut_of_mut_tuple_pin_mut_ty<'a, T>(
+    &pin mut (x,): &'a mut &'a pin mut (Foo<T>,), //~ ERROR mismatched type
+) -> &'a mut Foo<T> {
+    x
+}
+
+fn main() {}

--- a/tests/ui/pin-ergonomics/pin-pattern.stderr
+++ b/tests/ui/pin-ergonomics/pin-pattern.stderr
@@ -1,0 +1,152 @@
+error[E0277]: `T` cannot be unpinned
+  --> $DIR/pin-pattern.rs:63:22
+   |
+LL |     let &pin mut Foo(ref mut x) = foo_mut;
+   |                      ^^^^^^^^^ the trait `Unpin` is not implemented for `T`
+   |
+   = note: consider using the `pin!` macro
+           consider using `Box::pin` if you need to access the pinned value outside of the current scope
+help: consider restricting type parameter `T` with trait `Unpin`
+   |
+LL | fn by_ref_non_pinned_non_unpin<T: std::marker::Unpin>(foo_mut: &pin mut Foo<T>, foo_const: &pin const Foo<T>) {
+   |                                 ++++++++++++++++++++
+
+error[E0277]: `T` cannot be unpinned
+  --> $DIR/pin-pattern.rs:67:24
+   |
+LL |     let &pin const Foo(ref x) = foo_const;
+   |                        ^^^^^ the trait `Unpin` is not implemented for `T`
+   |
+   = note: consider using the `pin!` macro
+           consider using `Box::pin` if you need to access the pinned value outside of the current scope
+help: consider restricting type parameter `T` with trait `Unpin`
+   |
+LL | fn by_ref_non_pinned_non_unpin<T: std::marker::Unpin>(foo_mut: &pin mut Foo<T>, foo_const: &pin const Foo<T>) {
+   |                                 ++++++++++++++++++++
+
+error[E0277]: `T` cannot be unpinned
+  --> $DIR/pin-pattern.rs:91:15
+   |
+LL |     (&pin mut x,): &'a mut (&'a pin mut Foo<T>,),
+   |               ^ within `Foo<T>`, the trait `Unpin` is not implemented for `T`
+   |
+   = note: consider using the `pin!` macro
+           consider using `Box::pin` if you need to access the pinned value outside of the current scope
+note: required because it appears within the type `Foo<T>`
+  --> $DIR/pin-pattern.rs:11:8
+   |
+LL | struct Foo<T>(T);
+   |        ^^^
+help: consider restricting type parameter `T` with trait `Unpin`
+   |
+LL | fn tuple_ref_pin_mut_pat_and_mut_of_tuple_pin_mut_ty<'a, T: std::marker::Unpin>(
+   |                                                           ++++++++++++++++++++
+
+error[E0308]: mismatched types
+  --> $DIR/pin-pattern.rs:97:6
+   |
+LL |     (&pin mut x,): &'a mut &'a pin mut (Foo<T>,),
+   |      ^^^^^^^^^^    ----------------------------- expected due to this
+   |      |
+   |      expected `Foo<T>`, found `Pin<&mut _>`
+   |
+   = note: expected struct `Foo<T>`
+              found struct `Pin<&mut _>`
+note: to declare a mutable binding use: `mut x`
+  --> $DIR/pin-pattern.rs:97:6
+   |
+LL |     (&pin mut x,): &'a mut &'a pin mut (Foo<T>,),
+   |      ^^^^^^^^^^
+help: consider removing `&pin mut` from the pattern
+   |
+LL -     (&pin mut x,): &'a mut &'a pin mut (Foo<T>,),
+LL +     (x,): &'a mut &'a pin mut (Foo<T>,),
+   |
+
+error[E0308]: mismatched types
+  --> $DIR/pin-pattern.rs:103:5
+   |
+LL |     &pin mut (x,): &'a mut (&'a pin mut Foo<T>,),
+   |     ^^^^^^^^^^^^^  ----------------------------- expected due to this
+   |     |
+   |     expected `&mut (Pin<&mut Foo<T>>,)`, found `Pin<&mut _>`
+   |
+   = note: expected mutable reference `&'a mut (Pin<&'a mut Foo<T>>,)`
+                         found struct `Pin<&mut _>`
+
+error[E0308]: mismatched types
+  --> $DIR/pin-pattern.rs:109:5
+   |
+LL |     &pin mut (x,): &'a mut &'a pin mut (Foo<T>,),
+   |     ^^^^^^^^^^^^^  ----------------------------- expected due to this
+   |     |
+   |     expected `&mut Pin<&mut (Foo<T>,)>`, found `Pin<&mut _>`
+   |
+   = note: expected mutable reference `&'a mut Pin<&'a mut (Foo<T>,)>`
+                         found struct `Pin<&mut _>`
+
+error[E0507]: cannot move out of `foo_mut.pointer` which is behind a mutable reference
+  --> $DIR/pin-pattern.rs:45:27
+   |
+LL |     let &pin mut Foo(x) = foo_mut;
+   |                      -    ^^^^^^^
+   |                      |
+   |                      data moved here
+   |                      move occurs because `x` has type `T`, which does not implement the `Copy` trait
+   |
+help: consider removing the pinned mutable borrow
+   |
+LL -     let &pin mut Foo(x) = foo_mut;
+LL +     let Foo(x) = foo_mut;
+   |
+
+error[E0507]: cannot move out of `foo_const.pointer` which is behind a shared reference
+  --> $DIR/pin-pattern.rs:49:29
+   |
+LL |     let &pin const Foo(x) = foo_const;
+   |                        -    ^^^^^^^^^
+   |                        |
+   |                        data moved here
+   |                        move occurs because `x` has type `T`, which does not implement the `Copy` trait
+   |
+help: consider removing the pinned borrow
+   |
+LL -     let &pin const Foo(x) = foo_const;
+LL +     let Foo(x) = foo_const;
+   |
+
+error: cannot explicitly dereference within an implicitly-borrowing pattern
+  --> $DIR/pin-pattern.rs:83:7
+   |
+LL |     ((&pin mut x,),): &'a pin mut (&'a mut (&'a pin mut Foo<T>,),),
+   |       ^^^^^^^^ reference pattern not allowed when implicitly borrowing
+   |
+   = note: for more information, see <https://doc.rust-lang.org/reference/patterns.html#binding-modes>
+note: matching on a reference type with a non-reference pattern implicitly borrows the contents
+  --> $DIR/pin-pattern.rs:83:6
+   |
+LL |     ((&pin mut x,),): &'a pin mut (&'a mut (&'a pin mut Foo<T>,),),
+   |      ^^^^^^^^^^^^^ this non-reference pattern matches on a reference type `&mut _`
+help: match on the reference with a reference pattern to avoid implicitly borrowing
+   |
+LL |     (&mut (&pin mut x,),): &'a pin mut (&'a mut (&'a pin mut Foo<T>,),),
+   |      ++++
+
+error[E0507]: cannot move out of a mutable reference
+  --> $DIR/pin-pattern.rs:83:5
+   |
+LL |     ((&pin mut x,),): &'a pin mut (&'a mut (&'a pin mut Foo<T>,),),
+   |     ^^^^^^^^^^^-^^^^
+   |                |
+   |                data moved here
+   |                move occurs because `x` has type `Foo<T>`, which does not implement the `Copy` trait
+   |
+help: consider borrowing the pattern binding
+   |
+LL |     ((&pin mut ref x,),): &'a pin mut (&'a mut (&'a pin mut Foo<T>,),),
+   |                +++
+
+error: aborting due to 10 previous errors
+
+Some errors have detailed explanations: E0277, E0308, E0507.
+For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/pin-ergonomics/sugar-ambiguity.rs
+++ b/tests/ui/pin-ergonomics/sugar-ambiguity.rs
@@ -8,8 +8,16 @@ struct Foo;
 
 mod pin {
     pub struct Foo;
+    #[expect(non_camel_case_types)]
+    pub struct pin;
+
+    fn foo() {
+        let _x: &pin = &pin;
+    }
 }
 
 fn main() {
-    let _x: &pin ::Foo = &pin::Foo;
+    let _x: &pin::Foo = &pin::Foo;
+    let &pin: &i32 = &0;
+    let ref pin: i32 = 0;
 }

--- a/tests/ui/pin-ergonomics/sugar-no-const.rs
+++ b/tests/ui/pin-ergonomics/sugar-no-const.rs
@@ -3,6 +3,22 @@
 
 // Makes sure we don't accidentally accept `&pin Foo` without the `const` keyword.
 
-fn main() {
+fn ty() {
     let _x: &pin i32 = todo!(); //~ ERROR found `i32`
+}
+
+fn expr() {
+    let x = 0_i32;
+    let _x = &pin x; //~ ERROR found `x`
+}
+
+fn pat() {
+    let &pin _x: &pin i32 = todo!(); //~ ERROR found `_x`
+}
+
+fn binding() {
+    let ref pin _x: i32 = todo!(); //~ ERROR found `_x`
+}
+
+fn main() {
 }

--- a/tests/ui/pin-ergonomics/sugar-no-const.stderr
+++ b/tests/ui/pin-ergonomics/sugar-no-const.stderr
@@ -12,5 +12,41 @@ LL -     let _x: &pin i32 = todo!();
 LL +     let _x: &in i32 = todo!();
    |
 
-error: aborting due to 1 previous error
+error: expected one of `!`, `.`, `::`, `;`, `?`, `else`, `{`, or an operator, found `x`
+  --> $DIR/sugar-no-const.rs:12:19
+   |
+LL |     let _x = &pin x;
+   |                   ^ expected one of 8 possible tokens
+   |
+help: there is a keyword `in` with a similar name
+   |
+LL -     let _x = &pin x;
+LL +     let _x = &in x;
+   |
+
+error: expected one of `:`, `;`, `=`, `@`, or `|`, found `_x`
+  --> $DIR/sugar-no-const.rs:16:14
+   |
+LL |     let &pin _x: &pin i32 = todo!();
+   |              ^^ expected one of `:`, `;`, `=`, `@`, or `|`
+   |
+help: there is a keyword `in` with a similar name
+   |
+LL -     let &pin _x: &pin i32 = todo!();
+LL +     let &in _x: &pin i32 = todo!();
+   |
+
+error: expected one of `:`, `;`, `=`, `@`, or `|`, found `_x`
+  --> $DIR/sugar-no-const.rs:20:17
+   |
+LL |     let ref pin _x: i32 = todo!();
+   |                 ^^ expected one of `:`, `;`, `=`, `@`, or `|`
+   |
+help: there is a keyword `in` with a similar name
+   |
+LL -     let ref pin _x: i32 = todo!();
+LL +     let ref in _x: i32 = todo!();
+   |
+
+error: aborting due to 4 previous errors
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/148397)*
<!-- homu-ignore:end -->

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Implement `&pin` patterns and `ref pin` binding modes, part of [pin ergonomics](https://github.com/rust-lang/rust/issues/130494).

r? @Nadrieril 

cc @traviscross @eholk 