### PR TITLE
Promote `uninhabited_static` lint to a hard error

### DIFF
--- a/compiler/rustc_hir_analysis/src/check/check.rs
+++ b/compiler/rustc_hir_analysis/src/check/check.rs
@@ -23,7 +23,6 @@ use rustc_middle::ty::{
     AdtDef, BottomUpFolder, FnSig, GenericArgKind, RegionKind, TypeFoldable, TypeSuperVisitable,
     TypeVisitable, TypeVisitableExt, fold_regions,
 };
-use rustc_session::lint::builtin::UNINHABITED_STATIC;
 use rustc_target::spec::{AbiMap, AbiMapping};
 use rustc_trait_selection::error_reporting::InferCtxtErrorExt;
 use rustc_trait_selection::error_reporting::traits::on_unimplemented::OnUnimplementedDirective;
@@ -197,16 +196,13 @@ fn check_static_inhabited(tcx: TyCtxt<'_>, def_id: LocalDefId) {
         }
     };
     if layout.is_uninhabited() {
-        tcx.node_span_lint(
-            UNINHABITED_STATIC,
-            tcx.local_def_id_to_hir_id(def_id),
-            span,
-            |lint| {
-                lint.primary_message("static of uninhabited type");
-                lint
-                .note("uninhabited statics cannot be initialized, and any access would be an immediate error");
-            },
-        );
+        tcx.dcx()
+            .struct_span_err(span, "static of uninhabited type")
+            .with_note(
+                "uninhabited statics cannot be initialized, \
+                and any access would be an immediate error",
+            )
+            .emit();
     }
 }
 

--- a/compiler/rustc_lint/src/lib.rs
+++ b/compiler/rustc_lint/src/lib.rs
@@ -640,6 +640,11 @@ fn register_builtins(store: &mut LintStore) {
          see <https://github.com/rust-lang/rust/issues/40107> for more information",
     );
     store.register_removed("wasm_c_abi", "the wasm C ABI has been fixed");
