### PR TITLE
Add another *ExprWithBlock* test for `try` blocks

### DIFF
--- a/tests/ui/try-block/try-block-as-statement.rs
+++ b/tests/ui/try-block/try-block-as-statement.rs
@@ -1,0 +1,24 @@
+//@ check-fail
+//@ edition: 2018
+
+#![feature(try_blocks)]
+#![crate_type = "lib"]
+
+// fine because the `;` discards the value
+fn foo(a: &str, b: &str) -> i32 {
+    try {
+        let foo = std::fs::read_to_string(a)?;
+        std::fs::write(b, foo);
+    };
+    4 + 10
+}
+
+// parses without the semicolon, but gives a type error
+fn bar(a: &str, b: &str) -> i32 {
+    try {
+        let foo = std::fs::read_to_string(a)?;
+        //~^ ERROR mismatched types
+        std::fs::write(b, foo);
+    }
+    4 + 10
+}

--- a/tests/ui/try-block/try-block-as-statement.stderr
+++ b/tests/ui/try-block/try-block-as-statement.stderr
@@ -1,0 +1,16 @@
+error[E0308]: mismatched types
+  --> $DIR/try-block-as-statement.rs:19:19
+   |
+LL |         let foo = std::fs::read_to_string(a)?;
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found `Result<_, Error>`
+   |
+   = note: expected unit type `()`
+                   found enum `Result<_, std::io::Error>`
+help: consider using `Result::expect` to unwrap the `Result<_, std::io::Error>` value, panicking if the value is a `Result::Err`
+   |
+LL |         let foo = std::fs::read_to_string(a)?.expect("REASON");
+   |                                              +++++++++++++++++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Looking to address this open item from rust-lang/rust#31436

> Add a test confirming that it's an `ExprWithBlock`, so works in a match arm without a comma

It turns out that rust-lang/rust#120540 addressed that one, but it made me think of this other case that probably ought to have some kind of test as well.