### PR TITLE
`rust-analyzer` subtree update

### DIFF
--- a/src/tools/rust-analyzer/crates/proc-macro-api/src/legacy_protocol/msg/flat.rs
+++ b/src/tools/rust-analyzer/crates/proc-macro-api/src/legacy_protocol/msg/flat.rs
@@ -962,8 +962,6 @@ impl<T: SpanTransformer> Reader<'_, T> {
             };
             res[i] = Some(g);
         }
-        proc_macro_srv::TokenStream::new(vec![proc_macro_srv::TokenTree::Group(
-            res[0].take().unwrap(),
-        )])
+        res[0].take().unwrap().stream.unwrap_or_default()
     }
 }

--- a/src/tools/rust-analyzer/crates/proc-macro-srv/src/tests/mod.rs
+++ b/src/tools/rust-analyzer/crates/proc-macro-srv/src/tests/mod.rs
@@ -297,26 +297,38 @@ fn test_fn_like_macro_noop() {
 fn test_fn_like_macro_clone_ident_subtree() {
     assert_expand(
         "fn_like_clone_tokens",
-        r#"ident, []"#,
+        r#"ident, [ident2, ident3]"#,
         expect![[r#"
             IDENT 1 ident
             PUNCT 1 , [alone]
             GROUP [] 1 1 1
+              IDENT 1 ident2
+              PUNCT 1 , [alone]
+              IDENT 1 ident3
 
 
             IDENT 1 ident
             PUNCT 1 , [alone]
             GROUP [] 1 1 1
+              IDENT 1 ident2
+              PUNCT 1 , [alone]
+              IDENT 1 ident3
         "#]],
         expect![[r#"
             IDENT 42:Root[0000, 0]@0..5#ROOT2024 ident
             PUNCT 42:Root[0000, 0]@5..6#ROOT2024 , [alone]
-            GROUP [] 42:Root[0000, 0]@7..8#ROOT2024 42:Root[0000, 0]@8..9#ROOT2024 42:Root[0000, 0]@7..9#ROOT2024
+            GROUP [] 42:Root[0000, 0]@7..8#ROOT2024 42:Root[0000, 0]@22..23#ROOT2024 42:Root[0000, 0]@7..23#ROOT2024
+              IDENT 42:Root[0000, 0]@8..14#ROOT2024 ident2
+              PUNCT 42:Root[0000, 0]@14..15#ROOT2024 , [alone]
+              IDENT 42:Root[0000, 0]@16..22#ROOT2024 ident3
 
 
             IDENT 42:Root[0000, 0]@0..5#ROOT2024 ident
             PUNCT 42:Root[0000, 0]@5..6#ROOT2024 , [alone]
-            GROUP [] 42:Root[0000, 0]@7..9#ROOT2024 42:Root[0000, 0]@7..9#ROOT2024 42:Root[0000, 0]@7..9#ROOT2024
+            GROUP [] 42:Root[0000, 0]@7..23#ROOT2024 42:Root[0000, 0]@7..23#ROOT2024 42:Root[0000, 0]@7..23#ROOT2024
+              IDENT 42:Root[0000, 0]@8..14#ROOT2024 ident2
+              PUNCT 42:Root[0000, 0]@14..15#ROOT2024 , [alone]
+              IDENT 42:Root[0000, 0]@16..22#ROOT2024 ident3
         "#]],
     );
 }


### PR DESCRIPTION
Subtree update of `rust-analyzer` to https://github.com/rust-lang/rust-analyzer/commit/f25db5500baa047106d74962fe361ea59ce6f91e.

Created using https://github.com/rust-lang/josh-sync.

r? @ghost

Last one for now...