### PR TITLE
Tweak E0401

### DIFF
--- a/compiler/rustc_resolve/messages.ftl
+++ b/compiler/rustc_resolve/messages.ftl
@@ -175,6 +175,7 @@ resolve_generic_params_from_outer_item =
     } from outer item
     .refer_to_type_directly = refer to the type directly here instead
     .suggestion = try introducing a local generic parameter here
+    .note = nested items are independent from their parent item for everything except for privacy and name resolution
 
 resolve_generic_params_from_outer_item_const = a `const` is a separate item from the item that contains it
 

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -558,6 +558,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 has_generic_params,
                 def_kind,
                 inner_item,
+                current_self_ty,
             } => {
                 use errs::GenericParamsFromOuterItemLabel as Label;
                 let static_or_const = match def_kind {
@@ -595,7 +596,8 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                             sm,
                             self.def_span(def_id),
                         )));
-                        err.refer_to_type_directly = Some(span);
+                        err.refer_to_type_directly =
+                            current_self_ty.map(|snippet| errs::UseTypeDirectly { span, snippet });
                         return self.dcx().create_err(err);
                     }
                     Res::Def(DefKind::TyParam, def_id) => {

--- a/compiler/rustc_resolve/src/errors.rs
+++ b/compiler/rustc_resolve/src/errors.rs
@@ -17,8 +17,8 @@ pub(crate) struct GenericParamsFromOuterItem {
     pub(crate) span: Span,
     #[subdiagnostic]
     pub(crate) label: Option<GenericParamsFromOuterItemLabel>,
-    #[label(resolve_refer_to_type_directly)]
-    pub(crate) refer_to_type_directly: Option<Span>,
+    #[subdiagnostic]
+    pub(crate) refer_to_type_directly: Option<UseTypeDirectly>,
     #[subdiagnostic]
     pub(crate) sugg: Option<GenericParamsFromOuterItemSugg>,
     #[subdiagnostic]
@@ -64,6 +64,18 @@ pub(crate) enum GenericParamsFromOuterItemLabel {
     style = "verbose"
 )]
 pub(crate) struct GenericParamsFromOuterItemSugg {
+    #[primary_span]
+    pub(crate) span: Span,
+    pub(crate) snippet: String,
+}
+#[derive(Subdiagnostic)]
+#[suggestion(
+    resolve_refer_to_type_directly,
+    code = "{snippet}",
+    applicability = "maybe-incorrect",
+    style = "verbose"
+)]
+pub(crate) struct UseTypeDirectly {
     #[primary_span]
     pub(crate) span: Span,
     pub(crate) snippet: String,

--- a/compiler/rustc_resolve/src/errors.rs
+++ b/compiler/rustc_resolve/src/errors.rs
@@ -11,6 +11,7 @@ use crate::{Res, fluent_generated as fluent};
 
 #[derive(Diagnostic)]
 #[diag(resolve_generic_params_from_outer_item, code = E0401)]
+#[note]
 pub(crate) struct GenericParamsFromOuterItem {
     #[primary_span]
     #[label]

--- a/compiler/rustc_resolve/src/ident.rs
+++ b/compiler/rustc_resolve/src/ident.rs
@@ -326,7 +326,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                     i,
                     rib_ident,
                     *res,
-                    finalize.map(|finalize| finalize.path_span),
+                    finalize.map(|_| general_span),
                     *original_rib_ident_def,
                     ribs,
                     diag_metadata,

--- a/compiler/rustc_resolve/src/ident.rs
+++ b/compiler/rustc_resolve/src/ident.rs
@@ -1415,6 +1415,11 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                                 has_generic_params,
                                 def_kind,
                                 inner_item: item,
+                                current_self_ty: diag_metadata
+                                    .and_then(|m| m.current_self_type.as_ref())
+                                    .and_then(|ty| {
+                                        self.tcx.sess.source_map().span_to_snippet(ty.span).ok()
+                                    }),
                             },
                         );
                     }
@@ -1503,6 +1508,11 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                                 has_generic_params,
                                 def_kind,
                                 inner_item: item,
+                                current_self_ty: diag_metadata
+                                    .and_then(|m| m.current_self_type.as_ref())
+                                    .and_then(|ty| {
+                                        self.tcx.sess.source_map().span_to_snippet(ty.span).ok()
+                                    }),
                             },
                         );
                     }

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -675,7 +675,7 @@ pub(crate) struct DiagMetadata<'ast> {
     current_trait_assoc_items: Option<&'ast [Box<AssocItem>]>,
 
     /// The current self type if inside an impl (used for better errors).
