### PR TITLE
Add num_children method to some gdb pretty-printers

### DIFF
--- a/src/etc/gdb_providers.py
+++ b/src/etc/gdb_providers.py
@@ -128,6 +128,9 @@ class StdSliceProvider(printer_base):
             self._data_ptr + index for index in xrange(self._length)
         )
 
+    def num_children(self):
+        return self._length
+
     @staticmethod
     def display_hint():
         return "array"
@@ -148,6 +151,9 @@ class StdVecProvider(printer_base):
         return _enumerate_array_elements(
             self._data_ptr + index for index in xrange(self._length)
         )
+
+    def num_children(self):
+        return self._length
 
     @staticmethod
     def display_hint():
@@ -176,6 +182,9 @@ class StdVecDequeProvider(printer_base):
             (self._data_ptr + ((self._head + index) % self._cap))
             for index in xrange(self._size)
         )
+
+    def num_children(self):
+        return self._size
 
     @staticmethod
     def display_hint():
@@ -477,6 +486,12 @@ class StdHashMapProvider(printer_base):
                 yield "val{}".format(index), element[FIRST_FIELD]
             else:
                 yield "[{}]".format(index), element[ZERO_FIELD]
+
+    def num_children(self):
+        result = self._size
+        if self._show_values:
+            result *= 2
+        return result
 
     def display_hint(self):
         return "map" if self._show_values else "array"


### PR DESCRIPTION
gdb doesn't have a way to know when an object hasn't yet been initialized, and in this case, if a pretty-printer returns an absurd number of children, this can result in apparent hangs in some modes. This came up specifically with DAP, see this bug report:

    https://sourceware.org/bugzilla/show_bug.cgi?id=33594

This patch (mostly) addresses this potential issue in the Rust pretty-printers, by adding 'num_children' methods.  In particular a method like this is added when the number of children is variable and also relatively easy to compute.  (I.e., I didn't attempt the btree printers.)

Supplying num_children is good for DAP regardless of the initialization problem, because DAP requires a count of child objects and this is more efficient than enumerating the children, which is gdb's fallback approach.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
