### PR TITLE
Deeply normalize param env in `compare_impl_item` if using the next solver

### DIFF
--- a/tests/ui/higher-ranked/trait-bounds/issue-100689.rs
+++ b/tests/ui/higher-ranked/trait-bounds/issue-100689.rs
@@ -1,4 +1,6 @@
 //@ check-pass
+//@ revisions: old next
+//@[next] compile-flags: -Znext-solver
 
 struct Foo<'a> {
     foo: &'a mut usize,

--- a/tests/ui/higher-ranked/trait-bounds/issue-102899.rs
+++ b/tests/ui/higher-ranked/trait-bounds/issue-102899.rs
@@ -1,4 +1,6 @@
 //@ check-pass
+//@ revisions: old next
+//@[next] compile-flags: -Znext-solver
 
 pub trait BufferTrait<'buffer> {
     type Subset<'channel>

--- a/tests/ui/traits/next-solver/normalize/deeply-normalize-env-in-compare-impl-item.rs
+++ b/tests/ui/traits/next-solver/normalize/deeply-normalize-env-in-compare-impl-item.rs
@@ -1,0 +1,38 @@
+//@ check-pass
+//@ compile-flags: -Znext-solver
+
+// See trait-system-refactor-initiative/issues/166.
+// The old solver doesn't check normalization constraints in `compare_impl_item`.
+// The new solver performs lazy normalization so those region constraints may get postponed to
+// an infcx that considers regions.
+trait Trait {
+    type Assoc<'a>
+    where
+        Self: 'a;
+}
+impl<'b> Trait for &'b u32 {
+    type Assoc<'a> = &'a u32
+    where
+        Self: 'a;
+}
+
+trait Bound<T> {}
+trait Entailment<T: Trait> {
+    fn method()
+    where
+        Self: for<'a> Bound<<T as Trait>::Assoc<'a>>;
+}
+
+impl<'b, T> Entailment<&'b u32> for T {
+    // Instantiates trait where-clauses with `&'b u32` and then normalizes
+    // `T: for<'a> Bound<<&'b u32 as Trait>::Assoc<'a>>` in a separate infcx
+    // without checking region constraints.
+    //
+    // It normalizes to `T: Bound<&'a u32>`, dropping the `&'b u32: 'a` constraint.
+    fn method()
+    where
+        Self: for<'a> Bound<&'a u32>
+    {}
+}
+
+fn main() {}

--- a/tests/ui/traits/next-solver/normalize/normalize-param-env-2.stderr
+++ b/tests/ui/traits/next-solver/normalize/normalize-param-env-2.stderr
@@ -1,3 +1,11 @@
+error[E0275]: overflow evaluating the requirement `<() as A<T>>::Assoc == _`
+  --> $DIR/normalize-param-env-2.rs:22:5
+   |
+LL | /     fn f()
+LL | |     where
+LL | |         Self::Assoc: A<T>,
+   | |__________________________^
+
 error[E0275]: overflow evaluating the requirement `<() as A<T>>::Assoc: A<T>`
   --> $DIR/normalize-param-env-2.rs:24:22
    |
@@ -46,6 +54,6 @@ LL |     where
 LL |         Self::Assoc: A<T>,
    |                      ^^^^ required by this bound in `A::f`
 
-error: aborting due to 5 previous errors
+error: aborting due to 6 previous errors
 
 For more information about this error, try `rustc --explain E0275`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
Fixes https://github.com/rust-lang/trait-system-refactor-initiative/issues/166.

Duplicated the `normalize_param_env_or_error` function to force deep normalization for `compare_impl_item`.

r? @lcnr 