### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -36,6 +36,7 @@ use tracing::debug;
 
 pub use crate::config::cfg::{Cfg, CheckCfg, ExpectedValues};
 use crate::config::native_libs::parse_native_libs;
+pub use crate::config::print_request::{PrintKind, PrintRequest};
 use crate::errors::FileWriteFail;
 pub use crate::options::*;
 use crate::search_paths::SearchPath;
@@ -45,36 +46,8 @@ use crate::{EarlyDiagCtxt, HashStableContext, Session, filesearch, lint};
 mod cfg;
 mod externs;
 mod native_libs;
+mod print_request;
 pub mod sigpipe;
-
-pub const PRINT_KINDS: &[(&str, PrintKind)] = &[
-    // tidy-alphabetical-start
-    ("all-target-specs-json", PrintKind::AllTargetSpecsJson),
-    ("calling-conventions", PrintKind::CallingConventions),
-    ("cfg", PrintKind::Cfg),
-    ("check-cfg", PrintKind::CheckCfg),
-    ("code-models", PrintKind::CodeModels),
-    ("crate-name", PrintKind::CrateName),
-    ("crate-root-lint-levels", PrintKind::CrateRootLintLevels),
-    ("deployment-target", PrintKind::DeploymentTarget),
-    ("file-names", PrintKind::FileNames),
-    ("host-tuple", PrintKind::HostTuple),
-    ("link-args", PrintKind::LinkArgs),
-    ("native-static-libs", PrintKind::NativeStaticLibs),
-    ("relocation-models", PrintKind::RelocationModels),
-    ("split-debuginfo", PrintKind::SplitDebuginfo),
-    ("stack-protector-strategies", PrintKind::StackProtectorStrategies),
-    ("supported-crate-types", PrintKind::SupportedCrateTypes),
-    ("sysroot", PrintKind::Sysroot),
-    ("target-cpus", PrintKind::TargetCPUs),
-    ("target-features", PrintKind::TargetFeatures),
-    ("target-libdir", PrintKind::TargetLibdir),
-    ("target-list", PrintKind::TargetList),
-    ("target-spec-json", PrintKind::TargetSpecJson),
-    ("target-spec-json-schema", PrintKind::TargetSpecJsonSchema),
-    ("tls-models", PrintKind::TlsModels),
-    // tidy-alphabetical-end
-];
 
 /// The different settings that the `-C strip` flag can have.
 #[derive(Clone, Copy, PartialEq, Hash, Debug)]
@@ -1015,42 +988,6 @@ impl ExternEntry {
     }
 }
 
-#[derive(Clone, PartialEq, Debug)]
-pub struct PrintRequest {
-    pub kind: PrintKind,
-    pub out: OutFileName,
-}
-
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
-pub enum PrintKind {
-    // tidy-alphabetical-start
-    AllTargetSpecsJson,
-    CallingConventions,
-    Cfg,
-    CheckCfg,
-    CodeModels,
-    CrateName,
-    CrateRootLintLevels,
-    DeploymentTarget,
-    FileNames,
-    HostTuple,
-    LinkArgs,
-    NativeStaticLibs,
-    RelocationModels,
-    SplitDebuginfo,
-    StackProtectorStrategies,
-    SupportedCrateTypes,
-    Sysroot,
-    TargetCPUs,
-    TargetFeatures,
-    TargetLibdir,
-    TargetList,
-    TargetSpecJson,
-    TargetSpecJsonSchema,
-    TlsModels,
-    // tidy-alphabetical-end
-}
-
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq, Default)]
 pub struct NextSolverConfig {
     /// Whether the new trait solver should be enabled in coherence.
@@ -1798,14 +1735,6 @@ The default is {DEFAULT_EDITION} and the latest stable edition is {LATEST_STABLE
     )
 });
 
