### PR TITLE
Do not mention `-Zmacro-backtrace` for std macros that are a wrapper around a compiler intrinsic

### DIFF
--- a/src/tools/clippy/tests/ui/recursive_format_impl.stderr
+++ b/src/tools/clippy/tests/ui/recursive_format_impl.stderr
@@ -12,72 +12,54 @@ error: using `self` as `Display` in `impl Display` will cause infinite recursion
    |
 LL |         write!(f, "{}", self)
    |         ^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this error originates in the macro `write` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: using `self` as `Display` in `impl Display` will cause infinite recursion
   --> tests/ui/recursive_format_impl.rs:86:9
    |
 LL |         write!(f, "{}", &self)
    |         ^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this error originates in the macro `write` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: using `self` as `Debug` in `impl Debug` will cause infinite recursion
   --> tests/ui/recursive_format_impl.rs:93:9
    |
 LL |         write!(f, "{:?}", &self)
    |         ^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this error originates in the macro `write` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: using `self` as `Display` in `impl Display` will cause infinite recursion
   --> tests/ui/recursive_format_impl.rs:103:9
    |
 LL |         write!(f, "{}", &&&self)
    |         ^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this error originates in the macro `write` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: using `self` as `Display` in `impl Display` will cause infinite recursion
   --> tests/ui/recursive_format_impl.rs:178:9
    |
 LL |         write!(f, "{}", &*self)
    |         ^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this error originates in the macro `write` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: using `self` as `Debug` in `impl Debug` will cause infinite recursion
   --> tests/ui/recursive_format_impl.rs:185:9
    |
 LL |         write!(f, "{:?}", &*self)
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this error originates in the macro `write` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: using `self` as `Display` in `impl Display` will cause infinite recursion
   --> tests/ui/recursive_format_impl.rs:202:9
    |
 LL |         write!(f, "{}", *self)
    |         ^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this error originates in the macro `write` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: using `self` as `Display` in `impl Display` will cause infinite recursion
   --> tests/ui/recursive_format_impl.rs:219:9
    |
 LL |         write!(f, "{}", **&&*self)
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this error originates in the macro `write` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: using `self` as `Display` in `impl Display` will cause infinite recursion
   --> tests/ui/recursive_format_impl.rs:236:9
    |
 LL |         write!(f, "{}", &&**&&*self)
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this error originates in the macro `write` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 10 previous errors
 

--- a/src/tools/miri/tests/fail-dep/concurrency/windows_join_main.stderr
+++ b/src/tools/miri/tests/fail-dep/concurrency/windows_join_main.stderr
@@ -31,7 +31,6 @@ LL | |             assert_eq!(WaitForSingleObject(MAIN_THREAD, INFINITE), WAIT_O
 LL | |         }
 LL | |     })
    | |______^
-   = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/src/tools/miri/tests/fail/dangling_pointers/dangling_primitive.stderr
+++ b/src/tools/miri/tests/fail/dangling_pointers/dangling_primitive.stderr
@@ -16,7 +16,6 @@ help: ALLOC was deallocated here:
    |
 LL |     };
    |     ^
-   = note: this error originates in the macro `$crate::macros::dbg_internal` which comes from the expansion of the macro `dbg` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/src/tools/miri/tests/fail/dangling_pointers/out_of_bounds_read.stderr
+++ b/src/tools/miri/tests/fail/dangling_pointers/out_of_bounds_read.stderr
@@ -11,7 +11,6 @@ help: ALLOC was allocated here:
    |
 LL |     let v: Vec<u16> = vec![1, 2];
    |                       ^^^^^^^^^^
-   = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/src/tools/miri/tests/fail/dangling_pointers/out_of_bounds_read_neg_offset.stderr
+++ b/src/tools/miri/tests/fail/dangling_pointers/out_of_bounds_read_neg_offset.stderr
@@ -11,7 +11,6 @@ help: ALLOC was allocated here:
    |
 LL |     let v: Vec<u16> = vec![1, 2];
    |                       ^^^^^^^^^^
-   = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/src/tools/miri/tests/fail/dangling_pointers/out_of_bounds_write.stderr
+++ b/src/tools/miri/tests/fail/dangling_pointers/out_of_bounds_write.stderr
@@ -11,7 +11,6 @@ help: ALLOC was allocated here:
    |
 LL |     let mut v: Vec<u16> = vec![1, 2];
    |                           ^^^^^^^^^^
-   = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/src/tools/miri/tests/fail/erroneous_const2.stderr
+++ b/src/tools/miri/tests/fail/erroneous_const2.stderr
@@ -23,8 +23,6 @@ note: erroneous constant encountered
    |
 LL |     println!("{}", FOO);
    |                    ^^^
-   |
-   = note: this note originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/src/tools/miri/tests/fail/function_calls/return_pointer_on_unwind.stderr
+++ b/src/tools/miri/tests/fail/function_calls/return_pointer_on_unwind.stderr
@@ -11,7 +11,6 @@ LL |     dbg!(x.0);
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-   = note: this error originates in the macro `$crate::macros::dbg_internal` which comes from the expansion of the macro `dbg` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 Uninitialized memory occurred at ALLOC[0x0..0x4], in this allocation:
 ALLOC (stack variable, size: 132, align: 4) {

--- a/src/tools/miri/tests/fail/intrinsics/simd-scatter.stderr
+++ b/src/tools/miri/tests/fail/intrinsics/simd-scatter.stderr
@@ -16,7 +16,6 @@ help: ALLOC was allocated here:
    |
 LL |         let mut vec: Vec<i8> = vec![10, 11, 12, 13, 14, 15, 16, 17, 18];
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/src/tools/miri/tests/fail/provenance/mix-ptrs1.stderr
+++ b/src/tools/miri/tests/fail/provenance/mix-ptrs1.stderr
@@ -6,7 +6,6 @@ LL |         assert_eq!(*strange_ptr.with_addr(ptr.addr()), 0);
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-   = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/src/tools/miri/tests/fail/provenance/mix-ptrs2.stderr
+++ b/src/tools/miri/tests/fail/provenance/mix-ptrs2.stderr
@@ -6,7 +6,6 @@ LL |         assert_eq!(*ptr, 42);
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-   = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/src/tools/miri/tests/fail/rc_as_ptr.stderr
+++ b/src/tools/miri/tests/fail/rc_as_ptr.stderr
@@ -16,7 +16,6 @@ help: ALLOC was deallocated here:
    |
 LL |     drop(strong);
    |     ^^^^^^^^^^^^
-   = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/src/tools/miri/tests/fail/stacked_borrows/zst_slice.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/zst_slice.stderr
@@ -11,7 +11,6 @@ help: <TAG> would have been created here, but this is a zero-size retag ([0x0..0
    |
 LL |         assert_eq!(*s.as_ptr().add(1), 2);
    |                     ^^^^^^^^^^
-   = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/src/tools/miri/tests/fail/tree_borrows/parent_read_freezes_raw_mut.stderr
+++ b/src/tools/miri/tests/fail/tree_borrows/parent_read_freezes_raw_mut.stderr
@@ -24,7 +24,6 @@ help: the accessed tag <TAG> later transitioned to Frozen due to a reborrow (act
 LL |         assert_eq!(root, 0); // Parent Read
    |         ^^^^^^^^^^^^^^^^^^^
    = help: this transition corresponds to a loss of write permissions
-   = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/src/tools/miri/tests/fail/tree_borrows/protector-write-lazy.stderr
+++ b/src/tools/miri/tests/fail/tree_borrows/protector-write-lazy.stderr
@@ -18,7 +18,6 @@ help: the accessed tag <TAG> later transitioned to Disabled due to a protector r
 LL | }
    |  ^
    = help: this transition corresponds to a loss of read and write permissions
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/src/tools/miri/tests/pass/alloc-access-tracking.stderr
+++ b/src/tools/miri/tests/pass/alloc-access-tracking.stderr
@@ -15,8 +15,6 @@ note: read access at ALLOC[0..1]
    |
 LL |         assert_eq!(*ptr, 42);
    |         ^^^^^^^^^^^^^^^^^^^^ tracking was triggered here
-   |
-   = note: this note originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: freed allocation ALLOC
   --> RUSTLIB/alloc/src/boxed.rs:LL:CC

--- a/tests/rustdoc-ui/doctest/main-alongside-macro-calls.fail.stdout
+++ b/tests/rustdoc-ui/doctest/main-alongside-macro-calls.fail.stdout
@@ -13,8 +13,6 @@ error: macros that expand to items must be delimited with braces or followed by 
    |
 LL | println!();
    | ^^^^^^^^^^
-   |
-   = note: this error originates in the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: macro expansion ignores `{` and any tokens following
   --> $SRC_DIR/std/src/macros.rs:LL:COL
@@ -35,8 +33,6 @@ error: macros that expand to items must be delimited with braces or followed by 
    |
 LL | println!();
    | ^^^^^^^^^^
-   |
-   = note: this error originates in the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: macro expansion ignores `{` and any tokens following
   --> $SRC_DIR/std/src/macros.rs:LL:COL

--- a/tests/ui/asm/aarch64/type-check-2.stderr
+++ b/tests/ui/asm/aarch64/type-check-2.stderr
@@ -21,7 +21,6 @@ LL |         asm!("{}", in(reg) vec![0]);
    |                            ^^^^^^^
    |
    = note: only integers, floats, SIMD vectors, pointers and function pointers can be used as arguments for inline assembly
-   = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: cannot use value of type `(i32, i32, i32)` for inline assembly
   --> $DIR/type-check-2.rs:36:28

--- a/tests/ui/asm/parse-error.stderr
+++ b/tests/ui/asm/parse-error.stderr
@@ -193,16 +193,12 @@ error: asm template must be a string literal
    |
 LL |         asm!(format!("{{{}}}", 0), in(reg) foo);
    |              ^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this error originates in the macro `format` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: asm template must be a string literal
   --> $DIR/parse-error.rs:86:21
    |
 LL |         asm!("{1}", format!("{{{}}}", 0), in(reg) foo, out(reg) bar);
    |                     ^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this error originates in the macro `format` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: _ cannot be used for input operands
   --> $DIR/parse-error.rs:88:28
@@ -357,16 +353,12 @@ error: asm template must be a string literal
    |
 LL | global_asm!(format!("{{{}}}", 0), const FOO);
    |             ^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this error originates in the macro `format` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: asm template must be a string literal
   --> $DIR/parse-error.rs:143:20
    |
 LL | global_asm!("{1}", format!("{{{}}}", 0), const FOO, const BAR);
    |                    ^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this error originates in the macro `format` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: the `in` operand cannot be used with `global_asm!`
   --> $DIR/parse-error.rs:146:19

--- a/tests/ui/asm/x86_64/type-check-2.stderr
+++ b/tests/ui/asm/x86_64/type-check-2.stderr
@@ -21,7 +21,6 @@ LL |         asm!("{}", in(reg) vec![0]);
    |                            ^^^^^^^
    |
    = note: only integers, floats, SIMD vectors, pointers and function pointers can be used as arguments for inline assembly
-   = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: cannot use value of type `(i32, i32, i32)` for inline assembly
   --> $DIR/type-check-2.rs:52:28

--- a/tests/ui/associated-consts/defaults-not-assumed-fail.stderr
+++ b/tests/ui/associated-consts/defaults-not-assumed-fail.stderr
@@ -23,8 +23,6 @@ note: erroneous constant encountered
    |
 LL |     assert_eq!(<() as Tr>::B, 0);    // causes the error above
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this note originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: erroneous constant encountered
   --> $DIR/defaults-not-assumed-fail.rs:34:5
@@ -33,7 +31,6 @@ LL |     assert_eq!(<() as Tr>::B, 0);    // causes the error above
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-   = note: this note originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/async-await/unreachable-lint-2.stderr
+++ b/tests/ui/async-await/unreachable-lint-2.stderr
@@ -11,7 +11,6 @@ note: the lint level is defined here
    |
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
-   = note: this error originates in the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/binop/binary-operation-error-on-function-70724.stderr
+++ b/tests/ui/binop/binary-operation-error-on-function-70724.stderr
@@ -6,8 +6,6 @@ LL |     assert_eq!(a, 0);
    |     |
    |     fn() -> i32 {a}
    |     {integer}
-   |
-   = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0308]: mismatched types
   --> $DIR/binary-operation-error-on-function-70724.rs:7:5
@@ -17,7 +15,6 @@ LL |     assert_eq!(a, 0);
    |
    = note: expected fn item `fn() -> i32 {a}`
                  found type `{integer}`
-   = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `fn() -> i32 {a}` doesn't implement `Debug`
   --> $DIR/binary-operation-error-on-function-70724.rs:7:5
@@ -29,7 +26,6 @@ LL |     assert_eq!(a, 0);
    |     ^^^^^^^^^^^^^^^^ the trait `Debug` is not implemented for fn item `fn() -> i32 {a}`
    |
    = help: use parentheses to call this function: `a()`
-   = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/binop/eq-vec.stderr
+++ b/tests/ui/binop/eq-vec.stderr
@@ -12,7 +12,6 @@ note: an implementation of `PartialEq` might be missing for `Foo`
    |
 LL |     enum Foo {
    |     ^^^^^^^^ must implement `PartialEq`
-   = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `Foo` with `#[derive(PartialEq)]`
    |
 LL +     #[derive(PartialEq)]

--- a/tests/ui/binop/function-comparison-errors-59488.stderr
+++ b/tests/ui/binop/function-comparison-errors-59488.stderr
@@ -80,24 +80,18 @@ LL |     assert_eq!(Foo::Bar, i);
    |     |
    |     fn(usize) -> Foo {Foo::Bar}
    |     fn(usize) -> Foo {Foo::Bar}
-   |
-   = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `fn(usize) -> Foo {Foo::Bar}` doesn't implement `Debug`
   --> $DIR/function-comparison-errors-59488.rs:31:5
    |
 LL |     assert_eq!(Foo::Bar, i);
    |     ^^^^^^^^^^^^^^^^^^^^^^^ the trait `Debug` is not implemented for fn item `fn(usize) -> Foo {Foo::Bar}`
-   |
-   = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `fn(usize) -> Foo {Foo::Bar}` doesn't implement `Debug`
   --> $DIR/function-comparison-errors-59488.rs:31:5
    |
 LL |     assert_eq!(Foo::Bar, i);
    |     ^^^^^^^^^^^^^^^^^^^^^^^ the trait `Debug` is not implemented for fn item `fn(usize) -> Foo {Foo::Bar}`
-   |
-   = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 10 previous errors
 

--- a/tests/ui/binop/issue-77910-1.stderr
+++ b/tests/ui/binop/issue-77910-1.stderr
@@ -6,8 +6,6 @@ LL |     assert_eq!(foo, y);
    |     |
    |     for<'a> fn(&'a i32) -> &'a i32 {foo}
    |     _
-   |
-   = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `for<'a> fn(&'a i32) -> &'a i32 {foo}` doesn't implement `Debug`
   --> $DIR/issue-77910-1.rs:8:5
@@ -19,7 +17,6 @@ LL |     assert_eq!(foo, y);
    |     ^^^^^^^^^^^^^^^^^^ the trait `Debug` is not implemented for fn item `for<'a> fn(&'a i32) -> &'a i32 {foo}`
    |
    = help: use parentheses to call this function: `foo(/* &i32 */)`
-   = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0381]: used binding `xs` isn't initialized
   --> $DIR/issue-77910-1.rs:3:5

--- a/tests/ui/borrowck/alias-liveness/higher-ranked-outlives-for-capture.stderr
+++ b/tests/ui/borrowck/alias-liveness/higher-ranked-outlives-for-capture.stderr
@@ -8,8 +8,6 @@ LL |     test(&vec![])
    |     argument requires that borrow lasts for `'static`
 LL | }
    | - temporary value is freed at the end of this statement
