### PR TITLE
Add proper suggestion for associated function with unknown field

### DIFF
--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -3369,6 +3369,40 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             err.span_label(within_macro_span, "due to this macro variable");
         }
 
+        // Check if there is an associated function with the same name.
+        if let Some(def_id) = base_ty.peel_refs().ty_adt_def().map(|d| d.did()) {
+            for impl_def_id in self.tcx.inherent_impls(def_id) {
+                for item in self.tcx.associated_items(impl_def_id).in_definition_order() {
+                    if let ExprKind::Field(base_expr, _) = expr.kind
+                        && item.name() == field.name
+                        && matches!(item.kind, ty::AssocKind::Fn { has_self: false, .. })
+                    {
+                        err.span_label(field.span, "this is an associated function, not a method");
+                        err.note("found the following associated function; to be used as method, it must have a `self` parameter");
+                        let impl_ty = self.tcx.type_of(impl_def_id).instantiate_identity();
+                        err.span_note(
+                            self.tcx.def_span(item.def_id),
+                            format!("the candidate is defined in an impl for the type `{impl_ty}`"),
+                        );
+
+                        let ty_str = match base_ty.peel_refs().kind() {
+                            ty::Adt(def, args) => self.tcx.def_path_str_with_args(def.did(), args),
+                            _ => base_ty.peel_refs().to_string(),
+                        };
+                        err.multipart_suggestion(
+                            "use associated function syntax instead",
+                            vec![
+                                (base_expr.span, ty_str),
+                                (base_expr.span.between(field.span), "::".to_string()),
+                            ],
+                            Applicability::MaybeIncorrect,
+                        );
+                        return err;
+                    }
+                }
+            }
+        }
+
         // try to add a suggestion in case the field is a nested field of a field of the Adt
         let mod_id = self.tcx.parent_module(expr.hir_id).to_def_id();
         let (ty, unwrap) = if let ty::Adt(def, args) = base_ty.kind()

--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -2339,7 +2339,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 applicability = Applicability::HasPlaceholders;
                 "(...)".to_owned()
             };
