### PR TITLE
Work with `stdbuf` environment variables

### DIFF
--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -346,7 +346,7 @@ mod util;
 
 const DEFAULT_BUF_SIZE: usize = crate::sys::io::DEFAULT_BUF_SIZE;
 
-pub(crate) use stdio::cleanup;
+pub(crate) use stdio::{StderrRaw, StdinRaw, StdoutRaw, cleanup};
 
 struct Guard<'a> {
     buf: &'a mut Vec<u8>,

--- a/library/std/src/io/stdio/tests.rs
+++ b/library/std/src/io/stdio/tests.rs
@@ -1,8 +1,6 @@
 use super::*;
-use crate::assert_matches::assert_matches;
-use crate::os::fd::{FromRawFd, OwnedFd};
 use crate::panic::{RefUnwindSafe, UnwindSafe};
-use crate::sync::mpsc::{TryRecvError, sync_channel};
+use crate::sync::mpsc::sync_channel;
 use crate::thread;
 
 #[test]
@@ -165,96 +163,4 @@ where
         *log.lock().unwrap(),
         [Start1, Acquire1, Start2, Release1, Acquire2, Release2, Acquire1, Release1]
     );
-}
-
-#[test]
-#[cfg(unix)]
-fn stdiobufwriter_line_buffered() {
-    let mut fd1 = -1;
-    let mut fd2 = -1;
-
-    if unsafe {
-        libc::openpty(
-            &raw mut fd1,
-            &raw mut fd2,
-            crate::ptr::null_mut(),
-            crate::ptr::null(),
-            crate::ptr::null(),
-        )
-    } < 0
-    {
-        panic!("openpty() failed with {:?}", io::Error::last_os_error());
-    }
-
-    let writer = unsafe { File::from_raw_fd(fd1) };
-    let mut reader = unsafe { File::from_raw_fd(fd2) };
-
-    assert!(writer.is_terminal(), "file descriptor returned by openpty() must be a terminal");
-    assert!(reader.is_terminal(), "file descriptor returned by openpty() must be a terminal");
-
-    let (sender, receiver) = sync_channel(64);
-
-    thread::spawn(move || {
-        loop {
-            let mut buf = vec![0u8; 1024];
-            let size = reader.read(&mut buf[..]).expect("read failed");
-            buf.truncate(size);
-            sender.send(buf);
-        }
-    });
-
-    let mut writer = StdioBufWriter::new(writer);
-    assert_matches!(
-        writer,
-        StdioBufWriter::LineBuffered(_),
-        "StdioBufWriter should be line-buffered when created from a terminal"
-    );
-
-    writer.write_all(b"line 1\n").expect("write failed");
-    assert_eq!(receiver.recv().expect("recv failed"), b"line 1\n");
-
-    writer.write_all(b"line 2\nextra ").expect("write failed");
-    assert_eq!(receiver.recv().expect("recv failed"), b"line 2\n");
-
-    writer.write_all(b"line 3\n").expect("write failed");
-    assert_eq!(receiver.recv().expect("recv failed"), b"extra line 3\n");
-}
-
-#[test]
-fn stdiobufwriter_block_buffered() {
-    let (mut reader, mut writer) = io::pipe().expect("pipe() failed");
-
-    // Need to convert to an OwnedFd and then into a File because PipeReader/PipeWriter don't
-    // implement IsTerminal, but that is required by StdioBufWriter
-    let mut reader = File::from(OwnedFd::from(reader));
-    let mut writer = File::from(OwnedFd::from(writer));
-
-    assert!(!reader.is_terminal(), "file returned by pipe() cannot be a terminal");
-    assert!(!writer.is_terminal(), "file returned by pipe() cannot be a terminal");
-
-    let (sender, receiver) = sync_channel(64);
-
-    thread::spawn(move || {
-        loop {
-            let mut buf = vec![0u8; 1024];
-            let size = reader.read(&mut buf[..]).expect("read failed");
-            buf.truncate(size);
-            sender.send(buf);
-        }
-    });
-
-    let mut writer = StdioBufWriter::new(writer);
-    assert_matches!(
-        writer,
-        StdioBufWriter::BlockBuffered(_),
-        "StdioBufWriter should be block-buffered when created from a file that is not a terminal"
-    );
-
-    writer.write_all(b"line 1\n").expect("write failed");
-    writer.write_all(b"line 2\n").expect("write failed");
-    writer.write_all(b"line 3\n").expect("write failed");
-    assert_matches!(receiver.try_recv(), Err(TryRecvError::Empty));
-
-    writer.flush().expect("flush failed");
-    assert_eq!(receiver.recv().expect("recv failed"), b"line 1\nline 2\nline 3\n");
 }

--- a/library/std/src/os/fd/owned.rs
+++ b/library/std/src/os/fd/owned.rs
@@ -489,6 +489,13 @@ impl<'a> AsFd for io::StdinLock<'a> {
     }
 }
 
