### PR TITLE
Add allocator parameter to HashMap

### DIFF
--- a/tests/ui/generics/wrong-number-of-args.rs
+++ b/tests/ui/generics/wrong-number-of-args.rs
@@ -321,10 +321,6 @@ mod stdlib {
         //~| ERROR struct takes at least 2
         //~| HELP add missing
 
-        type D = HashMap<usize, String, char, f64>;
-        //~^ ERROR struct takes at most 3
-        //~| HELP remove the
-
         type E = HashMap<>;
         //~^ ERROR struct takes at least 2 generic arguments but 0 generic arguments
         //~| HELP add missing

--- a/tests/ui/generics/wrong-number-of-args.stderr
+++ b/tests/ui/generics/wrong-number-of-args.stderr
@@ -926,16 +926,8 @@ help: add missing generic arguments
 LL |         type C = HashMap<'static, K, V>;
    |                                 ++++++
 
-error[E0107]: struct takes at most 3 generic arguments but 4 generic arguments were supplied
-  --> $DIR/wrong-number-of-args.rs:324:18
-   |
-LL |         type D = HashMap<usize, String, char, f64>;
-   |                  ^^^^^^^                    ----- help: remove the unnecessary generic argument
-   |                  |
-   |                  expected at most 3 generic arguments
-
 error[E0107]: struct takes at least 2 generic arguments but 0 generic arguments were supplied
-  --> $DIR/wrong-number-of-args.rs:328:18
+  --> $DIR/wrong-number-of-args.rs:324:18
    |
 LL |         type E = HashMap<>;
    |                  ^^^^^^^ expected at least 2 generic arguments
@@ -946,7 +938,7 @@ LL |         type E = HashMap<K, V>;
    |                          ++++
 
 error[E0107]: missing generics for enum `Result`
-  --> $DIR/wrong-number-of-args.rs:334:18
+  --> $DIR/wrong-number-of-args.rs:330:18
    |
 LL |         type A = Result;
    |                  ^^^^^^ expected 2 generic arguments
@@ -957,7 +949,7 @@ LL |         type A = Result<T, E>;
    |                        ++++++
 
 error[E0107]: enum takes 2 generic arguments but 1 generic argument was supplied
-  --> $DIR/wrong-number-of-args.rs:338:18
+  --> $DIR/wrong-number-of-args.rs:334:18
    |
 LL |         type B = Result<String>;
    |                  ^^^^^^ ------ supplied 1 generic argument
@@ -970,7 +962,7 @@ LL |         type B = Result<String, E>;
    |                               +++
 
 error[E0107]: enum takes 0 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/wrong-number-of-args.rs:342:18
+  --> $DIR/wrong-number-of-args.rs:338:18
    |
 LL |         type C = Result<'static>;
    |                  ^^^^^^--------- help: remove the unnecessary generics
@@ -978,7 +970,7 @@ LL |         type C = Result<'static>;
    |                  expected 0 lifetime arguments
 
 error[E0107]: enum takes 2 generic arguments but 0 generic arguments were supplied
-  --> $DIR/wrong-number-of-args.rs:342:18
+  --> $DIR/wrong-number-of-args.rs:338:18
    |
 LL |         type C = Result<'static>;
    |                  ^^^^^^ expected 2 generic arguments
@@ -989,7 +981,7 @@ LL |         type C = Result<'static, T, E>;
    |                                ++++++
 
 error[E0107]: enum takes 2 generic arguments but 3 generic arguments were supplied
-  --> $DIR/wrong-number-of-args.rs:348:18
+  --> $DIR/wrong-number-of-args.rs:344:18
    |
 LL |         type D = Result<usize, String, char>;
    |                  ^^^^^^              ------ help: remove the unnecessary generic argument
@@ -997,7 +989,7 @@ LL |         type D = Result<usize, String, char>;
    |                  expected 2 generic arguments
 
 error[E0107]: enum takes 2 generic arguments but 0 generic arguments were supplied
-  --> $DIR/wrong-number-of-args.rs:352:18
+  --> $DIR/wrong-number-of-args.rs:348:18
    |
 LL |         type E = Result<>;
    |                  ^^^^^^ expected 2 generic arguments
@@ -1007,7 +999,7 @@ help: add missing generic arguments
 LL |         type E = Result<T, E>;
    |                         ++++
 
-error: aborting due to 71 previous errors
+error: aborting due to 70 previous errors
 
 Some errors have detailed explanations: E0106, E0107.
 For more information about an error, try `rustc --explain E0106`.

--- a/tests/ui/inference/issue-71732.stderr
+++ b/tests/ui/inference/issue-71732.stderr
@@ -10,7 +10,7 @@ LL |         .get(&"key".into())
            - impl Borrow<str> for String;
            - impl<T> Borrow<T> for T
              where T: ?Sized;
-note: required by a bound in `HashMap::<K, V, S>::get`
+note: required by a bound in `HashMap::<K, V, S, A>::get`
   --> $SRC_DIR/std/src/collections/hash/map.rs:LL:COL
 help: consider specifying the generic argument
    |

--- a/tests/ui/moves/suggest-clone-when-some-obligation-is-unmet.stderr
+++ b/tests/ui/moves/suggest-clone-when-some-obligation-is-unmet.stderr
@@ -6,7 +6,7 @@ LL |     let mut copy: Vec<U> = map.clone().into_values().collect();
    |                            |
    |                            move occurs because value has type `HashMap<T, U, Hash128_1>`, which does not implement the `Copy` trait
    |
-note: `HashMap::<K, V, S>::into_values` takes ownership of the receiver `self`, which moves value
+note: `HashMap::<K, V, S, A>::into_values` takes ownership of the receiver `self`, which moves value
   --> $SRC_DIR/std/src/collections/hash/map.rs:LL:COL
 note: if `Hash128_1` implemented `Clone`, you could clone the value
   --> $DIR/suggest-clone-when-some-obligation-is-unmet.rs:8:1

--- a/tests/ui/privacy/suggest-box-new.rs
+++ b/tests/ui/privacy/suggest-box-new.rs
@@ -14,7 +14,7 @@ fn main() {
     let _ = std::collections::HashMap();
     //~^ ERROR expected function, tuple struct or tuple variant, found struct `std::collections::HashMap`
     let _ = std::collections::HashMap {};
-    //~^ ERROR cannot construct `HashMap<_, _, _>` with struct literal syntax due to private fields
+    //~^ ERROR cannot construct `HashMap<_, _, _, _>` with struct literal syntax due to private fields
     let _ = Box {}; //~ ERROR cannot construct `Box<_, _>` with struct literal syntax due to private fields
 
     // test that we properly instantiate the parameter of `Box::<T>::new` with an inference variable

--- a/tests/ui/privacy/suggest-box-new.stderr
+++ b/tests/ui/privacy/suggest-box-new.stderr
@@ -5,6 +5,7 @@ LL |     let _ = std::collections::HashMap();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
   --> $SRC_DIR/std/src/collections/hash/map.rs:LL:COL
+  ::: $SRC_DIR/std/src/collections/hash/map.rs:LL:COL
    |
    = note: `std::collections::HashMap` defined here
 help: you might have meant to use an associated function to build this type
@@ -12,14 +13,15 @@ help: you might have meant to use an associated function to build this type
 LL |     let _ = std::collections::HashMap::new();
    |                                      +++++
 LL -     let _ = std::collections::HashMap();
+LL +     let _ = std::collections::HashMap::new_in(_);
+   |
+LL -     let _ = std::collections::HashMap();
 LL +     let _ = std::collections::HashMap::with_capacity(_);
    |
 LL -     let _ = std::collections::HashMap();
-LL +     let _ = std::collections::HashMap::with_hasher(_);
+LL +     let _ = std::collections::HashMap::with_capacity_in(_, _);
    |
-LL -     let _ = std::collections::HashMap();
-LL +     let _ = std::collections::HashMap::with_capacity_and_hasher(_, _);
-   |
+   = and 4 other candidates
 help: consider using the `Default` trait
    |
 LL |     let _ = <std::collections::HashMap as std::default::Default>::default();
@@ -73,7 +75,7 @@ LL -         })),
 LL +         wtf: Some(<Box as std::default::Default>::default()),
    |
 
