### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/library/core/src/num/f128.rs
+++ b/library/core/src/num/f128.rs
@@ -694,11 +694,14 @@ impl f128 {
 
     /// Returns the maximum of the two numbers, ignoring NaN.
     ///
-    /// If one of the arguments is NaN, then the other argument is returned.
+    /// If exactly one of the arguments is NaN, then the other argument is returned. If both
+    /// arguments are NaN, the return value is NaN, with the bit pattern picked using the usual
+    /// [rules for arithmetic operations](f32#nan-bit-patterns). If the inputs compare equal (such
+    /// as for the case of `+0.0` and `-0.0`), either input may be returned non-deterministically.
+    ///
     /// This follows the IEEE 754-2008 semantics for `maxNum`, except for handling of signaling NaNs;
     /// this function handles all NaNs the same way and avoids `maxNum`'s problems with associativity.
-    /// This also matches the behavior of libm’s fmax. In particular, if the inputs compare equal
-    /// (such as for the case of `+0.0` and `-0.0`), either input may be returned non-deterministically.
+    /// This also matches the behavior of libm’s `fmax`.
     ///
     /// ```
     /// #![feature(f128)]
@@ -722,11 +725,14 @@ impl f128 {
 
     /// Returns the minimum of the two numbers, ignoring NaN.
     ///
-    /// If one of the arguments is NaN, then the other argument is returned.
+    /// If exactly one of the arguments is NaN, then the other argument is returned. If both
+    /// arguments are NaN, the return value is NaN, with the bit pattern picked using the usual
+    /// [rules for arithmetic operations](f32#nan-bit-patterns). If the inputs compare equal (such
+    /// as for the case of `+0.0` and `-0.0`), either input may be returned non-deterministically.
+    ///
     /// This follows the IEEE 754-2008 semantics for `minNum`, except for handling of signaling NaNs;
     /// this function handles all NaNs the same way and avoids `minNum`'s problems with associativity.
-    /// This also matches the behavior of libm’s fmin. In particular, if the inputs compare equal
-    /// (such as for the case of `+0.0` and `-0.0`), either input may be returned non-deterministically.
+    /// This also matches the behavior of libm’s `fmin`.
     ///
     /// ```
     /// #![feature(f128)]

--- a/library/core/src/num/f16.rs
+++ b/library/core/src/num/f16.rs
@@ -687,11 +687,14 @@ impl f16 {
 
     /// Returns the maximum of the two numbers, ignoring NaN.
     ///
-    /// If one of the arguments is NaN, then the other argument is returned.
+    /// If exactly one of the arguments is NaN, then the other argument is returned. If both
+    /// arguments are NaN, the return value is NaN, with the bit pattern picked using the usual
+    /// [rules for arithmetic operations](f32#nan-bit-patterns). If the inputs compare equal (such
+    /// as for the case of `+0.0` and `-0.0`), either input may be returned non-deterministically.
+    ///
     /// This follows the IEEE 754-2008 semantics for `maxNum`, except for handling of signaling NaNs;
     /// this function handles all NaNs the same way and avoids `maxNum`'s problems with associativity.
-    /// This also matches the behavior of libm’s fmax. In particular, if the inputs compare equal
-    /// (such as for the case of `+0.0` and `-0.0`), either input may be returned non-deterministically.
+    /// This also matches the behavior of libm’s `fmax`.
     ///
     /// ```
     /// #![feature(f16)]
@@ -714,11 +717,14 @@ impl f16 {
 
     /// Returns the minimum of the two numbers, ignoring NaN.
     ///
-    /// If one of the arguments is NaN, then the other argument is returned.
+    /// If exactly one of the arguments is NaN, then the other argument is returned. If both
+    /// arguments are NaN, the return value is NaN, with the bit pattern picked using the usual
+    /// [rules for arithmetic operations](f32#nan-bit-patterns). If the inputs compare equal (such
+    /// as for the case of `+0.0` and `-0.0`), either input may be returned non-deterministically.
+    ///
     /// This follows the IEEE 754-2008 semantics for `minNum`, except for handling of signaling NaNs;
     /// this function handles all NaNs the same way and avoids `minNum`'s problems with associativity.
-    /// This also matches the behavior of libm’s fmin. In particular, if the inputs compare equal
-    /// (such as for the case of `+0.0` and `-0.0`), either input may be returned non-deterministically.
+    /// This also matches the behavior of libm’s `fmin`.
     ///
     /// ```
     /// #![feature(f16)]

--- a/library/core/src/num/f32.rs
+++ b/library/core/src/num/f32.rs
@@ -897,11 +897,14 @@ impl f32 {
 
     /// Returns the maximum of the two numbers, ignoring NaN.
     ///
-    /// If one of the arguments is NaN, then the other argument is returned.
+    /// If exactly one of the arguments is NaN, then the other argument is returned. If both
+    /// arguments are NaN, the return value is NaN, with the bit pattern picked using the usual
+    /// [rules for arithmetic operations](f32#nan-bit-patterns). If the inputs compare equal (such
+    /// as for the case of `+0.0` and `-0.0`), either input may be returned non-deterministically.
+    ///
     /// This follows the IEEE 754-2008 semantics for `maxNum`, except for handling of signaling NaNs;
     /// this function handles all NaNs the same way and avoids `maxNum`'s problems with associativity.
-    /// This also matches the behavior of libm’s fmax. In particular, if the inputs compare equal
-    /// (such as for the case of `+0.0` and `-0.0`), either input may be returned non-deterministically.
+    /// This also matches the behavior of libm’s `fmax`.
     ///
     /// ```
     /// let x = 1.0f32;
@@ -920,11 +923,14 @@ impl f32 {
 
     /// Returns the minimum of the two numbers, ignoring NaN.
     ///
-    /// If one of the arguments is NaN, then the other argument is returned.
+    /// If exactly one of the arguments is NaN, then the other argument is returned. If both
+    /// arguments are NaN, the return value is NaN, with the bit pattern picked using the usual
+    /// [rules for arithmetic operations](f32#nan-bit-patterns). If the inputs compare equal (such
+    /// as for the case of `+0.0` and `-0.0`), either input may be returned non-deterministically.
+    ///
     /// This follows the IEEE 754-2008 semantics for `minNum`, except for handling of signaling NaNs;
     /// this function handles all NaNs the same way and avoids `minNum`'s problems with associativity.
-    /// This also matches the behavior of libm’s fmin. In particular, if the inputs compare equal
-    /// (such as for the case of `+0.0` and `-0.0`), either input may be returned non-deterministically.
+    /// This also matches the behavior of libm’s `fmin`.
     ///
     /// ```
     /// let x = 1.0f32;

--- a/library/core/src/num/f64.rs
+++ b/library/core/src/num/f64.rs
@@ -915,11 +915,14 @@ impl f64 {
 
     /// Returns the maximum of the two numbers, ignoring NaN.
     ///
-    /// If one of the arguments is NaN, then the other argument is returned.
+    /// If exactly one of the arguments is NaN, then the other argument is returned. If both
+    /// arguments are NaN, the return value is NaN, with the bit pattern picked using the usual
+    /// [rules for arithmetic operations](f32#nan-bit-patterns). If the inputs compare equal (such
+    /// as for the case of `+0.0` and `-0.0`), either input may be returned non-deterministically.
+    ///
     /// This follows the IEEE 754-2008 semantics for `maxNum`, except for handling of signaling NaNs;
     /// this function handles all NaNs the same way and avoids `maxNum`'s problems with associativity.
-    /// This also matches the behavior of libm’s fmax. In particular, if the inputs compare equal
-    /// (such as for the case of `+0.0` and `-0.0`), either input may be returned non-deterministically.
+    /// This also matches the behavior of libm’s `fmax`.
     ///
     /// ```
     /// let x = 1.0_f64;
@@ -938,11 +941,14 @@ impl f64 {
 
     /// Returns the minimum of the two numbers, ignoring NaN.
     ///
-    /// If one of the arguments is NaN, then the other argument is returned.
+    /// If exactly one of the arguments is NaN, then the other argument is returned. If both
+    /// arguments are NaN, the return value is NaN, with the bit pattern picked using the usual
+    /// [rules for arithmetic operations](f32#nan-bit-patterns). If the inputs compare equal (such
+    /// as for the case of `+0.0` and `-0.0`), either input may be returned non-deterministically.
+    ///
     /// This follows the IEEE 754-2008 semantics for `minNum`, except for handling of signaling NaNs;
     /// this function handles all NaNs the same way and avoids `minNum`'s problems with associativity.
-    /// This also matches the behavior of libm’s fmin. In particular, if the inputs compare equal
-    /// (such as for the case of `+0.0` and `-0.0`), either input may be returned non-deterministically.
+    /// This also matches the behavior of libm’s `fmin`.
     ///
     /// ```
     /// let x = 1.0_f64;

--- a/library/std/src/sync/barrier.rs
+++ b/library/std/src/sync/barrier.rs
@@ -65,8 +65,8 @@ impl fmt::Debug for Barrier {
 impl Barrier {
     /// Creates a new barrier that can block a given number of threads.
     ///
-    /// A barrier will block `n`-1 threads which call [`wait()`] and then wake
-    /// up all threads at once when the `n`th thread calls [`wait()`].
+    /// A barrier will block all threads which call [`wait()`] until the `n`th thread calls [`wait()`],
+    /// and then wake up all threads at once.
     ///
     /// [`wait()`]: Barrier::wait
     ///

--- a/tests/crashes/137187.rs
+++ b/tests/crashes/137187.rs
@@ -1,9 +1,10 @@
 //@ known-bug: #137187
 use std::ops::Add;
-trait A where
+
+const trait A where
     *const Self: Add,
 {
-    const fn b(c: *const Self) -> <*const Self as Add>::Output {
+    fn b(c: *const Self) -> <*const Self as Add>::Output {
         c + c
     }
 }


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#149236 (Clarify edge cases for Barrier::new)
 - rust-lang/rust#149444 (collapse `constness` query `match` logic)
 - rust-lang/rust#149475 (float::min/max: reference NaN bit pattern rules)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=149236,149444,149475)
<!-- homu-ignore:end -->