### PR TITLE
Add riscv64 uefi target

### DIFF
--- a/compiler/rustc_codegen_llvm/src/back/write.rs
+++ b/compiler/rustc_codegen_llvm/src/back/write.rs
@@ -1190,7 +1190,11 @@ fn embed_bitcode(
     } else {
         // We need custom section flags, so emit module-level inline assembly.
         // The "n" flags is currently not supported on RISC-V
-        let section_flags = if cgcx.is_pe_coff && cgcx.target_arch != "riscv64" { "n" } else { "e" };
+        let mut section_flags = "";
+        if cgcx.target_arch != "riscv64"
+        {
+        	if cgcx.is_pe_coff { section_flags = "n" } else { section_flags = "e" };
+        }
         let asm = create_section_with_flags_asm(".llvmbc", section_flags, bitcode);
         llvm::append_module_inline_asm(llmod, &asm);
         let asm = create_section_with_flags_asm(".llvmcmd", section_flags, &[]);

--- a/compiler/rustc_codegen_llvm/src/back/write.rs
+++ b/compiler/rustc_codegen_llvm/src/back/write.rs
@@ -1189,7 +1189,8 @@ fn embed_bitcode(
         llvm::set_linkage(llglobal, llvm::Linkage::PrivateLinkage);
     } else {
         // We need custom section flags, so emit module-level inline assembly.
-        let section_flags = if cgcx.is_pe_coff { "n" } else { "e" };
+        // The "n" flags is currently not supported on RISC-V
+        let section_flags = if cgcx.is_pe_coff && cgcx.target_arch != "riscv64" { "n" } else { "e" };
         let asm = create_section_with_flags_asm(".llvmbc", section_flags, bitcode);
         llvm::append_module_inline_asm(llmod, &asm);
         let asm = create_section_with_flags_asm(".llvmcmd", section_flags, &[]);

--- a/compiler/rustc_codegen_ssa/src/back/metadata.rs
+++ b/compiler/rustc_codegen_ssa/src/back/metadata.rs
@@ -20,7 +20,7 @@ use rustc_metadata::fs::METADATA_FILENAME;
 use rustc_middle::bug;
 use rustc_session::Session;
 use rustc_span::sym;
-use rustc_target::spec::{Abi, Os, RelocModel, Target, ef_avr_arch};
+use rustc_target::spec::{Abi, Arch, Os, RelocModel, Target, ef_avr_arch};
 use tracing::debug;
 
 use super::apple;
@@ -211,6 +211,12 @@ pub(crate) fn create_object_file(sess: &Session) -> Option<write::Object<'static
         return None;
     };
     let binary_format = sess.target.binary_format.to_object();
+    
+    if sess.target.arch == Arch::RiscV64 && binary_format == BinaryFormat::Coff {
+        // Return None to use the fallback mechanism in create_wrapper_file
+        // Use this fallback specifically for RISC-V 64 UEFI
+        return None;
+    }
 
     let mut file = write::Object::new(binary_format, architecture, endianness);
     file.set_sub_architecture(sub_architecture);

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -1708,6 +1708,7 @@ supported_targets! {
     ("x86_64-unknown-uefi", x86_64_unknown_uefi),
     ("i686-unknown-uefi", i686_unknown_uefi),
     ("aarch64-unknown-uefi", aarch64_unknown_uefi),
+    ("riscv64gc-unknown-uefi", riscv64gc_unknown_uefi),
 
     ("nvptx64-nvidia-cuda", nvptx64_nvidia_cuda),
 

--- a/compiler/rustc_target/src/spec/targets/riscv64gc_unknown_uefi.rs
+++ b/compiler/rustc_target/src/spec/targets/riscv64gc_unknown_uefi.rs
@@ -1,45 +1,30 @@
 use crate::spec::{
-	Arch, CodeModel, LinkerFlavor, Lld, PanicStrategy, RelocModel,
-	Target, TargetOptions, TargetMetadata, Os
+	Arch, Target, TargetMetadata, base
 };
 
 pub(crate) fn target() -> Target {
+    // Get the base UEFI configuration
+    let mut base = base::uefi_msvc::opts();
+    
+    // Override with RISC-V specific settings
+    base.cpu = "generic-rv64".into();
+    base.features = "+m,+a,+f,+d,+c".into();
+    base.max_atomic_width = Some(64);
+    base.atomic_cas = true;
+    base.disable_redzone = true;
+
     Target {
-        data_layout: "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128".into(),
+        llvm_target: "riscv64".into(),
         metadata: TargetMetadata {
             description: Some("Bare RISC-V (RV64IMAFDC ISA) UEFI".into()),
             tier: Some(3),
             host_tools: Some(false),
-            std: Some(false),
+            std: None,
         },
-        llvm_target: "riscv64gc-unknown-windows".into(),
         pointer_width: 64,
+        data_layout: "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128".into(),
         arch: Arch::RiscV64,
         
-        options: TargetOptions {
-            os: Os::Uefi,
-            vendor: "unknown".into(),
-            linker_flavor: LinkerFlavor::Msvc(Lld::No),
-            
-            // UEFI characteristics
-            executables: true,
-            is_like_windows: true,
-            panic_strategy: PanicStrategy::Abort,
-            relocation_model: RelocModel::Pic,
-            
-            // RISC-V features
-            cpu: "generic-rv64".into(),
-            features: "+m,+a,+f,+d,+c".into(),
-            
-            // These are the current correct field names:
-            is_like_aix: false,
-            is_like_android: false,
-            is_like_msvc: true,
-            
-            // Codegen options
-            code_model: Some(CodeModel::Medium),
-            disable_redzone: true,
-            ..Default::default()
-        },
+        options: base,
     }
 }

--- a/compiler/rustc_target/src/spec/targets/riscv64gc_unknown_uefi.rs
+++ b/compiler/rustc_target/src/spec/targets/riscv64gc_unknown_uefi.rs
@@ -15,7 +15,7 @@ pub(crate) fn target() -> Target {
     base.llvm_abiname = "lp64d".into();
 
     Target {
-        llvm_target: "riscv64".into(),
+        llvm_target: "riscv64-unknown-windows".into(),
         metadata: TargetMetadata {
             description: Some("Bare RISC-V (RV64IMAFDC ISA) UEFI".into()),
             tier: Some(3),

--- a/compiler/rustc_target/src/spec/targets/riscv64gc_unknown_uefi.rs
+++ b/compiler/rustc_target/src/spec/targets/riscv64gc_unknown_uefi.rs
@@ -1,0 +1,45 @@
+use crate::spec::{
+	Arch, CodeModel, LinkerFlavor, Lld, PanicStrategy, RelocModel,
+	Target, TargetOptions, TargetMetadata, Os
+};
+
+pub(crate) fn target() -> Target {
+    Target {
+        data_layout: "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128".into(),
+        metadata: TargetMetadata {
+            description: Some("Bare RISC-V (RV64IMAFDC ISA) UEFI".into()),
+            tier: Some(3),
+            host_tools: Some(false),
+            std: Some(false),
+        },
+        llvm_target: "riscv64gc-unknown-windows".into(),
+        pointer_width: 64,
+        arch: Arch::RiscV64,
+        
+        options: TargetOptions {
+            os: Os::Uefi,
+            vendor: "unknown".into(),
+            linker_flavor: LinkerFlavor::Msvc(Lld::No),
+            
+            // UEFI characteristics
+            executables: true,
+            is_like_windows: true,
+            panic_strategy: PanicStrategy::Abort,
+            relocation_model: RelocModel::Pic,
+            
+            // RISC-V features
+            cpu: "generic-rv64".into(),
+            features: "+m,+a,+f,+d,+c".into(),
+            
+            // These are the current correct field names:
+            is_like_aix: false,
+            is_like_android: false,
+            is_like_msvc: true,
+            
+            // Codegen options
+            code_model: Some(CodeModel::Medium),
+            disable_redzone: true,
+            ..Default::default()
+        },
+    }
+}

--- a/compiler/rustc_target/src/spec/targets/riscv64gc_unknown_uefi.rs
+++ b/compiler/rustc_target/src/spec/targets/riscv64gc_unknown_uefi.rs
@@ -12,6 +12,7 @@ pub(crate) fn target() -> Target {
     base.max_atomic_width = Some(64);
     base.atomic_cas = true;
     base.disable_redzone = true;
+    base.llvm_abiname = "lp64d".into();
 
     Target {
         llvm_target: "riscv64".into(),

--- a/src/bootstrap/src/core/sanity.rs
+++ b/src/bootstrap/src/core/sanity.rs
@@ -41,6 +41,7 @@ const STAGE0_MISSING_TARGETS: &[&str] = &[
     "sparc64-unknown-helenos",
     // just a dummy comment so the list doesn't get onelined
     "riscv64gc-unknown-redox",
+    "riscv64gc-unknown-uefi",
 ];
 
 /// Minimum version threshold for libstdc++ required when using prebuilt LLVM

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -397,6 +397,7 @@ target | std | host | notes
 [`riscv64gc-unknown-nuttx-elf`](platform-support/nuttx.md) | ✓ |  | RISC-V 64bit with NuttX
 [`riscv64gc-unknown-openbsd`](platform-support/openbsd.md) | ✓ | ✓ | OpenBSD/riscv64
 [`riscv64gc-unknown-redox`](platform-support/redox.md) | ✓ |  | RISC-V 64bit Redox OS
+[`riscv64gc-unknown-uefi`](platform-support/unknown-uefi.md) | ? | RISC-V 64bit UEFI
 [`riscv64imac-unknown-nuttx-elf`](platform-support/nuttx.md) | ✓ |  | RISC-V 64bit with NuttX
 [`riscv64a23-unknown-linux-gnu`](platform-support/riscv64a23-unknown-linux-gnu.md) | ✓ | ✓ | RISC-V Linux (kernel 6.8.0+, glibc 2.39)
 [`s390x-unknown-linux-musl`](platform-support/s390x-unknown-linux-musl.md) | ✓ |  | S390x Linux (kernel 3.2, musl 1.2.5)

--- a/src/doc/rustc/src/platform-support/unknown-uefi.md
+++ b/src/doc/rustc/src/platform-support/unknown-uefi.md
@@ -1,9 +1,9 @@
 # `*-unknown-uefi`
 
-**Tier: 2**
-
 Unified Extensible Firmware Interface (UEFI) targets for application, driver,
 and core UEFI binaries.
+
+**Tier: 2**
 
 Available targets:
 
@@ -11,11 +11,18 @@ Available targets:
 - `i686-unknown-uefi`
 - `x86_64-unknown-uefi`
 
+**Tier: 3**
+
+Available targets:
+
+- `riscv64gc-unknown-uefi`
+
 ## Target maintainers
 
 - [@dvdhrm](https://github.com/dvdhrm)
 - [@nicholasbishop](https://github.com/nicholasbishop)
 - (for `aarch64-unknown-uefi` only) [@rust-lang/arm-maintainers][arm_maintainers] ([rust@arm.com][arm_email])
+- (for `riscv64gc-unknown-uefi` only) [@gjbauer](https://github.com/gjbauer)
 
 [arm_maintainers]: https://github.com/rust-lang/team/blob/master/teams/arm-maintainers.toml
 [arm_email]: mailto:rust@arm.com


### PR DESCRIPTION
# Add `riscv64gc-unknown-uefi` target

This PR includes the bare minimum changes currently required to include a `riscv64gc-unknown-uefi` target into the Rust compiler source tree. A few minor changes totally a handful of lines were required outside of the target's `target.rs` to get the build process to complete successfully, but these should not impose any challenges to existing targets.

One edit was made to the `-unknown-uefi.md` supported targets Markdown file to mention the existence of a tier 3 target. Since this target will originate as a tier 3 target, it will not be included in `rustup` for installation. I am willing to make more changes to the Markdown document in order to document how to build, install, and use this new target. Thank you for your consideration of this pull request!!