### PR TITLE
Implement Path::is_empty

### DIFF
--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -2756,6 +2756,28 @@ impl Path {
         iter_after(self.components().rev(), child.components().rev()).is_some()
     }
 
+    /// Checks whether the `Path` is empty.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(path_is_empty)]
+    /// use std::path::Path;
+    ///
+    /// let path = Path::new("");
+    /// assert!(path.is_empty());
+    ///
+    /// let path = Path::new("foo");
+    /// assert!(!path.is_empty());
+    ///
+    /// let path = Path::new(".");
+    /// assert!(!path.is_empty());
+    /// ```
+    #[unstable(feature = "path_is_empty", issue = "148494")]
+    pub fn is_empty(&self) -> bool {
+        self.as_os_str().is_empty()
+    }
+
     /// Extracts the stem (non-extension) portion of [`self.file_name`].
     ///
     /// [`self.file_name`]: Path::file_name


### PR DESCRIPTION
This implements `Path::is_empty` which is simply a convenience wrapper for `path.as_os_str().is_empty()`.

Tracking issue: https://github.com/rust-lang/rust/issues/148494
ACP: https://github.com/rust-lang/libs-team/issues/687

