### PR TITLE
add implementation-internal namespace for globalasm

### DIFF
--- a/compiler/rustc_symbol_mangling/src/v0.rs
+++ b/compiler/rustc_symbol_mangling/src/v0.rs
@@ -882,11 +882,11 @@ impl<'tcx> Printer<'tcx> for V0SymbolMangler<'tcx> {
             DefPathData::OpaqueTy => 'i',
             DefPathData::SyntheticCoroutineBody => 's',
             DefPathData::NestedStatic => 'n',
+            DefPathData::GlobalAsm => 'a',
 
             // These should never show up as `print_path_with_simple` arguments.
             DefPathData::CrateRoot
             | DefPathData::Use
-            | DefPathData::GlobalAsm
             | DefPathData::Impl
             | DefPathData::MacroNs(_)
             | DefPathData::LifetimeNs(_)

--- a/tests/ui/symbol-names/const-in-global-asm.rs
+++ b/tests/ui/symbol-names/const-in-global-asm.rs
@@ -1,0 +1,20 @@
+//@ build-pass
+//@ compile-flags: -Clink-dead-code
+//@ needs-asm-support
+
+#![allow(unused)]
+
+// Test that a symbol in a `global_asm` namespace doesn't cause an ICE during v0 symbol mangling
+// due to a lack of missing namespace character for `global_asm`.
+//
+// FIXME: Can't use `#[rustc_symbol_name]` on the `foo` call to check its symbol, so just checking
+// the test compiles.
+
+fn foo<const N: usize>() {}
+
+core::arch::global_asm!("/* {} */", sym foo::<{
+    || {};
+    0
+}>);
+
+fn main() {}


### PR DESCRIPTION
Fixes rust-lang/rust#138261

Adds a namespace for `global_asm` with a lowercase letter which [is reserved for implementation-internal disambiguation](https://doc.rust-lang.org/rustc/symbol-mangling/v0.html#namespace:~:text=Lowercase%20letters%20are%20reserved%20for%20implementation%2Dinternal%20disambiguation%20categories%20(and%20demanglers%20should%20never%20show%20them)):

> Lowercase letters are reserved for implementation-internal disambiguation categories (and demanglers should never show them)

As a implementation-internal disambiguation category, the demangler implementations shouldn't need updated (i.e. if this were an uppercase letter, then our mangle-then-demangle checks would fail because the demangler would expect to have explicit handling). `'a'` is chosen arbitrarily, for **a**sm, but I can change it to something else if preferred.

`#[rustc_symbol_name]` only looks at top-level items, and would need a bunch of changes to be able to check the symbol for `foo::{constant}::{closure}` in the `global_asm` in this test, so for now the test just checks this compiles.

The alternative to this would be to prohibit declaration of items in the operand of a `global_asm`, which is a breaking change.