### PR TITLE
Use `overflow_checks` intrinsic so `IterRangeFrom` yields MAX before panicking in debug

### DIFF
--- a/library/core/src/range/iter.rs
+++ b/library/core/src/range/iter.rs
@@ -168,7 +168,7 @@ impl<A: Step> IterRangeInclusive<A> {
     }
 }
 
-#[unstable(feature = "trusted_random_access", issue = "none")]
+#[unstable(feature = "new_range_api", issue = "125687")]
 impl<A: Step> Iterator for IterRangeInclusive<A> {
     type Item = A;
 
@@ -302,7 +302,7 @@ impl<A> IterRangeFrom<A> {
     }
 }
 
-#[unstable(feature = "trusted_random_access", issue = "none")]
+#[unstable(feature = "new_range_api", issue = "125687")]
 impl<A: Step> Iterator for IterRangeFrom<A> {
     type Item = A;
 

--- a/tests/codegen-llvm/iterrangefrom-overflow-checks.rs
+++ b/tests/codegen-llvm/iterrangefrom-overflow-checks.rs
@@ -1,0 +1,27 @@
+// With -Coverflow-checks=yes (enabled by default by -Cdebug-assertions=yes) we will produce a
+// runtime check that panics after yielding the maximum value of the range bound type. That is
+// tested for by tests/ui/iterators/rangefrom-overflow-overflow-checks.rs
+//
+// This test ensures that such a runtime check is *not* emitted when debug-assertions are
+// enabled, but overflow-checks are explicitly disabled.
+
+//@ revisions: DEBUG NOCHECKS
+//@ compile-flags: -O -Cdebug-assertions=yes
+//@ [NOCHECKS] compile-flags: -Coverflow-checks=no
+
+#![crate_type = "lib"]
+#![feature(new_range_api)]
+use std::range::{IterRangeFrom, RangeFrom};
+
+// CHECK-LABEL: @iterrangefrom_remainder(
+#[no_mangle]
+pub unsafe fn iterrangefrom_remainder(x: IterRangeFrom<i32>) -> RangeFrom<i32> {
+    //        DEBUG: i32 noundef %x
+    //     NOCHECKS: i32 noundef returned %x
+    //        DEBUG: br i1
+    //        DEBUG: call core::panicking::panic_const::panic_const_add_overflow
+    //        DEBUG: unreachable
+    // NOCHECKS-NOT: unreachable
+    //     NOCHECKS: ret i32 %x
+    x.remainder()
+}

--- a/tests/ui/iterators/iterrangefrom.rs
+++ b/tests/ui/iterators/iterrangefrom.rs
@@ -1,0 +1,23 @@
+//@ run-pass
+//@ compile-flags: -C overflow-checks=yes
+
+#![feature(new_range_api)]
+
+use std::{iter, range};
+
+fn main() {
+    for (a, b) in iter::zip(0_u32..256, range::RangeFrom::from(0_u8..)) {
+        assert_eq!(a, u32::from(b));
+    }
+
+    let mut a = range::RangeFrom::from(0_u8..).into_iter();
+    let mut b = 0_u8..;
+    assert_eq!(a.next(), b.next());
+    assert_eq!(a.nth(5), b.nth(5));
+    assert_eq!(a.nth(0), b.next());
+
+    let mut a = range::RangeFrom::from(0_u8..).into_iter();
+    let mut b = 0_u8..;
+    assert_eq!(a.nth(5), b.nth(5));
+    assert_eq!(a.nth(0), b.next());
+}

--- a/tests/ui/iterators/rangefrom-overflow-debug.rs
+++ b/tests/ui/iterators/rangefrom-overflow-debug.rs
@@ -1,0 +1,17 @@
+//@ run-pass
+//@ needs-unwind
+//@ compile-flags: -O -C debug_assertions=yes
+
+#![feature(new_range_api)]
+
+use std::panic;
+
+fn main() {
+    let mut it = core::range::RangeFrom::from(u8::MAX..).into_iter();
+    assert_eq!(it.next().unwrap(), 255);
+
+    let r = panic::catch_unwind(|| {
+        let _ = it.remainder();
+    });
+    assert!(r.is_err());
+}

--- a/tests/ui/iterators/rangefrom-overflow-ndebug.rs
+++ b/tests/ui/iterators/rangefrom-overflow-ndebug.rs
@@ -1,0 +1,10 @@
+//@ run-pass
+//@ compile-flags: -O -C debug_assertions=no
+
+#![feature(new_range_api)]
+
+fn main() {
+    let mut it = core::range::RangeFrom::from(u8::MAX..).into_iter();
+    assert_eq!(it.next().unwrap(), 255);
+    assert_eq!(it.remainder().start, u8::MIN);
+}

--- a/tests/ui/iterators/rangefrom-overflow-overflow-checks.rs
+++ b/tests/ui/iterators/rangefrom-overflow-overflow-checks.rs
@@ -1,0 +1,48 @@
+//@ run-pass
+//@ needs-unwind
+//@ compile-flags: -O -C overflow-checks=yes
+
+#![feature(new_range_api)]
+
+use std::panic;
+
+fn main() {
+    let mut it = core::range::RangeFrom::from(u8::MAX..).into_iter();
+    assert_eq!(it.next().unwrap(), 255);
+
+    let r = panic::catch_unwind(move || {
+        let _ = it.remainder();
+    });
+    assert!(r.is_err());
+
+    let mut it = core::range::RangeFrom::from(u8::MAX..).into_iter();
+    assert_eq!(it.next().unwrap(), 255);
+
+    let r = panic::catch_unwind(move || {
+        let _ = it.next();
+    });
+    assert!(r.is_err());
+
+    let mut it = core::range::RangeFrom::from(u8::MAX..).into_iter();
+    assert_eq!(it.next().unwrap(), 255);
+
+    let r = panic::catch_unwind(move || {
+        let _ = it.nth(0);
+    });
+    assert!(r.is_err());
+
+    let mut it = core::range::RangeFrom::from(u8::MAX-1..).into_iter();
+    assert_eq!(it.nth(1).unwrap(), 255);
+
+    let r = panic::catch_unwind(move || {
+        let _ = it.next();
+    });
+    assert!(r.is_err());
+
+    let mut it = core::range::RangeFrom::from(u8::MAX-1..).into_iter();
+
+    let r = panic::catch_unwind(move || {
+        let _ = it.nth(2);
+    });
+    assert!(r.is_err());
+}


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Based on rust-lang/rust#128666. For your convenience, here is the [diff from that PR](https://github.com/pitaj/rust/compare/intrinsic-overflow_checks...pitaj:rust:rangefrom-overflow_checks).

When `overflow_checks` are enabled, the following code will output as shown
```rust
for n in std::range::RangeFrom::from(253_u8..) {
    println!("{n}");
}
// 253
// 254
// 255
// panic
```

Which is a change from the current behavior, where it will panic after printing 254.

This behavior was [requested by the libs team](https://github.com/rust-lang/rust/issues/125687#issuecomment-2151118208)

r? @Mark-Simulacrum