### PR TITLE
Move `struct Placeholder<T>`

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/region_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/region_errors.rs
@@ -109,15 +109,15 @@ pub(crate) enum RegionErrorKind<'tcx> {
         /// The placeholder free region.
         longer_fr: RegionVid,
         /// The region element that erroneously must be outlived by `longer_fr`.
-        error_element: RegionElement,
+        error_element: RegionElement<'tcx>,
         /// The placeholder region.
-        placeholder: ty::PlaceholderRegion,
+        placeholder: ty::PlaceholderRegion<'tcx>,
     },
 
     /// Any other lifetime error.
     RegionError {
         /// The origin of the region.
-        fr_origin: NllRegionVariableOrigin,
+        fr_origin: NllRegionVariableOrigin<'tcx>,
         /// The region that should outlive `shorter_fr`.
         longer_fr: RegionVid,
         /// The region that should be shorter, but we can't prove it.
@@ -427,7 +427,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
     pub(crate) fn report_region_error(
         &mut self,
         fr: RegionVid,
-        fr_origin: NllRegionVariableOrigin,
+        fr_origin: NllRegionVariableOrigin<'tcx>,
         outlived_fr: RegionVid,
         outlives_suggestion: &mut OutlivesSuggestionBuilder,
     ) {

--- a/compiler/rustc_borrowck/src/handle_placeholders.rs
+++ b/compiler/rustc_borrowck/src/handle_placeholders.rs
@@ -32,7 +32,7 @@ pub(crate) struct LoweredConstraints<'tcx> {
     pub(crate) type_tests: Vec<TypeTest<'tcx>>,
     pub(crate) liveness_constraints: LivenessValues,
     pub(crate) universe_causes: FxIndexMap<UniverseIndex, UniverseInfo<'tcx>>,
-    pub(crate) placeholder_indices: PlaceholderIndices,
+    pub(crate) placeholder_indices: PlaceholderIndices<'tcx>,
 }
 
 impl<'d, 'tcx, A: scc::Annotation> SccAnnotations<'d, 'tcx, A> {

--- a/compiler/rustc_borrowck/src/lib.rs
+++ b/compiler/rustc_borrowck/src/lib.rs
@@ -661,7 +661,7 @@ impl<'tcx> BorrowckInferCtxt<'tcx> {
 
     pub(crate) fn next_region_var<F>(
         &self,
-        origin: RegionVariableOrigin,
+        origin: RegionVariableOrigin<'tcx>,
         get_ctxt_fn: F,
     ) -> ty::Region<'tcx>
     where
@@ -683,7 +683,7 @@ impl<'tcx> BorrowckInferCtxt<'tcx> {
     #[instrument(skip(self, get_ctxt_fn), level = "debug")]
     pub(crate) fn next_nll_region_var<F>(
         &self,
-        origin: NllRegionVariableOrigin,
+        origin: NllRegionVariableOrigin<'tcx>,
         get_ctxt_fn: F,
     ) -> ty::Region<'tcx>
     where

--- a/compiler/rustc_borrowck/src/region_infer/mod.rs
+++ b/compiler/rustc_borrowck/src/region_infer/mod.rs
@@ -110,7 +110,7 @@ pub struct RegionInferenceContext<'tcx> {
     /// The final inferred values of the region variables; we compute
     /// one value per SCC. To get the value for any given *region*,
     /// you first find which scc it is a part of.
-    scc_values: RegionValues<ConstraintSccIndex>,
+    scc_values: RegionValues<'tcx, ConstraintSccIndex>,
 
     /// Type constraints that we check after solving.
     type_tests: Vec<TypeTest<'tcx>>,
@@ -125,7 +125,7 @@ pub(crate) struct RegionDefinition<'tcx> {
     /// What kind of variable is this -- a free region? existential
     /// variable? etc. (See the `NllRegionVariableOrigin` for more
     /// info.)
-    pub(crate) origin: NllRegionVariableOrigin,
+    pub(crate) origin: NllRegionVariableOrigin<'tcx>,
 
     /// Which universe is this region variable defined in? This is
     /// most often `ty::UniverseIndex::ROOT`, but when we encounter
@@ -453,7 +453,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
     /// Returns `true` if the region `r` contains the point `p`.
     ///
     /// Panics if called before `solve()` executes,
-    pub(crate) fn region_contains(&self, r: RegionVid, p: impl ToElementIndex) -> bool {
+    pub(crate) fn region_contains(&self, r: RegionVid, p: impl ToElementIndex<'tcx>) -> bool {
         let scc = self.constraint_sccs.scc(r);
         self.scc_values.contains(scc, p)
     }
@@ -481,7 +481,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
     pub(crate) fn placeholders_contained_in(
         &self,
         r: RegionVid,
-    ) -> impl Iterator<Item = ty::PlaceholderRegion> {
+    ) -> impl Iterator<Item = ty::PlaceholderRegion<'tcx>> {
         let scc = self.constraint_sccs.scc(r);
         self.scc_values.placeholders_contained_in(scc)
     }
@@ -1311,7 +1311,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
     fn check_bound_universal_region(
         &self,
         longer_fr: RegionVid,
-        placeholder: ty::PlaceholderRegion,
+        placeholder: ty::PlaceholderRegion<'tcx>,
         errors_buffer: &mut RegionErrors<'tcx>,
     ) {
         debug!("check_bound_universal_region(fr={:?}, placeholder={:?})", longer_fr, placeholder,);
@@ -1523,7 +1523,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
     pub(crate) fn region_from_element(
         &self,
         longer_fr: RegionVid,
-        element: &RegionElement,
+        element: &RegionElement<'tcx>,
     ) -> RegionVid {
         match *element {
             RegionElement::Location(l) => self.find_sub_region_live_at(longer_fr, l),
@@ -1564,7 +1564,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
     pub(crate) fn best_blame_constraint(
         &self,
         from_region: RegionVid,
-        from_region_origin: NllRegionVariableOrigin,
+        from_region_origin: NllRegionVariableOrigin<'tcx>,
         to_region: RegionVid,
     ) -> (BlameConstraint<'tcx>, Vec<OutlivesConstraint<'tcx>>) {
         assert!(from_region != to_region, "Trying to blame a region for itself!");

--- a/compiler/rustc_borrowck/src/region_infer/opaque_types/region_ctxt.rs
+++ b/compiler/rustc_borrowck/src/region_infer/opaque_types/region_ctxt.rs
@@ -27,7 +27,7 @@ pub(super) struct RegionCtxt<'a, 'tcx> {
     pub(super) constraint_sccs: ConstraintSccs,
     pub(super) scc_annotations: IndexVec<ConstraintSccIndex, RegionTracker>,
     pub(super) rev_scc_graph: ReverseSccGraph,
-    pub(super) scc_values: RegionValues<ConstraintSccIndex>,
+    pub(super) scc_values: RegionValues<'tcx, ConstraintSccIndex>,
 }
 
 impl<'a, 'tcx> RegionCtxt<'a, 'tcx> {

--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -258,7 +258,7 @@ pub(crate) struct MirTypeckRegionConstraints<'tcx> {
     ///
     /// To keep everything in sync, do not insert this set
     /// directly. Instead, use the `placeholder_region` helper.
-    pub(crate) placeholder_indices: PlaceholderIndices,
+    pub(crate) placeholder_indices: PlaceholderIndices<'tcx>,
 
     /// Each time we add a placeholder to `placeholder_indices`, we
     /// also create a corresponding "representative" region vid for
@@ -289,7 +289,7 @@ impl<'tcx> MirTypeckRegionConstraints<'tcx> {
     pub(crate) fn placeholder_region(
         &mut self,
         infcx: &InferCtxt<'tcx>,
-        placeholder: ty::PlaceholderRegion,
+        placeholder: ty::PlaceholderRegion<'tcx>,
     ) -> ty::Region<'tcx> {
         let placeholder_index = self.placeholder_indices.insert(placeholder);
         match self.placeholder_index_to_region.get(placeholder_index) {

--- a/compiler/rustc_borrowck/src/type_check/relate_tys.rs
+++ b/compiler/rustc_borrowck/src/type_check/relate_tys.rs
@@ -184,7 +184,7 @@ impl<'a, 'b, 'tcx> NllTypeRelating<'a, 'b, 'tcx> {
                         universe
                     });
 
-                    let placeholder = ty::PlaceholderRegion { universe, bound: br };
+                    let placeholder = ty::PlaceholderRegion::new(universe, br);
                     debug!(?placeholder);
                     let placeholder_reg = self.next_placeholder_region(placeholder);
                     debug!(?placeholder_reg);
@@ -257,7 +257,10 @@ impl<'a, 'b, 'tcx> NllTypeRelating<'a, 'b, 'tcx> {
     }
 
     #[instrument(skip(self), level = "debug")]
-    fn next_placeholder_region(&mut self, placeholder: ty::PlaceholderRegion) -> ty::Region<'tcx> {
+    fn next_placeholder_region(
+        &mut self,
+        placeholder: ty::PlaceholderRegion<'tcx>,
+    ) -> ty::Region<'tcx> {
         let reg =
             self.type_checker.constraints.placeholder_region(self.type_checker.infcx, placeholder);
 

--- a/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
+++ b/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
@@ -590,10 +590,10 @@ pub(super) fn collect_return_position_impl_trait_in_trait_tys<'tcx>(
                 ty,
                 Ty::new_placeholder(
                     tcx,
-                    ty::Placeholder {
+                    ty::Placeholder::new(
                         universe,
-                        bound: ty::BoundTy { var: idx, kind: ty::BoundTyKind::Anon },
-                    },
+                        ty::BoundTy { var: idx, kind: ty::BoundTyKind::Anon },
+                    ),
                 ),
             )
         })

--- a/compiler/rustc_infer/src/infer/canonical/canonicalizer.rs
+++ b/compiler/rustc_infer/src/infer/canonical/canonicalizer.rs
@@ -684,22 +684,22 @@ impl<'cx, 'tcx> Canonicalizer<'cx, 'tcx> {
                 CanonicalVarKind::Region(u) => CanonicalVarKind::Region(reverse_universe_map[&u]),
                 CanonicalVarKind::Const(u) => CanonicalVarKind::Const(reverse_universe_map[&u]),
                 CanonicalVarKind::PlaceholderTy(placeholder) => {
-                    CanonicalVarKind::PlaceholderTy(ty::Placeholder {
-                        universe: reverse_universe_map[&placeholder.universe],
-                        ..placeholder
-                    })
+                    CanonicalVarKind::PlaceholderTy(ty::Placeholder::new(
+                        reverse_universe_map[&placeholder.universe],
+                        placeholder.bound,
+                    ))
                 }
                 CanonicalVarKind::PlaceholderRegion(placeholder) => {
-                    CanonicalVarKind::PlaceholderRegion(ty::Placeholder {
-                        universe: reverse_universe_map[&placeholder.universe],
-                        ..placeholder
-                    })
+                    CanonicalVarKind::PlaceholderRegion(ty::Placeholder::new(
+                        reverse_universe_map[&placeholder.universe],
+                        placeholder.bound,
+                    ))
                 }
                 CanonicalVarKind::PlaceholderConst(placeholder) => {
-                    CanonicalVarKind::PlaceholderConst(ty::Placeholder {
-                        universe: reverse_universe_map[&placeholder.universe],
-                        ..placeholder
-                    })
+                    CanonicalVarKind::PlaceholderConst(ty::Placeholder::new(
+                        reverse_universe_map[&placeholder.universe],
+                        placeholder.bound,
+                    ))
                 }
             })
             .collect()

--- a/compiler/rustc_infer/src/infer/canonical/mod.rs
+++ b/compiler/rustc_infer/src/infer/canonical/mod.rs
@@ -109,9 +109,9 @@ impl<'tcx> InferCtxt<'tcx> {
 
             CanonicalVarKind::Float => self.next_float_var().into(),
 
-            CanonicalVarKind::PlaceholderTy(ty::PlaceholderType { universe, bound }) => {
+            CanonicalVarKind::PlaceholderTy(ty::PlaceholderType { universe, bound, .. }) => {
                 let universe_mapped = universe_map(universe);
-                let placeholder_mapped = ty::PlaceholderType { universe: universe_mapped, bound };
+                let placeholder_mapped = ty::PlaceholderType::new(universe_mapped, bound);
                 Ty::new_placeholder(self.tcx, placeholder_mapped).into()
             }
 
@@ -119,18 +119,22 @@ impl<'tcx> InferCtxt<'tcx> {
                 .next_region_var_in_universe(RegionVariableOrigin::Misc(span), universe_map(ui))
                 .into(),
 
-            CanonicalVarKind::PlaceholderRegion(ty::PlaceholderRegion { universe, bound }) => {
+            CanonicalVarKind::PlaceholderRegion(ty::PlaceholderRegion {
+                universe, bound, ..
+            }) => {
                 let universe_mapped = universe_map(universe);
-                let placeholder_mapped = ty::PlaceholderRegion { universe: universe_mapped, bound };
+                let placeholder_mapped = ty::PlaceholderRegion::new(universe_mapped, bound);
                 ty::Region::new_placeholder(self.tcx, placeholder_mapped).into()
             }
 
             CanonicalVarKind::Const(ui) => {
                 self.next_const_var_in_universe(span, universe_map(ui)).into()
             }
-            CanonicalVarKind::PlaceholderConst(ty::PlaceholderConst { universe, bound }) => {
+            CanonicalVarKind::PlaceholderConst(ty::PlaceholderConst {
+                universe, bound, ..
+            }) => {
                 let universe_mapped = universe_map(universe);
-                let placeholder_mapped = ty::PlaceholderConst { universe: universe_mapped, bound };
+                let placeholder_mapped = ty::PlaceholderConst::new(universe_mapped, bound);
                 ty::Const::new_placeholder(self.tcx, placeholder_mapped).into()
             }
         }

--- a/compiler/rustc_infer/src/infer/lexical_region_resolve/mod.rs
+++ b/compiler/rustc_infer/src/infer/lexical_region_resolve/mod.rs
@@ -31,7 +31,7 @@ use crate::infer::{RegionRelations, RegionVariableOrigin, SubregionOrigin};
 #[instrument(level = "debug", skip(region_rels, var_infos, data))]
 pub(crate) fn resolve<'tcx>(
     region_rels: &RegionRelations<'_, 'tcx>,
-    var_infos: VarInfos,
+    var_infos: VarInfos<'tcx>,
     data: RegionConstraintData<'tcx>,
 ) -> (LexicalRegionResolutions<'tcx>, Vec<RegionResolutionError<'tcx>>) {
     let mut errors = vec![];
@@ -80,7 +80,7 @@ pub enum RegionResolutionError<'tcx> {
     /// `sub_r <= sup_r` does not hold.
     SubSupConflict(
         RegionVid,
-        RegionVariableOrigin,
+        RegionVariableOrigin<'tcx>,
         SubregionOrigin<'tcx>,
         Region<'tcx>,
         SubregionOrigin<'tcx>,
@@ -92,7 +92,7 @@ pub enum RegionResolutionError<'tcx> {
     /// cannot name the placeholder `'b`.
     UpperBoundUniverseConflict(
         RegionVid,
-        RegionVariableOrigin,
+        RegionVariableOrigin<'tcx>,
         ty::UniverseIndex,     // the universe index of the region variable
         SubregionOrigin<'tcx>, // cause of the constraint
         Region<'tcx>,          // the placeholder `'b`
@@ -122,7 +122,7 @@ type RegionGraph<'tcx> = LinkedGraph<(), Constraint<'tcx>>;
 
 struct LexicalResolver<'cx, 'tcx> {
     region_rels: &'cx RegionRelations<'cx, 'tcx>,
-    var_infos: VarInfos,
+    var_infos: VarInfos<'tcx>,
     data: RegionConstraintData<'tcx>,
 }
 

--- a/compiler/rustc_infer/src/infer/outlives/obligations.rs
+++ b/compiler/rustc_infer/src/infer/outlives/obligations.rs
@@ -394,7 +394,7 @@ where
         &mut self,
         origin: infer::SubregionOrigin<'tcx>,
         region: ty::Region<'tcx>,
-        placeholder_ty: ty::PlaceholderType,
+        placeholder_ty: ty::PlaceholderType<'tcx>,
     ) {
         let verify_bound = self
             .verify_bound

--- a/compiler/rustc_infer/src/infer/region_constraints/leak_check.rs
+++ b/compiler/rustc_infer/src/infer/region_constraints/leak_check.rs
@@ -105,7 +105,7 @@ struct LeakCheck<'a, 'tcx> {
     // is repurposed to store some placeholder `P` such that the weaker
     // condition `S: P` must hold. (This is true if `S: S1` transitively and `S1
     // = P`.)
-    scc_placeholders: IndexVec<LeakCheckScc, Option<ty::PlaceholderRegion>>,
+    scc_placeholders: IndexVec<LeakCheckScc, Option<ty::PlaceholderRegion<'tcx>>>,
 
     // For each SCC S, track the minimum universe that flows into it. Note that
     // this is both the minimum of the universes for every region that is a
@@ -258,15 +258,15 @@ impl<'a, 'tcx> LeakCheck<'a, 'tcx> {
 
     fn placeholder_error(
         &self,
-        placeholder1: ty::PlaceholderRegion,
-        placeholder2: ty::PlaceholderRegion,
+        placeholder1: ty::PlaceholderRegion<'tcx>,
+        placeholder2: ty::PlaceholderRegion<'tcx>,
     ) -> TypeError<'tcx> {
         self.error(placeholder1, ty::Region::new_placeholder(self.tcx, placeholder2))
     }
 
     fn error(
         &self,
-        placeholder: ty::PlaceholderRegion,
+        placeholder: ty::PlaceholderRegion<'tcx>,
         other_region: ty::Region<'tcx>,
     ) -> TypeError<'tcx> {
         debug!("error: placeholder={:?}, other_region={:?}", placeholder, other_region);

--- a/compiler/rustc_infer/src/infer/relate/higher_ranked.rs
+++ b/compiler/rustc_infer/src/infer/relate/higher_ranked.rs
@@ -34,21 +34,15 @@ impl<'tcx> InferCtxt<'tcx> {
 
         let delegate = FnMutDelegate {
             regions: &mut |br: ty::BoundRegion| {
-                ty::Region::new_placeholder(
-                    self.tcx,
-                    ty::PlaceholderRegion { universe: next_universe, bound: br },
-                )
+                ty::Region::new_placeholder(self.tcx, ty::PlaceholderRegion::new(next_universe, br))
             },
             types: &mut |bound_ty: ty::BoundTy| {
-                Ty::new_placeholder(
-                    self.tcx,
-                    ty::PlaceholderType { universe: next_universe, bound: bound_ty },
-                )
+                Ty::new_placeholder(self.tcx, ty::PlaceholderType::new(next_universe, bound_ty))
             },
             consts: &mut |bound_const: ty::BoundConst| {
                 ty::Const::new_placeholder(
                     self.tcx,
-                    ty::PlaceholderConst { universe: next_universe, bound: bound_const },
+                    ty::PlaceholderConst::new(next_universe, bound_const),
                 )
             },
         };

--- a/compiler/rustc_infer/src/infer/snapshot/fudge.rs
+++ b/compiler/rustc_infer/src/infer/snapshot/fudge.rs
@@ -113,7 +113,7 @@ impl<'tcx> InferCtxt<'tcx> {
 
     fn fudge_inference<T: TypeFoldable<TyCtxt<'tcx>>>(
         &self,
-        snapshot_vars: SnapshotVarData,
+        snapshot_vars: SnapshotVarData<'tcx>,
         value: T,
     ) -> T {
         // Micro-optimization: if no variables have been created, then
@@ -126,16 +126,16 @@ impl<'tcx> InferCtxt<'tcx> {
     }
 }
 
-struct SnapshotVarData {
-    region_vars: (Range<RegionVid>, Vec<RegionVariableOrigin>),
+struct SnapshotVarData<'tcx> {
+    region_vars: (Range<RegionVid>, Vec<RegionVariableOrigin<'tcx>>),
     type_vars: (Range<TyVid>, Vec<TypeVariableOrigin>),
     int_vars: Range<IntVid>,
     float_vars: Range<FloatVid>,
     const_vars: (Range<ConstVid>, Vec<ConstVariableOrigin>),
 }
 
-impl SnapshotVarData {
-    fn new(infcx: &InferCtxt<'_>, vars_pre_snapshot: VariableLengths) -> SnapshotVarData {
+impl<'tcx> SnapshotVarData<'tcx> {
+    fn new(infcx: &InferCtxt<'tcx>, vars_pre_snapshot: VariableLengths) -> SnapshotVarData<'tcx> {
         let mut inner = infcx.inner.borrow_mut();
         let region_vars = inner
             .unwrap_region_constraints()
@@ -165,7 +165,7 @@ impl SnapshotVarData {
 
 struct InferenceFudger<'a, 'tcx> {
     infcx: &'a InferCtxt<'tcx>,
-    snapshot_vars: SnapshotVarData,
+    snapshot_vars: SnapshotVarData<'tcx>,
 }
 
 impl<'a, 'tcx> TypeFolder<TyCtxt<'tcx>> for InferenceFudger<'a, 'tcx> {

--- a/compiler/rustc_middle/src/ty/consts.rs
+++ b/compiler/rustc_middle/src/ty/consts.rs
@@ -107,7 +107,10 @@ impl<'tcx> Const<'tcx> {
     }
 
     #[inline]
-    pub fn new_placeholder(tcx: TyCtxt<'tcx>, placeholder: ty::PlaceholderConst) -> Const<'tcx> {
+    pub fn new_placeholder(
+        tcx: TyCtxt<'tcx>,
+        placeholder: ty::PlaceholderConst<'tcx>,
+    ) -> Const<'tcx> {
         Const::new(tcx, ty::ConstKind::Placeholder(placeholder))
     }
 
@@ -192,7 +195,7 @@ impl<'tcx> rustc_type_ir::inherent::Const<TyCtxt<'tcx>> for Const<'tcx> {
         Const::new_canonical_bound(tcx, var)
     }
 
-    fn new_placeholder(tcx: TyCtxt<'tcx>, placeholder: ty::PlaceholderConst) -> Self {
+    fn new_placeholder(tcx: TyCtxt<'tcx>, placeholder: ty::PlaceholderConst<'tcx>) -> Self {
         Const::new_placeholder(tcx, placeholder)
     }
 

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -148,7 +148,7 @@ impl<'tcx> Interner for TyCtxt<'tcx> {
     type BoundTy = ty::BoundTy;
     type Symbol = Symbol;
 
-    type PlaceholderTy = ty::PlaceholderType;
+    type PlaceholderTy = ty::PlaceholderType<'tcx>;
     type ErrorGuaranteed = ErrorGuaranteed;
     type BoundExistentialPredicates = &'tcx List<PolyExistentialPredicate<'tcx>>;
 
@@ -158,7 +158,7 @@ impl<'tcx> Interner for TyCtxt<'tcx> {
     type Safety = hir::Safety;
     type Abi = ExternAbi;
     type Const = ty::Const<'tcx>;
-    type PlaceholderConst = ty::PlaceholderConst;
+    type PlaceholderConst = ty::PlaceholderConst<'tcx>;
 
     type ParamConst = ty::ParamConst;
     type BoundConst = ty::BoundConst;
@@ -170,7 +170,7 @@ impl<'tcx> Interner for TyCtxt<'tcx> {
     type EarlyParamRegion = ty::EarlyParamRegion;
     type LateParamRegion = ty::LateParamRegion;
     type BoundRegion = ty::BoundRegion;
-    type PlaceholderRegion = ty::PlaceholderRegion;
+    type PlaceholderRegion = ty::PlaceholderRegion<'tcx>;
 
     type RegionAssumptions = &'tcx ty::List<ty::ArgOutlivesPredicate<'tcx>>;
 

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -886,20 +886,9 @@ impl<'tcx> DefinitionSiteHiddenType<'tcx> {
     }
 }
 
-/// The "placeholder index" fully defines a placeholder region, type, or const. Placeholders are
-/// identified by both a universe, as well as a name residing within that universe. Distinct bound
-/// regions/types/consts within the same universe simply have an unknown relationship to one
-/// another.
-#[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-#[derive(HashStable, TyEncodable, TyDecodable)]
-pub struct Placeholder<T> {
-    pub universe: UniverseIndex,
-    pub bound: T,
-}
+pub type PlaceholderRegion<'tcx> = ty::Placeholder<TyCtxt<'tcx>, BoundRegion>;
 
-pub type PlaceholderRegion = Placeholder<BoundRegion>;
-
-impl<'tcx> rustc_type_ir::inherent::PlaceholderLike<TyCtxt<'tcx>> for PlaceholderRegion {
+impl<'tcx> rustc_type_ir::inherent::PlaceholderLike<TyCtxt<'tcx>> for PlaceholderRegion<'tcx> {
     type Bound = BoundRegion;
 
     fn universe(self) -> UniverseIndex {
@@ -911,21 +900,21 @@ impl<'tcx> rustc_type_ir::inherent::PlaceholderLike<TyCtxt<'tcx>> for Placeholde
     }
 
     fn with_updated_universe(self, ui: UniverseIndex) -> Self {
-        Placeholder { universe: ui, ..self }
+        ty::Placeholder::new(ui, self.bound)
     }
 
     fn new(ui: UniverseIndex, bound: BoundRegion) -> Self {
-        Placeholder { universe: ui, bound }
+        ty::Placeholder::new(ui, bound)
     }
 
     fn new_anon(ui: UniverseIndex, var: BoundVar) -> Self {
-        Placeholder { universe: ui, bound: BoundRegion { var, kind: BoundRegionKind::Anon } }
+        ty::Placeholder::new(ui, BoundRegion { var, kind: BoundRegionKind::Anon })
     }
 }
 
-pub type PlaceholderType = Placeholder<BoundTy>;
+pub type PlaceholderType<'tcx> = ty::Placeholder<TyCtxt<'tcx>, BoundTy>;
 
-impl<'tcx> rustc_type_ir::inherent::PlaceholderLike<TyCtxt<'tcx>> for PlaceholderType {
+impl<'tcx> rustc_type_ir::inherent::PlaceholderLike<TyCtxt<'tcx>> for PlaceholderType<'tcx> {
     type Bound = BoundTy;
 
     fn universe(self) -> UniverseIndex {
@@ -937,15 +926,15 @@ impl<'tcx> rustc_type_ir::inherent::PlaceholderLike<TyCtxt<'tcx>> for Placeholde
     }
 
     fn with_updated_universe(self, ui: UniverseIndex) -> Self {
-        Placeholder { universe: ui, ..self }
+        ty::Placeholder::new(ui, self.bound)
     }
 
     fn new(ui: UniverseIndex, bound: BoundTy) -> Self {
-        Placeholder { universe: ui, bound }
+        ty::Placeholder::new(ui, bound)
     }
 
     fn new_anon(ui: UniverseIndex, var: BoundVar) -> Self {
-        Placeholder { universe: ui, bound: BoundTy { var, kind: BoundTyKind::Anon } }
+        ty::Placeholder::new(ui, BoundTy { var, kind: BoundTyKind::Anon })
     }
 }
 
@@ -965,9 +954,9 @@ impl<'tcx> rustc_type_ir::inherent::BoundVarLike<TyCtxt<'tcx>> for BoundConst {
     }
 }
 
-pub type PlaceholderConst = Placeholder<BoundConst>;
+pub type PlaceholderConst<'tcx> = ty::Placeholder<TyCtxt<'tcx>, BoundConst>;
 
-impl<'tcx> rustc_type_ir::inherent::PlaceholderLike<TyCtxt<'tcx>> for PlaceholderConst {
+impl<'tcx> rustc_type_ir::inherent::PlaceholderLike<TyCtxt<'tcx>> for PlaceholderConst<'tcx> {
     type Bound = BoundConst;
 
     fn universe(self) -> UniverseIndex {
@@ -979,15 +968,15 @@ impl<'tcx> rustc_type_ir::inherent::PlaceholderLike<TyCtxt<'tcx>> for Placeholde
     }
 
     fn with_updated_universe(self, ui: UniverseIndex) -> Self {
-        Placeholder { universe: ui, ..self }
+        ty::Placeholder::new(ui, self.bound)
     }
 
     fn new(ui: UniverseIndex, bound: BoundConst) -> Self {
-        Placeholder { universe: ui, bound }
+        ty::Placeholder::new(ui, bound)
     }
 
     fn new_anon(ui: UniverseIndex, var: BoundVar) -> Self {
-        Placeholder { universe: ui, bound: BoundConst { var } }
+        ty::Placeholder::new(ui, BoundConst { var })
     }
 }
 

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -3274,6 +3274,16 @@ define_print! {
         p.reset_type_limit();
         self.term.print(p)?;
     }
+
+    ty::PlaceholderType<'tcx> {
+        match self.bound.kind {
+            ty::BoundTyKind::Anon => write!(p, "{self:?}")?,
+            ty::BoundTyKind::Param(def_id) => match p.should_print_verbose() {
+                true => write!(p, "{self:?}")?,
+                false => write!(p, "{}", p.tcx().item_name(def_id))?,
+            },
+        }
+    }
 }
 
 define_print_and_forward_display! {
@@ -3336,16 +3346,6 @@ define_print_and_forward_display! {
 
     ty::ParamTy {
         write!(p, "{}", self.name)?;
-    }
-
-    ty::PlaceholderType {
-        match self.bound.kind {
-            ty::BoundTyKind::Anon => write!(p, "{self:?}")?,
-            ty::BoundTyKind::Param(def_id) => match p.should_print_verbose() {
-                true => write!(p, "{self:?}")?,
-                false => write!(p, "{}", p.tcx().item_name(def_id))?,
-            },
-        }
     }
 
     ty::ParamConst {

--- a/compiler/rustc_middle/src/ty/region.rs
+++ b/compiler/rustc_middle/src/ty/region.rs
@@ -97,7 +97,10 @@ impl<'tcx> Region<'tcx> {
     }
 
     #[inline]
-    pub fn new_placeholder(tcx: TyCtxt<'tcx>, placeholder: ty::PlaceholderRegion) -> Region<'tcx> {
+    pub fn new_placeholder(
+        tcx: TyCtxt<'tcx>,
+        placeholder: ty::PlaceholderRegion<'tcx>,
+    ) -> Region<'tcx> {
         tcx.intern_region(ty::RePlaceholder(placeholder))
     }
 
@@ -170,7 +173,7 @@ impl<'tcx> rustc_type_ir::inherent::Region<TyCtxt<'tcx>> for Region<'tcx> {
         Region::new_canonical_bound(tcx, var)
     }
 
-    fn new_placeholder(tcx: TyCtxt<'tcx>, placeholder: ty::PlaceholderRegion) -> Self {
+    fn new_placeholder(tcx: TyCtxt<'tcx>, placeholder: ty::PlaceholderRegion<'tcx>) -> Self {
         Region::new_placeholder(tcx, placeholder)
     }
 

--- a/compiler/rustc_middle/src/ty/structural_impls.rs
+++ b/compiler/rustc_middle/src/ty/structural_impls.rs
@@ -184,16 +184,6 @@ impl fmt::Debug for ty::BoundTy {
     }
 }
 
-impl<T: fmt::Debug> fmt::Debug for ty::Placeholder<T> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if self.universe == ty::UniverseIndex::ROOT {
-            write!(f, "!{:?}", self.bound)
-        } else {
-            write!(f, "!{}_{:?}", self.universe.index(), self.bound)
-        }
-    }
-}
-
 impl<'tcx> fmt::Debug for GenericArg<'tcx> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.kind() {
@@ -294,8 +284,8 @@ TrivialTypeTraversalImpls! {
 // interners).
 TrivialTypeTraversalAndLiftImpls! {
     // tidy-alphabetical-start
+    crate::ty::BoundTy,
     crate::ty::ParamTy,
-    crate::ty::PlaceholderType,
     crate::ty::instance::ReifyReason,
     rustc_hir::def_id::DefId,
     // tidy-alphabetical-end

--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -39,6 +39,7 @@ pub type FnSig<'tcx> = ir::FnSig<TyCtxt<'tcx>>;
 pub type Binder<'tcx, T> = ir::Binder<TyCtxt<'tcx>, T>;
 pub type EarlyBinder<'tcx, T> = ir::EarlyBinder<TyCtxt<'tcx>, T>;
 pub type TypingMode<'tcx> = ir::TypingMode<TyCtxt<'tcx>>;
+pub type Placeholder<'tcx, T> = ir::Placeholder<TyCtxt<'tcx>, T>;
 
 pub trait Article {
     fn article(&self) -> &'static str;
@@ -508,7 +509,7 @@ impl<'tcx> Ty<'tcx> {
     }
 
     #[inline]
-    pub fn new_placeholder(tcx: TyCtxt<'tcx>, placeholder: ty::PlaceholderType) -> Ty<'tcx> {
+    pub fn new_placeholder(tcx: TyCtxt<'tcx>, placeholder: ty::PlaceholderType<'tcx>) -> Ty<'tcx> {
         Ty::new(tcx, Placeholder(placeholder))
     }
 
@@ -957,7 +958,7 @@ impl<'tcx> rustc_type_ir::inherent::Ty<TyCtxt<'tcx>> for Ty<'tcx> {
         Ty::new_param(tcx, param.index, param.name)
     }
 
-    fn new_placeholder(tcx: TyCtxt<'tcx>, placeholder: ty::PlaceholderType) -> Self {
+    fn new_placeholder(tcx: TyCtxt<'tcx>, placeholder: ty::PlaceholderType<'tcx>) -> Self {
         Ty::new_placeholder(tcx, placeholder)
     }
 

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/region.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/region.rs
@@ -980,7 +980,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
     fn report_sub_sup_conflict(
         &self,
         generic_param_scope: LocalDefId,
-        var_origin: RegionVariableOrigin,
+        var_origin: RegionVariableOrigin<'tcx>,
         sub_origin: SubregionOrigin<'tcx>,
         sub_region: Region<'tcx>,
         sup_origin: SubregionOrigin<'tcx>,
@@ -1051,7 +1051,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         if sub_region.is_error() | sup_region.is_error() { err.delay_as_bug() } else { err.emit() }
     }
 
-    fn report_inference_failure(&self, var_origin: RegionVariableOrigin) -> Diag<'_> {
+    fn report_inference_failure(&self, var_origin: RegionVariableOrigin<'tcx>) -> Diag<'_> {
         let br_string = |br: ty::BoundRegionKind| {
             let mut s = match br {
                 ty::BoundRegionKind::Named(def_id) => self.tcx.item_name(def_id).to_string(),

--- a/compiler/rustc_trait_selection/src/traits/coherence.rs
+++ b/compiler/rustc_trait_selection/src/traits/coherence.rs
@@ -566,13 +566,10 @@ fn plug_infer_with_placeholders<'tcx>(
                         ty,
                         Ty::new_placeholder(
                             self.infcx.tcx,
-                            ty::Placeholder {
-                                universe: self.universe,
-                                bound: ty::BoundTy {
-                                    var: self.next_var(),
-                                    kind: ty::BoundTyKind::Anon,
-                                },
-                            },
+                            ty::Placeholder::new(
+                                self.universe,
+                                ty::BoundTy { var: self.next_var(), kind: ty::BoundTyKind::Anon },
+                            ),
                         ),
                     )
                 else {
@@ -595,10 +592,10 @@ fn plug_infer_with_placeholders<'tcx>(
                         ct,
                         ty::Const::new_placeholder(
                             self.infcx.tcx,
-                            ty::Placeholder {
-                                universe: self.universe,
-                                bound: ty::BoundConst { var: self.next_var() },
-                            },
+                            ty::Placeholder::new(
+                                self.universe,
+                                ty::BoundConst { var: self.next_var() },
+                            ),
                         ),
                     )
                 else {
@@ -626,13 +623,13 @@ fn plug_infer_with_placeholders<'tcx>(
                             r,
                             ty::Region::new_placeholder(
                                 self.infcx.tcx,
-                                ty::Placeholder {
-                                    universe: self.universe,
-                                    bound: ty::BoundRegion {
+                                ty::Placeholder::new(
+                                    self.universe,
+                                    ty::BoundRegion {
                                         var: self.next_var(),
                                         kind: ty::BoundRegionKind::Anon,
                                     },
-                                },
+                                ),
                             ),
                         )
                     else {

--- a/compiler/rustc_trait_selection/src/traits/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/mod.rs
@@ -756,10 +756,10 @@ fn replace_param_and_infer_args_with_placeholder<'tcx>(
                 self.idx += 1;
                 Ty::new_placeholder(
                     self.tcx,
-                    ty::PlaceholderType {
-                        universe: ty::UniverseIndex::ROOT,
-                        bound: ty::BoundTy { var: idx, kind: ty::BoundTyKind::Anon },
-                    },
+                    ty::PlaceholderType::new(
+                        ty::UniverseIndex::ROOT,
+                        ty::BoundTy { var: idx, kind: ty::BoundTyKind::Anon },
+                    ),
                 )
             } else {
                 t.super_fold_with(self)
@@ -772,10 +772,7 @@ fn replace_param_and_infer_args_with_placeholder<'tcx>(
                 self.idx += 1;
                 ty::Const::new_placeholder(
                     self.tcx,
-                    ty::PlaceholderConst {
-                        universe: ty::UniverseIndex::ROOT,
-                        bound: ty::BoundConst { var: idx },
-                    },
+                    ty::PlaceholderConst::new(ty::UniverseIndex::ROOT, ty::BoundConst { var: idx }),
                 )
             } else {
                 c.super_fold_with(self)

--- a/compiler/rustc_trait_selection/src/traits/util.rs
+++ b/compiler/rustc_trait_selection/src/traits/util.rs
@@ -220,9 +220,9 @@ pub fn with_replaced_escaping_bound_vars<
 /// The inverse of [`BoundVarReplacer`]: replaces placeholders with the bound vars from which they came.
 pub struct PlaceholderReplacer<'a, 'tcx> {
     infcx: &'a InferCtxt<'tcx>,
-    mapped_regions: FxIndexMap<ty::PlaceholderRegion, ty::BoundRegion>,
-    mapped_types: FxIndexMap<ty::PlaceholderType, ty::BoundTy>,
-    mapped_consts: FxIndexMap<ty::PlaceholderConst, ty::BoundConst>,
+    mapped_regions: FxIndexMap<ty::PlaceholderRegion<'tcx>, ty::BoundRegion>,
+    mapped_types: FxIndexMap<ty::PlaceholderType<'tcx>, ty::BoundTy>,
+    mapped_consts: FxIndexMap<ty::PlaceholderConst<'tcx>, ty::BoundConst>,
     universe_indices: &'a [Option<ty::UniverseIndex>],
     current_index: ty::DebruijnIndex,
 }
@@ -230,9 +230,9 @@ pub struct PlaceholderReplacer<'a, 'tcx> {
 impl<'a, 'tcx> PlaceholderReplacer<'a, 'tcx> {
     pub fn replace_placeholders<T: TypeFoldable<TyCtxt<'tcx>>>(
         infcx: &'a InferCtxt<'tcx>,
-        mapped_regions: FxIndexMap<ty::PlaceholderRegion, ty::BoundRegion>,
-        mapped_types: FxIndexMap<ty::PlaceholderType, ty::BoundTy>,
-        mapped_consts: FxIndexMap<ty::PlaceholderConst, ty::BoundConst>,
+        mapped_regions: FxIndexMap<ty::PlaceholderRegion<'tcx>, ty::BoundRegion>,
+        mapped_types: FxIndexMap<ty::PlaceholderType<'tcx>, ty::BoundTy>,
+        mapped_consts: FxIndexMap<ty::PlaceholderConst<'tcx>, ty::BoundConst>,
         universe_indices: &'a [Option<ty::UniverseIndex>],
         value: T,
     ) -> T {

--- a/compiler/rustc_type_ir/src/ir_print.rs
+++ b/compiler/rustc_type_ir/src/ir_print.rs
@@ -3,7 +3,8 @@ use std::fmt;
 use crate::{
     AliasTerm, AliasTy, Binder, ClosureKind, CoercePredicate, ExistentialProjection,
     ExistentialTraitRef, FnSig, HostEffectPredicate, Interner, NormalizesTo, OutlivesPredicate,
-    PatternKind, ProjectionPredicate, SubtypePredicate, TraitPredicate, TraitRef, UnevaluatedConst,
+    PatternKind, Placeholder, ProjectionPredicate, SubtypePredicate, TraitPredicate, TraitRef,
+    UnevaluatedConst,
 };
 
 pub trait IrPrint<T> {
@@ -20,15 +21,6 @@ macro_rules! define_display_via_print {
                 }
             }
         )*
-    }
-}
-
-impl<I: Interner, T> fmt::Display for Binder<I, T>
-where
-    I: IrPrint<Binder<I, T>>,
-{
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        <I as IrPrint<Binder<I, T>>>::print(self, fmt)
     }
 }
 
@@ -68,6 +60,24 @@ where
 {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         <I as IrPrint<OutlivesPredicate<I, T>>>::print(self, fmt)
+    }
+}
+
+impl<I: Interner, T> fmt::Display for Binder<I, T>
+where
+    I: IrPrint<Binder<I, T>>,
+{
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        <I as IrPrint<Binder<I, T>>>::print(self, fmt)
+    }
+}
+
+impl<I: Interner, T> fmt::Display for Placeholder<I, T>
+where
+    I: IrPrint<Placeholder<I, T>>,
+{
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        <I as IrPrint<Placeholder<I, T>>>::print(self, fmt)
     }
 }
 

--- a/compiler/rustc_type_ir/src/lib.rs
+++ b/compiler/rustc_type_ir/src/lib.rs
@@ -61,7 +61,7 @@ pub use InferTy::*;
 pub use RegionKind::*;
 pub use TyKind::*;
 pub use Variance::*;
-pub use binder::*;
+pub use binder::{Placeholder, *};
 pub use canonical::*;
 pub use const_kind::*;
 pub use flags::*;


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
r? ghost


Couple of issues I've encountered;
- `compiler/rustc_infer/src/infer/region_constraints/mod.rs` `GenericKind` I can't call `write!(f, "{p}")` due to error 1. Which looks like I may need to implement `Lift` for `Placeholder`?
- Using the `define_print_and_forward_display!` for `ty::PlaceholderType` caused error 2, as I've moved the struct it no longer exists in the crate. I suspect because I'm not using that macro it causes the error for `GenericKind`

<details>
<summary>Error 1</summary>

```
error: lifetime may not live long enough
   --> compiler/rustc_infer/src/infer/region_constraints/mod.rs:672:38
    |
668 | impl<'tcx> fmt::Display for GenericKind<'tcx> {
    |      ---- lifetime `'tcx` defined here
...
672 |             GenericKind::Placeholder(ref p) => write!(f, "{p}"),
    |                                      ^^^^^ assignment requires that `'tcx` must outlive `'static`
    |
    = note: requirement occurs because of the type `rustc_middle::ty::TyCtxt<'_>`, which makes the generic argument `'_` invariant
    = note: the struct `rustc_middle::ty::TyCtxt<'tcx>` is invariant over the parameter `'tcx`
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance

error: implementation of `Lift` is not general enough
   --> compiler/rustc_infer/src/infer/region_constraints/mod.rs:672:38
    |
672 |             GenericKind::Placeholder(ref p) => write!(f, "{p}"),
    |                                      ^^^^^ implementation of `Lift` is not general enough
    |
    = note: `Lift<rustc_middle::ty::TyCtxt<'0>>` would have to be implemented for the type `rustc_type_ir::Placeholder<rustc_middle::ty::TyCtxt<'_>, BoundTy>`, for any lifetime `'0`...
    = note: ...but `Lift<rustc_middle::ty::TyCtxt<'1>>` is actually implemented for the type `rustc_type_ir::Placeholder<rustc_middle::ty::TyCtxt<'1>, BoundTy>`, for some specific lifetime `'1`

error: implementation of `Print` is not general enough
   --> compiler/rustc_infer/src/infer/region_constraints/mod.rs:672:38
    |
672 |             GenericKind::Placeholder(ref p) => write!(f, "{p}"),
    |                                      ^^^^^ implementation of `Print` is not general enough
```

</details>

<details>
<summary>Error 2</summary>

```
error[E0117]: only traits defined in the current crate can be implemented for arbitrary types
    --> compiler/rustc_middle/src/ty/print/pretty.rs:3060:38
     |
3057 | / macro_rules! forward_display_to_print {
3058 | |     ($($ty:ty),+) => {
3059 | |         // Some of the $ty arguments may not actually use 'tcx
3060 | |         $(#[allow(unused_lifetimes)] impl<'tcx> fmt::Display for $ty {
     | |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
...    |
3072 | |     };
3073 | | }
     | |_- in this expansion of `forward_display_to_print!`
...
3093 | / forward_display_to_print! {
3094 | |     ty::Region<'tcx>,
3095 | |     Ty<'tcx>,
3096 | |     &'tcx ty::List<ty::PolyExistentialPredicate<'tcx>>,
3097 | |     ty::Const<'tcx>,
3098 | |     &'tcx ty::PlaceholderType<'tcx>
     | |     ------------------------------- `rustc_type_ir::Placeholder` is not defined in the current crate
3099 | | }
     | |_- in this macro invocation
     |
     = note: impl doesn't have any local type before any uncovered type parameters
     = note: for more information see https://doc.rust-lang.org/reference/items/implementations.html#orphan-rules
     = note: define and implement a trait or new type instead

error: implementation of `Lift` is not general enough
    --> compiler/rustc_middle/src/ty/print/pretty.rs:3060:38
     |
3057 | / macro_rules! forward_display_to_print {
3058 | |     ($($ty:ty),+) => {
3059 | |         // Some of the $ty arguments may not actually use 'tcx
3060 | |         $(#[allow(unused_lifetimes)] impl<'tcx> fmt::Display for $ty {
     | |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ implementation of `Lift` is not general enough
...    |
3072 | |     };
3073 | | }
     | |_- in this expansion of `forward_display_to_print!`
...
3093 | / forward_display_to_print! {
3094 | |     ty::Region<'tcx>,
3095 | |     Ty<'tcx>,
3096 | |     &'tcx ty::List<ty::PolyExistentialPredicate<'tcx>>,
3097 | |     ty::Const<'tcx>,
3098 | |     &'tcx ty::PlaceholderType<'tcx>
3099 | | }
     | |_- in this macro invocation
     |
     = note: `Lift<context::TyCtxt<'0>>` would have to be implemented for the type `rustc_type_ir::Placeholder<context::TyCtxt<'tcx>, BoundTy>`, for any lifetime `'0`...
     = note: ...but `Lift<context::TyCtxt<'1>>` is actually implemented for the type `rustc_type_ir::Placeholder<context::TyCtxt<'1>, BoundTy>`, for some specific lifetime `'1`

error: implementation of `print::Print` is not general enough
    --> compiler/rustc_middle/src/ty/print/pretty.rs:3060:38
     |
3057 | / macro_rules! forward_display_to_print {
3058 | |     ($($ty:ty),+) => {
3059 | |         // Some of the $ty arguments may not actually use 'tcx
3060 | |         $(#[allow(unused_lifetimes)] impl<'tcx> fmt::Display for $ty {
     | |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ implementation of `print::Print` is not general enough
...    |
3072 | |     };
3073 | | }
     | |_- in this expansion of `forward_display_to_print!`
...
3093 | / forward_display_to_print! {
3094 | |     ty::Region<'tcx>,
3095 | |     Ty<'tcx>,
3096 | |     &'tcx ty::List<ty::PolyExistentialPredicate<'tcx>>,
3097 | |     ty::Const<'tcx>,
3098 | |     &'tcx ty::PlaceholderType<'tcx>
3099 | | }
     | |_- in this macro invocation
     |
     = note: `print::Print<'0, print::pretty::FmtPrinter<'a, '0>>` would have to be implemented for the type `rustc_type_ir::Placeholder<context::TyCtxt<'tcx>, BoundTy>`, for any lifetime `'0`...
     = note: ...but `print::Print<'1, print::pretty::FmtPrinter<'a, 'tcx>>` is actually implemented for the type `rustc_type_ir::Placeholder<context::TyCtxt<'1>, BoundTy>`, for some specific lifetime `'1`

error: specializing impl repeats parameter `'tcx`
    --> compiler/rustc_middle/src/ty/print/pretty.rs:3060:38
     |
3057 | / macro_rules! forward_display_to_print {
3058 | |     ($($ty:ty),+) => {
3059 | |         // Some of the $ty arguments may not actually use 'tcx
3060 | |         $(#[allow(unused_lifetimes)] impl<'tcx> fmt::Display for $ty {
     | |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
...    |
3072 | |     };
3073 | | }
     | |_- in this expansion of `forward_display_to_print!`
...
3093 | / forward_display_to_print! {
3094 | |     ty::Region<'tcx>,
3095 | |     Ty<'tcx>,
3096 | |     &'tcx ty::List<ty::PolyExistentialPredicate<'tcx>>,
3097 | |     ty::Const<'tcx>,
3098 | |     &'tcx ty::PlaceholderType<'tcx>
3099 | | }
     | |_- in this macro invocation

error[E0277]: the trait bound `&Placeholder<TyCtxt<'tcx>, BoundTy>: Lift<...>` is not satisfied
    --> compiler/rustc_middle/src/ty/print/pretty.rs:3064:30
     |
3057 | / macro_rules! forward_display_to_print {
3058 | |     ($($ty:ty),+) => {
3059 | |         // Some of the $ty arguments may not actually use 'tcx
3060 | |         $(#[allow(unused_lifetimes)] impl<'tcx> fmt::Display for $ty {
...    |
3064 | |                     tcx.lift(*self)
     | |                         ---- ^^^^^ unsatisfied trait bound
     | |                         |
     | |                         required by a bound introduced by this call
...    |
3072 | |     };
3073 | | }
     | |_- in this expansion of `forward_display_to_print!`
...
3093 | / forward_display_to_print! {
3094 | |     ty::Region<'tcx>,
3095 | |     Ty<'tcx>,
3096 | |     &'tcx ty::List<ty::PolyExistentialPredicate<'tcx>>,
3097 | |     ty::Const<'tcx>,
3098 | |     &'tcx ty::PlaceholderType<'tcx>
3099 | | }
     | |_- in this macro invocation
     |
     = help: the trait `Lift<context::TyCtxt<'_>>` is not implemented for `&rustc_type_ir::Placeholder<context::TyCtxt<'tcx>, BoundTy>`
note: required by a bound in `context::TyCtxt::<'tcx>::lift`
    --> compiler/rustc_middle/src/ty/context.rs:1807:20
     |
1807 |     pub fn lift<T: Lift<TyCtxt<'tcx>>>(self, value: T) -> Option<T::Lifted> {
     |                    ^^^^^^^^^^^^^^^^^^ required by this bound in `TyCtxt::<'tcx>::lift`
     = note: the full name for the type has been written to '/home/jambar02/Documents/arm/rust/build/x86_64-unknown-linux-gnu/stage1-rustc/x86_64-unknown-linux-gnu/release/deps/rustc_middle-16e5c44041028d8b.long-type-3843651570422266958.txt'
     = note: consider using `--verbose` to print the full type name to the console
help: consider dereferencing here
     |
3064 |                     tcx.lift(**self)
     |                              +

error[E0282]: type annotations needed
    --> compiler/rustc_middle/src/ty/print/pretty.rs:3064:21
     |
3057 | /  macro_rules! forward_display_to_print {
3058 | |      ($($ty:ty),+) => {
3059 | |          // Some of the $ty arguments may not actually use 'tcx
3060 | |          $(#[allow(unused_lifetimes)] impl<'tcx> fmt::Display for $ty {
...    |
3064 | |/                     tcx.lift(*self)
3065 | ||                         .expect("could not lift for printing")
     | ||______________________________________________________________^ cannot infer type
...    |
3072 | |      };
3073 | |  }
     | |__- in this expansion of `forward_display_to_print!`
...
3093 |  / forward_display_to_print! {
3094 |  |     ty::Region<'tcx>,
3095 |  |     Ty<'tcx>,
3096 |  |     &'tcx ty::List<ty::PolyExistentialPredicate<'tcx>>,
3097 |  |     ty::Const<'tcx>,
3098 |  |     &'tcx ty::PlaceholderType<'tcx>
3099 |  | }
     |  |_- in this macro invocation
```

</details>