### PR TITLE
Provide more context when mutably borrowing an imutably borrowed value

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/mutability_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/mutability_errors.rs
@@ -213,7 +213,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
             AccessKind::Mutate => {
                 err = self.cannot_assign(span, &(item_msg + &reason));
                 act = "assign";
-                acted_on = "written";
+                acted_on = "written to";
                 span
             }
             AccessKind::MutableBorrow => {
@@ -518,8 +518,8 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
                         err.span_label(
                             span,
                             format!(
-                                "`{name}` is a `{pointer_sigil}` {pointer_desc}, \
-                                 so the data it refers to cannot be {acted_on}",
+                                "`{name}` is a `{pointer_sigil}` {pointer_desc}, so it cannot be \
+                                 {acted_on}",
                             ),
                         );
 
@@ -542,7 +542,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
                 self.expected_fn_found_fn_mut_call(&mut err, span, act);
             }
 
-            PlaceRef { local: _, projection: [.., ProjectionElem::Deref] } => {
+            PlaceRef { local, projection: [.., ProjectionElem::Deref] } => {
                 err.span_label(span, format!("cannot {act}"));
 
                 match opt_source {
@@ -559,11 +559,36 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
                         ));
                         self.suggest_map_index_mut_alternatives(ty, &mut err, span);
                     }
-                    _ => (),
+                    _ => {
+                        let local = &self.body.local_decls[local];
+                        match local.local_info() {
+                            LocalInfo::StaticRef { def_id, .. } => {
+                                let span = self.infcx.tcx.def_span(def_id);
+                                err.span_label(span, format!("this `static` cannot be {acted_on}"));
+                            }
+                            LocalInfo::ConstRef { def_id } => {
+                                let span = self.infcx.tcx.def_span(def_id);
+                                err.span_label(span, format!("this `const` cannot be {acted_on}"));
+                            }
+                            LocalInfo::BlockTailTemp(_) | LocalInfo::Boring
+                                if !local.source_info.span.overlaps(span) =>
+                            {
+                                err.span_label(
+                                    local.source_info.span,
+                                    format!("this cannot be {acted_on}"),
+                                );
+                            }
+                            _ => {}
+                        }
+                    }
                 }
             }
 
-            _ => {
+            PlaceRef { local, .. } => {
+                let local = &self.body.local_decls[local];
+                if !local.source_info.span.overlaps(span) {
+                    err.span_label(local.source_info.span, format!("this cannot be {acted_on}"));
+                }
                 err.span_label(span, format!("cannot {act}"));
             }
         }

--- a/tests/ui/array-slice-vec/slice-mut-2.stderr
+++ b/tests/ui/array-slice-vec/slice-mut-2.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
   --> $DIR/slice-mut-2.rs:7:18
    |
 LL |     let _ = &mut x[2..4];
-   |                  ^ `x` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |                  ^ `x` is a `&` reference, so it cannot be borrowed as mutable
    |
 help: consider changing this binding's type
    |

--- a/tests/ui/borrowck/accidentally-cloning-ref-borrow-error.stderr
+++ b/tests/ui/borrowck/accidentally-cloning-ref-borrow-error.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `sm.x` as mutable, as it is behind a `&` reference
   --> $DIR/accidentally-cloning-ref-borrow-error.rs:32:9
    |
 LL |     foo(&mut sm.x);
-   |         ^^^^^^^^^ `sm` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |         ^^^^^^^^^ `sm` is a `&` reference, so it cannot be borrowed as mutable
    |
 help: `Str` doesn't implement `Clone`, so this call clones the reference `&Str`
   --> $DIR/accidentally-cloning-ref-borrow-error.rs:31:21

--- a/tests/ui/borrowck/argument_number_mismatch_ice.stderr
+++ b/tests/ui/borrowck/argument_number_mismatch_ice.stderr
@@ -11,7 +11,7 @@ error[E0594]: cannot assign to `*input`, which is behind a `&` reference
   --> $DIR/argument_number_mismatch_ice.rs:10:9
    |
 LL |         *input = self.0;
-   |         ^^^^^^^^^^^^^^^ `input` is a `&` reference, so the data it refers to cannot be written
+   |         ^^^^^^^^^^^^^^^ `input` is a `&` reference, so it cannot be written to
    |
 help: consider changing this to be a mutable reference in the `impl` method and the `trait` definition
    |

--- a/tests/ui/borrowck/borrow-raw-address-of-deref-mutability.stderr
+++ b/tests/ui/borrowck/borrow-raw-address-of-deref-mutability.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
   --> $DIR/borrow-raw-address-of-deref-mutability.rs:6:13
    |
 LL |     let q = &raw mut *x;
-   |             ^^^^^^^^^^^ `x` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |             ^^^^^^^^^^^ `x` is a `&` reference, so it cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -13,7 +13,7 @@ error[E0596]: cannot borrow `*x` as mutable, as it is behind a `*const` pointer
   --> $DIR/borrow-raw-address-of-deref-mutability.rs:12:13
    |
 LL |     let q = &raw mut *x;
-   |             ^^^^^^^^^^^ `x` is a `*const` pointer, so the data it refers to cannot be borrowed as mutable
+   |             ^^^^^^^^^^^ `x` is a `*const` pointer, so it cannot be borrowed as mutable
    |
 help: consider specifying this binding's type
    |

--- a/tests/ui/borrowck/borrowck-access-permissions.stderr
+++ b/tests/ui/borrowck/borrowck-access-permissions.stderr
@@ -12,6 +12,9 @@ LL |     let mut x = 1;
 error[E0596]: cannot borrow immutable static item `static_x` as mutable
   --> $DIR/borrowck-access-permissions.rs:16:19
    |
+LL | static static_x: i32 = 1;
+   | -------------------- this `static` cannot be borrowed as mutable
+...
 LL |         let _y1 = &mut static_x;
    |                   ^^^^^^^^^^^^^ cannot borrow as mutable
 
@@ -30,7 +33,7 @@ error[E0596]: cannot borrow `*ref_x` as mutable, as it is behind a `&` reference
   --> $DIR/borrowck-access-permissions.rs:36:19
    |
 LL |         let _y1 = &mut *ref_x;
-   |                   ^^^^^^^^^^^ `ref_x` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |                   ^^^^^^^^^^^ `ref_x` is a `&` reference, so it cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -41,7 +44,7 @@ error[E0596]: cannot borrow `*ptr_x` as mutable, as it is behind a `*const` poin
   --> $DIR/borrowck-access-permissions.rs:46:23
    |
 LL |             let _y1 = &mut *ptr_x;
-   |                       ^^^^^^^^^^^ `ptr_x` is a `*const` pointer, so the data it refers to cannot be borrowed as mutable
+   |                       ^^^^^^^^^^^ `ptr_x` is a `*const` pointer, so it cannot be borrowed as mutable
    |
 help: consider changing this binding's type
    |
@@ -53,7 +56,7 @@ error[E0596]: cannot borrow `*foo_ref.f` as mutable, as it is behind a `&` refer
   --> $DIR/borrowck-access-permissions.rs:59:18
    |
 LL |         let _y = &mut *foo_ref.f;
-   |                  ^^^^^^^^^^^^^^^ `foo_ref` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |                  ^^^^^^^^^^^^^^^ `foo_ref` is a `&` reference, so it cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/borrowck/borrowck-assign-to-andmut-in-aliasable-loc.stderr
+++ b/tests/ui/borrowck/borrowck-assign-to-andmut-in-aliasable-loc.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to `*s.pointer`, which is behind a `&` reference
   --> $DIR/borrowck-assign-to-andmut-in-aliasable-loc.rs:9:5
    |
 LL |     *s.pointer += 1;
-   |     ^^^^^^^^^^^^^^^ `s` is a `&` reference, so the data it refers to cannot be written
+   |     ^^^^^^^^^^^^^^^ `s` is a `&` reference, so it cannot be written to
    |
 help: consider changing this to be a mutable reference
    |
@@ -13,7 +13,7 @@ error[E0594]: cannot assign to `*s.pointer`, which is behind a `&` reference
   --> $DIR/borrowck-assign-to-andmut-in-aliasable-loc.rs:17:5
    |
 LL |     *s.pointer += 1;
-   |     ^^^^^^^^^^^^^^^ `s` is a `&` reference, so the data it refers to cannot be written
+   |     ^^^^^^^^^^^^^^^ `s` is a `&` reference, so it cannot be written to
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/borrowck/borrowck-assign-to-constants.stderr
+++ b/tests/ui/borrowck/borrowck-assign-to-constants.stderr
@@ -1,6 +1,9 @@
 error[E0594]: cannot assign to immutable static item `foo`
   --> $DIR/borrowck-assign-to-constants.rs:5:5
    |
+LL | static foo: isize = 5;
+   | ----------------- this `static` cannot be written to
+...
 LL |     foo = 6;
    |     ^^^^^^^ cannot assign
 

--- a/tests/ui/borrowck/borrowck-borrow-mut-base-ptr-in-aliasable-loc.stderr
+++ b/tests/ui/borrowck/borrowck-borrow-mut-base-ptr-in-aliasable-loc.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to `**t1`, which is behind a `&` reference
   --> $DIR/borrowck-borrow-mut-base-ptr-in-aliasable-loc.rs:9:5
    |
 LL |     **t1 = 22;
-   |     ^^^^^^^^^ `t1` is a `&` reference, so the data it refers to cannot be written
+   |     ^^^^^^^^^ `t1` is a `&` reference, so it cannot be written to
    |
 help: consider specifying this binding's type
    |
@@ -23,7 +23,7 @@ error[E0596]: cannot borrow `**t0` as mutable, as it is behind a `&` reference
   --> $DIR/borrowck-borrow-mut-base-ptr-in-aliasable-loc.rs:19:26
    |
 LL |     let x:  &mut isize = &mut **t0;
