### PR TITLE
Rollup of 2 pull requests

### DIFF
--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -433,6 +433,8 @@ mod spec_extend;
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_diagnostic_item = "Vec"]
 #[rustc_insignificant_dtor]
+#[doc(alias = "list")]
+#[doc(alias = "vector")]
 pub struct Vec<T, #[unstable(feature = "allocator_api", issue = "32838")] A: Allocator = Global> {
     buf: RawVec<T, A>,
     len: usize,

--- a/tests/ui/dyn-compatibility/no-duplicate-e0038.rs
+++ b/tests/ui/dyn-compatibility/no-duplicate-e0038.rs
@@ -1,0 +1,17 @@
+// Test that E0038 is not emitted twice for the same trait object coercion
+// regression test for issue <https://github.com/rust-lang/rust/issues/128705>
+
+#![allow(dead_code)]
+
+trait Tr {
+    const N: usize;
+}
+
+impl Tr for u8 {
+    const N: usize = 1;
+}
+
+fn main() {
+    let x: &dyn Tr = &0_u8;
+    //~^ ERROR E0038
+}

--- a/tests/ui/dyn-compatibility/no-duplicate-e0038.stderr
+++ b/tests/ui/dyn-compatibility/no-duplicate-e0038.stderr
@@ -1,0 +1,20 @@
+error[E0038]: the trait `Tr` is not dyn compatible
+  --> $DIR/no-duplicate-e0038.rs:15:17
+   |
+LL |     let x: &dyn Tr = &0_u8;
+   |                 ^^ `Tr` is not dyn compatible
+   |
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
+  --> $DIR/no-duplicate-e0038.rs:7:11
+   |
+LL | trait Tr {
+   |       -- this trait is not dyn compatible...
+LL |     const N: usize;
+   |           ^ ...because it contains this associated `const`
+   = help: consider moving `N` to another trait
+   = help: only type `u8` implements `Tr`; consider using it directly instead.
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0038`.


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#149179 (Add regression test for 128705)
 - rust-lang/rust#149232 (Add doc aliases "vector" and "list" to `Vec`)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=149179,149232)
<!-- homu-ignore:end -->