### PR TITLE
Don't suggest unwrap for Result in const

### DIFF
--- a/tests/ui/consts/const-result-no-expect-suggestion.rs
+++ b/tests/ui/consts/const-result-no-expect-suggestion.rs
@@ -1,0 +1,15 @@
+const fn f(value: u32) -> Result<u32, ()> {
+    Ok(value)
+}
+
+const TEST: u32 = f(2);
+//~^ ERROR: mismatched types
+
+const fn g() -> Result<String, ()> {
+    Ok(String::new())
+}
+
+const TEST2: usize = g().len();
+//~^ ERROR: no method named `len` found for enum `Result<T, E>`
+
+fn main() {}

--- a/tests/ui/consts/const-result-no-expect-suggestion.stderr
+++ b/tests/ui/consts/const-result-no-expect-suggestion.stderr
@@ -1,0 +1,24 @@
+error[E0308]: mismatched types
+  --> $DIR/const-result-no-expect-suggestion.rs:5:19
+   |
+LL | const TEST: u32 = f(2);
+   |                   ^^^^ expected `u32`, found `Result<u32, ()>`
+   |
+   = note: expected type `u32`
+              found enum `Result<u32, ()>`
+
+error[E0599]: no method named `len` found for enum `Result<T, E>` in the current scope
+  --> $DIR/const-result-no-expect-suggestion.rs:12:26
+   |
+LL | const TEST2: usize = g().len();
+   |                          ^^^
+   |
+note: the method `len` exists on the type `String`
+  --> $SRC_DIR/alloc/src/string.rs:LL:COL
+help: there is a method `le` with a similar name, but with different arguments
+  --> $SRC_DIR/core/src/cmp.rs:LL:COL
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0308, E0599.
+For more information about an error, try `rustc --explain E0308`.


### PR DESCRIPTION
close rust-lang/rust#149316 

Regarding `const fn` that returns `Result`, we should avoid suggesting unwrapping. The original issue reported cases where types didn't match, but in practice, such suggestions may also appear when methods are not found, so this PR includes a fix for that case as well.