### PR TITLE
cmse: do not calculate the layout of a type with infer types

### DIFF
--- a/tests/crashes/130104.rs
+++ b/tests/crashes/130104.rs
@@ -1,6 +1,0 @@
-//@ known-bug: rust-lang/rust#130104
-
-fn main() {
-    let non_secure_function =
-        core::mem::transmute::<fn() -> _, extern "cmse-nonsecure-call" fn() -> _>;
-}

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-call/infer.rs
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-call/infer.rs
@@ -1,0 +1,34 @@
+//@ add-minicore
+//@ compile-flags: --target thumbv8m.main-none-eabi --crate-type lib
+//@ needs-llvm-components: arm
+#![feature(abi_cmse_nonsecure_call, no_core, lang_items)]
+#![no_core]
+
+// Infer variables cause panics in layout generation, so the argument/return type is checked for
+// whether it contains an infer var, and `LayoutError::Unknown` is emitted if so.
+//
+// See https://github.com/rust-lang/rust/issues/130104.
+
+extern crate minicore;
+use minicore::*;
+
+fn infer_1() {
+    let _ = mem::transmute::<fn() -> _, extern "cmse-nonsecure-call" fn() -> _>;
+    //~^ ERROR type annotations needed
+}
+
+fn infer_2() {
+    let _ = mem::transmute::<fn() -> (i32, _), extern "cmse-nonsecure-call" fn() -> (i32, _)>;
+    //~^ ERROR type annotations needed
+}
+
+fn infer_3() {
+    let _ = mem::transmute::<fn(_: _) -> (), extern "cmse-nonsecure-call" fn(_: _) -> ()>;
+    //~^ ERROR type annotations needed
+}
+
+fn infer_4() {
+    let _ =
+        mem::transmute::<fn(_: (i32, _)) -> (), extern "cmse-nonsecure-call" fn(_: (i32, _)) -> ()>;
+    //~^ ERROR type annotations needed
+}

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-call/infer.stderr
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-call/infer.stderr
@@ -1,0 +1,27 @@
+error[E0282]: type annotations needed
+  --> $DIR/infer.rs:16:13
+   |
+LL |     let _ = mem::transmute::<fn() -> _, extern "cmse-nonsecure-call" fn() -> _>;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type of the type parameter `Src` declared on the function `transmute`
+
+error[E0282]: type annotations needed
+  --> $DIR/infer.rs:21:13
+   |
+LL |     let _ = mem::transmute::<fn() -> (i32, _), extern "cmse-nonsecure-call" fn() -> (i32, _)>;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type of the type parameter `Src` declared on the function `transmute`
+
+error[E0282]: type annotations needed
+  --> $DIR/infer.rs:26:13
+   |
+LL |     let _ = mem::transmute::<fn(_: _) -> (), extern "cmse-nonsecure-call" fn(_: _) -> ()>;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type of the type parameter `Src` declared on the function `transmute`
+
+error[E0282]: type annotations needed
+  --> $DIR/infer.rs:32:9
+   |
+LL |         mem::transmute::<fn(_: (i32, _)) -> (), extern "cmse-nonsecure-call" fn(_: (i32, _)) -> ()>;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type of the type parameter `Src` declared on the function `transmute`
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0282`.

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/infer.rs
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/infer.rs
@@ -1,0 +1,36 @@
+//@ add-minicore
+//@ compile-flags: --target thumbv8m.main-none-eabi --crate-type lib
+//@ needs-llvm-components: arm
+#![feature(cmse_nonsecure_entry, no_core, lang_items)]
+#![no_core]
+
+// Infer variables cause panics in layout generation, so the argument/return type is checked for
+// whether it contains an infer var, and `LayoutError::Unknown` is emitted if so.
+//
+// See https://github.com/rust-lang/rust/issues/130104.
+
+extern crate minicore;
+use minicore::*;
+
+fn infer_1() {
+    let _ = mem::transmute::<fn() -> _, extern "cmse-nonsecure-entry" fn() -> _>;
+    //~^ ERROR type annotations needed
+}
+
+fn infer_2() {
+    let _ = mem::transmute::<fn() -> (i32, _), extern "cmse-nonsecure-entry" fn() -> (i32, _)>;
+    //~^ ERROR type annotations needed
+}
+
+fn infer_3() {
+    let _ = mem::transmute::<fn(_: _) -> (), extern "cmse-nonsecure-entry" fn(_: _) -> ()>;
+    //~^ ERROR type annotations needed
+}
+
+fn infer_4() {
+    let _ = mem::transmute::<
+        //~^ ERROR type annotations needed
+        fn(_: (i32, _)) -> (),
+        extern "cmse-nonsecure-entry" fn(_: (i32, _)) -> (),
+    >;
+}

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/infer.stderr
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/infer.stderr
@@ -1,0 +1,32 @@
+error[E0282]: type annotations needed
+  --> $DIR/infer.rs:16:13
+   |
+LL |     let _ = mem::transmute::<fn() -> _, extern "cmse-nonsecure-entry" fn() -> _>;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type of the type parameter `Src` declared on the function `transmute`
+
+error[E0282]: type annotations needed
+  --> $DIR/infer.rs:21:13
+   |
+LL |     let _ = mem::transmute::<fn() -> (i32, _), extern "cmse-nonsecure-entry" fn() -> (i32, _)>;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type of the type parameter `Src` declared on the function `transmute`
+
+error[E0282]: type annotations needed
+  --> $DIR/infer.rs:26:13
+   |
+LL |     let _ = mem::transmute::<fn(_: _) -> (), extern "cmse-nonsecure-entry" fn(_: _) -> ()>;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type of the type parameter `Src` declared on the function `transmute`
+
+error[E0282]: type annotations needed
+  --> $DIR/infer.rs:31:13
+   |
+LL |       let _ = mem::transmute::<
+   |  _____________^
+LL | |
+LL | |         fn(_: (i32, _)) -> (),
+LL | |         extern "cmse-nonsecure-entry" fn(_: (i32, _)) -> (),
+LL | |     >;
+   | |_____^ cannot infer type of the type parameter `Src` declared on the function `transmute`
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0282`.


### PR DESCRIPTION
tracking issue: https://github.com/rust-lang/rust/issues/81391
tracking issue: https://github.com/rust-lang/rust/issues/75835
fixes https://github.com/rust-lang/rust/issues/130104

Don't calculate the layout of a type with an infer type (`_`). This now emits `LayoutError::Unknown`, causing an error similar to when any other calling convention is used in this location.

The tests use separate functions because only the first such error in a function body is reported.

r? @davidtwco (might need some T-types assistance)