### PR TITLE
stabilize maybe_uninit_slice

### DIFF
--- a/compiler/rustc_arena/src/lib.rs
+++ b/compiler/rustc_arena/src/lib.rs
@@ -10,13 +10,13 @@
 // tidy-alphabetical-start
 #![allow(clippy::mut_from_ref)] // Arena allocators are one place where this pattern is fine.
 #![allow(internal_features)]
+#![cfg_attr(bootstrap, feature(maybe_uninit_slice))]
 #![cfg_attr(test, feature(test))]
 #![deny(unsafe_op_in_unsafe_fn)]
 #![doc(test(no_crate_inject, attr(deny(warnings), allow(internal_features))))]
 #![feature(core_intrinsics)]
 #![feature(decl_macro)]
 #![feature(dropck_eyepatch)]
-#![feature(maybe_uninit_slice)]
 #![feature(never_type)]
 #![feature(rustc_attrs)]
 #![feature(unwrap_infallible)]

--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -127,7 +127,6 @@
 #![feature(layout_for_ptr)]
 #![feature(legacy_receiver_trait)]
 #![feature(local_waker)]
-#![feature(maybe_uninit_slice)]
 #![feature(maybe_uninit_uninit_array_transpose)]
 #![feature(panic_internals)]
 #![feature(pattern)]

--- a/library/alloctests/lib.rs
+++ b/library/alloctests/lib.rs
@@ -28,7 +28,6 @@
 #![feature(inplace_iteration)]
 #![feature(iter_advance_by)]
 #![feature(iter_next_chunk)]
-#![feature(maybe_uninit_slice)]
 #![feature(maybe_uninit_uninit_array_transpose)]
 #![feature(ptr_alignment_type)]
 #![feature(ptr_internals)]

--- a/library/core/src/clone/uninit.rs
+++ b/library/core/src/clone/uninit.rs
@@ -114,16 +114,10 @@ impl<'a, T> InitializingSlice<'a, T> {
 impl<'a, T> Drop for InitializingSlice<'a, T> {
     #[cold] // will only be invoked on unwind
     fn drop(&mut self) {
-        let initialized_slice = ptr::slice_from_raw_parts_mut(
-            MaybeUninit::slice_as_mut_ptr(self.data),
-            self.initialized_len,
-        );
         // SAFETY:
         // * the pointer is valid because it was made from a mutable reference
         // * `initialized_len` counts the initialized elements as an invariant of this type,
         //   so each of the pointed-to elements is initialized and may be dropped.
-        unsafe {
-            ptr::drop_in_place::<[T]>(initialized_slice);
-        }
+        unsafe { self.data[..self.initialized_len].assume_init_drop() };
     }
 }

--- a/library/core/src/mem/maybe_uninit.rs
+++ b/library/core/src/mem/maybe_uninit.rs
@@ -1097,20 +1097,6 @@ impl<T> MaybeUninit<T> {
             )
         }
     }
