### PR TITLE
Show env normalization differences under two solvers

### DIFF
--- a/tests/ui/specialization/fuzzed/fuzzing-ice-134905.rs
+++ b/tests/ui/specialization/fuzzed/fuzzing-ice-134905.rs
@@ -14,8 +14,12 @@ where
 }
 
 trait Check {}
-impl<'a, T> Eq for T where <T as Iterate<'a>>::Ty: Valid {}
+impl<'a, T> Eq for T
 //~^ ERROR type parameter `T` must be used as the type parameter for some local type
+where
+    T: Iterate<'a>,
+    <T as Iterate<'a>>::Ty: Valid,
+{}
 
 trait Valid {}
 

--- a/tests/ui/specialization/fuzzed/fuzzing-ice-134905.stderr
+++ b/tests/ui/specialization/fuzzed/fuzzing-ice-134905.stderr
@@ -15,7 +15,7 @@ LL |     default type Ty = ();
    |                       ^^ the trait `Valid` is not implemented for `()`
    |
 help: this trait has no implementations, consider adding one
-  --> $DIR/fuzzing-ice-134905.rs:20:1
+  --> $DIR/fuzzing-ice-134905.rs:24:1
    |
 LL | trait Valid {}
    | ^^^^^^^^^^^
@@ -28,7 +28,7 @@ LL |     type Ty: Valid;
 error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
   --> $DIR/fuzzing-ice-134905.rs:17:10
    |
-LL | impl<'a, T> Eq for T where <T as Iterate<'a>>::Ty: Valid {}
+LL | impl<'a, T> Eq for T
    |          ^ type parameter `T` must be used as the type parameter for some local type
    |
    = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local

--- a/tests/ui/specialization/issue-38091-2.rs
+++ b/tests/ui/specialization/issue-38091-2.rs
@@ -1,6 +1,3 @@
-//@ build-fail
-//~^ ERROR overflow evaluating the requirement `i32: Check`
-
 #![feature(specialization)]
 //~^ WARN the feature `specialization` is incomplete
 
@@ -17,7 +14,11 @@ where
 }
 
 trait Check {}
-impl<'a, T> Check for T where <T as Iterate<'a>>::Ty: Valid {}
+impl<'a, T> Check for T
+//~^ ERROR: overflow evaluating the requirement `T: Check`
+where
+    T: Iterate<'a>,
+    <T as Iterate<'a>>::Ty: Valid {}
 
 trait Valid {}
 

--- a/tests/ui/specialization/issue-38091-2.stderr
+++ b/tests/ui/specialization/issue-38091-2.stderr
@@ -1,5 +1,5 @@
 warning: the feature `specialization` is incomplete and may not be safe to use and/or cause compiler crashes
-  --> $DIR/issue-38091-2.rs:4:12
+  --> $DIR/issue-38091-2.rs:1:12
    |
 LL | #![feature(specialization)]
    |            ^^^^^^^^^^^^^^
@@ -8,16 +8,35 @@ LL | #![feature(specialization)]
    = help: consider using `min_specialization` instead, which is more stable and complete
    = note: `#[warn(incomplete_features)]` on by default
 
-error[E0275]: overflow evaluating the requirement `i32: Check`
+error[E0275]: overflow evaluating the requirement `T: Check`
+  --> $DIR/issue-38091-2.rs:17:1
    |
-note: required for `i32` to implement `Iterate<'_>`
-  --> $DIR/issue-38091-2.rs:11:13
+LL | / impl<'a, T> Check for T
+LL | |
+LL | | where
+LL | |     T: Iterate<'a>,
+LL | |     <T as Iterate<'a>>::Ty: Valid {}
+   | |_________________________________^
+   |
+   = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`issue_38091_2`)
+note: required for `T` to implement `Iterate<'_>`
+  --> $DIR/issue-38091-2.rs:8:13
    |
 LL | impl<'a, T> Iterate<'a> for T
    |             ^^^^^^^^^^^     ^
 LL | where
 LL |     T: Check,
    |        ----- unsatisfied trait bound introduced here
+note: required for `T` to implement `Check`
+  --> $DIR/issue-38091-2.rs:17:13
+   |
+LL | impl<'a, T> Check for T
+   |             ^^^^^     ^
+...
+LL |     <T as Iterate<'a>>::Ty: Valid {}
+   |                             ----- unsatisfied trait bound introduced here
+   = note: 125 redundant requirements hidden
+   = note: required for `T` to implement `Iterate<'a>`
 
 error: aborting due to 1 previous error; 1 warning emitted
 

