### PR TITLE
fix the fragment_in_dst_padding_gets_overwritten test on s390x

### DIFF
--- a/tests/ui/consts/const-eval/ptr_fragments.rs
+++ b/tests/ui/consts/const-eval/ptr_fragments.rs
@@ -68,6 +68,7 @@ const _PARTIAL_OVERWRITE: () = {
 };
 
 #[allow(dead_code)]
+#[cfg(not(target_arch = "s390x"))] // u128 is less aligned on s390x, removing the padding
 fn fragment_in_dst_padding_gets_overwritten() {
     #[repr(C)]
     struct Pair {


### PR DESCRIPTION
on s390x 128bit types have a smaller alignment then on x86[^1]. This leads to smaller structs (24 instead of 32 bytes) and therefore the write_unaligned will write outside of the structs boundary.

To fix the test, change the trailing u32 into a u8. This will generate 7 trailing padding bytes on s390x and 15 on x86_64. Also change the start of the garbage data so it will span over x,y and padding:

```
s390x:   XXXXXXXXXXXXXXXXY-------
x86_64:  XXXXXXXXXXXXXXXXY---------------
                      GGGGGGGG

```

[^1]: s390x ELF ABI Table 1.1, Page 12 https://github.com/IBM/s390x-abi

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
