### PR TITLE
rustc_target: aarch64: Remove deprecated FEAT_TME

### DIFF
--- a/compiler/rustc_codegen_llvm/src/llvm_util.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm_util.rs
@@ -243,6 +243,8 @@ pub(crate) fn to_llvm_features<'a>(sess: &Session, s: &'a str) -> Option<LLVMFea
                 "fp16" => Some(LLVMFeature::new("fullfp16")),
                 // Filter out features that are not supported by the current LLVM version
                 "fpmr" => None, // only existed in 18
+                // Withdrawn by ARM; removed from LLVM in 22
+                "tme" if major >= 22 => None,
                 s => Some(LLVMFeature::new(s)),
             }
         }

--- a/library/std/tests/run-time-detect.rs
+++ b/library/std/tests/run-time-detect.rs
@@ -106,7 +106,6 @@ fn aarch64_linux() {
     println!("sve2: {}", is_aarch64_feature_detected!("sve2"));
     println!("sve2p1: {}", is_aarch64_feature_detected!("sve2p1"));
     println!("sve: {}", is_aarch64_feature_detected!("sve"));
-    println!("tme: {}", is_aarch64_feature_detected!("tme"));
     println!("wfxt: {}", is_aarch64_feature_detected!("wfxt"));
     // tidy-alphabetical-end
 }

--- a/library/std_detect/src/detect/os/aarch64.rs
+++ b/library/std_detect/src/detect/os/aarch64.rs
@@ -84,7 +84,6 @@ pub(crate) fn parse_system_registers(
 
     // ID_AA64ISAR0_EL1 - Instruction Set Attribute Register 0
     enable_feature(Feature::pmull, bits_shift(aa64isar0, 7, 4) >= 2);
-    enable_feature(Feature::tme, bits_shift(aa64isar0, 27, 24) == 1);
     enable_feature(Feature::lse, bits_shift(aa64isar0, 23, 20) >= 2);
     enable_feature(Feature::crc, bits_shift(aa64isar0, 19, 16) >= 1);
 

--- a/library/std_detect/tests/cpu-detection.rs
+++ b/library/std_detect/tests/cpu-detection.rs
@@ -85,7 +85,6 @@ fn aarch64_linux() {
     println!("rcpc2: {}", is_aarch64_feature_detected!("rcpc2"));
     println!("rcpc3: {}", is_aarch64_feature_detected!("rcpc3"));
     println!("dotprod: {}", is_aarch64_feature_detected!("dotprod"));
-    println!("tme: {}", is_aarch64_feature_detected!("tme"));
     println!("fhm: {}", is_aarch64_feature_detected!("fhm"));
     println!("dit: {}", is_aarch64_feature_detected!("dit"));
     println!("flagm: {}", is_aarch64_feature_detected!("flagm"));
@@ -175,7 +174,6 @@ fn aarch64_bsd() {
     println!("rdm: {:?}", is_aarch64_feature_detected!("rdm"));
     println!("rcpc: {:?}", is_aarch64_feature_detected!("rcpc"));
     println!("dotprod: {:?}", is_aarch64_feature_detected!("dotprod"));
-    println!("tme: {:?}", is_aarch64_feature_detected!("tme"));
     println!("paca: {:?}", is_aarch64_feature_detected!("paca"));
     println!("pacg: {:?}", is_aarch64_feature_detected!("pacg"));
     println!("aes: {:?}", is_aarch64_feature_detected!("aes"));


### PR DESCRIPTION
fixes https://github.com/rust-lang/rust/issues/149308

ARM has withdrawn FEAT_TME

https://developer.arm.com/documentation/102105/lb-05/

LLVM has dropped support for generating it
llvm/llvm-project#167687

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

@rustbot label llvm-main

r? @durin42 