### PR TITLE
Regression test for system register `ttbr0_el2`

### DIFF
--- a/tests/ui/asm/aarch64/ttbr0_el2.rs
+++ b/tests/ui/asm/aarch64/ttbr0_el2.rs
@@ -1,0 +1,11 @@
+//! Regression test for #97724, recognising ttbr0_el2 as a valid armv8 system register
+//@ only-aarch64
+//@ build-pass
+use std::arch::asm;
+
+static PT: [u64; 512] = [0; 512];
+fn main() {
+    unsafe {
+        asm!("msr ttbr0_el2, {pt}", pt = in(reg) &PT as *const _ );
+    }
+}


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Regression test for recognising the `ttbr0_el2` register.

closes rust-lang/rust#97724
