### PR TITLE
std: don't call `current_os_id` from signal handler

### DIFF
--- a/library/std/src/rt.rs
+++ b/library/std/src/rt.rs
@@ -109,14 +109,14 @@ fn handle_rt_panic<T>(e: Box<dyn Any + Send>) -> T {
 // `compiler/rustc_session/src/config/sigpipe.rs`.
 #[cfg_attr(test, allow(dead_code))]
 unsafe fn init(argc: isize, argv: *const *const u8, sigpipe: u8) {
+    // Remember the main thread ID to give it the correct name.
+    // SAFETY: this is the only time and place where we call this function.
+    unsafe { main_thread::set(thread::current_id()) };
+
     #[cfg_attr(target_os = "teeos", allow(unused_unsafe))]
     unsafe {
         sys::init(argc, argv, sigpipe)
     };
-
-    // Remember the main thread ID to give it the correct name.
-    // SAFETY: this is the only time and place where we call this function.
-    unsafe { main_thread::set(thread::current_id()) };
 }
 
 /// Clean up the thread-local runtime state. This *should* be run after all other

--- a/library/std/src/sys/thread/unix.rs
+++ b/library/std/src/sys/thread/unix.rs
@@ -14,7 +14,7 @@ use crate::sys::weak::dlsym;
 #[cfg(any(target_os = "solaris", target_os = "illumos", target_os = "nto",))]
 use crate::sys::weak::weak;
 use crate::sys::{os, stack_overflow};
-use crate::thread::{ThreadInit, current};
+use crate::thread::ThreadInit;
 use crate::time::Duration;
 use crate::{cmp, io, ptr};
 #[cfg(not(any(
@@ -111,10 +111,9 @@ impl Thread {
                 let init = Box::from_raw(data as *mut ThreadInit);
                 let rust_start = init.init();
 
-                // Set up our thread name and stack overflow handler which may get triggered
-                // if we run out of stack.
-                let thread = current();
-                let _handler = stack_overflow::Handler::new(thread.name().map(Box::from));
+                // Now that the thread information is set, set up our stack
+                // overflow handler.
+                let _handler = stack_overflow::Handler::new();
 
                 rust_start();
             }


### PR DESCRIPTION
`current_os_id` is not always async-signal-safe depending on the platform, hence it may not be called from the SIGSEGV handler. Instead, store the thread ID along with the thread name during setup. With rust-lang/rust#144465 merged, this information is available even before the thread main function.