### PR TITLE
Run `eval_config_entry` on all branches so we always emit lints

### DIFF
--- a/tests/ui/check-cfg/cfg-select.rs
+++ b/tests/ui/check-cfg/cfg-select.rs
@@ -1,0 +1,18 @@
+//@ check-pass
+
+#![feature(cfg_select)]
+#![crate_type = "lib"]
+
+cfg_select! {
+    true => {}
+    invalid_cfg1 => {}
+    //~^ WARN unexpected `cfg` condition name
+    _ => {}
+}
+
+cfg_select! {
+    invalid_cfg2 => {}
+    //~^ WARN unexpected `cfg` condition name
+    true => {}
+    _ => {}
+}

--- a/tests/ui/check-cfg/cfg-select.stderr
+++ b/tests/ui/check-cfg/cfg-select.stderr
@@ -1,0 +1,22 @@
+warning: unexpected `cfg` condition name: `invalid_cfg1`
+  --> $DIR/cfg-select.rs:8:5
+   |
+LL |     invalid_cfg1 => {}
+   |     ^^^^^^^^^^^^
+   |
+   = help: expected names are: `FALSE` and `test` and 31 more
+   = help: to expect this configuration use `--check-cfg=cfg(invalid_cfg1)`
+   = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
+   = note: `#[warn(unexpected_cfgs)]` on by default
+
+warning: unexpected `cfg` condition name: `invalid_cfg2`
+  --> $DIR/cfg-select.rs:14:5
+   |
+LL |     invalid_cfg2 => {}
+   |     ^^^^^^^^^^^^
+   |
+   = help: to expect this configuration use `--check-cfg=cfg(invalid_cfg2)`
+   = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
+
+warning: 2 warnings emitted
+


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/149090

Ideally I'd have liked to fix this issue using https://github.com/rust-lang/rust/pull/149215, and this is still the long term plan, but this is slightly more annoying to implement than I'd have liked to, and this is also a nice and easy solution to the problem.

r? @tgross35 