### PR TITLE
Don't delegate to default implementations of `ExactSizeIterator`

### DIFF
--- a/library/alloc/src/collections/binary_heap/mod.rs
+++ b/library/alloc/src/collections/binary_heap/mod.rs
@@ -1720,7 +1720,12 @@ impl<T: Ord, A: Allocator> Iterator for IntoIterSorted<T, A> {
 }
 
 #[unstable(feature = "binary_heap_into_iter_sorted", issue = "59278")]
-impl<T: Ord, A: Allocator> ExactSizeIterator for IntoIterSorted<T, A> {}
+impl<T: Ord, A: Allocator> ExactSizeIterator for IntoIterSorted<T, A> {
+    #[inline]
+    fn len(&self) -> usize {
+        self.inner.len()
+    }
+}
 
 #[unstable(feature = "binary_heap_into_iter_sorted", issue = "59278")]
 impl<T: Ord, A: Allocator> FusedIterator for IntoIterSorted<T, A> {}
@@ -1846,7 +1851,12 @@ impl<T: Ord, A: Allocator> Iterator for DrainSorted<'_, T, A> {
 }
 
 #[unstable(feature = "binary_heap_drain_sorted", issue = "59278")]
-impl<T: Ord, A: Allocator> ExactSizeIterator for DrainSorted<'_, T, A> {}
+impl<T: Ord, A: Allocator> ExactSizeIterator for DrainSorted<'_, T, A> {
+    #[inline]
+    fn len(&self) -> usize {
+        self.inner.len()
+    }
+}
 
 #[unstable(feature = "binary_heap_drain_sorted", issue = "59278")]
 impl<T: Ord, A: Allocator> FusedIterator for DrainSorted<'_, T, A> {}

--- a/library/alloc/src/collections/linked_list.rs
+++ b/library/alloc/src/collections/linked_list.rs
@@ -1244,7 +1244,11 @@ impl<'a, T> DoubleEndedIterator for Iter<'a, T> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T> ExactSizeIterator for Iter<'_, T> {}
+impl<T> ExactSizeIterator for Iter<'_, T> {
+    fn len(&self) -> usize {
+        self.len
+    }
+}
 
 #[stable(feature = "fused", since = "1.26.0")]
 impl<T> FusedIterator for Iter<'_, T> {}
@@ -1312,7 +1316,11 @@ impl<'a, T> DoubleEndedIterator for IterMut<'a, T> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T> ExactSizeIterator for IterMut<'_, T> {}
+impl<T> ExactSizeIterator for IterMut<'_, T> {
+    fn len(&self) -> usize {
+        self.len
+    }
+}
 
 #[stable(feature = "fused", since = "1.26.0")]
 impl<T> FusedIterator for IterMut<'_, T> {}
@@ -2023,7 +2031,11 @@ impl<T, A: Allocator> DoubleEndedIterator for IntoIter<T, A> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T, A: Allocator> ExactSizeIterator for IntoIter<T, A> {}
+impl<T, A: Allocator> ExactSizeIterator for IntoIter<T, A> {
+    fn len(&self) -> usize {
+        self.list.len
+    }
+}
 
 #[stable(feature = "fused", since = "1.26.0")]
 impl<T, A: Allocator> FusedIterator for IntoIter<T, A> {}

--- a/library/alloc/src/collections/vec_deque/drain.rs
+++ b/library/alloc/src/collections/vec_deque/drain.rs
@@ -268,7 +268,11 @@ impl<T, A: Allocator> DoubleEndedIterator for Drain<'_, T, A> {
 }
 
 #[stable(feature = "drain", since = "1.6.0")]
-impl<T, A: Allocator> ExactSizeIterator for Drain<'_, T, A> {}
+impl<T, A: Allocator> ExactSizeIterator for Drain<'_, T, A> {
+    fn len(&self) -> usize {
+        self.remaining
+    }
+}
 
 #[stable(feature = "fused", since = "1.26.0")]
 impl<T, A: Allocator> FusedIterator for Drain<'_, T, A> {}

--- a/library/alloc/src/vec/drain.rs
+++ b/library/alloc/src/vec/drain.rs
@@ -241,6 +241,10 @@ impl<T, A: Allocator> Drop for Drain<'_, T, A> {
 
 #[stable(feature = "drain", since = "1.6.0")]
 impl<T, A: Allocator> ExactSizeIterator for Drain<'_, T, A> {
