### PR TITLE
`DisplayFn` trait for print fns on `clean` rustdoc items

### DIFF
--- a/src/librustdoc/display.rs
+++ b/src/librustdoc/display.rs
@@ -2,6 +2,8 @@
 
 use std::fmt::{self, Display, Formatter, FormattingOptions};
 
+use crate::html::render::Context;
+
 pub(crate) trait Joined: IntoIterator {
     /// Takes an iterator over elements that implement [`Display`], and format them into `f`, separated by `sep`.
     ///
@@ -127,5 +129,18 @@ impl WithOpts {
             let mut f = f.with_options(self.opts);
             t.fmt(&mut f)
         })
+    }
+}
+
+pub(crate) trait DisplayFn<C: ?Sized> {
+    fn display_fn(&self, clean_item: &C, cx: &Context<'_>) -> impl Display;
+}
+
+impl<F, C: ?Sized> DisplayFn<C> for F
+where
+    F: Fn(&mut Formatter<'_>, &C, &Context<'_>) -> fmt::Result,
+{
+    fn display_fn(&self, clean_item: &C, cx: &Context<'_>) -> impl Display {
+        fmt::from_fn(move |f| self(f, clean_item, cx))
     }
 }

--- a/src/librustdoc/html/render/context.rs
+++ b/src/librustdoc/html/render/context.rs
@@ -22,6 +22,7 @@ use crate::clean::types::ExternalLocation;
 use crate::clean::utils::has_doc_flag;
 use crate::clean::{self, ExternalCrate};
 use crate::config::{ModuleSorting, RenderOptions, ShouldMerge};
+use crate::display::DisplayFn as _;
 use crate::docfs::{DocFS, PathError};
 use crate::error::Error;
 use crate::formats::FormatRenderer;
@@ -249,7 +250,7 @@ impl<'tcx> Context<'tcx> {
         };
 
         if !render_redirect_pages {
-            let content = print_item(self, it);
+            let content = print_item.display_fn(it, self);
             let page = layout::Page {
                 css_class: tyname_s,
                 root_path: &self.root_path(),

--- a/src/librustdoc/html/render/sidebar.rs
+++ b/src/librustdoc/html/render/sidebar.rs
@@ -11,6 +11,7 @@ use tracing::debug;
 
 use super::{Context, ItemSection, item_ty_to_section};
 use crate::clean;
+use crate::display::DisplayFn as _;
 use crate::formats::Impl;
 use crate::formats::item_type::ItemType;
 use crate::html::format::{print_path, print_type};
@@ -559,8 +560,8 @@ fn sidebar_deref_methods<'a>(
                 };
                 let title = format!(
                     "Methods from {:#}<Target={:#}>",
-                    print_path(impl_.inner_impl().trait_.as_ref().unwrap(), cx),
-                    print_type(real_target, cx),
+                    print_path.display_fn(impl_.inner_impl().trait_.as_ref().unwrap(), cx),
+                    print_type.display_fn(real_target, cx),
                 );
                 // We want links' order to be reproducible so we don't use unstable sort.
                 ret.sort();
@@ -691,7 +692,8 @@ fn sidebar_render_assoc_items(
                     ty::ImplPolarity::Positive | ty::ImplPolarity::Reservation => "",
                     ty::ImplPolarity::Negative => "!",
                 };
-                let generated = Link::new(encoded, format!("{prefix}{:#}", print_path(trait_, cx)));
+                let generated =
+                    Link::new(encoded, format!("{prefix}{:#}", print_path.display_fn(trait_, cx)));
                 if links.insert(generated.clone()) { Some(generated) } else { None }
             })
             .collect::<Vec<Link<'static>>>();

--- a/src/librustdoc/html/render/write_shared.rs
+++ b/src/librustdoc/html/render/write_shared.rs
@@ -40,6 +40,7 @@ use serde::{Deserialize, Serialize, Serializer};
 use super::{Context, RenderMode, collect_paths_for_type, ensure_trailing_slash};
 use crate::clean::{Crate, Item, ItemId, ItemKind};
 use crate::config::{EmitType, PathToParts, RenderOptions, ShouldMerge};
+use crate::display::DisplayFn as _;
 use crate::docfs::PathError;
 use crate::error::Error;
 use crate::formats::Impl;
@@ -602,11 +603,10 @@ impl TypeAliasPart {
                             )
                             .to_string();
                             // The alternate display prints it as plaintext instead of HTML.
-                            let trait_ = impl_
-                                .inner_impl()
-                                .trait_
-                                .as_ref()
-                                .map(|trait_| format!("{:#}", print_path(trait_, cx)));
+                            let trait_ =
+                                impl_.inner_impl().trait_.as_ref().map(|trait_| {
+                                    format!("{:#}", print_path.display_fn(trait_, cx))
+                                });
                             ret = Some(AliasSerializableImpl {
                                 text,
                                 trait_,


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
Not sure if I like this change or not, but it has some pros (and cons) so thought I'd put it up here for discussion.

In https://github.com/rust-lang/rust/pull/148585#issuecomment-3498817982, I lamented the fact that there was a lot of boilerplate around our `print_*` fns, due to the `fmt::from_fn` opening a new block (and indenting everything by another tab).
Using a macro to change the signature of a function is definitely not a good idea, so I attempted to do something similar with a trait and a blanket impl.

Basically, the `DisplayFn` trait is implemented for fns that take a `&mut fmt::Formatter`, a "clean" item, and a rustdoc ctx, and adds a `display_fn` method on such functions that does the whole `fmt::from_fn` wrapping.

Pros:
* De-indent all our print fn code by one level
* Maximalist API - call sites that already have a `&mut Formatter` can just pass it to the original function, while those that don't can use the `display_fn` trait method
* IMHO improves readability for both the fns and the call sites

Major con:
* Blanket impls on `Fn`s are not the greatest DX. If you get a function signature wrong, the diagnostics are not going to be very helpful. And it's not really clear where that `display_fn` method is coming from (though I don't think it should matter much most of the time, since its functionality is pretty easy to infer from the context, IMHO)

r? @GuillaumeGomez feel free to just close this if you don't like the idea, not married to it myself :)