### PR TITLE
Stabilize `alloc_layout_extra`

### DIFF
--- a/compiler/rustc_codegen_cranelift/patches/0027-sysroot_tests-128bit-atomic-operations.patch
+++ b/compiler/rustc_codegen_cranelift/patches/0027-sysroot_tests-128bit-atomic-operations.patch
@@ -14,11 +14,10 @@ diff --git a/coretests/tests/lib.rs b/coretests/tests/lib.rs
 index 1e336bf..35e6f54 100644
 --- a/coretests/tests/lib.rs
 +++ b/coretests/tests/lib.rs
-@@ -2,5 +2,4 @@
+@@ -2,4 +2,3 @@
  // tidy-alphabetical-start
 -#![cfg_attr(target_has_atomic = "128", feature(integer_atomics))]
  #![cfg_attr(test, feature(cfg_select))]
- #![feature(alloc_layout_extra)]
  #![feature(array_ptr_get)]
 diff --git a/coretests/tests/atomic.rs b/coretests/tests/atomic.rs
 index b735957..ea728b6 100644

--- a/library/alloc/src/alloc.rs
+++ b/library/alloc/src/alloc.rs
@@ -184,7 +184,7 @@ impl Global {
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
     fn alloc_impl_runtime(layout: Layout, zeroed: bool) -> Result<NonNull<[u8]>, AllocError> {
         match layout.size() {
-            0 => Ok(NonNull::slice_from_raw_parts(layout.dangling(), 0)),
+            0 => Ok(NonNull::slice_from_raw_parts(layout.dangling_ptr(), 0)),
             // SAFETY: `layout` is non-zero in size,
             size => unsafe {
                 let raw_ptr = if zeroed { alloc_zeroed(layout) } else { alloc(layout) };
@@ -277,7 +277,7 @@ impl Global {
             // SAFETY: conditions must be upheld by the caller
             0 => unsafe {
                 self.deallocate(ptr, old_layout);
-                Ok(NonNull::slice_from_raw_parts(new_layout.dangling(), 0))
+                Ok(NonNull::slice_from_raw_parts(new_layout.dangling_ptr(), 0))
             },
 
             // SAFETY: `new_size` is non-zero. Other conditions must be upheld by the caller
@@ -368,7 +368,7 @@ impl Global {
     #[rustc_const_unstable(feature = "const_heap", issue = "79597")]
     const fn alloc_impl_const(layout: Layout, zeroed: bool) -> Result<NonNull<[u8]>, AllocError> {
         match layout.size() {
-            0 => Ok(NonNull::slice_from_raw_parts(layout.dangling(), 0)),
+            0 => Ok(NonNull::slice_from_raw_parts(layout.dangling_ptr(), 0)),
             // SAFETY: `layout` is non-zero in size,
             size => unsafe {
                 let raw_ptr = core::intrinsics::const_allocate(layout.size(), layout.align());

--- a/library/alloc/src/boxed.rs
+++ b/library/alloc/src/boxed.rs
@@ -834,7 +834,7 @@ impl<T: ?Sized + CloneToUninit, A: Allocator> Box<T, A> {
         }
         let layout = Layout::for_value::<T>(src);
         let (ptr, guard) = if layout.size() == 0 {
-            (layout.dangling(), None)
+            (layout.dangling_ptr(), None)
         } else {
             // Safety: layout is non-zero-sized
             let ptr = alloc.allocate(layout)?.cast();

--- a/library/alloc/src/boxed/thin.rs
+++ b/library/alloc/src/boxed/thin.rs
@@ -245,7 +245,7 @@ impl<H> WithHeader<H> {
                 // Some paranoia checking, mostly so that the ThinBox tests are
                 // more able to catch issues.
                 debug_assert!(value_offset == 0 && T::IS_ZST && H::IS_ZST);
-                layout.dangling()
+                layout.dangling_ptr()
             } else {
                 let ptr = alloc::alloc(layout);
                 if ptr.is_null() {
@@ -282,7 +282,7 @@ impl<H> WithHeader<H> {
                 // Some paranoia checking, mostly so that the ThinBox tests are
                 // more able to catch issues.
                 debug_assert!(value_offset == 0 && size_of::<T>() == 0 && size_of::<H>() == 0);
-                layout.dangling()
+                layout.dangling_ptr()
             } else {
                 let ptr = alloc::alloc(layout);
                 if ptr.is_null() {

--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -86,7 +86,6 @@
 // Library features:
 // tidy-alphabetical-start
 #![cfg_attr(not(no_global_oom_handling), feature(string_replace_in_place))]
-#![feature(alloc_layout_extra)]
 #![feature(allocator_api)]
 #![feature(array_into_iter_constructors)]
 #![feature(ascii_char)]

--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -261,7 +261,7 @@ use core::panic::{RefUnwindSafe, UnwindSafe};
 #[cfg(not(no_global_oom_handling))]
 use core::pin::Pin;
 use core::pin::PinCoerceUnsized;
-use core::ptr::{self, NonNull, drop_in_place};
+use core::ptr::{self, Alignment, NonNull, drop_in_place};
 #[cfg(not(no_global_oom_handling))]
 use core::slice::from_raw_parts_mut;
 use core::{borrow, fmt, hint};
@@ -3847,11 +3847,11 @@ unsafe fn data_offset<T: ?Sized>(ptr: *const T) -> usize {
     // and extern types, the input safety requirement is currently enough to
     // satisfy the requirements of align_of_val_raw; this is an implementation
     // detail of the language that must not be relied upon outside of std.
-    unsafe { data_offset_align(align_of_val_raw(ptr)) }
+    unsafe { data_offset_align(Alignment::new_unchecked(align_of_val_raw(ptr))) }
 }
 
 #[inline]
-fn data_offset_align(align: usize) -> usize {
+fn data_offset_align(align: Alignment) -> usize {
     let layout = Layout::new::<RcInner<()>>();
     layout.size() + layout.padding_needed_for(align)
 }
@@ -4478,7 +4478,7 @@ impl<T: ?Sized, A: Allocator> UniqueRcUninit<T, A> {
 
     /// Returns the pointer to be written into to initialize the [`Rc`].
     fn data_ptr(&mut self) -> *mut T {
-        let offset = data_offset_align(self.layout_for_value.align());
+        let offset = data_offset_align(self.layout_for_value.alignment());
         unsafe { self.ptr.as_ptr().byte_add(offset) as *mut T }
     }
 

--- a/library/alloctests/lib.rs
+++ b/library/alloctests/lib.rs
@@ -14,7 +14,6 @@
 //
 // Library features:
 // tidy-alphabetical-start
-#![feature(alloc_layout_extra)]
 #![feature(allocator_api)]
 #![feature(array_into_iter_constructors)]
 #![feature(assert_matches)]

--- a/library/alloctests/tests/boxed.rs
+++ b/library/alloctests/tests/boxed.rs
@@ -104,7 +104,7 @@ pub struct ConstAllocator;
 unsafe impl Allocator for ConstAllocator {
     fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
         match layout.size() {
-            0 => Ok(NonNull::slice_from_raw_parts(layout.dangling(), 0)),
+            0 => Ok(NonNull::slice_from_raw_parts(layout.dangling_ptr(), 0)),
             _ => unsafe {
                 let ptr = core::intrinsics::const_allocate(layout.size(), layout.align());
                 Ok(NonNull::new_unchecked(ptr as *mut [u8; 0] as *mut [u8]))

--- a/library/alloctests/tests/lib.rs
+++ b/library/alloctests/tests/lib.rs
@@ -1,5 +1,4 @@
 #![feature(allocator_api)]
-#![feature(alloc_layout_extra)]
 #![feature(const_heap)]
 #![feature(deque_extend_front)]
 #![feature(iter_array_chunks)]

--- a/library/coretests/tests/alloc.rs
+++ b/library/coretests/tests/alloc.rs
@@ -6,7 +6,7 @@ fn const_unchecked_layout() {
     const SIZE: usize = 0x2000;
     const ALIGN: usize = 0x1000;
     const LAYOUT: Layout = unsafe { Layout::from_size_align_unchecked(SIZE, ALIGN) };
-    const DANGLING: NonNull<u8> = LAYOUT.dangling();
+    const DANGLING: NonNull<u8> = LAYOUT.dangling_ptr();
     assert_eq!(LAYOUT.size(), SIZE);
     assert_eq!(LAYOUT.align(), ALIGN);
     assert_eq!(Some(DANGLING), NonNull::new(ptr::without_provenance_mut(ALIGN)));

--- a/library/coretests/tests/lib.rs
+++ b/library/coretests/tests/lib.rs
@@ -1,7 +1,6 @@
 // tidy-alphabetical-start
 #![cfg_attr(target_has_atomic = "128", feature(integer_atomics))]
 #![cfg_attr(test, feature(cfg_select))]
-#![feature(alloc_layout_extra)]
 #![feature(array_ptr_get)]
 #![feature(array_try_from_fn)]
 #![feature(array_try_map)]

--- a/library/std/src/alloc.rs
+++ b/library/std/src/alloc.rs
@@ -142,7 +142,7 @@ impl System {
     #[inline]
     fn alloc_impl(&self, layout: Layout, zeroed: bool) -> Result<NonNull<[u8]>, AllocError> {
         match layout.size() {
-            0 => Ok(NonNull::slice_from_raw_parts(layout.dangling(), 0)),
+            0 => Ok(NonNull::slice_from_raw_parts(layout.dangling_ptr(), 0)),
             // SAFETY: `layout` is non-zero in size,
             size => unsafe {
                 let raw_ptr = if zeroed {
@@ -266,7 +266,7 @@ unsafe impl Allocator for System {
             // SAFETY: conditions must be upheld by the caller
             0 => unsafe {
                 Allocator::deallocate(self, ptr, old_layout);
-                Ok(NonNull::slice_from_raw_parts(new_layout.dangling(), 0))
+                Ok(NonNull::slice_from_raw_parts(new_layout.dangling_ptr(), 0))
             },
 
             // SAFETY: `new_size` is non-zero. Other conditions must be upheld by the caller

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -367,7 +367,6 @@
 //
 // Library features (alloc):
 // tidy-alphabetical-start
-#![feature(alloc_layout_extra)]
 #![feature(allocator_api)]
 #![feature(clone_from_ref)]
 #![feature(get_mut_unchecked)]


### PR DESCRIPTION
Tracking issue: rust-lang/rust#55724
FCP completed in https://github.com/rust-lang/rust/issues/55724#issuecomment-3447699364
Closes rust-lang/rust#55724

----

As per https://github.com/rust-lang/rust/issues/55724#issuecomment-3403555985,
- `repeat_packed` and `extend_packed` are unchanged
- `repeat` now excludes trailing padding on the last element from the total array size
- `dangling` renamed to `dangling_ptr`
- `padding_needed_for` not stabilized, changed to accept `Alignment` instead of `usize` and moved to the `ptr_aligment_type` feature flag (tracking issue: rust-lang/rust#102070)
