### PR TITLE
Document that `build.description` affects symbol mangling and crate IDs

### DIFF
--- a/bootstrap.example.toml
+++ b/bootstrap.example.toml
@@ -220,6 +220,11 @@
 # which is also used in places like debuginfo `DW_AT_producer`. This may be useful for
 # supplementary build information, like distro-specific package versions.
 #
+# IMPORTANT: Changing this value changes crate IDs and symbol name mangling, making
+# compiled artifacts incompatible. PGO profiles cannot be reused across different
+# descriptions, and incremental compilation caches are invalidated. Keep this value
+# consistent when reusing build artifacts.
+#
 # The Rust compiler will differentiate between versions of itself, including
 # based on this string, which means that if you wish to be compatible with
 # upstream Rust you need to set this to "". However, note that if you set this to "" but


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
Addresses issue rust-lang/rust#103557

Adds warning to `bootstrap.example.toml` explaining that changing build.description affects crate IDs and symbol name mangling, which makes compiled artifacts incompatible across different values.

As @Mark-Simulacrum points out, "if you're building with different settings, we really can't guarantee compatibility in any nice way." This documentation attempts to make that clear. This is my first contribution here, so any feedback would be greatly appreciated!
