### PR TITLE
Fix query cycle when encounter unevaluated const

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/mod.rs
@@ -635,9 +635,10 @@ pub fn try_evaluate_const<'tcx>(
                         return Err(EvaluateConstErr::HasGenericsOrInfers);
                     }
 
-                    let typing_env = infcx
-                        .typing_env(tcx.erase_and_anonymize_regions(param_env))
-                        .with_post_analysis_normalized(tcx);
+                    // Since there is no generic parameter, we can just drop the environment
+                    // to prevent query cycle.
+                    let typing_env = infcx.typing_env(ty::ParamEnv::empty());
+
                     (uv.args, typing_env)
                 }
             };

--- a/tests/ui/traits/next-solver/unevaluated_const_query_cycle.rs
+++ b/tests/ui/traits/next-solver/unevaluated_const_query_cycle.rs
@@ -1,0 +1,20 @@
+//@ compile-flags: -Znext-solver
+//@ check-pass
+
+// Regression test for https://github.com/rust-lang/trait-system-refactor-initiative/issues/249
+
+const CONST: &str = "hi";
+
+trait ToUnit {
+    type Assoc;
+}
+impl<T> ToUnit for T {
+    type Assoc = ();
+}
+
+fn foo()
+where
+    <[u8; CONST.len()] as ToUnit>::Assoc: Sized,
+{}
+
+fn main(){}


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Fixes https://github.com/rust-lang/trait-system-refactor-initiative/issues/249

In this PR, the environment is dropped when evaluating const that does not have any generic parameter to fix the query cycle.