-   |
-   = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/borrowck/borrowck-and-init.stderr
+++ b/tests/ui/borrowck/borrowck-and-init.stderr
@@ -8,8 +8,6 @@ LL |     println!("{}", false && { i = 5; true });
    |                               ----- binding initialized here in some conditions
 LL |     println!("{}", i);
    |                    ^ `i` used here but it is possibly-uninitialized
-   |
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/borrowck/borrowck-borrowed-uniq-rvalue-2.stderr
+++ b/tests/ui/borrowck/borrowck-borrowed-uniq-rvalue-2.stderr
@@ -8,7 +8,6 @@ LL |     let x = defer(&vec!["Goodbye", "world!"]);
 LL |     x.x[0];
    |     ------ borrow later used here
    |
-   = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider using a `let` binding to create a longer lived value
    |
 LL ~     let binding = vec!["Goodbye", "world!"];

--- a/tests/ui/borrowck/borrowck-break-uninit-2.stderr
+++ b/tests/ui/borrowck/borrowck-break-uninit-2.stderr
@@ -7,7 +7,6 @@ LL |     let x: isize;
 LL |     println!("{}", x);
    |                    ^ `x` used here but it isn't initialized
    |
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider assigning a value
    |
 LL |     let x: isize = 42;

--- a/tests/ui/borrowck/borrowck-break-uninit.stderr
+++ b/tests/ui/borrowck/borrowck-break-uninit.stderr
@@ -7,7 +7,6 @@ LL |     let x: isize;
 LL |     println!("{}", x);
    |                    ^ `x` used here but it isn't initialized
    |
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider assigning a value
    |
 LL |     let x: isize = 42;

--- a/tests/ui/borrowck/borrowck-or-init.stderr
+++ b/tests/ui/borrowck/borrowck-or-init.stderr
@@ -8,8 +8,6 @@ LL |     println!("{}", false || { i = 5; true });
    |                               ----- binding initialized here in some conditions
 LL |     println!("{}", i);
    |                    ^ `i` used here but it is possibly-uninitialized
-   |
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/borrowck/borrowck-while-break.stderr
+++ b/tests/ui/borrowck/borrowck-while-break.stderr
@@ -8,8 +8,6 @@ LL |     while cond {
 ...
 LL |     println!("{}", v);
    |                    ^ `v` used here but it is possibly-uninitialized
-   |
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/borrowck/issue-24267-flow-exit.stderr
+++ b/tests/ui/borrowck/issue-24267-flow-exit.stderr
@@ -7,7 +7,6 @@ LL |     loop { x = break; }
 LL |     println!("{}", x);
    |                    ^ `x` used here but it isn't initialized
    |
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider assigning a value
    |
 LL |     let x: i32 = 42;
@@ -22,7 +21,6 @@ LL |     for _ in 0..10 { x = continue; }
 LL |     println!("{}", x);
    |                    ^ `x` used here but it isn't initialized
    |
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider assigning a value
    |
 LL |     let x: i32 = 42;

--- a/tests/ui/borrowck/issue-47646.stderr
+++ b/tests/ui/borrowck/issue-47646.stderr
@@ -12,8 +12,6 @@ LL |             println!("{:?}", heap);
 ...
 LL |     };
    |      - ... and the mutable borrow might be used here, when that temporary is dropped and runs the destructor for type `(Option<std::collections::binary_heap::PeekMut<'_, i32>>, ())`
-   |
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/borrowck/issue-64453.stderr
+++ b/tests/ui/borrowck/issue-64453.stderr
@@ -8,7 +8,6 @@ note: function `format` is not const
   --> $SRC_DIR/alloc/src/fmt.rs:LL:COL
    = note: calls in statics are limited to constant functions, tuple structs and tuple variants
    = note: consider wrapping this expression in `std::sync::LazyLock::new(|| ...)`
-   = note: this error originates in the macro `format` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0507]: cannot move out of static item `settings_dir`
   --> $DIR/issue-64453.rs:13:37

