### PR TITLE
Use inline asm rather than llvm intrinsic for panics on wasm

### DIFF
--- a/library/unwind/src/lib.rs
+++ b/library/unwind/src/lib.rs
@@ -7,7 +7,7 @@
 #![cfg_attr(not(target_env = "msvc"), feature(libc))]
 #![cfg_attr(
     all(target_family = "wasm", any(not(target_os = "emscripten"), emscripten_wasm_eh)),
-    feature(link_llvm_intrinsics, simd_wasm64)
+    feature(asm_experimental_arch, asm_unwind, simd_wasm64)
 )]
 #![allow(internal_features)]
 #![deny(unsafe_op_in_unsafe_fn)]

--- a/library/unwind/src/wasm.rs
+++ b/library/unwind/src/wasm.rs
@@ -55,6 +55,8 @@ pub unsafe fn _Unwind_RaiseException(exception: *mut _Unwind_Exception) -> _Unwi
             // unwinding for llvm intrinsics complicates things in the backend.
             core::arch::asm!("
                 .tagtype __cpp_exception i32
+                .globl __cpp_exception
+                .weak __cpp_exception
                 local.get {exc}
                 throw __cpp_exception
             ", exc = in(local) exception, options(may_unwind, noreturn, nostack));


### PR DESCRIPTION
This way we don't have to support unwinding llvm intrinsics in the codegen backends.