### PR TITLE
Rollup of 11 pull requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,9 +80,9 @@ dependencies = [
 
 [[package]]
 name = "annotate-snippets"
-version = "0.12.8"
+version = "0.12.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "025c7edcdffa4ccc5c0905f472a0ae3759378cfbef88ef518a3575e19ae3aebd"
+checksum = "a44baf24dd94e781f74dfe67ffee75a09a57971ddf0f615a178b4f6d404b48ff"
 dependencies = [
  "anstyle",
  "unicode-width 0.2.2",
@@ -3766,7 +3766,7 @@ dependencies = [
 name = "rustc_errors"
 version = "0.0.0"
 dependencies = [
- "annotate-snippets 0.12.8",
+ "annotate-snippets 0.12.9",
  "anstream",
  "anstyle",
  "derive_setters",

--- a/compiler/rustc_errors/Cargo.toml
+++ b/compiler/rustc_errors/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 
 [dependencies]
 # tidy-alphabetical-start
-annotate-snippets = "0.12.8"
+annotate-snippets = "0.12.9"
 anstream = "0.6.20"
 anstyle = "1.0.13"
 derive_setters = "0.1.6"

--- a/library/Cargo.lock
+++ b/library/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "addr2line"
-version = "0.25.0"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9acbfca36652500c911ddb767ed433e3ed99b032b5d935be73c6923662db1d43"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
 dependencies = [
  "gimli",
  "rustc-std-workspace-alloc",
@@ -49,9 +49,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.1"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 dependencies = [
  "rustc-std-workspace-core",
 ]
@@ -78,9 +78,9 @@ dependencies = [
 
 [[package]]
 name = "dlmalloc"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa3a2dbee57b69fbb5dbe852fa9c0925697fb0c7fbcb1593e90e5ffaedf13d51"
+checksum = "06cdfe340b16dd990c54cce79743613fa09fbb16774f33a77c9fd196f8f3fa30"
 dependencies = [
  "cfg-if",
  "libc",
@@ -109,9 +109,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.32.0"
+version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93563d740bc9ef04104f9ed6f86f1e3275c2cdafb95664e26584b9ca807a8ffe"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 dependencies = [
  "rustc-std-workspace-alloc",
  "rustc-std-workspace-core",
@@ -393,9 +393,9 @@ dependencies = [
 
 [[package]]
 name = "vex-sdk"
-version = "0.27.0"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89f74fce61d7a7ba1589da9634c6305a72befb7cc9150c1f872d87d8060f32b9"
+checksum = "79e5fe15afde1305478b35e2cb717fff59f485428534cf49cfdbfa4723379bf6"
 dependencies = [
  "rustc-std-workspace-core",
 ]
@@ -422,12 +422,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-sys"
-version = "0.59.0"
+name = "windows-link"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -436,10 +442,11 @@ version = "0.0.0"
 
 [[package]]
 name = "windows-targets"
-version = "0.52.6"
+version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
+ "windows-link",
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
  "windows_i686_gnu",
@@ -452,57 +459,57 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.6"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.6"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.6"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.52.6"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.6"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.6"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.6"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.6"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "wit-bindgen"
-version = "0.45.0"
+version = "0.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052283831dbae3d879dc7f51f3d92703a316ca49f91540417d38591826127814"
+checksum = "5c573471f125075647d03df72e026074b7203790d41351cd6edc96f46bcccd36"
 dependencies = [
  "rustc-std-workspace-alloc",
  "rustc-std-workspace-core",

--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -146,6 +146,7 @@
 #![feature(std_internals)]
 #![feature(str_internals)]
 #![feature(temporary_niche_types)]
+#![feature(transmutability)]
 #![feature(trivial_clone)]
 #![feature(trusted_fused)]
 #![feature(trusted_len)]

--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -265,18 +265,11 @@ use crate::vec::{self, Vec};
 /// You can look at these with the [`as_ptr`], [`len`], and [`capacity`]
 /// methods:
 ///
-// FIXME Update this when vec_into_raw_parts is stabilized
 /// ```
-/// use std::mem;
-///
 /// let story = String::from("Once upon a time...");
 ///
-/// // Prevent automatically dropping the String's data
-/// let mut story = mem::ManuallyDrop::new(story);
-///
-/// let ptr = story.as_mut_ptr();
-/// let len = story.len();
-/// let capacity = story.capacity();
+/// // Deconstruct the String into parts.
+/// let (ptr, len, capacity) = story.into_raw_parts();
 ///
 /// // story has nineteen bytes
 /// assert_eq!(19, len);
@@ -932,7 +925,6 @@ impl String {
     /// # Examples
     ///
     /// ```
-    /// #![feature(vec_into_raw_parts)]
     /// let s = String::from("hello");
     ///
     /// let (ptr, len, cap) = s.into_raw_parts();
@@ -941,7 +933,7 @@ impl String {
     /// assert_eq!(rebuilt, "hello");
     /// ```
     #[must_use = "losing the pointer will leak memory"]
-    #[unstable(feature = "vec_into_raw_parts", reason = "new API", issue = "65816")]
+    #[stable(feature = "vec_into_raw_parts", since = "CURRENT_RUSTC_VERSION")]
     pub fn into_raw_parts(self) -> (*mut u8, usize, usize) {
         self.vec.into_raw_parts()
     }
@@ -970,19 +962,12 @@ impl String {
     ///
     /// # Examples
     ///
-    // FIXME Update this when vec_into_raw_parts is stabilized
     /// ```
-    /// use std::mem;
-    ///
     /// unsafe {
     ///     let s = String::from("hello");
     ///
-    ///     // Prevent automatically dropping the String's data
-    ///     let mut s = mem::ManuallyDrop::new(s);
-    ///
-    ///     let ptr = s.as_mut_ptr();
-    ///     let len = s.len();
-    ///     let capacity = s.capacity();
+    ///     // Deconstruct the String into parts.
+    ///     let (ptr, len, capacity) = s.into_raw_parts();
     ///
     ///     let s = String::from_raw_parts(ptr, len, capacity);
     ///

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -592,21 +592,13 @@ impl<T> Vec<T> {
     ///
     /// # Examples
     ///
-    // FIXME Update this when vec_into_raw_parts is stabilized
     /// ```
     /// use std::ptr;
-    /// use std::mem;
     ///
     /// let v = vec![1, 2, 3];
     ///
-    /// // Prevent running `v`'s destructor so we are in complete control
-    /// // of the allocation.
-    /// let mut v = mem::ManuallyDrop::new(v);
-    ///
-    /// // Pull out the various important pieces of information about `v`
-    /// let p = v.as_mut_ptr();
-    /// let len = v.len();
-    /// let cap = v.capacity();
+    /// // Deconstruct the vector into parts.
+    /// let (p, len, cap) = v.into_raw_parts();
     ///
     /// unsafe {
     ///     // Overwrite memory with 4, 5, 6
@@ -700,23 +692,13 @@ impl<T> Vec<T> {
     ///
     /// # Examples
     ///
-    // FIXME Update this when vec_into_raw_parts is stabilized
     /// ```
     /// #![feature(box_vec_non_null)]
     ///
-    /// use std::ptr::NonNull;
-    /// use std::mem;
-    ///
     /// let v = vec![1, 2, 3];
     ///
-    /// // Prevent running `v`'s destructor so we are in complete control
-    /// // of the allocation.
-    /// let mut v = mem::ManuallyDrop::new(v);
-    ///
-    /// // Pull out the various important pieces of information about `v`
-    /// let p = unsafe { NonNull::new_unchecked(v.as_mut_ptr()) };
-    /// let len = v.len();
-    /// let cap = v.capacity();
+    /// // Deconstruct the vector into parts.
+    /// let (p, len, cap) = v.into_parts();
     ///
     /// unsafe {
     ///     // Overwrite memory with 4, 5, 6
@@ -783,7 +765,6 @@ impl<T> Vec<T> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(vec_into_raw_parts)]
     /// let v: Vec<i32> = vec![-1, 0, 1];
     ///
     /// let (ptr, len, cap) = v.into_raw_parts();
@@ -798,7 +779,7 @@ impl<T> Vec<T> {
     /// assert_eq!(rebuilt, [4294967295, 0, 1]);
     /// ```
     #[must_use = "losing the pointer will leak memory"]
-    #[unstable(feature = "vec_into_raw_parts", reason = "new API", issue = "65816")]
+    #[stable(feature = "vec_into_raw_parts", since = "CURRENT_RUSTC_VERSION")]
     pub fn into_raw_parts(self) -> (*mut T, usize, usize) {
         let mut me = ManuallyDrop::new(self);
         (me.as_mut_ptr(), me.len(), me.capacity())
@@ -823,7 +804,7 @@ impl<T> Vec<T> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(vec_into_raw_parts, box_vec_non_null)]
+    /// #![feature(box_vec_non_null)]
     ///
     /// let v: Vec<i32> = vec![-1, 0, 1];
     ///
@@ -840,7 +821,6 @@ impl<T> Vec<T> {
     /// ```
     #[must_use = "losing the pointer will leak memory"]
     #[unstable(feature = "box_vec_non_null", reason = "new API", issue = "130364")]
-    // #[unstable(feature = "vec_into_raw_parts", reason = "new API", issue = "65816")]
     pub fn into_parts(self) -> (NonNull<T>, usize, usize) {
         let (ptr, len, capacity) = self.into_raw_parts();
         // SAFETY: A `Vec` always has a non-null pointer.
@@ -996,29 +976,20 @@ impl<T, A: Allocator> Vec<T, A> {
     ///
     /// # Examples
     ///
-    // FIXME Update this when vec_into_raw_parts is stabilized
     /// ```
     /// #![feature(allocator_api)]
     ///
     /// use std::alloc::System;
     ///
     /// use std::ptr;
-    /// use std::mem;
     ///
     /// let mut v = Vec::with_capacity_in(3, System);
     /// v.push(1);
     /// v.push(2);
     /// v.push(3);
     ///
-    /// // Prevent running `v`'s destructor so we are in complete control
-    /// // of the allocation.
-    /// let mut v = mem::ManuallyDrop::new(v);
-    ///
-    /// // Pull out the various important pieces of information about `v`
-    /// let p = v.as_mut_ptr();
-    /// let len = v.len();
-    /// let cap = v.capacity();
-    /// let alloc = v.allocator();
+    /// // Deconstruct the vector into parts.
+    /// let (p, len, cap, alloc) = v.into_raw_parts_with_alloc();
     ///
     /// unsafe {
     ///     // Overwrite memory with 4, 5, 6
@@ -1116,29 +1087,18 @@ impl<T, A: Allocator> Vec<T, A> {
     ///
     /// # Examples
     ///
-    // FIXME Update this when vec_into_raw_parts is stabilized
     /// ```
     /// #![feature(allocator_api, box_vec_non_null)]
     ///
     /// use std::alloc::System;
-    ///
-    /// use std::ptr::NonNull;
-    /// use std::mem;
     ///
     /// let mut v = Vec::with_capacity_in(3, System);
     /// v.push(1);
     /// v.push(2);
     /// v.push(3);
     ///
-    /// // Prevent running `v`'s destructor so we are in complete control
-    /// // of the allocation.
-    /// let mut v = mem::ManuallyDrop::new(v);
-    ///
-    /// // Pull out the various important pieces of information about `v`
-    /// let p = unsafe { NonNull::new_unchecked(v.as_mut_ptr()) };
-    /// let len = v.len();
-    /// let cap = v.capacity();
-    /// let alloc = v.allocator();
+    /// // Deconstruct the vector into parts.
+    /// let (p, len, cap, alloc) = v.into_parts_with_alloc();
     ///
     /// unsafe {
     ///     // Overwrite memory with 4, 5, 6
@@ -1206,7 +1166,7 @@ impl<T, A: Allocator> Vec<T, A> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(allocator_api, vec_into_raw_parts)]
+    /// #![feature(allocator_api)]
     ///
     /// use std::alloc::System;
     ///
@@ -1228,7 +1188,6 @@ impl<T, A: Allocator> Vec<T, A> {
     /// ```
     #[must_use = "losing the pointer will leak memory"]
     #[unstable(feature = "allocator_api", issue = "32838")]
-    // #[unstable(feature = "vec_into_raw_parts", reason = "new API", issue = "65816")]
     pub fn into_raw_parts_with_alloc(self) -> (*mut T, usize, usize, A) {
         let mut me = ManuallyDrop::new(self);
         let len = me.len();
@@ -1256,7 +1215,7 @@ impl<T, A: Allocator> Vec<T, A> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(allocator_api, vec_into_raw_parts, box_vec_non_null)]
+    /// #![feature(allocator_api, box_vec_non_null)]
     ///
     /// use std::alloc::System;
     ///
@@ -1279,7 +1238,6 @@ impl<T, A: Allocator> Vec<T, A> {
     #[must_use = "losing the pointer will leak memory"]
     #[unstable(feature = "allocator_api", issue = "32838")]
     // #[unstable(feature = "box_vec_non_null", reason = "new API", issue = "130364")]
-    // #[unstable(feature = "vec_into_raw_parts", reason = "new API", issue = "65816")]
     pub fn into_parts_with_alloc(self) -> (NonNull<T>, usize, usize, A) {
         let (ptr, len, capacity, alloc) = self.into_raw_parts_with_alloc();
         // SAFETY: A `Vec` always has a non-null pointer.

--- a/library/core/src/intrinsics/mod.rs
+++ b/library/core/src/intrinsics/mod.rs
@@ -769,13 +769,9 @@ pub const fn forget<T: ?Sized>(_: T);
 /// // in terms of converting the original inner type (`&i32`) to the new one (`Option<&i32>`),
 /// // this has all the same caveats. Besides the information provided above, also consult the
 /// // [`from_raw_parts`] documentation.
+/// let (ptr, len, capacity) = v_clone.into_raw_parts();
 /// let v_from_raw = unsafe {
-// FIXME Update this when vec_into_raw_parts is stabilized
-///     // Ensure the original vector is not dropped.
-///     let mut v_clone = std::mem::ManuallyDrop::new(v_clone);
-///     Vec::from_raw_parts(v_clone.as_mut_ptr() as *mut Option<&i32>,
-///                         v_clone.len(),
-///                         v_clone.capacity())
+///     Vec::from_raw_parts(ptr.cast::<*mut Option<&i32>>(), len, capacity)
 /// };
 /// ```
 ///

--- a/library/core/src/primitive_docs.rs
+++ b/library/core/src/primitive_docs.rs
@@ -1647,7 +1647,7 @@ mod prim_usize {}
 /// For the other direction, things are more complicated: when unsafe code passes arguments
 /// to safe functions or returns values from safe functions, they generally must *at least*
 /// not violate these invariants. The full requirements are stronger, as the reference generally
-/// must point to data that is safe to use at type `T`.
+/// must point to data that is safe to use as type `T`.
 ///
 /// It is not decided yet whether unsafe code may violate these invariants temporarily on internal
 /// data. As a consequence, unsafe code which violates these invariants temporarily on internal data

--- a/library/core/src/primitive_docs.rs
+++ b/library/core/src/primitive_docs.rs
@@ -1531,9 +1531,8 @@ mod prim_usize {}
 /// `&mut T` references can be freely coerced into `&T` references with the same referent type, and
 /// references with longer lifetimes can be freely coerced into references with shorter ones.
 ///
-/// Reference equality by address, instead of comparing the values pointed to, is accomplished via
-/// implicit reference-pointer coercion and raw pointer equality via [`ptr::eq`], while
-/// [`PartialEq`] compares values.
+/// [`PartialEq`] will compare referenced values. It is possible to compare the reference address
+/// using reference-pointer coercion and raw pointer equality via [`ptr::eq`].
 ///
 /// ```
 /// use std::ptr;

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -381,7 +381,6 @@
 #![feature(try_reserve_kind)]
 #![feature(try_with_capacity)]
 #![feature(unique_rc_arc)]
-#![feature(vec_into_raw_parts)]
 #![feature(wtf8_internals)]
 // tidy-alphabetical-end
 //

--- a/src/librustdoc/html/render/search_index/encode.rs
+++ b/src/librustdoc/html/render/search_index/encode.rs
@@ -78,16 +78,9 @@ pub fn read_postings_from_string(postings: &mut Vec<Vec<u32>>, mut buf: &[u8]) {
     while let Some(&c) = buf.get(0) {
         if c < 0x3a {
             buf = &buf[1..];
-            let mut slot = Vec::new();
-            for _ in 0..c {
-                slot.push(
-                    (buf[0] as u32)
-                        | ((buf[1] as u32) << 8)
-                        | ((buf[2] as u32) << 16)
-                        | ((buf[3] as u32) << 24),
-                );
-                buf = &buf[4..];
-            }
+            let buf = buf.split_off(..usize::from(c) * size_of::<u32>()).unwrap();
+            let (chunks, _) = buf.as_chunks();
+            let slot = chunks.iter().copied().map(u32::from_le_bytes).collect();
             postings.push(slot);
         } else {
             let (bitmap, consumed_bytes_len) =

--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -153,6 +153,7 @@ static TARGETS: &[&str] = &[
     "riscv32imafc-unknown-none-elf",
     "riscv32gc-unknown-linux-gnu",
     "riscv64imac-unknown-none-elf",
+    "riscv64a23-unknown-linux-gnu",
     "riscv64gc-unknown-hermit",
     "riscv64gc-unknown-none-elf",
     "riscv64gc-unknown-linux-gnu",

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -1635,8 +1635,7 @@ impl<'test> TestCx<'test> {
                     // executed and that don't specify their own optimization levels.
                     // Note: aux libs don't have a pass-mode, so they won't get optimized
                     // unless compile-flags are set in the aux file.
-                    if self.config.optimize_tests
-                        && self.props.pass_mode(&self.config) == Some(PassMode::Run)
+                    if self.props.pass_mode(&self.config) == Some(PassMode::Run)
                         && !self
                             .props
                             .compile_flags

--- a/src/tools/tidy/src/deps.rs
+++ b/src/tools/tidy/src/deps.rs
@@ -530,6 +530,7 @@ const PERMITTED_STDLIB_DEPENDENCIES: &[&str] = &[
     "unwinding",
     "vex-sdk",
     "wasi",
+    "windows-link",
     "windows-sys",
     "windows-targets",
     "windows_aarch64_gnullvm",

--- a/tests/codegen-llvm/overflow-checks.rs
+++ b/tests/codegen-llvm/overflow-checks.rs
@@ -18,7 +18,7 @@ extern crate overflow_checks_add;
 // CHECK-LABEL: @add(
 #[no_mangle]
 pub unsafe fn add(a: u8, b: u8) -> u8 {
-    //        CHECK: i8 noundef %a, i8 noundef %b
+    //        CHECK: i8 noundef{{( zeroext)?}} %a, i8 noundef{{( zeroext)?}} %b
     //        CHECK: add i8 %b, %a
     //        DEBUG: icmp ult i8 [[zero:[^,]+]], %a
     //        DEBUG: call core::num::overflow_panic::add

--- a/tests/ui/abi/compatibility.rs
+++ b/tests/ui/abi/compatibility.rs
@@ -40,10 +40,9 @@
 //@ revisions: loongarch64
 //@[loongarch64] compile-flags: --target loongarch64-unknown-linux-gnu
 //@[loongarch64] needs-llvm-components: loongarch
-//FIXME: wasm is disabled due to <https://github.com/rust-lang/rust/issues/115666>.
-//FIXME @ revisions: wasm
-//FIXME @[wasm] compile-flags: --target wasm32-unknown-unknown
-//FIXME @[wasm] needs-llvm-components: webassembly
+//@ revisions: wasm
+//@[wasm] compile-flags: --target wasm32-unknown-unknown
+//@[wasm] needs-llvm-components: webassembly
 //@ revisions: wasip1
 //@[wasip1] compile-flags: --target wasm32-wasip1
 //@[wasip1] needs-llvm-components: webassembly

--- a/tests/ui/lifetimes/borrowck-let-suggestion.stderr
+++ b/tests/ui/lifetimes/borrowck-let-suggestion.stderr
@@ -13,7 +13,7 @@ LL |     x.use_mut();
 help: consider consuming the `Vec<i32>` when turning it into an `Iterator`
    |
 LL |     let mut x = vec![1].into_iter();
-   |                          +++++
+   |                         +++++
 help: consider using a `let` binding to create a longer lived value
    |
 LL ~     let binding = vec![1];

--- a/tests/ui/test-attrs/inaccessible-test-modules.stderr
+++ b/tests/ui/test-attrs/inaccessible-test-modules.stderr
@@ -13,7 +13,7 @@ LL | use test as y;
 help: consider importing this module instead
    |
 LL | use test::test as y;
-   |         ++++++
+   |     ++++++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/try-block/try-block-as-statement.rs
+++ b/tests/ui/try-block/try-block-as-statement.rs
@@ -1,0 +1,24 @@
+//@ check-fail
+//@ edition: 2018
+
+#![feature(try_blocks)]
+#![crate_type = "lib"]
+
+// fine because the `;` discards the value
+fn foo(a: &str, b: &str) -> i32 {
+    try {
+        let foo = std::fs::read_to_string(a)?;
+        std::fs::write(b, foo);
+    };
+    4 + 10
+}
+
+// parses without the semicolon, but gives a type error
+fn bar(a: &str, b: &str) -> i32 {
+    try {
+        let foo = std::fs::read_to_string(a)?;
+        //~^ ERROR mismatched types
+        std::fs::write(b, foo);
+    }
+    4 + 10
+}

--- a/tests/ui/try-block/try-block-as-statement.stderr
+++ b/tests/ui/try-block/try-block-as-statement.stderr
@@ -1,0 +1,16 @@
+error[E0308]: mismatched types
+  --> $DIR/try-block-as-statement.rs:19:19
+   |
+LL |         let foo = std::fs::read_to_string(a)?;
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found `Result<_, Error>`
+   |
+   = note: expected unit type `()`
+                   found enum `Result<_, std::io::Error>`
+help: consider using `Result::expect` to unwrap the `Result<_, std::io::Error>` value, panicking if the value is a `Result::Err`
+   |
+LL |         let foo = std::fs::read_to_string(a)?.expect("REASON");
+   |                                              +++++++++++++++++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#148416 (`vec_recycle`: implementation)
 - rust-lang/rust#148522 (Micro-optimize rustdoc search index parsing)
 - rust-lang/rust#148827 (Stabilize vec_into_raw_parts)
 - rust-lang/rust#148832 (Bump library dependencies)
 - rust-lang/rust#148836 (tweak primitive reference docs)
 - rust-lang/rust#148859 (Fix overflow-checks test for RISC-V target)
 - rust-lang/rust#148886 (Add riscv64a23-unknown-linux-gnu to build-manifest TARGETS)
 - rust-lang/rust#148956 (re-enable wasm abi test)
 - rust-lang/rust#148963 (runtest.rs: remove redundant check)
 - rust-lang/rust#148968 (Add another *ExprWithBlock* test for `try` blocks)
 - rust-lang/rust#148984 (chore: Update annotate-snippets to 0.12.9)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=148416,148522,148827,148832,148836,148859,148886,148956,148963,148968,148984)
<!-- homu-ignore:end -->