### PR TITLE
Fix ICE when collecting opaques from trait method declarations

### DIFF
--- a/compiler/rustc_ty_utils/src/opaque_types.rs
+++ b/compiler/rustc_ty_utils/src/opaque_types.rs
@@ -64,7 +64,10 @@ impl<'tcx> OpaqueTypeCollector<'tcx> {
 
     #[instrument(level = "trace", skip(self))]
     fn collect_taits_declared_in_body(&mut self) {
-        let body = self.tcx.hir_body_owned_by(self.item).value;
+        let Some(body) = self.tcx.hir_maybe_body_owned_by(self.item) else {
+            return;
+        };
+        let body = body.value;
         struct TaitInBodyFinder<'a, 'tcx> {
             collector: &'a mut OpaqueTypeCollector<'tcx>,
         }

--- a/tests/ui/impl-trait/ice-148622-opaque-as-const-generics.rs
+++ b/tests/ui/impl-trait/ice-148622-opaque-as-const-generics.rs
@@ -1,0 +1,12 @@
+#![feature(type_alias_impl_trait)]
+
+pub type Opaque = impl std::future::Future;
+//~^ ERROR: unconstrained opaque type
+
+trait Foo<const N: Opaque> {
+    //~^ ERROR: `Opaque` is forbidden as the type of a const generic parameter
+    fn bar(&self) -> [u8; N];
+    //~^ ERROR: the constant `N` is not of type `usize`
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/ice-148622-opaque-as-const-generics.stderr
+++ b/tests/ui/impl-trait/ice-148622-opaque-as-const-generics.stderr
@@ -1,0 +1,31 @@
+error: `Opaque` is forbidden as the type of a const generic parameter
+  --> $DIR/ice-148622-opaque-as-const-generics.rs:6:20
+   |
+LL | trait Foo<const N: Opaque> {
+   |                    ^^^^^^
+   |
+   = note: the only supported types are integers, `bool`, and `char`
+
+error: the constant `N` is not of type `usize`
+  --> $DIR/ice-148622-opaque-as-const-generics.rs:8:22
+   |
+LL |     fn bar(&self) -> [u8; N];
+   |                      ^^^^^^^ expected `usize`, found future
+   |
+note: this item must have a `#[define_opaque(Opaque)]` attribute to be able to define hidden types
+  --> $DIR/ice-148622-opaque-as-const-generics.rs:8:8
+   |
+LL |     fn bar(&self) -> [u8; N];
+   |        ^^^
+   = note: the length of array `[u8; N]` must be type `usize`
+
+error: unconstrained opaque type
+  --> $DIR/ice-148622-opaque-as-const-generics.rs:3:19
+   |
+LL | pub type Opaque = impl std::future::Future;
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `Opaque` must be used in combination with a concrete type within the same crate
+
+error: aborting due to 3 previous errors
+


### PR DESCRIPTION
fixes rust-lang/rust#148622

When using an `opaque` type as a `const` generic parameter, the compiler would attempt to collect TAIT from trait method declarations, causing an ICE by panicking in `hir_body_owned_by`.