### PR TITLE
compiletest: Use JSON "binary-format" to decide `//@ only-elf` and `//@ ignore-elf`

### DIFF
--- a/src/tools/compiletest/src/common.rs
+++ b/src/tools/compiletest/src/common.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::iter;
 use std::process::Command;
@@ -1011,6 +1012,13 @@ pub struct TargetCfg {
     // target spec).
     pub(crate) rustc_abi: Option<String>,
 
+    /// ELF is the "default" binary format, so the compiler typically doesn't
+    /// emit a `"binary-format"` field for ELF targets.
+    ///
+    /// See `impl ToJson for Target` in `compiler/rustc_target/src/spec/json.rs`.
+    #[serde(default = "default_binary_format_elf")]
+    pub(crate) binary_format: Cow<'static, str>,
+
     // Not present in target cfg json output, additional derived information.
     #[serde(skip)]
     /// Supported target atomic widths: e.g. `8` to `128` or `ptr`. This is derived from the builtin
@@ -1030,6 +1038,10 @@ fn default_os() -> String {
 
 fn default_reloc_model() -> String {
     "pic".into()
+}
+
+fn default_binary_format_elf() -> Cow<'static, str> {
+    Cow::Borrowed("elf")
 }
 
 #[derive(Eq, PartialEq, Clone, Debug, Default, serde::Deserialize)]

--- a/src/tools/compiletest/src/directives/cfg.rs
+++ b/src/tools/compiletest/src/directives/cfg.rs
@@ -169,11 +169,7 @@ fn parse_cfg_name_directive<'a>(
 
     condition! {
         name: "elf",
-        condition: !config.target.contains("windows")
-            && !config.target.contains("wasm")
-            && !config.target.contains("apple")
-            && !config.target.contains("aix")
-            && !config.target.contains("uefi"),
+        condition: target_cfg.binary_format == "elf",
         message: "when the target binary format is ELF"
     }
 

--- a/src/tools/compiletest/src/directives/tests.rs
+++ b/src/tools/compiletest/src/directives/tests.rs
@@ -767,6 +767,29 @@ fn ignore_coverage() {
 }
 
 #[test]
+fn only_ignore_elf() {
+    let cases = &[
+        ("aarch64-apple-darwin", false),
+        ("aarch64-unknown-linux-gnu", true),
+        ("powerpc64-ibm-aix", false),
+        ("wasm32-unknown-unknown", false),
+        ("wasm32-wasip1", false),
+        ("x86_64-apple-darwin", false),
+        ("x86_64-pc-windows-msvc", false),
+        ("x86_64-unknown-freebsd", true),
+        ("x86_64-unknown-illumos", true),
+        ("x86_64-unknown-linux-gnu", true),
+        ("x86_64-unknown-none", true),
+        ("x86_64-unknown-uefi", false),
+    ];
+    for &(target, is_elf) in cases {
+        let config = &cfg().target(target).build();
+        assert_eq!(is_elf, check_ignore(config, "//@ ignore-elf"), "`//@ ignore-elf` for {target}");
+        assert_eq!(is_elf, !check_ignore(config, "//@ only-elf"), "`//@ only-elf` for {target}");
+    }
+}
+
+#[test]
 fn threads_support() {
     let threads = [
         ("x86_64-unknown-linux-gnu", true),


### PR DESCRIPTION
Some tests only apply to ELF targets, or want to enable different test revisions for ELF and non-ELF targets. So compiletest supports the `//@ only-elf` and `//@ ignore-elf` directives to make that possible.

Historically, deciding whether the current target is an ELF target relied on a handful of ad-hoc string comparisons against the target tuple.

However, nowadays compiletest has access to the output of `--print=all-target-specs-json`, and that JSON output specifies the binary format of each target, making it much easier to determine whether a target is ELF or not.