### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/compiler/rustc_expand/src/base.rs
+++ b/compiler/rustc_expand/src/base.rs
@@ -1099,6 +1099,9 @@ pub struct Indeterminate;
 pub struct DeriveResolution {
     pub path: ast::Path,
     pub item: Annotatable,
+    // FIXME: currently this field is only used in `is_none`/`is_some` conditions. However, the
+    // `Arc<SyntaxExtension>` will be used if the FIXME in `MacroExpander::fully_expand_fragment`
+    // is completed.
     pub exts: Option<Arc<SyntaxExtension>>,
     pub is_const: bool,
 }

--- a/compiler/rustc_hir_typeck/src/inline_asm.rs
+++ b/compiler/rustc_hir_typeck/src/inline_asm.rs
@@ -93,6 +93,14 @@ impl<'a, 'tcx> InlineAsmCtxt<'a, 'tcx> {
                 }
             }
             ty::Adt(adt, args) if adt.repr().simd() => {
+                if !adt.is_struct() {
+                    self.fcx.dcx().span_delayed_bug(
+                        span,
+                        format!("repr(simd) should only be used on structs, got {}", adt.descr()),
+                    );
+                    return Err(NonAsmTypeReason::Invalid(ty));
+                }
+
                 let fields = &adt.non_enum_variant().fields;
                 if fields.is_empty() {
                     return Err(NonAsmTypeReason::EmptySIMDArray(ty));

--- a/compiler/rustc_resolve/src/ident.rs
+++ b/compiler/rustc_resolve/src/ident.rs
@@ -458,14 +458,11 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                         let mut result = Err(Determinacy::Determined);
                         for derive in parent_scope.derives {
                             let parent_scope = &ParentScope { derives: &[], ..*parent_scope };
-                            match this.reborrow().resolve_macro_path(
+                            match this.reborrow().resolve_derive_macro_path(
                                 derive,
-                                MacroKind::Derive,
                                 parent_scope,
-                                true,
                                 force,
                                 ignore_import,
-                                None,
                             ) {
                                 Ok((Some(ext), _)) => {
                                     if ext.helper_attrs.contains(&ident.name) {

--- a/compiler/rustc_resolve/src/macros.rs
+++ b/compiler/rustc_resolve/src/macros.rs
@@ -395,13 +395,10 @@ impl<'ra, 'tcx> ResolverExpand for Resolver<'ra, 'tcx> {
         for (i, resolution) in entry.resolutions.iter_mut().enumerate() {
             if resolution.exts.is_none() {
                 resolution.exts = Some(
-                    match self.cm().resolve_macro_path(
+                    match self.cm().resolve_derive_macro_path(
                         &resolution.path,
-                        MacroKind::Derive,
                         &parent_scope,
-                        true,
                         force,
-                        None,
                         None,
                     ) {
                         Ok((Some(ext), _)) => {
@@ -706,26 +703,23 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         Ok((ext, res))
     }
 
-    pub(crate) fn resolve_macro_path<'r>(
+    pub(crate) fn resolve_derive_macro_path<'r>(
         self: CmResolver<'r, 'ra, 'tcx>,
         path: &ast::Path,
-        kind: MacroKind,
         parent_scope: &ParentScope<'ra>,
-        trace: bool,
         force: bool,
         ignore_import: Option<Import<'ra>>,
-        suggestion_span: Option<Span>,
     ) -> Result<(Option<Arc<SyntaxExtension>>, Res), Determinacy> {
         self.resolve_macro_or_delegation_path(
             path,
-            kind,
+            MacroKind::Derive,
             parent_scope,
-            trace,
+            true,
             force,
             None,
             None,
             ignore_import,
-            suggestion_span,
+            None,
         )
     }
 

--- a/compiler/rustc_resolve/src/macros.rs
+++ b/compiler/rustc_resolve/src/macros.rs
@@ -561,7 +561,6 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             path,
             kind,
             parent_scope,
-            true,
             force,
             deleg_impl,
             invoc_in_mod_inert_attr.map(|def_id| (def_id, node_id)),
@@ -714,7 +713,6 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             path,
             MacroKind::Derive,
             parent_scope,
-            true,
             force,
             None,
             None,
@@ -728,7 +726,6 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         ast_path: &ast::Path,
         kind: MacroKind,
         parent_scope: &ParentScope<'ra>,
-        trace: bool,
         force: bool,
         deleg_impl: Option<LocalDefId>,
         invoc_in_mod_inert_attr: Option<(LocalDefId, NodeId)>,
@@ -767,16 +764,14 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 PathResult::Module(..) => unreachable!(),
             };
 
-            if trace {
-                self.multi_segment_macro_resolutions.borrow_mut(&self).push((
-                    path,
-                    path_span,
-                    kind,
-                    *parent_scope,
-                    res.ok(),
-                    ns,
-                ));
-            }
+            self.multi_segment_macro_resolutions.borrow_mut(&self).push((
+                path,
+                path_span,
+                kind,
+                *parent_scope,
+                res.ok(),
+                ns,
+            ));
 
             self.prohibit_imported_non_macro_attrs(None, res.ok(), path_span);
             res
@@ -794,15 +789,13 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 return Err(Determinacy::Undetermined);
             }
 
-            if trace {
-                self.single_segment_macro_resolutions.borrow_mut(&self).push((
-                    path[0].ident,
-                    kind,
-                    *parent_scope,
-                    binding.ok(),
-                    suggestion_span,
-                ));
-            }
+            self.single_segment_macro_resolutions.borrow_mut(&self).push((
+                path[0].ident,
+                kind,
+                *parent_scope,
+                binding.ok(),
+                suggestion_span,
+            ));
 
             let res = binding.map(|binding| binding.res());
             self.prohibit_imported_non_macro_attrs(binding.ok(), res.ok(), path_span);

--- a/library/core/src/time.rs
+++ b/library/core/src/time.rs
@@ -317,7 +317,6 @@ impl Duration {
     /// # Examples
     ///
     /// ```
-    /// #![feature(duration_from_nanos_u128)]
     /// use std::time::Duration;
     ///
     /// let nanos = 10_u128.pow(24) + 321;
@@ -326,12 +325,12 @@ impl Duration {
     /// assert_eq!(10_u64.pow(15), duration.as_secs());
     /// assert_eq!(321, duration.subsec_nanos());
     /// ```
-    #[unstable(feature = "duration_from_nanos_u128", issue = "139201")]
-    // This is necessary because of const `try_from`, but can be removed if a trait-free impl is used instead
-    #[rustc_const_unstable(feature = "duration_from_nanos_u128", issue = "139201")]
+    #[stable(feature = "duration_from_nanos_u128", since = "CURRENT_RUSTC_VERSION")]
+    #[rustc_const_stable(feature = "duration_from_nanos_u128", since = "CURRENT_RUSTC_VERSION")]
     #[must_use]
     #[inline]
     #[track_caller]
+    #[rustc_allow_const_fn_unstable(const_trait_impl, const_convert)] // for `u64::try_from`
     pub const fn from_nanos_u128(nanos: u128) -> Duration {
         const NANOS_PER_SEC: u128 = self::NANOS_PER_SEC as u128;
         let Ok(secs) = u64::try_from(nanos / NANOS_PER_SEC) else {

--- a/library/coretests/tests/lib.rs
+++ b/library/coretests/tests/lib.rs
@@ -42,7 +42,6 @@
 #![feature(drop_guard)]
 #![feature(duration_constants)]
 #![feature(duration_constructors)]
-#![feature(duration_from_nanos_u128)]
 #![feature(error_generic_member_access)]
 #![feature(exact_div)]
 #![feature(exact_size_is_empty)]

--- a/src/tools/miri/src/lib.rs
+++ b/src/tools/miri/src/lib.rs
@@ -17,7 +17,7 @@
 #![feature(derive_coerce_pointee)]
 #![feature(arbitrary_self_types)]
 #![feature(iter_advance_by)]
-#![feature(duration_from_nanos_u128)]
+#![cfg_attr(bootstrap, feature(duration_from_nanos_u128))]
 // Configure clippy and other lints
 #![allow(
     clippy::collapsible_else_if,

--- a/tests/run-make/rustdoc-test-builder/rmake.rs
+++ b/tests/run-make/rustdoc-test-builder/rmake.rs
@@ -25,7 +25,10 @@ fn main() {
 
     // Some targets (for example wasm) cannot execute doctests directly even with a runner,
     // so only exercise the success path when the target can run on the host.
-    if target().contains("wasm") || std::env::var_os("REMOTE_TEST_CLIENT").is_some() {
+    if target().contains("wasm")
+        || target().contains("sgx")
+        || std::env::var_os("REMOTE_TEST_CLIENT").is_some()
+    {
         return;
     }
 

--- a/tests/ui/asm/invalid-repr-simd-on-enum-148634.rs
+++ b/tests/ui/asm/invalid-repr-simd-on-enum-148634.rs
@@ -11,6 +11,5 @@ fn main() {
     unsafe {
         let mut x: Es;
         asm!("{}", out(reg) x);
-        //~^ ERROR cannot use value of type `Es` for inline assembly
     }
 }

--- a/tests/ui/asm/invalid-repr-simd-on-enum-148634.rs
+++ b/tests/ui/asm/invalid-repr-simd-on-enum-148634.rs
@@ -1,0 +1,16 @@
+#![feature(repr_simd)]
+
+use std::arch::asm;
+
+#[repr(simd)]
+//~^ ERROR attribute should be applied to a struct
+//~| ERROR unsupported representation for zero-variant enum
+enum Es {}
+
+fn main() {
+    unsafe {
+        let mut x: Es;
+        asm!("{}", out(reg) x);
+        //~^ ERROR cannot use value of type `Es` for inline assembly
+    }
+}

--- a/tests/ui/asm/invalid-repr-simd-on-enum-148634.stderr
+++ b/tests/ui/asm/invalid-repr-simd-on-enum-148634.stderr
@@ -16,15 +16,7 @@ LL | #[repr(simd)]
 LL | enum Es {}
    | ------- zero-variant enum
 
-error: cannot use value of type `Es` for inline assembly
-  --> $DIR/invalid-repr-simd-on-enum-148634.rs:13:29
-   |
-LL |         asm!("{}", out(reg) x);
-   |                             ^
-   |
-   = note: only integers, floats, SIMD vectors, pointers and function pointers can be used as arguments for inline assembly
-
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 
 Some errors have detailed explanations: E0084, E0517.
 For more information about an error, try `rustc --explain E0084`.

--- a/tests/ui/asm/invalid-repr-simd-on-enum-148634.stderr
+++ b/tests/ui/asm/invalid-repr-simd-on-enum-148634.stderr
@@ -1,0 +1,30 @@
+error[E0517]: attribute should be applied to a struct
+  --> $DIR/invalid-repr-simd-on-enum-148634.rs:5:8
+   |
+LL | #[repr(simd)]
+   |        ^^^^
+...
+LL | enum Es {}
+   | ---------- not a struct
+
+error[E0084]: unsupported representation for zero-variant enum
+  --> $DIR/invalid-repr-simd-on-enum-148634.rs:5:8
+   |
+LL | #[repr(simd)]
+   |        ^^^^
+...
+LL | enum Es {}
+   | ------- zero-variant enum
+
+error: cannot use value of type `Es` for inline assembly
+  --> $DIR/invalid-repr-simd-on-enum-148634.rs:13:29
+   |
+LL |         asm!("{}", out(reg) x);
+   |                             ^
+   |
+   = note: only integers, floats, SIMD vectors, pointers and function pointers can be used as arguments for inline assembly
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0084, E0517.
+For more information about an error, try `rustc --explain E0084`.


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#148587 (stabilize duration_from_nanos_u128)
 - rust-lang/rust#148638 (Fix ICE for repr simd on non struct)
 - rust-lang/rust#148808 (Some resolve cleanups)
 - rust-lang/rust#148901 (Disable rustdoc-test-builder test partially for SGX target.)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=148587,148638,148808,148901)
<!-- homu-ignore:end -->