### PR TITLE
chore: Update annotate-snippets to 0.12.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,9 +80,9 @@ dependencies = [
 
 [[package]]
 name = "annotate-snippets"
-version = "0.12.8"
+version = "0.12.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "025c7edcdffa4ccc5c0905f472a0ae3759378cfbef88ef518a3575e19ae3aebd"
+checksum = "a44baf24dd94e781f74dfe67ffee75a09a57971ddf0f615a178b4f6d404b48ff"
 dependencies = [
  "anstyle",
  "unicode-width 0.2.2",
@@ -3766,7 +3766,7 @@ dependencies = [
 name = "rustc_errors"
 version = "0.0.0"
 dependencies = [
- "annotate-snippets 0.12.8",
+ "annotate-snippets 0.12.9",
  "anstream",
  "anstyle",
  "derive_setters",

--- a/compiler/rustc_errors/Cargo.toml
+++ b/compiler/rustc_errors/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 
 [dependencies]
 # tidy-alphabetical-start
-annotate-snippets = "0.12.8"
+annotate-snippets = "0.12.9"
 anstream = "0.6.20"
 anstyle = "1.0.13"
 derive_setters = "0.1.6"

--- a/tests/ui/lifetimes/borrowck-let-suggestion.stderr
+++ b/tests/ui/lifetimes/borrowck-let-suggestion.stderr
@@ -13,7 +13,7 @@ LL |     x.use_mut();
 help: consider consuming the `Vec<i32>` when turning it into an `Iterator`
    |
 LL |     let mut x = vec![1].into_iter();
-   |                          +++++
+   |                         +++++
 help: consider using a `let` binding to create a longer lived value
    |
 LL ~     let binding = vec![1];

--- a/tests/ui/test-attrs/inaccessible-test-modules.stderr
+++ b/tests/ui/test-attrs/inaccessible-test-modules.stderr
@@ -13,7 +13,7 @@ LL | use test as y;
 help: consider importing this module instead
    |
 LL | use test::test as y;
-   |         ++++++
+   |     ++++++
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
This PR updates `annotate-snippets` to `0.12.9`, which includes a fix for rust-lang/rust#148070.

fixes rust-lang/rust#148070
