### PR TITLE
fix: disable self-contained linker when bootstrap-override-lld is set

### DIFF
--- a/src/bootstrap/src/utils/helpers.rs
+++ b/src/bootstrap/src/utils/helpers.rs
@@ -430,6 +430,7 @@ pub fn linker_flags(
         match builder.config.bootstrap_override_lld {
             BootstrapOverrideLld::External => {
                 args.push("-Clinker-features=+lld".to_string());
+                args.push("-Clink-self-contained=-linker".to_string());
                 args.push("-Zunstable-options".to_string());
             }
             BootstrapOverrideLld::SelfContained => {


### PR DESCRIPTION
Part of rust-lang/rust#148708.

Makes `rust.bootstrap-override-lld` set to `true` or `"external"` disable self-contained linker — actually using linker from one's system.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
