### PR TITLE
Don't require a normal tool build of clippy/rustfmt when running their test steps

### DIFF
--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -524,8 +524,7 @@ impl Step for Rustfmt {
 
     /// Runs `cargo test` for rustfmt.
     fn run(self, builder: &Builder<'_>) {
-        let tool_result = builder.ensure(tool::Rustfmt::from_compilers(self.compilers));
-        let build_compiler = tool_result.build_compiler;
+        let build_compiler = self.compilers.build_compiler();
         let target = self.compilers.target();
 
         let mut cargo = tool::prepare_tool_cargo(
@@ -869,11 +868,9 @@ impl Step for Clippy {
         // We need to carefully distinguish the compiler that builds clippy, and the compiler
         // that is linked into the clippy being tested. `target_compiler` is the latter,
         // and it must also be used by clippy's test runner to build tests and their dependencies.
-        let compilers = self.compilers;
-        let target_compiler = compilers.target_compiler();
+        let target_compiler = self.compilers.target_compiler();
+        let build_compiler = self.compilers.build_compiler();
 
-        let tool_result = builder.ensure(tool::Clippy::from_compilers(compilers));
-        let build_compiler = tool_result.build_compiler;
         let mut cargo = tool::prepare_tool_cargo(
             builder,
             build_compiler,


### PR DESCRIPTION
This is redundant and wasteful.

Noticed in https://github.com/rust-lang/rust/pull/147372#discussion_r2585886897.