### PR TITLE
Point at span within local macros even when error happens in nested external macro

### DIFF
--- a/compiler/rustc_errors/src/emitter.rs
+++ b/compiler/rustc_errors/src/emitter.rs
@@ -474,9 +474,12 @@ pub trait Emitter {
             .chain(span.span_labels().iter().map(|sp_label| sp_label.span))
             .filter_map(|sp| {
                 if !sp.is_dummy() && source_map.is_imported(sp) {
-                    let maybe_callsite = sp.source_callsite();
-                    if sp != maybe_callsite {
-                        return Some((sp, maybe_callsite));
+                    let mut span = sp;
+                    while let Some(callsite) = span.parent_callsite() {
+                        span = callsite;
+                        if !source_map.is_imported(span) {
+                            return Some((sp, span));
+                        }
                     }
                 }
                 None

--- a/src/tools/miri/tests/fail/panic/tls_macro_drop_panic.rs
+++ b/src/tools/miri/tests/fail/panic/tls_macro_drop_panic.rs
@@ -1,7 +1,7 @@
 //@error-in-other-file: aborted execution
 // Backtraces vary wildly between platforms, we have to normalize away almost the entire thing
 //@normalize-stderr-test: "'main'|'<unnamed>'" -> "$$NAME"
-//@normalize-stderr-test: ".*(note|-->|\|).*\n" -> ""
+//@normalize-stderr-test: ".*(note|-->|:::|\|).*\n" -> ""
 
 pub struct NoisyDrop {}
 

--- a/tests/ui-fulldeps/rustc-dev-remap.only-remap.stderr
+++ b/tests/ui-fulldeps/rustc-dev-remap.only-remap.stderr
@@ -18,6 +18,9 @@ help: the following other types implement trait `VisitorResult`
    = note: `ControlFlow<T>`
 note: required by a bound in `rustc_ast::visit::Visitor::Result`
   --> /rustc-dev/xyz/compiler/rustc_ast/src/visit.rs:LL:COL
+  ::: /rustc-dev/xyz/compiler/rustc_ast/src/visit.rs:LL:COL
+   |
+   = note: in this macro invocation
    = note: this error originates in the macro `common_visitor_and_walkers` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error

--- a/tests/ui-fulldeps/rustc-dev-remap.remap-unremap.stderr
+++ b/tests/ui-fulldeps/rustc-dev-remap.remap-unremap.stderr
@@ -20,8 +20,11 @@ LL | impl<T> VisitorResult for ControlFlow<T> {
 note: required by a bound in `rustc_ast::visit::Visitor::Result`
   --> $COMPILER_DIR_REAL/rustc_ast/src/visit.rs:LL:COL
    |
+LL |                 type Result: VisitorResult = ();
+   |                              ^^^^^^^^^^^^^ required by this bound in `Visitor::Result`
+...
 LL | common_visitor_and_walkers!(Visitor<'a>);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `Visitor::Result`
+   | ---------------------------------------- in this macro invocation
    = note: this error originates in the macro `common_visitor_and_walkers` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error

--- a/tests/ui-fulldeps/session-diagnostic/diagnostic-derive-doc-comment-field.stderr
+++ b/tests/ui-fulldeps/session-diagnostic/diagnostic-derive-doc-comment-field.stderr
@@ -15,6 +15,9 @@ LL | struct NotIntoDiagArg;
    = help: normalized in stderr
 note: required by a bound in `Diag::<'a, G>::arg`
   --> $COMPILER_DIR/rustc_errors/src/diagnostic.rs:LL:CC
+  ::: $COMPILER_DIR/rustc_errors/src/diagnostic.rs:LL:CC
+   |
+   = note: in this macro invocation
    = note: this error originates in the macro `with_fn` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotIntoDiagArg: IntoDiagArg` is not satisfied
@@ -34,6 +37,9 @@ LL | struct NotIntoDiagArg;
    = help: normalized in stderr
 note: required by a bound in `Diag::<'a, G>::arg`
   --> $COMPILER_DIR/rustc_errors/src/diagnostic.rs:LL:CC
+  ::: $COMPILER_DIR/rustc_errors/src/diagnostic.rs:LL:CC
+   |
+   = note: in this macro invocation
    = note: this error originates in the macro `with_fn` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors

--- a/tests/ui-fulldeps/session-diagnostic/diagnostic-derive.stderr
+++ b/tests/ui-fulldeps/session-diagnostic/diagnostic-derive.stderr
@@ -665,6 +665,9 @@ LL | struct Hello {}
    = help: normalized in stderr
 note: required by a bound in `Diag::<'a, G>::arg`
   --> $COMPILER_DIR/rustc_errors/src/diagnostic.rs:LL:CC
+  ::: $COMPILER_DIR/rustc_errors/src/diagnostic.rs:LL:CC
+   |
+   = note: in this macro invocation
    = note: this error originates in the macro `with_fn` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 85 previous errors

--- a/tests/ui/binop/binary-op-suggest-deref.stderr
+++ b/tests/ui/binop/binary-op-suggest-deref.stderr
@@ -305,13 +305,19 @@ LL |     let _ = FOO & (*"Sized".to_string().into_boxed_str());
 help: the following other types implement trait `BitAnd<Rhs>`
   --> $SRC_DIR/core/src/ops/bit.rs:LL:COL
    |
-   = note: `&i32` implements `BitAnd<i32>`
+   = note: `i32` implements `BitAnd`
+  ::: $SRC_DIR/core/src/ops/bit.rs:LL:COL
    |
-   = note: `&i32` implements `BitAnd`
+   = note: in this macro invocation
+  --> $SRC_DIR/core/src/internal_macros.rs:LL:COL
+   |
+   = note: `&i32` implements `BitAnd<i32>`
+  ::: $SRC_DIR/core/src/internal_macros.rs:LL:COL
    |
    = note: `i32` implements `BitAnd<&i32>`
+  ::: $SRC_DIR/core/src/internal_macros.rs:LL:COL
    |
-   = note: `i32` implements `BitAnd`
+   = note: `&i32` implements `BitAnd`
    = note: this error originates in the macro `bitand_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `str` cannot be known at compilation time

--- a/tests/ui/binop/binop-mul-i32-f32.stderr
+++ b/tests/ui/binop/binop-mul-i32-f32.stderr
@@ -8,13 +8,19 @@ LL |     x * y
 help: the following other types implement trait `Mul<Rhs>`
   --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
    |
-   = note: `&i32` implements `Mul<i32>`
+   = note: `i32` implements `Mul`
+  ::: $SRC_DIR/core/src/ops/arith.rs:LL:COL
    |
-   = note: `&i32` implements `Mul`
+   = note: in this macro invocation
+  --> $SRC_DIR/core/src/internal_macros.rs:LL:COL
+   |
+   = note: `&i32` implements `Mul<i32>`
+  ::: $SRC_DIR/core/src/internal_macros.rs:LL:COL
    |
    = note: `i32` implements `Mul<&i32>`
+  ::: $SRC_DIR/core/src/internal_macros.rs:LL:COL
    |
-   = note: `i32` implements `Mul`
+   = note: `&i32` implements `Mul`
    = note: this error originates in the macro `mul_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error

--- a/tests/ui/const-generics/adt_const_params/const_param_ty_bad.stderr
+++ b/tests/ui/const-generics/adt_const_params/const_param_ty_bad.stderr
@@ -84,6 +84,9 @@ LL |     check(&mut () as *mut ());
    |
 help: the trait `ConstParamTy_` is implemented for `()`
   --> $SRC_DIR/core/src/marker.rs:LL:COL
+  ::: $SRC_DIR/core/src/marker.rs:LL:COL
+   |
+   = note: in this macro invocation
 note: required by a bound in `check`
   --> $DIR/const_param_ty_bad.rs:4:18
    |
@@ -101,6 +104,9 @@ LL |     check(&() as *const ());
    |
 help: the trait `ConstParamTy_` is implemented for `()`
   --> $SRC_DIR/core/src/marker.rs:LL:COL
+  ::: $SRC_DIR/core/src/marker.rs:LL:COL
+   |
+   = note: in this macro invocation
 note: required by a bound in `check`
   --> $DIR/const_param_ty_bad.rs:4:18
    |

--- a/tests/ui/consts/const-eval/const-eval-overflow-3b.stderr
+++ b/tests/ui/consts/const-eval/const-eval-overflow-3b.stderr
@@ -14,13 +14,19 @@ LL |     = [0; (i8::MAX + 1u8) as usize];
 help: the following other types implement trait `Add<Rhs>`
   --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
    |
-   = note: `&i8` implements `Add<i8>`
+   = note: `i8` implements `Add`
+  ::: $SRC_DIR/core/src/ops/arith.rs:LL:COL
    |
-   = note: `&i8` implements `Add`
+   = note: in this macro invocation
+  --> $SRC_DIR/core/src/internal_macros.rs:LL:COL
+   |
+   = note: `&i8` implements `Add<i8>`
+  ::: $SRC_DIR/core/src/internal_macros.rs:LL:COL
    |
    = note: `i8` implements `Add<&i8>`
+  ::: $SRC_DIR/core/src/internal_macros.rs:LL:COL
    |
-   = note: `i8` implements `Add`
+   = note: `&i8` implements `Add`
    = note: this error originates in the macro `add_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors

--- a/tests/ui/consts/const-eval/const-eval-overflow-4b.stderr
+++ b/tests/ui/consts/const-eval/const-eval-overflow-4b.stderr
@@ -14,13 +14,19 @@ LL |     : [u32; (i8::MAX as i8 + 1u8) as usize]
 help: the following other types implement trait `Add<Rhs>`
   --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
    |
-   = note: `&i8` implements `Add<i8>`
+   = note: `i8` implements `Add`
+  ::: $SRC_DIR/core/src/ops/arith.rs:LL:COL
    |
-   = note: `&i8` implements `Add`
+   = note: in this macro invocation
+  --> $SRC_DIR/core/src/internal_macros.rs:LL:COL
+   |
+   = note: `&i8` implements `Add<i8>`
+  ::: $SRC_DIR/core/src/internal_macros.rs:LL:COL
    |
    = note: `i8` implements `Add<&i8>`
+  ::: $SRC_DIR/core/src/internal_macros.rs:LL:COL
    |
-   = note: `i8` implements `Add`
+   = note: `&i8` implements `Add`
    = note: this error originates in the macro `add_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0604]: only `u8` can be cast as `char`, not `i8`

--- a/tests/ui/consts/const-eval/issue-85155.stderr
+++ b/tests/ui/consts/const-eval/issue-85155.stderr
@@ -5,10 +5,13 @@ LL |         let _ = 1 / ((IMM >= MIN && IMM <= MAX) as usize);
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `post_monomorphization_error::ValidateConstImm::<2, 0, 1>::VALID` failed here
 
 note: erroneous constant encountered
-  --> $DIR/auxiliary/post_monomorphization_error.rs:19:5
+  --> $DIR/auxiliary/post_monomorphization_error.rs:13:17
    |
+LL |         let _ = $crate::ValidateConstImm::<$imm, 0, { (1 << 1) - 1 }>::VALID;
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+...
 LL |     static_assert_imm1!(IMM1);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ------------------------- in this macro invocation
    |
    = note: this note originates in the macro `static_assert_imm1` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/const-eval/parse_ints.stderr
+++ b/tests/ui/consts/const-eval/parse_ints.stderr
@@ -6,8 +6,14 @@ LL | const _TOO_LOW: () = { u64::from_str_radix("12345ABCD", 1); };
    |
 note: inside `core::num::<impl u64>::from_str_radix`
   --> $SRC_DIR/core/src/num/mod.rs:LL:COL
+  ::: $SRC_DIR/core/src/num/mod.rs:LL:COL
+   |
+   = note: in this macro invocation
 note: inside `core::num::<impl u64>::from_ascii_radix`
   --> $SRC_DIR/core/src/num/mod.rs:LL:COL
+  ::: $SRC_DIR/core/src/num/mod.rs:LL:COL
+   |
+   = note: in this macro invocation
    = note: this error originates in the macro `from_str_int_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0080]: evaluation panicked: from_ascii_radix: radix must lie in the range `[2, 36]`
@@ -18,8 +24,14 @@ LL | const _TOO_HIGH: () = { u64::from_str_radix("12345ABCD", 37); };
    |
 note: inside `core::num::<impl u64>::from_str_radix`
   --> $SRC_DIR/core/src/num/mod.rs:LL:COL
+  ::: $SRC_DIR/core/src/num/mod.rs:LL:COL
+   |
+   = note: in this macro invocation
 note: inside `core::num::<impl u64>::from_ascii_radix`
   --> $SRC_DIR/core/src/num/mod.rs:LL:COL
+  ::: $SRC_DIR/core/src/num/mod.rs:LL:COL
+   |
+   = note: in this macro invocation
    = note: this error originates in the macro `from_str_int_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors

--- a/tests/ui/consts/const-ptr-is-null.stderr
+++ b/tests/ui/consts/const-ptr-is-null.stderr
@@ -5,9 +5,16 @@ LL |     assert!(!ptr.wrapping_sub(512).is_null());
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `MAYBE_NULL` failed inside this call
    |
 note: inside `std::ptr::const_ptr::<impl *const i32>::is_null`
+  --> $SRC_DIR/core/src/intrinsics/mod.rs:LL:COL
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+  ::: $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+   |
+   = note: in this macro invocation
 note: inside `std::ptr::const_ptr::<impl *const T>::is_null::compiletime`
+  --> $SRC_DIR/core/src/panic.rs:LL:COL
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+   |
+   = note: in this macro invocation
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/const_transmute_type_id2.stderr
+++ b/tests/ui/consts/const_transmute_type_id2.stderr
@@ -5,7 +5,11 @@ LL |     assert!(a == b);
    |             ^^^^^^ evaluation of `_` failed inside this call
    |
 note: inside `<TypeId as PartialEq>::eq`
+  --> $SRC_DIR/core/src/intrinsics/mod.rs:LL:COL
   --> $SRC_DIR/core/src/any.rs:LL:COL
+  ::: $SRC_DIR/core/src/any.rs:LL:COL
+   |
+   = note: in this macro invocation
 note: inside `<TypeId as PartialEq>::eq::compiletime`
   --> $SRC_DIR/core/src/any.rs:LL:COL
    = note: this error originates in the macro `$crate::intrinsics::const_eval_select` which comes from the expansion of the macro `crate::intrinsics::const_eval_select` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/consts/const_transmute_type_id3.stderr
+++ b/tests/ui/consts/const_transmute_type_id3.stderr
@@ -5,7 +5,11 @@ LL |     assert!(a == b);
    |             ^^^^^^ evaluation of `_` failed inside this call
    |
 note: inside `<TypeId as PartialEq>::eq`
+  --> $SRC_DIR/core/src/intrinsics/mod.rs:LL:COL
   --> $SRC_DIR/core/src/any.rs:LL:COL
+  ::: $SRC_DIR/core/src/any.rs:LL:COL
+   |
+   = note: in this macro invocation
 note: inside `<TypeId as PartialEq>::eq::compiletime`
   --> $SRC_DIR/core/src/any.rs:LL:COL
    = note: this error originates in the macro `$crate::intrinsics::const_eval_select` which comes from the expansion of the macro `crate::intrinsics::const_eval_select` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/consts/const_transmute_type_id4.stderr
+++ b/tests/ui/consts/const_transmute_type_id4.stderr
@@ -5,7 +5,11 @@ LL |     assert!(a == b);
    |             ^^^^^^ evaluation of `_` failed inside this call
    |
 note: inside `<TypeId as PartialEq>::eq`
+  --> $SRC_DIR/core/src/intrinsics/mod.rs:LL:COL
   --> $SRC_DIR/core/src/any.rs:LL:COL
+  ::: $SRC_DIR/core/src/any.rs:LL:COL
+   |
+   = note: in this macro invocation
 note: inside `<TypeId as PartialEq>::eq::compiletime`
   --> $SRC_DIR/core/src/any.rs:LL:COL
    = note: this error originates in the macro `$crate::intrinsics::const_eval_select` which comes from the expansion of the macro `crate::intrinsics::const_eval_select` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/consts/const_transmute_type_id5.stderr
+++ b/tests/ui/consts/const_transmute_type_id5.stderr
@@ -5,7 +5,11 @@ LL |     assert!(b == b);
    |             ^^^^^^ evaluation of `_` failed inside this call
    |
 note: inside `<TypeId as PartialEq>::eq`
+  --> $SRC_DIR/core/src/intrinsics/mod.rs:LL:COL
   --> $SRC_DIR/core/src/any.rs:LL:COL
+  ::: $SRC_DIR/core/src/any.rs:LL:COL
+   |
+   = note: in this macro invocation
 note: inside `<TypeId as PartialEq>::eq::compiletime`
   --> $SRC_DIR/core/src/any.rs:LL:COL
    = note: this error originates in the macro `$crate::intrinsics::const_eval_select` which comes from the expansion of the macro `crate::intrinsics::const_eval_select` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/consts/const_transmute_type_id6.stderr
+++ b/tests/ui/consts/const_transmute_type_id6.stderr
@@ -5,7 +5,11 @@ LL |     id == id
    |     ^^^^^^^^ evaluation of `X` failed inside this call
    |
 note: inside `<TypeId as PartialEq>::eq`
+  --> $SRC_DIR/core/src/intrinsics/mod.rs:LL:COL
   --> $SRC_DIR/core/src/any.rs:LL:COL
+  ::: $SRC_DIR/core/src/any.rs:LL:COL
+   |
+   = note: in this macro invocation
 note: inside `<TypeId as PartialEq>::eq::compiletime`
   --> $SRC_DIR/core/src/any.rs:LL:COL
    = note: this error originates in the macro `$crate::intrinsics::const_eval_select` which comes from the expansion of the macro `crate::intrinsics::const_eval_select` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/consts/timeout.stderr
+++ b/tests/ui/consts/timeout.stderr
@@ -1,5 +1,10 @@
 error: constant evaluation is taking a long time
+  --> $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
+   |
   --> $SRC_DIR/core/src/num/mod.rs:LL:COL
+  ::: $SRC_DIR/core/src/num/mod.rs:LL:COL
+   |
+   = note: in this macro invocation
    |
    = note: this lint makes sure the compiler doesn't get stuck due to infinite loops in const eval.
            If your compilation actually takes a long time, you can safely allow the lint.

--- a/tests/ui/hygiene/cross-crate-name-hiding-2.stderr
+++ b/tests/ui/hygiene/cross-crate-name-hiding-2.stderr
@@ -4,10 +4,10 @@ error[E0422]: cannot find struct, variant or union type `MyStruct` in this scope
 LL |     let x = MyStruct {};
    |             ^^^^^^^^ not found in this scope
    |
-  ::: $DIR/auxiliary/use_by_macro.rs:15:1
+  ::: $DIR/auxiliary/use_by_macro.rs:7:24
    |
-LL | x!(my_struct);
-   | ------------- you might have meant to refer to this struct
+LL |             pub struct MyStruct;
+   |                        -------- you might have meant to refer to this struct
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/impl-trait/equality.stderr
+++ b/tests/ui/impl-trait/equality.stderr
@@ -33,13 +33,19 @@ LL |         n + sum_to(n - 1)
 help: the following other types implement trait `Add<Rhs>`
   --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
    |
-   = note: `&u32` implements `Add<u32>`
+   = note: `u32` implements `Add`
+  ::: $SRC_DIR/core/src/ops/arith.rs:LL:COL
    |
-   = note: `&u32` implements `Add`
+   = note: in this macro invocation
+  --> $SRC_DIR/core/src/internal_macros.rs:LL:COL
+   |
+   = note: `&u32` implements `Add<u32>`
+  ::: $SRC_DIR/core/src/internal_macros.rs:LL:COL
    |
    = note: `u32` implements `Add<&u32>`
+  ::: $SRC_DIR/core/src/internal_macros.rs:LL:COL
    |
-   = note: `u32` implements `Add`
+   = note: `&u32` implements `Add`
    = note: this error originates in the macro `add_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors; 1 warning emitted

--- a/tests/ui/imports/ambiguous-glob-vs-expanded-extern.stderr
+++ b/tests/ui/imports/ambiguous-glob-vs-expanded-extern.stderr
@@ -8,10 +8,13 @@ LL |     glob_vs_expanded::mac!();
    = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of a conflict between a name from a glob import and a macro-expanded name in the same module during import or macro resolution
 note: `mac` could refer to the macro defined here
-  --> $DIR/auxiliary/glob-vs-expanded.rs:11:1
+  --> $DIR/auxiliary/glob-vs-expanded.rs:9:13
    |
+LL |     () => { pub macro mac() {} }
+   |             ^^^^^^^^^^^^^
+LL | }
 LL | define_mac!();
-   | ^^^^^^^^^^^^^
+   | ------------- in this macro invocation
 note: `mac` could also refer to the macro defined here
   --> $DIR/auxiliary/glob-vs-expanded.rs:5:9
    |
@@ -33,10 +36,13 @@ LL |     glob_vs_expanded::mac!();
    = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of a conflict between a name from a glob import and a macro-expanded name in the same module during import or macro resolution
 note: `mac` could refer to the macro defined here
-  --> $DIR/auxiliary/glob-vs-expanded.rs:11:1
+  --> $DIR/auxiliary/glob-vs-expanded.rs:9:13
    |
+LL |     () => { pub macro mac() {} }
+   |             ^^^^^^^^^^^^^
+LL | }
 LL | define_mac!();
-   | ^^^^^^^^^^^^^
+   | ------------- in this macro invocation
 note: `mac` could also refer to the macro defined here
   --> $DIR/auxiliary/glob-vs-expanded.rs:5:9
    |

--- a/tests/ui/infinite/issue-41731-infinite-macro-print.stderr
+++ b/tests/ui/infinite/issue-41731-infinite-macro-print.stderr
@@ -1,8 +1,11 @@
 error: recursion limit reached while expanding `$crate::format_args!`
-  --> $DIR/issue-41731-infinite-macro-print.rs:14:5
+  --> $DIR/issue-41731-infinite-macro-print.rs:8:13
    |
+LL |             print!(stack!($overflow))
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^
+...
 LL |     stack!("overflow");
-   |     ^^^^^^^^^^^^^^^^^^
+   |     ------------------ in this macro invocation
    |
    = help: consider increasing the recursion limit by adding a `#![recursion_limit = "10"]` attribute to your crate (`issue_41731_infinite_macro_print`)
    = note: this error originates in the macro `print` which comes from the expansion of the macro `stack` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -23,10 +26,13 @@ LL |     stack!("overflow");
    = note: to `{ $crate :: io :: _print($crate :: format_args! (stack! ("overflow"))); }`
 
 error: format argument must be a string literal
-  --> $DIR/issue-41731-infinite-macro-print.rs:14:5
+  --> $DIR/issue-41731-infinite-macro-print.rs:8:13
    |
+LL |             print!(stack!($overflow))
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^
+...
 LL |     stack!("overflow");
-   |     ^^^^^^^^^^^^^^^^^^
+   |     ------------------ in this macro invocation
    |
    = note: this error originates in the macro `print` which comes from the expansion of the macro `stack` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: you might be missing a string literal to format with

--- a/tests/ui/infinite/issue-41731-infinite-macro-println.stderr
+++ b/tests/ui/infinite/issue-41731-infinite-macro-println.stderr
@@ -1,8 +1,11 @@
 error: recursion limit reached while expanding `$crate::format_args_nl!`
-  --> $DIR/issue-41731-infinite-macro-println.rs:14:5
+  --> $DIR/issue-41731-infinite-macro-println.rs:8:13
    |
+LL |             println!(stack!($overflow))
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+...
 LL |     stack!("overflow");
-   |     ^^^^^^^^^^^^^^^^^^
+   |     ------------------ in this macro invocation
    |
    = help: consider increasing the recursion limit by adding a `#![recursion_limit = "10"]` attribute to your crate (`issue_41731_infinite_macro_println`)
    = note: this error originates in the macro `println` which comes from the expansion of the macro `stack` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -23,10 +26,13 @@ LL |     stack!("overflow");
    = note: to `{ $crate :: io :: _print($crate :: format_args_nl! (stack! ("overflow"))); }`
 
 error: format argument must be a string literal
-  --> $DIR/issue-41731-infinite-macro-println.rs:14:5
+  --> $DIR/issue-41731-infinite-macro-println.rs:8:13
    |
+LL |             println!(stack!($overflow))
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+...
 LL |     stack!("overflow");
-   |     ^^^^^^^^^^^^^^^^^^
+   |     ------------------ in this macro invocation
    |
    = note: this error originates in the macro `println` which comes from the expansion of the macro `stack` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: you might be missing a string literal to format with

--- a/tests/ui/iterators/invalid-iterator-chain-fixable.stderr
+++ b/tests/ui/iterators/invalid-iterator-chain-fixable.stderr
@@ -36,9 +36,13 @@ LL |     println!("{}", scores.sum::<i32>());
 help: the following other types implement trait `Sum<A>`
   --> $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
    |
-   = note: `i32` implements `Sum<&i32>`
-   |
    = note: `i32` implements `Sum`
+  ::: $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
+   |
+   = note: `i32` implements `Sum<&i32>`
+  ::: $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
+   |
+   = note: in this macro invocation
 note: the method call chain might not have had the expected associated types
   --> $DIR/invalid-iterator-chain-fixable.rs:14:10
    |
@@ -73,9 +77,13 @@ LL |             .sum::<i32>(),
 help: the following other types implement trait `Sum<A>`
   --> $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
    |
-   = note: `i32` implements `Sum<&i32>`
-   |
    = note: `i32` implements `Sum`
+  ::: $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
+   |
+   = note: `i32` implements `Sum<&i32>`
+  ::: $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
+   |
+   = note: in this macro invocation
 note: the method call chain might not have had the expected associated types
   --> $DIR/invalid-iterator-chain-fixable.rs:23:14
    |
@@ -110,9 +118,13 @@ LL |     println!("{}", vec![0, 1].iter().map(|x| { x; }).sum::<i32>());
 help: the following other types implement trait `Sum<A>`
   --> $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
    |
-   = note: `i32` implements `Sum<&i32>`
-   |
    = note: `i32` implements `Sum`
+  ::: $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
+   |
+   = note: `i32` implements `Sum<&i32>`
+  ::: $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
+   |
+   = note: in this macro invocation
 note: the method call chain might not have had the expected associated types
   --> $DIR/invalid-iterator-chain-fixable.rs:27:38
    |

--- a/tests/ui/iterators/invalid-iterator-chain-with-int-infer.stderr
+++ b/tests/ui/iterators/invalid-iterator-chain-with-int-infer.stderr
@@ -10,9 +10,13 @@ LL |     let x = Some(()).iter().map(|()| 1).sum::<f32>();
 help: the following other types implement trait `Sum<A>`
   --> $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
    |
-   = note: `f32` implements `Sum<&f32>`
-   |
    = note: `f32` implements `Sum`
+  ::: $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
+   |
+   = note: `f32` implements `Sum<&f32>`
+  ::: $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
+   |
+   = note: in this macro invocation
 note: the method call chain might not have had the expected associated types
   --> $DIR/invalid-iterator-chain-with-int-infer.rs:2:29
    |

--- a/tests/ui/iterators/invalid-iterator-chain.stderr
+++ b/tests/ui/iterators/invalid-iterator-chain.stderr
@@ -36,9 +36,13 @@ LL |     println!("{}", scores.sum::<i32>());
 help: the following other types implement trait `Sum<A>`
   --> $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
    |
-   = note: `i32` implements `Sum<&i32>`
-   |
    = note: `i32` implements `Sum`
+  ::: $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
+   |
+   = note: `i32` implements `Sum<&i32>`
+  ::: $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
+   |
+   = note: in this macro invocation
 note: the method call chain might not have had the expected associated types
   --> $DIR/invalid-iterator-chain.rs:12:10
    |
@@ -72,9 +76,13 @@ LL |             .sum::<i32>(),
 help: the following other types implement trait `Sum<A>`
   --> $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
    |
-   = note: `i32` implements `Sum<&i32>`
-   |
    = note: `i32` implements `Sum`
+  ::: $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
+   |
+   = note: `i32` implements `Sum<&i32>`
+  ::: $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
+   |
+   = note: in this macro invocation
 note: the method call chain might not have had the expected associated types
   --> $DIR/invalid-iterator-chain.rs:25:14
    |
@@ -115,9 +123,13 @@ LL |             .sum::<i32>(),
 help: the following other types implement trait `Sum<A>`
   --> $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
    |
-   = note: `i32` implements `Sum<&i32>`
-   |
    = note: `i32` implements `Sum`
+  ::: $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
+   |
+   = note: `i32` implements `Sum<&i32>`
+  ::: $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
+   |
+   = note: in this macro invocation
 note: the method call chain might not have had the expected associated types
   --> $DIR/invalid-iterator-chain.rs:33:14
    |
@@ -149,9 +161,13 @@ LL |     println!("{}", vec![0, 1].iter().map(|x| { x; }).sum::<i32>());
 help: the following other types implement trait `Sum<A>`
   --> $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
    |
-   = note: `i32` implements `Sum<&i32>`
-   |
    = note: `i32` implements `Sum`
+  ::: $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
+   |
+   = note: `i32` implements `Sum<&i32>`
+  ::: $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
+   |
+   = note: in this macro invocation
 note: the method call chain might not have had the expected associated types
   --> $DIR/invalid-iterator-chain.rs:38:38
    |
@@ -181,9 +197,13 @@ LL |     println!("{}", vec![(), ()].iter().sum::<i32>());
 help: the following other types implement trait `Sum<A>`
   --> $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
    |
-   = note: `i32` implements `Sum<&i32>`
-   |
    = note: `i32` implements `Sum`
+  ::: $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
+   |
+   = note: `i32` implements `Sum<&i32>`
+  ::: $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
+   |
+   = note: in this macro invocation
 note: the method call chain might not have had the expected associated types
   --> $DIR/invalid-iterator-chain.rs:39:33
    |

--- a/tests/ui/mismatched_types/binops.stderr
+++ b/tests/ui/mismatched_types/binops.stderr
@@ -26,13 +26,19 @@ LL |     2 as usize - Some(1);
 help: the following other types implement trait `Sub<Rhs>`
   --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
    |
-   = note: `&usize` implements `Sub<usize>`
+   = note: `usize` implements `Sub`
+  ::: $SRC_DIR/core/src/ops/arith.rs:LL:COL
    |
-   = note: `&usize` implements `Sub`
+   = note: in this macro invocation
+  --> $SRC_DIR/core/src/internal_macros.rs:LL:COL
+   |
+   = note: `&usize` implements `Sub<usize>`
+  ::: $SRC_DIR/core/src/internal_macros.rs:LL:COL
    |
    = note: `usize` implements `Sub<&usize>`
+  ::: $SRC_DIR/core/src/internal_macros.rs:LL:COL
    |
-   = note: `usize` implements `Sub`
+   = note: `&usize` implements `Sub`
    = note: this error originates in the macro `sub_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: cannot multiply `{integer}` by `()`

--- a/tests/ui/mismatched_types/float-integer-subtraction-error-24352.stderr
+++ b/tests/ui/mismatched_types/float-integer-subtraction-error-24352.stderr
@@ -8,13 +8,19 @@ LL |     1.0f64 - 1
 help: the following other types implement trait `Sub<Rhs>`
   --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
    |
-   = note: `&f64` implements `Sub<f64>`
+   = note: `f64` implements `Sub`
+  ::: $SRC_DIR/core/src/ops/arith.rs:LL:COL
    |
-   = note: `&f64` implements `Sub`
+   = note: in this macro invocation
+  --> $SRC_DIR/core/src/internal_macros.rs:LL:COL
+   |
+   = note: `&f64` implements `Sub<f64>`
+  ::: $SRC_DIR/core/src/internal_macros.rs:LL:COL
    |
    = note: `f64` implements `Sub<&f64>`
+  ::: $SRC_DIR/core/src/internal_macros.rs:LL:COL
    |
-   = note: `f64` implements `Sub`
+   = note: `&f64` implements `Sub`
    = note: this error originates in the macro `sub_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider using a floating-point literal by writing it with `.0`
    |

--- a/tests/ui/never_type/issue-13352.stderr
+++ b/tests/ui/never_type/issue-13352.stderr
@@ -8,13 +8,19 @@ LL |     2_usize + (loop {});
 help: the following other types implement trait `Add<Rhs>`
   --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
    |
-   = note: `&usize` implements `Add<usize>`
+   = note: `usize` implements `Add`
+  ::: $SRC_DIR/core/src/ops/arith.rs:LL:COL
    |
-   = note: `&usize` implements `Add`
+   = note: in this macro invocation
+  --> $SRC_DIR/core/src/internal_macros.rs:LL:COL
+   |
+   = note: `&usize` implements `Add<usize>`
+  ::: $SRC_DIR/core/src/internal_macros.rs:LL:COL
    |
    = note: `usize` implements `Add<&usize>`
+  ::: $SRC_DIR/core/src/internal_macros.rs:LL:COL
    |
-   = note: `usize` implements `Add`
+   = note: `&usize` implements `Add`
    = note: this error originates in the macro `add_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error

--- a/tests/ui/numbers-arithmetic/not-suggest-float-literal.stderr
+++ b/tests/ui/numbers-arithmetic/not-suggest-float-literal.stderr
@@ -8,13 +8,19 @@ LL |     x + 100.0
 help: the following other types implement trait `Add<Rhs>`
   --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
    |
-   = note: `&u8` implements `Add<u8>`
+   = note: `u8` implements `Add`
+  ::: $SRC_DIR/core/src/ops/arith.rs:LL:COL
    |
-   = note: `&u8` implements `Add`
+   = note: in this macro invocation
+  --> $SRC_DIR/core/src/internal_macros.rs:LL:COL
+   |
+   = note: `&u8` implements `Add<u8>`
+  ::: $SRC_DIR/core/src/internal_macros.rs:LL:COL
    |
    = note: `u8` implements `Add<&u8>`
+  ::: $SRC_DIR/core/src/internal_macros.rs:LL:COL
    |
-   = note: `u8` implements `Add`
+   = note: `&u8` implements `Add`
    = note: this error originates in the macro `add_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: cannot add `&str` to `f64`
@@ -27,13 +33,19 @@ LL |     x + "foo"
 help: the following other types implement trait `Add<Rhs>`
   --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
    |
-   = note: `&f64` implements `Add<f64>`
+   = note: `f64` implements `Add`
+  ::: $SRC_DIR/core/src/ops/arith.rs:LL:COL
    |
-   = note: `&f64` implements `Add`
+   = note: in this macro invocation
+  --> $SRC_DIR/core/src/internal_macros.rs:LL:COL
+   |
+   = note: `&f64` implements `Add<f64>`
+  ::: $SRC_DIR/core/src/internal_macros.rs:LL:COL
    |
    = note: `f64` implements `Add<&f64>`
+  ::: $SRC_DIR/core/src/internal_macros.rs:LL:COL
    |
-   = note: `f64` implements `Add`
+   = note: `&f64` implements `Add`
    = note: this error originates in the macro `add_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: cannot add `{integer}` to `f64`
@@ -46,13 +58,19 @@ LL |     x + y
 help: the following other types implement trait `Add<Rhs>`
   --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
    |
-   = note: `&f64` implements `Add<f64>`
+   = note: `f64` implements `Add`
+  ::: $SRC_DIR/core/src/ops/arith.rs:LL:COL
    |
-   = note: `&f64` implements `Add`
+   = note: in this macro invocation
+  --> $SRC_DIR/core/src/internal_macros.rs:LL:COL
+   |
+   = note: `&f64` implements `Add<f64>`
+  ::: $SRC_DIR/core/src/internal_macros.rs:LL:COL
    |
    = note: `f64` implements `Add<&f64>`
+  ::: $SRC_DIR/core/src/internal_macros.rs:LL:COL
    |
-   = note: `f64` implements `Add`
+   = note: `&f64` implements `Add`
    = note: this error originates in the macro `add_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: cannot subtract `{float}` from `u8`
@@ -65,13 +83,19 @@ LL |     x - 100.0
 help: the following other types implement trait `Sub<Rhs>`
   --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
    |
-   = note: `&u8` implements `Sub<u8>`
+   = note: `u8` implements `Sub`
+  ::: $SRC_DIR/core/src/ops/arith.rs:LL:COL
    |
-   = note: `&u8` implements `Sub`
+   = note: in this macro invocation
+  --> $SRC_DIR/core/src/internal_macros.rs:LL:COL
+   |
+   = note: `&u8` implements `Sub<u8>`
+  ::: $SRC_DIR/core/src/internal_macros.rs:LL:COL
    |
    = note: `u8` implements `Sub<&u8>`
+  ::: $SRC_DIR/core/src/internal_macros.rs:LL:COL
    |
-   = note: `u8` implements `Sub`
+   = note: `&u8` implements `Sub`
    = note: this error originates in the macro `sub_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: cannot subtract `&str` from `f64`
@@ -84,13 +108,19 @@ LL |     x - "foo"
 help: the following other types implement trait `Sub<Rhs>`
   --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
    |
-   = note: `&f64` implements `Sub<f64>`
+   = note: `f64` implements `Sub`
+  ::: $SRC_DIR/core/src/ops/arith.rs:LL:COL
    |
-   = note: `&f64` implements `Sub`
+   = note: in this macro invocation
+  --> $SRC_DIR/core/src/internal_macros.rs:LL:COL
+   |
+   = note: `&f64` implements `Sub<f64>`
+  ::: $SRC_DIR/core/src/internal_macros.rs:LL:COL
    |
    = note: `f64` implements `Sub<&f64>`
+  ::: $SRC_DIR/core/src/internal_macros.rs:LL:COL
    |
-   = note: `f64` implements `Sub`
+   = note: `&f64` implements `Sub`
    = note: this error originates in the macro `sub_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: cannot subtract `{integer}` from `f64`
@@ -103,13 +133,19 @@ LL |     x - y
 help: the following other types implement trait `Sub<Rhs>`
   --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
    |
-   = note: `&f64` implements `Sub<f64>`
+   = note: `f64` implements `Sub`
+  ::: $SRC_DIR/core/src/ops/arith.rs:LL:COL
    |
-   = note: `&f64` implements `Sub`
+   = note: in this macro invocation
+  --> $SRC_DIR/core/src/internal_macros.rs:LL:COL
+   |
+   = note: `&f64` implements `Sub<f64>`
+  ::: $SRC_DIR/core/src/internal_macros.rs:LL:COL
    |
    = note: `f64` implements `Sub<&f64>`
+  ::: $SRC_DIR/core/src/internal_macros.rs:LL:COL
    |
-   = note: `f64` implements `Sub`
+   = note: `&f64` implements `Sub`
    = note: this error originates in the macro `sub_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: cannot multiply `u8` by `{float}`
@@ -122,13 +158,19 @@ LL |     x * 100.0
 help: the following other types implement trait `Mul<Rhs>`
   --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
    |
-   = note: `&u8` implements `Mul<u8>`
+   = note: `u8` implements `Mul`
+  ::: $SRC_DIR/core/src/ops/arith.rs:LL:COL
    |
-   = note: `&u8` implements `Mul`
+   = note: in this macro invocation
+  --> $SRC_DIR/core/src/internal_macros.rs:LL:COL
+   |
+   = note: `&u8` implements `Mul<u8>`
+  ::: $SRC_DIR/core/src/internal_macros.rs:LL:COL
    |
    = note: `u8` implements `Mul<&u8>`
+  ::: $SRC_DIR/core/src/internal_macros.rs:LL:COL
    |
-   = note: `u8` implements `Mul`
+   = note: `&u8` implements `Mul`
    = note: this error originates in the macro `mul_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: cannot multiply `f64` by `&str`
@@ -141,13 +183,19 @@ LL |     x * "foo"
 help: the following other types implement trait `Mul<Rhs>`
   --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
    |
-   = note: `&f64` implements `Mul<f64>`
+   = note: `f64` implements `Mul`
+  ::: $SRC_DIR/core/src/ops/arith.rs:LL:COL
    |
-   = note: `&f64` implements `Mul`
+   = note: in this macro invocation
+  --> $SRC_DIR/core/src/internal_macros.rs:LL:COL
+   |
+   = note: `&f64` implements `Mul<f64>`
+  ::: $SRC_DIR/core/src/internal_macros.rs:LL:COL
    |
    = note: `f64` implements `Mul<&f64>`
+  ::: $SRC_DIR/core/src/internal_macros.rs:LL:COL
    |
-   = note: `f64` implements `Mul`
+   = note: `&f64` implements `Mul`
    = note: this error originates in the macro `mul_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: cannot multiply `f64` by `{integer}`
@@ -160,13 +208,19 @@ LL |     x * y
 help: the following other types implement trait `Mul<Rhs>`
   --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
    |
-   = note: `&f64` implements `Mul<f64>`
+   = note: `f64` implements `Mul`
+  ::: $SRC_DIR/core/src/ops/arith.rs:LL:COL
    |
-   = note: `&f64` implements `Mul`
+   = note: in this macro invocation
+  --> $SRC_DIR/core/src/internal_macros.rs:LL:COL
+   |
+   = note: `&f64` implements `Mul<f64>`
+  ::: $SRC_DIR/core/src/internal_macros.rs:LL:COL
    |
    = note: `f64` implements `Mul<&f64>`
+  ::: $SRC_DIR/core/src/internal_macros.rs:LL:COL
    |
-   = note: `f64` implements `Mul`
+   = note: `&f64` implements `Mul`
    = note: this error originates in the macro `mul_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: cannot divide `u8` by `{float}`
@@ -193,13 +247,19 @@ LL |     x / "foo"
 help: the following other types implement trait `Div<Rhs>`
   --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
    |
-   = note: `&f64` implements `Div<f64>`
+   = note: `f64` implements `Div`
+  ::: $SRC_DIR/core/src/ops/arith.rs:LL:COL
    |
-   = note: `&f64` implements `Div`
+   = note: in this macro invocation
+  --> $SRC_DIR/core/src/internal_macros.rs:LL:COL
+   |
+   = note: `&f64` implements `Div<f64>`
+  ::: $SRC_DIR/core/src/internal_macros.rs:LL:COL
    |
    = note: `f64` implements `Div<&f64>`
+  ::: $SRC_DIR/core/src/internal_macros.rs:LL:COL
    |
-   = note: `f64` implements `Div`
+   = note: `&f64` implements `Div`
    = note: this error originates in the macro `div_impl_float` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: cannot divide `f64` by `{integer}`
@@ -212,13 +272,19 @@ LL |     x / y
 help: the following other types implement trait `Div<Rhs>`
   --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
    |
-   = note: `&f64` implements `Div<f64>`
+   = note: `f64` implements `Div`
+  ::: $SRC_DIR/core/src/ops/arith.rs:LL:COL
    |
-   = note: `&f64` implements `Div`
+   = note: in this macro invocation
+  --> $SRC_DIR/core/src/internal_macros.rs:LL:COL
+   |
+   = note: `&f64` implements `Div<f64>`
+  ::: $SRC_DIR/core/src/internal_macros.rs:LL:COL
    |
    = note: `f64` implements `Div<&f64>`
+  ::: $SRC_DIR/core/src/internal_macros.rs:LL:COL
    |
-   = note: `f64` implements `Div`
+   = note: `&f64` implements `Div`
    = note: this error originates in the macro `div_impl_float` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 12 previous errors

--- a/tests/ui/numbers-arithmetic/suggest-float-literal.stderr
+++ b/tests/ui/numbers-arithmetic/suggest-float-literal.stderr
@@ -8,13 +8,19 @@ LL |     x + 100
 help: the following other types implement trait `Add<Rhs>`
   --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
    |
-   = note: `&f32` implements `Add<f32>`
+   = note: `f32` implements `Add`
+  ::: $SRC_DIR/core/src/ops/arith.rs:LL:COL
    |
-   = note: `&f32` implements `Add`
+   = note: in this macro invocation
+  --> $SRC_DIR/core/src/internal_macros.rs:LL:COL
+   |
+   = note: `&f32` implements `Add<f32>`
+  ::: $SRC_DIR/core/src/internal_macros.rs:LL:COL
    |
    = note: `f32` implements `Add<&f32>`
+  ::: $SRC_DIR/core/src/internal_macros.rs:LL:COL
    |
-   = note: `f32` implements `Add`
+   = note: `&f32` implements `Add`
    = note: this error originates in the macro `add_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider using a floating-point literal by writing it with `.0`
    |
@@ -31,13 +37,19 @@ LL |     x + 100
 help: the following other types implement trait `Add<Rhs>`
   --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
    |
-   = note: `&f64` implements `Add<f64>`
+   = note: `f64` implements `Add`
+  ::: $SRC_DIR/core/src/ops/arith.rs:LL:COL
    |
-   = note: `&f64` implements `Add`
+   = note: in this macro invocation
+  --> $SRC_DIR/core/src/internal_macros.rs:LL:COL
+   |
+   = note: `&f64` implements `Add<f64>`
+  ::: $SRC_DIR/core/src/internal_macros.rs:LL:COL
    |
    = note: `f64` implements `Add<&f64>`
+  ::: $SRC_DIR/core/src/internal_macros.rs:LL:COL
    |
-   = note: `f64` implements `Add`
+   = note: `&f64` implements `Add`
    = note: this error originates in the macro `add_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider using a floating-point literal by writing it with `.0`
    |
@@ -54,13 +66,19 @@ LL |     x - 100
 help: the following other types implement trait `Sub<Rhs>`
   --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
    |
-   = note: `&f32` implements `Sub<f32>`
+   = note: `f32` implements `Sub`
+  ::: $SRC_DIR/core/src/ops/arith.rs:LL:COL
    |
-   = note: `&f32` implements `Sub`
+   = note: in this macro invocation
+  --> $SRC_DIR/core/src/internal_macros.rs:LL:COL
+   |
+   = note: `&f32` implements `Sub<f32>`
+  ::: $SRC_DIR/core/src/internal_macros.rs:LL:COL
    |
    = note: `f32` implements `Sub<&f32>`
+  ::: $SRC_DIR/core/src/internal_macros.rs:LL:COL
    |
-   = note: `f32` implements `Sub`
+   = note: `&f32` implements `Sub`
    = note: this error originates in the macro `sub_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider using a floating-point literal by writing it with `.0`
    |
@@ -77,13 +95,19 @@ LL |     x - 100
 help: the following other types implement trait `Sub<Rhs>`
   --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
    |
-   = note: `&f64` implements `Sub<f64>`
+   = note: `f64` implements `Sub`
+  ::: $SRC_DIR/core/src/ops/arith.rs:LL:COL
    |
-   = note: `&f64` implements `Sub`
+   = note: in this macro invocation
+  --> $SRC_DIR/core/src/internal_macros.rs:LL:COL
+   |
+   = note: `&f64` implements `Sub<f64>`
+  ::: $SRC_DIR/core/src/internal_macros.rs:LL:COL
    |
    = note: `f64` implements `Sub<&f64>`
+  ::: $SRC_DIR/core/src/internal_macros.rs:LL:COL
    |
-   = note: `f64` implements `Sub`
+   = note: `&f64` implements `Sub`
    = note: this error originates in the macro `sub_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider using a floating-point literal by writing it with `.0`
    |
@@ -100,13 +124,19 @@ LL |     x * 100
 help: the following other types implement trait `Mul<Rhs>`
   --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
    |
-   = note: `&f32` implements `Mul<f32>`
+   = note: `f32` implements `Mul`
+  ::: $SRC_DIR/core/src/ops/arith.rs:LL:COL
    |
-   = note: `&f32` implements `Mul`
+   = note: in this macro invocation
+  --> $SRC_DIR/core/src/internal_macros.rs:LL:COL
+   |
+   = note: `&f32` implements `Mul<f32>`
+  ::: $SRC_DIR/core/src/internal_macros.rs:LL:COL
    |
    = note: `f32` implements `Mul<&f32>`
+  ::: $SRC_DIR/core/src/internal_macros.rs:LL:COL
    |
-   = note: `f32` implements `Mul`
+   = note: `&f32` implements `Mul`
    = note: this error originates in the macro `mul_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider using a floating-point literal by writing it with `.0`
    |
@@ -123,13 +153,19 @@ LL |     x * 100
 help: the following other types implement trait `Mul<Rhs>`
   --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
    |
-   = note: `&f64` implements `Mul<f64>`
+   = note: `f64` implements `Mul`
+  ::: $SRC_DIR/core/src/ops/arith.rs:LL:COL
    |
-   = note: `&f64` implements `Mul`
+   = note: in this macro invocation
+  --> $SRC_DIR/core/src/internal_macros.rs:LL:COL
+   |
+   = note: `&f64` implements `Mul<f64>`
+  ::: $SRC_DIR/core/src/internal_macros.rs:LL:COL
    |
    = note: `f64` implements `Mul<&f64>`
+  ::: $SRC_DIR/core/src/internal_macros.rs:LL:COL
    |
-   = note: `f64` implements `Mul`
+   = note: `&f64` implements `Mul`
    = note: this error originates in the macro `mul_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider using a floating-point literal by writing it with `.0`
    |
@@ -146,13 +182,19 @@ LL |     x / 100
 help: the following other types implement trait `Div<Rhs>`
   --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
    |
-   = note: `&f32` implements `Div<f32>`
+   = note: `f32` implements `Div`
+  ::: $SRC_DIR/core/src/ops/arith.rs:LL:COL
    |
-   = note: `&f32` implements `Div`
+   = note: in this macro invocation
+  --> $SRC_DIR/core/src/internal_macros.rs:LL:COL
+   |
+   = note: `&f32` implements `Div<f32>`
+  ::: $SRC_DIR/core/src/internal_macros.rs:LL:COL
    |
    = note: `f32` implements `Div<&f32>`
+  ::: $SRC_DIR/core/src/internal_macros.rs:LL:COL
    |
-   = note: `f32` implements `Div`
+   = note: `&f32` implements `Div`
    = note: this error originates in the macro `div_impl_float` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider using a floating-point literal by writing it with `.0`
    |
@@ -169,13 +211,19 @@ LL |     x / 100
 help: the following other types implement trait `Div<Rhs>`
   --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
    |
-   = note: `&f64` implements `Div<f64>`
+   = note: `f64` implements `Div`
+  ::: $SRC_DIR/core/src/ops/arith.rs:LL:COL
    |
-   = note: `&f64` implements `Div`
+   = note: in this macro invocation
+  --> $SRC_DIR/core/src/internal_macros.rs:LL:COL
+   |
+   = note: `&f64` implements `Div<f64>`
+  ::: $SRC_DIR/core/src/internal_macros.rs:LL:COL
    |
    = note: `f64` implements `Div<&f64>`
+  ::: $SRC_DIR/core/src/internal_macros.rs:LL:COL
    |
-   = note: `f64` implements `Div`
+   = note: `&f64` implements `Div`
    = note: this error originates in the macro `div_impl_float` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider using a floating-point literal by writing it with `.0`
    |

--- a/tests/ui/on-unimplemented/slice-index.stderr
+++ b/tests/ui/on-unimplemented/slice-index.stderr
@@ -28,6 +28,9 @@ help: the following other types implement trait `SliceIndex<T>`
   --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
    |
    = note: `RangeTo<usize>` implements `SliceIndex<ByteStr>`
+  ::: $SRC_DIR/core/src/bstr/traits.rs:LL:COL
+   |
+   = note: in this macro invocation
   --> $SRC_DIR/core/src/str/traits.rs:LL:COL
    |
    = note: `RangeTo<usize>` implements `SliceIndex<str>`

--- a/tests/ui/on-unimplemented/sum.stderr
+++ b/tests/ui/on-unimplemented/sum.stderr
@@ -10,9 +10,13 @@ LL |     vec![(), ()].iter().sum::<i32>();
 help: the following other types implement trait `Sum<A>`
   --> $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
    |
-   = note: `i32` implements `Sum<&i32>`
-   |
    = note: `i32` implements `Sum`
+  ::: $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
+   |
+   = note: `i32` implements `Sum<&i32>`
+  ::: $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
+   |
+   = note: in this macro invocation
 note: the method call chain might not have had the expected associated types
   --> $DIR/sum.rs:4:18
    |
@@ -36,9 +40,13 @@ LL |     vec![(), ()].iter().product::<i32>();
 help: the following other types implement trait `Product<A>`
   --> $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
    |
-   = note: `i32` implements `Product<&i32>`
-   |
    = note: `i32` implements `Product`
+  ::: $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
+   |
+   = note: `i32` implements `Product<&i32>`
+  ::: $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
+   |
+   = note: in this macro invocation
 note: the method call chain might not have had the expected associated types
   --> $DIR/sum.rs:7:18
    |

--- a/tests/ui/proc-macro/mixed-site-span.stderr
+++ b/tests/ui/proc-macro/mixed-site-span.stderr
@@ -112,10 +112,13 @@ LL |     test!();
    = note: this error originates in the macro `with_crate` which comes from the expansion of the macro `test` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0432]: unresolved import `$crate`
-  --> $DIR/mixed-site-span.rs:69:5
+  --> $DIR/mixed-site-span.rs:67:9
    |
+LL |         invoke_with_ident!{$crate call proc_macro_item}
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `proc_macro_item` in the root
+LL |     }}
 LL |     test!();
-   |     ^^^^^^^ no `proc_macro_item` in the root
+   |     ------- in this macro invocation
    |
    = note: this error originates in the macro `with_crate` which comes from the expansion of the macro `test` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -262,10 +265,13 @@ LL +         token_site_span::TokenItem as _
    |
 
 error[E0432]: unresolved import `$crate`
-  --> $DIR/mixed-site-span.rs:110:5
+  --> $DIR/mixed-site-span.rs:106:9
    |
+LL |         invoke_with_ident!{$crate mixed TokenItem}
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `TokenItem` in the root
+...
 LL |     test!();
-   |     ^^^^^^^ no `TokenItem` in the root
+   |     ------- in this macro invocation
    |
    = note: this error originates in the macro `with_crate` which comes from the expansion of the macro `test` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider importing this struct instead
@@ -417,10 +423,13 @@ LL +     ($m:ident $s:ident $i:ident) => { ItemUse as _ };
    |
 
 error[E0432]: unresolved import `$crate`
-  --> $DIR/mixed-site-span.rs:150:5
+  --> $DIR/mixed-site-span.rs:145:9
    |
+LL |         invoke_with_ident!{$crate mixed ItemUse}
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `ItemUse` in the root
+...
 LL |     test!();
-   |     ^^^^^^^ no `ItemUse` in the root
+   |     ------- in this macro invocation
    |
    = note: this error originates in the macro `with_crate` which comes from the expansion of the macro `test` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider importing this struct instead
@@ -447,10 +456,13 @@ LL +         ItemUse as _
    |
 
 error[E0432]: unresolved import `$crate`
-  --> $DIR/mixed-site-span.rs:150:5
+  --> $DIR/mixed-site-span.rs:148:9
    |
+LL |         invoke_with_ident!{$crate call ItemUse}
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `ItemUse` in the root
+LL |     }}
 LL |     test!();
