### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_mir_build/src/builder/block.rs
+++ b/compiler/rustc_mir_build/src/builder/block.rs
@@ -39,7 +39,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         expr: Option<ExprId>,
         region_scope: Scope,
     ) -> BlockAnd<()> {
-        let this = self;
+        let this = self; // See "LET_THIS_SELF".
 
         // This convoluted structure is to avoid using recursion as we walk down a list
         // of statements. Basically, the structure we get back is something like:

--- a/compiler/rustc_mir_build/src/builder/expr/as_constant.rs
+++ b/compiler/rustc_mir_build/src/builder/expr/as_constant.rs
@@ -19,7 +19,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
     /// Compile `expr`, yielding a compile-time constant. Assumes that
     /// `expr` is a valid compile-time constant!
     pub(crate) fn as_constant(&mut self, expr: &Expr<'tcx>) -> ConstOperand<'tcx> {
-        let this = self;
+        let this = self; // See "LET_THIS_SELF".
         let tcx = this.tcx;
         let Expr { ty, temp_scope_id: _, span, ref kind } = *expr;
         match kind {

--- a/compiler/rustc_mir_build/src/builder/expr/as_operand.rs
+++ b/compiler/rustc_mir_build/src/builder/expr/as_operand.rs
@@ -119,7 +119,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         local_info: LocalInfo<'tcx>,
         needs_temporary: NeedsTemporary,
     ) -> BlockAnd<Operand<'tcx>> {
-        let this = self;
+        let this = self; // See "LET_THIS_SELF".
 
         let expr = &this.thir[expr_id];
         if let ExprKind::Scope { region_scope, lint_level, value } = expr.kind {
@@ -161,7 +161,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         scope: TempLifetime,
         expr_id: ExprId,
     ) -> BlockAnd<Operand<'tcx>> {
-        let this = self;
+        let this = self; // See "LET_THIS_SELF".
         let expr = &this.thir[expr_id];
         debug!("as_call_operand(block={:?}, expr={:?})", block, expr);
 

--- a/compiler/rustc_mir_build/src/builder/expr/as_place.rs
+++ b/compiler/rustc_mir_build/src/builder/expr/as_place.rs
@@ -423,7 +423,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         let expr = &self.thir[expr_id];
         debug!("expr_as_place(block={:?}, expr={:?}, mutability={:?})", block, expr, mutability);
 
-        let this = self;
+        let this = self; // See "LET_THIS_SELF".
         let expr_span = expr.span;
         let source_info = this.source_info(expr_span);
         match expr.kind {

--- a/compiler/rustc_mir_build/src/builder/expr/as_rvalue.rs
+++ b/compiler/rustc_mir_build/src/builder/expr/as_rvalue.rs
@@ -47,7 +47,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         scope: TempLifetime,
         expr_id: ExprId,
     ) -> BlockAnd<Rvalue<'tcx>> {
-        let this = self;
+        let this = self; // See "LET_THIS_SELF".
         let expr = &this.thir[expr_id];
         debug!("expr_as_rvalue(block={:?}, scope={:?}, expr={:?})", block, scope, expr);
 
@@ -676,7 +676,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         scope: TempLifetime,
         outer_source_info: SourceInfo,
     ) -> BlockAnd<Rvalue<'tcx>> {
-        let this = self;
+        let this = self; // See "LET_THIS_SELF".
         let value_expr = &this.thir[value];
         let elem_ty = value_expr.ty;
         if this.check_constness(&value_expr.kind) {
@@ -716,7 +716,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         mut block: BasicBlock,
         arg: ExprId,
     ) -> BlockAnd<Operand<'tcx>> {
-        let this = self;
+        let this = self; // See "LET_THIS_SELF".
 
         let source_info = this.source_info(upvar_span);
         let temp = this.local_decls.push(LocalDecl::new(upvar_ty, upvar_span));

--- a/compiler/rustc_mir_build/src/builder/expr/as_temp.rs
+++ b/compiler/rustc_mir_build/src/builder/expr/as_temp.rs
@@ -34,7 +34,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         expr_id: ExprId,
         mutability: Mutability,
     ) -> BlockAnd<Local> {
-        let this = self;
+        let this = self; // See "LET_THIS_SELF".
 
         let expr = &this.thir[expr_id];
         let expr_span = expr.span;

--- a/compiler/rustc_mir_build/src/builder/expr/into.rs
+++ b/compiler/rustc_mir_build/src/builder/expr/into.rs
@@ -32,7 +32,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         // since we frequently have to reference `self` from within a
         // closure, where `self` would be shadowed, it's easier to
         // just use the name `this` uniformly
-        let this = self;
+        let this = self; // See "LET_THIS_SELF".
         let expr = &this.thir[expr_id];
         let expr_span = expr.span;
         let source_info = this.source_info(expr_span);

--- a/compiler/rustc_mir_build/src/builder/expr/stmt.rs
+++ b/compiler/rustc_mir_build/src/builder/expr/stmt.rs
@@ -18,7 +18,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         expr_id: ExprId,
         statement_scope: Option<region::Scope>,
     ) -> BlockAnd<()> {
-        let this = self;
+        let this = self; // See "LET_THIS_SELF".
         let expr = &this.thir[expr_id];
         let expr_span = expr.span;
         let source_info = this.source_info(expr.span);

--- a/compiler/rustc_mir_build/src/builder/matches/mod.rs
+++ b/compiler/rustc_mir_build/src/builder/matches/mod.rs
@@ -109,7 +109,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         expr_id: ExprId,   // Condition expression to lower
         args: ThenElseArgs,
     ) -> BlockAnd<()> {
-        let this = self;
+        let this = self; // See "LET_THIS_SELF".
         let expr = &this.thir[expr_id];
         let expr_span = expr.span;
 

--- a/compiler/rustc_mir_build/src/builder/mod.rs
+++ b/compiler/rustc_mir_build/src/builder/mod.rs
@@ -2,6 +2,23 @@
 //! "Go to file" feature to silently ignore all files in the module, probably
 //! because it assumes that "build" is a build-output directory.
 //! See <https://github.com/rust-lang/rust/pull/134365>.
+//!
+//! ## The `let this = self;` idiom (LET_THIS_SELF)
+//!
+//! Throughout MIR building there are several places where a `Builder` method
+//! needs to borrow `self`, and then re-expose it to a closure as `|this|`.
+//!
+//! In complex builder methods, potentially with multiple levels of nesting, it
+//! would thus become necessary to mentally keep track of whether the builder
+//! is `self` (at the top level) or `this` (nested in a closure), or to replace
+//! one with the other when moving code in or out of a closure.
+//!
+//! (The borrow checker will prevent incorrect usage, but having to go back and
+//! satisfy the borrow checker still creates contributor friction.)
+//!
+//! To reduce that friction, some builder methods therefore start with
+//! `let this = self;` or similar, allowing subsequent code to uniformly refer
+//! to the builder as `this` (and never `self`), even when not nested.
 
 use itertools::Itertools;
 use rustc_abi::{ExternAbi, FieldIdx};

--- a/compiler/rustc_next_trait_solver/src/solve/assembly/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/assembly/mod.rs
@@ -1125,11 +1125,12 @@ where
     /// treat the alias as rigid.
     ///
     /// See trait-system-refactor-initiative#124 for more details.
-    #[instrument(level = "debug", skip(self, inject_normalize_to_rigid_candidate), ret)]
+    #[instrument(level = "debug", skip_all, fields(proven_via, goal), ret)]
     pub(super) fn assemble_and_merge_candidates<G: GoalKind<D>>(
         &mut self,
         proven_via: Option<TraitGoalProvenVia>,
         goal: Goal<I, G>,
+        inject_forced_ambiguity_candidate: impl FnOnce(&mut EvalCtxt<'_, D>) -> Option<QueryResult<I>>,
         inject_normalize_to_rigid_candidate: impl FnOnce(&mut EvalCtxt<'_, D>) -> QueryResult<I>,
     ) -> QueryResult<I> {
         let Some(proven_via) = proven_via else {
@@ -1149,15 +1150,24 @@ where
                 // `tests/ui/next-solver/alias-bound-shadowed-by-env.rs`.
                 let (mut candidates, _) = self
                     .assemble_and_evaluate_candidates(goal, AssembleCandidatesFrom::EnvAndBounds);
+                debug!(?candidates);
+
+                // If the trait goal has been proven by using the environment, we want to treat
+                // aliases as rigid if there are no applicable projection bounds in the environment.
+                if candidates.is_empty() {
+                    return inject_normalize_to_rigid_candidate(self);
+                }
+
+                // If we're normalizing an GAT, we bail if using a where-bound would constrain
+                // its generic arguments.
+                if let Some(result) = inject_forced_ambiguity_candidate(self) {
+                    return result;
+                }
 
                 // We still need to prefer where-bounds over alias-bounds however.
                 // See `tests/ui/winnowing/norm-where-bound-gt-alias-bound.rs`.
                 if candidates.iter().any(|c| matches!(c.source, CandidateSource::ParamEnv(_))) {
                     candidates.retain(|c| matches!(c.source, CandidateSource::ParamEnv(_)));
-                } else if candidates.is_empty() {
-                    // If the trait goal has been proven by using the environment, we want to treat
-                    // aliases as rigid if there are no applicable projection bounds in the environment.
-                    return inject_normalize_to_rigid_candidate(self);
                 }
 
                 if let Some((response, _)) = self.try_merge_candidates(&candidates) {

--- a/compiler/rustc_next_trait_solver/src/solve/effect_goals.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/effect_goals.rs
@@ -446,6 +446,6 @@ where
                 goal.with(ecx.cx(), goal.predicate.trait_ref);
             ecx.compute_trait_goal(trait_goal)
         })?;
-        self.assemble_and_merge_candidates(proven_via, goal, |_ecx| Err(NoSolution))
+        self.assemble_and_merge_candidates(proven_via, goal, |_ecx| None, |_ecx| Err(NoSolution))
     }
 }

--- a/compiler/rustc_next_trait_solver/src/solve/normalizes_to/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/normalizes_to/mod.rs
@@ -39,15 +39,49 @@ where
                         let trait_goal: Goal<I, ty::TraitPredicate<I>> = goal.with(cx, trait_ref);
                         ecx.compute_trait_goal(trait_goal)
                     })?;
-                self.assemble_and_merge_candidates(proven_via, goal, |ecx| {
-                    ecx.probe(|&result| ProbeKind::RigidAlias { result }).enter(|this| {
-                        this.structurally_instantiate_normalizes_to_term(
-                            goal,
-                            goal.predicate.alias,
-                        );
-                        this.evaluate_added_goals_and_make_canonical_response(Certainty::Yes)
-                    })
-                })
+                self.assemble_and_merge_candidates(
+                    proven_via,
+                    goal,
+                    |ecx| {
+                        // FIXME(generic_associated_types): Addresses aggressive inference in #92917.
+                        //
+                        // If this type is a GAT with currently unconstrained arguments, we do not
+                        // want to normalize it via a candidate which only applies for a specific
+                        // instantiation. We could otherwise keep the GAT as rigid and succeed this way.
+                        // See tests/ui/generic-associated-types/no-incomplete-gat-arg-inference.rs.
+                        //
+                        // This only avoids normalization if a GAT argument is fully unconstrained.
+                        // This is quite arbitrary but fixing it causes some ambiguity, see #125196.
+                        for arg in goal.predicate.alias.own_args(cx).iter() {
+                            let Some(term) = arg.as_term() else {
+                                continue;
+                            };
+                            match ecx.structurally_normalize_term(goal.param_env, term) {
+                                Ok(term) => {
+                                    if term.is_infer() {
+                                        return Some(
+                                            ecx.evaluate_added_goals_and_make_canonical_response(
+                                                Certainty::AMBIGUOUS,
+                                            ),
+                                        );
+                                    }
+                                }
+                                Err(NoSolution) => return Some(Err(NoSolution)),
+                            }
+                        }
+
+                        None
+                    },
+                    |ecx| {
+                        ecx.probe(|&result| ProbeKind::RigidAlias { result }).enter(|this| {
+                            this.structurally_instantiate_normalizes_to_term(
+                                goal,
+                                goal.predicate.alias,
+                            );
+                            this.evaluate_added_goals_and_make_canonical_response(Certainty::Yes)
+                        })
+                    },
+                )
             }
             ty::AliasTermKind::InherentTy | ty::AliasTermKind::InherentConst => {
                 self.normalize_inherent_associated_term(goal)
@@ -132,39 +166,7 @@ where
         then: impl FnOnce(&mut EvalCtxt<'_, D>) -> QueryResult<I>,
     ) -> QueryResult<I> {
         let cx = ecx.cx();
-        // FIXME(generic_associated_types): Addresses aggressive inference in #92917.
-        //
-        // If this type is a GAT with currently unconstrained arguments, we do not
-        // want to normalize it via a candidate which only applies for a specific
-        // instantiation. We could otherwise keep the GAT as rigid and succeed this way.
-        // See tests/ui/generic-associated-types/no-incomplete-gat-arg-inference.rs.
-        //
-        // This only avoids normalization if the GAT arguments are fully unconstrained.
-        // This is quite arbitrary but fixing it causes some ambiguity, see #125196.
-        match goal.predicate.alias.kind(cx) {
-            ty::AliasTermKind::ProjectionTy | ty::AliasTermKind::ProjectionConst => {
-                for arg in goal.predicate.alias.own_args(cx).iter() {
-                    let Some(term) = arg.as_term() else {
-                        continue;
-                    };
-                    let term = ecx.structurally_normalize_term(goal.param_env, term)?;
-                    if term.is_infer() {
-                        return ecx.evaluate_added_goals_and_make_canonical_response(
-                            Certainty::AMBIGUOUS,
-                        );
-                    }
-                }
-            }
-            ty::AliasTermKind::OpaqueTy
-            | ty::AliasTermKind::InherentTy
-            | ty::AliasTermKind::InherentConst
-            | ty::AliasTermKind::FreeTy
-            | ty::AliasTermKind::FreeConst
-            | ty::AliasTermKind::UnevaluatedConst => {}
-        }
-
         let projection_pred = assumption.as_projection_clause().unwrap();
-
         let assumption_projection_pred = ecx.instantiate_binder_with_infer(projection_pred);
         ecx.eq(goal.param_env, goal.predicate.alias, assumption_projection_pred.projection_term)?;
 

--- a/compiler/rustc_trait_selection/src/traits/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/mod.rs
@@ -635,9 +635,10 @@ pub fn try_evaluate_const<'tcx>(
                         return Err(EvaluateConstErr::HasGenericsOrInfers);
                     }
 
-                    let typing_env = infcx
-                        .typing_env(tcx.erase_and_anonymize_regions(param_env))
-                        .with_post_analysis_normalized(tcx);
+                    // Since there is no generic parameter, we can just drop the environment
+                    // to prevent query cycle.
+                    let typing_env = infcx.typing_env(ty::ParamEnv::empty());
+
                     (uv.args, typing_env)
                 }
             };

