### PR TITLE
Add feature to set path-based visibility of macro_rules to pub by default

### DIFF
--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -568,6 +568,8 @@ declare_features! (
     (unstable, macro_attr, "1.91.0", Some(143547)),
     /// Allow `macro_rules!` derive rules
     (unstable, macro_derive, "1.91.0", Some(143549)),
+    /// Make `macro_rules!` implicitly pub even without `macro_export`
+    (unstable, macro_implicit_pub, "CURRENT_RUSTC_VERSION", Some(148610)),
     /// Give access to additional metadata about declarative macro meta-variables.
     (unstable, macro_metavar_expr, "1.61.0", Some(83527)),
     /// Provides a way to concatenate identifiers using metavariable expressions.

--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -1288,6 +1288,11 @@ impl<'tcx> LateLintPass<'tcx> for UnreachablePub {
         if let hir::ItemKind::Use(_, hir::UseKind::ListStem) = &item.kind {
             return;
         }
+        // Do not warn for macro_rules definitions which are pub and unreachable by default,
+        // only check their associated use re-exports.
+        if let hir::ItemKind::Macro(_, ast::MacroDef { macro_rules: true, .. }, _) = &item.kind {
+            return;
+        }
         self.perform_lint(cx, "item", item.owner_id.def_id, item.vis_span, true);
     }
 

--- a/compiler/rustc_resolve/src/build_reduced_graph.rs
+++ b/compiler/rustc_resolve/src/build_reduced_graph.rs
@@ -1299,7 +1299,7 @@ impl<'a, 'ra, 'tcx> BuildReducedGraphVisitor<'a, 'ra, 'tcx> {
             let ident = ident.normalize_to_macros_2_0();
             self.r.macro_names.insert(ident);
             let is_macro_export = ast::attr::contains_name(&item.attrs, sym::macro_export);
-            let vis = if is_macro_export {
+            let vis = if is_macro_export || self.r.tcx().features().macro_implicit_pub() {
                 Visibility::Public
             } else {
                 Visibility::Restricted(CRATE_DEF_ID)

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1380,6 +1380,7 @@ symbols! {
         macro_derive,
         macro_escape,
         macro_export,
+        macro_implicit_pub,
         macro_lifetime_matcher,
         macro_literal_matcher,
         macro_metavar_expr,

--- a/tests/ui/feature-gates/feature-gate-macro-implicit-pub.rs
+++ b/tests/ui/feature-gates/feature-gate-macro-implicit-pub.rs
@@ -1,0 +1,8 @@
+//@ edition:2018
+#![crate_type = "lib"]
+
+macro_rules! not_pub {
+    () => {}
+}
+
+pub use not_pub; //~ ERROR: `not_pub` is only public within the crate, and cannot be re-exported outside [E0364]

--- a/tests/ui/feature-gates/feature-gate-macro-implicit-pub.stderr
+++ b/tests/ui/feature-gates/feature-gate-macro-implicit-pub.stderr
@@ -1,0 +1,21 @@
+error[E0364]: `not_pub` is only public within the crate, and cannot be re-exported outside
+  --> $DIR/feature-gate-macro-implicit-pub.rs:8:9
+   |
+LL | pub use not_pub;
+   |         ^^^^^^^
+   |
+help: consider adding a `#[macro_export]` to the macro in the imported module
+  --> $DIR/feature-gate-macro-implicit-pub.rs:4:1
+   |
+LL | / macro_rules! not_pub {
+LL | |     () => {}
+LL | | }
+   | |_^
+help: in case you want to use the macro within this crate only, reduce the visibility to `pub(crate)`
+   |
+LL | pub(crate) use not_pub;
+   |    +++++++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0364`.

--- a/tests/ui/macros/auxiliary/implicit-pub.rs
+++ b/tests/ui/macros/auxiliary/implicit-pub.rs
@@ -1,10 +1,10 @@
 //@ edition:2018
+#![feature(macro_implicit_pub)]
 #[allow(unused_macros)]
 macro_rules! fake_pub {
     () => {}
 }
 
-#[macro_export]
 macro_rules! real_pub {
     () => {}
 }

--- a/tests/ui/macros/auxiliary/implicit-pub.rs
+++ b/tests/ui/macros/auxiliary/implicit-pub.rs
@@ -1,0 +1,16 @@
+//@ edition:2018
+#[allow(unused_macros)]
+macro_rules! fake_pub {
+    () => {}
+}
+
+#[macro_export]
+macro_rules! real_pub {
+    () => {}
+}
+
+pub mod inner {
+    pub use real_pub;
+}
+
+pub use real_pub as real_pub_reexport;

--- a/tests/ui/macros/implicit-pub-macros2-linted-still.rs
+++ b/tests/ui/macros/implicit-pub-macros2-linted-still.rs
@@ -1,0 +1,10 @@
+//@ edition:2018
+#![feature(decl_macro)]
+#![crate_type = "lib"]
+#![deny(unreachable_pub)]
+
+mod inner {
+    pub macro m($inner_str:expr) { //~ ERROR: unreachable `pub` item [unreachable_pub]
+        struct S;
+    }
+}

--- a/tests/ui/macros/implicit-pub-macros2-linted-still.stderr
+++ b/tests/ui/macros/implicit-pub-macros2-linted-still.stderr
@@ -1,0 +1,17 @@
+error: unreachable `pub` item
+  --> $DIR/implicit-pub-macros2-linted-still.rs:7:5
+   |
+LL |     pub macro m($inner_str:expr) {
+   |     ---^^^^^^^^
+   |     |
+   |     help: consider restricting its visibility: `pub(crate)`
+   |
+   = help: or consider exporting it for use by other crates
+note: the lint level is defined here
+  --> $DIR/implicit-pub-macros2-linted-still.rs:4:9
+   |
+LL | #![deny(unreachable_pub)]
+   |         ^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/macros/implicit-pub-still-unreachable.rs
+++ b/tests/ui/macros/implicit-pub-still-unreachable.rs
@@ -1,0 +1,8 @@
+//@ aux-build:implicit-pub.rs
+//@ edition:2018
+
+extern crate implicit_pub;
+
+fn main() {
+    implicit_pub::inner::fake_pub!(); //~ error: failed to resolve: could not find `fake_pub` in `inner` [E0433]
+}

--- a/tests/ui/macros/implicit-pub-still-unreachable.stderr
+++ b/tests/ui/macros/implicit-pub-still-unreachable.stderr
@@ -1,0 +1,9 @@
+error[E0433]: failed to resolve: could not find `fake_pub` in `inner`
+  --> $DIR/implicit-pub-still-unreachable.rs:7:26
+   |
+LL |     implicit_pub::inner::fake_pub!();
+   |                          ^^^^^^^^ could not find `fake_pub` in `inner`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0433`.

--- a/tests/ui/macros/implicit-pub-unreachable-lint.rs
+++ b/tests/ui/macros/implicit-pub-unreachable-lint.rs
@@ -1,0 +1,12 @@
+//@ edition:2018
+#![crate_type = "lib"]
+#![deny(unreachable_pub)]
+
+#[macro_export]
+macro_rules! not_reexported {
+    () => {}
+}
+
+mod inner {
+    pub use not_reexported; //~ ERROR: unreachable `pub` item [unreachable_pub]
+}

--- a/tests/ui/macros/implicit-pub-unreachable-lint.rs
+++ b/tests/ui/macros/implicit-pub-unreachable-lint.rs
@@ -1,8 +1,8 @@
 //@ edition:2018
 #![crate_type = "lib"]
+#![feature(macro_implicit_pub)]
 #![deny(unreachable_pub)]
 
-#[macro_export]
 macro_rules! not_reexported {
     () => {}
 }

--- a/tests/ui/macros/implicit-pub-unreachable-lint.stderr
+++ b/tests/ui/macros/implicit-pub-unreachable-lint.stderr
@@ -8,7 +8,7 @@ LL |     pub use not_reexported;
    |
    = help: or consider exporting it for use by other crates
 note: the lint level is defined here
-  --> $DIR/implicit-pub-unreachable-lint.rs:3:9
+  --> $DIR/implicit-pub-unreachable-lint.rs:4:9
    |
 LL | #![deny(unreachable_pub)]
    |         ^^^^^^^^^^^^^^^

--- a/tests/ui/macros/implicit-pub-unreachable-lint.stderr
+++ b/tests/ui/macros/implicit-pub-unreachable-lint.stderr
@@ -1,0 +1,17 @@
+error: unreachable `pub` item
+  --> $DIR/implicit-pub-unreachable-lint.rs:11:13
+   |
+LL |     pub use not_reexported;
+   |     ---     ^^^^^^^^^^^^^^
+   |     |
+   |     help: consider restricting its visibility: `pub(crate)`
+   |
+   = help: or consider exporting it for use by other crates
+note: the lint level is defined here
+  --> $DIR/implicit-pub-unreachable-lint.rs:3:9
+   |
+LL | #![deny(unreachable_pub)]
+   |         ^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/macros/implicit-pub-unreachable-no-lint.rs
+++ b/tests/ui/macros/implicit-pub-unreachable-no-lint.rs
@@ -1,0 +1,7 @@
+//@ check-pass
+//@ edition:2018
+#![crate_type = "lib"]
+
+macro_rules! not_reexported {
+    () => {}
+}

--- a/tests/ui/macros/implicit-pub.rs
+++ b/tests/ui/macros/implicit-pub.rs
@@ -1,0 +1,10 @@
+//@ check-pass
+//@ aux-build:implicit-pub.rs
+//@ edition:2018
+
+extern crate implicit_pub;
+
+fn main() {
+    implicit_pub::inner::real_pub!();
+    implicit_pub::real_pub_reexport!();
+}


### PR DESCRIPTION
experiment for https://github.com/rust-lang/rust/issues/148610

This change takes advantage of the fact that `macro_rules` cannot be resolved via path-based scope by default[^1], letting us change their implicit visibility without changing their reach-ability from dependent crates for all existing stable code.

### TODO

- [x] fix unreachable_pub lint to not apply directly to macro_rules definitions
- [x] implement feature flag

---

@petrochenkov the PR is split into two commits. The first adds tests that show the current behavior, the second implements the feature, modifies the tests to take advantage of the new feature, and adds a feature gate test.

[^1]: https://github.com/rust-lang/reference/pull/2055/files#diff-6ea1ee99d6fb8818703d2bd8bf5d373182871235ea102d2de541af0dd87d20bbR368-R374