### PR TITLE
Fix ICE caused by invalid spans for shrink_file

### DIFF
--- a/compiler/rustc_errors/src/annotate_snippet_emitter_writer.rs
+++ b/compiler/rustc_errors/src/annotate_snippet_emitter_writer.rs
@@ -749,7 +749,7 @@ fn shrink_file(
     let hi_byte = spans.iter().map(|s| s.hi()).max()?;
     let hi_loc = sm.lookup_char_pos(hi_byte);
 
-    if lo_loc.file.name != hi_loc.file.name {
+    if lo_loc.file.stable_id != hi_loc.file.stable_id {
         // this may happen when spans cross file boundaries due to macro expansion.
         return None;
     }

--- a/compiler/rustc_errors/src/annotate_snippet_emitter_writer.rs
+++ b/compiler/rustc_errors/src/annotate_snippet_emitter_writer.rs
@@ -749,7 +749,7 @@ fn shrink_file(
 
     let hi_byte = spans.iter().map(|s| s.hi()).max()?;
     let hi_loc = sm.lookup_char_pos(hi_byte);
-    let hi = lo_loc.file.line_bounds(hi_loc.line.saturating_sub(1)).end;
+    let hi = hi_loc.file.line_bounds(hi_loc.line.saturating_sub(1)).end;
 
     let bounding_span = Span::with_root_ctxt(lo, hi);
     let source = sm.span_to_snippet(bounding_span).unwrap_or_default();

--- a/tests/ui/delegation/ice-line-bounds-issue-148732.rs
+++ b/tests/ui/delegation/ice-line-bounds-issue-148732.rs
@@ -1,0 +1,8 @@
+reuse a as b {
+    //~^ ERROR cannot find function `a` in this scope
+    //~| ERROR functions delegation is not yet fully implemented
+    dbg!(b);
+    //~^ ERROR missing lifetime specifier
+}
+
+fn main() {}

--- a/tests/ui/delegation/ice-line-bounds-issue-148732.stderr
+++ b/tests/ui/delegation/ice-line-bounds-issue-148732.stderr
@@ -1,0 +1,37 @@
+ WARN rustc_errors::emitter Invalid span $SRC_DIR/std/src/macros.rs:LL:COL (#4), error=SourceNotAvailable { filename: Real(Remapped { local_path: None, virtual_name: "$SRC_DIR/std/src/macros.rs" }) }
+ WARN rustc_errors::emitter Invalid span $SRC_DIR/std/src/macros.rs:LL:COL (#4), error=SourceNotAvailable { filename: Real(Remapped { local_path: None, virtual_name: "$SRC_DIR/std/src/macros.rs" }) }
+ WARN rustc_errors::emitter Invalid span $SRC_DIR/std/src/macros.rs:LL:COL (#4), error=SourceNotAvailable { filename: Real(Remapped { local_path: None, virtual_name: "$SRC_DIR/std/src/macros.rs" }) }
+error[E0106]: missing lifetime specifier
+  --> $DIR/ice-line-bounds-issue-148732.rs:4:5
+   |
+LL |     dbg!(b);
+   |     ^^^^^^^ expected named lifetime parameter
+   |
+   = note: this error originates in the macro `dbg` (in Nightly builds, run with -Z macro-backtrace for more info)
+   |
+
+error[E0425]: cannot find function `a` in this scope
+  --> $DIR/ice-line-bounds-issue-148732.rs:1:7
+   |
+LL | reuse a as b {
+   |       ^ not found in this scope
+
+error[E0658]: functions delegation is not yet fully implemented
+  --> $DIR/ice-line-bounds-issue-148732.rs:1:1
+   |
+LL | / reuse a as b {
+LL | |
+LL | |
+LL | |     dbg!(b);
+LL | |
+LL | | }
+   | |_^
+   |
+   = note: see issue #118212 <https://github.com/rust-lang/rust/issues/118212> for more information
+   = help: add `#![feature(fn_delegation)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0106, E0425, E0658.
+For more information about an error, try `rustc --explain E0106`.

--- a/tests/ui/delegation/ice-line-bounds-issue-148732.stderr
+++ b/tests/ui/delegation/ice-line-bounds-issue-148732.stderr
@@ -1,6 +1,3 @@
- WARN rustc_errors::emitter Invalid span $SRC_DIR/std/src/macros.rs:LL:COL (#4), error=SourceNotAvailable { filename: Real(Remapped { local_path: None, virtual_name: "$SRC_DIR/std/src/macros.rs" }) }
- WARN rustc_errors::emitter Invalid span $SRC_DIR/std/src/macros.rs:LL:COL (#4), error=SourceNotAvailable { filename: Real(Remapped { local_path: None, virtual_name: "$SRC_DIR/std/src/macros.rs" }) }
- WARN rustc_errors::emitter Invalid span $SRC_DIR/std/src/macros.rs:LL:COL (#4), error=SourceNotAvailable { filename: Real(Remapped { local_path: None, virtual_name: "$SRC_DIR/std/src/macros.rs" }) }
 error[E0106]: missing lifetime specifier
   --> $DIR/ice-line-bounds-issue-148732.rs:4:5
    |

--- a/tests/ui/structs/ice-line-bounds-issue-148684.rs
+++ b/tests/ui/structs/ice-line-bounds-issue-148684.rs
@@ -1,0 +1,9 @@
+struct A {
+    b: Vec<u8>,
+    c: usize,
+}
+
+fn main() {
+    A(2, vec![])
+    //~^ ERROR expected function, tuple struct or tuple variant, found struct `A`
+}

--- a/tests/ui/structs/ice-line-bounds-issue-148684.stderr
+++ b/tests/ui/structs/ice-line-bounds-issue-148684.stderr
@@ -1,0 +1,22 @@
+ WARN rustc_errors::emitter Invalid span $SRC_DIR/alloc/src/macros.rs:LL:COL (#4), error=SourceNotAvailable { filename: Real(Remapped { local_path: None, virtual_name: "$SRC_DIR/alloc/src/macros.rs" }) }
+ WARN rustc_errors::emitter Invalid span $SRC_DIR/alloc/src/macros.rs:LL:COL (#4), error=SourceNotAvailable { filename: Real(Remapped { local_path: None, virtual_name: "$SRC_DIR/alloc/src/macros.rs" }) }
+ WARN rustc_errors::emitter Invalid span $SRC_DIR/alloc/src/macros.rs:LL:COL (#4), error=SourceNotAvailable { filename: Real(Remapped { local_path: None, virtual_name: "$SRC_DIR/alloc/src/macros.rs" }) }
+ WARN rustc_errors::emitter Invalid span $SRC_DIR/alloc/src/macros.rs:LL:COL (#4), error=SourceNotAvailable { filename: Real(Remapped { local_path: None, virtual_name: "$SRC_DIR/alloc/src/macros.rs" }) }
+ WARN rustc_errors::emitter Invalid span $SRC_DIR/alloc/src/macros.rs:LL:COL (#4), error=SourceNotAvailable { filename: Real(Remapped { local_path: None, virtual_name: "$SRC_DIR/alloc/src/macros.rs" }) }
+ WARN rustc_errors::emitter Invalid span $SRC_DIR/alloc/src/macros.rs:LL:COL (#4), error=SourceNotAvailable { filename: Real(Remapped { local_path: None, virtual_name: "$SRC_DIR/alloc/src/macros.rs" }) }
+error[E0423]: expected function, tuple struct or tuple variant, found struct `A`
+  --> $DIR/ice-line-bounds-issue-148684.rs:7:5
+   |
+LL | / struct A {
+LL | |     b: Vec<u8>,
+LL | |     c: usize,
+LL | | }
+   | |_- `A` defined here
+...
+LL |       A(2, vec![])
+   |       ^^^^^^^^^^^^
+   |
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0423`.

--- a/tests/ui/structs/ice-line-bounds-issue-148684.stderr
+++ b/tests/ui/structs/ice-line-bounds-issue-148684.stderr
@@ -1,9 +1,3 @@
- WARN rustc_errors::emitter Invalid span $SRC_DIR/alloc/src/macros.rs:LL:COL (#4), error=SourceNotAvailable { filename: Real(Remapped { local_path: None, virtual_name: "$SRC_DIR/alloc/src/macros.rs" }) }
- WARN rustc_errors::emitter Invalid span $SRC_DIR/alloc/src/macros.rs:LL:COL (#4), error=SourceNotAvailable { filename: Real(Remapped { local_path: None, virtual_name: "$SRC_DIR/alloc/src/macros.rs" }) }
- WARN rustc_errors::emitter Invalid span $SRC_DIR/alloc/src/macros.rs:LL:COL (#4), error=SourceNotAvailable { filename: Real(Remapped { local_path: None, virtual_name: "$SRC_DIR/alloc/src/macros.rs" }) }
- WARN rustc_errors::emitter Invalid span $SRC_DIR/alloc/src/macros.rs:LL:COL (#4), error=SourceNotAvailable { filename: Real(Remapped { local_path: None, virtual_name: "$SRC_DIR/alloc/src/macros.rs" }) }
- WARN rustc_errors::emitter Invalid span $SRC_DIR/alloc/src/macros.rs:LL:COL (#4), error=SourceNotAvailable { filename: Real(Remapped { local_path: None, virtual_name: "$SRC_DIR/alloc/src/macros.rs" }) }
- WARN rustc_errors::emitter Invalid span $SRC_DIR/alloc/src/macros.rs:LL:COL (#4), error=SourceNotAvailable { filename: Real(Remapped { local_path: None, virtual_name: "$SRC_DIR/alloc/src/macros.rs" }) }
 error[E0423]: expected function, tuple struct or tuple variant, found struct `A`
   --> $DIR/ice-line-bounds-issue-148684.rs:7:5
    |


### PR DESCRIPTION
Fixes rust-lang/rust#148732 

There are two issues in this function:
1. the original issue is caused by a typo error, which is fixed in the first commit
2. another different ice(Patch span `7..7` is beyond the end of buffer `0`) will be reported after fixing the first one, is caused by spans cross file boundaries due to macro expansion. It is fixed in the second commit.

r? @nnethercote

edited: also fixes rust-lang/rust#148684, added a new testcase for it in the last commit.
