### PR TITLE
Rollup of 16 pull requests

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -9,7 +9,7 @@ Aaron Todd <github@opprobrio.us>
 Abhishek Chanda <abhishek.becs@gmail.com> Abhishek Chanda <abhishek@cloudscaling.com>
 Abhijeet Bhagat <abhijeet.bhagat@gmx.com>
 Abroskin Alexander <arkweid@evilmartians.com>
-Adolfo Ochagavía <aochagavia92@gmail.com>
+Adolfo Ochagavía <aochagavia92@gmail.com> <github@adolfo.ochagavia.xyz>
 Adrian Heine né Lang <mail@adrianheine.de>
 Adrien Tétar <adri-from-59@hotmail.fr>
 Ahmed Charles <ahmedcharles@gmail.com> <acharles@outlook.com>
@@ -36,6 +36,7 @@ Amanda Stjerna <mail@amandastjerna.se> <albin.stjerna@gmail.com>
 Amanda Stjerna <mail@amandastjerna.se> <amanda.stjerna@it.uu.se>
 Amanieu d'Antras <amanieu@gmail.com> <amanieu.dantras@huawei.com>
 Amos Onn <amosonn@gmail.com>
+Amos Wenger <amoswenger@gmail.com> <fasterthanlime@users.noreply.github.com>
 Ana-Maria Mihalache <mihalacheana.maria@yahoo.com>
 Anatoly Ikorsky <aikorsky@gmail.com>
 Andre Bogus <bogusandre@gmail.com>
@@ -276,7 +277,8 @@ Irina Popa <irinagpopa@gmail.com>
 Ivan Ivaschenko <defuz.net@gmail.com>
 ivan tkachenko <me@ratijas.tk>
 J. J. Weber <jjweber@gmail.com>
-Jack Huey <jack.huey@umassmed.edu> <jackh726@gmail.com>
+Jack Huey <jackh726@gmail.com> <jack.huey@umassmed.edu>
+Jack Huey <jackh726@gmail.com> <31162821+jackh726@users.noreply.github.com>
 Jacob <jacob.macritchie@gmail.com>
 Jacob Hoffman-Andrews <rust@hoffman-andrews.com> <github@hoffman-andrews.com>
 Jacob Greenfield <xales@naveria.com>
@@ -292,6 +294,8 @@ Jakub Adam Wieczorek <jakub.adam.wieczorek@gmail.com>
 Jakub Adam Wieczorek <jakub.adam.wieczorek@gmail.com> <jakub.bukaj@yahoo.com>
 Jakub Adam Wieczorek <jakub.adam.wieczorek@gmail.com> <jakub@jakub.cc>
 Jakub Adam Wieczorek <jakub.adam.wieczorek@gmail.com> <jakubw@jakubw.net>
+Jakub Adam Wieczorek <jakub.adam.wieczorek@gmail.com> <ja.wieczorek@student.uw.edu.pl>
+Jakub Adam Wieczorek <jakub.adam.wieczorek@gmail.com> <software@jacobadam.net>
 Jakub Beránek <berykubik@gmail.com> <jakub.beranek@vsb.cz>
 James [Undefined] <tpzker@thepuzzlemaker.info>
 James Deng <cnjamesdeng@gmail.com> <cnJamesDeng@gmail.com>
@@ -303,6 +307,7 @@ Jamie Hill-Daniel <jamie@hill-daniel.co.uk> <clubby789@gmail.com>
 Jana Dönszelmann <jana@donsz.nl>
 Jana Dönszelmann <jana@donsz.nl> <jonathan@donsz.nl>
 Jana Dönszelmann <jana@donsz.nl> <jonabent@gmail.com>
+Jane Lusby <jlusby42@gmail.com> <jlusby@yaah.dev>
 Jan-Erik Rediger <janerik@fnordig.de> <badboy@archlinux.us>
 Jaro Fietz <jaro.fietz@gmx.de>
 Jason Fager <jfager@gmail.com>
@@ -313,6 +318,7 @@ Jason Toffaletti <toffaletti@gmail.com> Jason Toffaletti <jason@topsy.com>
 Jauhien Piatlicki <jauhien@gentoo.org> Jauhien Piatlicki <jpiatlicki@zertisa.com>
 Jay True <glacjay@gmail.com>
 Jeremy Letang <letang.jeremy@gmail.com>
+Jeremy Soller <jackpot51@gmail.com> <jeremy@system76.com>
 Jeremy Sorensen <jeremy.a.sorensen@gmail.com>
 Jeremy Stucki <dev@jeremystucki.ch> <stucki.jeremy@gmail.com>
 Jeremy Stucki <dev@jeremystucki.ch> <jeremy@myelin.ch>
@@ -336,6 +342,7 @@ John Kåre Alsaker <john.kare.alsaker@gmail.com>
 John Kåre Alsaker <john.kare.alsaker@gmail.com> <zoxc32@gmail.com>
 John Talling <inrustwetrust@users.noreply.github.com>
 John Van Enk <vanenkj@gmail.com>
+Jon Gjengset <jon@thesquareplanet.com> <jongje@amazon.com>
 Jonas Tepe <jonasprogrammer@gmail.com>
 Jonathan Bailey <jbailey@mozilla.com> <jbailey@jbailey-20809.local>
 Jonathan Chan Kwan Yin <sofe2038@gmail.com>
@@ -424,7 +431,7 @@ Malo Jaffré <jaffre.malo@gmail.com>
 Manish Goregaokar <manishsmail@gmail.com>
 Mara Bos <m-ou.se@m-ou.se>
 Marcell Pardavi <marcell.pardavi@gmail.com>
-Marco Ieni <11428655+MarcoIeni@users.noreply.github.com>
+Marco Ieni <marcoieni@rustfoundation.org> <11428655+MarcoIeni@users.noreply.github.com>
 Marcus Klaas de Vries <mail@marcusklaas.nl>
 Margaret Meyerhofer <mmeyerho@andrew.cmu.edu> <mmeyerho@andrew>
 Marijn Schouten <mhkbst@gmail.com> <hkBst@users.noreply.github.com>
@@ -531,6 +538,7 @@ Oliver Scherer <oli-obk@users.noreply.github.com> <oliver.schneider@kit.edu>
 Oliver Scherer <oli-obk@users.noreply.github.com> <obk8176014uqher834@olio-obk.de>
 Oliver Scherer <oli-obk@users.noreply.github.com> <rustc-contact@oli-obk.de>
 Oliver Scherer <oli-obk@users.noreply.github.com>
+Onur Özkan <onurozkan.dev@outlook.com> <contact@onurozkan.dev>
 Onur Özkan <onurozkan.dev@outlook.com> <work@onurozkan.dev>
 Onur Özkan <onurozkan.dev@outlook.com>
 Ömer Sinan Ağacan <omeragacan@gmail.com>
@@ -591,6 +599,7 @@ Rusty Blitzerr <rusty.blitzerr@gmail.com>
 RustyYato <krishna.sd.2012@gmail.com>
 Ruud van Asseldonk <dev@veniogames.com> Ruud van Asseldonk <ruuda@google.com>
 Ryan Leung <rleungx@gmail.com>
+Ryan Levick <me@ryanlevick.com> <rylev@users.noreply.github.com>
 Ryan Scheel <ryan.havvy@gmail.com>
 Ryan Sullivant <rsulli55@gmail.com>
 Ryan Wiedemann <Ryan1729@gmail.com>
@@ -685,6 +694,8 @@ Weihang Lo <me@weihanglo.tw>
 Weihang Lo <me@weihanglo.tw> <weihanglo@users.noreply.github.com>
 Wesley Wiser <wwiser@gmail.com> <wesleywiser@microsoft.com>
 whitequark <whitequark@whitequark.org>
+Will Crichton <crichton.will@gmail.com> <wcrichto@stanford.edu>
+Will Crichton <crichton.will@gmail.com> <wcrichto@cs.stanford.edu>
 William Ting <io@williamting.com> <william.h.ting@gmail.com>
 Wim Looman <wim@nemo157.com> <rust-lang@nemo157.com>
 Wim Looman <wim@nemo157.com> <git@nemo157.com>
@@ -694,6 +705,8 @@ Xinye Tao <xy.tao@outlook.com>
 Xuefeng Wu <benewu@gmail.com> Xuefeng Wu <xfwu@thoughtworks.com>
 Xuefeng Wu <benewu@gmail.com> XuefengWu <benewu@gmail.com>
 York Xiang <bombless@126.com>
+Yoshua Wuyts <yoshuawuyts@gmail.com> <yoshuawuyts+github@gmail.com>
+Yoshua Wuyts <yoshuawuyts@gmail.com> <2467194+yoshuawuyts@users.noreply.github.com>
 Yotam Ofek <yotam.ofek@gmail.com> <yotamofek@microsoft.com>
 Youngsoo Son <ysson83@gmail.com> <ysoo.son@samsung.com>
 Youngsuk Kim <joseph942010@gmail.com>

