### PR TITLE
Forbid `CHECK: br` and `CHECK-NOT: br` in codegen tests (suggest `br {{.*}}` instead)

### DIFF
--- a/src/tools/tidy/src/style.rs
+++ b/src/tools/tidy/src/style.rs
@@ -445,6 +445,7 @@ pub fn check(path: &Path, tidy_ctx: TidyCtx) {
         let mut comment_block: Option<(usize, usize)> = None;
         let is_test = file.components().any(|c| c.as_os_str() == "tests")
             || file.file_stem().unwrap() == "tests";
+        let is_codegen_test = is_test && file.components().any(|c| c.as_os_str() == "codegen-llvm");
         let is_this_file = file.ends_with(this_file) || this_file.ends_with(file);
         let is_test_for_this_file =
             is_test && file.parent().unwrap().ends_with(this_file.with_extension(""));
@@ -486,6 +487,11 @@ pub fn check(path: &Path, tidy_ctx: TidyCtx) {
                     skip_dbg,
                     "`dbg!` macro is intended as a debugging tool. It should not be in version control."
                 )
+            }
+
+            if is_codegen_test && trimmed.contains("CHECK") && trimmed.ends_with(": br") {
+                err("`CHECK: br` and `CHECK-NOT: br` in codegen tests are fragile to false \
+                    positives in mangled symbols. Try using `br {{.*}}` instead.")
             }
 
             if !under_rustfmt

--- a/tests/codegen-llvm/char-ascii-branchless.rs
+++ b/tests/codegen-llvm/char-ascii-branchless.rs
@@ -7,41 +7,41 @@
 // CHECK-LABEL: @is_ascii_alphanumeric_char
 #[no_mangle]
 pub fn is_ascii_alphanumeric_char(x: char) -> bool {
-    // CHECK-NOT: br
+    // CHECK-NOT: br {{.*}}
     x.is_ascii_alphanumeric()
 }
 
 // CHECK-LABEL: @is_ascii_alphanumeric_u8
 #[no_mangle]
 pub fn is_ascii_alphanumeric_u8(x: u8) -> bool {
-    // CHECK-NOT: br
+    // CHECK-NOT: br {{.*}}
     x.is_ascii_alphanumeric()
 }
 
 // CHECK-LABEL: @is_ascii_hexdigit_char
 #[no_mangle]
 pub fn is_ascii_hexdigit_char(x: char) -> bool {
-    // CHECK-NOT: br
+    // CHECK-NOT: br {{.*}}
     x.is_ascii_hexdigit()
 }
 
 // CHECK-LABEL: @is_ascii_hexdigit_u8
 #[no_mangle]
 pub fn is_ascii_hexdigit_u8(x: u8) -> bool {
-    // CHECK-NOT: br
+    // CHECK-NOT: br {{.*}}
     x.is_ascii_hexdigit()
 }
 
 // CHECK-LABEL: @is_ascii_punctuation_char
 #[no_mangle]
 pub fn is_ascii_punctuation_char(x: char) -> bool {
-    // CHECK-NOT: br
+    // CHECK-NOT: br {{.*}}
     x.is_ascii_punctuation()
 }
 
 // CHECK-LABEL: @is_ascii_punctuation_u8
 #[no_mangle]
 pub fn is_ascii_punctuation_u8(x: u8) -> bool {
-    // CHECK-NOT: br
+    // CHECK-NOT: br {{.*}}
     x.is_ascii_punctuation()
 }

