### PR TITLE
Ignore `#[doc(hidden)]` items when computing trimmed paths for printing

### DIFF
--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -3421,6 +3421,13 @@ fn for_each_def(tcx: TyCtxt<'_>, mut collect_fn: impl for<'b> FnMut(&'b Ident, N
                 def::Res::Def(DefKind::AssocTy, _) => {}
                 def::Res::Def(DefKind::TyAlias, _) => {}
                 def::Res::Def(defkind, def_id) => {
+                    // Ignore external `#[doc(hidden)]` items and their descendants.
+                    // They shouldn't prevent other items from being considered
+                    // unique, and should be printed with a full path if necessary.
+                    if tcx.is_doc_hidden(def_id) {
+                        continue;
+                    }
+
                     if let Some(ns) = defkind.ns() {
                         collect_fn(&child.ident, ns, def_id);
                     }

--- a/tests/mir-opt/async_closure_fake_read_for_by_move.foo-{closure#0}-{closure#0}.built.after.mir
+++ b/tests/mir-opt/async_closure_fake_read_for_by_move.foo-{closure#0}-{closure#0}.built.after.mir
@@ -1,6 +1,6 @@
 // MIR for `foo::{closure#0}::{closure#0}` after built
 
-fn foo::{closure#0}::{closure#0}(_1: {async closure body@$DIR/async_closure_fake_read_for_by_move.rs:12:27: 15:6}, _2: ResumeTy) -> ()
+fn foo::{closure#0}::{closure#0}(_1: {async closure body@$DIR/async_closure_fake_read_for_by_move.rs:12:27: 15:6}, _2: std::future::ResumeTy) -> ()
 yields ()
  {
     debug _task_context => _2;

--- a/tests/mir-opt/async_closure_fake_read_for_by_move.foo-{closure#0}-{synthetic#0}.built.after.mir
+++ b/tests/mir-opt/async_closure_fake_read_for_by_move.foo-{closure#0}-{synthetic#0}.built.after.mir
@@ -1,6 +1,6 @@
 // MIR for `foo::{closure#0}::{synthetic#0}` after built
 
-fn foo::{closure#0}::{synthetic#0}(_1: {async closure body@$DIR/async_closure_fake_read_for_by_move.rs:12:27: 15:6}, _2: ResumeTy) -> ()
+fn foo::{closure#0}::{synthetic#0}(_1: {async closure body@$DIR/async_closure_fake_read_for_by_move.rs:12:27: 15:6}, _2: std::future::ResumeTy) -> ()
 yields ()
  {
     debug _task_context => _2;

--- a/tests/mir-opt/async_closure_shims.main-{closure#0}-{closure#0}-{closure#0}.built.after.mir
+++ b/tests/mir-opt/async_closure_shims.main-{closure#0}-{closure#0}-{closure#0}.built.after.mir
@@ -1,6 +1,6 @@
 // MIR for `main::{closure#0}::{closure#0}::{closure#0}` after built
 
-fn main::{closure#0}::{closure#0}::{closure#0}(_1: {async closure body@$DIR/async_closure_shims.rs:53:53: 56:10}, _2: ResumeTy) -> ()
+fn main::{closure#0}::{closure#0}::{closure#0}(_1: {async closure body@$DIR/async_closure_shims.rs:53:53: 56:10}, _2: std::future::ResumeTy) -> ()
 yields ()
  {
     debug _task_context => _2;

--- a/tests/mir-opt/async_closure_shims.main-{closure#0}-{closure#0}-{synthetic#0}.built.after.mir
+++ b/tests/mir-opt/async_closure_shims.main-{closure#0}-{closure#0}-{synthetic#0}.built.after.mir
@@ -1,6 +1,6 @@
 // MIR for `main::{closure#0}::{closure#0}::{synthetic#0}` after built
 
-fn main::{closure#0}::{closure#0}::{synthetic#0}(_1: {async closure body@$DIR/async_closure_shims.rs:53:53: 56:10}, _2: ResumeTy) -> ()
+fn main::{closure#0}::{closure#0}::{synthetic#0}(_1: {async closure body@$DIR/async_closure_shims.rs:53:53: 56:10}, _2: std::future::ResumeTy) -> ()
 yields ()
  {
     debug _task_context => _2;

--- a/tests/mir-opt/async_closure_shims.main-{closure#0}-{closure#1}-{closure#0}.built.after.mir
+++ b/tests/mir-opt/async_closure_shims.main-{closure#0}-{closure#1}-{closure#0}.built.after.mir
@@ -1,6 +1,6 @@
 // MIR for `main::{closure#0}::{closure#1}::{closure#0}` after built
 
-fn main::{closure#0}::{closure#1}::{closure#0}(_1: {async closure body@$DIR/async_closure_shims.rs:62:48: 65:10}, _2: ResumeTy) -> ()
+fn main::{closure#0}::{closure#1}::{closure#0}(_1: {async closure body@$DIR/async_closure_shims.rs:62:48: 65:10}, _2: std::future::ResumeTy) -> ()
 yields ()
  {
     debug _task_context => _2;

--- a/tests/mir-opt/async_closure_shims.main-{closure#0}-{closure#1}-{synthetic#0}.built.after.mir
+++ b/tests/mir-opt/async_closure_shims.main-{closure#0}-{closure#1}-{synthetic#0}.built.after.mir
@@ -1,6 +1,6 @@
 // MIR for `main::{closure#0}::{closure#1}::{synthetic#0}` after built
 
-fn main::{closure#0}::{closure#1}::{synthetic#0}(_1: {async closure body@$DIR/async_closure_shims.rs:62:48: 65:10}, _2: ResumeTy) -> ()
+fn main::{closure#0}::{closure#1}::{synthetic#0}(_1: {async closure body@$DIR/async_closure_shims.rs:62:48: 65:10}, _2: std::future::ResumeTy) -> ()
 yields ()
  {
     debug _task_context => _2;

--- a/tests/mir-opt/box_expr.rs
+++ b/tests/mir-opt/box_expr.rs
@@ -8,7 +8,7 @@ fn main() {
     // CHECK-LABEL: fn main(
     // CHECK:   [[ptr:_.*]] = move {{_.*}} as *const S (Transmute);
     // CHECK:   [[nonnull:_.*]] = NonNull::<S> { pointer: move [[ptr]] };
-    // CHECK:   [[unique:_.*]] = Unique::<S> { pointer: move [[nonnull]], _marker: const PhantomData::<S> };
+    // CHECK:   [[unique:_.*]] = std::ptr::Unique::<S> { pointer: move [[nonnull]], _marker: const PhantomData::<S> };
     // CHECK:   [[box:_.*]] = Box::<S>(move [[unique]], const std::alloc::Global);
     // CHECK:   [[ptr:_.*]] = copy (([[box]].0: std::ptr::Unique<S>).0: std::ptr::NonNull<S>) as *const S (Transmute);
     // CHECK:   (*[[ptr]]) = S::new() -> [return: [[ret:bb.*]], unwind: [[unwind:bb.*]]];

--- a/tests/mir-opt/building/issue_101867.main.built.after.mir
+++ b/tests/mir-opt/building/issue_101867.main.built.after.mir
@@ -32,7 +32,7 @@ fn main() -> () {
     bb1: {
         StorageLive(_3);
         StorageLive(_4);
-        _4 = begin_panic::<&str>(const "explicit panic") -> bb8;
+        _4 = std::rt::begin_panic::<&str>(const "explicit panic") -> bb8;
     }
 
     bb2: {

--- a/tests/mir-opt/const_prop/boxes.main.GVN.panic-abort.diff
+++ b/tests/mir-opt/const_prop/boxes.main.GVN.panic-abort.diff
@@ -29,10 +29,10 @@
           StorageLive(_5);
 -         _6 = move _4 as *const i32 (Transmute);
 -         _7 = NonNull::<i32> { pointer: move _6 };
--         _8 = Unique::<i32> { pointer: move _7, _marker: const PhantomData::<i32> };
+-         _8 = std::ptr::Unique::<i32> { pointer: move _7, _marker: const PhantomData::<i32> };
 +         _6 = copy _4 as *const i32 (PtrToPtr);
 +         _7 = NonNull::<i32> { pointer: copy _6 };
-+         _8 = Unique::<i32> { pointer: copy _7, _marker: const PhantomData::<i32> };
++         _8 = std::ptr::Unique::<i32> { pointer: copy _7, _marker: const PhantomData::<i32> };
           _5 = Box::<i32>(move _8, const std::alloc::Global);
 -         _9 = copy ((_5.0: std::ptr::Unique<i32>).0: std::ptr::NonNull<i32>) as *const i32 (Transmute);
 -         (*_9) = const 42_i32;

--- a/tests/mir-opt/const_prop/boxes.main.GVN.panic-unwind.diff
+++ b/tests/mir-opt/const_prop/boxes.main.GVN.panic-unwind.diff
@@ -29,10 +29,10 @@
           StorageLive(_5);
 -         _6 = move _4 as *const i32 (Transmute);
 -         _7 = NonNull::<i32> { pointer: move _6 };
--         _8 = Unique::<i32> { pointer: move _7, _marker: const PhantomData::<i32> };
+-         _8 = std::ptr::Unique::<i32> { pointer: move _7, _marker: const PhantomData::<i32> };
 +         _6 = copy _4 as *const i32 (PtrToPtr);
 +         _7 = NonNull::<i32> { pointer: copy _6 };
-+         _8 = Unique::<i32> { pointer: copy _7, _marker: const PhantomData::<i32> };
++         _8 = std::ptr::Unique::<i32> { pointer: copy _7, _marker: const PhantomData::<i32> };
           _5 = Box::<i32>(move _8, const std::alloc::Global);
 -         _9 = copy ((_5.0: std::ptr::Unique<i32>).0: std::ptr::NonNull<i32>) as *const i32 (Transmute);
 -         (*_9) = const 42_i32;

--- a/tests/mir-opt/const_prop/control_flow_simplification.hello.GVN.panic-abort.diff
+++ b/tests/mir-opt/const_prop/control_flow_simplification.hello.GVN.panic-abort.diff
@@ -10,7 +10,7 @@
       }
   
       bb1: {
-          _1 = begin_panic::<&str>(const "explicit panic") -> unwind unreachable;
+          _1 = std::rt::begin_panic::<&str>(const "explicit panic") -> unwind unreachable;
       }
   
       bb2: {

--- a/tests/mir-opt/const_prop/control_flow_simplification.hello.GVN.panic-unwind.diff
+++ b/tests/mir-opt/const_prop/control_flow_simplification.hello.GVN.panic-unwind.diff
@@ -10,7 +10,7 @@
       }
   
       bb1: {
-          _1 = begin_panic::<&str>(const "explicit panic") -> unwind continue;
+          _1 = std::rt::begin_panic::<&str>(const "explicit panic") -> unwind continue;
       }
   
       bb2: {

--- a/tests/mir-opt/const_prop/transmute.unreachable_box.GVN.32bit.diff
+++ b/tests/mir-opt/const_prop/transmute.unreachable_box.GVN.32bit.diff
@@ -13,7 +13,7 @@
           StorageLive(_1);
 -         _1 = const 1_usize as std::boxed::Box<Never> (Transmute);
 -         _2 = copy ((_1.0: std::ptr::Unique<Never>).0: std::ptr::NonNull<Never>) as *const Never (Transmute);
-+         _1 = const Box::<Never>(Unique::<Never> {{ pointer: NonNull::<Never> {{ pointer: {0x1 as *const Never} }}, _marker: PhantomData::<Never> }}, std::alloc::Global);
++         _1 = const Box::<Never>(std::ptr::Unique::<Never> {{ pointer: NonNull::<Never> {{ pointer: {0x1 as *const Never} }}, _marker: PhantomData::<Never> }}, std::alloc::Global);
 +         _2 = const std::ptr::NonNull::<Never> {{ pointer: {0x1 as *const Never} }} as *const Never (Transmute);
           unreachable;
       }

--- a/tests/mir-opt/const_prop/transmute.unreachable_box.GVN.64bit.diff
+++ b/tests/mir-opt/const_prop/transmute.unreachable_box.GVN.64bit.diff
@@ -13,7 +13,7 @@
           StorageLive(_1);
 -         _1 = const 1_usize as std::boxed::Box<Never> (Transmute);
 -         _2 = copy ((_1.0: std::ptr::Unique<Never>).0: std::ptr::NonNull<Never>) as *const Never (Transmute);
-+         _1 = const Box::<Never>(Unique::<Never> {{ pointer: NonNull::<Never> {{ pointer: {0x1 as *const Never} }}, _marker: PhantomData::<Never> }}, std::alloc::Global);
++         _1 = const Box::<Never>(std::ptr::Unique::<Never> {{ pointer: NonNull::<Never> {{ pointer: {0x1 as *const Never} }}, _marker: PhantomData::<Never> }}, std::alloc::Global);
 +         _2 = const std::ptr::NonNull::<Never> {{ pointer: {0x1 as *const Never} }} as *const Never (Transmute);
           unreachable;
       }

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.32bit.panic-abort.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.32bit.panic-abort.diff
@@ -13,7 +13,7 @@
           let mut _4: std::ptr::Unique<[bool; 0]>;
           scope 3 {
           }
-          scope 4 (inlined Unique::<[bool; 0]>::dangling) {
+          scope 4 (inlined std::ptr::Unique::<[bool; 0]>::dangling) {
               let mut _5: std::ptr::NonNull<[bool; 0]>;
               scope 5 (inlined NonNull::<[bool; 0]>::dangling) {
                   let mut _6: std::num::NonZero<usize>;
@@ -51,13 +51,13 @@
           _5 = const NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }};
           StorageDead(_7);
           StorageDead(_6);
-          _4 = const Unique::<[bool; 0]> {{ pointer: NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }}, _marker: PhantomData::<[bool; 0]> }};
+          _4 = const std::ptr::Unique::<[bool; 0]> {{ pointer: NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }}, _marker: PhantomData::<[bool; 0]> }};
           StorageDead(_5);
-          _3 = const Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC0, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }};
+          _3 = const std::ptr::Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC0, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }};
           StorageDead(_4);
-          _2 = const Box::<[bool]>(Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC1, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global);
+          _2 = const Box::<[bool]>(std::ptr::Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC1, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global);
           StorageDead(_3);
-          _1 = const A {{ foo: Box::<[bool]>(Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC2, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global) }};
+          _1 = const A {{ foo: Box::<[bool]>(std::ptr::Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC2, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global) }};
           StorageDead(_2);
           _0 = const ();
           drop(_1) -> [return: bb1, unwind unreachable];

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.32bit.panic-unwind.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.32bit.panic-unwind.diff
@@ -13,7 +13,7 @@
           let mut _4: std::ptr::Unique<[bool; 0]>;
           scope 3 {
           }
-          scope 4 (inlined Unique::<[bool; 0]>::dangling) {
+          scope 4 (inlined std::ptr::Unique::<[bool; 0]>::dangling) {
               let mut _5: std::ptr::NonNull<[bool; 0]>;
               scope 5 (inlined NonNull::<[bool; 0]>::dangling) {
                   let mut _6: std::num::NonZero<usize>;
@@ -51,13 +51,13 @@
           _5 = const NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }};
           StorageDead(_7);
           StorageDead(_6);
-          _4 = const Unique::<[bool; 0]> {{ pointer: NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }}, _marker: PhantomData::<[bool; 0]> }};
+          _4 = const std::ptr::Unique::<[bool; 0]> {{ pointer: NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }}, _marker: PhantomData::<[bool; 0]> }};
           StorageDead(_5);
-          _3 = const Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC0, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }};
+          _3 = const std::ptr::Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC0, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }};
           StorageDead(_4);
-          _2 = const Box::<[bool]>(Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC1, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global);
+          _2 = const Box::<[bool]>(std::ptr::Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC1, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global);
           StorageDead(_3);
-          _1 = const A {{ foo: Box::<[bool]>(Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC2, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global) }};
+          _1 = const A {{ foo: Box::<[bool]>(std::ptr::Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC2, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global) }};
           StorageDead(_2);
           _0 = const ();
           drop(_1) -> [return: bb1, unwind: bb2];

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.64bit.panic-abort.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.64bit.panic-abort.diff
@@ -13,7 +13,7 @@
           let mut _4: std::ptr::Unique<[bool; 0]>;
           scope 3 {
           }
-          scope 4 (inlined Unique::<[bool; 0]>::dangling) {
+          scope 4 (inlined std::ptr::Unique::<[bool; 0]>::dangling) {
               let mut _5: std::ptr::NonNull<[bool; 0]>;
               scope 5 (inlined NonNull::<[bool; 0]>::dangling) {
                   let mut _6: std::num::NonZero<usize>;
@@ -51,13 +51,13 @@
           _5 = const NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }};
           StorageDead(_7);
           StorageDead(_6);
-          _4 = const Unique::<[bool; 0]> {{ pointer: NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }}, _marker: PhantomData::<[bool; 0]> }};
+          _4 = const std::ptr::Unique::<[bool; 0]> {{ pointer: NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }}, _marker: PhantomData::<[bool; 0]> }};
           StorageDead(_5);
-          _3 = const Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC0, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }};
+          _3 = const std::ptr::Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC0, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }};
           StorageDead(_4);
-          _2 = const Box::<[bool]>(Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC1, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global);
+          _2 = const Box::<[bool]>(std::ptr::Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC1, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global);
           StorageDead(_3);
-          _1 = const A {{ foo: Box::<[bool]>(Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC2, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global) }};
+          _1 = const A {{ foo: Box::<[bool]>(std::ptr::Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC2, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global) }};
           StorageDead(_2);
           _0 = const ();
           drop(_1) -> [return: bb1, unwind unreachable];

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.64bit.panic-unwind.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.64bit.panic-unwind.diff
@@ -13,7 +13,7 @@
           let mut _4: std::ptr::Unique<[bool; 0]>;
           scope 3 {
           }
-          scope 4 (inlined Unique::<[bool; 0]>::dangling) {
+          scope 4 (inlined std::ptr::Unique::<[bool; 0]>::dangling) {
               let mut _5: std::ptr::NonNull<[bool; 0]>;
               scope 5 (inlined NonNull::<[bool; 0]>::dangling) {
                   let mut _6: std::num::NonZero<usize>;
@@ -51,13 +51,13 @@
           _5 = const NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }};
           StorageDead(_7);
           StorageDead(_6);
-          _4 = const Unique::<[bool; 0]> {{ pointer: NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }}, _marker: PhantomData::<[bool; 0]> }};
+          _4 = const std::ptr::Unique::<[bool; 0]> {{ pointer: NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }}, _marker: PhantomData::<[bool; 0]> }};
           StorageDead(_5);
-          _3 = const Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC0, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }};
+          _3 = const std::ptr::Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC0, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }};
           StorageDead(_4);
-          _2 = const Box::<[bool]>(Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC1, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global);
+          _2 = const Box::<[bool]>(std::ptr::Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC1, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global);
           StorageDead(_3);
-          _1 = const A {{ foo: Box::<[bool]>(Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC2, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global) }};
+          _1 = const A {{ foo: Box::<[bool]>(std::ptr::Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC2, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global) }};
           StorageDead(_2);
           _0 = const ();
           drop(_1) -> [return: bb1, unwind: bb2];

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.32bit.panic-abort.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.32bit.panic-abort.diff
@@ -13,7 +13,7 @@
           let mut _4: std::ptr::Unique<[bool; 0]>;
           scope 3 {
           }
-          scope 4 (inlined Unique::<[bool; 0]>::dangling) {
+          scope 4 (inlined std::ptr::Unique::<[bool; 0]>::dangling) {
               let mut _5: std::ptr::NonNull<[bool; 0]>;
               scope 5 (inlined NonNull::<[bool; 0]>::dangling) {
                   let mut _6: std::num::NonZero<usize>;
@@ -54,17 +54,17 @@
 +         _5 = const NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }};
           StorageDead(_7);
           StorageDead(_6);
--         _4 = Unique::<[bool; 0]> { pointer: move _5, _marker: const PhantomData::<[bool; 0]> };
-+         _4 = const Unique::<[bool; 0]> {{ pointer: NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }}, _marker: PhantomData::<[bool; 0]> }};
+-         _4 = std::ptr::Unique::<[bool; 0]> { pointer: move _5, _marker: const PhantomData::<[bool; 0]> };
++         _4 = const std::ptr::Unique::<[bool; 0]> {{ pointer: NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }}, _marker: PhantomData::<[bool; 0]> }};
           StorageDead(_5);
 -         _3 = move _4 as std::ptr::Unique<[bool]> (PointerCoercion(Unsize, Implicit));
-+         _3 = const Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC0, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }};
++         _3 = const std::ptr::Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC0, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }};
           StorageDead(_4);
 -         _2 = Box::<[bool]>(copy _3, const std::alloc::Global);
