### PR TITLE
don't normalize where-clauses when checking well-formedness

### DIFF
--- a/compiler/rustc_hir_analysis/src/check/wfcheck.rs
+++ b/compiler/rustc_hir_analysis/src/check/wfcheck.rs
@@ -1147,17 +1147,16 @@ fn check_trait(tcx: TyCtxt<'_>, item: &hir::Item<'_>) -> Result<(), ErrorGuarant
 ///
 /// Assuming the defaults are used, check that all predicates (bounds on the
 /// assoc type and where clauses on the trait) hold.
-fn check_associated_type_bounds(wfcx: &WfCheckingCtxt<'_, '_>, item: ty::AssocItem, span: Span) {
+fn check_associated_type_bounds(wfcx: &WfCheckingCtxt<'_, '_>, item: ty::AssocItem, _span: Span) {
     let bounds = wfcx.tcx().explicit_item_bounds(item.def_id);
 
     debug!("check_associated_type_bounds: bounds={:?}", bounds);
     let wf_obligations = bounds.iter_identity_copied().flat_map(|(bound, bound_span)| {
-        let normalized_bound = wfcx.normalize(span, None, bound);
         traits::wf::clause_obligations(
             wfcx.infcx,
             wfcx.param_env,
             wfcx.body_def_id,
-            normalized_bound,
+            bound,
             bound_span,
         )
     });
@@ -1525,7 +1524,6 @@ pub(super) fn check_where_clauses<'tcx>(wfcx: &WfCheckingCtxt<'_, 'tcx>, def_id:
 
     assert_eq!(predicates.predicates.len(), predicates.spans.len());
     let wf_obligations = predicates.into_iter().flat_map(|(p, sp)| {
-        let p = wfcx.normalize(sp, None, p);
         traits::wf::clause_obligations(infcx, wfcx.param_env, wfcx.body_def_id, p, sp)
     });
     let obligations: Vec<_> = wf_obligations.chain(default_obligations).collect();

--- a/tests/crashes/133613.rs
+++ b/tests/crashes/133613.rs
@@ -1,3 +1,4 @@
+//@ needs-rustc-debug-assertions
 //@ known-bug: #133613
 
 struct Wrapper<'a>();

--- a/tests/ui/associated-consts/assoc-const-eq-bound-var-in-ty-not-wf.rs
+++ b/tests/ui/associated-consts/assoc-const-eq-bound-var-in-ty-not-wf.rs
@@ -21,8 +21,7 @@ fn take(
         K = { () }
     >,
 ) {}
-//~^^^^^ ERROR implementation of `Project` is not general enough
-//~^^^^ ERROR higher-ranked subtype error
+//~^^^ ERROR higher-ranked subtype error
 //~| ERROR higher-ranked subtype error
 
 trait Project { type Out; }

--- a/tests/ui/associated-consts/assoc-const-eq-bound-var-in-ty-not-wf.stderr
+++ b/tests/ui/associated-consts/assoc-const-eq-bound-var-in-ty-not-wf.stderr
@@ -12,18 +12,5 @@ LL |         K = { () }
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error: implementation of `Project` is not general enough
-  --> $DIR/assoc-const-eq-bound-var-in-ty-not-wf.rs:19:13
-   |
-LL |       _: impl Trait<
-   |  _____________^
-LL | |         <<for<'a> fn(&'a str) -> &'a str as Project>::Out as Discard>::Out,
-LL | |         K = { () }
-LL | |     >,
-   | |_____^ implementation of `Project` is not general enough
-   |
-   = note: `Project` would have to be implemented for the type `for<'a> fn(&'a str) -> &'a str`
-   = note: ...but `Project` is actually implemented for the type `fn(&'0 str) -> &'0 str`, for some specific lifetime `'0`
-
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 

--- a/tests/ui/associated-types/issue-38821.rs
+++ b/tests/ui/associated-types/issue-38821.rs
@@ -32,16 +32,16 @@ pub trait Column: Expression {}
 //~| ERROR the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
 //~| ERROR the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
 //~| ERROR the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
+//~| ERROR the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
+//~| ERROR the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
+//~| ERROR the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
+//~| ERROR the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
+//~| ERROR the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
 pub enum ColumnInsertValue<Col, Expr> where
 //~^ ERROR the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
     Col: Column,
     Expr: Expression<SqlType=<Col::SqlType as IntoNullable>::Nullable>,
-//~^ ERROR the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
-//~| ERROR the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
-//~| ERROR the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
-//~| ERROR the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
-//~| ERROR the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
-//~| ERROR the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
+//~^ ERROR the trait bound `<Col as Expression>::SqlType: IntoNullable` is not satisfied
 {
     Expression(Col, Expr),
     Default(Col),

--- a/tests/ui/associated-types/issue-38821.stderr
+++ b/tests/ui/associated-types/issue-38821.stderr
@@ -1,5 +1,5 @@
 error[E0277]: the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
-  --> $DIR/issue-38821.rs:35:1
+  --> $DIR/issue-38821.rs:40:1
    |
 LL | pub enum ColumnInsertValue<Col, Expr> where
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `NotNull` is not implemented for `<Col as Expression>::SqlType`
@@ -16,8 +16,8 @@ help: consider extending the `where` clause, but there might be an alternative b
 LL |     Expr: Expression<SqlType=<Col::SqlType as IntoNullable>::Nullable>, <Col as Expression>::SqlType: NotNull
    |                                                                         +++++++++++++++++++++++++++++++++++++
 
-error[E0277]: the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
-  --> $DIR/issue-38821.rs:38:22
+error[E0277]: the trait bound `<Col as Expression>::SqlType: IntoNullable` is not satisfied
+  --> $DIR/issue-38821.rs:43:22
    |
 LL |     Expr: Expression<SqlType=<Col::SqlType as IntoNullable>::Nullable>,
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `NotNull` is not implemented for `<Col as Expression>::SqlType`
@@ -82,10 +82,36 @@ LL | impl<T: NotNull> IntoNullable for T {
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0277]: the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
-  --> $DIR/issue-38821.rs:38:22
+  --> $DIR/issue-38821.rs:23:10
    |
+LL | #[derive(Debug, Copy, Clone)]
+   |          ^^^^^ the trait `NotNull` is not implemented for `<Col as Expression>::SqlType`
+   |
+note: required for `<Col as Expression>::SqlType` to implement `IntoNullable`
+  --> $DIR/issue-38821.rs:9:18
+   |
+LL | impl<T: NotNull> IntoNullable for T {
+   |         -------  ^^^^^^^^^^^^     ^
+   |         |
+   |         unsatisfied trait bound introduced here
+note: required for `ColumnInsertValue<Col, Expr>` to implement `Debug`
+  --> $DIR/issue-38821.rs:23:10
+   |
+LL | #[derive(Debug, Copy, Clone)]
+   |          ^^^^^
+...
 LL |     Expr: Expression<SqlType=<Col::SqlType as IntoNullable>::Nullable>,
-   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `NotNull` is not implemented for `<Col as Expression>::SqlType`
+   |                      ------------------------------------------------ unsatisfied trait bound introduced in this `derive` macro
+help: consider further restricting the associated type
+   |
+LL |     Expr: Expression<SqlType=<Col::SqlType as IntoNullable>::Nullable>, <Col as Expression>::SqlType: NotNull,
+   |                                                                       +++++++++++++++++++++++++++++++++++++++
+
+error[E0277]: the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
+  --> $DIR/issue-38821.rs:23:17
+   |
+LL | #[derive(Debug, Copy, Clone)]
+   |                 ^^^^ the trait `NotNull` is not implemented for `<Col as Expression>::SqlType`
    |
 note: required for `<Col as Expression>::SqlType` to implement `IntoNullable`
   --> $DIR/issue-38821.rs:9:18
@@ -112,24 +138,14 @@ LL | impl<T: NotNull> IntoNullable for T {
    |         -------  ^^^^^^^^^^^^     ^
    |         |
    |         unsatisfied trait bound introduced here
-help: consider further restricting the associated type
+note: required for `ColumnInsertValue<Col, Expr>` to implement `Copy`
+  --> $DIR/issue-38821.rs:23:17
    |
-LL |     Expr: Expression<SqlType=<Col::SqlType as IntoNullable>::Nullable>, <Col as Expression>::SqlType: NotNull,
-   |                                                                       +++++++++++++++++++++++++++++++++++++++
-
-error[E0277]: the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
-  --> $DIR/issue-38821.rs:38:22
-   |
+LL | #[derive(Debug, Copy, Clone)]
+   |                 ^^^^
+...
 LL |     Expr: Expression<SqlType=<Col::SqlType as IntoNullable>::Nullable>,
-   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `NotNull` is not implemented for `<Col as Expression>::SqlType`
-   |
-note: required for `<Col as Expression>::SqlType` to implement `IntoNullable`
-  --> $DIR/issue-38821.rs:9:18
-   |
-LL | impl<T: NotNull> IntoNullable for T {
-   |         -------  ^^^^^^^^^^^^     ^
-   |         |
-   |         unsatisfied trait bound introduced here
+   |                      ------------------------------------------------ unsatisfied trait bound introduced in this `derive` macro
 help: consider further restricting the associated type
    |
 LL |     Expr: Expression<SqlType=<Col::SqlType as IntoNullable>::Nullable>, <Col as Expression>::SqlType: NotNull,
@@ -183,10 +199,10 @@ LL | impl<T: NotNull> IntoNullable for T {
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0277]: the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
-  --> $DIR/issue-38821.rs:38:22
+  --> $DIR/issue-38821.rs:23:23
    |
-LL |     Expr: Expression<SqlType=<Col::SqlType as IntoNullable>::Nullable>,
-   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `NotNull` is not implemented for `<Col as Expression>::SqlType`
+LL | #[derive(Debug, Copy, Clone)]
+   |                       ^^^^^ the trait `NotNull` is not implemented for `<Col as Expression>::SqlType`
    |
 note: required for `<Col as Expression>::SqlType` to implement `IntoNullable`
   --> $DIR/issue-38821.rs:9:18
@@ -195,6 +211,14 @@ LL | impl<T: NotNull> IntoNullable for T {
    |         -------  ^^^^^^^^^^^^     ^
    |         |
    |         unsatisfied trait bound introduced here
+note: required for `ColumnInsertValue<Col, Expr>` to implement `Clone`
+  --> $DIR/issue-38821.rs:23:23
+   |
+LL | #[derive(Debug, Copy, Clone)]
+   |                       ^^^^^
+...
+LL |     Expr: Expression<SqlType=<Col::SqlType as IntoNullable>::Nullable>,
+   |                      ------------------------------------------------ unsatisfied trait bound introduced in this `derive` macro
 help: consider further restricting the associated type
    |
 LL |     Expr: Expression<SqlType=<Col::SqlType as IntoNullable>::Nullable>, <Col as Expression>::SqlType: NotNull,
@@ -216,10 +240,10 @@ LL | impl<T: NotNull> IntoNullable for T {
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0277]: the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
-  --> $DIR/issue-38821.rs:38:22
+  --> $DIR/issue-38821.rs:23:10
    |
-LL |     Expr: Expression<SqlType=<Col::SqlType as IntoNullable>::Nullable>,
-   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `NotNull` is not implemented for `<Col as Expression>::SqlType`
+LL | #[derive(Debug, Copy, Clone)]
+   |          ^^^^^ the trait `NotNull` is not implemented for `<Col as Expression>::SqlType`
    |
 note: required for `<Col as Expression>::SqlType` to implement `IntoNullable`
   --> $DIR/issue-38821.rs:9:18
@@ -245,10 +269,10 @@ LL | impl<T: NotNull> IntoNullable for T {
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0277]: the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
-  --> $DIR/issue-38821.rs:38:22
+  --> $DIR/issue-38821.rs:23:23
    |
-LL |     Expr: Expression<SqlType=<Col::SqlType as IntoNullable>::Nullable>,
-   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `NotNull` is not implemented for `<Col as Expression>::SqlType`
+LL | #[derive(Debug, Copy, Clone)]
+   |                       ^^^^^ the trait `NotNull` is not implemented for `<Col as Expression>::SqlType`
    |
 note: required for `<Col as Expression>::SqlType` to implement `IntoNullable`
   --> $DIR/issue-38821.rs:9:18
@@ -257,7 +281,6 @@ LL | impl<T: NotNull> IntoNullable for T {
    |         -------  ^^^^^^^^^^^^     ^
    |         |
    |         unsatisfied trait bound introduced here
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0277]: the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
   --> $DIR/issue-38821.rs:23:10

--- a/tests/ui/impl-trait/in-trait/refine-resolution-errors.rs
+++ b/tests/ui/impl-trait/in-trait/refine-resolution-errors.rs
@@ -14,6 +14,7 @@ impl<T: ?Sized> Mirror for () {
 
 pub trait First {
     async fn first() -> <() as Mirror>::Assoc;
+    //~^ ERROR type annotations needed
 }
 
 impl First for () {

--- a/tests/ui/impl-trait/in-trait/refine-resolution-errors.stderr
+++ b/tests/ui/impl-trait/in-trait/refine-resolution-errors.stderr
@@ -28,7 +28,13 @@ help: consider relaxing the implicit `Sized` restriction
 LL |     type Assoc: ?Sized;
    |               ++++++++
 
-error: aborting due to 2 previous errors
+error[E0282]: type annotations needed
+  --> $DIR/refine-resolution-errors.rs:16:25
+   |
+LL |     async fn first() -> <() as Mirror>::Assoc;
+   |                         ^^^^^^^^^^^^^^^^^^^^^ cannot infer type
 
-Some errors have detailed explanations: E0207, E0277.
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0207, E0277, E0282.
 For more information about an error, try `rustc --explain E0207`.

--- a/tests/ui/lifetimes/issue-76168-hr-outlives-3.rs
+++ b/tests/ui/lifetimes/issue-76168-hr-outlives-3.rs
@@ -10,9 +10,6 @@ async fn wrapper<F>(f: F)
 where
 F:,
 for<'a> <i32 as FnOnce<(&'a mut i32,)>>::Output: Future<Output = ()> + 'a,
-//~^ ERROR: expected a `FnOnce(&'a mut i32)` closure, found `i32`
-//~| ERROR: expected a `FnOnce(&'a mut i32)` closure, found `i32`
-//~| ERROR: expected a `FnOnce(&'a mut i32)` closure, found `i32`
 {
     //~^ ERROR: expected a `FnOnce(&'a mut i32)` closure, found `i32`
     let mut i = 41;

--- a/tests/ui/lifetimes/issue-76168-hr-outlives-3.stderr
+++ b/tests/ui/lifetimes/issue-76168-hr-outlives-3.stderr
@@ -10,30 +10,6 @@ LL | | for<'a> <i32 as FnOnce<(&'a mut i32,)>>::Output: Future<Output = ()> + 'a
    = help: the trait `for<'a> FnOnce(&'a mut i32)` is not implemented for `i32`
 
 error[E0277]: expected a `FnOnce(&'a mut i32)` closure, found `i32`
-  --> $DIR/issue-76168-hr-outlives-3.rs:12:50
-   |
-LL | for<'a> <i32 as FnOnce<(&'a mut i32,)>>::Output: Future<Output = ()> + 'a,
-   |                                                  ^^^^^^^^^^^^^^^^^^^ expected an `FnOnce(&'a mut i32)` closure, found `i32`
-   |
-   = help: the trait `for<'a> FnOnce(&'a mut i32)` is not implemented for `i32`
-
-error[E0277]: expected a `FnOnce(&'a mut i32)` closure, found `i32`
-  --> $DIR/issue-76168-hr-outlives-3.rs:12:57
-   |
-LL | for<'a> <i32 as FnOnce<(&'a mut i32,)>>::Output: Future<Output = ()> + 'a,
-   |                                                         ^^^^^^^^^^^ expected an `FnOnce(&'a mut i32)` closure, found `i32`
-   |
-   = help: the trait `for<'a> FnOnce(&'a mut i32)` is not implemented for `i32`
-
-error[E0277]: expected a `FnOnce(&'a mut i32)` closure, found `i32`
-  --> $DIR/issue-76168-hr-outlives-3.rs:12:72
-   |
-LL | for<'a> <i32 as FnOnce<(&'a mut i32,)>>::Output: Future<Output = ()> + 'a,
-   |                                                                        ^^ expected an `FnOnce(&'a mut i32)` closure, found `i32`
-   |
-   = help: the trait `for<'a> FnOnce(&'a mut i32)` is not implemented for `i32`
-
-error[E0277]: expected a `FnOnce(&'a mut i32)` closure, found `i32`
   --> $DIR/issue-76168-hr-outlives-3.rs:6:26
    |
 LL | async fn wrapper<F>(f: F)
@@ -51,7 +27,7 @@ LL | async fn wrapper<F>(f: F)
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0277]: expected a `FnOnce(&'a mut i32)` closure, found `i32`
-  --> $DIR/issue-76168-hr-outlives-3.rs:16:1
+  --> $DIR/issue-76168-hr-outlives-3.rs:13:1
    |
 LL | / {
 LL | |
@@ -62,6 +38,6 @@ LL | | }
    |
    = help: the trait `for<'a> FnOnce(&'a mut i32)` is not implemented for `i32`
 
-error: aborting due to 7 previous errors
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/methods/filter-relevant-fn-bounds.rs
+++ b/tests/ui/methods/filter-relevant-fn-bounds.rs
@@ -9,8 +9,6 @@ impl Wrapper {
     //~^ ERROR the trait bound `for<'a> F: Output<'a>` is not satisfied
     where
         F: for<'a> FnOnce(<F as Output<'a>>::Type),
-        //~^ ERROR the trait bound `for<'a> F: Output<'a>` is not satisfied
-        //~| ERROR the trait bound `for<'a> F: Output<'a>` is not satisfied
     {
     }
 }

--- a/tests/ui/methods/filter-relevant-fn-bounds.stderr
+++ b/tests/ui/methods/filter-relevant-fn-bounds.stderr
@@ -12,37 +12,15 @@ help: consider further restricting type parameter `F` with trait `Output`
 LL |         F: for<'a> FnOnce(<F as Output<'a>>::Type) + for<'a> Output<'a>,
    |                                                    ++++++++++++++++++++
 
-error[E0277]: the trait bound `for<'a> F: Output<'a>` is not satisfied
-  --> $DIR/filter-relevant-fn-bounds.rs:11:12
-   |
-LL |         F: for<'a> FnOnce(<F as Output<'a>>::Type),
-   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `for<'a> Output<'a>` is not implemented for `F`
-   |
-help: consider further restricting type parameter `F` with trait `Output`
-   |
-LL |         F: for<'a> FnOnce(<F as Output<'a>>::Type) + for<'a> Output<'a>,
-   |                                                    ++++++++++++++++++++
-
-error[E0277]: the trait bound `for<'a> F: Output<'a>` is not satisfied
-  --> $DIR/filter-relevant-fn-bounds.rs:11:20
-   |
-LL |         F: for<'a> FnOnce(<F as Output<'a>>::Type),
-   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `for<'a> Output<'a>` is not implemented for `F`
-   |
-help: consider further restricting type parameter `F` with trait `Output`
-   |
-LL |         F: for<'a> FnOnce(<F as Output<'a>>::Type) + for<'a> Output<'a>,
-   |                                                    ++++++++++++++++++++
-
-error[E0277]: expected a `FnOnce(<{closure@$DIR/filter-relevant-fn-bounds.rs:20:34: 20:41} as Output<'a>>::Type)` closure, found `{closure@$DIR/filter-relevant-fn-bounds.rs:20:34: 20:41}`
-  --> $DIR/filter-relevant-fn-bounds.rs:20:34
+error[E0277]: expected a `FnOnce(<{closure@$DIR/filter-relevant-fn-bounds.rs:18:34: 18:41} as Output<'a>>::Type)` closure, found `{closure@$DIR/filter-relevant-fn-bounds.rs:18:34: 18:41}`
+  --> $DIR/filter-relevant-fn-bounds.rs:18:34
    |
 LL |     wrapper.do_something_wrapper(|value| ());
