### PR TITLE
coverage: Sort the expansion tree to help choose a single BCB for child expansions

### DIFF
--- a/compiler/rustc_mir_transform/src/coverage/mod.rs
+++ b/compiler/rustc_mir_transform/src/coverage/mod.rs
@@ -73,12 +73,13 @@ fn instrument_function_for_coverage<'tcx>(tcx: TyCtxt<'tcx>, mir_body: &mut mir:
     ////////////////////////////////////////////////////
     // Extract coverage spans and other mapping info from MIR.
     let ExtractedMappings { mappings } =
-        mappings::extract_mappings_from_mir(tcx, mir_body, &hir_info, &graph);
-    if mappings.is_empty() {
-        // No spans could be converted into valid mappings, so skip this function.
-        debug!("no spans could be converted into valid mappings; skipping");
-        return;
-    }
+        match mappings::extract_mappings_from_mir(tcx, mir_body, &hir_info, &graph) {
+            Ok(m) => m,
+            Err(error) => {
+                tracing::debug!(?error, "mapping extraction failed; skipping this function");
+                return;
+            }
+        };
 
     // Use the coverage graph to prepare intermediate data that will eventually
     // be used to assign physical counters and counter expressions to points in

--- a/compiler/rustc_mir_transform/src/lib.rs
+++ b/compiler/rustc_mir_transform/src/lib.rs
@@ -5,7 +5,6 @@
 #![feature(const_type_name)]
 #![feature(cow_is_borrowed)]
 #![feature(file_buffered)]
-#![feature(gen_blocks)]
 #![feature(if_let_guard)]
 #![feature(impl_trait_in_assoc_type)]
 #![feature(try_blocks)]

