### PR TITLE
std: use `nonpoison::Mutex` for all internal mutexes

### DIFF
--- a/library/std/src/io/stdio/tests.rs
+++ b/library/std/src/io/stdio/tests.rs
@@ -122,21 +122,21 @@ where
     let th1 = {
         let (log, tx) = (Arc::clone(&log), tx1);
         thread::spawn(move || {
-            log.lock().unwrap().push(Start1);
+            log.lock().push(Start1);
             let handle = get_handle();
             {
                 let locked = handle.lock();
-                log.lock().unwrap().push(Acquire1);
+                log.lock().push(Acquire1);
                 tx.send(Acquire1).unwrap(); // notify of acquisition
                 tx.send(Release1).unwrap(); // wait for release command
-                log.lock().unwrap().push(Release1);
+                log.lock().push(Release1);
             }
             tx.send(Acquire1).unwrap(); // wait for th2 acquire
             {
                 let locked = handle.lock();
-                log.lock().unwrap().push(Acquire1);
+                log.lock().push(Acquire1);
             }
-            log.lock().unwrap().push(Release1);
+            log.lock().push(Release1);
         })
     };
     let th2 = {
@@ -144,14 +144,14 @@ where
         thread::spawn(move || {
             tx.send(Start2).unwrap(); // wait for start command
             let locked = get_locked();
-            log.lock().unwrap().push(Acquire2);
+            log.lock().push(Acquire2);
             tx.send(Acquire2).unwrap(); // notify of acquisition
             tx.send(Release2).unwrap(); // wait for release command
-            log.lock().unwrap().push(Release2);
+            log.lock().push(Release2);
         })
     };
     assert_eq!(rx1.recv().unwrap(), Acquire1); // wait for th1 acquire
-    log.lock().unwrap().push(Start2);
+    log.lock().push(Start2);
     assert_eq!(rx2.recv().unwrap(), Start2); // block th2
     assert_eq!(rx1.recv().unwrap(), Release1); // release th1
     assert_eq!(rx2.recv().unwrap(), Acquire2); // wait for th2 acquire
@@ -160,7 +160,7 @@ where
     th2.join().unwrap();
     th1.join().unwrap();
     assert_eq!(
-        *log.lock().unwrap(),
+        *log.lock(),
         [Start1, Acquire1, Start2, Release1, Acquire2, Release2, Acquire1, Release1]
     );
 }

--- a/library/std/src/sys/backtrace.rs
+++ b/library/std/src/sys/backtrace.rs
@@ -5,7 +5,7 @@ use crate::backtrace_rs::{self, BacktraceFmt, BytesOrWideString, PrintFmt};
 use crate::borrow::Cow;
 use crate::io::prelude::*;
 use crate::path::{self, Path, PathBuf};
-use crate::sync::{Mutex, MutexGuard, PoisonError};
+use crate::sync::nonpoison::{Mutex, MutexGuard};
 use crate::{env, fmt, io};
 
 /// Max number of frames to print.
@@ -15,7 +15,7 @@ pub(crate) struct BacktraceLock<'a>(#[allow(dead_code)] MutexGuard<'a, ()>);
 
 pub(crate) fn lock<'a>() -> BacktraceLock<'a> {
     static LOCK: Mutex<()> = Mutex::new(());
-    BacktraceLock(LOCK.lock().unwrap_or_else(PoisonError::into_inner))
+    BacktraceLock(LOCK.lock())
 }
 
 impl BacktraceLock<'_> {

--- a/library/std/src/sys/pal/unix/stack_overflow/thread_info.rs
+++ b/library/std/src/sys/pal/unix/stack_overflow/thread_info.rs
@@ -27,8 +27,8 @@
 use crate::collections::BTreeMap;
 use crate::hint::spin_loop;
 use crate::ops::Range;
-use crate::sync::Mutex;
 use crate::sync::atomic::{AtomicUsize, Ordering};
+use crate::sync::nonpoison::Mutex;
 use crate::sys::os::errno_location;
 
 pub struct ThreadInfo {

--- a/library/std/src/sys/process/windows.rs
+++ b/library/std/src/sys/process/windows.rs
@@ -16,7 +16,7 @@ use crate::os::windows::io::{AsHandle, AsRawHandle, BorrowedHandle, FromRawHandl
 use crate::os::windows::process::ProcThreadAttributeList;
 use crate::path::{Path, PathBuf};
 use crate::process::StdioPipes;
-use crate::sync::Mutex;
+use crate::sync::nonpoison::Mutex;
 use crate::sys::args::{self, Arg};
 use crate::sys::c::{self, EXIT_FAILURE, EXIT_SUCCESS};
 use crate::sys::fs::{File, OpenOptions};

--- a/library/std/src/sys/thread/sgx.rs
+++ b/library/std/src/sys/thread/sgx.rs
@@ -12,7 +12,7 @@ pub use self::task_queue::JoinNotifier;
 
 mod task_queue {
     use super::wait_notify;
-    use crate::sync::{Mutex, MutexGuard};
+    use crate::sync::nonpoison::{Mutex, MutexGuard};
 
     pub type JoinHandle = wait_notify::Waiter;
 
@@ -48,7 +48,7 @@ mod task_queue {
     static TASK_QUEUE: Mutex<Vec<Task>> = Mutex::new(Vec::new());
 
     pub(super) fn lock() -> MutexGuard<'static, Vec<Task>> {
-        TASK_QUEUE.lock().unwrap()
+        TASK_QUEUE.lock()
     }
 }
 

--- a/library/std/src/thread/mod.rs
+++ b/library/std/src/thread/mod.rs
@@ -1257,11 +1257,11 @@ impl ThreadId {
                 }
             }
             _ => {
-                use crate::sync::{Mutex, PoisonError};
+                use crate::sync::nonpoison::Mutex;
 
                 static COUNTER: Mutex<u64> = Mutex::new(0);
 
-                let mut counter = COUNTER.lock().unwrap_or_else(PoisonError::into_inner);
+                let mut counter = COUNTER.lock();
                 let Some(id) = counter.checked_add(1) else {
                     // in case the panic handler ends up calling `ThreadId::new()`,
                     // avoid reentrant lock acquire.


### PR DESCRIPTION
Under the hopefully reasonable assumption that `std`'s code is bug-free, all of the mutexes switched here will never be poisoned. The only poisoning mutex left is the one used for output capturing, as that has subtle effects on what gets captured.