### PR TITLE
ignore `build-rust-analyzer` even if it's a symlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,7 +48,7 @@ no_llvm_build
 /llvm/
 /mingw-build/
 /build
-/build-rust-analyzer/
+/build-rust-analyzer
 /dist/
 /unicode-downloads
 /target


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

r? @jieyouxu