### PR TITLE
Add a regression test for issue 129865

### DIFF
--- a/tests/ui/traits/next-solver/normalize/normalize-const-in-async-body.rs
+++ b/tests/ui/traits/next-solver/normalize/normalize-const-in-async-body.rs
@@ -1,0 +1,14 @@
+//@ compile-flags: -Znext-solver
+//@ check-pass
+//@ edition:2021
+
+pub async fn cleanse_old_array_async(_: &[u8; BUCKET_LEN]) {}
+
+pub const BUCKET_LEN: usize = 0;
+
+pub fn cleanse_old_array_async2() -> impl std::future::Future {
+    let x: [u8; 0 + 0] = [];
+    async move { let _ = x; }
+}
+
+fn main() {}


### PR DESCRIPTION
Closes rust-lang/rust#129865

Looks like the previous versions (`< 1.85.0`) failed to normalize async block's upvar types containing constants but not anymore