+    fn len(&self) -> usize {
+        self.iter.len()
+    }
+
     fn is_empty(&self) -> bool {
         self.iter.is_empty()
     }

--- a/library/alloc/src/vec/splice.rs
+++ b/library/alloc/src/vec/splice.rs
@@ -48,7 +48,11 @@ impl<I: Iterator, A: Allocator> DoubleEndedIterator for Splice<'_, I, A> {
 }
 
 #[stable(feature = "vec_splice", since = "1.21.0")]
-impl<I: Iterator, A: Allocator> ExactSizeIterator for Splice<'_, I, A> {}
+impl<I: Iterator, A: Allocator> ExactSizeIterator for Splice<'_, I, A> {
+    fn len(&self) -> usize {
+        self.drain.len()
+    }
+}
 
 #[stable(feature = "vec_splice", since = "1.21.0")]
 impl<I: Iterator, A: Allocator> Drop for Splice<'_, I, A> {

--- a/library/core/src/iter/adapters/peekable.rs
+++ b/library/core/src/iter/adapters/peekable.rs
@@ -168,7 +168,13 @@ where
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<I: ExactSizeIterator> ExactSizeIterator for Peekable<I> {}
+impl<I: ExactSizeIterator> ExactSizeIterator for Peekable<I> {
+    #[inline]
+    fn len(&self) -> usize {
+        let peek_len = usize::from(matches!(self.peeked, Some(Some(_))));
+        self.iter.len().saturating_add(peek_len)
+    }
+}
 
 #[stable(feature = "fused", since = "1.26.0")]
 impl<I: FusedIterator> FusedIterator for Peekable<I> {}

--- a/library/core/src/iter/adapters/skip.rs
+++ b/library/core/src/iter/adapters/skip.rs
@@ -185,7 +185,14 @@ where
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<I> ExactSizeIterator for Skip<I> where I: ExactSizeIterator {}
+impl<I> ExactSizeIterator for Skip<I>
+where
+    I: ExactSizeIterator,
+{
+    fn len(&self) -> usize {
+        self.iter.len().saturating_sub(self.n)
+    }
+}
 
 #[stable(feature = "double_ended_skip_iterator", since = "1.9.0")]
 impl<I> DoubleEndedIterator for Skip<I>

--- a/library/core/src/iter/adapters/take.rs
+++ b/library/core/src/iter/adapters/take.rs
@@ -238,7 +238,14 @@ where
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<I> ExactSizeIterator for Take<I> where I: ExactSizeIterator {}
+impl<I> ExactSizeIterator for Take<I>
+where
+    I: ExactSizeIterator,
+{
+    fn len(&self) -> usize {
+        cmp::min(self.n, self.iter.len())
+    }
+}
 
 #[stable(feature = "fused", since = "1.26.0")]
 impl<I> FusedIterator for Take<I> where I: FusedIterator {}

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -807,7 +807,7 @@ impl<T> Option<T> {
     }
 
     #[inline]
-    const fn len(&self) -> usize {
+    pub(crate) const fn len(&self) -> usize {
         // Using the intrinsic avoids emitting a branch to get the 0 or 1.
         let discriminant: isize = crate::intrinsics::discriminant_value(self);
         discriminant as usize
@@ -2461,6 +2461,7 @@ impl<'a, A> Iterator for Iter<'a, A> {
     fn next(&mut self) -> Option<&'a A> {
         self.inner.next()
     }
+
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.inner.size_hint()
@@ -2476,7 +2477,11 @@ impl<'a, A> DoubleEndedIterator for Iter<'a, A> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<A> ExactSizeIterator for Iter<'_, A> {}
+impl<A> ExactSizeIterator for Iter<'_, A> {
+    fn len(&self) -> usize {
+        self.inner.len()
+    }
+}
 
 #[stable(feature = "fused", since = "1.26.0")]
 impl<A> FusedIterator for Iter<'_, A> {}
@@ -2511,6 +2516,7 @@ impl<'a, A> Iterator for IterMut<'a, A> {
     fn next(&mut self) -> Option<&'a mut A> {
         self.inner.next()
     }
+
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.inner.size_hint()
@@ -2526,7 +2532,11 @@ impl<'a, A> DoubleEndedIterator for IterMut<'a, A> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<A> ExactSizeIterator for IterMut<'_, A> {}
+impl<A> ExactSizeIterator for IterMut<'_, A> {
+    fn len(&self) -> usize {
+        self.inner.len()
+    }
+}
 
 #[stable(feature = "fused", since = "1.26.0")]
 impl<A> FusedIterator for IterMut<'_, A> {}
