### PR TITLE
Simplify OnceCell Clone impl

### DIFF
--- a/library/core/src/cell/once.rs
+++ b/library/core/src/cell/once.rs
@@ -376,14 +376,10 @@ impl<T: fmt::Debug> fmt::Debug for OnceCell<T> {
 impl<T: Clone> Clone for OnceCell<T> {
     #[inline]
     fn clone(&self) -> OnceCell<T> {
-        let res = OnceCell::new();
-        if let Some(value) = self.get() {
-            match res.set(value.clone()) {
-                Ok(()) => (),
-                Err(_) => unreachable!(),
-            }
+        match self.get() {
+            Some(value) => OnceCell::from(value.clone()),
+            None => OnceCell::new(),
         }
-        res
     }
 }
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Noticed when developing https://github.com/fast/mea/pull/79.

This may also apply to `OnceLock`. But unfortunately, we can't construct a completed `Once` beforehand.

Note that `OnceCell::from` is marked as [`rustc_const_unstable`](https://github.com/rust-lang/rust/issues/143773) so we don't need an extra `const fn from_value` to leverage possible const convert benefit.