### PR TITLE
Implement benchmarks for uN::{gather,scatter}_bits

### DIFF
--- a/library/coretests/benches/lib.rs
+++ b/library/coretests/benches/lib.rs
@@ -8,6 +8,7 @@
 #![feature(iter_array_chunks)]
 #![feature(iter_next_chunk)]
 #![feature(iter_advance_by)]
+#![feature(uint_gather_scatter_bits)]
 
 extern crate test;
 

--- a/library/coretests/benches/num/int_bits/mod.rs
+++ b/library/coretests/benches/num/int_bits/mod.rs
@@ -1,0 +1,62 @@
+const BYTES: usize = 1 << 10;
+
+macro_rules! bench_template {
+    ($op:path, $name:ident, $mask:expr) => {
+        #[bench]
+        fn $name(bench: &mut ::test::Bencher) {
+            use ::rand::Rng;
+            let mut rng = crate::bench_rng();
+            let mut dst = vec![0; ITERATIONS];
+            let src1: Vec<U> = (0..ITERATIONS).map(|_| rng.random_range(0..=U::MAX)).collect();
+            let mut src2: Vec<U> = (0..ITERATIONS).map(|_| rng.random_range(0..=U::MAX)).collect();
+            // Fix the loop invariant mask
+            src2[0] = U::MAX / 3;
+            let dst = dst.first_chunk_mut().unwrap();
+            let src1 = src1.first_chunk().unwrap();
+            let src2 = src2.first_chunk().unwrap();
+
+            #[allow(unused)]
+            fn vectored(dst: &mut Data, src1: &Data, src2: &Data) {
+                let mask = $mask;
+                for k in 0..ITERATIONS {
+                    dst[k] = $op(src1[k], mask(src2, k));
+                }
+            }
+            let f: fn(&mut Data, &Data, &Data) = vectored;
+            let f = ::test::black_box(f);
+
+            bench.iter(|| {
+                f(dst, src1, src2);
+            });
+        }
+    };
+}
+
+macro_rules! bench_type {
+    ($U:ident) => {
+        mod $U {
+            type U = $U;
+            const ITERATIONS: usize = super::BYTES / size_of::<U>();
+            type Data = [U; ITERATIONS];
+            bench_mask_kind!(constant, |_, _| const { U::MAX / 3 });
+            bench_mask_kind!(invariant, |src: &Data, _| src[0]);
+            bench_mask_kind!(variable, |src: &Data, k| src[k]);
+        }
+    };
+}
+
+macro_rules! bench_mask_kind {
+    ($mask_kind:ident, $mask:expr) => {
+        mod $mask_kind {
+            use super::{Data, ITERATIONS, U};
+            bench_template!(U::gather_bits, gather_bits, $mask);
+            bench_template!(U::scatter_bits, scatter_bits, $mask);
+        }
+    };
+}
+
+bench_type!(u8);
+bench_type!(u16);
+bench_type!(u32);
+bench_type!(u64);
+bench_type!(u128);

--- a/library/coretests/benches/num/mod.rs
+++ b/library/coretests/benches/num/mod.rs
@@ -1,5 +1,6 @@
 mod dec2flt;
 mod flt2dec;
+mod int_bits;
 mod int_log;
 mod int_pow;
 mod int_sqrt;


### PR DESCRIPTION
Feature gate: #![feature(uint_gather_scatter_bits)]
Tracking issue: https://github.com/rust-lang/rust/issues/149069
Accepted ACP: https://github.com/rust-lang/libs-team/issues/695#issuecomment-3549284861

For each method, there are three benchmarks, which differ in that the mask (second) argument is one of:
 - constant at compile time
 - runtime value but invariant for the measured loop
 - different for each call

Sample output
```text
    num::int_bits::u32::constant::gather_bits      555.82ns/iter   +/- 22.41
    num::int_bits::u32::constant::scatter_bits     545.45ns/iter  +/- 124.26
    num::int_bits::u32::invariant::gather_bits    8178.86ns/iter  +/- 217.37
    num::int_bits::u32::invariant::scatter_bits   7135.95ns/iter  +/- 214.51
    num::int_bits::u32::variable::gather_bits    10539.29ns/iter  +/- 198.90
    num::int_bits::u32::variable::scatter_bits    9671.26ns/iter  +/- 254.88
```
(and similarly for the other `uN` types)