### PR TITLE
Stabilize `atomic_try_update`and deprecate `fetch_update` starting 1.99.0

### DIFF
--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -3270,7 +3270,7 @@ impl<T: ?Sized, A: Allocator> Weak<T, A> {
         // Acquire is necessary for the success case to synchronise with `Arc::new_cyclic`, when the inner
         // value can be initialized after `Weak` references have already been created. In that case, we
         // expect to observe the fully initialized value.
-        if self.inner()?.strong.fetch_update(Acquire, Relaxed, checked_increment).is_ok() {
+        if self.inner()?.strong.try_update(Acquire, Relaxed, checked_increment).is_ok() {
             // SAFETY: pointer is not null, verified in checked_increment
             unsafe { Some(Arc::from_inner_in(self.ptr, self.alloc.clone())) }
         } else {

--- a/library/core/src/alloc/global.rs
+++ b/library/core/src/alloc/global.rs
@@ -57,7 +57,7 @@ use crate::{cmp, ptr};
 ///         let mut allocated = 0;
 ///         if self
 ///             .remaining
-///             .fetch_update(Relaxed, Relaxed, |mut remaining| {
+///             .try_update(Relaxed, Relaxed, |mut remaining| {
 ///                 if size > remaining {
 ///                     return None;
 ///                 }

--- a/library/std/src/sys/sync/condvar/xous.rs
+++ b/library/std/src/sys/sync/condvar/xous.rs
@@ -38,7 +38,7 @@ impl Condvar {
         // possible for `counter` to decrease due to a condvar timing out, in which
         // case the corresponding `timed_out` will increase accordingly.
         let Ok(waiter_count) =
-            self.counter.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |counter| {
+            self.counter.try_update(Ordering::Relaxed, Ordering::Relaxed, |counter| {
                 if counter == 0 {
                     return None;
                 } else {

--- a/library/std/src/sys/sync/rwlock/futex.rs
+++ b/library/std/src/sys/sync/rwlock/futex.rs
@@ -86,7 +86,7 @@ impl RwLock {
     #[inline]
     pub fn try_read(&self) -> bool {
         self.state
-            .fetch_update(Acquire, Relaxed, |s| is_read_lockable(s).then(|| s + READ_LOCKED))
+            .try_update(Acquire, Relaxed, |s| is_read_lockable(s).then(|| s + READ_LOCKED))
             .is_ok()
     }
 
@@ -164,7 +164,7 @@ impl RwLock {
     #[inline]
     pub fn try_write(&self) -> bool {
         self.state
-            .fetch_update(Acquire, Relaxed, |s| is_unlocked(s).then(|| s + WRITE_LOCKED))
+            .try_update(Acquire, Relaxed, |s| is_unlocked(s).then(|| s + WRITE_LOCKED))
             .is_ok()
     }
 

--- a/tests/ui/lint/const-item-interior-mutations-const-atomics.fixed
+++ b/tests/ui/lint/const-item-interior-mutations-const-atomics.fixed
@@ -3,7 +3,6 @@
 
 #![allow(deprecated)]
 #![allow(dead_code)]
-#![feature(atomic_try_update)]
 
 use std::sync::atomic::{AtomicBool, AtomicPtr, AtomicU32, Ordering};
 

--- a/tests/ui/lint/const-item-interior-mutations-const-atomics.rs
+++ b/tests/ui/lint/const-item-interior-mutations-const-atomics.rs
@@ -3,7 +3,6 @@
 
 #![allow(deprecated)]
 #![allow(dead_code)]
-#![feature(atomic_try_update)]
 
 use std::sync::atomic::{AtomicBool, AtomicPtr, AtomicU32, Ordering};
 

--- a/tests/ui/lint/const-item-interior-mutations-const-atomics.stderr
+++ b/tests/ui/lint/const-item-interior-mutations-const-atomics.stderr
@@ -1,5 +1,5 @@
 warning: mutation of an interior mutable `const` item with call to `store`
-  --> $DIR/const-item-interior-mutations-const-atomics.rs:13:14
+  --> $DIR/const-item-interior-mutations-const-atomics.rs:12:14
    |
 LL |     let _a = A.store(true, Ordering::SeqCst);
    |              -^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -17,7 +17,7 @@ LL +     static A: AtomicBool = AtomicBool::new(false);
    |
 
 warning: mutation of an interior mutable `const` item with call to `swap`
-  --> $DIR/const-item-interior-mutations-const-atomics.rs:16:14
+  --> $DIR/const-item-interior-mutations-const-atomics.rs:15:14
    |
 LL |     let _a = A.swap(true, Ordering::SeqCst);
    |              -^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -34,7 +34,7 @@ LL +     static A: AtomicBool = AtomicBool::new(false);
    |
 
 warning: mutation of an interior mutable `const` item with call to `compare_and_swap`
-  --> $DIR/const-item-interior-mutations-const-atomics.rs:19:14
+  --> $DIR/const-item-interior-mutations-const-atomics.rs:18:14
    |
 LL |     let _a = A.compare_and_swap(false, true, Ordering::SeqCst);
    |              -^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -51,7 +51,7 @@ LL +     static A: AtomicBool = AtomicBool::new(false);
    |
 
 warning: mutation of an interior mutable `const` item with call to `compare_exchange`
-  --> $DIR/const-item-interior-mutations-const-atomics.rs:22:14
+  --> $DIR/const-item-interior-mutations-const-atomics.rs:21:14
    |
 LL |     let _a = A.compare_exchange(false, true, Ordering::SeqCst, Ordering::Relaxed);
    |              -^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -68,7 +68,7 @@ LL +     static A: AtomicBool = AtomicBool::new(false);
    |
 
 warning: mutation of an interior mutable `const` item with call to `compare_exchange_weak`
-  --> $DIR/const-item-interior-mutations-const-atomics.rs:25:14
+  --> $DIR/const-item-interior-mutations-const-atomics.rs:24:14
    |
 LL |     let _a = A.compare_exchange_weak(false, true, Ordering::SeqCst, Ordering::Relaxed);
    |              -^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -85,7 +85,7 @@ LL +     static A: AtomicBool = AtomicBool::new(false);
    |
 
 warning: mutation of an interior mutable `const` item with call to `fetch_and`
-  --> $DIR/const-item-interior-mutations-const-atomics.rs:28:14
+  --> $DIR/const-item-interior-mutations-const-atomics.rs:27:14
    |
 LL |     let _a = A.fetch_and(true, Ordering::SeqCst);
    |              -^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -102,7 +102,7 @@ LL +     static A: AtomicBool = AtomicBool::new(false);
    |
 
 warning: mutation of an interior mutable `const` item with call to `fetch_nand`
-  --> $DIR/const-item-interior-mutations-const-atomics.rs:31:14
+  --> $DIR/const-item-interior-mutations-const-atomics.rs:30:14
    |
 LL |     let _a = A.fetch_nand(true, Ordering::SeqCst);
    |              -^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -119,7 +119,7 @@ LL +     static A: AtomicBool = AtomicBool::new(false);
    |
 
 warning: mutation of an interior mutable `const` item with call to `fetch_or`
-  --> $DIR/const-item-interior-mutations-const-atomics.rs:34:14
+  --> $DIR/const-item-interior-mutations-const-atomics.rs:33:14
    |
 LL |     let _a = A.fetch_or(true, Ordering::SeqCst);
    |              -^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -136,7 +136,7 @@ LL +     static A: AtomicBool = AtomicBool::new(false);
    |
 
 warning: mutation of an interior mutable `const` item with call to `fetch_xor`
-  --> $DIR/const-item-interior-mutations-const-atomics.rs:37:14
+  --> $DIR/const-item-interior-mutations-const-atomics.rs:36:14
    |
 LL |     let _a = A.fetch_xor(true, Ordering::SeqCst);
    |              -^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -153,7 +153,7 @@ LL +     static A: AtomicBool = AtomicBool::new(false);
    |
 
 warning: mutation of an interior mutable `const` item with call to `fetch_not`
-  --> $DIR/const-item-interior-mutations-const-atomics.rs:40:14
+  --> $DIR/const-item-interior-mutations-const-atomics.rs:39:14
    |
 LL |     let _a = A.fetch_not(Ordering::SeqCst);
    |              -^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -170,7 +170,7 @@ LL +     static A: AtomicBool = AtomicBool::new(false);
    |
 
 warning: mutation of an interior mutable `const` item with call to `fetch_update`
-  --> $DIR/const-item-interior-mutations-const-atomics.rs:43:14
+  --> $DIR/const-item-interior-mutations-const-atomics.rs:42:14
    |
 LL |     let _a = A.fetch_update(Ordering::SeqCst, Ordering::Relaxed, |_| Some(true));
    |              -^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -187,7 +187,7 @@ LL +     static A: AtomicBool = AtomicBool::new(false);
    |
 
 warning: mutation of an interior mutable `const` item with call to `try_update`
-  --> $DIR/const-item-interior-mutations-const-atomics.rs:46:14
+  --> $DIR/const-item-interior-mutations-const-atomics.rs:45:14
    |
 LL |     let _a = A.try_update(Ordering::SeqCst, Ordering::Relaxed, |_| Some(false));
    |              -^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -204,7 +204,7 @@ LL +     static A: AtomicBool = AtomicBool::new(false);
    |
 
 warning: mutation of an interior mutable `const` item with call to `update`
-  --> $DIR/const-item-interior-mutations-const-atomics.rs:49:14
+  --> $DIR/const-item-interior-mutations-const-atomics.rs:48:14
    |
 LL |     let _a = A.update(Ordering::SeqCst, Ordering::Relaxed, |_| true);
    |              -^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -221,7 +221,7 @@ LL +     static A: AtomicBool = AtomicBool::new(false);
    |
 
 warning: mutation of an interior mutable `const` item with call to `store`
-  --> $DIR/const-item-interior-mutations-const-atomics.rs:56:14
+  --> $DIR/const-item-interior-mutations-const-atomics.rs:55:14
    |
 LL |     let _a = A.store(std::ptr::null_mut(), Ordering::SeqCst);
    |              -^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -238,7 +238,7 @@ LL +     static A: AtomicPtr<i32> = AtomicPtr::new(std::ptr::null_mut());
    |
 
 warning: mutation of an interior mutable `const` item with call to `swap`
-  --> $DIR/const-item-interior-mutations-const-atomics.rs:59:14
+  --> $DIR/const-item-interior-mutations-const-atomics.rs:58:14
    |
 LL |     let _a = A.swap(std::ptr::null_mut(), Ordering::SeqCst);
    |              -^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -255,7 +255,7 @@ LL +     static A: AtomicPtr<i32> = AtomicPtr::new(std::ptr::null_mut());
    |
 
 warning: mutation of an interior mutable `const` item with call to `compare_and_swap`
-  --> $DIR/const-item-interior-mutations-const-atomics.rs:62:14
+  --> $DIR/const-item-interior-mutations-const-atomics.rs:61:14
    |
 LL |     let _a = A.compare_and_swap(std::ptr::null_mut(), std::ptr::null_mut(), Ordering::SeqCst);
    |              -^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -272,7 +272,7 @@ LL +     static A: AtomicPtr<i32> = AtomicPtr::new(std::ptr::null_mut());
    |
 
 warning: mutation of an interior mutable `const` item with call to `compare_exchange`
-  --> $DIR/const-item-interior-mutations-const-atomics.rs:65:14
+  --> $DIR/const-item-interior-mutations-const-atomics.rs:64:14
    |
 LL |       let _a = A.compare_exchange(
    |                ^ `A` is a interior mutable `const` item of type `AtomicPtr<i32>`
@@ -296,7 +296,7 @@ LL +     static A: AtomicPtr<i32> = AtomicPtr::new(std::ptr::null_mut());
    |
 
 warning: mutation of an interior mutable `const` item with call to `compare_exchange_weak`
-  --> $DIR/const-item-interior-mutations-const-atomics.rs:73:14
+  --> $DIR/const-item-interior-mutations-const-atomics.rs:72:14
    |
 LL |       let _a = A.compare_exchange_weak(
    |                ^ `A` is a interior mutable `const` item of type `AtomicPtr<i32>`
@@ -320,7 +320,7 @@ LL +     static A: AtomicPtr<i32> = AtomicPtr::new(std::ptr::null_mut());
    |
 
 warning: mutation of an interior mutable `const` item with call to `fetch_update`
-  --> $DIR/const-item-interior-mutations-const-atomics.rs:81:14
+  --> $DIR/const-item-interior-mutations-const-atomics.rs:80:14
    |
 LL |     let _a = A.fetch_update(Ordering::SeqCst, Ordering::Relaxed, |_| Some(std::ptr::null_mut()));
    |              -^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -337,7 +337,7 @@ LL +     static A: AtomicPtr<i32> = AtomicPtr::new(std::ptr::null_mut());
    |
 
 warning: mutation of an interior mutable `const` item with call to `try_update`
-  --> $DIR/const-item-interior-mutations-const-atomics.rs:84:14
+  --> $DIR/const-item-interior-mutations-const-atomics.rs:83:14
    |
 LL |     let _a = A.try_update(Ordering::SeqCst, Ordering::Relaxed, |_| Some(std::ptr::null_mut()));
    |              -^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -354,7 +354,7 @@ LL +     static A: AtomicPtr<i32> = AtomicPtr::new(std::ptr::null_mut());
    |
 
 warning: mutation of an interior mutable `const` item with call to `update`
-  --> $DIR/const-item-interior-mutations-const-atomics.rs:87:14
+  --> $DIR/const-item-interior-mutations-const-atomics.rs:86:14
    |
 LL |     let _a = A.update(Ordering::SeqCst, Ordering::Relaxed, |_| std::ptr::null_mut());
    |              -^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -371,7 +371,7 @@ LL +     static A: AtomicPtr<i32> = AtomicPtr::new(std::ptr::null_mut());
    |
 
 warning: mutation of an interior mutable `const` item with call to `fetch_ptr_add`
-  --> $DIR/const-item-interior-mutations-const-atomics.rs:90:14
+  --> $DIR/const-item-interior-mutations-const-atomics.rs:89:14
    |
 LL |     let _a = A.fetch_ptr_add(1, Ordering::SeqCst);
    |              -^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -388,7 +388,7 @@ LL +     static A: AtomicPtr<i32> = AtomicPtr::new(std::ptr::null_mut());
    |
 
 warning: mutation of an interior mutable `const` item with call to `fetch_ptr_sub`
-  --> $DIR/const-item-interior-mutations-const-atomics.rs:93:14
+  --> $DIR/const-item-interior-mutations-const-atomics.rs:92:14
    |
 LL |     let _a = A.fetch_ptr_sub(1, Ordering::SeqCst);
    |              -^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -405,7 +405,7 @@ LL +     static A: AtomicPtr<i32> = AtomicPtr::new(std::ptr::null_mut());
    |
 
 warning: mutation of an interior mutable `const` item with call to `fetch_byte_add`
-  --> $DIR/const-item-interior-mutations-const-atomics.rs:96:14
+  --> $DIR/const-item-interior-mutations-const-atomics.rs:95:14
    |
 LL |     let _a = A.fetch_byte_add(1, Ordering::SeqCst);
    |              -^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -422,7 +422,7 @@ LL +     static A: AtomicPtr<i32> = AtomicPtr::new(std::ptr::null_mut());
    |
 
 warning: mutation of an interior mutable `const` item with call to `fetch_byte_sub`
-  --> $DIR/const-item-interior-mutations-const-atomics.rs:99:14
+  --> $DIR/const-item-interior-mutations-const-atomics.rs:98:14
    |
 LL |     let _a = A.fetch_byte_sub(1, Ordering::SeqCst);
    |              -^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -439,7 +439,7 @@ LL +     static A: AtomicPtr<i32> = AtomicPtr::new(std::ptr::null_mut());
    |
 
 warning: mutation of an interior mutable `const` item with call to `fetch_and`
-  --> $DIR/const-item-interior-mutations-const-atomics.rs:102:14
+  --> $DIR/const-item-interior-mutations-const-atomics.rs:101:14
    |
 LL |     let _a = A.fetch_and(1, Ordering::SeqCst);
    |              -^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -456,7 +456,7 @@ LL +     static A: AtomicPtr<i32> = AtomicPtr::new(std::ptr::null_mut());
    |
 
 warning: mutation of an interior mutable `const` item with call to `fetch_or`
-  --> $DIR/const-item-interior-mutations-const-atomics.rs:105:14
+  --> $DIR/const-item-interior-mutations-const-atomics.rs:104:14
    |
 LL |     let _a = A.fetch_or(1, Ordering::SeqCst);
    |              -^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -473,7 +473,7 @@ LL +     static A: AtomicPtr<i32> = AtomicPtr::new(std::ptr::null_mut());
    |
 
 warning: mutation of an interior mutable `const` item with call to `fetch_xor`
-  --> $DIR/const-item-interior-mutations-const-atomics.rs:108:14
+  --> $DIR/const-item-interior-mutations-const-atomics.rs:107:14
    |
 LL |     let _a = A.fetch_xor(1, Ordering::SeqCst);
    |              -^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -490,7 +490,7 @@ LL +     static A: AtomicPtr<i32> = AtomicPtr::new(std::ptr::null_mut());
    |
 
 warning: mutation of an interior mutable `const` item with call to `store`
-  --> $DIR/const-item-interior-mutations-const-atomics.rs:115:14
+  --> $DIR/const-item-interior-mutations-const-atomics.rs:114:14
    |
 LL |     let _a = A.store(1, Ordering::SeqCst);
    |              -^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -507,7 +507,7 @@ LL +     static A: AtomicU32 = AtomicU32::new(0);
    |
 
 warning: mutation of an interior mutable `const` item with call to `swap`
-  --> $DIR/const-item-interior-mutations-const-atomics.rs:118:14
+  --> $DIR/const-item-interior-mutations-const-atomics.rs:117:14
    |
 LL |     let _a = A.swap(2, Ordering::SeqCst);
    |              -^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -524,7 +524,7 @@ LL +     static A: AtomicU32 = AtomicU32::new(0);
    |
 
 warning: mutation of an interior mutable `const` item with call to `compare_and_swap`
-  --> $DIR/const-item-interior-mutations-const-atomics.rs:121:14
+  --> $DIR/const-item-interior-mutations-const-atomics.rs:120:14
    |
 LL |     let _a = A.compare_and_swap(2, 3, Ordering::SeqCst);
    |              -^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -541,7 +541,7 @@ LL +     static A: AtomicU32 = AtomicU32::new(0);
    |
 
 warning: mutation of an interior mutable `const` item with call to `compare_exchange`
-  --> $DIR/const-item-interior-mutations-const-atomics.rs:124:14
+  --> $DIR/const-item-interior-mutations-const-atomics.rs:123:14
    |
 LL |     let _a = A.compare_exchange(3, 4, Ordering::SeqCst, Ordering::Relaxed);
    |              -^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -558,7 +558,7 @@ LL +     static A: AtomicU32 = AtomicU32::new(0);
    |
 
 warning: mutation of an interior mutable `const` item with call to `compare_exchange_weak`
-  --> $DIR/const-item-interior-mutations-const-atomics.rs:127:14
+  --> $DIR/const-item-interior-mutations-const-atomics.rs:126:14
    |
 LL |     let _a = A.compare_exchange_weak(4, 5, Ordering::SeqCst, Ordering::Relaxed);
    |              -^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -575,7 +575,7 @@ LL +     static A: AtomicU32 = AtomicU32::new(0);
    |
 
 warning: mutation of an interior mutable `const` item with call to `fetch_add`
-  --> $DIR/const-item-interior-mutations-const-atomics.rs:130:14
+  --> $DIR/const-item-interior-mutations-const-atomics.rs:129:14
    |
 LL |     let _a = A.fetch_add(1, Ordering::SeqCst);
    |              -^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -592,7 +592,7 @@ LL +     static A: AtomicU32 = AtomicU32::new(0);
    |
 
 warning: mutation of an interior mutable `const` item with call to `fetch_sub`
-  --> $DIR/const-item-interior-mutations-const-atomics.rs:133:14
+  --> $DIR/const-item-interior-mutations-const-atomics.rs:132:14
    |
 LL |     let _a = A.fetch_sub(1, Ordering::SeqCst);
    |              -^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -609,7 +609,7 @@ LL +     static A: AtomicU32 = AtomicU32::new(0);
    |
 
 warning: mutation of an interior mutable `const` item with call to `fetch_add`
-  --> $DIR/const-item-interior-mutations-const-atomics.rs:136:14
+  --> $DIR/const-item-interior-mutations-const-atomics.rs:135:14
    |
 LL |     let _a = A.fetch_add(2, Ordering::SeqCst);
    |              -^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -626,7 +626,7 @@ LL +     static A: AtomicU32 = AtomicU32::new(0);
    |
 
 warning: mutation of an interior mutable `const` item with call to `fetch_nand`
-  --> $DIR/const-item-interior-mutations-const-atomics.rs:139:14
+  --> $DIR/const-item-interior-mutations-const-atomics.rs:138:14
    |
 LL |     let _a = A.fetch_nand(1, Ordering::SeqCst);
    |              -^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -643,7 +643,7 @@ LL +     static A: AtomicU32 = AtomicU32::new(0);
    |
 
 warning: mutation of an interior mutable `const` item with call to `fetch_or`
-  --> $DIR/const-item-interior-mutations-const-atomics.rs:142:14
+  --> $DIR/const-item-interior-mutations-const-atomics.rs:141:14
    |
 LL |     let _a = A.fetch_or(1, Ordering::SeqCst);
    |              -^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -660,7 +660,7 @@ LL +     static A: AtomicU32 = AtomicU32::new(0);
    |
 
 warning: mutation of an interior mutable `const` item with call to `fetch_xor`
-  --> $DIR/const-item-interior-mutations-const-atomics.rs:145:14
+  --> $DIR/const-item-interior-mutations-const-atomics.rs:144:14
    |
 LL |     let _a = A.fetch_xor(1, Ordering::SeqCst);
    |              -^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -677,7 +677,7 @@ LL +     static A: AtomicU32 = AtomicU32::new(0);
    |
 
 warning: mutation of an interior mutable `const` item with call to `fetch_update`
-  --> $DIR/const-item-interior-mutations-const-atomics.rs:148:14
+  --> $DIR/const-item-interior-mutations-const-atomics.rs:147:14
    |
 LL |     let _a = A.fetch_update(Ordering::SeqCst, Ordering::Relaxed, |_| Some(10));
    |              -^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -694,7 +694,7 @@ LL +     static A: AtomicU32 = AtomicU32::new(0);
    |
 
 warning: mutation of an interior mutable `const` item with call to `try_update`
-  --> $DIR/const-item-interior-mutations-const-atomics.rs:151:14
+  --> $DIR/const-item-interior-mutations-const-atomics.rs:150:14
    |
 LL |     let _a = A.try_update(Ordering::SeqCst, Ordering::Relaxed, |_| Some(11));
    |              -^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -711,7 +711,7 @@ LL +     static A: AtomicU32 = AtomicU32::new(0);
    |
 
 warning: mutation of an interior mutable `const` item with call to `update`
-  --> $DIR/const-item-interior-mutations-const-atomics.rs:154:14
+  --> $DIR/const-item-interior-mutations-const-atomics.rs:153:14
    |
 LL |     let _a = A.update(Ordering::SeqCst, Ordering::Relaxed, |_| 12);
    |              -^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -728,7 +728,7 @@ LL +     static A: AtomicU32 = AtomicU32::new(0);
    |
 
 warning: mutation of an interior mutable `const` item with call to `fetch_max`
-  --> $DIR/const-item-interior-mutations-const-atomics.rs:157:14
+  --> $DIR/const-item-interior-mutations-const-atomics.rs:156:14
    |
 LL |     let _a = A.fetch_max(20, Ordering::SeqCst);
    |              -^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -745,7 +745,7 @@ LL +     static A: AtomicU32 = AtomicU32::new(0);
    |
 
 warning: mutation of an interior mutable `const` item with call to `fetch_min`
-  --> $DIR/const-item-interior-mutations-const-atomics.rs:160:14
+  --> $DIR/const-item-interior-mutations-const-atomics.rs:159:14
    |
 LL |     let _a = A.fetch_min(5, Ordering::SeqCst);
    |              -^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/lint/lint-invalid-atomic-ordering-update.rs
+++ b/tests/ui/lint/lint-invalid-atomic-ordering-update.rs
@@ -1,6 +1,4 @@
 //@ only-x86_64
-#![feature(atomic_try_update)]
-
 use std::sync::atomic::{AtomicIsize, Ordering};
 
 fn main() {

--- a/tests/ui/lint/lint-invalid-atomic-ordering-update.stderr
+++ b/tests/ui/lint/lint-invalid-atomic-ordering-update.stderr
@@ -1,5 +1,5 @@
 error: `fetch_update`'s failure ordering may not be `Release` or `AcqRel`, since a failed `fetch_update` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-update.rs:73:47
+  --> $DIR/lint-invalid-atomic-ordering-update.rs:71:47
    |
 LL |     let _ = x.fetch_update(Ordering::Relaxed, Ordering::AcqRel, |old| Some(old + 1));
    |                                               ^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -8,7 +8,7 @@ LL |     let _ = x.fetch_update(Ordering::Relaxed, Ordering::AcqRel, |old| Some(
    = note: `#[deny(invalid_atomic_ordering)]` on by default
 
 error: `try_update`'s failure ordering may not be `Release` or `AcqRel`, since a failed `try_update` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-update.rs:75:45
+  --> $DIR/lint-invalid-atomic-ordering-update.rs:73:45
    |
 LL |     let _ = x.try_update(Ordering::Relaxed, Ordering::AcqRel, |old| Some(old + 1));
    |                                             ^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -16,7 +16,7 @@ LL |     let _ = x.try_update(Ordering::Relaxed, Ordering::AcqRel, |old| Some(ol
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `update`'s failure ordering may not be `Release` or `AcqRel`, since a failed `update` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-update.rs:77:41
+  --> $DIR/lint-invalid-atomic-ordering-update.rs:75:41
    |
 LL |     let _ = x.update(Ordering::Relaxed, Ordering::AcqRel, |old| old + 1);
    |                                         ^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -24,7 +24,7 @@ LL |     let _ = x.update(Ordering::Relaxed, Ordering::AcqRel, |old| old + 1);
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `fetch_update`'s failure ordering may not be `Release` or `AcqRel`, since a failed `fetch_update` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-update.rs:80:47
+  --> $DIR/lint-invalid-atomic-ordering-update.rs:78:47
    |
 LL |     let _ = x.fetch_update(Ordering::Acquire, Ordering::AcqRel, |old| Some(old + 1));
    |                                               ^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -32,7 +32,7 @@ LL |     let _ = x.fetch_update(Ordering::Acquire, Ordering::AcqRel, |old| Some(
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `try_update`'s failure ordering may not be `Release` or `AcqRel`, since a failed `try_update` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-update.rs:82:45
+  --> $DIR/lint-invalid-atomic-ordering-update.rs:80:45
    |
 LL |     let _ = x.try_update(Ordering::Acquire, Ordering::AcqRel, |old| Some(old + 1));
    |                                             ^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -40,7 +40,7 @@ LL |     let _ = x.try_update(Ordering::Acquire, Ordering::AcqRel, |old| Some(ol
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `update`'s failure ordering may not be `Release` or `AcqRel`, since a failed `update` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-update.rs:84:41
+  --> $DIR/lint-invalid-atomic-ordering-update.rs:82:41
    |
 LL |     let _ = x.update(Ordering::Acquire, Ordering::AcqRel, |old| old + 1);
    |                                         ^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -48,7 +48,7 @@ LL |     let _ = x.update(Ordering::Acquire, Ordering::AcqRel, |old| old + 1);
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `fetch_update`'s failure ordering may not be `Release` or `AcqRel`, since a failed `fetch_update` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-update.rs:87:47
+  --> $DIR/lint-invalid-atomic-ordering-update.rs:85:47
    |
 LL |     let _ = x.fetch_update(Ordering::Release, Ordering::AcqRel, |old| Some(old + 1));
    |                                               ^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -56,7 +56,7 @@ LL |     let _ = x.fetch_update(Ordering::Release, Ordering::AcqRel, |old| Some(
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `try_update`'s failure ordering may not be `Release` or `AcqRel`, since a failed `try_update` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-update.rs:89:45
+  --> $DIR/lint-invalid-atomic-ordering-update.rs:87:45
    |
 LL |     let _ = x.try_update(Ordering::Release, Ordering::AcqRel, |old| Some(old + 1));
    |                                             ^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -64,7 +64,7 @@ LL |     let _ = x.try_update(Ordering::Release, Ordering::AcqRel, |old| Some(ol
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `update`'s failure ordering may not be `Release` or `AcqRel`, since a failed `update` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-update.rs:91:41
+  --> $DIR/lint-invalid-atomic-ordering-update.rs:89:41
    |
 LL |     let _ = x.update(Ordering::Release, Ordering::AcqRel, |old| old + 1);
    |                                         ^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -72,7 +72,7 @@ LL |     let _ = x.update(Ordering::Release, Ordering::AcqRel, |old| old + 1);
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `fetch_update`'s failure ordering may not be `Release` or `AcqRel`, since a failed `fetch_update` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-update.rs:94:46
+  --> $DIR/lint-invalid-atomic-ordering-update.rs:92:46
    |
 LL |     let _ = x.fetch_update(Ordering::AcqRel, Ordering::AcqRel, |old| Some(old + 1));
    |                                              ^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -80,7 +80,7 @@ LL |     let _ = x.fetch_update(Ordering::AcqRel, Ordering::AcqRel, |old| Some(o
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `try_update`'s failure ordering may not be `Release` or `AcqRel`, since a failed `try_update` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-update.rs:96:44
+  --> $DIR/lint-invalid-atomic-ordering-update.rs:94:44
    |
 LL |     let _ = x.try_update(Ordering::AcqRel, Ordering::AcqRel, |old| Some(old + 1));
    |                                            ^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -88,7 +88,7 @@ LL |     let _ = x.try_update(Ordering::AcqRel, Ordering::AcqRel, |old| Some(old
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `update`'s failure ordering may not be `Release` or `AcqRel`, since a failed `update` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-update.rs:98:40
+  --> $DIR/lint-invalid-atomic-ordering-update.rs:96:40
    |
 LL |     let _ = x.update(Ordering::AcqRel, Ordering::AcqRel, |old| old + 1);
    |                                        ^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -96,7 +96,7 @@ LL |     let _ = x.update(Ordering::AcqRel, Ordering::AcqRel, |old| old + 1);
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `fetch_update`'s failure ordering may not be `Release` or `AcqRel`, since a failed `fetch_update` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-update.rs:101:46
+  --> $DIR/lint-invalid-atomic-ordering-update.rs:99:46
    |
 LL |     let _ = x.fetch_update(Ordering::SeqCst, Ordering::AcqRel, |old| Some(old + 1));
    |                                              ^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -104,7 +104,7 @@ LL |     let _ = x.fetch_update(Ordering::SeqCst, Ordering::AcqRel, |old| Some(o
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `try_update`'s failure ordering may not be `Release` or `AcqRel`, since a failed `try_update` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-update.rs:103:44
+  --> $DIR/lint-invalid-atomic-ordering-update.rs:101:44
    |
 LL |     let _ = x.try_update(Ordering::SeqCst, Ordering::AcqRel, |old| Some(old + 1));
    |                                            ^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -112,7 +112,7 @@ LL |     let _ = x.try_update(Ordering::SeqCst, Ordering::AcqRel, |old| Some(old
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `update`'s failure ordering may not be `Release` or `AcqRel`, since a failed `update` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-update.rs:105:40
+  --> $DIR/lint-invalid-atomic-ordering-update.rs:103:40
    |
 LL |     let _ = x.update(Ordering::SeqCst, Ordering::AcqRel, |old| old + 1);
    |                                        ^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -120,7 +120,7 @@ LL |     let _ = x.update(Ordering::SeqCst, Ordering::AcqRel, |old| old + 1);
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `fetch_update`'s failure ordering may not be `Release` or `AcqRel`, since a failed `fetch_update` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-update.rs:110:47
+  --> $DIR/lint-invalid-atomic-ordering-update.rs:108:47
    |
 LL |     let _ = x.fetch_update(Ordering::Relaxed, Ordering::Release, |old| Some(old + 1));
    |                                               ^^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -128,7 +128,7 @@ LL |     let _ = x.fetch_update(Ordering::Relaxed, Ordering::Release, |old| Some
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `try_update`'s failure ordering may not be `Release` or `AcqRel`, since a failed `try_update` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-update.rs:112:45
+  --> $DIR/lint-invalid-atomic-ordering-update.rs:110:45
    |
 LL |     let _ = x.try_update(Ordering::Relaxed, Ordering::Release, |old| Some(old + 1));
    |                                             ^^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -136,7 +136,7 @@ LL |     let _ = x.try_update(Ordering::Relaxed, Ordering::Release, |old| Some(o
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `update`'s failure ordering may not be `Release` or `AcqRel`, since a failed `update` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-update.rs:114:41
+  --> $DIR/lint-invalid-atomic-ordering-update.rs:112:41
    |
 LL |     let _ = x.update(Ordering::Relaxed, Ordering::Release, |old| old + 1);
    |                                         ^^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -144,7 +144,7 @@ LL |     let _ = x.update(Ordering::Relaxed, Ordering::Release, |old| old + 1);
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `fetch_update`'s failure ordering may not be `Release` or `AcqRel`, since a failed `fetch_update` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-update.rs:117:47
+  --> $DIR/lint-invalid-atomic-ordering-update.rs:115:47
    |
 LL |     let _ = x.fetch_update(Ordering::Acquire, Ordering::Release, |old| Some(old + 1));
    |                                               ^^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -152,7 +152,7 @@ LL |     let _ = x.fetch_update(Ordering::Acquire, Ordering::Release, |old| Some
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `try_update`'s failure ordering may not be `Release` or `AcqRel`, since a failed `try_update` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-update.rs:119:45
+  --> $DIR/lint-invalid-atomic-ordering-update.rs:117:45
    |
 LL |     let _ = x.try_update(Ordering::Acquire, Ordering::Release, |old| Some(old + 1));
    |                                             ^^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -160,7 +160,7 @@ LL |     let _ = x.try_update(Ordering::Acquire, Ordering::Release, |old| Some(o
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `update`'s failure ordering may not be `Release` or `AcqRel`, since a failed `update` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-update.rs:121:41
+  --> $DIR/lint-invalid-atomic-ordering-update.rs:119:41
    |
 LL |     let _ = x.update(Ordering::Acquire, Ordering::Release, |old| old + 1);
    |                                         ^^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -168,7 +168,7 @@ LL |     let _ = x.update(Ordering::Acquire, Ordering::Release, |old| old + 1);
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `fetch_update`'s failure ordering may not be `Release` or `AcqRel`, since a failed `fetch_update` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-update.rs:124:47
+  --> $DIR/lint-invalid-atomic-ordering-update.rs:122:47
    |
 LL |     let _ = x.fetch_update(Ordering::Release, Ordering::Release, |old| Some(old + 1));
    |                                               ^^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -176,7 +176,7 @@ LL |     let _ = x.fetch_update(Ordering::Release, Ordering::Release, |old| Some
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `try_update`'s failure ordering may not be `Release` or `AcqRel`, since a failed `try_update` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-update.rs:126:45
+  --> $DIR/lint-invalid-atomic-ordering-update.rs:124:45
    |
 LL |     let _ = x.try_update(Ordering::Release, Ordering::Release, |old| Some(old + 1));
    |                                             ^^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -184,7 +184,7 @@ LL |     let _ = x.try_update(Ordering::Release, Ordering::Release, |old| Some(o
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `update`'s failure ordering may not be `Release` or `AcqRel`, since a failed `update` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-update.rs:128:41
+  --> $DIR/lint-invalid-atomic-ordering-update.rs:126:41
    |
 LL |     let _ = x.update(Ordering::Release, Ordering::Release, |old| old + 1);
    |                                         ^^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -192,7 +192,7 @@ LL |     let _ = x.update(Ordering::Release, Ordering::Release, |old| old + 1);
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `fetch_update`'s failure ordering may not be `Release` or `AcqRel`, since a failed `fetch_update` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-update.rs:131:46
+  --> $DIR/lint-invalid-atomic-ordering-update.rs:129:46
    |
 LL |     let _ = x.fetch_update(Ordering::AcqRel, Ordering::Release, |old| Some(old + 1));
    |                                              ^^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -200,7 +200,7 @@ LL |     let _ = x.fetch_update(Ordering::AcqRel, Ordering::Release, |old| Some(
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `try_update`'s failure ordering may not be `Release` or `AcqRel`, since a failed `try_update` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-update.rs:133:44
+  --> $DIR/lint-invalid-atomic-ordering-update.rs:131:44
    |
 LL |     let _ = x.try_update(Ordering::AcqRel, Ordering::Release, |old| Some(old + 1));
    |                                            ^^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -208,7 +208,7 @@ LL |     let _ = x.try_update(Ordering::AcqRel, Ordering::Release, |old| Some(ol
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `update`'s failure ordering may not be `Release` or `AcqRel`, since a failed `update` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-update.rs:135:40
+  --> $DIR/lint-invalid-atomic-ordering-update.rs:133:40
    |
 LL |     let _ = x.update(Ordering::AcqRel, Ordering::Release, |old| old + 1);
    |                                        ^^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -216,7 +216,7 @@ LL |     let _ = x.update(Ordering::AcqRel, Ordering::Release, |old| old + 1);
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `fetch_update`'s failure ordering may not be `Release` or `AcqRel`, since a failed `fetch_update` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-update.rs:138:46
+  --> $DIR/lint-invalid-atomic-ordering-update.rs:136:46
    |
 LL |     let _ = x.fetch_update(Ordering::SeqCst, Ordering::Release, |old| Some(old + 1));
    |                                              ^^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -224,7 +224,7 @@ LL |     let _ = x.fetch_update(Ordering::SeqCst, Ordering::Release, |old| Some(
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `try_update`'s failure ordering may not be `Release` or `AcqRel`, since a failed `try_update` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-update.rs:140:44
+  --> $DIR/lint-invalid-atomic-ordering-update.rs:138:44
    |
 LL |     let _ = x.try_update(Ordering::SeqCst, Ordering::Release, |old| Some(old + 1));
    |                                            ^^^^^^^^^^^^^^^^^ invalid failure ordering
@@ -232,7 +232,7 @@ LL |     let _ = x.try_update(Ordering::SeqCst, Ordering::Release, |old| Some(ol
    = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
 error: `update`'s failure ordering may not be `Release` or `AcqRel`, since a failed `update` does not result in a write
-  --> $DIR/lint-invalid-atomic-ordering-update.rs:142:40
+  --> $DIR/lint-invalid-atomic-ordering-update.rs:140:40
    |
 LL |     let _ = x.update(Ordering::SeqCst, Ordering::Release, |old| old + 1);
    |                                        ^^^^^^^^^^^^^^^^^ invalid failure ordering


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/148590)*
<!-- homu-ignore:end -->

Tracking issue: rust-lang/rust#135894
FCP completed: https://github.com/rust-lang/rust/issues/135894#issuecomment-3685449783

~1.96.0 was chosen because I don't think the remaining month until 1.93.0 becomes beta is enough for the FCP to finish and this to get merged, so 1.94.0 + a couple of versions of leeway: https://github.com/rust-lang/rust/issues/135894#issuecomment-3491707614~

1.99 suggested in https://github.com/rust-lang/rust/pull/148590#discussion_r2730000452

Closes rust-lang/rust#135894
