### PR TITLE
Enable std file locking functions on AIX

### DIFF
--- a/library/std/src/sys/fs/unix.rs
+++ b/library/std/src/sys/fs/unix.rs
@@ -1296,6 +1296,7 @@ impl File {
         target_os = "openbsd",
         target_os = "cygwin",
         target_os = "illumos",
+        target_os = "aix",
         target_vendor = "apple",
     ))]
     pub fn lock(&self) -> io::Result<()> {
@@ -1321,6 +1322,7 @@ impl File {
         target_os = "cygwin",
         target_os = "solaris",
         target_os = "illumos",
+        target_os = "aix",
         target_vendor = "apple",
     )))]
     pub fn lock(&self) -> io::Result<()> {
@@ -1335,6 +1337,7 @@ impl File {
         target_os = "openbsd",
         target_os = "cygwin",
         target_os = "illumos",
+        target_os = "aix",
         target_vendor = "apple",
     ))]
     pub fn lock_shared(&self) -> io::Result<()> {
@@ -1360,6 +1363,7 @@ impl File {
         target_os = "cygwin",
         target_os = "solaris",
         target_os = "illumos",
+        target_os = "aix",
         target_vendor = "apple",
     )))]
     pub fn lock_shared(&self) -> io::Result<()> {
@@ -1374,6 +1378,7 @@ impl File {
         target_os = "openbsd",
         target_os = "cygwin",
         target_os = "illumos",
+        target_os = "aix",
         target_vendor = "apple",
     ))]
     pub fn try_lock(&self) -> Result<(), TryLockError> {
@@ -1415,6 +1420,7 @@ impl File {
         target_os = "cygwin",
         target_os = "solaris",
         target_os = "illumos",
+        target_os = "aix",
         target_vendor = "apple",
     )))]
     pub fn try_lock(&self) -> Result<(), TryLockError> {
@@ -1432,6 +1438,7 @@ impl File {
         target_os = "openbsd",
         target_os = "cygwin",
         target_os = "illumos",
+        target_os = "aix",
         target_vendor = "apple",
     ))]
     pub fn try_lock_shared(&self) -> Result<(), TryLockError> {
@@ -1473,6 +1480,7 @@ impl File {
         target_os = "cygwin",
         target_os = "solaris",
         target_os = "illumos",
+        target_os = "aix",
         target_vendor = "apple",
     )))]
     pub fn try_lock_shared(&self) -> Result<(), TryLockError> {
@@ -1490,6 +1498,7 @@ impl File {
         target_os = "openbsd",
         target_os = "cygwin",
         target_os = "illumos",
+        target_os = "aix",
         target_vendor = "apple",
     ))]
     pub fn unlock(&self) -> io::Result<()> {
@@ -1515,6 +1524,7 @@ impl File {
         target_os = "cygwin",
         target_os = "solaris",
         target_os = "illumos",
+        target_os = "aix",
         target_vendor = "apple",
     )))]
     pub fn unlock(&self) -> io::Result<()> {


### PR DESCRIPTION
This patch enables the std locking functions on AIX by including AIX on the list of supported targets for the locking functions. Excluding AIX from the std locking functions results to compilation errors such as: ("try_lock() not supported").

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
