### PR TITLE
Allow shortening lifetime in CoerceUnsized for &mut

### DIFF
--- a/library/core/src/ops/unsize.rs
+++ b/library/core/src/ops/unsize.rs
@@ -39,7 +39,10 @@ pub trait CoerceUnsized<T: PointeeSized>: Sized {
 
 // &mut T -> &mut U
 #[unstable(feature = "coerce_unsized", issue = "18598")]
-impl<'a, T: PointeeSized + Unsize<U>, U: PointeeSized> CoerceUnsized<&'a mut U> for &'a mut T {}
+impl<'a, 'b: 'a, T: PointeeSized + Unsize<U>, U: PointeeSized> CoerceUnsized<&'a mut U>
+    for &'b mut T
+{
+}
 // &mut T -> &U
 #[unstable(feature = "coerce_unsized", issue = "18598")]
 impl<'a, 'b: 'a, T: PointeeSized + Unsize<U>, U: PointeeSized> CoerceUnsized<&'a U> for &'b mut T {}

--- a/tests/ui/coercion/unsize-lifetime-shrinking.rs
+++ b/tests/ui/coercion/unsize-lifetime-shrinking.rs
@@ -1,0 +1,253 @@
+// Even though a type being invariant prevents shortening lifetimes via subtyping,
+// unsize coercions may shorten lifetimes through an invariant type,
+// but only if the appropriate CoerceUnsized impl allows it to.
+
+use std::cell::{Cell, Ref, RefMut};
+
+struct Thing;
+trait Trait {}
+impl Trait for Thing {}
+trait Sub: Trait {}
+impl Sub for Thing {}
+
+//////////////////////////////////////////////////
+
+// &T -> &U has a CoerceUnsized impl that allows shortening lifetimes
+
+// Check that unsize-coercion works if the lifetime doesn't change.
+fn ref_to_ref_same_lifetime<'a>(x: Cell<&'a Thing>) -> Cell<&'a (dyn Trait + 'static)> {
+    x
+}
+
+// Sized-to-Sized unsize coercions aren't a thing, so this can't shorten the lifetime.
+fn ref_to_ref_sized_to_sized<'a: 'b, 'b>(x: Cell<&'a Thing>) -> Cell<&'b Thing> {
+    x
+}
+//~^^ ERROR lifetime may not live long enough
+
+// Sized-to-dyn unsize coercions can shorten the lifetime
+// if the CoerceUnsized impl allows it to.
+fn ref_to_ref_sized_to_dyn<'a: 'b, 'b>(x: Cell<&'a Thing>) -> Cell<&'b (dyn Trait + 'static)> {
+    x
+}
+
+// Trait upcasting is an unsize coercion.
+fn ref_to_ref_upcast<'a: 'b, 'b>(
+    x: Cell<&'a (dyn Sub + 'static)>,
+) -> Cell<&'b (dyn Trait + 'static)> {
+    x
+}
+
+// An "identity" coercion from a trait object to itself is an unsize coercion.
+fn ref_to_ref_dyn_same<'a: 'b, 'b>(
+    x: Cell<&'a (dyn Trait + 'static)>,
+) -> Cell<&'b (dyn Trait + 'static)> {
+    x
+}
+
+// An unsize coercion can, surprisingly, shorten the lifetime inside a trait object.
+// This ignores whether CoerceUnsized allows shortening lifetimes or not,
+// since the lifetime-shortening is done "inside" Unsize, not CoerceUnsized.
+fn ref_to_ref_shorten_in_dyn<'a>(x: Cell<&'a (dyn Trait + 'static)>) -> Cell<&'a (dyn Trait + 'a)> {
+    x
+}
+
+//////////////////////////////////////////////////
+
+// &mut T -> &U has a CoerceUnsized impl that allows shortening lifetimes
+
+// Check that unsize-coercion works if the lifetime doesn't change.
+fn mut_to_ref_same_lifetime<'a>(x: Cell<&'a mut Thing>) -> Cell<&'a (dyn Trait + 'static)> {
+    x
+}
+
+// Sized-to-Sized unsize coercions aren't a thing, so this can't shorten the lifetime.
+fn mut_to_ref_sized_to_sized<'a: 'b, 'b>(x: Cell<&'a mut Thing>) -> Cell<&'b Thing> {
+    x
+}
+//~^^ ERROR mismatched types
+
+// Sized-to-dyn unsize coercions can shorten the lifetime
+// if the CoerceUnsized impl allows it to.
+fn mut_to_ref_sized_to_dyn<'a: 'b, 'b>(x: Cell<&'a mut Thing>) -> Cell<&'b (dyn Trait + 'static)> {
+    x
+}
+
+// Trait upcasting is an unsize coercion.
+fn mut_to_ref_upcast<'a: 'b, 'b>(
+    x: Cell<&'a mut (dyn Sub + 'static)>,
+) -> Cell<&'b (dyn Trait + 'static)> {
+    x
+}
+
+// An "identity" coercion from a trait object to itself is an unsize coercion.
+fn mut_to_ref_dyn_same<'a: 'b, 'b>(
+    x: Cell<&'a mut (dyn Trait + 'static)>,
+) -> Cell<&'b (dyn Trait + 'static)> {
+    x
+}
+
+// An unsize coercion can, surprisingly, shorten the lifetime inside a trait object.
+// This ignores whether CoerceUnsized allows shortening lifetimes or not,
+// since the lifetime-shortening is done "inside" Unsize, not CoerceUnsized.
+fn mut_to_ref_shorten_in_dyn<'a>(
+    x: Cell<&'a mut (dyn Trait + 'static)>,
+) -> Cell<&'a (dyn Trait + 'a)> {
+    x
+}
+
+//////////////////////////////////////////////////
+
+// &mut T -> &mut U has a CoerceUnsized impl that does not allow shortening lifetimes.
+// This may change in the future.
+
+// Check that unsize-coercion works if the lifetime doesn't change.
+fn mut_to_mut_same_lifetime<'a>(x: Cell<&'a mut Thing>) -> Cell<&'a mut (dyn Trait + 'static)> {
+    x
+}
+
+// Sized-to-Sized unsize coercions aren't a thing, so this can't shorten the lifetime.
+fn mut_to_mut_sized_to_sized<'a: 'b, 'b>(x: Cell<&'a mut Thing>) -> Cell<&'b mut Thing> {
+    x
+}
+//~^^ ERROR lifetime may not live long enough
+
+// Sized-to-dyn unsize coercions can shorten the lifetime
+// if the CoerceUnsized impl allows it to.
+fn mut_to_mut_sized_to_dyn<'a: 'b, 'b>(
+    x: Cell<&'a mut Thing>,
+) -> Cell<&'b mut (dyn Trait + 'static)> {
+    x
+}
+//~^^ ERROR lifetime may not live long enough
+
+// Trait upcasting is an unsize coercion.
+fn mut_to_mut_upcast<'a: 'b, 'b>(
+    x: Cell<&'a mut (dyn Sub + 'static)>,
+) -> Cell<&'b mut (dyn Trait + 'static)> {
+    x
+}
+//~^^ ERROR lifetime may not live long enough
+
+// An "identity" coercion from a trait object to itself is an unsize coercion.
+fn mut_to_mut_dyn_same<'a: 'b, 'b>(
+    x: Cell<&'a mut (dyn Trait + 'static)>,
+) -> Cell<&'b mut (dyn Trait + 'static)> {
+    x
+}
+//~^^ ERROR lifetime may not live long enough
+
+// An unsize coercion can, surprisingly, shorten the lifetime inside a trait object.
+// This ignores whether CoerceUnsized allows shortening lifetimes or not,
+// since the lifetime-shortening is done "inside" Unsize, not CoerceUnsized.
+fn mut_to_mut_shorten_in_dyn<'a>(
+    x: Cell<&'a mut (dyn Trait + 'static)>,
+) -> Cell<&'a mut (dyn Trait + 'a)> {
+    x
+}
+
+//////////////////////////////////////////////////
+
+// Ref<T> -> Ref<U> has a CoerceUnsized impl that does not allow shortening lifetimes.
+// This may change in the future.
+
+// Check that unsize-coercion works if the lifetime doesn't change.
+fn cell_ref_same_lifetime<'a>(x: Cell<Ref<'a, Thing>>) -> Cell<Ref<'a, dyn Trait + 'static>> {
+    x
+}
+
+// Sized-to-Sized unsize coercions aren't a thing, so this can't shorten the lifetime.
+fn cell_ref_sized_to_sized<'a: 'b, 'b>(x: Cell<Ref<'a, Thing>>) -> Cell<Ref<'b, Thing>> {
+    x
+}
+//~^^ ERROR lifetime may not live long enough
+
+// Sized-to-dyn unsize coercions can shorten the lifetime
+// if the CoerceUnsized impl allows it to.
+fn cell_ref_sized_to_dyn<'a: 'b, 'b>(
+    x: Cell<Ref<'a, Thing>>,
+) -> Cell<Ref<'b, dyn Trait + 'static>> {
+    x
+}
+//~^^ ERROR lifetime may not live long enough
+
+// Trait upcasting is an unsize coercion.
+fn cell_ref_upcast<'a: 'b, 'b>(
+    x: Cell<Ref<'a, dyn Sub + 'static>>,
+) -> Cell<Ref<'b, dyn Trait + 'static>> {
+    x
+}
+//~^^ ERROR lifetime may not live long enough
+
+// An "identity" coercion from a trait object to itself is an unsize coercion.
+fn cell_ref_dyn_same<'a: 'b, 'b>(
+    x: Cell<Ref<'a, dyn Trait + 'static>>,
+) -> Cell<Ref<'b, dyn Trait + 'static>> {
+    x
+}
+//~^^ ERROR lifetime may not live long enough
+
+// An unsize coercion can, surprisingly, shorten the lifetime inside a trait object.
+// This ignores whether CoerceUnsized allows shortening lifetimes or not,
+// since the lifetime-shortening is done "inside" Unsize, not CoerceUnsized.
+fn cell_ref_shorten_in_dyn<'a>(
+    x: Cell<Ref<'a, dyn Trait + 'static>>,
+) -> Cell<Ref<'a, dyn Trait + 'a>> {
+    x
+}
+
+//////////////////////////////////////////////////
+
+// RefMut<T> -> RefMut<U> has a CoerceUnsized impl that does not allow shortening lifetimes.
+// This may change in the future.
+
+// Check that unsize-coercion works if the lifetime doesn't change.
+fn cell_ref_mut_same_lifetime<'a>(
+    x: Cell<RefMut<'a, Thing>>,
+) -> Cell<RefMut<'a, dyn Trait + 'static>> {
+    x
+}
+
+// Sized-to-Sized unsize coercions aren't a thing, so this can't shorten the lifetime.
+fn cell_ref_mut_sized_to_sized<'a: 'b, 'b>(x: Cell<RefMut<'a, Thing>>) -> Cell<RefMut<'b, Thing>> {
+    x
+}
+//~^^ ERROR lifetime may not live long enough
+
+// Sized-to-dyn unsize coercions can shorten the lifetime
+// if the CoerceUnsized impl allows it to.
+fn cell_ref_mut_sized_to_dyn<'a: 'b, 'b>(
+    x: Cell<RefMut<'a, Thing>>,
+) -> Cell<RefMut<'b, dyn Trait + 'static>> {
+    x
+}
+//~^^ ERROR lifetime may not live long enough
+
+// Trait upcasting is an unsize coercion.
+fn cell_ref_mut_upcast<'a: 'b, 'b>(
+    x: Cell<RefMut<'a, dyn Sub + 'static>>,
+) -> Cell<RefMut<'b, dyn Trait + 'static>> {
+    x
+}
+//~^^ ERROR lifetime may not live long enough
+
+// An "identity" coercion from a trait object to itself is an unsize coercion.
+fn cell_ref_mut_dyn_same<'a: 'b, 'b>(
+    x: Cell<RefMut<'a, dyn Trait + 'static>>,
+) -> Cell<RefMut<'b, dyn Trait + 'static>> {
+    x
+}
+//~^^ ERROR lifetime may not live long enough
+
+// An unsize coercion can, surprisingly, shorten the lifetime inside a trait object.
+// This ignores whether CoerceUnsized allows shortening lifetimes or not,
+// since the lifetime-shortening is done "inside" Unsize, not CoerceUnsized.
+fn cell_ref_mut_shorten_in_dyn<'a>(
+    x: Cell<RefMut<'a, dyn Trait + 'static>>,
+) -> Cell<RefMut<'a, dyn Trait + 'a>> {
+    x
+}
+
+//////////////////////////////////////////////////
+
+fn main() {}

