### PR TITLE
Rollup of 2 pull requests

### DIFF
--- a/compiler/rustc_mir_transform/src/coverage/mod.rs
+++ b/compiler/rustc_mir_transform/src/coverage/mod.rs
@@ -17,7 +17,6 @@ pub(super) mod query;
 mod spans;
 #[cfg(test)]
 mod tests;
-mod unexpand;
 
 /// Inserts `StatementKind::Coverage` statements that either instrument the binary with injected
 /// counters, via intrinsic `llvm.instrprof.increment`, and/or inject metadata used during codegen

--- a/compiler/rustc_mir_transform/src/coverage/unexpand.rs
+++ b/compiler/rustc_mir_transform/src/coverage/unexpand.rs
@@ -1,9 +1,0 @@
-use rustc_span::Span;
-
-/// Walks through the expansion ancestors of `original_span` to find a span that
-/// is contained in `body_span` and has the same [syntax context] as `body_span`.
-pub(crate) fn unexpand_into_body_span(original_span: Span, body_span: Span) -> Option<Span> {
-    // Because we don't need to return any extra ancestor information,
-    // we can just delegate directly to `find_ancestor_inside_same_ctxt`.
-    original_span.find_ancestor_inside_same_ctxt(body_span)
-}

--- a/compiler/rustc_resolve/src/rustdoc.rs
+++ b/compiler/rustc_resolve/src/rustdoc.rs
@@ -393,13 +393,15 @@ pub fn has_primitive_or_keyword_or_attribute_docs(attrs: &[impl AttributeExt]) -
 }
 
 /// Simplified version of the corresponding function in rustdoc.
