### PR TITLE
Build with -Zannotate-moves by default (non-stage-0 only)

### DIFF
--- a/bootstrap.example.toml
+++ b/bootstrap.example.toml
@@ -831,6 +831,11 @@
 # If an explicit setting is given, it will be used for all parts of the codebase.
 #rust.new-symbol-mangling = true|false (see comment)
 
+# Size limit in bytes for move/copy annotations (-Zannotate-moves). Only types
+# at or above this size will be annotated. If not specified, uses the default
+# limit (65 bytes).
+#rust.annotate-moves-size-limit = 65
+
 # Select LTO mode that will be used for compiling rustc. By default, thin local LTO
 # (LTO within a single crate) is used (like for any Rust crate). You can also select
 # "thin" or "fat" to apply Thin/Fat LTO to the `rustc_driver` dylib, or "off" to disable

--- a/src/bootstrap/src/core/builder/cargo.rs
+++ b/src/bootstrap/src/core/builder/cargo.rs
@@ -673,6 +673,16 @@ impl Builder<'_> {
             rustflags.arg("-Csymbol-mangling-version=legacy");
         }
 
+        // Always enable move/copy annotations for profiler visibility (non-stage0 only).
+        // Note that -Zannotate-moves is only effective with debugging info enabled.
+        if build_compiler_stage >= 1 {
+            if let Some(limit) = self.config.rust_annotate_moves_size_limit {
+                rustflags.arg(&format!("-Zannotate-moves={limit}"));
+            } else {
+                rustflags.arg("-Zannotate-moves");
+            }
+        }
+
         // FIXME: the following components don't build with `-Zrandomize-layout` yet:
         // - rust-analyzer, due to the rowan crate
         // so we exclude an entire category of steps here due to lack of fine-grained control over

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -217,6 +217,7 @@ pub struct Config {
     pub rust_randomize_layout: bool,
     pub rust_remap_debuginfo: bool,
     pub rust_new_symbol_mangling: Option<bool>,
+    pub rust_annotate_moves_size_limit: Option<u64>,
     pub rust_profile_use: Option<String>,
     pub rust_profile_generate: Option<String>,
     pub rust_lto: RustcLto,
@@ -561,6 +562,7 @@ impl Config {
             control_flow_guard: rust_control_flow_guard,
             ehcont_guard: rust_ehcont_guard,
             new_symbol_mangling: rust_new_symbol_mangling,
+            annotate_moves_size_limit: rust_annotate_moves_size_limit,
             profile_generate: rust_profile_generate,
             profile_use: rust_profile_use,
             download_rustc: rust_download_rustc,
@@ -1405,6 +1407,7 @@ impl Config {
             reproducible_artifacts: flags_reproducible_artifact,
             reuse: build_reuse.map(PathBuf::from),
             rust_analyzer_info,
+            rust_annotate_moves_size_limit,
             rust_break_on_ice: rust_break_on_ice.unwrap_or(true),
             rust_codegen_backends: rust_codegen_backends
                 .map(|backends| parse_codegen_backends(backends, "rust"))

--- a/src/bootstrap/src/core/config/toml/rust.rs
+++ b/src/bootstrap/src/core/config/toml/rust.rs
@@ -60,6 +60,7 @@ define_config! {
         control_flow_guard: Option<bool> = "control-flow-guard",
         ehcont_guard: Option<bool> = "ehcont-guard",
         new_symbol_mangling: Option<bool> = "new-symbol-mangling",
+        annotate_moves_size_limit: Option<u64> = "annotate-moves-size-limit",
         profile_generate: Option<String> = "profile-generate",
         profile_use: Option<String> = "profile-use",
         // ignored; this is set from an env var set by bootstrap.py
@@ -364,6 +365,7 @@ pub fn check_incompatible_options_for_ci_rustc(
         control_flow_guard: _,
         ehcont_guard: _,
         new_symbol_mangling: _,
+        annotate_moves_size_limit: _,
         profile_generate: _,
         profile_use: _,
         download_rustc: _,

--- a/src/bootstrap/src/utils/change_tracker.rs
+++ b/src/bootstrap/src/utils/change_tracker.rs
@@ -591,4 +591,9 @@ pub const CONFIG_CHANGE_HISTORY: &[ChangeInfo] = &[
         severity: ChangeSeverity::Info,
         summary: "`yarn` is now used instead of `npm` to install dependencies for some extra tidy checks. Use `build.yarn` to manually specify the path to `yarn` (`build.npm` is no longer used).",
     },
+    ChangeInfo {
+        change_id: 148803,
+        severity: ChangeSeverity::Info,
+        summary: "The `-Zannotate-moves` option is now always enabled when building rustc, sysroot and tools.",
+    },
 ];


### PR DESCRIPTION
Build rustc and tools with -Zannotate-moves by default, both to exercise the feature and because could be useful for doing performance measurement on rustc and its tools. This has no effect on generated code, it just adds extra debug info in
the form of some new inlined functions.

This also adds bootstrap.toml config options 
```
# rust.annotate-moves = true
# rust.annotate-moves-size-limit = 65
```
to allow this to be controlled locally.

This is only added for stage 1 and later. Stage 0 (the bootstrap compiler) doesn't yet support -Zannotate-moves.

<!-- homu-ignore:start -->
https://github.com/rust-lang/rust/issues/148197
<!-- homu-ignore:end -->
