### PR TITLE
collapse `constness` query `match` logic

### DIFF
--- a/tests/crashes/137187.rs
+++ b/tests/crashes/137187.rs
@@ -1,9 +1,10 @@
 //@ known-bug: #137187
 use std::ops::Add;
-trait A where
+
+const trait A where
     *const Self: Add,
 {
-    const fn b(c: *const Self) -> <*const Self as Add>::Output {
+    fn b(c: *const Self) -> <*const Self as Add>::Output {
         c + c
     }
 }


### PR DESCRIPTION
We already have the HIR node data, so no need for asking `def_kind` again.

r? oli-obk
