### PR TITLE
doc: panic::{take_hook, set_hook, update_hook} abort when called from…

### DIFF
--- a/library/std/src/panicking.rs
+++ b/library/std/src/panicking.rs
@@ -121,9 +121,9 @@ static HOOK: RwLock<Hook> = RwLock::new(Hook::Default);
 ///
 /// The panic hook is a global resource.
 ///
-/// # Panics
+/// # Aborts
 ///
-/// Panics if called from a panicking thread.
+/// Aborts if called from a panicking thread.
 ///
 /// # Examples
 ///
@@ -158,9 +158,9 @@ pub fn set_hook(hook: Box<dyn Fn(&PanicHookInfo<'_>) + 'static + Sync + Send>) {
 ///
 /// If the default hook is registered it will be returned, but remain registered.
 ///
-/// # Panics
+/// # Aborts
 ///
-/// Panics if called from a panicking thread.
+/// Aborts if called from a panicking thread.
 ///
 /// # Examples
 ///
@@ -193,9 +193,9 @@ pub fn take_hook() -> Box<dyn Fn(&PanicHookInfo<'_>) + 'static + Sync + Send> {
 /// [`take_hook`]: ./fn.take_hook.html
 /// [`set_hook`]: ./fn.set_hook.html
 ///
-/// # Panics
+/// # Aborts
 ///
-/// Panics if called from a panicking thread.
+/// Aborts if called from a panicking thread.
 ///
 /// # Examples
 ///


### PR DESCRIPTION
We had an abort in production because I skimmed the docs for `take_hook`, not realizing that calling it from a panicking thread results in an abort. The code was written defensively to account for panics but failed to account for a function that outright aborts if called under the wrong circumstances.

It seems better to short circuit the comment and cut straight to the chase instead of letting reader deduce 2*panic == abort.

OTOH, there is no precedent for an `Aborts` section anywhere else in std.