### PR TITLE
Apply the `bors` environment also to the `outcome` job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -313,6 +313,7 @@ jobs:
     needs: [ calculate_matrix, job ]
     # !cancelled() executes the job regardless of whether the previous jobs passed or failed
     if: ${{ !cancelled() && contains(fromJSON('["auto", "try"]'), needs.calculate_matrix.outputs.run_type) }}
+    environment: ${{ ((github.repository == 'rust-lang/rust' && (github.ref == 'refs/heads/try' || github.ref == 'refs/heads/try-perf' || github.ref == 'refs/heads/automation/bors/try' || github.ref == 'refs/heads/auto')) && 'bors') || '' }}
     steps:
       - name: checkout the source code
         uses: actions/checkout@v5


### PR DESCRIPTION
To fix passing the toolstate token to `publish_toolstate.sh`. Found in https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/TOOLSTATE_REPO_ACCESS_TOKEN/with/561580948.

r? ehuss