@@ -2552,6 +2562,7 @@ impl<A> Iterator for IntoIter<A> {
     fn next(&mut self) -> Option<A> {
         self.inner.next()
     }
+
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.inner.size_hint()
@@ -2567,7 +2578,11 @@ impl<A> DoubleEndedIterator for IntoIter<A> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<A> ExactSizeIterator for IntoIter<A> {}
+impl<A> ExactSizeIterator for IntoIter<A> {
+    fn len(&self) -> usize {
+        self.inner.len()
+    }
+}
 
 #[stable(feature = "fused", since = "1.26.0")]
 impl<A> FusedIterator for IntoIter<A> {}

--- a/library/core/src/result.rs
+++ b/library/core/src/result.rs
@@ -1984,9 +1984,10 @@ impl<'a, T> Iterator for Iter<'a, T> {
     fn next(&mut self) -> Option<&'a T> {
         self.inner.take()
     }
+
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let n = if self.inner.is_some() { 1 } else { 0 };
+        let n = self.len();
         (n, Some(n))
     }
 }
@@ -2000,7 +2001,11 @@ impl<'a, T> DoubleEndedIterator for Iter<'a, T> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T> ExactSizeIterator for Iter<'_, T> {}
+impl<T> ExactSizeIterator for Iter<'_, T> {
+    fn len(&self) -> usize {
+        self.inner.len()
+    }
+}
 
 #[stable(feature = "fused", since = "1.26.0")]
 impl<T> FusedIterator for Iter<'_, T> {}
@@ -2035,7 +2040,7 @@ impl<'a, T> Iterator for IterMut<'a, T> {
     }
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let n = if self.inner.is_some() { 1 } else { 0 };
+        let n = self.len();
         (n, Some(n))
     }
 }
@@ -2049,7 +2054,11 @@ impl<'a, T> DoubleEndedIterator for IterMut<'a, T> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T> ExactSizeIterator for IterMut<'_, T> {}
+impl<T> ExactSizeIterator for IterMut<'_, T> {
+    fn len(&self) -> usize {
+        self.inner.len()
+    }
+}
 
 #[stable(feature = "fused", since = "1.26.0")]
 impl<T> FusedIterator for IterMut<'_, T> {}
@@ -2079,9 +2088,10 @@ impl<T> Iterator for IntoIter<T> {
     fn next(&mut self) -> Option<T> {
         self.inner.take()
     }
+
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let n = if self.inner.is_some() { 1 } else { 0 };
+        let n = self.len();
         (n, Some(n))
     }
 }
@@ -2095,7 +2105,11 @@ impl<T> DoubleEndedIterator for IntoIter<T> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T> ExactSizeIterator for IntoIter<T> {}
+impl<T> ExactSizeIterator for IntoIter<T> {
+    fn len(&self) -> usize {
+        self.inner.len()
+    }
+}
 
 #[stable(feature = "fused", since = "1.26.0")]
 impl<T> FusedIterator for IntoIter<T> {}

--- a/library/core/src/slice/iter.rs
+++ b/library/core/src/slice/iter.rs
@@ -1365,12 +1365,8 @@ impl<'a, T> Iterator for Windows<'a, T> {
 
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
-        if self.size.get() > self.v.len() {
-            (0, Some(0))
-        } else {
-            let size = self.v.len() - self.size.get() + 1;
-            (size, Some(size))
-        }
+        let n = self.len();
+        (n, Some(n))
     }
 
     #[inline]
@@ -1440,7 +1436,17 @@ impl<'a, T> DoubleEndedIterator for Windows<'a, T> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T> ExactSizeIterator for Windows<'_, T> {}
+impl<T> ExactSizeIterator for Windows<'_, T> {
+    #[inline]
+    fn len(&self) -> usize {
+        if self.size.get() > self.v.len() { 0 } else { self.v.len() - self.size.get() + 1 }
+    }
+
+    #[inline]
+    fn is_empty(&self) -> bool {
+        self.size.get() > self.v.len()
+    }
+}
 
 #[unstable(feature = "trusted_len", issue = "37572")]
 unsafe impl<T> TrustedLen for Windows<'_, T> {}
@@ -1520,14 +1526,8 @@ impl<'a, T> Iterator for Chunks<'a, T> {
 
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
-        if self.v.is_empty() {
-            (0, Some(0))
-        } else {
-            let n = self.v.len() / self.chunk_size;
-            let rem = self.v.len() % self.chunk_size;
-            let n = if rem > 0 { n + 1 } else { n };
-            (n, Some(n))
-        }
+        let n = self.len();
+        (n, Some(n))
     }
 
     #[inline]