--- a/compiler/rustc_builtin_macros/src/test.rs
+++ b/compiler/rustc_builtin_macros/src/test.rs
@@ -207,30 +207,30 @@ pub(crate) fn expand_test_or_bench(
     };
 
     let test_fn = if is_bench {
-        // A simple ident for a lambda
-        let b = Ident::from_str_and_span("b", attr_sp);
-
+        // avoid name collisions by using the function name within the identifier, see bug #148275
+        let bencher_param =
+            Ident::from_str_and_span(&format!("__bench_{}", fn_.ident.name), attr_sp);
         cx.expr_call(
             sp,
             cx.expr_path(test_path("StaticBenchFn")),
             thin_vec![
                 // #[coverage(off)]
-                // |b| self::test::assert_test_result(
+                // |__bench_fn_name| self::test::assert_test_result(
                 coverage_off(cx.lambda1(
                     sp,
                     cx.expr_call(
                         sp,
                         cx.expr_path(test_path("assert_test_result")),
                         thin_vec![
-                            // super::$test_fn(b)
+                            // super::$test_fn(__bench_fn_name)
                             cx.expr_call(
                                 ret_ty_sp,
                                 cx.expr_path(cx.path(sp, vec![fn_.ident])),
-                                thin_vec![cx.expr_ident(sp, b)],
+                                thin_vec![cx.expr_ident(sp, bencher_param)],
                             ),
                         ],
                     ),
-                    b,
+                    bencher_param,
                 )), // )
             ],
         )

--- a/compiler/rustc_hir_analysis/src/collect.rs
+++ b/compiler/rustc_hir_analysis/src/collect.rs
@@ -1264,6 +1264,21 @@ pub fn suggest_impl_trait<'tcx>(
             format_as_assoc,
         ),
         (
+            infcx.tcx.lang_items().async_fn_trait(),
+            infcx.tcx.lang_items().async_fn_once_output(),
+            format_as_parenthesized,
+        ),
+        (
+            infcx.tcx.lang_items().async_fn_mut_trait(),
+            infcx.tcx.lang_items().async_fn_once_output(),
+            format_as_parenthesized,
+        ),
+        (
+            infcx.tcx.lang_items().async_fn_once_trait(),
+            infcx.tcx.lang_items().async_fn_once_output(),
+            format_as_parenthesized,
+        ),
+        (
             infcx.tcx.lang_items().fn_trait(),
             infcx.tcx.lang_items().fn_once_output(),
             format_as_parenthesized,

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -1512,9 +1512,8 @@ impl<'tcx> TyCtxt<'tcx> {
             field_shuffle_seed ^= user_seed;
         }
 
-        if let Some(reprs) =
-            find_attr!(self.get_all_attrs(did), AttributeKind::Repr { reprs, .. } => reprs)
-        {
+        let attributes = self.get_all_attrs(did);
+        if let Some(reprs) = find_attr!(attributes, AttributeKind::Repr { reprs, .. } => reprs) {
             for (r, _) in reprs {
                 flags.insert(match *r {
                     attr::ReprRust => ReprFlags::empty(),
@@ -1574,10 +1573,7 @@ impl<'tcx> TyCtxt<'tcx> {
         }
 
         // See `TyAndLayout::pass_indirectly_in_non_rustic_abis` for details.
-        if find_attr!(
-            self.get_all_attrs(did),
-            AttributeKind::RustcPassIndirectlyInNonRusticAbis(..)
-        ) {
+        if find_attr!(attributes, AttributeKind::RustcPassIndirectlyInNonRusticAbis(..)) {
             flags.insert(ReprFlags::PASS_INDIRECTLY_IN_NON_RUSTIC_ABIS);
         }
 

--- a/compiler/rustc_target/src/spec/targets/hexagon_unknown_linux_musl.rs
+++ b/compiler/rustc_target/src/spec/targets/hexagon_unknown_linux_musl.rs
@@ -8,6 +8,7 @@ pub(crate) fn target() -> Target {
     base.features = "-small-data,+hvx-length128b".into();
 
     base.has_rpath = true;
+    base.linker = Some("rust-lld".into());
     base.linker_flavor = LinkerFlavor::Unix(Cc::Yes);
 
     base.c_enum_min_bits = Some(8);

--- a/compiler/rustc_target/src/spec/targets/hexagon_unknown_none_elf.rs
+++ b/compiler/rustc_target/src/spec/targets/hexagon_unknown_none_elf.rs
@@ -27,6 +27,7 @@ pub(crate) fn target() -> Target {
             max_atomic_width: Some(32),
             emit_debug_gdb_scripts: false,
             c_enum_min_bits: Some(8),
+            linker: Some("rust-lld".into()),
             ..Default::default()
         },
     }

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -660,12 +660,15 @@ macro_rules! nonzero_integer {
                         without modifying the original"]
             #[inline(always)]
             pub const fn isolate_highest_one(self) -> Self {
-                let n = self.get() & (((1 as $Int) << (<$Int>::BITS - 1)).wrapping_shr(self.leading_zeros()));
-
                 // SAFETY:
                 // `self` is non-zero, so masking to preserve only the most
                 // significant set bit will result in a non-zero `n`.
-                unsafe { NonZero::new_unchecked(n) }
+                // and self.leading_zeros() is always < $INT::BITS since
+                // at least one of the bits in the number is not zero
+                unsafe {
+                    let bit = (((1 as $Uint) << (<$Uint>::BITS - 1)).unchecked_shr(self.leading_zeros()));
+                    NonZero::new_unchecked(bit as $Int)
+                }
             }
 
             /// Returns `self` with only the least significant bit set.

--- a/library/std/src/alloc.rs
+++ b/library/std/src/alloc.rs
@@ -394,7 +394,6 @@ fn default_alloc_error_hook(layout: Layout) {
     let mut lock = crate::sys::backtrace::lock();
 
     match crate::panic::get_backtrace_style() {
-        // SAFETY: we took out a lock just a second ago.
         Some(crate::panic::BacktraceStyle::Short) => {
             drop(lock.print(&mut out, crate::backtrace_rs::PrintFmt::Short))
         }

--- a/library/std/src/alloc.rs
+++ b/library/std/src/alloc.rs
@@ -57,7 +57,7 @@
 #![stable(feature = "alloc_module", since = "1.28.0")]
 
 use core::ptr::NonNull;
-use core::sync::atomic::{Atomic, AtomicPtr, Ordering};
+use core::sync::atomic::{AtomicBool, AtomicPtr, Ordering};
 use core::{hint, mem, ptr};
 
 #[stable(feature = "alloc_module", since = "1.28.0")]
@@ -287,7 +287,7 @@ unsafe impl Allocator for System {
     }
 }
 
-static HOOK: Atomic<*mut ()> = AtomicPtr::new(ptr::null_mut());
+static HOOK: AtomicPtr<()> = AtomicPtr::new(ptr::null_mut());
 
 /// Registers a custom allocation error hook, replacing any that was previously registered.
 ///
@@ -344,7 +344,12 @@ pub fn take_alloc_error_hook() -> fn(Layout) {
     if hook.is_null() { default_alloc_error_hook } else { unsafe { mem::transmute(hook) } }
 }
 
+#[optimize(size)]
 fn default_alloc_error_hook(layout: Layout) {
+    if cfg!(panic = "immediate-abort") {
+        return;
+    }
+
     unsafe extern "Rust" {
         // This symbol is emitted by rustc next to __rust_alloc_error_handler.
         // Its value depends on the -Zoom={panic,abort} compiler option.
@@ -354,15 +359,65 @@ fn default_alloc_error_hook(layout: Layout) {
 
     if unsafe { __rust_alloc_error_handler_should_panic_v2() != 0 } {
         panic!("memory allocation of {} bytes failed", layout.size());
+    }
+
+    // This is the default path taken on OOM, and the only path taken on stable with std.
+    // Crucially, it does *not* call any user-defined code, and therefore users do not have to
+    // worry about allocation failure causing reentrancy issues. That makes it different from
+    // the default `__rdl_alloc_error_handler` defined in alloc (i.e., the default alloc error
+    // handler that is  called when there is no `#[alloc_error_handler]`), which triggers a
+    // regular panic and thus can invoke a user-defined panic hook, executing arbitrary
+    // user-defined code.
+
+    static PREV_ALLOC_FAILURE: AtomicBool = AtomicBool::new(false);
+    if PREV_ALLOC_FAILURE.swap(true, Ordering::Relaxed) {
+        // Don't try to print a backtrace if a previous alloc error happened. This likely means
+        // there is not enough memory to print a backtrace, although it could also mean that two
+        // threads concurrently run out of memory.
+        rtprintpanic!(
+            "memory allocation of {} bytes failed\nskipping backtrace printing to avoid potential recursion\n",
+            layout.size()
+        );
+        return;
     } else {
-        // This is the default path taken on OOM, and the only path taken on stable with std.
-        // Crucially, it does *not* call any user-defined code, and therefore users do not have to
-        // worry about allocation failure causing reentrancy issues. That makes it different from
-        // the default `__rdl_alloc_error_handler` defined in alloc (i.e., the default alloc error
-        // handler that is  called when there is no `#[alloc_error_handler]`), which triggers a
-        // regular panic and thus can invoke a user-defined panic hook, executing arbitrary
-        // user-defined code.
         rtprintpanic!("memory allocation of {} bytes failed\n", layout.size());
+    }
+
+    let Some(mut out) = crate::sys::stdio::panic_output() else {
+        return;
+    };
+
+    // Use a lock to prevent mixed output in multithreading context.
+    // Some platforms also require it when printing a backtrace, like `SymFromAddr` on Windows.
+    // Make sure to not take this lock until after checking PREV_ALLOC_FAILURE to avoid deadlocks
+    // when there is too little memory to print a backtrace.
+    let mut lock = crate::sys::backtrace::lock();
+
+    match crate::panic::get_backtrace_style() {
+        // SAFETY: we took out a lock just a second ago.
+        Some(crate::panic::BacktraceStyle::Short) => {
+            drop(lock.print(&mut out, crate::backtrace_rs::PrintFmt::Short))
+        }
+        Some(crate::panic::BacktraceStyle::Full) => {
+            drop(lock.print(&mut out, crate::backtrace_rs::PrintFmt::Full))
+        }
+        Some(crate::panic::BacktraceStyle::Off) => {
+            use crate::io::Write;
+            let _ = writeln!(
+                out,
+                "note: run with `RUST_BACKTRACE=1` environment variable to display a \
+                             backtrace"
+            );
+            if cfg!(miri) {
+                let _ = writeln!(
+                    out,
+                    "note: in Miri, you may have to set `MIRIFLAGS=-Zmiri-env-forward=RUST_BACKTRACE` \
+                                for the environment variable to have an effect"
+                );
+            }
+        }
+        // If backtraces aren't supported or are forced-off, do nothing.
+        None => {}
     }
 }
 
@@ -371,11 +426,13 @@ fn default_alloc_error_hook(layout: Layout) {
 #[alloc_error_handler]
 #[unstable(feature = "alloc_internals", issue = "none")]
 pub fn rust_oom(layout: Layout) -> ! {
-    let hook = HOOK.load(Ordering::Acquire);
-    let hook: fn(Layout) =
-        if hook.is_null() { default_alloc_error_hook } else { unsafe { mem::transmute(hook) } };
-    hook(layout);
-    crate::process::abort()
+    crate::sys::backtrace::__rust_end_short_backtrace(|| {
+        let hook = HOOK.load(Ordering::Acquire);
+        let hook: fn(Layout) =
+            if hook.is_null() { default_alloc_error_hook } else { unsafe { mem::transmute(hook) } };
+        hook(layout);
+        crate::process::abort()
+    })
 }
 
 #[cfg(not(test))]

--- a/library/std/src/panicking.rs
+++ b/library/std/src/panicking.rs
@@ -293,7 +293,6 @@ fn default_hook(info: &PanicHookInfo<'_>) {
         static FIRST_PANIC: Atomic<bool> = AtomicBool::new(true);
 
         match backtrace {
-            // SAFETY: we took out a lock just a second ago.
             Some(BacktraceStyle::Short) => {
                 drop(lock.print(err, crate::backtrace_rs::PrintFmt::Short))
             }

--- a/library/std/src/sys/fs/unix.rs
+++ b/library/std/src/sys/fs/unix.rs
@@ -1296,6 +1296,7 @@ impl File {
         target_os = "openbsd",
         target_os = "cygwin",
         target_os = "illumos",
+        target_os = "aix",
         target_vendor = "apple",
     ))]
     pub fn lock(&self) -> io::Result<()> {
@@ -1321,6 +1322,7 @@ impl File {
         target_os = "cygwin",
         target_os = "solaris",
         target_os = "illumos",
+        target_os = "aix",
         target_vendor = "apple",
     )))]
     pub fn lock(&self) -> io::Result<()> {
@@ -1335,6 +1337,7 @@ impl File {
         target_os = "openbsd",
         target_os = "cygwin",
         target_os = "illumos",
+        target_os = "aix",
         target_vendor = "apple",
     ))]
     pub fn lock_shared(&self) -> io::Result<()> {
@@ -1360,6 +1363,7 @@ impl File {
         target_os = "cygwin",
         target_os = "solaris",
         target_os = "illumos",
+        target_os = "aix",
         target_vendor = "apple",
     )))]
     pub fn lock_shared(&self) -> io::Result<()> {
@@ -1374,6 +1378,7 @@ impl File {
         target_os = "openbsd",
         target_os = "cygwin",
         target_os = "illumos",
+        target_os = "aix",
         target_vendor = "apple",
     ))]
     pub fn try_lock(&self) -> Result<(), TryLockError> {
@@ -1415,6 +1420,7 @@ impl File {
         target_os = "cygwin",
         target_os = "solaris",
         target_os = "illumos",
+        target_os = "aix",
         target_vendor = "apple",
     )))]
     pub fn try_lock(&self) -> Result<(), TryLockError> {
@@ -1432,6 +1438,7 @@ impl File {
         target_os = "openbsd",
         target_os = "cygwin",
         target_os = "illumos",
+        target_os = "aix",
         target_vendor = "apple",
     ))]
     pub fn try_lock_shared(&self) -> Result<(), TryLockError> {
@@ -1473,6 +1480,7 @@ impl File {
         target_os = "cygwin",
         target_os = "solaris",
         target_os = "illumos",
+        target_os = "aix",
         target_vendor = "apple",
     )))]
     pub fn try_lock_shared(&self) -> Result<(), TryLockError> {
@@ -1490,6 +1498,7 @@ impl File {
         target_os = "openbsd",
         target_os = "cygwin",
         target_os = "illumos",
+        target_os = "aix",
         target_vendor = "apple",
     ))]
     pub fn unlock(&self) -> io::Result<()> {
@@ -1515,6 +1524,7 @@ impl File {
         target_os = "cygwin",
         target_os = "solaris",
         target_os = "illumos",
+        target_os = "aix",
         target_vendor = "apple",
     )))]
     pub fn unlock(&self) -> io::Result<()> {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,10 @@
         "browser-ui-test": "^0.22.2",
         "es-check": "^6.2.1",
         "eslint": "^8.57.1",
-        "eslint-js": "github:eslint/js",
         "typescript": "^5.8.3"
+      },
+      "devDependencies": {
+        "@types/node": "^24.10.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -56,6 +58,12 @@
       "engines": {
         "node": ">= 10"
       }
+    },
+    "node_modules/@caporal/core/node_modules/@types/node": {
+      "version": "13.9.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.3.tgz",
+      "integrity": "sha512-01s+ac4qerwd6RHD+mVbOEsraDHSgUaefQlEdBbUolnQFjKwCr7luvAlEwW1RFojh67u0z4OUTjPn9LEl4zIkA==",
+      "license": "MIT"
     },
     "node_modules/@colors/colors": {
       "version": "1.6.0",
@@ -225,8 +233,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "13.9.3",
-      "license": "MIT"
+      "version": "24.10.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.0.tgz",
+      "integrity": "sha512-qzQZRBqkFsYyaSWXuEHc2WR9c0a0CXwiE5FWUvn7ZM+vdy1uZLfCunD38UzhuB7YN/J11ndbDBcTmOdxJo9Q7A==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
     },
     "node_modules/@types/table": {
       "version": "5.0.0",
@@ -943,13 +956,6 @@
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
-    },
-    "node_modules/eslint-js": {
-      "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/eslint/js.git#9e5b4fabf073b915abc56d6c14cc24177036d43e",
-      "workspaces": [
-        "packages/*"
-      ]
     },
     "node_modules/eslint-scope": {
       "version": "7.2.2",
@@ -2574,6 +2580,12 @@
         "buffer": "^5.2.1",
         "through": "^2.3.8"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "license": "MIT"
     },
     "node_modules/untildify": {
       "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
     "browser-ui-test": "^0.22.2",
     "es-check": "^6.2.1",
     "eslint": "^8.57.1",
-    "eslint-js": "github:eslint/js",
     "typescript": "^5.8.3"
+  },
+  "devDependencies": {
+    "@types/node": "^24.10.0"
   }
 }

