### PR TITLE
coverage: Store signature/body spans and branch spans in the expansion tree

### DIFF
--- a/compiler/rustc_mir_transform/src/coverage/mod.rs
+++ b/compiler/rustc_mir_transform/src/coverage/mod.rs
@@ -17,7 +17,6 @@ pub(super) mod query;
 mod spans;
 #[cfg(test)]
 mod tests;
-mod unexpand;
 
 /// Inserts `StatementKind::Coverage` statements that either instrument the binary with injected
 /// counters, via intrinsic `llvm.instrprof.increment`, and/or inject metadata used during codegen

--- a/compiler/rustc_mir_transform/src/coverage/unexpand.rs
+++ b/compiler/rustc_mir_transform/src/coverage/unexpand.rs
@@ -1,9 +1,0 @@
-use rustc_span::Span;
-
-/// Walks through the expansion ancestors of `original_span` to find a span that
-/// is contained in `body_span` and has the same [syntax context] as `body_span`.
-pub(crate) fn unexpand_into_body_span(original_span: Span, body_span: Span) -> Option<Span> {
-    // Because we don't need to return any extra ancestor information,
-    // we can just delegate directly to `find_ancestor_inside_same_ctxt`.
-    original_span.find_ancestor_inside_same_ctxt(body_span)
-}

--- a/tests/coverage/branch/fn-in-macro.cov-map
+++ b/tests/coverage/branch/fn-in-macro.cov-map
@@ -1,0 +1,44 @@
+Function name: fn_in_macro::branch_in_macro
+Raw bytes (19): 0x[01, 01, 00, 03, 01, 22, 01, 00, 15, 01, 0b, 05, 00, 17, 01, 01, 01, 00, 02]
+Number of files: 1
+- file 0 => $DIR/fn-in-macro.rs
+Number of expressions: 0
+Number of file 0 mappings: 3
+- Code(Counter(0)) at (prev + 34, 1) to (start + 0, 21)
+- Code(Counter(0)) at (prev + 11, 5) to (start + 0, 23)
+- Code(Counter(0)) at (prev + 1, 1) to (start + 0, 2)
+Highest counter ID seen: c0
+
+Function name: fn_in_macro::fn_in_macro
+Raw bytes (31): 0x[01, 01, 01, 01, 05, 05, 01, 0c, 09, 00, 19, 01, 01, 10, 00, 25, 05, 00, 2c, 02, 0e, 02, 02, 14, 02, 0e, 01, 03, 09, 00, 0a]
+Number of files: 1
+- file 0 => $DIR/fn-in-macro.rs
+Number of expressions: 1
+- expression 0 operands: lhs = Counter(0), rhs = Counter(1)
+Number of file 0 mappings: 5
+- Code(Counter(0)) at (prev + 12, 9) to (start + 0, 25)
+- Code(Counter(0)) at (prev + 1, 16) to (start + 0, 37)
+- Code(Counter(1)) at (prev + 0, 44) to (start + 2, 14)
+- Code(Expression(0, Sub)) at (prev + 2, 20) to (start + 2, 14)
+    = (c0 - c1)
+- Code(Counter(0)) at (prev + 3, 9) to (start + 0, 10)
+Highest counter ID seen: c1
+
+Function name: fn_in_macro::fn_not_in_macro
+Raw bytes (38): 0x[01, 01, 01, 01, 05, 06, 01, 19, 01, 00, 15, 01, 01, 08, 00, 1d, 20, 05, 02, 00, 08, 00, 23, 05, 00, 24, 02, 06, 02, 02, 0c, 02, 06, 01, 03, 01, 00, 02]
+Number of files: 1
+- file 0 => $DIR/fn-in-macro.rs
+Number of expressions: 1
+- expression 0 operands: lhs = Counter(0), rhs = Counter(1)
+Number of file 0 mappings: 6
+- Code(Counter(0)) at (prev + 25, 1) to (start + 0, 21)
+- Code(Counter(0)) at (prev + 1, 8) to (start + 0, 29)
+- Branch { true: Counter(1), false: Expression(0, Sub) } at (prev + 0, 8) to (start + 0, 35)
+    true  = c1
+    false = (c0 - c1)
+- Code(Counter(1)) at (prev + 0, 36) to (start + 2, 6)
+- Code(Expression(0, Sub)) at (prev + 2, 12) to (start + 2, 6)
+    = (c0 - c1)
+- Code(Counter(0)) at (prev + 3, 1) to (start + 0, 2)
+Highest counter ID seen: c1
+

