### PR TITLE
inline constant localized typeck constraint computation

### DIFF
--- a/compiler/rustc_borrowck/src/polonius/typeck_constraints.rs
+++ b/compiler/rustc_borrowck/src/polonius/typeck_constraints.rs
@@ -142,14 +142,12 @@ fn localize_terminator_constraint<'tcx>(
     universal_regions: &UniversalRegions<'tcx>,
 ) -> LocalizedOutlivesConstraint {
     // FIXME: check if other terminators need the same handling as `Call`s, in particular
-    // Assert/Yield/Drop. A handful of tests are failing with Drop related issues, as well as some
-    // coroutine tests, and that may be why.
+    // Assert/Yield/Drop.
     match &terminator.kind {
         // FIXME: also handle diverging calls.
         TerminatorKind::Call { destination, target: Some(target), .. } => {
-            // Calls are similar to assignments, and thus follow the same pattern. If there is a
-            // target for the call we also relate what flows into the destination here to entry to
-            // that successor.
+            // If there is a target for the call we also relate what flows into the destination here
+            // to entry to that successor.
             let destination_ty = destination.ty(&body.local_decls, tcx);
             let successor_location = Location { block: *target, statement_index: 0 };
             let successor_point = liveness.point_from_location(successor_location);


### PR DESCRIPTION
This fixes an oversight in the previous PRs, this constraint is local to a point (and liveness does the rest) and so has a fixed direction.

I wasn't planning on trying to improve the impl for perf, versus computing loan liveness without first unifying the cfg and subset graph, but it's like a 20x improvement for typeck constraints on wg-grammar (-15% end-to-end) for a trivial fix.

r? @jackh726 

In general, I want to cleanup these edges to avoid off-by-one errors in constraints at effectful statements and ensure the midpoint-avoidance strategy is sound and works well, in particular with respect to edges that flow backwards from the result into its inputs. But I'd like to start from something that passes all tests and is simpler, because the eventual solution may 
1. involve localizing these edges differently than *separate* liveness and typeck lowering passes/approaches, which would need to be lowered at the same time for example. I'm already doing the latter in the loan liveness rewrite as part of creating edges on-demand during traversal, and this new structure would be a better fit to verify, or fix, these subtle edges.
2. also require changes in MIR typeck to track the flow across points more precisely, and I don't know how hard that would be. *Computing* the constraint direction is currently a workaround for that.

Therefore, in a future PR, I'll also remove this computation from the terminator constraints, but I can also do that in this PR if you'd prefer.