### PR TITLE
Fix mailmap issue

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -43,6 +43,7 @@ Andre Bogus <bogusandre@gmail.com>
 Andre Bogus <bogusandre@gmail.com> <andre.bogus@aleph-alpha.de>
 Andre Bogus <bogusandre@gmail.com> <andre.bogus@ankordata.de>
 Andrea Ciliberti <meziu210@icloud.com>
+
 Andreas Gal <gal@mozilla.com> <andreas.gal@gmail.com>
 Andreas Jonson <andjo403@users.noreply.github.com>
 Andrew Gauger <andygauge@gmail.com>
@@ -87,7 +88,9 @@ bjorn3 <17426603+bjorn3@users.noreply.github.com> <bjorn3@users.noreply.github.c
 bjorn3 <17426603+bjorn3@users.noreply.github.com> <bjorn3_gh@protonmail.com>
 Björn Steinbrink <bsteinbr@gmail.com> <B.Steinbrink@gmx.de>
 blake2-ppc <ulrik.sverdrup@gmail.com> <blake2-ppc>
-blyxyas <blyxyas@gmail.com> Alejandra González <blyxyas@gmail.com>
+Alejandra González <blyxyas@goose.love> blyxyas <blyxyas@gmail.com>
+Alejandra González <blyxyas@goose.love> blyxyas <blyxyas@goose.love>
+Alejandra González <blyxyas@goose.love> Alejandra González <blyxyas@gmail.com>
 boolean_coercion <booleancoercion@gmail.com>
 Boris Egorov <jightuse@gmail.com> <egorov@linux.com>
 bors <bors@rust-lang.org> bors[bot] <26634292+bors[bot]@users.noreply.github.com>


### PR DESCRIPTION
My name and username got separated in thanks.rust-lang.org, probably due to me changing my email in Github about a month ago.