### PR TITLE
deeply normalize where-clauses in wfcheck

### DIFF
--- a/compiler/rustc_hir_analysis/src/check/wfcheck.rs
+++ b/compiler/rustc_hir_analysis/src/check/wfcheck.rs
@@ -1500,7 +1500,8 @@ pub(super) fn check_where_clauses<'tcx>(wfcx: &WfCheckingCtxt<'_, 'tcx>, def_id:
 
     assert_eq!(predicates.predicates.len(), predicates.spans.len());
     let wf_obligations = predicates.into_iter().flat_map(|(p, sp)| {
-        let p = wfcx.normalize(sp, None, p);
+        // FIXME: we should be checking for well-formedness pre-normalization.
+        let p = wfcx.deeply_normalize(sp, None, p);
         traits::wf::clause_obligations(infcx, wfcx.param_env, wfcx.body_def_id, p, sp)
     });
     let obligations: Vec<_> = wf_obligations.chain(default_obligations).collect();

--- a/tests/ui/const-generics/issues/issue-88119.stderr
+++ b/tests/ui/const-generics/issues/issue-88119.stderr
@@ -6,6 +6,12 @@ LL | #![feature(const_trait_impl, generic_const_exprs)]
    |
    = help: remove one of these features
 
+error[E0284]: type annotations needed: cannot normalize `<&T as ConstName>::{constant#0}`
+  --> $DIR/issue-88119.rs:21:5
+   |
+LL |     [(); name_len::<T>()]:,
+   |     ^^^^^^^^^^^^^^^^^^^^^ cannot normalize `<&T as ConstName>::{constant#0}`
+
 error[E0275]: overflow evaluating the requirement `&T: [const] ConstName`
   --> $DIR/issue-88119.rs:19:49
    |
@@ -41,6 +47,12 @@ note: required by a bound in `<&T as ConstName>`
    |
 LL |     [(); name_len::<T>()]:,
    |     ^^^^^^^^^^^^^^^^^^^^^ required by this bound in `<&T as ConstName>`
+
+error[E0284]: type annotations needed: cannot normalize `<&mut T as ConstName>::{constant#0}`
+  --> $DIR/issue-88119.rs:28:5
+   |
+LL |     [(); name_len::<T>()]:,
+   |     ^^^^^^^^^^^^^^^^^^^^^ cannot normalize `<&mut T as ConstName>::{constant#0}`
 
 error[E0275]: overflow evaluating the requirement `&mut T: [const] ConstName`
   --> $DIR/issue-88119.rs:26:49
@@ -90,6 +102,7 @@ error[E0275]: overflow evaluating the requirement `&mut &u8: ConstName`
 LL | pub const ICE_2: &'static [u8] = <&mut &u8 as ConstName>::NAME_BYTES;
    |                                   ^^^^^^^^
 
-error: aborting due to 11 previous errors
+error: aborting due to 13 previous errors
 
-For more information about this error, try `rustc --explain E0275`.
+Some errors have detailed explanations: E0275, E0284.
+For more information about an error, try `rustc --explain E0275`.

--- a/tests/ui/traits/next-solver/cycles/normalizes-to-is-not-productive.stderr
+++ b/tests/ui/traits/next-solver/cycles/normalizes-to-is-not-productive.stderr
@@ -21,13 +21,6 @@ LL | impl<T: Bound, U> Trait<U> for T {
    |         -----     ^^^^^^^^     ^
    |         |
    |         unsatisfied trait bound introduced here
-note: required by a bound in `Bound`
-  --> $DIR/normalizes-to-is-not-productive.rs:8:1
-   |
-LL | / trait Bound {
-LL | |     fn method();
-LL | | }
-   | |_^ required by this bound in `Bound`
 
 error[E0277]: the trait bound `Foo: Bound` is not satisfied
   --> $DIR/normalizes-to-is-not-productive.rs:47:19

--- a/tests/ui/traits/next-solver/normalize/normalize-param-env-2.stderr
+++ b/tests/ui/traits/next-solver/normalize/normalize-param-env-2.stderr
@@ -13,6 +13,12 @@ LL | trait A<T> {
 LL |     fn f()
    |        ^ this trait's associated function doesn't have the requirement `<() as A<T>>::Assoc: A<T>`
 
+error[E0275]: overflow evaluating the requirement `<() as A<T>>::Assoc == _`
+  --> $DIR/normalize-param-env-2.rs:24:22
+   |
+LL |         Self::Assoc: A<T>,
+   |                      ^^^^
+
 error[E0275]: overflow evaluating the requirement `<() as A<T>>::Assoc: A<T>`
   --> $DIR/normalize-param-env-2.rs:24:22
    |
@@ -46,6 +52,6 @@ LL |     where
 LL |         Self::Assoc: A<T>,
    |                      ^^^^ required by this bound in `A::f`
 
-error: aborting due to 5 previous errors
+error: aborting due to 6 previous errors
 
 For more information about this error, try `rustc --explain E0275`.

--- a/tests/ui/traits/next-solver/normalize/normalize-param-env-4.next.stderr
+++ b/tests/ui/traits/next-solver/normalize/normalize-param-env-4.next.stderr
@@ -1,9 +1,15 @@
+error[E0275]: overflow evaluating the requirement `<T as Trait>::Assoc == _`
+  --> $DIR/normalize-param-env-4.rs:19:26
+   |
+LL |     <T as Trait>::Assoc: Trait,
+   |                          ^^^^^
+
 error[E0275]: overflow evaluating the requirement `<T as Trait>::Assoc: Trait`
   --> $DIR/normalize-param-env-4.rs:19:26
    |
 LL |     <T as Trait>::Assoc: Trait,
    |                          ^^^^^
 
-error: aborting due to 1 previous error
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0275`.

--- a/tests/ui/traits/next-solver/normalize/normalize-wc-for-wfcheck.rs
+++ b/tests/ui/traits/next-solver/normalize/normalize-wc-for-wfcheck.rs
@@ -1,0 +1,24 @@
+// Wfcheck normalizes where-clauses when checking for WF, so this test passes with the old solver,
+// even though it probably shouldn't due to `repro` missing a `T: 'a` bound. For now, until wfcheck
+// checks clauses pre-normalization, the new solver matches the old solver.
+
+// This test is extracted from a new solver crater run error encountered in `modcholesky`.
+
+//@ check-pass
+//@ compile-flags: -Znext-solver
+
+pub struct View<A>(A);
+pub trait Data {
+    type Elem;
+}
+impl<'a, A> Data for View<&'a A> {
+    type Elem = A;
+}
+
+pub fn repro<'a, T>()
+where
+    <View<&'a T> as Data>::Elem: Sized,
+{
+}
+
+fn main() {}


### PR DESCRIPTION
This deeply normalizes where-clauses so the new solver matches the old solver for some dubious cases, to "fix" https://github.com/rust-lang/trait-system-refactor-initiative/issues/255

r? lcnr
opening as draft (and before squashing) so that you can see the diagnostics fallout 🤔