### PR TITLE
Make Wasm target features `atomics` and `exception-handling` target modifiers

### DIFF
--- a/compiler/rustc_codegen_llvm/src/llvm_util.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm_util.rs
@@ -515,7 +515,7 @@ fn print_target_features(sess: &Session, tm: &llvm::TargetMachine, out: &mut Str
         .target
         .rust_target_features()
         .iter()
-        .filter_map(|(feature, gate, _implied)| {
+        .filter_map(|(feature, gate, _implied, _)| {
             if !gate.in_cfg() {
                 // Only list (experimentally) supported features.
                 return None;

--- a/compiler/rustc_codegen_ssa/src/target_features.rs
+++ b/compiler/rustc_codegen_ssa/src/target_features.rs
@@ -173,7 +173,7 @@ fn parse_rust_feature_flag<'a>(
 
             let inverse_implied_features = inverse_implied_features.get_or_insert_with(|| {
                 let mut set: FxHashMap<&str, FxHashSet<&str>> = FxHashMap::default();
-                for (f, _, is) in sess.target.rust_target_features() {
+                for (f, _, is, _) in sess.target.rust_target_features() {
                     for i in is.iter() {
                         set.entry(i).or_default().insert(f);
                     }
@@ -222,8 +222,8 @@ pub fn cfg_target_feature(
         .target
         .rust_target_features()
         .iter()
-        .filter(|(feature, _, _)| target_base_has_feature(feature))
-        .flat_map(|(base_feature, _, _)| {
+        .filter(|(feature, _, _, _)| target_base_has_feature(feature))
+        .flat_map(|(base_feature, _, _, _)| {
             // Expand the direct base feature into all transitively-implied features. Note that we
             // cannot simply use the `implied` field of the tuple since that only contains
             // directly-implied features.
@@ -260,7 +260,7 @@ pub fn cfg_target_feature(
         sess.target
             .rust_target_features()
             .iter()
-            .filter_map(|(feature, gate, _)| {
+            .filter_map(|(feature, gate, _, _)| {
                 // The `allow_unstable` set is used by rustc internally to determine which target
                 // features are truly available, so we want to return even perma-unstable
                 // "forbidden" features.
@@ -330,13 +330,13 @@ pub fn flag_to_backend_features<'a, const N: usize>(
             );
             // Check feature validity.
             if diagnostics {
-                let feature_state = known_features.iter().find(|&&(v, _, _)| v == base_feature);
+                let feature_state = known_features.iter().find(|&&(v, _, _, _)| v == base_feature);
                 match feature_state {
                     None => {
                         // This is definitely not a valid Rust feature name. Maybe it is a backend
                         // feature name? If so, give a better error message.
                         let rust_feature =
-                            known_features.iter().find_map(|&(rust_feature, _, _)| {
+                            known_features.iter().find_map(|&(rust_feature, _, _, _)| {
                                 let backend_features = to_backend_features(rust_feature);
                                 if backend_features.contains(&base_feature)
                                     && !backend_features.contains(&rust_feature)
@@ -359,7 +359,7 @@ pub fn flag_to_backend_features<'a, const N: usize>(
                         };
                         sess.dcx().emit_warn(unknown_feature);
                     }
-                    Some((_, stability, _)) => {
+                    Some((_, stability, _, _)) => {
                         if let Err(reason) = stability.toggle_allowed() {
                             sess.dcx().emit_warn(errors::ForbiddenCTargetFeature {
                                 feature: base_feature,
@@ -463,7 +463,7 @@ pub(crate) fn provide(providers: &mut Providers) {
                     .target
                     .rust_target_features()
                     .iter()
-                    .map(|(a, b, _)| (a.to_string(), *b))
+                    .map(|(a, b, _, _)| (a.to_string(), *b))
                     .collect()
             }
         },

--- a/compiler/rustc_metadata/src/creader.rs
+++ b/compiler/rustc_metadata/src/creader.rs
@@ -412,7 +412,7 @@ impl CStore {
             match (&left_name_val, &right_name_val) {
                 (Some(l), Some(r)) => match l.1.opt.cmp(&r.1.opt) {
                     cmp::Ordering::Equal => {
-                        if !l.1.consistent(&tcx.sess.opts, Some(&r.1)) {
+                        if !l.1.consistent(&tcx.sess, Some(&r.1)) {
                             report_diff(
                                 &l.0.prefix,
                                 &l.0.name,
@@ -424,26 +424,26 @@ impl CStore {
                         right_name_val = None;
                     }
                     cmp::Ordering::Greater => {
-                        if !r.1.consistent(&tcx.sess.opts, None) {
+                        if !r.1.consistent(&tcx.sess, None) {
                             report_diff(&r.0.prefix, &r.0.name, None, Some(&r.1.value_name));
                         }
                         right_name_val = None;
                     }
                     cmp::Ordering::Less => {
-                        if !l.1.consistent(&tcx.sess.opts, None) {
+                        if !l.1.consistent(&tcx.sess, None) {
                             report_diff(&l.0.prefix, &l.0.name, Some(&l.1.value_name), None);
                         }
                         left_name_val = None;
                     }
                 },
                 (Some(l), None) => {
-                    if !l.1.consistent(&tcx.sess.opts, None) {
+                    if !l.1.consistent(&tcx.sess, None) {
                         report_diff(&l.0.prefix, &l.0.name, Some(&l.1.value_name), None);
                     }
                     left_name_val = None;
                 }
                 (None, Some(r)) => {
-                    if !r.1.consistent(&tcx.sess.opts, None) {
+                    if !r.1.consistent(&tcx.sess, None) {
                         report_diff(&r.0.prefix, &r.0.name, None, Some(&r.1.value_name));
                     }
                     right_name_val = None;

--- a/compiler/rustc_target/src/target_features.rs
+++ b/compiler/rustc_target/src/target_features.rs
@@ -773,9 +773,9 @@ static RISCV_FEATURES: &[(&str, Stability, ImpliedFeatures, TargetModifier)] = &
 
 static WASM_FEATURES: &[(&str, Stability, ImpliedFeatures, TargetModifier)] = &[
     // tidy-alphabetical-start
-    ("atomics", Unstable(sym::wasm_target_feature), &[], false),
+    ("atomics", Unstable(sym::wasm_target_feature), &[], true),
     ("bulk-memory", Stable, &[], false),
-    ("exception-handling", Unstable(sym::wasm_target_feature), &[], false),
+    ("exception-handling", Unstable(sym::wasm_target_feature), &[], true),
     ("extended-const", Stable, &[], false),
     ("multivalue", Stable, &[], false),
     ("mutable-globals", Stable, &[], false),

--- a/compiler/rustc_target/src/target_features.rs
+++ b/compiler/rustc_target/src/target_features.rs
@@ -129,192 +129,201 @@ impl Stability {
 // Both of these are also applied transitively.
 type ImpliedFeatures = &'static [&'static str];
 
-static ARM_FEATURES: &[(&str, Stability, ImpliedFeatures)] = &[
+// If feature is a target modifier.
+type TargetModifier = bool;
+
+static ARM_FEATURES: &[(&str, Stability, ImpliedFeatures, TargetModifier)] = &[
     // tidy-alphabetical-start
-    ("aclass", Unstable(sym::arm_target_feature), &[]),
-    ("aes", Unstable(sym::arm_target_feature), &["neon"]),
+    ("aclass", Unstable(sym::arm_target_feature), &[], false),
+    ("aes", Unstable(sym::arm_target_feature), &["neon"], false),
     (
         "atomics-32",
         Stability::Forbidden { reason: "unsound because it changes the ABI of atomic operations" },
         &[],
+        false,
     ),
-    ("crc", Unstable(sym::arm_target_feature), &[]),
-    ("d32", Unstable(sym::arm_target_feature), &[]),
-    ("dotprod", Unstable(sym::arm_target_feature), &["neon"]),
-    ("dsp", Unstable(sym::arm_target_feature), &[]),
-    ("fp-armv8", Unstable(sym::arm_target_feature), &["vfp4"]),
-    ("fp16", Unstable(sym::arm_target_feature), &["neon"]),
-    ("fpregs", Unstable(sym::arm_target_feature), &[]),
-    ("i8mm", Unstable(sym::arm_target_feature), &["neon"]),
-    ("mclass", Unstable(sym::arm_target_feature), &[]),
-    ("neon", Unstable(sym::arm_target_feature), &["vfp3"]),
-    ("rclass", Unstable(sym::arm_target_feature), &[]),
-    ("sha2", Unstable(sym::arm_target_feature), &["neon"]),
+    ("crc", Unstable(sym::arm_target_feature), &[], false),
+    ("d32", Unstable(sym::arm_target_feature), &[], false),
+    ("dotprod", Unstable(sym::arm_target_feature), &["neon"], false),
+    ("dsp", Unstable(sym::arm_target_feature), &[], false),
+    ("fp-armv8", Unstable(sym::arm_target_feature), &["vfp4"], false),
+    ("fp16", Unstable(sym::arm_target_feature), &["neon"], false),
+    ("fpregs", Unstable(sym::arm_target_feature), &[], false),
+    ("i8mm", Unstable(sym::arm_target_feature), &["neon"], false),
+    ("mclass", Unstable(sym::arm_target_feature), &[], false),
+    ("neon", Unstable(sym::arm_target_feature), &["vfp3"], false),
+    ("rclass", Unstable(sym::arm_target_feature), &[], false),
+    ("sha2", Unstable(sym::arm_target_feature), &["neon"], false),
     // This can be *disabled* on non-`hf` targets to enable the use
     // of hardfloats while keeping the softfloat ABI.
     // FIXME before stabilization: Should we expose this as a `hard-float` target feature instead of
     // matching the odd negative feature LLVM uses?
-    ("soft-float", Unstable(sym::arm_target_feature), &[]),
+    ("soft-float", Unstable(sym::arm_target_feature), &[], false),
     // This is needed for inline assembly, but shouldn't be stabilized as-is
     // since it should be enabled per-function using #[instruction_set], not
     // #[target_feature].
-    ("thumb-mode", Unstable(sym::arm_target_feature), &[]),
-    ("thumb2", Unstable(sym::arm_target_feature), &[]),
-    ("trustzone", Unstable(sym::arm_target_feature), &[]),
-    ("v5te", Unstable(sym::arm_target_feature), &[]),
-    ("v6", Unstable(sym::arm_target_feature), &["v5te"]),
-    ("v6k", Unstable(sym::arm_target_feature), &["v6"]),
-    ("v6t2", Unstable(sym::arm_target_feature), &["v6k", "thumb2"]),
-    ("v7", Unstable(sym::arm_target_feature), &["v6t2"]),
-    ("v8", Unstable(sym::arm_target_feature), &["v7"]),
-    ("vfp2", Unstable(sym::arm_target_feature), &[]),
-    ("vfp3", Unstable(sym::arm_target_feature), &["vfp2", "d32"]),
-    ("vfp4", Unstable(sym::arm_target_feature), &["vfp3"]),
-    ("virtualization", Unstable(sym::arm_target_feature), &[]),
+    ("thumb-mode", Unstable(sym::arm_target_feature), &[], false),
+    ("thumb2", Unstable(sym::arm_target_feature), &[], false),
+    ("trustzone", Unstable(sym::arm_target_feature), &[], false),
+    ("v5te", Unstable(sym::arm_target_feature), &[], false),
+    ("v6", Unstable(sym::arm_target_feature), &["v5te"], false),
+    ("v6k", Unstable(sym::arm_target_feature), &["v6"], false),
+    ("v6t2", Unstable(sym::arm_target_feature), &["v6k", "thumb2"], false),
+    ("v7", Unstable(sym::arm_target_feature), &["v6t2"], false),
+    ("v8", Unstable(sym::arm_target_feature), &["v7"], false),
+    ("vfp2", Unstable(sym::arm_target_feature), &[], false),
+    ("vfp3", Unstable(sym::arm_target_feature), &["vfp2", "d32"], false),
+    ("vfp4", Unstable(sym::arm_target_feature), &["vfp3"], false),
+    ("virtualization", Unstable(sym::arm_target_feature), &[], false),
     // tidy-alphabetical-end
 ];
 
-static AARCH64_FEATURES: &[(&str, Stability, ImpliedFeatures)] = &[
+static AARCH64_FEATURES: &[(&str, Stability, ImpliedFeatures, TargetModifier)] = &[
     // tidy-alphabetical-start
     // FEAT_AES & FEAT_PMULL
-    ("aes", Stable, &["neon"]),
+    ("aes", Stable, &["neon"], false),
     // FEAT_BF16
-    ("bf16", Stable, &[]),
+    ("bf16", Stable, &[], false),
     // FEAT_BTI
-    ("bti", Stable, &[]),
+    ("bti", Stable, &[], false),
     // FEAT_CRC
-    ("crc", Stable, &[]),
+    ("crc", Stable, &[], false),
     // FEAT_CSSC
-    ("cssc", Unstable(sym::aarch64_unstable_target_feature), &[]),
+    ("cssc", Unstable(sym::aarch64_unstable_target_feature), &[], false),
     // FEAT_DIT
-    ("dit", Stable, &[]),
+    ("dit", Stable, &[], false),
     // FEAT_DotProd
-    ("dotprod", Stable, &["neon"]),
+    ("dotprod", Stable, &["neon"], false),
     // FEAT_DPB
-    ("dpb", Stable, &[]),
+    ("dpb", Stable, &[], false),
     // FEAT_DPB2
-    ("dpb2", Stable, &["dpb"]),
+    ("dpb2", Stable, &["dpb"], false),
     // FEAT_ECV
-    ("ecv", Unstable(sym::aarch64_unstable_target_feature), &[]),
+    ("ecv", Unstable(sym::aarch64_unstable_target_feature), &[], false),
     // FEAT_F32MM
-    ("f32mm", Stable, &["sve"]),
+    ("f32mm", Stable, &["sve"], false),
     // FEAT_F64MM
-    ("f64mm", Stable, &["sve"]),
+    ("f64mm", Stable, &["sve"], false),
     // FEAT_FAMINMAX
-    ("faminmax", Unstable(sym::aarch64_unstable_target_feature), &[]),
+    ("faminmax", Unstable(sym::aarch64_unstable_target_feature), &[], false),
     // FEAT_FCMA
-    ("fcma", Stable, &["neon"]),
+    ("fcma", Stable, &["neon"], false),
     // FEAT_FHM
-    ("fhm", Stable, &["fp16"]),
+    ("fhm", Stable, &["fp16"], false),
     // FEAT_FLAGM
-    ("flagm", Stable, &[]),
+    ("flagm", Stable, &[], false),
     // FEAT_FLAGM2
-    ("flagm2", Unstable(sym::aarch64_unstable_target_feature), &[]),
+    ("flagm2", Unstable(sym::aarch64_unstable_target_feature), &[], false),
     // We forbid directly toggling just `fp-armv8`; it must be toggled with `neon`.
-    ("fp-armv8", Stability::Forbidden { reason: "Rust ties `fp-armv8` to `neon`" }, &[]),
+    ("fp-armv8", Stability::Forbidden { reason: "Rust ties `fp-armv8` to `neon`" }, &[], false),
     // FEAT_FP8
-    ("fp8", Unstable(sym::aarch64_unstable_target_feature), &["faminmax", "lut", "bf16"]),
+    ("fp8", Unstable(sym::aarch64_unstable_target_feature), &["faminmax", "lut", "bf16"], false),
     // FEAT_FP8DOT2
-    ("fp8dot2", Unstable(sym::aarch64_unstable_target_feature), &["fp8dot4"]),
+    ("fp8dot2", Unstable(sym::aarch64_unstable_target_feature), &["fp8dot4"], false),
     // FEAT_FP8DOT4
-    ("fp8dot4", Unstable(sym::aarch64_unstable_target_feature), &["fp8fma"]),
+    ("fp8dot4", Unstable(sym::aarch64_unstable_target_feature), &["fp8fma"], false),
     // FEAT_FP8FMA
-    ("fp8fma", Unstable(sym::aarch64_unstable_target_feature), &["fp8"]),
+    ("fp8fma", Unstable(sym::aarch64_unstable_target_feature), &["fp8"], false),
     // FEAT_FP16
     // Rust ties FP and Neon: https://github.com/rust-lang/rust/pull/91608
-    ("fp16", Stable, &["neon"]),
+    ("fp16", Stable, &["neon"], false),
     // FEAT_FRINTTS
-    ("frintts", Stable, &[]),
+    ("frintts", Stable, &[], false),
     // FEAT_HBC
-    ("hbc", Unstable(sym::aarch64_unstable_target_feature), &[]),
+    ("hbc", Unstable(sym::aarch64_unstable_target_feature), &[], false),
     // FEAT_I8MM
-    ("i8mm", Stable, &[]),
+    ("i8mm", Stable, &[], false),
     // FEAT_JSCVT
     // Rust ties FP and Neon: https://github.com/rust-lang/rust/pull/91608
-    ("jsconv", Stable, &["neon"]),
+    ("jsconv", Stable, &["neon"], false),
     // FEAT_LOR
-    ("lor", Stable, &[]),
+    ("lor", Stable, &[], false),
     // FEAT_LSE
-    ("lse", Stable, &[]),
+    ("lse", Stable, &[], false),
     // FEAT_LSE2
-    ("lse2", Unstable(sym::aarch64_unstable_target_feature), &[]),
+    ("lse2", Unstable(sym::aarch64_unstable_target_feature), &[], false),
     // FEAT_LSE128
-    ("lse128", Unstable(sym::aarch64_unstable_target_feature), &["lse"]),
+    ("lse128", Unstable(sym::aarch64_unstable_target_feature), &["lse"], false),
     // FEAT_LUT
-    ("lut", Unstable(sym::aarch64_unstable_target_feature), &[]),
+    ("lut", Unstable(sym::aarch64_unstable_target_feature), &[], false),
     // FEAT_MOPS
-    ("mops", Unstable(sym::aarch64_unstable_target_feature), &[]),
+    ("mops", Unstable(sym::aarch64_unstable_target_feature), &[], false),
     // FEAT_MTE & FEAT_MTE2
-    ("mte", Stable, &[]),
+    ("mte", Stable, &[], false),
     // FEAT_AdvSimd & FEAT_FP
-    ("neon", Stable, &[]),
+    ("neon", Stable, &[], false),
     // Backend option to turn atomic operations into an intrinsic call when `lse` is not known to be
     // available, so the intrinsic can do runtime LSE feature detection rather than unconditionally
     // using slower non-LSE operations. Unstable since it doesn't need to user-togglable.
-    ("outline-atomics", Unstable(sym::aarch64_unstable_target_feature), &[]),
+    ("outline-atomics", Unstable(sym::aarch64_unstable_target_feature), &[], false),
     // FEAT_PAUTH (address authentication)
-    ("paca", Stable, &[]),
+    ("paca", Stable, &[], false),
     // FEAT_PAUTH (generic authentication)
-    ("pacg", Stable, &[]),
+    ("pacg", Stable, &[], false),
     // FEAT_PAN
-    ("pan", Stable, &[]),
+    ("pan", Stable, &[], false),
     // FEAT_PAuth_LR
-    ("pauth-lr", Unstable(sym::aarch64_unstable_target_feature), &[]),
+    ("pauth-lr", Unstable(sym::aarch64_unstable_target_feature), &[], false),
     // FEAT_PMUv3
-    ("pmuv3", Stable, &[]),
+    ("pmuv3", Stable, &[], false),
     // FEAT_RNG
-    ("rand", Stable, &[]),
+    ("rand", Stable, &[], false),
     // FEAT_RAS & FEAT_RASv1p1
-    ("ras", Stable, &[]),
+    ("ras", Stable, &[], false),
     // FEAT_LRCPC
-    ("rcpc", Stable, &[]),
+    ("rcpc", Stable, &[], false),
     // FEAT_LRCPC2
-    ("rcpc2", Stable, &["rcpc"]),
+    ("rcpc2", Stable, &["rcpc"], false),
     // FEAT_LRCPC3
-    ("rcpc3", Unstable(sym::aarch64_unstable_target_feature), &["rcpc2"]),
+    ("rcpc3", Unstable(sym::aarch64_unstable_target_feature), &["rcpc2"], false),
     // FEAT_RDM
-    ("rdm", Stable, &["neon"]),
-    ("reserve-x18", Forbidden { reason: "use `-Zfixed-x18` compiler flag instead" }, &[]),
+    ("rdm", Stable, &["neon"], false),
+    ("reserve-x18", Forbidden { reason: "use `-Zfixed-x18` compiler flag instead" }, &[], false),
     // FEAT_SB
-    ("sb", Stable, &[]),
+    ("sb", Stable, &[], false),
     // FEAT_SHA1 & FEAT_SHA256
-    ("sha2", Stable, &["neon"]),
+    ("sha2", Stable, &["neon"], false),
     // FEAT_SHA512 & FEAT_SHA3
-    ("sha3", Stable, &["sha2"]),
+    ("sha3", Stable, &["sha2"], false),
     // FEAT_SM3 & FEAT_SM4
-    ("sm4", Stable, &["neon"]),
+    ("sm4", Stable, &["neon"], false),
     // FEAT_SME
-    ("sme", Unstable(sym::aarch64_unstable_target_feature), &["bf16"]),
+    ("sme", Unstable(sym::aarch64_unstable_target_feature), &["bf16"], false),
     // FEAT_SME_B16B16
-    ("sme-b16b16", Unstable(sym::aarch64_unstable_target_feature), &["bf16", "sme2", "sve-b16b16"]),
+    (
+        "sme-b16b16",
+        Unstable(sym::aarch64_unstable_target_feature),
+        &["bf16", "sme2", "sve-b16b16"],
+        false,
+    ),
     // FEAT_SME_F8F16
-    ("sme-f8f16", Unstable(sym::aarch64_unstable_target_feature), &["sme-f8f32"]),
+    ("sme-f8f16", Unstable(sym::aarch64_unstable_target_feature), &["sme-f8f32"], false),
     // FEAT_SME_F8F32
-    ("sme-f8f32", Unstable(sym::aarch64_unstable_target_feature), &["sme2", "fp8"]),
+    ("sme-f8f32", Unstable(sym::aarch64_unstable_target_feature), &["sme2", "fp8"], false),
     // FEAT_SME_F16F16
-    ("sme-f16f16", Unstable(sym::aarch64_unstable_target_feature), &["sme2"]),
+    ("sme-f16f16", Unstable(sym::aarch64_unstable_target_feature), &["sme2"], false),
     // FEAT_SME_F64F64
-    ("sme-f64f64", Unstable(sym::aarch64_unstable_target_feature), &["sme"]),
+    ("sme-f64f64", Unstable(sym::aarch64_unstable_target_feature), &["sme"], false),
     // FEAT_SME_FA64
-    ("sme-fa64", Unstable(sym::aarch64_unstable_target_feature), &["sme", "sve2"]),
+    ("sme-fa64", Unstable(sym::aarch64_unstable_target_feature), &["sme", "sve2"], false),
     // FEAT_SME_I16I64
-    ("sme-i16i64", Unstable(sym::aarch64_unstable_target_feature), &["sme"]),
+    ("sme-i16i64", Unstable(sym::aarch64_unstable_target_feature), &["sme"], false),
     // FEAT_SME_LUTv2
-    ("sme-lutv2", Unstable(sym::aarch64_unstable_target_feature), &[]),
+    ("sme-lutv2", Unstable(sym::aarch64_unstable_target_feature), &[], false),
     // FEAT_SME2
-    ("sme2", Unstable(sym::aarch64_unstable_target_feature), &["sme"]),
+    ("sme2", Unstable(sym::aarch64_unstable_target_feature), &["sme"], false),
     // FEAT_SME2p1
-    ("sme2p1", Unstable(sym::aarch64_unstable_target_feature), &["sme2"]),
+    ("sme2p1", Unstable(sym::aarch64_unstable_target_feature), &["sme2"], false),
     // FEAT_SPE
-    ("spe", Stable, &[]),
+    ("spe", Stable, &[], false),
     // FEAT_SSBS & FEAT_SSBS2
-    ("ssbs", Stable, &[]),
+    ("ssbs", Stable, &[], false),
     // FEAT_SSVE_FP8FDOT2
-    ("ssve-fp8dot2", Unstable(sym::aarch64_unstable_target_feature), &["ssve-fp8dot4"]),
+    ("ssve-fp8dot2", Unstable(sym::aarch64_unstable_target_feature), &["ssve-fp8dot4"], false),
     // FEAT_SSVE_FP8FDOT4
-    ("ssve-fp8dot4", Unstable(sym::aarch64_unstable_target_feature), &["ssve-fp8fma"]),
+    ("ssve-fp8dot4", Unstable(sym::aarch64_unstable_target_feature), &["ssve-fp8fma"], false),
     // FEAT_SSVE_FP8FMA
-    ("ssve-fp8fma", Unstable(sym::aarch64_unstable_target_feature), &["sme2", "fp8"]),
+    ("ssve-fp8fma", Unstable(sym::aarch64_unstable_target_feature), &["sme2", "fp8"], false),
     // FEAT_SVE
     // It was decided that SVE requires Neon: https://github.com/rust-lang/rust/pull/91608
     //
@@ -322,50 +331,62 @@ static AARCH64_FEATURES: &[(&str, Stability, ImpliedFeatures)] = &[
     // exist together: https://developer.arm.com/documentation/102340/0100/New-features-in-SVE2
     //
     // "For backwards compatibility, Neon and VFP are required in the latest architectures."
-    ("sve", Stable, &["neon"]),
+    ("sve", Stable, &["neon"], false),
     // FEAT_SVE_B16B16 (SVE or SME Z-targeting instructions)
-    ("sve-b16b16", Unstable(sym::aarch64_unstable_target_feature), &["bf16"]),
+    ("sve-b16b16", Unstable(sym::aarch64_unstable_target_feature), &["bf16"], false),
     // FEAT_SVE2
-    ("sve2", Stable, &["sve"]),
+    ("sve2", Stable, &["sve"], false),
     // FEAT_SVE_AES & FEAT_SVE_PMULL128
-    ("sve2-aes", Stable, &["sve2", "aes"]),
+    ("sve2-aes", Stable, &["sve2", "aes"], false),
     // FEAT_SVE2_BitPerm
-    ("sve2-bitperm", Stable, &["sve2"]),
+    ("sve2-bitperm", Stable, &["sve2"], false),
     // FEAT_SVE2_SHA3
-    ("sve2-sha3", Stable, &["sve2", "sha3"]),
+    ("sve2-sha3", Stable, &["sve2", "sha3"], false),
     // FEAT_SVE2_SM4
-    ("sve2-sm4", Stable, &["sve2", "sm4"]),
+    ("sve2-sm4", Stable, &["sve2", "sm4"], false),
     // FEAT_SVE2p1
-    ("sve2p1", Unstable(sym::aarch64_unstable_target_feature), &["sve2"]),
+    ("sve2p1", Unstable(sym::aarch64_unstable_target_feature), &["sve2"], false),
     // FEAT_TME
-    ("tme", Stable, &[]),
+    ("tme", Stable, &[], false),
     (
         "v8.1a",
         Unstable(sym::aarch64_ver_target_feature),
         &["crc", "lse", "rdm", "pan", "lor", "vh"],
+        false,
     ),
-    ("v8.2a", Unstable(sym::aarch64_ver_target_feature), &["v8.1a", "ras", "dpb"]),
+    ("v8.2a", Unstable(sym::aarch64_ver_target_feature), &["v8.1a", "ras", "dpb"], false),
     (
         "v8.3a",
         Unstable(sym::aarch64_ver_target_feature),
         &["v8.2a", "rcpc", "paca", "pacg", "jsconv"],
+        false,
     ),
-    ("v8.4a", Unstable(sym::aarch64_ver_target_feature), &["v8.3a", "dotprod", "dit", "flagm"]),
-    ("v8.5a", Unstable(sym::aarch64_ver_target_feature), &["v8.4a", "ssbs", "sb", "dpb2", "bti"]),
-    ("v8.6a", Unstable(sym::aarch64_ver_target_feature), &["v8.5a", "bf16", "i8mm"]),
-    ("v8.7a", Unstable(sym::aarch64_ver_target_feature), &["v8.6a", "wfxt"]),
-    ("v8.8a", Unstable(sym::aarch64_ver_target_feature), &["v8.7a", "hbc", "mops"]),
-    ("v8.9a", Unstable(sym::aarch64_ver_target_feature), &["v8.8a", "cssc"]),
-    ("v9.1a", Unstable(sym::aarch64_ver_target_feature), &["v9a", "v8.6a"]),
-    ("v9.2a", Unstable(sym::aarch64_ver_target_feature), &["v9.1a", "v8.7a"]),
-    ("v9.3a", Unstable(sym::aarch64_ver_target_feature), &["v9.2a", "v8.8a"]),
-    ("v9.4a", Unstable(sym::aarch64_ver_target_feature), &["v9.3a", "v8.9a"]),
-    ("v9.5a", Unstable(sym::aarch64_ver_target_feature), &["v9.4a"]),
-    ("v9a", Unstable(sym::aarch64_ver_target_feature), &["v8.5a", "sve2"]),
+    (
+        "v8.4a",
+        Unstable(sym::aarch64_ver_target_feature),
+        &["v8.3a", "dotprod", "dit", "flagm"],
+        false,
+    ),
+    (
+        "v8.5a",
+        Unstable(sym::aarch64_ver_target_feature),
+        &["v8.4a", "ssbs", "sb", "dpb2", "bti"],
+        false,
+    ),
+    ("v8.6a", Unstable(sym::aarch64_ver_target_feature), &["v8.5a", "bf16", "i8mm"], false),
+    ("v8.7a", Unstable(sym::aarch64_ver_target_feature), &["v8.6a", "wfxt"], false),
+    ("v8.8a", Unstable(sym::aarch64_ver_target_feature), &["v8.7a", "hbc", "mops"], false),
+    ("v8.9a", Unstable(sym::aarch64_ver_target_feature), &["v8.8a", "cssc"], false),
+    ("v9.1a", Unstable(sym::aarch64_ver_target_feature), &["v9a", "v8.6a"], false),
+    ("v9.2a", Unstable(sym::aarch64_ver_target_feature), &["v9.1a", "v8.7a"], false),
+    ("v9.3a", Unstable(sym::aarch64_ver_target_feature), &["v9.2a", "v8.8a"], false),
+    ("v9.4a", Unstable(sym::aarch64_ver_target_feature), &["v9.3a", "v8.9a"], false),
+    ("v9.5a", Unstable(sym::aarch64_ver_target_feature), &["v9.4a"], false),
+    ("v9a", Unstable(sym::aarch64_ver_target_feature), &["v8.5a", "sve2"], false),
     // FEAT_VHE
-    ("vh", Stable, &[]),
+    ("vh", Stable, &[], false),
     // FEAT_WFxT
-    ("wfxt", Unstable(sym::aarch64_unstable_target_feature), &[]),
+    ("wfxt", Unstable(sym::aarch64_unstable_target_feature), &[], false),
     // tidy-alphabetical-end
 ];
 
@@ -373,22 +394,22 @@ const AARCH64_TIED_FEATURES: &[&[&str]] = &[
     &["paca", "pacg"], // Together these represent `pauth` in LLVM
 ];
 
-static X86_FEATURES: &[(&str, Stability, ImpliedFeatures)] = &[
+static X86_FEATURES: &[(&str, Stability, ImpliedFeatures, TargetModifier)] = &[
     // tidy-alphabetical-start
-    ("adx", Stable, &[]),
-    ("aes", Stable, &["sse2"]),
-    ("amx-avx512", Unstable(sym::x86_amx_intrinsics), &["amx-tile"]),
-    ("amx-bf16", Unstable(sym::x86_amx_intrinsics), &["amx-tile"]),
-    ("amx-complex", Unstable(sym::x86_amx_intrinsics), &["amx-tile"]),
-    ("amx-fp8", Unstable(sym::x86_amx_intrinsics), &["amx-tile"]),
-    ("amx-fp16", Unstable(sym::x86_amx_intrinsics), &["amx-tile"]),
-    ("amx-int8", Unstable(sym::x86_amx_intrinsics), &["amx-tile"]),
-    ("amx-movrs", Unstable(sym::x86_amx_intrinsics), &["amx-tile"]),
-    ("amx-tf32", Unstable(sym::x86_amx_intrinsics), &["amx-tile"]),
-    ("amx-tile", Unstable(sym::x86_amx_intrinsics), &[]),
-    ("apxf", Unstable(sym::apx_target_feature), &[]),
-    ("avx", Stable, &["sse4.2"]),
-    ("avx2", Stable, &["avx"]),
+    ("adx", Stable, &[], false),
+    ("aes", Stable, &["sse2"], false),
+    ("amx-avx512", Unstable(sym::x86_amx_intrinsics), &["amx-tile"], false),
+    ("amx-bf16", Unstable(sym::x86_amx_intrinsics), &["amx-tile"], false),
+    ("amx-complex", Unstable(sym::x86_amx_intrinsics), &["amx-tile"], false),
+    ("amx-fp8", Unstable(sym::x86_amx_intrinsics), &["amx-tile"], false),
+    ("amx-fp16", Unstable(sym::x86_amx_intrinsics), &["amx-tile"], false),
+    ("amx-int8", Unstable(sym::x86_amx_intrinsics), &["amx-tile"], false),
+    ("amx-movrs", Unstable(sym::x86_amx_intrinsics), &["amx-tile"], false),
+    ("amx-tf32", Unstable(sym::x86_amx_intrinsics), &["amx-tile"], false),
+    ("amx-tile", Unstable(sym::x86_amx_intrinsics), &[], false),
+    ("apxf", Unstable(sym::apx_target_feature), &[], false),
+    ("avx", Stable, &["sse4.2"], false),
+    ("avx2", Stable, &["avx"], false),
     (
         "avx10.1",
         Unstable(sym::avx10_target_feature),
@@ -407,199 +428,209 @@ static X86_FEATURES: &[(&str, Stability, ImpliedFeatures)] = &[
             "avx512vnni",
             "avx512vpopcntdq",
         ],
+        false,
     ),
-    ("avx10.2", Unstable(sym::avx10_target_feature), &["avx10.1"]),
-    ("avx512bf16", Stable, &["avx512bw"]),
-    ("avx512bitalg", Stable, &["avx512bw"]),
-    ("avx512bw", Stable, &["avx512f"]),
-    ("avx512cd", Stable, &["avx512f"]),
-    ("avx512dq", Stable, &["avx512f"]),
-    ("avx512f", Stable, &["avx2", "fma", "f16c"]),
-    ("avx512fp16", Stable, &["avx512bw"]),
-    ("avx512ifma", Stable, &["avx512f"]),
-    ("avx512vbmi", Stable, &["avx512bw"]),
-    ("avx512vbmi2", Stable, &["avx512bw"]),
-    ("avx512vl", Stable, &["avx512f"]),
-    ("avx512vnni", Stable, &["avx512f"]),
-    ("avx512vp2intersect", Stable, &["avx512f"]),
-    ("avx512vpopcntdq", Stable, &["avx512f"]),
-    ("avxifma", Stable, &["avx2"]),
-    ("avxneconvert", Stable, &["avx2"]),
-    ("avxvnni", Stable, &["avx2"]),
-    ("avxvnniint8", Stable, &["avx2"]),
-    ("avxvnniint16", Stable, &["avx2"]),
-    ("bmi1", Stable, &[]),
-    ("bmi2", Stable, &[]),
-    ("cmpxchg16b", Stable, &[]),
-    ("ermsb", Unstable(sym::ermsb_target_feature), &[]),
-    ("f16c", Stable, &["avx"]),
-    ("fma", Stable, &["avx"]),
-    ("fxsr", Stable, &[]),
-    ("gfni", Stable, &["sse2"]),
-    ("kl", Stable, &["sse2"]),
-    ("lahfsahf", Unstable(sym::lahfsahf_target_feature), &[]),
-    ("lzcnt", Stable, &[]),
-    ("movbe", Stable, &[]),
-    ("movrs", Unstable(sym::movrs_target_feature), &[]),
-    ("pclmulqdq", Stable, &["sse2"]),
-    ("popcnt", Stable, &[]),
-    ("prfchw", Unstable(sym::prfchw_target_feature), &[]),
-    ("rdrand", Stable, &[]),
-    ("rdseed", Stable, &[]),
+    ("avx10.2", Unstable(sym::avx10_target_feature), &["avx10.1"], false),
+    ("avx512bf16", Stable, &["avx512bw"], false),
+    ("avx512bitalg", Stable, &["avx512bw"], false),
+    ("avx512bw", Stable, &["avx512f"], false),
+    ("avx512cd", Stable, &["avx512f"], false),
+    ("avx512dq", Stable, &["avx512f"], false),
+    ("avx512f", Stable, &["avx2", "fma", "f16c"], false),
+    ("avx512fp16", Stable, &["avx512bw"], false),
+    ("avx512ifma", Stable, &["avx512f"], false),
+    ("avx512vbmi", Stable, &["avx512bw"], false),
+    ("avx512vbmi2", Stable, &["avx512bw"], false),
+    ("avx512vl", Stable, &["avx512f"], false),
+    ("avx512vnni", Stable, &["avx512f"], false),
+    ("avx512vp2intersect", Stable, &["avx512f"], false),
+    ("avx512vpopcntdq", Stable, &["avx512f"], false),
+    ("avxifma", Stable, &["avx2"], false),
+    ("avxneconvert", Stable, &["avx2"], false),
+    ("avxvnni", Stable, &["avx2"], false),
+    ("avxvnniint8", Stable, &["avx2"], false),
+    ("avxvnniint16", Stable, &["avx2"], false),
+    ("bmi1", Stable, &[], false),
+    ("bmi2", Stable, &[], false),
+    ("cmpxchg16b", Stable, &[], false),
+    ("ermsb", Unstable(sym::ermsb_target_feature), &[], false),
+    ("f16c", Stable, &["avx"], false),
+    ("fma", Stable, &["avx"], false),
+    ("fxsr", Stable, &[], false),
+    ("gfni", Stable, &["sse2"], false),
+    ("kl", Stable, &["sse2"], false),
+    ("lahfsahf", Unstable(sym::lahfsahf_target_feature), &[], false),
+    ("lzcnt", Stable, &[], false),
+    ("movbe", Stable, &[], false),
+    ("movrs", Unstable(sym::movrs_target_feature), &[], false),
+    ("pclmulqdq", Stable, &["sse2"], false),
+    ("popcnt", Stable, &[], false),
+    ("prfchw", Unstable(sym::prfchw_target_feature), &[], false),
+    ("rdrand", Stable, &[], false),
+    ("rdseed", Stable, &[], false),
     (
         "retpoline-external-thunk",
         Stability::Forbidden { reason: "use `-Zretpoline-external-thunk` compiler flag instead" },
         &[],
+        false,
     ),
     (
         "retpoline-indirect-branches",
         Stability::Forbidden { reason: "use `-Zretpoline` compiler flag instead" },
         &[],
+        false,
     ),
     (
         "retpoline-indirect-calls",
         Stability::Forbidden { reason: "use `-Zretpoline` compiler flag instead" },
         &[],
+        false,
     ),
-    ("rtm", Unstable(sym::rtm_target_feature), &[]),
-    ("sha", Stable, &["sse2"]),
-    ("sha512", Stable, &["avx2"]),
-    ("sm3", Stable, &["avx"]),
-    ("sm4", Stable, &["avx2"]),
+    ("rtm", Unstable(sym::rtm_target_feature), &[], false),
+    ("sha", Stable, &["sse2"], false),
+    ("sha512", Stable, &["avx2"], false),
+    ("sm3", Stable, &["avx"], false),
+    ("sm4", Stable, &["avx2"], false),
     // This cannot actually be toggled, the ABI always fixes it, so it'd make little sense to
     // stabilize. It must be in this list for the ABI check to be able to use it.
-    ("soft-float", Stability::Unstable(sym::x87_target_feature), &[]),
-    ("sse", Stable, &[]),
-    ("sse2", Stable, &["sse"]),
-    ("sse3", Stable, &["sse2"]),
-    ("sse4.1", Stable, &["ssse3"]),
-    ("sse4.2", Stable, &["sse4.1"]),
-    ("sse4a", Stable, &["sse3"]),
-    ("ssse3", Stable, &["sse3"]),
-    ("tbm", Stable, &[]),
-    ("vaes", Stable, &["avx2", "aes"]),
-    ("vpclmulqdq", Stable, &["avx", "pclmulqdq"]),
-    ("widekl", Stable, &["kl"]),
-    ("x87", Unstable(sym::x87_target_feature), &[]),
-    ("xop", Unstable(sym::xop_target_feature), &[/*"fma4", */ "avx", "sse4a"]),
-    ("xsave", Stable, &[]),
-    ("xsavec", Stable, &["xsave"]),
-    ("xsaveopt", Stable, &["xsave"]),
-    ("xsaves", Stable, &["xsave"]),
+    ("soft-float", Stability::Unstable(sym::x87_target_feature), &[], false),
+    ("sse", Stable, &[], false),
+    ("sse2", Stable, &["sse"], false),
+    ("sse3", Stable, &["sse2"], false),
+    ("sse4.1", Stable, &["ssse3"], false),
+    ("sse4.2", Stable, &["sse4.1"], false),
+    ("sse4a", Stable, &["sse3"], false),
+    ("ssse3", Stable, &["sse3"], false),
+    ("tbm", Stable, &[], false),
+    ("vaes", Stable, &["avx2", "aes"], false),
+    ("vpclmulqdq", Stable, &["avx", "pclmulqdq"], false),
+    ("widekl", Stable, &["kl"], false),
+    ("x87", Unstable(sym::x87_target_feature), &[], false),
+    ("xop", Unstable(sym::xop_target_feature), &[/*"fma4", */ "avx", "sse4a"], false),
+    ("xsave", Stable, &[], false),
+    ("xsavec", Stable, &["xsave"], false),
+    ("xsaveopt", Stable, &["xsave"], false),
+    ("xsaves", Stable, &["xsave"], false),
     // tidy-alphabetical-end
 ];
 
-const HEXAGON_FEATURES: &[(&str, Stability, ImpliedFeatures)] = &[
+const HEXAGON_FEATURES: &[(&str, Stability, ImpliedFeatures, TargetModifier)] = &[
     // tidy-alphabetical-start
-    ("hvx", Unstable(sym::hexagon_target_feature), &[]),
-    ("hvx-length128b", Unstable(sym::hexagon_target_feature), &["hvx"]),
+    ("hvx", Unstable(sym::hexagon_target_feature), &[], false),
+    ("hvx-length128b", Unstable(sym::hexagon_target_feature), &["hvx"], false),
     // tidy-alphabetical-end
 ];
 
-static POWERPC_FEATURES: &[(&str, Stability, ImpliedFeatures)] = &[
+static POWERPC_FEATURES: &[(&str, Stability, ImpliedFeatures, TargetModifier)] = &[
     // tidy-alphabetical-start
-    ("altivec", Unstable(sym::powerpc_target_feature), &[]),
-    ("msync", Unstable(sym::powerpc_target_feature), &[]),
-    ("partword-atomics", Unstable(sym::powerpc_target_feature), &[]),
-    ("power8-altivec", Unstable(sym::powerpc_target_feature), &["altivec"]),
-    ("power8-crypto", Unstable(sym::powerpc_target_feature), &["power8-altivec"]),
-    ("power8-vector", Unstable(sym::powerpc_target_feature), &["vsx", "power8-altivec"]),
-    ("power9-altivec", Unstable(sym::powerpc_target_feature), &["power8-altivec"]),
-    ("power9-vector", Unstable(sym::powerpc_target_feature), &["power8-vector", "power9-altivec"]),
-    ("power10-vector", Unstable(sym::powerpc_target_feature), &["power9-vector"]),
-    ("quadword-atomics", Unstable(sym::powerpc_target_feature), &[]),
-    ("vsx", Unstable(sym::powerpc_target_feature), &["altivec"]),
+    ("altivec", Unstable(sym::powerpc_target_feature), &[], false),
+    ("msync", Unstable(sym::powerpc_target_feature), &[], false),
+    ("partword-atomics", Unstable(sym::powerpc_target_feature), &[], false),
+    ("power8-altivec", Unstable(sym::powerpc_target_feature), &["altivec"], false),
+    ("power8-crypto", Unstable(sym::powerpc_target_feature), &["power8-altivec"], false),
+    ("power8-vector", Unstable(sym::powerpc_target_feature), &["vsx", "power8-altivec"], false),
+    ("power9-altivec", Unstable(sym::powerpc_target_feature), &["power8-altivec"], false),
+    (
+        "power9-vector",
+        Unstable(sym::powerpc_target_feature),
+        &["power8-vector", "power9-altivec"],
+        false,
+    ),
+    ("power10-vector", Unstable(sym::powerpc_target_feature), &["power9-vector"], false),
+    ("quadword-atomics", Unstable(sym::powerpc_target_feature), &[], false),
+    ("vsx", Unstable(sym::powerpc_target_feature), &["altivec"], false),
     // tidy-alphabetical-end
 ];
 
-const MIPS_FEATURES: &[(&str, Stability, ImpliedFeatures)] = &[
+const MIPS_FEATURES: &[(&str, Stability, ImpliedFeatures, TargetModifier)] = &[
     // tidy-alphabetical-start
-    ("fp64", Unstable(sym::mips_target_feature), &[]),
-    ("msa", Unstable(sym::mips_target_feature), &[]),
-    ("virt", Unstable(sym::mips_target_feature), &[]),
+    ("fp64", Unstable(sym::mips_target_feature), &[], false),
+    ("msa", Unstable(sym::mips_target_feature), &[], false),
+    ("virt", Unstable(sym::mips_target_feature), &[], false),
     // tidy-alphabetical-end
 ];
 
-const NVPTX_FEATURES: &[(&str, Stability, ImpliedFeatures)] = &[
+const NVPTX_FEATURES: &[(&str, Stability, ImpliedFeatures, TargetModifier)] = &[
     // tidy-alphabetical-start
-    ("sm_20", Unstable(sym::nvptx_target_feature), &[]),
-    ("sm_21", Unstable(sym::nvptx_target_feature), &["sm_20"]),
-    ("sm_30", Unstable(sym::nvptx_target_feature), &["sm_21"]),
-    ("sm_32", Unstable(sym::nvptx_target_feature), &["sm_30"]),
-    ("sm_35", Unstable(sym::nvptx_target_feature), &["sm_32"]),
-    ("sm_37", Unstable(sym::nvptx_target_feature), &["sm_35"]),
-    ("sm_50", Unstable(sym::nvptx_target_feature), &["sm_37"]),
-    ("sm_52", Unstable(sym::nvptx_target_feature), &["sm_50"]),
-    ("sm_53", Unstable(sym::nvptx_target_feature), &["sm_52"]),
-    ("sm_60", Unstable(sym::nvptx_target_feature), &["sm_53"]),
-    ("sm_61", Unstable(sym::nvptx_target_feature), &["sm_60"]),
-    ("sm_62", Unstable(sym::nvptx_target_feature), &["sm_61"]),
-    ("sm_70", Unstable(sym::nvptx_target_feature), &["sm_62"]),
-    ("sm_72", Unstable(sym::nvptx_target_feature), &["sm_70"]),
-    ("sm_75", Unstable(sym::nvptx_target_feature), &["sm_72"]),
-    ("sm_80", Unstable(sym::nvptx_target_feature), &["sm_75"]),
-    ("sm_86", Unstable(sym::nvptx_target_feature), &["sm_80"]),
-    ("sm_87", Unstable(sym::nvptx_target_feature), &["sm_86"]),
-    ("sm_89", Unstable(sym::nvptx_target_feature), &["sm_87"]),
-    ("sm_90", Unstable(sym::nvptx_target_feature), &["sm_89"]),
-    ("sm_90a", Unstable(sym::nvptx_target_feature), &["sm_90"]),
+    ("sm_20", Unstable(sym::nvptx_target_feature), &[], false),
+    ("sm_21", Unstable(sym::nvptx_target_feature), &["sm_20"], false),
+    ("sm_30", Unstable(sym::nvptx_target_feature), &["sm_21"], false),
+    ("sm_32", Unstable(sym::nvptx_target_feature), &["sm_30"], false),
+    ("sm_35", Unstable(sym::nvptx_target_feature), &["sm_32"], false),
+    ("sm_37", Unstable(sym::nvptx_target_feature), &["sm_35"], false),
+    ("sm_50", Unstable(sym::nvptx_target_feature), &["sm_37"], false),
+    ("sm_52", Unstable(sym::nvptx_target_feature), &["sm_50"], false),
+    ("sm_53", Unstable(sym::nvptx_target_feature), &["sm_52"], false),
+    ("sm_60", Unstable(sym::nvptx_target_feature), &["sm_53"], false),
+    ("sm_61", Unstable(sym::nvptx_target_feature), &["sm_60"], false),
+    ("sm_62", Unstable(sym::nvptx_target_feature), &["sm_61"], false),
+    ("sm_70", Unstable(sym::nvptx_target_feature), &["sm_62"], false),
+    ("sm_72", Unstable(sym::nvptx_target_feature), &["sm_70"], false),
+    ("sm_75", Unstable(sym::nvptx_target_feature), &["sm_72"], false),
+    ("sm_80", Unstable(sym::nvptx_target_feature), &["sm_75"], false),
+    ("sm_86", Unstable(sym::nvptx_target_feature), &["sm_80"], false),
+    ("sm_87", Unstable(sym::nvptx_target_feature), &["sm_86"], false),
+    ("sm_89", Unstable(sym::nvptx_target_feature), &["sm_87"], false),
+    ("sm_90", Unstable(sym::nvptx_target_feature), &["sm_89"], false),
+    ("sm_90a", Unstable(sym::nvptx_target_feature), &["sm_90"], false),
     // tidy-alphabetical-end
     // tidy-alphabetical-start
-    ("sm_100", Unstable(sym::nvptx_target_feature), &["sm_90"]),
-    ("sm_100a", Unstable(sym::nvptx_target_feature), &["sm_100"]),
-    ("sm_101", Unstable(sym::nvptx_target_feature), &["sm_100"]),
-    ("sm_101a", Unstable(sym::nvptx_target_feature), &["sm_101"]),
-    ("sm_120", Unstable(sym::nvptx_target_feature), &["sm_101"]),
-    ("sm_120a", Unstable(sym::nvptx_target_feature), &["sm_120"]),
+    ("sm_100", Unstable(sym::nvptx_target_feature), &["sm_90"], false),
+    ("sm_100a", Unstable(sym::nvptx_target_feature), &["sm_100"], false),
+    ("sm_101", Unstable(sym::nvptx_target_feature), &["sm_100"], false),
+    ("sm_101a", Unstable(sym::nvptx_target_feature), &["sm_101"], false),
+    ("sm_120", Unstable(sym::nvptx_target_feature), &["sm_101"], false),
+    ("sm_120a", Unstable(sym::nvptx_target_feature), &["sm_120"], false),
     // tidy-alphabetical-end
     // tidy-alphabetical-start
-    ("ptx32", Unstable(sym::nvptx_target_feature), &[]),
-    ("ptx40", Unstable(sym::nvptx_target_feature), &["ptx32"]),
-    ("ptx41", Unstable(sym::nvptx_target_feature), &["ptx40"]),
-    ("ptx42", Unstable(sym::nvptx_target_feature), &["ptx41"]),
-    ("ptx43", Unstable(sym::nvptx_target_feature), &["ptx42"]),
-    ("ptx50", Unstable(sym::nvptx_target_feature), &["ptx43"]),
-    ("ptx60", Unstable(sym::nvptx_target_feature), &["ptx50"]),
-    ("ptx61", Unstable(sym::nvptx_target_feature), &["ptx60"]),
-    ("ptx62", Unstable(sym::nvptx_target_feature), &["ptx61"]),
-    ("ptx63", Unstable(sym::nvptx_target_feature), &["ptx62"]),
-    ("ptx64", Unstable(sym::nvptx_target_feature), &["ptx63"]),
-    ("ptx65", Unstable(sym::nvptx_target_feature), &["ptx64"]),
-    ("ptx70", Unstable(sym::nvptx_target_feature), &["ptx65"]),
-    ("ptx71", Unstable(sym::nvptx_target_feature), &["ptx70"]),
-    ("ptx72", Unstable(sym::nvptx_target_feature), &["ptx71"]),
-    ("ptx73", Unstable(sym::nvptx_target_feature), &["ptx72"]),
-    ("ptx74", Unstable(sym::nvptx_target_feature), &["ptx73"]),
-    ("ptx75", Unstable(sym::nvptx_target_feature), &["ptx74"]),
-    ("ptx76", Unstable(sym::nvptx_target_feature), &["ptx75"]),
-    ("ptx77", Unstable(sym::nvptx_target_feature), &["ptx76"]),
-    ("ptx78", Unstable(sym::nvptx_target_feature), &["ptx77"]),
-    ("ptx80", Unstable(sym::nvptx_target_feature), &["ptx78"]),
-    ("ptx81", Unstable(sym::nvptx_target_feature), &["ptx80"]),
-    ("ptx82", Unstable(sym::nvptx_target_feature), &["ptx81"]),
-    ("ptx83", Unstable(sym::nvptx_target_feature), &["ptx82"]),
-    ("ptx84", Unstable(sym::nvptx_target_feature), &["ptx83"]),
-    ("ptx85", Unstable(sym::nvptx_target_feature), &["ptx84"]),
-    ("ptx86", Unstable(sym::nvptx_target_feature), &["ptx85"]),
-    ("ptx87", Unstable(sym::nvptx_target_feature), &["ptx86"]),
+    ("ptx32", Unstable(sym::nvptx_target_feature), &[], false),
+    ("ptx40", Unstable(sym::nvptx_target_feature), &["ptx32"], false),
+    ("ptx41", Unstable(sym::nvptx_target_feature), &["ptx40"], false),
+    ("ptx42", Unstable(sym::nvptx_target_feature), &["ptx41"], false),
+    ("ptx43", Unstable(sym::nvptx_target_feature), &["ptx42"], false),
+    ("ptx50", Unstable(sym::nvptx_target_feature), &["ptx43"], false),
+    ("ptx60", Unstable(sym::nvptx_target_feature), &["ptx50"], false),
+    ("ptx61", Unstable(sym::nvptx_target_feature), &["ptx60"], false),
+    ("ptx62", Unstable(sym::nvptx_target_feature), &["ptx61"], false),
+    ("ptx63", Unstable(sym::nvptx_target_feature), &["ptx62"], false),
+    ("ptx64", Unstable(sym::nvptx_target_feature), &["ptx63"], false),
+    ("ptx65", Unstable(sym::nvptx_target_feature), &["ptx64"], false),
+    ("ptx70", Unstable(sym::nvptx_target_feature), &["ptx65"], false),
+    ("ptx71", Unstable(sym::nvptx_target_feature), &["ptx70"], false),
+    ("ptx72", Unstable(sym::nvptx_target_feature), &["ptx71"], false),
+    ("ptx73", Unstable(sym::nvptx_target_feature), &["ptx72"], false),
+    ("ptx74", Unstable(sym::nvptx_target_feature), &["ptx73"], false),
+    ("ptx75", Unstable(sym::nvptx_target_feature), &["ptx74"], false),
+    ("ptx76", Unstable(sym::nvptx_target_feature), &["ptx75"], false),
+    ("ptx77", Unstable(sym::nvptx_target_feature), &["ptx76"], false),
+    ("ptx78", Unstable(sym::nvptx_target_feature), &["ptx77"], false),
+    ("ptx80", Unstable(sym::nvptx_target_feature), &["ptx78"], false),
+    ("ptx81", Unstable(sym::nvptx_target_feature), &["ptx80"], false),
+    ("ptx82", Unstable(sym::nvptx_target_feature), &["ptx81"], false),
+    ("ptx83", Unstable(sym::nvptx_target_feature), &["ptx82"], false),
+    ("ptx84", Unstable(sym::nvptx_target_feature), &["ptx83"], false),
+    ("ptx85", Unstable(sym::nvptx_target_feature), &["ptx84"], false),
+    ("ptx86", Unstable(sym::nvptx_target_feature), &["ptx85"], false),
+    ("ptx87", Unstable(sym::nvptx_target_feature), &["ptx86"], false),
     // tidy-alphabetical-end
 ];
 
-static RISCV_FEATURES: &[(&str, Stability, ImpliedFeatures)] = &[
+static RISCV_FEATURES: &[(&str, Stability, ImpliedFeatures, TargetModifier)] = &[
     // tidy-alphabetical-start
-    ("a", Stable, &["zaamo", "zalrsc"]),
-    ("b", Unstable(sym::riscv_target_feature), &["zba", "zbb", "zbs"]),
-    ("c", Stable, &["zca"]),
-    ("d", Unstable(sym::riscv_target_feature), &["f"]),
-    ("e", Unstable(sym::riscv_target_feature), &[]),
-    ("f", Unstable(sym::riscv_target_feature), &["zicsr"]),
+    ("a", Stable, &["zaamo", "zalrsc"], false),
+    ("b", Unstable(sym::riscv_target_feature), &["zba", "zbb", "zbs"], false),
+    ("c", Stable, &["zca"], false),
+    ("d", Unstable(sym::riscv_target_feature), &["f"], false),
+    ("e", Unstable(sym::riscv_target_feature), &[], false),
+    ("f", Unstable(sym::riscv_target_feature), &["zicsr"], false),
     (
         "forced-atomics",
         Stability::Forbidden { reason: "unsound because it changes the ABI of atomic operations" },
         &[],
+        false,
     ),
-    ("m", Stable, &[]),
-    ("relax", Unstable(sym::riscv_target_feature), &[]),
+    ("m", Stable, &[], false),
+    ("relax", Unstable(sym::riscv_target_feature), &[], false),
     (
         "rva23u64",
         Unstable(sym::riscv_target_feature),
@@ -641,245 +672,246 @@ static RISCV_FEATURES: &[(&str, Stability, ImpliedFeatures)] = &[
             "zawrs",
             "supm",
         ],
+        false,
     ),
-    ("supm", Unstable(sym::riscv_target_feature), &[]),
-    ("unaligned-scalar-mem", Unstable(sym::riscv_target_feature), &[]),
-    ("unaligned-vector-mem", Unstable(sym::riscv_target_feature), &[]),
-    ("v", Unstable(sym::riscv_target_feature), &["zvl128b", "zve64d"]),
-    ("za64rs", Unstable(sym::riscv_target_feature), &["za128rs"]), // Za64rs ⊃ Za128rs
-    ("za128rs", Unstable(sym::riscv_target_feature), &[]),
-    ("zaamo", Unstable(sym::riscv_target_feature), &[]),
-    ("zabha", Unstable(sym::riscv_target_feature), &["zaamo"]),
-    ("zacas", Unstable(sym::riscv_target_feature), &["zaamo"]),
-    ("zalrsc", Unstable(sym::riscv_target_feature), &[]),
-    ("zama16b", Unstable(sym::riscv_target_feature), &[]),
-    ("zawrs", Unstable(sym::riscv_target_feature), &[]),
-    ("zba", Stable, &[]),
-    ("zbb", Stable, &[]),
-    ("zbc", Stable, &["zbkc"]), // Zbc ⊃ Zbkc
-    ("zbkb", Stable, &[]),
-    ("zbkc", Stable, &[]),
-    ("zbkx", Stable, &[]),
-    ("zbs", Stable, &[]),
-    ("zca", Unstable(sym::riscv_target_feature), &[]),
-    ("zcb", Unstable(sym::riscv_target_feature), &["zca"]),
-    ("zcmop", Unstable(sym::riscv_target_feature), &["zca"]),
-    ("zdinx", Unstable(sym::riscv_target_feature), &["zfinx"]),
-    ("zfa", Unstable(sym::riscv_target_feature), &["f"]),
-    ("zfbfmin", Unstable(sym::riscv_target_feature), &["f"]), // and a subset of Zfhmin
-    ("zfh", Unstable(sym::riscv_target_feature), &["zfhmin"]),
-    ("zfhmin", Unstable(sym::riscv_target_feature), &["f"]),
-    ("zfinx", Unstable(sym::riscv_target_feature), &["zicsr"]),
-    ("zhinx", Unstable(sym::riscv_target_feature), &["zhinxmin"]),
-    ("zhinxmin", Unstable(sym::riscv_target_feature), &["zfinx"]),
-    ("zic64b", Unstable(sym::riscv_target_feature), &[]),
-    ("zicbom", Unstable(sym::riscv_target_feature), &[]),
-    ("zicbop", Unstable(sym::riscv_target_feature), &[]),
-    ("zicboz", Unstable(sym::riscv_target_feature), &[]),
-    ("ziccamoa", Unstable(sym::riscv_target_feature), &[]),
-    ("ziccif", Unstable(sym::riscv_target_feature), &[]),
-    ("zicclsm", Unstable(sym::riscv_target_feature), &[]),
-    ("ziccrse", Unstable(sym::riscv_target_feature), &[]),
-    ("zicntr", Unstable(sym::riscv_target_feature), &["zicsr"]),
-    ("zicond", Unstable(sym::riscv_target_feature), &[]),
-    ("zicsr", Unstable(sym::riscv_target_feature), &[]),
-    ("zifencei", Unstable(sym::riscv_target_feature), &[]),
-    ("zihintntl", Unstable(sym::riscv_target_feature), &[]),
-    ("zihintpause", Unstable(sym::riscv_target_feature), &[]),
-    ("zihpm", Unstable(sym::riscv_target_feature), &["zicsr"]),
-    ("zimop", Unstable(sym::riscv_target_feature), &[]),
-    ("zk", Stable, &["zkn", "zkr", "zkt"]),
-    ("zkn", Stable, &["zbkb", "zbkc", "zbkx", "zkne", "zknd", "zknh"]),
-    ("zknd", Stable, &[]),
-    ("zkne", Stable, &[]),
-    ("zknh", Stable, &[]),
-    ("zkr", Stable, &[]),
-    ("zks", Stable, &["zbkb", "zbkc", "zbkx", "zksed", "zksh"]),
-    ("zksed", Stable, &[]),
-    ("zksh", Stable, &[]),
-    ("zkt", Stable, &[]),
-    ("ztso", Unstable(sym::riscv_target_feature), &[]),
-    ("zvbb", Unstable(sym::riscv_target_feature), &["zvkb"]), // Zvbb ⊃ Zvkb
-    ("zvbc", Unstable(sym::riscv_target_feature), &["zve64x"]),
-    ("zve32f", Unstable(sym::riscv_target_feature), &["zve32x", "f"]),
-    ("zve32x", Unstable(sym::riscv_target_feature), &["zvl32b", "zicsr"]),
-    ("zve64d", Unstable(sym::riscv_target_feature), &["zve64f", "d"]),
-    ("zve64f", Unstable(sym::riscv_target_feature), &["zve32f", "zve64x"]),
-    ("zve64x", Unstable(sym::riscv_target_feature), &["zve32x", "zvl64b"]),
-    ("zvfbfmin", Unstable(sym::riscv_target_feature), &["zve32f"]),
-    ("zvfbfwma", Unstable(sym::riscv_target_feature), &["zfbfmin", "zvfbfmin"]),
-    ("zvfh", Unstable(sym::riscv_target_feature), &["zvfhmin", "zve32f", "zfhmin"]), // Zvfh ⊃ Zvfhmin
-    ("zvfhmin", Unstable(sym::riscv_target_feature), &["zve32f"]),
-    ("zvkb", Unstable(sym::riscv_target_feature), &["zve32x"]),
-    ("zvkg", Unstable(sym::riscv_target_feature), &["zve32x"]),
-    ("zvkn", Unstable(sym::riscv_target_feature), &["zvkned", "zvknhb", "zvkb", "zvkt"]),
-    ("zvknc", Unstable(sym::riscv_target_feature), &["zvkn", "zvbc"]),
-    ("zvkned", Unstable(sym::riscv_target_feature), &["zve32x"]),
-    ("zvkng", Unstable(sym::riscv_target_feature), &["zvkn", "zvkg"]),
-    ("zvknha", Unstable(sym::riscv_target_feature), &["zve32x"]),
-    ("zvknhb", Unstable(sym::riscv_target_feature), &["zvknha", "zve64x"]), // Zvknhb ⊃ Zvknha
-    ("zvks", Unstable(sym::riscv_target_feature), &["zvksed", "zvksh", "zvkb", "zvkt"]),
-    ("zvksc", Unstable(sym::riscv_target_feature), &["zvks", "zvbc"]),
-    ("zvksed", Unstable(sym::riscv_target_feature), &["zve32x"]),
-    ("zvksg", Unstable(sym::riscv_target_feature), &["zvks", "zvkg"]),
-    ("zvksh", Unstable(sym::riscv_target_feature), &["zve32x"]),
-    ("zvkt", Unstable(sym::riscv_target_feature), &[]),
-    ("zvl32b", Unstable(sym::riscv_target_feature), &[]),
-    ("zvl64b", Unstable(sym::riscv_target_feature), &["zvl32b"]),
-    ("zvl128b", Unstable(sym::riscv_target_feature), &["zvl64b"]),
-    ("zvl256b", Unstable(sym::riscv_target_feature), &["zvl128b"]),
-    ("zvl512b", Unstable(sym::riscv_target_feature), &["zvl256b"]),
-    ("zvl1024b", Unstable(sym::riscv_target_feature), &["zvl512b"]),
-    ("zvl2048b", Unstable(sym::riscv_target_feature), &["zvl1024b"]),
-    ("zvl4096b", Unstable(sym::riscv_target_feature), &["zvl2048b"]),
-    ("zvl8192b", Unstable(sym::riscv_target_feature), &["zvl4096b"]),
-    ("zvl16384b", Unstable(sym::riscv_target_feature), &["zvl8192b"]),
-    ("zvl32768b", Unstable(sym::riscv_target_feature), &["zvl16384b"]),
-    ("zvl65536b", Unstable(sym::riscv_target_feature), &["zvl32768b"]),
+    ("supm", Unstable(sym::riscv_target_feature), &[], false),
+    ("unaligned-scalar-mem", Unstable(sym::riscv_target_feature), &[], false),
+    ("unaligned-vector-mem", Unstable(sym::riscv_target_feature), &[], false),
+    ("v", Unstable(sym::riscv_target_feature), &["zvl128b", "zve64d"], false),
+    ("za64rs", Unstable(sym::riscv_target_feature), &["za128rs"], false), // Za64rs ⊃ Za128rs
+    ("za128rs", Unstable(sym::riscv_target_feature), &[], false),
+    ("zaamo", Unstable(sym::riscv_target_feature), &[], false),
+    ("zabha", Unstable(sym::riscv_target_feature), &["zaamo"], false),
+    ("zacas", Unstable(sym::riscv_target_feature), &["zaamo"], false),
+    ("zalrsc", Unstable(sym::riscv_target_feature), &[], false),
+    ("zama16b", Unstable(sym::riscv_target_feature), &[], false),
+    ("zawrs", Unstable(sym::riscv_target_feature), &[], false),
+    ("zba", Stable, &[], false),
+    ("zbb", Stable, &[], false),
+    ("zbc", Stable, &["zbkc"], false), // Zbc ⊃ Zbkc
+    ("zbkb", Stable, &[], false),
+    ("zbkc", Stable, &[], false),
+    ("zbkx", Stable, &[], false),
+    ("zbs", Stable, &[], false),
+    ("zca", Unstable(sym::riscv_target_feature), &[], false),
+    ("zcb", Unstable(sym::riscv_target_feature), &["zca"], false),
+    ("zcmop", Unstable(sym::riscv_target_feature), &["zca"], false),
+    ("zdinx", Unstable(sym::riscv_target_feature), &["zfinx"], false),
+    ("zfa", Unstable(sym::riscv_target_feature), &["f"], false),
+    ("zfbfmin", Unstable(sym::riscv_target_feature), &["f"], false), // and a subset of Zfhmin
+    ("zfh", Unstable(sym::riscv_target_feature), &["zfhmin"], false),
+    ("zfhmin", Unstable(sym::riscv_target_feature), &["f"], false),
+    ("zfinx", Unstable(sym::riscv_target_feature), &["zicsr"], false),
+    ("zhinx", Unstable(sym::riscv_target_feature), &["zhinxmin"], false),
+    ("zhinxmin", Unstable(sym::riscv_target_feature), &["zfinx"], false),
+    ("zic64b", Unstable(sym::riscv_target_feature), &[], false),
+    ("zicbom", Unstable(sym::riscv_target_feature), &[], false),
+    ("zicbop", Unstable(sym::riscv_target_feature), &[], false),
+    ("zicboz", Unstable(sym::riscv_target_feature), &[], false),
+    ("ziccamoa", Unstable(sym::riscv_target_feature), &[], false),
+    ("ziccif", Unstable(sym::riscv_target_feature), &[], false),
+    ("zicclsm", Unstable(sym::riscv_target_feature), &[], false),
+    ("ziccrse", Unstable(sym::riscv_target_feature), &[], false),
+    ("zicntr", Unstable(sym::riscv_target_feature), &["zicsr"], false),
+    ("zicond", Unstable(sym::riscv_target_feature), &[], false),
+    ("zicsr", Unstable(sym::riscv_target_feature), &[], false),
+    ("zifencei", Unstable(sym::riscv_target_feature), &[], false),
+    ("zihintntl", Unstable(sym::riscv_target_feature), &[], false),
+    ("zihintpause", Unstable(sym::riscv_target_feature), &[], false),
+    ("zihpm", Unstable(sym::riscv_target_feature), &["zicsr"], false),
+    ("zimop", Unstable(sym::riscv_target_feature), &[], false),
+    ("zk", Stable, &["zkn", "zkr", "zkt"], false),
+    ("zkn", Stable, &["zbkb", "zbkc", "zbkx", "zkne", "zknd", "zknh"], false),
+    ("zknd", Stable, &[], false),
+    ("zkne", Stable, &[], false),
+    ("zknh", Stable, &[], false),
+    ("zkr", Stable, &[], false),
+    ("zks", Stable, &["zbkb", "zbkc", "zbkx", "zksed", "zksh"], false),
+    ("zksed", Stable, &[], false),
+    ("zksh", Stable, &[], false),
+    ("zkt", Stable, &[], false),
+    ("ztso", Unstable(sym::riscv_target_feature), &[], false),
+    ("zvbb", Unstable(sym::riscv_target_feature), &["zvkb"], false), // Zvbb ⊃ Zvkb
+    ("zvbc", Unstable(sym::riscv_target_feature), &["zve64x"], false),
+    ("zve32f", Unstable(sym::riscv_target_feature), &["zve32x", "f"], false),
+    ("zve32x", Unstable(sym::riscv_target_feature), &["zvl32b", "zicsr"], false),
+    ("zve64d", Unstable(sym::riscv_target_feature), &["zve64f", "d"], false),
+    ("zve64f", Unstable(sym::riscv_target_feature), &["zve32f", "zve64x"], false),
+    ("zve64x", Unstable(sym::riscv_target_feature), &["zve32x", "zvl64b"], false),
+    ("zvfbfmin", Unstable(sym::riscv_target_feature), &["zve32f"], false),
+    ("zvfbfwma", Unstable(sym::riscv_target_feature), &["zfbfmin", "zvfbfmin"], false),
+    ("zvfh", Unstable(sym::riscv_target_feature), &["zvfhmin", "zve32f", "zfhmin"], false), // Zvfh ⊃ Zvfhmin
+    ("zvfhmin", Unstable(sym::riscv_target_feature), &["zve32f"], false),
+    ("zvkb", Unstable(sym::riscv_target_feature), &["zve32x"], false),
+    ("zvkg", Unstable(sym::riscv_target_feature), &["zve32x"], false),
+    ("zvkn", Unstable(sym::riscv_target_feature), &["zvkned", "zvknhb", "zvkb", "zvkt"], false),
+    ("zvknc", Unstable(sym::riscv_target_feature), &["zvkn", "zvbc"], false),
+    ("zvkned", Unstable(sym::riscv_target_feature), &["zve32x"], false),
+    ("zvkng", Unstable(sym::riscv_target_feature), &["zvkn", "zvkg"], false),
+    ("zvknha", Unstable(sym::riscv_target_feature), &["zve32x"], false),
+    ("zvknhb", Unstable(sym::riscv_target_feature), &["zvknha", "zve64x"], false), // Zvknhb ⊃ Zvknha
+    ("zvks", Unstable(sym::riscv_target_feature), &["zvksed", "zvksh", "zvkb", "zvkt"], false),
+    ("zvksc", Unstable(sym::riscv_target_feature), &["zvks", "zvbc"], false),
+    ("zvksed", Unstable(sym::riscv_target_feature), &["zve32x"], false),
+    ("zvksg", Unstable(sym::riscv_target_feature), &["zvks", "zvkg"], false),
+    ("zvksh", Unstable(sym::riscv_target_feature), &["zve32x"], false),
+    ("zvkt", Unstable(sym::riscv_target_feature), &[], false),
+    ("zvl32b", Unstable(sym::riscv_target_feature), &[], false),
+    ("zvl64b", Unstable(sym::riscv_target_feature), &["zvl32b"], false),
+    ("zvl128b", Unstable(sym::riscv_target_feature), &["zvl64b"], false),
+    ("zvl256b", Unstable(sym::riscv_target_feature), &["zvl128b"], false),
+    ("zvl512b", Unstable(sym::riscv_target_feature), &["zvl256b"], false),
+    ("zvl1024b", Unstable(sym::riscv_target_feature), &["zvl512b"], false),
+    ("zvl2048b", Unstable(sym::riscv_target_feature), &["zvl1024b"], false),
+    ("zvl4096b", Unstable(sym::riscv_target_feature), &["zvl2048b"], false),
+    ("zvl8192b", Unstable(sym::riscv_target_feature), &["zvl4096b"], false),
+    ("zvl16384b", Unstable(sym::riscv_target_feature), &["zvl8192b"], false),
+    ("zvl32768b", Unstable(sym::riscv_target_feature), &["zvl16384b"], false),
+    ("zvl65536b", Unstable(sym::riscv_target_feature), &["zvl32768b"], false),
     // tidy-alphabetical-end
 ];
 
-static WASM_FEATURES: &[(&str, Stability, ImpliedFeatures)] = &[
+static WASM_FEATURES: &[(&str, Stability, ImpliedFeatures, TargetModifier)] = &[
     // tidy-alphabetical-start
-    ("atomics", Unstable(sym::wasm_target_feature), &[]),
-    ("bulk-memory", Stable, &[]),
-    ("exception-handling", Unstable(sym::wasm_target_feature), &[]),
-    ("extended-const", Stable, &[]),
-    ("multivalue", Stable, &[]),
-    ("mutable-globals", Stable, &[]),
-    ("nontrapping-fptoint", Stable, &[]),
-    ("reference-types", Stable, &[]),
-    ("relaxed-simd", Stable, &["simd128"]),
-    ("sign-ext", Stable, &[]),
-    ("simd128", Stable, &[]),
-    ("tail-call", Stable, &[]),
-    ("wide-arithmetic", Unstable(sym::wasm_target_feature), &[]),
+    ("atomics", Unstable(sym::wasm_target_feature), &[], false),
+    ("bulk-memory", Stable, &[], false),
+    ("exception-handling", Unstable(sym::wasm_target_feature), &[], false),
+    ("extended-const", Stable, &[], false),
+    ("multivalue", Stable, &[], false),
+    ("mutable-globals", Stable, &[], false),
+    ("nontrapping-fptoint", Stable, &[], false),
+    ("reference-types", Stable, &[], false),
+    ("relaxed-simd", Stable, &["simd128"], false),
+    ("sign-ext", Stable, &[], false),
+    ("simd128", Stable, &[], false),
+    ("tail-call", Stable, &[], false),
+    ("wide-arithmetic", Unstable(sym::wasm_target_feature), &[], false),
     // tidy-alphabetical-end
 ];
 
-const BPF_FEATURES: &[(&str, Stability, ImpliedFeatures)] =
-    &[("alu32", Unstable(sym::bpf_target_feature), &[])];
+const BPF_FEATURES: &[(&str, Stability, ImpliedFeatures, TargetModifier)] =
+    &[("alu32", Unstable(sym::bpf_target_feature), &[], false)];
 
-static CSKY_FEATURES: &[(&str, Stability, ImpliedFeatures)] = &[
+static CSKY_FEATURES: &[(&str, Stability, ImpliedFeatures, TargetModifier)] = &[
     // tidy-alphabetical-start
-    ("2e3", Unstable(sym::csky_target_feature), &["e2"]),
-    ("3e3r1", Unstable(sym::csky_target_feature), &[]),
-    ("3e3r2", Unstable(sym::csky_target_feature), &["3e3r1", "doloop"]),
-    ("3e3r3", Unstable(sym::csky_target_feature), &["doloop"]),
-    ("3e7", Unstable(sym::csky_target_feature), &["2e3"]),
-    ("7e10", Unstable(sym::csky_target_feature), &["3e7"]),
-    ("10e60", Unstable(sym::csky_target_feature), &["7e10"]),
-    ("cache", Unstable(sym::csky_target_feature), &[]),
-    ("doloop", Unstable(sym::csky_target_feature), &[]),
-    ("dsp1e2", Unstable(sym::csky_target_feature), &[]),
-    ("dspe60", Unstable(sym::csky_target_feature), &[]),
-    ("e1", Unstable(sym::csky_target_feature), &["elrw"]),
-    ("e2", Unstable(sym::csky_target_feature), &["e2"]),
-    ("edsp", Unstable(sym::csky_target_feature), &[]),
-    ("elrw", Unstable(sym::csky_target_feature), &[]),
-    ("float1e2", Unstable(sym::csky_target_feature), &[]),
-    ("float1e3", Unstable(sym::csky_target_feature), &[]),
-    ("float3e4", Unstable(sym::csky_target_feature), &[]),
-    ("float7e60", Unstable(sym::csky_target_feature), &[]),
-    ("floate1", Unstable(sym::csky_target_feature), &[]),
-    ("hard-tp", Unstable(sym::csky_target_feature), &[]),
-    ("high-registers", Unstable(sym::csky_target_feature), &[]),
-    ("hwdiv", Unstable(sym::csky_target_feature), &[]),
-    ("mp", Unstable(sym::csky_target_feature), &["2e3"]),
-    ("mp1e2", Unstable(sym::csky_target_feature), &["3e7"]),
-    ("nvic", Unstable(sym::csky_target_feature), &[]),
-    ("trust", Unstable(sym::csky_target_feature), &[]),
-    ("vdsp2e60f", Unstable(sym::csky_target_feature), &[]),
-    ("vdspv1", Unstable(sym::csky_target_feature), &[]),
-    ("vdspv2", Unstable(sym::csky_target_feature), &[]),
+    ("2e3", Unstable(sym::csky_target_feature), &["e2"], false),
+    ("3e3r1", Unstable(sym::csky_target_feature), &[], false),
+    ("3e3r2", Unstable(sym::csky_target_feature), &["3e3r1", "doloop"], false),
+    ("3e3r3", Unstable(sym::csky_target_feature), &["doloop"], false),
+    ("3e7", Unstable(sym::csky_target_feature), &["2e3"], false),
+    ("7e10", Unstable(sym::csky_target_feature), &["3e7"], false),
+    ("10e60", Unstable(sym::csky_target_feature), &["7e10"], false),
+    ("cache", Unstable(sym::csky_target_feature), &[], false),
+    ("doloop", Unstable(sym::csky_target_feature), &[], false),
+    ("dsp1e2", Unstable(sym::csky_target_feature), &[], false),
+    ("dspe60", Unstable(sym::csky_target_feature), &[], false),
+    ("e1", Unstable(sym::csky_target_feature), &["elrw"], false),
+    ("e2", Unstable(sym::csky_target_feature), &["e2"], false),
+    ("edsp", Unstable(sym::csky_target_feature), &[], false),
+    ("elrw", Unstable(sym::csky_target_feature), &[], false),
+    ("float1e2", Unstable(sym::csky_target_feature), &[], false),
+    ("float1e3", Unstable(sym::csky_target_feature), &[], false),
+    ("float3e4", Unstable(sym::csky_target_feature), &[], false),
+    ("float7e60", Unstable(sym::csky_target_feature), &[], false),
+    ("floate1", Unstable(sym::csky_target_feature), &[], false),
+    ("hard-tp", Unstable(sym::csky_target_feature), &[], false),
+    ("high-registers", Unstable(sym::csky_target_feature), &[], false),
+    ("hwdiv", Unstable(sym::csky_target_feature), &[], false),
+    ("mp", Unstable(sym::csky_target_feature), &["2e3"], false),
+    ("mp1e2", Unstable(sym::csky_target_feature), &["3e7"], false),
+    ("nvic", Unstable(sym::csky_target_feature), &[], false),
+    ("trust", Unstable(sym::csky_target_feature), &[], false),
+    ("vdsp2e60f", Unstable(sym::csky_target_feature), &[], false),
+    ("vdspv1", Unstable(sym::csky_target_feature), &[], false),
+    ("vdspv2", Unstable(sym::csky_target_feature), &[], false),
     // tidy-alphabetical-end
     //fpu
     // tidy-alphabetical-start
-    ("fdivdu", Unstable(sym::csky_target_feature), &[]),
-    ("fpuv2_df", Unstable(sym::csky_target_feature), &[]),
-    ("fpuv2_sf", Unstable(sym::csky_target_feature), &[]),
-    ("fpuv3_df", Unstable(sym::csky_target_feature), &[]),
-    ("fpuv3_hf", Unstable(sym::csky_target_feature), &[]),
-    ("fpuv3_hi", Unstable(sym::csky_target_feature), &[]),
-    ("fpuv3_sf", Unstable(sym::csky_target_feature), &[]),
-    ("hard-float", Unstable(sym::csky_target_feature), &[]),
-    ("hard-float-abi", Unstable(sym::csky_target_feature), &[]),
+    ("fdivdu", Unstable(sym::csky_target_feature), &[], false),
+    ("fpuv2_df", Unstable(sym::csky_target_feature), &[], false),
+    ("fpuv2_sf", Unstable(sym::csky_target_feature), &[], false),
+    ("fpuv3_df", Unstable(sym::csky_target_feature), &[], false),
+    ("fpuv3_hf", Unstable(sym::csky_target_feature), &[], false),
+    ("fpuv3_hi", Unstable(sym::csky_target_feature), &[], false),
+    ("fpuv3_sf", Unstable(sym::csky_target_feature), &[], false),
+    ("hard-float", Unstable(sym::csky_target_feature), &[], false),
+    ("hard-float-abi", Unstable(sym::csky_target_feature), &[], false),
     // tidy-alphabetical-end
 ];
 
-static LOONGARCH_FEATURES: &[(&str, Stability, ImpliedFeatures)] = &[
+static LOONGARCH_FEATURES: &[(&str, Stability, ImpliedFeatures, TargetModifier)] = &[
     // tidy-alphabetical-start
-    ("32s", Unstable(sym::loongarch_target_feature), &[]),
-    ("d", Stable, &["f"]),
-    ("div32", Unstable(sym::loongarch_target_feature), &[]),
-    ("f", Stable, &[]),
-    ("frecipe", Stable, &[]),
-    ("lam-bh", Unstable(sym::loongarch_target_feature), &[]),
-    ("lamcas", Unstable(sym::loongarch_target_feature), &[]),
-    ("lasx", Stable, &["lsx"]),
-    ("lbt", Stable, &[]),
-    ("ld-seq-sa", Unstable(sym::loongarch_target_feature), &[]),
-    ("lsx", Stable, &["d"]),
-    ("lvz", Stable, &[]),
-    ("relax", Unstable(sym::loongarch_target_feature), &[]),
-    ("scq", Unstable(sym::loongarch_target_feature), &[]),
-    ("ual", Unstable(sym::loongarch_target_feature), &[]),
+    ("32s", Unstable(sym::loongarch_target_feature), &[], false),
+    ("d", Stable, &["f"], false),
+    ("div32", Unstable(sym::loongarch_target_feature), &[], false),
+    ("f", Stable, &[], false),
+    ("frecipe", Stable, &[], false),
+    ("lam-bh", Unstable(sym::loongarch_target_feature), &[], false),
+    ("lamcas", Unstable(sym::loongarch_target_feature), &[], false),
+    ("lasx", Stable, &["lsx"], false),
+    ("lbt", Stable, &[], false),
+    ("ld-seq-sa", Unstable(sym::loongarch_target_feature), &[], false),
+    ("lsx", Stable, &["d"], false),
+    ("lvz", Stable, &[], false),
+    ("relax", Unstable(sym::loongarch_target_feature), &[], false),
+    ("scq", Unstable(sym::loongarch_target_feature), &[], false),
+    ("ual", Unstable(sym::loongarch_target_feature), &[], false),
     // tidy-alphabetical-end
 ];
 
 #[rustfmt::skip]
-const IBMZ_FEATURES: &[(&str, Stability, ImpliedFeatures)] = &[
+const IBMZ_FEATURES: &[(&str, Stability, ImpliedFeatures, TargetModifier)] = &[
     // tidy-alphabetical-start
     // For "backchain", https://github.com/rust-lang/rust/issues/142412 is a stabilization blocker
-    ("backchain", Unstable(sym::s390x_target_feature), &[]),
-    ("concurrent-functions", Unstable(sym::s390x_target_feature), &[]),
-    ("deflate-conversion", Unstable(sym::s390x_target_feature), &[]),
-    ("enhanced-sort", Unstable(sym::s390x_target_feature), &[]),
-    ("guarded-storage", Unstable(sym::s390x_target_feature), &[]),
-    ("high-word", Unstable(sym::s390x_target_feature), &[]),
+    ("backchain", Unstable(sym::s390x_target_feature), &[], false),
+    ("concurrent-functions", Unstable(sym::s390x_target_feature), &[], false),
+    ("deflate-conversion", Unstable(sym::s390x_target_feature), &[], false),
+    ("enhanced-sort", Unstable(sym::s390x_target_feature), &[], false),
+    ("guarded-storage", Unstable(sym::s390x_target_feature), &[], false),
+    ("high-word", Unstable(sym::s390x_target_feature), &[], false),
     // LLVM does not define message-security-assist-extension versions 1, 2, 6, 10 and 11.
-    ("message-security-assist-extension3", Unstable(sym::s390x_target_feature), &[]),
-    ("message-security-assist-extension4", Unstable(sym::s390x_target_feature), &[]),
-    ("message-security-assist-extension5", Unstable(sym::s390x_target_feature), &[]),
-    ("message-security-assist-extension8", Unstable(sym::s390x_target_feature), &["message-security-assist-extension3"]),
-    ("message-security-assist-extension9", Unstable(sym::s390x_target_feature), &["message-security-assist-extension3", "message-security-assist-extension4"]),
-    ("message-security-assist-extension12", Unstable(sym::s390x_target_feature), &[]),
-    ("miscellaneous-extensions-2", Unstable(sym::s390x_target_feature), &[]),
-    ("miscellaneous-extensions-3", Unstable(sym::s390x_target_feature), &[]),
-    ("miscellaneous-extensions-4", Unstable(sym::s390x_target_feature), &[]),
-    ("nnp-assist", Unstable(sym::s390x_target_feature), &["vector"]),
-    ("soft-float", Forbidden { reason: "currently unsupported ABI-configuration feature" }, &[]),
-    ("transactional-execution", Unstable(sym::s390x_target_feature), &[]),
-    ("vector", Unstable(sym::s390x_target_feature), &[]),
-    ("vector-enhancements-1", Unstable(sym::s390x_target_feature), &["vector"]),
-    ("vector-enhancements-2", Unstable(sym::s390x_target_feature), &["vector-enhancements-1"]),
-    ("vector-enhancements-3", Unstable(sym::s390x_target_feature), &["vector-enhancements-2"]),
-    ("vector-packed-decimal", Unstable(sym::s390x_target_feature), &["vector"]),
-    ("vector-packed-decimal-enhancement", Unstable(sym::s390x_target_feature), &["vector-packed-decimal"]),
-    ("vector-packed-decimal-enhancement-2", Unstable(sym::s390x_target_feature), &["vector-packed-decimal-enhancement"]),
-    ("vector-packed-decimal-enhancement-3", Unstable(sym::s390x_target_feature), &["vector-packed-decimal-enhancement-2"]),
+    ("message-security-assist-extension3", Unstable(sym::s390x_target_feature), &[], false),
+    ("message-security-assist-extension4", Unstable(sym::s390x_target_feature), &[], false),
+    ("message-security-assist-extension5", Unstable(sym::s390x_target_feature), &[], false),
+    ("message-security-assist-extension8", Unstable(sym::s390x_target_feature), &["message-security-assist-extension3"], false),
+    ("message-security-assist-extension9", Unstable(sym::s390x_target_feature), &["message-security-assist-extension3", "message-security-assist-extension4"], false),
+    ("message-security-assist-extension12", Unstable(sym::s390x_target_feature), &[], false),
+    ("miscellaneous-extensions-2", Unstable(sym::s390x_target_feature), &[], false),
+    ("miscellaneous-extensions-3", Unstable(sym::s390x_target_feature), &[], false),
+    ("miscellaneous-extensions-4", Unstable(sym::s390x_target_feature), &[], false),
+    ("nnp-assist", Unstable(sym::s390x_target_feature), &["vector"], false),
+    ("soft-float", Forbidden { reason: "currently unsupported ABI-configuration feature" }, &[], false),
+    ("transactional-execution", Unstable(sym::s390x_target_feature), &[], false),
+    ("vector", Unstable(sym::s390x_target_feature), &[], false),
+    ("vector-enhancements-1", Unstable(sym::s390x_target_feature), &["vector"], false),
+    ("vector-enhancements-2", Unstable(sym::s390x_target_feature), &["vector-enhancements-1"], false),
+    ("vector-enhancements-3", Unstable(sym::s390x_target_feature), &["vector-enhancements-2"], false),
+    ("vector-packed-decimal", Unstable(sym::s390x_target_feature), &["vector"], false),
+    ("vector-packed-decimal-enhancement", Unstable(sym::s390x_target_feature), &["vector-packed-decimal"], false),
+    ("vector-packed-decimal-enhancement-2", Unstable(sym::s390x_target_feature), &["vector-packed-decimal-enhancement"], false),
+    ("vector-packed-decimal-enhancement-3", Unstable(sym::s390x_target_feature), &["vector-packed-decimal-enhancement-2"], false),
     // tidy-alphabetical-end
 ];
 
-const SPARC_FEATURES: &[(&str, Stability, ImpliedFeatures)] = &[
+const SPARC_FEATURES: &[(&str, Stability, ImpliedFeatures, TargetModifier)] = &[
     // tidy-alphabetical-start
-    ("leoncasa", Unstable(sym::sparc_target_feature), &[]),
-    ("v8plus", Unstable(sym::sparc_target_feature), &[]),
-    ("v9", Unstable(sym::sparc_target_feature), &[]),
+    ("leoncasa", Unstable(sym::sparc_target_feature), &[], false),
+    ("v8plus", Unstable(sym::sparc_target_feature), &[], false),
+    ("v9", Unstable(sym::sparc_target_feature), &[], false),
     // tidy-alphabetical-end
 ];
 
-static M68K_FEATURES: &[(&str, Stability, ImpliedFeatures)] = &[
+static M68K_FEATURES: &[(&str, Stability, ImpliedFeatures, TargetModifier)] = &[
     // tidy-alphabetical-start
-    ("isa-68000", Unstable(sym::m68k_target_feature), &[]),
-    ("isa-68010", Unstable(sym::m68k_target_feature), &["isa-68000"]),
-    ("isa-68020", Unstable(sym::m68k_target_feature), &["isa-68010"]),
-    ("isa-68030", Unstable(sym::m68k_target_feature), &["isa-68020"]),
-    ("isa-68040", Unstable(sym::m68k_target_feature), &["isa-68030", "isa-68882"]),
-    ("isa-68060", Unstable(sym::m68k_target_feature), &["isa-68040"]),
+    ("isa-68000", Unstable(sym::m68k_target_feature), &[], false),
+    ("isa-68010", Unstable(sym::m68k_target_feature), &["isa-68000"], false),
+    ("isa-68020", Unstable(sym::m68k_target_feature), &["isa-68010"], false),
+    ("isa-68030", Unstable(sym::m68k_target_feature), &["isa-68020"], false),
+    ("isa-68040", Unstable(sym::m68k_target_feature), &["isa-68030", "isa-68882"], false),
+    ("isa-68060", Unstable(sym::m68k_target_feature), &["isa-68040"], false),
     // FPU
-    ("isa-68881", Unstable(sym::m68k_target_feature), &[]),
-    ("isa-68882", Unstable(sym::m68k_target_feature), &["isa-68881"]),
+    ("isa-68881", Unstable(sym::m68k_target_feature), &[], false),
+    ("isa-68882", Unstable(sym::m68k_target_feature), &["isa-68881"], false),
     // tidy-alphabetical-end
 ];
 
@@ -905,7 +937,7 @@ pub fn all_rust_features() -> impl Iterator<Item = (&'static str, Stability)> {
         .chain(SPARC_FEATURES)
         .chain(M68K_FEATURES)
         .cloned()
-        .map(|(f, s, _)| (f, s))
+        .map(|(f, s, _, _)| (f, s))
 }
 
 // These arrays represent the least-constraining feature that is required for vector types up to a
@@ -954,7 +986,9 @@ pub struct FeatureConstraints {
 }
 
 impl Target {
-    pub fn rust_target_features(&self) -> &'static [(&'static str, Stability, ImpliedFeatures)] {
+    pub fn rust_target_features(
+        &self,
+    ) -> &'static [(&'static str, Stability, ImpliedFeatures, TargetModifier)] {
         match &*self.arch {
             "arm" => ARM_FEATURES,
             "aarch64" | "arm64ec" => AARCH64_FEATURES,
@@ -1005,8 +1039,11 @@ impl Target {
 
     // Note: the returned set includes `base_feature`.
     pub fn implied_target_features<'a>(&self, base_feature: &'a str) -> FxHashSet<&'a str> {
-        let implied_features =
-            self.rust_target_features().iter().map(|(f, _, i)| (f, i)).collect::<FxHashMap<_, _>>();
+        let implied_features = self
+            .rust_target_features()
+            .iter()
+            .map(|(f, _, i, _)| (f, i))
+            .collect::<FxHashMap<_, _>>();
 
         // Implied target features have their own implied target features, so we traverse the
         // map until there are no more features to add.

--- a/src/librustdoc/json/mod.rs
+++ b/src/librustdoc/json/mod.rs
@@ -135,7 +135,7 @@ fn target(sess: &rustc_session::Session) -> types::Target {
         .rust_target_features()
         .iter()
         .copied()
-        .map(|(name, stability, _)| (name, stability))
+        .map(|(name, stability, _, _)| (name, stability))
         .collect();
 
     types::Target {
@@ -145,11 +145,11 @@ fn target(sess: &rustc_session::Session) -> types::Target {
             .rust_target_features()
             .iter()
             .copied()
-            .filter(|(_, stability, _)| {
+            .filter(|(_, stability, _, _)| {
                 // Describe only target features which the user can toggle
                 stability.toggle_allowed().is_ok()
             })
-            .map(|(name, stability, implied_features)| {
+            .map(|(name, stability, implied_features, _)| {
                 types::TargetFeature {
                     name: name.into(),
                     unstable_feature_gate: match stability {

--- a/src/tools/tidy/src/style.rs
+++ b/src/tools/tidy/src/style.rs
@@ -215,7 +215,7 @@ fn should_ignore(line: &str) -> bool {
     // For `ui_test`-style UI test directives, also ignore
     // - `//@[rev] compile-flags`
     // - `//@[rev] normalize-stderr`
-        || static_regex!("\\s*//@(\\[.*\\]) (compile-flags|normalize-stderr|error-pattern).*")
+        || static_regex!("\\s*//@ *(\\[.*\\]) (compile-flags|normalize-stderr|error-pattern).*")
             .is_match(line)
         // Matching for rustdoc tests commands.
         // It allows to prevent them emitting warnings like `line longer than 100 chars`.

--- a/tests/assembly-llvm/wasm_exceptions.rs
+++ b/tests/assembly-llvm/wasm_exceptions.rs
@@ -1,6 +1,6 @@
 //@ only-wasm32
 //@ assembly-output: emit-asm
-//@ compile-flags: -C target-feature=+exception-handling
+//@ compile-flags: -C target-feature=+exception-handling -C unsafe-allow-abi-mismatch=target-feature
 //@ compile-flags: -C panic=unwind
 
 #![crate_type = "lib"]

--- a/tests/codegen-llvm/unwind-abis/c-unwind-abi-panic-abort.rs
+++ b/tests/codegen-llvm/unwind-abis/c-unwind-abi-panic-abort.rs
@@ -3,7 +3,7 @@
 //@ [NONWASM] ignore-wasm32
 //@ [WASM] only-wasm32
 //@ [WASMEXN] only-wasm32
-//@ [WASMEXN] compile-flags: -Ctarget-feature=+exception-handling
+//@ [WASMEXN] compile-flags: -Ctarget-feature=+exception-handling -C unsafe-allow-abi-mismatch=target-feature
 
 // Test that `nounwind` attributes are also applied to extern `C-unwind` Rust functions
 // when the code is compiled with `panic=abort`.

--- a/tests/codegen-llvm/unwind-and-panic-abort.rs
+++ b/tests/codegen-llvm/unwind-and-panic-abort.rs
@@ -3,7 +3,7 @@
 //@ [NONWASM] ignore-wasm32
 //@ [WASM] only-wasm32
 //@ [WASMEXN] only-wasm32
-//@ [WASMEXN] compile-flags: -Ctarget-feature=+exception-handling
+//@ [WASMEXN] compile-flags: -Ctarget-feature=+exception-handling -C unsafe-allow-abi-mismatch=target-feature
 
 #![crate_type = "lib"]
 

--- a/tests/run-make/wasm-exceptions-nostd/rmake.rs
+++ b/tests/run-make/wasm-exceptions-nostd/rmake.rs
@@ -12,6 +12,7 @@ fn main() {
         .panic("unwind")
         .arg("-Cllvm-args=-wasm-enable-eh")
         .arg("-Ctarget-feature=+exception-handling")
+        .arg("-Cunsafe-allow-abi-mismatch=target-feature")
         .run();
 
     cmd(&env_var("NODE")).arg("verify.mjs").arg("lib.wasm").run();


### PR DESCRIPTION
Adds the ability to make any target feature a target modifier.
Specifically makes Wasm target features `atomics` and `exception-handling` target modifiers

Tracking issue: rust-lang/rust#136966.

r? @alexcrichton

---

### Draft

Would like to get some initial feedback on the implementation and the green light from @alexcrichton if this makes sense in the first place.

Still missing tests as well.