### PR TITLE
add missing s390x target feature to std detect test

### DIFF
--- a/library/std/tests/run-time-detect.rs
+++ b/library/std/tests/run-time-detect.rs
@@ -16,6 +16,7 @@
     all(target_arch = "powerpc64", target_os = "linux"),
     feature(stdarch_powerpc_feature_detection)
 )]
+#![cfg_attr(all(target_arch = "s390x", target_os = "linux"), feature(s390x_target_feature))]
 
 #[test]
 #[cfg(all(target_arch = "arm", any(target_os = "linux", target_os = "android")))]


### PR DESCRIPTION
Fix an oversight from https://github.com/rust-lang/rust/pull/145656, where the `is_s390x_feature_detected!` macro and some target features were stabilized, but other target features remain unstable under a new target feature name.

I tested this locally using a `stage1` build on the test file with the `s390x-unknown-linux-gnu` target.

cc @uweigand 
r? @Amanieu (or whoever really)
