### PR TITLE
Point to the item that is incorrectly annotated with `#[diagnostic::on_const]`

### DIFF
--- a/compiler/rustc_passes/messages.ftl
+++ b/compiler/rustc_passes/messages.ftl
@@ -98,6 +98,7 @@ passes_deprecated_attribute =
 
 passes_diagnostic_diagnostic_on_const_only_for_trait_impls =
     `#[diagnostic::on_const]` can only be applied to trait impls
+    .label = not a trait impl
 
 passes_diagnostic_diagnostic_on_unimplemented_only_for_traits =
     `#[diagnostic::on_unimplemented]` can only be applied to trait definitions

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -57,7 +57,10 @@ struct DiagnosticOnUnimplementedOnlyForTraits;
 
 #[derive(LintDiagnostic)]
 #[diag(passes_diagnostic_diagnostic_on_const_only_for_trait_impls)]
-struct DiagnosticOnConstOnlyForTraitImpls;
+struct DiagnosticOnConstOnlyForTraitImpls {
+    #[label]
+    item_span: Span,
+}
 
 fn target_from_impl_item<'tcx>(tcx: TyCtxt<'tcx>, impl_item: &hir::ImplItem<'_>) -> Target {
     match impl_item.kind {
@@ -541,11 +544,12 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                 ItemLike::ForeignItem => {}
             }
         }
+        let item_span = self.tcx.hir_span(hir_id);
         self.tcx.emit_node_span_lint(
             MISPLACED_DIAGNOSTIC_ATTRIBUTES,
             hir_id,
             attr_span,
-            DiagnosticOnConstOnlyForTraitImpls,
+            DiagnosticOnConstOnlyForTraitImpls { item_span },
         );
     }
 

--- a/tests/ui/diagnostic_namespace/on_const/misplaced_attr.stderr
+++ b/tests/ui/diagnostic_namespace/on_const/misplaced_attr.stderr
@@ -3,6 +3,9 @@ error: `#[diagnostic::on_const]` can only be applied to trait impls
    |
 LL | #[diagnostic::on_const(message = "tadaa", note = "boing")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |
+LL | pub struct Foo;
+   | -------------- not a trait impl
    |
 note: the lint level is defined here
   --> $DIR/misplaced_attr.rs:2:9
@@ -15,18 +18,27 @@ error: `#[diagnostic::on_const]` can only be applied to trait impls
    |
 LL | #[diagnostic::on_const(message = "tadaa", note = "boing")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |
+LL | impl const PartialEq for Foo {
+   | ---------------------------- not a trait impl
 
 error: `#[diagnostic::on_const]` can only be applied to trait impls
   --> $DIR/misplaced_attr.rs:16:1
    |
 LL | #[diagnostic::on_const(message = "tadaa", note = "boing")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |
+LL | impl Foo {
+   | -------- not a trait impl
 
 error: `#[diagnostic::on_const]` can only be applied to trait impls
   --> $DIR/misplaced_attr.rs:25:5
    |
 LL |     #[diagnostic::on_const(message = "tadaa", note = "boing")]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |
+LL |     fn partial_cmp(&self, other: &Foo) -> Option<std::cmp::Ordering> {
+   |     ---------------------------------------------------------------- not a trait impl
 
 error: aborting due to 4 previous errors
 


### PR DESCRIPTION
close rust-lang/rust#149606

r? estebank