### PR TITLE
add a test for combining RPIT with explicit tail calls

### DIFF
--- a/tests/ui/explicit-tail-calls/rpit.rs
+++ b/tests/ui/explicit-tail-calls/rpit.rs
@@ -1,0 +1,20 @@
+#![feature(explicit_tail_calls)]
+#![expect(incomplete_features)]
+
+// Regression test for https://github.com/rust-lang/rust/issues/139305.
+//
+// Combining return position impl trait (RPIT) with guaranteed tail calls does not
+// currently work, but at least it does not ICE.
+
+fn foo(x: u32, y: u32) -> u32 {
+    x + y
+}
+
+fn bar(x: u32, y: u32) -> impl ToString {
+    become foo(x, y);
+    //~^ ERROR mismatched signatures
+}
+
+fn main() {
+    assert_eq!(bar(1, 2).to_string(), "3");
+}

--- a/tests/ui/explicit-tail-calls/rpit.stderr
+++ b/tests/ui/explicit-tail-calls/rpit.stderr
@@ -1,0 +1,12 @@
+error: mismatched signatures
+  --> $DIR/rpit.rs:14:5
+   |
+LL |     become foo(x, y);
+   |     ^^^^^^^^^^^^^^^^
+   |
+   = note: `become` requires caller and callee to have matching signatures
+   = note: caller signature: `fn(u32, u32) -> impl ToString`
+   = note: callee signature: `fn(u32, u32) -> u32`
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
tracking issue: https://github.com/rust-lang/rust/issues/112788
fixes https://github.com/rust-lang/rust/issues/139305

Combining return position impl trait (RPIT) with guaranteed tail calls does not currently work, but at least it does not ICE any more. 

Using RPIT probably should work, see also https://github.com/rust-lang/rust/issues/144953.

The snippet in the issue is not valid for a variety of reasons, and based on the assert that got triggered the ICE was just any `-> impl Trait` at all, so I've made a minimal example using RPIT.

r? @WaffleLapkin 