### PR TITLE
Fix comment wording in simplify_comparison_integral.rs

### DIFF
--- a/compiler/rustc_mir_transform/src/simplify_comparison_integral.rs
+++ b/compiler/rustc_mir_transform/src/simplify_comparison_integral.rs
@@ -74,7 +74,7 @@ impl<'tcx> crate::MirPass<'tcx> for SimplifyComparisonIntegral {
             }
 
             // delete comparison statement if it the value being switched on was moved, which means
-            // it can not be user later on
+            // it can not be used later on
             if opt.can_remove_bin_op_stmt {
                 bb.statements[opt.bin_op_stmt_idx].make_nop(true);
             } else {


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->


This change corrects the wording in a comment within `simplify_comparison_integral.rs`, changing "user" to "used" to accurately describe that a moved value cannot be used later on. 

The adjustment improves code documentation clarity while maintaining consistency with our standards for precise terminology in comments.