--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -99,7 +99,6 @@
 #![feature(cast_maybe_uninit)]
 #![feature(cell_get_cloned)]
 #![feature(char_internals)]
-#![feature(char_max_len)]
 #![feature(clone_to_uninit)]
 #![feature(coerce_unsized)]
 #![feature(const_convert)]

--- a/library/alloc/src/wtf8/mod.rs
+++ b/library/alloc/src/wtf8/mod.rs
@@ -14,7 +14,7 @@
 #[cfg(test)]
 mod tests;
 
-use core::char::{MAX_LEN_UTF8, encode_utf8_raw};
+use core::char::encode_utf8_raw;
 use core::hash::{Hash, Hasher};
 pub use core::wtf8::{CodePoint, Wtf8};
 #[cfg(not(test))]
@@ -166,7 +166,7 @@ impl Wtf8Buf {
     /// This does **not** include the WTF-8 concatenation check or `is_known_utf8` check.
     /// Copied from String::push.
     unsafe fn push_code_point_unchecked(&mut self, code_point: CodePoint) {
-        let mut bytes = [0; MAX_LEN_UTF8];
+        let mut bytes = [0; char::MAX_LEN_UTF8];
         let bytes = encode_utf8_raw(code_point.to_u32(), &mut bytes);
         self.bytes.extend_from_slice(bytes)
     }

--- a/library/alloctests/lib.rs
+++ b/library/alloctests/lib.rs
@@ -19,7 +19,6 @@
 #![feature(array_into_iter_constructors)]
 #![feature(assert_matches)]
 #![feature(char_internals)]
-#![feature(char_max_len)]
 #![feature(copied_into_inner)]
 #![feature(core_intrinsics)]
 #![feature(exact_size_is_empty)]

--- a/library/alloctests/tests/lib.rs
+++ b/library/alloctests/tests/lib.rs
@@ -3,7 +3,6 @@
 #![feature(iter_array_chunks)]
 #![feature(assert_matches)]
 #![feature(wtf8_internals)]
-#![feature(char_max_len)]
 #![feature(cow_is_borrowed)]
 #![feature(core_intrinsics)]
 #![feature(deque_extend_front)]

--- a/library/alloctests/tests/str.rs
+++ b/library/alloctests/tests/str.rs
@@ -2,7 +2,6 @@
 
 use std::assert_matches::assert_matches;
 use std::borrow::Cow;
-use std::char::MAX_LEN_UTF8;
 use std::cmp::Ordering::{Equal, Greater, Less};
 use std::str::{from_utf8, from_utf8_unchecked};
 
@@ -1232,7 +1231,7 @@ fn test_to_uppercase_rev_iterator() {
 #[test]
 #[cfg_attr(miri, ignore)] // Miri is too slow
 fn test_chars_decoding() {
-    let mut bytes = [0; MAX_LEN_UTF8];
+    let mut bytes = [0; char::MAX_LEN_UTF8];
     for c in (0..0x110000).filter_map(std::char::from_u32) {
         let s = c.encode_utf8(&mut bytes);
         if Some(c) != s.chars().next() {
@@ -1244,7 +1243,7 @@ fn test_chars_decoding() {
 #[test]
 #[cfg_attr(miri, ignore)] // Miri is too slow
 fn test_chars_rev_decoding() {
-    let mut bytes = [0; MAX_LEN_UTF8];
+    let mut bytes = [0; char::MAX_LEN_UTF8];
     for c in (0..0x110000).filter_map(std::char::from_u32) {
         let s = c.encode_utf8(&mut bytes);
         if Some(c) != s.chars().rev().next() {

--- a/library/core/src/char/methods.rs
+++ b/library/core/src/char/methods.rs
@@ -74,12 +74,12 @@ impl char {
 
     /// The maximum number of bytes required to [encode](char::encode_utf8) a `char` to
     /// UTF-8 encoding.
-    #[unstable(feature = "char_max_len", issue = "121714")]
+    #[stable(feature = "char_max_len_assoc", since = "CURRENT_RUSTC_VERSION")]
     pub const MAX_LEN_UTF8: usize = 4;
 
     /// The maximum number of two-byte units required to [encode](char::encode_utf16) a `char`
     /// to UTF-16 encoding.
-    #[unstable(feature = "char_max_len", issue = "121714")]
+    #[stable(feature = "char_max_len_assoc", since = "CURRENT_RUSTC_VERSION")]
     pub const MAX_LEN_UTF16: usize = 2;
 
     /// `U+FFFD REPLACEMENT CHARACTER` (�) is used in Unicode to represent a

--- a/library/core/src/ffi/c_longlong.md
+++ b/library/core/src/ffi/c_longlong.md
@@ -2,4 +2,4 @@ Equivalent to C's `signed long long` (`long long`) type.
 
 This type will almost always be [`i64`], but may differ on some systems. The C standard technically only requires that this type be a signed integer that is at least 64 bits and at least the size of a [`long`], although in practice, no system would have a `long long` that is not an `i64`, as most systems do not have a standardised [`i128`] type.
 
-[`long`]: c_int
+[`long`]: c_long

--- a/library/core/src/fmt/mod.rs
+++ b/library/core/src/fmt/mod.rs
@@ -3,7 +3,7 @@
 #![stable(feature = "rust1", since = "1.0.0")]
 
 use crate::cell::{Cell, Ref, RefCell, RefMut, SyncUnsafeCell, UnsafeCell};
-use crate::char::{EscapeDebugExtArgs, MAX_LEN_UTF8};
+use crate::char::EscapeDebugExtArgs;
 use crate::hint::assert_unchecked;
 use crate::marker::{PhantomData, PointeeSized};
 use crate::num::fmt as numfmt;
@@ -181,7 +181,7 @@ pub trait Write {
     /// ```
     #[stable(feature = "fmt_write_char", since = "1.1.0")]
     fn write_char(&mut self, c: char) -> Result {
-        self.write_str(c.encode_utf8(&mut [0; MAX_LEN_UTF8]))
+        self.write_str(c.encode_utf8(&mut [0; char::MAX_LEN_UTF8]))
     }
 
     /// Glue for usage of the [`write!`] macro with implementors of this trait.
@@ -2983,7 +2983,7 @@ impl Display for char {
         if f.options.flags & (flags::WIDTH_FLAG | flags::PRECISION_FLAG) == 0 {
             f.write_char(*self)
         } else {
-            f.pad(self.encode_utf8(&mut [0; MAX_LEN_UTF8]))
+            f.pad(self.encode_utf8(&mut [0; char::MAX_LEN_UTF8]))
         }
     }
 }

--- a/library/core/src/str/pattern.rs
+++ b/library/core/src/str/pattern.rs
@@ -38,7 +38,6 @@
     issue = "27721"
 )]
 
-use crate::char::MAX_LEN_UTF8;
 use crate::cmp::Ordering;
 use crate::convert::TryInto as _;
 use crate::slice::memchr;
@@ -563,7 +562,7 @@ impl Pattern for char {
 
     #[inline]
     fn into_searcher<'a>(self, haystack: &'a str) -> Self::Searcher<'a> {
-        let mut utf8_encoded = [0; MAX_LEN_UTF8];
+        let mut utf8_encoded = [0; char::MAX_LEN_UTF8];
         let utf8_size = self
             .encode_utf8(&mut utf8_encoded)
             .len()

--- a/library/core/src/wtf8.rs
+++ b/library/core/src/wtf8.rs
@@ -19,7 +19,7 @@
 // implementations, so, we'll have to add more doc(hidden)s anyway
 #![doc(hidden)]
 
-use crate::char::{MAX_LEN_UTF16, encode_utf16_raw};
+use crate::char::encode_utf16_raw;
 use crate::clone::CloneToUninit;
 use crate::fmt::{self, Write};
 use crate::hash::{Hash, Hasher};
@@ -541,7 +541,7 @@ impl Iterator for EncodeWide<'_> {
             return Some(tmp);
         }
 
-        let mut buf = [0; MAX_LEN_UTF16];
+        let mut buf = [0; char::MAX_LEN_UTF16];
         self.code_points.next().map(|code_point| {
             let n = encode_utf16_raw(code_point.to_u32(), &mut buf).len();
             if n == 2 {

--- a/library/coretests/tests/char.rs
+++ b/library/coretests/tests/char.rs
@@ -1,4 +1,3 @@
-use std::char::MAX_LEN_UTF8;
 use std::str::FromStr;
 use std::{char, str};
 
@@ -259,7 +258,7 @@ fn test_escape_unicode() {
 #[test]
 fn test_encode_utf8() {
     fn check(input: char, expect: &[u8]) {
-        let mut buf = [0; MAX_LEN_UTF8];
+        let mut buf = [0; char::MAX_LEN_UTF8];
         let ptr = buf.as_ptr();
         let s = input.encode_utf8(&mut buf);
         assert_eq!(s.as_ptr() as usize, ptr as usize);

--- a/library/std/src/fs/tests.rs
+++ b/library/std/src/fs/tests.rs
@@ -9,7 +9,6 @@ use rand::RngCore;
     target_vendor = "apple",
 ))]
 use crate::assert_matches::assert_matches;
-use crate::char::MAX_LEN_UTF8;
 #[cfg(any(
     windows,
     target_os = "freebsd",
@@ -174,7 +173,7 @@ fn file_test_io_non_positional_read() {
 #[test]
 fn file_test_io_seek_and_tell_smoke_test() {
     let message = "ten-four";
-    let mut read_mem = [0; MAX_LEN_UTF8];
+    let mut read_mem = [0; char::MAX_LEN_UTF8];
     let set_cursor = 4 as u64;
     let tell_pos_pre_read;
     let tell_pos_post_read;
@@ -405,7 +404,7 @@ fn file_test_io_seek_shakedown() {
     let chunk_one: &str = "qwer";
     let chunk_two: &str = "asdf";
     let chunk_three: &str = "zxcv";
-    let mut read_mem = [0; MAX_LEN_UTF8];
+    let mut read_mem = [0; char::MAX_LEN_UTF8];
     let tmpdir = tmpdir();
     let filename = &tmpdir.join("file_rt_io_file_test_seek_shakedown.txt");
     {
@@ -782,7 +781,7 @@ fn file_test_directoryinfo_readdir() {
         check!(w.write(msg));
     }
     let files = check!(fs::read_dir(dir));
-    let mut mem = [0; MAX_LEN_UTF8];
+    let mut mem = [0; char::MAX_LEN_UTF8];
     for f in files {
         let f = f.unwrap().path();
         {

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -276,7 +276,6 @@
 #![feature(cfg_sanitizer_cfi)]
 #![feature(cfg_target_thread_local)]
 #![feature(cfi_encoding)]
-#![feature(char_max_len)]
 #![feature(const_trait_impl)]
 #![feature(core_float_math)]
 #![feature(decl_macro)]

--- a/library/std/src/sys/stdio/windows.rs
+++ b/library/std/src/sys/stdio/windows.rs
@@ -1,6 +1,5 @@
 #![unstable(issue = "none", feature = "windows_stdio")]
 
-use core::char::MAX_LEN_UTF8;
 use core::str::utf8_char_width;
 
 use crate::mem::MaybeUninit;
@@ -427,7 +426,7 @@ fn utf16_to_utf8(utf16: &[u16], utf8: &mut [u8]) -> io::Result<usize> {
 
 impl IncompleteUtf8 {
     pub const fn new() -> IncompleteUtf8 {
-        IncompleteUtf8 { bytes: [0; MAX_LEN_UTF8], len: 0 }
+        IncompleteUtf8 { bytes: [0; char::MAX_LEN_UTF8], len: 0 }
     }
 }
 

--- a/tests/ui/generic-associated-types/gat-with-ambig-args-still-rigid.rs
+++ b/tests/ui/generic-associated-types/gat-with-ambig-args-still-rigid.rs
@@ -1,0 +1,45 @@
+//@ check-pass
+//@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@[next] compile-flags: -Znext-solver
+
+// Regression test for trait-system-refactor-initiative#256. The ambiguous
+// GAT arg check previously happened before checking whether the projection
+// candidate actually applied in the new trait solver.
+//
+// This meant we didn't consider `T::Assoc<_>` to be a rigid alias, resulting
+// in an inference failure.
+
+pub trait Proj {
+    type Assoc<T>;
+}
+
+trait Id {
+    type This;
+}
+impl<T> Id for T {
+    type This = T;
+}
+
+// This previously compiled as the "assumption would incompletely constrain GAT args"
+// check happened in each individual assumption after the `DeepRejectCtxt` fast path.
+fn with_fast_reject<T, U>(x: T::Assoc<u32>)
+where
+    T: Proj,
+    U: Proj<Assoc<i32> = u32>,
+{
+    let _: T::Assoc<_> = x;
+}
+
+// This previously failed with ambiguity as that check did happen before we actually
+// equated the goal with the assumption. Due to the alias in the where-clause
+// we didn't fast-reject this candidate.
+fn no_fast_reject<T, U>(x: T::Assoc<u32>)
+where
+    T: Proj,
+    <U as Id>::This: Proj<Assoc<i32> = u32>,
+{
+    let _: T::Assoc<_> = x;
+}
+
+fn main() {}

--- a/tests/ui/traits/next-solver/unevaluated_const_query_cycle.rs
+++ b/tests/ui/traits/next-solver/unevaluated_const_query_cycle.rs
@@ -1,0 +1,20 @@
+//@ compile-flags: -Znext-solver
+//@ check-pass
+
+// Regression test for https://github.com/rust-lang/trait-system-refactor-initiative/issues/249
+
+const CONST: &str = "hi";
+
+trait ToUnit {
+    type Assoc;
+}
+impl<T> ToUnit for T {
+    type Assoc = ();
+}
+
+fn foo()
+where
+    <[u8; CONST.len()] as ToUnit>::Assoc: Sized,
+{}
+
+fn main(){}


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#145610 (Stabilize `char_max_len`)
 - rust-lang/rust#148504 (Fix link in c_longlong documentation)
 - rust-lang/rust#148698 (Fix query cycle when encounter unevaluated const)
 - rust-lang/rust#148865 (move GAT inference prevention hack)
 - rust-lang/rust#149016 (Document the `let this = self;` idiom used in MIR building)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=145610,148504,148698,148865,149016)
<!-- homu-ignore:end -->