-+         _2 = const Box::<[bool]>(Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC1, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global);
++         _2 = const Box::<[bool]>(std::ptr::Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC1, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global);
           StorageDead(_3);
 -         _1 = A { foo: move _2 };
-+         _1 = const A {{ foo: Box::<[bool]>(Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC2, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global) }};
++         _1 = const A {{ foo: Box::<[bool]>(std::ptr::Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC2, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global) }};
           StorageDead(_2);
           _0 = const ();
           drop(_1) -> [return: bb1, unwind unreachable];

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.32bit.panic-unwind.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.32bit.panic-unwind.diff
@@ -13,7 +13,7 @@
           let mut _4: std::ptr::Unique<[bool; 0]>;
           scope 3 {
           }
-          scope 4 (inlined Unique::<[bool; 0]>::dangling) {
+          scope 4 (inlined std::ptr::Unique::<[bool; 0]>::dangling) {
               let mut _5: std::ptr::NonNull<[bool; 0]>;
               scope 5 (inlined NonNull::<[bool; 0]>::dangling) {
                   let mut _6: std::num::NonZero<usize>;
@@ -54,17 +54,17 @@
 +         _5 = const NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }};
           StorageDead(_7);
           StorageDead(_6);
--         _4 = Unique::<[bool; 0]> { pointer: move _5, _marker: const PhantomData::<[bool; 0]> };
-+         _4 = const Unique::<[bool; 0]> {{ pointer: NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }}, _marker: PhantomData::<[bool; 0]> }};
+-         _4 = std::ptr::Unique::<[bool; 0]> { pointer: move _5, _marker: const PhantomData::<[bool; 0]> };
++         _4 = const std::ptr::Unique::<[bool; 0]> {{ pointer: NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }}, _marker: PhantomData::<[bool; 0]> }};
           StorageDead(_5);
 -         _3 = move _4 as std::ptr::Unique<[bool]> (PointerCoercion(Unsize, Implicit));
-+         _3 = const Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC0, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }};
++         _3 = const std::ptr::Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC0, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }};
           StorageDead(_4);
 -         _2 = Box::<[bool]>(copy _3, const std::alloc::Global);
-+         _2 = const Box::<[bool]>(Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC1, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global);
++         _2 = const Box::<[bool]>(std::ptr::Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC1, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global);
           StorageDead(_3);
 -         _1 = A { foo: move _2 };
-+         _1 = const A {{ foo: Box::<[bool]>(Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC2, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global) }};
++         _1 = const A {{ foo: Box::<[bool]>(std::ptr::Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC2, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global) }};
           StorageDead(_2);
           _0 = const ();
           drop(_1) -> [return: bb1, unwind: bb2];

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.64bit.panic-abort.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.64bit.panic-abort.diff
@@ -13,7 +13,7 @@
           let mut _4: std::ptr::Unique<[bool; 0]>;
           scope 3 {
           }
-          scope 4 (inlined Unique::<[bool; 0]>::dangling) {
+          scope 4 (inlined std::ptr::Unique::<[bool; 0]>::dangling) {
               let mut _5: std::ptr::NonNull<[bool; 0]>;
               scope 5 (inlined NonNull::<[bool; 0]>::dangling) {
                   let mut _6: std::num::NonZero<usize>;
@@ -54,17 +54,17 @@
 +         _5 = const NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }};
           StorageDead(_7);
           StorageDead(_6);
--         _4 = Unique::<[bool; 0]> { pointer: move _5, _marker: const PhantomData::<[bool; 0]> };
-+         _4 = const Unique::<[bool; 0]> {{ pointer: NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }}, _marker: PhantomData::<[bool; 0]> }};
+-         _4 = std::ptr::Unique::<[bool; 0]> { pointer: move _5, _marker: const PhantomData::<[bool; 0]> };
++         _4 = const std::ptr::Unique::<[bool; 0]> {{ pointer: NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }}, _marker: PhantomData::<[bool; 0]> }};
           StorageDead(_5);
 -         _3 = move _4 as std::ptr::Unique<[bool]> (PointerCoercion(Unsize, Implicit));
-+         _3 = const Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC0, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }};
++         _3 = const std::ptr::Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC0, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }};
           StorageDead(_4);
 -         _2 = Box::<[bool]>(copy _3, const std::alloc::Global);
-+         _2 = const Box::<[bool]>(Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC1, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global);
++         _2 = const Box::<[bool]>(std::ptr::Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC1, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global);
           StorageDead(_3);
 -         _1 = A { foo: move _2 };