--- a/tests/coverage/macros/pass-through.cov-map
+++ b/tests/coverage/macros/pass-through.cov-map
@@ -1,0 +1,57 @@
+Function name: pass_through::uses_inner_macro
+Raw bytes (51): 0x[01, 01, 01, 01, 05, 09, 01, 24, 01, 00, 16, 01, 01, 08, 00, 1d, 05, 01, 09, 00, 0c, 05, 00, 0d, 00, 21, 05, 01, 09, 00, 15, 05, 01, 09, 00, 0c, 05, 00, 0d, 00, 20, 02, 01, 05, 00, 06, 01, 01, 01, 00, 02]
+Number of files: 1
+- file 0 => $DIR/pass-through.rs
+Number of expressions: 1
+- expression 0 operands: lhs = Counter(0), rhs = Counter(1)
+Number of file 0 mappings: 9
+- Code(Counter(0)) at (prev + 36, 1) to (start + 0, 22)
+- Code(Counter(0)) at (prev + 1, 8) to (start + 0, 29)
+- Code(Counter(1)) at (prev + 1, 9) to (start + 0, 12)
+- Code(Counter(1)) at (prev + 0, 13) to (start + 0, 33)
+- Code(Counter(1)) at (prev + 1, 9) to (start + 0, 21)
+- Code(Counter(1)) at (prev + 1, 9) to (start + 0, 12)
+- Code(Counter(1)) at (prev + 0, 13) to (start + 0, 32)
+- Code(Expression(0, Sub)) at (prev + 1, 5) to (start + 0, 6)
+    = (c0 - c1)
+- Code(Counter(0)) at (prev + 1, 1) to (start + 0, 2)
+Highest counter ID seen: c1
+
+Function name: pass_through::uses_middle_macro
+Raw bytes (51): 0x[01, 01, 01, 01, 05, 09, 01, 2c, 01, 00, 17, 01, 01, 08, 00, 1d, 05, 01, 09, 00, 0c, 05, 00, 0d, 00, 22, 05, 01, 09, 00, 16, 05, 01, 09, 00, 0c, 05, 00, 0d, 00, 21, 02, 01, 05, 00, 06, 01, 01, 01, 00, 02]
+Number of files: 1
+- file 0 => $DIR/pass-through.rs
+Number of expressions: 1
+- expression 0 operands: lhs = Counter(0), rhs = Counter(1)
+Number of file 0 mappings: 9
+- Code(Counter(0)) at (prev + 44, 1) to (start + 0, 23)
+- Code(Counter(0)) at (prev + 1, 8) to (start + 0, 29)
+- Code(Counter(1)) at (prev + 1, 9) to (start + 0, 12)
+- Code(Counter(1)) at (prev + 0, 13) to (start + 0, 34)
+- Code(Counter(1)) at (prev + 1, 9) to (start + 0, 22)
+- Code(Counter(1)) at (prev + 1, 9) to (start + 0, 12)
+- Code(Counter(1)) at (prev + 0, 13) to (start + 0, 33)
+- Code(Expression(0, Sub)) at (prev + 1, 5) to (start + 0, 6)
+    = (c0 - c1)
+- Code(Counter(0)) at (prev + 1, 1) to (start + 0, 2)
+Highest counter ID seen: c1
+
+Function name: pass_through::uses_outer_macro
+Raw bytes (51): 0x[01, 01, 01, 01, 05, 09, 01, 34, 01, 00, 16, 01, 01, 08, 00, 1d, 05, 01, 09, 00, 0c, 05, 00, 0d, 00, 21, 05, 01, 09, 00, 15, 05, 01, 09, 00, 0c, 05, 00, 0d, 00, 20, 02, 01, 05, 00, 06, 01, 01, 01, 00, 02]
+Number of files: 1
+- file 0 => $DIR/pass-through.rs
+Number of expressions: 1
+- expression 0 operands: lhs = Counter(0), rhs = Counter(1)
+Number of file 0 mappings: 9
+- Code(Counter(0)) at (prev + 52, 1) to (start + 0, 22)
+- Code(Counter(0)) at (prev + 1, 8) to (start + 0, 29)
+- Code(Counter(1)) at (prev + 1, 9) to (start + 0, 12)
+- Code(Counter(1)) at (prev + 0, 13) to (start + 0, 33)
+- Code(Counter(1)) at (prev + 1, 9) to (start + 0, 21)
+- Code(Counter(1)) at (prev + 1, 9) to (start + 0, 12)
+- Code(Counter(1)) at (prev + 0, 13) to (start + 0, 32)
+- Code(Expression(0, Sub)) at (prev + 1, 5) to (start + 0, 6)
+    = (c0 - c1)
+- Code(Counter(0)) at (prev + 1, 1) to (start + 0, 2)
+Highest counter ID seen: c1
+

