### PR TITLE
Add regression test for 141845

### DIFF
--- a/tests/ui/const-generics/mgca/resolution-with-inherent-associated-types.rs
+++ b/tests/ui/const-generics/mgca/resolution-with-inherent-associated-types.rs
@@ -1,0 +1,13 @@
+//! Regression test for <https://github.com/rust-lang/rust/issues/141845>
+//! Checks const resolution stability when using inherent associated types
+//! and generic const arguments.
+
+//@compile-flags: --crate-type=lib
+#![expect(incomplete_features)]
+#![feature(inherent_associated_types, min_generic_const_args)]
+trait Trait {}
+
+struct Struct<const N: usize>;
+
+type Alias<T: Trait> = Struct<{ Struct::N }>;
+//~^ ERROR: missing generics for struct `Struct` [E0107]

--- a/tests/ui/const-generics/mgca/resolution-with-inherent-associated-types.stderr
+++ b/tests/ui/const-generics/mgca/resolution-with-inherent-associated-types.stderr
@@ -1,0 +1,19 @@
+error[E0107]: missing generics for struct `Struct`
+  --> $DIR/resolution-with-inherent-associated-types.rs:12:33
+   |
+LL | type Alias<T: Trait> = Struct<{ Struct::N }>;
+   |                                 ^^^^^^ expected 1 generic argument
+   |
+note: struct defined here, with 1 generic parameter: `N`
+  --> $DIR/resolution-with-inherent-associated-types.rs:10:8
+   |
+LL | struct Struct<const N: usize>;
+   |        ^^^^^^ --------------
+help: add missing generic argument
+   |
+LL | type Alias<T: Trait> = Struct<{ Struct<N>::N }>;
+   |                                       +++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0107`.


### PR DESCRIPTION
close: rust-lang/rust#141845 

I saw the `tests/ui/associated-inherent-types` directory, but I felt the current location was a better fit. 