### PR TITLE
Rename supertrait item shadowing lints

### DIFF
--- a/compiler/rustc_hir_analysis/src/check/wfcheck.rs
+++ b/compiler/rustc_hir_analysis/src/check/wfcheck.rs
@@ -13,7 +13,7 @@ use rustc_hir::lang_items::LangItem;
 use rustc_hir::{AmbigArg, ItemKind, find_attr};
 use rustc_infer::infer::outlives::env::OutlivesEnvironment;
 use rustc_infer::infer::{self, InferCtxt, SubregionOrigin, TyCtxtInferExt};
-use rustc_lint_defs::builtin::SUPERTRAIT_ITEM_SHADOWING_DEFINITION;
+use rustc_lint_defs::builtin::SHADOWING_SUPERTRAIT_ITEMS;
 use rustc_macros::LintDiagnostic;
 use rustc_middle::mir::interpret::ErrorHandled;
 use rustc_middle::traits::solve::NoSolution;
@@ -797,7 +797,7 @@ fn lint_item_shadowing_supertrait_item<'tcx>(tcx: TyCtxt<'tcx>, trait_item_def_i
         };
 
         tcx.emit_node_span_lint(
-            SUPERTRAIT_ITEM_SHADOWING_DEFINITION,
+            SHADOWING_SUPERTRAIT_ITEMS,
             tcx.local_def_id_to_hir_id(trait_item_def_id),
             tcx.def_span(trait_item_def_id),
             errors::SupertraitItemShadowing {

--- a/compiler/rustc_hir_typeck/src/method/confirm.rs
+++ b/compiler/rustc_hir_typeck/src/method/confirm.rs
@@ -12,7 +12,7 @@ use rustc_hir_analysis::hir_ty_lowering::{
 use rustc_infer::infer::{
     BoundRegionConversionTime, DefineOpaqueTypes, InferOk, RegionVariableOrigin,
 };
-use rustc_lint::builtin::SUPERTRAIT_ITEM_SHADOWING_USAGE;
+use rustc_lint::builtin::RESOLVING_TO_ITEMS_SHADOWING_SUPERTRAIT_ITEMS;
 use rustc_middle::traits::ObligationCauseCode;
 use rustc_middle::ty::adjustment::{
     Adjust, Adjustment, AllowTwoPhase, AutoBorrow, AutoBorrowMutability, PointerCoercion,
@@ -709,7 +709,7 @@ impl<'a, 'tcx> ConfirmContext<'a, 'tcx> {
         };
 
         self.tcx.emit_node_span_lint(
-            SUPERTRAIT_ITEM_SHADOWING_USAGE,
+            RESOLVING_TO_ITEMS_SHADOWING_SUPERTRAIT_ITEMS,
             segment.hir_id,
             segment.ident.span,
             SupertraitItemShadowing { shadower, shadowee, item: segment.ident.name, subtrait },

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -88,6 +88,7 @@ declare_lint_pass! {
         RENAMED_AND_REMOVED_LINTS,
         REPR_C_ENUMS_LARGER_THAN_INT,
         REPR_TRANSPARENT_NON_ZST_FIELDS,
+        RESOLVING_TO_ITEMS_SHADOWING_SUPERTRAIT_ITEMS,
         RTSAN_NONBLOCKING_ASYNC,
         RUST_2021_INCOMPATIBLE_CLOSURE_CAPTURES,
         RUST_2021_INCOMPATIBLE_OR_PATTERNS,
@@ -98,11 +99,10 @@ declare_lint_pass! {
         RUST_2024_PRELUDE_COLLISIONS,
         SELF_CONSTRUCTOR_FROM_OUTER_ITEM,
         SEMICOLON_IN_EXPRESSIONS_FROM_MACROS,
+        SHADOWING_SUPERTRAIT_ITEMS,
         SINGLE_USE_LIFETIMES,
         SOFT_UNSTABLE,
         STABLE_FEATURES,
-        SUPERTRAIT_ITEM_SHADOWING_DEFINITION,
-        SUPERTRAIT_ITEM_SHADOWING_USAGE,
         TAIL_EXPR_DROP_ORDER,
         TEST_UNSTABLE_LINT,
         TEXT_DIRECTION_CODEPOINT_IN_COMMENT,
@@ -4922,15 +4922,16 @@ declare_lint! {
 }
 
 declare_lint! {
-    /// The `supertrait_item_shadowing_usage` lint detects when the
+    /// The `resolving_to_items_shadowing_supertrait_items` lint detects when the
     /// usage of an item that is provided by both a subtrait and supertrait
     /// is shadowed, preferring the subtrait.
     ///
     /// ### Example
     ///
-    /// ```rust,compile_fail
+    #[cfg_attr(bootstrap, doc = "```ignore")]
+    #[cfg_attr(not(bootstrap), doc = "```rust,compile_fail")]
     /// #![feature(supertrait_item_shadowing)]
-    /// #![deny(supertrait_item_shadowing_usage)]
+    /// #![deny(resolving_to_items_shadowing_supertrait_items)]
     ///
     /// trait Upstream {
     ///     fn hello(&self) {}
@@ -4944,7 +4945,8 @@ declare_lint! {
     ///
     /// struct MyType;
     /// MyType.hello();
-    /// ```
+    #[cfg_attr(bootstrap, doc = "```")]
+    #[cfg_attr(not(bootstrap), doc = "```")]
     ///
     /// {{produces}}
     ///
@@ -4955,7 +4957,7 @@ declare_lint! {
     /// selection. In order to mitigate side-effects of this happening
     /// silently, this lint detects these cases when users want to deny them
     /// or fix the call sites.
-    pub SUPERTRAIT_ITEM_SHADOWING_USAGE,
+    pub RESOLVING_TO_ITEMS_SHADOWING_SUPERTRAIT_ITEMS,
     // FIXME(supertrait_item_shadowing): It is not decided if this should
     // warn by default at the call site.
     Allow,
@@ -4964,15 +4966,16 @@ declare_lint! {
 }
 
 declare_lint! {
-    /// The `supertrait_item_shadowing_definition` lint detects when the
+    /// The `shadowing_supertrait_items` lint detects when the
     /// definition of an item that is provided by both a subtrait and
     /// supertrait is shadowed, preferring the subtrait.
     ///
     /// ### Example
     ///
-    /// ```rust,compile_fail
+    #[cfg_attr(bootstrap, doc = "```ignore")]
+    #[cfg_attr(not(bootstrap), doc = "```rust,compile_fail")]
     /// #![feature(supertrait_item_shadowing)]
-    /// #![deny(supertrait_item_shadowing_definition)]
+    /// #![deny(shadowing_supertrait_items)]
     ///
     /// trait Upstream {
     ///     fn hello(&self) {}
@@ -4983,7 +4986,8 @@ declare_lint! {
     ///     fn hello(&self) {}
     /// }
     /// impl<T> Downstream for T {}
-    /// ```
+    #[cfg_attr(bootstrap, doc = "```")]
+    #[cfg_attr(not(bootstrap), doc = "```")]
     ///
     /// {{produces}}
     ///
@@ -4994,7 +4998,7 @@ declare_lint! {
     /// selection. In order to mitigate side-effects of this happening
     /// silently, this lint detects these cases when users want to deny them
     /// or fix their trait definitions.
-    pub SUPERTRAIT_ITEM_SHADOWING_DEFINITION,
+    pub SHADOWING_SUPERTRAIT_ITEMS,
     // FIXME(supertrait_item_shadowing): It is not decided if this should
     // warn by default at the usage site.
     Allow,

--- a/tests/ui/methods/supertrait-shadowing/common-ancestor-2.rs
+++ b/tests/ui/methods/supertrait-shadowing/common-ancestor-2.rs
@@ -2,8 +2,8 @@
 //@ check-run-results
 
 #![feature(supertrait_item_shadowing)]
-#![warn(supertrait_item_shadowing_usage)]
-#![warn(supertrait_item_shadowing_definition)]
+#![warn(resolving_to_items_shadowing_supertrait_items)]
+#![warn(shadowing_supertrait_items)]
 #![allow(dead_code)]
 
 trait A {

--- a/tests/ui/methods/supertrait-shadowing/common-ancestor-2.stderr
+++ b/tests/ui/methods/supertrait-shadowing/common-ancestor-2.stderr
@@ -15,8 +15,8 @@ LL |     fn hello(&self) {
 note: the lint level is defined here
   --> $DIR/common-ancestor-2.rs:6:9
    |
-LL | #![warn(supertrait_item_shadowing_definition)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | #![warn(shadowing_supertrait_items)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: trait item `hello` from `C` shadows identically named item from supertrait
   --> $DIR/common-ancestor-2.rs:32:8
@@ -40,8 +40,8 @@ LL |     fn hello(&self) {
 note: the lint level is defined here
   --> $DIR/common-ancestor-2.rs:5:9
    |
-LL | #![warn(supertrait_item_shadowing_usage)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | #![warn(resolving_to_items_shadowing_supertrait_items)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: 2 warnings emitted
 

--- a/tests/ui/methods/supertrait-shadowing/common-ancestor-3.rs
+++ b/tests/ui/methods/supertrait-shadowing/common-ancestor-3.rs
@@ -2,8 +2,8 @@
 //@ check-run-results
 
 #![feature(supertrait_item_shadowing)]
-#![warn(supertrait_item_shadowing_usage)]
-#![warn(supertrait_item_shadowing_definition)]
+#![warn(resolving_to_items_shadowing_supertrait_items)]
+#![warn(shadowing_supertrait_items)]
 #![allow(dead_code)]
 
 trait A {

--- a/tests/ui/methods/supertrait-shadowing/common-ancestor-3.stderr
+++ b/tests/ui/methods/supertrait-shadowing/common-ancestor-3.stderr
@@ -15,8 +15,8 @@ LL |     fn hello(&self) {
 note: the lint level is defined here
   --> $DIR/common-ancestor-3.rs:6:9
    |
-LL | #![warn(supertrait_item_shadowing_definition)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | #![warn(shadowing_supertrait_items)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: trait item `hello` from `D` shadows identically named item from supertrait
   --> $DIR/common-ancestor-3.rs:34:5
@@ -61,8 +61,8 @@ LL |     fn hello(&self) {
 note: the lint level is defined here
   --> $DIR/common-ancestor-3.rs:5:9
    |
-LL | #![warn(supertrait_item_shadowing_usage)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | #![warn(resolving_to_items_shadowing_supertrait_items)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: 3 warnings emitted
 

--- a/tests/ui/methods/supertrait-shadowing/common-ancestor.rs
+++ b/tests/ui/methods/supertrait-shadowing/common-ancestor.rs
@@ -2,8 +2,8 @@
 //@ check-run-results
 
 #![feature(supertrait_item_shadowing)]
-#![warn(supertrait_item_shadowing_usage)]
-#![warn(supertrait_item_shadowing_definition)]
+#![warn(resolving_to_items_shadowing_supertrait_items)]
+#![warn(shadowing_supertrait_items)]
 #![allow(dead_code)]
 
 trait A {

--- a/tests/ui/methods/supertrait-shadowing/common-ancestor.stderr
+++ b/tests/ui/methods/supertrait-shadowing/common-ancestor.stderr
@@ -12,8 +12,8 @@ LL |     fn hello(&self) {
 note: the lint level is defined here
   --> $DIR/common-ancestor.rs:6:9
    |
-LL | #![warn(supertrait_item_shadowing_definition)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | #![warn(shadowing_supertrait_items)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: trait item `hello` from `B` shadows identically named item from supertrait
   --> $DIR/common-ancestor.rs:25:8
@@ -34,8 +34,8 @@ LL |     fn hello(&self) {
 note: the lint level is defined here
   --> $DIR/common-ancestor.rs:5:9
    |
-LL | #![warn(supertrait_item_shadowing_usage)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | #![warn(resolving_to_items_shadowing_supertrait_items)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: 2 warnings emitted
 

--- a/tests/ui/methods/supertrait-shadowing/definition-site.rs
+++ b/tests/ui/methods/supertrait-shadowing/definition-site.rs
@@ -1,5 +1,5 @@
 #![feature(supertrait_item_shadowing)]
-#![deny(supertrait_item_shadowing_definition)]
+#![deny(shadowing_supertrait_items)]
 
 trait SuperSuper {
     fn method();

--- a/tests/ui/methods/supertrait-shadowing/definition-site.stderr
+++ b/tests/ui/methods/supertrait-shadowing/definition-site.stderr
@@ -12,8 +12,8 @@ LL |     fn method();
 note: the lint level is defined here
   --> $DIR/definition-site.rs:2:9
    |
-LL | #![deny(supertrait_item_shadowing_definition)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | #![deny(shadowing_supertrait_items)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: trait item `method` from `Sub` shadows identically named item from supertrait
   --> $DIR/definition-site.rs:14:5

--- a/tests/ui/methods/supertrait-shadowing/false-subtrait-after-inference.rs
+++ b/tests/ui/methods/supertrait-shadowing/false-subtrait-after-inference.rs
@@ -1,6 +1,6 @@
 #![feature(supertrait_item_shadowing)]
-#![warn(supertrait_item_shadowing_usage)]
-#![warn(supertrait_item_shadowing_definition)]
+#![warn(resolving_to_items_shadowing_supertrait_items)]
+#![warn(shadowing_supertrait_items)]
 
 struct W<T>(T);
 

--- a/tests/ui/methods/supertrait-shadowing/false-subtrait-after-inference.stderr
+++ b/tests/ui/methods/supertrait-shadowing/false-subtrait-after-inference.stderr
@@ -12,8 +12,8 @@ LL |     fn hello(&self) {}
 note: the lint level is defined here
   --> $DIR/false-subtrait-after-inference.rs:3:9
    |
-LL | #![warn(supertrait_item_shadowing_definition)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | #![warn(shadowing_supertrait_items)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: trait item `hello` from `Downstream` shadows identically named item from supertrait
   --> $DIR/false-subtrait-after-inference.rs:22:7
@@ -34,8 +34,8 @@ LL |     fn hello(&self) {}
 note: the lint level is defined here
   --> $DIR/false-subtrait-after-inference.rs:2:9
    |
-LL | #![warn(supertrait_item_shadowing_usage)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | #![warn(resolving_to_items_shadowing_supertrait_items)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `i32: Foo` is not satisfied
   --> $DIR/false-subtrait-after-inference.rs:22:7


### PR DESCRIPTION
This follows the lang team decision [here](https://github.com/rust-lang/rust/pull/148605#issuecomment-3525414326) and renames:
- `supertrait_item_shadowing_definition` to `shadowing_supertrait_items`
- `supertrait_item_shadowing_usage` to `resolving_to_items_shadowing_supertrait_items`

The lint levels are left unchanged as allow-by-default until stabilization.