### PR TITLE
reword error for invalid range patterns

### DIFF
--- a/compiler/rustc_mir_build/messages.ftl
+++ b/compiler/rustc_mir_build/messages.ftl
@@ -250,11 +250,11 @@ mir_build_loop_match_unsupported_type =
     .note = only integers, floats, bool, char, and enums without fields are supported
 
 mir_build_lower_range_bound_must_be_less_than_or_equal_to_upper =
-    lower range bound must be less than or equal to upper
+    lower bound for range pattern must be less than or equal to upper bound
     .label = lower bound larger than upper bound
     .teach_note = When matching against a range, the compiler verifies that the range is non-empty. Range patterns include both end-points, so this is equivalent to requiring the start of the range to be less than or equal to the end of the range.
 
-mir_build_lower_range_bound_must_be_less_than_upper = lower range bound must be less than upper
+mir_build_lower_range_bound_must_be_less_than_upper = lower bound for range pattern must be less than upper bound
 
 mir_build_more_information = for more information, visit https://doc.rust-lang.org/book/ch19-02-refutability.html
 
@@ -505,6 +505,8 @@ mir_build_unused_unsafe = unnecessary `unsafe` block
     .label = unnecessary `unsafe` block
 
 mir_build_unused_unsafe_enclosing_block_label = because it's nested under this `unsafe` block
+
+mir_build_upper_range_bound_cannot_be_min = exclusive upper bound for a range bound cannot be the minimum
 
 mir_build_variant_defined_here = not covered
 

--- a/compiler/rustc_mir_build/src/errors.rs
+++ b/compiler/rustc_mir_build/src/errors.rs
@@ -776,6 +776,13 @@ pub(crate) struct LowerRangeBoundMustBeLessThanUpper {
     pub(crate) span: Span,
 }
 
+#[derive(Diagnostic)]
+#[diag(mir_build_upper_range_bound_cannot_be_min, code = E0579)]
+pub(crate) struct UpperRangeBoundCannotBeMin {
+    #[primary_span]
+    pub(crate) span: Span,
+}
+
 #[derive(LintDiagnostic)]
 #[diag(mir_build_leading_irrefutable_let_patterns)]
 #[note]

--- a/compiler/rustc_mir_build/src/thir/pattern/mod.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/mod.rs
@@ -273,6 +273,9 @@ impl<'a, 'tcx> PatCtxt<'a, 'tcx> {
                             teach: self.tcx.sess.teach(E0030),
                         })
                     }
+                    RangeEnd::Excluded if lo_expr.is_none() => {
+                        self.tcx.dcx().emit_err(UpperRangeBoundCannotBeMin { span })
+                    }
                     RangeEnd::Excluded => {
                         self.tcx.dcx().emit_err(LowerRangeBoundMustBeLessThanUpper { span })
                     }

--- a/tests/ui/error-codes/E0030-teach.rs
+++ b/tests/ui/error-codes/E0030-teach.rs
@@ -3,6 +3,6 @@
 fn main() {
     match 5u32 {
         1000 ..= 5 => {}
-        //~^ ERROR lower range bound must be less than or equal to upper
+        //~^ ERROR lower bound for range pattern must be less than or equal to upper bound
     }
 }

--- a/tests/ui/error-codes/E0030-teach.stderr
+++ b/tests/ui/error-codes/E0030-teach.stderr
@@ -1,4 +1,4 @@
-error[E0030]: lower range bound must be less than or equal to upper
+error[E0030]: lower bound for range pattern must be less than or equal to upper bound
   --> $DIR/E0030-teach.rs:5:9
    |
 LL |         1000 ..= 5 => {}

--- a/tests/ui/error-codes/E0030.rs
+++ b/tests/ui/error-codes/E0030.rs
@@ -1,6 +1,6 @@
 fn main() {
     match 5u32 {
         1000 ..= 5 => {}
-        //~^ ERROR lower range bound must be less than or equal to upper
+        //~^ ERROR lower bound for range pattern must be less than or equal to upper bound
     }
 }

