### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -2025,13 +2025,11 @@ fn render_impl(
         let mut methods = Vec::new();
 
         if !impl_.is_negative_trait_impl() {
-            for trait_item in &impl_.items {
-                match trait_item.kind {
-                    clean::MethodItem(..) | clean::RequiredMethodItem(_) => {
-                        methods.push(trait_item)
-                    }
+            for impl_item in &impl_.items {
+                match impl_item.kind {
+                    clean::MethodItem(..) | clean::RequiredMethodItem(_) => methods.push(impl_item),
                     clean::RequiredAssocTypeItem(..) | clean::AssocTypeItem(..) => {
-                        assoc_types.push(trait_item)
+                        assoc_types.push(impl_item)
                     }
                     clean::RequiredAssocConstItem(..)
                     | clean::ProvidedAssocConstItem(_)
@@ -2041,7 +2039,7 @@ fn render_impl(
                             &mut default_impl_items,
                             &mut impl_items,
                             cx,
-                            trait_item,
+                            impl_item,
                             if trait_.is_some() { &i.impl_item } else { parent },
                             link,
                             render_mode,

--- a/src/librustdoc/html/render/write_shared.rs
+++ b/src/librustdoc/html/render/write_shared.rs
@@ -568,18 +568,14 @@ impl TypeAliasPart {
                         if let Some(ret) = &mut ret {
                             ret.aliases.push(type_alias_fqp);
                         } else {
-                            let target_did = impl_
-                                .inner_impl()
-                                .trait_
-                                .as_ref()
-                                .map(|trait_| trait_.def_id())
-                                .or_else(|| impl_.inner_impl().for_.def_id(&cx.shared.cache));
+                            let target_trait_did =
+                                impl_.inner_impl().trait_.as_ref().map(|trait_| trait_.def_id());
                             let provided_methods;
-                            let assoc_link = if let Some(target_did) = target_did {
+                            let assoc_link = if let Some(target_trait_did) = target_trait_did {
                                 provided_methods =
                                     impl_.inner_impl().provided_trait_methods(cx.tcx());
                                 AssocItemLink::GotoSource(
-                                    ItemId::DefId(target_did),
+                                    ItemId::DefId(target_trait_did),
                                     &provided_methods,
                                 )
                             } else {

--- a/tests/rustdoc-gui/src/test_docs/lib.rs
+++ b/tests/rustdoc-gui/src/test_docs/lib.rs
@@ -786,3 +786,13 @@ pub mod tooltips {
         Vec::new()
     }
 }
+
+pub mod tyalias {
+    pub struct X<T>(pub T);
+
+    impl<T: std::fmt::Debug> X<T> {
+        pub fn blob(&self) {}
+    }
+
+    pub type Y = X<u8>;
+}

--- a/tests/rustdoc-gui/type-alias.goml
+++ b/tests/rustdoc-gui/type-alias.goml
@@ -1,0 +1,7 @@
+// This test ensures that we correctly generate links to methods on type aliases.
+go-to: "file://" + |DOC_PATH| + "/test_docs/tyalias/type.Y.html"
+
+// It's generated with JS so we need to wait for it to be done generating.
+wait-for: "#implementations"
+// We check that it's "#method." and not "#tymethod.".
+assert-text: ('#method\.blob a.fn[href="#method.blob"]', "blob")

--- a/tests/ui/proc-macro/auxiliary/extra-empty-derive.rs
+++ b/tests/ui/proc-macro/auxiliary/extra-empty-derive.rs
@@ -1,0 +1,7 @@
+extern crate proc_macro;
+use proc_macro::{TokenStream, TokenTree};
+
+#[proc_macro_derive(Empty2, attributes(empty_helper))]
+pub fn empty_derive2(_: TokenStream) -> TokenStream {
+    TokenStream::new()
+}

--- a/tests/ui/proc-macro/helper-attr-compat-collision.rs
+++ b/tests/ui/proc-macro/helper-attr-compat-collision.rs
@@ -1,0 +1,23 @@
+//@ proc-macro: test-macros.rs
+//@ proc-macro: extra-empty-derive.rs
+//@ build-pass
+
+#[macro_use(Empty)]
+extern crate test_macros;
+#[macro_use(Empty2)]
+extern crate extra_empty_derive;
+
+// Testing the behavior of derive attributes with helpers that share the same name.
+//
+// Normally if the first derive below were absent the call to #[empty_helper] before it it
+// introduced by its own derive would produce a future incompat error.
+//
+// With the extra derive also introducing that attribute in advanced the warning gets supressed.
+// Demonstrates a lack of identity to helper attributes, the compiler does not track which derive
+// introduced a helper, just that a derive introduced the helper.
+#[derive(Empty)]
+#[empty_helper]
+#[derive(Empty2)]
+struct S;
+
+fn main() {}

--- a/tests/ui/proc-macro/helper-attr-compat-collision.rs
+++ b/tests/ui/proc-macro/helper-attr-compat-collision.rs
@@ -1,6 +1,6 @@
 //@ proc-macro: test-macros.rs
 //@ proc-macro: extra-empty-derive.rs
-//@ build-pass
+//@ check-pass
 
 #[macro_use(Empty)]
 extern crate test_macros;


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#148652 (Cleanup and refactor FnCtxt::report_no_match_method_error)
 - rust-lang/rust#149200 (Add test for derive helper compat collisions)
 - rust-lang/rust#149274 (Fix invalid link generation for type alias methods)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=148652,149200,149274)
<!-- homu-ignore:end -->