-+         _1 = const A {{ foo: Box::<[bool]>(Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC2, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global) }};
++         _1 = const A {{ foo: Box::<[bool]>(std::ptr::Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC2, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global) }};
           StorageDead(_2);
           _0 = const ();
           drop(_1) -> [return: bb1, unwind unreachable];

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.64bit.panic-unwind.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.64bit.panic-unwind.diff
@@ -13,7 +13,7 @@
           let mut _4: std::ptr::Unique<[bool; 0]>;
           scope 3 {
           }
-          scope 4 (inlined Unique::<[bool; 0]>::dangling) {
+          scope 4 (inlined std::ptr::Unique::<[bool; 0]>::dangling) {
               let mut _5: std::ptr::NonNull<[bool; 0]>;
               scope 5 (inlined NonNull::<[bool; 0]>::dangling) {
                   let mut _6: std::num::NonZero<usize>;
@@ -54,17 +54,17 @@
 +         _5 = const NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }};
           StorageDead(_7);
           StorageDead(_6);
--         _4 = Unique::<[bool; 0]> { pointer: move _5, _marker: const PhantomData::<[bool; 0]> };
-+         _4 = const Unique::<[bool; 0]> {{ pointer: NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }}, _marker: PhantomData::<[bool; 0]> }};
+-         _4 = std::ptr::Unique::<[bool; 0]> { pointer: move _5, _marker: const PhantomData::<[bool; 0]> };
++         _4 = const std::ptr::Unique::<[bool; 0]> {{ pointer: NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }}, _marker: PhantomData::<[bool; 0]> }};
           StorageDead(_5);
 -         _3 = move _4 as std::ptr::Unique<[bool]> (PointerCoercion(Unsize, Implicit));
-+         _3 = const Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC0, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }};
++         _3 = const std::ptr::Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC0, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }};
           StorageDead(_4);
 -         _2 = Box::<[bool]>(copy _3, const std::alloc::Global);
-+         _2 = const Box::<[bool]>(Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC1, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global);
++         _2 = const Box::<[bool]>(std::ptr::Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC1, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global);
           StorageDead(_3);
 -         _1 = A { foo: move _2 };
-+         _1 = const A {{ foo: Box::<[bool]>(Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC2, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global) }};
++         _1 = const A {{ foo: Box::<[bool]>(std::ptr::Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC2, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global) }};
           StorageDead(_2);
           _0 = const ();
           drop(_1) -> [return: bb1, unwind: bb2];

--- a/tests/mir-opt/dataflow-const-prop/transmute.unreachable_box.DataflowConstProp.32bit.diff
+++ b/tests/mir-opt/dataflow-const-prop/transmute.unreachable_box.DataflowConstProp.32bit.diff
@@ -12,7 +12,7 @@
       bb0: {
           StorageLive(_1);
 -         _1 = const 1_usize as std::boxed::Box<Never> (Transmute);
-+         _1 = const Box::<Never>(Unique::<Never> {{ pointer: NonNull::<Never> {{ pointer: {0x1 as *const Never} }}, _marker: PhantomData::<Never> }}, std::alloc::Global);
++         _1 = const Box::<Never>(std::ptr::Unique::<Never> {{ pointer: NonNull::<Never> {{ pointer: {0x1 as *const Never} }}, _marker: PhantomData::<Never> }}, std::alloc::Global);
           _2 = copy ((_1.0: std::ptr::Unique<Never>).0: std::ptr::NonNull<Never>) as *const Never (Transmute);
           unreachable;
       }

--- a/tests/mir-opt/dataflow-const-prop/transmute.unreachable_box.DataflowConstProp.64bit.diff
+++ b/tests/mir-opt/dataflow-const-prop/transmute.unreachable_box.DataflowConstProp.64bit.diff
@@ -12,7 +12,7 @@
       bb0: {
           StorageLive(_1);
 -         _1 = const 1_usize as std::boxed::Box<Never> (Transmute);
-+         _1 = const Box::<Never>(Unique::<Never> {{ pointer: NonNull::<Never> {{ pointer: {0x1 as *const Never} }}, _marker: PhantomData::<Never> }}, std::alloc::Global);
++         _1 = const Box::<Never>(std::ptr::Unique::<Never> {{ pointer: NonNull::<Never> {{ pointer: {0x1 as *const Never} }}, _marker: PhantomData::<Never> }}, std::alloc::Global);
           _2 = copy ((_1.0: std::ptr::Unique<Never>).0: std::ptr::NonNull<Never>) as *const Never (Transmute);
           unreachable;
       }

--- a/tests/mir-opt/dont_reset_cast_kind_without_updating_operand.test.GVN.32bit.panic-abort.diff
+++ b/tests/mir-opt/dont_reset_cast_kind_without_updating_operand.test.GVN.32bit.panic-abort.diff
@@ -133,7 +133,7 @@
 -         _13 = copy _12 as *const () (PtrToPtr);
 +         _13 = copy _25 as *const () (PtrToPtr);
           _14 = NonNull::<()> { pointer: copy _13 };
-          _15 = Unique::<()> { pointer: copy _14, _marker: const PhantomData::<()> };
+          _15 = std::ptr::Unique::<()> { pointer: copy _14, _marker: const PhantomData::<()> };
           _3 = Box::<()>(move _15, const std::alloc::Global);
 -         (*_13) = move _4;
 +         (*_13) = const ();

--- a/tests/mir-opt/dont_reset_cast_kind_without_updating_operand.test.GVN.64bit.panic-abort.diff
+++ b/tests/mir-opt/dont_reset_cast_kind_without_updating_operand.test.GVN.64bit.panic-abort.diff
@@ -133,7 +133,7 @@
 -         _13 = copy _12 as *const () (PtrToPtr);
 +         _13 = copy _25 as *const () (PtrToPtr);
           _14 = NonNull::<()> { pointer: copy _13 };
-          _15 = Unique::<()> { pointer: copy _14, _marker: const PhantomData::<()> };
+          _15 = std::ptr::Unique::<()> { pointer: copy _14, _marker: const PhantomData::<()> };
           _3 = Box::<()>(move _15, const std::alloc::Global);
 -         (*_13) = move _4;
 +         (*_13) = const ();

--- a/tests/mir-opt/funky_arms.float_to_exponential_common.GVN.32bit.panic-abort.diff
+++ b/tests/mir-opt/funky_arms.float_to_exponential_common.GVN.32bit.panic-abort.diff
@@ -56,8 +56,8 @@
       }
   
       bb1: {
--         _5 = MinusPlus;
-+         _5 = const MinusPlus;
+-         _5 = core::num::flt2dec::Sign::MinusPlus;
++         _5 = const core::num::flt2dec::Sign::MinusPlus;
           goto -> bb3;
       }
   

--- a/tests/mir-opt/funky_arms.float_to_exponential_common.GVN.32bit.panic-unwind.diff
+++ b/tests/mir-opt/funky_arms.float_to_exponential_common.GVN.32bit.panic-unwind.diff
@@ -56,8 +56,8 @@
       }
   
       bb1: {
--         _5 = MinusPlus;
-+         _5 = const MinusPlus;
+-         _5 = core::num::flt2dec::Sign::MinusPlus;
++         _5 = const core::num::flt2dec::Sign::MinusPlus;
           goto -> bb3;
       }
   

--- a/tests/mir-opt/funky_arms.float_to_exponential_common.GVN.64bit.panic-abort.diff
+++ b/tests/mir-opt/funky_arms.float_to_exponential_common.GVN.64bit.panic-abort.diff
@@ -56,8 +56,8 @@
       }
   
       bb1: {
--         _5 = MinusPlus;
-+         _5 = const MinusPlus;
+-         _5 = core::num::flt2dec::Sign::MinusPlus;
++         _5 = const core::num::flt2dec::Sign::MinusPlus;
           goto -> bb3;
       }
   

--- a/tests/mir-opt/funky_arms.float_to_exponential_common.GVN.64bit.panic-unwind.diff
+++ b/tests/mir-opt/funky_arms.float_to_exponential_common.GVN.64bit.panic-unwind.diff
@@ -56,8 +56,8 @@
       }
   
       bb1: {
--         _5 = MinusPlus;
-+         _5 = const MinusPlus;
+-         _5 = core::num::flt2dec::Sign::MinusPlus;
++         _5 = const core::num::flt2dec::Sign::MinusPlus;
           goto -> bb3;
       }
   

--- a/tests/mir-opt/gvn.slices.GVN.panic-abort.diff
+++ b/tests/mir-opt/gvn.slices.GVN.panic-abort.diff
@@ -210,9 +210,9 @@
           _26 = &(*_27);
           StorageLive(_28);
 -         _28 = Option::<Arguments<'_>>::None;
--         _22 = assert_failed::<*const u8, *const u8>(move _23, move _24, move _26, move _28) -> unwind unreachable;
+-         _22 = core::panicking::assert_failed::<*const u8, *const u8>(move _23, move _24, move _26, move _28) -> unwind unreachable;
 +         _28 = const Option::<Arguments<'_>>::None;
