### PR TITLE
bootstrap: Split out a separate `./x test bootstrap-py` step

### DIFF
--- a/src/bootstrap/src/core/builder/mod.rs
+++ b/src/bootstrap/src/core/builder/mod.rs
@@ -869,6 +869,7 @@ impl<'a> Builder<'a> {
             Kind::Test => describe!(
                 crate::core::build_steps::toolstate::ToolStateCheck,
                 test::Tidy,
+                test::BootstrapPy,
                 test::Bootstrap,
                 test::Ui,
                 test::Crashes,


### PR DESCRIPTION
While testing changes to bootstrap, I was annoyed by the fact that `./x test bootstrap` spams a bunch of mysterious output to the console.

That output turns out to come from `bootstrap_test.py`, which runs unit tests for the Python parts of bootstrap. Those tests are (presumably) useful, but they don't add value when working on the Rust parts of bootstrap.

This PR therefore pulls them out into a separate test step that can be run with `./x test bootstrap-py`.