### PR TITLE
make assoc fn inherit const stability from inherent `const impl` blocks

### DIFF
--- a/compiler/rustc_passes/src/stability.rs
+++ b/compiler/rustc_passes/src/stability.rs
@@ -54,7 +54,7 @@ fn inherit_const_stability(tcx: TyCtxt<'_>, def_id: LocalDefId) -> bool {
     match def_kind {
         DefKind::AssocFn | DefKind::AssocTy | DefKind::AssocConst => {
             match tcx.def_kind(tcx.local_parent(def_id)) {
-                DefKind::Impl { of_trait: true } => true,
+                DefKind::Impl { .. } => true,
                 _ => false,
             }
         }

--- a/tests/ui/traits/const-traits/auxiliary/staged-api.rs
+++ b/tests/ui/traits/const-traits/auxiliary/staged-api.rs
@@ -1,4 +1,3 @@
-//@ compile-flags: -Znext-solver
 #![feature(const_trait_impl)]
 #![feature(staged_api)]
 #![stable(feature = "rust1", since = "1.0.0")]
@@ -17,6 +16,14 @@ pub struct Unstable;
 #[rustc_const_unstable(feature = "unstable", issue = "none")]
 impl const MyTrait for Unstable {
     fn func() {}
+}
+
+// tested in inherent-impl-stability.rs instead to avoid clutter
+#[stable(feature = "rust1", since = "1.0.0")]
+#[rustc_const_unstable(feature = "unstable", issue = "none")]
+const impl Unstable {
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub fn inherent_func() {}
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/tests/ui/traits/const-traits/inherent-impl-stability.rs
+++ b/tests/ui/traits/const-traits/inherent-impl-stability.rs
@@ -1,0 +1,16 @@
+//@ aux-build: staged-api.rs
+extern crate staged_api;
+
+use staged_api::*;
+
+// Const stability has no impact on usage in non-const contexts.
+fn non_const_context() {
+    Unstable::inherent_func();
+}
+
+const fn stable_const_context() {
+    Unstable::inherent_func();
+    //~^ ERROR: `staged_api::Unstable::inherent_func` is not yet stable as a const fn
+}
+
+fn main() {}

--- a/tests/ui/traits/const-traits/inherent-impl-stability.stderr
+++ b/tests/ui/traits/const-traits/inherent-impl-stability.stderr
@@ -1,0 +1,13 @@
+error: `staged_api::Unstable::inherent_func` is not yet stable as a const fn
+  --> $DIR/inherent-impl-stability.rs:12:5
+   |
+LL |     Unstable::inherent_func();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: add `#![feature(unstable)]` to the crate attributes to enable
+   |
+LL + #![feature(unstable)]
+   |
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Pulled out of rust-lang/rust#147893, "Currently, one cannot add any const stability annotations on the individual assoc fns at all, as the specific pass that checks for const stability on const fn seems to run as a HIR visitor [and looks at HIR assoc fn constness, which should be changed to also look at its parent]. I suspect there are things to be cleaned up there."

I was slightly lazy so didn't add the "staged_api using staged_api in implicit const stable context, in const unstable context, in explicit const stable context" tests. nudge me if you want to see those! 