### PR TITLE
Address annotate-snippets test differences

### DIFF
--- a/compiler/rustc_errors/src/annotate_snippet_emitter_writer.rs
+++ b/compiler/rustc_errors/src/annotate_snippet_emitter_writer.rs
@@ -633,7 +633,7 @@ impl AnnotateSnippetEmitter {
                     report.push(std::mem::replace(&mut group, Group::with_level(level.clone())));
                 }
 
-                if !line_tracker.contains(&lo.line) {
+                if !line_tracker.contains(&lo.line) && (i == 0 || hi.line <= lo.line) {
                     line_tracker.push(lo.line);
                     // ╭▸ $SRC_DIR/core/src/option.rs:594:0 (<- It adds *this*)
                     // ⸬  $SRC_DIR/core/src/option.rs:602:4

--- a/compiler/rustc_errors/src/annotate_snippet_emitter_writer.rs
+++ b/compiler/rustc_errors/src/annotate_snippet_emitter_writer.rs
@@ -742,6 +742,14 @@ fn collect_annotations(
             }
         }
     }
+
+    // Sort annotations within each file by line number
+    for (_, ann) in output.iter_mut() {
+        ann.sort_by_key(|a| {
+            let lo = sm.lookup_char_pos(a.span.lo());
+            lo.line
+        });
+    }
     output
 }
 

--- a/compiler/rustc_errors/src/annotate_snippet_emitter_writer.rs
+++ b/compiler/rustc_errors/src/annotate_snippet_emitter_writer.rs
@@ -213,6 +213,7 @@ impl AnnotateSnippetEmitter {
                 file_ann.swap(0, pos);
             }
 
+            let file_ann_len = file_ann.len();
             for (file_idx, (file, annotations)) in file_ann.into_iter().enumerate() {
                 if should_show_source_code(&self.ignored_directories_in_source_blocks, sm, &file) {
                     if let Some(snippet) = self.annotated_snippet(annotations, &file.name, sm) {
@@ -240,6 +241,7 @@ impl AnnotateSnippetEmitter {
                     // ╰ warning: this was previously accepted
                     if let Some(c) = children.first()
                         && (!c.span.has_primary_spans() && !c.span.has_span_labels())
+                        && file_idx == file_ann_len - 1
                     {
                         group = group.element(Padding);
                     }

--- a/tests/rustdoc-ui/doctest/main-alongside-macro-calls.fail.stdout
+++ b/tests/rustdoc-ui/doctest/main-alongside-macro-calls.fail.stdout
@@ -19,7 +19,6 @@ LL | println!();
 error: macro expansion ignores `{` and any tokens following
   --> $SRC_DIR/std/src/macros.rs:LL:COL
    |
-   |
   ::: $DIR/main-alongside-macro-calls.rs:30:1
    |
 LL | println!();
@@ -41,7 +40,6 @@ LL | println!();
 
 error: macro expansion ignores `{` and any tokens following
   --> $SRC_DIR/std/src/macros.rs:LL:COL
-   |
    |
   ::: $DIR/main-alongside-macro-calls.rs:34:1
    |

--- a/tests/ui/statics/check-values-constraints.stderr
+++ b/tests/ui/statics/check-values-constraints.stderr
@@ -38,10 +38,10 @@ LL |     field2: SafeEnum::Variant4("str".to_string()),
 note: method `to_string` is not const because trait `ToString` is not const
   --> $SRC_DIR/alloc/src/string.rs:LL:COL
    |
-   = note: this method is not const
+   = note: this trait is not const
   ::: $SRC_DIR/alloc/src/string.rs:LL:COL
    |
-   = note: this trait is not const
+   = note: this method is not const
    = note: calls in statics are limited to constant functions, tuple structs and tuple variants
    = note: consider wrapping this expression in `std::sync::LazyLock::new(|| ...)`
 

--- a/tests/ui/typeck/typeck_type_placeholder_item.stderr
+++ b/tests/ui/typeck/typeck_type_placeholder_item.stderr
@@ -686,12 +686,12 @@ LL | const _: _ = (1..10).filter(|x| x % 2 == 0).map(|x| x * x);
    |
 note: method `filter` is not const because trait `Iterator` is not const
   --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
+   |
+   = note: this trait is not const
+  ::: $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
   ::: $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
    |
    = note: this method is not const
-  ::: $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
-   |
-   = note: this trait is not const
    = note: calls in constants are limited to constant functions, tuple structs and tuple variants
 
 error[E0015]: cannot call non-const method `<Filter<std::ops::Range<i32>, {closure@$DIR/typeck_type_placeholder_item.rs:240:29: 240:32}> as Iterator>::map::<i32, {closure@$DIR/typeck_type_placeholder_item.rs:240:49: 240:52}>` in constants
@@ -702,12 +702,12 @@ LL | const _: _ = (1..10).filter(|x| x % 2 == 0).map(|x| x * x);
    |
 note: method `map` is not const because trait `Iterator` is not const
   --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
+   |
+   = note: this trait is not const
+  ::: $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
   ::: $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
    |
    = note: this method is not const
-  ::: $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
-   |
-   = note: this trait is not const
    = note: calls in constants are limited to constant functions, tuple structs and tuple variants
 
 error: aborting due to 83 previous errors

--- a/tests/ui/typeck/typeck_type_placeholder_item.stderr
+++ b/tests/ui/typeck/typeck_type_placeholder_item.stderr
@@ -689,7 +689,6 @@ note: method `filter` is not const because trait `Iterator` is not const
    |
    = note: this trait is not const
   ::: $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
-  ::: $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
    |
    = note: this method is not const
    = note: calls in constants are limited to constant functions, tuple structs and tuple variants
@@ -704,7 +703,6 @@ note: method `map` is not const because trait `Iterator` is not const
   --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
    |
    = note: this trait is not const
-  ::: $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
   ::: $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
    |
    = note: this method is not const


### PR DESCRIPTION
When `annotate-snippets` became the default renderer on `nightly`, it came with a few rendering differences. I was not entirely happy with a few of the differences, and after talking with @davidtwco about them, I decided to address those that seemed like regressions.

r? @davidtwco