### PR TITLE
Change default branch references

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -6,7 +6,7 @@ name: Post merge analysis
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   analysis:

--- a/src/ci/scripts/verify-channel.sh
+++ b/src/ci/scripts/verify-channel.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # We want to make sure all PRs are targeting the right branch when they're
 # opened, otherwise we risk (for example) to land a beta-specific change to the
-# master branch. This script ensures the branch of the PR matches the channel.
+# default branch. This script ensures the branch of the PR matches the channel.
 
 set -euo pipefail
 IFS=$'\n\t'
@@ -16,7 +16,7 @@ fi
 channel=$(cat "$(ciCheckoutPath)/src/ci/channel")
 case "${channel}" in
     nightly)
-        channel_branch="master"
+        channel_branch="main"
         ;;
     beta)
         channel_branch="beta"

--- a/src/stage0
+++ b/src/stage0
@@ -2,7 +2,7 @@ dist_server=https://static.rust-lang.org
 artifacts_server=https://ci-artifacts.rust-lang.org/rustc-builds
 artifacts_with_llvm_assertions_server=https://ci-artifacts.rust-lang.org/rustc-builds-alt
 git_merge_commit_email=bors@rust-lang.org
-nightly_branch=master
+nightly_branch=main
 
 # The configuration above this comment is editable, and can be changed
 # by forks of the repository if they have alternate values.

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1663,7 +1663,7 @@ labels = ["has-merge-commits", "S-waiting-on-author"]
 format = "rustc"
 project-name = "Rust"
 changelog-path = "RELEASES.md"
-changelog-branch = "master"
+changelog-branch = "main"
 
 [shortcut]
 


### PR DESCRIPTION
As per https://blog.rust-lang.org/inside-rust/2025/10/16/renaming-the-default-branch-of-rust-lang-rust/.

Please do not approve this, we will merge it with Marco on Monday November 10.

r? @marcoieni
