### PR TITLE
[DO NOT MERGE] Add a crater lint for issue 145739

### DIFF
--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -482,6 +482,19 @@ lint_invalid_target = `#[{$name}]` attribute cannot be used on {$target}
     .help = `#[{$name}]` can {$only}be applied to {$applied}
     .suggestion = remove the attribute
 
+lint_issue_145739 = `format_args!` is called with multiple parameters that capturing the same {$kind} violating issue 145739
+    .note1 = the type of this {$kind} is `{$ty}` and it has {$is_not_freeze ->
+            [true] {$needs_drop ->
+                    [true] interior mutability and drop implementation
+                    *[false] interior mutability
+                }
+            *[false] {$needs_drop ->
+                    [true] drop implementation
+                    *[false] (none)
+                }
+        }
+    .note2 = these are the duplicated parameters
+
 lint_lintpass_by_hand = implementing `LintPass` by hand
     .help = try using `declare_lint_pass!` or `impl_lint_pass!` instead
 
@@ -997,16 +1010,3 @@ lint_uses_power_alignment = repr(C) does not follow the power alignment rule. Th
 
 lint_variant_size_differences =
     enum variant is more than three times larger ({$largest} bytes) than the next largest
-
-lint_issue_145739 = `format_args!` is called with multiple parameters that capturing the same {$kind} violating issue 145739
-    .note1 = the type of this {$kind} is `{$ty}` and it has {$is_not_freeze ->
-            [true] {$needs_drop ->
-                    [true] interior mutability and drop implementation
-                    *[false] interior mutability
-                }
-            *[false] {$needs_drop ->
-                    [true] drop implementation
-                    *[false] (none)
-                }
-        }
-    .note2 = these are the duplicated parameters

--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -997,3 +997,16 @@ lint_uses_power_alignment = repr(C) does not follow the power alignment rule. Th
 
 lint_variant_size_differences =
     enum variant is more than three times larger ({$largest} bytes) than the next largest
+
+lint_issue_145739 = `format_args!` is called with multiple parameters that capturing the same {$kind} violating issue 145739
+    .note1 = the type of this {$kind} is `{$ty}` and it has {$is_not_freeze ->
+            [true] {$needs_drop ->
+                    [true] interior mutability and drop implementation
+                    *[false] interior mutability
+                }
+            *[false] {$needs_drop ->
+                    [true] drop implementation
+                    *[false] (none)
+                }
+        }
+    .note2 = these are the duplicated parameters

