### PR TITLE
add assembly test for infinite recursion with `become`

### DIFF
--- a/tests/assembly-llvm/tail-call-infinite-recursion.rs
+++ b/tests/assembly-llvm/tail-call-infinite-recursion.rs
@@ -1,0 +1,21 @@
+//@ add-minicore
+//@ assembly-output: emit-asm
+//@ compile-flags: --target x86_64-unknown-linux-gnu -Copt-level=0 -Cllvm-args=-x86-asm-syntax=intel
+//@ needs-llvm-components: x86
+#![expect(incomplete_features)]
+#![feature(no_core, explicit_tail_calls)]
+#![crate_type = "lib"]
+#![no_core]
+
+extern crate minicore;
+use minicore::*;
+
+// Test that an infinite loop via guaranteed tail calls does not blow the stack.
+
+// CHECK-LABEL: inf
+// CHECK: mov rax, qword ptr [rip + inf@GOTPCREL]
+// CHECK: jmp rax
+#[unsafe(no_mangle)]
+fn inf() -> ! {
+    become inf()
+}


### PR DESCRIPTION
tracking issue: https://github.com/rust-lang/rust/issues/112788
fixes https://github.com/rust-lang/rust/issues/125698

Check that infinite recursion via `become` does not grow the stack (even on opt-level 0). The incomplete implementation of `become` did not guarantee that earlier. Although it's unlikely this ever regresses we may as well test it and close the issue.

r? @WaffleLapkin 