-error: cannot construct `HashMap<_, _, _>` with struct literal syntax due to private fields
+error: cannot construct `HashMap<_, _, _, _>` with struct literal syntax due to private fields
   --> $DIR/suggest-box-new.rs:16:13
    |
 LL |     let _ = std::collections::HashMap {};
@@ -86,14 +88,15 @@ LL -     let _ = std::collections::HashMap {};
 LL +     let _ = std::collections::HashMap::new();
    |
 LL -     let _ = std::collections::HashMap {};
+LL +     let _ = std::collections::HashMap::new_in(_);
+   |
+LL -     let _ = std::collections::HashMap {};
 LL +     let _ = std::collections::HashMap::with_capacity(_);
    |
 LL -     let _ = std::collections::HashMap {};
-LL +     let _ = std::collections::HashMap::with_hasher(_);
+LL +     let _ = std::collections::HashMap::with_capacity_in(_, _);
    |
-LL -     let _ = std::collections::HashMap {};
-LL +     let _ = std::collections::HashMap::with_capacity_and_hasher(_, _);
-   |
+   = and 4 other candidates
 help: consider using the `Default` trait
    |
 LL -     let _ = std::collections::HashMap {};

--- a/tests/ui/suggestions/multi-suggestion.ascii.stderr
+++ b/tests/ui/suggestions/multi-suggestion.ascii.stderr
@@ -5,6 +5,7 @@ LL |     let _ = std::collections::HashMap();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
   --> $SRC_DIR/std/src/collections/hash/map.rs:LL:COL
