### PR TITLE
cmse: add test for `async` and `const` functions

### DIFF
--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/c-variadic.rs
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/c-variadic.rs
@@ -21,6 +21,11 @@ async unsafe extern "cmse-nonsecure-entry" fn async_and_c_variadic(_: ...) {
     //~| ERROR functions cannot be both `async` and C-variadic
 }
 
+// Async on its own is also not allowed.
+async unsafe extern "cmse-nonsecure-entry" fn async_is_not_allowed() {
+    //~^ ERROR `impl Trait` is not allowed in `extern "cmse-nonsecure-entry"` signatures
+}
+
 // Below are the lang items that are required for a program that defines an `async` function.
 // Without them, the ICE that is tested for here is not reached for this target. For now they are in
 // this file, but they may be moved into `minicore` if/when other `#[no_core]` tests want to use

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/c-variadic.stderr
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/c-variadic.stderr
@@ -24,5 +24,12 @@ LL | async unsafe extern "cmse-nonsecure-entry" fn async_and_c_variadic(_: ...) 
    |
    = help: only `extern "C"` and `extern "C-unwind"` functions may have a C variable argument list
 
-error: aborting due to 3 previous errors
+error[E0798]: `impl Trait` is not allowed in `extern "cmse-nonsecure-entry"` signatures
+  --> $DIR/c-variadic.rs:25:1
+   |
+LL | async unsafe extern "cmse-nonsecure-entry" fn async_is_not_allowed() {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0798`.

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/generics.rs
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/generics.rs
@@ -89,3 +89,13 @@ extern "cmse-nonsecure-entry" fn identity_impl_trait_nested(
     //~^ ERROR `impl Trait` is not allowed in `extern "cmse-nonsecure-entry"` signatures
     v
 }
+
+const extern "cmse-nonsecure-entry" fn const_fn_works(x: u8) -> u8 {
+    x
+}
+
+const CONST: u8 = const_fn_works(0);
+
+fn fn_ptr_works(f: extern "cmse-nonsecure-entry" fn(_: u8) -> u8) -> u8 {
+    f(0)
+}


### PR DESCRIPTION
tracking issue: https://github.com/rust-lang/rust/issues/81391
tracking issue: https://github.com/rust-lang/rust/issues/75835

Some additional tests that seemed useful while working on the RFC text.

`async` functions are disallowed (because `-> impl Trait` is not supported). 

`const` entry functions are allowed, `nonsecure-call` does not make sense, because this abi can only be used on function pointers, which cannot be evaluated during constant evaluation.

The async test is in the `c-variadic.rs` file because it has the minicore-compatible machinery for defining an async function. Splitting that logic out (like `minisimd.rs`) turns out to be complicated because the async stuff relies on types defined by minicore.

r? @davidtwco 