--- a/tests/coverage/branch/fn-in-macro.coverage
+++ b/tests/coverage/branch/fn-in-macro.coverage
@@ -1,0 +1,62 @@
+   LL|       |#![feature(coverage_attribute)]
+   LL|       |//@ edition: 2024
+   LL|       |//@ compile-flags: -Zcoverage-options=branch
+   LL|       |//@ llvm-cov-flags: --show-branches=count
+   LL|       |
+   LL|       |// Snapshot test demonstrating how branch coverage interacts with code in macros.
+   LL|       |// This test captures current behavior, which is not necessarily "correct".
+   LL|       |
+   LL|       |macro_rules! define_fn {
+   LL|       |    () => {
+   LL|       |        /// Function defined entirely within a macro.
+   LL|      1|        fn fn_in_macro() {
+   LL|      1|            if core::hint::black_box(true) {
+   LL|      1|                say("true");
+   LL|      1|            } else {
+   LL|      0|                say("false");
+   LL|      0|            }
+   LL|      1|        }
+   LL|       |    };
+   LL|       |}
+   LL|       |
+   LL|       |define_fn!();
+   LL|       |
+   LL|       |/// Function not in a macro at all, for comparison.
+   LL|      1|fn fn_not_in_macro() {
+   LL|      1|    if core::hint::black_box(true) {
+  ------------------
+  |  Branch (LL:8): [True: 1, False: 0]
+  ------------------
+   LL|      1|        say("true");
+   LL|      1|    } else {
+   LL|      0|        say("false");
+   LL|      0|    }
+   LL|      1|}
+   LL|       |
+   LL|       |/// Function that is not in a macro, containing a branch that is in a macro.
+   LL|      1|fn branch_in_macro() {
+   LL|       |    macro_rules! macro_with_branch {
+   LL|       |        () => {{
+   LL|       |            if core::hint::black_box(true) {
+   LL|       |                say("true");
+   LL|       |            } else {
+   LL|       |                say("false");
+   LL|       |            }
+   LL|       |        }};
+   LL|       |    }
+   LL|       |
+   LL|      1|    macro_with_branch!();
+   LL|      1|}
+   LL|       |
+   LL|       |#[coverage(off)]
+   LL|       |fn main() {
+   LL|       |    fn_in_macro();
+   LL|       |    fn_not_in_macro();
+   LL|       |    branch_in_macro();
+   LL|       |}
+   LL|       |
+   LL|       |#[coverage(off)]
+   LL|       |fn say(message: &str) {
+   LL|       |    println!("{message}");
+   LL|       |}
+

--- a/tests/coverage/branch/fn-in-macro.rs
+++ b/tests/coverage/branch/fn-in-macro.rs
@@ -1,0 +1,58 @@
+#![feature(coverage_attribute)]
+//@ edition: 2024
+//@ compile-flags: -Zcoverage-options=branch
+//@ llvm-cov-flags: --show-branches=count
+
+// Snapshot test demonstrating how branch coverage interacts with code in macros.
+// This test captures current behavior, which is not necessarily "correct".
+
+macro_rules! define_fn {
+    () => {
+        /// Function defined entirely within a macro.
+        fn fn_in_macro() {
+            if core::hint::black_box(true) {
+                say("true");
+            } else {
+                say("false");
+            }
+        }
+    };
+}
+
+define_fn!();
+
+/// Function not in a macro at all, for comparison.
+fn fn_not_in_macro() {
+    if core::hint::black_box(true) {
+        say("true");
+    } else {
+        say("false");
+    }
+}
+
+/// Function that is not in a macro, containing a branch that is in a macro.
+fn branch_in_macro() {
+    macro_rules! macro_with_branch {
+        () => {{
+            if core::hint::black_box(true) {
+                say("true");
+            } else {
+                say("false");
+            }
+        }};
+    }
+
+    macro_with_branch!();
+}
+
+#[coverage(off)]
+fn main() {
+    fn_in_macro();
+    fn_not_in_macro();
+    branch_in_macro();
+}
+
+#[coverage(off)]
+fn say(message: &str) {
+    println!("{message}");
+}

