### PR TITLE
GVN: consider constants of primitive types as deterministic

### DIFF
--- a/compiler/rustc_middle/src/mir/consts.rs
+++ b/compiler/rustc_middle/src/mir/consts.rs
@@ -181,26 +181,6 @@ impl ConstValue {
         Some(data.inner().inspect_with_uninit_and_ptr_outside_interpreter(start..end))
     }
 
-    /// Check if a constant may contain provenance information. This is used by MIR opts.
-    /// Can return `true` even if there is no provenance.
-    pub fn may_have_provenance(&self, tcx: TyCtxt<'_>, size: Size) -> bool {
-        match *self {
-            ConstValue::ZeroSized | ConstValue::Scalar(Scalar::Int(_)) => return false,
-            ConstValue::Scalar(Scalar::Ptr(..)) => return true,
-            // It's hard to find out the part of the allocation we point to;
-            // just conservatively check everything.
-            ConstValue::Slice { alloc_id, meta: _ } => {
-                !tcx.global_alloc(alloc_id).unwrap_memory().inner().provenance().ptrs().is_empty()
-            }
-            ConstValue::Indirect { alloc_id, offset } => !tcx
-                .global_alloc(alloc_id)
-                .unwrap_memory()
-                .inner()
-                .provenance()
-                .range_empty(AllocRange::from(offset..offset + size), &tcx),
-        }
-    }
-
     /// Check if a constant only contains uninitialized bytes.
     pub fn all_bytes_uninit(&self, tcx: TyCtxt<'_>) -> bool {
         let ConstValue::Indirect { alloc_id, .. } = self else {
@@ -473,39 +453,6 @@ impl<'tcx> Const<'tcx> {
     pub fn from_scalar(_tcx: TyCtxt<'tcx>, s: Scalar, ty: Ty<'tcx>) -> Self {
         let val = ConstValue::Scalar(s);
         Self::Val(val, ty)
-    }
-
-    /// Return true if any evaluation of this constant always returns the same value,
-    /// taking into account even pointer identity tests.
-    pub fn is_deterministic(&self) -> bool {
-        // Primitive types cannot contain provenance and always have the same value.
-        if self.ty().is_primitive() {
-            return true;
-        }
-
-        // Some constants may generate fresh allocations for pointers they contain,
-        // so using the same constant twice can yield two different results.
-        // Notably, valtrees purposefully generate new allocations.
-        match self {
-            Const::Ty(_, c) => match c.kind() {
-                ty::ConstKind::Param(..) => true,
-                // A valtree may be a reference. Valtree references correspond to a
-                // different allocation each time they are evaluated. Valtrees for primitive
-                // types are fine though.
-                ty::ConstKind::Value(..)
-                | ty::ConstKind::Expr(..)
-                | ty::ConstKind::Unevaluated(..)
-                // This can happen if evaluation of a constant failed. The result does not matter
-                // much since compilation is doomed.
-                | ty::ConstKind::Error(..) => false,
-                // Should not appear in runtime MIR.
-                ty::ConstKind::Infer(..)
-                | ty::ConstKind::Bound(..)
-                | ty::ConstKind::Placeholder(..) => bug!(),
-            },
-            Const::Unevaluated(..) => false,
-            Const::Val(..) => true,
-        }
     }
 }
 

--- a/compiler/rustc_mir_transform/src/gvn.rs
+++ b/compiler/rustc_mir_transform/src/gvn.rs
@@ -1002,21 +1002,19 @@ impl<'body, 'a, 'tcx> VnState<'body, 'a, 'tcx> {
         operand: &mut Operand<'tcx>,
         location: Location,
     ) -> Option<VnIndex> {
-        match *operand {
-            Operand::RuntimeChecks(c) => {
-                Some(self.insert(self.tcx.types.bool, Value::RuntimeChecks(c)))
-            }
-            Operand::Constant(ref constant) => Some(self.insert_constant(constant.const_)),
+        let value = match *operand {
+            Operand::RuntimeChecks(c) => self.insert(self.tcx.types.bool, Value::RuntimeChecks(c)),
+            Operand::Constant(ref constant) => self.insert_constant(constant.const_),
             Operand::Copy(ref mut place) | Operand::Move(ref mut place) => {
-                let value = self.simplify_place_value(place, location)?;
-                if let Some(const_) = self.try_as_constant(value) {
-                    *operand = Operand::Constant(Box::new(const_));
-                } else if let Value::RuntimeChecks(c) = self.get(value) {
-                    *operand = Operand::RuntimeChecks(c);
-                }
-                Some(value)
+                self.simplify_place_value(place, location)?
             }
+        };
+        if let Some(const_) = self.try_as_constant(value) {
+            *operand = Operand::Constant(Box::new(const_));
+        } else if let Value::RuntimeChecks(c) = self.get(value) {
+            *operand = Operand::RuntimeChecks(c);
         }
+        Some(value)
     }
 
     #[instrument(level = "trace", skip(self), ret)]
@@ -1831,14 +1829,28 @@ impl<'tcx> VnState<'_, '_, 'tcx> {
 
     /// If `index` is a `Value::Constant`, return the `Constant` to be put in the MIR.
     fn try_as_constant(&mut self, index: VnIndex) -> Option<ConstOperand<'tcx>> {
-        // This was already constant in MIR, do not change it. If the constant is not
-        // deterministic, adding an additional mention of it in MIR will not give the same value as
-        // the former mention.
-        if let Value::Constant { value, disambiguator: None } = self.get(index) {
-            debug_assert!(value.is_deterministic());
+        let value = self.get(index);
+
+        // This was already an *evaluated* constant in MIR, do not change it.
+        if let Value::Constant { value, disambiguator: None } = value
+            && let Const::Val(..) = value
+        {
             return Some(ConstOperand { span: DUMMY_SP, user_ty: None, const_: value });
         }
 
+        if let Some(value) = self.try_as_evaluated_constant(index) {
+            return Some(ConstOperand { span: DUMMY_SP, user_ty: None, const_: value });
+        }
+
+        // We failed to provide an evaluated form, fallback to using the unevaluated constant.
+        if let Value::Constant { value, disambiguator: None } = value {
+            return Some(ConstOperand { span: DUMMY_SP, user_ty: None, const_: value });
+        }
+
+        None
+    }
+
+    fn try_as_evaluated_constant(&mut self, index: VnIndex) -> Option<Const<'tcx>> {
         let op = self.eval_to_const(index)?;
         if op.layout.is_unsized() {
             // Do not attempt to propagate unsized locals.
@@ -1852,8 +1864,7 @@ impl<'tcx> VnState<'_, '_, 'tcx> {
         // FIXME: remove this hack once https://github.com/rust-lang/rust/issues/79738 is fixed.
         assert!(!value.may_have_provenance(self.tcx, op.layout.size));
 
-        let const_ = Const::Val(value, op.layout.ty);
-        Some(ConstOperand { span: DUMMY_SP, user_ty: None, const_ })
+        Some(Const::Val(value, op.layout.ty))
     }
 
     /// Construct a place which holds the same value as `index` and for which all locals strictly

--- a/compiler/rustc_mir_transform/src/gvn.rs
+++ b/compiler/rustc_mir_transform/src/gvn.rs
@@ -61,10 +61,8 @@
 //! The evaluated form is inserted in `evaluated` as an `OpTy` or `None` if evaluation failed.
 //!
 //! The difficulty is non-deterministic evaluation of MIR constants. Some `Const` can have
-//! different runtime values each time they are evaluated. This is the case with
-//! `Const::Slice` which have a new pointer each time they are evaluated, and constants that
-//! contain a fn pointer (`AllocId` pointing to a `GlobalAlloc::Function`) pointing to a different
-//! symbol in each codegen unit.
+//! different runtime values each time they are evaluated. This happens with valtrees that
+//! generate a new allocation each time they are used. This is checked by `is_deterministic`.
 //!
 //! Meanwhile, we want to be able to read indirect constants. For instance:
 //! ```
@@ -81,8 +79,12 @@
 //! may be non-deterministic. When that happens, we assign a disambiguator to ensure that we do not
 //! merge the constants. See `duplicate_slice` test in `gvn.rs`.
 //!
-//! Second, when writing constants in MIR, we do not write `Const::Slice` or `Const`
-//! that contain `AllocId`s.
+//! Conversely, some constants cannot cross function boundaries, which could happen because of
+//! inlining. For instance, constants that contain a fn pointer (`AllocId` pointing to a
+//! `GlobalAlloc::Function`) point to a different symbol in each codegen unit. To avoid this,
+//! when writing constants in MIR, we do not write `Const`s that contain `AllocId`s. This is
+//! checked by `may_have_provenance`. See <https://github.com/rust-lang/rust/issues/128775> for
+//! more information.
 
 use std::borrow::Cow;
 use std::hash::{Hash, Hasher};
@@ -103,7 +105,7 @@ use rustc_hir::def::DefKind;
 use rustc_index::bit_set::DenseBitSet;
 use rustc_index::{IndexVec, newtype_index};
 use rustc_middle::bug;
-use rustc_middle::mir::interpret::GlobalAlloc;
+use rustc_middle::mir::interpret::{AllocRange, GlobalAlloc};
 use rustc_middle::mir::visit::*;
 use rustc_middle::mir::*;
 use rustc_middle::ty::layout::HasTypingEnv;
@@ -487,7 +489,7 @@ impl<'body, 'a, 'tcx> VnState<'body, 'a, 'tcx> {
 
     #[instrument(level = "trace", skip(self), ret)]
     fn insert_constant(&mut self, value: Const<'tcx>) -> VnIndex {
-        if value.is_deterministic() {
+        if is_deterministic(value) {
             // The constant is deterministic, no need to disambiguate.
             let constant = Value::Constant { value, disambiguator: None };
             self.insert(value.ty(), constant)
@@ -522,14 +524,14 @@ impl<'body, 'a, 'tcx> VnState<'body, 'a, 'tcx> {
     fn insert_bool(&mut self, flag: bool) -> VnIndex {
         // Booleans are deterministic.
         let value = Const::from_bool(self.tcx, flag);
-        debug_assert!(value.is_deterministic());
+        debug_assert!(is_deterministic(value));
         self.insert(self.tcx.types.bool, Value::Constant { value, disambiguator: None })
     }
 
     fn insert_scalar(&mut self, ty: Ty<'tcx>, scalar: Scalar) -> VnIndex {
         // Scalars are deterministic.
         let value = Const::from_scalar(self.tcx, scalar, ty);
-        debug_assert!(value.is_deterministic());
+        debug_assert!(is_deterministic(value));
         self.insert(ty, Value::Constant { value, disambiguator: None })
     }
 
@@ -1729,6 +1731,49 @@ impl<'body, 'a, 'tcx> VnState<'body, 'a, 'tcx> {
     }
 }
 
+/// Return true if any evaluation of this constant in the same MIR body
+/// always returns the same value, taking into account even pointer identity tests.
+///
+/// In other words, this answers: is "cloning" the `Const` ok?
+///
+/// This returns `false` for constants that synthesize new `AllocId` when they are instantiated.
+/// It is `true` for anything else, since a given `AllocId` *does* have a unique runtime value
+/// within the scope of a single MIR body.
+fn is_deterministic(c: Const<'_>) -> bool {
+    // Primitive types cannot contain provenance and always have the same value.
+    if c.ty().is_primitive() {
+        return true;
+    }
+
+    match c {
+        // Some constants may generate fresh allocations for pointers they contain,
+        // so using the same constant twice can yield two different results.
+        // Notably, valtrees purposefully generate new allocations.
+        Const::Ty(..) => false,
+        // We do not know the contents, so don't attempt to do anything clever.
+        Const::Unevaluated(..) => false,
+        // When an evaluated constant contains provenance, it is encoded as an `AllocId`.
+        // Cloning the constant will reuse the same `AllocId`. If this is in the same MIR
+        // body, this same `AllocId` will result in the same pointer in codegen.
+        Const::Val(..) => true,
+    }
+}
+
+/// Check if a constant may contain provenance information.
+/// Can return `true` even if there is no provenance.
+fn may_have_provenance(tcx: TyCtxt<'_>, value: ConstValue, size: Size) -> bool {
+    match value {
+        ConstValue::ZeroSized | ConstValue::Scalar(Scalar::Int(_)) => return false,
+        ConstValue::Scalar(Scalar::Ptr(..)) | ConstValue::Slice { .. } => return true,
+        ConstValue::Indirect { alloc_id, offset } => !tcx
+            .global_alloc(alloc_id)
+            .unwrap_memory()
+            .inner()
+            .provenance()
+            .range_empty(AllocRange::from(offset..offset + size), &tcx),
+    }
+}
+
 fn op_to_prop_const<'tcx>(
     ecx: &mut InterpCx<'tcx, DummyMachine>,
     op: &OpTy<'tcx>,
@@ -1760,7 +1805,7 @@ fn op_to_prop_const<'tcx>(
         if !scalar.try_to_scalar_int().is_ok() {
             // Check that we do not leak a pointer.
             // Those pointers may lose part of their identity in codegen.
-            // FIXME: remove this hack once https://github.com/rust-lang/rust/issues/79738 is fixed.
+            // FIXME: remove this hack once https://github.com/rust-lang/rust/issues/128775 is fixed.
             return None;
         }
         return Some(ConstValue::Scalar(scalar));
@@ -1772,7 +1817,7 @@ fn op_to_prop_const<'tcx>(
         let (size, _align) = ecx.size_and_align_of_val(&mplace).discard_err()??;
 
         // Do not try interning a value that contains provenance.
-        // Due to https://github.com/rust-lang/rust/issues/79738, doing so could lead to bugs.
+        // Due to https://github.com/rust-lang/rust/issues/128775, doing so could lead to bugs.
         // FIXME: remove this hack once that issue is fixed.
         let alloc_ref = ecx.get_ptr_alloc(mplace.ptr(), size).discard_err()??;
         if alloc_ref.has_provenance() {
@@ -1803,8 +1848,17 @@ fn op_to_prop_const<'tcx>(
 
     // Check that we do not leak a pointer.
     // Those pointers may lose part of their identity in codegen.
-    // FIXME: remove this hack once https://github.com/rust-lang/rust/issues/79738 is fixed.
-    if ecx.tcx.global_alloc(alloc_id).unwrap_memory().inner().provenance().ptrs().is_empty() {
+    // FIXME: remove this hack once https://github.com/rust-lang/rust/issues/128775 is fixed.
+    if ecx
+        .tcx
+        .global_alloc(alloc_id)
+        .unwrap_memory()
+        .inner()
+        .provenance()
+        .provenances()
+        .next()
+        .is_none()
+    {
         return Some(value);
     }
 
@@ -1861,8 +1915,8 @@ impl<'tcx> VnState<'_, '_, 'tcx> {
 
         // Check that we do not leak a pointer.
         // Those pointers may lose part of their identity in codegen.
-        // FIXME: remove this hack once https://github.com/rust-lang/rust/issues/79738 is fixed.
-        assert!(!value.may_have_provenance(self.tcx, op.layout.size));
+        // FIXME: remove this hack once https://github.com/rust-lang/rust/issues/128775 is fixed.
+        assert!(!may_have_provenance(self.tcx, value, op.layout.size));
 
         Some(Const::Val(value, op.layout.ty))
     }

--- a/compiler/rustc_mir_transform/src/gvn.rs
+++ b/compiler/rustc_mir_transform/src/gvn.rs
@@ -1844,25 +1844,7 @@ fn op_to_prop_const<'tcx>(
     // Everything failed: create a new allocation to hold the data.
     let alloc_id =
         ecx.intern_with_temp_alloc(op.layout, |ecx, dest| ecx.copy_op(op, dest)).discard_err()?;
-    let value = ConstValue::Indirect { alloc_id, offset: Size::ZERO };
-
-    // Check that we do not leak a pointer.
-    // Those pointers may lose part of their identity in codegen.
-    // FIXME: remove this hack once https://github.com/rust-lang/rust/issues/128775 is fixed.
-    if ecx
-        .tcx
-        .global_alloc(alloc_id)
-        .unwrap_memory()
-        .inner()
-        .provenance()
-        .provenances()
-        .next()
-        .is_none()
-    {
-        return Some(value);
-    }
-
-    None
+    Some(ConstValue::Indirect { alloc_id, offset: Size::ZERO })
 }
 
 impl<'tcx> VnState<'_, '_, 'tcx> {
@@ -1916,7 +1898,9 @@ impl<'tcx> VnState<'_, '_, 'tcx> {
         // Check that we do not leak a pointer.
         // Those pointers may lose part of their identity in codegen.
         // FIXME: remove this hack once https://github.com/rust-lang/rust/issues/128775 is fixed.
-        assert!(!may_have_provenance(self.tcx, value, op.layout.size));
+        if may_have_provenance(self.tcx, value, op.layout.size) {
+            return None;
+        }
 
         Some(Const::Val(value, op.layout.ty))
     }

--- a/tests/incremental/hashes/enum_constructors.rs
+++ b/tests/incremental/hashes/enum_constructors.rs
@@ -65,7 +65,7 @@ pub fn change_field_order_struct_like() -> Enum {
 #[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,typeck")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,typeck,optimized_mir")]
+#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,typeck")]
 #[rustc_clean(cfg="cfail6")]
 // FIXME(michaelwoerister):Interesting. I would have thought that that changes the MIR. And it
 // would if it were not all constants

--- a/tests/incremental/hashes/struct_constructors.rs
+++ b/tests/incremental/hashes/struct_constructors.rs
@@ -62,7 +62,7 @@ pub fn change_field_order_regular_struct() -> RegularStruct {
 #[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,typeck")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,typeck,optimized_mir")]
+#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,typeck")]
 #[rustc_clean(cfg="cfail6")]
 pub fn change_field_order_regular_struct() -> RegularStruct {
     RegularStruct {

--- a/tests/mir-opt/dont_reset_cast_kind_without_updating_operand.test.GVN.32bit.panic-abort.diff
+++ b/tests/mir-opt/dont_reset_cast_kind_without_updating_operand.test.GVN.32bit.panic-abort.diff
@@ -50,7 +50,8 @@
 +         _4 = const ();
           StorageLive(_12);
           StorageLive(_13);
-          _13 = boxed::box_new_uninit(const <() as std::mem::SizedTypeProperties>::LAYOUT) -> [return: bb2, unwind unreachable];
+-         _13 = boxed::box_new_uninit(const <() as std::mem::SizedTypeProperties>::LAYOUT) -> [return: bb2, unwind unreachable];
++         _13 = boxed::box_new_uninit(const Layout {{ size: 0_usize, align: std::ptr::Alignment {{ _inner_repr_trick: std::ptr::alignment::AlignmentEnum::_Align1Shl0 }} }}) -> [return: bb2, unwind unreachable];
       }
   
       bb1: {
@@ -103,5 +104,9 @@
 +         nop;
           drop(_3) -> [return: bb1, unwind unreachable];
       }
++ }
++ 
++ ALLOC0 (size: 8, align: 4) {
++     01 00 00 00 00 00 00 00                         │ ........
   }
   

--- a/tests/mir-opt/dont_reset_cast_kind_without_updating_operand.test.GVN.64bit.panic-abort.diff
+++ b/tests/mir-opt/dont_reset_cast_kind_without_updating_operand.test.GVN.64bit.panic-abort.diff
@@ -50,7 +50,8 @@
 +         _4 = const ();
           StorageLive(_12);
           StorageLive(_13);
-          _13 = boxed::box_new_uninit(const <() as std::mem::SizedTypeProperties>::LAYOUT) -> [return: bb2, unwind unreachable];
+-         _13 = boxed::box_new_uninit(const <() as std::mem::SizedTypeProperties>::LAYOUT) -> [return: bb2, unwind unreachable];
++         _13 = boxed::box_new_uninit(const Layout {{ size: 0_usize, align: std::ptr::Alignment {{ _inner_repr_trick: std::ptr::alignment::AlignmentEnum::_Align1Shl0 }} }}) -> [return: bb2, unwind unreachable];
       }
   
       bb1: {
@@ -103,5 +104,9 @@
 +         nop;
           drop(_3) -> [return: bb1, unwind unreachable];
       }
++ }
++ 
++ ALLOC0 (size: 16, align: 8) {
++     01 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 │ ................
   }
   

--- a/tests/mir-opt/funky_arms.float_to_exponential_common.GVN.32bit.panic-abort.diff
+++ b/tests/mir-opt/funky_arms.float_to_exponential_common.GVN.32bit.panic-abort.diff
@@ -47,7 +47,7 @@
           StorageLive(_20);
           StorageLive(_21);
           _21 = copy (((*_1).0: std::fmt::FormattingOptions).0: u32);
-          _20 = BitAnd(move _21, const core::fmt::flags::SIGN_PLUS_FLAG);
+          _20 = BitAnd(move _21, const 2097152_u32);
           StorageDead(_21);
           _4 = Ne(move _20, const 0_u32);
           StorageDead(_20);
@@ -72,7 +72,7 @@
           StorageLive(_22);
           StorageLive(_23);
           _23 = copy (((*_1).0: std::fmt::FormattingOptions).0: u32);
-          _22 = BitAnd(move _23, const core::fmt::flags::PRECISION_FLAG);
+          _22 = BitAnd(move _23, const 268435456_u32);
           StorageDead(_23);
           switchInt(copy _22) -> [0: bb10, otherwise: bb11];
       }

--- a/tests/mir-opt/funky_arms.float_to_exponential_common.GVN.32bit.panic-unwind.diff
+++ b/tests/mir-opt/funky_arms.float_to_exponential_common.GVN.32bit.panic-unwind.diff
@@ -47,7 +47,7 @@
           StorageLive(_20);
           StorageLive(_21);
           _21 = copy (((*_1).0: std::fmt::FormattingOptions).0: u32);
-          _20 = BitAnd(move _21, const core::fmt::flags::SIGN_PLUS_FLAG);
+          _20 = BitAnd(move _21, const 2097152_u32);
           StorageDead(_21);
           _4 = Ne(move _20, const 0_u32);
           StorageDead(_20);
@@ -72,7 +72,7 @@
           StorageLive(_22);
           StorageLive(_23);
           _23 = copy (((*_1).0: std::fmt::FormattingOptions).0: u32);
-          _22 = BitAnd(move _23, const core::fmt::flags::PRECISION_FLAG);
+          _22 = BitAnd(move _23, const 268435456_u32);
           StorageDead(_23);
           switchInt(copy _22) -> [0: bb10, otherwise: bb11];
       }

--- a/tests/mir-opt/funky_arms.float_to_exponential_common.GVN.64bit.panic-abort.diff
+++ b/tests/mir-opt/funky_arms.float_to_exponential_common.GVN.64bit.panic-abort.diff
@@ -47,7 +47,7 @@
           StorageLive(_20);
           StorageLive(_21);
           _21 = copy (((*_1).0: std::fmt::FormattingOptions).0: u32);
-          _20 = BitAnd(move _21, const core::fmt::flags::SIGN_PLUS_FLAG);
+          _20 = BitAnd(move _21, const 2097152_u32);
           StorageDead(_21);
           _4 = Ne(move _20, const 0_u32);
           StorageDead(_20);
@@ -72,7 +72,7 @@
           StorageLive(_22);
           StorageLive(_23);
           _23 = copy (((*_1).0: std::fmt::FormattingOptions).0: u32);
-          _22 = BitAnd(move _23, const core::fmt::flags::PRECISION_FLAG);
+          _22 = BitAnd(move _23, const 268435456_u32);
           StorageDead(_23);
           switchInt(copy _22) -> [0: bb10, otherwise: bb11];
       }

--- a/tests/mir-opt/funky_arms.float_to_exponential_common.GVN.64bit.panic-unwind.diff
+++ b/tests/mir-opt/funky_arms.float_to_exponential_common.GVN.64bit.panic-unwind.diff
@@ -47,7 +47,7 @@
           StorageLive(_20);
           StorageLive(_21);
           _21 = copy (((*_1).0: std::fmt::FormattingOptions).0: u32);
-          _20 = BitAnd(move _21, const core::fmt::flags::SIGN_PLUS_FLAG);
+          _20 = BitAnd(move _21, const 2097152_u32);
           StorageDead(_21);
           _4 = Ne(move _20, const 0_u32);
           StorageDead(_20);
@@ -72,7 +72,7 @@
           StorageLive(_22);
           StorageLive(_23);
           _23 = copy (((*_1).0: std::fmt::FormattingOptions).0: u32);
-          _22 = BitAnd(move _23, const core::fmt::flags::PRECISION_FLAG);
+          _22 = BitAnd(move _23, const 268435456_u32);
           StorageDead(_23);
           switchInt(copy _22) -> [0: bb10, otherwise: bb11];
       }

--- a/tests/mir-opt/gvn_const_eval_polymorphic.no_optimize.GVN.diff
+++ b/tests/mir-opt/gvn_const_eval_polymorphic.no_optimize.GVN.diff
@@ -5,7 +5,8 @@
       let mut _0: bool;
   
       bb0: {
-          _0 = Eq(const no_optimize::<T>::{constant#0}, const no_optimize::<T>::{constant#1});
+-         _0 = Eq(const no_optimize::<T>::{constant#0}, const no_optimize::<T>::{constant#1});
++         _0 = Eq(const no_optimize::<T>::{constant#0}, const true);
           return;
       }
   }

--- a/tests/mir-opt/gvn_const_eval_polymorphic.rs
+++ b/tests/mir-opt/gvn_const_eval_polymorphic.rs
@@ -51,7 +51,7 @@ fn optimize_false<T>() -> bool {
 // EMIT_MIR gvn_const_eval_polymorphic.no_optimize.GVN.diff
 fn no_optimize<T>() -> bool {
     // CHECK-LABEL: fn no_optimize(
-    // CHECK: _0 = Eq(const no_optimize::<T>::{constant#0}, const no_optimize::<T>::{constant#1});
+    // CHECK: _0 = Eq(const no_optimize::<T>::{constant#0}, const true);
     // CHECK-NEXT: return;
     (const { type_name_contains_i32(&generic::<T>) }) == const { true }
 }

--- a/tests/mir-opt/pre-codegen/checked_ops.checked_shl.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/checked_ops.checked_shl.PreCodegen.after.panic-abort.mir
@@ -17,7 +17,7 @@ fn checked_shl(_1: u32, _2: u32) -> Option<u32> {
 
     bb0: {
         StorageLive(_3);
-        _3 = Lt(copy _2, const core::num::<impl u32>::BITS);
+        _3 = Lt(copy _2, const 32_u32);
         switchInt(move _3) -> [0: bb1, otherwise: bb2];
     }
 

--- a/tests/mir-opt/pre-codegen/checked_ops.checked_shl.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/checked_ops.checked_shl.PreCodegen.after.panic-unwind.mir
@@ -17,7 +17,7 @@ fn checked_shl(_1: u32, _2: u32) -> Option<u32> {
 
     bb0: {
         StorageLive(_3);
-        _3 = Lt(copy _2, const core::num::<impl u32>::BITS);
+        _3 = Lt(copy _2, const 32_u32);
         switchInt(move _3) -> [0: bb1, otherwise: bb2];
     }
 

--- a/tests/mir-opt/pre-codegen/checked_ops.step_forward.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/checked_ops.step_forward.PreCodegen.after.panic-abort.mir
@@ -72,7 +72,7 @@ fn step_forward(_1: u16, _2: usize) -> u16 {
     }
 
     bb6: {
-        assert(!const true, "attempt to compute `{} + {}`, which would overflow", const core::num::<impl u16>::MAX, const 1_u16) -> [success: bb7, unwind unreachable];
+        assert(!const true, "attempt to compute `{} + {}`, which would overflow", const u16::MAX, const 1_u16) -> [success: bb7, unwind unreachable];
     }
 
     bb7: {

--- a/tests/mir-opt/pre-codegen/checked_ops.step_forward.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/checked_ops.step_forward.PreCodegen.after.panic-unwind.mir
@@ -72,7 +72,7 @@ fn step_forward(_1: u16, _2: usize) -> u16 {
     }
 
     bb6: {
-        assert(!const true, "attempt to compute `{} + {}`, which would overflow", const core::num::<impl u16>::MAX, const 1_u16) -> [success: bb7, unwind continue];
+        assert(!const true, "attempt to compute `{} + {}`, which would overflow", const u16::MAX, const 1_u16) -> [success: bb7, unwind continue];
     }
 
     bb7: {

--- a/tests/mir-opt/pre-codegen/drop_box_of_sized.drop_generic.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/drop_box_of_sized.drop_generic.PreCodegen.after.panic-abort.mir
@@ -6,7 +6,7 @@ fn drop_generic(_1: *mut Box<T>) -> () {
     scope 1 (inlined drop_in_place::<Box<T>> - shim(Some(Box<T>))) {
         scope 2 (inlined <Box<T> as Drop>::drop) {
             let _2: std::ptr::NonNull<T>;
-            let _7: ();
+            let _5: ();
             scope 3 {
                 scope 4 {
                     scope 17 (inlined Layout::size) {
@@ -24,7 +24,7 @@ fn drop_generic(_1: *mut Box<T>) -> () {
                     scope 23 (inlined <std::alloc::Global as Allocator>::deallocate) {
                         scope 24 (inlined std::alloc::Global::deallocate_impl) {
                             scope 25 (inlined std::alloc::Global::deallocate_impl_runtime) {
-                                let mut _6: *mut u8;
+                                let mut _4: *mut u8;
                                 scope 26 (inlined Layout::size) {
                                 }
                                 scope 27 (inlined NonNull::<u8>::as_ptr) {
@@ -44,8 +44,7 @@ fn drop_generic(_1: *mut Box<T>) -> () {
                     }
                 }
                 scope 7 (inlined Layout::for_value_raw::<T>) {
-                    let mut _3: usize;
-                    let mut _5: std::ptr::Alignment;
+                    let mut _3: std::ptr::Alignment;
                     scope 8 {
                         scope 16 (inlined #[track_caller] Layout::from_size_alignment_unchecked) {
                         }
@@ -53,7 +52,6 @@ fn drop_generic(_1: *mut Box<T>) -> () {
                     scope 9 (inlined size_of_val_raw::<T>) {
                     }
                     scope 10 (inlined std::ptr::Alignment::of_val_raw::<T>) {
-                        let _4: usize;
                         scope 11 {
                             scope 13 (inlined #[track_caller] std::ptr::Alignment::new_unchecked) {
                                 scope 14 (inlined core::ub_checks::check_language_ub) {
@@ -72,26 +70,26 @@ fn drop_generic(_1: *mut Box<T>) -> () {
 
     bb0: {
         _2 = copy (((*_1).0: std::ptr::Unique<T>).0: std::ptr::NonNull<T>);
-        _3 = const <T as std::mem::SizedTypeProperties>::SIZE;
-        StorageLive(_4);
-        _4 = const <T as std::mem::SizedTypeProperties>::ALIGN;
-        _5 = copy _4 as std::ptr::Alignment (Transmute);
-        StorageDead(_4);
-        switchInt(copy _3) -> [0: bb3, otherwise: bb1];
+        _3 = const <T as std::mem::SizedTypeProperties>::ALIGN as std::ptr::Alignment (Transmute);
+        switchInt(const <T as std::mem::SizedTypeProperties>::SIZE) -> [0: bb4, otherwise: bb1];
     }
 
     bb1: {
-        StorageLive(_6);
-        _6 = copy _2 as *mut u8 (Transmute);
-        _7 = alloc::alloc::__rust_dealloc(move _6, move _3, move _5) -> [return: bb2, unwind unreachable];
+        switchInt(const <T as std::mem::SizedTypeProperties>::SIZE) -> [0: bb4, otherwise: bb2];
     }
 
     bb2: {
-        StorageDead(_6);
-        goto -> bb3;
+        StorageLive(_4);
+        _4 = copy _2 as *mut u8 (Transmute);
+        _5 = alloc::alloc::__rust_dealloc(move _4, const <T as std::mem::SizedTypeProperties>::SIZE, move _3) -> [return: bb3, unwind unreachable];
     }
 
     bb3: {
+        StorageDead(_4);
+        goto -> bb4;
+    }
+
+    bb4: {
         return;
     }
 }

--- a/tests/mir-opt/pre-codegen/drop_box_of_sized.drop_generic.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/drop_box_of_sized.drop_generic.PreCodegen.after.panic-unwind.mir
@@ -6,7 +6,7 @@ fn drop_generic(_1: *mut Box<T>) -> () {
     scope 1 (inlined drop_in_place::<Box<T>> - shim(Some(Box<T>))) {
         scope 2 (inlined <Box<T> as Drop>::drop) {
             let _2: std::ptr::NonNull<T>;
-            let _7: ();
+            let _5: ();
             scope 3 {
                 scope 4 {
                     scope 17 (inlined Layout::size) {
@@ -24,7 +24,7 @@ fn drop_generic(_1: *mut Box<T>) -> () {
                     scope 23 (inlined <std::alloc::Global as Allocator>::deallocate) {
                         scope 24 (inlined std::alloc::Global::deallocate_impl) {
                             scope 25 (inlined std::alloc::Global::deallocate_impl_runtime) {
-                                let mut _6: *mut u8;
+                                let mut _4: *mut u8;
                                 scope 26 (inlined Layout::size) {
                                 }
                                 scope 27 (inlined NonNull::<u8>::as_ptr) {
@@ -44,8 +44,7 @@ fn drop_generic(_1: *mut Box<T>) -> () {
                     }
                 }
                 scope 7 (inlined Layout::for_value_raw::<T>) {
-                    let mut _3: usize;
-                    let mut _5: std::ptr::Alignment;
+                    let mut _3: std::ptr::Alignment;
                     scope 8 {
                         scope 16 (inlined #[track_caller] Layout::from_size_alignment_unchecked) {
                         }
@@ -53,7 +52,6 @@ fn drop_generic(_1: *mut Box<T>) -> () {
                     scope 9 (inlined size_of_val_raw::<T>) {
                     }
                     scope 10 (inlined std::ptr::Alignment::of_val_raw::<T>) {
-                        let _4: usize;
                         scope 11 {
                             scope 13 (inlined #[track_caller] std::ptr::Alignment::new_unchecked) {
                                 scope 14 (inlined core::ub_checks::check_language_ub) {
@@ -72,26 +70,26 @@ fn drop_generic(_1: *mut Box<T>) -> () {
 
     bb0: {
         _2 = copy (((*_1).0: std::ptr::Unique<T>).0: std::ptr::NonNull<T>);
-        _3 = const <T as std::mem::SizedTypeProperties>::SIZE;
-        StorageLive(_4);
-        _4 = const <T as std::mem::SizedTypeProperties>::ALIGN;
-        _5 = copy _4 as std::ptr::Alignment (Transmute);
-        StorageDead(_4);
-        switchInt(copy _3) -> [0: bb3, otherwise: bb1];
+        _3 = const <T as std::mem::SizedTypeProperties>::ALIGN as std::ptr::Alignment (Transmute);
+        switchInt(const <T as std::mem::SizedTypeProperties>::SIZE) -> [0: bb4, otherwise: bb1];
     }
 
     bb1: {
-        StorageLive(_6);
-        _6 = copy _2 as *mut u8 (Transmute);
-        _7 = alloc::alloc::__rust_dealloc(move _6, move _3, move _5) -> [return: bb2, unwind unreachable];
+        switchInt(const <T as std::mem::SizedTypeProperties>::SIZE) -> [0: bb4, otherwise: bb2];
     }
 
     bb2: {
-        StorageDead(_6);
-        goto -> bb3;
+        StorageLive(_4);
+        _4 = copy _2 as *mut u8 (Transmute);
+        _5 = alloc::alloc::__rust_dealloc(move _4, const <T as std::mem::SizedTypeProperties>::SIZE, move _3) -> [return: bb3, unwind unreachable];
     }
 
     bb3: {
+        StorageDead(_4);
+        goto -> bb4;
+    }
+
+    bb4: {
         return;
     }
 }

--- a/tests/mir-opt/pre-codegen/drop_box_of_sized.rs
+++ b/tests/mir-opt/pre-codegen/drop_box_of_sized.rs
@@ -6,10 +6,8 @@
 // EMIT_MIR drop_box_of_sized.drop_generic.PreCodegen.after.mir
 pub unsafe fn drop_generic<T: Copy>(x: *mut Box<T>) {
     // CHECK-LABEL: fn drop_generic
-    // CHECK: [[SIZE:_.+]] = const <T as std::mem::SizedTypeProperties>::SIZE;
-    // CHECK: [[ALIGN:_.+]] = const <T as std::mem::SizedTypeProperties>::ALIGN;
-    // CHECK: [[ALIGNMENT:_.+]] = copy [[ALIGN]] as std::ptr::Alignment (Transmute)
-    // CHECK: alloc::alloc::__rust_dealloc({{.+}}, move [[SIZE]], move [[ALIGNMENT]])
+    // CHECK: [[ALIGNMENT:_.+]] = const <T as std::mem::SizedTypeProperties>::ALIGN as std::ptr::Alignment (Transmute)
+    // CHECK: alloc::alloc::__rust_dealloc({{.+}}, const <T as std::mem::SizedTypeProperties>::SIZE, move [[ALIGNMENT]])
     std::ptr::drop_in_place(x)
 }
 

--- a/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.32bit.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.32bit.panic-abort.mir
@@ -8,7 +8,7 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
             let _2: std::ptr::NonNull<[T]>;
             let mut _3: *mut [T];
             let mut _4: *const [T];
-            let _9: ();
+            let _8: ();
             scope 3 {
                 scope 4 {
                     scope 17 (inlined Layout::size) {
@@ -26,7 +26,7 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
                     scope 23 (inlined <std::alloc::Global as Allocator>::deallocate) {
                         scope 24 (inlined std::alloc::Global::deallocate_impl) {
                             scope 25 (inlined std::alloc::Global::deallocate_impl_runtime) {
-                                let mut _8: *mut u8;
+                                let mut _7: *mut u8;
                                 scope 26 (inlined Layout::size) {
                                 }
                                 scope 27 (inlined NonNull::<u8>::as_ptr) {
@@ -47,7 +47,7 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
                 }
                 scope 7 (inlined Layout::for_value_raw::<[T]>) {
                     let mut _5: usize;
-                    let mut _7: std::ptr::Alignment;
+                    let mut _6: std::ptr::Alignment;
                     scope 8 {
                         scope 16 (inlined #[track_caller] Layout::from_size_alignment_unchecked) {
                         }
@@ -55,7 +55,6 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
                     scope 9 (inlined size_of_val_raw::<[T]>) {
                     }
                     scope 10 (inlined std::ptr::Alignment::of_val_raw::<[T]>) {
-                        let _6: usize;
                         scope 11 {
                             scope 13 (inlined #[track_caller] std::ptr::Alignment::new_unchecked) {
                                 scope 14 (inlined core::ub_checks::check_language_ub) {
@@ -82,22 +81,19 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
     }
 
     bb1: {
-        StorageLive(_6);
-        _6 = const <T as std::mem::SizedTypeProperties>::ALIGN;
-        _7 = copy _6 as std::ptr::Alignment (Transmute);
-        StorageDead(_6);
+        _6 = const <T as std::mem::SizedTypeProperties>::ALIGN as std::ptr::Alignment (Transmute);
         StorageDead(_4);
         switchInt(copy _5) -> [0: bb4, otherwise: bb2];
     }
 
     bb2: {
-        StorageLive(_8);
-        _8 = copy _3 as *mut u8 (PtrToPtr);
-        _9 = alloc::alloc::__rust_dealloc(move _8, move _5, move _7) -> [return: bb3, unwind unreachable];
+        StorageLive(_7);
+        _7 = copy _3 as *mut u8 (PtrToPtr);
+        _8 = alloc::alloc::__rust_dealloc(move _7, move _5, move _6) -> [return: bb3, unwind unreachable];
     }
 
     bb3: {
-        StorageDead(_8);
+        StorageDead(_7);
         goto -> bb4;
     }
 

--- a/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.32bit.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.32bit.panic-unwind.mir
@@ -8,7 +8,7 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
             let _2: std::ptr::NonNull<[T]>;
             let mut _3: *mut [T];
             let mut _4: *const [T];
-            let _9: ();
+            let _8: ();
             scope 3 {
                 scope 4 {
                     scope 17 (inlined Layout::size) {
@@ -26,7 +26,7 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
                     scope 23 (inlined <std::alloc::Global as Allocator>::deallocate) {
                         scope 24 (inlined std::alloc::Global::deallocate_impl) {
                             scope 25 (inlined std::alloc::Global::deallocate_impl_runtime) {
-                                let mut _8: *mut u8;
+                                let mut _7: *mut u8;
                                 scope 26 (inlined Layout::size) {
                                 }
                                 scope 27 (inlined NonNull::<u8>::as_ptr) {
@@ -47,7 +47,7 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
                 }
                 scope 7 (inlined Layout::for_value_raw::<[T]>) {
                     let mut _5: usize;
-                    let mut _7: std::ptr::Alignment;
+                    let mut _6: std::ptr::Alignment;
                     scope 8 {
                         scope 16 (inlined #[track_caller] Layout::from_size_alignment_unchecked) {
                         }
@@ -55,7 +55,6 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
                     scope 9 (inlined size_of_val_raw::<[T]>) {
                     }
                     scope 10 (inlined std::ptr::Alignment::of_val_raw::<[T]>) {
-                        let _6: usize;
                         scope 11 {
                             scope 13 (inlined #[track_caller] std::ptr::Alignment::new_unchecked) {
                                 scope 14 (inlined core::ub_checks::check_language_ub) {
@@ -82,22 +81,19 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
     }
 
     bb1: {
-        StorageLive(_6);
-        _6 = const <T as std::mem::SizedTypeProperties>::ALIGN;
-        _7 = copy _6 as std::ptr::Alignment (Transmute);
-        StorageDead(_6);
+        _6 = const <T as std::mem::SizedTypeProperties>::ALIGN as std::ptr::Alignment (Transmute);
         StorageDead(_4);
         switchInt(copy _5) -> [0: bb4, otherwise: bb2];
     }
 
     bb2: {
-        StorageLive(_8);
-        _8 = copy _3 as *mut u8 (PtrToPtr);
-        _9 = alloc::alloc::__rust_dealloc(move _8, move _5, move _7) -> [return: bb3, unwind unreachable];
+        StorageLive(_7);
+        _7 = copy _3 as *mut u8 (PtrToPtr);
+        _8 = alloc::alloc::__rust_dealloc(move _7, move _5, move _6) -> [return: bb3, unwind unreachable];
     }
 
     bb3: {
-        StorageDead(_8);
+        StorageDead(_7);
         goto -> bb4;
     }
 

--- a/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.64bit.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.64bit.panic-abort.mir
@@ -8,7 +8,7 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
             let _2: std::ptr::NonNull<[T]>;
             let mut _3: *mut [T];
             let mut _4: *const [T];
-            let _9: ();
+            let _8: ();
             scope 3 {
                 scope 4 {
                     scope 17 (inlined Layout::size) {
@@ -26,7 +26,7 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
                     scope 23 (inlined <std::alloc::Global as Allocator>::deallocate) {
                         scope 24 (inlined std::alloc::Global::deallocate_impl) {
                             scope 25 (inlined std::alloc::Global::deallocate_impl_runtime) {
-                                let mut _8: *mut u8;
+                                let mut _7: *mut u8;
                                 scope 26 (inlined Layout::size) {
                                 }
                                 scope 27 (inlined NonNull::<u8>::as_ptr) {
@@ -47,7 +47,7 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
                 }
                 scope 7 (inlined Layout::for_value_raw::<[T]>) {
                     let mut _5: usize;
-                    let mut _7: std::ptr::Alignment;
+                    let mut _6: std::ptr::Alignment;
                     scope 8 {
                         scope 16 (inlined #[track_caller] Layout::from_size_alignment_unchecked) {
                         }
@@ -55,7 +55,6 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
                     scope 9 (inlined size_of_val_raw::<[T]>) {
                     }
                     scope 10 (inlined std::ptr::Alignment::of_val_raw::<[T]>) {
-                        let _6: usize;
                         scope 11 {
                             scope 13 (inlined #[track_caller] std::ptr::Alignment::new_unchecked) {
                                 scope 14 (inlined core::ub_checks::check_language_ub) {
@@ -82,22 +81,19 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
     }
 
     bb1: {
-        StorageLive(_6);
-        _6 = const <T as std::mem::SizedTypeProperties>::ALIGN;
-        _7 = copy _6 as std::ptr::Alignment (Transmute);
-        StorageDead(_6);
+        _6 = const <T as std::mem::SizedTypeProperties>::ALIGN as std::ptr::Alignment (Transmute);
         StorageDead(_4);
         switchInt(copy _5) -> [0: bb4, otherwise: bb2];
     }
 
     bb2: {
-        StorageLive(_8);
-        _8 = copy _3 as *mut u8 (PtrToPtr);
-        _9 = alloc::alloc::__rust_dealloc(move _8, move _5, move _7) -> [return: bb3, unwind unreachable];
+        StorageLive(_7);
+        _7 = copy _3 as *mut u8 (PtrToPtr);
+        _8 = alloc::alloc::__rust_dealloc(move _7, move _5, move _6) -> [return: bb3, unwind unreachable];
     }
 
     bb3: {
-        StorageDead(_8);
+        StorageDead(_7);
         goto -> bb4;
     }
 

--- a/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.64bit.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.64bit.panic-unwind.mir
@@ -8,7 +8,7 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
             let _2: std::ptr::NonNull<[T]>;
             let mut _3: *mut [T];
             let mut _4: *const [T];
-            let _9: ();
+            let _8: ();
             scope 3 {
                 scope 4 {
                     scope 17 (inlined Layout::size) {
@@ -26,7 +26,7 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
                     scope 23 (inlined <std::alloc::Global as Allocator>::deallocate) {
                         scope 24 (inlined std::alloc::Global::deallocate_impl) {
                             scope 25 (inlined std::alloc::Global::deallocate_impl_runtime) {
-                                let mut _8: *mut u8;
+                                let mut _7: *mut u8;
                                 scope 26 (inlined Layout::size) {
                                 }
                                 scope 27 (inlined NonNull::<u8>::as_ptr) {
@@ -47,7 +47,7 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
                 }
                 scope 7 (inlined Layout::for_value_raw::<[T]>) {
                     let mut _5: usize;
-                    let mut _7: std::ptr::Alignment;
+                    let mut _6: std::ptr::Alignment;
                     scope 8 {
                         scope 16 (inlined #[track_caller] Layout::from_size_alignment_unchecked) {
                         }
@@ -55,7 +55,6 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
                     scope 9 (inlined size_of_val_raw::<[T]>) {
                     }
                     scope 10 (inlined std::ptr::Alignment::of_val_raw::<[T]>) {
-                        let _6: usize;
                         scope 11 {
                             scope 13 (inlined #[track_caller] std::ptr::Alignment::new_unchecked) {
                                 scope 14 (inlined core::ub_checks::check_language_ub) {
@@ -82,22 +81,19 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
     }
 
     bb1: {
-        StorageLive(_6);
-        _6 = const <T as std::mem::SizedTypeProperties>::ALIGN;
-        _7 = copy _6 as std::ptr::Alignment (Transmute);
-        StorageDead(_6);
+        _6 = const <T as std::mem::SizedTypeProperties>::ALIGN as std::ptr::Alignment (Transmute);
         StorageDead(_4);
         switchInt(copy _5) -> [0: bb4, otherwise: bb2];
     }
 
     bb2: {
-        StorageLive(_8);
-        _8 = copy _3 as *mut u8 (PtrToPtr);
-        _9 = alloc::alloc::__rust_dealloc(move _8, move _5, move _7) -> [return: bb3, unwind unreachable];
+        StorageLive(_7);
+        _7 = copy _3 as *mut u8 (PtrToPtr);
+        _8 = alloc::alloc::__rust_dealloc(move _7, move _5, move _6) -> [return: bb3, unwind unreachable];
     }
 
     bb3: {
-        StorageDead(_8);
+        StorageDead(_7);
         goto -> bb4;
     }
 

--- a/tests/mir-opt/pre-codegen/drop_boxed_slice.rs
+++ b/tests/mir-opt/pre-codegen/drop_boxed_slice.rs
@@ -9,8 +9,7 @@ pub unsafe fn generic_in_place<T: Copy>(ptr: *mut Box<[T]>) {
     // CHECK-LABEL: fn generic_in_place(_1: *mut Box<[T]>)
     // CHECK: (inlined <Box<[T]> as Drop>::drop)
     // CHECK: [[SIZE:_.+]] = std::intrinsics::size_of_val::<[T]>
-    // CHECK: [[ALIGN:_.+]] = const <T as std::mem::SizedTypeProperties>::ALIGN;
-    // CHECK: [[B:_.+]] = copy [[ALIGN]] as std::ptr::Alignment (Transmute);
-    // CHECK: = alloc::alloc::__rust_dealloc({{.+}}, move [[SIZE]], move [[B]]) ->
+    // CHECK: [[ALIGN:_.+]] = const <T as std::mem::SizedTypeProperties>::ALIGN as std::ptr::Alignment (Transmute);
+    // CHECK: = alloc::alloc::__rust_dealloc({{.+}}, move [[SIZE]], move [[ALIGN]]) ->
     std::ptr::drop_in_place(ptr)
 }


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/149366)*

GVN separates MIR constants into deterministic and non-deterministic constants. Deterministic constants are defined here as: gives the exact same value each time it is evaluated.

This was mainly useful because of `ConstValue::Slice` that generated an extra `AllocId` each time it appeared in the MIR. That variant has been removed. This is still useful for valtrees that hold references, which generate a fresh `AllocId` for each evaluation.

This PR proposes to consider all constants of primitive type to be deterministic. If a constant of primitive type passes validation, then it does not contain provenance, so we have no risk of having a reference becoming different `AllocId`s. In particular, valtrees only are leaves.

r? @ghost for perf 

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
