### PR TITLE
std: use a mutex for `ThreadId` generation if available

### DIFF
--- a/library/std/src/thread/current.rs
+++ b/library/std/src/thread/current.rs
@@ -108,7 +108,7 @@ pub(super) mod id {
         get().unwrap_or_else(
             #[cold]
             || {
-                let id = ThreadId::new();
+                let id = ThreadId::desperate_new();
                 id::set(id);
                 id
             },


### PR DESCRIPTION
Fixes https://github.com/rust-lang/miri/issues/4737

rust-lang/rust#144465 changed `ThreadId::new` to use a spinlock on platforms without 64-bit atomics. This introduces subtle scheduling changes such as the one described in https://github.com/rust-lang/miri/issues/4737 and isn't ideal from a performance perspective either. The necessity of avoiding `Mutex` is not always given however – it only needs to be avoided if the thread handle is lazily initialised. For normal Rust threads however, `std` generates the thread id inside the spawning logic, where allocation is expected. Thus this PR renames the current `ThreadId::new` to `desperate_new` and reintroduces a version `ThreadId::new` that employs a `Mutex` to synchronise access to the inner spin-lock.

CC @RalfJung @orlp 