--- a/tests/ui/specialization/issue-38091.rs
+++ b/tests/ui/specialization/issue-38091.rs
@@ -15,7 +15,12 @@ where
 }
 
 trait Check {}
-impl<'a, T> Check for T where <T as Iterate<'a>>::Ty: Valid {}
+impl<'a, T> Check for T
+//~^ ERROR: overflow evaluating the requirement `T: Check`
+where
+    T: Iterate<'a>,
+    <T as Iterate<'a>>::Ty: Valid,
+{}
 
 trait Valid {}
 

--- a/tests/ui/specialization/issue-38091.stderr
+++ b/tests/ui/specialization/issue-38091.stderr
@@ -15,7 +15,7 @@ LL |     default type Ty = ();
    |                       ^^ the trait `Valid` is not implemented for `()`
    |
 help: this trait has no implementations, consider adding one
-  --> $DIR/issue-38091.rs:20:1
+  --> $DIR/issue-38091.rs:25:1
    |
 LL | trait Valid {}
    | ^^^^^^^^^^^
@@ -25,6 +25,37 @@ note: required by a bound in `Iterate::Ty`
 LL |     type Ty: Valid;
    |              ^^^^^ required by this bound in `Iterate::Ty`
 
-error: aborting due to 1 previous error; 1 warning emitted
+error[E0275]: overflow evaluating the requirement `T: Check`
+  --> $DIR/issue-38091.rs:18:1
+   |
+LL | / impl<'a, T> Check for T
+LL | |
+LL | | where
+LL | |     T: Iterate<'a>,
+LL | |     <T as Iterate<'a>>::Ty: Valid,
+   | |__________________________________^
+   |
+   = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`issue_38091`)
+note: required for `T` to implement `Iterate<'_>`
+  --> $DIR/issue-38091.rs:8:13
+   |
+LL | impl<'a, T> Iterate<'a> for T
+   |             ^^^^^^^^^^^     ^
+LL | where
+LL |     T: Check,
+   |        ----- unsatisfied trait bound introduced here
+note: required for `T` to implement `Check`
+  --> $DIR/issue-38091.rs:18:13
+   |
+LL | impl<'a, T> Check for T
+   |             ^^^^^     ^
+...
+LL |     <T as Iterate<'a>>::Ty: Valid,
+   |                             ----- unsatisfied trait bound introduced here
+   = note: 125 redundant requirements hidden
+   = note: required for `T` to implement `Iterate<'a>`
 
-For more information about this error, try `rustc --explain E0277`.
+error: aborting due to 2 previous errors; 1 warning emitted
+
+Some errors have detailed explanations: E0275, E0277.
+For more information about an error, try `rustc --explain E0275`.

--- a/tests/ui/traits/const-traits/unsatisfied-const-trait-bound.stderr
+++ b/tests/ui/traits/const-traits/unsatisfied-const-trait-bound.stderr
@@ -6,94 +6,34 @@ LL | #![feature(const_trait_impl, generic_const_exprs)]
    |
    = help: remove one of these features
 
-error[E0391]: cycle detected when evaluating type-level constant
-  --> $DIR/unsatisfied-const-trait-bound.rs:28:35
+error[E0277]: the trait bound `T: const Trait` is not satisfied
+  --> $DIR/unsatisfied-const-trait-bound.rs:28:37
    |
 LL | fn accept0<T: Trait>(_: Container<{ T::make() }>) {}
