### PR TITLE
Fix link in c_longlong documentation

### DIFF
--- a/library/core/src/ffi/c_longlong.md
+++ b/library/core/src/ffi/c_longlong.md
@@ -2,4 +2,4 @@ Equivalent to C's `signed long long` (`long long`) type.
 
 This type will almost always be [`i64`], but may differ on some systems. The C standard technically only requires that this type be a signed integer that is at least 64 bits and at least the size of a [`long`], although in practice, no system would have a `long long` that is not an `i64`, as most systems do not have a standardised [`i128`] type.
 
-[`long`]: c_int
+[`long`]: c_long


### PR DESCRIPTION
Ran across this mistake when reading [the documentation](https://doc.rust-lang.org/std/ffi/type.c_longlong.html). I went through the other `.md` files in this directory and didn't spot any other errors.

**I did not check the output of this change** - I couldn't figure out how to get `cargo doc` to work and I figured it's not worth the distraction. It can't really go wrong, can it?