### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_codegen_llvm/src/back/write.rs
+++ b/compiler/rustc_codegen_llvm/src/back/write.rs
@@ -765,6 +765,13 @@ pub(crate) unsafe fn llvm_optimize(
             llvm_plugins.len(),
         )
     };
+
+    if cgcx.target_is_like_gpu && config.offload.contains(&config::Offload::Enable) {
+        unsafe {
+            llvm::LLVMRustBundleImages(module.module_llvm.llmod(), module.module_llvm.tm.raw());
+        }
+    }
+
     result.into_result().unwrap_or_else(|()| llvm_err(dcx, LlvmError::RunLlvmPasses))
 }
 

--- a/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
@@ -1641,6 +1641,9 @@ unsafe extern "C" {
         Name: *const c_char,
     ) -> &'a Value;
 
+    /// Processes the module and writes it in an offload compatible way into a "host.out" file.
+    pub(crate) fn LLVMRustBundleImages<'a>(M: &'a Module, TM: &'a TargetMachine) -> bool;
+
     /// Writes a module to the specified path. Returns 0 on success.
     pub(crate) fn LLVMWriteBitcodeToFile(M: &Module, Path: *const c_char) -> c_int;
 

--- a/compiler/rustc_target/src/spec/targets/aarch64_pc_windows_gnullvm.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_pc_windows_gnullvm.rs
@@ -1,10 +1,11 @@
-use crate::spec::{Arch, FramePointer, Target, TargetMetadata, base};
+use crate::spec::{Arch, Cc, FramePointer, LinkerFlavor, Lld, Target, TargetMetadata, base};
 
 pub(crate) fn target() -> Target {
     let mut base = base::windows_gnullvm::opts();
     base.max_atomic_width = Some(128);
     base.features = "+v8a,+neon,+fp-armv8".into();
     base.linker = Some("aarch64-w64-mingw32-clang".into());
+    base.add_pre_link_args(LinkerFlavor::Gnu(Cc::No, Lld::No), &["-m", "arm64pe"]);
 
     // Microsoft recommends enabling frame pointers on Arm64 Windows.
     // From https://learn.microsoft.com/en-us/cpp/build/arm64-windows-abi-conventions?view=msvc-170#integer-registers

--- a/compiler/rustc_target/src/spec/targets/x86_64_pc_windows_gnullvm.rs
+++ b/compiler/rustc_target/src/spec/targets/x86_64_pc_windows_gnullvm.rs
@@ -6,6 +6,7 @@ pub(crate) fn target() -> Target {
     base.features = "+cx16,+sse3,+sahf".into();
     base.plt_by_default = false;
     base.add_pre_link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &["-m64"]);
+    base.add_pre_link_args(LinkerFlavor::Gnu(Cc::No, Lld::No), &["-m", "i386pep"]);
     base.max_atomic_width = Some(128);
     base.linker = Some("x86_64-w64-mingw32-clang".into());
 

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -1,12 +1,13 @@
 // ignore-tidy-filelength
 use core::ops::ControlFlow;
 use std::borrow::Cow;
+use std::collections::hash_set;
 use std::path::PathBuf;
 
 use rustc_abi::ExternAbi;
 use rustc_ast::ast::LitKind;
 use rustc_ast::{LitIntType, TraitObjectSyntax};
-use rustc_data_structures::fx::FxHashMap;
+use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_data_structures::unord::UnordSet;
 use rustc_errors::codes::*;
 use rustc_errors::{
@@ -1956,11 +1957,17 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                         if self.tcx.visibility(did).is_accessible_from(body_def_id, self.tcx) {
                             // don't suggest foreign `#[doc(hidden)]` types
                             if !did.is_local() {
-                                while let Some(parent) = parent_map.get(&did) {
+                                let mut previously_seen_dids: FxHashSet<DefId> = Default::default();
+                                previously_seen_dids.insert(did);
+                                while let Some(&parent) = parent_map.get(&did)
+                                    && let hash_set::Entry::Vacant(v) =
+                                        previously_seen_dids.entry(parent)
+                                {
                                     if self.tcx.is_doc_hidden(did) {
                                         return false;
                                     }
-                                    did = *parent;
+                                    v.insert();
+                                    did = parent;
                                 }
                             }
                             true

--- a/compiler/rustc_trait_selection/src/lib.rs
+++ b/compiler/rustc_trait_selection/src/lib.rs
@@ -17,6 +17,7 @@
 #![feature(associated_type_defaults)]
 #![feature(box_patterns)]
 #![feature(default_field_values)]
+#![feature(hash_set_entry)]
 #![feature(if_let_guard)]
 #![feature(iter_intersperse)]
 #![feature(iterator_try_reduce)]

--- a/compiler/rustc_ty_utils/src/opaque_types.rs
+++ b/compiler/rustc_ty_utils/src/opaque_types.rs
@@ -64,7 +64,10 @@ impl<'tcx> OpaqueTypeCollector<'tcx> {
 
     #[instrument(level = "trace", skip(self))]
     fn collect_taits_declared_in_body(&mut self) {
-        let body = self.tcx.hir_body_owned_by(self.item).value;
+        let Some(body) = self.tcx.hir_maybe_body_owned_by(self.item) else {
+            return;
+        };
+        let body = body.value;
         struct TaitInBodyFinder<'a, 'tcx> {
             collector: &'a mut OpaqueTypeCollector<'tcx>,
         }

--- a/library/alloc/src/collections/vec_deque/mod.rs
+++ b/library/alloc/src/collections/vec_deque/mod.rs
@@ -2479,11 +2479,11 @@ impl<T, A: Allocator> VecDeque<T, A> {
         let other_len = len - at;
         let mut other = VecDeque::with_capacity_in(other_len, self.allocator().clone());
 
-        unsafe {
-            let (first_half, second_half) = self.as_slices();
+        let (first_half, second_half) = self.as_slices();
+        let first_len = first_half.len();
+        let second_len = second_half.len();
 
-            let first_len = first_half.len();
-            let second_len = second_half.len();
+        unsafe {
             if at < first_len {
                 // `at` lies in the first half.
                 let amount_in_first = first_len - at;

--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -448,7 +448,7 @@ fn copy_self_contained_objects(
                 DependencyType::TargetSelfContained,
             );
         }
-    } else if target.is_windows_gnu() {
+    } else if target.is_windows_gnu() || target.is_windows_gnullvm() {
         for obj in ["crt2.o", "dllcrt2.o"].iter() {
             let src = compiler_file(builder, &builder.cc(target), target, CLang::C, obj);
             let dst = libdir_self_contained.join(obj);

--- a/src/bootstrap/src/core/config/target_selection.rs
+++ b/src/bootstrap/src/core/config/target_selection.rs
@@ -86,6 +86,10 @@ impl TargetSelection {
         self.ends_with("windows-gnu")
     }
 
+    pub fn is_windows_gnullvm(&self) -> bool {
+        self.ends_with("windows-gnullvm")
+    }
+
     pub fn is_cygwin(&self) -> bool {
         self.is_windows() &&
         // ref. https://cygwin.com/pipermail/cygwin/2022-February/250802.html

--- a/src/doc/rustc-dev-guide/src/offload/usage.md
+++ b/src/doc/rustc-dev-guide/src/offload/usage.md
@@ -79,19 +79,8 @@ Now we generate the device code. Replace the target-cpu with the right code for 
 RUSTFLAGS="-Ctarget-cpu=gfx90a --emit=llvm-bc,llvm-ir -Zoffload=Enable -Zunstable-options" cargo +offload build -Zunstable-options -r -v --target amdgcn-amd-amdhsa -Zbuild-std=core
 ```
 
-Now find the `<libname>.ll` under target/amdgcn-amd-amdhsa folder and copy it to a device.ll file (or adjust the file names below).
-If you work on an NVIDIA or Intel gpu, please adjust the names acordingly and open an issue to share your results (either if you succeed or fail).
-First we compile our .ll files (good for manual inspections) to .bc files and clean up leftover artifacts. The cleanup is important, otherwise caching might interfere on following runs.
-```
-opt lib.ll -o lib.bc
-opt device.ll -o device.bc
-rm *.o
-rm bare.amdgcn.gfx90a.img*
-```
 
 ```
-"clang-offload-packager" "-o" "host.out" "--image=file=device.bc,triple=amdgcn-amd-amdhsa,arch=gfx90a,kind=openmp"
-
 "clang-21" "-cc1" "-triple" "x86_64-unknown-linux-gnu" "-S" "-save-temps=cwd" "-disable-free" "-clear-ast-before-backend" "-main-file-name" "lib.rs" "-mrelocation-model" "pic" "-pic-level" "2" "-pic-is-pie" "-mframe-pointer=all" "-fmath-errno" "-ffp-contract=on" "-fno-rounding-math" "-mconstructor-aliases" "-funwind-tables=2" "-target-cpu" "x86-64" "-tune-cpu" "generic" "-resource-dir" "/<ABSOLUTE_PATH_TO>/rust/build/x86_64-unknown-linux-gnu/llvm/lib/clang/21" "-ferror-limit" "19" "-fopenmp" "-fopenmp-offload-mandatory" "-fgnuc-version=4.2.1" "-fskip-odr-check-in-gmf" "-fembed-offload-object=host.out" "-fopenmp-targets=amdgcn-amd-amdhsa" "-faddrsig" "-D__GCC_HAVE_DWARF2_CFI_ASM=1" "-o" "host.s" "-x" "ir" "lib.bc"
 
 "clang-21" "-cc1as" "-triple" "x86_64-unknown-linux-gnu" "-filetype" "obj" "-main-file-name" "lib.rs" "-target-cpu" "x86-64" "-mrelocation-model" "pic" "-o" "host.o" "host.s"
@@ -99,7 +88,8 @@ rm bare.amdgcn.gfx90a.img*
 "clang-linker-wrapper" "--should-extract=gfx90a" "--device-compiler=amdgcn-amd-amdhsa=-g" "--device-compiler=amdgcn-amd-amdhsa=-save-temps=cwd" "--device-linker=amdgcn-amd-amdhsa=-lompdevice" "--host-triple=x86_64-unknown-linux-gnu" "--save-temps" "--linker-path=/ABSOlUTE_PATH_TO/rust/build/x86_64-unknown-linux-gnu/lld/bin/ld.lld" "--hash-style=gnu" "--eh-frame-hdr" "-m" "elf_x86_64" "-pie" "-dynamic-linker" "/lib64/ld-linux-x86-64.so.2" "-o" "bare" "/lib/../lib64/Scrt1.o" "/lib/../lib64/crti.o" "/ABSOLUTE_PATH_TO/crtbeginS.o" "-L/ABSOLUTE_PATH_TO/rust/build/x86_64-unknown-linux-gnu/llvm/bin/../lib/x86_64-unknown-linux-gnu" "-L/ABSOLUTE_PATH_TO/rust/build/x86_64-unknown-linux-gnu/llvm/lib/clang/21/lib/x86_64-unknown-linux-gnu" "-L/lib/../lib64" "-L/usr/lib64" "-L/lib" "-L/usr/lib" "host.o" "-lstdc++" "-lm" "-lomp" "-lomptarget" "-L/ABSOLUTE_PATH_TO/rust/build/x86_64-unknown-linux-gnu/llvm/lib" "-lgcc_s" "-lgcc" "-lpthread" "-lc" "-lgcc_s" "-lgcc" "/ABSOLUTE_PATH_TO/crtendS.o" "/lib/../lib64/crtn.o"
 ```
 
-Especially for the last command I recommend to not fix the paths, but rather just re-generate them by copying a bare-mode openmp example and compiling it with your clang. By adding `-###` to your clang invocation, you can see the invidual steps.
+Especially for the last three commands I recommend to not fix the paths, but rather just re-generate them by copying a bare-mode openmp example and compiling it with your clang. By adding `-###` to your clang invocation, you can see the invidual steps.
+You can ignore other steps, e.g. the invocation of a "clang-offload-packager".
 ```
 myclang++ -fuse-ld=lld -O3 -fopenmp  -fopenmp-offload-mandatory --offload-arch=gfx90a omp_bare.cpp -o main -###
 ```

--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -476,7 +476,7 @@ impl Builder {
                 }
                 // so is rust-mingw if it's available for the target
                 PkgType::RustMingw => {
-                    if host.ends_with("pc-windows-gnu") {
+                    if host.contains("pc-windows-gnu") {
                         components.push(host_component(pkg));
                     }
                 }

--- a/tests/ui/impl-trait/ice-148622-opaque-as-const-generics.rs
+++ b/tests/ui/impl-trait/ice-148622-opaque-as-const-generics.rs
@@ -1,0 +1,12 @@
+#![feature(type_alias_impl_trait)]
+
+pub type Opaque = impl std::future::Future;
+//~^ ERROR: unconstrained opaque type
+
+trait Foo<const N: Opaque> {
+    //~^ ERROR: `Opaque` is forbidden as the type of a const generic parameter
+    fn bar(&self) -> [u8; N];
+    //~^ ERROR: the constant `N` is not of type `usize`
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/ice-148622-opaque-as-const-generics.stderr
+++ b/tests/ui/impl-trait/ice-148622-opaque-as-const-generics.stderr
@@ -1,0 +1,31 @@
+error: `Opaque` is forbidden as the type of a const generic parameter
+  --> $DIR/ice-148622-opaque-as-const-generics.rs:6:20
+   |
+LL | trait Foo<const N: Opaque> {
+   |                    ^^^^^^
+   |
+   = note: the only supported types are integers, `bool`, and `char`
+
+error: the constant `N` is not of type `usize`
+  --> $DIR/ice-148622-opaque-as-const-generics.rs:8:22
+   |
+LL |     fn bar(&self) -> [u8; N];
+   |                      ^^^^^^^ expected `usize`, found future
+   |
+note: this item must have a `#[define_opaque(Opaque)]` attribute to be able to define hidden types
+  --> $DIR/ice-148622-opaque-as-const-generics.rs:8:8
+   |
+LL |     fn bar(&self) -> [u8; N];
+   |        ^^^
+   = note: the length of array `[u8; N]` must be type `usize`
+
+error: unconstrained opaque type
+  --> $DIR/ice-148622-opaque-as-const-generics.rs:3:19
+   |
+LL | pub type Opaque = impl std::future::Future;
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `Opaque` must be used in combination with a concrete type within the same crate
+
+error: aborting due to 3 previous errors
+

--- a/tests/ui/suggestions/auxiliary/hidden-struct.rs
+++ b/tests/ui/suggestions/auxiliary/hidden-struct.rs
@@ -33,3 +33,6 @@ impl Marker for hidden::Foo {}
 impl Marker for hidden1::Bar {}
 impl Marker for Baz {}
 impl Marker for Quux {}
+
+
+pub use crate as library;

--- a/tests/ui/suggestions/dont-suggest-foreign-doc-hidden.rs
+++ b/tests/ui/suggestions/dont-suggest-foreign-doc-hidden.rs
@@ -21,7 +21,12 @@ pub fn test4(_: Quux) {}
 
 fn test5<T: hidden_struct::Marker>() {}
 
+fn test6<T: hidden_struct::library::Marker>() {}
+
 fn main() {
     test5::<i32>();
+    //~^ ERROR [E0277]
+
+    test6::<i32>();
     //~^ ERROR [E0277]
 }

--- a/tests/ui/suggestions/dont-suggest-foreign-doc-hidden.stderr
+++ b/tests/ui/suggestions/dont-suggest-foreign-doc-hidden.stderr
@@ -38,7 +38,7 @@ LL + use hidden_struct::Quux;
    |
 
 error[E0277]: the trait bound `i32: Marker` is not satisfied
-  --> $DIR/dont-suggest-foreign-doc-hidden.rs:25:13
+  --> $DIR/dont-suggest-foreign-doc-hidden.rs:27:13
    |
 LL |     test5::<i32>();
    |             ^^^ the trait `Marker` is not implemented for `i32`
@@ -59,7 +59,29 @@ note: required by a bound in `test5`
 LL | fn test5<T: hidden_struct::Marker>() {}
    |             ^^^^^^^^^^^^^^^^^^^^^ required by this bound in `test5`
 
-error: aborting due to 5 previous errors
+error[E0277]: the trait bound `i32: Marker` is not satisfied
+  --> $DIR/dont-suggest-foreign-doc-hidden.rs:30:13
+   |
+LL |     test6::<i32>();
+   |             ^^^ the trait `Marker` is not implemented for `i32`
+   |
+help: the following other types implement trait `Marker`
+  --> $DIR/auxiliary/hidden-struct.rs:31:1
+   |
+LL | impl Marker for Option<u32> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Option<u32>`
+...
+LL | impl Marker for Baz {}
+   | ^^^^^^^^^^^^^^^^^^^ `Baz`
+LL | impl Marker for Quux {}
+   | ^^^^^^^^^^^^^^^^^^^^ `Quux`
+note: required by a bound in `test6`
+  --> $DIR/dont-suggest-foreign-doc-hidden.rs:24:13
+   |
+LL | fn test6<T: hidden_struct::library::Marker>() {}
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `test6`
+
+error: aborting due to 6 previous errors
 
 Some errors have detailed explanations: E0277, E0412.
 For more information about an error, try `rustc --explain E0277`.


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#147536 (Add `rust-mingw` component for `*-windows-gnullvm` hosts)
 - rust-lang/rust#149168 (Fix ICE when collecting opaques from trait method declarations)
 - rust-lang/rust#149170 (automate gpu offloading - part 1)
 - rust-lang/rust#149185 (Handle cycles when checking impl candidates for `doc(hidden)`)
 - rust-lang/rust#149194 (Move safe computation out of unsafe block)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=147536,149168,149170,149185,149194)
<!-- homu-ignore:end -->