### PR TITLE
Add new `failed_merged_doctest_compilation` rustdoc lint

### DIFF
--- a/src/librustdoc/doctest/markdown.rs
+++ b/src/librustdoc/doctest/markdown.rs
@@ -131,6 +131,7 @@ pub(crate) fn test(input: &Input, options: Options, dcx: DiagCtxtHandle<'_>) -> 
         standalone_tests,
         mergeable_tests,
         None,
+        None,
     );
     Ok(())
 }

--- a/src/librustdoc/lint.rs
+++ b/src/librustdoc/lint.rs
@@ -196,6 +196,17 @@ declare_rustdoc_lint! {
     "detects redundant explicit links in doc comments"
 }
 
+declare_rustdoc_lint! {
+    /// This lint is **warn-by-default**. It warns when merged doctests fail to compile
+    /// when running doctests. This is a `rustdoc` only lint, see the documentation in
+    /// the [rustdoc book].
+    ///
+    /// [rustdoc book]: ../../../rustdoc/lints.html#failed_merged_doctest_compilation
+    FAILED_MERGED_DOCTEST_COMPILATION,
+    Warn,
+    "warns when merged doctest fail to compile when running doctests"
+}
+
 pub(crate) static RUSTDOC_LINTS: Lazy<Vec<&'static Lint>> = Lazy::new(|| {
     vec![
         BROKEN_INTRA_DOC_LINKS,
@@ -209,6 +220,7 @@ pub(crate) static RUSTDOC_LINTS: Lazy<Vec<&'static Lint>> = Lazy::new(|| {
         MISSING_CRATE_LEVEL_DOCS,
         UNESCAPED_BACKTICKS,
         REDUNDANT_EXPLICIT_LINKS,
+        FAILED_MERGED_DOCTEST_COMPILATION,
     ]
 });
 

--- a/tests/rustdoc-ui/doctest/dead-code-2024.rs
+++ b/tests/rustdoc-ui/doctest/dead-code-2024.rs
@@ -8,6 +8,7 @@
 //@ normalize-stdout: "compilation took \d+\.\d+s" -> "compilation took $$TIME"
 //@ failure-status: 101
 
+#![allow(rustdoc::failed_merged_doctest_compilation)]
 #![doc(test(attr(allow(unused_variables), deny(warnings))))]
 
 /// Example

--- a/tests/rustdoc-ui/doctest/dead-code-2024.stdout
+++ b/tests/rustdoc-ui/doctest/dead-code-2024.stdout
@@ -1,18 +1,18 @@
 
 running 1 test
-test $DIR/dead-code-2024.rs - f (line 15) - compile ... FAILED
+test $DIR/dead-code-2024.rs - f (line 16) - compile ... FAILED
 
 failures:
 
----- $DIR/dead-code-2024.rs - f (line 15) stdout ----
+---- $DIR/dead-code-2024.rs - f (line 16) stdout ----
 error: trait `T` is never used
-  --> $DIR/dead-code-2024.rs:16:7
+  --> $DIR/dead-code-2024.rs:17:7
    |
 LL | trait T { fn f(); }
    |       ^
    |
 note: the lint level is defined here
-  --> $DIR/dead-code-2024.rs:14:9
+  --> $DIR/dead-code-2024.rs:15:9
    |
 LL | #![deny(warnings)]
    |         ^^^^^^^^
@@ -23,7 +23,7 @@ error: aborting due to 1 previous error
 Couldn't compile the test.
 
 failures:
-    $DIR/dead-code-2024.rs - f (line 15)
+    $DIR/dead-code-2024.rs - f (line 16)
 
 test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
 

--- a/tests/rustdoc-ui/doctest/dead-code-items.rs
+++ b/tests/rustdoc-ui/doctest/dead-code-items.rs
@@ -9,6 +9,7 @@
 //@ failure-status: 101
 
 #![doc(test(attr(deny(warnings))))]
+#![allow(rustdoc::failed_merged_doctest_compilation)]
 
 #[doc(test(attr(allow(dead_code))))]
 /// Example

--- a/tests/rustdoc-ui/doctest/dead-code-items.stdout
+++ b/tests/rustdoc-ui/doctest/dead-code-items.stdout
@@ -1,30 +1,30 @@
 
 running 13 tests
