### PR TITLE
Recover on misspelled item keyword

### DIFF
--- a/tests/ui/parser/misspelled-keywords/assoc-type.rs
+++ b/tests/ui/parser/misspelled-keywords/assoc-type.rs
@@ -1,6 +1,8 @@
+#![feature(associated_type_defaults)]
+
 trait Animal {
     Type Result = u8;
-    //~^ ERROR expected one of
+    //~^ ERROR keyword `type` is written in the wrong case
 }
 
 fn main() {}

--- a/tests/ui/parser/misspelled-keywords/assoc-type.stderr
+++ b/tests/ui/parser/misspelled-keywords/assoc-type.stderr
@@ -1,15 +1,10 @@
-error: expected one of `!` or `::`, found `Result`
-  --> $DIR/assoc-type.rs:2:10
+error: keyword `type` is written in the wrong case
+  --> $DIR/assoc-type.rs:4:5
    |
-LL | trait Animal {
-   |              - while parsing this item list starting here
 LL |     Type Result = u8;
-   |          ^^^^^^ expected one of `!` or `::`
-LL |
-LL | }
-   | - the item list ends here
+   |     ^^^^
    |
-help: write keyword `type` in lowercase
+help: write it in lowercase
    |
 LL -     Type Result = u8;
 LL +     type Result = u8;

--- a/tests/ui/parser/misspelled-keywords/recovery.rs
+++ b/tests/ui/parser/misspelled-keywords/recovery.rs
@@ -1,0 +1,23 @@
+// Shows that we perform recovery on misspelled item keyword.
+
+#![feature(associated_type_defaults)]
+
+trait Animal {
+    Type Result = u8;
+    //~^ ERROR expected one of
+}
+
+Struct Foor {
+    //~^ ERROR expected one of
+    hello: String,
+}
+
+Const A: u8 = 10;
+
+Fn code() {}
+
+Static a: u8 = 0;
+
+usee a::b;
+
+fn main() {}

--- a/tests/ui/parser/misspelled-keywords/recovery.rs
+++ b/tests/ui/parser/misspelled-keywords/recovery.rs
@@ -4,20 +4,24 @@
 
 trait Animal {
     Type Result = u8;
-    //~^ ERROR expected one of
+    //~^ ERROR keyword `type` is written in the wrong case
 }
 
 Struct Foor {
-    //~^ ERROR expected one of
+    //~^ ERROR keyword `struct` is written in the wrong case
     hello: String,
 }
 
 Const A: u8 = 10;
+//~^ ERROR keyword `const` is written in the wrong case
 
 Fn code() {}
+//~^ ERROR keyword `fn` is written in the wrong case
 
 Static a: u8 = 0;
+//~^ ERROR keyword `static` is written in the wrong case
 
 usee a::b;
+//~^ ERROR expected one of
 
 fn main() {}

--- a/tests/ui/parser/misspelled-keywords/recovery.stderr
+++ b/tests/ui/parser/misspelled-keywords/recovery.stderr
@@ -1,31 +1,74 @@
-error: expected one of `!` or `::`, found `Result`
-  --> $DIR/recovery.rs:6:10
+error: keyword `type` is written in the wrong case
+  --> $DIR/recovery.rs:6:5
    |
-LL | trait Animal {
-   |              - while parsing this item list starting here
 LL |     Type Result = u8;
-   |          ^^^^^^ expected one of `!` or `::`
-LL |
-LL | }
-   | - the item list ends here
+   |     ^^^^
    |
-help: write keyword `type` in lowercase
+help: write it in lowercase
    |
 LL -     Type Result = u8;
 LL +     type Result = u8;
    |
 