-   |                                   ^^^^^^^^^^^^^
-   |
-note: ...which requires const-evaluating + checking `accept0::{constant#0}`...
-  --> $DIR/unsatisfied-const-trait-bound.rs:28:35
-   |
-LL | fn accept0<T: Trait>(_: Container<{ T::make() }>) {}
-   |                                   ^^^^^^^^^^^^^
-note: ...which requires checking if `accept0::{constant#0}` is a trivial const...
-  --> $DIR/unsatisfied-const-trait-bound.rs:28:35
-   |
-LL | fn accept0<T: Trait>(_: Container<{ T::make() }>) {}
-   |                                   ^^^^^^^^^^^^^
-note: ...which requires building MIR for `accept0::{constant#0}`...
-  --> $DIR/unsatisfied-const-trait-bound.rs:28:35
-   |
-LL | fn accept0<T: Trait>(_: Container<{ T::make() }>) {}
-   |                                   ^^^^^^^^^^^^^
-note: ...which requires building an abstract representation for `accept0::{constant#0}`...
-  --> $DIR/unsatisfied-const-trait-bound.rs:28:35
-   |
-LL | fn accept0<T: Trait>(_: Container<{ T::make() }>) {}
-   |                                   ^^^^^^^^^^^^^
-note: ...which requires building THIR for `accept0::{constant#0}`...
-  --> $DIR/unsatisfied-const-trait-bound.rs:28:35
-   |
-LL | fn accept0<T: Trait>(_: Container<{ T::make() }>) {}
-   |                                   ^^^^^^^^^^^^^
-note: ...which requires type-checking `accept0::{constant#0}`...
-  --> $DIR/unsatisfied-const-trait-bound.rs:28:35
-   |
-LL | fn accept0<T: Trait>(_: Container<{ T::make() }>) {}
-   |                                   ^^^^^^^^^^^^^
-   = note: ...which again requires evaluating type-level constant, completing the cycle
-note: cycle used when checking that `accept0` is well-formed
-  --> $DIR/unsatisfied-const-trait-bound.rs:28:35
-   |
-LL | fn accept0<T: Trait>(_: Container<{ T::make() }>) {}
-   |                                   ^^^^^^^^^^^^^
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   |                                     ^
 
-error[E0391]: cycle detected when checking if `accept1::{constant#0}` is a trivial const
-  --> $DIR/unsatisfied-const-trait-bound.rs:32:49
+error[E0277]: the trait bound `T: const Trait` is not satisfied
+  --> $DIR/unsatisfied-const-trait-bound.rs:32:51
    |
 LL | const fn accept1<T: [const] Trait>(_: Container<{ T::make() }>) {}
-   |                                                 ^^^^^^^^^^^^^
-   |
-note: ...which requires building MIR for `accept1::{constant#0}`...
-  --> $DIR/unsatisfied-const-trait-bound.rs:32:49
-   |
-LL | const fn accept1<T: [const] Trait>(_: Container<{ T::make() }>) {}
-   |                                                 ^^^^^^^^^^^^^
-note: ...which requires building an abstract representation for `accept1::{constant#0}`...
-  --> $DIR/unsatisfied-const-trait-bound.rs:32:49
-   |
-LL | const fn accept1<T: [const] Trait>(_: Container<{ T::make() }>) {}
-   |                                                 ^^^^^^^^^^^^^
-note: ...which requires building THIR for `accept1::{constant#0}`...
-  --> $DIR/unsatisfied-const-trait-bound.rs:32:49
-   |
-LL | const fn accept1<T: [const] Trait>(_: Container<{ T::make() }>) {}
-   |                                                 ^^^^^^^^^^^^^
-note: ...which requires type-checking `accept1::{constant#0}`...
-  --> $DIR/unsatisfied-const-trait-bound.rs:32:49
-   |
-LL | const fn accept1<T: [const] Trait>(_: Container<{ T::make() }>) {}
-   |                                                 ^^^^^^^^^^^^^
-note: ...which requires evaluating type-level constant...
-  --> $DIR/unsatisfied-const-trait-bound.rs:32:49
-   |
-LL | const fn accept1<T: [const] Trait>(_: Container<{ T::make() }>) {}
-   |                                                 ^^^^^^^^^^^^^
-note: ...which requires const-evaluating + checking `accept1::{constant#0}`...
-  --> $DIR/unsatisfied-const-trait-bound.rs:32:49
-   |
-LL | const fn accept1<T: [const] Trait>(_: Container<{ T::make() }>) {}
-   |                                                 ^^^^^^^^^^^^^
-   = note: ...which again requires checking if `accept1::{constant#0}` is a trivial const, completing the cycle
-note: cycle used when const-evaluating + checking `accept1::{constant#0}`
-  --> $DIR/unsatisfied-const-trait-bound.rs:32:49
-   |
-LL | const fn accept1<T: [const] Trait>(_: Container<{ T::make() }>) {}
-   |                                                 ^^^^^^^^^^^^^
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   |                                                   ^
 
