### PR TITLE
feat: Enable annotate-snippets' simd feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,6 +85,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a44baf24dd94e781f74dfe67ffee75a09a57971ddf0f615a178b4f6d404b48ff"
 dependencies = [
  "anstyle",
+ "memchr",
  "unicode-width 0.2.2",
 ]
 

--- a/compiler/rustc_errors/Cargo.toml
+++ b/compiler/rustc_errors/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 
 [dependencies]
 # tidy-alphabetical-start
-annotate-snippets = "0.12.9"
+annotate-snippets = { version = "0.12.9", features = ["simd"] }
 anstream = "0.6.20"
 anstyle = "1.0.13"
 derive_setters = "0.1.6"


### PR DESCRIPTION
`annotate-snippets` `simd` feature enables the use of `memchr` when searching for `char`/`str`. This should hopefully improve performance when [`annotate-snippets` is passed large `source`](https://github.com/rust-lang/rust/pull/148188#issuecomment-3550280300).



