### PR TITLE
crater experiment: do not promote function calls in const/static items

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -713,7 +713,7 @@ dependencies = [
  "eyre",
  "indenter",
  "once_cell",
- "owo-colors 4.2.2",
+ "owo-colors",
  "tracing-error",
 ]
 
@@ -745,7 +745,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8b88ea9df13354b55bc7234ebcce36e6ef896aca2e42a15de9e10edce01b427"
 dependencies = [
  "once_cell",
- "owo-colors 4.2.2",
+ "owo-colors",
  "tracing-core",
  "tracing-error",
 ]
@@ -763,7 +763,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -772,7 +772,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2713,24 +2713,9 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "owo-colors"
-version = "3.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
-
-[[package]]
-name = "owo-colors"
 version = "4.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48dd4f4a2c8405440fd0462561f0e5806bd0f77e86f51c761481bdd4018b545e"
-
-[[package]]
-name = "pad"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ad9b889f1b12e0b9ee24db044b5129150d5eada288edc800f789928dc8c0e3"
-dependencies = [
- "unicode-width 0.1.14",
-]
 
 [[package]]
 name = "papergrid"
@@ -2952,12 +2937,11 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "prettydiff"
-version = "0.7.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abec3fb083c10660b3854367697da94c674e9e82aa7511014dc958beeb7215e9"
+checksum = "ac17546d82912e64874e3d5b40681ce32eac4e5834344f51efcf689ff1550a65"
 dependencies = [
- "owo-colors 3.5.0",
- "pad",
+ "owo-colors",
 ]
 
 [[package]]
@@ -5239,7 +5223,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5383,7 +5367,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5817,9 +5801,9 @@ checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "ui_test"
-version = "0.30.2"
+version = "0.30.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b56a6897cc4bb6f8daf1939b0b39cd9645856997f46f4d0b3e3cb7122dfe9251"
+checksum = "44eb652e1a8799d4e47f20851370e86247cbc5270ce677ab1e9409a6d45a9649"
 dependencies = [
  "annotate-snippets 0.11.5",
  "anyhow",
@@ -5827,7 +5811,7 @@ dependencies = [
  "cargo-platform 0.1.9",
  "cargo_metadata 0.18.1",
  "color-eyre",
- "colored 2.2.0",
+ "colored 3.0.0",
  "comma",
  "crossbeam-channel",
  "indicatif",
@@ -6280,7 +6264,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/compiler/rustc_mir_transform/src/promote_consts.rs
+++ b/compiler/rustc_mir_transform/src/promote_consts.rs
@@ -9,6 +9,7 @@
 //! This pass assumes that every use is dominated by an initialization and can
 //! otherwise silence errors, if move analysis runs after promotion on broken
 //! MIR.
+#![allow(unused)]
 
 use std::assert_matches::assert_matches;
 use std::cell::Cell;
@@ -662,33 +663,8 @@ impl<'tcx> Validator<'_, 'tcx> {
             }
         }
 
-        // Ideally, we'd stop here and reject the rest.
-        // But for backward compatibility, we have to accept some promotion in const/static
-        // initializers. Inline consts are explicitly excluded, they are more recent so we have no
-        // backwards compatibility reason to allow more promotion inside of them.
-        let promote_all_fn = matches!(
-            self.const_kind,
-            Some(hir::ConstContext::Static(_) | hir::ConstContext::Const { inline: false })
-        );
-        if !promote_all_fn {
-            return Err(Unpromotable);
-        }
-        // Make sure the callee is a `const fn`.
-        let is_const_fn = match *fn_ty.kind() {
-            ty::FnDef(def_id, _) => self.tcx.is_const_fn(def_id),
-            _ => false,
-        };
-        if !is_const_fn {
-            return Err(Unpromotable);
-        }
-        // The problem is, this may promote calls to functions that panic.
-        // We don't want to introduce compilation errors if there's a panic in a call in dead code.
-        // So we ensure that this is not dead code.
-        if !self.is_promotion_safe_block(block) {
-            return Err(Unpromotable);
-        }
-        // This passed all checks, so let's accept.
-        Ok(())
+        // Ideally, we'd stop here and reject the rest. So let's do that.
+        return Err(Unpromotable);
     }
 }
 


### PR DESCRIPTION
This repeats the experiment from rust-lang/rust#122819. Back then, not even cargo built; since then, https://github.com/time-rs/time/pull/704 has landed so maybe we get a bit further this time.

See https://github.com/rust-lang/rust/issues/124328 for context.