### PR TITLE
remove `let this = self;` in compiler

### DIFF
--- a/compiler/rustc_mir_build/src/builder/expr/as_constant.rs
+++ b/compiler/rustc_mir_build/src/builder/expr/as_constant.rs
@@ -19,17 +19,16 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
     /// Compile `expr`, yielding a compile-time constant. Assumes that
     /// `expr` is a valid compile-time constant!
     pub(crate) fn as_constant(&mut self, expr: &Expr<'tcx>) -> ConstOperand<'tcx> {
-        let this = self;
-        let tcx = this.tcx;
+        let tcx = self.tcx;
         let Expr { ty, temp_lifetime: _, span, ref kind } = *expr;
         match kind {
             ExprKind::Scope { region_scope: _, lint_level: _, value } => {
-                this.as_constant(&this.thir[*value])
+                self.as_constant(&self.thir[*value])
             }
             _ => as_constant_inner(
                 expr,
                 |user_ty| {
-                    Some(this.canonical_user_type_annotations.push(CanonicalUserTypeAnnotation {
+                    Some(self.canonical_user_type_annotations.push(CanonicalUserTypeAnnotation {
                         span,
                         user_ty: user_ty.clone(),
                         inferred_ty: ty,

--- a/compiler/rustc_mir_build/src/builder/expr/as_operand.rs
+++ b/compiler/rustc_mir_build/src/builder/expr/as_operand.rs
@@ -118,13 +118,11 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         local_info: LocalInfo<'tcx>,
         needs_temporary: NeedsTemporary,
     ) -> BlockAnd<Operand<'tcx>> {
-        let this = self;
-
-        let expr = &this.thir[expr_id];
+        let expr = &self.thir[expr_id];
         if let ExprKind::Scope { region_scope, lint_level, value } = expr.kind {
-            let source_info = this.source_info(expr.span);
+            let source_info = self.source_info(expr.span);
             let region_scope = (region_scope, source_info);
-            return this.in_scope(region_scope, lint_level, |this| {
+            return self.in_scope(region_scope, lint_level, |this| {
                 this.as_operand(block, scope, value, local_info, needs_temporary)
             });
         }
@@ -134,17 +132,17 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         match category {
             Category::Constant
                 if matches!(needs_temporary, NeedsTemporary::No)
-                    || !expr.ty.needs_drop(this.tcx, this.typing_env()) =>
+                    || !expr.ty.needs_drop(self.tcx, self.typing_env()) =>
             {
-                let constant = this.as_constant(expr);
+                let constant = self.as_constant(expr);
                 block.and(Operand::Constant(Box::new(constant)))
             }
             Category::Constant | Category::Place | Category::Rvalue(..) => {
-                let operand = unpack!(block = this.as_temp(block, scope, expr_id, Mutability::Mut));
+                let operand = unpack!(block = self.as_temp(block, scope, expr_id, Mutability::Mut));
                 // Overwrite temp local info if we have something more interesting to record.
                 if !matches!(local_info, LocalInfo::Boring) {
                     let decl_info =
-                        this.local_decls[operand].local_info.as_mut().unwrap_crate_local();
+                        self.local_decls[operand].local_info.as_mut().unwrap_crate_local();
                     if let LocalInfo::Boring | LocalInfo::BlockTailTemp(_) = **decl_info {
                         **decl_info = local_info;
                     }
@@ -160,31 +158,30 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         scope: TempLifetime,
         expr_id: ExprId,
     ) -> BlockAnd<Operand<'tcx>> {
-        let this = self;
-        let expr = &this.thir[expr_id];
+        let expr = &self.thir[expr_id];
         debug!("as_call_operand(block={:?}, expr={:?})", block, expr);
 
         if let ExprKind::Scope { region_scope, lint_level, value } = expr.kind {
-            let source_info = this.source_info(expr.span);
+            let source_info = self.source_info(expr.span);
             let region_scope = (region_scope, source_info);
-            return this.in_scope(region_scope, lint_level, |this| {
+            return self.in_scope(region_scope, lint_level, |this| {
                 this.as_call_operand(block, scope, value)
             });
         }
 
-        let tcx = this.tcx;
+        let tcx = self.tcx;
 
         if tcx.features().unsized_fn_params() {
             let ty = expr.ty;
-            if !ty.is_sized(tcx, this.typing_env()) {
+            if !ty.is_sized(tcx, self.typing_env()) {
                 // !sized means !copy, so this is an unsized move
-                assert!(!tcx.type_is_copy_modulo_regions(this.typing_env(), ty));
+                assert!(!tcx.type_is_copy_modulo_regions(self.typing_env(), ty));
 
                 // As described above, detect the case where we are passing a value of unsized
                 // type, and that value is coming from the deref of a box.
                 if let ExprKind::Deref { arg } = expr.kind {
                     // Generate let tmp0 = arg0
-                    let operand = unpack!(block = this.as_temp(block, scope, arg, Mutability::Mut));
+                    let operand = unpack!(block = self.as_temp(block, scope, arg, Mutability::Mut));
 
                     // Return the operand *tmp0 to be used as the call argument
                     let place = Place {
@@ -197,6 +194,6 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             }
         }
 
-        this.as_operand(block, scope, expr_id, LocalInfo::Boring, NeedsTemporary::Maybe)
+        self.as_operand(block, scope, expr_id, LocalInfo::Boring, NeedsTemporary::Maybe)
     }
 }


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

I still kept `this` as name for closure argument

I don't know original story why this was `let this = self` but I don't see any problems to remove it

by the way, there is one place, where it's actually necessary and provides a good solution because of macro https://github.com/rust-lang/rust/blob/main/compiler/rustc_parse/src/parser/expr.rs#L495