--- a/tests/ui/borrowck/ownership-struct-update-moved-error.stderr
+++ b/tests/ui/borrowck/ownership-struct-update-moved-error.stderr
@@ -13,7 +13,6 @@ note: `Mine::make_string_bar` takes ownership of the receiver `self`, which move
    |
 LL |     fn make_string_bar(mut self) -> Mine {
    |                            ^^^^
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/borrowck/suggest-assign-rvalue.stderr
+++ b/tests/ui/borrowck/suggest-assign-rvalue.stderr
@@ -19,7 +19,6 @@ LL |     let my_float: f32;
 LL |     println!("my_float: {}", my_float);
    |                              ^^^^^^^^ `my_float` used here but it isn't initialized
    |
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider assigning a value
    |
 LL |     let my_float: f32 = 3.14159;
@@ -33,7 +32,6 @@ LL |     let demo: Demo;
 LL |     println!("demo: {:?}", demo);
    |                            ^^^^ `demo` used here but it isn't initialized
    |
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider assigning a value
    |
 LL |     let demo: Demo = Default::default();
@@ -47,7 +45,6 @@ LL |     let demo_no: DemoNoDef;
 LL |     println!("demo_no: {:?}", demo_no);
    |                               ^^^^^^^ `demo_no` used here but it isn't initialized
    |
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider assigning a value
    |
 LL |     let demo_no: DemoNoDef = /* value */;
@@ -61,7 +58,6 @@ LL |     let arr: [i32; 5];
 LL |     println!("arr: {:?}", arr);
    |                           ^^^ `arr` used here but it isn't initialized
    |
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider assigning a value
    |
 LL |     let arr: [i32; 5] = [42; 5];
@@ -75,7 +71,6 @@ LL |     let foo: Vec<&str>;
 LL |     println!("foo: {:?}", foo);
    |                           ^^^ `foo` used here but it isn't initialized
    |
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider assigning a value
    |
 LL |     let foo: Vec<&str> = vec![];
@@ -89,7 +84,6 @@ LL |     let my_string: String;
 LL |     println!("my_string: {}", my_string);
    |                               ^^^^^^^^^ `my_string` used here but it isn't initialized
    |
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider assigning a value
    |
 LL |     let my_string: String = Default::default();
@@ -103,7 +97,6 @@ LL |     let my_int: &i32;
 LL |     println!("my_int: {}", *my_int);
    |                            ^^^^^^^ `*my_int` used here but it isn't initialized
    |
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider assigning a value
    |
 LL |     let my_int: &i32 = &42;
@@ -117,7 +110,6 @@ LL |     let hello: &str;
 LL |     println!("hello: {}", hello);
    |                           ^^^^^ `hello` used here but it isn't initialized
    |
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider assigning a value
    |
 LL |     let hello: &str = "";
@@ -130,8 +122,6 @@ LL |     let never: !;
    |         ----- binding declared here but left uninitialized
 LL |     println!("never: {}", never);
    |                           ^^^^^ `never` used here but it isn't initialized
-   |
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 10 previous errors
 

--- a/tests/ui/closures/2229_closure_analysis/diagnostics/arrays.stderr
+++ b/tests/ui/closures/2229_closure_analysis/diagnostics/arrays.stderr
@@ -53,8 +53,6 @@ LL |     println!("{}", arr[3]);
 ...
 LL |     c();
    |     - mutable borrow later used here
-   |
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0502]: cannot borrow `arr` as immutable because it is also borrowed as mutable
   --> $DIR/arrays.rs:71:24

--- a/tests/ui/closures/2229_closure_analysis/diagnostics/box.stderr
+++ b/tests/ui/closures/2229_closure_analysis/diagnostics/box.stderr
@@ -25,8 +25,6 @@ LL |     println!("{}", e.0.0.m.x);
 LL |
 LL |     c();
    |     - mutable borrow later used here
-   |
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0506]: cannot assign to `e.0.0.m.x` because it is borrowed
   --> $DIR/box.rs:55:5

--- a/tests/ui/closures/2229_closure_analysis/diagnostics/repr_packed.stderr
+++ b/tests/ui/closures/2229_closure_analysis/diagnostics/repr_packed.stderr
@@ -7,7 +7,6 @@ LL |         println!("{}", foo.x);
    = note: this struct is 1-byte aligned, but the type of this field may require higher alignment
    = note: creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
    = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/closures/2229_closure_analysis/diagnostics/simple-struct-min-capture.stderr
+++ b/tests/ui/closures/2229_closure_analysis/diagnostics/simple-struct-min-capture.stderr
@@ -13,8 +13,6 @@ LL |     println!("{:?}", p);
 LL |
 LL |     c();
    |     - mutable borrow later used here
-   |
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/closures/issue-111932.stderr
+++ b/tests/ui/closures/issue-111932.stderr
@@ -17,7 +17,6 @@ LL |         println!("{:?}", foo);
    |                   required by this formatting parameter
    |
    = help: the trait `Sized` is not implemented for `dyn Foo`
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/codemap_tests/bad-format-args.stderr
+++ b/tests/ui/codemap_tests/bad-format-args.stderr
@@ -3,8 +3,6 @@ error: requires at least a format string argument
    |
 LL |     format!();
    |     ^^^^^^^^^
-   |
-   = note: this error originates in the macro `$crate::__export::format_args` which comes from the expansion of the macro `format` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: expected `,`, found `1`
   --> $DIR/bad-format-args.rs:3:16

--- a/tests/ui/codemap_tests/tab_3.stderr
+++ b/tests/ui/codemap_tests/tab_3.stderr
@@ -11,7 +11,6 @@ LL |         println!("{:?}", some_vec);
    |
 note: `into_iter` takes ownership of the receiver `self`, which moves `some_vec`
   --> $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: you can `clone` the value and consume it, but this might not be your desired behavior
    |
 LL |     some_vec.clone().into_iter();

--- a/tests/ui/const-generics/vec-macro-in-static-array.stderr
+++ b/tests/ui/const-generics/vec-macro-in-static-array.stderr
@@ -6,7 +6,6 @@ LL | static VEC: [u32; 256] = vec![];
    |
    = note: expected array `[u32; 256]`
              found struct `Vec<_>`
-   = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/const-eval/const_panic.stderr
+++ b/tests/ui/consts/const-eval/const_panic.stderr
@@ -21,8 +21,6 @@ error[E0080]: evaluation panicked: not implemented
    |
 LL | const X: () = std::unimplemented!();
    |               ^^^^^^^^^^^^^^^^^^^^^ evaluation of `X` failed here
-   |
-   = note: this error originates in the macro `std::unimplemented` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0080]: evaluation panicked: hello
   --> $DIR/const_panic.rs:19:15
@@ -59,8 +57,6 @@ error[E0080]: evaluation panicked: not implemented
    |
 LL | const X_CORE: () = core::unimplemented!();
    |                    ^^^^^^^^^^^^^^^^^^^^^^ evaluation of `X_CORE` failed here
-   |
-   = note: this error originates in the macro `core::unimplemented` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0080]: evaluation panicked: hello
   --> $DIR/const_panic.rs:37:20

--- a/tests/ui/consts/const-eval/const_panic_2021.stderr
+++ b/tests/ui/consts/const-eval/const_panic_2021.stderr
@@ -21,8 +21,6 @@ error[E0080]: evaluation panicked: not implemented
    |
 LL | const D: () = std::unimplemented!();
    |               ^^^^^^^^^^^^^^^^^^^^^ evaluation of `D` failed here
-   |
-   = note: this error originates in the macro `std::unimplemented` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0080]: evaluation panicked: hello
   --> $DIR/const_panic_2021.rs:18:15
@@ -53,8 +51,6 @@ error[E0080]: evaluation panicked: not implemented
    |
 LL | const D_CORE: () = core::unimplemented!();
    |                    ^^^^^^^^^^^^^^^^^^^^^^ evaluation of `D_CORE` failed here
-   |
-   = note: this error originates in the macro `core::unimplemented` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0080]: evaluation panicked: hello
   --> $DIR/const_panic_2021.rs:33:20

--- a/tests/ui/consts/const-eval/const_panic_libcore_bin.stderr
+++ b/tests/ui/consts/const-eval/const_panic_libcore_bin.stderr
@@ -15,8 +15,6 @@ error[E0080]: evaluation panicked: not implemented
    |
 LL | const X: () = unimplemented!();
    |               ^^^^^^^^^^^^^^^^ evaluation of `X` failed here
-   |
-   = note: this error originates in the macro `unimplemented` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/consts/const-eval/format.stderr
+++ b/tests/ui/consts/const-eval/format.stderr
@@ -13,7 +13,6 @@ LL |     println!("{:?}", 0);
    |     ^^^^^^^^^^^^^^^^^^^
    |
    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
-   = note: this error originates in the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0015]: cannot call non-const function `std::io::_print` in constant functions
   --> $DIR/format.rs:7:5
@@ -24,7 +23,6 @@ LL |     println!("{:?}", 0);
 note: function `_print` is not const
   --> $SRC_DIR/std/src/io/stdio.rs:LL:COL
    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
-   = note: this error originates in the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0015]: cannot call non-const formatting macro in constant functions
   --> $DIR/format.rs:13:5

--- a/tests/ui/consts/const-eval/issue-44578.stderr
+++ b/tests/ui/consts/const-eval/issue-44578.stderr
@@ -23,8 +23,6 @@ note: erroneous constant encountered
    |
 LL |     println!("{}", <Bar<u16, u8> as Foo>::AMT);
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this note originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: erroneous constant encountered
   --> $DIR/issue-44578.rs:26:20
@@ -33,7 +31,6 @@ LL |     println!("{}", <Bar<u16, u8> as Foo>::AMT);
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-   = note: this note originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/control-flow/issue-50577.stderr
+++ b/tests/ui/consts/control-flow/issue-50577.stderr
@@ -3,8 +3,6 @@ error[E0308]: mismatched types
    |
 LL |         Drop = assert_eq!(1, 1),
    |                ^^^^^^^^^^^^^^^^ expected `isize`, found `()`
-   |
-   = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/min_const_fn/bad_const_fn_body_ice.stderr
+++ b/tests/ui/consts/min_const_fn/bad_const_fn_body_ice.stderr
@@ -3,8 +3,6 @@ error[E0010]: allocations are not allowed in constant functions
    |
 LL |     vec![1, 2, 3]
    |     ^^^^^^^^^^^^^ allocation not allowed in constant functions
-   |
-   = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0015]: cannot call non-const method `slice::<impl [i32]>::into_vec::<std::alloc::Global>` in constant functions
   --> $DIR/bad_const_fn_body_ice.rs:2:5
@@ -13,7 +11,6 @@ LL |     vec![1, 2, 3]
    |     ^^^^^^^^^^^^^
    |
    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
-   = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/consts/recursive-const-in-impl.stderr
+++ b/tests/ui/consts/recursive-const-in-impl.stderr
@@ -6,7 +6,6 @@ LL |     println!("{}", Thing::<i32>::X);
    |
    = help: consider increasing the recursion limit by adding a `#![recursion_limit = "14"]` attribute to your crate (`recursive_const_in_impl`)
    = note: query depth increased by 9 when simplifying constant for the type system `main::promoted[0]`
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/coroutine/yield-while-ref-reborrowed.stderr
+++ b/tests/ui/coroutine/yield-while-ref-reborrowed.stderr
@@ -10,8 +10,6 @@ LL |     println!("{}", x);
    |                    ^ second borrow occurs here
 LL |     Pin::new(&mut b).resume(());
    |              ------ first borrow later used here
-   |
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/delegation/ice-line-bounds-issue-148732.stderr
+++ b/tests/ui/delegation/ice-line-bounds-issue-148732.stderr
@@ -3,8 +3,6 @@ error[E0106]: missing lifetime specifier
    |
 LL |     dbg!(b);
    |     ^^^^^^^ expected named lifetime parameter