--- a/tests/coverage/macros/pass-through.coverage
+++ b/tests/coverage/macros/pass-through.coverage
@@ -1,0 +1,71 @@
+   LL|       |#![feature(coverage_attribute)]
+   LL|       |//@ edition: 2024
+   LL|       |
+   LL|       |// Test that when a macro expands to another macro, without any significant
+   LL|       |// spans of its own, that this doesn't cause coverage instrumentation to give
+   LL|       |// up and ignore the inner spans.
+   LL|       |
+   LL|       |macro_rules! inner_macro {
+   LL|       |    () => {
+   LL|       |        if core::hint::black_box(true) {
+   LL|       |            say("true");
+   LL|       |        } else {
+   LL|       |            say("false");
+   LL|       |        }
+   LL|       |    };
+   LL|       |}
+   LL|       |
+   LL|       |macro_rules! middle_macro {
+   LL|       |    () => {
+   LL|       |        inner_macro!()
+   LL|       |    };
+   LL|       |}
+   LL|       |
+   LL|       |macro_rules! outer_macro {
+   LL|       |    () => {
+   LL|       |        middle_macro!()
+   LL|       |    };
+   LL|       |}
+   LL|       |
+   LL|       |// In each of these three functions, the macro call should be instrumented,
+   LL|       |// and should have an execution count of 1.
+   LL|       |//
+   LL|       |// Each function contains some extra code to ensure that control flow is
+   LL|       |// non-trivial.
+   LL|       |
+   LL|      1|fn uses_inner_macro() {
+   LL|      1|    if core::hint::black_box(true) {
+   LL|      1|        say("before inner_macro");
+   LL|      1|        inner_macro!();
+   LL|      1|        say("after inner_macro");
+   LL|      0|    }
+   LL|      1|}
+   LL|       |
+   LL|      1|fn uses_middle_macro() {
+   LL|      1|    if core::hint::black_box(true) {
+   LL|      1|        say("before middle_macro");
+   LL|      1|        middle_macro!();
+   LL|      1|        say("after middle_macro")
+   LL|      0|    }
+   LL|      1|}
+   LL|       |
+   LL|      1|fn uses_outer_macro() {
+   LL|      1|    if core::hint::black_box(true) {
+   LL|      1|        say("before outer_macro");
+   LL|      1|        outer_macro!();
+   LL|      1|        say("after outer_macro");
+   LL|      0|    }
+   LL|      1|}
+   LL|       |
+   LL|       |#[coverage(off)]
+   LL|       |fn main() {
+   LL|       |    uses_inner_macro();
+   LL|       |    uses_middle_macro();
+   LL|       |    uses_outer_macro();
+   LL|       |}
+   LL|       |
+   LL|       |#[coverage(off)]
+   LL|       |fn say(message: &str) {
+   LL|       |    println!("{message}");
+   LL|       |}
+

--- a/tests/coverage/macros/pass-through.rs
+++ b/tests/coverage/macros/pass-through.rs
@@ -1,0 +1,70 @@
+#![feature(coverage_attribute)]
+//@ edition: 2024
+
+// Test that when a macro expands to another macro, without any significant
+// spans of its own, that this doesn't cause coverage instrumentation to give
+// up and ignore the inner spans.
+
+macro_rules! inner_macro {
+    () => {
+        if core::hint::black_box(true) {
+            say("true");
+        } else {
+            say("false");
+        }
+    };
+}
+
+macro_rules! middle_macro {
+    () => {
+        inner_macro!()
+    };
+}
+
+macro_rules! outer_macro {
+    () => {
+        middle_macro!()
+    };
+}
+
+// In each of these three functions, the macro call should be instrumented,
+// and should have an execution count of 1.
+//
+// Each function contains some extra code to ensure that control flow is
+// non-trivial.
+
+fn uses_inner_macro() {
+    if core::hint::black_box(true) {
+        say("before inner_macro");
+        inner_macro!();
+        say("after inner_macro");
+    }
+}
+
+fn uses_middle_macro() {
+    if core::hint::black_box(true) {
+        say("before middle_macro");
+        middle_macro!();
+        say("after middle_macro")
+    }
+}
+
+fn uses_outer_macro() {
+    if core::hint::black_box(true) {
+        say("before outer_macro");
+        outer_macro!();
+        say("after outer_macro");
+    }
+}
+
+#[coverage(off)]
+fn main() {
+    uses_inner_macro();
+    uses_middle_macro();
+    uses_outer_macro();
+}
+
+#[coverage(off)]
+fn say(message: &str) {
+    println!("{message}");
+}


### PR DESCRIPTION
This PR is another incremental step on the road towards proper coverage instrumentation of expansion regions.

When creating coverage mappings for each relevant span in a function body, the current implementation also needs to do a separate tree traversal for each child expansion (e.g. macro calls like `println!("foo")`), in order to associate a single control-flow point (BCB) with that macro call's span.

This PR changes things so that we now keep track of the “minimum” and ”maximum” BCB associated with each node in the expansion tree, which makes it much easier for the parent node to get a single BCB (min or max) for each of its child expansions.

In order to make this (relatively) easy, we first need to sort the tree nodes into depth-first order. Once that's taken care of, we can iterate over all the nodes in reverse order, knowing that each node's children will have been visited before visiting the node itself.