### PR TITLE
fix "is_closure_like" doc comment

### DIFF
--- a/compiler/rustc_middle/src/ty/util.rs
+++ b/compiler/rustc_middle/src/ty/util.rs
@@ -607,9 +607,9 @@ impl<'tcx> TyCtxt<'tcx> {
     /// have the same `DefKind`.
     ///
     /// Note that closures have a `DefId`, but the closure *expression* also has a
-    // `HirId` that is located within the context where the closure appears (and, sadly,
-    // a corresponding `NodeId`, since those are not yet phased out). The parent of
-    // the closure's `DefId` will also be the context where it appears.
+    /// `HirId` that is located within the context where the closure appears (and, sadly,
+    /// a corresponding `NodeId`, since those are not yet phased out). The parent of
+    /// the closure's `DefId` will also be the context where it appears.
     pub fn is_closure_like(self, def_id: DefId) -> bool {
         matches!(self.def_kind(def_id), DefKind::Closure)
     }


### PR DESCRIPTION
Noticed that the [docs](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/ty/struct.TyCtxt.html#method.is_closure_like) stopped in the middle of the sentence. The text exists, but wasn't rendered because it was a regular comment.