-   |
-   = note: this error originates in the macro `$crate::macros::dbg_internal` which comes from the expansion of the macro `dbg` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0425]: cannot find function `a` in this scope
   --> $DIR/ice-line-bounds-issue-148732.rs:1:7
@@ -37,7 +35,6 @@ LL |     dbg!(b);
    |     ^^^^^^^ the trait `Debug` is not implemented for fn item `fn() {b}`
    |
    = help: use parentheses to call this function: `b()`
-   = note: this error originates in the macro `$crate::macros::dbg_internal` which comes from the expansion of the macro `dbg` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/derives/nonsense-input-to-debug.stderr
+++ b/tests/ui/derives/nonsense-input-to-debug.stderr
@@ -13,8 +13,6 @@ LL |     should_be_vec_t: vec![T],
    |                      expected type
    |                      in this macro invocation
    |                      this macro call doesn't expand to a type
-   |
-   = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0392]: type parameter `T` is never used
   --> $DIR/nonsense-input-to-debug.rs:5:17

--- a/tests/ui/error-codes/E0010-teach.stderr
+++ b/tests/ui/error-codes/E0010-teach.stderr
@@ -5,7 +5,6 @@ LL | const CON: Vec<i32> = vec![1, 2, 3];
    |                       ^^^^^^^^^^^^^ allocation not allowed in constants
    |
    = note: The runtime heap is not yet available at compile-time, so no runtime heap allocations can be created.
-   = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0015]: cannot call non-const method `slice::<impl [i32]>::into_vec::<std::alloc::Global>` in constants
   --> $DIR/E0010-teach.rs:5:23
@@ -14,7 +13,6 @@ LL | const CON: Vec<i32> = vec![1, 2, 3];
    |                       ^^^^^^^^^^^^^
    |
    = note: calls in constants are limited to constant functions, tuple structs and tuple variants
-   = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/error-codes/E0010.stderr
+++ b/tests/ui/error-codes/E0010.stderr
@@ -3,8 +3,6 @@ error[E0010]: allocations are not allowed in constants
    |
 LL | const CON: Vec<i32> = vec![1, 2, 3];
    |                       ^^^^^^^^^^^^^ allocation not allowed in constants
-   |
-   = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0015]: cannot call non-const method `slice::<impl [i32]>::into_vec::<std::alloc::Global>` in constants
   --> $DIR/E0010.rs:3:23
@@ -13,7 +11,6 @@ LL | const CON: Vec<i32> = vec![1, 2, 3];
    |                       ^^^^^^^^^^^^^
    |
    = note: calls in constants are limited to constant functions, tuple structs and tuple variants
-   = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/errors/span-format_args-issue-140578.stderr
+++ b/tests/ui/errors/span-format_args-issue-140578.stderr
@@ -3,40 +3,30 @@ error[E0282]: type annotations needed
    |
 LL |   print!("{:?} {a} {a:?}", [], a = 1 + 1);
    |                            ^^ cannot infer type
-   |
-   = note: this error originates in the macro `$crate::format_args` which comes from the expansion of the macro `print` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0282]: type annotations needed
   --> $DIR/span-format_args-issue-140578.rs:7:30
    |
 LL |   println!("{:?} {a} {a:?}", [], a = 1 + 1);
    |                              ^^ cannot infer type
-   |
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0282]: type annotations needed
   --> $DIR/span-format_args-issue-140578.rs:12:35
    |
 LL |   println!("{:?} {:?} {a} {a:?}", [], [], a = 1 + 1);
    |                                   ^^ cannot infer type
-   |
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0282]: type annotations needed
   --> $DIR/span-format_args-issue-140578.rs:17:41
    |
 LL |   println!("{:?} {:?} {a} {a:?} {b:?}", [], [], a = 1 + 1, b = []);
    |                                         ^^ cannot infer type
-   |
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0282]: type annotations needed
   --> $DIR/span-format_args-issue-140578.rs:26:9
    |
 LL |         [],
    |         ^^ cannot infer type
-   |
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/expr/if/assert-macro-without-else.stderr
+++ b/tests/ui/expr/if/assert-macro-without-else.stderr
@@ -11,16 +11,12 @@ error[E0308]: mismatched types
    |
 LL |     assert_eq!(1, 1)
    |     ^^^^^^^^^^^^^^^^ expected `i32`, found `()`
-   |
-   = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0308]: mismatched types
   --> $DIR/assert-macro-without-else.rs:14:5
    |
 LL |     assert_ne!(1, 2)
    |     ^^^^^^^^^^^^^^^^ expected `bool`, found `()`
-   |
-   = note: this error originates in the macro `assert_ne` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0308]: mismatched types
   --> $DIR/assert-macro-without-else.rs:26:9

--- a/tests/ui/feature-gates/feature-gate-global-registration.stderr
+++ b/tests/ui/feature-gates/feature-gate-global-registration.stderr
@@ -6,8 +6,6 @@ LL | todo!();
    | |
    | expected one of `!` or `::`
    | in this macro invocation
-   |
-   = note: this error originates in the macro `todo` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/fmt/format-args-argument-span.stderr
+++ b/tests/ui/fmt/format-args-argument-span.stderr
@@ -6,7 +6,6 @@ LL |     println!("{x:?} {x} {x:?}");
    |
    = help: the trait `std::fmt::Display` is not implemented for `Option<{integer}>`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `Option<{integer}>` doesn't implement `std::fmt::Display`
   --> $DIR/format-args-argument-span.rs:15:37
@@ -18,7 +17,6 @@ LL |     println!("{x:?} {x} {x:?}", x = Some(1));
    |
    = help: the trait `std::fmt::Display` is not implemented for `Option<{integer}>`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `DisplayOnly` doesn't implement `Debug`
   --> $DIR/format-args-argument-span.rs:18:19
@@ -28,7 +26,6 @@ LL |     println!("{x} {x:?} {x}");
    |
    = help: the trait `Debug` is not implemented for `DisplayOnly`
    = note: add `#[derive(Debug)]` to `DisplayOnly` or manually `impl Debug for DisplayOnly`
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `DisplayOnly` with `#[derive(Debug)]`
    |
 LL + #[derive(Debug)]
@@ -45,7 +42,6 @@ LL |     println!("{x} {x:?} {x}", x = DisplayOnly);
    |
    = help: the trait `Debug` is not implemented for `DisplayOnly`
    = note: add `#[derive(Debug)]` to `DisplayOnly` or manually `impl Debug for DisplayOnly`
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `DisplayOnly` with `#[derive(Debug)]`
    |
 LL + #[derive(Debug)]

--- a/tests/ui/fmt/ifmt-bad-arg.stderr
+++ b/tests/ui/fmt/ifmt-bad-arg.stderr
@@ -320,7 +320,6 @@ LL |     println!("{} {:.*} {}", 1, 3.2, 4);
               found reference `&{float}`
 note: associated function defined here
   --> $SRC_DIR/core/src/fmt/rt.rs:LL:COL
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0308]: mismatched types
   --> $DIR/ifmt-bad-arg.rs:81:35
@@ -334,7 +333,6 @@ LL |     println!("{} {:07$.*} {}", 1, 3.2, 4);
               found reference `&{float}`
 note: associated function defined here
   --> $SRC_DIR/core/src/fmt/rt.rs:LL:COL
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 38 previous errors
 

--- a/tests/ui/fmt/ifmt-unimpl.stderr
+++ b/tests/ui/fmt/ifmt-unimpl.stderr
@@ -17,7 +17,6 @@ LL |     format!("{:X}", "3");
              i32
            and 9 others
    = note: required for `&str` to implement `UpperHex`
-   = note: this error originates in the macro `$crate::__export::format_args` which comes from the expansion of the macro `format` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/fmt/non-source-literals.stderr
+++ b/tests/ui/fmt/non-source-literals.stderr
@@ -10,7 +10,6 @@ help: the trait `std::fmt::Display` is not implemented for `NonDisplay`
 LL | pub struct NonDisplay;
    | ^^^^^^^^^^^^^^^^^^^^^
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
-   = note: this error originates in the macro `$crate::__export::format_args` which comes from the expansion of the macro `format` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `NonDisplay` doesn't implement `std::fmt::Display`
   --> $DIR/non-source-literals.rs:10:45
@@ -24,7 +23,6 @@ help: the trait `std::fmt::Display` is not implemented for `NonDisplay`
 LL | pub struct NonDisplay;
    | ^^^^^^^^^^^^^^^^^^^^^
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
-   = note: this error originates in the macro `$crate::__export::format_args` which comes from the expansion of the macro `format` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `NonDebug` doesn't implement `Debug`
   --> $DIR/non-source-literals.rs:11:42
@@ -34,7 +32,6 @@ LL |     let _ = format!(concat!("{:", "?}"), NonDebug);
    |
    = help: the trait `Debug` is not implemented for `NonDebug`
    = note: add `#[derive(Debug)]` to `NonDebug` or manually `impl Debug for NonDebug`
-   = note: this error originates in the macro `$crate::__export::format_args` which comes from the expansion of the macro `format` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `NonDebug` with `#[derive(Debug)]`
    |
 LL + #[derive(Debug)]
@@ -49,7 +46,6 @@ LL |     let _ = format!(concat!("{", "0", ":?}"), NonDebug);
    |
    = help: the trait `Debug` is not implemented for `NonDebug`
    = note: add `#[derive(Debug)]` to `NonDebug` or manually `impl Debug for NonDebug`
-   = note: this error originates in the macro `$crate::__export::format_args` which comes from the expansion of the macro `format` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `NonDebug` with `#[derive(Debug)]`
    |
 LL + #[derive(Debug)]

