### PR TITLE
Run clippy on cg_gcc in CI

### DIFF
--- a/compiler/rustc_codegen_gcc/src/builder.rs
+++ b/compiler/rustc_codegen_gcc/src/builder.rs
@@ -500,11 +500,11 @@ impl<'gcc, 'tcx> BackendTypes for Builder<'_, 'gcc, 'tcx> {
 }
 
 fn set_rvalue_location<'a, 'gcc, 'tcx>(
-    bx: &mut Builder<'a, 'gcc, 'tcx>,
+    _bx: &mut Builder<'a, 'gcc, 'tcx>,
     rvalue: RValue<'gcc>,
 ) -> RValue<'gcc> {
-    if let Some(location) = bx.location {
-        #[cfg(feature = "master")]
+    #[cfg(feature = "master")]
+    if let Some(location) = _bx.location {
         rvalue.set_location(location);
     }
     rvalue

--- a/src/bootstrap/src/core/build_steps/clippy.rs
+++ b/src/bootstrap/src/core/build_steps/clippy.rs
@@ -394,6 +394,7 @@ impl Step for CodegenGcc {
             &[],
         );
         self.build_compiler.configure_cargo(&mut cargo);
+        println!("Now running clippy on `rustc_codegen_gcc` with `--no-default-features`");
         cargo.arg("--no-default-features");
         run_cargo(builder, cargo, args, &stamp, vec![], true, false);
     }

--- a/src/bootstrap/src/core/build_steps/clippy.rs
+++ b/src/bootstrap/src/core/build_steps/clippy.rs
@@ -379,15 +379,23 @@ impl Step for CodegenGcc {
         let stamp = BuildStamp::new(&builder.cargo_out(build_compiler, Mode::Codegen, target))
             .with_prefix("rustc_codegen_gcc-check");
 
-        run_cargo(
+        let args = lint_args(builder, &self.config, &[]);
+        run_cargo(builder, cargo, args.clone(), &stamp, vec![], true, false);
+
+        // Same but we disable the features enabled by default.
+        let mut cargo = prepare_tool_cargo(
             builder,
-            cargo,
-            lint_args(builder, &self.config, &[]),
-            &stamp,
-            vec![],
-            true,
-            false,
+            build_compiler,
+            Mode::Codegen,
+            target,
+            Kind::Clippy,
+            "compiler/rustc_codegen_gcc",
+            SourceType::InTree,
+            &[],
         );
+        self.build_compiler.configure_cargo(&mut cargo);
+        cargo.arg("--no-default-features");
+        run_cargo(builder, cargo, args, &stamp, vec![], true, false);
     }
 
     fn metadata(&self) -> Option<StepMetadata> {


### PR DESCRIPTION
This is to prevent [this issue](https://github.com/rust-lang/rust/pull/149449#discussion_r2573045524): in cg_gcc repository, we run clippy on our code but not in here, which can create issues.

cc @antoyo
r? @Kobzol 