-   |     ^^^^^^^ no `ItemUse` in the root
+   |     ------- in this macro invocation
    |
    = note: this error originates in the macro `with_crate` which comes from the expansion of the macro `test` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider importing this struct instead

--- a/tests/ui/span/macro-span-caller-replacement.rs
+++ b/tests/ui/span/macro-span-caller-replacement.rs
@@ -1,0 +1,16 @@
+macro_rules! macro_with_format { () => {
+    fn check_5(arg : usize) -> String {
+        let s : &str;
+        if arg < 5 {
+            s = format!("{arg}");
+        } else {
+            s = String::new(); //~ ERROR mismatched types
+        }
+        String::from(s)
+    }
+}}
+
+fn main() {
+    macro_with_format!(); //~ ERROR mismatched types
+    println!( "{}", check_5(6) ); 
+}

--- a/tests/ui/span/macro-span-caller-replacement.rs
+++ b/tests/ui/span/macro-span-caller-replacement.rs
@@ -2,7 +2,7 @@ macro_rules! macro_with_format { () => {
     fn check_5(arg : usize) -> String {
         let s : &str;
         if arg < 5 {
-            s = format!("{arg}");
+            s = format!("{arg}"); //~ ERROR mismatched types
         } else {
             s = String::new(); //~ ERROR mismatched types
         }
@@ -11,6 +11,6 @@ macro_rules! macro_with_format { () => {
 }}
 
 fn main() {
-    macro_with_format!(); //~ ERROR mismatched types
-    println!( "{}", check_5(6) ); 
+    macro_with_format!();
+    println!( "{}", check_5(6) );
 }

--- a/tests/ui/span/macro-span-caller-replacement.stderr
+++ b/tests/ui/span/macro-span-caller-replacement.stderr
@@ -1,0 +1,29 @@
+error[E0308]: mismatched types
+  --> $DIR/macro-span-caller-replacement.rs:5:17
+   |
+LL |     macro_with_format!();
+   |     ^^^^^^^^^^^^^^^^^^^^ expected `&str`, found `String`
+   |
+   = note: this error originates in the macro `format` which comes from the expansion of the macro `macro_with_format` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> $DIR/macro-span-caller-replacement.rs:7:17
+   |
+LL |         let s : &str;
+   |                 ---- expected due to this type
+...
+LL |             s = String::new();
+   |                 ^^^^^^^^^^^^^ expected `&str`, found `String`
+...
+LL |     macro_with_format!();
+   |     -------------------- in this macro invocation
+   |
+   = note: this error originates in the macro `macro_with_format` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider borrowing here
+   |
+LL |             s = &String::new();
+   |                 +
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/span/macro-span-caller-replacement.stderr
+++ b/tests/ui/span/macro-span-caller-replacement.stderr
@@ -1,8 +1,11 @@
 error[E0308]: mismatched types
   --> $DIR/macro-span-caller-replacement.rs:5:17
    |
+LL |             s = format!("{arg}");
+   |                 ^^^^^^^^^^^^^^^^ expected `&str`, found `String`
+...
 LL |     macro_with_format!();
-   |     ^^^^^^^^^^^^^^^^^^^^ expected `&str`, found `String`
+   |     -------------------- in this macro invocation
    |
    = note: this error originates in the macro `format` which comes from the expansion of the macro `macro_with_format` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/span/multiline-span-simple.stderr
+++ b/tests/ui/span/multiline-span-simple.stderr
@@ -8,13 +8,19 @@ LL |     foo(1 as u32 +
 help: the following other types implement trait `Add<Rhs>`
   --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
    |
-   = note: `&u32` implements `Add<u32>`
+   = note: `u32` implements `Add`
+  ::: $SRC_DIR/core/src/ops/arith.rs:LL:COL
    |
-   = note: `&u32` implements `Add`
+   = note: in this macro invocation
+  --> $SRC_DIR/core/src/internal_macros.rs:LL:COL
+   |
+   = note: `&u32` implements `Add<u32>`
+  ::: $SRC_DIR/core/src/internal_macros.rs:LL:COL
    |
    = note: `u32` implements `Add<&u32>`
+  ::: $SRC_DIR/core/src/internal_macros.rs:LL:COL
    |
-   = note: `u32` implements `Add`
+   = note: `&u32` implements `Add`
    = note: this error originates in the macro `add_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error

--- a/tests/ui/stdlib-unit-tests/atomic-from-mut-not-available.alignment_mismatch.stderr
+++ b/tests/ui/stdlib-unit-tests/atomic-from-mut-not-available.alignment_mismatch.stderr
@@ -6,6 +6,9 @@ LL |     core::sync::atomic::AtomicU64::from_mut(&mut 0u64);
    |
 note: if you're trying to build a new `AtomicU64`, consider using `AtomicU64::new` which returns `AtomicU64`
   --> $SRC_DIR/core/src/sync/atomic.rs:LL:COL
+  ::: $SRC_DIR/core/src/sync/atomic.rs:LL:COL
+   |
+   = note: in this macro invocation
    = note: this error originates in the macro `atomic_int` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: there is an associated function `from` with a similar name
    |

--- a/tests/ui/suggestions/dont-suggest-deref-inside-macro-issue-58298.stderr
+++ b/tests/ui/suggestions/dont-suggest-deref-inside-macro-issue-58298.stderr
@@ -1,10 +1,13 @@
 error[E0308]: mismatched types
-  --> $DIR/dont-suggest-deref-inside-macro-issue-58298.rs:11:5
+  --> $DIR/dont-suggest-deref-inside-macro-issue-58298.rs:5:14
    |
+LL |           warn(format!("unsupported intrinsic {}", $intrinsic));
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `&str`, found `String`
+...
 LL | /     intrinsic_match! {
 LL | |         "abc"
 LL | |     };
-   | |_____^ expected `&str`, found `String`
+   | |_____- in this macro invocation
    |
    = note: this error originates in the macro `format` which comes from the expansion of the macro `intrinsic_match` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/traits/suggest-dereferences/invalid-suggest-deref-issue-127590.stderr
+++ b/tests/ui/traits/suggest-dereferences/invalid-suggest-deref-issue-127590.stderr
@@ -24,7 +24,11 @@ LL |     for (src, dest) in std::iter::zip(fields.iter(), &variant.iter()) {
    |
    = help: the trait `Iterator` is not implemented for `&std::slice::Iter<'_, {integer}>`
 help: the trait `Iterator` is implemented for `std::slice::Iter<'_, T>`
+  --> $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
   --> $SRC_DIR/core/src/slice/iter.rs:LL:COL
+  ::: $SRC_DIR/core/src/slice/iter.rs:LL:COL
+   |
+   = note: in this macro invocation
    = note: required for `Zip<std::slice::Iter<'_, {integer}>, &std::slice::Iter<'_, {integer}>>` to implement `Iterator`
    = note: required for `Zip<std::slice::Iter<'_, {integer}>, &std::slice::Iter<'_, {integer}>>` to implement `IntoIterator`
    = note: this error originates in the macro `iterator` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -55,7 +59,11 @@ LL |     for (src, dest) in std::iter::zip(fields.iter(), &variant.iter().clone(
    |
    = help: the trait `Iterator` is not implemented for `&std::slice::Iter<'_, {integer}>`
 help: the trait `Iterator` is implemented for `std::slice::Iter<'_, T>`
+  --> $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
   --> $SRC_DIR/core/src/slice/iter.rs:LL:COL
+  ::: $SRC_DIR/core/src/slice/iter.rs:LL:COL
+   |
+   = note: in this macro invocation
    = note: required for `Zip<std::slice::Iter<'_, {integer}>, &std::slice::Iter<'_, {integer}>>` to implement `Iterator`
    = note: required for `Zip<std::slice::Iter<'_, {integer}>, &std::slice::Iter<'_, {integer}>>` to implement `IntoIterator`
    = note: this error originates in the macro `iterator` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -68,7 +76,11 @@ LL |     for (src, dest) in std::iter::zip(fields.iter(), &variant.iter()) {
    |
    = help: the trait `Iterator` is not implemented for `&std::slice::Iter<'_, {integer}>`
 help: the trait `Iterator` is implemented for `std::slice::Iter<'_, T>`
+  --> $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
   --> $SRC_DIR/core/src/slice/iter.rs:LL:COL
+  ::: $SRC_DIR/core/src/slice/iter.rs:LL:COL
+   |
+   = note: in this macro invocation
    = note: required for `&std::slice::Iter<'_, {integer}>` to implement `IntoIterator`
    = note: this error originates in the macro `iterator` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -80,7 +92,11 @@ LL |     for (src, dest) in std::iter::zip(fields.iter(), &variant.iter().clone(
    |
    = help: the trait `Iterator` is not implemented for `&std::slice::Iter<'_, {integer}>`
 help: the trait `Iterator` is implemented for `std::slice::Iter<'_, T>`
+  --> $SRC_DIR/core/src/slice/iter/macros.rs:LL:COL
   --> $SRC_DIR/core/src/slice/iter.rs:LL:COL
+  ::: $SRC_DIR/core/src/slice/iter.rs:LL:COL
+   |
+   = note: in this macro invocation
    = note: required for `&std::slice::Iter<'_, {integer}>` to implement `IntoIterator`
    = note: this error originates in the macro `iterator` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/try-trait/bad-interconversion.stderr
+++ b/tests/ui/try-trait/bad-interconversion.stderr
@@ -13,9 +13,15 @@ help: the following other types implement trait `From<T>`
   --> $SRC_DIR/core/src/convert/num.rs:LL:COL
    |
    = note: `u8` implements `From<bool>`
+  ::: $SRC_DIR/core/src/convert/num.rs:LL:COL
+   |
+   = note: in this macro invocation
   --> $SRC_DIR/core/src/ascii/ascii_char.rs:LL:COL
    |
    = note: `u8` implements `From<Char>`
+  ::: $SRC_DIR/core/src/ascii/ascii_char.rs:LL:COL
+   |
+   = note: in this macro invocation
    = note: this error originates in the macro `impl_from` which comes from the expansion of the macro `into_int_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the `?` operator can only be used on `Result`s, not `Option`s, in a function that returns `Result`

--- a/tests/ui/type-alias-impl-trait/self-referential-2.current.stderr
+++ b/tests/ui/type-alias-impl-trait/self-referential-2.current.stderr
@@ -9,6 +9,9 @@ LL |     42_i32
 help: the trait `PartialEq<Foo>` is not implemented for `i32`
       but trait `PartialEq<i32>` is implemented for it
   --> $SRC_DIR/core/src/cmp.rs:LL:COL
+  ::: $SRC_DIR/core/src/cmp.rs:LL:COL
+   |
+   = note: in this macro invocation
    = note: this error originates in the macro `partial_eq_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error

--- a/tests/ui/type-alias-impl-trait/self-referential-3.stderr
+++ b/tests/ui/type-alias-impl-trait/self-referential-3.stderr
@@ -10,6 +10,9 @@ LL |     i
    = help: the trait `PartialEq<Bar<'a, 'b>>` is not implemented for `&i32`
 help: the trait `PartialEq` is implemented for `i32`
   --> $SRC_DIR/core/src/cmp.rs:LL:COL
+  ::: $SRC_DIR/core/src/cmp.rs:LL:COL
+   |
+   = note: in this macro invocation
    = note: this error originates in the macro `partial_eq_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error

--- a/tests/ui/type-alias-impl-trait/self-referential-4.stderr
+++ b/tests/ui/type-alias-impl-trait/self-referential-4.stderr
@@ -9,6 +9,9 @@ LL |     i
    = help: the trait `PartialEq<Bar<'b, 'static>>` is not implemented for `&i32`
 help: the trait `PartialEq` is implemented for `i32`
   --> $SRC_DIR/core/src/cmp.rs:LL:COL
+  ::: $SRC_DIR/core/src/cmp.rs:LL:COL
+   |
+   = note: in this macro invocation
    = note: this error originates in the macro `partial_eq_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: can't compare `&i32` with `Foo<'static, 'b>`
@@ -22,6 +25,9 @@ LL |     i
    = help: the trait `PartialEq<Foo<'static, 'b>>` is not implemented for `&i32`
 help: the trait `PartialEq` is implemented for `i32`
   --> $SRC_DIR/core/src/cmp.rs:LL:COL
+  ::: $SRC_DIR/core/src/cmp.rs:LL:COL
+   |
+   = note: in this macro invocation
    = note: this error originates in the macro `partial_eq_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: can't compare `&i32` with `Moo<'static, 'a>`
@@ -35,6 +41,9 @@ LL |     i
    = help: the trait `PartialEq<Moo<'static, 'a>>` is not implemented for `&i32`
 help: the trait `PartialEq` is implemented for `i32`
   --> $SRC_DIR/core/src/cmp.rs:LL:COL
+  ::: $SRC_DIR/core/src/cmp.rs:LL:COL
+   |
+   = note: in this macro invocation
    = note: this error originates in the macro `partial_eq_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 3 previous errors

--- a/tests/ui/type-alias-impl-trait/self-referential.stderr
+++ b/tests/ui/type-alias-impl-trait/self-referential.stderr
@@ -10,6 +10,9 @@ LL |     i
    = help: the trait `PartialEq<Bar<'b, 'a>>` is not implemented for `&i32`
 help: the trait `PartialEq` is implemented for `i32`
   --> $SRC_DIR/core/src/cmp.rs:LL:COL
+  ::: $SRC_DIR/core/src/cmp.rs:LL:COL
+   |
+   = note: in this macro invocation
    = note: this error originates in the macro `partial_eq_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: can't compare `&i32` with `(i32, Foo<'a, 'b>::{opaque#0}<'a, 'b>)`
@@ -24,6 +27,9 @@ LL |     (42, i)
    = help: the trait `PartialEq<(i32, Foo<'a, 'b>::{opaque#0}<'a, 'b>)>` is not implemented for `&i32`
 help: the trait `PartialEq` is implemented for `i32`
   --> $SRC_DIR/core/src/cmp.rs:LL:COL
+  ::: $SRC_DIR/core/src/cmp.rs:LL:COL
+   |
+   = note: in this macro invocation
    = note: this error originates in the macro `partial_eq_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: can't compare `&i32` with `(i32, Moo<'b, 'a>::{opaque#0}<'b, 'a>)`
@@ -38,6 +44,9 @@ LL |     (42, i)
    = help: the trait `PartialEq<(i32, Moo<'b, 'a>::{opaque#0}<'b, 'a>)>` is not implemented for `&i32`
 help: the trait `PartialEq` is implemented for `i32`
   --> $SRC_DIR/core/src/cmp.rs:LL:COL
+  ::: $SRC_DIR/core/src/cmp.rs:LL:COL
+   |
+   = note: in this macro invocation
    = note: this error originates in the macro `partial_eq_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 3 previous errors

--- a/tests/ui/type/type-check-defaults.stderr
+++ b/tests/ui/type/type-check-defaults.stderr
@@ -86,13 +86,19 @@ LL | trait ProjectionPred<T:Iterator = IntoIter<i32>> where T::Item : Add<u8> {}
 help: the following other types implement trait `Add<Rhs>`
   --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
    |
-   = note: `&i32` implements `Add<i32>`
+   = note: `i32` implements `Add`
+  ::: $SRC_DIR/core/src/ops/arith.rs:LL:COL
    |
-   = note: `&i32` implements `Add`
+   = note: in this macro invocation
+  --> $SRC_DIR/core/src/internal_macros.rs:LL:COL
+   |
+   = note: `&i32` implements `Add<i32>`
+  ::: $SRC_DIR/core/src/internal_macros.rs:LL:COL
    |
    = note: `i32` implements `Add<&i32>`
+  ::: $SRC_DIR/core/src/internal_macros.rs:LL:COL
    |
-   = note: `i32` implements `Add`
+   = note: `&i32` implements `Add`
 note: required by a bound in `ProjectionPred`
   --> $DIR/type-check-defaults.rs:24:66
    |

--- a/tests/ui/typeck/issue-110017-format-into-help-deletes-macro.stderr
+++ b/tests/ui/typeck/issue-110017-format-into-help-deletes-macro.stderr
@@ -13,10 +13,13 @@ LL |      Err(format!("error: {x}").into())
    |                               +++++++
 
 error[E0308]: mismatched types
-  --> $DIR/issue-110017-format-into-help-deletes-macro.rs:23:10
+  --> $DIR/issue-110017-format-into-help-deletes-macro.rs:17:10
    |
+LL |          format!("error: {}", $x)
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^ expected `Box<dyn Error>`, found `String`
+...
 LL |      Err(outer!(x))
-   |          ^^^^^^^^^ expected `Box<dyn Error>`, found `String`
+   |          --------- in this macro invocation
    |
    = note: expected struct `Box<dyn std::error::Error>`
               found struct `String`
@@ -27,10 +30,13 @@ LL |          format!("error: {}", $x).into()
    |                                  +++++++
 
 error[E0308]: mismatched types
-  --> $DIR/issue-110017-format-into-help-deletes-macro.rs:41:2
+  --> $DIR/issue-110017-format-into-help-deletes-macro.rs:35:18
    |
+LL |              Err(format!("error: {x}"))
+   |                  ^^^^^^^^^^^^^^^^^^^^^ expected `Box<dyn Error>`, found `String`
+...
 LL |  entire_fn_outer!();
-   |  ^^^^^^^^^^^^^^^^^^ expected `Box<dyn Error>`, found `String`
+   |  ------------------ in this macro invocation
    |
    = note: expected struct `Box<dyn std::error::Error>`
               found struct `String`
@@ -41,10 +47,13 @@ LL |              Err(format!("error: {x}").into())
    |                                       +++++++
 
 error[E0308]: mismatched types
-  --> $DIR/issue-110017-format-into-help-deletes-macro.rs:51:5
+  --> $DIR/issue-110017-format-into-help-deletes-macro.rs:45:13
    |
+LL |         Err(format!("error: {}", $x))
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^ expected `Box<dyn Error>`, found `String`
+...
 LL |     nontrivial!(x)
-   |     ^^^^^^^^^^^^^^ expected `Box<dyn Error>`, found `String`
+   |     -------------- in this macro invocation
    |
    = note: expected struct `Box<dyn std::error::Error>`
               found struct `String`

--- a/tests/ui/typeck/issue-112007-leaked-writeln-macro-internals.stderr
+++ b/tests/ui/typeck/issue-112007-leaked-writeln-macro-internals.stderr
@@ -27,13 +27,16 @@ LL |         writeln!(w, "but not here")?
    |                                    +
 
 error[E0308]: mismatched types
-  --> $DIR/issue-112007-leaked-writeln-macro-internals.rs:40:9
+  --> $DIR/issue-112007-leaked-writeln-macro-internals.rs:31:9
    |
+LL |           writeln!($w, "but not here")
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found `Result<(), Error>`
+...
 LL | /     if true {
 LL | |         writeln!(w, "`;?` here ->")?;
 LL | |     } else {
 LL | |         baz!(w)
-   | |         ^^^^^^^ expected `()`, found `Result<(), Error>`
+   | |         ------- in this macro invocation
 LL | |     }
    | |_____- expected this to be `()`
    |

--- a/tests/ui/typeck/issue-81293.stderr
+++ b/tests/ui/typeck/issue-81293.stderr
@@ -23,13 +23,19 @@ LL |     a = c + b * 5;
 help: the following other types implement trait `Add<Rhs>`
   --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
    |
-   = note: `&usize` implements `Add<usize>`
+   = note: `usize` implements `Add`
+  ::: $SRC_DIR/core/src/ops/arith.rs:LL:COL
    |
-   = note: `&usize` implements `Add`
+   = note: in this macro invocation
+  --> $SRC_DIR/core/src/internal_macros.rs:LL:COL
+   |
+   = note: `&usize` implements `Add<usize>`
+  ::: $SRC_DIR/core/src/internal_macros.rs:LL:COL
    |
    = note: `usize` implements `Add<&usize>`
+  ::: $SRC_DIR/core/src/internal_macros.rs:LL:COL
    |
-   = note: `usize` implements `Add`
+   = note: `&usize` implements `Add`
    = note: this error originates in the macro `add_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 3 previous errors

--- a/tests/ui/ufcs/ufcs-qpath-self-mismatch.stderr
+++ b/tests/ui/ufcs/ufcs-qpath-self-mismatch.stderr
@@ -8,13 +8,19 @@ LL |     <i32 as Add<u32>>::add(1, 2);
 help: the following other types implement trait `Add<Rhs>`
   --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
    |
-   = note: `&i32` implements `Add<i32>`
+   = note: `i32` implements `Add`
+  ::: $SRC_DIR/core/src/ops/arith.rs:LL:COL
    |
-   = note: `&i32` implements `Add`
+   = note: in this macro invocation
+  --> $SRC_DIR/core/src/internal_macros.rs:LL:COL
+   |
+   = note: `&i32` implements `Add<i32>`
+  ::: $SRC_DIR/core/src/internal_macros.rs:LL:COL
    |
    = note: `i32` implements `Add<&i32>`
+  ::: $SRC_DIR/core/src/internal_macros.rs:LL:COL
    |
-   = note: `i32` implements `Add`
+   = note: `&i32` implements `Add`
    = note: this error originates in the macro `add_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0308]: mismatched types
@@ -73,13 +79,19 @@ LL |     <i32 as Add<u32>>::add(1, 2);
 help: the following other types implement trait `Add<Rhs>`
   --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
    |
-   = note: `&i32` implements `Add<i32>`
+   = note: `i32` implements `Add`
+  ::: $SRC_DIR/core/src/ops/arith.rs:LL:COL
    |
-   = note: `&i32` implements `Add`
+   = note: in this macro invocation
+  --> $SRC_DIR/core/src/internal_macros.rs:LL:COL
+   |
+   = note: `&i32` implements `Add<i32>`
+  ::: $SRC_DIR/core/src/internal_macros.rs:LL:COL
    |
    = note: `i32` implements `Add<&i32>`
+  ::: $SRC_DIR/core/src/internal_macros.rs:LL:COL
    |
-   = note: `i32` implements `Add`
+   = note: `&i32` implements `Add`
    = note: this error originates in the macro `add_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 4 previous errors


### PR DESCRIPTION
Address issue noticed at https://users.rust-lang.org/t/error-message-does-not-specify-where-in-macro/135157/1. On errors occurring within a macro expansion, point at the innermost local macro expansion point.

```
error[E0308]: mismatched types
  --> $DIR/macro-span-caller-replacement.rs:5:17
   |
LL |             s = format!("{arg}");
   |                 ^^^^^^^^^^^^^^^^ expected `&str`, found `String`
...
LL |     macro_with_format!();
   |     -------------------- in this macro invocation
   |
   = note: this error originates in the macro `format` which comes from the expansion of the macro `macro_with_format` (in Nightly builds, run with -Z macro-backtrace for more info)
```

