### PR TITLE
[rustdoc] Remove `UrlFragment::render` method to unify `clean::types::links` and `anchor`

### DIFF
--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -249,7 +249,7 @@ pub(crate) fn clean_trait_ref_with_constraints<'tcx>(
     trait_ref: ty::PolyTraitRef<'tcx>,
     constraints: ThinVec<AssocItemConstraint>,
 ) -> Path {
-    let kind = cx.tcx.def_kind(trait_ref.def_id()).into();
+    let kind = ItemType::from_def_id(trait_ref.def_id(), cx.tcx);
     if !matches!(kind, ItemType::Trait | ItemType::TraitAlias) {
         span_bug!(cx.tcx.def_span(trait_ref.def_id()), "`TraitRef` had unexpected kind {kind:?}");
     }

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -1,3 +1,4 @@
+use std::fmt::Write;
 use std::hash::Hash;
 use std::path::PathBuf;
 use std::sync::{Arc, OnceLock as OnceCell};
@@ -524,7 +525,8 @@ impl Item {
                     debug!(?url);
                     match fragment {
                         Some(UrlFragment::Item(def_id)) => {
-                            url.push_str(&crate::html::format::fragment(*def_id, cx.tcx()))
+                            write!(url, "{}", crate::html::format::fragment(*def_id, cx.tcx()))
+                                .unwrap();
                         }
                         Some(UrlFragment::UserWritten(raw)) => {
                             url.push('#');

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -522,8 +522,15 @@ impl Item {
                 debug!(?id);
                 if let Ok(HrefInfo { mut url, .. }) = href(*id, cx) {
                     debug!(?url);
-                    if let Some(ref fragment) = *fragment {
-                        fragment.render(&mut url, cx.tcx())
+                    match fragment {
+                        Some(UrlFragment::Item(def_id)) => {
+                            url.push_str(&crate::html::format::fragment(*def_id, cx.tcx()))
+                        }
+                        Some(UrlFragment::UserWritten(raw)) => {
+                            url.push('#');
+                            url.push_str(raw);
+                        }
+                        None => {}
                     }
                     Some(RenderedLink {
                         original_text: s.clone(),

--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -26,6 +26,7 @@ use crate::clean::{
 };
 use crate::core::DocContext;
 use crate::display::Joined as _;
+use crate::formats::item_type::ItemType;
 
 #[cfg(test)]
 mod tests;
@@ -496,7 +497,7 @@ pub(crate) fn register_res(cx: &mut DocContext<'_>, res: Res) -> DefId {
 
     let (kind, did) = match res {
         Res::Def(
-            kind @ (AssocTy
+            AssocTy
             | AssocFn
             | AssocConst
             | Variant
@@ -511,9 +512,9 @@ pub(crate) fn register_res(cx: &mut DocContext<'_>, res: Res) -> DefId {
             | Const
             | Static { .. }
             | Macro(..)
-            | TraitAlias),
+            | TraitAlias,
             did,
-        ) => (kind.into(), did),
+        ) => (ItemType::from_def_id(did, cx.tcx), did),
 
         _ => panic!("register_res: unexpected {res:?}"),
     };

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -431,7 +431,6 @@ fn generate_item_def_id_path(
     original_def_id: DefId,
     cx: &Context<'_>,
     root_path: Option<&str>,
-    original_def_kind: DefKind,
 ) -> Result<HrefInfo, HrefError> {
     use rustc_middle::traits::ObligationCause;
     use rustc_trait_selection::infer::TyCtxtInferExt;
@@ -457,15 +456,14 @@ fn generate_item_def_id_path(
     let relative = clean::inline::item_relative_path(tcx, def_id);
     let fqp: Vec<Symbol> = once(crate_name).chain(relative).collect();
 
-    let def_kind = tcx.def_kind(def_id);
-    let shortty = def_kind.into();
+    let shortty = ItemType::from_def_id(def_id, tcx);
     let module_fqp = to_module_fqp(shortty, &fqp);
     let mut is_remote = false;
 
     let url_parts = url_parts(cx.cache(), def_id, module_fqp, &cx.current, &mut is_remote)?;
     let mut url_parts = make_href(root_path, shortty, url_parts, &fqp, is_remote);
     if def_id != original_def_id {
-        let kind = ItemType::from_def_kind(original_def_kind, Some(def_kind));
+        let kind = ItemType::from_def_id(original_def_id, tcx);
         url_parts = format!("{url_parts}#{kind}.{}", tcx.item_name(original_def_id))
     };
     Ok(HrefInfo { url: url_parts, kind: shortty, rust_path: fqp })
@@ -605,7 +603,7 @@ pub(crate) fn href_with_root_path(
             } else if did.is_local() {
                 return Err(HrefError::Private);
             } else {
-                return generate_item_def_id_path(did, original_did, cx, root_path, def_kind);
+                return generate_item_def_id_path(did, original_did, cx, root_path);
             }
         }
     };
@@ -835,35 +833,35 @@ fn print_higher_ranked_params_with_space(
     })
 }
 
+pub(crate) fn fragment(did: DefId, tcx: TyCtxt<'_>) -> String {
+    let def_kind = tcx.def_kind(did);
+    match def_kind {
+        DefKind::AssocTy | DefKind::AssocFn | DefKind::AssocConst | DefKind::Variant => {
+            let item_type = ItemType::from_def_id(did, tcx);
+            format!("#{}.{}", item_type.as_str(), tcx.item_name(did))
+        }
+        DefKind::Field => {
+            let parent_def_id = tcx.parent(did);
+            let s;
+            let kind = if tcx.def_kind(parent_def_id) == DefKind::Variant {
+                s = format!("variant.{}.field", tcx.item_name(parent_def_id).as_str());
+                &s
+            } else {
+                "structfield"
+            };
+            format!("#{kind}.{}", tcx.item_name(did))
+        }
+        _ => String::new(),
+    }
+}
+
 pub(crate) fn print_anchor(did: DefId, text: Symbol, cx: &Context<'_>) -> impl Display {
     fmt::from_fn(move |f| {
         if let Ok(HrefInfo { url, kind, rust_path }) = href(did, cx) {
-            let tcx = cx.tcx();
-            let def_kind = tcx.def_kind(did);
-            let anchor = match def_kind {
-                DefKind::AssocTy | DefKind::AssocFn | DefKind::AssocConst | DefKind::Variant => {
-                    let parent_def_id = tcx.parent(did);
-                    let item_type =
-                        ItemType::from_def_kind(def_kind, Some(tcx.def_kind(parent_def_id)));
-                    format!("#{}.{}", item_type.as_str(), tcx.item_name(did))
-                }
-                DefKind::Field => {
-                    let s;
-                    let parent_id = tcx.parent(did);
-                    let kind = if tcx.def_kind(parent_id) == DefKind::Variant {
-                        s = format!("variant.{}.field", tcx.item_name(parent_id).as_str());
-                        &s
-                    } else {
-                        "structfield"
-                    };
-                    format!("#{kind}.{}", tcx.item_name(did))
-                }
-                _ => String::new(),
-            };
-
             write!(
                 f,
                 r#"<a class="{kind}" href="{url}{anchor}" title="{kind} {path}">{text}</a>"#,
+                anchor = fragment(did, cx.tcx()),
                 path = join_path_syms(rust_path),
                 text = EscapeBodyText(text.as_str()),
             )

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -203,43 +203,6 @@ pub(crate) enum UrlFragment {
     UserWritten(String),
 }
 
-impl UrlFragment {
-    /// Render the fragment, including the leading `#`.
-    pub(crate) fn render(&self, s: &mut String, tcx: TyCtxt<'_>) {
-        s.push('#');
-        match self {
-            &UrlFragment::Item(def_id) => {
-                let kind = match tcx.def_kind(def_id) {
-                    DefKind::AssocFn => {
-                        if tcx.associated_item(def_id).defaultness(tcx).has_value() {
-                            "method."
-                        } else {
-                            "tymethod."
-                        }
-                    }
-                    DefKind::AssocConst => "associatedconstant.",
-                    DefKind::AssocTy => "associatedtype.",
-                    DefKind::Variant => "variant.",
-                    DefKind::Field => {
-                        let parent_id = tcx.parent(def_id);
-                        if tcx.def_kind(parent_id) == DefKind::Variant {
-                            s.push_str("variant.");
-                            s.push_str(tcx.item_name(parent_id).as_str());
-                            ".field."
-                        } else {
-                            "structfield."
-                        }
-                    }
-                    kind => bug!("unexpected associated item kind: {kind:?}"),
-                };
-                s.push_str(kind);
-                s.push_str(tcx.item_name(def_id).as_str());
-            }
-            UrlFragment::UserWritten(raw) => s.push_str(raw),
-        }
-    }
-}
-
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub(crate) struct ResolutionInfo {
     item_id: DefId,


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/148648.
First part of https://github.com/rust-lang/rust/issues/148547.

The last part will be about handle `AssocItemLink` differently (either remove it or change how we do it).

r? @lolbinarycat 