### PR TITLE
compiletest: don't pickup a Python from `PYTHONPATH` in debuginfo

### DIFF
--- a/bootstrap.example.toml
+++ b/bootstrap.example.toml
@@ -322,7 +322,9 @@
 # Python interpreter to use for various tasks throughout the build, notably
 # rustdoc tests, the lldb python interpreter, and some dist bits and pieces.
 #
-# Defaults to the Python interpreter used to execute x.py.
+# Defaults to the Python interpreter used to execute x.py, or /usr/bin/python3
+# on macOS. Note that LLDB tests require a Python version compatible with the
+# LLDB plugin to be loaded.
 #build.python = "python"
 
 # The path to (or name of) the resource compiler executable to use on Windows.

--- a/src/bootstrap/src/lib.rs
+++ b/src/bootstrap/src/lib.rs
@@ -1525,10 +1525,11 @@ impl Build {
     /// Path to the python interpreter to use
     fn python(&self) -> &Path {
         if self.config.host_target.ends_with("apple-darwin") {
-            // Force /usr/bin/python3 on macOS for LLDB tests because we're loading the
-            // LLDB plugin's compiled module which only works with the system python
-            // (namely not Homebrew-installed python)
-            Path::new("/usr/bin/python3")
+            // LLDB tests require the Python version the LLDB plugin was built for.
+            // On macOS, the system Python/LLDB are compatible. Many users install
+            // Homebrew Python but not Homebrew LLVM, so default to system Python.
+            // Can be overridden via `build.python` for custom LLVM installations.
+            self.config.python.as_deref().unwrap_or_else(|| Path::new("/usr/bin/python3"))
         } else {
             self.config
                 .python

--- a/src/bootstrap/src/utils/change_tracker.rs
+++ b/src/bootstrap/src/utils/change_tracker.rs
@@ -576,4 +576,9 @@ pub const CONFIG_CHANGE_HISTORY: &[ChangeInfo] = &[
         severity: ChangeSeverity::Info,
         summary: "`llvm.enzyme` now works with `download-ci-llvm=true`.",
     },
+    ChangeInfo {
+        change_id: 148636,
+        severity: ChangeSeverity::Info,
+        summary: "The `build.python` option is now respected on macOS (previously ignored).",
+    },
 ];

--- a/src/tools/compiletest/src/common.rs
+++ b/src/tools/compiletest/src/common.rs
@@ -524,9 +524,6 @@ pub struct Config {
     ///
     /// FIXME: the fallback path when `gdb` isn't provided tries to find *a* `gdb` or `gdb.exe` from
     /// `PATH`, which is... arguably questionable.
-    ///
-    /// FIXME: we are propagating a python from `PYTHONPATH`, not from an explicit config for gdb
-    /// debugger script.
     pub gdb: Option<String>,
 
     /// Version of GDB, encoded as ((major * 1000) + minor) * 1000 + patch
@@ -587,8 +584,6 @@ pub struct Config {
     pub adb_device_status: bool,
 
     /// Path containing LLDB's Python module.
-    ///
-    /// FIXME: `PYTHONPATH` takes precedence over this flag...? See `runtest::run_lldb`.
     pub lldb_python_dir: Option<String>,
 
     /// Verbose dump a lot of info.

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -196,14 +196,12 @@ pub fn compute_stamp_hash(config: &Config) -> String {
         Some(Debugger::Gdb) => {
             config.gdb.hash(&mut hash);
             env::var_os("PATH").hash(&mut hash);
-            env::var_os("PYTHONPATH").hash(&mut hash);
         }
 
         Some(Debugger::Lldb) => {
             config.python.hash(&mut hash);
             config.lldb_python_dir.hash(&mut hash);
             env::var_os("PATH").hash(&mut hash);
-            env::var_os("PYTHONPATH").hash(&mut hash);
         }
 
         None => {}

--- a/src/tools/compiletest/src/runtest/debuginfo.rs
+++ b/src/tools/compiletest/src/runtest/debuginfo.rs
@@ -303,14 +303,7 @@ impl TestCx<'_> {
                 &["-quiet".as_ref(), "-batch".as_ref(), "-nx".as_ref(), &debugger_script];
 
             let mut gdb = Command::new(self.config.gdb.as_ref().unwrap());
-
-            // FIXME: we are propagating `PYTHONPATH` from the environment, not a compiletest flag!
-            let pythonpath = if let Ok(pp) = std::env::var("PYTHONPATH") {
-                format!("{pp}:{rust_pp_module_abs_path}")
-            } else {
-                rust_pp_module_abs_path.to_string()
-            };
-            gdb.args(debugger_opts).env("PYTHONPATH", pythonpath);
+            gdb.args(debugger_opts);
 
             debugger_run_result =
                 self.compose_and_run(gdb, self.config.run_lib_path.as_path(), None, None);
@@ -449,19 +442,12 @@ impl TestCx<'_> {
         // Prepare the lldb_batchmode which executes the debugger script
         let lldb_script_path = self.config.src_root.join("src/etc/lldb_batchmode.py");
 
-        // FIXME: `PYTHONPATH` takes precedence over the flag...?
-        let pythonpath = if let Ok(pp) = std::env::var("PYTHONPATH") {
-            format!("{pp}:{}", self.config.lldb_python_dir.as_ref().unwrap())
-        } else {
-            self.config.lldb_python_dir.clone().unwrap()
-        };
         self.run_command_to_procres(
             Command::new(&self.config.python)
                 .arg(&lldb_script_path)
                 .arg(test_executable)
                 .arg(debugger_script)
-                .env("PYTHONUNBUFFERED", "1") // Help debugging #78665
-                .env("PYTHONPATH", pythonpath),
+                .env("PYTHONUNBUFFERED", "1"), // Help debugging #78665
         )
     }
 }


### PR DESCRIPTION
Debugging https://github.com/rust-lang/rust/pull/148636#issuecomment-3502025066.

r? ghost

try-job: aarch64-apple