### PR TITLE
DispatchFromDyn: require additional checks

### DIFF
--- a/compiler/rustc_hir_analysis/messages.ftl
+++ b/compiler/rustc_hir_analysis/messages.ftl
@@ -149,6 +149,9 @@ hir_analysis_cross_crate_traits = cross-crate traits with a default impl, like `
 hir_analysis_cross_crate_traits_defined = cross-crate traits with a default impl, like `{$traits}`, can only be implemented for a struct/enum type defined in the current crate
     .label = can't implement cross-crate trait for type in another crate
 
+hir_analysis_dispatch_from_dyn_multiple_refs = the trait `DispatchFromDyn` does not allow dispatch through references
+    .note = the trait `DispatchFromDyn` may only be implemented when dispatch goes through at most one reference to a generic
+
 hir_analysis_dispatch_from_dyn_repr = structs implementing `DispatchFromDyn` may not have `#[repr(packed)]` or `#[repr(C)]`
 
 hir_analysis_dispatch_from_dyn_zst = the trait `DispatchFromDyn` may only be implemented for structs containing the field being coerced, ZST fields with 1 byte alignment that don't mention type/const generics, and nothing else

--- a/compiler/rustc_hir_analysis/src/errors.rs
+++ b/compiler/rustc_hir_analysis/src/errors.rs
@@ -1248,6 +1248,14 @@ pub(crate) struct CoerceSamePatKind {
 }
 
 #[derive(Diagnostic)]
+#[diag(hir_analysis_dispatch_from_dyn_multiple_refs)]
+#[note]
+pub(crate) struct DispatchFromDynMultiRefs {
+    #[primary_span]
+    pub span: Span,
+}
+
+#[derive(Diagnostic)]
 #[diag(hir_analysis_coerce_unsized_may, code = E0377)]
 pub(crate) struct CoerceSameStruct {
     #[primary_span]

--- a/library/core/src/pat.rs
+++ b/library/core/src/pat.rs
@@ -82,7 +82,7 @@ impl<T: PointeeSized, U: PointeeSized> CoerceUnsized<pattern_type!(*const U is !
 {
 }
 
-impl<T: DispatchFromDyn<U>, U> DispatchFromDyn<pattern_type!(U is !null)> for pattern_type!(T is !null) {}
+impl<T: DispatchFromDyn<U> + Unsize<U>, U> DispatchFromDyn<pattern_type!(U is !null)> for pattern_type!(T is !null) {}
 
 impl<T: PointeeSized> Unpin for pattern_type!(*const T is !null) {}
 

--- a/tests/ui/traits/dispatch-from-dyn-blanket-impl.rs
+++ b/tests/ui/traits/dispatch-from-dyn-blanket-impl.rs
@@ -1,10 +1,11 @@
 // Test that blanket impl of DispatchFromDyn is rejected.
 // regression test for issue <https://github.com/rust-lang/rust/issues/148062>
 
-#![feature(dispatch_from_dyn)]
+#![feature(dispatch_from_dyn, unsize)]
 
-impl<T> std::ops::DispatchFromDyn<T> for T {}
+use std::marker::Unsize;
+
+impl<T: Unsize<T>> std::ops::DispatchFromDyn<T> for T {}
 //~^ ERROR type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
-//~| ERROR the trait `DispatchFromDyn` may only be implemented for a coercion between structures
 
 fn main() {}

--- a/tests/ui/traits/dispatch-from-dyn-blanket-impl.stderr
+++ b/tests/ui/traits/dispatch-from-dyn-blanket-impl.stderr
@@ -1,19 +1,12 @@
 error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
-  --> $DIR/dispatch-from-dyn-blanket-impl.rs:6:6
+  --> $DIR/dispatch-from-dyn-blanket-impl.rs:8:6
    |
-LL | impl<T> std::ops::DispatchFromDyn<T> for T {}
+LL | impl<T: Unsize<T>> std::ops::DispatchFromDyn<T> for T {}
    |      ^ type parameter `T` must be used as the type parameter for some local type
    |
    = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter
 
-error[E0377]: the trait `DispatchFromDyn` may only be implemented for a coercion between structures
-  --> $DIR/dispatch-from-dyn-blanket-impl.rs:6:1
-   |
-LL | impl<T> std::ops::DispatchFromDyn<T> for T {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+error: aborting due to 1 previous error
 
-error: aborting due to 2 previous errors
-
-Some errors have detailed explanations: E0210, E0377.
-For more information about an error, try `rustc --explain E0210`.
+For more information about this error, try `rustc --explain E0210`.

--- a/tests/ui/traits/dispatch-from-dyn-invalid-impls.rs
+++ b/tests/ui/traits/dispatch-from-dyn-invalid-impls.rs
@@ -68,4 +68,9 @@ where
 {
 }
 
+pub struct Ptr<T: ?Sized>(PhantomData<T>, Box<T>);
+
+impl<'a, T: ?Sized, U: ?Sized> DispatchFromDyn<&'a Ptr<U>> for &'a Ptr<T> {}
+//~^ ERROR the trait `DispatchFromDyn` does not allow dispatch through references
+
 fn main() {}

--- a/tests/ui/traits/dispatch-from-dyn-invalid-impls.stderr
+++ b/tests/ui/traits/dispatch-from-dyn-invalid-impls.stderr
@@ -54,7 +54,15 @@ LL | |     T: Unsize<U>
    |
    = note: extra field `1` of type `OverAlignedZst` is not allowed
 
-error: aborting due to 5 previous errors
+error: the trait `DispatchFromDyn` does not allow dispatch through references
+  --> $DIR/dispatch-from-dyn-invalid-impls.rs:73:1
+   |
+LL | impl<'a, T: ?Sized, U: ?Sized> DispatchFromDyn<&'a Ptr<U>> for &'a Ptr<T> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: the trait `DispatchFromDyn` may only be implemented when dispatch goes through at most one reference to a generic
+
+error: aborting due to 6 previous errors
 
 Some errors have detailed explanations: E0374, E0375, E0378.
 For more information about an error, try `rustc --explain E0374`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/149068)*
<!-- homu-ignore:end -->

The new checks are we check the pair of constituent types for same shapes structurally, and demand capability for dispatch for ADTs as usual; and we demand source generic parameter to be unsized of another for sanity.

Fix rust-lang/rust#148727

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

cc @theemathas 