+impl AsFd for io::StdinRaw {
+    #[inline]
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        unsafe { BorrowedFd::borrow_raw(0) }
+    }
+}
+
 #[stable(feature = "io_safety", since = "1.63.0")]
 impl AsFd for io::Stdout {
     #[inline]
@@ -506,6 +513,13 @@ impl<'a> AsFd for io::StdoutLock<'a> {
     }
 }
 
+impl AsFd for io::StdoutRaw {
+    #[inline]
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        unsafe { BorrowedFd::borrow_raw(1) }
+    }
+}
+
 #[stable(feature = "io_safety", since = "1.63.0")]
 impl AsFd for io::Stderr {
     #[inline]
@@ -519,6 +533,13 @@ impl<'a> AsFd for io::StderrLock<'a> {
     #[inline]
     fn as_fd(&self) -> BorrowedFd<'_> {
         // SAFETY: user code should not close stderr out from under the standard library
+        unsafe { BorrowedFd::borrow_raw(2) }
+    }
+}
+
+impl AsFd for io::StderrRaw {
+    #[inline]
+    fn as_fd(&self) -> BorrowedFd<'_> {
         unsafe { BorrowedFd::borrow_raw(2) }
     }
 }

--- a/library/std/src/os/windows/io/handle.rs
+++ b/library/std/src/os/windows/io/handle.rs
@@ -562,6 +562,13 @@ impl<'a> AsHandle for crate::io::StdinLock<'a> {
     }
 }
 
+impl AsHandle for crate::io::StdinRaw {
+    #[inline]
+    fn as_handle(&self) -> BorrowedHandle<'_> {
+        unsafe { BorrowedHandle::borrow_raw(self.as_raw_handle()) }
+    }
+}
+
 #[stable(feature = "io_safety", since = "1.63.0")]
 impl AsHandle for crate::io::Stdout {
     #[inline]
@@ -578,6 +585,13 @@ impl<'a> AsHandle for crate::io::StdoutLock<'a> {
     }
 }
 
+impl AsHandle for crate::io::StdoutRaw {
+    #[inline]
+    fn as_handle(&self) -> BorrowedHandle<'_> {
+        unsafe { BorrowedHandle::borrow_raw(self.as_raw_handle()) }
+    }
+}
+
 #[stable(feature = "io_safety", since = "1.63.0")]
 impl AsHandle for crate::io::Stderr {
     #[inline]
@@ -588,6 +602,13 @@ impl AsHandle for crate::io::Stderr {
 
 #[stable(feature = "io_safety", since = "1.63.0")]
 impl<'a> AsHandle for crate::io::StderrLock<'a> {
+    #[inline]
+    fn as_handle(&self) -> BorrowedHandle<'_> {
+        unsafe { BorrowedHandle::borrow_raw(self.as_raw_handle()) }
+    }
+}
+
+impl AsHandle for crate::io::StderrRaw {
     #[inline]
     fn as_handle(&self) -> BorrowedHandle<'_> {
         unsafe { BorrowedHandle::borrow_raw(self.as_raw_handle()) }

--- a/library/std/src/os/windows/io/raw.rs
+++ b/library/std/src/os/windows/io/raw.rs
@@ -140,6 +140,24 @@ impl<'a> AsRawHandle for io::StderrLock<'a> {
     }
 }
 
+impl AsRawHandle for io::StdinRaw {
+    fn as_raw_handle(&self) -> RawHandle {
+        stdio_handle(unsafe { sys::c::GetStdHandle(sys::c::STD_INPUT_HANDLE) as RawHandle })
+    }
+}
+
+impl AsRawHandle for io::StdoutRaw {
+    fn as_raw_handle(&self) -> RawHandle {
+        stdio_handle(unsafe { sys::c::GetStdHandle(sys::c::STD_OUTPUT_HANDLE) as RawHandle })
+    }
+}
+
+impl AsRawHandle for io::StderrRaw {
+    fn as_raw_handle(&self) -> RawHandle {
+        stdio_handle(unsafe { sys::c::GetStdHandle(sys::c::STD_ERROR_HANDLE) as RawHandle })
+    }
+}
+
 // Translate a handle returned from `GetStdHandle` into a handle to return to
 // the user.
 fn stdio_handle(raw: RawHandle) -> RawHandle {


### PR DESCRIPTION
Check `_STDBUF_O` and `_STDBUF_E` environment variables for setting up stdout and stderr. This makes Rust programs compatible with coreutils's (and `uutils`'s) `stdbuf` program. It incidentally also solves https://github.com/uutils/coreutils/issues/7967.

This lays ground work for solving rust-lang/rust#60673 because it lets the user of a Rust program decide the default buffering, offering the opportunity to change the current default, letting stdout buffer blockwise if it's not connected to a terminal, because the user can now override the behavior using [`stdbuf`](https://linux.die.net/man/1/stdbuf) if it's needed.