### PR TITLE
bootstrap: respect `build.python` on macOS

### DIFF
--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -2075,7 +2075,9 @@ Please disable assertions with `rust.debug-assertions = false`.
             cmd.arg("--target-rustcflags").arg(flag);
         }
 
-        cmd.arg("--python").arg(builder.python());
+        cmd.arg("--python").arg(
+            builder.config.python.as_ref().expect("python is required for running rustdoc tests"),
+        );
 
         // FIXME(#148099): Currently we set these Android-related flags in all
         // modes, even though they should only be needed in "debuginfo" mode,
@@ -3359,7 +3361,9 @@ impl Step for BootstrapPy {
     }
 
     fn run(self, builder: &Builder<'_>) -> Self::Output {
-        let mut check_bootstrap = command(builder.python());
+        let mut check_bootstrap = command(
+            builder.config.python.as_ref().expect("python is required for running bootstrap tests"),
+        );
         check_bootstrap
             .args(["-m", "unittest", "bootstrap_test.py"])
             // Forward command-line args after `--` to unittest, for filtering etc.

--- a/src/bootstrap/src/core/sanity.rs
+++ b/src/bootstrap/src/core/sanity.rs
@@ -1,9 +1,10 @@
-//! Sanity checking performed by bootstrap before actually executing anything.
+//! Sanity checking and tool selection performed by bootstrap.
 //!
-//! This module contains the implementation of ensuring that the build
-//! environment looks reasonable before progressing. This will verify that
-//! various programs like git and python exist, along with ensuring that all C
-//! compilers for cross-compiling are found.
+//! This module ensures that the build environment is correctly set up before
+//! executing any build tasks. It verifies required programs exist (like git and
+//! cmake when needed), selects some tools based on the environment (like the
+//! Python interpreter), and validates that C compilers for cross-compiling are
+//! available.
 //!
 //! In theory if we get past this phase it's a bug if a build fails, but in
 //! practice that's likely not true!

--- a/src/bootstrap/src/lib.rs
+++ b/src/bootstrap/src/lib.rs
@@ -1522,21 +1522,6 @@ impl Build {
         self.config.target_config.get(&target).and_then(|t| t.qemu_rootfs.as_ref()).map(|p| &**p)
     }
 
-    /// Path to the python interpreter to use
-    fn python(&self) -> &Path {
-        if self.config.host_target.ends_with("apple-darwin") {
-            // Force /usr/bin/python3 on macOS for LLDB tests because we're loading the
-            // LLDB plugin's compiled module which only works with the system python
-            // (namely not Homebrew-installed python)
-            Path::new("/usr/bin/python3")
-        } else {
-            self.config
-                .python
-                .as_ref()
-                .expect("python is required for running LLDB or rustdoc tests")
-        }
-    }
-
     /// Temporary directory that extended error information is emitted to.
     fn extended_error_dir(&self) -> PathBuf {
         self.out.join("tmp/extended-error-metadata")

--- a/src/bootstrap/src/utils/change_tracker.rs
+++ b/src/bootstrap/src/utils/change_tracker.rs
@@ -576,4 +576,9 @@ pub const CONFIG_CHANGE_HISTORY: &[ChangeInfo] = &[
         severity: ChangeSeverity::Info,
         summary: "`llvm.enzyme` now works with `download-ci-llvm=true`.",
     },
+    ChangeInfo {
+        change_id: 148636,
+        severity: ChangeSeverity::Info,
+        summary: "The `build.python` option is now respected on macOS (previously ignored).",
+    },
 ];

--- a/src/bootstrap/src/utils/change_tracker.rs
+++ b/src/bootstrap/src/utils/change_tracker.rs
@@ -579,6 +579,6 @@ pub const CONFIG_CHANGE_HISTORY: &[ChangeInfo] = &[
     ChangeInfo {
         change_id: 148636,
         severity: ChangeSeverity::Info,
-        summary: "The `build.python` option is now respected on macOS (previously ignored).",
+        summary: "The `build.python` option is now respected on macOS (previously ignored and forced to be /usr/bin/python3).",
     },
 ];


### PR DESCRIPTION
The `python()` method was hardcoded to return `/usr/bin/python3` on macOS, ignoring the `build.python` config option. This change respects the config while maintaining the system Python as the default.