-
-    /// Gets a pointer to the first element of the array.
-    #[unstable(feature = "maybe_uninit_slice", issue = "63569")]
-    #[inline(always)]
-    pub const fn slice_as_ptr(this: &[MaybeUninit<T>]) -> *const T {
-        this.as_ptr() as *const T
-    }
-
-    /// Gets a mutable pointer to the first element of the array.
-    #[unstable(feature = "maybe_uninit_slice", issue = "63569")]
-    #[inline(always)]
-    pub const fn slice_as_mut_ptr(this: &mut [MaybeUninit<T>]) -> *mut T {
-        this.as_mut_ptr() as *mut T
-    }
 }
 
 impl<T> [MaybeUninit<T>] {
@@ -1477,7 +1463,7 @@ impl<T> [MaybeUninit<T>] {
     /// requirement the compiler knows about it is that the data pointer must be
     /// non-null. Dropping such a `Vec<T>` however will cause undefined
     /// behaviour.
-    #[unstable(feature = "maybe_uninit_slice", issue = "63569")]
+    #[stable(feature = "maybe_uninit_slice", since = "CURRENT_RUSTC_VERSION")]
     #[inline(always)]
     #[rustc_const_unstable(feature = "const_drop_in_place", issue = "109342")]
     pub const unsafe fn assume_init_drop(&mut self)
@@ -1499,7 +1485,8 @@ impl<T> [MaybeUninit<T>] {
     /// Calling this when the content is not yet fully initialized causes undefined
     /// behavior: it is up to the caller to guarantee that every `MaybeUninit<T>` in
     /// the slice really is in an initialized state.
-    #[unstable(feature = "maybe_uninit_slice", issue = "63569")]
+    #[stable(feature = "maybe_uninit_slice", since = "CURRENT_RUSTC_VERSION")]
+    #[rustc_const_stable(feature = "maybe_uninit_slice", since = "CURRENT_RUSTC_VERSION")]
     #[inline(always)]
     pub const unsafe fn assume_init_ref(&self) -> &[T] {
         // SAFETY: casting `slice` to a `*const [T]` is safe since the caller guarantees that
@@ -1517,7 +1504,8 @@ impl<T> [MaybeUninit<T>] {
     /// behavior: it is up to the caller to guarantee that every `MaybeUninit<T>` in the
     /// slice really is in an initialized state. For instance, `.assume_init_mut()` cannot
     /// be used to initialize a `MaybeUninit` slice.
-    #[unstable(feature = "maybe_uninit_slice", issue = "63569")]
+    #[stable(feature = "maybe_uninit_slice", since = "CURRENT_RUSTC_VERSION")]
+    #[rustc_const_stable(feature = "maybe_uninit_slice", since = "CURRENT_RUSTC_VERSION")]
     #[inline(always)]
     pub const unsafe fn assume_init_mut(&mut self) -> &mut [T] {
         // SAFETY: similar to safety notes for `slice_get_ref`, but we have a

--- a/library/core/src/mem/maybe_uninit.rs
+++ b/library/core/src/mem/maybe_uninit.rs
@@ -1047,7 +1047,7 @@ impl<T> MaybeUninit<T> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(maybe_uninit_as_bytes, maybe_uninit_slice)]
+    /// #![feature(maybe_uninit_as_bytes)]
     /// use std::mem::MaybeUninit;
     ///
     /// let val = 0x12345678_i32;
@@ -1396,7 +1396,7 @@ impl<T> [MaybeUninit<T>] {
     /// # Examples
     ///
     /// ```
-    /// #![feature(maybe_uninit_as_bytes, maybe_uninit_slice)]
+    /// #![feature(maybe_uninit_as_bytes)]
     /// use std::mem::MaybeUninit;
     ///
     /// let uninit = [MaybeUninit::new(0x1234u16), MaybeUninit::new(0x5678u16)];
@@ -1423,7 +1423,7 @@ impl<T> [MaybeUninit<T>] {
     /// # Examples
     ///
     /// ```
-    /// #![feature(maybe_uninit_as_bytes, maybe_uninit_slice)]
+    /// #![feature(maybe_uninit_as_bytes)]
     /// use std::mem::MaybeUninit;
     ///
     /// let mut uninit = [MaybeUninit::<u16>::uninit(), MaybeUninit::<u16>::uninit()];

--- a/library/core/src/slice/sort/stable/merge.rs
+++ b/library/core/src/slice/sort/stable/merge.rs
@@ -35,7 +35,7 @@ pub fn merge<T, F: FnMut(&T, &T) -> bool>(
         //  1. Protects integrity of `v` from panics in `is_less`.
         //  2. Fills the remaining gap in `v` if the longer run gets consumed first.
 
-        let buf = MaybeUninit::slice_as_mut_ptr(scratch);
+        let buf = scratch.as_mut_ptr().cast_init();
 
         let v_base = v.as_mut_ptr();
         let v_mid = v_base.add(mid);

--- a/library/core/src/slice/sort/stable/quicksort.rs
+++ b/library/core/src/slice/sort/stable/quicksort.rs
@@ -97,7 +97,7 @@ fn stable_partition<T, F: FnMut(&T, &T) -> bool>(
     }
 
     let v_base = v.as_ptr();
-    let scratch_base = MaybeUninit::slice_as_mut_ptr(scratch);
+    let scratch_base = scratch.as_mut_ptr().cast_init();
 
     // The core idea is to write the values that compare as less-than to the left
     // side of `scratch`, while the values that compared as greater or equal than

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -348,7 +348,6 @@
 #![feature(ip)]
 #![feature(lazy_get)]
 #![feature(maybe_uninit_array_assume_init)]
-#![feature(maybe_uninit_slice)]
 #![feature(panic_can_unwind)]
 #![feature(panic_internals)]
 #![feature(pin_coerce_unsized_trait)]

--- a/library/std/tests/path.rs
+++ b/library/std/tests/path.rs
@@ -1,6 +1,5 @@
 // tidy-alphabetical-start
 #![feature(clone_to_uninit)]
-#![feature(maybe_uninit_slice)]
 #![feature(normalize_lexically)]
 #![feature(path_trailing_sep)]
 // tidy-alphabetical-end


### PR DESCRIPTION
Tracking issue: rust-lang/rust#63569
Closes: rust-lang/rust#63569
FCP completed: https://github.com/rust-lang/rust/issues/63569#issuecomment-3477510504

Removes:
```rs
pub const fn slice_as_ptr(this: &[MaybeUninit<T>]) -> *const T;
pub const fn slice_as_mut_ptr(this: &mut [MaybeUninit<T>]) -> *mut T;
```