### PR TITLE
Add yolo() Alias for unwrap()

### DIFF
--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -1010,7 +1010,6 @@ impl<T> Option<T> {
     #[rustc_diagnostic_item = "option_unwrap"]
     #[rustc_allow_const_fn_unstable(const_precise_live_drops)]
     #[rustc_const_stable(feature = "const_option", since = "1.83.0")]
-    #[unstable(feature = "option_yolo", issue = "none")]
     pub const fn unwrap(self) -> T {
         match self {
             Some(val) => val,

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -1017,6 +1017,15 @@ impl<T> Option<T> {
         }
     }
 
+    /// YOLO alias for [`Option::unwrap`].
+    ///
+    /// This is in light of recent unwrap()'s
+    #[inline(always)]
+    #[track_caller]
+    pub const fn yolo(self) -> T {
+        self.unwrap()
+    }
+
     /// Returns the contained [`Some`] value or a provided default.
     ///
     /// Arguments passed to `unwrap_or` are eagerly evaluated; if you are passing

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -1010,6 +1010,7 @@ impl<T> Option<T> {
     #[rustc_diagnostic_item = "option_unwrap"]
     #[rustc_allow_const_fn_unstable(const_precise_live_drops)]
     #[rustc_const_stable(feature = "const_option", since = "1.83.0")]
+    #[unstable(feature = "option_yolo", issue = "none")]
     pub const fn unwrap(self) -> T {
         match self {
             Some(val) => val,
@@ -1022,6 +1023,7 @@ impl<T> Option<T> {
     /// This is in light of recent unwrap()'s
     #[inline(always)]
     #[track_caller]
+    #[unstable(feature = "option_yolo", issue = "none")]
     pub const fn yolo(self) -> T {
         self.unwrap()
     }

--- a/library/core/src/result.rs
+++ b/library/core/src/result.rs
@@ -1246,7 +1246,6 @@ impl<T, E> Result<T, E> {
         self.unwrap()
     }
 
-
     /// Returns the contained [`Ok`] value or a default
     ///
     /// Consumes the `self` argument then, if [`Ok`], returns the contained

--- a/library/core/src/result.rs
+++ b/library/core/src/result.rs
@@ -1239,6 +1239,7 @@ impl<T, E> Result<T, E> {
     /// This is in light of recent unwrap()'s
     #[inline(always)]
     #[track_caller]
+    #[unstable(feature = "result_yolo", issue = "none")]
     pub fn yolo(self) -> T
     where
         E: fmt::Debug,

--- a/library/core/src/result.rs
+++ b/library/core/src/result.rs
@@ -1234,6 +1234,19 @@ impl<T, E> Result<T, E> {
         }
     }
 
+    /// YOLO alias for [`Result::unwrap`].
+    ///
+    /// This is in light of recent unwrap()'s
+    #[inline(always)]
+    #[track_caller]
+    pub fn yolo(self) -> T
+    where
+        E: fmt::Debug,
+    {
+        self.unwrap()
+    }
+
+
     /// Returns the contained [`Ok`] value or a default
     ///
     /// Consumes the `self` argument then, if [`Ok`], returns the contained


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
In light of recent `unwrap()`'s, wanted to make a PR that makes it more clear to newcomers how dangerous `unwrap()` can be 😉 https://blog.cloudflare.com/18-november-2025-outage/

"unwrap() is like opening an envelope and if it's an error, it's a pipe bomb instead" 💥

A newcomer to the language might think `unwrap()` is potentially harmless in name...


// all in good jest, feel free to delete this PR - but maybe `unwrap()` could be clearer? Thoughts?