-+         _22 = assert_failed::<*const u8, *const u8>(const core::panicking::AssertKind::Eq, move _24, move _26, const Option::<Arguments<'_>>::None) -> unwind unreachable;
++         _22 = core::panicking::assert_failed::<*const u8, *const u8>(const core::panicking::AssertKind::Eq, move _24, move _26, const Option::<Arguments<'_>>::None) -> unwind unreachable;
       }
   
       bb7: {
@@ -313,9 +313,9 @@
           _52 = &(*_53);
           StorageLive(_54);
 -         _54 = Option::<Arguments<'_>>::None;
--         _48 = assert_failed::<*const u8, *const u8>(move _49, move _50, move _52, move _54) -> unwind unreachable;
+-         _48 = core::panicking::assert_failed::<*const u8, *const u8>(move _49, move _50, move _52, move _54) -> unwind unreachable;
 +         _54 = const Option::<Arguments<'_>>::None;
-+         _48 = assert_failed::<*const u8, *const u8>(const core::panicking::AssertKind::Eq, move _50, move _52, const Option::<Arguments<'_>>::None) -> unwind unreachable;
++         _48 = core::panicking::assert_failed::<*const u8, *const u8>(const core::panicking::AssertKind::Eq, move _50, move _52, const Option::<Arguments<'_>>::None) -> unwind unreachable;
       }
   }
   

--- a/tests/mir-opt/gvn.slices.GVN.panic-unwind.diff
+++ b/tests/mir-opt/gvn.slices.GVN.panic-unwind.diff
@@ -210,9 +210,9 @@
           _26 = &(*_27);
           StorageLive(_28);
 -         _28 = Option::<Arguments<'_>>::None;
--         _22 = assert_failed::<*const u8, *const u8>(move _23, move _24, move _26, move _28) -> unwind continue;
+-         _22 = core::panicking::assert_failed::<*const u8, *const u8>(move _23, move _24, move _26, move _28) -> unwind continue;
 +         _28 = const Option::<Arguments<'_>>::None;
-+         _22 = assert_failed::<*const u8, *const u8>(const core::panicking::AssertKind::Eq, move _24, move _26, const Option::<Arguments<'_>>::None) -> unwind continue;
++         _22 = core::panicking::assert_failed::<*const u8, *const u8>(const core::panicking::AssertKind::Eq, move _24, move _26, const Option::<Arguments<'_>>::None) -> unwind continue;
       }
   
       bb7: {
@@ -313,9 +313,9 @@
           _52 = &(*_53);
           StorageLive(_54);
 -         _54 = Option::<Arguments<'_>>::None;
--         _48 = assert_failed::<*const u8, *const u8>(move _49, move _50, move _52, move _54) -> unwind continue;
+-         _48 = core::panicking::assert_failed::<*const u8, *const u8>(move _49, move _50, move _52, move _54) -> unwind continue;
 +         _54 = const Option::<Arguments<'_>>::None;
-+         _48 = assert_failed::<*const u8, *const u8>(const core::panicking::AssertKind::Eq, move _50, move _52, const Option::<Arguments<'_>>::None) -> unwind continue;
++         _48 = core::panicking::assert_failed::<*const u8, *const u8>(const core::panicking::AssertKind::Eq, move _50, move _52, const Option::<Arguments<'_>>::None) -> unwind continue;
       }
   }
   

--- a/tests/mir-opt/gvn.wrap_unwrap.GVN.panic-abort.diff
+++ b/tests/mir-opt/gvn.wrap_unwrap.GVN.panic-abort.diff
@@ -32,7 +32,7 @@
   
       bb2: {
           StorageLive(_6);
-          _6 = begin_panic::<&str>(const "explicit panic") -> unwind unreachable;
+          _6 = std::rt::begin_panic::<&str>(const "explicit panic") -> unwind unreachable;
       }
   
       bb3: {

--- a/tests/mir-opt/gvn.wrap_unwrap.GVN.panic-unwind.diff
+++ b/tests/mir-opt/gvn.wrap_unwrap.GVN.panic-unwind.diff
@@ -32,7 +32,7 @@
   
       bb2: {
           StorageLive(_6);
-          _6 = begin_panic::<&str>(const "explicit panic") -> unwind continue;
+          _6 = std::rt::begin_panic::<&str>(const "explicit panic") -> unwind continue;
       }
   
       bb3: {

--- a/tests/mir-opt/inline/inline_diverging.g.Inline.panic-abort.diff
+++ b/tests/mir-opt/inline/inline_diverging.g.Inline.panic-abort.diff
@@ -36,7 +36,7 @@
           StorageLive(_6);
 -         _6 = panic() -> unwind unreachable;
 +         StorageLive(_7);
-+         _7 = begin_panic::<&str>(const "explicit panic") -> unwind unreachable;
++         _7 = std::rt::begin_panic::<&str>(const "explicit panic") -> unwind unreachable;
       }
 + }
 + 

--- a/tests/mir-opt/inline/inline_diverging.g.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/inline_diverging.g.Inline.panic-unwind.diff
@@ -36,7 +36,7 @@
           StorageLive(_6);
 -         _6 = panic() -> unwind continue;
 +         StorageLive(_7);
-+         _7 = begin_panic::<&str>(const "explicit panic") -> unwind continue;
++         _7 = std::rt::begin_panic::<&str>(const "explicit panic") -> unwind continue;
       }
 + }
 + 

--- a/tests/mir-opt/inline/inline_shims.drop.Inline.panic-abort.diff
+++ b/tests/mir-opt/inline/inline_shims.drop.Inline.panic-abort.diff
@@ -20,13 +20,13 @@
 +                     scope 5 (inlined alloc::raw_vec::RawVecInner::ptr::<A>) {
 +                         scope 6 (inlined alloc::raw_vec::RawVecInner::non_null::<A>) {
 +                             let mut _11: std::ptr::NonNull<u8>;
-+                             scope 7 (inlined Unique::<u8>::cast::<A>) {
++                             scope 7 (inlined std::ptr::Unique::<u8>::cast::<A>) {
 +                                 scope 8 (inlined NonNull::<u8>::cast::<A>) {
 +                                     scope 9 (inlined NonNull::<u8>::as_ptr) {
 +                                     }
 +                                 }
 +                             }
-+                             scope 10 (inlined Unique::<A>::as_non_null_ptr) {
++                             scope 10 (inlined std::ptr::Unique::<A>::as_non_null_ptr) {
 +                             }
 +                         }
 +                         scope 11 (inlined NonNull::<A>::as_ptr) {

--- a/tests/mir-opt/jump_threading.chained_conditions.JumpThreading.panic-abort.diff
+++ b/tests/mir-opt/jump_threading.chained_conditions.JumpThreading.panic-abort.diff
@@ -57,13 +57,13 @@
                                   scope 11 (inlined alloc::raw_vec::RawVecInner::ptr::<u8>) {
                                       scope 12 (inlined alloc::raw_vec::RawVecInner::non_null::<u8>) {
                                           let mut _34: std::ptr::NonNull<u8>;
-                                          scope 13 (inlined Unique::<u8>::cast::<u8>) {
+                                          scope 13 (inlined std::ptr::Unique::<u8>::cast::<u8>) {
                                               scope 14 (inlined NonNull::<u8>::cast::<u8>) {
                                                   scope 15 (inlined NonNull::<u8>::as_ptr) {
                                                   }
                                               }
                                           }
-                                          scope 16 (inlined Unique::<u8>::as_non_null_ptr) {
+                                          scope 16 (inlined std::ptr::Unique::<u8>::as_non_null_ptr) {
                                           }
                                       }
                                       scope 17 (inlined NonNull::<u8>::as_ptr) {
@@ -115,13 +115,13 @@
                                   scope 34 (inlined alloc::raw_vec::RawVecInner::ptr::<u8>) {
                                       scope 35 (inlined alloc::raw_vec::RawVecInner::non_null::<u8>) {
                                           let mut _46: std::ptr::NonNull<u8>;
-                                          scope 36 (inlined Unique::<u8>::cast::<u8>) {
+                                          scope 36 (inlined std::ptr::Unique::<u8>::cast::<u8>) {
                                               scope 37 (inlined NonNull::<u8>::cast::<u8>) {
                                                   scope 38 (inlined NonNull::<u8>::as_ptr) {
                                                   }
                                               }
                                           }
-                                          scope 39 (inlined Unique::<u8>::as_non_null_ptr) {
+                                          scope 39 (inlined std::ptr::Unique::<u8>::as_non_null_ptr) {
                                           }
                                       }
                                       scope 40 (inlined NonNull::<u8>::as_ptr) {

--- a/tests/mir-opt/jump_threading.chained_conditions.JumpThreading.panic-unwind.diff
+++ b/tests/mir-opt/jump_threading.chained_conditions.JumpThreading.panic-unwind.diff
@@ -57,13 +57,13 @@
                                   scope 11 (inlined alloc::raw_vec::RawVecInner::ptr::<u8>) {
                                       scope 12 (inlined alloc::raw_vec::RawVecInner::non_null::<u8>) {
                                           let mut _34: std::ptr::NonNull<u8>;
-                                          scope 13 (inlined Unique::<u8>::cast::<u8>) {
+                                          scope 13 (inlined std::ptr::Unique::<u8>::cast::<u8>) {
                                               scope 14 (inlined NonNull::<u8>::cast::<u8>) {
                                                   scope 15 (inlined NonNull::<u8>::as_ptr) {
                                                   }
                                               }
                                           }
-                                          scope 16 (inlined Unique::<u8>::as_non_null_ptr) {
+                                          scope 16 (inlined std::ptr::Unique::<u8>::as_non_null_ptr) {
                                           }
                                       }
                                       scope 17 (inlined NonNull::<u8>::as_ptr) {
@@ -115,13 +115,13 @@
                                   scope 34 (inlined alloc::raw_vec::RawVecInner::ptr::<u8>) {
                                       scope 35 (inlined alloc::raw_vec::RawVecInner::non_null::<u8>) {
                                           let mut _46: std::ptr::NonNull<u8>;
-                                          scope 36 (inlined Unique::<u8>::cast::<u8>) {
+                                          scope 36 (inlined std::ptr::Unique::<u8>::cast::<u8>) {
                                               scope 37 (inlined NonNull::<u8>::cast::<u8>) {
                                                   scope 38 (inlined NonNull::<u8>::as_ptr) {
                                                   }
                                               }
                                           }
-                                          scope 39 (inlined Unique::<u8>::as_non_null_ptr) {
+                                          scope 39 (inlined std::ptr::Unique::<u8>::as_non_null_ptr) {
                                           }
                                       }
                                       scope 40 (inlined NonNull::<u8>::as_ptr) {

--- a/tests/mir-opt/no_drop_for_inactive_variant.unwrap.SimplifyCfg-pre-optimizations.after.panic-abort.mir
+++ b/tests/mir-opt/no_drop_for_inactive_variant.unwrap.SimplifyCfg-pre-optimizations.after.panic-abort.mir
@@ -24,7 +24,7 @@ fn unwrap(_1: Option<T>) -> T {
 
     bb2: {
         StorageLive(_4);
-        _4 = begin_panic::<&str>(const "explicit panic") -> unwind unreachable;
+        _4 = std::rt::begin_panic::<&str>(const "explicit panic") -> unwind unreachable;
     }
 
     bb3: {

--- a/tests/mir-opt/no_drop_for_inactive_variant.unwrap.SimplifyCfg-pre-optimizations.after.panic-unwind.mir
+++ b/tests/mir-opt/no_drop_for_inactive_variant.unwrap.SimplifyCfg-pre-optimizations.after.panic-unwind.mir
@@ -24,7 +24,7 @@ fn unwrap(_1: Option<T>) -> T {
 
     bb2: {
         StorageLive(_4);
-        _4 = begin_panic::<&str>(const "explicit panic") -> bb4;
+        _4 = std::rt::begin_panic::<&str>(const "explicit panic") -> bb4;
     }
 
     bb3: {

--- a/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.32bit.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.32bit.panic-abort.mir
@@ -14,14 +14,14 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
                 scope 4 {
                     scope 12 (inlined Layout::size) {
                     }
-                    scope 13 (inlined Unique::<[T]>::cast::<u8>) {
+                    scope 13 (inlined std::ptr::Unique::<[T]>::cast::<u8>) {
                         scope 14 (inlined NonNull::<[T]>::cast::<u8>) {
                             scope 15 (inlined NonNull::<[T]>::as_ptr) {
                             }
                         }
                     }
-                    scope 16 (inlined <NonNull<u8> as From<Unique<u8>>>::from) {
-                        scope 17 (inlined Unique::<u8>::as_non_null_ptr) {
+                    scope 16 (inlined <NonNull<u8> as From<std::ptr::Unique<u8>>>::from) {
+                        scope 17 (inlined std::ptr::Unique::<u8>::as_non_null_ptr) {
                         }
                     }
                     scope 18 (inlined <std::alloc::Global as Allocator>::deallocate) {
@@ -45,7 +45,7 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
                         }
                     }
                 }
-                scope 5 (inlined Unique::<[T]>::as_ptr) {
+                scope 5 (inlined std::ptr::Unique::<[T]>::as_ptr) {
                     scope 6 (inlined NonNull::<[T]>::as_ptr) {
                     }
                 }

--- a/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.32bit.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.32bit.panic-unwind.mir
@@ -14,14 +14,14 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
                 scope 4 {
                     scope 12 (inlined Layout::size) {
                     }
-                    scope 13 (inlined Unique::<[T]>::cast::<u8>) {
+                    scope 13 (inlined std::ptr::Unique::<[T]>::cast::<u8>) {
                         scope 14 (inlined NonNull::<[T]>::cast::<u8>) {
                             scope 15 (inlined NonNull::<[T]>::as_ptr) {
                             }
                         }
                     }
-                    scope 16 (inlined <NonNull<u8> as From<Unique<u8>>>::from) {
-                        scope 17 (inlined Unique::<u8>::as_non_null_ptr) {
+                    scope 16 (inlined <NonNull<u8> as From<std::ptr::Unique<u8>>>::from) {
+                        scope 17 (inlined std::ptr::Unique::<u8>::as_non_null_ptr) {
                         }
                     }
                     scope 18 (inlined <std::alloc::Global as Allocator>::deallocate) {
@@ -45,7 +45,7 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
                         }
                     }
                 }
-                scope 5 (inlined Unique::<[T]>::as_ptr) {
+                scope 5 (inlined std::ptr::Unique::<[T]>::as_ptr) {
                     scope 6 (inlined NonNull::<[T]>::as_ptr) {
                     }
                 }

--- a/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.64bit.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.64bit.panic-abort.mir
@@ -14,14 +14,14 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
                 scope 4 {
                     scope 12 (inlined Layout::size) {
                     }
-                    scope 13 (inlined Unique::<[T]>::cast::<u8>) {
+                    scope 13 (inlined std::ptr::Unique::<[T]>::cast::<u8>) {
                         scope 14 (inlined NonNull::<[T]>::cast::<u8>) {
                             scope 15 (inlined NonNull::<[T]>::as_ptr) {
                             }
                         }
                     }
-                    scope 16 (inlined <NonNull<u8> as From<Unique<u8>>>::from) {
-                        scope 17 (inlined Unique::<u8>::as_non_null_ptr) {
+                    scope 16 (inlined <NonNull<u8> as From<std::ptr::Unique<u8>>>::from) {
+                        scope 17 (inlined std::ptr::Unique::<u8>::as_non_null_ptr) {
                         }
                     }
                     scope 18 (inlined <std::alloc::Global as Allocator>::deallocate) {
@@ -45,7 +45,7 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
                         }
                     }
                 }
-                scope 5 (inlined Unique::<[T]>::as_ptr) {
+                scope 5 (inlined std::ptr::Unique::<[T]>::as_ptr) {
                     scope 6 (inlined NonNull::<[T]>::as_ptr) {
                     }
                 }

--- a/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.64bit.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.64bit.panic-unwind.mir
@@ -14,14 +14,14 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
                 scope 4 {
                     scope 12 (inlined Layout::size) {
                     }
-                    scope 13 (inlined Unique::<[T]>::cast::<u8>) {
+                    scope 13 (inlined std::ptr::Unique::<[T]>::cast::<u8>) {
                         scope 14 (inlined NonNull::<[T]>::cast::<u8>) {
                             scope 15 (inlined NonNull::<[T]>::as_ptr) {
                             }
                         }
                     }
-                    scope 16 (inlined <NonNull<u8> as From<Unique<u8>>>::from) {
-                        scope 17 (inlined Unique::<u8>::as_non_null_ptr) {
+                    scope 16 (inlined <NonNull<u8> as From<std::ptr::Unique<u8>>>::from) {
+                        scope 17 (inlined std::ptr::Unique::<u8>::as_non_null_ptr) {
                         }
                     }
                     scope 18 (inlined <std::alloc::Global as Allocator>::deallocate) {
@@ -45,7 +45,7 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
                         }
                     }
                 }
-                scope 5 (inlined Unique::<[T]>::as_ptr) {
+                scope 5 (inlined std::ptr::Unique::<[T]>::as_ptr) {
                     scope 6 (inlined NonNull::<[T]>::as_ptr) {
                     }
                 }

--- a/tests/mir-opt/pre-codegen/loops.vec_move.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/loops.vec_move.PreCodegen.after.mir
@@ -139,14 +139,14 @@ fn vec_move(_1: Vec<impl Sized>) -> () {
                     debug self => _31;
                     scope 23 (inlined alloc::raw_vec::RawVecInner::non_null::<impl Sized>) {
                         let mut _5: std::ptr::NonNull<u8>;
-                        scope 24 (inlined Unique::<u8>::cast::<impl Sized>) {
+                        scope 24 (inlined std::ptr::Unique::<u8>::cast::<impl Sized>) {
                             scope 25 (inlined NonNull::<u8>::cast::<impl Sized>) {
                                 let mut _6: *const impl Sized;
                                 scope 26 (inlined NonNull::<u8>::as_ptr) {
                                 }
                             }
                         }
-                        scope 27 (inlined Unique::<impl Sized>::as_non_null_ptr) {
+                        scope 27 (inlined std::ptr::Unique::<impl Sized>::as_non_null_ptr) {
                         }
                     }
                 }

--- a/tests/mir-opt/pre-codegen/vec_deref.vec_deref_to_slice.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/vec_deref.vec_deref_to_slice.PreCodegen.after.panic-abort.mir
@@ -16,13 +16,13 @@ fn vec_deref_to_slice(_1: &Vec<u8>) -> &[u8] {
                     scope 5 (inlined alloc::raw_vec::RawVecInner::ptr::<u8>) {
                         scope 6 (inlined alloc::raw_vec::RawVecInner::non_null::<u8>) {
                             let mut _2: std::ptr::NonNull<u8>;
-                            scope 7 (inlined Unique::<u8>::cast::<u8>) {
+                            scope 7 (inlined std::ptr::Unique::<u8>::cast::<u8>) {
                                 scope 8 (inlined NonNull::<u8>::cast::<u8>) {
                                     scope 9 (inlined NonNull::<u8>::as_ptr) {
                                     }
                                 }
                             }
-                            scope 10 (inlined Unique::<u8>::as_non_null_ptr) {
+                            scope 10 (inlined std::ptr::Unique::<u8>::as_non_null_ptr) {
                             }
                         }
                         scope 11 (inlined NonNull::<u8>::as_ptr) {

--- a/tests/mir-opt/pre-codegen/vec_deref.vec_deref_to_slice.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/vec_deref.vec_deref_to_slice.PreCodegen.after.panic-unwind.mir
@@ -16,13 +16,13 @@ fn vec_deref_to_slice(_1: &Vec<u8>) -> &[u8] {
                     scope 5 (inlined alloc::raw_vec::RawVecInner::ptr::<u8>) {
                         scope 6 (inlined alloc::raw_vec::RawVecInner::non_null::<u8>) {
                             let mut _2: std::ptr::NonNull<u8>;
-                            scope 7 (inlined Unique::<u8>::cast::<u8>) {
+                            scope 7 (inlined std::ptr::Unique::<u8>::cast::<u8>) {
                                 scope 8 (inlined NonNull::<u8>::cast::<u8>) {
                                     scope 9 (inlined NonNull::<u8>::as_ptr) {
                                     }
                                 }
                             }
-                            scope 10 (inlined Unique::<u8>::as_non_null_ptr) {
+                            scope 10 (inlined std::ptr::Unique::<u8>::as_non_null_ptr) {
                             }
                         }
                         scope 11 (inlined NonNull::<u8>::as_ptr) {

--- a/tests/mir-opt/sroa/lifetimes.foo.ScalarReplacementOfAggregates.diff
+++ b/tests/mir-opt/sroa/lifetimes.foo.ScalarReplacementOfAggregates.diff
@@ -152,7 +152,7 @@
           StorageDead(_22);
           StorageDead(_21);
           StorageDead(_20);
-          _10 = _eprint(move _11) -> [return: bb6, unwind unreachable];
+          _10 = std::io::_eprint(move _11) -> [return: bb6, unwind unreachable];
       }
   
       bb6: {

--- a/tests/ui/async-await/async-closures/def-path.stderr
+++ b/tests/ui/async-await/async-closures/def-path.stderr
@@ -5,11 +5,11 @@ LL |     let x = async || {};
    |                      -- the expected `async` closure body
 LL |
 LL |     let () = x();
-   |         ^^   --- this expression has type `{static main::{closure#0}::{closure#0}<?15t> upvar_tys=?14t resume_ty=ResumeTy yield_ty=() return_ty=()}`
+   |         ^^   --- this expression has type `{static main::{closure#0}::{closure#0}<?15t> upvar_tys=?14t resume_ty=std::future::ResumeTy yield_ty=() return_ty=()}`
    |         |
    |         expected `async` closure body, found `()`
    |
-   = note: expected `async` closure body `{static main::{closure#0}::{closure#0}<?15t> upvar_tys=?14t resume_ty=ResumeTy yield_ty=() return_ty=()}`
+   = note: expected `async` closure body `{static main::{closure#0}::{closure#0}<?15t> upvar_tys=?14t resume_ty=std::future::ResumeTy yield_ty=() return_ty=()}`
                          found unit type `()`
 
 error: aborting due to 1 previous error

--- a/tests/ui/const-generics/adt_const_params/unsizing-wfcheck-issue-126272.stderr
+++ b/tests/ui/const-generics/adt_const_params/unsizing-wfcheck-issue-126272.stderr
@@ -99,7 +99,7 @@ LL | #[derive(Debug, PartialEq, Eq, ConstParamTy)]
    |                            ^^ unsatisfied trait bound introduced in this `derive` macro
    = note: 1 redundant requirement hidden
    = note: required for `&'static Bar<dyn Debug>` to implement `Eq`
-note: required by a bound in `AssertParamIsEq`
+note: required by a bound in `std::cmp::AssertParamIsEq`
   --> $SRC_DIR/core/src/cmp.rs:LL:COL
 
 error[E0277]: the size for values of type `dyn Debug` cannot be known at compilation time

--- a/tests/ui/consts/const-eval/format.rs
+++ b/tests/ui/consts/const-eval/format.rs
@@ -6,7 +6,7 @@ const fn failure() {
 const fn print() {
     println!("{:?}", 0);
     //~^ ERROR cannot call non-const formatting macro in constant functions
-    //~| ERROR cannot call non-const function `_print` in constant functions
+    //~| ERROR cannot call non-const function `std::io::_print` in constant functions
 }
 
 const fn format_args() {

--- a/tests/ui/consts/const-eval/format.stderr
+++ b/tests/ui/consts/const-eval/format.stderr
@@ -15,7 +15,7 @@ LL |     println!("{:?}", 0);
    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
    = note: this error originates in the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0015]: cannot call non-const function `_print` in constant functions
+error[E0015]: cannot call non-const function `std::io::_print` in constant functions
   --> $DIR/format.rs:7:5
    |
 LL |     println!("{:?}", 0);

--- a/tests/ui/contracts/contract-captures-via-closure-noncopy.rs
+++ b/tests/ui/contracts/contract-captures-via-closure-noncopy.rs
@@ -13,7 +13,7 @@ struct Baz {
 #[core::contracts::ensures({let old = x; move |ret:&Baz| ret.baz == old.baz*2 })]
 // Relevant thing is this:  ^^^^^^^^^^^
 // because we are capturing state that is non-Copy.
-//~^^^ ERROR trait bound `Baz: std::marker::Copy` is not satisfied
+//~^^^ ERROR trait bound `Baz: Copy` is not satisfied
 fn doubler(x: Baz) -> Baz {
     Baz { baz: x.baz + 10 }
 }

--- a/tests/ui/contracts/contract-captures-via-closure-noncopy.stderr
+++ b/tests/ui/contracts/contract-captures-via-closure-noncopy.stderr
@@ -1,4 +1,4 @@
-error[E0277]: the trait bound `Baz: std::marker::Copy` is not satisfied in `{closure@$DIR/contract-captures-via-closure-noncopy.rs:13:42: 13:57}`
+error[E0277]: the trait bound `Baz: Copy` is not satisfied in `{closure@$DIR/contract-captures-via-closure-noncopy.rs:13:42: 13:57}`
   --> $DIR/contract-captures-via-closure-noncopy.rs:13:1
    |
 LL | #[core::contracts::ensures({let old = x; move |ret:&Baz| ret.baz == old.baz*2 })]
@@ -9,7 +9,7 @@ LL | #[core::contracts::ensures({let old = x; move |ret:&Baz| ret.baz == old.baz
    | unsatisfied trait bound
    | required by a bound introduced by this call
    |
-   = help: within `{closure@$DIR/contract-captures-via-closure-noncopy.rs:13:42: 13:57}`, the trait `std::marker::Copy` is not implemented for `Baz`
+   = help: within `{closure@$DIR/contract-captures-via-closure-noncopy.rs:13:42: 13:57}`, the trait `Copy` is not implemented for `Baz`
 note: required because it's used within this closure
   --> $DIR/contract-captures-via-closure-noncopy.rs:13:42
    |

--- a/tests/ui/derives/derives-span-Eq-enum-struct-variant.stderr
+++ b/tests/ui/derives/derives-span-Eq-enum-struct-variant.stderr
@@ -7,7 +7,7 @@ LL | #[derive(Eq,PartialEq)]
 LL |      x: Error
    |      ^^^^^^^^ the trait `Eq` is not implemented for `Error`
    |
-note: required by a bound in `AssertParamIsEq`
+note: required by a bound in `std::cmp::AssertParamIsEq`
   --> $SRC_DIR/core/src/cmp.rs:LL:COL
 help: consider annotating `Error` with `#[derive(Eq)]`
    |

--- a/tests/ui/derives/derives-span-Eq-enum.stderr
+++ b/tests/ui/derives/derives-span-Eq-enum.stderr
@@ -7,7 +7,7 @@ LL | #[derive(Eq,PartialEq)]
 LL |      Error
    |      ^^^^^ the trait `Eq` is not implemented for `Error`
    |
-note: required by a bound in `AssertParamIsEq`
+note: required by a bound in `std::cmp::AssertParamIsEq`
   --> $SRC_DIR/core/src/cmp.rs:LL:COL
 help: consider annotating `Error` with `#[derive(Eq)]`
    |

--- a/tests/ui/derives/derives-span-Eq-struct.stderr
+++ b/tests/ui/derives/derives-span-Eq-struct.stderr
@@ -7,7 +7,7 @@ LL | struct Struct {
 LL |     x: Error
    |     ^^^^^^^^ the trait `Eq` is not implemented for `Error`
    |
-note: required by a bound in `AssertParamIsEq`
+note: required by a bound in `std::cmp::AssertParamIsEq`
   --> $SRC_DIR/core/src/cmp.rs:LL:COL
 help: consider annotating `Error` with `#[derive(Eq)]`
    |

--- a/tests/ui/derives/derives-span-Eq-tuple-struct.stderr
+++ b/tests/ui/derives/derives-span-Eq-tuple-struct.stderr
@@ -7,7 +7,7 @@ LL | struct Struct(
 LL |     Error
    |     ^^^^^ the trait `Eq` is not implemented for `Error`
    |
-note: required by a bound in `AssertParamIsEq`
+note: required by a bound in `std::cmp::AssertParamIsEq`
   --> $SRC_DIR/core/src/cmp.rs:LL:COL
 help: consider annotating `Error` with `#[derive(Eq)]`
    |

--- a/tests/ui/deriving/issue-103157.stderr
+++ b/tests/ui/deriving/issue-103157.stderr
@@ -18,7 +18,7 @@ LL |     Float(Option<f64>),
              u16
            and 4 others
    = note: required for `Option<f64>` to implement `Eq`
-note: required by a bound in `AssertParamIsEq`
+note: required by a bound in `std::cmp::AssertParamIsEq`
   --> $SRC_DIR/core/src/cmp.rs:LL:COL
 
 error: aborting due to 1 previous error

--- a/tests/ui/issues/issue-27340.stderr
+++ b/tests/ui/issues/issue-27340.stderr
@@ -16,7 +16,7 @@ LL |
 LL | struct Bar(Foo);
    |            ^^^ the trait `Clone` is not implemented for `Foo`
    |
-note: required by a bound in `AssertParamIsClone`
+note: required by a bound in `std::clone::AssertParamIsClone`
   --> $SRC_DIR/core/src/clone.rs:LL:COL
 help: consider annotating `Foo` with `#[derive(Clone)]`
    |

--- a/tests/ui/kindck/kindck-send-object.stderr
+++ b/tests/ui/kindck/kindck-send-object.stderr
@@ -19,7 +19,7 @@ LL |     assert_send::<Box<dyn Dummy>>();
    |                   ^^^^^^^^^^^^^^ `dyn Dummy` cannot be sent between threads safely
    |
    = help: the trait `Send` is not implemented for `dyn Dummy`
-   = note: required for `Unique<dyn Dummy>` to implement `Send`
+   = note: required for `std::ptr::Unique<dyn Dummy>` to implement `Send`
 note: required because it appears within the type `Box<dyn Dummy>`
   --> $SRC_DIR/alloc/src/boxed.rs:LL:COL
 note: required by a bound in `assert_send`

--- a/tests/ui/kindck/kindck-send-object1.stderr
+++ b/tests/ui/kindck/kindck-send-object1.stderr
@@ -19,7 +19,7 @@ LL |     assert_send::<Box<dyn Dummy + 'a>>();
    |                   ^^^^^^^^^^^^^^^^^^^ `(dyn Dummy + 'a)` cannot be sent between threads safely
    |
    = help: the trait `Send` is not implemented for `(dyn Dummy + 'a)`
-   = note: required for `Unique<(dyn Dummy + 'a)>` to implement `Send`
+   = note: required for `std::ptr::Unique<(dyn Dummy + 'a)>` to implement `Send`
 note: required because it appears within the type `Box<(dyn Dummy + 'a)>`
   --> $SRC_DIR/alloc/src/boxed.rs:LL:COL
 note: required by a bound in `assert_send`

--- a/tests/ui/kindck/kindck-send-object2.stderr
+++ b/tests/ui/kindck/kindck-send-object2.stderr
@@ -19,7 +19,7 @@ LL |     assert_send::<Box<dyn Dummy>>();
    |                   ^^^^^^^^^^^^^^ `dyn Dummy` cannot be sent between threads safely
    |
    = help: the trait `Send` is not implemented for `dyn Dummy`
-   = note: required for `Unique<dyn Dummy>` to implement `Send`
+   = note: required for `std::ptr::Unique<dyn Dummy>` to implement `Send`
 note: required because it appears within the type `Box<dyn Dummy>`
   --> $SRC_DIR/alloc/src/boxed.rs:LL:COL
 note: required by a bound in `assert_send`

--- a/tests/ui/kindck/kindck-send-owned.stderr
+++ b/tests/ui/kindck/kindck-send-owned.stderr
@@ -5,7 +5,7 @@ LL |     assert_send::<Box<*mut u8>>();
    |                   ^^^^^^^^^^^^ `*mut u8` cannot be sent between threads safely
    |
    = help: the trait `Send` is not implemented for `*mut u8`
-   = note: required for `Unique<*mut u8>` to implement `Send`
+   = note: required for `std::ptr::Unique<*mut u8>` to implement `Send`
 note: required because it appears within the type `Box<*mut u8>`
   --> $SRC_DIR/alloc/src/boxed.rs:LL:COL
 note: required by a bound in `assert_send`

--- a/tests/ui/limits/type-length-limit-enforcement.stderr
+++ b/tests/ui/limits/type-length-limit-enforcement.stderr
@@ -8,9 +8,11 @@ LL |     drop::<Option<A>>(None);
    = note: the full name for the type has been written to '$TEST_BUILD_DIR/type-length-limit-enforcement.long-type-$LONG_TYPE_HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
 
-error: reached the type-length limit while instantiating `<{closure@rt::lang_start<()>::{closure#0}} as FnMut<()>>::call_mut`
+error: reached the type-length limit while instantiating `<{closure@...} as FnMut<()>>::call_mut`
    |
    = help: consider adding a `#![type_length_limit="10"]` attribute to your crate
+   = note: the full name for the type has been written to '$TEST_BUILD_DIR/type-length-limit-enforcement.long-type-$LONG_TYPE_HASH.txt'
+   = note: consider using `--verbose` to print the full type name to the console
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/proc-macro/bad-projection.stderr
+++ b/tests/ui/proc-macro/bad-projection.stderr
@@ -33,7 +33,7 @@ LL | pub fn uwu() -> <() as Project>::Assoc {}
    | takes 0 arguments
    | required by a bound introduced by this call
    |
-note: required by a bound in `ProcMacro::bang`
+note: required by a bound in `proc_macro::bridge::client::ProcMacro::bang`
   --> $SRC_DIR/proc_macro/src/bridge/client.rs:LL:COL
 
 error[E0277]: the trait bound `(): Project` is not satisfied

--- a/tests/ui/proc-macro/proc-macro-abi.stderr
+++ b/tests/ui/proc-macro/proc-macro-abi.stderr
@@ -4,8 +4,8 @@ error: function-like proc macro has incorrect signature
 LL | pub extern "C" fn abi(a: TokenStream) -> TokenStream {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected "Rust" fn, found "C" fn
    |
-   = note: expected signature `fn(proc_macro::TokenStream) -> proc_macro::TokenStream`
-              found signature `extern "C" fn(proc_macro::TokenStream) -> proc_macro::TokenStream`
+   = note: expected signature `fn(TokenStream) -> TokenStream`
+              found signature `extern "C" fn(TokenStream) -> TokenStream`
 
 error: function-like proc macro has incorrect signature
   --> $DIR/proc-macro-abi.rs:17:1
@@ -13,8 +13,8 @@ error: function-like proc macro has incorrect signature
 LL | pub extern "system" fn abi2(a: TokenStream) -> TokenStream {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected "Rust" fn, found "system" fn
    |
-   = note: expected signature `fn(proc_macro::TokenStream) -> proc_macro::TokenStream`
-              found signature `extern "system" fn(proc_macro::TokenStream) -> proc_macro::TokenStream`
+   = note: expected signature `fn(TokenStream) -> TokenStream`
+              found signature `extern "system" fn(TokenStream) -> TokenStream`
 
 error: function-like proc macro has incorrect signature
   --> $DIR/proc-macro-abi.rs:23:1
@@ -22,8 +22,8 @@ error: function-like proc macro has incorrect signature
 LL | pub extern fn abi3(a: TokenStream) -> TokenStream {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected "Rust" fn, found "C" fn
    |
-   = note: expected signature `fn(proc_macro::TokenStream) -> proc_macro::TokenStream`
-              found signature `extern "C" fn(proc_macro::TokenStream) -> proc_macro::TokenStream`
+   = note: expected signature `fn(TokenStream) -> TokenStream`
+              found signature `extern "C" fn(TokenStream) -> TokenStream`
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/proc-macro/quote/does-not-have-iter-interpolated-dup.stderr
+++ b/tests/ui/proc-macro/quote/does-not-have-iter-interpolated-dup.stderr
@@ -5,7 +5,7 @@ LL |     quote!($($nonrep $nonrep)*);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |     |
    |     expected `HasIterator`, found `ThereIsNoIteratorInRepetition`
-   |     here the type of `has_iter` is inferred to be `ThereIsNoIteratorInRepetition`
+   |     here the type of `has_iter` is inferred to be `proc_macro::ThereIsNoIteratorInRepetition`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/proc-macro/quote/does-not-have-iter-interpolated.stderr
+++ b/tests/ui/proc-macro/quote/does-not-have-iter-interpolated.stderr
@@ -5,7 +5,7 @@ LL |     quote!($($nonrep)*);
    |     ^^^^^^^^^^^^^^^^^^^
    |     |
    |     expected `HasIterator`, found `ThereIsNoIteratorInRepetition`
-   |     here the type of `has_iter` is inferred to be `ThereIsNoIteratorInRepetition`
+   |     here the type of `has_iter` is inferred to be `proc_macro::ThereIsNoIteratorInRepetition`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/proc-macro/quote/not-quotable.stderr
+++ b/tests/ui/proc-macro/quote/not-quotable.stderr
@@ -11,11 +11,11 @@ LL |     let _ = quote! { $ip };
              &T
              &mut T
              Box<T>
+             CStr
              CString
              Cow<'_, T>
              Option<T>
              Rc<T>
-             bool
            and 24 others
 
 error: aborting due to 1 previous error

--- a/tests/ui/proc-macro/signature-proc-macro-attribute.stderr
+++ b/tests/ui/proc-macro/signature-proc-macro-attribute.stderr
@@ -4,8 +4,8 @@ error: attribute proc macro has incorrect signature
 LL | pub fn bad_input(input: String) -> TokenStream {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ incorrect number of function parameters
    |
-   = note: expected signature `fn(proc_macro::TokenStream, proc_macro::TokenStream) -> proc_macro::TokenStream`
-              found signature `fn(std::string::String) -> proc_macro::TokenStream`
+   = note: expected signature `fn(TokenStream, TokenStream) -> TokenStream`
+              found signature `fn(String) -> TokenStream`
 
 error: attribute proc macro has incorrect signature
   --> $DIR/signature-proc-macro-attribute.rs:16:1
@@ -13,8 +13,8 @@ error: attribute proc macro has incorrect signature
 LL | pub fn bad_output(input: TokenStream) -> String {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ incorrect number of function parameters
    |
-   = note: expected signature `fn(proc_macro::TokenStream, proc_macro::TokenStream) -> proc_macro::TokenStream`
-              found signature `fn(proc_macro::TokenStream) -> std::string::String`
+   = note: expected signature `fn(TokenStream, TokenStream) -> TokenStream`
+              found signature `fn(TokenStream) -> String`
 
 error: attribute proc macro has incorrect signature
   --> $DIR/signature-proc-macro-attribute.rs:22:1
@@ -22,8 +22,8 @@ error: attribute proc macro has incorrect signature
 LL | pub fn bad_everything(input: String) -> String {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ incorrect number of function parameters
    |
-   = note: expected signature `fn(proc_macro::TokenStream, proc_macro::TokenStream) -> proc_macro::TokenStream`
-              found signature `fn(std::string::String) -> std::string::String`
+   = note: expected signature `fn(TokenStream, TokenStream) -> TokenStream`
+              found signature `fn(String) -> String`
 
 error: attribute proc macro has incorrect signature
   --> $DIR/signature-proc-macro-attribute.rs:28:52
@@ -31,8 +31,8 @@ error: attribute proc macro has incorrect signature
 LL | pub fn too_many(a: TokenStream, b: TokenStream, c: String) -> TokenStream {
    |                                                    ^^^^^^ incorrect number of function parameters
    |
-   = note: expected signature `fn(proc_macro::TokenStream, proc_macro::TokenStream) -> proc_macro::TokenStream`
-              found signature `fn(proc_macro::TokenStream, proc_macro::TokenStream, std::string::String) -> proc_macro::TokenStream`
+   = note: expected signature `fn(TokenStream, TokenStream) -> TokenStream`
+              found signature `fn(TokenStream, TokenStream, String) -> TokenStream`
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/proc-macro/signature-proc-macro-derive.stderr
+++ b/tests/ui/proc-macro/signature-proc-macro-derive.stderr
@@ -2,28 +2,28 @@ error: derive proc macro has incorrect signature
   --> $DIR/signature-proc-macro-derive.rs:10:25
    |
 LL | pub fn bad_input(input: String) -> TokenStream {
-   |                         ^^^^^^ expected `proc_macro::TokenStream`, found `std::string::String`
+   |                         ^^^^^^ expected `TokenStream`, found `String`
    |
-   = note: expected signature `fn(proc_macro::TokenStream) -> proc_macro::TokenStream`
-              found signature `fn(std::string::String) -> proc_macro::TokenStream`
+   = note: expected signature `fn(TokenStream) -> TokenStream`
+              found signature `fn(String) -> TokenStream`
 
 error: derive proc macro has incorrect signature
   --> $DIR/signature-proc-macro-derive.rs:16:42
    |
 LL | pub fn bad_output(input: TokenStream) -> String {
-   |                                          ^^^^^^ expected `proc_macro::TokenStream`, found `std::string::String`
+   |                                          ^^^^^^ expected `TokenStream`, found `String`
    |
-   = note: expected signature `fn(proc_macro::TokenStream) -> proc_macro::TokenStream`
-              found signature `fn(proc_macro::TokenStream) -> std::string::String`
+   = note: expected signature `fn(TokenStream) -> TokenStream`
+              found signature `fn(TokenStream) -> String`
 
 error: derive proc macro has incorrect signature
   --> $DIR/signature-proc-macro-derive.rs:22:30
    |
 LL | pub fn bad_everything(input: String) -> String {
-   |                              ^^^^^^ expected `proc_macro::TokenStream`, found `std::string::String`
+   |                              ^^^^^^ expected `TokenStream`, found `String`
    |
-   = note: expected signature `fn(proc_macro::TokenStream) -> proc_macro::TokenStream`
-              found signature `fn(std::string::String) -> std::string::String`
+   = note: expected signature `fn(TokenStream) -> TokenStream`
+              found signature `fn(String) -> String`
 
 error: derive proc macro has incorrect signature
   --> $DIR/signature-proc-macro-derive.rs:28:36
@@ -31,8 +31,8 @@ error: derive proc macro has incorrect signature
 LL | pub fn too_many(a: TokenStream, b: TokenStream, c: String) -> TokenStream {
    |                                    ^^^^^^^^^^^ incorrect number of function parameters
    |
-   = note: expected signature `fn(proc_macro::TokenStream) -> proc_macro::TokenStream`
-              found signature `fn(proc_macro::TokenStream, proc_macro::TokenStream, std::string::String) -> proc_macro::TokenStream`
+   = note: expected signature `fn(TokenStream) -> TokenStream`
+              found signature `fn(TokenStream, TokenStream, String) -> TokenStream`
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/proc-macro/signature-proc-macro.stderr
+++ b/tests/ui/proc-macro/signature-proc-macro.stderr
@@ -2,28 +2,28 @@ error: function-like proc macro has incorrect signature
   --> $DIR/signature-proc-macro.rs:10:25
    |
 LL | pub fn bad_input(input: String) -> TokenStream {
-   |                         ^^^^^^ expected `proc_macro::TokenStream`, found `std::string::String`
+   |                         ^^^^^^ expected `TokenStream`, found `String`
    |
-   = note: expected signature `fn(proc_macro::TokenStream) -> proc_macro::TokenStream`
-              found signature `fn(std::string::String) -> proc_macro::TokenStream`
+   = note: expected signature `fn(TokenStream) -> TokenStream`
+              found signature `fn(String) -> TokenStream`
 
 error: function-like proc macro has incorrect signature
   --> $DIR/signature-proc-macro.rs:16:42
    |
 LL | pub fn bad_output(input: TokenStream) -> String {
-   |                                          ^^^^^^ expected `proc_macro::TokenStream`, found `std::string::String`
+   |                                          ^^^^^^ expected `TokenStream`, found `String`
    |
-   = note: expected signature `fn(proc_macro::TokenStream) -> proc_macro::TokenStream`
-              found signature `fn(proc_macro::TokenStream) -> std::string::String`
+   = note: expected signature `fn(TokenStream) -> TokenStream`
+              found signature `fn(TokenStream) -> String`
 
 error: function-like proc macro has incorrect signature
   --> $DIR/signature-proc-macro.rs:22:30
    |
 LL | pub fn bad_everything(input: String) -> String {
-   |                              ^^^^^^ expected `proc_macro::TokenStream`, found `std::string::String`
+   |                              ^^^^^^ expected `TokenStream`, found `String`
    |
-   = note: expected signature `fn(proc_macro::TokenStream) -> proc_macro::TokenStream`
-              found signature `fn(std::string::String) -> std::string::String`
+   = note: expected signature `fn(TokenStream) -> TokenStream`
+              found signature `fn(String) -> String`
 
 error: function-like proc macro has incorrect signature
   --> $DIR/signature-proc-macro.rs:28:36
@@ -31,8 +31,8 @@ error: function-like proc macro has incorrect signature
 LL | pub fn too_many(a: TokenStream, b: TokenStream, c: String) -> TokenStream {
    |                                    ^^^^^^^^^^^ incorrect number of function parameters
    |
-   = note: expected signature `fn(proc_macro::TokenStream) -> proc_macro::TokenStream`
-              found signature `fn(proc_macro::TokenStream, proc_macro::TokenStream, std::string::String) -> proc_macro::TokenStream`
+   = note: expected signature `fn(TokenStream) -> TokenStream`
+              found signature `fn(TokenStream, TokenStream, String) -> TokenStream`
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/proc-macro/signature.stderr
+++ b/tests/ui/proc-macro/signature.stderr
@@ -4,7 +4,7 @@ error: derive proc macro has incorrect signature
 LL | pub unsafe extern "C" fn foo(a: i32, b: u32) -> u32 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected safe fn, found unsafe fn
    |
-   = note: expected signature `fn(proc_macro::TokenStream) -> proc_macro::TokenStream`
+   = note: expected signature `fn(TokenStream) -> TokenStream`
               found signature `unsafe extern "C" fn(i32, u32) -> u32`
 
 error: aborting due to 1 previous error

--- a/tests/ui/static/global-variable-promotion-error-7364.stderr
+++ b/tests/ui/static/global-variable-promotion-error-7364.stderr
@@ -6,7 +6,7 @@ LL | static boxed: Box<RefCell<isize>> = Box::new(RefCell::new(0));
    |
    = help: the trait `Sync` is not implemented for `RefCell<isize>`
    = note: if you want to do aliasing and mutation between multiple threads, use `std::sync::RwLock` instead
-   = note: required for `Unique<RefCell<isize>>` to implement `Sync`
+   = note: required for `std::ptr::Unique<RefCell<isize>>` to implement `Sync`
 note: required because it appears within the type `Box<RefCell<isize>>`
   --> $SRC_DIR/alloc/src/boxed.rs:LL:COL
    = note: shared static variables must have a type that implements `Sync`

--- a/tests/ui/traits/const-traits/issue-79450.rs
+++ b/tests/ui/traits/const-traits/issue-79450.rs
@@ -5,7 +5,7 @@ const trait Tr {
     fn req(&self);
 
     fn prov(&self) {
-        println!("lul"); //~ ERROR: cannot call non-const function `_print` in constant functions
+        println!("lul"); //~ ERROR: cannot call non-const function `std::io::_print` in constant functions
         self.req();
     }
 }

--- a/tests/ui/traits/const-traits/issue-79450.stderr
+++ b/tests/ui/traits/const-traits/issue-79450.stderr
@@ -1,4 +1,4 @@
-error[E0015]: cannot call non-const function `_print` in constant functions
+error[E0015]: cannot call non-const function `std::io::_print` in constant functions
   --> $DIR/issue-79450.rs:8:9
    |
 LL |         println!("lul");

--- a/tests/ui/traits/cycle-cache-err-60010.stderr
+++ b/tests/ui/traits/cycle-cache-err-60010.stderr
@@ -6,7 +6,7 @@ LL |     _parse: <ParseQuery as Query<RootDatabase>>::Data,
    |
 note: required because it appears within the type `PhantomData<SalsaStorage>`
   --> $SRC_DIR/core/src/marker.rs:LL:COL
-note: required because it appears within the type `Unique<SalsaStorage>`
+note: required because it appears within the type `std::ptr::Unique<SalsaStorage>`
   --> $SRC_DIR/core/src/ptr/unique.rs:LL:COL
 note: required because it appears within the type `Box<SalsaStorage>`
   --> $SRC_DIR/alloc/src/boxed.rs:LL:COL
@@ -45,7 +45,7 @@ LL |     type Storage = SalsaStorage;
    |
 note: required because it appears within the type `PhantomData<SalsaStorage>`
   --> $SRC_DIR/core/src/marker.rs:LL:COL
-note: required because it appears within the type `Unique<SalsaStorage>`
+note: required because it appears within the type `std::ptr::Unique<SalsaStorage>`
   --> $SRC_DIR/core/src/ptr/unique.rs:LL:COL
 note: required because it appears within the type `Box<SalsaStorage>`
   --> $SRC_DIR/alloc/src/boxed.rs:LL:COL

--- a/tests/ui/traits/negative-impls/negated-auto-traits-error.stderr
+++ b/tests/ui/traits/negative-impls/negated-auto-traits-error.stderr
@@ -77,12 +77,12 @@ error[E0277]: `dummy2::TestType` cannot be sent between threads safely
   --> $DIR/negated-auto-traits-error.rs:48:13
    |
 LL |     is_send(Box::new(TestType));
-   |     ------- ^^^^^^^^^^^^^^^^^^ the trait `Send` is not implemented for `Unique<dummy2::TestType>`
+   |     ------- ^^^^^^^^^^^^^^^^^^ the trait `Send` is not implemented for `std::ptr::Unique<dummy2::TestType>`
    |     |
    |     required by a bound introduced by this call
    |
-   = note: the trait bound `Unique<dummy2::TestType>: Send` is not satisfied
-   = note: required for `Unique<dummy2::TestType>` to implement `Send`
+   = note: the trait bound `std::ptr::Unique<dummy2::TestType>: Send` is not satisfied
+   = note: required for `std::ptr::Unique<dummy2::TestType>` to implement `Send`
 note: required because it appears within the type `Box<dummy2::TestType>`
   --> $SRC_DIR/alloc/src/boxed.rs:LL:COL
 note: required by a bound in `is_send`
@@ -113,7 +113,7 @@ note: required because it appears within the type `Outer2<dummy3::TestType>`
    |
 LL | struct Outer2<T>(T);
    |        ^^^^^^
-   = note: required for `Unique<Outer2<dummy3::TestType>>` to implement `Send`
+   = note: required for `std::ptr::Unique<Outer2<dummy3::TestType>>` to implement `Send`
 note: required because it appears within the type `Box<Outer2<dummy3::TestType>>`
   --> $SRC_DIR/alloc/src/boxed.rs:LL:COL
 note: required by a bound in `is_send`

--- a/tests/ui/trimmed-paths/auxiliary/doc_hidden_helper.rs
+++ b/tests/ui/trimmed-paths/auxiliary/doc_hidden_helper.rs
@@ -1,0 +1,18 @@
+//@ edition: 2024
+
+pub struct ActuallyPub {}
+#[doc(hidden)]
+pub struct DocHidden {}
+
+pub mod pub_mod {
+    pub struct ActuallyPubInPubMod {}
+    #[doc(hidden)]
+    pub struct DocHiddenInPubMod {}
+}
+
+#[doc(hidden)]
+pub mod hidden_mod {
+    pub struct ActuallyPubInHiddenMod {}
+    #[doc(hidden)]
+    pub struct DocHiddenInHiddenMod {}
+}

--- a/tests/ui/trimmed-paths/core-unicode.rs
+++ b/tests/ui/trimmed-paths/core-unicode.rs
@@ -14,6 +14,6 @@ fn main() {
     let PhantomData::<(inner::unicode, u32)> = PhantomData::<(u32, inner::unicode)>;
     //~^ ERROR mismatched types [E0308]
     //~| NOTE expected `PhantomData<(u32, unicode)>`, found `PhantomData<(unicode, u32)>`
-    //~| NOTE this expression has type `PhantomData<(u32, inner::unicode)>`
-    //~| NOTE expected struct `PhantomData<(u32, inner::unicode)>`
+    //~| NOTE this expression has type `PhantomData<(u32, unicode)>`
+    //~| NOTE expected struct `PhantomData<(u32, unicode)>`
 }

--- a/tests/ui/trimmed-paths/core-unicode.rs
+++ b/tests/ui/trimmed-paths/core-unicode.rs
@@ -1,0 +1,19 @@
+//@ edition: 2024
+
+// Test that the `#[doc(hidden)]` module `core::unicode` module does not
+// disqualify another item named `unicode` from path trimming in diagnostics.
+
+use core::marker::PhantomData;
+
+mod inner {
+    #[expect(non_camel_case_types)]
+    pub(crate) enum unicode {}
+}
+
+fn main() {
+    let PhantomData::<(inner::unicode, u32)> = PhantomData::<(u32, inner::unicode)>;
+    //~^ ERROR mismatched types [E0308]
+    //~| NOTE expected `PhantomData<(u32, unicode)>`, found `PhantomData<(unicode, u32)>`
+    //~| NOTE this expression has type `PhantomData<(u32, inner::unicode)>`
+    //~| NOTE expected struct `PhantomData<(u32, inner::unicode)>`
+}

--- a/tests/ui/trimmed-paths/core-unicode.stderr
+++ b/tests/ui/trimmed-paths/core-unicode.stderr
@@ -2,12 +2,12 @@ error[E0308]: mismatched types
   --> $DIR/core-unicode.rs:14:9
    |
 LL |     let PhantomData::<(inner::unicode, u32)> = PhantomData::<(u32, inner::unicode)>;
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   ------------------------------------ this expression has type `PhantomData<(u32, inner::unicode)>`
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   ------------------------------------ this expression has type `PhantomData<(u32, unicode)>`
    |         |
    |         expected `PhantomData<(u32, unicode)>`, found `PhantomData<(unicode, u32)>`
    |
-   = note: expected struct `PhantomData<(u32, inner::unicode)>`
-              found struct `PhantomData<(inner::unicode, u32)>`
+   = note: expected struct `PhantomData<(u32, unicode)>`
+              found struct `PhantomData<(unicode, u32)>`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/trimmed-paths/core-unicode.stderr
+++ b/tests/ui/trimmed-paths/core-unicode.stderr
@@ -1,0 +1,14 @@
+error[E0308]: mismatched types
+  --> $DIR/core-unicode.rs:14:9
+   |
+LL |     let PhantomData::<(inner::unicode, u32)> = PhantomData::<(u32, inner::unicode)>;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   ------------------------------------ this expression has type `PhantomData<(u32, inner::unicode)>`
+   |         |
+   |         expected `PhantomData<(u32, unicode)>`, found `PhantomData<(unicode, u32)>`
+   |
+   = note: expected struct `PhantomData<(u32, inner::unicode)>`
+              found struct `PhantomData<(inner::unicode, u32)>`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/trimmed-paths/doc-hidden.rs
+++ b/tests/ui/trimmed-paths/doc-hidden.rs
@@ -45,7 +45,7 @@ fn uses_local() {
     ) = 3u32;
     //~^ ERROR mismatched types [E0308]
     //~| NOTE expected `(ActuallyPub, ..., ..., ..., ..., ...)`, found `u32`
-    //~| NOTE expected tuple `(local::ActuallyPub, local::DocHidden, local::pub_mod::ActuallyPubInPubMod, local::pub_mod::DocHiddenInPubMod, local::hidden_mod::ActuallyPubInHiddenMod, local::hidden_mod::DocHiddenInHiddenMod)`
+    //~| NOTE expected tuple `(local::ActuallyPub, DocHidden, local::pub_mod::ActuallyPubInPubMod, DocHiddenInPubMod, ActuallyPubInHiddenMod, DocHiddenInHiddenMod)`
 }
 
 fn uses_helper() {

--- a/tests/ui/trimmed-paths/doc-hidden.rs
+++ b/tests/ui/trimmed-paths/doc-hidden.rs
@@ -1,0 +1,68 @@
+//@ edition: 2024
+//@ aux-crate: helper=doc_hidden_helper.rs
+
+// Test that `#[doc(hidden)]` items in other crates do not disqualify another
+// item with the same name from path trimming in diagnostics.
+
+// Declare several modules and types whose short names match those in the aux crate.
+//
+// Of these, only `ActuallyPub` and `ActuallyPubInPubMod` should be disqualified
+// from path trimming, because the other names only collide with `#[doc(hidden)]`
+// names.
+mod local {
+    pub(crate) struct ActuallyPub {}
+    pub(crate) struct DocHidden {}
+
+    pub(crate) mod pub_mod {
+        pub(crate) struct ActuallyPubInPubMod {}
+        pub(crate) struct DocHiddenInPubMod {}
+    }
+
+    pub(crate) mod hidden_mod {
+        pub(crate) struct ActuallyPubInHiddenMod {}
+        pub(crate) struct DocHiddenInHiddenMod {}
+    }
+}
+
+fn main() {
+    uses_local();
+    uses_helper();
+}
+
+fn uses_local() {
+    use local::{ActuallyPub, DocHidden};
+    use local::pub_mod::{ActuallyPubInPubMod, DocHiddenInPubMod};
+    use local::hidden_mod::{ActuallyPubInHiddenMod, DocHiddenInHiddenMod};
+
+    let _: (
+        //~^ NOTE expected due to this
+        ActuallyPub,
+        DocHidden,
+        ActuallyPubInPubMod,
+        DocHiddenInPubMod,
+        ActuallyPubInHiddenMod,
+        DocHiddenInHiddenMod,
+    ) = 3u32;
+    //~^ ERROR mismatched types [E0308]
+    //~| NOTE expected `(ActuallyPub, ..., ..., ..., ..., ...)`, found `u32`
+    //~| NOTE expected tuple `(local::ActuallyPub, local::DocHidden, local::pub_mod::ActuallyPubInPubMod, local::pub_mod::DocHiddenInPubMod, local::hidden_mod::ActuallyPubInHiddenMod, local::hidden_mod::DocHiddenInHiddenMod)`
+}
+
+fn uses_helper() {
+    use helper::{ActuallyPub, DocHidden};
+    use helper::pub_mod::{ActuallyPubInPubMod, DocHiddenInPubMod};
+    use helper::hidden_mod::{ActuallyPubInHiddenMod, DocHiddenInHiddenMod};
+
+    let _: (
+        //~^ NOTE expected due to this
+        ActuallyPub,
+        DocHidden,
+        ActuallyPubInPubMod,
+        DocHiddenInPubMod,
+        ActuallyPubInHiddenMod,
+        DocHiddenInHiddenMod,
+    ) = 3u32;
+    //~^ ERROR mismatched types [E0308]
+    //~| NOTE expected `(ActuallyPub, ..., ..., ..., ..., ...)`, found `u32`
+    //~| NOTE expected tuple `(doc_hidden_helper::ActuallyPub, doc_hidden_helper::DocHidden, doc_hidden_helper::pub_mod::ActuallyPubInPubMod, doc_hidden_helper::pub_mod::DocHiddenInPubMod, doc_hidden_helper::hidden_mod::ActuallyPubInHiddenMod, doc_hidden_helper::hidden_mod::DocHiddenInHiddenMod)`
+}

--- a/tests/ui/trimmed-paths/doc-hidden.stderr
+++ b/tests/ui/trimmed-paths/doc-hidden.stderr
@@ -13,7 +13,7 @@ LL | |     ) = 3u32;
    | |_____|
    |       expected due to this
    |
-   = note: expected tuple `(local::ActuallyPub, local::DocHidden, local::pub_mod::ActuallyPubInPubMod, local::pub_mod::DocHiddenInPubMod, local::hidden_mod::ActuallyPubInHiddenMod, local::hidden_mod::DocHiddenInHiddenMod)`
+   = note: expected tuple `(local::ActuallyPub, DocHidden, local::pub_mod::ActuallyPubInPubMod, DocHiddenInPubMod, ActuallyPubInHiddenMod, DocHiddenInHiddenMod)`
                found type `u32`
 
 error[E0308]: mismatched types

--- a/tests/ui/trimmed-paths/doc-hidden.stderr
+++ b/tests/ui/trimmed-paths/doc-hidden.stderr
@@ -1,0 +1,39 @@
+error[E0308]: mismatched types
+  --> $DIR/doc-hidden.rs:45:9
+   |
+LL |       let _: (
+   |  ____________-
+LL | |
+LL | |         ActuallyPub,
+LL | |         DocHidden,
+...  |
+LL | |         DocHiddenInHiddenMod,
+LL | |     ) = 3u32;
+   | |     -   ^^^^ expected `(ActuallyPub, ..., ..., ..., ..., ...)`, found `u32`
+   | |_____|
+   |       expected due to this
+   |
+   = note: expected tuple `(local::ActuallyPub, local::DocHidden, local::pub_mod::ActuallyPubInPubMod, local::pub_mod::DocHiddenInPubMod, local::hidden_mod::ActuallyPubInHiddenMod, local::hidden_mod::DocHiddenInHiddenMod)`
+               found type `u32`
+
+error[E0308]: mismatched types
+  --> $DIR/doc-hidden.rs:64:9
+   |
+LL |       let _: (
+   |  ____________-
+LL | |
+LL | |         ActuallyPub,
+LL | |         DocHidden,
+...  |
+LL | |         DocHiddenInHiddenMod,
+LL | |     ) = 3u32;
+   | |     -   ^^^^ expected `(ActuallyPub, ..., ..., ..., ..., ...)`, found `u32`
+   | |_____|
+   |       expected due to this
+   |
+   = note: expected tuple `(doc_hidden_helper::ActuallyPub, doc_hidden_helper::DocHidden, doc_hidden_helper::pub_mod::ActuallyPubInPubMod, doc_hidden_helper::pub_mod::DocHiddenInPubMod, doc_hidden_helper::hidden_mod::ActuallyPubInHiddenMod, doc_hidden_helper::hidden_mod::DocHiddenInHiddenMod)`
+               found type `u32`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/type-inference/panic-with-unspecified-type.stderr
+++ b/tests/ui/type-inference/panic-with-unspecified-type.stderr
@@ -8,7 +8,7 @@ LL |     panic!(std::default::Default::default());
    |     required by a bound introduced by this call
    |
    = note: cannot satisfy `_: Any`
-note: required by a bound in `begin_panic`
+note: required by a bound in `std::rt::begin_panic`
   --> $SRC_DIR/std/src/panicking.rs:LL:COL
 
 error: aborting due to 1 previous error

--- a/tests/ui/type/pattern_types/derives_fail.stderr
+++ b/tests/ui/type/pattern_types/derives_fail.stderr
@@ -16,7 +16,7 @@ LL | #[repr(transparent)]
 LL | struct Nanoseconds(NanoI32);
    |                    ^^^^^^^ the trait `Eq` is not implemented for `(i32) is 0..=999999999`
    |
-note: required by a bound in `AssertParamIsEq`
+note: required by a bound in `std::cmp::AssertParamIsEq`
   --> $SRC_DIR/core/src/cmp.rs:LL:COL
 
 error[E0277]: `(i32) is 0..=999999999` doesn't implement `Debug`

--- a/tests/ui/union/union-derive-clone.stderr
+++ b/tests/ui/union/union-derive-clone.stderr
@@ -4,7 +4,7 @@ error[E0277]: the trait bound `U1: Copy` is not satisfied
 LL | #[derive(Clone)]
    |          ^^^^^ the trait `Copy` is not implemented for `U1`
    |
-note: required by a bound in `AssertParamIsCopy`
+note: required by a bound in `std::clone::AssertParamIsCopy`
   --> $SRC_DIR/core/src/clone.rs:LL:COL
 help: consider annotating `U1` with `#[derive(Copy)]`
    |

--- a/tests/ui/union/union-derive-eq.current.stderr
+++ b/tests/ui/union/union-derive-eq.current.stderr
@@ -7,7 +7,7 @@ LL | union U2 {
 LL |     a: PartialEqNotEq,
    |     ^^^^^^^^^^^^^^^^^ the trait `Eq` is not implemented for `PartialEqNotEq`
    |
-note: required by a bound in `AssertParamIsEq`
+note: required by a bound in `std::cmp::AssertParamIsEq`
   --> $SRC_DIR/core/src/cmp.rs:LL:COL
 help: consider annotating `PartialEqNotEq` with `#[derive(Eq)]`
    |

--- a/tests/ui/union/union-derive-eq.next.stderr
+++ b/tests/ui/union/union-derive-eq.next.stderr
@@ -7,7 +7,7 @@ LL | union U2 {
 LL |     a: PartialEqNotEq,
    |     ^^^^^^^^^^^^^^^^^ the trait `Eq` is not implemented for `PartialEqNotEq`
    |
-note: required by a bound in `AssertParamIsEq`
+note: required by a bound in `std::cmp::AssertParamIsEq`
   --> $SRC_DIR/core/src/cmp.rs:LL:COL
 help: consider annotating `PartialEqNotEq` with `#[derive(Eq)]`
    |


### PR DESCRIPTION
The `trimmed_def_paths` query examines all items in the current crate, and all pub items in immediate-dependency crates (including the standard library), to see which item names are unique and can therefore be printed unambiguously as a bare name without a module path.

Currently that query has no special handling for `#[doc(hidden)]` items, which has two consequences:
- Hidden names can be considered unique, and will therefore be printed without a path, making it hard to find where that name is defined (since it normally isn't listed in documentation).
- Hidden names can conflict with visible names that would otherwise be considered unique, causing diagnostics to mysteriously become more verbose based on internal details of other crates.

This PR therefore makes the `trimmed_def_paths` query ignore external-crate items that are `#[doc(hidden)]`, along with their descendants.

As a result, hidden item names are never considered unique for trimming, and no longer interfere with visible item names being considered unique.

---
- Fixes https://github.com/rust-lang/rust/issues/148387.