### PR TITLE
Fix std::mem::drop rustdoc misleading statement

### DIFF
--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -898,8 +898,6 @@ pub const fn replace<T>(dest: &mut T, src: T) -> T {
 
 /// Disposes of a value.
 ///
-/// This does so by calling the argument's implementation of [`Drop`][drop].
-///
 /// This effectively does nothing for types which implement `Copy`, e.g.
 /// integers. Such values are copied and _then_ moved into the function, so the
 /// value persists after this function call.
@@ -910,7 +908,7 @@ pub const fn replace<T>(dest: &mut T, src: T) -> T {
 /// pub fn drop<T>(_x: T) {}
 /// ```
 ///
-/// Because `_x` is moved into the function, it is automatically dropped before
+/// Because `_x` is moved into the function, it is automatically [dropped][drop] before
 /// the function returns.
 ///
 /// [drop]: Drop

--- a/tests/ui/thir-print/offset_of.stdout
+++ b/tests/ui/thir-print/offset_of.stdout
@@ -68,7 +68,7 @@ body:
                                             )
                                             else_block: None
                                             lint_level: Explicit(HirId(DefId(offset_of::concrete).10))
-                                            span: $DIR/offset_of.rs:37:5: 1435:57 (#0)
+                                            span: $DIR/offset_of.rs:37:5: 1433:57 (#0)
                                         }
                                     }
                                     Stmt {
@@ -117,7 +117,7 @@ body:
                                             )
                                             else_block: None
                                             lint_level: Explicit(HirId(DefId(offset_of::concrete).20))
-                                            span: $DIR/offset_of.rs:38:5: 1435:57 (#0)
+                                            span: $DIR/offset_of.rs:38:5: 1433:57 (#0)
                                         }
                                     }
                                     Stmt {
@@ -166,7 +166,7 @@ body:
                                             )
                                             else_block: None
                                             lint_level: Explicit(HirId(DefId(offset_of::concrete).30))
-                                            span: $DIR/offset_of.rs:39:5: 1435:57 (#0)
+                                            span: $DIR/offset_of.rs:39:5: 1433:57 (#0)
                                         }
                                     }
                                     Stmt {
@@ -215,7 +215,7 @@ body:
                                             )
                                             else_block: None
                                             lint_level: Explicit(HirId(DefId(offset_of::concrete).40))
-                                            span: $DIR/offset_of.rs:40:5: 1435:57 (#0)
+                                            span: $DIR/offset_of.rs:40:5: 1433:57 (#0)
                                         }
                                     }
                                     Stmt {
@@ -264,7 +264,7 @@ body:
                                             )
                                             else_block: None
                                             lint_level: Explicit(HirId(DefId(offset_of::concrete).50))
-                                            span: $DIR/offset_of.rs:41:5: 1435:57 (#0)
+                                            span: $DIR/offset_of.rs:41:5: 1433:57 (#0)
                                         }
                                     }
                                 ]
@@ -864,7 +864,7 @@ body:
                                             )
                                             else_block: None
                                             lint_level: Explicit(HirId(DefId(offset_of::generic).12))
-                                            span: $DIR/offset_of.rs:45:5: 1435:57 (#0)
+                                            span: $DIR/offset_of.rs:45:5: 1433:57 (#0)
                                         }
                                     }
                                     Stmt {
@@ -913,7 +913,7 @@ body:
                                             )
                                             else_block: None
                                             lint_level: Explicit(HirId(DefId(offset_of::generic).24))
-                                            span: $DIR/offset_of.rs:46:5: 1435:57 (#0)
+                                            span: $DIR/offset_of.rs:46:5: 1433:57 (#0)
                                         }
                                     }
                                     Stmt {
@@ -962,7 +962,7 @@ body:
                                             )
                                             else_block: None
                                             lint_level: Explicit(HirId(DefId(offset_of::generic).36))
-                                            span: $DIR/offset_of.rs:47:5: 1435:57 (#0)
+                                            span: $DIR/offset_of.rs:47:5: 1433:57 (#0)
                                         }
                                     }
                                     Stmt {
@@ -1011,7 +1011,7 @@ body:
                                             )
                                             else_block: None
                                             lint_level: Explicit(HirId(DefId(offset_of::generic).48))
-                                            span: $DIR/offset_of.rs:48:5: 1435:57 (#0)
+                                            span: $DIR/offset_of.rs:48:5: 1433:57 (#0)
                                         }
                                     }
                                 ]


### PR DESCRIPTION
This is a bit misleading, we were discussing this with our Rust team and some people could think that the compiler does some special magic for this specific function and that's not true or well the compiler does something special but for every function.
The reality according to my understanding is that this is a normal function that takes ownership of the given value and as with every other function mir building injects Drop Terminators , drop elaboration refines this and then we would insert the corresponding drop glue, then potentially calling Drop::drop.

Not sure if it would be best to remove the sentence as this PR does or explaining something along the lines of the previous text.