### PR TITLE
Batched compiletest Config fixups

### DIFF
--- a/src/tools/compiletest/src/common.rs
+++ b/src/tools/compiletest/src/common.rs
@@ -260,13 +260,10 @@ pub struct Config {
     /// For example:
     /// - `/home/ferris/rust/build/x86_64-unknown-linux-gnu/stage1/lib/rustlib/i686-unknown-linux-gnu/lib`
     ///
-    /// FIXME: maybe rename this to reflect (1) which target platform (target, not host), and (2)
-    /// what "run libraries" are against.
-    ///
     /// FIXME: this is very under-documented in conjunction with the `remote-test-client` scheme and
     /// `RUNNER` scheme to actually run the target executable under the target platform environment,
     /// cf. [`Self::remote_test_client`] and [`Self::runner`].
-    pub run_lib_path: Utf8PathBuf,
+    pub target_run_lib_path: Utf8PathBuf,
 
     /// Path to the *staged*  `rustc`-under-test. Unless forced, this `rustc` is *staged*, and must
     /// not be confused with [`Self::stage0_rustc_path`].

--- a/src/tools/compiletest/src/common.rs
+++ b/src/tools/compiletest/src/common.rs
@@ -252,10 +252,7 @@ pub struct Config {
     ///
     /// For example:
     /// - `/home/ferris/rust/build/x86_64-unknown-linux-gnu/stage1/bin/lib`
-    ///
-    /// FIXME: maybe rename this to reflect (1) which target platform (host, not target), and (2)
-    /// which `rustc` (the `rustc`-under-test, not the stage 0 `rustc` unless forced).
-    pub compile_lib_path: Utf8PathBuf,
+    pub host_compile_lib_path: Utf8PathBuf,
 
     /// Path to libraries needed to run the compiled executable for the **target** platform. This
     /// corresponds to the **target** sysroot libraries, including the **target** standard library.
@@ -1093,7 +1090,7 @@ fn query_rustc_output(config: &Config, args: &[&str], envs: HashMap<String, Stri
     let query_rustc_path = config.query_rustc_path.as_deref().unwrap_or(&config.rustc_path);
 
     let mut command = Command::new(query_rustc_path);
-    add_dylib_path(&mut command, iter::once(&config.compile_lib_path));
+    add_dylib_path(&mut command, iter::once(&config.host_compile_lib_path));
     command.args(&config.target_rustcflags).args(args);
     command.env("RUSTC_BOOTSTRAP", "1");
     command.envs(envs);

--- a/src/tools/compiletest/src/common.rs
+++ b/src/tools/compiletest/src/common.rs
@@ -265,13 +265,23 @@ pub struct Config {
     /// cf. [`Self::remote_test_client`] and [`Self::runner`].
     pub target_run_lib_path: Utf8PathBuf,
 
-    /// Path to the *staged*  `rustc`-under-test. Unless forced, this `rustc` is *staged*, and must
-    /// not be confused with [`Self::stage0_rustc_path`].
+    /// Path to the `rustc`-under-test.
+    ///
+    /// For `ui-fulldeps` test suite specifically:
+    ///
+    /// - This is the **stage 0** compiler when testing `ui-fulldeps` under `--stage=1`.
+    /// - This is the **stage 2** compiler when testing `ui-fulldeps` under `--stage=2`.
+    ///
+    /// See [`Self::query_rustc_path`] for the `--stage=1` `ui-fulldeps` scenario where a separate
+    /// in-tree `rustc` is used for querying target information.
     ///
     /// For example:
     /// - `/home/ferris/rust/build/x86_64-unknown-linux-gnu/stage1/bin/rustc`
     ///
-    /// FIXME: maybe rename this to reflect that this is the `rustc`-under-test.
+    /// # Note on forced stage0
+    ///
+    /// It is possible for this `rustc` to be a stage 0 `rustc` if explicitly configured with the
+    /// bootstrap option `build.compiletest-allow-stage0=true` and specifying `--stage=0`.
     pub rustc_path: Utf8PathBuf,
 
     /// Path to a *staged* **host** platform cargo executable (unless stage 0 is forced). This

--- a/src/tools/compiletest/src/common.rs
+++ b/src/tools/compiletest/src/common.rs
@@ -687,9 +687,12 @@ pub struct Config {
     pub builtin_cfg_names: OnceLock<HashSet<String>>,
     pub supported_crate_types: OnceLock<HashSet<String>>,
 
-    /// FIXME: rename this to the more canonical `no_capture`, or better, invert this to `capture`
-    /// to avoid `!nocapture` double-negatives.
-    pub nocapture: bool,
+    /// Should we capture console output that would be printed by test runners via their `stdout`
+    /// and `stderr` trait objects, or via the custom panic hook.
+    ///
+    /// The default is `true`. This can be disabled via the compiletest cli flag `--no-capture`
+    /// (which mirrors the libtest `--no-capture` flag).
+    pub capture: bool,
 
     /// Needed both to construct [`build_helper::git::GitConfig`].
     pub nightly_branch: String,

--- a/src/tools/compiletest/src/common.rs
+++ b/src/tools/compiletest/src/common.rs
@@ -321,10 +321,10 @@ pub struct Config {
     pub python: String,
 
     /// Path to the `src/tools/jsondocck/` bootstrap tool executable.
-    pub jsondocck_path: Option<String>,
+    pub jsondocck_path: Option<Utf8PathBuf>,
 
     /// Path to the `src/tools/jsondoclint/` bootstrap tool executable.
-    pub jsondoclint_path: Option<String>,
+    pub jsondoclint_path: Option<Utf8PathBuf>,
 
     /// Path to a host LLVM `FileCheck` executable.
     pub llvm_filecheck: Option<Utf8PathBuf>,
@@ -337,7 +337,7 @@ pub struct Config {
 
     /// The path to the **target** `clang` executable to run `clang`-based tests with. If `None`,
     /// then these tests will be ignored.
-    pub run_clang_based_tests_with: Option<String>,
+    pub run_clang_based_tests_with: Option<Utf8PathBuf>,
 
     /// Path to the directory containing the sources. This corresponds to the root folder of a
     /// `rust-lang/rust` checkout.
@@ -530,7 +530,7 @@ pub struct Config {
     ///
     /// FIXME: we are propagating a python from `PYTHONPATH`, not from an explicit config for gdb
     /// debugger script.
-    pub gdb: Option<String>,
+    pub gdb: Option<Utf8PathBuf>,
 
     /// Version of GDB, encoded as ((major * 1000) + minor) * 1000 + patch
     ///
@@ -575,7 +575,7 @@ pub struct Config {
     ///
     /// FIXME: take a look at this; this is piggy-backing off of gdb code paths but only for
     /// `arm-linux-androideabi` target.
-    pub adb_path: String,
+    pub adb_path: Utf8PathBuf,
 
     /// Extra parameter to run test suite on `arm-linux-androideabi`.
     ///
@@ -584,7 +584,7 @@ pub struct Config {
     ///
     /// FIXME: take a look at this; this is piggy-backing off of gdb code paths but only for
     /// `arm-linux-androideabi` target.
-    pub adb_test_dir: String,
+    pub adb_test_dir: Utf8PathBuf,
 
     /// Status whether android device available or not. When unavailable, this will cause tests to
     /// panic when the test binary is attempted to be run.
@@ -660,7 +660,7 @@ pub struct Config {
     pub llvm_components: String,
 
     /// Path to a NodeJS executable. Used for JS doctests, emscripten and WASM tests.
-    pub nodejs: Option<String>,
+    pub nodejs: Option<Utf8PathBuf>,
 
     /// Whether to rerun tests even if the inputs are unchanged.
     pub force_rerun: bool,

--- a/src/tools/compiletest/src/debuggers.rs
+++ b/src/tools/compiletest/src/debuggers.rs
@@ -133,7 +133,7 @@ pub(crate) fn discover_gdb(
     gdb: Option<String>,
     target: &str,
     android_cross_path: &Utf8Path,
-) -> Option<String> {
+) -> Option<Utf8PathBuf> {
     #[cfg(not(windows))]
     const GDB_FALLBACK: &str = "gdb";
     #[cfg(windows)]
@@ -155,10 +155,10 @@ pub(crate) fn discover_gdb(
         Some(ref s) => s.to_owned(),
     };
 
-    Some(gdb)
+    Some(Utf8PathBuf::from(gdb))
 }
 
-pub(crate) fn query_gdb_version(gdb: &str) -> Option<u32> {
+pub(crate) fn query_gdb_version(gdb: &Utf8Path) -> Option<u32> {
     let mut version_line = None;
     if let Ok(output) = Command::new(&gdb).arg("--version").output() {
         if let Some(first_line) = String::from_utf8_lossy(&output.stdout).lines().next() {

--- a/src/tools/compiletest/src/directives/needs.rs
+++ b/src/tools/compiletest/src/directives/needs.rs
@@ -367,7 +367,7 @@ impl CachedNeedsConditions {
             //
             // However, `rust-lld` is only located under the lib path, so we look for it there.
             rust_lld: config
-                .compile_lib_path
+                .host_compile_lib_path
                 .parent()
                 .expect("couldn't traverse to the parent of the specified --compile-lib-path")
                 .join("lib")

--- a/src/tools/compiletest/src/executor.rs
+++ b/src/tools/compiletest/src/executor.rs
@@ -196,10 +196,10 @@ enum CaptureKind {
 
 impl CaptureKind {
     fn for_config(config: &Config) -> Self {
-        if config.nocapture {
-            Self::None
-        } else {
+        if config.capture {
             Self::Capture { buf: output_capture::CaptureBuf::new() }
+        } else {
+            Self::None
         }
     }
 

--- a/src/tools/compiletest/src/lib.rs
+++ b/src/tools/compiletest/src/lib.rs
@@ -375,7 +375,7 @@ fn parse_config(args: Vec<String>) -> Config {
         fail_fast: matches.opt_present("fail-fast")
             || env::var_os("RUSTC_TEST_FAIL_FAST").is_some(),
 
-        compile_lib_path: make_absolute(opt_path(matches, "compile-lib-path")),
+        host_compile_lib_path: make_absolute(opt_path(matches, "compile-lib-path")),
         run_lib_path: make_absolute(opt_path(matches, "run-lib-path")),
         rustc_path: opt_path(matches, "rustc-path"),
         cargo_path: matches.opt_str("cargo-path").map(Utf8PathBuf::from),

--- a/src/tools/compiletest/src/lib.rs
+++ b/src/tools/compiletest/src/lib.rs
@@ -384,9 +384,11 @@ fn parse_config(args: Vec<String>) -> Config {
         rustdoc_path: matches.opt_str("rustdoc-path").map(Utf8PathBuf::from),
         coverage_dump_path: matches.opt_str("coverage-dump-path").map(Utf8PathBuf::from),
         python: matches.opt_str("python").unwrap(),
-        jsondocck_path: matches.opt_str("jsondocck-path"),
-        jsondoclint_path: matches.opt_str("jsondoclint-path"),
-        run_clang_based_tests_with: matches.opt_str("run-clang-based-tests-with"),
+        jsondocck_path: matches.opt_str("jsondocck-path").map(Utf8PathBuf::from),
+        jsondoclint_path: matches.opt_str("jsondoclint-path").map(Utf8PathBuf::from),
+        run_clang_based_tests_with: matches
+            .opt_str("run-clang-based-tests-with")
+            .map(Utf8PathBuf::from),
         llvm_filecheck: matches.opt_str("llvm-filecheck").map(Utf8PathBuf::from),
         llvm_bin_dir: matches.opt_str("llvm-bin-dir").map(Utf8PathBuf::from),
 
@@ -441,8 +443,8 @@ fn parse_config(args: Vec<String>) -> Config {
         llvm_version,
         system_llvm: matches.opt_present("system-llvm"),
         android_cross_path,
-        adb_path: opt_str2(matches.opt_str("adb-path")),
-        adb_test_dir: opt_str2(matches.opt_str("adb-test-dir")),
+        adb_path: Utf8PathBuf::from(opt_str2(matches.opt_str("adb-path"))),
+        adb_test_dir: Utf8PathBuf::from(opt_str2(matches.opt_str("adb-test-dir"))),
         adb_device_status: opt_str2(matches.opt_str("target")).contains("android")
             && "(none)" != opt_str2(matches.opt_str("adb-test-dir"))
             && !opt_str2(matches.opt_str("adb-test-dir")).is_empty(),
@@ -466,7 +468,7 @@ fn parse_config(args: Vec<String>) -> Config {
         target_linker: matches.opt_str("target-linker"),
         host_linker: matches.opt_str("host-linker"),
         llvm_components: matches.opt_str("llvm-components").unwrap(),
-        nodejs: matches.opt_str("nodejs"),
+        nodejs: matches.opt_str("nodejs").map(Utf8PathBuf::from),
 
         force_rerun: matches.opt_present("force-rerun"),
 

--- a/src/tools/compiletest/src/lib.rs
+++ b/src/tools/compiletest/src/lib.rs
@@ -476,7 +476,7 @@ fn parse_config(args: Vec<String>) -> Config {
         builtin_cfg_names: OnceLock::new(),
         supported_crate_types: OnceLock::new(),
 
-        nocapture: matches.opt_present("no-capture"),
+        capture: !matches.opt_present("no-capture"),
 
         nightly_branch: matches.opt_str("nightly-branch").unwrap(),
         git_merge_commit_email: matches.opt_str("git-merge-commit-email").unwrap(),

--- a/src/tools/compiletest/src/lib.rs
+++ b/src/tools/compiletest/src/lib.rs
@@ -376,7 +376,7 @@ fn parse_config(args: Vec<String>) -> Config {
             || env::var_os("RUSTC_TEST_FAIL_FAST").is_some(),
 
         host_compile_lib_path: make_absolute(opt_path(matches, "compile-lib-path")),
-        run_lib_path: make_absolute(opt_path(matches, "run-lib-path")),
+        target_run_lib_path: make_absolute(opt_path(matches, "run-lib-path")),
         rustc_path: opt_path(matches, "rustc-path"),
         cargo_path: matches.opt_str("cargo-path").map(Utf8PathBuf::from),
         stage0_rustc_path: matches.opt_str("stage0-rustc-path").map(Utf8PathBuf::from),
@@ -688,7 +688,7 @@ fn common_inputs_stamp(config: &Config) -> Stamp {
 
     stamp.add_dir(&src_root.join("src/etc/natvis"));
 
-    stamp.add_dir(&config.run_lib_path);
+    stamp.add_dir(&config.target_run_lib_path);
 
     if let Some(ref rustdoc_path) = config.rustdoc_path {
         stamp.add_path(&rustdoc_path);

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -1060,7 +1060,7 @@ impl<'test> TestCx<'test> {
         rustdoc.current_dir(current_dir);
         rustdoc
             .arg("-L")
-            .arg(self.config.run_lib_path.as_path())
+            .arg(self.config.target_run_lib_path.as_path())
             .arg("-L")
             .arg(aux_dir)
             .arg("-o")
@@ -1151,7 +1151,7 @@ impl<'test> TestCx<'test> {
 
                 self.compose_and_run(
                     test_client,
-                    self.config.run_lib_path.as_path(),
+                    self.config.target_run_lib_path.as_path(),
                     Some(aux_dir.as_path()),
                     None,
                 )
@@ -1166,7 +1166,7 @@ impl<'test> TestCx<'test> {
 
                 self.compose_and_run(
                     wr_run,
-                    self.config.run_lib_path.as_path(),
+                    self.config.target_run_lib_path.as_path(),
                     Some(aux_dir.as_path()),
                     None,
                 )
@@ -1181,7 +1181,7 @@ impl<'test> TestCx<'test> {
 
                 self.compose_and_run(
                     program,
-                    self.config.run_lib_path.as_path(),
+                    self.config.target_run_lib_path.as_path(),
                     Some(aux_dir.as_path()),
                     None,
                 )

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -458,7 +458,7 @@ impl<'test> TestCx<'test> {
 
         self.compose_and_run(
             rustc,
-            self.config.compile_lib_path.as_path(),
+            self.config.host_compile_lib_path.as_path(),
             Some(aux_dir.as_path()),
             src,
         )
@@ -1321,7 +1321,7 @@ impl<'test> TestCx<'test> {
         self.props.unset_rustc_env.iter().fold(&mut rustc, Command::env_remove);
         self.compose_and_run(
             rustc,
-            self.config.compile_lib_path.as_path(),
+            self.config.host_compile_lib_path.as_path(),
             Some(aux_dir.as_path()),
             input,
         )
@@ -1344,7 +1344,8 @@ impl<'test> TestCx<'test> {
         rustc.arg("-Cpanic=abort");
         rustc.args(self.props.minicore_compile_flags.clone());
 
-        let res = self.compose_and_run(rustc, self.config.compile_lib_path.as_path(), None, None);
+        let res =
+            self.compose_and_run(rustc, self.config.host_compile_lib_path.as_path(), None, None);
         if !res.status.success() {
             self.fatal_proc_rec(
                 &format!("auxiliary build of {} failed to compile: ", self.config.minicore_path),
@@ -1458,7 +1459,7 @@ impl<'test> TestCx<'test> {
 
         let auxres = aux_cx.compose_and_run(
             aux_rustc,
-            aux_cx.config.compile_lib_path.as_path(),
+            aux_cx.config.host_compile_lib_path.as_path(),
             Some(aux_dir.as_path()),
             None,
         );

--- a/src/tools/compiletest/src/runtest/debuginfo.rs
+++ b/src/tools/compiletest/src/runtest/debuginfo.rs
@@ -90,7 +90,7 @@ impl TestCx<'_> {
 
         let debugger_run_result = self.compose_and_run(
             cdb,
-            self.config.run_lib_path.as_path(),
+            self.config.target_run_lib_path.as_path(),
             None, // aux_path
             None, // input
         );
@@ -313,7 +313,7 @@ impl TestCx<'_> {
             gdb.args(debugger_opts).env("PYTHONPATH", pythonpath);
 
             debugger_run_result =
-                self.compose_and_run(gdb, self.config.run_lib_path.as_path(), None, None);
+                self.compose_and_run(gdb, self.config.target_run_lib_path.as_path(), None, None);
         }
 
         if !debugger_run_result.status.success() {

--- a/src/tools/compiletest/src/runtest/run_make.rs
+++ b/src/tools/compiletest/src/runtest/run_make.rs
@@ -172,7 +172,7 @@ impl TestCx<'_> {
             .env(dylib_env_var(), &env::join_paths(recipe_dylib_search_paths).unwrap())
             // Provide the directory to libraries that are needed to run the *compiler* invoked
             // by the recipe.
-            .env("HOST_RUSTC_DYLIB_PATH", &self.config.compile_lib_path)
+            .env("HOST_RUSTC_DYLIB_PATH", &self.config.host_compile_lib_path)
             // Provide the directory to libraries that might be needed to run binaries created
             // by a compiler invoked by the recipe.
             .env("TARGET_EXE_DYLIB_PATH", &self.config.run_lib_path)

--- a/src/tools/compiletest/src/runtest/run_make.rs
+++ b/src/tools/compiletest/src/runtest/run_make.rs
@@ -175,7 +175,7 @@ impl TestCx<'_> {
             .env("HOST_RUSTC_DYLIB_PATH", &self.config.host_compile_lib_path)
             // Provide the directory to libraries that might be needed to run binaries created
             // by a compiler invoked by the recipe.
-            .env("TARGET_EXE_DYLIB_PATH", &self.config.run_lib_path)
+            .env("TARGET_EXE_DYLIB_PATH", &self.config.target_run_lib_path)
             // Provide the target.
             .env("TARGET", &self.config.target)
             // Some tests unfortunately still need Python, so provide path to a Python interpreter.

--- a/src/tools/compiletest/src/rustdoc_gui_test.rs
+++ b/src/tools/compiletest/src/rustdoc_gui_test.rs
@@ -58,7 +58,7 @@ fn incomplete_config_for_rustdoc_gui_test() -> Config {
         edition: Default::default(),
         bless: Default::default(),
         fail_fast: Default::default(),
-        compile_lib_path: Utf8PathBuf::default(),
+        host_compile_lib_path: Utf8PathBuf::default(),
         run_lib_path: Utf8PathBuf::default(),
         rustc_path: Utf8PathBuf::default(),
         cargo_path: Default::default(),

--- a/src/tools/compiletest/src/rustdoc_gui_test.rs
+++ b/src/tools/compiletest/src/rustdoc_gui_test.rs
@@ -59,7 +59,7 @@ fn incomplete_config_for_rustdoc_gui_test() -> Config {
         bless: Default::default(),
         fail_fast: Default::default(),
         host_compile_lib_path: Utf8PathBuf::default(),
-        run_lib_path: Utf8PathBuf::default(),
+        target_run_lib_path: Utf8PathBuf::default(),
         rustc_path: Utf8PathBuf::default(),
         cargo_path: Default::default(),
         stage0_rustc_path: Default::default(),

--- a/src/tools/compiletest/src/rustdoc_gui_test.rs
+++ b/src/tools/compiletest/src/rustdoc_gui_test.rs
@@ -130,7 +130,7 @@ fn incomplete_config_for_rustdoc_gui_test() -> Config {
         target_cfgs: Default::default(),
         builtin_cfg_names: Default::default(),
         supported_crate_types: Default::default(),
-        nocapture: Default::default(),
+        capture: Default::default(),
         nightly_branch: Default::default(),
         git_merge_commit_email: Default::default(),
         profiler_runtime: Default::default(),


### PR DESCRIPTION
A few batched `compiletest` `Config` self-consistency fixups, mostly to get it out of the way for follow-up changes I would like to make (namely, I would like to slightly cleanup the config parsing logic).

### Review remarks

Changes are best reviewed commit-by-commit. This PR should contain no functional changes.


r? @Zalathar (or bootstrap/compiler)