### PR TITLE
Document Error::{new,other} as to be avoided in pre_exec

### DIFF
--- a/library/std/src/os/unix/process.rs
+++ b/library/std/src/os/unix/process.rs
@@ -80,6 +80,9 @@ pub trait CommandExt: Sealed {
     /// or acquiring a mutex are not guaranteed to work (due to
     /// other threads perhaps still running when the `fork` was run).
     ///
+    /// Note that the list of allocating functions includes [`Error::new`] and
+    /// [`Error::other`]. To signal a non-trivial error, prefer [`panic!`].
+    ///
     /// For further details refer to the [POSIX fork() specification]
     /// and the equivalent documentation for any targeted
     /// platform, especially the requirements around *async-signal-safety*.
@@ -102,6 +105,8 @@ pub trait CommandExt: Sealed {
     /// [POSIX fork() specification]:
     ///     https://pubs.opengroup.org/onlinepubs/9699919799/functions/fork.html
     /// [`std::env`]: mod@crate::env
+    /// [`Error::new`]: crate::io::Error::new
+    /// [`Error::other`]: crate::io::Error::other
     #[stable(feature = "process_pre_exec", since = "1.34.0")]
     unsafe fn pre_exec<F>(&mut self, f: F) -> &mut process::Command
     where


### PR DESCRIPTION
This is a mistake I've found in many projects on GitHub and made myself. It's obvious that `Error::new`/`Error::other` allocate when you look at their signatures, and it's obvious that the `pre_exec` closure shouldn't allocate, but when you're asked to write a closure that returns a specific type, you don't expect its main constructor to be problematic.

I've included the list of 71 affected projects in a spoiler, though I don't expect anyone to look through it closely. It includes popular projects like alacritty, pika-backup, rio, rpm-ostree, and headcrab, as well as many smaller ones. For the most part, the snippets I've found are careful to only call functions from `libc`, `nix`, or `rustix`, so it's not a case of general incompetence, but something that just slipped through the cracks.

This docs section is already cluttered, so I've kept it terse.

If this is merged, I'd like to mass-post issues to the affected projects linking to this PR as a centralized source of information and place for discussion. Are there any objections about that?

@rustbot label +A-docs +A-process +O-unix +T-libs-api

<details>
<summary>List of affected projects</summary>

Format: links (witness of multi-threading)

- https://github.com/0x4D44/mdmcp/blob/cccdfab32d5a203d03ccbc6ed261a2f4a4e6420d/mdmcpsrvr/src/sandbox.rs#L385 (`tokio::main`)
- https://github.com/alacritty/alacritty/blob/bf68154f9e4b91e5ba21dfb8151dbde23c46d47d/alacritty_terminal/src/tty/unix.rs#L250 (`thread::spawn`)
- https://github.com/AsterZephyr/polyagent/blob/6a7f5aced0335926941931ca965e5455890a7ce3/rust/agent-core/src/sandbox.rs#L257 (`tokio::main`)
- https://github.com/bootc-dev/containers-image-proxy-rs/blob/68673c836a91070811c17858183266e634f9719d/src/imageproxy.rs#L285 (`library`)
- https://github.com/delft-hyperloop/DH09-sw/blob/27f489edd297e9b93b8caa2c0b222ae8a9f1a70f/gs/station/src/tui/app.rs#L69 (`thread::spawn`)
- https://github.com/fcoury/oxproc/blob/85e8b510102d1caf7f15fd88694b4ad24bcd59b7/src/manager.rs#L55 (`tokio::runtime::Builder::new_multi_thread`)
- https://github.com/galqiwi/runner/blob/35d4756bc518b5947e0275e4251b674c8c354b62/src/run.rs#L75 (`tokio::main`)
- https://github.com/golemfactory/yagna/blob/31f5353e5532e947abb824adc30791583d01bf74/golem_cli/src/command/yagna.rs#L384, https://github.com/golemfactory/yagna/blob/31f5353e5532e947abb824adc30791583d01bf74/test-utils/test-framework/src/yagna.rs#L103 (`actix_rt::main`)
- https://github.com/greshake/i3status-rust/blob/2d797c50702873fc8efe518156e204a0b3979fc8/src/subprocess.rs#L14 (`thread::Builder::new`)
- https://github.com/hattmo/projects/blob/626feea965cebd90490e3e16f2c4b0c6725212e1/opstation/src/manager/mod.rs#L50 (`none`)
- https://github.com/iamazy/nxshell/blob/ca3b94324831cdc8f8b533c1ff252bdeeba3acbf/crates/alacritty_terminal/src/tty/unix.rs#L256 (`thread::spawn`)
- https://github.com/ironcore-dev/FeOS/blob/9dee27162f5860991dc176bf2e0d9f948dc97d5b/feos/services/vm-service/src/vmm/ch_adapter.rs#L272 (`tokio::main`)
- https://github.com/jamesmcm/vopono/blob/d1aad75d9fc8959488e020f3ffea6ffd1f798609/vopono_core/src/network/application_wrapper.rs#L193 (`thread::spawn`)
- https://github.com/Kocoro-lab/Shannon/blob/05b0c5ca7b65b2d2c2c8be83906b37d5307718e7/rust/agent-core/src/sandbox.rs#L261 (`tokio::main`)
- https://github.com/kolloch/zack/blob/2244f29a74f74401abd8869c50c7d868afd656b9/zaun/src/lib.rs#L157 (`library`)
- https://github.com/MaxVerevkin/wlr-which-key/blob/179261a45867544f2b3c25871b8ef77c6f9bdf43/src/main.rs#L532 (`none`)
- https://github.com/openanolis/cryptpilot/blob/8deab3eee1d6488f6578f6284d0494c70ce7f6b4/src/provider/mod.rs#L228 (`tokio::main`)
- https://github.com/pantsbuild/pants/blob/e5ee289fc67a02a8d011f3fd160e8544727bd613/src/rust/process_execution/children/src/lib.rs#L44 (`tokio::main`)
- https://github.com/pika-backup/pika-backup/blob/297d21a2b02dc7230c2d8e7cf86289d25ba82de1/pika-backup/src/utils.rs#L171 (`library`)
- https://github.com/proxmox/pve-xtermjs/blob/1c92330cccb21fb65abcff6e35848b712592dccb/termproxy/src/main.rs#L290 (`none`)
- https://github.com/rand/mnemosyne/blob/3db85ed0bde68f25c38fb4a77c6cac50fa638d52/src/daemon/mod.rs#L181, https://github.com/rand/mnemosyne/blob/3db85ed0bde68f25c38fb4a77c6cac50fa638d52/src/daemon/orchestration.rs#L204 (`tokio::main`)
- https://github.com/raphamorim/rio/blob/c0d687a3a1a439dbe81405d805c3dc191c90c45f/teletypewriter/src/unix/mod.rs#L551 (`library`)
- https://github.com/rawkode/cuenv/blob/2e76ab93b0faa25a53094406e7f5f1ca15e32068/crates/security/src/access_restrictions.rs#L379 (`thread::spawn`)
- https://github.com/reubeno/brush/blob/b1a76480bf000bb2d351b65c2012eb06f88fa0ae/brush-core/src/sys/unix/commands.rs#L64 (`tokio::runtime::Runtime::new()`)
- https://github.com/sebosp/chartacritty/blob/b2c19ee7836ca3d939fff045cad93182749cc0ea/alacritty_terminal/src/tty/unix.rs#L250 (`thread::spawn`)
- https://github.com/skanehira/ghost/blob/ad500f9fb47b7266e6d5989b0232881efe1bfa87/src/app/process.rs#L82 (`tokio::main`)
- https://github.com/coreos/rpm-ostree/blob/0ad2ee53f3c2d77bc4adfd618d865e919c943865/rust/src/bwrap.rs#L100 (`thread::spawn`)
- https://github.com/zerocore-ai/microsandbox/blob/9d334572a821775070de68d7cb20f1b2b65da9c3/microsandbox-utils/lib/runtime/supervisor.rs#L131 (`tokio::main`)
- https://github.com/willfindlay/bpfcontain-rs/blob/eb2cd826b609e165d63d784c0f562b7a278171d2/src/subcommands/run.rs#L62 (`library`)
- https://github.com/willothy/sesh/blob/c013dda71e69d59de3e23c08aa7fc4f71c8e087c/shared/src/pty.rs#L216 (`tokio::main`)
- https://github.com/AiTerminalFoundation/ai-terminal/blob/33618aedf66229ee5075519640344fef44b058e1/ai-terminal/src-tauri/src/command/core/execute_command.rs#L388 (`thread::spawn`)
- https://github.com/Toromino/chromiumos-platform2/blob/97e6ba18f0e5ab6723f3448a66f82c1a07538d87/os_install_service/src/util.rs#L92 (`thread::spawn`)
- https://github.com/jimmyff/nixfiles/blob/462d487680d91b25a74f69ce2509e519504ea5de/scripts/flitter/flitter.rs#L455 (`tokio::main`)
- https://github.com/simonrw/dap-gui/blob/5d073ff0ea4e99ba94af6c0137c089418ead5298/crates/server/src/debugpy.rs#L43 (`thread::spawn`)
- https://github.com/Team-Atlanta/aixcc-afc-atlantis/blob/ef3425da2bc8951afcfe419913e88b064eb3bcf0/example-crs-webservice/crs-multilang/uniafl/src/concolic/executor/symcc/symcc.rs#L216, https://github.com/Team-Atlanta/aixcc-afc-atlantis/blob/ef3425da2bc8951afcfe419913e88b064eb3bcf0/example-crs-webservice/crs-multilang/uniafl/src/concolic/executor/symcc/symqemu.rs#L259 (`thread::spawn`)
- https://github.com/nullpo-head/dbgee/blob/e2a34f3271ee7e100eeccd8e00f8a50729ef0f1a/dbgee/src/os/linux.rs#L162 (`thread::spawn`)
- https://github.com/KingBright/training_manager/blob/22e54166ed4e153e05b6902d7d8661a6a4b5e31a/src/task_manager.rs#L87 (`tokio::main`)
- https://github.com/SparkyTD/ovpn/blob/c55e2945776ab0da0616707315141a5a04c4129c/ovpnd/src/session_manager.rs#L32 (`tokio::main`)
- https://github.com/FulanXisen/like/blob/e5b6543e8f1729e410439e1e50ceed1fdc9fddc2/like-strace/src/main.rs#L51 (`none`)
- https://github.com/patrickdappollonio/dotenv/blob/5ec161045b21c5548f867cae637bea64bea59550/src/main.rs#L166 (`none`)
- https://github.com/jefflouisma/KasmVNCPlus/blob/765a77371645cbbba5b639f49591c251aa97f363/novnc_recorder/src/ffmpeg.rs#L11 (`thread::spawn`)
- https://github.com/xlsynth/xlsynth-crate/blob/02967d938910cf23a09e93ffb3284e50c1e11d7d/xlsynth-driver/src/prover.rs#L474 (`thread::spawn`)
- https://github.com/M00NLIG7/pandoras_box/blob/d2dcfff230426688af6d6770899d9865d27b5733/rustrc/src/stateful_process.rs#L37 (`tokio::main`)
- https://github.com/bendiksolheim/term/blob/9906f5c5a0115fc330ac6c56e947d41c4ad78545/src/term/term.rs#L155 (`async_std::task::spawn`)
- https://github.com/yskszk63/ssssh/blob/9c03e1d7bab2b1cdc52892d4c28e11daf639bd94/examples/bash.rs#L87 (`tokio::main`)
- https://github.com/jarhodes314/tcp-buffer-test/blob/63c366f5c1dd940f9a392fc73be653c0c0d81b4c/src/main.rs#L281 (`tokio::main`)
- https://github.com/luser/spawn-ptrace/blob/d29c538c0c81ac1d62f19cee8be48e4ab0926392/src/lib.rs#L59 (`library`)
- https://github.com/OSH-2020/x-chital/blob/fadcc96868b619f4463c95edd01b71f23fb20c13/rvisor/src/sentry/platform/ptrace.rs#L21 (`none`)
- https://github.com/sbstp/supermon/blob/3353fad862970eb54c293c63dda9980539e1ac0b/src/reactor.rs#L76 (`thread::spawn`)
- https://github.com/headcrab-rs/headcrab/blob/5a420c5da3f51196cd991680bb2b3fded6ce7033/src/target/unix.rs#L55 (`library`)
- https://github.com/taoky/greenhook/blob/2a69aa432ab7fd4eee68eea2a2b4dbec845165cc/src/lib.rs#L430 (`thread::spawn`)
- https://github.com/saltnpepper97/snug/blob/b59df7f112f059f144c7a32c00bd8ad73a7d584d/src/process.rs#L89 (`thread::spawn`)
- https://github.com/regiontog/WebDM/blob/43b557295316668a975466354d86703f7ad3dd2d/src/main.rs#L488 (`gtk`)
- https://github.com/KailasMahavarkar/rustbox/blob/c27801cc479c75fec6c12a08272d507793769871/rustbox/src/executor.rs#L226 (`thread::spawn`)
- https://github.com/roboplc/virtual-terminal/blob/967e6c9dea5455c7f7f3b9276b88abb445009a3a/src/lib.rs#L224 (`library`)
- https://github.com/nui/caco3/blob/ce093f81c6a57dd9172894e7d5ab28d2984f5cc8/caco3-pty/src/nixpty.rs#L67 (`library`)
- https://github.com/nohackjustnoobb/Macro-Deck-Driver/blob/531421e41266ca952cf7c62644da0194877c1e24/src/cli/background_start.rs#L69 (`thread::spawn`)
- https://github.com/ManishaChavva/a653rs-linux/blob/1b2830594519d9eff3779f6cd22795dbe14f8d54/hypervisor/src/hypervisor/partition.rs#L258 (`thread::spawn`)
- https://github.com/rhinos0608/codecrucible-synth/blob/7c7d5fb7743116a2a94c3156dee43439675a4e2e/rust-executor/src/executors/command.rs#L422 (`library`)
- https://github.com/Nughm3/sandbox/blob/5146a95e29b198b85c496077dc096bbe1e882d23/src/lib.rs#L73 (`library`)
- https://github.com/naverwhale/whaleos-platform2/blob/166e825c8a43753dda3b021c5519124842d1d8d5/os_install_service/src/util.rs#L92 (`thread::spawn`)
- https://github.com/de-vri-es/webterm-server-rs/blob/69845f7f0678dce942de8313d6d4b0a57f83a9a9/src/pty/pseudo_terminal_pair.rs#L59, https://github.com/de-vri-es/webterm-server-rs/blob/69845f7f0678dce942de8313d6d4b0a57f83a9a9/src/pty/pseudo_terminal_pair.rs#L63 (`tokio::main`)
- https://github.com/jjs-dev/jjs/blob/bf00423f70f8a6ed508bbcb8b38840225e43cc73/src/invoker/src/worker/valuer.rs#L39 (`tokio::main`)
- https://github.com/Drumblow/seac/blob/9c9fea1222ab98aee25376b51de8a66fe0eb4676/src/executor/process_manager.rs#L139 (`tokio::main`)
- https://github.com/CJacob314/rustcon/blob/92c582fa21fc68bb8740f617455820c3377a0274/src/main.rs#L166 (`none`)
- https://github.com/antialize/simple-admin/blob/cbde17d1b132be8427340fcc55f82958641d32a6/src/bin/sadmin/persist_daemon.rs#L223 (`tokio::main`)
- https://github.com/jonathanforhan/pty-exec/blob/c08b037747aa049cd7d41d6ea8de02305775d789/src/unix/pty.rs#L48 (`library`)
- https://github.com/0b01/tail2/blob/5f699b6aafb4c5be677c21e8f619c35bca33efcf/tail2/src/client/run.rs#L178 (`tokio::main`)
- https://github.com/owtaylor/ttymon/blob/61dfc842151c1e45920c427471617cbb27caff0d/src/pty.rs#L187 (`none`)
- https://github.com/Nughm3/contest-platform/blob/25a6ad7ff84550f5a2b32f270660acdd010e5a93/judge/src/sandbox.rs#L96 (`tokio::main`)
- https://github.com/valoq/glycin/blob/3447555afb60245f4e2329f129c921573f077d1b/glycin/src/sandbox.rs#L335 (`library`)
</details>