### PR TITLE
fix: Filter only self when elaborating `impl_super_outlives`

### DIFF
--- a/compiler/rustc_hir_analysis/src/collect/item_bounds.rs
+++ b/compiler/rustc_hir_analysis/src/collect/item_bounds.rs
@@ -528,12 +528,14 @@ pub(super) fn impl_super_outlives(
 ) -> ty::EarlyBinder<'_, ty::Clauses<'_>> {
     tcx.impl_trait_header(def_id).trait_ref.map_bound(|trait_ref| {
         let clause: ty::Clause<'_> = trait_ref.upcast(tcx);
-        tcx.mk_clauses_from_iter(util::elaborate(tcx, [clause]).filter(|clause| {
-            matches!(
-                clause.kind().skip_binder(),
-                ty::ClauseKind::TypeOutlives(_) | ty::ClauseKind::RegionOutlives(_)
-            )
-        }))
+        tcx.mk_clauses_from_iter(util::elaborate(tcx, [clause]).filter_only_self().filter(
+            |clause| {
+                matches!(
+                    clause.kind().skip_binder(),
+                    ty::ClauseKind::TypeOutlives(_) | ty::ClauseKind::RegionOutlives(_)
+                )
+            },
+        ))
     })
 }
 

--- a/tests/ui/traits/next-solver/normalization-cycle-due-to-super-assoc-outlives-bound.rs
+++ b/tests/ui/traits/next-solver/normalization-cycle-due-to-super-assoc-outlives-bound.rs
@@ -1,0 +1,45 @@
+//@ check-pass
+//@ compile-flags: -Znext-solver
+
+// A regression test for https://github.com/rust-lang/trait-system-refactor-initiative/issues/257.
+// This used to make an ambiguous error while wf-checking the global where bound on `fn foo`
+// because we used to add every outlives bounds from the supertraits when adding trait goals, and
+// the one on the associated type resulted in adding another normalization goal, which effectively
+// made a cycle.
+
+#![feature(rustc_attrs)]
+#![expect(internal_features)]
+#![rustc_no_implicit_bounds]
+
+pub trait Bound {}
+impl Bound for u8 {}
+
+pub trait Proj {
+    type Assoc;
+}
+impl<U: Bound> Proj for U {
+    type Assoc = U;
+}
+impl Proj for MyField {
+    type Assoc = u8;
+}
+
+pub trait Field: Proj<Assoc: Bound + 'static> {}
+
+struct MyField;
+impl Field for MyField {}
+
+trait IdReqField {
+    type This;
+}
+impl<F: Field> IdReqField for F {
+    type This = F;
+}
+
+fn foo()
+where
+    <MyField as IdReqField>::This: Field,
+{
+}
+
+fn main() {}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/trait-system-refactor-initiative/issues/257

Seems that considering super outlives bounds only on self type is enough for preventing unsoundnesses like in rust-lang/rust#98117

r? lcnr