--- a/tests/ui/error-codes/E0030.stderr
+++ b/tests/ui/error-codes/E0030.stderr
@@ -1,4 +1,4 @@
-error[E0030]: lower range bound must be less than or equal to upper
+error[E0030]: lower bound for range pattern must be less than or equal to upper bound
   --> $DIR/E0030.rs:3:9
    |
 LL |         1000 ..= 5 => {}

--- a/tests/ui/half-open-range-patterns/half-open-range-pats-thir-lower-empty.rs
+++ b/tests/ui/half-open-range-patterns/half-open-range-pats-thir-lower-empty.rs
@@ -9,36 +9,36 @@ macro_rules! m {
 
 fn main() {
     m!(0, ..u8::MIN);
-    //~^ ERROR lower range bound must be less than upper
+    //~^ ERROR exclusive upper bound for a range bound cannot be the minimum
     m!(0, ..u16::MIN);
-    //~^ ERROR lower range bound must be less than upper
+    //~^ ERROR exclusive upper bound for a range bound cannot be the minimum
     m!(0, ..u32::MIN);
-    //~^ ERROR lower range bound must be less than upper
+    //~^ ERROR exclusive upper bound for a range bound cannot be the minimum
     m!(0, ..u64::MIN);
-    //~^ ERROR lower range bound must be less than upper
+    //~^ ERROR exclusive upper bound for a range bound cannot be the minimum
     m!(0, ..u128::MIN);
-    //~^ ERROR lower range bound must be less than upper
+    //~^ ERROR exclusive upper bound for a range bound cannot be the minimum
 
     m!(0, ..i8::MIN);
-    //~^ ERROR lower range bound must be less than upper
+    //~^ ERROR exclusive upper bound for a range bound cannot be the minimum
     m!(0, ..i16::MIN);
-    //~^ ERROR lower range bound must be less than upper
+    //~^ ERROR exclusive upper bound for a range bound cannot be the minimum
     m!(0, ..i32::MIN);
-    //~^ ERROR lower range bound must be less than upper
+    //~^ ERROR exclusive upper bound for a range bound cannot be the minimum
     m!(0, ..i64::MIN);
-    //~^ ERROR lower range bound must be less than upper
+    //~^ ERROR exclusive upper bound for a range bound cannot be the minimum
     m!(0, ..i128::MIN);
-    //~^ ERROR lower range bound must be less than upper
+    //~^ ERROR exclusive upper bound for a range bound cannot be the minimum
 
     m!(0f16, ..f16::NEG_INFINITY);
-    //~^ ERROR lower range bound must be less than upper
+    //~^ ERROR exclusive upper bound for a range bound cannot be the minimum
     m!(0f32, ..f32::NEG_INFINITY);
-    //~^ ERROR lower range bound must be less than upper
+    //~^ ERROR exclusive upper bound for a range bound cannot be the minimum
     m!(0f64, ..f64::NEG_INFINITY);
-    //~^ ERROR lower range bound must be less than upper
+    //~^ ERROR exclusive upper bound for a range bound cannot be the minimum
     m!(0f128, ..f128::NEG_INFINITY);
-    //~^ ERROR lower range bound must be less than upper
+    //~^ ERROR exclusive upper bound for a range bound cannot be the minimum
 
     m!('a', ..'\u{0}');
-    //~^ ERROR lower range bound must be less than upper
+    //~^ ERROR exclusive upper bound for a range bound cannot be the minimum
 }

--- a/tests/ui/half-open-range-patterns/half-open-range-pats-thir-lower-empty.stderr
+++ b/tests/ui/half-open-range-patterns/half-open-range-pats-thir-lower-empty.stderr
@@ -1,88 +1,88 @@
-error[E0579]: lower range bound must be less than upper
+error[E0579]: exclusive upper bound for a range bound cannot be the minimum
   --> $DIR/half-open-range-pats-thir-lower-empty.rs:11:11
    |
 LL |     m!(0, ..u8::MIN);
    |           ^^^^^^^^^
 
-error[E0579]: lower range bound must be less than upper
+error[E0579]: exclusive upper bound for a range bound cannot be the minimum
   --> $DIR/half-open-range-pats-thir-lower-empty.rs:13:11
    |
 LL |     m!(0, ..u16::MIN);
    |           ^^^^^^^^^^
 
-error[E0579]: lower range bound must be less than upper
+error[E0579]: exclusive upper bound for a range bound cannot be the minimum
   --> $DIR/half-open-range-pats-thir-lower-empty.rs:15:11
    |
 LL |     m!(0, ..u32::MIN);
    |           ^^^^^^^^^^
 
-error[E0579]: lower range bound must be less than upper
+error[E0579]: exclusive upper bound for a range bound cannot be the minimum
   --> $DIR/half-open-range-pats-thir-lower-empty.rs:17:11
    |
 LL |     m!(0, ..u64::MIN);
    |           ^^^^^^^^^^
 
-error[E0579]: lower range bound must be less than upper
+error[E0579]: exclusive upper bound for a range bound cannot be the minimum
   --> $DIR/half-open-range-pats-thir-lower-empty.rs:19:11
    |
 LL |     m!(0, ..u128::MIN);
    |           ^^^^^^^^^^^
 
-error[E0579]: lower range bound must be less than upper
+error[E0579]: exclusive upper bound for a range bound cannot be the minimum
   --> $DIR/half-open-range-pats-thir-lower-empty.rs:22:11
    |
 LL |     m!(0, ..i8::MIN);
    |           ^^^^^^^^^
 
-error[E0579]: lower range bound must be less than upper
+error[E0579]: exclusive upper bound for a range bound cannot be the minimum
   --> $DIR/half-open-range-pats-thir-lower-empty.rs:24:11
    |
 LL |     m!(0, ..i16::MIN);
    |           ^^^^^^^^^^
 
-error[E0579]: lower range bound must be less than upper
+error[E0579]: exclusive upper bound for a range bound cannot be the minimum
   --> $DIR/half-open-range-pats-thir-lower-empty.rs:26:11
    |
 LL |     m!(0, ..i32::MIN);
    |           ^^^^^^^^^^
 
-error[E0579]: lower range bound must be less than upper
+error[E0579]: exclusive upper bound for a range bound cannot be the minimum
   --> $DIR/half-open-range-pats-thir-lower-empty.rs:28:11
    |
 LL |     m!(0, ..i64::MIN);
    |           ^^^^^^^^^^
 
-error[E0579]: lower range bound must be less than upper
+error[E0579]: exclusive upper bound for a range bound cannot be the minimum
   --> $DIR/half-open-range-pats-thir-lower-empty.rs:30:11
    |
 LL |     m!(0, ..i128::MIN);
    |           ^^^^^^^^^^^
 
-error[E0579]: lower range bound must be less than upper
+error[E0579]: exclusive upper bound for a range bound cannot be the minimum
   --> $DIR/half-open-range-pats-thir-lower-empty.rs:33:14
    |
 LL |     m!(0f16, ..f16::NEG_INFINITY);
    |              ^^^^^^^^^^^^^^^^^^^
 
-error[E0579]: lower range bound must be less than upper
+error[E0579]: exclusive upper bound for a range bound cannot be the minimum
   --> $DIR/half-open-range-pats-thir-lower-empty.rs:35:14
    |
 LL |     m!(0f32, ..f32::NEG_INFINITY);
    |              ^^^^^^^^^^^^^^^^^^^
 
-error[E0579]: lower range bound must be less than upper
+error[E0579]: exclusive upper bound for a range bound cannot be the minimum
   --> $DIR/half-open-range-pats-thir-lower-empty.rs:37:14
    |
 LL |     m!(0f64, ..f64::NEG_INFINITY);
    |              ^^^^^^^^^^^^^^^^^^^
 
-error[E0579]: lower range bound must be less than upper
+error[E0579]: exclusive upper bound for a range bound cannot be the minimum
   --> $DIR/half-open-range-pats-thir-lower-empty.rs:39:15
    |
 LL |     m!(0f128, ..f128::NEG_INFINITY);
    |               ^^^^^^^^^^^^^^^^^^^^
 
-error[E0579]: lower range bound must be less than upper
+error[E0579]: exclusive upper bound for a range bound cannot be the minimum
   --> $DIR/half-open-range-pats-thir-lower-empty.rs:42:13
    |
 LL |     m!('a', ..'\u{0}');

--- a/tests/ui/loop-match/invalid.rs
+++ b/tests/ui/loop-match/invalid.rs
@@ -202,7 +202,7 @@ fn invalid_range_pattern(state: f32) {
                     break 'blk 2.5;
                 }
                 4.0..3.0 => {
-                    //~^ ERROR lower range bound must be less than upper
+                    //~^ ERROR lower bound for range pattern must be less than upper bound
                     todo!()
                 }
             }

