### PR TITLE
Add doc aliases "vector" and "list" to `Vec`

### DIFF
--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -433,6 +433,8 @@ mod spec_extend;
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_diagnostic_item = "Vec"]
 #[rustc_insignificant_dtor]
+#[doc(alias = "list")]
+#[doc(alias = "vector")]
 pub struct Vec<T, #[unstable(feature = "allocator_api", issue = "32838")] A: Allocator = Global> {
     buf: RawVec<T, A>,
     len: usize,


### PR DESCRIPTION
- "vector" is what "vec" is short form for.
- "list" is a common name for this concept in a lot of other languages (`ArrayList` in Java, `list` in Python, `List` in C#). C++ uses the term for a linked list (`std::list`), so maybe this is contentious?

I believe that this falls under [the doc alias policy](https://std-dev-guide.rust-lang.org/policy/doc-alias.html), and I think it's plausible that a newcomer would search for either of these terms, and expect to find `Vec`.

r? libs