### PR TITLE
fix more filecheck errors

### DIFF
--- a/tests/codegen-llvm/float/f128.rs
+++ b/tests/codegen-llvm/float/f128.rs
@@ -173,8 +173,8 @@ pub fn f128_rem_assign(a: &mut f128, b: f128) {
 
 // x86-sse-LABEL: <2 x i8> @f128_as_f16(
 // x86-nosse-LABEL: i16 @f128_as_f16(
-// bits32-LABEL: half @f128_as_f16(
-// bits64-LABEL: half @f128_as_f16(
+// bit32-LABEL: half @f128_as_f16(
+// bit64-LABEL: half @f128_as_f16(
 #[no_mangle]
 pub fn f128_as_f16(a: f128) -> f16 {
     // CHECK: fptrunc fp128 %{{.+}} to half

--- a/tests/codegen-llvm/nrvo.rs
+++ b/tests/codegen-llvm/nrvo.rs
@@ -10,7 +10,7 @@ pub fn nrvo(init: fn(&mut [u8; 4096])) -> [u8; 4096] {
     // CHECK: @llvm.memset
     // FIXME: turn on nrvo then check-not: @llvm.memcpy
     // CHECK: ret
-    // CHECK-EMPTY
+    // CHECK-EMPTY:
     let mut buf = [0; 4096];
     init(&mut buf);
     buf


### PR DESCRIPTION
Fixes few more filecheck issues.

Additionally there two tests: https://github.com/rust-lang/rust/blob/main/tests/codegen-llvm/virtual-function-elimination.rs and https://github.com/rust-lang/rust/blob/main/tests/codegen-llvm/virtual-function-elimination-32bit.rs which uses wrong (not existing) filecheck directive `CHECK-LABEL-NOT` they was added in rust-lang/rust#96285, so @flip1995