### PR TITLE
Fix ICE caused by const block pattern matching with deref patterns

### DIFF
--- a/compiler/rustc_hir_typeck/src/pat.rs
+++ b/compiler/rustc_hir_typeck/src/pat.rs
@@ -773,7 +773,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     && self.tcx.features().deref_patterns()
                     && !matches!(lt.kind, PatExprKind::Lit { .. })
                 {
-                    self.dcx().span_delayed_bug!(
+                    span_delayed_bug!(
                         lt.span,
                         format!("FIXME(deref_patterns): adjust mode unimplemented for {:?}", lt.kind),
                     );

--- a/compiler/rustc_hir_typeck/src/pat.rs
+++ b/compiler/rustc_hir_typeck/src/pat.rs
@@ -773,7 +773,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     && self.tcx.features().deref_patterns()
                     && !matches!(lt.kind, PatExprKind::Lit { .. })
                 {
-                    self.dcx().span_delayed_bug(
+                    self.dcx().span_delayed_bug!(
                         lt.span,
                         format!("FIXME(deref_patterns): adjust mode unimplemented for {:?}", lt.kind),
                     );

--- a/compiler/rustc_hir_typeck/src/pat.rs
+++ b/compiler/rustc_hir_typeck/src/pat.rs
@@ -773,10 +773,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     && self.tcx.features().deref_patterns()
                     && !matches!(lt.kind, PatExprKind::Lit { .. })
                 {
-                    span_bug!(
+                    self.dcx().span_delayed_bug(
                         lt.span,
-                        "FIXME(deref_patterns): adjust mode unimplemented for {:?}",
-                        lt.kind
+                        format!("FIXME(deref_patterns): adjust mode unimplemented for {:?}", lt.kind),
                     );
                 }
                 // Call `resolve_vars_if_possible` here for inline const blocks.

--- a/compiler/rustc_hir_typeck/src/tempCodeRunnerFile.rs
+++ b/compiler/rustc_hir_typeck/src/tempCodeRunnerFile.rs
@@ -1,1 +1,0 @@
-delayed_

--- a/compiler/rustc_hir_typeck/src/tempCodeRunnerFile.rs
+++ b/compiler/rustc_hir_typeck/src/tempCodeRunnerFile.rs
@@ -1,0 +1,1 @@
+delayed_

--- a/tests/ui/pattern/deref-patterns/ice-adjust-mode-unimplemented-for-constblock.rs
+++ b/tests/ui/pattern/deref-patterns/ice-adjust-mode-unimplemented-for-constblock.rs
@@ -1,0 +1,15 @@
+// compile-flags: --error-format=json
+// error-pattern: expected a pattern
+// or
+//~ ERROR expected a pattern
+
+//~ ERROR expected a pattern, found a function call
+//~ ERROR usage of qualified paths in this context is experimental
+//~ WARN the feature `deref_patterns` is incomplete
+//~ ERROR expected tuple struct or tuple variant, found associated function
+
+#![feature(deref_patterns)]
+
+fn main() {
+    let vec![const { vec![] }]: Vec<usize> = vec![];
+}

--- a/tests/ui/pattern/deref-patterns/ice-adjust-mode-unimplemented-for-constblock.stderr
+++ b/tests/ui/pattern/deref-patterns/ice-adjust-mode-unimplemented-for-constblock.stderr
@@ -1,0 +1,42 @@
+error[E0532]: expected a pattern, found a function call
+  --> $DIR/ice-adjust-mode-unimplemented-for-constblock.rs:14:9
+   |
+LL |     let vec![const { vec![] }]: Vec<usize> = vec![];
+   |         ^^^^^^^^^^^^^^^^^^^^^^ not a tuple struct or tuple variant
+   |
+   = note: function calls are not allowed in patterns: <https://doc.rust-lang.org/book/ch19-00-patterns.html>
+   = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0658]: usage of qualified paths in this context is experimental
+  --> $DIR/ice-adjust-mode-unimplemented-for-constblock.rs:14:9
+   |
+LL |     let vec![const { vec![] }]: Vec<usize> = vec![];
+   |         ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #86935 <https://github.com/rust-lang/rust/issues/86935> for more information
+   = help: add `#![feature(more_qualified_paths)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+   = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+warning: the feature `deref_patterns` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/ice-adjust-mode-unimplemented-for-constblock.rs:11:12
+   |
+LL | #![feature(deref_patterns)]
+   |            ^^^^^^^^^^^^^^
+   |
+   = note: see issue #87121 <https://github.com/rust-lang/rust/issues/87121> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+error[E0164]: expected tuple struct or tuple variant, found associated function `<[_]>::into_vec`
+  --> $DIR/ice-adjust-mode-unimplemented-for-constblock.rs:14:9
+   |
+LL |     let vec![const { vec![] }]: Vec<usize> = vec![];
+   |         ^^^^^^^^^^^^^^^^^^^^^^ `fn` calls are not allowed in patterns
+   |
+   = help: for more information, visit https://doc.rust-lang.org/book/ch19-00-patterns.html
+   = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 3 previous errors; 1 warning emitted
+
+Some errors have detailed explanations: E0164, E0532, E0658.
+For more information about an error, try `rustc --explain E0164`.


### PR DESCRIPTION
### Summary
This PR fixes an internal compiler error (ICE) occurring when matching a deref pattern inside a `const` block.

### Changes made
- Adjusted logic in `rustc_hir_typeck` from 'span_bug' to 'span_delayed_bug'
- Added a test: `tests/ui/pattern/deref-patterns/ice-adjust-mode-unimplemented-for-constblock.rs`
- Generated the corresponding `.stderr` file for the test using `./x test tests/ui/pattern/deref-patterns/ice-adjust-mode-unimplemented-for-constblock.rs --bless`

### Notes
- Verified locally with `./x test tidy`
- Open for review and feedback
