### PR TITLE
Add `Box::clone_from_ref` and similar under `feature(clone_from_ref)`

### DIFF
--- a/library/alloc/src/ffi/c_str.rs
+++ b/library/alloc/src/ffi/c_str.rs
@@ -766,8 +766,7 @@ impl From<&CStr> for Box<CStr> {
     /// Converts a `&CStr` into a `Box<CStr>`,
     /// by copying the contents into a newly allocated [`Box`].
     fn from(s: &CStr) -> Box<CStr> {
-        let boxed: Box<[u8]> = Box::from(s.to_bytes_with_nul());
-        unsafe { Box::from_raw(Box::into_raw(boxed) as *mut CStr) }
+        Box::clone_from_ref(s)
     }
 }
 

--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -243,9 +243,9 @@
 
 use core::any::Any;
 use core::cell::{Cell, CloneFromCell};
-use core::clone::UseCloned;
 #[cfg(not(no_global_oom_handling))]
-use core::clone::{CloneToUninit, TrivialClone};
+use core::clone::TrivialClone;
+use core::clone::{CloneToUninit, UseCloned};
 use core::cmp::Ordering;
 use core::hash::{Hash, Hasher};
 use core::intrinsics::abort;
@@ -1287,6 +1287,104 @@ impl<T, A: Allocator> Rc<mem::MaybeUninit<T>, A> {
     pub unsafe fn assume_init(self) -> Rc<T, A> {
         let (ptr, alloc) = Rc::into_inner_with_allocator(self);
         unsafe { Rc::from_inner_in(ptr.cast(), alloc) }
+    }
+}
+
+impl<T: ?Sized + CloneToUninit> Rc<T> {
+    /// Constructs a new `Rc<T>` with a clone of `value`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(clone_from_ref)]
+    /// use std::rc::Rc;
+    ///
+    /// let hello: Rc<str> = Rc::clone_from_ref("hello");
+    /// ```
+    #[cfg(not(no_global_oom_handling))]
+    #[unstable(feature = "clone_from_ref", issue = "149075")]
+    pub fn clone_from_ref(value: &T) -> Rc<T> {
+        Rc::clone_from_ref_in(value, Global)
+    }
+
+    /// Constructs a new `Rc<T>` with a clone of `value`, returning an error if allocation fails
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(clone_from_ref)]
+    /// #![feature(allocator_api)]
+    /// use std::rc::Rc;
+    ///
+    /// let hello: Rc<str> = Rc::try_clone_from_ref("hello")?;
+    /// # Ok::<(), std::alloc::AllocError>(())
+    /// ```
+    #[unstable(feature = "clone_from_ref", issue = "149075")]
+    //#[unstable(feature = "allocator_api", issue = "32838")]
+    pub fn try_clone_from_ref(value: &T) -> Result<Rc<T>, AllocError> {
+        Rc::try_clone_from_ref_in(value, Global)
+    }
+}
+
+impl<T: ?Sized + CloneToUninit, A: Allocator> Rc<T, A> {
+    /// Constructs a new `Rc<T>` with a clone of `value` in the provided allocator.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(clone_from_ref)]
+    /// #![feature(allocator_api)]
+    /// use std::rc::Rc;
+    /// use std::alloc::System;
+    ///
+    /// let hello: Rc<str, System> = Rc::clone_from_ref_in("hello", System);
+    /// ```
+    #[cfg(not(no_global_oom_handling))]
+    #[unstable(feature = "clone_from_ref", issue = "149075")]
+    //#[unstable(feature = "allocator_api", issue = "32838")]
+    pub fn clone_from_ref_in(value: &T, alloc: A) -> Rc<T, A> {
+        // `in_progress` drops the allocation if we panic before finishing initializing it.
+        let mut in_progress: UniqueRcUninit<T, A> = UniqueRcUninit::new(value, alloc);
+
+        // Initialize with clone of value.
+        let initialized_clone = unsafe {
+            // Clone. If the clone panics, `in_progress` will be dropped and clean up.
+            value.clone_to_uninit(in_progress.data_ptr().cast());
+            // Cast type of pointer, now that it is initialized.
+            in_progress.into_rc()
+        };
+
+        initialized_clone
+    }
+
+    /// Constructs a new `Rc<T>` with a clone of `value` in the provided allocator, returning an error if allocation fails
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(clone_from_ref)]
+    /// #![feature(allocator_api)]
+    /// use std::rc::Rc;
+    /// use std::alloc::System;
+    ///
+    /// let hello: Rc<str, System> = Rc::try_clone_from_ref_in("hello", System)?;
+    /// # Ok::<(), std::alloc::AllocError>(())
+    /// ```
+    #[unstable(feature = "clone_from_ref", issue = "149075")]
+    //#[unstable(feature = "allocator_api", issue = "32838")]
+    pub fn try_clone_from_ref_in(value: &T, alloc: A) -> Result<Rc<T, A>, AllocError> {
+        // `in_progress` drops the allocation if we panic before finishing initializing it.
+        let mut in_progress: UniqueRcUninit<T, A> = UniqueRcUninit::try_new(value, alloc)?;
+
+        // Initialize with clone of value.
+        let initialized_clone = unsafe {
+            // Clone. If the clone panics, `in_progress` will be dropped and clean up.
+            value.clone_to_uninit(in_progress.data_ptr().cast());
+            // Cast type of pointer, now that it is initialized.
+            in_progress.into_rc()
+        };
+
+        Ok(initialized_clone)
     }
 }
 
