### PR TITLE
Add new Tier-3 target: riscv64im-unknown-none-elf

### DIFF
--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -1686,6 +1686,7 @@ supported_targets! {
     ("riscv32imac-unknown-xous-elf", riscv32imac_unknown_xous_elf),
     ("riscv32gc-unknown-linux-gnu", riscv32gc_unknown_linux_gnu),
     ("riscv32gc-unknown-linux-musl", riscv32gc_unknown_linux_musl),
+    ("riscv64im-unknown-none-elf", riscv64im_unknown_none_elf),
     ("riscv64imac-unknown-none-elf", riscv64imac_unknown_none_elf),
     ("riscv64gc-unknown-none-elf", riscv64gc_unknown_none_elf),
     ("riscv64gc-unknown-linux-gnu", riscv64gc_unknown_linux_gnu),

--- a/compiler/rustc_target/src/spec/targets/riscv64im_unknown_none_elf.rs
+++ b/compiler/rustc_target/src/spec/targets/riscv64im_unknown_none_elf.rs
@@ -1,0 +1,35 @@
+use crate::spec::{
+    Arch, Cc, CodeModel, LinkerFlavor, Lld, PanicStrategy, RelocModel, Target, TargetMetadata,
+    TargetOptions,
+};
+
+pub(crate) fn target() -> Target {
+    Target {
+        data_layout: "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128".into(),
+        llvm_target: "riscv64".into(),
+        metadata: TargetMetadata {
+            description: Some("Bare RISC-V (RV64IM ISA)".into()),
+            tier: Some(3),
+            host_tools: Some(false),
+            std: Some(false),
+        },
+        pointer_width: 64,
+        arch: Arch::RiscV64,
+
+        options: TargetOptions {
+            linker_flavor: LinkerFlavor::Gnu(Cc::No, Lld::Yes),
+            linker: Some("rust-lld".into()),
+            cpu: "generic-rv64".into(),
+            max_atomic_width: Some(64),
+            atomic_cas: false,
+            features: "+m,+forced-atomics".into(),
+            llvm_abiname: "lp64".into(),
+            panic_strategy: PanicStrategy::Abort,
+            relocation_model: RelocModel::Static,
+            code_model: Some(CodeModel::Medium),
+            emit_debug_gdb_scripts: false,
+            eh_frame_header: false,
+            ..Default::default()
+        },
+    }
+}

--- a/src/bootstrap/src/core/sanity.rs
+++ b/src/bootstrap/src/core/sanity.rs
@@ -41,6 +41,7 @@ const STAGE0_MISSING_TARGETS: &[&str] = &[
     "sparc64-unknown-helenos",
     // just a dummy comment so the list doesn't get onelined
     "riscv64gc-unknown-redox",
+    "riscv64im-unknown-none-elf",
     "hexagon-unknown-qurt",
 ];
 

--- a/src/doc/rustc/src/SUMMARY.md
+++ b/src/doc/rustc/src/SUMMARY.md
@@ -112,6 +112,7 @@
     - [riscv32i\*-unknown-none-elf](platform-support/riscv32-unknown-none-elf.md)
     - [riscv32im-risc0-zkvm-elf](platform-support/riscv32im-risc0-zkvm-elf.md)
     - [riscv32imac-unknown-xous-elf](platform-support/riscv32imac-unknown-xous-elf.md)
+    - [riscv64im-unknown-none-elf](platform-support/riscv64im-unknown-none-elf.md)
     - [riscv64gc-unknown-linux-gnu](platform-support/riscv64gc-unknown-linux-gnu.md)
     - [riscv64gc-unknown-linux-musl](platform-support/riscv64gc-unknown-linux-musl.md)
     - [riscv64a23-unknown-linux-gnu](platform-support/riscv64a23-unknown-linux-gnu.md)

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -184,6 +184,7 @@ target | std | notes
 [`riscv32imc-unknown-none-elf`](platform-support/riscv32-unknown-none-elf.md) | * | Bare RISC-V (RV32IMC ISA)
 [`riscv64gc-unknown-linux-musl`](platform-support/riscv64gc-unknown-linux-musl.md) | ✓ |RISC-V Linux (kernel 4.20+, musl 1.2.5)
 `riscv64gc-unknown-none-elf` | * | Bare RISC-V (RV64IMAFDC ISA)
+[`riscv64im-unknown-none-elf`](platform-support/riscv64im-unknown-none-elf.md) | * | Bare RISC-V (RV64IM ISA)
 `riscv64imac-unknown-none-elf` | * | Bare RISC-V (RV64IMAC ISA)
 `sparc64-unknown-linux-gnu` | ✓ | SPARC Linux (kernel 4.4+, glibc 2.23)
 [`thumbv6m-none-eabi`](platform-support/thumbv6m-none-eabi.md) | * | Bare Armv6-M

--- a/src/doc/rustc/src/platform-support/riscv64im-unknown-none-elf.md
+++ b/src/doc/rustc/src/platform-support/riscv64im-unknown-none-elf.md
@@ -12,7 +12,7 @@ Bare-metal target for RISC-V CPUs with the RV64IM ISA.
 
 This target is cross-compiled and uses static linking. The target supports `core` and `alloc`, but not `std`.
 
-The target does not support atomic compare-and-swap operations, as the RV64IM ISA lacks the "A" (Atomics) extension. Atomic operations are emulated using the `+forced-atomics` feature.
+As the RV64IM ISA lacks the "A" (Atomics) extension, atomic operations are emulated using the `+forced-atomics` feature.
 
 No external toolchain is required and the default `rust-lld` linker works, but you must specify a linker script. The [`riscv-rt`] crate provides suitable linker scripts. The [`riscv-rust-quickstart`] repository gives examples of RISC-V bare-metal projects.
 
@@ -21,33 +21,26 @@ No external toolchain is required and the default `rust-lld` linker works, but y
 
 ## Building the target
 
-This target is included in Rust and can be installed via `rustup`:
+You can build Rust with support for the target by adding it to the `target` list in `bootstrap.toml`:
+
+```toml
+[build]
+target = ["riscv64im-unknown-none-elf"]
+```
+
+Alternatively, you can use the `-Z build-std` flag to build the standard library on-demand:
 
 ```bash
-rustup target add riscv64im-unknown-none-elf
+cargo build -Z build-std=core,alloc --target riscv64im-unknown-none-elf
 ```
 
 ## Building Rust programs
 
-Build using the standard Cargo workflow:
-
-```bash
-cargo build --target riscv64im-unknown-none-elf
-```
-
-You will need to provide a linker script. The [`riscv-rt`] crate handles this automatically when used as a dependency.
+Rust does not yet ship pre-compiled artifacts for this target. To compile for this target (see "Building the target" above)
 
 ## Testing
 
 This is a cross-compiled `no-std` target, which must be run either in a simulator or by programming onto suitable hardware. It is not possible to run the Rust test-suite on this target.
-
-You can test the target in QEMU with:
-
-```bash
-qemu-system-riscv64 -machine virt -cpu rv64,a=false,c=false -nographic -semihosting -kernel your-binary
-```
-
-Note: You must explicitly disable the 'a' (atomics) and 'c' (compressed) extensions when using QEMU to accurately emulate an RV64IM-only CPU.
 
 ## Cross-compilation toolchains and C code
 

--- a/src/doc/rustc/src/platform-support/riscv64im-unknown-none-elf.md
+++ b/src/doc/rustc/src/platform-support/riscv64im-unknown-none-elf.md
@@ -1,0 +1,54 @@
+# `riscv64im-unknown-none-elf`
+
+**Tier: 3**
+
+Bare-metal target for RISC-V CPUs with the RV64IM ISA.
+
+## Target maintainers
+
+* Rust Embedded Working Group, [RISC-V team](https://github.com/rust-embedded/wg#the-risc-v-team)
+
+## Requirements
+
+This target is cross-compiled and uses static linking. The target supports `core` and `alloc`, but not `std`.
+
+The target does not support atomic compare-and-swap operations, as the RV64IM ISA lacks the "A" (Atomics) extension. Atomic operations are emulated using the `+forced-atomics` feature.
+
+No external toolchain is required and the default `rust-lld` linker works, but you must specify a linker script. The [`riscv-rt`] crate provides suitable linker scripts. The [`riscv-rust-quickstart`] repository gives examples of RISC-V bare-metal projects.
+
+[`riscv-rt`]: https://crates.io/crates/riscv-rt
+[`riscv-rust-quickstart`]: https://github.com/riscv-rust/riscv-rust-quickstart
+
+## Building the target
+
+This target is included in Rust and can be installed via `rustup`:
+
+```bash
+rustup target add riscv64im-unknown-none-elf
+```
+
+## Building Rust programs
+
+Build using the standard Cargo workflow:
+
+```bash
+cargo build --target riscv64im-unknown-none-elf
+```
+
+You will need to provide a linker script. The [`riscv-rt`] crate handles this automatically when used as a dependency.
+
+## Testing
+
+This is a cross-compiled `no-std` target, which must be run either in a simulator or by programming onto suitable hardware. It is not possible to run the Rust test-suite on this target.
+
+You can test the target in QEMU with:
+
+```bash
+qemu-system-riscv64 -machine virt -cpu rv64,a=false,c=false -nographic -semihosting -kernel your-binary
+```
+
+Note: You must explicitly disable the 'a' (atomics) and 'c' (compressed) extensions when using QEMU to accurately emulate an RV64IM-only CPU.
+
+## Cross-compilation toolchains and C code
+
+This target supports C code. If interlinking with C or C++, you may need to use `riscv64-unknown-elf-gcc` with the appropriate `-march=rv64im -mabi=lp64` flags as a linker instead of `rust-lld`.

--- a/tests/assembly-llvm/targets/targets-elf.rs
+++ b/tests/assembly-llvm/targets/targets-elf.rs
@@ -520,6 +520,9 @@
 //@ revisions: riscv64gc_unknown_redox
 //@ [riscv64gc_unknown_redox] compile-flags: --target riscv64gc-unknown-redox
 //@ [riscv64gc_unknown_redox] needs-llvm-components: riscv
+//@ revisions: riscv64im_unknown_none_elf
+//@ [riscv64im_unknown_none_elf] compile-flags: --target riscv64im-unknown-none-elf
+//@ [riscv64im_unknown_none_elf] needs-llvm-components: riscv
 //@ revisions: riscv64imac_unknown_none_elf
 //@ [riscv64imac_unknown_none_elf] compile-flags: --target riscv64imac-unknown-none-elf
 //@ [riscv64imac_unknown_none_elf] needs-llvm-components: riscv


### PR DESCRIPTION
This PR proposes to add riscv64im-unknown-none-elf, a subset of the already supported riscv64imac-unknown-none-elf.

The motivation behind this PR is that we want to standardize (most) zkVMs on riscv64im-none and riscv64ima-none. Having different variants of riscv extensions, also seems to be within expectation, atleast with respects to riscv32.  

Note: This does not mean that we will be able to remove [riscv32im-risc0-zkvm-elf](https://doc.rust-lang.org/rustc/platform-support/riscv32im-risc0-zkvm-elf.html) -- I am not aware of all of the dependents for this

**Tier-3 Policy**

> A tier 3 target must have a designated developer or developers (the "target maintainers") on record to be CCed when issues arise regarding the target. (The mechanism to track and CC such developers may evolve over time.)

I assigned  Rust Embedded Working Group, since they are already maintaining riscv64IMAC, though I am happy to assign myself.

> Targets must use naming consistent with any existing targets; for instance, a target for the same CPU or OS as an existing Rust target should use the same name for that CPU or OS. Targets should normally use the same names and naming conventions as used elsewhere in the broader ecosystem beyond Rust (such as in other toolchains), unless they have a very good reason to diverge. Changing the name of a target can be highly disruptive, especially once the target reaches a higher tier, so getting the name right is important even for a tier 3 target.

It follows the naming convention of the other bare metal riscv targets

> Tier 3 targets may have unusual requirements to build or use, but must not create legal issues or impose onerous legal terms for the Rust project or for Rust developers or users.

This has the same requirements as riscv{32, 64}imac

> Neither this policy nor any decisions made regarding targets shall create any binding agreement or estoppel by any party. If any member of an approving Rust team serves as one of the maintainers of a target, or has any legal or employment requirement (explicit or implicit) that might affect their decisions regarding a target, they must recuse themselves from any approval decisions regarding the target's tier status, though they may otherwise participate in discussions.

> Tier 3 targets should attempt to implement as much of the standard libraries as possible and appropriate (core for most targets, alloc for targets that can support dynamic memory allocation, std for targets with an operating system or equivalent layer of system-provided functionality), but may leave some code unimplemented (either unavailable or stubbed out as appropriate), whether because the target makes it impossible to implement or challenging to implement. The authors of pull requests are not obligated to avoid calling any portions of the standard library on the basis of a tier 3 target not implementing those portions.

> The target must provide documentation for the Rust community explaining how to build for the target, using cross-compilation if possible. If the target supports running binaries, or running tests (even if they do not pass), the documentation must explain how to run such binaries or tests for the target, using emulation if possible or dedicated hardware if necessary.

> Tier 3 targets must not impose burden on the authors of pull requests, or other developers in the community, to maintain the target. In particular, do not post comments (automated or manual) on a PR that derail or suggest a block on the PR based on a tier 3 target. Do not send automated messages or notifications (via any medium, including via @) to a PR author or others involved with a PR regarding a tier 3 target, unless they have opted into such messages.

> Patches adding or updating tier 3 targets must not break any existing tier 2 or tier 1 target, and must not knowingly break another tier 3 target without approval of either the compiler team or the maintainers of the other tier 3 target.

> Tier 3 targets must be able to produce assembly using at least one of rustc's supported backends from any host target. (Having support in a fork of the backend is not sufficient, it must be upstream.)

Acknowledging the above.
