### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/compiler/rustc_abi/src/layout.rs
+++ b/compiler/rustc_abi/src/layout.rs
@@ -812,7 +812,7 @@ impl<Cx: HasDataLayout> LayoutCalculator<Cx> {
         let (max, min) = largest_niche
             // We might have no inhabited variants, so pretend there's at least one.
             .unwrap_or((0, 0));
-        let (min_ity, signed) = discr_range_of_repr(min, max); //Integer::repr_discr(tcx, ty, &repr, min, max);
+        let (min_ity, signed) = discr_range_of_repr(min, max); //Integer::discr_range_of_repr(tcx, ty, &repr, min, max);
 
         let mut align = dl.aggregate_align;
         let mut max_repr_align = repr.align;

--- a/compiler/rustc_abi/src/lib.rs
+++ b/compiler/rustc_abi/src/lib.rs
@@ -183,6 +183,11 @@ impl ReprOptions {
 
     /// Returns the discriminant type, given these `repr` options.
     /// This must only be called on enums!
+    ///
+    /// This is the "typeck type" of the discriminant, which is effectively the maximum size:
+    /// discriminant values will be wrapped to fit (with a lint). Layout can later decide to use a
+    /// smaller type for the tag that stores the discriminant at runtime and that will work just
+    /// fine, it just induces casts when getting/setting the discriminant.
     pub fn discr_type(&self) -> IntegerType {
         self.int.unwrap_or(IntegerType::Pointer(true))
     }

--- a/compiler/rustc_attr_parsing/src/attributes/cfg.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/cfg.rs
@@ -19,6 +19,7 @@ use crate::context::{AcceptContext, ShouldEmit, Stage};
 use crate::parser::{ArgParser, MetaItemListParser, MetaItemOrLitParser, NameValueParser};
 use crate::session_diagnostics::{
     AttributeParseError, AttributeParseErrorReason, CfgAttrBadDelim, MetaBadDelimSugg,
+    ParsedDescription,
 };
 use crate::{
     AttributeParser, CfgMatchesLintEmitter, fluent_generated, parse_version, session_diagnostics,
@@ -352,7 +353,8 @@ pub fn parse_cfg_attr(
                 span,
                 attr_span: cfg_attr.span,
                 template: CFG_ATTR_TEMPLATE,
-                attribute: AttrPath::from_ast(&cfg_attr.get_normal_item().path),
+                path: AttrPath::from_ast(&cfg_attr.get_normal_item().path),
+                description: ParsedDescription::Attribute,
                 reason,
                 suggestions: CFG_ATTR_TEMPLATE.suggestions(Some(cfg_attr.style), sym::cfg_attr),
             });
@@ -395,6 +397,7 @@ fn parse_cfg_attr_internal<'a>(
                 .into_boxed_slice(),
             span: attribute.span,
         },
+        ParsedDescription::Attribute,
         pred_span,
         CRATE_NODE_ID,
         features,

--- a/compiler/rustc_attr_parsing/src/attributes/cfg.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/cfg.rs
@@ -12,7 +12,7 @@ use rustc_session::config::ExpectedValues;
 use rustc_session::lint::BuiltinLintDiag;
 use rustc_session::lint::builtin::UNEXPECTED_CFGS;
 use rustc_session::parse::{ParseSess, feature_err};
-use rustc_span::{Span, Symbol, sym};
+use rustc_span::{ErrorGuaranteed, Span, Symbol, sym};
 use thin_vec::ThinVec;
 
 use crate::context::{AcceptContext, ShouldEmit, Stage};
@@ -47,20 +47,19 @@ pub fn parse_cfg<'c, S: Stage>(
         cx.expected_single_argument(list.span);
         return None;
     };
-    parse_cfg_entry(cx, single)
+    parse_cfg_entry(cx, single).ok()
 }
 
 pub(crate) fn parse_cfg_entry<S: Stage>(
     cx: &mut AcceptContext<'_, '_, S>,
     item: &MetaItemOrLitParser<'_>,
-) -> Option<CfgEntry> {
-    Some(match item {
+) -> Result<CfgEntry, ErrorGuaranteed> {
+    Ok(match item {
         MetaItemOrLitParser::MetaItemParser(meta) => match meta.args() {
             ArgParser::List(list) => match meta.path().word_sym() {
                 Some(sym::not) => {
                     let Some(single) = list.single() else {
-                        cx.expected_single_argument(list.span);
-                        return None;
+                        return Err(cx.expected_single_argument(list.span));
                     };
                     CfgEntry::Not(Box::new(parse_cfg_entry(cx, single)?), list.span)
                 }
@@ -75,29 +74,24 @@ pub(crate) fn parse_cfg_entry<S: Stage>(
                 Some(sym::target) => parse_cfg_entry_target(cx, list, meta.span())?,
                 Some(sym::version) => parse_cfg_entry_version(cx, list, meta.span())?,
                 _ => {
-                    cx.emit_err(session_diagnostics::InvalidPredicate {
+                    return Err(cx.emit_err(session_diagnostics::InvalidPredicate {
                         span: meta.span(),
                         predicate: meta.path().to_string(),
-                    });
-                    return None;
+                    }));
                 }
             },
             a @ (ArgParser::NoArgs | ArgParser::NameValue(_)) => {
                 let Some(name) = meta.path().word_sym() else {
-                    cx.expected_identifier(meta.path().span());
-                    return None;
+                    return Err(cx.expected_identifier(meta.path().span()));
                 };
                 parse_name_value(name, meta.path().span(), a.name_value(), meta.span(), cx)?
             }
         },
         MetaItemOrLitParser::Lit(lit) => match lit.kind {
             LitKind::Bool(b) => CfgEntry::Bool(b, lit.span),
-            _ => {
-                cx.expected_identifier(lit.span);
-                return None;
-            }
+            _ => return Err(cx.expected_identifier(lit.span)),
         },
-        MetaItemOrLitParser::Err(_, _) => return None,
+        MetaItemOrLitParser::Err(_, err) => return Err(*err),
     })
 }
 
@@ -105,19 +99,22 @@ fn parse_cfg_entry_version<S: Stage>(
     cx: &mut AcceptContext<'_, '_, S>,
     list: &MetaItemListParser<'_>,
     meta_span: Span,
-) -> Option<CfgEntry> {
+) -> Result<CfgEntry, ErrorGuaranteed> {
     try_gate_cfg(sym::version, meta_span, cx.sess(), cx.features_option());
     let Some(version) = list.single() else {
-        cx.emit_err(session_diagnostics::ExpectedSingleVersionLiteral { span: list.span });
-        return None;
+        return Err(
+            cx.emit_err(session_diagnostics::ExpectedSingleVersionLiteral { span: list.span })
+        );
     };
     let Some(version_lit) = version.lit() else {
-        cx.emit_err(session_diagnostics::ExpectedVersionLiteral { span: version.span() });
-        return None;
+        return Err(
+            cx.emit_err(session_diagnostics::ExpectedVersionLiteral { span: version.span() })
+        );
     };
     let Some(version_str) = version_lit.value_str() else {
-        cx.emit_err(session_diagnostics::ExpectedVersionLiteral { span: version_lit.span });
-        return None;
+        return Err(
+            cx.emit_err(session_diagnostics::ExpectedVersionLiteral { span: version_lit.span })
+        );
     };
 
     let min_version = parse_version(version_str).or_else(|| {
@@ -127,14 +124,14 @@ fn parse_cfg_entry_version<S: Stage>(
         None
     });
 
-    Some(CfgEntry::Version(min_version, list.span))
+    Ok(CfgEntry::Version(min_version, list.span))
 }
 
 fn parse_cfg_entry_target<S: Stage>(
     cx: &mut AcceptContext<'_, '_, S>,
     list: &MetaItemListParser<'_>,
     meta_span: Span,
-) -> Option<CfgEntry> {
+) -> Result<CfgEntry, ErrorGuaranteed> {
     if let Some(features) = cx.features_option()
         && !features.cfg_target_compact()
     {
@@ -161,17 +158,16 @@ fn parse_cfg_entry_target<S: Stage>(
 
         // Then, parse it as a name-value item
         let Some(name) = sub_item.path().word_sym() else {
-            cx.expected_identifier(sub_item.path().span());
-            return None;
+            return Err(cx.expected_identifier(sub_item.path().span()));
         };
         let name = Symbol::intern(&format!("target_{name}"));
-        if let Some(cfg) =
+        if let Ok(cfg) =
             parse_name_value(name, sub_item.path().span(), Some(nv), sub_item.span(), cx)
         {
             result.push(cfg);
         }
     }
-    Some(CfgEntry::All(result, list.span))
+    Ok(CfgEntry::All(result, list.span))
 }
 
 fn parse_name_value<S: Stage>(
@@ -180,21 +176,22 @@ fn parse_name_value<S: Stage>(
     value: Option<&NameValueParser>,
     span: Span,
     cx: &mut AcceptContext<'_, '_, S>,
-) -> Option<CfgEntry> {
+) -> Result<CfgEntry, ErrorGuaranteed> {
     try_gate_cfg(name, span, cx.sess(), cx.features_option());
 
     let value = match value {
         None => None,
         Some(value) => {
             let Some(value_str) = value.value_as_str() else {
-                cx.expected_string_literal(value.value_span, Some(value.value_as_lit()));
-                return None;
+                return Err(
+                    cx.expected_string_literal(value.value_span, Some(value.value_as_lit()))
+                );
             };
             Some((value_str, value.value_span))
         }
     };
 
-    Some(CfgEntry::NameValue { name, name_span, value, span })
+    Ok(CfgEntry::NameValue { name, name_span, value, span })
 }
 
 pub fn eval_config_entry(
@@ -406,7 +403,8 @@ fn parse_cfg_attr_internal<'a>(
         parse_cfg_entry,
         &CFG_ATTR_TEMPLATE,
     )
-    .ok_or_else(|| {
+    .map_err(|_err: ErrorGuaranteed| {
+        // We have an `ErrorGuaranteed` so this delayed bug cannot fail, but we need a `Diag` for the `PResult` so we make one anyways
         let mut diag = sess.dcx().struct_err(
             "cfg_entry parsing failing with `ShouldEmit::ErrorsAndLints` should emit a error.",
         );

--- a/compiler/rustc_attr_parsing/src/attributes/cfg.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/cfg.rs
@@ -50,7 +50,7 @@ pub fn parse_cfg<'c, S: Stage>(
     parse_cfg_entry(cx, single).ok()
 }
 
-pub(crate) fn parse_cfg_entry<S: Stage>(
+pub fn parse_cfg_entry<S: Stage>(
     cx: &mut AcceptContext<'_, '_, S>,
     item: &MetaItemOrLitParser<'_>,
 ) -> Result<CfgEntry, ErrorGuaranteed> {

--- a/compiler/rustc_attr_parsing/src/attributes/link_attrs.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/link_attrs.rs
@@ -396,7 +396,7 @@ impl LinkParser {
             )
             .emit();
         }
-        *cfg = parse_cfg_entry(cx, link_cfg);
+        *cfg = parse_cfg_entry(cx, link_cfg).ok();
         true
     }
 

--- a/compiler/rustc_attr_parsing/src/context.rs
+++ b/compiler/rustc_attr_parsing/src/context.rs
@@ -71,7 +71,9 @@ use crate::attributes::traits::{
 use crate::attributes::transparency::TransparencyParser;
 use crate::attributes::{AttributeParser as _, Combine, Single, WithoutArgs};
 use crate::parser::{ArgParser, PathParser};
-use crate::session_diagnostics::{AttributeParseError, AttributeParseErrorReason, UnknownMetaItem};
+use crate::session_diagnostics::{
+    AttributeParseError, AttributeParseErrorReason, ParsedDescription, UnknownMetaItem,
+};
 use crate::target_checking::AllowedTargets;
 
 type GroupType<S> = LazyLock<GroupTypeInner<S>>;
@@ -353,6 +355,10 @@ pub struct AcceptContext<'f, 'sess, S: Stage> {
     /// Whether it is an inner or outer attribute
     pub(crate) attr_style: AttrStyle,
 
+    /// A description of the thing we are parsing using this attribute parser
+    /// We are not only using these parsers for attributes, but also for macros such as the `cfg!()` macro.
+    pub(crate) parsed_description: ParsedDescription,
+
     /// The expected structure of the attribute.
     ///
     /// Used in reporting errors to give a hint to users what the attribute *should* look like.
@@ -431,7 +437,8 @@ impl<'f, 'sess: 'f, S: Stage> AcceptContext<'f, 'sess, S> {
             span,
             attr_span: self.attr_span,
             template: self.template.clone(),
-            attribute: self.attr_path.clone(),
+            path: self.attr_path.clone(),
+            description: self.parsed_description,
             reason: AttributeParseErrorReason::ExpectedStringLiteral {
                 byte_string: actual_literal.and_then(|i| {
                     i.kind.is_bytestr().then(|| self.sess().source_map().start_point(i.span))
@@ -446,7 +453,8 @@ impl<'f, 'sess: 'f, S: Stage> AcceptContext<'f, 'sess, S> {
             span,
             attr_span: self.attr_span,
             template: self.template.clone(),
-            attribute: self.attr_path.clone(),
+            path: self.attr_path.clone(),
+            description: self.parsed_description,
             reason: AttributeParseErrorReason::ExpectedIntegerLiteral,
             suggestions: self.suggestions(),
         })
@@ -457,7 +465,8 @@ impl<'f, 'sess: 'f, S: Stage> AcceptContext<'f, 'sess, S> {
             span,
             attr_span: self.attr_span,
             template: self.template.clone(),
-            attribute: self.attr_path.clone(),
+            path: self.attr_path.clone(),
+            description: self.parsed_description,
             reason: AttributeParseErrorReason::ExpectedList,
             suggestions: self.suggestions(),
         })
@@ -468,7 +477,8 @@ impl<'f, 'sess: 'f, S: Stage> AcceptContext<'f, 'sess, S> {
             span: args_span,
             attr_span: self.attr_span,
             template: self.template.clone(),
-            attribute: self.attr_path.clone(),
+            path: self.attr_path.clone(),
+            description: self.parsed_description,
             reason: AttributeParseErrorReason::ExpectedNoArgs,
             suggestions: self.suggestions(),
         })
@@ -480,7 +490,8 @@ impl<'f, 'sess: 'f, S: Stage> AcceptContext<'f, 'sess, S> {
             span,
             attr_span: self.attr_span,
             template: self.template.clone(),
-            attribute: self.attr_path.clone(),
+            path: self.attr_path.clone(),
+            description: self.parsed_description,
             reason: AttributeParseErrorReason::ExpectedIdentifier,
             suggestions: self.suggestions(),
         })
@@ -493,7 +504,8 @@ impl<'f, 'sess: 'f, S: Stage> AcceptContext<'f, 'sess, S> {
             span,
             attr_span: self.attr_span,
             template: self.template.clone(),
-            attribute: self.attr_path.clone(),
+            path: self.attr_path.clone(),
+            description: self.parsed_description,
             reason: AttributeParseErrorReason::ExpectedNameValue(name),
             suggestions: self.suggestions(),
         })
@@ -505,7 +517,8 @@ impl<'f, 'sess: 'f, S: Stage> AcceptContext<'f, 'sess, S> {
             span,
             attr_span: self.attr_span,
             template: self.template.clone(),
-            attribute: self.attr_path.clone(),
+            path: self.attr_path.clone(),
+            description: self.parsed_description,
             reason: AttributeParseErrorReason::DuplicateKey(key),
             suggestions: self.suggestions(),
         })
@@ -518,7 +531,8 @@ impl<'f, 'sess: 'f, S: Stage> AcceptContext<'f, 'sess, S> {
             span,
             attr_span: self.attr_span,
             template: self.template.clone(),
-            attribute: self.attr_path.clone(),
+            path: self.attr_path.clone(),
+            description: self.parsed_description,
             reason: AttributeParseErrorReason::UnexpectedLiteral,
             suggestions: self.suggestions(),
         })
@@ -529,7 +543,8 @@ impl<'f, 'sess: 'f, S: Stage> AcceptContext<'f, 'sess, S> {
             span,
             attr_span: self.attr_span,
             template: self.template.clone(),
-            attribute: self.attr_path.clone(),
+            path: self.attr_path.clone(),
+            description: self.parsed_description,
             reason: AttributeParseErrorReason::ExpectedSingleArgument,
             suggestions: self.suggestions(),
         })
