### PR TITLE
rustdoc: Add unstable `--merge-doctests=yes/no/auto` flag

### DIFF
--- a/src/librustdoc/doctest/make.rs
+++ b/src/librustdoc/doctest/make.rs
@@ -20,6 +20,7 @@ use rustc_span::{DUMMY_SP, FileName, Span, kw};
 use tracing::debug;
 
 use super::GlobalTestOptions;
+use crate::config::MergeDoctests;
 use crate::display::Joined as _;
 use crate::html::markdown::LangString;
 
@@ -41,7 +42,7 @@ pub(crate) struct BuildDocTestBuilder<'a> {
     source: &'a str,
     crate_name: Option<&'a str>,
     edition: Edition,
-    can_merge_doctests: bool,
+    can_merge_doctests: MergeDoctests,
     // If `test_id` is `None`, it means we're generating code for a code example "run" link.
     test_id: Option<String>,
     lang_str: Option<&'a LangString>,
@@ -55,7 +56,7 @@ impl<'a> BuildDocTestBuilder<'a> {
             source,
             crate_name: None,
             edition: DEFAULT_EDITION,
-            can_merge_doctests: false,
+            can_merge_doctests: MergeDoctests::Never,
             test_id: None,
             lang_str: None,
             span: DUMMY_SP,
@@ -70,7 +71,7 @@ impl<'a> BuildDocTestBuilder<'a> {
     }
 
     #[inline]
-    pub(crate) fn can_merge_doctests(mut self, can_merge_doctests: bool) -> Self {
+    pub(crate) fn can_merge_doctests(mut self, can_merge_doctests: MergeDoctests) -> Self {
         self.can_merge_doctests = can_merge_doctests;
         self
     }
@@ -117,10 +118,6 @@ impl<'a> BuildDocTestBuilder<'a> {
             span,
             global_crate_attrs,
         } = self;
-        let can_merge_doctests = can_merge_doctests
-            && lang_str.is_some_and(|lang_str| {
-                !lang_str.compile_fail && !lang_str.test_harness && !lang_str.standalone_crate
-            });
 
         let result = rustc_driver::catch_fatal_errors(|| {
             rustc_span::create_session_if_not_set_then(edition, |_| {
@@ -155,14 +152,26 @@ impl<'a> BuildDocTestBuilder<'a> {
         debug!("crate_attrs:\n{crate_attrs}{maybe_crate_attrs}");
         debug!("crates:\n{crates}");
         debug!("after:\n{everything_else}");
+        debug!("merge-doctests: {can_merge_doctests:?}");
 
-        // If it contains `#[feature]` or `#[no_std]`, we don't want it to be merged either.
-        let can_be_merged = can_merge_doctests
-            && !has_global_allocator
-            && crate_attrs.is_empty()
-            // If this is a merged doctest and a defined macro uses `$crate`, then the path will
-            // not work, so better not put it into merged doctests.
-            && !(has_macro_def && everything_else.contains("$crate"));
+        // Up until now, we've been dealing with settings for the whole crate.
+        // Now, infer settings for this particular test.
+        let can_be_merged = if can_merge_doctests == MergeDoctests::Auto {
+            let mut can_merge = false;
+            // Avoid tests with incompatible attributes.
+            can_merge |= lang_str.is_some_and(|lang_str| {
+                !lang_str.compile_fail && !lang_str.test_harness && !lang_str.standalone_crate
+            });
+            // If it contains `#[feature]` or `#[no_std]`, we don't want it to be merged either.
+            can_merge &= !has_global_allocator
+                && crate_attrs.is_empty()
+                // If this is a merged doctest and a defined macro uses `$crate`, then the path will
+                // not work, so better not put it into merged doctests.
+                && !(has_macro_def && everything_else.contains("$crate"));
+            can_merge
+        } else {
+            can_merge_doctests != MergeDoctests::Never
+        };
         DocTestBuilder {
             supports_color,
             has_main_fn,

--- a/src/librustdoc/doctest/markdown.rs
+++ b/src/librustdoc/doctest/markdown.rs
@@ -3,6 +3,7 @@
 use std::fs::read_to_string;
 use std::sync::{Arc, Mutex};
 
+use rustc_errors::DiagCtxtHandle;
 use rustc_session::config::Input;
 use rustc_span::{DUMMY_SP, FileName};
 use tempfile::tempdir;
@@ -78,7 +79,7 @@ impl DocTestVisitor for MdCollector {
 }
 
 /// Runs any tests/code examples in the markdown file `options.input`.
-pub(crate) fn test(input: &Input, options: Options) -> Result<(), String> {
+pub(crate) fn test(input: &Input, options: Options, dcx: DiagCtxtHandle<'_>) -> Result<(), String> {
     let input_str = match input {
         Input::File(path) => {
             read_to_string(path).map_err(|err| format!("{}: {err}", path.display()))?
@@ -118,6 +119,7 @@ pub(crate) fn test(input: &Input, options: Options) -> Result<(), String> {
     let CreateRunnableDocTests { opts, rustdoc_options, standalone_tests, mergeable_tests, .. } =
         collector;
     crate::doctest::run_tests(
+        dcx,
         opts,
         &rustdoc_options,
         &Arc::new(Mutex::new(Vec::new())),

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -546,6 +546,14 @@ fn opts() -> Vec<RustcOptGroup> {
         opt(Unstable, FlagMulti, "", "no-run", "Compile doctests without running them", ""),
         opt(
             Unstable,
+            Opt,
+            "",
+            "merge-doctests",
+            "Force all doctests to be compiled as a single binary, instead of one binary per test. If merging fails, rustdoc will emit a hard error.",
+            "yes|no|auto",
+        ),
+        opt(
+            Unstable,
             Multi,
             "",
             "remap-path-prefix",
@@ -822,7 +830,7 @@ fn main_args(early_dcx: &mut EarlyDiagCtxt, at_args: &[String]) {
         options.should_test || output_format == config::OutputFormat::Doctest,
         config::markdown_input(&input),
     ) {
-        (true, Some(_)) => return wrap_return(dcx, doctest::test_markdown(&input, options)),
+        (true, Some(_)) => return wrap_return(dcx, doctest::test_markdown(&input, options, dcx)),
         (true, None) => return doctest::run(dcx, input, options),
         (false, Some(md_input)) => {
             let md_input = md_input.to_owned();

--- a/tests/run-make/rustdoc-default-output/output-default.stdout
+++ b/tests/run-make/rustdoc-default-output/output-default.stdout
@@ -154,6 +154,10 @@ Options:
                         Comma separated list of types of output for rustdoc to
                         emit
         --no-run        Compile doctests without running them
+        --merge-doctests yes|no|auto
+                        Force all doctests to be compiled as a single binary,
+                        instead of one binary per test. If merging fails,
+                        rustdoc will emit a hard error.
         --remap-path-prefix FROM=TO
                         Remap source names in compiler messages
         --show-type-layout 

--- a/tests/rustdoc-ui/doctest/force-merge-default-not-override.rs
+++ b/tests/rustdoc-ui/doctest/force-merge-default-not-override.rs
@@ -1,0 +1,25 @@
+//@ check-pass
+//@ edition: 2024
+//@ compile-flags: --test --test-args=--test-threads=1 --merge-doctests=yes -Z unstable-options
+//@ normalize-stdout: "tests/rustdoc-ui/doctest" -> "$$DIR"
+//@ normalize-stdout: "finished in \d+\.\d+s" -> "finished in $$TIME"
+//@ normalize-stdout: "ran in \d+\.\d+s" -> "ran in $$TIME"
+//@ normalize-stdout: "compilation took \d+\.\d+s" -> "compilation took $$TIME"
+//@ normalize-stdout: ".rs:\d+:\d+" -> ".rs:$$LINE:$$COL"
+
+// FIXME: compiletest doesn't support `// RAW` for doctests because the progress messages aren't
+// emitted as JSON. Instead the .stderr file tests that this doesn't contains a
+// "merged compilation took ..." message.
+
+/// ```standalone_crate
+/// let x = 12;
+/// ```
+///
+/// These two doctests should be not be merged, even though this passes `--merge-doctests=yes`.
+///
+/// ```standalone_crate
+/// fn main() {
+///     println!("owo");
+/// }
+/// ```
+pub struct Foo;

--- a/tests/rustdoc-ui/doctest/force-merge-default-not-override.stdout
+++ b/tests/rustdoc-ui/doctest/force-merge-default-not-override.stdout
@@ -1,0 +1,7 @@
+
+running 2 tests
+test $DIR/force-merge-default-not-override.rs - Foo (line 14) ... ok
+test $DIR/force-merge-default-not-override.rs - Foo (line 20) ... ok
+
+test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
+

--- a/tests/rustdoc-ui/doctest/force-merge-fail.rs
+++ b/tests/rustdoc-ui/doctest/force-merge-fail.rs
@@ -1,0 +1,18 @@
+//@ edition: 2018
+//@ compile-flags: --test --test-args=--test-threads=1 --merge-doctests=yes -Z unstable-options
+//@ normalize-stderr: ".*doctest_bundle_2018.rs:\d+:\d+" -> "doctest_bundle_2018.rs:$$LINE:$$COL"
+
+//~? ERROR failed to merge doctests
+
+/// These two doctests will fail to force-merge, and should give a hard error as a result.
+///
+/// ```
+/// #![deny(clashing_extern_declarations)]
+/// unsafe extern "C" { fn unmangled_name() -> u8; }
+/// ```
+///
+/// ```
+/// #![deny(clashing_extern_declarations)]
+/// unsafe extern "C" { fn unmangled_name(); }
+/// ```
+pub struct Foo;

--- a/tests/rustdoc-ui/doctest/force-merge-fail.stderr
+++ b/tests/rustdoc-ui/doctest/force-merge-fail.stderr
@@ -1,0 +1,6 @@
+doctest_bundle_2018.rs:$LINE:$COL: error: `unmangled_name` redeclared with a different signature: this signature doesn't match the previous declaration
+error: aborting due to 1 previous error
+error: failed to merge doctests
+   |
+   = note: requested explicitly on the command line with `--merge-doctests=yes`
+

--- a/tests/rustdoc-ui/doctest/force-merge.rs
+++ b/tests/rustdoc-ui/doctest/force-merge.rs
@@ -1,0 +1,25 @@
+//@ check-pass
+//@ edition: 2018
+//@ compile-flags: --test --test-args=--test-threads=1 --merge-doctests=yes -Z unstable-options
+//@ normalize-stdout: "tests/rustdoc-ui/doctest" -> "$$DIR"
+//@ normalize-stdout: "finished in \d+\.\d+s" -> "finished in $$TIME"
+//@ normalize-stdout: "ran in \d+\.\d+s" -> "ran in $$TIME"
+//@ normalize-stdout: "compilation took \d+\.\d+s" -> "compilation took $$TIME"
+//@ normalize-stdout: ".rs:\d+:\d+" -> ".rs:$$LINE:$$COL"
+
+// FIXME: compiletest doesn't support `// RAW` for doctests because the progress messages aren't
+// emitted as JSON. Instead the .stderr file tests that this contains a
+// "merged compilation took ..." message.
+
+/// ```
+/// let x = 12;
+/// ```
+///
+/// These two doctests should be force-merged, even though this uses edition 2018.
+///
+/// ```
+/// fn main() {
+///     println!("owo");
+/// }
+/// ```
+pub struct Foo;

--- a/tests/rustdoc-ui/doctest/force-merge.stdout
+++ b/tests/rustdoc-ui/doctest/force-merge.stdout
@@ -1,0 +1,8 @@
+
+running 2 tests
+test $DIR/force-merge.rs - Foo (line 14) ... ok
+test $DIR/force-merge.rs - Foo (line 20) ... ok
+
+test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
+
+all doctests ran in $TIME; merged doctests compilation took $TIME

--- a/tests/rustdoc-ui/doctest/force-no-merge.rs
+++ b/tests/rustdoc-ui/doctest/force-no-merge.rs
@@ -1,0 +1,24 @@
+//@ edition: 2024
+//@ check-pass
+//@ compile-flags: --test --test-args=--test-threads=1 --merge-doctests=no -Z unstable-options
+//@ normalize-stderr: ".*doctest_bundle_2018.rs:\d+:\d+" -> "doctest_bundle_2018.rs:$$LINE:$$COL"
+
+//@ normalize-stdout: "tests/rustdoc-ui/doctest" -> "$$DIR"
+//@ normalize-stdout: "finished in \d+\.\d+s" -> "finished in $$TIME"
+//@ normalize-stdout: "ran in \d+\.\d+s" -> "ran in $$TIME"
+//@ normalize-stdout: "compilation took \d+\.\d+s" -> "compilation took $$TIME"
+//@ normalize-stdout: ".rs:\d+:\d+" -> ".rs:$$LINE:$$COL"
+
+/// These two doctests should not force-merge, even though this crate has edition 2024 and the
+/// individual doctests are not annotated.
+///
+/// ```
+/// #![deny(clashing_extern_declarations)]
+/// unsafe extern "C" { fn unmangled_name() -> u8; }
+/// ```
+///
+/// ```
+/// #![deny(clashing_extern_declarations)]
+/// unsafe extern "C" { fn unmangled_name(); }
+/// ```
+pub struct Foo;

--- a/tests/rustdoc-ui/doctest/force-no-merge.stdout
+++ b/tests/rustdoc-ui/doctest/force-no-merge.stdout
@@ -1,0 +1,7 @@
+
+running 2 tests
+test $DIR/force-no-merge.rs - Foo (line 15) ... ok
+test $DIR/force-no-merge.rs - Foo (line 20) ... ok
+
+test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
+

--- a/tests/rustdoc-ui/doctest/merge-doctests-auto.rs
+++ b/tests/rustdoc-ui/doctest/merge-doctests-auto.rs
@@ -1,0 +1,28 @@
+//! `--merge-doctests=auto` should override the edition.
+
+//@ check-pass
+//@ edition: 2018
+//@ compile-flags: --test --test-args=--test-threads=1 --merge-doctests=auto -Z unstable-options
+
+//@ normalize-stdout: "tests/rustdoc-ui/doctest" -> "$$DIR"
+//@ normalize-stdout: "finished in \d+\.\d+s" -> "finished in $$TIME"
+//@ normalize-stdout: "ran in \d+\.\d+s" -> "ran in $$TIME"
+//@ normalize-stdout: "compilation took \d+\.\d+s" -> "compilation took $$TIME"
+//@ normalize-stdout: ".rs:\d+:\d+" -> ".rs:$$LINE:$$COL"
+
+// FIXME: compiletest doesn't support `// RAW` for doctests because the progress messages aren't
+// emitted as JSON. Instead the .stderr file tests that this contains a
+// "merged compilation took ..." message.
+
+/// ```
+/// let x = 12;
+/// ```
+///
+/// These two doctests should be auto-merged, even though this uses edition 2018.
+///
+/// ```
+/// fn main() {
+///     println!("owo");
+/// }
+/// ```
+pub struct Foo;

--- a/tests/rustdoc-ui/doctest/merge-doctests-auto.stdout
+++ b/tests/rustdoc-ui/doctest/merge-doctests-auto.stdout
@@ -1,0 +1,8 @@
+
+running 2 tests
+test $DIR/merge-doctests-auto.rs - Foo (line 17) ... ok
+test $DIR/merge-doctests-auto.rs - Foo (line 23) ... ok
+
+test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
+
+all doctests ran in $TIME; merged doctests compilation took $TIME

--- a/tests/rustdoc-ui/doctest/merge-doctests-invalid.rs
+++ b/tests/rustdoc-ui/doctest/merge-doctests-invalid.rs
@@ -1,0 +1,2 @@
+//@ compile-flags: --merge-doctests=bad-opt -Zunstable-options
+//~? ERROR must be a boolean

--- a/tests/rustdoc-ui/doctest/merge-doctests-invalid.stderr
+++ b/tests/rustdoc-ui/doctest/merge-doctests-invalid.stderr
@@ -1,0 +1,2 @@
+error: argument to --merge-doctests must be a boolean (true/false) or 'auto'
+

--- a/tests/rustdoc-ui/doctest/merge-doctests-unstable.rs
+++ b/tests/rustdoc-ui/doctest/merge-doctests-unstable.rs
@@ -1,0 +1,2 @@
+//@ compile-flags: --merge-doctests=no
+//~? RAW `-Z unstable-options` flag must also be passed

--- a/tests/rustdoc-ui/doctest/merge-doctests-unstable.stderr
+++ b/tests/rustdoc-ui/doctest/merge-doctests-unstable.stderr
@@ -1,0 +1,2 @@
+error: the `-Z unstable-options` flag must also be passed to enable the flag `merge-doctests`
+


### PR DESCRIPTION
This is useful for changing the *default* for whether doctests are merged or not. Currently, that default is solely controlled by `edition = 2024`, which adds a high switching cost to get doctest merging. This flag allows opting in even on earlier editions.

Unlike the `edition = 2024` default, `--merge-doctests=yes` gives a hard error if merging fails instead of falling back to running standalone tests. The user has explicitly said they want merging, so we shouldn't silently do something else.

`--merge-doctests=auto` is equivalent to the current 2024 edition behavior, but available on earlier editions.

Helps with https://github.com/rust-lang/rust/issues/141240. @epage said in that issue he would like a per-doctest opt-in, and that seems useful to me in addition to this flag, but I think it's a separate use case from changing the default.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
