### PR TITLE
Remove unnecessary lifetime in `with_generic_param_rib`

### DIFF
--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -2916,9 +2916,9 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
         }
     }
 
-    fn with_generic_param_rib<'c, F>(
-        &'c mut self,
-        params: &'c [GenericParam],
+    fn with_generic_param_rib<F>(
+        &mut self,
+        params: &[GenericParam],
         kind: RibKind<'ra>,
         binder: NodeId,
         generics_kind: LifetimeBinderKind,


### PR DESCRIPTION
Having the same lifetime in two covariant arguments doesn't do anything.

The lifetime was unnecessarilly added in https://github.com/rust-lang/rust/commit/faf0852fc1d01aef18fe8098a0f2f601dbfebd9b#diff-3cff50afc88a11e641a6851dd19471a7e6470f05dd0cddaf2271e5cdd9936b73L2125

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