-   |             -------------------- ^^^^^^^^^^ expected an `FnOnce(<{closure@$DIR/filter-relevant-fn-bounds.rs:20:34: 20:41} as Output<'a>>::Type)` closure, found `{closure@$DIR/filter-relevant-fn-bounds.rs:20:34: 20:41}`
+   |             -------------------- ^^^^^^^^^^ expected an `FnOnce(<{closure@$DIR/filter-relevant-fn-bounds.rs:18:34: 18:41} as Output<'a>>::Type)` closure, found `{closure@$DIR/filter-relevant-fn-bounds.rs:18:34: 18:41}`
    |             |
    |             required by a bound introduced by this call
    |
-   = help: the trait `for<'a> Output<'a>` is not implemented for closure `{closure@$DIR/filter-relevant-fn-bounds.rs:20:34: 20:41}`
+   = help: the trait `for<'a> Output<'a>` is not implemented for closure `{closure@$DIR/filter-relevant-fn-bounds.rs:18:34: 18:41}`
 help: this trait has no implementations, consider adding one
   --> $DIR/filter-relevant-fn-bounds.rs:1:1
    |
@@ -57,6 +35,6 @@ LL |     fn do_something_wrapper<O, F>(self, _: F)
 LL |         F: for<'a> FnOnce(<F as Output<'a>>::Type),
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `Wrapper::do_something_wrapper`
 
