### PR TITLE
fs: Run file lock tests on all platforms that support it

### DIFF
--- a/library/std/src/fs/tests.rs
+++ b/library/std/src/fs/tests.rs
@@ -224,11 +224,15 @@ fn file_test_io_seek_and_write() {
 #[test]
 #[cfg(any(
     windows,
+    target_os = "aix",
+    target_os = "cygwin",
     target_os = "freebsd",
+    target_os = "fuchsia",
+    target_os = "illumos",
     target_os = "linux",
     target_os = "netbsd",
+    target_os = "openbsd",
     target_os = "solaris",
-    target_os = "illumos",
     target_vendor = "apple",
 ))]
 fn file_lock_multiple_shared() {
@@ -249,11 +253,15 @@ fn file_lock_multiple_shared() {
 #[test]
 #[cfg(any(
     windows,
+    target_os = "aix",
+    target_os = "cygwin",
     target_os = "freebsd",
+    target_os = "fuchsia",
+    target_os = "illumos",
     target_os = "linux",
     target_os = "netbsd",
+    target_os = "openbsd",
     target_os = "solaris",
-    target_os = "illumos",
     target_vendor = "apple",
 ))]
 fn file_lock_blocking() {
@@ -275,11 +283,15 @@ fn file_lock_blocking() {
 #[test]
 #[cfg(any(
     windows,
+    target_os = "aix",
+    target_os = "cygwin",
     target_os = "freebsd",
+    target_os = "fuchsia",
+    target_os = "illumos",
     target_os = "linux",
     target_os = "netbsd",
+    target_os = "openbsd",
     target_os = "solaris",
-    target_os = "illumos",
     target_vendor = "apple",
 ))]
 fn file_lock_drop() {
@@ -298,11 +310,15 @@ fn file_lock_drop() {
 #[test]
 #[cfg(any(
     windows,
+    target_os = "aix",
+    target_os = "cygwin",
     target_os = "freebsd",
+    target_os = "fuchsia",
+    target_os = "illumos",
     target_os = "linux",
     target_os = "netbsd",
+    target_os = "openbsd",
     target_os = "solaris",
-    target_os = "illumos",
     target_vendor = "apple",
 ))]
 fn file_lock_dup() {

--- a/library/std/src/fs/tests.rs
+++ b/library/std/src/fs/tests.rs
@@ -1263,7 +1263,7 @@ fn readlink_not_symlink() {
 }
 
 #[test]
-#[cfg_attr(target_os = "android", ignore)] // Android SELinux rules prevent creating hardlinks
+#[cfg_attr(target_os = "android", ignore = "Android SELinux rules prevent creating hardlinks")]
 fn links_work() {
     let tmpdir = tmpdir();
     let input = tmpdir.join("in.txt");
@@ -1759,7 +1759,7 @@ fn metadata_access_times() {
 
 /// Test creating hard links to symlinks.
 #[test]
-#[cfg_attr(target_os = "android", ignore)] // Android SELinux rules prevent creating hardlinks
+#[cfg_attr(target_os = "android", ignore = "Android SELinux rules prevent creating hardlinks")]
 fn symlink_hard_link() {
     let tmpdir = tmpdir();
     if !got_symlink_permission(&tmpdir) {

--- a/library/std/src/fs/tests.rs
+++ b/library/std/src/fs/tests.rs
@@ -1,24 +1,7 @@
 use rand::RngCore;
 
-#[cfg(any(
-    windows,
-    target_os = "freebsd",
-    target_os = "linux",
-    target_os = "netbsd",
-    target_os = "illumos",
-    target_vendor = "apple",
-))]
 use crate::assert_matches::assert_matches;
-#[cfg(any(
-    windows,
-    target_os = "freebsd",
-    target_os = "linux",
-    target_os = "netbsd",
-    target_os = "illumos",
-    target_vendor = "apple",
-))]
-use crate::fs::TryLockError;
-use crate::fs::{self, File, FileTimes, OpenOptions};
+use crate::fs::{self, File, FileTimes, OpenOptions, TryLockError};
 use crate::io::prelude::*;
 use crate::io::{BorrowedBuf, ErrorKind, SeekFrom};
 use crate::mem::MaybeUninit;
@@ -222,19 +205,22 @@ fn file_test_io_seek_and_write() {
 }
 
 #[test]