--- a/compiler/rustc_lint/src/issue_145739.rs
+++ b/compiler/rustc_lint/src/issue_145739.rs
@@ -1,0 +1,84 @@
+use rustc_errors::MultiSpan;
+use rustc_hir as hir;
+use rustc_middle::span_bug;
+use rustc_session::{declare_lint, declare_lint_pass};
+use rustc_span::symbol::sym;
+
+use crate::lints::Issue145738Diag;
+use crate::{LateContext, LateLintPass, LintContext};
+
+declare_lint! {
+    pub ISSUE_145739,
+    Deny,
+    "a violation for issue 145739 is caught",
+}
+
+declare_lint_pass!(
+    Issue145739 => [ISSUE_145739]
+);
+
+impl<'tcx> LateLintPass<'tcx> for Issue145739 {
+    fn check_stmt(&mut self, cx: &LateContext<'tcx>, stmt: &'tcx hir::Stmt<'tcx>) {
+        let hir::StmtKind::Let(hir::LetStmt {
+            pat:
+                hir::Pat { kind: hir::PatKind::Binding(hir::BindingMode::NONE, _, ident, None), .. },
+            init: Some(hir::Expr { kind: hir::ExprKind::Tup(tup), .. }),
+            ..
+        }) = stmt.kind
+        else {
+            return;
+        };
+
+        if ident.name != sym::__issue_145739 {
+            return;
+        }
+
+        if tup.len() < 3 {
+            span_bug!(stmt.span, "Duplicated tuple is too short");
+        }
+
+        let hir::ExprKind::AddrOf(hir::BorrowKind::Ref, hir::Mutability::Not, arg_expr) =
+            tup[0].kind
+        else {
+            span_bug!(stmt.span, "Duplicated tuple first element is not a ref");
+        };
+
+        let hir::ExprKind::Path(hir::QPath::Resolved(None, path)) = arg_expr.kind else {
+            return;
+        };
+
+        let hir::def::Res::Def(def_kind, def_id) = path.res else {
+            return;
+        };
+
+        let tcx = cx.tcx;
+        let typing_env = cx.typing_env();
+        let (ty, kind) = match def_kind {
+            hir::def::DefKind::Const => (tcx.type_of(def_id).skip_binder(), "constant"),
+            hir::def::DefKind::Ctor(_, hir::def::CtorKind::Const) => {
+                (tcx.type_of(tcx.parent(def_id)).skip_binder(), "constant constructor")
+            }
+            _ => {
+                return;
+            }
+        };
+
+        let lint = |is_not_freeze, needs_drop| {
+            let diag = Issue145738Diag {
+                const_span: tcx.def_span(def_id),
+                kind,
+                ty,
+                is_not_freeze,
+                needs_drop,
+                duplicates: MultiSpan::from_spans(tup.iter().skip(1).map(|e| e.span).collect()),
+            };
+            cx.emit_span_lint(ISSUE_145739, stmt.span, diag);
+        };
+
+        if !ty.is_freeze(tcx, typing_env) {
+            lint(true, ty.needs_drop(tcx, typing_env));
+        } else if ty.needs_drop(tcx, typing_env) {
+            lint(false, true);
+        }
+    }
+}

--- a/compiler/rustc_lint/src/issue_145739.rs
+++ b/compiler/rustc_lint/src/issue_145739.rs
@@ -8,6 +8,8 @@ use crate::lints::Issue145738Diag;
 use crate::{LateContext, LateLintPass, LintContext};
 
 declare_lint! {
+    /// A crater only lint that checks for multiple parameters capturing a single const/const ctor
+    /// inside a single `format_args!` macro expansion.
     pub ISSUE_145739,
     Deny,
     "a violation for issue 145739 is caught",

--- a/compiler/rustc_lint/src/lib.rs
+++ b/compiler/rustc_lint/src/lib.rs
@@ -51,6 +51,7 @@ mod impl_trait_overcaptures;
 mod interior_mutable_consts;
 mod internal;
 mod invalid_from_utf8;
+mod issue_145739;
 mod late;
 mod let_underscore;
 mod levels;
@@ -97,6 +98,7 @@ use impl_trait_overcaptures::ImplTraitOvercaptures;
 use interior_mutable_consts::*;
 use internal::*;
 use invalid_from_utf8::*;
+use issue_145739::Issue145739;
 use let_underscore::*;
 use lifetime_syntax::*;
 use macro_expr_fragment_specifier_2024_migration::*;
@@ -249,6 +251,7 @@ late_lint_methods!(
             FunctionCastsAsInteger: FunctionCastsAsInteger,
             CheckTransmutes: CheckTransmutes,
             LifetimeSyntax: LifetimeSyntax,
+            Issue145739: Issue145739,
         ]
     ]
 );

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -3199,3 +3199,17 @@ pub(crate) struct UnusedVisibility {
     #[suggestion(style = "short", code = "", applicability = "machine-applicable")]
     pub span: Span,
 }
