### PR TITLE
rustdoc: use dyn Fn in run_test to avoid monomorphization bloat

### DIFF
--- a/src/librustdoc/doctest.rs
+++ b/src/librustdoc/doctest.rs
@@ -553,7 +553,7 @@ fn run_test(
     doctest: RunnableDocTest,
     rustdoc_options: &RustdocOptions,
     supports_color: bool,
-    report_unused_externs: impl Fn(UnusedExterns),
+    report_unused_externs: &dyn Fn(UnusedExterns),
 ) -> (Duration, Result<(), TestFailure>) {
     let langstr = &doctest.langstr;
     // Make sure we emit well-formed executable names for our target.
@@ -1142,7 +1142,7 @@ fn doctest_run_fn(
         merged_test_code: None,
     };
     let (_, res) =
-        run_test(runnable_test, &rustdoc_options, doctest.supports_color, report_unused_externs);
+        run_test(runnable_test, &rustdoc_options, doctest.supports_color, &report_unused_externs);
 
     if let Err(err) = res {
         match err {

--- a/src/librustdoc/doctest/runner.rs
+++ b/src/librustdoc/doctest/runner.rs
@@ -210,7 +210,7 @@ std::process::Termination::report(test::test_main(test_args, tests, None))
             merged_test_code: Some(code),
         };
         let (duration, ret) =
-            run_test(runnable_test, rustdoc_options, self.supports_color, |_: UnusedExterns| {});
+            run_test(runnable_test, rustdoc_options, self.supports_color, &|_: UnusedExterns| {});
         (duration, if let Err(TestFailure::CompileError) = ret { Err(()) } else { Ok(ret.is_ok()) })
     }
 }


### PR DESCRIPTION
I wrote a little program to evaluate monomorphization bloat, and it said this could save several kB alone, I'm curious what perf would look like on this. 

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
