### PR TITLE
Remove `'static` bound on contract ensures closure

### DIFF
--- a/library/core/src/contracts.rs
+++ b/library/core/src/contracts.rs
@@ -18,7 +18,7 @@ pub use crate::macros::builtin::{contracts_ensures as ensures, contracts_require
 #[lang = "contract_build_check_ensures"]
 pub const fn build_check_ensures<Ret, C>(cond: C) -> C
 where
-    C: Fn(&Ret) -> bool + Copy + 'static,
+    C: Fn(&Ret) -> bool + Copy,
 {
     cond
 }

--- a/tests/ui/contracts/ensures-lifetime.rs
+++ b/tests/ui/contracts/ensures-lifetime.rs
@@ -1,0 +1,29 @@
+//@ run-pass
+//@ compile-flags: -Zcontract-checks=yes
+
+#![feature(contracts)]
+//~^ WARN the feature `contracts` is incomplete and may not be safe to use
+//and/or cause compiler crashes [incomplete_features]
+#![allow(unused)]
+
+// Regression test to allow contract `ensures` clauses to reference non-static
+// references and non-static types. Previously, contracts in the below functions
+// would raise type/lifetime errors due a `'static` bound on the `ensures`
+// closure.
+
+extern crate core;
+use core::contracts::ensures;
+
+#[ensures(|_| { x; true })]
+pub fn noop<T>(x: &T) {}
+
+#[ensures(move |_| { x; true })]
+pub fn noop_mv<T>(x: &T) {}
+
+#[ensures(|_| { x; true })]
+pub fn noop_ptr<T>(x: *const T) {}
+
+#[ensures(move |_| { x; true })]
+pub fn noop_ptr_mv<T>(x: *const T) {}
+
+fn main() {}

--- a/tests/ui/contracts/ensures-lifetime.stderr
+++ b/tests/ui/contracts/ensures-lifetime.stderr
@@ -1,0 +1,11 @@
+warning: the feature `contracts` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/ensures-lifetime.rs:4:12
+   |
+LL | #![feature(contracts)]
+   |            ^^^^^^^^^
+   |
+   = note: see issue #128044 <https://github.com/rust-lang/rust/issues/128044> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+warning: 1 warning emitted
+


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/148595)*
<!-- homu-ignore:end -->

The `'static` bound on the closure of `build_check_ensures` prevented some patterns of contracts from type checking, without a clear reason for doing so. As such, this change removes the `'static` bound.

