### PR TITLE
rustdoc: quality of life changes

### DIFF
--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -683,6 +683,7 @@ function preLoadCss(cssUrl) {
                 break;
 
             case "+":
+            case "=":
                 ev.preventDefault();
                 expandAllDocs();
                 break;
@@ -1620,7 +1621,7 @@ function preLoadCss(cssUrl) {
             ["↓", "Move down in search results"],
             ["← / →", "Switch result tab (when results focused)"],
             ["&#9166;", "Go to active search result"],
-            ["+", "Expand all sections"],
+            ["+ / =", "Expand all sections"],
             ["-", "Collapse all sections"],
             // for the sake of brevity, we don't say "inherit impl blocks",
             // although that would be more correct,


### PR DESCRIPTION
- Support `=` shortcut (alongside `+`) to expand all sections. Already support `s` and `S`, `Shift` or not.
- ~~Fix search-input's placeholder. The input is auto focused, any key press will be accepted as input not shortcut, current placeholder is missleading.~~

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
