### PR TITLE
compiletest: Don't apply "emscripten" directives to `wasm32-unknown-unknown`

### DIFF
--- a/src/doc/rustc-dev-guide/src/tests/directives.md
+++ b/src/doc/rustc-dev-guide/src/tests/directives.md
@@ -141,8 +141,7 @@ Some examples of `X` in `ignore-X` or `only-X`:
 - OS: `android`, `emscripten`, `freebsd`, `ios`, `linux`, `macos`, `windows`,
   ...
 - Environment (fourth word of the target triple): `gnu`, `msvc`, `musl`
-- WASM: `wasm32-bare` matches `wasm32-unknown-unknown`. `emscripten` also
-  matches that target as well as the emscripten targets.
+- WASM: `wasm32-bare` matches `wasm32-unknown-unknown`.
 - Pointer width: `32bit`, `64bit`
 - Endianness: `endian-big`
 - Stage: `stage1`, `stage2`

--- a/src/tools/compiletest/src/directives/cfg.rs
+++ b/src/tools/compiletest/src/directives/cfg.rs
@@ -112,12 +112,7 @@ fn parse_cfg_name_directive<'a>(
         message: "when the target is {name}"
     }
     condition! {
-        name: &[
-            Some(&*target_cfg.os),
-            // If something is ignored for emscripten, it likely also needs to be
-            // ignored for wasm32-unknown-unknown.
-            (config.target == "wasm32-unknown-unknown").then_some("emscripten"),
-        ],
+        name: &target_cfg.os,
         allowed_names: &target_cfgs.all_oses,
         message: "when the operating system is {name}"
     }

--- a/src/tools/compiletest/src/directives/tests.rs
+++ b/src/tools/compiletest/src/directives/tests.rs
@@ -708,7 +708,7 @@ fn pointer_width() {
 #[test]
 fn wasm_special() {
     let ignores = [
-        ("wasm32-unknown-unknown", "emscripten", true),
+        ("wasm32-unknown-unknown", "emscripten", false),
         ("wasm32-unknown-unknown", "wasm32", true),
         ("wasm32-unknown-unknown", "wasm32-bare", true),
         ("wasm32-unknown-unknown", "wasm64", false),
@@ -729,8 +729,13 @@ fn wasm_special() {
         assert_eq!(
             check_ignore(&config, &format!("//@ ignore-{pattern}")),
             ignore,
-            "{target} {pattern}"
+            "target `{target}` vs `//@ ignore-{pattern}`"
         );
+        assert_eq!(
+            check_ignore(&config, &format!("//@ only-{pattern}")),
+            !ignore,
+            "target `{target}` vs `//@ only-{pattern}`"
+        )
     }
 }
 


### PR DESCRIPTION
This special case dates all the way back to the original introduction of the `wasm32-unknown-unknown` target, in https://github.com/rust-lang/rust/pull/45905.

Either it isn't needed, in which case we should remove it, or it *is* needed, in which case we should fix the directives in any affected tests.

Note that while the intent of this code was presumably to make `//@ ignore-emscripten` also ignore tests on w32-u-u, it has the unfortunate side-effect of also causing `//@ only-emscripten` tests to *run* on w32-u-u, which is potentially very confusing.