### PR TITLE
v0 mangling for std on nightly

### DIFF
--- a/src/bootstrap/src/core/builder/cargo.rs
+++ b/src/bootstrap/src/core/builder/cargo.rs
@@ -647,6 +647,8 @@ impl Builder<'_> {
                 // If an explicit setting is given, use that
                 setting
             }
+            // Per compiler-team#938, v0 mangling is used on nightly
+            None if self.config.channel == "dev" || self.config.channel == "nightly" => true,
             None => {
                 if mode == Mode::Std {
                     // The standard library defaults to the legacy scheme

--- a/tests/ui/sanitizer/dataflow-abilist.txt
+++ b/tests/ui/sanitizer/dataflow-abilist.txt
@@ -491,6 +491,8 @@ fun:__dfso_*=discard
 
 # Rust functions.
 fun:_ZN4core*=uninstrumented
+fun:_R*4core*=uninstrumented
 fun:_ZN3std*=uninstrumented
+fun:_R*3std*=uninstrumented
 fun:rust_eh_personality=uninstrumented
 fun:_R*__rustc*=uninstrumented


### PR DESCRIPTION
Following rust-lang/rust#89917 and rust-lang/compiler-team#938, it doesn't make sense that `std` for these channels would have legacy mangling while the user's code would use `v0`.

r? @Kobzol 
