### PR TITLE
Added unlock functionality to mutex guard and rw lock guards

### DIFF
--- a/library/std/src/sync/nonpoison/mutex.rs
+++ b/library/std/src/sync/nonpoison/mutex.rs
@@ -450,10 +450,7 @@ impl<T: ?Sized + fmt::Debug> fmt::Debug for Mutex<T> {
 
 impl<'mutex, T: ?Sized> MutexGuard<'mutex, T> {
     unsafe fn new(lock: &'mutex Mutex<T>) -> MutexGuard<'mutex, T> {
-        MutexGuard {
-            lock,
-            unlocked: false,
-        }
+        MutexGuard { lock, unlocked: false, }
     }
 }
 
@@ -534,13 +531,13 @@ impl<'mutex, T: ?Sized> MutexGuard<'mutex, T> {
     #[unstable(feature = "unlockable_guards", issue = "148568")]
     pub fn unlocked<F>(self: &mut Self, func: F) -> ()
     where
-        F: FnOnce() -> ()
+        F: FnOnce() -> (),
     {
         self.unlocked = true;
         unsafe { self.lock.inner.unlock() };
 
         func();
-        
+
         self.lock.inner.lock();
         self.unlocked = false;
     }

--- a/library/std/src/sync/nonpoison/mutex.rs
+++ b/library/std/src/sync/nonpoison/mutex.rs
@@ -450,7 +450,7 @@ impl<T: ?Sized + fmt::Debug> fmt::Debug for Mutex<T> {
 
 impl<'mutex, T: ?Sized> MutexGuard<'mutex, T> {
     unsafe fn new(lock: &'mutex Mutex<T>) -> MutexGuard<'mutex, T> {
-        MutexGuard { lock, unlocked: false, }
+        MutexGuard { lock, unlocked: false }
     }
 }
 

--- a/library/std/src/sync/nonpoison/mutex.rs
+++ b/library/std/src/sync/nonpoison/mutex.rs
@@ -98,6 +98,9 @@ unsafe impl<T: ?Sized + Send> Sync for Mutex<T> {}
 #[cfg_attr(not(test), rustc_diagnostic_item = "NonPoisonMutexGuard")]
 pub struct MutexGuard<'a, T: ?Sized + 'a> {
     lock: &'a Mutex<T>,
+    /// The unlocked state is used to prevent double unlocking of guards upon panicking in
+    /// unlocked scopes.
+    unlocked: bool,
 }
 
 /// A [`MutexGuard`] is not `Send` to maximize platform portability.
@@ -447,7 +450,10 @@ impl<T: ?Sized + fmt::Debug> fmt::Debug for Mutex<T> {
 
 impl<'mutex, T: ?Sized> MutexGuard<'mutex, T> {
     unsafe fn new(lock: &'mutex Mutex<T>) -> MutexGuard<'mutex, T> {
-        return MutexGuard { lock };
+        MutexGuard {
+            lock,
+            unlocked: false,
+        }
     }
 }
 
@@ -471,8 +477,10 @@ impl<T: ?Sized> DerefMut for MutexGuard<'_, T> {
 impl<T: ?Sized> Drop for MutexGuard<'_, T> {
     #[inline]
     fn drop(&mut self) {
-        unsafe {
-            self.lock.inner.unlock();
+        if !self.unlocked {
+            unsafe {
+                self.lock.inner.unlock();
+            }
         }
     }
 }
@@ -494,6 +502,48 @@ impl<T: ?Sized + fmt::Display> fmt::Display for MutexGuard<'_, T> {
 /// For use in [`nonpoison::condvar`](super::condvar).
 pub(super) fn guard_lock<'a, T: ?Sized>(guard: &MutexGuard<'a, T>) -> &'a sys::Mutex {
     &guard.lock.inner
+}
+
+impl<'mutex, T: ?Sized> MutexGuard<'mutex, T> {
+    /// Unlocks the [`MutexGuard`] for the scope of `func` and acquires it again after.
+    /// Panics won't lock the guard again.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #[feature(unlockable_guards)]
+    ///
+    /// use std::sync::nonpoison::Mutex;
+    /// use std::sync::nonpoison::MutexGuard;
+    /// use std::sync::nonpoison::TryLockResult;
+    ///
+    /// let mutex = Mutex::new(1usize);
+    /// let mut guard = mutex.lock();
+    ///
+    /// // guard is locked and can be used here
+    /// *guard = 5;
+    ///
+    /// MutexGuard::unlocked(&mut guard, || {
+    ///     // guard is locked and can be acquired potentially from another thread
+    ///     assert!(matches!(mutex.try_lock(), TryLockResult::Ok(_)));
+    /// });
+    ///
+    /// // guard is locked again
+    /// assert_eq!(*guard, 5);
+    /// ```
+    #[unstable(feature = "unlockable_guards", issue = "148568")]
+    pub fn unlocked<F>(self: &mut Self, func: F) -> ()
+    where
+        F: FnOnce() -> ()
+    {
+        self.unlocked = true;
+        unsafe { self.lock.inner.unlock() };
+
+        func();
+        
+        self.lock.inner.lock();
+        self.unlocked = false;
+    }
 }
 
 impl<'a, T: ?Sized> MutexGuard<'a, T> {

--- a/library/std/src/sync/nonpoison/rwlock.rs
+++ b/library/std/src/sync/nonpoison/rwlock.rs
@@ -691,10 +691,7 @@ impl<'rwlock, T: ?Sized> RwLockWriteGuard<'rwlock, T> {
     /// `lock.inner.write()`, `lock.inner.try_write()`, or `lock.inner.try_upgrade` before
     /// instantiating this object.
     unsafe fn new(lock: &'rwlock RwLock<T>) -> RwLockWriteGuard<'rwlock, T> {
-        RwLockWriteGuard {
-            lock,
-            unlocked: false,
-        }
+        RwLockWriteGuard { lock, unlocked: false }
     }
 
     /// Downgrades a write-locked `RwLockWriteGuard` into a read-locked [`RwLockReadGuard`].
@@ -1183,7 +1180,7 @@ impl<'rw_lock, T: ?Sized> RwLockReadGuard<'rw_lock, T> {
     #[unstable(feature = "unlockable_guards", issue = "148568")]
     pub fn unlocked<F>(self: &mut Self, func: F) -> ()
     where
-        F: FnOnce() -> ()
+        F: FnOnce() -> (),
     {
         self.unlocked = true;
         unsafe { self.inner_lock.read_unlock() };
@@ -1225,7 +1222,7 @@ impl<'rw_lock, T: ?Sized> RwLockWriteGuard<'rw_lock, T> {
     #[unstable(feature = "unlockable_guards", issue = "148568")]
     pub fn unlocked<F>(self: &mut Self, func: F) -> ()
     where
-        F: FnOnce() -> ()
+        F: FnOnce() -> (),
     {
         self.unlocked = true;
         unsafe { self.lock.inner.write_unlock() };

--- a/library/std/src/sync/nonpoison/rwlock.rs
+++ b/library/std/src/sync/nonpoison/rwlock.rs
@@ -81,6 +81,9 @@ pub struct RwLockReadGuard<'rwlock, T: ?Sized + 'rwlock> {
     data: NonNull<T>,
     /// A reference to the internal [`sys::RwLock`] that we have read-locked.
     inner_lock: &'rwlock sys::RwLock,
+    /// The unlocked state is used to prevent double unlocking of guards upon panicking in
+    /// unlocked scopes.
+    unlocked: bool,
 }
 
 #[unstable(feature = "nonpoison_rwlock", issue = "134645")]
@@ -107,6 +110,9 @@ unsafe impl<T: ?Sized + Sync> Sync for RwLockReadGuard<'_, T> {}
 pub struct RwLockWriteGuard<'rwlock, T: ?Sized + 'rwlock> {
     /// A reference to the [`RwLock`] that we have write-locked.
     lock: &'rwlock RwLock<T>,
+    /// The unlocked state is used to prevent double unlocking of guards upon panicking in
+    /// unlocked scopes.
+    unlocked: bool,
 }
 
 #[unstable(feature = "nonpoison_rwlock", issue = "134645")]
@@ -607,6 +613,7 @@ impl<'rwlock, T: ?Sized> RwLockReadGuard<'rwlock, T> {
         RwLockReadGuard {
             data: unsafe { NonNull::new_unchecked(lock.data.get()) },
             inner_lock: &lock.inner,
+            unlocked: false,
         }
     }
 
@@ -684,7 +691,10 @@ impl<'rwlock, T: ?Sized> RwLockWriteGuard<'rwlock, T> {
     /// `lock.inner.write()`, `lock.inner.try_write()`, or `lock.inner.try_upgrade` before
     /// instantiating this object.
     unsafe fn new(lock: &'rwlock RwLock<T>) -> RwLockWriteGuard<'rwlock, T> {
-        RwLockWriteGuard { lock }
+        RwLockWriteGuard {
+            lock,
+            unlocked: false,
+        }
     }
 
     /// Downgrades a write-locked `RwLockWriteGuard` into a read-locked [`RwLockReadGuard`].
@@ -976,9 +986,11 @@ impl<'rwlock, T: ?Sized> MappedRwLockWriteGuard<'rwlock, T> {
 #[unstable(feature = "nonpoison_rwlock", issue = "134645")]
 impl<T: ?Sized> Drop for RwLockReadGuard<'_, T> {
     fn drop(&mut self) {
-        // SAFETY: the conditions of `RwLockReadGuard::new` were satisfied when created.
-        unsafe {
-            self.inner_lock.read_unlock();
+        if !self.unlocked {
+            // SAFETY: the conditions of `RwLockReadGuard::new` were satisfied when created.
+            unsafe {
+                self.inner_lock.read_unlock();
+            }
         }
     }
 }
@@ -986,9 +998,11 @@ impl<T: ?Sized> Drop for RwLockReadGuard<'_, T> {
 #[unstable(feature = "nonpoison_rwlock", issue = "134645")]
 impl<T: ?Sized> Drop for RwLockWriteGuard<'_, T> {
     fn drop(&mut self) {
-        // SAFETY: the conditions of `RwLockWriteGuard::new` were satisfied when created.
-        unsafe {
-            self.lock.inner.write_unlock();
+        if !self.unlocked {
+            // SAFETY: the conditions of `RwLockWriteGuard::new` were satisfied when created.
+            unsafe {
+                self.lock.inner.write_unlock();
+            }
         }
     }
 }
@@ -1136,5 +1150,89 @@ impl<T: ?Sized + fmt::Debug> fmt::Debug for MappedRwLockWriteGuard<'_, T> {
 impl<T: ?Sized + fmt::Display> fmt::Display for MappedRwLockWriteGuard<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         (**self).fmt(f)
+    }
+}
+
+impl<'rw_lock, T: ?Sized> RwLockReadGuard<'rw_lock, T> {
+    /// Unlocks the [`RwLockReadGuard`] for the scope of `func` and acquires it again after.
+    /// Panics won't lock the guard again.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #[feature(unlockable_guards)]
+    ///
+    /// use std::sync::nonpoison::RwLock;
+    /// use std::sync::nonpoison::RwLockReadGuard;
+    /// use std::sync::nonpoison::TryLockResult;
+    ///
+    /// let rw_lock = RwLock::new(1usize);
+    /// let mut read_guard = rw_lock.read();
+    ///
+    /// // guard is locked and can be used here
+    /// assert_eq!(*read_guard, 1);
+    ///
+    /// RwLockReadGuard::unlocked(&mut read_guard, || {
+    ///     // guard is locked and can be acquired potentially from another thread
+    ///     assert!(matches!(rw_lock.try_write(), TryLockResult::Ok(_)));
+    /// });
+    ///
+    /// // guard is locked again
+    /// assert_eq!(*read_guard, 1);
+    /// ```
+    #[unstable(feature = "unlockable_guards", issue = "148568")]
+    pub fn unlocked<F>(self: &mut Self, func: F) -> ()
+    where
+        F: FnOnce() -> ()
+    {
+        self.unlocked = true;
+        unsafe { self.inner_lock.read_unlock() };
+
+        func();
+
+        self.inner_lock.read();
+        self.unlocked = false;
+    }
+}
+
+impl<'rw_lock, T: ?Sized> RwLockWriteGuard<'rw_lock, T> {
+    /// Unlocks the [`RwLockWriteGuard`] for the scope of `func` and acquires it again after.
+    /// Panics won't lock the guard again.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #[feature(unlockable_guards)]
+    ///
+    /// use std::sync::nonpoison::RwLock;
+    /// use std::sync::nonpoison::RwLockWriteGuard;
+    /// use std::sync::nonpoison::TryLockResult;
+    ///
+    /// let rw_lock = RwLock::new(1usize);
+    /// let mut write_guard = rw_lock.write();
+    ///
+    /// // guard is locked and can be used here
+    /// *write_guard = 5;
+    ///
+    /// RwLockWriteGuard::unlocked(&mut write_guard, || {
+    ///     // guard is locked and can be acquired potentially from another thread
+    ///     assert!(matches!(rw_lock.try_write(), TryLockResult::Ok(_)));
+    /// });
+    ///
+    /// // guard is locked again
+    /// assert_eq!(*write_guard, 5);
+    /// ```
+    #[unstable(feature = "unlockable_guards", issue = "148568")]
+    pub fn unlocked<F>(self: &mut Self, func: F) -> ()
+    where
+        F: FnOnce() -> ()
+    {
+        self.unlocked = true;
+        unsafe { self.lock.inner.write_unlock() };
+
+        func();
+
+        self.lock.inner.write();
+        self.unlocked = false;
     }
 }

--- a/library/std/tests/sync/mutex.rs
+++ b/library/std/tests/sync/mutex.rs
@@ -541,11 +541,10 @@ fn test_mutex_guard_unlocked() {
     let mutex = Mutex::new(1usize);
     let mut guard = mutex.lock();
 
-
     assert!(matches!(mutex.try_lock(), std::sync::nonpoison::TryLockResult::Err(_)));
-    
+
     MutexGuard::unlocked(&mut guard, || {
-        assert!(matches!(mutex.try_lock(),  std::sync::nonpoison::TryLockResult::Ok(_)));
+        assert!(matches!(mutex.try_lock(), std::sync::nonpoison::TryLockResult::Ok(_)));
     });
 
     assert!(matches!(mutex.try_lock(), std::sync::nonpoison::TryLockResult::Err(_)));

--- a/library/std/tests/sync/mutex.rs
+++ b/library/std/tests/sync/mutex.rs
@@ -538,7 +538,7 @@ fn test_mutex_with_mut() {
 
 #[test]
 fn test_mutex_guard_unlocked() {
-    let mutex = Mutex::new(1usize);
+    let mutex = std::sync::nonpoison::Mutex::new(1usize);
     let mut guard = mutex.lock();
 
     assert!(matches!(mutex.try_lock(), std::sync::nonpoison::TryLockResult::Err(_)));

--- a/library/std/tests/sync/mutex.rs
+++ b/library/std/tests/sync/mutex.rs
@@ -531,3 +531,22 @@ fn test_mutex_with_mut() {
     assert_eq!(*mutex.lock(), 5);
     assert_eq!(result, 10);
 }
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// Nonpoison Tests
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#[test]
+fn test_mutex_guard_unlocked() {
+    let mutex = Mutex::new(1usize);
+    let mut guard = mutex.lock();
+
+
+    assert!(matches!(mutex.try_lock(), std::sync::nonpoison::TryLockResult::Err(_)));
+    
+    MutexGuard::unlocked(&mut guard, || {
+        assert!(matches!(mutex.try_lock(),  std::sync::nonpoison::TryLockResult::Ok(_)));
+    });
+
+    assert!(matches!(mutex.try_lock(), std::sync::nonpoison::TryLockResult::Err(_)));
+}

--- a/library/std/tests/sync/rwlock.rs
+++ b/library/std/tests/sync/rwlock.rs
@@ -3,7 +3,10 @@ use std::ops::FnMut;
 use std::panic::{self, AssertUnwindSafe};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::mpsc::channel;
-use std::sync::{Arc, MappedRwLockReadGuard, MappedRwLockWriteGuard, Mutex, MutexGuard, RwLock, RwLockReadGuard, RwLockWriteGuard, TryLockError};
+use std::sync::{
+    Arc, MappedRwLockReadGuard, MappedRwLockWriteGuard, Mutex, MutexGuard, RwLock, RwLockReadGuard,
+    RwLockWriteGuard, TryLockError,
+};
 use std::{hint, mem, thread};
 
 use rand::Rng;
@@ -880,7 +883,6 @@ fn test_rwlock_with_mut() {
     assert_eq!(*rwlock.read(), 5);
     assert_eq!(result, 10);
 }
-
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Non-poison Tests

--- a/library/std/tests/sync/rwlock.rs
+++ b/library/std/tests/sync/rwlock.rs
@@ -5,7 +5,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::mpsc::channel;
 use std::sync::{
     Arc, MappedRwLockReadGuard, MappedRwLockWriteGuard, RwLock, RwLockReadGuard, RwLockWriteGuard,
-    TryLockError
+    TryLockError,
 };
 use std::{hint, mem, thread};
 

--- a/library/std/tests/sync/rwlock.rs
+++ b/library/std/tests/sync/rwlock.rs
@@ -4,8 +4,8 @@ use std::panic::{self, AssertUnwindSafe};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::mpsc::channel;
 use std::sync::{
-    Arc, MappedRwLockReadGuard, MappedRwLockWriteGuard, Mutex, MutexGuard, RwLock, RwLockReadGuard,
-    RwLockWriteGuard, TryLockError,
+    Arc, MappedRwLockReadGuard, MappedRwLockWriteGuard, RwLock, RwLockReadGuard, RwLockWriteGuard,
+    TryLockError
 };
 use std::{hint, mem, thread};
 
@@ -890,12 +890,12 @@ fn test_rwlock_with_mut() {
 
 #[test]
 fn test_read_guard_unlocked() {
-    let rw_lock = RwLock::new(1usize);
+    let rw_lock = std::sync::nonpoison::RwLock::new(1usize);
     let mut read_guard = rw_lock.read();
 
     assert!(matches!(rw_lock.try_write(), std::sync::nonpoison::TryLockResult::Err(_)));
 
-    RwLockWriteGuard::unlocked(&mut read_guard, || {
+    RwLockReadGuard::unlocked(&mut read_guard, || {
         assert!(matches!(rw_lock.try_write(), std::sync::nonpoison::TryLockResult::Ok(_)));
     });
 
@@ -904,7 +904,7 @@ fn test_read_guard_unlocked() {
 
 #[test]
 fn test_write_guard_unlocked() {
-    let rw_lock = RwLock::new(1usize);
+    let rw_lock = std::sync::nonpoison::RwLock::new(1usize);
     let mut write_guard = rw_lock.write();
 
     assert!(matches!(rw_lock.try_write(), std::sync::nonpoison::TryLockResult::Err(_)));


### PR DESCRIPTION
Added unlock functionality for nonpoison mutex guards and RwLock guards. 

Associated Tracking Issue: https://github.com/rust-lang/rust/issues/148568