### PR TITLE
Regression test for undefined `__chkstk` on `aarch64-unknown-uefi`

### DIFF
--- a/src/tools/compiletest/src/directives/directive_names.rs
+++ b/src/tools/compiletest/src/directives/directive_names.rs
@@ -190,6 +190,7 @@ pub(crate) const KNOWN_DIRECTIVE_NAMES: &[&str] = &[
     "only-aarch64",
     "only-aarch64-apple-darwin",
     "only-aarch64-unknown-linux-gnu",
+    "only-aarch64-unknown-uefi",
     "only-apple",
     "only-arm",
     "only-arm64ec",

--- a/tests/ui/stack-probes/aarch64-unknown-uefi-chkstk-98254.rs
+++ b/tests/ui/stack-probes/aarch64-unknown-uefi-chkstk-98254.rs
@@ -1,0 +1,16 @@
+//! Regression test for #98254, missing `__chkstk` symbol on `aarch64-unknown-uefi`.
+//@ build-pass
+//@ only-aarch64-unknown-uefi
+//@ compile-flags: -Cpanic=abort
+//@ compile-flags: -Clinker=rust-lld
+#![no_std]
+#![no_main]
+#[panic_handler]
+fn panic_handler(_info: &core::panic::PanicInfo) -> ! {
+    loop {}
+}
+
+#[export_name = "efi_main"]
+fn main() {
+    let b = [0; 1024];
+}


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
Adds a test for compiling a block of code with target `aarch64-unknown-uefi`.

Closes https://github.com/rust-lang/rust/issues/98254