### PR TITLE
Disable rustdoc-test-builder test partially for SGX target.

### DIFF
--- a/tests/run-make/rustdoc-test-builder/rmake.rs
+++ b/tests/run-make/rustdoc-test-builder/rmake.rs
@@ -25,7 +25,10 @@ fn main() {
 
     // Some targets (for example wasm) cannot execute doctests directly even with a runner,
     // so only exercise the success path when the target can run on the host.
-    if target().contains("wasm") || std::env::var_os("REMOTE_TEST_CLIENT").is_some() {
+    if target().contains("wasm")
+        || target().contains("sgx")
+        || std::env::var_os("REMOTE_TEST_CLIENT").is_some()
+    {
         return;
     }
 


### PR DESCRIPTION
The `rustdoc-test-builder` test started to fail after https://github.com/rust-lang/rust/pull/148608 for SGX target. The reason is, sgx binary can not be executed directly so rustdoc fails to execute passed `--test-builder` binary. This PR simply ignores the success part just like it ignores for `wasm` target.

Thank you.