### PR TITLE
ignore unsized types in mips64 and sparc64 callconvs

### DIFF
--- a/compiler/rustc_target/src/callconv/mips64.rs
+++ b/compiler/rustc_target/src/callconv/mips64.rs
@@ -148,12 +148,12 @@ where
     Ty: TyAbiInterface<'a, C> + Copy,
     C: HasDataLayout,
 {
-    if !fn_abi.ret.is_ignore() {
+    if !fn_abi.ret.is_ignore() && fn_abi.ret.layout.is_sized() {
         classify_ret(cx, &mut fn_abi.ret);
     }
 
     for arg in fn_abi.args.iter_mut() {
-        if arg.is_ignore() {
+        if arg.is_ignore() || !arg.layout.is_sized() {
             continue;
         }
         classify_arg(cx, arg);

--- a/compiler/rustc_target/src/callconv/sparc64.rs
+++ b/compiler/rustc_target/src/callconv/sparc64.rs
@@ -216,11 +216,14 @@ where
     Ty: TyAbiInterface<'a, C> + Copy,
     C: HasDataLayout + HasTargetSpec,
 {
-    if !fn_abi.ret.is_ignore() {
+    if !fn_abi.ret.is_ignore() && fn_abi.ret.layout.is_sized() {
         classify_arg(cx, &mut fn_abi.ret, Size::from_bytes(32));
     }
 
     for arg in fn_abi.args.iter_mut() {
+        if !arg.layout.is_sized() {
+            continue;
+        }
         if arg.is_ignore() {
             // sparc64-unknown-linux-{gnu,musl,uclibc} doesn't ignore ZSTs.
             if cx.target_spec().os == Os::Linux

--- a/tests/ui/abi/compatibility.rs
+++ b/tests/ui/abi/compatibility.rs
@@ -280,7 +280,8 @@ macro_rules! test_transparent_unsized {
     };
 }
 
-#[cfg(not(any(target_arch = "mips64", target_arch = "sparc64")))]
+// NOTE: non-rustic ABIs do not support unsized types: they are skipped during ABI generation, and
+// will trigger an error if they make it to rustc_monomorphize/src/mono_checks/abi_check.rs
 mod unsized_ {
     use super::*;
     test_transparent_unsized!(str_, str);


### PR DESCRIPTION
Non-rustic calling conventions should not make up an ABI for unsized types (cc https://github.com/rust-lang/rust/pull/148302). The vast majority of our callconv implementations already ignore unsized types, `sparc64` and `mips64` I guess were missed.

r? @bjorn3 