### PR TITLE
opt-dist: prebuild std in Stage 5 to make cross builds work

### DIFF
--- a/src/tools/opt-dist/src/exec.rs
+++ b/src/tools/opt-dist/src/exec.rs
@@ -118,6 +118,24 @@ impl Bootstrap {
         Self { cmd, metrics_path }
     }
 
+    pub fn build_std(env: &Environment) -> Self {
+        let metrics_path = env.build_root().join("build").join("metrics.json");
+        let cmd = cmd(&[
+            env.python_binary(),
+            env.checkout_path().join("x.py").as_str(),
+            "build",
+            "--host",
+            &env.host_tuple(),
+            "--stage",
+            "1",
+            "library/std",
+        ])
+        .env("RUST_BACKTRACE", "full");
+        let cmd = add_shared_x_flags(env, cmd);
+
+        Self { cmd, metrics_path }
+    }
+
     pub fn dist(env: &Environment, dist_args: &[String]) -> Self {
         let metrics_path = env.build_root().join("metrics.json");
         let args = dist_args.iter().map(|arg| arg.as_str()).collect::<Vec<_>>();

--- a/src/tools/opt-dist/src/main.rs
+++ b/src/tools/opt-dist/src/main.rs
@@ -373,6 +373,8 @@ fn execute_pipeline(
         vec![]
     };
 
+    let std = Bootstrap::build_std(env);
+
     let mut dist = Bootstrap::dist(env, &dist_args)
         .llvm_pgo_optimize(llvm_pgo_profile.as_ref())
         .rustc_pgo_optimize(&rustc_pgo_profile);
@@ -390,7 +392,10 @@ fn execute_pipeline(
 
     // Final stage: Assemble the dist artifacts
     // The previous PGO optimized rustc build and PGO optimized LLVM builds should be reused.
-    timer.section("Stage 5 (final build)", |stage| dist.run(stage))?;
+    timer.section("Stage 5 (final build)", |stage| {
+        std.run(stage)?;
+        dist.run(stage)
+    })?;
 
     // After dist has finished, run a subset of the test suite on the optimized artifacts to discover
     // possible regressions.


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

stage0 redesign broke builds with multiple targets because of `--keep-stage 1`:

```
[2025-10-28T18:40:13.472Z INFO  opt_dist::timer] Section `Stage 5 (final build)` starts
[2025-10-28T18:40:13.472Z INFO  opt_dist::exec] Executing `RUST_BACKTRACE=full python x.py install --rust-profile-use D:/_/B/src/rustc-1.91.0-src\opt-artifacts-CLANG64\rustc-pgo.profdata --keep-stage 0 --keep-stage 1 [at D:\_\B\src\rustc-1.91.0-src]`
Building bootstrap
WARNING: Using a potentially old librustc. This may not behave well.
WARNING: Use `--keep-stage-std` if you want to rebuild the compiler when it changes
Creating a sysroot for stage1 compiler (use `rustup toolchain link 'name' build/host/stage1`)
WARNING: Using a potentially old libstd. This may not behave well.
ERROR: Unable to find the stamp file D:\_\B\src\rustc-1.91.0-src\build-CLANG64\x86_64-pc-windows-gnullvm\stage1-std\wasm32-unknown-unknown\release\.libstd-stamp, did you try to keep a nonexistent build stage?
Bootstrap failed while executing `install --rust-profile-use D:/_/B/src/rustc-1.91.0-src\opt-artifacts-CLANG64\rustc-pgo.profdata --keep-stage 0 --keep-stage 1`
```

add a build job for stage-1 std so we get that stamp available.

r? Kobzol 

*somehow failed locally, maybe `build_std()` should behave differently?*

try-job: dist-x86_64-msvc
try-job: dist-x86_64-linux