### PR TITLE
Clarify edge cases for Barrier::new

### DIFF
--- a/library/std/src/sync/barrier.rs
+++ b/library/std/src/sync/barrier.rs
@@ -65,8 +65,8 @@ impl fmt::Debug for Barrier {
 impl Barrier {
     /// Creates a new barrier that can block a given number of threads.
     ///
-    /// A barrier will block `n`-1 threads which call [`wait()`] and then wake
-    /// up all threads at once when the `n`th thread calls [`wait()`].
+    /// A barrier will block all threads which call [`wait()`] until the `n`th thread calls [`wait()`],
+    /// and then wake up all threads at once.
     ///
     /// [`wait()`]: Barrier::wait
     ///


### PR DESCRIPTION
... since n-1 is undefined when the usize n is 0.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
