### PR TITLE
Remove unneeded `allow(unknown_attribute)` attributes

### DIFF
--- a/src/tools/miri/src/shims/native_lib/trace/parent.rs
+++ b/src/tools/miri/src/shims/native_lib/trace/parent.rs
@@ -500,7 +500,6 @@ fn handle_segfault(
     capstone_disassemble(&instr, addr, cs, acc_events).expect("Failed to disassemble instruction");
 
     // Move the instr ptr into the deprotection code.
-    #[allow(unknown_lints)]
     #[expect(clippy::as_conversions, function_casts_as_integer)]
     new_regs.set_ip(mempr_off as usize);
     // Don't mess up the stack by accident!

--- a/src/tools/miri/tests/pass/backtrace/backtrace-api-v1.rs
+++ b/src/tools/miri/tests/pass/backtrace/backtrace-api-v1.rs
@@ -1,7 +1,5 @@
 //@normalize-stderr-test: "::<.*>" -> ""
 
-#![allow(function_casts_as_integer)]
-
 #[inline(never)]
 fn func_a() -> Box<[*mut ()]> {
     func_b::<u8>()


### PR DESCRIPTION
Follow-up of https://github.com/rust-lang/rust/pull/141470.

I will restart CI tomorrow once new nightly is out.

r? @RalfJung 