### PR TITLE
Add missing trailing period to RustDoc for fn create_dir().

### DIFF
--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -2918,7 +2918,7 @@ pub fn canonicalize<P: AsRef<Path>>(path: P) -> io::Result<PathBuf> {
     fs_imp::canonicalize(path.as_ref())
 }
 
-/// Creates a new, empty directory at the provided path
+/// Creates a new, empty directory at the provided path.
 ///
 /// # Platform-specific behavior
 ///


### PR DESCRIPTION
Documentation for other functions in the standard library RustDocs have a trailing period at the end of the first sentence, e.g. `create_dir_all()` and `create_buffered()` have the trailing period, but the first line of documentation for `fn create_dir()` lacks a trailing period. This PR adds the missing period.