### PR TITLE
Avoid copy when convert owned String to Arc<str>

### DIFF
--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -3878,7 +3878,7 @@ impl From<&mut str> for Arc<str> {
 #[cfg(not(no_global_oom_handling))]
 #[stable(feature = "shared_from_slice", since = "1.21.0")]
 impl From<String> for Arc<str> {
-    /// Allocates a reference-counted `str` and copies `v` into it.
+    /// Converts the given [`String`] to a shared reference-counted `str` slice.
     ///
     /// # Example
     ///
@@ -3890,7 +3890,7 @@ impl From<String> for Arc<str> {
     /// ```
     #[inline]
     fn from(v: String) -> Arc<str> {
-        Arc::from(&v[..])
+        Arc::from(v.into_boxed_str())
     }
 }
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

This is almost `Arc::<str>::from(Box::<str>::from(owned_string))` that could avoid an extra copy.