--- a/tests/ui/coercion/unsize-lifetime-shrinking.rs
+++ b/tests/ui/coercion/unsize-lifetime-shrinking.rs
@@ -98,8 +98,7 @@ fn mut_to_ref_shorten_in_dyn<'a>(
 
 //////////////////////////////////////////////////
 
-// &mut T -> &mut U has a CoerceUnsized impl that does not allow shortening lifetimes.
-// This may change in the future.
+// &mut T -> &mut U has a CoerceUnsized impl that allows shortening lifetimes
 
 // Check that unsize-coercion works if the lifetime doesn't change.
 fn mut_to_mut_same_lifetime<'a>(x: Cell<&'a mut Thing>) -> Cell<&'a mut (dyn Trait + 'static)> {
@@ -119,7 +118,6 @@ fn mut_to_mut_sized_to_dyn<'a: 'b, 'b>(
 ) -> Cell<&'b mut (dyn Trait + 'static)> {
     x
 }
-//~^^ ERROR lifetime may not live long enough
 
 // Trait upcasting is an unsize coercion.
 fn mut_to_mut_upcast<'a: 'b, 'b>(
@@ -127,7 +125,6 @@ fn mut_to_mut_upcast<'a: 'b, 'b>(
 ) -> Cell<&'b mut (dyn Trait + 'static)> {
     x
 }
