### PR TITLE
Change `aarch64-unknown-none` to generate static-PIE binaries by default

### DIFF
--- a/compiler/rustc_target/src/spec/targets/aarch64_unknown_none.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_unknown_none.rs
@@ -7,7 +7,7 @@
 // For example, `-C target-cpu=cortex-a53`.
 
 use crate::spec::{
-    Arch, Cc, LinkerFlavor, Lld, PanicStrategy, RelocModel, SanitizerSet, StackProbeType, Target,
+    Arch, Cc, LinkerFlavor, Lld, PanicStrategy, SanitizerSet, StackProbeType, Target,
     TargetMetadata, TargetOptions,
 };
 
@@ -22,12 +22,13 @@ pub(crate) fn target() -> Target {
         ),
         features: "+v8a,+strict-align,+neon".into(),
         supported_sanitizers: SanitizerSet::KCFI | SanitizerSet::KERNELADDRESS,
-        relocation_model: RelocModel::Static,
         disable_redzone: true,
         max_atomic_width: Some(128),
         stack_probes: StackProbeType::Inline,
         panic_strategy: PanicStrategy::Abort,
         default_uwtable: true,
+        position_independent_executables: true,
+        static_position_independent_executables: true,
         ..Default::default()
     };
     Target {

--- a/compiler/rustc_target/src/spec/targets/aarch64_unknown_none_softfloat.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_unknown_none_softfloat.rs
@@ -7,8 +7,8 @@
 // For example, `-C target-cpu=cortex-a53`.
 
 use crate::spec::{
-    Abi, Arch, Cc, LinkerFlavor, Lld, PanicStrategy, RelocModel, SanitizerSet, StackProbeType,
-    Target, TargetMetadata, TargetOptions,
+    Abi, Arch, Cc, LinkerFlavor, Lld, PanicStrategy, SanitizerSet, StackProbeType, Target,
+    TargetMetadata, TargetOptions,
 };
 
 pub(crate) fn target() -> Target {
@@ -17,13 +17,14 @@ pub(crate) fn target() -> Target {
         linker_flavor: LinkerFlavor::Gnu(Cc::No, Lld::Yes),
         linker: Some("rust-lld".into()),
         features: "+v8a,+strict-align,-neon".into(),
-        relocation_model: RelocModel::Static,
         disable_redzone: true,
         max_atomic_width: Some(128),
         supported_sanitizers: SanitizerSet::KCFI | SanitizerSet::KERNELADDRESS,
         stack_probes: StackProbeType::Inline,
         panic_strategy: PanicStrategy::Abort,
         default_uwtable: true,
+        position_independent_executables: true,
+        static_position_independent_executables: true,
         ..Default::default()
     };
     Target {

--- a/tests/codegen-llvm/abi-efiapi.rs
+++ b/tests/codegen-llvm/abi-efiapi.rs
@@ -23,7 +23,7 @@ use minicore::*;
 
 //x86_64: define win64cc void @has_efiapi
 //i686: define void @has_efiapi
-//aarch64: define dso_local void @has_efiapi
+//aarch64: define void @has_efiapi
 //arm: define dso_local arm_aapcscc void @has_efiapi
 //riscv: define dso_local void @has_efiapi
 #[no_mangle]


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/149622)*
<!-- homu-ignore:end -->

Currently, `aarch64-unknown-none` generates static position *dependent* binaries which must be loaded at a fixed address in memory. The [openVMM](https://github.com/microsoft/openvmm) project uses the `*-unknown-none` targets for an embedded-like environment but needs the binary to be loadable to any memory address. Currently, the `x86_64-unknown-none` target is configured to allow this by default but the `aarch64-unknown-none` target is not. 

This commit changes the defaults for the `aarch64-unknown-none` target to enable static-PIE binaries which aligns the target more closely with the corresponding `x86_64-unknown-none` target. If users prefer the prior behavior, they can request that via `-Crelocation-model=static`.

cc @BartMassey as lead maintainer for this target in REWG
