### PR TITLE
Lint unused associated types

### DIFF
--- a/tests/ui/associated-type-bounds/union-bounds.rs
+++ b/tests/ui/associated-type-bounds/union-bounds.rs
@@ -4,7 +4,7 @@
 
 trait Tr1: Copy { type As1: Copy; }
 trait Tr2: Copy { type As2: Copy; }
-trait Tr3: Copy { type As3: Copy; }
+trait Tr3: Copy { #[allow(dead_code)] type As3: Copy; }
 trait Tr4<'a>: Copy { type As4: Copy; }
 trait Tr5: Copy { type As5: Copy; }
 

--- a/tests/ui/associated-types/impl-wf-cycle-5.fixed
+++ b/tests/ui/associated-types/impl-wf-cycle-5.fixed
@@ -11,7 +11,7 @@ impl Fiz for bool {}
 
 trait Grault {
     type A;
-    type B;
+    #[allow(dead_code)] type B;
 }
 
 impl Grault for () {

--- a/tests/ui/associated-types/impl-wf-cycle-5.rs
+++ b/tests/ui/associated-types/impl-wf-cycle-5.rs
@@ -11,7 +11,7 @@ impl Fiz for bool {}
 
 trait Grault {
     type A;
-    type B;
+    #[allow(dead_code)] type B;
 }
 
 impl Grault for () {

--- a/tests/ui/associated-types/impl-wf-cycle-6.fixed
+++ b/tests/ui/associated-types/impl-wf-cycle-6.fixed
@@ -11,7 +11,7 @@ impl Fiz for bool {}
 
 trait Grault {
     type A;
-    type B;
+    #[allow(dead_code)] type B;
 }
 
 impl Grault for () {

--- a/tests/ui/associated-types/impl-wf-cycle-6.rs
+++ b/tests/ui/associated-types/impl-wf-cycle-6.rs
@@ -11,7 +11,7 @@ impl Fiz for bool {}
 
 trait Grault {
     type A;
-    type B;
+    #[allow(dead_code)] type B;
 }
 
 impl Grault for () {

--- a/tests/ui/generic-associated-types/collections.rs
+++ b/tests/ui/generic-associated-types/collections.rs
@@ -10,7 +10,7 @@ trait Collection<T> {
     type Iter<'iter>: Iterator<Item=&'iter T> where T: 'iter, Self: 'iter;
     type Family: CollectionFamily;
     // Test associated type defaults with parameters
-    type Sibling<U>: Collection<U> =
+    #[allow(dead_code)] type Sibling<U>: Collection<U> =
         <<Self as Collection<T>>::Family as CollectionFamily>::Member<U>;
 
     fn empty() -> Self;

--- a/tests/ui/lint/dead-code/unused-assoc-ty.rs
+++ b/tests/ui/lint/dead-code/unused-assoc-ty.rs
@@ -1,0 +1,71 @@
+#![deny(dead_code)]
+
+trait Tr {
+    type A;
+    type B;
+    type C: Default;
+    type D;
+    type E;
+    type F;
+    type G;
+    type H; //~ ERROR associated type `H` is never used
+}
+
+impl Tr for i32 {
+    type A = Self;
+    type B = Self;
+    type C = Self;
+    type D = Self;
+    type E = Self;
+    type F = Self;
+    type G = Self;
+    type H = Self;
+}
+
+trait Tr2 {
+    type A;
+}
+
+impl Tr2 for i32 {
+    type A = Self;
+}
+
+struct Foo<T: Tr2> {
+    _x: T::A,
+}
+
+struct Bar<T> {
+    _x: T
+}
+
+impl<T> Bar<T>
+where
+    T: Tr2<A = i32>
+{}
+
+type Baz<T> = <T as Tr>::G;
+
+struct FooBaz<T: Tr> {
+    _x: Baz<T>,
+}
+
+fn foo<T: Tr>(t: impl Tr<A = T>) -> impl Tr
+where
+    T::B: Copy
+{
+    let _a: T::C = Default::default();
+    baz::<T::F>();
+    t
+}
+fn bar<T: ?Sized>() {}
+fn baz<T>() {}
+
+fn main() {
+    foo::<i32>(42);
+    bar::<dyn Tr2<A = i32>>();
+    let _d: <i32 as Tr>::D = Default::default();
+    baz::<<i32 as Tr>::E>();
+    baz::<Foo<i32>>();
+    baz::<Bar<i32>>();
+    baz::<FooBaz<i32>>();
+}

--- a/tests/ui/lint/dead-code/unused-assoc-ty.stderr
+++ b/tests/ui/lint/dead-code/unused-assoc-ty.stderr
@@ -1,0 +1,17 @@
+error: associated type `H` is never used
+  --> $DIR/unused-assoc-ty.rs:11:10
+   |
+LL | trait Tr {
+   |       -- associated type in this trait
+...
+LL |     type H;
+   |          ^
+   |
+note: the lint level is defined here
+  --> $DIR/unused-assoc-ty.rs:1:9
+   |
+LL | #![deny(dead_code)]
+   |         ^^^^^^^^^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/lint/dead-code/used-assoc-ty-in-struct.rs
+++ b/tests/ui/lint/dead-code/used-assoc-ty-in-struct.rs
@@ -1,0 +1,16 @@
+//@ check-pass
+
+#![deny(dead_code)]
+
+trait Trait { type Ty; }
+
+impl Trait for () { type Ty = (); }
+
+pub struct Wrap(Inner<()>);
+struct Inner<T: Trait>(T::Ty); // <- use of QPath::TypeRelative `Ty` in a non-body only
+
+impl Wrap {
+    pub fn live(self) { _ = self.0; }
+}
+
+fn main() {}

--- a/tests/ui/lint/dead-code/used-assoc-ty-on-const.rs
+++ b/tests/ui/lint/dead-code/used-assoc-ty-on-const.rs
@@ -1,0 +1,19 @@
+//@ check-pass
+
+#![deny(dead_code)]
+
+pub struct A;
+
+trait B {
+    type Assoc;
+}
+
+impl B for A {
+    type Assoc = A;
+}
+
+const X: <A as B>::Assoc = A;
+
+fn main() {
+    let _x: A = X;
+}

--- a/tests/ui/lint/dead-code/used-assoc-ty-on-impl.rs
+++ b/tests/ui/lint/dead-code/used-assoc-ty-on-impl.rs
@@ -1,0 +1,23 @@
+//@ check-pass
+
+#![deny(dead_code)]
+
+pub struct A;
+
+trait B {
+    type Assoc;
+}
+
+impl B for A {
+    type Assoc = A;
+}
+
+trait C {}
+
+impl C for <A as B>::Assoc {}
+
+fn foo<T: C>() {}
+
+fn main() {
+    foo::<A>();
+}

--- a/tests/ui/lint/dead-code/used-inherent-assoc-ty.rs
+++ b/tests/ui/lint/dead-code/used-inherent-assoc-ty.rs
@@ -1,0 +1,12 @@
+//@ check-pass
+
+#![feature(inherent_associated_types)]
+#![allow(incomplete_features)]
+#[deny(dead_code)]
+
+fn main() {
+    let _: Struct::Item = ();
+}
+
+struct Struct;
+impl Struct { type Item = (); }

--- a/tests/ui/sanitizer/cfi/sized-associated-ty.rs
+++ b/tests/ui/sanitizer/cfi/sized-associated-ty.rs
@@ -15,7 +15,7 @@
 //@ run-pass
 
 trait Foo {
-    type Bar<'a>
+    #[allow(dead_code)] type Bar<'a>
     where
         Self: Sized;
 

--- a/tests/ui/traits/issue-38033.rs
+++ b/tests/ui/traits/issue-38033.rs
@@ -16,10 +16,11 @@ trait Future {
 
 trait IntoFuture {
     type Future: Future<Item=Self::Item, Error=Self::Error>;
+    //~^ WARN associated items `Future` and `into_future` are never used
     type Item;
     type Error;
 
-    fn into_future(self) -> Self::Future; //~ WARN method `into_future` is never used
+    fn into_future(self) -> Self::Future;
 }
 
 impl<F: Future> IntoFuture for F {

--- a/tests/ui/traits/issue-38033.stderr
+++ b/tests/ui/traits/issue-38033.stderr
@@ -1,8 +1,10 @@
-warning: method `into_future` is never used
-  --> $DIR/issue-38033.rs:22:8
+warning: associated items `Future` and `into_future` are never used
+  --> $DIR/issue-38033.rs:18:10
    |
 LL | trait IntoFuture {
-   |       ---------- method in this trait
+   |       ---------- associated items in this trait
+LL |     type Future: Future<Item=Self::Item, Error=Self::Error>;
+   |          ^^^^^^
 ...
 LL |     fn into_future(self) -> Self::Future;
    |        ^^^^^^^^^^^


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/148654)*
<!-- homu-ignore:end -->

This PR lints unused associated types, like associated consts and fns.

Different from assoc consts and fns, associated types correspond to `QPath::TypeRelative`, and `Res::Err` will be obtained in HIR. Therefore, it is necessary to traverse `rustc_middle::ty::Ty` to help propagate liveness to the corresponding associated type.

Fixes https://github.com/rust-lang/rust/issues/127673
Fixes https://github.com/rust-lang/rust/issues/110332