### PR TITLE
transmutability: Stall new solver when inference variables remain

### DIFF
--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
@@ -1174,6 +1174,9 @@ where
         dst: I::Ty,
         assume: I::Const,
     ) -> Result<Certainty, NoSolution> {
+        if src.has_non_region_infer() || dst.has_non_region_infer() {
+            return Ok(Certainty::AMBIGUOUS);
+        }
         self.delegate.is_transmutable(dst, src, assume)
     }
 

--- a/tests/ui/transmutability/transmutability-coherence.rs
+++ b/tests/ui/transmutability/transmutability-coherence.rs
@@ -1,0 +1,10 @@
+#![feature(transmutability)]
+trait OpaqueTrait {}
+
+impl<T: std::mem::TransmuteFrom<(), ()>> OpaqueTrait for T {}
+//~^ ERROR: type provided when a constant was expected
+
+impl<T> OpaqueTrait for &T where T: OpaqueTrait {}
+//~^ ERROR: conflicting implementations of trait `OpaqueTrait` for type `&_`
+
+fn main() {}

--- a/tests/ui/transmutability/transmutability-coherence.stderr
+++ b/tests/ui/transmutability/transmutability-coherence.stderr
@@ -1,0 +1,19 @@
+error[E0747]: type provided when a constant was expected
+  --> $DIR/transmutability-coherence.rs:4:37
+   |
+LL | impl<T: std::mem::TransmuteFrom<(), ()>> OpaqueTrait for T {}
+   |                                     ^^
+
+error[E0119]: conflicting implementations of trait `OpaqueTrait` for type `&_`
+  --> $DIR/transmutability-coherence.rs:7:1
+   |
+LL | impl<T: std::mem::TransmuteFrom<(), ()>> OpaqueTrait for T {}
+   | ---------------------------------------------------------- first implementation here
+...
+LL | impl<T> OpaqueTrait for &T where T: OpaqueTrait {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `&_`
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0119, E0747.
+For more information about an error, try `rustc --explain E0119`.


### PR DESCRIPTION
fixes rust-lang/rust#141400, fixes rust-lang/rust#148809

The new trait solver's `consider_builtin_transmute_candidate()` was passing types with inference variables directly to `rustc_transmute()`, which attempts layout computation and ICEs.

The old solver already guards against this [in `assemble_candidates_for_transmutability()`](https://github.com/rust-lang/rust/blob/2972b5e59f1c5529b6ba770437812fd83ab4ebd4/compiler/rustc_trait_selection/src/traits/select/candidate_assembly.rs#L1108-L1111) by setting `candidates.ambiguous = true`. Add the equivalent guard in the new solver by returning `forced_ambiguity` when the predicate contains non-region inference variables.