### PR TITLE
triagebot: remove jsha from notifications for rustdoc HTML

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1070,7 +1070,6 @@ source file via `./x run src/tools/unicode-table-generator` instead of editing \
 message = "Some changes occurred in HTML/CSS/JS."
 cc = [
     "@GuillaumeGomez",
-    "@jsha",
     "@lolbinarycat",
 ]
 


### PR DESCRIPTION
See https://github.com/rust-lang/team/pull/2083 - I'm moving to alumni status for rustdoc and no longer need these notifications.