### PR TITLE
Fix indent in E0591.md

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes/E0591.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0591.md
@@ -62,14 +62,14 @@ This pattern should be rewritten. There are a few possible ways to do this:
   and do the cast in the fn body (the preferred option)
 - cast the fn item of a fn pointer before calling transmute, as shown here:
 
-    ```
-    # extern "C" fn foo(_: Box<i32>) {}
-    # use std::mem::transmute;
-    # unsafe {
-    let f: extern "C" fn(*mut i32) = transmute(foo as extern "C" fn(_));
-    let f: extern "C" fn(*mut i32) = transmute(foo as usize); // works too
-    # }
-    ```
+```
+# extern "C" fn foo(_: Box<i32>) {}
+# use std::mem::transmute;
+# unsafe {
+let f: extern "C" fn(*mut i32) = transmute(foo as extern "C" fn(_));
+let f: extern "C" fn(*mut i32) = transmute(foo as usize); // works too
+# }
+```
 
 The same applies to transmutes to `*mut fn()`, which were observed in practice.
 Note though that use of this type is generally incorrect.

--- a/tests/ui/explain/basic.stdout
+++ b/tests/ui/explain/basic.stdout
@@ -56,10 +56,10 @@ This pattern should be rewritten. There are a few possible ways to do this:
   and do the cast in the fn body (the preferred option)
 - cast the fn item of a fn pointer before calling transmute, as shown here:
 
-    ```
-    let f: extern "C" fn(*mut i32) = transmute(foo as extern "C" fn(_));
-    let f: extern "C" fn(*mut i32) = transmute(foo as usize); // works too
-    ```
+```
+let f: extern "C" fn(*mut i32) = transmute(foo as extern "C" fn(_));
+let f: extern "C" fn(*mut i32) = transmute(foo as usize); // works too
+```
 
 The same applies to transmutes to `*mut fn()`, which were observed in practice.
 Note though that use of this type is generally incorrect.


### PR DESCRIPTION
It currently looks like this.

<img width="1389" height="595" alt="image" src="https://github.com/user-attachments/assets/5336eebd-42a6-43c6-9127-9278cd82a9c2" />

https://doc.rust-lang.org/nightly/error_codes/E0591.html


So I can't run it, and the copied code has `#` in front.