--- a/tests/codegen-llvm/enum/enum-early-otherwise-branch.rs
+++ b/tests/codegen-llvm/enum/enum-early-otherwise-branch.rs
@@ -12,7 +12,7 @@ pub enum Enum {
 pub fn foo(lhs: &Enum, rhs: &Enum) -> bool {
     // CHECK-LABEL: define{{.*}}i1 @foo(
     // CHECK-NOT: switch
-    // CHECK-NOT: br
+    // CHECK-NOT: br {{.*}}
     // CHECK: [[SELECT:%.*]] = select
     // CHECK-NEXT: ret i1 [[SELECT]]
     // CHECK-NEXT: }

--- a/tests/codegen-llvm/issues/cows-dont-have-branches-117763.rs
+++ b/tests/codegen-llvm/issues/cows-dont-have-branches-117763.rs
@@ -9,7 +9,7 @@
 // CHECK-LABEL: @branchless_cow_slices
 #[no_mangle]
 pub fn branchless_cow_slices<'a>(cow: &'a std::borrow::Cow<'a, [u8]>) -> &'a [u8] {
-    // CHECK-NOT: br
+    // CHECK-NOT: br {{.*}}
     // CHECK-NOT: select
     // CHECK-NOT: icmp
     // CHECK: ret { ptr, {{i32|i64}} }

--- a/tests/codegen-llvm/issues/issue-107681-unwrap_unchecked.rs
+++ b/tests/codegen-llvm/issues/issue-107681-unwrap_unchecked.rs
@@ -11,7 +11,7 @@ use std::slice::Iter;
 #[no_mangle]
 pub unsafe fn foo(x: &mut Copied<Iter<'_, u32>>) -> u32 {
     // CHECK-LABEL: @foo(
-    // CHECK-NOT: br
+    // CHECK-NOT: br {{.*}}
     // CHECK-NOT: select
     // CHECK: [[RET:%.*]] = load i32, ptr
     // CHECK-NEXT: ret i32 [[RET]]

--- a/tests/codegen-llvm/issues/issue-108395-branchy-bool-match.rs
+++ b/tests/codegen-llvm/issues/issue-108395-branchy-bool-match.rs
@@ -6,7 +6,7 @@
 // CHECK-LABEL: @wildcard(
 #[no_mangle]
 pub fn wildcard(a: u16, b: u16, v: u16) -> u16 {
-    // CHECK-NOT: br
+    // CHECK-NOT: br {{.*}}
     match (a == v, b == v) {
         (true, false) => 0,
         (false, true) => u16::MAX,
@@ -17,7 +17,7 @@ pub fn wildcard(a: u16, b: u16, v: u16) -> u16 {
 // CHECK-LABEL: @exhaustive(
 #[no_mangle]
 pub fn exhaustive(a: u16, b: u16, v: u16) -> u16 {
-    // CHECK-NOT: br
+    // CHECK-NOT: br {{.*}}
     match (a == v, b == v) {
         (true, false) => 0,
         (false, true) => u16::MAX,

--- a/tests/codegen-llvm/issues/issue-119422.rs
+++ b/tests/codegen-llvm/issues/issue-119422.rs
@@ -19,45 +19,45 @@ pub fn check_non_null(x: NonNull<u8>) -> bool {
 // CHECK-LABEL: @equals_zero_is_false_u8
 #[no_mangle]
 pub fn equals_zero_is_false_u8(x: NonZero<u8>) -> bool {
-    // CHECK-NOT: br
+    // CHECK-NOT: br {{.*}}
     // CHECK: ret i1 false
-    // CHECK-NOT: br
+    // CHECK-NOT: br {{.*}}
     x.get() == 0
 }
 
 // CHECK-LABEL: @not_equals_zero_is_true_u8
 #[no_mangle]
 pub fn not_equals_zero_is_true_u8(x: NonZero<u8>) -> bool {
-    // CHECK-NOT: br
+    // CHECK-NOT: br {{.*}}
     // CHECK: ret i1 true
-    // CHECK-NOT: br
+    // CHECK-NOT: br {{.*}}
     x.get() != 0
 }
 
 // CHECK-LABEL: @equals_zero_is_false_i8
 #[no_mangle]
 pub fn equals_zero_is_false_i8(x: NonZero<i8>) -> bool {
-    // CHECK-NOT: br
+    // CHECK-NOT: br {{.*}}
     // CHECK: ret i1 false
-    // CHECK-NOT: br
+    // CHECK-NOT: br {{.*}}
     x.get() == 0
 }
 
 // CHECK-LABEL: @not_equals_zero_is_true_i8
 #[no_mangle]
 pub fn not_equals_zero_is_true_i8(x: NonZero<i8>) -> bool {
-    // CHECK-NOT: br
+    // CHECK-NOT: br {{.*}}
     // CHECK: ret i1 true
-    // CHECK-NOT: br
+    // CHECK-NOT: br {{.*}}
     x.get() != 0
 }
 
 // CHECK-LABEL: @usize_try_from_u32
 #[no_mangle]
 pub fn usize_try_from_u32(x: NonZero<u32>) -> NonZero<usize> {
-    // CHECK-NOT: br
+    // CHECK-NOT: br {{.*}}
     // CHECK: zext i32 %{{.*}} to i64
-    // CHECK-NOT: br
+    // CHECK-NOT: br {{.*}}
     // CHECK: ret i64
     x.try_into().unwrap()
 }
@@ -65,9 +65,9 @@ pub fn usize_try_from_u32(x: NonZero<u32>) -> NonZero<usize> {
 // CHECK-LABEL: @isize_try_from_i32
 #[no_mangle]
 pub fn isize_try_from_i32(x: NonZero<i32>) -> NonZero<isize> {
-    // CHECK-NOT: br
+    // CHECK-NOT: br {{.*}}
     // CHECK: sext i32 %{{.*}} to i64
-    // CHECK-NOT: br
+    // CHECK-NOT: br {{.*}}
     // CHECK: ret i64
     x.try_into().unwrap()
 }
@@ -75,9 +75,9 @@ pub fn isize_try_from_i32(x: NonZero<i32>) -> NonZero<isize> {
 // CHECK-LABEL: @u64_from_nonzero_is_not_zero
 #[no_mangle]
 pub fn u64_from_nonzero_is_not_zero(x: NonZero<u64>) -> bool {
-    // CHECK-NOT: br
+    // CHECK-NOT: br {{.*}}
     // CHECK: ret i1 false
-    // CHECK-NOT: br
+    // CHECK-NOT: br {{.*}}
     let v: u64 = x.into();
     v == 0
 }

--- a/tests/codegen-llvm/issues/issue-73258.rs
+++ b/tests/codegen-llvm/issues/issue-73258.rs
@@ -18,7 +18,7 @@ pub enum Foo {
 pub unsafe fn issue_73258(ptr: *const Foo) -> Foo {
     // CHECK-NOT: icmp
     // CHECK-NOT: call
-    // CHECK-NOT: br
+    // CHECK-NOT: br {{.*}}
     // CHECK-NOT: select
 
     // CHECK: %[[R:.+]] = load i8
@@ -26,14 +26,14 @@ pub unsafe fn issue_73258(ptr: *const Foo) -> Foo {
 
     // CHECK-NOT: icmp
     // CHECK-NOT: call
-    // CHECK-NOT: br
+    // CHECK-NOT: br {{.*}}
     // CHECK-NOT: select
 
     // CHECK: ret i8 %[[R]]
 
     // CHECK-NOT: icmp
     // CHECK-NOT: call
-    // CHECK-NOT: br
+    // CHECK-NOT: br {{.*}}
     // CHECK-NOT: select
     let k: Option<Foo> = Some(ptr.read());
     return k.unwrap();

--- a/tests/codegen-llvm/issues/num-is-digit-to-digit-59352.rs
+++ b/tests/codegen-llvm/issues/num-is-digit-to-digit-59352.rs
@@ -8,7 +8,7 @@
 // CHECK-LABEL: @num_to_digit_slow
 #[no_mangle]
 pub fn num_to_digit_slow(num: char) -> u32 {
-    // CHECK-NOT: br
+    // CHECK-NOT: br {{.*}}
     // CHECK-NOT: panic
     if num.is_digit(8) { num.to_digit(8).unwrap() } else { 0 }
 }

--- a/tests/codegen-llvm/iter-repeat-n-trivial-drop.rs
+++ b/tests/codegen-llvm/iter-repeat-n-trivial-drop.rs
@@ -19,23 +19,23 @@ impl Drop for NotCopy {
 // CHECK-LABEL: @iter_repeat_n_next
 pub fn iter_repeat_n_next(it: &mut std::iter::RepeatN<NotCopy>) -> Option<NotCopy> {
     // CHECK-NEXT: start:
-    // CHECK-NOT: br
+    // CHECK-NOT: br {{.*}}
     // CHECK: %[[COUNT:.+]] = load i64
     // CHECK-NEXT: %[[COUNT_ZERO:.+]] = icmp eq i64 %[[COUNT]], 0
     // CHECK-NEXT: br i1 %[[COUNT_ZERO]], label %[[EMPTY:.+]], label %[[NOT_EMPTY:.+]]
 
     // CHECK: [[NOT_EMPTY]]:
-    // CHECK-NOT: br
+    // CHECK-NOT: br {{.*}}
     // CHECK: %[[DEC:.+]] = add i64 %[[COUNT]], -1
     // CHECK-NEXT: %[[VAL:.+]] = load i16
     // CHECK-NEXT: store i64 %[[DEC]]
     // CHECK-NEXT: br label %[[EMPTY]]
 
     // CHECK: [[EMPTY]]:
-    // CHECK-NOT: br
+    // CHECK-NOT: br {{.*}}
     // CHECK: phi i16
     // CHECK-SAME: [ %[[VAL]], %[[NOT_EMPTY]] ]
-    // CHECK-NOT: br
+    // CHECK-NOT: br {{.*}}
     // CHECK: ret
 
     it.next()

--- a/tests/codegen-llvm/option-as-slice.rs
+++ b/tests/codegen-llvm/option-as-slice.rs
@@ -11,14 +11,14 @@ use core::option::Option;
 #[no_mangle]
 pub fn u64_opt_as_slice(o: &Option<u64>) -> &[u64] {
     // CHECK-NOT: select
-    // CHECK-NOT: br
+    // CHECK-NOT: br {{.*}}
     // CHECK-NOT: switch
     // CHECK-NOT: icmp
     // CHECK: %[[LEN:.+]] = load i64
     // CHECK-SAME: !range ![[META_U64:[0-9]+]],
     // CHECK-SAME: !noundef
     // CHECK-NOT: select
-    // CHECK-NOT: br
+    // CHECK-NOT: br {{.*}}
     // CHECK-NOT: switch
     // CHECK-NOT: icmp
     // CHECK: %[[T0:.+]] = insertvalue { ptr, i64 } poison, ptr %{{.+}}, 0
@@ -31,13 +31,13 @@ pub fn u64_opt_as_slice(o: &Option<u64>) -> &[u64] {
 #[no_mangle]
 pub fn nonzero_u64_opt_as_slice(o: &Option<NonZero<u64>>) -> &[NonZero<u64>] {
     // CHECK-NOT: select
-    // CHECK-NOT: br
+    // CHECK-NOT: br {{.*}}
     // CHECK-NOT: switch
     // CHECK-NOT: icmp
     // CHECK: %[[NZ:.+]] = icmp ne i64 %{{.+}}, 0
     // CHECK-NEXT: %[[LEN:.+]] = zext i1 %[[NZ]] to i64
     // CHECK-NOT: select
-    // CHECK-NOT: br
+    // CHECK-NOT: br {{.*}}
     // CHECK-NOT: switch
     // CHECK-NOT: icmp
     // CHECK: %[[T0:.+]] = insertvalue { ptr, i64 } poison, ptr %o, 0
@@ -50,7 +50,7 @@ pub fn nonzero_u64_opt_as_slice(o: &Option<NonZero<u64>>) -> &[NonZero<u64>] {
 #[no_mangle]
 pub fn u8_opt_as_slice(o: &Option<u8>) -> &[u8] {
     // CHECK-NOT: select
-    // CHECK-NOT: br
+    // CHECK-NOT: br {{.*}}
     // CHECK-NOT: switch
     // CHECK-NOT: icmp
     // CHECK: %[[TAG:.+]] = load i8
@@ -58,7 +58,7 @@ pub fn u8_opt_as_slice(o: &Option<u8>) -> &[u8] {
     // CHECK-SAME: !noundef
     // CHECK: %[[LEN:.+]] = zext{{.*}} i8 %[[TAG]] to i64
     // CHECK-NOT: select
-    // CHECK-NOT: br
+    // CHECK-NOT: br {{.*}}
     // CHECK-NOT: switch
     // CHECK-NOT: icmp
     // CHECK: %[[T0:.+]] = insertvalue { ptr, i64 } poison, ptr %{{.+}}, 0

--- a/tests/codegen-llvm/slice-init.rs
+++ b/tests/codegen-llvm/slice-init.rs
@@ -69,7 +69,7 @@ const N: usize = 100;
 #[no_mangle]
 pub fn u16_init_one_bytes() -> [u16; N] {
     // CHECK-NOT: select
-    // CHECK-NOT: br
+    // CHECK-NOT: br {{.*}}
     // CHECK-NOT: switch
     // CHECK-NOT: icmp
     // CHECK: call void @llvm.memset.p0

--- a/tests/codegen-llvm/slice-iter-fold.rs
+++ b/tests/codegen-llvm/slice-iter-fold.rs
@@ -5,7 +5,7 @@
 #[no_mangle]
 pub fn slice_fold_to_last(slice: &[i32]) -> Option<&i32> {
     // CHECK-NOT: loop
-    // CHECK-NOT: br
+    // CHECK-NOT: br {{.*}}
     // CHECK-NOT: call
     // CHECK: ret
     slice.iter().fold(None, |_, i| Some(i))

--- a/tests/codegen-llvm/vecdeque-drain.rs
+++ b/tests/codegen-llvm/vecdeque-drain.rs
@@ -10,7 +10,7 @@ use std::collections::VecDeque;
 
 // CHECK-LABEL: @clear
 // CHECK-NOT: call
-// CHECK-NOT: br
+// CHECK-NOT: br {{.*}}
 // CHECK: getelementptr inbounds
 // CHECK-NEXT: {{call void @llvm.memset|store}}
 // CHECK-NEXT: ret void
@@ -21,15 +21,15 @@ pub fn clear(v: &mut VecDeque<i32>) {
 
 // CHECK-LABEL: @truncate
 // CHECK-NOT: call
-// CHECK: br
+// CHECK: br {{.*}}
 // CHECK-NOT: call
-// CHECK: br
+// CHECK: br {{.*}}
 // CHECK-NOT: call
-// CHECK: br
+// CHECK: br {{.*}}
 // CHECK-NOT: call
-// CHECK: br
+// CHECK: br {{.*}}
 // CHECK-NOT: call
-// CHECK-NOT: br
+// CHECK-NOT: br {{.*}}
 // CHECK: ret void
 #[no_mangle]
 pub fn truncate(v: &mut VecDeque<i32>, n: usize) {
@@ -40,17 +40,17 @@ pub fn truncate(v: &mut VecDeque<i32>, n: usize) {
 
 // CHECK-LABEL: @advance
 // CHECK-NOT: call
-// CHECK: br
+// CHECK: br {{.*}}
 // CHECK-NOT: call
-// CHECK: br
+// CHECK: br {{.*}}
 // CHECK-NOT: call
-// CHECK: br
+// CHECK: br {{.*}}
 // CHECK-NOT: call
-// CHECK: br
+// CHECK: br {{.*}}
 // CHECK-NOT: call
-// CHECK: br
+// CHECK: br {{.*}}
 // CHECK-NOT: call
-// CHECK-NOT: br
+// CHECK-NOT: br {{.*}}
 // CHECK: ret void
 #[no_mangle]
 pub fn advance(v: &mut VecDeque<i32>, n: usize) {


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

`// CHECK-NOT: br` is fragile to false positives in mangled symbol names, while `// CHECK-NOT: br {{.*}}` is not. Remove and forbid the former in codegen tests, and suggest the latter.

cc https://github.com/rust-lang/rust/pull/149125#issuecomment-3560003847 where this caused a CI failure due to a v0 mangled symbol containing `br` in a disambiguator/crate hash/something.