@@ -4358,16 +4456,15 @@ unsafe impl<#[may_dangle] T: ?Sized, A: Allocator> Drop for UniqueRc<T, A> {
 /// This is a helper for [`Rc::make_mut()`] to ensure correct cleanup on panic.
 /// It is nearly a duplicate of `UniqueRc<MaybeUninit<T>, A>` except that it allows `T: !Sized`,
 /// which `MaybeUninit` does not.
-#[cfg(not(no_global_oom_handling))]
 struct UniqueRcUninit<T: ?Sized, A: Allocator> {
     ptr: NonNull<RcInner<T>>,
     layout_for_value: Layout,
     alloc: Option<A>,
 }
 
-#[cfg(not(no_global_oom_handling))]
 impl<T: ?Sized, A: Allocator> UniqueRcUninit<T, A> {
     /// Allocates a RcInner with layout suitable to contain `for_value` or a clone of it.
+    #[cfg(not(no_global_oom_handling))]
     fn new(for_value: &T, alloc: A) -> UniqueRcUninit<T, A> {
         let layout = Layout::for_value(for_value);
         let ptr = unsafe {
@@ -4378,6 +4475,20 @@ impl<T: ?Sized, A: Allocator> UniqueRcUninit<T, A> {
             )
         };
         Self { ptr: NonNull::new(ptr).unwrap(), layout_for_value: layout, alloc: Some(alloc) }
+    }
+
+    /// Allocates a RcInner with layout suitable to contain `for_value` or a clone of it,
+    /// returning an error if allocation fails.
+    fn try_new(for_value: &T, alloc: A) -> Result<UniqueRcUninit<T, A>, AllocError> {
+        let layout = Layout::for_value(for_value);
+        let ptr = unsafe {
+            Rc::try_allocate_for_layout(
+                layout,
+                |layout_for_rc_inner| alloc.allocate(layout_for_rc_inner),
+                |mem| mem.with_metadata_of(ptr::from_ref(for_value) as *const RcInner<T>),
+            )?
+        };
+        Ok(Self { ptr: NonNull::new(ptr).unwrap(), layout_for_value: layout, alloc: Some(alloc) })
     }
 
     /// Returns the pointer to be written into to initialize the [`Rc`].
@@ -4402,7 +4513,6 @@ impl<T: ?Sized, A: Allocator> UniqueRcUninit<T, A> {
     }
 }
 
