### PR TITLE
re-use `self.get_all_attrs` result for pass indirectly attribute

### DIFF
--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -1512,9 +1512,8 @@ impl<'tcx> TyCtxt<'tcx> {
             field_shuffle_seed ^= user_seed;
         }
 
-        if let Some(reprs) =
-            find_attr!(self.get_all_attrs(did), AttributeKind::Repr { reprs, .. } => reprs)
-        {
+        let attributes = self.get_all_attrs(did);
+        if let Some(reprs) = find_attr!(attributes, AttributeKind::Repr { reprs, .. } => reprs) {
             for (r, _) in reprs {
                 flags.insert(match *r {
                     attr::ReprRust => ReprFlags::empty(),
@@ -1574,10 +1573,7 @@ impl<'tcx> TyCtxt<'tcx> {
         }
 
         // See `TyAndLayout::pass_indirectly_in_non_rustic_abis` for details.
-        if find_attr!(
-            self.get_all_attrs(did),
-            AttributeKind::RustcPassIndirectlyInNonRusticAbis(..)
-        ) {
+        if find_attr!(attributes, AttributeKind::RustcPassIndirectlyInNonRusticAbis(..)) {
             flags.insert(ReprFlags::PASS_INDIRECTLY_IN_NON_RUSTIC_ABIS);
         }
 


### PR DESCRIPTION
Could be a fix for a potential performance regression reported here https://github.com/rust-lang/rust/pull/144529#issuecomment-3491236458. Apparently the regression later disappeared. Nevertheless, this seems like a decent refactor.

r? @JonathanBrouwer (vaguely attribute-related, maybe there are other optimizations to that PR that we're missing)
