### PR TITLE
Fix overflow-checks test for RISC-V target

### DIFF
--- a/tests/codegen-llvm/overflow-checks.rs
+++ b/tests/codegen-llvm/overflow-checks.rs
@@ -18,7 +18,7 @@ extern crate overflow_checks_add;
 // CHECK-LABEL: @add(
 #[no_mangle]
 pub unsafe fn add(a: u8, b: u8) -> u8 {
-    //        CHECK: i8 noundef %a, i8 noundef %b
+    //        CHECK: i8 noundef{{( zeroext)?}} %a, i8 noundef{{( zeroext)?}} %b
     //        CHECK: add i8 %b, %a
     //        DEBUG: icmp ult i8 [[zero:[^,]+]], %a
     //        DEBUG: call core::num::overflow_panic::add


### PR DESCRIPTION
The overflow-checks codegen test was failing on riscv64gc target because the FileCheck pattern did not account for ABI extension attributes. RISC-V LP64 ABI requires integer types smaller than XLEN (64-bit) to be zero-extended or sign-extended to register width.

For u8 parameters, RISC-V generates:
  i8 noundef zeroext %a, i8 noundef zeroext %b

While x86_64 and aarch64 generate:
  i8 noundef %a, i8 noundef %b

The original CHECK pattern only matched the format without the `zeroext` attribute, causing test failures on RISC-V.

This patch makes the zeroext attribute optional in the FileCheck pattern using `{{( zeroext)?}}`, allowing the test to pass on architectures that add ABI extension attributes (e.g., RISC-V).

Test results before fix:
- x86_64-unknown-linux-gnu: 3 passed
- aarch64-unknown-linux-gnu: 3 passed
- riscv64gc-unknown-linux-gnu: 1 passed, 2 failed

Test results after fix:
- x86_64-unknown-linux-gnu: 3 passed
- aarch64-unknown-linux-gnu: 3 passed
- riscv64gc-unknown-linux-gnu: 3 passed

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
