### PR TITLE
float::minimum/maximum: say which exact IEEE operation this corresponds to

### DIFF
--- a/library/core/src/num/f128.rs
+++ b/library/core/src/num/f128.rs
@@ -695,8 +695,8 @@ impl f128 {
     /// Returns the maximum of the two numbers, ignoring NaN.
     ///
     /// If one of the arguments is NaN, then the other argument is returned.
-    /// This follows the IEEE 754-2008 semantics for maxNum, except for handling of signaling NaNs;
-    /// this function handles all NaNs the same way and avoids maxNum's problems with associativity.
+    /// This follows the IEEE 754-2008 semantics for `maxNum`, except for handling of signaling NaNs;
+    /// this function handles all NaNs the same way and avoids `maxNum`'s problems with associativity.
     /// This also matches the behavior of libm’s fmax. In particular, if the inputs compare equal
     /// (such as for the case of `+0.0` and `-0.0`), either input may be returned non-deterministically.
     ///
@@ -723,8 +723,8 @@ impl f128 {
     /// Returns the minimum of the two numbers, ignoring NaN.
     ///
     /// If one of the arguments is NaN, then the other argument is returned.
-    /// This follows the IEEE 754-2008 semantics for minNum, except for handling of signaling NaNs;
-    /// this function handles all NaNs the same way and avoids minNum's problems with associativity.
+    /// This follows the IEEE 754-2008 semantics for `minNum`, except for handling of signaling NaNs;
+    /// this function handles all NaNs the same way and avoids `minNum`'s problems with associativity.
     /// This also matches the behavior of libm’s fmin. In particular, if the inputs compare equal
     /// (such as for the case of `+0.0` and `-0.0`), either input may be returned non-deterministically.
     ///
@@ -769,7 +769,7 @@ impl f128 {
     ///
     /// If one of the arguments is NaN, then NaN is returned. Otherwise this returns the greater
     /// of the two numbers. For this operation, -0.0 is considered to be less than +0.0.
-    /// Note that this follows the semantics specified in IEEE 754-2019.
+    /// Note that this follows the IEEE 754-2019 semantics for `maximum`.
     ///
     /// Also note that "propagation" of NaNs here doesn't necessarily mean that the bitpattern of a NaN
     /// operand is conserved; see the [specification of NaN bit patterns](f32#nan-bit-patterns) for more info.
@@ -802,7 +802,7 @@ impl f128 {
     ///
     /// If one of the arguments is NaN, then NaN is returned. Otherwise this returns the lesser
     /// of the two numbers. For this operation, -0.0 is considered to be less than +0.0.
-    /// Note that this follows the semantics specified in IEEE 754-2019.
+    /// Note that this follows the IEEE 754-2019 semantics for `minimum`.
     ///
     /// Also note that "propagation" of NaNs here doesn't necessarily mean that the bitpattern of a NaN
     /// operand is conserved; see the [specification of NaN bit patterns](f32#nan-bit-patterns) for more info.

--- a/library/core/src/num/f16.rs
+++ b/library/core/src/num/f16.rs
@@ -688,8 +688,8 @@ impl f16 {
     /// Returns the maximum of the two numbers, ignoring NaN.
     ///
     /// If one of the arguments is NaN, then the other argument is returned.
-    /// This follows the IEEE 754-2008 semantics for maxNum, except for handling of signaling NaNs;
-    /// this function handles all NaNs the same way and avoids maxNum's problems with associativity.
+    /// This follows the IEEE 754-2008 semantics for `maxNum`, except for handling of signaling NaNs;
+    /// this function handles all NaNs the same way and avoids `maxNum`'s problems with associativity.
     /// This also matches the behavior of libm’s fmax. In particular, if the inputs compare equal
     /// (such as for the case of `+0.0` and `-0.0`), either input may be returned non-deterministically.
     ///
@@ -715,8 +715,8 @@ impl f16 {
     /// Returns the minimum of the two numbers, ignoring NaN.
     ///
     /// If one of the arguments is NaN, then the other argument is returned.
-    /// This follows the IEEE 754-2008 semantics for minNum, except for handling of signaling NaNs;
-    /// this function handles all NaNs the same way and avoids minNum's problems with associativity.
+    /// This follows the IEEE 754-2008 semantics for `minNum`, except for handling of signaling NaNs;
+    /// this function handles all NaNs the same way and avoids `minNum`'s problems with associativity.
     /// This also matches the behavior of libm’s fmin. In particular, if the inputs compare equal
     /// (such as for the case of `+0.0` and `-0.0`), either input may be returned non-deterministically.
     ///
@@ -759,7 +759,7 @@ impl f16 {
     ///
     /// If one of the arguments is NaN, then NaN is returned. Otherwise this returns the greater
     /// of the two numbers. For this operation, -0.0 is considered to be less than +0.0.
-    /// Note that this follows the semantics specified in IEEE 754-2019.
+    /// Note that this follows the IEEE 754-2019 semantics for `maximum`.
     ///
     /// Also note that "propagation" of NaNs here doesn't necessarily mean that the bitpattern of a NaN
     /// operand is conserved; see the [specification of NaN bit patterns](f32#nan-bit-patterns) for more info.
@@ -791,7 +791,7 @@ impl f16 {
     ///
     /// If one of the arguments is NaN, then NaN is returned. Otherwise this returns the lesser
     /// of the two numbers. For this operation, -0.0 is considered to be less than +0.0.
-    /// Note that this follows the semantics specified in IEEE 754-2019.
+    /// Note that this follows the IEEE 754-2019 semantics for `minimum`.
     ///
     /// Also note that "propagation" of NaNs here doesn't necessarily mean that the bitpattern of a NaN
     /// operand is conserved; see the [specification of NaN bit patterns](f32#nan-bit-patterns) for more info.

--- a/library/core/src/num/f32.rs
+++ b/library/core/src/num/f32.rs
@@ -898,8 +898,8 @@ impl f32 {
     /// Returns the maximum of the two numbers, ignoring NaN.
     ///
     /// If one of the arguments is NaN, then the other argument is returned.
-    /// This follows the IEEE 754-2008 semantics for maxNum, except for handling of signaling NaNs;
-    /// this function handles all NaNs the same way and avoids maxNum's problems with associativity.
+    /// This follows the IEEE 754-2008 semantics for `maxNum`, except for handling of signaling NaNs;
+    /// this function handles all NaNs the same way and avoids `maxNum`'s problems with associativity.
     /// This also matches the behavior of libm’s fmax. In particular, if the inputs compare equal
     /// (such as for the case of `+0.0` and `-0.0`), either input may be returned non-deterministically.
     ///
@@ -921,8 +921,8 @@ impl f32 {
     /// Returns the minimum of the two numbers, ignoring NaN.
     ///
     /// If one of the arguments is NaN, then the other argument is returned.
-    /// This follows the IEEE 754-2008 semantics for minNum, except for handling of signaling NaNs;
-    /// this function handles all NaNs the same way and avoids minNum's problems with associativity.
+    /// This follows the IEEE 754-2008 semantics for `minNum`, except for handling of signaling NaNs;
+    /// this function handles all NaNs the same way and avoids `minNum`'s problems with associativity.
     /// This also matches the behavior of libm’s fmin. In particular, if the inputs compare equal
     /// (such as for the case of `+0.0` and `-0.0`), either input may be returned non-deterministically.
     ///
@@ -957,7 +957,7 @@ impl f32 {
     ///
     /// If one of the arguments is NaN, then NaN is returned. Otherwise this returns the greater
     /// of the two numbers. For this operation, -0.0 is considered to be less than +0.0.
-    /// Note that this follows the semantics specified in IEEE 754-2019.
+    /// Note that this follows the IEEE 754-2019 semantics for `maximum`.
     ///
     /// Also note that "propagation" of NaNs here doesn't necessarily mean that the bitpattern of a NaN
     /// operand is conserved; see the [specification of NaN bit patterns](f32#nan-bit-patterns) for more info.
@@ -984,7 +984,7 @@ impl f32 {
     ///
     /// If one of the arguments is NaN, then NaN is returned. Otherwise this returns the lesser
     /// of the two numbers. For this operation, -0.0 is considered to be less than +0.0.
-    /// Note that this follows the semantics specified in IEEE 754-2019.
+    /// Note that this follows the IEEE 754-2019 semantics for `minimum`.
     ///
     /// Also note that "propagation" of NaNs here doesn't necessarily mean that the bitpattern of a NaN
     /// operand is conserved; see the [specification of NaN bit patterns](f32#nan-bit-patterns) for more info.

--- a/library/core/src/num/f64.rs
+++ b/library/core/src/num/f64.rs
@@ -916,8 +916,8 @@ impl f64 {
     /// Returns the maximum of the two numbers, ignoring NaN.
     ///
     /// If one of the arguments is NaN, then the other argument is returned.
-    /// This follows the IEEE 754-2008 semantics for maxNum, except for handling of signaling NaNs;
-    /// this function handles all NaNs the same way and avoids maxNum's problems with associativity.
+    /// This follows the IEEE 754-2008 semantics for `maxNum`, except for handling of signaling NaNs;
+    /// this function handles all NaNs the same way and avoids `maxNum`'s problems with associativity.
     /// This also matches the behavior of libm’s fmax. In particular, if the inputs compare equal
     /// (such as for the case of `+0.0` and `-0.0`), either input may be returned non-deterministically.
     ///
@@ -939,8 +939,8 @@ impl f64 {
     /// Returns the minimum of the two numbers, ignoring NaN.
     ///
     /// If one of the arguments is NaN, then the other argument is returned.
-    /// This follows the IEEE 754-2008 semantics for minNum, except for handling of signaling NaNs;
-    /// this function handles all NaNs the same way and avoids minNum's problems with associativity.
+    /// This follows the IEEE 754-2008 semantics for `minNum`, except for handling of signaling NaNs;
+    /// this function handles all NaNs the same way and avoids `minNum`'s problems with associativity.
     /// This also matches the behavior of libm’s fmin. In particular, if the inputs compare equal
     /// (such as for the case of `+0.0` and `-0.0`), either input may be returned non-deterministically.
     ///
@@ -975,7 +975,7 @@ impl f64 {
     ///
     /// If one of the arguments is NaN, then NaN is returned. Otherwise this returns the greater
     /// of the two numbers. For this operation, -0.0 is considered to be less than +0.0.
-    /// Note that this follows the semantics specified in IEEE 754-2019.
+    /// Note that this follows the IEEE 754-2019 semantics for `maximum`.
     ///
     /// Also note that "propagation" of NaNs here doesn't necessarily mean that the bitpattern of a NaN
     /// operand is conserved; see the [specification of NaN bit patterns](f32#nan-bit-patterns) for more info.
@@ -1002,7 +1002,7 @@ impl f64 {
     ///
     /// If one of the arguments is NaN, then NaN is returned. Otherwise this returns the lesser
     /// of the two numbers. For this operation, -0.0 is considered to be less than +0.0.
-    /// Note that this follows the semantics specified in IEEE 754-2019.
+    /// Note that this follows the IEEE 754-2019 semantics for `minimum`.
     ///
     /// Also note that "propagation" of NaNs here doesn't necessarily mean that the bitpattern of a NaN
     /// operand is conserved; see the [specification of NaN bit patterns](f32#nan-bit-patterns) for more info.


### PR DESCRIPTION
There's both `minimum` and `minimumNumber`, so this seems worth clarifying.

Also use code font for these names to make it more clear that they are technical terms.