### PR TITLE
Fix ICE from lit_to_mir_constant caused by type error

### DIFF
--- a/compiler/rustc_trait_selection/src/error_reporting/traits/mod.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/mod.rs
@@ -250,29 +250,30 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         }
 
         let mut reported = None;
-
         for from_expansion in [false, true] {
             for (error, suppressed) in iter::zip(&errors, &is_suppressed) {
-                if !suppressed
-                    && error.obligation.cause.span.from_expansion() == from_expansion
-                    && !error.references_error()
-                {
-                    let guar = self.report_fulfillment_error(error);
-                    self.infcx.set_tainted_by_errors(guar);
-                    reported = Some(guar);
-                    // We want to ignore desugarings here: spans are equivalent even
-                    // if one is the result of a desugaring and the other is not.
-                    let mut span = error.obligation.cause.span;
-                    let expn_data = span.ctxt().outer_expn_data();
-                    if let ExpnKind::Desugaring(_) = expn_data.kind {
-                        span = expn_data.call_site;
+                if !suppressed && error.obligation.cause.span.from_expansion() == from_expansion {
+                    if !error.references_error() {
+                        let guar = self.report_fulfillment_error(error);
+                        self.infcx.set_tainted_by_errors(guar);
+                        reported = Some(guar);
+                        // We want to ignore desugarings here: spans are equivalent even
+                        // if one is the result of a desugaring and the other is not.
+                        let mut span = error.obligation.cause.span;
+                        let expn_data = span.ctxt().outer_expn_data();
+                        if let ExpnKind::Desugaring(_) = expn_data.kind {
+                            span = expn_data.call_site;
+                        }
+                        self.reported_trait_errors
+                            .borrow_mut()
+                            .entry(span)
+                            .or_insert_with(|| (vec![], guar))
+                            .0
+                            .push(error.obligation.as_goal());
                     }
-                    self.reported_trait_errors
-                        .borrow_mut()
-                        .entry(span)
-                        .or_insert_with(|| (vec![], guar))
-                        .0
-                        .push(error.obligation.as_goal());
+                    if let Some(guar) = self.dcx().has_errors() {
+                        self.infcx.set_tainted_by_errors(guar);
+                    }
                 }
             }
         }

--- a/tests/ui/enum-discriminant/ice-from-type-error-issue-148515.rs
+++ b/tests/ui/enum-discriminant/ice-from-type-error-issue-148515.rs
@@ -1,0 +1,18 @@
+//@ edition: 2024
+
+enum Test {
+    Value = -5 >> 1_usize,
+}
+
+fn test1(x: impl Iterator<Item = Foo>) {
+    //~^ ERROR cannot find type `Foo` in this scope
+    assert_eq!(Test::Value as u8, -3);
+}
+
+fn test2(_: impl Iterator<Item = Foo>) {
+    //~^ ERROR cannot find type `Foo` in this scope
+    0u8 == -3;
+    //~^ ERROR cannot apply unary operator `-` to type `u8`
+}
+
+fn main() {}

--- a/tests/ui/enum-discriminant/ice-from-type-error-issue-148515.stderr
+++ b/tests/ui/enum-discriminant/ice-from-type-error-issue-148515.stderr
@@ -1,0 +1,24 @@
+error[E0412]: cannot find type `Foo` in this scope
+  --> $DIR/ice-from-type-error-issue-148515.rs:7:34
+   |
+LL | fn test1(x: impl Iterator<Item = Foo>) {
+   |                                  ^^^ not found in this scope
+
+error[E0412]: cannot find type `Foo` in this scope
+  --> $DIR/ice-from-type-error-issue-148515.rs:12:34
+   |
+LL | fn test2(_: impl Iterator<Item = Foo>) {
+   |                                  ^^^ not found in this scope
+
+error[E0600]: cannot apply unary operator `-` to type `u8`
+  --> $DIR/ice-from-type-error-issue-148515.rs:14:12
+   |
+LL |     0u8 == -3;
+   |            ^^ cannot apply unary operator `-`
+   |
+   = note: unsigned values cannot be negated
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0412, E0600.
+For more information about an error, try `rustc --explain E0412`.


### PR DESCRIPTION
Fixes rust-lang/rust#148515

we still need to mark that there were errors to prevent later phases (like MIR building) from proceeding.