-/// If the rustdoc version returns a successful result, this function must return the same result.
-/// Otherwise this function may return anything.
 fn preprocess_link(link: &str) -> Box<str> {
+    // IMPORTANT: To be kept in sync with the corresponding function in rustdoc.
+    // Namely, whenever the rustdoc function returns a successful result for a given input,
+    // this function *MUST* return a link that's equal to `PreprocessingInfo.path_str`!
+
     let link = link.replace('`', "");
     let link = link.split('#').next().unwrap();
     let link = link.trim();
-    let link = link.rsplit('@').next().unwrap();
+    let link = link.split_once('@').map_or(link, |(_, rhs)| rhs);
     let link = link.trim_suffix("()");
     let link = link.trim_suffix("{}");
     let link = link.trim_suffix("[]");

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -938,14 +938,18 @@ pub(crate) struct PreprocessedMarkdownLink(
 
 /// Returns:
 /// - `None` if the link should be ignored.
-/// - `Some(Err)` if the link should emit an error
-/// - `Some(Ok)` if the link is valid
+/// - `Some(Err(_))` if the link should emit an error
+/// - `Some(Ok(_))` if the link is valid
 ///
 /// `link_buffer` is needed for lifetime reasons; it will always be overwritten and the contents ignored.
 fn preprocess_link(
     ori_link: &MarkdownLink,
     dox: &str,
 ) -> Option<Result<PreprocessingInfo, PreprocessingError>> {
+    // IMPORTANT: To be kept in sync with the corresponding function in `rustc_resolve::rustdoc`.
+    // Namely, whenever this function returns a successful result for a given input,
+    // the rustc counterpart *MUST* return a link that's equal to `PreprocessingInfo.path_str`!
+
     // certain link kinds cannot have their path be urls,
     // so they should not be ignored, no matter how much they look like urls.
     // e.g. [https://example.com/] is not a link to example.com.

--- a/tests/coverage/branch/fn-in-macro.cov-map
+++ b/tests/coverage/branch/fn-in-macro.cov-map
@@ -1,0 +1,44 @@
+Function name: fn_in_macro::branch_in_macro
+Raw bytes (19): 0x[01, 01, 00, 03, 01, 22, 01, 00, 15, 01, 0b, 05, 00, 17, 01, 01, 01, 00, 02]
+Number of files: 1
+- file 0 => $DIR/fn-in-macro.rs
+Number of expressions: 0
+Number of file 0 mappings: 3
+- Code(Counter(0)) at (prev + 34, 1) to (start + 0, 21)
+- Code(Counter(0)) at (prev + 11, 5) to (start + 0, 23)
+- Code(Counter(0)) at (prev + 1, 1) to (start + 0, 2)
+Highest counter ID seen: c0
+
+Function name: fn_in_macro::fn_in_macro
+Raw bytes (31): 0x[01, 01, 01, 01, 05, 05, 01, 0c, 09, 00, 19, 01, 01, 10, 00, 25, 05, 00, 2c, 02, 0e, 02, 02, 14, 02, 0e, 01, 03, 09, 00, 0a]
+Number of files: 1
+- file 0 => $DIR/fn-in-macro.rs
+Number of expressions: 1
+- expression 0 operands: lhs = Counter(0), rhs = Counter(1)
+Number of file 0 mappings: 5
+- Code(Counter(0)) at (prev + 12, 9) to (start + 0, 25)
+- Code(Counter(0)) at (prev + 1, 16) to (start + 0, 37)
+- Code(Counter(1)) at (prev + 0, 44) to (start + 2, 14)
+- Code(Expression(0, Sub)) at (prev + 2, 20) to (start + 2, 14)
+    = (c0 - c1)
+- Code(Counter(0)) at (prev + 3, 9) to (start + 0, 10)
+Highest counter ID seen: c1
+
+Function name: fn_in_macro::fn_not_in_macro
+Raw bytes (38): 0x[01, 01, 01, 01, 05, 06, 01, 19, 01, 00, 15, 01, 01, 08, 00, 1d, 20, 05, 02, 00, 08, 00, 23, 05, 00, 24, 02, 06, 02, 02, 0c, 02, 06, 01, 03, 01, 00, 02]
+Number of files: 1
+- file 0 => $DIR/fn-in-macro.rs
+Number of expressions: 1
+- expression 0 operands: lhs = Counter(0), rhs = Counter(1)
+Number of file 0 mappings: 6
+- Code(Counter(0)) at (prev + 25, 1) to (start + 0, 21)
+- Code(Counter(0)) at (prev + 1, 8) to (start + 0, 29)
+- Branch { true: Counter(1), false: Expression(0, Sub) } at (prev + 0, 8) to (start + 0, 35)
+    true  = c1
+    false = (c0 - c1)
+- Code(Counter(1)) at (prev + 0, 36) to (start + 2, 6)
+- Code(Expression(0, Sub)) at (prev + 2, 12) to (start + 2, 6)
+    = (c0 - c1)
+- Code(Counter(0)) at (prev + 3, 1) to (start + 0, 2)
+Highest counter ID seen: c1
+

--- a/tests/coverage/branch/fn-in-macro.coverage
+++ b/tests/coverage/branch/fn-in-macro.coverage
@@ -1,0 +1,62 @@
+   LL|       |#![feature(coverage_attribute)]
+   LL|       |//@ edition: 2024
+   LL|       |//@ compile-flags: -Zcoverage-options=branch
+   LL|       |//@ llvm-cov-flags: --show-branches=count
+   LL|       |
+   LL|       |// Snapshot test demonstrating how branch coverage interacts with code in macros.
+   LL|       |// This test captures current behavior, which is not necessarily "correct".
+   LL|       |
+   LL|       |macro_rules! define_fn {
+   LL|       |    () => {
+   LL|       |        /// Function defined entirely within a macro.
+   LL|      1|        fn fn_in_macro() {
+   LL|      1|            if core::hint::black_box(true) {
+   LL|      1|                say("true");
+   LL|      1|            } else {
+   LL|      0|                say("false");
+   LL|      0|            }
+   LL|      1|        }
+   LL|       |    };
+   LL|       |}
+   LL|       |
+   LL|       |define_fn!();
+   LL|       |
+   LL|       |/// Function not in a macro at all, for comparison.
+   LL|      1|fn fn_not_in_macro() {
+   LL|      1|    if core::hint::black_box(true) {
+  ------------------
+  |  Branch (LL:8): [True: 1, False: 0]
+  ------------------
+   LL|      1|        say("true");
+   LL|      1|    } else {
+   LL|      0|        say("false");
+   LL|      0|    }
+   LL|      1|}
+   LL|       |
+   LL|       |/// Function that is not in a macro, containing a branch that is in a macro.
+   LL|      1|fn branch_in_macro() {
+   LL|       |    macro_rules! macro_with_branch {
+   LL|       |        () => {{
+   LL|       |            if core::hint::black_box(true) {
+   LL|       |                say("true");
+   LL|       |            } else {
+   LL|       |                say("false");
+   LL|       |            }
+   LL|       |        }};
+   LL|       |    }
+   LL|       |
+   LL|      1|    macro_with_branch!();
+   LL|      1|}
+   LL|       |
+   LL|       |#[coverage(off)]
+   LL|       |fn main() {
+   LL|       |    fn_in_macro();
+   LL|       |    fn_not_in_macro();
+   LL|       |    branch_in_macro();
+   LL|       |}
+   LL|       |
+   LL|       |#[coverage(off)]
+   LL|       |fn say(message: &str) {
+   LL|       |    println!("{message}");
+   LL|       |}
+

--- a/tests/coverage/branch/fn-in-macro.rs
+++ b/tests/coverage/branch/fn-in-macro.rs
@@ -1,0 +1,58 @@
+#![feature(coverage_attribute)]
+//@ edition: 2024
+//@ compile-flags: -Zcoverage-options=branch
+//@ llvm-cov-flags: --show-branches=count
+
+// Snapshot test demonstrating how branch coverage interacts with code in macros.
+// This test captures current behavior, which is not necessarily "correct".
+
+macro_rules! define_fn {
+    () => {
+        /// Function defined entirely within a macro.
+        fn fn_in_macro() {
+            if core::hint::black_box(true) {
+                say("true");
+            } else {
+                say("false");
+            }
+        }
+    };
+}
+
+define_fn!();
+
+/// Function not in a macro at all, for comparison.
+fn fn_not_in_macro() {
+    if core::hint::black_box(true) {
+        say("true");
+    } else {
+        say("false");
+    }
+}
+
+/// Function that is not in a macro, containing a branch that is in a macro.
+fn branch_in_macro() {
+    macro_rules! macro_with_branch {
+        () => {{
+            if core::hint::black_box(true) {
+                say("true");
+            } else {
+                say("false");
+            }
+        }};
+    }
+
+    macro_with_branch!();
+}
+
+#[coverage(off)]
+fn main() {
+    fn_in_macro();
+    fn_not_in_macro();
+    branch_in_macro();
+}
+
+#[coverage(off)]
+fn say(message: &str) {
+    println!("{message}");
+}

--- a/tests/coverage/macros/call-site-body.cov-map
+++ b/tests/coverage/macros/call-site-body.cov-map
@@ -1,0 +1,21 @@
+Function name: call_site_body::fn_with_call_site_body
+Raw bytes (19): 0x[01, 01, 00, 03, 01, 15, 05, 00, 06, 01, 01, 09, 00, 0c, 01, 00, 0d, 00, 14]
+Number of files: 1
+- file 0 => $DIR/call-site-body.rs
+Number of expressions: 0
+Number of file 0 mappings: 3
+- Code(Counter(0)) at (prev + 21, 5) to (start + 0, 6)
+- Code(Counter(0)) at (prev + 1, 9) to (start + 0, 12)
+- Code(Counter(0)) at (prev + 0, 13) to (start + 0, 20)
+Highest counter ID seen: c0
+
+Function name: call_site_body::fn_with_call_site_inner (unused)
+Raw bytes (14): 0x[01, 01, 00, 02, 00, 1e, 09, 02, 0f, 00, 05, 09, 00, 0a]
+Number of files: 1
+- file 0 => $DIR/call-site-body.rs
+Number of expressions: 0
+Number of file 0 mappings: 2
+- Code(Zero) at (prev + 30, 9) to (start + 2, 15)
+- Code(Zero) at (prev + 5, 9) to (start + 0, 10)
+Highest counter ID seen: (none)
+

--- a/tests/coverage/macros/call-site-body.coverage
+++ b/tests/coverage/macros/call-site-body.coverage
@@ -1,0 +1,55 @@
+   LL|       |#![feature(coverage_attribute)]
+   LL|       |//@ edition: 2024
+   LL|       |
+   LL|       |// Snapshot test demonstrating how the function signature span and body span
+   LL|       |// affect coverage instrumentation in the presence of macro expansion.
+   LL|       |// This test captures current behaviour, which is not necessarily "correct".
+   LL|       |
+   LL|       |// This macro uses an argument token tree directly as a function body.
+   LL|       |#[rustfmt::skip]
+   LL|       |macro_rules! with_call_site_body {
+   LL|       |    ($body:tt) => {
+   LL|       |        fn
+   LL|       |        fn_with_call_site_body
+   LL|       |            ()
+   LL|       |        $body
+   LL|       |    }
+   LL|       |}
+   LL|       |
+   LL|       |with_call_site_body!(
+   LL|       |    // (force line break)
+   LL|      1|    {
+   LL|      1|        say("hello");
+   LL|       |    }
+   LL|       |);
+   LL|       |
+   LL|       |// This macro uses as an argument token tree as code within an explicit body.
+   LL|       |#[rustfmt::skip]
+   LL|       |macro_rules! with_call_site_inner {
+   LL|       |    ($inner:tt) => {
+   LL|      0|        fn
+   LL|      0|        fn_with_call_site_inner
+   LL|      0|            ()
+   LL|       |        {
+   LL|       |            $inner
+   LL|      0|        }
+   LL|       |    };
+   LL|       |}
+   LL|       |
+   LL|       |with_call_site_inner!(
+   LL|       |    // (force line break)
+   LL|       |    {
+   LL|       |        say("hello");
+   LL|       |    }
+   LL|       |);
+   LL|       |
+   LL|       |#[coverage(off)]
+   LL|       |fn main() {
+   LL|       |    fn_with_call_site_body();
+   LL|       |}
+   LL|       |
+   LL|       |#[coverage(off)]
+   LL|       |fn say(message: &str) {
+   LL|       |    println!("{message}");
+   LL|       |}
+

--- a/tests/coverage/macros/call-site-body.rs
+++ b/tests/coverage/macros/call-site-body.rs
@@ -1,0 +1,54 @@
+#![feature(coverage_attribute)]
+//@ edition: 2024
+
+// Snapshot test demonstrating how the function signature span and body span
+// affect coverage instrumentation in the presence of macro expansion.
+// This test captures current behaviour, which is not necessarily "correct".
+
+// This macro uses an argument token tree directly as a function body.
+#[rustfmt::skip]
+macro_rules! with_call_site_body {
+    ($body:tt) => {
+        fn
+        fn_with_call_site_body
+            ()
+        $body
+    }
+}
+
+with_call_site_body!(
+    // (force line break)
+    {
+        say("hello");
+    }
+);
+
+// This macro uses as an argument token tree as code within an explicit body.
+#[rustfmt::skip]
+macro_rules! with_call_site_inner {
+    ($inner:tt) => {
+        fn
+        fn_with_call_site_inner
+            ()
+        {
+            $inner
+        }
+    };
+}
+
+with_call_site_inner!(
+    // (force line break)
+    {
+        say("hello");
+    }
+);
+
+#[coverage(off)]
+fn main() {
+    fn_with_call_site_body();
+}
+
+#[coverage(off)]
+fn say(message: &str) {
+    println!("{message}");
+}

--- a/tests/rustdoc-ui/intra-doc/empty-associated-items.rs
+++ b/tests/rustdoc-ui/intra-doc/empty-associated-items.rs
@@ -1,8 +1,0 @@
-// This test ensures that an empty associated item will not crash rustdoc.
-// This is a regression test for <https://github.com/rust-lang/rust/issues/140026>.
-
-#[deny(rustdoc::broken_intra_doc_links)]
-
-/// [`String::`]
-//~^ ERROR
-pub struct Foo;

--- a/tests/rustdoc-ui/intra-doc/malformed-paths.rs
+++ b/tests/rustdoc-ui/intra-doc/malformed-paths.rs
@@ -1,0 +1,17 @@
+// This test ensures that (syntactically) malformed paths will not crash rustdoc.
+#![deny(rustdoc::broken_intra_doc_links)]
+
+// This is a regression test for <https://github.com/rust-lang/rust/issues/140026>.
+//! [`Type::`]
+//~^ ERROR
+
+// This is a regression test for <https://github.com/rust-lang/rust/issues/147981>.
+//! [`struct@Type@field`]
+//~^ ERROR
+
+//! [Type&content]
+//~^ ERROR
+//! [`Type::field%extra`]
+//~^ ERROR
+
+pub struct Type { pub field: () }

--- a/tests/rustdoc-ui/intra-doc/malformed-paths.stderr
+++ b/tests/rustdoc-ui/intra-doc/malformed-paths.stderr
@@ -1,0 +1,36 @@
+error: unresolved link to `Type::`
+  --> $DIR/malformed-paths.rs:5:7
+   |
+LL | //! [`Type::`]
+   |       ^^^^^^ the struct `Type` has no field or associated item named ``
+   |
+note: the lint level is defined here
+  --> $DIR/malformed-paths.rs:2:9
+   |
+LL | #![deny(rustdoc::broken_intra_doc_links)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: unresolved link to `Type@field`
+  --> $DIR/malformed-paths.rs:9:7
+   |
+LL | //! [`struct@Type@field`]
+   |       ^^^^^^^^^^^^^^^^^ no item named `Type@field` in scope
+   |
+   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
+
+error: unresolved link to `Type&content`
+  --> $DIR/malformed-paths.rs:12:6
+   |
+LL | //! [Type&content]
+   |      ^^^^^^^^^^^^ no item named `Type&content` in scope
+   |
+   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
+
+error: unresolved link to `Type::field%extra`
+  --> $DIR/malformed-paths.rs:14:7
+   |
+LL | //! [`Type::field%extra`]
+   |       ^^^^^^^^^^^^^^^^^ the struct `Type` has no field or associated item named `field%extra`
+
+error: aborting due to 4 previous errors
+


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#148169 (Fix bad intra-doc-link preprocessing)
 - rust-lang/rust#149471 (coverage: Store signature/body spans and branch spans in the expansion tree)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=148169,149471)
<!-- homu-ignore:end -->