### PR TITLE
bootstrap: Render doctest timing reports as text, not JSON

### DIFF
--- a/src/bootstrap/src/utils/render_tests.rs
+++ b/src/bootstrap/src/utils/render_tests.rs
@@ -306,6 +306,14 @@ impl<'a> Renderer<'a> {
         );
     }
 
+    fn render_report(&self, report: &Report) {
+        let &Report { total_time, compilation_time } = report;
+        // Should match `write_merged_doctest_times` in `library/test/src/formatters/pretty.rs`.
+        println!(
+            "all doctests ran in {total_time:.2}s; merged doctests compilation took {compilation_time:.2}s"
+        );
+    }
+
     fn render_message(&mut self, message: Message) {
         match message {
             Message::Suite(SuiteMessage::Started { test_count }) => {
@@ -322,6 +330,9 @@ impl<'a> Renderer<'a> {
             }
             Message::Suite(SuiteMessage::Failed(outcome)) => {
                 self.render_suite_outcome(Outcome::Failed, &outcome);
+            }
+            Message::Report(report) => {
+                self.render_report(&report);
             }
             Message::Bench(outcome) => {
                 // The formatting for benchmarks doesn't replicate 1:1 the formatting libtest
@@ -435,6 +446,7 @@ enum Message {
     Suite(SuiteMessage),
     Test(TestMessage),
     Bench(BenchOutcome),
+    Report(Report),
 }
 
 #[derive(serde_derive::Deserialize)]
@@ -480,4 +492,11 @@ struct TestOutcome {
     exec_time: Option<f64>,
     stdout: Option<String>,
     message: Option<String>,
+}
+
+/// Emitted when running doctests.
+#[derive(serde_derive::Deserialize)]
+struct Report {
+    total_time: f64,
+    compilation_time: f64,
 }


### PR DESCRIPTION
These doctest timing reports were added to libtest/rustdoc in https://github.com/rust-lang/rust/pull/144909, but bootstrap's custom test-output renderer wasn't taught about them, so they were being printed as raw JSON instead.

Before:
```text
{ "type": "report", "total_time": 0.738403958, "compilation_time": 0.731513292 }
```

After:
```text
all doctests ran in 0.73s; merged doctests compilation took 0.72s
```

<details>
<summary><b>Detailed before/after in context</b></summary>

## Before

```text
$ x test rustc_mir_transform --doc
Building bootstrap
    Finished `dev` profile [unoptimized] target(s) in 0.03s
Testing stage1 {rustc_mir_transform} (aarch64-apple-darwin)
    Finished `release` profile [optimized + debuginfo] target(s) in 0.12s
   Doc-tests rustc_mir_transform

running 19 tests
iiiiiiiiiiii.......

test result: ok. 7 passed; 0 failed; 12 ignored; 0 measured; 0 filtered out; finished in 3.28ms


running 7 tests
iiiiiii

test result: ok. 0 passed; 0 failed; 7 ignored; 0 measured; 0 filtered out; finished in 403.67µs

{ "type": "report", "total_time": 0.738403958, "compilation_time": 0.731513292 }
	finished in 1.505 seconds
Build completed successfully in 0:00:01
```

## After

```text
$ x test rustc_mir_transform --doc
Building bootstrap
    Finished `dev` profile [unoptimized] target(s) in 0.03s
Testing stage1 {rustc_mir_transform} (aarch64-apple-darwin)
    Finished `release` profile [optimized + debuginfo] target(s) in 0.12s
   Doc-tests rustc_mir_transform

running 19 tests
iiiiiiiiiiii.......

test result: ok. 7 passed; 0 failed; 12 ignored; 0 measured; 0 filtered out; finished in 3.12ms


running 7 tests
iiiiiii

test result: ok. 0 passed; 0 failed; 7 ignored; 0 measured; 0 filtered out; finished in 395.67µs

all doctests ran in 0.73s; merged doctests compilation took 0.72s
	finished in 1.493 seconds
Build completed successfully in 0:00:01
```

</details>