### PR TITLE
Fix ICE in const param defaults with lifetime-dependent types

### DIFF
--- a/tests/ui/const-generics/generic_const_parameter_types/ice-142913-const-defaults-with-lifetimes.rs
+++ b/tests/ui/const-generics/generic_const_parameter_types/ice-142913-const-defaults-with-lifetimes.rs
@@ -1,0 +1,10 @@
+#![allow(incomplete_features)]
+#![feature(generic_const_parameter_types)]
+struct Variant;
+
+fn foo<'a, const N: &'a Variant = {}>() {}
+//~^ ERROR: defaults for generic parameters are not allowed here
+//~| ERROR: anonymous constants with lifetimes in their type are not yet supported
+//~| ERROR: `&'a Variant` is forbidden as the type of a const generic parameter
+
+fn main() {}

--- a/tests/ui/const-generics/generic_const_parameter_types/ice-142913-const-defaults-with-lifetimes.stderr
+++ b/tests/ui/const-generics/generic_const_parameter_types/ice-142913-const-defaults-with-lifetimes.stderr
@@ -1,0 +1,30 @@
+error: defaults for generic parameters are not allowed here
+  --> $DIR/ice-142913-const-defaults-with-lifetimes.rs:5:12
+   |
+LL | fn foo<'a, const N: &'a Variant = {}>() {}
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: anonymous constants with lifetimes in their type are not yet supported
+  --> $DIR/ice-142913-const-defaults-with-lifetimes.rs:5:35
+   |
+LL | fn foo<'a, const N: &'a Variant = {}>() {}
+   |                                   ^^
+
+error: `&'a Variant` is forbidden as the type of a const generic parameter
+  --> $DIR/ice-142913-const-defaults-with-lifetimes.rs:5:21
+   |
+LL | fn foo<'a, const N: &'a Variant = {}>() {}
+   |                     ^^^^^^^^^^^
+   |
+   = note: the only supported types are integers, `bool`, and `char`
+help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
+   |
+LL + #![feature(adt_const_params)]
+   |
+help: add `#![feature(unsized_const_params)]` to the crate attributes to enable references to implement the `ConstParamTy` trait
+   |
+LL + #![feature(unsized_const_params)]
+   |
+
+error: aborting due to 3 previous errors
+


### PR DESCRIPTION
fixes rust-lang/rust#142913

The ICE happened because `const_param_default` instantiated the default expression using the const parameter’s own identity arguments, which are empty. When the default’s type referenced earlier generics, the subsequent `instantiate` call saw parameters but no arguments and panicked. In this PR, supplying the slice of the parent’s generic arguments up to the parameter being defaulted prevents that mismatch.