### PR TITLE
Minor fixes to StdNonZeroNumberProvider for gdb

### DIFF
--- a/src/etc/gdb_providers.py
+++ b/src/etc/gdb_providers.py
@@ -252,15 +252,15 @@ class StdNonZeroNumberProvider(printer_base):
     def __init__(self, valobj):
         fields = valobj.type.fields()
         assert len(fields) == 1
-        field = list(fields)[0]
+        field = fields[0]
 
-        inner_valobj = valobj[field.name]
+        inner_valobj = valobj[field]
 
         inner_fields = inner_valobj.type.fields()
         assert len(inner_fields) == 1
-        inner_field = list(inner_fields)[0]
+        inner_field = inner_fields[0]
 
-        self._value = str(inner_valobj[inner_field.name])
+        self._value = inner_valobj[inner_field]
 
     def to_string(self):
         return self._value

--- a/tests/debuginfo/numeric-types.rs
+++ b/tests/debuginfo/numeric-types.rs
@@ -202,6 +202,8 @@
 // gdb-command:print nz_usize
 // gdb-check:[...]$12 = 122
 
+// gdb-command:print/x nz_i8
+// gdb-check:[...]$13 = 0xb
 
 
 // === LLDB TESTS ==================================================================================


### PR DESCRIPTION
While looking at the pretty-printers, I found a few minor oddities in StdNonZeroNumberProvider.

First, gdb.Type.fields() already returns a sequence, so there's no need to call list().

Second, it's more idiomatic for the (somewhat misnamed) to_string method to simply return the underlying gdb.Value.  This also lets gdb apply whatever formats were passed to `print`, as the new test shows.

Third, there's no need to use the field's name when looking up a field in a value, the gdb.Field itself can be used.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
