### PR TITLE
debuginfo/macro-stepping test: extend comments

### DIFF
--- a/tests/debuginfo/macro-stepping.rs
+++ b/tests/debuginfo/macro-stepping.rs
@@ -1,3 +1,8 @@
+//! This tests that `next` skips over macro invocations correctly.
+//! The `#locN` markers have no meaning for compiletest, we include them just
+//! so that the debugger prints them when printing the current source location,
+//! and we can match on them for testing purposes.
+
 //@ ignore-android
 //@ min-lldb-version: 1800
 //@ min-gdb-version: 13.0
@@ -68,6 +73,7 @@ extern crate macro_stepping; // exports new_scope!()
 //@ lldb-command:next
 //@ lldb-command:frame select
 //@ lldb-check:[...] #loc5 [...]
+// FIXME: what about loc6?
 
 //@ lldb-command:continue
 //@ lldb-command:step


### PR DESCRIPTION
Those `#locN` markers look like they are debuginfo compiletest magic (since `#break` is debuginfo compiletest magic). However, they are actually just magic strings used by the `check` commands in the test itself. This threw me off when I looked at the test (prompted by a CI failure), so let's leave a comment for the next poor soul that ends up lost in this test.

Also, for some reason the lldb instructions do not check for `#loc6`, unlike the gdb instructions. I do not know of an lldb version that actually makes the test pass (do we even run it with lldb at all on CI?), so I won't try to add a check for loc6, but let's at least add a comment to increase the chance that someone more knowledgeable about lldb and our test suite notices this in the future.