### PR TITLE
doc: fix `strict_provenance_lints` tracking issue link

### DIFF
--- a/src/doc/unstable-book/src/language-features/strict-provenance-lints.md
+++ b/src/doc/unstable-book/src/language-features/strict-provenance-lints.md
@@ -1,8 +1,8 @@
 # `strict_provenance_lints`
 
-The tracking issue for this feature is: [#95228]
+The tracking issue for this feature is: [#130351]
 
-[#95228]: https://github.com/rust-lang/rust/issues/95228
+[#130351]: https://github.com/rust-lang/rust/issues/130351
 -----
 
 The `strict_provenance_lints` feature allows to enable the `fuzzy_provenance_casts` and `lossy_provenance_casts` lints.

--- a/src/tools/rust-analyzer/crates/ide-db/src/generated/lints.rs
+++ b/src/tools/rust-analyzer/crates/ide-db/src/generated/lints.rs
@@ -10723,9 +10723,9 @@ The tracking issue for this feature is: [#99108]
         label: "strict_provenance_lints",
         description: r##"# `strict_provenance_lints`
 
-The tracking issue for this feature is: [#95228]
+The tracking issue for this feature is: [#130351]
 
-[#95228]: https://github.com/rust-lang/rust/issues/95228
+[#130351]: https://github.com/rust-lang/rust/issues/130351
 -----
 
 The `strict_provenance_lints` feature allows to enable the `fuzzy_provenance_casts` and `lossy_provenance_casts` lints.


### PR DESCRIPTION
This PR is a follow-up on https://github.com/rust-lang/rust/commit/56ee492a6e7a917b2b3f888e33dd52a13d3ecb64 and fixes the link to the `strict_provenance_lints` tracking issue.

I am not sure whether we should touch this line too:

https://github.com/rust-lang/rust/blob/66bc5a43e55eae14a2ec70b11004c88072fe7f02/compiler/rustc_lint_defs/src/builtin.rs#L2537

r? @RalfJung 