### PR TITLE
Deny const auto traits

### DIFF
--- a/compiler/rustc_ast_passes/messages.ftl
+++ b/compiler/rustc_ast_passes/messages.ftl
@@ -89,6 +89,9 @@ ast_passes_const_and_coroutine = functions cannot be both `const` and `{$corouti
     .coroutine = `{$coroutine_kind}` because of this
     .label = {""}
 
+ast_passes_const_auto_trait = auto traits cannot be const
+    .help = remove the `const` keyword
+
 ast_passes_const_bound_trait_object = const trait bounds are not allowed in trait object types
 
 ast_passes_const_without_body =

--- a/compiler/rustc_ast_passes/src/errors.rs
+++ b/compiler/rustc_ast_passes/src/errors.rs
@@ -430,6 +430,14 @@ pub(crate) struct AutoTraitItems {
 }
 
 #[derive(Diagnostic)]
+#[diag(ast_passes_const_auto_trait)]
+#[help]
+pub(crate) struct ConstAutoTrait {
+    #[primary_span]
+    pub span: Span,
+}
+
+#[derive(Diagnostic)]
 #[diag(ast_passes_generic_before_constraints)]
 pub(crate) struct ArgsBeforeConstraint {
     #[primary_span]

--- a/compiler/rustc_next_trait_solver/src/solve/effect_goals.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/effect_goals.rs
@@ -189,10 +189,11 @@ where
     }
 
     fn consider_auto_trait_candidate(
-        _ecx: &mut EvalCtxt<'_, D>,
+        ecx: &mut EvalCtxt<'_, D>,
         _goal: Goal<I, Self>,
     ) -> Result<Candidate<I>, NoSolution> {
-        unreachable!("auto traits are never const")
+        ecx.cx().delay_bug("auto traits are never const");
+        Err(NoSolution)
     }
 
     fn consider_trait_alias_candidate(

--- a/tests/ui/traits/const-traits/const-auto-trait.rs
+++ b/tests/ui/traits/const-traits/const-auto-trait.rs
@@ -1,6 +1,15 @@
+//@ compile-flags: -Znext-solver
+// See rust-lang/rust#149285 for this test
+
 #![feature(auto_traits, const_trait_impl)]
 
 const auto trait Marker {}
 //~^ ERROR: auto traits cannot be const
+
+fn scope() {
+    fn check<T: const Marker>() {}
+    check::<()>();
+    //~^ ERROR: the trait bound `(): const Marker` is not satisfied
+}
 
 fn main() {}

--- a/tests/ui/traits/const-traits/const-auto-trait.rs
+++ b/tests/ui/traits/const-traits/const-auto-trait.rs
@@ -1,0 +1,6 @@
+#![feature(auto_traits, const_trait_impl)]
+
+const auto trait Marker {}
+//~^ ERROR: auto traits cannot be const
+
+fn main() {}

--- a/tests/ui/traits/const-traits/const-auto-trait.stderr
+++ b/tests/ui/traits/const-traits/const-auto-trait.stderr
@@ -1,0 +1,10 @@
+error: auto traits cannot be const
+  --> $DIR/const-auto-trait.rs:3:1
+   |
+LL | const auto trait Marker {}
+   | ^^^^^
+   |
+   = help: remove the `const` keyword
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/traits/const-traits/const-auto-trait.stderr
+++ b/tests/ui/traits/const-traits/const-auto-trait.stderr
@@ -1,10 +1,23 @@
 error: auto traits cannot be const
-  --> $DIR/const-auto-trait.rs:3:1
+  --> $DIR/const-auto-trait.rs:6:1
    |
 LL | const auto trait Marker {}
    | ^^^^^
    |
    = help: remove the `const` keyword
 
-error: aborting due to 1 previous error
+error[E0277]: the trait bound `(): const Marker` is not satisfied
+  --> $DIR/const-auto-trait.rs:11:13
+   |
+LL |     check::<()>();
+   |             ^^
+   |
+note: required by a bound in `check`
+  --> $DIR/const-auto-trait.rs:10:17
+   |
+LL |     fn check<T: const Marker>() {}
+   |                 ^^^^^^^^^^^^ required by this bound in `check`
 
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/traits/const-traits/parse-const-unsafe-trait.rs
+++ b/tests/ui/traits/const-traits/parse-const-unsafe-trait.rs
@@ -1,5 +1,6 @@
 // Test that `const unsafe trait` and `const unsafe auto trait` works.
 
+//@ compile-flags: -Zparse-crate-root-only
 //@ check-pass
 
 #![feature(const_trait_impl)]


### PR DESCRIPTION
close rust-lang/rust#149285

The AST validation now detects and rejects const auto traits. Additionally, I updated an existing test that was using `const unsafe auto trait`.

r? fmease