### PR TITLE
unstable proc_macro tracked::* rename/restructure

### DIFF
--- a/compiler/rustc_fluent_macro/src/fluent.rs
+++ b/compiler/rustc_fluent_macro/src/fluent.rs
@@ -8,6 +8,9 @@ use fluent_syntax::ast::{
     Attribute, Entry, Expression, Identifier, InlineExpression, Message, Pattern, PatternElement,
 };
 use fluent_syntax::parser::ParserError;
+#[cfg(not(bootstrap))]
+use proc_macro::tracked::path;
+#[cfg(bootstrap)]
 use proc_macro::tracked_path::path;
 use proc_macro::{Diagnostic, Level, Span};
 use proc_macro2::TokenStream;

--- a/compiler/rustc_fluent_macro/src/lib.rs
+++ b/compiler/rustc_fluent_macro/src/lib.rs
@@ -1,7 +1,8 @@
 // tidy-alphabetical-start
 #![allow(rustc::default_hash_types)]
+#![cfg_attr(bootstrap, feature(track_path))]
+#![cfg_attr(not(bootstrap), feature(proc_macro_tracked_path))]
 #![feature(proc_macro_diagnostic)]
-#![feature(track_path)]
 // tidy-alphabetical-end
 
 use proc_macro::TokenStream;