-//~^^ ERROR lifetime may not live long enough
 
 // An "identity" coercion from a trait object to itself is an unsize coercion.
 fn mut_to_mut_dyn_same<'a: 'b, 'b>(
@@ -135,7 +132,6 @@ fn mut_to_mut_dyn_same<'a: 'b, 'b>(
 ) -> Cell<&'b mut (dyn Trait + 'static)> {
     x
 }
-//~^^ ERROR lifetime may not live long enough
 
 // An unsize coercion can, surprisingly, shorten the lifetime inside a trait object.
 // This ignores whether CoerceUnsized allows shortening lifetimes or not,

--- a/tests/ui/coercion/unsize-lifetime-shrinking.stderr
+++ b/tests/ui/coercion/unsize-lifetime-shrinking.stderr
@@ -1,0 +1,218 @@
+error[E0308]: mismatched types
+  --> $DIR/unsize-lifetime-shrinking.rs:66:5
+   |
+LL | fn mut_to_ref_sized_to_sized<'a: 'b, 'b>(x: Cell<&'a mut Thing>) -> Cell<&'b Thing> {
+   |                                                                     --------------- expected `Cell<&'b Thing>` because of return type
+LL |     x
+   |     ^ types differ in mutability
+   |
+   = note: expected struct `Cell<&'b Thing>`
+              found struct `Cell<&'a mut Thing>`
+
+error: lifetime may not live long enough
+  --> $DIR/unsize-lifetime-shrinking.rs:24:5
+   |
+LL | fn ref_to_ref_sized_to_sized<'a: 'b, 'b>(x: Cell<&'a Thing>) -> Cell<&'b Thing> {
+   |                              --      -- lifetime `'b` defined here
+   |                              |
+   |                              lifetime `'a` defined here
+LL |     x
+   |     ^ function was supposed to return data with lifetime `'a` but it is returning data with lifetime `'b`
+   |
+   = help: consider adding the following bound: `'b: 'a`
+   = note: requirement occurs because of the type `Cell<&Thing>`, which makes the generic argument `&Thing` invariant
+   = note: the struct `Cell<T>` is invariant over the parameter `T`
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
+
+error: lifetime may not live long enough
+  --> $DIR/unsize-lifetime-shrinking.rs:111:5
+   |
+LL | fn mut_to_mut_sized_to_sized<'a: 'b, 'b>(x: Cell<&'a mut Thing>) -> Cell<&'b mut Thing> {
+   |                              --      -- lifetime `'b` defined here
+   |                              |
+   |                              lifetime `'a` defined here
+LL |     x
+   |     ^ function was supposed to return data with lifetime `'a` but it is returning data with lifetime `'b`
+   |
+   = help: consider adding the following bound: `'b: 'a`
+   = note: requirement occurs because of the type `Cell<&mut Thing>`, which makes the generic argument `&mut Thing` invariant
+   = note: the struct `Cell<T>` is invariant over the parameter `T`
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
+
+error: lifetime may not live long enough
+  --> $DIR/unsize-lifetime-shrinking.rs:120:5
+   |
+LL | fn mut_to_mut_sized_to_dyn<'a: 'b, 'b>(
+   |                            --      -- lifetime `'b` defined here
+   |                            |
+   |                            lifetime `'a` defined here
+...
+LL |     x
+   |     ^ function was supposed to return data with lifetime `'a` but it is returning data with lifetime `'b`
+   |
+   = help: consider adding the following bound: `'b: 'a`
+   = note: requirement occurs because of the type `Cell<&mut dyn Trait>`, which makes the generic argument `&mut dyn Trait` invariant
+   = note: the struct `Cell<T>` is invariant over the parameter `T`
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
+
+error: lifetime may not live long enough
+  --> $DIR/unsize-lifetime-shrinking.rs:128:5
+   |
+LL | fn mut_to_mut_upcast<'a: 'b, 'b>(
+   |                      --      -- lifetime `'b` defined here
+   |                      |
+   |                      lifetime `'a` defined here
+...
+LL |     x
+   |     ^ function was supposed to return data with lifetime `'a` but it is returning data with lifetime `'b`
+   |
+   = help: consider adding the following bound: `'b: 'a`
+   = note: requirement occurs because of the type `Cell<&mut dyn Trait>`, which makes the generic argument `&mut dyn Trait` invariant
+   = note: the struct `Cell<T>` is invariant over the parameter `T`
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
+
+error: lifetime may not live long enough
+  --> $DIR/unsize-lifetime-shrinking.rs:136:5
+   |
+LL | fn mut_to_mut_dyn_same<'a: 'b, 'b>(
+   |                        --      -- lifetime `'b` defined here
+   |                        |
+   |                        lifetime `'a` defined here
+...
+LL |     x
+   |     ^ function was supposed to return data with lifetime `'a` but it is returning data with lifetime `'b`
+   |
+   = help: consider adding the following bound: `'b: 'a`
+   = note: requirement occurs because of the type `Cell<&mut dyn Trait>`, which makes the generic argument `&mut dyn Trait` invariant
+   = note: the struct `Cell<T>` is invariant over the parameter `T`
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
+
+error: lifetime may not live long enough
+  --> $DIR/unsize-lifetime-shrinking.rs:161:5
+   |
+LL | fn cell_ref_sized_to_sized<'a: 'b, 'b>(x: Cell<Ref<'a, Thing>>) -> Cell<Ref<'b, Thing>> {
+   |                            --      -- lifetime `'b` defined here
+   |                            |
+   |                            lifetime `'a` defined here
+LL |     x
+   |     ^ function was supposed to return data with lifetime `'a` but it is returning data with lifetime `'b`
+   |
+   = help: consider adding the following bound: `'b: 'a`
+   = note: requirement occurs because of the type `Cell<Ref<'_, Thing>>`, which makes the generic argument `Ref<'_, Thing>` invariant
+   = note: the struct `Cell<T>` is invariant over the parameter `T`
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
+
+error: lifetime may not live long enough
+  --> $DIR/unsize-lifetime-shrinking.rs:170:5
+   |
+LL | fn cell_ref_sized_to_dyn<'a: 'b, 'b>(
+   |                          --      -- lifetime `'b` defined here
+   |                          |
+   |                          lifetime `'a` defined here
+...
+LL |     x
+   |     ^ function was supposed to return data with lifetime `'a` but it is returning data with lifetime `'b`
+   |
+   = help: consider adding the following bound: `'b: 'a`
+   = note: requirement occurs because of the type `Cell<Ref<'_, dyn Trait>>`, which makes the generic argument `Ref<'_, dyn Trait>` invariant
+   = note: the struct `Cell<T>` is invariant over the parameter `T`
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
+
+error: lifetime may not live long enough
+  --> $DIR/unsize-lifetime-shrinking.rs:178:5
+   |
+LL | fn cell_ref_upcast<'a: 'b, 'b>(
+   |                    --      -- lifetime `'b` defined here
+   |                    |
+   |                    lifetime `'a` defined here
+...
+LL |     x
+   |     ^ function was supposed to return data with lifetime `'a` but it is returning data with lifetime `'b`
+   |
+   = help: consider adding the following bound: `'b: 'a`
+   = note: requirement occurs because of the type `Cell<Ref<'_, dyn Trait>>`, which makes the generic argument `Ref<'_, dyn Trait>` invariant
+   = note: the struct `Cell<T>` is invariant over the parameter `T`
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
+
+error: lifetime may not live long enough
+  --> $DIR/unsize-lifetime-shrinking.rs:186:5
+   |
+LL | fn cell_ref_dyn_same<'a: 'b, 'b>(
+   |                      --      -- lifetime `'b` defined here
+   |                      |
+   |                      lifetime `'a` defined here
+...
+LL |     x
+   |     ^ function was supposed to return data with lifetime `'a` but it is returning data with lifetime `'b`
+   |
+   = help: consider adding the following bound: `'b: 'a`
+   = note: requirement occurs because of the type `Cell<Ref<'_, dyn Trait>>`, which makes the generic argument `Ref<'_, dyn Trait>` invariant
+   = note: the struct `Cell<T>` is invariant over the parameter `T`
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
+
+error: lifetime may not live long enough
+  --> $DIR/unsize-lifetime-shrinking.rs:213:5
+   |
+LL | fn cell_ref_mut_sized_to_sized<'a: 'b, 'b>(x: Cell<RefMut<'a, Thing>>) -> Cell<RefMut<'b, Thing>> {
+   |                                --      -- lifetime `'b` defined here
+   |                                |
+   |                                lifetime `'a` defined here
+LL |     x
+   |     ^ function was supposed to return data with lifetime `'a` but it is returning data with lifetime `'b`
+   |
+   = help: consider adding the following bound: `'b: 'a`
+   = note: requirement occurs because of the type `Cell<RefMut<'_, Thing>>`, which makes the generic argument `RefMut<'_, Thing>` invariant
+   = note: the struct `Cell<T>` is invariant over the parameter `T`
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
+
+error: lifetime may not live long enough
+  --> $DIR/unsize-lifetime-shrinking.rs:222:5
+   |
+LL | fn cell_ref_mut_sized_to_dyn<'a: 'b, 'b>(
+   |                              --      -- lifetime `'b` defined here
+   |                              |
+   |                              lifetime `'a` defined here
+...
+LL |     x
+   |     ^ function was supposed to return data with lifetime `'a` but it is returning data with lifetime `'b`
+   |
+   = help: consider adding the following bound: `'b: 'a`
+   = note: requirement occurs because of the type `Cell<RefMut<'_, dyn Trait>>`, which makes the generic argument `RefMut<'_, dyn Trait>` invariant
+   = note: the struct `Cell<T>` is invariant over the parameter `T`
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
+
+error: lifetime may not live long enough
+  --> $DIR/unsize-lifetime-shrinking.rs:230:5
+   |
+LL | fn cell_ref_mut_upcast<'a: 'b, 'b>(
+   |                        --      -- lifetime `'b` defined here
+   |                        |
+   |                        lifetime `'a` defined here
+...
+LL |     x
+   |     ^ function was supposed to return data with lifetime `'a` but it is returning data with lifetime `'b`
+   |
+   = help: consider adding the following bound: `'b: 'a`
+   = note: requirement occurs because of the type `Cell<RefMut<'_, dyn Trait>>`, which makes the generic argument `RefMut<'_, dyn Trait>` invariant
+   = note: the struct `Cell<T>` is invariant over the parameter `T`
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
+
+error: lifetime may not live long enough
+  --> $DIR/unsize-lifetime-shrinking.rs:238:5
+   |
+LL | fn cell_ref_mut_dyn_same<'a: 'b, 'b>(
+   |                          --      -- lifetime `'b` defined here
+   |                          |
+   |                          lifetime `'a` defined here
+...
+LL |     x
+   |     ^ function was supposed to return data with lifetime `'a` but it is returning data with lifetime `'b`
+   |
+   = help: consider adding the following bound: `'b: 'a`
+   = note: requirement occurs because of the type `Cell<RefMut<'_, dyn Trait>>`, which makes the generic argument `RefMut<'_, dyn Trait>` invariant
+   = note: the struct `Cell<T>` is invariant over the parameter `T`
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
+
+error: aborting due to 14 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/coercion/unsize-lifetime-shrinking.stderr
+++ b/tests/ui/coercion/unsize-lifetime-shrinking.stderr
@@ -25,7 +25,7 @@ LL |     x
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
 error: lifetime may not live long enough
