### PR TITLE
rustdoc: add regression test for #140968

### DIFF
--- a/tests/rustdoc-js/alias-sort.js
+++ b/tests/rustdoc-js/alias-sort.js
@@ -1,0 +1,10 @@
+// rank doc aliases lower than exact matches
+// regression test for <https://github.com/rust-lang/rust/issues/140968>
+
+const EXPECTED = {
+    'query': 'foobazbar',
+    'others': [
+        { 'name': 'foobazbar' },
+        { 'name': 'foo' },
+    ],
+};

--- a/tests/rustdoc-js/alias-sort.rs
+++ b/tests/rustdoc-js/alias-sort.rs
@@ -1,0 +1,5 @@
+/// asdf
+pub fn foobazbar() {}
+
+#[doc(alias("foobazbar"))]
+pub fn foo() {}


### PR DESCRIPTION
fixes rust-lang/rust#140968

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