-error: aborting due to 3 previous errors
+error[E0277]: the trait bound `Ty: const Trait` is not satisfied
+  --> $DIR/unsatisfied-const-trait-bound.rs:21:15
+   |
+LL |     require::<Ty>();
+   |               ^^
+   |
+note: required by a bound in `require`
+  --> $DIR/unsatisfied-const-trait-bound.rs:8:15
+   |
+LL | fn require<T: const Trait>() {}
+   |               ^^^^^^^^^^^ required by this bound in `require`
+help: make the `impl` of trait `Trait` `const`
+   |
+LL | impl const Trait for Ty {
+   |      +++++
 
-For more information about this error, try `rustc --explain E0391`.
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/traits/next-solver/normalize/normalize-param-env-4.current.stderr
+++ b/tests/ui/traits/next-solver/normalize/normalize-param-env-4.current.stderr
@@ -1,0 +1,22 @@
+error: inconsistency during normalizing env `Binder { value: TraitPredicate(<<T as Trait>::Assoc as Trait>, polarity:Positive), bound_vars: [] }`, old=Binder { value: TraitPredicate(<T as Trait>, polarity:Positive), bound_vars: [] }, next=None
+  --> $DIR/normalize-param-env-4.rs:16:1
+   |
+LL | / fn foo<T>()
+LL | |
+LL | |
+LL | | where
+LL | |     <T as Trait>::Assoc: Trait,
+   | |_______________________________^
+
+error: inconsistency during normalizing env `Binder { value: TraitPredicate(<<T as Trait>::Assoc as std::marker::MetaSized>, polarity:Positive), bound_vars: [] }`, old=Binder { value: TraitPredicate(<T as std::marker::MetaSized>, polarity:Positive), bound_vars: [] }, next=None
+  --> $DIR/normalize-param-env-4.rs:16:1
+   |
+LL | / fn foo<T>()
+LL | |
+LL | |
+LL | | where
+LL | |     <T as Trait>::Assoc: Trait,
+   | |_______________________________^
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/traits/next-solver/normalize/normalize-param-env-4.next.stderr
+++ b/tests/ui/traits/next-solver/normalize/normalize-param-env-4.next.stderr
@@ -1,5 +1,5 @@
 error[E0275]: overflow evaluating the requirement `<T as Trait>::Assoc: Trait`
-  --> $DIR/normalize-param-env-4.rs:19:26
+  --> $DIR/normalize-param-env-4.rs:20:26
    |
 LL |     <T as Trait>::Assoc: Trait,
    |                          ^^^^^

--- a/tests/ui/traits/next-solver/normalize/normalize-param-env-4.rs
+++ b/tests/ui/traits/next-solver/normalize/normalize-param-env-4.rs
@@ -2,7 +2,6 @@
 //@ ignore-compare-mode-next-solver (explicit revisions)
 //@[next] compile-flags: -Znext-solver
 //@[next] known-bug: #92505
-//@[current] check-pass
 
 trait Trait {
     type Assoc;
@@ -15,6 +14,8 @@ impl<T> Trait for T {
 fn impls_trait<T: Trait>() {}
 
 fn foo<T>()
+    //[current]~^ ERROR: inconsistency during normalizing env
+    //[current]~| ERROR: inconsistency during normalizing env
 where
     <T as Trait>::Assoc: Trait,
 {


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/148939)*
<!-- homu-ignore:end -->

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    
-->
<!-- homu-ignore:end -->

First step for param_env normalization future compat warning. [zulip thread](https://rust-lang.zulipchat.com/#narrow/channel/364551-t-types.2Ftrait-system-refactor/topic/ask.20for.20help/near/553835079)

I didn't put the check directly in `param_env` query because `normalize_param_env_or_error` has some adjustments on the predicates: elaboration and outlive predicates manipulation. I'd have to replicate these in `param_env` to compare normalized predicates properly.
The downside of putting the check inside `normalize_param_env_or_error` is that it's used in more than `param_env` query. It's also used in `compare_impl_item` and several other places. I'm not sure if this is desired.


~~I didn't bless tests since the hard error will be changed to lint later.~~
Blessed tests to demonstrate the changes.

And there's one [test](https://github.com/rust-lang/rust/blob/c880acdd3171dfafdb55be8cd9822a857e99348d/tests/ui/const-generics/generic_const_exprs/feature-attribute-missing-in-dependent-crate-ice.rs) about const generics I don't know how to fix.
Canonicalizer for the next solver will replace `ParamConst` with `PlaceholderConst`, but it still uses the same `try_evaluate_const` internally and `process_obligation` [doesn't like](https://github.com/rust-lang/rust/blob/c880acdd3171dfafdb55be8cd9822a857e99348d/compiler/rustc_trait_selection/src/traits/fulfill.rs#L538) `PlaceholderConst`.

r? @lcnr 