--- a/tests/ui/impl-trait/precise-capturing/migration-note.stderr
+++ b/tests/ui/impl-trait/precise-capturing/migration-note.stderr
@@ -282,7 +282,6 @@ note: this call may capture more lifetimes than intended, because Rust 2024 has 
    |
 LL |     let x = { let x = display_len(&mut vec![0]); x };
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: use the precise capturing `use<...>` syntax to make the captures explicit
    |
 LL | fn display_len<T>(x: &Vec<T>) -> impl Display + use<T> {

--- a/tests/ui/inference/need_type_info/issue-107745-avoid-expr-from-macro-expansion.stderr
+++ b/tests/ui/inference/need_type_info/issue-107745-avoid-expr-from-macro-expansion.stderr
@@ -3,8 +3,6 @@ error[E0282]: type annotations needed
    |
 LL |     println!("{:?}", []);
    |                      ^^ cannot infer type
-   |
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/issues/issue-42796.stderr
+++ b/tests/ui/issues/issue-42796.stderr
@@ -9,7 +9,6 @@ LL |     let mut s_copy = s;
 LL |     println!("{}", s);
    |                    ^ value borrowed here after move
    |
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider cloning the value if the performance cost is acceptable
    |
 LL |     let mut s_copy = s.clone();

--- a/tests/ui/iterators/iter-macro-not-async-closure.stderr
+++ b/tests/ui/iterators/iter-macro-not-async-closure.stderr
@@ -35,7 +35,6 @@ note: required by a bound in `call_async_once`
    |
 LL | async fn call_async_once(f: impl AsyncFnOnce()) {
    |                                  ^^^^^^^^^^^^^ required by this bound in `call_async_once`
-   = note: this error originates in the macro `pin` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `{gen closure@$DIR/iter-macro-not-async-closure.rs:19:21: 19:28}: AsyncFnOnce()` is not satisfied
   --> $DIR/iter-macro-not-async-closure.rs:25:13
@@ -48,7 +47,6 @@ note: required by a bound in `call_async_once`
    |
 LL | async fn call_async_once(f: impl AsyncFnOnce()) {
    |                                  ^^^^^^^^^^^^^ required by this bound in `call_async_once`
-   = note: this error originates in the macro `pin` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `{gen closure@$DIR/iter-macro-not-async-closure.rs:19:21: 19:28}: AsyncFnOnce()` is not satisfied
   --> $DIR/iter-macro-not-async-closure.rs:30:5

--- a/tests/ui/lifetimes/borrowck-let-suggestion.stderr
+++ b/tests/ui/lifetimes/borrowck-let-suggestion.stderr
@@ -9,7 +9,6 @@ LL |
 LL |     x.use_mut();
    |     - borrow later used here
    |
-   = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider consuming the `Vec<i32>` when turning it into an `Iterator`
    |
 LL |     let mut x = vec![1].into_iter();

--- a/tests/ui/lint/dead-code/closure-bang.stderr
+++ b/tests/ui/lint/dead-code/closure-bang.stderr
@@ -11,7 +11,6 @@ note: the lint level is defined here
    |
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
-   = note: this error originates in the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/lint/fn-ptr-comparisons-some.stderr
+++ b/tests/ui/lint/fn-ptr-comparisons-some.stderr
@@ -18,7 +18,6 @@ LL |     assert_eq!(Some::<FnPtr>(func), Some(func as unsafe extern "C" fn()));
    = note: the address of the same function can vary between different codegen units
    = note: furthermore, different functions could have the same address after being merged together
    = note: for more information visit <https://doc.rust-lang.org/nightly/core/ptr/fn.fn_addr_eq.html>
-   = note: this warning originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: 2 warnings emitted
 

--- a/tests/ui/lint/fn-ptr-comparisons-weird.stderr
+++ b/tests/ui/lint/fn-ptr-comparisons-weird.stderr
@@ -61,7 +61,6 @@ LL |     let _ = assert_eq!(g, g);
    = note: the address of the same function can vary between different codegen units
    = note: furthermore, different functions could have the same address after being merged together
    = note: for more information visit <https://doc.rust-lang.org/nightly/core/ptr/fn.fn_addr_eq.html>
-   = note: this warning originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: function pointer comparisons do not produce meaningful results since their addresses are not guaranteed to be unique
   --> $DIR/fn-ptr-comparisons-weird.rs:35:13
@@ -72,7 +71,6 @@ LL |     let _ = assert_ne!(g, g);
    = note: the address of the same function can vary between different codegen units
    = note: furthermore, different functions could have the same address after being merged together
    = note: for more information visit <https://doc.rust-lang.org/nightly/core/ptr/fn.fn_addr_eq.html>
-   = note: this warning originates in the macro `assert_ne` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: 7 warnings emitted
 

--- a/tests/ui/liveness/liveness-move-in-while.stderr
+++ b/tests/ui/liveness/liveness-move-in-while.stderr
@@ -35,7 +35,6 @@ LL |         while true { while true { while true { x = y; x.clone(); } } }
    |         |            inside of this loop
    |         inside of this loop
    |
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider cloning the value if the performance cost is acceptable
    |
 LL |         while true { while true { while true { x = y.clone(); x.clone(); } } }

--- a/tests/ui/liveness/liveness-use-after-move.stderr
+++ b/tests/ui/liveness/liveness-use-after-move.stderr
@@ -9,7 +9,6 @@ LL |
 LL |     println!("{}", *x);
    |                    ^^ value borrowed here after move
    |
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider cloning the value if the performance cost is acceptable
    |
 LL |     let y = x.clone();

--- a/tests/ui/liveness/liveness-use-after-send.stderr
+++ b/tests/ui/liveness/liveness-use-after-send.stderr
@@ -13,7 +13,6 @@ note: consider changing this parameter type in function `send` to borrow instead
    |
 LL | fn send<T:Send + std::fmt::Debug>(ch: Chan<T>, data: T) {
    |    ---- in this function                             ^ this parameter takes ownership of the value
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider cloning the value if the performance cost is acceptable
    |
 LL |     send(ch, message.clone());

--- a/tests/ui/loops/loop-proper-liveness.stderr
+++ b/tests/ui/loops/loop-proper-liveness.stderr
@@ -7,7 +7,6 @@ LL |     let x: i32;
 LL |     println!("{:?}", x);
    |                      ^ `x` used here but it isn't initialized
    |
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider assigning a value
    |
 LL |     let x: i32 = 42;

--- a/tests/ui/macros/assert.with-generic-asset.stderr
+++ b/tests/ui/macros/assert.with-generic-asset.stderr
@@ -15,8 +15,6 @@ error: macro requires a boolean expression as an argument
    |
 LL |     debug_assert!();
    |     ^^^^^^^^^^^^^^^ boolean expression required
-   |
-   = note: this error originates in the macro `debug_assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: expected expression, found keyword `struct`
   --> $DIR/assert.rs:8:19

--- a/tests/ui/macros/assert.without-generic-asset.stderr
+++ b/tests/ui/macros/assert.without-generic-asset.stderr
@@ -15,8 +15,6 @@ error: macro requires a boolean expression as an argument
    |
 LL |     debug_assert!();
    |     ^^^^^^^^^^^^^^^ boolean expression required
-   |
-   = note: this error originates in the macro `debug_assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: expected expression, found keyword `struct`
   --> $DIR/assert.rs:8:19

--- a/tests/ui/macros/failed-to-reparse-issue-139445.stderr
+++ b/tests/ui/macros/failed-to-reparse-issue-139445.stderr
@@ -9,16 +9,12 @@ error: expected `while`, `for`, `loop` or `{` after a label
    |
 LL |     assert_eq!(3, 'a,)
    |     ^^^^^^^^^^^^^^^^^^ expected `while`, `for`, `loop` or `{` after a label
-   |
-   = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: expected expression, found ``
   --> $DIR/failed-to-reparse-issue-139445.rs:2:5
    |
 LL |     assert_eq!(3, 'a,)
    |     ^^^^^^^^^^^^^^^^^^ expected expression
-   |
-   = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/macros/format-parse-errors.stderr
+++ b/tests/ui/macros/format-parse-errors.stderr
@@ -3,8 +3,6 @@ error: requires at least a format string argument
    |
 LL |     format!();
    |     ^^^^^^^^^
-   |
-   = note: this error originates in the macro `$crate::__export::format_args` which comes from the expansion of the macro `format` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: expected expression, found keyword `struct`
   --> $DIR/format-parse-errors.rs:5:13

--- a/tests/ui/macros/macro-expansion-empty-span-147255.stderr
+++ b/tests/ui/macros/macro-expansion-empty-span-147255.stderr
@@ -8,7 +8,6 @@ LL |     println!("{}", x_str);
    |
    = help: the trait `std::fmt::Display` is not implemented for `()`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/macros/macro-local-data-key-priv.stderr
+++ b/tests/ui/macros/macro-local-data-key-priv.stderr
@@ -9,7 +9,6 @@ note: the constant `baz` is defined here
    |
 LL |     thread_local!(static baz: f64 = 0.0);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: this error originates in the macro `$crate::thread::local_impl::thread_local_process_attrs` which comes from the expansion of the macro `thread_local` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/macros/vec-macro-in-pattern.stderr
+++ b/tests/ui/macros/vec-macro-in-pattern.stderr
@@ -5,7 +5,6 @@ LL |         Some(vec![43]) => {}
    |              ^^^^^^^^ not a tuple struct or tuple variant
    |
    = note: function calls are not allowed in patterns: <https://doc.rust-lang.org/book/ch19-00-patterns.html>
-   = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0658]: usage of qualified paths in this context is experimental
   --> $DIR/vec-macro-in-pattern.rs:7:14
@@ -16,7 +15,6 @@ LL |         Some(vec![43]) => {}
    = note: see issue #86935 <https://github.com/rust-lang/rust/issues/86935> for more information
    = help: add `#![feature(more_qualified_paths)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-   = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0164]: expected tuple struct or tuple variant, found associated function `<[_]>::into_vec`
   --> $DIR/vec-macro-in-pattern.rs:7:14
@@ -25,7 +23,6 @@ LL |         Some(vec![43]) => {}
    |              ^^^^^^^^ `fn` calls are not allowed in patterns
    |
    = help: for more information, visit https://doc.rust-lang.org/book/ch19-00-patterns.html
-   = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/mismatched_types/mismatched-types-issue-126222.stderr
+++ b/tests/ui/mismatched_types/mismatched-types-issue-126222.stderr
@@ -4,7 +4,6 @@ error[E0308]: mismatched types
 LL |             x => dbg!(x),
    |                  ^^^^^^^ expected `()`, found integer
    |
-   = note: this error originates in the macro `$crate::macros::dbg_internal` which comes from the expansion of the macro `dbg` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: you might have meant to return this value
    |
 LL |             x => return dbg!(x),
@@ -16,7 +15,6 @@ error[E0308]: mismatched types
 LL |                 dbg!(x)
    |                 ^^^^^^^ expected `()`, found integer
    |
-   = note: this error originates in the macro `$crate::macros::dbg_internal` which comes from the expansion of the macro `dbg` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: you might have meant to return this value
    |
 LL |                 return dbg!(x)
@@ -28,7 +26,6 @@ error[E0308]: mismatched types
 LL |             _ => dbg!(1)
    |                  ^^^^^^^ expected `()`, found integer
    |
-   = note: this error originates in the macro `$crate::macros::dbg_internal` which comes from the expansion of the macro `dbg` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: you might have meant to return this value
    |
 LL |             _ => return dbg!(1)
@@ -40,7 +37,6 @@ error[E0308]: mismatched types
 LL |             _ => {dbg!(1)}
    |                   ^^^^^^^ expected `()`, found integer
    |
-   = note: this error originates in the macro `$crate::macros::dbg_internal` which comes from the expansion of the macro `dbg` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: you might have meant to return this value
    |
 LL |             _ => {return dbg!(1)}

--- a/tests/ui/modules/issue-107649.stderr
+++ b/tests/ui/modules/issue-107649.stderr
@@ -5,7 +5,6 @@ error[E0277]: `Dummy` doesn't implement `Debug`
     |     ^^^^^^^^^^^^^^^^ the trait `Debug` is not implemented for `Dummy`
     |
     = note: add `#[derive(Debug)]` to `Dummy` or manually `impl Debug for Dummy`
-    = note: this error originates in the macro `$crate::macros::dbg_internal` which comes from the expansion of the macro `dbg` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `Dummy` with `#[derive(Debug)]`
    --> $DIR/auxiliary/dummy_lib.rs:2:1
     |

--- a/tests/ui/moves/moves-based-on-type-capture-clause-bad.stderr
+++ b/tests/ui/moves/moves-based-on-type-capture-clause-bad.stderr
@@ -11,7 +11,6 @@ LL |     });
 LL |     println!("{}", x);
    |                    ^ value borrowed here after move
    |
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider cloning the value before moving it into the closure
    |
 LL ~     let value = x.clone();

--- a/tests/ui/nll/polonius/nll-problem-case-3-issue-21906.nll.stderr
+++ b/tests/ui/nll/polonius/nll-problem-case-3-issue-21906.nll.stderr
@@ -59,8 +59,6 @@ LL |         return Some(y);
 ...
 LL |     println!("{:?}", x.data);
    |                      ^^^^^^ immutable borrow occurs here
-   |
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0499]: cannot borrow `*vec` as mutable more than once at a time
   --> $DIR/nll-problem-case-3-issue-21906.rs:77:9

--- a/tests/ui/on-unimplemented/no-debug.stderr
+++ b/tests/ui/on-unimplemented/no-debug.stderr
@@ -8,7 +8,6 @@ LL |     println!("{:?} {:?}", Foo, Bar);
    |
    = help: the trait `Debug` is not implemented for `Foo`
    = note: add `#[derive(Debug)]` to `Foo` or manually `impl Debug for Foo`
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `Foo` with `#[derive(Debug)]`
    |
 LL + #[derive(Debug)]
@@ -24,7 +23,6 @@ LL |     println!("{:?} {:?}", Foo, Bar);
    |                    required by this formatting parameter
    |
    = help: the trait `Debug` is not implemented for `Bar`
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `Foo` doesn't implement `std::fmt::Display`
   --> $DIR/no-debug.rs:11:23
@@ -40,7 +38,6 @@ help: the trait `std::fmt::Display` is not implemented for `Foo`
 LL | struct Foo;
    | ^^^^^^^^^^
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `Bar` doesn't implement `std::fmt::Display`
   --> $DIR/no-debug.rs:11:28
@@ -52,7 +49,6 @@ LL |     println!("{} {}", Foo, Bar);
    |
    = help: the trait `std::fmt::Display` is not implemented for `Bar`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/pattern/deref-patterns/ice-adjust-mode-unimplemented-for-constblock.stderr
+++ b/tests/ui/pattern/deref-patterns/ice-adjust-mode-unimplemented-for-constblock.stderr
@@ -5,7 +5,6 @@ LL |     let vec![const { vec![] }]: Vec<usize> = vec![];
    |         ^^^^^^^^^^^^^^^^^^^^^^ not a tuple struct or tuple variant
    |
    = note: function calls are not allowed in patterns: <https://doc.rust-lang.org/book/ch19-00-patterns.html>
-   = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0658]: usage of qualified paths in this context is experimental
   --> $DIR/ice-adjust-mode-unimplemented-for-constblock.rs:5:9
@@ -16,7 +15,6 @@ LL |     let vec![const { vec![] }]: Vec<usize> = vec![];
    = note: see issue #86935 <https://github.com/rust-lang/rust/issues/86935> for more information
    = help: add `#![feature(more_qualified_paths)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-   = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: arbitrary expressions aren't allowed in patterns
   --> $DIR/ice-adjust-mode-unimplemented-for-constblock.rs:5:14
@@ -33,7 +31,6 @@ LL |     let vec![const { vec![] }]: Vec<usize> = vec![];
    |         ^^^^^^^^^^^^^^^^^^^^^^ `fn` calls are not allowed in patterns
    |
    = help: for more information, visit https://doc.rust-lang.org/book/ch19-00-patterns.html
-   = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/pin-macro/lifetime_errors_on_promotion_misusage.stderr
+++ b/tests/ui/pin-macro/lifetime_errors_on_promotion_misusage.stderr
@@ -10,7 +10,6 @@ LL |     stuff(phantom_pinned)
    |           -------------- borrow later used here
    |
    = note: consider using a `let` binding to create a longer lived value
-   = note: this error originates in the macro `pin` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/lifetime_errors_on_promotion_misusage.rs:18:30
@@ -24,7 +23,6 @@ LL |     };
    |     - temporary value is freed at the end of this statement
    |
    = note: consider using a `let` binding to create a longer lived value
-   = note: this error originates in the macro `pin` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/reachable/expr_again.stderr
+++ b/tests/ui/reachable/expr_again.stderr
@@ -11,7 +11,6 @@ note: the lint level is defined here
    |
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
-   = note: this error originates in the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/reachable/expr_block.stderr
+++ b/tests/ui/reachable/expr_block.stderr
@@ -19,8 +19,6 @@ LL |         return;
    |         ------ any code following this expression is unreachable
 LL |         println!("foo");
    |         ^^^^^^^^^^^^^^^ unreachable statement
-   |
-   = note: this error originates in the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/reachable/expr_if.stderr
+++ b/tests/ui/reachable/expr_if.stderr
@@ -23,8 +23,6 @@ LL |         return;
 ...
 LL |     println!("But I am.");
    |     ^^^^^^^^^^^^^^^^^^^^^ unreachable statement
-   |
-   = note: this error originates in the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/reachable/expr_loop.stderr
+++ b/tests/ui/reachable/expr_loop.stderr
@@ -11,7 +11,6 @@ note: the lint level is defined here
    |
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
-   = note: this error originates in the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: unreachable statement
   --> $DIR/expr_loop.rs:21:5
@@ -20,8 +19,6 @@ LL |     loop { return; }
    |            ------ any code following this expression is unreachable
 LL |     println!("I am dead.");
    |     ^^^^^^^^^^^^^^^^^^^^^^ unreachable statement
-   |
-   = note: this error originates in the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: unreachable statement
   --> $DIR/expr_loop.rs:32:5
@@ -30,8 +27,6 @@ LL |     loop { 'middle: loop { loop { break 'middle; } } }
    |     -------------------------------------------------- any code following this expression is unreachable
 LL |     println!("I am dead.");
    |     ^^^^^^^^^^^^^^^^^^^^^^ unreachable statement
-   |
-   = note: this error originates in the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/reachable/expr_match.stderr
+++ b/tests/ui/reachable/expr_match.stderr
@@ -11,7 +11,6 @@ note: the lint level is defined here
    |
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
-   = note: this error originates in the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: unreachable statement
   --> $DIR/expr_match.rs:19:5
@@ -20,8 +19,6 @@ LL |     match () { () if false => return, () => return }
    |     ------------------------------------------------ any code following this `match` expression is unreachable, as all arms diverge
 LL |     println!("I am dead");
    |     ^^^^^^^^^^^^^^^^^^^^^ unreachable statement
-   |
-   = note: this error originates in the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: unreachable expression
   --> $DIR/expr_match.rs:25:25
@@ -42,8 +39,6 @@ LL | |     }
    | |_____- any code following this `match` expression is unreachable, as all arms diverge
 LL |       println!("I am dead");
    |       ^^^^^^^^^^^^^^^^^^^^^ unreachable statement
-   |
-   = note: this error originates in the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/reachable/unreachable-code-ret.stderr
+++ b/tests/ui/reachable/unreachable-code-ret.stderr
@@ -11,7 +11,6 @@ note: the lint level is defined here
    |
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
-   = note: this error originates in the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/resolve/underscore-bindings-disambiguators.stderr
+++ b/tests/ui/resolve/underscore-bindings-disambiguators.stderr
@@ -21,48 +21,36 @@ error[E0080]: evaluation panicked: not yet implemented
    |
 LL |     const _: () = todo!();
    |                   ^^^^^^^ evaluation of `impls::_` failed here
-   |
-   = note: this error originates in the macro `todo` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0080]: evaluation panicked: not yet implemented
   --> $DIR/underscore-bindings-disambiguators.rs:20:19
    |
 LL |     const _: () = todo!();
    |                   ^^^^^^^ evaluation of `impls::_` failed here
-   |
-   = note: this error originates in the macro `todo` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0080]: evaluation panicked: not yet implemented
   --> $DIR/underscore-bindings-disambiguators.rs:21:19
    |
 LL |     const _: () = todo!();
    |                   ^^^^^^^ evaluation of `impls::_` failed here
-   |
-   = note: this error originates in the macro `todo` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0080]: evaluation panicked: not yet implemented
   --> $DIR/underscore-bindings-disambiguators.rs:22:19
    |
 LL |     const _: () = todo!();
    |                   ^^^^^^^ evaluation of `impls::_` failed here
-   |
-   = note: this error originates in the macro `todo` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0080]: evaluation panicked: not yet implemented
   --> $DIR/underscore-bindings-disambiguators.rs:23:19
    |
 LL |     const _: () = todo!();
    |                   ^^^^^^^ evaluation of `impls::_` failed here
-   |
-   = note: this error originates in the macro `todo` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0080]: evaluation panicked: not yet implemented
   --> $DIR/underscore-bindings-disambiguators.rs:28:15
    |
 LL | const _: () = todo!();
    |               ^^^^^^^ evaluation of `_` failed here
-   |
-   = note: this error originates in the macro `todo` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/rfcs/rfc-0000-never_patterns/diverge-causes-unreachable-code.stderr
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/diverge-causes-unreachable-code.stderr
@@ -11,7 +11,6 @@ note: the lint level is defined here
    |
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
-   = note: this error originates in the macro `$crate::print` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: unreachable statement
   --> $DIR/diverge-causes-unreachable-code.rs:16:5
@@ -20,8 +19,6 @@ LL | fn ref_never_arg(&!: &Void) -> u32 {
    |                  -- any code following a never pattern is unreachable
 LL |     println!();
    |     ^^^^^^^^^^ unreachable statement
-   |
-   = note: this error originates in the macro `$crate::print` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: unreachable statement
   --> $DIR/diverge-causes-unreachable-code.rs:25:5
@@ -31,8 +28,6 @@ LL |         let ! = *ptr;
 LL |     }
 LL |     println!();
    |     ^^^^^^^^^^ unreachable statement
-   |
-   = note: this error originates in the macro `$crate::print` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: unreachable statement
   --> $DIR/diverge-causes-unreachable-code.rs:34:5
@@ -42,8 +37,6 @@ LL |         match *ptr { ! };
 LL |     }
 LL |     println!();
    |     ^^^^^^^^^^ unreachable statement
-   |
-   = note: this error originates in the macro `$crate::print` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/rfcs/rfc-2361-dbg-macro/dbg-macro-move-semantics.stderr
+++ b/tests/ui/rfcs/rfc-2361-dbg-macro/dbg-macro-move-semantics.stderr
@@ -8,7 +8,6 @@ LL |     let _ = dbg!(a);
 LL |     let _ = dbg!(a);
    |             ^^^^^^^ value used here after move
    |
-   = note: this error originates in the macro `$crate::macros::dbg_internal` which comes from the expansion of the macro `dbg` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider borrowing instead of transferring ownership
    |
 LL |     let _ = dbg!(&a);

--- a/tests/ui/rfcs/rfc-2361-dbg-macro/dbg-macro-requires-debug.stderr
+++ b/tests/ui/rfcs/rfc-2361-dbg-macro/dbg-macro-requires-debug.stderr
@@ -5,7 +5,6 @@ LL |     let _: NotDebug = dbg!(NotDebug);
    |                       ^^^^^^^^^^^^^^ the trait `Debug` is not implemented for `NotDebug`
    |
    = note: add `#[derive(Debug)]` to `NotDebug` or manually `impl Debug for NotDebug`
-   = note: this error originates in the macro `$crate::macros::dbg_internal` which comes from the expansion of the macro `dbg` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `NotDebug` with `#[derive(Debug)]`
    |
 LL + #[derive(Debug)]

--- a/tests/ui/span/coerce-suggestions.stderr
+++ b/tests/ui/span/coerce-suggestions.stderr
@@ -56,8 +56,6 @@ error[E0308]: mismatched types
    |
 LL |     s = format!("foo");
    |         ^^^^^^^^^^^^^^ expected `&mut String`, found `String`
-   |
-   = note: this error originates in the macro `format` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/span/issue-33884.stderr
+++ b/tests/ui/span/issue-33884.stderr
@@ -3,8 +3,6 @@ error[E0308]: mismatched types
    |
 LL |     stream.write_fmt(format!("message received"))
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Arguments<'_>`, found `String`
-   |
-   = note: this error originates in the macro `format` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/span/issue-39698.stderr
+++ b/tests/ui/span/issue-39698.stderr
@@ -71,8 +71,6 @@ LL |         T::T1(a, d) | T::T2(d, b) | T::T3(c) | T::T4(a) => { println!("{:?}
    |               |                                      binding initialized here in some conditions
    |               binding initialized here in some conditions
    |               binding declared here but left uninitialized
-   |
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/span/slice-borrow.stderr
+++ b/tests/ui/span/slice-borrow.stderr
@@ -10,7 +10,6 @@ LL |     y.use_ref();
    |     - borrow later used here
    |
    = note: consider using a `let` binding to create a longer lived value
-   = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/statics/check-values-constraints.stderr
+++ b/tests/ui/statics/check-values-constraints.stderr
@@ -16,8 +16,6 @@ error[E0010]: allocations are not allowed in statics
    |
 LL | static STATIC11: Vec<MyOwned> = vec![MyOwned];
    |                                 ^^^^^^^^^^^^^ allocation not allowed in statics
-   |
-   = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0015]: cannot call non-const method `slice::<impl [MyOwned]>::into_vec::<std::alloc::Global>` in statics
   --> $DIR/check-values-constraints.rs:81:33
@@ -27,7 +25,6 @@ LL | static STATIC11: Vec<MyOwned> = vec![MyOwned];
    |
    = note: calls in statics are limited to constant functions, tuple structs and tuple variants
    = note: consider wrapping this expression in `std::sync::LazyLock::new(|| ...)`
-   = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0015]: cannot call non-const method `<str as ToString>::to_string` in statics
   --> $DIR/check-values-constraints.rs:92:38
@@ -50,8 +47,6 @@ error[E0010]: allocations are not allowed in statics
    |
 LL |     vec![MyOwned],
    |     ^^^^^^^^^^^^^ allocation not allowed in statics
-   |
-   = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0015]: cannot call non-const method `slice::<impl [MyOwned]>::into_vec::<std::alloc::Global>` in statics
   --> $DIR/check-values-constraints.rs:96:5