-  --> $DIR/unsize-lifetime-shrinking.rs:111:5
+  --> $DIR/unsize-lifetime-shrinking.rs:110:5
    |
 LL | fn mut_to_mut_sized_to_sized<'a: 'b, 'b>(x: Cell<&'a mut Thing>) -> Cell<&'b mut Thing> {
    |                              --      -- lifetime `'b` defined here
@@ -40,55 +40,7 @@ LL |     x
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
 error: lifetime may not live long enough
-  --> $DIR/unsize-lifetime-shrinking.rs:120:5
-   |
-LL | fn mut_to_mut_sized_to_dyn<'a: 'b, 'b>(
-   |                            --      -- lifetime `'b` defined here
-   |                            |
-   |                            lifetime `'a` defined here
-...
-LL |     x
-   |     ^ function was supposed to return data with lifetime `'a` but it is returning data with lifetime `'b`
-   |
-   = help: consider adding the following bound: `'b: 'a`
-   = note: requirement occurs because of the type `Cell<&mut dyn Trait>`, which makes the generic argument `&mut dyn Trait` invariant
-   = note: the struct `Cell<T>` is invariant over the parameter `T`
-   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
-
-error: lifetime may not live long enough
-  --> $DIR/unsize-lifetime-shrinking.rs:128:5
-   |
-LL | fn mut_to_mut_upcast<'a: 'b, 'b>(
-   |                      --      -- lifetime `'b` defined here
-   |                      |
-   |                      lifetime `'a` defined here
-...
-LL |     x
-   |     ^ function was supposed to return data with lifetime `'a` but it is returning data with lifetime `'b`
-   |
-   = help: consider adding the following bound: `'b: 'a`
-   = note: requirement occurs because of the type `Cell<&mut dyn Trait>`, which makes the generic argument `&mut dyn Trait` invariant
-   = note: the struct `Cell<T>` is invariant over the parameter `T`
-   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
-
-error: lifetime may not live long enough
-  --> $DIR/unsize-lifetime-shrinking.rs:136:5
-   |
-LL | fn mut_to_mut_dyn_same<'a: 'b, 'b>(
-   |                        --      -- lifetime `'b` defined here
-   |                        |
-   |                        lifetime `'a` defined here
-...
-LL |     x
-   |     ^ function was supposed to return data with lifetime `'a` but it is returning data with lifetime `'b`
-   |
-   = help: consider adding the following bound: `'b: 'a`
-   = note: requirement occurs because of the type `Cell<&mut dyn Trait>`, which makes the generic argument `&mut dyn Trait` invariant
-   = note: the struct `Cell<T>` is invariant over the parameter `T`
-   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
-
-error: lifetime may not live long enough
-  --> $DIR/unsize-lifetime-shrinking.rs:161:5
+  --> $DIR/unsize-lifetime-shrinking.rs:157:5
    |
 LL | fn cell_ref_sized_to_sized<'a: 'b, 'b>(x: Cell<Ref<'a, Thing>>) -> Cell<Ref<'b, Thing>> {
    |                            --      -- lifetime `'b` defined here
