### PR TITLE
skip checking supertraits in object candidate for `NormalizesTo` goal

### DIFF
--- a/compiler/rustc_next_trait_solver/src/solve/assembly/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/assembly/mod.rs
@@ -74,6 +74,8 @@ where
     /// Consider a clause specifically for a `dyn Trait` self type. This requires
     /// additionally checking all of the supertraits and object bounds to hold,
     /// since they're not implied by the well-formedness of the object type.
+    /// `NormalizesTo` overrides this to not check the supertraits for backwards
+    /// compatibility with the old solver. cc trait-system-refactor-initiative#245.
     fn probe_and_consider_object_bound_candidate(
         ecx: &mut EvalCtxt<'_, D>,
         source: CandidateSource<I>,

--- a/compiler/rustc_next_trait_solver/src/solve/normalizes_to/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/normalizes_to/mod.rs
@@ -184,6 +184,20 @@ where
         then(ecx)
     }
 
+    // Hack for trait-system-refactor-initiative#245.
+    // FIXME(-Zhigher-ranked-assumptions): this impl differs from trait goals and we should unify
+    // them again once we properly support binders.
+    fn probe_and_consider_object_bound_candidate(
+        ecx: &mut EvalCtxt<'_, D>,
+        source: CandidateSource<I>,
+        goal: Goal<I, Self>,
+        assumption: I::Clause,
+    ) -> Result<Candidate<I>, NoSolution> {
+        Self::probe_and_match_goal_against_assumption(ecx, source, goal, assumption, |ecx| {
+            ecx.evaluate_added_goals_and_make_canonical_response(Certainty::Yes)
+        })
+    }
+
     fn consider_additional_alias_assumptions(
         _ecx: &mut EvalCtxt<'_, D>,
         _goal: Goal<I, Self>,

--- a/tests/ui/traits/next-solver/normalize/skip-supertraits-in-object-candidate.rs
+++ b/tests/ui/traits/next-solver/normalize/skip-supertraits-in-object-candidate.rs
@@ -1,0 +1,39 @@
+//@ check-pass
+//@ compile-flags: -Znext-solver
+//@ edition: 2024
+
+// A regression test for trait-system-refactor-initiative#245.
+// The old solver doesn't check the supertraits of the principal trait
+// when considering object candidate for normalization.
+// And the new solver previously did, resulting in a placeholder error
+// while normalizing inside of a generator witness.
+
+trait AsyncFn: Send + 'static {
+    type Fut: Future<Output = ()> + Send;
+
+    fn call(&self) -> Self::Fut;
+}
+
+type BoxFuture<'a, T> = std::pin::Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+type DynAsyncFnBoxed = dyn AsyncFn<Fut = BoxFuture<'static, ()>>;
+
+fn wrap_call<P: AsyncFn + ?Sized>(func: Box<P>) -> impl Future<Output = ()> {
+    func.call()
+}
+
+fn get_boxed_fn() -> Box<DynAsyncFnBoxed> {
+    todo!()
+}
+
+async fn cursed_fut() {
+    wrap_call(get_boxed_fn()).await;
+}
+
+fn observe_fut_not_send() {
+    fn assert_send<T: Send>(t: T) -> T {
+        t
+    }
+    assert_send(cursed_fut());
+}
+
+fn main() {}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/trait-system-refactor-initiative/issues/245.
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
r? @lcnr 