@@ -61,15 +56,12 @@ LL |     vec![MyOwned],
    |
    = note: calls in statics are limited to constant functions, tuple structs and tuple variants
    = note: consider wrapping this expression in `std::sync::LazyLock::new(|| ...)`
-   = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0010]: allocations are not allowed in statics
   --> $DIR/check-values-constraints.rs:98:5
    |
 LL |     vec![MyOwned],
    |     ^^^^^^^^^^^^^ allocation not allowed in statics
-   |
-   = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0015]: cannot call non-const method `slice::<impl [MyOwned]>::into_vec::<std::alloc::Global>` in statics
   --> $DIR/check-values-constraints.rs:98:5
@@ -79,15 +71,12 @@ LL |     vec![MyOwned],
    |
    = note: calls in statics are limited to constant functions, tuple structs and tuple variants
    = note: consider wrapping this expression in `std::sync::LazyLock::new(|| ...)`
-   = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0010]: allocations are not allowed in statics
   --> $DIR/check-values-constraints.rs:103:6
    |
 LL |     &vec![MyOwned],
    |      ^^^^^^^^^^^^^ allocation not allowed in statics
-   |
-   = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0015]: cannot call non-const method `slice::<impl [MyOwned]>::into_vec::<std::alloc::Global>` in statics
   --> $DIR/check-values-constraints.rs:103:6
