### PR TITLE
Move bootstrap configuration to library workspace

### DIFF
--- a/library/Cargo.toml
+++ b/library/Cargo.toml
@@ -62,9 +62,10 @@ inherits = "release"
 codegen-units = 1
 debug = 1 # "limited"
 rustflags = [
-    # Unconditionally embedding bitcode is necessary for when users enable LTO.
-    # Until Cargo can rebuild the standard library with the user profile's `lto`
-    # setting, Cargo will force this to be `no`
+    # `profile.lto=off` implies `-Cembed-bitcode=no`, but unconditionally embedding
+    # bitcode is necessary for when users enable LTO.
+    # Required until Cargo can re-build the standard library based on the value
+    # of `profile.lto` in the user's profile.
     "-Cembed-bitcode=yes",
     # Enable frame pointers
     "-Zunstable-options",

--- a/library/Cargo.toml
+++ b/library/Cargo.toml
@@ -64,12 +64,17 @@ rustflags = [
     # Until Cargo can rebuild the standard library with the user profile's `lto`
     # setting, Cargo will force this to be `no`
     "-Cembed-bitcode=yes",
+    # Enable frame pointers
+    "-Zunstable-options",
+    "-Cforce-frame-pointers=non-leaf",
 ]
 
 [profile.dist.package.panic_abort]
 rustflags = [
     "-Cpanic=abort",
     "-Cembed-bitcode=yes",
+    "-Zunstable-options",
+    "-Cforce-frame-pointers=non-leaf",
 ]
 
 [patch.crates-io]

--- a/library/Cargo.toml
+++ b/library/Cargo.toml
@@ -54,6 +54,24 @@ rustflags = ["-Cpanic=abort"]
 [profile.release.package.panic_abort]
 rustflags = ["-Cpanic=abort"]
 
+# The "dist" profile is used by bootstrap for prebuilt libstd artifacts
+# These settings ensure that the prebuilt artifacts support a variety of features
+# in the user's profile.
+[profile.dist]
+inherits = "release"
+rustflags = [
+    # Unconditionally embedding bitcode is necessary for when users enable LTO.
+    # Until Cargo can rebuild the standard library with the user profile's `lto`
+    # setting, Cargo will force this to be `no`
+    "-Cembed-bitcode=yes",
+]
+
+[profile.dist.package.panic_abort]
+rustflags = [
+    "-Cpanic=abort",
+    "-Cembed-bitcode=yes",
+]
+
 [patch.crates-io]
 # See comments in `library/rustc-std-workspace-core/README.md` for what's going on here
 rustc-std-workspace-core = { path = 'rustc-std-workspace-core' }

--- a/library/Cargo.toml
+++ b/library/Cargo.toml
@@ -59,6 +59,8 @@ rustflags = ["-Cpanic=abort"]
 # in the user's profile.
 [profile.dist]
 inherits = "release"
+codegen-units = 1
+debug = 1 # "limited"
 rustflags = [
     # Unconditionally embedding bitcode is necessary for when users enable LTO.
     # Until Cargo can rebuild the standard library with the user profile's `lto`

--- a/library/test/build.rs
+++ b/library/test/build.rs
@@ -1,0 +1,11 @@
+fn main() {
+    println!("cargo:rustc-check-cfg=cfg(enable_unstable_features)");
+
+    let rustc = std::env::var("RUSTC").unwrap_or_else(|_| "rustc".into());
+    let version = std::process::Command::new(rustc).arg("-vV").output().unwrap();
+    let stdout = String::from_utf8(version.stdout).unwrap();
+
+    if stdout.contains("nightly") || stdout.contains("dev") {
+        println!("cargo:rustc-cfg=enable_unstable_features");
+    }
+}

--- a/library/test/src/cli.rs
+++ b/library/test/src/cli.rs
@@ -314,15 +314,14 @@ fn parse_opts_impl(matches: getopts::Matches) -> OptRes {
     Ok(test_opts)
 }
 
-// FIXME: Copied from librustc_ast until linkage errors are resolved. Issue #47566
 fn is_nightly() -> bool {
-    // Whether this is a feature-staged build, i.e., on the beta or stable channel
-    let disable_unstable_features =
-        option_env!("CFG_DISABLE_UNSTABLE_FEATURES").map(|s| s != "0").unwrap_or(false);
-    // Whether we should enable unstable features for bootstrapping
+    // Whether the current rustc version should allow unstable features
+    let enable_unstable_features = cfg!(enable_unstable_features);
+
+    // The runtime override for unstable features
     let bootstrap = env::var("RUSTC_BOOTSTRAP").is_ok();
 
-    bootstrap || !disable_unstable_features
+    bootstrap || enable_unstable_features
 }
 
 // Gets the CLI options associated with `report-time` feature.

--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -626,12 +626,6 @@ pub fn std_cargo(
         CompilerBuiltins::BuildRustOnly => "",
     };
 
-    // `libtest` uses this to know whether or not to support
-    // `-Zunstable-options`.
-    if !builder.unstable_features() {
-        cargo.env("CFG_DISABLE_UNSTABLE_FEATURES", "1");
-    }
-
     for krate in crates {
         cargo.args(["-p", krate]);
     }

--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -680,13 +680,6 @@ pub fn std_cargo(
         }
     }
 
-    // By default, rustc uses `-Cembed-bitcode=yes`, and Cargo overrides that
-    // with `-Cembed-bitcode=no` for non-LTO builds. However, libstd must be
-    // built with bitcode so that the produced rlibs can be used for both LTO
-    // builds (which use bitcode) and non-LTO builds (which use object code).
-    // So we override the override here!
-    cargo.rustflag("-Cembed-bitcode=yes");
-
     if builder.config.rust_lto == RustcLto::Off {
         cargo.rustflag("-Clto=off");
     }

--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -694,11 +694,6 @@ pub fn std_cargo(
         cargo.rustflag("-Cforce-unwind-tables=yes");
     }
 
-    // Enable frame pointers by default for the library. Note that they are still controlled by a
-    // separate setting for the compiler.
-    cargo.rustflag("-Zunstable-options");
-    cargo.rustflag("-Cforce-frame-pointers=non-leaf");
-
     let html_root =
         format!("-Zcrate-attr=doc(html_root_url=\"{}/\")", builder.doc_rust_lang_org_channel(),);
     cargo.rustflag(&html_root);

--- a/src/bootstrap/src/core/build_steps/dist.rs
+++ b/src/bootstrap/src/core/build_steps/dist.rs
@@ -1008,7 +1008,7 @@ impl Step for Analysis {
         let src = builder
             .stage_out(compiler, Mode::Std)
             .join(target)
-            .join(builder.cargo_dir())
+            .join(builder.cargo_dir(Mode::Std))
             .join("deps")
             .join("save-analysis");
 

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -927,8 +927,9 @@ impl Step for Clippy {
 
         cargo.env("RUSTC_TEST_SUITE", builder.rustc(build_compiler));
         cargo.env("RUSTC_LIB_PATH", builder.rustc_libdir(build_compiler));
-        let host_libs =
-            builder.stage_out(build_compiler, Mode::ToolRustcPrivate).join(builder.cargo_dir());
+        let host_libs = builder
+            .stage_out(build_compiler, Mode::ToolRustcPrivate)
+            .join(builder.cargo_dir(Mode::ToolRustcPrivate));
         cargo.env("HOST_LIBS", host_libs);
 
         // Build the standard library that the tests can use.

--- a/src/bootstrap/src/core/build_steps/tool.rs
+++ b/src/bootstrap/src/core/build_steps/tool.rs
@@ -133,7 +133,7 @@ impl Step for ToolBuild {
                 RustcLto::ThinLocal => None,
             };
             if let Some(lto) = lto {
-                cargo.env(cargo_profile_var("LTO", &builder.config), lto);
+                cargo.env(cargo_profile_var("LTO", &builder.config, self.mode), lto);
             }
         }
 

--- a/src/bootstrap/src/core/builder/cargo.rs
+++ b/src/bootstrap/src/core/builder/cargo.rs
@@ -683,11 +683,13 @@ impl Builder<'_> {
             rustflags.arg("--cfg=windows_raw_dylib");
         }
 
-        rustflags.arg(match use_new_symbol_mangling {
-            Some(true) => "-Csymbol-mangling-version=v0",
-            Some(false) => "-Csymbol-mangling-version=legacy",
-            None => "",
-        });
+        if let Some(usm) = use_new_symbol_mangling {
+            rustflags.arg(if usm {
+                "-Csymbol-mangling-version=v0"
+            } else {
+                "-Csymbol-mangling-version=legacy"
+            });
+        }
 
         // Always enable move/copy annotations for profiler visibility (non-stage0 only).
         // Note that -Zannotate-moves is only effective with debugging info enabled.

--- a/src/bootstrap/src/lib.rs
+++ b/src/bootstrap/src/lib.rs
@@ -900,7 +900,7 @@ impl Build {
     /// release/debug)
     fn cargo_dir(&self, mode: Mode) -> &'static str {
         match (mode, self.config.rust_optimize.is_release()) {
-            (Mode::Std, true) => "dist",
+            (Mode::Std, _) => "dist",
             (_, true) => "release",
             (_, false) => "debug",
         }

--- a/src/bootstrap/src/lib.rs
+++ b/src/bootstrap/src/lib.rs
@@ -898,8 +898,12 @@ impl Build {
 
     /// Component directory that Cargo will produce output into (e.g.
     /// release/debug)
-    fn cargo_dir(&self) -> &'static str {
-        if self.config.rust_optimize.is_release() { "release" } else { "debug" }
+    fn cargo_dir(&self, mode: Mode) -> &'static str {
+        match (mode, self.config.rust_optimize.is_release()) {
+            (Mode::Std, true) => "dist",
+            (_, true) => "release",
+            (_, false) => "debug",
+        }
     }
 
     fn tools_dir(&self, build_compiler: Compiler) -> PathBuf {
@@ -956,7 +960,7 @@ impl Build {
     /// running a particular compiler, whether or not we're building the
     /// standard library, and targeting the specified architecture.
     fn cargo_out(&self, build_compiler: Compiler, mode: Mode, target: TargetSelection) -> PathBuf {
-        self.stage_out(build_compiler, mode).join(target).join(self.cargo_dir())
+        self.stage_out(build_compiler, mode).join(target).join(self.cargo_dir(mode))
     }
 
     /// Root output directory of LLVM for `target`

--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -120,6 +120,8 @@ if [ "$DEPLOY$DEPLOY_ALT" = "1" ]; then
 
   if [ "$DEPLOY_ALT" != "" ] && isLinux; then
     RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --debuginfo-level=2"
+  else
+    RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --debuginfo-level-std=1"
   fi
 
   if [ "$NO_LLVM_ASSERTIONS" = "1" ]; then

--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -120,8 +120,6 @@ if [ "$DEPLOY$DEPLOY_ALT" = "1" ]; then
 
   if [ "$DEPLOY_ALT" != "" ] && isLinux; then
     RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --debuginfo-level=2"
-  else
-    RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --debuginfo-level-std=1"
   fi
 
   if [ "$NO_LLVM_ASSERTIONS" = "1" ]; then


### PR DESCRIPTION
This creates a new "dist" profile in the standard library which contains configuration for the distributed std artifacts previously contained in bootstrap, in order for a future build-std implementation to use. bootstrap.toml settings continue to override these defaults, as would any RUSTFLAGS provided. I've left some cargo features driven by bootstrap for a future patch.

Unfortunately, profiles aren't expressive enough to express per-target overrides, so [this risc-v example](https://github.com/rust-lang/rust/blob/c8f22ca269a1f2653ac962fe2bc21105065fd6cd/src/bootstrap/src/core/build_steps/compile.rs#L692) was not able to be moved across. This could go in its own profile which Cargo would have to know to use, and then the panic-abort rustflags overrides would need duplicating again. Doesn't seem like a sustainable solution as a couple similar overrides would explode the number of lines here.

We could use a cargo config in the library workspace for this, but this then would have to be respected by Cargo's build-std implementation and I'm not yet sure about the tradeoffs there.

This patch also introduces a build probe to deal with the test crate's stability which is obviously not ideal, I'm open to other solutions here or can back that change out for now if anyone prefers.

cc @Mark-Simulacrum https://github.com/rust-lang/rfcs/pull/3874