### PR TITLE
Constify `DropGuard::dismiss` and trait impls

### DIFF
--- a/library/core/src/mem/drop_guard.rs
+++ b/library/core/src/mem/drop_guard.rs
@@ -79,30 +79,30 @@ where
     ///
     /// let value = String::from("Nori likes chicken");
     /// let guard = DropGuard::new(value, |s| println!("{s}"));
-    /// assert_eq!(guard.dismiss(), "Nori likes chicken");
+    /// assert_eq!(DropGuard::dismiss(guard), "Nori likes chicken");
     /// ```
     #[unstable(feature = "drop_guard", issue = "144426")]
     #[rustc_const_unstable(feature = "const_drop_guard", issue = "none")]
     #[inline]
-    pub const fn dismiss(self) -> T
+    pub const fn dismiss(guard: Self) -> T
     where
         F: [const] Destruct,
     {
         // First we ensure that dropping the guard will not trigger
         // its destructor
-        let mut this = ManuallyDrop::new(self);
+        let mut guard = ManuallyDrop::new(guard);
 
         // Next we manually read the stored value from the guard.
         //
         // SAFETY: this is safe because we've taken ownership of the guard.
-        let value = unsafe { ManuallyDrop::take(&mut this.inner) };
+        let value = unsafe { ManuallyDrop::take(&mut guard.inner) };
 
         // Finally we drop the stored closure. We do this *after* having read
         // the value, so that even if the closure's `drop` function panics,
         // unwinding still tries to drop the value.
         //
         // SAFETY: this is safe because we've taken ownership of the guard.
-        unsafe { ManuallyDrop::drop(&mut this.f) };
+        unsafe { ManuallyDrop::drop(&mut guard.f) };
         value
     }
 }

--- a/library/coretests/tests/mem.rs
+++ b/library/coretests/tests/mem.rs
@@ -815,7 +815,7 @@ fn drop_guard_into_inner() {
     let dropped = Cell::new(false);
     let value = DropGuard::new(42, |_| dropped.set(true));
     let guard = DropGuard::new(value, |_| dropped.set(true));
-    let inner = guard.dismiss();
+    let inner = DropGuard::dismiss(guard);
     assert_eq!(dropped.get(), false);
     assert_eq!(*inner, 42);
 }
@@ -837,7 +837,7 @@ fn drop_guard_always_drops_value_if_closure_drop_unwinds() {
     // run the destructor of the value we passed, which we validate.
     let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         let guard = DropGuard::new(value_with_tracked_destruction, closure_that_panics_on_drop);
-        guard.dismiss();
+        DropGuard::dismiss(guard);
     }));
     assert!(value_was_dropped);
 }


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
Feature: `drop_guard` (rust-lang/rust#144426), `const_convert` (rust-lang/rust#143773), `const_drop_guard` (no tracking issue yet)

Constifies `DropGuard::dismiss` and trait impls.
I reused `const_convert` (rust-lang/rust#143773) for the `Deref*` impls.