@@ -103,7 +55,7 @@ LL |     x
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
 error: lifetime may not live long enough
-  --> $DIR/unsize-lifetime-shrinking.rs:170:5
+  --> $DIR/unsize-lifetime-shrinking.rs:166:5
    |
 LL | fn cell_ref_sized_to_dyn<'a: 'b, 'b>(
    |                          --      -- lifetime `'b` defined here
@@ -119,7 +71,7 @@ LL |     x
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
 error: lifetime may not live long enough
-  --> $DIR/unsize-lifetime-shrinking.rs:178:5
+  --> $DIR/unsize-lifetime-shrinking.rs:174:5
    |
 LL | fn cell_ref_upcast<'a: 'b, 'b>(
    |                    --      -- lifetime `'b` defined here
@@ -135,7 +87,7 @@ LL |     x
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
 error: lifetime may not live long enough
-  --> $DIR/unsize-lifetime-shrinking.rs:186:5
+  --> $DIR/unsize-lifetime-shrinking.rs:182:5
    |
 LL | fn cell_ref_dyn_same<'a: 'b, 'b>(
    |                      --      -- lifetime `'b` defined here
@@ -151,7 +103,7 @@ LL |     x
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
 error: lifetime may not live long enough
-  --> $DIR/unsize-lifetime-shrinking.rs:213:5
+  --> $DIR/unsize-lifetime-shrinking.rs:209:5
    |
 LL | fn cell_ref_mut_sized_to_sized<'a: 'b, 'b>(x: Cell<RefMut<'a, Thing>>) -> Cell<RefMut<'b, Thing>> {
    |                                --      -- lifetime `'b` defined here