-   |                          ^^^^^^^^^ `t0` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |                          ^^^^^^^^^ `t0` is a `&` reference, so it cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/borrowck/borrowck-issue-14498.stderr
+++ b/tests/ui/borrowck/borrowck-issue-14498.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to `***p`, which is behind a `&` reference
   --> $DIR/borrowck-issue-14498.rs:16:5
    |
 LL |     ***p = 2;
-   |     ^^^^^^^^ `p` is a `&` reference, so the data it refers to cannot be written
+   |     ^^^^^^^^ `p` is a `&` reference, so it cannot be written to
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/borrowck/borrowck-reborrow-from-mut.stderr
+++ b/tests/ui/borrowck/borrowck-reborrow-from-mut.stderr
@@ -106,7 +106,7 @@ error[E0596]: cannot borrow `foo.bar1` as mutable, as it is behind a `&` referen
   --> $DIR/borrowck-reborrow-from-mut.rs:88:17
    |
 LL |     let _bar1 = &mut foo.bar1;
-   |                 ^^^^^^^^^^^^^ `foo` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |                 ^^^^^^^^^^^^^ `foo` is a `&` reference, so it cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/borrowck/issue-115259-suggest-iter-mut.stderr
+++ b/tests/ui/borrowck/issue-115259-suggest-iter-mut.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `**layer` as mutable, as it is behind a `&` referenc
   --> $DIR/issue-115259-suggest-iter-mut.rs:15:65
    |
 LL |         self.layers.iter().fold(0, |result, mut layer| result + layer.process())
-   |                                             ---------           ^^^^^ `layer` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |                                             ---------           ^^^^^ `layer` is a `&` reference, so it cannot be borrowed as mutable
    |                                             |
    |                                             consider changing this binding's type to be: `&mut Box<dyn Layer>`
    |

--- a/tests/ui/borrowck/issue-42344.stderr
+++ b/tests/ui/borrowck/issue-42344.stderr
@@ -1,6 +1,9 @@
 error[E0596]: cannot borrow `*TAB[_]` as mutable, as `TAB` is an immutable static item
   --> $DIR/issue-42344.rs:4:5
    |
+LL | static TAB: [&mut [u8]; 0] = [];
+   | -------------------------- this `static` cannot be borrowed as mutable
+...
 LL |     TAB[0].iter_mut();
    |     ^^^^^^ cannot borrow as mutable
 

--- a/tests/ui/borrowck/issue-62387-suggest-iter-mut-2.stderr
+++ b/tests/ui/borrowck/issue-62387-suggest-iter-mut-2.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `*container` as mutable, as it is behind a `&` refer
   --> $DIR/issue-62387-suggest-iter-mut-2.rs:30:45
    |
 LL |             vec.iter().flat_map(|container| container.things()).cloned().collect::<Vec<PathBuf>>();
-   |                                  ---------  ^^^^^^^^^ `container` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |                                  ---------  ^^^^^^^^^ `container` is a `&` reference, so it cannot be borrowed as mutable
    |                                  |
    |                                  consider changing this binding's type to be: `&mut Container`
    |

--- a/tests/ui/borrowck/issue-62387-suggest-iter-mut.stderr
+++ b/tests/ui/borrowck/issue-62387-suggest-iter-mut.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `*a` as mutable, as it is behind a `&` reference
   --> $DIR/issue-62387-suggest-iter-mut.rs:18:27
    |
 LL |     v.iter().for_each(|a| a.double());
-   |                        -  ^ `a` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |                        -  ^ `a` is a `&` reference, so it cannot be borrowed as mutable
    |                        |
    |                        consider changing this binding's type to be: `&mut A`
    |
@@ -15,7 +15,7 @@ error[E0596]: cannot borrow `*a` as mutable, as it is behind a `&` reference
   --> $DIR/issue-62387-suggest-iter-mut.rs:25:39
    |
 LL |     v.iter().rev().rev().for_each(|a| a.double());
-   |                                    -  ^ `a` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |                                    -  ^ `a` is a `&` reference, so it cannot be borrowed as mutable
    |                                    |
    |                                    consider changing this binding's type to be: `&mut A`
    |

--- a/tests/ui/borrowck/issue-69789-iterator-mut-suggestion.stderr
+++ b/tests/ui/borrowck/issue-69789-iterator-mut-suggestion.stderr
@@ -5,7 +5,7 @@ LL |     for item in &mut std::iter::empty::<&'static ()>() {
    |                 -------------------------------------- this iterator yields `&` references
 LL |
 LL |         *item = ();
-   |         ^^^^^^^^^^ `item` is a `&` reference, so the data it refers to cannot be written
+   |         ^^^^^^^^^^ `item` is a `&` reference, so it cannot be written to
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/borrowck/issue-82032.stderr
+++ b/tests/ui/borrowck/issue-82032.stderr
@@ -7,7 +7,7 @@ LL |         for v in self.0.values() {
    |                  |      help: use mutable method: `values_mut()`
    |                  this iterator yields `&` references
 LL |             v.flush();
-   |             ^ `v` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |             ^ `v` is a `&` reference, so it cannot be borrowed as mutable
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/borrowck/issue-83309-ice-immut-in-for-loop.rs
+++ b/tests/ui/borrowck/issue-83309-ice-immut-in-for-loop.rs
@@ -10,7 +10,7 @@ fn main() {
         //~^ NOTE this iterator yields `&` references
         *v -= 1;
         //~^ ERROR cannot assign to `*v`, which is behind a `&` reference
-        //~| NOTE `v` is a `&` reference, so the data it refers to cannot be written
+        //~| NOTE `v` is a `&` reference, so it cannot be written to
     }
 }
 

--- a/tests/ui/borrowck/issue-83309-ice-immut-in-for-loop.stderr
+++ b/tests/ui/borrowck/issue-83309-ice-immut-in-for-loop.stderr
@@ -5,7 +5,7 @@ LL |     for v in Query.iter_mut() {
    |              ---------------- this iterator yields `&` references
 LL |
 LL |         *v -= 1;
-   |         ^^^^^^^ `v` is a `&` reference, so the data it refers to cannot be written
+   |         ^^^^^^^ `v` is a `&` reference, so it cannot be written to
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/borrowck/issue-85765-closure.rs
+++ b/tests/ui/borrowck/issue-85765-closure.rs
@@ -5,27 +5,27 @@ fn main() {
         //~^ HELP consider changing this binding's type
         rofl.push(Vec::new());
         //~^ ERROR cannot borrow `*rofl` as mutable, as it is behind a `&` reference
-        //~| NOTE `rofl` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+        //~| NOTE `rofl` is a `&` reference, so it cannot be borrowed as mutable
 
         let mut mutvar = 42;
         let r = &mutvar;
         //~^ HELP consider changing this to be a mutable reference
         *r = 0;
         //~^ ERROR cannot assign to `*r`, which is behind a `&` reference
-        //~| NOTE `r` is a `&` reference, so the data it refers to cannot be written
+        //~| NOTE `r` is a `&` reference, so it cannot be written to
 
         #[rustfmt::skip]
         let x: &usize = &mut{0};
         //~^ HELP consider changing this binding's type
         *x = 1;
         //~^ ERROR cannot assign to `*x`, which is behind a `&` reference
-        //~| NOTE `x` is a `&` reference, so the data it refers to cannot be written
+        //~| NOTE `x` is a `&` reference, so it cannot be written to
 
         #[rustfmt::skip]
         let y: &usize = &mut(0);
         //~^ HELP consider changing this binding's type
         *y = 1;
         //~^ ERROR cannot assign to `*y`, which is behind a `&` reference
-        //~| NOTE `y` is a `&` reference, so the data it refers to cannot be written
+        //~| NOTE `y` is a `&` reference, so it cannot be written to
     };
 }

--- a/tests/ui/borrowck/issue-85765-closure.stderr
+++ b/tests/ui/borrowck/issue-85765-closure.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `*rofl` as mutable, as it is behind a `&` reference
   --> $DIR/issue-85765-closure.rs:6:9
    |
 LL |         rofl.push(Vec::new());
-   |         ^^^^ `rofl` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |         ^^^^ `rofl` is a `&` reference, so it cannot be borrowed as mutable
    |
 help: consider changing this binding's type
    |
@@ -13,7 +13,7 @@ error[E0594]: cannot assign to `*r`, which is behind a `&` reference
   --> $DIR/issue-85765-closure.rs:13:9
    |
 LL |         *r = 0;
-   |         ^^^^^^ `r` is a `&` reference, so the data it refers to cannot be written
+   |         ^^^^^^ `r` is a `&` reference, so it cannot be written to
    |
 help: consider changing this to be a mutable reference
    |
@@ -24,7 +24,7 @@ error[E0594]: cannot assign to `*x`, which is behind a `&` reference
   --> $DIR/issue-85765-closure.rs:20:9
    |
 LL |         *x = 1;
-   |         ^^^^^^ `x` is a `&` reference, so the data it refers to cannot be written
+   |         ^^^^^^ `x` is a `&` reference, so it cannot be written to
    |
 help: consider changing this binding's type
    |
@@ -35,7 +35,7 @@ error[E0594]: cannot assign to `*y`, which is behind a `&` reference
   --> $DIR/issue-85765-closure.rs:27:9
    |
 LL |         *y = 1;
-   |         ^^^^^^ `y` is a `&` reference, so the data it refers to cannot be written
+   |         ^^^^^^ `y` is a `&` reference, so it cannot be written to
    |
 help: consider changing this binding's type
    |

