### PR TITLE
Fix invalid macro tag generation for keywords which can be followed by values

### DIFF
--- a/tests/rustdoc/source-code-pages/failing-expansion-on-wrong-macro.rs
+++ b/tests/rustdoc/source-code-pages/failing-expansion-on-wrong-macro.rs
@@ -1,0 +1,13 @@
+// This code crashed because a `if` followed by a `!` was considered a macro,
+// creating an invalid class stack.
+// Regression test for <https://github.com/rust-lang/rust/issues/148617>.
+
+//@ compile-flags: -Zunstable-options --generate-macro-expansion
+
+enum Enum {
+    Variant,
+}
+
+pub fn repro() {
+    if !matches!(Enum::Variant, Enum::Variant) {}
+}

--- a/tests/rustdoc/source-code-pages/keyword-macros.rs
+++ b/tests/rustdoc/source-code-pages/keyword-macros.rs
@@ -1,0 +1,30 @@
+// This test ensures that keywords which can be followed by values (and therefore `!`)
+// are not considered as macros.
+// This is a regression test for <https://github.com/rust-lang/rust/issues/148617>.
+
+#![crate_name = "foo"]
+#![feature(negative_impls)]
+
+//@ has 'src/foo/keyword-macros.rs.html'
+
+//@ has - '//*[@class="rust"]//*[@class="number"]' '2'
+//@ has - '//*[@class="rust"]//*[@class="number"]' '0'
+//@ has - '//*[@class="rust"]//*[@class="number"]' '1'
+const ARR: [u8; 2] = [!0,! 1];
+
+trait X {}
+
+//@ has - '//*[@class="rust"]//*[@class="kw"]' 'impl'
+impl !X for i32 {}
+
+fn a() {
+    //@ has - '//*[@class="rust"]//*[@class="kw"]' 'if'
+    if! true{}
+    //@ has - '//*[@class="rust"]//*[@class="kw"]' 'match'
+    match !true { _ => {} }
+    //@ has - '//*[@class="rust"]//*[@class="kw"]' 'while'
+    let _ = while !true {
+    //@ has - '//*[@class="rust"]//*[@class="kw"]' 'break'
+        break !true;
+    };
+}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/148617.

The problem didn't come from the `generate-macro-expansion` feature but was actually uncovered thanks to it.

Keywords like `if` or `return`, when followed by a `!` were considered as macros, which was wrong and let to invalid class stack and to the panic.

~~While working on it, I realized that `_` was considered as a keyword, so I fixed that as well in the second commit.~~ (reverted, see https://github.com/rust-lang/rust/pull/148655#issuecomment-3508220823, https://github.com/rust-lang/rust/pull/148655#issuecomment-3508262637)

r? @yotamofek 