### PR TITLE
Merge redundant error codes E0412 and E0425

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes/E0412.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0412.md
@@ -1,8 +1,12 @@
+#### Note: this error code is no longer emitted by the compiler.
+
+This error has been merged into E0425.
+
 A used type name is not in scope.
 
 Erroneous code examples:
 
-```compile_fail,E0412
+```compile_fail,E0425
 impl Something {} // error: type name `Something` is not in scope
 
 // or:
@@ -42,7 +46,7 @@ module. To fix this, you can follow the suggestion and use File directly or
 `use super::File;` which will import the types from the parent namespace. An
 example that causes this error is below:
 
-```compile_fail,E0412
+```compile_fail,E0425
 use std::fs::File;
 
 mod foo {

--- a/compiler/rustc_error_codes/src/error_codes/E0425.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0425.md
@@ -17,6 +17,14 @@ trait Foo {
 // or:
 
 let x = unknown_variable;  // error: unresolved name `unknown_variable`
+
+// or:
+
+impl Something {} // error: type name `Something` is not in scope
+
+// or:
+
+fn foo(x: T) {} // error: type name `T` is not in scope
 ```
 
 Please verify that the name wasn't misspelled and ensure that the
@@ -43,6 +51,18 @@ Or:
 ```
 let unknown_variable = 12u32;
 let x = unknown_variable; // ok!
+```
+
+Or for types:
+
+```
+struct Something;
+
+impl Something {} // ok!
+
+// or:
+
+fn foo<T>(x: T) {} // ok!
 ```
 
 If the item is not defined in the current module, it must be imported using a

--- a/compiler/rustc_error_codes/src/lib.rs
+++ b/compiler/rustc_error_codes/src/lib.rs
@@ -607,7 +607,7 @@ E0805: 0805,
 //  E0246, // invalid recursive type
 //  E0247,
 //  E0248, // value used as a type, now reported earlier during resolution
-//         // as E0412
+//         // as E0425
 //  E0249,
 //  E0257,
 //  E0258,

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -622,7 +622,7 @@ impl PathSource<'_, '_, '_> {
             (PathSource::Trait(_), true) => E0404,
             (PathSource::Trait(_), false) => E0405,
             (PathSource::Type | PathSource::DefineOpaques, true) => E0573,
-            (PathSource::Type | PathSource::DefineOpaques, false) => E0412,
+            (PathSource::Type | PathSource::DefineOpaques, false) => E0425,
             (PathSource::Struct(_), true) => E0574,
             (PathSource::Struct(_), false) => E0422,
             (PathSource::Expr(..), true) | (PathSource::Delegation, true) => E0423,
@@ -3161,7 +3161,7 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
         result
     }
 
-    /// When evaluating a `trait` use its associated types' idents for suggestions in E0412.
+    /// When evaluating a `trait` use its associated types' idents for suggestions in E0425.
     fn resolve_trait_items(&mut self, trait_items: &'ast [Box<AssocItem>]) {
         let trait_assoc_items =
             replace(&mut self.diag_metadata.current_trait_assoc_items, Some(trait_items));
@@ -4362,15 +4362,15 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
 
                 // There are two different error messages user might receive at
                 // this point:
-                // - E0412 cannot find type `{}` in this scope
+                // - E0425 cannot find value `{}` in this scope
                 // - E0433 failed to resolve: use of undeclared type or module `{}`
                 //
-                // The first one is emitted for paths in type-position, and the
-                // latter one - for paths in expression-position.
+                // The first one is emitted for unresolved names, and the
+                // latter one - for paths in use statements.
                 //
                 // Thus (since we're in expression-position at this point), not to
                 // confuse the user, we want to keep the *message* from E0433 (so
-                // `parent_err`), but we want *hints* from E0412 (so `err`).
+                // `parent_err`), but we want *hints* from E0425 (so `err`).
                 //
                 // And that's what happens below - we're just mixing both messages
                 // into a single one.

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -705,7 +705,7 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
             if !enum_candidates.is_empty() {
                 enum_candidates.sort();
 
-                // Contextualize for E0412 "cannot find type", but don't belabor the point
+                // Contextualize for E0425 "cannot find value", but don't belabor the point
                 // (that it's a variant) for E0573 "expected type, found variant".
                 let preamble = if res.is_none() {
                     let others = match enum_candidates.len() {
@@ -1127,7 +1127,7 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
                 }
 
                 self.suggest_ident_hidden_by_hygiene(err, path, span);
-            } else if err_code == E0412 {
+            } else if err_code == E0425 {
                 if let Some(correct) = Self::likely_rust_type(path) {
                     err.span_suggestion(
                         span,

--- a/tests/rustdoc-ui/impl-fn-nesting.stderr
+++ b/tests/rustdoc-ui/impl-fn-nesting.stderr
@@ -10,7 +10,7 @@ error[E0405]: cannot find trait `UnknownBound` in this scope
 LL | pub fn f<B: UnknownBound>(a: UnknownType, b: B) {
    |             ^^^^^^^^^^^^ not found in this scope
 
-error[E0412]: cannot find type `UnknownType` in this scope
+error[E0425]: cannot find type `UnknownType` in this scope
   --> $DIR/impl-fn-nesting.rs:11:30
    |
 LL | pub fn f<B: UnknownBound>(a: UnknownType, b: B) {
@@ -34,7 +34,7 @@ error[E0405]: cannot find trait `UnknownBound` in this scope
 LL |     impl<T: UnknownBound> UnknownTrait for T {}
    |             ^^^^^^^^^^^^ not found in this scope
 
-error[E0412]: cannot find type `UnknownType` in this scope
+error[E0425]: cannot find type `UnknownType` in this scope
   --> $DIR/impl-fn-nesting.rs:18:25
    |
 LL |     impl ValidTrait for UnknownType {}
@@ -46,13 +46,13 @@ error[E0405]: cannot find trait `UnknownBound` in this scope
 LL |     impl ValidTrait for ValidType where ValidTrait: UnknownBound {}
    |                                                     ^^^^^^^^^^^^ not found in this scope
 
-error[E0412]: cannot find type `UnknownType` in this scope
+error[E0425]: cannot find type `UnknownType` in this scope
   --> $DIR/impl-fn-nesting.rs:25:21
    |
 LL |         type Item = UnknownType;
    |                     ^^^^^^^^^^^ not found in this scope
 
-error[E0412]: cannot find type `UnknownType` in this scope
+error[E0425]: cannot find type `UnknownType` in this scope
   --> $DIR/impl-fn-nesting.rs:44:37
    |
 LL |             pub fn doubly_nested(c: UnknownType) {
@@ -60,5 +60,5 @@ LL |             pub fn doubly_nested(c: UnknownType) {
 
 error: aborting due to 10 previous errors
 
-Some errors have detailed explanations: E0405, E0412.
+Some errors have detailed explanations: E0405, E0425.
 For more information about an error, try `rustc --explain E0405`.

--- a/tests/ui/annotate-snippet/missing-type.stderr
+++ b/tests/ui/annotate-snippet/missing-type.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `Iter` in this scope
+error[E0425]: cannot find type `Iter` in this scope
   --> $DIR/missing-type.rs:4:12
    |
 LL |     let x: Iter;
@@ -18,4 +18,4 @@ LL + use std::collections::hash_map::Iter;
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/argument-suggestions/extern-fn-arg-names.stderr
+++ b/tests/ui/argument-suggestions/extern-fn-arg-names.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `err` in this scope
+error[E0425]: cannot find type `err` in this scope
   --> $DIR/extern-fn-arg-names.rs:2:29
    |
 LL |     fn dstfn(src: i32, dst: err);
@@ -22,5 +22,5 @@ LL |     dstfn(1, /* dst */);
 
 error: aborting due to 2 previous errors
 
-Some errors have detailed explanations: E0061, E0412.
+Some errors have detailed explanations: E0061, E0425.
 For more information about an error, try `rustc --explain E0061`.

--- a/tests/ui/argument-suggestions/issue-109831.rs
+++ b/tests/ui/argument-suggestions/issue-109831.rs
@@ -1,7 +1,7 @@
 struct A;
 struct B;
 
-fn f(b1: B, b2: B, a2: C) {} //~ ERROR E0412
+fn f(b1: B, b2: B, a2: C) {} //~ ERROR E0425
 
 fn main() {
     f(A, A, B, C); //~ ERROR E0425

--- a/tests/ui/argument-suggestions/issue-109831.stderr
+++ b/tests/ui/argument-suggestions/issue-109831.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `C` in this scope
+error[E0425]: cannot find type `C` in this scope
   --> $DIR/issue-109831.rs:4:24
    |
 LL | struct A;
@@ -48,5 +48,5 @@ LL +     f(/* B */, /* B */, B);
 
 error: aborting due to 3 previous errors
 
-Some errors have detailed explanations: E0061, E0412, E0425.
+Some errors have detailed explanations: E0061, E0425, E0425.
 For more information about an error, try `rustc --explain E0061`.

--- a/tests/ui/asm/issue-113788.rs
+++ b/tests/ui/asm/issue-113788.rs
@@ -2,6 +2,6 @@
 //@ needs-asm-support
 //@ only-x86_64
 fn main() {
-    let peb: *const PEB; //~ ERROR cannot find type `PEB` in this scope [E0412]
+    let peb: *const PEB; //~ ERROR cannot find type `PEB` in this scope [E0425]
     unsafe { std::arch::asm!("mov {0}, fs:[0x30]", out(reg) peb); }
 }

--- a/tests/ui/asm/issue-113788.stderr
+++ b/tests/ui/asm/issue-113788.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `PEB` in this scope
+error[E0425]: cannot find type `PEB` in this scope
   --> $DIR/issue-113788.rs:5:21
    |
 LL |     let peb: *const PEB;
@@ -6,4 +6,4 @@ LL |     let peb: *const PEB;
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/associated-consts/issue-93835.stderr
+++ b/tests/ui/associated-consts/issue-93835.stderr
@@ -4,7 +4,7 @@ error[E0425]: cannot find value `p` in this scope
 LL |     type_ascribe!(p, a<p:p<e=6>>);
    |                   ^ not found in this scope
 
-error[E0412]: cannot find type `a` in this scope
+error[E0425]: cannot find type `a` in this scope
   --> $DIR/issue-93835.rs:4:22
    |
 LL |     type_ascribe!(p, a<p:p<e=6>>);
@@ -39,5 +39,5 @@ LL |     type_ascribe!(p, a<p:p<e=6>>);
 
 error: aborting due to 5 previous errors
 
-Some errors have detailed explanations: E0405, E0412, E0425, E0658.
+Some errors have detailed explanations: E0405, E0425, E0425, E0658.
 For more information about an error, try `rustc --explain E0405`.

--- a/tests/ui/associated-type-bounds/return-type-notation/not-a-method.stderr
+++ b/tests/ui/associated-type-bounds/return-type-notation/not-a-method.stderr
@@ -16,7 +16,7 @@ error[E0576]: cannot find function `method` in this scope
 LL |     method(..): Send,
    |     ^^^^^^ not found in this scope
 
-error[E0412]: cannot find type `method` in this scope
+error[E0425]: cannot find type `method` in this scope
   --> $DIR/not-a-method.rs:36:5
    |
 LL |     method(): Send,
@@ -36,5 +36,5 @@ LL |     method(..): Send,
 
 error: aborting due to 6 previous errors
 
-Some errors have detailed explanations: E0412, E0573, E0575, E0576.
-For more information about an error, try `rustc --explain E0412`.
+Some errors have detailed explanations: E0425, E0573, E0575, E0576.
+For more information about an error, try `rustc --explain E0425`.

--- a/tests/ui/associated-types/associated-types-eq-1.stderr
+++ b/tests/ui/associated-types/associated-types-eq-1.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `A` in this scope
+error[E0425]: cannot find type `A` in this scope
   --> $DIR/associated-types-eq-1.rs:10:12
    |
 LL | fn foo2<I: Foo>(x: I) {
@@ -18,4 +18,4 @@ LL | fn foo2<I: Foo, A>(x: I) {
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/async-await/in-trait/return-not-existing-pair.rs
+++ b/tests/ui/async-await/in-trait/return-not-existing-pair.rs
@@ -3,7 +3,7 @@
 
 trait MyTrait<'a, 'b, T> {
     async fn foo(&'a self, key: &'b T) -> (&'a ConnImpl, &'b T);
-    //~^ ERROR: cannot find type `ConnImpl` in this scope [E0412]
+    //~^ ERROR: cannot find type `ConnImpl` in this scope [E0425]
 }
 
 impl<'a, 'b, T, U> MyTrait<T> for U {

--- a/tests/ui/async-await/in-trait/return-not-existing-pair.stderr
+++ b/tests/ui/async-await/in-trait/return-not-existing-pair.stderr
@@ -9,7 +9,7 @@ help: indicate the anonymous lifetimes
 LL | impl<'a, 'b, T, U> MyTrait<'_, '_, T> for U {
    |                            +++++++
 
-error[E0412]: cannot find type `ConnImpl` in this scope
+error[E0425]: cannot find type `ConnImpl` in this scope
   --> $DIR/return-not-existing-pair.rs:5:48
    |
 LL |     async fn foo(&'a self, key: &'b T) -> (&'a ConnImpl, &'b T);
@@ -26,5 +26,5 @@ LL |     async fn foo(_: T) -> (&'a U, &'b T) {}
 
 error: aborting due to 3 previous errors
 
-Some errors have detailed explanations: E0308, E0412, E0726.
+Some errors have detailed explanations: E0308, E0425, E0726.
 For more information about an error, try `rustc --explain E0308`.

--- a/tests/ui/async-await/in-trait/return-not-existing-type-wrapping-rpitit.rs
+++ b/tests/ui/async-await/in-trait/return-not-existing-type-wrapping-rpitit.rs
@@ -5,7 +5,7 @@ struct Wrapper<T>(T);
 
 trait Foo {
     fn bar() -> Wrapper<Missing<impl Sized>>;
-    //~^ ERROR: cannot find type `Missing` in this scope [E0412]
+    //~^ ERROR: cannot find type `Missing` in this scope [E0425]
 }
 
 impl Foo for () {

--- a/tests/ui/async-await/in-trait/return-not-existing-type-wrapping-rpitit.stderr
+++ b/tests/ui/async-await/in-trait/return-not-existing-type-wrapping-rpitit.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `Missing` in this scope
+error[E0425]: cannot find type `Missing` in this scope
   --> $DIR/return-not-existing-type-wrapping-rpitit.rs:7:25
    |
 LL |     fn bar() -> Wrapper<Missing<impl Sized>>;
@@ -6,4 +6,4 @@ LL |     fn bar() -> Wrapper<Missing<impl Sized>>;
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/async-await/issue-72590-type-error-sized.stderr
+++ b/tests/ui/async-await/issue-72590-type-error-sized.stderr
@@ -1,10 +1,10 @@
-error[E0412]: cannot find type `Nonexistent` in this scope
+error[E0425]: cannot find type `Nonexistent` in this scope
   --> $DIR/issue-72590-type-error-sized.rs:6:10
    |
 LL |     foo: Nonexistent,
    |          ^^^^^^^^^^^ not found in this scope
 
-error[E0412]: cannot find type `Missing` in this scope
+error[E0425]: cannot find type `Missing` in this scope
   --> $DIR/issue-72590-type-error-sized.rs:11:11
    |
 LL |     test: Missing
@@ -30,5 +30,5 @@ LL |     async fn frob(&self) {}
 
 error: aborting due to 3 previous errors
 
-Some errors have detailed explanations: E0277, E0412.
+Some errors have detailed explanations: E0277, E0425.
 For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/async-await/unconstrained-lifetimes.stderr
+++ b/tests/ui/async-await/unconstrained-lifetimes.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `Missing` in this scope
+error[E0425]: cannot find type `Missing` in this scope
   --> $DIR/unconstrained-lifetimes.rs:6:17
    |
 LL | async fn foo(_: Missing<'_>) {}
@@ -6,4 +6,4 @@ LL | async fn foo(_: Missing<'_>) {}
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/borrowck/bad-drop-side-effects.stderr
+++ b/tests/ui/borrowck/bad-drop-side-effects.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `Missing` in this scope
+error[E0425]: cannot find type `Missing` in this scope
   --> $DIR/bad-drop-side-effects.rs:7:16
    |
 LL | impl<U> B for &Missing {
@@ -6,4 +6,4 @@ LL | impl<U> B for &Missing {
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/c-variadic/issue-86053-1.stderr
+++ b/tests/ui/c-variadic/issue-86053-1.stderr
@@ -54,7 +54,7 @@ LL |     self , ... ,   self ,   self , ... ) where F : FnOnce ( & 'a & 'b usize
    |
    = help: only `extern "C"` and `extern "C-unwind"` functions may have a C variable argument list
 
-error[E0412]: cannot find type `F` in this scope
+error[E0425]: cannot find type `F` in this scope
   --> $DIR/issue-86053-1.rs:11:48
    |
 LL |     self , ... ,   self ,   self , ... ) where F : FnOnce ( & 'a & 'b usize ) {
@@ -74,4 +74,4 @@ LL | fn ordering4 < 'a , 'b, F     > ( a :            ,   self , self ,   self ,
 
 error: aborting due to 10 previous errors
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/cast/casts-issue-46365.stderr
+++ b/tests/ui/cast/casts-issue-46365.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `Ipsum` in this scope
+error[E0425]: cannot find type `Ipsum` in this scope
   --> $DIR/casts-issue-46365.rs:2:12
    |
 LL |     ipsum: Ipsum
@@ -6,4 +6,4 @@ LL |     ipsum: Ipsum
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/cast/ice-cast-type-with-error-124848.stderr
+++ b/tests/ui/cast/ice-cast-type-with-error-124848.stderr
@@ -31,7 +31,7 @@ help: consider introducing lifetime `'a` here
 LL | fn main<'a>() {
    |        ++++
 
-error[E0412]: cannot find type `Pin` in this scope
+error[E0425]: cannot find type `Pin` in this scope
   --> $DIR/ice-cast-type-with-error-124848.rs:7:60
    |
 LL | struct MyType<'a>(Cell<Option<&'unpinned mut MyType<'a>>>, Pin);
@@ -66,5 +66,5 @@ LL |     let bad_addr = &unpinned as *const Cell<Option<&'a mut MyType<'a>>> as 
 
 error: aborting due to 6 previous errors
 
-Some errors have detailed explanations: E0061, E0261, E0412, E0606.
+Some errors have detailed explanations: E0061, E0261, E0425, E0606.
 For more information about an error, try `rustc --explain E0061`.

--- a/tests/ui/closures/issue-78720.stderr
+++ b/tests/ui/closures/issue-78720.stderr
@@ -4,7 +4,7 @@ error: at least one trait must be specified
 LL | fn server() -> impl {
    |                ^^^^
 
-error[E0412]: cannot find type `F` in this scope
+error[E0425]: cannot find type `F` in this scope
   --> $DIR/issue-78720.rs:14:12
    |
 LL |     _func: F,
@@ -55,5 +55,5 @@ LL |     fn map2<F>(&self, f: F) -> Map2<F> {}
 
 error: aborting due to 5 previous errors
 
-Some errors have detailed explanations: E0277, E0282, E0308, E0412.
+Some errors have detailed explanations: E0277, E0282, E0308, E0425.
 For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/closures/issue-90871.stderr
+++ b/tests/ui/closures/issue-90871.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `n` in this scope
+error[E0425]: cannot find type `n` in this scope
   --> $DIR/issue-90871.rs:4:22
    |
 LL |     type_ascribe!(2, n([u8; || 1]))
@@ -23,5 +23,5 @@ LL |     type_ascribe!(2, n([u8; (|| 1)()]))
 
 error: aborting due to 2 previous errors
 
-Some errors have detailed explanations: E0308, E0412.
+Some errors have detailed explanations: E0308, E0425.
 For more information about an error, try `rustc --explain E0308`.

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-call/generics.stderr
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-call/generics.stderr
@@ -4,7 +4,7 @@ error: function pointer types may not have generic parameters
 LL |     f1: extern "cmse-nonsecure-call" fn<U: Copy>(U, u32, u32, u32) -> u64,
    |                                        ^^^^^^^^^
 
-error[E0412]: cannot find type `U` in this scope
+error[E0425]: cannot find type `U` in this scope
   --> $DIR/generics.rs:14:50
    |
 LL | struct Test<T: Copy> {
@@ -101,5 +101,5 @@ LL | type WithVarArgs = extern "cmse-nonsecure-call" fn(u32, ...);
 
 error: aborting due to 12 previous errors
 
-Some errors have detailed explanations: E0045, E0412, E0562, E0798.
+Some errors have detailed explanations: E0045, E0425, E0562, E0798.
 For more information about an error, try `rustc --explain E0045`.

--- a/tests/ui/coercion/type-errors.stderr
+++ b/tests/ui/coercion/type-errors.stderr
@@ -1,16 +1,16 @@
-error[E0412]: cannot find type `TypeError` in this scope
+error[E0425]: cannot find type `TypeError` in this scope
   --> $DIR/type-errors.rs:5:23
    |
 LL | pub fn has_error() -> TypeError {}
    |                       ^^^^^^^^^ not found in this scope
 
-error[E0412]: cannot find type `TypeError` in this scope
+error[E0425]: cannot find type `TypeError` in this scope
   --> $DIR/type-errors.rs:18:29
    |
 LL | pub fn autoderef_source(e: &TypeError) {
    |                             ^^^^^^^^^ not found in this scope
 
-error[E0412]: cannot find type `TypeError` in this scope
+error[E0425]: cannot find type `TypeError` in this scope
   --> $DIR/type-errors.rs:23:29
    |
 LL | pub fn autoderef_target(_: &TypeError) {}
@@ -18,4 +18,4 @@ LL | pub fn autoderef_target(_: &TypeError) {}
 
 error: aborting due to 3 previous errors
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/coherence/coherence-error-suppression.rs
+++ b/tests/ui/coherence/coherence-error-suppression.rs
@@ -7,7 +7,7 @@ impl Foo for i16 {}
 impl Foo for i32 {}
 impl Foo for i64 {}
 impl Foo for DoesNotExist {}
-//~^ ERROR E0412
+//~^ ERROR E0425
 impl Foo for u8 {}
 impl Foo for u16 {}
 impl Foo for u32 {}

--- a/tests/ui/coherence/coherence-error-suppression.stderr
+++ b/tests/ui/coherence/coherence-error-suppression.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `DoesNotExist` in this scope
+error[E0425]: cannot find type `DoesNotExist` in this scope
   --> $DIR/coherence-error-suppression.rs:9:14
    |
 LL | impl Foo for DoesNotExist {}
@@ -6,4 +6,4 @@ LL | impl Foo for DoesNotExist {}
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/coherence/illegal-copy-bad-projection.stderr
+++ b/tests/ui/coherence/illegal-copy-bad-projection.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `void` in this scope
+error[E0425]: cannot find type `void` in this scope
   --> $DIR/illegal-copy-bad-projection.rs:6:23
    |
 LL |     type Ptr = *const void;
@@ -6,4 +6,4 @@ LL |     type Ptr = *const void;
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/coherence/impl-coherence-error-for-undefined-type-18058.stderr
+++ b/tests/ui/coherence/impl-coherence-error-for-undefined-type-18058.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `Undefined` in this scope
+error[E0425]: cannot find type `Undefined` in this scope
   --> $DIR/impl-coherence-error-for-undefined-type-18058.rs:2:6
    |
 LL | impl Undefined {}
@@ -6,4 +6,4 @@ LL | impl Undefined {}
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/compiletest-self-test/ui-testing-optout.stderr
+++ b/tests/ui/compiletest-self-test/ui-testing-optout.stderr
@@ -1,10 +1,10 @@
-error[E0412]: cannot find type `B` in this scope
+error[E0425]: cannot find type `B` in this scope
  --> $DIR/ui-testing-optout.rs:4:10
   |
 4 | type A = B;
   |          ^ not found in this scope
 
-error[E0412]: cannot find type `D` in this scope
+error[E0425]: cannot find type `D` in this scope
  --> $DIR/ui-testing-optout.rs:7:10
   |
 4 | type A = B;
@@ -13,7 +13,7 @@ error[E0412]: cannot find type `D` in this scope
 7 | type C = D;
   |          ^ help: a type alias with a similar name exists: `A`
 
-error[E0412]: cannot find type `F` in this scope
+error[E0425]: cannot find type `F` in this scope
   --> $DIR/ui-testing-optout.rs:92:10
    |
  4 | type A = B;
@@ -24,4 +24,4 @@ error[E0412]: cannot find type `F` in this scope
 
 error: aborting due to 3 previous errors
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/const-generics/early/const_arg_trivial_macro_expansion-2.stderr
+++ b/tests/ui/const-generics/early/const_arg_trivial_macro_expansion-2.stderr
@@ -9,7 +9,7 @@ LL | | >;
    | |__|
    |
 
-error[E0412]: cannot find type `A` in this scope
+error[E0425]: cannot find type `A` in this scope
   --> $DIR/const_arg_trivial_macro_expansion-2.rs:12:10
    |
 LL | const _: A<
@@ -32,5 +32,5 @@ LL | const _<const x: /* Type */>: A<
 
 error: aborting due to 3 previous errors
 
-Some errors have detailed explanations: E0412, E0425.
-For more information about an error, try `rustc --explain E0412`.
+Some errors have detailed explanations: E0425, E0425.
+For more information about an error, try `rustc --explain E0425`.

--- a/tests/ui/const-generics/early/invalid-const-arguments.stderr
+++ b/tests/ui/const-generics/early/invalid-const-arguments.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `N` in this scope
+error[E0425]: cannot find type `N` in this scope
   --> $DIR/invalid-const-arguments.rs:5:16
    |
 LL | struct A<const N: u8>;
@@ -17,7 +17,7 @@ help: you might be missing a type parameter
 LL | impl<N> Foo for A<N> {}
    |     +++
 
-error[E0412]: cannot find type `T` in this scope
+error[E0425]: cannot find type `T` in this scope
   --> $DIR/invalid-const-arguments.rs:14:32
    |
 LL | struct A<const N: u8>;
@@ -72,5 +72,5 @@ LL | impl<const N: u8> Foo for C<N, { T }> {}
 
 error: aborting due to 5 previous errors
 
-Some errors have detailed explanations: E0412, E0747.
-For more information about an error, try `rustc --explain E0412`.
+Some errors have detailed explanations: E0425, E0747.
+For more information about an error, try `rustc --explain E0425`.

--- a/tests/ui/const-generics/generic_const_exprs/expected-type-of-closure-body-to-be-a-closure-or-coroutine-ice-113776.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/expected-type-of-closure-body-to-be-a-closure-or-coroutine-ice-113776.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `F` in this scope
+error[E0425]: cannot find type `F` in this scope
   --> $DIR/expected-type-of-closure-body-to-be-a-closure-or-coroutine-ice-113776.rs:11:17
    |
 LL |          let f: F = async { 1 };
@@ -59,5 +59,5 @@ LL | ) -> impl Iterator<Item = SubAssign> {
 
 error: aborting due to 4 previous errors
 
-Some errors have detailed explanations: E0277, E0412, E0782.
+Some errors have detailed explanations: E0277, E0425, E0782.
 For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/const-generics/generic_const_exprs/ice-predicates-of-no-entry-found-for-key-119275.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/ice-predicates-of-no-entry-found-for-key-119275.stderr
@@ -15,7 +15,7 @@ LL | fn bug<const N: Nat>(&self)
 LL |     for<const N: usize = 3, T = u32> [(); COT::BYTES]:,
    |               ^ already used
 
-error[E0412]: cannot find type `Nat` in this scope
+error[E0425]: cannot find type `Nat` in this scope
   --> $DIR/ice-predicates-of-no-entry-found-for-key-119275.rs:6:17
    |
 LL | fn bug<const N: Nat>(&self)
@@ -51,5 +51,5 @@ LL |     for<const N: usize = 3, T = u32> [(); COT::BYTES]:,
 
 error: aborting due to 7 previous errors
 
-Some errors have detailed explanations: E0403, E0412, E0433, E0658.
+Some errors have detailed explanations: E0403, E0425, E0433, E0658.
 For more information about an error, try `rustc --explain E0403`.

--- a/tests/ui/const-generics/generic_const_exprs/unevaluated-const-ice-119731.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/unevaluated-const-ice-119731.stderr
@@ -13,7 +13,7 @@ error[E0425]: cannot find value `v8` in this scope
 LL |     const v0: [[usize; v4]; v4] = v6(v8);
    |                                      ^^ not found in this scope
 
-error[E0412]: cannot find type `v18` in this scope
+error[E0425]: cannot find type `v18` in this scope
   --> $DIR/unevaluated-const-ice-119731.rs:23:31
    |
 LL |     pub type v11 = [[usize; v4]; v4];
@@ -22,7 +22,7 @@ LL |     pub type v11 = [[usize; v4]; v4];
 LL |         pub const fn v21() -> v18 {}
    |                               ^^^ help: a type alias with a similar name exists: `v11`
 
-error[E0412]: cannot find type `v18` in this scope
+error[E0425]: cannot find type `v18` in this scope
   --> $DIR/unevaluated-const-ice-119731.rs:35:31
    |
 LL |     pub type v11 = [[usize; v4]; v4];
@@ -129,5 +129,5 @@ LL |         pub const fn v21() -> v18 {
 
 error: aborting due to 14 previous errors; 2 warnings emitted
 
-Some errors have detailed explanations: E0412, E0422, E0425, E0432, E0592.
-For more information about an error, try `rustc --explain E0412`.
+Some errors have detailed explanations: E0425, E0422, E0425, E0432, E0592.
+For more information about an error, try `rustc --explain E0425`.

--- a/tests/ui/const-generics/mgca/projection-error.stderr
+++ b/tests/ui/const-generics/mgca/projection-error.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `T` in this scope
+error[E0425]: cannot find type `T` in this scope
   --> $DIR/projection-error.rs:14:17
    |
 LL | pub trait Tr<A> {
@@ -16,7 +16,7 @@ help: you might be missing a type parameter
 LL | fn mk_array<T>(_x: T) -> [(); <T as Tr<bool>>::SIZE] {}
    |            +++
 
-error[E0412]: cannot find type `T` in this scope
+error[E0425]: cannot find type `T` in this scope
   --> $DIR/projection-error.rs:14:29
    |
 LL | pub trait Tr<A> {
@@ -36,4 +36,4 @@ LL | fn mk_array<T>(_x: T) -> [(); <T as Tr<bool>>::SIZE] {}
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/const-generics/trait-resolution-error-with-const-generics-77919.stderr
+++ b/tests/ui/const-generics/trait-resolution-error-with-const-generics-77919.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `PhantomData` in this scope
+error[E0425]: cannot find type `PhantomData` in this scope
   --> $DIR/trait-resolution-error-with-const-generics-77919.rs:10:9
    |
 LL |     _n: PhantomData,
@@ -9,7 +9,7 @@ help: consider importing this struct
 LL + use std::marker::PhantomData;
    |
 
-error[E0412]: cannot find type `VAL` in this scope
+error[E0425]: cannot find type `VAL` in this scope
   --> $DIR/trait-resolution-error-with-const-generics-77919.rs:12:63
    |
 LL | impl<N, M> TypeVal<usize> for Multiply<N, M> where N: TypeVal<VAL> {}
@@ -31,5 +31,5 @@ LL | impl<N, M> TypeVal<usize> for Multiply<N, M> where N: TypeVal<VAL> {}
 
 error: aborting due to 3 previous errors
 
-Some errors have detailed explanations: E0046, E0412.
+Some errors have detailed explanations: E0046, E0425.
 For more information about an error, try `rustc --explain E0046`.

--- a/tests/ui/const-generics/type_not_in_scope.stderr
+++ b/tests/ui/const-generics/type_not_in_scope.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `X` in this scope
+error[E0425]: cannot find type `X` in this scope
   --> $DIR/type_not_in_scope.rs:1:6
    |
 LL | impl X {
@@ -20,5 +20,5 @@ LL | fn getn<const N: cfg_attr>() -> [u8; N] {}
 
 error: aborting due to 3 previous errors
 
-Some errors have detailed explanations: E0308, E0412, E0573.
+Some errors have detailed explanations: E0308, E0425, E0573.
 For more information about an error, try `rustc --explain E0308`.

--- a/tests/ui/const-generics/unknown_adt.stderr
+++ b/tests/ui/const-generics/unknown_adt.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `UnknownStruct` in this scope
+error[E0425]: cannot find type `UnknownStruct` in this scope
   --> $DIR/unknown_adt.rs:2:12
    |
 LL |     let _: UnknownStruct<7>;
@@ -6,4 +6,4 @@ LL |     let _: UnknownStruct<7>;
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/const_prop/ice-type-mismatch-when-copying-112824.stderr
+++ b/tests/ui/const_prop/ice-type-mismatch-when-copying-112824.stderr
@@ -9,7 +9,7 @@ help: consider introducing lifetime `'a` here
 LL | pub struct Opcode2<'a>(&'a S);
    |                   ++++
 
-error[E0412]: cannot find type `S` in this scope
+error[E0425]: cannot find type `S` in this scope
   --> $DIR/ice-type-mismatch-when-copying-112824.rs:5:24
    |
 LL | pub struct Opcode2(&'a S);
@@ -22,5 +22,5 @@ LL | pub struct Opcode2<S>(&'a S);
 
 error: aborting due to 2 previous errors
 
-Some errors have detailed explanations: E0261, E0412.
+Some errors have detailed explanations: E0261, E0425.
 For more information about an error, try `rustc --explain E0261`.

--- a/tests/ui/consts/erroneous_type_in_const_return_value.stderr
+++ b/tests/ui/consts/erroneous_type_in_const_return_value.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `Sum` in this scope
+error[E0425]: cannot find type `Sum` in this scope
   --> $DIR/erroneous_type_in_const_return_value.rs:6:22
    |
 LL |     UnusedByTheConst(Sum),
@@ -11,4 +11,4 @@ LL + use std::iter::Sum;
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/consts/erroneous_type_in_promoted.stderr
+++ b/tests/ui/consts/erroneous_type_in_promoted.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `Sum` in this scope
+error[E0425]: cannot find type `Sum` in this scope
   --> $DIR/erroneous_type_in_promoted.rs:6:22
    |
 LL |     UnusedByTheConst(Sum),
@@ -11,4 +11,4 @@ LL + use std::iter::Sum;
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/consts/error-is-freeze.stderr
+++ b/tests/ui/consts/error-is-freeze.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `UndefinedType` in this scope
+error[E0425]: cannot find type `UndefinedType` in this scope
   --> $DIR/error-is-freeze.rs:4:17
    |
 LL |     foo: Option<UndefinedType>,
@@ -11,4 +11,4 @@ LL | struct MyStruct<UndefinedType> {
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/consts/ice-bad-input-type-for-cast-83056.stderr
+++ b/tests/ui/consts/ice-bad-input-type-for-cast-83056.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `T` in this scope
+error[E0425]: cannot find type `T` in this scope
   --> $DIR/ice-bad-input-type-for-cast-83056.rs:5:11
    |
 LL | struct S([bool; f as usize]);
@@ -18,4 +18,4 @@ LL | fn f<T>() -> T {}
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/did_you_mean/issue-56028-there-is-an-enum-variant.stderr
+++ b/tests/ui/did_you_mean/issue-56028-there-is-an-enum-variant.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `Set` in this scope
+error[E0425]: cannot find type `Set` in this scope
   --> $DIR/issue-56028-there-is-an-enum-variant.rs:9:15
    |
 LL | fn setup() -> Set { Set }
@@ -40,5 +40,5 @@ LL + use PutDown::Set;
 
 error: aborting due to 2 previous errors
 
-Some errors have detailed explanations: E0412, E0425.
-For more information about an error, try `rustc --explain E0412`.
+Some errors have detailed explanations: E0425, E0425.
+For more information about an error, try `rustc --explain E0425`.

--- a/tests/ui/did_you_mean/sugg-stable-import-first-issue-140240.stderr
+++ b/tests/ui/did_you_mean/sugg-stable-import-first-issue-140240.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `Range` in this scope
+error[E0425]: cannot find type `Range` in this scope
   --> $DIR/sugg-stable-import-first-issue-140240.rs:2:14
    |
 LL |     const _: Range = 0..1;
@@ -17,4 +17,4 @@ LL + use std::range::Range;
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/dropck/drop-on-non-struct.stderr
+++ b/tests/ui/dropck/drop-on-non-struct.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `Nonexistent` in this scope
+error[E0425]: cannot find type `Nonexistent` in this scope
   --> $DIR/drop-on-non-struct.rs:9:15
    |
 LL | impl Drop for Nonexistent {
@@ -24,5 +24,5 @@ LL | impl<'a> Drop for &'a mut isize {
 
 error: aborting due to 3 previous errors
 
-Some errors have detailed explanations: E0117, E0120, E0412.
+Some errors have detailed explanations: E0117, E0120, E0425.
 For more information about an error, try `rustc --explain E0117`.

--- a/tests/ui/dyn-compatibility/erroneous_signature.stderr
+++ b/tests/ui/dyn-compatibility/erroneous_signature.stderr
@@ -1,10 +1,10 @@
-error[E0412]: cannot find type `MissingType` in this scope
+error[E0425]: cannot find type `MissingType` in this scope
   --> $DIR/erroneous_signature.rs:2:22
    |
 LL |     fn err(&self) -> MissingType;
    |                      ^^^^^^^^^^^ not found in this scope
 
-error[E0412]: cannot find type `MissingType` in this scope
+error[E0425]: cannot find type `MissingType` in this scope
   --> $DIR/erroneous_signature.rs:7:22
    |
 LL |     fn err(&self) -> MissingType {
@@ -12,4 +12,4 @@ LL |     fn err(&self) -> MissingType {
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/error-codes/E0412.rs
+++ b/tests/ui/error-codes/E0412.rs
@@ -1,4 +1,4 @@
-impl Something {} //~ ERROR E0412
+impl Something {} //~ ERROR E0425
 
 fn main() {
 }

--- a/tests/ui/error-codes/E0412.stderr
+++ b/tests/ui/error-codes/E0412.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `Something` in this scope
+error[E0425]: cannot find type `Something` in this scope
   --> $DIR/E0412.rs:1:6
    |
 LL | impl Something {}
@@ -6,4 +6,4 @@ LL | impl Something {}
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/extern/issue-112363-extern-item-where-clauses-debug-ice.stderr
+++ b/tests/ui/extern/issue-112363-extern-item-where-clauses-debug-ice.stderr
@@ -20,13 +20,13 @@ LL |     type Item = [T] where [T]: Sized;
    |
    = note: for more information, visit https://doc.rust-lang.org/std/keyword.extern.html
 
-error[E0412]: cannot find type `T` in this scope
+error[E0425]: cannot find type `T` in this scope
   --> $DIR/issue-112363-extern-item-where-clauses-debug-ice.rs:2:28
    |
 LL |     type Item = [T] where [T]: Sized;
    |                            ^ not found in this scope
 
-error[E0412]: cannot find type `T` in this scope
+error[E0425]: cannot find type `T` in this scope
   --> $DIR/issue-112363-extern-item-where-clauses-debug-ice.rs:2:18
    |
 LL |     type Item = [T] where [T]: Sized;
@@ -44,5 +44,5 @@ LL |     type Item = [T] where [T]: Sized;
 
 error: aborting due to 5 previous errors
 
-Some errors have detailed explanations: E0412, E0658.
-For more information about an error, try `rustc --explain E0412`.
+Some errors have detailed explanations: E0425, E0658.
+For more information about an error, try `rustc --explain E0425`.

--- a/tests/ui/fn/trait-fn-generic-mismatch.stderr
+++ b/tests/ui/fn/trait-fn-generic-mismatch.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `XXX` in this scope
+error[E0425]: cannot find type `XXX` in this scope
   --> $DIR/trait-fn-generic-mismatch.rs:5:11
    |
 LL | impl Core<XXX> {
@@ -28,5 +28,5 @@ LL +     core.spawn();
 
 error: aborting due to 2 previous errors
 
-Some errors have detailed explanations: E0061, E0412.
+Some errors have detailed explanations: E0061, E0425.
 For more information about an error, try `rustc --explain E0061`.

--- a/tests/ui/functions-closures/fn-help-with-err-generic-is-not-function.stderr
+++ b/tests/ui/functions-closures/fn-help-with-err-generic-is-not-function.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `T` in this scope
+error[E0425]: cannot find type `T` in this scope
   --> $DIR/fn-help-with-err-generic-is-not-function.rs:2:13
    |
 LL | impl Struct<T>
@@ -9,7 +9,7 @@ help: you might be missing a type parameter
 LL | impl<T> Struct<T>
    |     +++
 
-error[E0412]: cannot find type `T` in this scope
+error[E0425]: cannot find type `T` in this scope
   --> $DIR/fn-help-with-err-generic-is-not-function.rs:7:5
    |
 LL |     T: Copy,
@@ -17,4 +17,4 @@ LL |     T: Copy,
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/generic-associated-types/equality-bound.stderr
+++ b/tests/ui/generic-associated-types/equality-bound.stderr
@@ -110,7 +110,7 @@ LL -     fn from_iter<T>(_: T) -> Self where T::Item = A, T: IntoIterator,
 LL +     fn from_iter<T>(_: T) -> Self where T: IntoIterator<Item = A>,
    |
 
-error[E0412]: cannot find type `A` in this scope
+error[E0425]: cannot find type `A` in this scope
   --> $DIR/equality-bound.rs:20:79
    |
 LL |     fn from_iter<T>(_: T) -> Self where T: IntoIterator, IntoIterator::Item = A,
@@ -119,7 +119,7 @@ LL |     fn from_iter<T>(_: T) -> Self where T: IntoIterator, IntoIterator::Item
 LL | struct K {}
    | -------- similarly named struct `K` defined here
 
-error[E0412]: cannot find type `A` in this scope
+error[E0425]: cannot find type `A` in this scope
   --> $DIR/equality-bound.rs:31:68
    |
 LL |     fn from_iter<T>(_: T) -> Self where T: IntoIterator, T::Item = A,
@@ -128,7 +128,7 @@ LL |     fn from_iter<T>(_: T) -> Self where T: IntoIterator, T::Item = A,
 LL | struct K {}
    | -------- similarly named struct `K` defined here
 
-error[E0412]: cannot find type `A` in this scope
+error[E0425]: cannot find type `A` in this scope
   --> $DIR/equality-bound.rs:42:76
    |
 LL |     fn from_iter<T: IntoIterator>(_: T) -> Self where IntoIterator::Item = A,
@@ -137,7 +137,7 @@ LL |     fn from_iter<T: IntoIterator>(_: T) -> Self where IntoIterator::Item = 
 LL | struct K {}
    | -------- similarly named struct `K` defined here
 
-error[E0412]: cannot find type `A` in this scope
+error[E0425]: cannot find type `A` in this scope
   --> $DIR/equality-bound.rs:53:65
    |
 LL | struct K {}
@@ -146,7 +146,7 @@ LL | struct K {}
 LL |     fn from_iter<T: IntoIterator>(_: T) -> Self where T::Item = A,
    |                                                                 ^ help: a struct with a similar name exists: `K`
 
-error[E0412]: cannot find type `A` in this scope
+error[E0425]: cannot find type `A` in this scope
   --> $DIR/equality-bound.rs:64:62
    |
 LL | struct K {}
@@ -155,7 +155,7 @@ LL | struct K {}
 LL |     fn from_iter<T>(_: T) -> Self where IntoIterator::Item = A, T: IntoIterator,
    |                                                              ^ help: a struct with a similar name exists: `K`
 
-error[E0412]: cannot find type `A` in this scope
+error[E0425]: cannot find type `A` in this scope
   --> $DIR/equality-bound.rs:75:51
    |
 LL | struct K {}
@@ -175,5 +175,5 @@ LL | fn sum3<J: Iterator>(i: J) -> i32 where I::Item = i32 {
 
 error: aborting due to 16 previous errors
 
-Some errors have detailed explanations: E0412, E0433.
-For more information about an error, try `rustc --explain E0412`.
+Some errors have detailed explanations: E0425, E0433.
+For more information about an error, try `rustc --explain E0425`.

--- a/tests/ui/hygiene/arguments.stderr
+++ b/tests/ui/hygiene/arguments.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `S` in this scope
+error[E0425]: cannot find type `S` in this scope
   --> $DIR/arguments.rs:14:8
    |
 LL |         struct S;
@@ -9,4 +9,4 @@ LL |     m!(S, S);
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/hygiene/generate-mod.stderr
+++ b/tests/ui/hygiene/generate-mod.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `FromOutside` in this scope
+error[E0425]: cannot find type `FromOutside` in this scope
   --> $DIR/generate-mod.rs:35:13
    |
 LL |     type A = $FromOutside;
@@ -7,7 +7,7 @@ LL |     type A = $FromOutside;
 LL |     genmod!(FromOutside, Outer);
    |             ^^^^^^^^^^^ not found in this scope
 
-error[E0412]: cannot find type `Outer` in this scope
+error[E0425]: cannot find type `Outer` in this scope
   --> $DIR/generate-mod.rs:35:26
    |
 LL |     struct $Outer;
@@ -16,7 +16,7 @@ LL |     struct $Outer;
 LL |     genmod!(FromOutside, Outer);
    |                          ^^^^^ not found in this scope
 
-error[E0412]: cannot find type `FromOutside` in this scope
+error[E0425]: cannot find type `FromOutside` in this scope
   --> $DIR/generate-mod.rs:19:18
    |
 LL |         type A = FromOutside;
@@ -27,7 +27,7 @@ LL |     genmod_transparent!();
    |
    = note: this error originates in the macro `genmod_transparent` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0412]: cannot find type `Outer` in this scope
+error[E0425]: cannot find type `Outer` in this scope
   --> $DIR/generate-mod.rs:20:22
    |
 LL |         type Inner = Outer;
@@ -38,7 +38,7 @@ LL |     genmod_transparent!();
    |
    = note: this error originates in the macro `genmod_transparent` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0412]: cannot find type `FromOutside` in this scope
+error[E0425]: cannot find type `FromOutside` in this scope
   --> $DIR/generate-mod.rs:28:18
    |
 LL |         type A = FromOutside;
@@ -49,7 +49,7 @@ LL |     genmod_legacy!();
    |
    = note: this error originates in the macro `genmod_legacy` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0412]: cannot find type `Outer` in this scope
+error[E0425]: cannot find type `Outer` in this scope
   --> $DIR/generate-mod.rs:29:22
    |
 LL |         type Inner = Outer;
@@ -62,4 +62,4 @@ LL |     genmod_legacy!();
 
 error: aborting due to 6 previous errors
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/impl-trait/in-trait/ensure-rpitits-are-created-before-freezing.stderr
+++ b/tests/ui/impl-trait/in-trait/ensure-rpitits-are-created-before-freezing.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `Missing` in this scope
+error[E0425]: cannot find type `Missing` in this scope
   --> $DIR/ensure-rpitits-are-created-before-freezing.rs:8:19
    |
 LL | impl Iterable for Missing {
@@ -6,4 +6,4 @@ LL | impl Iterable for Missing {
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/impl-trait/in-trait/refine-err.stderr
+++ b/tests/ui/impl-trait/in-trait/refine-err.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `T` in this scope
+error[E0425]: cannot find type `T` in this scope
   --> $DIR/refine-err.rs:4:38
    |
 LL |     fn prepare(self) -> impl Fn() -> T;
@@ -6,4 +6,4 @@ LL |     fn prepare(self) -> impl Fn() -> T;
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/impl-trait/in-trait/rpitit-shadowed-by-missing-adt.stderr
+++ b/tests/ui/impl-trait/in-trait/rpitit-shadowed-by-missing-adt.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `Missing` in this scope
+error[E0425]: cannot find type `Missing` in this scope
   --> $DIR/rpitit-shadowed-by-missing-adt.rs:6:35
    |
 LL |     fn w() -> impl Deref<Target = Missing<impl Sized>>;
@@ -6,4 +6,4 @@ LL |     fn w() -> impl Deref<Target = Missing<impl Sized>>;
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/impl-trait/issues/issue-54966.stderr
+++ b/tests/ui/impl-trait/issues/issue-54966.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `Oper` in this scope
+error[E0425]: cannot find type `Oper` in this scope
   --> $DIR/issue-54966.rs:3:27
    |
 LL | fn generate_duration() -> Oper<impl FnMut()> {}
@@ -6,4 +6,4 @@ LL | fn generate_duration() -> Oper<impl FnMut()> {}
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/impl-trait/opaque-used-in-extraneous-argument.stderr
+++ b/tests/ui/impl-trait/opaque-used-in-extraneous-argument.stderr
@@ -11,7 +11,7 @@ LL - fn frob() -> impl Fn<P, Output = T> + '_ {}
 LL + fn frob() -> impl Fn<P, Output = T> + 'static {}
    |
 
-error[E0412]: cannot find type `P` in this scope
+error[E0425]: cannot find type `P` in this scope
   --> $DIR/opaque-used-in-extraneous-argument.rs:5:22
    |
 LL | fn frob() -> impl Fn<P, Output = T> + '_ {}
@@ -22,7 +22,7 @@ help: you might be missing a type parameter
 LL | fn frob<P>() -> impl Fn<P, Output = T> + '_ {}
    |        +++
 
-error[E0412]: cannot find type `T` in this scope
+error[E0425]: cannot find type `T` in this scope
   --> $DIR/opaque-used-in-extraneous-argument.rs:5:34
    |
 LL | fn frob() -> impl Fn<P, Output = T> + '_ {}
@@ -90,5 +90,5 @@ LL +     open_parent()
 
 error: aborting due to 7 previous errors
 
-Some errors have detailed explanations: E0061, E0106, E0412, E0658.
+Some errors have detailed explanations: E0061, E0106, E0425, E0658.
 For more information about an error, try `rustc --explain E0061`.

--- a/tests/ui/implied-bounds/references-err.stderr
+++ b/tests/ui/implied-bounds/references-err.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `DoesNotExist` in this scope
+error[E0425]: cannot find type `DoesNotExist` in this scope
   --> $DIR/references-err.rs:14:18
    |
 LL |     type Assoc = DoesNotExist;
@@ -6,4 +6,4 @@ LL |     type Assoc = DoesNotExist;
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/imports/glob-conflict-cross-crate-2.stderr
+++ b/tests/ui/imports/glob-conflict-cross-crate-2.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `C` in this scope
+error[E0425]: cannot find type `C` in this scope
   --> $DIR/glob-conflict-cross-crate-2.rs:8:13
    |
 LL |     let _a: C = 1;
@@ -6,4 +6,4 @@ LL |     let _a: C = 1;
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/imports/glob-resolve1.stderr
+++ b/tests/ui/imports/glob-resolve1.stderr
@@ -68,7 +68,7 @@ help: consider importing this function
 LL + use other::import;
    |
 
-error[E0412]: cannot find type `A` in this scope
+error[E0425]: cannot find type `A` in this scope
   --> $DIR/glob-resolve1.rs:32:11
    |
 LL |     pub enum B {
@@ -83,7 +83,7 @@ note: enum `bar::A` exists but is inaccessible
 LL |     enum A {
    |     ^^^^^^ not accessible
 
-error[E0412]: cannot find type `C` in this scope
+error[E0425]: cannot find type `C` in this scope
   --> $DIR/glob-resolve1.rs:33:11
    |
 LL |     pub enum B {
@@ -98,7 +98,7 @@ note: struct `bar::C` exists but is inaccessible
 LL |     struct C;
    |     ^^^^^^^^^ not accessible
 
-error[E0412]: cannot find type `D` in this scope
+error[E0425]: cannot find type `D` in this scope
   --> $DIR/glob-resolve1.rs:34:11
    |
 LL |     pub enum B {
@@ -115,5 +115,5 @@ LL |     type D = isize;
 
 error: aborting due to 8 previous errors
 
-Some errors have detailed explanations: E0412, E0423, E0425.
-For more information about an error, try `rustc --explain E0412`.
+Some errors have detailed explanations: E0423, E0425.
+For more information about an error, try `rustc --explain E0423`.

--- a/tests/ui/imports/import-alias-issue-121168.edition2015.stderr
+++ b/tests/ui/imports/import-alias-issue-121168.edition2015.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `Foo` in this scope
+error[E0425]: cannot find type `Foo` in this scope
   --> $DIR/import-alias-issue-121168.rs:11:12
    |
 LL |     let _: Foo<i32> = todo!();
@@ -11,4 +11,4 @@ LL + use nice_crate_name::Foo;
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/imports/import-alias-issue-121168.edition2018.stderr
+++ b/tests/ui/imports/import-alias-issue-121168.edition2018.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `Foo` in this scope
+error[E0425]: cannot find type `Foo` in this scope
   --> $DIR/import-alias-issue-121168.rs:11:12
    |
 LL |     let _: Foo<i32> = todo!();
@@ -13,4 +13,4 @@ LL + use import_alias_issue_121168_extern::Foo;
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/imports/import-alias-issue-121168.edition2021.stderr
+++ b/tests/ui/imports/import-alias-issue-121168.edition2021.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `Foo` in this scope
+error[E0425]: cannot find type `Foo` in this scope
   --> $DIR/import-alias-issue-121168.rs:11:12
    |
 LL |     let _: Foo<i32> = todo!();
@@ -13,4 +13,4 @@ LL + use import_alias_issue_121168_extern::Foo;
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/imports/inaccessible_type_aliases.stderr
+++ b/tests/ui/imports/inaccessible_type_aliases.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `Foo` in this scope
+error[E0425]: cannot find type `Foo` in this scope
   --> $DIR/inaccessible_type_aliases.rs:11:12
    |
 LL |     let x: Foo = 100;
@@ -13,7 +13,7 @@ LL |     type Foo = u64;
 LL |     type Foo = u64;
    |     ^^^^^^^^^^^^^^^ `b::Foo`: not accessible
 
-error[E0412]: cannot find type `Bar` in this scope
+error[E0425]: cannot find type `Bar` in this scope
   --> $DIR/inaccessible_type_aliases.rs:12:12
    |
 LL |     let y: Bar = 100;
@@ -27,4 +27,4 @@ LL |     type Bar = u64;
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/imports/issue-4366-2.stderr
+++ b/tests/ui/imports/issue-4366-2.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `Bar` in this scope
+error[E0425]: cannot find type `Bar` in this scope
   --> $DIR/issue-4366-2.rs:15:21
    |
 LL |         fn sub() -> Bar { 1 }
@@ -28,5 +28,5 @@ LL + use foo::foo;
 
 error: aborting due to 2 previous errors
 
-Some errors have detailed explanations: E0412, E0423.
-For more information about an error, try `rustc --explain E0412`.
+Some errors have detailed explanations: E0425, E0423.
+For more information about an error, try `rustc --explain E0425`.

--- a/tests/ui/issues/issue-30589.stderr
+++ b/tests/ui/issues/issue-30589.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `DecoderError` in this scope
+error[E0425]: cannot find type `DecoderError` in this scope
   --> $DIR/issue-30589.rs:3:23
    |
 LL | impl fmt::Display for DecoderError {
@@ -6,4 +6,4 @@ LL | impl fmt::Display for DecoderError {
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/issues/issue-36836.stderr
+++ b/tests/ui/issues/issue-36836.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `Bar` in this scope
+error[E0425]: cannot find type `Bar` in this scope
   --> $DIR/issue-36836.rs:13:17
    |
 LL | impl<T> Foo for Bar<T> {}
@@ -6,4 +6,4 @@ LL | impl<T> Foo for Bar<T> {}
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/issues/issue-53300.rs
+++ b/tests/ui/issues/issue-53300.rs
@@ -5,7 +5,7 @@ pub trait A {
 }
 
 fn addition() -> Wrapper<impl A> {}
-//~^ ERROR cannot find type `Wrapper` in this scope [E0412]
+//~^ ERROR cannot find type `Wrapper` in this scope [E0425]
 
 fn main() {
     let res = addition();

--- a/tests/ui/issues/issue-53300.stderr
+++ b/tests/ui/issues/issue-53300.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `Wrapper` in this scope
+error[E0425]: cannot find type `Wrapper` in this scope
   --> $DIR/issue-53300.rs:7:18
    |
 LL | fn addition() -> Wrapper<impl A> {}
@@ -6,4 +6,4 @@ LL | fn addition() -> Wrapper<impl A> {}
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/layout/cannot-transmute-unnormalizable-type.stderr
+++ b/tests/ui/layout/cannot-transmute-unnormalizable-type.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `Missing` in this scope
+error[E0425]: cannot find type `Missing` in this scope
   --> $DIR/cannot-transmute-unnormalizable-type.rs:7:5
    |
 LL |     Missing: Trait,
@@ -15,5 +15,5 @@ LL |         std::mem::transmute::<Option<()>, Option<&Other>>(None);
 
 error: aborting due to 2 previous errors
 
-Some errors have detailed explanations: E0412, E0512.
-For more information about an error, try `rustc --explain E0412`.
+Some errors have detailed explanations: E0425, E0512.
+For more information about an error, try `rustc --explain E0425`.

--- a/tests/ui/layout/issue-84108.stderr
+++ b/tests/ui/layout/issue-84108.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `OsStr` in this scope
+error[E0425]: cannot find type `OsStr` in this scope
   --> $DIR/issue-84108.rs:6:24
    |
 LL | static FOO: (dyn AsRef<OsStr>, u8) = ("hello", 42);
@@ -9,7 +9,7 @@ help: consider importing this struct
 LL + use std::ffi::OsStr;
    |
 
-error[E0412]: cannot find type `Path` in this scope
+error[E0425]: cannot find type `Path` in this scope
   --> $DIR/issue-84108.rs:9:14
    |
 LL | const BAR: (&Path, [u8], usize) = ("hello", [], 42);
@@ -40,5 +40,5 @@ LL | const BAR: (&Path, [u8], usize) = ("hello", [], 42);
 
 error: aborting due to 4 previous errors
 
-Some errors have detailed explanations: E0277, E0308, E0412.
+Some errors have detailed explanations: E0277, E0308, E0425.
 For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/layout/malformed-unsized-type-in-union.stderr
+++ b/tests/ui/layout/malformed-unsized-type-in-union.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `Missing` in this scope
+error[E0425]: cannot find type `Missing` in this scope
   --> $DIR/malformed-unsized-type-in-union.rs:3:34
    |
 LL | union W { s: dyn Iterator<Item = Missing> }
@@ -18,5 +18,5 @@ LL | union W { s: std::mem::ManuallyDrop<dyn Iterator<Item = Missing>> }
 
 error: aborting due to 2 previous errors
 
-Some errors have detailed explanations: E0412, E0740.
-For more information about an error, try `rustc --explain E0412`.
+Some errors have detailed explanations: E0425, E0740.
+For more information about an error, try `rustc --explain E0425`.

--- a/tests/ui/layout/thaw-transmute-invalid-enum.stderr
+++ b/tests/ui/layout/thaw-transmute-invalid-enum.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `Subset` in this scope
+error[E0425]: cannot find type `Subset` in this scope
   --> $DIR/thaw-transmute-invalid-enum.rs:35:41
    |
 LL |     assert::is_transmutable::<Superset, Subset>();
@@ -75,5 +75,5 @@ LL |         a: std::mem::ManuallyDrop<Ox00>,
 
 error: aborting due to 7 previous errors
 
-Some errors have detailed explanations: E0412, E0517, E0658, E0740.
-For more information about an error, try `rustc --explain E0412`.
+Some errors have detailed explanations: E0425, E0517, E0658, E0740.
+For more information about an error, try `rustc --explain E0425`.

--- a/tests/ui/layout/transmute-to-tail-with-err.stderr
+++ b/tests/ui/layout/transmute-to-tail-with-err.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `T` in this scope
+error[E0425]: cannot find type `T` in this scope
   --> $DIR/transmute-to-tail-with-err.rs:3:26
    |
 LL | struct Bar(Box<dyn Trait<T>>);
@@ -20,5 +20,5 @@ LL |     let x: Bar = unsafe { std::mem::transmute(()) };
 
 error: aborting due to 2 previous errors
 
-Some errors have detailed explanations: E0412, E0512.
-For more information about an error, try `rustc --explain E0412`.
+Some errors have detailed explanations: E0425, E0512.
+For more information about an error, try `rustc --explain E0425`.

--- a/tests/ui/lifetimes/elided-lifetime-in-const-param-type.stderr
+++ b/tests/ui/lifetimes/elided-lifetime-in-const-param-type.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `c` in this scope
+error[E0425]: cannot find type `c` in this scope
   --> $DIR/elided-lifetime-in-const-param-type.rs:8:27
    |
 LL | type A = dyn for<const B: c(&())> D;
@@ -16,5 +16,5 @@ LL | type A = dyn for<const B: c(&())> D;
 
 error: aborting due to 2 previous errors
 
-Some errors have detailed explanations: E0412, E0658.
-For more information about an error, try `rustc --explain E0412`.
+Some errors have detailed explanations: E0425, E0658.
+For more information about an error, try `rustc --explain E0425`.

--- a/tests/ui/lifetimes/issue-83907-invalid-fn-like-path.stderr
+++ b/tests/ui/lifetimes/issue-83907-invalid-fn-like-path.stderr
@@ -6,7 +6,7 @@ LL | static STATIC_VAR_FIVE: &One();
    |                               |
    |                               help: provide a definition for the static: `= <expr>;`
 
-error[E0412]: cannot find type `One` in this scope
+error[E0425]: cannot find type `One` in this scope
   --> $DIR/issue-83907-invalid-fn-like-path.rs:3:26
    |
 LL | static STATIC_VAR_FIVE: &One();
@@ -14,4 +14,4 @@ LL | static STATIC_VAR_FIVE: &One();
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/lint/issue-35075.stderr
+++ b/tests/ui/lint/issue-35075.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `Foo` in this scope
+error[E0425]: cannot find type `Foo` in this scope
   --> $DIR/issue-35075.rs:2:12
    |
 LL |     inner: Foo<T>
@@ -10,7 +10,7 @@ LL -     inner: Foo<T>
 LL +     inner: Baz
    |
 
-error[E0412]: cannot find type `Foo` in this scope
+error[E0425]: cannot find type `Foo` in this scope
   --> $DIR/issue-35075.rs:6:9
    |
 LL |     Foo(Foo<T>)
@@ -24,4 +24,4 @@ LL +     Foo(Baz)
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/lint/recommend-literal.rs
+++ b/tests/ui/lint/recommend-literal.rs
@@ -8,10 +8,10 @@ fn main() {
     //~^ ERROR cannot find type `long` in this scope
     //~| HELP perhaps you intended to use this type
     let v1: Boolean = true;
-    //~^ ERROR: cannot find type `Boolean` in this scope [E0412]
+    //~^ ERROR: cannot find type `Boolean` in this scope [E0425]
     //~| HELP perhaps you intended to use this type
     let v2: Bool = true;
-    //~^ ERROR: cannot find type `Bool` in this scope [E0412]
+    //~^ ERROR: cannot find type `Bool` in this scope [E0425]
     //~| HELP a builtin type with a similar name exists
     //~| HELP perhaps you intended to use this type
 }

--- a/tests/ui/lint/recommend-literal.stderr
+++ b/tests/ui/lint/recommend-literal.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `double` in this scope
+error[E0425]: cannot find type `double` in this scope
   --> $DIR/recommend-literal.rs:1:13
    |
 LL | type Real = double;
@@ -7,7 +7,7 @@ LL | type Real = double;
    |             not found in this scope
    |             help: perhaps you intended to use this type: `f64`
 
-error[E0412]: cannot find type `long` in this scope
+error[E0425]: cannot find type `long` in this scope
   --> $DIR/recommend-literal.rs:7:12
    |
 LL |     let y: long = 74802374902374923;
@@ -16,7 +16,7 @@ LL |     let y: long = 74802374902374923;
    |            not found in this scope
    |            help: perhaps you intended to use this type: `i64`
 
-error[E0412]: cannot find type `Boolean` in this scope
+error[E0425]: cannot find type `Boolean` in this scope
   --> $DIR/recommend-literal.rs:10:13
    |
 LL |     let v1: Boolean = true;
@@ -25,7 +25,7 @@ LL |     let v1: Boolean = true;
    |             not found in this scope
    |             help: perhaps you intended to use this type: `bool`
 
-error[E0412]: cannot find type `Bool` in this scope
+error[E0425]: cannot find type `Bool` in this scope
   --> $DIR/recommend-literal.rs:13:13
    |
 LL |     let v2: Bool = true;
@@ -42,7 +42,7 @@ LL -     let v2: Bool = true;
 LL +     let v2: bool = true;
    |
 
-error[E0412]: cannot find type `boolean` in this scope
+error[E0425]: cannot find type `boolean` in this scope
   --> $DIR/recommend-literal.rs:19:9
    |
 LL | fn z(a: boolean) {
@@ -51,7 +51,7 @@ LL | fn z(a: boolean) {
    |         not found in this scope
    |         help: perhaps you intended to use this type: `bool`
 
-error[E0412]: cannot find type `byte` in this scope
+error[E0425]: cannot find type `byte` in this scope
   --> $DIR/recommend-literal.rs:24:11
    |
 LL | fn a() -> byte {
@@ -60,7 +60,7 @@ LL | fn a() -> byte {
    |           not found in this scope
    |           help: perhaps you intended to use this type: `u8`
 
-error[E0412]: cannot find type `float` in this scope
+error[E0425]: cannot find type `float` in this scope
   --> $DIR/recommend-literal.rs:31:12
    |
 LL |     width: float,
@@ -69,7 +69,7 @@ LL |     width: float,
    |            not found in this scope
    |            help: perhaps you intended to use this type: `f32`
 
-error[E0412]: cannot find type `int` in this scope
+error[E0425]: cannot find type `int` in this scope
   --> $DIR/recommend-literal.rs:34:19
    |
 LL |     depth: Option<int>,
@@ -85,7 +85,7 @@ help: you might be missing a type parameter
 LL | struct Data<int> {
    |            +++++
 
-error[E0412]: cannot find type `short` in this scope
+error[E0425]: cannot find type `short` in this scope
   --> $DIR/recommend-literal.rs:40:16
    |
 LL | impl Stuff for short {}
@@ -96,4 +96,4 @@ LL | impl Stuff for short {}
 
 error: aborting due to 9 previous errors
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/lint/use_suggestion_json.stderr
+++ b/tests/ui/lint/use_suggestion_json.stderr
@@ -2,12 +2,12 @@
   "$message_type": "diagnostic",
   "message": "cannot find type `Iter` in this scope",
   "code": {
-    "code": "E0412",
+    "code": "E0425",
     "explanation": "A used type name is not in scope.
 
 Erroneous code examples:
 
-```compile_fail,E0412
+```compile_fail,E0425
 impl Something {} // error: type name `Something` is not in scope
 
 // or:
@@ -47,7 +47,7 @@ module. To fix this, you can follow the suggestion and use File directly or
 `use super::File;` which will import the types from the parent namespace. An
 example that causes this error is below:
 
-```compile_fail,E0412
+```compile_fail,E0425
 use std::fs::File;
 
 mod foo {
@@ -403,7 +403,7 @@ mod foo {
       "rendered": null
     }
   ],
-  "rendered": "\u001b[1m\u001b[91merror[E0412]\u001b[0m\u001b[1m: cannot find type `Iter` in this scope\u001b[0m
+  "rendered": "\u001b[1m\u001b[91merror[E0425]\u001b[0m\u001b[1m: cannot find type `Iter` in this scope\u001b[0m
   \u001b[1m\u001b[94m--> \u001b[0m$DIR/use_suggestion_json.rs:12:12
    \u001b[1m\u001b[94m|\u001b[0m
 \u001b[1m\u001b[94mLL\u001b[0m \u001b[1m\u001b[94m|\u001b[0m     let x: Iter;
@@ -436,11 +436,11 @@ mod foo {
 }
 {
   "$message_type": "diagnostic",
-  "message": "For more information about this error, try `rustc --explain E0412`.",
+  "message": "For more information about this error, try `rustc --explain E0425`.",
   "code": null,
   "level": "failure-note",
   "spans": [],
   "children": [],
-  "rendered": "\u001b[1mFor more information about this error, try `rustc --explain E0412`.\u001b[0m
+  "rendered": "\u001b[1mFor more information about this error, try `rustc --explain E0425`.\u001b[0m
 "
 }

--- a/tests/ui/macros/macro-context.stderr
+++ b/tests/ui/macros/macro-context.stderr
@@ -42,7 +42,7 @@ LL |     m!();
    |
    = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0412]: cannot find type `i` in this scope
+error[E0425]: cannot find type `i` in this scope
   --> $DIR/macro-context.rs:3:13
    |
 LL |     () => ( i ; typeof );
@@ -80,8 +80,8 @@ LL |     let i = m!();
 
 error: aborting due to 7 previous errors
 
-Some errors have detailed explanations: E0412, E0425.
-For more information about an error, try `rustc --explain E0412`.
+Some errors have detailed explanations: E0425, E0425.
+For more information about an error, try `rustc --explain E0425`.
 Future incompatibility report: Future breakage diagnostic:
 error: trailing semicolon in macro used in expression position
   --> $DIR/macro-context.rs:3:15

--- a/tests/ui/match/issue-82866.stderr
+++ b/tests/ui/match/issue-82866.stderr
@@ -4,7 +4,7 @@ error[E0425]: cannot find value `x` in this scope
 LL |     match x {
    |           ^ not found in this scope
 
-error[E0412]: cannot find type `v` in this scope
+error[E0425]: cannot find type `v` in this scope
   --> $DIR/issue-82866.rs:4:16
    |
 LL |         Some::<v>(v) => (),
@@ -12,5 +12,5 @@ LL |         Some::<v>(v) => (),
 
 error: aborting due to 2 previous errors
 
-Some errors have detailed explanations: E0412, E0425.
-For more information about an error, try `rustc --explain E0412`.
+Some errors have detailed explanations: E0425, E0425.
+For more information about an error, try `rustc --explain E0425`.

--- a/tests/ui/mir/gvn-nonsensical-coroutine-layout.rs
+++ b/tests/ui/mir/gvn-nonsensical-coroutine-layout.rs
@@ -4,7 +4,7 @@
 
 pub enum Request {
     TestSome(T),
-    //~^ ERROR cannot find type `T` in this scope [E0412]
+    //~^ ERROR cannot find type `T` in this scope [E0425]
 }
 
 pub async fn handle_event(event: Request) {

--- a/tests/ui/mir/gvn-nonsensical-coroutine-layout.stderr
+++ b/tests/ui/mir/gvn-nonsensical-coroutine-layout.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `T` in this scope
+error[E0425]: cannot find type `T` in this scope
   --> $DIR/gvn-nonsensical-coroutine-layout.rs:6:14
    |
 LL |     TestSome(T),
@@ -22,5 +22,5 @@ LL + use std::error::Request;
 
 error: aborting due to 2 previous errors
 
-Some errors have detailed explanations: E0412, E0574.
-For more information about an error, try `rustc --explain E0412`.
+Some errors have detailed explanations: E0425, E0574.
+For more information about an error, try `rustc --explain E0425`.

--- a/tests/ui/mir/issue-83499-input-output-iteration-ice.stderr
+++ b/tests/ui/mir/issue-83499-input-output-iteration-ice.stderr
@@ -4,7 +4,7 @@ error: at least one trait must be specified
 LL | unsafe extern "C" fn foo(_: Bar, ...) -> impl {}
    |                                          ^^^^
 
-error[E0412]: cannot find type `Bar` in this scope
+error[E0425]: cannot find type `Bar` in this scope
   --> $DIR/issue-83499-input-output-iteration-ice.rs:7:29
    |
 LL | unsafe extern "C" fn foo(_: Bar, ...) -> impl {}
@@ -12,4 +12,4 @@ LL | unsafe extern "C" fn foo(_: Bar, ...) -> impl {}
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/mir/meaningless-bound.stderr
+++ b/tests/ui/mir/meaningless-bound.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `b` in this scope
+error[E0425]: cannot find type `b` in this scope
   --> $DIR/meaningless-bound.rs:6:5
    |
 LL |     b: Sized,
@@ -15,5 +15,5 @@ LL |     Self: Sized,
 
 error: aborting due to 2 previous errors
 
-Some errors have detailed explanations: E0411, E0412.
+Some errors have detailed explanations: E0411, E0425.
 For more information about an error, try `rustc --explain E0411`.

--- a/tests/ui/mir/mir-build-2021-closure-capture-ice-110453-1.stderr
+++ b/tests/ui/mir/mir-build-2021-closure-capture-ice-110453-1.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `B` in this scope
+error[E0425]: cannot find type `B` in this scope
   --> $DIR/mir-build-2021-closure-capture-ice-110453-1.rs:12:18
    |
 LL |     pub struct C(B);
@@ -11,4 +11,4 @@ LL +     use crate::B;
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/mir/mir-build-2021-closure-capture-ice-110453-2.stderr
+++ b/tests/ui/mir/mir-build-2021-closure-capture-ice-110453-2.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `as_str` in this scope
+error[E0425]: cannot find type `as_str` in this scope
   --> $DIR/mir-build-2021-closure-capture-ice-110453-2.rs:8:47
    |
 LL | pub fn dup(f: impl Fn(i32) -> i32) -> impl Fn(as_str) -> i32 {
@@ -6,4 +6,4 @@ LL | pub fn dup(f: impl Fn(i32) -> i32) -> impl Fn(as_str) -> i32 {
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/missing/missing-items/missing-type-parameter2.stderr
+++ b/tests/ui/missing/missing-items/missing-type-parameter2.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `N` in this scope
+error[E0425]: cannot find type `N` in this scope
   --> $DIR/missing-type-parameter2.rs:3:8
    |
 LL | struct X<const N: u8>();
@@ -17,7 +17,7 @@ help: you might be missing a type parameter
 LL | impl<N> X<N> {}
    |     +++
 
-error[E0412]: cannot find type `N` in this scope
+error[E0425]: cannot find type `N` in this scope
   --> $DIR/missing-type-parameter2.rs:6:28
    |
 LL | impl<T, const A: u8 = 2> X<N> {}
@@ -35,7 +35,7 @@ help: you might be missing a type parameter
 LL | impl<T, const A: u8 = 2, N> X<N> {}
    |                        +++
 
-error[E0412]: cannot find type `T` in this scope
+error[E0425]: cannot find type `T` in this scope
   --> $DIR/missing-type-parameter2.rs:11:20
    |
 LL | struct X<const N: u8>();
@@ -54,7 +54,7 @@ help: you might be missing a type parameter
 LL | fn foo<T>(_: T) where T: Send {}
    |       +++
 
-error[E0412]: cannot find type `T` in this scope
+error[E0425]: cannot find type `T` in this scope
   --> $DIR/missing-type-parameter2.rs:11:11
    |
 LL | struct X<const N: u8>();
@@ -73,7 +73,7 @@ help: you might be missing a type parameter
 LL | fn foo<T>(_: T) where T: Send {}
    |       +++
 
-error[E0412]: cannot find type `A` in this scope
+error[E0425]: cannot find type `A` in this scope
   --> $DIR/missing-type-parameter2.rs:15:24
    |
 LL | struct X<const N: u8>();
@@ -122,5 +122,5 @@ LL | impl<T, const A: u8 = 2> X<{ N }> {}
 
 error: aborting due to 8 previous errors
 
-Some errors have detailed explanations: E0412, E0747.
-For more information about an error, try `rustc --explain E0412`.
+Some errors have detailed explanations: E0425, E0747.
+For more information about an error, try `rustc --explain E0425`.

--- a/tests/ui/offset-of/offset-of-enum.stderr
+++ b/tests/ui/offset-of/offset-of-enum.stderr
@@ -7,7 +7,7 @@ LL |     offset_of!(Alpha::One, 0);
    |                not a type
    |                help: try using the variant's enum: `Alpha`
 
-error[E0412]: cannot find type `Beta` in this scope
+error[E0425]: cannot find type `Beta` in this scope
   --> $DIR/offset-of-enum.rs:17:16
    |
 LL |     offset_of!(Beta, One);
@@ -43,5 +43,5 @@ LL |     offset_of!(Alpha, NonExistent);
 
 error: aborting due to 6 previous errors
 
-Some errors have detailed explanations: E0412, E0573, E0599, E0609, E0795.
-For more information about an error, try `rustc --explain E0412`.
+Some errors have detailed explanations: E0425, E0573, E0599, E0609, E0795.
+For more information about an error, try `rustc --explain E0425`.

--- a/tests/ui/offset-of/offset-of-self.stderr
+++ b/tests/ui/offset-of/offset-of-self.stderr
@@ -4,7 +4,7 @@ error: offset_of expects dot-separated field and variant names
 LL |         offset_of!(Self, Self::v);
    |                          ^^^^^^^
 
-error[E0412]: cannot find type `S` in module `self`
+error[E0425]: cannot find type `S` in module `self`
   --> $DIR/offset-of-self.rs:32:26
    |
 LL |         offset_of!(self::S, v);
@@ -59,5 +59,5 @@ LL |     offset_of!(S, v.self);
 
 error: aborting due to 7 previous errors
 
-Some errors have detailed explanations: E0411, E0412, E0609, E0616.
+Some errors have detailed explanations: E0411, E0425, E0609, E0616.
 For more information about an error, try `rustc --explain E0411`.

--- a/tests/ui/parallel-rustc/ty-variance-issue-124423.stderr
+++ b/tests/ui/parallel-rustc/ty-variance-issue-124423.stderr
@@ -237,7 +237,7 @@ help: consider introducing lifetime `'a` here
 LL | fn elided4<'a>(_: &impl Copy + 'a) ->  new  { x(x) }
    |           ++++
 
-error[E0412]: cannot find type `new` in this scope
+error[E0425]: cannot find type `new` in this scope
   --> $DIR/ty-variance-issue-124423.rs:48:36
    |
 LL | fn elided4(_: &impl Copy + 'a) ->  new  { x(x) }
@@ -282,5 +282,5 @@ note: if you're trying to build a new `Box<_, _>` consider using one of the foll
 
 error: aborting due to 30 previous errors
 
-Some errors have detailed explanations: E0121, E0224, E0261, E0412, E0599.
+Some errors have detailed explanations: E0121, E0224, E0261, E0425, E0599.
 For more information about an error, try `rustc --explain E0121`.

--- a/tests/ui/parser/associated-path-shl.stderr
+++ b/tests/ui/parser/associated-path-shl.stderr
@@ -1,28 +1,28 @@
-error[E0412]: cannot find type `A` in this scope
+error[E0425]: cannot find type `A` in this scope
   --> $DIR/associated-path-shl.rs:4:14
    |
 LL |     let _: <<A>::B>::C;
    |              ^ not found in this scope
 
-error[E0412]: cannot find type `A` in this scope
+error[E0425]: cannot find type `A` in this scope
   --> $DIR/associated-path-shl.rs:5:15
    |
 LL |     let _ = <<A>::B>::C;
    |               ^ not found in this scope
 
-error[E0412]: cannot find type `A` in this scope
+error[E0425]: cannot find type `A` in this scope
   --> $DIR/associated-path-shl.rs:6:11
    |
 LL |     let <<A>::B>::C;
    |           ^ not found in this scope
 
-error[E0412]: cannot find type `A` in this scope
+error[E0425]: cannot find type `A` in this scope
   --> $DIR/associated-path-shl.rs:7:17
    |
 LL |     let 0 ..= <<A>::B>::C;
    |                 ^ not found in this scope
 
-error[E0412]: cannot find type `A` in this scope
+error[E0425]: cannot find type `A` in this scope
   --> $DIR/associated-path-shl.rs:8:7
    |
 LL |     <<A>::B>::C;
@@ -30,4 +30,4 @@ LL |     <<A>::B>::C;
 
 error: aborting due to 5 previous errors
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/parser/const-param-decl-on-type-instead-of-impl.stderr
+++ b/tests/ui/parser/const-param-decl-on-type-instead-of-impl.stderr
@@ -30,7 +30,7 @@ LL |     path::path::Struct::<const N: usize>()
    |
    = help: you might be missing a crate named `path`
 
-error[E0412]: cannot find type `T` in this scope
+error[E0425]: cannot find type `T` in this scope
   --> $DIR/const-param-decl-on-type-instead-of-impl.rs:8:15
    |
 LL | fn banana(a: <T<const N: usize>>::BAR) {}
@@ -46,5 +46,5 @@ LL |     let _: () = 42;
 
 error: aborting due to 6 previous errors
 
-Some errors have detailed explanations: E0308, E0412, E0433.
+Some errors have detailed explanations: E0308, E0425, E0433.
 For more information about an error, try `rustc --explain E0308`.

--- a/tests/ui/parser/dyn-trait-compatibility.stderr
+++ b/tests/ui/parser/dyn-trait-compatibility.stderr
@@ -1,28 +1,28 @@
-error[E0412]: cannot find type `dyn` in this scope
+error[E0425]: cannot find type `dyn` in this scope
   --> $DIR/dyn-trait-compatibility.rs:3:11
    |
 LL | type A0 = dyn;
    |           ^^^ not found in this scope
 
-error[E0412]: cannot find type `dyn` in this scope
+error[E0425]: cannot find type `dyn` in this scope
   --> $DIR/dyn-trait-compatibility.rs:7:11
    |
 LL | type A2 = dyn<dyn, dyn>;
    |           ^^^ not found in this scope
 
-error[E0412]: cannot find type `dyn` in this scope
+error[E0425]: cannot find type `dyn` in this scope
   --> $DIR/dyn-trait-compatibility.rs:7:15
    |
 LL | type A2 = dyn<dyn, dyn>;
    |               ^^^ not found in this scope
 
-error[E0412]: cannot find type `dyn` in this scope
+error[E0425]: cannot find type `dyn` in this scope
   --> $DIR/dyn-trait-compatibility.rs:7:20
    |
 LL | type A2 = dyn<dyn, dyn>;
    |                    ^^^ not found in this scope
 
-error[E0412]: cannot find type `dyn` in this scope
+error[E0425]: cannot find type `dyn` in this scope
   --> $DIR/dyn-trait-compatibility.rs:11:11
    |
 LL | type A3 = dyn<<dyn as dyn>::dyn>;
@@ -34,7 +34,7 @@ error[E0405]: cannot find trait `dyn` in this scope
 LL | type A3 = dyn<<dyn as dyn>::dyn>;
    |                       ^^^ not found in this scope
 
-error[E0412]: cannot find type `dyn` in this scope
+error[E0425]: cannot find type `dyn` in this scope
   --> $DIR/dyn-trait-compatibility.rs:11:16
    |
 LL | type A3 = dyn<<dyn as dyn>::dyn>;
@@ -50,5 +50,5 @@ LL | type A1 = dyn::dyn;
 
 error: aborting due to 8 previous errors
 
-Some errors have detailed explanations: E0405, E0412, E0433.
+Some errors have detailed explanations: E0405, E0425, E0433.
 For more information about an error, try `rustc --explain E0405`.

--- a/tests/ui/parser/fn-field-parse-error-ice.stderr
+++ b/tests/ui/parser/fn-field-parse-error-ice.stderr
@@ -17,7 +17,7 @@ help: escape `fn` to use it as an identifier
 LL |     inner : dyn r#fn ()
    |                 ++
 
-error[E0412]: cannot find type `dyn` in this scope
+error[E0425]: cannot find type `dyn` in this scope
   --> $DIR/fn-field-parse-error-ice.rs:5:13
    |
 LL |     inner : dyn fn ()
@@ -25,4 +25,4 @@ LL |     inner : dyn fn ()
 
 error: aborting due to 3 previous errors
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/parser/recover/recover-fn-ptr-with-generics.stderr
+++ b/tests/ui/parser/recover/recover-fn-ptr-with-generics.stderr
@@ -88,13 +88,13 @@ error: expected identifier, found `>`
 LL |     type QuiteBroken = fn<const>();
    |                                ^ expected identifier
 
-error[E0412]: cannot find type `T` in this scope
+error[E0425]: cannot find type `T` in this scope
   --> $DIR/recover-fn-ptr-with-generics.rs:5:27
    |
 LL |     type Identity = fn<T>(T) -> T;
    |                           ^ not found in this scope
 
-error[E0412]: cannot find type `T` in this scope
+error[E0425]: cannot find type `T` in this scope
   --> $DIR/recover-fn-ptr-with-generics.rs:5:33
    |
 LL |     type Identity = fn<T>(T) -> T;
@@ -108,4 +108,4 @@ LL |     let _: extern "C" fn<'a: 'static>();
 
 error: aborting due to 12 previous errors
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/parser/unmatched-langle-1.rs
+++ b/tests/ui/parser/unmatched-langle-1.rs
@@ -5,5 +5,5 @@ fn main() {
     foo::<<<<Ty<i32>>();
     //~^ ERROR: unmatched angle brackets
     //~| ERROR: cannot find function `foo` in this scope [E0425]
-    //~| ERROR: cannot find type `Ty` in this scope [E0412]
+    //~| ERROR: cannot find type `Ty` in this scope [E0425]
 }

--- a/tests/ui/parser/unmatched-langle-1.stderr
+++ b/tests/ui/parser/unmatched-langle-1.stderr
@@ -10,7 +10,7 @@ LL -     foo::<<<<Ty<i32>>();
 LL +     foo::<Ty<i32>>();
    |
 
-error[E0412]: cannot find type `Ty` in this scope
+error[E0425]: cannot find type `Ty` in this scope
   --> $DIR/unmatched-langle-1.rs:5:14
    |
 LL |     foo::<<<<Ty<i32>>();
@@ -24,5 +24,5 @@ LL |     foo::<<<<Ty<i32>>();
 
 error: aborting due to 3 previous errors
 
-Some errors have detailed explanations: E0412, E0425.
-For more information about an error, try `rustc --explain E0412`.
+Some errors have detailed explanations: E0425, E0425.
+For more information about an error, try `rustc --explain E0425`.

--- a/tests/ui/parser/where_with_bound.stderr
+++ b/tests/ui/parser/where_with_bound.stderr
@@ -4,7 +4,7 @@ error: generic parameters on `where` clauses are reserved for future use
 LL | fn foo<T>() where <T>::Item: ToString, T: Iterator { }
    |                   ^^^ currently unsupported
 
-error[E0412]: cannot find type `Item` in the crate root
+error[E0425]: cannot find type `Item` in the crate root
   --> $DIR/where_with_bound.rs:1:24
    |
 LL | fn foo<T>() where <T>::Item: ToString, T: Iterator { }
@@ -12,4 +12,4 @@ LL | fn foo<T>() where <T>::Item: ToString, T: Iterator { }
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/pattern/usefulness/issue-119493-type-error-ice.stderr
+++ b/tests/ui/pattern/usefulness/issue-119493-type-error-ice.stderr
@@ -1,10 +1,10 @@
-error[E0412]: cannot find type `NonExistent` in this scope
+error[E0425]: cannot find type `NonExistent` in this scope
   --> $DIR/issue-119493-type-error-ice.rs:5:16
    |
 LL |     struct Foo(NonExistent);
    |                ^^^^^^^^^^^ not found in this scope
 
-error[E0412]: cannot find type `NonExistent` in this scope
+error[E0425]: cannot find type `NonExistent` in this scope
   --> $DIR/issue-119493-type-error-ice.rs:5:16
    |
 LL |     struct Foo(NonExistent);
@@ -27,5 +27,5 @@ LL |     type U = impl Copy;
 
 error: aborting due to 3 previous errors
 
-Some errors have detailed explanations: E0412, E0658.
-For more information about an error, try `rustc --explain E0412`.
+Some errors have detailed explanations: E0425, E0658.
+For more information about an error, try `rustc --explain E0425`.

--- a/tests/ui/privacy/privacy-ns1.stderr
+++ b/tests/ui/privacy/privacy-ns1.stderr
@@ -52,7 +52,7 @@ help: consider importing this function
 LL + use foo2::Bar;
    |
 
-error[E0412]: cannot find type `Bar` in this scope
+error[E0425]: cannot find type `Bar` in this scope
   --> $DIR/privacy-ns1.rs:52:17
    |
 LL |     pub struct Baz;
@@ -90,5 +90,5 @@ LL |     let _x: Box<Bar>;
 
 error: aborting due to 4 previous errors
 
-Some errors have detailed explanations: E0412, E0423, E0425, E0747.
-For more information about an error, try `rustc --explain E0412`.
+Some errors have detailed explanations: E0425, E0423, E0425, E0747.
+For more information about an error, try `rustc --explain E0425`.

--- a/tests/ui/privacy/sysroot-private.default.stderr
+++ b/tests/ui/privacy/sysroot-private.default.stderr
@@ -4,7 +4,7 @@ error[E0405]: cannot find trait `Equivalent` in this scope
 LL | trait Trait2<K>: Equivalent<K> {}
    |                  ^^^^^^^^^^ not found in this scope
 
-error[E0412]: cannot find type `K` in this scope
+error[E0425]: cannot find type `K` in this scope
   --> $DIR/sysroot-private.rs:32:35
    |
 LL | fn trait_member<T>(val: &T, key: &K) -> bool {
@@ -36,5 +36,5 @@ LL |     memchr2(b'a', b'b', buf)
 
 error: aborting due to 4 previous errors
 
-Some errors have detailed explanations: E0220, E0405, E0412, E0425.
+Some errors have detailed explanations: E0220, E0405, E0425, E0425.
 For more information about an error, try `rustc --explain E0220`.

--- a/tests/ui/privacy/sysroot-private.rustc_private_enabled.stderr
+++ b/tests/ui/privacy/sysroot-private.rustc_private_enabled.stderr
@@ -4,7 +4,7 @@ error[E0405]: cannot find trait `Equivalent` in this scope
 LL | trait Trait2<K>: Equivalent<K> {}
    |                  ^^^^^^^^^^ not found in this scope
 
-error[E0412]: cannot find type `K` in this scope
+error[E0425]: cannot find type `K` in this scope
   --> $DIR/sysroot-private.rs:32:35
    |
 LL | fn trait_member<T>(val: &T, key: &K) -> bool {
@@ -36,5 +36,5 @@ LL |     memchr2(b'a', b'b', buf)
 
 error: aborting due to 4 previous errors
 
-Some errors have detailed explanations: E0220, E0405, E0412, E0425.
+Some errors have detailed explanations: E0220, E0405, E0425, E0425.
 For more information about an error, try `rustc --explain E0220`.

--- a/tests/ui/proc-macro/attributes-on-modules-fail.stderr
+++ b/tests/ui/proc-macro/attributes-on-modules-fail.stderr
@@ -46,7 +46,7 @@ LL |     mod inner;
    = help: add `#![feature(proc_macro_hygiene)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0412]: cannot find type `Y` in this scope
+error[E0425]: cannot find type `Y` in this scope
   --> $DIR/attributes-on-modules-fail.rs:10:14
    |
 LL |     type A = Y;
@@ -57,7 +57,7 @@ help: consider importing this struct
 LL +     use Y;
    |
 
-error[E0412]: cannot find type `X` in this scope
+error[E0425]: cannot find type `X` in this scope
   --> $DIR/attributes-on-modules-fail.rs:14:10
    |
 LL | type A = X;
@@ -70,5 +70,5 @@ LL + use m::X;
 
 error: aborting due to 7 previous errors
 
-Some errors have detailed explanations: E0412, E0658, E0774.
-For more information about an error, try `rustc --explain E0412`.
+Some errors have detailed explanations: E0425, E0658, E0774.
+For more information about an error, try `rustc --explain E0425`.

--- a/tests/ui/proc-macro/empty-where-clause.stderr
+++ b/tests/ui/proc-macro/empty-where-clause.stderr
@@ -1,16 +1,16 @@
-error[E0412]: cannot find type `MissingType1` in this scope
+error[E0425]: cannot find type `MissingType1` in this scope
   --> $DIR/empty-where-clause.rs:8:12
    |
 LL |     field: MissingType1
    |            ^^^^^^^^^^^^ not found in this scope
 
-error[E0412]: cannot find type `MissingType2` in this scope
+error[E0425]: cannot find type `MissingType2` in this scope
   --> $DIR/empty-where-clause.rs:12:20
    |
 LL | struct TupleStruct(MissingType2) where;
    |                    ^^^^^^^^^^^^ not found in this scope
 
-error[E0412]: cannot find type `MissingType3` in this scope
+error[E0425]: cannot find type `MissingType3` in this scope
   --> $DIR/empty-where-clause.rs:15:13
    |
 LL |     Variant(MissingType3)
@@ -18,4 +18,4 @@ LL |     Variant(MissingType3)
 
 error: aborting due to 3 previous errors
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/proc-macro/generate-mod.stderr
+++ b/tests/ui/proc-macro/generate-mod.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `FromOutside` in this scope
+error[E0425]: cannot find type `FromOutside` in this scope
   --> $DIR/generate-mod.rs:10:1
    |
 LL | generate_mod::check!();
@@ -8,7 +8,7 @@ LL | generate_mod::check!();
            FromOutside
    = note: this error originates in the macro `generate_mod::check` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0412]: cannot find type `Outer` in this scope
+error[E0425]: cannot find type `Outer` in this scope
   --> $DIR/generate-mod.rs:10:1
    |
 LL | generate_mod::check!();
@@ -18,7 +18,7 @@ LL | generate_mod::check!();
            Outer
    = note: this error originates in the macro `generate_mod::check` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0412]: cannot find type `FromOutside` in this scope
+error[E0425]: cannot find type `FromOutside` in this scope
   --> $DIR/generate-mod.rs:13:1
    |
 LL | #[generate_mod::check_attr]
@@ -28,7 +28,7 @@ LL | #[generate_mod::check_attr]
            FromOutside
    = note: this error originates in the attribute macro `generate_mod::check_attr` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0412]: cannot find type `OuterAttr` in this scope
+error[E0425]: cannot find type `OuterAttr` in this scope
   --> $DIR/generate-mod.rs:13:1
    |
 LL | #[generate_mod::check_attr]
@@ -81,7 +81,7 @@ LL |     #[derive(generate_mod::CheckDerive)]
 
 error: aborting due to 8 previous errors
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.
 Future incompatibility report: Future breakage diagnostic:
 error: cannot find type `FromOutside` in this scope
   --> $DIR/generate-mod.rs:17:10

--- a/tests/ui/proc-macro/issue-83510.stderr
+++ b/tests/ui/proc-macro/issue-83510.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `Foo` in this scope
+error[E0425]: cannot find type `Foo` in this scope
   --> $DIR/issue-83510.rs:6:1
    |
 LL | issue_83510::dance_like_you_want_to_ice!();
@@ -35,5 +35,5 @@ LL | issue_83510::dance_like_you_want_to_ice!();
 
 error: aborting due to 4 previous errors
 
-Some errors have detailed explanations: E0404, E0405, E0412, E0658.
+Some errors have detailed explanations: E0404, E0405, E0425, E0658.
 For more information about an error, try `rustc --explain E0404`.

--- a/tests/ui/proc-macro/macro-rules-derive.stderr
+++ b/tests/ui/proc-macro/macro-rules-derive.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `MissingType` in this scope
+error[E0425]: cannot find type `MissingType` in this scope
   --> $DIR/macro-rules-derive.rs:10:20
    |
 LL |             field: MissingType
@@ -11,4 +11,4 @@ LL | produce_it!(MyName);
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/proc-macro/mixed-site-span.stderr
+++ b/tests/ui/proc-macro/mixed-site-span.stderr
@@ -576,7 +576,7 @@ LL |         proc_macro_rules!();
    |
    = note: this error originates in the macro `proc_macro_rules` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0412]: cannot find type `ItemUse` in crate `$crate`
+error[E0425]: cannot find type `ItemUse` in crate `$crate`
   --> $DIR/mixed-site-span.rs:22:9
    |
 LL |         proc_macro_rules!();
@@ -609,5 +609,5 @@ LL |         local_def;
 
 error: aborting due to 52 previous errors
 
-Some errors have detailed explanations: E0412, E0425, E0426, E0432.
-For more information about an error, try `rustc --explain E0412`.
+Some errors have detailed explanations: E0425, E0425, E0426, E0432.
+For more information about an error, try `rustc --explain E0425`.

--- a/tests/ui/proc-macro/span-from-proc-macro.stderr
+++ b/tests/ui/proc-macro/span-from-proc-macro.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `MissingType` in this scope
+error[E0425]: cannot find type `MissingType` in this scope
   --> $DIR/auxiliary/span-from-proc-macro.rs:33:20
    |
 LL | pub fn error_from_attribute(_args: TokenStream, _input: TokenStream) -> TokenStream {
@@ -12,7 +12,7 @@ LL |             field: MissingType
 LL | #[error_from_attribute]
    | ----------------------- in this attribute macro expansion
 
-error[E0412]: cannot find type `OtherMissingType` in this scope
+error[E0425]: cannot find type `OtherMissingType` in this scope
   --> $DIR/auxiliary/span-from-proc-macro.rs:42:21
    |
 LL | pub fn error_from_derive(_input: TokenStream) -> TokenStream {
@@ -58,5 +58,5 @@ LL |     error_from_bang!();
 
 error: aborting due to 4 previous errors
 
-Some errors have detailed explanations: E0308, E0412, E0425.
+Some errors have detailed explanations: E0308, E0425, E0425.
 For more information about an error, try `rustc --explain E0308`.

--- a/tests/ui/recursion/recursive-reexports.stderr
+++ b/tests/ui/recursion/recursive-reexports.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `S` in crate `recursive_reexports`
+error[E0425]: cannot find type `S` in crate `recursive_reexports`
   --> $DIR/recursive-reexports.rs:5:32
    |
 LL | fn f() -> recursive_reexports::S {}
@@ -6,4 +6,4 @@ LL | fn f() -> recursive_reexports::S {}
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/regions/outlives-with-missing.stderr
+++ b/tests/ui/regions/outlives-with-missing.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `T` in this scope
+error[E0425]: cannot find type `T` in this scope
   --> $DIR/outlives-with-missing.rs:10:9
    |
 LL | impl<H: HandlerFamily> HandlerWrapper<H> {
@@ -9,4 +9,4 @@ LL |         T: Send + Sync + 'static,
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/resolve/dont-compute-arg-names-for-non-fn.stderr
+++ b/tests/ui/resolve/dont-compute-arg-names-for-non-fn.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `Bar` in this scope
+error[E0425]: cannot find type `Bar` in this scope
   --> $DIR/dont-compute-arg-names-for-non-fn.rs:8:14
    |
 LL | impl Foo for Bar {}
@@ -11,4 +11,4 @@ LL | impl Foo for Self::Bar {}
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/resolve/editions-crate-root-2015.stderr
+++ b/tests/ui/resolve/editions-crate-root-2015.stderr
@@ -20,13 +20,13 @@ help: you might be missing a crate named `nonexistant`, add it to your project a
 LL + extern crate nonexistant;
    |
 
-error[E0412]: cannot find type `nonexistant` in the crate root
+error[E0425]: cannot find type `nonexistant` in the crate root
   --> $DIR/editions-crate-root-2015.rs:11:25
    |
 LL |     fn bare_global(_: ::nonexistant) {
    |                         ^^^^^^^^^^^ not found in the crate root
 
-error[E0412]: cannot find type `nonexistant` in the crate root
+error[E0425]: cannot find type `nonexistant` in the crate root
   --> $DIR/editions-crate-root-2015.rs:14:29
    |
 LL |     fn bare_crate(_: crate::nonexistant) {
@@ -34,5 +34,5 @@ LL |     fn bare_crate(_: crate::nonexistant) {
 
 error: aborting due to 4 previous errors
 
-Some errors have detailed explanations: E0412, E0433.
-For more information about an error, try `rustc --explain E0412`.
+Some errors have detailed explanations: E0425, E0433.
+For more information about an error, try `rustc --explain E0425`.

--- a/tests/ui/resolve/editions-crate-root-2018.stderr
+++ b/tests/ui/resolve/editions-crate-root-2018.stderr
@@ -10,13 +10,13 @@ error[E0433]: failed to resolve: could not find `nonexistant` in the crate root
 LL |     fn crate_inner(_: crate::nonexistant::Foo) {
    |                              ^^^^^^^^^^^ could not find `nonexistant` in the crate root
 
-error[E0412]: cannot find crate `nonexistant` in the list of imported crates
+error[E0425]: cannot find crate `nonexistant` in the list of imported crates
   --> $DIR/editions-crate-root-2018.rs:11:25
    |
 LL |     fn bare_global(_: ::nonexistant) {
    |                         ^^^^^^^^^^^ not found in the list of imported crates
 
-error[E0412]: cannot find type `nonexistant` in the crate root
+error[E0425]: cannot find type `nonexistant` in the crate root
   --> $DIR/editions-crate-root-2018.rs:14:29
    |
 LL |     fn bare_crate(_: crate::nonexistant) {
@@ -24,5 +24,5 @@ LL |     fn bare_crate(_: crate::nonexistant) {
 
 error: aborting due to 4 previous errors
 
-Some errors have detailed explanations: E0412, E0433.
-For more information about an error, try `rustc --explain E0412`.
+Some errors have detailed explanations: E0425, E0433.
+For more information about an error, try `rustc --explain E0425`.

--- a/tests/ui/resolve/issue-21221-1.rs
+++ b/tests/ui/resolve/issue-21221-1.rs
@@ -45,7 +45,7 @@ impl Mul for Foo {
 }
 
 // BEFORE, we got:
-//   error: use of undeclared type name `Mul` [E0412]
+//   error: use of undeclared type name `Mul` [E0425]
 // AFTER, we get:
 //   error: type name `Mul` is not in scope. Maybe you meant:
 //   help: ...

--- a/tests/ui/resolve/issue-21221-1.stderr
+++ b/tests/ui/resolve/issue-21221-1.stderr
@@ -13,7 +13,7 @@ LL + use mul1::Mul;
 LL + use mul2::Mul;
    |
 
-error[E0412]: cannot find type `Mul` in this scope
+error[E0425]: cannot find type `Mul` in this scope
   --> $DIR/issue-21221-1.rs:58:16
    |
 LL | fn getMul() -> Mul {
@@ -58,5 +58,5 @@ LL + use std::ops::Div;
 
 error: aborting due to 4 previous errors
 
-Some errors have detailed explanations: E0405, E0412.
+Some errors have detailed explanations: E0405, E0425.
 For more information about an error, try `rustc --explain E0405`.

--- a/tests/ui/resolve/issue-35675.stderr
+++ b/tests/ui/resolve/issue-35675.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `Apple` in this scope
+error[E0425]: cannot find type `Apple` in this scope
   --> $DIR/issue-35675.rs:7:29
    |
 LL | fn should_return_fruit() -> Apple {
@@ -50,7 +50,7 @@ LL | fn foo() -> Ok {
    |             not a type
    |             help: try using the variant's enum: `std::result::Result`
 
-error[E0412]: cannot find type `Variant3` in this scope
+error[E0425]: cannot find type `Variant3` in this scope
   --> $DIR/issue-35675.rs:24:13
    |
 LL | fn bar() -> Variant3 {
@@ -73,5 +73,5 @@ LL | fn qux() -> Some {
 
 error: aborting due to 7 previous errors
 
-Some errors have detailed explanations: E0412, E0425, E0573.
-For more information about an error, try `rustc --explain E0412`.
+Some errors have detailed explanations: E0425, E0573.
+For more information about an error, try `rustc --explain E0425`.

--- a/tests/ui/resolve/issue-69401-trait-fn-no-body-ty-local.rs
+++ b/tests/ui/resolve/issue-69401-trait-fn-no-body-ty-local.rs
@@ -2,5 +2,5 @@ fn main() {}
 
 trait Foo {
     fn fn_with_type_named_same_as_local_in_param(b: b);
-    //~^ ERROR cannot find type `b` in this scope [E0412]
+    //~^ ERROR cannot find type `b` in this scope [E0425]
 }

--- a/tests/ui/resolve/issue-69401-trait-fn-no-body-ty-local.stderr
+++ b/tests/ui/resolve/issue-69401-trait-fn-no-body-ty-local.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `b` in this scope
+error[E0425]: cannot find type `b` in this scope
   --> $DIR/issue-69401-trait-fn-no-body-ty-local.rs:4:53
    |
 LL |     fn fn_with_type_named_same_as_local_in_param(b: b);
@@ -6,4 +6,4 @@ LL |     fn fn_with_type_named_same_as_local_in_param(b: b);
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/resolve/issue-85348.rs
+++ b/tests/ui/resolve/issue-85348.rs
@@ -1,7 +1,7 @@
 // Checks whether shadowing a const parameter leads to an ICE (#85348).
 
 impl<const N: usize> ArrayWindowsExample {
-//~^ ERROR: cannot find type `ArrayWindowsExample` in this scope [E0412]
+//~^ ERROR: cannot find type `ArrayWindowsExample` in this scope [E0425]
     fn next() {
         let mut N;
         //~^ ERROR: let bindings cannot shadow const parameters [E0530]

--- a/tests/ui/resolve/issue-85348.stderr
+++ b/tests/ui/resolve/issue-85348.stderr
@@ -7,7 +7,7 @@ LL | impl<const N: usize> ArrayWindowsExample {
 LL |         let mut N;
    |                 ^ cannot be named the same as a const parameter
 
-error[E0412]: cannot find type `ArrayWindowsExample` in this scope
+error[E0425]: cannot find type `ArrayWindowsExample` in this scope
   --> $DIR/issue-85348.rs:3:22
    |
 LL | impl<const N: usize> ArrayWindowsExample {
@@ -26,5 +26,5 @@ LL |         let mut N: /* Type */;
 
 error: aborting due to 3 previous errors
 
-Some errors have detailed explanations: E0282, E0412, E0530.
+Some errors have detailed explanations: E0282, E0425, E0530.
 For more information about an error, try `rustc --explain E0282`.

--- a/tests/ui/resolve/issue-88472.rs
+++ b/tests/ui/resolve/issue-88472.rs
@@ -14,7 +14,7 @@ mod b {
     use crate::a::*;
     //~^ WARNING: unused import
     type Bar = Foo;
-    //~^ ERROR: cannot find type `Foo` in this scope [E0412]
+    //~^ ERROR: cannot find type `Foo` in this scope [E0425]
     //~| NOTE: not found in this scope
 }
 
@@ -31,7 +31,7 @@ mod c {
 
 mod e {
     type Baz = Eee;
-    //~^ ERROR: cannot find type `Eee` in this scope [E0412]
+    //~^ ERROR: cannot find type `Eee` in this scope [E0425]
     //~| NOTE: not found in this scope
 }
 

--- a/tests/ui/resolve/issue-88472.stderr
+++ b/tests/ui/resolve/issue-88472.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `Foo` in this scope
+error[E0425]: cannot find type `Foo` in this scope
   --> $DIR/issue-88472.rs:16:16
    |
 LL |     type Bar = Foo;
@@ -10,7 +10,7 @@ note: struct `a::Foo` exists but is inaccessible
 LL |     struct Foo;
    |     ^^^^^^^^^^^ not accessible
 
-error[E0412]: cannot find type `Eee` in this scope
+error[E0425]: cannot find type `Eee` in this scope
   --> $DIR/issue-88472.rs:33:16
    |
 LL |     type Baz = Eee;
@@ -39,4 +39,4 @@ LL | #![warn(unused_imports)]
 
 error: aborting due to 2 previous errors; 1 warning emitted
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/resolve/levenshtein.stderr
+++ b/tests/ui/resolve/levenshtein.stderr
@@ -1,10 +1,10 @@
-error[E0412]: cannot find type `esize` in this scope
+error[E0425]: cannot find type `esize` in this scope
   --> $DIR/levenshtein.rs:5:11
    |
 LL | fn foo(c: esize) {} // Misspelled primitive type name.
    |           ^^^^^ help: a builtin type with a similar name exists: `isize`
 
-error[E0412]: cannot find type `Baz` in this scope
+error[E0425]: cannot find type `Baz` in this scope
   --> $DIR/levenshtein.rs:10:10
    |
 LL | enum Bar { }
@@ -13,7 +13,7 @@ LL |
 LL | type A = Baz; // Misspelled type name.
    |          ^^^ help: an enum with a similar name exists: `Bar`
 
-error[E0412]: cannot find type `Opiton` in this scope
+error[E0425]: cannot find type `Opiton` in this scope
   --> $DIR/levenshtein.rs:12:10
    |
 LL | type B = Opiton<u8>; // Misspelled type name from the prelude.
@@ -23,7 +23,7 @@ LL | type B = Opiton<u8>; // Misspelled type name from the prelude.
    |
    = note: similarly named enum `Option` defined here
 
-error[E0412]: cannot find type `Baz` in this scope
+error[E0425]: cannot find type `Baz` in this scope
   --> $DIR/levenshtein.rs:16:14
    |
 LL |     type A = Baz; // No suggestion here, Bar is not visible
@@ -38,7 +38,7 @@ LL | const MAX_ITEM: usize = 10;
 LL |     let v = [0u32; MAXITEM]; // Misspelled constant name.
    |                    ^^^^^^^ help: a constant with a similar name exists: `MAX_ITEM`
 
-error[E0412]: cannot find type `first` in module `m`
+error[E0425]: cannot find type `first` in module `m`
   --> $DIR/levenshtein.rs:28:15
    |
 LL |     pub struct First;
@@ -67,5 +67,4 @@ LL |     foobar(); // Misspelled function name.
 
 error: aborting due to 8 previous errors
 
-Some errors have detailed explanations: E0412, E0425.
-For more information about an error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/resolve/missing-type-in-scope-58712.stderr
+++ b/tests/ui/resolve/missing-type-in-scope-58712.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `DeviceId` in this scope
+error[E0425]: cannot find type `DeviceId` in this scope
   --> $DIR/missing-type-in-scope-58712.rs:7:20
    |
 LL | impl<H> AddrVec<H, DeviceId> {
@@ -9,7 +9,7 @@ help: you might be missing a type parameter
 LL | impl<H, DeviceId> AddrVec<H, DeviceId> {
    |       ++++++++++
 
-error[E0412]: cannot find type `DeviceId` in this scope
+error[E0425]: cannot find type `DeviceId` in this scope
   --> $DIR/missing-type-in-scope-58712.rs:9:29
    |
 LL |     pub fn device(&self) -> DeviceId {
@@ -17,4 +17,4 @@ LL |     pub fn device(&self) -> DeviceId {
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/resolve/privacy-enum-ctor.stderr
+++ b/tests/ui/resolve/privacy-enum-ctor.stderr
@@ -142,7 +142,7 @@ LL + use std::f32::consts::E;
 LL + use std::f64::consts::E;
    |
 
-error[E0412]: cannot find type `Z` in this scope
+error[E0425]: cannot find type `Z` in this scope
   --> $DIR/privacy-enum-ctor.rs:57:12
    |
 LL |     pub enum E {
@@ -185,7 +185,7 @@ LL -     let _: Z = m::n::Z;
 LL +     let _: Z = (m::Z::Fn(/* fields */));
    |
 
-error[E0412]: cannot find type `Z` in this scope
+error[E0425]: cannot find type `Z` in this scope
   --> $DIR/privacy-enum-ctor.rs:61:12
    |
 LL |     pub enum E {
@@ -200,7 +200,7 @@ note: enum `m::Z` exists but is inaccessible
 LL |         pub(in crate::m) enum Z {
    |         ^^^^^^^^^^^^^^^^^^^^^^^ not accessible
 
-error[E0412]: cannot find type `Z` in this scope
+error[E0425]: cannot find type `Z` in this scope
   --> $DIR/privacy-enum-ctor.rs:64:12
    |
 LL |     pub enum E {
@@ -215,7 +215,7 @@ note: enum `m::Z` exists but is inaccessible
 LL |         pub(in crate::m) enum Z {
    |         ^^^^^^^^^^^^^^^^^^^^^^^ not accessible
 
-error[E0412]: cannot find type `Z` in this scope
+error[E0425]: cannot find type `Z` in this scope
   --> $DIR/privacy-enum-ctor.rs:68:12
    |
 LL |     pub enum E {
@@ -433,5 +433,5 @@ LL |     let _: Z = m::n::Z::Struct { s: /* value */ };
 
 error: aborting due to 23 previous errors
 
-Some errors have detailed explanations: E0308, E0412, E0423, E0533, E0603, E0618.
+Some errors have detailed explanations: E0308, E0423, E0425, E0533, E0603, E0618.
 For more information about an error, try `rustc --explain E0308`.

--- a/tests/ui/resolve/raw-ident-in-path.stderr
+++ b/tests/ui/resolve/raw-ident-in-path.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `r#break` in the crate root
+error[E0425]: cannot find type `r#break` in the crate root
   --> $DIR/raw-ident-in-path.rs:3:17
    |
 LL | type A = crate::r#break;
@@ -6,4 +6,4 @@ LL | type A = crate::r#break;
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/resolve/resolve-assoc-suggestions.stderr
+++ b/tests/ui/resolve/resolve-assoc-suggestions.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `field` in this scope
+error[E0425]: cannot find type `field` in this scope
   --> $DIR/resolve-assoc-suggestions.rs:16:16
    |
 LL |         let _: field;
@@ -21,7 +21,7 @@ help: you might have meant to use the available field
 LL |         self.field;
    |         +++++
 
-error[E0412]: cannot find type `Type` in this scope
+error[E0425]: cannot find type `Type` in this scope
   --> $DIR/resolve-assoc-suggestions.rs:23:16
    |
 LL |         let _: Type;
@@ -44,7 +44,7 @@ error[E0425]: cannot find value `Type` in this scope
 LL |         Type;
    |         ^^^^ not found in this scope
 
-error[E0412]: cannot find type `method` in this scope
+error[E0425]: cannot find type `method` in this scope
   --> $DIR/resolve-assoc-suggestions.rs:30:16
    |
 LL |         let _: method;
@@ -69,5 +69,5 @@ LL |         self.method;
 
 error: aborting due to 9 previous errors
 
-Some errors have detailed explanations: E0412, E0425, E0531.
-For more information about an error, try `rustc --explain E0412`.
+Some errors have detailed explanations: E0425, E0531.
+For more information about an error, try `rustc --explain E0425`.

--- a/tests/ui/resolve/resolve-primitive-fallback.stderr
+++ b/tests/ui/resolve/resolve-primitive-fallback.stderr
@@ -4,7 +4,7 @@ error[E0423]: expected value, found builtin type `u16`
 LL |     std::mem::size_of(u16);
    |                       ^^^ not a value
 
-error[E0412]: cannot find type `u8` in the crate root
+error[E0425]: cannot find type `u8` in the crate root
   --> $DIR/resolve-primitive-fallback.rs:8:14
    |
 LL |     let _: ::u8;
@@ -36,5 +36,5 @@ LL +     std::mem::size_of();
 
 error: aborting due to 3 previous errors
 
-Some errors have detailed explanations: E0061, E0412, E0423.
+Some errors have detailed explanations: E0061, E0423, E0425.
 For more information about an error, try `rustc --explain E0061`.

--- a/tests/ui/resolve/typo-suggestion-for-variable-with-name-similar-to-struct-field.stderr
+++ b/tests/ui/resolve/typo-suggestion-for-variable-with-name-similar-to-struct-field.stderr
@@ -61,7 +61,7 @@ help: a constant with a similar name exists
 LL |         BARR;
    |            +
 
-error[E0412]: cannot find type `Baz` in this scope
+error[E0425]: cannot find type `Baz` in this scope
   --> $DIR/typo-suggestion-for-variable-with-name-similar-to-struct-field.rs:37:18
    |
 LL |         let foo: Baz = "".to_string();
@@ -101,5 +101,4 @@ LL +         ba();
 
 error: aborting due to 7 previous errors
 
-Some errors have detailed explanations: E0412, E0425.
-For more information about an error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/resolve/use_suggestion.stderr
+++ b/tests/ui/resolve/use_suggestion.stderr
@@ -9,7 +9,7 @@ help: consider importing this struct
 LL + use std::collections::HashMap;
    |
 
-error[E0412]: cannot find type `HashMap` in this scope
+error[E0425]: cannot find type `HashMap` in this scope
   --> $DIR/use_suggestion.rs:5:13
    |
 LL |     let y1: HashMap;
@@ -20,7 +20,7 @@ help: consider importing this struct
 LL + use std::collections::HashMap;
    |
 
-error[E0412]: cannot find type `GooMap` in this scope
+error[E0425]: cannot find type `GooMap` in this scope
   --> $DIR/use_suggestion.rs:6:13
    |
 LL |     let y2: GooMap;
@@ -34,5 +34,5 @@ LL |     let x2 = GooMap::new();
 
 error: aborting due to 4 previous errors
 
-Some errors have detailed explanations: E0412, E0433.
-For more information about an error, try `rustc --explain E0412`.
+Some errors have detailed explanations: E0425, E0433.
+For more information about an error, try `rustc --explain E0425`.

--- a/tests/ui/resolve/use_suggestion_placement.stderr
+++ b/tests/ui/resolve/use_suggestion_placement.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `Path` in this scope
+error[E0425]: cannot find type `Path` in this scope
   --> $DIR/use_suggestion_placement.rs:18:16
    |
 LL |     type Bar = Path;
@@ -20,7 +20,7 @@ help: consider importing this constant
 LL + use m::A;
    |
 
-error[E0412]: cannot find type `HashMap` in this scope
+error[E0425]: cannot find type `HashMap` in this scope
   --> $DIR/use_suggestion_placement.rs:28:23
    |
 LL |     type Dict<K, V> = HashMap<K, V>;
@@ -33,5 +33,4 @@ LL + use std::collections::HashMap;
 
 error: aborting due to 3 previous errors
 
-Some errors have detailed explanations: E0412, E0425.
-For more information about an error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/self/elision/nested-item.stderr
+++ b/tests/ui/self/elision/nested-item.stderr
@@ -35,7 +35,7 @@ LL - fn wrap(self: Wrap<{ fn bar(&self) {} }>) -> &() {
 LL + fn wrap(self: Wrap<{ fn bar(&self) {} }>) -> () {
    |
 
-error[E0412]: cannot find type `Wrap` in this scope
+error[E0425]: cannot find type `Wrap` in this scope
   --> $DIR/nested-item.rs:5:15
    |
 LL | fn wrap(self: Wrap<{ fn bar(&self) {} }>) -> &() {
@@ -43,5 +43,5 @@ LL | fn wrap(self: Wrap<{ fn bar(&self) {} }>) -> &() {
 
 error: aborting due to 4 previous errors
 
-Some errors have detailed explanations: E0106, E0412.
+Some errors have detailed explanations: E0106, E0425.
 For more information about an error, try `rustc --explain E0106`.

--- a/tests/ui/sized/ensure-overriding-bindings-in-pattern-with-ty-err-doesnt-ice.stderr
+++ b/tests/ui/sized/ensure-overriding-bindings-in-pattern-with-ty-err-doesnt-ice.stderr
@@ -6,7 +6,7 @@ LL |     let str::<{fn str() { let str::T>>::as_bytes; }}, T>::as_bytes;
    |
    = note: arbitrary expressions are not allowed in patterns: <https://doc.rust-lang.org/book/ch19-00-patterns.html>
 
-error[E0412]: cannot find type `T` in this scope
+error[E0425]: cannot find type `T` in this scope
   --> $DIR/ensure-overriding-bindings-in-pattern-with-ty-err-doesnt-ice.rs:2:55
    |
 LL |     let str::<{fn str() { let str::T>>::as_bytes; }}, T>::as_bytes;
@@ -47,5 +47,5 @@ LL |     let str::<{fn str() { let str::T>>::as_bytes: /* Type */; }}, T>::as_by
 
 error: aborting due to 5 previous errors
 
-Some errors have detailed explanations: E0109, E0282, E0412, E0533.
+Some errors have detailed explanations: E0109, E0282, E0425, E0533.
 For more information about an error, try `rustc --explain E0109`.

--- a/tests/ui/span/drop-location-span-error-rust-2021-incompatible-closure-captures-96258.stderr
+++ b/tests/ui/span/drop-location-span-error-rust-2021-incompatible-closure-captures-96258.stderr
@@ -7,7 +7,7 @@ LL |     pub(crate) async fn new(
    = help: pass `--edition 2024` to `rustc`
    = note: for more on editions, read https://doc.rust-lang.org/edition-guide
 
-error[E0412]: cannot find type `Duration` in this scope
+error[E0425]: cannot find type `Duration` in this scope
   --> $DIR/drop-location-span-error-rust-2021-incompatible-closure-captures-96258.rs:12:19
    |
 LL |         interval: Duration,
@@ -20,5 +20,5 @@ LL + use std::time::Duration;
 
 error: aborting due to 2 previous errors
 
-Some errors have detailed explanations: E0412, E0670.
-For more information about an error, try `rustc --explain E0412`.
+Some errors have detailed explanations: E0425, E0670.
+For more information about an error, try `rustc --explain E0425`.

--- a/tests/ui/specialization/issue-68830-spurious-diagnostics.stderr
+++ b/tests/ui/specialization/issue-68830-spurious-diagnostics.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `MissingType` in this scope
+error[E0425]: cannot find type `MissingType` in this scope
   --> $DIR/issue-68830-spurious-diagnostics.rs:8:10
    |
 LL |     err: MissingType
@@ -6,4 +6,4 @@ LL |     err: MissingType
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/specialization/min_specialization/impl-on-nonexisting.stderr
+++ b/tests/ui/specialization/min_specialization/impl-on-nonexisting.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `NonExistent` in this scope
+error[E0425]: cannot find type `NonExistent` in this scope
   --> $DIR/impl-on-nonexisting.rs:4:16
    |
 LL | impl Trait for NonExistent {}
@@ -6,4 +6,4 @@ LL | impl Trait for NonExistent {}
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/structs/ice-struct-tail-normalization-113272.stderr
+++ b/tests/ui/structs/ice-struct-tail-normalization-113272.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `Missing` in this scope
+error[E0425]: cannot find type `Missing` in this scope
   --> $DIR/ice-struct-tail-normalization-113272.rs:5:25
    |
 LL | impl Trait for () where Missing: Trait {}
@@ -24,5 +24,5 @@ LL |         std::mem::transmute::<Option<()>, Option<&Other>>(None);
 
 error: aborting due to 3 previous errors
 
-Some errors have detailed explanations: E0046, E0412, E0512.
+Some errors have detailed explanations: E0046, E0425, E0512.
 For more information about an error, try `rustc --explain E0046`.

--- a/tests/ui/suggestions/assoc-type-in-method-return.stderr
+++ b/tests/ui/suggestions/assoc-type-in-method-return.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `Bla` in this scope
+error[E0425]: cannot find type `Bla` in this scope
   --> $DIR/assoc-type-in-method-return.rs:3:25
    |
 LL |     fn to_bla(&self) -> Bla;
@@ -11,4 +11,4 @@ LL |     fn to_bla(&self) -> Self::Bla;
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/suggestions/dont-suggest-foreign-doc-hidden.rs
+++ b/tests/ui/suggestions/dont-suggest-foreign-doc-hidden.rs
@@ -8,16 +8,16 @@ mod local {
 }
 
 pub fn test(_: Foo) {}
-//~^ ERROR [E0412]
+//~^ ERROR [E0425]
 
 pub fn test2(_: Bar) {}
-//~^ ERROR [E0412]
+//~^ ERROR [E0425]
 
 pub fn test3(_: Baz) {}
-//~^ ERROR [E0412]
+//~^ ERROR [E0425]
 
 pub fn test4(_: Quux) {}
-//~^ ERROR [E0412]
+//~^ ERROR [E0425]
 
 fn test5<T: hidden_struct::Marker>() {}
 

--- a/tests/ui/suggestions/dont-suggest-foreign-doc-hidden.stderr
+++ b/tests/ui/suggestions/dont-suggest-foreign-doc-hidden.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `Foo` in this scope
+error[E0425]: cannot find type `Foo` in this scope
   --> $DIR/dont-suggest-foreign-doc-hidden.rs:10:16
    |
 LL | pub fn test(_: Foo) {}
@@ -9,13 +9,13 @@ help: consider importing this struct
 LL + use local::Foo;
    |
 
-error[E0412]: cannot find type `Bar` in this scope
+error[E0425]: cannot find type `Bar` in this scope
   --> $DIR/dont-suggest-foreign-doc-hidden.rs:13:17
    |
 LL | pub fn test2(_: Bar) {}
    |                 ^^^ not found in this scope
 
-error[E0412]: cannot find type `Baz` in this scope
+error[E0425]: cannot find type `Baz` in this scope
   --> $DIR/dont-suggest-foreign-doc-hidden.rs:16:17
    |
 LL | pub fn test3(_: Baz) {}
@@ -26,7 +26,7 @@ help: consider importing this struct
 LL + use hidden_struct::Baz;
    |
 
-error[E0412]: cannot find type `Quux` in this scope
+error[E0425]: cannot find type `Quux` in this scope
   --> $DIR/dont-suggest-foreign-doc-hidden.rs:19:17
    |
 LL | pub fn test4(_: Quux) {}
@@ -61,5 +61,5 @@ LL | fn test5<T: hidden_struct::Marker>() {}
 
 error: aborting due to 5 previous errors
 
-Some errors have detailed explanations: E0277, E0412.
+Some errors have detailed explanations: E0277, E0425.
 For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/suggestions/no-extern-crate-in-type.stderr
+++ b/tests/ui/suggestions/no-extern-crate-in-type.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `Foo` in this scope
+error[E0425]: cannot find type `Foo` in this scope
   --> $DIR/no-extern-crate-in-type.rs:5:22
    |
 LL | type Output = Option<Foo>;
@@ -11,4 +11,4 @@ LL + use foo::Foo;
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/suggestions/type-not-found-in-adt-field.stderr
+++ b/tests/ui/suggestions/type-not-found-in-adt-field.stderr
@@ -1,10 +1,10 @@
-error[E0412]: cannot find type `Someunknownname` in this scope
+error[E0425]: cannot find type `Someunknownname` in this scope
   --> $DIR/type-not-found-in-adt-field.rs:2:12
    |
 LL |     m: Vec<Someunknownname<String, ()>>,
    |            ^^^^^^^^^^^^^^^ not found in this scope
 
-error[E0412]: cannot find type `K` in this scope
+error[E0425]: cannot find type `K` in this scope
   --> $DIR/type-not-found-in-adt-field.rs:6:8
    |
 LL |     m: K,
@@ -17,4 +17,4 @@ LL | struct OtherStruct<K> {
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/trait-bounds/ice-unsized-struct-arg-issue-121612.stderr
+++ b/tests/ui/trait-bounds/ice-unsized-struct-arg-issue-121612.stderr
@@ -1,10 +1,10 @@
-error[E0412]: cannot find type `Idx` in this scope
+error[E0425]: cannot find type `Idx` in this scope
   --> $DIR/ice-unsized-struct-arg-issue-121612.rs:5:30
    |
 LL | struct MySlice<T: FnOnce(&T, Idx) -> Idx>(bool, T);
    |                              ^^^ not found in this scope
 
-error[E0412]: cannot find type `Idx` in this scope
+error[E0425]: cannot find type `Idx` in this scope
   --> $DIR/ice-unsized-struct-arg-issue-121612.rs:5:38
    |
 LL | struct MySlice<T: FnOnce(&T, Idx) -> Idx>(bool, T);
@@ -53,5 +53,5 @@ LL | struct MySlice<T: FnOnce(&T, Idx) -> Idx>(bool, T);
 
 error: aborting due to 4 previous errors
 
-Some errors have detailed explanations: E0277, E0412.
+Some errors have detailed explanations: E0277, E0425.
 For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/trait-bounds/impl-bound-with-references-error.rs
+++ b/tests/ui/trait-bounds/impl-bound-with-references-error.rs
@@ -10,7 +10,7 @@ impl<T> From<T> for LabelText
 //~^ ERROR conflicting implementations of trait `From<LabelText>` for type `LabelText` [E0119]
 where
     T: Into<Cow<'static, str>>,
-    //~^ ERROR cannot find type `Cow` in this scope [E0412]
+    //~^ ERROR cannot find type `Cow` in this scope [E0425]
 {
     fn from(text: T) -> Self {
         LabelText::Plain(text.into()) //~ ERROR expected function, found `LabelText`

--- a/tests/ui/trait-bounds/impl-bound-with-references-error.stderr
+++ b/tests/ui/trait-bounds/impl-bound-with-references-error.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `Cow` in this scope
+error[E0425]: cannot find type `Cow` in this scope
   --> $DIR/impl-bound-with-references-error.rs:12:13
    |
 LL |     T: Into<Cow<'static, str>>,
@@ -34,5 +34,5 @@ LL |         LabelText::Plain(text.into())
 
 error: aborting due to 3 previous errors
 
-Some errors have detailed explanations: E0119, E0412, E0618.
+Some errors have detailed explanations: E0119, E0425, E0618.
 For more information about an error, try `rustc --explain E0119`.

--- a/tests/ui/traits/duplicate-generic-parameter-error-86756.stderr
+++ b/tests/ui/traits/duplicate-generic-parameter-error-86756.stderr
@@ -6,7 +6,7 @@ LL | trait Foo<T, T = T> {}
    |           |
    |           first use of `T`
 
-error[E0412]: cannot find type `dyn` in this scope
+error[E0425]: cannot find type `dyn` in this scope
   --> $DIR/duplicate-generic-parameter-error-86756.rs:7:10
    |
 LL |     eq::<dyn, Foo>
@@ -44,5 +44,5 @@ LL |     eq::<dyn, Foo<T>>
 
 error: aborting due to 3 previous errors; 1 warning emitted
 
-Some errors have detailed explanations: E0107, E0403, E0412.
+Some errors have detailed explanations: E0107, E0403, E0425.
 For more information about an error, try `rustc --explain E0107`.

--- a/tests/ui/traits/error-reporting/apit-with-bad-path.stderr
+++ b/tests/ui/traits/error-reporting/apit-with-bad-path.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `Path` in this scope
+error[E0425]: cannot find type `Path` in this scope
   --> $DIR/apit-with-bad-path.rs:3:29
    |
 LL | fn foo(filename: impl AsRef<Path>) {
@@ -11,4 +11,4 @@ LL + use std::path::Path;
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/traits/error-reporting/where-clause-with-bad-path.stderr
+++ b/tests/ui/traits/error-reporting/where-clause-with-bad-path.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `Path` in this scope
+error[E0425]: cannot find type `Path` in this scope
   --> $DIR/where-clause-with-bad-path.rs:3:17
    |
 LL | fn foo<T: AsRef<Path>>(filename: T) {
@@ -11,4 +11,4 @@ LL + use std::path::Path;
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/traits/ignore-err-impls.stderr
+++ b/tests/ui/traits/ignore-err-impls.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `Type` in this scope
+error[E0425]: cannot find type `Type` in this scope
   --> $DIR/ignore-err-impls.rs:6:14
    |
 LL | impl Generic<Type> for S {}
@@ -11,4 +11,4 @@ LL | impl<Type> Generic<Type> for S {}
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/traits/issue-50480.stderr
+++ b/tests/ui/traits/issue-50480.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `N` in this scope
+error[E0425]: cannot find type `N` in this scope
   --> $DIR/issue-50480.rs:3:12
    |
 LL | struct Foo(N, NotDefined, <i32 as Iterator>::Item, Vec<i32>, String);
@@ -9,13 +9,13 @@ help: you might be missing a type parameter
 LL | struct Foo<N>(N, NotDefined, <i32 as Iterator>::Item, Vec<i32>, String);
    |           +++
 
-error[E0412]: cannot find type `NotDefined` in this scope
+error[E0425]: cannot find type `NotDefined` in this scope
   --> $DIR/issue-50480.rs:3:15
    |
 LL | struct Foo(N, NotDefined, <i32 as Iterator>::Item, Vec<i32>, String);
    |               ^^^^^^^^^^ not found in this scope
 
-error[E0412]: cannot find type `N` in this scope
+error[E0425]: cannot find type `N` in this scope
   --> $DIR/issue-50480.rs:3:12
    |
 LL | struct Foo(N, NotDefined, <i32 as Iterator>::Item, Vec<i32>, String);
@@ -26,7 +26,7 @@ help: you might be missing a type parameter
 LL | struct Foo<N>(N, NotDefined, <i32 as Iterator>::Item, Vec<i32>, String);
    |           +++
 
-error[E0412]: cannot find type `NotDefined` in this scope
+error[E0425]: cannot find type `NotDefined` in this scope
   --> $DIR/issue-50480.rs:3:15
    |
 LL | struct Foo(N, NotDefined, <i32 as Iterator>::Item, Vec<i32>, String);
@@ -37,7 +37,7 @@ help: you might be missing a type parameter
 LL | struct Foo<NotDefined>(N, NotDefined, <i32 as Iterator>::Item, Vec<i32>, String);
    |           ++++++++++++
 
-error[E0412]: cannot find type `N` in this scope
+error[E0425]: cannot find type `N` in this scope
   --> $DIR/issue-50480.rs:14:18
    |
 LL | struct Bar<T>(T, N, NotDefined, <i32 as Iterator>::Item, Vec<i32>, String);
@@ -55,7 +55,7 @@ help: you might be missing a type parameter
 LL | struct Bar<T, N>(T, N, NotDefined, <i32 as Iterator>::Item, Vec<i32>, String);
    |             +++
 
-error[E0412]: cannot find type `NotDefined` in this scope
+error[E0425]: cannot find type `NotDefined` in this scope
   --> $DIR/issue-50480.rs:14:21
    |
 LL | struct Bar<T>(T, N, NotDefined, <i32 as Iterator>::Item, Vec<i32>, String);
@@ -128,5 +128,5 @@ LL | struct Bar<T>(T, N, NotDefined, <i32 as Iterator>::Item, Vec<i32>, String);
 
 error: aborting due to 13 previous errors
 
-Some errors have detailed explanations: E0204, E0277, E0412.
+Some errors have detailed explanations: E0204, E0277, E0425.
 For more information about an error, try `rustc --explain E0204`.

--- a/tests/ui/traits/issue-75627.stderr
+++ b/tests/ui/traits/issue-75627.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `T` in this scope
+error[E0425]: cannot find type `T` in this scope
   --> $DIR/issue-75627.rs:3:26
    |
 LL | unsafe impl Send for Foo<T> {}
@@ -11,4 +11,4 @@ LL | unsafe impl<T> Send for Foo<T> {}
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/traits/issue-78372.stderr
+++ b/tests/ui/traits/issue-78372.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `PhantomData` in this scope
+error[E0425]: cannot find type `PhantomData` in this scope
   --> $DIR/issue-78372.rs:2:23
    |
 LL | struct Smaht<T, MISC>(PhantomData);
@@ -9,7 +9,7 @@ help: consider importing this struct
 LL + use std::marker::PhantomData;
    |
 
-error[E0412]: cannot find type `U` in this scope
+error[E0425]: cannot find type `U` in this scope
   --> $DIR/issue-78372.rs:3:31
    |
 LL | impl<T> DispatchFromDyn<Smaht<U, MISC>> for T {}
@@ -27,7 +27,7 @@ help: you might be missing a type parameter
 LL | impl<T, U> DispatchFromDyn<Smaht<U, MISC>> for T {}
    |       +++
 
-error[E0412]: cannot find type `MISC` in this scope
+error[E0425]: cannot find type `MISC` in this scope
   --> $DIR/issue-78372.rs:3:34
    |
 LL | impl<T> DispatchFromDyn<Smaht<U, MISC>> for T {}
@@ -73,5 +73,5 @@ LL |     fn foo(self: Smaht<Self, T>);
 
 error: aborting due to 7 previous errors
 
-Some errors have detailed explanations: E0307, E0377, E0412, E0658.
+Some errors have detailed explanations: E0307, E0377, E0425, E0658.
 For more information about an error, try `rustc --explain E0307`.

--- a/tests/ui/traits/next-solver/dont-normalize-proj-with-error.stderr
+++ b/tests/ui/traits/next-solver/dont-normalize-proj-with-error.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `TypeError` in this scope
+error[E0425]: cannot find type `TypeError` in this scope
   --> $DIR/dont-normalize-proj-with-error.rs:17:20
    |
 LL | fn type_error() -> TypeError { todo!() }
@@ -6,4 +6,4 @@ LL | fn type_error() -> TypeError { todo!() }
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/traits/next-solver/issue-118950-root-region.stderr
+++ b/tests/ui/traits/next-solver/issue-118950-root-region.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `Missing` in this scope
+error[E0425]: cannot find type `Missing` in this scope
   --> $DIR/issue-118950-root-region.rs:19:55
    |
 LL | impl<T> Overlap<for<'a> fn(Assoc<'a, T>)> for T where Missing: Overlap<T> {}
@@ -28,5 +28,5 @@ LL | trait ToUnit<'a> {
  WARN rustc_infer::infer::relate::generalize may incompletely handle alias type: AliasTy { args: ['^0.Named(DefId(0:15 ~ issue_118950_root_region[d54f]::{impl#1}::'a)), ?1t], def_id: DefId(0:8 ~ issue_118950_root_region[d54f]::Assoc), .. }
 error: aborting due to 2 previous errors; 1 warning emitted
 
-Some errors have detailed explanations: E0277, E0412.
+Some errors have detailed explanations: E0277, E0425.
 For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/traits/non_lifetime_binders/binder-defaults-112547.stderr
+++ b/tests/ui/traits/non_lifetime_binders/binder-defaults-112547.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `V` in this scope
+error[E0425]: cannot find type `V` in this scope
   --> $DIR/binder-defaults-112547.rs:10:4
    |
 LL | }> V: IntoIterator
@@ -37,4 +37,4 @@ LL | | }> V: IntoIterator
 
 error: aborting due to 3 previous errors; 1 warning emitted
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/traits/non_lifetime_binders/binder-defaults-118697.stderr
+++ b/tests/ui/traits/non_lifetime_binders/binder-defaults-118697.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `A` in this scope
+error[E0425]: cannot find type `A` in this scope
   --> $DIR/binder-defaults-118697.rs:4:22
    |
 LL | type T = dyn for<V = A(&())> Fn(());
@@ -18,4 +18,4 @@ LL | type T = dyn for<V = A(&())> Fn(());
 
 error: aborting due to 3 previous errors
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/traits/trait-selection-ice-84727.stderr
+++ b/tests/ui/traits/trait-selection-ice-84727.stderr
@@ -1,22 +1,22 @@
-error[E0412]: cannot find type `Color` in this scope
+error[E0425]: cannot find type `Color` in this scope
   --> $DIR/trait-selection-ice-84727.rs:5:17
    |
 LL |     foreground: Color<Fg>,
    |                 ^^^^^ not found in this scope
 
-error[E0412]: cannot find type `Color` in this scope
+error[E0425]: cannot find type `Color` in this scope
   --> $DIR/trait-selection-ice-84727.rs:7:17
    |
 LL |     background: Color<Bg>,
    |                 ^^^^^ not found in this scope
 
-error[E0412]: cannot find type `Color` in this scope
+error[E0425]: cannot find type `Color` in this scope
   --> $DIR/trait-selection-ice-84727.rs:18:16
    |
 LL |     Self: Over<Color<BottomBg>, Cell<NewFg>>,
    |                ^^^^^ not found in this scope
 
-error[E0412]: cannot find type `NewBg` in this scope
+error[E0425]: cannot find type `NewBg` in this scope
   --> $DIR/trait-selection-ice-84727.rs:32:27
    |
 LL |     fn over(self) -> Cell<NewBg> {
@@ -43,5 +43,5 @@ LL |         self.over();
 
 error: aborting due to 5 previous errors
 
-Some errors have detailed explanations: E0308, E0412.
+Some errors have detailed explanations: E0308, E0425.
 For more information about an error, try `rustc --explain E0308`.

--- a/tests/ui/transmutability/issue-101739-1.stderr
+++ b/tests/ui/transmutability/issue-101739-1.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `Dst` in this scope
+error[E0425]: cannot find type `Dst` in this scope
   --> $DIR/issue-101739-1.rs:8:9
    |
 LL |         Dst: TransmuteFrom<Src, ASSUME_ALIGNMENT>,
@@ -6,4 +6,4 @@ LL |         Dst: TransmuteFrom<Src, ASSUME_ALIGNMENT>,
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/transmutability/malformed-program-gracefulness/unknown_dst.stderr
+++ b/tests/ui/transmutability/malformed-program-gracefulness/unknown_dst.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `Dst` in this scope
+error[E0425]: cannot find type `Dst` in this scope
   --> $DIR/unknown_dst.rs:18:36
    |
 LL |     assert::is_transmutable::<Src, Dst>();
@@ -11,4 +11,4 @@ LL | fn should_gracefully_handle_unknown_dst<Dst>() {
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/transmutability/malformed-program-gracefulness/unknown_dst_field.stderr
+++ b/tests/ui/transmutability/malformed-program-gracefulness/unknown_dst_field.stderr
@@ -1,10 +1,10 @@
-error[E0412]: cannot find type `Missing` in this scope
+error[E0425]: cannot find type `Missing` in this scope
   --> $DIR/unknown_dst_field.rs:18:27
    |
 LL |     #[repr(C)] struct Dst(Missing);
    |                           ^^^^^^^ not found in this scope
 
-error[E0412]: cannot find type `Missing` in this scope
+error[E0425]: cannot find type `Missing` in this scope
   --> $DIR/unknown_dst_field.rs:24:36
    |
 LL |     #[repr(C)] struct Dst(&'static Missing);
@@ -42,5 +42,5 @@ LL |         Dst: TransmuteFrom<Src>
 
 error: aborting due to 4 previous errors
 
-Some errors have detailed explanations: E0277, E0412.
+Some errors have detailed explanations: E0277, E0425.
 For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/transmutability/malformed-program-gracefulness/unknown_src.stderr
+++ b/tests/ui/transmutability/malformed-program-gracefulness/unknown_src.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `Src` in this scope
+error[E0425]: cannot find type `Src` in this scope
   --> $DIR/unknown_src.rs:18:31
    |
 LL |     assert::is_transmutable::<Src, Dst>();
@@ -11,4 +11,4 @@ LL | fn should_gracefully_handle_unknown_src<Src>() {
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/transmutability/malformed-program-gracefulness/unknown_src_field.stderr
+++ b/tests/ui/transmutability/malformed-program-gracefulness/unknown_src_field.stderr
@@ -1,10 +1,10 @@
-error[E0412]: cannot find type `Missing` in this scope
+error[E0425]: cannot find type `Missing` in this scope
   --> $DIR/unknown_src_field.rs:17:27
    |
 LL |     #[repr(C)] struct Src(Missing);
    |                           ^^^^^^^ not found in this scope
 
-error[E0412]: cannot find type `Missing` in this scope
+error[E0425]: cannot find type `Missing` in this scope
   --> $DIR/unknown_src_field.rs:23:36
    |
 LL |     #[repr(C)] struct Src(&'static Missing);
@@ -42,5 +42,5 @@ LL |         Dst: TransmuteFrom<Src>
 
 error: aborting due to 4 previous errors
 
-Some errors have detailed explanations: E0277, E0412.
+Some errors have detailed explanations: E0277, E0425.
 For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/tuple/tuple-struct-fields/test.stderr
+++ b/tests/ui/tuple/tuple-struct-fields/test.stderr
@@ -6,7 +6,7 @@ LL |     struct S2(pub((foo)) ());
    |                         |
    |                         help: missing `,`
 
-error[E0412]: cannot find type `foo` in this scope
+error[E0425]: cannot find type `foo` in this scope
   --> $DIR/test.rs:4:20
    |
 LL |     struct S2(pub((foo)) ());
@@ -14,4 +14,4 @@ LL |     struct S2(pub((foo)) ());
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/tuple/tuple-struct-fields/test2.stderr
+++ b/tests/ui/tuple/tuple-struct-fields/test2.stderr
@@ -11,13 +11,13 @@ LL |     define_struct! { (foo) }
    |
    = note: this error originates in the macro `define_struct` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0412]: cannot find type `foo` in this scope
+error[E0425]: cannot find type `foo` in this scope
   --> $DIR/test2.rs:11:23
    |
 LL |     define_struct! { (foo) }
    |                       ^^^ not found in this scope
 
-error[E0412]: cannot find type `foo` in this scope
+error[E0425]: cannot find type `foo` in this scope
   --> $DIR/test2.rs:11:23
    |
 LL |     define_struct! { (foo) }
@@ -27,4 +27,4 @@ LL |     define_struct! { (foo) }
 
 error: aborting due to 3 previous errors
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/tuple/tuple-struct-fields/test3.stderr
+++ b/tests/ui/tuple/tuple-struct-fields/test3.stderr
@@ -11,13 +11,13 @@ LL |     define_struct! { foo }
    |
    = note: this error originates in the macro `define_struct` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0412]: cannot find type `foo` in this scope
+error[E0425]: cannot find type `foo` in this scope
   --> $DIR/test3.rs:11:22
    |
 LL |     define_struct! { foo }
    |                      ^^^ not found in this scope
 
-error[E0412]: cannot find type `foo` in this scope
+error[E0425]: cannot find type `foo` in this scope
   --> $DIR/test3.rs:11:22
    |
 LL |     define_struct! { foo }
@@ -27,4 +27,4 @@ LL |     define_struct! { foo }
 
 error: aborting due to 3 previous errors
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/type-alias-impl-trait/define_opaques_attr/invalid_path.stderr
+++ b/tests/ui/type-alias-impl-trait/define_opaques_attr/invalid_path.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type alias or associated type with opaqaue types `Boom` in this scope
+error[E0425]: cannot find type alias or associated type with opaqaue types `Boom` in this scope
   --> $DIR/invalid_path.rs:3:17
    |
 LL | #[define_opaque(Boom)]
@@ -6,4 +6,4 @@ LL | #[define_opaque(Boom)]
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/type-alias-impl-trait/nested-impl-trait-in-tait.stderr
+++ b/tests/ui/type-alias-impl-trait/nested-impl-trait-in-tait.stderr
@@ -14,7 +14,7 @@ help: consider introducing lifetime `'db` here
 LL | pub type Tait<'db> = impl Iterator<Item = (&'db LocalKey, impl Iterator)>;
    |              +++++
 
-error[E0412]: cannot find type `LocalKey` in this scope
+error[E0425]: cannot find type `LocalKey` in this scope
   --> $DIR/nested-impl-trait-in-tait.rs:3:44
    |
 LL | pub type Tait = impl Iterator<Item = (&'db LocalKey, impl Iterator)>;
@@ -43,5 +43,5 @@ LL | pub type Tait = impl Iterator<Item = (&'db LocalKey, impl Iterator)>;
 
 error: aborting due to 4 previous errors
 
-Some errors have detailed explanations: E0261, E0412.
+Some errors have detailed explanations: E0261, E0425.
 For more information about an error, try `rustc --explain E0261`.

--- a/tests/ui/type/issue-7607-1.stderr
+++ b/tests/ui/type/issue-7607-1.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `Fo` in this scope
+error[E0425]: cannot find type `Fo` in this scope
   --> $DIR/issue-7607-1.rs:5:6
    |
 LL | impl Fo {
@@ -10,4 +10,4 @@ LL | impl Fo {
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/type/type-path-err-node-types.stderr
+++ b/tests/ui/type/type-path-err-node-types.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `Nonexistent` in this scope
+error[E0425]: cannot find type `Nonexistent` in this scope
   --> $DIR/type-path-err-node-types.rs:7:12
    |
 LL |     let _: Nonexistent<u8, Assoc = u16>;
@@ -35,5 +35,5 @@ LL |     let _ = |a: /* Type */, b: _| -> _ { 0 };
 
 error: aborting due to 5 previous errors
 
-Some errors have detailed explanations: E0282, E0412, E0425, E0433, E0576.
+Some errors have detailed explanations: E0282, E0425, E0425, E0433, E0576.
 For more information about an error, try `rustc --explain E0282`.

--- a/tests/ui/typeck/apit-with-error-type-in-sig.stderr
+++ b/tests/ui/typeck/apit-with-error-type-in-sig.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `Bar` in this scope
+error[E0425]: cannot find type `Bar` in this scope
   --> $DIR/apit-with-error-type-in-sig.rs:1:12
    |
 LL | type Foo = Bar;
@@ -6,4 +6,4 @@ LL | type Foo = Bar;
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/typeck/autoderef-with-param-env-error.stderr
+++ b/tests/ui/typeck/autoderef-with-param-env-error.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `T` in this scope
+error[E0425]: cannot find type `T` in this scope
   --> $DIR/autoderef-with-param-env-error.rs:3:5
    |
 LL |     T: Send,
@@ -11,4 +11,4 @@ LL | fn foo<T>()
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/typeck/impl-for-nonexistent-type-error-8767.stderr
+++ b/tests/ui/typeck/impl-for-nonexistent-type-error-8767.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `B` in this scope
+error[E0425]: cannot find type `B` in this scope
   --> $DIR/impl-for-nonexistent-type-error-8767.rs:2:6
    |
 LL | impl B {
@@ -6,4 +6,4 @@ LL | impl B {
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/typeck/issue-104510-ice.stderr
+++ b/tests/ui/typeck/issue-104510-ice.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `Oops` in this scope
+error[E0425]: cannot find type `Oops` in this scope
   --> $DIR/issue-104510-ice.rs:4:21
    |
 LL | struct W<T: ?Sized>(Oops);
@@ -6,4 +6,4 @@ LL | struct W<T: ?Sized>(Oops);
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/typeck/issue-83693.rs
+++ b/tests/ui/typeck/issue-83693.rs
@@ -4,16 +4,16 @@
 #![crate_type="lib"]
 
 impl F {
-//~^ ERROR: cannot find type `F` in this scope [E0412]
+//~^ ERROR: cannot find type `F` in this scope [E0425]
     fn call() {
         <Self as Fn(&TestResult)>::call
-        //~^ ERROR: cannot find type `TestResult` in this scope [E0412]
+        //~^ ERROR: cannot find type `TestResult` in this scope [E0425]
         //~| ERROR associated item constraints are not allowed here [E0229]
     }
 }
 
 fn call() {
     <x as Fn(&usize)>::call
-    //~^ ERROR: cannot find type `x` in this scope [E0412]
+    //~^ ERROR: cannot find type `x` in this scope [E0425]
     //~| ERROR: associated item constraints are not allowed here [E0229]
 }

--- a/tests/ui/typeck/issue-83693.stderr
+++ b/tests/ui/typeck/issue-83693.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `F` in this scope
+error[E0425]: cannot find type `F` in this scope
   --> $DIR/issue-83693.rs:6:6
    |
 LL | impl F {
@@ -8,13 +8,13 @@ LL | impl F {
    |
    = note: similarly named trait `Fn` defined here
 
-error[E0412]: cannot find type `TestResult` in this scope
+error[E0425]: cannot find type `TestResult` in this scope
   --> $DIR/issue-83693.rs:9:22
    |
 LL |         <Self as Fn(&TestResult)>::call
    |                      ^^^^^^^^^^ not found in this scope
 
-error[E0412]: cannot find type `x` in this scope
+error[E0425]: cannot find type `x` in this scope
   --> $DIR/issue-83693.rs:16:6
    |
 LL |     <x as Fn(&usize)>::call
@@ -34,5 +34,5 @@ LL |     <x as Fn(&usize)>::call
 
 error: aborting due to 5 previous errors
 
-Some errors have detailed explanations: E0229, E0412.
+Some errors have detailed explanations: E0229, E0425.
 For more information about an error, try `rustc --explain E0229`.

--- a/tests/ui/typeck/issue-88844.rs
+++ b/tests/ui/typeck/issue-88844.rs
@@ -4,7 +4,7 @@ struct Struct { value: i32 }
 //~^ NOTE: similarly named struct `Struct` defined here
 
 impl Stuct {
-//~^ ERROR: cannot find type `Stuct` in this scope [E0412]
+//~^ ERROR: cannot find type `Stuct` in this scope [E0425]
 //~| HELP: a struct with a similar name exists
     fn new() -> Self {
         Self { value: 42 }

--- a/tests/ui/typeck/issue-88844.stderr
+++ b/tests/ui/typeck/issue-88844.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `Stuct` in this scope
+error[E0425]: cannot find type `Stuct` in this scope
   --> $DIR/issue-88844.rs:6:6
    |
 LL | struct Struct { value: i32 }
@@ -9,4 +9,4 @@ LL | impl Stuct {
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/typeck/issue-90319.rs
+++ b/tests/ui/typeck/issue-90319.rs
@@ -11,7 +11,7 @@ fn get<T>() -> T {
 }
 
 fn main() {
-    let thing = get::<Thing>();//~ERROR cannot find type `Thing` in this scope [E0412]
+    let thing = get::<Thing>();//~ERROR cannot find type `Thing` in this scope [E0425]
     let wrapper = Wrapper(thing);
     Trait::method(&wrapper);
 }

--- a/tests/ui/typeck/issue-90319.stderr
+++ b/tests/ui/typeck/issue-90319.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `Thing` in this scope
+error[E0425]: cannot find type `Thing` in this scope
   --> $DIR/issue-90319.rs:14:23
    |
 LL |     let thing = get::<Thing>();
@@ -6,4 +6,4 @@ LL |     let thing = get::<Thing>();
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/typeck/issue-91267.rs
+++ b/tests/ui/typeck/issue-91267.rs
@@ -2,7 +2,7 @@
 
 fn main() {
     type_ascribe!(0, u8<e<5>=e>)
-    //~^ ERROR: cannot find type `e` in this scope [E0412]
+    //~^ ERROR: cannot find type `e` in this scope [E0425]
     //~| ERROR: associated item constraints are not allowed here [E0229]
     //~| ERROR: mismatched types [E0308]
 }

--- a/tests/ui/typeck/issue-91267.stderr
+++ b/tests/ui/typeck/issue-91267.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `e` in this scope
+error[E0425]: cannot find type `e` in this scope
   --> $DIR/issue-91267.rs:4:30
    |
 LL |     type_ascribe!(0, u8<e<5>=e>)
@@ -22,5 +22,5 @@ LL |     type_ascribe!(0, u8<e<5>=e>)
 
 error: aborting due to 3 previous errors
 
-Some errors have detailed explanations: E0229, E0308, E0412.
+Some errors have detailed explanations: E0229, E0308, E0425.
 For more information about an error, try `rustc --explain E0229`.

--- a/tests/ui/typeck/nonexistent-field-not-ambiguous.stderr
+++ b/tests/ui/typeck/nonexistent-field-not-ambiguous.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `MissingType` in this scope
+error[E0425]: cannot find type `MissingType` in this scope
   --> $DIR/nonexistent-field-not-ambiguous.rs:2:10
    |
 LL |     val: MissingType,
@@ -6,4 +6,4 @@ LL |     val: MissingType,
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/typeck/sugg-swap-equality-in-macro-issue-139050.rs
+++ b/tests/ui/typeck/sugg-swap-equality-in-macro-issue-139050.rs
@@ -26,7 +26,7 @@ macro_rules! eq_local {
 
 pub fn foo<I: Iterator>(mut iter: I, value: &I::Item)
 where
-    Item: Eq + Debug, //~ ERROR cannot find type `Item` in this scope [E0412]
+    Item: Eq + Debug, //~ ERROR cannot find type `Item` in this scope [E0425]
 {
     ext::eq!(assert iter.next(), Some(value)); //~ ERROR  mismatched types [E0308]
     eq_local!(assert iter.next(), Some(value));

--- a/tests/ui/typeck/sugg-swap-equality-in-macro-issue-139050.stderr
+++ b/tests/ui/typeck/sugg-swap-equality-in-macro-issue-139050.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `Item` in this scope
+error[E0425]: cannot find type `Item` in this scope
   --> $DIR/sugg-swap-equality-in-macro-issue-139050.rs:29:5
    |
 LL |     Item: Eq + Debug,
@@ -35,5 +35,5 @@ LL +                 if !(*right_val == *left_val) {
 
 error: aborting due to 3 previous errors
 
-Some errors have detailed explanations: E0308, E0412.
+Some errors have detailed explanations: E0308, E0425.
 For more information about an error, try `rustc --explain E0308`.

--- a/tests/ui/union/unresolved-field-isnt-copy.stderr
+++ b/tests/ui/union/unresolved-field-isnt-copy.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `Missing` in this scope
+error[E0425]: cannot find type `Missing` in this scope
   --> $DIR/unresolved-field-isnt-copy.rs:4:15
    |
 LL |     x: *const Missing,
@@ -6,4 +6,4 @@ LL |     x: *const Missing,
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/variance/type-resolve-error-two-structs-deep.stderr
+++ b/tests/ui/variance/type-resolve-error-two-structs-deep.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `Missing` in this scope
+error[E0425]: cannot find type `Missing` in this scope
   --> $DIR/type-resolve-error-two-structs-deep.rs:5:14
    |
 LL |     missing: Missing<'a>,
@@ -6,4 +6,4 @@ LL |     missing: Missing<'a>,
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/wf/issue-110157.stderr
+++ b/tests/ui/wf/issue-110157.stderr
@@ -1,10 +1,10 @@
-error[E0412]: cannot find type `Missing` in this scope
+error[E0425]: cannot find type `Missing` in this scope
   --> $DIR/issue-110157.rs:6:12
    |
 LL |     F: Fn(&Missing) -> Result<I, ()>,
    |            ^^^^^^^ not found in this scope
 
-error[E0412]: cannot find type `Missing` in this scope
+error[E0425]: cannot find type `Missing` in this scope
   --> $DIR/issue-110157.rs:8:24
    |
 LL |     I: Iterator<Item = Missing>,
@@ -26,5 +26,5 @@ LL | |     I: Iterator<Item = Missing>,
 
 error: aborting due to 3 previous errors
 
-Some errors have detailed explanations: E0046, E0412.
+Some errors have detailed explanations: E0046, E0425.
 For more information about an error, try `rustc --explain E0046`.

--- a/tests/ui/where-clauses/ignore-err-clauses.stderr
+++ b/tests/ui/where-clauses/ignore-err-clauses.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `UUU` in this scope
+error[E0425]: cannot find type `UUU` in this scope
   --> $DIR/ignore-err-clauses.rs:6:5
    |
 LL |     UUU: Copy,
@@ -29,5 +29,5 @@ note: calling this operator moves the left-hand side
 
 error: aborting due to 2 previous errors
 
-Some errors have detailed explanations: E0382, E0412.
+Some errors have detailed explanations: E0382, E0425.
 For more information about an error, try `rustc --explain E0382`.

--- a/tests/ui/where-clauses/normalization-of-unknown-type.stderr
+++ b/tests/ui/where-clauses/normalization-of-unknown-type.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `Foo` in this scope
+error[E0425]: cannot find type `Foo` in this scope
   --> $DIR/normalization-of-unknown-type.rs:24:5
    |
 LL |     Foo: Filter,
@@ -6,4 +6,4 @@ LL |     Foo: Filter,
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0425`.


### PR DESCRIPTION
Fixes rust-lang/rust#148558

## Summary

This PR merges the redundant error codes E0412 and E0425 into a single unified error code (E0425).

## Background

E0412 ("type name is not in scope") and E0425 ("unresolved name") conveyed essentially the same information to users - that an identifier cannot be found in the current scope. The only difference was that E0412 was used for type positions while E0425 was used for value/expression positions. This distinction was not meaningful to users and created unnecessary complexity.

## Changes

- **Compiler changes:**
  - Updated error code mapping in `rustc_resolve` to use E0425 for both type and expression positions
  - Updated diagnostic handling code and comments throughout the codebase to reflect the merge
  
- **Documentation changes:**
  - Marked E0412 documentation as no longer emitted, with a note that it has been merged into E0425
  - Enhanced E0425 documentation to include examples for both type and value resolution errors
  
- **Test changes:**
  - Updated all test files (21 `.rs` files and 173 `.stderr` files) to expect E0425 instead of E0412
  - Blessed all affected tests to update expected outputs

## Testing

All tests pass successfully:
- ✓ tests/ui/error-codes/E0412.rs (with --bless)
- ✓ tests/ui/resolve/* (292 tests)
- ✓ tests/ui/typeck/* (262 tests)
- ✓ tests/ui/trait-bounds/* (140 tests)
- ✓ rustdoc error code tests
- ✓ All tidy checks

This is a cleanup change that improves consistency in error reporting without changing the user-facing error messages themselves.