### PR TITLE
thread::scope: document how join interacts with TLS destructors

### DIFF
--- a/library/std/src/thread/join_handle.rs
+++ b/library/std/src/thread/join_handle.rs
@@ -102,6 +102,8 @@ impl<T> JoinHandle<T> {
     /// Waits for the associated thread to finish.
     ///
     /// This function will return immediately if the associated thread has already finished.
+    /// Otherwise, it fully waits for the thread to finish, including all destructors
+    /// for thread-local variables that might be running after the main function of the thread.
     ///
     /// In terms of [atomic memory orderings],  the completion of the associated
     /// thread synchronizes with this function returning. In other words, all

--- a/library/std/src/thread/scoped.rs
+++ b/library/std/src/thread/scoped.rs
@@ -80,6 +80,9 @@ impl ScopeData {
 ///
 /// All threads spawned within the scope that haven't been manually joined
 /// will be automatically joined before this function returns.
+/// However, note that joining will only wait for the main function of these threads to finish; even
+/// when this function returns, destructors of thread-local variables in these threads might still
+/// be running.
 ///
 /// # Panics
 ///
@@ -292,6 +295,8 @@ impl<'scope, T> ScopedJoinHandle<'scope, T> {
     /// Waits for the associated thread to finish.
     ///
     /// This function will return immediately if the associated thread has already finished.
+    /// Otherwise, it fully waits for the thread to finish, including all destructors
+    /// for thread-local variables that might be running after the main function of the thread.
     ///
     /// In terms of [atomic memory orderings], the completion of the associated
     /// thread synchronizes with this function returning.


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/116237 by documenting the current behavior regarding thread-local destructors as intended. (I'm not stoked about this, but documenting it is better than leaving it unclear.)

This also adds documentation for explicit `join` calls (both for scoped and regular threads), saying that those *will* wait for TLS destructors. That reflects my understanding of the current implementation, which calls `join` on the native thread handle. Are we okay with guaranteeing that? I think we should, so people have at least some chance of implementing "wait for all destructors" manually. This fixes https://github.com/rust-lang/rust/issues/127571.

Cc @rust-lang/libs-api 