### PR TITLE
Make `proc_macro::Group` take up less space remove redundant field.

### DIFF
--- a/compiler/rustc_expand/src/proc_macro_server.rs
+++ b/compiler/rustc_expand/src/proc_macro_server.rs
@@ -151,11 +151,7 @@ impl FromInternal<(TokenStream, &mut Rustc<'_, '_>)> for Vec<TokenTree<TokenStre
                     trees.push(TokenTree::Group(Group {
                         delimiter: rustc_proc_macro::Delimiter::from_internal(delim),
                         stream: Some(stream),
-                        span: DelimSpan {
-                            open: span.open,
-                            close: span.close,
-                            entire: span.entire(),
-                        },
+                        span: DelimSpan { open: span.open, close: span.close },
                     }));
                     continue;
                 }

--- a/library/proc_macro/src/bridge/mod.rs
+++ b/library/proc_macro/src/bridge/mod.rs
@@ -420,16 +420,15 @@ compound_traits!(
 pub struct DelimSpan<Span> {
     pub open: Span,
     pub close: Span,
-    pub entire: Span,
 }
 
 impl<Span: Copy> DelimSpan<Span> {
     pub fn from_single(span: Span) -> Self {
-        DelimSpan { open: span, close: span, entire: span }
+        DelimSpan { open: span, close: span }
     }
 }
 
-compound_traits!(struct DelimSpan<Span> { open, close, entire });
+compound_traits!(struct DelimSpan<Span> { open, close });
 
 #[derive(Clone)]
 pub struct Group<TokenStream, Span> {

--- a/library/proc_macro/src/lib.rs
+++ b/library/proc_macro/src/lib.rs
@@ -847,7 +847,8 @@ impl Group {
     /// ```
     #[stable(feature = "proc_macro_lib2", since = "1.29.0")]
     pub fn span(&self) -> Span {
-        Span(self.0.span.entire)
+        let sp = self.0.span;
+        Span(sp.open.join(sp.close).unwrap_or(sp.open))
     }
 
     /// Returns the span pointing to the opening delimiter of this group.

--- a/src/tools/rust-analyzer/crates/proc-macro-api/src/legacy_protocol/msg/flat.rs
+++ b/src/tools/rust-analyzer/crates/proc-macro-api/src/legacy_protocol/msg/flat.rs
@@ -222,6 +222,7 @@ impl FlatTree {
             span: proc_macro_srv::DelimSpan {
                 open: call_site,
                 close: call_site,
+                #[cfg(bootstrap)]
                 entire: call_site,
             },
         };
@@ -273,6 +274,7 @@ impl FlatTree {
             span: proc_macro_srv::DelimSpan {
                 open: call_site,
                 close: call_site,
+                #[cfg(bootstrap)]
                 entire: call_site,
             },
         };
@@ -947,6 +949,7 @@ impl<T: SpanTransformer> Reader<'_, T> {
                     open: read_span(repr.open),
                     close: read_span(repr.close),
                     // FIXME
+                    #[cfg(bootstrap)]
                     entire: read_span(repr.close),
                 },
             };

--- a/src/tools/rust-analyzer/crates/proc-macro-srv/src/tests/mod.rs
+++ b/src/tools/rust-analyzer/crates/proc-macro-srv/src/tests/mod.rs
@@ -14,14 +14,14 @@ fn test_derive_empty() {
         expect![[r#"
             IDENT 1 struct
             IDENT 1 S
-            GROUP {} 1 1 1
+            GROUP {} 1 1
               IDENT 1 field
               PUNCT 1 : [alone]
               PUNCT 1 & [joint]
               PUNCT 1 ' [joint]
               IDENT 1 r#lt
               IDENT 1 fn
-              GROUP () 1 1 1
+              GROUP () 1 1
                 IDENT 1 u32
               PUNCT 1 - [joint]
               PUNCT 1 > [alone]
@@ -33,14 +33,14 @@ fn test_derive_empty() {
         expect![[r#"
             IDENT 42:Root[0000, 0]@0..6#ROOT2024 struct
             IDENT 42:Root[0000, 0]@7..8#ROOT2024 S
-            GROUP {} 42:Root[0000, 0]@9..10#ROOT2024 42:Root[0000, 0]@46..47#ROOT2024 42:Root[0000, 0]@9..47#ROOT2024
+            GROUP {} 42:Root[0000, 0]@9..10#ROOT2024 42:Root[0000, 0]@46..47#ROOT2024
               IDENT 42:Root[0000, 0]@11..16#ROOT2024 field
               PUNCT 42:Root[0000, 0]@16..17#ROOT2024 : [alone]
               PUNCT 42:Root[0000, 0]@18..19#ROOT2024 & [joint]
               PUNCT 42:Root[0000, 0]@22..23#ROOT2024 ' [joint]
               IDENT 42:Root[0000, 0]@22..24#ROOT2024 r#lt
               IDENT 42:Root[0000, 0]@25..27#ROOT2024 fn
-              GROUP () 42:Root[0000, 0]@27..28#ROOT2024 42:Root[0000, 0]@31..32#ROOT2024 42:Root[0000, 0]@27..32#ROOT2024
+              GROUP () 42:Root[0000, 0]@27..28#ROOT2024 42:Root[0000, 0]@31..32#ROOT2024
                 IDENT 42:Root[0000, 0]@28..31#ROOT2024 u32
               PUNCT 42:Root[0000, 0]@33..34#ROOT2024 - [joint]
               PUNCT 42:Root[0000, 0]@34..35#ROOT2024 > [alone]
@@ -60,7 +60,7 @@ fn test_derive_error() {
         expect![[r#"
             IDENT 1 struct
             IDENT 1 S
-            GROUP {} 1 1 1
+            GROUP {} 1 1
               IDENT 1 field
               PUNCT 1 : [alone]
               IDENT 1 u32
@@ -68,14 +68,14 @@ fn test_derive_error() {
 
             IDENT 1 compile_error
             PUNCT 1 ! [joint]
-            GROUP () 1 1 1
+            GROUP () 1 1
               LITER 1 Str #[derive(DeriveError)] struct S {field 58 u32 }
             PUNCT 1 ; [alone]
         "#]],
         expect![[r#"
             IDENT 42:Root[0000, 0]@0..6#ROOT2024 struct
             IDENT 42:Root[0000, 0]@7..8#ROOT2024 S
-            GROUP {} 42:Root[0000, 0]@9..10#ROOT2024 42:Root[0000, 0]@22..23#ROOT2024 42:Root[0000, 0]@9..23#ROOT2024
+            GROUP {} 42:Root[0000, 0]@9..10#ROOT2024 42:Root[0000, 0]@22..23#ROOT2024
               IDENT 42:Root[0000, 0]@11..16#ROOT2024 field
               PUNCT 42:Root[0000, 0]@16..17#ROOT2024 : [alone]
               IDENT 42:Root[0000, 0]@18..21#ROOT2024 u32
@@ -83,7 +83,7 @@ fn test_derive_error() {
 
             IDENT 42:Root[0000, 0]@0..13#ROOT2024 compile_error
             PUNCT 42:Root[0000, 0]@13..14#ROOT2024 ! [joint]
-            GROUP () 42:Root[0000, 0]@14..15#ROOT2024 42:Root[0000, 0]@64..65#ROOT2024 42:Root[0000, 0]@14..65#ROOT2024
+            GROUP () 42:Root[0000, 0]@14..15#ROOT2024 42:Root[0000, 0]@64..65#ROOT2024
               LITER 42:Root[0000, 0]@15..64#ROOT2024 Str #[derive(DeriveError)] struct S {field 58 u32 }
             PUNCT 42:Root[0000, 0]@65..66#ROOT2024 ; [alone]
         "#]],
@@ -102,7 +102,7 @@ fn test_fn_like_macro_noop() {
             PUNCT 1 , [alone]
             LITER 1 Integer 1
             PUNCT 1 , [alone]
-            GROUP [] 1 1 1
+            GROUP [] 1 1
 
 
             IDENT 1 ident
@@ -111,7 +111,7 @@ fn test_fn_like_macro_noop() {
             PUNCT 1 , [alone]
             LITER 1 Integer 1
             PUNCT 1 , [alone]
-            GROUP [] 1 1 1
+            GROUP [] 1 1
         "#]],
         expect![[r#"
             IDENT 42:Root[0000, 0]@0..5#ROOT2024 ident
@@ -120,7 +120,7 @@ fn test_fn_like_macro_noop() {
             PUNCT 42:Root[0000, 0]@8..9#ROOT2024 , [alone]
             LITER 42:Root[0000, 0]@10..11#ROOT2024 Integer 1
             PUNCT 42:Root[0000, 0]@11..12#ROOT2024 , [alone]
-            GROUP [] 42:Root[0000, 0]@13..14#ROOT2024 42:Root[0000, 0]@14..15#ROOT2024 42:Root[0000, 0]@13..15#ROOT2024
+            GROUP [] 42:Root[0000, 0]@13..14#ROOT2024 42:Root[0000, 0]@14..15#ROOT2024
 
 
             IDENT 42:Root[0000, 0]@0..5#ROOT2024 ident
@@ -129,7 +129,7 @@ fn test_fn_like_macro_noop() {
             PUNCT 42:Root[0000, 0]@8..9#ROOT2024 , [alone]
             LITER 42:Root[0000, 0]@10..11#ROOT2024 Integer 1
             PUNCT 42:Root[0000, 0]@11..12#ROOT2024 , [alone]
-            GROUP [] 42:Root[0000, 0]@13..14#ROOT2024 42:Root[0000, 0]@14..15#ROOT2024 42:Root[0000, 0]@13..15#ROOT2024
+            GROUP [] 42:Root[0000, 0]@13..14#ROOT2024 42:Root[0000, 0]@14..15#ROOT2024
         "#]],
     );
 }
@@ -142,22 +142,22 @@ fn test_fn_like_macro_clone_ident_subtree() {
         expect![[r#"
             IDENT 1 ident
             PUNCT 1 , [alone]
-            GROUP [] 1 1 1
+            GROUP [] 1 1
 
 
             IDENT 1 ident
             PUNCT 1 , [alone]
-            GROUP [] 1 1 1
+            GROUP [] 1 1
         "#]],
         expect![[r#"
             IDENT 42:Root[0000, 0]@0..5#ROOT2024 ident
             PUNCT 42:Root[0000, 0]@5..6#ROOT2024 , [alone]
-            GROUP [] 42:Root[0000, 0]@7..8#ROOT2024 42:Root[0000, 0]@8..9#ROOT2024 42:Root[0000, 0]@7..9#ROOT2024
+            GROUP [] 42:Root[0000, 0]@7..8#ROOT2024 42:Root[0000, 0]@8..9#ROOT2024
 
 
             IDENT 42:Root[0000, 0]@0..5#ROOT2024 ident
             PUNCT 42:Root[0000, 0]@5..6#ROOT2024 , [alone]
-            GROUP [] 42:Root[0000, 0]@7..9#ROOT2024 42:Root[0000, 0]@7..9#ROOT2024 42:Root[0000, 0]@7..9#ROOT2024
+            GROUP [] 42:Root[0000, 0]@7..9#ROOT2024 42:Root[0000, 0]@7..9#ROOT2024
         "#]],
     );
 }
@@ -462,7 +462,7 @@ fn test_attr_macro() {
         expect![[r#"
             IDENT 1 mod
             IDENT 1 m
-            GROUP {} 1 1 1
+            GROUP {} 1 1
 
 
             IDENT 1 some
@@ -471,14 +471,14 @@ fn test_attr_macro() {
 
             IDENT 1 compile_error
             PUNCT 1 ! [joint]
-            GROUP () 1 1 1
+            GROUP () 1 1
               LITER 1 Str #[attr_error(some arguments )] mod m {}
             PUNCT 1 ; [alone]
         "#]],
         expect![[r#"
             IDENT 42:Root[0000, 0]@0..3#ROOT2024 mod
             IDENT 42:Root[0000, 0]@4..5#ROOT2024 m
-            GROUP {} 42:Root[0000, 0]@6..7#ROOT2024 42:Root[0000, 0]@7..8#ROOT2024 42:Root[0000, 0]@6..8#ROOT2024
+            GROUP {} 42:Root[0000, 0]@6..7#ROOT2024 42:Root[0000, 0]@7..8#ROOT2024
 
 
             IDENT 42:Root[0000, 0]@0..4#ROOT2024 some
@@ -487,7 +487,7 @@ fn test_attr_macro() {
 
             IDENT 42:Root[0000, 0]@0..13#ROOT2024 compile_error
             PUNCT 42:Root[0000, 0]@13..14#ROOT2024 ! [joint]
-            GROUP () 42:Root[0000, 0]@14..15#ROOT2024 42:Root[0000, 0]@56..57#ROOT2024 42:Root[0000, 0]@14..57#ROOT2024
+            GROUP () 42:Root[0000, 0]@14..15#ROOT2024 42:Root[0000, 0]@56..57#ROOT2024
               LITER 42:Root[0000, 0]@15..56#ROOT2024 Str #[attr_error(some arguments )] mod m {}
             PUNCT 42:Root[0000, 0]@57..58#ROOT2024 ; [alone]
         "#]],

--- a/src/tools/rust-analyzer/crates/proc-macro-srv/src/token_stream.rs
+++ b/src/tools/rust-analyzer/crates/proc-macro-srv/src/token_stream.rs
@@ -115,6 +115,7 @@ impl<S> TokenStream<S> {
                                 Some(TokenStream::new(stream))
                             },
                             span: DelimSpan {
+                                #[cfg(bootstrap)]
                                 entire: span.derive_ranged(open_range.start..range.end),
                                 open: span.derive_ranged(open_range),
                                 close: span.derive_ranged(range),
@@ -143,6 +144,7 @@ impl<S> TokenStream<S> {
                                 Some(TokenStream::new(stream))
                             },
                             span: DelimSpan {
+                                #[cfg(bootstrap)]
                                 entire: span.derive_ranged(open_range.start..range.end),
                                 open: span.derive_ranged(open_range),
                                 close: span.derive_ranged(range),
@@ -171,6 +173,7 @@ impl<S> TokenStream<S> {
                                 Some(TokenStream::new(stream))
                             },
                             span: DelimSpan {
+                                #[cfg(bootstrap)]
                                 entire: span.derive_ranged(open_range.start..range.end),
                                 open: span.derive_ranged(open_range),
                                 close: span.derive_ranged(range),
@@ -204,7 +207,12 @@ impl<S> TokenStream<S> {
                                 span: span.derive_ranged(range),
                             }),
                         ])),
-                        span: DelimSpan { open: span, close: span, entire: span },
+                        span: DelimSpan {
+                            open: span,
+                            close: span,
+                            #[cfg(bootstrap)]
+                            entire: span,
+                        },
                     }));
                 }
                 rustc_lexer::TokenKind::BlockComment { doc_style: Some(doc_style), terminated } => {
@@ -230,7 +238,12 @@ impl<S> TokenStream<S> {
                                 span: span.derive_ranged(range),
                             }),
                         ])),
-                        span: DelimSpan { open: span, close: span, entire: span },
+                        span: DelimSpan {
+                            open: span,
+                            close: span,
+                            #[cfg(bootstrap)]
+                            entire: span,
+                        },
                     }));
                 }
                 rustc_lexer::TokenKind::Whitespace => continue,
@@ -570,7 +583,7 @@ fn debug_token_tree<S: fmt::Debug>(
         TokenTree::Group(Group { delimiter, stream, span }) => {
             writeln!(
                 f,
-                "GROUP {}{} {:#?} {:#?} {:#?}",
+                "GROUP {}{} {:#?} {:#?}",
                 match delimiter {
                     proc_macro::Delimiter::Parenthesis => "(",
                     proc_macro::Delimiter::Brace => "{",
@@ -585,7 +598,6 @@ fn debug_token_tree<S: fmt::Debug>(
                 },
                 span.open,
                 span.close,
-                span.entire,
             )?;
             if let Some(stream) = stream {
                 debug_token_stream(stream, depth + 1, f)?;


### PR DESCRIPTION
The field `entire` is redundant. This saves 4 bytes and makes the `proc_macro::DelimSpan` match up with what the compiler uses. Moreover `Group::set_span()` overwrites all the fields anyways so there not is any chance for entire not to be derived from the open and close. Lastly, the way the compiler constructs the entire field is also be based off the open and close. 

This takes the size from 20 bytes to 16 bytes which is also a nice power of 2.