### PR TITLE
Rename `DropGuard::into_inner` to `DropGuard::dismiss`

### DIFF
--- a/library/core/src/mem/drop_guard.rs
+++ b/library/core/src/mem/drop_guard.rs
@@ -63,13 +63,10 @@ where
 
     /// Consumes the `DropGuard`, returning the wrapped value.
     ///
-    /// This will not execute the closure. This is implemented as an associated
-    /// function to prevent any potential conflicts with any other methods called
-    /// `into_inner` from the `Deref` and `DerefMut` impls.
-    ///
-    /// It is typically preferred to call this function instead of `mem::forget`
-    /// because it will return the stored value and drop variables captured
-    /// by the closure instead of leaking their owned resources.
+    /// This will not execute the closure. It is typically preferred to call
+    /// this function instead of `mem::forget` because it will return the stored
+    /// value and drop variables captured by the closure instead of leaking their
+    /// owned resources.
     ///
     /// # Example
     ///
@@ -81,11 +78,11 @@ where
     ///
     /// let value = String::from("Nori likes chicken");
     /// let guard = DropGuard::new(value, |s| println!("{s}"));
-    /// assert_eq!(DropGuard::into_inner(guard), "Nori likes chicken");
+    /// assert_eq!(guard.dismiss(), "Nori likes chicken");
     /// ```
     #[unstable(feature = "drop_guard", issue = "144426")]
     #[inline]
-    pub fn into_inner(guard: Self) -> T {
+    pub fn dismiss(self) -> T {
         // First we ensure that dropping the guard will not trigger
         // its destructor
         let mut guard = ManuallyDrop::new(guard);

--- a/library/core/src/mem/drop_guard.rs
+++ b/library/core/src/mem/drop_guard.rs
@@ -85,19 +85,19 @@ where
     pub fn dismiss(self) -> T {
         // First we ensure that dropping the guard will not trigger
         // its destructor
-        let mut guard = ManuallyDrop::new(guard);
+        let mut this = ManuallyDrop::new(self);
 
         // Next we manually read the stored value from the guard.
         //
         // SAFETY: this is safe because we've taken ownership of the guard.
-        let value = unsafe { ManuallyDrop::take(&mut guard.inner) };
+        let value = unsafe { ManuallyDrop::take(&mut this.inner) };
 
         // Finally we drop the stored closure. We do this *after* having read
         // the value, so that even if the closure's `drop` function panics,
         // unwinding still tries to drop the value.
         //
         // SAFETY: this is safe because we've taken ownership of the guard.
-        unsafe { ManuallyDrop::drop(&mut guard.f) };
+        unsafe { ManuallyDrop::drop(&mut this.f) };
         value
     }
 }

--- a/library/coretests/tests/mem.rs
+++ b/library/coretests/tests/mem.rs
@@ -815,7 +815,7 @@ fn drop_guard_into_inner() {
     let dropped = Cell::new(false);
     let value = DropGuard::new(42, |_| dropped.set(true));
     let guard = DropGuard::new(value, |_| dropped.set(true));
-    let inner = DropGuard::into_inner(guard);
+    let inner = guard.dismiss();
     assert_eq!(dropped.get(), false);
     assert_eq!(*inner, 42);
 }
@@ -837,7 +837,7 @@ fn drop_guard_always_drops_value_if_closure_drop_unwinds() {
     // run the destructor of the value we passed, which we validate.
     let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         let guard = DropGuard::new(value_with_tracked_destruction, closure_that_panics_on_drop);
-        DropGuard::into_inner(guard);
+        guard.dismiss();
     }));
     assert!(value_was_dropped);
 }


### PR DESCRIPTION
Tracking issue: https://github.com/rust-lang/rust/issues/144426

One of the open questions blocking the stabilization of `DropGuard` is what to name the associated method that prevents the destructor from running, and returns the captured value. This method is currently called `into_inner`, but most people (including myself) feel like this would benefit from a method that calls more attention to itself.

This PR proposes naming this method `dismiss`, after the Linux kernel's [`ScopeGuard::dismiss`](https://rust.docs.kernel.org/kernel/types/struct.ScopeGuard.html#method.dismiss). Which crucially does not evoke images of violence or weaponry the way alternatives such as "disarm" or "defuse" do. And personally I enjoy the visual metaphor of "dismissing a guard" (e.g. a person keeping watch over something) - a job well done, they're free to go.

This PR also changes the signature from an static method to an instance method. This also matches the Linux kernel's API, and seems alright since `dismiss` is not nearly as ubiquitous as `into_inner`. This makes it more convenient to use, with a much lower risk of conflicting. Though in the rare case there might be ambiguity, the explicit notation is available as a fallback.

```rust
let x = DropGuard::into_inner(guard);  // ← current
let x = guard.dismiss();               // ← proposed