### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/mutability_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/mutability_errors.rs
@@ -1198,6 +1198,12 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
             );
             return;
         }
+
+        // Do not suggest changing type if that is not under user control.
+        if self.is_closure_arg_with_non_locally_decided_type(local) {
+            return;
+        }
+
         let decl_span = local_decl.source_info.span;
 
         let (amp_mut_sugg, local_var_ty_info) = match *local_decl.local_info() {
@@ -1499,6 +1505,60 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
             sugg,
             Applicability::HasPlaceholders,
         );
+    }
+
+    /// Returns `true` if `local` is an argument in a closure passed to a
+    /// function defined in another crate.
+    ///
+    /// For example, in the following code this function returns `true` for `x`
+    /// since `Option::inspect()` is not defined in the current crate:
+    ///
+    /// ```text
+    /// some_option.as_mut().inspect(|x| {
+    /// ```
+    fn is_closure_arg_with_non_locally_decided_type(&self, local: Local) -> bool {
+        // We don't care about regular local variables, only args.
+        if self.body.local_kind(local) != LocalKind::Arg {
+            return false;
+        }
+
+        // Make sure we are inside a closure.
+        let InstanceKind::Item(body_def_id) = self.body.source.instance else {
+            return false;
+        };
+        let Some(Node::Expr(hir::Expr { hir_id: body_hir_id, kind, .. })) =
+            self.infcx.tcx.hir_get_if_local(body_def_id)
+        else {
+            return false;
+        };
+        let ExprKind::Closure(hir::Closure { kind: hir::ClosureKind::Closure, .. }) = kind else {
+            return false;
+        };
+
+        // Check if the method/function that our closure is passed to is defined
+        // in another crate.
+        let Node::Expr(closure_parent) = self.infcx.tcx.parent_hir_node(*body_hir_id) else {
+            return false;
+        };
+        match closure_parent.kind {
+            ExprKind::MethodCall(method, _, _, _) => self
+                .infcx
+                .tcx
+                .typeck(method.hir_id.owner.def_id)
+                .type_dependent_def_id(closure_parent.hir_id)
+                .is_some_and(|def_id| !def_id.is_local()),
+            ExprKind::Call(func, _) => self
+                .infcx
+                .tcx
+                .typeck(func.hir_id.owner.def_id)
+                .node_type_opt(func.hir_id)
+                .and_then(|ty| match ty.kind() {
+                    ty::FnDef(def_id, _) => Some(def_id),
+                    _ => None,
+                })
+                .is_some_and(|def_id| !def_id.is_local()),
+            _ => false,
+        }
     }
 }
 

--- a/compiler/rustc_interface/src/interface.rs
+++ b/compiler/rustc_interface/src/interface.rs
@@ -24,6 +24,7 @@ use rustc_session::parse::ParseSess;
 use rustc_session::{CompilerIO, EarlyDiagCtxt, Session, lint};
 use rustc_span::source_map::{FileLoader, RealFileLoader, SourceMapInputs};
 use rustc_span::{FileName, sym};
+use rustc_target::spec::Target;
 use tracing::trace;
 
 use crate::util;