@@ -1625,7 +1625,17 @@ impl<'a, T> DoubleEndedIterator for Chunks<'a, T> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T> ExactSizeIterator for Chunks<'_, T> {}
+impl<T> ExactSizeIterator for Chunks<'_, T> {
+    #[inline]
+    fn len(&self) -> usize {
+        if self.v.is_empty() { 0 } else { self.v.len().div_ceil(self.chunk_size) }
+    }
+
+    #[inline]
+    fn is_empty(&self) -> bool {
+        self.v.is_empty()
+    }
+}
 
 #[unstable(feature = "trusted_len", issue = "37572")]
 unsafe impl<T> TrustedLen for Chunks<'_, T> {}
@@ -1702,14 +1712,8 @@ impl<'a, T> Iterator for ChunksMut<'a, T> {
 
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
-        if self.v.is_empty() {
-            (0, Some(0))
-        } else {
-            let n = self.v.len() / self.chunk_size;
-            let rem = self.v.len() % self.chunk_size;
-            let n = if rem > 0 { n + 1 } else { n };
-            (n, Some(n))
-        }
+        let n = self.len();
+        (n, Some(n))
     }
 
     #[inline]
@@ -1806,7 +1810,17 @@ impl<'a, T> DoubleEndedIterator for ChunksMut<'a, T> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T> ExactSizeIterator for ChunksMut<'_, T> {}
+impl<T> ExactSizeIterator for ChunksMut<'_, T> {
+    #[inline]
+    fn len(&self) -> usize {
+        if self.v.is_empty() { 0 } else { self.v.len().div_ceil(self.chunk_size) }
+    }
+
+    #[inline]
+    fn is_empty(&self) -> bool {
+        self.v.is_empty()
+    }
+}
 
 #[unstable(feature = "trusted_len", issue = "37572")]
 unsafe impl<T> TrustedLen for ChunksMut<'_, T> {}
@@ -1920,7 +1934,7 @@ impl<'a, T> Iterator for ChunksExact<'a, T> {
 
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let n = self.v.len() / self.chunk_size;
+        let n = self.len();
         (n, Some(n))
     }
 
