### PR TITLE
Reduce confusing `unreachable_code` lints

### DIFF
--- a/tests/ui/uninhabited/unreachable.rs
+++ b/tests/ui/uninhabited/unreachable.rs
@@ -1,0 +1,34 @@
+//! Test that a diverging function as the final expression in a block does not
+//! raise an 'unreachable code' lint.
+
+//@ check-pass
+#![deny(unreachable_code)]
+
+enum Never {}
+
+fn make_never() -> Never {
+    loop {}
+}
+
+fn func() {
+    make_never();
+}
+
+fn block() {
+    {
+        make_never();
+    }
+}
+
+fn branchy() {
+    if false {
+        make_never();
+    } else {
+        make_never();
+    }
+}
+
+fn main() {
+    func();
+    block();
+}

--- a/tests/ui/uninhabited/void-branch.rs
+++ b/tests/ui/uninhabited/void-branch.rs
@@ -6,8 +6,9 @@ enum Void {}
 fn with_void() {
     if false {
         unsafe {
-            //~^ ERROR unreachable expression
             std::mem::uninitialized::<Void>();
+            println!();
+            //~^ ERROR unreachable expression
         }
     }
 
@@ -20,8 +21,9 @@ fn infallible() -> std::convert::Infallible {
 
 fn with_infallible() {
     if false {
-        //~^ ERROR unreachable expression
         infallible();
+        println!()
+        //~^ ERROR unreachable expression
     }
 
     println!()

--- a/tests/ui/uninhabited/void-branch.stderr
+++ b/tests/ui/uninhabited/void-branch.stderr
@@ -1,15 +1,13 @@
 error: unreachable expression
-  --> $DIR/void-branch.rs:8:9
+  --> $DIR/void-branch.rs:10:13
    |
-LL | /         unsafe {
-LL | |
-LL | |             std::mem::uninitialized::<Void>();
-   | |             --------------------------------- any code following this expression is unreachable
-LL | |         }
-   | |_________^ unreachable expression
+LL |             std::mem::uninitialized::<Void>();
+   |             --------------------------------- any code following this expression is unreachable
+LL |             println!();
+   |             ^^^^^^^^^^ unreachable expression
    |
 note: this expression has type `Void`, which is uninhabited
-  --> $DIR/void-branch.rs:10:13
+  --> $DIR/void-branch.rs:9:13
    |
 LL |             std::mem::uninitialized::<Void>();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -18,23 +16,22 @@ note: the lint level is defined here
    |
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
+   = note: this error originates in the macro `$crate::format_args` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: unreachable expression
-  --> $DIR/void-branch.rs:22:14
+  --> $DIR/void-branch.rs:25:9
    |
-LL |       if false {
-   |  ______________^
-LL | |
-LL | |         infallible();
-   | |         ------------ any code following this expression is unreachable
-LL | |     }
-   | |_____^ unreachable expression
+LL |         infallible();
+   |         ------------ any code following this expression is unreachable
+LL |         println!()
+   |         ^^^^^^^^^^ unreachable expression
    |
 note: this expression has type `Infallible`, which is uninhabited
   --> $DIR/void-branch.rs:24:9
    |
 LL |         infallible();
    |         ^^^^^^^^^^^^
+   = note: this error originates in the macro `$crate::format_args` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
Closes rust-lang/rust#149042

Attempts to be smarter about identifying 'real'/user-written unreachable code to raise the lint