### PR TITLE
Fix armv8r-none-eabihf tier

### DIFF
--- a/src/doc/rustc/src/platform-support/arm-none-eabi.md
+++ b/src/doc/rustc/src/platform-support/arm-none-eabi.md
@@ -16,6 +16,7 @@ their own document.
 - Arm R-Profile Architectures
   - [`armv7r-none-eabi` and `armv7r-none-eabihf`](armv7r-none-eabi.md)
   - [`armebv7r-none-eabi` and `armebv7r-none-eabihf`](armebv7r-none-eabi.md)
+  - [`armv8r-none-eabihf`](armv8r-none-eabihf.md)
 - Arm M-Profile Architectures
   - [`thumbv6m-none-eabi`](thumbv6m-none-eabi.md)
   - [`thumbv7m-none-eabi`](thumbv7m-none-eabi.md)
@@ -30,7 +31,7 @@ their own document.
 - Arm A-Profile Architectures
   - [`armv7a-none-eabihf`](armv7a-none-eabi.md)
 - Arm R-Profile Architectures
-  - [`armv8r-none-eabihf`](armv8r-none-eabihf.md)
+  - None
 - Arm M-Profile Architectures
   - None
 - *Legacy* Arm Architectures


### PR DESCRIPTION
It's listed as Tier 2 in `armv8r-none-eabihf.md`, but Tier 3 in `arm-none-eabi.md`. Updated to reflect current state of Tier 2.

r? @thejpster