### PR TITLE
rustc_hir_analysis: Remove premature classification of repeats as `AnonConstKind::MCG`

### DIFF
--- a/compiler/rustc_hir_analysis/src/collect.rs
+++ b/compiler/rustc_hir_analysis/src/collect.rs
@@ -1577,8 +1577,6 @@ fn anon_const_kind<'tcx>(tcx: TyCtxt<'tcx>, def: LocalDefId) -> ty::AnonConstKin
             let parent_hir_node = tcx.hir_node(tcx.parent_hir_id(const_arg_id));
             if tcx.features().generic_const_exprs() {
                 ty::AnonConstKind::GCE
-            } else if tcx.features().min_generic_const_args() {
-                ty::AnonConstKind::MCG
             } else if let hir::Node::Expr(hir::Expr {
                 kind: hir::ExprKind::Repeat(_, repeat_count),
                 ..

--- a/tests/ui/const-generics/mgca/repeat-self-const.rs
+++ b/tests/ui/const-generics/mgca/repeat-self-const.rs
@@ -1,0 +1,17 @@
+//@ check-pass
+#![expect(incomplete_features)]
+#![feature(min_generic_const_args)]
+
+struct S<const M: usize>();
+
+impl<const M: usize> S<M> {
+    const N: usize = M;
+
+    fn f() {
+        let arr = [0; Self::N + 1];
+    }
+}
+
+fn main() {
+    S::<3>::f();
+}


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
Fixes https://github.com/rust-lang/rust/issues/148822
Tracking issue: https://github.com/rust-lang/rust/issues/132980

Root cause:
https://github.com/rust-lang/rust/blob/996a185ba74755cb39a4fe24151ea65e671d4c0d/compiler/rustc_hir_analysis/src/collect.rs#L1840-L1851

L1840 causes const args to be identified prematurely when the feature is enabled. for repeat array this is problematic because the next else-if at 1842 will not be hit (but it should be).

Fix:
Removed L1840 else-if block, it seems redundant if we move below the L1842 one, but it might have other responsibilities later on?

Testing:
Regression test from the issue.

r? @BoxyUwU 




