### PR TITLE
Don't leak sysroot crates through dependencies

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -278,7 +278,7 @@ pub fn each_linked_rlib(
         }
         let crate_name = info.crate_name[&cnum];
         let used_crate_source = &info.used_crate_source[&cnum];
-        if let Some((path, _)) = &used_crate_source.rlib {
+        if let Some(path) = &used_crate_source.rlib {
             f(cnum, path);
         } else if used_crate_source.rmeta.is_some() {
             return Err(errors::LinkRlibError::OnlyRmetaFound { crate_name });
@@ -542,7 +542,7 @@ fn link_staticlib(
         };
         let crate_name = codegen_results.crate_info.crate_name[&cnum];
         let used_crate_source = &codegen_results.crate_info.used_crate_source[&cnum];
-        if let Some((path, _)) = &used_crate_source.dylib {
+        if let Some(path) = &used_crate_source.dylib {
             all_rust_dylibs.push(&**path);
         } else if used_crate_source.rmeta.is_some() {
             sess.dcx().emit_fatal(errors::LinkRlibError::OnlyRmetaFound { crate_name });
@@ -620,7 +620,6 @@ fn link_dwarf_object(sess: &Session, cg_results: &CodegenResults, executable_out
             .used_crate_source
             .items()
             .filter_map(|(_, csource)| csource.rlib.as_ref())
-            .map(|(path, _)| path)
             .into_sorted_stable_ord();
 
         for input_rlib in input_rlibs {
@@ -2178,12 +2177,7 @@ fn add_rpath_args(
             .crate_info
             .used_crates
             .iter()
-            .filter_map(|cnum| {
-                codegen_results.crate_info.used_crate_source[cnum]
-                    .dylib
-                    .as_ref()
-                    .map(|(path, _)| &**path)
-            })
+            .filter_map(|cnum| codegen_results.crate_info.used_crate_source[cnum].dylib.as_deref())
             .collect::<Vec<_>>();
         let rpath_config = RPathConfig {
             libs: &*libs,
@@ -2661,7 +2655,7 @@ fn add_native_libs_from_crate(
 
     if link_static && cnum != LOCAL_CRATE && !bundled_libs.is_empty() {
         // If rlib contains native libs as archives, unpack them to tmpdir.
-        let rlib = &codegen_results.crate_info.used_crate_source[&cnum].rlib.as_ref().unwrap().0;
+        let rlib = codegen_results.crate_info.used_crate_source[&cnum].rlib.as_ref().unwrap();
         archive_builder_builder
             .extract_bundled_libs(rlib, tmpdir, bundled_libs)
             .unwrap_or_else(|e| sess.dcx().emit_fatal(e));
@@ -2832,7 +2826,7 @@ fn add_upstream_rust_crates(
             }
             Linkage::Dynamic => {
                 let src = &codegen_results.crate_info.used_crate_source[&cnum];
-                add_dynamic_crate(cmd, sess, &src.dylib.as_ref().unwrap().0);
+                add_dynamic_crate(cmd, sess, src.dylib.as_ref().unwrap());
             }
         }
 
@@ -2960,7 +2954,7 @@ fn add_static_crate(
     bundled_lib_file_names: &FxIndexSet<Symbol>,
 ) {
     let src = &codegen_results.crate_info.used_crate_source[&cnum];
-    let cratepath = &src.rlib.as_ref().unwrap().0;
+    let cratepath = src.rlib.as_ref().unwrap();
 
     let mut link_upstream =
         |path: &Path| cmd.link_staticlib_by_path(&rehome_lib_path(sess, path), false);

--- a/compiler/rustc_data_structures/src/fx.rs
+++ b/compiler/rustc_data_structures/src/fx.rs
@@ -1,6 +1,6 @@
 use std::hash::BuildHasherDefault;
 
-pub use rustc_hash::{FxHashMap, FxHashSet, FxHasher};
+pub use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet, FxHasher};
 
 pub type StdEntry<'a, K, V> = std::collections::hash_map::Entry<'a, K, V>;
 

--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -684,19 +684,19 @@ fn write_out_deps(tcx: TyCtxt<'_>, outputs: &OutputFilenames, out_filenames: &[P
 
             for &cnum in tcx.crates(()) {
                 let source = tcx.used_crate_source(cnum);
-                if let Some((path, _)) = &source.dylib {
+                if let Some(path) = &source.dylib {
                     files.extend(hash_iter_files(
                         iter::once(escape_dep_filename(&path.display().to_string())),
                         checksum_hash_algo,
                     ));
                 }
-                if let Some((path, _)) = &source.rlib {
+                if let Some(path) = &source.rlib {
                     files.extend(hash_iter_files(
                         iter::once(escape_dep_filename(&path.display().to_string())),
                         checksum_hash_algo,
                     ));
                 }
-                if let Some((path, _)) = &source.rmeta {
+                if let Some(path) = &source.rmeta {
                     files.extend(hash_iter_files(
                         iter::once(escape_dep_filename(&path.display().to_string())),
                         checksum_hash_algo,

--- a/compiler/rustc_metadata/src/creader.rs
+++ b/compiler/rustc_metadata/src/creader.rs
@@ -135,16 +135,16 @@ impl<'a> std::fmt::Debug for CrateDump<'a> {
             writeln!(fmt, "  priv: {:?}", data.is_private_dep())?;
             let CrateSource { dylib, rlib, rmeta, sdylib_interface } = data.source();
             if let Some(dylib) = dylib {
-                writeln!(fmt, "  dylib: {}", dylib.0.display())?;
+                writeln!(fmt, "  dylib: {}", dylib.display())?;
             }
             if let Some(rlib) = rlib {
-                writeln!(fmt, "   rlib: {}", rlib.0.display())?;
+                writeln!(fmt, "   rlib: {}", rlib.display())?;
             }
             if let Some(rmeta) = rmeta {
-                writeln!(fmt, "   rmeta: {}", rmeta.0.display())?;
+                writeln!(fmt, "   rmeta: {}", rmeta.display())?;
             }
             if let Some(sdylib_interface) = sdylib_interface {
-                writeln!(fmt, "   sdylib interface: {}", sdylib_interface.0.display())?;
+                writeln!(fmt, "   sdylib interface: {}", sdylib_interface.display())?;
             }
         }
         Ok(())
@@ -550,9 +550,9 @@ impl CStore {
                 if let Some(mut files) = entry.files() {
                     if files.any(|l| {
                         let l = l.canonicalized();
-                        source.dylib.as_ref().map(|(p, _)| p) == Some(l)
-                            || source.rlib.as_ref().map(|(p, _)| p) == Some(l)
-                            || source.rmeta.as_ref().map(|(p, _)| p) == Some(l)
+                        source.dylib.as_ref() == Some(l)
+                            || source.rlib.as_ref() == Some(l)
+                            || source.rmeta.as_ref() == Some(l)
                     }) {
                         return Some(cnum);
                     }
@@ -658,7 +658,7 @@ impl CStore {
                 None => (&source, &crate_root),
             };
             let dlsym_dylib = dlsym_source.dylib.as_ref().expect("no dylib for a proc-macro crate");
-            Some(self.dlsym_proc_macros(tcx.sess, &dlsym_dylib.0, dlsym_root.stable_crate_id())?)
+            Some(self.dlsym_proc_macros(tcx.sess, dlsym_dylib, dlsym_root.stable_crate_id())?)
         } else {
             None
         };

--- a/compiler/rustc_session/src/cstore.rs
+++ b/compiler/rustc_session/src/cstore.rs
@@ -15,24 +15,22 @@ use rustc_hir::definitions::{DefKey, DefPath, DefPathHash, Definitions};
 use rustc_macros::{Decodable, Encodable, HashStable_Generic};
 use rustc_span::{Span, Symbol};
 
-use crate::search_paths::PathKind;
-
 // lonely orphan structs and enums looking for a better home
 
 /// Where a crate came from on the local filesystem. One of these three options
 /// must be non-None.
 #[derive(PartialEq, Clone, Debug, HashStable_Generic, Encodable, Decodable)]
 pub struct CrateSource {
-    pub dylib: Option<(PathBuf, PathKind)>,
-    pub rlib: Option<(PathBuf, PathKind)>,
-    pub rmeta: Option<(PathBuf, PathKind)>,
-    pub sdylib_interface: Option<(PathBuf, PathKind)>,
+    pub dylib: Option<PathBuf>,
+    pub rlib: Option<PathBuf>,
+    pub rmeta: Option<PathBuf>,
+    pub sdylib_interface: Option<PathBuf>,
 }
 
 impl CrateSource {
     #[inline]
     pub fn paths(&self) -> impl Iterator<Item = &PathBuf> {
-        self.dylib.iter().chain(self.rlib.iter()).chain(self.rmeta.iter()).map(|p| &p.0)
+        self.dylib.iter().chain(self.rlib.iter()).chain(self.rmeta.iter())
     }
 }
 

--- a/compiler/rustc_session/src/search_paths.rs
+++ b/compiler/rustc_session/src/search_paths.rs
@@ -71,7 +71,6 @@ pub enum PathKind {
     Crate,
     Dependency,
     Framework,
-    ExternFlag,
     All,
 }
 

--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -7,7 +7,7 @@
 //! goes along from the output of the previous stage.
 
 use std::borrow::Cow;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::ffi::OsStr;
 use std::io::BufReader;
 use std::io::prelude::*;
@@ -1558,7 +1558,7 @@ impl Step for RustcLink {
         run.never()
     }
 
-    /// Same as `std_link`, only for librustc
+    /// Same as `StdLink`, only for librustc
     fn run(self, builder: &Builder<'_>) {
         let build_compiler = self.build_compiler;
         let sysroot_compiler = self.sysroot_compiler;
@@ -2418,13 +2418,52 @@ pub fn add_to_sysroot(
     t!(fs::create_dir_all(sysroot_dst));
     t!(fs::create_dir_all(sysroot_host_dst));
     t!(fs::create_dir_all(self_contained_dst));
+
+    let mut crates = HashMap::new();
     for (path, dependency_type) in builder.read_stamp_file(stamp) {
+        let filename = path.file_name().unwrap().to_str().unwrap();
         let dst = match dependency_type {
-            DependencyType::Host => sysroot_host_dst,
-            DependencyType::Target => sysroot_dst,
+            DependencyType::Host => {
+                if sysroot_dst == sysroot_host_dst {
+                    // Only insert the part before the . to deduplicate different files for the same crate.
+                    // For example foo-1234.dll and foo-1234.dll.lib.
+                    crates.insert(filename.split_once('.').unwrap().0.to_owned(), path.clone());
+                }
+
+                sysroot_host_dst
+            }
+            DependencyType::Target => {
+                // Only insert the part before the . to deduplicate different files for the same crate.
+                // For example foo-1234.dll and foo-1234.dll.lib.
+                crates.insert(filename.split_once('.').unwrap().0.to_owned(), path.clone());
+
+                sysroot_dst
+            }
             DependencyType::TargetSelfContained => self_contained_dst,
         };
-        builder.copy_link(&path, &dst.join(path.file_name().unwrap()), FileType::Regular);
+        builder.copy_link(&path, &dst.join(filename), FileType::Regular);
+    }
+
+    // Check that none of the rustc_* crates have multiple versions. Otherwise using them from
+    // the sysroot would cause ambiguity errors. We do allow rustc_hash however as it is an
+    // external dependency that we build multiple copies of. It is re-exported by
+    // rustc_data_structures, so not being able to use extern crate rustc_hash; is not a big
+    // issue.
+    let mut seen_crates = HashMap::new();
+    for (filestem, path) in crates {
+        if !filestem.contains("rustc_") || filestem.contains("rustc_hash") {
+            continue;
+        }
+        if let Some(other_path) =
+            seen_crates.insert(filestem.split_once('-').unwrap().0.to_owned(), path.clone())
+        {
+            panic!(
+                "duplicate rustc crate {}\n-  first copy at {}\n- second copy at {}",
+                filestem.split_once('-').unwrap().0.to_owned(),
+                other_path.display(),
+                path.display(),
+            );
+        }
     }
 }
 
@@ -2511,7 +2550,13 @@ pub fn run_cargo(
             if filename.starts_with(&host_root_dir) {
                 // Unless it's a proc macro used in the compiler
                 if crate_types.iter().any(|t| t == "proc-macro") {
-                    deps.push((filename.to_path_buf(), DependencyType::Host));
+                    // Cargo will compile proc-macros that are part of the rustc workspace twice.
+                    // Once as libmacro-hash.so as build dependency and once as libmacro.so as
+                    // output artifact. Only keep the former to avoid ambiguity when trying to use
+                    // the proc macro from the sysroot.
+                    if filename.file_name().unwrap().to_str().unwrap().contains("-") {
+                        deps.push((filename.to_path_buf(), DependencyType::Host));
+                    }
                 }
                 continue;
             }

--- a/src/tools/miri/src/diagnostics.rs
+++ b/src/tools/miri/src/diagnostics.rs
@@ -3,8 +3,8 @@ use std::num::NonZero;
 use std::sync::Mutex;
 
 use rustc_abi::{Align, Size};
+use rustc_data_structures::fx::{FxBuildHasher, FxHashSet};
 use rustc_errors::{Diag, DiagMessage, Level};
-use rustc_hash::FxHashSet;
 use rustc_span::{DUMMY_SP, Span, SpanData, Symbol};
 
 use crate::borrow_tracker::stacked_borrows::diagnostics::TagHistory;
@@ -878,6 +878,6 @@ pub struct SpanDedupDiagnostic(Mutex<FxHashSet<Span>>);
 
 impl SpanDedupDiagnostic {
     pub const fn new() -> Self {
-        Self(Mutex::new(FxHashSet::with_hasher(rustc_hash::FxBuildHasher)))
+        Self(Mutex::new(FxHashSet::with_hasher(FxBuildHasher)))
     }
 }

--- a/src/tools/miri/src/helpers.rs
+++ b/src/tools/miri/src/helpers.rs
@@ -6,7 +6,7 @@ use std::{cmp, iter};
 use rand::RngCore;
 use rustc_abi::{Align, ExternAbi, FieldIdx, FieldsShape, Size, Variants};
 use rustc_apfloat::Float;
-use rustc_hash::FxHashSet;
+use rustc_data_structures::fx::{FxBuildHasher, FxHashSet};
 use rustc_hir::Safety;
 use rustc_hir::def::{DefKind, Namespace};
 use rustc_hir::def_id::{CRATE_DEF_INDEX, CrateNum, DefId, LOCAL_CRATE};
@@ -647,7 +647,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             RejectOpWith::WarningWithoutBacktrace => {
                 // Deduplicate these warnings *by shim* (not by span)
                 static DEDUP: Mutex<FxHashSet<String>> =
-                    Mutex::new(FxHashSet::with_hasher(rustc_hash::FxBuildHasher));
+                    Mutex::new(FxHashSet::with_hasher(FxBuildHasher));
                 let mut emitted_warnings = DEDUP.lock().unwrap();
                 if !emitted_warnings.contains(op_name) {
                     // First time we are seeing this.

--- a/src/tools/miri/src/lib.rs
+++ b/src/tools/miri/src/lib.rs
@@ -57,7 +57,6 @@ extern crate rustc_codegen_ssa;
 extern crate rustc_const_eval;
 extern crate rustc_data_structures;
 extern crate rustc_errors;
-extern crate rustc_hash;
 extern crate rustc_hir;
 extern crate rustc_index;
 extern crate rustc_log;

--- a/tests/run-make/duplicate-dependency-no-disambiguate/foo-v1.rs
+++ b/tests/run-make/duplicate-dependency-no-disambiguate/foo-v1.rs
@@ -1,0 +1,1 @@
+pub struct Foo;

--- a/tests/run-make/duplicate-dependency-no-disambiguate/foo-v2.rs
+++ b/tests/run-make/duplicate-dependency-no-disambiguate/foo-v2.rs
@@ -1,0 +1,1 @@
+pub struct Foo;

--- a/tests/run-make/duplicate-dependency-no-disambiguate/main.rs
+++ b/tests/run-make/duplicate-dependency-no-disambiguate/main.rs
@@ -1,0 +1,10 @@
+#![feature(custom_inner_attributes)]
+#![rustfmt::skip] // use_foo must be referenced before foo
+
+// Load foo-v2 through use-foo
+use use_foo as _;
+
+// Make sure we don't disambiguate this as foo-v2.
+use foo as _;
+
+fn main() {}

--- a/tests/run-make/duplicate-dependency-no-disambiguate/main.stderr
+++ b/tests/run-make/duplicate-dependency-no-disambiguate/main.stderr
@@ -1,0 +1,12 @@
+error[E0464]: multiple candidates for `rlib` dependency `foo` found
+  --> main.rs:8:5
+   |
+LL | use foo as _;
+   |     ^^^
+   |
+   = note: candidate #1: /build-root/test/run-make/duplicate-dependency-no-disambiguate/rmake_out/libfoo-v1.rlib
+   = note: candidate #2: /build-root/test/run-make/duplicate-dependency-no-disambiguate/rmake_out/libfoo-v2.rlib
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0464`.

--- a/tests/run-make/duplicate-dependency-no-disambiguate/rmake.rs
+++ b/tests/run-make/duplicate-dependency-no-disambiguate/rmake.rs
@@ -1,0 +1,54 @@
+//@ needs-target-std
+
+use run_make_support::{Rustc, cwd, diff, regex, rust_lib_name, rustc};
+
+fn rustc_with_common_args() -> Rustc {
+    let mut rustc = rustc();
+    rustc.remap_path_prefix(cwd(), "$DIR");
+    rustc.edition("2018"); // Don't require `extern crate`
+    rustc
+}
+
+fn main() {
+    rustc_with_common_args()
+        .input("foo-v1.rs")
+        .crate_type("rlib")
+        .crate_name("foo")
+        .extra_filename("-v1")
+        .metadata("-v1")
+        .run();
+
+    rustc_with_common_args()
+        .input("foo-v2.rs")
+        .crate_type("rlib")
+        .crate_name("foo")
+        .extra_filename("-v2")
+        .metadata("-v2")
+        .run();
+
+    rustc_with_common_args()
+        .input("use-foo.rs")
+        .crate_type("rlib")
+        .extern_("foo", rust_lib_name("foo-v2"))
+        .run();
+
+    let stderr = rustc_with_common_args()
+        .input("main.rs")
+        .extern_("foo", rust_lib_name("foo-v1"))
+        .extern_("foo", rust_lib_name("foo-v2"))
+        .extern_("use_foo", rust_lib_name("use_foo"))
+        .library_search_path(cwd())
+        .ui_testing()
+        .run_fail()
+        .stderr_utf8();
+
+    diff()
+        .expected_file("main.stderr")
+        .normalize(
+            regex::escape(run_make_support::build_root().canonicalize().unwrap().to_str().unwrap()),
+            "/build-root",
+        )
+        .normalize(r"\\", "/")
+        .actual_text("(rustc)", &stderr)
+        .run();
+}

--- a/tests/run-make/duplicate-dependency-no-disambiguate/use-foo.rs
+++ b/tests/run-make/duplicate-dependency-no-disambiguate/use-foo.rs
@@ -1,0 +1,1 @@
+use foo as _;


### PR DESCRIPTION
Previously if a dependency of the current crate depended on a sysroot crate, then `extern crate` would in the current crate would pick the first loaded version of said sysroot crate even in case of an ambiguity. This is surprising and brittle. For `-Ldependency=` we already blocked this since rust-lang/rust#110229, but the fix didn't account for sysroot crates.

Should fix https://github.com/rust-lang/rust/issues/147966