### PR TITLE
Run codegen tests on a 32-bit target in PR CI

### DIFF
--- a/src/ci/docker/host-x86_64/pr-check-2/Dockerfile
+++ b/src/ci/docker/host-x86_64/pr-check-2/Dockerfile
@@ -21,6 +21,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   mingw-w64 \
   && rm -rf /var/lib/apt/lists/*
 
+RUN curl -L https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-27/wasi-sdk-27.0-x86_64-linux.tar.gz | \
+  tar -xz
+ENV WASI_SDK_PATH=/wasi-sdk-27.0-x86_64-linux
+
 ENV RUST_CONFIGURE_ARGS="--set rust.validate-mir-opts=3"
 
 COPY scripts/sccache.sh /scripts/
@@ -30,6 +34,10 @@ ENV SCRIPT \
         python3 ../x.py check && \
         python3 ../x.py clippy ci --stage 2 && \
         python3 ../x.py test --stage 1 core alloc std test proc_macro && \
+        # Elsewhere, we run all tests for the host. A number of codegen tests are sensitive to the target pointer
+        # width, for example because they mention a usize. wasm32-wasip1 in test-various, so using it here can't make
+        # PR CI more strict than full CI.
+        python3 ../x.py test --stage 1 tests/codegen-llvm --target wasm32-wasip1 && \
         python3 ../x.py test --stage 1 src/tools/compiletest && \
         python3 ../x.py doc bootstrap --stage 1 && \
         # Build both public and internal documentation.


### PR DESCRIPTION
wasm32-wasip1 is the wasm target used in test-various. So using it somewhere else seems like a good bet.