### PR TITLE
chore: Update annotate-snippets to 0.12.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,9 +74,9 @@ dependencies = [
 
 [[package]]
 name = "annotate-snippets"
-version = "0.12.9"
+version = "0.12.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44baf24dd94e781f74dfe67ffee75a09a57971ddf0f615a178b4f6d404b48ff"
+checksum = "15580ece6ea97cbf832d60ba19c021113469480852c6a2a6beb0db28f097bf1f"
 dependencies = [
  "anstyle",
  "memchr",
@@ -3838,7 +3838,7 @@ dependencies = [
 name = "rustc_errors"
 version = "0.0.0"
 dependencies = [
- "annotate-snippets 0.12.9",
+ "annotate-snippets 0.12.10",
  "anstream",
  "anstyle",
  "derive_setters",

--- a/compiler/rustc_errors/Cargo.toml
+++ b/compiler/rustc_errors/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 
 [dependencies]
 # tidy-alphabetical-start
-annotate-snippets = { version = "0.12.9", features = ["simd"] }
+annotate-snippets = { version = "0.12.10", features = ["simd"] }
 anstream = "0.6.20"
 anstyle = "1.0.13"
 derive_setters = "0.1.6"

--- a/src/tools/clippy/tests/ui/manual_async_fn.stderr
+++ b/src/tools/clippy/tests/ui/manual_async_fn.stderr
@@ -9,6 +9,9 @@ LL | fn fut() -> impl Future<Output = i32> {
 help: make the function `async` and return the output of the future directly
    |
 LL - fn fut() -> impl Future<Output = i32> {
+LL -
+LL -     async { 42 }
+LL - }
 LL + async fn fut() -> i32 { 42 }
    |
 
@@ -21,6 +24,9 @@ LL | fn fut2() ->impl Future<Output = i32> {
 help: make the function `async` and return the output of the future directly
    |
 LL - fn fut2() ->impl Future<Output = i32> {
+LL -
+LL -     async { 42 }
+LL - }
 LL + async fn fut2() -> i32 { 42 }
    |
 
@@ -33,6 +39,9 @@ LL | fn fut3()-> impl Future<Output = i32> {
 help: make the function `async` and return the output of the future directly
    |
 LL - fn fut3()-> impl Future<Output = i32> {
+LL -
+LL -     async { 42 }
+LL - }
 LL + async fn fut3() -> i32 { 42 }
    |
 
@@ -45,6 +54,9 @@ LL | fn empty_fut() -> impl Future<Output = ()> {
 help: make the function `async` and return the output of the future directly
    |
 LL - fn empty_fut() -> impl Future<Output = ()> {
+LL -
+LL -     async {}
+LL - }
 LL + async fn empty_fut() {}
    |
 
@@ -57,6 +69,9 @@ LL | fn empty_fut2() ->impl Future<Output = ()> {
 help: make the function `async` and return the output of the future directly
    |
 LL - fn empty_fut2() ->impl Future<Output = ()> {
+LL -
+LL -     async {}
+LL - }
 LL + async fn empty_fut2() {}
    |
 
@@ -69,6 +84,9 @@ LL | fn empty_fut3()-> impl Future<Output = ()> {
 help: make the function `async` and return the output of the future directly
    |
 LL - fn empty_fut3()-> impl Future<Output = ()> {
+LL -
+LL -     async {}
+LL - }
 LL + async fn empty_fut3() {}
    |
 
@@ -81,6 +99,9 @@ LL | fn core_fut() -> impl core::future::Future<Output = i32> {
 help: make the function `async` and return the output of the future directly
    |
 LL - fn core_fut() -> impl core::future::Future<Output = i32> {
+LL -
+LL -     async move { 42 }
+LL - }
 LL + async fn core_fut() -> i32 { 42 }
    |
 
@@ -116,6 +137,9 @@ LL | fn elided(_: &i32) -> impl Future<Output = i32> + '_ {
 help: make the function `async` and return the output of the future directly
    |
 LL - fn elided(_: &i32) -> impl Future<Output = i32> + '_ {
+LL -
+LL -     async { 42 }
+LL - }
 LL + async fn elided(_: &i32) -> i32 { 42 }
    |
 
@@ -128,6 +152,9 @@ LL | fn explicit<'a, 'b>(_: &'a i32, _: &'b i32) -> impl Future<Output = i32> + 
 help: make the function `async` and return the output of the future directly
    |
 LL - fn explicit<'a, 'b>(_: &'a i32, _: &'b i32) -> impl Future<Output = i32> + 'a + 'b {
+LL -
+LL -     async { 42 }
+LL - }
 LL + async fn explicit<'a, 'b>(_: &'a i32, _: &'b i32) -> i32 { 42 }
    |
 
@@ -140,6 +167,9 @@ LL | pub fn issue_10450() -> impl Future<Output = i32> {
 help: make the function `async` and return the output of the future directly
    |
 LL - pub fn issue_10450() -> impl Future<Output = i32> {
+LL -
+LL -     async { 42 }
+LL - }
 LL + pub async fn issue_10450() -> i32 { 42 }
    |
 
@@ -152,6 +182,9 @@ LL | pub(crate) fn issue_10450_2() -> impl Future<Output = i32> {
 help: make the function `async` and return the output of the future directly
    |
 LL - pub(crate) fn issue_10450_2() -> impl Future<Output = i32> {
+LL -
+LL -     async { 42 }
+LL - }
 LL + pub(crate) async fn issue_10450_2() -> i32 { 42 }
    |
 
@@ -164,6 +197,9 @@ LL | pub(self) fn issue_10450_3() -> impl Future<Output = i32> {
 help: make the function `async` and return the output of the future directly
    |
 LL - pub(self) fn issue_10450_3() -> impl Future<Output = i32> {
+LL -
+LL -     async { 42 }
+LL - }
 LL + pub(self) async fn issue_10450_3() -> i32 { 42 }
    |
 

--- a/src/tools/clippy/tests/ui/map_unwrap_or.stderr
+++ b/src/tools/clippy/tests/ui/map_unwrap_or.stderr
@@ -12,6 +12,9 @@ LL | |         .unwrap_or(0);
 help: use `map_or(<a>, <f>)` instead
    |
 LL -     let _ = opt.map(|x| x + 1)
+LL -
+LL -         // Should lint even though this call is on a separate line.
+LL -         .unwrap_or(0);
 LL +     let _ = opt.map_or(0, |x| x + 1);
    |
 
@@ -98,6 +101,7 @@ LL | |         .unwrap_or(None);
 help: use `and_then(<f>)` instead
    |
 LL -         .map(|x| Some(x + 1))
+LL -         .unwrap_or(None);
 LL +         .and_then(|x| Some(x + 1));
    |
 

--- a/src/tools/clippy/tests/ui/match_same_arms.stderr
+++ b/src/tools/clippy/tests/ui/match_same_arms.stderr
@@ -30,7 +30,6 @@ help: otherwise remove the non-wildcard arms
    |
 LL -         2 => 'b',
 LL -         3 => 'b',
-LL +         _ => 'b',
    |
 
 error: these match arms have identical bodies

--- a/src/tools/clippy/tests/ui/non_canonical_partial_ord_impl.stderr
+++ b/src/tools/clippy/tests/ui/non_canonical_partial_ord_impl.stderr
@@ -28,6 +28,8 @@ LL | | }
 help: change this to
    |
 LL -     fn partial_cmp(&self, _: &Self) -> Option<Ordering> {
+LL -         todo!();
+LL -     }
 LL +     fn partial_cmp(&self, other: &Self) -> Option<Ordering> { Some(self.cmp(other)) }
    |
 

--- a/src/tools/clippy/tests/ui/print_literal.stderr
+++ b/src/tools/clippy/tests/ui/print_literal.stderr
@@ -310,6 +310,7 @@ LL |         "name", 5, "x", 0.01
 help: try
    |
 LL -         "Hello {}: {2} is {3:.*} (which {3} with {1} places)",
+LL -         "name", 5, "x", 0.01
 LL +         "Hello name: x is {1:.*} (which {1} with {0} places)", 5, 0.01
    |
 

--- a/tests/ui/argument-suggestions/issue-112507.stderr
+++ b/tests/ui/argument-suggestions/issue-112507.stderr
@@ -20,6 +20,9 @@ help: remove the extra arguments
    |
 LL -         0,
 LL -         None,
+LL -         None,
+LL -         0,
+LL -     );
 LL +         None);
    |
 

--- a/tests/ui/lint/invalid-nan-comparison-suggestion.stderr
+++ b/tests/ui/lint/invalid-nan-comparison-suggestion.stderr
@@ -131,6 +131,9 @@ LL | |         };
 help: use `f32::is_nan()` or `f64::is_nan()` instead
    |
 LL -         b != {
+LL -
+LL -             &f32::NAN
+LL -         };
 LL +         !b.is_nan();
    |
 

--- a/tests/ui/lint/unused/closure-body-issue-136741.stderr
+++ b/tests/ui/lint/unused/closure-body-issue-136741.stderr
@@ -43,6 +43,7 @@ help: remove these parentheses
    |
 LL -     let _ = (0..).find(|n| (
 LL -         n % 2 == 0
+LL -     ));
 LL +     let _ = (0..).find(|n| n % 2 == 0);
    |
 

--- a/tests/ui/privacy/suggest-box-new.stderr
+++ b/tests/ui/privacy/suggest-box-new.stderr
@@ -67,6 +67,9 @@ LL +         wtf: Some(Box::new_in(_, _)),
 help: consider using the `Default` trait
    |
 LL -         wtf: Some(Box(U {
+LL -             wtf: None,
+LL -             x: (),
+LL -         })),
 LL +         wtf: Some(<Box as std::default::Default>::default()),
    |
 

--- a/tests/ui/suggestions/issue-109396.stderr
+++ b/tests/ui/suggestions/issue-109396.stderr
@@ -25,6 +25,11 @@ note: function defined here
 help: remove the extra arguments
    |
 LL -             file.as_raw_fd(),
+LL -
+LL -             0,
+LL -             0,
+LL -             0,
+LL -         );
 LL +             );
    |
 

--- a/tests/ui/suggestions/issue-109854.stderr
+++ b/tests/ui/suggestions/issue-109854.stderr
@@ -23,6 +23,10 @@ note: associated function defined here
 help: remove the extra arguments
    |
 LL -     generate_setter,
+LL -     r#"
+LL - pub(crate) struct Person<T: Clone> {}
+LL - "#,
+LL -      r#""#,
 LL +     /* usize */,
    |
 

--- a/tests/ui/suggestions/multi-suggestion.ascii.stderr
+++ b/tests/ui/suggestions/multi-suggestion.ascii.stderr
@@ -67,6 +67,9 @@ LL +         wtf: Some(Box::new_in(_, _)),
 help: consider using the `Default` trait
    |
 LL -         wtf: Some(Box(U {
+LL -             wtf: None,
+LL -             x: (),
+LL -         })),
 LL +         wtf: Some(<Box as std::default::Default>::default()),
    |
 

--- a/tests/ui/suggestions/multi-suggestion.unicode.stderr
+++ b/tests/ui/suggestions/multi-suggestion.unicode.stderr
@@ -67,6 +67,9 @@ LL +         wtf: Some(Box::new_in(_, _)),
 help: consider using the `Default` trait
    ╭╴
 LL -         wtf: Some(Box(U {
+LL -             wtf: None,
+LL -             x: (),
+LL -         })),
 LL +         wtf: Some(<Box as std::default::Default>::default()),
    ╰╴
 

--- a/tests/ui/suggestions/suggest-remove-refs-3.stderr
+++ b/tests/ui/suggestions/suggest-remove-refs-3.stderr
@@ -13,6 +13,7 @@ LL | |         .enumerate() {
 help: consider removing 5 leading `&`-references
    |
 LL -     for (i, _) in & & &
+LL -         & &v
 LL +     for (i, _) in v
    |
 


### PR DESCRIPTION
This PR updates `annotate-snippets` to `0.12.10`, which [includes a fix](https://github.com/rust-lang/annotate-snippets-rs/blob/756366223cbf72b161757aec18209f21b3d19049/CHANGELOG.md#fixed) that modifies some test output.
