### PR TITLE
rustc_hir_analysis: fix generics_of ICE on unresolved const arguments

### DIFF
--- a/tests/ui/const-generics/const-arg-unresolved.rs
+++ b/tests/ui/const-generics/const-arg-unresolved.rs
@@ -1,0 +1,10 @@
+#![feature(min_generic_const_args)]
+#![feature(generic_const_exprs)]
+#![expect(incomplete_features)]
+
+struct Both<const is_123: u32 = 3, T> { //~ ERROR generic parameters with a default must be trailing
+    a: A<{ B::<1>::M }>, //~ ERROR cannot find type `A` in this scope
+    //~| ERROR failed to resolve: use of undeclared type `B`
+}
+
+fn main() {}

--- a/tests/ui/const-generics/const-arg-unresolved.stderr
+++ b/tests/ui/const-generics/const-arg-unresolved.stderr
@@ -1,0 +1,27 @@
+error: generic parameters with a default must be trailing
+  --> $DIR/const-arg-unresolved.rs:5:19
+   |
+LL | struct Both<const is_123: u32 = 3, T> {
+   |                   ^^^^^^
+
+error[E0412]: cannot find type `A` in this scope
+  --> $DIR/const-arg-unresolved.rs:6:8
+   |
+LL | struct Both<const is_123: u32 = 3, T> {
+   |                                    - similarly named type parameter `T` defined here
+LL |     a: A<{ B::<1>::M }>,
+   |        ^ help: a type parameter with a similar name exists: `T`
+
+error[E0433]: failed to resolve: use of undeclared type `B`
+  --> $DIR/const-arg-unresolved.rs:6:12
+   |
+LL |     a: A<{ B::<1>::M }>,
+   |            ^
+   |            |
+   |            use of undeclared type `B`
+   |            help: a type parameter with a similar name exists: `T`
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0412, E0433.
+For more information about an error, try `rustc --explain E0412`.


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/148838

Root cause:
`generics_of` currently does not handle `hir::Node::ConstArg` so defaulted const args nested inside const paths try to inherit generics from the wrong place and trigger ICE.

Symptom:
https://github.com/rust-lang/rust/issues/148838 ICE

Fix

Handle `Node::ConstArg`, in fact, similar logic already exists although it is in another branch and slightly more complex, not sure if there is a more elegant way:

https://github.com/rust-lang/rust/blob/2636cb4c1328f5a3ab05b8d13a666ac5f3a48a08/compiler/rustc_hir_analysis/src/collect/generics_of.rs#L76-L90

Testing:
1 more test case `const-arg-unresolved.rs`