### PR TITLE
Expand pow docs with special-case tests

### DIFF
--- a/library/core/src/num/f128.rs
+++ b/library/core/src/num/f128.rs
@@ -1770,6 +1770,7 @@ impl f128 {
     /// assert!(abs_difference <= f128::EPSILON);
     ///
     /// assert_eq!(f128::powi(f128::NAN, 0), 1.0);
+    /// assert_eq!(f128::powi(0.0, 0), 1.0);
     /// # }
     /// ```
     #[inline]

--- a/library/core/src/num/f16.rs
+++ b/library/core/src/num/f16.rs
@@ -1745,6 +1745,7 @@ impl f16 {
     /// assert!(abs_difference <= f16::EPSILON);
     ///
     /// assert_eq!(f16::powi(f16::NAN, 0), 1.0);
+    /// assert_eq!(f16::powi(0.0, 0), 1.0);
     /// # }
     /// ```
     #[inline]

--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -1714,6 +1714,7 @@ macro_rules! int_impl {
         ///
         /// ```
         #[doc = concat!("assert_eq!(8", stringify!($SelfT), ".checked_pow(2), Some(64));")]
+        #[doc = concat!("assert_eq!(0_", stringify!($SelfT), ".checked_pow(0), Some(1));")]
         #[doc = concat!("assert_eq!(", stringify!($SelfT), "::MAX.checked_pow(2), None);")]
         /// ```
 
@@ -1755,6 +1756,7 @@ macro_rules! int_impl {
         ///
         /// ```
         #[doc = concat!("assert_eq!(8", stringify!($SelfT), ".strict_pow(2), 64);")]
+        #[doc = concat!("assert_eq!(0_", stringify!($SelfT), ".strict_pow(0), 1);")]
         /// ```
         ///
         /// The following panics because of overflow:
@@ -2027,6 +2029,7 @@ macro_rules! int_impl {
         ///
         /// ```
         #[doc = concat!("assert_eq!((-4", stringify!($SelfT), ").saturating_pow(3), -64);")]
+        #[doc = concat!("assert_eq!(0_", stringify!($SelfT), ".saturating_pow(0), 1);")]
         #[doc = concat!("assert_eq!(", stringify!($SelfT), "::MIN.saturating_pow(2), ", stringify!($SelfT), "::MAX);")]
         #[doc = concat!("assert_eq!(", stringify!($SelfT), "::MIN.saturating_pow(3), ", stringify!($SelfT), "::MIN);")]
         /// ```
@@ -2371,6 +2374,7 @@ macro_rules! int_impl {
         #[doc = concat!("assert_eq!(3", stringify!($SelfT), ".wrapping_pow(4), 81);")]
         /// assert_eq!(3i8.wrapping_pow(5), -13);
         /// assert_eq!(3i8.wrapping_pow(6), -39);
+        #[doc = concat!("assert_eq!(0_", stringify!($SelfT), ".wrapping_pow(0), 1);")]
         /// ```
         #[stable(feature = "no_panic_pow", since = "1.34.0")]
         #[rustc_const_stable(feature = "const_int_pow", since = "1.50.0")]
@@ -2961,6 +2965,7 @@ macro_rules! int_impl {
         ///
         /// ```
         #[doc = concat!("assert_eq!(3", stringify!($SelfT), ".overflowing_pow(4), (81, false));")]
+        #[doc = concat!("assert_eq!(0_", stringify!($SelfT), ".overflowing_pow(0), (1, false));")]
         /// assert_eq!(3i8.overflowing_pow(5), (-13, true));
         /// ```
         #[stable(feature = "no_panic_pow", since = "1.34.0")]
@@ -3004,6 +3009,7 @@ macro_rules! int_impl {
         #[doc = concat!("let x: ", stringify!($SelfT), " = 2; // or any other integer type")]
         ///
         /// assert_eq!(x.pow(5), 32);
+        #[doc = concat!("assert_eq!(0_", stringify!($SelfT), ".pow(0), 1);")]
         /// ```
         #[stable(feature = "rust1", since = "1.0.0")]
         #[rustc_const_stable(feature = "const_int_pow", since = "1.50.0")]

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -2057,6 +2057,7 @@ macro_rules! uint_impl {
         ///
         /// ```
         #[doc = concat!("assert_eq!(2", stringify!($SelfT), ".checked_pow(5), Some(32));")]
+        #[doc = concat!("assert_eq!(0_", stringify!($SelfT), ".checked_pow(0), Some(1));")]
         #[doc = concat!("assert_eq!(", stringify!($SelfT), "::MAX.checked_pow(2), None);")]
         /// ```
         #[stable(feature = "no_panic_pow", since = "1.34.0")]
@@ -2097,6 +2098,7 @@ macro_rules! uint_impl {
         ///
         /// ```
         #[doc = concat!("assert_eq!(2", stringify!($SelfT), ".strict_pow(5), 32);")]
+        #[doc = concat!("assert_eq!(0_", stringify!($SelfT), ".strict_pow(0), 1);")]
         /// ```
         ///
         /// The following panics because of overflow:
@@ -2271,6 +2273,7 @@ macro_rules! uint_impl {
         ///
         /// ```
         #[doc = concat!("assert_eq!(4", stringify!($SelfT), ".saturating_pow(3), 64);")]
+        #[doc = concat!("assert_eq!(0_", stringify!($SelfT), ".saturating_pow(0), 1);")]
         #[doc = concat!("assert_eq!(", stringify!($SelfT), "::MAX.saturating_pow(2), ", stringify!($SelfT), "::MAX);")]
         /// ```
         #[stable(feature = "no_panic_pow", since = "1.34.0")]
@@ -2580,6 +2583,7 @@ macro_rules! uint_impl {
         /// ```
         #[doc = concat!("assert_eq!(3", stringify!($SelfT), ".wrapping_pow(5), 243);")]
         /// assert_eq!(3u8.wrapping_pow(6), 217);
+        #[doc = concat!("assert_eq!(0_", stringify!($SelfT), ".wrapping_pow(0), 1);")]
         /// ```
         #[stable(feature = "no_panic_pow", since = "1.34.0")]
         #[rustc_const_stable(feature = "const_int_pow", since = "1.50.0")]
@@ -3254,6 +3258,7 @@ macro_rules! uint_impl {
         ///
         /// ```
         #[doc = concat!("assert_eq!(3", stringify!($SelfT), ".overflowing_pow(5), (243, false));")]
+        #[doc = concat!("assert_eq!(0_", stringify!($SelfT), ".overflowing_pow(0), (1, false));")]
         /// assert_eq!(3u8.overflowing_pow(6), (217, true));
         /// ```
         #[stable(feature = "no_panic_pow", since = "1.34.0")]
@@ -3295,6 +3300,7 @@ macro_rules! uint_impl {
         ///
         /// ```
         #[doc = concat!("assert_eq!(2", stringify!($SelfT), ".pow(5), 32);")]
+        #[doc = concat!("assert_eq!(0_", stringify!($SelfT), ".pow(0), 1);")]
         /// ```
         #[stable(feature = "rust1", since = "1.0.0")]
         #[rustc_const_stable(feature = "const_int_pow", since = "1.50.0")]

--- a/library/std/src/num/f128.rs
+++ b/library/std/src/num/f128.rs
@@ -37,6 +37,7 @@ impl f128 {
     ///
     /// assert_eq!(f128::powf(1.0, f128::NAN), 1.0);
     /// assert_eq!(f128::powf(f128::NAN, 0.0), 1.0);
+    /// assert_eq!(f128::powf(0.0, 0.0), 1.0);
     /// # }
     /// ```
     #[inline]

--- a/library/std/src/num/f16.rs
+++ b/library/std/src/num/f16.rs
@@ -37,6 +37,7 @@ impl f16 {
     ///
     /// assert_eq!(f16::powf(1.0, f16::NAN), 1.0);
     /// assert_eq!(f16::powf(f16::NAN, 0.0), 1.0);
+    /// assert_eq!(f16::powf(0.0, 0.0), 1.0);
     /// # }
     /// ```
     #[inline]

--- a/library/std/src/num/f32.rs
+++ b/library/std/src/num/f32.rs
@@ -308,6 +308,7 @@ impl f32 {
     /// assert!(abs_difference <= 1e-5);
     ///
     /// assert_eq!(f32::powi(f32::NAN, 0), 1.0);
+    /// assert_eq!(f32::powi(0.0, 0), 1.0);
     /// ```
     #[rustc_allow_incoherent_impl]
     #[must_use = "method returns a new number and does not mutate the original value"]
@@ -333,6 +334,7 @@ impl f32 {
     ///
     /// assert_eq!(f32::powf(1.0, f32::NAN), 1.0);
     /// assert_eq!(f32::powf(f32::NAN, 0.0), 1.0);
+    /// assert_eq!(f32::powf(0.0, 0.0), 1.0);
     /// ```
     #[rustc_allow_incoherent_impl]
     #[must_use = "method returns a new number and does not mutate the original value"]

--- a/library/std/src/num/f64.rs
+++ b/library/std/src/num/f64.rs
@@ -308,6 +308,7 @@ impl f64 {
     /// assert!(abs_difference <= 1e-14);
     ///
     /// assert_eq!(f64::powi(f64::NAN, 0), 1.0);
+    /// assert_eq!(f64::powi(0.0, 0), 1.0);
     /// ```
     #[rustc_allow_incoherent_impl]
     #[must_use = "method returns a new number and does not mutate the original value"]
@@ -333,6 +334,7 @@ impl f64 {
     ///
     /// assert_eq!(f64::powf(1.0, f64::NAN), 1.0);
     /// assert_eq!(f64::powf(f64::NAN, 0.0), 1.0);
+    /// assert_eq!(f64::powf(0.0, 0.0), 1.0);
     /// ```
     #[rustc_allow_incoherent_impl]
     #[must_use = "method returns a new number and does not mutate the original value"]


### PR DESCRIPTION
resolve: rust-lang/rust#148316 

Files changed:

* library/std/src/num: f32.rs, f64.rs, 
  * powi
  * powf
* library/std/src/num: f16.rs, f128.rs
  * powf
* library/core/src/num: f16.rs, f128.rs
  * powi
* library/core/src/num: int_macros.rs, uint_macros.rs
  * checked_pow
  * strict_pow
  * saturating_pow 
  * wrapping_pow
  * overflowing_pow
  * pow