+  ::: $SRC_DIR/std/src/collections/hash/map.rs:LL:COL
    |
    = note: `std::collections::HashMap` defined here
 help: you might have meant to use an associated function to build this type
@@ -12,14 +13,15 @@ help: you might have meant to use an associated function to build this type
 LL |     let _ = std::collections::HashMap::new();
    |                                      +++++
 LL -     let _ = std::collections::HashMap();
+LL +     let _ = std::collections::HashMap::new_in(_);
+   |
+LL -     let _ = std::collections::HashMap();
 LL +     let _ = std::collections::HashMap::with_capacity(_);
    |
 LL -     let _ = std::collections::HashMap();
-LL +     let _ = std::collections::HashMap::with_hasher(_);
+LL +     let _ = std::collections::HashMap::with_capacity_in(_, _);
    |
-LL -     let _ = std::collections::HashMap();
-LL +     let _ = std::collections::HashMap::with_capacity_and_hasher(_, _);
-   |
+   = and 4 other candidates
 help: consider using the `Default` trait
    |
 LL |     let _ = <std::collections::HashMap as std::default::Default>::default();
@@ -73,7 +75,7 @@ LL -         })),
 LL +         wtf: Some(<Box as std::default::Default>::default()),
    |
 
-error: cannot construct `HashMap<_, _, _>` with struct literal syntax due to private fields
+error: cannot construct `HashMap<_, _, _, _>` with struct literal syntax due to private fields
   --> $DIR/multi-suggestion.rs:19:13
    |
 LL |     let _ = std::collections::HashMap {};
@@ -86,14 +88,15 @@ LL -     let _ = std::collections::HashMap {};
 LL +     let _ = std::collections::HashMap::new();
    |
 LL -     let _ = std::collections::HashMap {};
+LL +     let _ = std::collections::HashMap::new_in(_);
+   |
+LL -     let _ = std::collections::HashMap {};
 LL +     let _ = std::collections::HashMap::with_capacity(_);
    |
 LL -     let _ = std::collections::HashMap {};
-LL +     let _ = std::collections::HashMap::with_hasher(_);
+LL +     let _ = std::collections::HashMap::with_capacity_in(_, _);
    |
-LL -     let _ = std::collections::HashMap {};
-LL +     let _ = std::collections::HashMap::with_capacity_and_hasher(_, _);
-   |
+   = and 4 other candidates
 help: consider using the `Default` trait
    |
 LL -     let _ = std::collections::HashMap {};

--- a/tests/ui/suggestions/multi-suggestion.rs
+++ b/tests/ui/suggestions/multi-suggestion.rs
@@ -17,6 +17,6 @@ fn main() {
     let _ = std::collections::HashMap();
     //[ascii]~^ ERROR expected function, tuple struct or tuple variant, found struct `std::collections::HashMap`
     let _ = std::collections::HashMap {};
-    //[ascii]~^ ERROR cannot construct `HashMap<_, _, _>` with struct literal syntax due to private fields
+    //[ascii]~^ ERROR cannot construct `HashMap<_, _, _, _>` with struct literal syntax due to private fields
     let _ = Box {}; //[ascii]~ ERROR cannot construct `Box<_, _>` with struct literal syntax due to private fields
 }