--- a/tests/coverage/macros/call-site-body.cov-map
+++ b/tests/coverage/macros/call-site-body.cov-map
@@ -1,0 +1,21 @@
+Function name: call_site_body::fn_with_call_site_body
+Raw bytes (19): 0x[01, 01, 00, 03, 01, 15, 05, 00, 06, 01, 01, 09, 00, 0c, 01, 00, 0d, 00, 14]
+Number of files: 1
+- file 0 => $DIR/call-site-body.rs
+Number of expressions: 0
+Number of file 0 mappings: 3
+- Code(Counter(0)) at (prev + 21, 5) to (start + 0, 6)
+- Code(Counter(0)) at (prev + 1, 9) to (start + 0, 12)
+- Code(Counter(0)) at (prev + 0, 13) to (start + 0, 20)
+Highest counter ID seen: c0
+
+Function name: call_site_body::fn_with_call_site_inner (unused)
+Raw bytes (14): 0x[01, 01, 00, 02, 00, 1e, 09, 02, 0f, 00, 05, 09, 00, 0a]
+Number of files: 1
+- file 0 => $DIR/call-site-body.rs
+Number of expressions: 0
+Number of file 0 mappings: 2
+- Code(Zero) at (prev + 30, 9) to (start + 2, 15)
+- Code(Zero) at (prev + 5, 9) to (start + 0, 10)
+Highest counter ID seen: (none)
+

--- a/tests/coverage/macros/call-site-body.coverage
+++ b/tests/coverage/macros/call-site-body.coverage
@@ -1,0 +1,55 @@
+   LL|       |#![feature(coverage_attribute)]
+   LL|       |//@ edition: 2024
+   LL|       |
+   LL|       |// Snapshot test demonstrating how the function signature span and body span
+   LL|       |// affect coverage instrumentation in the presence of macro expansion.
+   LL|       |// This test captures current behaviour, which is not necessarily "correct".
+   LL|       |
+   LL|       |// This macro uses an argument token tree directly as a function body.
+   LL|       |#[rustfmt::skip]
+   LL|       |macro_rules! with_call_site_body {
+   LL|       |    ($body:tt) => {
+   LL|       |        fn
+   LL|       |        fn_with_call_site_body
+   LL|       |            ()
+   LL|       |        $body
+   LL|       |    }
+   LL|       |}
+   LL|       |
+   LL|       |with_call_site_body!(
+   LL|       |    // (force line break)
+   LL|      1|    {
+   LL|      1|        say("hello");
+   LL|       |    }
+   LL|       |);
+   LL|       |
+   LL|       |// This macro uses as an argument token tree as code within an explicit body.
+   LL|       |#[rustfmt::skip]
+   LL|       |macro_rules! with_call_site_inner {
+   LL|       |    ($inner:tt) => {
+   LL|      0|        fn
+   LL|      0|        fn_with_call_site_inner
+   LL|      0|            ()
+   LL|       |        {
+   LL|       |            $inner
+   LL|      0|        }
+   LL|       |    };
+   LL|       |}
+   LL|       |
+   LL|       |with_call_site_inner!(
+   LL|       |    // (force line break)
+   LL|       |    {
+   LL|       |        say("hello");
+   LL|       |    }
+   LL|       |);
+   LL|       |
+   LL|       |#[coverage(off)]
+   LL|       |fn main() {
+   LL|       |    fn_with_call_site_body();
+   LL|       |}
+   LL|       |
+   LL|       |#[coverage(off)]
+   LL|       |fn say(message: &str) {
+   LL|       |    println!("{message}");
+   LL|       |}
+

--- a/tests/coverage/macros/call-site-body.rs
+++ b/tests/coverage/macros/call-site-body.rs
@@ -1,0 +1,54 @@
+#![feature(coverage_attribute)]
+//@ edition: 2024
+
+// Snapshot test demonstrating how the function signature span and body span
+// affect coverage instrumentation in the presence of macro expansion.
+// This test captures current behaviour, which is not necessarily "correct".
+
+// This macro uses an argument token tree directly as a function body.
+#[rustfmt::skip]
+macro_rules! with_call_site_body {
+    ($body:tt) => {
+        fn
+        fn_with_call_site_body
+            ()
+        $body
+    }
+}
+
+with_call_site_body!(
+    // (force line break)
+    {
+        say("hello");
+    }
+);
+
+// This macro uses as an argument token tree as code within an explicit body.
+#[rustfmt::skip]
+macro_rules! with_call_site_inner {
+    ($inner:tt) => {
+        fn
+        fn_with_call_site_inner
+            ()
+        {
+            $inner
+        }
+    };
+}
+
+with_call_site_inner!(
+    // (force line break)
+    {
+        say("hello");
+    }
+);
+
+#[coverage(off)]
+fn main() {
+    fn_with_call_site_body();
+}
+
+#[coverage(off)]
+fn say(message: &str) {
+    println!("{message}");
+}


### PR DESCRIPTION
In order to support coverage instrumentation of expansion regions, we need to reduce the amount of code that assumes we're only instrumenting a flat function body. Moving more data into expansion tree nodes is an incremental step in that direction.

There should be no change to compiler output.