### PR TITLE
add regression test for guard patterns liveness ICE

### DIFF
--- a/tests/ui/pattern/rfc-3637-guard-patterns/liveness-ice-issue-146445.rs
+++ b/tests/ui/pattern/rfc-3637-guard-patterns/liveness-ice-issue-146445.rs
@@ -1,0 +1,21 @@
+//@ check-pass
+//! Regression test for issue #146445.
+//!
+//! This test ensures that liveness linting works correctly with guard patterns
+//! and doesn't cause an ICE ("no successor") when using variables without
+//! underscore prefixes in guard expressions.
+//!
+//! Fixed by #142390 which moved liveness analysis to MIR.
+
+#![feature(guard_patterns)]
+#![expect(incomplete_features)]
+
+fn main() {
+    // This used to ICE before liveness analysis was moved to MIR.
+    // The variable `main` (without underscore prefix) would trigger
+    // liveness linting which wasn't properly implemented for guard patterns.
+    match (0,) {
+        (_ if { let main = false; main },) => {}
+        _ => {}
+    }
+}


### PR DESCRIPTION
closes rust-lang/rust#146445 
