### PR TITLE
Check identifiers defined in macros when suggesting identifiers hidden by hygiene

### DIFF
--- a/tests/ui/hygiene/pattern-macro.stderr
+++ b/tests/ui/hygiene/pattern-macro.stderr
@@ -3,6 +3,16 @@ error[E0425]: cannot find value `x` in this scope
    |
 LL |     x + 1;
    |     ^ not found in this scope
+   |
+help: an identifier with the same name is defined here, but is not accessible due to macro hygiene
+  --> $DIR/pattern-macro.rs:1:28
+   |
+LL | macro_rules! foo { () => ( x ) }
+   |                            ^
+...
+LL |     let foo!() = 2;
+   |         ------ in this macro invocation
+   = note: this error originates in the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/macros/macro-hygiene-help-issue-149604.rs
+++ b/tests/ui/macros/macro-hygiene-help-issue-149604.rs
@@ -1,0 +1,9 @@
+macro_rules! let_it { {} => { let it = (); } }
+macro_rules! print_it { {} => { println!("{:?}", it); } }
+//~^ ERROR cannot find value `it` in this scope
+
+fn main() {
+    let_it!();
+    let () = it; //~ ERROR cannot find value `it` in this scope
+    print_it!();
+}

--- a/tests/ui/macros/macro-hygiene-help-issue-149604.stderr
+++ b/tests/ui/macros/macro-hygiene-help-issue-149604.stderr
@@ -1,0 +1,38 @@
+error[E0425]: cannot find value `it` in this scope
+  --> $DIR/macro-hygiene-help-issue-149604.rs:7:14
+   |
+LL |     let () = it;
+   |              ^^ not found in this scope
+   |
+help: an identifier with the same name is defined here, but is not accessible due to macro hygiene
+  --> $DIR/macro-hygiene-help-issue-149604.rs:1:35
+   |
+LL | macro_rules! let_it { {} => { let it = (); } }
+   |                                   ^^
+...
+LL |     let_it!();
+   |     --------- in this macro invocation
+   = note: this error originates in the macro `let_it` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0425]: cannot find value `it` in this scope
+  --> $DIR/macro-hygiene-help-issue-149604.rs:2:50
+   |
+LL | macro_rules! print_it { {} => { println!("{:?}", it); } }
+   |                                                  ^^ not found in this scope
+...
+LL |     print_it!();
+   |     ----------- in this macro invocation
+   |
+help: an identifier with the same name is defined here, but is not accessible due to macro hygiene
+  --> $DIR/macro-hygiene-help-issue-149604.rs:1:35
+   |
+LL | macro_rules! let_it { {} => { let it = (); } }
+   |                                   ^^
+...
+LL |     let_it!();
+   |     --------- in this macro invocation
+   = note: this error originates in the macro `print_it` which comes from the expansion of the macro `let_it` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/proc-macro/gen-macro-rules-hygiene.stderr
+++ b/tests/ui/proc-macro/gen-macro-rules-hygiene.stderr
@@ -30,6 +30,16 @@ error[E0425]: cannot find value `local_def` in this scope
    |
 LL |         local_def;
    |         ^^^^^^^^^ help: a local variable with a similar name exists: `local_use`
+   |
+help: an identifier with the same name is defined here, but is not accessible due to macro hygiene
+  --> $DIR/gen-macro-rules-hygiene.rs:13:1
+   |
+LL | gen_macro_rules!();
+   | ^^^^^^^^^^^^^^^^^^
+...
+LL |         generated!();
+   |         ------------ in this macro invocation
+   = note: this error originates in the macro `generated` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/proc-macro/mixed-site-span.stderr
+++ b/tests/ui/proc-macro/mixed-site-span.stderr
@@ -606,6 +606,13 @@ error[E0425]: cannot find value `local_def` in this scope
    |
 LL |         local_def;
    |         ^^^^^^^^^ help: a local variable with a similar name exists: `local_use`
+   |
+help: an identifier with the same name is defined here, but is not accessible due to macro hygiene
+  --> $DIR/mixed-site-span.rs:23:9
+   |
+LL |         proc_macro_rules!();
+   |         ^^^^^^^^^^^^^^^^^^^
+   = note: this error originates in the macro `proc_macro_rules` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 52 previous errors
 


### PR DESCRIPTION
Fix rust-lang/rust#149604

r? @JonathanBrouwer (Since you reviewed the other one related to this)