### PR TITLE
triagebot: Create Zulip topics for libs backports

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -794,6 +794,55 @@ zulip_stream = 474880 # #t-compiler/backports
 topic = "#{number}: stable-nominated"
 message_on_add = "PR #{number} has been **accepted** for **stable** backport."
 
+[notify-zulip."beta-nominated".libs]
+required_labels = ["T-libs"]
+zulip_stream = 542373 # #t-libs/backports
+topic = "#{number}: beta-nominated"
+message_on_add = [
+    """\
+@*T-libs* PR #{number} "{title}" has been nominated for beta backport.
+""",
+    """\
+/poll Should #{number} be beta backported?
+approve
+decline
+don't know
+""",
+]
+message_on_remove = "PR #{number}'s beta-nomination has been removed."
+
+[notify-zulip."beta-accepted".libs]
+required_labels = ["T-libs"]
+zulip_stream = 542373 # #t-libs/backports
+# Put it in the same Zulip topic as beta-nominated.
+topic = "#{number}: beta-nominated"
+message_on_add = "PR #{number} has been **accepted** for **beta** backport."
+
+[notify-zulip."stable-nominated".libs]
+required_labels = ["T-libs"]
+zulip_stream = 542373 # #t-libs/backports
+topic = "#{number}: stable-nominated"
+message_on_add = [
+    """\
+@**channel** PR #{number} "{title}" has been nominated for stable backport.
+""",
+    """\
+/poll Approve stable backport of #{number}?
+approve
+approve (but does not justify new dot release on its own)
+decline
+don't know
+""",
+]
+message_on_remove = "PR #{number}'s stable-nomination has been removed."
+
+[notify-zulip."stable-accepted".libs]
+required_labels = ["T-libs"]
+zulip_stream = 542373 # #t-libs/backports
+# Put it in the same thread as stable-nominated.
+topic = "#{number}: stable-nominated"
+message_on_add = "PR #{number} has been **accepted** for **stable** backport."
+
 
 [notify-zulip."beta-nominated".bootstrap]
 required_labels = ["T-bootstrap"]


### PR DESCRIPTION
Take the configuration used by other teams to create Zulip topics for T-libs backports.

<!-- homu-ignore:start -->
r? @Amanieu
<!-- homu-ignore:end -->
