### PR TITLE
Allow running `x test reference` locally

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ exclude = [
   "compiler/rustc_codegen_gcc",
   "src/bootstrap",
   "tests/rustdoc-gui",
+  "src/doc/reference/mdbook-spec",
   # HACK(eddyb) This hardcodes the fact that our CI uses `/checkout/obj`.
   "obj",
 ]

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -2496,7 +2496,9 @@ impl BookTest {
         let path = builder.src.join(&self.path);
         // Books often have feature-gated example text.
         rustbook_cmd.env("RUSTC_BOOTSTRAP", "1");
-        rustbook_cmd.env("PATH", new_path).arg("test").arg(path);
+        rustbook_cmd.env("PATH", new_path).arg("test").arg(&path);
+        // The reference has a nested `cargo run` in `preprocessor.spec` which uses relative paths.
+        rustbook_cmd.current_dir(&path);
 
         // Books may also need to build dependencies. For example, `TheBook` has
         // code samples which use the `trpl` crate. For the `rustdoc` invocation


### PR DESCRIPTION
Previously this would break for me with:
```
Testing stage2 mdbook src/doc/reference (aarch64-apple-darwin)
error: manifest path `mdbook-spec/Cargo.toml` does not exist
```
but then would say "build completed successfully" ... I guess that's related to toolstate somehow.

I have no idea how this ever passed in CI.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
