### PR TITLE
Check for intrinsic to fn ptr casts in unified coercions

### DIFF
--- a/tests/ui/coercion/intrinsic-in-unifying-coercion-149143.rs
+++ b/tests/ui/coercion/intrinsic-in-unifying-coercion-149143.rs
@@ -1,0 +1,25 @@
+// Regression test for #149143.
+// The compiler did not check for a coercion from intrinsics
+// to fn ptrs in all possible code paths that could lead to such a coercion.
+// This caused an ICE during a later sanity check.
+
+use std::mem::transmute;
+
+fn main() {
+    unsafe {
+        let f = if true { transmute } else { safe_transmute };
+        //~^ ERROR `if` and `else` have incompatible type
+
+        let _: i64 = f(5i64);
+    }
+    unsafe {
+        let f = if true { safe_transmute } else { transmute };
+        //~^ ERROR `if` and `else` have incompatible type
+
+        let _: i64 = f(5i64);
+    }
+}
+
+unsafe fn safe_transmute<A, B>(x: A) -> B {
+    panic!()
+}

--- a/tests/ui/coercion/intrinsic-in-unifying-coercion-149143.stderr
+++ b/tests/ui/coercion/intrinsic-in-unifying-coercion-149143.stderr
@@ -1,0 +1,27 @@
+error[E0308]: `if` and `else` have incompatible types
+  --> $DIR/intrinsic-in-unifying-coercion-149143.rs:10:46
+   |
+LL |         let f = if true { transmute } else { safe_transmute };
+   |                           ---------          ^^^^^^^^^^^^^^ cannot coerce intrinsics to function pointers
+   |                           |
+   |                           expected because of this
+   |
+   = note: expected fn item `unsafe fn(_) -> _ {std::intrinsics::transmute::<_, _>}`
+              found fn item `unsafe fn(_) -> _ {safe_transmute::<_, _>}`
+   = note: different fn items have unique types, even if their signatures are the same
+
+error[E0308]: `if` and `else` have incompatible types
+  --> $DIR/intrinsic-in-unifying-coercion-149143.rs:16:51
+   |
+LL |         let f = if true { safe_transmute } else { transmute };
+   |                           --------------          ^^^^^^^^^ cannot coerce intrinsics to function pointers
+   |                           |
+   |                           expected because of this
+   |
+   = note: expected fn item `unsafe fn(_) -> _ {safe_transmute::<_, _>}`
+              found fn item `unsafe fn(_) -> _ {std::intrinsics::transmute::<_, _>}`
+   = note: different fn items have unique types, even if their signatures are the same
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Fixes rust-lang/rust#149143 by ensuring that when coercing multiple expressions to a unified type, the same "intrinsic to fn ptr" check is applied as for other coercions.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
