### PR TITLE
Remove specialized warning for removed target

### DIFF
--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -3194,15 +3194,7 @@ impl Target {
                     return load_file(&p);
                 }
 
-                // Leave in a specialized error message for the removed target.
-                // FIXME: If you see this and it's been a few months after this has been released,
-                // you can probably remove it.
-                if target_tuple == "i586-pc-windows-msvc" {
-                    Err("the `i586-pc-windows-msvc` target has been removed. Use the `i686-pc-windows-msvc` target instead.\n\
-                        Windows 10 (the minimum required OS version) requires a CPU baseline of at least i686 so you can safely switch".into())
-                } else {
-                    Err(format!("could not find specification for target {target_tuple:?}"))
-                }
+                Err(format!("could not find specification for target {target_tuple:?}"))
             }
             TargetTuple::TargetJson { ref contents, .. } => Target::from_json(contents),
         }


### PR DESCRIPTION
It has been removed 9 months ago, which is more than a few months.