### PR TITLE
Implement DynSend and DynSync for std::panic::Location.

### DIFF
--- a/compiler/rustc_data_structures/src/marker.rs
+++ b/compiler/rustc_data_structures/src/marker.rs
@@ -53,13 +53,13 @@ impl !DynSend for std::env::VarsOs {}
 
 macro_rules! already_send {
     ($([$ty: ty])*) => {
-        $(unsafe impl DynSend for $ty where $ty: Send {})*
+        $(unsafe impl DynSend for $ty where Self: Send {})*
     };
 }
 
 // These structures are already `Send`.
 already_send!(
-    [std::backtrace::Backtrace][std::io::Stdout][std::io::Stderr][std::io::Error][std::fs::File]
+    [std::backtrace::Backtrace][std::io::Stdout][std::io::Stderr][std::io::Error][std::fs::File][std::panic::Location<'_>]
         [rustc_arena::DroplessArena][jobserver_crate::Client][jobserver_crate::HelperThread]
         [crate::memmap::Mmap][crate::profiling::SelfProfiler][crate::owned_slice::OwnedSlice]
 );
@@ -127,14 +127,14 @@ impl !DynSync for std::env::VarsOs {}
 
 macro_rules! already_sync {
     ($([$ty: ty])*) => {
-        $(unsafe impl DynSync for $ty where $ty: Sync {})*
+        $(unsafe impl DynSync for $ty where Self: Sync {})*
     };
 }
 
 // These structures are already `Sync`.
 already_sync!(
     [std::sync::atomic::AtomicBool][std::sync::atomic::AtomicUsize][std::sync::atomic::AtomicU8]
-        [std::sync::atomic::AtomicU32][std::backtrace::Backtrace][std::io::Error][std::fs::File]
+        [std::sync::atomic::AtomicU32][std::backtrace::Backtrace][std::io::Error][std::fs::File][std::panic::Location<'_>]
         [jobserver_crate::Client][jobserver_crate::HelperThread][crate::memmap::Mmap]
         [crate::profiling::SelfProfiler][crate::owned_slice::OwnedSlice]
 );


### PR DESCRIPTION
Allows the compiler to build with the `debug_refcell` stdlib cargo feature.

With `rust.std-features = ["debug_refcell"]` in bootstrap.toml, `./x.py build --stage 2` fails before this patch, and succeeds afterwards.

<details> <summary>error for `./x.py build --stage 2` before this patch</summary>

```Rust
error[E0277]: `NonNull<str>` doesn't implement `DynSync`. Add it to `rustc_data_structures::marker` or use `IntoDynSyncSend` if it's already `Sync`
    --> compiler/rustc_query_system/src/dep_graph/serialized.rs:719:33
     |
 719 |           let results = broadcast(|_| {
     |  _______________________---------_^
     | |                       |
     | |                       required by a bound introduced by this call
 720 | |             let mut local = self.local.borrow_mut();
...    |
 734 | |         });
     | |_________^ within `Location<'static>`, the trait `DynSync` is not implemented for `NonNull<str>`
     |
note: required because it appears within the type `Location<'static>`
    --> /home/zachary/opt_mount/zachary/Programming/rust-compiler-2/library/core/src/panic/location.rs:39:12
     |
  39 | pub struct Location<'a> {
     |            ^^^^^^^^
     = note: required for `&'static Location<'static>` to implement `DynSend`
note: required because it appears within the type `std::option::Option<&'static Location<'static>>`
    --> /home/zachary/opt_mount/zachary/Programming/rust-compiler-2/library/core/src/option.rs:599:10
     |
 599 | pub enum Option<T> {
     |          ^^^^^^
note: required because it appears within the type `std::cell::UnsafeCell<std::option::Option<&'static Location<'static>>>`
    --> /home/zachary/opt_mount/zachary/Programming/rust-compiler-2/library/core/src/cell.rs:2289:12
     |
2289 | pub struct UnsafeCell<T: ?Sized> {
     |            ^^^^^^^^^^
note: required because it appears within the type `Cell<std::option::Option<&'static Location<'static>>>`
    --> /home/zachary/opt_mount/zachary/Programming/rust-compiler-2/library/core/src/cell.rs:313:12
     |
 313 | pub struct Cell<T: ?Sized> {
     |            ^^^^
note: required because it appears within the type `RefCell<LocalEncoderState>`
    --> /home/zachary/opt_mount/zachary/Programming/rust-compiler-2/library/core/src/cell.rs:822:12
     |
 822 | pub struct RefCell<T: ?Sized> {
     |            ^^^^^^^
     = note: required for `rustc_data_structures::sync::WorkerLocal<RefCell<LocalEncoderState>>` to implement `DynSync`
note: required because it appears within the type `EncoderState<D>`
    --> compiler/rustc_query_system/src/dep_graph/serialized.rs:546:8
     |
 546 | struct EncoderState<D: Deps> {
     |        ^^^^^^^^^^^^
     = note: required because it appears within the type `&EncoderState<D>`
note: required because it's used within this closure
    --> compiler/rustc_query_system/src/dep_graph/serialized.rs:719:33
     |
 719 |         let results = broadcast(|_| {
     |                                 ^^^
note: required by a bound in `rustc_data_structures::sync::broadcast`
    --> /home/zachary/opt_mount/zachary/Programming/rust-compiler-2/compiler/rustc_data_structures/src/sync/parallel.rs:239:56
     |
 239 | pub fn broadcast<R: DynSend>(op: impl Fn(usize) -> R + DynSync) -> Vec<R> {
     |                                                        ^^^^^^^ required by this bound in `broadcast`

For more information about this error, try `rustc --explain E0277`.
error: could not compile `rustc_query_system` (lib) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
Build completed unsuccessfully in 0:02:04
```

</details>

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
