### PR TITLE
rustc_target: introduce Abi, Env, Os

### DIFF
--- a/compiler/rustc_codegen_cranelift/src/lib.rs
+++ b/compiler/rustc_codegen_cranelift/src/lib.rs
@@ -49,7 +49,7 @@ use rustc_middle::dep_graph::{WorkProduct, WorkProductId};
 use rustc_session::Session;
 use rustc_session::config::OutputFilenames;
 use rustc_span::{Symbol, sym};
-use rustc_target::spec::Arch;
+use rustc_target::spec::{Abi, Arch};
 
 pub use crate::config::*;
 use crate::prelude::*;
@@ -186,7 +186,7 @@ impl CodegenBackend for CraneliftCodegenBackend {
         let has_reliable_f16_f128 = !(sess.target.arch == Arch::X86_64
             && sess.target.os == "windows"
             && sess.target.env == "gnu"
-            && sess.target.abi != "llvm");
+            && sess.target.abi != Abi::Llvm);
 
         TargetConfig {
             target_features,

--- a/compiler/rustc_codegen_cranelift/src/lib.rs
+++ b/compiler/rustc_codegen_cranelift/src/lib.rs
@@ -49,7 +49,7 @@ use rustc_middle::dep_graph::{WorkProduct, WorkProductId};
 use rustc_session::Session;
 use rustc_session::config::OutputFilenames;
 use rustc_span::{Symbol, sym};
-use rustc_target::spec::{Abi, Arch, Env};
+use rustc_target::spec::{Abi, Arch, Env, Os};
 
 pub use crate::config::*;
 use crate::prelude::*;
@@ -163,15 +163,15 @@ impl CodegenBackend for CraneliftCodegenBackend {
     fn target_config(&self, sess: &Session) -> TargetConfig {
         // FIXME return the actually used target features. this is necessary for #[cfg(target_feature)]
         let target_features = match sess.target.arch {
-            Arch::X86_64 if sess.target.os != "none" => {
+            Arch::X86_64 if sess.target.os != Os::None => {
                 // x86_64 mandates SSE2 support and rustc requires the x87 feature to be enabled
                 vec![sym::fxsr, sym::sse, sym::sse2, Symbol::intern("x87")]
             }
-            Arch::AArch64 => match &*sess.target.os {
-                "none" => vec![],
+            Arch::AArch64 => match &sess.target.os {
+                Os::None => vec![],
                 // On macOS the aes, sha2 and sha3 features are enabled by default and ring
                 // fails to compile on macOS when they are not present.
-                "macos" => vec![sym::neon, sym::aes, sym::sha2, sym::sha3],
+                Os::MacOs => vec![sym::neon, sym::aes, sym::sha2, sym::sha3],
                 // AArch64 mandates Neon support
                 _ => vec![sym::neon],
             },
@@ -184,7 +184,7 @@ impl CodegenBackend for CraneliftCodegenBackend {
         // targets due to GCC using a different ABI than LLVM. Therefore `f16` and `f128`
         // won't be available when using a LLVM-built sysroot.
         let has_reliable_f16_f128 = !(sess.target.arch == Arch::X86_64
-            && sess.target.os == "windows"
+            && sess.target.os == Os::Windows
             && sess.target.env == Env::Gnu
             && sess.target.abi != Abi::Llvm);
 

--- a/compiler/rustc_codegen_cranelift/src/lib.rs
+++ b/compiler/rustc_codegen_cranelift/src/lib.rs
@@ -49,7 +49,7 @@ use rustc_middle::dep_graph::{WorkProduct, WorkProductId};
 use rustc_session::Session;
 use rustc_session::config::OutputFilenames;
 use rustc_span::{Symbol, sym};
-use rustc_target::spec::{Abi, Arch};
+use rustc_target::spec::{Abi, Arch, Env};
 
 pub use crate::config::*;
 use crate::prelude::*;
@@ -185,7 +185,7 @@ impl CodegenBackend for CraneliftCodegenBackend {
         // won't be available when using a LLVM-built sysroot.
         let has_reliable_f16_f128 = !(sess.target.arch == Arch::X86_64
             && sess.target.os == "windows"
-            && sess.target.env == "gnu"
+            && sess.target.env == Env::Gnu
             && sess.target.abi != Abi::Llvm);
 
         TargetConfig {

--- a/compiler/rustc_codegen_llvm/src/callee.rs
+++ b/compiler/rustc_codegen_llvm/src/callee.rs
@@ -7,7 +7,7 @@
 use rustc_codegen_ssa::common;
 use rustc_middle::ty::layout::{FnAbiOf, HasTyCtxt, HasTypingEnv};
 use rustc_middle::ty::{self, Instance, TypeVisitableExt};
-use rustc_target::spec::Arch;
+use rustc_target::spec::{Arch, Env};
 use tracing::debug;
 
 use crate::context::CodegenCx;
@@ -145,7 +145,7 @@ pub(crate) fn get_fn<'ll, 'tcx>(cx: &CodegenCx<'ll, 'tcx>, instance: Instance<'t
         if cx.use_dll_storage_attrs
             && let Some(library) = tcx.native_library(instance_def_id)
             && library.kind.is_dllimport()
-            && !matches!(tcx.sess.target.env.as_ref(), "gnu" | "uclibc")
+            && !matches!(tcx.sess.target.env, Env::Gnu | Env::Uclibc)
         {
             llvm::set_dllimport_storage_class(llfn);
         }

--- a/compiler/rustc_codegen_llvm/src/context.rs
+++ b/compiler/rustc_codegen_llvm/src/context.rs
@@ -29,7 +29,7 @@ use rustc_span::source_map::Spanned;
 use rustc_span::{DUMMY_SP, Span, Symbol};
 use rustc_symbol_mangling::mangle_internal_symbol;
 use rustc_target::spec::{
-    Arch, HasTargetSpec, RelocModel, SmallDataThresholdSupport, Target, TlsModel,
+    Abi, Arch, HasTargetSpec, RelocModel, SmallDataThresholdSupport, Target, TlsModel,
 };
 use smallvec::SmallVec;
 
@@ -337,7 +337,7 @@ pub(crate) unsafe fn create_module<'ll>(
     if sess.target.is_like_msvc
         || (sess.target.options.os == "windows"
             && sess.target.options.env == "gnu"
-            && sess.target.options.abi == "llvm")
+            && sess.target.options.abi == Abi::Llvm)
     {
         match sess.opts.cg.control_flow_guard {
             CFGuard::Disabled => {}

--- a/compiler/rustc_codegen_llvm/src/context.rs
+++ b/compiler/rustc_codegen_llvm/src/context.rs
@@ -29,7 +29,7 @@ use rustc_span::source_map::Spanned;
 use rustc_span::{DUMMY_SP, Span, Symbol};
 use rustc_symbol_mangling::mangle_internal_symbol;
 use rustc_target::spec::{
-    Abi, Arch, HasTargetSpec, RelocModel, SmallDataThresholdSupport, Target, TlsModel,
+    Abi, Arch, Env, HasTargetSpec, RelocModel, SmallDataThresholdSupport, Target, TlsModel,
 };
 use smallvec::SmallVec;
 
@@ -336,7 +336,7 @@ pub(crate) unsafe fn create_module<'ll>(
     // Control Flow Guard is currently only supported by MSVC and LLVM on Windows.
     if sess.target.is_like_msvc
         || (sess.target.options.os == "windows"
-            && sess.target.options.env == "gnu"
+            && sess.target.options.env == Env::Gnu
             && sess.target.options.abi == Abi::Llvm)
     {
         match sess.opts.cg.control_flow_guard {
@@ -710,7 +710,7 @@ impl<'ll, 'tcx> CodegenCx<'ll, 'tcx> {
             },
         );
 
-        if self.tcx.sess.target.env == "sim" {
+        if self.tcx.sess.target.env == Env::Sim {
             llvm::add_module_flag_u32(
                 self.llmod,
                 llvm::ModuleFlagMergeBehavior::Error,

--- a/compiler/rustc_codegen_llvm/src/context.rs
+++ b/compiler/rustc_codegen_llvm/src/context.rs
@@ -29,7 +29,7 @@ use rustc_span::source_map::Spanned;
 use rustc_span::{DUMMY_SP, Span, Symbol};
 use rustc_symbol_mangling::mangle_internal_symbol;
 use rustc_target::spec::{
-    Abi, Arch, Env, HasTargetSpec, RelocModel, SmallDataThresholdSupport, Target, TlsModel,
+    Abi, Arch, Env, HasTargetSpec, Os, RelocModel, SmallDataThresholdSupport, Target, TlsModel,
 };
 use smallvec::SmallVec;
 
@@ -335,7 +335,7 @@ pub(crate) unsafe fn create_module<'ll>(
 
     // Control Flow Guard is currently only supported by MSVC and LLVM on Windows.
     if sess.target.is_like_msvc
-        || (sess.target.options.os == "windows"
+        || (sess.target.options.os == Os::Windows
             && sess.target.options.env == Env::Gnu
             && sess.target.options.abi == Abi::Llvm)
     {
@@ -669,7 +669,7 @@ impl<'ll, 'tcx> CodegenCx<'ll, 'tcx> {
     /// This corresponds to the `-fobjc-abi-version=` flag in Clang / GCC.
     pub(crate) fn objc_abi_version(&self) -> u32 {
         assert!(self.tcx.sess.target.is_like_darwin);
-        if self.tcx.sess.target.arch == Arch::X86 && self.tcx.sess.target.os == "macos" {
+        if self.tcx.sess.target.arch == Arch::X86 && self.tcx.sess.target.os == Os::MacOs {
             // 32-bit x86 macOS uses ABI version 1 (a.k.a. the "fragile ABI").
             1
         } else {
@@ -963,7 +963,7 @@ impl<'ll> CodegenCx<'ll, '_> {
             return eh_catch_typeinfo;
         }
         let tcx = self.tcx;
-        assert!(self.sess().target.os == "emscripten");
+        assert!(self.sess().target.os == Os::Emscripten);
         let eh_catch_typeinfo = match tcx.lang_items().eh_catch_typeinfo() {
             Some(def_id) => self.get_static(def_id),
             _ => {

--- a/compiler/rustc_codegen_llvm/src/intrinsic.rs
+++ b/compiler/rustc_codegen_llvm/src/intrinsic.rs
@@ -18,6 +18,7 @@ use rustc_middle::{bug, span_bug};
 use rustc_span::{Span, Symbol, sym};
 use rustc_symbol_mangling::{mangle_internal_symbol, symbol_name_for_instance_in_crate};
 use rustc_target::callconv::PassMode;
+use rustc_target::spec::Os;
 use tracing::debug;
 
 use crate::abi::FnAbiLlvmExt;
@@ -681,7 +682,7 @@ fn catch_unwind_intrinsic<'ll, 'tcx>(
         codegen_msvc_try(bx, try_func, data, catch_func, dest);
     } else if wants_wasm_eh(bx.sess()) {
         codegen_wasm_try(bx, try_func, data, catch_func, dest);
-    } else if bx.sess().target.os == "emscripten" {
+    } else if bx.sess().target.os == Os::Emscripten {
         codegen_emcc_try(bx, try_func, data, catch_func, dest);
     } else {
         codegen_gnu_try(bx, try_func, data, catch_func, dest);

--- a/compiler/rustc_codegen_llvm/src/llvm_util.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm_util.rs
@@ -15,7 +15,7 @@ use rustc_fs_util::path_to_c_string;
 use rustc_middle::bug;
 use rustc_session::Session;
 use rustc_session::config::{PrintKind, PrintRequest};
-use rustc_target::spec::{Arch, MergeFunctions, PanicStrategy, SmallDataThresholdSupport};
+use rustc_target::spec::{Abi, Arch, MergeFunctions, PanicStrategy, SmallDataThresholdSupport};
 use smallvec::{SmallVec, smallvec};
 
 use crate::back::write::create_informational_target_machine;
@@ -353,7 +353,7 @@ fn update_target_reliable_float_cfg(sess: &Session, cfg: &mut TargetConfig) {
     let target_arch = &sess.target.arch;
     let target_os = sess.target.options.os.as_ref();
     let target_env = sess.target.options.env.as_ref();
-    let target_abi = sess.target.options.abi.as_ref();
+    let target_abi = &sess.target.options.abi;
     let target_pointer_width = sess.target.pointer_width;
     let version = get_version();
     let lt_20_1_1 = version < (20, 1, 1);
@@ -371,7 +371,7 @@ fn update_target_reliable_float_cfg(sess: &Session, cfg: &mut TargetConfig) {
         // Selection failure <https://github.com/llvm/llvm-project/issues/50374> (fixed in llvm21)
         (Arch::S390x, _) if lt_21_0_0 => false,
         // MinGW ABI bugs <https://gcc.gnu.org/bugzilla/show_bug.cgi?id=115054>
-        (Arch::X86_64, "windows") if target_env == "gnu" && target_abi != "llvm" => false,
+        (Arch::X86_64, "windows") if target_env == "gnu" && *target_abi != Abi::Llvm => false,
         // Infinite recursion <https://github.com/llvm/llvm-project/issues/97981>
         (Arch::CSky, _) => false,
         (Arch::Hexagon, _) if lt_21_0_0 => false, // (fixed in llvm21)
@@ -403,7 +403,7 @@ fn update_target_reliable_float_cfg(sess: &Session, cfg: &mut TargetConfig) {
         // not fail if our compiler-builtins is linked. (fixed in llvm21)
         (Arch::X86, _) if lt_21_0_0 => false,
         // MinGW ABI bugs <https://gcc.gnu.org/bugzilla/show_bug.cgi?id=115054>
-        (Arch::X86_64, "windows") if target_env == "gnu" && target_abi != "llvm" => false,
+        (Arch::X86_64, "windows") if target_env == "gnu" && *target_abi != Abi::Llvm => false,
         // There are no known problems on other platforms, so the only requirement is that symbols
         // are available. `compiler-builtins` provides all symbols required for core `f128`
         // support, so this should work for everything else.

--- a/compiler/rustc_codegen_llvm/src/va_arg.rs
+++ b/compiler/rustc_codegen_llvm/src/va_arg.rs
@@ -7,7 +7,7 @@ use rustc_codegen_ssa::traits::{
 };
 use rustc_middle::ty::Ty;
 use rustc_middle::ty::layout::{HasTyCtxt, LayoutOf};
-use rustc_target::spec::Arch;
+use rustc_target::spec::{Abi, Arch};
 
 use crate::builder::Builder;
 use crate::llvm::{Type, Value};
@@ -270,7 +270,7 @@ fn emit_powerpc_va_arg<'ll, 'tcx>(
 
     // Rust does not currently support any powerpc softfloat targets.
     let target = &bx.cx.tcx.sess.target;
-    let is_soft_float_abi = target.abi == "softfloat";
+    let is_soft_float_abi = target.abi == Abi::SoftFloat;
     assert!(!is_soft_float_abi);
 
     // All instances of VaArgSafe are passed directly.

--- a/compiler/rustc_codegen_ssa/src/back/apple.rs
+++ b/compiler/rustc_codegen_ssa/src/back/apple.rs
@@ -6,7 +6,7 @@ use itertools::Itertools;
 use rustc_middle::middle::exported_symbols::SymbolExportKind;
 use rustc_session::Session;
 pub(super) use rustc_target::spec::apple::OSVersion;
-use rustc_target::spec::{Arch, Target};
+use rustc_target::spec::{Arch, Env, Target};
 use tracing::debug;
 
 use crate::errors::{XcrunError, XcrunSdkPathWarning};
@@ -17,35 +17,35 @@ mod tests;
 
 /// The canonical name of the desired SDK for a given target.
 pub(super) fn sdk_name(target: &Target) -> &'static str {
-    match (&*target.os, &*target.env) {
-        ("macos", "") => "MacOSX",
-        ("ios", "") => "iPhoneOS",
-        ("ios", "sim") => "iPhoneSimulator",
+    match (&*target.os, &target.env) {
+        ("macos", Env::Unspecified) => "MacOSX",
+        ("ios", Env::Unspecified) => "iPhoneOS",
+        ("ios", Env::Sim) => "iPhoneSimulator",
         // Mac Catalyst uses the macOS SDK
-        ("ios", "macabi") => "MacOSX",
-        ("tvos", "") => "AppleTVOS",
-        ("tvos", "sim") => "AppleTVSimulator",
-        ("visionos", "") => "XROS",
-        ("visionos", "sim") => "XRSimulator",
-        ("watchos", "") => "WatchOS",
-        ("watchos", "sim") => "WatchSimulator",
+        ("ios", Env::MacAbi) => "MacOSX",
+        ("tvos", Env::Unspecified) => "AppleTVOS",
+        ("tvos", Env::Sim) => "AppleTVSimulator",
+        ("visionos", Env::Unspecified) => "XROS",
+        ("visionos", Env::Sim) => "XRSimulator",
+        ("watchos", Env::Unspecified) => "WatchOS",
+        ("watchos", Env::Sim) => "WatchSimulator",
         (os, abi) => unreachable!("invalid os '{os}' / abi '{abi}' combination for Apple target"),
     }
 }
 
 pub(super) fn macho_platform(target: &Target) -> u32 {
-    match (&*target.os, &*target.env) {
+    match (&*target.os, &target.env) {
         ("macos", _) => object::macho::PLATFORM_MACOS,
-        ("ios", "macabi") => object::macho::PLATFORM_MACCATALYST,
-        ("ios", "sim") => object::macho::PLATFORM_IOSSIMULATOR,
+        ("ios", Env::MacAbi) => object::macho::PLATFORM_MACCATALYST,
+        ("ios", Env::Sim) => object::macho::PLATFORM_IOSSIMULATOR,
         ("ios", _) => object::macho::PLATFORM_IOS,
-        ("watchos", "sim") => object::macho::PLATFORM_WATCHOSSIMULATOR,
+        ("watchos", Env::Sim) => object::macho::PLATFORM_WATCHOSSIMULATOR,
         ("watchos", _) => object::macho::PLATFORM_WATCHOS,
-        ("tvos", "sim") => object::macho::PLATFORM_TVOSSIMULATOR,
+        ("tvos", Env::Sim) => object::macho::PLATFORM_TVOSSIMULATOR,
         ("tvos", _) => object::macho::PLATFORM_TVOS,
-        ("visionos", "sim") => object::macho::PLATFORM_XROSSIMULATOR,
+        ("visionos", Env::Sim) => object::macho::PLATFORM_XROSSIMULATOR,
         ("visionos", _) => object::macho::PLATFORM_XROS,
-        _ => unreachable!("tried to get Mach-O platform for non-Apple target"),
+        (os, env) => unreachable!("invalid os '{os}' / env '{env}' combination for Apple target"),
     }
 }
 

--- a/compiler/rustc_codegen_ssa/src/back/apple.rs
+++ b/compiler/rustc_codegen_ssa/src/back/apple.rs
@@ -6,7 +6,7 @@ use itertools::Itertools;
 use rustc_middle::middle::exported_symbols::SymbolExportKind;
 use rustc_session::Session;
 pub(super) use rustc_target::spec::apple::OSVersion;
-use rustc_target::spec::{Arch, Env, Target};
+use rustc_target::spec::{Arch, Env, Os, Target};
 use tracing::debug;
 
 use crate::errors::{XcrunError, XcrunSdkPathWarning};
@@ -17,34 +17,34 @@ mod tests;
 
 /// The canonical name of the desired SDK for a given target.
 pub(super) fn sdk_name(target: &Target) -> &'static str {
-    match (&*target.os, &target.env) {
-        ("macos", Env::Unspecified) => "MacOSX",
-        ("ios", Env::Unspecified) => "iPhoneOS",
-        ("ios", Env::Sim) => "iPhoneSimulator",
+    match (&target.os, &target.env) {
+        (Os::MacOs, Env::Unspecified) => "MacOSX",
+        (Os::IOs, Env::Unspecified) => "iPhoneOS",
+        (Os::IOs, Env::Sim) => "iPhoneSimulator",
         // Mac Catalyst uses the macOS SDK
-        ("ios", Env::MacAbi) => "MacOSX",
-        ("tvos", Env::Unspecified) => "AppleTVOS",
-        ("tvos", Env::Sim) => "AppleTVSimulator",
-        ("visionos", Env::Unspecified) => "XROS",
-        ("visionos", Env::Sim) => "XRSimulator",
-        ("watchos", Env::Unspecified) => "WatchOS",
-        ("watchos", Env::Sim) => "WatchSimulator",
+        (Os::IOs, Env::MacAbi) => "MacOSX",
+        (Os::TvOs, Env::Unspecified) => "AppleTVOS",
+        (Os::TvOs, Env::Sim) => "AppleTVSimulator",
+        (Os::VisionOs, Env::Unspecified) => "XROS",
+        (Os::VisionOs, Env::Sim) => "XRSimulator",
+        (Os::WatchOs, Env::Unspecified) => "WatchOS",
+        (Os::WatchOs, Env::Sim) => "WatchSimulator",
         (os, abi) => unreachable!("invalid os '{os}' / abi '{abi}' combination for Apple target"),
     }
 }
 
 pub(super) fn macho_platform(target: &Target) -> u32 {
-    match (&*target.os, &target.env) {
-        ("macos", _) => object::macho::PLATFORM_MACOS,
-        ("ios", Env::MacAbi) => object::macho::PLATFORM_MACCATALYST,
-        ("ios", Env::Sim) => object::macho::PLATFORM_IOSSIMULATOR,
-        ("ios", _) => object::macho::PLATFORM_IOS,
-        ("watchos", Env::Sim) => object::macho::PLATFORM_WATCHOSSIMULATOR,
-        ("watchos", _) => object::macho::PLATFORM_WATCHOS,
-        ("tvos", Env::Sim) => object::macho::PLATFORM_TVOSSIMULATOR,
-        ("tvos", _) => object::macho::PLATFORM_TVOS,
-        ("visionos", Env::Sim) => object::macho::PLATFORM_XROSSIMULATOR,
-        ("visionos", _) => object::macho::PLATFORM_XROS,
+    match (&target.os, &target.env) {
+        (Os::MacOs, _) => object::macho::PLATFORM_MACOS,
+        (Os::IOs, Env::MacAbi) => object::macho::PLATFORM_MACCATALYST,
+        (Os::IOs, Env::Sim) => object::macho::PLATFORM_IOSSIMULATOR,
+        (Os::IOs, _) => object::macho::PLATFORM_IOS,
+        (Os::WatchOs, Env::Sim) => object::macho::PLATFORM_WATCHOSSIMULATOR,
+        (Os::WatchOs, _) => object::macho::PLATFORM_WATCHOS,
+        (Os::TvOs, Env::Sim) => object::macho::PLATFORM_TVOSSIMULATOR,
+        (Os::TvOs, _) => object::macho::PLATFORM_TVOS,
+        (Os::VisionOs, Env::Sim) => object::macho::PLATFORM_XROSSIMULATOR,
+        (Os::VisionOs, _) => object::macho::PLATFORM_XROS,
         (os, env) => unreachable!("invalid os '{os}' / env '{env}' combination for Apple target"),
     }
 }

--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -47,7 +47,7 @@ use rustc_span::Symbol;
 use rustc_target::spec::crt_objects::CrtObjects;
 use rustc_target::spec::{
     Abi, BinaryFormat, Cc, Env, LinkOutputKind, LinkSelfContainedComponents,
-    LinkSelfContainedDefault, LinkerFeatures, LinkerFlavor, LinkerFlavorCli, Lld, RelocModel,
+    LinkSelfContainedDefault, LinkerFeatures, LinkerFlavor, LinkerFlavorCli, Lld, Os, RelocModel,
     RelroLevel, SanitizerSet, SplitDebuginfo,
 };
 use tracing::{debug, info, warn};
@@ -1845,7 +1845,7 @@ fn add_pre_link_objects(
     let empty = Default::default();
     let objects = if self_contained {
         &opts.pre_link_objects_self_contained
-    } else if !(sess.target.os == "fuchsia" && matches!(flavor, LinkerFlavor::Gnu(Cc::Yes, _))) {
+    } else if !(sess.target.os == Os::Fuchsia && matches!(flavor, LinkerFlavor::Gnu(Cc::Yes, _))) {
         &opts.pre_link_objects
     } else {
         &empty
@@ -2496,7 +2496,7 @@ fn add_order_independent_options(
 
     let apple_sdk_root = add_apple_sdk(cmd, sess, flavor);
 
-    if sess.target.os == "fuchsia"
+    if sess.target.os == Os::Fuchsia
         && crate_type == CrateType::Executable
         && !matches!(flavor, LinkerFlavor::Gnu(Cc::Yes, _))
     {
@@ -2515,7 +2515,7 @@ fn add_order_independent_options(
         cmd.no_crt_objects();
     }
 
-    if sess.target.os == "emscripten" {
+    if sess.target.os == Os::Emscripten {
         cmd.cc_arg(if sess.opts.unstable_opts.emscripten_wasm_eh {
             "-fwasm-exceptions"
         } else if sess.panic_strategy().unwinds() {
@@ -3070,7 +3070,7 @@ fn add_apple_link_args(cmd: &mut dyn Linker, sess: &Session, flavor: LinkerFlavo
 
     // `sess.target.arch` (`target_arch`) is not detailed enough.
     let llvm_arch = sess.target.llvm_target.split_once('-').expect("LLVM target must have arch").0;
-    let target_os = &*sess.target.os;
+    let target_os = &sess.target.os;
     let target_env = &sess.target.env;
 
     // The architecture name to forward to the linker.
@@ -3123,12 +3123,12 @@ fn add_apple_link_args(cmd: &mut dyn Linker, sess: &Session, flavor: LinkerFlavo
         // > - xros-simulator
         // > - driverkit
         let platform_name = match (target_os, target_env) {
-            (os, Env::Unspecified) => os,
-            ("ios", Env::MacAbi) => "mac-catalyst",
-            ("ios", Env::Sim) => "ios-simulator",
-            ("tvos", Env::Sim) => "tvos-simulator",
-            ("watchos", Env::Sim) => "watchos-simulator",
-            ("visionos", Env::Sim) => "visionos-simulator",
+            (os, Env::Unspecified) => os.desc(),
+            (Os::IOs, Env::MacAbi) => "mac-catalyst",
+            (Os::IOs, Env::Sim) => "ios-simulator",
+            (Os::TvOs, Env::Sim) => "tvos-simulator",
+            (Os::WatchOs, Env::Sim) => "watchos-simulator",
+            (Os::VisionOs, Env::Sim) => "visionos-simulator",
             _ => bug!("invalid OS/env combination for Apple target: {target_os}, {target_env}"),
         };
 
@@ -3192,7 +3192,7 @@ fn add_apple_link_args(cmd: &mut dyn Linker, sess: &Session, flavor: LinkerFlavo
         // fairly safely use `-target`. See also the following, where it is
         // made explicit that the recommendation by LLVM developers is to use
         // `-target`: <https://github.com/llvm/llvm-project/issues/88271>
-        if target_os == "macos" {
+        if *target_os == Os::MacOs {
             // `-arch` communicates the architecture.
             //
             // CC forwards the `-arch` to the linker, so we use the same value

--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -46,9 +46,9 @@ use rustc_session::{Session, filesearch};
 use rustc_span::Symbol;
 use rustc_target::spec::crt_objects::CrtObjects;
 use rustc_target::spec::{
-    Abi, BinaryFormat, Cc, LinkOutputKind, LinkSelfContainedComponents, LinkSelfContainedDefault,
-    LinkerFeatures, LinkerFlavor, LinkerFlavorCli, Lld, RelocModel, RelroLevel, SanitizerSet,
-    SplitDebuginfo,
+    Abi, BinaryFormat, Cc, Env, LinkOutputKind, LinkSelfContainedComponents,
+    LinkSelfContainedDefault, LinkerFeatures, LinkerFlavor, LinkerFlavorCli, Lld, RelocModel,
+    RelroLevel, SanitizerSet, SplitDebuginfo,
 };
 use tracing::{debug, info, warn};
 
@@ -3071,7 +3071,7 @@ fn add_apple_link_args(cmd: &mut dyn Linker, sess: &Session, flavor: LinkerFlavo
     // `sess.target.arch` (`target_arch`) is not detailed enough.
     let llvm_arch = sess.target.llvm_target.split_once('-').expect("LLVM target must have arch").0;
     let target_os = &*sess.target.os;
-    let target_env = &*sess.target.env;
+    let target_env = &sess.target.env;
 
     // The architecture name to forward to the linker.
     //
@@ -3123,12 +3123,12 @@ fn add_apple_link_args(cmd: &mut dyn Linker, sess: &Session, flavor: LinkerFlavo
         // > - xros-simulator
         // > - driverkit
         let platform_name = match (target_os, target_env) {
-            (os, "") => os,
-            ("ios", "macabi") => "mac-catalyst",
-            ("ios", "sim") => "ios-simulator",
-            ("tvos", "sim") => "tvos-simulator",
-            ("watchos", "sim") => "watchos-simulator",
-            ("visionos", "sim") => "visionos-simulator",
+            (os, Env::Unspecified) => os,
+            ("ios", Env::MacAbi) => "mac-catalyst",
+            ("ios", Env::Sim) => "ios-simulator",
+            ("tvos", Env::Sim) => "tvos-simulator",
+            ("watchos", Env::Sim) => "watchos-simulator",
+            ("visionos", Env::Sim) => "visionos-simulator",
             _ => bug!("invalid OS/env combination for Apple target: {target_os}, {target_env}"),
         };
 

--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -1407,11 +1407,9 @@ pub fn linker_and_flavor(sess: &Session) -> (PathBuf, LinkerFlavor) {
         Some(LinkerFlavorCli::Llbc) => Some(LinkerFlavor::Llbc),
         Some(LinkerFlavorCli::Ptx) => Some(LinkerFlavor::Ptx),
         // The linker flavors that corresponds to targets needs logic that keeps the base LinkerFlavor
-        _ => sess
-            .opts
-            .cg
-            .linker_flavor
-            .map(|flavor| sess.target.linker_flavor.with_cli_hints(flavor)),
+        linker_flavor => {
+            linker_flavor.map(|flavor| sess.target.linker_flavor.with_cli_hints(flavor))
+        }
     };
     if let Some(ret) = infer_from(sess, sess.opts.cg.linker.clone(), linker_flavor, features) {
         return ret;

--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -46,7 +46,7 @@ use rustc_session::{Session, filesearch};
 use rustc_span::Symbol;
 use rustc_target::spec::crt_objects::CrtObjects;
 use rustc_target::spec::{
-    BinaryFormat, Cc, LinkOutputKind, LinkSelfContainedComponents, LinkSelfContainedDefault,
+    Abi, BinaryFormat, Cc, LinkOutputKind, LinkSelfContainedComponents, LinkSelfContainedDefault,
     LinkerFeatures, LinkerFlavor, LinkerFlavorCli, Lld, RelocModel, RelroLevel, SanitizerSet,
     SplitDebuginfo,
 };
@@ -1819,7 +1819,7 @@ fn self_contained_components(
                 LinkSelfContainedDefault::InferredForMusl => sess.crt_static(Some(crate_type)),
                 LinkSelfContainedDefault::InferredForMingw => {
                     sess.host == sess.target
-                        && sess.target.abi != "uwp"
+                        && sess.target.abi != Abi::Uwp
                         && detect_self_contained_mingw(sess, linker)
                 }
             }

--- a/compiler/rustc_codegen_ssa/src/back/linker.rs
+++ b/compiler/rustc_codegen_ssa/src/back/linker.rs
@@ -17,7 +17,7 @@ use rustc_middle::middle::exported_symbols::{
 use rustc_middle::ty::TyCtxt;
 use rustc_session::Session;
 use rustc_session::config::{self, CrateType, DebugInfo, LinkerPluginLto, Lto, OptLevel, Strip};
-use rustc_target::spec::{Arch, Cc, LinkOutputKind, LinkerFlavor, Lld};
+use rustc_target::spec::{Abi, Arch, Cc, LinkOutputKind, LinkerFlavor, Lld};
 use tracing::{debug, warn};
 
 use super::command::Command;
@@ -83,7 +83,7 @@ pub(crate) fn get_linker<'a>(
     // To comply with the Windows App Certification Kit,
     // MSVC needs to link with the Store versions of the runtime libraries (vcruntime, msvcrt, etc).
     let t = &sess.target;
-    if matches!(flavor, LinkerFlavor::Msvc(..)) && t.abi == "uwp" {
+    if matches!(flavor, LinkerFlavor::Msvc(..)) && t.abi == Abi::Uwp {
         if let Some(ref tool) = msvc_tool {
             let original_path = tool.path();
             if let Some(root_lib_path) = original_path.ancestors().nth(4) {
@@ -134,7 +134,7 @@ pub(crate) fn get_linker<'a>(
 
     // FIXME: Move `/LIBPATH` addition for uwp targets from the linker construction
     // to the linker args construction.
-    assert!(cmd.get_args().is_empty() || sess.target.abi == "uwp");
+    assert!(cmd.get_args().is_empty() || sess.target.abi == Abi::Uwp);
     match flavor {
         LinkerFlavor::Unix(Cc::No) if sess.target.os == "l4re" => {
             Box::new(L4Bender::new(cmd, sess)) as Box<dyn Linker>

--- a/compiler/rustc_codegen_ssa/src/back/linker.rs
+++ b/compiler/rustc_codegen_ssa/src/back/linker.rs
@@ -17,7 +17,7 @@ use rustc_middle::middle::exported_symbols::{
 use rustc_middle::ty::TyCtxt;
 use rustc_session::Session;
 use rustc_session::config::{self, CrateType, DebugInfo, LinkerPluginLto, Lto, OptLevel, Strip};
-use rustc_target::spec::{Abi, Arch, Cc, LinkOutputKind, LinkerFlavor, Lld};
+use rustc_target::spec::{Abi, Arch, Cc, LinkOutputKind, LinkerFlavor, Lld, Os};
 use tracing::{debug, warn};
 
 use super::command::Command;
@@ -136,10 +136,10 @@ pub(crate) fn get_linker<'a>(
     // to the linker args construction.
     assert!(cmd.get_args().is_empty() || sess.target.abi == Abi::Uwp);
     match flavor {
-        LinkerFlavor::Unix(Cc::No) if sess.target.os == "l4re" => {
+        LinkerFlavor::Unix(Cc::No) if sess.target.os == Os::L4Re => {
             Box::new(L4Bender::new(cmd, sess)) as Box<dyn Linker>
         }
-        LinkerFlavor::Unix(Cc::No) if sess.target.os == "aix" => {
+        LinkerFlavor::Unix(Cc::No) if sess.target.os == Os::Aix => {
             Box::new(AixLinker::new(cmd, sess)) as Box<dyn Linker>
         }
         LinkerFlavor::WasmLld(Cc::No) => Box::new(WasmLd::new(cmd, sess)) as Box<dyn Linker>,
@@ -573,7 +573,7 @@ impl<'a> Linker for GccLinker<'a> {
         // any `#[link]` attributes in the `libc` crate, see #72782 for details.
         // FIXME: Switch to using `#[link]` attributes in the `libc` crate
         // similarly to other targets.
-        if self.sess.target.os == "vxworks"
+        if self.sess.target.os == Os::VxWorks
             && matches!(
                 output_kind,
                 LinkOutputKind::StaticNoPicExe
@@ -595,7 +595,7 @@ impl<'a> Linker for GccLinker<'a> {
     }
 
     fn link_dylib_by_name(&mut self, name: &str, verbatim: bool, as_needed: bool) {
-        if self.sess.target.os == "illumos" && name == "c" {
+        if self.sess.target.os == Os::Illumos && name == "c" {
             // libc will be added via late_link_args on illumos so that it will
             // appear last in the library search order.
             // FIXME: This should be replaced by a more complete and generic
@@ -1439,7 +1439,7 @@ impl<'a> Linker for WasmLd<'a> {
         // symbols explicitly passed via the `--export` flags above and hides all
         // others. Various bits and pieces of wasm32-unknown-unknown tooling use
         // this, so be sure these symbols make their way out of the linker as well.
-        if self.sess.target.os == "unknown" || self.sess.target.os == "none" {
+        if matches!(self.sess.target.os, Os::Unknown | Os::None) {
             self.link_args(&["--export=__heap_base", "--export=__data_end"]);
         }
     }

--- a/compiler/rustc_codegen_ssa/src/back/metadata.rs
+++ b/compiler/rustc_codegen_ssa/src/back/metadata.rs
@@ -20,7 +20,7 @@ use rustc_metadata::fs::METADATA_FILENAME;
 use rustc_middle::bug;
 use rustc_session::Session;
 use rustc_span::sym;
-use rustc_target::spec::{RelocModel, Target, ef_avr_arch};
+use rustc_target::spec::{Abi, RelocModel, Target, ef_avr_arch};
 use tracing::debug;
 
 use super::apple;
@@ -379,11 +379,11 @@ pub(super) fn elf_e_flags(architecture: Architecture, sess: &Session) -> u32 {
             }
         }
         Architecture::Csky => {
-            let e_flags = match sess.target.options.abi.as_ref() {
-                "abiv2" => elf::EF_CSKY_ABIV2,
-                _ => elf::EF_CSKY_ABIV1,
-            };
-            e_flags
+            if matches!(sess.target.options.abi, Abi::AbiV2) {
+                elf::EF_CSKY_ABIV2
+            } else {
+                elf::EF_CSKY_ABIV1
+            }
         }
         Architecture::PowerPc64 => {
             const EF_PPC64_ABI_UNKNOWN: u32 = 0;

--- a/compiler/rustc_codegen_ssa/src/back/metadata.rs
+++ b/compiler/rustc_codegen_ssa/src/back/metadata.rs
@@ -20,7 +20,7 @@ use rustc_metadata::fs::METADATA_FILENAME;
 use rustc_middle::bug;
 use rustc_session::Session;
 use rustc_span::sym;
-use rustc_target::spec::{Abi, RelocModel, Target, ef_avr_arch};
+use rustc_target::spec::{Abi, Os, RelocModel, Target, ef_avr_arch};
 use tracing::debug;
 
 use super::apple;
@@ -260,10 +260,10 @@ pub(crate) fn create_object_file(sess: &Session) -> Option<write::Object<'static
 }
 
 pub(super) fn elf_os_abi(sess: &Session) -> u8 {
-    match sess.target.options.os.as_ref() {
-        "hermit" => elf::ELFOSABI_STANDALONE,
-        "freebsd" => elf::ELFOSABI_FREEBSD,
-        "solaris" => elf::ELFOSABI_SOLARIS,
+    match sess.target.options.os {
+        Os::Hermit => elf::ELFOSABI_STANDALONE,
+        Os::FreeBsd => elf::ELFOSABI_FREEBSD,
+        Os::Solaris => elf::ELFOSABI_SOLARIS,
         _ => elf::ELFOSABI_NONE,
     }
 }

--- a/compiler/rustc_codegen_ssa/src/back/symbol_export.rs
+++ b/compiler/rustc_codegen_ssa/src/back/symbol_export.rs
@@ -17,7 +17,7 @@ use rustc_middle::ty::{self, GenericArgKind, GenericArgsRef, Instance, SymbolNam
 use rustc_middle::util::Providers;
 use rustc_session::config::{CrateType, OomStrategy};
 use rustc_symbol_mangling::mangle_internal_symbol;
-use rustc_target::spec::{Arch, TlsModel};
+use rustc_target::spec::{Arch, Os, TlsModel};
 use tracing::debug;
 
 use crate::back::symbol_export;
@@ -711,7 +711,7 @@ pub(crate) fn extend_exported_symbols<'tcx>(
 ) {
     let (callconv, _) = calling_convention_for_symbol(tcx, symbol);
 
-    if callconv != CanonAbi::GpuKernel || tcx.sess.target.os != "amdhsa" {
+    if callconv != CanonAbi::GpuKernel || tcx.sess.target.os != Os::AmdHsa {
         return;
     }
 

--- a/compiler/rustc_codegen_ssa/src/base.rs
+++ b/compiler/rustc_codegen_ssa/src/base.rs
@@ -33,7 +33,7 @@ use rustc_session::Session;
 use rustc_session::config::{self, CrateType, EntryFnType};
 use rustc_span::{DUMMY_SP, Symbol, sym};
 use rustc_symbol_mangling::mangle_internal_symbol;
-use rustc_target::spec::Arch;
+use rustc_target::spec::{Arch, Os};
 use rustc_trait_selection::infer::{BoundRegionConversionTime, TyCtxtInferExt};
 use rustc_trait_selection::traits::{ObligationCause, ObligationCtxt};
 use tracing::{debug, info};
@@ -366,7 +366,7 @@ pub(crate) fn build_shift_expr_rhs<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
 // us
 pub fn wants_wasm_eh(sess: &Session) -> bool {
     sess.target.is_like_wasm
-        && (sess.target.os != "emscripten" || sess.opts.unstable_opts.emscripten_wasm_eh)
+        && (sess.target.os != Os::Emscripten || sess.opts.unstable_opts.emscripten_wasm_eh)
 }
 
 /// Returns `true` if this session's target will use SEH-based unwinding.
@@ -500,7 +500,7 @@ pub fn maybe_create_entry_wrapper<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
     ) -> Bx::Function {
         // The entry function is either `int main(void)` or `int main(int argc, char **argv)`, or
         // `usize efi_main(void *handle, void *system_table)` depending on the target.
-        let llfty = if cx.sess().target.os.contains("uefi") {
+        let llfty = if cx.sess().target.os == Os::Uefi {
             cx.type_func(&[cx.type_ptr(), cx.type_ptr()], cx.type_isize())
         } else if cx.sess().target.main_needs_argc_argv {
             cx.type_func(&[cx.type_int(), cx.type_ptr()], cx.type_int())
@@ -562,7 +562,7 @@ pub fn maybe_create_entry_wrapper<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
         };
 
         let result = bx.call(start_ty, None, None, start_fn, &args, None, instance);
-        if cx.sess().target.os.contains("uefi") {
+        if cx.sess().target.os == Os::Uefi {
             bx.ret(result);
         } else {
             let cast = bx.intcast(result, cx.type_int(), true);
@@ -576,7 +576,7 @@ pub fn maybe_create_entry_wrapper<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
 /// Obtain the `argc` and `argv` values to pass to the rust start function
 /// (i.e., the "start" lang item).
 fn get_argc_argv<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(bx: &mut Bx) -> (Bx::Value, Bx::Value) {
-    if bx.cx().sess().target.os.contains("uefi") {
+    if bx.cx().sess().target.os == Os::Uefi {
         // Params for UEFI
         let param_handle = bx.get_param(0);
         let param_system_table = bx.get_param(1);

--- a/compiler/rustc_codegen_ssa/src/codegen_attrs.rs
+++ b/compiler/rustc_codegen_ssa/src/codegen_attrs.rs
@@ -16,6 +16,7 @@ use rustc_middle::ty::{self as ty, TyCtxt};
 use rustc_session::lint;
 use rustc_session::parse::feature_err;
 use rustc_span::{Ident, Span, sym};
+use rustc_target::spec::Os;
 
 use crate::errors;
 use crate::target_features::{
@@ -258,7 +259,7 @@ fn process_builtin_attrs(
                     UsedBy::Compiler => codegen_fn_attrs.flags |= CodegenFnAttrFlags::USED_COMPILER,
                     UsedBy::Linker => codegen_fn_attrs.flags |= CodegenFnAttrFlags::USED_LINKER,
                     UsedBy::Default => {
-                        let used_form = if tcx.sess.target.os == "illumos" {
+                        let used_form = if tcx.sess.target.os == Os::Illumos {
                             // illumos' `ld` doesn't support a section header that would represent
                             // `#[used(linker)]`, see
                             // https://github.com/rust-lang/rust/issues/146169. For that target,

--- a/compiler/rustc_codegen_ssa/src/common.rs
+++ b/compiler/rustc_codegen_ssa/src/common.rs
@@ -7,7 +7,7 @@ use rustc_middle::ty::{self, Instance, TyCtxt};
 use rustc_middle::{bug, mir, span_bug};
 use rustc_session::cstore::{DllCallingConvention, DllImport};
 use rustc_span::Span;
-use rustc_target::spec::Target;
+use rustc_target::spec::{Abi, Target};
 
 use crate::traits::*;
 
@@ -171,7 +171,7 @@ pub fn asm_const_to_str<'tcx>(
 }
 
 pub fn is_mingw_gnu_toolchain(target: &Target) -> bool {
-    target.os == "windows" && target.env == "gnu" && target.abi.is_empty()
+    target.os == "windows" && target.env == "gnu" && target.abi == Abi::Unspecified
 }
 
 pub fn i686_decorated_name(

--- a/compiler/rustc_codegen_ssa/src/common.rs
+++ b/compiler/rustc_codegen_ssa/src/common.rs
@@ -7,7 +7,7 @@ use rustc_middle::ty::{self, Instance, TyCtxt};
 use rustc_middle::{bug, mir, span_bug};
 use rustc_session::cstore::{DllCallingConvention, DllImport};
 use rustc_span::Span;
-use rustc_target::spec::{Abi, Env, Target};
+use rustc_target::spec::{Abi, Env, Os, Target};
 
 use crate::traits::*;
 
@@ -171,7 +171,7 @@ pub fn asm_const_to_str<'tcx>(
 }
 
 pub fn is_mingw_gnu_toolchain(target: &Target) -> bool {
-    target.os == "windows" && target.env == Env::Gnu && target.abi == Abi::Unspecified
+    target.os == Os::Windows && target.env == Env::Gnu && target.abi == Abi::Unspecified
 }
 
 pub fn i686_decorated_name(

--- a/compiler/rustc_codegen_ssa/src/common.rs
+++ b/compiler/rustc_codegen_ssa/src/common.rs
@@ -7,7 +7,7 @@ use rustc_middle::ty::{self, Instance, TyCtxt};
 use rustc_middle::{bug, mir, span_bug};
 use rustc_session::cstore::{DllCallingConvention, DllImport};
 use rustc_span::Span;
-use rustc_target::spec::{Abi, Target};
+use rustc_target::spec::{Abi, Env, Target};
 
 use crate::traits::*;
 
@@ -171,7 +171,7 @@ pub fn asm_const_to_str<'tcx>(
 }
 
 pub fn is_mingw_gnu_toolchain(target: &Target) -> bool {
-    target.os == "windows" && target.env == "gnu" && target.abi == Abi::Unspecified
+    target.os == "windows" && target.env == Env::Gnu && target.abi == Abi::Unspecified
 }
 
 pub fn i686_decorated_name(

--- a/compiler/rustc_lint/src/types/improper_ctypes.rs
+++ b/compiler/rustc_lint/src/types/improper_ctypes.rs
@@ -16,6 +16,7 @@ use rustc_middle::ty::{
 use rustc_session::{declare_lint, declare_lint_pass};
 use rustc_span::def_id::LocalDefId;
 use rustc_span::{Span, sym};
+use rustc_target::spec::Os;
 use tracing::debug;
 
 use super::repr_nullable_ptr;
@@ -177,7 +178,7 @@ fn variant_has_complex_ctor(variant: &ty::VariantDef) -> bool {
 /// the Power alignment Rule (see the `check_struct_for_power_alignment` function).
 fn check_arg_for_power_alignment<'tcx>(cx: &LateContext<'tcx>, ty: Ty<'tcx>) -> bool {
     let tcx = cx.tcx;
-    assert!(tcx.sess.target.os == "aix");
+    assert!(tcx.sess.target.os == Os::Aix);
     // Structs (under repr(C)) follow the power alignment rule if:
     //   - the first field of the struct is a floating-point type that
     //     is greater than 4-bytes, or
@@ -222,7 +223,7 @@ fn check_struct_for_power_alignment<'tcx>(
     let tcx = cx.tcx;
 
     // Only consider structs (not enums or unions) on AIX.
-    if tcx.sess.target.os != "aix" || !adt_def.is_struct() {
+    if tcx.sess.target.os != Os::Aix || !adt_def.is_struct() {
         return;
     }
 

--- a/compiler/rustc_metadata/src/native_libs.rs
+++ b/compiler/rustc_metadata/src/native_libs.rs
@@ -15,7 +15,7 @@ use rustc_session::cstore::{DllCallingConvention, DllImport, ForeignModule, Nati
 use rustc_session::search_paths::PathKind;
 use rustc_span::Symbol;
 use rustc_span::def_id::{DefId, LOCAL_CRATE};
-use rustc_target::spec::{Abi, Arch, BinaryFormat, LinkSelfContainedComponents};
+use rustc_target::spec::{Abi, Arch, BinaryFormat, Env, LinkSelfContainedComponents};
 
 use crate::errors;
 
@@ -79,7 +79,7 @@ pub fn walk_native_lib_search_dirs<R>(
     // Mac Catalyst uses the macOS SDK, but to link to iOS-specific frameworks
     // we must have the support library stubs in the library search path (#121430).
     if let Some(sdk_root) = apple_sdk_root
-        && sess.target.env == "macabi"
+        && sess.target.env == Env::MacAbi
     {
         f(&sdk_root.join("System/iOSSupport/usr/lib"), false)?;
         f(&sdk_root.join("System/iOSSupport/System/Library/Frameworks"), true)?;

--- a/compiler/rustc_metadata/src/native_libs.rs
+++ b/compiler/rustc_metadata/src/native_libs.rs
@@ -15,7 +15,7 @@ use rustc_session::cstore::{DllCallingConvention, DllImport, ForeignModule, Nati
 use rustc_session::search_paths::PathKind;
 use rustc_span::Symbol;
 use rustc_span::def_id::{DefId, LOCAL_CRATE};
-use rustc_target::spec::{Abi, Arch, BinaryFormat, Env, LinkSelfContainedComponents};
+use rustc_target::spec::{Abi, Arch, BinaryFormat, Env, LinkSelfContainedComponents, Os};
 
 use crate::errors;
 
@@ -68,8 +68,8 @@ pub fn walk_native_lib_search_dirs<R>(
     // non-empty, which is needed or the linker may decide to record the LIBPATH env, if
     // defined, as the search path instead of appending the default search paths.
     if sess.target.abi == Abi::Fortanix
-        || sess.target.os == "linux"
-        || sess.target.os == "fuchsia"
+        || sess.target.os == Os::Linux
+        || sess.target.os == Os::Fuchsia
         || sess.target.is_like_aix
         || sess.target.is_like_darwin && !sess.sanitizers().is_empty()
     {

--- a/compiler/rustc_metadata/src/native_libs.rs
+++ b/compiler/rustc_metadata/src/native_libs.rs
@@ -15,7 +15,7 @@ use rustc_session::cstore::{DllCallingConvention, DllImport, ForeignModule, Nati
 use rustc_session::search_paths::PathKind;
 use rustc_span::Symbol;
 use rustc_span::def_id::{DefId, LOCAL_CRATE};
-use rustc_target::spec::{Arch, BinaryFormat, LinkSelfContainedComponents};
+use rustc_target::spec::{Abi, Arch, BinaryFormat, LinkSelfContainedComponents};
 
 use crate::errors;
 
@@ -67,7 +67,7 @@ pub fn walk_native_lib_search_dirs<R>(
     // FIXME: On AIX this also has the side-effect of making the list of library search paths
     // non-empty, which is needed or the linker may decide to record the LIBPATH env, if
     // defined, as the search path instead of appending the default search paths.
-    if sess.target.abi == "fortanix"
+    if sess.target.abi == Abi::Fortanix
         || sess.target.os == "linux"
         || sess.target.os == "fuchsia"
         || sess.target.is_like_aix

--- a/compiler/rustc_passes/src/weak_lang_items.rs
+++ b/compiler/rustc_passes/src/weak_lang_items.rs
@@ -8,6 +8,7 @@ use rustc_hir::weak_lang_items::WEAK_LANG_ITEMS;
 use rustc_middle::middle::lang_items::required;
 use rustc_middle::ty::TyCtxt;
 use rustc_session::config::CrateType;
+use rustc_target::spec::Os;
 
 use crate::errors::{
     MissingLangItem, MissingPanicHandler, PanicUnwindWithoutStd, UnknownExternLangItem,
@@ -26,7 +27,7 @@ pub(crate) fn check_crate(
     if items.eh_personality().is_none() {
         items.missing.push(LangItem::EhPersonality);
     }
-    if tcx.sess.target.os == "emscripten"
+    if tcx.sess.target.os == Os::Emscripten
         && items.eh_catch_typeinfo().is_none()
         && !tcx.sess.opts.unstable_opts.emscripten_wasm_eh
     {

--- a/compiler/rustc_session/src/config/cfg.rs
+++ b/compiler/rustc_session/src/config/cfg.rs
@@ -242,7 +242,7 @@ pub(crate) fn default_configuration(sess: &Session) -> Cfg {
     ins_sym!(sym::target_abi, sess.target.abi.desc_symbol());
     ins_sym!(sym::target_arch, sess.target.arch.desc_symbol());
     ins_str!(sym::target_endian, sess.target.endian.as_str());
-    ins_str!(sym::target_env, &sess.target.env);
+    ins_sym!(sym::target_env, sess.target.env.desc_symbol());
 
     for family in sess.target.families.as_ref() {
         ins_str!(sym::target_family, family);
@@ -450,7 +450,7 @@ impl CheckCfg {
                     values_target_abi.insert(target.options.abi.desc_symbol());
                     values_target_arch.insert(target.arch.desc_symbol());
                     values_target_endian.insert(Symbol::intern(target.options.endian.as_str()));
-                    values_target_env.insert(Symbol::intern(&target.options.env));
+                    values_target_env.insert(target.options.env.desc_symbol());
                     values_target_family.extend(
                         target.options.families.iter().map(|family| Symbol::intern(family)),
                     );

--- a/compiler/rustc_session/src/config/cfg.rs
+++ b/compiler/rustc_session/src/config/cfg.rs
@@ -239,7 +239,7 @@ pub(crate) fn default_configuration(sess: &Session) -> Cfg {
         ins_none!(sym::sanitizer_cfi_normalize_integers);
     }
 
-    ins_str!(sym::target_abi, &sess.target.abi);
+    ins_sym!(sym::target_abi, sess.target.abi.desc_symbol());
     ins_sym!(sym::target_arch, sess.target.arch.desc_symbol());
     ins_str!(sym::target_endian, sess.target.endian.as_str());
     ins_str!(sym::target_env, &sess.target.env);
@@ -447,7 +447,7 @@ impl CheckCfg {
                 };
 
                 for target in Target::builtins().chain(iter::once(current_target.clone())) {
-                    values_target_abi.insert(Symbol::intern(&target.options.abi));
+                    values_target_abi.insert(target.options.abi.desc_symbol());
                     values_target_arch.insert(target.arch.desc_symbol());
                     values_target_endian.insert(Symbol::intern(target.options.endian.as_str()));
                     values_target_env.insert(Symbol::intern(&target.options.env));

--- a/compiler/rustc_session/src/config/cfg.rs
+++ b/compiler/rustc_session/src/config/cfg.rs
@@ -291,7 +291,7 @@ pub(crate) fn default_configuration(sess: &Session) -> Cfg {
         }
     }
 
-    ins_str!(sym::target_os, &sess.target.os);
+    ins_sym!(sym::target_os, sess.target.os.desc_symbol());
     ins_sym!(sym::target_pointer_width, sym::integer(sess.target.pointer_width));
 
     if sess.opts.unstable_opts.has_thread_local.unwrap_or(sess.target.has_thread_local) {
@@ -454,7 +454,7 @@ impl CheckCfg {
                     values_target_family.extend(
                         target.options.families.iter().map(|family| Symbol::intern(family)),
                     );
-                    values_target_os.insert(Symbol::intern(&target.options.os));
+                    values_target_os.insert(target.options.os.desc_symbol());
                     values_target_pointer_width.insert(sym::integer(target.pointer_width));
                     values_target_vendor.insert(target.vendor_symbol());
                 }

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -32,7 +32,7 @@ use rustc_span::source_map::{FilePathMapping, SourceMap};
 use rustc_span::{FileNameDisplayPreference, RealFileName, Span, Symbol};
 use rustc_target::asm::InlineAsmArch;
 use rustc_target::spec::{
-    Arch, CodeModel, DebuginfoKind, PanicStrategy, RelocModel, RelroLevel, SanitizerSet,
+    Arch, CodeModel, DebuginfoKind, Os, PanicStrategy, RelocModel, RelroLevel, SanitizerSet,
     SmallDataThresholdSupport, SplitDebuginfo, StackProtector, SymbolVisibility, Target,
     TargetTuple, TlsModel, apple,
 };
@@ -382,7 +382,7 @@ impl Session {
     }
 
     pub fn is_wasi_reactor(&self) -> bool {
-        self.target.options.os == "wasi"
+        self.target.options.os == Os::Wasi
             && matches!(
                 self.opts.unstable_opts.wasi_exec_model,
                 Some(config::WasiExecModel::Reactor)

--- a/compiler/rustc_target/src/asm/aarch64.rs
+++ b/compiler/rustc_target/src/asm/aarch64.rs
@@ -4,7 +4,7 @@ use rustc_data_structures::fx::FxIndexSet;
 use rustc_span::{Symbol, sym};
 
 use super::{InlineAsmArch, InlineAsmType, ModifierInfo};
-use crate::spec::{Env, RelocModel, Target};
+use crate::spec::{Env, Os, RelocModel, Target};
 
 def_reg_class! {
     AArch64 AArch64InlineAsmRegClass {
@@ -75,8 +75,8 @@ pub(crate) fn target_reserves_x18(target: &Target, target_features: &FxIndexSet<
     // See isX18ReservedByDefault in LLVM for targets reserve x18 by default:
     // https://github.com/llvm/llvm-project/blob/llvmorg-19.1.0/llvm/lib/TargetParser/AArch64TargetParser.cpp#L102-L105
     // Note that +reserve-x18 is currently not set for the above targets.
-    target.os == "android"
-        || target.os == "fuchsia"
+    target.os == Os::Android
+        || target.os == Os::Fuchsia
         || target.env == Env::Ohos
         || target.is_like_darwin
         || target.is_like_windows

--- a/compiler/rustc_target/src/asm/aarch64.rs
+++ b/compiler/rustc_target/src/asm/aarch64.rs
@@ -4,7 +4,7 @@ use rustc_data_structures::fx::FxIndexSet;
 use rustc_span::{Symbol, sym};
 
 use super::{InlineAsmArch, InlineAsmType, ModifierInfo};
-use crate::spec::{RelocModel, Target};
+use crate::spec::{Env, RelocModel, Target};
 
 def_reg_class! {
     AArch64 AArch64InlineAsmRegClass {
@@ -77,7 +77,7 @@ pub(crate) fn target_reserves_x18(target: &Target, target_features: &FxIndexSet<
     // Note that +reserve-x18 is currently not set for the above targets.
     target.os == "android"
         || target.os == "fuchsia"
-        || target.env == "ohos"
+        || target.env == Env::Ohos
         || target.is_like_darwin
         || target.is_like_windows
         || target_features.contains(&sym::reserve_x18)

--- a/compiler/rustc_target/src/asm/mod.rs
+++ b/compiler/rustc_target/src/asm/mod.rs
@@ -273,7 +273,7 @@ impl InlineAsmArch {
             Arch::Msp430 => Some(Self::Msp430),
             Arch::M68k => Some(Self::M68k),
             Arch::CSky => Some(Self::CSKY),
-            Arch::AmdGpu | Arch::Xtensa | Arch::Unknown(_) => None,
+            Arch::AmdGpu | Arch::Xtensa | Arch::Other(_) => None,
         }
     }
 }

--- a/compiler/rustc_target/src/asm/powerpc.rs
+++ b/compiler/rustc_target/src/asm/powerpc.rs
@@ -4,7 +4,7 @@ use rustc_data_structures::fx::FxIndexSet;
 use rustc_span::Symbol;
 
 use super::{InlineAsmArch, InlineAsmType, ModifierInfo};
-use crate::spec::{RelocModel, Target};
+use crate::spec::{Abi, RelocModel, Target};
 
 def_reg_class! {
     PowerPC PowerPCInlineAsmRegClass {
@@ -104,10 +104,10 @@ fn reserved_v20to31(
     _is_clobber: bool,
 ) -> Result<(), &'static str> {
     if target.is_like_aix {
-        match &*target.options.abi {
-            "vec-default" => Err("v20-v31 (vs52-vs63) are reserved on vec-default ABI"),
-            "vec-extabi" => Ok(()),
-            _ => unreachable!("unrecognized AIX ABI"),
+        match &target.options.abi {
+            Abi::VecDefault => Err("v20-v31 (vs52-vs63) are reserved on vec-default ABI"),
+            Abi::VecExtAbi => Ok(()),
+            abi => unreachable!("unrecognized AIX ABI: {abi}"),
         }
     } else {
         Ok(())

--- a/compiler/rustc_target/src/callconv/aarch64.rs
+++ b/compiler/rustc_target/src/callconv/aarch64.rs
@@ -3,7 +3,7 @@ use std::iter;
 use rustc_abi::{BackendRepr, HasDataLayout, Primitive, TyAbiInterface};
 
 use crate::callconv::{ArgAbi, FnAbi, Reg, RegKind, Uniform};
-use crate::spec::{HasTargetSpec, Target};
+use crate::spec::{Abi, HasTargetSpec, Target};
 
 /// Indicates the variant of the AArch64 ABI we are compiling for.
 /// Used to accommodate Apple and Microsoft's deviations from the usual AAPCS ABI.
@@ -33,7 +33,7 @@ where
             RegKind::Integer => false,
             // The softfloat ABI treats floats like integers, so they
             // do not get homogeneous aggregate treatment.
-            RegKind::Float => cx.target_spec().abi != "softfloat",
+            RegKind::Float => cx.target_spec().abi != Abi::SoftFloat,
             RegKind::Vector => size.bits() == 64 || size.bits() == 128,
         };
 
@@ -42,7 +42,7 @@ where
 }
 
 fn softfloat_float_abi<Ty>(target: &Target, arg: &mut ArgAbi<'_, Ty>) {
-    if target.abi != "softfloat" {
+    if target.abi != Abi::SoftFloat {
         return;
     }
     // Do *not* use the float registers for passing arguments, as that would make LLVM pick the ABI

--- a/compiler/rustc_target/src/callconv/mod.rs
+++ b/compiler/rustc_target/src/callconv/mod.rs
@@ -702,7 +702,7 @@ impl<'a, Ty> FnAbi<'a, Ty> {
             Arch::RiscV32 | Arch::RiscV64 => riscv::compute_abi_info(cx, self),
             Arch::Wasm32 | Arch::Wasm64 => wasm::compute_abi_info(cx, self),
             Arch::Bpf => bpf::compute_abi_info(cx, self),
-            arch @ (Arch::PowerPC64LE | Arch::SpirV | Arch::Unknown(_)) => {
+            arch @ (Arch::PowerPC64LE | Arch::SpirV | Arch::Other(_)) => {
                 panic!("no lowering implemented for {arch}")
             }
         }

--- a/compiler/rustc_target/src/callconv/powerpc.rs
+++ b/compiler/rustc_target/src/callconv/powerpc.rs
@@ -1,7 +1,7 @@
 use rustc_abi::TyAbiInterface;
 
 use crate::callconv::{ArgAbi, FnAbi};
-use crate::spec::HasTargetSpec;
+use crate::spec::{Env, HasTargetSpec};
 
 fn classify_ret<Ty>(ret: &mut ArgAbi<'_, Ty>) {
     if ret.layout.is_aggregate() {
@@ -18,7 +18,7 @@ where
     if arg.is_ignore() {
         // powerpc-unknown-linux-{gnu,musl,uclibc} doesn't ignore ZSTs.
         if cx.target_spec().os == "linux"
-            && matches!(&*cx.target_spec().env, "gnu" | "musl" | "uclibc")
+            && matches!(cx.target_spec().env, Env::Gnu | Env::Musl | Env::Uclibc)
             && arg.layout.is_zst()
         {
             arg.make_indirect_from_ignore();

--- a/compiler/rustc_target/src/callconv/powerpc.rs
+++ b/compiler/rustc_target/src/callconv/powerpc.rs
@@ -1,7 +1,7 @@
 use rustc_abi::TyAbiInterface;
 
 use crate::callconv::{ArgAbi, FnAbi};
-use crate::spec::{Env, HasTargetSpec};
+use crate::spec::{Env, HasTargetSpec, Os};
 
 fn classify_ret<Ty>(ret: &mut ArgAbi<'_, Ty>) {
     if ret.layout.is_aggregate() {
@@ -17,7 +17,7 @@ where
 {
     if arg.is_ignore() {
         // powerpc-unknown-linux-{gnu,musl,uclibc} doesn't ignore ZSTs.
-        if cx.target_spec().os == "linux"
+        if cx.target_spec().os == Os::Linux
             && matches!(cx.target_spec().env, Env::Gnu | Env::Musl | Env::Uclibc)
             && arg.layout.is_zst()
         {

--- a/compiler/rustc_target/src/callconv/powerpc64.rs
+++ b/compiler/rustc_target/src/callconv/powerpc64.rs
@@ -5,7 +5,7 @@
 use rustc_abi::{Endian, HasDataLayout, TyAbiInterface};
 
 use crate::callconv::{Align, ArgAbi, FnAbi, Reg, RegKind, Uniform};
-use crate::spec::{Env, HasTargetSpec};
+use crate::spec::{Env, HasTargetSpec, Os};
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 enum ABI {
@@ -106,9 +106,9 @@ where
     Ty: TyAbiInterface<'a, C> + Copy,
     C: HasDataLayout + HasTargetSpec,
 {
-    let abi = if cx.target_spec().env == Env::Musl || cx.target_spec().os == "freebsd" {
+    let abi = if cx.target_spec().env == Env::Musl || cx.target_spec().os == Os::FreeBsd {
         ELFv2
-    } else if cx.target_spec().os == "aix" {
+    } else if cx.target_spec().os == Os::Aix {
         AIX
     } else {
         match cx.data_layout().endian {

--- a/compiler/rustc_target/src/callconv/powerpc64.rs
+++ b/compiler/rustc_target/src/callconv/powerpc64.rs
@@ -5,7 +5,7 @@
 use rustc_abi::{Endian, HasDataLayout, TyAbiInterface};
 
 use crate::callconv::{Align, ArgAbi, FnAbi, Reg, RegKind, Uniform};
-use crate::spec::HasTargetSpec;
+use crate::spec::{Env, HasTargetSpec};
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 enum ABI {
@@ -106,7 +106,7 @@ where
     Ty: TyAbiInterface<'a, C> + Copy,
     C: HasDataLayout + HasTargetSpec,
 {
-    let abi = if cx.target_spec().env == "musl" || cx.target_spec().os == "freebsd" {
+    let abi = if cx.target_spec().env == Env::Musl || cx.target_spec().os == "freebsd" {
         ELFv2
     } else if cx.target_spec().os == "aix" {
         AIX

--- a/compiler/rustc_target/src/callconv/s390x.rs
+++ b/compiler/rustc_target/src/callconv/s390x.rs
@@ -4,7 +4,7 @@
 use rustc_abi::{BackendRepr, HasDataLayout, TyAbiInterface};
 
 use crate::callconv::{ArgAbi, FnAbi, Reg, RegKind};
-use crate::spec::HasTargetSpec;
+use crate::spec::{Env, HasTargetSpec};
 
 fn classify_ret<Ty>(ret: &mut ArgAbi<'_, Ty>) {
     let size = ret.layout.size;
@@ -30,7 +30,7 @@ where
     if arg.is_ignore() {
         // s390x-unknown-linux-{gnu,musl,uclibc} doesn't ignore ZSTs.
         if cx.target_spec().os == "linux"
-            && matches!(&*cx.target_spec().env, "gnu" | "musl" | "uclibc")
+            && matches!(cx.target_spec().env, Env::Gnu | Env::Musl | Env::Uclibc)
             && arg.layout.is_zst()
         {
             arg.make_indirect_from_ignore();

--- a/compiler/rustc_target/src/callconv/s390x.rs
+++ b/compiler/rustc_target/src/callconv/s390x.rs
@@ -4,7 +4,7 @@
 use rustc_abi::{BackendRepr, HasDataLayout, TyAbiInterface};
 
 use crate::callconv::{ArgAbi, FnAbi, Reg, RegKind};
-use crate::spec::{Env, HasTargetSpec};
+use crate::spec::{Env, HasTargetSpec, Os};
 
 fn classify_ret<Ty>(ret: &mut ArgAbi<'_, Ty>) {
     let size = ret.layout.size;
@@ -29,7 +29,7 @@ where
     }
     if arg.is_ignore() {
         // s390x-unknown-linux-{gnu,musl,uclibc} doesn't ignore ZSTs.
-        if cx.target_spec().os == "linux"
+        if cx.target_spec().os == Os::Linux
             && matches!(cx.target_spec().env, Env::Gnu | Env::Musl | Env::Uclibc)
             && arg.layout.is_zst()
         {

--- a/compiler/rustc_target/src/callconv/sparc64.rs
+++ b/compiler/rustc_target/src/callconv/sparc64.rs
@@ -6,7 +6,7 @@ use rustc_abi::{
 };
 
 use crate::callconv::{ArgAbi, ArgAttribute, CastTarget, FnAbi, Uniform};
-use crate::spec::HasTargetSpec;
+use crate::spec::{Env, HasTargetSpec};
 
 #[derive(Clone, Debug)]
 struct Sdata {
@@ -224,7 +224,7 @@ where
         if arg.is_ignore() {
             // sparc64-unknown-linux-{gnu,musl,uclibc} doesn't ignore ZSTs.
             if cx.target_spec().os == "linux"
-                && matches!(&*cx.target_spec().env, "gnu" | "musl" | "uclibc")
+                && matches!(cx.target_spec().env, Env::Gnu | Env::Musl | Env::Uclibc)
                 && arg.layout.is_zst()
             {
                 arg.make_indirect_from_ignore();

--- a/compiler/rustc_target/src/callconv/sparc64.rs
+++ b/compiler/rustc_target/src/callconv/sparc64.rs
@@ -6,7 +6,7 @@ use rustc_abi::{
 };
 
 use crate::callconv::{ArgAbi, ArgAttribute, CastTarget, FnAbi, Uniform};
-use crate::spec::{Env, HasTargetSpec};
+use crate::spec::{Env, HasTargetSpec, Os};
 
 #[derive(Clone, Debug)]
 struct Sdata {
@@ -223,7 +223,7 @@ where
     for arg in fn_abi.args.iter_mut() {
         if arg.is_ignore() {
             // sparc64-unknown-linux-{gnu,musl,uclibc} doesn't ignore ZSTs.
-            if cx.target_spec().os == "linux"
+            if cx.target_spec().os == Os::Linux
                 && matches!(cx.target_spec().env, Env::Gnu | Env::Musl | Env::Uclibc)
                 && arg.layout.is_zst()
             {

--- a/compiler/rustc_target/src/lib.rs
+++ b/compiler/rustc_target/src/lib.rs
@@ -137,6 +137,14 @@ macro_rules! target_spec_enum {
                 $( #[$variant_attr:meta] )*
                 $Variant,
             )*
+            /// The vast majority of the time, the compiler deals with a fixed
+            /// set of values, so it is convenient for them to be represented in
+            /// an enum. However, it is possible to have arbitrary values in a
+            /// target JSON file (which can be parsed when `--target` is
+            /// specified). This might occur, for example, for an out-of-tree
+            /// codegen backend that supports a value (e.g. architecture or OS)
+            /// that rustc currently doesn't know about. This variant exists as
+            /// an escape hatch for such cases.
             $( #[$other_variant_attr] )*
             $OtherVariant(crate::spec::StaticCow<str>),
         }

--- a/compiler/rustc_target/src/spec/base/aix.rs
+++ b/compiler/rustc_target/src/spec/base/aix.rs
@@ -1,7 +1,8 @@
 use rustc_abi::Endian;
 
 use crate::spec::{
-    Abi, BinaryFormat, Cc, CodeModel, LinkOutputKind, LinkerFlavor, TargetOptions, crt_objects, cvs,
+    Abi, BinaryFormat, Cc, CodeModel, LinkOutputKind, LinkerFlavor, Os, TargetOptions, crt_objects,
+    cvs,
 };
 
 pub(crate) fn opts() -> TargetOptions {
@@ -9,7 +10,7 @@ pub(crate) fn opts() -> TargetOptions {
         abi: Abi::VecExtAbi,
         code_model: Some(CodeModel::Large),
         cpu: "pwr7".into(),
-        os: "aix".into(),
+        os: Os::Aix,
         vendor: "ibm".into(),
         dynamic_linking: true,
         endian: Endian::Big,

--- a/compiler/rustc_target/src/spec/base/aix.rs
+++ b/compiler/rustc_target/src/spec/base/aix.rs
@@ -1,12 +1,12 @@
 use rustc_abi::Endian;
 
 use crate::spec::{
-    BinaryFormat, Cc, CodeModel, LinkOutputKind, LinkerFlavor, TargetOptions, crt_objects, cvs,
+    Abi, BinaryFormat, Cc, CodeModel, LinkOutputKind, LinkerFlavor, TargetOptions, crt_objects, cvs,
 };
 
 pub(crate) fn opts() -> TargetOptions {
     TargetOptions {
-        abi: "vec-extabi".into(),
+        abi: Abi::VecExtAbi,
         code_model: Some(CodeModel::Large),
         cpu: "pwr7".into(),
         os: "aix".into(),

--- a/compiler/rustc_target/src/spec/base/android.rs
+++ b/compiler/rustc_target/src/spec/base/android.rs
@@ -1,8 +1,8 @@
-use crate::spec::{SanitizerSet, TargetOptions, TlsModel, base};
+use crate::spec::{Os, SanitizerSet, TargetOptions, TlsModel, base};
 
 pub(crate) fn opts() -> TargetOptions {
     let mut base = base::linux::opts();
-    base.os = "android".into();
+    base.os = Os::Android;
     base.is_like_android = true;
     base.default_dwarf_version = 2;
     base.tls_model = TlsModel::Emulated;

--- a/compiler/rustc_target/src/spec/base/apple/mod.rs
+++ b/compiler/rustc_target/src/spec/base/apple/mod.rs
@@ -4,8 +4,8 @@ use std::num::ParseIntError;
 use std::str::FromStr;
 
 use crate::spec::{
-    Abi, BinaryFormat, Cc, DebuginfoKind, Env, FloatAbi, FramePointer, LinkerFlavor, Lld, RustcAbi,
-    SplitDebuginfo, StackProbeType, StaticCow, Target, TargetOptions, cvs,
+    Abi, BinaryFormat, Cc, DebuginfoKind, Env, FloatAbi, FramePointer, LinkerFlavor, Lld, Os,
+    RustcAbi, SplitDebuginfo, StackProbeType, StaticCow, Target, TargetOptions, cvs,
 };
 
 #[cfg(test)]
@@ -114,13 +114,15 @@ impl TargetEnv {
 /// Get the base target options, unversioned LLVM target and `target_arch` from the three
 /// things that uniquely identify Rust's Apple targets: The OS, the architecture, and the ABI.
 pub(crate) fn base(
-    os: &'static str,
+    os: Os,
     arch: Arch,
     env: TargetEnv,
 ) -> (TargetOptions, StaticCow<str>, crate::spec::Arch) {
+    let link_env_remove = link_env_remove(&os);
+    let unversioned_llvm_target = unversioned_llvm_target(&os, arch, env);
     let mut opts = TargetOptions {
         llvm_floatabi: Some(FloatAbi::Hard),
-        os: os.into(),
+        os,
         env: env.target_env(),
         // NOTE: We originally set `cfg(target_abi = "macabi")` / `cfg(target_abi = "sim")`,
         // before it was discovered that those are actually environments:
@@ -130,7 +132,7 @@ pub(crate) fn base(
         // FIXME(madsmtm): Warn about using these in the future.
         abi: env.target_abi(),
         cpu: arch.target_cpu(env).into(),
-        link_env_remove: link_env_remove(os),
+        link_env_remove,
         vendor: "apple".into(),
         linker_flavor: LinkerFlavor::Darwin(Cc::Yes, Lld::No),
         // macOS has -dead_strip, which doesn't rely on function_sections
@@ -197,23 +199,23 @@ pub(crate) fn base(
         // All Apple x86-32 targets have SSE2.
         opts.rustc_abi = Some(RustcAbi::X86Sse2);
     }
-    (opts, unversioned_llvm_target(os, arch, env), arch.target_arch())
+    (opts, unversioned_llvm_target, arch.target_arch())
 }
 
 /// Generate part of the LLVM target triple.
 ///
 /// See `rustc_codegen_ssa::back::versioned_llvm_target` for the full triple passed to LLVM and
 /// Clang.
-fn unversioned_llvm_target(os: &str, arch: Arch, env: TargetEnv) -> StaticCow<str> {
+fn unversioned_llvm_target(os: &Os, arch: Arch, env: TargetEnv) -> StaticCow<str> {
     let arch = arch.target_name();
     // Convert to the "canonical" OS name used by LLVM:
     // https://github.com/llvm/llvm-project/blob/llvmorg-18.1.8/llvm/lib/TargetParser/Triple.cpp#L236-L282
     let os = match os {
-        "macos" => "macosx",
-        "ios" => "ios",
-        "watchos" => "watchos",
-        "tvos" => "tvos",
-        "visionos" => "xros",
+        Os::MacOs => "macosx",
+        Os::IOs => "ios",
+        Os::WatchOs => "watchos",
+        Os::TvOs => "tvos",
+        Os::VisionOs => "xros",
         _ => unreachable!("tried to get LLVM target OS for non-Apple platform"),
     };
     let environment = match env {
@@ -224,13 +226,13 @@ fn unversioned_llvm_target(os: &str, arch: Arch, env: TargetEnv) -> StaticCow<st
     format!("{arch}-apple-{os}{environment}").into()
 }
 
-fn link_env_remove(os: &'static str) -> StaticCow<[StaticCow<str>]> {
+fn link_env_remove(os: &Os) -> StaticCow<[StaticCow<str>]> {
     // Apple platforms only officially support macOS as a host for any compilation.
     //
     // If building for macOS, we go ahead and remove any erroneous environment state
     // that's only applicable to cross-OS compilation. Always leave anything for the
     // host OS alone though.
-    if os == "macos" {
+    if *os == Os::MacOs {
         // `IPHONEOS_DEPLOYMENT_TARGET` must not be set when using the Xcode linker at
         // "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ld",
         // although this is apparently ignored when using the linker at "/usr/bin/ld".
@@ -292,7 +294,7 @@ impl OSVersion {
     }
 
     /// Minimum operating system versions currently supported by `rustc`.
-    pub fn os_minimum_deployment_target(os: &str) -> Self {
+    pub fn os_minimum_deployment_target(os: &Os) -> Self {
         // When bumping a version in here, remember to update the platform-support docs too.
         //
         // NOTE: The defaults may change in future `rustc` versions, so if you are looking for the
@@ -301,12 +303,14 @@ impl OSVersion {
         // $ rustc --print deployment-target
         // ```
         let (major, minor, patch) = match os {
-            "macos" => (10, 12, 0),
-            "ios" => (10, 0, 0),
-            "tvos" => (10, 0, 0),
-            "watchos" => (5, 0, 0),
-            "visionos" => (1, 0, 0),
-            _ => unreachable!("tried to get deployment target for non-Apple platform"),
+            Os::MacOs => (10, 12, 0),
+            Os::IOs => (10, 0, 0),
+            Os::TvOs => (10, 0, 0),
+            Os::WatchOs => (5, 0, 0),
+            Os::VisionOs => (1, 0, 0),
+            other => {
+                unreachable!("tried to get deployment target for non-Apple platform: {:?}", other)
+            }
         };
         Self { major, minor, patch }
     }
@@ -319,36 +323,36 @@ impl OSVersion {
     /// This matches what LLVM does, see in part:
     /// <https://github.com/llvm/llvm-project/blob/llvmorg-21.1.3/llvm/lib/TargetParser/Triple.cpp#L2140-L2175>
     pub fn minimum_deployment_target(target: &Target) -> Self {
-        let (major, minor, patch) = match (&*target.os, &target.arch, &target.env) {
-            ("macos", crate::spec::Arch::AArch64, _) => (11, 0, 0),
-            ("ios", crate::spec::Arch::AArch64, Env::MacAbi) => (14, 0, 0),
-            ("ios", crate::spec::Arch::AArch64, Env::Sim) => (14, 0, 0),
-            ("ios", _, _) if target.llvm_target.starts_with("arm64e") => (14, 0, 0),
+        let (major, minor, patch) = match (&target.os, &target.arch, &target.env) {
+            (Os::MacOs, crate::spec::Arch::AArch64, _) => (11, 0, 0),
+            (Os::IOs, crate::spec::Arch::AArch64, Env::MacAbi) => (14, 0, 0),
+            (Os::IOs, crate::spec::Arch::AArch64, Env::Sim) => (14, 0, 0),
+            (Os::IOs, _, _) if target.llvm_target.starts_with("arm64e") => (14, 0, 0),
             // Mac Catalyst defaults to 13.1 in Clang.
-            ("ios", _, Env::MacAbi) => (13, 1, 0),
-            ("tvos", crate::spec::Arch::AArch64, Env::Sim) => (14, 0, 0),
-            ("watchos", crate::spec::Arch::AArch64, Env::Sim) => (7, 0, 0),
+            (Os::IOs, _, Env::MacAbi) => (13, 1, 0),
+            (Os::TvOs, crate::spec::Arch::AArch64, Env::Sim) => (14, 0, 0),
+            (Os::WatchOs, crate::spec::Arch::AArch64, Env::Sim) => (7, 0, 0),
             // True Aarch64 on watchOS (instead of their Aarch64 Ilp32 called `arm64_32`) has been
             // available since Xcode 14, but it's only actually used more recently in watchOS 26.
-            ("watchos", crate::spec::Arch::AArch64, Env::Unspecified)
+            (Os::WatchOs, crate::spec::Arch::AArch64, Env::Unspecified)
                 if !target.llvm_target.starts_with("arm64_32") =>
             {
                 (26, 0, 0)
             }
-            (os, _, _) => return Self::os_minimum_deployment_target(os),
+            _ => return Self::os_minimum_deployment_target(&target.os),
         };
         Self { major, minor, patch }
     }
 }
 
 /// Name of the environment variable used to fetch the deployment target on the given OS.
-pub fn deployment_target_env_var(os: &str) -> &'static str {
+pub fn deployment_target_env_var(os: &Os) -> &'static str {
     match os {
-        "macos" => "MACOSX_DEPLOYMENT_TARGET",
-        "ios" => "IPHONEOS_DEPLOYMENT_TARGET",
-        "watchos" => "WATCHOS_DEPLOYMENT_TARGET",
-        "tvos" => "TVOS_DEPLOYMENT_TARGET",
-        "visionos" => "XROS_DEPLOYMENT_TARGET",
+        Os::MacOs => "MACOSX_DEPLOYMENT_TARGET",
+        Os::IOs => "IPHONEOS_DEPLOYMENT_TARGET",
+        Os::WatchOs => "WATCHOS_DEPLOYMENT_TARGET",
+        Os::TvOs => "TVOS_DEPLOYMENT_TARGET",
+        Os::VisionOs => "XROS_DEPLOYMENT_TARGET",
         _ => unreachable!("tried to get deployment target env var for non-Apple platform"),
     }
 }

--- a/compiler/rustc_target/src/spec/base/apple/mod.rs
+++ b/compiler/rustc_target/src/spec/base/apple/mod.rs
@@ -102,6 +102,12 @@ impl TargetEnv {
         }
     }
 
+    // NOTE: We originally set `cfg(target_abi = "macabi")` / `cfg(target_abi = "sim")`,
+    // before it was discovered that those are actually environments:
+    // https://github.com/rust-lang/rust/issues/133331
+    //
+    // But let's continue setting them for backwards compatibility.
+    // FIXME(madsmtm): Warn about using these in the future.
     fn target_abi(self) -> Abi {
         match self {
             Self::Normal => Abi::Unspecified,
@@ -124,12 +130,6 @@ pub(crate) fn base(
         llvm_floatabi: Some(FloatAbi::Hard),
         os,
         env: env.target_env(),
-        // NOTE: We originally set `cfg(target_abi = "macabi")` / `cfg(target_abi = "sim")`,
-        // before it was discovered that those are actually environments:
-        // https://github.com/rust-lang/rust/issues/133331
-        //
-        // But let's continue setting them for backwards compatibility.
-        // FIXME(madsmtm): Warn about using these in the future.
         abi: env.target_abi(),
         cpu: arch.target_cpu(env).into(),
         link_env_remove,

--- a/compiler/rustc_target/src/spec/base/apple/mod.rs
+++ b/compiler/rustc_target/src/spec/base/apple/mod.rs
@@ -4,7 +4,7 @@ use std::num::ParseIntError;
 use std::str::FromStr;
 
 use crate::spec::{
-    Abi, BinaryFormat, Cc, DebuginfoKind, FloatAbi, FramePointer, LinkerFlavor, Lld, RustcAbi,
+    Abi, BinaryFormat, Cc, DebuginfoKind, Env, FloatAbi, FramePointer, LinkerFlavor, Lld, RustcAbi,
     SplitDebuginfo, StackProbeType, StaticCow, Target, TargetOptions, cvs,
 };
 
@@ -94,11 +94,11 @@ pub(crate) enum TargetEnv {
 }
 
 impl TargetEnv {
-    fn target_env(self) -> &'static str {
+    fn target_env(self) -> Env {
         match self {
-            Self::Normal => "",
-            Self::MacCatalyst => "macabi",
-            Self::Simulator => "sim",
+            Self::Normal => Env::Unspecified,
+            Self::MacCatalyst => Env::MacAbi,
+            Self::Simulator => Env::Sim,
         }
     }
 
@@ -121,7 +121,7 @@ pub(crate) fn base(
     let mut opts = TargetOptions {
         llvm_floatabi: Some(FloatAbi::Hard),
         os: os.into(),
-        env: env.target_env().into(),
+        env: env.target_env(),
         // NOTE: We originally set `cfg(target_abi = "macabi")` / `cfg(target_abi = "sim")`,
         // before it was discovered that those are actually environments:
         // https://github.com/rust-lang/rust/issues/133331
@@ -319,18 +319,18 @@ impl OSVersion {
     /// This matches what LLVM does, see in part:
     /// <https://github.com/llvm/llvm-project/blob/llvmorg-21.1.3/llvm/lib/TargetParser/Triple.cpp#L2140-L2175>
     pub fn minimum_deployment_target(target: &Target) -> Self {
-        let (major, minor, patch) = match (&*target.os, &target.arch, &*target.env) {
+        let (major, minor, patch) = match (&*target.os, &target.arch, &target.env) {
             ("macos", crate::spec::Arch::AArch64, _) => (11, 0, 0),
-            ("ios", crate::spec::Arch::AArch64, "macabi") => (14, 0, 0),
-            ("ios", crate::spec::Arch::AArch64, "sim") => (14, 0, 0),
+            ("ios", crate::spec::Arch::AArch64, Env::MacAbi) => (14, 0, 0),
+            ("ios", crate::spec::Arch::AArch64, Env::Sim) => (14, 0, 0),
             ("ios", _, _) if target.llvm_target.starts_with("arm64e") => (14, 0, 0),
             // Mac Catalyst defaults to 13.1 in Clang.
-            ("ios", _, "macabi") => (13, 1, 0),
-            ("tvos", crate::spec::Arch::AArch64, "sim") => (14, 0, 0),
-            ("watchos", crate::spec::Arch::AArch64, "sim") => (7, 0, 0),
+            ("ios", _, Env::MacAbi) => (13, 1, 0),
+            ("tvos", crate::spec::Arch::AArch64, Env::Sim) => (14, 0, 0),
+            ("watchos", crate::spec::Arch::AArch64, Env::Sim) => (7, 0, 0),
             // True Aarch64 on watchOS (instead of their Aarch64 Ilp32 called `arm64_32`) has been
             // available since Xcode 14, but it's only actually used more recently in watchOS 26.
-            ("watchos", crate::spec::Arch::AArch64, "")
+            ("watchos", crate::spec::Arch::AArch64, Env::Unspecified)
                 if !target.llvm_target.starts_with("arm64_32") =>
             {
                 (26, 0, 0)

--- a/compiler/rustc_target/src/spec/base/apple/mod.rs
+++ b/compiler/rustc_target/src/spec/base/apple/mod.rs
@@ -4,7 +4,7 @@ use std::num::ParseIntError;
 use std::str::FromStr;
 
 use crate::spec::{
-    BinaryFormat, Cc, DebuginfoKind, FloatAbi, FramePointer, LinkerFlavor, Lld, RustcAbi,
+    Abi, BinaryFormat, Cc, DebuginfoKind, FloatAbi, FramePointer, LinkerFlavor, Lld, RustcAbi,
     SplitDebuginfo, StackProbeType, StaticCow, Target, TargetOptions, cvs,
 };
 
@@ -101,6 +101,14 @@ impl TargetEnv {
             Self::Simulator => "sim",
         }
     }
+
+    fn target_abi(self) -> Abi {
+        match self {
+            Self::Normal => Abi::Unspecified,
+            Self::MacCatalyst => Abi::MacAbi,
+            Self::Simulator => Abi::Sim,
+        }
+    }
 }
 
 /// Get the base target options, unversioned LLVM target and `target_arch` from the three
@@ -120,7 +128,7 @@ pub(crate) fn base(
         //
         // But let's continue setting them for backwards compatibility.
         // FIXME(madsmtm): Warn about using these in the future.
-        abi: env.target_env().into(),
+        abi: env.target_abi(),
         cpu: arch.target_cpu(env).into(),
         link_env_remove: link_env_remove(os),
         vendor: "apple".into(),

--- a/compiler/rustc_target/src/spec/base/apple/tests.rs
+++ b/compiler/rustc_target/src/spec/base/apple/tests.rs
@@ -1,10 +1,10 @@
 use super::OSVersion;
-use crate::spec::Abi;
 use crate::spec::targets::{
     aarch64_apple_darwin, aarch64_apple_ios_sim, aarch64_apple_visionos_sim,
     aarch64_apple_watchos_sim, i686_apple_darwin, x86_64_apple_darwin, x86_64_apple_ios,
     x86_64_apple_tvos, x86_64_apple_watchos_sim,
 };
+use crate::spec::{Abi, Env};
 
 #[test]
 fn simulator_targets_set_env() {
@@ -19,7 +19,7 @@ fn simulator_targets_set_env() {
     ];
 
     for target in &all_sim_targets {
-        assert_eq!(target.env, "sim");
+        assert_eq!(target.env, Env::Sim);
         // Ensure backwards compat
         assert_eq!(target.abi, Abi::Sim);
     }

--- a/compiler/rustc_target/src/spec/base/apple/tests.rs
+++ b/compiler/rustc_target/src/spec/base/apple/tests.rs
@@ -1,4 +1,5 @@
 use super::OSVersion;
+use crate::spec::Abi;
 use crate::spec::targets::{
     aarch64_apple_darwin, aarch64_apple_ios_sim, aarch64_apple_visionos_sim,
     aarch64_apple_watchos_sim, i686_apple_darwin, x86_64_apple_darwin, x86_64_apple_ios,
@@ -20,7 +21,7 @@ fn simulator_targets_set_env() {
     for target in &all_sim_targets {
         assert_eq!(target.env, "sim");
         // Ensure backwards compat
-        assert_eq!(target.abi, "sim");
+        assert_eq!(target.abi, Abi::Sim);
     }
 }
 

--- a/compiler/rustc_target/src/spec/base/cygwin.rs
+++ b/compiler/rustc_target/src/spec/base/cygwin.rs
@@ -1,8 +1,8 @@
 use std::borrow::Cow;
 
 use crate::spec::{
-    BinaryFormat, Cc, DebuginfoKind, LinkerFlavor, Lld, SplitDebuginfo, TargetOptions, TlsModel,
-    cvs,
+    BinaryFormat, Cc, DebuginfoKind, LinkerFlavor, Lld, Os, SplitDebuginfo, TargetOptions,
+    TlsModel, cvs,
 };
 
 pub(crate) fn opts() -> TargetOptions {
@@ -24,7 +24,7 @@ pub(crate) fn opts() -> TargetOptions {
         cygwin_libs,
     );
     TargetOptions {
-        os: "cygwin".into(),
+        os: Os::Cygwin,
         vendor: "pc".into(),
         // FIXME(#13846) this should be enabled for cygwin
         function_sections: false,

--- a/compiler/rustc_target/src/spec/base/dragonfly.rs
+++ b/compiler/rustc_target/src/spec/base/dragonfly.rs
@@ -1,8 +1,8 @@
-use crate::spec::{RelroLevel, TargetOptions, cvs};
+use crate::spec::{Os, RelroLevel, TargetOptions, cvs};
 
 pub(crate) fn opts() -> TargetOptions {
     TargetOptions {
-        os: "dragonfly".into(),
+        os: Os::Dragonfly,
         dynamic_linking: true,
         families: cvs!["unix"],
         has_rpath: true,

--- a/compiler/rustc_target/src/spec/base/freebsd.rs
+++ b/compiler/rustc_target/src/spec/base/freebsd.rs
@@ -1,8 +1,8 @@
-use crate::spec::{RelroLevel, TargetOptions, cvs};
+use crate::spec::{Os, RelroLevel, TargetOptions, cvs};
 
 pub(crate) fn opts() -> TargetOptions {
     TargetOptions {
-        os: "freebsd".into(),
+        os: Os::FreeBsd,
         dynamic_linking: true,
         families: cvs!["unix"],
         has_rpath: true,

--- a/compiler/rustc_target/src/spec/base/fuchsia.rs
+++ b/compiler/rustc_target/src/spec/base/fuchsia.rs
@@ -1,5 +1,5 @@
 use crate::spec::{
-    Cc, FramePointer, LinkOutputKind, LinkerFlavor, Lld, TargetOptions, crt_objects, cvs,
+    Cc, FramePointer, LinkOutputKind, LinkerFlavor, Lld, Os, TargetOptions, crt_objects, cvs,
 };
 
 pub(crate) fn opts() -> TargetOptions {
@@ -30,7 +30,7 @@ pub(crate) fn opts() -> TargetOptions {
     );
 
     TargetOptions {
-        os: "fuchsia".into(),
+        os: Os::Fuchsia,
         linker_flavor: LinkerFlavor::Gnu(Cc::No, Lld::Yes),
         linker: Some("rust-lld".into()),
         dynamic_linking: true,

--- a/compiler/rustc_target/src/spec/base/haiku.rs
+++ b/compiler/rustc_target/src/spec/base/haiku.rs
@@ -1,8 +1,8 @@
-use crate::spec::{RelroLevel, TargetOptions, cvs};
+use crate::spec::{Os, RelroLevel, TargetOptions, cvs};
 
 pub(crate) fn opts() -> TargetOptions {
     TargetOptions {
-        os: "haiku".into(),
+        os: Os::Haiku,
         dynamic_linking: true,
         families: cvs!["unix"],
         relro_level: RelroLevel::Full,

--- a/compiler/rustc_target/src/spec/base/helenos.rs
+++ b/compiler/rustc_target/src/spec/base/helenos.rs
@@ -1,8 +1,8 @@
-use crate::spec::{PanicStrategy, RelroLevel, StackProbeType, TargetOptions};
+use crate::spec::{Os, PanicStrategy, RelroLevel, StackProbeType, TargetOptions};
 
 pub(crate) fn opts() -> TargetOptions {
     TargetOptions {
-        os: "helenos".into(),
+        os: Os::HelenOs,
 
         dynamic_linking: true,
         // we need the linker to keep libgcc and friends

--- a/compiler/rustc_target/src/spec/base/hermit.rs
+++ b/compiler/rustc_target/src/spec/base/hermit.rs
@@ -1,8 +1,8 @@
-use crate::spec::{Cc, LinkerFlavor, Lld, PanicStrategy, TargetOptions, TlsModel};
+use crate::spec::{Cc, LinkerFlavor, Lld, Os, PanicStrategy, TargetOptions, TlsModel};
 
 pub(crate) fn opts() -> TargetOptions {
     TargetOptions {
-        os: "hermit".into(),
+        os: Os::Hermit,
         linker: Some("rust-lld".into()),
         linker_flavor: LinkerFlavor::Gnu(Cc::No, Lld::Yes),
         tls_model: TlsModel::InitialExec,

--- a/compiler/rustc_target/src/spec/base/hurd.rs
+++ b/compiler/rustc_target/src/spec/base/hurd.rs
@@ -1,8 +1,8 @@
-use crate::spec::{RelroLevel, TargetOptions, cvs};
+use crate::spec::{Os, RelroLevel, TargetOptions, cvs};
 
 pub(crate) fn opts() -> TargetOptions {
     TargetOptions {
-        os: "hurd".into(),
+        os: Os::Hurd,
         dynamic_linking: true,
         families: cvs!["unix"],
         has_rpath: true,

--- a/compiler/rustc_target/src/spec/base/hurd_gnu.rs
+++ b/compiler/rustc_target/src/spec/base/hurd_gnu.rs
@@ -1,5 +1,5 @@
-use crate::spec::{TargetOptions, base};
+use crate::spec::{Env, TargetOptions, base};
 
 pub(crate) fn opts() -> TargetOptions {
-    TargetOptions { env: "gnu".into(), ..base::hurd::opts() }
+    TargetOptions { env: Env::Gnu, ..base::hurd::opts() }
 }

--- a/compiler/rustc_target/src/spec/base/illumos.rs
+++ b/compiler/rustc_target/src/spec/base/illumos.rs
@@ -1,4 +1,4 @@
-use crate::spec::{Cc, FramePointer, LinkerFlavor, TargetOptions, cvs};
+use crate::spec::{Cc, FramePointer, LinkerFlavor, Os, TargetOptions, cvs};
 
 pub(crate) fn opts() -> TargetOptions {
     let late_link_args = TargetOptions::link_args(
@@ -25,7 +25,7 @@ pub(crate) fn opts() -> TargetOptions {
     );
 
     TargetOptions {
-        os: "illumos".into(),
+        os: Os::Illumos,
         dynamic_linking: true,
         has_rpath: true,
         families: cvs!["unix"],

--- a/compiler/rustc_target/src/spec/base/l4re.rs
+++ b/compiler/rustc_target/src/spec/base/l4re.rs
@@ -1,8 +1,8 @@
-use crate::spec::{Cc, Env, LinkerFlavor, PanicStrategy, RelocModel, TargetOptions, cvs};
+use crate::spec::{Cc, Env, LinkerFlavor, Os, PanicStrategy, RelocModel, TargetOptions, cvs};
 
 pub(crate) fn opts() -> TargetOptions {
     TargetOptions {
-        os: "l4re".into(),
+        os: Os::L4Re,
         env: Env::Uclibc,
         linker_flavor: LinkerFlavor::Unix(Cc::No),
         panic_strategy: PanicStrategy::Abort,

--- a/compiler/rustc_target/src/spec/base/l4re.rs
+++ b/compiler/rustc_target/src/spec/base/l4re.rs
@@ -1,9 +1,9 @@
-use crate::spec::{Cc, LinkerFlavor, PanicStrategy, RelocModel, TargetOptions, cvs};
+use crate::spec::{Cc, Env, LinkerFlavor, PanicStrategy, RelocModel, TargetOptions, cvs};
 
 pub(crate) fn opts() -> TargetOptions {
     TargetOptions {
         os: "l4re".into(),
-        env: "uclibc".into(),
+        env: Env::Uclibc,
         linker_flavor: LinkerFlavor::Unix(Cc::No),
         panic_strategy: PanicStrategy::Abort,
         linker: Some("l4-bender".into()),

--- a/compiler/rustc_target/src/spec/base/linux.rs
+++ b/compiler/rustc_target/src/spec/base/linux.rs
@@ -1,10 +1,10 @@
 use std::borrow::Cow;
 
-use crate::spec::{RelroLevel, SplitDebuginfo, TargetOptions, cvs};
+use crate::spec::{Os, RelroLevel, SplitDebuginfo, TargetOptions, cvs};
 
 pub(crate) fn opts() -> TargetOptions {
     TargetOptions {
-        os: "linux".into(),
+        os: Os::Linux,
         dynamic_linking: true,
         families: cvs!["unix"],
         has_rpath: true,

--- a/compiler/rustc_target/src/spec/base/linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/base/linux_gnu.rs
@@ -1,7 +1,7 @@
-use crate::spec::{Cc, LinkerFlavor, Lld, TargetOptions, base};
+use crate::spec::{Cc, Env, LinkerFlavor, Lld, TargetOptions, base};
 
 pub(crate) fn opts() -> TargetOptions {
-    let mut base = TargetOptions { env: "gnu".into(), ..base::linux::opts() };
+    let mut base = TargetOptions { env: Env::Gnu, ..base::linux::opts() };
 
     // When we're asked to use the `rust-lld` linker by default, set the appropriate lld-using
     // linker flavor, and self-contained linker component.

--- a/compiler/rustc_target/src/spec/base/linux_musl.rs
+++ b/compiler/rustc_target/src/spec/base/linux_musl.rs
@@ -1,8 +1,8 @@
-use crate::spec::{LinkSelfContainedDefault, TargetOptions, base, crt_objects};
+use crate::spec::{Env, LinkSelfContainedDefault, TargetOptions, base, crt_objects};
 
 pub(crate) fn opts() -> TargetOptions {
     TargetOptions {
-        env: "musl".into(),
+        env: Env::Musl,
         pre_link_objects_self_contained: crt_objects::pre_musl_self_contained(),
         post_link_objects_self_contained: crt_objects::post_musl_self_contained(),
         link_self_contained: LinkSelfContainedDefault::InferredForMusl,

--- a/compiler/rustc_target/src/spec/base/linux_ohos.rs
+++ b/compiler/rustc_target/src/spec/base/linux_ohos.rs
@@ -1,8 +1,8 @@
-use crate::spec::{TargetOptions, TlsModel, base};
+use crate::spec::{Env, TargetOptions, TlsModel, base};
 
 pub(crate) fn opts() -> TargetOptions {
     TargetOptions {
-        env: "ohos".into(),
+        env: Env::Ohos,
         crt_static_default: false,
         tls_model: TlsModel::Emulated,
         has_thread_local: false,

--- a/compiler/rustc_target/src/spec/base/linux_uclibc.rs
+++ b/compiler/rustc_target/src/spec/base/linux_uclibc.rs
@@ -1,5 +1,5 @@
-use crate::spec::{TargetOptions, base};
+use crate::spec::{Env, TargetOptions, base};
 
 pub(crate) fn opts() -> TargetOptions {
-    TargetOptions { env: "uclibc".into(), ..base::linux::opts() }
+    TargetOptions { env: Env::Uclibc, ..base::linux::opts() }
 }

--- a/compiler/rustc_target/src/spec/base/linux_wasm.rs
+++ b/compiler/rustc_target/src/spec/base/linux_wasm.rs
@@ -2,7 +2,7 @@
 //! aspects from their respective base targets
 
 use crate::spec::{
-    Cc, Env, LinkSelfContainedDefault, LinkerFlavor, PanicStrategy, RelocModel, TargetOptions,
+    Cc, Env, LinkSelfContainedDefault, LinkerFlavor, Os, PanicStrategy, RelocModel, TargetOptions,
     TlsModel, add_link_args, crt_objects, cvs,
 };
 
@@ -57,7 +57,7 @@ pub(crate) fn opts() -> TargetOptions {
     TargetOptions {
         is_like_wasm: true,
         families: cvs!["wasm", "unix"],
-        os: "linux".into(),
+        os: Os::Linux,
         env: Env::Musl,
 
         // we allow dynamic linking, but only cdylibs. Basically we allow a

--- a/compiler/rustc_target/src/spec/base/linux_wasm.rs
+++ b/compiler/rustc_target/src/spec/base/linux_wasm.rs
@@ -2,8 +2,8 @@
 //! aspects from their respective base targets
 
 use crate::spec::{
-    Cc, LinkSelfContainedDefault, LinkerFlavor, PanicStrategy, RelocModel, TargetOptions, TlsModel,
-    add_link_args, crt_objects, cvs,
+    Cc, Env, LinkSelfContainedDefault, LinkerFlavor, PanicStrategy, RelocModel, TargetOptions,
+    TlsModel, add_link_args, crt_objects, cvs,
 };
 
 pub(crate) fn opts() -> TargetOptions {
@@ -58,7 +58,7 @@ pub(crate) fn opts() -> TargetOptions {
         is_like_wasm: true,
         families: cvs!["wasm", "unix"],
         os: "linux".into(),
-        env: "musl".into(),
+        env: Env::Musl,
 
         // we allow dynamic linking, but only cdylibs. Basically we allow a
         // final library artifact that exports some symbols (a wasm module) but

--- a/compiler/rustc_target/src/spec/base/lynxos178.rs
+++ b/compiler/rustc_target/src/spec/base/lynxos178.rs
@@ -1,12 +1,12 @@
 use std::borrow::Cow;
 
 use crate::spec::{
-    PanicStrategy, RelocModel, RelroLevel, SplitDebuginfo, StackProbeType, TargetOptions, cvs,
+    Os, PanicStrategy, RelocModel, RelroLevel, SplitDebuginfo, StackProbeType, TargetOptions, cvs,
 };
 
 pub(crate) fn opts() -> TargetOptions {
     TargetOptions {
-        os: "lynxos178".into(),
+        os: Os::LynxOs178,
         dynamic_linking: false,
         families: cvs!["unix"],
         position_independent_executables: false,

--- a/compiler/rustc_target/src/spec/base/managarm_mlibc.rs
+++ b/compiler/rustc_target/src/spec/base/managarm_mlibc.rs
@@ -1,8 +1,8 @@
-use crate::spec::{Env, RelroLevel, TargetOptions, cvs};
+use crate::spec::{Env, Os, RelroLevel, TargetOptions, cvs};
 
 pub(crate) fn opts() -> TargetOptions {
     TargetOptions {
-        os: "managarm".into(),
+        os: Os::Managarm,
         env: Env::Mlibc,
         dynamic_linking: true,
         executables: true,

--- a/compiler/rustc_target/src/spec/base/managarm_mlibc.rs
+++ b/compiler/rustc_target/src/spec/base/managarm_mlibc.rs
@@ -1,9 +1,9 @@
-use crate::spec::{RelroLevel, TargetOptions, cvs};
+use crate::spec::{Env, RelroLevel, TargetOptions, cvs};
 
 pub(crate) fn opts() -> TargetOptions {
     TargetOptions {
         os: "managarm".into(),
-        env: "mlibc".into(),
+        env: Env::Mlibc,
         dynamic_linking: true,
         executables: true,
         families: cvs!["unix"],

--- a/compiler/rustc_target/src/spec/base/motor.rs
+++ b/compiler/rustc_target/src/spec/base/motor.rs
@@ -1,5 +1,5 @@
 use crate::spec::{
-    Cc, FramePointer, LinkerFlavor, Lld, PanicStrategy, StackProbeType, TargetOptions,
+    Cc, FramePointer, LinkerFlavor, Lld, Os, PanicStrategy, StackProbeType, TargetOptions,
 };
 
 pub(crate) fn opts() -> TargetOptions {
@@ -16,7 +16,7 @@ pub(crate) fn opts() -> TargetOptions {
         ],
     );
     TargetOptions {
-        os: "motor".into(),
+        os: Os::Motor,
         executables: true,
         // TLS is false below because if true, the compiler assumes
         // we handle TLS at the ELF loading level, which we don't.

--- a/compiler/rustc_target/src/spec/base/netbsd.rs
+++ b/compiler/rustc_target/src/spec/base/netbsd.rs
@@ -1,8 +1,8 @@
-use crate::spec::{RelroLevel, TargetOptions, cvs};
+use crate::spec::{Os, RelroLevel, TargetOptions, cvs};
 
 pub(crate) fn opts() -> TargetOptions {
     TargetOptions {
-        os: "netbsd".into(),
+        os: Os::NetBsd,
         dynamic_linking: true,
         families: cvs!["unix"],
         no_default_libraries: false,

--- a/compiler/rustc_target/src/spec/base/nto_qnx.rs
+++ b/compiler/rustc_target/src/spec/base/nto_qnx.rs
@@ -1,5 +1,5 @@
 use crate::spec::{
-    Cc, LinkArgs, LinkerFlavor, Lld, RelroLevel, Target, TargetMetadata, TargetOptions, cvs,
+    Cc, LinkArgs, LinkerFlavor, Lld, Os, RelroLevel, Target, TargetMetadata, TargetOptions, cvs,
 };
 
 pub(crate) fn opts() -> TargetOptions {
@@ -11,7 +11,7 @@ pub(crate) fn opts() -> TargetOptions {
         has_rpath: true,
         has_thread_local: false,
         linker: Some("qcc".into()),
-        os: "nto".into(),
+        os: Os::Nto,
         // We want backtraces to work by default and they rely on unwind tables
         // (regardless of `-C panic` strategy).
         default_uwtable: true,

--- a/compiler/rustc_target/src/spec/base/openbsd.rs
+++ b/compiler/rustc_target/src/spec/base/openbsd.rs
@@ -1,8 +1,8 @@
-use crate::spec::{FramePointer, RelroLevel, TargetOptions, TlsModel, cvs};
+use crate::spec::{FramePointer, Os, RelroLevel, TargetOptions, TlsModel, cvs};
 
 pub(crate) fn opts() -> TargetOptions {
     TargetOptions {
-        os: "openbsd".into(),
+        os: Os::OpenBsd,
         dynamic_linking: true,
         families: cvs!["unix"],
         has_rpath: true,

--- a/compiler/rustc_target/src/spec/base/redox.rs
+++ b/compiler/rustc_target/src/spec/base/redox.rs
@@ -1,8 +1,8 @@
-use crate::spec::{Cc, Env, LinkerFlavor, Lld, RelroLevel, TargetOptions, cvs};
+use crate::spec::{Cc, Env, LinkerFlavor, Lld, Os, RelroLevel, TargetOptions, cvs};
 
 pub(crate) fn opts() -> TargetOptions {
     TargetOptions {
-        os: "redox".into(),
+        os: Os::Redox,
         env: Env::Relibc,
         dynamic_linking: true,
         families: cvs!["unix"],

--- a/compiler/rustc_target/src/spec/base/redox.rs
+++ b/compiler/rustc_target/src/spec/base/redox.rs
@@ -1,9 +1,9 @@
-use crate::spec::{Cc, LinkerFlavor, Lld, RelroLevel, TargetOptions, cvs};
+use crate::spec::{Cc, Env, LinkerFlavor, Lld, RelroLevel, TargetOptions, cvs};
 
 pub(crate) fn opts() -> TargetOptions {
     TargetOptions {
         os: "redox".into(),
-        env: "relibc".into(),
+        env: Env::Relibc,
         dynamic_linking: true,
         families: cvs!["unix"],
         has_rpath: true,

--- a/compiler/rustc_target/src/spec/base/solaris.rs
+++ b/compiler/rustc_target/src/spec/base/solaris.rs
@@ -1,8 +1,8 @@
-use crate::spec::{Cc, LinkerFlavor, TargetOptions, cvs};
+use crate::spec::{Cc, LinkerFlavor, Os, TargetOptions, cvs};
 
 pub(crate) fn opts() -> TargetOptions {
     TargetOptions {
-        os: "solaris".into(),
+        os: Os::Solaris,
         dynamic_linking: true,
         has_rpath: true,
         families: cvs!["unix"],

--- a/compiler/rustc_target/src/spec/base/solid.rs
+++ b/compiler/rustc_target/src/spec/base/solid.rs
@@ -1,8 +1,8 @@
-use crate::spec::{FramePointer, TargetOptions};
+use crate::spec::{FramePointer, Os, TargetOptions};
 
-pub(crate) fn opts(kernel: &str) -> TargetOptions {
+pub(crate) fn opts() -> TargetOptions {
     TargetOptions {
-        os: format!("solid_{kernel}").into(),
+        os: Os::SolidAsp3,
         vendor: "kmc".into(),
         executables: false,
         frame_pointer: FramePointer::NonLeaf,

--- a/compiler/rustc_target/src/spec/base/teeos.rs
+++ b/compiler/rustc_target/src/spec/base/teeos.rs
@@ -1,4 +1,6 @@
-use crate::spec::{Cc, LinkerFlavor, Lld, PanicStrategy, RelroLevel, TargetOptions, add_link_args};
+use crate::spec::{
+    Cc, LinkerFlavor, Lld, Os, PanicStrategy, RelroLevel, TargetOptions, add_link_args,
+};
 
 pub(crate) fn opts() -> TargetOptions {
     let lld_args = &["-zmax-page-size=4096", "-znow", "-ztext", "--execute-only"];
@@ -8,8 +10,7 @@ pub(crate) fn opts() -> TargetOptions {
     add_link_args(&mut pre_link_args, LinkerFlavor::Gnu(Cc::Yes, Lld::No), cc_args);
 
     TargetOptions {
-        os: "teeos".into(),
-        vendor: "unknown".into(),
+        os: Os::TeeOs,
         dynamic_linking: true,
         linker_flavor: LinkerFlavor::Gnu(Cc::Yes, Lld::No),
         // rpath hardcodes -Wl, so it can't be used together with ld.lld.

--- a/compiler/rustc_target/src/spec/base/uefi_msvc.rs
+++ b/compiler/rustc_target/src/spec/base/uefi_msvc.rs
@@ -9,7 +9,7 @@
 // the timer-interrupt. Device-drivers are required to use polling-based models. Furthermore, all
 // code runs in the same environment, no process separation is supported.
 
-use crate::spec::{LinkerFlavor, Lld, PanicStrategy, StackProbeType, TargetOptions, base};
+use crate::spec::{LinkerFlavor, Lld, Os, PanicStrategy, StackProbeType, TargetOptions, base};
 
 pub(crate) fn opts() -> TargetOptions {
     let mut base = base::msvc::opts();
@@ -35,7 +35,7 @@ pub(crate) fn opts() -> TargetOptions {
     );
 
     TargetOptions {
-        os: "uefi".into(),
+        os: Os::Uefi,
         linker_flavor: LinkerFlavor::Msvc(Lld::Yes),
         disable_redzone: true,
         exe_suffix: ".efi".into(),

--- a/compiler/rustc_target/src/spec/base/unikraft_linux_musl.rs
+++ b/compiler/rustc_target/src/spec/base/unikraft_linux_musl.rs
@@ -1,8 +1,8 @@
-use crate::spec::{Env, PanicStrategy, RelocModel, TargetOptions, cvs};
+use crate::spec::{Env, Os, PanicStrategy, RelocModel, TargetOptions, cvs};
 
 pub(crate) fn opts() -> TargetOptions {
     TargetOptions {
-        os: "linux".into(),
+        os: Os::Linux,
         env: Env::Musl,
         vendor: "unikraft".into(),
         linker: Some("kraftld".into()),

--- a/compiler/rustc_target/src/spec/base/unikraft_linux_musl.rs
+++ b/compiler/rustc_target/src/spec/base/unikraft_linux_musl.rs
@@ -1,9 +1,9 @@
-use crate::spec::{PanicStrategy, RelocModel, TargetOptions, cvs};
+use crate::spec::{Env, PanicStrategy, RelocModel, TargetOptions, cvs};
 
 pub(crate) fn opts() -> TargetOptions {
     TargetOptions {
         os: "linux".into(),
-        env: "musl".into(),
+        env: Env::Musl,
         vendor: "unikraft".into(),
         linker: Some("kraftld".into()),
         relocation_model: RelocModel::Static,

--- a/compiler/rustc_target/src/spec/base/vxworks.rs
+++ b/compiler/rustc_target/src/spec/base/vxworks.rs
@@ -1,8 +1,8 @@
-use crate::spec::{Env, TargetOptions, cvs};
+use crate::spec::{Env, Os, TargetOptions, cvs};
 
 pub(crate) fn opts() -> TargetOptions {
     TargetOptions {
-        os: "vxworks".into(),
+        os: Os::VxWorks,
         env: Env::Gnu,
         vendor: "wrs".into(),
         linker: Some("wr-c++".into()),

--- a/compiler/rustc_target/src/spec/base/vxworks.rs
+++ b/compiler/rustc_target/src/spec/base/vxworks.rs
@@ -1,9 +1,9 @@
-use crate::spec::{TargetOptions, cvs};
+use crate::spec::{Env, TargetOptions, cvs};
 
 pub(crate) fn opts() -> TargetOptions {
     TargetOptions {
         os: "vxworks".into(),
-        env: "gnu".into(),
+        env: Env::Gnu,
         vendor: "wrs".into(),
         linker: Some("wr-c++".into()),
         exe_suffix: ".vxe".into(),

--- a/compiler/rustc_target/src/spec/base/windows_gnu.rs
+++ b/compiler/rustc_target/src/spec/base/windows_gnu.rs
@@ -1,8 +1,8 @@
 use std::borrow::Cow;
 
 use crate::spec::{
-    BinaryFormat, Cc, DebuginfoKind, LinkSelfContainedDefault, LinkerFlavor, Lld, SplitDebuginfo,
-    TargetOptions, add_link_args, crt_objects, cvs,
+    BinaryFormat, Cc, DebuginfoKind, Env, LinkSelfContainedDefault, LinkerFlavor, Lld,
+    SplitDebuginfo, TargetOptions, add_link_args, crt_objects, cvs,
 };
 
 pub(crate) fn opts() -> TargetOptions {
@@ -78,7 +78,7 @@ pub(crate) fn opts() -> TargetOptions {
 
     TargetOptions {
         os: "windows".into(),
-        env: "gnu".into(),
+        env: Env::Gnu,
         vendor: "pc".into(),
         // FIXME(#13846) this should be enabled for windows
         function_sections: false,

--- a/compiler/rustc_target/src/spec/base/windows_gnu.rs
+++ b/compiler/rustc_target/src/spec/base/windows_gnu.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
 use crate::spec::{
-    BinaryFormat, Cc, DebuginfoKind, Env, LinkSelfContainedDefault, LinkerFlavor, Lld,
+    BinaryFormat, Cc, DebuginfoKind, Env, LinkSelfContainedDefault, LinkerFlavor, Lld, Os,
     SplitDebuginfo, TargetOptions, add_link_args, crt_objects, cvs,
 };
 
@@ -77,7 +77,7 @@ pub(crate) fn opts() -> TargetOptions {
     );
 
     TargetOptions {
-        os: "windows".into(),
+        os: Os::Windows,
         env: Env::Gnu,
         vendor: "pc".into(),
         // FIXME(#13846) this should be enabled for windows

--- a/compiler/rustc_target/src/spec/base/windows_gnullvm.rs
+++ b/compiler/rustc_target/src/spec/base/windows_gnullvm.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
 use crate::spec::{
-    BinaryFormat, Cc, DebuginfoKind, LinkerFlavor, Lld, SplitDebuginfo, TargetOptions, cvs,
+    Abi, BinaryFormat, Cc, DebuginfoKind, LinkerFlavor, Lld, SplitDebuginfo, TargetOptions, cvs,
 };
 
 pub(crate) fn opts() -> TargetOptions {
@@ -23,7 +23,7 @@ pub(crate) fn opts() -> TargetOptions {
         os: "windows".into(),
         env: "gnu".into(),
         vendor: "pc".into(),
-        abi: "llvm".into(),
+        abi: Abi::Llvm,
         linker: Some("clang".into()),
         dynamic_linking: true,
         dll_tls_export: false,

--- a/compiler/rustc_target/src/spec/base/windows_gnullvm.rs
+++ b/compiler/rustc_target/src/spec/base/windows_gnullvm.rs
@@ -1,7 +1,8 @@
 use std::borrow::Cow;
 
 use crate::spec::{
-    Abi, BinaryFormat, Cc, DebuginfoKind, LinkerFlavor, Lld, SplitDebuginfo, TargetOptions, cvs,
+    Abi, BinaryFormat, Cc, DebuginfoKind, Env, LinkerFlavor, Lld, SplitDebuginfo, TargetOptions,
+    cvs,
 };
 
 pub(crate) fn opts() -> TargetOptions {
@@ -21,7 +22,7 @@ pub(crate) fn opts() -> TargetOptions {
 
     TargetOptions {
         os: "windows".into(),
-        env: "gnu".into(),
+        env: Env::Gnu,
         vendor: "pc".into(),
         abi: Abi::Llvm,
         linker: Some("clang".into()),

--- a/compiler/rustc_target/src/spec/base/windows_gnullvm.rs
+++ b/compiler/rustc_target/src/spec/base/windows_gnullvm.rs
@@ -1,8 +1,8 @@
 use std::borrow::Cow;
 
 use crate::spec::{
-    Abi, BinaryFormat, Cc, DebuginfoKind, Env, LinkerFlavor, Lld, SplitDebuginfo, TargetOptions,
-    cvs,
+    Abi, BinaryFormat, Cc, DebuginfoKind, Env, LinkerFlavor, Lld, Os, SplitDebuginfo,
+    TargetOptions, cvs,
 };
 
 pub(crate) fn opts() -> TargetOptions {
@@ -21,7 +21,7 @@ pub(crate) fn opts() -> TargetOptions {
     );
 
     TargetOptions {
-        os: "windows".into(),
+        os: Os::Windows,
         env: Env::Gnu,
         vendor: "pc".into(),
         abi: Abi::Llvm,

--- a/compiler/rustc_target/src/spec/base/windows_msvc.rs
+++ b/compiler/rustc_target/src/spec/base/windows_msvc.rs
@@ -1,11 +1,11 @@
-use crate::spec::{TargetOptions, base, cvs};
+use crate::spec::{Env, TargetOptions, base, cvs};
 
 pub(crate) fn opts() -> TargetOptions {
     let base = base::msvc::opts();
 
     TargetOptions {
         os: "windows".into(),
-        env: "msvc".into(),
+        env: Env::Msvc,
         vendor: "pc".into(),
         dynamic_linking: true,
         dll_prefix: "".into(),

--- a/compiler/rustc_target/src/spec/base/windows_msvc.rs
+++ b/compiler/rustc_target/src/spec/base/windows_msvc.rs
@@ -1,10 +1,10 @@
-use crate::spec::{Env, TargetOptions, base, cvs};
+use crate::spec::{Env, Os, TargetOptions, base, cvs};
 
 pub(crate) fn opts() -> TargetOptions {
     let base = base::msvc::opts();
 
     TargetOptions {
-        os: "windows".into(),
+        os: Os::Windows,
         env: Env::Msvc,
         vendor: "pc".into(),
         dynamic_linking: true,

--- a/compiler/rustc_target/src/spec/base/windows_uwp_gnu.rs
+++ b/compiler/rustc_target/src/spec/base/windows_uwp_gnu.rs
@@ -1,4 +1,4 @@
-use crate::spec::{Cc, LinkArgs, LinkerFlavor, Lld, TargetOptions, add_link_args, base};
+use crate::spec::{Abi, Cc, LinkArgs, LinkerFlavor, Lld, TargetOptions, add_link_args, base};
 
 pub(crate) fn opts() -> TargetOptions {
     let base = base::windows_gnu::opts();
@@ -23,7 +23,7 @@ pub(crate) fn opts() -> TargetOptions {
     let late_link_args_static = LinkArgs::new();
 
     TargetOptions {
-        abi: "uwp".into(),
+        abi: Abi::Uwp,
         vendor: "uwp".into(),
         limit_rdylib_exports: false,
         late_link_args,

--- a/compiler/rustc_target/src/spec/base/windows_uwp_msvc.rs
+++ b/compiler/rustc_target/src/spec/base/windows_uwp_msvc.rs
@@ -1,8 +1,8 @@
-use crate::spec::{LinkerFlavor, Lld, TargetOptions, base};
+use crate::spec::{Abi, LinkerFlavor, Lld, TargetOptions, base};
 
 pub(crate) fn opts() -> TargetOptions {
     let mut opts =
-        TargetOptions { abi: "uwp".into(), vendor: "uwp".into(), ..base::windows_msvc::opts() };
+        TargetOptions { abi: Abi::Uwp, vendor: "uwp".into(), ..base::windows_msvc::opts() };
 
     opts.add_pre_link_args(LinkerFlavor::Msvc(Lld::No), &["/APPCONTAINER", "mincore.lib"]);
 

--- a/compiler/rustc_target/src/spec/base/xtensa.rs
+++ b/compiler/rustc_target/src/spec/base/xtensa.rs
@@ -1,10 +1,10 @@
 use rustc_abi::Endian;
 
-use crate::spec::{Cc, LinkerFlavor, Lld, PanicStrategy, RelocModel, TargetOptions};
+use crate::spec::{Cc, LinkerFlavor, Lld, Os, PanicStrategy, RelocModel, TargetOptions};
 
 pub(crate) fn opts() -> TargetOptions {
     TargetOptions {
-        os: "none".into(),
+        os: Os::None,
         endian: Endian::Little,
         c_int_width: 32,
         linker_flavor: LinkerFlavor::Gnu(Cc::Yes, Lld::No),

--- a/compiler/rustc_target/src/spec/json.rs
+++ b/compiler/rustc_target/src/spec/json.rs
@@ -5,7 +5,7 @@ use rustc_abi::{Align, AlignFromBytesError};
 
 use super::crt_objects::CrtObjects;
 use super::{
-    Abi, Arch, BinaryFormat, CodeModel, DebuginfoKind, FloatAbi, FramePointer, LinkArgsCli,
+    Abi, Arch, BinaryFormat, CodeModel, DebuginfoKind, Env, FloatAbi, FramePointer, LinkArgsCli,
     LinkSelfContainedComponents, LinkSelfContainedDefault, LinkerFlavorCli, LldFlavor,
     MergeFunctions, PanicStrategy, RelocModel, RelroLevel, RustcAbi, SanitizerSet,
     SmallDataThresholdSupport, SplitDebuginfo, StackProbeType, StaticCow, SymbolVisibility, Target,
@@ -506,7 +506,7 @@ struct TargetSpecJson {
     c_int_width: Option<u16>,
     c_enum_min_bits: Option<u64>,
     os: Option<StaticCow<str>>,
-    env: Option<StaticCow<str>>,
+    env: Option<Env>,
     abi: Option<Abi>,
     vendor: Option<StaticCow<str>>,
     linker: Option<StaticCow<str>>,

--- a/compiler/rustc_target/src/spec/json.rs
+++ b/compiler/rustc_target/src/spec/json.rs
@@ -5,7 +5,7 @@ use rustc_abi::{Align, AlignFromBytesError};
 
 use super::crt_objects::CrtObjects;
 use super::{
-    Arch, BinaryFormat, CodeModel, DebuginfoKind, FloatAbi, FramePointer, LinkArgsCli,
+    Abi, Arch, BinaryFormat, CodeModel, DebuginfoKind, FloatAbi, FramePointer, LinkArgsCli,
     LinkSelfContainedComponents, LinkSelfContainedDefault, LinkerFlavorCli, LldFlavor,
     MergeFunctions, PanicStrategy, RelocModel, RelroLevel, RustcAbi, SanitizerSet,
     SmallDataThresholdSupport, SplitDebuginfo, StackProbeType, StaticCow, SymbolVisibility, Target,
@@ -507,7 +507,7 @@ struct TargetSpecJson {
     c_enum_min_bits: Option<u64>,
     os: Option<StaticCow<str>>,
     env: Option<StaticCow<str>>,
-    abi: Option<StaticCow<str>>,
+    abi: Option<Abi>,
     vendor: Option<StaticCow<str>>,
     linker: Option<StaticCow<str>>,
     #[serde(rename = "linker-flavor")]

--- a/compiler/rustc_target/src/spec/json.rs
+++ b/compiler/rustc_target/src/spec/json.rs
@@ -7,7 +7,7 @@ use super::crt_objects::CrtObjects;
 use super::{
     Abi, Arch, BinaryFormat, CodeModel, DebuginfoKind, Env, FloatAbi, FramePointer, LinkArgsCli,
     LinkSelfContainedComponents, LinkSelfContainedDefault, LinkerFlavorCli, LldFlavor,
-    MergeFunctions, PanicStrategy, RelocModel, RelroLevel, RustcAbi, SanitizerSet,
+    MergeFunctions, Os, PanicStrategy, RelocModel, RelroLevel, RustcAbi, SanitizerSet,
     SmallDataThresholdSupport, SplitDebuginfo, StackProbeType, StaticCow, SymbolVisibility, Target,
     TargetKind, TargetOptions, TargetWarnings, TlsModel,
 };
@@ -505,7 +505,7 @@ struct TargetSpecJson {
     #[serde(rename = "target-c-int-width")]
     c_int_width: Option<u16>,
     c_enum_min_bits: Option<u64>,
-    os: Option<StaticCow<str>>,
+    os: Option<Os>,
     env: Option<Env>,
     abi: Option<Abi>,
     vendor: Option<StaticCow<str>>,

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -1927,6 +1927,66 @@ impl Arch {
 }
 
 crate::target_spec_enum! {
+    pub enum Os {
+        Aix = "aix",
+        AmdHsa = "amdhsa",
+        Android = "android",
+        Cuda = "cuda",
+        Cygwin = "cygwin",
+        Dragonfly = "dragonfly",
+        Emscripten = "emscripten",
+        EspIdf = "espidf",
+        FreeBsd = "freebsd",
+        Fuchsia = "fuchsia",
+        Haiku = "haiku",
+        HelenOs = "helenos",
+        Hermit = "hermit",
+        Horizon = "horizon",
+        Hurd = "hurd",
+        Illumos = "illumos",
+        IOs = "ios",
+        L4Re = "l4re",
+        Linux = "linux",
+        LynxOs178 = "lynxos178",
+        MacOs = "macos",
+        Managarm = "managarm",
+        Motor = "motor",
+        NetBsd = "netbsd",
+        None = "none",
+        Nto = "nto",
+        NuttX = "nuttx",
+        OpenBsd = "openbsd",
+        Psp = "psp",
+        Psx = "psx",
+        Redox = "redox",
+        Rtems = "rtems",
+        Solaris = "solaris",
+        SolidAsp3 = "solid_asp3",
+        TeeOs = "teeos",
+        Trusty = "trusty",
+        TvOs = "tvos",
+        Uefi = "uefi",
+        VexOs = "vexos",
+        VisionOs = "visionos",
+        Vita = "vita",
+        VxWorks = "vxworks",
+        Wasi = "wasi",
+        WatchOs = "watchos",
+        Windows = "windows",
+        Xous = "xous",
+        Zkvm = "zkvm",
+        Unknown = "unknown",
+    }
+    other_variant = Other;
+}
+
+impl Os {
+    pub fn desc_symbol(&self) -> Symbol {
+        Symbol::intern(self.desc())
+    }
+}
+
+crate::target_spec_enum! {
     pub enum Env {
         Gnu = "gnu",
         MacAbi = "macabi",
@@ -2108,11 +2168,11 @@ pub struct TargetOptions {
     pub endian: Endian,
     /// Width of c_int type. Defaults to "32".
     pub c_int_width: u16,
-    /// OS name to use for conditional compilation (`target_os`). Defaults to "none".
-    /// "none" implies a bare metal target without `std` library.
-    /// A couple of targets having `std` also use "unknown" as an `os` value,
+    /// OS name to use for conditional compilation (`target_os`). Defaults to [`Os::None`].
+    /// [`Os::None`] implies a bare metal target without `std` library.
+    /// A couple of targets having `std` also use [`Os::Unknown`] as their `os` value,
     /// but they are exceptions.
-    pub os: StaticCow<str>,
+    pub os: Os,
     /// Environment name to use for conditional compilation (`target_env`). Defaults to [`Env::Unspecified`].
     pub env: Env,
     /// ABI name to distinguish multiple ABIs on the same OS and architecture. For instance, `"eabi"`
@@ -2622,7 +2682,7 @@ impl Default for TargetOptions {
         TargetOptions {
             endian: Endian::Little,
             c_int_width: 32,
-            os: "none".into(),
+            os: Os::None,
             env: Env::Unspecified,
             abi: Abi::Unspecified,
             vendor: "unknown".into(),
@@ -2820,7 +2880,7 @@ impl Target {
         );
         check_eq!(
             self.is_like_solaris,
-            self.os == "solaris" || self.os == "illumos",
+            matches!(self.os, Os::Solaris | Os::Illumos),
             "`is_like_solaris` must be set if and only if `os` is `solaris` or `illumos`"
         );
         check_eq!(
@@ -2830,7 +2890,7 @@ impl Target {
         );
         check_eq!(
             self.is_like_windows,
-            self.os == "windows" || self.os == "uefi" || self.os == "cygwin",
+            matches!(self.os, Os::Windows | Os::Uefi | Os::Cygwin),
             "`is_like_windows` must be set if and only if `os` is `windows`, `uefi` or `cygwin`"
         );
         check_eq!(
@@ -2841,7 +2901,7 @@ impl Target {
         if self.is_like_msvc {
             check!(self.is_like_windows, "if `is_like_msvc` is set, `is_like_windows` must be set");
         }
-        if self.os == "emscripten" {
+        if self.os == Os::Emscripten {
             check!(self.is_like_wasm, "the `emcscripten` os only makes sense on wasm-like targets");
         }
 
@@ -2857,12 +2917,12 @@ impl Target {
             "`linker_flavor` must be `msvc` if and only if `is_like_msvc` is set"
         );
         check_eq!(
-            self.is_like_wasm && self.os != "emscripten",
+            self.is_like_wasm && self.os != Os::Emscripten,
             matches!(self.linker_flavor, LinkerFlavor::WasmLld(..)),
             "`linker_flavor` must be `wasm-lld` if and only if `is_like_wasm` is set and the `os` is not `emscripten`",
         );
         check_eq!(
-            self.os == "emscripten",
+            self.os == Os::Emscripten,
             matches!(self.linker_flavor, LinkerFlavor::EmCc),
             "`linker_flavor` must be `em-cc` if and only if `os` is `emscripten`"
         );
@@ -2989,12 +3049,14 @@ impl Target {
         // except it and document the reasons.
         // Keep the default "unknown" vendor instead.
         check_ne!(self.vendor, "", "`vendor` cannot be empty");
-        check_ne!(self.os, "", "`os` cannot be empty");
+        if let Os::Other(s) = &self.os {
+            check!(!s.is_empty(), "`os` cannot be empty");
+        }
         if !self.can_use_os_unknown() {
             // Keep the default "none" for bare metal targets instead.
             check_ne!(
                 self.os,
-                "unknown",
+                Os::Unknown,
                 "`unknown` os can only be used on particular targets; use `none` for bare-metal targets"
             );
         }
@@ -3008,7 +3070,7 @@ impl Target {
             // BPF: when targeting user space vms (like rbpf), those can load dynamic libraries.
             // hexagon: when targeting QuRT, that OS can load dynamic libraries.
             // wasm{32,64}: dynamic linking is inherent in the definition of the VM.
-            if self.os == "none"
+            if self.os == Os::None
                 && !matches!(self.arch, Arch::Bpf | Arch::Hexagon | Arch::Wasm32 | Arch::Wasm64)
             {
                 check!(
@@ -3041,7 +3103,7 @@ impl Target {
                 );
             }
             // The UEFI targets do not support dynamic linking but still require PIC (#101377).
-            if self.relocation_model == RelocModel::Pic && (self.os != "uefi") {
+            if self.relocation_model == RelocModel::Pic && self.os != Os::Uefi {
                 check!(
                     self.dynamic_linking || self.position_independent_executables,
                     "when the relocation model is `pic`, the target must support dynamic linking or use position-independent executables. \

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -1927,6 +1927,38 @@ impl Arch {
 }
 
 crate::target_spec_enum! {
+    pub enum Env {
+        Gnu = "gnu",
+        MacAbi = "macabi",
+        Mlibc = "mlibc",
+        Msvc = "msvc",
+        Musl = "musl",
+        Newlib = "newlib",
+        Nto70 = "nto70",
+        Nto71 = "nto71",
+        Nto71IoSock = "nto71_iosock",
+        Nto80 = "nto80",
+        Ohos = "ohos",
+        Relibc = "relibc",
+        Sgx = "sgx",
+        Sim = "sim",
+        P1 = "p1",
+        P2 = "p2",
+        P3 = "p3",
+        Uclibc = "uclibc",
+        V5 = "v5",
+        Unspecified = "",
+    }
+    other_variant = Other;
+}
+
+impl Env {
+    pub fn desc_symbol(&self) -> Symbol {
+        Symbol::intern(self.desc())
+    }
+}
+
+crate::target_spec_enum! {
     pub enum Abi {
         Abi64 = "abi64",
         AbiV2 = "abiv2",
@@ -2081,8 +2113,8 @@ pub struct TargetOptions {
     /// A couple of targets having `std` also use "unknown" as an `os` value,
     /// but they are exceptions.
     pub os: StaticCow<str>,
-    /// Environment name to use for conditional compilation (`target_env`). Defaults to "".
-    pub env: StaticCow<str>,
+    /// Environment name to use for conditional compilation (`target_env`). Defaults to [`Env::Unspecified`].
+    pub env: Env,
     /// ABI name to distinguish multiple ABIs on the same OS and architecture. For instance, `"eabi"`
     /// or `"eabihf"`. Defaults to [`Abi::Unspecified`].
     /// This field is *not* forwarded directly to LLVM; its primary purpose is `cfg(target_abi)`.
@@ -2591,7 +2623,7 @@ impl Default for TargetOptions {
             endian: Endian::Little,
             c_int_width: 32,
             os: "none".into(),
-            env: "".into(),
+            env: Env::Unspecified,
             abi: Abi::Unspecified,
             vendor: "unknown".into(),
             linker: option_env!("CFG_DEFAULT_LINKER").map(|s| s.into()),
@@ -3148,7 +3180,7 @@ impl Target {
     fn can_use_os_unknown(&self) -> bool {
         self.llvm_target == "wasm32-unknown-unknown"
             || self.llvm_target == "wasm64-unknown-unknown"
-            || (self.env == "sgx" && self.vendor == "fortanix")
+            || (self.env == Env::Sgx && self.vendor == "fortanix")
     }
 
     /// Load a built-in target

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -1884,7 +1884,7 @@ crate::target_spec_enum! {
         X86_64 = "x86_64",
         Xtensa = "xtensa",
     }
-    other_variant = Unknown;
+    other_variant = Other;
 }
 
 impl Arch {
@@ -1921,7 +1921,7 @@ impl Arch {
             Self::X86 => sym::x86,
             Self::X86_64 => sym::x86_64,
             Self::Xtensa => sym::xtensa,
-            Self::Unknown(name) => rustc_span::Symbol::intern(name),
+            Self::Other(name) => rustc_span::Symbol::intern(name),
         }
     }
 }
@@ -3298,7 +3298,7 @@ impl Target {
             | Arch::SpirV
             | Arch::Wasm32
             | Arch::Wasm64
-            | Arch::Unknown(_) => return None,
+            | Arch::Other(_) => return None,
         })
     }
 

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -1884,13 +1884,6 @@ crate::target_spec_enum! {
         X86_64 = "x86_64",
         Xtensa = "xtensa",
     }
-    /// The vast majority of the time, the compiler deals with a fixed set of
-    /// target architectures, so it is convenient for them to be represented in
-    /// an enum. However, it is possible to have arbitrary values for the "arch"
-    /// field in a target JSON file (which can be parsed when `--target` is
-    /// specified). This might occur, for example, for an out-of-tree codegen
-    /// backend that supports an architecture that rustc currently doesn't know
-    /// about. This variant exists as an escape hatch for such cases.
     other_variant = Unknown;
 }
 

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -1926,6 +1926,38 @@ impl Arch {
     }
 }
 
+crate::target_spec_enum! {
+    pub enum Abi {
+        Abi64 = "abi64",
+        AbiV2 = "abiv2",
+        AbiV2Hf = "abiv2hf",
+        Eabi = "eabi",
+        EabiHf = "eabihf",
+        ElfV1 = "elfv1",
+        ElfV2 = "elfv2",
+        Fortanix = "fortanix",
+        Ilp32 = "ilp32",
+        Ilp32e = "ilp32e",
+        Llvm = "llvm",
+        MacAbi = "macabi",
+        Sim = "sim",
+        SoftFloat = "softfloat",
+        Spe = "spe",
+        Uwp = "uwp",
+        VecDefault = "vec-default",
+        VecExtAbi = "vec-extabi",
+        X32 = "x32",
+        Unspecified = "",
+    }
+    other_variant = Other;
+}
+
+impl Abi {
+    pub fn desc_symbol(&self) -> Symbol {
+        Symbol::intern(self.desc())
+    }
+}
+
 /// Everything `rustc` knows about how to compile for a specific target.
 ///
 /// Every field here must be specified, and has no default value.
@@ -2052,10 +2084,10 @@ pub struct TargetOptions {
     /// Environment name to use for conditional compilation (`target_env`). Defaults to "".
     pub env: StaticCow<str>,
     /// ABI name to distinguish multiple ABIs on the same OS and architecture. For instance, `"eabi"`
-    /// or `"eabihf"`. Defaults to "".
+    /// or `"eabihf"`. Defaults to [`Abi::Unspecified`].
     /// This field is *not* forwarded directly to LLVM; its primary purpose is `cfg(target_abi)`.
     /// However, parts of the backend do check this field for specific values to enable special behavior.
-    pub abi: StaticCow<str>,
+    pub abi: Abi,
     /// Vendor name to use for conditional compilation (`target_vendor`). Defaults to "unknown".
     #[rustc_lint_opt_deny_field_access(
         "use `Target::is_like_*` instead of this field; see https://github.com/rust-lang/rust/issues/100343 for rationale"
@@ -2560,7 +2592,7 @@ impl Default for TargetOptions {
             c_int_width: 32,
             os: "none".into(),
             env: "".into(),
-            abi: "".into(),
+            abi: Abi::Unspecified,
             vendor: "unknown".into(),
             linker: option_env!("CFG_DEFAULT_LINKER").map(|s| s.into()),
             linker_flavor: LinkerFlavor::Gnu(Cc::Yes, Lld::No),

--- a/compiler/rustc_target/src/spec/targets/aarch64_apple_darwin.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_apple_darwin.rs
@@ -1,8 +1,8 @@
 use crate::spec::base::apple::{Arch, TargetEnv, base};
-use crate::spec::{SanitizerSet, Target, TargetMetadata, TargetOptions};
+use crate::spec::{Os, SanitizerSet, Target, TargetMetadata, TargetOptions};
 
 pub(crate) fn target() -> Target {
-    let (opts, llvm_target, arch) = base("macos", Arch::Arm64, TargetEnv::Normal);
+    let (opts, llvm_target, arch) = base(Os::MacOs, Arch::Arm64, TargetEnv::Normal);
     Target {
         llvm_target,
         metadata: TargetMetadata {

--- a/compiler/rustc_target/src/spec/targets/aarch64_apple_ios.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_apple_ios.rs
@@ -1,8 +1,8 @@
 use crate::spec::base::apple::{Arch, TargetEnv, base};
-use crate::spec::{SanitizerSet, Target, TargetMetadata, TargetOptions};
+use crate::spec::{Os, SanitizerSet, Target, TargetMetadata, TargetOptions};
 
 pub(crate) fn target() -> Target {
-    let (opts, llvm_target, arch) = base("ios", Arch::Arm64, TargetEnv::Normal);
+    let (opts, llvm_target, arch) = base(Os::IOs, Arch::Arm64, TargetEnv::Normal);
     Target {
         llvm_target,
         metadata: TargetMetadata {

--- a/compiler/rustc_target/src/spec/targets/aarch64_apple_ios_macabi.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_apple_ios_macabi.rs
@@ -1,8 +1,8 @@
 use crate::spec::base::apple::{Arch, TargetEnv, base};
-use crate::spec::{SanitizerSet, Target, TargetMetadata, TargetOptions};
+use crate::spec::{Os, SanitizerSet, Target, TargetMetadata, TargetOptions};
 
 pub(crate) fn target() -> Target {
-    let (opts, llvm_target, arch) = base("ios", Arch::Arm64, TargetEnv::MacCatalyst);
+    let (opts, llvm_target, arch) = base(Os::IOs, Arch::Arm64, TargetEnv::MacCatalyst);
     Target {
         llvm_target,
         metadata: TargetMetadata {

--- a/compiler/rustc_target/src/spec/targets/aarch64_apple_ios_sim.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_apple_ios_sim.rs
@@ -1,8 +1,8 @@
 use crate::spec::base::apple::{Arch, TargetEnv, base};
-use crate::spec::{SanitizerSet, Target, TargetMetadata, TargetOptions};
+use crate::spec::{Os, SanitizerSet, Target, TargetMetadata, TargetOptions};
 
 pub(crate) fn target() -> Target {
-    let (opts, llvm_target, arch) = base("ios", Arch::Arm64, TargetEnv::Simulator);
+    let (opts, llvm_target, arch) = base(Os::IOs, Arch::Arm64, TargetEnv::Simulator);
     Target {
         llvm_target,
         metadata: TargetMetadata {

--- a/compiler/rustc_target/src/spec/targets/aarch64_apple_tvos.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_apple_tvos.rs
@@ -1,8 +1,8 @@
 use crate::spec::base::apple::{Arch, TargetEnv, base};
-use crate::spec::{Target, TargetMetadata, TargetOptions};
+use crate::spec::{Os, Target, TargetMetadata, TargetOptions};
 
 pub(crate) fn target() -> Target {
-    let (opts, llvm_target, arch) = base("tvos", Arch::Arm64, TargetEnv::Normal);
+    let (opts, llvm_target, arch) = base(Os::TvOs, Arch::Arm64, TargetEnv::Normal);
     Target {
         llvm_target,
         metadata: TargetMetadata {

--- a/compiler/rustc_target/src/spec/targets/aarch64_apple_tvos_sim.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_apple_tvos_sim.rs
@@ -1,8 +1,8 @@
 use crate::spec::base::apple::{Arch, TargetEnv, base};
-use crate::spec::{Target, TargetMetadata, TargetOptions};
+use crate::spec::{Os, Target, TargetMetadata, TargetOptions};
 
 pub(crate) fn target() -> Target {
-    let (opts, llvm_target, arch) = base("tvos", Arch::Arm64, TargetEnv::Simulator);
+    let (opts, llvm_target, arch) = base(Os::TvOs, Arch::Arm64, TargetEnv::Simulator);
     Target {
         llvm_target,
         metadata: TargetMetadata {

--- a/compiler/rustc_target/src/spec/targets/aarch64_apple_visionos.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_apple_visionos.rs
@@ -1,8 +1,8 @@
 use crate::spec::base::apple::{Arch, TargetEnv, base};
-use crate::spec::{SanitizerSet, Target, TargetMetadata, TargetOptions};
+use crate::spec::{Os, SanitizerSet, Target, TargetMetadata, TargetOptions};
 
 pub(crate) fn target() -> Target {
-    let (opts, llvm_target, arch) = base("visionos", Arch::Arm64, TargetEnv::Normal);
+    let (opts, llvm_target, arch) = base(Os::VisionOs, Arch::Arm64, TargetEnv::Normal);
     Target {
         llvm_target,
         metadata: TargetMetadata {

--- a/compiler/rustc_target/src/spec/targets/aarch64_apple_visionos_sim.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_apple_visionos_sim.rs
@@ -1,8 +1,8 @@
 use crate::spec::base::apple::{Arch, TargetEnv, base};
-use crate::spec::{SanitizerSet, Target, TargetMetadata, TargetOptions};
+use crate::spec::{Os, SanitizerSet, Target, TargetMetadata, TargetOptions};
 
 pub(crate) fn target() -> Target {
-    let (opts, llvm_target, arch) = base("visionos", Arch::Arm64, TargetEnv::Simulator);
+    let (opts, llvm_target, arch) = base(Os::VisionOs, Arch::Arm64, TargetEnv::Simulator);
     Target {
         llvm_target,
         metadata: TargetMetadata {

--- a/compiler/rustc_target/src/spec/targets/aarch64_apple_watchos.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_apple_watchos.rs
@@ -1,8 +1,8 @@
 use crate::spec::base::apple::{Arch, TargetEnv, base};
-use crate::spec::{Target, TargetMetadata, TargetOptions};
+use crate::spec::{Os, Target, TargetMetadata, TargetOptions};
 
 pub(crate) fn target() -> Target {
-    let (opts, llvm_target, arch) = base("watchos", Arch::Arm64, TargetEnv::Normal);
+    let (opts, llvm_target, arch) = base(Os::WatchOs, Arch::Arm64, TargetEnv::Normal);
     Target {
         llvm_target,
         metadata: TargetMetadata {

--- a/compiler/rustc_target/src/spec/targets/aarch64_apple_watchos_sim.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_apple_watchos_sim.rs
@@ -1,8 +1,8 @@
 use crate::spec::base::apple::{Arch, TargetEnv, base};
-use crate::spec::{Target, TargetMetadata, TargetOptions};
+use crate::spec::{Os, Target, TargetMetadata, TargetOptions};
 
 pub(crate) fn target() -> Target {
-    let (opts, llvm_target, arch) = base("watchos", Arch::Arm64, TargetEnv::Simulator);
+    let (opts, llvm_target, arch) = base(Os::WatchOs, Arch::Arm64, TargetEnv::Simulator);
     Target {
         llvm_target,
         metadata: TargetMetadata {

--- a/compiler/rustc_target/src/spec/targets/aarch64_be_unknown_linux_gnu_ilp32.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_be_unknown_linux_gnu_ilp32.rs
@@ -1,7 +1,7 @@
 use rustc_abi::Endian;
 
 use crate::spec::{
-    Arch, FramePointer, StackProbeType, Target, TargetMetadata, TargetOptions, base,
+    Abi, Arch, FramePointer, StackProbeType, Target, TargetMetadata, TargetOptions, base,
 };
 
 pub(crate) fn target() -> Target {
@@ -20,7 +20,7 @@ pub(crate) fn target() -> Target {
         data_layout: "E-m:e-p:32:32-p270:32:32-p271:32:32-p272:64:64-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128-Fn32".into(),
         arch: Arch::AArch64,
         options: TargetOptions {
-            abi: "ilp32".into(),
+            abi: Abi::Ilp32,
             features: "+v8a,+outline-atomics".into(),
             // the AAPCS64 expects use of non-leaf frame pointers per
             // https://github.com/ARM-software/abi-aa/blob/4492d1570eb70c8fd146623e0db65b2d241f12e7/aapcs64/aapcs64.rst#the-frame-pointer

--- a/compiler/rustc_target/src/spec/targets/aarch64_be_unknown_none_softfloat.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_be_unknown_none_softfloat.rs
@@ -8,13 +8,13 @@
 use rustc_abi::Endian;
 
 use crate::spec::{
-    Arch, Cc, LinkerFlavor, Lld, PanicStrategy, RelocModel, SanitizerSet, StackProbeType, Target,
-    TargetMetadata, TargetOptions,
+    Abi, Arch, Cc, LinkerFlavor, Lld, PanicStrategy, RelocModel, SanitizerSet, StackProbeType,
+    Target, TargetMetadata, TargetOptions,
 };
 
 pub(crate) fn target() -> Target {
     let opts = TargetOptions {
-        abi: "softfloat".into(),
+        abi: Abi::SoftFloat,
         linker_flavor: LinkerFlavor::Gnu(Cc::No, Lld::Yes),
         linker: Some("rust-lld".into()),
         features: "+v8a,+strict-align,-neon,-fp-armv8".into(),

--- a/compiler/rustc_target/src/spec/targets/aarch64_kmc_solid_asp3.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_kmc_solid_asp3.rs
@@ -1,7 +1,7 @@
 use crate::spec::{Arch, RelocModel, StackProbeType, Target, TargetMetadata, TargetOptions, base};
 
 pub(crate) fn target() -> Target {
-    let base = base::solid::opts("asp3");
+    let base = base::solid::opts();
     Target {
         llvm_target: "aarch64-unknown-none".into(),
         metadata: TargetMetadata {

--- a/compiler/rustc_target/src/spec/targets/aarch64_nintendo_switch_freestanding.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_nintendo_switch_freestanding.rs
@@ -1,6 +1,6 @@
 use crate::spec::{
-    Arch, Cc, LinkerFlavor, Lld, PanicStrategy, RelroLevel, StackProbeType, Target, TargetMetadata,
-    TargetOptions,
+    Arch, Cc, LinkerFlavor, Lld, Os, PanicStrategy, RelroLevel, StackProbeType, Target,
+    TargetMetadata, TargetOptions,
 };
 
 const LINKER_SCRIPT: &str = include_str!("./aarch64_nintendo_switch_freestanding_linker_script.ld");
@@ -23,7 +23,7 @@ pub(crate) fn target() -> Target {
             linker_flavor: LinkerFlavor::Gnu(Cc::No, Lld::Yes),
             linker: Some("rust-lld".into()),
             link_script: Some(LINKER_SCRIPT.into()),
-            os: "horizon".into(),
+            os: Os::Horizon,
             vendor: "nintendo".into(),
             max_atomic_width: Some(128),
             stack_probes: StackProbeType::Inline,

--- a/compiler/rustc_target/src/spec/targets/aarch64_unknown_linux_gnu_ilp32.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_unknown_linux_gnu_ilp32.rs
@@ -1,5 +1,5 @@
 use crate::spec::{
-    Arch, FramePointer, StackProbeType, Target, TargetMetadata, TargetOptions, base,
+    Abi, Arch, FramePointer, StackProbeType, Target, TargetMetadata, TargetOptions, base,
 };
 
 pub(crate) fn target() -> Target {
@@ -15,7 +15,7 @@ pub(crate) fn target() -> Target {
         data_layout: "e-m:e-p:32:32-p270:32:32-p271:32:32-p272:64:64-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128-Fn32".into(),
         arch: Arch::AArch64,
         options: TargetOptions {
-            abi: "ilp32".into(),
+            abi: Abi::Ilp32,
             features: "+v8a,+outline-atomics".into(),
             // the AAPCS64 expects use of non-leaf frame pointers per
             // https://github.com/ARM-software/abi-aa/blob/4492d1570eb70c8fd146623e0db65b2d241f12e7/aapcs64/aapcs64.rst#the-frame-pointer

--- a/compiler/rustc_target/src/spec/targets/aarch64_unknown_none_softfloat.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_unknown_none_softfloat.rs
@@ -7,13 +7,13 @@
 // For example, `-C target-cpu=cortex-a53`.
 
 use crate::spec::{
-    Arch, Cc, LinkerFlavor, Lld, PanicStrategy, RelocModel, SanitizerSet, StackProbeType, Target,
-    TargetMetadata, TargetOptions,
+    Abi, Arch, Cc, LinkerFlavor, Lld, PanicStrategy, RelocModel, SanitizerSet, StackProbeType,
+    Target, TargetMetadata, TargetOptions,
 };
 
 pub(crate) fn target() -> Target {
     let opts = TargetOptions {
-        abi: "softfloat".into(),
+        abi: Abi::SoftFloat,
         linker_flavor: LinkerFlavor::Gnu(Cc::No, Lld::Yes),
         linker: Some("rust-lld".into()),
         features: "+v8a,+strict-align,-neon,-fp-armv8".into(),

--- a/compiler/rustc_target/src/spec/targets/aarch64_unknown_nto_qnx700.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_unknown_nto_qnx700.rs
@@ -1,11 +1,11 @@
-use crate::spec::Target;
 use crate::spec::base::nto_qnx;
+use crate::spec::{Env, Target};
 
 pub(crate) fn target() -> Target {
     let mut target = nto_qnx::aarch64();
     target.metadata.description = Some("ARM64 QNX Neutrino 7.0 RTOS".into());
     target.options.pre_link_args =
         nto_qnx::pre_link_args(nto_qnx::ApiVariant::Default, nto_qnx::Arch::Aarch64);
-    target.options.env = "nto70".into();
+    target.options.env = Env::Nto70;
     target
 }

--- a/compiler/rustc_target/src/spec/targets/aarch64_unknown_nto_qnx710.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_unknown_nto_qnx710.rs
@@ -1,5 +1,5 @@
-use crate::spec::Target;
 use crate::spec::base::nto_qnx;
+use crate::spec::{Env, Target};
 
 pub(crate) fn target() -> Target {
     let mut target = nto_qnx::aarch64();
@@ -7,6 +7,6 @@ pub(crate) fn target() -> Target {
         Some("ARM64 QNX Neutrino 7.1 RTOS with io-pkt network stack".into());
     target.options.pre_link_args =
         nto_qnx::pre_link_args(nto_qnx::ApiVariant::Default, nto_qnx::Arch::Aarch64);
-    target.options.env = "nto71".into();
+    target.options.env = Env::Nto71;
     target
 }

--- a/compiler/rustc_target/src/spec/targets/aarch64_unknown_nto_qnx710_iosock.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_unknown_nto_qnx710_iosock.rs
@@ -1,5 +1,5 @@
-use crate::spec::Target;
 use crate::spec::base::nto_qnx;
+use crate::spec::{Env, Target};
 
 pub(crate) fn target() -> Target {
     let mut target = nto_qnx::aarch64();
@@ -7,6 +7,6 @@ pub(crate) fn target() -> Target {
         Some("ARM64 QNX Neutrino 7.1 RTOS with io-sock network stack".into());
     target.options.pre_link_args =
         nto_qnx::pre_link_args(nto_qnx::ApiVariant::IoSock, nto_qnx::Arch::Aarch64);
-    target.options.env = "nto71_iosock".into();
+    target.options.env = Env::Nto71IoSock;
     target
 }

--- a/compiler/rustc_target/src/spec/targets/aarch64_unknown_nto_qnx800.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_unknown_nto_qnx800.rs
@@ -1,11 +1,11 @@
-use crate::spec::Target;
 use crate::spec::base::nto_qnx;
+use crate::spec::{Env, Target};
 
 pub(crate) fn target() -> Target {
     let mut target = nto_qnx::aarch64();
     target.metadata.description = Some("ARM64 QNX Neutrino 8.0 RTOS".into());
     target.options.pre_link_args =
         nto_qnx::pre_link_args(nto_qnx::ApiVariant::Default, nto_qnx::Arch::Aarch64);
-    target.options.env = "nto80".into();
+    target.options.env = Env::Nto80;
     target
 }

--- a/compiler/rustc_target/src/spec/targets/aarch64_unknown_nuttx.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_unknown_nuttx.rs
@@ -7,8 +7,8 @@
 // For example, `-C target-cpu=cortex-a53`.
 
 use crate::spec::{
-    Arch, Cc, LinkerFlavor, Lld, PanicStrategy, RelocModel, SanitizerSet, StackProbeType, Target,
-    TargetMetadata, TargetOptions, cvs,
+    Arch, Cc, LinkerFlavor, Lld, Os, PanicStrategy, RelocModel, SanitizerSet, StackProbeType,
+    Target, TargetMetadata, TargetOptions, cvs,
 };
 
 pub(crate) fn target() -> Target {
@@ -28,7 +28,7 @@ pub(crate) fn target() -> Target {
         stack_probes: StackProbeType::Inline,
         panic_strategy: PanicStrategy::Abort,
         families: cvs!["unix"],
-        os: "nuttx".into(),
+        os: Os::NuttX,
         ..Default::default()
     };
     Target {

--- a/compiler/rustc_target/src/spec/targets/aarch64_unknown_trusty.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_unknown_trusty.rs
@@ -1,7 +1,7 @@
 // Trusty OS target for AArch64.
 
 use crate::spec::{
-    Arch, LinkSelfContainedDefault, PanicStrategy, RelroLevel, Target, TargetMetadata,
+    Arch, LinkSelfContainedDefault, Os, PanicStrategy, RelroLevel, Target, TargetMetadata,
     TargetOptions,
 };
 
@@ -22,7 +22,7 @@ pub(crate) fn target() -> Target {
             executables: true,
             max_atomic_width: Some(128),
             panic_strategy: PanicStrategy::Abort,
-            os: "trusty".into(),
+            os: Os::Trusty,
             position_independent_executables: true,
             static_position_independent_executables: true,
             crt_static_default: true,

--- a/compiler/rustc_target/src/spec/targets/amdgcn_amd_amdhsa.rs
+++ b/compiler/rustc_target/src/spec/targets/amdgcn_amd_amdhsa.rs
@@ -1,5 +1,5 @@
 use crate::spec::{
-    Arch, Cc, LinkerFlavor, Lld, PanicStrategy, Target, TargetMetadata, TargetOptions,
+    Arch, Cc, LinkerFlavor, Lld, Os, PanicStrategy, Target, TargetMetadata, TargetOptions,
 };
 
 pub(crate) fn target() -> Target {
@@ -16,7 +16,7 @@ pub(crate) fn target() -> Target {
         pointer_width: 64,
 
         options: TargetOptions {
-            os: "amdhsa".into(),
+            os: Os::AmdHsa,
             vendor: "amd".into(),
             linker_flavor: LinkerFlavor::Gnu(Cc::No, Lld::Yes),
             linker: Some("rust-lld".into()),

--- a/compiler/rustc_target/src/spec/targets/arm64_32_apple_watchos.rs
+++ b/compiler/rustc_target/src/spec/targets/arm64_32_apple_watchos.rs
@@ -1,8 +1,8 @@
 use crate::spec::base::apple::{Arch, TargetEnv, base};
-use crate::spec::{Target, TargetMetadata, TargetOptions};
+use crate::spec::{Os, Target, TargetMetadata, TargetOptions};
 
 pub(crate) fn target() -> Target {
-    let (opts, llvm_target, arch) = base("watchos", Arch::Arm64_32, TargetEnv::Normal);
+    let (opts, llvm_target, arch) = base(Os::WatchOs, Arch::Arm64_32, TargetEnv::Normal);
     Target {
         llvm_target,
         metadata: TargetMetadata {

--- a/compiler/rustc_target/src/spec/targets/arm64e_apple_darwin.rs
+++ b/compiler/rustc_target/src/spec/targets/arm64e_apple_darwin.rs
@@ -1,8 +1,8 @@
 use crate::spec::base::apple::{Arch, TargetEnv, base};
-use crate::spec::{SanitizerSet, Target, TargetMetadata, TargetOptions};
+use crate::spec::{Os, SanitizerSet, Target, TargetMetadata, TargetOptions};
 
 pub(crate) fn target() -> Target {
-    let (opts, llvm_target, arch) = base("macos", Arch::Arm64e, TargetEnv::Normal);
+    let (opts, llvm_target, arch) = base(Os::MacOs, Arch::Arm64e, TargetEnv::Normal);
     Target {
         llvm_target,
         metadata: TargetMetadata {

--- a/compiler/rustc_target/src/spec/targets/arm64e_apple_ios.rs
+++ b/compiler/rustc_target/src/spec/targets/arm64e_apple_ios.rs
@@ -1,8 +1,8 @@
 use crate::spec::base::apple::{Arch, TargetEnv, base};
-use crate::spec::{SanitizerSet, Target, TargetMetadata, TargetOptions};
+use crate::spec::{Os, SanitizerSet, Target, TargetMetadata, TargetOptions};
 
 pub(crate) fn target() -> Target {
-    let (opts, llvm_target, arch) = base("ios", Arch::Arm64e, TargetEnv::Normal);
+    let (opts, llvm_target, arch) = base(Os::IOs, Arch::Arm64e, TargetEnv::Normal);
     Target {
         llvm_target,
         metadata: TargetMetadata {

--- a/compiler/rustc_target/src/spec/targets/arm64e_apple_tvos.rs
+++ b/compiler/rustc_target/src/spec/targets/arm64e_apple_tvos.rs
@@ -1,8 +1,8 @@
 use crate::spec::base::apple::{Arch, TargetEnv, base};
-use crate::spec::{Target, TargetMetadata, TargetOptions};
+use crate::spec::{Os, Target, TargetMetadata, TargetOptions};
 
 pub(crate) fn target() -> Target {
-    let (opts, llvm_target, arch) = base("tvos", Arch::Arm64e, TargetEnv::Normal);
+    let (opts, llvm_target, arch) = base(Os::TvOs, Arch::Arm64e, TargetEnv::Normal);
     Target {
         llvm_target,
         metadata: TargetMetadata {

--- a/compiler/rustc_target/src/spec/targets/arm_linux_androideabi.rs
+++ b/compiler/rustc_target/src/spec/targets/arm_linux_androideabi.rs
@@ -1,4 +1,4 @@
-use crate::spec::{Arch, FloatAbi, SanitizerSet, Target, TargetMetadata, TargetOptions, base};
+use crate::spec::{Abi, Arch, FloatAbi, SanitizerSet, Target, TargetMetadata, TargetOptions, base};
 
 pub(crate) fn target() -> Target {
     Target {
@@ -13,7 +13,7 @@ pub(crate) fn target() -> Target {
         data_layout: "e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64".into(),
         arch: Arch::Arm,
         options: TargetOptions {
-            abi: "eabi".into(),
+            abi: Abi::Eabi,
             llvm_floatabi: Some(FloatAbi::Soft),
             // https://developer.android.com/ndk/guides/abis.html#armeabi
             features: "+strict-align,+v5te".into(),

--- a/compiler/rustc_target/src/spec/targets/arm_unknown_linux_gnueabi.rs
+++ b/compiler/rustc_target/src/spec/targets/arm_unknown_linux_gnueabi.rs
@@ -1,4 +1,4 @@
-use crate::spec::{Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base};
+use crate::spec::{Abi, Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base};
 
 pub(crate) fn target() -> Target {
     Target {
@@ -13,7 +13,7 @@ pub(crate) fn target() -> Target {
         data_layout: "e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64".into(),
         arch: Arch::Arm,
         options: TargetOptions {
-            abi: "eabi".into(),
+            abi: Abi::Eabi,
             llvm_floatabi: Some(FloatAbi::Soft),
             features: "+strict-align,+v6".into(),
             max_atomic_width: Some(64),

--- a/compiler/rustc_target/src/spec/targets/arm_unknown_linux_gnueabihf.rs
+++ b/compiler/rustc_target/src/spec/targets/arm_unknown_linux_gnueabihf.rs
@@ -1,4 +1,4 @@
-use crate::spec::{Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base};
+use crate::spec::{Abi, Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base};
 
 pub(crate) fn target() -> Target {
     Target {
@@ -13,7 +13,7 @@ pub(crate) fn target() -> Target {
         data_layout: "e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64".into(),
         arch: Arch::Arm,
         options: TargetOptions {
-            abi: "eabihf".into(),
+            abi: Abi::EabiHf,
             llvm_floatabi: Some(FloatAbi::Hard),
             features: "+strict-align,+v6,+vfp2,-d32".into(),
             max_atomic_width: Some(64),

--- a/compiler/rustc_target/src/spec/targets/arm_unknown_linux_musleabi.rs
+++ b/compiler/rustc_target/src/spec/targets/arm_unknown_linux_musleabi.rs
@@ -1,4 +1,4 @@
-use crate::spec::{Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base};
+use crate::spec::{Abi, Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base};
 
 pub(crate) fn target() -> Target {
     Target {
@@ -13,7 +13,7 @@ pub(crate) fn target() -> Target {
         data_layout: "e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64".into(),
         arch: Arch::Arm,
         options: TargetOptions {
-            abi: "eabi".into(),
+            abi: Abi::Eabi,
             llvm_floatabi: Some(FloatAbi::Soft),
             // Most of these settings are copied from the arm_unknown_linux_gnueabi
             // target.

--- a/compiler/rustc_target/src/spec/targets/arm_unknown_linux_musleabihf.rs
+++ b/compiler/rustc_target/src/spec/targets/arm_unknown_linux_musleabihf.rs
@@ -1,4 +1,4 @@
-use crate::spec::{Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base};
+use crate::spec::{Abi, Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base};
 
 pub(crate) fn target() -> Target {
     Target {
@@ -13,7 +13,7 @@ pub(crate) fn target() -> Target {
         data_layout: "e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64".into(),
         arch: Arch::Arm,
         options: TargetOptions {
-            abi: "eabihf".into(),
+            abi: Abi::EabiHf,
             llvm_floatabi: Some(FloatAbi::Hard),
             // Most of these settings are copied from the arm_unknown_linux_gnueabihf
             // target.

--- a/compiler/rustc_target/src/spec/targets/armeb_unknown_linux_gnueabi.rs
+++ b/compiler/rustc_target/src/spec/targets/armeb_unknown_linux_gnueabi.rs
@@ -1,6 +1,6 @@
 use rustc_abi::Endian;
 
-use crate::spec::{Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base};
+use crate::spec::{Abi, Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base};
 
 pub(crate) fn target() -> Target {
     Target {
@@ -15,7 +15,7 @@ pub(crate) fn target() -> Target {
         data_layout: "E-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64".into(),
         arch: Arch::Arm,
         options: TargetOptions {
-            abi: "eabi".into(),
+            abi: Abi::Eabi,
             llvm_floatabi: Some(FloatAbi::Soft),
             features: "+strict-align,+v8,+crc".into(),
             endian: Endian::Big,

--- a/compiler/rustc_target/src/spec/targets/armebv7r_none_eabi.rs
+++ b/compiler/rustc_target/src/spec/targets/armebv7r_none_eabi.rs
@@ -3,7 +3,7 @@
 use rustc_abi::Endian;
 
 use crate::spec::{
-    Arch, Cc, FloatAbi, LinkerFlavor, Lld, PanicStrategy, RelocModel, Target, TargetMetadata,
+    Abi, Arch, Cc, FloatAbi, LinkerFlavor, Lld, PanicStrategy, RelocModel, Target, TargetMetadata,
     TargetOptions,
 };
 
@@ -20,7 +20,7 @@ pub(crate) fn target() -> Target {
         data_layout: "E-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64".into(),
         arch: Arch::Arm,
         options: TargetOptions {
-            abi: "eabi".into(),
+            abi: Abi::Eabi,
             llvm_floatabi: Some(FloatAbi::Soft),
             endian: Endian::Big,
             linker_flavor: LinkerFlavor::Gnu(Cc::No, Lld::Yes),

--- a/compiler/rustc_target/src/spec/targets/armebv7r_none_eabihf.rs
+++ b/compiler/rustc_target/src/spec/targets/armebv7r_none_eabihf.rs
@@ -3,7 +3,7 @@
 use rustc_abi::Endian;
 
 use crate::spec::{
-    Arch, Cc, FloatAbi, LinkerFlavor, Lld, PanicStrategy, RelocModel, Target, TargetMetadata,
+    Abi, Arch, Cc, FloatAbi, LinkerFlavor, Lld, PanicStrategy, RelocModel, Target, TargetMetadata,
     TargetOptions,
 };
 
@@ -20,7 +20,7 @@ pub(crate) fn target() -> Target {
         data_layout: "E-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64".into(),
         arch: Arch::Arm,
         options: TargetOptions {
-            abi: "eabihf".into(),
+            abi: Abi::EabiHf,
             llvm_floatabi: Some(FloatAbi::Hard),
             endian: Endian::Big,
             linker_flavor: LinkerFlavor::Gnu(Cc::No, Lld::Yes),

--- a/compiler/rustc_target/src/spec/targets/armv4t_none_eabi.rs
+++ b/compiler/rustc_target/src/spec/targets/armv4t_none_eabi.rs
@@ -10,7 +10,7 @@
 //! `-Clink-arg=-Tmy_script.ld` to override that with a correct linker script.
 
 use crate::spec::{
-    Arch, Cc, FloatAbi, LinkerFlavor, Lld, PanicStrategy, RelocModel, Target, TargetMetadata,
+    Abi, Arch, Cc, FloatAbi, LinkerFlavor, Lld, PanicStrategy, RelocModel, Target, TargetMetadata,
     TargetOptions, cvs,
 };
 
@@ -36,7 +36,7 @@ pub(crate) fn target() -> Target {
          */
         data_layout: "e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64".into(),
         options: TargetOptions {
-            abi: "eabi".into(),
+            abi: Abi::Eabi,
             llvm_floatabi: Some(FloatAbi::Soft),
             linker_flavor: LinkerFlavor::Gnu(Cc::No, Lld::Yes),
             linker: Some("rust-lld".into()),

--- a/compiler/rustc_target/src/spec/targets/armv4t_unknown_linux_gnueabi.rs
+++ b/compiler/rustc_target/src/spec/targets/armv4t_unknown_linux_gnueabi.rs
@@ -1,4 +1,4 @@
-use crate::spec::{Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base};
+use crate::spec::{Abi, Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base};
 
 pub(crate) fn target() -> Target {
     Target {
@@ -13,7 +13,7 @@ pub(crate) fn target() -> Target {
         data_layout: "e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64".into(),
         arch: Arch::Arm,
         options: TargetOptions {
-            abi: "eabi".into(),
+            abi: Abi::Eabi,
             llvm_floatabi: Some(FloatAbi::Soft),
             features: "+soft-float,+strict-align".into(),
             // Atomic operations provided by compiler-builtins

--- a/compiler/rustc_target/src/spec/targets/armv5te_none_eabi.rs
+++ b/compiler/rustc_target/src/spec/targets/armv5te_none_eabi.rs
@@ -1,6 +1,8 @@
 //! Targets the ARMv5TE, with code as `a32` code by default.
 
-use crate::spec::{Arch, FloatAbi, FramePointer, Target, TargetMetadata, TargetOptions, base, cvs};
+use crate::spec::{
+    Abi, Arch, FloatAbi, FramePointer, Target, TargetMetadata, TargetOptions, base, cvs,
+};
 
 pub(crate) fn target() -> Target {
     Target {
@@ -25,7 +27,7 @@ pub(crate) fn target() -> Target {
         data_layout: "e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64".into(),
 
         options: TargetOptions {
-            abi: "eabi".into(),
+            abi: Abi::Eabi,
             llvm_floatabi: Some(FloatAbi::Soft),
             // extra args passed to the external assembler (assuming `arm-none-eabi-as`):
             // * activate t32/a32 interworking

--- a/compiler/rustc_target/src/spec/targets/armv5te_unknown_linux_gnueabi.rs
+++ b/compiler/rustc_target/src/spec/targets/armv5te_unknown_linux_gnueabi.rs
@@ -1,4 +1,4 @@
-use crate::spec::{Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base};
+use crate::spec::{Abi, Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base};
 
 pub(crate) fn target() -> Target {
     Target {
@@ -13,7 +13,7 @@ pub(crate) fn target() -> Target {
         data_layout: "e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64".into(),
         arch: Arch::Arm,
         options: TargetOptions {
-            abi: "eabi".into(),
+            abi: Abi::Eabi,
             llvm_floatabi: Some(FloatAbi::Soft),
             features: "+soft-float,+strict-align".into(),
             // Atomic operations provided by compiler-builtins

--- a/compiler/rustc_target/src/spec/targets/armv5te_unknown_linux_musleabi.rs
+++ b/compiler/rustc_target/src/spec/targets/armv5te_unknown_linux_musleabi.rs
@@ -1,4 +1,4 @@
-use crate::spec::{Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base};
+use crate::spec::{Abi, Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base};
 
 pub(crate) fn target() -> Target {
     Target {
@@ -13,7 +13,7 @@ pub(crate) fn target() -> Target {
         data_layout: "e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64".into(),
         arch: Arch::Arm,
         options: TargetOptions {
-            abi: "eabi".into(),
+            abi: Abi::Eabi,
             llvm_floatabi: Some(FloatAbi::Soft),
             features: "+soft-float,+strict-align".into(),
             // Atomic operations provided by compiler-builtins

--- a/compiler/rustc_target/src/spec/targets/armv5te_unknown_linux_uclibceabi.rs
+++ b/compiler/rustc_target/src/spec/targets/armv5te_unknown_linux_uclibceabi.rs
@@ -1,4 +1,4 @@
-use crate::spec::{Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base};
+use crate::spec::{Abi, Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base};
 
 pub(crate) fn target() -> Target {
     Target {
@@ -13,7 +13,7 @@ pub(crate) fn target() -> Target {
         data_layout: "e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64".into(),
         arch: Arch::Arm,
         options: TargetOptions {
-            abi: "eabi".into(),
+            abi: Abi::Eabi,
             llvm_floatabi: Some(FloatAbi::Soft),
             features: "+soft-float,+strict-align".into(),
             // Atomic operations provided by compiler-builtins

--- a/compiler/rustc_target/src/spec/targets/armv6_unknown_freebsd.rs
+++ b/compiler/rustc_target/src/spec/targets/armv6_unknown_freebsd.rs
@@ -1,4 +1,4 @@
-use crate::spec::{Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base};
+use crate::spec::{Abi, Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base};
 
 pub(crate) fn target() -> Target {
     Target {
@@ -13,7 +13,7 @@ pub(crate) fn target() -> Target {
         data_layout: "e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64".into(),
         arch: Arch::Arm,
         options: TargetOptions {
-            abi: "eabihf".into(),
+            abi: Abi::EabiHf,
             llvm_floatabi: Some(FloatAbi::Hard),
             features: "+v6,+vfp2,-d32".into(),
             max_atomic_width: Some(64),

--- a/compiler/rustc_target/src/spec/targets/armv6_unknown_netbsd_eabihf.rs
+++ b/compiler/rustc_target/src/spec/targets/armv6_unknown_netbsd_eabihf.rs
@@ -1,4 +1,4 @@
-use crate::spec::{Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base};
+use crate::spec::{Abi, Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base};
 
 pub(crate) fn target() -> Target {
     Target {
@@ -13,7 +13,7 @@ pub(crate) fn target() -> Target {
         data_layout: "e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64".into(),
         arch: Arch::Arm,
         options: TargetOptions {
-            abi: "eabihf".into(),
+            abi: Abi::EabiHf,
             llvm_floatabi: Some(FloatAbi::Hard),
             features: "+v6,+vfp2,-d32".into(),
             max_atomic_width: Some(64),

--- a/compiler/rustc_target/src/spec/targets/armv6k_nintendo_3ds.rs
+++ b/compiler/rustc_target/src/spec/targets/armv6k_nintendo_3ds.rs
@@ -1,6 +1,6 @@
 use crate::spec::{
-    Abi, Arch, Cc, FloatAbi, LinkerFlavor, Lld, RelocModel, Target, TargetMetadata, TargetOptions,
-    cvs,
+    Abi, Arch, Cc, Env, FloatAbi, LinkerFlavor, Lld, RelocModel, Target, TargetMetadata,
+    TargetOptions, cvs,
 };
 
 /// A base target for Nintendo 3DS devices using the devkitARM toolchain.
@@ -26,7 +26,7 @@ pub(crate) fn target() -> Target {
 
         options: TargetOptions {
             os: "horizon".into(),
-            env: "newlib".into(),
+            env: Env::Newlib,
             vendor: "nintendo".into(),
             cpu: "mpcore".into(),
             abi: Abi::EabiHf,

--- a/compiler/rustc_target/src/spec/targets/armv6k_nintendo_3ds.rs
+++ b/compiler/rustc_target/src/spec/targets/armv6k_nintendo_3ds.rs
@@ -1,5 +1,6 @@
 use crate::spec::{
-    Arch, Cc, FloatAbi, LinkerFlavor, Lld, RelocModel, Target, TargetMetadata, TargetOptions, cvs,
+    Abi, Arch, Cc, FloatAbi, LinkerFlavor, Lld, RelocModel, Target, TargetMetadata, TargetOptions,
+    cvs,
 };
 
 /// A base target for Nintendo 3DS devices using the devkitARM toolchain.
@@ -28,7 +29,7 @@ pub(crate) fn target() -> Target {
             env: "newlib".into(),
             vendor: "nintendo".into(),
             cpu: "mpcore".into(),
-            abi: "eabihf".into(),
+            abi: Abi::EabiHf,
             llvm_floatabi: Some(FloatAbi::Hard),
             families: cvs!["unix"],
             linker: Some("arm-none-eabi-gcc".into()),

--- a/compiler/rustc_target/src/spec/targets/armv6k_nintendo_3ds.rs
+++ b/compiler/rustc_target/src/spec/targets/armv6k_nintendo_3ds.rs
@@ -1,5 +1,5 @@
 use crate::spec::{
-    Abi, Arch, Cc, Env, FloatAbi, LinkerFlavor, Lld, RelocModel, Target, TargetMetadata,
+    Abi, Arch, Cc, Env, FloatAbi, LinkerFlavor, Lld, Os, RelocModel, Target, TargetMetadata,
     TargetOptions, cvs,
 };
 
@@ -25,7 +25,7 @@ pub(crate) fn target() -> Target {
         arch: Arch::Arm,
 
         options: TargetOptions {
-            os: "horizon".into(),
+            os: Os::Horizon,
             env: Env::Newlib,
             vendor: "nintendo".into(),
             cpu: "mpcore".into(),

--- a/compiler/rustc_target/src/spec/targets/armv7_linux_androideabi.rs
+++ b/compiler/rustc_target/src/spec/targets/armv7_linux_androideabi.rs
@@ -1,6 +1,6 @@
 use crate::spec::{
-    Arch, Cc, FloatAbi, LinkerFlavor, Lld, SanitizerSet, Target, TargetMetadata, TargetOptions,
-    base,
+    Abi, Arch, Cc, FloatAbi, LinkerFlavor, Lld, SanitizerSet, Target, TargetMetadata,
+    TargetOptions, base,
 };
 
 // This target if is for the baseline of the Android v7a ABI
@@ -26,7 +26,7 @@ pub(crate) fn target() -> Target {
         data_layout: "e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64".into(),
         arch: Arch::Arm,
         options: TargetOptions {
-            abi: "eabi".into(),
+            abi: Abi::Eabi,
             llvm_floatabi: Some(FloatAbi::Soft),
             features: "+v7,+thumb-mode,+thumb2,+vfp3,-d32,-neon".into(),
             supported_sanitizers: SanitizerSet::ADDRESS,

--- a/compiler/rustc_target/src/spec/targets/armv7_rtems_eabihf.rs
+++ b/compiler/rustc_target/src/spec/targets/armv7_rtems_eabihf.rs
@@ -1,6 +1,6 @@
 use crate::spec::{
-    Abi, Arch, Cc, FloatAbi, LinkerFlavor, Lld, PanicStrategy, RelocModel, Target, TargetMetadata,
-    TargetOptions, cvs,
+    Abi, Arch, Cc, Env, FloatAbi, LinkerFlavor, Lld, PanicStrategy, RelocModel, Target,
+    TargetMetadata, TargetOptions, cvs,
 };
 
 pub(crate) fn target() -> Target {
@@ -32,7 +32,7 @@ pub(crate) fn target() -> Target {
             c_enum_min_bits: Some(8),
             eh_frame_header: false,
             no_default_libraries: false,
-            env: "newlib".into(),
+            env: Env::Newlib,
             ..Default::default()
         },
     }

--- a/compiler/rustc_target/src/spec/targets/armv7_rtems_eabihf.rs
+++ b/compiler/rustc_target/src/spec/targets/armv7_rtems_eabihf.rs
@@ -1,5 +1,5 @@
 use crate::spec::{
-    Arch, Cc, FloatAbi, LinkerFlavor, Lld, PanicStrategy, RelocModel, Target, TargetMetadata,
+    Abi, Arch, Cc, FloatAbi, LinkerFlavor, Lld, PanicStrategy, RelocModel, Target, TargetMetadata,
     TargetOptions, cvs,
 };
 
@@ -19,7 +19,7 @@ pub(crate) fn target() -> Target {
         options: TargetOptions {
             os: "rtems".into(),
             families: cvs!["unix"],
-            abi: "eabihf".into(),
+            abi: Abi::EabiHf,
             llvm_floatabi: Some(FloatAbi::Hard),
             linker_flavor: LinkerFlavor::Gnu(Cc::Yes, Lld::No),
             linker: None,

--- a/compiler/rustc_target/src/spec/targets/armv7_rtems_eabihf.rs
+++ b/compiler/rustc_target/src/spec/targets/armv7_rtems_eabihf.rs
@@ -1,5 +1,5 @@
 use crate::spec::{
-    Abi, Arch, Cc, Env, FloatAbi, LinkerFlavor, Lld, PanicStrategy, RelocModel, Target,
+    Abi, Arch, Cc, Env, FloatAbi, LinkerFlavor, Lld, Os, PanicStrategy, RelocModel, Target,
     TargetMetadata, TargetOptions, cvs,
 };
 
@@ -17,7 +17,7 @@ pub(crate) fn target() -> Target {
         arch: Arch::Arm,
 
         options: TargetOptions {
-            os: "rtems".into(),
+            os: Os::Rtems,
             families: cvs!["unix"],
             abi: Abi::EabiHf,
             llvm_floatabi: Some(FloatAbi::Hard),

--- a/compiler/rustc_target/src/spec/targets/armv7_sony_vita_newlibeabihf.rs
+++ b/compiler/rustc_target/src/spec/targets/armv7_sony_vita_newlibeabihf.rs
@@ -1,8 +1,8 @@
 use rustc_abi::Endian;
 
 use crate::spec::{
-    Abi, Arch, Cc, FloatAbi, LinkerFlavor, Lld, RelocModel, Target, TargetMetadata, TargetOptions,
-    cvs,
+    Abi, Arch, Cc, Env, FloatAbi, LinkerFlavor, Lld, RelocModel, Target, TargetMetadata,
+    TargetOptions, cvs,
 };
 
 /// A base target for PlayStation Vita devices using the VITASDK toolchain (using newlib).
@@ -32,7 +32,7 @@ pub(crate) fn target() -> Target {
             os: "vita".into(),
             endian: Endian::Little,
             c_int_width: 32,
-            env: "newlib".into(),
+            env: Env::Newlib,
             vendor: "sony".into(),
             abi: Abi::EabiHf,
             llvm_floatabi: Some(FloatAbi::Hard),

--- a/compiler/rustc_target/src/spec/targets/armv7_sony_vita_newlibeabihf.rs
+++ b/compiler/rustc_target/src/spec/targets/armv7_sony_vita_newlibeabihf.rs
@@ -1,7 +1,8 @@
 use rustc_abi::Endian;
 
 use crate::spec::{
-    Arch, Cc, FloatAbi, LinkerFlavor, Lld, RelocModel, Target, TargetMetadata, TargetOptions, cvs,
+    Abi, Arch, Cc, FloatAbi, LinkerFlavor, Lld, RelocModel, Target, TargetMetadata, TargetOptions,
+    cvs,
 };
 
 /// A base target for PlayStation Vita devices using the VITASDK toolchain (using newlib).
@@ -33,7 +34,7 @@ pub(crate) fn target() -> Target {
             c_int_width: 32,
             env: "newlib".into(),
             vendor: "sony".into(),
-            abi: "eabihf".into(),
+            abi: Abi::EabiHf,
             llvm_floatabi: Some(FloatAbi::Hard),
             linker_flavor: LinkerFlavor::Gnu(Cc::Yes, Lld::No),
             no_default_libraries: false,

--- a/compiler/rustc_target/src/spec/targets/armv7_sony_vita_newlibeabihf.rs
+++ b/compiler/rustc_target/src/spec/targets/armv7_sony_vita_newlibeabihf.rs
@@ -1,7 +1,7 @@
 use rustc_abi::Endian;
 
 use crate::spec::{
-    Abi, Arch, Cc, Env, FloatAbi, LinkerFlavor, Lld, RelocModel, Target, TargetMetadata,
+    Abi, Arch, Cc, Env, FloatAbi, LinkerFlavor, Lld, Os, RelocModel, Target, TargetMetadata,
     TargetOptions, cvs,
 };
 
@@ -29,7 +29,7 @@ pub(crate) fn target() -> Target {
         arch: Arch::Arm,
 
         options: TargetOptions {
-            os: "vita".into(),
+            os: Os::Vita,
             endian: Endian::Little,
             c_int_width: 32,
             env: Env::Newlib,

--- a/compiler/rustc_target/src/spec/targets/armv7_unknown_freebsd.rs
+++ b/compiler/rustc_target/src/spec/targets/armv7_unknown_freebsd.rs
@@ -1,4 +1,4 @@
-use crate::spec::{Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base};
+use crate::spec::{Abi, Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base};
 
 pub(crate) fn target() -> Target {
     Target {
@@ -13,7 +13,7 @@ pub(crate) fn target() -> Target {
         data_layout: "e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64".into(),
         arch: Arch::Arm,
         options: TargetOptions {
-            abi: "eabihf".into(),
+            abi: Abi::EabiHf,
             llvm_floatabi: Some(FloatAbi::Hard),
             features: "+v7,+vfp3,-d32,+thumb2,-neon".into(),
             max_atomic_width: Some(64),

--- a/compiler/rustc_target/src/spec/targets/armv7_unknown_linux_gnueabi.rs
+++ b/compiler/rustc_target/src/spec/targets/armv7_unknown_linux_gnueabi.rs
@@ -1,4 +1,4 @@
-use crate::spec::{Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base};
+use crate::spec::{Abi, Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base};
 
 // This target is for glibc Linux on ARMv7 without thumb-mode, NEON or
 // hardfloat.
@@ -16,7 +16,7 @@ pub(crate) fn target() -> Target {
         data_layout: "e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64".into(),
         arch: Arch::Arm,
         options: TargetOptions {
-            abi: "eabi".into(),
+            abi: Abi::Eabi,
             llvm_floatabi: Some(FloatAbi::Soft),
             features: "+v7,+thumb2,+soft-float,-neon".into(),
             max_atomic_width: Some(64),

--- a/compiler/rustc_target/src/spec/targets/armv7_unknown_linux_gnueabihf.rs
+++ b/compiler/rustc_target/src/spec/targets/armv7_unknown_linux_gnueabihf.rs
@@ -1,4 +1,4 @@
-use crate::spec::{Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base};
+use crate::spec::{Abi, Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base};
 
 // This target is for glibc Linux on ARMv7 without NEON or
 // thumb-mode. See the thumbv7neon variant for enabling both.
@@ -16,7 +16,7 @@ pub(crate) fn target() -> Target {
         data_layout: "e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64".into(),
         arch: Arch::Arm,
         options: TargetOptions {
-            abi: "eabihf".into(),
+            abi: Abi::EabiHf,
             llvm_floatabi: Some(FloatAbi::Hard),
             // Info about features at https://wiki.debian.org/ArmHardFloatPort
             features: "+v7,+vfp3,-d32,+thumb2,-neon".into(),

--- a/compiler/rustc_target/src/spec/targets/armv7_unknown_linux_musleabi.rs
+++ b/compiler/rustc_target/src/spec/targets/armv7_unknown_linux_musleabi.rs
@@ -1,4 +1,4 @@
-use crate::spec::{Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base};
+use crate::spec::{Abi, Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base};
 
 // This target is for musl Linux on ARMv7 without thumb-mode, NEON or
 // hardfloat.
@@ -19,7 +19,7 @@ pub(crate) fn target() -> Target {
         arch: Arch::Arm,
 
         options: TargetOptions {
-            abi: "eabi".into(),
+            abi: Abi::Eabi,
             llvm_floatabi: Some(FloatAbi::Soft),
             features: "+v7,+thumb2,+soft-float,-neon".into(),
             max_atomic_width: Some(64),

--- a/compiler/rustc_target/src/spec/targets/armv7_unknown_linux_musleabihf.rs
+++ b/compiler/rustc_target/src/spec/targets/armv7_unknown_linux_musleabihf.rs
@@ -1,4 +1,4 @@
-use crate::spec::{Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base};
+use crate::spec::{Abi, Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base};
 
 // This target is for musl Linux on ARMv7 without thumb-mode or NEON.
 
@@ -18,7 +18,7 @@ pub(crate) fn target() -> Target {
         // Most of these settings are copied from the armv7_unknown_linux_gnueabihf
         // target.
         options: TargetOptions {
-            abi: "eabihf".into(),
+            abi: Abi::EabiHf,
             llvm_floatabi: Some(FloatAbi::Hard),
             features: "+v7,+vfp3,-d32,+thumb2,-neon".into(),
             max_atomic_width: Some(64),

--- a/compiler/rustc_target/src/spec/targets/armv7_unknown_linux_ohos.rs
+++ b/compiler/rustc_target/src/spec/targets/armv7_unknown_linux_ohos.rs
@@ -1,4 +1,4 @@
-use crate::spec::{Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base};
+use crate::spec::{Abi, Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base};
 
 // This target is for OpenHarmony on ARMv7 Linux with thumb-mode, but no NEON or
 // hardfloat.
@@ -19,7 +19,7 @@ pub(crate) fn target() -> Target {
         arch: Arch::Arm,
 
         options: TargetOptions {
-            abi: "eabi".into(),
+            abi: Abi::Eabi,
             llvm_floatabi: Some(FloatAbi::Soft),
             features: "+v7,+thumb2,+soft-float,-neon".into(),
             max_atomic_width: Some(64),

--- a/compiler/rustc_target/src/spec/targets/armv7_unknown_linux_uclibceabi.rs
+++ b/compiler/rustc_target/src/spec/targets/armv7_unknown_linux_uclibceabi.rs
@@ -1,4 +1,4 @@
-use crate::spec::{Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base};
+use crate::spec::{Abi, Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base};
 
 // This target is for uclibc Linux on ARMv7 without NEON,
 // thumb-mode or hardfloat.
@@ -18,7 +18,7 @@ pub(crate) fn target() -> Target {
         arch: Arch::Arm,
 
         options: TargetOptions {
-            abi: "eabi".into(),
+            abi: Abi::Eabi,
             llvm_floatabi: Some(FloatAbi::Soft),
             features: "+v7,+thumb2,+soft-float,-neon".into(),
             cpu: "generic".into(),

--- a/compiler/rustc_target/src/spec/targets/armv7_unknown_linux_uclibceabihf.rs
+++ b/compiler/rustc_target/src/spec/targets/armv7_unknown_linux_uclibceabihf.rs
@@ -1,4 +1,4 @@
-use crate::spec::{Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base};
+use crate::spec::{Abi, Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base};
 
 // This target is for uclibc Linux on ARMv7 without NEON or
 // thumb-mode. See the thumbv7neon variant for enabling both.
@@ -23,7 +23,7 @@ pub(crate) fn target() -> Target {
             cpu: "generic".into(),
             max_atomic_width: Some(64),
             mcount: "_mcount".into(),
-            abi: "eabihf".into(),
+            abi: Abi::EabiHf,
             llvm_floatabi: Some(FloatAbi::Hard),
             ..base
         },

--- a/compiler/rustc_target/src/spec/targets/armv7_unknown_netbsd_eabihf.rs
+++ b/compiler/rustc_target/src/spec/targets/armv7_unknown_netbsd_eabihf.rs
@@ -1,4 +1,4 @@
-use crate::spec::{Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base};
+use crate::spec::{Abi, Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base};
 
 pub(crate) fn target() -> Target {
     Target {
@@ -13,7 +13,7 @@ pub(crate) fn target() -> Target {
         data_layout: "e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64".into(),
         arch: Arch::Arm,
         options: TargetOptions {
-            abi: "eabihf".into(),
+            abi: Abi::EabiHf,
             llvm_floatabi: Some(FloatAbi::Hard),
             features: "+v7,+vfp3,-d32,+thumb2,-neon".into(),
             max_atomic_width: Some(64),

--- a/compiler/rustc_target/src/spec/targets/armv7_unknown_trusty.rs
+++ b/compiler/rustc_target/src/spec/targets/armv7_unknown_trusty.rs
@@ -1,6 +1,6 @@
 use crate::spec::{
-    Arch, FloatAbi, LinkSelfContainedDefault, PanicStrategy, RelroLevel, Target, TargetMetadata,
-    TargetOptions,
+    Abi, Arch, FloatAbi, LinkSelfContainedDefault, PanicStrategy, RelroLevel, Target,
+    TargetMetadata, TargetOptions,
 };
 
 pub(crate) fn target() -> Target {
@@ -19,7 +19,7 @@ pub(crate) fn target() -> Target {
         data_layout: "e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64".into(),
         arch: Arch::Arm,
         options: TargetOptions {
-            abi: "eabi".into(),
+            abi: Abi::Eabi,
             llvm_floatabi: Some(FloatAbi::Soft),
             features: "+v7,+thumb2,+soft-float,-neon".into(),
             max_atomic_width: Some(64),

--- a/compiler/rustc_target/src/spec/targets/armv7_unknown_trusty.rs
+++ b/compiler/rustc_target/src/spec/targets/armv7_unknown_trusty.rs
@@ -1,5 +1,5 @@
 use crate::spec::{
-    Abi, Arch, FloatAbi, LinkSelfContainedDefault, PanicStrategy, RelroLevel, Target,
+    Abi, Arch, FloatAbi, LinkSelfContainedDefault, Os, PanicStrategy, RelroLevel, Target,
     TargetMetadata, TargetOptions,
 };
 
@@ -24,7 +24,7 @@ pub(crate) fn target() -> Target {
             features: "+v7,+thumb2,+soft-float,-neon".into(),
             max_atomic_width: Some(64),
             mcount: "\u{1}mcount".into(),
-            os: "trusty".into(),
+            os: Os::Trusty,
             link_self_contained: LinkSelfContainedDefault::InferredForMusl,
             dynamic_linking: false,
             executables: true,

--- a/compiler/rustc_target/src/spec/targets/armv7_wrs_vxworks_eabihf.rs
+++ b/compiler/rustc_target/src/spec/targets/armv7_wrs_vxworks_eabihf.rs
@@ -1,4 +1,4 @@
-use crate::spec::{Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base};
+use crate::spec::{Abi, Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base};
 
 pub(crate) fn target() -> Target {
     Target {
@@ -13,7 +13,7 @@ pub(crate) fn target() -> Target {
         data_layout: "e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64".into(),
         arch: Arch::Arm,
         options: TargetOptions {
-            abi: "eabihf".into(),
+            abi: Abi::EabiHf,
             llvm_floatabi: Some(FloatAbi::Hard),
             // Info about features at https://wiki.debian.org/ArmHardFloatPort
             features: "+v7,+vfp3,-d32,+thumb2,-neon".into(),

--- a/compiler/rustc_target/src/spec/targets/armv7a_kmc_solid_asp3_eabi.rs
+++ b/compiler/rustc_target/src/spec/targets/armv7a_kmc_solid_asp3_eabi.rs
@@ -1,7 +1,7 @@
 use crate::spec::{Abi, Arch, FloatAbi, RelocModel, Target, TargetMetadata, TargetOptions, base};
 
 pub(crate) fn target() -> Target {
-    let base = base::solid::opts("asp3");
+    let base = base::solid::opts();
     Target {
         llvm_target: "armv7a-none-eabi".into(),
         metadata: TargetMetadata {

--- a/compiler/rustc_target/src/spec/targets/armv7a_kmc_solid_asp3_eabi.rs
+++ b/compiler/rustc_target/src/spec/targets/armv7a_kmc_solid_asp3_eabi.rs
@@ -1,4 +1,4 @@
-use crate::spec::{Arch, FloatAbi, RelocModel, Target, TargetMetadata, TargetOptions, base};
+use crate::spec::{Abi, Arch, FloatAbi, RelocModel, Target, TargetMetadata, TargetOptions, base};
 
 pub(crate) fn target() -> Target {
     let base = base::solid::opts("asp3");
@@ -14,7 +14,7 @@ pub(crate) fn target() -> Target {
         data_layout: "e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64".into(),
         arch: Arch::Arm,
         options: TargetOptions {
-            abi: "eabi".into(),
+            abi: Abi::Eabi,
             llvm_floatabi: Some(FloatAbi::Soft),
             linker: Some("arm-kmc-eabi-gcc".into()),
             features: "+v7,+soft-float,+thumb2,-neon".into(),

--- a/compiler/rustc_target/src/spec/targets/armv7a_kmc_solid_asp3_eabihf.rs
+++ b/compiler/rustc_target/src/spec/targets/armv7a_kmc_solid_asp3_eabihf.rs
@@ -1,4 +1,4 @@
-use crate::spec::{Arch, FloatAbi, RelocModel, Target, TargetMetadata, TargetOptions, base};
+use crate::spec::{Abi, Arch, FloatAbi, RelocModel, Target, TargetMetadata, TargetOptions, base};
 
 pub(crate) fn target() -> Target {
     let base = base::solid::opts("asp3");
@@ -14,7 +14,7 @@ pub(crate) fn target() -> Target {
         data_layout: "e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64".into(),
         arch: Arch::Arm,
         options: TargetOptions {
-            abi: "eabihf".into(),
+            abi: Abi::EabiHf,
             llvm_floatabi: Some(FloatAbi::Hard),
             linker: Some("arm-kmc-eabi-gcc".into()),
             features: "+v7,+vfp3,-d32,+thumb2,-neon".into(),

--- a/compiler/rustc_target/src/spec/targets/armv7a_kmc_solid_asp3_eabihf.rs
+++ b/compiler/rustc_target/src/spec/targets/armv7a_kmc_solid_asp3_eabihf.rs
@@ -1,7 +1,7 @@
 use crate::spec::{Abi, Arch, FloatAbi, RelocModel, Target, TargetMetadata, TargetOptions, base};
 
 pub(crate) fn target() -> Target {
-    let base = base::solid::opts("asp3");
+    let base = base::solid::opts();
     Target {
         llvm_target: "armv7a-none-eabihf".into(),
         metadata: TargetMetadata {

--- a/compiler/rustc_target/src/spec/targets/armv7a_none_eabi.rs
+++ b/compiler/rustc_target/src/spec/targets/armv7a_none_eabi.rs
@@ -15,13 +15,13 @@
 // linking. rationale: matches `thumb` targets
 
 use crate::spec::{
-    Arch, Cc, FloatAbi, LinkerFlavor, Lld, PanicStrategy, RelocModel, Target, TargetMetadata,
+    Abi, Arch, Cc, FloatAbi, LinkerFlavor, Lld, PanicStrategy, RelocModel, Target, TargetMetadata,
     TargetOptions,
 };
 
 pub(crate) fn target() -> Target {
     let opts = TargetOptions {
-        abi: "eabi".into(),
+        abi: Abi::Eabi,
         llvm_floatabi: Some(FloatAbi::Soft),
         linker_flavor: LinkerFlavor::Gnu(Cc::No, Lld::Yes),
         linker: Some("rust-lld".into()),

--- a/compiler/rustc_target/src/spec/targets/armv7a_none_eabihf.rs
+++ b/compiler/rustc_target/src/spec/targets/armv7a_none_eabihf.rs
@@ -6,13 +6,13 @@
 // `thumb` & `aarch64` targets.
 
 use crate::spec::{
-    Arch, Cc, FloatAbi, LinkerFlavor, Lld, PanicStrategy, RelocModel, Target, TargetMetadata,
+    Abi, Arch, Cc, FloatAbi, LinkerFlavor, Lld, PanicStrategy, RelocModel, Target, TargetMetadata,
     TargetOptions,
 };
 
 pub(crate) fn target() -> Target {
     let opts = TargetOptions {
-        abi: "eabihf".into(),
+        abi: Abi::EabiHf,
         llvm_floatabi: Some(FloatAbi::Hard),
         linker_flavor: LinkerFlavor::Gnu(Cc::No, Lld::Yes),
         linker: Some("rust-lld".into()),

--- a/compiler/rustc_target/src/spec/targets/armv7a_nuttx_eabi.rs
+++ b/compiler/rustc_target/src/spec/targets/armv7a_nuttx_eabi.rs
@@ -5,13 +5,13 @@
 // configuration without hardware floating point support.
 
 use crate::spec::{
-    Arch, Cc, FloatAbi, LinkerFlavor, Lld, PanicStrategy, RelocModel, Target, TargetMetadata,
+    Abi, Arch, Cc, FloatAbi, LinkerFlavor, Lld, PanicStrategy, RelocModel, Target, TargetMetadata,
     TargetOptions, cvs,
 };
 
 pub(crate) fn target() -> Target {
     let opts = TargetOptions {
-        abi: "eabi".into(),
+        abi: Abi::Eabi,
         llvm_floatabi: Some(FloatAbi::Soft),
         linker_flavor: LinkerFlavor::Gnu(Cc::No, Lld::Yes),
         linker: Some("rust-lld".into()),

--- a/compiler/rustc_target/src/spec/targets/armv7a_nuttx_eabi.rs
+++ b/compiler/rustc_target/src/spec/targets/armv7a_nuttx_eabi.rs
@@ -5,8 +5,8 @@
 // configuration without hardware floating point support.
 
 use crate::spec::{
-    Abi, Arch, Cc, FloatAbi, LinkerFlavor, Lld, PanicStrategy, RelocModel, Target, TargetMetadata,
-    TargetOptions, cvs,
+    Abi, Arch, Cc, FloatAbi, LinkerFlavor, Lld, Os, PanicStrategy, RelocModel, Target,
+    TargetMetadata, TargetOptions, cvs,
 };
 
 pub(crate) fn target() -> Target {
@@ -23,7 +23,7 @@ pub(crate) fn target() -> Target {
         emit_debug_gdb_scripts: false,
         c_enum_min_bits: Some(8),
         families: cvs!["unix"],
-        os: "nuttx".into(),
+        os: Os::NuttX,
         ..Default::default()
     };
     Target {

--- a/compiler/rustc_target/src/spec/targets/armv7a_nuttx_eabihf.rs
+++ b/compiler/rustc_target/src/spec/targets/armv7a_nuttx_eabihf.rs
@@ -5,8 +5,8 @@
 // configuration with hardware floating point support.
 
 use crate::spec::{
-    Abi, Arch, Cc, FloatAbi, LinkerFlavor, Lld, PanicStrategy, RelocModel, Target, TargetMetadata,
-    TargetOptions, cvs,
+    Abi, Arch, Cc, FloatAbi, LinkerFlavor, Lld, Os, PanicStrategy, RelocModel, Target,
+    TargetMetadata, TargetOptions, cvs,
 };
 
 pub(crate) fn target() -> Target {
@@ -23,7 +23,7 @@ pub(crate) fn target() -> Target {
         emit_debug_gdb_scripts: false,
         c_enum_min_bits: Some(8),
         families: cvs!["unix"],
-        os: "nuttx".into(),
+        os: Os::NuttX,
         ..Default::default()
     };
     Target {

--- a/compiler/rustc_target/src/spec/targets/armv7a_nuttx_eabihf.rs
+++ b/compiler/rustc_target/src/spec/targets/armv7a_nuttx_eabihf.rs
@@ -5,13 +5,13 @@
 // configuration with hardware floating point support.
 
 use crate::spec::{
-    Arch, Cc, FloatAbi, LinkerFlavor, Lld, PanicStrategy, RelocModel, Target, TargetMetadata,
+    Abi, Arch, Cc, FloatAbi, LinkerFlavor, Lld, PanicStrategy, RelocModel, Target, TargetMetadata,
     TargetOptions, cvs,
 };
 
 pub(crate) fn target() -> Target {
     let opts = TargetOptions {
-        abi: "eabihf".into(),
+        abi: Abi::EabiHf,
         llvm_floatabi: Some(FloatAbi::Hard),
         linker_flavor: LinkerFlavor::Gnu(Cc::No, Lld::Yes),
         linker: Some("rust-lld".into()),

--- a/compiler/rustc_target/src/spec/targets/armv7a_vex_v5.rs
+++ b/compiler/rustc_target/src/spec/targets/armv7a_vex_v5.rs
@@ -1,5 +1,5 @@
 use crate::spec::{
-    Arch, Cc, FloatAbi, LinkerFlavor, Lld, PanicStrategy, RelocModel, Target, TargetMetadata,
+    Abi, Arch, Cc, FloatAbi, LinkerFlavor, Lld, PanicStrategy, RelocModel, Target, TargetMetadata,
     TargetOptions,
 };
 
@@ -11,7 +11,7 @@ pub(crate) fn target() -> Target {
         env: "v5".into(),
         os: "vexos".into(),
         cpu: "cortex-a9".into(),
-        abi: "eabihf".into(),
+        abi: Abi::EabiHf,
         is_like_vexos: true,
         llvm_floatabi: Some(FloatAbi::Hard),
         linker_flavor: LinkerFlavor::Gnu(Cc::No, Lld::Yes),

--- a/compiler/rustc_target/src/spec/targets/armv7a_vex_v5.rs
+++ b/compiler/rustc_target/src/spec/targets/armv7a_vex_v5.rs
@@ -1,5 +1,5 @@
 use crate::spec::{
-    Abi, Arch, Cc, Env, FloatAbi, LinkerFlavor, Lld, PanicStrategy, RelocModel, Target,
+    Abi, Arch, Cc, Env, FloatAbi, LinkerFlavor, Lld, Os, PanicStrategy, RelocModel, Target,
     TargetMetadata, TargetOptions,
 };
 
@@ -9,7 +9,7 @@ pub(crate) fn target() -> Target {
     let opts = TargetOptions {
         vendor: "vex".into(),
         env: Env::V5,
-        os: "vexos".into(),
+        os: Os::VexOs,
         cpu: "cortex-a9".into(),
         abi: Abi::EabiHf,
         is_like_vexos: true,

--- a/compiler/rustc_target/src/spec/targets/armv7a_vex_v5.rs
+++ b/compiler/rustc_target/src/spec/targets/armv7a_vex_v5.rs
@@ -1,6 +1,6 @@
 use crate::spec::{
-    Abi, Arch, Cc, FloatAbi, LinkerFlavor, Lld, PanicStrategy, RelocModel, Target, TargetMetadata,
-    TargetOptions,
+    Abi, Arch, Cc, Env, FloatAbi, LinkerFlavor, Lld, PanicStrategy, RelocModel, Target,
+    TargetMetadata, TargetOptions,
 };
 
 const LINKER_SCRIPT: &str = include_str!("./armv7a_vex_v5_linker_script.ld");
@@ -8,7 +8,7 @@ const LINKER_SCRIPT: &str = include_str!("./armv7a_vex_v5_linker_script.ld");
 pub(crate) fn target() -> Target {
     let opts = TargetOptions {
         vendor: "vex".into(),
-        env: "v5".into(),
+        env: Env::V5,
         os: "vexos".into(),
         cpu: "cortex-a9".into(),
         abi: Abi::EabiHf,

--- a/compiler/rustc_target/src/spec/targets/armv7k_apple_watchos.rs
+++ b/compiler/rustc_target/src/spec/targets/armv7k_apple_watchos.rs
@@ -1,8 +1,8 @@
 use crate::spec::base::apple::{Arch, TargetEnv, base};
-use crate::spec::{Target, TargetMetadata, TargetOptions};
+use crate::spec::{Os, Target, TargetMetadata, TargetOptions};
 
 pub(crate) fn target() -> Target {
-    let (opts, llvm_target, arch) = base("watchos", Arch::Armv7k, TargetEnv::Normal);
+    let (opts, llvm_target, arch) = base(Os::WatchOs, Arch::Armv7k, TargetEnv::Normal);
     Target {
         llvm_target,
         metadata: TargetMetadata {

--- a/compiler/rustc_target/src/spec/targets/armv7r_none_eabi.rs
+++ b/compiler/rustc_target/src/spec/targets/armv7r_none_eabi.rs
@@ -1,7 +1,7 @@
 // Targets the Little-endian Cortex-R4/R5 processor (ARMv7-R)
 
 use crate::spec::{
-    Arch, Cc, FloatAbi, LinkerFlavor, Lld, PanicStrategy, RelocModel, Target, TargetMetadata,
+    Abi, Arch, Cc, FloatAbi, LinkerFlavor, Lld, PanicStrategy, RelocModel, Target, TargetMetadata,
     TargetOptions,
 };
 
@@ -19,7 +19,7 @@ pub(crate) fn target() -> Target {
         arch: Arch::Arm,
 
         options: TargetOptions {
-            abi: "eabi".into(),
+            abi: Abi::Eabi,
             llvm_floatabi: Some(FloatAbi::Soft),
             linker_flavor: LinkerFlavor::Gnu(Cc::No, Lld::Yes),
             linker: Some("rust-lld".into()),

--- a/compiler/rustc_target/src/spec/targets/armv7r_none_eabihf.rs
+++ b/compiler/rustc_target/src/spec/targets/armv7r_none_eabihf.rs
@@ -1,7 +1,7 @@
 // Targets the Little-endian Cortex-R4F/R5F processor (ARMv7-R)
 
 use crate::spec::{
-    Arch, Cc, FloatAbi, LinkerFlavor, Lld, PanicStrategy, RelocModel, Target, TargetMetadata,
+    Abi, Arch, Cc, FloatAbi, LinkerFlavor, Lld, PanicStrategy, RelocModel, Target, TargetMetadata,
     TargetOptions,
 };
 
@@ -19,7 +19,7 @@ pub(crate) fn target() -> Target {
         arch: Arch::Arm,
 
         options: TargetOptions {
-            abi: "eabihf".into(),
+            abi: Abi::EabiHf,
             llvm_floatabi: Some(FloatAbi::Hard),
             linker_flavor: LinkerFlavor::Gnu(Cc::No, Lld::Yes),
             linker: Some("rust-lld".into()),

--- a/compiler/rustc_target/src/spec/targets/armv7s_apple_ios.rs
+++ b/compiler/rustc_target/src/spec/targets/armv7s_apple_ios.rs
@@ -1,8 +1,8 @@
 use crate::spec::base::apple::{Arch, TargetEnv, base};
-use crate::spec::{Target, TargetMetadata, TargetOptions};
+use crate::spec::{Os, Target, TargetMetadata, TargetOptions};
 
 pub(crate) fn target() -> Target {
-    let (opts, llvm_target, arch) = base("ios", Arch::Armv7s, TargetEnv::Normal);
+    let (opts, llvm_target, arch) = base(Os::IOs, Arch::Armv7s, TargetEnv::Normal);
     Target {
         llvm_target,
         metadata: TargetMetadata {

--- a/compiler/rustc_target/src/spec/targets/armv8r_none_eabihf.rs
+++ b/compiler/rustc_target/src/spec/targets/armv8r_none_eabihf.rs
@@ -1,7 +1,7 @@
 // Targets the Little-endian Cortex-R52 processor (ARMv8-R)
 
 use crate::spec::{
-    Arch, Cc, FloatAbi, LinkerFlavor, Lld, PanicStrategy, RelocModel, Target, TargetMetadata,
+    Abi, Arch, Cc, FloatAbi, LinkerFlavor, Lld, PanicStrategy, RelocModel, Target, TargetMetadata,
     TargetOptions,
 };
 
@@ -19,7 +19,7 @@ pub(crate) fn target() -> Target {
         arch: Arch::Arm,
 
         options: TargetOptions {
-            abi: "eabihf".into(),
+            abi: Abi::EabiHf,
             llvm_floatabi: Some(FloatAbi::Hard),
             linker_flavor: LinkerFlavor::Gnu(Cc::No, Lld::Yes),
             linker: Some("rust-lld".into()),

--- a/compiler/rustc_target/src/spec/targets/csky_unknown_linux_gnuabiv2.rs
+++ b/compiler/rustc_target/src/spec/targets/csky_unknown_linux_gnuabiv2.rs
@@ -1,4 +1,4 @@
-use crate::spec::{Arch, Cc, LinkerFlavor, Lld, Target, TargetMetadata, TargetOptions, base};
+use crate::spec::{Abi, Arch, Cc, LinkerFlavor, Lld, Target, TargetMetadata, TargetOptions, base};
 
 // This target is for glibc Linux on Csky
 
@@ -16,7 +16,7 @@ pub(crate) fn target() -> Target {
         data_layout: "e-m:e-S32-p:32:32-i32:32:32-i64:32:32-f32:32:32-f64:32:32-v64:32:32-v128:32:32-a:0:32-Fi32-n32".into(),
         arch: Arch::CSky,
         options: TargetOptions {
-            abi: "abiv2".into(),
+            abi: Abi::AbiV2,
             features: "+2e3,+3e7,+7e10,+cache,+dsp1e2,+dspe60,+e1,+e2,+edsp,+elrw,+hard-tp,+high-registers,+hwdiv,+mp,+mp1e2,+nvic,+trust".into(),
             late_link_args: TargetOptions::link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &["-l:libatomic.a"]),
             max_atomic_width: Some(32),

--- a/compiler/rustc_target/src/spec/targets/csky_unknown_linux_gnuabiv2hf.rs
+++ b/compiler/rustc_target/src/spec/targets/csky_unknown_linux_gnuabiv2hf.rs
@@ -1,4 +1,4 @@
-use crate::spec::{Arch, Cc, LinkerFlavor, Lld, Target, TargetMetadata, TargetOptions, base};
+use crate::spec::{Abi, Arch, Cc, LinkerFlavor, Lld, Target, TargetMetadata, TargetOptions, base};
 
 // This target is for glibc Linux on Csky
 
@@ -16,7 +16,7 @@ pub(crate) fn target() -> Target {
         data_layout: "e-m:e-S32-p:32:32-i32:32:32-i64:32:32-f32:32:32-f64:32:32-v64:32:32-v128:32:32-a:0:32-Fi32-n32".into(),
         arch: Arch::CSky,
         options: TargetOptions {
-            abi: "abiv2hf".into(),
+            abi: Abi::AbiV2Hf,
             cpu: "ck860fv".into(),
             features: "+hard-float,+hard-float-abi,+2e3,+3e7,+7e10,+cache,+dsp1e2,+dspe60,+e1,+e2,+edsp,+elrw,+hard-tp,+high-registers,+hwdiv,+mp,+mp1e2,+nvic,+trust".into(),
             late_link_args: TargetOptions::link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &["-l:libatomic.a", "-mhard-float"]),

--- a/compiler/rustc_target/src/spec/targets/i386_apple_ios.rs
+++ b/compiler/rustc_target/src/spec/targets/i386_apple_ios.rs
@@ -1,10 +1,10 @@
 use crate::spec::base::apple::{Arch, TargetEnv, base};
-use crate::spec::{Target, TargetMetadata, TargetOptions};
+use crate::spec::{Os, Target, TargetMetadata, TargetOptions};
 
 pub(crate) fn target() -> Target {
     // i386-apple-ios is a simulator target, even though it isn't declared
     // that way in the target name like the other ones...
-    let (opts, llvm_target, arch) = base("ios", Arch::I386, TargetEnv::Simulator);
+    let (opts, llvm_target, arch) = base(Os::IOs, Arch::I386, TargetEnv::Simulator);
     Target {
         llvm_target,
         metadata: TargetMetadata {

--- a/compiler/rustc_target/src/spec/targets/i686_apple_darwin.rs
+++ b/compiler/rustc_target/src/spec/targets/i686_apple_darwin.rs
@@ -1,8 +1,8 @@
 use crate::spec::base::apple::{Arch, TargetEnv, base};
-use crate::spec::{Target, TargetMetadata, TargetOptions};
+use crate::spec::{Os, Target, TargetMetadata, TargetOptions};
 
 pub(crate) fn target() -> Target {
-    let (opts, llvm_target, arch) = base("macos", Arch::I686, TargetEnv::Normal);
+    let (opts, llvm_target, arch) = base(Os::MacOs, Arch::I686, TargetEnv::Normal);
     Target {
         llvm_target,
         metadata: TargetMetadata {

--- a/compiler/rustc_target/src/spec/targets/i686_pc_nto_qnx700.rs
+++ b/compiler/rustc_target/src/spec/targets/i686_pc_nto_qnx700.rs
@@ -1,5 +1,5 @@
 use crate::spec::base::nto_qnx;
-use crate::spec::{Arch, RustcAbi, StackProbeType, Target, TargetOptions, base};
+use crate::spec::{Arch, Env, RustcAbi, StackProbeType, Target, TargetOptions, base};
 
 pub(crate) fn target() -> Target {
     let mut meta = nto_qnx::meta();
@@ -21,7 +21,7 @@ pub(crate) fn target() -> Target {
                 nto_qnx::ApiVariant::Default,
                 nto_qnx::Arch::I586,
             ),
-            env: "nto70".into(),
+            env: Env::Nto70,
             vendor: "pc".into(),
             stack_probes: StackProbeType::Inline,
             ..base::nto_qnx::opts()

--- a/compiler/rustc_target/src/spec/targets/loongarch32_unknown_none_softfloat.rs
+++ b/compiler/rustc_target/src/spec/targets/loongarch32_unknown_none_softfloat.rs
@@ -1,5 +1,6 @@
 use crate::spec::{
-    Arch, Cc, LinkerFlavor, Lld, PanicStrategy, RelocModel, Target, TargetMetadata, TargetOptions,
+    Abi, Arch, Cc, LinkerFlavor, Lld, PanicStrategy, RelocModel, Target, TargetMetadata,
+    TargetOptions,
 };
 
 pub(crate) fn target() -> Target {
@@ -17,7 +18,7 @@ pub(crate) fn target() -> Target {
         options: TargetOptions {
             cpu: "generic".into(),
             features: "-f,-d".into(),
-            abi: "softfloat".into(),
+            abi: Abi::SoftFloat,
             linker_flavor: LinkerFlavor::Gnu(Cc::No, Lld::Yes),
             linker: Some("rust-lld".into()),
             llvm_abiname: "ilp32s".into(),

--- a/compiler/rustc_target/src/spec/targets/loongarch64_unknown_none_softfloat.rs
+++ b/compiler/rustc_target/src/spec/targets/loongarch64_unknown_none_softfloat.rs
@@ -1,5 +1,5 @@
 use crate::spec::{
-    Arch, Cc, CodeModel, LinkerFlavor, Lld, PanicStrategy, RelocModel, Target, TargetMetadata,
+    Abi, Arch, Cc, CodeModel, LinkerFlavor, Lld, PanicStrategy, RelocModel, Target, TargetMetadata,
     TargetOptions,
 };
 
@@ -18,7 +18,7 @@ pub(crate) fn target() -> Target {
         options: TargetOptions {
             cpu: "generic".into(),
             features: "-f,-d".into(),
-            abi: "softfloat".into(),
+            abi: Abi::SoftFloat,
             linker_flavor: LinkerFlavor::Gnu(Cc::No, Lld::Yes),
             linker: Some("rust-lld".into()),
             llvm_abiname: "lp64s".into(),

--- a/compiler/rustc_target/src/spec/targets/mips64_openwrt_linux_musl.rs
+++ b/compiler/rustc_target/src/spec/targets/mips64_openwrt_linux_musl.rs
@@ -2,7 +2,7 @@
 
 use rustc_abi::Endian;
 
-use crate::spec::{Arch, Target, TargetMetadata, TargetOptions, base};
+use crate::spec::{Abi, Arch, Target, TargetMetadata, TargetOptions, base};
 
 pub(crate) fn target() -> Target {
     let mut base = base::linux_musl::opts();
@@ -24,7 +24,7 @@ pub(crate) fn target() -> Target {
         arch: Arch::Mips64,
         options: TargetOptions {
             vendor: "openwrt".into(),
-            abi: "abi64".into(),
+            abi: Abi::Abi64,
             endian: Endian::Big,
             mcount: "_mcount".into(),
             llvm_abiname: "n64".into(),

--- a/compiler/rustc_target/src/spec/targets/mips64_unknown_linux_gnuabi64.rs
+++ b/compiler/rustc_target/src/spec/targets/mips64_unknown_linux_gnuabi64.rs
@@ -1,6 +1,6 @@
 use rustc_abi::Endian;
 
-use crate::spec::{Arch, Target, TargetMetadata, TargetOptions, base};
+use crate::spec::{Abi, Arch, Target, TargetMetadata, TargetOptions, base};
 
 pub(crate) fn target() -> Target {
     Target {
@@ -15,7 +15,7 @@ pub(crate) fn target() -> Target {
         data_layout: "E-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128".into(),
         arch: Arch::Mips64,
         options: TargetOptions {
-            abi: "abi64".into(),
+            abi: Abi::Abi64,
             endian: Endian::Big,
             // NOTE(mips64r2) matches C toolchain
             cpu: "mips64r2".into(),

--- a/compiler/rustc_target/src/spec/targets/mips64_unknown_linux_muslabi64.rs
+++ b/compiler/rustc_target/src/spec/targets/mips64_unknown_linux_muslabi64.rs
@@ -1,6 +1,6 @@
 use rustc_abi::Endian;
 
-use crate::spec::{Arch, Target, TargetMetadata, TargetOptions, base};
+use crate::spec::{Abi, Arch, Target, TargetMetadata, TargetOptions, base};
 
 pub(crate) fn target() -> Target {
     let mut base = base::linux_musl::opts();
@@ -20,7 +20,7 @@ pub(crate) fn target() -> Target {
         data_layout: "E-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128".into(),
         arch: Arch::Mips64,
         options: TargetOptions {
-            abi: "abi64".into(),
+            abi: Abi::Abi64,
             endian: Endian::Big,
             mcount: "_mcount".into(),
             llvm_abiname: "n64".into(),

--- a/compiler/rustc_target/src/spec/targets/mips64el_unknown_linux_gnuabi64.rs
+++ b/compiler/rustc_target/src/spec/targets/mips64el_unknown_linux_gnuabi64.rs
@@ -1,4 +1,4 @@
-use crate::spec::{Arch, Target, TargetMetadata, TargetOptions, base};
+use crate::spec::{Abi, Arch, Target, TargetMetadata, TargetOptions, base};
 
 pub(crate) fn target() -> Target {
     Target {
@@ -13,7 +13,7 @@ pub(crate) fn target() -> Target {
         data_layout: "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128".into(),
         arch: Arch::Mips64,
         options: TargetOptions {
-            abi: "abi64".into(),
+            abi: Abi::Abi64,
             // NOTE(mips64r2) matches C toolchain
             cpu: "mips64r2".into(),
             features: "+mips64r2,+xgot".into(),

--- a/compiler/rustc_target/src/spec/targets/mips64el_unknown_linux_muslabi64.rs
+++ b/compiler/rustc_target/src/spec/targets/mips64el_unknown_linux_muslabi64.rs
@@ -1,4 +1,4 @@
-use crate::spec::{Arch, Target, TargetMetadata, TargetOptions, base};
+use crate::spec::{Abi, Arch, Target, TargetMetadata, TargetOptions, base};
 
 pub(crate) fn target() -> Target {
     let mut base = base::linux_musl::opts();
@@ -18,7 +18,7 @@ pub(crate) fn target() -> Target {
         data_layout: "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128".into(),
         arch: Arch::Mips64,
         options: TargetOptions {
-            abi: "abi64".into(),
+            abi: Abi::Abi64,
             mcount: "_mcount".into(),
             llvm_abiname: "n64".into(),
             ..base

--- a/compiler/rustc_target/src/spec/targets/mipsel_sony_psp.rs
+++ b/compiler/rustc_target/src/spec/targets/mipsel_sony_psp.rs
@@ -1,5 +1,5 @@
 use crate::spec::{
-    Arch, Cc, LinkerFlavor, Lld, RelocModel, Target, TargetMetadata, TargetOptions, cvs,
+    Arch, Cc, LinkerFlavor, Lld, Os, RelocModel, Target, TargetMetadata, TargetOptions, cvs,
 };
 
 // The PSP has custom linker requirements.
@@ -24,7 +24,7 @@ pub(crate) fn target() -> Target {
         arch: Arch::Mips,
 
         options: TargetOptions {
-            os: "psp".into(),
+            os: Os::Psp,
             vendor: "sony".into(),
             linker_flavor: LinkerFlavor::Gnu(Cc::No, Lld::Yes),
             cpu: "mips2".into(),

--- a/compiler/rustc_target/src/spec/targets/mipsel_sony_psx.rs
+++ b/compiler/rustc_target/src/spec/targets/mipsel_sony_psx.rs
@@ -1,6 +1,6 @@
 use crate::spec::{
-    Arch, Cc, LinkerFlavor, Lld, PanicStrategy, RelocModel, Target, TargetMetadata, TargetOptions,
-    cvs,
+    Arch, Cc, LinkerFlavor, Lld, Os, PanicStrategy, RelocModel, Target, TargetMetadata,
+    TargetOptions, cvs,
 };
 
 pub(crate) fn target() -> Target {
@@ -21,7 +21,7 @@ pub(crate) fn target() -> Target {
             // of functionality post load, so we still declare it as `cfg!(target_os = "psx")`.
             //
             // See <https://github.com/rust-lang/rust/pull/131168> for details.
-            os: "psx".into(),
+            os: Os::Psx,
             vendor: "sony".into(),
             linker_flavor: LinkerFlavor::Gnu(Cc::No, Lld::Yes),
             cpu: "mips1".into(),

--- a/compiler/rustc_target/src/spec/targets/mipsisa64r6_unknown_linux_gnuabi64.rs
+++ b/compiler/rustc_target/src/spec/targets/mipsisa64r6_unknown_linux_gnuabi64.rs
@@ -1,6 +1,6 @@
 use rustc_abi::Endian;
 
-use crate::spec::{Arch, Target, TargetMetadata, TargetOptions, base};
+use crate::spec::{Abi, Arch, Target, TargetMetadata, TargetOptions, base};
 
 pub(crate) fn target() -> Target {
     Target {
@@ -15,7 +15,7 @@ pub(crate) fn target() -> Target {
         data_layout: "E-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128".into(),
         arch: Arch::Mips64r6,
         options: TargetOptions {
-            abi: "abi64".into(),
+            abi: Abi::Abi64,
             endian: Endian::Big,
             // NOTE(mips64r6) matches C toolchain
             cpu: "mips64r6".into(),

--- a/compiler/rustc_target/src/spec/targets/mipsisa64r6el_unknown_linux_gnuabi64.rs
+++ b/compiler/rustc_target/src/spec/targets/mipsisa64r6el_unknown_linux_gnuabi64.rs
@@ -1,4 +1,4 @@
-use crate::spec::{Arch, Target, TargetMetadata, TargetOptions, base};
+use crate::spec::{Abi, Arch, Target, TargetMetadata, TargetOptions, base};
 
 pub(crate) fn target() -> Target {
     Target {
@@ -13,7 +13,7 @@ pub(crate) fn target() -> Target {
         data_layout: "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128".into(),
         arch: Arch::Mips64r6,
         options: TargetOptions {
-            abi: "abi64".into(),
+            abi: Abi::Abi64,
             // NOTE(mips64r6) matches C toolchain
             cpu: "mips64r6".into(),
             features: "+mips64r6".into(),

--- a/compiler/rustc_target/src/spec/targets/nvptx64_nvidia_cuda.rs
+++ b/compiler/rustc_target/src/spec/targets/nvptx64_nvidia_cuda.rs
@@ -1,5 +1,5 @@
 use crate::spec::{
-    Arch, LinkSelfContainedDefault, LinkerFlavor, MergeFunctions, PanicStrategy, Target,
+    Arch, LinkSelfContainedDefault, LinkerFlavor, MergeFunctions, Os, PanicStrategy, Target,
     TargetMetadata, TargetOptions,
 };
 
@@ -17,7 +17,7 @@ pub(crate) fn target() -> Target {
         pointer_width: 64,
 
         options: TargetOptions {
-            os: "cuda".into(),
+            os: Os::Cuda,
             vendor: "nvidia".into(),
             linker_flavor: LinkerFlavor::Ptx,
             // The linker can be installed from `crates.io`.

--- a/compiler/rustc_target/src/spec/targets/powerpc64_unknown_freebsd.rs
+++ b/compiler/rustc_target/src/spec/targets/powerpc64_unknown_freebsd.rs
@@ -1,7 +1,7 @@
 use rustc_abi::Endian;
 
 use crate::spec::{
-    Arch, Cc, LinkerFlavor, Lld, StackProbeType, Target, TargetMetadata, TargetOptions, base,
+    Abi, Arch, Cc, LinkerFlavor, Lld, StackProbeType, Target, TargetMetadata, TargetOptions, base,
 };
 
 pub(crate) fn target() -> Target {
@@ -10,7 +10,7 @@ pub(crate) fn target() -> Target {
     base.add_pre_link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &["-m64"]);
     base.max_atomic_width = Some(64);
     base.stack_probes = StackProbeType::Inline;
-    base.abi = "elfv2".into();
+    base.abi = Abi::ElfV2;
     base.llvm_abiname = "elfv2".into();
 
     Target {

--- a/compiler/rustc_target/src/spec/targets/powerpc64_unknown_linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/targets/powerpc64_unknown_linux_gnu.rs
@@ -1,7 +1,7 @@
 use rustc_abi::Endian;
 
 use crate::spec::{
-    Arch, Cc, LinkerFlavor, Lld, StackProbeType, Target, TargetMetadata, TargetOptions, base,
+    Abi, Arch, Cc, LinkerFlavor, Lld, StackProbeType, Target, TargetMetadata, TargetOptions, base,
 };
 
 pub(crate) fn target() -> Target {
@@ -10,7 +10,7 @@ pub(crate) fn target() -> Target {
     base.add_pre_link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &["-m64"]);
     base.max_atomic_width = Some(64);
     base.stack_probes = StackProbeType::Inline;
-    base.abi = "elfv1".into();
+    base.abi = Abi::ElfV1;
     base.llvm_abiname = "elfv1".into();
 
     Target {

--- a/compiler/rustc_target/src/spec/targets/powerpc64_unknown_linux_musl.rs
+++ b/compiler/rustc_target/src/spec/targets/powerpc64_unknown_linux_musl.rs
@@ -1,7 +1,7 @@
 use rustc_abi::Endian;
 
 use crate::spec::{
-    Arch, Cc, LinkerFlavor, Lld, StackProbeType, Target, TargetMetadata, TargetOptions, base,
+    Abi, Arch, Cc, LinkerFlavor, Lld, StackProbeType, Target, TargetMetadata, TargetOptions, base,
 };
 
 pub(crate) fn target() -> Target {
@@ -10,7 +10,7 @@ pub(crate) fn target() -> Target {
     base.add_pre_link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &["-m64"]);
     base.max_atomic_width = Some(64);
     base.stack_probes = StackProbeType::Inline;
-    base.abi = "elfv2".into();
+    base.abi = Abi::ElfV2;
     base.llvm_abiname = "elfv2".into();
 
     Target {

--- a/compiler/rustc_target/src/spec/targets/powerpc64_unknown_openbsd.rs
+++ b/compiler/rustc_target/src/spec/targets/powerpc64_unknown_openbsd.rs
@@ -1,7 +1,7 @@
 use rustc_abi::Endian;
 
 use crate::spec::{
-    Arch, Cc, LinkerFlavor, Lld, StackProbeType, Target, TargetMetadata, TargetOptions, base,
+    Abi, Arch, Cc, LinkerFlavor, Lld, StackProbeType, Target, TargetMetadata, TargetOptions, base,
 };
 
 pub(crate) fn target() -> Target {
@@ -10,7 +10,7 @@ pub(crate) fn target() -> Target {
     base.add_pre_link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &["-m64"]);
     base.max_atomic_width = Some(64);
     base.stack_probes = StackProbeType::Inline;
-    base.abi = "elfv2".into();
+    base.abi = Abi::ElfV2;
     base.llvm_abiname = "elfv2".into();
 
     Target {

--- a/compiler/rustc_target/src/spec/targets/powerpc64_wrs_vxworks.rs
+++ b/compiler/rustc_target/src/spec/targets/powerpc64_wrs_vxworks.rs
@@ -1,7 +1,7 @@
 use rustc_abi::Endian;
 
 use crate::spec::{
-    Arch, Cc, LinkerFlavor, Lld, StackProbeType, Target, TargetMetadata, TargetOptions, base,
+    Abi, Arch, Cc, LinkerFlavor, Lld, StackProbeType, Target, TargetMetadata, TargetOptions, base,
 };
 
 pub(crate) fn target() -> Target {
@@ -10,7 +10,7 @@ pub(crate) fn target() -> Target {
     base.add_pre_link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &["-m64"]);
     base.max_atomic_width = Some(64);
     base.stack_probes = StackProbeType::Inline;
-    base.abi = "elfv1".into();
+    base.abi = Abi::ElfV1;
     base.llvm_abiname = "elfv1".into();
 
     Target {

--- a/compiler/rustc_target/src/spec/targets/powerpc64le_unknown_freebsd.rs
+++ b/compiler/rustc_target/src/spec/targets/powerpc64le_unknown_freebsd.rs
@@ -1,5 +1,5 @@
 use crate::spec::{
-    Arch, Cc, LinkerFlavor, Lld, StackProbeType, Target, TargetMetadata, TargetOptions, base,
+    Abi, Arch, Cc, LinkerFlavor, Lld, StackProbeType, Target, TargetMetadata, TargetOptions, base,
 };
 
 pub(crate) fn target() -> Target {
@@ -8,7 +8,7 @@ pub(crate) fn target() -> Target {
     base.add_pre_link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &["-m64"]);
     base.max_atomic_width = Some(64);
     base.stack_probes = StackProbeType::Inline;
-    base.abi = "elfv2".into();
+    base.abi = Abi::ElfV2;
     base.llvm_abiname = "elfv2".into();
 
     Target {

--- a/compiler/rustc_target/src/spec/targets/powerpc64le_unknown_linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/targets/powerpc64le_unknown_linux_gnu.rs
@@ -1,5 +1,5 @@
 use crate::spec::{
-    Arch, Cc, LinkerFlavor, Lld, StackProbeType, Target, TargetMetadata, TargetOptions, base,
+    Abi, Arch, Cc, LinkerFlavor, Lld, StackProbeType, Target, TargetMetadata, TargetOptions, base,
 };
 
 pub(crate) fn target() -> Target {
@@ -8,7 +8,7 @@ pub(crate) fn target() -> Target {
     base.add_pre_link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &["-m64"]);
     base.max_atomic_width = Some(64);
     base.stack_probes = StackProbeType::Inline;
-    base.abi = "elfv2".into();
+    base.abi = Abi::ElfV2;
     base.llvm_abiname = "elfv2".into();
 
     Target {

--- a/compiler/rustc_target/src/spec/targets/powerpc64le_unknown_linux_musl.rs
+++ b/compiler/rustc_target/src/spec/targets/powerpc64le_unknown_linux_musl.rs
@@ -1,5 +1,5 @@
 use crate::spec::{
-    Arch, Cc, LinkerFlavor, Lld, StackProbeType, Target, TargetMetadata, TargetOptions, base,
+    Abi, Arch, Cc, LinkerFlavor, Lld, StackProbeType, Target, TargetMetadata, TargetOptions, base,
 };
 
 pub(crate) fn target() -> Target {
@@ -10,7 +10,7 @@ pub(crate) fn target() -> Target {
     base.stack_probes = StackProbeType::Inline;
     // FIXME(compiler-team#422): musl targets should be dynamically linked by default.
     base.crt_static_default = true;
-    base.abi = "elfv2".into();
+    base.abi = Abi::ElfV2;
     base.llvm_abiname = "elfv2".into();
 
     Target {

--- a/compiler/rustc_target/src/spec/targets/powerpc_unknown_linux_gnuspe.rs
+++ b/compiler/rustc_target/src/spec/targets/powerpc_unknown_linux_gnuspe.rs
@@ -1,7 +1,7 @@
 use rustc_abi::Endian;
 
 use crate::spec::{
-    Arch, Cc, LinkerFlavor, Lld, StackProbeType, Target, TargetMetadata, TargetOptions, base,
+    Abi, Arch, Cc, LinkerFlavor, Lld, StackProbeType, Target, TargetMetadata, TargetOptions, base,
 };
 
 pub(crate) fn target() -> Target {
@@ -22,7 +22,7 @@ pub(crate) fn target() -> Target {
         data_layout: "E-m:e-p:32:32-Fn32-i64:64-n32".into(),
         arch: Arch::PowerPC,
         options: TargetOptions {
-            abi: "spe".into(),
+            abi: Abi::Spe,
             endian: Endian::Big,
             features: "+secure-plt,+msync".into(),
             mcount: "_mcount".into(),

--- a/compiler/rustc_target/src/spec/targets/powerpc_unknown_linux_muslspe.rs
+++ b/compiler/rustc_target/src/spec/targets/powerpc_unknown_linux_muslspe.rs
@@ -1,7 +1,7 @@
 use rustc_abi::Endian;
 
 use crate::spec::{
-    Arch, Cc, LinkerFlavor, Lld, StackProbeType, Target, TargetMetadata, TargetOptions, base,
+    Abi, Arch, Cc, LinkerFlavor, Lld, StackProbeType, Target, TargetMetadata, TargetOptions, base,
 };
 
 pub(crate) fn target() -> Target {
@@ -22,7 +22,7 @@ pub(crate) fn target() -> Target {
         data_layout: "E-m:e-p:32:32-Fn32-i64:64-n32".into(),
         arch: Arch::PowerPC,
         options: TargetOptions {
-            abi: "spe".into(),
+            abi: Abi::Spe,
             endian: Endian::Big,
             features: "+msync".into(),
             mcount: "_mcount".into(),

--- a/compiler/rustc_target/src/spec/targets/powerpc_wrs_vxworks_spe.rs
+++ b/compiler/rustc_target/src/spec/targets/powerpc_wrs_vxworks_spe.rs
@@ -1,7 +1,7 @@
 use rustc_abi::Endian;
 
 use crate::spec::{
-    Arch, Cc, LinkerFlavor, Lld, StackProbeType, Target, TargetMetadata, TargetOptions, base,
+    Abi, Arch, Cc, LinkerFlavor, Lld, StackProbeType, Target, TargetMetadata, TargetOptions, base,
 };
 
 pub(crate) fn target() -> Target {
@@ -22,7 +22,7 @@ pub(crate) fn target() -> Target {
         data_layout: "E-m:e-p:32:32-Fn32-i64:64-n32".into(),
         arch: Arch::PowerPC,
         options: TargetOptions {
-            abi: "spe".into(),
+            abi: Abi::Spe,
             endian: Endian::Big,
             // feature msync would disable instruction 'fsync' which is not supported by fsl_p1p2
             features: "+secure-plt,+msync".into(),

--- a/compiler/rustc_target/src/spec/targets/riscv32e_unknown_none_elf.rs
+++ b/compiler/rustc_target/src/spec/targets/riscv32e_unknown_none_elf.rs
@@ -1,9 +1,9 @@
 use crate::spec::{
-    Arch, Cc, LinkerFlavor, Lld, PanicStrategy, RelocModel, Target, TargetMetadata, TargetOptions,
+    Abi, Arch, Cc, LinkerFlavor, Lld, PanicStrategy, RelocModel, Target, TargetMetadata,
+    TargetOptions,
 };
 
 pub(crate) fn target() -> Target {
-    let abi = "ilp32e";
     Target {
         // The below `data_layout` is explicitly specified by the ilp32e ABI in LLVM. See also
         // `options.llvm_abiname`.
@@ -19,12 +19,12 @@ pub(crate) fn target() -> Target {
         arch: Arch::RiscV32,
 
         options: TargetOptions {
-            abi: abi.into(),
+            abi: Abi::Ilp32e,
             linker_flavor: LinkerFlavor::Gnu(Cc::No, Lld::Yes),
             linker: Some("rust-lld".into()),
             cpu: "generic-rv32".into(),
             // The ilp32e ABI specifies the `data_layout`
-            llvm_abiname: abi.into(),
+            llvm_abiname: "ilp32e".into(),
             max_atomic_width: Some(32),
             atomic_cas: false,
             features: "+e,+forced-atomics".into(),

--- a/compiler/rustc_target/src/spec/targets/riscv32em_unknown_none_elf.rs
+++ b/compiler/rustc_target/src/spec/targets/riscv32em_unknown_none_elf.rs
@@ -1,9 +1,9 @@
 use crate::spec::{
-    Arch, Cc, LinkerFlavor, Lld, PanicStrategy, RelocModel, Target, TargetMetadata, TargetOptions,
+    Abi, Arch, Cc, LinkerFlavor, Lld, PanicStrategy, RelocModel, Target, TargetMetadata,
+    TargetOptions,
 };
 
 pub(crate) fn target() -> Target {
-    let abi = "ilp32e";
     Target {
         // The below `data_layout` is explicitly specified by the ilp32e ABI in LLVM. See also
         // `options.llvm_abiname`.
@@ -19,12 +19,12 @@ pub(crate) fn target() -> Target {
         arch: Arch::RiscV32,
 
         options: TargetOptions {
-            abi: abi.into(),
+            abi: Abi::Ilp32e,
             linker_flavor: LinkerFlavor::Gnu(Cc::No, Lld::Yes),
             linker: Some("rust-lld".into()),
             cpu: "generic-rv32".into(),
             // The ilp32e ABI specifies the `data_layout`
-            llvm_abiname: abi.into(),
+            llvm_abiname: "ilp32e".into(),
             max_atomic_width: Some(32),
             atomic_cas: false,
             features: "+e,+m,+forced-atomics".into(),

--- a/compiler/rustc_target/src/spec/targets/riscv32emc_unknown_none_elf.rs
+++ b/compiler/rustc_target/src/spec/targets/riscv32emc_unknown_none_elf.rs
@@ -1,9 +1,9 @@
 use crate::spec::{
-    Arch, Cc, LinkerFlavor, Lld, PanicStrategy, RelocModel, Target, TargetMetadata, TargetOptions,
+    Abi, Arch, Cc, LinkerFlavor, Lld, PanicStrategy, RelocModel, Target, TargetMetadata,
+    TargetOptions,
 };
 
 pub(crate) fn target() -> Target {
-    let abi = "ilp32e";
     Target {
         // The below `data_layout` is explicitly specified by the ilp32e ABI in LLVM. See also
         // `options.llvm_abiname`.
@@ -19,12 +19,12 @@ pub(crate) fn target() -> Target {
         arch: Arch::RiscV32,
 
         options: TargetOptions {
-            abi: abi.into(),
+            abi: Abi::Ilp32e,
             linker_flavor: LinkerFlavor::Gnu(Cc::No, Lld::Yes),
             linker: Some("rust-lld".into()),
             cpu: "generic-rv32".into(),
             // The ilp32e ABI specifies the `data_layout`
-            llvm_abiname: abi.into(),
+            llvm_abiname: "ilp32e".into(),
             max_atomic_width: Some(32),
             atomic_cas: false,
             features: "+e,+m,+c,+forced-atomics".into(),

--- a/compiler/rustc_target/src/spec/targets/riscv32im_risc0_zkvm_elf.rs
+++ b/compiler/rustc_target/src/spec/targets/riscv32im_risc0_zkvm_elf.rs
@@ -1,5 +1,6 @@
 use crate::spec::{
-    Arch, Cc, LinkerFlavor, Lld, PanicStrategy, RelocModel, Target, TargetMetadata, TargetOptions,
+    Arch, Cc, LinkerFlavor, Lld, Os, PanicStrategy, RelocModel, Target, TargetMetadata,
+    TargetOptions,
 };
 
 pub(crate) fn target() -> Target {
@@ -16,7 +17,7 @@ pub(crate) fn target() -> Target {
         arch: Arch::RiscV32,
 
         options: TargetOptions {
-            os: "zkvm".into(),
+            os: Os::Zkvm,
             vendor: "risc0".into(),
             linker_flavor: LinkerFlavor::Gnu(Cc::No, Lld::Yes),
             linker: Some("rust-lld".into()),

--- a/compiler/rustc_target/src/spec/targets/riscv32imac_esp_espidf.rs
+++ b/compiler/rustc_target/src/spec/targets/riscv32imac_esp_espidf.rs
@@ -1,5 +1,5 @@
 use crate::spec::{
-    Arch, Env, PanicStrategy, RelocModel, Target, TargetMetadata, TargetOptions, cvs,
+    Arch, Env, Os, PanicStrategy, RelocModel, Target, TargetMetadata, TargetOptions, cvs,
 };
 
 pub(crate) fn target() -> Target {
@@ -17,7 +17,7 @@ pub(crate) fn target() -> Target {
 
         options: TargetOptions {
             families: cvs!["unix"],
-            os: "espidf".into(),
+            os: Os::EspIdf,
             env: Env::Newlib,
             vendor: "espressif".into(),
             linker: Some("riscv32-esp-elf-gcc".into()),

--- a/compiler/rustc_target/src/spec/targets/riscv32imac_esp_espidf.rs
+++ b/compiler/rustc_target/src/spec/targets/riscv32imac_esp_espidf.rs
@@ -1,4 +1,6 @@
-use crate::spec::{Arch, PanicStrategy, RelocModel, Target, TargetMetadata, TargetOptions, cvs};
+use crate::spec::{
+    Arch, Env, PanicStrategy, RelocModel, Target, TargetMetadata, TargetOptions, cvs,
+};
 
 pub(crate) fn target() -> Target {
     Target {
@@ -16,7 +18,7 @@ pub(crate) fn target() -> Target {
         options: TargetOptions {
             families: cvs!["unix"],
             os: "espidf".into(),
-            env: "newlib".into(),
+            env: Env::Newlib,
             vendor: "espressif".into(),
             linker: Some("riscv32-esp-elf-gcc".into()),
             cpu: "generic-rv32".into(),

--- a/compiler/rustc_target/src/spec/targets/riscv32imac_unknown_nuttx_elf.rs
+++ b/compiler/rustc_target/src/spec/targets/riscv32imac_unknown_nuttx_elf.rs
@@ -1,6 +1,6 @@
 use crate::spec::{
-    Arch, Cc, LinkerFlavor, Lld, PanicStrategy, RelocModel, Target, TargetMetadata, TargetOptions,
-    cvs,
+    Arch, Cc, LinkerFlavor, Lld, Os, PanicStrategy, RelocModel, Target, TargetMetadata,
+    TargetOptions, cvs,
 };
 
 pub(crate) fn target() -> Target {
@@ -18,7 +18,7 @@ pub(crate) fn target() -> Target {
 
         options: TargetOptions {
             families: cvs!["unix"],
-            os: "nuttx".into(),
+            os: Os::NuttX,
             linker_flavor: LinkerFlavor::Gnu(Cc::No, Lld::Yes),
             linker: Some("rust-lld".into()),
             cpu: "generic-rv32".into(),

--- a/compiler/rustc_target/src/spec/targets/riscv32imac_unknown_xous_elf.rs
+++ b/compiler/rustc_target/src/spec/targets/riscv32imac_unknown_xous_elf.rs
@@ -1,5 +1,6 @@
 use crate::spec::{
-    Arch, Cc, LinkerFlavor, Lld, PanicStrategy, RelocModel, Target, TargetMetadata, TargetOptions,
+    Arch, Cc, LinkerFlavor, Lld, Os, PanicStrategy, RelocModel, Target, TargetMetadata,
+    TargetOptions,
 };
 
 pub(crate) fn target() -> Target {
@@ -16,7 +17,7 @@ pub(crate) fn target() -> Target {
         arch: Arch::RiscV32,
 
         options: TargetOptions {
-            os: "xous".into(),
+            os: Os::Xous,
             linker_flavor: LinkerFlavor::Gnu(Cc::No, Lld::Yes),
             linker: Some("rust-lld".into()),
             cpu: "generic-rv32".into(),

--- a/compiler/rustc_target/src/spec/targets/riscv32imafc_esp_espidf.rs
+++ b/compiler/rustc_target/src/spec/targets/riscv32imafc_esp_espidf.rs
@@ -1,5 +1,5 @@
 use crate::spec::{
-    Arch, Env, PanicStrategy, RelocModel, Target, TargetMetadata, TargetOptions, cvs,
+    Arch, Env, Os, PanicStrategy, RelocModel, Target, TargetMetadata, TargetOptions, cvs,
 };
 
 pub(crate) fn target() -> Target {
@@ -17,7 +17,7 @@ pub(crate) fn target() -> Target {
 
         options: TargetOptions {
             families: cvs!["unix"],
-            os: "espidf".into(),
+            os: Os::EspIdf,
             env: Env::Newlib,
             vendor: "espressif".into(),
             linker: Some("riscv32-esp-elf-gcc".into()),

--- a/compiler/rustc_target/src/spec/targets/riscv32imafc_esp_espidf.rs
+++ b/compiler/rustc_target/src/spec/targets/riscv32imafc_esp_espidf.rs
@@ -1,4 +1,6 @@
-use crate::spec::{Arch, PanicStrategy, RelocModel, Target, TargetMetadata, TargetOptions, cvs};
+use crate::spec::{
+    Arch, Env, PanicStrategy, RelocModel, Target, TargetMetadata, TargetOptions, cvs,
+};
 
 pub(crate) fn target() -> Target {
     Target {
@@ -16,7 +18,7 @@ pub(crate) fn target() -> Target {
         options: TargetOptions {
             families: cvs!["unix"],
             os: "espidf".into(),
-            env: "newlib".into(),
+            env: Env::Newlib,
             vendor: "espressif".into(),
             linker: Some("riscv32-esp-elf-gcc".into()),
             cpu: "generic-rv32".into(),

--- a/compiler/rustc_target/src/spec/targets/riscv32imafc_unknown_nuttx_elf.rs
+++ b/compiler/rustc_target/src/spec/targets/riscv32imafc_unknown_nuttx_elf.rs
@@ -1,6 +1,6 @@
 use crate::spec::{
-    Arch, Cc, LinkerFlavor, Lld, PanicStrategy, RelocModel, Target, TargetMetadata, TargetOptions,
-    cvs,
+    Arch, Cc, LinkerFlavor, Lld, Os, PanicStrategy, RelocModel, Target, TargetMetadata,
+    TargetOptions, cvs,
 };
 
 pub(crate) fn target() -> Target {
@@ -18,7 +18,7 @@ pub(crate) fn target() -> Target {
 
         options: TargetOptions {
             families: cvs!["unix"],
-            os: "nuttx".into(),
+            os: Os::NuttX,
             linker_flavor: LinkerFlavor::Gnu(Cc::No, Lld::Yes),
             linker: Some("rust-lld".into()),
             cpu: "generic-rv32".into(),

--- a/compiler/rustc_target/src/spec/targets/riscv32imc_esp_espidf.rs
+++ b/compiler/rustc_target/src/spec/targets/riscv32imc_esp_espidf.rs
@@ -1,5 +1,5 @@
 use crate::spec::{
-    Arch, Env, PanicStrategy, RelocModel, Target, TargetMetadata, TargetOptions, cvs,
+    Arch, Env, Os, PanicStrategy, RelocModel, Target, TargetMetadata, TargetOptions, cvs,
 };
 
 pub(crate) fn target() -> Target {
@@ -17,7 +17,7 @@ pub(crate) fn target() -> Target {
 
         options: TargetOptions {
             families: cvs!["unix"],
-            os: "espidf".into(),
+            os: Os::EspIdf,
             env: Env::Newlib,
             vendor: "espressif".into(),
             linker: Some("riscv32-esp-elf-gcc".into()),

--- a/compiler/rustc_target/src/spec/targets/riscv32imc_esp_espidf.rs
+++ b/compiler/rustc_target/src/spec/targets/riscv32imc_esp_espidf.rs
@@ -1,4 +1,6 @@
-use crate::spec::{Arch, PanicStrategy, RelocModel, Target, TargetMetadata, TargetOptions, cvs};
+use crate::spec::{
+    Arch, Env, PanicStrategy, RelocModel, Target, TargetMetadata, TargetOptions, cvs,
+};
 
 pub(crate) fn target() -> Target {
     Target {
@@ -16,7 +18,7 @@ pub(crate) fn target() -> Target {
         options: TargetOptions {
             families: cvs!["unix"],
             os: "espidf".into(),
-            env: "newlib".into(),
+            env: Env::Newlib,
             vendor: "espressif".into(),
             linker: Some("riscv32-esp-elf-gcc".into()),
             cpu: "generic-rv32".into(),

--- a/compiler/rustc_target/src/spec/targets/riscv32imc_unknown_nuttx_elf.rs
+++ b/compiler/rustc_target/src/spec/targets/riscv32imc_unknown_nuttx_elf.rs
@@ -1,6 +1,6 @@
 use crate::spec::{
-    Arch, Cc, LinkerFlavor, Lld, PanicStrategy, RelocModel, Target, TargetMetadata, TargetOptions,
-    cvs,
+    Arch, Cc, LinkerFlavor, Lld, Os, PanicStrategy, RelocModel, Target, TargetMetadata,
+    TargetOptions, cvs,
 };
 
 pub(crate) fn target() -> Target {
@@ -18,7 +18,7 @@ pub(crate) fn target() -> Target {
 
         options: TargetOptions {
             families: cvs!["unix"],
-            os: "nuttx".into(),
+            os: Os::NuttX,
             linker_flavor: LinkerFlavor::Gnu(Cc::No, Lld::Yes),
             linker: Some("rust-lld".into()),
             cpu: "generic-rv32".into(),

--- a/compiler/rustc_target/src/spec/targets/riscv64gc_unknown_nuttx_elf.rs
+++ b/compiler/rustc_target/src/spec/targets/riscv64gc_unknown_nuttx_elf.rs
@@ -1,5 +1,5 @@
 use crate::spec::{
-    Arch, Cc, CodeModel, LinkerFlavor, Lld, PanicStrategy, RelocModel, SanitizerSet, Target,
+    Arch, Cc, CodeModel, LinkerFlavor, Lld, Os, PanicStrategy, RelocModel, SanitizerSet, Target,
     TargetMetadata, TargetOptions, cvs,
 };
 
@@ -18,7 +18,7 @@ pub(crate) fn target() -> Target {
 
         options: TargetOptions {
             families: cvs!["unix"],
-            os: "nuttx".into(),
+            os: Os::NuttX,
             linker_flavor: LinkerFlavor::Gnu(Cc::No, Lld::Yes),
             linker: Some("rust-lld".into()),
             llvm_abiname: "lp64d".into(),

--- a/compiler/rustc_target/src/spec/targets/riscv64imac_unknown_nuttx_elf.rs
+++ b/compiler/rustc_target/src/spec/targets/riscv64imac_unknown_nuttx_elf.rs
@@ -1,5 +1,5 @@
 use crate::spec::{
-    Arch, Cc, CodeModel, LinkerFlavor, Lld, PanicStrategy, RelocModel, SanitizerSet, Target,
+    Arch, Cc, CodeModel, LinkerFlavor, Lld, Os, PanicStrategy, RelocModel, SanitizerSet, Target,
     TargetMetadata, TargetOptions, cvs,
 };
 
@@ -18,7 +18,7 @@ pub(crate) fn target() -> Target {
 
         options: TargetOptions {
             families: cvs!["unix"],
-            os: "nuttx".into(),
+            os: Os::NuttX,
             linker_flavor: LinkerFlavor::Gnu(Cc::No, Lld::Yes),
             linker: Some("rust-lld".into()),
             cpu: "generic-rv64".into(),

--- a/compiler/rustc_target/src/spec/targets/thumbv4t_none_eabi.rs
+++ b/compiler/rustc_target/src/spec/targets/thumbv4t_none_eabi.rs
@@ -10,8 +10,8 @@
 //! `-Clink-arg=-Tmy_script.ld` to override that with a correct linker script.
 
 use crate::spec::{
-    Arch, FloatAbi, FramePointer, PanicStrategy, RelocModel, Target, TargetMetadata, TargetOptions,
-    base, cvs,
+    Abi, Arch, FloatAbi, FramePointer, PanicStrategy, RelocModel, Target, TargetMetadata,
+    TargetOptions, base, cvs,
 };
 
 pub(crate) fn target() -> Target {
@@ -36,7 +36,7 @@ pub(crate) fn target() -> Target {
          */
         data_layout: "e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64".into(),
         options: TargetOptions {
-            abi: "eabi".into(),
+            abi: Abi::Eabi,
             llvm_floatabi: Some(FloatAbi::Soft),
 
             // extra args passed to the external assembler (assuming `arm-none-eabi-as`):

--- a/compiler/rustc_target/src/spec/targets/thumbv5te_none_eabi.rs
+++ b/compiler/rustc_target/src/spec/targets/thumbv5te_none_eabi.rs
@@ -1,6 +1,8 @@
 //! Targets the ARMv5TE, with code as `t32` code by default.
 
-use crate::spec::{Arch, FloatAbi, FramePointer, Target, TargetMetadata, TargetOptions, base, cvs};
+use crate::spec::{
+    Abi, Arch, FloatAbi, FramePointer, Target, TargetMetadata, TargetOptions, base, cvs,
+};
 
 pub(crate) fn target() -> Target {
     Target {
@@ -25,7 +27,7 @@ pub(crate) fn target() -> Target {
         data_layout: "e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64".into(),
 
         options: TargetOptions {
-            abi: "eabi".into(),
+            abi: Abi::Eabi,
             llvm_floatabi: Some(FloatAbi::Soft),
             // extra args passed to the external assembler (assuming `arm-none-eabi-as`):
             // * activate t32/a32 interworking

--- a/compiler/rustc_target/src/spec/targets/thumbv6m_none_eabi.rs
+++ b/compiler/rustc_target/src/spec/targets/thumbv6m_none_eabi.rs
@@ -1,6 +1,6 @@
 // Targets the Cortex-M0, Cortex-M0+ and Cortex-M1 processors (ARMv6-M architecture)
 
-use crate::spec::{Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base};
+use crate::spec::{Abi, Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base};
 
 pub(crate) fn target() -> Target {
     Target {
@@ -16,7 +16,7 @@ pub(crate) fn target() -> Target {
         arch: Arch::Arm,
 
         options: TargetOptions {
-            abi: "eabi".into(),
+            abi: Abi::Eabi,
             llvm_floatabi: Some(FloatAbi::Soft),
             // The ARMv6-M architecture doesn't support unaligned loads/stores so we disable them
             // with +strict-align.

--- a/compiler/rustc_target/src/spec/targets/thumbv6m_nuttx_eabi.rs
+++ b/compiler/rustc_target/src/spec/targets/thumbv6m_nuttx_eabi.rs
@@ -1,6 +1,6 @@
 // Targets the Cortex-M0, Cortex-M0+ and Cortex-M1 processors (ARMv6-M architecture)
 
-use crate::spec::{Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base, cvs};
+use crate::spec::{Abi, Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base, cvs};
 
 pub(crate) fn target() -> Target {
     Target {
@@ -18,7 +18,7 @@ pub(crate) fn target() -> Target {
         options: TargetOptions {
             families: cvs!["unix"],
             os: "nuttx".into(),
-            abi: "eabi".into(),
+            abi: Abi::Eabi,
             llvm_floatabi: Some(FloatAbi::Soft),
             // The ARMv6-M architecture doesn't support unaligned loads/stores so we disable them
             // with +strict-align.

--- a/compiler/rustc_target/src/spec/targets/thumbv6m_nuttx_eabi.rs
+++ b/compiler/rustc_target/src/spec/targets/thumbv6m_nuttx_eabi.rs
@@ -1,6 +1,6 @@
 // Targets the Cortex-M0, Cortex-M0+ and Cortex-M1 processors (ARMv6-M architecture)
 
-use crate::spec::{Abi, Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base, cvs};
+use crate::spec::{Abi, Arch, FloatAbi, Os, Target, TargetMetadata, TargetOptions, base, cvs};
 
 pub(crate) fn target() -> Target {
     Target {
@@ -17,7 +17,7 @@ pub(crate) fn target() -> Target {
 
         options: TargetOptions {
             families: cvs!["unix"],
-            os: "nuttx".into(),
+            os: Os::NuttX,
             abi: Abi::Eabi,
             llvm_floatabi: Some(FloatAbi::Soft),
             // The ARMv6-M architecture doesn't support unaligned loads/stores so we disable them

--- a/compiler/rustc_target/src/spec/targets/thumbv7a_nuttx_eabi.rs
+++ b/compiler/rustc_target/src/spec/targets/thumbv7a_nuttx_eabi.rs
@@ -4,7 +4,7 @@
 // and will use software floating point operations. This matches the NuttX EABI
 // configuration without hardware floating point support.
 
-use crate::spec::{Abi, Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base, cvs};
+use crate::spec::{Abi, Arch, FloatAbi, Os, Target, TargetMetadata, TargetOptions, base, cvs};
 
 pub(crate) fn target() -> Target {
     Target {
@@ -21,7 +21,7 @@ pub(crate) fn target() -> Target {
 
         options: TargetOptions {
             families: cvs!["unix"],
-            os: "nuttx".into(),
+            os: Os::NuttX,
             abi: Abi::Eabi,
             llvm_floatabi: Some(FloatAbi::Soft),
             // Cortex-A7/A8/A9 with software floating point

--- a/compiler/rustc_target/src/spec/targets/thumbv7a_nuttx_eabi.rs
+++ b/compiler/rustc_target/src/spec/targets/thumbv7a_nuttx_eabi.rs
@@ -4,7 +4,7 @@
 // and will use software floating point operations. This matches the NuttX EABI
 // configuration without hardware floating point support.
 
-use crate::spec::{Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base, cvs};
+use crate::spec::{Abi, Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base, cvs};
 
 pub(crate) fn target() -> Target {
     Target {
@@ -22,7 +22,7 @@ pub(crate) fn target() -> Target {
         options: TargetOptions {
             families: cvs!["unix"],
             os: "nuttx".into(),
-            abi: "eabi".into(),
+            abi: Abi::Eabi,
             llvm_floatabi: Some(FloatAbi::Soft),
             // Cortex-A7/A8/A9 with software floating point
             features: "+soft-float,-neon".into(),

--- a/compiler/rustc_target/src/spec/targets/thumbv7a_nuttx_eabihf.rs
+++ b/compiler/rustc_target/src/spec/targets/thumbv7a_nuttx_eabihf.rs
@@ -7,7 +7,7 @@
 // This target uses the "hard" floating convention (ABI) where floating point values
 // are passed to/from subroutines via FPU registers (S0, S1, D0, D1, etc.).
 
-use crate::spec::{Abi, Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base, cvs};
+use crate::spec::{Abi, Arch, FloatAbi, Os, Target, TargetMetadata, TargetOptions, base, cvs};
 
 pub(crate) fn target() -> Target {
     Target {
@@ -24,7 +24,7 @@ pub(crate) fn target() -> Target {
 
         options: TargetOptions {
             families: cvs!["unix"],
-            os: "nuttx".into(),
+            os: Os::NuttX,
             abi: Abi::EabiHf,
             llvm_floatabi: Some(FloatAbi::Hard),
             // Cortex-A7/A8/A9 support VFPv3-D32/VFPv4-D32 with optional double-precision

--- a/compiler/rustc_target/src/spec/targets/thumbv7a_nuttx_eabihf.rs
+++ b/compiler/rustc_target/src/spec/targets/thumbv7a_nuttx_eabihf.rs
@@ -7,7 +7,7 @@
 // This target uses the "hard" floating convention (ABI) where floating point values
 // are passed to/from subroutines via FPU registers (S0, S1, D0, D1, etc.).
 
-use crate::spec::{Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base, cvs};
+use crate::spec::{Abi, Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base, cvs};
 
 pub(crate) fn target() -> Target {
     Target {
@@ -25,7 +25,7 @@ pub(crate) fn target() -> Target {
         options: TargetOptions {
             families: cvs!["unix"],
             os: "nuttx".into(),
-            abi: "eabihf".into(),
+            abi: Abi::EabiHf,
             llvm_floatabi: Some(FloatAbi::Hard),
             // Cortex-A7/A8/A9 support VFPv3-D32/VFPv4-D32 with optional double-precision
             // and NEON SIMD instructions

--- a/compiler/rustc_target/src/spec/targets/thumbv7em_none_eabi.rs
+++ b/compiler/rustc_target/src/spec/targets/thumbv7em_none_eabi.rs
@@ -9,7 +9,7 @@
 // To opt-in to hardware accelerated floating point operations, you can use, for example,
 // `-C target-feature=+vfp4` or `-C target-cpu=cortex-m4`.
 
-use crate::spec::{Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base};
+use crate::spec::{Abi, Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base};
 
 pub(crate) fn target() -> Target {
     Target {
@@ -25,7 +25,7 @@ pub(crate) fn target() -> Target {
         arch: Arch::Arm,
 
         options: TargetOptions {
-            abi: "eabi".into(),
+            abi: Abi::Eabi,
             llvm_floatabi: Some(FloatAbi::Soft),
             max_atomic_width: Some(32),
             ..base::thumb::opts()

--- a/compiler/rustc_target/src/spec/targets/thumbv7em_none_eabihf.rs
+++ b/compiler/rustc_target/src/spec/targets/thumbv7em_none_eabihf.rs
@@ -8,7 +8,7 @@
 //
 // To opt into double precision hardware support, use the `-C target-feature=+fp64` flag.
 
-use crate::spec::{Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base};
+use crate::spec::{Abi, Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base};
 
 pub(crate) fn target() -> Target {
     Target {
@@ -24,7 +24,7 @@ pub(crate) fn target() -> Target {
         arch: Arch::Arm,
 
         options: TargetOptions {
-            abi: "eabihf".into(),
+            abi: Abi::EabiHf,
             llvm_floatabi: Some(FloatAbi::Hard),
             // vfp4 is the lowest common denominator between the Cortex-M4F (vfp4) and the
             // Cortex-M7 (vfp5).

--- a/compiler/rustc_target/src/spec/targets/thumbv7em_nuttx_eabi.rs
+++ b/compiler/rustc_target/src/spec/targets/thumbv7em_nuttx_eabi.rs
@@ -9,7 +9,7 @@
 // To opt-in to hardware accelerated floating point operations, you can use, for example,
 // `-C target-feature=+vfp4` or `-C target-cpu=cortex-m4`.
 
-use crate::spec::{Abi, Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base, cvs};
+use crate::spec::{Abi, Arch, FloatAbi, Os, Target, TargetMetadata, TargetOptions, base, cvs};
 
 pub(crate) fn target() -> Target {
     Target {
@@ -26,7 +26,7 @@ pub(crate) fn target() -> Target {
 
         options: TargetOptions {
             families: cvs!["unix"],
-            os: "nuttx".into(),
+            os: Os::NuttX,
             abi: Abi::Eabi,
             llvm_floatabi: Some(FloatAbi::Soft),
             max_atomic_width: Some(32),

--- a/compiler/rustc_target/src/spec/targets/thumbv7em_nuttx_eabi.rs
+++ b/compiler/rustc_target/src/spec/targets/thumbv7em_nuttx_eabi.rs
@@ -9,7 +9,7 @@
 // To opt-in to hardware accelerated floating point operations, you can use, for example,
 // `-C target-feature=+vfp4` or `-C target-cpu=cortex-m4`.
 
-use crate::spec::{Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base, cvs};
+use crate::spec::{Abi, Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base, cvs};
 
 pub(crate) fn target() -> Target {
     Target {
@@ -27,7 +27,7 @@ pub(crate) fn target() -> Target {
         options: TargetOptions {
             families: cvs!["unix"],
             os: "nuttx".into(),
-            abi: "eabi".into(),
+            abi: Abi::Eabi,
             llvm_floatabi: Some(FloatAbi::Soft),
             max_atomic_width: Some(32),
             ..base::thumb::opts()

--- a/compiler/rustc_target/src/spec/targets/thumbv7em_nuttx_eabihf.rs
+++ b/compiler/rustc_target/src/spec/targets/thumbv7em_nuttx_eabihf.rs
@@ -8,7 +8,7 @@
 //
 // To opt into double precision hardware support, use the `-C target-feature=+fp64` flag.
 
-use crate::spec::{Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base, cvs};
+use crate::spec::{Abi, Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base, cvs};
 
 pub(crate) fn target() -> Target {
     Target {
@@ -26,7 +26,7 @@ pub(crate) fn target() -> Target {
         options: TargetOptions {
             families: cvs!["unix"],
             os: "nuttx".into(),
-            abi: "eabihf".into(),
+            abi: Abi::EabiHf,
             llvm_floatabi: Some(FloatAbi::Hard),
             // vfp4 is the lowest common denominator between the Cortex-M4F (vfp4) and the
             // Cortex-M7 (vfp5).

--- a/compiler/rustc_target/src/spec/targets/thumbv7em_nuttx_eabihf.rs
+++ b/compiler/rustc_target/src/spec/targets/thumbv7em_nuttx_eabihf.rs
@@ -8,7 +8,7 @@
 //
 // To opt into double precision hardware support, use the `-C target-feature=+fp64` flag.
 
-use crate::spec::{Abi, Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base, cvs};
+use crate::spec::{Abi, Arch, FloatAbi, Os, Target, TargetMetadata, TargetOptions, base, cvs};
 
 pub(crate) fn target() -> Target {
     Target {
@@ -25,7 +25,7 @@ pub(crate) fn target() -> Target {
 
         options: TargetOptions {
             families: cvs!["unix"],
-            os: "nuttx".into(),
+            os: Os::NuttX,
             abi: Abi::EabiHf,
             llvm_floatabi: Some(FloatAbi::Hard),
             // vfp4 is the lowest common denominator between the Cortex-M4F (vfp4) and the

--- a/compiler/rustc_target/src/spec/targets/thumbv7m_none_eabi.rs
+++ b/compiler/rustc_target/src/spec/targets/thumbv7m_none_eabi.rs
@@ -1,6 +1,6 @@
 // Targets the Cortex-M3 processor (ARMv7-M)
 
-use crate::spec::{Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base};
+use crate::spec::{Abi, Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base};
 
 pub(crate) fn target() -> Target {
     Target {
@@ -16,7 +16,7 @@ pub(crate) fn target() -> Target {
         arch: Arch::Arm,
 
         options: TargetOptions {
-            abi: "eabi".into(),
+            abi: Abi::Eabi,
             llvm_floatabi: Some(FloatAbi::Soft),
             max_atomic_width: Some(32),
             ..base::thumb::opts()

--- a/compiler/rustc_target/src/spec/targets/thumbv7m_nuttx_eabi.rs
+++ b/compiler/rustc_target/src/spec/targets/thumbv7m_nuttx_eabi.rs
@@ -1,6 +1,6 @@
 // Targets the Cortex-M3 processor (ARMv7-M)
 
-use crate::spec::{Abi, Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base, cvs};
+use crate::spec::{Abi, Arch, FloatAbi, Os, Target, TargetMetadata, TargetOptions, base, cvs};
 
 pub(crate) fn target() -> Target {
     Target {
@@ -17,7 +17,7 @@ pub(crate) fn target() -> Target {
 
         options: TargetOptions {
             families: cvs!["unix"],
-            os: "nuttx".into(),
+            os: Os::NuttX,
             abi: Abi::Eabi,
             llvm_floatabi: Some(FloatAbi::Soft),
             max_atomic_width: Some(32),

--- a/compiler/rustc_target/src/spec/targets/thumbv7m_nuttx_eabi.rs
+++ b/compiler/rustc_target/src/spec/targets/thumbv7m_nuttx_eabi.rs
@@ -1,6 +1,6 @@
 // Targets the Cortex-M3 processor (ARMv7-M)
 
-use crate::spec::{Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base, cvs};
+use crate::spec::{Abi, Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base, cvs};
 
 pub(crate) fn target() -> Target {
     Target {
@@ -18,7 +18,7 @@ pub(crate) fn target() -> Target {
         options: TargetOptions {
             families: cvs!["unix"],
             os: "nuttx".into(),
-            abi: "eabi".into(),
+            abi: Abi::Eabi,
             llvm_floatabi: Some(FloatAbi::Soft),
             max_atomic_width: Some(32),
             ..base::thumb::opts()

--- a/compiler/rustc_target/src/spec/targets/thumbv7neon_linux_androideabi.rs
+++ b/compiler/rustc_target/src/spec/targets/thumbv7neon_linux_androideabi.rs
@@ -1,5 +1,5 @@
 use crate::spec::{
-    Arch, Cc, FloatAbi, LinkerFlavor, Lld, Target, TargetMetadata, TargetOptions, base,
+    Abi, Arch, Cc, FloatAbi, LinkerFlavor, Lld, Target, TargetMetadata, TargetOptions, base,
 };
 
 // This target if is for the Android v7a ABI in thumb mode with
@@ -25,7 +25,7 @@ pub(crate) fn target() -> Target {
         data_layout: "e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64".into(),
         arch: Arch::Arm,
         options: TargetOptions {
-            abi: "eabi".into(),
+            abi: Abi::Eabi,
             llvm_floatabi: Some(FloatAbi::Soft),
             features: "+v7,+thumb-mode,+thumb2,+vfp3,+neon".into(),
             max_atomic_width: Some(64),

--- a/compiler/rustc_target/src/spec/targets/thumbv7neon_unknown_linux_gnueabihf.rs
+++ b/compiler/rustc_target/src/spec/targets/thumbv7neon_unknown_linux_gnueabihf.rs
@@ -1,4 +1,4 @@
-use crate::spec::{Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base};
+use crate::spec::{Abi, Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base};
 
 // This target is for glibc Linux on ARMv7 with thumb mode enabled
 // (for consistency with Android and Debian-based distributions)
@@ -21,7 +21,7 @@ pub(crate) fn target() -> Target {
         data_layout: "e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64".into(),
         arch: Arch::Arm,
         options: TargetOptions {
-            abi: "eabihf".into(),
+            abi: Abi::EabiHf,
             llvm_floatabi: Some(FloatAbi::Hard),
             // Info about features at https://wiki.debian.org/ArmHardFloatPort
             features: "+v7,+thumb-mode,+thumb2,+vfp3,+neon".into(),

--- a/compiler/rustc_target/src/spec/targets/thumbv7neon_unknown_linux_musleabihf.rs
+++ b/compiler/rustc_target/src/spec/targets/thumbv7neon_unknown_linux_musleabihf.rs
@@ -1,4 +1,4 @@
-use crate::spec::{Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base};
+use crate::spec::{Abi, Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base};
 
 // This target is for musl Linux on ARMv7 with thumb mode enabled
 // (for consistency with Android and Debian-based distributions)
@@ -22,7 +22,7 @@ pub(crate) fn target() -> Target {
         // Most of these settings are copied from the thumbv7neon_unknown_linux_gnueabihf
         // target.
         options: TargetOptions {
-            abi: "eabihf".into(),
+            abi: Abi::EabiHf,
             llvm_floatabi: Some(FloatAbi::Hard),
             features: "+v7,+thumb-mode,+thumb2,+vfp3,+neon".into(),
             max_atomic_width: Some(64),

--- a/compiler/rustc_target/src/spec/targets/thumbv8m_base_none_eabi.rs
+++ b/compiler/rustc_target/src/spec/targets/thumbv8m_base_none_eabi.rs
@@ -1,6 +1,6 @@
 // Targets the Cortex-M23 processor (Baseline ARMv8-M)
 
-use crate::spec::{Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base};
+use crate::spec::{Abi, Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base};
 
 pub(crate) fn target() -> Target {
     Target {
@@ -16,7 +16,7 @@ pub(crate) fn target() -> Target {
         arch: Arch::Arm,
 
         options: TargetOptions {
-            abi: "eabi".into(),
+            abi: Abi::Eabi,
             llvm_floatabi: Some(FloatAbi::Soft),
             // ARMv8-M baseline doesn't support unaligned loads/stores so we disable them
             // with +strict-align.

--- a/compiler/rustc_target/src/spec/targets/thumbv8m_base_nuttx_eabi.rs
+++ b/compiler/rustc_target/src/spec/targets/thumbv8m_base_nuttx_eabi.rs
@@ -1,6 +1,6 @@
 // Targets the Cortex-M23 processor (Baseline ARMv8-M)
 
-use crate::spec::{Abi, Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base, cvs};
+use crate::spec::{Abi, Arch, FloatAbi, Os, Target, TargetMetadata, TargetOptions, base, cvs};
 
 pub(crate) fn target() -> Target {
     Target {
@@ -17,7 +17,7 @@ pub(crate) fn target() -> Target {
 
         options: TargetOptions {
             families: cvs!["unix"],
-            os: "nuttx".into(),
+            os: Os::NuttX,
             abi: Abi::Eabi,
             llvm_floatabi: Some(FloatAbi::Soft),
             // ARMv8-M baseline doesn't support unaligned loads/stores so we disable them

--- a/compiler/rustc_target/src/spec/targets/thumbv8m_base_nuttx_eabi.rs
+++ b/compiler/rustc_target/src/spec/targets/thumbv8m_base_nuttx_eabi.rs
@@ -1,6 +1,6 @@
 // Targets the Cortex-M23 processor (Baseline ARMv8-M)
 
-use crate::spec::{Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base, cvs};
+use crate::spec::{Abi, Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base, cvs};
 
 pub(crate) fn target() -> Target {
     Target {
@@ -18,7 +18,7 @@ pub(crate) fn target() -> Target {
         options: TargetOptions {
             families: cvs!["unix"],
             os: "nuttx".into(),
-            abi: "eabi".into(),
+            abi: Abi::Eabi,
             llvm_floatabi: Some(FloatAbi::Soft),
             // ARMv8-M baseline doesn't support unaligned loads/stores so we disable them
             // with +strict-align.

--- a/compiler/rustc_target/src/spec/targets/thumbv8m_main_none_eabi.rs
+++ b/compiler/rustc_target/src/spec/targets/thumbv8m_main_none_eabi.rs
@@ -1,7 +1,7 @@
 // Targets the Cortex-M33 processor (Armv8-M Mainline architecture profile),
 // without the Floating Point extension.
 
-use crate::spec::{Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base};
+use crate::spec::{Abi, Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base};
 
 pub(crate) fn target() -> Target {
     Target {
@@ -17,7 +17,7 @@ pub(crate) fn target() -> Target {
         arch: Arch::Arm,
 
         options: TargetOptions {
-            abi: "eabi".into(),
+            abi: Abi::Eabi,
             llvm_floatabi: Some(FloatAbi::Soft),
             max_atomic_width: Some(32),
             ..base::thumb::opts()

--- a/compiler/rustc_target/src/spec/targets/thumbv8m_main_none_eabihf.rs
+++ b/compiler/rustc_target/src/spec/targets/thumbv8m_main_none_eabihf.rs
@@ -1,7 +1,7 @@
 // Targets the Cortex-M33 processor (Armv8-M Mainline architecture profile),
 // with the Floating Point extension.
 
-use crate::spec::{Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base};
+use crate::spec::{Abi, Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base};
 
 pub(crate) fn target() -> Target {
     Target {
@@ -17,7 +17,7 @@ pub(crate) fn target() -> Target {
         arch: Arch::Arm,
 
         options: TargetOptions {
-            abi: "eabihf".into(),
+            abi: Abi::EabiHf,
             llvm_floatabi: Some(FloatAbi::Hard),
             // If the Floating Point extension is implemented in the Cortex-M33
             // processor, the Cortex-M33 Technical Reference Manual states that

--- a/compiler/rustc_target/src/spec/targets/thumbv8m_main_nuttx_eabi.rs
+++ b/compiler/rustc_target/src/spec/targets/thumbv8m_main_nuttx_eabi.rs
@@ -1,7 +1,7 @@
 // Targets the Cortex-M33 processor (Armv8-M Mainline architecture profile),
 // without the Floating Point extension.
 
-use crate::spec::{Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base, cvs};
+use crate::spec::{Abi, Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base, cvs};
 
 pub(crate) fn target() -> Target {
     Target {
@@ -19,7 +19,7 @@ pub(crate) fn target() -> Target {
         options: TargetOptions {
             families: cvs!["unix"],
             os: "nuttx".into(),
-            abi: "eabi".into(),
+            abi: Abi::Eabi,
             llvm_floatabi: Some(FloatAbi::Soft),
             max_atomic_width: Some(32),
             ..base::thumb::opts()

--- a/compiler/rustc_target/src/spec/targets/thumbv8m_main_nuttx_eabi.rs
+++ b/compiler/rustc_target/src/spec/targets/thumbv8m_main_nuttx_eabi.rs
@@ -1,7 +1,7 @@
 // Targets the Cortex-M33 processor (Armv8-M Mainline architecture profile),
 // without the Floating Point extension.
 
-use crate::spec::{Abi, Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base, cvs};
+use crate::spec::{Abi, Arch, FloatAbi, Os, Target, TargetMetadata, TargetOptions, base, cvs};
 
 pub(crate) fn target() -> Target {
     Target {
@@ -18,7 +18,7 @@ pub(crate) fn target() -> Target {
 
         options: TargetOptions {
             families: cvs!["unix"],
-            os: "nuttx".into(),
+            os: Os::NuttX,
             abi: Abi::Eabi,
             llvm_floatabi: Some(FloatAbi::Soft),
             max_atomic_width: Some(32),

--- a/compiler/rustc_target/src/spec/targets/thumbv8m_main_nuttx_eabihf.rs
+++ b/compiler/rustc_target/src/spec/targets/thumbv8m_main_nuttx_eabihf.rs
@@ -1,7 +1,7 @@
 // Targets the Cortex-M33 processor (Armv8-M Mainline architecture profile),
 // with the Floating Point extension.
 
-use crate::spec::{Abi, Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base, cvs};
+use crate::spec::{Abi, Arch, FloatAbi, Os, Target, TargetMetadata, TargetOptions, base, cvs};
 
 pub(crate) fn target() -> Target {
     Target {
@@ -18,7 +18,7 @@ pub(crate) fn target() -> Target {
 
         options: TargetOptions {
             families: cvs!["unix"],
-            os: "nuttx".into(),
+            os: Os::NuttX,
             abi: Abi::EabiHf,
             llvm_floatabi: Some(FloatAbi::Hard),
             // If the Floating Point extension is implemented in the Cortex-M33

--- a/compiler/rustc_target/src/spec/targets/thumbv8m_main_nuttx_eabihf.rs
+++ b/compiler/rustc_target/src/spec/targets/thumbv8m_main_nuttx_eabihf.rs
@@ -1,7 +1,7 @@
 // Targets the Cortex-M33 processor (Armv8-M Mainline architecture profile),
 // with the Floating Point extension.
 
-use crate::spec::{Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base, cvs};
+use crate::spec::{Abi, Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base, cvs};
 
 pub(crate) fn target() -> Target {
     Target {
@@ -19,7 +19,7 @@ pub(crate) fn target() -> Target {
         options: TargetOptions {
             families: cvs!["unix"],
             os: "nuttx".into(),
-            abi: "eabihf".into(),
+            abi: Abi::EabiHf,
             llvm_floatabi: Some(FloatAbi::Hard),
             // If the Floating Point extension is implemented in the Cortex-M33
             // processor, the Cortex-M33 Technical Reference Manual states that

--- a/compiler/rustc_target/src/spec/targets/wasm32_unknown_emscripten.rs
+++ b/compiler/rustc_target/src/spec/targets/wasm32_unknown_emscripten.rs
@@ -1,6 +1,6 @@
 use crate::spec::{
-    Arch, LinkArgs, LinkerFlavor, PanicStrategy, RelocModel, Target, TargetMetadata, TargetOptions,
-    base, cvs,
+    Arch, LinkArgs, LinkerFlavor, Os, PanicStrategy, RelocModel, Target, TargetMetadata,
+    TargetOptions, base, cvs,
 };
 
 pub(crate) fn target() -> Target {
@@ -10,7 +10,7 @@ pub(crate) fn target() -> Target {
         TargetOptions::link_args(LinkerFlavor::EmCc, &["-sABORTING_MALLOC=0", "-sWASM_BIGINT"]);
 
     let opts = TargetOptions {
-        os: "emscripten".into(),
+        os: Os::Emscripten,
         linker_flavor: LinkerFlavor::EmCc,
         // emcc emits two files - a .js file to instantiate the wasm and supply platform
         // functionality, and a .wasm file.

--- a/compiler/rustc_target/src/spec/targets/wasm32_unknown_unknown.rs
+++ b/compiler/rustc_target/src/spec/targets/wasm32_unknown_unknown.rs
@@ -10,11 +10,11 @@
 //! This target is more or less managed by the Rust and WebAssembly Working
 //! Group nowadays at <https://github.com/rustwasm>.
 
-use crate::spec::{Arch, Cc, LinkerFlavor, Target, TargetMetadata, base};
+use crate::spec::{Arch, Cc, LinkerFlavor, Os, Target, TargetMetadata, base};
 
 pub(crate) fn target() -> Target {
     let mut options = base::wasm::options();
-    options.os = "unknown".into();
+    options.os = Os::Unknown;
 
     options.add_pre_link_args(
         LinkerFlavor::WasmLld(Cc::No),

--- a/compiler/rustc_target/src/spec/targets/wasm32_wasip1.rs
+++ b/compiler/rustc_target/src/spec/targets/wasm32_wasip1.rs
@@ -11,14 +11,14 @@
 //! introduced.
 
 use crate::spec::{
-    Arch, Cc, Env, LinkSelfContainedDefault, LinkerFlavor, Target, TargetMetadata, base,
+    Arch, Cc, Env, LinkSelfContainedDefault, LinkerFlavor, Os, Target, TargetMetadata, base,
     crt_objects,
 };
 
 pub(crate) fn target() -> Target {
     let mut options = base::wasm::options();
 
-    options.os = "wasi".into();
+    options.os = Os::Wasi;
     options.env = Env::P1;
     options.add_pre_link_args(LinkerFlavor::WasmLld(Cc::Yes), &["--target=wasm32-wasip1"]);
 

--- a/compiler/rustc_target/src/spec/targets/wasm32_wasip1.rs
+++ b/compiler/rustc_target/src/spec/targets/wasm32_wasip1.rs
@@ -11,14 +11,15 @@
 //! introduced.
 
 use crate::spec::{
-    Arch, Cc, LinkSelfContainedDefault, LinkerFlavor, Target, TargetMetadata, base, crt_objects,
+    Arch, Cc, Env, LinkSelfContainedDefault, LinkerFlavor, Target, TargetMetadata, base,
+    crt_objects,
 };
 
 pub(crate) fn target() -> Target {
     let mut options = base::wasm::options();
 
     options.os = "wasi".into();
-    options.env = "p1".into();
+    options.env = Env::P1;
     options.add_pre_link_args(LinkerFlavor::WasmLld(Cc::Yes), &["--target=wasm32-wasip1"]);
 
     options.pre_link_objects_self_contained = crt_objects::pre_wasi_self_contained();

--- a/compiler/rustc_target/src/spec/targets/wasm32_wasip1_threads.rs
+++ b/compiler/rustc_target/src/spec/targets/wasm32_wasip1_threads.rs
@@ -8,14 +8,14 @@
 //! Historically this target was known as `wasm32-wasi-preview1-threads`.
 
 use crate::spec::{
-    Arch, Cc, Env, LinkSelfContainedDefault, LinkerFlavor, Target, TargetMetadata, base,
+    Arch, Cc, Env, LinkSelfContainedDefault, LinkerFlavor, Os, Target, TargetMetadata, base,
     crt_objects,
 };
 
 pub(crate) fn target() -> Target {
     let mut options = base::wasm::options();
 
-    options.os = "wasi".into();
+    options.os = Os::Wasi;
     options.env = Env::P1;
 
     options.add_pre_link_args(

--- a/compiler/rustc_target/src/spec/targets/wasm32_wasip1_threads.rs
+++ b/compiler/rustc_target/src/spec/targets/wasm32_wasip1_threads.rs
@@ -8,14 +8,15 @@
 //! Historically this target was known as `wasm32-wasi-preview1-threads`.
 
 use crate::spec::{
-    Arch, Cc, LinkSelfContainedDefault, LinkerFlavor, Target, TargetMetadata, base, crt_objects,
+    Arch, Cc, Env, LinkSelfContainedDefault, LinkerFlavor, Target, TargetMetadata, base,
+    crt_objects,
 };
 
 pub(crate) fn target() -> Target {
     let mut options = base::wasm::options();
 
     options.os = "wasi".into();
-    options.env = "p1".into();
+    options.env = Env::P1;
 
     options.add_pre_link_args(
         LinkerFlavor::WasmLld(Cc::No),

--- a/compiler/rustc_target/src/spec/targets/wasm32_wasip2.rs
+++ b/compiler/rustc_target/src/spec/targets/wasm32_wasip2.rs
@@ -17,14 +17,14 @@
 //! <https://github.com/WebAssembly/component-model>.
 
 use crate::spec::{
-    Arch, LinkSelfContainedDefault, RelocModel, Target, TargetMetadata, base, crt_objects,
+    Arch, Env, LinkSelfContainedDefault, RelocModel, Target, TargetMetadata, base, crt_objects,
 };
 
 pub(crate) fn target() -> Target {
     let mut options = base::wasm::options();
 
     options.os = "wasi".into();
-    options.env = "p2".into();
+    options.env = Env::P2;
     options.linker = Some("wasm-component-ld".into());
 
     options.pre_link_objects_self_contained = crt_objects::pre_wasi_self_contained();

--- a/compiler/rustc_target/src/spec/targets/wasm32_wasip2.rs
+++ b/compiler/rustc_target/src/spec/targets/wasm32_wasip2.rs
@@ -17,13 +17,13 @@
 //! <https://github.com/WebAssembly/component-model>.
 
 use crate::spec::{
-    Arch, Env, LinkSelfContainedDefault, RelocModel, Target, TargetMetadata, base, crt_objects,
+    Arch, Env, LinkSelfContainedDefault, Os, RelocModel, Target, TargetMetadata, base, crt_objects,
 };
 
 pub(crate) fn target() -> Target {
     let mut options = base::wasm::options();
 
-    options.os = "wasi".into();
+    options.os = Os::Wasi;
     options.env = Env::P2;
     options.linker = Some("wasm-component-ld".into());
 

--- a/compiler/rustc_target/src/spec/targets/wasm32_wasip3.rs
+++ b/compiler/rustc_target/src/spec/targets/wasm32_wasip3.rs
@@ -8,13 +8,13 @@
 //! all component-model-level imports anyway. Over time the imports of the
 //! standard library will change to WASIp3.
 
-use crate::spec::Target;
+use crate::spec::{Env, Target};
 
 pub(crate) fn target() -> Target {
     // As of now WASIp3 is a lightly edited wasip2 target, so start with that
     // and this may grow over time as more features are supported.
     let mut target = super::wasm32_wasip2::target();
     target.llvm_target = "wasm32-wasip3".into();
-    target.options.env = "p3".into();
+    target.options.env = Env::P3;
     target
 }

--- a/compiler/rustc_target/src/spec/targets/wasm32v1_none.rs
+++ b/compiler/rustc_target/src/spec/targets/wasm32v1_none.rs
@@ -12,11 +12,11 @@
 //! nightly Rust feature `-Zbuild-std`. This target is for people who want to
 //! use stable Rust, and target a stable set pf WebAssembly features.
 
-use crate::spec::{Arch, Cc, LinkerFlavor, Target, TargetMetadata, base};
+use crate::spec::{Arch, Cc, LinkerFlavor, Os, Target, TargetMetadata, base};
 
 pub(crate) fn target() -> Target {
     let mut options = base::wasm::options();
-    options.os = "none".into();
+    options.os = Os::None;
 
     // WebAssembly 1.0 shipped in 2019 and included exactly one proposal
     // after the initial "MVP" feature set: "mutable-globals".

--- a/compiler/rustc_target/src/spec/targets/wasm64_unknown_unknown.rs
+++ b/compiler/rustc_target/src/spec/targets/wasm64_unknown_unknown.rs
@@ -7,11 +7,11 @@
 //! the standard library is available, most of it returns an error immediately
 //! (e.g. trying to create a TCP stream or something like that).
 
-use crate::spec::{Arch, Cc, LinkerFlavor, Target, TargetMetadata, base};
+use crate::spec::{Arch, Cc, LinkerFlavor, Os, Target, TargetMetadata, base};
 
 pub(crate) fn target() -> Target {
     let mut options = base::wasm::options();
-    options.os = "unknown".into();
+    options.os = Os::Unknown;
 
     options.add_pre_link_args(
         LinkerFlavor::WasmLld(Cc::No),

--- a/compiler/rustc_target/src/spec/targets/x86_64_apple_darwin.rs
+++ b/compiler/rustc_target/src/spec/targets/x86_64_apple_darwin.rs
@@ -1,8 +1,8 @@
 use crate::spec::base::apple::{Arch, TargetEnv, base};
-use crate::spec::{SanitizerSet, Target, TargetMetadata, TargetOptions};
+use crate::spec::{Os, SanitizerSet, Target, TargetMetadata, TargetOptions};
 
 pub(crate) fn target() -> Target {
-    let (opts, llvm_target, arch) = base("macos", Arch::X86_64, TargetEnv::Normal);
+    let (opts, llvm_target, arch) = base(Os::MacOs, Arch::X86_64, TargetEnv::Normal);
     Target {
         llvm_target,
         metadata: TargetMetadata {

--- a/compiler/rustc_target/src/spec/targets/x86_64_apple_ios.rs
+++ b/compiler/rustc_target/src/spec/targets/x86_64_apple_ios.rs
@@ -1,10 +1,10 @@
 use crate::spec::base::apple::{Arch, TargetEnv, base};
-use crate::spec::{SanitizerSet, Target, TargetMetadata, TargetOptions};
+use crate::spec::{Os, SanitizerSet, Target, TargetMetadata, TargetOptions};
 
 pub(crate) fn target() -> Target {
     // x86_64-apple-ios is a simulator target, even though it isn't declared
     // that way in the target name like the other ones...
-    let (opts, llvm_target, arch) = base("ios", Arch::X86_64, TargetEnv::Simulator);
+    let (opts, llvm_target, arch) = base(Os::IOs, Arch::X86_64, TargetEnv::Simulator);
     Target {
         llvm_target,
         metadata: TargetMetadata {

--- a/compiler/rustc_target/src/spec/targets/x86_64_apple_ios_macabi.rs
+++ b/compiler/rustc_target/src/spec/targets/x86_64_apple_ios_macabi.rs
@@ -1,8 +1,8 @@
 use crate::spec::base::apple::{Arch, TargetEnv, base};
-use crate::spec::{SanitizerSet, Target, TargetMetadata, TargetOptions};
+use crate::spec::{Os, SanitizerSet, Target, TargetMetadata, TargetOptions};
 
 pub(crate) fn target() -> Target {
-    let (opts, llvm_target, arch) = base("ios", Arch::X86_64, TargetEnv::MacCatalyst);
+    let (opts, llvm_target, arch) = base(Os::IOs, Arch::X86_64, TargetEnv::MacCatalyst);
     Target {
         llvm_target,
         metadata: TargetMetadata {

--- a/compiler/rustc_target/src/spec/targets/x86_64_apple_tvos.rs
+++ b/compiler/rustc_target/src/spec/targets/x86_64_apple_tvos.rs
@@ -1,10 +1,10 @@
 use crate::spec::base::apple::{Arch, TargetEnv, base};
-use crate::spec::{Target, TargetMetadata, TargetOptions};
+use crate::spec::{Os, Target, TargetMetadata, TargetOptions};
 
 pub(crate) fn target() -> Target {
     // x86_64-apple-tvos is a simulator target, even though it isn't declared
     // that way in the target name like the other ones...
-    let (opts, llvm_target, arch) = base("tvos", Arch::X86_64, TargetEnv::Simulator);
+    let (opts, llvm_target, arch) = base(Os::TvOs, Arch::X86_64, TargetEnv::Simulator);
     Target {
         llvm_target,
         metadata: TargetMetadata {

--- a/compiler/rustc_target/src/spec/targets/x86_64_apple_watchos_sim.rs
+++ b/compiler/rustc_target/src/spec/targets/x86_64_apple_watchos_sim.rs
@@ -1,8 +1,8 @@
 use crate::spec::base::apple::{Arch, TargetEnv, base};
-use crate::spec::{Target, TargetMetadata, TargetOptions};
+use crate::spec::{Os, Target, TargetMetadata, TargetOptions};
 
 pub(crate) fn target() -> Target {
-    let (opts, llvm_target, arch) = base("watchos", Arch::X86_64, TargetEnv::Simulator);
+    let (opts, llvm_target, arch) = base(Os::WatchOs, Arch::X86_64, TargetEnv::Simulator);
     Target {
         llvm_target,
         metadata: TargetMetadata {

--- a/compiler/rustc_target/src/spec/targets/x86_64_fortanix_unknown_sgx.rs
+++ b/compiler/rustc_target/src/spec/targets/x86_64_fortanix_unknown_sgx.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use crate::spec::{Arch, Cc, LinkerFlavor, Lld, Target, TargetMetadata, TargetOptions, cvs};
+use crate::spec::{Abi, Arch, Cc, LinkerFlavor, Lld, Target, TargetMetadata, TargetOptions, cvs};
 
 pub(crate) fn target() -> Target {
     let pre_link_args = TargetOptions::link_args(
@@ -58,7 +58,7 @@ pub(crate) fn target() -> Target {
         os: "unknown".into(),
         env: "sgx".into(),
         vendor: "fortanix".into(),
-        abi: "fortanix".into(),
+        abi: Abi::Fortanix,
         linker_flavor: LinkerFlavor::Gnu(Cc::No, Lld::Yes),
         linker: Some("rust-lld".into()),
         max_atomic_width: Some(64),

--- a/compiler/rustc_target/src/spec/targets/x86_64_fortanix_unknown_sgx.rs
+++ b/compiler/rustc_target/src/spec/targets/x86_64_fortanix_unknown_sgx.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
 use crate::spec::{
-    Abi, Arch, Cc, Env, LinkerFlavor, Lld, Target, TargetMetadata, TargetOptions, cvs,
+    Abi, Arch, Cc, Env, LinkerFlavor, Lld, Os, Target, TargetMetadata, TargetOptions, cvs,
 };
 
 pub(crate) fn target() -> Target {
@@ -57,7 +57,7 @@ pub(crate) fn target() -> Target {
         "TEXT_SIZE",
     ];
     let opts = TargetOptions {
-        os: "unknown".into(),
+        os: Os::Unknown,
         env: Env::Sgx,
         vendor: "fortanix".into(),
         abi: Abi::Fortanix,

--- a/compiler/rustc_target/src/spec/targets/x86_64_fortanix_unknown_sgx.rs
+++ b/compiler/rustc_target/src/spec/targets/x86_64_fortanix_unknown_sgx.rs
@@ -1,6 +1,8 @@
 use std::borrow::Cow;
 
-use crate::spec::{Abi, Arch, Cc, LinkerFlavor, Lld, Target, TargetMetadata, TargetOptions, cvs};
+use crate::spec::{
+    Abi, Arch, Cc, Env, LinkerFlavor, Lld, Target, TargetMetadata, TargetOptions, cvs,
+};
 
 pub(crate) fn target() -> Target {
     let pre_link_args = TargetOptions::link_args(
@@ -56,7 +58,7 @@ pub(crate) fn target() -> Target {
     ];
     let opts = TargetOptions {
         os: "unknown".into(),
-        env: "sgx".into(),
+        env: Env::Sgx,
         vendor: "fortanix".into(),
         abi: Abi::Fortanix,
         linker_flavor: LinkerFlavor::Gnu(Cc::No, Lld::Yes),

--- a/compiler/rustc_target/src/spec/targets/x86_64_pc_nto_qnx710.rs
+++ b/compiler/rustc_target/src/spec/targets/x86_64_pc_nto_qnx710.rs
@@ -1,5 +1,5 @@
-use crate::spec::Target;
 use crate::spec::base::nto_qnx;
+use crate::spec::{Env, Target};
 
 pub(crate) fn target() -> Target {
     let mut target = nto_qnx::x86_64();
@@ -7,6 +7,6 @@ pub(crate) fn target() -> Target {
         Some("x86 64-bit QNX Neutrino 7.1 RTOS with io-pkt network stack".into());
     target.options.pre_link_args =
         nto_qnx::pre_link_args(nto_qnx::ApiVariant::Default, nto_qnx::Arch::X86_64);
-    target.options.env = "nto71".into();
+    target.options.env = Env::Nto71;
     target
 }

--- a/compiler/rustc_target/src/spec/targets/x86_64_pc_nto_qnx710_iosock.rs
+++ b/compiler/rustc_target/src/spec/targets/x86_64_pc_nto_qnx710_iosock.rs
@@ -1,5 +1,5 @@
-use crate::spec::Target;
 use crate::spec::base::nto_qnx;
+use crate::spec::{Env, Target};
 
 pub(crate) fn target() -> Target {
     let mut target = nto_qnx::x86_64();
@@ -7,6 +7,6 @@ pub(crate) fn target() -> Target {
         Some("x86 64-bit QNX Neutrino 7.1 RTOS with io-sock network stack".into());
     target.options.pre_link_args =
         nto_qnx::pre_link_args(nto_qnx::ApiVariant::IoSock, nto_qnx::Arch::X86_64);
-    target.options.env = "nto71_iosock".into();
+    target.options.env = Env::Nto71IoSock;
     target
 }

--- a/compiler/rustc_target/src/spec/targets/x86_64_pc_nto_qnx800.rs
+++ b/compiler/rustc_target/src/spec/targets/x86_64_pc_nto_qnx800.rs
@@ -1,11 +1,11 @@
-use crate::spec::Target;
 use crate::spec::base::nto_qnx;
+use crate::spec::{Env, Target};
 
 pub(crate) fn target() -> Target {
     let mut target = nto_qnx::x86_64();
     target.metadata.description = Some("x86 64-bit QNX Neutrino 8.0 RTOS".into());
     target.options.pre_link_args =
         nto_qnx::pre_link_args(nto_qnx::ApiVariant::Default, nto_qnx::Arch::X86_64);
-    target.options.env = "nto80".into();
+    target.options.env = Env::Nto80;
     target
 }

--- a/compiler/rustc_target/src/spec/targets/x86_64_unknown_linux_gnux32.rs
+++ b/compiler/rustc_target/src/spec/targets/x86_64_unknown_linux_gnux32.rs
@@ -1,9 +1,9 @@
-use crate::spec::{Arch, Cc, LinkerFlavor, Lld, StackProbeType, Target, TargetMetadata, base};
+use crate::spec::{Abi, Arch, Cc, LinkerFlavor, Lld, StackProbeType, Target, TargetMetadata, base};
 
 pub(crate) fn target() -> Target {
     let mut base = base::linux_gnu::opts();
     base.cpu = "x86-64".into();
-    base.abi = "x32".into();
+    base.abi = Abi::X32;
     base.max_atomic_width = Some(64);
     base.add_pre_link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &["-mx32"]);
     base.stack_probes = StackProbeType::Inline;

--- a/compiler/rustc_target/src/spec/targets/x86_64_unknown_trusty.rs
+++ b/compiler/rustc_target/src/spec/targets/x86_64_unknown_trusty.rs
@@ -1,7 +1,7 @@
 // Trusty OS target for X86_64.
 
 use crate::spec::{
-    Arch, LinkSelfContainedDefault, PanicStrategy, RelroLevel, StackProbeType, Target,
+    Arch, LinkSelfContainedDefault, Os, PanicStrategy, RelroLevel, StackProbeType, Target,
     TargetMetadata, TargetOptions,
 };
 
@@ -22,7 +22,7 @@ pub(crate) fn target() -> Target {
             executables: true,
             max_atomic_width: Some(64),
             panic_strategy: PanicStrategy::Abort,
-            os: "trusty".into(),
+            os: Os::Trusty,
             link_self_contained: LinkSelfContainedDefault::InferredForMusl,
             position_independent_executables: true,
             static_position_independent_executables: true,

--- a/compiler/rustc_target/src/spec/targets/x86_64h_apple_darwin.rs
+++ b/compiler/rustc_target/src/spec/targets/x86_64h_apple_darwin.rs
@@ -1,8 +1,8 @@
 use crate::spec::base::apple::{Arch, TargetEnv, base};
-use crate::spec::{SanitizerSet, Target, TargetMetadata, TargetOptions};
+use crate::spec::{Os, SanitizerSet, Target, TargetMetadata, TargetOptions};
 
 pub(crate) fn target() -> Target {
-    let (mut opts, llvm_target, arch) = base("macos", Arch::X86_64h, TargetEnv::Normal);
+    let (mut opts, llvm_target, arch) = base(Os::MacOs, Arch::X86_64h, TargetEnv::Normal);
     opts.max_atomic_width = Some(128);
     opts.supported_sanitizers =
         SanitizerSet::ADDRESS | SanitizerSet::CFI | SanitizerSet::LEAK | SanitizerSet::THREAD;

--- a/compiler/rustc_target/src/spec/targets/xtensa_esp32_espidf.rs
+++ b/compiler/rustc_target/src/spec/targets/xtensa_esp32_espidf.rs
@@ -1,7 +1,7 @@
 use rustc_abi::Endian;
 
 use crate::spec::base::xtensa;
-use crate::spec::{Arch, Target, TargetMetadata, TargetOptions, cvs};
+use crate::spec::{Arch, Env, Target, TargetMetadata, TargetOptions, cvs};
 
 pub(crate) fn target() -> Target {
     Target {
@@ -16,7 +16,7 @@ pub(crate) fn target() -> Target {
             c_int_width: 32,
             families: cvs!["unix"],
             os: "espidf".into(),
-            env: "newlib".into(),
+            env: Env::Newlib,
             vendor: "espressif".into(),
 
             executables: true,

--- a/compiler/rustc_target/src/spec/targets/xtensa_esp32_espidf.rs
+++ b/compiler/rustc_target/src/spec/targets/xtensa_esp32_espidf.rs
@@ -1,7 +1,7 @@
 use rustc_abi::Endian;
 
 use crate::spec::base::xtensa;
-use crate::spec::{Arch, Env, Target, TargetMetadata, TargetOptions, cvs};
+use crate::spec::{Arch, Env, Os, Target, TargetMetadata, TargetOptions, cvs};
 
 pub(crate) fn target() -> Target {
     Target {
@@ -15,7 +15,7 @@ pub(crate) fn target() -> Target {
             endian: Endian::Little,
             c_int_width: 32,
             families: cvs!["unix"],
-            os: "espidf".into(),
+            os: Os::EspIdf,
             env: Env::Newlib,
             vendor: "espressif".into(),
 

--- a/compiler/rustc_target/src/spec/targets/xtensa_esp32s2_espidf.rs
+++ b/compiler/rustc_target/src/spec/targets/xtensa_esp32s2_espidf.rs
@@ -1,7 +1,7 @@
 use rustc_abi::Endian;
 
 use crate::spec::base::xtensa;
-use crate::spec::{Arch, Target, TargetMetadata, TargetOptions, cvs};
+use crate::spec::{Arch, Env, Target, TargetMetadata, TargetOptions, cvs};
 
 pub(crate) fn target() -> Target {
     Target {
@@ -16,7 +16,7 @@ pub(crate) fn target() -> Target {
             c_int_width: 32,
             families: cvs!["unix"],
             os: "espidf".into(),
-            env: "newlib".into(),
+            env: Env::Newlib,
             vendor: "espressif".into(),
 
             executables: true,

--- a/compiler/rustc_target/src/spec/targets/xtensa_esp32s2_espidf.rs
+++ b/compiler/rustc_target/src/spec/targets/xtensa_esp32s2_espidf.rs
@@ -1,7 +1,7 @@
 use rustc_abi::Endian;
 
 use crate::spec::base::xtensa;
-use crate::spec::{Arch, Env, Target, TargetMetadata, TargetOptions, cvs};
+use crate::spec::{Arch, Env, Os, Target, TargetMetadata, TargetOptions, cvs};
 
 pub(crate) fn target() -> Target {
     Target {
@@ -15,7 +15,7 @@ pub(crate) fn target() -> Target {
             endian: Endian::Little,
             c_int_width: 32,
             families: cvs!["unix"],
-            os: "espidf".into(),
+            os: Os::EspIdf,
             env: Env::Newlib,
             vendor: "espressif".into(),
 

--- a/compiler/rustc_target/src/spec/targets/xtensa_esp32s3_espidf.rs
+++ b/compiler/rustc_target/src/spec/targets/xtensa_esp32s3_espidf.rs
@@ -1,7 +1,7 @@
 use rustc_abi::Endian;
 
 use crate::spec::base::xtensa;
-use crate::spec::{Arch, Target, TargetMetadata, TargetOptions, cvs};
+use crate::spec::{Arch, Env, Target, TargetMetadata, TargetOptions, cvs};
 
 pub(crate) fn target() -> Target {
     Target {
@@ -16,7 +16,7 @@ pub(crate) fn target() -> Target {
             c_int_width: 32,
             families: cvs!["unix"],
             os: "espidf".into(),
-            env: "newlib".into(),
+            env: Env::Newlib,
             vendor: "espressif".into(),
 
             executables: true,

--- a/compiler/rustc_target/src/spec/targets/xtensa_esp32s3_espidf.rs
+++ b/compiler/rustc_target/src/spec/targets/xtensa_esp32s3_espidf.rs
@@ -1,7 +1,7 @@
 use rustc_abi::Endian;
 
 use crate::spec::base::xtensa;
-use crate::spec::{Arch, Env, Target, TargetMetadata, TargetOptions, cvs};
+use crate::spec::{Arch, Env, Os, Target, TargetMetadata, TargetOptions, cvs};
 
 pub(crate) fn target() -> Target {
     Target {
@@ -15,7 +15,7 @@ pub(crate) fn target() -> Target {
             endian: Endian::Little,
             c_int_width: 32,
             families: cvs!["unix"],
-            os: "espidf".into(),
+            os: Os::EspIdf,
             env: Env::Newlib,
             vendor: "espressif".into(),
 

--- a/compiler/rustc_target/src/target_features.rs
+++ b/compiler/rustc_target/src/target_features.rs
@@ -5,7 +5,7 @@ use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
 use rustc_span::{Symbol, sym};
 
-use crate::spec::{Arch, FloatAbi, RustcAbi, Target};
+use crate::spec::{Abi, Arch, FloatAbi, RustcAbi, Target};
 
 /// Features that control behaviour of rustc, rather than the codegen.
 /// These exist globally and are not in the target-specific lists below.
@@ -1119,20 +1119,17 @@ impl Target {
             Arch::AArch64 | Arch::Arm64EC => {
                 // Aarch64 has no sane ABI specifier, and LLVM doesn't even have a way to force
                 // the use of soft-float, so all we can do here is some crude hacks.
-                match &*self.abi {
-                    "softfloat" => {
-                        // LLVM will use float registers when `fp-armv8` is available, e.g. for
-                        // calls to built-ins. The only way to ensure a consistent softfloat ABI
-                        // on aarch64 is to never enable `fp-armv8`, so we enforce that.
-                        // In Rust we tie `neon` and `fp-armv8` together, therefore `neon` is the
-                        // feature we have to mark as incompatible.
-                        FeatureConstraints { required: &[], incompatible: &["neon"] }
-                    }
-                    _ => {
-                        // Everything else is assumed to use a hardfloat ABI. neon and fp-armv8 must be enabled.
-                        // `FeatureConstraints` uses Rust feature names, hence only "neon" shows up.
-                        FeatureConstraints { required: &["neon"], incompatible: &[] }
-                    }
+                if matches!(self.abi, Abi::SoftFloat) {
+                    // LLVM will use float registers when `fp-armv8` is available, e.g. for
+                    // calls to built-ins. The only way to ensure a consistent softfloat ABI
+                    // on aarch64 is to never enable `fp-armv8`, so we enforce that.
+                    // In Rust we tie `neon` and `fp-armv8` together, therefore `neon` is the
+                    // feature we have to mark as incompatible.
+                    FeatureConstraints { required: &[], incompatible: &["neon"] }
+                } else {
+                    // Everything else is assumed to use a hardfloat ABI. neon and fp-armv8 must be enabled.
+                    // `FeatureConstraints` uses Rust feature names, hence only "neon" shows up.
+                    FeatureConstraints { required: &["neon"], incompatible: &[] }
                 }
             }
             Arch::RiscV32 | Arch::RiscV64 => {

--- a/compiler/rustc_target/src/target_features.rs
+++ b/compiler/rustc_target/src/target_features.rs
@@ -977,7 +977,7 @@ impl Target {
             | Arch::PowerPC64LE
             | Arch::SpirV
             | Arch::Xtensa
-            | Arch::Unknown(_) => &[],
+            | Arch::Other(_) => &[],
         }
     }
 
@@ -1006,7 +1006,7 @@ impl Target {
             | Arch::PowerPC64LE
             | Arch::SpirV
             | Arch::Xtensa
-            | Arch::Unknown(_) => &[],
+            | Arch::Other(_) => &[],
         }
     }
 

--- a/src/tools/miri/src/concurrency/thread.rs
+++ b/src/tools/miri/src/concurrency/thread.rs
@@ -15,6 +15,7 @@ use rustc_index::{Idx, IndexVec};
 use rustc_middle::mir::Mutability;
 use rustc_middle::ty::layout::TyAndLayout;
 use rustc_span::Span;
+use rustc_target::spec::Os;
 
 use crate::concurrency::GlobalDataRaceHandler;
 use crate::shims::tls;
@@ -471,7 +472,7 @@ impl<'tcx> ThreadManager<'tcx> {
     ) {
         ecx.machine.threads.threads[ThreadId::MAIN_THREAD].on_stack_empty =
             Some(on_main_stack_empty);
-        if ecx.tcx.sess.target.os.as_ref() != "windows" {
+        if ecx.tcx.sess.target.os != Os::Windows {
             // The main thread can *not* be joined on except on windows.
             ecx.machine.threads.threads[ThreadId::MAIN_THREAD].join_status =
                 ThreadJoinStatus::Detached;

--- a/src/tools/miri/src/eval.rs
+++ b/src/tools/miri/src/eval.rs
@@ -14,6 +14,7 @@ use rustc_hir::def_id::DefId;
 use rustc_middle::ty::layout::{HasTyCtxt, HasTypingEnv, LayoutCx};
 use rustc_middle::ty::{self, Ty, TyCtxt};
 use rustc_session::config::EntryFnType;
+use rustc_target::spec::Os;
 
 use crate::concurrency::GenmcCtx;
 use crate::concurrency::thread::TlsAllocAction;
@@ -341,7 +342,7 @@ pub fn create_ecx<'tcx>(
             ecx.machine.argv = Some(argv_place.ptr());
         }
         // Store command line as UTF-16 for Windows `GetCommandLineW`.
-        if tcx.sess.target.os == "windows" {
+        if tcx.sess.target.os == Os::Windows {
             // Construct a command string with all the arguments.
             let cmd_utf16: Vec<u16> = args_to_utf16_command_string(config.args.iter());
 

--- a/src/tools/miri/src/machine.rs
+++ b/src/tools/miri/src/machine.rs
@@ -31,7 +31,7 @@ use rustc_span::def_id::{CrateNum, DefId};
 use rustc_span::{Span, SpanData, Symbol};
 use rustc_symbol_mangling::mangle_internal_symbol;
 use rustc_target::callconv::FnAbi;
-use rustc_target::spec::Arch;
+use rustc_target::spec::{Arch, Os};
 
 use crate::alloc_addresses::EvalContextExt;
 use crate::concurrency::cpu_affinity::{self, CpuAffinityMask};
@@ -739,7 +739,7 @@ impl<'tcx> MiriMachine<'tcx> {
         );
         let threads = ThreadManager::new(config);
         let mut thread_cpu_affinity = FxHashMap::default();
-        if matches!(&*tcx.sess.target.os, "linux" | "freebsd" | "android") {
+        if matches!(&tcx.sess.target.os, Os::Linux | Os::FreeBsd | Os::Android) {
             thread_cpu_affinity
                 .insert(threads.active_thread(), CpuAffinityMask::new(&layout_cx, config.num_cpus));
         }

--- a/src/tools/miri/src/shims/alloc.rs
+++ b/src/tools/miri/src/shims/alloc.rs
@@ -3,7 +3,7 @@ use rustc_ast::expand::allocator::SpecialAllocatorMethod;
 use rustc_middle::ty::Ty;
 use rustc_span::Symbol;
 use rustc_target::callconv::FnAbi;
-use rustc_target::spec::Arch;
+use rustc_target::spec::{Arch, Os};
 
 use crate::*;
 
@@ -19,10 +19,10 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         // This is given by `alignof(max_align_t)`. The following list is taken from
         // `library/std/src/sys/alloc/mod.rs` (where this is called `MIN_ALIGN`) and should
         // be kept in sync.
-        let os = this.tcx.sess.target.os.as_ref();
+        let os = &this.tcx.sess.target.os;
         let max_fundamental_align = match &this.tcx.sess.target.arch {
-            Arch::RiscV32 if matches!(os, "espidf" | "zkvm") => 4,
-            Arch::Xtensa if matches!(os, "espidf") => 4,
+            Arch::RiscV32 if matches!(os, Os::EspIdf | Os::Zkvm) => 4,
+            Arch::Xtensa if matches!(os, Os::EspIdf) => 4,
             Arch::X86
             | Arch::Arm
             | Arch::M68k

--- a/src/tools/miri/src/shims/alloc.rs
+++ b/src/tools/miri/src/shims/alloc.rs
@@ -54,7 +54,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             | Arch::Nvptx64
             | Arch::PowerPC64LE
             | Arch::SpirV
-            | Arch::Unknown(_)) => bug!("unsupported target architecture for malloc: `{arch}`"),
+            | Arch::Other(_)) => bug!("unsupported target architecture for malloc: `{arch}`"),
         };
         // The C standard only requires sufficient alignment for any *type* with size less than or
         // equal to the size requested. Types one can define in standard C seem to never have an alignment

--- a/src/tools/miri/src/shims/env.rs
+++ b/src/tools/miri/src/shims/env.rs
@@ -1,6 +1,7 @@
 use std::ffi::{OsStr, OsString};
 
 use rustc_data_structures::fx::FxHashMap;
+use rustc_target::spec::Os;
 
 use self::shims::unix::UnixEnvVars;
 use self::shims::windows::WindowsEnvVars;
@@ -48,7 +49,7 @@ impl<'tcx> EnvVars<'tcx> {
 
         let env_vars = if ecx.target_os_is_unix() {
             EnvVars::Unix(UnixEnvVars::new(ecx, env_vars)?)
-        } else if ecx.tcx.sess.target.os == "windows" {
+        } else if ecx.tcx.sess.target.os == Os::Windows {
             EnvVars::Windows(WindowsEnvVars::new(ecx, env_vars)?)
         } else {
             // For "none" targets (i.e., without an OS).
@@ -118,7 +119,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         let this = self.eval_context_ref();
         let index = thread.to_u32();
         let target_os = &this.tcx.sess.target.os;
-        if target_os == "linux" || target_os == "netbsd" {
+        if matches!(target_os, Os::Linux | Os::NetBsd) {
             // On Linux, the main thread has PID == TID so we uphold this. NetBSD also appears
             // to exhibit the same behavior, though I can't find a citation.
             this.get_pid().strict_add(index)

--- a/src/tools/miri/src/shims/foreign_items.rs
+++ b/src/tools/miri/src/shims/foreign_items.rs
@@ -15,7 +15,7 @@ use rustc_middle::{mir, ty};
 use rustc_session::config::OomStrategy;
 use rustc_span::Symbol;
 use rustc_target::callconv::FnAbi;
-use rustc_target::spec::Arch;
+use rustc_target::spec::{Os, Arch};
 
 use super::alloc::EvalContextExt as _;
 use super::backtrace::EvalContextExt as _;
@@ -101,9 +101,9 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
     fn is_dyn_sym(&self, name: &str) -> bool {
         let this = self.eval_context_ref();
-        match this.tcx.sess.target.os.as_ref() {
+        match &this.tcx.sess.target.os {
             os if this.target_os_is_unix() => shims::unix::foreign_items::is_dyn_sym(name, os),
-            "windows" => shims::windows::foreign_items::is_dyn_sym(name),
+            Os::Windows => shims::windows::foreign_items::is_dyn_sym(name),
             _ => false,
         }
     }
@@ -842,12 +842,12 @@ trait EvalContextExtPriv<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 }
 
                 // Platform-specific shims
-                return match this.tcx.sess.target.os.as_ref() {
+                return match &this.tcx.sess.target.os {
                     _ if this.target_os_is_unix() =>
                         shims::unix::foreign_items::EvalContextExt::emulate_foreign_item_inner(
                             this, link_name, abi, args, dest,
                         ),
-                    "windows" =>
+                    Os::Windows =>
                         shims::windows::foreign_items::EvalContextExt::emulate_foreign_item_inner(
                             this, link_name, abi, args, dest,
                         ),

--- a/src/tools/miri/src/shims/os_str.rs
+++ b/src/tools/miri/src/shims/os_str.rs
@@ -7,6 +7,7 @@ use std::os::windows::ffi::{OsStrExt, OsStringExt};
 use std::path::{Path, PathBuf};
 
 use rustc_middle::ty::Ty;
+use rustc_target::spec::Os;
 
 use crate::*;
 
@@ -329,7 +330,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         // Below we assume that everything non-Windows works like Unix, at least
         // when it comes to file system path conventions.
         #[cfg(windows)]
-        return if target_os == "windows" {
+        return if *target_os == Os::Windows {
             // Windows-on-Windows, all fine.
             os_str
         } else {
@@ -346,7 +347,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             Cow::Owned(OsString::from_wide(&path))
         };
         #[cfg(unix)]
-        return if target_os == "windows" {
+        return if *target_os == Os::Windows {
             // Windows target, Unix host.
             let mut path: Vec<u8> = os_str.into_owned().into_encoded_bytes();
             match direction {

--- a/src/tools/miri/src/shims/tls.rs
+++ b/src/tools/miri/src/shims/tls.rs
@@ -6,6 +6,7 @@ use std::task::Poll;
 
 use rustc_abi::{ExternAbi, HasDataLayout, Size};
 use rustc_middle::ty;
+use rustc_target::spec::Os;
 
 use crate::*;
 
@@ -234,8 +235,8 @@ impl<'tcx> TlsDtorsState<'tcx> {
         let new_state = 'new_state: {
             match &mut self.0 {
                 Init => {
-                    match this.tcx.sess.target.os.as_ref() {
-                        "macos" => {
+                    match this.tcx.sess.target.os {
+                        Os::MacOs => {
                             // macOS has a _tlv_atexit function that allows
                             // registering destructors without associated keys.
                             // These are run first.
@@ -245,7 +246,7 @@ impl<'tcx> TlsDtorsState<'tcx> {
                             // All other Unixes directly jump to running the pthread dtors.
                             break 'new_state PthreadDtors(Default::default());
                         }
-                        "windows" => {
+                        Os::Windows => {
                             // Determine which destructors to run.
                             let dtors = this.lookup_windows_tls_dtors()?;
                             // And move to the next state, that runs them.

--- a/src/tools/miri/src/shims/unix/env.rs
+++ b/src/tools/miri/src/shims/unix/env.rs
@@ -6,6 +6,7 @@ use rustc_abi::{FieldIdx, Size};
 use rustc_data_structures::fx::FxHashMap;
 use rustc_index::IndexVec;
 use rustc_middle::ty::Ty;
+use rustc_target::spec::Os;
 
 use crate::*;
 
@@ -281,7 +282,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         tid_op: &OpTy<'tcx>,
     ) -> InterpResult<'tcx, Scalar> {
         let this = self.eval_context_mut();
-        this.assert_target_os("macos", "pthread_threadip_np");
+        this.assert_target_os(Os::MacOs, "pthread_threadip_np");
 
         let tid_dest = this.read_pointer(tid_op)?;
         if this.ptr_is_null(tid_dest)? {

--- a/src/tools/miri/src/shims/unix/fd.rs
+++ b/src/tools/miri/src/shims/unix/fd.rs
@@ -6,6 +6,7 @@ use std::io::ErrorKind;
 
 use rand::Rng;
 use rustc_abi::Size;
+use rustc_target::spec::Os;
 
 use crate::shims::files::FileDescription;
 use crate::shims::sig::check_min_vararg_count;
@@ -197,7 +198,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
                 fd.set_flags(flag, this)
             }
-            cmd if this.tcx.sess.target.os == "macos"
+            cmd if this.tcx.sess.target.os == Os::MacOs
                 && cmd == this.eval_libc_i32("F_FULLFSYNC") =>
             {
                 // Reject if isolation is enabled.

--- a/src/tools/miri/src/shims/unix/foreign_items.rs
+++ b/src/tools/miri/src/shims/unix/foreign_items.rs
@@ -5,6 +5,7 @@ use rustc_abi::{CanonAbi, Size};
 use rustc_middle::ty::Ty;
 use rustc_span::Symbol;
 use rustc_target::callconv::FnAbi;
+use rustc_target::spec::Os;
 
 use self::shims::unix::android::foreign_items as android;
 use self::shims::unix::freebsd::foreign_items as freebsd;
@@ -16,7 +17,7 @@ use crate::shims::alloc::EvalContextExt as _;
 use crate::shims::unix::*;
 use crate::{shim_sig, *};
 
-pub fn is_dyn_sym(name: &str, target_os: &str) -> bool {
+pub fn is_dyn_sym(name: &str, target_os: &Os) -> bool {
     match name {
         // Used for tests.
         "isatty" => true,
@@ -26,15 +27,14 @@ pub fn is_dyn_sym(name: &str, target_os: &str) -> bool {
         // needed at least on macOS to avoid file-based fallback in getrandom
         "getentropy" | "getrandom" => true,
         // Give specific OSes a chance to allow their symbols.
-        _ =>
-            match target_os {
-                "android" => android::is_dyn_sym(name),
-                "freebsd" => freebsd::is_dyn_sym(name),
-                "linux" => linux::is_dyn_sym(name),
-                "macos" => macos::is_dyn_sym(name),
-                "solaris" | "illumos" => solarish::is_dyn_sym(name),
-                _ => false,
-            },
+        _ => match *target_os {
+            Os::Android => android::is_dyn_sym(name),
+            Os::FreeBsd => freebsd::is_dyn_sym(name),
+            Os::Linux => linux::is_dyn_sym(name),
+            Os::MacOs => macos::is_dyn_sym(name),
+            Os::Solaris | Os::Illumos => solarish::is_dyn_sym(name),
+            _ => false,
+        },
     }
 }
 
@@ -302,7 +302,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             }
             "flock" => {
                 // Currently this function does not exist on all Unixes, e.g. on Solaris.
-                this.check_target_os(&["linux", "freebsd", "macos", "illumos"], link_name)?;
+                this.check_target_os(&[Os::Linux, Os::FreeBsd, Os::MacOs, Os::Illumos], link_name)?;
                 let [fd, op] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(i32, i32) -> i32),
                     link_name,
@@ -530,7 +530,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             }
             "pipe2" => {
                 // Currently this function does not exist on all Unixes, e.g. on macOS.
-                this.check_target_os(&["linux", "freebsd", "solaris", "illumos"], link_name)?;
+                this.check_target_os(&[Os::Linux, Os::FreeBsd, Os::Solaris, Os::Illumos], link_name)?;
                 let [pipefd, flags] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(*mut _, i32) -> i32),
                     link_name,
@@ -596,7 +596,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
             "reallocarray" => {
                 // Currently this function does not exist on all Unixes, e.g. on macOS.
-                this.check_target_os(&["linux", "freebsd", "android"], link_name)?;
+                this.check_target_os(&[Os::Linux, Os::FreeBsd, Os::Android], link_name)?;
                 let [ptr, nmemb, size] =
                     this.check_shim_sig_lenient(abi, CanonAbi::C, link_name, args)?;
                 let ptr = this.read_pointer(ptr)?;
@@ -861,7 +861,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "clock_nanosleep" => {
                 // Currently this function does not exist on all Unixes, e.g. on macOS.
                 this.check_target_os(
-                    &["freebsd", "linux", "android", "solaris", "illumos"],
+                    &[Os::FreeBsd, Os::Linux, Os::Android, Os::Solaris, Os::Illumos],
                     link_name,
                 )?;
                 let [clock_id, flags, req, rem] =
@@ -871,7 +871,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             }
             "sched_getaffinity" => {
                 // Currently this function does not exist on all Unixes, e.g. on macOS.
-                this.check_target_os(&["linux", "freebsd", "android"], link_name)?;
+                this.check_target_os(&[Os::Linux, Os::FreeBsd, Os::Android], link_name)?;
                 let [pid, cpusetsize, mask] =
                     this.check_shim_sig_lenient(abi, CanonAbi::C, link_name, args)?;
                 let pid = this.read_scalar(pid)?.to_u32()?;
@@ -909,7 +909,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             }
             "sched_setaffinity" => {
                 // Currently this function does not exist on all Unixes, e.g. on macOS.
-                this.check_target_os(&["linux", "freebsd", "android"], link_name)?;
+                this.check_target_os(&[Os::Linux, Os::FreeBsd, Os::Android], link_name)?;
                 let [pid, cpusetsize, mask] =
                     this.check_shim_sig_lenient(abi, CanonAbi::C, link_name, args)?;
                 let pid = this.read_scalar(pid)?.to_u32()?;
@@ -968,7 +968,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // This function is non-standard but exists with the same signature and behavior on
                 // Linux, macOS, FreeBSD and Solaris/Illumos.
                 this.check_target_os(
-                    &["linux", "macos", "freebsd", "illumos", "solaris", "android"],
+                    &[Os::Linux, Os::MacOs, Os::FreeBsd, Os::Illumos, Os::Solaris, Os::Android],
                     link_name,
                 )?;
                 let [buf, bufsize] =
@@ -1000,7 +1000,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // This function is non-standard but exists with the same signature and behavior on
                 // Linux, FreeBSD and Solaris/Illumos.
                 this.check_target_os(
-                    &["linux", "freebsd", "illumos", "solaris", "android"],
+                    &[Os::Linux, Os::FreeBsd, Os::Illumos, Os::Solaris, Os::Android],
                     link_name,
                 )?;
                 let [ptr, len, flags] =
@@ -1015,7 +1015,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "arc4random_buf" => {
                 // This function is non-standard but exists with the same signature and
                 // same behavior (eg never fails) on FreeBSD and Solaris/Illumos.
-                this.check_target_os(&["freebsd", "illumos", "solaris"], link_name)?;
+                this.check_target_os(&[Os::FreeBsd, Os::Illumos, Os::Solaris], link_name)?;
                 let [ptr, len] = this.check_shim_sig_lenient(abi, CanonAbi::C, link_name, args)?;
                 let ptr = this.read_pointer(ptr)?;
                 let len = this.read_target_usize(len)?;
@@ -1036,7 +1036,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // `_Unwind_RaiseException` impl in miri should work:
                 // https://github.com/ARM-software/abi-aa/blob/main/ehabi32/ehabi32.rst
                 this.check_target_os(
-                    &["linux", "freebsd", "illumos", "solaris", "android", "macos"],
+                    &[Os::Linux, Os::FreeBsd, Os::Illumos, Os::Solaris, Os::Android, Os::MacOs],
                     link_name,
                 )?;
                 // This function looks and behaves excatly like miri_start_unwind.
@@ -1146,25 +1146,25 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
             // Platform-specific shims
             _ => {
-                let target_os = &*this.tcx.sess.target.os;
+                let target_os = &this.tcx.sess.target.os;
                 return match target_os {
-                    "android" =>
+                    Os::Android =>
                         android::EvalContextExt::emulate_foreign_item_inner(
                             this, link_name, abi, args, dest,
                         ),
-                    "freebsd" =>
+                    Os::FreeBsd =>
                         freebsd::EvalContextExt::emulate_foreign_item_inner(
                             this, link_name, abi, args, dest,
                         ),
-                    "linux" =>
+                    Os::Linux =>
                         linux::EvalContextExt::emulate_foreign_item_inner(
                             this, link_name, abi, args, dest,
                         ),
-                    "macos" =>
+                    Os::MacOs =>
                         macos::EvalContextExt::emulate_foreign_item_inner(
                             this, link_name, abi, args, dest,
                         ),
-                    "solaris" | "illumos" =>
+                    Os::Solaris | Os::Illumos =>
                         solarish::EvalContextExt::emulate_foreign_item_inner(
                             this, link_name, abi, args, dest,
                         ),

--- a/src/tools/miri/src/shims/unix/mem.rs
+++ b/src/tools/miri/src/shims/unix/mem.rs
@@ -15,6 +15,7 @@
 //! report UB.
 
 use rustc_abi::Size;
+use rustc_target::spec::Os;
 
 use crate::*;
 
@@ -46,7 +47,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         // This is a horrible hack, but on MacOS and Solarish the guard page mechanism uses mmap
         // in a way we do not support. We just give it the return value it expects.
         if this.frame_in_std()
-            && matches!(&*this.tcx.sess.target.os, "macos" | "solaris" | "illumos")
+            && matches!(&this.tcx.sess.target.os, Os::MacOs | Os::Solaris | Os::Illumos)
             && (flags & map_fixed) != 0
         {
             return interp_ok(Scalar::from_maybe_pointer(Pointer::without_provenance(addr), this));

--- a/src/tools/miri/src/shims/unix/solarish/foreign_items.rs
+++ b/src/tools/miri/src/shims/unix/solarish/foreign_items.rs
@@ -2,6 +2,7 @@ use rustc_abi::CanonAbi;
 use rustc_middle::ty::Ty;
 use rustc_span::Symbol;
 use rustc_target::callconv::FnAbi;
+use rustc_target::spec::Os;
 
 use crate::shims::unix::foreign_items::EvalContextExt as _;
 use crate::shims::unix::linux_like::epoll::EvalContextExt as _;
@@ -26,26 +27,26 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         match link_name.as_str() {
             // epoll, eventfd (NOT available on Solaris!)
             "epoll_create1" => {
-                this.assert_target_os("illumos", "epoll_create1");
+                this.assert_target_os(Os::Illumos, "epoll_create1");
                 let [flag] = this.check_shim_sig_lenient(abi, CanonAbi::C, link_name, args)?;
                 let result = this.epoll_create1(flag)?;
                 this.write_scalar(result, dest)?;
             }
             "epoll_ctl" => {
-                this.assert_target_os("illumos", "epoll_ctl");
+                this.assert_target_os(Os::Illumos, "epoll_ctl");
                 let [epfd, op, fd, event] =
                     this.check_shim_sig_lenient(abi, CanonAbi::C, link_name, args)?;
                 let result = this.epoll_ctl(epfd, op, fd, event)?;
                 this.write_scalar(result, dest)?;
             }
             "epoll_wait" => {
-                this.assert_target_os("illumos", "epoll_wait");
+                this.assert_target_os(Os::Illumos, "epoll_wait");
                 let [epfd, events, maxevents, timeout] =
                     this.check_shim_sig_lenient(abi, CanonAbi::C, link_name, args)?;
                 this.epoll_wait(epfd, events, maxevents, timeout, dest)?;
             }
             "eventfd" => {
-                this.assert_target_os("illumos", "eventfd");
+                this.assert_target_os(Os::Illumos, "eventfd");
                 let [val, flag] = this.check_shim_sig_lenient(abi, CanonAbi::C, link_name, args)?;
                 let result = this.eventfd(val, flag)?;
                 this.write_scalar(result, dest)?;

--- a/src/tools/miri/src/shims/unix/unnamed_socket.rs
+++ b/src/tools/miri/src/shims/unix/unnamed_socket.rs
@@ -7,6 +7,8 @@ use std::collections::VecDeque;
 use std::io;
 use std::io::ErrorKind;
 
+use rustc_target::spec::Os;
+
 use crate::concurrency::VClock;
 use crate::shims::files::{
     EvalContextExt as _, FileDescription, FileDescriptionRef, WeakFileDescriptionRef,
@@ -448,7 +450,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
         // Interpret the flag. Every flag we recognize is "subtracted" from `flags`, so
         // if there is anything left at the end, that's an unsupported flag.
-        if this.tcx.sess.target.os == "linux" {
+        if this.tcx.sess.target.os == Os::Linux {
             // SOCK_NONBLOCK only exists on Linux.
             let sock_nonblock = this.eval_libc_i32("SOCK_NONBLOCK");
             let sock_cloexec = this.eval_libc_i32("SOCK_CLOEXEC");

--- a/src/tools/miri/src/shims/windows/env.rs
+++ b/src/tools/miri/src/shims/windows/env.rs
@@ -3,6 +3,7 @@ use std::ffi::{OsStr, OsString};
 use std::io::ErrorKind;
 
 use rustc_data_structures::fx::FxHashMap;
+use rustc_target::spec::Os;
 
 use self::helpers::windows_check_buffer_size;
 use crate::*;
@@ -45,7 +46,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         // ^ Returns DWORD (u32 on Windows)
 
         let this = self.eval_context_mut();
-        this.assert_target_os("windows", "GetEnvironmentVariableW");
+        this.assert_target_os(Os::Windows, "GetEnvironmentVariableW");
 
         let name_ptr = this.read_pointer(name_op)?;
         let buf_ptr = this.read_pointer(buf_op)?;
@@ -73,7 +74,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
     #[allow(non_snake_case)]
     fn GetEnvironmentStringsW(&mut self) -> InterpResult<'tcx, Pointer> {
         let this = self.eval_context_mut();
-        this.assert_target_os("windows", "GetEnvironmentStringsW");
+        this.assert_target_os(Os::Windows, "GetEnvironmentStringsW");
 
         // Info on layout of environment blocks in Windows:
         // https://docs.microsoft.com/en-us/windows/win32/procthread/environment-variables
@@ -95,7 +96,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
     #[allow(non_snake_case)]
     fn FreeEnvironmentStringsW(&mut self, env_block_op: &OpTy<'tcx>) -> InterpResult<'tcx, Scalar> {
         let this = self.eval_context_mut();
-        this.assert_target_os("windows", "FreeEnvironmentStringsW");
+        this.assert_target_os(Os::Windows, "FreeEnvironmentStringsW");
 
         let env_block_ptr = this.read_pointer(env_block_op)?;
         this.deallocate_ptr(env_block_ptr, None, MiriMemoryKind::Runtime.into())?;
@@ -110,7 +111,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         value_op: &OpTy<'tcx>, // LPCWSTR
     ) -> InterpResult<'tcx, Scalar> {
         let this = self.eval_context_mut();
-        this.assert_target_os("windows", "SetEnvironmentVariableW");
+        this.assert_target_os(Os::Windows, "SetEnvironmentVariableW");
 
         let name_ptr = this.read_pointer(name_op)?;
         let value_ptr = this.read_pointer(value_op)?;
@@ -143,7 +144,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         buf_op: &OpTy<'tcx>,  // LPTSTR
     ) -> InterpResult<'tcx, Scalar> {
         let this = self.eval_context_mut();
-        this.assert_target_os("windows", "GetCurrentDirectoryW");
+        this.assert_target_os(Os::Windows, "GetCurrentDirectoryW");
 
         let size = u64::from(this.read_scalar(size_op)?.to_u32()?);
         let buf = this.read_pointer(buf_op)?;
@@ -176,7 +177,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         // ^ Returns BOOL (i32 on Windows)
 
         let this = self.eval_context_mut();
-        this.assert_target_os("windows", "SetCurrentDirectoryW");
+        this.assert_target_os(Os::Windows, "SetCurrentDirectoryW");
 
         let path = this.read_path_from_wide_str(this.read_pointer(path_op)?)?;
 
@@ -199,7 +200,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
     #[allow(non_snake_case)]
     fn GetCurrentProcessId(&mut self) -> InterpResult<'tcx, Scalar> {
         let this = self.eval_context_mut();
-        this.assert_target_os("windows", "GetCurrentProcessId");
+        this.assert_target_os(Os::Windows, "GetCurrentProcessId");
 
         interp_ok(Scalar::from_u32(this.get_pid()))
     }
@@ -213,7 +214,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
     ) -> InterpResult<'tcx, Scalar> // returns BOOL
     {
         let this = self.eval_context_mut();
-        this.assert_target_os("windows", "GetUserProfileDirectoryW");
+        this.assert_target_os(Os::Windows, "GetUserProfileDirectoryW");
         this.check_no_isolation("`GetUserProfileDirectoryW`")?;
 
         let token = this.read_target_isize(token)?;

--- a/src/tools/miri/src/shims/windows/foreign_items.rs
+++ b/src/tools/miri/src/shims/windows/foreign_items.rs
@@ -6,7 +6,7 @@ use rustc_abi::{Align, CanonAbi, Size, X86Call};
 use rustc_middle::ty::Ty;
 use rustc_span::Symbol;
 use rustc_target::callconv::FnAbi;
-use rustc_target::spec::Arch;
+use rustc_target::spec::{Arch, Env};
 
 use self::shims::windows::handle::{Handle, PseudoHandle};
 use crate::shims::os_str::bytes_to_os_str;
@@ -826,7 +826,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // It was originally specified as part of the Itanium C++ ABI:
                 // https://itanium-cxx-abi.github.io/cxx-abi/abi-eh.html#base-throw.
                 // MinGW implements _Unwind_RaiseException on top of SEH exceptions.
-                if this.tcx.sess.target.env != "gnu" {
+                if this.tcx.sess.target.env != Env::Gnu {
                     throw_unsup_format!(
                         "`_Unwind_RaiseException` is not supported on non-MinGW Windows",
                     );

--- a/src/tools/miri/src/shims/windows/fs.rs
+++ b/src/tools/miri/src/shims/windows/fs.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 use std::time::SystemTime;
 
 use bitflags::bitflags;
+use rustc_target::spec::Os;
 
 use crate::shims::files::{FileDescription, FileHandle};
 use crate::shims::windows::handle::{EvalContextExt as _, Handle};
@@ -164,7 +165,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         use CreationDisposition::*;
 
         let this = self.eval_context_mut();
-        this.assert_target_os("windows", "CreateFileW");
+        this.assert_target_os(Os::Windows, "CreateFileW");
         this.check_no_isolation("`CreateFileW`")?;
 
         // This function appears to always set the error to 0. This is important for some flag
@@ -309,7 +310,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
     ) -> InterpResult<'tcx, Scalar> {
         // ^ Returns BOOL (i32 on Windows)
         let this = self.eval_context_mut();
-        this.assert_target_os("windows", "GetFileInformationByHandle");
+        this.assert_target_os(Os::Windows, "GetFileInformationByHandle");
         this.check_no_isolation("`GetFileInformationByHandle`")?;
 
         let file = this.read_handle(file, "GetFileInformationByHandle")?;
@@ -379,7 +380,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
     ) -> InterpResult<'tcx, Scalar> {
         // ^ Returns BOOL (i32 on Windows)
         let this = self.eval_context_mut();
-        this.assert_target_os("windows", "DeleteFileW");
+        this.assert_target_os(Os::Windows, "DeleteFileW");
         this.check_no_isolation("`DeleteFileW`")?;
 
         let file_name = this.read_path_from_wide_str(this.read_pointer(file_name)?)?;


### PR DESCRIPTION
Improve type safety by using an enum rather than strings.

I'm not really sure this is better since only a few vendors have special semantics. r? @nnethercote