### PR TITLE
Rollup of 2 pull requests

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes/E0591.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0591.md
@@ -62,14 +62,14 @@ This pattern should be rewritten. There are a few possible ways to do this:
   and do the cast in the fn body (the preferred option)
 - cast the fn item of a fn pointer before calling transmute, as shown here:
 
-    ```
-    # extern "C" fn foo(_: Box<i32>) {}
-    # use std::mem::transmute;
-    # unsafe {
-    let f: extern "C" fn(*mut i32) = transmute(foo as extern "C" fn(_));
-    let f: extern "C" fn(*mut i32) = transmute(foo as usize); // works too
-    # }
-    ```
+```
+# extern "C" fn foo(_: Box<i32>) {}
+# use std::mem::transmute;
+# unsafe {
+let f: extern "C" fn(*mut i32) = transmute(foo as extern "C" fn(_));
+let f: extern "C" fn(*mut i32) = transmute(foo as usize); // works too
+# }
+```
 
 The same applies to transmutes to `*mut fn()`, which were observed in practice.
 Note though that use of this type is generally incorrect.

--- a/library/std/src/sys/thread/unix.rs
+++ b/library/std/src/sys/thread/unix.rs
@@ -14,7 +14,7 @@ use crate::sys::weak::dlsym;
 #[cfg(any(target_os = "solaris", target_os = "illumos", target_os = "nto",))]
 use crate::sys::weak::weak;
 use crate::sys::{os, stack_overflow};
-use crate::thread::{ThreadInit, current};
+use crate::thread::ThreadInit;
 use crate::time::Duration;
 use crate::{cmp, io, ptr};
 #[cfg(not(any(
@@ -111,10 +111,9 @@ impl Thread {
                 let init = Box::from_raw(data as *mut ThreadInit);
                 let rust_start = init.init();
 
-                // Set up our thread name and stack overflow handler which may get triggered
-                // if we run out of stack.
-                let thread = current();
-                let _handler = stack_overflow::Handler::new(thread.name().map(Box::from));
+                // Now that the thread information is set, set up our stack
+                // overflow handler.
+                let _handler = stack_overflow::Handler::new();
 
                 rust_start();
             }

--- a/tests/ui/explain/basic.stdout
+++ b/tests/ui/explain/basic.stdout
@@ -56,10 +56,10 @@ This pattern should be rewritten. There are a few possible ways to do this:
   and do the cast in the fn body (the preferred option)
 - cast the fn item of a fn pointer before calling transmute, as shown here:
 
-    ```
-    let f: extern "C" fn(*mut i32) = transmute(foo as extern "C" fn(_));
-    let f: extern "C" fn(*mut i32) = transmute(foo as usize); // works too
-    ```
+```
+let f: extern "C" fn(*mut i32) = transmute(foo as extern "C" fn(_));
+let f: extern "C" fn(*mut i32) = transmute(foo as usize); // works too
+```
 
 The same applies to transmutes to `*mut fn()`, which were observed in practice.
 Note though that use of this type is generally incorrect.


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#149456 (std: don't call `current_os_id` from signal handler)
 - rust-lang/rust#149479 (Fix indent in E0591.md)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=149456,149479)
<!-- homu-ignore:end -->