+    store.register_removed(
+        "uninhabited_static",
+        "converted into a hard error, \
+        see <https://github.com/rust-lang/rust/issues/74840> for more information",
+    )
 }
 
 fn register_internals(store: &mut LintStore) {

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -114,7 +114,6 @@ declare_lint_pass! {
         UNCOVERED_PARAM_IN_PROJECTION,
         UNEXPECTED_CFGS,
         UNFULFILLED_LINT_EXPECTATIONS,
-        UNINHABITED_STATIC,
         UNKNOWN_CRATE_TYPES,
         UNKNOWN_DIAGNOSTIC_ATTRIBUTES,
         UNKNOWN_LINTS,
@@ -2675,34 +2674,6 @@ declare_lint! {
     pub FUNCTION_ITEM_REFERENCES,
     Warn,
     "suggest casting to a function pointer when attempting to take references to function items",
-}
-
-declare_lint! {
-    /// The `uninhabited_static` lint detects uninhabited statics.
-    ///
-    /// ### Example
-    ///
-    /// ```rust
-    /// enum Void {}
-    /// unsafe extern {
-    ///     static EXTERN: Void;
-    /// }
-    /// ```
-    ///
-    /// {{produces}}
-    ///
-    /// ### Explanation
-    ///
-    /// Statics with an uninhabited type can never be initialized, so they are impossible to define.
-    /// However, this can be side-stepped with an `extern static`, leading to problems later in the
-    /// compiler which assumes that there are no initialized uninhabited places (such as locals or
-    /// statics). This was accidentally allowed, but is being phased out.
-    pub UNINHABITED_STATIC,
-    Warn,
-    "uninhabited static",
-    @future_incompatible = FutureIncompatibleInfo {
-        reason: fcw!(FutureReleaseError #74840),
-    };
 }
 
 declare_lint! {

--- a/tests/ui/statics/uninhabited-static.rs
+++ b/tests/ui/statics/uninhabited-static.rs
@@ -1,19 +1,16 @@
 #![feature(never_type)]
-#![deny(uninhabited_static)]
 
 enum Void {}
 extern "C" {
     static VOID: Void; //~ ERROR static of uninhabited type
-    //~| WARN: previously accepted
     static NEVER: !; //~ ERROR static of uninhabited type
-    //~| WARN: previously accepted
 }
 
-static VOID2: Void = unsafe { std::mem::transmute(()) }; //~ ERROR static of uninhabited type
-//~| WARN: previously accepted
+static VOID2: Void = unsafe { std::mem::transmute(()) };
+//~^ ERROR static of uninhabited type
 //~| ERROR value of uninhabited type `Void`
-static NEVER2: Void = unsafe { std::mem::transmute(()) }; //~ ERROR static of uninhabited type
-//~| WARN: previously accepted
+static NEVER2: Void = unsafe { std::mem::transmute(()) };
+//~^ ERROR static of uninhabited type
 //~| ERROR value of uninhabited type `Void`
 
 fn main() {}

--- a/tests/ui/statics/uninhabited-static.stderr
+++ b/tests/ui/statics/uninhabited-static.stderr
@@ -1,56 +1,43 @@
 error: static of uninhabited type
-  --> $DIR/uninhabited-static.rs:12:1
+  --> $DIR/uninhabited-static.rs:9:1
    |
 LL | static VOID2: Void = unsafe { std::mem::transmute(()) };
    | ^^^^^^^^^^^^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #74840 <https://github.com/rust-lang/rust/issues/74840>
    = note: uninhabited statics cannot be initialized, and any access would be an immediate error
-note: the lint level is defined here
-  --> $DIR/uninhabited-static.rs:2:9
-   |
-LL | #![deny(uninhabited_static)]
-   |         ^^^^^^^^^^^^^^^^^^
 
 error: static of uninhabited type
-  --> $DIR/uninhabited-static.rs:15:1
+  --> $DIR/uninhabited-static.rs:12:1
    |
 LL | static NEVER2: Void = unsafe { std::mem::transmute(()) };
    | ^^^^^^^^^^^^^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #74840 <https://github.com/rust-lang/rust/issues/74840>
+   = note: uninhabited statics cannot be initialized, and any access would be an immediate error
+
+error: static of uninhabited type
+  --> $DIR/uninhabited-static.rs:5:5
+   |
+LL |     static VOID: Void;
+   |     ^^^^^^^^^^^^^^^^^
+   |
    = note: uninhabited statics cannot be initialized, and any access would be an immediate error
 
 error: static of uninhabited type
   --> $DIR/uninhabited-static.rs:6:5
    |
-LL |     static VOID: Void;
-   |     ^^^^^^^^^^^^^^^^^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #74840 <https://github.com/rust-lang/rust/issues/74840>
-   = note: uninhabited statics cannot be initialized, and any access would be an immediate error
-
-error: static of uninhabited type
-  --> $DIR/uninhabited-static.rs:8:5
-   |
 LL |     static NEVER: !;
    |     ^^^^^^^^^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #74840 <https://github.com/rust-lang/rust/issues/74840>
    = note: uninhabited statics cannot be initialized, and any access would be an immediate error
 
 error[E0080]: constructing invalid value: encountered a value of uninhabited type `Void`
-  --> $DIR/uninhabited-static.rs:12:31
+  --> $DIR/uninhabited-static.rs:9:31
    |
 LL | static VOID2: Void = unsafe { std::mem::transmute(()) };
    |                               ^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `VOID2` failed here
 
 error[E0080]: constructing invalid value: encountered a value of uninhabited type `Void`
-  --> $DIR/uninhabited-static.rs:15:32
+  --> $DIR/uninhabited-static.rs:12:32
    |
 LL | static NEVER2: Void = unsafe { std::mem::transmute(()) };
    |                                ^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `NEVER2` failed here


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

The lint was introduced as a FCW in rust-lang/rust#78324 and landed in rust 1.49.0 (5 years ago); see also rust-lang/rust#74840. I think we can promote this to a hard error ^^'
