### PR TITLE
Fix missing double-quote in `std::env::consts::OS` values

### DIFF
--- a/library/std/src/env.rs
+++ b/library/std/src/env.rs
@@ -1097,7 +1097,7 @@ pub mod consts {
     /// * `"nto"`
     /// * `"redox"`
     /// * `"solaris"`
-    /// * `"solid_asp3`
+    /// * `"solid_asp3"`
     /// * `"vexos"`
     /// * `"vita"`
     /// * `"vxworks"`


### PR DESCRIPTION
Noticed this one while reading the docs. Hopefully it's not too small change.