### PR TITLE
Fix ICE for repr simd on non struct

### DIFF
--- a/compiler/rustc_hir_typeck/src/inline_asm.rs
+++ b/compiler/rustc_hir_typeck/src/inline_asm.rs
@@ -93,6 +93,14 @@ impl<'a, 'tcx> InlineAsmCtxt<'a, 'tcx> {
                 }
             }
             ty::Adt(adt, args) if adt.repr().simd() => {
+                if !adt.is_struct() {
+                    self.fcx.dcx().span_delayed_bug(
+                        span,
+                        format!("repr(simd) should only be used on structs, got {}", adt.descr()),
+                    );
+                    return Err(NonAsmTypeReason::Invalid(ty));
+                }
+
                 let fields = &adt.non_enum_variant().fields;
                 if fields.is_empty() {
                     return Err(NonAsmTypeReason::EmptySIMDArray(ty));

--- a/tests/ui/asm/invalid-repr-simd-on-enum-148634.rs
+++ b/tests/ui/asm/invalid-repr-simd-on-enum-148634.rs
@@ -1,3 +1,4 @@
+//@ needs-asm-support
 #![feature(repr_simd)]
 
 use std::arch::asm;
@@ -11,6 +12,5 @@ fn main() {
     unsafe {
         let mut x: Es;
         asm!("{}", out(reg) x);
-        //~^ ERROR cannot use value of type `Es` for inline assembly
     }
 }

--- a/tests/ui/asm/invalid-repr-simd-on-enum-148634.rs
+++ b/tests/ui/asm/invalid-repr-simd-on-enum-148634.rs
@@ -1,0 +1,16 @@
+#![feature(repr_simd)]
+
+use std::arch::asm;
+
+#[repr(simd)]
+//~^ ERROR attribute should be applied to a struct
+//~| ERROR unsupported representation for zero-variant enum
+enum Es {}
+
+fn main() {
+    unsafe {
+        let mut x: Es;
+        asm!("{}", out(reg) x);
+        //~^ ERROR cannot use value of type `Es` for inline assembly
+    }
+}

--- a/tests/ui/asm/invalid-repr-simd-on-enum-148634.stderr
+++ b/tests/ui/asm/invalid-repr-simd-on-enum-148634.stderr
@@ -1,5 +1,5 @@
 error[E0517]: attribute should be applied to a struct
-  --> $DIR/invalid-repr-simd-on-enum-148634.rs:5:8
+  --> $DIR/invalid-repr-simd-on-enum-148634.rs:6:8
    |
 LL | #[repr(simd)]
    |        ^^^^
@@ -8,7 +8,7 @@ LL | enum Es {}
    | ---------- not a struct
 
 error[E0084]: unsupported representation for zero-variant enum
-  --> $DIR/invalid-repr-simd-on-enum-148634.rs:5:8
+  --> $DIR/invalid-repr-simd-on-enum-148634.rs:6:8
    |
 LL | #[repr(simd)]
    |        ^^^^
@@ -16,15 +16,7 @@ LL | #[repr(simd)]
 LL | enum Es {}
    | ------- zero-variant enum
 
-error: cannot use value of type `Es` for inline assembly
-  --> $DIR/invalid-repr-simd-on-enum-148634.rs:13:29
-   |
-LL |         asm!("{}", out(reg) x);
-   |                             ^
-   |
-   = note: only integers, floats, SIMD vectors, pointers and function pointers can be used as arguments for inline assembly
-
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 
 Some errors have detailed explanations: E0084, E0517.
 For more information about an error, try `rustc --explain E0084`.

--- a/tests/ui/asm/invalid-repr-simd-on-enum-148634.stderr
+++ b/tests/ui/asm/invalid-repr-simd-on-enum-148634.stderr
@@ -1,0 +1,30 @@
+error[E0517]: attribute should be applied to a struct
+  --> $DIR/invalid-repr-simd-on-enum-148634.rs:5:8
+   |
+LL | #[repr(simd)]
+   |        ^^^^
+...
+LL | enum Es {}
+   | ---------- not a struct
+
+error[E0084]: unsupported representation for zero-variant enum
+  --> $DIR/invalid-repr-simd-on-enum-148634.rs:5:8
+   |
+LL | #[repr(simd)]
+   |        ^^^^
+...
+LL | enum Es {}
+   | ------- zero-variant enum
+
+error: cannot use value of type `Es` for inline assembly
+  --> $DIR/invalid-repr-simd-on-enum-148634.rs:13:29
+   |
+LL |         asm!("{}", out(reg) x);
+   |                             ^
+   |
+   = note: only integers, floats, SIMD vectors, pointers and function pointers can be used as arguments for inline assembly
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0084, E0517.
+For more information about an error, try `rustc --explain E0084`.


### PR DESCRIPTION
Fixes rust-lang/rust#148634

The ICE happened because 
https://github.com/rust-lang/rust/blob/995c11894fdabe1c630694254de756f82389c6cf/compiler/rustc_middle/src/ty/mod.rs#L1531

will always set `IS_SIMD` according to `get_all_attrs`, and since we already report error `attribute should be applied to a struct`, it's OK to bypass here.