### PR TITLE
Fix `name()` functions for local defs in rustc_public

### DIFF
--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -105,7 +105,7 @@ define_helper!(
     ///
     /// Overrides `with_crate_prefix`.
 
-    // This function is not currently used in-tree, but it's used by a downstream rustc-driver in
+    // This function is used by `rustc_public` and downstream rustc-driver in
     // Ferrocene. Please check with them before removing it.
     fn with_resolve_crate_name(CrateNamePrefixGuard, SHOULD_PREFIX_WITH_CRATE_NAME);
     /// Adds the `crate::` prefix to paths where appropriate.

--- a/compiler/rustc_public/src/lib.rs
+++ b/compiler/rustc_public/src/lib.rs
@@ -178,7 +178,7 @@ impl CrateItem {
     pub fn emit_mir<W: io::Write>(&self, w: &mut W) -> io::Result<()> {
         self.body()
             .ok_or_else(|| io::Error::other(format!("No body found for `{}`", self.name())))?
-            .dump(w, &self.name())
+            .dump(w, &self.trimmed_name())
     }
 }
 

--- a/compiler/rustc_public/src/mir/pretty.rs
+++ b/compiler/rustc_public/src/mir/pretty.rs
@@ -412,7 +412,7 @@ fn pretty_aggregate<W: Write>(
         }
         AggregateKind::Adt(def, var, _, _, _) => {
             if def.kind() == AdtKind::Enum {
-                write!(writer, "{}::{}", def.name(), def.variant(*var).unwrap().name())?;
+                write!(writer, "{}::{}", def.trimmed_name(), def.variant(*var).unwrap().name())?;
             } else {
                 write!(writer, "{}", def.variant(*var).unwrap().name())?;
             }

--- a/compiler/rustc_public/src/ty.rs
+++ b/compiler/rustc_public/src/ty.rs
@@ -876,6 +876,9 @@ pub struct VariantDef {
 }
 
 impl VariantDef {
+    /// The name of the variant, struct or union.
+    ///
+    /// This will not include the name of the enum or qualified path.
     pub fn name(&self) -> Symbol {
         with(|cx| cx.variant_name(*self))
     }

--- a/compiler/rustc_public_bridge/src/context/impls.rs
+++ b/compiler/rustc_public_bridge/src/context/impls.rs
@@ -10,7 +10,7 @@ use rustc_hir::{Attribute, LangItem};
 use rustc_middle::mir::interpret::{AllocId, ConstAllocation, ErrorHandled, GlobalAlloc, Scalar};
 use rustc_middle::mir::{BinOp, Body, Const as MirConst, ConstValue, UnOp};
 use rustc_middle::ty::layout::{FnAbiOf, LayoutOf};
-use rustc_middle::ty::print::{with_forced_trimmed_paths, with_no_trimmed_paths};
+use rustc_middle::ty::print::{with_forced_trimmed_paths, with_resolve_crate_name};
 use rustc_middle::ty::util::Discr;
 use rustc_middle::ty::{
     AdtDef, AdtKind, AssocItem, Binder, ClosureKind, CoroutineArgsExt, EarlyBinder,
@@ -264,7 +264,8 @@ impl<'tcx, B: Bridge> CompilerCtxt<'tcx, B> {
         if trimmed {
             with_forced_trimmed_paths!(self.tcx.def_path_str(def_id))
         } else {
-            with_no_trimmed_paths!(self.tcx.def_path_str(def_id))
+            // For local definitions, we need to prepend with crate name.
+            with_resolve_crate_name!(self.tcx.def_path_str(def_id))
         }
     }
 
@@ -724,7 +725,7 @@ impl<'tcx, B: Bridge> CompilerCtxt<'tcx, B> {
                 self.tcx.def_path_str_with_args(instance.def_id(), instance.args)
             )
         } else {
-            with_no_trimmed_paths!(
+            with_resolve_crate_name!(
                 self.tcx.def_path_str_with_args(instance.def_id(), instance.args)
             )
         }

--- a/compiler/rustc_public_bridge/src/context/impls.rs
+++ b/compiler/rustc_public_bridge/src/context/impls.rs
@@ -10,7 +10,9 @@ use rustc_hir::{Attribute, LangItem};
 use rustc_middle::mir::interpret::{AllocId, ConstAllocation, ErrorHandled, GlobalAlloc, Scalar};
 use rustc_middle::mir::{BinOp, Body, Const as MirConst, ConstValue, UnOp};
 use rustc_middle::ty::layout::{FnAbiOf, LayoutOf};
-use rustc_middle::ty::print::{with_forced_trimmed_paths, with_resolve_crate_name};
+use rustc_middle::ty::print::{
+    with_forced_trimmed_paths, with_no_trimmed_paths, with_resolve_crate_name,
+};
 use rustc_middle::ty::util::Discr;
 use rustc_middle::ty::{
     AdtDef, AdtKind, AssocItem, Binder, ClosureKind, CoroutineArgsExt, EarlyBinder,
@@ -265,7 +267,7 @@ impl<'tcx, B: Bridge> CompilerCtxt<'tcx, B> {
             with_forced_trimmed_paths!(self.tcx.def_path_str(def_id))
         } else {
             // For local definitions, we need to prepend with crate name.
-            with_resolve_crate_name!(self.tcx.def_path_str(def_id))
+            with_resolve_crate_name!(with_no_trimmed_paths!(self.tcx.def_path_str(def_id)))
         }
     }
 
@@ -725,9 +727,9 @@ impl<'tcx, B: Bridge> CompilerCtxt<'tcx, B> {
                 self.tcx.def_path_str_with_args(instance.def_id(), instance.args)
             )
         } else {
-            with_resolve_crate_name!(
+            with_resolve_crate_name!(with_no_trimmed_paths!(
                 self.tcx.def_path_str_with_args(instance.def_id(), instance.args)
-            )
+            ))
         }
     }
 

--- a/tests/ui-fulldeps/rustc_public/check_abi.rs
+++ b/tests/ui-fulldeps/rustc_public/check_abi.rs
@@ -9,10 +9,10 @@
 #![feature(assert_matches)]
 #![feature(ascii_char, ascii_char_variants)]
 
-extern crate rustc_hir;
-extern crate rustc_middle;
 extern crate rustc_driver;
+extern crate rustc_hir;
 extern crate rustc_interface;
+extern crate rustc_middle;
 #[macro_use]
 extern crate rustc_public;
 
@@ -39,7 +39,7 @@ fn test_stable_mir() -> ControlFlow<()> {
     let items = rustc_public::all_local_items();
 
     // Test fn_abi
-    let target_fn = *get_item(&items, (ItemKind::Fn, "fn_abi")).unwrap();
+    let target_fn = *get_item(&items, (ItemKind::Fn, "input::fn_abi")).unwrap();
     let instance = Instance::try_from(target_fn).unwrap();
     let fn_abi = instance.fn_abi().unwrap();
     assert_eq!(fn_abi.conv, CallConvention::Rust);
@@ -51,11 +51,11 @@ fn test_stable_mir() -> ControlFlow<()> {
     check_result(&fn_abi.ret);
 
     // Test variadic function.
-    let variadic_fn = *get_item(&items, (ItemKind::Fn, "variadic_fn")).unwrap();
+    let variadic_fn = *get_item(&items, (ItemKind::Fn, "input::variadic_fn")).unwrap();
     check_variadic(variadic_fn);
 
     // Extract function pointers.
-    let fn_ptr_holder = *get_item(&items, (ItemKind::Fn, "fn_ptr_holder")).unwrap();
+    let fn_ptr_holder = *get_item(&items, (ItemKind::Fn, "input::fn_ptr_holder")).unwrap();
     let fn_ptr_holder_instance = Instance::try_from(fn_ptr_holder).unwrap();
     let body = fn_ptr_holder_instance.body().unwrap();
     let args = body.arg_locals();

--- a/tests/ui-fulldeps/rustc_public/check_allocation.rs
+++ b/tests/ui-fulldeps/rustc_public/check_allocation.rs
@@ -40,11 +40,11 @@ const CRATE_NAME: &str = "input";
 fn test_stable_mir() -> ControlFlow<()> {
     // Find items in the local crate.
     let items = rustc_public::all_local_items();
-    check_foo(*get_item(&items, (ItemKind::Static, "FOO")).unwrap());
-    check_bar(*get_item(&items, (ItemKind::Static, "BAR")).unwrap());
-    check_len(*get_item(&items, (ItemKind::Static, "LEN")).unwrap());
-    check_cstr(*get_item(&items, (ItemKind::Static, "C_STR")).unwrap());
-    check_other_consts(*get_item(&items, (ItemKind::Fn, "other_consts")).unwrap());
+    check_foo(*get_item(&items, (ItemKind::Static, "input::FOO")).unwrap());
+    check_bar(*get_item(&items, (ItemKind::Static, "input::BAR")).unwrap());
+    check_len(*get_item(&items, (ItemKind::Static, "input::LEN")).unwrap());
+    check_cstr(*get_item(&items, (ItemKind::Static, "input::C_STR")).unwrap());
+    check_other_consts(*get_item(&items, (ItemKind::Fn, "input::other_consts")).unwrap());
     ControlFlow::Continue(())
 }
 

--- a/tests/ui-fulldeps/rustc_public/check_assoc_items.rs
+++ b/tests/ui-fulldeps/rustc_public/check_assoc_items.rs
@@ -77,7 +77,7 @@ fn test_assoc_items() -> ControlFlow<()> {
 /// Note that order doesn't matter.
 fn check_items<T: CrateDef>(items: &[T], expected: &[&str]) {
     let expected: HashSet<_> = expected.iter().map(|s| s.to_string()).collect();
-    let item_names: HashSet<_> = items.iter().map(|item| item.name()).collect();
+    let item_names: HashSet<_> = items.iter().map(|item| item.trimmed_name()).collect();
     assert_eq!(item_names, expected);
 }
 

--- a/tests/ui-fulldeps/rustc_public/check_attribute.rs
+++ b/tests/ui-fulldeps/rustc_public/check_attribute.rs
@@ -38,16 +38,13 @@ fn test_tool(items: &CrateItems) {
     assert_eq!(rustfmt_attrs[0].as_str(), "#[rustfmt::skip]\n");
 
     let clippy_fn = *get_item(&items, "complex_fn").unwrap();
-    let clippy_attrs = clippy_fn.tool_attrs(&["clippy".to_string(),
-                                               "cyclomatic_complexity".to_string()]);
+    let clippy_attrs =
+        clippy_fn.tool_attrs(&["clippy".to_string(), "cyclomatic_complexity".to_string()]);
     assert_eq!(clippy_attrs[0].as_str(), "#[clippy::cyclomatic_complexity = \"100\"]\n");
 }
 
-fn get_item<'a>(
-    items: &'a CrateItems,
-    name: &str,
-) -> Option<&'a rustc_public::CrateItem> {
-    items.iter().find(|crate_item| crate_item.name() == name)
+fn get_item<'a>(items: &'a CrateItems, name: &str) -> Option<&'a rustc_public::CrateItem> {
+    items.iter().find(|crate_item| crate_item.trimmed_name() == name)
 }
 
 /// This test will generate and analyze a dummy crate using the stable mir.

--- a/tests/ui-fulldeps/rustc_public/check_coroutine_body.rs
+++ b/tests/ui-fulldeps/rustc_public/check_coroutine_body.rs
@@ -29,11 +29,7 @@ fn test_coroutine_body() -> ControlFlow<()> {
     if let Some(body) = crate_items.iter().find_map(|item| {
         let item_ty = item.ty();
         if let TyKind::RigidTy(RigidTy::Coroutine(def, ..)) = &item_ty.kind() {
-            if def.0.name() == "gbc::{closure#0}".to_string() {
-                def.body()
-            } else {
-                None
-            }
+            if def.0.trimmed_name() == "gbc::{closure#0}".to_string() { def.body() } else { None }
         } else {
             None
         }
@@ -51,26 +47,23 @@ fn check_coroutine_body(body: Body) {
     let local_3 = &body.locals()[3].ty;
     let local_4 = &body.locals()[4].ty;
 
-    let TyKind::RigidTy(RigidTy::Adt(def, ..)) = &ret_ty.kind()
-    else {
+    let TyKind::RigidTy(RigidTy::Adt(def, ..)) = &ret_ty.kind() else {
         panic!("Expected RigidTy::Adt, got: {:#?}", ret_ty);
     };
 
     assert_eq!("std::task::Poll", def.0.name());
 
-    let TyKind::RigidTy(RigidTy::Coroutine(def, ..)) = &local_3.kind()
-    else {
+    let TyKind::RigidTy(RigidTy::Coroutine(def, ..)) = &local_3.kind() else {
         panic!("Expected RigidTy::Coroutine, got: {:#?}", local_3);
     };
 
-    assert_eq!("gbc::{closure#0}::{closure#0}", def.0.name());
+    assert_eq!("crate_coroutine_body::gbc::{closure#0}::{closure#0}", def.0.name());
 
-    let TyKind::RigidTy(RigidTy::Coroutine(def, ..)) = &local_4.kind()
-    else {
+    let TyKind::RigidTy(RigidTy::Coroutine(def, ..)) = &local_4.kind() else {
         panic!("Expected RigidTy::Coroutine, got: {:#?}", local_4);
     };
 
-    assert_eq!("gbc::{closure#0}::{closure#0}", def.0.name());
+    assert_eq!("crate_coroutine_body::gbc::{closure#0}::{closure#0}", def.0.name());
 }
 
 fn main() {

--- a/tests/ui-fulldeps/rustc_public/check_crate_defs.rs
+++ b/tests/ui-fulldeps/rustc_public/check_crate_defs.rs
@@ -27,17 +27,20 @@ const CRATE_NAME: &str = "crate_defs";
 fn test_stable_mir() -> ControlFlow<()> {
     // Find items in the local crate.
     let local = rustc_public::local_crate();
-    check_items(&local.statics(), &["PRIVATE_STATIC", "dummy::PUBLIC_STATIC"]);
+    check_items(
+        &local.statics(),
+        &["crate_defs::PRIVATE_STATIC", "crate_defs::dummy::PUBLIC_STATIC"],
+    );
     check_items(
         &local.fn_defs(),
         &[
-            "top_level",
-            "dummy::public_fn",
-            "dummy::private_fn",
-            "dummy::PrivateStruct::new",
-            "<dummy::PrivateStruct as std::ops::Drop>::drop",
-            "DummyTrait::method",
-            "<T as DummyTrait>::method",
+            "crate_defs::top_level",
+            "crate_defs::dummy::public_fn",
+            "crate_defs::dummy::private_fn",
+            "crate_defs::dummy::PrivateStruct::new",
+            "<crate_defs::dummy::PrivateStruct as std::ops::Drop>::drop",
+            "crate_defs::DummyTrait::method",
+            "<T as crate_defs::DummyTrait>::method",
         ],
     );
 

--- a/tests/ui-fulldeps/rustc_public/check_def_parent.rs
+++ b/tests/ui-fulldeps/rustc_public/check_def_parent.rs
@@ -47,44 +47,47 @@ fn test_stable_mir() -> ControlFlow<()> {
     let krate = rustc_public::local_crate();
     for it in rustc_public::all_local_items() {
         match &*it.0.name() {
-            "wrapper_mod::CONST_ITEM" => {
+            "input::wrapper_mod::CONST_ITEM" => {
                 set_once(&mut const_item, it.0);
             }
-            "wrapper_mod::STATIC_ITEM" => {
+            "input::wrapper_mod::STATIC_ITEM" => {
                 set_once(&mut static_item, it.0);
             }
-            "<wrapper_mod::MyStruct as wrapper_mod::MyTrait>::trait_method" => {
+            "<input::wrapper_mod::MyStruct as input::wrapper_mod::MyTrait>::trait_method" => {
                 set_once(&mut trait_method, it.0);
             }
-            "<wrapper_mod::MyStruct as wrapper_mod::MyTrait>::trait_method::trait_method_helper" => {
+            "<input::wrapper_mod::MyStruct as input::wrapper_mod::MyTrait>::trait_method::trait_method_helper" =>
+            {
                 set_once(&mut trait_method_helper, it.0);
             }
-            "wrapper_mod::MyStruct::inherent_method" => {
+            "input::wrapper_mod::MyStruct::inherent_method" => {
                 set_once(&mut inherent_method, it.0);
             }
-            "wrapper_mod::MyStruct::inherent_method::inherent_method_helper" => {
+            "input::wrapper_mod::MyStruct::inherent_method::inherent_method_helper" => {
                 set_once(&mut inherent_method_helper, it.0);
             }
-            "main" => {
+            "input::main" => {
                 set_once(&mut main, it.0);
             }
-            "wrapper_mod::MyStruct" => {
+            "input::wrapper_mod::MyStruct" => {
                 set_once(&mut mystruct_ctor, it.0);
                 mystruct_ctor_ty = Some(it.ty());
             }
-            _ => (),
+            name => panic!("Unexpected item: `{name}`"),
         }
     }
     for it in krate.trait_decls() {
         match &*it.0.name() {
-            "wrapper_mod::MyTrait" => set_once(&mut trait_decl, it.0),
+            "input::wrapper_mod::MyTrait" => set_once(&mut trait_decl, it.0),
             _ => (),
         }
     }
     for it in krate.trait_impls() {
         match &*it.0.name() {
-            "<wrapper_mod::MyStruct as wrapper_mod::MyTrait>" => set_once(&mut trait_impl, it.0),
-            _ => (),
+            "<input::wrapper_mod::MyStruct as input::wrapper_mod::MyTrait>" => {
+                set_once(&mut trait_impl, it.0)
+            }
+            name => panic!("Unexpected trait impl: `{name}`"),
         }
     }
 
@@ -106,9 +109,10 @@ fn test_stable_mir() -> ControlFlow<()> {
     let inherent_impl = inherent_method.parent().unwrap();
     let wrapper_mod = const_item.parent().unwrap();
     let crate_root = wrapper_mod.parent().unwrap();
-    assert_eq!(&*wrapper_mod.name(), "wrapper_mod");
+    assert_eq!(&*wrapper_mod.name(), "input::wrapper_mod");
 
     // Check that each def-id has the correct parent
+    assert_eq!(crate_root.name(), "input");
     assert_eq!(crate_root.parent(), None);
     assert_eq!(inherent_impl.parent(), Some(wrapper_mod));
     assert_eq!(const_item.parent(), Some(wrapper_mod));

--- a/tests/ui-fulldeps/rustc_public/check_def_ty.rs
+++ b/tests/ui-fulldeps/rustc_public/check_def_ty.rs
@@ -16,7 +16,7 @@ extern crate rustc_driver;
 extern crate rustc_interface;
 extern crate rustc_public;
 
-use rustc_public::ty::{Ty, ForeignItemKind};
+use rustc_public::ty::{ForeignItemKind, Ty};
 use rustc_public::*;
 use std::io::Write;
 use std::ops::ControlFlow;
@@ -29,11 +29,11 @@ fn test_def_tys() -> ControlFlow<()> {
     for item in &items {
         // Type from crate items.
         let ty = item.ty();
-        match item.name().as_str() {
+        match item.trimmed_name().as_str() {
             "STATIC_STR" => assert!(ty.kind().is_ref()),
             "CONST_U32" => assert!(ty.kind().is_integral()),
-            "main" => { check_fn_def(ty) }
-            _ => unreachable!("Unexpected item: `{item:?}`")
+            "main" => check_fn_def(ty),
+            _ => unreachable!("Unexpected item: `{item:?}`"),
         }
     }
 
@@ -42,7 +42,7 @@ fn test_def_tys() -> ControlFlow<()> {
         // Type from foreign items.
         let ty = item.ty();
         let item_kind = item.kind();
-        let name = item.name();
+        let name = item.trimmed_name();
         match item_kind {
             ForeignItemKind::Fn(fn_def) => {
                 assert_eq!(&name, "extern_fn");
@@ -54,7 +54,7 @@ fn test_def_tys() -> ControlFlow<()> {
                 assert_eq!(ty, def.ty());
                 assert!(ty.kind().is_integral())
             }
-            _ => unreachable!("Unexpected kind: {item_kind:?}")
+            _ => unreachable!("Unexpected kind: {item_kind:?}"),
         };
     }
 

--- a/tests/ui-fulldeps/rustc_public/check_foreign.rs
+++ b/tests/ui-fulldeps/rustc_public/check_foreign.rs
@@ -13,8 +13,8 @@ extern crate rustc_middle;
 
 extern crate rustc_driver;
 extern crate rustc_interface;
-extern crate rustc_span;
 extern crate rustc_public;
+extern crate rustc_span;
 
 use rustc_public::{
     ty::{Abi, ForeignItemKind},
@@ -40,7 +40,7 @@ fn test_foreign() -> ControlFlow<()> {
     assert_eq!(c_items.len(), 3);
     for item in c_items {
         let kind = item.kind();
-        match item.name().as_str() {
+        match item.trimmed_name().as_str() {
             "foo" => assert_matches!(kind, ForeignItemKind::Fn(..)),
             "bar" => assert_matches!(kind, ForeignItemKind::Static(..)),
             "Baz" => assert_matches!(kind, ForeignItemKind::Type(..)),

--- a/tests/ui-fulldeps/rustc_public/check_item_kind.rs
+++ b/tests/ui-fulldeps/rustc_public/check_item_kind.rs
@@ -27,7 +27,7 @@ fn test_item_kind() -> ControlFlow<()> {
     assert_eq!(items.len(), 4);
     // Constructor item.
     for item in items {
-        let expected_kind = match item.name().as_str() {
+        let expected_kind = match item.trimmed_name().as_str() {
             "Dummy" => ItemKind::Ctor(CtorKind::Fn),
             "dummy" => ItemKind::Fn,
             "unit" => ItemKind::Fn,

--- a/tests/ui-fulldeps/rustc_public/check_trait_queries.rs
+++ b/tests/ui-fulldeps/rustc_public/check_trait_queries.rs
@@ -28,19 +28,20 @@ fn test_traits() -> ControlFlow<()> {
     let local_crate = rustc_public::local_crate();
     let local_traits = local_crate.trait_decls();
     assert_eq!(local_traits.len(), 1, "Expected `Max` trait, but found {:?}", local_traits);
-    assert_eq!(&local_traits[0].name(), "Max");
+    assert_eq!(&local_traits[0].trimmed_name(), "Max");
 
     let local_impls = local_crate.trait_impls();
-    let impl_names = local_impls.iter().map(|trait_impl| trait_impl.name()).collect::<HashSet<_>>();
+    let impl_names =
+        local_impls.iter().map(|trait_impl| trait_impl.trimmed_name()).collect::<HashSet<_>>();
     assert_impl(&impl_names, "<Positive as Max>");
-    assert_impl(&impl_names, "<Positive as std::marker::Copy>");
-    assert_impl(&impl_names, "<Positive as std::clone::Clone>");
-    assert_impl(&impl_names, "<Positive as std::fmt::Debug>");
-    assert_impl(&impl_names, "<Positive as std::cmp::PartialEq>");
-    assert_impl(&impl_names, "<Positive as std::cmp::Eq>");
-    assert_impl(&impl_names, "<Positive as std::convert::TryFrom<u64>>");
+    assert_impl(&impl_names, "<Positive as Copy>");
+    assert_impl(&impl_names, "<Positive as Clone>");
+    assert_impl(&impl_names, "<Positive as Debug>");
+    assert_impl(&impl_names, "<Positive as PartialEq>");
+    assert_impl(&impl_names, "<Positive as Eq>");
+    assert_impl(&impl_names, "<Positive as TryFrom<u64>>");
     assert_impl(&impl_names, "<u64 as Max>");
-    assert_impl(&impl_names, "<impl std::convert::From<Positive> for u64>");
+    assert_impl(&impl_names, "<impl From<Positive> for u64>");
 
     let all_traits = rustc_public::all_trait_decls();
     assert!(all_traits.len() > local_traits.len());

--- a/tests/ui-fulldeps/rustc_public/check_transform.rs
+++ b/tests/ui-fulldeps/rustc_public/check_transform.rs
@@ -34,7 +34,7 @@ fn test_transform() -> ControlFlow<()> {
     let items = rustc_public::all_local_items();
 
     // Test fn_abi
-    let target_fn = *get_item(&items, (ItemKind::Fn, "dummy")).unwrap();
+    let target_fn = *get_item(&items, (ItemKind::Fn, "input::dummy")).unwrap();
     let instance = Instance::try_from(target_fn).unwrap();
     let body = instance.body().unwrap();
     check_msg(&body, "oops");

--- a/tests/ui-fulldeps/rustc_public/check_variant.rs
+++ b/tests/ui-fulldeps/rustc_public/check_variant.rs
@@ -97,7 +97,7 @@ fn check_adt_poly2() {
 }
 
 fn get_fn(name: &str) -> CrateItem {
-    rustc_public::all_local_items().into_iter().find(|it| it.name().eq(name)).unwrap()
+    rustc_public::all_local_items().into_iter().find(|it| it.trimmed_name().eq(name)).unwrap()
 }
 
 fn check_statement_is_aggregate_assign(

--- a/tests/ui-fulldeps/rustc_public/closure-generic-body.rs
+++ b/tests/ui-fulldeps/rustc_public/closure-generic-body.rs
@@ -52,7 +52,7 @@ fn check_incr_closure_body(body: Body) {
         panic!("expected FnDef");
     };
 
-    assert_eq!(def_id.name(), "id");
+    assert_eq!(def_id.trimmed_name(), "id");
 }
 
 fn main() {

--- a/tests/ui-fulldeps/rustc_public/closure_body.rs
+++ b/tests/ui-fulldeps/rustc_public/closure_body.rs
@@ -52,7 +52,7 @@ fn check_incr_closure_body(body: Body) {
         panic!("expected FnDef");
     };
 
-    assert_eq!(def_id.name(), "incr");
+    assert_eq!(def_id.name(), "crate_closure_body::incr");
 }
 
 fn main() {

--- a/tests/ui-fulldeps/rustc_public/crate-info.rs
+++ b/tests/ui-fulldeps/rustc_public/crate-info.rs
@@ -38,12 +38,12 @@ fn test_stable_mir() -> ControlFlow<()> {
 
     // Find items in the local crate.
     let items = rustc_public::all_local_items();
-    assert!(get_item(&items, (DefKind::Fn, "foo::bar")).is_some());
+    assert!(get_item(&items, (DefKind::Fn, "input::foo::bar")).is_some());
 
     // Find the `std` crate and assert that there is only one of it.
     assert!(rustc_public::find_crates("std").len() == 1);
 
-    let bar = get_item(&items, (DefKind::Fn, "bar")).unwrap();
+    let bar = get_item(&items, (DefKind::Fn, "input::bar")).unwrap();
     let body = bar.expect_body();
     assert_eq!(body.locals().len(), 2);
     assert_eq!(body.blocks.len(), 1);
@@ -58,7 +58,7 @@ fn test_stable_mir() -> ControlFlow<()> {
         other => panic!("{other:?}"),
     }
 
-    let foo_bar = get_item(&items, (DefKind::Fn, "foo_bar")).unwrap();
+    let foo_bar = get_item(&items, (DefKind::Fn, "input::foo_bar")).unwrap();
     let body = foo_bar.expect_body();
     assert_eq!(body.locals().len(), 5);
     assert_eq!(body.blocks.len(), 4);
@@ -68,7 +68,7 @@ fn test_stable_mir() -> ControlFlow<()> {
         other => panic!("{other:?}"),
     }
 
-    let types = get_item(&items, (DefKind::Fn, "types")).unwrap();
+    let types = get_item(&items, (DefKind::Fn, "input::types")).unwrap();
     let body = types.expect_body();
     assert_eq!(body.locals().len(), 6);
     assert_matches!(
@@ -85,15 +85,15 @@ fn test_stable_mir() -> ControlFlow<()> {
     );
     assert_matches!(
         body.locals()[3].ty.kind(),
-        rustc_public::ty::TyKind::RigidTy(
-            rustc_public::ty::RigidTy::Int(rustc_public::ty::IntTy::I32)
-        )
+        rustc_public::ty::TyKind::RigidTy(rustc_public::ty::RigidTy::Int(
+            rustc_public::ty::IntTy::I32
+        ))
     );
     assert_matches!(
         body.locals()[4].ty.kind(),
-        rustc_public::ty::TyKind::RigidTy(
-            rustc_public::ty::RigidTy::Uint(rustc_public::ty::UintTy::U64)
-        )
+        rustc_public::ty::TyKind::RigidTy(rustc_public::ty::RigidTy::Uint(
+            rustc_public::ty::UintTy::U64
+        ))
     );
     assert_matches!(
         body.locals()[5].ty.kind(),
@@ -102,7 +102,7 @@ fn test_stable_mir() -> ControlFlow<()> {
         ))
     );
 
-    let drop = get_item(&items, (DefKind::Fn, "drop")).unwrap();
+    let drop = get_item(&items, (DefKind::Fn, "input::drop")).unwrap();
     let body = drop.expect_body();
     assert_eq!(body.blocks.len(), 2);
     let block = &body.blocks[0];
@@ -111,7 +111,7 @@ fn test_stable_mir() -> ControlFlow<()> {
         other => panic!("{other:?}"),
     }
 
-    let assert = get_item(&items, (DefKind::Fn, "assert")).unwrap();
+    let assert = get_item(&items, (DefKind::Fn, "input::assert")).unwrap();
     let body = assert.expect_body();
     assert_eq!(body.blocks.len(), 2);
     let block = &body.blocks[0];
@@ -120,7 +120,7 @@ fn test_stable_mir() -> ControlFlow<()> {
         other => panic!("{other:?}"),
     }
 
-    let monomorphic = get_item(&items, (DefKind::Fn, "monomorphic")).unwrap();
+    let monomorphic = get_item(&items, (DefKind::Fn, "input::monomorphic")).unwrap();
     let instance = Instance::try_from(monomorphic.clone()).unwrap();
     for block in instance.body().unwrap().blocks {
         match &block.terminator.kind {
@@ -140,11 +140,11 @@ fn test_stable_mir() -> ControlFlow<()> {
         }
     }
 
-    let foo_const = get_item(&items, (DefKind::Const, "FOO")).unwrap();
+    let foo_const = get_item(&items, (DefKind::Const, "input::FOO")).unwrap();
     // Ensure we don't panic trying to get the body of a constant.
     foo_const.expect_body();
 
-    let locals_fn = get_item(&items, (DefKind::Fn, "locals")).unwrap();
+    let locals_fn = get_item(&items, (DefKind::Fn, "input::locals")).unwrap();
     let body = locals_fn.expect_body();
     assert_eq!(body.locals().len(), 4);
     assert_matches!(
@@ -154,15 +154,15 @@ fn test_stable_mir() -> ControlFlow<()> {
     assert_eq!(body.arg_locals().len(), 2);
     assert_matches!(
         body.arg_locals()[0].ty.kind(),
-        rustc_public::ty::TyKind::RigidTy(
-            rustc_public::ty::RigidTy::Int(rustc_public::ty::IntTy::I32)
-        )
+        rustc_public::ty::TyKind::RigidTy(rustc_public::ty::RigidTy::Int(
+            rustc_public::ty::IntTy::I32
+        ))
     );
     assert_matches!(
         body.arg_locals()[1].ty.kind(),
-        rustc_public::ty::TyKind::RigidTy(
-            rustc_public::ty::RigidTy::Uint(rustc_public::ty::UintTy::U64)
-        )
+        rustc_public::ty::TyKind::RigidTy(rustc_public::ty::RigidTy::Uint(
+            rustc_public::ty::UintTy::U64
+        ))
     );
     assert_eq!(body.inner_locals().len(), 1);
     // If conditions have an extra inner local to hold their results

--- a/tests/ui-fulldeps/rustc_public/projections.rs
+++ b/tests/ui-fulldeps/rustc_public/projections.rs
@@ -136,7 +136,9 @@ fn get_item<'a>(
     items: &'a rustc_public::CrateItems,
     item: (ItemKind, &str),
 ) -> Option<&'a rustc_public::CrateItem> {
-    items.iter().find(|crate_item| crate_item.kind() == item.0 && crate_item.name() == item.1)
+    items
+        .iter()
+        .find(|crate_item| crate_item.kind() == item.0 && crate_item.trimmed_name() == item.1)
 }
 
 /// This test will generate and analyze a dummy crate using the stable mir.

--- a/tests/ui/rustc_public-ir-print/async-closure.stdout
+++ b/tests/ui/rustc_public-ir-print/async-closure.stdout
@@ -56,7 +56,7 @@ fn foo::{closure#0}::{closure#0}(_1: Pin<&mut {async closure body@$DIR/async-clo
         _3 = (*_4);
         _5 = ();
         StorageDead(_3);
-        _0 = std::task::Poll::Ready(move _5);
+        _0 = Poll::Ready(move _5);
         discriminant((*_7)) = 1;
         return;
     }
@@ -88,7 +88,7 @@ fn foo::{closure#0}::{synthetic#0}(_1: Pin<&mut {async closure body@$DIR/async-c
         _3 = (*_4);
         _5 = ();
         StorageDead(_3);
-        _0 = std::task::Poll::Ready(move _5);
+        _0 = Poll::Ready(move _5);
         discriminant((*_7)) = 1;
         return;
     }

--- a/tests/ui/rustc_public-ir-print/operands.stdout
+++ b/tests/ui/rustc_public-ir-print/operands.stdout
@@ -206,7 +206,7 @@ fn operands(_1: u8) -> () {
         StorageDead(_19);
         StorageDead(_18);
         StorageLive(_21);
-        _21 = core::panicking::AssertKind::Eq;
+        _21 = AssertKind::Eq;
         StorageLive(_22);
         StorageLive(_23);
         _23 = move _21;
@@ -219,7 +219,7 @@ fn operands(_1: u8) -> () {
         _27 = &(*_16);
         _26 = &(*_27);
         StorageLive(_28);
-        _28 = std::option::Option::None;
+        _28 = Option::None;
         _22 = core::panicking::assert_failed::<u8, u8>(move _23, move _24, move _26, move _28) -> unwind unreachable;
     }
     bb6: {
@@ -268,7 +268,7 @@ fn operands(_1: u8) -> () {
         StorageDead(_39);
         StorageDead(_38);
         StorageLive(_41);
-        _41 = core::panicking::AssertKind::Eq;
+        _41 = AssertKind::Eq;
         StorageLive(_42);
         StorageLive(_43);
         _43 = move _41;
@@ -281,7 +281,7 @@ fn operands(_1: u8) -> () {
         _47 = &(*_36);
         _46 = &(*_47);
         StorageLive(_48);
-        _48 = std::option::Option::None;
+        _48 = Option::None;
         _42 = core::panicking::assert_failed::<u8, u8>(move _43, move _44, move _46, move _48) -> unwind unreachable;
     }
     bb8: {
@@ -305,7 +305,7 @@ fn operands(_1: u8) -> () {
         StorageDead(_62);
         StorageDead(_61);
         StorageLive(_64);
-        _64 = core::panicking::AssertKind::Eq;
+        _64 = AssertKind::Eq;
         StorageLive(_65);
         StorageLive(_66);
         _66 = move _64;
@@ -318,7 +318,7 @@ fn operands(_1: u8) -> () {
         _70 = &(*_59);
         _69 = &(*_70);
         StorageLive(_71);
-        _71 = std::option::Option::None;
+        _71 = Option::None;
         _65 = core::panicking::assert_failed::<u8, u8>(move _66, move _67, move _69, move _71) -> unwind unreachable;
     }
     bb10: {
@@ -380,7 +380,7 @@ fn operands(_1: u8) -> () {
         StorageDead(_86);
         StorageDead(_85);
         StorageLive(_88);
-        _88 = core::panicking::AssertKind::Eq;
+        _88 = AssertKind::Eq;
         StorageLive(_89);
         StorageLive(_90);
         _90 = move _88;
@@ -393,7 +393,7 @@ fn operands(_1: u8) -> () {
         _94 = &(*_83);
         _93 = &(*_94);
         StorageLive(_95);
-        _95 = std::option::Option::None;
+        _95 = Option::None;
         _89 = core::panicking::assert_failed::<usize, usize>(move _90, move _91, move _93, move _95) -> unwind unreachable;
     }
 }


### PR DESCRIPTION
This change fixes the behavior of the `name()` function for `CrateDef` and `Instance` which should return absolute path of items. For local items, the crate name was missing.

This resolves: https://github.com/rust-lang/project-stable-mir/issues/109