### PR TITLE
Add typo suggestion for a misspelt Cargo environment variable

### DIFF
--- a/compiler/rustc_builtin_macros/messages.ftl
+++ b/compiler/rustc_builtin_macros/messages.ftl
@@ -156,6 +156,7 @@ builtin_macros_duplicate_macro_attribute = duplicated attribute
 
 builtin_macros_env_not_defined = environment variable `{$var}` not defined at compile time
     .cargo = Cargo sets build script variables at run time. Use `std::env::var({$var_expr})` instead
+    .cargo_typo = there is a similar Cargo environment variable: `{$suggested_var}`
     .custom = use `std::env::var({$var_expr})` to read the variable at run time
 
 builtin_macros_env_not_unicode = environment variable `{$var}` is not a valid Unicode string

--- a/compiler/rustc_builtin_macros/src/errors.rs
+++ b/compiler/rustc_builtin_macros/src/errors.rs
@@ -535,6 +535,14 @@ pub(crate) enum EnvNotDefined<'a> {
         var_expr: &'a rustc_ast::Expr,
     },
     #[diag(builtin_macros_env_not_defined)]
+    #[help(builtin_macros_cargo_typo)]
+    CargoEnvVarTypo {
+        #[primary_span]
+        span: Span,
+        var: Symbol,
+        suggested_var: Symbol,
+    },
+    #[diag(builtin_macros_env_not_defined)]
     #[help(builtin_macros_custom)]
     CustomEnvVar {
         #[primary_span]

--- a/tests/ui/env-macro/env-cargo-var-typo-issue-148439.rs
+++ b/tests/ui/env-macro/env-cargo-var-typo-issue-148439.rs
@@ -1,0 +1,50 @@
+//@ edition: 2021
+
+// Regression test for issue #148439
+// Ensure that when using misspelled Cargo environment variables in env!(),
+
+fn test_cargo_package_version() {
+    let _ = env!("CARGO_PACKAGE_VERSION");
+    //~^ ERROR environment variable `CARGO_PACKAGE_VERSION` not defined at compile time
+    //~| HELP there is a similar Cargo environment variable: `CARGO_PKG_VERSION`
+}
+
+fn test_cargo_package_name() {
+    let _ = env!("CARGO_PACKAGE_NAME");
+    //~^ ERROR environment variable `CARGO_PACKAGE_NAME` not defined at compile time
+    //~| HELP there is a similar Cargo environment variable: `CARGO_PKG_NAME`
+}
+
+fn test_cargo_package_authors() {
+    let _ = env!("CARGO_PACKAGE_AUTHORS");
+    //~^ ERROR environment variable `CARGO_PACKAGE_AUTHORS` not defined at compile time
+    //~| HELP there is a similar Cargo environment variable: `CARGO_PKG_AUTHORS`
+}
+
+fn test_cargo_manifest_directory() {
+    let _ = env!("CARGO_MANIFEST_DIRECTORY");
+    //~^ ERROR environment variable `CARGO_MANIFEST_DIRECTORY` not defined at compile time
+    //~| HELP there is a similar Cargo environment variable: `CARGO_MANIFEST_DIR`
+}
+
+fn test_cargo_pkg_version_typo() {
+    let _ = env!("CARGO_PKG_VERSIO");
+    //~^ ERROR environment variable `CARGO_PKG_VERSIO` not defined at compile time
+    //~| HELP there is a similar Cargo environment variable: `CARGO_PKG_VERSION`
+}
+
+fn test_non_cargo_var() {
+    // Non-Cargo variable should get different help message
+    let _ = env!("MY_CUSTOM_VAR");
+    //~^ ERROR environment variable `MY_CUSTOM_VAR` not defined at compile time
+    //~| HELP use `std::env::var("MY_CUSTOM_VAR")` to read the variable at run time
+}
+
+fn test_cargo_unknown_var() {
+    // Cargo-prefixed but not similar to any known variable
+    let _ = env!("CARGO_SOMETHING_TOTALLY_UNKNOWN");
+    //~^ ERROR environment variable `CARGO_SOMETHING_TOTALLY_UNKNOWN` not defined at compile time
+    //~| HELP Cargo sets build script variables at run time. Use `std::env::var("CARGO_SOMETHING_TOTALLY_UNKNOWN")` instead
+}
+
+fn main() {}

--- a/tests/ui/env-macro/env-cargo-var-typo-issue-148439.stderr
+++ b/tests/ui/env-macro/env-cargo-var-typo-issue-148439.stderr
@@ -1,0 +1,58 @@
+error: environment variable `CARGO_PACKAGE_VERSION` not defined at compile time
+  --> $DIR/env-cargo-var-typo-issue-148439.rs:7:13
+   |
+LL |     let _ = env!("CARGO_PACKAGE_VERSION");
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: there is a similar Cargo environment variable: `CARGO_PKG_VERSION`
+
+error: environment variable `CARGO_PACKAGE_NAME` not defined at compile time
+  --> $DIR/env-cargo-var-typo-issue-148439.rs:13:13
+   |
+LL |     let _ = env!("CARGO_PACKAGE_NAME");
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: there is a similar Cargo environment variable: `CARGO_PKG_NAME`
+
+error: environment variable `CARGO_PACKAGE_AUTHORS` not defined at compile time
+  --> $DIR/env-cargo-var-typo-issue-148439.rs:19:13
+   |
+LL |     let _ = env!("CARGO_PACKAGE_AUTHORS");
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: there is a similar Cargo environment variable: `CARGO_PKG_AUTHORS`
+
+error: environment variable `CARGO_MANIFEST_DIRECTORY` not defined at compile time
+  --> $DIR/env-cargo-var-typo-issue-148439.rs:25:13
+   |
+LL |     let _ = env!("CARGO_MANIFEST_DIRECTORY");
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: there is a similar Cargo environment variable: `CARGO_MANIFEST_DIR`
+
+error: environment variable `CARGO_PKG_VERSIO` not defined at compile time
+  --> $DIR/env-cargo-var-typo-issue-148439.rs:31:13
+   |
+LL |     let _ = env!("CARGO_PKG_VERSIO");
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: there is a similar Cargo environment variable: `CARGO_PKG_VERSION`
+
+error: environment variable `MY_CUSTOM_VAR` not defined at compile time
+  --> $DIR/env-cargo-var-typo-issue-148439.rs:38:13
+   |
+LL |     let _ = env!("MY_CUSTOM_VAR");
+   |             ^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: use `std::env::var("MY_CUSTOM_VAR")` to read the variable at run time
+
+error: environment variable `CARGO_SOMETHING_TOTALLY_UNKNOWN` not defined at compile time
+  --> $DIR/env-cargo-var-typo-issue-148439.rs:45:13
+   |
+LL |     let _ = env!("CARGO_SOMETHING_TOTALLY_UNKNOWN");
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: Cargo sets build script variables at run time. Use `std::env::var("CARGO_SOMETHING_TOTALLY_UNKNOWN")` instead
+
+error: aborting due to 7 previous errors
+


### PR DESCRIPTION
Fixes rust-lang/rust#148439