-test $DIR/dead-code-items.rs - A (line 34) - compile ... ok
-test $DIR/dead-code-items.rs - A (line 90) - compile ... ok
-test $DIR/dead-code-items.rs - A::field (line 41) - compile ... FAILED
-test $DIR/dead-code-items.rs - A::method (line 96) - compile ... ok
-test $DIR/dead-code-items.rs - C (line 24) - compile ... FAILED
-test $DIR/dead-code-items.rs - Enum (line 72) - compile ... FAILED
-test $DIR/dead-code-items.rs - Enum::Variant1 (line 79) - compile ... FAILED
-test $DIR/dead-code-items.rs - MyTrait (line 105) - compile ... FAILED
-test $DIR/dead-code-items.rs - MyTrait::my_trait_fn (line 112) - compile ... FAILED
-test $DIR/dead-code-items.rs - S (line 16) - compile ... ok
-test $DIR/dead-code-items.rs - U (line 50) - compile ... ok
-test $DIR/dead-code-items.rs - U::field (line 57) - compile ... FAILED
-test $DIR/dead-code-items.rs - U::field2 (line 63) - compile ... ok
+test $DIR/dead-code-items.rs - A (line 35) - compile ... ok
+test $DIR/dead-code-items.rs - A (line 91) - compile ... ok
+test $DIR/dead-code-items.rs - A::field (line 42) - compile ... FAILED
+test $DIR/dead-code-items.rs - A::method (line 97) - compile ... ok
+test $DIR/dead-code-items.rs - C (line 25) - compile ... FAILED
+test $DIR/dead-code-items.rs - Enum (line 73) - compile ... FAILED
+test $DIR/dead-code-items.rs - Enum::Variant1 (line 80) - compile ... FAILED
+test $DIR/dead-code-items.rs - MyTrait (line 106) - compile ... FAILED
+test $DIR/dead-code-items.rs - MyTrait::my_trait_fn (line 113) - compile ... FAILED
+test $DIR/dead-code-items.rs - S (line 17) - compile ... ok
+test $DIR/dead-code-items.rs - U (line 51) - compile ... ok
+test $DIR/dead-code-items.rs - U::field (line 58) - compile ... FAILED
+test $DIR/dead-code-items.rs - U::field2 (line 64) - compile ... ok
 
 failures:
 
----- $DIR/dead-code-items.rs - A::field (line 41) stdout ----
+---- $DIR/dead-code-items.rs - A::field (line 42) stdout ----
 error: trait `DeadCodeInField` is never used
-  --> $DIR/dead-code-items.rs:42:7
+  --> $DIR/dead-code-items.rs:43:7
    |
 LL | trait DeadCodeInField {}
    |       ^^^^^^^^^^^^^^^
    |
 note: the lint level is defined here
-  --> $DIR/dead-code-items.rs:40:9
+  --> $DIR/dead-code-items.rs:41:9
    |
 LL | #![deny(dead_code)]
    |         ^^^^^^^^^
@@ -32,15 +32,15 @@ LL | #![deny(dead_code)]
 error: aborting due to 1 previous error
 
 Couldn't compile the test.
----- $DIR/dead-code-items.rs - C (line 24) stdout ----
+---- $DIR/dead-code-items.rs - C (line 25) stdout ----
 error: unused variable: `unused_error`
-  --> $DIR/dead-code-items.rs:25:5
+  --> $DIR/dead-code-items.rs:26:5
    |
 LL | let unused_error = 5;
    |     ^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_unused_error`
    |
 note: the lint level is defined here
-  --> $DIR/dead-code-items.rs:22:9
+  --> $DIR/dead-code-items.rs:23:9
    |
 LL | #![deny(warnings)]
    |         ^^^^^^^^
@@ -49,15 +49,15 @@ LL | #![deny(warnings)]
 error: aborting due to 1 previous error
 
 Couldn't compile the test.
----- $DIR/dead-code-items.rs - Enum (line 72) stdout ----
+---- $DIR/dead-code-items.rs - Enum (line 73) stdout ----
 error: unused variable: `not_dead_code_but_unused`
-  --> $DIR/dead-code-items.rs:73:5
+  --> $DIR/dead-code-items.rs:74:5
    |
 LL | let not_dead_code_but_unused = 5;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_not_dead_code_but_unused`
    |
 note: the lint level is defined here
-  --> $DIR/dead-code-items.rs:70:9
+  --> $DIR/dead-code-items.rs:71:9
    |
 LL | #![deny(warnings)]
    |         ^^^^^^^^
