### PR TITLE
Add very basic "comptime" fn implementation

### DIFF
--- a/compiler/rustc_ast_lowering/src/diagnostics.rs
+++ b/compiler/rustc_ast_lowering/src/diagnostics.rs
@@ -123,6 +123,17 @@ pub(crate) struct AwaitOnlyInAsyncFnAndBlocks {
 }
 
 #[derive(Diagnostic)]
+#[diag("a function cannot be both `comptime` and `const`")]
+pub(crate) struct ConstComptimeFn {
+    #[primary_span]
+    #[suggestion("remove the `const`", applicability = "machine-applicable", code = "")]
+    #[note("`const` implies the function can be called at runtime, too")]
+    pub span: Span,
+    #[label("`comptime` because of this")]
+    pub attr_span: Span,
+}
+
+#[derive(Diagnostic)]
 #[diag("too many parameters for a coroutine (expected 0 or 1 parameters)", code = E0628)]
 pub(crate) struct CoroutineTooManyParameters {
     #[primary_span]

--- a/compiler/rustc_ast_lowering/src/item.rs
+++ b/compiler/rustc_ast_lowering/src/item.rs
@@ -27,6 +27,7 @@ use super::{
     AstOwner, FnDeclKind, GenericArgsMode, ImplTraitContext, ImplTraitPosition, LoweringContext,
     ParamMode, RelaxedBoundForbiddenReason, RelaxedBoundPolicy, ResolverAstLoweringExt,
 };
+use crate::diagnostics::ConstComptimeFn;
 
 /// Wraps either IndexVec (during `hir_crate`), which acts like a primary
 /// storage for most of the MaybeOwners, or FxIndexMap during delayed AST -> HIR
@@ -1773,12 +1774,23 @@ impl<'hir> LoweringContext<'_, 'hir> {
             safety.into()
         };
 
-        hir::FnHeader {
-            safety,
-            asyncness,
-            constness: self.lower_constness(h.constness),
-            abi: self.lower_extern(h.ext),
+        let mut constness = self.lower_constness(h.constness);
+        if let Some(&attr_span) = find_attr!(attrs, RustcComptime(span) => span) {
+            match std::mem::replace(&mut constness, rustc_hir::Constness::Const { always: true }) {
+                rustc_hir::Constness::Const { always: true } => {
+                    unreachable!("lower_constness cannot produce comptime")
+                }
+                // A function can't be `const` and `comptime` at the same time
+                rustc_hir::Constness::Const { always: false } => {
+                    let Const::Yes(span) = h.constness else { unreachable!() };
+                    self.dcx().emit_err(ConstComptimeFn { span, attr_span });
+                }
+                // Good
+                rustc_hir::Constness::NotConst => {}
+            }
         }
+
+        hir::FnHeader { safety, asyncness, constness, abi: self.lower_extern(h.ext) }
     }
 
     pub(super) fn lower_abi(&mut self, abi_str: StrLit) -> ExternAbi {

--- a/compiler/rustc_ast_lowering/src/item.rs
+++ b/compiler/rustc_ast_lowering/src/item.rs
@@ -1840,7 +1840,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
 
     pub(super) fn lower_constness(&mut self, c: Const) -> hir::Constness {
         match c {
-            Const::Yes(_) => hir::Constness::Const,
+            Const::Yes(_) => hir::Constness::Const { always: false },
             Const::No => hir::Constness::NotConst,
         }
     }

--- a/compiler/rustc_attr_parsing/src/attributes/semantics.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/semantics.rs
@@ -9,3 +9,15 @@ impl NoArgsAttributeParser for MayDangleParser {
     const STABILITY: AttributeStability = unstable!(dropck_eyepatch);
     const CREATE: fn(span: Span) -> AttributeKind = AttributeKind::MayDangle;
 }
+
+pub(crate) struct ComptimeParser;
+impl NoArgsAttributeParser for ComptimeParser {
+    const PATH: &[Symbol] = &[sym::rustc_comptime];
+    const ON_DUPLICATE: OnDuplicate = OnDuplicate::Error;
+    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
+        Allow(Target::Method(MethodKind::Inherent)),
+        Allow(Target::Fn),
+    ]);
+    const STABILITY: AttributeStability = unstable!(rustc_attrs);
+    const CREATE: fn(Span) -> AttributeKind = AttributeKind::RustcComptime;
+}

--- a/compiler/rustc_attr_parsing/src/context.rs
+++ b/compiler/rustc_attr_parsing/src/context.rs
@@ -56,7 +56,7 @@ use crate::attributes::repr::*;
 use crate::attributes::rustc_allocator::*;
 use crate::attributes::rustc_dump::*;
 use crate::attributes::rustc_internal::*;
-use crate::attributes::semantics::*;
+use crate::attributes::semantics::{ComptimeParser, *};
 use crate::attributes::stability::*;
 use crate::attributes::test_attrs::*;
 use crate::attributes::traits::*;
@@ -234,6 +234,7 @@ attribute_parsers!(
         Single<WithoutArgs<AutomaticallyDerivedParser>>,
         Single<WithoutArgs<ColdParser>>,
         Single<WithoutArgs<CompilerBuiltinsParser>>,
+        Single<WithoutArgs<ComptimeParser>>,
         Single<WithoutArgs<ConstContinueParser>>,
         Single<WithoutArgs<CoroutineParser>>,
         Single<WithoutArgs<DefaultLibAllocatorParser>>,

--- a/compiler/rustc_const_eval/src/check_consts/check.rs
+++ b/compiler/rustc_const_eval/src/check_consts/check.rs
@@ -779,7 +779,8 @@ impl<'tcx> Visitor<'tcx> for Checker<'_, 'tcx> {
                     // to do different checks than usual.
 
                     trace!("attempting to call a trait method");
-                    let is_const = tcx.constness(callee) == hir::Constness::Const;
+                    let is_const =
+                        matches!(tcx.constness(callee), hir::Constness::Const { always: false });
 
                     // Only consider a trait to be const if the const conditions hold.
                     // Otherwise, it's really misleading to call something "conditionally"

--- a/compiler/rustc_const_eval/src/check_consts/ops.rs
+++ b/compiler/rustc_const_eval/src/check_consts/ops.rs
@@ -423,7 +423,8 @@ fn build_error_for_const_call<'tcx>(
                         err.help("const traits are not yet supported on stable Rust");
                     }
                 }
