### PR TITLE
Implement the MCP 932: Promote riscv64a23-unknown-linux-gnu to Tier 2

### DIFF
--- a/compiler/rustc_target/src/spec/targets/riscv64a23_unknown_linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/targets/riscv64a23_unknown_linux_gnu.rs
@@ -7,8 +7,8 @@ pub(crate) fn target() -> Target {
         llvm_target: "riscv64-unknown-linux-gnu".into(),
         metadata: TargetMetadata {
             description: Some("RISC-V Linux (kernel 6.8.0, glibc 2.39)".into()),
-            tier: Some(3),
-            host_tools: Some(true),
+            tier: Some(2),
+            host_tools: Some(false),
             std: Some(true),
         },
         pointer_width: 64,

--- a/src/ci/docker/host-x86_64/dist-riscv64-linux/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-riscv64-linux/Dockerfile
@@ -22,9 +22,13 @@ ENV PATH=$PATH:/x-tools/riscv64-unknown-linux-gnu/bin
 
 ENV CC_riscv64gc_unknown_linux_gnu=riscv64-unknown-linux-gnu-gcc \
     AR_riscv64gc_unknown_linux_gnu=riscv64-unknown-linux-gnu-ar \
-    CXX_riscv64gc_unknown_linux_gnu=riscv64-unknown-linux-gnu-g++
+    CXX_riscv64gc_unknown_linux_gnu=riscv64-unknown-linux-gnu-g++ \
+    CC_riscv64a23_unknown_linux_gnu=riscv64-unknown-linux-gnu-gcc \
+    AR_riscv64a23_unknown_linux_gnu=riscv64-unknown-linux-gnu-ar \
+    CXX_riscv64a23_unknown_linux_gnu=riscv64-unknown-linux-gnu-g++
 
 ENV HOSTS=riscv64gc-unknown-linux-gnu
+ENV TARGETS=riscv64gc-unknown-linux-gnu,riscv64a23-unknown-linux-gnu
 
 ENV RUST_CONFIGURE_ARGS --enable-extended --enable-profiler --disable-docs
-ENV SCRIPT python3 ../x.py dist --target $HOSTS --host $HOSTS
+ENV SCRIPT python3 ../x.py dist --target $TARGETS --host $HOSTS

--- a/src/doc/rustc/src/platform-support/riscv64a23-unknown-linux-gnu.md
+++ b/src/doc/rustc/src/platform-support/riscv64a23-unknown-linux-gnu.md
@@ -1,6 +1,6 @@
 # `riscv64a23-unknown-linux-gnu`
 
-**Tier: 3**
+**Tier: 2 (without Host Tools)**
 
 RISC-V target using the ratified [RVA23 Profile](https://github.com/riscv/riscv-profiles/blob/main/src/rva23-profile.adoc).
 This target will enable all mandary features of rva23u64 by default.
@@ -18,24 +18,26 @@ Other platforms may work, but are not tested. Please contanct if you encounter a
 
 ## Building the target
 
-Tier-3 target is not distributed through `rustup`.
-
-You need to build your own Rust, the target can be build with:
+Tier-2 targets are distributed through `rustup`. Install the target with:
 
 ```bash
-./x build --target riscv64a23-unknown-linux-gnu
+rustup target add riscv64a23-unknown-linux-gnu
 ```
 
 ## Building Rust programs
 
-Add the toolchain:
+Cross compile crates with:
 
 ```bash
-rustup toolchain link rva23-toolchain {path-to-rust}/build/host/stage2
+cargo build --target=riscv64a23-unknown-linux-gnu
 ```
 
-Then cross compile crates with:
+For cross-compilation, you may need to install the appropriate linker:
 
 ```bash
-RUSTFLAGS="-C linker=riscv64-linux-gnu-gcc" cargo +rva23-toolchain build --target=riscv64a23-unknown-linux-gnu
+# Ubuntu/Debian
+sudo apt-get install gcc-riscv64-linux-gnu
+
+# Then set the linker
+RUSTFLAGS="-C linker=riscv64-linux-gnu-gcc" cargo build --target=riscv64a23-unknown-linux-gnu
 ```


### PR DESCRIPTION
Implement the [MCP 932](https://github.com/rust-lang/compiler-team/issues/932): Promote riscv64a23-unknown-linux-gnu to Tier 2 without host tools.

Closes rust-lang/rust#148353.

Changes:
- Update target tier from 3 to 2 in target specification
- Update platform documentation
- Add CI/CD support for automatic building and distribution via rustup

r? jieyouxu
cc @davidtwco @Noratrieb 