@@ -540,7 +555,8 @@ impl<'f, 'sess: 'f, S: Stage> AcceptContext<'f, 'sess, S> {
             span,
             attr_span: self.attr_span,
             template: self.template.clone(),
-            attribute: self.attr_path.clone(),
+            path: self.attr_path.clone(),
+            description: self.parsed_description,
             reason: AttributeParseErrorReason::ExpectedAtLeastOneArgument,
             suggestions: self.suggestions(),
         })
@@ -556,7 +572,8 @@ impl<'f, 'sess: 'f, S: Stage> AcceptContext<'f, 'sess, S> {
             span,
             attr_span: self.attr_span,
             template: self.template.clone(),
-            attribute: self.attr_path.clone(),
+            path: self.attr_path.clone(),
+            description: self.parsed_description,
             reason: AttributeParseErrorReason::ExpectedSpecificArgument {
                 possibilities,
                 strings: false,
@@ -577,7 +594,8 @@ impl<'f, 'sess: 'f, S: Stage> AcceptContext<'f, 'sess, S> {
             span,
             attr_span: self.attr_span,
             template: self.template.clone(),
-            attribute: self.attr_path.clone(),
+            path: self.attr_path.clone(),
+            description: self.parsed_description,
             reason: AttributeParseErrorReason::ExpectedSpecificArgument {
                 possibilities,
                 strings: false,
@@ -597,7 +615,8 @@ impl<'f, 'sess: 'f, S: Stage> AcceptContext<'f, 'sess, S> {
             span,
             attr_span: self.attr_span,
             template: self.template.clone(),
-            attribute: self.attr_path.clone(),
+            path: self.attr_path.clone(),
+            description: self.parsed_description,
             reason: AttributeParseErrorReason::ExpectedSpecificArgument {
                 possibilities,
                 strings: true,

--- a/compiler/rustc_attr_parsing/src/interface.rs
+++ b/compiler/rustc_attr_parsing/src/interface.rs
@@ -12,6 +12,7 @@ use rustc_span::{DUMMY_SP, Span, Symbol, sym};
 
 use crate::context::{AcceptContext, FinalizeContext, SharedContext, Stage};
 use crate::parser::{ArgParser, MetaItemParser, PathParser};
+use crate::session_diagnostics::ParsedDescription;
 use crate::{Early, Late, OmitDoc, ShouldEmit};
 
 /// Context created once, for example as part of the ast lowering
@@ -145,6 +146,7 @@ impl<'sess> AttributeParser<'sess, Early> {
             normal_attr.item.span(),
             attr.style,
             path.get_attribute_path(),
+            ParsedDescription::Attribute,
             target_span,
             target_node_id,
             features,
@@ -163,6 +165,7 @@ impl<'sess> AttributeParser<'sess, Early> {
         inner_span: Span,
         attr_style: AttrStyle,
         attr_path: AttrPath,
+        parsed_description: ParsedDescription,
         target_span: Span,
         target_node_id: NodeId,
         features: Option<&'sess Features>,
@@ -190,6 +193,7 @@ impl<'sess> AttributeParser<'sess, Early> {
             attr_span,
             inner_span,
             attr_style,
+            parsed_description,
             template,
             attr_path,
         };
@@ -310,6 +314,7 @@ impl<'sess, S: Stage> AttributeParser<'sess, S> {
                                 attr_span: lower_span(attr.span),
                                 inner_span: lower_span(attr.get_normal_item().span()),
                                 attr_style: attr.style,
+                                parsed_description: ParsedDescription::Attribute,
                                 template: &accept.template,
                                 attr_path: path.get_attribute_path(),
                             };

--- a/compiler/rustc_attr_parsing/src/interface.rs
+++ b/compiler/rustc_attr_parsing/src/interface.rs
@@ -168,9 +168,9 @@ impl<'sess> AttributeParser<'sess, Early> {
         features: Option<&'sess Features>,
         emit_errors: ShouldEmit,
         args: &I,
-        parse_fn: fn(cx: &mut AcceptContext<'_, '_, Early>, item: &I) -> Option<T>,
+        parse_fn: fn(cx: &mut AcceptContext<'_, '_, Early>, item: &I) -> T,
         template: &AttributeTemplate,
-    ) -> Option<T> {
+    ) -> T {
         let mut parser = Self {
             features,
             tools: Vec::new(),

--- a/compiler/rustc_attr_parsing/src/lib.rs
+++ b/compiler/rustc_attr_parsing/src/lib.rs
@@ -106,7 +106,7 @@ mod target_checking;
 pub mod validate_attr;
 
 pub use attributes::cfg::{
-    CFG_TEMPLATE, EvalConfigResult, eval_config_entry, parse_cfg, parse_cfg_attr,
+    CFG_TEMPLATE, EvalConfigResult, eval_config_entry, parse_cfg, parse_cfg_attr, parse_cfg_entry,
 };
 pub use attributes::cfg_old::*;
 pub use attributes::util::{is_builtin_attr, is_doc_alias_attrs_contain_symbol, parse_version};

--- a/compiler/rustc_attr_parsing/src/lib.rs
+++ b/compiler/rustc_attr_parsing/src/lib.rs
@@ -113,5 +113,6 @@ pub use attributes::util::{is_builtin_attr, is_doc_alias_attrs_contain_symbol, p
 pub use context::{Early, Late, OmitDoc, ShouldEmit};
 pub use interface::AttributeParser;
 pub use lints::emit_attribute_lint;
+pub use session_diagnostics::ParsedDescription;
 
 rustc_fluent_macro::fluent_messages! { "../messages.ftl" }

--- a/compiler/rustc_builtin_macros/src/cfg.rs
+++ b/compiler/rustc_builtin_macros/src/cfg.rs
@@ -2,13 +2,16 @@
 //! a literal `true` or `false` based on whether the given cfg matches the
 //! current compilation environment.
 
-use rustc_ast::token;
 use rustc_ast::tokenstream::TokenStream;
-use rustc_errors::PResult;
+use rustc_ast::{AttrStyle, CRATE_NODE_ID, token};
+use rustc_attr_parsing as attr;
+use rustc_attr_parsing::parser::MetaItemOrLitParser;
+use rustc_attr_parsing::{AttributeParser, CFG_TEMPLATE, ShouldEmit, parse_cfg_entry};
 use rustc_expand::base::{DummyResult, ExpandResult, ExtCtxt, MacEager, MacroExpanderResult};
+use rustc_hir::AttrPath;
+use rustc_hir::attrs::CfgEntry;
 use rustc_parse::exp;
-use rustc_span::Span;
-use {rustc_ast as ast, rustc_attr_parsing as attr};
+use rustc_span::{ErrorGuaranteed, Ident, Span};
 
 use crate::errors;
 
@@ -21,38 +24,48 @@ pub(crate) fn expand_cfg(
 
     ExpandResult::Ready(match parse_cfg(cx, sp, tts) {
         Ok(cfg) => {
-            let matches_cfg = attr::cfg_matches(
+            let matches_cfg = attr::eval_config_entry(
+                cx.sess,
                 &cfg,
-                &cx.sess,
                 cx.current_expansion.lint_node_id,
                 Some(cx.ecfg.features),
-            );
+                ShouldEmit::ErrorsAndLints,
+            )
+            .as_bool();
+
             MacEager::expr(cx.expr_bool(sp, matches_cfg))
         }
-        Err(err) => {
-            let guar = err.emit();
-            DummyResult::any(sp, guar)
-        }
+        Err(guar) => DummyResult::any(sp, guar),
     })
 }
 
-fn parse_cfg<'a>(
-    cx: &ExtCtxt<'a>,
-    span: Span,
-    tts: TokenStream,
-) -> PResult<'a, ast::MetaItemInner> {
-    let mut p = cx.new_parser_from_tts(tts);
-
-    if p.token == token::Eof {
-        return Err(cx.dcx().create_err(errors::RequiresCfgPattern { span }));
+fn parse_cfg(cx: &ExtCtxt<'_>, span: Span, tts: TokenStream) -> Result<CfgEntry, ErrorGuaranteed> {
+    let mut parser = cx.new_parser_from_tts(tts);
+    if parser.token == token::Eof {
+        return Err(cx.dcx().emit_err(errors::RequiresCfgPattern { span }));
     }
 
-    let cfg = p.parse_meta_item_inner()?;
+    let meta = MetaItemOrLitParser::parse_single(&mut parser, ShouldEmit::ErrorsAndLints)
+        .map_err(|diag| diag.emit())?;
+    let cfg = AttributeParser::parse_single_args(
+        cx.sess,
+        span,
+        span,
+        AttrStyle::Inner,
+        AttrPath { segments: vec![Ident::from_str("cfg")].into_boxed_slice(), span },
+        span,
+        CRATE_NODE_ID,
+        Some(cx.ecfg.features),
+        ShouldEmit::ErrorsAndLints,
+        &meta,
+        parse_cfg_entry,
+        &CFG_TEMPLATE,
+    )?;
 
-    let _ = p.eat(exp!(Comma));
+    let _ = parser.eat(exp!(Comma));
 
-    if !p.eat(exp!(Eof)) {
-        return Err(cx.dcx().create_err(errors::OneCfgPattern { span }));
+    if !parser.eat(exp!(Eof)) {
+        return Err(cx.dcx().emit_err(errors::OneCfgPattern { span }));
     }
 
     Ok(cfg)

--- a/compiler/rustc_builtin_macros/src/cfg.rs
+++ b/compiler/rustc_builtin_macros/src/cfg.rs
@@ -6,7 +6,9 @@ use rustc_ast::tokenstream::TokenStream;
 use rustc_ast::{AttrStyle, CRATE_NODE_ID, token};
 use rustc_attr_parsing as attr;
 use rustc_attr_parsing::parser::MetaItemOrLitParser;
-use rustc_attr_parsing::{AttributeParser, CFG_TEMPLATE, ShouldEmit, parse_cfg_entry};
+use rustc_attr_parsing::{
+    AttributeParser, CFG_TEMPLATE, ParsedDescription, ShouldEmit, parse_cfg_entry,
+};
 use rustc_expand::base::{DummyResult, ExpandResult, ExtCtxt, MacEager, MacroExpanderResult};
 use rustc_hir::AttrPath;
 use rustc_hir::attrs::CfgEntry;
@@ -53,6 +55,7 @@ fn parse_cfg(cx: &ExtCtxt<'_>, span: Span, tts: TokenStream) -> Result<CfgEntry,
         span,
         AttrStyle::Inner,
         AttrPath { segments: vec![Ident::from_str("cfg")].into_boxed_slice(), span },
+        ParsedDescription::Macro,
         span,
         CRATE_NODE_ID,
         Some(cx.ecfg.features),

--- a/compiler/rustc_error_codes/src/error_codes/E0536.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0536.md
@@ -1,18 +1,22 @@
 The `not` cfg-predicate was malformed.
 
-Erroneous code example:
+Erroneous code example (using `cargo doc`):
 
-```compile_fail,E0536
+```ignore, E0536 (only triggers on cargo doc)
+#![feature(doc_cfg)]
+#[doc(cfg(not()))]
 pub fn main() {
-    if cfg!(not()) { }
+
 }
 ```
 
 The `not` predicate expects one cfg-pattern. Example:
 
 ```
+#![feature(doc_cfg)]
+#[doc(cfg(not(target_os = "linux")))] // ok!
 pub fn main() {
-    if cfg!(not(target_os = "linux")) { } // ok!
+
 }
 ```
 

--- a/compiler/rustc_errors/src/emitter.rs
+++ b/compiler/rustc_errors/src/emitter.rs
@@ -2152,6 +2152,7 @@ impl HumanEmitter {
 
             let line_start = sm.lookup_char_pos(parts[0].original_span.lo()).line;
             let mut lines = complete.lines();
+            let lines_len = lines.clone().count();
             if lines.clone().next().is_none() {
                 // Account for a suggestion to completely remove a line(s) with whitespace (#94192).
                 let line_end = sm.lookup_char_pos(parts[0].original_span.hi()).line;
@@ -2192,6 +2193,7 @@ impl HumanEmitter {
                 if highlight_parts.len() == 1
                     && line.trim().starts_with("#[")
                     && line.trim().ends_with(']')
+                    && lines_len == 1
                 {
                     is_item_attribute = true;
                 }

--- a/compiler/rustc_hir_analysis/src/check/check.rs
+++ b/compiler/rustc_hir_analysis/src/check/check.rs
@@ -782,7 +782,7 @@ pub(crate) fn check_item_type(tcx: TyCtxt<'_>, def_id: LocalDefId) -> Result<(),
             tcx.ensure_ok().generics_of(def_id);
             tcx.ensure_ok().type_of(def_id);
             tcx.ensure_ok().predicates_of(def_id);
-            crate::collect::lower_enum_variant_types(tcx, def_id.to_def_id());
+            crate::collect::lower_enum_variant_types(tcx, def_id);
             check_enum(tcx, def_id);
             check_variances_for_type_defn(tcx, def_id);
         }

--- a/compiler/rustc_hir_analysis/src/collect.rs
+++ b/compiler/rustc_hir_analysis/src/collect.rs
@@ -19,7 +19,7 @@ use std::cell::Cell;
 use std::iter;
 use std::ops::Bound;
 
-use rustc_abi::ExternAbi;
+use rustc_abi::{ExternAbi, Size};
 use rustc_ast::Recovered;
 use rustc_data_structures::fx::{FxHashSet, FxIndexMap};
 use rustc_data_structures::unord::UnordMap;
@@ -605,7 +605,7 @@ pub(super) fn lower_variant_ctor(tcx: TyCtxt<'_>, def_id: LocalDefId) {
     tcx.ensure_ok().predicates_of(def_id);
 }
 
-pub(super) fn lower_enum_variant_types(tcx: TyCtxt<'_>, def_id: DefId) {
+pub(super) fn lower_enum_variant_types(tcx: TyCtxt<'_>, def_id: LocalDefId) {
     let def = tcx.adt_def(def_id);
     let repr_type = def.repr().discr_type();
     let initial = repr_type.initial_discriminant(tcx);
@@ -614,23 +614,44 @@ pub(super) fn lower_enum_variant_types(tcx: TyCtxt<'_>, def_id: DefId) {
     // fill the discriminant values and field types
     for variant in def.variants() {
         let wrapped_discr = prev_discr.map_or(initial, |d| d.wrap_incr(tcx));
-        prev_discr = Some(
-            if let ty::VariantDiscr::Explicit(const_def_id) = variant.discr {
-                def.eval_explicit_discr(tcx, const_def_id).ok()
-            } else if let Some(discr) = repr_type.disr_incr(tcx, prev_discr) {
-                Some(discr)
-            } else {
+        let cur_discr = if let ty::VariantDiscr::Explicit(const_def_id) = variant.discr {
+            def.eval_explicit_discr(tcx, const_def_id).ok()
+        } else if let Some(discr) = repr_type.disr_incr(tcx, prev_discr) {
+            Some(discr)
+        } else {
+            let span = tcx.def_span(variant.def_id);
+            tcx.dcx().emit_err(errors::EnumDiscriminantOverflowed {
+                span,
+                discr: prev_discr.unwrap().to_string(),
+                item_name: tcx.item_ident(variant.def_id),
+                wrapped_discr: wrapped_discr.to_string(),
+            });
+            None
+        }
+        .unwrap_or(wrapped_discr);
+
+        if def.repr().c() {
+            // c_int is a signed type, so get a proper signed version of the discriminant
+            let discr_size = cur_discr.ty.int_size_and_signed(tcx).0;
+            let discr_val = discr_size.sign_extend(cur_discr.val);
+
+            let c_int = Size::from_bits(tcx.sess.target.c_int_width);
+            if discr_val < c_int.signed_int_min() || discr_val > c_int.signed_int_max() {
                 let span = tcx.def_span(variant.def_id);
-                tcx.dcx().emit_err(errors::EnumDiscriminantOverflowed {
+                tcx.node_span_lint(
+                    rustc_session::lint::builtin::REPR_C_ENUMS_LARGER_THAN_INT,
+                    tcx.local_def_id_to_hir_id(def_id),
                     span,
-                    discr: prev_discr.unwrap().to_string(),
-                    item_name: tcx.item_ident(variant.def_id),
-                    wrapped_discr: wrapped_discr.to_string(),
-                });
-                None
+                    |d| {
+                        d.primary_message("`repr(C)` enum discriminant does not fit into C `int`")
+                        .note("`repr(C)` enums with big discriminants are non-portable, and their size in Rust might not match their size in C")
+                        .help("use `repr($int_ty)` instead to explicitly set the size of this enum");
+                    }
+                );
             }
-            .unwrap_or(wrapped_discr),
-        );
+        }
+
+        prev_discr = Some(cur_discr);
 
         for f in &variant.fields {
             tcx.ensure_ok().generics_of(f.did);

--- a/compiler/rustc_hir_typeck/src/errors.rs
+++ b/compiler/rustc_hir_typeck/src/errors.rs
@@ -3,20 +3,21 @@
 use std::borrow::Cow;
 
 use rustc_abi::ExternAbi;
-use rustc_ast::Label;
+use rustc_ast::{AssignOpKind, Label};
 use rustc_errors::codes::*;
 use rustc_errors::{
     Applicability, Diag, DiagArgValue, DiagCtxtHandle, DiagSymbolList, Diagnostic,
-    EmissionGuarantee, IntoDiagArg, Level, MultiSpan, Subdiagnostic,
+    EmissionGuarantee, IntoDiagArg, Level, MultiSpan, Subdiagnostic, struct_span_code_err,
 };
 use rustc_hir as hir;
 use rustc_hir::ExprKind;
 use rustc_macros::{Diagnostic, LintDiagnostic, Subdiagnostic};
 use rustc_middle::ty::{self, Ty};
 use rustc_span::edition::{Edition, LATEST_STABLE_EDITION};
+use rustc_span::source_map::Spanned;
 use rustc_span::{Ident, Span, Symbol};
 
-use crate::fluent_generated as fluent;
+use crate::{FnCtxt, fluent_generated as fluent};
 
 #[derive(Diagnostic)]
 #[diag(hir_typeck_base_expression_double_dot, code = E0797)]
@@ -1131,6 +1132,39 @@ impl<G: EmissionGuarantee> Diagnostic<'_, G> for NakedFunctionsAsmBlock {
         }
         diag
     }
+}
+
+pub(crate) fn maybe_emit_plus_equals_diagnostic<'a>(
+    fnctxt: &FnCtxt<'a, '_>,
+    assign_op: Spanned<AssignOpKind>,
+    lhs_expr: &hir::Expr<'_>,
+) -> Result<(), Diag<'a>> {
+    if assign_op.node == hir::AssignOpKind::AddAssign
+        && let hir::ExprKind::Binary(bin_op, left, right) = &lhs_expr.kind
+        && bin_op.node == hir::BinOpKind::And
+        && crate::op::contains_let_in_chain(left)
+        && let hir::ExprKind::Path(hir::QPath::Resolved(_, path)) = &right.kind
+        && matches!(path.res, hir::def::Res::Local(_))
+    {
+        let mut err = struct_span_code_err!(
+            fnctxt.dcx(),
+            assign_op.span,
+            E0368,
+            "binary assignment operation `+=` cannot be used in a let chain",
+        );
+
+        err.span_label(assign_op.span, "cannot use `+=` in a let chain");
+
+        err.span_suggestion(
+            assign_op.span,
+            "you might have meant to compare with `==` instead of assigning with `+=`",
+            "==",
+            Applicability::MaybeIncorrect,
+        );
+
+        return Err(err);
+    }
+    Ok(())
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_hir_typeck/src/errors.rs
+++ b/compiler/rustc_hir_typeck/src/errors.rs
@@ -7,7 +7,7 @@ use rustc_ast::{AssignOpKind, Label};
 use rustc_errors::codes::*;
 use rustc_errors::{
     Applicability, Diag, DiagArgValue, DiagCtxtHandle, DiagSymbolList, Diagnostic,
-    EmissionGuarantee, IntoDiagArg, Level, MultiSpan, Subdiagnostic, struct_span_code_err,
+    EmissionGuarantee, IntoDiagArg, Level, MultiSpan, Subdiagnostic,
 };
 use rustc_hir as hir;
 use rustc_hir::ExprKind;
@@ -1146,11 +1146,14 @@ pub(crate) fn maybe_emit_plus_equals_diagnostic<'a>(
         && let hir::ExprKind::Path(hir::QPath::Resolved(_, path)) = &right.kind
         && matches!(path.res, hir::def::Res::Local(_))
     {
-        let mut err = struct_span_code_err!(
-            fnctxt.dcx(),
+        let mut err = fnctxt.dcx().struct_span_err(
             assign_op.span,
-            E0368,
             "binary assignment operation `+=` cannot be used in a let chain",
+        );
+
+        err.span_label(
+            lhs_expr.span,
+            "you are add-assigning the right-hand side expression to the result of this let-chain",
         );
 
         err.span_label(assign_op.span, "cannot use `+=` in a let chain");

--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -1249,6 +1249,12 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             return;
         }
 
+        // Skip suggestion if LHS contains a let-chain at this would likely be spurious
+        // cc: https://github.com/rust-lang/rust/issues/147664
+        if crate::op::contains_let_in_chain(lhs) {
+            return;
+        }
+
         let mut err = self.dcx().struct_span_err(op_span, "invalid left-hand side of assignment");
         err.code(code);
         err.span_label(lhs.span, "cannot assign to this expression");

--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -48,6 +48,7 @@ use crate::errors::{
     NoFieldOnVariant, ReturnLikeStatementKind, ReturnStmtOutsideOfFnBody, StructExprNonExhaustive,
     TypeMismatchFruTypo, YieldExprOutsideOfCoroutine,
 };
+use crate::op::contains_let_in_chain;
 use crate::{
     BreakableCtxt, CoroutineTypes, Diverges, FnCtxt, GatherLocalsVisitor, Needs,
     TupleArgumentsFlag, cast, fatally_break_rust, report_unexpected_variant_res, type_error_struct,
@@ -1251,7 +1252,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         // Skip suggestion if LHS contains a let-chain at this would likely be spurious
         // cc: https://github.com/rust-lang/rust/issues/147664
-        if crate::op::contains_let_in_chain(lhs) {
+        if contains_let_in_chain(lhs) {
             return;
         }
 

--- a/compiler/rustc_lint/src/types.rs
+++ b/compiler/rustc_lint/src/types.rs
@@ -10,7 +10,7 @@ use rustc_span::{Span, Symbol, sym};
 use tracing::debug;
 use {rustc_ast as ast, rustc_hir as hir};
 
-mod improper_ctypes; // these filed do the implementation for ImproperCTypesDefinitions,ImproperCTypesDeclarations
+mod improper_ctypes; // these files do the implementation for ImproperCTypesDefinitions,ImproperCTypesDeclarations
 pub(crate) use improper_ctypes::ImproperCTypesLint;
 
 use crate::lints::{
@@ -25,7 +25,6 @@ use crate::lints::{
 use crate::{LateContext, LateLintPass, LintContext};
 
 mod literal;
-
 use literal::{int_ty_range, lint_literal, uint_ty_range};
 
 declare_lint! {

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -86,6 +86,7 @@ declare_lint_pass! {
         REFINING_IMPL_TRAIT_INTERNAL,
         REFINING_IMPL_TRAIT_REACHABLE,
         RENAMED_AND_REMOVED_LINTS,
+        REPR_C_ENUMS_LARGER_THAN_INT,
         REPR_TRANSPARENT_NON_ZST_FIELDS,
         RUST_2021_INCOMPATIBLE_CLOSURE_CAPTURES,
         RUST_2021_INCOMPATIBLE_OR_PATTERNS,
@@ -5212,4 +5213,51 @@ declare_lint! {
     pub INLINE_ALWAYS_MISMATCHING_TARGET_FEATURES,
     Warn,
     r#"detects when a function annotated with `#[inline(always)]` and `#[target_feature(enable = "..")]` is inlined into a caller without the required target feature"#,
+}
+
+declare_lint! {
+    /// The `repr_c_enums_larger_than_int` lint detects `repr(C)` enums with discriminant
+    /// values that do not fit into a C `int`.
+    ///
+    /// ### Example
+    ///
+    /// ```rust,ignore (only errors on 64bit)
+    /// #[repr(C)]
+    /// enum E {
+    ///     V = 9223372036854775807, // i64::MAX
+    /// }
+    /// ```
+    ///
+    /// This will produce:
+    ///
+    /// ```text
+    /// error: `repr(C)` enum discriminant does not fit into C `int`
+    ///   --> $DIR/repr-c-big-discriminant1.rs:16:5
+    ///    |
+    /// LL |     A = 9223372036854775807, // i64::MAX
+    ///    |     ^
+    ///    |
+    ///    = note: `repr(C)` enums with big discriminants are non-portable, and their size in Rust might not match their size in C
+    ///    = help: use `repr($int_ty)` instead to explicitly set the size of this enum
+    /// ```
+    ///
+    /// ### Explanation
+    ///
+    /// In C, enums with discriminants that do not fit into an `int` are a portability hazard: such
+    /// enums are only permitted since C23, and not supported e.g. by MSVC. Furthermore, Rust
+    /// interprets the discriminant values of `repr(C)` enums as expressions of type `isize`, which
+    /// cannot be changed in a backwards-compatible way. If the discriminant is given as a literal
+    /// that does not fit into `isize`, it is wrapped (with a warning). This makes it impossible to
+    /// implement the C23 behavior of enums where the enum discriminants have no predefined type and
+    /// instead the enum uses a type large enough to hold all discriminants.
+    ///
+    /// Therefore, `repr(C)` enums require all discriminants to fit into a C `int`.
+    pub REPR_C_ENUMS_LARGER_THAN_INT,
+    Warn,
+    "repr(C) enums with discriminant values that do not fit into a C int",
+    @future_incompatible = FutureIncompatibleInfo {
+        reason: FutureIncompatibilityReason::FutureReleaseError,
+        reference: "issue #124403 <https://github.com/rust-lang/rust/issues/124403>",
+        report_in_deps: false,
+    };
 }

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -5217,7 +5217,7 @@ declare_lint! {
 
 declare_lint! {
     /// The `repr_c_enums_larger_than_int` lint detects `repr(C)` enums with discriminant
-    /// values that do not fit into a C `int`.
+    /// values that do not fit into a C `int` or `unsigned int`.
     ///
     /// ### Example
     ///
@@ -5231,7 +5231,7 @@ declare_lint! {
     /// This will produce:
     ///
     /// ```text
-    /// error: `repr(C)` enum discriminant does not fit into C `int`
+    /// error: `repr(C)` enum discriminant does not fit into C `int` nor into C `unsigned int`
     ///   --> $DIR/repr-c-big-discriminant1.rs:16:5
     ///    |
     /// LL |     A = 9223372036854775807, // i64::MAX
@@ -5243,15 +5243,17 @@ declare_lint! {
     ///
     /// ### Explanation
     ///
-    /// In C, enums with discriminants that do not fit into an `int` are a portability hazard: such
-    /// enums are only permitted since C23, and not supported e.g. by MSVC. Furthermore, Rust
-    /// interprets the discriminant values of `repr(C)` enums as expressions of type `isize`, which
-    /// cannot be changed in a backwards-compatible way. If the discriminant is given as a literal
-    /// that does not fit into `isize`, it is wrapped (with a warning). This makes it impossible to
-    /// implement the C23 behavior of enums where the enum discriminants have no predefined type and
-    /// instead the enum uses a type large enough to hold all discriminants.
+    /// In C, enums with discriminants that do not all fit into an `int` or all fit into an
+    /// `unsigned int` are a portability hazard: such enums are only permitted since C23, and not
+    /// supported e.g. by MSVC.
     ///
-    /// Therefore, `repr(C)` enums require all discriminants to fit into a C `int`.
+    /// Furthermore, Rust interprets the discriminant values of `repr(C)` enums as expressions of
+    /// type `isize`. This makes it impossible to implement the C23 behavior of enums where the enum
+    /// discriminants have no predefined type and instead the enum uses a type large enough to hold
+    /// all discriminants.
+    ///
+    /// Therefore, `repr(C)` enums in Rust require that either all discriminants to fit into a C
+    /// `int` or they all fit into an `unsigned int`.
     pub REPR_C_ENUMS_LARGER_THAN_INT,
     Warn,
     "repr(C) enums with discriminant values that do not fit into a C int",

--- a/compiler/rustc_middle/src/ty/layout.rs
+++ b/compiler/rustc_middle/src/ty/layout.rs
@@ -72,7 +72,10 @@ impl abi::Integer {
     /// signed discriminant range and `#[repr]` attribute.
     /// N.B.: `u128` values above `i128::MAX` will be treated as signed, but
     /// that shouldn't affect anything, other than maybe debuginfo.
-    fn repr_discr<'tcx>(
+    ///
+    /// This is the basis for computing the type of the *tag* of an enum (which can be smaller than
+    /// the type of the *discriminant*, which is determined by [`ReprOptions::discr_type`]).
+    fn discr_range_of_repr<'tcx>(
         tcx: TyCtxt<'tcx>,
         ty: Ty<'tcx>,
         repr: &ReprOptions,

--- a/compiler/rustc_middle/src/ty/layout.rs
+++ b/compiler/rustc_middle/src/ty/layout.rs
@@ -111,7 +111,8 @@ impl abi::Integer {
             abi::Integer::I8
         };
 
-        // Pick the smallest fit.
+        // Pick the smallest fit. Prefer unsigned; that matches clang in cases where this makes a
+        // difference (https://godbolt.org/z/h4xEasW1d) so it is crucial for repr(C).
         if unsigned_fit <= signed_fit {
             (cmp::max(unsigned_fit, at_least), false)
         } else {

--- a/compiler/rustc_resolve/messages.ftl
+++ b/compiler/rustc_resolve/messages.ftl
@@ -175,6 +175,7 @@ resolve_generic_params_from_outer_item =
     } from outer item
     .refer_to_type_directly = refer to the type directly here instead
     .suggestion = try introducing a local generic parameter here
+    .note = nested items are independent from their parent item for everything except for privacy and name resolution
 
 resolve_generic_params_from_outer_item_const = a `const` is a separate item from the item that contains it
 

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -558,6 +558,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 has_generic_params,
                 def_kind,
                 inner_item,
+                current_self_ty,
             } => {
                 use errs::GenericParamsFromOuterItemLabel as Label;
                 let static_or_const = match def_kind {
@@ -595,7 +596,8 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                             sm,
                             self.def_span(def_id),
                         )));
-                        err.refer_to_type_directly = Some(span);
+                        err.refer_to_type_directly =
+                            current_self_ty.map(|snippet| errs::UseTypeDirectly { span, snippet });
                         return self.dcx().create_err(err);
                     }
                     Res::Def(DefKind::TyParam, def_id) => {

--- a/compiler/rustc_resolve/src/errors.rs
+++ b/compiler/rustc_resolve/src/errors.rs
@@ -17,8 +17,8 @@ pub(crate) struct GenericParamsFromOuterItem {
     pub(crate) span: Span,
     #[subdiagnostic]
     pub(crate) label: Option<GenericParamsFromOuterItemLabel>,
-    #[label(resolve_refer_to_type_directly)]
-    pub(crate) refer_to_type_directly: Option<Span>,
+    #[subdiagnostic]
+    pub(crate) refer_to_type_directly: Option<UseTypeDirectly>,
     #[subdiagnostic]
     pub(crate) sugg: Option<GenericParamsFromOuterItemSugg>,
     #[subdiagnostic]
@@ -64,6 +64,18 @@ pub(crate) enum GenericParamsFromOuterItemLabel {
     style = "verbose"
 )]
 pub(crate) struct GenericParamsFromOuterItemSugg {
+    #[primary_span]
+    pub(crate) span: Span,
+    pub(crate) snippet: String,
+}
+#[derive(Subdiagnostic)]
+#[suggestion(
+    resolve_refer_to_type_directly,
+    code = "{snippet}",
+    applicability = "maybe-incorrect",
+    style = "verbose"
+)]
+pub(crate) struct UseTypeDirectly {
     #[primary_span]
     pub(crate) span: Span,
     pub(crate) snippet: String,

--- a/compiler/rustc_resolve/src/errors.rs
+++ b/compiler/rustc_resolve/src/errors.rs
@@ -11,6 +11,7 @@ use crate::{Res, fluent_generated as fluent};
 
 #[derive(Diagnostic)]
 #[diag(resolve_generic_params_from_outer_item, code = E0401)]
+#[note]
 pub(crate) struct GenericParamsFromOuterItem {
     #[primary_span]
     #[label]

--- a/compiler/rustc_resolve/src/ident.rs
+++ b/compiler/rustc_resolve/src/ident.rs
@@ -326,7 +326,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                     i,
                     rib_ident,
                     *res,
-                    finalize.map(|finalize| finalize.path_span),
+                    finalize.map(|_| general_span),
                     *original_rib_ident_def,
                     ribs,
                     diag_metadata,

--- a/compiler/rustc_resolve/src/ident.rs
+++ b/compiler/rustc_resolve/src/ident.rs
@@ -1415,6 +1415,11 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                                 has_generic_params,
                                 def_kind,
                                 inner_item: item,
+                                current_self_ty: diag_metadata
+                                    .and_then(|m| m.current_self_type.as_ref())
+                                    .and_then(|ty| {
+                                        self.tcx.sess.source_map().span_to_snippet(ty.span).ok()
+                                    }),
                             },
                         );
                     }
@@ -1503,6 +1508,11 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                                 has_generic_params,
                                 def_kind,
                                 inner_item: item,
+                                current_self_ty: diag_metadata
+                                    .and_then(|m| m.current_self_type.as_ref())
+                                    .and_then(|ty| {
+                                        self.tcx.sess.source_map().span_to_snippet(ty.span).ok()
+                                    }),
                             },
                         );
                     }

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -675,7 +675,7 @@ pub(crate) struct DiagMetadata<'ast> {
     current_trait_assoc_items: Option<&'ast [Box<AssocItem>]>,
 
     /// The current self type if inside an impl (used for better errors).
-    current_self_type: Option<Ty>,
+    pub(crate) current_self_type: Option<Ty>,
 
     /// The current self item if inside an ADT (used for better errors).
     current_self_item: Option<NodeId>,

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -246,6 +246,7 @@ enum ResolutionError<'ra> {
         has_generic_params: HasGenericParams,
         def_kind: DefKind,
         inner_item: Option<(Span, ast::ItemKind)>,
+        current_self_ty: Option<String>,
     },
     /// Error E0403: the name is already used for a type or const parameter in this generic
     /// parameter list.

--- a/compiler/rustc_symbol_mangling/src/lib.rs
+++ b/compiler/rustc_symbol_mangling/src/lib.rs
@@ -228,7 +228,7 @@ fn compute_symbol_name<'tcx>(
         // However, we don't have the wasm import module map there yet.
         tcx.is_foreign_item(def_id)
             && tcx.sess.target.is_like_wasm
-            && tcx.wasm_import_module_map(LOCAL_CRATE).contains_key(&def_id.into())
+            && tcx.wasm_import_module_map(def_id.krate).contains_key(&def_id.into())
     };
 
     if !wasm_import_module_exception_force_mangling {

--- a/compiler/rustc_ty_utils/src/layout.rs
+++ b/compiler/rustc_ty_utils/src/layout.rs
@@ -639,8 +639,8 @@ fn layout_of_uncached<'tcx>(
             // UnsafeCell and UnsafePinned both disable niche optimizations
             let is_special_no_niche = def.is_unsafe_cell() || def.is_unsafe_pinned();
 
-            let get_discriminant_type =
-                |min, max| abi::Integer::repr_discr(tcx, ty, &def.repr(), min, max);
+            let discr_range_of_repr =
+                |min, max| abi::Integer::discr_range_of_repr(tcx, ty, &def.repr(), min, max);
 
             let discriminants_iter = || {
                 def.is_enum()
@@ -663,7 +663,7 @@ fn layout_of_uncached<'tcx>(
                     def.is_enum(),
                     is_special_no_niche,
                     tcx.layout_scalar_valid_range(def.did()),
-                    get_discriminant_type,
+                    discr_range_of_repr,
                     discriminants_iter(),
                     !maybe_unsized,
                 )
@@ -688,7 +688,7 @@ fn layout_of_uncached<'tcx>(
                     def.is_enum(),
                     is_special_no_niche,
                     tcx.layout_scalar_valid_range(def.did()),
-                    get_discriminant_type,
+                    discr_range_of_repr,
                     discriminants_iter(),
                     !maybe_unsized,
                 ) else {

--- a/compiler/rustc_ty_utils/src/layout/invariant.rs
+++ b/compiler/rustc_ty_utils/src/layout/invariant.rs
@@ -14,6 +14,8 @@ pub(super) fn layout_sanity_check<'tcx>(cx: &LayoutCx<'tcx>, layout: &TyAndLayou
     if layout.size.bytes() >= tcx.data_layout.obj_size_bound() {
         bug!("size is too large, in the following layout:\n{layout:#?}");
     }
+    // FIXME(#124403): Once `repr_c_enums_larger_than_int` is a hard error, we could assert
+    // here that a repr(c) enum discriminant is never larger than a c_int.
 
     if !cfg!(debug_assertions) {
         // Stop here, the rest is kind of expensive.

--- a/src/tools/clippy/tests/ui/new_without_default.stderr
+++ b/src/tools/clippy/tests/ui/new_without_default.stderr
@@ -191,7 +191,6 @@ LL +     fn default() -> Self {
 LL +         Self::new()
 LL +     }
 LL + }
-LL | impl NewWithCfg {
    |
 
 error: you should consider adding a `Default` implementation for `NewWith2Cfgs`
@@ -212,7 +211,6 @@ LL +     fn default() -> Self {
 LL +         Self::new()
 LL +     }
 LL + }
-LL | impl NewWith2Cfgs {
    |
 
 error: you should consider adding a `Default` implementation for `NewWithExtraneous`
@@ -250,7 +248,6 @@ LL +     fn default() -> Self {
 LL +         Self::new()
 LL +     }
 LL + }
-LL | impl NewWithCfgAndExtraneous {
    |
 
 error: aborting due to 13 previous errors

--- a/tests/auxiliary/minicore.rs
+++ b/tests/auxiliary/minicore.rs
@@ -177,6 +177,21 @@ impl Add<isize> for isize {
     }
 }
 
+#[lang = "neg"]
+pub trait Neg {
+    type Output;
+
+    fn neg(self) -> Self::Output;
+}
+
+impl Neg for isize {
+    type Output = isize;
+
+    fn neg(self) -> isize {
+        loop {} // Dummy impl, not actually used
+    }
+}
+
 #[lang = "sync"]
 trait Sync {}
 impl_marker_trait!(
@@ -231,6 +246,13 @@ pub mod mem {
     #[rustc_nounwind]
     #[rustc_intrinsic]
     pub unsafe fn transmute<Src, Dst>(src: Src) -> Dst;
+
+    #[rustc_nounwind]
+    #[rustc_intrinsic]
+    pub const fn size_of<T>() -> usize;
+    #[rustc_nounwind]
+    #[rustc_intrinsic]
+    pub const fn align_of<T>() -> usize;
 }
 
 #[lang = "c_void"]

--- a/tests/ui/associated-item/associated-item-duplicate-bounds.stderr
+++ b/tests/ui/associated-item/associated-item-duplicate-bounds.stderr
@@ -2,7 +2,7 @@ error: generic parameters may not be used in const operations
   --> $DIR/associated-item-duplicate-bounds.rs:7:18
    |
 LL |     links: [u32; A::LINKS], // Shouldn't suggest bounds already there.
-   |                  ^^^^^^^^ cannot perform const operation using `A`
+   |                  ^ cannot perform const operation using `A`
    |
    = note: type parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions

--- a/tests/ui/borrowck/mut-borrow-of-mut-ref.rs
+++ b/tests/ui/borrowck/mut-borrow-of-mut-ref.rs
@@ -2,22 +2,24 @@
 #![crate_type = "rlib"]
 
 pub fn f(b: &mut i32) {
-    //~^ ERROR cannot borrow
-    //~| NOTE not mutable
-    //~| NOTE the binding is already a mutable borrow
+    //~^ ERROR: cannot borrow
+    //~| NOTE: not mutable
+    //~| NOTE: the binding is already a mutable borrow
+    //~| HELP: consider making the binding mutable if you need to reborrow multiple times
     h(&mut b);
-    //~^ NOTE cannot borrow as mutable
-    //~| HELP try removing `&mut` here
+    //~^ NOTE: cannot borrow as mutable
+    //~| HELP: if there is only one mutable reborrow, remove the `&mut`
     g(&mut &mut b);
-    //~^ NOTE cannot borrow as mutable
-    //~| HELP try removing `&mut` here
+    //~^ NOTE: cannot borrow as mutable
+    //~| HELP: if there is only one mutable reborrow, remove the `&mut`
 }
 
-pub fn g(b: &mut i32) { //~ NOTE the binding is already a mutable borrow
+pub fn g(b: &mut i32) { //~ NOTE: the binding is already a mutable borrow
+    //~^ HELP: consider making the binding mutable if you need to reborrow multiple times
     h(&mut &mut b);
-    //~^ ERROR cannot borrow
-    //~| NOTE cannot borrow as mutable
-    //~| HELP try removing `&mut` here
+    //~^ ERROR: cannot borrow
+    //~| NOTE: cannot borrow as mutable
+    //~| HELP: if there is only one mutable reborrow, remove the `&mut`
 }
 
 pub fn h(_: &mut i32) {}

--- a/tests/ui/borrowck/mut-borrow-of-mut-ref.stderr
+++ b/tests/ui/borrowck/mut-borrow-of-mut-ref.stderr
@@ -15,36 +15,44 @@ note: the binding is already a mutable borrow
    |
 LL | pub fn f(b: &mut i32) {
    |             ^^^^^^^^
-help: try removing `&mut` here
+help: consider making the binding mutable if you need to reborrow multiple times
+   |
+LL | pub fn f(mut b: &mut i32) {
+   |          +++
+help: if there is only one mutable reborrow, remove the `&mut`
    |
 LL -     h(&mut b);
 LL +     h(b);
    |
-help: try removing `&mut` here
+help: if there is only one mutable reborrow, remove the `&mut`
    |
 LL -     g(&mut &mut b);
 LL +     g(&mut b);
    |
 
 error[E0596]: cannot borrow `b` as mutable, as it is not declared as mutable
-  --> $DIR/mut-borrow-of-mut-ref.rs:17:12
+  --> $DIR/mut-borrow-of-mut-ref.rs:19:12
    |
 LL |     h(&mut &mut b);
    |            ^^^^^^ cannot borrow as mutable
    |
 note: the binding is already a mutable borrow
-  --> $DIR/mut-borrow-of-mut-ref.rs:16:13
+  --> $DIR/mut-borrow-of-mut-ref.rs:17:13
    |
 LL | pub fn g(b: &mut i32) {
    |             ^^^^^^^^
-help: try removing `&mut` here
+help: consider making the binding mutable if you need to reborrow multiple times
+   |
+LL | pub fn g(mut b: &mut i32) {
+   |          +++
+help: if there is only one mutable reborrow, remove the `&mut`
    |
 LL -     h(&mut &mut b);
 LL +     h(&mut b);
    |
 
 error[E0596]: cannot borrow `f` as mutable, as it is not declared as mutable
-  --> $DIR/mut-borrow-of-mut-ref.rs:34:5
+  --> $DIR/mut-borrow-of-mut-ref.rs:36:5
    |
 LL |     f.bar();
    |     ^ cannot borrow as mutable

--- a/tests/ui/const-generics/argument_order.rs
+++ b/tests/ui/const-generics/argument_order.rs
@@ -1,15 +1,17 @@
-struct Bad<const N: usize, T> {
+//@ reference: items.generics.syntax.decl-order
+
+struct Good<const N: usize, T> {
     arr: [u8; { N }],
     another: T,
 }
 
-struct AlsoBad<const N: usize, 'a, T, 'b, const M: usize, U> {
+struct Bad<const N: usize, 'a, T, 'b, const M: usize, U> {
     //~^ ERROR lifetime parameters must be declared prior
     a: &'a T,
     b: &'b U,
 }
 
 fn main() {
-    let _: AlsoBad<7, 'static, u32, 'static, 17, u16>;
+    let _: Bad<7, 'static, u32, 'static, 17, u16>;
     //~^ ERROR lifetime provided when a type was expected
  }

--- a/tests/ui/const-generics/argument_order.stderr
+++ b/tests/ui/const-generics/argument_order.stderr
@@ -1,14 +1,14 @@
 error: lifetime parameters must be declared prior to type and const parameters
-  --> $DIR/argument_order.rs:6:32
+  --> $DIR/argument_order.rs:8:28
    |
-LL | struct AlsoBad<const N: usize, 'a, T, 'b, const M: usize, U> {
-   |               -----------------^^-----^^-------------------- help: reorder the parameters: lifetimes, then consts and types: `<'a, 'b, const N: usize, T, const M: usize, U>`
+LL | struct Bad<const N: usize, 'a, T, 'b, const M: usize, U> {
+   |           -----------------^^-----^^-------------------- help: reorder the parameters: lifetimes, then consts and types: `<'a, 'b, const N: usize, T, const M: usize, U>`
 
 error[E0747]: lifetime provided when a type was expected
-  --> $DIR/argument_order.rs:13:23
+  --> $DIR/argument_order.rs:15:19
    |
-LL |     let _: AlsoBad<7, 'static, u32, 'static, 17, u16>;
-   |                       ^^^^^^^
+LL |     let _: Bad<7, 'static, u32, 'static, 17, u16>;
+   |                   ^^^^^^^
    |
    = note: lifetime arguments must be provided before type arguments
    = help: reorder the arguments: lifetimes, then type and consts: `<'a, 'b, N, T, M, U>`

--- a/tests/ui/const-generics/early/const-param-from-outer-fn.stderr
+++ b/tests/ui/const-generics/early/const-param-from-outer-fn.stderr
@@ -8,6 +8,7 @@ LL |     fn bar() -> u32 {
 LL |         X
    |         ^ use of generic parameter from outer item
    |
+   = note: nested items are independent from their parent item for everything except for privacy and name resolution
 help: try introducing a local generic parameter here
    |
 LL |     fn bar<X>() -> u32 {

--- a/tests/ui/delegation/target-expr.stderr
+++ b/tests/ui/delegation/target-expr.stderr
@@ -8,6 +8,8 @@ LL |     reuse Trait::static_method {
 LL |
 LL |         let _ = T::Default();
    |                 ^ use of generic parameter from outer item
+   |
+   = note: nested items are independent from their parent item for everything except for privacy and name resolution
 
 error[E0434]: can't capture dynamic environment in a fn item
   --> $DIR/target-expr.rs:26:17

--- a/tests/ui/delegation/target-expr.stderr
+++ b/tests/ui/delegation/target-expr.stderr
@@ -7,7 +7,7 @@ LL |     reuse Trait::static_method {
    |                  ------------- generic parameter used in this inner delegated function
 LL |
 LL |         let _ = T::Default();
-   |                 ^^^^^^^^^^ use of generic parameter from outer item
+   |                 ^ use of generic parameter from outer item
 
 error[E0434]: can't capture dynamic environment in a fn item
   --> $DIR/target-expr.rs:26:17

--- a/tests/ui/did_you_mean/issue-31424.rs
+++ b/tests/ui/did_you_mean/issue-31424.rs
@@ -4,17 +4,18 @@ struct Struct;
 
 impl Struct {
     fn foo(&mut self) {
-        (&mut self).bar(); //~ ERROR cannot borrow
-        //~^ HELP try removing `&mut` here
+        (&mut self).bar(); //~ ERROR: cannot borrow
+        //~^ HELP: try removing `&mut` here
     }
 
     // In this case we could keep the suggestion, but to distinguish the
     // two cases is pretty hard. It's an obscure case anyway.
     fn bar(self: &mut Self) {
-        //~^ WARN function cannot return without recursing
-        //~^^ HELP a `loop` may express intention better if this is on purpose
+        //~^ WARN: function cannot return without recursing
+        //~| HELP: a `loop` may express intention better if this is on purpose
+        //~| HELP: consider making the binding mutable if you need to reborrow multiple times
         (&mut self).bar(); //~ ERROR cannot borrow
-        //~^ HELP try removing `&mut` here
+        //~^ HELP: try removing `&mut` here
     }
 }
 

--- a/tests/ui/did_you_mean/issue-31424.stderr
+++ b/tests/ui/did_you_mean/issue-31424.stderr
@@ -28,7 +28,7 @@ LL |         (&mut self).bar();
    = note: `#[warn(unconditional_recursion)]` on by default
 
 error[E0596]: cannot borrow `self` as mutable, as it is not declared as mutable
-  --> $DIR/issue-31424.rs:16:9
+  --> $DIR/issue-31424.rs:17:9
    |
 LL |         (&mut self).bar();
    |         ^^^^^^^^^^^ cannot borrow as mutable
@@ -39,10 +39,14 @@ note: the binding is already a mutable borrow
 LL |     fn bar(self: &mut Self) {
    |                  ^^^^^^^^^
 help: try removing `&mut` here
-  --> $DIR/issue-31424.rs:16:9
+  --> $DIR/issue-31424.rs:17:9
    |
 LL |         (&mut self).bar();
    |         ^^^^^^^^^^^
+help: consider making the binding mutable if you need to reborrow multiple times
+   |
+LL |     fn bar(mut self: &mut Self) {
+   |            +++
 
 error: aborting due to 2 previous errors; 1 warning emitted
 

--- a/tests/ui/did_you_mean/issue-34126.rs
+++ b/tests/ui/did_you_mean/issue-34126.rs
@@ -3,9 +3,9 @@ struct Z { }
 impl Z {
     fn run(&self, z: &mut Z) { }
     fn start(&mut self) {
-        self.run(&mut self); //~ ERROR cannot borrow
-        //~| ERROR cannot borrow
-        //~| HELP try removing `&mut` here
+        self.run(&mut self); //~ ERROR: cannot borrow
+        //~| ERROR: cannot borrow
+        //~| HELP: if there is only one mutable reborrow, remove the `&mut`
     }
 }
 

--- a/tests/ui/did_you_mean/issue-34126.stderr
+++ b/tests/ui/did_you_mean/issue-34126.stderr
@@ -9,7 +9,7 @@ note: the binding is already a mutable borrow
    |
 LL |     fn start(&mut self) {
    |              ^^^^^^^^^
-help: try removing `&mut` here
+help: if there is only one mutable reborrow, remove the `&mut`
    |
 LL -         self.run(&mut self);
 LL +         self.run(self);

--- a/tests/ui/enum-discriminant/discriminant_size.rs
+++ b/tests/ui/enum-discriminant/discriminant_size.rs
@@ -2,6 +2,7 @@
 #![feature(core_intrinsics)]
 
 use std::intrinsics::discriminant_value;
+use std::mem::size_of;
 
 enum E1 {
     A,
@@ -20,6 +21,14 @@ enum E3 {
     B = 100,
 }
 
+// Enums like this are found in the ecosystem, let's make sure they get the right size.
+#[repr(C)]
+#[allow(overflowing_literals)]
+enum UnsignedIntEnum {
+    A = 0,
+    O = 0xffffffff, // doesn't fit into `int`, but fits into `unsigned int`
+}
+
 #[repr(i128)]
 enum E4 {
     A = 0x1223_3445_5667_7889,
@@ -27,24 +36,38 @@ enum E4 {
 }
 
 fn main() {
+    assert_eq!(size_of::<E1>(), 1);
     let mut target: [isize; 3] = [0, 0, 0];
     target[1] = discriminant_value(&E1::A);
     assert_eq!(target, [0, 0, 0]);
     target[1] = discriminant_value(&E1::B);
     assert_eq!(target, [0, 1, 0]);
 
+    assert_eq!(size_of::<E2>(), 1);
     let mut target: [i8; 3] = [0, 0, 0];
     target[1] = discriminant_value(&E2::A);
     assert_eq!(target, [0, 7, 0]);
     target[1] = discriminant_value(&E2::B);
     assert_eq!(target, [0, -2, 0]);
 
+    // E3's size is target-dependent
     let mut target: [isize; 3] = [0, 0, 0];
     target[1] = discriminant_value(&E3::A);
     assert_eq!(target, [0, 42, 0]);
     target[1] = discriminant_value(&E3::B);
     assert_eq!(target, [0, 100, 0]);
 
+    #[allow(overflowing_literals)]
+    {
+        assert_eq!(size_of::<UnsignedIntEnum>(), 4);
+        let mut target: [isize; 3] = [0, -1, 0];
+        target[1] = discriminant_value(&UnsignedIntEnum::A);
+        assert_eq!(target, [0, 0, 0]);
+        target[1] = discriminant_value(&UnsignedIntEnum::O);
+        assert_eq!(target, [0, 0xffffffff as isize, 0]);
+    }
+
+    assert_eq!(size_of::<E4>(), 16);
     let mut target: [i128; 3] = [0, 0, 0];
     target[1] = discriminant_value(&E4::A);
     assert_eq!(target, [0, 0x1223_3445_5667_7889, 0]);

--- a/tests/ui/enum-discriminant/repr-c-big-discriminant1.ptr32.stderr
+++ b/tests/ui/enum-discriminant/repr-c-big-discriminant1.ptr32.stderr
@@ -1,0 +1,19 @@
+error: literal out of range for `isize`
+  --> $DIR/repr-c-big-discriminant1.rs:16:9
+   |
+LL |     A = 9223372036854775807, // i64::MAX
+   |         ^^^^^^^^^^^^^^^^^^^
+   |
+   = note: the literal `9223372036854775807` does not fit into the type `isize` whose range is `-2147483648..=2147483647`
+   = note: `#[deny(overflowing_literals)]` on by default
+
+error: literal out of range for `isize`
+  --> $DIR/repr-c-big-discriminant1.rs:24:9
+   |
+LL |     A = -2147483649, // i32::MIN-1
+   |         ^^^^^^^^^^^
+   |
+   = note: the literal `-2147483649` does not fit into the type `isize` whose range is `-2147483648..=2147483647`
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/enum-discriminant/repr-c-big-discriminant1.ptr32.stderr
+++ b/tests/ui/enum-discriminant/repr-c-big-discriminant1.ptr32.stderr
@@ -1,5 +1,5 @@
 error: literal out of range for `isize`
-  --> $DIR/repr-c-big-discriminant1.rs:16:9
+  --> $DIR/repr-c-big-discriminant1.rs:18:9
    |
 LL |     A = 9223372036854775807, // i64::MAX
    |         ^^^^^^^^^^^^^^^^^^^
@@ -8,12 +8,28 @@ LL |     A = 9223372036854775807, // i64::MAX
    = note: `#[deny(overflowing_literals)]` on by default
 
 error: literal out of range for `isize`
-  --> $DIR/repr-c-big-discriminant1.rs:24:9
+  --> $DIR/repr-c-big-discriminant1.rs:26:9
    |
 LL |     A = -2147483649, // i32::MIN-1
    |         ^^^^^^^^^^^
    |
    = note: the literal `-2147483649` does not fit into the type `isize` whose range is `-2147483648..=2147483647`
 
-error: aborting due to 2 previous errors
+error: literal out of range for `isize`
+  --> $DIR/repr-c-big-discriminant1.rs:34:9
+   |
+LL |     A = 2147483648, // i32::MAX+1
+   |         ^^^^^^^^^^
+   |
+   = note: the literal `2147483648` does not fit into the type `isize` whose range is `-2147483648..=2147483647`
+
+error: literal out of range for `isize`
+  --> $DIR/repr-c-big-discriminant1.rs:43:9
+   |
+LL |     A = 2147483648, // i32::MAX+1
+   |         ^^^^^^^^^^
+   |
+   = note: the literal `2147483648` does not fit into the type `isize` whose range is `-2147483648..=2147483647`
+
+error: aborting due to 4 previous errors
 

--- a/tests/ui/enum-discriminant/repr-c-big-discriminant1.ptr64.stderr
+++ b/tests/ui/enum-discriminant/repr-c-big-discriminant1.ptr64.stderr
@@ -1,0 +1,40 @@
+error: `repr(C)` enum discriminant does not fit into C `int`
+  --> $DIR/repr-c-big-discriminant1.rs:16:5
+   |
+LL |     A = 9223372036854775807, // i64::MAX
+   |     ^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #124403 <https://github.com/rust-lang/rust/issues/124403>
+   = note: `repr(C)` enums with big discriminants are non-portable, and their size in Rust might not match their size in C
+   = help: use `repr($int_ty)` instead to explicitly set the size of this enum
+note: the lint level is defined here
+  --> $DIR/repr-c-big-discriminant1.rs:6:9
+   |
+LL | #![deny(repr_c_enums_larger_than_int)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: `repr(C)` enum discriminant does not fit into C `int`
+  --> $DIR/repr-c-big-discriminant1.rs:24:5
+   |
+LL |     A = -2147483649, // i32::MIN-1
+   |     ^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #124403 <https://github.com/rust-lang/rust/issues/124403>
+   = note: `repr(C)` enums with big discriminants are non-portable, and their size in Rust might not match their size in C
+   = help: use `repr($int_ty)` instead to explicitly set the size of this enum
+
+error: `repr(C)` enum discriminant does not fit into C `int`
+  --> $DIR/repr-c-big-discriminant1.rs:34:5
+   |
+LL |     A = I64_MAX as isize,
+   |     ^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #124403 <https://github.com/rust-lang/rust/issues/124403>
+   = note: `repr(C)` enums with big discriminants are non-portable, and their size in Rust might not match their size in C
+   = help: use `repr($int_ty)` instead to explicitly set the size of this enum
+
+error: aborting due to 3 previous errors
+

--- a/tests/ui/enum-discriminant/repr-c-big-discriminant1.ptr64.stderr
+++ b/tests/ui/enum-discriminant/repr-c-big-discriminant1.ptr64.stderr
@@ -1,5 +1,5 @@
-error: `repr(C)` enum discriminant does not fit into C `int`
-  --> $DIR/repr-c-big-discriminant1.rs:16:5
+error: `repr(C)` enum discriminant does not fit into C `int` nor into C `unsigned int`
+  --> $DIR/repr-c-big-discriminant1.rs:18:5
    |
 LL |     A = 9223372036854775807, // i64::MAX
    |     ^
@@ -9,13 +9,13 @@ LL |     A = 9223372036854775807, // i64::MAX
    = note: `repr(C)` enums with big discriminants are non-portable, and their size in Rust might not match their size in C
    = help: use `repr($int_ty)` instead to explicitly set the size of this enum
 note: the lint level is defined here
-  --> $DIR/repr-c-big-discriminant1.rs:6:9
+  --> $DIR/repr-c-big-discriminant1.rs:8:9
    |
 LL | #![deny(repr_c_enums_larger_than_int)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: `repr(C)` enum discriminant does not fit into C `int`
-  --> $DIR/repr-c-big-discriminant1.rs:24:5
+error: `repr(C)` enum discriminant does not fit into C `int` nor into C `unsigned int`
+  --> $DIR/repr-c-big-discriminant1.rs:26:5
    |
 LL |     A = -2147483649, // i32::MIN-1
    |     ^
@@ -25,8 +25,30 @@ LL |     A = -2147483649, // i32::MIN-1
    = note: `repr(C)` enums with big discriminants are non-portable, and their size in Rust might not match their size in C
    = help: use `repr($int_ty)` instead to explicitly set the size of this enum
 
-error: `repr(C)` enum discriminant does not fit into C `int`
-  --> $DIR/repr-c-big-discriminant1.rs:34:5
+error: `repr(C)` enum discriminant does not fit into C `unsigned int`, and a previous discriminant does not fit into C `int`
+  --> $DIR/repr-c-big-discriminant1.rs:36:5
+   |
+LL |     B = -1,
+   |     ^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #124403 <https://github.com/rust-lang/rust/issues/124403>
+   = note: `repr(C)` enums with big discriminants are non-portable, and their size in Rust might not match their size in C
+   = help: use `repr($int_ty)` instead to explicitly set the size of this enum
+
+error: `repr(C)` enum discriminant does not fit into C `int`, and a previous discriminant does not fit into C `unsigned int`
+  --> $DIR/repr-c-big-discriminant1.rs:43:5
+   |
+LL |     A = 2147483648, // i32::MAX+1
+   |     ^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #124403 <https://github.com/rust-lang/rust/issues/124403>
+   = note: `repr(C)` enums with big discriminants are non-portable, and their size in Rust might not match their size in C
+   = help: use `repr($int_ty)` instead to explicitly set the size of this enum
+
+error: `repr(C)` enum discriminant does not fit into C `int` nor into C `unsigned int`
+  --> $DIR/repr-c-big-discriminant1.rs:53:5
    |
 LL |     A = I64_MAX as isize,
    |     ^
@@ -36,5 +58,5 @@ LL |     A = I64_MAX as isize,
    = note: `repr(C)` enums with big discriminants are non-portable, and their size in Rust might not match their size in C
    = help: use `repr($int_ty)` instead to explicitly set the size of this enum
 
-error: aborting due to 3 previous errors
+error: aborting due to 5 previous errors
 

--- a/tests/ui/enum-discriminant/repr-c-big-discriminant1.rs
+++ b/tests/ui/enum-discriminant/repr-c-big-discriminant1.rs
@@ -1,0 +1,40 @@
+//@ revisions: ptr32 ptr64
+//@[ptr32] compile-flags: --target i686-unknown-linux-gnu
+//@[ptr32] needs-llvm-components: x86
+//@[ptr64] compile-flags: --target x86_64-unknown-linux-gnu
+//@[ptr64] needs-llvm-components: x86
+#![deny(repr_c_enums_larger_than_int)]
+
+//@ add-core-stubs
+#![feature(no_core)]
+#![no_core]
+extern crate minicore;
+use minicore::*;
+
+#[repr(C)]
+enum OverflowingEnum1 {
+    A = 9223372036854775807, // i64::MAX
+    //[ptr32]~^ ERROR: literal out of range
+    //[ptr64]~^^ ERROR: discriminant does not fit into C `int`
+    //[ptr64]~^^^ WARN: previously accepted
+}
+
+#[repr(C)]
+enum OverflowingEnum2 {
+    A = -2147483649, // i32::MIN-1
+    //[ptr32]~^ ERROR: literal out of range
+    //[ptr64]~^^ ERROR: discriminant does not fit into C `int`
+    //[ptr64]~^^^ WARN: previously accepted
+}
+
+const I64_MAX: i64 = 9223372036854775807;
+
+#[repr(C)]
+enum OverflowingEnum3 {
+    A = I64_MAX as isize,
+    //[ptr64]~^ ERROR: discriminant does not fit into C `int`
+    //[ptr64]~^^ WARN: previously accepted
+    // No warning/error on 32bit targets, but the `as isize` hints that wrapping is occurring.
+}
+
+fn main() {}

--- a/tests/ui/enum-discriminant/repr-c-big-discriminant1.rs
+++ b/tests/ui/enum-discriminant/repr-c-big-discriminant1.rs
@@ -3,6 +3,8 @@
 //@[ptr32] needs-llvm-components: x86
 //@[ptr64] compile-flags: --target x86_64-unknown-linux-gnu
 //@[ptr64] needs-llvm-components: x86
+// GCC doesn't like cross-compilation
+//@ ignore-backends: gcc
 #![deny(repr_c_enums_larger_than_int)]
 
 //@ add-core-stubs
@@ -15,7 +17,7 @@ use minicore::*;
 enum OverflowingEnum1 {
     A = 9223372036854775807, // i64::MAX
     //[ptr32]~^ ERROR: literal out of range
-    //[ptr64]~^^ ERROR: discriminant does not fit into C `int`
+    //[ptr64]~^^ ERROR: discriminant does not fit into C `int` nor into C `unsigned int`
     //[ptr64]~^^^ WARN: previously accepted
 }
 
@@ -23,18 +25,43 @@ enum OverflowingEnum1 {
 enum OverflowingEnum2 {
     A = -2147483649, // i32::MIN-1
     //[ptr32]~^ ERROR: literal out of range
-    //[ptr64]~^^ ERROR: discriminant does not fit into C `int`
+    //[ptr64]~^^ ERROR: discriminant does not fit into C `int` nor into C `unsigned int`
+    //[ptr64]~^^^ WARN: previously accepted
+}
+
+#[repr(C)]
+enum OverflowingEnum3a {
+    A = 2147483648, // i32::MAX+1
+    //[ptr32]~^ ERROR: literal out of range
+    B = -1,
+    //[ptr64]~^ ERROR: discriminant does not fit into C `unsigned int`, and a previous
+    //[ptr64]~^^ WARN: previously accepted
+}
+#[repr(C)]
+enum OverflowingEnum3b {
+    B = -1,
+    A = 2147483648, // i32::MAX+1
+    //[ptr32]~^ ERROR: literal out of range
+    //[ptr64]~^^ ERROR: discriminant does not fit into C `int`, and a previous
     //[ptr64]~^^^ WARN: previously accepted
 }
 
 const I64_MAX: i64 = 9223372036854775807;
 
 #[repr(C)]
-enum OverflowingEnum3 {
+enum OverflowingEnum4 {
     A = I64_MAX as isize,
-    //[ptr64]~^ ERROR: discriminant does not fit into C `int`
+    //[ptr64]~^ ERROR: discriminant does not fit into C `int` nor into C `unsigned int`
     //[ptr64]~^^ WARN: previously accepted
     // No warning/error on 32bit targets, but the `as isize` hints that wrapping is occurring.
+}
+
+// Enums like this are found in the ecosystem, let's make sure they get accepted.
+#[repr(C)]
+#[allow(overflowing_literals)]
+enum OkayEnum {
+    A = 0,
+    O = 0xffffffff,
 }
 
 fn main() {}

--- a/tests/ui/enum-discriminant/repr-c-big-discriminant2.ptr32.stderr
+++ b/tests/ui/enum-discriminant/repr-c-big-discriminant2.ptr32.stderr
@@ -1,5 +1,5 @@
 error[E0370]: enum discriminant overflowed
-  --> $DIR/repr-c-big-discriminant2.rs:19:5
+  --> $DIR/repr-c-big-discriminant2.rs:24:5
    |
 LL |     B, // +1
    |     ^ overflowed on value after 2147483647

--- a/tests/ui/enum-discriminant/repr-c-big-discriminant2.ptr32.stderr
+++ b/tests/ui/enum-discriminant/repr-c-big-discriminant2.ptr32.stderr
@@ -1,0 +1,11 @@
+error[E0370]: enum discriminant overflowed
+  --> $DIR/repr-c-big-discriminant2.rs:19:5
+   |
+LL |     B, // +1
+   |     ^ overflowed on value after 2147483647
+   |
+   = note: explicitly set `B = -2147483648` if that is desired outcome
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0370`.

--- a/tests/ui/enum-discriminant/repr-c-big-discriminant2.ptr64.stderr
+++ b/tests/ui/enum-discriminant/repr-c-big-discriminant2.ptr64.stderr
@@ -1,5 +1,5 @@
-error: `repr(C)` enum discriminant does not fit into C `int`
-  --> $DIR/repr-c-big-discriminant2.rs:19:5
+error: `repr(C)` enum discriminant does not fit into C `int`, and a previous discriminant does not fit into C `unsigned int`
+  --> $DIR/repr-c-big-discriminant2.rs:24:5
    |
 LL |     B, // +1
    |     ^
@@ -9,7 +9,7 @@ LL |     B, // +1
    = note: `repr(C)` enums with big discriminants are non-portable, and their size in Rust might not match their size in C
    = help: use `repr($int_ty)` instead to explicitly set the size of this enum
 note: the lint level is defined here
-  --> $DIR/repr-c-big-discriminant2.rs:6:9
+  --> $DIR/repr-c-big-discriminant2.rs:8:9
    |
 LL | #![deny(repr_c_enums_larger_than_int)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/enum-discriminant/repr-c-big-discriminant2.ptr64.stderr
+++ b/tests/ui/enum-discriminant/repr-c-big-discriminant2.ptr64.stderr
@@ -1,0 +1,18 @@
+error: `repr(C)` enum discriminant does not fit into C `int`
+  --> $DIR/repr-c-big-discriminant2.rs:19:5
+   |
+LL |     B, // +1
+   |     ^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #124403 <https://github.com/rust-lang/rust/issues/124403>
+   = note: `repr(C)` enums with big discriminants are non-portable, and their size in Rust might not match their size in C
+   = help: use `repr($int_ty)` instead to explicitly set the size of this enum
+note: the lint level is defined here
+  --> $DIR/repr-c-big-discriminant2.rs:6:9
+   |
+LL | #![deny(repr_c_enums_larger_than_int)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/enum-discriminant/repr-c-big-discriminant2.rs
+++ b/tests/ui/enum-discriminant/repr-c-big-discriminant2.rs
@@ -1,0 +1,25 @@
+//@ revisions: ptr32 ptr64
+//@[ptr32] compile-flags: --target i686-unknown-linux-gnu
+//@[ptr32] needs-llvm-components: x86
+//@[ptr64] compile-flags: --target x86_64-unknown-linux-gnu
+//@[ptr64] needs-llvm-components: x86
+#![deny(repr_c_enums_larger_than_int)]
+
+//@ add-core-stubs
+#![feature(no_core)]
+#![no_core]
+extern crate minicore;
+use minicore::*;
+
+// Separate test since it suppresses other errors on ptr32
+
+#[repr(C)]
+enum OverflowingEnum {
+    A = 2147483647, // i32::MAX
+    B, // +1
+    //[ptr32]~^ ERROR: enum discriminant overflowed
+    //[ptr64]~^^ ERROR: discriminant does not fit into C `int`
+    //[ptr64]~^^^ WARN: previously accepted
+}
+
+fn main() {}

--- a/tests/ui/enum-discriminant/repr-c-big-discriminant2.rs
+++ b/tests/ui/enum-discriminant/repr-c-big-discriminant2.rs
@@ -3,6 +3,8 @@
 //@[ptr32] needs-llvm-components: x86
 //@[ptr64] compile-flags: --target x86_64-unknown-linux-gnu
 //@[ptr64] needs-llvm-components: x86
+// GCC doesn't like cross-compilation
+//@ ignore-backends: gcc
 #![deny(repr_c_enums_larger_than_int)]
 
 //@ add-core-stubs
@@ -11,10 +13,13 @@
 extern crate minicore;
 use minicore::*;
 
-// Separate test since it suppresses other errors on ptr32
+// Separate test since it suppresses other errors on ptr32:
+// ensure we find the bad discriminant when it is implicitly computed by incrementing
+// the previous discriminant.
 
 #[repr(C)]
 enum OverflowingEnum {
+    NEG = -1,
     A = 2147483647, // i32::MAX
     B, // +1
     //[ptr32]~^ ERROR: enum discriminant overflowed

--- a/tests/ui/error-codes/E0401.stderr
+++ b/tests/ui/error-codes/E0401.stderr
@@ -8,6 +8,7 @@ LL |     fn bfnr<U, V: Baz<U>, W: Fn()>(y: T) {
    |        |
    |        generic parameter used in this inner function
    |
+   = note: nested items are independent from their parent item for everything except for privacy and name resolution
 help: try introducing a local generic parameter here
    |
 LL |     fn bfnr<T, U, V: Baz<U>, W: Fn()>(y: T) {
@@ -25,6 +26,7 @@ LL |     fn baz<U,
 LL |            (y: T) {
    |                ^ use of generic parameter from outer item
    |
+   = note: nested items are independent from their parent item for everything except for privacy and name resolution
 help: try introducing a local generic parameter here
    |
 LL |     fn baz<T, U,
@@ -41,6 +43,7 @@ LL |         fn helper(sel: &Self) -> u8 {
    |            |
    |            `Self` used in this inner function
    |
+   = note: nested items are independent from their parent item for everything except for privacy and name resolution
 help: refer to the type directly here instead
    |
 LL -         fn helper(sel: &Self) -> u8 {

--- a/tests/ui/error-codes/E0401.stderr
+++ b/tests/ui/error-codes/E0401.stderr
@@ -37,11 +37,15 @@ LL | impl<T> Iterator for A<T> {
    | ---- `Self` type implicitly declared here, by this `impl`
 ...
 LL |         fn helper(sel: &Self) -> u8 {
-   |            ------       ^^^^
-   |            |            |
-   |            |            use of `Self` from outer item
-   |            |            refer to the type directly here instead
+   |            ------       ^^^^ use of `Self` from outer item
+   |            |
    |            `Self` used in this inner function
+   |
+help: refer to the type directly here instead
+   |
+LL -         fn helper(sel: &Self) -> u8 {
+LL +         fn helper(sel: &A<T>) -> u8 {
+   |
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/generics/enum-definition-with-outer-generic-parameter-5997.stderr
+++ b/tests/ui/generics/enum-definition-with-outer-generic-parameter-5997.stderr
@@ -8,6 +8,7 @@ LL |     enum E { V(Z) }
    |          |
    |          generic parameter used in this inner enum
    |
+   = note: nested items are independent from their parent item for everything except for privacy and name resolution
 help: try introducing a local generic parameter here
    |
 LL |     enum E<Z> { V(Z) }

--- a/tests/ui/generics/generic-params-nested-fn-scope-error.stderr
+++ b/tests/ui/generics/generic-params-nested-fn-scope-error.stderr
@@ -8,6 +8,7 @@ LL |     fn bar(w: [U]) -> U {
    |        |
    |        generic parameter used in this inner function
    |
+   = note: nested items are independent from their parent item for everything except for privacy and name resolution
 help: try introducing a local generic parameter here
    |
 LL |     fn bar<U>(w: [U]) -> U {
@@ -23,6 +24,7 @@ LL |     fn bar(w: [U]) -> U {
    |        |
    |        generic parameter used in this inner function
    |
+   = note: nested items are independent from their parent item for everything except for privacy and name resolution
 help: try introducing a local generic parameter here
    |
 LL |     fn bar<U>(w: [U]) -> U {

--- a/tests/ui/generics/invalid-type-param-default.stderr
+++ b/tests/ui/generics/invalid-type-param-default.stderr
@@ -2,7 +2,7 @@ error[E0128]: generic parameter defaults cannot reference parameters before they
   --> $DIR/invalid-type-param-default.rs:12:12
    |
 LL | fn mdn<T = T::Item>(_: T) {}
-   |            ^^^^^^^ cannot reference `T` before it is declared
+   |            ^ cannot reference `T` before it is declared
 
 error: defaults for generic parameters are not allowed here
   --> $DIR/invalid-type-param-default.rs:7:8

--- a/tests/ui/generics/issue-98432.stderr
+++ b/tests/ui/generics/issue-98432.stderr
@@ -9,6 +9,7 @@ LL |         struct _Obligation where T:;
    |                |
    |                generic parameter used in this inner struct
    |
+   = note: nested items are independent from their parent item for everything except for privacy and name resolution
 help: try introducing a local generic parameter here
    |
 LL |         struct _Obligation<T> where T:;

--- a/tests/ui/macros/cfg.rs
+++ b/tests/ui/macros/cfg.rs
@@ -1,6 +1,6 @@
 fn main() {
     cfg!(); //~ ERROR macro requires a cfg-pattern
-    cfg!(123); //~ ERROR malformed `cfg` attribute input
-    cfg!(foo = 123); //~ ERROR malformed `cfg` attribute input
+    cfg!(123); //~ ERROR malformed `cfg` macro input
+    cfg!(foo = 123); //~ ERROR malformed `cfg` macro input
     cfg!(foo, bar); //~ ERROR expected 1 cfg-pattern
 }

--- a/tests/ui/macros/cfg.rs
+++ b/tests/ui/macros/cfg.rs
@@ -1,6 +1,6 @@
 fn main() {
     cfg!(); //~ ERROR macro requires a cfg-pattern
-    cfg!(123); //~ ERROR literal in `cfg` predicate value must be a boolean
-    cfg!(foo = 123); //~ ERROR literal in `cfg` predicate value must be a string
+    cfg!(123); //~ ERROR malformed `cfg` attribute input
+    cfg!(foo = 123); //~ ERROR malformed `cfg` attribute input
     cfg!(foo, bar); //~ ERROR expected 1 cfg-pattern
 }

--- a/tests/ui/macros/cfg.stderr
+++ b/tests/ui/macros/cfg.stderr
@@ -4,17 +4,27 @@ error: macro requires a cfg-pattern as an argument
 LL |     cfg!();
    |     ^^^^^^ cfg-pattern required
 
-error[E0565]: literal in `cfg` predicate value must be a boolean
-  --> $DIR/cfg.rs:3:10
+error[E0539]: malformed `cfg` attribute input
+  --> $DIR/cfg.rs:3:5
    |
 LL |     cfg!(123);
-   |          ^^^
+   |     ^^^^^---^
+   |     |    |
+   |     |    expected a valid identifier here
+   |     help: must be of the form: `cfg(predicate)`
+   |
+   = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
 
-error[E0565]: literal in `cfg` predicate value must be a string
-  --> $DIR/cfg.rs:4:16
+error[E0539]: malformed `cfg` attribute input
+  --> $DIR/cfg.rs:4:5
    |
 LL |     cfg!(foo = 123);
-   |                ^^^
+   |     ^^^^^^^^^^^---^
+   |     |          |
+   |     |          expected a string literal here
+   |     help: must be of the form: `cfg(predicate)`
+   |
+   = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
 
 error: expected 1 cfg-pattern
   --> $DIR/cfg.rs:5:5
@@ -24,4 +34,4 @@ LL |     cfg!(foo, bar);
 
 error: aborting due to 4 previous errors
 
-For more information about this error, try `rustc --explain E0565`.
+For more information about this error, try `rustc --explain E0539`.

--- a/tests/ui/macros/cfg.stderr
+++ b/tests/ui/macros/cfg.stderr
@@ -4,7 +4,7 @@ error: macro requires a cfg-pattern as an argument
 LL |     cfg!();
    |     ^^^^^^ cfg-pattern required
 
-error[E0539]: malformed `cfg` attribute input
+error[E0539]: malformed `cfg` macro input
   --> $DIR/cfg.rs:3:5
    |
 LL |     cfg!(123);
@@ -15,7 +15,7 @@ LL |     cfg!(123);
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
 
-error[E0539]: malformed `cfg` attribute input
+error[E0539]: malformed `cfg` macro input
   --> $DIR/cfg.rs:4:5
    |
 LL |     cfg!(foo = 123);

--- a/tests/ui/nll/issue-51191.rs
+++ b/tests/ui/nll/issue-51191.rs
@@ -2,16 +2,17 @@ struct Struct;
 
 impl Struct {
     fn bar(self: &mut Self) {
-        //~^ WARN function cannot return without recursing
-        //~^^ HELP a `loop` may express intention better if this is on purpose
+        //~^ WARN: function cannot return without recursing
+        //~| HELP: a `loop` may express intention better if this is on purpose
+        //~| HELP: consider making the binding mutable if you need to reborrow multiple times
         (&mut self).bar();
-        //~^ ERROR cannot borrow `self` as mutable, as it is not declared as mutable [E0596]
-        //~^^ HELP try removing `&mut` here
+        //~^ ERROR: cannot borrow `self` as mutable, as it is not declared as mutable [E0596]
+        //~| HELP: try removing `&mut` here
     }
 
     fn imm(self) { //~ HELP consider changing this to be mutable
         (&mut self).bar();
-        //~^ ERROR cannot borrow `self` as mutable, as it is not declared as mutable [E0596]
+        //~^ ERROR: cannot borrow `self` as mutable, as it is not declared as mutable [E0596]
     }
 
     fn mtbl(mut self) {
@@ -20,14 +21,14 @@ impl Struct {
 
     fn immref(&self) {
         (&mut self).bar();
-        //~^ ERROR cannot borrow `self` as mutable, as it is not declared as mutable [E0596]
-        //~^^ ERROR cannot borrow data in a `&` reference as mutable [E0596]
+        //~^ ERROR: cannot borrow `self` as mutable, as it is not declared as mutable [E0596]
+        //~| ERROR: cannot borrow data in a `&` reference as mutable [E0596]
     }
 
     fn mtblref(&mut self) {
         (&mut self).bar();
-        //~^ ERROR cannot borrow `self` as mutable, as it is not declared as mutable [E0596]
-        //~^^ HELP try removing `&mut` here
+        //~^ ERROR: cannot borrow `self` as mutable, as it is not declared as mutable [E0596]
+        //~| HELP: try removing `&mut` here
     }
 }
 

--- a/tests/ui/nll/issue-51191.stderr
+++ b/tests/ui/nll/issue-51191.stderr
@@ -11,7 +11,7 @@ LL |         (&mut self).bar();
    = note: `#[warn(unconditional_recursion)]` on by default
 
 error[E0596]: cannot borrow `self` as mutable, as it is not declared as mutable
-  --> $DIR/issue-51191.rs:7:9
+  --> $DIR/issue-51191.rs:8:9
    |
 LL |         (&mut self).bar();
    |         ^^^^^^^^^^^ cannot borrow as mutable
@@ -22,13 +22,17 @@ note: the binding is already a mutable borrow
 LL |     fn bar(self: &mut Self) {
    |                  ^^^^^^^^^
 help: try removing `&mut` here
-  --> $DIR/issue-51191.rs:7:9
+  --> $DIR/issue-51191.rs:8:9
    |
 LL |         (&mut self).bar();
    |         ^^^^^^^^^^^
+help: consider making the binding mutable if you need to reborrow multiple times
+   |
+LL |     fn bar(mut self: &mut Self) {
+   |            +++
 
 error[E0596]: cannot borrow `self` as mutable, as it is not declared as mutable
-  --> $DIR/issue-51191.rs:13:9
+  --> $DIR/issue-51191.rs:14:9
    |
 LL |         (&mut self).bar();
    |         ^^^^^^^^^^^ cannot borrow as mutable
@@ -39,30 +43,30 @@ LL |     fn imm(mut self) {
    |            +++
 
 error[E0596]: cannot borrow `self` as mutable, as it is not declared as mutable
-  --> $DIR/issue-51191.rs:22:9
+  --> $DIR/issue-51191.rs:23:9
    |
 LL |         (&mut self).bar();
    |         ^^^^^^^^^^^ cannot borrow as mutable
 
 error[E0596]: cannot borrow data in a `&` reference as mutable
-  --> $DIR/issue-51191.rs:22:9
+  --> $DIR/issue-51191.rs:23:9
    |
 LL |         (&mut self).bar();
    |         ^^^^^^^^^^^ cannot borrow as mutable
 
 error[E0596]: cannot borrow `self` as mutable, as it is not declared as mutable
-  --> $DIR/issue-51191.rs:28:9
+  --> $DIR/issue-51191.rs:29:9
    |
 LL |         (&mut self).bar();
    |         ^^^^^^^^^^^ cannot borrow as mutable
    |
 note: the binding is already a mutable borrow
-  --> $DIR/issue-51191.rs:27:16
+  --> $DIR/issue-51191.rs:28:16
    |
 LL |     fn mtblref(&mut self) {
    |                ^^^^^^^^^
 help: try removing `&mut` here
-  --> $DIR/issue-51191.rs:28:9
+  --> $DIR/issue-51191.rs:29:9
    |
 LL |         (&mut self).bar();
    |         ^^^^^^^^^^^

--- a/tests/ui/parser/let-chains-assign-add-incorrect.fixed
+++ b/tests/ui/parser/let-chains-assign-add-incorrect.fixed
@@ -5,7 +5,7 @@
 
 fn test_where_left_is_not_let() {
     let y = 2;
-    if let _ = 1 && true && y += 2 {};
+    if let _ = 1 && true && y == 2 {};
     //~^ ERROR expected expression, found `let` statement
     //~| NOTE only supported directly in conditions of `if` and `while` expressions
     //~| ERROR mismatched types
@@ -19,7 +19,7 @@ fn test_where_left_is_not_let() {
 
 fn test_where_left_is_let() {
     let y = 2;
-    if let _ = 1 && y += 2 {};
+    if let _ = 1 && y == 2 {};
     //~^ ERROR expected expression, found `let` statement
     //~| NOTE only supported directly in conditions of `if` and `while` expressions
     //~| ERROR mismatched types

--- a/tests/ui/parser/let-chains-assign-add-incorrect.rs
+++ b/tests/ui/parser/let-chains-assign-add-incorrect.rs
@@ -1,0 +1,28 @@
+//@ edition:2024
+
+fn test_where_left_is_not_let() {
+    let mut y = 2;
+    if let x = 1 && true && y += 2 {};
+    //~^ ERROR expected expression, found `let` statement
+    //~| NOTE only supported directly in conditions of `if` and `while` expressions
+    //~| ERROR mismatched types
+    //~| NOTE expected `bool`, found integer
+    //~| NOTE expected because this is `bool`
+    //~| ERROR binary assignment operation `+=` cannot be used in a let chain
+    //~| NOTE cannot use `+=` in a let chain
+    //~| HELP you might have meant to compare with `==` instead of assigning with `+=`
+}
+
+fn test_where_left_is_let() {
+    let mut y = 2;
+    if let x = 1 && y += 2 {};
+    //~^ ERROR expected expression, found `let` statement
+    //~| NOTE only supported directly in conditions of `if` and `while` expressions
+    //~| ERROR mismatched types
+    //~| NOTE expected `bool`, found integer
+    //~| ERROR binary assignment operation `+=` cannot be used in a let chain
+    //~| NOTE cannot use `+=` in a let chain
+    //~| HELP you might have meant to compare with `==` instead of assigning with `+=`
+}
+
+fn main() {}

--- a/tests/ui/parser/let-chains-assign-add-incorrect.stderr
+++ b/tests/ui/parser/let-chains-assign-add-incorrect.stderr
@@ -1,0 +1,58 @@
+error: expected expression, found `let` statement
+  --> $DIR/let-chains-assign-add-incorrect.rs:5:8
+   |
+LL |     if let x = 1 && true && y += 2 {};
+   |        ^^^^^^^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
+
+error: expected expression, found `let` statement
+  --> $DIR/let-chains-assign-add-incorrect.rs:18:8
+   |
+LL |     if let x = 1 && y += 2 {};
+   |        ^^^^^^^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
+
+error[E0308]: mismatched types
+  --> $DIR/let-chains-assign-add-incorrect.rs:5:29
+   |
+LL |     if let x = 1 && true && y += 2 {};
+   |        -----------------    ^ expected `bool`, found integer
+   |        |
+   |        expected because this is `bool`
+
+error[E0368]: binary assignment operation `+=` cannot be used in a let chain
+  --> $DIR/let-chains-assign-add-incorrect.rs:5:31
+   |
+LL |     if let x = 1 && true && y += 2 {};
+   |                               ^^ cannot use `+=` in a let chain
+   |
+help: you might have meant to compare with `==` instead of assigning with `+=`
+   |
+LL -     if let x = 1 && true && y += 2 {};
+LL +     if let x = 1 && true && y == 2 {};
+   |
+
+error[E0308]: mismatched types
+  --> $DIR/let-chains-assign-add-incorrect.rs:18:21
+   |
+LL |     if let x = 1 && y += 2 {};
+   |                     ^ expected `bool`, found integer
+
+error[E0368]: binary assignment operation `+=` cannot be used in a let chain
+  --> $DIR/let-chains-assign-add-incorrect.rs:18:23
+   |
+LL |     if let x = 1 && y += 2 {};
+   |                       ^^ cannot use `+=` in a let chain
+   |
+help: you might have meant to compare with `==` instead of assigning with `+=`
+   |
+LL -     if let x = 1 && y += 2 {};
+LL +     if let x = 1 && y == 2 {};
+   |
+
+error: aborting due to 6 previous errors
+
+Some errors have detailed explanations: E0308, E0368.
+For more information about an error, try `rustc --explain E0308`.

--- a/tests/ui/parser/let-chains-assign-add-incorrect.stderr
+++ b/tests/ui/parser/let-chains-assign-add-incorrect.stderr
@@ -1,58 +1,61 @@
 error: expected expression, found `let` statement
-  --> $DIR/let-chains-assign-add-incorrect.rs:5:8
+  --> $DIR/let-chains-assign-add-incorrect.rs:8:8
    |
-LL |     if let x = 1 && true && y += 2 {};
+LL |     if let _ = 1 && true && y += 2 {};
    |        ^^^^^^^^^
    |
    = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
-  --> $DIR/let-chains-assign-add-incorrect.rs:18:8
+  --> $DIR/let-chains-assign-add-incorrect.rs:22:8
    |
-LL |     if let x = 1 && y += 2 {};
+LL |     if let _ = 1 && y += 2 {};
    |        ^^^^^^^^^
    |
    = note: only supported directly in conditions of `if` and `while` expressions
 
 error[E0308]: mismatched types
-  --> $DIR/let-chains-assign-add-incorrect.rs:5:29
+  --> $DIR/let-chains-assign-add-incorrect.rs:8:29
    |
-LL |     if let x = 1 && true && y += 2 {};
+LL |     if let _ = 1 && true && y += 2 {};
    |        -----------------    ^ expected `bool`, found integer
    |        |
    |        expected because this is `bool`
 
-error[E0368]: binary assignment operation `+=` cannot be used in a let chain
-  --> $DIR/let-chains-assign-add-incorrect.rs:5:31
+error: binary assignment operation `+=` cannot be used in a let chain
+  --> $DIR/let-chains-assign-add-incorrect.rs:8:31
    |
-LL |     if let x = 1 && true && y += 2 {};
-   |                               ^^ cannot use `+=` in a let chain
+LL |     if let _ = 1 && true && y += 2 {};
+   |        ---------------------- ^^ cannot use `+=` in a let chain
+   |        |
+   |        you are add-assigning the right-hand side expression to the result of this let-chain
    |
 help: you might have meant to compare with `==` instead of assigning with `+=`
    |
-LL -     if let x = 1 && true && y += 2 {};
-LL +     if let x = 1 && true && y == 2 {};
+LL -     if let _ = 1 && true && y += 2 {};
+LL +     if let _ = 1 && true && y == 2 {};
    |
 
 error[E0308]: mismatched types
-  --> $DIR/let-chains-assign-add-incorrect.rs:18:21
+  --> $DIR/let-chains-assign-add-incorrect.rs:22:21
    |
-LL |     if let x = 1 && y += 2 {};
+LL |     if let _ = 1 && y += 2 {};
    |                     ^ expected `bool`, found integer
 
-error[E0368]: binary assignment operation `+=` cannot be used in a let chain
-  --> $DIR/let-chains-assign-add-incorrect.rs:18:23
+error: binary assignment operation `+=` cannot be used in a let chain
+  --> $DIR/let-chains-assign-add-incorrect.rs:22:23
    |
-LL |     if let x = 1 && y += 2 {};
-   |                       ^^ cannot use `+=` in a let chain
+LL |     if let _ = 1 && y += 2 {};
+   |        -------------- ^^ cannot use `+=` in a let chain
+   |        |
+   |        you are add-assigning the right-hand side expression to the result of this let-chain
    |
 help: you might have meant to compare with `==` instead of assigning with `+=`
    |
-LL -     if let x = 1 && y += 2 {};
-LL +     if let x = 1 && y == 2 {};
+LL -     if let _ = 1 && y += 2 {};
+LL +     if let _ = 1 && y == 2 {};
    |
 
 error: aborting due to 6 previous errors
 
-Some errors have detailed explanations: E0308, E0368.
-For more information about an error, try `rustc --explain E0308`.
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/resolve/bad-type-env-capture.stderr
+++ b/tests/ui/resolve/bad-type-env-capture.stderr
@@ -8,6 +8,7 @@ LL |     fn bar(b: T) { }
    |        |
    |        generic parameter used in this inner function
    |
+   = note: nested items are independent from their parent item for everything except for privacy and name resolution
 help: try introducing a local generic parameter here
    |
 LL |     fn bar<T>(b: T) { }

--- a/tests/ui/resolve/generic-params-from-outer-item-in-const-item.default.stderr
+++ b/tests/ui/resolve/generic-params-from-outer-item-in-const-item.default.stderr
@@ -4,7 +4,7 @@ error[E0401]: can't use generic parameters from outer item
 LL | fn outer<T: Tr>() { // outer function
    |          - type parameter from outer item
 LL |     const K: u32 = T::C;
-   |           -        ^^^^ use of generic parameter from outer item
+   |           -        ^ use of generic parameter from outer item
    |           |
    |           generic parameter used in this inner constant item
    |
@@ -17,7 +17,7 @@ LL | impl<T> Tr for T { // outer impl block
    |      - type parameter from outer item
 LL |     const C: u32 = {
 LL |         const I: u32 = T::C;
-   |               -        ^^^^ use of generic parameter from outer item
+   |               -        ^ use of generic parameter from outer item
    |               |
    |               generic parameter used in this inner constant item
    |
@@ -29,7 +29,7 @@ error[E0401]: can't use generic parameters from outer item
 LL | struct S<T: Tr>(U32<{ // outer struct
    |          - type parameter from outer item
 LL |     const _: u32 = T::C;
-   |           -        ^^^^ use of generic parameter from outer item
+   |           -        ^ use of generic parameter from outer item
    |           |
    |           generic parameter used in this inner constant item
    |

--- a/tests/ui/resolve/generic-params-from-outer-item-in-const-item.default.stderr
+++ b/tests/ui/resolve/generic-params-from-outer-item-in-const-item.default.stderr
@@ -8,6 +8,7 @@ LL |     const K: u32 = T::C;
    |           |
    |           generic parameter used in this inner constant item
    |
+   = note: nested items are independent from their parent item for everything except for privacy and name resolution
    = note: a `const` is a separate item from the item that contains it
 
 error[E0401]: can't use generic parameters from outer item
@@ -21,6 +22,7 @@ LL |         const I: u32 = T::C;
    |               |
    |               generic parameter used in this inner constant item
    |
+   = note: nested items are independent from their parent item for everything except for privacy and name resolution
    = note: a `const` is a separate item from the item that contains it
 
 error[E0401]: can't use generic parameters from outer item
@@ -33,6 +35,7 @@ LL |     const _: u32 = T::C;
    |           |
    |           generic parameter used in this inner constant item
    |
+   = note: nested items are independent from their parent item for everything except for privacy and name resolution
    = note: a `const` is a separate item from the item that contains it
 
 error: aborting due to 3 previous errors

--- a/tests/ui/resolve/generic-params-from-outer-item-in-const-item.generic_const_items.stderr
+++ b/tests/ui/resolve/generic-params-from-outer-item-in-const-item.generic_const_items.stderr
@@ -4,7 +4,7 @@ error[E0401]: can't use generic parameters from outer item
 LL | fn outer<T: Tr>() { // outer function
    |          - type parameter from outer item
 LL |     const K: u32 = T::C;
-   |           -        ^^^^ use of generic parameter from outer item
+   |           -        ^ use of generic parameter from outer item
    |           |
    |           generic parameter used in this inner constant item
    |
@@ -21,7 +21,7 @@ LL | impl<T> Tr for T { // outer impl block
    |      - type parameter from outer item
 LL |     const C: u32 = {
 LL |         const I: u32 = T::C;
-   |               -        ^^^^ use of generic parameter from outer item
+   |               -        ^ use of generic parameter from outer item
    |               |
    |               generic parameter used in this inner constant item
    |
@@ -37,7 +37,7 @@ error[E0401]: can't use generic parameters from outer item
 LL | struct S<T: Tr>(U32<{ // outer struct
    |          - type parameter from outer item
 LL |     const _: u32 = T::C;
-   |           -        ^^^^ use of generic parameter from outer item
+   |           -        ^ use of generic parameter from outer item
    |           |
    |           generic parameter used in this inner constant item
    |

--- a/tests/ui/resolve/generic-params-from-outer-item-in-const-item.generic_const_items.stderr
+++ b/tests/ui/resolve/generic-params-from-outer-item-in-const-item.generic_const_items.stderr
@@ -8,6 +8,7 @@ LL |     const K: u32 = T::C;
    |           |
    |           generic parameter used in this inner constant item
    |
+   = note: nested items are independent from their parent item for everything except for privacy and name resolution
    = note: a `const` is a separate item from the item that contains it
 help: try introducing a local generic parameter here
    |
@@ -25,6 +26,7 @@ LL |         const I: u32 = T::C;
    |               |
    |               generic parameter used in this inner constant item
    |
+   = note: nested items are independent from their parent item for everything except for privacy and name resolution
    = note: a `const` is a separate item from the item that contains it
 help: try introducing a local generic parameter here
    |
@@ -41,6 +43,7 @@ LL |     const _: u32 = T::C;
    |           |
    |           generic parameter used in this inner constant item
    |
+   = note: nested items are independent from their parent item for everything except for privacy and name resolution
    = note: a `const` is a separate item from the item that contains it
 help: try introducing a local generic parameter here
    |

--- a/tests/ui/resolve/issue-12796.stderr
+++ b/tests/ui/resolve/issue-12796.stderr
@@ -7,6 +7,8 @@ LL |         fn inner(_: &Self) {
    |            |         use of `Self` from outer item
    |            |         can't use `Self` here
    |            `Self` used in this inner function
+   |
+   = note: nested items are independent from their parent item for everything except for privacy and name resolution
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/resolve/issue-3021-c.stderr
+++ b/tests/ui/resolve/issue-3021-c.stderr
@@ -9,6 +9,7 @@ LL |     trait U {
 LL |         fn g(&self, x: T) -> T;
    |                        ^ use of generic parameter from outer item
    |
+   = note: nested items are independent from their parent item for everything except for privacy and name resolution
 help: try introducing a local generic parameter here
    |
 LL |     trait U<T> {
@@ -25,6 +26,7 @@ LL |     trait U {
 LL |         fn g(&self, x: T) -> T;
    |                              ^ use of generic parameter from outer item
    |
+   = note: nested items are independent from their parent item for everything except for privacy and name resolution
 help: try introducing a local generic parameter here
    |
 LL |     trait U<T> {

--- a/tests/ui/resolve/issue-3214.stderr
+++ b/tests/ui/resolve/issue-3214.stderr
@@ -8,6 +8,7 @@ LL |     struct Foo {
 LL |         x: T,
    |            ^ use of generic parameter from outer item
    |
+   = note: nested items are independent from their parent item for everything except for privacy and name resolution
 help: try introducing a local generic parameter here
    |
 LL |     struct Foo<T> {

--- a/tests/ui/resolve/issue-39559.stderr
+++ b/tests/ui/resolve/issue-39559.stderr
@@ -2,7 +2,7 @@ error: generic parameters may not be used in const operations
   --> $DIR/issue-39559.rs:14:18
    |
 LL |     entries: [T; D::dim()],
-   |                  ^^^^^^ cannot perform const operation using `D`
+   |                  ^ cannot perform const operation using `D`
    |
    = note: type parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions

--- a/tests/ui/resolve/issue-65025-extern-static-parent-generics.stderr
+++ b/tests/ui/resolve/issue-65025-extern-static-parent-generics.stderr
@@ -10,6 +10,7 @@ LL | |
 LL | |     }
    | |_____- generic parameter used in this inner extern block
    |
+   = note: nested items are independent from their parent item for everything except for privacy and name resolution
    = note: a `static` is a separate item from the item that contains it
 
 error: aborting due to 1 previous error

--- a/tests/ui/resolve/issue-65035-static-with-parent-generics.stderr
+++ b/tests/ui/resolve/issue-65035-static-with-parent-generics.stderr
@@ -10,6 +10,7 @@ LL | |
 LL | |     }
    | |_____- generic parameter used in this inner extern block
    |
+   = note: nested items are independent from their parent item for everything except for privacy and name resolution
    = note: a `static` is a separate item from the item that contains it
 
 error[E0401]: can't use generic parameters from outer item
@@ -22,6 +23,7 @@ LL |     static a: *const T = Default::default();
    |            |
    |            generic parameter used in this inner static item
    |
+   = note: nested items are independent from their parent item for everything except for privacy and name resolution
    = note: a `static` is a separate item from the item that contains it
 
 error[E0401]: can't use generic parameters from outer item
@@ -36,6 +38,7 @@ LL | |
 LL | |     }
    | |_____- generic parameter used in this inner extern block
    |
+   = note: nested items are independent from their parent item for everything except for privacy and name resolution
    = note: a `static` is a separate item from the item that contains it
 
 error[E0401]: can't use generic parameters from outer item
@@ -48,6 +51,7 @@ LL |     static a: [u8; N] = [0; N];
    |            |
    |            generic parameter used in this inner static item
    |
+   = note: nested items are independent from their parent item for everything except for privacy and name resolution
    = note: a `static` is a separate item from the item that contains it
 
 error[E0401]: can't use generic parameters from outer item
@@ -60,6 +64,7 @@ LL |     static a: [u8; N] = [0; N];
    |            |
    |            generic parameter used in this inner static item
    |
+   = note: nested items are independent from their parent item for everything except for privacy and name resolution
    = note: a `static` is a separate item from the item that contains it
 
 error: aborting due to 5 previous errors

--- a/tests/ui/resolve/resolve-type-param-in-item-in-trait.stderr
+++ b/tests/ui/resolve/resolve-type-param-in-item-in-trait.stderr
@@ -9,6 +9,7 @@ LL |         enum Foo<B> {
 LL |             Variance(A)
    |                      ^ use of generic parameter from outer item
    |
+   = note: nested items are independent from their parent item for everything except for privacy and name resolution
 help: try introducing a local generic parameter here
    |
 LL |         enum Foo<A, B> {
@@ -25,6 +26,7 @@ LL |         struct Foo<B>(A);
    |                |
    |                generic parameter used in this inner struct
    |
+   = note: nested items are independent from their parent item for everything except for privacy and name resolution
 help: try introducing a local generic parameter here
    |
 LL |         struct Foo<A, B>(A);
@@ -41,6 +43,7 @@ LL |         struct Foo<B> { a: A }
    |                |
    |                generic parameter used in this inner struct
    |
+   = note: nested items are independent from their parent item for everything except for privacy and name resolution
 help: try introducing a local generic parameter here
    |
 LL |         struct Foo<A, B> { a: A }
@@ -57,6 +60,7 @@ LL |         fn foo<B>(a: A) { }
    |            |
    |            generic parameter used in this inner function
    |
+   = note: nested items are independent from their parent item for everything except for privacy and name resolution
 help: try introducing a local generic parameter here
    |
 LL |         fn foo<A, B>(a: A) { }

--- a/tests/ui/resolve/use-self-in-inner-fn.rs
+++ b/tests/ui/resolve/use-self-in-inner-fn.rs
@@ -8,6 +8,7 @@ impl A {
         //~| NOTE use of `Self` from outer item
         //~| NOTE `Self` used in this inner function
         //~| HELP refer to the type directly here instead
+        //~| NOTE nested items are independent from their
         }
     }
 }
@@ -27,6 +28,7 @@ impl MyEnum {
             //~^ ERROR can't use `Self` from outer item
             //~| NOTE use of `Self` from outer item
             //~| HELP refer to the type directly here instead
+            //~| NOTE nested items are independent from their
             MyEnum::do_something(move || {});
         }
         inner();

--- a/tests/ui/resolve/use-self-in-inner-fn.rs
+++ b/tests/ui/resolve/use-self-in-inner-fn.rs
@@ -7,8 +7,29 @@ impl A {
         //~^ ERROR can't use `Self` from outer item
         //~| NOTE use of `Self` from outer item
         //~| NOTE `Self` used in this inner function
-        //~| NOTE refer to the type directly here instead
+        //~| HELP refer to the type directly here instead
         }
+    }
+}
+
+enum MyEnum {}
+
+impl MyEnum {
+//~^ NOTE `Self` type implicitly declared here, by this `impl`
+    fn do_something(result: impl FnOnce()) {
+        result();
+    }
+
+    fn do_something_extra() {
+        fn inner() {
+        //~^ NOTE `Self` used in this inner function
+            Self::do_something(move || {});
+            //~^ ERROR can't use `Self` from outer item
+            //~| NOTE use of `Self` from outer item
+            //~| HELP refer to the type directly here instead
+            MyEnum::do_something(move || {});
+        }
+        inner();
     }
 }
 

--- a/tests/ui/resolve/use-self-in-inner-fn.stderr
+++ b/tests/ui/resolve/use-self-in-inner-fn.stderr
@@ -25,12 +25,12 @@ LL |         fn inner() {
    |            ----- `Self` used in this inner function
 LL |
 LL |             Self::do_something(move || {});
-   |             ^^^^^^^^^^^^^^^^^^ use of `Self` from outer item
+   |             ^^^^ use of `Self` from outer item
    |
 help: refer to the type directly here instead
    |
 LL -             Self::do_something(move || {});
-LL +             MyEnum(move || {});
+LL +             MyEnum::do_something(move || {});
    |
 
 error: aborting due to 2 previous errors

--- a/tests/ui/resolve/use-self-in-inner-fn.stderr
+++ b/tests/ui/resolve/use-self-in-inner-fn.stderr
@@ -15,6 +15,24 @@ LL -         fn peach(this: &Self) {
 LL +         fn peach(this: &A) {
    |
 
-error: aborting due to 1 previous error
+error[E0401]: can't use `Self` from outer item
+  --> $DIR/use-self-in-inner-fn.rs:26:13
+   |
+LL | impl MyEnum {
+   | ---- `Self` type implicitly declared here, by this `impl`
+...
+LL |         fn inner() {
+   |            ----- `Self` used in this inner function
+LL |
+LL |             Self::do_something(move || {});
+   |             ^^^^^^^^^^^^^^^^^^ use of `Self` from outer item
+   |
+help: refer to the type directly here instead
+   |
+LL -             Self::do_something(move || {});
+LL +             MyEnum(move || {});
+   |
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0401`.

--- a/tests/ui/resolve/use-self-in-inner-fn.stderr
+++ b/tests/ui/resolve/use-self-in-inner-fn.stderr
@@ -9,6 +9,7 @@ LL |         fn peach(this: &Self) {
    |            |
    |            `Self` used in this inner function
    |
+   = note: nested items are independent from their parent item for everything except for privacy and name resolution
 help: refer to the type directly here instead
    |
 LL -         fn peach(this: &Self) {
@@ -16,7 +17,7 @@ LL +         fn peach(this: &A) {
    |
 
 error[E0401]: can't use `Self` from outer item
-  --> $DIR/use-self-in-inner-fn.rs:26:13
+  --> $DIR/use-self-in-inner-fn.rs:27:13
    |
 LL | impl MyEnum {
    | ---- `Self` type implicitly declared here, by this `impl`
@@ -27,6 +28,7 @@ LL |
 LL |             Self::do_something(move || {});
    |             ^^^^ use of `Self` from outer item
    |
+   = note: nested items are independent from their parent item for everything except for privacy and name resolution
 help: refer to the type directly here instead
    |
 LL -             Self::do_something(move || {});

--- a/tests/ui/resolve/use-self-in-inner-fn.stderr
+++ b/tests/ui/resolve/use-self-in-inner-fn.stderr
@@ -5,11 +5,15 @@ LL | impl A {
    | ---- `Self` type implicitly declared here, by this `impl`
 ...
 LL |         fn peach(this: &Self) {
-   |            -----        ^^^^
-   |            |            |
-   |            |            use of `Self` from outer item
-   |            |            refer to the type directly here instead
+   |            -----        ^^^^ use of `Self` from outer item
+   |            |
    |            `Self` used in this inner function
+   |
+help: refer to the type directly here instead
+   |
+LL -         fn peach(this: &Self) {
+LL +         fn peach(this: &A) {
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/span/E0536.rs
+++ b/tests/ui/span/E0536.rs
@@ -1,3 +1,0 @@
-pub fn main() {
-    if cfg!(not()) { } //~ ERROR E0536
-}

--- a/tests/ui/span/E0536.stderr
+++ b/tests/ui/span/E0536.stderr
@@ -1,9 +1,0 @@
-error[E0536]: expected 1 cfg-pattern
-  --> $DIR/E0536.rs:2:13
-   |
-LL |     if cfg!(not()) { }
-   |             ^^^^^
-
-error: aborting due to 1 previous error
-
-For more information about this error, try `rustc --explain E0536`.

--- a/tests/ui/span/E0805.rs
+++ b/tests/ui/span/E0805.rs
@@ -1,0 +1,3 @@
+pub fn main() {
+    if cfg!(not()) { } //~ ERROR E0805
+}

--- a/tests/ui/span/E0805.stderr
+++ b/tests/ui/span/E0805.stderr
@@ -1,4 +1,4 @@
-error[E0805]: malformed `cfg` attribute input
+error[E0805]: malformed `cfg` macro input
   --> $DIR/E0805.rs:2:8
    |
 LL |     if cfg!(not()) { }

--- a/tests/ui/span/E0805.stderr
+++ b/tests/ui/span/E0805.stderr
@@ -1,0 +1,14 @@
+error[E0805]: malformed `cfg` attribute input
+  --> $DIR/E0805.rs:2:8
+   |
+LL |     if cfg!(not()) { }
+   |        ^^^^^^^^--^
+   |        |       |
+   |        |       expected a single argument here
+   |        help: must be of the form: `cfg(predicate)`
+   |
+   = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0805`.

--- a/tests/ui/statics/static-generic-param-soundness.stderr
+++ b/tests/ui/statics/static-generic-param-soundness.stderr
@@ -8,6 +8,7 @@ LL |     static a: Bar<T> = Bar::What;
    |            |
    |            generic parameter used in this inner static item
    |
+   = note: nested items are independent from their parent item for everything except for privacy and name resolution
    = note: a `static` is a separate item from the item that contains it
 
 error[E0392]: type parameter `T` is never used

--- a/tests/ui/type/pattern_types/assoc_const.default.stderr
+++ b/tests/ui/type/pattern_types/assoc_const.default.stderr
@@ -20,7 +20,7 @@ error: generic parameters may not be used in const operations
   --> $DIR/assoc_const.rs:20:40
    |
 LL | fn bar<T: Foo>(_: pattern_type!(u32 is T::START..=T::END)) {}
-   |                                        ^^^^^^^^ cannot perform const operation using `T`
+   |                                        ^ cannot perform const operation using `T`
    |
    = note: type parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
@@ -29,7 +29,7 @@ error: generic parameters may not be used in const operations
   --> $DIR/assoc_const.rs:20:51
    |
 LL | fn bar<T: Foo>(_: pattern_type!(u32 is T::START..=T::END)) {}
-   |                                                   ^^^^^^ cannot perform const operation using `T`
+   |                                                   ^ cannot perform const operation using `T`
    |
    = note: type parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions

--- a/tests/ui/type/type-arg-out-of-scope.stderr
+++ b/tests/ui/type/type-arg-out-of-scope.stderr
@@ -8,6 +8,7 @@ LL |     fn bar(f: Box<dyn FnMut(T) -> T>) { }
    |        |
    |        generic parameter used in this inner function
    |
+   = note: nested items are independent from their parent item for everything except for privacy and name resolution
 help: try introducing a local generic parameter here
    |
 LL |     fn bar<T>(f: Box<dyn FnMut(T) -> T>) { }
@@ -23,6 +24,7 @@ LL |     fn bar(f: Box<dyn FnMut(T) -> T>) { }
    |        |
    |        generic parameter used in this inner function
    |
+   = note: nested items are independent from their parent item for everything except for privacy and name resolution
 help: try introducing a local generic parameter here
    |
 LL |     fn bar<T>(f: Box<dyn FnMut(T) -> T>) { }

--- a/tests/ui/wasm/auxiliary/link-name-in-foreign-crate.rs
+++ b/tests/ui/wasm/auxiliary/link-name-in-foreign-crate.rs
@@ -1,0 +1,7 @@
+#![no_std]
+
+#[link(wasm_import_module = "test")]
+unsafe extern "C" {
+    #[link_name = "close"]
+    pub fn close(x: u32) -> u32;
+}

--- a/tests/ui/wasm/wasm-link-name-in-foreign-crate-respected.rs
+++ b/tests/ui/wasm/wasm-link-name-in-foreign-crate-respected.rs
@@ -1,0 +1,22 @@
+//@ only-wasm32
+//@ aux-build:link-name-in-foreign-crate.rs
+//@ compile-flags: --crate-type cdylib
+//@ build-pass
+//@ no-prefer-dynamic
+
+extern crate link_name_in_foreign_crate;
+
+// This test that the definition of a function named `close`, which collides
+// with the `close` function in libc in theory, is handled correctly in
+// cross-crate situations. The `link_name_in_foreign_crate` dependency declares
+// `close` from a non-`env` wasm import module and then this crate attempts to
+// use the symbol. This should properly ensure that the wasm module name is
+// tagged as `test` and the `close` symbol, to LLD, is mangled, to avoid
+// colliding with the `close` symbol in libc itself.
+
+#[unsafe(no_mangle)]
+pub extern "C" fn foo() {
+    unsafe {
+        link_name_in_foreign_crate::close(1);
+    }
+}


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#147017 (FCW for repr(C) enums whose discriminant values do not fit into a c_int or c_uint)
 - rust-lang/rust#147141 (Suggest making binding `mut` on `&mut` reborrow)
 - rust-lang/rust#147945 (Port `cfg!()` macro to the new attribute parsing system )
 - rust-lang/rust#147951 (Add check for `+=` typo in let chains)
 - rust-lang/rust#148004 (fix: Only special case single line item attribute suggestions)
 - rust-lang/rust#148264 (reflect that type and const parameter can be intermixed)
 - rust-lang/rust#148363 (Fix `wasm_import_module` attribute cross-crate)
 - rust-lang/rust#148447 (Tweak E0401)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=147017,147141,147945,147951,148004,148264,148363,148447)
<!-- homu-ignore:end -->