### PR TITLE
Move the libgccjit.so file in a target directory

### DIFF
--- a/compiler/rustc_codegen_gcc/src/lib.rs
+++ b/compiler/rustc_codegen_gcc/src/lib.rs
@@ -98,6 +98,7 @@ use rustc_middle::ty::TyCtxt;
 use rustc_middle::util::Providers;
 use rustc_session::Session;
 use rustc_session::config::{OptLevel, OutputFilenames};
+use rustc_session::filesearch::make_target_lib_path;
 use rustc_span::Symbol;
 use rustc_target::spec::{Arch, RelocModel};
 use tempfile::TempDir;
@@ -182,9 +183,7 @@ pub struct GccCodegenBackend {
 static LTO_SUPPORTED: AtomicBool = AtomicBool::new(false);
 
 fn libgccjit_path(sysroot_path: &Path, target_triple: &str) -> PathBuf {
-    let sysroot_lib_dir = sysroot_path.join("lib").join("rustlib");
-    let libgccjit_target_lib_file =
-        sysroot_lib_dir.join(target_triple).join("lib").join("libgccjit.so");
+    make_target_lib_path(sysroot_path, target_triple).join("libgccjit.so")
 }
 
 fn load_libgccjit_if_needed(sysroot_path: &Path, target_triple: &str) {

--- a/compiler/rustc_codegen_gcc/src/lib.rs
+++ b/compiler/rustc_codegen_gcc/src/lib.rs
@@ -182,8 +182,9 @@ pub struct GccCodegenBackend {
 static LTO_SUPPORTED: AtomicBool = AtomicBool::new(false);
 
 fn libgccjit_path(sysroot_path: &Path, target_triple: &str) -> PathBuf {
-    let sysroot_lib_dir = sysroot_path.join("lib");
-    sysroot_lib_dir.join(target_triple).join("libgccjit.so")
+    let sysroot_lib_dir = sysroot_path.join("lib").join("rustlib");
+    let libgccjit_target_lib_file =
+        sysroot_lib_dir.join(target_triple).join("lib").join("libgccjit.so");
 }
 
 fn load_libgccjit_if_needed(sysroot_path: &Path, target_triple: &str) {

--- a/src/bootstrap/src/core/build_steps/gcc.rs
+++ b/src/bootstrap/src/core/build_steps/gcc.rs
@@ -47,7 +47,7 @@ impl GccOutput {
             format!("Cannot find libgccjit at {}", self.libgccjit.display())
         );
 
-        let dest_dir = directory.join(self.target);
+        let dest_dir = directory.join("rustlib").join(self.target).join("lib");
         t!(fs::create_dir_all(&dest_dir));
         let dst = dest_dir.join(target_filename);
         builder.copy_link(&actual_libgccjit_path, &dst, FileType::NativeLibrary);

--- a/src/bootstrap/src/core/build_steps/gcc.rs
+++ b/src/bootstrap/src/core/build_steps/gcc.rs
@@ -27,6 +27,7 @@ pub struct Gcc {
 #[derive(Clone)]
 pub struct GccOutput {
     pub libgccjit: PathBuf,
+    target: TargetSelection,
 }
 
 impl GccOutput {
@@ -46,7 +47,9 @@ impl GccOutput {
             format!("Cannot find libgccjit at {}", self.libgccjit.display())
         );
 
-        let dst = directory.join(target_filename);
+        let dest_dir = directory.join(self.target);
+        t!(fs::create_dir_all(&dest_dir));
+        let dst = dest_dir.join(target_filename);
         builder.copy_link(&actual_libgccjit_path, &dst, FileType::NativeLibrary);
     }
 }
@@ -70,7 +73,7 @@ impl Step for Gcc {
 
         // If GCC has already been built, we avoid building it again.
         let metadata = match get_gcc_build_status(builder, target) {
-            GccBuildStatus::AlreadyBuilt(path) => return GccOutput { libgccjit: path },
+            GccBuildStatus::AlreadyBuilt(path) => return GccOutput { libgccjit: path, target },
             GccBuildStatus::ShouldBuild(m) => m,
         };
 
@@ -80,14 +83,14 @@ impl Step for Gcc {
 
         let libgccjit_path = libgccjit_built_path(&metadata.install_dir);
         if builder.config.dry_run() {
-            return GccOutput { libgccjit: libgccjit_path };
+            return GccOutput { libgccjit: libgccjit_path, target };
         }
 
         build_gcc(&metadata, builder, target);
 
         t!(metadata.stamp.write());
 
-        GccOutput { libgccjit: libgccjit_path }
+        GccOutput { libgccjit: libgccjit_path, target }
     }
 }
 

--- a/tests/mir-opt/inline/inline_instruction_set.rs
+++ b/tests/mir-opt/inline/inline_instruction_set.rs
@@ -4,6 +4,7 @@
 //
 //@ compile-flags: --target thumbv4t-none-eabi
 //@ needs-llvm-components: arm
+//@ ignore-backends: gcc
 
 #![crate_type = "lib"]
 #![feature(rustc_attrs)]

--- a/tests/ui/check-cfg/values-target-json.rs
+++ b/tests/ui/check-cfg/values-target-json.rs
@@ -5,6 +5,7 @@
 //@ no-auto-check-cfg
 //@ needs-llvm-components: x86
 //@ compile-flags: --crate-type=lib --check-cfg=cfg() --target={{src-base}}/check-cfg/my-awesome-platform.json
+//@ ignore-backends: gcc
 
 #![feature(lang_items, no_core, auto_traits, rustc_attrs)]
 #![no_core]

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-call/generics.rs
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-call/generics.rs
@@ -1,6 +1,7 @@
 //@ add-minicore
 //@ compile-flags: --target thumbv8m.main-none-eabi --crate-type lib
 //@ needs-llvm-components: arm
+//@ ignore-backends: gcc
 #![feature(abi_cmse_nonsecure_call, no_core, lang_items)]
 #![no_core]
 

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-call/generics.stderr
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-call/generics.stderr
@@ -1,11 +1,11 @@
 error: function pointer types may not have generic parameters
-  --> $DIR/generics.rs:14:40
+  --> $DIR/generics.rs:15:40
    |
 LL |     f1: extern "cmse-nonsecure-call" fn<U: Copy>(U, u32, u32, u32) -> u64,
    |                                        ^^^^^^^^^
 
 error[E0425]: cannot find type `U` in this scope
-  --> $DIR/generics.rs:14:50
+  --> $DIR/generics.rs:15:50
    |
 LL | struct Test<T: Copy> {
    |             - similarly named type parameter `T` defined here
@@ -23,7 +23,7 @@ LL | struct Test<T: Copy, U> {
    |                    +++
 
 error[E0562]: `impl Trait` is not allowed in `fn` pointer parameters
-  --> $DIR/generics.rs:17:41
+  --> $DIR/generics.rs:18:41
    |
 LL |     f2: extern "cmse-nonsecure-call" fn(impl Copy, u32, u32, u32) -> impl Copy,
    |                                         ^^^^^^^^^
@@ -31,7 +31,7 @@ LL |     f2: extern "cmse-nonsecure-call" fn(impl Copy, u32, u32, u32) -> impl C
    = note: `impl Trait` is only allowed in arguments and return types of functions and methods
 
 error[E0562]: `impl Trait` is not allowed in `fn` pointer return types
-  --> $DIR/generics.rs:17:70
+  --> $DIR/generics.rs:18:70
    |
 LL |     f2: extern "cmse-nonsecure-call" fn(impl Copy, u32, u32, u32) -> impl Copy,
    |                                                                      ^^^^^^^^^
@@ -39,7 +39,7 @@ LL |     f2: extern "cmse-nonsecure-call" fn(impl Copy, u32, u32, u32) -> impl C
    = note: `impl Trait` is only allowed in arguments and return types of functions and methods
 
 error[E0562]: `impl Trait` is not allowed in `fn` pointer parameters
-  --> $DIR/generics.rs:20:42
+  --> $DIR/generics.rs:21:42
    |
 LL |     f3: extern "cmse-nonsecure-call" fn((impl Copy, u32), u32, u32, u32) -> (impl Copy, u32),
    |                                          ^^^^^^^^^
@@ -47,7 +47,7 @@ LL |     f3: extern "cmse-nonsecure-call" fn((impl Copy, u32), u32, u32, u32) ->
    = note: `impl Trait` is only allowed in arguments and return types of functions and methods
 
 error[E0562]: `impl Trait` is not allowed in `fn` pointer return types
-  --> $DIR/generics.rs:20:78
+  --> $DIR/generics.rs:21:78
    |
 LL |     f3: extern "cmse-nonsecure-call" fn((impl Copy, u32), u32, u32, u32) -> (impl Copy, u32),
    |                                                                              ^^^^^^^^^
@@ -55,19 +55,19 @@ LL |     f3: extern "cmse-nonsecure-call" fn((impl Copy, u32), u32, u32, u32) ->
    = note: `impl Trait` is only allowed in arguments and return types of functions and methods
 
 error[E0798]: generics are not allowed in `extern "cmse-nonsecure-call"` signatures
-  --> $DIR/generics.rs:23:41
+  --> $DIR/generics.rs:24:41
    |
 LL |     f4: extern "cmse-nonsecure-call" fn(T, u32, u32, u32) -> u64,
    |                                         ^
 
 error[E0798]: generics are not allowed in `extern "cmse-nonsecure-call"` signatures
-  --> $DIR/generics.rs:24:41
+  --> $DIR/generics.rs:25:41
    |
 LL |     f5: extern "cmse-nonsecure-call" fn(Wrapper<T>, u32, u32, u32) -> u64,
    |                                         ^^^^^^^^^^
 
 error[E0798]: return value of `"cmse-nonsecure-call"` function too large to pass via registers
-  --> $DIR/generics.rs:30:71
+  --> $DIR/generics.rs:31:71
    |
 LL | type WithTraitObject = extern "cmse-nonsecure-call" fn(&dyn Trait) -> &dyn Trait;
    |                                                                       ^^^^^^^^^^ this type doesn't fit in the available registers
@@ -76,7 +76,7 @@ LL | type WithTraitObject = extern "cmse-nonsecure-call" fn(&dyn Trait) -> &dyn 
    = note: the result must either be a (transparently wrapped) i64, u64 or f64, or be at most 4 bytes in size
 
 error[E0798]: return value of `"cmse-nonsecure-call"` function too large to pass via registers
-  --> $DIR/generics.rs:34:60
+  --> $DIR/generics.rs:35:60
    |
 LL |     extern "cmse-nonsecure-call" fn(&'static dyn Trait) -> &'static dyn Trait;
    |                                                            ^^^^^^^^^^^^^^^^^^ this type doesn't fit in the available registers
@@ -85,7 +85,7 @@ LL |     extern "cmse-nonsecure-call" fn(&'static dyn Trait) -> &'static dyn Tra
    = note: the result must either be a (transparently wrapped) i64, u64 or f64, or be at most 4 bytes in size
 
 error[E0798]: return value of `"cmse-nonsecure-call"` function too large to pass via registers
-  --> $DIR/generics.rs:41:60
+  --> $DIR/generics.rs:42:60
    |
 LL |     extern "cmse-nonsecure-call" fn(WrapperTransparent) -> WrapperTransparent;
    |                                                            ^^^^^^^^^^^^^^^^^^ this type doesn't fit in the available registers
@@ -94,7 +94,7 @@ LL |     extern "cmse-nonsecure-call" fn(WrapperTransparent) -> WrapperTranspare
    = note: the result must either be a (transparently wrapped) i64, u64 or f64, or be at most 4 bytes in size
 
 error[E0045]: C-variadic functions with the "cmse-nonsecure-call" calling convention are not supported
-  --> $DIR/generics.rs:44:20
+  --> $DIR/generics.rs:45:20
    |
 LL | type WithVarArgs = extern "cmse-nonsecure-call" fn(u32, ...);
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ C-variadic function must have a compatible calling convention

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-call/infer.rs
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-call/infer.rs
@@ -1,6 +1,7 @@
 //@ add-minicore
 //@ compile-flags: --target thumbv8m.main-none-eabi --crate-type lib
 //@ needs-llvm-components: arm
+//@ ignore-backends: gcc
 #![feature(abi_cmse_nonsecure_call, no_core, lang_items)]
 #![no_core]
 

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-call/infer.stderr
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-call/infer.stderr
@@ -1,23 +1,23 @@
 error[E0282]: type annotations needed
-  --> $DIR/infer.rs:16:13
+  --> $DIR/infer.rs:17:13
    |
 LL |     let _ = mem::transmute::<fn() -> _, extern "cmse-nonsecure-call" fn() -> _>;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type of the type parameter `Src` declared on the function `transmute`
 
 error[E0282]: type annotations needed
-  --> $DIR/infer.rs:21:13
+  --> $DIR/infer.rs:22:13
    |
 LL |     let _ = mem::transmute::<fn() -> (i32, _), extern "cmse-nonsecure-call" fn() -> (i32, _)>;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type of the type parameter `Src` declared on the function `transmute`
 
 error[E0282]: type annotations needed
-  --> $DIR/infer.rs:26:13
+  --> $DIR/infer.rs:27:13
    |
 LL |     let _ = mem::transmute::<fn(_: _) -> (), extern "cmse-nonsecure-call" fn(_: _) -> ()>;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type of the type parameter `Src` declared on the function `transmute`
 
 error[E0282]: type annotations needed
-  --> $DIR/infer.rs:32:9
+  --> $DIR/infer.rs:33:9
    |
 LL |         mem::transmute::<fn(_: (i32, _)) -> (), extern "cmse-nonsecure-call" fn(_: (i32, _)) -> ()>;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type of the type parameter `Src` declared on the function `transmute`

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-call/params-via-stack.rs
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-call/params-via-stack.rs
@@ -1,6 +1,7 @@
 //@ add-minicore
 //@ compile-flags: --target thumbv8m.main-none-eabi --crate-type lib
 //@ needs-llvm-components: arm
+//@ ignore-backends: gcc
 #![feature(abi_cmse_nonsecure_call, no_core, lang_items)]
 #![no_core]
 

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-call/params-via-stack.stderr
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-call/params-via-stack.stderr
@@ -1,5 +1,5 @@
 error[E0798]: arguments for `"cmse-nonsecure-call"` function too large to pass via registers
-  --> $DIR/params-via-stack.rs:16:64
+  --> $DIR/params-via-stack.rs:17:64
    |
 LL |     f1: extern "cmse-nonsecure-call" fn(u32, u32, u32, u32, x: u32, y: u32),
    |                                                                ^^^     ^^^ does not fit in the available registers
@@ -9,7 +9,7 @@ LL |     f1: extern "cmse-nonsecure-call" fn(u32, u32, u32, u32, x: u32, y: u32)
    = note: functions with the `"cmse-nonsecure-call"` ABI must pass all their arguments via the 4 32-bit argument registers
 
 error[E0798]: arguments for `"cmse-nonsecure-call"` function too large to pass via registers
-  --> $DIR/params-via-stack.rs:17:61
+  --> $DIR/params-via-stack.rs:18:61
    |
 LL |     f2: extern "cmse-nonsecure-call" fn(u32, u32, u32, u16, u16),
    |                                                             ^^^ does not fit in the available registers
@@ -17,7 +17,7 @@ LL |     f2: extern "cmse-nonsecure-call" fn(u32, u32, u32, u16, u16),
    = note: functions with the `"cmse-nonsecure-call"` ABI must pass all their arguments via the 4 32-bit argument registers
 
 error[E0798]: arguments for `"cmse-nonsecure-call"` function too large to pass via registers
-  --> $DIR/params-via-stack.rs:18:51
+  --> $DIR/params-via-stack.rs:19:51
    |
 LL |     f3: extern "cmse-nonsecure-call" fn(u32, u64, u32),
    |                                                   ^^^ does not fit in the available registers
@@ -25,7 +25,7 @@ LL |     f3: extern "cmse-nonsecure-call" fn(u32, u64, u32),
    = note: functions with the `"cmse-nonsecure-call"` ABI must pass all their arguments via the 4 32-bit argument registers
 
 error[E0798]: arguments for `"cmse-nonsecure-call"` function too large to pass via registers
-  --> $DIR/params-via-stack.rs:19:56
+  --> $DIR/params-via-stack.rs:20:56
    |
 LL |     f4: extern "cmse-nonsecure-call" fn(AlignRelevant, u32),
    |                                                        ^^^ does not fit in the available registers
@@ -33,7 +33,7 @@ LL |     f4: extern "cmse-nonsecure-call" fn(AlignRelevant, u32),
    = note: functions with the `"cmse-nonsecure-call"` ABI must pass all their arguments via the 4 32-bit argument registers
 
 error[E0798]: arguments for `"cmse-nonsecure-call"` function too large to pass via registers
-  --> $DIR/params-via-stack.rs:20:41
+  --> $DIR/params-via-stack.rs:21:41
    |
 LL |     f5: extern "cmse-nonsecure-call" fn([u32; 5]),
    |                                         ^^^^^^^^ does not fit in the available registers

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-call/return-via-stack.rs
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-call/return-via-stack.rs
@@ -2,6 +2,7 @@
 //@ compile-flags: --target thumbv8m.main-none-eabi --crate-type lib
 //@ needs-llvm-components: arm
 //@ add-minicore
+//@ ignore-backends: gcc
 
 #![feature(abi_cmse_nonsecure_call, no_core, lang_items)]
 #![no_core]

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-call/return-via-stack.stderr
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-call/return-via-stack.stderr
@@ -1,5 +1,5 @@
 error[E0798]: return value of `"cmse-nonsecure-call"` function too large to pass via registers
-  --> $DIR/return-via-stack.rs:36:48
+  --> $DIR/return-via-stack.rs:37:48
    |
 LL |     u128: extern "cmse-nonsecure-call" fn() -> u128,
    |                                                ^^^^ this type doesn't fit in the available registers
@@ -8,7 +8,7 @@ LL |     u128: extern "cmse-nonsecure-call" fn() -> u128,
    = note: the result must either be a (transparently wrapped) i64, u64 or f64, or be at most 4 bytes in size
 
 error[E0798]: return value of `"cmse-nonsecure-call"` function too large to pass via registers
-  --> $DIR/return-via-stack.rs:37:48
+  --> $DIR/return-via-stack.rs:38:48
    |
 LL |     i128: extern "cmse-nonsecure-call" fn() -> i128,
    |                                                ^^^^ this type doesn't fit in the available registers
@@ -17,7 +17,7 @@ LL |     i128: extern "cmse-nonsecure-call" fn() -> i128,
    = note: the result must either be a (transparently wrapped) i64, u64 or f64, or be at most 4 bytes in size
 
 error[E0798]: return value of `"cmse-nonsecure-call"` function too large to pass via registers
-  --> $DIR/return-via-stack.rs:26:46
+  --> $DIR/return-via-stack.rs:27:46
    |
 LL |     f1: extern "cmse-nonsecure-call" fn() -> ReprCU64,
    |                                              ^^^^^^^^ this type doesn't fit in the available registers
@@ -26,7 +26,7 @@ LL |     f1: extern "cmse-nonsecure-call" fn() -> ReprCU64,
    = note: the result must either be a (transparently wrapped) i64, u64 or f64, or be at most 4 bytes in size
 
 error[E0798]: return value of `"cmse-nonsecure-call"` function too large to pass via registers
-  --> $DIR/return-via-stack.rs:27:46
+  --> $DIR/return-via-stack.rs:28:46
    |
 LL |     f2: extern "cmse-nonsecure-call" fn() -> ReprCBytes,
    |                                              ^^^^^^^^^^ this type doesn't fit in the available registers
@@ -35,7 +35,7 @@ LL |     f2: extern "cmse-nonsecure-call" fn() -> ReprCBytes,
    = note: the result must either be a (transparently wrapped) i64, u64 or f64, or be at most 4 bytes in size
 
 error[E0798]: return value of `"cmse-nonsecure-call"` function too large to pass via registers
-  --> $DIR/return-via-stack.rs:28:46
+  --> $DIR/return-via-stack.rs:29:46
    |
 LL |     f3: extern "cmse-nonsecure-call" fn() -> U64Compound,
    |                                              ^^^^^^^^^^^ this type doesn't fit in the available registers
@@ -44,7 +44,7 @@ LL |     f3: extern "cmse-nonsecure-call" fn() -> U64Compound,
    = note: the result must either be a (transparently wrapped) i64, u64 or f64, or be at most 4 bytes in size
 
 error[E0798]: return value of `"cmse-nonsecure-call"` function too large to pass via registers
-  --> $DIR/return-via-stack.rs:29:46
+  --> $DIR/return-via-stack.rs:30:46
    |
 LL |     f4: extern "cmse-nonsecure-call" fn() -> ReprCAlign16,
    |                                              ^^^^^^^^^^^^ this type doesn't fit in the available registers
@@ -53,7 +53,7 @@ LL |     f4: extern "cmse-nonsecure-call" fn() -> ReprCAlign16,
    = note: the result must either be a (transparently wrapped) i64, u64 or f64, or be at most 4 bytes in size
 
 error[E0798]: return value of `"cmse-nonsecure-call"` function too large to pass via registers
-  --> $DIR/return-via-stack.rs:30:46
+  --> $DIR/return-via-stack.rs:31:46
    |
 LL |     f5: extern "cmse-nonsecure-call" fn() -> [u8; 5],
    |                                              ^^^^^^^ this type doesn't fit in the available registers
@@ -62,7 +62,7 @@ LL |     f5: extern "cmse-nonsecure-call" fn() -> [u8; 5],
    = note: the result must either be a (transparently wrapped) i64, u64 or f64, or be at most 4 bytes in size
 
 error[E0798]: return value of `"cmse-nonsecure-call"` function too large to pass via registers
-  --> $DIR/return-via-stack.rs:52:46
+  --> $DIR/return-via-stack.rs:53:46
    |
 LL |     f1: extern "cmse-nonsecure-call" fn() -> ReprRustUnionU64,
    |                                              ^^^^^^^^^^^^^^^^ this type doesn't fit in the available registers
@@ -71,7 +71,7 @@ LL |     f1: extern "cmse-nonsecure-call" fn() -> ReprRustUnionU64,
    = note: the result must either be a (transparently wrapped) i64, u64 or f64, or be at most 4 bytes in size
 
 error[E0798]: return value of `"cmse-nonsecure-call"` function too large to pass via registers
-  --> $DIR/return-via-stack.rs:53:46
+  --> $DIR/return-via-stack.rs:54:46
    |
 LL |     f2: extern "cmse-nonsecure-call" fn() -> ReprCUnionU64,
    |                                              ^^^^^^^^^^^^^ this type doesn't fit in the available registers

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-call/undeclared-lifetime.rs
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-call/undeclared-lifetime.rs
@@ -2,6 +2,7 @@
 //@ compile-flags: --target thumbv8m.main-none-eabi --crate-type lib
 //@ incremental (required to trigger the bug)
 //@ needs-llvm-components: arm
+//@ ignore-backends: gcc
 #![feature(abi_cmse_nonsecure_call, no_core)]
 #![no_core]
 

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-call/undeclared-lifetime.stderr
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-call/undeclared-lifetime.stderr
@@ -1,5 +1,5 @@
 error[E0261]: use of undeclared lifetime name `'a`
-  --> $DIR/undeclared-lifetime.rs:15:43
+  --> $DIR/undeclared-lifetime.rs:16:43
    |
 LL |     id::<extern "cmse-nonsecure-call" fn(&'a ())>(PhantomData);
    |                                           ^^ undeclared lifetime

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-call/via-registers.rs
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-call/via-registers.rs
@@ -2,6 +2,7 @@
 //@ build-pass
 //@ compile-flags: --target thumbv8m.main-none-eabi --crate-type lib
 //@ needs-llvm-components: arm
+//@ ignore-backends: gcc
 #![feature(abi_cmse_nonsecure_call, no_core, lang_items, intrinsics)]
 #![no_core]
 

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-call/wrong-abi-location-1.rs
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-call/wrong-abi-location-1.rs
@@ -1,6 +1,7 @@
 //@ add-minicore
 //@ compile-flags: --target thumbv8m.main-none-eabi --crate-type lib
 //@ needs-llvm-components: arm
+//@ ignore-backends: gcc
 #![feature(abi_cmse_nonsecure_call, lang_items, no_core)]
 #![no_core]
 

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-call/wrong-abi-location-1.stderr
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-call/wrong-abi-location-1.stderr
@@ -1,5 +1,5 @@
 error[E0781]: the `"cmse-nonsecure-call"` ABI is only allowed on function pointers
-  --> $DIR/wrong-abi-location-1.rs:10:1
+  --> $DIR/wrong-abi-location-1.rs:11:1
    |
 LL | pub extern "cmse-nonsecure-call" fn test() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-call/wrong-abi-location-2.rs
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-call/wrong-abi-location-2.rs
@@ -1,6 +1,7 @@
 //@ add-minicore
 //@ compile-flags: --target thumbv8m.main-none-eabi --crate-type lib
 //@ needs-llvm-components: arm
+//@ ignore-backends: gcc
 #![feature(abi_cmse_nonsecure_call, lang_items, no_core)]
 #![no_core]
 

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-call/wrong-abi-location-2.stderr
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-call/wrong-abi-location-2.stderr
@@ -1,5 +1,5 @@
 error[E0781]: the `"cmse-nonsecure-call"` ABI is only allowed on function pointers
-  --> $DIR/wrong-abi-location-2.rs:10:1
+  --> $DIR/wrong-abi-location-2.rs:11:1
    |
 LL | / extern "cmse-nonsecure-call" {
 LL | |     fn test();

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/c-variadic.rs
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/c-variadic.rs
@@ -2,6 +2,7 @@
 //@ edition: 2018
 //@ compile-flags: --target thumbv8m.main-none-eabi --crate-type lib
 //@ needs-llvm-components: arm
+//@ ignore-backends: gcc
 #![feature(cmse_nonsecure_entry, c_variadic, no_core, lang_items)]
 #![no_core]
 

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/c-variadic.stderr
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/c-variadic.stderr
@@ -1,5 +1,5 @@
 error: `...` is not supported for `extern "cmse-nonsecure-entry"` functions
-  --> $DIR/c-variadic.rs:14:60
+  --> $DIR/c-variadic.rs:15:60
    |
 LL | unsafe extern "cmse-nonsecure-entry" fn c_variadic(_: u32, _: ...) {
    |        -----------------------------                       ^^^^^^
@@ -9,13 +9,13 @@ LL | unsafe extern "cmse-nonsecure-entry" fn c_variadic(_: u32, _: ...) {
    = help: only `extern "C"` and `extern "C-unwind"` functions may have a C variable argument list
 
 error: functions cannot be both `async` and C-variadic
-  --> $DIR/c-variadic.rs:19:1
+  --> $DIR/c-variadic.rs:20:1
    |
 LL | async unsafe extern "cmse-nonsecure-entry" fn async_and_c_variadic(_: ...) {
    | ^^^^^ `async` because of this                                      ^^^^^^ C-variadic because of this
 
 error: `...` is not supported for `extern "cmse-nonsecure-entry"` functions
-  --> $DIR/c-variadic.rs:19:68
+  --> $DIR/c-variadic.rs:20:68
    |
 LL | async unsafe extern "cmse-nonsecure-entry" fn async_and_c_variadic(_: ...) {
    |              -----------------------------                         ^^^^^^
@@ -25,7 +25,7 @@ LL | async unsafe extern "cmse-nonsecure-entry" fn async_and_c_variadic(_: ...) 
    = help: only `extern "C"` and `extern "C-unwind"` functions may have a C variable argument list
 
 error[E0798]: `impl Trait` is not allowed in `extern "cmse-nonsecure-entry"` signatures
-  --> $DIR/c-variadic.rs:25:1
+  --> $DIR/c-variadic.rs:26:1
    |
 LL | async unsafe extern "cmse-nonsecure-entry" fn async_is_not_allowed() {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/generics.rs
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/generics.rs
@@ -1,6 +1,7 @@
 //@ add-minicore
 //@ compile-flags: --target thumbv8m.main-none-eabi --crate-type lib
 //@ needs-llvm-components: arm
+//@ ignore-backends: gcc
 #![feature(cmse_nonsecure_entry, no_core, lang_items)]
 #![no_core]
 

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/generics.stderr
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/generics.stderr
@@ -1,53 +1,53 @@
 error[E0798]: generics are not allowed in `extern "cmse-nonsecure-entry"` signatures
-  --> $DIR/generics.rs:31:8
+  --> $DIR/generics.rs:32:8
    |
 LL |     _: U,
    |        ^
 
 error[E0798]: generics are not allowed in `extern "cmse-nonsecure-entry"` signatures
-  --> $DIR/generics.rs:64:48
+  --> $DIR/generics.rs:65:48
    |
 LL | extern "cmse-nonsecure-entry" fn impl_trait(_: impl Copy, _: u32, _: u32, _: u32) -> u64 {
    |                                                ^^^^^^^^^
 
 error[E0798]: generics are not allowed in `extern "cmse-nonsecure-entry"` signatures
-  --> $DIR/generics.rs:79:57
+  --> $DIR/generics.rs:80:57
    |
 LL | extern "cmse-nonsecure-entry" fn identity_impl_trait(v: impl Copy) -> impl Copy {
    |                                                         ^^^^^^^^^
 
 error[E0798]: `impl Trait` is not allowed in `extern "cmse-nonsecure-entry"` signatures
-  --> $DIR/generics.rs:79:71
+  --> $DIR/generics.rs:80:71
    |
 LL | extern "cmse-nonsecure-entry" fn identity_impl_trait(v: impl Copy) -> impl Copy {
    |                                                                       ^^^^^^^^^
 
 error[E0798]: generics are not allowed in `extern "cmse-nonsecure-entry"` signatures
-  --> $DIR/generics.rs:86:8
+  --> $DIR/generics.rs:87:8
    |
 LL |     v: (impl Copy, i32),
    |        ^^^^^^^^^^^^^^^^
 
 error[E0798]: `impl Trait` is not allowed in `extern "cmse-nonsecure-entry"` signatures
-  --> $DIR/generics.rs:88:6
+  --> $DIR/generics.rs:89:6
    |
 LL | ) -> (impl Copy, i32) {
    |      ^^^^^^^^^^^^^^^^
 
 error[E0798]: generics are not allowed in `extern "cmse-nonsecure-entry"` signatures
-  --> $DIR/generics.rs:14:57
+  --> $DIR/generics.rs:15:57
    |
 LL |     extern "cmse-nonsecure-entry" fn ambient_generic(_: T, _: u32, _: u32, _: u32) -> u64 {
    |                                                         ^
 
 error[E0798]: generics are not allowed in `extern "cmse-nonsecure-entry"` signatures
-  --> $DIR/generics.rs:20:12
+  --> $DIR/generics.rs:21:12
    |
 LL |         _: Wrapper<T>,
    |            ^^^^^^^^^^
 
 error[E0798]: return value of `"cmse-nonsecure-entry"` function too large to pass via registers
-  --> $DIR/generics.rs:46:65
+  --> $DIR/generics.rs:47:65
    |
 LL | extern "cmse-nonsecure-entry" fn trait_object(x: &dyn Trait) -> &dyn Trait {
    |                                                                 ^^^^^^^^^^ this type doesn't fit in the available registers
@@ -56,7 +56,7 @@ LL | extern "cmse-nonsecure-entry" fn trait_object(x: &dyn Trait) -> &dyn Trait 
    = note: the result must either be a (transparently wrapped) i64, u64 or f64, or be at most 4 bytes in size
 
 error[E0798]: return value of `"cmse-nonsecure-entry"` function too large to pass via registers
-  --> $DIR/generics.rs:51:80
+  --> $DIR/generics.rs:52:80
    |
 LL | extern "cmse-nonsecure-entry" fn static_trait_object(x: &'static dyn Trait) -> &'static dyn Trait {
    |                                                                                ^^^^^^^^^^^^^^^^^^ this type doesn't fit in the available registers
@@ -65,7 +65,7 @@ LL | extern "cmse-nonsecure-entry" fn static_trait_object(x: &'static dyn Trait)
    = note: the result must either be a (transparently wrapped) i64, u64 or f64, or be at most 4 bytes in size
 
 error[E0798]: return value of `"cmse-nonsecure-entry"` function too large to pass via registers
-  --> $DIR/generics.rs:59:81
+  --> $DIR/generics.rs:60:81
    |
 LL | extern "cmse-nonsecure-entry" fn wrapped_trait_object(x: WrapperTransparent) -> WrapperTransparent {
    |                                                                                 ^^^^^^^^^^^^^^^^^^ this type doesn't fit in the available registers
@@ -74,13 +74,13 @@ LL | extern "cmse-nonsecure-entry" fn wrapped_trait_object(x: WrapperTransparent
    = note: the result must either be a (transparently wrapped) i64, u64 or f64, or be at most 4 bytes in size
 
 error[E0798]: `impl Trait` is not allowed in `extern "cmse-nonsecure-entry"` signatures
-  --> $DIR/generics.rs:69:57
+  --> $DIR/generics.rs:70:57
    |
 LL | extern "cmse-nonsecure-entry" fn return_impl_trait() -> impl Copy {
    |                                                         ^^^^^^^^^
 
 error[E0798]: `impl Trait` is not allowed in `extern "cmse-nonsecure-entry"` signatures
-  --> $DIR/generics.rs:74:64
+  --> $DIR/generics.rs:75:64
    |
 LL | extern "cmse-nonsecure-entry" fn return_impl_trait_nested() -> (impl Copy, i32) {
    |                                                                ^^^^^^^^^^^^^^^^

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/infer.rs
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/infer.rs
@@ -1,6 +1,7 @@
 //@ add-minicore
 //@ compile-flags: --target thumbv8m.main-none-eabi --crate-type lib
 //@ needs-llvm-components: arm
+//@ ignore-backends: gcc
 #![feature(cmse_nonsecure_entry, no_core, lang_items)]
 #![no_core]
 

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/infer.stderr
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/infer.stderr
@@ -1,23 +1,23 @@
 error[E0282]: type annotations needed
-  --> $DIR/infer.rs:16:13
+  --> $DIR/infer.rs:17:13
    |
 LL |     let _ = mem::transmute::<fn() -> _, extern "cmse-nonsecure-entry" fn() -> _>;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type of the type parameter `Src` declared on the function `transmute`
 
 error[E0282]: type annotations needed
-  --> $DIR/infer.rs:21:13
+  --> $DIR/infer.rs:22:13
    |
 LL |     let _ = mem::transmute::<fn() -> (i32, _), extern "cmse-nonsecure-entry" fn() -> (i32, _)>;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type of the type parameter `Src` declared on the function `transmute`
 
 error[E0282]: type annotations needed
-  --> $DIR/infer.rs:26:13
+  --> $DIR/infer.rs:27:13
    |
 LL |     let _ = mem::transmute::<fn(_: _) -> (), extern "cmse-nonsecure-entry" fn(_: _) -> ()>;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type of the type parameter `Src` declared on the function `transmute`
 
 error[E0282]: type annotations needed
-  --> $DIR/infer.rs:31:13
+  --> $DIR/infer.rs:32:13
    |
 LL |       let _ = mem::transmute::<
    |  _____________^

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/params-via-stack.rs
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/params-via-stack.rs
@@ -1,6 +1,7 @@
 //@ add-minicore
 //@ compile-flags: --target thumbv8m.main-none-eabi --crate-type lib
 //@ needs-llvm-components: arm
+//@ ignore-backends: gcc
 #![feature(cmse_nonsecure_entry, no_core, lang_items)]
 #![no_core]
 

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/params-via-stack.stderr
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/params-via-stack.stderr
@@ -1,5 +1,5 @@
 error[E0798]: arguments for `"cmse-nonsecure-entry"` function too large to pass via registers
-  --> $DIR/params-via-stack.rs:15:76
+  --> $DIR/params-via-stack.rs:16:76
    |
 LL | pub extern "cmse-nonsecure-entry" fn f1(_: u32, _: u32, _: u32, _: u32, _: u32, _: u32) {}
    |                                                                            ^^^     ^^^ does not fit in the available registers
@@ -9,7 +9,7 @@ LL | pub extern "cmse-nonsecure-entry" fn f1(_: u32, _: u32, _: u32, _: u32, _: 
    = note: functions with the `"cmse-nonsecure-entry"` ABI must pass all their arguments via the 4 32-bit argument registers
 
 error[E0798]: arguments for `"cmse-nonsecure-entry"` function too large to pass via registers
-  --> $DIR/params-via-stack.rs:17:76
+  --> $DIR/params-via-stack.rs:18:76
    |
 LL | pub extern "cmse-nonsecure-entry" fn f2(_: u32, _: u32, _: u32, _: u16, _: u16) {}
    |                                                                            ^^^ does not fit in the available registers
@@ -17,7 +17,7 @@ LL | pub extern "cmse-nonsecure-entry" fn f2(_: u32, _: u32, _: u32, _: u16, _: 
    = note: functions with the `"cmse-nonsecure-entry"` ABI must pass all their arguments via the 4 32-bit argument registers
 
 error[E0798]: arguments for `"cmse-nonsecure-entry"` function too large to pass via registers
-  --> $DIR/params-via-stack.rs:19:60
+  --> $DIR/params-via-stack.rs:20:60
    |
 LL | pub extern "cmse-nonsecure-entry" fn f3(_: u32, _: u64, _: u32) {}
    |                                                            ^^^ does not fit in the available registers
@@ -25,7 +25,7 @@ LL | pub extern "cmse-nonsecure-entry" fn f3(_: u32, _: u64, _: u32) {}
    = note: functions with the `"cmse-nonsecure-entry"` ABI must pass all their arguments via the 4 32-bit argument registers
 
 error[E0798]: arguments for `"cmse-nonsecure-entry"` function too large to pass via registers
-  --> $DIR/params-via-stack.rs:21:62
+  --> $DIR/params-via-stack.rs:22:62
    |
 LL | pub extern "cmse-nonsecure-entry" fn f4(_: AlignRelevant, _: u32) {}
    |                                                              ^^^ does not fit in the available registers
@@ -33,7 +33,7 @@ LL | pub extern "cmse-nonsecure-entry" fn f4(_: AlignRelevant, _: u32) {}
    = note: functions with the `"cmse-nonsecure-entry"` ABI must pass all their arguments via the 4 32-bit argument registers
 
 error[E0798]: arguments for `"cmse-nonsecure-entry"` function too large to pass via registers
-  --> $DIR/params-via-stack.rs:25:44
+  --> $DIR/params-via-stack.rs:26:44
    |
 LL | pub extern "cmse-nonsecure-entry" fn f5(_: [u32; 5]) {}
    |                                            ^^^^^^^^ does not fit in the available registers

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/return-via-stack.rs
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/return-via-stack.rs
@@ -1,6 +1,7 @@
 //@ add-minicore
 //@ compile-flags: --target thumbv8m.main-none-eabi --crate-type lib
 //@ needs-llvm-components: arm
+//@ ignore-backends: gcc
 
 #![feature(cmse_nonsecure_entry, no_core, lang_items)]
 #![no_core]

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/return-via-stack.stderr
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/return-via-stack.stderr
@@ -1,5 +1,5 @@
 error[E0798]: return value of `"cmse-nonsecure-entry"` function too large to pass via registers
-  --> $DIR/return-via-stack.rs:24:46
+  --> $DIR/return-via-stack.rs:25:46
    |
 LL | pub extern "cmse-nonsecure-entry" fn f1() -> ReprCU64 {
    |                                              ^^^^^^^^ this type doesn't fit in the available registers
@@ -8,7 +8,7 @@ LL | pub extern "cmse-nonsecure-entry" fn f1() -> ReprCU64 {
    = note: the result must either be a (transparently wrapped) i64, u64 or f64, or be at most 4 bytes in size
 
 error[E0798]: return value of `"cmse-nonsecure-entry"` function too large to pass via registers
-  --> $DIR/return-via-stack.rs:29:46
+  --> $DIR/return-via-stack.rs:30:46
    |
 LL | pub extern "cmse-nonsecure-entry" fn f2() -> ReprCBytes {
    |                                              ^^^^^^^^^^ this type doesn't fit in the available registers
@@ -17,7 +17,7 @@ LL | pub extern "cmse-nonsecure-entry" fn f2() -> ReprCBytes {
    = note: the result must either be a (transparently wrapped) i64, u64 or f64, or be at most 4 bytes in size
 
 error[E0798]: return value of `"cmse-nonsecure-entry"` function too large to pass via registers
-  --> $DIR/return-via-stack.rs:34:46
+  --> $DIR/return-via-stack.rs:35:46
    |
 LL | pub extern "cmse-nonsecure-entry" fn f3() -> U64Compound {
    |                                              ^^^^^^^^^^^ this type doesn't fit in the available registers
@@ -26,7 +26,7 @@ LL | pub extern "cmse-nonsecure-entry" fn f3() -> U64Compound {
    = note: the result must either be a (transparently wrapped) i64, u64 or f64, or be at most 4 bytes in size
 
 error[E0798]: return value of `"cmse-nonsecure-entry"` function too large to pass via registers
-  --> $DIR/return-via-stack.rs:39:46
+  --> $DIR/return-via-stack.rs:40:46
    |
 LL | pub extern "cmse-nonsecure-entry" fn f4() -> ReprCAlign16 {
    |                                              ^^^^^^^^^^^^ this type doesn't fit in the available registers
@@ -35,7 +35,7 @@ LL | pub extern "cmse-nonsecure-entry" fn f4() -> ReprCAlign16 {
    = note: the result must either be a (transparently wrapped) i64, u64 or f64, or be at most 4 bytes in size
 
 error[E0798]: return value of `"cmse-nonsecure-entry"` function too large to pass via registers
-  --> $DIR/return-via-stack.rs:46:46
+  --> $DIR/return-via-stack.rs:47:46
    |
 LL | pub extern "cmse-nonsecure-entry" fn f5() -> [u8; 5] {
    |                                              ^^^^^^^ this type doesn't fit in the available registers
@@ -44,7 +44,7 @@ LL | pub extern "cmse-nonsecure-entry" fn f5() -> [u8; 5] {
    = note: the result must either be a (transparently wrapped) i64, u64 or f64, or be at most 4 bytes in size
 
 error[E0798]: return value of `"cmse-nonsecure-entry"` function too large to pass via registers
-  --> $DIR/return-via-stack.rs:52:48
+  --> $DIR/return-via-stack.rs:53:48
    |
 LL | pub extern "cmse-nonsecure-entry" fn u128() -> u128 {
    |                                                ^^^^ this type doesn't fit in the available registers
@@ -53,7 +53,7 @@ LL | pub extern "cmse-nonsecure-entry" fn u128() -> u128 {
    = note: the result must either be a (transparently wrapped) i64, u64 or f64, or be at most 4 bytes in size
 
 error[E0798]: return value of `"cmse-nonsecure-entry"` function too large to pass via registers
-  --> $DIR/return-via-stack.rs:58:48
+  --> $DIR/return-via-stack.rs:59:48
    |
 LL | pub extern "cmse-nonsecure-entry" fn i128() -> i128 {
    |                                                ^^^^ this type doesn't fit in the available registers
@@ -62,7 +62,7 @@ LL | pub extern "cmse-nonsecure-entry" fn i128() -> i128 {
    = note: the result must either be a (transparently wrapped) i64, u64 or f64, or be at most 4 bytes in size
 
 error[E0798]: return value of `"cmse-nonsecure-entry"` function too large to pass via registers
-  --> $DIR/return-via-stack.rs:75:54
+  --> $DIR/return-via-stack.rs:76:54
    |
 LL | pub extern "cmse-nonsecure-entry" fn union_rust() -> ReprRustUnionU64 {
    |                                                      ^^^^^^^^^^^^^^^^ this type doesn't fit in the available registers
@@ -71,7 +71,7 @@ LL | pub extern "cmse-nonsecure-entry" fn union_rust() -> ReprRustUnionU64 {
    = note: the result must either be a (transparently wrapped) i64, u64 or f64, or be at most 4 bytes in size
 
 error[E0798]: return value of `"cmse-nonsecure-entry"` function too large to pass via registers
-  --> $DIR/return-via-stack.rs:80:51
+  --> $DIR/return-via-stack.rs:81:51
    |
 LL | pub extern "cmse-nonsecure-entry" fn union_c() -> ReprCUnionU64 {
    |                                                   ^^^^^^^^^^^^^ this type doesn't fit in the available registers

--- a/tests/ui/feature-gates/feature-gate-abi-msp430-interrupt.rs
+++ b/tests/ui/feature-gates/feature-gate-abi-msp430-interrupt.rs
@@ -1,6 +1,7 @@
 //@ add-minicore
 //@ needs-llvm-components: msp430
 //@ compile-flags: --target=msp430-none-elf --crate-type=rlib
+//@ ignore-backends: gcc
 #![no_core]
 #![feature(no_core, lang_items)]
 

--- a/tests/ui/feature-gates/feature-gate-abi-msp430-interrupt.stderr
+++ b/tests/ui/feature-gates/feature-gate-abi-msp430-interrupt.stderr
@@ -1,5 +1,5 @@
 error[E0658]: the extern "msp430-interrupt" ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi-msp430-interrupt.rs:10:8
+  --> $DIR/feature-gate-abi-msp430-interrupt.rs:11:8
    |
 LL | extern "msp430-interrupt" fn f() {}
    |        ^^^^^^^^^^^^^^^^^^
@@ -9,7 +9,7 @@ LL | extern "msp430-interrupt" fn f() {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the extern "msp430-interrupt" ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi-msp430-interrupt.rs:14:12
+  --> $DIR/feature-gate-abi-msp430-interrupt.rs:15:12
    |
 LL |     extern "msp430-interrupt" fn m();
    |            ^^^^^^^^^^^^^^^^^^
@@ -19,7 +19,7 @@ LL |     extern "msp430-interrupt" fn m();
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the extern "msp430-interrupt" ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi-msp430-interrupt.rs:17:12
+  --> $DIR/feature-gate-abi-msp430-interrupt.rs:18:12
    |
 LL |     extern "msp430-interrupt" fn dm() {}
    |            ^^^^^^^^^^^^^^^^^^
@@ -29,7 +29,7 @@ LL |     extern "msp430-interrupt" fn dm() {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the extern "msp430-interrupt" ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi-msp430-interrupt.rs:23:12
+  --> $DIR/feature-gate-abi-msp430-interrupt.rs:24:12
    |
 LL |     extern "msp430-interrupt" fn m() {}
    |            ^^^^^^^^^^^^^^^^^^
@@ -39,7 +39,7 @@ LL |     extern "msp430-interrupt" fn m() {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the extern "msp430-interrupt" ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi-msp430-interrupt.rs:28:12
+  --> $DIR/feature-gate-abi-msp430-interrupt.rs:29:12
    |
 LL |     extern "msp430-interrupt" fn im() {}
    |            ^^^^^^^^^^^^^^^^^^
@@ -49,7 +49,7 @@ LL |     extern "msp430-interrupt" fn im() {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the extern "msp430-interrupt" ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi-msp430-interrupt.rs:32:18
+  --> $DIR/feature-gate-abi-msp430-interrupt.rs:33:18
    |
 LL | type TA = extern "msp430-interrupt" fn();
    |                  ^^^^^^^^^^^^^^^^^^
@@ -59,7 +59,7 @@ LL | type TA = extern "msp430-interrupt" fn();
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the extern "msp430-interrupt" ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi-msp430-interrupt.rs:35:8
+  --> $DIR/feature-gate-abi-msp430-interrupt.rs:36:8
    |
 LL | extern "msp430-interrupt" {}
    |        ^^^^^^^^^^^^^^^^^^

--- a/tests/ui/force-inlining/asm.rs
+++ b/tests/ui/force-inlining/asm.rs
@@ -2,6 +2,7 @@
 //@ build-fail
 //@ compile-flags: --crate-type=lib --target thumbv4t-none-eabi
 //@ needs-llvm-components: arm
+//@ ignore-backends: gcc
 
 // Checks that forced inlining won't mix asm with incompatible instruction sets.
 

--- a/tests/ui/force-inlining/asm.stderr
+++ b/tests/ui/force-inlining/asm.stderr
@@ -1,5 +1,5 @@
 error: `instruction_set_a32` could not be inlined into `t32` but is required to be inlined
-  --> $DIR/asm.rs:45:5
+  --> $DIR/asm.rs:46:5
    |
 LL |     instruction_set_a32();
    |     ^^^^^^^^^^^^^^^^^^^^^ ...`instruction_set_a32` called here
@@ -7,7 +7,7 @@ LL |     instruction_set_a32();
    = note: could not be inlined due to: incompatible instruction set
 
 error: `inline_always_and_using_inline_asm` could not be inlined into `t32` but is required to be inlined
-  --> $DIR/asm.rs:49:5
+  --> $DIR/asm.rs:50:5
    |
 LL |     inline_always_and_using_inline_asm();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ...`inline_always_and_using_inline_asm` called here
@@ -15,7 +15,7 @@ LL |     inline_always_and_using_inline_asm();
    = note: could not be inlined due to: cannot move inline-asm across instruction sets
 
 error: `instruction_set_a32` could not be inlined into `default` but is required to be inlined
-  --> $DIR/asm.rs:54:5
+  --> $DIR/asm.rs:55:5
    |
 LL |     instruction_set_a32();
    |     ^^^^^^^^^^^^^^^^^^^^^ ...`instruction_set_a32` called here
@@ -23,7 +23,7 @@ LL |     instruction_set_a32();
    = note: could not be inlined due to: incompatible instruction set
 
 error: `instruction_set_t32` could not be inlined into `default` but is required to be inlined
-  --> $DIR/asm.rs:56:5
+  --> $DIR/asm.rs:57:5
    |
 LL |     instruction_set_t32();
    |     ^^^^^^^^^^^^^^^^^^^^^ ...`instruction_set_t32` called here

--- a/tests/ui/issues/issue-37131.rs
+++ b/tests/ui/issues/issue-37131.rs
@@ -7,5 +7,6 @@
 //@ compile-flags: --target=thumbv6m-none-eabi
 //@ ignore-arm
 //@ needs-llvm-components: arm
+//@ ignore-backends: gcc
 
 fn main() { }

--- a/tests/ui/linkage-attr/raw-dylib/windows/unsupported-abi.rs
+++ b/tests/ui/linkage-attr/raw-dylib/windows/unsupported-abi.rs
@@ -2,6 +2,7 @@
 //@ compile-flags: --target x86_64-pc-windows-msvc
 //@ compile-flags: --crate-type lib --emit link
 //@ needs-llvm-components: x86
+//@ ignore-backends: gcc
 #![no_core]
 #![feature(no_core)]
 extern crate minicore;

--- a/tests/ui/linkage-attr/raw-dylib/windows/unsupported-abi.stderr
+++ b/tests/ui/linkage-attr/raw-dylib/windows/unsupported-abi.stderr
@@ -1,5 +1,5 @@
 warning: "stdcall" is not a supported ABI for the current target
-  --> $DIR/unsupported-abi.rs:13:1
+  --> $DIR/unsupported-abi.rs:14:1
    |
 LL | / extern "stdcall" {
 LL | |
@@ -15,7 +15,7 @@ LL | | }
    = note: `#[warn(unsupported_calling_conventions)]` (part of `#[warn(future_incompatible)]`) on by default
 
 error: ABI not supported by `#[link(kind = "raw-dylib")]` on this architecture
-  --> $DIR/unsupported-abi.rs:16:5
+  --> $DIR/unsupported-abi.rs:17:5
    |
 LL |     fn f(x: i32);
    |     ^^^^^^^^^^^^^

--- a/tests/ui/print-request/supported-crate-types.rs
+++ b/tests/ui/print-request/supported-crate-types.rs
@@ -17,9 +17,11 @@
 
 //@[wasm] compile-flags: --target=wasm32-unknown-unknown --print=supported-crate-types -Zunstable-options
 //@[wasm] needs-llvm-components: webassembly
+//@[wasm] ignore-backends: gcc
 
 //@[musl] compile-flags: --target=x86_64-unknown-linux-musl --print=supported-crate-types -Zunstable-options
 //@[musl] needs-llvm-components: x86
+//@[musl] ignore-backends: gcc
 
 //@[linux] compile-flags: --target=x86_64-unknown-linux-gnu --print=supported-crate-types -Zunstable-options
 //@[linux] needs-llvm-components: x86

--- a/tests/ui/repr/repr_align_greater_usize.msp430.stderr
+++ b/tests/ui/repr/repr_align_greater_usize.msp430.stderr
@@ -1,5 +1,5 @@
 error[E0589]: alignment must not be greater than `isize::MAX` bytes
-  --> $DIR/repr_align_greater_usize.rs:22:8
+  --> $DIR/repr_align_greater_usize.rs:23:8
    |
 LL | #[repr(align(32768))]
    |        ^^^^^^^^^^^^
@@ -7,7 +7,7 @@ LL | #[repr(align(32768))]
    = note: `isize::MAX` is 32767 for the current target
 
 error[E0589]: alignment must not be greater than `isize::MAX` bytes
-  --> $DIR/repr_align_greater_usize.rs:25:8
+  --> $DIR/repr_align_greater_usize.rs:26:8
    |
 LL | #[repr(align(65536))]
    |        ^^^^^^^^^^^^

--- a/tests/ui/repr/repr_align_greater_usize.rs
+++ b/tests/ui/repr/repr_align_greater_usize.rs
@@ -5,6 +5,7 @@
 //@[aarch32] build-pass
 //@[aarch32] needs-llvm-components: arm
 //@[aarch32] compile-flags: --target=thumbv7m-none-eabi
+//@ ignore-backends: gcc
 
 // We should fail to compute alignment for types aligned higher than usize::MAX.
 // We can't handle alignments that require all 32 bits, so this only affects 16-bit.

--- a/tests/ui/target-feature/abi-incompatible-target-feature-attribute-fcw.rs
+++ b/tests/ui/target-feature/abi-incompatible-target-feature-attribute-fcw.rs
@@ -2,6 +2,7 @@
 //@ compile-flags: --target=aarch64-unknown-none-softfloat
 //@ needs-llvm-components: aarch64
 //@ add-minicore
+//@ ignore-backends: gcc
 #![feature(no_core)]
 #![no_core]
 #![deny(aarch64_softfloat_neon)]

--- a/tests/ui/target-feature/abi-incompatible-target-feature-attribute-fcw.stderr
+++ b/tests/ui/target-feature/abi-incompatible-target-feature-attribute-fcw.stderr
@@ -1,5 +1,5 @@
 error: enabling the `neon` target feature on the current target is unsound due to ABI issues
-  --> $DIR/abi-incompatible-target-feature-attribute-fcw.rs:12:18
+  --> $DIR/abi-incompatible-target-feature-attribute-fcw.rs:13:18
    |
 LL | #[target_feature(enable = "neon")]
    |                  ^^^^^^^^^^^^^^^
@@ -7,7 +7,7 @@ LL | #[target_feature(enable = "neon")]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #134375 <https://github.com/rust-lang/rust/issues/134375>
 note: the lint level is defined here
-  --> $DIR/abi-incompatible-target-feature-attribute-fcw.rs:7:9
+  --> $DIR/abi-incompatible-target-feature-attribute-fcw.rs:8:9
    |
 LL | #![deny(aarch64_softfloat_neon)]
    |         ^^^^^^^^^^^^^^^^^^^^^^
@@ -16,7 +16,7 @@ error: aborting due to 1 previous error
 
 Future incompatibility report: Future breakage diagnostic:
 error: enabling the `neon` target feature on the current target is unsound due to ABI issues
-  --> $DIR/abi-incompatible-target-feature-attribute-fcw.rs:12:18
+  --> $DIR/abi-incompatible-target-feature-attribute-fcw.rs:13:18
    |
 LL | #[target_feature(enable = "neon")]
    |                  ^^^^^^^^^^^^^^^
@@ -24,7 +24,7 @@ LL | #[target_feature(enable = "neon")]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #134375 <https://github.com/rust-lang/rust/issues/134375>
 note: the lint level is defined here
-  --> $DIR/abi-incompatible-target-feature-attribute-fcw.rs:7:9
+  --> $DIR/abi-incompatible-target-feature-attribute-fcw.rs:8:9
    |
 LL | #![deny(aarch64_softfloat_neon)]
    |         ^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/target-feature/feature-hierarchy.rs
+++ b/tests/ui/target-feature/feature-hierarchy.rs
@@ -5,6 +5,7 @@
 //@ [aarch64-sve2] needs-llvm-components: aarch64
 //@ build-pass
 //@ add-minicore
+//@ ignore-backends: gcc
 #![no_core]
 #![crate_type = "rlib"]
 #![feature(intrinsics, rustc_attrs, no_core, staged_api)]

--- a/tests/ui/target-feature/no-llvm-leaks.rs
+++ b/tests/ui/target-feature/no-llvm-leaks.rs
@@ -2,6 +2,7 @@
 //@ revisions: aarch64 x86-64
 //@ [aarch64] compile-flags: -Ctarget-feature=+neon,+fp16,+fhm --target=aarch64-unknown-linux-gnu
 //@ [aarch64] needs-llvm-components: aarch64
+//@ [aarch64] ignore-backends: gcc
 //@ [x86-64] compile-flags: -Ctarget-feature=+sse4.2,+rdrand --target=x86_64-unknown-linux-gnu
 //@ [x86-64] needs-llvm-components: x86
 //@ build-pass


### PR DESCRIPTION
Since GCC is not multi-target, we need multiple libgccjit.so. Our solution to have a directory per target so that we can have multiple libgccjit.so.

r? @Kobzol