@@ -166,7 +118,7 @@ LL |     x
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
 error: lifetime may not live long enough
-  --> $DIR/unsize-lifetime-shrinking.rs:222:5
+  --> $DIR/unsize-lifetime-shrinking.rs:218:5
    |
 LL | fn cell_ref_mut_sized_to_dyn<'a: 'b, 'b>(
    |                              --      -- lifetime `'b` defined here
@@ -182,7 +134,7 @@ LL |     x
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
 error: lifetime may not live long enough
-  --> $DIR/unsize-lifetime-shrinking.rs:230:5
+  --> $DIR/unsize-lifetime-shrinking.rs:226:5
    |
 LL | fn cell_ref_mut_upcast<'a: 'b, 'b>(
    |                        --      -- lifetime `'b` defined here
@@ -198,7 +150,7 @@ LL |     x
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
 error: lifetime may not live long enough
-  --> $DIR/unsize-lifetime-shrinking.rs:238:5
+  --> $DIR/unsize-lifetime-shrinking.rs:234:5
    |
 LL | fn cell_ref_mut_dyn_same<'a: 'b, 'b>(
    |                          --      -- lifetime `'b` defined here
@@ -213,6 +165,6 @@ LL |     x
    = note: the struct `Cell<T>` is invariant over the parameter `T`
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
-error: aborting due to 14 previous errors
+error: aborting due to 11 previous errors
 
 For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/149219)*
<!-- homu-ignore:end -->

This modifies the &mut -> &mut CoerceUnsized impl so that, it can shorten the lifetime.

Note that there are already two impls that allow shortening the lifetime like this (the &mut T -> &U and the &T -> &U impls). So this change makes the impls consistent with each other.

I initially tried to also do the same to the CoerceUnsized impl for core::cell::{Ref, RefMut}. However, this can't be done because Ref and RefMut "store" the lifetime and the data in different fields, and CoerceUnsized can only coerce one field.

This change has an effect on stable code, since it allows shortening lifetimes inside invariant types via a &mut -> &mut unsize coercion.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
