### PR TITLE
Add suggest alternatives for Out-of-range \x escapes

### DIFF
--- a/compiler/rustc_parse/messages.ftl
+++ b/compiler/rustc_parse/messages.ftl
@@ -732,8 +732,6 @@ parse_or_in_let_chain = `||` operators are not supported in let chain conditions
 
 parse_or_pattern_not_allowed_in_fn_parameters = function parameters require top-level or-patterns in parentheses
 parse_or_pattern_not_allowed_in_let_binding = `let` bindings require top-level or-patterns in parentheses
-parse_out_of_range_hex_escape = out of range hex escape
-    .label = must be a character in the range [\x00-\x7f]
 
 parse_outer_attr_explanation = outer attributes, like `#[test]`, annotate the item following them
 

--- a/compiler/rustc_parse/src/errors.rs
+++ b/compiler/rustc_parse/src/errors.rs
@@ -2455,12 +2455,6 @@ pub(crate) enum UnescapeError {
         is_hex: bool,
         ch: String,
     },
-    #[diag(parse_out_of_range_hex_escape)]
-    OutOfRangeHexEscape(
-        #[primary_span]
-        #[label]
-        Span,
-    ),
     #[diag(parse_leading_underscore_unicode_escape)]
     LeadingUnderscoreUnicodeEscape {
         #[primary_span]

--- a/tests/ui/parser/ascii-only-character-escape.stderr
+++ b/tests/ui/parser/ascii-only-character-escape.stderr
@@ -3,18 +3,27 @@ error: out of range hex escape
    |
 LL |     let x = "\x80";
    |              ^^^^ must be a character in the range [\x00-\x7f]
+   |
+   = help: if you want to write a byte literal, use `b'\x80'`
+   = help: if you want to write a Unicode character, use `'\u{80}'`
 
 error: out of range hex escape
   --> $DIR/ascii-only-character-escape.rs:3:14
    |
 LL |     let y = "\xff";
    |              ^^^^ must be a character in the range [\x00-\x7f]
+   |
+   = help: if you want to write a byte literal, use `b'\xff'`
+   = help: if you want to write a Unicode character, use `'\u{FF}'`
 
 error: out of range hex escape
   --> $DIR/ascii-only-character-escape.rs:4:14
    |
 LL |     let z = "\xe2";
    |              ^^^^ must be a character in the range [\x00-\x7f]
+   |
+   = help: if you want to write a byte literal, use `b'\xe2'`
+   = help: if you want to write a Unicode character, use `'\u{E2}'`
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/parser/out-of-range-hex-escape-suggestions-148917.rs
+++ b/tests/ui/parser/out-of-range-hex-escape-suggestions-148917.rs
@@ -1,0 +1,21 @@
+fn main() {
+    let _c = '\xFF'; //~ ERROR out of range hex escape
+    let _s = "\xFF"; //~ ERROR out of range hex escape
+
+    let _c2 = '\xff'; //~ ERROR out of range hex escape
+    let _s2 = "\xff"; //~ ERROR out of range hex escape
+
+    let _c3 = '\x80'; //~ ERROR out of range hex escape
+    let _s3 = "\x80"; //~ ERROR out of range hex escape
+
+    // Byte literals should not get suggestions (they're already valid)
+    let _b = b'\xFF'; // OK
+    let _bs = b"\xFF"; // OK
+
+    dbg!('\xFF'); //~ ERROR out of range hex escape
+
+    // do not suggest for out of range escapes that are too long
+    dbg!("\xFFFFF"); //~ ERROR out of range hex escape
+
+    dbg!("this is some kind of string \xa7"); //~ ERROR out of range hex escape
+}

--- a/tests/ui/parser/out-of-range-hex-escape-suggestions-148917.stderr
+++ b/tests/ui/parser/out-of-range-hex-escape-suggestions-148917.stderr
@@ -1,0 +1,77 @@
+error: out of range hex escape
+  --> $DIR/out-of-range-hex-escape-suggestions-148917.rs:2:15
+   |
+LL |     let _c = '\xFF';
+   |               ^^^^ must be a character in the range [\x00-\x7f]
+   |
+   = help: if you want to write a byte literal, use `b'\xFF'`
+   = help: if you want to write a Unicode character, use `'\u{FF}'`
+
+error: out of range hex escape
+  --> $DIR/out-of-range-hex-escape-suggestions-148917.rs:3:15
+   |
+LL |     let _s = "\xFF";
+   |               ^^^^ must be a character in the range [\x00-\x7f]
+   |
+   = help: if you want to write a byte literal, use `b'\xFF'`
+   = help: if you want to write a Unicode character, use `'\u{FF}'`
+
+error: out of range hex escape
+  --> $DIR/out-of-range-hex-escape-suggestions-148917.rs:5:16
+   |
+LL |     let _c2 = '\xff';
+   |                ^^^^ must be a character in the range [\x00-\x7f]
+   |
+   = help: if you want to write a byte literal, use `b'\xff'`
+   = help: if you want to write a Unicode character, use `'\u{FF}'`
+
+error: out of range hex escape
+  --> $DIR/out-of-range-hex-escape-suggestions-148917.rs:6:16
+   |
+LL |     let _s2 = "\xff";
+   |                ^^^^ must be a character in the range [\x00-\x7f]
+   |
+   = help: if you want to write a byte literal, use `b'\xff'`
+   = help: if you want to write a Unicode character, use `'\u{FF}'`
+
+error: out of range hex escape
+  --> $DIR/out-of-range-hex-escape-suggestions-148917.rs:8:16
+   |
+LL |     let _c3 = '\x80';
+   |                ^^^^ must be a character in the range [\x00-\x7f]
+   |
+   = help: if you want to write a byte literal, use `b'\x80'`
+   = help: if you want to write a Unicode character, use `'\u{80}'`
+
+error: out of range hex escape
+  --> $DIR/out-of-range-hex-escape-suggestions-148917.rs:9:16
+   |
+LL |     let _s3 = "\x80";
+   |                ^^^^ must be a character in the range [\x00-\x7f]
+   |
+   = help: if you want to write a byte literal, use `b'\x80'`
+   = help: if you want to write a Unicode character, use `'\u{80}'`
+
+error: out of range hex escape
+  --> $DIR/out-of-range-hex-escape-suggestions-148917.rs:15:11
+   |
+LL |     dbg!('\xFF');
+   |           ^^^^ must be a character in the range [\x00-\x7f]
+   |
+   = help: if you want to write a byte literal, use `b'\xFF'`
+   = help: if you want to write a Unicode character, use `'\u{FF}'`
+
+error: out of range hex escape
+  --> $DIR/out-of-range-hex-escape-suggestions-148917.rs:18:11
+   |
+LL |     dbg!("\xFFFFF");
+   |           ^^^^ must be a character in the range [\x00-\x7f]
+
+error: out of range hex escape
+  --> $DIR/out-of-range-hex-escape-suggestions-148917.rs:20:39
+   |
+LL |     dbg!("this is some kind of string \xa7");
+   |                                       ^^^^ must be a character in the range [\x00-\x7f]
+
+error: aborting due to 9 previous errors
+


### PR DESCRIPTION
Fixes rust-lang/rust#148917

seems add two notes seems better.

r? @scottmcm