### PR TITLE
Also compile rustc_driver as rlib

### DIFF
--- a/compiler/rustc_driver/Cargo.toml
+++ b/compiler/rustc_driver/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 edition = "2024"
 
 [lib]
-crate-type = ["dylib"]
+crate-type = ["rlib", "dylib"]
 
 [dependencies]
 # tidy-alphabetical-start


### PR DESCRIPTION
This reduces the amount of patching necessary to get rustc working in environments where dynamic linking is not possible like wasm, miri or some niche OSes. There is still a single line patch necessary for miri to get the sysroot location (a future PR I have planned would as a side effect likely remove the need for this patch). For wasm some more intrusive patches are still necessary to disable thread usage.

We will still only ship it in rustc-dev as dylib (all rlibs are filtered) and given that it is an empty crate, it shouldn't have any noticable size or compile time impact on building rustc.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