-#[cfg(not(no_global_oom_handling))]
 impl<T: ?Sized, A: Allocator> Drop for UniqueRcUninit<T, A> {
     fn drop(&mut self) {
         // SAFETY:

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -11,10 +11,8 @@
 use core::any::Any;
 use core::cell::CloneFromCell;
 #[cfg(not(no_global_oom_handling))]
-use core::clone::CloneToUninit;
-#[cfg(not(no_global_oom_handling))]
 use core::clone::TrivialClone;
-use core::clone::UseCloned;
+use core::clone::{CloneToUninit, UseCloned};
 use core::cmp::Ordering;
 use core::hash::{Hash, Hasher};
 use core::intrinsics::abort;
@@ -1439,6 +1437,104 @@ impl<T, A: Allocator> Arc<mem::MaybeUninit<T>, A> {
     pub unsafe fn assume_init(self) -> Arc<T, A> {
         let (ptr, alloc) = Arc::into_inner_with_allocator(self);
         unsafe { Arc::from_inner_in(ptr.cast(), alloc) }
+    }
+}
+
+impl<T: ?Sized + CloneToUninit> Arc<T> {
+    /// Constructs a new `Arc<T>` with a clone of `value`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(clone_from_ref)]
+    /// use std::sync::Arc;
+    ///
+    /// let hello: Arc<str> = Arc::clone_from_ref("hello");
+    /// ```
+    #[cfg(not(no_global_oom_handling))]
+    #[unstable(feature = "clone_from_ref", issue = "149075")]
+    pub fn clone_from_ref(value: &T) -> Arc<T> {
+        Arc::clone_from_ref_in(value, Global)
+    }
+
+    /// Constructs a new `Arc<T>` with a clone of `value`, returning an error if allocation fails
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(clone_from_ref)]
+    /// #![feature(allocator_api)]
+    /// use std::sync::Arc;
+    ///
+    /// let hello: Arc<str> = Arc::try_clone_from_ref("hello")?;
+    /// # Ok::<(), std::alloc::AllocError>(())
+    /// ```
+    #[unstable(feature = "clone_from_ref", issue = "149075")]
+    //#[unstable(feature = "allocator_api", issue = "32838")]
+    pub fn try_clone_from_ref(value: &T) -> Result<Arc<T>, AllocError> {
+        Arc::try_clone_from_ref_in(value, Global)
+    }
+}
+
+impl<T: ?Sized + CloneToUninit, A: Allocator> Arc<T, A> {
+    /// Constructs a new `Arc<T>` with a clone of `value` in the provided allocator.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(clone_from_ref)]
+    /// #![feature(allocator_api)]
+    /// use std::sync::Arc;
+    /// use std::alloc::System;
+    ///
+    /// let hello: Arc<str, System> = Arc::clone_from_ref_in("hello", System);
+    /// ```
+    #[cfg(not(no_global_oom_handling))]
+    #[unstable(feature = "clone_from_ref", issue = "149075")]
+    //#[unstable(feature = "allocator_api", issue = "32838")]
+    pub fn clone_from_ref_in(value: &T, alloc: A) -> Arc<T, A> {
+        // `in_progress` drops the allocation if we panic before finishing initializing it.
+        let mut in_progress: UniqueArcUninit<T, A> = UniqueArcUninit::new(value, alloc);
+
+        // Initialize with clone of value.
+        let initialized_clone = unsafe {
+            // Clone. If the clone panics, `in_progress` will be dropped and clean up.
+            value.clone_to_uninit(in_progress.data_ptr().cast());
+            // Cast type of pointer, now that it is initialized.
+            in_progress.into_arc()
+        };
+
+        initialized_clone
+    }
+
+    /// Constructs a new `Arc<T>` with a clone of `value` in the provided allocator, returning an error if allocation fails
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(clone_from_ref)]
+    /// #![feature(allocator_api)]
+    /// use std::sync::Arc;
+    /// use std::alloc::System;
+    ///
+    /// let hello: Arc<str, System> = Arc::try_clone_from_ref_in("hello", System)?;
+    /// # Ok::<(), std::alloc::AllocError>(())
+    /// ```
+    #[unstable(feature = "clone_from_ref", issue = "149075")]
+    //#[unstable(feature = "allocator_api", issue = "32838")]
+    pub fn try_clone_from_ref_in(value: &T, alloc: A) -> Result<Arc<T, A>, AllocError> {
+        // `in_progress` drops the allocation if we panic before finishing initializing it.
+        let mut in_progress: UniqueArcUninit<T, A> = UniqueArcUninit::try_new(value, alloc)?;
+
+        // Initialize with clone of value.
+        let initialized_clone = unsafe {
+            // Clone. If the clone panics, `in_progress` will be dropped and clean up.
+            value.clone_to_uninit(in_progress.data_ptr().cast());
+            // Cast type of pointer, now that it is initialized.
+            in_progress.into_arc()
+        };
+
+        Ok(initialized_clone)
     }
 }
 
