### PR TITLE
Add `--ignore-scripts` flag to npm install invocation

### DIFF
--- a/src/build_helper/src/npm.rs
+++ b/src/build_helper/src/npm.rs
@@ -29,6 +29,8 @@ pub fn install(src_root_path: &Path, out_dir: &Path, npm: &Path) -> Result<PathB
     // this makes tidy output less noisy, and also significantly improves runtime
     // of repeated tidy invocations.
     cmd.args(&["--audit=false", "--save=false", "--fund=false"]);
+    // temporary workaround for rollup breakage
+    cmd.arg("--ignore-scripts");
     cmd.current_dir(out_dir);
     let exit_status = cmd.spawn()?.wait()?;
     if !exit_status.success() {


### PR DESCRIPTION
Newest version of rollup is broken: https://github.com/rollup/rollup/issues/6168
This allows builds to pass until rollup releases a fix and/or we implement a better solution to the fact that npm is not honoring our package lock files

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
