### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/compiler/rustc_passes/messages.ftl
+++ b/compiler/rustc_passes/messages.ftl
@@ -126,6 +126,14 @@ passes_doc_alias_not_string_literal =
 passes_doc_alias_start_end =
     {$attr_str} cannot start or end with ' '
 
+passes_doc_attr_expects_no_value =
+    `doc({$attr_name})` does not accept a value
+    .suggestion = use `doc({$attr_name})`
+
+passes_doc_attr_expects_string =
+    `doc({$attr_name})` expects a string value
+    .suggestion = use `doc({$attr_name} = "...")`
+
 passes_doc_attr_not_crate_level =
     `#![doc({$attr_name} = "...")]` isn't allowed as a crate-level attribute
 

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -1122,6 +1122,28 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
         true
     }
 
+    fn check_doc_attr_string_value(&self, meta: &MetaItemInner, hir_id: HirId) {
+        if meta.value_str().is_none() {
+            self.tcx.emit_node_span_lint(
+                INVALID_DOC_ATTRIBUTES,
+                hir_id,
+                meta.span(),
+                errors::DocAttrExpectsString { attr_name: meta.name().unwrap() },
+            );
+        }
+    }
+
+    fn check_doc_attr_no_value(&self, meta: &MetaItemInner, hir_id: HirId) {
+        if !meta.is_word() {
+            self.tcx.emit_node_span_lint(
+                INVALID_DOC_ATTRIBUTES,
+                hir_id,
+                meta.span(),
+                errors::DocAttrExpectsNoValue { attr_name: meta.name().unwrap() },
+            );
+        }
+    }
+
     /// Checks that `doc(test(...))` attribute contains only valid attributes and are at the right place.
     fn check_test_attr(
         &self,
@@ -1292,10 +1314,15 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                             | sym::html_logo_url
                             | sym::html_playground_url
                             | sym::issue_tracker_base_url
-                            | sym::html_root_url
-                            | sym::html_no_source,
+                            | sym::html_root_url,
                         ) => {
                             self.check_attr_crate_level(attr_span, style, meta, hir_id);
+                            self.check_doc_attr_string_value(meta, hir_id);
+                        }
+
+                        Some(sym::html_no_source) => {
+                            self.check_attr_crate_level(attr_span, style, meta, hir_id);
+                            self.check_doc_attr_no_value(meta, hir_id);
                         }
 
                         Some(sym::auto_cfg) => {

--- a/compiler/rustc_passes/src/errors.rs
+++ b/compiler/rustc_passes/src/errors.rs
@@ -24,6 +24,18 @@ pub(crate) struct IncorrectDoNotRecommendLocation;
 #[diag(passes_incorrect_do_not_recommend_args)]
 pub(crate) struct DoNotRecommendDoesNotExpectArgs;
 
+#[derive(LintDiagnostic)]
+#[diag(passes_doc_attr_expects_string)]
+pub(crate) struct DocAttrExpectsString {
+    pub(crate) attr_name: Symbol,
+}
+
+#[derive(LintDiagnostic)]
+#[diag(passes_doc_attr_expects_no_value)]
+pub(crate) struct DocAttrExpectsNoValue {
+    pub(crate) attr_name: Symbol,
+}
+
 #[derive(Diagnostic)]
 #[diag(passes_autodiff_attr)]
 pub(crate) struct AutoDiffAttr {

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -433,6 +433,8 @@ mod spec_extend;
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_diagnostic_item = "Vec"]
 #[rustc_insignificant_dtor]
+#[doc(alias = "list")]
+#[doc(alias = "vector")]
 pub struct Vec<T, #[unstable(feature = "allocator_api", issue = "32838")] A: Allocator = Global> {
     buf: RawVec<T, A>,
     len: usize,

--- a/tests/rustdoc-ui/bad-render-options.rs
+++ b/tests/rustdoc-ui/bad-render-options.rs
@@ -1,0 +1,11 @@
+// regression test for https://github.com/rust-lang/rust/issues/149187
+
+#![doc(html_favicon_url)] //~ ERROR: `doc(html_favicon_url)` expects a string value [invalid_doc_attributes]
+#![doc(html_logo_url)] //~ ERROR: `doc(html_logo_url)` expects a string value [invalid_doc_attributes]
+#![doc(html_playground_url)] //~ ERROR: `doc(html_playground_url)` expects a string value [invalid_doc_attributes]
+#![doc(issue_tracker_base_url)] //~ ERROR expects a string value
+#![doc(html_favicon_url = 1)] //~ ERROR expects a string value
+#![doc(html_logo_url = 2)] //~ ERROR expects a string value
+#![doc(html_playground_url = 3)] //~ ERROR expects a string value
+#![doc(issue_tracker_base_url = 4)] //~ ERROR expects a string value
+#![doc(html_no_source = "asdf")] //~ ERROR `doc(html_no_source)` does not accept a value [invalid_doc_attributes]

--- a/tests/rustdoc-ui/bad-render-options.stderr
+++ b/tests/rustdoc-ui/bad-render-options.stderr
@@ -1,0 +1,58 @@
+error: `doc(html_favicon_url)` expects a string value
+  --> $DIR/bad-render-options.rs:3:8
+   |
+LL | #![doc(html_favicon_url)]
+   |        ^^^^^^^^^^^^^^^^
+   |
+   = note: `#[deny(invalid_doc_attributes)]` on by default
+
+error: `doc(html_logo_url)` expects a string value
+  --> $DIR/bad-render-options.rs:4:8
+   |
+LL | #![doc(html_logo_url)]
+   |        ^^^^^^^^^^^^^
+
+error: `doc(html_playground_url)` expects a string value
+  --> $DIR/bad-render-options.rs:5:8
+   |
+LL | #![doc(html_playground_url)]
+   |        ^^^^^^^^^^^^^^^^^^^
+
+error: `doc(issue_tracker_base_url)` expects a string value
+  --> $DIR/bad-render-options.rs:6:8
+   |
+LL | #![doc(issue_tracker_base_url)]
+   |        ^^^^^^^^^^^^^^^^^^^^^^
+
+error: `doc(html_favicon_url)` expects a string value
+  --> $DIR/bad-render-options.rs:7:8
+   |
+LL | #![doc(html_favicon_url = 1)]
+   |        ^^^^^^^^^^^^^^^^^^^^
+
+error: `doc(html_logo_url)` expects a string value
+  --> $DIR/bad-render-options.rs:8:8
+   |
+LL | #![doc(html_logo_url = 2)]
+   |        ^^^^^^^^^^^^^^^^^
+
+error: `doc(html_playground_url)` expects a string value
+  --> $DIR/bad-render-options.rs:9:8
+   |
+LL | #![doc(html_playground_url = 3)]
+   |        ^^^^^^^^^^^^^^^^^^^^^^^
+
+error: `doc(issue_tracker_base_url)` expects a string value
+  --> $DIR/bad-render-options.rs:10:8
+   |
+LL | #![doc(issue_tracker_base_url = 4)]
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: `doc(html_no_source)` does not accept a value
+  --> $DIR/bad-render-options.rs:11:8
+   |
+LL | #![doc(html_no_source = "asdf")]
+   |        ^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 9 previous errors
+

--- a/tests/ui/dyn-compatibility/no-duplicate-e0038.rs
+++ b/tests/ui/dyn-compatibility/no-duplicate-e0038.rs
@@ -1,0 +1,17 @@
+// Test that E0038 is not emitted twice for the same trait object coercion
+// regression test for issue <https://github.com/rust-lang/rust/issues/128705>
+
+#![allow(dead_code)]
+
+trait Tr {
+    const N: usize;
+}
+
+impl Tr for u8 {
+    const N: usize = 1;
+}
+
+fn main() {
+    let x: &dyn Tr = &0_u8;
+    //~^ ERROR E0038
+}

--- a/tests/ui/dyn-compatibility/no-duplicate-e0038.stderr
+++ b/tests/ui/dyn-compatibility/no-duplicate-e0038.stderr
@@ -1,0 +1,20 @@
+error[E0038]: the trait `Tr` is not dyn compatible
+  --> $DIR/no-duplicate-e0038.rs:15:17
+   |
+LL |     let x: &dyn Tr = &0_u8;
+   |                 ^^ `Tr` is not dyn compatible
+   |
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
+  --> $DIR/no-duplicate-e0038.rs:7:11
+   |
+LL | trait Tr {
+   |       -- this trait is not dyn compatible...
+LL |     const N: usize;
+   |           ^ ...because it contains this associated `const`
+   = help: consider moving `N` to another trait
+   = help: only type `u8` implements `Tr`; consider using it directly instead.
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0038`.


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#149179 (Add regression test for 128705)
 - rust-lang/rust#149197 (validate usage of crate-level doc attributes)
 - rust-lang/rust#149232 (Add doc aliases "vector" and "list" to `Vec`)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=149179,149197,149232)
<!-- homu-ignore:end -->