@@ -4137,16 +4233,15 @@ fn data_offset_align(align: usize) -> usize {
 /// but will deallocate it (without dropping the value) when dropped.
 ///
 /// This is a helper for [`Arc::make_mut()`] to ensure correct cleanup on panic.
-#[cfg(not(no_global_oom_handling))]
 struct UniqueArcUninit<T: ?Sized, A: Allocator> {
     ptr: NonNull<ArcInner<T>>,
     layout_for_value: Layout,
     alloc: Option<A>,
 }
 
-#[cfg(not(no_global_oom_handling))]
 impl<T: ?Sized, A: Allocator> UniqueArcUninit<T, A> {
     /// Allocates an ArcInner with layout suitable to contain `for_value` or a clone of it.
+    #[cfg(not(no_global_oom_handling))]
     fn new(for_value: &T, alloc: A) -> UniqueArcUninit<T, A> {
         let layout = Layout::for_value(for_value);
         let ptr = unsafe {
@@ -4157,6 +4252,20 @@ impl<T: ?Sized, A: Allocator> UniqueArcUninit<T, A> {
             )
         };
         Self { ptr: NonNull::new(ptr).unwrap(), layout_for_value: layout, alloc: Some(alloc) }
+    }
+
+    /// Allocates an ArcInner with layout suitable to contain `for_value` or a clone of it,
+    /// returning an error if allocation fails.
+    fn try_new(for_value: &T, alloc: A) -> Result<UniqueArcUninit<T, A>, AllocError> {
+        let layout = Layout::for_value(for_value);
+        let ptr = unsafe {
+            Arc::try_allocate_for_layout(
+                layout,
+                |layout_for_arcinner| alloc.allocate(layout_for_arcinner),
+                |mem| mem.with_metadata_of(ptr::from_ref(for_value) as *const ArcInner<T>),
+            )?
+        };
+        Ok(Self { ptr: NonNull::new(ptr).unwrap(), layout_for_value: layout, alloc: Some(alloc) })
     }
 
     /// Returns the pointer to be written into to initialize the [`Arc`].

--- a/library/std/src/ffi/os_str.rs
+++ b/library/std/src/ffi/os_str.rs
@@ -1285,8 +1285,7 @@ impl From<&OsStr> for Box<OsStr> {
     /// Copies the string into a newly allocated <code>[Box]&lt;[OsStr]&gt;</code>.
     #[inline]
     fn from(s: &OsStr) -> Box<OsStr> {
-        let rw = Box::into_raw(s.inner.into_box()) as *mut OsStr;
-        unsafe { Box::from_raw(rw) }
+        Box::clone_from_ref(s)
     }
 }
 

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -374,6 +374,7 @@
 // tidy-alphabetical-start
 #![feature(alloc_layout_extra)]
 #![feature(allocator_api)]
+#![feature(clone_from_ref)]
 #![feature(get_mut_unchecked)]
 #![feature(map_try_insert)]
 #![feature(slice_concat_trait)]

--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -1877,9 +1877,7 @@ impl From<&Path> for Box<Path> {
     ///
     /// This will allocate and clone `path` to it.
     fn from(path: &Path) -> Box<Path> {
-        let boxed: Box<OsStr> = path.inner.into();
-        let rw = Box::into_raw(boxed) as *mut Path;
-        unsafe { Box::from_raw(rw) }
+        Box::clone_from_ref(path)
     }
 }
 

--- a/library/std/src/sys/os_str/bytes.rs
+++ b/library/std/src/sys/os_str/bytes.rs
@@ -322,12 +322,6 @@ impl Slice {
     }
 
     #[inline]
-    pub fn into_box(&self) -> Box<Slice> {
-        let boxed: Box<[u8]> = self.inner.into();
-        unsafe { mem::transmute(boxed) }
-    }
-
-    #[inline]
     pub fn empty_box() -> Box<Slice> {
         let boxed: Box<[u8]> = Default::default();
         unsafe { mem::transmute(boxed) }

--- a/library/std/src/sys/os_str/wtf8.rs
+++ b/library/std/src/sys/os_str/wtf8.rs
@@ -272,11 +272,6 @@ impl Slice {
     }
 
     #[inline]
-    pub fn into_box(&self) -> Box<Slice> {
-        unsafe { mem::transmute(self.inner.into_box()) }
-    }
-
-    #[inline]
     pub fn empty_box() -> Box<Slice> {
         unsafe { mem::transmute(Wtf8::empty_box()) }
     }

--- a/tests/ui/privacy/suggest-box-new.stderr
+++ b/tests/ui/privacy/suggest-box-new.stderr
@@ -63,7 +63,7 @@ LL -             x: (),
 LL -         })),
 LL +         wtf: Some(Box::new_in(_, _)),
    |
