### PR TITLE
Error if an autodiff user does not set lto=fat

### DIFF
--- a/compiler/rustc_codegen_llvm/messages.ftl
+++ b/compiler/rustc_codegen_llvm/messages.ftl
@@ -1,4 +1,5 @@
 codegen_llvm_autodiff_without_enable = using the autodiff feature requires -Z autodiff=Enable
+codegen_llvm_autodiff_without_lto = using the autodiff feature requires setting `lto="fat"` in your Cargo.toml
 
 codegen_llvm_copy_bitcode = failed to copy bitcode to object file: {$err}
 

--- a/compiler/rustc_codegen_llvm/src/errors.rs
+++ b/compiler/rustc_codegen_llvm/src/errors.rs
@@ -33,6 +33,10 @@ impl<G: EmissionGuarantee> Diagnostic<'_, G> for ParseTargetMachineConfig<'_> {
 }
 
 #[derive(Diagnostic)]
+#[diag(codegen_llvm_autodiff_without_lto)]
+pub(crate) struct AutoDiffWithoutLto;
+
+#[derive(Diagnostic)]
 #[diag(codegen_llvm_autodiff_without_enable)]
 pub(crate) struct AutoDiffWithoutEnable;
 

--- a/compiler/rustc_codegen_llvm/src/intrinsic.rs
+++ b/compiler/rustc_codegen_llvm/src/intrinsic.rs
@@ -24,7 +24,7 @@ use crate::abi::FnAbiLlvmExt;
 use crate::builder::Builder;
 use crate::builder::autodiff::{adjust_activity_to_abi, generate_enzyme_call};
 use crate::context::CodegenCx;
-use crate::errors::AutoDiffWithoutEnable;
+use crate::errors::{AutoDiffWithoutEnable, AutoDiffWithoutLto};
 use crate::llvm::{self, Metadata, Type, Value};
 use crate::type_of::LayoutLlvmExt;
 use crate::va_arg::emit_va_arg;
@@ -1144,6 +1144,9 @@ fn codegen_autodiff<'ll, 'tcx>(
 ) {
     if !tcx.sess.opts.unstable_opts.autodiff.contains(&rustc_session::config::AutoDiff::Enable) {
         let _ = tcx.dcx().emit_almost_fatal(AutoDiffWithoutEnable);
+    }
+    if tcx.sess.lto() != rustc_session::config::Lto::Fat {
+        let _ = tcx.dcx().emit_almost_fatal(AutoDiffWithoutLto);
     }
 
     let fn_args = instance.args;

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -594,14 +594,6 @@ impl Session {
 
     /// Calculates the flavor of LTO to use for this compilation.
     pub fn lto(&self) -> config::Lto {
-        // Autodiff currently requires fat-lto to have access to the llvm-ir of all (indirectly) used functions and types.
-        // fat-lto is the easiest solution to this requirement, but quite expensive.
-        // FIXME(autodiff): Make autodiff also work with embed-bc instead of fat-lto.
-        // Don't apply fat-lto to proc-macro crates as they cannot use fat-lto without -Zdylib-lto
-        if self.opts.autodiff_enabled() && !self.opts.crate_types.contains(&CrateType::ProcMacro) {
-            return config::Lto::Fat;
-        }
-
         // If our target has codegen requirements ignore the command line
         if self.target.requires_lto {
             return config::Lto::Fat;

--- a/tests/ui/autodiff/no_lto_flag.no_lto.stderr
+++ b/tests/ui/autodiff/no_lto_flag.no_lto.stderr
@@ -1,0 +1,4 @@
+error: using the autodiff feature requires setting `lto="fat"` in your Cargo.toml
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/autodiff/no_lto_flag.rs
+++ b/tests/ui/autodiff/no_lto_flag.rs
@@ -1,0 +1,31 @@
+//@ needs-enzyme
+//@ no-prefer-dynamic
+//@ revisions: with_lto no_lto
+//@[with_lto] compile-flags: -Zautodiff=Enable -C opt-level=3  -Clto=fat
+//@[no_lto] compile-flags: -Zautodiff=Enable -C opt-level=3 -Clto=thin
+
+#![feature(autodiff)]
+//@[no_lto] build-fail
+//@[with_lto] build-pass
+
+// Autodiff requires users to enable lto=fat (for now).
+// In the past, autodiff did not run if users forget to enable fat-lto, which caused functions to
+// returning zero-derivatives. That's obviously wrong and confusing to users. We now added a check
+// which will abort compilation instead.
+
+use std::autodiff::autodiff_reverse;
+//[no_lto]~? ERROR using the autodiff feature requires setting `lto="fat"` in your Cargo.toml
+
+#[autodiff_reverse(d_square, Duplicated, Active)]
+fn square(x: &f64) -> f64 {
+    *x * *x
+}
+
+fn main() {
+    let xf64: f64 = std::hint::black_box(3.0);
+
+    let mut df_dxf64: f64 = std::hint::black_box(0.0);
+
+    let _output_f64 = d_square(&xf64, &mut df_dxf64, 1.0);
+    assert_eq!(6.0, df_dxf64);
+}


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Based on your feedback, I started to provide a nice error message for a lack of `lto=fat`, instead of us forcing it.

In a next step, we should replace  `RUSTFLAGS="-Zautodiff=Enable"` with another Cargo.toml setting, as discussed here: https://github.com/rust-lang/rust/issues/147487#issuecomment-3446558644

As another improvement, we should also figure out why rlib builds do not properly obey the fat=lto setting.


@bjorn3