-    current_self_type: Option<Ty>,
+    pub(crate) current_self_type: Option<Ty>,
 
     /// The current self item if inside an ADT (used for better errors).
     current_self_item: Option<NodeId>,

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -246,6 +246,7 @@ enum ResolutionError<'ra> {
         has_generic_params: HasGenericParams,
         def_kind: DefKind,
         inner_item: Option<(Span, ast::ItemKind)>,
+        current_self_ty: Option<String>,
     },
     /// Error E0403: the name is already used for a type or const parameter in this generic
     /// parameter list.

--- a/tests/ui/associated-item/associated-item-duplicate-bounds.stderr
+++ b/tests/ui/associated-item/associated-item-duplicate-bounds.stderr
@@ -2,7 +2,7 @@ error: generic parameters may not be used in const operations
   --> $DIR/associated-item-duplicate-bounds.rs:7:18
    |
 LL |     links: [u32; A::LINKS], // Shouldn't suggest bounds already there.
-   |                  ^^^^^^^^ cannot perform const operation using `A`
+   |                  ^ cannot perform const operation using `A`
    |
    = note: type parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions

--- a/tests/ui/const-generics/early/const-param-from-outer-fn.stderr
+++ b/tests/ui/const-generics/early/const-param-from-outer-fn.stderr
@@ -8,6 +8,7 @@ LL |     fn bar() -> u32 {
 LL |         X
    |         ^ use of generic parameter from outer item
    |
+   = note: nested items are independent from their parent item for everything except for privacy and name resolution
 help: try introducing a local generic parameter here
    |
 LL |     fn bar<X>() -> u32 {

--- a/tests/ui/delegation/target-expr.stderr
+++ b/tests/ui/delegation/target-expr.stderr
@@ -8,6 +8,8 @@ LL |     reuse Trait::static_method {
 LL |
 LL |         let _ = T::Default();
    |                 ^ use of generic parameter from outer item
+   |
+   = note: nested items are independent from their parent item for everything except for privacy and name resolution
 
 error[E0434]: can't capture dynamic environment in a fn item
   --> $DIR/target-expr.rs:26:17

--- a/tests/ui/delegation/target-expr.stderr
+++ b/tests/ui/delegation/target-expr.stderr
@@ -7,7 +7,7 @@ LL |     reuse Trait::static_method {
    |                  ------------- generic parameter used in this inner delegated function
 LL |
 LL |         let _ = T::Default();
-   |                 ^^^^^^^^^^ use of generic parameter from outer item
+   |                 ^ use of generic parameter from outer item
 
 error[E0434]: can't capture dynamic environment in a fn item
   --> $DIR/target-expr.rs:26:17

--- a/tests/ui/error-codes/E0401.stderr
+++ b/tests/ui/error-codes/E0401.stderr
@@ -8,6 +8,7 @@ LL |     fn bfnr<U, V: Baz<U>, W: Fn()>(y: T) {
    |        |
    |        generic parameter used in this inner function
    |
+   = note: nested items are independent from their parent item for everything except for privacy and name resolution
 help: try introducing a local generic parameter here
    |
 LL |     fn bfnr<T, U, V: Baz<U>, W: Fn()>(y: T) {
@@ -25,6 +26,7 @@ LL |     fn baz<U,
 LL |            (y: T) {
    |                ^ use of generic parameter from outer item
    |
+   = note: nested items are independent from their parent item for everything except for privacy and name resolution
 help: try introducing a local generic parameter here
    |
 LL |     fn baz<T, U,
@@ -41,6 +43,7 @@ LL |         fn helper(sel: &Self) -> u8 {
    |            |
    |            `Self` used in this inner function
    |
+   = note: nested items are independent from their parent item for everything except for privacy and name resolution
 help: refer to the type directly here instead
    |
 LL -         fn helper(sel: &Self) -> u8 {

--- a/tests/ui/error-codes/E0401.stderr
+++ b/tests/ui/error-codes/E0401.stderr
@@ -37,11 +37,15 @@ LL | impl<T> Iterator for A<T> {
    | ---- `Self` type implicitly declared here, by this `impl`
 ...
 LL |         fn helper(sel: &Self) -> u8 {
-   |            ------       ^^^^
-   |            |            |
-   |            |            use of `Self` from outer item
-   |            |            refer to the type directly here instead
+   |            ------       ^^^^ use of `Self` from outer item
+   |            |
    |            `Self` used in this inner function
+   |
+help: refer to the type directly here instead
+   |
+LL -         fn helper(sel: &Self) -> u8 {
+LL +         fn helper(sel: &A<T>) -> u8 {
+   |
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/generics/enum-definition-with-outer-generic-parameter-5997.stderr
+++ b/tests/ui/generics/enum-definition-with-outer-generic-parameter-5997.stderr
@@ -8,6 +8,7 @@ LL |     enum E { V(Z) }
    |          |
    |          generic parameter used in this inner enum
    |
+   = note: nested items are independent from their parent item for everything except for privacy and name resolution
 help: try introducing a local generic parameter here
    |
 LL |     enum E<Z> { V(Z) }

--- a/tests/ui/generics/generic-params-nested-fn-scope-error.stderr
+++ b/tests/ui/generics/generic-params-nested-fn-scope-error.stderr
@@ -8,6 +8,7 @@ LL |     fn bar(w: [U]) -> U {
    |        |
    |        generic parameter used in this inner function
    |
+   = note: nested items are independent from their parent item for everything except for privacy and name resolution
 help: try introducing a local generic parameter here
    |
 LL |     fn bar<U>(w: [U]) -> U {
@@ -23,6 +24,7 @@ LL |     fn bar(w: [U]) -> U {
    |        |
    |        generic parameter used in this inner function
    |
+   = note: nested items are independent from their parent item for everything except for privacy and name resolution
 help: try introducing a local generic parameter here
    |
 LL |     fn bar<U>(w: [U]) -> U {

--- a/tests/ui/generics/invalid-type-param-default.stderr
+++ b/tests/ui/generics/invalid-type-param-default.stderr
@@ -2,7 +2,7 @@ error[E0128]: generic parameter defaults cannot reference parameters before they
   --> $DIR/invalid-type-param-default.rs:12:12
    |
 LL | fn mdn<T = T::Item>(_: T) {}
-   |            ^^^^^^^ cannot reference `T` before it is declared
+   |            ^ cannot reference `T` before it is declared
 
 error: defaults for generic parameters are not allowed here
   --> $DIR/invalid-type-param-default.rs:7:8

--- a/tests/ui/generics/issue-98432.stderr
+++ b/tests/ui/generics/issue-98432.stderr
@@ -9,6 +9,7 @@ LL |         struct _Obligation where T:;
    |                |
    |                generic parameter used in this inner struct
    |
+   = note: nested items are independent from their parent item for everything except for privacy and name resolution
 help: try introducing a local generic parameter here
    |
 LL |         struct _Obligation<T> where T:;

--- a/tests/ui/resolve/bad-type-env-capture.stderr
+++ b/tests/ui/resolve/bad-type-env-capture.stderr
@@ -8,6 +8,7 @@ LL |     fn bar(b: T) { }
    |        |
    |        generic parameter used in this inner function
    |
+   = note: nested items are independent from their parent item for everything except for privacy and name resolution
 help: try introducing a local generic parameter here
    |
 LL |     fn bar<T>(b: T) { }

--- a/tests/ui/resolve/generic-params-from-outer-item-in-const-item.default.stderr
+++ b/tests/ui/resolve/generic-params-from-outer-item-in-const-item.default.stderr
@@ -4,7 +4,7 @@ error[E0401]: can't use generic parameters from outer item
 LL | fn outer<T: Tr>() { // outer function
    |          - type parameter from outer item
 LL |     const K: u32 = T::C;
-   |           -        ^^^^ use of generic parameter from outer item
+   |           -        ^ use of generic parameter from outer item
    |           |
    |           generic parameter used in this inner constant item
    |
@@ -17,7 +17,7 @@ LL | impl<T> Tr for T { // outer impl block
    |      - type parameter from outer item
 LL |     const C: u32 = {
 LL |         const I: u32 = T::C;
-   |               -        ^^^^ use of generic parameter from outer item
+   |               -        ^ use of generic parameter from outer item
    |               |
    |               generic parameter used in this inner constant item
    |
@@ -29,7 +29,7 @@ error[E0401]: can't use generic parameters from outer item
 LL | struct S<T: Tr>(U32<{ // outer struct
    |          - type parameter from outer item
 LL |     const _: u32 = T::C;
-   |           -        ^^^^ use of generic parameter from outer item
+   |           -        ^ use of generic parameter from outer item
    |           |
    |           generic parameter used in this inner constant item
    |

--- a/tests/ui/resolve/generic-params-from-outer-item-in-const-item.default.stderr
+++ b/tests/ui/resolve/generic-params-from-outer-item-in-const-item.default.stderr
@@ -8,6 +8,7 @@ LL |     const K: u32 = T::C;
    |           |
    |           generic parameter used in this inner constant item
    |
+   = note: nested items are independent from their parent item for everything except for privacy and name resolution
    = note: a `const` is a separate item from the item that contains it
 
 error[E0401]: can't use generic parameters from outer item
@@ -21,6 +22,7 @@ LL |         const I: u32 = T::C;
    |               |
    |               generic parameter used in this inner constant item
    |
+   = note: nested items are independent from their parent item for everything except for privacy and name resolution
    = note: a `const` is a separate item from the item that contains it
 
 error[E0401]: can't use generic parameters from outer item
@@ -33,6 +35,7 @@ LL |     const _: u32 = T::C;
    |           |
    |           generic parameter used in this inner constant item
    |
+   = note: nested items are independent from their parent item for everything except for privacy and name resolution
    = note: a `const` is a separate item from the item that contains it
 
 error: aborting due to 3 previous errors

--- a/tests/ui/resolve/generic-params-from-outer-item-in-const-item.generic_const_items.stderr
+++ b/tests/ui/resolve/generic-params-from-outer-item-in-const-item.generic_const_items.stderr
@@ -4,7 +4,7 @@ error[E0401]: can't use generic parameters from outer item
 LL | fn outer<T: Tr>() { // outer function
    |          - type parameter from outer item
 LL |     const K: u32 = T::C;
-   |           -        ^^^^ use of generic parameter from outer item
+   |           -        ^ use of generic parameter from outer item
    |           |
    |           generic parameter used in this inner constant item
    |
@@ -21,7 +21,7 @@ LL | impl<T> Tr for T { // outer impl block
    |      - type parameter from outer item
 LL |     const C: u32 = {
 LL |         const I: u32 = T::C;
-   |               -        ^^^^ use of generic parameter from outer item
+   |               -        ^ use of generic parameter from outer item
    |               |
    |               generic parameter used in this inner constant item
    |
@@ -37,7 +37,7 @@ error[E0401]: can't use generic parameters from outer item
 LL | struct S<T: Tr>(U32<{ // outer struct
    |          - type parameter from outer item
 LL |     const _: u32 = T::C;
-   |           -        ^^^^ use of generic parameter from outer item
+   |           -        ^ use of generic parameter from outer item
    |           |
    |           generic parameter used in this inner constant item
    |

--- a/tests/ui/resolve/generic-params-from-outer-item-in-const-item.generic_const_items.stderr
+++ b/tests/ui/resolve/generic-params-from-outer-item-in-const-item.generic_const_items.stderr
@@ -8,6 +8,7 @@ LL |     const K: u32 = T::C;
    |           |
    |           generic parameter used in this inner constant item
    |
+   = note: nested items are independent from their parent item for everything except for privacy and name resolution
    = note: a `const` is a separate item from the item that contains it
 help: try introducing a local generic parameter here
    |
@@ -25,6 +26,7 @@ LL |         const I: u32 = T::C;
    |               |
    |               generic parameter used in this inner constant item
    |
+   = note: nested items are independent from their parent item for everything except for privacy and name resolution
    = note: a `const` is a separate item from the item that contains it
 help: try introducing a local generic parameter here
    |
@@ -41,6 +43,7 @@ LL |     const _: u32 = T::C;
    |           |
    |           generic parameter used in this inner constant item
    |
+   = note: nested items are independent from their parent item for everything except for privacy and name resolution
    = note: a `const` is a separate item from the item that contains it
 help: try introducing a local generic parameter here
    |

--- a/tests/ui/resolve/issue-12796.stderr
+++ b/tests/ui/resolve/issue-12796.stderr
@@ -7,6 +7,8 @@ LL |         fn inner(_: &Self) {
    |            |         use of `Self` from outer item
    |            |         can't use `Self` here
    |            `Self` used in this inner function
+   |
+   = note: nested items are independent from their parent item for everything except for privacy and name resolution
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/resolve/issue-3021-c.stderr
+++ b/tests/ui/resolve/issue-3021-c.stderr
@@ -9,6 +9,7 @@ LL |     trait U {
 LL |         fn g(&self, x: T) -> T;
    |                        ^ use of generic parameter from outer item
    |
+   = note: nested items are independent from their parent item for everything except for privacy and name resolution
 help: try introducing a local generic parameter here
    |
 LL |     trait U<T> {
@@ -25,6 +26,7 @@ LL |     trait U {
 LL |         fn g(&self, x: T) -> T;
    |                              ^ use of generic parameter from outer item
    |
+   = note: nested items are independent from their parent item for everything except for privacy and name resolution
 help: try introducing a local generic parameter here
    |
 LL |     trait U<T> {

--- a/tests/ui/resolve/issue-3214.stderr
+++ b/tests/ui/resolve/issue-3214.stderr
@@ -8,6 +8,7 @@ LL |     struct Foo {
 LL |         x: T,
    |            ^ use of generic parameter from outer item
    |
+   = note: nested items are independent from their parent item for everything except for privacy and name resolution
 help: try introducing a local generic parameter here
    |
 LL |     struct Foo<T> {

--- a/tests/ui/resolve/issue-39559.stderr
+++ b/tests/ui/resolve/issue-39559.stderr
@@ -2,7 +2,7 @@ error: generic parameters may not be used in const operations
   --> $DIR/issue-39559.rs:14:18
    |
 LL |     entries: [T; D::dim()],
-   |                  ^^^^^^ cannot perform const operation using `D`
+   |                  ^ cannot perform const operation using `D`
    |
    = note: type parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions

--- a/tests/ui/resolve/issue-65025-extern-static-parent-generics.stderr
+++ b/tests/ui/resolve/issue-65025-extern-static-parent-generics.stderr
@@ -10,6 +10,7 @@ LL | |
 LL | |     }
    | |_____- generic parameter used in this inner extern block
    |
+   = note: nested items are independent from their parent item for everything except for privacy and name resolution
    = note: a `static` is a separate item from the item that contains it
 
 error: aborting due to 1 previous error

--- a/tests/ui/resolve/issue-65035-static-with-parent-generics.stderr
+++ b/tests/ui/resolve/issue-65035-static-with-parent-generics.stderr
@@ -10,6 +10,7 @@ LL | |
 LL | |     }
    | |_____- generic parameter used in this inner extern block
    |
+   = note: nested items are independent from their parent item for everything except for privacy and name resolution
    = note: a `static` is a separate item from the item that contains it
 
 error[E0401]: can't use generic parameters from outer item
@@ -22,6 +23,7 @@ LL |     static a: *const T = Default::default();
    |            |
    |            generic parameter used in this inner static item
    |
+   = note: nested items are independent from their parent item for everything except for privacy and name resolution
    = note: a `static` is a separate item from the item that contains it
 
 error[E0401]: can't use generic parameters from outer item
@@ -36,6 +38,7 @@ LL | |
 LL | |     }
    | |_____- generic parameter used in this inner extern block
    |
+   = note: nested items are independent from their parent item for everything except for privacy and name resolution
    = note: a `static` is a separate item from the item that contains it
 
 error[E0401]: can't use generic parameters from outer item
@@ -48,6 +51,7 @@ LL |     static a: [u8; N] = [0; N];
    |            |
    |            generic parameter used in this inner static item
    |
+   = note: nested items are independent from their parent item for everything except for privacy and name resolution
    = note: a `static` is a separate item from the item that contains it
 
 error[E0401]: can't use generic parameters from outer item
@@ -60,6 +64,7 @@ LL |     static a: [u8; N] = [0; N];
    |            |
    |            generic parameter used in this inner static item
    |
+   = note: nested items are independent from their parent item for everything except for privacy and name resolution
    = note: a `static` is a separate item from the item that contains it
 
 error: aborting due to 5 previous errors

--- a/tests/ui/resolve/resolve-type-param-in-item-in-trait.stderr
+++ b/tests/ui/resolve/resolve-type-param-in-item-in-trait.stderr
@@ -9,6 +9,7 @@ LL |         enum Foo<B> {
 LL |             Variance(A)
    |                      ^ use of generic parameter from outer item
    |
+   = note: nested items are independent from their parent item for everything except for privacy and name resolution
 help: try introducing a local generic parameter here
    |
 LL |         enum Foo<A, B> {
@@ -25,6 +26,7 @@ LL |         struct Foo<B>(A);
    |                |
    |                generic parameter used in this inner struct
    |
+   = note: nested items are independent from their parent item for everything except for privacy and name resolution
 help: try introducing a local generic parameter here
    |
 LL |         struct Foo<A, B>(A);
@@ -41,6 +43,7 @@ LL |         struct Foo<B> { a: A }
    |                |
    |                generic parameter used in this inner struct
    |
+   = note: nested items are independent from their parent item for everything except for privacy and name resolution
 help: try introducing a local generic parameter here
    |
 LL |         struct Foo<A, B> { a: A }
@@ -57,6 +60,7 @@ LL |         fn foo<B>(a: A) { }
    |            |
    |            generic parameter used in this inner function
    |
+   = note: nested items are independent from their parent item for everything except for privacy and name resolution
 help: try introducing a local generic parameter here
    |
 LL |         fn foo<A, B>(a: A) { }

--- a/tests/ui/resolve/use-self-in-inner-fn.rs
+++ b/tests/ui/resolve/use-self-in-inner-fn.rs
@@ -8,6 +8,7 @@ impl A {
         //~| NOTE use of `Self` from outer item
         //~| NOTE `Self` used in this inner function
         //~| HELP refer to the type directly here instead
+        //~| NOTE nested items are independent from their
         }
     }
 }
@@ -27,6 +28,7 @@ impl MyEnum {
             //~^ ERROR can't use `Self` from outer item
             //~| NOTE use of `Self` from outer item
             //~| HELP refer to the type directly here instead
+            //~| NOTE nested items are independent from their
             MyEnum::do_something(move || {});
         }
         inner();

--- a/tests/ui/resolve/use-self-in-inner-fn.rs
+++ b/tests/ui/resolve/use-self-in-inner-fn.rs
@@ -7,8 +7,29 @@ impl A {
         //~^ ERROR can't use `Self` from outer item
         //~| NOTE use of `Self` from outer item
         //~| NOTE `Self` used in this inner function
-        //~| NOTE refer to the type directly here instead
+        //~| HELP refer to the type directly here instead
         }
+    }
+}
+
+enum MyEnum {}
+
+impl MyEnum {
+//~^ NOTE `Self` type implicitly declared here, by this `impl`
+    fn do_something(result: impl FnOnce()) {
+        result();
+    }
+
+    fn do_something_extra() {
+        fn inner() {
+        //~^ NOTE `Self` used in this inner function
+            Self::do_something(move || {});
+            //~^ ERROR can't use `Self` from outer item
+            //~| NOTE use of `Self` from outer item
+            //~| HELP refer to the type directly here instead
+            MyEnum::do_something(move || {});
+        }
+        inner();
     }
 }
 

--- a/tests/ui/resolve/use-self-in-inner-fn.stderr
+++ b/tests/ui/resolve/use-self-in-inner-fn.stderr
@@ -25,12 +25,12 @@ LL |         fn inner() {
    |            ----- `Self` used in this inner function
 LL |
 LL |             Self::do_something(move || {});
-   |             ^^^^^^^^^^^^^^^^^^ use of `Self` from outer item
+   |             ^^^^ use of `Self` from outer item
    |
 help: refer to the type directly here instead
    |
 LL -             Self::do_something(move || {});
-LL +             MyEnum(move || {});
+LL +             MyEnum::do_something(move || {});
    |
 
 error: aborting due to 2 previous errors

--- a/tests/ui/resolve/use-self-in-inner-fn.stderr
+++ b/tests/ui/resolve/use-self-in-inner-fn.stderr
@@ -15,6 +15,24 @@ LL -         fn peach(this: &Self) {
 LL +         fn peach(this: &A) {
    |
 
-error: aborting due to 1 previous error
+error[E0401]: can't use `Self` from outer item
+  --> $DIR/use-self-in-inner-fn.rs:26:13
+   |
+LL | impl MyEnum {
+   | ---- `Self` type implicitly declared here, by this `impl`
+...
+LL |         fn inner() {
+   |            ----- `Self` used in this inner function
+LL |
+LL |             Self::do_something(move || {});
+   |             ^^^^^^^^^^^^^^^^^^ use of `Self` from outer item
+   |
+help: refer to the type directly here instead
+   |
+LL -             Self::do_something(move || {});
+LL +             MyEnum(move || {});
+   |
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0401`.

--- a/tests/ui/resolve/use-self-in-inner-fn.stderr
+++ b/tests/ui/resolve/use-self-in-inner-fn.stderr
@@ -9,6 +9,7 @@ LL |         fn peach(this: &Self) {
    |            |
    |            `Self` used in this inner function
    |
+   = note: nested items are independent from their parent item for everything except for privacy and name resolution
 help: refer to the type directly here instead
    |
 LL -         fn peach(this: &Self) {
@@ -16,7 +17,7 @@ LL +         fn peach(this: &A) {
    |
 
 error[E0401]: can't use `Self` from outer item
-  --> $DIR/use-self-in-inner-fn.rs:26:13
+  --> $DIR/use-self-in-inner-fn.rs:27:13
    |
 LL | impl MyEnum {
    | ---- `Self` type implicitly declared here, by this `impl`
@@ -27,6 +28,7 @@ LL |
 LL |             Self::do_something(move || {});
    |             ^^^^ use of `Self` from outer item
    |
+   = note: nested items are independent from their parent item for everything except for privacy and name resolution
 help: refer to the type directly here instead
    |
 LL -             Self::do_something(move || {});

--- a/tests/ui/resolve/use-self-in-inner-fn.stderr
+++ b/tests/ui/resolve/use-self-in-inner-fn.stderr
@@ -5,11 +5,15 @@ LL | impl A {
    | ---- `Self` type implicitly declared here, by this `impl`
 ...
 LL |         fn peach(this: &Self) {
-   |            -----        ^^^^
-   |            |            |
-   |            |            use of `Self` from outer item
-   |            |            refer to the type directly here instead
+   |            -----        ^^^^ use of `Self` from outer item
+   |            |
    |            `Self` used in this inner function
+   |
+help: refer to the type directly here instead
+   |
+LL -         fn peach(this: &Self) {
+LL +         fn peach(this: &A) {
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/statics/static-generic-param-soundness.stderr
+++ b/tests/ui/statics/static-generic-param-soundness.stderr
@@ -8,6 +8,7 @@ LL |     static a: Bar<T> = Bar::What;
    |            |
    |            generic parameter used in this inner static item
    |
+   = note: nested items are independent from their parent item for everything except for privacy and name resolution
    = note: a `static` is a separate item from the item that contains it
 
 error[E0392]: type parameter `T` is never used

--- a/tests/ui/type/pattern_types/assoc_const.default.stderr
+++ b/tests/ui/type/pattern_types/assoc_const.default.stderr
@@ -20,7 +20,7 @@ error: generic parameters may not be used in const operations
   --> $DIR/assoc_const.rs:20:40
    |
 LL | fn bar<T: Foo>(_: pattern_type!(u32 is T::START..=T::END)) {}
-   |                                        ^^^^^^^^ cannot perform const operation using `T`
+   |                                        ^ cannot perform const operation using `T`
    |
    = note: type parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
@@ -29,7 +29,7 @@ error: generic parameters may not be used in const operations
   --> $DIR/assoc_const.rs:20:51
    |
 LL | fn bar<T: Foo>(_: pattern_type!(u32 is T::START..=T::END)) {}
-   |                                                   ^^^^^^ cannot perform const operation using `T`
+   |                                                   ^ cannot perform const operation using `T`
    |
    = note: type parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions

--- a/tests/ui/type/type-arg-out-of-scope.stderr
+++ b/tests/ui/type/type-arg-out-of-scope.stderr
@@ -8,6 +8,7 @@ LL |     fn bar(f: Box<dyn FnMut(T) -> T>) { }
    |        |
    |        generic parameter used in this inner function
    |
+   = note: nested items are independent from their parent item for everything except for privacy and name resolution
 help: try introducing a local generic parameter here
    |
 LL |     fn bar<T>(f: Box<dyn FnMut(T) -> T>) { }
@@ -23,6 +24,7 @@ LL |     fn bar(f: Box<dyn FnMut(T) -> T>) { }
    |        |
    |        generic parameter used in this inner function
    |
+   = note: nested items are independent from their parent item for everything except for privacy and name resolution
 help: try introducing a local generic parameter here
    |
 LL |     fn bar<T>(f: Box<dyn FnMut(T) -> T>) { }


### PR DESCRIPTION
More accurate span pointing at use place of outer param (at ident instead of full path).

Add note explaining why outer item params can't be used in inner item.

Use structured suggestion for what `Self` should have been.

Follow up to rust-lang/rust#148370.

Fix rust-lang/rust#37892.