-   = and 13 other candidates
+   = and 15 other candidates
 help: consider using the `Default` trait
    |
 LL -         wtf: Some(Box(U {
@@ -118,7 +118,7 @@ LL +     let _ = Box::new_zeroed();
 LL -     let _ = Box {};
 LL +     let _ = Box::new_in(_, _);
    |
-   = and 14 other candidates
+   = and 16 other candidates
 help: consider using the `Default` trait
    |
 LL -     let _ = Box {};
@@ -146,7 +146,7 @@ LL +     let _ = Box::<i32>::map(_, _);
 LL -     let _ = Box::<i32> {};
 LL +     let _ = Box::<i32>::into_inner(_);
    |
-   = and 5 other candidates
+   = and 7 other candidates
 help: consider using the `Default` trait
    |
 LL -     let _ = Box::<i32> {};

--- a/tests/ui/suggestions/multi-suggestion.ascii.stderr
+++ b/tests/ui/suggestions/multi-suggestion.ascii.stderr
@@ -63,7 +63,7 @@ LL -             x: (),
 LL -         })),
 LL +         wtf: Some(Box::new_in(_, _)),
    |
-   = and 13 other candidates
+   = and 15 other candidates
 help: consider using the `Default` trait
    |
 LL -         wtf: Some(Box(U {
@@ -118,7 +118,7 @@ LL +     let _ = Box::new_zeroed();
 LL -     let _ = Box {};
 LL +     let _ = Box::new_in(_, _);
    |
-   = and 14 other candidates
+   = and 16 other candidates
 help: consider using the `Default` trait
    |
 LL -     let _ = Box {};

--- a/tests/ui/suggestions/multi-suggestion.unicode.stderr
+++ b/tests/ui/suggestions/multi-suggestion.unicode.stderr
@@ -63,7 +63,7 @@ LL -             x: (),
 LL -         })),
 LL +         wtf: Some(Box::new_in(_, _)),
    │
-   ╰ and 13 other candidates
+   ╰ and 15 other candidates
 help: consider using the `Default` trait
    ╭╴
 LL -         wtf: Some(Box(U {
@@ -118,7 +118,7 @@ LL +     let _ = Box::new_zeroed();
 LL -     let _ = Box {};
 LL +     let _ = Box::new_in(_, _);
    │
-   ╰ and 14 other candidates
+   ╰ and 16 other candidates
 help: consider using the `Default` trait
    ╭╴
 LL -     let _ = Box {};


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Tracking issue: https://github.com/rust-lang/rust/issues/149075

Accepted ACP: https://github.com/rust-lang/libs-team/issues/483

This PR implements `clone_from_ref` (and `try_*` and `_*in` variants), to get a `Box<T>`, `Arc<T>`, or `Rc<T>` by cloning from a `&T` where `T: CloneToUninit`.

The "Implement..." commits replace some ad-hoc conversions with `clone_from_ref` variants, which can be split out to a separate PR if desired.

This PR will conflict with https://github.com/rust-lang/rust/pull/148769 due to usage of `Layout::dangling` (which that PR is renaming to `dangling_ptr`), so they should not be rolled up together, and the one which merges later will need to be amended.
