### PR TITLE
bootstrap: dont require cmake if local-rebuild is enabled

### DIFF
--- a/src/bootstrap/src/core/sanity.rs
+++ b/src/bootstrap/src/core/sanity.rs
@@ -142,6 +142,7 @@ pub fn check(build: &mut Build) {
 
     // We need cmake, but only if we're actually building LLVM or sanitizers.
     let building_llvm = !build.config.llvm_from_ci
+        && !build.config.local_rebuild
         && build.hosts.iter().any(|host| {
             build.config.llvm_enabled(*host)
                 && build


### PR DESCRIPTION
This is for people rebuilding stdlib directly from stage 0 with the full toolchain from rust-src rustup component. The toolchain itself should have sufficient LLVM tools, so CMake and LLVM are not required when `build.local-rebuild = true`

Fixes rust-lang/rust#148835

r? Kobzol 
