### PR TITLE
Skipping borrowck because of trivial const

### DIFF
--- a/compiler/rustc_borrowck/src/lib.rs
+++ b/compiler/rustc_borrowck/src/lib.rs
@@ -115,6 +115,11 @@ fn mir_borrowck(
     def: LocalDefId,
 ) -> Result<&FxIndexMap<LocalDefId, ty::DefinitionSiteHiddenType<'_>>, ErrorGuaranteed> {
     assert!(!tcx.is_typeck_child(def.to_def_id()));
+    if tcx.is_trivial_const(def) {
+        debug!("Skipping borrowck because of trivial const");
+        let opaque_types = Default::default();
+        return Ok(tcx.arena.alloc(opaque_types));
+    }
     let (input_body, _) = tcx.mir_promoted(def);
     debug!("run query mir_borrowck: {}", tcx.def_path_str(def));
 

--- a/compiler/rustc_mir_transform/src/trivial_const.rs
+++ b/compiler/rustc_mir_transform/src/trivial_const.rs
@@ -59,6 +59,10 @@ where
         return None;
     }
 
+    if !tcx.opaque_types_defined_by(def).is_empty() {
+        return None;
+    }
+
     let body = body_provider();
 
     if body.has_opaque_types() {

--- a/tests/ui/traits/const-traits/trivial-const-ice-149278.rs
+++ b/tests/ui/traits/const-traits/trivial-const-ice-149278.rs
@@ -1,0 +1,11 @@
+trait Trait2: Sized {}
+
+impl Trait2 for () {
+    const FOO: () = {
+        //~^ ERROR const `FOO` is not a member of trait `Trait2`
+        //~^^ ERROR item does not constrain `Assoc::{opaque#0}`
+        type Assoc = impl Copy; //~ ERROR `impl Trait` in type aliases is unstable
+    };
+}
+
+fn main() {}

--- a/tests/ui/traits/const-traits/trivial-const-ice-149278.stderr
+++ b/tests/ui/traits/const-traits/trivial-const-ice-149278.stderr
@@ -1,0 +1,37 @@
+error[E0438]: const `FOO` is not a member of trait `Trait2`
+  --> $DIR/trivial-const-ice-149278.rs:4:5
+   |
+LL | /     const FOO: () = {
+LL | |
+LL | |
+LL | |         type Assoc = impl Copy;
+LL | |     };
+   | |______^ not a member of trait `Trait2`
+
+error[E0658]: `impl Trait` in type aliases is unstable
+  --> $DIR/trivial-const-ice-149278.rs:7:22
+   |
+LL |         type Assoc = impl Copy;
+   |                      ^^^^^^^^^
+   |
+   = note: see issue #63063 <https://github.com/rust-lang/rust/issues/63063> for more information
+   = help: add `#![feature(type_alias_impl_trait)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: item does not constrain `Assoc::{opaque#0}`
+  --> $DIR/trivial-const-ice-149278.rs:4:11
+   |
+LL |     const FOO: () = {
+   |           ^^^
+   |
+   = note: consider removing `#[define_opaque]` or adding an empty `#[define_opaque()]`
+note: this opaque type is supposed to be constrained
+  --> $DIR/trivial-const-ice-149278.rs:7:22
+   |
+LL |         type Assoc = impl Copy;
+   |                      ^^^^^^^^^
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0438, E0658.
+For more information about an error, try `rustc --explain E0438`.

--- a/tests/ui/traits/next-solver/opaques/trivial-const-defines-opaque.rs
+++ b/tests/ui/traits/next-solver/opaques/trivial-const-defines-opaque.rs
@@ -1,0 +1,15 @@
+//@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@[next] compile-flags: -Znext-solver
+//@ check-pass
+
+#![feature(type_alias_impl_trait)]
+
+type Tait = impl Sized;
+
+#[define_opaque(Tait)]
+const FOO: Tait = 1;
+
+fn main() {
+    let _: Tait = FOO;
+}


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/149468)*
<!-- homu-ignore:end -->

r? @saethlin

the [assertion](https://github.com/chenyukang/rust/blob/31c38576a4cf1a0864af536f62d11f829db1c7c8/compiler/rustc_mir_transform/src/lib.rs#L424) is added in PR: https://github.com/rust-lang/rust/pull/148040

I think we also need to skip trvial const in `mir_borrowck`.


