### PR TITLE
std: sys: fs: uefi: Fix FileAttr size

### DIFF
--- a/library/std/src/sys/fs/uefi.rs
+++ b/library/std/src/sys/fs/uefi.rs
@@ -81,7 +81,7 @@ impl FileAttr {
         unsafe {
             Self {
                 attr: (*info.as_ptr()).attribute,
-                size: (*info.as_ptr()).size,
+                size: (*info.as_ptr()).file_size,
                 modified: uefi_fs::uefi_to_systemtime((*info.as_ptr()).modification_time),
                 accessed: uefi_fs::uefi_to_systemtime((*info.as_ptr()).last_access_time),
                 created: uefi_fs::uefi_to_systemtime((*info.as_ptr()).create_time),


### PR DESCRIPTION
- The underlying file size is represented by file_size field. The size field is just the size of structure since it is a C DST.
- Fixes bug created in https://github.com/rust-lang/rust/pull/148970

@rustbot label +O-UEFI