### PR TITLE
fix rustdoc search says “Consider searching for "null" instead.” #149324

### DIFF
--- a/src/librustdoc/html/static/js/search.js
+++ b/src/librustdoc/html/static/js/search.js
@@ -5050,11 +5050,11 @@ ${obj.displayPath}<span class="${type}">${name}</span>\
     if (query.proposeCorrectionFrom !== null && isTypeSearch) {
         const orig = query.proposeCorrectionFrom;
         const targ = query.proposeCorrectionTo;
-        const parts = [`Type "${orig}" not found and used as generic parameter.`];
+        let message = `Type "${orig}" not found and used as generic parameter.`;
         if (targ !== null) {
-            parts.push(`Consider searching for "${targ}" instead.`);
+            message += ` Consider searching for "${targ}" instead.`;
         }
-        correctionOutput = `<h3 class="search-corrections">${parts.join(" ")}</h3>`;
+        correctionOutput = `<h3 class="search-corrections">${message}</h3>`;
     }
     if (firstResult.value) {
         if (correctionOutput !== "") {

--- a/src/librustdoc/html/static/js/search.js
+++ b/src/librustdoc/html/static/js/search.js
@@ -5050,9 +5050,11 @@ ${obj.displayPath}<span class="${type}">${name}</span>\
     if (query.proposeCorrectionFrom !== null && isTypeSearch) {
         const orig = query.proposeCorrectionFrom;
         const targ = query.proposeCorrectionTo;
-        correctionOutput = "<h3 class=\"search-corrections\">" +
-            `Type "${orig}" not found and used as generic parameter. ` +
-            `Consider searching for "${targ}" instead.</h3>`;
+        const parts = [`Type "${orig}" not found and used as generic parameter.`];
+        if (targ !== null) {
+            parts.push(`Consider searching for "${targ}" instead.`);
+        }
+        correctionOutput = `<h3 class="search-corrections">${parts.join(" ")}</h3>`;
     }
     if (firstResult.value) {
         if (correctionOutput !== "") {

--- a/tests/rustdoc-js/generics-trait.js
+++ b/tests/rustdoc-js/generics-trait.js
@@ -95,3 +95,24 @@ const EXPECTED = [
         ],
     },
 ];
+
+const PARSED = [
+    {
+        'query': 'Result<SomeTraiz>',
+        'userQuery': 'Result<SomeTraiz>',
+        'foundElems': 1,
+        'returned': [],
+        'error': null,
+        'proposeCorrectionFrom': 'SomeTraiz',
+        'proposeCorrectionTo': 'SomeTrait',
+    },
+    {
+        'query': 'Result<NoSuchTrait>',
+        'userQuery': 'Result<NoSuchTrait>',
+        'foundElems': 1,
+        'returned': [],
+        'error': null,
+        'proposeCorrectionFrom': 'NoSuchTrait',
+        'proposeCorrectionTo': null,
+    },
+];


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

fix rust-lang/rust#149324

Now builds the “generic parameter” correction banner from discrete sentence fragments and appends the “Consider searching …” clause only when query.proposeCorrectionTo is non-null, so the UI no longer renders null as the suggested type.

Adds a PARSED section with two queries: one typo (Result<SomeTraiz>) that still produces a concrete suggestion and one fully unknown type (Result<NoSuchTrait>) that leaves proposeCorrectionTo null.