@@ -385,7 +386,7 @@ pub struct Config {
     /// custom driver where the custom codegen backend has arbitrary data."
     /// (See #102759.)
     pub make_codegen_backend:
-        Option<Box<dyn FnOnce(&config::Options) -> Box<dyn CodegenBackend> + Send>>,
+        Option<Box<dyn FnOnce(&config::Options, &Target) -> Box<dyn CodegenBackend> + Send>>,
 
     /// Registry of diagnostics codes.
     pub registry: Registry,
@@ -453,7 +454,7 @@ pub fn run_compiler<R: Send>(config: Config, f: impl FnOnce(&Compiler) -> R + Se
                 Some(make_codegen_backend) => {
                     // N.B. `make_codegen_backend` takes precedence over
                     // `target.default_codegen_backend`, which is ignored in this case.
-                    make_codegen_backend(&config.opts)
+                    make_codegen_backend(&config.opts, &target)
                 }
             };
 

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -126,8 +126,6 @@
 #![feature(str_split_inclusive_remainder)]
 #![feature(str_split_remainder)]
 #![feature(ub_checks)]
-#![feature(unchecked_neg)]
-#![feature(unchecked_shifts)]
 #![feature(unsafe_pinned)]
 #![feature(utf16_extra)]
 #![feature(variant_count)]

--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -1259,11 +1259,8 @@ macro_rules! int_impl {
         /// i.e. when [`checked_neg`] would return `None`.
         ///
         #[doc = concat!("[`checked_neg`]: ", stringify!($SelfT), "::checked_neg")]
-        #[unstable(
-            feature = "unchecked_neg",
-            reason = "niche optimization path",
-            issue = "85122",
-        )]
+        #[stable(feature = "unchecked_neg", since = "CURRENT_RUSTC_VERSION")]
+        #[rustc_const_stable(feature = "unchecked_neg", since = "CURRENT_RUSTC_VERSION")]
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline(always)]
@@ -1379,11 +1376,8 @@ macro_rules! int_impl {
         /// i.e. when [`checked_shl`] would return `None`.
         ///
         #[doc = concat!("[`checked_shl`]: ", stringify!($SelfT), "::checked_shl")]
-        #[unstable(
-            feature = "unchecked_shifts",
-            reason = "niche optimization path",
-            issue = "85122",
-        )]
+        #[stable(feature = "unchecked_shifts", since = "CURRENT_RUSTC_VERSION")]
+        #[rustc_const_stable(feature = "unchecked_shifts", since = "CURRENT_RUSTC_VERSION")]
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline(always)]
@@ -1554,11 +1548,8 @@ macro_rules! int_impl {
         /// i.e. when [`checked_shr`] would return `None`.
         ///
         #[doc = concat!("[`checked_shr`]: ", stringify!($SelfT), "::checked_shr")]
-        #[unstable(
-            feature = "unchecked_shifts",
-            reason = "niche optimization path",
-            issue = "85122",
-        )]
+        #[stable(feature = "unchecked_shifts", since = "CURRENT_RUSTC_VERSION")]
+        #[rustc_const_stable(feature = "unchecked_shifts", since = "CURRENT_RUSTC_VERSION")]
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline(always)]

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -1781,11 +1781,8 @@ macro_rules! uint_impl {
         /// i.e. when [`checked_shl`] would return `None`.
         ///
         #[doc = concat!("[`checked_shl`]: ", stringify!($SelfT), "::checked_shl")]
-        #[unstable(
-            feature = "unchecked_shifts",
-            reason = "niche optimization path",
-            issue = "85122",
-        )]
+        #[stable(feature = "unchecked_shifts", since = "CURRENT_RUSTC_VERSION")]
+        #[rustc_const_stable(feature = "unchecked_shifts", since = "CURRENT_RUSTC_VERSION")]
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline(always)]
@@ -1953,11 +1950,8 @@ macro_rules! uint_impl {
         /// i.e. when [`checked_shr`] would return `None`.
         ///
         #[doc = concat!("[`checked_shr`]: ", stringify!($SelfT), "::checked_shr")]
-        #[unstable(
-            feature = "unchecked_shifts",
-            reason = "niche optimization path",
-            issue = "85122",
-        )]
+        #[stable(feature = "unchecked_shifts", since = "CURRENT_RUSTC_VERSION")]
+        #[rustc_const_stable(feature = "unchecked_shifts", since = "CURRENT_RUSTC_VERSION")]
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline(always)]

