### PR TITLE
added default_uwtables=true to aarch64_unknown_none targets

### DIFF
--- a/compiler/rustc_target/src/spec/targets/aarch64_unknown_none.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_unknown_none.rs
@@ -27,6 +27,7 @@ pub(crate) fn target() -> Target {
         max_atomic_width: Some(128),
         stack_probes: StackProbeType::Inline,
         panic_strategy: PanicStrategy::Abort,
+        default_uwtable: true,
         ..Default::default()
     };
     Target {

--- a/compiler/rustc_target/src/spec/targets/aarch64_unknown_none_softfloat.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_unknown_none_softfloat.rs
@@ -23,6 +23,7 @@ pub(crate) fn target() -> Target {
         supported_sanitizers: SanitizerSet::KCFI | SanitizerSet::KERNELADDRESS,
         stack_probes: StackProbeType::Inline,
         panic_strategy: PanicStrategy::Abort,
+        default_uwtable: true,
         ..Default::default()
     };
     Target {


### PR DESCRIPTION
This patch adds DWARF unwinding tables by default for `aarch64-unknown-none` and `aarch64-unknown-none-softfloat` targets. By implication, the `core` library for these targets will be built with unwinding tables. These tables are often useful, and are especially needed for backtracing through `core` on embedded targets. The tables can be turned off for user compilation with `-C force-unwind-tables=no` if desired.

(I am the lead maintainer for these targets in the Rust Embedded Working Group, and have discussed this with REWG.)