--- a/tests/ui/loop-match/invalid.stderr
+++ b/tests/ui/loop-match/invalid.stderr
@@ -121,7 +121,7 @@ LL ~                 State::A => State::B,
 LL ~                 State::B | State::C => todo!(),
    |
 
-error[E0579]: lower range bound must be less than upper
+error[E0579]: lower bound for range pattern must be less than upper bound
   --> $DIR/invalid.rs:204:17
    |
 LL |                 4.0..3.0 => {

--- a/tests/ui/match/match-range-fail-2.rs
+++ b/tests/ui/match/match-range-fail-2.rs
@@ -1,19 +1,19 @@
 fn main() {
     match 5 {
         6 ..= 1 => { }
-        //~^ ERROR lower range bound must be less than or equal to upper
+        //~^ ERROR lower bound for range pattern must be less than or equal to upper bound
         _ => { }
     };
 
     match 5 {
         0 .. 0 => { }
-        //~^ ERROR lower range bound must be less than upper
+        //~^ ERROR lower bound for range pattern must be less than upper bound
         _ => { }
     };
 
     match 5u64 {
         0xFFFF_FFFF_FFFF_FFFF ..= 1 => { }
-        //~^ ERROR lower range bound must be less than or equal to upper
+        //~^ ERROR lower bound for range pattern must be less than or equal to upper bound
         _ => { }
     };
 }

--- a/tests/ui/match/match-range-fail-2.stderr
+++ b/tests/ui/match/match-range-fail-2.stderr
@@ -1,16 +1,16 @@
-error[E0030]: lower range bound must be less than or equal to upper
+error[E0030]: lower bound for range pattern must be less than or equal to upper bound
   --> $DIR/match-range-fail-2.rs:3:9
    |
 LL |         6 ..= 1 => { }
    |         ^^^^^^^ lower bound larger than upper bound
 
-error[E0579]: lower range bound must be less than upper
+error[E0579]: lower bound for range pattern must be less than upper bound
   --> $DIR/match-range-fail-2.rs:9:9
    |
 LL |         0 .. 0 => { }
    |         ^^^^^^
 
-error[E0030]: lower range bound must be less than or equal to upper
+error[E0030]: lower bound for range pattern must be less than or equal to upper bound
   --> $DIR/match-range-fail-2.rs:15:9
    |
 LL |         0xFFFF_FFFF_FFFF_FFFF ..= 1 => { }

--- a/tests/ui/match/validate-range-endpoints.rs
+++ b/tests/ui/match/validate-range-endpoints.rs
@@ -15,7 +15,7 @@ fn main() {
 
         // There isn't really a way to detect these
         1..=TOO_BIG => {}
-        //~^ ERROR lower range bound must be less than or equal to upper
+        //~^ ERROR lower bound for range pattern must be less than or equal to upper bound
         _ => {}
     }
 

--- a/tests/ui/match/validate-range-endpoints.stderr
+++ b/tests/ui/match/validate-range-endpoints.stderr
@@ -10,7 +10,7 @@ error: literal out of range for `u8`
 LL |         1..=256 => {}
    |             ^^^ this value does not fit into the type `u8` whose range is `0..=255`
 
-error[E0030]: lower range bound must be less than or equal to upper
+error[E0030]: lower bound for range pattern must be less than or equal to upper bound
   --> $DIR/validate-range-endpoints.rs:17:9
    |
 LL |         1..=TOO_BIG => {}


### PR DESCRIPTION
For half-open ranges, specifies that the upper bound cannot be the minimum.

Also specify that this only applies to range patterns and not also expressions.

Fixes rust-lang/rust#149165