### PR TITLE
[rustdoc] Remove unneeded `allow(rustc::potential_query_instability)`

### DIFF
--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -1215,7 +1215,6 @@ impl LinkCollector<'_, '_> {
             || !did.is_local()
     }
 
-    #[allow(rustc::potential_query_instability)]
     pub(crate) fn resolve_ambiguities(&mut self) {
         let mut ambiguous_links = mem::take(&mut self.ambiguous_links);
         for ((item_id, path_str), info_items) in ambiguous_links.iter_mut() {


### PR DESCRIPTION
Originally replaced it with an `expect` and since it failed compilation because it wasn't triggered, I removed it.