### PR TITLE
Use `let...else` consistently in user-facing diagnostics

### DIFF
--- a/compiler/rustc_hir_analysis/src/check/region.rs
+++ b/compiler/rustc_hir_analysis/src/check/region.rs
@@ -99,7 +99,7 @@ fn resolve_block<'tcx>(
         for (i, statement) in blk.stmts.iter().enumerate() {
             match statement.kind {
                 hir::StmtKind::Let(LetStmt { els: Some(els), .. }) => {
-                    // Let-else has a special lexical structure for variables.
+                    // let-else has a special lexical structure for variables.
                     // First we take a checkpoint of the current scope context here.
                     let mut prev_cx = visitor.cx;
 

--- a/compiler/rustc_mir_build/messages.ftl
+++ b/compiler/rustc_mir_build/messages.ftl
@@ -334,7 +334,7 @@ mir_build_suggest_if_let = you might want to use `if let` to ignore the {$count 
         *[other] variants that aren't
     } matched
 
-mir_build_suggest_let_else = you might want to use `let else` to handle the {$count ->
+mir_build_suggest_let_else = you might want to use `let...else` to handle the {$count ->
         [one] variant that isn't
         *[other] variants that aren't
     } matched

--- a/compiler/rustc_parse/src/parser/stmt.rs
+++ b/compiler/rustc_parse/src/parser/stmt.rs
@@ -867,7 +867,7 @@ impl<'a> Parser<'a> {
         if let_else || !if_let {
             err.span_suggestion_verbose(
                 block_span.shrink_to_lo(),
-                format!("{alternatively}you might have meant to use `let else`"),
+                format!("{alternatively}you might have meant to use `let...else`"),
                 "else ".to_string(),
                 if let_else {
                     Applicability::MachineApplicable

--- a/tests/ui/empty/empty-never-array.stderr
+++ b/tests/ui/empty/empty-never-array.stderr
@@ -14,7 +14,7 @@ LL | enum Helper<T, U> {
 LL |     T(T, [!; 0]),
    |     - not covered
    = note: the matched value is of type `Helper<T, U>`
-help: you might want to use `let else` to handle the variant that isn't matched
+help: you might want to use `let...else` to handle the variant that isn't matched
    |
 LL |     let Helper::U(u) = Helper::T(t, []) else { todo!() };
    |                                         ++++++++++++++++

--- a/tests/ui/error-codes/E0005.stderr
+++ b/tests/ui/error-codes/E0005.stderr
@@ -7,7 +7,7 @@ LL |     let Some(y) = x;
    = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
    = note: for more information, visit https://doc.rust-lang.org/book/ch19-02-refutability.html
    = note: the matched value is of type `Option<i32>`
-help: you might want to use `let else` to handle the variant that isn't matched
+help: you might want to use `let...else` to handle the variant that isn't matched
    |
 LL |     let Some(y) = x else { todo!() };
    |                     ++++++++++++++++

--- a/tests/ui/feature-gates/feature-gate-exhaustive-patterns.stderr
+++ b/tests/ui/feature-gates/feature-gate-exhaustive-patterns.stderr
@@ -7,7 +7,7 @@ LL |     let Ok(_x) = &foo();
    = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
    = note: for more information, visit https://doc.rust-lang.org/book/ch19-02-refutability.html
    = note: the matched value is of type `&Result<u32, !>`
-help: you might want to use `let else` to handle the variant that isn't matched
+help: you might want to use `let...else` to handle the variant that isn't matched
    |
 LL |     let Ok(_x) = &foo() else { todo!() };
    |                         ++++++++++++++++

--- a/tests/ui/half-open-range-patterns/feature-gate-half-open-range-patterns-in-slices.stderr
+++ b/tests/ui/half-open-range-patterns/feature-gate-half-open-range-patterns-in-slices.stderr
@@ -17,7 +17,7 @@ LL |     let [a @ 3.., b @ ..3, c @ 4..6, ..] = xs;
    = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
    = note: for more information, visit https://doc.rust-lang.org/book/ch19-02-refutability.html
    = note: the matched value is of type `[i32; 8]`
-help: you might want to use `let else` to handle the variant that isn't matched
+help: you might want to use `let...else` to handle the variant that isn't matched
    |
 LL |     let [a @ 3.., b @ ..3, c @ 4..6, ..] = xs else { todo!() };
    |                                               ++++++++++++++++

--- a/tests/ui/half-open-range-patterns/slice_pattern_syntax_problem1.stderr
+++ b/tests/ui/half-open-range-patterns/slice_pattern_syntax_problem1.stderr
@@ -17,7 +17,7 @@ LL |     let [a @ 3.., b @ ..3, c @ 4..6, ..] = xs;
    = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
    = note: for more information, visit https://doc.rust-lang.org/book/ch19-02-refutability.html
    = note: the matched value is of type `[i32; 8]`
-help: you might want to use `let else` to handle the variant that isn't matched
+help: you might want to use `let...else` to handle the variant that isn't matched
    |
 LL |     let [a @ 3.., b @ ..3, c @ 4..6, ..] = xs else { todo!() };
    |                                               ++++++++++++++++

--- a/tests/ui/pattern/issue-106552.stderr
+++ b/tests/ui/pattern/issue-106552.stderr
@@ -25,7 +25,7 @@ LL |     let x @ 5 = 6;
    = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
    = note: for more information, visit https://doc.rust-lang.org/book/ch19-02-refutability.html
    = note: the matched value is of type `i32`
-help: you might want to use `let else` to handle the variants that aren't matched
+help: you might want to use `let...else` to handle the variants that aren't matched
    |
 LL |     let x @ 5 = 6 else { todo!() };
    |                   ++++++++++++++++

--- a/tests/ui/pattern/usefulness/empty-types.exhaustive_patterns.stderr
+++ b/tests/ui/pattern/usefulness/empty-types.exhaustive_patterns.stderr
@@ -152,7 +152,7 @@ LL |     let Ok(_x) = res_u32_never.as_ref();
    = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
    = note: for more information, visit https://doc.rust-lang.org/book/ch19-02-refutability.html
    = note: the matched value is of type `Result<&u32, &!>`
-help: you might want to use `let else` to handle the variant that isn't matched
+help: you might want to use `let...else` to handle the variant that isn't matched
    |
 LL |     let Ok(_x) = res_u32_never.as_ref() else { todo!() };
    |                                         ++++++++++++++++

--- a/tests/ui/pattern/usefulness/empty-types.never_pats.stderr
+++ b/tests/ui/pattern/usefulness/empty-types.never_pats.stderr
@@ -106,7 +106,7 @@ LL |     let Ok(_x) = res_u32_never.as_ref();
    = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
    = note: for more information, visit https://doc.rust-lang.org/book/ch19-02-refutability.html
    = note: the matched value is of type `Result<&u32, &!>`
-help: you might want to use `let else` to handle the variant that isn't matched
+help: you might want to use `let...else` to handle the variant that isn't matched
    |
 LL |     let Ok(_x) = res_u32_never.as_ref() else { todo!() };
    |                                         ++++++++++++++++
@@ -120,7 +120,7 @@ LL |     let Ok(_x) = &res_u32_never;
    = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
    = note: for more information, visit https://doc.rust-lang.org/book/ch19-02-refutability.html
    = note: the matched value is of type `&Result<u32, !>`
-help: you might want to use `let else` to handle the variant that isn't matched
+help: you might want to use `let...else` to handle the variant that isn't matched
    |
 LL |     let Ok(_x) = &res_u32_never else { todo!() };
    |                                 ++++++++++++++++

--- a/tests/ui/pattern/usefulness/empty-types.normal.stderr
+++ b/tests/ui/pattern/usefulness/empty-types.normal.stderr
@@ -97,7 +97,7 @@ LL |     let Ok(_x) = res_u32_never.as_ref();
    = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
    = note: for more information, visit https://doc.rust-lang.org/book/ch19-02-refutability.html
    = note: the matched value is of type `Result<&u32, &!>`
-help: you might want to use `let else` to handle the variant that isn't matched
+help: you might want to use `let...else` to handle the variant that isn't matched
    |
 LL |     let Ok(_x) = res_u32_never.as_ref() else { todo!() };
    |                                         ++++++++++++++++
@@ -111,7 +111,7 @@ LL |     let Ok(_x) = &res_u32_never;
    = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
    = note: for more information, visit https://doc.rust-lang.org/book/ch19-02-refutability.html
    = note: the matched value is of type `&Result<u32, !>`
-help: you might want to use `let else` to handle the variant that isn't matched
+help: you might want to use `let...else` to handle the variant that isn't matched
    |
 LL |     let Ok(_x) = &res_u32_never else { todo!() };
    |                                 ++++++++++++++++

--- a/tests/ui/pattern/usefulness/issue-31561.stderr
+++ b/tests/ui/pattern/usefulness/issue-31561.stderr
@@ -17,7 +17,7 @@ LL |     Bar,
 LL |     Baz
    |     --- not covered
    = note: the matched value is of type `Thing`
-help: you might want to use `let else` to handle the variants that aren't matched
+help: you might want to use `let...else` to handle the variants that aren't matched
    |
 LL |     let Thing::Foo(y) = Thing::Foo(1) else { todo!() };
    |                                       ++++++++++++++++

--- a/tests/ui/pattern/usefulness/non-exhaustive-defined-here.stderr
+++ b/tests/ui/pattern/usefulness/non-exhaustive-defined-here.stderr
@@ -183,7 +183,7 @@ LL | enum Opt {
 LL |     None,
    |     ---- not covered
    = note: the matched value is of type `Opt`
-help: you might want to use `let else` to handle the variant that isn't matched
+help: you might want to use `let...else` to handle the variant that isn't matched
    |
 LL |     let Opt::Some(ref _x) = e else { todo!() };
    |                               ++++++++++++++++

--- a/tests/ui/recursion/recursive-types-are-not-uninhabited.stderr
+++ b/tests/ui/recursion/recursive-types-are-not-uninhabited.stderr
@@ -7,7 +7,7 @@ LL |     let Ok(x) = res;
    = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
    = note: for more information, visit https://doc.rust-lang.org/book/ch19-02-refutability.html
    = note: the matched value is of type `Result<u32, &R<'_>>`
-help: you might want to use `let else` to handle the variant that isn't matched
+help: you might want to use `let...else` to handle the variant that isn't matched
    |
 LL |     let Ok(x) = res else { todo!() };
    |                     ++++++++++++++++

--- a/tests/ui/rfcs/rfc-2008-non-exhaustive/omitted-patterns.stderr
+++ b/tests/ui/rfcs/rfc-2008-non-exhaustive/omitted-patterns.stderr
@@ -138,7 +138,7 @@ LL |     let local_refutable @ NonExhaustiveEnum::Unit = NonExhaustiveEnum::Unit
    = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
    = note: for more information, visit https://doc.rust-lang.org/book/ch19-02-refutability.html
    = note: the matched value is of type `NonExhaustiveEnum`
-help: you might want to use `let else` to handle the variant that isn't matched
+help: you might want to use `let...else` to handle the variant that isn't matched
    |
 LL |     let local_refutable @ NonExhaustiveEnum::Unit = NonExhaustiveEnum::Unit else { todo!() };
    |                                                                             ++++++++++++++++

--- a/tests/ui/uninhabited/missing-if-let-or-let-else.rs
+++ b/tests/ui/uninhabited/missing-if-let-or-let-else.rs
@@ -6,14 +6,14 @@ fn a() {
 }
 fn b() {
     let Some(x) = foo() { //~ ERROR expected one of
-        //~^ HELP you might have meant to use `let else`
+        //~^ HELP you might have meant to use `let...else`
         return;
     }
 }
 fn c() {
     let Some(x) = foo() { //~ ERROR expected one of
         //~^ HELP you might have meant to use `if let`
-        //~| HELP alternatively, you might have meant to use `let else`
+        //~| HELP alternatively, you might have meant to use `let...else`
         // The parser check happens pre-macro-expansion, so we don't know for sure.
         println!("{x}");
     }

--- a/tests/ui/uninhabited/missing-if-let-or-let-else.stderr
+++ b/tests/ui/uninhabited/missing-if-let-or-let-else.stderr
@@ -15,7 +15,7 @@ error: expected one of `.`, `;`, `?`, `else`, or an operator, found `{`
 LL |     let Some(x) = foo() {
    |                         ^ expected one of `.`, `;`, `?`, `else`, or an operator
    |
-help: you might have meant to use `let else`
+help: you might have meant to use `let...else`
    |
 LL |     let Some(x) = foo() else {
    |                         ++++
@@ -30,7 +30,7 @@ help: you might have meant to use `if let`
    |
 LL |     if let Some(x) = foo() {
    |     ++
-help: alternatively, you might have meant to use `let else`
+help: alternatively, you might have meant to use `let...else`
    |
 LL |     let Some(x) = foo() else {
    |                         ++++

--- a/tests/ui/uninhabited/uninhabited-irrefutable.exhaustive_patterns.stderr
+++ b/tests/ui/uninhabited/uninhabited-irrefutable.exhaustive_patterns.stderr
@@ -16,7 +16,7 @@ LL |     A(foo::SecretlyEmpty),
    |     - not covered
    = note: pattern `Foo::A(_)` is currently uninhabited, but this variant contains private fields which may become inhabited in the future
    = note: the matched value is of type `Foo`
-help: you might want to use `let else` to handle the variant that isn't matched
+help: you might want to use `let...else` to handle the variant that isn't matched
    |
 LL |     let Foo::D(_y, _z) = x else { todo!() };
    |                            ++++++++++++++++

--- a/tests/ui/uninhabited/uninhabited-irrefutable.normal.stderr
+++ b/tests/ui/uninhabited/uninhabited-irrefutable.normal.stderr
@@ -16,7 +16,7 @@ LL |     A(foo::SecretlyEmpty),
    |     - not covered
    = note: pattern `Foo::A(_)` is currently uninhabited, but this variant contains private fields which may become inhabited in the future
    = note: the matched value is of type `Foo`
-help: you might want to use `let else` to handle the variant that isn't matched
+help: you might want to use `let...else` to handle the variant that isn't matched
    |
 LL |     let Foo::D(_y, _z) = x else { todo!() };
    |                            ++++++++++++++++

--- a/tests/ui/uninhabited/uninhabited-irrefutable.rs
+++ b/tests/ui/uninhabited/uninhabited-irrefutable.rs
@@ -34,5 +34,5 @@ fn main() {
     //~| NOTE for more information
     //~| NOTE pattern `Foo::A(_)` is currently uninhabited
     //~| NOTE the matched value is of type `Foo`
-    //~| HELP you might want to use `let else`
+    //~| HELP you might want to use `let...else`
 }


### PR DESCRIPTION
resolve: rust-lang/rust#148772

Standardize `let...else` terminology in user-facing diagnostics.

Goal: Consistently use `let...else` in all error/warning messages.

Internal technical names (`let-else`) in comments and documentation remain unchanged.

cc @carols10cents, @jieyouxu 