--- a/src/bootstrap/src/core/build_steps/doc.rs
+++ b/src/bootstrap/src/core/build_steps/doc.rs
@@ -73,7 +73,7 @@ book!(
     EditionGuide, "src/doc/edition-guide", "edition-guide", &[];
     EmbeddedBook, "src/doc/embedded-book", "embedded-book", &[];
     Nomicon, "src/doc/nomicon", "nomicon", &[];
-    RustByExample, "src/doc/rust-by-example", "rust-by-example", &["ja", "zh"];
+    RustByExample, "src/doc/rust-by-example", "rust-by-example", &["es", "ja", "zh"];
     RustdocBook, "src/doc/rustdoc", "rustdoc", &[];
     StyleGuide, "src/doc/style-guide", "style-guide", &[];
 );

--- a/src/bootstrap/src/core/build_steps/doc.rs
+++ b/src/bootstrap/src/core/build_steps/doc.rs
@@ -1228,9 +1228,12 @@ impl Step for ErrorIndex {
         t!(fs::create_dir_all(&out));
         tool::ErrorIndex::command(builder, self.compilers)
             .arg("html")
-            .arg(out)
+            .arg(&out)
             .arg(&builder.version)
             .run(builder);
+
+        let index = out.join("error-index.html");
+        builder.maybe_open_in_browser::<Self>(index);
     }
 
     fn metadata(&self) -> Option<StepMetadata> {

--- a/src/doc/rustc/src/platform-support/hexagon-unknown-linux-musl.md
+++ b/src/doc/rustc/src/platform-support/hexagon-unknown-linux-musl.md
@@ -39,6 +39,12 @@ dynamically linked executables.
 # /opt/clang+llvm-18.1.0-cross-hexagon-unknown-linux-musl/x86_64-linux-gnu/bin/qemu-hexagon -L /opt/clang+llvm-18.1.0-cross-hexagon-unknown-linux-musl/x86_64-linux-gnu/target/hexagon-unknown-linux-musl/usr/ ./hello
 ```
 
+## Linking
+
+This target selects `rust-lld` by default.  Another option to use is
+[eld](https://github.com/qualcomm/eld), which is also provided with
+the opensource hexagon toolchain and the Hexagon SDK.
+
 ## Building the target
 Because it is Tier 3, rust does not yet ship pre-compiled artifacts for this
 target.

--- a/src/doc/rustc/src/platform-support/hexagon-unknown-none-elf.md
+++ b/src/doc/rustc/src/platform-support/hexagon-unknown-none-elf.md
@@ -25,6 +25,13 @@ Functions marked `extern "C"` use the [Hexagon architecture calling convention](
 
 This target generates PIC ELF binaries.
 
+## Linking
+
+This target selects `rust-lld` by default.  Another option to use is
+[eld](https://github.com/qualcomm/eld), which is also provided with
+[the opensource hexagon toolchain](https://github.com/quic/toolchain_for_hexagon)
+and the Hexagon SDK.
+
 ## Building the target
 
 You can build Rust with support for the target by adding it to the `target`

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -1545,7 +1545,7 @@ fn print_generic_arg(generic_arg: &clean::GenericArg, cx: &Context<'_>) -> impl 
         clean::GenericArg::Lifetime(lt) => f.write_str(print_lifetime(lt)),
         clean::GenericArg::Type(ty) => print_type(ty, cx).fmt(f),
         clean::GenericArg::Const(ct) => print_constant_kind(ct, cx.tcx()).fmt(f),
-        clean::GenericArg::Infer => Display::fmt("_", f),
+        clean::GenericArg::Infer => f.write_char('_'),
     })
 }
 

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -47,71 +47,69 @@ pub(crate) fn print_generic_bounds(
         bounds
             .iter()
             .filter(move |b| bounds_dup.insert(*b))
-            .map(|bound| bound.print(cx))
+            .map(|bound| print_generic_bound(bound, cx))
             .joined(" + ", f)
     })
 }
 
-impl clean::GenericParamDef {
-    pub(crate) fn print(&self, cx: &Context<'_>) -> impl Display {
-        fmt::from_fn(move |f| match &self.kind {
-            clean::GenericParamDefKind::Lifetime { outlives } => {
-                write!(f, "{}", self.name)?;
+pub(crate) fn print_generic_param_def(
+    generic_param: &clean::GenericParamDef,
+    cx: &Context<'_>,
+) -> impl Display {
+    fmt::from_fn(move |f| match &generic_param.kind {
+        clean::GenericParamDefKind::Lifetime { outlives } => {
+            write!(f, "{}", generic_param.name)?;
 
-                if !outlives.is_empty() {
-                    f.write_str(": ")?;
-                    outlives.iter().map(|lt| lt.print()).joined(" + ", f)?;
-                }
-
-                Ok(())
+            if !outlives.is_empty() {
+                f.write_str(": ")?;
+                outlives.iter().map(|lt| print_lifetime(lt)).joined(" + ", f)?;
             }
-            clean::GenericParamDefKind::Type { bounds, default, .. } => {
-                f.write_str(self.name.as_str())?;
 
-                if !bounds.is_empty() {
-                    f.write_str(": ")?;
-                    print_generic_bounds(bounds, cx).fmt(f)?;
-                }
+            Ok(())
+        }
+        clean::GenericParamDefKind::Type { bounds, default, .. } => {
+            f.write_str(generic_param.name.as_str())?;
 
-                if let Some(ty) = default {
-                    f.write_str(" = ")?;
-                    ty.print(cx).fmt(f)?;
-                }
-
-                Ok(())
+            if !bounds.is_empty() {
+                f.write_str(": ")?;
+                print_generic_bounds(bounds, cx).fmt(f)?;
             }
-            clean::GenericParamDefKind::Const { ty, default, .. } => {
-                write!(f, "const {}: ", self.name)?;
-                ty.print(cx).fmt(f)?;
 
-                if let Some(default) = default {
-                    f.write_str(" = ")?;
-                    if f.alternate() {
-                        write!(f, "{default}")?;
-                    } else {
-                        write!(f, "{}", Escape(default))?;
-                    }
-                }
-
-                Ok(())
+            if let Some(ty) = default {
+                f.write_str(" = ")?;
+                print_type(ty, cx).fmt(f)?;
             }
-        })
-    }
+
+            Ok(())
+        }
+        clean::GenericParamDefKind::Const { ty, default, .. } => {
+            write!(f, "const {}: ", generic_param.name)?;
+            print_type(ty, cx).fmt(f)?;
+
+            if let Some(default) = default {
+                f.write_str(" = ")?;
+                if f.alternate() {
+                    write!(f, "{default}")?;
+                } else {
+                    write!(f, "{}", Escape(default))?;
+                }
+            }
+
+            Ok(())
+        }
+    })
 }
 
-impl clean::Generics {
-    pub(crate) fn print(&self, cx: &Context<'_>) -> impl Display {
-        let mut real_params = self.params.iter().filter(|p| !p.is_synthetic_param()).peekable();
-        if real_params.peek().is_none() {
-            None
-        } else {
-            Some(
-                Wrapped::with_angle_brackets()
-                    .wrap_fn(move |f| real_params.clone().map(|g| g.print(cx)).joined(", ", f)),
-            )
-        }
-        .maybe_display()
+pub(crate) fn print_generics(generics: &clean::Generics, cx: &Context<'_>) -> impl Display {
+    let mut real_params = generics.params.iter().filter(|p| !p.is_synthetic_param()).peekable();
+    if real_params.peek().is_none() {
+        None
+    } else {
+        Some(Wrapped::with_angle_brackets().wrap_fn(move |f| {
+            real_params.clone().map(|g| print_generic_param_def(g, cx)).joined(", ", f)
+        }))
     }
+    .maybe_display()
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -125,7 +123,7 @@ fn print_where_predicate(predicate: &clean::WherePredicate, cx: &Context<'_>) ->
         match predicate {
             clean::WherePredicate::BoundPredicate { ty, bounds, bound_params } => {
                 print_higher_ranked_params_with_space(bound_params, cx, "for").fmt(f)?;
-                ty.print(cx).fmt(f)?;
+                print_type(ty, cx).fmt(f)?;
                 f.write_str(":")?;
                 if !bounds.is_empty() {
                     f.write_str(" ")?;
@@ -136,7 +134,7 @@ fn print_where_predicate(predicate: &clean::WherePredicate, cx: &Context<'_>) ->
             clean::WherePredicate::RegionPredicate { lifetime, bounds } => {
                 // We don't need to check `alternate` since we can be certain that neither
                 // the lifetime nor the bounds contain any characters which need escaping.
-                write!(f, "{}:", lifetime.print())?;
+                write!(f, "{}:", print_lifetime(lifetime))?;
                 if !bounds.is_empty() {
                     write!(f, " {}", print_generic_bounds(bounds, cx))?;
                 }
@@ -144,7 +142,12 @@ fn print_where_predicate(predicate: &clean::WherePredicate, cx: &Context<'_>) ->
             }
             clean::WherePredicate::EqPredicate { lhs, rhs } => {
                 let opts = WithOpts::from(f);
-                write!(f, "{} == {}", opts.display(lhs.print(cx)), opts.display(rhs.print(cx)))
+                write!(
+                    f,
+                    "{} == {}",
+                    opts.display(print_qpath_data(lhs, cx)),
+                    opts.display(print_term(rhs, cx)),
+                )
             }
         }
     })
@@ -229,92 +232,91 @@ pub(crate) fn print_where_clause(
     }))
 }
 
-impl clean::Lifetime {
-    pub(crate) fn print(&self) -> impl Display {
-        self.0.as_str()
-    }
+#[inline]
+pub(crate) fn print_lifetime(lt: &clean::Lifetime) -> &str {
+    lt.0.as_str()
 }
 
-impl clean::ConstantKind {
-    pub(crate) fn print(&self, tcx: TyCtxt<'_>) -> impl Display {
-        let expr = self.expr(tcx);
-        fmt::from_fn(move |f| {
+pub(crate) fn print_constant_kind(
+    constant_kind: &clean::ConstantKind,
+    tcx: TyCtxt<'_>,
+) -> impl Display {
+    let expr = constant_kind.expr(tcx);
+    fmt::from_fn(
+        move |f| {
             if f.alternate() { f.write_str(&expr) } else { write!(f, "{}", Escape(&expr)) }
-        })
-    }
+        },
+    )
 }
 
-impl clean::PolyTrait {
-    fn print(&self, cx: &Context<'_>) -> impl Display {
-        fmt::from_fn(move |f| {
-            print_higher_ranked_params_with_space(&self.generic_params, cx, "for").fmt(f)?;
-            self.trait_.print(cx).fmt(f)
-        })
-    }
+fn print_poly_trait(poly_trait: &clean::PolyTrait, cx: &Context<'_>) -> impl Display {
+    fmt::from_fn(move |f| {
+        print_higher_ranked_params_with_space(&poly_trait.generic_params, cx, "for").fmt(f)?;
+        print_path(&poly_trait.trait_, cx).fmt(f)
+    })
 }
 
-impl clean::GenericBound {
-    pub(crate) fn print(&self, cx: &Context<'_>) -> impl Display {
-        fmt::from_fn(move |f| match self {
-            clean::GenericBound::Outlives(lt) => write!(f, "{}", lt.print()),
-            clean::GenericBound::TraitBound(ty, modifiers) => {
-                // `const` and `[const]` trait bounds are experimental; don't render them.
-                let hir::TraitBoundModifiers { polarity, constness: _ } = modifiers;
-                f.write_str(match polarity {
-                    hir::BoundPolarity::Positive => "",
-                    hir::BoundPolarity::Maybe(_) => "?",
-                    hir::BoundPolarity::Negative(_) => "!",
-                })?;
-                ty.print(cx).fmt(f)
-            }
-            clean::GenericBound::Use(args) => {
-                f.write_str("use")?;
-                Wrapped::with_angle_brackets()
-                    .wrap_fn(|f| args.iter().map(|arg| arg.name()).joined(", ", f))
-                    .fmt(f)
-            }
-        })
-    }
+pub(crate) fn print_generic_bound(
+    generic_bound: &clean::GenericBound,
+    cx: &Context<'_>,
+) -> impl Display {
+    fmt::from_fn(move |f| match generic_bound {
+        clean::GenericBound::Outlives(lt) => f.write_str(print_lifetime(lt)),
+        clean::GenericBound::TraitBound(ty, modifiers) => {
+            // `const` and `[const]` trait bounds are experimental; don't render them.
+            let hir::TraitBoundModifiers { polarity, constness: _ } = modifiers;
+            f.write_str(match polarity {
+                hir::BoundPolarity::Positive => "",
+                hir::BoundPolarity::Maybe(_) => "?",
+                hir::BoundPolarity::Negative(_) => "!",
+            })?;
+            print_poly_trait(ty, cx).fmt(f)
+        }
+        clean::GenericBound::Use(args) => {
+            f.write_str("use")?;
+            Wrapped::with_angle_brackets()
+                .wrap_fn(|f| args.iter().map(|arg| arg.name()).joined(", ", f))
+                .fmt(f)
+        }
+    })
 }
 
-impl clean::GenericArgs {
-    fn print(&self, cx: &Context<'_>) -> impl Display {
-        fmt::from_fn(move |f| {
-            match self {
-                clean::GenericArgs::AngleBracketed { args, constraints } => {
-                    if !args.is_empty() || !constraints.is_empty() {
-                        Wrapped::with_angle_brackets()
-                            .wrap_fn(|f| {
-                                [Either::Left(args), Either::Right(constraints)]
-                                    .into_iter()
-                                    .flat_map(Either::factor_into_iter)
-                                    .map(|either| {
-                                        either.map_either(
-                                            |arg| arg.print(cx),
-                                            |constraint| constraint.print(cx),
-                                        )
-                                    })
-                                    .joined(", ", f)
-                            })
-                            .fmt(f)?;
-                    }
-                }
-                clean::GenericArgs::Parenthesized { inputs, output } => {
-                    Wrapped::with_parens()
-                        .wrap_fn(|f| inputs.iter().map(|ty| ty.print(cx)).joined(", ", f))
+fn print_generic_args(generic_args: &clean::GenericArgs, cx: &Context<'_>) -> impl Display {
+    fmt::from_fn(move |f| {
+        match generic_args {
+            clean::GenericArgs::AngleBracketed { args, constraints } => {
+                if !args.is_empty() || !constraints.is_empty() {
+                    Wrapped::with_angle_brackets()
+                        .wrap_fn(|f| {
+                            [Either::Left(args), Either::Right(constraints)]
+                                .into_iter()
+                                .flat_map(Either::factor_into_iter)
+                                .map(|either| {
+                                    either.map_either(
+                                        |arg| print_generic_arg(arg, cx),
+                                        |constraint| print_assoc_item_constraint(constraint, cx),
+                                    )
+                                })
+                                .joined(", ", f)
+                        })
                         .fmt(f)?;
-                    if let Some(ref ty) = *output {
-                        f.write_str(if f.alternate() { " -> " } else { " -&gt; " })?;
-                        ty.print(cx).fmt(f)?;
-                    }
-                }
-                clean::GenericArgs::ReturnTypeNotation => {
-                    f.write_str("(..)")?;
                 }
             }
-            Ok(())
-        })
-    }
+            clean::GenericArgs::Parenthesized { inputs, output } => {
+                Wrapped::with_parens()
+                    .wrap_fn(|f| inputs.iter().map(|ty| print_type(ty, cx)).joined(", ", f))
+                    .fmt(f)?;
+                if let Some(ref ty) = *output {
+                    f.write_str(if f.alternate() { " -> " } else { " -&gt; " })?;
+                    print_type(ty, cx).fmt(f)?;
+                }
+            }
+            clean::GenericArgs::ReturnTypeNotation => {
+                f.write_str("(..)")?;
+            }
+        }
+        Ok(())
+    })
 }
 
 // Possible errors when computing href link source for a `DefId`
@@ -684,7 +686,7 @@ fn resolved_path(
         }
     }
     if w.alternate() {
-        write!(w, "{}{:#}", last.name, last.args.print(cx))?;
+        write!(w, "{}{:#}", last.name, print_generic_args(&last.args, cx))?;
     } else {
         let path = fmt::from_fn(|f| {
             if use_absolute {
@@ -702,7 +704,7 @@ fn resolved_path(
                 write!(f, "{}", print_anchor(did, last.name, cx))
             }
         });
-        write!(w, "{path}{args}", args = last.args.print(cx))?;
+        write!(w, "{path}{args}", args = print_generic_args(&last.args, cx))?;
     }
     Ok(())
 }
@@ -791,11 +793,11 @@ fn print_tybounds(
     cx: &Context<'_>,
 ) -> impl Display {
     fmt::from_fn(move |f| {
-        bounds.iter().map(|bound| bound.print(cx)).joined(" + ", f)?;
+        bounds.iter().map(|bound| print_poly_trait(bound, cx)).joined(" + ", f)?;
         if let Some(lt) = lt {
             // We don't need to check `alternate` since we can be certain that
             // the lifetime doesn't contain any characters which need escaping.
-            write!(f, " + {}", lt.print())?;
+            write!(f, " + {}", print_lifetime(lt))?;
         }
         Ok(())
     })
@@ -810,7 +812,9 @@ fn print_higher_ranked_params_with_space(
         if !params.is_empty() {
             f.write_str(keyword)?;
             Wrapped::with_angle_brackets()
-                .wrap_fn(|f| params.iter().map(|lt| lt.print(cx)).joined(", ", f))
+                .wrap_fn(|f| {
+                    params.iter().map(|lt| print_generic_param_def(lt, cx)).joined(", ", f)
+                })
                 .fmt(f)?;
             f.write_char(' ')?;
         }
@@ -868,11 +872,11 @@ fn fmt_type(
             } else {
                 primitive_link(f, PrimitiveType::Fn, format_args!("fn"), cx)?;
             }
-            decl.decl.print(cx).fmt(f)
+            print_fn_decl(&decl.decl, cx).fmt(f)
         }
         clean::UnsafeBinder(binder) => {
             print_higher_ranked_params_with_space(&binder.generic_params, cx, "unsafe").fmt(f)?;
-            binder.ty.print(cx).fmt(f)
+            print_type(&binder.ty, cx).fmt(f)
         }
         clean::Tuple(typs) => match &typs[..] {
             &[] => primitive_link(f, PrimitiveType::Unit, format_args!("()"), cx),
@@ -881,7 +885,7 @@ fn fmt_type(
                     primitive_link(f, PrimitiveType::Tuple, format_args!("({name},)"), cx)
                 } else {
                     write!(f, "(")?;
-                    one.print(cx).fmt(f)?;
+                    print_type(one, cx).fmt(f)?;
                     write!(f, ",)")
                 }
             }
@@ -907,7 +911,7 @@ fn fmt_type(
                     )
                 } else {
                     Wrapped::with_parens()
-                        .wrap_fn(|f| many.iter().map(|item| item.print(cx)).joined(", ", f))
+                        .wrap_fn(|f| many.iter().map(|item| print_type(item, cx)).joined(", ", f))
                         .fmt(f)
                 }
             }
@@ -915,9 +919,9 @@ fn fmt_type(
         clean::Slice(box clean::Generic(name)) => {
             primitive_link(f, PrimitiveType::Slice, format_args!("[{name}]"), cx)
         }
-        clean::Slice(t) => Wrapped::with_square_brackets().wrap(t.print(cx)).fmt(f),
+        clean::Slice(t) => Wrapped::with_square_brackets().wrap(print_type(t, cx)).fmt(f),
         clean::Type::Pat(t, pat) => {
-            fmt::Display::fmt(&t.print(cx), f)?;
+            fmt::Display::fmt(&print_type(t, cx), f)?;
             write!(f, " is {pat}")
         }
         clean::Array(box clean::Generic(name), n) if !f.alternate() => primitive_link(
@@ -928,7 +932,7 @@ fn fmt_type(
         ),
         clean::Array(t, n) => Wrapped::with_square_brackets()
             .wrap(fmt::from_fn(|f| {
-                t.print(cx).fmt(f)?;
+                print_type(t, cx).fmt(f)?;
                 f.write_str("; ")?;
                 if f.alternate() {
                     f.write_str(n)
@@ -944,17 +948,17 @@ fn fmt_type(
                 primitive_link(
                     f,
                     clean::PrimitiveType::RawPointer,
-                    format_args!("*{m} {ty}", ty = WithOpts::from(f).display(t.print(cx))),
+                    format_args!("*{m} {ty}", ty = WithOpts::from(f).display(print_type(t, cx))),
                     cx,
                 )
             } else {
                 primitive_link(f, clean::PrimitiveType::RawPointer, format_args!("*{m} "), cx)?;
-                t.print(cx).fmt(f)
+                print_type(t, cx).fmt(f)
             }
         }
         clean::BorrowedRef { lifetime: l, mutability, type_: ty } => {
             let lt = fmt::from_fn(|f| match l {
-                Some(l) => write!(f, "{} ", l.print()),
+                Some(l) => write!(f, "{} ", print_lifetime(l)),
                 _ => Ok(()),
             });
             let m = mutability.print_with_space();
@@ -989,133 +993,133 @@ fn fmt_type(
             f.write_str("impl ")?;
             print_generic_bounds(bounds, cx).fmt(f)
         }
-        clean::QPath(qpath) => qpath.print(cx).fmt(f),
+        clean::QPath(qpath) => print_qpath_data(qpath, cx).fmt(f),
     }
 }
 
-impl clean::Type {
-    pub(crate) fn print(&self, cx: &Context<'_>) -> impl Display {
-        fmt::from_fn(move |f| fmt_type(self, f, false, cx))
-    }
+pub(crate) fn print_type(type_: &clean::Type, cx: &Context<'_>) -> impl Display {
+    fmt::from_fn(move |f| fmt_type(type_, f, false, cx))
 }
 
-impl clean::Path {
-    pub(crate) fn print(&self, cx: &Context<'_>) -> impl Display {
-        fmt::from_fn(move |f| resolved_path(f, self.def_id(), self, false, false, cx))
-    }
+pub(crate) fn print_path(path: &clean::Path, cx: &Context<'_>) -> impl Display {
+    fmt::from_fn(move |f| resolved_path(f, path.def_id(), path, false, false, cx))
 }
 
-impl clean::QPathData {
-    fn print(&self, cx: &Context<'_>) -> impl Display {
-        let Self { ref assoc, ref self_type, should_fully_qualify, ref trait_ } = *self;
+fn print_qpath_data(qpath_data: &clean::QPathData, cx: &Context<'_>) -> impl Display {
+    let clean::QPathData { ref assoc, ref self_type, should_fully_qualify, ref trait_ } =
+        *qpath_data;
 
-        fmt::from_fn(move |f| {
-            // FIXME(inherent_associated_types): Once we support non-ADT self-types (#106719),
-            // we need to surround them with angle brackets in some cases (e.g. `<dyn …>::P`).
+    fmt::from_fn(move |f| {
+        // FIXME(inherent_associated_types): Once we support non-ADT self-types (#106719),
+        // we need to surround them with angle brackets in some cases (e.g. `<dyn …>::P`).
 
-            if let Some(trait_) = trait_
-                && should_fully_qualify
-            {
-                let opts = WithOpts::from(f);
-                Wrapped::with_angle_brackets()
-                    .wrap(format_args!(
-                        "{} as {}",
-                        opts.display(self_type.print(cx)),
-                        opts.display(trait_.print(cx))
-                    ))
-                    .fmt(f)?
-            } else {
-                self_type.print(cx).fmt(f)?;
-            }
-            f.write_str("::")?;
-            // It's pretty unsightly to look at `<A as B>::C` in output, and
-            // we've got hyperlinking on our side, so try to avoid longer
-            // notation as much as possible by making `C` a hyperlink to trait
-            // `B` to disambiguate.
-            //
-            // FIXME: this is still a lossy conversion and there should probably
-            //        be a better way of representing this in general? Most of
-            //        the ugliness comes from inlining across crates where
-            //        everything comes in as a fully resolved QPath (hard to
-            //        look at).
-            if !f.alternate() {
-                // FIXME(inherent_associated_types): We always link to the very first associated
-                // type (in respect to source order) that bears the given name (`assoc.name`) and that is
-                // affiliated with the computed `DefId`. This is obviously incorrect when we have
-                // multiple impl blocks. Ideally, we would thread the `DefId` of the assoc ty itself
-                // through here and map it to the corresponding HTML ID that was generated by
-                // `render::Context::derive_id` when the impl blocks were rendered.
-                // There is no such mapping unfortunately.
-                // As a hack, we could badly imitate `derive_id` here by keeping *count* when looking
-                // for the assoc ty `DefId` in `tcx.associated_items(self_ty_did).in_definition_order()`
-                // considering privacy, `doc(hidden)`, etc.
-                // I don't feel like that right now :cold_sweat:.
+        if let Some(trait_) = trait_
+            && should_fully_qualify
+        {
+            let opts = WithOpts::from(f);
+            Wrapped::with_angle_brackets()
+                .wrap(format_args!(
+                    "{} as {}",
+                    opts.display(print_type(self_type, cx)),
+                    opts.display(print_path(trait_, cx))
+                ))
+                .fmt(f)?
+        } else {
+            print_type(self_type, cx).fmt(f)?;
+        }
+        f.write_str("::")?;
+        // It's pretty unsightly to look at `<A as B>::C` in output, and
+        // we've got hyperlinking on our side, so try to avoid longer
+        // notation as much as possible by making `C` a hyperlink to trait
+        // `B` to disambiguate.
+        //
+        // FIXME: this is still a lossy conversion and there should probably
+        //        be a better way of representing this in general? Most of
+        //        the ugliness comes from inlining across crates where
+        //        everything comes in as a fully resolved QPath (hard to
+        //        look at).
+        if !f.alternate() {
+            // FIXME(inherent_associated_types): We always link to the very first associated
+            // type (in respect to source order) that bears the given name (`assoc.name`) and that is
+            // affiliated with the computed `DefId`. This is obviously incorrect when we have
+            // multiple impl blocks. Ideally, we would thread the `DefId` of the assoc ty itself
+            // through here and map it to the corresponding HTML ID that was generated by
+            // `render::Context::derive_id` when the impl blocks were rendered.
+            // There is no such mapping unfortunately.
+            // As a hack, we could badly imitate `derive_id` here by keeping *count* when looking
+            // for the assoc ty `DefId` in `tcx.associated_items(self_ty_did).in_definition_order()`
+            // considering privacy, `doc(hidden)`, etc.
+            // I don't feel like that right now :cold_sweat:.
 
-                let parent_href = match trait_ {
-                    Some(trait_) => href(trait_.def_id(), cx).ok(),
-                    None => self_type.def_id(cx.cache()).and_then(|did| href(did, cx).ok()),
-                };
+            let parent_href = match trait_ {
+                Some(trait_) => href(trait_.def_id(), cx).ok(),
+                None => self_type.def_id(cx.cache()).and_then(|did| href(did, cx).ok()),
+            };
 
-                if let Some((url, _, path)) = parent_href {
-                    write!(
-                        f,
-                        "<a class=\"associatedtype\" href=\"{url}#{shortty}.{name}\" \
-                                    title=\"type {path}::{name}\">{name}</a>",
-                        shortty = ItemType::AssocType,
-                        name = assoc.name,
-                        path = join_path_syms(path),
-                    )
-                } else {
-                    write!(f, "{}", assoc.name)
-                }
+            if let Some((url, _, path)) = parent_href {
+                write!(
+                    f,
+                    "<a class=\"associatedtype\" href=\"{url}#{shortty}.{name}\" \
+                                title=\"type {path}::{name}\">{name}</a>",
+                    shortty = ItemType::AssocType,
+                    name = assoc.name,
+                    path = join_path_syms(path),
+                )
             } else {
                 write!(f, "{}", assoc.name)
-            }?;
+            }
+        } else {
+            write!(f, "{}", assoc.name)
+        }?;
 
-            assoc.args.print(cx).fmt(f)
-        })
-    }
+        print_generic_args(&assoc.args, cx).fmt(f)
+    })
+}
+
+pub(crate) fn print_impl(
+    impl_: &clean::Impl,
+    use_absolute: bool,
+    cx: &Context<'_>,
+) -> impl Display {
+    fmt::from_fn(move |f| {
+        f.write_str("impl")?;
+        print_generics(&impl_.generics, cx).fmt(f)?;
+        f.write_str(" ")?;
+
+        if let Some(ref ty) = impl_.trait_ {
+            if impl_.is_negative_trait_impl() {
+                f.write_char('!')?;
+            }
+            if impl_.kind.is_fake_variadic()
+                && let Some(generics) = ty.generics()
+                && let Ok(inner_type) = generics.exactly_one()
+            {
+                let last = ty.last();
+                if f.alternate() {
+                    write!(f, "{last}")?;
+                } else {
+                    write!(f, "{}", print_anchor(ty.def_id(), last, cx))?;
+                };
+                Wrapped::with_angle_brackets()
+                    .wrap_fn(|f| impl_.print_type(inner_type, f, use_absolute, cx))
+                    .fmt(f)?;
+            } else {
+                print_path(ty, cx).fmt(f)?;
+            }
+            f.write_str(" for ")?;
+        }
+
+        if let Some(ty) = impl_.kind.as_blanket_ty() {
+            fmt_type(ty, f, use_absolute, cx)?;
+        } else {
+            impl_.print_type(&impl_.for_, f, use_absolute, cx)?;
+        }
+
+        print_where_clause(&impl_.generics, cx, 0, Ending::Newline).maybe_display().fmt(f)
+    })
 }
 
 impl clean::Impl {
-    pub(crate) fn print(&self, use_absolute: bool, cx: &Context<'_>) -> impl Display {
-        fmt::from_fn(move |f| {
-            f.write_str("impl")?;
-            self.generics.print(cx).fmt(f)?;
-            f.write_str(" ")?;
-
-            if let Some(ref ty) = self.trait_ {
-                if self.is_negative_trait_impl() {
-                    f.write_char('!')?;
-                }
-                if self.kind.is_fake_variadic()
-                    && let Some(generics) = ty.generics()
-                    && let Ok(inner_type) = generics.exactly_one()
-                {
-                    let last = ty.last();
-                    if f.alternate() {
-                        write!(f, "{last}")?;
-                    } else {
-                        write!(f, "{}", print_anchor(ty.def_id(), last, cx))?;
-                    };
-                    Wrapped::with_angle_brackets()
-                        .wrap_fn(|f| self.print_type(inner_type, f, use_absolute, cx))
-                        .fmt(f)?;
-                } else {
-                    ty.print(cx).fmt(f)?;
-                }
-                f.write_str(" for ")?;
-            }
-
-            if let Some(ty) = self.kind.as_blanket_ty() {
-                fmt_type(ty, f, use_absolute, cx)?;
-            } else {
-                self.print_type(&self.for_, f, use_absolute, cx)?;
-            }
-
-            print_where_clause(&self.generics, cx, 0, Ending::Newline).maybe_display().fmt(f)
-        })
-    }
     fn print_type(
         &self,
         type_: &clean::Type,
@@ -1191,7 +1195,7 @@ pub(crate) fn print_params(params: &[clean::Parameter], cx: &Context<'_>) -> imp
                     if let Some(name) = param.name {
                         write!(f, "{name}: ")?;
                     }
-                    param.type_.print(cx).fmt(f)
+                    print_type(&param.type_, cx).fmt(f)
                 })
             })
             .joined(", ", f)
@@ -1221,76 +1225,73 @@ impl Display for Indent {
     }
 }
 
-impl clean::Parameter {
-    fn print(&self, cx: &Context<'_>) -> impl fmt::Display {
-        fmt::from_fn(move |f| {
-            if let Some(self_ty) = self.to_receiver() {
-                match self_ty {
-                    clean::SelfTy => f.write_str("self"),
-                    clean::BorrowedRef { lifetime, mutability, type_: box clean::SelfTy } => {
-                        f.write_str(if f.alternate() { "&" } else { "&amp;" })?;
-                        if let Some(lt) = lifetime {
-                            write!(f, "{lt} ", lt = lt.print())?;
-                        }
-                        write!(f, "{mutability}self", mutability = mutability.print_with_space())
+fn print_parameter(parameter: &clean::Parameter, cx: &Context<'_>) -> impl fmt::Display {
+    fmt::from_fn(move |f| {
+        if let Some(self_ty) = parameter.to_receiver() {
+            match self_ty {
+                clean::SelfTy => f.write_str("self"),
+                clean::BorrowedRef { lifetime, mutability, type_: box clean::SelfTy } => {
+                    f.write_str(if f.alternate() { "&" } else { "&amp;" })?;
+                    if let Some(lt) = lifetime {
+                        write!(f, "{lt} ", lt = print_lifetime(lt))?;
                     }
-                    _ => {
-                        f.write_str("self: ")?;
-                        self_ty.print(cx).fmt(f)
-                    }
+                    write!(f, "{mutability}self", mutability = mutability.print_with_space())
                 }
-            } else {
-                if self.is_const {
-                    write!(f, "const ")?;
+                _ => {
+                    f.write_str("self: ")?;
+                    print_type(self_ty, cx).fmt(f)
                 }
-                if let Some(name) = self.name {
-                    write!(f, "{name}: ")?;
-                }
-                self.type_.print(cx).fmt(f)
             }
-        })
-    }
+        } else {
+            if parameter.is_const {
+                write!(f, "const ")?;
+            }
+            if let Some(name) = parameter.name {
+                write!(f, "{name}: ")?;
+            }
+            print_type(&parameter.type_, cx).fmt(f)
+        }
+    })
+}
+
+fn print_fn_decl(fn_decl: &clean::FnDecl, cx: &Context<'_>) -> impl Display {
+    fmt::from_fn(move |f| {
+        let ellipsis = if fn_decl.c_variadic { ", ..." } else { "" };
+        Wrapped::with_parens()
+            .wrap_fn(|f| {
+                print_params(&fn_decl.inputs, cx).fmt(f)?;
+                f.write_str(ellipsis)
+            })
+            .fmt(f)?;
+        fn_decl.print_output(cx).fmt(f)
+    })
+}
+
+/// * `header_len`: The length of the function header and name. In other words, the number of
+///   characters in the function declaration up to but not including the parentheses.
+///   This is expected to go into a `<pre>`/`code-header` block, so indentation and newlines
+///   are preserved.
+/// * `indent`: The number of spaces to indent each successive line with, if line-wrapping is
+///   necessary.
+pub(crate) fn full_print_fn_decl(
+    fn_decl: &clean::FnDecl,
+    header_len: usize,
+    indent: usize,
+    cx: &Context<'_>,
+) -> impl Display {
+    fmt::from_fn(move |f| {
+        // First, generate the text form of the declaration, with no line wrapping, and count the bytes.
+        let mut counter = WriteCounter(0);
+        write!(&mut counter, "{:#}", fmt::from_fn(|f| { fn_decl.inner_full_print(None, f, cx) }))?;
+        // If the text form was over 80 characters wide, we will line-wrap our output.
+        let line_wrapping_indent = if header_len + counter.0 > 80 { Some(indent) } else { None };
+        // Generate the final output. This happens to accept `{:#}` formatting to get textual
+        // output but in practice it is only formatted with `{}` to get HTML output.
+        fn_decl.inner_full_print(line_wrapping_indent, f, cx)
+    })
 }
 
 impl clean::FnDecl {
-    pub(crate) fn print(&self, cx: &Context<'_>) -> impl Display {
-        fmt::from_fn(move |f| {
-            let ellipsis = if self.c_variadic { ", ..." } else { "" };
-            Wrapped::with_parens()
-                .wrap_fn(|f| {
-                    print_params(&self.inputs, cx).fmt(f)?;
-                    f.write_str(ellipsis)
-                })
-                .fmt(f)?;
-            self.print_output(cx).fmt(f)
-        })
-    }
-
-    /// * `header_len`: The length of the function header and name. In other words, the number of
-    ///   characters in the function declaration up to but not including the parentheses.
-    ///   This is expected to go into a `<pre>`/`code-header` block, so indentation and newlines
-    ///   are preserved.
-    /// * `indent`: The number of spaces to indent each successive line with, if line-wrapping is
-    ///   necessary.
-    pub(crate) fn full_print(
-        &self,
-        header_len: usize,
-        indent: usize,
-        cx: &Context<'_>,
-    ) -> impl Display {
-        fmt::from_fn(move |f| {
-            // First, generate the text form of the declaration, with no line wrapping, and count the bytes.
-            let mut counter = WriteCounter(0);
-            write!(&mut counter, "{:#}", fmt::from_fn(|f| { self.inner_full_print(None, f, cx) }))?;
-            // If the text form was over 80 characters wide, we will line-wrap our output.
-            let line_wrapping_indent =
-                if header_len + counter.0 > 80 { Some(indent) } else { None };
-            // Generate the final output. This happens to accept `{:#}` formatting to get textual
-            // output but in practice it is only formatted with `{}` to get HTML output.
-            self.inner_full_print(line_wrapping_indent, f, cx)
-        })
-    }
-
     fn inner_full_print(
         &self,
         // For None, the declaration will not be line-wrapped. For Some(n),
@@ -1316,7 +1317,7 @@ impl clean::FnDecl {
                         }
                     });
 
