### PR TITLE
attempt to fix unreachable code regression 

### DIFF
--- a/compiler/rustc_mir_build/src/builder/mod.rs
+++ b/compiler/rustc_mir_build/src/builder/mod.rs
@@ -839,6 +839,25 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 self.infcx.typing_env(self.param_env),
             );
 
+            // check if the function's return type is inhabited
+            // this was added here because of this regression
+            // https://github.com/rust-lang/rust/issues/149571
+            let output_is_inhabited =
+                if matches!(self.tcx.def_kind(self.def_id), DefKind::Fn | DefKind::AssocFn) {
+                    self.tcx
+                        .fn_sig(self.def_id)
+                        .instantiate_identity()
+                        .skip_binder()
+                        .output()
+                        .is_inhabited_from(
+                            self.tcx,
+                            self.parent_module,
+                            self.infcx.typing_env(self.param_env),
+                        )
+                } else {
+                    true
+                };
+
             if !ty_is_inhabited {
                 // Unreachable code warnings are already emitted during type checking.
                 // However, during type checking, full type information is being
@@ -849,7 +868,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 // uninhabited types (e.g. empty enums). The check above is used so
                 // that we do not emit the same warning twice if the uninhabited type
                 // is indeed `!`.
-                if !ty.is_never() {
+                if !ty.is_never() && output_is_inhabited {
                     lints.push((target_bb, ty, term.source_info.span));
                 }
 

--- a/tests/ui/uninhabited/uninhabited-unreachable-warning-149571.rs
+++ b/tests/ui/uninhabited/uninhabited-unreachable-warning-149571.rs
@@ -1,0 +1,10 @@
+#![deny(unreachable_code)]
+//@ run-pass
+
+use std::convert::Infallible;
+
+pub fn foo(f: impl FnOnce() -> Infallible) -> Infallible {
+    f()
+}
+
+fn main() {}


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

For some reason it works, it checks function output type and suppress warning if type is uninhabited  

~~This double negations in code breaks my mind actually~~

I'd love to revisit this part in future and try to find a proper solution maybe, but for now I feel like it's enough before release to fix the issue? I really wonder what team does think, especially @cjgillot and other people who are more confident in this part of compiler than I do 

I tried a lot of things here, it's only approach that pass all tests included new regression one

fixes https://github.com/rust-lang/rust/issues/149571

r? compiler