### PR TITLE
`vec_recycle`: implementation

### DIFF
--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -146,6 +146,7 @@
 #![feature(std_internals)]
 #![feature(str_internals)]
 #![feature(temporary_niche_types)]
+#![feature(transmutability)]
 #![feature(trivial_clone)]
 #![feature(trusted_fused)]
 #![feature(trusted_len)]


### PR DESCRIPTION
Tracking issue: rust-lang/rust#148227

Going with the `TransmuteFrom` approach suggested in https://github.com/rust-lang/libs-team/issues/674#issuecomment-3457795183, but a bit simplified.

Currently does not work in some places where it should due to the limitations of the current implementation of the transmutability analysis: https://github.com/rust-lang/rust/issues/148227#issuecomment-3478099591