+
+// issue_145739.rs
+#[derive(LintDiagnostic)]
+#[diag(lint_issue_145739)]
+pub(crate) struct Issue145738Diag<'a> {
+    #[note(lint_note1)]
+    pub const_span: Span,
+    pub kind: &'static str,
+    pub ty: Ty<'a>,
+    pub is_not_freeze: bool,
+    pub needs_drop: bool,
+    #[note(lint_note2)]
+    pub duplicates: MultiSpan,
+}

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -399,6 +399,7 @@ symbols! {
         __S,
         __T,
         __awaitee,
+        __issue_145739,
         __try_var,
         _t,
         _task_context,

--- a/tests/ui/lint/format-args-issue-145739.rs
+++ b/tests/ui/lint/format-args-issue-145739.rs
@@ -1,0 +1,40 @@
+use std::cell::Cell;
+use std::fmt::{self, Display, Formatter};
+
+#[derive(Debug)]
+struct NonFreeze(Cell<usize>);
+
+impl Display for DropImpl {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "DropImpl")
+    }
+}
+
+#[derive(Debug)]
+struct DropImpl;
+
+impl Drop for DropImpl {
+    fn drop(&mut self) {}
+}
+
+const NON_FREEZE: NonFreeze = NonFreeze(Cell::new(0));
+const DROP_IMPL: DropImpl = DropImpl;
+const FINE: &str = "fine";
+
+fn main() {
+    // These are okay
+    format_args!("{FINE}{FINE}");
+    format_args!("{DROP_IMPL}{DropImpl}");
+    let _ = format!("{NON_FREEZE:?}{:?}", NON_FREEZE);
+
+    // These are not
+    print!("{DROP_IMPL}, {DROP_IMPL}");
+    //~^ ERROR `format_args!` is called with multiple parameters that capturing the same constant violating issue 145739 [issue_145739]
+    println!("{DropImpl}{DropImpl:?}");
+    //~^ ERROR `format_args!` is called with multiple parameters that capturing the same constant constructor violating issue 145739 [issue_145739]
+    format!("{NON_FREEZE:?}{:?}{NON_FREEZE:?}", NON_FREEZE);
+    //~^ ERROR `format_args!` is called with multiple parameters that capturing the same constant violating issue 145739 [issue_145739]
+    format!("{NON_FREEZE:?}{DropImpl}{NON_FREEZE:?}{DropImpl}");
+    //~^ ERROR `format_args!` is called with multiple parameters that capturing the same constant violating issue 145739 [issue_145739]
+    //~| ERROR `format_args!` is called with multiple parameters that capturing the same constant constructor violating issue 145739 [issue_145739]
+}

