### PR TITLE
Fix division syntax in doc comments

### DIFF
--- a/library/core/src/num/f128.rs
+++ b/library/core/src/num/f128.rs
@@ -1704,7 +1704,8 @@ impl f128 {
         q
     }
 
-    /// Calculates the least nonnegative remainder of `self (mod rhs)`.
+    /// Calculates the least nonnegative remainder of `self` when
+    /// divided by `rhs`.
     ///
     /// In particular, the return value `r` satisfies `0.0 <= r < rhs.abs()` in
     /// most cases. However, due to a floating point round-off error it can

--- a/library/core/src/num/f16.rs
+++ b/library/core/src/num/f16.rs
@@ -1679,7 +1679,8 @@ impl f16 {
         q
     }
 
-    /// Calculates the least nonnegative remainder of `self (mod rhs)`.
+    /// Calculates the least nonnegative remainder of `self` when
+    /// divided by `rhs`.
     ///
     /// In particular, the return value `r` satisfies `0.0 <= r < rhs.abs()` in
     /// most cases. However, due to a floating point round-off error it can

--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -3124,7 +3124,8 @@ macro_rules! int_impl {
         }
 
 
-        /// Calculates the least nonnegative remainder of `self (mod rhs)`.
+        /// Calculates the least nonnegative remainder of `self` when
+        /// divided by `rhs`.
         ///
         /// This is done as if by the Euclidean division algorithm -- given
         /// `r = self.rem_euclid(rhs)`, the result satisfies

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -3399,7 +3399,8 @@ macro_rules! uint_impl {
         }
 
 
-        /// Calculates the least remainder of `self (mod rhs)`.
+        /// Calculates the least remainder of `self` when divided by
+        /// `rhs`.
         ///
         /// Since, for the positive integers, all common
         /// definitions of division are equal, this

--- a/library/std/src/num/f32.rs
+++ b/library/std/src/num/f32.rs
@@ -252,7 +252,8 @@ impl f32 {
         core::f32::math::div_euclid(self, rhs)
     }
 
-    /// Calculates the least nonnegative remainder of `self (mod rhs)`.
+    /// Calculates the least nonnegative remainder of `self` when divided by
+    /// `rhs`.
     ///
     /// In particular, the return value `r` satisfies `0.0 <= r < rhs.abs()` in
     /// most cases. However, due to a floating point round-off error it can

--- a/library/std/src/num/f64.rs
+++ b/library/std/src/num/f64.rs
@@ -252,7 +252,8 @@ impl f64 {
         core::f64::math::div_euclid(self, rhs)
     }
 
-    /// Calculates the least nonnegative remainder of `self (mod rhs)`.
+    /// Calculates the least nonnegative remainder of `self` when divided by
+    /// `rhs`.
     ///
     /// In particular, the return value `r` satisfies `0.0 <= r < rhs.abs()` in
     /// most cases. However, due to a floating point round-off error it can


### PR DESCRIPTION
`mod` is a keyword in Rust, and since we're talking about remainders we should be using division syntax here.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
