### PR TITLE
Reject `async fn` in `const impl` during AST validation

### DIFF
--- a/compiler/rustc_ast_passes/messages.ftl
+++ b/compiler/rustc_ast_passes/messages.ftl
@@ -37,9 +37,10 @@ ast_passes_assoc_type_without_body =
     .suggestion = provide a definition for the type
 
 ast_passes_async_fn_in_const_trait_or_trait_impl =
-    async functions are not allowed in `const` {$in_impl ->
-        [true] trait impls
-        *[false] traits
+    async functions are not allowed in `const` {$context ->
+        [trait_impl] trait impls
+        [impl] impls
+        *[trait] traits
     }
     .label = associated functions of `const` cannot be declared `async`
 

--- a/compiler/rustc_ast_passes/src/errors.rs
+++ b/compiler/rustc_ast_passes/src/errors.rs
@@ -76,7 +76,7 @@ pub(crate) struct TraitFnConst {
 pub(crate) struct AsyncFnInConstTraitOrTraitImpl {
     #[primary_span]
     pub async_keyword: Span,
-    pub in_impl: bool,
+    pub context: &'static str,
     #[label]
     pub const_keyword: Span,
 }

--- a/tests/ui/traits/const-traits/ice-149083-async-in-const-impl.rs
+++ b/tests/ui/traits/const-traits/ice-149083-async-in-const-impl.rs
@@ -1,0 +1,9 @@
+//@ edition:2024
+
+#![feature(const_trait_impl)]
+struct Foo;
+const impl Foo {
+    async fn e() {}
+    //~^ ERROR async functions are not allowed in `const` impls
+}
+fn main() {}

--- a/tests/ui/traits/const-traits/ice-149083-async-in-const-impl.stderr
+++ b/tests/ui/traits/const-traits/ice-149083-async-in-const-impl.stderr
@@ -1,0 +1,10 @@
+error: async functions are not allowed in `const` impls
+  --> $DIR/ice-149083-async-in-const-impl.rs:6:5
+   |
+LL | const impl Foo {
+   | ----- associated functions of `const` cannot be declared `async`
+LL |     async fn e() {}
+   |     ^^^^^
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
closes rust-lang/rust#149083

Fixes the ICE when using `async fn` inside `const impl` blocks by adding AST validation.

Currently, inherent `impl`s does not perform any checks to verify whether it contains `async fn` declarations. In this PR, I have modified the `visit_assoc_item` function to call `check_async_fn_in_const_trait_or_impl` within the `TraitOrImpl::Impl` case to handle this requirement. Additionally, this change has introduced three possible contexts for the corresponding error messages, so I have updated to properly distinguish between these different contexts when generating messages.

r? oli-obk