@@ -97,15 +86,12 @@ LL |     &vec![MyOwned],
    |
    = note: calls in statics are limited to constant functions, tuple structs and tuple variants
    = note: consider wrapping this expression in `std::sync::LazyLock::new(|| ...)`
-   = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0010]: allocations are not allowed in statics
   --> $DIR/check-values-constraints.rs:105:6
    |
 LL |     &vec![MyOwned],
    |      ^^^^^^^^^^^^^ allocation not allowed in statics
-   |
-   = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0015]: cannot call non-const method `slice::<impl [MyOwned]>::into_vec::<std::alloc::Global>` in statics
   --> $DIR/check-values-constraints.rs:105:6
@@ -115,15 +101,12 @@ LL |     &vec![MyOwned],
    |
    = note: calls in statics are limited to constant functions, tuple structs and tuple variants
    = note: consider wrapping this expression in `std::sync::LazyLock::new(|| ...)`
-   = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0010]: allocations are not allowed in statics
   --> $DIR/check-values-constraints.rs:111:31
    |
 LL | static STATIC19: Vec<isize> = vec![3];
    |                               ^^^^^^^ allocation not allowed in statics
-   |
-   = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0015]: cannot call non-const method `slice::<impl [isize]>::into_vec::<std::alloc::Global>` in statics
   --> $DIR/check-values-constraints.rs:111:31
@@ -133,15 +116,12 @@ LL | static STATIC19: Vec<isize> = vec![3];
    |
    = note: calls in statics are limited to constant functions, tuple structs and tuple variants
    = note: consider wrapping this expression in `std::sync::LazyLock::new(|| ...)`
-   = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0010]: allocations are not allowed in statics
   --> $DIR/check-values-constraints.rs:117:32
    |
 LL |         static x: Vec<isize> = vec![3];
    |                                ^^^^^^^ allocation not allowed in statics
-   |
-   = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0015]: cannot call non-const method `slice::<impl [isize]>::into_vec::<std::alloc::Global>` in statics
   --> $DIR/check-values-constraints.rs:117:32
@@ -151,7 +131,6 @@ LL |         static x: Vec<isize> = vec![3];
    |
    = note: calls in statics are limited to constant functions, tuple structs and tuple variants
    = note: consider wrapping this expression in `std::sync::LazyLock::new(|| ...)`
-   = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0507]: cannot move out of static item `x`
   --> $DIR/check-values-constraints.rs:119:9

