### PR TITLE
Remove more `#[must_use]` from portable-simd

### DIFF
--- a/library/portable-simd/crates/core_simd/src/masks/bitmask.rs
+++ b/library/portable-simd/crates/core_simd/src/masks/bitmask.rs
@@ -170,7 +170,6 @@ where
 {
     type Output = Self;
     #[inline]
-    #[must_use = "method returns a new mask and does not mutate the original value"]
     fn bitand(mut self, rhs: Self) -> Self {
         for (l, r) in self.0.as_mut().iter_mut().zip(rhs.0.as_ref().iter()) {
             *l &= r;
@@ -187,7 +186,6 @@ where
 {
     type Output = Self;
     #[inline]
-    #[must_use = "method returns a new mask and does not mutate the original value"]
     fn bitor(mut self, rhs: Self) -> Self {
         for (l, r) in self.0.as_mut().iter_mut().zip(rhs.0.as_ref().iter()) {
             *l |= r;
@@ -203,7 +201,6 @@ where
 {
     type Output = Self;
     #[inline]
-    #[must_use = "method returns a new mask and does not mutate the original value"]
     fn bitxor(mut self, rhs: Self) -> Self::Output {
         for (l, r) in self.0.as_mut().iter_mut().zip(rhs.0.as_ref().iter()) {
             *l ^= r;
@@ -219,7 +216,6 @@ where
 {
     type Output = Self;
     #[inline]
-    #[must_use = "method returns a new mask and does not mutate the original value"]
     fn not(mut self) -> Self::Output {
         for x in self.0.as_mut() {
             *x = !*x;


### PR DESCRIPTION
These lines were missed in <https://github.com/rust-lang/rust/commit/f3515fb127ae07f1b13340dde0c61a20291eb304>/rust-lang/rust#136923 because core_simd/src/masks/bitmask.rs is only conditionally compiled.

https://github.com/rust-lang/rust/blob/25d319a0f656ee8faa7a534da299e76e96068a40/library/portable-simd/crates/core_simd/src/masks.rs#L9-L13

Removing them unblocks bootstrapping rustc in an environment where avx512f is enabled. Without this change:

```console
error: `#[must_use]` attribute cannot be used on trait methods in impl blocks
   --> library/core/src/../../portable-simd/crates/core_simd/src/masks/bitmask.rs:173:5
    |
173 |     #[must_use = "method returns a new mask and does not mutate the original value"]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = help: `#[must_use]` can be applied to data types, functions, unions, required trait methods, provided trait methods, inherent methods, foreign functions, and traits
    = note: `-D unused-attributes` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(unused_attributes)]`
```

To reproduce:

`RUSTC_BOOTSTRAP=1 RUSTFLAGS=-Ctarget-feature=+avx512f cargo +nightly check --manifest-path=library/portable-simd/crates/core_simd/Cargo.toml --target=x86_64-unknown-linux-gnu --no-default-features`