-                    self.inputs.iter().map(|param| param.print(cx)).joined(sep, f)?;
+                    self.inputs.iter().map(|param| print_parameter(param, cx)).joined(sep, f)?;
 
                     if line_wrapping_indent.is_some() {
                         writeln!(f, ",")?
@@ -1348,7 +1349,7 @@ impl clean::FnDecl {
             }
 
             f.write_str(if f.alternate() { " -> " } else { " -&gt; " })?;
-            self.output.print(cx).fmt(f)
+            print_type(&self.output, cx).fmt(f)
         })
     }
 }
@@ -1461,67 +1462,68 @@ pub(crate) fn print_constness_with_space(
     }
 }
 
-impl clean::Import {
-    pub(crate) fn print(&self, cx: &Context<'_>) -> impl Display {
-        fmt::from_fn(move |f| match self.kind {
-            clean::ImportKind::Simple(name) => {
-                if name == self.source.path.last() {
-                    write!(f, "use {};", self.source.print(cx))
-                } else {
-                    write!(f, "use {source} as {name};", source = self.source.print(cx))
-                }
+pub(crate) fn print_import(import: &clean::Import, cx: &Context<'_>) -> impl Display {
+    fmt::from_fn(move |f| match import.kind {
+        clean::ImportKind::Simple(name) => {
+            if name == import.source.path.last() {
+                write!(f, "use {};", print_import_source(&import.source, cx))
+            } else {
+                write!(
+                    f,
+                    "use {source} as {name};",
+                    source = print_import_source(&import.source, cx)
+                )
             }
-            clean::ImportKind::Glob => {
-                if self.source.path.segments.is_empty() {
-                    write!(f, "use *;")
-                } else {
-                    write!(f, "use {}::*;", self.source.print(cx))
-                }
+        }
+        clean::ImportKind::Glob => {
+            if import.source.path.segments.is_empty() {
+                write!(f, "use *;")
+            } else {
+                write!(f, "use {}::*;", print_import_source(&import.source, cx))
             }
-        })
-    }
+        }
+    })
 }
 
-impl clean::ImportSource {
-    pub(crate) fn print(&self, cx: &Context<'_>) -> impl Display {
-        fmt::from_fn(move |f| match self.did {
-            Some(did) => resolved_path(f, did, &self.path, true, false, cx),
-            _ => {
-                for seg in &self.path.segments[..self.path.segments.len() - 1] {
-                    write!(f, "{}::", seg.name)?;
-                }
-                let name = self.path.last();
-                if let hir::def::Res::PrimTy(p) = self.path.res {
-                    primitive_link(f, PrimitiveType::from(p), format_args!("{name}"), cx)?;
-                } else {
-                    f.write_str(name.as_str())?;
-                }
-                Ok(())
+fn print_import_source(import_source: &clean::ImportSource, cx: &Context<'_>) -> impl Display {
+    fmt::from_fn(move |f| match import_source.did {
+        Some(did) => resolved_path(f, did, &import_source.path, true, false, cx),
+        _ => {
+            for seg in &import_source.path.segments[..import_source.path.segments.len() - 1] {
+                write!(f, "{}::", seg.name)?;
             }
-        })
-    }
-}
-
-impl clean::AssocItemConstraint {
-    pub(crate) fn print(&self, cx: &Context<'_>) -> impl Display {
-        fmt::from_fn(move |f| {
-            f.write_str(self.assoc.name.as_str())?;
-            self.assoc.args.print(cx).fmt(f)?;
-            match self.kind {
-                clean::AssocItemConstraintKind::Equality { ref term } => {
-                    f.write_str(" = ")?;
-                    term.print(cx).fmt(f)?;
-                }
-                clean::AssocItemConstraintKind::Bound { ref bounds } => {
-                    if !bounds.is_empty() {
-                        f.write_str(": ")?;
-                        print_generic_bounds(bounds, cx).fmt(f)?;
-                    }
-                }
+            let name = import_source.path.last();
+            if let hir::def::Res::PrimTy(p) = import_source.path.res {
+                primitive_link(f, PrimitiveType::from(p), format_args!("{name}"), cx)?;
+            } else {
+                f.write_str(name.as_str())?;
             }
             Ok(())
-        })
-    }
+        }
+    })
+}
+
+fn print_assoc_item_constraint(
+    assoc_item_constraint: &clean::AssocItemConstraint,
+    cx: &Context<'_>,
+) -> impl Display {
+    fmt::from_fn(move |f| {
+        f.write_str(assoc_item_constraint.assoc.name.as_str())?;
+        print_generic_args(&assoc_item_constraint.assoc.args, cx).fmt(f)?;
+        match assoc_item_constraint.kind {
+            clean::AssocItemConstraintKind::Equality { ref term } => {
+                f.write_str(" = ")?;
+                print_term(term, cx).fmt(f)?;
+            }
+            clean::AssocItemConstraintKind::Bound { ref bounds } => {
+                if !bounds.is_empty() {
+                    f.write_str(": ")?;
+                    print_generic_bounds(bounds, cx).fmt(f)?;
+                }
+            }
+        }
+        Ok(())
+    })
 }
 
 pub(crate) fn print_abi_with_space(abi: ExternAbi) -> impl Display {
@@ -1538,22 +1540,18 @@ pub(crate) fn print_default_space(v: bool) -> &'static str {
     if v { "default " } else { "" }
 }
 
-impl clean::GenericArg {
-    pub(crate) fn print(&self, cx: &Context<'_>) -> impl Display {
-        fmt::from_fn(move |f| match self {
-            clean::GenericArg::Lifetime(lt) => lt.print().fmt(f),
-            clean::GenericArg::Type(ty) => ty.print(cx).fmt(f),
-            clean::GenericArg::Const(ct) => ct.print(cx.tcx()).fmt(f),
-            clean::GenericArg::Infer => Display::fmt("_", f),
-        })
-    }
+fn print_generic_arg(generic_arg: &clean::GenericArg, cx: &Context<'_>) -> impl Display {
+    fmt::from_fn(move |f| match generic_arg {
+        clean::GenericArg::Lifetime(lt) => f.write_str(print_lifetime(lt)),
+        clean::GenericArg::Type(ty) => print_type(ty, cx).fmt(f),
+        clean::GenericArg::Const(ct) => print_constant_kind(ct, cx.tcx()).fmt(f),
+        clean::GenericArg::Infer => Display::fmt("_", f),
+    })
 }
 
-impl clean::Term {
-    pub(crate) fn print(&self, cx: &Context<'_>) -> impl Display {
-        fmt::from_fn(move |f| match self {
-            clean::Term::Type(ty) => ty.print(cx).fmt(f),
-            clean::Term::Constant(ct) => ct.print(cx.tcx()).fmt(f),
-        })
-    }
+fn print_term(term: &clean::Term, cx: &Context<'_>) -> impl Display {
+    fmt::from_fn(move |f| match term {
+        clean::Term::Type(ty) => print_type(ty, cx).fmt(f),
+        clean::Term::Constant(ct) => print_constant_kind(ct, cx.tcx()).fmt(f),
+    })
 }

--- a/src/librustdoc/html/render/sidebar.rs
+++ b/src/librustdoc/html/render/sidebar.rs
@@ -13,6 +13,7 @@ use super::{Context, ItemSection, item_ty_to_section};
 use crate::clean;
 use crate::formats::Impl;
 use crate::formats::item_type::ItemType;
+use crate::html::format::{print_path, print_type};
 use crate::html::markdown::{IdMap, MarkdownWithToc};
 use crate::html::render::print_item::compare_names;
 
@@ -558,8 +559,8 @@ fn sidebar_deref_methods<'a>(
                 };
                 let title = format!(
                     "Methods from {:#}<Target={:#}>",
-                    impl_.inner_impl().trait_.as_ref().unwrap().print(cx),
-                    real_target.print(cx),
+                    print_path(impl_.inner_impl().trait_.as_ref().unwrap(), cx),
+                    print_type(real_target, cx),
                 );
                 // We want links' order to be reproducible so we don't use unstable sort.
                 ret.sort();
@@ -690,7 +691,7 @@ fn sidebar_render_assoc_items(
                     ty::ImplPolarity::Positive | ty::ImplPolarity::Reservation => "",
                     ty::ImplPolarity::Negative => "!",
                 };
-                let generated = Link::new(encoded, format!("{prefix}{:#}", trait_.print(cx)));
+                let generated = Link::new(encoded, format!("{prefix}{:#}", print_path(trait_, cx)));
                 if links.insert(generated.clone()) { Some(generated) } else { None }
             })
             .collect::<Vec<Link<'static>>>();

--- a/src/librustdoc/html/render/write_shared.rs
+++ b/src/librustdoc/html/render/write_shared.rs
@@ -44,6 +44,7 @@ use crate::docfs::PathError;
 use crate::error::Error;
 use crate::formats::Impl;
 use crate::formats::item_type::ItemType;
+use crate::html::format::{print_impl, print_path};
 use crate::html::layout;
 use crate::html::render::ordered_json::{EscapedJson, OrderedJson};
 use crate::html::render::search_index::{SerializedSearchIndex, build_index};
@@ -605,7 +606,7 @@ impl TypeAliasPart {
                                 .inner_impl()
                                 .trait_
                                 .as_ref()
-                                .map(|trait_| format!("{:#}", trait_.print(cx)));
+                                .map(|trait_| format!("{:#}", print_path(trait_, cx)));
                             ret = Some(AliasSerializableImpl {
                                 text,
                                 trait_,
@@ -704,7 +705,7 @@ impl TraitAliasPart {
                         None
                     } else {
                         Some(Implementor {
-                            text: imp.inner_impl().print(false, cx).to_string(),
+                            text: print_impl(imp.inner_impl(), false, cx).to_string(),
                             synthetic: imp.inner_impl().kind.is_auto(),
                             types: collect_paths_for_type(&imp.inner_impl().for_, cache),
                         })

--- a/src/tools/miri/tests/fail/alloc/alloc_error_handler.stderr
+++ b/src/tools/miri/tests/fail/alloc/alloc_error_handler.stderr
@@ -1,11 +1,15 @@
 memory allocation of 4 bytes failed
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+note: in Miri, you may have to set `MIRIFLAGS=-Zmiri-env-forward=RUST_BACKTRACE` for the environment variable to have an effect
 error: abnormal termination: the program aborted execution
   --> RUSTLIB/std/src/alloc.rs:LL:CC
    |
-LL |     crate::process::abort()
-   |     ^^^^^^^^^^^^^^^^^^^^^^^ abnormal termination occurred here
+LL |         crate::process::abort()
+   |         ^^^^^^^^^^^^^^^^^^^^^^^ abnormal termination occurred here
    |
    = note: BACKTRACE:
+   = note: inside closure at RUSTLIB/std/src/alloc.rs:LL:CC
+   = note: inside `std::sys::backtrace::__rust_end_short_backtrace::<{closure@std::alloc::rust_oom::{closure#0}}, !>` at RUSTLIB/std/src/sys/backtrace.rs:LL:CC
    = note: inside `std::alloc::rust_oom` at RUSTLIB/std/src/alloc.rs:LL:CC
    = note: inside `std::alloc::_::__rust_alloc_error_handler` at RUSTLIB/std/src/alloc.rs:LL:CC
    = note: inside `std::alloc::handle_alloc_error::rt_error` at RUSTLIB/alloc/src/alloc.rs:LL:CC

--- a/src/tools/miri/tests/fail/intrinsics/simd-funnel_shl-too-far.rs
+++ b/src/tools/miri/tests/fail/intrinsics/simd-funnel_shl-too-far.rs
@@ -1,0 +1,12 @@
+#![feature(core_intrinsics, portable_simd)]
+
+use std::intrinsics::simd::simd_funnel_shl;
+use std::simd::*;
+
+fn main() {
+    unsafe {
+        let x = i32x2::from_array([1, 1]);
+        let y = i32x2::from_array([100, 0]);
+        simd_funnel_shl(x, x, y); //~ERROR: overflowing shift by 100 in `simd_funnel_shl` in lane 0
+    }
+}

--- a/src/tools/miri/tests/fail/intrinsics/simd-funnel_shl-too-far.stderr
+++ b/src/tools/miri/tests/fail/intrinsics/simd-funnel_shl-too-far.stderr
@@ -1,0 +1,13 @@
+error: Undefined Behavior: overflowing shift by 100 in `simd_funnel_shl` in lane 0
+  --> tests/fail/intrinsics/simd-funnel_shl-too-far.rs:LL:CC
+   |
+LL |         simd_funnel_shl(x, x, y);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^ Undefined Behavior occurred here
+   |
+   = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
+   = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
+
+note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
+
+error: aborting due to 1 previous error
+

--- a/src/tools/miri/tests/fail/intrinsics/simd-funnel_shr-too-far.rs
+++ b/src/tools/miri/tests/fail/intrinsics/simd-funnel_shr-too-far.rs
@@ -1,0 +1,12 @@
+#![feature(core_intrinsics, portable_simd)]
+
+use std::intrinsics::simd::simd_funnel_shr;
+use std::simd::*;
+
+fn main() {
+    unsafe {
+        let x = i32x2::from_array([1, 1]);
+        let y = i32x2::from_array([20, 40]);
+        simd_funnel_shr(x, x, y); //~ERROR: overflowing shift by 40 in `simd_funnel_shr` in lane 1
+    }
+}

--- a/src/tools/miri/tests/fail/intrinsics/simd-funnel_shr-too-far.stderr
+++ b/src/tools/miri/tests/fail/intrinsics/simd-funnel_shr-too-far.stderr
@@ -1,0 +1,13 @@
+error: Undefined Behavior: overflowing shift by 40 in `simd_funnel_shr` in lane 1
+  --> tests/fail/intrinsics/simd-funnel_shr-too-far.rs:LL:CC
+   |
+LL |         simd_funnel_shr(x, x, y);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^ Undefined Behavior occurred here
+   |
+   = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
+   = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
+
+note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
+
+error: aborting due to 1 previous error
+

--- a/src/tools/miri/tests/pass/intrinsics/portable-simd.rs
+++ b/src/tools/miri/tests/pass/intrinsics/portable-simd.rs
@@ -62,7 +62,7 @@ impl<T: Copy, const N: usize> PackedSimd<T, N> {
 #[rustc_nounwind]
 pub unsafe fn simd_shuffle_const_generic<T, U, const IDX: &'static [u32]>(x: T, y: T) -> U;
 
-pub fn simd_ops_f16() {
+fn simd_ops_f16() {
     use intrinsics::*;
 
     // small hack to make type inference better
@@ -273,7 +273,7 @@ fn simd_ops_f64() {
     assert_eq!(f64x2::from_array([f64::NAN, 0.0]).reduce_min(), 0.0);
 }
 
-pub fn simd_ops_f128() {
+fn simd_ops_f128() {
     use intrinsics::*;
 
     // small hack to make type inference better
@@ -454,6 +454,18 @@ fn simd_ops_i32() {
             0x3fffffffu32 as i32
         ])
     );
+
+    // these values are taken from the doctests of `u32::funnel_shl` and `u32::funnel_shr`
+    let c = u32x4::splat(0x010000b3);
+    let d = u32x4::splat(0x2fe78e45);
+
+    unsafe {
+        assert_eq!(intrinsics::simd_funnel_shl(c, d, u32x4::splat(0)), c);
+        assert_eq!(intrinsics::simd_funnel_shl(c, d, u32x4::splat(8)), u32x4::splat(0x0000b32f));
+
+        assert_eq!(intrinsics::simd_funnel_shr(c, d, u32x4::splat(0)), d);
+        assert_eq!(intrinsics::simd_funnel_shr(c, d, u32x4::splat(8)), u32x4::splat(0xb32fe78e));
+    }
 }
 
 fn simd_mask() {

--- a/tests/rustdoc/jump-to-def/shebang.rs
+++ b/tests/rustdoc/jump-to-def/shebang.rs
@@ -1,0 +1,15 @@
+#!/path/to/my/interpreter
+//@ compile-flags: -Zunstable-options --generate-link-to-definition
+
+// Ensure that we can successfully generate links to definitions in the presence of shebang.
+// Implementation-wise, shebang is not a token that's emitted by the lexer. Instead, we need
+// to offset the actual lexing which is tricky due to all the byte index and span calculations
+// in the Classifier.
+
+fn scope() {
+//@ has 'src/shebang/shebang.rs.html'
+//@ has - '//a[@href="#15"]' 'function'
+    function();
+}
+
+fn function() {}

--- a/tests/rustdoc/source-code-pages/frontmatter.rs
+++ b/tests/rustdoc/source-code-pages/frontmatter.rs
@@ -1,0 +1,10 @@
+--- json
+{"edition": "2024"}
+---
+#![feature(frontmatter)]
+
+// Test that we highlight frontmatter as comments on source code pages.
+
+//@ has 'src/frontmatter/frontmatter.rs.html'
+//@ has - '//pre[@class="rust"]//span[@class="comment"]' \
+//        '--- json {"edition": "2024"} ---'

--- a/tests/rustdoc/source-code-pages/shebang.rs
+++ b/tests/rustdoc/source-code-pages/shebang.rs
@@ -1,0 +1,6 @@
+#!/path/to/somewhere 0 if false ""
+
+// Test that we highlight shebang as comments on source code pages.
+
+//@ has 'src/shebang/shebang.rs.html'
+//@ has - '//pre[@class="rust"]//span[@class="comment"]' '#!/path/to/somewhere 0 if false ""'

--- a/tests/ui/async-await/async-closures/ice-async-closure-variance-issue-148488.stderr
+++ b/tests/ui/async-await/async-closures/ice-async-closure-variance-issue-148488.stderr
@@ -11,6 +11,12 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
    |
 LL | fn ord<a>() -> _ {
    |                ^ not allowed in type signatures
+   |
+help: replace with an appropriate return type
+   |
+LL - fn ord<a>() -> _ {
+LL + fn ord<a>() -> impl AsyncFn() {
+   |
 
 error[E0392]: lifetime parameter `'g` is never used
   --> $DIR/ice-async-closure-variance-issue-148488.rs:3:10

--- a/tests/ui/async-await/async-closures/suggest-impl-async-fn-issue-148493.fixed
+++ b/tests/ui/async-await/async-closures/suggest-impl-async-fn-issue-148493.fixed
@@ -1,0 +1,64 @@
+#![allow(dead_code)]
+//@ run-rustfix
+//@ edition: 2021
+
+// The suggestion should be `impl AsyncFn()` instead of something like `{async closure@...}`
+
+fn test1() -> impl AsyncFn() {
+    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for return types
+    //~| HELP replace with an appropriate return type
+    //~| SUGGESTION impl AsyncFn()
+    async || {}
+}
+
+fn test2() -> impl AsyncFn(i32) -> i32 {
+    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for return types
+    //~| HELP replace with an appropriate return type
+    //~| SUGGESTION impl AsyncFn(i32) -> i32
+    async |x: i32| x + 1
+}
+
+fn test3() -> impl AsyncFn(i32, i32) -> i32 {
+    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for return types
+    //~| HELP replace with an appropriate return type
+    //~| SUGGESTION impl AsyncFn(i32, i32) -> i32
+    async |x: i32, y: i32| x + y
+}
+
+fn test4() -> impl AsyncFn() {
+    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for return types
+    //~| HELP replace with an appropriate return type
+    //~| SUGGESTION impl AsyncFn()
+    async || -> () { () }
+}
+
+fn test5() -> impl AsyncFn() -> i32 {
+    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for return types
+    //~| HELP replace with an appropriate return type
+    //~| SUGGESTION impl AsyncFn() -> i32
+    let z = 42;
+    async move || z
+}
+
+fn test6() -> impl AsyncFnMut() -> i32 {
+    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for return types
+    //~| HELP replace with an appropriate return type
+    //~| SUGGESTION impl AsyncFnMut() -> i32
+    let mut x = 0;
+    async move || {
+        x += 1;
+        x
+    }
+}
+
+fn test7() -> impl AsyncFnOnce() {
+    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for return types
+    //~| HELP replace with an appropriate return type
+    //~| SUGGESTION impl AsyncFnOnce()
+    let s = String::from("hello");
+    async move || {
+        drop(s);
+    }
+}
+
+fn main() {}

--- a/tests/ui/async-await/async-closures/suggest-impl-async-fn-issue-148493.rs
+++ b/tests/ui/async-await/async-closures/suggest-impl-async-fn-issue-148493.rs
@@ -1,0 +1,64 @@
+#![allow(dead_code)]
+//@ run-rustfix
+//@ edition: 2021
+
+// The suggestion should be `impl AsyncFn()` instead of something like `{async closure@...}`
+
+fn test1() -> _ {
+    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for return types
+    //~| HELP replace with an appropriate return type
+    //~| SUGGESTION impl AsyncFn()
+    async || {}
+}
+
+fn test2() -> _ {
+    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for return types
+    //~| HELP replace with an appropriate return type
+    //~| SUGGESTION impl AsyncFn(i32) -> i32
+    async |x: i32| x + 1
+}
+
+fn test3() -> _ {
+    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for return types
+    //~| HELP replace with an appropriate return type
+    //~| SUGGESTION impl AsyncFn(i32, i32) -> i32
+    async |x: i32, y: i32| x + y
+}
+
+fn test4() -> _ {
+    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for return types
+    //~| HELP replace with an appropriate return type
+    //~| SUGGESTION impl AsyncFn()
+    async || -> () { () }
+}
+
+fn test5() -> _ {
+    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for return types
+    //~| HELP replace with an appropriate return type
+    //~| SUGGESTION impl AsyncFn() -> i32
+    let z = 42;
+    async move || z
+}
+
+fn test6() -> _ {
+    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for return types
+    //~| HELP replace with an appropriate return type
+    //~| SUGGESTION impl AsyncFnMut() -> i32
+    let mut x = 0;
+    async move || {
+        x += 1;
+        x
+    }
+}
+
+fn test7() -> _ {
+    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for return types
+    //~| HELP replace with an appropriate return type
+    //~| SUGGESTION impl AsyncFnOnce()
+    let s = String::from("hello");
+    async move || {
+        drop(s);
+    }
+}
+
+fn main() {}

--- a/tests/ui/async-await/async-closures/suggest-impl-async-fn-issue-148493.stderr
+++ b/tests/ui/async-await/async-closures/suggest-impl-async-fn-issue-148493.stderr
@@ -1,0 +1,87 @@
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
+  --> $DIR/suggest-impl-async-fn-issue-148493.rs:7:15
+   |
+LL | fn test1() -> _ {
+   |               ^ not allowed in type signatures
+   |
+help: replace with an appropriate return type
+   |
+LL - fn test1() -> _ {
+LL + fn test1() -> impl AsyncFn() {
+   |
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
+  --> $DIR/suggest-impl-async-fn-issue-148493.rs:14:15
+   |
+LL | fn test2() -> _ {
+   |               ^ not allowed in type signatures
+   |
+help: replace with an appropriate return type
+   |
+LL - fn test2() -> _ {
+LL + fn test2() -> impl AsyncFn(i32) -> i32 {
+   |
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
+  --> $DIR/suggest-impl-async-fn-issue-148493.rs:21:15
+   |
+LL | fn test3() -> _ {
+   |               ^ not allowed in type signatures
+   |
+help: replace with an appropriate return type
+   |
+LL - fn test3() -> _ {
+LL + fn test3() -> impl AsyncFn(i32, i32) -> i32 {
+   |
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
+  --> $DIR/suggest-impl-async-fn-issue-148493.rs:28:15
+   |
+LL | fn test4() -> _ {
+   |               ^ not allowed in type signatures
+   |
+help: replace with an appropriate return type
+   |
+LL - fn test4() -> _ {
+LL + fn test4() -> impl AsyncFn() {
+   |
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
+  --> $DIR/suggest-impl-async-fn-issue-148493.rs:35:15
+   |
+LL | fn test5() -> _ {
+   |               ^ not allowed in type signatures
+   |
+help: replace with an appropriate return type
+   |
+LL - fn test5() -> _ {
+LL + fn test5() -> impl AsyncFn() -> i32 {
+   |
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
+  --> $DIR/suggest-impl-async-fn-issue-148493.rs:43:15
+   |
+LL | fn test6() -> _ {
+   |               ^ not allowed in type signatures
+   |
+help: replace with an appropriate return type
+   |
+LL - fn test6() -> _ {
+LL + fn test6() -> impl AsyncFnMut() -> i32 {
+   |
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
+  --> $DIR/suggest-impl-async-fn-issue-148493.rs:54:15
+   |
+LL | fn test7() -> _ {
+   |               ^ not allowed in type signatures
+   |
+help: replace with an appropriate return type
+   |
+LL - fn test7() -> _ {
+LL + fn test7() -> impl AsyncFnOnce() {
+   |
+
+error: aborting due to 7 previous errors
+
+For more information about this error, try `rustc --explain E0121`.

--- a/tests/ui/macros/macro-hygiene-help-issue-148580.rs
+++ b/tests/ui/macros/macro-hygiene-help-issue-148580.rs
@@ -1,0 +1,15 @@
+macro_rules! print_it { {} => { println!("{:?}", it); } }
+//~^ ERROR cannot find value `it` in this scope
+
+fn main() {
+    {
+        let it = "hello";
+    }
+    {
+        let it = "world";
+        {
+            let it = ();
+            print_it!();
+        }
+    }
+}

--- a/tests/ui/macros/macro-hygiene-help-issue-148580.stderr
+++ b/tests/ui/macros/macro-hygiene-help-issue-148580.stderr
@@ -1,0 +1,19 @@
+error[E0425]: cannot find value `it` in this scope
+  --> $DIR/macro-hygiene-help-issue-148580.rs:1:50
+   |
+LL | macro_rules! print_it { {} => { println!("{:?}", it); } }
+   |                                                  ^^ not found in this scope
+...
+LL |             print_it!();
+   |             ----------- in this macro invocation
+   |
+help: an identifier with the same name exists, but is not accessible due to macro hygiene
+  --> $DIR/macro-hygiene-help-issue-148580.rs:11:17
+   |
+LL |             let it = ();
+   |                 ^^
+   = note: this error originates in the macro `print_it` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/macros/macro-hygiene-scope-15167.stderr
+++ b/tests/ui/macros/macro-hygiene-scope-15167.stderr
@@ -7,6 +7,11 @@ LL | macro_rules! f { () => (n) }
 LL |         println!("{}", f!());
    |                        ---- in this macro invocation
    |
+help: an identifier with the same name exists, but is not accessible due to macro hygiene
+  --> $DIR/macro-hygiene-scope-15167.rs:12:9
+   |
+LL |     for n in 0..1 {
+   |         ^
    = note: this error originates in the macro `f` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0425]: cannot find value `n` in this scope
@@ -18,6 +23,11 @@ LL | macro_rules! f { () => (n) }
 LL |         println!("{}", f!());
    |                        ---- in this macro invocation
    |
+help: an identifier with the same name exists, but is not accessible due to macro hygiene
+  --> $DIR/macro-hygiene-scope-15167.rs:16:17
+   |
+LL |     if let Some(n) = None {
+   |                 ^
    = note: this error originates in the macro `f` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0425]: cannot find value `n` in this scope
@@ -29,6 +39,11 @@ LL | macro_rules! f { () => (n) }
 LL |         println!("{}", f!());
    |                        ---- in this macro invocation
    |
+help: an identifier with the same name exists, but is not accessible due to macro hygiene
+  --> $DIR/macro-hygiene-scope-15167.rs:21:24
+   |
+LL |     } else if let Some(n) = None {
+   |                        ^
    = note: this error originates in the macro `f` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0425]: cannot find value `n` in this scope
@@ -40,6 +55,11 @@ LL | macro_rules! f { () => (n) }
 LL |         println!("{}", f!());
    |                        ---- in this macro invocation
    |
+help: an identifier with the same name exists, but is not accessible due to macro hygiene
+  --> $DIR/macro-hygiene-scope-15167.rs:25:20
+   |
+LL |     while let Some(n) = None {
+   |                    ^
    = note: this error originates in the macro `f` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 4 previous errors

--- a/tests/ui/macros/metavar-expressions/concat-hygiene.stderr
+++ b/tests/ui/macros/metavar-expressions/concat-hygiene.stderr
@@ -7,6 +7,11 @@ LL |         ${concat($lhs, $rhs)}
 LL |     let _another = join!(abc, def);
    |                    --------------- in this macro invocation
    |
+help: an identifier with the same name exists, but is not accessible due to macro hygiene
+  --> $DIR/concat-hygiene.rs:11:9
+   |
+LL |     let abcdef = 1;
+   |         ^^^^^^
    = note: this error originates in the macro `join` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error

--- a/tests/ui/proc-macro/gen-macro-rules-hygiene.stderr
+++ b/tests/ui/proc-macro/gen-macro-rules-hygiene.stderr
@@ -18,6 +18,11 @@ LL | gen_macro_rules!();
 LL |         generated!();
    |         ------------ in this macro invocation
    |
+help: an identifier with the same name exists, but is not accessible due to macro hygiene
+  --> $DIR/gen-macro-rules-hygiene.rs:19:13
+   |
+LL |         let local_use = 1;
+   |             ^^^^^^^^^
    = note: this error originates in the macro `generated` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0425]: cannot find value `local_def` in this scope

--- a/tests/ui/proc-macro/mixed-site-span.stderr
+++ b/tests/ui/proc-macro/mixed-site-span.stderr
@@ -594,6 +594,11 @@ error[E0425]: cannot find value `local_use` in this scope
 LL |         proc_macro_rules!();
    |         ^^^^^^^^^^^^^^^^^^^ help: a local variable with a similar name exists: `local_def`
    |
+help: an identifier with the same name exists, but is not accessible due to macro hygiene
+  --> $DIR/mixed-site-span.rs:21:13
+   |
+LL |         let local_use = 1;
+   |             ^^^^^^^^^
    = note: this error originates in the macro `proc_macro_rules` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0425]: cannot find value `local_def` in this scope

--- a/tests/ui/proc-macro/weird-hygiene.stderr
+++ b/tests/ui/proc-macro/weird-hygiene.stderr
@@ -7,6 +7,11 @@ LL |             Value = (stringify!($tokens + hidden_ident), 1).1
 LL |     other!(50);
    |     ---------- in this macro invocation
    |
+help: an identifier with the same name exists, but is not accessible due to macro hygiene
+  --> $DIR/weird-hygiene.rs:44:9
+   |
+LL |     let hidden_ident = "Hello1";
+   |         ^^^^^^^^^^^^
    = note: this error originates in the macro `inner` which comes from the expansion of the macro `other` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0425]: cannot find value `hidden_ident` in this scope
@@ -18,6 +23,11 @@ LL |             hidden_ident
 LL |     invoke_it!(25);
    |     -------------- in this macro invocation
    |
+help: an identifier with the same name exists, but is not accessible due to macro hygiene
+  --> $DIR/weird-hygiene.rs:44:9
+   |
+LL |     let hidden_ident = "Hello1";
+   |         ^^^^^^^^^^^^
    = note: this error originates in the macro `invoke_it` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#147534 (Implement SIMD funnel shifts in const-eval/Miri)
 - rust-lang/rust#147686 (update isolate_highest_one for NonZero<T>)
 - rust-lang/rust#148020 (Show backtrace on allocation failures when possible)
 - rust-lang/rust#148204 (Modify contributor email entries in .mailmap)
 - rust-lang/rust#148230 (rustdoc: Properly highlight shebang, frontmatter & weak keywords in source code pages and code blocks)
 - rust-lang/rust#148279 (rustc_builtin_macros: rename bench parameter to avoid collisions with user-defined function names)
 - rust-lang/rust#148555 (Fix rust-by-example spanish translation)
 - rust-lang/rust#148556 (Fix suggestion for returning async closures)
 - rust-lang/rust#148585 ([rustdoc] Replace `print` methods with functions to improve code readability)
 - rust-lang/rust#148600 (re-use `self.get_all_attrs` result for pass indirectly attribute)
 - rust-lang/rust#148612 (Add note for identifier with attempted hygiene violation)
 - rust-lang/rust#148613 (Switch hexagon targets to rust-lld)
 - rust-lang/rust#148619 (Enable std locking functions on AIX)
 - rust-lang/rust#148644 ([bootstrap] Make `--open` option work with `doc src/tools/error_index_generator`)
 - rust-lang/rust#148649 (don't completely reset `HeadUsages`)
 - rust-lang/rust#148675 (Remove eslint-js from npm dependencies)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=147534,147686,148020,148204,148230,148279,148555,148556,148585,148600,148612,148613,148619,148644,148649,148675)
<!-- homu-ignore:end -->