### PR TITLE
Avoid encoding non-constness or non-asyncness in metadata

### DIFF
--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -4224,8 +4224,10 @@ impl fmt::Display for Safety {
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Encodable, Decodable, HashStable_Generic)]
+#[derive(Default)]
 pub enum Constness {
     Const,
+    #[default]
     NotConst,
 }
 

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -1519,10 +1519,18 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
                 record!(self.tables.type_of[def_id] <- self.tcx.type_of(def_id));
             }
             if should_encode_constness(def_kind) {
-                self.tables.constness.set_some(def_id.index, self.tcx.constness(def_id));
+                let constness = self.tcx.constness(def_id);
+                match constness {
+                    hir::Constness::Const => self.tables.constness.set(def_id.index, constness),
+                    hir::Constness::NotConst => {}
+                }
             }
             if let DefKind::Fn | DefKind::AssocFn = def_kind {
-                self.tables.asyncness.set_some(def_id.index, tcx.asyncness(def_id));
+                let asyncness = tcx.asyncness(def_id);
+                match asyncness {
+                    ty::Asyncness::Yes => self.tables.asyncness.set(def_id.index, asyncness),
+                    ty::Asyncness::No => {}
+                }
                 record_array!(self.tables.fn_arg_idents[def_id] <- tcx.fn_arg_idents(def_id));
             }
             if let Some(name) = tcx.intrinsic(def_id) {

--- a/compiler/rustc_metadata/src/rmeta/mod.rs
+++ b/compiler/rustc_metadata/src/rmeta/mod.rs
@@ -400,6 +400,8 @@ define_tables! {
     // individually instead of `DefId`s.
     module_children_reexports: Table<DefIndex, LazyArray<ModChild>>,
     cross_crate_inlinable: Table<DefIndex, bool>,
+    asyncness: Table<DefIndex, ty::Asyncness>,
+    constness: Table<DefIndex, hir::Constness>,
 
 - optional:
     attributes: Table<DefIndex, LazyArray<hir::Attribute>>,
@@ -433,7 +435,6 @@ define_tables! {
     promoted_mir: Table<DefIndex, LazyValue<IndexVec<mir::Promoted, mir::Body<'static>>>>,
     thir_abstract_const: Table<DefIndex, LazyValue<ty::EarlyBinder<'static, ty::Const<'static>>>>,
     impl_parent: Table<DefIndex, RawDefId>,
-    constness: Table<DefIndex, hir::Constness>,
     const_conditions: Table<DefIndex, LazyValue<ty::ConstConditions<'static>>>,
     defaultness: Table<DefIndex, hir::Defaultness>,
     // FIXME(eddyb) perhaps compute this on the fly if cheap enough?
@@ -441,7 +442,6 @@ define_tables! {
     mir_const_qualif: Table<DefIndex, LazyValue<mir::ConstQualifs>>,
     rendered_const: Table<DefIndex, LazyValue<String>>,
     rendered_precise_capturing_args: Table<DefIndex, LazyArray<PreciseCapturingArgKind<Symbol, Symbol>>>,
-    asyncness: Table<DefIndex, ty::Asyncness>,
     fn_arg_idents: Table<DefIndex, LazyArray<Option<Ident>>>,
     coroutine_kind: Table<DefIndex, hir::CoroutineKind>,
     coroutine_for_closure: Table<DefIndex, RawDefId>,

--- a/compiler/rustc_metadata/src/rmeta/table.rs
+++ b/compiler/rustc_metadata/src/rmeta/table.rs
@@ -25,6 +25,24 @@ impl IsDefault for bool {
     }
 }
 
+impl IsDefault for ty::Asyncness {
+    fn is_default(&self) -> bool {
+        match self {
+            ty::Asyncness::Yes => false,
+            ty::Asyncness::No => true,
+        }
+    }
+}
+
+impl IsDefault for hir::Constness {
+    fn is_default(&self) -> bool {
+        match self {
+            rustc_hir::Constness::Const => false,
+            rustc_hir::Constness::NotConst => true,
+        }
+    }
+}
+
 impl IsDefault for u32 {
     fn is_default(&self) -> bool {
         *self == 0
@@ -290,6 +308,50 @@ impl FixedSizeEncoding for bool {
     fn write_to_bytes(self, b: &mut [u8; 1]) {
         debug_assert!(!self.is_default());
         b[0] = self as u8
+    }
+}
+
+impl FixedSizeEncoding for ty::Asyncness {
+    type ByteArray = [u8; 1];
+
+    #[inline]
+    fn from_bytes(b: &[u8; 1]) -> Self {
+        match b[0] {
+            0 => ty::Asyncness::No,
+            1 => ty::Asyncness::Yes,
+            _ => unreachable!(),
+        }
+    }
+
+    #[inline]
+    fn write_to_bytes(self, b: &mut [u8; 1]) {
+        debug_assert!(!self.is_default());
+        b[0] = match self {
+            ty::Asyncness::No => 0,
+            ty::Asyncness::Yes => 1,
+        }
+    }
+}
+
+impl FixedSizeEncoding for hir::Constness {
+    type ByteArray = [u8; 1];
+
+    #[inline]
+    fn from_bytes(b: &[u8; 1]) -> Self {
+        match b[0] {
+            0 => hir::Constness::NotConst,
+            1 => hir::Constness::Const,
+            _ => unreachable!(),
+        }
+    }
+
+    #[inline]
+    fn write_to_bytes(self, b: &mut [u8; 1]) {
+        debug_assert!(!self.is_default());
+        b[0] = match self {
+            hir::Constness::NotConst => 0,
+            hir::Constness::Const => 1,
+        }
     }
 }
 

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -250,9 +250,10 @@ pub struct ImplTraitHeader<'tcx> {
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash, TyEncodable, TyDecodable, HashStable, Debug)]
-#[derive(TypeFoldable, TypeVisitable)]
+#[derive(TypeFoldable, TypeVisitable, Default)]
 pub enum Asyncness {
     Yes,
+    #[default]
     No,
 }
 


### PR DESCRIPTION
r? @fee1-dead 

Let's see if we can get any benefit (even just metadata size) from not encoding the common case.

Inspired by https://github.com/rust-lang/rust/pull/148434#discussion_r2491732811