### PR TITLE
fix ICE: rustdoc: const parameter types cannot be generic #149288

### DIFF
--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -561,12 +561,7 @@ fn clean_generic_param_def(
             def.name,
             GenericParamDefKind::Const {
                 ty: Box::new(clean_middle_ty(
-                    ty::Binder::dummy(
-                        cx.tcx
-                            .type_of(def.def_id)
-                            .no_bound_vars()
-                            .expect("const parameter types cannot be generic"),
-                    ),
+                    ty::Binder::dummy(cx.tcx.type_of(def.def_id).instantiate_identity()),
                     cx,
                     Some(def.def_id),
                     None,

--- a/tests/rustdoc/const-generics/const-param-type-references-generics.rs
+++ b/tests/rustdoc/const-generics/const-param-type-references-generics.rs
@@ -1,0 +1,16 @@
+//! rustdoc regression test for #149288: const generic parameter types may depend on
+//! other generics when `generic_const_parameter_types` is enabled.
+#![allow(incomplete_features)]
+#![feature(adt_const_params, generic_const_parameter_types)]
+#![crate_name = "foo"]
+
+pub struct Bar<const N: usize, const M: [u8; N]>;
+
+pub fn takes<const N: usize, const M: [u8; N]>(_: Bar<N, M>) {}
+
+pub fn instantiate() {
+    takes(Bar::<2, { [1; 2] }>);
+}
+
+//@ has foo/struct.Bar.html '//pre[@class="rust item-decl"]' 'pub struct Bar<const N: usize, const M: [u8; N]>'
+//@ has foo/fn.takes.html '//pre[@class="rust item-decl"]' 'pub fn takes<const N: usize, const M: [u8; N]>(_: Bar<N, M>)'


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

fix rust-lang/rust#149288

Applied the patch.

