### PR TITLE
waffle: stop watching codegen ssa

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -922,9 +922,6 @@ cc = ["@davidtwco", "@wesleywiser"]
 [mentions."compiler/rustc_codegen_cranelift"]
 cc = ["@bjorn3"]
 
-[mentions."compiler/rustc_codegen_ssa"]
-cc = ["@WaffleLapkin"]
-
 [mentions."compiler/rustc_codegen_gcc"]
 cc = ["@antoyo", "@GuillaumeGomez"]
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

There is a surprising amount of PRs being open to codegen ssa, notification spam makes me stressed. I don't think knowing everything being changed in cg_ssa is useful for me, as most changes are irrelevant to me.