### PR TITLE
Do we still need the `NeverShortCircuit` type?

### DIFF
--- a/library/core/src/array/iter/iter_inner.rs
+++ b/library/core/src/array/iter/iter_inner.rs
@@ -199,7 +199,7 @@ impl<T> PolymorphicIter<[MaybeUninit<T>]> {
 
     #[inline]
     pub(super) fn fold<B>(&mut self, init: B, f: impl FnMut(B, T) -> B) -> B {
-        self.try_fold(init, NeverShortCircuit::wrap_mut_2(f)).0
+        self.try_fold(init, NeverShortCircuit::wrap_mut_2(f)).into_continue()
     }
 
     #[inline]
@@ -257,7 +257,7 @@ impl<T> PolymorphicIter<[MaybeUninit<T>]> {
 
     #[inline]
     pub(super) fn rfold<B>(&mut self, init: B, f: impl FnMut(B, T) -> B) -> B {
-        self.try_rfold(init, NeverShortCircuit::wrap_mut_2(f)).0
+        self.try_rfold(init, NeverShortCircuit::wrap_mut_2(f)).into_continue()
     }
 
     #[inline]

--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -109,7 +109,7 @@ pub fn from_fn<T, const N: usize, F>(f: F) -> [T; N]
 where
     F: FnMut(usize) -> T,
 {
-    try_from_fn(NeverShortCircuit::wrap_mut_1(f)).0
+    try_from_fn(NeverShortCircuit::wrap_mut_1(f)).into_continue()
 }
 
 /// Creates an array `[T; N]` where each fallible array element `T` is returned by the `cb` call.
@@ -553,7 +553,7 @@ impl<T, const N: usize> [T; N] {
     where
         F: FnMut(T) -> U,
     {
-        self.try_map(NeverShortCircuit::wrap_mut_1(f)).0
+        self.try_map(NeverShortCircuit::wrap_mut_1(f)).into_continue()
     }
 
     /// A fallible function `f` applied to each element on array `self` in order to
@@ -848,7 +848,7 @@ impl<T, const N: usize> [T; N] {
 /// it easily optimizes away) so it doesn't impact the loop that fills the array.
 #[inline]
 fn from_trusted_iterator<T, const N: usize>(iter: impl UncheckedIterator<Item = T>) -> [T; N] {
-    try_from_trusted_iterator(iter.map(NeverShortCircuit)).0
+    try_from_trusted_iterator(iter.map(NeverShortCircuit::Continue)).into_continue()
 }
 
 #[inline]

--- a/library/core/src/iter/adapters/array_chunks.rs
+++ b/library/core/src/iter/adapters/array_chunks.rs
@@ -212,7 +212,7 @@ where
         Self: Sized,
         F: FnMut(B, Self::Item) -> B,
     {
-        self.try_fold(init, NeverShortCircuit::wrap_mut_2(f)).0
+        self.try_fold(init, NeverShortCircuit::wrap_mut_2(f)).into_continue()
     }
 }
 

--- a/library/core/src/iter/adapters/by_ref_sized.rs
+++ b/library/core/src/iter/adapters/by_ref_sized.rs
@@ -42,7 +42,7 @@ impl<I: Iterator> Iterator for ByRefSized<'_, I> {
         F: FnMut(B, Self::Item) -> B,
     {
         // `fold` needs ownership, so this can't forward directly.
-        I::try_fold(self.0, init, NeverShortCircuit::wrap_mut_2(f)).0
+        I::try_fold(self.0, init, NeverShortCircuit::wrap_mut_2(f)).into_continue()
     }
 
     #[inline]
@@ -78,7 +78,7 @@ impl<I: DoubleEndedIterator> DoubleEndedIterator for ByRefSized<'_, I> {
         F: FnMut(B, Self::Item) -> B,
     {
         // `rfold` needs ownership, so this can't forward directly.
-        I::try_rfold(self.0, init, NeverShortCircuit::wrap_mut_2(f)).0
+        I::try_rfold(self.0, init, NeverShortCircuit::wrap_mut_2(f)).into_continue()
     }
 
     #[inline]

--- a/library/core/src/iter/adapters/take.rs
+++ b/library/core/src/iter/adapters/take.rs
@@ -266,7 +266,7 @@ impl<I: Iterator> SpecTake for Take<I> {
         F: FnMut(B, Self::Item) -> B,
     {
         use crate::ops::NeverShortCircuit;
-        self.try_fold(init, NeverShortCircuit::wrap_mut_2(f)).0
+        self.try_fold(init, NeverShortCircuit::wrap_mut_2(f)).into_continue()
     }
 
     #[inline]

--- a/library/core/src/iter/mod.rs
+++ b/library/core/src/iter/mod.rs
@@ -377,7 +377,7 @@ macro_rules! impl_fold_via_try_fold {
         {
             use crate::ops::NeverShortCircuit;
 
-            self.$try_fold(init, NeverShortCircuit::wrap_mut_2(fold)).0
+            self.$try_fold(init, NeverShortCircuit::wrap_mut_2(fold)).into_continue()
         }
     };
 }

--- a/library/core/src/ops/index_range.rs
+++ b/library/core/src/ops/index_range.rs
@@ -150,7 +150,7 @@ impl Iterator for IndexRange {
 
     #[inline]
     fn fold<B, F: FnMut(B, usize) -> B>(mut self, init: B, f: F) -> B {
-        self.try_fold(init, NeverShortCircuit::wrap_mut_2(f)).0
+        self.try_fold(init, NeverShortCircuit::wrap_mut_2(f)).into_continue()
     }
 
     #[inline]
@@ -192,7 +192,7 @@ impl DoubleEndedIterator for IndexRange {
 
     #[inline]
     fn rfold<B, F: FnMut(B, usize) -> B>(mut self, init: B, f: F) -> B {
-        self.try_rfold(init, NeverShortCircuit::wrap_mut_2(f)).0
+        self.try_rfold(init, NeverShortCircuit::wrap_mut_2(f)).into_continue()
     }
 
     #[inline]


### PR DESCRIPTION
This was added back before `ControlFlow` existed, when it was definitely better than `Result<T, !>` by avoiding the `From::from` calls.  But now that we have `ControlFlow`, maybe we can avoid the extra type and impls?

(Still keeps the helper methods for wrapping closures and such, of course.)

r? ghost