### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/compiler/rustc_symbol_mangling/src/v0.rs
+++ b/compiler/rustc_symbol_mangling/src/v0.rs
@@ -882,11 +882,11 @@ impl<'tcx> Printer<'tcx> for V0SymbolMangler<'tcx> {
             DefPathData::OpaqueTy => 'i',
             DefPathData::SyntheticCoroutineBody => 's',
             DefPathData::NestedStatic => 'n',
+            DefPathData::GlobalAsm => 'a',
 
             // These should never show up as `print_path_with_simple` arguments.
             DefPathData::CrateRoot
             | DefPathData::Use
-            | DefPathData::GlobalAsm
             | DefPathData::Impl
             | DefPathData::MacroNs(_)
             | DefPathData::LifetimeNs(_)

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -2025,13 +2025,11 @@ fn render_impl(
         let mut methods = Vec::new();
 
         if !impl_.is_negative_trait_impl() {
-            for trait_item in &impl_.items {
-                match trait_item.kind {
-                    clean::MethodItem(..) | clean::RequiredMethodItem(_) => {
-                        methods.push(trait_item)
-                    }
+            for impl_item in &impl_.items {
+                match impl_item.kind {
+                    clean::MethodItem(..) | clean::RequiredMethodItem(_) => methods.push(impl_item),
                     clean::RequiredAssocTypeItem(..) | clean::AssocTypeItem(..) => {
-                        assoc_types.push(trait_item)
+                        assoc_types.push(impl_item)
                     }
                     clean::RequiredAssocConstItem(..)
                     | clean::ProvidedAssocConstItem(_)
@@ -2041,7 +2039,7 @@ fn render_impl(
                             &mut default_impl_items,
                             &mut impl_items,
                             cx,
-                            trait_item,
+                            impl_item,
                             if trait_.is_some() { &i.impl_item } else { parent },
                             link,
                             render_mode,

--- a/src/librustdoc/html/render/write_shared.rs
+++ b/src/librustdoc/html/render/write_shared.rs
@@ -568,18 +568,14 @@ impl TypeAliasPart {
                         if let Some(ret) = &mut ret {
                             ret.aliases.push(type_alias_fqp);
                         } else {
-                            let target_did = impl_
-                                .inner_impl()
-                                .trait_
-                                .as_ref()
-                                .map(|trait_| trait_.def_id())
-                                .or_else(|| impl_.inner_impl().for_.def_id(&cx.shared.cache));
+                            let target_trait_did =
+                                impl_.inner_impl().trait_.as_ref().map(|trait_| trait_.def_id());
                             let provided_methods;
-                            let assoc_link = if let Some(target_did) = target_did {
+                            let assoc_link = if let Some(target_trait_did) = target_trait_did {
                                 provided_methods =
                                     impl_.inner_impl().provided_trait_methods(cx.tcx());
                                 AssocItemLink::GotoSource(
-                                    ItemId::DefId(target_did),
+                                    ItemId::DefId(target_trait_did),
                                     &provided_methods,
                                 )
                             } else {

--- a/tests/rustdoc-gui/src/test_docs/lib.rs
+++ b/tests/rustdoc-gui/src/test_docs/lib.rs
@@ -786,3 +786,13 @@ pub mod tooltips {
         Vec::new()
     }
 }
+
+pub mod tyalias {
+    pub struct X<T>(pub T);
+
+    impl<T: std::fmt::Debug> X<T> {
+        pub fn blob(&self) {}
+    }
+
+    pub type Y = X<u8>;
+}

--- a/tests/rustdoc-gui/type-alias.goml
+++ b/tests/rustdoc-gui/type-alias.goml
@@ -1,0 +1,7 @@
+// This test ensures that we correctly generate links to methods on type aliases.
+go-to: "file://" + |DOC_PATH| + "/test_docs/tyalias/type.Y.html"
+
+// It's generated with JS so we need to wait for it to be done generating.
+wait-for: "#implementations"
+// We check that it's "#method." and not "#tymethod.".
+assert-text: ('#method\.blob a.fn[href="#method.blob"]', "blob")

--- a/tests/ui/symbol-names/const-in-global-asm.rs
+++ b/tests/ui/symbol-names/const-in-global-asm.rs
@@ -1,0 +1,19 @@
+//@ compile-flags: -Clink-dead-code
+//@ build-pass
+
+#![allow(unused)]
+
+// Test that a symbol in a `global_asm` namespace doesn't cause an ICE during v0 symbol mangling
+// due to a lack of missing namespace character for `global_asm`.
+//
+// FIXME: Can't use `#[rustc_symbol_name]` on the `foo` call to check its symbol, so just checking
+// the test compiles.
+
+fn foo<const N: usize>() {}
+
+core::arch::global_asm!("/* {} */", sym foo::<{
+    || {};
+    0
+}>);
+
+fn main() {}


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#148652 (Cleanup and refactor FnCtxt::report_no_match_method_error)
 - rust-lang/rust#149268 (add implementation-internal namespace for globalasm)
 - rust-lang/rust#149274 (Fix invalid link generation for type alias methods)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=148652,149268,149274)
<!-- homu-ignore:end -->