### PR TITLE
refactor: remove Ord bound from BinaryHeap::new etc

### DIFF
--- a/library/alloc/src/collections/binary_heap/mod.rs
+++ b/library/alloc/src/collections/binary_heap/mod.rs
@@ -466,7 +466,7 @@ impl<T: Clone, A: Allocator + Clone> Clone for BinaryHeap<T, A> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: Ord> Default for BinaryHeap<T> {
+impl<T> Default for BinaryHeap<T> {
     /// Creates an empty `BinaryHeap<T>`.
     #[inline]
     fn default() -> BinaryHeap<T> {
@@ -496,7 +496,7 @@ impl<T: Ord, A: Allocator> Drop for RebuildOnDrop<'_, T, A> {
     }
 }
 
-impl<T: Ord> BinaryHeap<T> {
+impl<T> BinaryHeap<T> {
     /// Creates an empty `BinaryHeap` as a max-heap.
     ///
     /// # Examples
@@ -537,7 +537,7 @@ impl<T: Ord> BinaryHeap<T> {
     }
 }
 
-impl<T: Ord, A: Allocator> BinaryHeap<T, A> {
+impl<T, A: Allocator> BinaryHeap<T, A> {
     /// Creates an empty `BinaryHeap` as a max-heap, using `A` as allocator.
     ///
     /// # Examples
@@ -615,7 +615,9 @@ impl<T: Ord, A: Allocator> BinaryHeap<T, A> {
     pub fn peek_mut(&mut self) -> Option<PeekMut<'_, T, A>> {
         if self.is_empty() { None } else { Some(PeekMut { heap: self, original_len: None }) }
     }
+}
 
+impl<T: Ord, A: Allocator> BinaryHeap<T, A> {
     /// Removes the greatest item from the binary heap and returns it, or `None` if it
     /// is empty.
     ///

--- a/library/alloc/src/collections/binary_heap/mod.rs
+++ b/library/alloc/src/collections/binary_heap/mod.rs
@@ -581,7 +581,9 @@ impl<T, A: Allocator> BinaryHeap<T, A> {
     pub fn with_capacity_in(capacity: usize, alloc: A) -> BinaryHeap<T, A> {
         BinaryHeap { data: Vec::with_capacity_in(capacity, alloc) }
     }
+}
 
+impl<T: Ord, A: Allocator> BinaryHeap<T, A> {
     /// Returns a mutable reference to the greatest item in the binary heap, or
     /// `None` if it is empty.
     ///
@@ -615,9 +617,7 @@ impl<T, A: Allocator> BinaryHeap<T, A> {
     pub fn peek_mut(&mut self) -> Option<PeekMut<'_, T, A>> {
         if self.is_empty() { None } else { Some(PeekMut { heap: self, original_len: None }) }
     }
-}
 
-impl<T: Ord, A: Allocator> BinaryHeap<T, A> {
     /// Removes the greatest item from the binary heap and returns it, or `None` if it
     /// is empty.
     ///


### PR DESCRIPTION
This adds consistency with e.g `BTreeMap::new`, and makes it easier to e.g `#[derive(Default)]`[^1]

[^1]: https://play.rust-lang.org/?version=stable&mode=debug&edition=2024&gist=f848e472a176fae155f17455bdfe0aee 
