### PR TITLE
`is_const_default_method` is completely handled by the `constness` query

### DIFF
--- a/compiler/rustc_const_eval/src/check_consts/mod.rs
+++ b/compiler/rustc_const_eval/src/check_consts/mod.rs
@@ -95,8 +95,10 @@ pub fn rustc_allow_const_fn_unstable(
 /// unstable features, not even recursively), and those that are not.
 pub fn is_fn_or_trait_safe_to_expose_on_stable(tcx: TyCtxt<'_>, def_id: DefId) -> bool {
     // A default body in a `const trait` is const-stable when the trait is const-stable.
-    if tcx.is_const_default_method(def_id) {
-        return is_fn_or_trait_safe_to_expose_on_stable(tcx, tcx.parent(def_id));
+    if let Some(trait_id) = tcx.trait_of_assoc(def_id)
+        && tcx.is_const_trait(trait_id)
+    {
+        return is_fn_or_trait_safe_to_expose_on_stable(tcx, trait_id);
     }
 
     match tcx.lookup_const_stability(def_id) {

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -1132,8 +1132,7 @@ fn should_encode_mir(
                     && (generics.requires_monomorphization(tcx)
                         || tcx.cross_crate_inlinable(def_id)));
             // The function has a `const` modifier or is in a `const trait`.
-            let is_const_fn = tcx.is_const_fn(def_id.to_def_id())
-                || tcx.is_const_default_method(def_id.to_def_id());
+            let is_const_fn = tcx.is_const_fn(def_id.to_def_id());
             (is_const_fn, opt)
         }
         // The others don't have MIR.

--- a/compiler/rustc_middle/src/hir/map.rs
+++ b/compiler/rustc_middle/src/hir/map.rs
@@ -321,7 +321,6 @@ impl<'tcx> TyCtxt<'tcx> {
             BodyOwnerKind::Fn | BodyOwnerKind::Closure if self.is_const_fn(def_id) => {
                 ConstContext::ConstFn
             }
-            BodyOwnerKind::Fn if self.is_const_default_method(def_id) => ConstContext::ConstFn,
             BodyOwnerKind::Fn | BodyOwnerKind::Closure | BodyOwnerKind::GlobalAsm => return None,
         };
 

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -2224,11 +2224,6 @@ impl<'tcx> TyCtxt<'tcx> {
         self.trait_def(def_id).constness == hir::Constness::Const
     }
 
-    #[inline]
-    pub fn is_const_default_method(self, def_id: DefId) -> bool {
-        matches!(self.trait_of_assoc(def_id), Some(trait_id) if self.is_const_trait(trait_id))
-    }
-
     pub fn impl_method_has_trait_impl_trait_tys(self, def_id: DefId) -> bool {
         if self.def_kind(def_id) != DefKind::AssocFn {
             return false;

--- a/compiler/rustc_mir_transform/src/lib.rs
+++ b/compiler/rustc_mir_transform/src/lib.rs
@@ -429,8 +429,7 @@ fn mir_promoted(
 
     let const_qualifs = match tcx.def_kind(def) {
         DefKind::Fn | DefKind::AssocFn | DefKind::Closure
-            if tcx.constness(def) == hir::Constness::Const
-                || tcx.is_const_default_method(def.to_def_id()) =>
+            if tcx.constness(def) == hir::Constness::Const =>
         {
             tcx.mir_const_qualif(def)
         }


### PR DESCRIPTION
After  rust-lang/rust#149444 this function became obsolete

r? @fee1-dead 