### PR TITLE
bootstrap: add rustc-dev install target

### DIFF
--- a/src/bootstrap/src/core/build_steps/dist.rs
+++ b/src/bootstrap/src/core/build_steps/dist.rs
@@ -892,8 +892,8 @@ impl Step for Std {
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub struct RustcDev {
     /// The compiler that will build rustc which will be shipped in this component.
-    build_compiler: Compiler,
-    target: TargetSelection,
+    pub build_compiler: Compiler,
+    pub target: TargetSelection,
 }
 
 impl RustcDev {

--- a/src/bootstrap/src/core/build_steps/install.rs
+++ b/src/bootstrap/src/core/build_steps/install.rs
@@ -279,6 +279,17 @@ install!((self, builder, _config),
         });
         install_sh(builder, "rustc", self.build_compiler, Some(self.target), &tarball);
     };
+    RustcDev, alias = "rustc-dev", Self::should_build(_config), IS_HOST: true, {
+        if let Some(tarball) = builder.ensure(dist::RustcDev {
+            build_compiler: self.build_compiler, target: self.target
+        }) {
+            install_sh(builder, "rustc-dev", self.build_compiler, Some(self.target), &tarball);
+        } else {
+            builder.info(
+                &format!("skipping Install RustcDev stage{} ({})", self.build_compiler.stage + 1, self.target),
+            );
+        }
+    };
     RustcCodegenCranelift, alias = "rustc-codegen-cranelift", Self::should_build(_config), IS_HOST: true, {
         if let Some(tarball) = builder.ensure(dist::CraneliftCodegenBackend {
             compilers: RustcPrivateCompilers::from_build_compiler(builder, self.build_compiler, self.target),

--- a/src/bootstrap/src/core/builder/mod.rs
+++ b/src/bootstrap/src/core/builder/mod.rs
@@ -998,6 +998,7 @@ impl<'a> Builder<'a> {
                 // binary path, we must install rustc before the tools. Otherwise, the rust-installer will
                 // install the same binaries twice for each tool, leaving backup files (*.old) as a result.
                 install::Rustc,
+                install::RustcDev,
                 install::Cargo,
                 install::RustAnalyzer,
                 install::Rustfmt,

--- a/src/bootstrap/src/core/builder/tests.rs
+++ b/src/bootstrap/src/core/builder/tests.rs
@@ -2912,6 +2912,7 @@ mod snapshot {
         [build] rustc 1 <x86_64-unknown-linux-gnu> -> rust-analyzer-proc-macro-srv 2 <x86_64-unknown-linux-gnu>
         [build] rustc 0 <x86_64-unknown-linux-gnu> -> GenerateCopyright 1 <x86_64-unknown-linux-gnu>
         [dist] rustc <x86_64-unknown-linux-gnu>
+        [dist] rustc 1 <x86_64-unknown-linux-gnu> -> rustc-dev 2 <x86_64-unknown-linux-gnu>
         [build] rustc 1 <x86_64-unknown-linux-gnu> -> cargo 2 <x86_64-unknown-linux-gnu>
         [dist] rustc 1 <x86_64-unknown-linux-gnu> -> cargo 2 <x86_64-unknown-linux-gnu>
         [build] rustc 1 <x86_64-unknown-linux-gnu> -> rust-analyzer 2 <x86_64-unknown-linux-gnu>


### PR DESCRIPTION
I'm entirely new to bootstrap but there seemed to be no easy way to construct a sysroot with tools and librustc_driver.so. `./x install` is the command for that but as far as I can tell it doesn't include the rustc-dev files. This is my attempt at adding that.

`./x install rustc-dev` now does what you expect (at least on my machine™). If I'm understanding correctly this also means that `./x install` will now include rustc-dev files if `build.tools` contains `"rustc-dev"`.