-error: aborting due to 4 previous errors
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/regions/regions-normalize-in-where-clause-list.rs
+++ b/tests/ui/regions/regions-normalize-in-where-clause-list.rs
@@ -25,6 +25,7 @@ fn bar<'a, 'b>()
 where
     <() as Project<'a, 'b>>::Item: Eq,
     //~^ ERROR cannot infer
+    //~| ERROR cannot infer
 {
 }
 

--- a/tests/ui/regions/regions-normalize-in-where-clause-list.stderr
+++ b/tests/ui/regions/regions-normalize-in-where-clause-list.stderr
@@ -22,6 +22,31 @@ LL |     <() as Project<'a, 'b>>::Item: Eq,
    = note: expected `Project<'a, 'b>`
               found `Project<'_, '_>`
 
-error: aborting due to 1 previous error
+error[E0803]: cannot infer an appropriate lifetime for lifetime parameter `'a` due to conflicting requirements
+  --> $DIR/regions-normalize-in-where-clause-list.rs:26:36
+   |
+LL |     <() as Project<'a, 'b>>::Item: Eq,
+   |                                    ^^
+   |
+note: first, the lifetime cannot outlive the lifetime `'a` as defined here...
+  --> $DIR/regions-normalize-in-where-clause-list.rs:24:8
+   |
+LL | fn bar<'a, 'b>()
+   |        ^^
+note: ...but the lifetime must also be valid for the lifetime `'b` as defined here...
+  --> $DIR/regions-normalize-in-where-clause-list.rs:24:12
+   |
+LL | fn bar<'a, 'b>()
+   |            ^^
+note: ...so that the types are compatible
+  --> $DIR/regions-normalize-in-where-clause-list.rs:26:36
+   |
+LL |     <() as Project<'a, 'b>>::Item: Eq,
+   |                                    ^^
+   = note: expected `Project<'a, 'b>`
+              found `Project<'_, '_>`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0803`.

--- a/tests/ui/rfcs/rfc-2093-infer-outlives/regions-enum-not-wf.rs
+++ b/tests/ui/rfcs/rfc-2093-infer-outlives/regions-enum-not-wf.rs
@@ -34,6 +34,7 @@ enum RefIndirect<'a, T> {
 enum RefDouble<'a, 'b, T> {
     RefDoubleVariant1(&'a RequireOutlives<'b, T>),
     //~^ ERROR the parameter type `T` may not live long enough [E0309]
+    //~| ERROR the parameter type `T` may not live long enough [E0309]
 }
 
 fn main() {}

--- a/tests/ui/rfcs/rfc-2093-infer-outlives/regions-enum-not-wf.stderr
+++ b/tests/ui/rfcs/rfc-2093-infer-outlives/regions-enum-not-wf.stderr
@@ -38,6 +38,20 @@ help: consider adding an explicit lifetime bound
 LL | enum RefDouble<'a, 'b, T: 'b> {
    |                         ++++
 
-error: aborting due to 3 previous errors
+error[E0309]: the parameter type `T` may not live long enough
+  --> $DIR/regions-enum-not-wf.rs:35:23
+   |
+LL | enum RefDouble<'a, 'b, T> {
+   |                    -- the parameter type `T` must be valid for the lifetime `'b` as defined here...
+LL |     RefDoubleVariant1(&'a RequireOutlives<'b, T>),
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: consider adding an explicit lifetime bound
+   |
+LL | enum RefDouble<'a, 'b, T: 'b> {
+   |                         ++++
+
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0309`.

--- a/tests/ui/traits/deep-norm-pending.rs
+++ b/tests/ui/traits/deep-norm-pending.rs
@@ -7,11 +7,11 @@ trait Bar {
     //~^ ERROR the trait bound `T: Foo` is not satisfied
 }
 impl<T> Bar for T
-//~^ ERROR the trait bound `T: Foo` is not satisfied
+//~^ ERROR the trait bound `T: Bar` is not satisfied
+//~| ERROR the trait bound `T: Foo` is not satisfied
 where
     <T as Foo>::Assoc: Sized,
     //~^ ERROR the trait bound `T: Foo` is not satisfied
-    //~| ERROR the trait bound `T: Foo` is not satisfied
 {
     fn method() {}
     //~^ ERROR the trait bound `T: Foo` is not satisfied

--- a/tests/ui/traits/deep-norm-pending.stderr
+++ b/tests/ui/traits/deep-norm-pending.stderr
@@ -3,6 +3,7 @@ error[E0277]: the trait bound `T: Foo` is not satisfied
    |
 LL | / impl<T> Bar for T
 LL | |
+LL | |
 LL | | where
 LL | |     <T as Foo>::Assoc: Sized,
    | |_____________________________^ the trait `Foo` is not implemented for `T`
@@ -85,12 +86,20 @@ help: consider further restricting type parameter `T` with trait `Foo`
 LL |     <T as Foo>::Assoc: Sized, T: Foo
    |                               ++++++
 
-error[E0277]: the trait bound `T: Foo` is not satisfied
-  --> $DIR/deep-norm-pending.rs:12:24
+error[E0277]: the trait bound `T: Bar` is not satisfied
+  --> $DIR/deep-norm-pending.rs:9:17
    |
+LL | impl<T> Bar for T
+   |                 ^ the trait `Foo` is not implemented for `T`
+   |
+note: required for `T` to implement `Bar`
+  --> $DIR/deep-norm-pending.rs:9:9
+   |
+LL | impl<T> Bar for T
+   |         ^^^     ^
+...
 LL |     <T as Foo>::Assoc: Sized,
-   |                        ^^^^^ the trait `Foo` is not implemented for `T`
-   |
+   |                        ----- unsatisfied trait bound introduced here
 help: consider further restricting type parameter `T` with trait `Foo`
    |
 LL |     <T as Foo>::Assoc: Sized, T: Foo
@@ -109,12 +118,11 @@ LL |     <T as Foo>::Assoc: Sized, T: Foo
    |                               ++++++
 
 error[E0277]: the trait bound `T: Foo` is not satisfied
-  --> $DIR/deep-norm-pending.rs:12:24
+  --> $DIR/deep-norm-pending.rs:13:24
    |
 LL |     <T as Foo>::Assoc: Sized,
    |                        ^^^^^ the trait `Foo` is not implemented for `T`
    |
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: consider further restricting type parameter `T` with trait `Foo`
    |
 LL |     <T as Foo>::Assoc: Sized, T: Foo

--- a/tests/ui/wf/wf-where-clauses-pre-normalization.rs
+++ b/tests/ui/wf/wf-where-clauses-pre-normalization.rs
@@ -1,0 +1,20 @@
+// This is a test, extracted from `modcholesky`, that used to pass wfcheck because we checked
+// well-formedness of where-clauses *after* normalization. We generally want to move to always check
+// WF pre-normalization.
+
+pub struct View<A>(A);
+pub trait Data {
+    type Elem;
+}
+impl<'a, A> Data for View<&'a A> {
+    type Elem = A;
+}
+
+pub fn repro<'a, T>()
+where
+    <View<&'a T> as Data>::Elem: Sized,
+    //~^ ERROR: the parameter type `T` may not live long enough
+{
+}
+
+fn main() {}

--- a/tests/ui/wf/wf-where-clauses-pre-normalization.stderr
+++ b/tests/ui/wf/wf-where-clauses-pre-normalization.stderr
@@ -1,0 +1,17 @@
+error[E0309]: the parameter type `T` may not live long enough
+  --> $DIR/wf-where-clauses-pre-normalization.rs:15:34
+   |
+LL | pub fn repro<'a, T>()
+   |              -- the parameter type `T` must be valid for the lifetime `'a` as defined here...
+LL | where
+LL |     <View<&'a T> as Data>::Elem: Sized,
+   |                                  ^^^^^ ...so that the reference type `&'a T` does not outlive the data it points at
+   |
+help: consider adding an explicit lifetime bound
+   |
+LL | pub fn repro<'a, T: 'a>()
+   |                   ++++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0309`.


### PR DESCRIPTION
WfCheck checks where-clauses after normalization, and we'd like to see what would break if it didn't for https://github.com/rust-lang/trait-system-refactor-initiative/issues/255


r? ghost