### PR TITLE
Tweak Motor OS linker preset, fix `remote-test-server` for Motor OS

### DIFF
--- a/compiler/rustc_target/src/spec/base/motor.rs
+++ b/compiler/rustc_target/src/spec/base/motor.rs
@@ -4,16 +4,8 @@ use crate::spec::{
 
 pub(crate) fn opts() -> TargetOptions {
     let pre_link_args = TargetOptions::link_args(
-        LinkerFlavor::Gnu(Cc::No, Lld::No),
-        &[
-            "-e",
-            "motor_start",
-            "--no-undefined",
-            "--error-unresolved-symbols",
-            "--no-undefined-version",
-            "-u",
-            "__rust_abort",
-        ],
+        LinkerFlavor::Gnu(Cc::Yes, Lld::No),
+        &["-e", "motor_start", "-u", "__rust_abort"],
     );
     TargetOptions {
         os: Os::Motor,
@@ -23,7 +15,7 @@ pub(crate) fn opts() -> TargetOptions {
         // We use "OS level" TLS (see thread/local.rs in stdlib).
         has_thread_local: false,
         frame_pointer: FramePointer::NonLeaf,
-        linker_flavor: LinkerFlavor::Gnu(Cc::No, Lld::No),
+        linker_flavor: LinkerFlavor::Gnu(Cc::Yes, Lld::No),
         main_needs_argc_argv: true,
         panic_strategy: PanicStrategy::Abort,
         pre_link_args,

--- a/compiler/rustc_target/src/spec/targets/x86_64_unknown_motor.rs
+++ b/compiler/rustc_target/src/spec/targets/x86_64_unknown_motor.rs
@@ -1,5 +1,5 @@
 use crate::spec::{
-    Arch, CodeModel, LinkSelfContainedDefault, LldFlavor, RelocModel, RelroLevel, Target, base,
+    Arch, CodeModel, LinkSelfContainedDefault, RelocModel, RelroLevel, Target, base,
 };
 
 pub(crate) fn target() -> Target {
@@ -15,7 +15,6 @@ pub(crate) fn target() -> Target {
     base.relro_level = RelroLevel::Full;
     base.static_position_independent_executables = true;
     base.relocation_model = RelocModel::Pic;
-    base.lld_flavor_json = LldFlavor::Ld;
     base.link_self_contained = LinkSelfContainedDefault::True;
     base.dynamic_linking = false;
     base.crt_static_default = true;

--- a/src/tools/remote-test-server/src/main.rs
+++ b/src/tools/remote-test-server/src/main.rs
@@ -10,13 +10,13 @@
 //! themselves having support libraries. All data over the TCP sockets is in a
 //! basically custom format suiting our needs.
 
-#[cfg(not(windows))]
+#[cfg(all(not(windows), not(target_os = "motor")))]
 use std::fs::Permissions;
 use std::fs::{self, File};
 use std::io::prelude::*;
 use std::io::{self, BufReader};
 use std::net::{SocketAddr, TcpListener, TcpStream};
-#[cfg(not(windows))]
+#[cfg(all(not(windows), not(target_os = "motor")))]
 use std::os::unix::prelude::*;
 use std::path::{Path, PathBuf};
 use std::process::{Command, ExitStatus, Stdio};
@@ -325,7 +325,7 @@ fn handle_run(socket: TcpStream, work: &Path, tmp: &Path, lock: &Mutex<()>, conf
     ]));
 }
 
-#[cfg(not(windows))]
+#[cfg(all(not(windows), not(target_os = "motor")))]
 fn get_status_code(status: &ExitStatus) -> (u8, i32) {
     match status.code() {
         Some(n) => (0, n),
@@ -333,7 +333,7 @@ fn get_status_code(status: &ExitStatus) -> (u8, i32) {
     }
 }
 
-#[cfg(windows)]
+#[cfg(any(windows, target_os = "motor"))]
 fn get_status_code(status: &ExitStatus) -> (u8, i32) {
     (0, status.code().unwrap())
 }
@@ -359,11 +359,11 @@ fn recv<B: BufRead>(dir: &Path, io: &mut B) -> PathBuf {
     dst
 }
 
-#[cfg(not(windows))]
+#[cfg(all(not(windows), not(target_os = "motor")))]
 fn set_permissions(path: &Path) {
     t!(fs::set_permissions(&path, Permissions::from_mode(0o755)));
 }
-#[cfg(windows)]
+#[cfg(any(windows, target_os = "motor"))]
 fn set_permissions(_path: &Path) {}
 
 fn my_copy(src: &mut dyn Read, which: u8, dst: &Mutex<dyn Write>) {


### PR DESCRIPTION
Had to tweak linking options in target spec to make it work (see https://github.com/moturus/motor-os/issues/46).

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
