### PR TITLE
fix incorrect import in `std_detect` on `aarch64-unknown-openbsd`

### DIFF
--- a/library/std_detect/src/detect/os/openbsd/aarch64.rs
+++ b/library/std_detect/src/detect/os/openbsd/aarch64.rs
@@ -31,7 +31,7 @@ pub(crate) fn detect_features() -> cache::Initializer {
     // the feature is available.
     let aa64pfr0 = sysctl64(&[libc::CTL_MACHDEP, CPU_ID_AA64PFR0]);
 
-    super::aarch64::parse_system_registers(aa64isar0, aa64isar1, aa64mmfr2, aa64pfr0)
+    crate::detect::aarch64::parse_system_registers(aa64isar0, aa64isar1, aa64mmfr2, aa64pfr0)
 }
 
 #[inline]


### PR DESCRIPTION
fixes https://github.com/rust-lang/rust/issues/148898

In https://github.com/rust-lang/rust/pull/147024 the module structure of `std_detect` for `openbsd` was changed which invalidated this `super::` usage. 

I've now tested that `std_detect` builds (or well, checks, because I don't have the right linkers) with `aarch64-unknown-openbsd` and `powerpc64-unknown-openbsd`.