-            err.span_suggestion(
+            err.span_suggestion_verbose(
                 sugg_span,
                 "use associated function syntax instead",
                 format!("{ty_str}::{item_name}{args}"),

--- a/tests/ui/issues/issue-4265.stderr
+++ b/tests/ui/issues/issue-4265.stderr
@@ -14,10 +14,7 @@ LL | struct Foo {
    | ---------- method `bar` not found for this struct
 ...
 LL |         Foo { baz: 0 }.bar();
-   |         ---------------^^^--
-   |         |              |
-   |         |              this is an associated function, not a method
-   |         help: use associated function syntax instead: `Foo::bar()`
+   |                        ^^^ this is an associated function, not a method
    |
    = note: found the following associated functions; to be used as methods, functions must have a `self` parameter
 note: the candidate is defined in an impl for the type `Foo`
@@ -25,6 +22,11 @@ note: the candidate is defined in an impl for the type `Foo`
    |
 LL |     fn bar() {
    |     ^^^^^^^^
+help: use associated function syntax instead
+   |
+LL -         Foo { baz: 0 }.bar();
+LL +         Foo::bar();
+   |
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/methods/assc-func-issue-149038.rs
+++ b/tests/ui/methods/assc-func-issue-149038.rs
@@ -1,0 +1,10 @@
+struct S;
+impl S {
+    fn foo() {}
+    fn bar(&self) {
+        self.foo(); //~ ERROR no method named `foo` found for reference `&S` in the current scope
+        let f: fn() = self.foo; //~ ERROR no field `foo` on type `&S`
+    }
+}
+
+fn main() {}

--- a/tests/ui/methods/assc-func-issue-149038.stderr
+++ b/tests/ui/methods/assc-func-issue-149038.stderr
@@ -1,0 +1,43 @@
+error[E0599]: no method named `foo` found for reference `&S` in the current scope
+  --> $DIR/assc-func-issue-149038.rs:5:14
+   |
+LL |         self.foo();
+   |              ^^^ this is an associated function, not a method
+   |
+   = note: found the following associated functions; to be used as methods, functions must have a `self` parameter
+note: the candidate is defined in an impl for the type `S`
+  --> $DIR/assc-func-issue-149038.rs:3:5
+   |
+LL |     fn foo() {}
+   |     ^^^^^^^^
+help: use associated function syntax instead
+   |
+LL -         self.foo();
+LL +         S::foo();
+   |
+
+error[E0609]: no field `foo` on type `&S`
+  --> $DIR/assc-func-issue-149038.rs:6:28
+   |
+LL |         let f: fn() = self.foo;
+   |                            ^^^
+   |                            |
+   |                            this is an associated function, not a method
+   |                            unknown field
+   |
+   = note: found the following associated function; to be used as method, it must have a `self` parameter
+note: the candidate is defined in an impl for the type `S`
+  --> $DIR/assc-func-issue-149038.rs:3:5
+   |
+LL |     fn foo() {}
+   |     ^^^^^^^^
+help: use associated function syntax instead
+   |
+LL -         let f: fn() = self.foo;
+LL +         let f: fn() = S::foo;
+   |
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0599, E0609.
+For more information about an error, try `rustc --explain E0599`.

--- a/tests/ui/methods/issue-3707.stderr
+++ b/tests/ui/methods/issue-3707.stderr
@@ -2,10 +2,7 @@ error[E0599]: no method named `boom` found for reference `&Obj` in the current s
   --> $DIR/issue-3707.rs:10:14
    |
 LL |         self.boom();
-   |         -----^^^^--
-   |         |    |
-   |         |    this is an associated function, not a method
-   |         help: use associated function syntax instead: `Obj::boom()`
+   |              ^^^^ this is an associated function, not a method
    |
    = note: found the following associated functions; to be used as methods, functions must have a `self` parameter
 note: the candidate is defined in an impl for the type `Obj`
@@ -13,6 +10,11 @@ note: the candidate is defined in an impl for the type `Obj`
    |
 LL |     pub fn boom() -> bool {
    |     ^^^^^^^^^^^^^^^^^^^^^
+help: use associated function syntax instead
+   |
+LL -         self.boom();
+LL +         Obj::boom();
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/suggestions/issue-102354.stderr
+++ b/tests/ui/suggestions/issue-102354.stderr
@@ -2,10 +2,7 @@ error[E0599]: no method named `func` found for type `i32` in the current scope
   --> $DIR/issue-102354.rs:9:7
    |
 LL |     x.func();
-   |     --^^^^--
-   |     | |
-   |     | this is an associated function, not a method
-   |     help: use associated function syntax instead: `i32::func()`
+   |       ^^^^ this is an associated function, not a method
    |
    = note: found the following associated functions; to be used as methods, functions must have a `self` parameter
 note: the candidate is defined in the trait `Trait`
@@ -13,6 +10,11 @@ note: the candidate is defined in the trait `Trait`
    |
 LL |     fn func() {}
    |     ^^^^^^^^^
+help: use associated function syntax instead
+   |
+LL -     x.func();
+LL +     i32::func();
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/suggestions/issue-103646.stderr
+++ b/tests/ui/suggestions/issue-103646.stderr
@@ -4,10 +4,7 @@ error[E0599]: no method named `nya` found for type parameter `T` in the current 
 LL | fn uwu<T: Cat>(c: T) {
    |        - method `nya` not found for this type parameter
 LL |     c.nya();
-   |     --^^^--
-   |     | |
-   |     | this is an associated function, not a method
-   |     help: use associated function syntax instead: `T::nya()`
+   |       ^^^ this is an associated function, not a method
    |
    = note: found the following associated functions; to be used as methods, functions must have a `self` parameter
 note: the candidate is defined in the trait `Cat`
@@ -15,6 +12,11 @@ note: the candidate is defined in the trait `Cat`
    |
 LL |     fn nya() {}
    |     ^^^^^^^^
+help: use associated function syntax instead
+   |
+LL -     c.nya();
+LL +     T::nya();
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/suggestions/suggest-assoc-fn-call-deref.stderr
+++ b/tests/ui/suggestions/suggest-assoc-fn-call-deref.stderr
@@ -2,10 +2,7 @@ error[E0599]: no method named `test` found for struct `Box<Foo<i32>>` in the cur
   --> $DIR/suggest-assoc-fn-call-deref.rs:13:7
    |
 LL |     x.test();
-   |     --^^^^--
-   |     | |
-   |     | this is an associated function, not a method
-   |     help: use associated function syntax instead: `Foo::<i32>::test()`
+   |       ^^^^ this is an associated function, not a method
    |
    = note: found the following associated functions; to be used as methods, functions must have a `self` parameter
 note: the candidate is defined in an impl for the type `Foo<T>`
@@ -13,6 +10,11 @@ note: the candidate is defined in an impl for the type `Foo<T>`
    |
 LL |     fn test() -> i32 { 1 }
    |     ^^^^^^^^^^^^^^^^
+help: use associated function syntax instead
+   |
+LL -     x.test();
+LL +     Foo::<i32>::test();
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/suggestions/suggest-assoc-fn-call-for-impl-trait.stderr
+++ b/tests/ui/suggestions/suggest-assoc-fn-call-for-impl-trait.stderr
@@ -5,10 +5,7 @@ LL | struct A {
    | -------- method `foo` not found for this struct
 ...
 LL |     _a.foo();
-   |     ---^^^--
-   |     |  |
-   |     |  this is an associated function, not a method
-   |     help: use associated function syntax instead: `A::foo(_a)`
+   |        ^^^ this is an associated function, not a method
    |
    = note: found the following associated functions; to be used as methods, functions must have a `self` parameter
 note: the candidate is defined in the trait `M`
@@ -16,6 +13,11 @@ note: the candidate is defined in the trait `M`
    |
 LL |     fn foo(_a: Self);
    |     ^^^^^^^^^^^^^^^^^
+help: use associated function syntax instead
+   |
+LL -     _a.foo();
+LL +     A::foo(_a);
+   |
 
 error[E0599]: no method named `baz` found for struct `A` in the current scope
   --> $DIR/suggest-assoc-fn-call-for-impl-trait.rs:23:8
@@ -24,10 +26,7 @@ LL | struct A {
    | -------- method `baz` not found for this struct
 ...
 LL |     _a.baz(0);
-   |     ---^^^---
-   |     |  |
-   |     |  this is an associated function, not a method
-   |     help: use associated function syntax instead: `A::baz(0)`
+   |        ^^^ this is an associated function, not a method
    |
    = note: found the following associated functions; to be used as methods, functions must have a `self` parameter
 note: the candidate is defined in the trait `M`
@@ -35,6 +34,11 @@ note: the candidate is defined in the trait `M`
    |
 LL |     fn baz(_a: i32);
    |     ^^^^^^^^^^^^^^^^
+help: use associated function syntax instead
+   |
+LL -     _a.baz(0);
+LL +     A::baz(0);
+   |
 
 error[E0599]: no method named `bar` found for struct `A` in the current scope
   --> $DIR/suggest-assoc-fn-call-for-impl-trait.rs:27:8
@@ -43,10 +47,7 @@ LL | struct A {
    | -------- method `bar` not found for this struct
 ...
 LL |     _b.bar();
-   |     ---^^^--
-   |     |  |
-   |     |  this is an associated function, not a method
-   |     help: use associated function syntax instead: `A::bar(_b)`
+   |        ^^^ this is an associated function, not a method
    |
    = note: found the following associated functions; to be used as methods, functions must have a `self` parameter
 note: the candidate is defined in the trait `M`
@@ -54,6 +55,11 @@ note: the candidate is defined in the trait `M`
    |
 LL |     fn bar(_a: Self);
    |     ^^^^^^^^^^^^^^^^^
+help: use associated function syntax instead
+   |
+LL -     _b.bar();
+LL +     A::bar(_b);
+   |
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/suggestions/suggest-assoc-fn-call-with-turbofish-placeholder.stderr
+++ b/tests/ui/suggestions/suggest-assoc-fn-call-with-turbofish-placeholder.stderr
@@ -5,10 +5,7 @@ LL | struct GenericAssocMethod<T>(T);
    | ---------------------------- method `default_hello` not found for this struct
 ...
 LL |     x.default_hello();
-   |     --^^^^^^^^^^^^^--
-   |     | |
-   |     | this is an associated function, not a method
-   |     help: use associated function syntax instead: `GenericAssocMethod::<_>::default_hello()`
+   |       ^^^^^^^^^^^^^ this is an associated function, not a method
    |
    = note: found the following associated functions; to be used as methods, functions must have a `self` parameter
 note: the candidate is defined in an impl for the type `GenericAssocMethod<T>`
@@ -16,6 +13,11 @@ note: the candidate is defined in an impl for the type `GenericAssocMethod<T>`
    |
 LL |     fn default_hello() {}
    |     ^^^^^^^^^^^^^^^^^^
+help: use associated function syntax instead
+   |
+LL -     x.default_hello();
+LL +     GenericAssocMethod::<_>::default_hello();
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/suggestions/suggest-assoc-fn-call-with-turbofish-through-deref.stderr
+++ b/tests/ui/suggestions/suggest-assoc-fn-call-with-turbofish-through-deref.stderr
@@ -2,10 +2,7 @@ error[E0599]: no method named `hello` found for struct `RefMut<'_, HasAssocMetho
   --> $DIR/suggest-assoc-fn-call-with-turbofish-through-deref.rs:11:11
    |
 LL |     state.hello();
-   |     ------^^^^^--
-   |     |     |
-   |     |     this is an associated function, not a method
-   |     help: use associated function syntax instead: `HasAssocMethod::hello()`
+   |           ^^^^^ this is an associated function, not a method
    |
    = note: found the following associated functions; to be used as methods, functions must have a `self` parameter
 note: the candidate is defined in an impl for the type `HasAssocMethod`
@@ -13,6 +10,11 @@ note: the candidate is defined in an impl for the type `HasAssocMethod`
    |
 LL |     fn hello() {}
    |     ^^^^^^^^^^
+help: use associated function syntax instead
+   |
+LL -     state.hello();
+LL +     HasAssocMethod::hello();
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/suggestions/suggest-assoc-fn-call-with-turbofish.stderr
+++ b/tests/ui/suggestions/suggest-assoc-fn-call-with-turbofish.stderr
@@ -5,10 +5,7 @@ LL | struct GenericAssocMethod<T>(T);
    | ---------------------------- method `self_ty_ref_hello` not found for this struct
 ...
 LL |     x.self_ty_ref_hello();
-   |     --^^^^^^^^^^^^^^^^^--
-   |     | |
-   |     | this is an associated function, not a method
-   |     help: use associated function syntax instead: `GenericAssocMethod::<_>::self_ty_ref_hello(&x)`
+   |       ^^^^^^^^^^^^^^^^^ this is an associated function, not a method
    |
    = note: found the following associated functions; to be used as methods, functions must have a `self` parameter
 note: the candidate is defined in an impl for the type `GenericAssocMethod<T>`
@@ -16,6 +13,11 @@ note: the candidate is defined in an impl for the type `GenericAssocMethod<T>`
    |
 LL |     fn self_ty_ref_hello(_: &Self) {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: use associated function syntax instead
+   |
+LL -     x.self_ty_ref_hello();
+LL +     GenericAssocMethod::<_>::self_ty_ref_hello(&x);
+   |
 
 error[E0599]: no method named `self_ty_hello` found for struct `GenericAssocMethod<{integer}>` in the current scope
   --> $DIR/suggest-assoc-fn-call-with-turbofish.rs:16:7
@@ -24,10 +26,7 @@ LL | struct GenericAssocMethod<T>(T);
    | ---------------------------- method `self_ty_hello` not found for this struct
 ...
 LL |     x.self_ty_hello();
-   |     --^^^^^^^^^^^^^--
-   |     | |
-   |     | this is an associated function, not a method
-   |     help: use associated function syntax instead: `GenericAssocMethod::<_>::self_ty_hello(x)`
+   |       ^^^^^^^^^^^^^ this is an associated function, not a method
    |
    = note: found the following associated functions; to be used as methods, functions must have a `self` parameter
 note: the candidate is defined in an impl for the type `GenericAssocMethod<T>`
@@ -35,6 +34,11 @@ note: the candidate is defined in an impl for the type `GenericAssocMethod<T>`
    |
 LL |     fn self_ty_hello(_: Self) {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+help: use associated function syntax instead
+   |
+LL -     x.self_ty_hello();
+LL +     GenericAssocMethod::<_>::self_ty_hello(x);
+   |
 
 error[E0599]: no method named `default_hello` found for struct `GenericAssocMethod<i32>` in the current scope
   --> $DIR/suggest-assoc-fn-call-with-turbofish.rs:20:7
@@ -43,10 +47,7 @@ LL | struct GenericAssocMethod<T>(T);
    | ---------------------------- method `default_hello` not found for this struct
 ...
 LL |     y.default_hello();
-   |     --^^^^^^^^^^^^^--
-   |     | |
-   |     | this is an associated function, not a method
-   |     help: use associated function syntax instead: `GenericAssocMethod::<i32>::default_hello()`
+   |       ^^^^^^^^^^^^^ this is an associated function, not a method
    |
    = note: found the following associated functions; to be used as methods, functions must have a `self` parameter
 note: the candidate is defined in an impl for the type `GenericAssocMethod<T>`
@@ -54,6 +55,11 @@ note: the candidate is defined in an impl for the type `GenericAssocMethod<T>`
    |
 LL |     fn default_hello() {}
    |     ^^^^^^^^^^^^^^^^^^
+help: use associated function syntax instead
+   |
+LL -     y.default_hello();
+LL +     GenericAssocMethod::<i32>::default_hello();
+   |
 
 error[E0599]: no method named `self_ty_ref_hello` found for struct `GenericAssocMethod<i32>` in the current scope
   --> $DIR/suggest-assoc-fn-call-with-turbofish.rs:22:7
@@ -62,10 +68,7 @@ LL | struct GenericAssocMethod<T>(T);
    | ---------------------------- method `self_ty_ref_hello` not found for this struct
 ...
 LL |     y.self_ty_ref_hello();
-   |     --^^^^^^^^^^^^^^^^^--
-   |     | |
-   |     | this is an associated function, not a method
-   |     help: use associated function syntax instead: `GenericAssocMethod::<i32>::self_ty_ref_hello(&y)`
+   |       ^^^^^^^^^^^^^^^^^ this is an associated function, not a method
    |
    = note: found the following associated functions; to be used as methods, functions must have a `self` parameter
 note: the candidate is defined in an impl for the type `GenericAssocMethod<T>`
@@ -73,6 +76,11 @@ note: the candidate is defined in an impl for the type `GenericAssocMethod<T>`
    |
 LL |     fn self_ty_ref_hello(_: &Self) {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: use associated function syntax instead
+   |
+LL -     y.self_ty_ref_hello();
+LL +     GenericAssocMethod::<i32>::self_ty_ref_hello(&y);
+   |
 
 error[E0599]: no method named `self_ty_hello` found for struct `GenericAssocMethod<i32>` in the current scope
   --> $DIR/suggest-assoc-fn-call-with-turbofish.rs:24:7
@@ -81,10 +89,7 @@ LL | struct GenericAssocMethod<T>(T);
    | ---------------------------- method `self_ty_hello` not found for this struct
 ...
 LL |     y.self_ty_hello();
-   |     --^^^^^^^^^^^^^--
-   |     | |
-   |     | this is an associated function, not a method
-   |     help: use associated function syntax instead: `GenericAssocMethod::<i32>::self_ty_hello(y)`
+   |       ^^^^^^^^^^^^^ this is an associated function, not a method
    |
    = note: found the following associated functions; to be used as methods, functions must have a `self` parameter
 note: the candidate is defined in an impl for the type `GenericAssocMethod<T>`
@@ -92,6 +97,11 @@ note: the candidate is defined in an impl for the type `GenericAssocMethod<T>`
    |
 LL |     fn self_ty_hello(_: Self) {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+help: use associated function syntax instead
+   |
+LL -     y.self_ty_hello();
+LL +     GenericAssocMethod::<i32>::self_ty_hello(y);
+   |
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/suggestions/suggest-assoc-fn-call-without-receiver.stderr
+++ b/tests/ui/suggestions/suggest-assoc-fn-call-without-receiver.stderr
@@ -5,10 +5,7 @@ LL | struct A {}
    | -------- method `hello` not found for this struct
 ...
 LL |     _a.hello(1);
-   |     ---^^^^^---
-   |     |  |
-   |     |  this is an associated function, not a method
-   |     help: use associated function syntax instead: `A::hello(1)`
+   |        ^^^^^ this is an associated function, not a method
    |
    = note: found the following associated functions; to be used as methods, functions must have a `self` parameter
 note: the candidate is defined in an impl for the type `A`
@@ -16,6 +13,11 @@ note: the candidate is defined in an impl for the type `A`
    |
 LL |     fn hello(_a: i32) {}
    |     ^^^^^^^^^^^^^^^^^
+help: use associated function syntax instead
+   |
+LL -     _a.hello(1);
+LL +     A::hello(1);
+   |
 
 error[E0599]: no method named `test` found for struct `A` in the current scope
   --> $DIR/suggest-assoc-fn-call-without-receiver.rs:22:8
@@ -24,10 +26,7 @@ LL | struct A {}
    | -------- method `test` not found for this struct
 ...
 LL |     _a.test(1);
-   |     ---^^^^---
-   |     |  |
-   |     |  this is an associated function, not a method
-   |     help: use associated function syntax instead: `A::test(_a, 1)`
+   |        ^^^^ this is an associated function, not a method
    |
    = note: found the following associated functions; to be used as methods, functions must have a `self` parameter
 note: the candidate is defined in an impl for the type `A`
@@ -35,6 +34,11 @@ note: the candidate is defined in an impl for the type `A`
    |
 LL |     fn test(_a: Self, _b: i32) {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: use associated function syntax instead
+   |
+LL -     _a.test(1);
+LL +     A::test(_a, 1);
+   |
 
 error[E0599]: no method named `hello` found for struct `B<&str>` in the current scope
   --> $DIR/suggest-assoc-fn-call-without-receiver.rs:26:8
@@ -43,10 +47,7 @@ LL | struct B<T> {
    | ----------- method `hello` not found for this struct
 ...
 LL |     _b.hello(1);
-   |     ---^^^^^---
-   |     |  |
-   |     |  this is an associated function, not a method
-   |     help: use associated function syntax instead: `B::<&str>::hello(1)`
+   |        ^^^^^ this is an associated function, not a method
    |
    = note: found the following associated functions; to be used as methods, functions must have a `self` parameter
 note: the candidate is defined in an impl for the type `B<T>`
@@ -54,6 +55,11 @@ note: the candidate is defined in an impl for the type `B<T>`
    |
 LL |     fn hello(_a: i32) {}
    |     ^^^^^^^^^^^^^^^^^
+help: use associated function syntax instead
+   |
+LL -     _b.hello(1);
+LL +     B::<&str>::hello(1);
+   |
 
 error[E0599]: no method named `test` found for struct `B<&str>` in the current scope
   --> $DIR/suggest-assoc-fn-call-without-receiver.rs:28:8
@@ -62,10 +68,7 @@ LL | struct B<T> {
    | ----------- method `test` not found for this struct
 ...
 LL |     _b.test(1);
-   |     ---^^^^---
-   |     |  |
-   |     |  this is an associated function, not a method
-   |     help: use associated function syntax instead: `B::<&str>::test(_b, 1)`
+   |        ^^^^ this is an associated function, not a method
    |
    = note: found the following associated functions; to be used as methods, functions must have a `self` parameter
 note: the candidate is defined in an impl for the type `B<T>`
@@ -73,6 +76,11 @@ note: the candidate is defined in an impl for the type `B<T>`
    |
 LL |     fn test(_a: Self, _b: i32) {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: use associated function syntax instead
+   |
+LL -     _b.test(1);
+LL +     B::<&str>::test(_b, 1);
+   |
 
 error: aborting due to 4 previous errors
 


### PR DESCRIPTION
Fixes rust-lang/rust#149038

The first commit is changing the old suggestion to verbose,
the second commit is a new added suggestion.

r? @estebank