### PR TITLE
library: upgrade to hashbrown v0.16.1

### DIFF
--- a/library/Cargo.lock
+++ b/library/Cargo.lock
@@ -89,6 +89,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "fortanix-sgx-abi"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -119,10 +125,11 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
+ "foldhash",
  "rustc-std-workspace-alloc",
  "rustc-std-workspace-core",
 ]

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -20,7 +20,7 @@ panic_unwind = { path = "../panic_unwind", optional = true }
 panic_abort = { path = "../panic_abort" }
 core = { path = "../core", public = true }
 unwind = { path = "../unwind" }
-hashbrown = { version = "0.15", default-features = false, features = [
+hashbrown = { version = "0.16.1", default-features = false, features = [
     'rustc-dep-of-std',
 ] }
 std_detect = { path = "../std_detect", public = true }

--- a/library/std/src/collections/hash/map.rs
+++ b/library/std/src/collections/hash/map.rs
@@ -1051,7 +1051,7 @@ where
         K: Borrow<Q>,
         Q: Hash + Eq,
     {
-        self.base.get_many_mut(ks)
+        self.base.get_disjoint_mut(ks)
     }
 
     /// Attempts to get mutable references to `N` values in the map at once, without validating that
@@ -1118,7 +1118,7 @@ where
         K: Borrow<Q>,
         Q: Hash + Eq,
     {
-        unsafe { self.base.get_many_unchecked_mut(ks) }
+        unsafe { self.base.get_disjoint_unchecked_mut(ks) }
     }
 
     /// Returns `true` if the map contains a value for the specified key.

--- a/src/tools/tidy/src/deps.rs
+++ b/src/tools/tidy/src/deps.rs
@@ -42,6 +42,7 @@ const LICENSES: &[&str] = &[
     "MIT/Apache-2.0",
     "Unlicense OR MIT",
     "Unlicense/MIT",
+    "Zlib",                                                // foldhash (FIXME: see PERMITTED_STDLIB_DEPENDENCIES)
     // tidy-alphabetical-end
 ];
 
@@ -509,6 +510,7 @@ const PERMITTED_STDLIB_DEPENDENCIES: &[&str] = &[
     "cfg-if",
     "compiler_builtins",
     "dlmalloc",
+    "foldhash", // FIXME: only appears in Cargo.lock due to https://github.com/rust-lang/cargo/issues/10801
     "fortanix-sgx-abi",
     "getopts",
     "gimli",


### PR DESCRIPTION
This is another step toward unspecializing `Copy`.

See also rust-lang/rust#135634 and rust-lang/hashbrown#662

r? @Amanieu 
cc @joboet 
