### PR TITLE
Avoid infinite cycle in `coerce_unsized_old_solver` when encountering invalid recursive struct definition

### DIFF
--- a/compiler/rustc_hir_typeck/src/coercion.rs
+++ b/compiler/rustc_hir_typeck/src/coercion.rs
@@ -792,7 +792,16 @@ impl<'f, 'tcx> Coerce<'f, 'tcx> {
                         self.fcx.set_tainted_by_errors(guar);
                     }
                 }
-                Ok(Some(impl_source)) => queue.extend(impl_source.nested_obligations()),
+                Ok(Some(impl_source)) => {
+                    let nested = impl_source.nested_obligations();
+                    if nested.len() == 1 && &obligation == &nested[0] {
+                        // Avoid hang when expanding the current obligation to the same obligation.
+                        // This doesn't occur under normal circumstances, only on incorrect
+                        // recursive type definitions. Issue #148653.
+                    } else {
+                        queue.extend(nested);
+                    }
+                }
             }
         }
 

--- a/tests/ui/traits/solver-cycles/148653-recursive-struct-infinte-cycle.rs
+++ b/tests/ui/traits/solver-cycles/148653-recursive-struct-infinte-cycle.rs
@@ -1,0 +1,11 @@
+// Issue #148653.
+struct Vec<T> { //~ ERROR recursive type `Vec` has infinite size
+    data: Vec<T>, //~ ERROR type parameter `T` is only used recursively
+}
+impl<T> Vec<T> {
+    pub fn push(&mut self) -> &mut Self {
+        self
+    }
+}
+
+fn main() {}

--- a/tests/ui/traits/solver-cycles/148653-recursive-struct-infinte-cycle.stderr
+++ b/tests/ui/traits/solver-cycles/148653-recursive-struct-infinte-cycle.stderr
@@ -1,0 +1,27 @@
+error: type parameter `T` is only used recursively
+  --> $DIR/148653-recursive-struct-infinte-cycle.rs:3:15
+   |
+LL | struct Vec<T> {
+   |            - type parameter must be used non-recursively in the definition
+LL |     data: Vec<T>,
+   |               ^
+   |
+   = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
+   = note: all type parameters must be used in a non-recursive way in order to constrain their variance
+
+error[E0072]: recursive type `Vec` has infinite size
+  --> $DIR/148653-recursive-struct-infinte-cycle.rs:2:1
+   |
+LL | struct Vec<T> {
+   | ^^^^^^^^^^^^^
+LL |     data: Vec<T>,
+   |           ------ recursive without indirection
+   |
+help: insert some indirection (e.g., a `Box`, `Rc`, or `&`) to break the cycle
+   |
+LL |     data: Box<Vec<T>>,
+   |           ++++      +
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0072`.


### PR DESCRIPTION
If an obligation's nested obligations expands to itself, do not add it to the working queue.

Fix rust-lang/rust#148653.
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