--- a/tests/ui/lint/format-args-issue-145739.stderr
+++ b/tests/ui/lint/format-args-issue-145739.stderr
@@ -1,0 +1,93 @@
+error: `format_args!` is called with multiple parameters that capturing the same constant violating issue 145739
+  --> $DIR/format-args-issue-145739.rs:31:14
+   |
+LL |     print!("{DROP_IMPL}, {DROP_IMPL}");
+   |              ^^^^^^^^^
+   |
+note: the type of this constant is `DropImpl` and it has drop implementation
+  --> $DIR/format-args-issue-145739.rs:21:1
+   |
+LL | const DROP_IMPL: DropImpl = DropImpl;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+note: these are the duplicated parameters
+  --> $DIR/format-args-issue-145739.rs:31:13
+   |
+LL |     print!("{DROP_IMPL}, {DROP_IMPL}");
+   |             ^^^^^^^^^^^  ^^^^^^^^^^^
+   = note: `#[deny(issue_145739)]` on by default
+   = note: this error originates in the macro `$crate::format_args` which comes from the expansion of the macro `print` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: `format_args!` is called with multiple parameters that capturing the same constant constructor violating issue 145739
+  --> $DIR/format-args-issue-145739.rs:33:16
+   |
+LL |     println!("{DropImpl}{DropImpl:?}");
+   |                ^^^^^^^^
+   |
+note: the type of this constant constructor is `DropImpl` and it has drop implementation
+  --> $DIR/format-args-issue-145739.rs:14:1
+   |
+LL | struct DropImpl;
+   | ^^^^^^^^^^^^^^^
+note: these are the duplicated parameters
+  --> $DIR/format-args-issue-145739.rs:33:15
+   |
+LL |     println!("{DropImpl}{DropImpl:?}");
+   |               ^^^^^^^^^^^^^^^^^^^^^^
+   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: `format_args!` is called with multiple parameters that capturing the same constant violating issue 145739
+  --> $DIR/format-args-issue-145739.rs:35:15
+   |
+LL |     format!("{NON_FREEZE:?}{:?}{NON_FREEZE:?}", NON_FREEZE);
+   |               ^^^^^^^^^^
+   |
+note: the type of this constant is `NonFreeze` and it has interior mutability
+  --> $DIR/format-args-issue-145739.rs:20:1
+   |
+LL | const NON_FREEZE: NonFreeze = NonFreeze(Cell::new(0));
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: these are the duplicated parameters
+  --> $DIR/format-args-issue-145739.rs:35:14
+   |
+LL |     format!("{NON_FREEZE:?}{:?}{NON_FREEZE:?}", NON_FREEZE);
+   |              ^^^^^^^^^^^^^^    ^^^^^^^^^^^^^^
+   = note: this error originates in the macro `$crate::__export::format_args` which comes from the expansion of the macro `format` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: `format_args!` is called with multiple parameters that capturing the same constant violating issue 145739
+  --> $DIR/format-args-issue-145739.rs:37:15
+   |
+LL |     format!("{NON_FREEZE:?}{DropImpl}{NON_FREEZE:?}{DropImpl}");
+   |               ^^^^^^^^^^
+   |
+note: the type of this constant is `NonFreeze` and it has interior mutability
+  --> $DIR/format-args-issue-145739.rs:20:1
+   |
+LL | const NON_FREEZE: NonFreeze = NonFreeze(Cell::new(0));
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: these are the duplicated parameters
+  --> $DIR/format-args-issue-145739.rs:37:14
+   |
+LL |     format!("{NON_FREEZE:?}{DropImpl}{NON_FREEZE:?}{DropImpl}");
+   |              ^^^^^^^^^^^^^^          ^^^^^^^^^^^^^^
+   = note: this error originates in the macro `$crate::__export::format_args` which comes from the expansion of the macro `format` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: `format_args!` is called with multiple parameters that capturing the same constant constructor violating issue 145739
+  --> $DIR/format-args-issue-145739.rs:37:29
+   |
+LL |     format!("{NON_FREEZE:?}{DropImpl}{NON_FREEZE:?}{DropImpl}");
+   |                             ^^^^^^^^
+   |
+note: the type of this constant constructor is `DropImpl` and it has drop implementation
+  --> $DIR/format-args-issue-145739.rs:14:1
+   |
+LL | struct DropImpl;
+   | ^^^^^^^^^^^^^^^
+note: these are the duplicated parameters
+  --> $DIR/format-args-issue-145739.rs:37:28
+   |
+LL |     format!("{NON_FREEZE:?}{DropImpl}{NON_FREEZE:?}{DropImpl}");
+   |                            ^^^^^^^^^^              ^^^^^^^^^^
+   = note: this error originates in the macro `$crate::__export::format_args` which comes from the expansion of the macro `format` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 5 previous errors
+


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/149291)*
<!-- homu-ignore:end -->

I took some weird hack that expands the following macro call
```rust
format_args!("{x} {x}");
```
into
```rust
{
    super let args = (&x,);
    super let args = [format_argument::new_display(args.0)];
    // `&x` is for getting the information of captured parameter,
    // and the units have the same spans with actual parmeter occurrences, which can be used for lints
    let __issue_145739 = (&x, (), ());
    unsafe {
        format_arguments::new(b"\xc0\x01 \xc8\x00\x00\x01\n\x00",
            &args)
    }
}
```
and then look for those let stmt with `__issue_145739` later in the late lint pass.

It's because in early lint, we don't have much information other than AST, while in late lint, we have quite much information but not for AST 😂 So I have to leave some information about AST before executing late lint - macro expansion - and I think this would be okay as this lint will be used only for crater runs