-#[cfg(any(
-    windows,
-    target_os = "aix",
-    target_os = "cygwin",
-    target_os = "freebsd",
-    target_os = "fuchsia",
-    target_os = "illumos",
-    target_os = "linux",
-    target_os = "netbsd",
-    target_os = "openbsd",
-    target_os = "solaris",
-    target_vendor = "apple",
-))]
+#[cfg_attr(
+    not(any(
+        windows,
+        target_os = "aix",
+        target_os = "cygwin",
+        target_os = "freebsd",
+        target_os = "fuchsia",
+        target_os = "illumos",
+        target_os = "linux",
+        target_os = "netbsd",
+        target_os = "openbsd",
+        target_os = "solaris",
+        target_vendor = "apple",
+    )),
+    should_panic
+)]
 fn file_lock_multiple_shared() {
     let tmpdir = tmpdir();
     let filename = &tmpdir.join("file_lock_multiple_shared_test.txt");
@@ -251,19 +237,22 @@ fn file_lock_multiple_shared() {
 }
 
 #[test]
-#[cfg(any(
-    windows,
-    target_os = "aix",
-    target_os = "cygwin",
-    target_os = "freebsd",
-    target_os = "fuchsia",
-    target_os = "illumos",
-    target_os = "linux",
-    target_os = "netbsd",
-    target_os = "openbsd",
-    target_os = "solaris",
-    target_vendor = "apple",
-))]
+#[cfg_attr(
+    not(any(
+        windows,
+        target_os = "aix",
+        target_os = "cygwin",
+        target_os = "freebsd",
+        target_os = "fuchsia",
+        target_os = "illumos",
+        target_os = "linux",
+        target_os = "netbsd",
+        target_os = "openbsd",
+        target_os = "solaris",
+        target_vendor = "apple",
+    )),
+    should_panic
+)]
 fn file_lock_blocking() {
     let tmpdir = tmpdir();
     let filename = &tmpdir.join("file_lock_blocking_test.txt");
@@ -281,19 +270,22 @@ fn file_lock_blocking() {
 }
 
 #[test]
-#[cfg(any(
-    windows,
-    target_os = "aix",
-    target_os = "cygwin",
-    target_os = "freebsd",
-    target_os = "fuchsia",
-    target_os = "illumos",
-    target_os = "linux",
-    target_os = "netbsd",
-    target_os = "openbsd",
-    target_os = "solaris",
-    target_vendor = "apple",
-))]
+#[cfg_attr(
+    not(any(
+        windows,
+        target_os = "aix",
+        target_os = "cygwin",
+        target_os = "freebsd",
+        target_os = "fuchsia",
+        target_os = "illumos",
+        target_os = "linux",
+        target_os = "netbsd",
+        target_os = "openbsd",
+        target_os = "solaris",
+        target_vendor = "apple",
+    )),
+    should_panic
+)]
 fn file_lock_drop() {
     let tmpdir = tmpdir();
     let filename = &tmpdir.join("file_lock_dup_test.txt");
@@ -308,19 +300,22 @@ fn file_lock_drop() {
 }
 
 #[test]
-#[cfg(any(
-    windows,
-    target_os = "aix",
-    target_os = "cygwin",
-    target_os = "freebsd",
-    target_os = "fuchsia",
-    target_os = "illumos",
-    target_os = "linux",
-    target_os = "netbsd",
-    target_os = "openbsd",
-    target_os = "solaris",
-    target_vendor = "apple",
-))]
+#[cfg_attr(
+    not(any(
+        windows,
+        target_os = "aix",
+        target_os = "cygwin",
+        target_os = "freebsd",
+        target_os = "fuchsia",
+        target_os = "illumos",
+        target_os = "linux",
+        target_os = "netbsd",
+        target_os = "openbsd",
+        target_os = "solaris",
+        target_vendor = "apple",
+    )),
+    should_panic
+)]
 fn file_lock_dup() {
     let tmpdir = tmpdir();
     let filename = &tmpdir.join("file_lock_dup_test.txt");


### PR DESCRIPTION
There are a number of platforms that support file locking but aren't getting tested. Synchronize the list and mark the tests `should_panic` otherwise, to make sure they get updated if more platforms add locking support.

The supported platform list comes from https://github.com/rust-lang/rust/blob/07bdbaedc63094281483c40a88a1a8f2f8ffadc5/library/std/src/sys/fs/unix.rs#L1291-L1308. Windows also supports file locks, all other platforms are unsupported.