### PR TITLE
Use `TypingMode::PostAnalysis` in `try_evaluate_const`

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/mod.rs
@@ -618,7 +618,7 @@ pub fn try_evaluate_const<'tcx>(
 
                     (args, typing_env)
                 }
-                _ => {
+                Some(ty::AnonConstKind::MCG) | Some(ty::AnonConstKind::NonTypeSystem) | None => {
                     // We are only dealing with "truly" generic/uninferred constants here:
                     // - GCEConsts have been handled separately
                     // - Repeat expr count back compat consts have also been handled separately

--- a/compiler/rustc_trait_selection/src/traits/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/mod.rs
@@ -637,7 +637,7 @@ pub fn try_evaluate_const<'tcx>(
 
                     // Since there is no generic parameter, we can just drop the environment
                     // to prevent query cycle.
-                    let typing_env = infcx.typing_env(ty::ParamEnv::empty());
+                    let typing_env = ty::TypingEnv::fully_monomorphized();
 
                     (uv.args, typing_env)
                 }


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

As mentioned in https://github.com/rust-lang/rust/pull/148698#discussion_r2541882341, we should use ``TypingMode::PostAnalysis`` for that path. 

@BoxyUwU prefer the match in ``try_evaluate_const`` to be exhaustive, so I also included that in this PR :3

