### PR TITLE
See if this is the time we can remove `layout::size_align`

### DIFF
--- a/library/core/src/alloc/layout.rs
+++ b/library/core/src/alloc/layout.rs
@@ -10,16 +10,6 @@ use crate::mem::SizedTypeProperties;
 use crate::ptr::{Alignment, NonNull};
 use crate::{assert_unsafe_precondition, fmt, mem};
 
-// While this function is used in one place and its implementation
-// could be inlined, the previous attempts to do so made rustc
-// slower:
-//
-// * https://github.com/rust-lang/rust/pull/72189
-// * https://github.com/rust-lang/rust/pull/79827
-const fn size_align<T>() -> (usize, usize) {
-    (size_of::<T>(), align_of::<T>())
-}
-
 /// Layout of a block of memory.
 ///
 /// An instance of `Layout` describes a particular layout of memory.
@@ -168,11 +158,7 @@ impl Layout {
     #[must_use]
     #[inline]
     pub const fn new<T>() -> Self {
-        let (size, align) = size_align::<T>();
-        // SAFETY: if the type is instantiated, rustc already ensures that its
-        // layout is valid. Use the unchecked constructor to avoid inserting a
-        // panicking codepath that needs to be optimized out.
-        unsafe { Layout::from_size_align_unchecked(size, align) }
+        <T as SizedTypeProperties>::LAYOUT
     }
 
     /// Produces layout describing a record that could be used to

--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -1283,7 +1283,12 @@ pub trait SizedTypeProperties: Sized {
 
     #[doc(hidden)]
     #[unstable(feature = "sized_type_properties", issue = "none")]
-    const LAYOUT: Layout = Layout::new::<Self>();
+    const LAYOUT: Layout = {
+        // SAFETY: if the type is instantiated, rustc already ensures that its
+        // layout is valid. Use the unchecked constructor to avoid inserting a
+        // panicking codepath that needs to be optimized out.
+        unsafe { Layout::from_size_align_unchecked(Self::SIZE, Self::ALIGN) }
+    };
 
     /// The largest safe length for a `[Self]`.
     ///

--- a/tests/ui/thir-print/offset_of.stdout
+++ b/tests/ui/thir-print/offset_of.stdout
@@ -68,7 +68,7 @@ body:
                                             )
                                             else_block: None
                                             lint_level: Explicit(HirId(DefId(offset_of::concrete).10))
-                                            span: $DIR/offset_of.rs:37:5: 1430:57 (#0)
+                                            span: $DIR/offset_of.rs:37:5: 1435:57 (#0)
                                         }
                                     }
                                     Stmt {
@@ -117,7 +117,7 @@ body:
                                             )
                                             else_block: None
                                             lint_level: Explicit(HirId(DefId(offset_of::concrete).20))
-                                            span: $DIR/offset_of.rs:38:5: 1430:57 (#0)
+                                            span: $DIR/offset_of.rs:38:5: 1435:57 (#0)
                                         }
                                     }
                                     Stmt {
@@ -166,7 +166,7 @@ body:
                                             )
                                             else_block: None
                                             lint_level: Explicit(HirId(DefId(offset_of::concrete).30))
-                                            span: $DIR/offset_of.rs:39:5: 1430:57 (#0)
+                                            span: $DIR/offset_of.rs:39:5: 1435:57 (#0)
                                         }
                                     }
                                     Stmt {
@@ -215,7 +215,7 @@ body:
                                             )
                                             else_block: None
                                             lint_level: Explicit(HirId(DefId(offset_of::concrete).40))
-                                            span: $DIR/offset_of.rs:40:5: 1430:57 (#0)
+                                            span: $DIR/offset_of.rs:40:5: 1435:57 (#0)
                                         }
                                     }
                                     Stmt {
@@ -264,7 +264,7 @@ body:
                                             )
                                             else_block: None
                                             lint_level: Explicit(HirId(DefId(offset_of::concrete).50))
-                                            span: $DIR/offset_of.rs:41:5: 1430:57 (#0)
+                                            span: $DIR/offset_of.rs:41:5: 1435:57 (#0)
                                         }
                                     }
                                 ]
@@ -864,7 +864,7 @@ body:
                                             )
                                             else_block: None
                                             lint_level: Explicit(HirId(DefId(offset_of::generic).12))
-                                            span: $DIR/offset_of.rs:45:5: 1430:57 (#0)
+                                            span: $DIR/offset_of.rs:45:5: 1435:57 (#0)
                                         }
                                     }
                                     Stmt {
@@ -913,7 +913,7 @@ body:
                                             )
                                             else_block: None
                                             lint_level: Explicit(HirId(DefId(offset_of::generic).24))
-                                            span: $DIR/offset_of.rs:46:5: 1430:57 (#0)
+                                            span: $DIR/offset_of.rs:46:5: 1435:57 (#0)
                                         }
                                     }
                                     Stmt {
@@ -962,7 +962,7 @@ body:
                                             )
                                             else_block: None
                                             lint_level: Explicit(HirId(DefId(offset_of::generic).36))
-                                            span: $DIR/offset_of.rs:47:5: 1430:57 (#0)
+                                            span: $DIR/offset_of.rs:47:5: 1435:57 (#0)
                                         }
                                     }
                                     Stmt {
@@ -1011,7 +1011,7 @@ body:
                                             )
                                             else_block: None
                                             lint_level: Explicit(HirId(DefId(offset_of::generic).48))
-                                            span: $DIR/offset_of.rs:48:5: 1430:57 (#0)
+                                            span: $DIR/offset_of.rs:48:5: 1435:57 (#0)
                                         }
                                     }
                                 ]


### PR DESCRIPTION
This was a bad idea before, but now that `size_of` and `align_of` work completely differently than when removing it was first tried in 2020, maybe it makes sense now.

(Or maybe I'll just add another attempt to the list in the comments...)

r? ghost