### PR TITLE
Expose fmt::Arguments::from_str as unstable.

### DIFF
--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -116,6 +116,7 @@
 #![feature(exact_size_is_empty)]
 #![feature(extend_one)]
 #![feature(extend_one_unchecked)]
+#![feature(fmt_arguments_from_str)]
 #![feature(fmt_internals)]
 #![feature(fn_traits)]
 #![feature(formatting_options)]

--- a/library/core/src/fmt/mod.rs
+++ b/library/core/src/fmt/mod.rs
@@ -734,7 +734,21 @@ impl<'a> Arguments<'a> {
         unsafe { Arguments { template: mem::transmute(template), args: mem::transmute(args) } }
     }
 
+    // Same as `from_str`, but not const.
+    // Used by format_args!() expansion when arguments are inlined,
+    // e.g. format_args!("{}", 123), which is not allowed in const.
     #[inline]
+    pub fn from_str_nonconst(s: &'static str) -> Arguments<'a> {
+        Arguments::from_str(s)
+    }
+}
+
+impl<'a> Arguments<'a> {
+    /// Create a `fmt::Arguments` object for a single static string.
+    ///
+    /// Formatting this `fmt::Arguments` will just produce the string as-is.
+    #[inline]
+    #[unstable(feature = "fmt_arguments_from_str", issue = "148905")]
     pub const fn from_str(s: &'static str) -> Arguments<'a> {
         // SAFETY: This is the "static str" representation of fmt::Arguments; see above.
         unsafe {
@@ -743,14 +757,6 @@ impl<'a> Arguments<'a> {
                 args: mem::transmute(s.len() << 1 | 1),
             }
         }
-    }
-
-    // Same as `from_str`, but not const.
-    // Used by format_args!() expansion when arguments are inlined,
-    // e.g. format_args!("{}", 123), which is not allowed in const.
-    #[inline]
-    pub fn from_str_nonconst(s: &'static str) -> Arguments<'a> {
-        Arguments::from_str(s)
     }
 }
 

--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -991,7 +991,7 @@ pub(crate) mod builtin {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_diagnostic_item = "format_args_macro"]
     #[allow_internal_unsafe]
-    #[allow_internal_unstable(fmt_internals)]
+    #[allow_internal_unstable(fmt_internals, fmt_arguments_from_str)]
     #[rustc_builtin_macro]
     #[macro_export]
     macro_rules! format_args {
@@ -1005,7 +1005,7 @@ pub(crate) mod builtin {
     ///
     /// This macro will be removed once `format_args` is allowed in const contexts.
     #[unstable(feature = "const_format_args", issue = "none")]
-    #[allow_internal_unstable(fmt_internals, const_fmt_arguments_new)]
+    #[allow_internal_unstable(fmt_internals, fmt_arguments_from_str)]
     #[rustc_builtin_macro]
     #[macro_export]
     macro_rules! const_format_args {
@@ -1020,7 +1020,7 @@ pub(crate) mod builtin {
         reason = "`format_args_nl` is only for internal \
                   language use and is subject to change"
     )]
-    #[allow_internal_unstable(fmt_internals)]
+    #[allow_internal_unstable(fmt_internals, fmt_arguments_from_str)]
     #[rustc_builtin_macro]
     #[doc(hidden)]
     #[macro_export]


### PR DESCRIPTION
Now that https://github.com/rust-lang/rust/pull/148789 is merged, we can have a fmt::Arguments::from_str. I don't know if we want to commit to always having an implementation that allows for this, but we can expose it as unstable for now so we can play with it.

Tracking issue: https://github.com/rust-lang/rust/issues/148905