### PR TITLE
Check unsafety for non-macro attributes in `validate_attr`

### DIFF
--- a/compiler/rustc_attr_parsing/src/validate_attr.rs
+++ b/compiler/rustc_attr_parsing/src/validate_attr.rs
@@ -209,7 +209,7 @@ pub fn check_attribute_safety(
 
         // - Normal builtin attribute
         // - Writing `#[unsafe(..)]` is not permitted on normal builtin attributes
-        (Some(AttributeSafety::Normal), Safety::Unsafe(unsafe_span)) => {
+        (None | Some(AttributeSafety::Normal), Safety::Unsafe(unsafe_span)) => {
             psess.dcx().emit_err(errors::InvalidAttrUnsafe {
                 span: unsafe_span,
                 name: attr_item.path.clone(),
@@ -218,13 +218,8 @@ pub fn check_attribute_safety(
 
         // - Normal builtin attribute
         // - No explicit `#[unsafe(..)]` written.
-        (Some(AttributeSafety::Normal), Safety::Default) => {
+        (None | Some(AttributeSafety::Normal), Safety::Default) => {
             // OK
-        }
-
-        // - Non-builtin attribute
-        (None, Safety::Unsafe(_) | Safety::Default) => {
-            // OK (not checked here)
         }
 
         (

--- a/compiler/rustc_expand/src/expand.rs
+++ b/compiler/rustc_expand/src/expand.rs
@@ -886,9 +886,6 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
                         }
                     }
                 } else if let SyntaxExtensionKind::NonMacroAttr = ext {
-                    if let ast::Safety::Unsafe(span) = attr.get_normal_item().unsafety {
-                        self.cx.dcx().span_err(span, "unnecessary `unsafe` on safe attribute");
-                    }
                     // `-Zmacro-stats` ignores these because they don't do any real expansion.
                     self.cx.expanded_inert_attrs.mark(&attr);
                     item.visit_attrs(|attrs| attrs.insert(pos, attr));

--- a/tests/ui/attributes/proc-macro-unsafe.rs
+++ b/tests/ui/attributes/proc-macro-unsafe.rs
@@ -1,0 +1,9 @@
+//@ proc-macro: external-macro-use.rs
+
+extern crate external_macro_use;
+
+#[unsafe(external_macro_use::a)]
+//~^ ERROR unnecessary `unsafe` on safe attribute
+fn f() {}
+
+fn main() {}

--- a/tests/ui/attributes/proc-macro-unsafe.stderr
+++ b/tests/ui/attributes/proc-macro-unsafe.stderr
@@ -1,0 +1,8 @@
+error: unnecessary `unsafe` on safe attribute
+  --> $DIR/proc-macro-unsafe.rs:5:3
+   |
+LL | #[unsafe(external_macro_use::a)]
+   |   ^^^^^^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/attributes/unsafe/double-unsafe-attributes.rs
+++ b/tests/ui/attributes/unsafe/double-unsafe-attributes.rs
@@ -1,7 +1,7 @@
 #[unsafe(unsafe(no_mangle))]
 //~^ ERROR expected identifier, found keyword `unsafe`
 //~| ERROR cannot find attribute `r#unsafe` in this scope
-//~| ERROR unnecessary `unsafe`
+//~| ERROR `r#unsafe` is not an unsafe attribute
 fn a() {}
 
 fn main() {}

--- a/tests/ui/attributes/unsafe/double-unsafe-attributes.stderr
+++ b/tests/ui/attributes/unsafe/double-unsafe-attributes.stderr
@@ -9,11 +9,13 @@ help: escape `unsafe` to use it as an identifier
 LL | #[unsafe(r#unsafe(no_mangle))]
    |          ++
 
-error: unnecessary `unsafe` on safe attribute
+error: `r#unsafe` is not an unsafe attribute
   --> $DIR/double-unsafe-attributes.rs:1:3
    |
 LL | #[unsafe(unsafe(no_mangle))]
-   |   ^^^^^^
+   |   ^^^^^^ this is not an unsafe attribute
+   |
+   = note: extraneous unsafe is not allowed in attributes
 
 error: cannot find attribute `r#unsafe` in this scope
   --> $DIR/double-unsafe-attributes.rs:1:10

--- a/tests/ui/attributes/unsafe/unsafe-safe-attribute_diagnostic.rs
+++ b/tests/ui/attributes/unsafe/unsafe-safe-attribute_diagnostic.rs
@@ -1,4 +1,4 @@
-#[unsafe(diagnostic::on_unimplemented( //~ ERROR: unnecessary `unsafe`
+#[unsafe(diagnostic::on_unimplemented( //~ ERROR: `diagnostic::on_unimplemented` is not an unsafe attribute
     message = "testing",
 ))]
 trait Foo {}

--- a/tests/ui/attributes/unsafe/unsafe-safe-attribute_diagnostic.stderr
+++ b/tests/ui/attributes/unsafe/unsafe-safe-attribute_diagnostic.stderr
@@ -1,8 +1,10 @@
-error: unnecessary `unsafe` on safe attribute
+error: `diagnostic::on_unimplemented` is not an unsafe attribute
   --> $DIR/unsafe-safe-attribute_diagnostic.rs:1:3
    |
 LL | #[unsafe(diagnostic::on_unimplemented(
-   |   ^^^^^^
+   |   ^^^^^^ this is not an unsafe attribute
+   |
+   = note: extraneous unsafe is not allowed in attributes
 
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
r? @jdonszelmann 

Also adds a test for a previously untested case, unnecessary unsafe on a proc macro attribute

In preparation for https://github.com/rust-lang/rust/issues/148453