### PR TITLE
ptr_aligment_type: add more APIs

### DIFF
--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -252,7 +252,7 @@ use core::intrinsics::abort;
 #[cfg(not(no_global_oom_handling))]
 use core::iter;
 use core::marker::{PhantomData, Unsize};
-use core::mem::{self, ManuallyDrop, align_of_val_raw};
+use core::mem::{self, ManuallyDrop};
 use core::num::NonZeroUsize;
 use core::ops::{CoerceUnsized, Deref, DerefMut, DerefPure, DispatchFromDyn, LegacyReceiver};
 #[cfg(not(no_global_oom_handling))]
@@ -3845,15 +3845,15 @@ unsafe fn data_offset<T: ?Sized>(ptr: *const T) -> usize {
     // Because RcInner is repr(C), it will always be the last field in memory.
     // SAFETY: since the only unsized types possible are slices, trait objects,
     // and extern types, the input safety requirement is currently enough to
-    // satisfy the requirements of align_of_val_raw; this is an implementation
+    // satisfy the requirements of Alignment::of_val_raw; this is an implementation
     // detail of the language that must not be relied upon outside of std.
-    unsafe { data_offset_align(Alignment::new_unchecked(align_of_val_raw(ptr))) }
+    unsafe { data_offset_alignment(Alignment::of_val_raw(ptr)) }
 }
 
 #[inline]