@@ -1985,6 +1999,12 @@ impl<'a, T> DoubleEndedIterator for ChunksExact<'a, T> {
 
 #[stable(feature = "chunks_exact", since = "1.31.0")]
 impl<T> ExactSizeIterator for ChunksExact<'_, T> {
+    #[inline]
+    fn len(&self) -> usize {
+        self.v.len() / self.chunk_size
+    }
+
+    #[inline]
     fn is_empty(&self) -> bool {
         self.v.is_empty()
     }
@@ -2080,7 +2100,7 @@ impl<'a, T> Iterator for ChunksExactMut<'a, T> {
 
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let n = self.v.len() / self.chunk_size;
+        let n = self.len();
         (n, Some(n))
     }
 
@@ -2152,6 +2172,12 @@ impl<'a, T> DoubleEndedIterator for ChunksExactMut<'a, T> {
 
 #[stable(feature = "chunks_exact", since = "1.31.0")]
 impl<T> ExactSizeIterator for ChunksExactMut<'_, T> {
+    #[inline]
+    fn len(&self) -> usize {
+        self.v.len() / self.chunk_size
+    }
+
+    #[inline]
     fn is_empty(&self) -> bool {
         self.v.is_empty()
     }
@@ -2228,8 +2254,8 @@ impl<'a, T, const N: usize> Iterator for ArrayWindows<'a, T, N> {
 
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let size = self.v.len().saturating_sub(N - 1);
-        (size, Some(size))
+        let n = self.len();
+        (n, Some(n))
     }
 
     #[inline]
@@ -2271,6 +2297,12 @@ impl<'a, T, const N: usize> DoubleEndedIterator for ArrayWindows<'a, T, N> {
 
 #[unstable(feature = "array_windows", issue = "75027")]
 impl<T, const N: usize> ExactSizeIterator for ArrayWindows<'_, T, N> {
+    #[inline]
+    fn len(&self) -> usize {
+        self.v.len().saturating_sub(N - 1)
+    }
+
+    #[inline]
     fn is_empty(&self) -> bool {
         self.v.len() < N
     }
@@ -2344,14 +2376,8 @@ impl<'a, T> Iterator for RChunks<'a, T> {
 
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
-        if self.v.is_empty() {
-            (0, Some(0))
-        } else {
-            let n = self.v.len() / self.chunk_size;
-            let rem = self.v.len() % self.chunk_size;
-            let n = if rem > 0 { n + 1 } else { n };
-            (n, Some(n))
-        }
+        let n = self.len();
+        (n, Some(n))
     }
 
     #[inline]
@@ -2435,7 +2461,17 @@ impl<'a, T> DoubleEndedIterator for RChunks<'a, T> {
 }
 
 #[stable(feature = "rchunks", since = "1.31.0")]
-impl<T> ExactSizeIterator for RChunks<'_, T> {}
+impl<T> ExactSizeIterator for RChunks<'_, T> {
+    #[inline]
+    fn len(&self) -> usize {
+        if self.v.is_empty() { 0 } else { self.v.len().div_ceil(self.chunk_size) }
+    }
+
+    #[inline]
+    fn is_empty(&self) -> bool {
+        self.v.is_empty()
+    }
+}
 
 #[unstable(feature = "trusted_len", issue = "37572")]
 unsafe impl<T> TrustedLen for RChunks<'_, T> {}
@@ -2517,14 +2553,8 @@ impl<'a, T> Iterator for RChunksMut<'a, T> {
 
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
-        if self.v.is_empty() {
-            (0, Some(0))
-        } else {
-            let n = self.v.len() / self.chunk_size;
-            let rem = self.v.len() % self.chunk_size;
-            let n = if rem > 0 { n + 1 } else { n };
-            (n, Some(n))
-        }
+        let n = self.len();
+        (n, Some(n))
     }
 
     #[inline]
@@ -2621,7 +2651,17 @@ impl<'a, T> DoubleEndedIterator for RChunksMut<'a, T> {
 }
 
 #[stable(feature = "rchunks", since = "1.31.0")]
-impl<T> ExactSizeIterator for RChunksMut<'_, T> {}
+impl<T> ExactSizeIterator for RChunksMut<'_, T> {
+    #[inline]
+    fn len(&self) -> usize {
+        if self.v.is_empty() { 0 } else { self.v.len().div_ceil(self.chunk_size) }
+    }
+
+    #[inline]
+    fn is_empty(&self) -> bool {
+        self.v.is_empty()
+    }
+}
 
 #[unstable(feature = "trusted_len", issue = "37572")]
 unsafe impl<T> TrustedLen for RChunksMut<'_, T> {}
@@ -2735,7 +2775,7 @@ impl<'a, T> Iterator for RChunksExact<'a, T> {
 
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let n = self.v.len() / self.chunk_size;
+        let n = self.len();
         (n, Some(n))
     }
 
@@ -2804,6 +2844,12 @@ impl<'a, T> DoubleEndedIterator for RChunksExact<'a, T> {
 
 #[stable(feature = "rchunks", since = "1.31.0")]
 impl<'a, T> ExactSizeIterator for RChunksExact<'a, T> {
+    #[inline]
+    fn len(&self) -> usize {
+        self.v.len() / self.chunk_size
+    }
+
+    #[inline]
     fn is_empty(&self) -> bool {
         self.v.is_empty()
     }
@@ -2899,7 +2945,7 @@ impl<'a, T> Iterator for RChunksExactMut<'a, T> {
 
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let n = self.v.len() / self.chunk_size;
+        let n = self.len();
         (n, Some(n))
     }
 
@@ -2976,6 +3022,12 @@ impl<'a, T> DoubleEndedIterator for RChunksExactMut<'a, T> {
 
 #[stable(feature = "rchunks", since = "1.31.0")]
 impl<T> ExactSizeIterator for RChunksExactMut<'_, T> {
+    #[inline]
+    fn len(&self) -> usize {
+        self.v.len() / self.chunk_size
+    }
+
+    #[inline]
     fn is_empty(&self) -> bool {
         self.v.is_empty()
     }


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

The default `ExactSizeIterator` calls `self.size_hint()` and then performs an assertion that the size hint's lower and higher bounds are equal, which is wasteful.

I'm sure the compiler/LLVM can elide that assertion in most cases (e.g. when the `size_hint` impl returns something like `(n, Some(n))`, but it still might affect inlining decisions, and maybe even cause LLVM to have to work harder.

There are a lot of changes here, some of which are not as clear-cut as others, so first I wanna see if this has any perf impact.