### PR TITLE
re-enable wasm abi test

### DIFF
--- a/tests/ui/abi/compatibility.rs
+++ b/tests/ui/abi/compatibility.rs
@@ -40,10 +40,9 @@
 //@ revisions: loongarch64
 //@[loongarch64] compile-flags: --target loongarch64-unknown-linux-gnu
 //@[loongarch64] needs-llvm-components: loongarch
-//FIXME: wasm is disabled due to <https://github.com/rust-lang/rust/issues/115666>.
-//FIXME @ revisions: wasm
-//FIXME @[wasm] compile-flags: --target wasm32-unknown-unknown
-//FIXME @[wasm] needs-llvm-components: webassembly
+//@ revisions: wasm
+//@[wasm] compile-flags: --target wasm32-unknown-unknown
+//@[wasm] needs-llvm-components: webassembly
 //@ revisions: wasip1
 //@[wasip1] compile-flags: --target wasm32-wasip1
 //@[wasip1] needs-llvm-components: webassembly


### PR DESCRIPTION
The `wasm32-unknown-unknown` ABI has been fixed for a while now https://github.com/rust-lang/rust/issues/115666, so this test can be re-enabled and the fixme removed.

r? @bjorn3