### PR TITLE
Add riscv64a23-unknown-linux-gnu to build-manifest TARGETS

### DIFF
--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -153,6 +153,7 @@ static TARGETS: &[&str] = &[
     "riscv32imafc-unknown-none-elf",
     "riscv32gc-unknown-linux-gnu",
     "riscv64imac-unknown-none-elf",
+    "riscv64a23-unknown-linux-gnu",
     "riscv64gc-unknown-hermit",
     "riscv64gc-unknown-none-elf",
     "riscv64gc-unknown-linux-gnu",


### PR DESCRIPTION
This enables rustup distribution of the rust-std component for the riscv64a23-unknown-linux-gnu target
(Previous PR rust-lang/rust#148435 missed this step.)

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
