### PR TITLE
Remove outdated rust-analyzer config

### DIFF
--- a/src/etc/rust_analyzer_eglot.el
+++ b/src/etc/rust_analyzer_eglot.el
@@ -1,8 +1,7 @@
 ((rustic-mode
   .((eglot-workspace-configuration
      . (:rust-analyzer
-        ( :check ( :invocationLocation "root"
-                                       :invocationStrategy "once"
+        ( :check ( invocationStrategy "once"
                                        :overrideCommand ["python3"
                                                          "x.py"
                                                          "check"
@@ -20,7 +19,6 @@
                  :procMacro ( :server "build-rust-analyzer/host/stage0/libexec/rust-analyzer-proc-macro-srv"
                                       :enable t)
                  :cargo ( :buildScripts ( :enable t
-                                                  :invocationLocation "root"
                                                   :invocationStrategy "once"
                                                   :overrideCommand ["python3"
                                                                     "x.py"

--- a/src/etc/rust_analyzer_helix.toml
+++ b/src/etc/rust_analyzer_helix.toml
@@ -18,7 +18,6 @@ linkedProjects = [
 ]
 
 [language-server.rust-analyzer.config.check]
-invocationLocation = "root"
 invocationStrategy = "once"
 overrideCommand = [
     "python3",
@@ -50,7 +49,6 @@ RUSTC_BOOTSTRAP = "1"
 
 [language-server.rust-analyzer.config.cargo.buildScripts]
 enable = true
-invocationLocation = "root"
 invocationStrategy = "once"
 overrideCommand = [
     "python3",

--- a/src/etc/rust_analyzer_zed.json
+++ b/src/etc/rust_analyzer_zed.json
@@ -5,7 +5,6 @@
         "cargo": {
           "buildScripts": {
             "enable": true,
-            "invocationLocation": "root",
             "invocationStrategy": "once",
             "overrideCommand": [
               "python3",
@@ -23,7 +22,6 @@
           "sysrootSrc": "./library"
         },
         "check": {
-          "invocationLocation": "root",
           "invocationStrategy": "once",
           "overrideCommand": [
             "python3",


### PR DESCRIPTION
This config no longer exist in r-a, so it doesn't really do anything.