--- a/compiler/rustc_macros/src/current_version.rs
+++ b/compiler/rustc_macros/src/current_version.rs
@@ -22,7 +22,11 @@ struct RustcVersion {
 
 impl RustcVersion {
     fn parse_cfg_release(env_var: &str) -> Result<Self, Box<dyn std::error::Error>> {
+        #[cfg(not(bootstrap))]
+        let value = proc_macro::tracked::env_var(env_var)?;
+        #[cfg(bootstrap)]
         let value = proc_macro::tracked_env::var(env_var)?;
+
         Self::parse_str(&value)
             .ok_or_else(|| format!("failed to parse rustc version: {:?}", value).into())
     }

--- a/compiler/rustc_macros/src/symbols.rs
+++ b/compiler/rustc_macros/src/symbols.rs
@@ -259,7 +259,13 @@ fn symbols_with_errors(input: TokenStream) -> (TokenStream, Vec<syn::Error>) {
             break;
         }
 
-        let value = match proc_macro::tracked_env::var(env_var.value()) {
+        #[cfg(bootstrap)]
+        let tracked_env = proc_macro::tracked_env::var(env_var.value());
+
+        #[cfg(not(bootstrap))]
+        let tracked_env = proc_macro::tracked::env_var(env_var.value());
+
+        let value = match tracked_env {
             Ok(value) => value,
             Err(err) => {
                 errors.list.push(syn::Error::new_spanned(expr, err));

--- a/library/proc_macro/src/lib.rs
+++ b/library/proc_macro/src/lib.rs
@@ -1594,9 +1594,14 @@ impl fmt::Debug for Literal {
     }
 }
 
-/// Tracked access to environment variables.
-#[unstable(feature = "proc_macro_tracked_env", issue = "99515")]
-pub mod tracked_env {
+#[unstable(
+    feature = "proc_macro_tracked_path",
+    issue = "99515",
+    implied_by = "proc_macro_tracked_env"
+)]
+/// Functionality for adding environment state to the build dependency info.
+pub mod tracked {
+
     use std::env::{self, VarError};
     use std::ffi::OsStr;
 
@@ -1606,23 +1611,18 @@ pub mod tracked_env {
     /// Besides the dependency tracking this function should be equivalent to `env::var` from the
     /// standard library, except that the argument must be UTF-8.
     #[unstable(feature = "proc_macro_tracked_env", issue = "99515")]
-    pub fn var<K: AsRef<OsStr> + AsRef<str>>(key: K) -> Result<String, VarError> {
+    pub fn env_var<K: AsRef<OsStr> + AsRef<str>>(key: K) -> Result<String, VarError> {
         let key: &str = key.as_ref();
         let value = crate::bridge::client::FreeFunctions::injected_env_var(key)
             .map_or_else(|| env::var(key), Ok);
         crate::bridge::client::FreeFunctions::track_env_var(key, value.as_deref().ok());
         value
     }
-}
 
-/// Tracked access to additional files.
-#[unstable(feature = "track_path", issue = "99515")]
-pub mod tracked_path {
-
-    /// Track a file explicitly.
+    /// Track a file or directory explicitly.
     ///
     /// Commonly used for tracking asset preprocessing.
-    #[unstable(feature = "track_path", issue = "99515")]
+    #[unstable(feature = "proc_macro_tracked_path", issue = "99515")]
     pub fn path<P: AsRef<str>>(path: P) {
         let path: &str = path.as_ref();
         crate::bridge::client::FreeFunctions::track_path(path);

--- a/library/proc_macro/src/lib.rs
+++ b/library/proc_macro/src/lib.rs
@@ -1604,6 +1604,7 @@ pub mod tracked {
 
     use std::env::{self, VarError};
     use std::ffi::OsStr;
+    use std::path::Path;
 
     /// Retrieve an environment variable and add it to build dependency info.
     /// The build system executing the compiler will know that the variable was accessed during
@@ -1623,8 +1624,8 @@ pub mod tracked {
     ///
     /// Commonly used for tracking asset preprocessing.
     #[unstable(feature = "proc_macro_tracked_path", issue = "99515")]
-    pub fn path<P: AsRef<str>>(path: P) {
-        let path: &str = path.as_ref();
+    pub fn path<P: AsRef<Path>>(path: P) {
+        let path: &str = path.as_ref().to_str().unwrap();
         crate::bridge::client::FreeFunctions::track_path(path);
     }
 }

--- a/tests/run-make/env-dep-info/macro_def.rs
+++ b/tests/run-make/env-dep-info/macro_def.rs
@@ -6,7 +6,7 @@ use proc_macro::*;
 
 #[proc_macro]
 pub fn access_env_vars(_: TokenStream) -> TokenStream {
-    let _ = tracked_env::var("EXISTING_PROC_MACRO_ENV");
-    let _ = tracked_env::var("NONEXISTENT_PROC_MACEO_ENV");
+    let _ = tracked::env_var("EXISTING_PROC_MACRO_ENV");
+    let _ = tracked::env_var("NONEXISTENT_PROC_MACEO_ENV");
     TokenStream::new()
 }

--- a/tests/run-make/track-path-dep-info/macro_def.rs
+++ b/tests/run-make/track-path-dep-info/macro_def.rs
@@ -1,4 +1,4 @@
-#![feature(track_path)]
+#![feature(proc_macro_track_path)]
 #![crate_type = "proc-macro"]
 
 extern crate proc_macro;
@@ -6,6 +6,6 @@ use proc_macro::*;
 
 #[proc_macro]
 pub fn access_tracked_paths(_: TokenStream) -> TokenStream {
-    tracked_path::path("emojis.txt");
+    tracked::path("emojis.txt");
     TokenStream::new()
 }

--- a/tests/run-make/track-path-dep-info/macro_def.rs
+++ b/tests/run-make/track-path-dep-info/macro_def.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_track_path)]
+#![feature(proc_macro_tracked_path)]
 #![crate_type = "proc-macro"]
 
 extern crate proc_macro;

--- a/tests/ui/proc-macro/auxiliary/env.rs
+++ b/tests/ui/proc-macro/auxiliary/env.rs
@@ -3,11 +3,11 @@
 extern crate proc_macro;
 
 use proc_macro::TokenStream;
-use proc_macro::tracked_env::var;
+use proc_macro::tracked::env_var;
 
 #[proc_macro]
 pub fn generate_const(input: TokenStream) -> TokenStream {
-    let the_const = match var("THE_CONST") {
+    let the_const = match env_var("THE_CONST") {
         Ok(x) if x == "12" => {
             "const THE_CONST: u32 = 12;"
         }
@@ -15,7 +15,7 @@ pub fn generate_const(input: TokenStream) -> TokenStream {
             "const THE_CONST: u32 = 0;"
         }
     };
-    let another = if var("ANOTHER").is_ok() {
+    let another = if env_var("ANOTHER").is_ok() {
         "const ANOTHER: u32 = 1;"
     } else {
         "const ANOTHER: u32 = 2;"


### PR DESCRIPTION
Picking up what should be the uncontroversial part of rust-lang/rust#87173 (closed due to inactivity over two years ago).

Part of rust-lang/rust#99515.

- move `proc_macro::tracked_env::var` to `proc_macro::tracked::env_var`
- move `proc_macro::tracked_path::path` to `proc_macro::tracked::path`
- change the argument of `proc_macro::tracked::path` from `AsRef<str>` to `AsRef<Path>`.
