### PR TITLE
Fix/Make proc_macro span_close() and span_open() more accurate after set_span() calls

### DIFF
--- a/library/proc_macro/src/lib.rs
+++ b/library/proc_macro/src/lib.rs
@@ -46,7 +46,7 @@ mod to_tokens;
 
 use core::ops::BitOr;
 use std::ffi::CStr;
-use std::ops::{Range, RangeBounds};
+use std::ops::{Bound, Range, RangeBounds};
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::{error, fmt};
@@ -880,7 +880,47 @@ impl Group {
     /// tokens at the level of the `Group`.
     #[stable(feature = "proc_macro_lib2", since = "1.29.0")]
     pub fn set_span(&mut self, span: Span) {
-        self.0.span = bridge::DelimSpan::from_single(span.0);
+        let (open_chr, close_chr) = match self.0.delimiter {
+            Delimiter::Brace => (b'{', b'}'),
+            Delimiter::Bracket => (b'[', b']'),
+            Delimiter::Parenthesis => (b'(', b')'),
+            Delimiter::None => {
+                // None delimiters are the whole span for open and close
+                // same behavior as in the compiler.
+                self.0.span = bridge::DelimSpan::from_single(span.0);
+                return;
+            }
+        };
+
+        // No source text to check or source text is too small.
+        // just go back to default behavior.
+        let source = match span.0.source_text() {
+            Some(s) if s.len() >= 2 => s,
+            _ => {
+                self.0.span = bridge::DelimSpan::from_single(span.0);
+                return;
+            }
+        };
+        let src = source.as_bytes();
+
+        // Make sure that the last and first characters match up
+        if src[0] != open_chr || src[src.len() - 1] != close_chr {
+            self.0.span = bridge::DelimSpan::from_single(span.0);
+            return;
+        }
+
+        // Compute the spans.
+        let Some(open) = span.0.subspan(Bound::Included(0), Bound::Excluded(1)) else {
+            self.0.span = bridge::DelimSpan::from_single(span.0);
+            return;
+        };
+
+        let Some(close) = span.0.subspan(Bound::Included(src.len() - 1), Bound::Unbounded) else {
+            self.0.span = bridge::DelimSpan::from_single(span.0);
+            return;
+        };
+
+        self.0.span = bridge::DelimSpan { open, close, entire: span.0 };
     }
 }
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/149052)*
<!-- homu-ignore:end -->

When `Group::set_span()` is called the span's for `Group::span_open()` and `Group::span_close() ` methods just become the whole span instead where it should be the span of the delimiters. This PR ensures they have at least a more usable value after a call to `Group::set_span()`.

Here is a kinda of motivating example of this issue I observed. If you compare the current behavior the outputs the diagnostics will not be on the opening and closing delimiters after calling set span. If you look at the outputs after using this PR they will match. Further, afterward `Span::eq()` then evaluates to true which nice to see.

```rust
#![feature(proc_macro_diagnostic)]
#![feature(proc_macro_span)]
extern crate proc_macro;

use proc_macro::TokenStream;
use proc_macro::TokenTree;

#[proc_macro_attribute]
pub fn foo(args: TokenStream, _: TokenStream) -> TokenStream {
    let mut i = args.into_iter();
    let mut grp = match i.next().expect("iterator empty") {
    TokenTree::Group(g) => g,
        _ => panic!("Expected Group")
    };

    let o_open = grp.span_open();
    let o_close = grp.span_close();
    o_open.note("Old Open Span").emit();
    o_close.note("Old Close Span").emit();

    // Set the span with the same span
    grp.set_span(grp.span());

    // Notice where the span these diagnostics are compared to the first.
    let n_open = grp.span_open();
    let n_close = grp.span_close();
    n_open.note("New Open Span").emit();
    n_close.note("New Close Span").emit();


    grp.span().note(&format!(
        "old_open == new_open: {}\nold_close == new_close: {}",
        o_open.eq(&n_open),
        o_close.eq(&n_close)
    )).emit();

    return TokenStream::new();
}
```

This is all I did to invoke the proc_macro example above.
```rust
#[macro_test::foo({ bar })]
struct Foo;
```