### PR TITLE
Fix requires_lto targets needing lto set in cargo

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/write.rs
+++ b/compiler/rustc_codegen_ssa/src/back/write.rs
@@ -156,7 +156,7 @@ impl ModuleConfig {
             // `#![no_builtins]` is assumed to not participate in LTO and
             // instead goes on to generate object code.
             EmitObj::Bitcode
-        } else if need_bitcode_in_object(tcx) {
+        } else if need_bitcode_in_object(tcx) || sess.target.requires_lto {
             EmitObj::ObjectCode(BitcodeSection::Full)
         } else {
             EmitObj::ObjectCode(BitcodeSection::None)

--- a/src/doc/rustc/src/platform-support/amdgcn-amd-amdhsa.md
+++ b/src/doc/rustc/src/platform-support/amdgcn-amd-amdhsa.md
@@ -59,11 +59,6 @@ Build the library as `cdylib`:
 # Cargo.toml
 [lib]
 crate-type = ["cdylib"]
-
-[profile.dev]
-lto = true # LTO must be explicitly enabled for now
-[profile.release]
-lto = true
 ```
 
 The target-cpu must be from the list [supported by LLVM] (or printed with `rustc --target amdgcn-amd-amdhsa --print target-cpus`).

--- a/tests/run-make-cargo/amdgpu-lto/Cargo.toml
+++ b/tests/run-make-cargo/amdgpu-lto/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "amdgpu_lto"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+path = "lib.rs"
+crate-type = ["cdylib"]

--- a/tests/run-make-cargo/amdgpu-lto/lib.rs
+++ b/tests/run-make-cargo/amdgpu-lto/lib.rs
@@ -1,0 +1,15 @@
+#![feature(abi_gpu_kernel)]
+#![no_std]
+
+#[panic_handler]
+fn panic_handler(_info: &core::panic::PanicInfo) -> ! {
+    loop {}
+}
+
+#[unsafe(no_mangle)]
+fn foo(a: i32, b: i32) -> i32 {
+    a + b
+}
+
+#[unsafe(no_mangle)]
+extern "gpu-kernel" fn kernel() {}

--- a/tests/run-make-cargo/amdgpu-lto/rmake.rs
+++ b/tests/run-make-cargo/amdgpu-lto/rmake.rs
@@ -1,0 +1,28 @@
+// Check that compiling for the amdgpu target which needs LTO works with a default
+// cargo configuration.
+
+//@ needs-llvm-components: amdgpu
+//@ needs-rust-lld
+
+#![deny(warnings)]
+
+use run_make_support::{cargo, path};
+
+fn main() {
+    let target_dir = path("target");
+
+    cargo()
+        .args(&[
+            "build",
+            "--release",
+            "--lib",
+            "--manifest-path",
+            "Cargo.toml",
+            "-Zbuild-std=core",
+            "--target",
+            "amdgcn-amd-amdhsa",
+        ])
+        .env("RUSTFLAGS", "-Ctarget-cpu=gfx900")
+        .env("CARGO_TARGET_DIR", &target_dir)
+        .run();
+}


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/149624)*
<!-- homu-ignore:end -->

Targets that set `requires_lto = true` were not actually using lto when compiling with cargo by default. They needed an extra `lto = true` in `Cargo.toml` to work.

Fix this by letting lto take precedence over the `embed_bitcode` flag when lto is required by a target.

If both these flags would be supplied by the user, an error is generated. However, this did not happen when lto was requested by the target instead of the user.

Fixes rust-lang/rust#148514
Tracking issue: rust-lang/rust#135024

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
