### PR TITLE
Recover `[T: N]` as `[T; N]`

### DIFF
--- a/compiler/rustc_parse/src/parser/ty.rs
+++ b/compiler/rustc_parse/src/parser/ty.rs
@@ -687,7 +687,6 @@ impl<'a> Parser<'a> {
         let mut err =
             self.dcx().struct_span_err(span, format!("expected `;` or `]`, found {}", token_descr));
         err.span_label(span, "expected `;` or `]`");
-        err.note("you might have meant to write a slice or array type");
 
         // If we cannot recover, return the error immediately.
         if !self.may_recover() {
@@ -696,12 +695,10 @@ impl<'a> Parser<'a> {
 
         let snapshot = self.create_snapshot_for_diagnostic();
 
-        let suggestion_span = if self.eat(exp!(Comma)) || self.eat(exp!(Star)) {
-            // Consume common erroneous separators.
-            self.prev_token.span
-        } else {
-            self.token.span.shrink_to_lo()
-        };
+        // Consume common erroneous separators.
+        let hi = self.prev_token.span.hi();
+        _ = self.eat(exp!(Comma)) || self.eat(exp!(Colon)) || self.eat(exp!(Star));
+        let suggestion_span = self.prev_token.span.with_lo(hi);
 
         // we first try to parse pattern like `[u8 5]`
         let length = match self.parse_expr_anon_const() {

--- a/tests/ui/parser/better-expected.stderr
+++ b/tests/ui/parser/better-expected.stderr
@@ -4,11 +4,10 @@ error: expected `;` or `]`, found `3`
 LL |     let x: [isize 3];
    |                   ^ expected `;` or `]`
    |
-   = note: you might have meant to write a slice or array type
 help: you might have meant to use `;` as the separator
    |
-LL |     let x: [isize ;3];
-   |                   +
+LL |     let x: [isize; 3];
+   |                  +
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/issues/error-pattern-issue-50571.stderr
+++ b/tests/ui/parser/issues/error-pattern-issue-50571.stderr
@@ -4,7 +4,6 @@ error: expected `;` or `]`, found `,`
 LL |     fn foo([a, b]: [i32; 2]) {}
    |              ^ expected `;` or `]`
    |
-   = note: you might have meant to write a slice or array type
 help: you might have meant to use `;` as the separator
    |
 LL -     fn foo([a, b]: [i32; 2]) {}

--- a/tests/ui/parser/recover/array-type-no-semi.rs
+++ b/tests/ui/parser/recover/array-type-no-semi.rs
@@ -14,4 +14,6 @@ fn main() {
     //~| ERROR attempt to use a non-constant value in a constant [E0435]
     let e: [i32 5];
     //~^ ERROR expected `;` or `]`, found `5`
+    let f: [i32: 1 - 1];
+    //~^ ERROR expected `;` or `]`, found `:`
 }

--- a/tests/ui/parser/recover/array-type-no-semi.stderr
+++ b/tests/ui/parser/recover/array-type-no-semi.stderr
@@ -4,7 +4,6 @@ error: expected `;` or `]`, found `,`
 LL |     let b: [i32, 5];
    |                ^ expected `;` or `]`
    |
-   = note: you might have meant to write a slice or array type
 help: you might have meant to use `;` as the separator
    |
 LL -     let b: [i32, 5];
@@ -19,8 +18,6 @@ LL |     let a: [i32, ];
    |          |
    |          while parsing the type for `a`
    |          help: use `=` if you meant to assign
-   |
-   = note: you might have meant to write a slice or array type
 
 error: expected `;` or `]`, found `,`
   --> $DIR/array-type-no-semi.rs:12:16
@@ -28,7 +25,6 @@ error: expected `;` or `]`, found `,`
 LL |     let c: [i32, x];
    |                ^ expected `;` or `]`
    |
-   = note: you might have meant to write a slice or array type
 help: you might have meant to use `;` as the separator
    |
 LL -     let c: [i32, x];
@@ -41,11 +37,22 @@ error: expected `;` or `]`, found `5`
 LL |     let e: [i32 5];
    |                 ^ expected `;` or `]`
    |
-   = note: you might have meant to write a slice or array type
 help: you might have meant to use `;` as the separator
    |
-LL |     let e: [i32 ;5];
-   |                 +
+LL |     let e: [i32; 5];
+   |                +
+
+error: expected `;` or `]`, found `:`
+  --> $DIR/array-type-no-semi.rs:17:16
+   |
+LL |     let f: [i32: 1 - 1];
+   |                ^ expected `;` or `]`
+   |
+help: you might have meant to use `;` as the separator
+   |
+LL -     let f: [i32: 1 - 1];
+LL +     let f: [i32; 1 - 1];
+   |
 
 error[E0435]: attempt to use a non-constant value in a constant
   --> $DIR/array-type-no-semi.rs:12:18
@@ -65,7 +72,7 @@ error[E0423]: expected value, found builtin type `i32`
 LL |     let a: [i32, ];
    |             ^^^ not a value
 
-error: aborting due to 6 previous errors
+error: aborting due to 7 previous errors
 
 Some errors have detailed explanations: E0423, E0435.
 For more information about an error, try `rustc --explain E0423`.

--- a/tests/ui/parser/removed-syntax/removed-syntax-fixed-vec.stderr
+++ b/tests/ui/parser/removed-syntax/removed-syntax-fixed-vec.stderr
@@ -4,11 +4,10 @@ error: expected `;` or `]`, found `*`
 LL | type v = [isize * 3];
    |                 ^ expected `;` or `]`
    |
-   = note: you might have meant to write a slice or array type
 help: you might have meant to use `;` as the separator
    |
 LL - type v = [isize * 3];
-LL + type v = [isize ; 3];
+LL + type v = [isize; 3];
    |
 
 warning: type `v` should have an upper camel case name


### PR DESCRIPTION
`;` is similar and (keyboard-wise) next to `:`, so a verbose suggestion may help to see the difference.

Parent PR: rust-lang/rust#143905

---
@rustbot label +A-parser +A-array +A-diagnostics +A-suggestion-diagnostics +D-papercut