### PR TITLE
miri: use `tikv-jemalloc-sys` from sysroot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2486,7 +2486,6 @@ dependencies = [
  "serde_json",
  "smallvec",
  "tempfile",
- "tikv-jemalloc-sys",
  "ui_test",
 ]
 

--- a/src/bootstrap/src/core/build_steps/tool.rs
+++ b/src/bootstrap/src/core/build_steps/tool.rs
@@ -1567,6 +1567,11 @@ tool_rustc_extended!(Miri {
     tool_name: "miri",
     stable: false,
     add_bins_to_sysroot: ["miri"],
+    add_features: |builder, target, features| {
+        if builder.config.jemalloc(target) {
+            features.push("jemalloc".to_string());
+        }
+    },
     // Always compile also tests when building miri. Otherwise feature unification can cause rebuilds between building and testing miri.
     cargo_args: &["--all-targets"],
 });

--- a/src/tools/miri/Cargo.toml
+++ b/src/tools/miri/Cargo.toml
@@ -29,13 +29,6 @@ directories = "6"
 bitflags = "2.6"
 serde_json = { version = "1.0", optional = true }
 
-# Copied from `compiler/rustc/Cargo.toml`.
-# But only for some targets, it fails for others. Rustc configures this in its CI, but we can't
-# easily use that since we support of-tree builds.
-[target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies.tikv-jemalloc-sys]
-version = "0.6.1"
-features = ['override_allocator_on_supported_platforms']
-
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 # native-lib dependencies
@@ -75,6 +68,7 @@ stack-cache = []
 expensive-consistency-checks = ["stack-cache"]
 tracing = ["serde_json"]
 native-lib = ["dep:libffi", "dep:libloading", "dep:capstone", "dep:ipc-channel", "dep:nix", "dep:serde"]
+jemalloc = []
 
 [lints.rust.unexpected_cfgs]
 level = "warn"

--- a/src/tools/miri/src/bin/miri.rs
+++ b/src/tools/miri/src/bin/miri.rs
@@ -21,9 +21,13 @@ extern crate rustc_session;
 extern crate rustc_span;
 
 /// See docs in https://github.com/rust-lang/rust/blob/HEAD/compiler/rustc/src/main.rs
-/// and https://github.com/rust-lang/rust/pull/146627 for why we need this `use` statement.
-#[cfg(any(target_os = "linux", target_os = "macos"))]
-use tikv_jemalloc_sys as _;
+/// and https://github.com/rust-lang/rust/pull/146627 for why we need this.
+///
+/// FIXME(madsmtm): This is loaded from the sysroot that was built with the other `rustc` crates
+/// above, instead of via Cargo as you'd normally do. This is currently needed for LTO due to
+/// https://github.com/rust-lang/cc-rs/issues/1613.
+#[cfg(feature = "jemalloc")]
+extern crate tikv_jemalloc_sys as _;
 
 mod log;
 


### PR DESCRIPTION
This allows LTO to work when compiling jemalloc (which is currently broken due to https://github.com/rust-lang/cc-rs/issues/1613), which should yield a small performance boost, and makes Miri's behaviour here match Clippy
and Rustdoc.

Follow-up to https://github.com/rust-lang/rust/pull/148925 / https://github.com/rust-lang/rust/pull/146627 after discussion in https://github.com/rust-lang/rust/pull/148925#pullrequestreview-3465393783.

r? RalfJung