### PR TITLE
add note to `lines` docs about empty str behavior

### DIFF
--- a/library/core/src/str/mod.rs
+++ b/library/core/src/str/mod.rs
@@ -1251,7 +1251,7 @@ impl str {
     /// ending will return the same lines as an otherwise identical string
     /// without a final line ending.
     ///
-    /// An empty string returns no lines.
+    /// An empty string returns an empty iterator.
     ///
     /// # Examples
     ///
@@ -1284,7 +1284,7 @@ impl str {
     /// assert_eq!(None, lines.next());
     /// ```
     ///
-    /// An empty string returns no lines:
+    /// An empty string returns an empty iterator:
     ///
     /// ```
     /// let text = "";

--- a/library/core/src/str/mod.rs
+++ b/library/core/src/str/mod.rs
@@ -1251,6 +1251,8 @@ impl str {
     /// ending will return the same lines as an otherwise identical string
     /// without a final line ending.
     ///
+    /// An empty string returns no lines.
+    ///
     /// # Examples
     ///
     /// Basic usage:
@@ -1280,6 +1282,15 @@ impl str {
     /// assert_eq!(Some("baz"), lines.next());
     ///
     /// assert_eq!(None, lines.next());
+    /// ```
+    ///
+    /// An empty string returns no lines:
+    ///
+    /// ```
+    /// let text = "";
+    /// let mut lines = text.lines();
+    ///
+    /// assert_eq!(lines.next(), None);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

This pull request adds a short note to the documentation for `str::lines` that describes the behavior of the resulting iterator when called on an empty string. I tripped over this a few days ago because I thought (incorrectly) that the iterator would return a single line with an empty string. I don't doubt that the actual behavior (return no lines) is the correct behavior, but in the absence of explicit documentation describing it, I came to the wrong conclusion about it and maybe others will too. If this is so obvious as to be not worth including, I'm happy to withdraw the pull request! Thanks for taking a look.