@@ -66,15 +66,15 @@ LL | #![deny(warnings)]
 error: aborting due to 1 previous error
 
 Couldn't compile the test.
----- $DIR/dead-code-items.rs - Enum::Variant1 (line 79) stdout ----
+---- $DIR/dead-code-items.rs - Enum::Variant1 (line 80) stdout ----
 error: unused variable: `unused_in_variant`
-  --> $DIR/dead-code-items.rs:82:17
+  --> $DIR/dead-code-items.rs:83:17
    |
 LL | fn main() { let unused_in_variant = 5; }
    |                 ^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_unused_in_variant`
    |
 note: the lint level is defined here
-  --> $DIR/dead-code-items.rs:77:9
+  --> $DIR/dead-code-items.rs:78:9
    |
 LL | #![deny(warnings)]
    |         ^^^^^^^^
@@ -83,15 +83,15 @@ LL | #![deny(warnings)]
 error: aborting due to 1 previous error
 
 Couldn't compile the test.
----- $DIR/dead-code-items.rs - MyTrait (line 105) stdout ----
+---- $DIR/dead-code-items.rs - MyTrait (line 106) stdout ----
 error: trait `StillDeadCodeAtMyTrait` is never used
-  --> $DIR/dead-code-items.rs:106:7
+  --> $DIR/dead-code-items.rs:107:7
    |
 LL | trait StillDeadCodeAtMyTrait { }
    |       ^^^^^^^^^^^^^^^^^^^^^^
    |
 note: the lint level is defined here
-  --> $DIR/dead-code-items.rs:104:9
+  --> $DIR/dead-code-items.rs:105:9
    |
 LL | #![deny(dead_code)]
    |         ^^^^^^^^^
@@ -99,15 +99,15 @@ LL | #![deny(dead_code)]
 error: aborting due to 1 previous error
 
 Couldn't compile the test.
----- $DIR/dead-code-items.rs - MyTrait::my_trait_fn (line 112) stdout ----
+---- $DIR/dead-code-items.rs - MyTrait::my_trait_fn (line 113) stdout ----
 error: unused variable: `unused_in_impl`
-  --> $DIR/dead-code-items.rs:115:17
+  --> $DIR/dead-code-items.rs:116:17
    |
 LL | fn main() { let unused_in_impl = 5; }
    |                 ^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_unused_in_impl`
    |
 note: the lint level is defined here
-  --> $DIR/dead-code-items.rs:110:9
+  --> $DIR/dead-code-items.rs:111:9
    |
 LL | #![deny(warnings)]
    |         ^^^^^^^^
@@ -116,15 +116,15 @@ LL | #![deny(warnings)]
 error: aborting due to 1 previous error
 
 Couldn't compile the test.
----- $DIR/dead-code-items.rs - U::field (line 57) stdout ----
+---- $DIR/dead-code-items.rs - U::field (line 58) stdout ----
 error: trait `DeadCodeInUnionField` is never used
-  --> $DIR/dead-code-items.rs:58:7
+  --> $DIR/dead-code-items.rs:59:7
    |
 LL | trait DeadCodeInUnionField {}
    |       ^^^^^^^^^^^^^^^^^^^^
    |
 note: the lint level is defined here
-  --> $DIR/dead-code-items.rs:56:9
+  --> $DIR/dead-code-items.rs:57:9
    |
 LL | #![deny(dead_code)]
    |         ^^^^^^^^^
@@ -134,13 +134,13 @@ error: aborting due to 1 previous error
 Couldn't compile the test.
 
 failures:
-    $DIR/dead-code-items.rs - A::field (line 41)
-    $DIR/dead-code-items.rs - C (line 24)
-    $DIR/dead-code-items.rs - Enum (line 72)
-    $DIR/dead-code-items.rs - Enum::Variant1 (line 79)
-    $DIR/dead-code-items.rs - MyTrait (line 105)
-    $DIR/dead-code-items.rs - MyTrait::my_trait_fn (line 112)
-    $DIR/dead-code-items.rs - U::field (line 57)
+    $DIR/dead-code-items.rs - A::field (line 42)
+    $DIR/dead-code-items.rs - C (line 25)
+    $DIR/dead-code-items.rs - Enum (line 73)
+    $DIR/dead-code-items.rs - Enum::Variant1 (line 80)
+    $DIR/dead-code-items.rs - MyTrait (line 106)
+    $DIR/dead-code-items.rs - MyTrait::my_trait_fn (line 113)
+    $DIR/dead-code-items.rs - U::field (line 58)
 
 test result: FAILED. 6 passed; 7 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
 