--- a/tests/ui/borrowck/issue-85765.rs
+++ b/tests/ui/borrowck/issue-85765.rs
@@ -4,26 +4,26 @@ fn main() {
     //~^ HELP consider changing this binding's type
     rofl.push(Vec::new());
     //~^ ERROR cannot borrow `*rofl` as mutable, as it is behind a `&` reference
-    //~| NOTE `rofl` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+    //~| NOTE `rofl` is a `&` reference, so it cannot be borrowed as mutable
 
     let mut mutvar = 42;
     let r = &mutvar;
     //~^ HELP consider changing this to be a mutable reference
     *r = 0;
     //~^ ERROR cannot assign to `*r`, which is behind a `&` reference
-    //~| NOTE `r` is a `&` reference, so the data it refers to cannot be written
+    //~| NOTE `r` is a `&` reference, so it cannot be written to
 
     #[rustfmt::skip]
     let x: &usize = &mut{0};
     //~^ HELP consider changing this binding's type
     *x = 1;
     //~^ ERROR cannot assign to `*x`, which is behind a `&` reference
-    //~| NOTE `x` is a `&` reference, so the data it refers to cannot be written
+    //~| NOTE `x` is a `&` reference, so it cannot be written to
 
     #[rustfmt::skip]
     let y: &usize = &mut(0);
     //~^ HELP consider changing this binding's type
     *y = 1;
     //~^ ERROR cannot assign to `*y`, which is behind a `&` reference
-    //~| NOTE `y` is a `&` reference, so the data it refers to cannot be written
+    //~| NOTE `y` is a `&` reference, so it cannot be written to
 }

--- a/tests/ui/borrowck/issue-85765.stderr
+++ b/tests/ui/borrowck/issue-85765.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `*rofl` as mutable, as it is behind a `&` reference
   --> $DIR/issue-85765.rs:5:5
    |
 LL |     rofl.push(Vec::new());
-   |     ^^^^ `rofl` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |     ^^^^ `rofl` is a `&` reference, so it cannot be borrowed as mutable
    |
 help: consider changing this binding's type
    |
@@ -13,7 +13,7 @@ error[E0594]: cannot assign to `*r`, which is behind a `&` reference
   --> $DIR/issue-85765.rs:12:5
    |
 LL |     *r = 0;
-   |     ^^^^^^ `r` is a `&` reference, so the data it refers to cannot be written
+   |     ^^^^^^ `r` is a `&` reference, so it cannot be written to
    |
 help: consider changing this to be a mutable reference
    |
@@ -24,7 +24,7 @@ error[E0594]: cannot assign to `*x`, which is behind a `&` reference
   --> $DIR/issue-85765.rs:19:5
    |
 LL |     *x = 1;
-   |     ^^^^^^ `x` is a `&` reference, so the data it refers to cannot be written
+   |     ^^^^^^ `x` is a `&` reference, so it cannot be written to
    |
 help: consider changing this binding's type
    |
@@ -35,7 +35,7 @@ error[E0594]: cannot assign to `*y`, which is behind a `&` reference
   --> $DIR/issue-85765.rs:26:5
    |
 LL |     *y = 1;
-   |     ^^^^^^ `y` is a `&` reference, so the data it refers to cannot be written
+   |     ^^^^^^ `y` is a `&` reference, so it cannot be written to
    |
 help: consider changing this binding's type
    |

--- a/tests/ui/borrowck/issue-91206.rs
+++ b/tests/ui/borrowck/issue-91206.rs
@@ -12,5 +12,5 @@ fn main() {
     //~^ HELP consider specifying this binding's type
     inner.clear();
     //~^ ERROR cannot borrow `*inner` as mutable, as it is behind a `&` reference [E0596]
-    //~| NOTE `inner` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+    //~| NOTE `inner` is a `&` reference, so it cannot be borrowed as mutable
 }

--- a/tests/ui/borrowck/issue-91206.stderr
+++ b/tests/ui/borrowck/issue-91206.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `*inner` as mutable, as it is behind a `&` reference
   --> $DIR/issue-91206.rs:13:5
    |
 LL |     inner.clear();
-   |     ^^^^^ `inner` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |     ^^^^^ `inner` is a `&` reference, so it cannot be borrowed as mutable
    |
 help: consider specifying this binding's type
    |

--- a/tests/ui/borrowck/issue-92015.stderr
+++ b/tests/ui/borrowck/issue-92015.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to `*foo`, which is behind a `&` reference
   --> $DIR/issue-92015.rs:6:5
    |
 LL |     *foo = 1;
-   |     ^^^^^^^^ `foo` is a `&` reference, so the data it refers to cannot be written
+   |     ^^^^^^^^ `foo` is a `&` reference, so it cannot be written to
    |
 help: consider specifying this binding's type
    |

--- a/tests/ui/borrowck/issue-93093.stderr
+++ b/tests/ui/borrowck/issue-93093.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to `self.foo`, which is behind a `&` reference
   --> $DIR/issue-93093.rs:8:9
    |
 LL |         self.foo += 1;
-   |         ^^^^^^^^^^^^^ `self` is a `&` reference, so the data it refers to cannot be written
+   |         ^^^^^^^^^^^^^ `self` is a `&` reference, so it cannot be written to
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/borrowck/mutability-errors.stderr
+++ b/tests/ui/borrowck/mutability-errors.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to `*x`, which is behind a `&` reference
   --> $DIR/mutability-errors.rs:9:5
    |
 LL |     *x = (1,);
-   |     ^^^^^^^^^ `x` is a `&` reference, so the data it refers to cannot be written
+   |     ^^^^^^^^^ `x` is a `&` reference, so it cannot be written to
    |
 help: consider changing this to be a mutable reference
    |
@@ -13,7 +13,7 @@ error[E0594]: cannot assign to `x.0`, which is behind a `&` reference
   --> $DIR/mutability-errors.rs:10:5
    |
 LL |     x.0 = 1;
-   |     ^^^^^^^ `x` is a `&` reference, so the data it refers to cannot be written
+   |     ^^^^^^^ `x` is a `&` reference, so it cannot be written to
    |
 help: consider changing this to be a mutable reference
    |
@@ -24,7 +24,7 @@ error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
   --> $DIR/mutability-errors.rs:11:5
    |
 LL |     &mut *x;
-   |     ^^^^^^^ `x` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |     ^^^^^^^ `x` is a `&` reference, so it cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -35,7 +35,7 @@ error[E0596]: cannot borrow `x.0` as mutable, as it is behind a `&` reference
   --> $DIR/mutability-errors.rs:12:5
    |
 LL |     &mut x.0;
-   |     ^^^^^^^^ `x` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |     ^^^^^^^^ `x` is a `&` reference, so it cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -70,7 +70,7 @@ error[E0594]: cannot assign to `*x`, which is behind a `*const` pointer
   --> $DIR/mutability-errors.rs:23:5
    |
 LL |     *x = (1,);
-   |     ^^^^^^^^^ `x` is a `*const` pointer, so the data it refers to cannot be written
+   |     ^^^^^^^^^ `x` is a `*const` pointer, so it cannot be written to
    |
 help: consider changing this to be a mutable pointer
    |
@@ -81,7 +81,7 @@ error[E0594]: cannot assign to `x.0`, which is behind a `*const` pointer
   --> $DIR/mutability-errors.rs:24:5
    |
 LL |     (*x).0 = 1;
-   |     ^^^^^^^^^^ `x` is a `*const` pointer, so the data it refers to cannot be written
+   |     ^^^^^^^^^^ `x` is a `*const` pointer, so it cannot be written to
    |
 help: consider changing this to be a mutable pointer
    |
@@ -92,7 +92,7 @@ error[E0596]: cannot borrow `*x` as mutable, as it is behind a `*const` pointer
   --> $DIR/mutability-errors.rs:25:5
    |
 LL |     &mut *x;
-   |     ^^^^^^^ `x` is a `*const` pointer, so the data it refers to cannot be borrowed as mutable
+   |     ^^^^^^^ `x` is a `*const` pointer, so it cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable pointer
    |
@@ -103,7 +103,7 @@ error[E0596]: cannot borrow `x.0` as mutable, as it is behind a `*const` pointer
   --> $DIR/mutability-errors.rs:26:5
    |
 LL |     &mut (*x).0;
-   |     ^^^^^^^^^^^ `x` is a `*const` pointer, so the data it refers to cannot be borrowed as mutable
+   |     ^^^^^^^^^^^ `x` is a `*const` pointer, so it cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable pointer
    |
