### PR TITLE
Enable `outline-atomics` by default on AArch64 FreeBSD

### DIFF
--- a/compiler/rustc_target/src/spec/targets/aarch64_unknown_freebsd.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_unknown_freebsd.rs
@@ -15,7 +15,7 @@ pub(crate) fn target() -> Target {
         data_layout: "e-m:e-p270:32:32-p271:32:32-p272:64:64-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128-Fn32".into(),
         arch: Arch::AArch64,
         options: TargetOptions {
-            features: "+v8a".into(),
+            features: "+v8a,+outline-atomics".into(),
             max_atomic_width: Some(128),
             stack_probes: StackProbeType::Inline,
             supported_sanitizers: SanitizerSet::ADDRESS


### PR DESCRIPTION
Many aarch64 targets without LSE in the baseline enable the
`outline-atomics` feature, which uses runtime detection of LSE for its
faster atomic ops. This provides nontrivial performance improvements on
most hardware from the past decade, at a small cost to anything pre-LSE.

This matches what Clang does [1].

Context: https://github.com/rust-lang/rust/pull/144938

[1]: https://github.com/llvm/llvm-project/commit/e24f90190c772b6fdd915cd0a2e55cbd468c3024

try-job: dist-x86_64-freebsd