### PR TITLE
Constify `ManuallyDrop::take`

### DIFF
--- a/library/core/src/mem/manually_drop.rs
+++ b/library/core/src/mem/manually_drop.rs
@@ -217,7 +217,7 @@ impl<T> ManuallyDrop<T> {
     ///
     #[must_use = "if you don't need the value, you can use `ManuallyDrop::drop` instead"]
     #[stable(feature = "manually_drop_take", since = "1.42.0")]
-    #[rustc_const_unstable(feature = "const_manually_drop_take", issue = "none")]
+    #[rustc_const_unstable(feature = "const_manually_drop_take", issue = "148773")]
     #[inline]
     pub const unsafe fn take(slot: &mut ManuallyDrop<T>) -> T {
         // SAFETY: we are reading from a reference, which is guaranteed

--- a/library/core/src/mem/manually_drop.rs
+++ b/library/core/src/mem/manually_drop.rs
@@ -217,8 +217,9 @@ impl<T> ManuallyDrop<T> {
     ///
     #[must_use = "if you don't need the value, you can use `ManuallyDrop::drop` instead"]
     #[stable(feature = "manually_drop_take", since = "1.42.0")]
+    #[rustc_const_unstable(feature = "const_manually_drop_take", issue = "none")]
     #[inline]
-    pub unsafe fn take(slot: &mut ManuallyDrop<T>) -> T {
+    pub const unsafe fn take(slot: &mut ManuallyDrop<T>) -> T {
         // SAFETY: we are reading from a reference, which is guaranteed
         // to be valid for reads.
         unsafe { ptr::read(&slot.value) }


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
Feature: `const_manually_drop_take`
Tracking issue: rust-lang/rust#148773

This PR constifies `ManuallyDrop::take`.