--- a/src/tools/miri/src/lib.rs
+++ b/src/tools/miri/src/lib.rs
@@ -165,7 +165,6 @@ pub use crate::shims::unwind::{CatchUnwindData, EvalContextExt as _};
 /// Also disable the MIR pass that inserts an alignment check on every pointer dereference. Miri
 /// does that too, and with a better error message.
 pub const MIRI_DEFAULT_ARGS: &[&str] = &[
-    "-Zcodegen-backend=dummy",
     "--cfg=miri",
     "-Zalways-encode-mir",
     "-Zextra-const-ub-checks",

--- a/src/tools/miri/tests/fail/intrinsics/unchecked_shl.rs
+++ b/src/tools/miri/tests/fail/intrinsics/unchecked_shl.rs
@@ -1,5 +1,3 @@
-#![feature(unchecked_shifts)]
-
 fn main() {
     unsafe {
         let _n = 1i8.unchecked_shl(8);

--- a/src/tools/miri/tests/fail/intrinsics/unchecked_shr.rs
+++ b/src/tools/miri/tests/fail/intrinsics/unchecked_shr.rs
@@ -1,5 +1,3 @@
-#![feature(unchecked_shifts)]
-
 fn main() {
     unsafe {
         let _n = 1i64.unchecked_shr(64);

--- a/src/tools/miri/tests/pass/target-cpu-implies-target-feature.rs
+++ b/src/tools/miri/tests/pass/target-cpu-implies-target-feature.rs
@@ -3,10 +3,14 @@
 //@compile-flags: -C target-cpu=x86-64-v4
 
 fn main() {
+    assert!(cfg!(target_feature = "avx2"));
+    assert!(cfg!(target_feature = "avx512bw"));
+    assert!(cfg!(target_feature = "avx512cd"));
+    assert!(cfg!(target_feature = "avx512dq"));
+    assert!(cfg!(target_feature = "avx512f"));
+    assert!(cfg!(target_feature = "avx512vl"));
     assert!(is_x86_feature_detected!("avx512bw"));
-    assert!(is_x86_feature_detected!("avx512cd"));
-    assert!(is_x86_feature_detected!("avx512dq"));
-    assert!(is_x86_feature_detected!("avx512f"));
-    assert!(is_x86_feature_detected!("avx512vl"));
+
+    assert!(cfg!(not(target_feature = "avx512vpopcntdq")));
     assert!(!is_x86_feature_detected!("avx512vpopcntdq"));
 }

--- a/src/tools/miri/tests/pass/target-cpu-implies-target-feature.rs
+++ b/src/tools/miri/tests/pass/target-cpu-implies-target-feature.rs
@@ -1,0 +1,12 @@
+// Test that target-cpu implies the correct target features
+//@only-target: x86_64
+//@compile-flags: -C target-cpu=x86-64-v4
+
+fn main() {
+    assert!(is_x86_feature_detected!("avx512bw"));
+    assert!(is_x86_feature_detected!("avx512cd"));
+    assert!(is_x86_feature_detected!("avx512dq"));
+    assert!(is_x86_feature_detected!("avx512f"));
+    assert!(is_x86_feature_detected!("avx512vl"));
+    assert!(!is_x86_feature_detected!("avx512vpopcntdq"));
+}

--- a/src/tools/rust-analyzer/crates/ide-db/src/generated/lints.rs
+++ b/src/tools/rust-analyzer/crates/ide-db/src/generated/lints.rs
@@ -11846,34 +11846,6 @@ fn main() {}
         deny_since: None,
     },
     Lint {
-        label: "unchecked_neg",
-        description: r##"# `unchecked_neg`
-
-The tracking issue for this feature is: [#85122]
-
-[#85122]: https://github.com/rust-lang/rust/issues/85122
-
-------------------------
-"##,
-        default_severity: Severity::Allow,
-        warn_since: None,
-        deny_since: None,
-    },
-    Lint {
-        label: "unchecked_shifts",
-        description: r##"# `unchecked_shifts`
-
-The tracking issue for this feature is: [#85122]
-
-[#85122]: https://github.com/rust-lang/rust/issues/85122
-
-------------------------
-"##,
-        default_severity: Severity::Allow,
-        warn_since: None,
-        deny_since: None,
-    },
-    Lint {
         label: "unicode_internals",
         description: r##"# `unicode_internals`
 

--- a/tests/codegen-llvm/checked_math.rs
+++ b/tests/codegen-llvm/checked_math.rs
@@ -1,7 +1,6 @@
 //@ compile-flags: -Copt-level=3 -Z merge-functions=disabled
 
 #![crate_type = "lib"]
-#![feature(unchecked_shifts)]
 
 // Because the result of something like `u32::checked_sub` can only be used if it
 // didn't overflow, make sure that LLVM actually knows that in optimized builds.

--- a/tests/codegen-llvm/unchecked_shifts.rs
+++ b/tests/codegen-llvm/unchecked_shifts.rs
@@ -4,7 +4,6 @@
 // optimizations so it doesn't need to worry about them adding more flags.
 
 #![crate_type = "lib"]
-#![feature(unchecked_shifts)]
 #![feature(core_intrinsics)]
 
 // CHECK-LABEL: @unchecked_shl_unsigned_same

--- a/tests/mir-opt/inline/unchecked_shifts.rs
+++ b/tests/mir-opt/inline/unchecked_shifts.rs
@@ -1,6 +1,5 @@
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 #![crate_type = "lib"]
-#![feature(unchecked_shifts)]
 
 //@ compile-flags: -Zmir-opt-level=2 -Zinline-mir
 

--- a/tests/ui/borrowck/issue-115259-suggest-iter-mut.stderr
+++ b/tests/ui/borrowck/issue-115259-suggest-iter-mut.stderr
@@ -2,9 +2,7 @@ error[E0596]: cannot borrow `**layer` as mutable, as it is behind a `&` referenc
   --> $DIR/issue-115259-suggest-iter-mut.rs:15:65
    |
 LL |         self.layers.iter().fold(0, |result, mut layer| result + layer.process())
-   |                                             ---------           ^^^^^ `layer` is a `&` reference, so it cannot be borrowed as mutable
-   |                                             |
-   |                                             consider changing this binding's type to be: `&mut Box<dyn Layer>`
+   |                                                                 ^^^^^ `layer` is a `&` reference, so it cannot be borrowed as mutable
    |
 help: you may want to use `iter_mut` here
    |

--- a/tests/ui/borrowck/issue-62387-suggest-iter-mut-2.stderr
+++ b/tests/ui/borrowck/issue-62387-suggest-iter-mut-2.stderr
@@ -2,9 +2,7 @@ error[E0596]: cannot borrow `*container` as mutable, as it is behind a `&` refer
   --> $DIR/issue-62387-suggest-iter-mut-2.rs:30:45
    |
 LL |             vec.iter().flat_map(|container| container.things()).cloned().collect::<Vec<PathBuf>>();
-   |                                  ---------  ^^^^^^^^^ `container` is a `&` reference, so it cannot be borrowed as mutable
-   |                                  |
-   |                                  consider changing this binding's type to be: `&mut Container`
+   |                                             ^^^^^^^^^ `container` is a `&` reference, so it cannot be borrowed as mutable
    |
 help: you may want to use `iter_mut` here
    |

--- a/tests/ui/borrowck/issue-62387-suggest-iter-mut.stderr
+++ b/tests/ui/borrowck/issue-62387-suggest-iter-mut.stderr
@@ -2,9 +2,7 @@ error[E0596]: cannot borrow `*a` as mutable, as it is behind a `&` reference
   --> $DIR/issue-62387-suggest-iter-mut.rs:18:27
    |
 LL |     v.iter().for_each(|a| a.double());
-   |                        -  ^ `a` is a `&` reference, so it cannot be borrowed as mutable
-   |                        |
-   |                        consider changing this binding's type to be: `&mut A`
+   |                           ^ `a` is a `&` reference, so it cannot be borrowed as mutable
    |
 help: you may want to use `iter_mut` here
    |
@@ -15,9 +13,7 @@ error[E0596]: cannot borrow `*a` as mutable, as it is behind a `&` reference
   --> $DIR/issue-62387-suggest-iter-mut.rs:25:39
    |
 LL |     v.iter().rev().rev().for_each(|a| a.double());
-   |                                    -  ^ `a` is a `&` reference, so it cannot be borrowed as mutable
-   |                                    |
-   |                                    consider changing this binding's type to be: `&mut A`
+   |                                       ^ `a` is a `&` reference, so it cannot be borrowed as mutable
    |
 help: you may want to use `iter_mut` here
    |

--- a/tests/ui/borrowck/option-inspect-mutation.rs
+++ b/tests/ui/borrowck/option-inspect-mutation.rs
@@ -1,0 +1,18 @@
+//! Regression test for <https://github.com/rust-lang/rust/issues/128381>.
+
+struct Struct {
+    field: u32,
+}
+
+fn main() {
+    let mut some_struct = Some(Struct { field: 42 });
+    some_struct.as_mut().inspect(|some_struct| {
+        some_struct.field *= 10; //~ ERROR cannot assign to `some_struct.field`, which is behind a `&` reference
+        // Users can't change type of `some_struct` param, so above error must not suggest it.
+    });
+
+    // Same check as above but using `hir::ExprKind::Call` instead of `hir::ExprKind::MethodCall`.
+    Option::inspect(some_struct.as_mut(), |some_struct| {
+        some_struct.field *= 20; //~ ERROR cannot assign to `some_struct.field`, which is behind a `&` reference
+    });
+}

--- a/tests/ui/borrowck/option-inspect-mutation.stderr
+++ b/tests/ui/borrowck/option-inspect-mutation.stderr
@@ -1,16 +1,12 @@
 error[E0594]: cannot assign to `some_struct.field`, which is behind a `&` reference
   --> $DIR/option-inspect-mutation.rs:10:9
    |
-LL |     some_struct.as_mut().inspect(|some_struct| {
-   |                                   ----------- consider changing this binding's type to be: `&mut &mut Struct`
 LL |         some_struct.field *= 10;
    |         ^^^^^^^^^^^^^^^^^^^^^^^ `some_struct` is a `&` reference, so it cannot be written to
 
 error[E0594]: cannot assign to `some_struct.field`, which is behind a `&` reference
   --> $DIR/option-inspect-mutation.rs:16:9
    |
-LL |     Option::inspect(some_struct.as_mut(), |some_struct| {
-   |                                            ----------- consider changing this binding's type to be: `&mut &mut Struct`
 LL |         some_struct.field *= 20;
    |         ^^^^^^^^^^^^^^^^^^^^^^^ `some_struct` is a `&` reference, so it cannot be written to
 

--- a/tests/ui/borrowck/option-inspect-mutation.stderr
+++ b/tests/ui/borrowck/option-inspect-mutation.stderr
@@ -1,0 +1,19 @@
+error[E0594]: cannot assign to `some_struct.field`, which is behind a `&` reference
+  --> $DIR/option-inspect-mutation.rs:10:9
+   |
+LL |     some_struct.as_mut().inspect(|some_struct| {
+   |                                   ----------- consider changing this binding's type to be: `&mut &mut Struct`
+LL |         some_struct.field *= 10;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^ `some_struct` is a `&` reference, so it cannot be written to
+
+error[E0594]: cannot assign to `some_struct.field`, which is behind a `&` reference
+  --> $DIR/option-inspect-mutation.rs:16:9
+   |
+LL |     Option::inspect(some_struct.as_mut(), |some_struct| {
+   |                                            ----------- consider changing this binding's type to be: `&mut &mut Struct`
+LL |         some_struct.field *= 20;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^ `some_struct` is a `&` reference, so it cannot be written to
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0594`.

--- a/tests/ui/borrowck/suggest-as-ref-on-mut-closure.stderr
+++ b/tests/ui/borrowck/suggest-as-ref-on-mut-closure.stderr
@@ -18,9 +18,7 @@ error[E0596]: cannot borrow `*cb` as mutable, as it is behind a `&` reference
   --> $DIR/suggest-as-ref-on-mut-closure.rs:12:26
    |
 LL |     cb.as_ref().map(|cb| cb());
-   |                      --  ^^ `cb` is a `&` reference, so it cannot be borrowed as mutable
-   |                      |
-   |                      consider changing this binding's type to be: `&mut &mut dyn FnMut()`
+   |                          ^^ `cb` is a `&` reference, so it cannot be borrowed as mutable
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/check-cfg/cfg-select.rs
+++ b/tests/ui/check-cfg/cfg-select.rs
@@ -1,0 +1,18 @@
+//@ check-pass
+
+#![feature(cfg_select)]
+#![crate_type = "lib"]
+
+cfg_select! {
+    true => {}
+    invalid_cfg1 => {}
+    //~^ WARN unexpected `cfg` condition name
+    _ => {}
+}
+
+cfg_select! {
+    invalid_cfg2 => {}
+    //~^ WARN unexpected `cfg` condition name
+    true => {}
+    _ => {}
+}

--- a/tests/ui/check-cfg/cfg-select.stderr
+++ b/tests/ui/check-cfg/cfg-select.stderr
@@ -1,0 +1,22 @@
+warning: unexpected `cfg` condition name: `invalid_cfg1`
+  --> $DIR/cfg-select.rs:8:5
+   |
+LL |     invalid_cfg1 => {}
+   |     ^^^^^^^^^^^^
+   |
+   = help: expected names are: `FALSE` and `test` and 31 more
+   = help: to expect this configuration use `--check-cfg=cfg(invalid_cfg1)`
+   = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
+   = note: `#[warn(unexpected_cfgs)]` on by default
+
+warning: unexpected `cfg` condition name: `invalid_cfg2`
+  --> $DIR/cfg-select.rs:14:5
+   |
+LL |     invalid_cfg2 => {}
+   |     ^^^^^^^^^^^^
+   |
+   = help: to expect this configuration use `--check-cfg=cfg(invalid_cfg2)`
+   = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
+
+warning: 2 warnings emitted
+

--- a/tests/ui/pattern/rfc-3637-guard-patterns/liveness-ice-issue-146445.rs
+++ b/tests/ui/pattern/rfc-3637-guard-patterns/liveness-ice-issue-146445.rs
@@ -1,0 +1,21 @@
+//@ check-pass
+//! Regression test for issue #146445.
+//!
+//! This test ensures that liveness linting works correctly with guard patterns
+//! and doesn't cause an ICE ("no successor") when using variables without
+//! underscore prefixes in guard expressions.
+//!
+//! Fixed by #142390 which moved liveness analysis to MIR.
+
+#![feature(guard_patterns)]
+#![expect(incomplete_features)]
+
+fn main() {
+    // This used to ICE before liveness analysis was moved to MIR.
+    // The variable `main` (without underscore prefix) would trigger
+    // liveness linting which wasn't properly implemented for guard patterns.
+    match (0,) {
+        (_ if { let main = false; main },) => {}
+        _ => {}
+    }
+}

--- a/tests/ui/precondition-checks/unchecked_shl.rs
+++ b/tests/ui/precondition-checks/unchecked_shl.rs
@@ -2,8 +2,6 @@
 //@ compile-flags: -Copt-level=3 -Cdebug-assertions=no -Zub-checks=yes
 //@ error-pattern: unsafe precondition(s) violated: u8::unchecked_shl cannot overflow
 
-#![feature(unchecked_shifts)]
-
 fn main() {
     unsafe {
         0u8.unchecked_shl(u8::BITS);

--- a/tests/ui/precondition-checks/unchecked_shr.rs
+++ b/tests/ui/precondition-checks/unchecked_shr.rs
@@ -2,8 +2,6 @@
 //@ compile-flags: -Copt-level=3 -Cdebug-assertions=no -Zub-checks=yes
 //@ error-pattern: unsafe precondition(s) violated: u8::unchecked_shr cannot overflow
 
-#![feature(unchecked_shifts)]
-
 fn main() {
     unsafe {
         0u8.unchecked_shr(u8::BITS);


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#149087 (Stabilize `unchecked_neg` and `unchecked_shifts`)
 - rust-lang/rust#149107 (rustc_borrowck: Don't suggest changing closure param type not under user control)
 - rust-lang/rust#149323 (Use cg_llvm's target_config in miri)
 - rust-lang/rust#149380 (Run `eval_config_entry` on all branches so we always emit lints)
 - rust-lang/rust#149394 (add regression test for guard patterns liveness ICE)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=149087,149107,149323,149380,149394)
<!-- homu-ignore:end -->