### PR TITLE
feat: Add `bit_width` for unsigned `NonZero<T>`

### DIFF
--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -1777,6 +1777,30 @@ macro_rules! nonzero_integer_signedness_dependent_methods {
             // SAFETY: `self.get()` can't be zero
             unsafe { NonZero::new_unchecked(self.get().cast_signed()) }
         }
+
+        /// Returns the minimum number of bits required to represent `self`.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// #![feature(uint_bit_width)]
+        ///
+        /// # use core::num::NonZero;
+        /// #
+        /// # fn main() { test().unwrap(); }
+        /// # fn test() -> Option<()> {
+        #[doc = concat!("assert_eq!(NonZero::<", stringify!($Int), ">::new(0b111)?.bit_width(), 3);")]
+        #[doc = concat!("assert_eq!(NonZero::<", stringify!($Int), ">::new(0b1110)?.bit_width(), 4);")]
+        /// # Some(())
+        /// # }
+        /// ```
+        #[unstable(feature = "uint_bit_width", issue = "142326")]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[inline(always)]
+        pub const fn bit_width(self) -> u32 {
+            Self::BITS - self.leading_zeros()
+        }
     };
 
     // Associated items for signed nonzero types only.

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -1789,8 +1789,9 @@ macro_rules! nonzero_integer_signedness_dependent_methods {
         /// #
         /// # fn main() { test().unwrap(); }
         /// # fn test() -> Option<()> {
-        #[doc = concat!("assert_eq!(NonZero::<", stringify!($Int), ">::new(0b111)?.bit_width(), 3);")]
-        #[doc = concat!("assert_eq!(NonZero::<", stringify!($Int), ">::new(0b1110)?.bit_width(), 4);")]
+        #[doc = concat!("assert_eq!(NonZero::<", stringify!($Int), ">::MIN.bit_width(), NonZero::new(1)?);")]
+        #[doc = concat!("assert_eq!(NonZero::<", stringify!($Int), ">::new(0b111)?.bit_width(), NonZero::new(3)?);")]
+        #[doc = concat!("assert_eq!(NonZero::<", stringify!($Int), ">::new(0b1110)?.bit_width(), NonZero::new(4)?);")]
         /// # Some(())
         /// # }
         /// ```
@@ -1798,8 +1799,10 @@ macro_rules! nonzero_integer_signedness_dependent_methods {
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline(always)]
-        pub const fn bit_width(self) -> u32 {
-            Self::BITS - self.leading_zeros()
+        pub const fn bit_width(self) -> NonZero<u32> {
+            // SAFETY: Since `self.leading_zeros()` is always less than
+            // `Self::BITS`, this subtraction can never be zero.
+            unsafe { NonZero::new_unchecked(Self::BITS - self.leading_zeros()) }
         }
     };
 

--- a/library/coretests/tests/nonzero.rs
+++ b/library/coretests/tests/nonzero.rs
@@ -570,3 +570,21 @@ fn test_nonzero_lowest_one() {
     nonzero_int_impl!(i8, i16, i32, i64, i128, isize);
     nonzero_uint_impl!(u8, u16, u32, u64, u128, usize);
 }
+
+#[test]
+fn test_nonzero_bit_width() {
+    macro_rules! nonzero_uint_impl {
+        ($($T:ty),+) => {
+            $(
+                {
+                    assert_eq!(NonZero::<$T>::new(0b010_1100).unwrap().bit_width(), 6);
+                    assert_eq!(NonZero::<$T>::new(0b111_1001).unwrap().bit_width(), 7);
+                    assert_eq!(NonZero::<$T>::MIN.bit_width(), 1);
+                    assert_eq!(NonZero::<$T>::MAX.bit_width(), <$T>::BITS);
+                }
+            )+
+        };
+    }
+
+    nonzero_uint_impl!(u8, u16, u32, u64, u128, usize);
+}

--- a/library/coretests/tests/nonzero.rs
+++ b/library/coretests/tests/nonzero.rs
@@ -577,10 +577,10 @@ fn test_nonzero_bit_width() {
         ($($T:ty),+) => {
             $(
                 {
-                    assert_eq!(NonZero::<$T>::new(0b010_1100).unwrap().bit_width(), 6);
-                    assert_eq!(NonZero::<$T>::new(0b111_1001).unwrap().bit_width(), 7);
-                    assert_eq!(NonZero::<$T>::MIN.bit_width(), 1);
-                    assert_eq!(NonZero::<$T>::MAX.bit_width(), <$T>::BITS);
+                    assert_eq!(NonZero::<$T>::new(0b010_1100).unwrap().bit_width(), NonZero::new(6).unwrap());
+                    assert_eq!(NonZero::<$T>::new(0b111_1001).unwrap().bit_width(), NonZero::new(7).unwrap());
+                    assert_eq!(NonZero::<$T>::MIN.bit_width(), NonZero::new(1).unwrap());
+                    assert_eq!(NonZero::<$T>::MAX.bit_width(), NonZero::new(<$T>::BITS).unwrap());
                 }
             )+
         };


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

- Tracking issue: rust-lang/rust#142326

This pull request adds a method to the unsigned `NonZero<T>` that return the minimum number of bits required to represent a value.

This can be achieved by using the `get` method and the methods added in rust-lang/rust#142328, but I think adding the `NonZero::bit_width` method is useful because it accomplishes the same thing a little more succinctly.