--- a/tests/rustdoc-ui/doctest/dead-code-module-2.rs
+++ b/tests/rustdoc-ui/doctest/dead-code-module-2.rs
@@ -9,6 +9,7 @@
 //@ failure-status: 101
 
 #![doc(test(attr(allow(unused_variables))))]
+#![allow(rustdoc::failed_merged_doctest_compilation)]
 
 mod my_mod {
     #![doc(test(attr(deny(warnings))))]

--- a/tests/rustdoc-ui/doctest/dead-code-module-2.stdout
+++ b/tests/rustdoc-ui/doctest/dead-code-module-2.stdout
@@ -1,24 +1,24 @@
 
 running 1 test
-test $DIR/dead-code-module-2.rs - g (line 26) - compile ... ok
+test $DIR/dead-code-module-2.rs - g (line 27) - compile ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
 
 
 running 1 test
-test $DIR/dead-code-module-2.rs - my_mod::f (line 18) - compile ... FAILED
+test $DIR/dead-code-module-2.rs - my_mod::f (line 19) - compile ... FAILED
 
 failures:
 
----- $DIR/dead-code-module-2.rs - my_mod::f (line 18) stdout ----
+---- $DIR/dead-code-module-2.rs - my_mod::f (line 19) stdout ----
 error: trait `T` is never used
-  --> $DIR/dead-code-module-2.rs:19:7
+  --> $DIR/dead-code-module-2.rs:20:7
    |
 LL | trait T { fn f(); }
    |       ^
    |
 note: the lint level is defined here
-  --> $DIR/dead-code-module-2.rs:17:9
+  --> $DIR/dead-code-module-2.rs:18:9
    |
 LL | #![deny(warnings)]
    |         ^^^^^^^^
@@ -29,7 +29,7 @@ error: aborting due to 1 previous error
 Couldn't compile the test.
 
 failures:
-    $DIR/dead-code-module-2.rs - my_mod::f (line 18)
+    $DIR/dead-code-module-2.rs - my_mod::f (line 19)
 
 test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
 

--- a/tests/rustdoc-ui/doctest/dead-code-module.rs
+++ b/tests/rustdoc-ui/doctest/dead-code-module.rs
@@ -8,6 +8,8 @@
 //@ normalize-stdout: "compilation took \d+\.\d+s" -> "compilation took $$TIME"
 //@ failure-status: 101
 
+#![allow(rustdoc::failed_merged_doctest_compilation)]
+
 mod my_mod {
     #![doc(test(attr(allow(unused_variables), deny(warnings))))]
 

--- a/tests/rustdoc-ui/doctest/dead-code-module.stdout
+++ b/tests/rustdoc-ui/doctest/dead-code-module.stdout
@@ -1,18 +1,18 @@
 
 running 1 test
-test $DIR/dead-code-module.rs - my_mod::f (line 16) - compile ... FAILED
+test $DIR/dead-code-module.rs - my_mod::f (line 18) - compile ... FAILED
 
 failures:
 
----- $DIR/dead-code-module.rs - my_mod::f (line 16) stdout ----
+---- $DIR/dead-code-module.rs - my_mod::f (line 18) stdout ----
 error: trait `T` is never used
-  --> $DIR/dead-code-module.rs:17:7
+  --> $DIR/dead-code-module.rs:19:7
    |
 LL | trait T { fn f(); }
    |       ^
    |
 note: the lint level is defined here
-  --> $DIR/dead-code-module.rs:15:9
+  --> $DIR/dead-code-module.rs:17:9
    |
 LL | #![deny(warnings)]
    |         ^^^^^^^^
@@ -23,7 +23,7 @@ error: aborting due to 1 previous error
 Couldn't compile the test.
 
 failures:
-    $DIR/dead-code-module.rs - my_mod::f (line 16)
+    $DIR/dead-code-module.rs - my_mod::f (line 18)
 
 test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
 

--- a/tests/rustdoc-ui/doctest/doctest-output-include-fail.rs
+++ b/tests/rustdoc-ui/doctest/doctest-output-include-fail.rs
@@ -6,5 +6,7 @@
 //@ normalize-stdout: "compilation took \d+\.\d+s" -> "compilation took $$TIME"
 //@ failure-status: 101
 
+#![allow(rustdoc::failed_merged_doctest_compilation)]
+
 // https://github.com/rust-lang/rust/issues/130470
 #![doc = include_str!("doctest-output-include-fail.md")]

--- a/tests/rustdoc-ui/doctest/failed-doctest-test-crate.edition2015.stdout
+++ b/tests/rustdoc-ui/doctest/failed-doctest-test-crate.edition2015.stdout
@@ -1,12 +1,12 @@
 
 running 1 test
-test $DIR/failed-doctest-test-crate.rs - m (line 16) ... FAILED
+test $DIR/failed-doctest-test-crate.rs - m (line 18) ... FAILED
 
 failures:
 
----- $DIR/failed-doctest-test-crate.rs - m (line 16) stdout ----
+---- $DIR/failed-doctest-test-crate.rs - m (line 18) stdout ----
 error[E0432]: unresolved import `test`
-  --> $DIR/failed-doctest-test-crate.rs:17:5
+  --> $DIR/failed-doctest-test-crate.rs:19:5
    |
 LL | use test::*;
    |     ^^^^ use of unresolved module or unlinked crate `test`
@@ -22,7 +22,7 @@ For more information about this error, try `rustc --explain E0432`.
 Couldn't compile the test.
 
 failures:
-    $DIR/failed-doctest-test-crate.rs - m (line 16)
+    $DIR/failed-doctest-test-crate.rs - m (line 18)
 
 test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
 

--- a/tests/rustdoc-ui/doctest/failed-doctest-test-crate.edition2024.stdout
+++ b/tests/rustdoc-ui/doctest/failed-doctest-test-crate.edition2024.stdout
@@ -1,12 +1,12 @@
 
 running 1 test
-test $DIR/failed-doctest-test-crate.rs - m (line 16) ... FAILED
+test $DIR/failed-doctest-test-crate.rs - m (line 18) ... FAILED
 
 failures:
 
----- $DIR/failed-doctest-test-crate.rs - m (line 16) stdout ----
+---- $DIR/failed-doctest-test-crate.rs - m (line 18) stdout ----
 error[E0432]: unresolved import `test`
-  --> $DIR/failed-doctest-test-crate.rs:17:5
+  --> $DIR/failed-doctest-test-crate.rs:19:5
    |
 LL | use test::*;
    |     ^^^^ use of unresolved module or unlinked crate `test`
@@ -19,7 +19,7 @@ For more information about this error, try `rustc --explain E0432`.
 Couldn't compile the test.
 
 failures:
-    $DIR/failed-doctest-test-crate.rs - m (line 16)
+    $DIR/failed-doctest-test-crate.rs - m (line 18)
 
 test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
 

--- a/tests/rustdoc-ui/doctest/failed-doctest-test-crate.rs
+++ b/tests/rustdoc-ui/doctest/failed-doctest-test-crate.rs
@@ -11,6 +11,8 @@
 //@ normalize-stdout: "compilation took \d+\.\d+s" -> "compilation took $$TIME"
 //@ failure-status: 101
 
+#![allow(rustdoc::failed_merged_doctest_compilation)]
+
 /// <https://github.com/rust-lang/rust/pull/137899#discussion_r1976743383>
 ///
 /// ```rust

--- a/tests/rustdoc-ui/doctest/failed_merged_doctest_compilation-lint.rs
+++ b/tests/rustdoc-ui/doctest/failed_merged_doctest_compilation-lint.rs
@@ -1,0 +1,16 @@
+// Regression test for the `failed_merged_doctest_compilation` lint.
+
+//@ edition: 2024
+//@ compile-flags:--test
+//@ normalize-stdout: "tests/rustdoc-ui/doctest" -> "$$DIR"
+//@ normalize-stdout: "finished in \d+\.\d+s" -> "finished in $$TIME"
+//@ normalize-stdout: "ran in \d+\.\d+s" -> "ran in $$TIME"
+//@ normalize-stdout: "compilation took \d+\.\d+s" -> "compilation took $$TIME"
+//@ failure-status: 101
+
+#![deny(rustdoc::failed_merged_doctest_compilation)] //~ ERROR
+
+//! ```
+//!
+//! let x
+//! ```

--- a/tests/rustdoc-ui/doctest/failed_merged_doctest_compilation-lint.stderr
+++ b/tests/rustdoc-ui/doctest/failed_merged_doctest_compilation-lint.stderr
@@ -1,0 +1,17 @@
+error: failed to compile merged doctests for edition 2024. Reverting to standalone doctests.
+  --> $DIR/failed_merged_doctest_compilation-lint.rs:11:1
+   |
+LL | / #![deny(rustdoc::failed_merged_doctest_compilation)]
+LL | |
+LL | | //! ```
+LL | | //!
+LL | | //! let x
+LL | | //! ```
+   | |_______^
+   |
+note: the lint level is defined here
+  --> $DIR/failed_merged_doctest_compilation-lint.rs:11:9
+   |
+LL | #![deny(rustdoc::failed_merged_doctest_compilation)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+

--- a/tests/rustdoc-ui/doctest/failed_merged_doctest_compilation-lint.stdout
+++ b/tests/rustdoc-ui/doctest/failed_merged_doctest_compilation-lint.stdout
@@ -1,0 +1,37 @@
+
+running 1 test
+test $DIR/failed_merged_doctest_compilation-lint.rs - (line 13) ... FAILED
+
+failures:
+
+---- $DIR/failed_merged_doctest_compilation-lint.rs - (line 13) stdout ----
+error: expected `;`, found `}`
+  --> $DIR/failed_merged_doctest_compilation-lint.rs:14:6
+   |
+LL | let x
+   |      ^ help: add `;` here
+LL | } _doctest_main_tests_rustdoc_ui_doctest_failed_merged_doctest_compilation_lint_rs_13_0() }
+   | - unexpected token
+
+error[E0282]: type annotations needed
+  --> $DIR/failed_merged_doctest_compilation-lint.rs:14:5
+   |
+LL | let x
+   |     ^
+   |
+help: consider giving `x` an explicit type
+   |
+LL | let x: /* Type */
+   |      ++++++++++++
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0282`.
+Couldn't compile the test.
+
+failures:
+    $DIR/failed_merged_doctest_compilation-lint.rs - (line 13)
+
+test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
+
+all doctests ran in $TIME; merged doctests compilation took $TIME

--- a/tests/rustdoc-ui/doctest/relative-path-include-bytes-132203.edition2015.stdout
+++ b/tests/rustdoc-ui/doctest/relative-path-include-bytes-132203.edition2015.stdout
@@ -1,12 +1,12 @@
 
 running 1 test
-test $DIR/relative-path-include-bytes-132203.rs - (line 20) ... FAILED
+test $DIR/relative-path-include-bytes-132203.rs - (line 22) ... FAILED
 
 failures:
 
----- $DIR/relative-path-include-bytes-132203.rs - (line 20) stdout ----
+---- $DIR/relative-path-include-bytes-132203.rs - (line 22) stdout ----
 error: couldn't read `$DIR/relative-dir-empty-file`: $FILE_NOT_FOUND_MSG (os error 2)
-  --> $DIR/relative-path-include-bytes-132203.rs:21:9
+  --> $DIR/relative-path-include-bytes-132203.rs:23:9
    |
 LL | let x = include_bytes!("relative-dir-empty-file");
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -16,7 +16,7 @@ error: aborting due to 1 previous error
 Couldn't compile the test.
 
 failures:
-    $DIR/relative-path-include-bytes-132203.rs - (line 20)
+    $DIR/relative-path-include-bytes-132203.rs - (line 22)
 
 test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
 

--- a/tests/rustdoc-ui/doctest/relative-path-include-bytes-132203.rs
+++ b/tests/rustdoc-ui/doctest/relative-path-include-bytes-132203.rs
@@ -17,4 +17,6 @@
 // relative path. The edition2015 version fails, because paths are
 // resolved relative to the rs file instead of relative to the md file.
 
+#![allow(rustdoc::failed_merged_doctest_compilation)]
+
 #![doc=include_str!("auxiliary/relative-dir.md")]


### PR DESCRIPTION
Finally took the time to write this lint. We need to have a compiler context in order to be able to emit the lint, but I'm not sure if `DiagCtxtHandle` doesn't provide it somehow... Anyway, I'm expecting performance regression because we keep the compiler and its internals around for much longer, stacking doctests memory on top of the allocated memory to the current crate (which is why I'd really love to see if it's possible to emit lints from `DiagCtxtHandle` somehow, gonna investigate).

Also: both lint name and lint message are very much up to debate.

r? @fmease 