While working on the proposal for [`owned` and `block` for contracts](https://rust-lang.zulipchat.com/#narrow/channel/131828-t-compiler/topic/Next.20steps.20for.20contracts), I came across a pattern that was rejected by type checker while attempting to specify `std::ptr::write`:

```rust
#![feature(core_intrinsics)]
#![feature(contracts)]
use core::contracts::{requires, ensures};
use core::intrinsics;

use std::mem::MaybeUninit;

fn owned<T>(p: *const T) -> T {
    // Stub implementation for ownership assertion. Ignore this.
    unsafe { std::ptr::read(p) }
}

#[requires(owned::<MaybeUninit<T>>(dst as *const _); true)]
#[ensures(move |_| { owned::<T>(dst); true })]
pub unsafe fn write<T>(dst: *mut T, src: T) {
    unsafe {
        intrinsics::write_via_move(dst, src)
    }
}
```

```
error[E0310]: the parameter type `T` may not live long enough
  --> src/main.rs:13:1
   |
13 | #[ensures(move |_| { owned::<T>(dst); true })]
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   | |
   | the parameter type `T` must be valid for the static lifetime...
   | ...so that the type `T` will meet its required lifetime bounds
   |
help: consider adding an explicit lifetime bound
   |
14 | pub unsafe fn write<T: 'static>(dst: *mut T, src: T) {
   |                      +++++++++

For more information about this error, try `rustc --explain E0310`.
```

Eventually, I was able to track down the issue to a trait bound in `core::contracts::build_check_ensures`, which puts a `'static` bound on the `ensures` closure. Remvoing the `'static` bound allows the above contract to type-check, and additionally removes the need for the `move` in the `ensures` closure.

I have reduced the problem down to some minimal reproducible examples, which I included as part of this change as regression tests. The error messages for the regression tests before the change were as follows:

```
error: lifetime may not live long enough
  --> /Users/dawidl022/Development/rust/tests/ui/contracts/ensures-lifetime.rs:14:1
   |
LL | #[ensures(|_| { x; true })]
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ requires that `'1` must outlive `'static`
LL | pub fn noop<T>(x: &T) {}
   |                   - let's call the lifetime of this reference `'1`

error[E0597]: `x` does not live long enough
  --> /Users/dawidl022/Development/rust/tests/ui/contracts/ensures-lifetime.rs:14:17
   |
LL | #[ensures(|_| { x; true })]
   | ----------------^----------
   | |         |     |
   | |         |     borrowed value does not live long enough
   | |         value captured here
   | requires that `x` is borrowed for `'static`
LL | pub fn noop<T>(x: &T) {}
   |                -        - `x` dropped here while still borrowed
   |                |
   |                binding `x` declared here
   |
note: requirement that the value outlives `'static` introduced here
  --> /rustc/FAKE_PREFIX/library/core/src/contracts.rs:21:34

error: lifetime may not live long enough
  --> /Users/dawidl022/Development/rust/tests/ui/contracts/ensures-lifetime.rs:17:1
   |
LL | #[ensures(move |_| { x; true })]
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ requires that `'1` must outlive `'static`
LL | pub fn noop_mv<T>(x: &T) {}
   |                      - let's call the lifetime of this reference `'1`

error[E0310]: the parameter type `T` may not live long enough
  --> /Users/dawidl022/Development/rust/tests/ui/contracts/ensures-lifetime.rs:20:1
   |
LL | #[ensures(|_| { x; true })]
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
   | |
   | the parameter type `T` must be valid for the static lifetime...
   | ...so that the type `T` will meet its required lifetime bounds
   |
help: consider adding an explicit lifetime bound
   |
LL | pub fn noop_ptr<T: 'static>(x: *const T) {}
   |                  +++++++++

error[E0310]: the parameter type `T` may not live long enough
  --> /Users/dawidl022/Development/rust/tests/ui/contracts/ensures-lifetime.rs:20:1
   |
LL | #[ensures(|_| { x; true })]
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
   | |
   | the parameter type `T` must be valid for the static lifetime...
   | ...so that the type `T` will meet its required lifetime bounds
   |
   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
help: consider adding an explicit lifetime bound
   |
LL | pub fn noop_ptr<T: 'static>(x: *const T) {}
   |                  +++++++++

error[E0310]: the parameter type `T` may not live long enough
  --> /Users/dawidl022/Development/rust/tests/ui/contracts/ensures-lifetime.rs:20:1
   |
LL | #[ensures(|_| { x; true })]
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
   | |
   | the parameter type `T` must be valid for the static lifetime...
   | ...so that the type `T` will meet its required lifetime bounds
   |
   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
help: consider adding an explicit lifetime bound
   |
LL | pub fn noop_ptr<T: 'static>(x: *const T) {}
   |                  +++++++++

error[E0597]: `x` does not live long enough
  --> /Users/dawidl022/Development/rust/tests/ui/contracts/ensures-lifetime.rs:20:17
   |
LL | #[ensures(|_| { x; true })]
   | ----------------^----------
   | |         |     |
   | |         |     borrowed value does not live long enough
   | |         value captured here
   | requires that `x` is borrowed for `'static`
LL | pub fn noop_ptr<T>(x: *const T) {}
   |                    -              - `x` dropped here while still borrowed
   |                    |
   |                    binding `x` declared here
   |
note: requirement that the value outlives `'static` introduced here
  --> /rustc/FAKE_PREFIX/library/core/src/contracts.rs:21:34

error[E0310]: the parameter type `T` may not live long enough
  --> /Users/dawidl022/Development/rust/tests/ui/contracts/ensures-lifetime.rs:23:1
   |
LL | #[ensures(move |_| { x; true })]
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   | |
   | the parameter type `T` must be valid for the static lifetime...
   | ...so that the type `T` will meet its required lifetime bounds
   |
help: consider adding an explicit lifetime bound
   |
LL | pub fn noop_ptr_mv<T: 'static>(x: *const T) {}
   |                     +++++++++

error: aborting due to 8 previous errors; 1 warning emitted

Some errors have detailed explanations: E0310, E0597.
For more information about an error, try `rustc --explain E0310`.
------------------------------------------

---- [ui] tests/ui/contracts/ensures-lifetime.rs stdout end ----

failures:
    [ui] tests/ui/contracts/ensures-lifetime.rs
```

@celinval are you aware of any reason why the `'static` bound was put on `build_check_ensures` in the first place?

I have checked that the contracts in rust-lang/rust#136578 and rust-lang/rust#147148 still type check with this change.

Contracts tracking issue: https://github.com/rust-lang/rust/issues/128044