### PR TITLE
Micro-optimize rustdoc search index parsing

### DIFF
--- a/src/librustdoc/html/render/search_index/encode.rs
+++ b/src/librustdoc/html/render/search_index/encode.rs
@@ -78,16 +78,9 @@ pub fn read_postings_from_string(postings: &mut Vec<Vec<u32>>, mut buf: &[u8]) {
     while let Some(&c) = buf.get(0) {
         if c < 0x3a {
             buf = &buf[1..];
-            let mut slot = Vec::new();
-            for _ in 0..c {
-                slot.push(
-                    (buf[0] as u32)
-                        | ((buf[1] as u32) << 8)
-                        | ((buf[2] as u32) << 16)
-                        | ((buf[3] as u32) << 24),
-                );
-                buf = &buf[4..];
-            }
+            let buf = buf.split_off(..usize::from(c) * size_of::<u32>()).unwrap();
+            let (chunks, _) = buf.as_chunks();
+            let slot = chunks.iter().copied().map(u32::from_le_bytes).collect();
             postings.push(slot);
         } else {
             let (bitmap, consumed_bytes_len) =


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
This should pre-allocate the correct size for the `slot` vec. Not sure how much of a difference it'll make, but let's see.