@@ -358,24 +358,36 @@ LL | fn imm_capture(mut x: (i32,)) {
 error[E0594]: cannot assign to immutable static item `X`
   --> $DIR/mutability-errors.rs:76:5
    |
+LL | static X: (i32,) = (0,);
+   | ---------------- this `static` cannot be written to
+...
 LL |     X = (1,);
    |     ^^^^^^^^ cannot assign
 
 error[E0594]: cannot assign to `X.0`, as `X` is an immutable static item
   --> $DIR/mutability-errors.rs:77:5
    |
+LL | static X: (i32,) = (0,);
+   | ---------------- this `static` cannot be written to
+...
 LL |     X.0 = 1;
    |     ^^^^^^^ cannot assign
 
 error[E0596]: cannot borrow immutable static item `X` as mutable
   --> $DIR/mutability-errors.rs:78:5
    |
+LL | static X: (i32,) = (0,);
+   | ---------------- this `static` cannot be borrowed as mutable
+...
 LL |     &mut X;
    |     ^^^^^^ cannot borrow as mutable
 
 error[E0596]: cannot borrow `X.0` as mutable, as `X` is an immutable static item
   --> $DIR/mutability-errors.rs:79:5
    |
+LL | static X: (i32,) = (0,);
+   | ---------------- this `static` cannot be borrowed as mutable
+...
 LL |     &mut X.0;
    |     ^^^^^^^^ cannot borrow as mutable
 

--- a/tests/ui/borrowck/mutable-borrow-behind-reference-61623.stderr
+++ b/tests/ui/borrowck/mutable-borrow-behind-reference-61623.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `*x.1` as mutable, as it is behind a `&` reference
   --> $DIR/mutable-borrow-behind-reference-61623.rs:7:19
    |
 LL |     f2(|| x.0, f1(x.1))
-   |                   ^^^ `x` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |                   ^^^ `x` is a `&` reference, so it cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/borrowck/no-invalid-mut-suggestion-for-raw-pointer-issue-127562.stderr
+++ b/tests/ui/borrowck/no-invalid-mut-suggestion-for-raw-pointer-issue-127562.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to `*ptr`, which is behind a `*const` pointer
   --> $DIR/no-invalid-mut-suggestion-for-raw-pointer-issue-127562.rs:7:14
    |
 LL |     unsafe { *ptr = 3; }
-   |              ^^^^^^^^ `ptr` is a `*const` pointer, so the data it refers to cannot be written
+   |              ^^^^^^^^ `ptr` is a `*const` pointer, so it cannot be written to
    |
 help: consider changing this to be a mutable pointer
    |

--- a/tests/ui/borrowck/suggest-as-ref-on-mut-closure.stderr
+++ b/tests/ui/borrowck/suggest-as-ref-on-mut-closure.stderr
@@ -18,7 +18,7 @@ error[E0596]: cannot borrow `*cb` as mutable, as it is behind a `&` reference
   --> $DIR/suggest-as-ref-on-mut-closure.rs:12:26
    |
 LL |     cb.as_ref().map(|cb| cb());
-   |                      --  ^^ `cb` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |                      --  ^^ `cb` is a `&` reference, so it cannot be borrowed as mutable
    |                      |
    |                      consider changing this binding's type to be: `&mut &mut dyn FnMut()`
 

--- a/tests/ui/borrowck/suggest-mut-iterator.stderr
+++ b/tests/ui/borrowck/suggest-mut-iterator.stderr
@@ -4,7 +4,7 @@ error[E0596]: cannot borrow `*test` as mutable, as it is behind a `&` reference
 LL |     for test in &tests {
    |                 ------ this iterator yields `&` references
 LL |         test.add(2);
-   |         ^^^^ `test` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |         ^^^^ `test` is a `&` reference, so it cannot be borrowed as mutable
    |
 help: use a mutable iterator instead
    |

--- a/tests/ui/borrowck/suggestions/overloaded-index-not-mut-but-should-be-mut.stderr
+++ b/tests/ui/borrowck/suggestions/overloaded-index-not-mut-but-should-be-mut.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `*string` as mutable, as it is behind a `&` referenc
   --> $DIR/overloaded-index-not-mut-but-should-be-mut.rs:7:5
    |
 LL |     string.push_str("test");
-   |     ^^^^^^ `string` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |     ^^^^^^ `string` is a `&` reference, so it cannot be borrowed as mutable
    |
 help: consider using `get_mut`
    |
@@ -14,7 +14,7 @@ error[E0596]: cannot borrow `*string` as mutable, as it is behind a `&` referenc
   --> $DIR/overloaded-index-not-mut-but-should-be-mut.rs:14:5
    |
 LL |     string.push_str("test");
-   |     ^^^^^^ `string` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |     ^^^^^^ `string` is a `&` reference, so it cannot be borrowed as mutable
    |
 help: consider using `get_mut`
    |
@@ -26,7 +26,7 @@ error[E0596]: cannot borrow `*string` as mutable, as it is behind a `&` referenc
   --> $DIR/overloaded-index-not-mut-but-should-be-mut.rs:19:5
    |
 LL |     string.push_str("test");
-   |     ^^^^^^ `string` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |     ^^^^^^ `string` is a `&` reference, so it cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/borrowck/suggestions/overloaded-index-without-indexmut.stderr
+++ b/tests/ui/borrowck/suggestions/overloaded-index-without-indexmut.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `*y` as mutable, as it is behind a `&` reference
   --> $DIR/overloaded-index-without-indexmut.rs:14:5
    |
 LL |     y.push_str("");
-   |     ^ `y` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |     ^ `y` is a `&` reference, so it cannot be borrowed as mutable
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/borrowck/trait-impl-argument-difference-ice.stderr
+++ b/tests/ui/borrowck/trait-impl-argument-difference-ice.stderr
@@ -36,7 +36,7 @@ error[E0596]: cannot borrow `*self` as mutable, as it is behind a `&` reference
   --> $DIR/trait-impl-argument-difference-ice.rs:16:19
    |
 LL |         let a16 = self.read_word() as u16;
-   |                   ^^^^ `self` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |                   ^^^^ `self` is a `&` reference, so it cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference in the `impl` method and the `trait` definition
    |
@@ -47,7 +47,7 @@ error[E0596]: cannot borrow `*self` as mutable, as it is behind a `&` reference
   --> $DIR/trait-impl-argument-difference-ice.rs:18:19
    |
 LL |         let b16 = self.read_word() as u16;
-   |                   ^^^^ `self` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |                   ^^^^ `self` is a `&` reference, so it cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference in the `impl` method and the `trait` definition
    |

--- a/tests/ui/closures/2229_closure_analysis/diagnostics/mut_ref.stderr
+++ b/tests/ui/closures/2229_closure_analysis/diagnostics/mut_ref.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `**ref_mref_x` as mutable, as it is behind a `&` ref
   --> $DIR/mut_ref.rs:12:13
    |
 LL |     let c = || {
-   |             ^^ `ref_mref_x` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |             ^^ `ref_mref_x` is a `&` reference, so it cannot be borrowed as mutable
 LL |
 LL |         **ref_mref_x = y;
    |         ------------ mutable borrow occurs due to use of `**ref_mref_x` in closure

--- a/tests/ui/consts/miri_unleashed/mutable_references.stderr
+++ b/tests/ui/consts/miri_unleashed/mutable_references.stderr
@@ -131,6 +131,9 @@ LL | const RAW_MUT_COERCE: SyncPtr<i32> = SyncPtr { x: &mut 0 };
 error[E0594]: cannot assign to `*OH_YES`, as `OH_YES` is an immutable static item
   --> $DIR/mutable_references.rs:109:5
    |
+LL | static OH_YES: &mut i32 = &mut 42;
+   | ----------------------- this `static` cannot be written to
+...
 LL |     *OH_YES = 99;
    |     ^^^^^^^^^^^^ cannot assign
 

--- a/tests/ui/consts/write_to_static_via_mut_ref.stderr
+++ b/tests/ui/consts/write_to_static_via_mut_ref.stderr
@@ -11,6 +11,9 @@ LL | static OH_NO: &mut i32 = &mut 42;
 error[E0594]: cannot assign to `*OH_NO`, as `OH_NO` is an immutable static item
   --> $DIR/write_to_static_via_mut_ref.rs:4:5
    |
+LL | static OH_NO: &mut i32 = &mut 42;
+   | ---------------------- this `static` cannot be written to
+...
 LL |     *OH_NO = 43;
    |     ^^^^^^^^^^^ cannot assign
 

--- a/tests/ui/did_you_mean/issue-38147-1.stderr
+++ b/tests/ui/did_you_mean/issue-38147-1.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `*self.s` as mutable, as it is behind a `&` referenc
   --> $DIR/issue-38147-1.rs:17:9
    |
 LL |         self.s.push('x');
-   |         ^^^^^^ `self` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |         ^^^^^^ `self` is a `&` reference, so it cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/did_you_mean/issue-38147-4.stderr
+++ b/tests/ui/did_you_mean/issue-38147-4.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `*f.s` as mutable, as it is behind a `&` reference
   --> $DIR/issue-38147-4.rs:6:5
    |
 LL |     f.s.push('x');
-   |     ^^^ `f` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |     ^^^ `f` is a `&` reference, so it cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/did_you_mean/issue-39544.stderr
+++ b/tests/ui/did_you_mean/issue-39544.stderr
@@ -13,7 +13,7 @@ error[E0596]: cannot borrow `self.x` as mutable, as it is behind a `&` reference
   --> $DIR/issue-39544.rs:16:17
    |
 LL |         let _ = &mut self.x;
-   |                 ^^^^^^^^^^^ `self` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |                 ^^^^^^^^^^^ `self` is a `&` reference, so it cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -24,7 +24,7 @@ error[E0596]: cannot borrow `self.x` as mutable, as it is behind a `&` reference
   --> $DIR/issue-39544.rs:20:17
    |
 LL |         let _ = &mut self.x;
-   |                 ^^^^^^^^^^^ `self` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |                 ^^^^^^^^^^^ `self` is a `&` reference, so it cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -35,7 +35,7 @@ error[E0596]: cannot borrow `other.x` as mutable, as it is behind a `&` referenc
   --> $DIR/issue-39544.rs:21:17
    |
 LL |         let _ = &mut other.x;
-   |                 ^^^^^^^^^^^^ `other` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |                 ^^^^^^^^^^^^ `other` is a `&` reference, so it cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -46,7 +46,7 @@ error[E0596]: cannot borrow `self.x` as mutable, as it is behind a `&` reference
   --> $DIR/issue-39544.rs:25:17
    |
 LL |         let _ = &mut self.x;
-   |                 ^^^^^^^^^^^ `self` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |                 ^^^^^^^^^^^ `self` is a `&` reference, so it cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -57,7 +57,7 @@ error[E0596]: cannot borrow `other.x` as mutable, as it is behind a `&` referenc
   --> $DIR/issue-39544.rs:26:17
    |
 LL |         let _ = &mut other.x;
-   |                 ^^^^^^^^^^^^ `other` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |                 ^^^^^^^^^^^^ `other` is a `&` reference, so it cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -68,7 +68,7 @@ error[E0596]: cannot borrow `self.x` as mutable, as it is behind a `&` reference
   --> $DIR/issue-39544.rs:30:17
    |
 LL |         let _ = &mut self.x;
-   |                 ^^^^^^^^^^^ `self` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |                 ^^^^^^^^^^^ `self` is a `&` reference, so it cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -79,7 +79,7 @@ error[E0596]: cannot borrow `other.x` as mutable, as it is behind a `&` referenc
   --> $DIR/issue-39544.rs:31:17
    |
 LL |         let _ = &mut other.x;
-   |                 ^^^^^^^^^^^^ `other` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |                 ^^^^^^^^^^^^ `other` is a `&` reference, so it cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -90,7 +90,7 @@ error[E0596]: cannot borrow `other.x` as mutable, as it is behind a `&` referenc
   --> $DIR/issue-39544.rs:35:17
    |
 LL |         let _ = &mut other.x;
-   |                 ^^^^^^^^^^^^ `other` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |                 ^^^^^^^^^^^^ `other` is a `&` reference, so it cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -112,7 +112,7 @@ error[E0596]: cannot borrow `w.x` as mutable, as it is behind a `&` reference
   --> $DIR/issue-39544.rs:42:13
    |
 LL |     let _ = &mut w.x;
-   |             ^^^^^^^^ `w` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |             ^^^^^^^^ `w` is a `&` reference, so it cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/did_you_mean/issue-40823.stderr
+++ b/tests/ui/did_you_mean/issue-40823.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `*buf` as mutable, as it is behind a `&` reference
   --> $DIR/issue-40823.rs:3:5
    |
 LL |     buf.iter_mut();
-   |     ^^^ `buf` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |     ^^^ `buf` is a `&` reference, so it cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/error-codes/E0017.stderr
+++ b/tests/ui/error-codes/E0017.stderr
@@ -26,6 +26,9 @@ LL | const CR: &'static mut i32 = &mut C;
 error[E0596]: cannot borrow immutable static item `X` as mutable
   --> $DIR/E0017.rs:11:39
    |
+LL | static X: i32 = 1;
+   | ------------- this `static` cannot be borrowed as mutable
+...
 LL | static STATIC_REF: &'static mut i32 = &mut X;
    |                                       ^^^^^^ cannot borrow as mutable
 

--- a/tests/ui/error-codes/E0389.stderr
+++ b/tests/ui/error-codes/E0389.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to `fancy_ref.num`, which is behind a `&` reference
   --> $DIR/E0389.rs:8:5
    |
 LL |     fancy_ref.num = 6;
-   |     ^^^^^^^^^^^^^^^^^ `fancy_ref` is a `&` reference, so the data it refers to cannot be written
+   |     ^^^^^^^^^^^^^^^^^ `fancy_ref` is a `&` reference, so it cannot be written to
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/error-codes/E0594.stderr
+++ b/tests/ui/error-codes/E0594.stderr
@@ -1,6 +1,9 @@
 error[E0594]: cannot assign to immutable static item `NUM`
   --> $DIR/E0594.rs:4:5
    |
+LL | static NUM: i32 = 18;
+   | --------------- this `static` cannot be written to
+...
 LL |     NUM = 20;
    |     ^^^^^^^^ cannot assign
 

--- a/tests/ui/issues/issue-46604.stderr
+++ b/tests/ui/issues/issue-46604.stderr
@@ -11,6 +11,9 @@ LL | static buf: &mut [u8] = &mut [1u8,2,3,4,5,7];
 error[E0594]: cannot assign to `buf[_]`, as `buf` is an immutable static item
   --> $DIR/issue-46604.rs:6:5
    |
+LL | static buf: &mut [u8] = &mut [1u8,2,3,4,5,7];
+   | --------------------- this `static` cannot be written to
+...
 LL |     buf[0]=2;
    |     ^^^^^^^^ cannot assign
 

--- a/tests/ui/issues/issue-51515.stderr
+++ b/tests/ui/issues/issue-51515.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to `*foo`, which is behind a `&` reference
   --> $DIR/issue-51515.rs:4:5
    |
 LL |     *foo = 32;
-   |     ^^^^^^^^^ `foo` is a `&` reference, so the data it refers to cannot be written
+   |     ^^^^^^^^^ `foo` is a `&` reference, so it cannot be written to
    |
 help: consider changing this to be a mutable reference
    |
@@ -13,7 +13,7 @@ error[E0594]: cannot assign to `*bar`, which is behind a `&` reference
   --> $DIR/issue-51515.rs:8:5
    |
 LL |     *bar = 64;
-   |     ^^^^^^^^^ `bar` is a `&` reference, so the data it refers to cannot be written
+   |     ^^^^^^^^^ `bar` is a `&` reference, so it cannot be written to
    |
 help: consider specifying this binding's type
    |

--- a/tests/ui/let-else/let-else-binding-explicit-mut.stderr
+++ b/tests/ui/let-else/let-else-binding-explicit-mut.stderr
@@ -2,19 +2,19 @@ error[E0594]: cannot assign to `*n`, which is behind a `&` reference
   --> $DIR/let-else-binding-explicit-mut.rs:10:5
    |
 LL |     *n += 1;
-   |     ^^^^^^^ `n` is a `&` reference, so the data it refers to cannot be written
+   |     ^^^^^^^ `n` is a `&` reference, so it cannot be written to
 
 error[E0594]: cannot assign to `*n`, which is behind a `&` reference
   --> $DIR/let-else-binding-explicit-mut.rs:14:5
    |
 LL |     *n += 1;
-   |     ^^^^^^^ `n` is a `&` reference, so the data it refers to cannot be written
+   |     ^^^^^^^ `n` is a `&` reference, so it cannot be written to
 
 error[E0594]: cannot assign to `*n`, which is behind a `&` reference
   --> $DIR/let-else-binding-explicit-mut.rs:18:5
    |
 LL |     *n += 1;
-   |     ^^^^^^^ `n` is a `&` reference, so the data it refers to cannot be written
+   |     ^^^^^^^ `n` is a `&` reference, so it cannot be written to
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/let-else/let-else-binding-immutable.stderr
+++ b/tests/ui/let-else/let-else-binding-immutable.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to `*x`, which is behind a `&` reference
   --> $DIR/let-else-binding-immutable.rs:9:5
    |
 LL |     *x += 1;
-   |     ^^^^^^^ `x` is a `&` reference, so the data it refers to cannot be written
+   |     ^^^^^^^ `x` is a `&` reference, so it cannot be written to
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/mut/mutable-class-fields-2.stderr
+++ b/tests/ui/mut/mutable-class-fields-2.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to `self.how_hungry`, which is behind a `&` referenc
   --> $DIR/mutable-class-fields-2.rs:9:5
    |
 LL |     self.how_hungry -= 5;
-   |     ^^^^^^^^^^^^^^^^^^^^ `self` is a `&` reference, so the data it refers to cannot be written
+   |     ^^^^^^^^^^^^^^^^^^^^ `self` is a `&` reference, so it cannot be written to
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/nll/constant-thread-locals-issue-47053.stderr
+++ b/tests/ui/nll/constant-thread-locals-issue-47053.stderr
@@ -1,6 +1,9 @@
 error[E0594]: cannot assign to immutable static item `FOO`
   --> $DIR/constant-thread-locals-issue-47053.rs:9:5
    |
+LL | static FOO: isize = 5;
+   | ----------------- this `static` cannot be written to
+...
 LL |     FOO = 6;
    |     ^^^^^^^ cannot assign
 

--- a/tests/ui/nll/dont-print-desugared.stderr
+++ b/tests/ui/nll/dont-print-desugared.stderr
@@ -2,7 +2,9 @@ error[E0596]: cannot borrow data in a `&` reference as mutable
   --> $DIR/dont-print-desugared.rs:4:10
    |
 LL |     for &ref mut x in s {}
-   |          ^^^^^^^^^ cannot borrow as mutable
+   |          ^^^^^^^^^    - this cannot be borrowed as mutable
+   |          |
+   |          cannot borrow as mutable
 
 error[E0597]: `y` does not live long enough
   --> $DIR/dont-print-desugared.rs:17:16

--- a/tests/ui/nll/issue-47388.stderr
+++ b/tests/ui/nll/issue-47388.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to `fancy_ref.num`, which is behind a `&` reference
   --> $DIR/issue-47388.rs:8:5
    |
 LL |     fancy_ref.num = 6;
-   |     ^^^^^^^^^^^^^^^^^ `fancy_ref` is a `&` reference, so the data it refers to cannot be written
+   |     ^^^^^^^^^^^^^^^^^ `fancy_ref` is a `&` reference, so it cannot be written to
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/nll/issue-51191.stderr
+++ b/tests/ui/nll/issue-51191.stderr
@@ -45,6 +45,8 @@ LL |     fn imm(mut self) {
 error[E0596]: cannot borrow `self` as mutable, as it is not declared as mutable
   --> $DIR/issue-51191.rs:23:9
    |
+LL |     fn immref(&self) {
+   |               ----- this cannot be borrowed as mutable
 LL |         (&mut self).bar();
    |         ^^^^^^^^^^^ cannot borrow as mutable
 

--- a/tests/ui/nll/issue-51244.stderr
+++ b/tests/ui/nll/issue-51244.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to `*my_ref`, which is behind a `&` reference
   --> $DIR/issue-51244.rs:3:5
    |
 LL |     *my_ref = 0;
-   |     ^^^^^^^^^^^ `my_ref` is a `&` reference, so the data it refers to cannot be written
+   |     ^^^^^^^^^^^ `my_ref` is a `&` reference, so it cannot be written to
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/nll/issue-57989.stderr
+++ b/tests/ui/nll/issue-57989.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to `*x`, which is behind a `&` reference
   --> $DIR/issue-57989.rs:5:5
    |
 LL |     *x = 0;
-   |     ^^^^^^ `x` is a `&` reference, so the data it refers to cannot be written
+   |     ^^^^^^ `x` is a `&` reference, so it cannot be written to
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/pattern/issue-52240.stderr
+++ b/tests/ui/pattern/issue-52240.stderr
@@ -2,7 +2,9 @@ error[E0596]: cannot borrow data in a `&` reference as mutable
   --> $DIR/issue-52240.rs:9:27
    |
 LL |     if let (Some(Foo::Bar(ref mut val)), _) = (&arr.get(0), 0) {
-   |                           ^^^^^^^^^^^ cannot borrow as mutable
+   |                           ^^^^^^^^^^^         ---------------- this cannot be borrowed as mutable
+   |                           |
+   |                           cannot borrow as mutable
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/pattern/move-ref-patterns/borrowck-move-ref-pattern.stderr
+++ b/tests/ui/pattern/move-ref-patterns/borrowck-move-ref-pattern.stderr
@@ -119,7 +119,7 @@ error[E0594]: cannot assign to `*_x0`, which is behind a `&` reference
   --> $DIR/borrowck-move-ref-pattern.rs:26:5
    |
 LL |     *_x0 = U;
-   |     ^^^^^^^^ `_x0` is a `&` reference, so the data it refers to cannot be written
+   |     ^^^^^^^^ `_x0` is a `&` reference, so it cannot be written to
    |
 help: consider changing this to be a mutable reference
    |
@@ -130,7 +130,7 @@ error[E0594]: cannot assign to `*_x2`, which is behind a `&` reference
   --> $DIR/borrowck-move-ref-pattern.rs:27:5
    |
 LL |     *_x2 = U;
-   |     ^^^^^^^^ `_x2` is a `&` reference, so the data it refers to cannot be written
+   |     ^^^^^^^^ `_x2` is a `&` reference, so it cannot be written to
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/pattern/mut-pattern-of-immutable-borrow.rs
+++ b/tests/ui/pattern/mut-pattern-of-immutable-borrow.rs
@@ -1,0 +1,31 @@
+struct S {
+    field: Option<String>,
+}
+
+fn a(arg: &mut S) {
+    match arg.field { //~ ERROR cannot move out of `arg.field`
+        Some(s) => s.push('a'), //~ ERROR cannot borrow `s` as mutable
+        None => {}
+    }
+}
+fn b(arg: &mut S) {
+    match &arg.field { //~ ERROR cannot move out of a shared reference
+        Some(mut s) => s.push('a'),
+        None => {}
+    }
+}
+fn c(arg: &mut S) {
+    match &arg.field {
+        Some(ref mut s) => s.push('a'), //~ ERROR cannot borrow data in a `&` reference as mutable
+        None => {}
+    }
+}
+
+fn main() {
+    let mut s = S {
+        field: Some("a".to_owned()),
+    };
+    a(&mut s);
+    b(&mut s);
+    c(&mut s);
+}

--- a/tests/ui/pattern/mut-pattern-of-immutable-borrow.stderr
+++ b/tests/ui/pattern/mut-pattern-of-immutable-borrow.stderr
@@ -1,0 +1,55 @@
+error[E0507]: cannot move out of `arg.field` as enum variant `Some` which is behind a mutable reference
+  --> $DIR/mut-pattern-of-immutable-borrow.rs:6:11
+   |
+LL |     match arg.field {
+   |           ^^^^^^^^^
+LL |         Some(s) => s.push('a'),
+   |              -
+   |              |
+   |              data moved here
+   |              move occurs because `s` has type `String`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |     match &arg.field {
+   |           +
+
+error[E0596]: cannot borrow `s` as mutable, as it is not declared as mutable
+  --> $DIR/mut-pattern-of-immutable-borrow.rs:7:20
+   |
+LL |         Some(s) => s.push('a'),
+   |                    ^ cannot borrow as mutable
+   |
+help: consider changing this to be mutable
+   |
+LL |         Some(mut s) => s.push('a'),
+   |              +++
+
+error[E0507]: cannot move out of a shared reference
+  --> $DIR/mut-pattern-of-immutable-borrow.rs:12:11
+   |
+LL |     match &arg.field {
+   |           ^^^^^^^^^^
+LL |         Some(mut s) => s.push('a'),
+   |              -----
+   |              |
+   |              data moved here
+   |              move occurs because `s` has type `String`, which does not implement the `Copy` trait
+   |
+help: consider borrowing the pattern binding
+   |
+LL |         Some(ref mut s) => s.push('a'),
+   |              +++
+
+error[E0596]: cannot borrow data in a `&` reference as mutable
+  --> $DIR/mut-pattern-of-immutable-borrow.rs:19:14
+   |
+LL |     match &arg.field {
+   |           ---------- this cannot be borrowed as mutable
+LL |         Some(ref mut s) => s.push('a'),
+   |              ^^^^^^^^^ cannot borrow as mutable
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0507, E0596.
+For more information about an error, try `rustc --explain E0507`.

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/borrowck-errors.classic2021.stderr
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/borrowck-errors.classic2021.stderr
@@ -17,19 +17,25 @@ error[E0596]: cannot borrow data in a `&` reference as mutable
   --> $DIR/borrowck-errors.rs:38:10
    |
 LL |     let &ref mut x = &0;
-   |          ^^^^^^^^^ cannot borrow as mutable
+   |          ^^^^^^^^^   -- this cannot be borrowed as mutable
+   |          |
+   |          cannot borrow as mutable
 
 error[E0596]: cannot borrow data in a `&` reference as mutable
   --> $DIR/borrowck-errors.rs:43:23
    |
 LL |     if let &Some(Some(x)) = &Some(&mut Some(0)) {
-   |                       ^ cannot borrow as mutable
+   |                       ^     ------------------- this cannot be borrowed as mutable
+   |                       |
+   |                       cannot borrow as mutable
 
 error[E0596]: cannot borrow data in a `&` reference as mutable
   --> $DIR/borrowck-errors.rs:48:11
    |
 LL |     let &[x] = &&mut [0];
-   |           ^ cannot borrow as mutable
+   |           ^    --------- this cannot be borrowed as mutable
+   |           |
+   |           cannot borrow as mutable
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/borrowck-errors.classic2024.stderr
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/borrowck-errors.classic2024.stderr
@@ -45,7 +45,9 @@ error[E0596]: cannot borrow data in a `&` reference as mutable
   --> $DIR/borrowck-errors.rs:38:10
    |
 LL |     let &ref mut x = &0;
-   |          ^^^^^^^^^ cannot borrow as mutable
+   |          ^^^^^^^^^   -- this cannot be borrowed as mutable
+   |          |
+   |          cannot borrow as mutable
 
 error[E0596]: cannot borrow data in a `&` reference as mutable
   --> $DIR/borrowck-errors.rs:43:23
@@ -57,7 +59,9 @@ error[E0596]: cannot borrow data in a `&` reference as mutable
   --> $DIR/borrowck-errors.rs:48:11
    |
 LL |     let &[x] = &&mut [0];
-   |           ^ cannot borrow as mutable
+   |           ^    --------- this cannot be borrowed as mutable
+   |           |
+   |           cannot borrow as mutable
 
 error[E0508]: cannot move out of type `[&mut i32; 1]`, a non-copy array
   --> $DIR/borrowck-errors.rs:52:20

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/borrowck-errors.stable2021.stderr
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/borrowck-errors.stable2021.stderr
@@ -49,19 +49,25 @@ error[E0596]: cannot borrow data in a `&` reference as mutable
   --> $DIR/borrowck-errors.rs:38:10
    |
 LL |     let &ref mut x = &0;
-   |          ^^^^^^^^^ cannot borrow as mutable
+   |          ^^^^^^^^^   -- this cannot be borrowed as mutable
+   |          |
+   |          cannot borrow as mutable
 
 error[E0596]: cannot borrow data in a `&` reference as mutable
   --> $DIR/borrowck-errors.rs:43:23
    |
 LL |     if let &Some(Some(x)) = &Some(&mut Some(0)) {
-   |                       ^ cannot borrow as mutable
+   |                       ^     ------------------- this cannot be borrowed as mutable
+   |                       |
+   |                       cannot borrow as mutable
 
 error[E0596]: cannot borrow data in a `&` reference as mutable
   --> $DIR/borrowck-errors.rs:48:11
    |
 LL |     let &[x] = &&mut [0];
-   |           ^ cannot borrow as mutable
+   |           ^    --------- this cannot be borrowed as mutable
+   |           |
+   |           cannot borrow as mutable
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/borrowck-errors.structural2021.stderr
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/borrowck-errors.structural2021.stderr
@@ -17,7 +17,9 @@ error[E0596]: cannot borrow data in a `&` reference as mutable
   --> $DIR/borrowck-errors.rs:38:10
    |
 LL |     let &ref mut x = &0;
-   |          ^^^^^^^^^ cannot borrow as mutable
+   |          ^^^^^^^^^   -- this cannot be borrowed as mutable
+   |          |
+   |          cannot borrow as mutable
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/borrowck-errors.structural2024.stderr
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/borrowck-errors.structural2024.stderr
@@ -17,7 +17,9 @@ error[E0596]: cannot borrow data in a `&` reference as mutable
   --> $DIR/borrowck-errors.rs:38:10
    |
 LL |     let &ref mut x = &0;
-   |          ^^^^^^^^^ cannot borrow as mutable
+   |          ^^^^^^^^^   -- this cannot be borrowed as mutable
+   |          |
+   |          cannot borrow as mutable
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/mixed-editions.classic2021.stderr
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/mixed-editions.classic2021.stderr
@@ -81,19 +81,25 @@ error[E0596]: cannot borrow data in a `&` reference as mutable
   --> $DIR/mixed-editions.rs:61:21
    |
 LL |     let match_ref!([x]) = &&mut [0];
-   |                     ^ cannot borrow as mutable
+   |                     ^     --------- this cannot be borrowed as mutable
+   |                     |
+   |                     cannot borrow as mutable
 
 error[E0596]: cannot borrow data in a `&` reference as mutable
   --> $DIR/mixed-editions.rs:65:22
    |
 LL |     let &match_ctor!(y) = &&mut [0];
-   |                      ^ cannot borrow as mutable
+   |                      ^    --------- this cannot be borrowed as mutable
+   |                      |
+   |                      cannot borrow as mutable
 
 error[E0596]: cannot borrow data in a `&` reference as mutable
   --> $DIR/mixed-editions.rs:69:11
    |
 LL |     let &[bind!(z)] = &&mut [0];
-   |           ^^^^^^^^ cannot borrow as mutable
+   |           ^^^^^^^^    --------- this cannot be borrowed as mutable
+   |           |
+   |           cannot borrow as mutable
    |
    = note: this error originates in the macro `bind` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/mixed-editions.classic2024.stderr
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/mixed-editions.classic2024.stderr
@@ -75,19 +75,25 @@ error[E0596]: cannot borrow data in a `&` reference as mutable
   --> $DIR/mixed-editions.rs:61:21
    |
 LL |     let match_ref!([x]) = &&mut [0];
-   |                     ^ cannot borrow as mutable
+   |                     ^     --------- this cannot be borrowed as mutable
+   |                     |
+   |                     cannot borrow as mutable
 
 error[E0596]: cannot borrow data in a `&` reference as mutable
   --> $DIR/mixed-editions.rs:65:22
    |
 LL |     let &match_ctor!(y) = &&mut [0];
-   |                      ^ cannot borrow as mutable
+   |                      ^    --------- this cannot be borrowed as mutable
+   |                      |
+   |                      cannot borrow as mutable
 
 error[E0596]: cannot borrow data in a `&` reference as mutable
   --> $DIR/mixed-editions.rs:69:11
    |
 LL |     let &[bind!(z)] = &&mut [0];
-   |           ^^^^^^^^ cannot borrow as mutable
+   |           ^^^^^^^^    --------- this cannot be borrowed as mutable
+   |           |
+   |           cannot borrow as mutable
    |
    = note: this error originates in the macro `bind` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/ref-binding-on-inh-ref-errors.classic2021.stderr
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/ref-binding-on-inh-ref-errors.classic2021.stderr
@@ -2,7 +2,9 @@ error[E0596]: cannot borrow data in a `&` reference as mutable
   --> $DIR/ref-binding-on-inh-ref-errors.rs:73:10
    |
 LL |     let [ref mut x] = &[0];
-   |          ^^^^^^^^^ cannot borrow as mutable
+   |          ^^^^^^^^^    ---- this cannot be borrowed as mutable
+   |          |
+   |          cannot borrow as mutable
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/ref-binding-on-inh-ref-errors.classic2024.stderr
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/ref-binding-on-inh-ref-errors.classic2024.stderr
@@ -32,7 +32,9 @@ error[E0596]: cannot borrow data in a `&` reference as mutable
   --> $DIR/ref-binding-on-inh-ref-errors.rs:73:10
    |
 LL |     let [ref mut x] = &[0];
-   |          ^^^^^^^^^ cannot borrow as mutable
+   |          ^^^^^^^^^    ---- this cannot be borrowed as mutable
+   |          |
+   |          cannot borrow as mutable
 
 error: cannot explicitly borrow within an implicitly-borrowing pattern
   --> $DIR/ref-binding-on-inh-ref-errors.rs:81:10

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/ref-binding-on-inh-ref-errors.stable2021.stderr
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/ref-binding-on-inh-ref-errors.stable2021.stderr
@@ -34,7 +34,9 @@ error[E0596]: cannot borrow data in a `&` reference as mutable
   --> $DIR/ref-binding-on-inh-ref-errors.rs:73:10
    |
 LL |     let [ref mut x] = &[0];
-   |          ^^^^^^^^^ cannot borrow as mutable
+   |          ^^^^^^^^^    ---- this cannot be borrowed as mutable
+   |          |
+   |          cannot borrow as mutable
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/ref-binding-on-inh-ref-errors.structural2021.stderr
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/ref-binding-on-inh-ref-errors.structural2021.stderr
@@ -2,7 +2,9 @@ error[E0596]: cannot borrow data in a `&` reference as mutable
   --> $DIR/ref-binding-on-inh-ref-errors.rs:73:10
    |
 LL |     let [ref mut x] = &[0];
-   |          ^^^^^^^^^ cannot borrow as mutable
+   |          ^^^^^^^^^    ---- this cannot be borrowed as mutable
+   |          |
+   |          cannot borrow as mutable
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/ref-binding-on-inh-ref-errors.structural2024.stderr
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/ref-binding-on-inh-ref-errors.structural2024.stderr
@@ -138,7 +138,9 @@ error[E0596]: cannot borrow data in a `&` reference as mutable
   --> $DIR/ref-binding-on-inh-ref-errors.rs:73:10
    |
 LL |     let [ref mut x] = &[0];
-   |          ^^^^^^^^^ cannot borrow as mutable
+   |          ^^^^^^^^^    ---- this cannot be borrowed as mutable
+   |          |
+   |          cannot borrow as mutable
 
 error: cannot explicitly borrow within an implicitly-borrowing pattern
   --> $DIR/ref-binding-on-inh-ref-errors.rs:81:10

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/well-typed-edition-2024.classic2021.stderr
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/well-typed-edition-2024.classic2021.stderr
@@ -114,7 +114,9 @@ error[E0596]: cannot borrow data in a `&` reference as mutable
   --> $DIR/well-typed-edition-2024.rs:111:19
    |
 LL |         let [&mut ref mut x] = &mut [&0];
-   |                   ^^^^^^^^^ cannot borrow as mutable
+   |                   ^^^^^^^^^    --------- this cannot be borrowed as mutable
+   |                   |
+   |                   cannot borrow as mutable
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/well-typed-edition-2024.structural2021.stderr
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/well-typed-edition-2024.structural2021.stderr
@@ -114,7 +114,9 @@ error[E0596]: cannot borrow data in a `&` reference as mutable
   --> $DIR/well-typed-edition-2024.rs:111:19
    |
 LL |         let [&mut ref mut x] = &mut [&0];
-   |                   ^^^^^^^^^ cannot borrow as mutable
+   |                   ^^^^^^^^^    --------- this cannot be borrowed as mutable
+   |                   |
+   |                   cannot borrow as mutable
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/rfcs/rfc-2005-default-binding-mode/enum.stderr
+++ b/tests/ui/rfcs/rfc-2005-default-binding-mode/enum.stderr
@@ -2,19 +2,19 @@ error[E0594]: cannot assign to `*x`, which is behind a `&` reference
   --> $DIR/enum.rs:9:5
    |
 LL |     *x += 1;
-   |     ^^^^^^^ `x` is a `&` reference, so the data it refers to cannot be written
+   |     ^^^^^^^ `x` is a `&` reference, so it cannot be written to
 
 error[E0594]: cannot assign to `*x`, which is behind a `&` reference
   --> $DIR/enum.rs:13:9
    |
 LL |         *x += 1;
-   |         ^^^^^^^ `x` is a `&` reference, so the data it refers to cannot be written
+   |         ^^^^^^^ `x` is a `&` reference, so it cannot be written to
 
 error[E0594]: cannot assign to `*x`, which is behind a `&` reference
   --> $DIR/enum.rs:19:9
    |
 LL |         *x += 1;
-   |         ^^^^^^^ `x` is a `&` reference, so the data it refers to cannot be written
+   |         ^^^^^^^ `x` is a `&` reference, so it cannot be written to
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/rfcs/rfc-2005-default-binding-mode/explicit-mut.stderr
+++ b/tests/ui/rfcs/rfc-2005-default-binding-mode/explicit-mut.stderr
@@ -2,19 +2,19 @@ error[E0594]: cannot assign to `*n`, which is behind a `&` reference
   --> $DIR/explicit-mut.rs:7:13
    |
 LL |             *n += 1;
-   |             ^^^^^^^ `n` is a `&` reference, so the data it refers to cannot be written
+   |             ^^^^^^^ `n` is a `&` reference, so it cannot be written to
 
 error[E0594]: cannot assign to `*n`, which is behind a `&` reference
   --> $DIR/explicit-mut.rs:15:13
    |
 LL |             *n += 1;
-   |             ^^^^^^^ `n` is a `&` reference, so the data it refers to cannot be written
+   |             ^^^^^^^ `n` is a `&` reference, so it cannot be written to
 
 error[E0594]: cannot assign to `*n`, which is behind a `&` reference
   --> $DIR/explicit-mut.rs:23:13
    |
 LL |             *n += 1;
-   |             ^^^^^^^ `n` is a `&` reference, so the data it refers to cannot be written
+   |             ^^^^^^^ `n` is a `&` reference, so it cannot be written to
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/span/borrowck-borrow-overloaded-auto-deref-mut.stderr
+++ b/tests/ui/span/borrowck-borrow-overloaded-auto-deref-mut.stderr
@@ -13,7 +13,7 @@ error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
   --> $DIR/borrowck-borrow-overloaded-auto-deref-mut.rs:65:10
    |
 LL |     &mut x.y
-   |          ^ `x` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |          ^ `x` is a `&` reference, so it cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -45,7 +45,7 @@ error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
   --> $DIR/borrowck-borrow-overloaded-auto-deref-mut.rs:92:5
    |
 LL |     x.y = 3;
-   |     ^ `x` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |     ^ `x` is a `&` reference, so it cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -77,7 +77,7 @@ error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
   --> $DIR/borrowck-borrow-overloaded-auto-deref-mut.rs:121:5
    |
 LL |     x.y_mut()
-   |     ^ `x` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |     ^ `x` is a `&` reference, so it cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -99,7 +99,7 @@ error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
   --> $DIR/borrowck-borrow-overloaded-auto-deref-mut.rs:133:6
    |
 LL |     *x.y_mut() = 3;
-   |      ^ `x` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |      ^ `x` is a `&` reference, so it cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/span/borrowck-borrow-overloaded-deref-mut.stderr
+++ b/tests/ui/span/borrowck-borrow-overloaded-deref-mut.stderr
@@ -13,7 +13,7 @@ error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
   --> $DIR/borrowck-borrow-overloaded-deref-mut.rs:41:11
    |
 LL |     &mut **x
-   |           ^^ `x` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |           ^^ `x` is a `&` reference, so it cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -35,7 +35,7 @@ error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
   --> $DIR/borrowck-borrow-overloaded-deref-mut.rs:53:6
    |
 LL |     **x = 3;
-   |      ^^ `x` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |      ^^ `x` is a `&` reference, so it cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/span/borrowck-call-is-borrow-issue-12224.stderr
+++ b/tests/ui/span/borrowck-call-is-borrow-issue-12224.stderr
@@ -14,7 +14,7 @@ error[E0596]: cannot borrow `*f` as mutable, as it is behind a `&` reference
   --> $DIR/borrowck-call-is-borrow-issue-12224.rs:25:5
    |
 LL |     (*f)();
-   |     ^^^^ `f` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |     ^^^^ `f` is a `&` reference, so it cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -25,7 +25,7 @@ error[E0596]: cannot borrow `f.f` as mutable, as it is behind a `&` reference
   --> $DIR/borrowck-call-is-borrow-issue-12224.rs:34:5
    |
 LL |     f.f.call_mut(())
-   |     ^^^ `f` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |     ^^^ `f` is a `&` reference, so it cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/span/borrowck-call-method-from-mut-aliasable.stderr
+++ b/tests/ui/span/borrowck-call-method-from-mut-aliasable.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
   --> $DIR/borrowck-call-method-from-mut-aliasable.rs:17:5
    |
 LL |     x.h();
-   |     ^ `x` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |     ^ `x` is a `&` reference, so it cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/span/borrowck-fn-in-const-b.stderr
+++ b/tests/ui/span/borrowck-fn-in-const-b.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
   --> $DIR/borrowck-fn-in-const-b.rs:7:9
    |
 LL |         x.push(format!("this is broken"));
-   |         ^ `x` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |         ^ `x` is a `&` reference, so it cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/span/borrowck-object-mutability.stderr
+++ b/tests/ui/span/borrowck-object-mutability.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
   --> $DIR/borrowck-object-mutability.rs:8:5
    |
 LL |     x.borrowed_mut();
-   |     ^ `x` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |     ^ `x` is a `&` reference, so it cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/span/mut-arg-hint.stderr
+++ b/tests/ui/span/mut-arg-hint.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `*a` as mutable, as it is behind a `&` reference
   --> $DIR/mut-arg-hint.rs:3:9
    |
 LL |         a.push_str("bar");
-   |         ^ `a` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |         ^ `a` is a `&` reference, so it cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -13,7 +13,7 @@ error[E0596]: cannot borrow `*a` as mutable, as it is behind a `&` reference
   --> $DIR/mut-arg-hint.rs:8:5
    |
 LL |     a.push_str("foo");
-   |     ^ `a` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |     ^ `a` is a `&` reference, so it cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -24,7 +24,7 @@ error[E0596]: cannot borrow `*a` as mutable, as it is behind a `&` reference
   --> $DIR/mut-arg-hint.rs:15:9
    |
 LL |         a.push_str("foo");
-   |         ^ `a` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |         ^ `a` is a `&` reference, so it cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/suggestions/dont_suggest_raw_pointer_syntax-issue-127562.stderr
+++ b/tests/ui/suggestions/dont_suggest_raw_pointer_syntax-issue-127562.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to `*ptr`, which is behind a `*const` pointer
   --> $DIR/dont_suggest_raw_pointer_syntax-issue-127562.rs:5:9
    |
 LL |         *ptr = 3;
-   |         ^^^^^^^^ `ptr` is a `*const` pointer, so the data it refers to cannot be written
+   |         ^^^^^^^^ `ptr` is a `*const` pointer, so it cannot be written to
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/suggestions/issue-68049-1.stderr
+++ b/tests/ui/suggestions/issue-68049-1.stderr
@@ -4,7 +4,7 @@ error[E0594]: cannot assign to `self.0`, which is behind a `&` reference
 LL |     unsafe fn alloc(&self, _layout: Layout) -> *mut u8 {
    |                     ----- this is an immutable reference
 LL |         self.0 += 1;
-   |         ^^^^^^^^^^^ `self` is a `&` reference, so the data it refers to cannot be written
+   |         ^^^^^^^^^^^ `self` is a `&` reference, so it cannot be written to
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/suggestions/issue-68049-2.stderr
+++ b/tests/ui/suggestions/issue-68049-2.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to `*input`, which is behind a `&` reference
   --> $DIR/issue-68049-2.rs:9:7
    |
 LL |       *input = self.0;
-   |       ^^^^^^^^^^^^^^^ `input` is a `&` reference, so the data it refers to cannot be written
+   |       ^^^^^^^^^^^^^^^ `input` is a `&` reference, so it cannot be written to
    |
 help: consider changing this to be a mutable reference in the `impl` method and the `trait` definition
    |
@@ -13,7 +13,7 @@ error[E0594]: cannot assign to `self.0`, which is behind a `&` reference
   --> $DIR/issue-68049-2.rs:17:5
    |
 LL |     self.0 += *input;
-   |     ^^^^^^^^^^^^^^^^ `self` is a `&` reference, so the data it refers to cannot be written
+   |     ^^^^^^^^^^^^^^^^ `self` is a `&` reference, so it cannot be written to
    |
 help: consider changing this to be a mutable reference in the `impl` method and the `trait` definition
    |

--- a/tests/ui/suggestions/suggest-mut-method-for-loop-closure.stderr
+++ b/tests/ui/suggestions/suggest-mut-method-for-loop-closure.stderr
@@ -8,7 +8,7 @@ LL |         for mut t in buzz.values() {
    |                      this iterator yields `&` references
 ...
 LL |             t.v += 1;
-   |             ^^^^^^^^ `t` is a `&` reference, so the data it refers to cannot be written
+   |             ^^^^^^^^ `t` is a `&` reference, so it cannot be written to
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/suggestions/suggest-mut-method-for-loop-hashmap.stderr
+++ b/tests/ui/suggestions/suggest-mut-method-for-loop-hashmap.stderr
@@ -8,7 +8,7 @@ LL |     for (_k, v) in map.iter() {
    |                    this iterator yields `&` references
 ...
 LL |         v.v += 1;
-   |         ^^^^^^^^ `v` is a `&` reference, so the data it refers to cannot be written
+   |         ^^^^^^^^ `v` is a `&` reference, so it cannot be written to
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/suggestions/suggest-mut-method-for-loop.stderr
+++ b/tests/ui/suggestions/suggest-mut-method-for-loop.stderr
@@ -8,7 +8,7 @@ LL |     for mut t in buzz.values() {
    |                  this iterator yields `&` references
 ...
 LL |         t.v += 1;
-   |         ^^^^^^^^ `t` is a `&` reference, so the data it refers to cannot be written
+   |         ^^^^^^^^ `t` is a `&` reference, so it cannot be written to
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/suggestions/suggest-ref-mut.stderr
+++ b/tests/ui/suggestions/suggest-ref-mut.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to `self.0`, which is behind a `&` reference
   --> $DIR/suggest-ref-mut.rs:9:9
    |
 LL |         self.0 = 32;
-   |         ^^^^^^^^^^^ `self` is a `&` reference, so the data it refers to cannot be written
+   |         ^^^^^^^^^^^ `self` is a `&` reference, so it cannot be written to
    |
 help: consider changing this to be a mutable reference
    |
@@ -13,7 +13,7 @@ error[E0594]: cannot assign to `*foo`, which is behind a `&` reference
   --> $DIR/suggest-ref-mut.rs:17:5
    |
 LL |     *foo = 32;
-   |     ^^^^^^^^^ `foo` is a `&` reference, so the data it refers to cannot be written
+   |     ^^^^^^^^^ `foo` is a `&` reference, so it cannot be written to
    |
 help: consider changing this to be a mutable reference
    |
@@ -24,7 +24,7 @@ error[E0594]: cannot assign to `*bar`, which is behind a `&` reference
   --> $DIR/suggest-ref-mut.rs:21:9
    |
 LL |         *bar = 32;
-   |         ^^^^^^^^^ `bar` is a `&` reference, so the data it refers to cannot be written
+   |         ^^^^^^^^^ `bar` is a `&` reference, so it cannot be written to
    |
 help: consider changing this to be a mutable reference
    |
@@ -35,7 +35,7 @@ error[E0594]: cannot assign to `*quo`, which is behind a `&` reference
   --> $DIR/suggest-ref-mut.rs:25:22
    |
 LL |         ref quo => { *quo = 32; },
-   |                      ^^^^^^^^^ `quo` is a `&` reference, so the data it refers to cannot be written
+   |                      ^^^^^^^^^ `quo` is a `&` reference, so it cannot be written to
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/thread-local/thread-local-mutation.stderr
+++ b/tests/ui/thread-local/thread-local-mutation.stderr
@@ -1,6 +1,9 @@
 error[E0594]: cannot assign to immutable static item `S`
   --> $DIR/thread-local-mutation.rs:11:5
    |
+LL | static S: &str = "before";
+   | -------------- this `static` cannot be written to
+...
 LL |     S = "after";
    |     ^^^^^^^^^^^ cannot assign
 

--- a/tests/ui/trivial-bounds/trivial-bounds-inconsistent-copy-reborrow.stderr
+++ b/tests/ui/trivial-bounds/trivial-bounds-inconsistent-copy-reborrow.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `**t` as mutable, as it is behind a `&` reference
   --> $DIR/trivial-bounds-inconsistent-copy-reborrow.rs:6:5
    |
 LL |     *t
-   |     ^^ `t` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |     ^^ `t` is a `&` reference, so it cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -13,7 +13,7 @@ error[E0596]: cannot borrow `**t` as mutable, as it is behind a `&` reference
   --> $DIR/trivial-bounds-inconsistent-copy-reborrow.rs:10:6
    |
 LL |     {*t}
-   |      ^^ `t` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |      ^^ `t` is a `&` reference, so it cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |


### PR DESCRIPTION
Point at statics and consts being mutable borrowed or written to:

```
error[E0594]: cannot assign to immutable static item `NUM`
  --> $DIR/E0594.rs:4:5
   |
LL | static NUM: i32 = 18;
   | --------------- this `static` cannot be written to
...
LL |     NUM = 20;
   |     ^^^^^^^^ cannot assign
```

Point at the expression that couldn't be mutably borrowed from a pattern:

```
error[E0596]: cannot borrow data in a `&` reference as mutable
  --> $DIR/mut-pattern-of-immutable-borrow.rs:19:14
   |
LL |     match &arg.field {
   |           ---------- this cannot be borrowed as mutable
LL |         Some(ref mut s) => s.push('a'),
   |              ^^^^^^^^^ cannot borrow as mutable
```

Partially address rust-lang/rust#74617.