### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
+++ b/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
@@ -1097,14 +1097,14 @@ fn check_region_bounds_on_impl_item<'tcx>(
         .expect("expected impl item to have generics or else we can't compare them")
         .span;
 
-    let mut generics_span = None;
+    let mut generics_span = tcx.def_span(trait_m.def_id);
     let mut bounds_span = vec![];
     let mut where_span = None;
 
     if let Some(trait_node) = tcx.hir_get_if_local(trait_m.def_id)
         && let Some(trait_generics) = trait_node.generics()
     {
-        generics_span = Some(trait_generics.span);
+        generics_span = trait_generics.span;
         // FIXME: we could potentially look at the impl's bounds to not point at bounds that
         // *are* present in the impl.
         for p in trait_generics.predicates {

--- a/compiler/rustc_hir_analysis/src/errors.rs
+++ b/compiler/rustc_hir_analysis/src/errors.rs
@@ -191,7 +191,7 @@ pub(crate) struct LifetimesOrBoundsMismatchOnTrait {
     #[label]
     pub span: Span,
     #[label(hir_analysis_generics_label)]
-    pub generics_span: Option<Span>,
+    pub generics_span: Span,
     #[label(hir_analysis_where_label)]
     pub where_span: Option<Span>,
     #[label(hir_analysis_bounds_label)]

--- a/compiler/rustc_index/Cargo.toml
+++ b/compiler/rustc_index/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2024"
 rustc_index_macros = { path = "../rustc_index_macros" }
 rustc_macros = { path = "../rustc_macros", optional = true }
 rustc_serialize = { path = "../rustc_serialize", optional = true }
-smallvec = "1.8.1"
+smallvec = { version = "1.8.1", optional = true }
 # tidy-alphabetical-end
 
 [features]
@@ -17,6 +17,7 @@ default = ["nightly"]
 nightly = [
     "dep:rustc_macros",
     "dep:rustc_serialize",
+    "dep:smallvec",
     "rustc_index_macros/nightly",
 ]
 rustc_randomized_layouts = []

--- a/compiler/rustc_resolve/messages.ftl
+++ b/compiler/rustc_resolve/messages.ftl
@@ -11,9 +11,9 @@ resolve_added_macro_use =
 resolve_ancestor_only =
     visibilities can only be restricted to ancestor modules
 
-resolve_anonymous_lifetime_non_gat_report_error =
-    in the trait associated type is declared without lifetime parameters, so using a borrowed type for them requires that lifetime to come from the implemented type
+resolve_anonymous_lifetime_non_gat_report_error = missing lifetime in associated type
     .label = this lifetime must come from the implemented type
+    .note = in the trait the associated type is declared without lifetime parameters, so using a borrowed type for them requires that lifetime to come from the implemented type
 
 resolve_arguments_macro_use_not_allowed = arguments to `macro_use` are not allowed here
 

--- a/compiler/rustc_resolve/src/errors.rs
+++ b/compiler/rustc_resolve/src/errors.rs
@@ -930,6 +930,8 @@ pub(crate) struct AnonymousLifetimeNonGatReportError {
     #[primary_span]
     #[label]
     pub(crate) lifetime: Span,
+    #[note]
+    pub(crate) decl: MultiSpan,
 }
 
 #[derive(Subdiagnostic)]

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -374,11 +374,14 @@ enum LifetimeBinderKind {
     FnPtrType,
     PolyTrait,
     WhereBound,
+    // Item covers foreign items, ADTs, type aliases, trait associated items and
+    // trait alias associated items.
     Item,
     ConstItem,
     Function,
     Closure,
     ImplBlock,
+    // Covers only `impl` associated types.
     ImplAssocType,
 }
 
@@ -1950,14 +1953,12 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
         let Some((rib, span)) = self.lifetime_ribs[..i]
             .iter()
             .rev()
-            .skip(1)
-            .filter_map(|rib| match rib.kind {
+            .find_map(|rib| match rib.kind {
                 LifetimeRibKind::Generics { span, kind: LifetimeBinderKind::ImplBlock, .. } => {
                     Some((rib, span))
                 }
                 _ => None,
             })
-            .next()
         else {
             return;
         };

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -1950,10 +1950,8 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
     }
 
     fn point_at_impl_lifetimes(&mut self, err: &mut Diag<'_>, i: usize, lifetime: Span) {
-        let Some((rib, span)) = self.lifetime_ribs[..i]
-            .iter()
-            .rev()
-            .find_map(|rib| match rib.kind {
+        let Some((rib, span)) =
+            self.lifetime_ribs[..i].iter().rev().find_map(|rib| match rib.kind {
                 LifetimeRibKind::Generics { span, kind: LifetimeBinderKind::ImplBlock, .. } => {
                     Some((rib, span))
                 }

--- a/compiler/rustc_type_ir_macros/Cargo.toml
+++ b/compiler/rustc_type_ir_macros/Cargo.toml
@@ -10,6 +10,6 @@ proc-macro = true
 # tidy-alphabetical-start
 proc-macro2 = "1"
 quote = "1"
-syn = { version = "2.0.9", features = ["full"] }
+syn = { version = "2.0.9", features = ["full", "visit-mut"] }
 synstructure = "0.13.0"
 # tidy-alphabetical-end

--- a/tests/mir-opt/const_prop/invalid_constant.main.GVN.diff
+++ b/tests/mir-opt/const_prop/invalid_constant.main.GVN.diff
@@ -61,17 +61,11 @@
           StorageDead(_1);
           return;
       }
-+ }
-+ 
-+ ALLOC0 (size: 4, align: 4) {
-+     00 00 00 00                                     │ ....
-+ }
-+ 
-+ ALLOC1 (size: 4, align: 4) {
-+     04 00 00 00                                     │ ....
-+ }
-+ 
-+ ALLOC2 (size: 4, align: 4) {
-+     01 00 11 00                                     │ ....
   }
++ 
++ ALLOC0 (size: 4, align: 4) { .. }
++ 
++ ALLOC1 (size: 4, align: 4) { .. }
++ 
++ ALLOC2 (size: 4, align: 4) { .. }
   

--- a/tests/mir-opt/const_prop/invalid_constant.rs
+++ b/tests/mir-opt/const_prop/invalid_constant.rs
@@ -1,6 +1,6 @@
 // skip-filecheck
 //@ test-mir-pass: GVN
-//@ compile-flags: -Zmir-enable-passes=+RemoveZsts
+//@ compile-flags: -Zmir-enable-passes=+RemoveZsts -Zdump-mir-exclude-alloc-bytes
 // Verify that we can pretty print invalid constants.
 
 #![feature(adt_const_params, unsized_const_params)]

--- a/tests/mir-opt/const_prop/union.main.GVN.diff
+++ b/tests/mir-opt/const_prop/union.main.GVN.diff
@@ -34,9 +34,7 @@
           StorageDead(_1);
           return;
       }
-+ }
-+ 
-+ ALLOC0 (size: 4, align: 4) {
-+     01 00 00 00                                     │ ....
   }
++ 
++ ALLOC0 (size: 4, align: 4) { .. }
   

--- a/tests/mir-opt/const_prop/union.rs
+++ b/tests/mir-opt/const_prop/union.rs
@@ -1,6 +1,6 @@
 //! Tests that we can propagate into places that are projections into unions
 //@ test-mir-pass: GVN
-//@ compile-flags: -Zinline-mir
+//@ compile-flags: -Zinline-mir -Zdump-mir-exclude-alloc-bytes
 
 fn val() -> u32 {
     1

--- a/tests/mir-opt/gvn_loop.loop_deref_mut.GVN.diff
+++ b/tests/mir-opt/gvn_loop.loop_deref_mut.GVN.diff
@@ -107,9 +107,7 @@
           StorageDead(_11);
           goto -> bb4;
       }
-+ }
-+ 
-+ ALLOC0 (size: 8, align: 4) {
-+     01 00 00 00 __ __ __ __                         │ ....░░░░
   }
++ 
++ ALLOC0 (size: 8, align: 4) { .. }
   

--- a/tests/mir-opt/gvn_loop.rs
+++ b/tests/mir-opt/gvn_loop.rs
@@ -1,4 +1,5 @@
 //@ test-mir-pass: GVN
+//@ compile-flags: -Zdump-mir-exclude-alloc-bytes
 
 #![crate_type = "lib"]
 #![feature(core_intrinsics, rustc_attrs)]

--- a/tests/ui/impl-header-lifetime-elision/assoc-type.rs
+++ b/tests/ui/impl-header-lifetime-elision/assoc-type.rs
@@ -9,7 +9,7 @@ trait MyTrait {
 
 impl MyTrait for &i32 {
     type Output = &i32;
-    //~^ ERROR in the trait associated type is declared without lifetime parameters, so using a borrowed type for them requires that lifetime to come from the implemented type
+    //~^ ERROR missing lifetime in associated type
 }
 
 impl MyTrait for &u32 {
@@ -19,7 +19,7 @@ impl MyTrait for &u32 {
 
 impl<'a> MyTrait for &f64 {
     type Output = &f64;
-    //~^ ERROR in the trait associated type is declared without lifetime parameters, so using a borrowed type for them requires that lifetime to come from the implemented type
+    //~^ ERROR missing lifetime in associated type
 }
 
 trait OtherTrait<'a> {
@@ -27,7 +27,7 @@ trait OtherTrait<'a> {
 }
 impl OtherTrait<'_> for f64 {
     type Output = &f64;
-    //~^ ERROR in the trait associated type is declared without lifetime parameters, so using a borrowed type for them requires that lifetime to come from the implemented type
+    //~^ ERROR missing lifetime in associated type
 }
 
 // This is what you have to do:

--- a/tests/ui/impl-header-lifetime-elision/assoc-type.rs
+++ b/tests/ui/impl-header-lifetime-elision/assoc-type.rs
@@ -17,6 +17,19 @@ impl MyTrait for &u32 {
     //~^ ERROR `'_` cannot be used here
 }
 
+impl<'a> MyTrait for &f64 {
+    type Output = &f64;
+    //~^ ERROR in the trait associated type is declared without lifetime parameters, so using a borrowed type for them requires that lifetime to come from the implemented type
+}
+
+trait OtherTrait<'a> {
+    type Output;
+}
+impl OtherTrait<'_> for f64 {
+    type Output = &f64;
+    //~^ ERROR in the trait associated type is declared without lifetime parameters, so using a borrowed type for them requires that lifetime to come from the implemented type
+}
+
 // This is what you have to do:
 impl<'a> MyTrait for &'a f32 {
     type Output = &'a f32;

--- a/tests/ui/impl-header-lifetime-elision/assoc-type.stderr
+++ b/tests/ui/impl-header-lifetime-elision/assoc-type.stderr
@@ -1,10 +1,14 @@
 error: in the trait associated type is declared without lifetime parameters, so using a borrowed type for them requires that lifetime to come from the implemented type
   --> $DIR/assoc-type.rs:11:19
    |
-LL | impl MyTrait for &i32 {
-   |     - you could add a lifetime on the impl block, if the trait or the self type can have one
 LL |     type Output = &i32;
    |                   ^ this lifetime must come from the implemented type
+   |
+help: add a lifetime to the impl block and use it in the self type and associated type
+   |
+LL ~ impl<'a> MyTrait for &'a i32 {
+LL ~     type Output = &'a i32;
+   |
 
 error[E0637]: `'_` cannot be used here
   --> $DIR/assoc-type.rs:16:20
@@ -12,6 +16,31 @@ error[E0637]: `'_` cannot be used here
 LL |     type Output = &'_ i32;
    |                    ^^ `'_` is a reserved lifetime name
 
-error: aborting due to 2 previous errors
+error: in the trait associated type is declared without lifetime parameters, so using a borrowed type for them requires that lifetime to come from the implemented type
+  --> $DIR/assoc-type.rs:21:19
+   |
+LL | impl<'a> MyTrait for &f64 {
+   |     ---- there is a named lifetime specified on the impl block you could use
+LL |     type Output = &f64;
+   |                   ^ this lifetime must come from the implemented type
+   |
+help: consider using the lifetime from the impl block
+   |
+LL |     type Output = &'a f64;
+   |                    ++
+
+error: in the trait associated type is declared without lifetime parameters, so using a borrowed type for them requires that lifetime to come from the implemented type
+  --> $DIR/assoc-type.rs:29:19
+   |
+LL |     type Output = &f64;
+   |                   ^ this lifetime must come from the implemented type
+   |
+help: add a lifetime to the impl block and use it in the trait and associated type
+   |
+LL ~ impl<'a> OtherTrait<'a> for f64 {
+LL ~     type Output = &'a f64;
+   |
+
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0637`.

--- a/tests/ui/impl-header-lifetime-elision/assoc-type.stderr
+++ b/tests/ui/impl-header-lifetime-elision/assoc-type.stderr
@@ -1,9 +1,10 @@
-error: in the trait associated type is declared without lifetime parameters, so using a borrowed type for them requires that lifetime to come from the implemented type
+error: missing lifetime in associated type
   --> $DIR/assoc-type.rs:11:19
    |
 LL |     type Output = &i32;
    |                   ^ this lifetime must come from the implemented type
    |
+   = note: in the trait the associated type is declared without lifetime parameters, so using a borrowed type for them requires that lifetime to come from the implemented type
 help: add a lifetime to the impl block and use it in the self type and associated type
    |
 LL ~ impl<'a> MyTrait for &'a i32 {
@@ -16,7 +17,7 @@ error[E0637]: `'_` cannot be used here
 LL |     type Output = &'_ i32;
    |                    ^^ `'_` is a reserved lifetime name
 
-error: in the trait associated type is declared without lifetime parameters, so using a borrowed type for them requires that lifetime to come from the implemented type
+error: missing lifetime in associated type
   --> $DIR/assoc-type.rs:21:19
    |
 LL | impl<'a> MyTrait for &f64 {
@@ -24,17 +25,19 @@ LL | impl<'a> MyTrait for &f64 {
 LL |     type Output = &f64;
    |                   ^ this lifetime must come from the implemented type
    |
+   = note: in the trait the associated type is declared without lifetime parameters, so using a borrowed type for them requires that lifetime to come from the implemented type
 help: consider using the lifetime from the impl block
    |
 LL |     type Output = &'a f64;
    |                    ++
 
-error: in the trait associated type is declared without lifetime parameters, so using a borrowed type for them requires that lifetime to come from the implemented type
+error: missing lifetime in associated type
   --> $DIR/assoc-type.rs:29:19
    |
 LL |     type Output = &f64;
    |                   ^ this lifetime must come from the implemented type
    |
+   = note: in the trait the associated type is declared without lifetime parameters, so using a borrowed type for them requires that lifetime to come from the implemented type
 help: add a lifetime to the impl block and use it in the trait and associated type
    |
 LL ~ impl<'a> OtherTrait<'a> for f64 {

--- a/tests/ui/lifetimes/missing-lifetime-in-assoc-type-2.rs
+++ b/tests/ui/lifetimes/missing-lifetime-in-assoc-type-2.rs
@@ -3,7 +3,7 @@ struct T;
 
 impl IntoIterator for &S {
     type Item = &T;
-    //~^ ERROR in the trait associated type
+    //~^ ERROR missing lifetime in associated type
     type IntoIter = std::collections::btree_map::Values<'a, i32, T>;
     //~^ ERROR use of undeclared lifetime name `'a`
 

--- a/tests/ui/lifetimes/missing-lifetime-in-assoc-type-2.stderr
+++ b/tests/ui/lifetimes/missing-lifetime-in-assoc-type-2.stderr
@@ -1,10 +1,14 @@
 error: in the trait associated type is declared without lifetime parameters, so using a borrowed type for them requires that lifetime to come from the implemented type
   --> $DIR/missing-lifetime-in-assoc-type-2.rs:5:17
    |
-LL | impl IntoIterator for &S {
-   |     - you could add a lifetime on the impl block, if the trait or the self type can have one
 LL |     type Item = &T;
    |                 ^ this lifetime must come from the implemented type
+   |
+help: add a lifetime to the impl block and use it in the self type and associated type
+   |
+LL ~ impl<'a> IntoIterator for &'a S {
+LL ~     type Item = &'a T;
+   |
 
 error[E0261]: use of undeclared lifetime name `'a`
   --> $DIR/missing-lifetime-in-assoc-type-2.rs:7:57

--- a/tests/ui/lifetimes/missing-lifetime-in-assoc-type-2.stderr
+++ b/tests/ui/lifetimes/missing-lifetime-in-assoc-type-2.stderr
@@ -1,9 +1,11 @@
-error: in the trait associated type is declared without lifetime parameters, so using a borrowed type for them requires that lifetime to come from the implemented type
+error: missing lifetime in associated type
   --> $DIR/missing-lifetime-in-assoc-type-2.rs:5:17
    |
 LL |     type Item = &T;
    |                 ^ this lifetime must come from the implemented type
    |
+note: in the trait the associated type is declared without lifetime parameters, so using a borrowed type for them requires that lifetime to come from the implemented type
+  --> $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
 help: add a lifetime to the impl block and use it in the self type and associated type
    |
 LL ~ impl<'a> IntoIterator for &'a S {

--- a/tests/ui/lifetimes/missing-lifetime-in-assoc-type-3.rs
+++ b/tests/ui/lifetimes/missing-lifetime-in-assoc-type-3.rs
@@ -3,7 +3,7 @@ struct T;
 
 impl IntoIterator for &S {
     type Item = &T;
-    //~^ ERROR in the trait associated type
+    //~^ ERROR missing lifetime in associated type
     type IntoIter = std::collections::btree_map::Values<i32, T>;
     //~^ ERROR missing lifetime specifier
 

--- a/tests/ui/lifetimes/missing-lifetime-in-assoc-type-3.stderr
+++ b/tests/ui/lifetimes/missing-lifetime-in-assoc-type-3.stderr
@@ -1,9 +1,11 @@
-error: in the trait associated type is declared without lifetime parameters, so using a borrowed type for them requires that lifetime to come from the implemented type
+error: missing lifetime in associated type
   --> $DIR/missing-lifetime-in-assoc-type-3.rs:5:17
    |
 LL |     type Item = &T;
    |                 ^ this lifetime must come from the implemented type
    |
+note: in the trait the associated type is declared without lifetime parameters, so using a borrowed type for them requires that lifetime to come from the implemented type
+  --> $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
 help: add a lifetime to the impl block and use it in the self type and associated type
    |
 LL ~ impl<'a> IntoIterator for &'a S {

--- a/tests/ui/lifetimes/missing-lifetime-in-assoc-type-3.stderr
+++ b/tests/ui/lifetimes/missing-lifetime-in-assoc-type-3.stderr
@@ -1,10 +1,14 @@
 error: in the trait associated type is declared without lifetime parameters, so using a borrowed type for them requires that lifetime to come from the implemented type
   --> $DIR/missing-lifetime-in-assoc-type-3.rs:5:17
    |
-LL | impl IntoIterator for &S {
-   |     - you could add a lifetime on the impl block, if the trait or the self type can have one
 LL |     type Item = &T;
    |                 ^ this lifetime must come from the implemented type
+   |
+help: add a lifetime to the impl block and use it in the self type and associated type
+   |
+LL ~ impl<'a> IntoIterator for &'a S {
+LL ~     type Item = &'a T;
+   |
 
 error[E0106]: missing lifetime specifier
   --> $DIR/missing-lifetime-in-assoc-type-3.rs:7:56

--- a/tests/ui/lifetimes/missing-lifetime-in-assoc-type-4.rs
+++ b/tests/ui/lifetimes/missing-lifetime-in-assoc-type-4.rs
@@ -3,7 +3,7 @@ struct T;
 
 impl IntoIterator for &S {
     type Item = &T;
-    //~^ ERROR in the trait associated type
+    //~^ ERROR missing lifetime in associated type
     type IntoIter<'a> = std::collections::btree_map::Values<'a, i32, T>;
     //~^ ERROR lifetime parameters or bounds on associated type `IntoIter` do not match the trait declaration
 

--- a/tests/ui/lifetimes/missing-lifetime-in-assoc-type-4.stderr
+++ b/tests/ui/lifetimes/missing-lifetime-in-assoc-type-4.stderr
@@ -1,9 +1,11 @@
-error: in the trait associated type is declared without lifetime parameters, so using a borrowed type for them requires that lifetime to come from the implemented type
+error: missing lifetime in associated type
   --> $DIR/missing-lifetime-in-assoc-type-4.rs:5:17
    |
 LL |     type Item = &T;
    |                 ^ this lifetime must come from the implemented type
    |
+note: in the trait the associated type is declared without lifetime parameters, so using a borrowed type for them requires that lifetime to come from the implemented type
+  --> $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
 help: add a lifetime to the impl block and use it in the self type and associated type
    |
 LL ~ impl<'a> IntoIterator for &'a S {

--- a/tests/ui/lifetimes/missing-lifetime-in-assoc-type-4.stderr
+++ b/tests/ui/lifetimes/missing-lifetime-in-assoc-type-4.stderr
@@ -1,10 +1,14 @@
 error: in the trait associated type is declared without lifetime parameters, so using a borrowed type for them requires that lifetime to come from the implemented type
   --> $DIR/missing-lifetime-in-assoc-type-4.rs:5:17
    |
-LL | impl IntoIterator for &S {
-   |     - you could add a lifetime on the impl block, if the trait or the self type can have one
 LL |     type Item = &T;
    |                 ^ this lifetime must come from the implemented type
+   |
+help: add a lifetime to the impl block and use it in the self type and associated type
+   |
+LL ~ impl<'a> IntoIterator for &'a S {
+LL ~     type Item = &'a T;
+   |
 
 error[E0195]: lifetime parameters or bounds on associated type `IntoIter` do not match the trait declaration
   --> $DIR/missing-lifetime-in-assoc-type-4.rs:7:18

--- a/tests/ui/lifetimes/missing-lifetime-in-assoc-type-4.stderr
+++ b/tests/ui/lifetimes/missing-lifetime-in-assoc-type-4.stderr
@@ -11,6 +11,9 @@ error[E0195]: lifetime parameters or bounds on associated type `IntoIter` do not
    |
 LL |     type IntoIter<'a> = std::collections::btree_map::Values<'a, i32, T>;
    |                  ^^^^ lifetimes do not match associated type in trait
+  --> $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
+   |
+   = note: lifetimes in impl do not match this associated type in trait
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/lifetimes/missing-lifetime-in-assoc-type-4.stderr
+++ b/tests/ui/lifetimes/missing-lifetime-in-assoc-type-4.stderr
@@ -17,6 +17,7 @@ error[E0195]: lifetime parameters or bounds on associated type `IntoIter` do not
    |
 LL |     type IntoIter<'a> = std::collections::btree_map::Values<'a, i32, T>;
    |                  ^^^^ lifetimes do not match associated type in trait
+   |
   --> $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
    |
    = note: lifetimes in impl do not match this associated type in trait

--- a/tests/ui/lifetimes/missing-lifetime-in-assoc-type-5.rs
+++ b/tests/ui/lifetimes/missing-lifetime-in-assoc-type-5.rs
@@ -7,9 +7,10 @@ impl<'a> IntoIterator for &'_ S {
     //~| NOTE unconstrained lifetime parameter
     //~| HELP consider using the named lifetime here instead of an implicit lifetime
     type Item = &T;
-    //~^ ERROR in the trait associated type
+    //~^ ERROR missing lifetime in associated type
     //~| HELP consider using the lifetime from the impl block
     //~| NOTE this lifetime must come from the implemented type
+    //~| NOTE in the trait the associated type is declared without lifetime parameters
     type IntoIter = std::collections::btree_map::Values<'a, i32, T>;
 
     fn into_iter(self) -> Self::IntoIter {

--- a/tests/ui/lifetimes/missing-lifetime-in-assoc-type-5.stderr
+++ b/tests/ui/lifetimes/missing-lifetime-in-assoc-type-5.stderr
@@ -1,4 +1,4 @@
-error: in the trait associated type is declared without lifetime parameters, so using a borrowed type for them requires that lifetime to come from the implemented type
+error: missing lifetime in associated type
   --> $DIR/missing-lifetime-in-assoc-type-5.rs:9:17
    |
 LL | impl<'a> IntoIterator for &'_ S {
@@ -7,6 +7,8 @@ LL | impl<'a> IntoIterator for &'_ S {
 LL |     type Item = &T;
    |                 ^ this lifetime must come from the implemented type
    |
+note: in the trait the associated type is declared without lifetime parameters, so using a borrowed type for them requires that lifetime to come from the implemented type
+  --> $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
 help: consider using the lifetime from the impl block
    |
 LL |     type Item = &'a T;

--- a/tests/ui/lifetimes/missing-lifetime-in-assoc-type-6.rs
+++ b/tests/ui/lifetimes/missing-lifetime-in-assoc-type-6.rs
@@ -1,16 +1,22 @@
+//~ NOTE in the trait the associated type is declared without lifetime parameters
 struct S;
 struct T;
 
-impl<'a> IntoIterator for &S {
+trait Trait {
+    type Item;
+    type IntoIter;
+    fn into_iter(self) -> Self::IntoIter;
+}
+
+impl<'a> Trait for &'_ S {
     //~^ ERROR E0207
     //~| NOTE there is a named lifetime specified on the impl block you could use
     //~| NOTE unconstrained lifetime parameter
-    //~| HELP consider using the named lifetime here instead of an implicit lifetime
+    //~| HELP consider using the named lifetime here instead of an implict lifetime
     type Item = &T;
     //~^ ERROR missing lifetime in associated type
     //~| HELP consider using the lifetime from the impl block
     //~| NOTE this lifetime must come from the implemented type
-    //~| NOTE in the trait the associated type is declared without lifetime parameters
     type IntoIter = std::collections::btree_map::Values<'a, i32, T>;
 
     fn into_iter(self) -> Self::IntoIter {

--- a/tests/ui/lifetimes/missing-lifetime-in-assoc-type-6.rs
+++ b/tests/ui/lifetimes/missing-lifetime-in-assoc-type-6.rs
@@ -12,7 +12,7 @@ impl<'a> Trait for &'_ S {
     //~^ ERROR E0207
     //~| NOTE there is a named lifetime specified on the impl block you could use
     //~| NOTE unconstrained lifetime parameter
-    //~| HELP consider using the named lifetime here instead of an implict lifetime
+    //~| HELP consider using the named lifetime here instead of an implicit lifetime
     type Item = &T;
     //~^ ERROR missing lifetime in associated type
     //~| HELP consider using the lifetime from the impl block

--- a/tests/ui/lifetimes/missing-lifetime-in-assoc-type-6.stderr
+++ b/tests/ui/lifetimes/missing-lifetime-in-assoc-type-6.stderr
@@ -1,29 +1,29 @@
 error: missing lifetime in associated type
-  --> $DIR/missing-lifetime-in-assoc-type-1.rs:9:17
+  --> $DIR/missing-lifetime-in-assoc-type-6.rs:16:17
    |
-LL | impl<'a> IntoIterator for &S {
+LL | impl<'a> Trait for &'_ S {
    |     ---- there is a named lifetime specified on the impl block you could use
 ...
 LL |     type Item = &T;
    |                 ^ this lifetime must come from the implemented type
    |
-note: in the trait the associated type is declared without lifetime parameters, so using a borrowed type for them requires that lifetime to come from the implemented type
-  --> $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
+   = note: in the trait the associated type is declared without lifetime parameters, so using a borrowed type for them requires that lifetime to come from the implemented type
 help: consider using the lifetime from the impl block
    |
 LL |     type Item = &'a T;
    |                  ++
 
 error[E0207]: the lifetime parameter `'a` is not constrained by the impl trait, self type, or predicates
-  --> $DIR/missing-lifetime-in-assoc-type-1.rs:4:6
+  --> $DIR/missing-lifetime-in-assoc-type-6.rs:11:6
    |
-LL | impl<'a> IntoIterator for &S {
+LL | impl<'a> Trait for &'_ S {
    |      ^^ unconstrained lifetime parameter
    |
-help: consider using the named lifetime here instead of an implicit lifetime
+help: consider using the named lifetime here instead of an implict lifetime
    |
-LL | impl<'a> IntoIterator for &'a S {
-   |                            ++
+LL - impl<'a> Trait for &'_ S {
+LL + impl<'a> Trait for &'a S {
+   |
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/lifetimes/missing-lifetime-in-assoc-type-6.stderr
+++ b/tests/ui/lifetimes/missing-lifetime-in-assoc-type-6.stderr
@@ -19,7 +19,7 @@ error[E0207]: the lifetime parameter `'a` is not constrained by the impl trait, 
 LL | impl<'a> Trait for &'_ S {
    |      ^^ unconstrained lifetime parameter
    |
-help: consider using the named lifetime here instead of an implict lifetime
+help: consider using the named lifetime here instead of an implicit lifetime
    |
 LL - impl<'a> Trait for &'_ S {
 LL + impl<'a> Trait for &'a S {

--- a/tests/ui/lifetimes/no_lending_iterators.rs
+++ b/tests/ui/lifetimes/no_lending_iterators.rs
@@ -16,7 +16,7 @@ trait Bar {
 
 impl Bar for usize {
     type Item = &usize;
-    //~^ ERROR in the trait associated type is declared without lifetime parameters, so using a borrowed type for them requires that lifetime to come from the implemented type
+    //~^ ERROR missing lifetime in associated type
 
     fn poke(&mut self, item: Self::Item) {
         self += *item;

--- a/tests/ui/lifetimes/no_lending_iterators.stderr
+++ b/tests/ui/lifetimes/no_lending_iterators.stderr
@@ -14,7 +14,7 @@ error: in the trait associated type is declared without lifetime parameters, so 
   --> $DIR/no_lending_iterators.rs:18:17
    |
 LL | impl Bar for usize {
-   |     - you could add a lifetime on the impl block, if the trait or the self type can have one
+   |     - you could add a lifetime on the impl block, if the trait or the self type could have one
 LL |     type Item = &usize;
    |                 ^ this lifetime must come from the implemented type
 

--- a/tests/ui/lifetimes/no_lending_iterators.stderr
+++ b/tests/ui/lifetimes/no_lending_iterators.stderr
@@ -10,13 +10,15 @@ note: you can't create an `Iterator` that borrows each `Item` from itself, but y
 LL | impl Iterator for Data {
    |                   ^^^^
 
-error: in the trait associated type is declared without lifetime parameters, so using a borrowed type for them requires that lifetime to come from the implemented type
+error: missing lifetime in associated type
   --> $DIR/no_lending_iterators.rs:18:17
    |
 LL | impl Bar for usize {
    |     - you could add a lifetime on the impl block, if the trait or the self type could have one
 LL |     type Item = &usize;
    |                 ^ this lifetime must come from the implemented type
+   |
+   = note: in the trait the associated type is declared without lifetime parameters, so using a borrowed type for them requires that lifetime to come from the implemented type
 
 error[E0195]: lifetime parameters or bounds on associated type `Item` do not match the trait declaration
   --> $DIR/no_lending_iterators.rs:27:14


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#145314 (Tweak output of missing lifetime on associated type)
 - rust-lang/rust#147925 (Fix tests for big-endian)
 - rust-lang/rust#148341 (compiler: Fix a couple issues around cargo feature unification)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=145314,147925,148341)
<!-- homu-ignore:end -->