### PR TITLE
core docs: add notes about availability of `Atomic*::from_mut_slice`

### DIFF
--- a/library/core/src/sync/atomic.rs
+++ b/library/core/src/sync/atomic.rs
@@ -1558,6 +1558,8 @@ impl<T> AtomicPtr<T> {
 
     /// Gets atomic access to a pointer.
     ///
+    /// **Note:** This function is only available on targets where `AtomicPtr<T>` has the same alignment as `*const T`
+    ///
     /// # Examples
     ///
     /// ```
@@ -1624,6 +1626,8 @@ impl<T> AtomicPtr<T> {
     }
 
     /// Gets atomic access to a slice of pointers.
+    ///
+    /// **Note:** This function is only available on targets where `AtomicPtr<T>` has the same alignment as `*const T`
     ///
     /// # Examples
     ///
@@ -2803,6 +2807,14 @@ macro_rules! atomic_int {
             }
 
             #[doc = concat!("Get atomic access to a `&mut [", stringify!($int_type), "]` slice.")]
+            ///
+            #[doc = if_8_bit! {
+                $int_type,
+                no = [
+                    "**Note:** This function is only available on targets where `",
+                    stringify!($atomic_type), "` has the same alignment as `", stringify!($int_type), "`."
+                ],
+            }]
             ///
             /// # Examples
             ///


### PR DESCRIPTION
See https://github.com/rust-lang/rust/issues/76314#issuecomment-3496758620

r? libs-api