### PR TITLE
build-manifest: generate MSI and MINGW arrays from rustc

### DIFF
--- a/src/tools/build-manifest/build.rs
+++ b/src/tools/build-manifest/build.rs
@@ -60,7 +60,7 @@ fn main() {
     let mut output = String::new();
 
     writeln!(output, "static HOSTS: &[&str] = &[").unwrap();
-    for host in targets.hosts {
+    for host in &targets.hosts {
         writeln!(output, "    {:?},", host).unwrap();
     }
     writeln!(output, "];").unwrap();
@@ -68,6 +68,22 @@ fn main() {
     writeln!(output, "static TARGETS: &[&str] = &[").unwrap();
     for target in targets.targets {
         writeln!(output, "    {:?},", target).unwrap();
+    }
+    writeln!(output, "];").unwrap();
+
+    writeln!(output, "static MSI_INSTALLERS: &[&str] = &[").unwrap();
+    for host in &targets.hosts {
+        if host.contains("-windows-") {
+            writeln!(output, "    {:?},", host).unwrap();
+        }
+    }
+    writeln!(output, "];").unwrap();
+
+    writeln!(output, "static MINGW: &[&str] = &[").unwrap();
+    for host in targets.hosts {
+        if host.contains("-windows-gnu") {
+            writeln!(output, "    {:?},", host).unwrap();
+        }
     }
     writeln!(output, "];").unwrap();
 

--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -29,17 +29,7 @@ static DOCS_FALLBACK: &[(&str, &str)] = &[
     ("", "x86_64-unknown-linux-gnu"),
 ];
 
-static MSI_INSTALLERS: &[&str] = &[
-    "aarch64-pc-windows-msvc",
-    "i686-pc-windows-gnu",
-    "i686-pc-windows-msvc",
-    "x86_64-pc-windows-gnu",
-    "x86_64-pc-windows-msvc",
-];
-
 static PKG_INSTALLERS: &[&str] = &["x86_64-apple-darwin", "aarch64-apple-darwin"];
-
-static MINGW: &[&str] = &["i686-pc-windows-gnu", "x86_64-pc-windows-gnu"];
 
 static NIGHTLY_ONLY_COMPONENTS: &[PkgType] =
     &[PkgType::Miri, PkgType::JsonDocs, PkgType::RustcCodegenCranelift];


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
An alternative to rust-lang/rust#149503

The arrays after generating:
```
❯ bat -n build/x86_64-unknown-linux-gnu/stage2-tools/x86_64-unknown-linux-gnu/release/build/build-manifest-e0236666c7c4187b/out/targets.rs | rg MSI -A14
 136 static MSI_INSTALLERS: &[&str] = &[
 137     "aarch64-pc-windows-gnullvm",
 138     "aarch64-pc-windows-msvc",
 139     "i686-pc-windows-gnu",
 140     "i686-pc-windows-msvc",
 141     "x86_64-pc-windows-gnu",
 142     "x86_64-pc-windows-gnullvm",
 143     "x86_64-pc-windows-msvc",
 144 ];
 145 static MINGW: &[&str] = &[
 146     "aarch64-pc-windows-gnullvm",
 147     "i686-pc-windows-gnu",
 148     "x86_64-pc-windows-gnu",
 149     "x86_64-pc-windows-gnullvm",
 150 ];
```

r? @Mark-Simulacrum 