### PR TITLE
Mark riscv64gc-unknown-linux-musl as tier 2 target

### DIFF
--- a/compiler/rustc_target/src/spec/targets/riscv64gc_unknown_linux_musl.rs
+++ b/compiler/rustc_target/src/spec/targets/riscv64gc_unknown_linux_musl.rs
@@ -7,7 +7,7 @@ pub(crate) fn target() -> Target {
         llvm_target: "riscv64-unknown-linux-musl".into(),
         metadata: TargetMetadata {
             description: Some("RISC-V Linux (kernel 4.20, musl 1.2.5)".into()),
-            tier: Some(3),
+            tier: Some(2),
             host_tools: Some(false),
             std: Some(true),
         },


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
According to https://github.com/rust-lang/rust/blob/cdb4236e654a49c3035269588fe22dfafc0cfa3a/src/doc/rustc/src/platform-support/riscv64gc-unknown-linux-musl.md?plain=1#L3 it's tier 2 target.

In case you are wondering how I noticed it:
Dockerfiles at Wild linker repo started to fail building recently due to missing `riscv64gc-unknown-linux-musl` std. I had hoped the problem would go away by itself, but it did not (it never does...).
https://github.com/rust-lang/rust/pull/148983 happened recently, so I checked https://rust-lang.github.io/rustup-components-history/riscv64gc-unknown-linux-musl.html and yeah, the date matches.
Given this condition: https://github.com/rust-lang/rust/blob/cdb4236e654a49c3035269588fe22dfafc0cfa3a/src/tools/build-manifest/build.rs#L35 I'm certain PR will fix the problem.