### PR TITLE
Update the comment in the add_typo_suggestion function

### DIFF
--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -1900,7 +1900,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             if span.overlaps(def_span) {
                 // Don't suggest typo suggestion for itself like in the following:
                 // error[E0423]: expected function, tuple struct or tuple variant, found struct `X`
-                //   --> $DIR/issue-64792-bad-unicode-ctor.rs:3:14
+                //   --> $DIR/unicode-string-literal-syntax-error-64792.rs:4:14
                 //    |
                 // LL | struct X {}
                 //    | ----------- `X` defined here


### PR DESCRIPTION
This comment was added to https://github.com/rust-lang/rust/commit/089810a1cb28cfb0262b62f1d36c75ea790b0739. However, the test for the comment was moved elsewhere in https://github.com/rust-lang/rust/pull/145897.