### PR TITLE
Reduce code size of `{f32,f64}::is_finite`

### DIFF
--- a/library/core/src/num/f32.rs
+++ b/library/core/src/num/f32.rs
@@ -578,10 +578,9 @@ impl f32 {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_const_stable(feature = "const_float_classify", since = "1.83.0")]
     #[inline]
+    #[allow(clippy::eq_op)]
     pub const fn is_finite(self) -> bool {
-        // There's no need to handle NaN separately: if self is NaN,
-        // the comparison is not true, exactly as desired.
-        self.abs() < Self::INFINITY
+        self - self == self - self
     }
 
     /// Returns `true` if the number is [subnormal].

--- a/library/core/src/num/f64.rs
+++ b/library/core/src/num/f64.rs
@@ -577,10 +577,9 @@ impl f64 {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_const_stable(feature = "const_float_classify", since = "1.83.0")]
     #[inline]
+    #[allow(clippy::eq_op)]
     pub const fn is_finite(self) -> bool {
-        // There's no need to handle NaN separately: if self is NaN,
-        // the comparison is not true, exactly as desired.
-        self.abs() < Self::INFINITY
+        self - self == self - self
     }
 
     /// Returns `true` if the number is [subnormal].


### PR DESCRIPTION
This change eliminates the two constants (the `abs` mask and infinity), reducing code size at hopefully no performance cost. It works because `x - x` is always +0 when `x` is finite, and is NaN if and only if `x` is infinite or NaN.

Generated aarch64 assembly for `f32` compared to the current implementation:

```asm
is_finite:
    fsub  s0, s0, s0
    fcmp  s0, s0
    cset  w0, vc
    ret

is_finite_std:
    fmov  w9, s0
    mov   w8, #0x7f800000
    and   w9, w9, #0x7fffffff
    cmp   w9, w8
    cset  w0, lt
    ret
```