--- a/tests/ui/suggestions/multi-suggestion.unicode.stderr
+++ b/tests/ui/suggestions/multi-suggestion.unicode.stderr
@@ -5,6 +5,7 @@ LL │     let _ = std::collections::HashMap();
    │             ━━━━━━━━━━━━━━━━━━━━━━━━━━━
    ╰╴
    ╭▸ $SRC_DIR/std/src/collections/hash/map.rs:LL:COL
+   ⸬  $SRC_DIR/std/src/collections/hash/map.rs:LL:COL
    │
    ╰ note: `std::collections::HashMap` defined here
 help: you might have meant to use an associated function to build this type
@@ -12,14 +13,15 @@ help: you might have meant to use an associated function to build this type
 LL │     let _ = std::collections::HashMap::new();
    ├╴                                     +++++
 LL -     let _ = std::collections::HashMap();
+LL +     let _ = std::collections::HashMap::new_in(_);
+   ├╴
+LL -     let _ = std::collections::HashMap();
 LL +     let _ = std::collections::HashMap::with_capacity(_);
    ├╴
 LL -     let _ = std::collections::HashMap();
-LL +     let _ = std::collections::HashMap::with_hasher(_);
-   ├╴
-LL -     let _ = std::collections::HashMap();
-LL +     let _ = std::collections::HashMap::with_capacity_and_hasher(_, _);
-   ╰╴
+LL +     let _ = std::collections::HashMap::with_capacity_in(_, _);
+   │
+   ╰ and 4 other candidates
 help: consider using the `Default` trait
    ╭╴
 LL │     let _ = <std::collections::HashMap as std::default::Default>::default();
@@ -73,7 +75,7 @@ LL -         })),
 LL +         wtf: Some(<Box as std::default::Default>::default()),
    ╰╴
 
-error: cannot construct `HashMap<_, _, _>` with struct literal syntax due to private fields
+error: cannot construct `HashMap<_, _, _, _>` with struct literal syntax due to private fields
    ╭▸ $DIR/multi-suggestion.rs:19:13
    │
 LL │     let _ = std::collections::HashMap {};
@@ -86,14 +88,15 @@ LL -     let _ = std::collections::HashMap {};
 LL +     let _ = std::collections::HashMap::new();
    ├╴
 LL -     let _ = std::collections::HashMap {};
+LL +     let _ = std::collections::HashMap::new_in(_);
+   ├╴
+LL -     let _ = std::collections::HashMap {};
 LL +     let _ = std::collections::HashMap::with_capacity(_);
    ├╴
 LL -     let _ = std::collections::HashMap {};
-LL +     let _ = std::collections::HashMap::with_hasher(_);
-   ├╴
-LL -     let _ = std::collections::HashMap {};
-LL +     let _ = std::collections::HashMap::with_capacity_and_hasher(_, _);
-   ╰╴
+LL +     let _ = std::collections::HashMap::with_capacity_in(_, _);
+   │
+   ╰ and 4 other candidates
 help: consider using the `Default` trait
    ╭╴
 LL -     let _ = std::collections::HashMap {};

--- a/tests/ui/traits/issue-77982.stderr
+++ b/tests/ui/traits/issue-77982.stderr
@@ -10,7 +10,7 @@ LL |     opts.get(opt.as_ref());
            - impl Borrow<str> for String;
            - impl<T> Borrow<T> for T
              where T: ?Sized;
-note: required by a bound in `HashMap::<K, V, S>::get`
+note: required by a bound in `HashMap::<K, V, S, A>::get`
   --> $SRC_DIR/std/src/collections/hash/map.rs:LL:COL
 help: consider specifying the generic argument
    |


### PR DESCRIPTION
Hashbrown support originally added in https://github.com/rust-lang/hashbrown/pull/133
Part of https://github.com/rust-lang/wg-allocators/issues/7

~See also: hashset support in https://github.com/rust-lang/rust/pull/148550~ (Edit: merged into this PR for crater)