### PR TITLE
Couple of refactors to SharedEmitter

### DIFF
--- a/compiler/rustc_error_messages/src/lib.rs
+++ b/compiler/rustc_error_messages/src/lib.rs
@@ -455,10 +455,6 @@ impl MultiSpan {
         replacements_occurred
     }
 
-    pub fn pop_span_label(&mut self) -> Option<(Span, DiagMessage)> {
-        self.span_labels.pop()
-    }
-
     /// Returns the strings to highlight. We always ensure that there
     /// is an entry for each of the primary spans -- for each primary
     /// span `P`, if there is at least one label with span `P`, we return


### PR DESCRIPTION
I was trying to get rid of a dedicated `inline_asm_error` method in favor the regular error methods on `DiagCtxt` to allow replacing `SharedEmitter` with `sess.dcx()` when running on the main thread, but the `sess.source_map().new_source_file()` for the inline asm snippets prevents doing this. I'm going to solve the original motivating problem in a different way for this reason, but I figured these refactors do improve things a tiny bit.