### PR TITLE
gnullvm hosts: add to build-manifest

### DIFF
--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -30,16 +30,23 @@ static DOCS_FALLBACK: &[(&str, &str)] = &[
 ];
 
 static MSI_INSTALLERS: &[&str] = &[
+    "aarch64-pc-windows-gnullvm",
     "aarch64-pc-windows-msvc",
     "i686-pc-windows-gnu",
     "i686-pc-windows-msvc",
     "x86_64-pc-windows-gnu",
+    "x86_64-pc-windows-gnullvm",
     "x86_64-pc-windows-msvc",
 ];
 
 static PKG_INSTALLERS: &[&str] = &["x86_64-apple-darwin", "aarch64-apple-darwin"];
 
-static MINGW: &[&str] = &["i686-pc-windows-gnu", "x86_64-pc-windows-gnu"];
+static MINGW: &[&str] = &[
+    "aarch64-pc-windows-gnullvm",
+    "i686-pc-windows-gnu",
+    "x86_64-pc-windows-gnu",
+    "x86_64-pc-windows-gnullvm",
+];
 
 static NIGHTLY_ONLY_COMPONENTS: &[PkgType] =
     &[PkgType::Miri, PkgType::JsonDocs, PkgType::RustcCodegenCranelift];


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
A continuation of rust-lang/rust#147536 and rust-lang/rust#148751 fixing what I missed there.

After this change `rustup install nightly-x86_64-pc-windows-gnullvm --component rust-mingw` should work.