-static PRINT_HELP: LazyLock<String> = LazyLock::new(|| {
-    format!(
-        "Compiler information to print on stdout (or to a file)\n\
-        INFO may be one of <{}>.",
-        PRINT_KINDS.iter().map(|(name, _)| format!("{name}")).collect::<Vec<_>>().join("|")
-    )
-});
-
 static EMIT_HELP: LazyLock<String> = LazyLock::new(|| {
     let mut result =
         String::from("Comma separated list of types of output for the compiler to emit.\n");
@@ -1872,7 +1801,7 @@ pub fn rustc_optgroups() -> Vec<RustcOptGroup> {
         opt(Stable, Opt, "", "crate-name", "Specify the name of the crate being built", "<NAME>"),
         opt(Stable, Opt, "", "edition", &EDITION_STRING, EDITION_NAME_LIST),
         opt(Stable, Multi, "", "emit", &EMIT_HELP, "<TYPE>[=<FILE>]"),
-        opt(Stable, Multi, "", "print", &PRINT_HELP, "<INFO>[=<FILE>]"),
+        opt(Stable, Multi, "", "print", &print_request::PRINT_HELP, "<INFO>[=<FILE>]"),
         opt(Stable, FlagMulti, "g", "", "Equivalent to -C debuginfo=2", ""),
         opt(Stable, FlagMulti, "O", "", "Equivalent to -C opt-level=3", ""),
         opt(Stable, Opt, "o", "", "Write output to FILENAME", "<FILENAME>"),
@@ -2320,108 +2249,6 @@ fn should_override_cgus_and_disable_thinlto(
     (disable_local_thinlto, codegen_units)
 }
 
-fn collect_print_requests(
-    early_dcx: &EarlyDiagCtxt,
-    cg: &mut CodegenOptions,
-    unstable_opts: &UnstableOptions,
-    matches: &getopts::Matches,
-) -> Vec<PrintRequest> {
-    let mut prints = Vec::<PrintRequest>::new();
-    if cg.target_cpu.as_deref() == Some("help") {
-        prints.push(PrintRequest { kind: PrintKind::TargetCPUs, out: OutFileName::Stdout });
-        cg.target_cpu = None;
-    };
-    if cg.target_feature == "help" {
-        prints.push(PrintRequest { kind: PrintKind::TargetFeatures, out: OutFileName::Stdout });
-        cg.target_feature = String::new();
-    }
-
-    // We disallow reusing the same path in multiple prints, such as `--print
-    // cfg=output.txt --print link-args=output.txt`, because outputs are printed
-    // by disparate pieces of the compiler, and keeping track of which files
-    // need to be overwritten vs appended to is annoying.
-    let mut printed_paths = FxHashSet::default();
-
-    prints.extend(matches.opt_strs("print").into_iter().map(|req| {
-        let (req, out) = split_out_file_name(&req);
-
-        let kind = if let Some((print_name, print_kind)) =
-            PRINT_KINDS.iter().find(|&&(name, _)| name == req)
-        {
-            check_print_request_stability(early_dcx, unstable_opts, (print_name, *print_kind));
-            *print_kind
-        } else {
-            let is_nightly = nightly_options::match_is_nightly_build(matches);
-            emit_unknown_print_request_help(early_dcx, req, is_nightly)
-        };
-
-        let out = out.unwrap_or(OutFileName::Stdout);
-        if let OutFileName::Real(path) = &out {
-            if !printed_paths.insert(path.clone()) {
-                early_dcx.early_fatal(format!(
-                    "cannot print multiple outputs to the same path: {}",
-                    path.display(),
-                ));
-            }
-        }
-
-        PrintRequest { kind, out }
-    }));
-
-    prints
-}
-
-fn check_print_request_stability(
-    early_dcx: &EarlyDiagCtxt,
-    unstable_opts: &UnstableOptions,
-    (print_name, print_kind): (&str, PrintKind),
-) {
-    if !is_print_request_stable(print_kind) && !unstable_opts.unstable_options {
-        early_dcx.early_fatal(format!(
-            "the `-Z unstable-options` flag must also be passed to enable the `{print_name}` \
-                print option"
-        ));
-    }
-}
-
-fn is_print_request_stable(print_kind: PrintKind) -> bool {
-    match print_kind {
-        PrintKind::AllTargetSpecsJson
-        | PrintKind::CheckCfg
-        | PrintKind::CrateRootLintLevels
-        | PrintKind::SupportedCrateTypes
-        | PrintKind::TargetSpecJson
-        | PrintKind::TargetSpecJsonSchema => false,
-        _ => true,
-    }
-}
-
-fn emit_unknown_print_request_help(early_dcx: &EarlyDiagCtxt, req: &str, is_nightly: bool) -> ! {
-    let prints = PRINT_KINDS
-        .iter()
-        .filter_map(|(name, kind)| {
-            // If we're not on nightly, we don't want to print unstable options
-            if !is_nightly && !is_print_request_stable(*kind) {
-                None
-            } else {
-                Some(format!("`{name}`"))
-            }
-        })
-        .collect::<Vec<_>>();
-    let prints = prints.join(", ");
-
-    let mut diag = early_dcx.early_struct_fatal(format!("unknown print request: `{req}`"));
-    #[allow(rustc::diagnostic_outside_of_impl)]
-    diag.help(format!("valid print requests are: {prints}"));
-
-    if req == "lints" {
-        diag.help(format!("use `-Whelp` to print a list of lints"));
-    }
-
-    diag.help(format!("for more information, see the rustc book: https://doc.rust-lang.org/rustc/command-line-arguments.html#--print-print-compiler-information"));
-    diag.emit()
-}
-
 pub fn parse_target_triple(early_dcx: &EarlyDiagCtxt, matches: &getopts::Matches) -> TargetTuple {
     match matches.opt_str("target") {
         Some(target) if target.ends_with(".json") => {
@@ -2846,7 +2673,7 @@ pub fn build_session_options(early_dcx: &mut EarlyDiagCtxt, matches: &getopts::M
         ));
     }
 
-    let prints = collect_print_requests(early_dcx, &mut cg, &unstable_opts, matches);
+    let prints = print_request::collect_print_requests(early_dcx, &mut cg, &unstable_opts, matches);
 
     // -Zretpoline-external-thunk also requires -Zretpoline
     if unstable_opts.retpoline_external_thunk {

--- a/compiler/rustc_session/src/config/print_request.rs
+++ b/compiler/rustc_session/src/config/print_request.rs
@@ -1,0 +1,185 @@
+//! Code for dealing with `--print` requests.
+
+use std::sync::LazyLock;
+
+use rustc_data_structures::fx::FxHashSet;
+
+use crate::EarlyDiagCtxt;
+use crate::config::{
+    CodegenOptions, OutFileName, UnstableOptions, nightly_options, split_out_file_name,
+};
+
+const PRINT_KINDS: &[(&str, PrintKind)] = &[
+    // tidy-alphabetical-start
+    ("all-target-specs-json", PrintKind::AllTargetSpecsJson),
+    ("calling-conventions", PrintKind::CallingConventions),
+    ("cfg", PrintKind::Cfg),
+    ("check-cfg", PrintKind::CheckCfg),
+    ("code-models", PrintKind::CodeModels),
+    ("crate-name", PrintKind::CrateName),
+    ("crate-root-lint-levels", PrintKind::CrateRootLintLevels),
+    ("deployment-target", PrintKind::DeploymentTarget),
+    ("file-names", PrintKind::FileNames),
+    ("host-tuple", PrintKind::HostTuple),
+    ("link-args", PrintKind::LinkArgs),
+    ("native-static-libs", PrintKind::NativeStaticLibs),
+    ("relocation-models", PrintKind::RelocationModels),
+    ("split-debuginfo", PrintKind::SplitDebuginfo),
+    ("stack-protector-strategies", PrintKind::StackProtectorStrategies),
+    ("supported-crate-types", PrintKind::SupportedCrateTypes),
+    ("sysroot", PrintKind::Sysroot),
+    ("target-cpus", PrintKind::TargetCPUs),
+    ("target-features", PrintKind::TargetFeatures),
+    ("target-libdir", PrintKind::TargetLibdir),
+    ("target-list", PrintKind::TargetList),
+    ("target-spec-json", PrintKind::TargetSpecJson),
+    ("target-spec-json-schema", PrintKind::TargetSpecJsonSchema),
+    ("tls-models", PrintKind::TlsModels),
+    // tidy-alphabetical-end
+];
+
+#[derive(Clone, PartialEq, Debug)]
+pub struct PrintRequest {
+    pub kind: PrintKind,
+    pub out: OutFileName,
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub enum PrintKind {
+    // tidy-alphabetical-start
+    AllTargetSpecsJson,
+    CallingConventions,
+    Cfg,
+    CheckCfg,
+    CodeModels,
+    CrateName,
+    CrateRootLintLevels,
+    DeploymentTarget,
+    FileNames,
+    HostTuple,
+    LinkArgs,
+    NativeStaticLibs,
+    RelocationModels,
+    SplitDebuginfo,
+    StackProtectorStrategies,
+    SupportedCrateTypes,
+    Sysroot,
+    TargetCPUs,
+    TargetFeatures,
+    TargetLibdir,
+    TargetList,
+    TargetSpecJson,
+    TargetSpecJsonSchema,
+    TlsModels,
+    // tidy-alphabetical-end
+}
+
+pub(crate) static PRINT_HELP: LazyLock<String> = LazyLock::new(|| {
+    format!(
+        "Compiler information to print on stdout (or to a file)\n\
+        INFO may be one of <{}>.",
+        PRINT_KINDS.iter().map(|(name, _)| format!("{name}")).collect::<Vec<_>>().join("|")
+    )
+});
+
+pub(crate) fn collect_print_requests(
+    early_dcx: &EarlyDiagCtxt,
+    cg: &mut CodegenOptions,
+    unstable_opts: &UnstableOptions,
+    matches: &getopts::Matches,
+) -> Vec<PrintRequest> {
+    let mut prints = Vec::<PrintRequest>::new();
+    if cg.target_cpu.as_deref() == Some("help") {
+        prints.push(PrintRequest { kind: PrintKind::TargetCPUs, out: OutFileName::Stdout });
+        cg.target_cpu = None;
+    };
+    if cg.target_feature == "help" {
+        prints.push(PrintRequest { kind: PrintKind::TargetFeatures, out: OutFileName::Stdout });
+        cg.target_feature = String::new();
+    }
+
+    // We disallow reusing the same path in multiple prints, such as `--print
+    // cfg=output.txt --print link-args=output.txt`, because outputs are printed
+    // by disparate pieces of the compiler, and keeping track of which files
+    // need to be overwritten vs appended to is annoying.
+    let mut printed_paths = FxHashSet::default();
+
+    prints.extend(matches.opt_strs("print").into_iter().map(|req| {
+        let (req, out) = split_out_file_name(&req);
+
+        let kind = if let Some((print_name, print_kind)) =
+            PRINT_KINDS.iter().find(|&&(name, _)| name == req)
+        {
+            check_print_request_stability(early_dcx, unstable_opts, (print_name, *print_kind));
+            *print_kind
+        } else {
+            let is_nightly = nightly_options::match_is_nightly_build(matches);
+            emit_unknown_print_request_help(early_dcx, req, is_nightly)
+        };
+
+        let out = out.unwrap_or(OutFileName::Stdout);
+        if let OutFileName::Real(path) = &out {
+            if !printed_paths.insert(path.clone()) {
+                early_dcx.early_fatal(format!(
+                    "cannot print multiple outputs to the same path: {}",
+                    path.display(),
+                ));
+            }
+        }
+
+        PrintRequest { kind, out }
+    }));
+
+    prints
+}
+
+fn check_print_request_stability(
+    early_dcx: &EarlyDiagCtxt,
+    unstable_opts: &UnstableOptions,
+    (print_name, print_kind): (&str, PrintKind),
+) {
+    if !is_print_request_stable(print_kind) && !unstable_opts.unstable_options {
+        early_dcx.early_fatal(format!(
+            "the `-Z unstable-options` flag must also be passed to enable the `{print_name}` \
+                print option"
+        ));
+    }
+}
+
+fn is_print_request_stable(print_kind: PrintKind) -> bool {
+    match print_kind {
+        PrintKind::AllTargetSpecsJson
+        | PrintKind::CheckCfg
+        | PrintKind::CrateRootLintLevels
+        | PrintKind::SupportedCrateTypes
+        | PrintKind::TargetSpecJson
+        | PrintKind::TargetSpecJsonSchema => false,
+        _ => true,
+    }
+}
+
+fn emit_unknown_print_request_help(early_dcx: &EarlyDiagCtxt, req: &str, is_nightly: bool) -> ! {
+    let prints = PRINT_KINDS
+        .iter()
+        .filter_map(|(name, kind)| {
+            // If we're not on nightly, we don't want to print unstable options
+            if !is_nightly && !is_print_request_stable(*kind) {
+                None
+            } else {
+                Some(format!("`{name}`"))
+            }
+        })
+        .collect::<Vec<_>>();
+    let prints = prints.join(", ");
+
+    let mut diag = early_dcx.early_struct_fatal(format!("unknown print request: `{req}`"));
+    #[allow(rustc::diagnostic_outside_of_impl)]
+    diag.help(format!("valid print requests are: {prints}"));
+
+    if req == "lints" {
+        diag.help(format!("use `-Whelp` to print a list of lints"));
+    }
+
+    diag.help(format!("for more information, see the rustc book: https://doc.rust-lang.org/rustc/command-line-arguments.html#--print-print-compiler-information"));
+    diag.emit()
+}

--- a/compiler/rustc_session/src/lib.rs
+++ b/compiler/rustc_session/src/lib.rs
@@ -2,6 +2,7 @@
 #![allow(internal_features)]
 #![feature(default_field_values)]
 #![feature(iter_intersperse)]
+#![feature(macro_derive)]
 #![feature(rustc_attrs)]
 // To generate CodegenOptionsTargetModifiers and UnstableOptionsTargetModifiers enums
 // with macro_rules, it is necessary to use recursive mechanic ("Incremental TT Munchers").
@@ -20,6 +21,7 @@ pub mod code_stats;
 pub mod config;
 pub mod cstore;
 pub mod filesearch;
+mod macros;
 mod options;
 pub mod search_paths;
 

--- a/compiler/rustc_session/src/macros.rs
+++ b/compiler/rustc_session/src/macros.rs
@@ -1,0 +1,27 @@
+/// Derivable trait for enums with no fields (i.e. C-style enums) that want to
+/// allow iteration over a list of all variant values.
+pub(crate) trait AllVariants: Copy + 'static {
+    const ALL_VARIANTS: &[Self];
+}
+
+macro_rules! AllVariantsDerive {
+    derive() (
+        $(#[$meta:meta])*
+        $vis:vis enum $Type:ident {
+            $(
+                $(#[$varmeta:meta])*
+                $Variant:ident $( = $value:literal )?
+            ), *$(,)?
+        }
+    ) => {
+        impl $crate::macros::AllVariants for $Type {
+            const ALL_VARIANTS: &[$Type] = &[
+                $( $Type::$Variant, )*
+            ];
+        }
+    };
+}
+
+// For some reason the compiler won't allow `pub(crate) use AllVariants` due
+// to a conflict with the trait of the same name, but will allow this form.
+pub(crate) use AllVariantsDerive as AllVariants;

--- a/library/core/src/iter/adapters/array_chunks.rs
+++ b/library/core/src/iter/adapters/array_chunks.rs
@@ -40,17 +40,17 @@ where
     /// # // Also serves as a regression test for https://github.com/rust-lang/rust/issues/123333
     /// # #![feature(iter_array_chunks)]
     /// let x = [1,2,3,4,5].into_iter().array_chunks::<2>();
-    /// let mut rem = x.into_remainder().unwrap();
+    /// let mut rem = x.into_remainder();
     /// assert_eq!(rem.next(), Some(5));
     /// assert_eq!(rem.next(), None);
     /// ```
     #[unstable(feature = "iter_array_chunks", reason = "recently added", issue = "100450")]
     #[inline]
-    pub fn into_remainder(mut self) -> Option<array::IntoIter<I::Item, N>> {
+    pub fn into_remainder(mut self) -> array::IntoIter<I::Item, N> {
         if self.remainder.is_none() {
             while let Some(_) = self.next() {}
         }
-        self.remainder
+        self.remainder.unwrap_or_default()
     }
 }
 

--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -3523,7 +3523,7 @@ pub trait Iterator {
     /// assert_eq!(iter.next(), Some(['l', 'o']));
     /// assert_eq!(iter.next(), Some(['r', 'e']));
     /// assert_eq!(iter.next(), None);
-    /// assert_eq!(iter.into_remainder().unwrap().as_slice(), &['m']);
+    /// assert_eq!(iter.into_remainder().as_slice(), &['m']);
     /// ```
     ///
     /// ```

--- a/library/core/src/ops/try_trait.rs
+++ b/library/core/src/ops/try_trait.rs
@@ -371,11 +371,14 @@ pub const trait Residual<O>: Sized {
 /// but importantly not on the contextual type the way it would be if
 /// we called `<_ as FromResidual>::from_residual(r)` directly.
 #[unstable(feature = "try_trait_v2_residual", issue = "91285")]
+#[rustc_const_unstable(feature = "const_try_residual", issue = "91285")]
 // needs to be `pub` to avoid `private type` errors
 #[expect(unreachable_pub)]
 #[inline] // FIXME: force would be nice, but fails -- see #148915
 #[lang = "into_try_type"]
-pub fn residual_into_try_type<R: Residual<O>, O>(r: R) -> <R as Residual<O>>::TryType {
+pub const fn residual_into_try_type<R: [const] Residual<O>, O>(
+    r: R,
+) -> <R as Residual<O>>::TryType {
     FromResidual::from_residual(r)
 }
 

--- a/library/coretests/tests/iter/adapters/array_chunks.rs
+++ b/library/coretests/tests/iter/adapters/array_chunks.rs
@@ -18,10 +18,10 @@ fn test_iterator_array_chunks_clone_and_drop() {
     assert_eq!(count.get(), 3);
     let mut it2 = it.clone();
     assert_eq!(count.get(), 3);
-    assert_eq!(it.into_remainder().unwrap().len(), 2);
+    assert_eq!(it.into_remainder().len(), 2);
     assert_eq!(count.get(), 5);
     assert!(it2.next().is_none());
-    assert_eq!(it2.into_remainder().unwrap().len(), 2);
+    assert_eq!(it2.into_remainder().len(), 2);
     assert_eq!(count.get(), 7);
 }
 
@@ -31,7 +31,7 @@ fn test_iterator_array_chunks_remainder() {
     assert_eq!(it.next(), Some([0, 1, 2, 3]));
     assert_eq!(it.next(), Some([4, 5, 6, 7]));
     assert_eq!(it.next(), None);
-    assert_eq!(it.into_remainder().unwrap().as_slice(), &[8, 9, 10]);
+    assert_eq!(it.into_remainder().as_slice(), &[8, 9, 10]);
 }
 
 #[test]
@@ -89,7 +89,7 @@ fn test_iterator_array_chunks_next_and_next_back() {
     assert_eq!(it.next(), None);
     assert_eq!(it.next_back(), None);
     assert_eq!(it.next(), None);
-    assert_eq!(it.into_remainder().unwrap().as_slice(), &[9, 10]);
+    assert_eq!(it.into_remainder().as_slice(), &[9, 10]);
 }
 
 #[test]
@@ -102,7 +102,7 @@ fn test_iterator_array_chunks_rev_remainder() {
         assert_eq!(it.next(), None);
         assert_eq!(it.next(), None);
     }
-    assert_eq!(it.into_remainder().unwrap().as_slice(), &[8, 9, 10]);
+    assert_eq!(it.into_remainder().as_slice(), &[8, 9, 10]);
 }
 
 #[test]

--- a/library/std/src/sys/net/connection/uefi/mod.rs
+++ b/library/std/src/sys/net/connection/uefi/mod.rs
@@ -69,12 +69,11 @@ impl TcpStream {
     }
 
     pub fn read_vectored(&self, buf: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
-        // FIXME: UEFI does support vectored read, so implement that.
-        crate::io::default_read_vectored(|b| self.read(b), buf)
+        self.inner.read_vectored(buf, self.read_timeout()?)
     }
 
     pub fn is_read_vectored(&self) -> bool {
-        false
+        true
     }
 
     pub fn write(&self, buf: &[u8]) -> io::Result<usize> {

--- a/library/std/src/sys/net/connection/uefi/tcp.rs
+++ b/library/std/src/sys/net/connection/uefi/tcp.rs
@@ -1,5 +1,5 @@
 use super::tcp4;
-use crate::io::{self, IoSlice};
+use crate::io::{self, IoSlice, IoSliceMut};
 use crate::net::SocketAddr;
 use crate::ptr::NonNull;
 use crate::sys::{helpers, unsupported};
@@ -41,6 +41,16 @@ impl Tcp {
     pub(crate) fn read(&self, buf: &mut [u8], timeout: Option<Duration>) -> io::Result<usize> {
         match self {
             Self::V4(client) => client.read(buf, timeout),
+        }
+    }
+
+    pub(crate) fn read_vectored(
+        &self,
+        buf: &mut [IoSliceMut<'_>],
+        timeout: Option<Duration>,
+    ) -> io::Result<usize> {
+        match self {
+            Self::V4(client) => client.read_vectored(buf, timeout),
         }
     }
 

--- a/tests/ui/coercion/intrinsic-in-unifying-coercion-149143.rs
+++ b/tests/ui/coercion/intrinsic-in-unifying-coercion-149143.rs
@@ -1,0 +1,25 @@
+// Regression test for #149143.
+// The compiler did not check for a coercion from intrinsics
+// to fn ptrs in all possible code paths that could lead to such a coercion.
+// This caused an ICE during a later sanity check.
+
+use std::mem::transmute;
+
+fn main() {
+    unsafe {
+        let f = if true { transmute } else { safe_transmute };
+        //~^ ERROR `if` and `else` have incompatible type
+
+        let _: i64 = f(5i64);
+    }
+    unsafe {
+        let f = if true { safe_transmute } else { transmute };
+        //~^ ERROR `if` and `else` have incompatible type
+
+        let _: i64 = f(5i64);
+    }
+}
+
+unsafe fn safe_transmute<A, B>(x: A) -> B {
+    panic!()
+}

--- a/tests/ui/coercion/intrinsic-in-unifying-coercion-149143.stderr
+++ b/tests/ui/coercion/intrinsic-in-unifying-coercion-149143.stderr
@@ -1,0 +1,27 @@
+error[E0308]: `if` and `else` have incompatible types
+  --> $DIR/intrinsic-in-unifying-coercion-149143.rs:10:46
+   |
+LL |         let f = if true { transmute } else { safe_transmute };
+   |                           ---------          ^^^^^^^^^^^^^^ cannot coerce intrinsics to function pointers
+   |                           |
+   |                           expected because of this
+   |
+   = note: expected fn item `unsafe fn(_) -> _ {std::intrinsics::transmute::<_, _>}`
+              found fn item `unsafe fn(_) -> _ {safe_transmute::<_, _>}`
+   = note: different fn items have unique types, even if their signatures are the same
+
+error[E0308]: `if` and `else` have incompatible types
+  --> $DIR/intrinsic-in-unifying-coercion-149143.rs:16:51
+   |
+LL |         let f = if true { safe_transmute } else { transmute };
+   |                           --------------          ^^^^^^^^^ cannot coerce intrinsics to function pointers
+   |                           |
+   |                           expected because of this
+   |
+   = note: expected fn item `unsafe fn(_) -> _ {safe_transmute::<_, _>}`
+              found fn item `unsafe fn(_) -> _ {std::intrinsics::transmute::<_, _>}`
+   = note: different fn items have unique types, even if their signatures are the same
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#148990 (Exhaustively specify names and stability of `--print` values)
 - rust-lang/rust#149127 (unwrap ret ty of `iter::ArrayChunks::into_remainder` )
 - rust-lang/rust#149134 (std: sys: net: uefi: Implement read_vectored)
 - rust-lang/rust#149135 (Constify `residual_into_try_type`)
 - rust-lang/rust#149160 (Check for intrinsic to fn ptr casts in unified coercions)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=148990,149127,149134,149135,149160)
<!-- homu-ignore:end -->