### PR TITLE
Better warning message for crate type unsupported by codegen backend

### DIFF
--- a/compiler/rustc_driver_impl/src/lib.rs
+++ b/compiler/rustc_driver_impl/src/lib.rs
@@ -686,8 +686,12 @@ fn print_crate_info(
                 };
                 let t_outputs = rustc_interface::util::build_output_filenames(attrs, sess);
                 let crate_name = passes::get_crate_name(sess, attrs);
-                let crate_types =
-                    collect_crate_types(sess, &codegen_backend.supported_crate_types(sess), attrs);
+                let crate_types = collect_crate_types(
+                    sess,
+                    &codegen_backend.supported_crate_types(sess),
+                    codegen_backend.name(),
+                    attrs,
+                );
                 for &style in &crate_types {
                     let fname = rustc_session::output::filename_for_input(
                         sess, style, crate_name, &t_outputs,

--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -929,6 +929,7 @@ pub fn create_and_enter_global_ctxt<T, F: for<'tcx> FnOnce(TyCtxt<'tcx>) -> T>(
     let crate_types = collect_crate_types(
         sess,
         &compiler.codegen_backend.supported_crate_types(sess),
+        compiler.codegen_backend.name(),
         &pre_configured_attrs,
     );
     let stable_crate_id = StableCrateId::new(

--- a/compiler/rustc_session/messages.ftl
+++ b/compiler/rustc_session/messages.ftl
@@ -140,6 +140,9 @@ session_unleashed_feature_help_unnamed = skipping check that does not even have 
 
 session_unstable_virtual_function_elimination = `-Zvirtual-function-elimination` requires `-Clto`
 
+session_unsupported_crate_type_for_codegen_backend =
+    dropping unsupported crate type `{$crate_type}` for codegen backend `{$codegen_backend}`
+
 session_unsupported_crate_type_for_target =
     dropping unsupported crate type `{$crate_type}` for target `{$target_triple}`
 

--- a/compiler/rustc_session/src/errors.rs
+++ b/compiler/rustc_session/src/errors.rs
@@ -372,6 +372,13 @@ struct BinaryFloatLiteralNotSupported {
 }
 
 #[derive(Diagnostic)]
+#[diag(session_unsupported_crate_type_for_codegen_backend)]
+pub(crate) struct UnsupportedCrateTypeForCodegenBackend {
+    pub(crate) crate_type: CrateType,
+    pub(crate) codegen_backend: &'static str,
+}
+
+#[derive(Diagnostic)]
 #[diag(session_unsupported_crate_type_for_target)]
 pub(crate) struct UnsupportedCrateTypeForTarget<'a> {
     pub(crate) crate_type: CrateType,


### PR DESCRIPTION
Turns out cargo doesn't hard code the "for target" part of the message after all.