### PR TITLE
Fix span note for question mark expression

### DIFF
--- a/tests/ui/traits/question-mark-result-err-mismatch.rs
+++ b/tests/ui/traits/question-mark-result-err-mismatch.rs
@@ -9,7 +9,7 @@ fn foo() -> Result<String, String> { //~ NOTE expected `String` because of this
         });
     let one = x
         .map(|s| ())
-        .map_err(|e| { //~ NOTE this can't be annotated with `?` because it has type `Result<_, ()>`
+        .map_err(|e| { //~ NOTE this has type `Result<_, ()>`
             e; //~ HELP remove this semicolon
         })
         .map(|()| "")?; //~ ERROR `?` couldn't convert the error to `String`

--- a/tests/ui/traits/question-mark-result-err-mismatch.stderr
+++ b/tests/ui/traits/question-mark-result-err-mismatch.stderr
@@ -9,7 +9,7 @@ LL |           .map_err(|e| {
 LL | |             e;
    | |              - help: remove this semicolon
 LL | |         })
-   | |__________- this can't be annotated with `?` because it has type `Result<_, ()>`
+   | |__________- this has type `Result<_, ()>`
 LL |           .map(|()| "")?;
    |                        ^ the trait `From<()>` is not implemented for `String`
    |

--- a/tests/ui/traits/question-mark-span-144304.rs
+++ b/tests/ui/traits/question-mark-span-144304.rs
@@ -1,0 +1,8 @@
+//@ ignore-arm - armhf-gnu have more types implement trait `From<T>`, let's skip it
+fn f() -> Result<(), i32> {
+    Err("str").map_err(|e| e)?; //~ ERROR `?` couldn't convert the error to `i32`
+    Err("str").map_err(|e| e.to_string())?; //~ ERROR `?` couldn't convert the error to `i32`
+    Ok(())
+}
+
+fn main() {}

--- a/tests/ui/traits/question-mark-span-144304.stderr
+++ b/tests/ui/traits/question-mark-span-144304.stderr
@@ -1,0 +1,41 @@
+error[E0277]: `?` couldn't convert the error to `i32`
+  --> $DIR/question-mark-span-144304.rs:3:30
+   |
+LL | fn f() -> Result<(), i32> {
+   |           --------------- expected `i32` because of this
+LL |     Err("str").map_err(|e| e)?;
+   |     ----------               ^ the trait `From<&str>` is not implemented for `i32`
+   |     |
+   |     this has type `Result<_, &str>`
+   |
+   = note: the question mark operation (`?`) implicitly performs a conversion on the error value using the `From` trait
+   = help: the following other types implement trait `From<T>`:
+             `i32` implements `From<bool>`
+             `i32` implements `From<i16>`
+             `i32` implements `From<i8>`
+             `i32` implements `From<u16>`
+             `i32` implements `From<u8>`
+
+error[E0277]: `?` couldn't convert the error to `i32`
+  --> $DIR/question-mark-span-144304.rs:4:42
+   |
+LL | fn f() -> Result<(), i32> {
+   |           --------------- expected `i32` because of this
+LL |     Err("str").map_err(|e| e)?;
+LL |     Err("str").map_err(|e| e.to_string())?;
+   |     ---------- --------------------------^ the trait `From<String>` is not implemented for `i32`
+   |     |          |
+   |     |          this can't be annotated with `?` because it has type `Result<_, String>`
+   |     this has type `Result<_, &str>`
+   |
+   = note: the question mark operation (`?`) implicitly performs a conversion on the error value using the `From` trait
+   = help: the following other types implement trait `From<T>`:
+             `i32` implements `From<bool>`
+             `i32` implements `From<i16>`
+             `i32` implements `From<i8>`
+             `i32` implements `From<u16>`
+             `i32` implements `From<u8>`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Fixes rust-lang/rust#144304

Seems it's better to fix the note instead of modifying the span to cover the whole expression.

r? @estebank