--- a/tests/ui/suggestions/bound-suggestions.stderr
+++ b/tests/ui/suggestions/bound-suggestions.stderr
@@ -6,7 +6,6 @@ LL |     println!("{:?}", t);
    |               |
    |               required by this formatting parameter
    |
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider restricting opaque type `impl Sized` with trait `Debug`
    |
 LL | fn test_impl(t: impl Sized + std::fmt::Debug) {
@@ -20,7 +19,6 @@ LL |     println!("{:?}", t);
    |               |
    |               required by this formatting parameter
    |
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider restricting type parameter `T` with trait `Debug`
    |
 LL | fn test_no_bounds<T: std::fmt::Debug>(t: T) {
@@ -34,7 +32,6 @@ LL |     println!("{:?}", t);
    |               |
    |               required by this formatting parameter
    |
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider further restricting type parameter `T` with trait `Debug`
    |
 LL | fn test_one_bound<T: Sized + std::fmt::Debug>(t: T) {
@@ -48,7 +45,6 @@ LL |     println!("{:?} {:?}", x, y);
    |                    |
    |                    required by this formatting parameter
    |
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider further restricting type parameter `Y` with trait `Debug`
    |
 LL | fn test_no_bounds_where<X, Y>(x: X, y: Y) where X: std::fmt::Debug, Y: std::fmt::Debug {
@@ -62,7 +58,6 @@ LL |     println!("{:?}", x);
    |               |
    |               required by this formatting parameter
    |
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider further restricting type parameter `X` with trait `Debug`
    |
 LL | fn test_one_bound_where<X>(x: X) where X: Sized + std::fmt::Debug {
@@ -76,7 +71,6 @@ LL |     println!("{:?}", x);
    |               |
    |               required by this formatting parameter
    |
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider further restricting type parameter `X` with trait `Debug`
    |
 LL | fn test_many_bounds_where<X>(x: X) where X: Sized + std::fmt::Debug, X: Sized {

--- a/tests/ui/suggestions/issue-97760.stderr
+++ b/tests/ui/suggestions/issue-97760.stderr
@@ -6,7 +6,6 @@ LL |         println!("{x}");
    |
    = help: the trait `std::fmt::Display` is not implemented for `<impl IntoIterator as IntoIterator>::Item`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: introduce a type parameter with a trait bound instead of using `impl Trait`
    |
 LL ~ pub fn print_values<I: IntoIterator>(values: &I)

--- a/tests/ui/suggestions/path-display.stderr
+++ b/tests/ui/suggestions/path-display.stderr
@@ -10,7 +10,6 @@ LL |     println!("{}", path);
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
    = note: call `.display()` or `.to_string_lossy()` to safely print paths, as they may contain non-Unicode data
    = note: required for `&Path` to implement `std::fmt::Display`
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `PathBuf` doesn't implement `std::fmt::Display`
   --> $DIR/path-display.rs:9:20
@@ -23,7 +22,6 @@ LL |     println!("{}", path);
    = help: the trait `std::fmt::Display` is not implemented for `PathBuf`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
    = note: call `.display()` or `.to_string_lossy()` to safely print paths, as they may contain non-Unicode data
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/thread-local/no-unstable.stderr
+++ b/tests/ui/thread-local/no-unstable.stderr
@@ -10,7 +10,6 @@ LL | | }
    = help: add `#![feature(rustc_attrs)]` to the crate attributes to enable
    = note: the `#[rustc_dummy]` attribute is an internal implementation detail that will never be stable
    = note: the `#[rustc_dummy]` attribute is used for rustc unit tests
-   = note: this error originates in the macro `$crate::thread::local_impl::thread_local_process_attrs` which comes from the expansion of the macro `thread_local` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0658]: use of an internal attribute
   --> $DIR/no-unstable.rs:1:1
@@ -24,7 +23,6 @@ LL | | }
    = help: add `#![feature(rustc_attrs)]` to the crate attributes to enable
    = note: the `#[rustc_dummy]` attribute is an internal implementation detail that will never be stable
    = note: the `#[rustc_dummy]` attribute is used for rustc unit tests
-   = note: this error originates in the macro `$crate::thread::local_impl::thread_local_process_attrs` which comes from the expansion of the macro `thread_local` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0658]: `#[used(linker)]` is currently unstable
   --> $DIR/no-unstable.rs:1:1
@@ -38,7 +36,6 @@ LL | | }
    = note: see issue #93798 <https://github.com/rust-lang/rust/issues/93798> for more information
    = help: add `#![feature(used_with_arg)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-   = note: this error originates in the macro `$crate::thread::local_impl::thread_local_process_attrs` which comes from the expansion of the macro `thread_local` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: `#[used]` attribute cannot be used on constants
   --> $DIR/no-unstable.rs:1:1
@@ -50,7 +47,6 @@ LL | | }
    | |_^
    |
    = help: `#[used]` can only be applied to statics
-   = note: this error originates in the macro `$crate::thread::local_impl::thread_local_process_attrs` which comes from the expansion of the macro `thread_local` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/traits/const-traits/issue-79450.stderr
+++ b/tests/ui/traits/const-traits/issue-79450.stderr
@@ -7,7 +7,6 @@ LL |         println!("lul");
 note: function `_print` is not const
   --> $SRC_DIR/std/src/io/stdio.rs:LL:COL
    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
-   = note: this error originates in the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/try-block/try-block-maybe-bad-lifetime.stderr
+++ b/tests/ui/try-block/try-block-maybe-bad-lifetime.stderr
@@ -22,7 +22,6 @@ LL |         };
 LL |         println!("{}", x);
    |                        ^ value borrowed here after move
    |
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider cloning the value if the performance cost is acceptable
    |
 LL |             ::std::mem::drop(x.clone());

--- a/tests/ui/try-block/try-block-opt-init.stderr
+++ b/tests/ui/try-block/try-block-opt-init.stderr
@@ -9,8 +9,6 @@ LL |         cfg_res = 5;
 ...
 LL |     assert_eq!(cfg_res, 5);
    |     ^^^^^^^^^^^^^^^^^^^^^^ `cfg_res` used here but it is possibly-uninitialized
-   |
-   = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/type-alias-impl-trait/imply_bounds_from_bounds_param.edition2024.stderr
+++ b/tests/ui/type-alias-impl-trait/imply_bounds_from_bounds_param.edition2024.stderr
@@ -35,7 +35,6 @@ note: this call may capture more lifetimes than intended, because Rust 2024 has 
    |
 LL |     let mut thing = test(&mut z);
    |                     ^^^^^^^^^^^^
-   = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: use the precise capturing `use<...>` syntax to make the captures explicit
    |
 LL | fn test<'a>(y: &'a mut i32) -> impl PlusOne + use<> {
@@ -57,7 +56,6 @@ note: this call may capture more lifetimes than intended, because Rust 2024 has 
    |
 LL |     let mut thing = test(&mut z);
    |                     ^^^^^^^^^^^^
-   = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: use the precise capturing `use<...>` syntax to make the captures explicit
    |
 LL | fn test<'a>(y: &'a mut i32) -> impl PlusOne + use<> {
@@ -79,7 +77,6 @@ note: this call may capture more lifetimes than intended, because Rust 2024 has 
    |
 LL |     let mut thing = test(&mut z);
    |                     ^^^^^^^^^^^^
-   = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: use the precise capturing `use<...>` syntax to make the captures explicit
    |
 LL | fn test<'a>(y: &'a mut i32) -> impl PlusOne + use<> {

--- a/tests/ui/type-alias-impl-trait/nested.stderr
+++ b/tests/ui/type-alias-impl-trait/nested.stderr
@@ -20,7 +20,6 @@ LL |     println!("{:?}", bar());
    |               required by this formatting parameter
    |
    = help: the trait `Debug` is not implemented for `Bar`
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/type/binding-assigned-block-without-tail-expression.stderr
+++ b/tests/ui/type/binding-assigned-block-without-tail-expression.stderr
@@ -11,7 +11,6 @@ LL |     println!("{}", x);
    |
    = help: the trait `std::fmt::Display` is not implemented for `()`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `()` doesn't implement `std::fmt::Display`
   --> $DIR/binding-assigned-block-without-tail-expression.rs:15:20
@@ -26,7 +25,6 @@ LL |     println!("{}", y);
    |
    = help: the trait `std::fmt::Display` is not implemented for `()`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `()` doesn't implement `std::fmt::Display`
   --> $DIR/binding-assigned-block-without-tail-expression.rs:16:20
@@ -41,7 +39,6 @@ LL |     println!("{}", z);
    |
    = help: the trait `std::fmt::Display` is not implemented for `()`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `()` doesn't implement `std::fmt::Display`
   --> $DIR/binding-assigned-block-without-tail-expression.rs:17:20
@@ -59,7 +56,6 @@ LL |       println!("{}", s);
    |
    = help: the trait `std::fmt::Display` is not implemented for `()`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0308]: mismatched types
   --> $DIR/binding-assigned-block-without-tail-expression.rs:18:18

--- a/tests/ui/typeck/closure-ty-mismatch-issue-128561.stderr
+++ b/tests/ui/typeck/closure-ty-mismatch-issue-128561.stderr
@@ -14,8 +14,6 @@ error[E0308]: mismatched types
    |
 LL |     b"abc".iter().for_each(|x| dbg!(x));
    |                                ^^^^^^^ expected `()`, found `&u8`
-   |
-   = note: this error originates in the macro `$crate::macros::dbg_internal` which comes from the expansion of the macro `dbg` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0308]: mismatched types
   --> $DIR/closure-ty-mismatch-issue-128561.rs:8:9

--- a/tests/ui/typeck/issue-110017-format-into-help-deletes-macro.stderr
+++ b/tests/ui/typeck/issue-110017-format-into-help-deletes-macro.stderr
@@ -6,7 +6,6 @@ LL |      Err(format!("error: {x}"))
    |
    = note: expected struct `Box<dyn std::error::Error>`
               found struct `String`
-   = note: this error originates in the macro `format` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: call `Into::into` on this expression to convert `String` into `Box<dyn std::error::Error>`
    |
 LL |      Err(format!("error: {x}").into())

--- a/tests/ui/typeck/issue-112007-leaked-writeln-macro-internals.stderr
+++ b/tests/ui/typeck/issue-112007-leaked-writeln-macro-internals.stderr
@@ -12,7 +12,6 @@ LL | |     }
    |
    = note: expected unit type `()`
                    found enum `Result<(), std::fmt::Error>`
-   = note: this error originates in the macro `writeln` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider using a semicolon here
    |
 LL |     };

--- a/tests/ui/typeck/question-mark-operator-suggestion-span.stderr
+++ b/tests/ui/typeck/question-mark-operator-suggestion-span.stderr
@@ -12,7 +12,6 @@ LL | |     }
    |
    = note: expected unit type `()`
                    found enum `Result<(), std::fmt::Error>`
-   = note: this error originates in the macro `writeln` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider using a semicolon here
    |
 LL |     };

--- a/tests/ui/typeck/suggestions/suggest-clone-in-macro-issue-139253.stderr
+++ b/tests/ui/typeck/suggestions/suggest-clone-in-macro-issue-139253.stderr
@@ -26,7 +26,6 @@ error[E0308]: mismatched types
 LL |     let c: S = dbg!(field);
    |                ^^^^^^^^^^^ expected `S`, found `&S`
    |
-   = note: this error originates in the macro `$crate::macros::dbg_internal` which comes from the expansion of the macro `dbg` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider using clone here
    |
 LL |     let c: S = dbg!(field).clone();
@@ -38,7 +37,6 @@ error[E0308]: mismatched types
 LL |     let c: S = dbg!(dbg!(field));
    |                ^^^^^^^^^^^^^^^^^ expected `S`, found `&S`
    |
-   = note: this error originates in the macro `$crate::macros::dbg_internal` which comes from the expansion of the macro `dbg` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider using clone here
    |
 LL |     let c: S = dbg!(dbg!(field)).clone();

--- a/tests/ui/uninhabited/void-branch.stderr
+++ b/tests/ui/uninhabited/void-branch.stderr
@@ -16,7 +16,6 @@ note: the lint level is defined here
    |
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
-   = note: this error originates in the macro `$crate::format_args` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: unreachable expression
   --> $DIR/void-branch.rs:25:9
@@ -31,7 +30,6 @@ note: this expression has type `Infallible`, which is uninhabited
    |
 LL |         infallible();
    |         ^^^^^^^^^^^^
-   = note: this error originates in the macro `$crate::format_args` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/use/use-after-move-based-on-type.stderr
+++ b/tests/ui/use/use-after-move-based-on-type.stderr
@@ -8,7 +8,6 @@ LL |     let _y = x;
 LL |     println!("{}", x);
    |                    ^ value borrowed here after move
    |
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider cloning the value if the performance cost is acceptable
    |
 LL |     let _y = x.clone();


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
