### PR TITLE
Fix false positive of "multiple different versions of crate X in the dependency graph"

### DIFF
--- a/tests/ui/traits/auxiliary/crate1.rs
+++ b/tests/ui/traits/auxiliary/crate1.rs
@@ -1,0 +1,7 @@
+//@ aux-crate:crate2=crate2.rs
+
+pub trait Trait {}
+
+pub fn foo(_arg: impl Trait) {}
+
+pub fn bar(_arg: impl crate2::Trait) {}

--- a/tests/ui/traits/auxiliary/crate2.rs
+++ b/tests/ui/traits/auxiliary/crate2.rs
@@ -1,0 +1,1 @@
+pub trait Trait {}

--- a/tests/ui/traits/wrong-multiple-different-versions-of-a-crate.rs
+++ b/tests/ui/traits/wrong-multiple-different-versions-of-a-crate.rs
@@ -1,0 +1,12 @@
+// Test that we do not report false positives of a crate as being found multiple times in the
+// dependency graph with different versions, when this crate is only present once. In this test,
+// this was happening for `crate1` when two different crates in the dependencies were imported
+// as ExternCrateSource::Path.
+// Issue #148892.
+//@ aux-crate:crate1=crate1.rs
+
+struct MyStruct; //~ HELP  the trait `Trait` is not implemented for `MyStruct`
+
+fn main() {
+    crate1::foo(MyStruct); //~ ERROR the trait bound `MyStruct: Trait` is not satisfied
+}

--- a/tests/ui/traits/wrong-multiple-different-versions-of-a-crate.stderr
+++ b/tests/ui/traits/wrong-multiple-different-versions-of-a-crate.stderr
@@ -1,0 +1,22 @@
+error[E0277]: the trait bound `MyStruct: Trait` is not satisfied
+  --> $DIR/wrong-multiple-different-versions-of-a-crate.rs:11:17
+   |
+LL |     crate1::foo(MyStruct);
+   |     ----------- ^^^^^^^^ unsatisfied trait bound
+   |     |
+   |     required by a bound introduced by this call
+   |
+help: the trait `Trait` is not implemented for `MyStruct`
+  --> $DIR/wrong-multiple-different-versions-of-a-crate.rs:8:1
+   |
+LL | struct MyStruct;
+   | ^^^^^^^^^^^^^^^
+note: required by a bound in `foo`
+  --> $DIR/auxiliary/crate1.rs:5:23
+   |
+LL | pub fn foo(_arg: impl Trait) {}
+   |                       ^^^^^ required by this bound in `foo`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
cc rust-lang/rust#148892

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
