### PR TITLE
Remove an unnecessary `unwrap` in `rustc_codegen_gcc`

### DIFF
--- a/compiler/rustc_codegen_gcc/src/builder.rs
+++ b/compiler/rustc_codegen_gcc/src/builder.rs
@@ -503,9 +503,9 @@ fn set_rvalue_location<'a, 'gcc, 'tcx>(
     bx: &mut Builder<'a, 'gcc, 'tcx>,
     rvalue: RValue<'gcc>,
 ) -> RValue<'gcc> {
-    if bx.location.is_some() {
+    if let Some(location) = bx.location {
         #[cfg(feature = "master")]
-        rvalue.set_location(bx.location.unwrap());
+        rvalue.set_location(location);
     }
     rvalue
 }


### PR DESCRIPTION
This should hopefully unblock rust-lang/rust#149425 (I couldn't find an in-flight PR that was already doing this).
I've tested  locally with the `master` version of Clippy that `rustc_codegen_gcc` passes the lints (the syncing PR could still fail for other reasons however).

I understand that `rustc_codegen_gcc` is normally developed [outside of this repo](https://github.com/rust-lang/rustc_codegen_gcc) but my understanding is that that repo is two-way synced regularly and hopefully it is acceptable to do this tiny change here to unblock the Clippy syncing PR (is there an established process for how to unblock these syncing PRs?). Of course feel free to close if this isn't the expected process.

<!-- homu-ignore:start -->
r? @matthiaskrgr
<!-- homu-ignore:end -->