### PR TITLE
[DO NOT MERGE] Check performance hit of emitting full metadata in check mode

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/linker.rs
+++ b/compiler/rustc_codegen_ssa/src/back/linker.rs
@@ -1836,11 +1836,6 @@ fn exported_symbols_for_non_proc_macro(
 }
 
 fn exported_symbols_for_proc_macro_crate(tcx: TyCtxt<'_>) -> Vec<(String, SymbolExportKind)> {
-    // `exported_symbols` will be empty when !should_codegen.
-    if !tcx.sess.opts.output_types.should_codegen() {
-        return Vec::new();
-    }
-
     let stable_crate_id = tcx.stable_crate_id(LOCAL_CRATE);
     let proc_macro_decls_name = tcx.sess.generate_proc_macro_decls_symbol(stable_crate_id);
 

--- a/compiler/rustc_codegen_ssa/src/back/symbol_export.rs
+++ b/compiler/rustc_codegen_ssa/src/back/symbol_export.rs
@@ -47,10 +47,6 @@ pub fn crates_export_threshold(crate_types: &[CrateType]) -> SymbolExportLevel {
 }
 
 fn reachable_non_generics_provider(tcx: TyCtxt<'_>, _: LocalCrate) -> DefIdMap<SymbolExportInfo> {
-    if !tcx.sess.opts.output_types.should_codegen() && !tcx.is_sdylib_interface_build() {
-        return Default::default();
-    }
-
     let is_compiler_builtins = tcx.is_compiler_builtins(LOCAL_CRATE);
 
     let mut reachable_non_generics: DefIdMap<_> = tcx
@@ -166,10 +162,6 @@ fn exported_non_generic_symbols_provider_local<'tcx>(
     tcx: TyCtxt<'tcx>,
     _: LocalCrate,
 ) -> &'tcx [(ExportedSymbol<'tcx>, SymbolExportInfo)] {
-    if !tcx.sess.opts.output_types.should_codegen() && !tcx.is_sdylib_interface_build() {
-        return &[];
-    }
-
     // FIXME: Sorting this is unnecessary since we are sorting later anyway.
     //        Can we skip the later sorting?
     let sorted = tcx.with_stable_hashing_context(|hcx| {
@@ -221,10 +213,6 @@ fn exported_generic_symbols_provider_local<'tcx>(
     tcx: TyCtxt<'tcx>,
     _: LocalCrate,
 ) -> &'tcx [(ExportedSymbol<'tcx>, SymbolExportInfo)] {
-    if !tcx.sess.opts.output_types.should_codegen() && !tcx.is_sdylib_interface_build() {
-        return &[];
-    }
-
     let mut symbols: Vec<_> = vec![];
 
     if tcx.local_crate_exports_generics() {

--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -1114,9 +1114,7 @@ fn run_required_analyses(tcx: TyCtxt<'_>) {
             // If we need to codegen, ensure that we emit all errors from
             // `mir_drops_elaborated_and_const_checked` now, to avoid discovering
             // them later during codegen.
-            if tcx.sess.opts.output_types.should_codegen()
-                || tcx.hir_body_const_context(def_id).is_some()
-            {
+            if tcx.hir_body_const_context(def_id).is_some() {
                 tcx.ensure_ok().mir_drops_elaborated_and_const_checked(def_id);
             }
             if tcx.is_coroutine(def_id.to_def_id()) {


### PR DESCRIPTION
In https://github.com/rust-lang/rfcs/pull/3881#discussion_r2548965560 we are discussing how much this perf hit actually is. It was up to 10% when this optimization was originally done. It is not clear if this is still the case or what exactly is responsible for this big of a hit.