-error: expected one of `!` or `::`, found `Foor`
-  --> $DIR/recovery.rs:10:8
+error: keyword `struct` is written in the wrong case
+  --> $DIR/recovery.rs:10:1
    |
 LL | Struct Foor {
-   |        ^^^^ expected one of `!` or `::`
+   | ^^^^^^
    |
-help: write keyword `struct` in lowercase (notice the capitalization)
+help: write it in lowercase (notice the capitalization)
    |
 LL - Struct Foor {
 LL + struct Foor {
    |
 
-error: aborting due to 2 previous errors
+error: keyword `const` is written in the wrong case
+  --> $DIR/recovery.rs:15:1
+   |
+LL | Const A: u8 = 10;
+   | ^^^^^
+   |
+help: write it in lowercase (notice the capitalization)
+   |
+LL - Const A: u8 = 10;
+LL + const A: u8 = 10;
+   |
+
+error: keyword `fn` is written in the wrong case
+  --> $DIR/recovery.rs:18:1
+   |
+LL | Fn code() {}
+   | ^^
+   |
+help: write it in lowercase (notice the capitalization)
+   |
+LL - Fn code() {}
+LL + fn code() {}
+   |
+
+error: keyword `static` is written in the wrong case
+  --> $DIR/recovery.rs:21:1
+   |
+LL | Static a: u8 = 0;
+   | ^^^^^^
+   |
+help: write it in lowercase (notice the capitalization)
+   |
+LL - Static a: u8 = 0;
+LL + static a: u8 = 0;
+   |
+
+error: expected one of `!` or `::`, found `a`
+  --> $DIR/recovery.rs:24:6
+   |
+LL | usee a::b;
+   |      ^ expected one of `!` or `::`
+   |
+help: there is a keyword `use` with a similar name
+   |
+LL - usee a::b;
+LL + use a::b;
+   |
+
+error: aborting due to 6 previous errors
 

--- a/tests/ui/parser/misspelled-keywords/recovery.stderr
+++ b/tests/ui/parser/misspelled-keywords/recovery.stderr
@@ -1,0 +1,31 @@
+error: expected one of `!` or `::`, found `Result`
+  --> $DIR/recovery.rs:6:10
+   |
+LL | trait Animal {
+   |              - while parsing this item list starting here
+LL |     Type Result = u8;
+   |          ^^^^^^ expected one of `!` or `::`
+LL |
+LL | }
+   | - the item list ends here
+   |
+help: write keyword `type` in lowercase
+   |
+LL -     Type Result = u8;
+LL +     type Result = u8;
+   |
+
+error: expected one of `!` or `::`, found `Foor`
+  --> $DIR/recovery.rs:10:8
+   |
+LL | Struct Foor {
+   |        ^^^^ expected one of `!` or `::`
+   |
+help: write keyword `struct` in lowercase (notice the capitalization)
+   |
+LL - Struct Foor {
+LL + struct Foor {
+   |
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/parser/misspelled-keywords/static.rs
+++ b/tests/ui/parser/misspelled-keywords/static.rs
@@ -1,4 +1,3 @@
-Static a = 0;
-//~^ ERROR expected one of
-
+Static a: u32 = 0;
+//~^ ERROR keyword `static` is written in the wrong case
 fn main() {}

--- a/tests/ui/parser/misspelled-keywords/static.stderr
+++ b/tests/ui/parser/misspelled-keywords/static.stderr
@@ -1,13 +1,13 @@
-error: expected one of `!` or `::`, found `a`
-  --> $DIR/static.rs:1:8
+error: keyword `static` is written in the wrong case
+  --> $DIR/static.rs:1:1
    |
-LL | Static a = 0;
-   |        ^ expected one of `!` or `::`
+LL | Static a: u32 = 0;
+   | ^^^^^^
    |
-help: write keyword `static` in lowercase (notice the capitalization)
+help: write it in lowercase (notice the capitalization)
    |
-LL - Static a = 0;
-LL + static a = 0;
+LL - Static a: u32 = 0;
+LL + static a: u32 = 0;
    |
 
 error: aborting due to 1 previous error

--- a/tests/ui/parser/misspelled-keywords/struct.rs
+++ b/tests/ui/parser/misspelled-keywords/struct.rs
@@ -1,4 +1,6 @@
 Struct Foor {
-//~^ ERROR expected one of
+    //~^ ERROR keyword `struct` is written in the wrong case
     hello: String,
 }
+
+fn main() {}

--- a/tests/ui/parser/misspelled-keywords/struct.stderr
+++ b/tests/ui/parser/misspelled-keywords/struct.stderr
@@ -1,10 +1,10 @@
-error: expected one of `!` or `::`, found `Foor`
-  --> $DIR/struct.rs:1:8
+error: keyword `struct` is written in the wrong case
+  --> $DIR/struct.rs:1:1
    |
 LL | Struct Foor {
-   |        ^^^^ expected one of `!` or `::`
+   | ^^^^^^
    |
-help: write keyword `struct` in lowercase (notice the capitalization)
+help: write it in lowercase (notice the capitalization)
    |
 LL - Struct Foor {
 LL + struct Foor {


### PR DESCRIPTION
the title says everything. first commit adds a test that shows how current `main` behaves on misspelled item keyword. second commit adds the recovery, which allows to emit many more errors.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
r? @jdonszelmann 
<!-- homu-ignore:end -->
