### PR TITLE
stabilize duration_from_nanos_u128

### DIFF
--- a/library/core/src/time.rs
+++ b/library/core/src/time.rs
@@ -317,7 +317,6 @@ impl Duration {
     /// # Examples
     ///
     /// ```
-    /// #![feature(duration_from_nanos_u128)]
     /// use std::time::Duration;
     ///
     /// let nanos = 10_u128.pow(24) + 321;
@@ -326,12 +325,12 @@ impl Duration {
     /// assert_eq!(10_u64.pow(15), duration.as_secs());
     /// assert_eq!(321, duration.subsec_nanos());
     /// ```
-    #[unstable(feature = "duration_from_nanos_u128", issue = "139201")]
-    // This is necessary because of const `try_from`, but can be removed if a trait-free impl is used instead
-    #[rustc_const_unstable(feature = "duration_from_nanos_u128", issue = "139201")]
+    #[stable(feature = "duration_from_nanos_u128", since = "CURRENT_RUSTC_VERSION")]
+    #[rustc_const_stable(feature = "duration_from_nanos_u128", since = "CURRENT_RUSTC_VERSION")]
     #[must_use]
     #[inline]
     #[track_caller]
+    #[rustc_allow_const_fn_unstable(const_trait_impl, const_convert)] // for `u64::try_from`
     pub const fn from_nanos_u128(nanos: u128) -> Duration {
         const NANOS_PER_SEC: u128 = self::NANOS_PER_SEC as u128;
         let Ok(secs) = u64::try_from(nanos / NANOS_PER_SEC) else {

--- a/library/coretests/tests/lib.rs
+++ b/library/coretests/tests/lib.rs
@@ -42,7 +42,6 @@
 #![feature(drop_guard)]
 #![feature(duration_constants)]
 #![feature(duration_constructors)]
-#![feature(duration_from_nanos_u128)]
 #![feature(error_generic_member_access)]
 #![feature(exact_div)]
 #![feature(exact_size_is_empty)]

--- a/src/tools/miri/src/lib.rs
+++ b/src/tools/miri/src/lib.rs
@@ -17,7 +17,7 @@
 #![feature(derive_coerce_pointee)]
 #![feature(arbitrary_self_types)]
 #![feature(iter_advance_by)]
-#![feature(duration_from_nanos_u128)]
+#![cfg_attr(bootstrap, feature(duration_from_nanos_u128))]
 // Configure clippy and other lints
 #![allow(
     clippy::collapsible_else_if,


### PR DESCRIPTION
libs-api FCP passed in https://github.com/rust-lang/rust/issues/139201.
Closes https://github.com/rust-lang/rust/issues/139201.

@oli-obk would you prefer if we did a const-hack to avoid allowing `const_trait_impl` here?