### PR TITLE
Revert #149516 to fix i686-pc-windows-gnu host

### DIFF
--- a/src/ci/scripts/install-mingw.sh
+++ b/src/ci/scripts/install-mingw.sh
@@ -47,6 +47,12 @@ if isWindows && isKnownToBeMingwBuild; then
             ;;
     esac
 
+    # Stop /msys64/bin from being prepended to PATH by adding the bin directory manually.
+    # Note that this intentionally uses a Windows style path instead of the msys2 path to
+    # avoid being auto-translated into `/usr/bin`, which will not have the desired effect.
+    msys2Path="c:/msys64"
+    ciCommandAddPath "${msys2Path}/usr/bin"
+
     case "${mingw_archive}" in
         *.7z)
             curl -o mingw.7z "${MIRRORS_BASE}/${mingw_archive}"
@@ -67,4 +73,12 @@ if isWindows && isKnownToBeMingwBuild; then
     esac
 
     ciCommandAddPath "$(cygpath -m "$(pwd)/${mingw_dir}/bin")"
+
+    # MSYS2 is not installed on AArch64 runners
+    if [[ "${CI_JOB_NAME}" != *aarch64-llvm* ]]; then
+        # Initialize mingw for the user.
+        # This should be done by github but isn't for some reason.
+        # (see https://github.com/actions/runner-images/issues/12600)
+        /c/msys64/usr/bin/bash -lc ' '
+    fi
 fi


### PR DESCRIPTION
Revert rust-lang/rust#149516 because it caused dist to pick up x86_64 `libwinpthreads.dll` dependency, resulting in broken toolchain.

Note, I didn't use the procedure explained at: https://forge.rust-lang.org/compiler/reviews.html#reverts because the revert button isn't there.

This reverts commit 5afd8ff8df0e0850b4b5671676f4bb057b33dada, reversing
changes made to 7cb02f975248447461a95110eb466c76cb3ac7cf.
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
