### PR TITLE
Use branch name instead of HEAD when unshallowing

### DIFF
--- a/src/ci/scripts/checkout-submodules.sh
+++ b/src/ci/scripts/checkout-submodules.sh
@@ -17,7 +17,7 @@ ci_dir=$(cd $(dirname $0) && pwd)/..
 # On the beta channel we'll be automatically calculating the prerelease version
 # via the git history, so unshallow our shallow clone from CI.
 if [ "$(releaseChannel)" = "beta" ]; then
-  git fetch origin --unshallow beta HEAD
+  git fetch origin --unshallow beta main
 fi
 
 function fetch_github_commit_archive {


### PR DESCRIPTION
Fixes a regression with the beta channel that was discovered in https://github.com/rust-lang/rust/pull/149572.

r? @cuviper