-fn data_offset_align(align: Alignment) -> usize {
+fn data_offset_alignment(alignment: Alignment) -> usize {
     let layout = Layout::new::<RcInner<()>>();
-    layout.size() + layout.padding_needed_for(align)
+    layout.size() + layout.padding_needed_for(alignment)
 }
 
 /// A uniquely owned [`Rc`].
@@ -4478,7 +4478,7 @@ impl<T: ?Sized, A: Allocator> UniqueRcUninit<T, A> {
 
     /// Returns the pointer to be written into to initialize the [`Rc`].
     fn data_ptr(&mut self) -> *mut T {
-        let offset = data_offset_align(self.layout_for_value.alignment());
+        let offset = data_offset_alignment(self.layout_for_value.alignment());
         unsafe { self.ptr.as_ptr().byte_add(offset) as *mut T }
     }
 

--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -9,6 +9,7 @@ use crate::alloc::Layout;
 use crate::clone::TrivialClone;
 use crate::marker::{Destruct, DiscriminantKind};
 use crate::panic::const_assert;
+use crate::ptr::Alignment;
 use crate::{clone, cmp, fmt, hash, intrinsics, ptr};
 
 mod manually_drop;
@@ -1256,6 +1257,10 @@ pub trait SizedTypeProperties: Sized {
     #[unstable(feature = "sized_type_properties", issue = "none")]
     #[lang = "mem_align_const"]
     const ALIGN: usize = intrinsics::align_of::<Self>();
+
+    #[doc(hidden)]
+    #[unstable(feature = "ptr_alignment_type", issue = "102070")]
+    const ALIGNMENT: Alignment = Alignment::of::<Self>();
 
     /// `true` if this type requires no storage.
     /// `false` if its [size](size_of) is greater than zero.

--- a/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.32bit.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.32bit.panic-abort.mir
@@ -12,32 +12,32 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
             scope 3 {
                 let _8: std::ptr::alignment::AlignmentEnum;
                 scope 4 {
-                    scope 12 (inlined Layout::size) {
+                    scope 17 (inlined Layout::size) {
                     }
-                    scope 13 (inlined std::ptr::Unique::<[T]>::cast::<u8>) {
-                        scope 14 (inlined NonNull::<[T]>::cast::<u8>) {
-                            scope 15 (inlined NonNull::<[T]>::as_ptr) {
+                    scope 18 (inlined std::ptr::Unique::<[T]>::cast::<u8>) {
+                        scope 19 (inlined NonNull::<[T]>::cast::<u8>) {
+                            scope 20 (inlined NonNull::<[T]>::as_ptr) {
                             }
                         }
                     }
-                    scope 16 (inlined <NonNull<u8> as From<std::ptr::Unique<u8>>>::from) {
-                        scope 17 (inlined std::ptr::Unique::<u8>::as_non_null_ptr) {
+                    scope 21 (inlined <NonNull<u8> as From<std::ptr::Unique<u8>>>::from) {
+                        scope 22 (inlined std::ptr::Unique::<u8>::as_non_null_ptr) {
                         }
                     }
-                    scope 18 (inlined <std::alloc::Global as Allocator>::deallocate) {
-                        scope 19 (inlined std::alloc::Global::deallocate_impl) {
-                            scope 20 (inlined std::alloc::Global::deallocate_impl_runtime) {
+                    scope 23 (inlined <std::alloc::Global as Allocator>::deallocate) {
+                        scope 24 (inlined std::alloc::Global::deallocate_impl) {
+                            scope 25 (inlined std::alloc::Global::deallocate_impl_runtime) {
                                 let mut _9: *mut u8;
-                                scope 21 (inlined Layout::size) {
+                                scope 26 (inlined Layout::size) {
                                 }
-                                scope 22 (inlined NonNull::<u8>::as_ptr) {
+                                scope 27 (inlined NonNull::<u8>::as_ptr) {
                                 }
-                                scope 23 (inlined std::alloc::dealloc) {
+                                scope 28 (inlined std::alloc::dealloc) {
                                     let mut _10: usize;
-                                    scope 24 (inlined Layout::size) {
+                                    scope 29 (inlined Layout::size) {
                                     }
-                                    scope 25 (inlined Layout::align) {
-                                        scope 26 (inlined std::ptr::Alignment::as_usize) {
+                                    scope 30 (inlined Layout::align) {
+                                        scope 31 (inlined std::ptr::Alignment::as_usize) {
                                         }
                                     }
                                 }
@@ -51,15 +51,25 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
                 }
                 scope 7 (inlined Layout::for_value_raw::<[T]>) {
                     let mut _5: usize;
-                    let mut _6: usize;
+                    let mut _7: std::ptr::Alignment;
                     scope 8 {
-                        scope 11 (inlined #[track_caller] Layout::from_size_align_unchecked) {
-                            let mut _7: std::ptr::Alignment;
+                        scope 16 (inlined #[track_caller] Layout::from_size_alignment_unchecked) {
                         }
                     }
                     scope 9 (inlined size_of_val_raw::<[T]>) {
                     }
-                    scope 10 (inlined align_of_val_raw::<[T]>) {
+                    scope 10 (inlined std::ptr::Alignment::of_val_raw::<[T]>) {
+                        let _6: usize;
+                        scope 11 {
+                            scope 13 (inlined #[track_caller] std::ptr::Alignment::new_unchecked) {
+                                scope 14 (inlined core::ub_checks::check_language_ub) {
+                                    scope 15 (inlined core::ub_checks::check_language_ub::runtime) {
+                                    }
+                                }
+                            }
+                        }
+                        scope 12 (inlined align_of_val_raw::<[T]>) {
+                        }
                     }
                 }
             }
@@ -72,17 +82,17 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
         StorageLive(_4);
         _3 = copy _2 as *mut [T] (Transmute);
         _4 = copy _2 as *const [T] (Transmute);
-        StorageLive(_6);
+        StorageLive(_7);
         _5 = std::intrinsics::size_of_val::<[T]>(move _4) -> [return: bb1, unwind unreachable];
     }
 
     bb1: {
+        StorageLive(_6);
         _6 = const <T as std::mem::SizedTypeProperties>::ALIGN;
-        StorageLive(_7);
         _7 = copy _6 as std::ptr::Alignment (Transmute);
-        _8 = move (_7.0: std::ptr::alignment::AlignmentEnum);
-        StorageDead(_7);
         StorageDead(_6);
+        _8 = copy (_7.0: std::ptr::alignment::AlignmentEnum);
+        StorageDead(_7);
         StorageDead(_4);
         switchInt(copy _5) -> [0: bb4, otherwise: bb2];
     }

--- a/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.32bit.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.32bit.panic-unwind.mir
@@ -12,32 +12,32 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
             scope 3 {
                 let _8: std::ptr::alignment::AlignmentEnum;
                 scope 4 {
-                    scope 12 (inlined Layout::size) {
+                    scope 17 (inlined Layout::size) {
                     }
-                    scope 13 (inlined std::ptr::Unique::<[T]>::cast::<u8>) {
-                        scope 14 (inlined NonNull::<[T]>::cast::<u8>) {
-                            scope 15 (inlined NonNull::<[T]>::as_ptr) {
+                    scope 18 (inlined std::ptr::Unique::<[T]>::cast::<u8>) {
+                        scope 19 (inlined NonNull::<[T]>::cast::<u8>) {
+                            scope 20 (inlined NonNull::<[T]>::as_ptr) {
                             }
                         }
                     }
-                    scope 16 (inlined <NonNull<u8> as From<std::ptr::Unique<u8>>>::from) {
-                        scope 17 (inlined std::ptr::Unique::<u8>::as_non_null_ptr) {
+                    scope 21 (inlined <NonNull<u8> as From<std::ptr::Unique<u8>>>::from) {
+                        scope 22 (inlined std::ptr::Unique::<u8>::as_non_null_ptr) {
                         }
                     }
-                    scope 18 (inlined <std::alloc::Global as Allocator>::deallocate) {
-                        scope 19 (inlined std::alloc::Global::deallocate_impl) {
-                            scope 20 (inlined std::alloc::Global::deallocate_impl_runtime) {
+                    scope 23 (inlined <std::alloc::Global as Allocator>::deallocate) {
+                        scope 24 (inlined std::alloc::Global::deallocate_impl) {
+                            scope 25 (inlined std::alloc::Global::deallocate_impl_runtime) {
                                 let mut _9: *mut u8;
-                                scope 21 (inlined Layout::size) {
+                                scope 26 (inlined Layout::size) {
                                 }
-                                scope 22 (inlined NonNull::<u8>::as_ptr) {
+                                scope 27 (inlined NonNull::<u8>::as_ptr) {
                                 }
-                                scope 23 (inlined std::alloc::dealloc) {
+                                scope 28 (inlined std::alloc::dealloc) {
                                     let mut _10: usize;
-                                    scope 24 (inlined Layout::size) {
+                                    scope 29 (inlined Layout::size) {
                                     }
-                                    scope 25 (inlined Layout::align) {
-                                        scope 26 (inlined std::ptr::Alignment::as_usize) {
+                                    scope 30 (inlined Layout::align) {
+                                        scope 31 (inlined std::ptr::Alignment::as_usize) {
                                         }
                                     }
                                 }
@@ -51,15 +51,25 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
                 }
                 scope 7 (inlined Layout::for_value_raw::<[T]>) {
                     let mut _5: usize;
-                    let mut _6: usize;
+                    let mut _7: std::ptr::Alignment;
                     scope 8 {
-                        scope 11 (inlined #[track_caller] Layout::from_size_align_unchecked) {
-                            let mut _7: std::ptr::Alignment;
+                        scope 16 (inlined #[track_caller] Layout::from_size_alignment_unchecked) {
                         }
                     }
                     scope 9 (inlined size_of_val_raw::<[T]>) {
                     }
-                    scope 10 (inlined align_of_val_raw::<[T]>) {
+                    scope 10 (inlined std::ptr::Alignment::of_val_raw::<[T]>) {
+                        let _6: usize;
+                        scope 11 {
+                            scope 13 (inlined #[track_caller] std::ptr::Alignment::new_unchecked) {
+                                scope 14 (inlined core::ub_checks::check_language_ub) {
+                                    scope 15 (inlined core::ub_checks::check_language_ub::runtime) {
+                                    }
+                                }
+                            }
+                        }
+                        scope 12 (inlined align_of_val_raw::<[T]>) {
+                        }
                     }
                 }
             }
@@ -72,17 +82,17 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
         StorageLive(_4);
         _3 = copy _2 as *mut [T] (Transmute);
         _4 = copy _2 as *const [T] (Transmute);
-        StorageLive(_6);
+        StorageLive(_7);
         _5 = std::intrinsics::size_of_val::<[T]>(move _4) -> [return: bb1, unwind unreachable];
     }
 
     bb1: {
+        StorageLive(_6);
         _6 = const <T as std::mem::SizedTypeProperties>::ALIGN;
-        StorageLive(_7);
         _7 = copy _6 as std::ptr::Alignment (Transmute);
-        _8 = move (_7.0: std::ptr::alignment::AlignmentEnum);
-        StorageDead(_7);
         StorageDead(_6);
+        _8 = copy (_7.0: std::ptr::alignment::AlignmentEnum);
+        StorageDead(_7);
         StorageDead(_4);
         switchInt(copy _5) -> [0: bb4, otherwise: bb2];
     }

--- a/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.64bit.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.64bit.panic-abort.mir
@@ -12,32 +12,32 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
             scope 3 {
                 let _8: std::ptr::alignment::AlignmentEnum;
                 scope 4 {
-                    scope 12 (inlined Layout::size) {
+                    scope 17 (inlined Layout::size) {
                     }
-                    scope 13 (inlined std::ptr::Unique::<[T]>::cast::<u8>) {
-                        scope 14 (inlined NonNull::<[T]>::cast::<u8>) {
-                            scope 15 (inlined NonNull::<[T]>::as_ptr) {
+                    scope 18 (inlined std::ptr::Unique::<[T]>::cast::<u8>) {
+                        scope 19 (inlined NonNull::<[T]>::cast::<u8>) {
+                            scope 20 (inlined NonNull::<[T]>::as_ptr) {
                             }
                         }
                     }
-                    scope 16 (inlined <NonNull<u8> as From<std::ptr::Unique<u8>>>::from) {
-                        scope 17 (inlined std::ptr::Unique::<u8>::as_non_null_ptr) {
+                    scope 21 (inlined <NonNull<u8> as From<std::ptr::Unique<u8>>>::from) {
+                        scope 22 (inlined std::ptr::Unique::<u8>::as_non_null_ptr) {
                         }
                     }
-                    scope 18 (inlined <std::alloc::Global as Allocator>::deallocate) {
-                        scope 19 (inlined std::alloc::Global::deallocate_impl) {
-                            scope 20 (inlined std::alloc::Global::deallocate_impl_runtime) {
+                    scope 23 (inlined <std::alloc::Global as Allocator>::deallocate) {
+                        scope 24 (inlined std::alloc::Global::deallocate_impl) {
+                            scope 25 (inlined std::alloc::Global::deallocate_impl_runtime) {
                                 let mut _9: *mut u8;
-                                scope 21 (inlined Layout::size) {
+                                scope 26 (inlined Layout::size) {
                                 }
-                                scope 22 (inlined NonNull::<u8>::as_ptr) {
+                                scope 27 (inlined NonNull::<u8>::as_ptr) {
                                 }
-                                scope 23 (inlined std::alloc::dealloc) {
+                                scope 28 (inlined std::alloc::dealloc) {
                                     let mut _10: usize;
-                                    scope 24 (inlined Layout::size) {
+                                    scope 29 (inlined Layout::size) {
                                     }
-                                    scope 25 (inlined Layout::align) {
-                                        scope 26 (inlined std::ptr::Alignment::as_usize) {
+                                    scope 30 (inlined Layout::align) {
+                                        scope 31 (inlined std::ptr::Alignment::as_usize) {
                                         }
                                     }
                                 }
@@ -51,15 +51,25 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
                 }
                 scope 7 (inlined Layout::for_value_raw::<[T]>) {
                     let mut _5: usize;
-                    let mut _6: usize;
+                    let mut _7: std::ptr::Alignment;
                     scope 8 {
-                        scope 11 (inlined #[track_caller] Layout::from_size_align_unchecked) {
-                            let mut _7: std::ptr::Alignment;
+                        scope 16 (inlined #[track_caller] Layout::from_size_alignment_unchecked) {
                         }
                     }
                     scope 9 (inlined size_of_val_raw::<[T]>) {
                     }
-                    scope 10 (inlined align_of_val_raw::<[T]>) {
+                    scope 10 (inlined std::ptr::Alignment::of_val_raw::<[T]>) {
+                        let _6: usize;
+                        scope 11 {
+                            scope 13 (inlined #[track_caller] std::ptr::Alignment::new_unchecked) {
+                                scope 14 (inlined core::ub_checks::check_language_ub) {
+                                    scope 15 (inlined core::ub_checks::check_language_ub::runtime) {
+                                    }
+                                }
+                            }
+                        }
+                        scope 12 (inlined align_of_val_raw::<[T]>) {
+                        }
                     }
                 }
             }
@@ -72,17 +82,17 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
         StorageLive(_4);
         _3 = copy _2 as *mut [T] (Transmute);
         _4 = copy _2 as *const [T] (Transmute);
-        StorageLive(_6);
+        StorageLive(_7);
         _5 = std::intrinsics::size_of_val::<[T]>(move _4) -> [return: bb1, unwind unreachable];
     }
 
     bb1: {
+        StorageLive(_6);
         _6 = const <T as std::mem::SizedTypeProperties>::ALIGN;
-        StorageLive(_7);
         _7 = copy _6 as std::ptr::Alignment (Transmute);
-        _8 = move (_7.0: std::ptr::alignment::AlignmentEnum);
-        StorageDead(_7);
         StorageDead(_6);
+        _8 = copy (_7.0: std::ptr::alignment::AlignmentEnum);
+        StorageDead(_7);
         StorageDead(_4);
         switchInt(copy _5) -> [0: bb4, otherwise: bb2];
     }

--- a/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.64bit.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.64bit.panic-unwind.mir
@@ -12,32 +12,32 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
             scope 3 {
                 let _8: std::ptr::alignment::AlignmentEnum;
                 scope 4 {
-                    scope 12 (inlined Layout::size) {
+                    scope 17 (inlined Layout::size) {
                     }
-                    scope 13 (inlined std::ptr::Unique::<[T]>::cast::<u8>) {
-                        scope 14 (inlined NonNull::<[T]>::cast::<u8>) {
-                            scope 15 (inlined NonNull::<[T]>::as_ptr) {
+                    scope 18 (inlined std::ptr::Unique::<[T]>::cast::<u8>) {
+                        scope 19 (inlined NonNull::<[T]>::cast::<u8>) {
+                            scope 20 (inlined NonNull::<[T]>::as_ptr) {
                             }
                         }
                     }
-                    scope 16 (inlined <NonNull<u8> as From<std::ptr::Unique<u8>>>::from) {
-                        scope 17 (inlined std::ptr::Unique::<u8>::as_non_null_ptr) {
+                    scope 21 (inlined <NonNull<u8> as From<std::ptr::Unique<u8>>>::from) {
+                        scope 22 (inlined std::ptr::Unique::<u8>::as_non_null_ptr) {
                         }
                     }
-                    scope 18 (inlined <std::alloc::Global as Allocator>::deallocate) {
-                        scope 19 (inlined std::alloc::Global::deallocate_impl) {
-                            scope 20 (inlined std::alloc::Global::deallocate_impl_runtime) {
+                    scope 23 (inlined <std::alloc::Global as Allocator>::deallocate) {
+                        scope 24 (inlined std::alloc::Global::deallocate_impl) {
+                            scope 25 (inlined std::alloc::Global::deallocate_impl_runtime) {
                                 let mut _9: *mut u8;
-                                scope 21 (inlined Layout::size) {
+                                scope 26 (inlined Layout::size) {
                                 }
-                                scope 22 (inlined NonNull::<u8>::as_ptr) {
+                                scope 27 (inlined NonNull::<u8>::as_ptr) {
                                 }
-                                scope 23 (inlined std::alloc::dealloc) {
+                                scope 28 (inlined std::alloc::dealloc) {
                                     let mut _10: usize;
-                                    scope 24 (inlined Layout::size) {
+                                    scope 29 (inlined Layout::size) {
                                     }
-                                    scope 25 (inlined Layout::align) {
-                                        scope 26 (inlined std::ptr::Alignment::as_usize) {
+                                    scope 30 (inlined Layout::align) {
+                                        scope 31 (inlined std::ptr::Alignment::as_usize) {
                                         }
                                     }
                                 }
@@ -51,15 +51,25 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
                 }
                 scope 7 (inlined Layout::for_value_raw::<[T]>) {
                     let mut _5: usize;
-                    let mut _6: usize;
+                    let mut _7: std::ptr::Alignment;
                     scope 8 {
-                        scope 11 (inlined #[track_caller] Layout::from_size_align_unchecked) {
-                            let mut _7: std::ptr::Alignment;
+                        scope 16 (inlined #[track_caller] Layout::from_size_alignment_unchecked) {
                         }
                     }
                     scope 9 (inlined size_of_val_raw::<[T]>) {
                     }
-                    scope 10 (inlined align_of_val_raw::<[T]>) {
+                    scope 10 (inlined std::ptr::Alignment::of_val_raw::<[T]>) {
+                        let _6: usize;
+                        scope 11 {
+                            scope 13 (inlined #[track_caller] std::ptr::Alignment::new_unchecked) {
+                                scope 14 (inlined core::ub_checks::check_language_ub) {
+                                    scope 15 (inlined core::ub_checks::check_language_ub::runtime) {
+                                    }
+                                }
+                            }
+                        }
+                        scope 12 (inlined align_of_val_raw::<[T]>) {
+                        }
                     }
                 }
             }
@@ -72,17 +82,17 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
         StorageLive(_4);
         _3 = copy _2 as *mut [T] (Transmute);
         _4 = copy _2 as *const [T] (Transmute);
-        StorageLive(_6);
+        StorageLive(_7);
         _5 = std::intrinsics::size_of_val::<[T]>(move _4) -> [return: bb1, unwind unreachable];
     }
 
     bb1: {
+        StorageLive(_6);
         _6 = const <T as std::mem::SizedTypeProperties>::ALIGN;
-        StorageLive(_7);
         _7 = copy _6 as std::ptr::Alignment (Transmute);
-        _8 = move (_7.0: std::ptr::alignment::AlignmentEnum);
-        StorageDead(_7);
         StorageDead(_6);
+        _8 = copy (_7.0: std::ptr::alignment::AlignmentEnum);
+        StorageDead(_7);
         StorageDead(_4);
         switchInt(copy _5) -> [0: bb4, otherwise: bb2];
     }

--- a/tests/mir-opt/pre-codegen/drop_boxed_slice.rs
+++ b/tests/mir-opt/pre-codegen/drop_boxed_slice.rs
@@ -11,7 +11,7 @@ pub unsafe fn generic_in_place<T: Copy>(ptr: *mut Box<[T]>) {
     // CHECK: [[SIZE:_.+]] = std::intrinsics::size_of_val::<[T]>
     // CHECK: [[ALIGN:_.+]] = const <T as std::mem::SizedTypeProperties>::ALIGN;
     // CHECK: [[B:_.+]] = copy [[ALIGN]] as std::ptr::Alignment (Transmute);
-    // CHECK: [[C:_.+]] = move ([[B]].0: std::ptr::alignment::AlignmentEnum);
+    // CHECK: [[C:_.+]] = copy ([[B]].0: std::ptr::alignment::AlignmentEnum);
     // CHECK: [[D:_.+]] = discriminant([[C]]);
     // CHECK: = alloc::alloc::__rust_dealloc({{.+}}, move [[SIZE]], move [[D]]) ->
     std::ptr::drop_in_place(ptr)

--- a/tests/ui/thir-print/offset_of.stdout
+++ b/tests/ui/thir-print/offset_of.stdout
@@ -68,7 +68,7 @@ body:
                                             )
                                             else_block: None
                                             hir_id: HirId(DefId(offset_of::concrete).10)
-                                            span: $DIR/offset_of.rs:37:5: 1440:57 (#0)
+                                            span: $DIR/offset_of.rs:37:5: 1445:57 (#0)
                                         }
                                     }
                                     Stmt {
@@ -117,7 +117,7 @@ body:
                                             )
                                             else_block: None
                                             hir_id: HirId(DefId(offset_of::concrete).20)
-                                            span: $DIR/offset_of.rs:38:5: 1440:57 (#0)
+                                            span: $DIR/offset_of.rs:38:5: 1445:57 (#0)
                                         }
                                     }
                                     Stmt {
@@ -166,7 +166,7 @@ body:
                                             )
                                             else_block: None
                                             hir_id: HirId(DefId(offset_of::concrete).30)
-                                            span: $DIR/offset_of.rs:39:5: 1440:57 (#0)
+                                            span: $DIR/offset_of.rs:39:5: 1445:57 (#0)
                                         }
                                     }
                                     Stmt {
@@ -215,7 +215,7 @@ body:
                                             )
                                             else_block: None
                                             hir_id: HirId(DefId(offset_of::concrete).40)
-                                            span: $DIR/offset_of.rs:40:5: 1440:57 (#0)
+                                            span: $DIR/offset_of.rs:40:5: 1445:57 (#0)
                                         }
                                     }
                                     Stmt {
@@ -264,7 +264,7 @@ body:
                                             )
                                             else_block: None
                                             hir_id: HirId(DefId(offset_of::concrete).50)
-                                            span: $DIR/offset_of.rs:41:5: 1440:57 (#0)
+                                            span: $DIR/offset_of.rs:41:5: 1445:57 (#0)
                                         }
                                     }
                                 ]
@@ -864,7 +864,7 @@ body:
                                             )
                                             else_block: None
                                             hir_id: HirId(DefId(offset_of::generic).12)
-                                            span: $DIR/offset_of.rs:45:5: 1440:57 (#0)
+                                            span: $DIR/offset_of.rs:45:5: 1445:57 (#0)
                                         }
                                     }
                                     Stmt {
@@ -913,7 +913,7 @@ body:
                                             )
                                             else_block: None
                                             hir_id: HirId(DefId(offset_of::generic).24)
-                                            span: $DIR/offset_of.rs:46:5: 1440:57 (#0)
+                                            span: $DIR/offset_of.rs:46:5: 1445:57 (#0)
                                         }
                                     }
                                     Stmt {
@@ -962,7 +962,7 @@ body:
                                             )
                                             else_block: None
                                             hir_id: HirId(DefId(offset_of::generic).36)
-                                            span: $DIR/offset_of.rs:47:5: 1440:57 (#0)
+                                            span: $DIR/offset_of.rs:47:5: 1445:57 (#0)
                                         }
                                     }
                                     Stmt {
@@ -1011,7 +1011,7 @@ body:
                                             )
                                             else_block: None
                                             hir_id: HirId(DefId(offset_of::generic).48)
-                                            span: $DIR/offset_of.rs:48:5: 1440:57 (#0)
+                                            span: $DIR/offset_of.rs:48:5: 1445:57 (#0)
                                         }
                                     }
                                 ]


### PR DESCRIPTION
As per https://github.com/rust-lang/rust/issues/102070#issuecomment-1650043557

Tracking issue: rust-lang/rust#102070

Mostly duplicating methods that previously worked with `usize`-represented alignments.

Naming follows a convention of `align: usize`, `alignment: Alignment`.