### PR TITLE
add back LLVM-specific funnel shift implementation

### DIFF
--- a/compiler/rustc_codegen_llvm/src/intrinsic.rs
+++ b/compiler/rustc_codegen_llvm/src/intrinsic.rs
@@ -401,6 +401,8 @@ impl<'ll, 'tcx> IntrinsicCallBuilderMethods<'tcx> for Builder<'_, 'll, 'tcx> {
             | sym::ctpop
             | sym::bswap
             | sym::bitreverse
+            | sym::rotate_left
+            | sym::rotate_right
             | sym::saturating_add
             | sym::saturating_sub
             | sym::unchecked_funnel_shl
@@ -445,11 +447,19 @@ impl<'ll, 'tcx> IntrinsicCallBuilderMethods<'tcx> for Builder<'_, 'll, 'tcx> {
                     sym::bitreverse => {
                         self.call_intrinsic("llvm.bitreverse", &[llty], &[args[0].immediate()])
                     }
-                    sym::unchecked_funnel_shl | sym::unchecked_funnel_shr => {
-                        let is_left = name == sym::unchecked_funnel_shl;
+                    sym::rotate_left
+                    | sym::rotate_right
+                    | sym::unchecked_funnel_shl
+                    | sym::unchecked_funnel_shr => {
+                        let is_left = name == sym::rotate_left || name == sym::unchecked_funnel_shl;
                         let lhs = args[0].immediate();
-                        let rhs = args[1].immediate();
-                        let raw_shift = args[2].immediate();
+                        let (rhs, raw_shift) =
+                            if name == sym::rotate_left || name == sym::rotate_right {
+                                // rotate = funnel shift with first two args the same
+                                (lhs, args[1].immediate())
+                            } else {
+                                (args[1].immediate(), args[2].immediate())
+                            };
                         let llvm_name = format!("llvm.fsh{}", if is_left { 'l' } else { 'r' });
 
                         // llvm expects shift to be the same type as the values, but rust

--- a/tests/codegen-llvm/intrinsics/rotate_left.rs
+++ b/tests/codegen-llvm/intrinsics/rotate_left.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: -O
+//@ compile-flags: -C no-prepopulate-passes
 
 #![crate_type = "lib"]
 #![feature(core_intrinsics)]
@@ -9,7 +9,7 @@ use std::intrinsics::rotate_left;
 #[no_mangle]
 pub unsafe fn rotate_left_u16(x: u16, shift: u32) -> u16 {
     // CHECK: %[[tmp:.*]] = trunc i32 %shift to i16
-    // CHECK: call noundef i16 @llvm.fshl.i16(i16 %x, i16 %x, i16 %[[tmp]])
+    // CHECK: call i16 @llvm.fshl.i16(i16 %x, i16 %x, i16 %[[tmp]])
     rotate_left(x, shift)
 }
 
@@ -18,7 +18,7 @@ pub unsafe fn rotate_left_u16(x: u16, shift: u32) -> u16 {
 pub unsafe fn rotate_left_u32(x: u32, shift: u32) -> u32 {
     // CHECK-NOT: trunc
     // CHECK-NOT: zext
-    // CHECK: call noundef i32 @llvm.fshl.i32(i32 %x, i32 %x, i32 %shift)
+    // CHECK: call i32 @llvm.fshl.i32(i32 %x, i32 %x, i32 %shift)
     rotate_left(x, shift)
 }
 
@@ -26,6 +26,6 @@ pub unsafe fn rotate_left_u32(x: u32, shift: u32) -> u32 {
 #[no_mangle]
 pub unsafe fn rotate_left_u64(x: u64, shift: u32) -> u64 {
     // CHECK: %[[tmp:.*]] = zext i32 %shift to i64
-    // CHECK: call noundef i64 @llvm.fshl.i64(i64 %x, i64 %x, i64 %[[tmp]])
+    // CHECK: call i64 @llvm.fshl.i64(i64 %x, i64 %x, i64 %[[tmp]])
     rotate_left(x, shift)
 }


### PR DESCRIPTION
This reverts commit a00db66b007ebee4815c9d821b39c5ba2a83df08. That commit is likely the culprit for the unexpected perf regression in https://github.com/rust-lang/rust/pull/148478; let's see if reverting it helps.
