### PR TITLE
Don't use fmt::Arguments implementation details in assert_unsafe_precondition

### DIFF
--- a/library/core/src/ub_checks.rs
+++ b/library/core/src/ub_checks.rs
@@ -70,7 +70,7 @@ macro_rules! assert_unsafe_precondition {
                     let msg = concat!("unsafe precondition(s) violated: ", $message,
                         "\n\nThis indicates a bug in the program. \
                         This Undefined Behavior check is optional, and cannot be relied on for safety.");
-                    ::core::panicking::panic_nounwind_fmt(::core::fmt::Arguments::new_const(&[msg]), false);
+                    ::core::panicking::panic_nounwind(msg);
                 }
             }
 

--- a/tests/ui/consts/const-eval/ub-slice-get-unchecked.stderr
+++ b/tests/ui/consts/const-eval/ub-slice-get-unchecked.stderr
@@ -4,7 +4,10 @@ error[E0080]: evaluation panicked: unsafe precondition(s) violated: slice::get_u
   --> $DIR/ub-slice-get-unchecked.rs:7:27
    |
 LL | const B: &[()] = unsafe { A.get_unchecked(3..1) };
-   |                           ^^^^^^^^^^^^^^^^^^^^^ evaluation of `B` failed here
+   |                           ^^^^^^^^^^^^^^^^^^^^^ evaluation of `B` failed inside this call
+   |
+note: inside `core::panicking::panic_nounwind`
+  --> $SRC_DIR/core/src/panicking.rs:LL:COL
 
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
Removes the use of fmt::Arguments unstable implementation details fom the `assert_unsafe_precondition` expansion.

The fewer places that rely on the exact implementation details of fmt::Arguments, the better.

Also, see https://github.com/rust-lang/rust/pull/129658#discussion_r2181834781