-            } else if ccx.tcx.constness(callee) != hir::Constness::Const {
+            } else if !matches!(ccx.tcx.constness(callee), hir::Constness::Const { always: false })
+            {
                 let name = ccx.tcx.item_name(callee);
                 err.span_note(
                     ccx.tcx.def_span(callee),

--- a/compiler/rustc_const_eval/src/const_eval/fn_queries.rs
+++ b/compiler/rustc_const_eval/src/const_eval/fn_queries.rs
@@ -11,13 +11,13 @@ fn constness(tcx: TyCtxt<'_>, def_id: LocalDefId) -> Constness {
     let node = tcx.hir_node_by_def_id(def_id);
 
     match node {
-        Node::Ctor(VariantData::Tuple(..)) => Constness::Const,
+        Node::Ctor(VariantData::Tuple(..)) => Constness::Const { always: false },
         Node::ForeignItem(item) if let ForeignItemKind::Fn(..) = item.kind => {
             // Foreign functions cannot be evaluated at compile-time.
             Constness::NotConst
         }
         Node::Expr(e) if let ExprKind::Closure(c) = e.kind => {
-            if let Constness::Const = c.constness && tcx.hir_body_const_context(tcx.local_parent(def_id)).is_none() {
+            if let Constness::Const { .. } = c.constness && tcx.hir_body_const_context(tcx.local_parent(def_id)).is_none() {
                 tcx.dcx().span_err(tcx.def_span(def_id), "cannot use `const` closures outside of const contexts");
                 return Constness::NotConst;
             }
@@ -37,7 +37,7 @@ fn constness(tcx: TyCtxt<'_>, def_id: LocalDefId) -> Constness {
             ..
         }) => {
             match sig.header.constness {
-                Constness::Const => Constness::Const,
+                Constness::Const { always } => Constness::Const { always },
                 // inherent impl could be const
                 Constness::NotConst => tcx.constness(tcx.local_parent(def_id)),
             }

--- a/compiler/rustc_feature/src/builtin_attrs.rs
+++ b/compiler/rustc_feature/src/builtin_attrs.rs
@@ -452,6 +452,7 @@ pub static BUILTIN_ATTRIBUTES: &[Symbol] = &[
     sym::rustc_no_implicit_autorefs,
     sym::rustc_coherence_is_core,
     sym::rustc_coinductive,
+    sym::rustc_comptime,
     sym::rustc_allow_incoherent_impl,
     sym::rustc_preserve_ub_checks,
     sym::rustc_deny_explicit_impl,

--- a/compiler/rustc_hir/src/attrs/data_structures.rs
+++ b/compiler/rustc_hir/src/attrs/data_structures.rs
@@ -1311,6 +1311,9 @@ pub enum AttributeKind {
     /// Represents `#[rustc_coinductive]`.
     RustcCoinductive,
 
+    /// Represents `#[rustc_comptime]`
+    RustcComptime(Span),
+
     /// Represents `#[rustc_confusables]`.
     RustcConfusables {
         confusables: ThinVec<Symbol>,

--- a/compiler/rustc_hir/src/attrs/encode_cross_crate.rs
+++ b/compiler/rustc_hir/src/attrs/encode_cross_crate.rs
@@ -112,6 +112,7 @@ impl AttributeKind {
             RustcClean { .. } => No,
             RustcCoherenceIsCore => No,
             RustcCoinductive => No,
+            RustcComptime(..) => No, // Encoded directly in signature
             RustcConfusables { .. } => Yes,
             RustcConstStability { .. } => Yes,
             RustcConstStableIndirect => No,

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -2467,10 +2467,12 @@ pub enum ConstContext {
     /// - Array length expressions
     /// - Enum discriminants
     /// - Const generics
-    ///
-    /// For the most part, other contexts are treated just like a regular `const`, so they are
-    /// lumped into the same category.
-    Const { inline: bool },
+    Const {
+        /// For backwards compatibility `const` items allow
+        /// calls to `const fn` to get promoted.
+        /// We forbid that in comptime fns and inline consts.
+        allow_const_fn_promotion: bool,
+    },
 }
 
 impl ConstContext {

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -4705,10 +4705,6 @@ impl FnHeader {
         matches!(self.asyncness, IsAsync::Async(_))
     }
 
-    pub fn is_const(&self) -> bool {
-        matches!(self.constness, Constness::Const { .. })
-    }
-
     pub fn is_unsafe(&self) -> bool {
         self.safety().is_unsafe()
     }

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -4632,17 +4632,24 @@ impl fmt::Display for Safety {
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Encodable, Decodable, StableHash)]
-#[derive(Default)]
 pub enum Constness {
-    #[default]
-    Const,
+    Const { always: bool },
     NotConst,
+}
+
+/// This impl exists as an optimization so that metadata deserialization can
+/// store the value directly and not have to encode it wrapped in another `Option`.
+impl Default for Constness {
+    fn default() -> Self {
+        Self::Const { always: false }
+    }
 }
 
 impl fmt::Display for Constness {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(match *self {
-            Self::Const => "const",
+            Self::Const { always: true } => "comptime",
+            Self::Const { always: false } => "const",
             Self::NotConst => "non-const",
         })
     }
@@ -4697,7 +4704,7 @@ impl FnHeader {
     }
 
     pub fn is_const(&self) -> bool {
-        matches!(self.constness, Constness::Const)
+        matches!(self.constness, Constness::Const { .. })
     }
 
     pub fn is_unsafe(&self) -> bool {

--- a/compiler/rustc_hir_pretty/src/lib.rs
+++ b/compiler/rustc_hir_pretty/src/lib.rs
@@ -716,7 +716,7 @@ impl<'a> State<'a> {
 
                 match of_trait {
                     None => {
-                        if let hir::Constness::Const = constness {
+                        if let hir::Constness::Const { always: false } = constness {
                             self.word_nbsp("const");
                         }
                         impl_generics(self)
@@ -733,7 +733,7 @@ impl<'a> State<'a> {
 
                         impl_generics(self);
 
-                        if let hir::Constness::Const = constness {
+                        if let hir::Constness::Const { always: false } = constness {
                             self.word_nbsp("const");
                         }
 
@@ -2623,7 +2623,8 @@ impl<'a> State<'a> {
     fn print_constness(&mut self, s: hir::Constness) {
         match s {
             hir::Constness::NotConst => {}
-            hir::Constness::Const => self.word_nbsp("const"),
+            hir::Constness::Const { always: false } => self.word_nbsp("const"),
+            hir::Constness::Const { always: true } => { /* printed as an attribute */ }
         }
     }
 

--- a/compiler/rustc_hir_typeck/src/callee.rs
+++ b/compiler/rustc_hir_typeck/src/callee.rs
@@ -1024,6 +1024,17 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         callee_did: DefId,
         callee_args: GenericArgsRef<'tcx>,
     ) {
+        let const_context = self.tcx.hir_body_const_context(self.body_id);
+
+        if let hir::Constness::Const { always: true } = self.tcx.constness(callee_did) {
+            match const_context {
+                Some(hir::ConstContext::Const { .. } | hir::ConstContext::Static(_)) => {}
+                Some(hir::ConstContext::ConstFn) | None => {
+                    self.dcx().span_err(span, "comptime fns can only be called at compile time");
+                }
+            }
+        }
+
         // FIXME(const_trait_impl): We should be enforcing these effects unconditionally.
         // This can be done as soon as we convert the standard library back to
         // using const traits, since if we were to enforce these conditions now,
@@ -1037,7 +1048,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             return;
         }
 
-        let host = match self.tcx.hir_body_const_context(self.body_id) {
+        let host = match const_context {
             Some(hir::ConstContext::Const { .. } | hir::ConstContext::Static(_)) => {
                 ty::BoundConstness::Const
             }

--- a/compiler/rustc_metadata/src/rmeta/table.rs
+++ b/compiler/rustc_metadata/src/rmeta/table.rs
@@ -225,8 +225,9 @@ defaulted_enum! {
 
 defaulted_enum! {
     hir::Constness {
-        ( Const    )
+        ( Const { always: false } )
         ( NotConst )
+        ( Const { always: true } )
     }
 }
 

--- a/compiler/rustc_middle/src/hir/map.rs
+++ b/compiler/rustc_middle/src/hir/map.rs
@@ -346,13 +346,15 @@ impl<'tcx> TyCtxt<'tcx> {
     pub fn hir_body_const_context(self, local_def_id: LocalDefId) -> Option<ConstContext> {
         let def_id = local_def_id.into();
         let ccx = match self.hir_body_owner_kind(def_id) {
-            BodyOwnerKind::Const { inline } => ConstContext::Const { inline },
+            BodyOwnerKind::Const { inline } => {
+                ConstContext::Const { allow_const_fn_promotion: !inline }
+            }
             BodyOwnerKind::Static(mutability) => ConstContext::Static(mutability),
 
             BodyOwnerKind::Fn if self.is_constructor(def_id) => return None,
             BodyOwnerKind::Fn | BodyOwnerKind::Closure if self.is_const_fn(def_id) => {
                 if matches!(self.constness(def_id), rustc_hir::Constness::Const { always: true }) {
-                    ConstContext::Const { inline: true }
+                    ConstContext::Const { allow_const_fn_promotion: false }
                 } else {
                     ConstContext::ConstFn
                 }

--- a/compiler/rustc_middle/src/hir/map.rs
+++ b/compiler/rustc_middle/src/hir/map.rs
@@ -351,7 +351,11 @@ impl<'tcx> TyCtxt<'tcx> {
 
             BodyOwnerKind::Fn if self.is_constructor(def_id) => return None,
             BodyOwnerKind::Fn | BodyOwnerKind::Closure if self.is_const_fn(def_id) => {
-                ConstContext::ConstFn
+                if matches!(self.constness(def_id), rustc_hir::Constness::Const { always: true }) {
+                    ConstContext::Const { inline: true }
+                } else {
+                    ConstContext::ConstFn
+                }
             }
             BodyOwnerKind::Fn | BodyOwnerKind::Closure | BodyOwnerKind::GlobalAsm => return None,
         };

--- a/compiler/rustc_middle/src/ty/adt.rs
+++ b/compiler/rustc_middle/src/ty/adt.rs
@@ -311,7 +311,8 @@ impl<'tcx> rustc_type_ir::inherent::AdtDef<TyCtxt<'tcx>> for AdtDef<'tcx> {
 
     fn destructor(self, tcx: TyCtxt<'tcx>) -> Option<AdtDestructorKind> {
         Some(match tcx.constness(self.destructor(tcx)?.did) {
-            hir::Constness::Const => AdtDestructorKind::Const,
+            hir::Constness::Const { always: true } => todo!("FIXME(comptime)"),
+            hir::Constness::Const { always: false } => AdtDestructorKind::Const,
             hir::Constness::NotConst => AdtDestructorKind::NotConst,
         })
     }

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -2666,7 +2666,10 @@ impl<'tcx> TyCtxt<'tcx> {
     /// Whether the trait impl is marked const. This does not consider stability or feature gates.
     pub fn is_const_trait_impl(self, def_id: DefId) -> bool {
         self.def_kind(def_id) == DefKind::Impl { of_trait: true }
-            && self.impl_trait_header(def_id).constness == hir::Constness::Const
+            && matches!(
+                self.impl_trait_header(def_id).constness,
+                hir::Constness::Const { always: false }
+            )
     }
 
     pub fn is_sdylib_interface_build(self) -> bool {

--- a/compiler/rustc_middle/src/ty/context/impl_interner.rs
+++ b/compiler/rustc_middle/src/ty/context/impl_interner.rs
@@ -455,7 +455,7 @@ impl<'tcx> Interner for TyCtxt<'tcx> {
 
     fn closure_is_const(self, def_id: DefId) -> bool {
         debug_assert_matches!(self.def_kind(def_id), DefKind::Closure);
-        self.constness(def_id) == hir::Constness::Const
+        matches!(self.constness(def_id), hir::Constness::Const { always: false })
     }
 
     fn alias_has_const_conditions(self, def_id: DefId) -> bool {

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -2141,7 +2141,7 @@ impl<'tcx> TyCtxt<'tcx> {
         matches!(
             self.def_kind(def_id),
             DefKind::Fn | DefKind::AssocFn | DefKind::Ctor(_, CtorKind::Fn) | DefKind::Closure
-        ) && self.constness(def_id) == hir::Constness::Const
+        ) && matches!(self.constness(def_id), hir::Constness::Const { .. })
     }
 
     /// Whether this item is conditionally constant for the purposes of the
@@ -2155,12 +2155,14 @@ impl<'tcx> TyCtxt<'tcx> {
         match self.def_kind(def_id) {
             DefKind::Impl { of_trait: true } => {
                 let header = self.impl_trait_header(def_id);
-                header.constness == hir::Constness::Const
+                matches!(header.constness, hir::Constness::Const { always: false })
                     && self.is_const_trait(header.trait_ref.skip_binder().def_id)
             }
-            DefKind::Impl { of_trait: false } => self.constness(def_id) == hir::Constness::Const,
+            DefKind::Impl { of_trait: false } => {
+                matches!(self.constness(def_id), hir::Constness::Const { always: false })
+            }
             DefKind::Fn | DefKind::Ctor(_, CtorKind::Fn) => {
-                self.constness(def_id) == hir::Constness::Const
+                matches!(self.constness(def_id), hir::Constness::Const { always: false })
             }
             DefKind::TraitAlias | DefKind::Trait => self.is_const_trait(def_id),
             DefKind::AssocTy => {
@@ -2177,17 +2179,19 @@ impl<'tcx> TyCtxt<'tcx> {
                 let parent_def_id = self.parent(def_id);
                 match self.def_kind(parent_def_id) {
                     DefKind::Impl { of_trait: false } => {
-                        self.constness(def_id) == hir::Constness::Const
+                        matches!(self.constness(def_id), hir::Constness::Const { always: false })
                     }
                     DefKind::Impl { of_trait: true } => {
                         let Some(trait_method_did) = self.trait_item_of(def_id) else {
                             return false;
                         };
-                        self.constness(trait_method_did) == hir::Constness::Const
-                            && self.is_conditionally_const(parent_def_id)
+                        matches!(
+                            self.constness(trait_method_did),
+                            hir::Constness::Const { always: false }
+                        ) && self.is_conditionally_const(parent_def_id)
                     }
                     DefKind::Trait => {
-                        self.constness(def_id) == hir::Constness::Const
+                        matches!(self.constness(def_id), hir::Constness::Const { always: false })
                             && self.is_conditionally_const(parent_def_id)
                     }
                     _ => bug!("unexpected parent item of associated fn: {parent_def_id:?}"),
@@ -2199,7 +2203,9 @@ impl<'tcx> TyCtxt<'tcx> {
                 // FIXME(const_trait_impl): ATPITs could be conditionally const?
                 hir::OpaqueTyOrigin::TyAlias { .. } => false,
             },
-            DefKind::Closure => self.constness(def_id) == hir::Constness::Const,
+            DefKind::Closure => {
+                matches!(self.constness(def_id), hir::Constness::Const { always: false })
+            }
             DefKind::Ctor(_, CtorKind::Const)
             | DefKind::Mod
             | DefKind::Struct
@@ -2228,7 +2234,7 @@ impl<'tcx> TyCtxt<'tcx> {
 
     #[inline]
     pub fn is_const_trait(self, def_id: DefId) -> bool {
-        self.trait_def(def_id).constness == hir::Constness::Const
+        matches!(self.trait_def(def_id).constness, hir::Constness::Const { .. })
     }
 
     pub fn impl_method_has_trait_impl_trait_tys(self, def_id: DefId) -> bool {

--- a/compiler/rustc_mir_transform/src/lib.rs
+++ b/compiler/rustc_mir_transform/src/lib.rs
@@ -259,8 +259,12 @@ fn remap_mir_for_const_eval_select<'tcx>(
                 let ty = tupled_args.node.ty(&body.local_decls, tcx);
                 let fields = ty.tuple_fields();
                 let num_args = fields.len();
-                let func =
-                    if context == hir::Constness::Const { called_in_const } else { called_at_rt };
+                let func = match context {
+                    // Using `const_eval_select` in always-const code is useful when used in macros
+                    // that you don't know whether they are going to be used in `const fn` or in `const` items.
+                    hir::Constness::Const { .. } => called_in_const,
+                    hir::Constness::NotConst => called_at_rt,
+                };
                 let (method, place): (fn(Place<'tcx>) -> Operand<'tcx>, Place<'tcx>) =
                     match tupled_args.node {
                         Operand::Constant(_) | Operand::RuntimeChecks(_) => {
@@ -432,7 +436,7 @@ fn mir_promoted(
 
     let const_qualifs = match tcx.def_kind(def) {
         DefKind::Fn | DefKind::AssocFn | DefKind::Closure
-            if tcx.constness(def) == hir::Constness::Const =>
+            if matches!(tcx.constness(def), hir::Constness::Const { .. }) =>
         {
             tcx.mir_const_qualif(def)
         }
@@ -496,15 +500,17 @@ fn inner_mir_for_ctfe(tcx: TyCtxt<'_>, def: LocalDefId) -> Body<'_> {
     }
 
     let body = tcx.mir_drops_elaborated_and_const_checked(def);
-    let body = match tcx.hir_body_const_context(def) {
+    let (body, always) = match tcx.hir_body_const_context(def) {
         // consts and statics do not have `optimized_mir`, so we can steal the body instead of
         // cloning it.
-        Some(hir::ConstContext::Const { .. } | hir::ConstContext::Static(_)) => body.steal(),
-        Some(hir::ConstContext::ConstFn) => body.borrow().clone(),
+        Some(hir::ConstContext::Const { .. } | hir::ConstContext::Static(_)) => {
+            (body.steal(), true)
+        }
+        Some(hir::ConstContext::ConstFn) => (body.borrow().clone(), false),
         None => bug!("`mir_for_ctfe` called on non-const {def:?}"),
     };
 
-    let mut body = remap_mir_for_const_eval_select(tcx, body, hir::Constness::Const);
+    let mut body = remap_mir_for_const_eval_select(tcx, body, hir::Constness::Const { always });
     pm::run_passes(tcx, &mut body, &[&ctfe_limit::CtfeLimit], None, pm::Optimizations::Allowed);
 
     body

--- a/compiler/rustc_mir_transform/src/promote_consts.rs
+++ b/compiler/rustc_mir_transform/src/promote_consts.rs
@@ -659,7 +659,10 @@ impl<'tcx> Validator<'_, 'tcx> {
         // backwards compatibility reason to allow more promotion inside of them.
         let promote_all_fn = matches!(
             self.const_kind,
-            Some(hir::ConstContext::Static(_) | hir::ConstContext::Const { inline: false })
+            Some(
+                hir::ConstContext::Static(_)
+                    | hir::ConstContext::Const { allow_const_fn_promotion: true }
+            )
         );
         if !promote_all_fn {
             return Err(Unpromotable);

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -326,6 +326,7 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
             AttributeKind::RustcClean(..) => (),
             AttributeKind::RustcCoherenceIsCore => (),
             AttributeKind::RustcCoinductive => (),
+            AttributeKind::RustcComptime(_) => (),
             AttributeKind::RustcConfusables { .. } => (),
             AttributeKind::RustcConstStability { .. } => (),
             AttributeKind::RustcConstStableIndirect => (),

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -544,7 +544,7 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
         if target == (Target::Impl { of_trait: true }) {
             match item.unwrap() {
                 ItemLike::Item(it) => match it.expect_impl().constness {
-                    Constness::Const => {
+                    Constness::Const { .. } => {
                         let item_span = self.tcx.hir_span(hir_id);
                         self.tcx.emit_node_span_lint(
                             MISPLACED_DIAGNOSTIC_ATTRIBUTES,

--- a/compiler/rustc_passes/src/stability.rs
+++ b/compiler/rustc_passes/src/stability.rs
@@ -12,9 +12,9 @@ use rustc_hir::def::{DefKind, Res};
 use rustc_hir::def_id::{CRATE_DEF_ID, LOCAL_CRATE, LocalDefId, LocalModDefId};
 use rustc_hir::intravisit::{self, Visitor, VisitorExt};
 use rustc_hir::{
-    self as hir, AmbigArg, ConstStability, DefaultBodyStability, FieldDef, HirId, Item, ItemKind,
-    Path, Stability, StabilityLevel, StableSince, TraitRef, Ty, TyKind, UnstableReason, UsePath,
-    VERSION_PLACEHOLDER, Variant, find_attr,
+    self as hir, AmbigArg, ConstStability, Constness, DefaultBodyStability, FieldDef, HirId, Item,
+    ItemKind, Path, Stability, StabilityLevel, StableSince, TraitRef, Ty, TyKind, UnstableReason,
+    UsePath, VERSION_PLACEHOLDER, Variant, find_attr,
 };
 use rustc_middle::hir::nested_filter;
 use rustc_middle::middle::lib_features::{FeatureStability, LibFeatures};
@@ -207,7 +207,7 @@ fn lookup_const_stability(tcx: TyCtxt<'_>, def_id: LocalDefId) -> Option<ConstSt
             let parent_stab = tcx.lookup_stability(parent)?;
             if parent_stab.is_unstable()
                 && let Some(fn_sig) = tcx.hir_node_by_def_id(def_id).fn_sig()
-                && fn_sig.header.is_const()
+                && matches!(fn_sig.header.constness, Constness::Const { .. })
             {
                 let const_stable_indirect = find_attr!(tcx, def_id, RustcConstStableIndirect);
                 return Some(ConstStability::unmarked(const_stable_indirect, parent_stab));
@@ -229,7 +229,7 @@ fn lookup_const_stability(tcx: TyCtxt<'_>, def_id: LocalDefId) -> Option<ConstSt
     // If this is a const fn but not annotated with stability markers, see if we can inherit
     // regular stability.
     if let Some(fn_sig) = tcx.hir_node_by_def_id(def_id).fn_sig()
-        && fn_sig.header.is_const()
+        && matches!(fn_sig.header.constness, Constness::Const { .. })
         && const_stab.is_none()
         // We only ever inherit unstable features.
         && let Some(inherit_regular_stab) = tcx.lookup_stability(def_id)
@@ -385,7 +385,7 @@ impl<'tcx> MissingStabilityAnnotations<'tcx> {
         // implied), check if the function/method is const or the parent impl block is const.
         let fn_sig = self.tcx.hir_node_by_def_id(def_id).fn_sig();
         if let Some(fn_sig) = fn_sig
-            && !fn_sig.header.is_const()
+            && !matches!(fn_sig.header.constness, Constness::Const { .. })
             && const_stab.is_some()
             && find_attr_span!(RustcConstStability).is_some()
         {

--- a/compiler/rustc_passes/src/stability.rs
+++ b/compiler/rustc_passes/src/stability.rs
@@ -652,7 +652,7 @@ impl<'tcx> Visitor<'tcx> for Checker<'tcx> {
                     }
 
                     if features.const_trait_impl()
-                        && let hir::Constness::Const = constness
+                        && let hir::Constness::Const { .. } = constness
                     {
                         let stable_or_implied_stable = match const_stab {
                             None => true,
@@ -696,7 +696,7 @@ impl<'tcx> Visitor<'tcx> for Checker<'tcx> {
                     }
                 }
 
-                if let hir::Constness::Const = constness
+                if let hir::Constness::Const { .. } = constness
                     && let Some(def_id) = of_trait.trait_ref.trait_def_id()
                 {
                     // FIXME(const_trait_impl): Improve the span here.

--- a/compiler/rustc_public/src/ty.rs
+++ b/compiler/rustc_public/src/ty.rs
@@ -1117,13 +1117,13 @@ impl FnSig {
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize)]
 pub enum Constness {
-    Const,
+    Const { always: bool },
     NotConst,
 }
 
 impl Constness {
     pub fn is_const(self) -> bool {
-        matches!(self, Constness::Const)
+        matches!(self, Constness::Const { always: false })
     }
 }
 

--- a/compiler/rustc_public/src/unstable/convert/internal.rs
+++ b/compiler/rustc_public/src/unstable/convert/internal.rs
@@ -648,8 +648,8 @@ impl RustcInternal for Constness {
         _tables: &mut Tables<'_, BridgeTys>,
         _tcx: impl InternalCx<'tcx>,
     ) -> Self::T<'tcx> {
-        match self {
-            Constness::Const => rustc_hir::Constness::Const,
+        match *self {
+            Constness::Const { always } => rustc_hir::Constness::Const { always },
             Constness::NotConst => rustc_hir::Constness::NotConst,
         }
     }

--- a/compiler/rustc_public/src/unstable/convert/stable/mod.rs
+++ b/compiler/rustc_public/src/unstable/convert/stable/mod.rs
@@ -24,8 +24,8 @@ impl<'tcx> Stable<'tcx> for rustc_hir::Safety {
 impl<'tcx> Stable<'tcx> for rustc_hir::Constness {
     type T = crate::ty::Constness;
     fn stable(&self, _: &mut Tables<'_, BridgeTys>, _: &CompilerCtxt<'_, BridgeTys>) -> Self::T {
-        match self {
-            rustc_hir::Constness::Const => crate::ty::Constness::Const,
+        match *self {
+            rustc_hir::Constness::Const { always } => crate::ty::Constness::Const { always },
             rustc_hir::Constness::NotConst => crate::ty::Constness::NotConst,
         }
     }

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1725,6 +1725,7 @@ symbols! {
         rustc_clean,
         rustc_coherence_is_core,
         rustc_coinductive,
+        rustc_comptime,
         rustc_confusables,
         rustc_const_stable,
         rustc_const_stable_indirect,

--- a/compiler/rustc_trait_selection/src/traits/effects.rs
+++ b/compiler/rustc_trait_selection/src/traits/effects.rs
@@ -463,10 +463,11 @@ fn evaluate_host_effect_for_destruct_goal<'tcx>(
                 })
                 .collect();
             match adt_def.destructor(tcx).map(|dtor| tcx.constness(dtor.did)) {
+                Some(hir::Constness::Const { always: true }) => todo!("FIXME(comptime)"),
                 // `Drop` impl exists, but it's not const. Type cannot be `[const] Destruct`.
                 Some(hir::Constness::NotConst) => return Err(EvaluationFailure::NoSolution),
                 // `Drop` impl exists, and it's const. Require `Ty: [const] Drop` to hold.
-                Some(hir::Constness::Const) => {
+                Some(hir::Constness::Const { always: false }) => {
                     let drop_def_id = tcx.require_lang_item(LangItem::Drop, obligation.cause.span);
                     let drop_trait_ref = ty::TraitRef::new(tcx, drop_def_id, [self_ty]);
                     const_conditions.push(drop_trait_ref);
@@ -563,7 +564,9 @@ fn evaluate_host_effect_for_fn_goal<'tcx>(
     };
 
     match tcx.constness(def) {
-        hir::Constness::Const => Ok(tcx
+        // FIXME(comptime)
+        hir::Constness::Const { always: true } => Err(EvaluationFailure::NoSolution),
+        hir::Constness::Const { always: false } => Ok(tcx
             .const_conditions(def)
             .instantiate(tcx, args)
             .into_iter()
@@ -594,8 +597,15 @@ fn evaluate_host_effect_from_selection_candidate<'tcx>(
             Err(_) => Err(EvaluationFailure::NoSolution),
             Ok(Some(source)) => match source {
                 ImplSource::UserDefined(impl_) => {
-                    if tcx.impl_trait_header(impl_.impl_def_id).constness != hir::Constness::Const {
-                        return Err(EvaluationFailure::NoSolution);
+                    match tcx.impl_trait_header(impl_.impl_def_id).constness {
+                        rustc_hir::Constness::Const { always } => {
+                            if always {
+                                todo!()
+                            }
+                        }
+                        rustc_hir::Constness::NotConst => {
+                            return Err(EvaluationFailure::NoSolution);
+                        }
                     }
 
                     let mut nested = impl_.nested;

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -822,7 +822,7 @@ impl Item {
                 {
                     hir::Constness::NotConst
                 } else {
-                    hir::Constness::Const
+                    hir::Constness::Const { always: false }
                 }
             } else {
                 hir::Constness::NotConst
@@ -853,11 +853,8 @@ impl Item {
                         safety.into()
                     },
                     abi,
-                    constness: if tcx.is_const_fn(def_id) {
-                        hir::Constness::Const
-                    } else {
-                        hir::Constness::NotConst
-                    },
+                    // Foreign functions can never be const or comptime
+                    constness: hir::Constness::NotConst,
                     asyncness: hir::IsAsync::NotAsync,
                 }
             }

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -1509,15 +1509,21 @@ pub(crate) fn print_constness_with_space(
     overall_stab: Option<StableSince>,
     const_stab: Option<ConstStability>,
 ) -> &'static str {
-    match c {
-        hir::Constness::Const => match (overall_stab, const_stab) {
+    match *c {
+        hir::Constness::Const { always } => match (overall_stab, const_stab) {
             // const stable...
             (_, Some(ConstStability { level: StabilityLevel::Stable { .. }, .. }))
             // ...or when feature(staged_api) is not set...
             | (_, None)
             // ...or when const unstable, but overall unstable too
             | (None, Some(ConstStability { level: StabilityLevel::Unstable { .. }, .. })) => {
-                "const "
+                if always {
+                    // FIXME(comptime) show something when stable, currently relying on the attribute
+                    // being rendered as part of the regular attribute list.
+                    ""
+                } else {
+                    "const "
+                }
             }
             // const unstable (and overall stable)
             (Some(_), Some(ConstStability { level: StabilityLevel::Unstable { .. }, .. })) => "",

--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -410,7 +410,7 @@ impl FromClean<rustc_hir::FnHeader> for FunctionHeader {
         };
         FunctionHeader {
             is_async: header.is_async(),
-            is_const: header.is_const(),
+            is_const: matches!(header.constness, rustc_hir::Constness::Const { .. }),
             is_unsafe,
             abi: header.abi.into_json(renderer),
         }

--- a/src/tools/clippy/clippy_lints/src/default_numeric_fallback.rs
+++ b/src/tools/clippy/clippy_lints/src/default_numeric_fallback.rs
@@ -56,7 +56,7 @@ impl<'tcx> LateLintPass<'tcx> for DefaultNumericFallback {
         // Inline const supports type inference.
         let is_parent_const = matches!(
             cx.tcx.hir_body_const_context(cx.tcx.hir_body_owner_def_id(body.id())),
-            Some(ConstContext::Const { inline: false } | ConstContext::Static(_))
+            Some(ConstContext::Const { allow_const_fn_promotion: true } | ConstContext::Static(_))
         );
         let mut visitor = NumericFallbackVisitor::new(cx, is_parent_const);
         visitor.visit_body(body);

--- a/src/tools/clippy/clippy_lints/src/derivable_impls.rs
+++ b/src/tools/clippy/clippy_lints/src/derivable_impls.rs
@@ -253,7 +253,7 @@ impl<'tcx> LateLintPass<'tcx> for DerivableImpls {
             && !attrs.iter().any(|attr| attr.doc_str().is_some())
             && cx.tcx.hir_attrs(impl_item_hir).is_empty()
         {
-            let is_const = constness == hir::Constness::Const;
+            let is_const = matches!(constness, hir::Constness::Const { always: false });
             if adt_def.is_struct() {
                 check_struct(
                     cx,

--- a/src/tools/clippy/clippy_lints/src/methods/should_implement_trait.rs
+++ b/src/tools/clippy/clippy_lints/src/methods/should_implement_trait.rs
@@ -29,7 +29,7 @@ pub(super) fn check_impl_item<'tcx>(
         && first_arg_ty_opt
             .is_none_or(|first_arg_ty| method_config.self_kind.matches(cx, self_ty, first_arg_ty))
         && sig.header.is_safe()
-        && !sig.header.is_const()
+        && matches!(sig.header.constness, hir::Constness::NotConst)
         && !sig.header.is_async()
         && sig.header.abi == ExternAbi::Rust
         && method_config.lifetime_param_cond(impl_item)

--- a/src/tools/clippy/clippy_lints/src/missing_const_for_fn.rs
+++ b/src/tools/clippy/clippy_lints/src/missing_const_for_fn.rs
@@ -187,7 +187,7 @@ impl<'tcx> LateLintPass<'tcx> for MissingConstForFn {
 // We don't have to lint on something that's already `const`
 #[must_use]
 fn already_const(header: hir::FnHeader) -> bool {
-    header.constness == Constness::Const
+    matches!(header.constness, Constness::Const { .. })
 }
 
 fn could_be_const_with_abi(cx: &LateContext<'_>, msrv: Msrv, abi: ExternAbi) -> bool {

--- a/src/tools/clippy/clippy_utils/src/check_proc_macro.rs
+++ b/src/tools/clippy/clippy_utils/src/check_proc_macro.rs
@@ -242,7 +242,7 @@ fn expr_search_pat(tcx: TyCtxt<'_>, e: &Expr<'_>) -> (Pat, Pat) {
 fn fn_header_search_pat(header: FnHeader) -> Pat {
     if header.is_async() {
         Pat::Str("async")
-    } else if header.is_const() {
+    } else if matches!(header.constness, rustc_hir::Constness::Const { always: false }) {
         Pat::Str("const")
     } else if header.is_unsafe() {
         Pat::Str("unsafe")

--- a/src/tools/clippy/clippy_utils/src/lib.rs
+++ b/src/tools/clippy/clippy_utils/src/lib.rs
@@ -242,7 +242,7 @@ pub fn is_inside_always_const_context(tcx: TyCtxt<'_>, hir_id: HirId) -> bool {
     };
     match ctx {
         ConstFn => false,
-        Static(_) | Const { inline: _ } => true,
+        Static(_) | Const { allow_const_fn_promotion: _ } => true,
     }
 }
 

--- a/tests/ui-fulldeps/rustc_public/check_fn_attrs.rs
+++ b/tests/ui-fulldeps/rustc_public/check_fn_attrs.rs
@@ -14,20 +14,26 @@ extern crate rustc_middle;
 #[macro_use]
 extern crate rustc_public;
 
-use rustc_public::crate_def::CrateDef;
-use rustc_public::ty::{Asyncness, Constness, FnDef};
 use std::io::Write;
 use std::ops::ControlFlow;
+
+use rustc_public::crate_def::CrateDef;
+use rustc_public::ty::{Asyncness, Constness, FnDef};
 
 const CRATE_NAME: &str = "input";
 
 fn test_stable_mir() -> ControlFlow<()> {
     let fns = rustc_public::local_crate().fn_defs();
 
-    check_fn(&fns, "input::const_sync", Constness::Const, Asyncness::NotAsync);
+    check_fn(&fns, "input::const_sync", Constness::Const { always: false }, Asyncness::NotAsync);
     check_fn(&fns, "input::async_fn", Constness::NotConst, Asyncness::Async);
     check_fn(&fns, "input::plain", Constness::NotConst, Asyncness::NotAsync);
-    check_fn(&fns, "input::Widget::assoc_const", Constness::Const, Asyncness::NotAsync);
+    check_fn(
+        &fns,
+        "input::Widget::assoc_const",
+        Constness::Const { always: false },
+        Asyncness::NotAsync,
+    );
     check_fn(&fns, "input::Widget::assoc_async", Constness::NotConst, Asyncness::Async);
     check_fn(&fns, "input::Widget::assoc_plain", Constness::NotConst, Asyncness::NotAsync);
 

--- a/tests/ui/README.md
+++ b/tests/ui/README.md
@@ -296,6 +296,10 @@ Tests for compile flags.
 
 Meta test suite of the test harness `compiletest` itself.
 
+## `tests/ui/comptime`: compile-time only functions and intrinsics
+
+Test the `#[rustc_comptime]` attribute and intrinsics that inherently can only run at compile-time.
+
 ## `tests/ui/conditional-compilation/`: Conditional Compilation
 
 Tests for `#[cfg]` attribute or `--cfg` flags, used to compile certain files or code blocks only if certain conditions are met (such as developing on a specific architecture).

--- a/tests/ui/argument-suggestions/wrong-highlight-span-extra-arguments-147070.svg
+++ b/tests/ui/argument-suggestions/wrong-highlight-span-extra-arguments-147070.svg
@@ -1,4 +1,4 @@
-<svg width="944px" height="434px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="434px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }

--- a/tests/ui/compiletest-self-test/ui-test-missing-annotations-detection.stderr
+++ b/tests/ui/compiletest-self-test/ui-test-missing-annotations-detection.stderr
@@ -1,0 +1,18 @@
+error[E0463]: can't find crate for `std`
+   |
+   = note: the `x86_64-unknown-linux-gnu` target may not support the standard library
+   = note: `std` is required by `<unknown>` because it does not declare `#![no_std]`
+   = help: consider building the standard library from source with `cargo build -Zbuild-std`
+
+error: cannot resolve a prelude import
+
+error: `#[panic_handler]` function required, but not found
+
+error: unwinding panics are not supported without std
+   |
+   = help: using nightly cargo, use -Zbuild-std with panic="abort" to avoid unwinding
+   = note: since the core library is usually precompiled with panic="unwind", rebuilding your crate with panic="abort" may not be enough to fix the problem
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0463`.

--- a/tests/ui/comptime/const_comptime.rs
+++ b/tests/ui/comptime/const_comptime.rs
@@ -1,0 +1,7 @@
+#![feature(rustc_attrs)]
+
+#[rustc_comptime]
+const fn foo() {}
+//~^ ERROR a function cannot be both `comptime` and `const`
+
+fn main() {}

--- a/tests/ui/comptime/const_comptime.stderr
+++ b/tests/ui/comptime/const_comptime.stderr
@@ -1,0 +1,16 @@
+error: a function cannot be both `comptime` and `const`
+  --> $DIR/const_comptime.rs:4:1
+   |
+LL | #[rustc_comptime]
+   | ----------------- `comptime` because of this
+LL | const fn foo() {}
+   | ^^^^^ help: remove the `const`
+   |
+note: `const` implies the function can be called at runtime, too
+  --> $DIR/const_comptime.rs:4:1
+   |
+LL | const fn foo() {}
+   | ^^^^^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/comptime/feature-gate-test.rs
+++ b/tests/ui/comptime/feature-gate-test.rs
@@ -1,0 +1,5 @@
+#[rustc_comptime]
+//~^ ERROR use of an internal attribute
+fn foo() {}
+
+fn main() {}

--- a/tests/ui/comptime/feature-gate-test.stderr
+++ b/tests/ui/comptime/feature-gate-test.stderr
@@ -1,0 +1,12 @@
+error[E0658]: use of an internal attribute
+  --> $DIR/feature-gate-test.rs:1:1
+   |
+LL | #[rustc_comptime]
+   | ^^^^^^^^^^^^^^^^^
+   |
+   = help: add `#![feature(rustc_attrs)]` to the crate attributes to enable
+   = note: the `#[rustc_comptime]` attribute is an internal implementation detail that will never be stable
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/comptime/not_callable.rs
+++ b/tests/ui/comptime/not_callable.rs
@@ -1,0 +1,25 @@
+#![feature(rustc_attrs)]
+
+//TODO: should fail
+//@check-pass
+
+#[rustc_comptime]
+fn foo() {}
+
+fn main() {
+    // Ok
+    const { foo() };
+    // TODO: Not ok
+    foo();
+}
+
+const fn bar() {
+    // TODO: Not ok
+    foo();
+}
+
+#[rustc_comptime]
+fn baz() {
+    // Should be allowed
+    foo();
+}

--- a/tests/ui/comptime/not_callable.rs
+++ b/tests/ui/comptime/not_callable.rs
@@ -17,6 +17,6 @@ const fn bar() {
 
 #[rustc_comptime]
 fn baz() {
-    // TODO: Should be allowed
-    foo(); //~ ERROR: comptime fns can only be called at compile time
+    // Ok
+    foo();
 }

--- a/tests/ui/comptime/not_callable.rs
+++ b/tests/ui/comptime/not_callable.rs
@@ -1,7 +1,4 @@
-#![feature(rustc_attrs)]
-
-//TODO: should fail
-//@check-pass
+#![feature(rustc_attrs, const_trait_impl)]
 
 #[rustc_comptime]
 fn foo() {}
@@ -9,17 +6,17 @@ fn foo() {}
 fn main() {
     // Ok
     const { foo() };
-    // TODO: Not ok
-    foo();
+    // Not Ok
+    foo(); //~ ERROR: comptime fns can only be called at compile time
 }
 
 const fn bar() {
-    // TODO: Not ok
-    foo();
+    // Not Ok
+    foo(); //~ ERROR: comptime fns can only be called at compile time
 }
 
 #[rustc_comptime]
 fn baz() {
-    // Should be allowed
-    foo();
+    // TODO: Should be allowed
+    foo(); //~ ERROR: comptime fns can only be called at compile time
 }

--- a/tests/ui/comptime/not_callable.stderr
+++ b/tests/ui/comptime/not_callable.stderr
@@ -10,11 +10,5 @@ error: comptime fns can only be called at compile time
 LL |     foo();
    |     ^^^^^
 
-error: comptime fns can only be called at compile time
-  --> $DIR/not_callable.rs:21:5
-   |
-LL |     foo();
-   |     ^^^^^
-
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 

--- a/tests/ui/comptime/not_callable.stderr
+++ b/tests/ui/comptime/not_callable.stderr
@@ -1,0 +1,20 @@
+error: comptime fns can only be called at compile time
+  --> $DIR/not_callable.rs:10:5
+   |
+LL |     foo();
+   |     ^^^^^
+
+error: comptime fns can only be called at compile time
+  --> $DIR/not_callable.rs:15:5
+   |
+LL |     foo();
+   |     ^^^^^
+
+error: comptime fns can only be called at compile time
+  --> $DIR/not_callable.rs:21:5
+   |
+LL |     foo();
+   |     ^^^^^
+
+error: aborting due to 3 previous errors
+

--- a/tests/ui/comptime/trait_bounds.rs
+++ b/tests/ui/comptime/trait_bounds.rs
@@ -1,0 +1,25 @@
+#![feature(rustc_attrs, const_trait_impl)]
+
+const trait Trait {
+    fn method() {}
+}
+
+#[rustc_comptime]
+fn always_const<T: const Trait>() {
+    T::method()
+}
+
+#[rustc_comptime]
+fn conditionally_const<T: [const] Trait>() {
+    //~^ ERROR: `[const]` is not allowed here
+    T::method()
+    //~^ ERROR: `T: const Trait` is not satisfied
+}
+
+#[rustc_comptime]
+fn non_const<T: Trait>() {
+    T::method()
+    //~^ ERROR: `T: const Trait` is not satisfied
+}
+
+fn main() {}

--- a/tests/ui/comptime/trait_bounds.stderr
+++ b/tests/ui/comptime/trait_bounds.stderr
@@ -1,0 +1,27 @@
+error: `[const]` is not allowed here
+  --> $DIR/trait_bounds.rs:13:27
+   |
+LL | fn conditionally_const<T: [const] Trait>() {
+   |                           ^^^^^^^
+   |
+note: this function is not `const`, so it cannot have `[const]` trait bounds
+  --> $DIR/trait_bounds.rs:13:4
+   |
+LL | fn conditionally_const<T: [const] Trait>() {
+   |    ^^^^^^^^^^^^^^^^^^^
+
+error[E0277]: the trait bound `T: const Trait` is not satisfied
+  --> $DIR/trait_bounds.rs:15:5
+   |
+LL |     T::method()
+   |     ^
+
+error[E0277]: the trait bound `T: const Trait` is not satisfied
+  --> $DIR/trait_bounds.rs:21:5
+   |
+LL |     T::method()
+   |     ^
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/comptime/trait_comptime.rs
+++ b/tests/ui/comptime/trait_comptime.rs
@@ -1,0 +1,26 @@
+#![feature(rustc_attrs)]
+
+trait Foo {
+    #[rustc_comptime]
+    //~^ ERROR: cannot be used on required trait methods
+    fn foo();
+
+    #[rustc_comptime]
+    //~^ ERROR: cannot be used on provided trait methods
+    fn bar() {}
+}
+
+struct Bar;
+
+impl Bar {
+    #[rustc_comptime]
+    fn foo() {}
+}
+
+impl Foo for Bar {
+    #[rustc_comptime]
+    //~^ ERROR: cannot be used on trait methods
+    fn foo() {}
+}
+
+fn main() {}

--- a/tests/ui/comptime/trait_comptime.stderr
+++ b/tests/ui/comptime/trait_comptime.stderr
@@ -1,0 +1,26 @@
+error: `#[rustc_comptime]` attribute cannot be used on required trait methods
+  --> $DIR/trait_comptime.rs:4:5
+   |
+LL |     #[rustc_comptime]
+   |     ^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[rustc_comptime]` can only be applied to functions with a body
+
+error: `#[rustc_comptime]` attribute cannot be used on provided trait methods
+  --> $DIR/trait_comptime.rs:8:5
+   |
+LL |     #[rustc_comptime]
+   |     ^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[rustc_comptime]` can be applied to functions and inherent methods
+
+error: `#[rustc_comptime]` attribute cannot be used on trait methods in impl blocks
+  --> $DIR/trait_comptime.rs:21:5
+   |
+LL |     #[rustc_comptime]
+   |     ^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[rustc_comptime]` can be applied to functions and inherent methods
+
+error: aborting due to 3 previous errors
+

--- a/tests/ui/error-emitter/multiline-removal-suggestion.svg
+++ b/tests/ui/error-emitter/multiline-removal-suggestion.svg
@@ -1,4 +1,4 @@
-<svg width="2288px" height="3890px" xmlns="http://www.w3.org/2000/svg">
+<svg width="1952px" height="3890px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }

--- a/tests/ui/impl-trait/diagnostics/highlight-difference-between-expected-trait-and-found-trait.svg
+++ b/tests/ui/impl-trait/diagnostics/highlight-difference-between-expected-trait-and-found-trait.svg
@@ -1,4 +1,4 @@
-<svg width="1188px" height="470px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="470px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }

--- a/tests/ui/parallel-rustc/recursive-trait-fn-sig-issue-142064.stderr
+++ b/tests/ui/parallel-rustc/recursive-trait-fn-sig-issue-142064.stderr
@@ -13,19 +13,6 @@ LL | trait A { fn foo() -> dyn A; }
    |                       +++
 
 warning: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/recursive-trait-fn-sig-issue-142064.rs:13:23
-   |
-LL | trait B { fn foo() -> A; }
-   |                       ^
-   |
-   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
-help: if this is a dyn-compatible trait, use `dyn`
-   |
-LL | trait B { fn foo() -> dyn A; }
-   |                       +++
-
-warning: trait objects without an explicit `dyn` are deprecated
   --> $DIR/recursive-trait-fn-sig-issue-142064.rs:7:23
    |
 LL | trait A { fn foo() -> A; }
@@ -37,6 +24,19 @@ LL | trait A { fn foo() -> A; }
 help: if this is a dyn-compatible trait, use `dyn`
    |
 LL | trait A { fn foo() -> dyn A; }
+   |                       +++
+
+warning: trait objects without an explicit `dyn` are deprecated
+  --> $DIR/recursive-trait-fn-sig-issue-142064.rs:13:23
+   |
+LL | trait B { fn foo() -> A; }
+   |                       ^
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
+help: if this is a dyn-compatible trait, use `dyn`
+   |
+LL | trait B { fn foo() -> dyn A; }
    |                       +++
 
 warning: trait objects without an explicit `dyn` are deprecated

--- a/tests/ui/parallel-rustc/ty-variance-issue-124423.stderr
+++ b/tests/ui/parallel-rustc/ty-variance-issue-124423.stderr
@@ -244,15 +244,15 @@ LL | fn elided4(_: &impl Copy + 'a) ->  new  { x(x) }
    |                                    ^^^ not found in this scope
 
 error[E0224]: at least one trait is required for an object type
-  --> $DIR/ty-variance-issue-124423.rs:41:40
-   |
-LL | fn x<'b>(_: &'a impl Copy + 'a) -> Box<dyn 'b> { Box::u32(x) }
-   |                                        ^^^^^^
-
-error[E0224]: at least one trait is required for an object type
   --> $DIR/ty-variance-issue-124423.rs:55:40
    |
 LL | impl<'a> LifetimeTrait<'a> for &'a Box<dyn 'a> {}
+   |                                        ^^^^^^
+
+error[E0224]: at least one trait is required for an object type
+  --> $DIR/ty-variance-issue-124423.rs:41:40
+   |
+LL | fn x<'b>(_: &'a impl Copy + 'a) -> Box<dyn 'b> { Box::u32(x) }
    |                                        ^^^^^^
 
 error[E0224]: at least one trait is required for an object type


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/148820)*
<!-- homu-ignore:end -->

Implements functions that cannot be called at runtime (and thus also not from normal const functions, as those could be called from runtime).

This is done via the internal attribute `rustc_comptime` that can be added to normal functions, turning them into compile-time-only functions.  

Because @fee1-dead and @compiler-errors did amazing work, we even get trait bounds that work inside comptime fns: via unconditionally-const `const Trait` bounds.

Use cases are

* https://github.com/rust-lang/rust/pull/146923
* const heap intrinsics
* and the other various intrinsics (e.g. size_of 😆) that will just ICE in codegen or panic at runtime if they actually end up in runtime code


project goal issue: https://github.com/rust-lang/rust-project-goals/issues/406

no tracking issue until we have a feature gate and some sort of syntax

cc @scottmcm as the T-lang goal champion