### PR TITLE
CTFE: avoid emitting a hard error on generic normalization failures

### DIFF
--- a/compiler/rustc_const_eval/src/interpret/eval_context.rs
+++ b/compiler/rustc_const_eval/src/interpret/eval_context.rs
@@ -11,7 +11,9 @@ use rustc_middle::ty::layout::{
     self, FnAbiError, FnAbiOf, FnAbiOfHelpers, FnAbiRequest, LayoutError, LayoutOf,
     LayoutOfHelpers, TyAndLayout,
 };
-use rustc_middle::ty::{self, GenericArgsRef, Ty, TyCtxt, TypeFoldable, TypingEnv, Variance};
+use rustc_middle::ty::{
+    self, GenericArgsRef, Ty, TyCtxt, TypeFoldable, TypeVisitableExt, TypingEnv, Variance,
+};
 use rustc_middle::{mir, span_bug};
 use rustc_span::Span;
 use rustc_target::callconv::FnAbi;
@@ -84,10 +86,31 @@ impl<'tcx, M: Machine<'tcx>> LayoutOfHelpers<'tcx> for InterpCx<'tcx, M> {
     #[inline]
     fn handle_layout_err(
         &self,
-        err: LayoutError<'tcx>,
+        mut err: LayoutError<'tcx>,
         _: Span,
         _: Ty<'tcx>,
     ) -> InterpErrorKind<'tcx> {
+        // FIXME(#149283): This is really hacky and is only used to hide type
+        // system bugs. We use it as a temporary fix for #149081.
+        //
+        // While it's expected that we sometimes get ambiguity errors when
+        // entering another generic environment while the current environment
+        // itself is still generic, we should never fail to entirely prove
+        // something.
+        match err {
+            LayoutError::NormalizationFailure(ty, _) => {
+                if ty.has_non_region_param() {
+                    err = LayoutError::TooGeneric(ty);
+                }
+            }
+
+            LayoutError::Unknown(_)
+            | LayoutError::SizeOverflow(_)
+            | LayoutError::InvalidSimd { .. }
+            | LayoutError::TooGeneric(_)
+            | LayoutError::ReferencesError(_)
+            | LayoutError::Cycle(_) => {}
+        }
         err_inval!(Layout(err))
     }
 }
@@ -112,7 +135,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
     /// and allows wrapping the actual [LayoutOf::layout_of] with a tracing span.
     /// See [LayoutOf::layout_of] for the original documentation.
     #[inline(always)]
-    pub fn layout_of(&self, ty: Ty<'tcx>) -> <Self as LayoutOfHelpers<'tcx>>::LayoutOfResult {
+    pub fn layout_of(&self, ty: Ty<'tcx>) -> Result<TyAndLayout<'tcx>, InterpErrorKind<'tcx>> {
         let _trace = enter_trace_span!(M, layouting::layout_of, ty = ?ty.kind());
         LayoutOf::layout_of(self, ty)
     }

--- a/tests/ui/where-clauses/projection-bound-unsatisfied-item-bounds-mit-opt-ice.rs
+++ b/tests/ui/where-clauses/projection-bound-unsatisfied-item-bounds-mit-opt-ice.rs
@@ -1,0 +1,25 @@
+//@ compile-flags: -Copt-level=3 --crate-type=rlib
+//@ build-pass
+
+// A regression test for #149081. The environment of `size` and `align`
+// currently means that the item bound of`T::Assoc` doesn't hold. This can
+// result in normalization failures and ICE during MIR optimizations.
+//
+// This will no longer be an issue once #149283 is implemented.
+
+pub fn align<T: WithAssoc<Assoc = U>, U>() -> usize {
+    std::mem::align_of::<Wrapper<T>>()
+}
+
+pub fn size<T: WithAssoc<Assoc = U>, U>() -> usize {
+    std::mem::size_of::<Wrapper<T>>()
+}
+
+pub struct Wrapper<T: WithAssoc> {
+    assoc2: <T::Assoc as WithAssoc>::Assoc,
+    value: T,
+}
+
+pub trait WithAssoc {
+    type Assoc: WithAssoc;
+}


### PR DESCRIPTION
Fixes rust-lang/rust#149081.

The fix is quite unsatisfying and should not be necessary, cc rust-lang/rust#149283. That change is significantly more involved. This temporary fix introduces some unnecessary complexity and may hide other type system bugs.

cc @rust-lang/types I think we should try to fix issue rust-lang/rust#149283 in the near future and then remove this hack again.

I originally intended a more targeted fix. I wanted to skip evaluating constants in MIR opts if their body was polymorphic and the current generic arguments still reference generic parameters. Notes from looking into this:
- we only fetch the MIR in the `eval_to_allocation_raw` query
- figuring out which MIR to use is hard
	- dealing with trivial consts is annoying
	- need to resolve instances for associated consts
	- implementing this by hand is hard
- inlining handles this issue by bailing on literally all normalization failures, even the ones that imply an unsoundness
	- `try_normalize_after_erasing_regions` generally does two things
		- deal with ambiguity after inlining
		- deal with error tainting issues (please don't, we should stop doing that)
- CTFE could be changed to always silently ignore normalization failures if we're in a generic body
	- hides actual bugs <- went with this option

r? types