### PR TITLE
Make inline attributes apply to the generated `poll` in async fn

### DIFF
--- a/compiler/rustc_ast_lowering/src/expr.rs
+++ b/compiler/rustc_ast_lowering/src/expr.rs
@@ -1,12 +1,13 @@
-use std::mem;
 use std::ops::ControlFlow;
 use std::sync::Arc;
+use std::{iter, mem};
 
 use rustc_ast::*;
 use rustc_ast_pretty::pprust::expr_to_string;
 use rustc_data_structures::stack::ensure_sufficient_stack;
 use rustc_errors::msg;
 use rustc_hir as hir;
+use rustc_hir::attrs::AttributeKind;
 use rustc_hir::def::{DefKind, Res};
 use rustc_hir::definitions::DefPathData;
 use rustc_hir::{HirId, Target, find_attr};
@@ -829,6 +830,36 @@ impl<'hir, R: ResolverAstLoweringExt<'hir>> LoweringContext<'_, 'hir, R> {
         }
     }
 
+    pub(super) fn forward_inline(&mut self, _span: Span, outer_hir_id: HirId, inner_hir_id: HirId) {
+        let Some(attrs) = self.attrs.get(&outer_hir_id.local_id) else {
+            return;
+        };
+
+        let Some((inline_attr, span)) = find_attr!(*attrs, Inline(attr, span) => (attr, span))
+        else {
+            return;
+        };
+
+        let filtered_iter = attrs
+            .iter()
+            .cloned()
+            .filter(|attr| !matches!(attr, hir::Attribute::Parsed(AttributeKind::Inline(_, _))));
+
+        let filtered_attrs = self.arena.alloc_from_iter(filtered_iter);
+
+        if filtered_attrs.is_empty() {
+            self.attrs.remove(&outer_hir_id.local_id);
+        } else {
+            self.attrs.insert(outer_hir_id.local_id, filtered_attrs);
+        }
+
+        let attr = self.arena.alloc_from_iter(iter::once(hir::Attribute::Parsed(
+            AttributeKind::Inline(*inline_attr, *span),
+        )));
+
+        self.attrs.insert(inner_hir_id.local_id, attr);
+    }
+
     /// Desugar `<expr>.await` into:
     /// ```ignore (pseudo-rust)
     /// match ::std::future::IntoFuture::into_future(<expr>) {
@@ -1199,6 +1230,7 @@ impl<'hir, R: ResolverAstLoweringExt<'hir>> LoweringContext<'_, 'hir, R> {
                 );
 
                 this.maybe_forward_track_caller(body.span, closure_hir_id, expr.hir_id);
+                this.forward_inline(body.span, closure_hir_id, expr.hir_id);
 
                 (parameters, expr)
             });


### PR DESCRIPTION
This PR adds lowering code (similar to how track_caller forwarding works) to `async fn` items and `async ||` closures such that any inline attributes put on them are inherited by the generated coroutine (corresponding to the `poll()` implementation) and are not applied to the outer function. This behavior matches the accepted FCP in the first linked issue.

Code like the following now correctly codegen 3 functions
- `async_fn_test::consumer`
- `async_fn_test::hi::{closure#0}`
- `core::ptr::drop_in_place::<async_fn_test::hi::{closure#0}>`
```rust
#[inline(never)]
pub async fn hi() -> i32 {
    1337
}

pub fn consumer(cx: &mut Context<'_>) -> Option<i32> {
    let fut = hi();
    let pinned = pin!(fut);
    match pinned.poll(cx) {
        Poll::Ready(value) => Some(value),
        Poll::Pending => None,
    }
}
```

Fixes rust-lang/rust#129347 and fixes rust-lang/rust#106765.

This has already been FCP'ed here: https://github.com/rust-lang/rust/issues/129347