### PR TITLE
`rustc_lexer` SIMD double quoted string and block comment parsing

### DIFF
--- a/compiler/rustc_lexer/src/cursor.rs
+++ b/compiler/rustc_lexer/src/cursor.rs
@@ -21,7 +21,6 @@ pub struct Cursor<'a> {
 pub(crate) const EOF_CHAR: char = '\0';
 
 impl<'a> Cursor<'a> {
-    #[inline]
     pub fn new(input: &'a str, frontmatter_allowed: FrontmatterAllowed) -> Cursor<'a> {
         Cursor {
             len_remaining: input.len(),
@@ -32,7 +31,6 @@ impl<'a> Cursor<'a> {
         }
     }
 
-    #[inline]
     pub fn as_str(&self) -> &'a str {
         self.chars.as_str()
     }
@@ -55,14 +53,12 @@ impl<'a> Cursor<'a> {
     /// If requested position doesn't exist, `EOF_CHAR` is returned.
     /// However, getting `EOF_CHAR` doesn't always mean actual end of file,
     /// it should be checked with `is_eof` method.
-    #[inline]
     pub fn first(&self) -> char {
         // `.next()` optimizes better than `.nth(0)`
         self.chars.clone().next().unwrap_or(EOF_CHAR)
     }
 
     /// Peeks the second symbol from the input stream without consuming it.
-    #[inline]
     pub(crate) fn second(&self) -> char {
         // `.next()` optimizes better than `.nth(1)`
         let mut iter = self.chars.clone();
@@ -71,7 +67,6 @@ impl<'a> Cursor<'a> {
     }
 
     /// Peeks the third symbol from the input stream without consuming it.
-    #[inline]
     pub fn third(&self) -> char {
         // `.next()` optimizes better than `.nth(2)`
         let mut iter = self.chars.clone();
@@ -81,25 +76,21 @@ impl<'a> Cursor<'a> {
     }
 
     /// Checks if there is nothing more to consume.
-    #[inline]
     pub(crate) fn is_eof(&self) -> bool {
         self.chars.as_str().is_empty()
     }
 
     /// Returns amount of already consumed symbols.
-    #[inline]
     pub(crate) fn pos_within_token(&self) -> u32 {
         (self.len_remaining - self.chars.as_str().len()) as u32
     }
 
     /// Resets the number of bytes consumed to 0.
-    #[inline]
     pub(crate) fn reset_pos_within_token(&mut self) {
         self.len_remaining = self.chars.as_str().len();
     }
 
     /// Moves to the next character.
-    #[inline]
     pub(crate) fn bump(&mut self) -> Option<char> {
         let c = self.chars.next()?;
 
@@ -111,10 +102,9 @@ impl<'a> Cursor<'a> {
         Some(c)
     }
 
-    #[inline]
-    pub(crate) fn bump_if(&mut self, expected: char) -> bool {
+    pub(crate) fn bump_if(&mut self, byte: char) -> bool {
         let mut chars = self.chars.clone();
-        if chars.next() == Some(expected) {
+        if chars.next() == Some(byte) {
             self.chars = chars;
             true
         } else {
@@ -123,11 +113,10 @@ impl<'a> Cursor<'a> {
     }
 
     /// Bumps the cursor if the next character is either of the two expected characters.
-    #[inline]
-    pub(crate) fn bump_if2(&mut self, expected1: char, expected2: char) -> bool {
+    pub(crate) fn bump_if_either(&mut self, byte1: char, byte2: char) -> bool {
         let mut chars = self.chars.clone();
         if let Some(c) = chars.next()
-            && (c == expected1 || c == expected2)
+            && (c == byte1 || c == byte2)
         {
             self.chars = chars;
             return true;
@@ -136,13 +125,11 @@ impl<'a> Cursor<'a> {
     }
 
     /// Moves to a substring by a number of bytes.
-    #[inline]
     pub(crate) fn bump_bytes(&mut self, n: usize) {
-        self.chars = self.as_str().get(n..).unwrap_or("").chars();
+        self.chars = self.as_str()[n..].chars();
     }
 
     /// Eats symbols while predicate returns true or until the end of file is reached.
-    #[inline]
     pub(crate) fn eat_while(&mut self, mut predicate: impl FnMut(char) -> bool) {
         // It was tried making optimized version of this for eg. line comments, but
         // LLVM can inline all of this and compile it down to fast iteration over bytes.
@@ -152,7 +139,6 @@ impl<'a> Cursor<'a> {
     }
     /// Eats characters until the given byte is found.
     /// Returns true if the byte was found, false if end of file was reached.
-    #[inline]
     pub(crate) fn eat_until(&mut self, byte: u8) -> bool {
         match memchr::memchr(byte, self.as_str().as_bytes()) {
             Some(index) => {
@@ -168,8 +154,7 @@ impl<'a> Cursor<'a> {
 
     /// Eats characters until any of the given bytes is found, then consumes past it.
     /// Returns the found byte if any, or None if end of file was reached.
-    #[inline]
-    pub(crate) fn eat_past2(&mut self, byte1: u8, byte2: u8) -> Option<u8> {
+    pub(crate) fn eat_past_either(&mut self, byte1: u8, byte2: u8) -> Option<u8> {
         let bytes = self.as_str().as_bytes();
         match memchr::memchr2(byte1, byte2, bytes) {
             Some(index) => {

--- a/compiler/rustc_lexer/src/cursor.rs
+++ b/compiler/rustc_lexer/src/cursor.rs
@@ -153,17 +153,11 @@ impl<'a> Cursor<'a> {
     }
     /// Eats characters until the given byte is found.
     /// Returns true if the byte was found, false if end of file was reached.
-    pub(crate) fn eat_until(&mut self, byte: u8) -> bool {
-        match memchr::memchr(byte, self.as_str().as_bytes()) {
-            Some(index) => {
-                self.bump_bytes(index);
-                true
-            }
-            None => {
-                self.chars = "".chars();
-                false
-            }
-        }
+    pub(crate) fn eat_until(&mut self, byte: u8) {
+        self.chars = match memchr::memchr(byte, self.as_str().as_bytes()) {
+            Some(index) => self.as_str()[index..].chars(),
+            None => "".chars(),
+        };
     }
 
     /// Eats characters until any of the given bytes is found, then consumes past it.

--- a/compiler/rustc_lexer/src/cursor.rs
+++ b/compiler/rustc_lexer/src/cursor.rs
@@ -105,6 +105,10 @@ impl<'a> Cursor<'a> {
     pub(crate) fn bump_if(&mut self, byte: char) -> bool {
         let mut chars = self.chars.clone();
         if chars.next() == Some(byte) {
+            #[cfg(debug_assertions)]
+            {
+                self.prev = byte;
+            }
             self.chars = chars;
             true
         } else {
@@ -118,6 +122,10 @@ impl<'a> Cursor<'a> {
         if let Some(c) = chars.next()
             && (c == byte1 || c == byte2)
         {
+            #[cfg(debug_assertions)]
+            {
+                self.prev = c;
+            }
             self.chars = chars;
             return true;
         }
@@ -126,6 +134,12 @@ impl<'a> Cursor<'a> {
 
     /// Moves to a substring by a number of bytes.
     pub(crate) fn bump_bytes(&mut self, n: usize) {
+        #[cfg(debug_assertions)]
+        {
+            if n > 0 {
+                self.prev = self.as_str()[n - 1..].chars().next().unwrap();
+            }
+        }
         self.chars = self.as_str()[n..].chars();
     }
 

--- a/compiler/rustc_lexer/src/cursor.rs
+++ b/compiler/rustc_lexer/src/cursor.rs
@@ -103,13 +103,8 @@ impl<'a> Cursor<'a> {
     }
 
     pub(crate) fn bump_if(&mut self, byte: char) -> bool {
-        let mut chars = self.chars.clone();
-        if chars.next() == Some(byte) {
-            #[cfg(debug_assertions)]
-            {
-                self.prev = byte;
-            }
-            self.chars = chars;
+        if self.first() == byte {
+            self.bump();
             true
         } else {
             false
@@ -118,15 +113,9 @@ impl<'a> Cursor<'a> {
 
     /// Bumps the cursor if the next character is either of the two expected characters.
     pub(crate) fn bump_either(&mut self, byte1: char, byte2: char) -> bool {
-        let mut chars = self.chars.clone();
-        if let Some(c) = chars.next()
-            && (c == byte1 || c == byte2)
-        {
-            #[cfg(debug_assertions)]
-            {
-                self.prev = c;
-            }
-            self.chars = chars;
+        let c = self.first();
+        if c == byte1 || c == byte2 {
+            self.bump();
             return true;
         }
         false

--- a/compiler/rustc_lexer/src/cursor.rs
+++ b/compiler/rustc_lexer/src/cursor.rs
@@ -134,12 +134,6 @@ impl<'a> Cursor<'a> {
 
     /// Moves to a substring by a number of bytes.
     pub(crate) fn bump_bytes(&mut self, n: usize) {
-        #[cfg(debug_assertions)]
-        {
-            if n > 0 {
-                self.prev = self.as_str()[..n].chars().last().unwrap();
-            }
-        }
         self.chars = self.as_str()[n..].chars();
     }
 
@@ -151,17 +145,14 @@ impl<'a> Cursor<'a> {
             self.bump();
         }
     }
-    /// Eats characters until the given byte is found.
-    /// Returns true if the byte was found, false if end of file was reached.
+
     pub(crate) fn eat_until(&mut self, byte: u8) {
         self.chars = match memchr::memchr(byte, self.as_str().as_bytes()) {
             Some(index) => self.as_str()[index..].chars(),
             None => "".chars(),
-        };
+        }
     }
 
-    /// Eats characters until any of the given bytes is found, then consumes past it.
-    /// Returns the found byte if any, or None if end of file was reached.
     pub(crate) fn eat_past_either(&mut self, byte1: u8, byte2: u8) -> Option<u8> {
         let bytes = self.as_str().as_bytes();
         if let Some(index) = memchr::memchr2(byte1, byte2, bytes) {

--- a/compiler/rustc_lexer/src/cursor.rs
+++ b/compiler/rustc_lexer/src/cursor.rs
@@ -137,7 +137,7 @@ impl<'a> Cursor<'a> {
         #[cfg(debug_assertions)]
         {
             if n > 0 {
-                self.prev = self.as_str()[n - 1..].chars().next().unwrap();
+                self.prev = self.as_str()[..n].chars().last().unwrap();
             }
         }
         self.chars = self.as_str()[n..].chars();

--- a/compiler/rustc_lexer/src/cursor.rs
+++ b/compiler/rustc_lexer/src/cursor.rs
@@ -164,16 +164,12 @@ impl<'a> Cursor<'a> {
     /// Returns the found byte if any, or None if end of file was reached.
     pub(crate) fn eat_past_either(&mut self, byte1: u8, byte2: u8) -> Option<u8> {
         let bytes = self.as_str().as_bytes();
-        match memchr::memchr2(byte1, byte2, bytes) {
-            Some(index) => {
-                let found = bytes[index];
-                self.bump_bytes(index + 1);
-                Some(found)
-            }
-            None => {
-                self.chars = "".chars();
-                None
-            }
+        if let Some(index) = memchr::memchr2(byte1, byte2, bytes) {
+            let found = Some(bytes[index]);
+            self.chars = self.as_str()[index + 1..].chars();
+            return found;
         }
+        self.chars = "".chars();
+        None
     }
 }

--- a/compiler/rustc_lexer/src/cursor.rs
+++ b/compiler/rustc_lexer/src/cursor.rs
@@ -117,7 +117,7 @@ impl<'a> Cursor<'a> {
     }
 
     /// Bumps the cursor if the next character is either of the two expected characters.
-    pub(crate) fn bump_if_either(&mut self, byte1: char, byte2: char) -> bool {
+    pub(crate) fn bump_either(&mut self, byte1: char, byte2: char) -> bool {
         let mut chars = self.chars.clone();
         if let Some(c) = chars.next()
             && (c == byte1 || c == byte2)

--- a/compiler/rustc_lexer/src/lib.rs
+++ b/compiler/rustc_lexer/src/lib.rs
@@ -1031,7 +1031,9 @@ impl Cursor<'_> {
         // Skip the string contents and on each '#' character met, check if this is
         // a raw string termination.
         loop {
-            if !self.eat_until(b'"') {
+            self.eat_until(b'"');
+
+            if self.is_eof() {
                 return Err(RawStrError::NoTerminator {
                     expected: n_start_hashes,
                     found: max_hashes,

--- a/compiler/rustc_lexer/src/lib.rs
+++ b/compiler/rustc_lexer/src/lib.rs
@@ -935,7 +935,7 @@ impl Cursor<'_> {
                 return true;
             }
             // Current is '\\', bump again if next is an escaped character.
-            self.bump_if_either('\\', '"');
+            self.bump_either('\\', '"');
         }
         // End of file reached.
         false
@@ -1105,7 +1105,7 @@ impl Cursor<'_> {
     /// and returns false otherwise.
     fn eat_float_exponent(&mut self) -> bool {
         debug_assert!(self.prev() == 'e' || self.prev() == 'E');
-        self.bump_if_either('-', '+');
+        self.bump_either('-', '+');
         self.eat_decimal_digits()
     }
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/149689)*
<!-- homu-ignore:end -->

Hi, this PR improves lexer performance by ~5-10% when lexing the entire standard library. It specifically targets the string lexer, comment lexer, and frontmatter lexer.

- For strings and comments, it replaces the previous logic with a new `eat_past2` function that leverages `memchr2`.
- ~For frontmatter, I eliminated the heap allocation from `format!` and rewrote the lexer using `memchr`-based scanning, which is roughly 4× faster.~

I also applied a few minor optimizations in other areas.

I’ll send the benchmark repo in the next message. Here are the results on my x86_64 laptop (AMD 6650U):

```
Benchmarking tokenize_real_world/stdlib_all_files: Collecting 100 samples in esttokenize_real_world/stdlib_all_files
                        time:   [74.193 ms 74.224 ms 74.256 ms]
                        thrpt:  [423.74 MiB/s 423.92 MiB/s 424.10 MiB/s]
                 change:
                        time:   [−5.4046% −5.3465% −5.2907%] (p = 0.00 < 0.05)
                        thrpt:  [+5.5862% +5.6484% +5.7134%]
                        Performance has improved.
Found 21 outliers among 100 measurements (21.00%)
  2 (2.00%) high mild
  19 (19.00%) high severe

Benchmarking strip_shebang/valid_shebang: Collecting 100 samples in estimated 5.strip_shebang/valid_shebang
                        time:   [11.391 ns 11.401 ns 11.412 ns]
                        thrpt:  [1.7954 GiB/s 1.7971 GiB/s 1.7987 GiB/s]
                 change:
                        time:   [−8.1076% −7.8921% −7.6485%] (p = 0.00 < 0.05)
                        thrpt:  [+8.2820% +8.5683% +8.8229%]
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) high mild
  3 (3.00%) high severe
Benchmarking strip_shebang/no_shebang: Collecting 100 samples in estimated 5.000strip_shebang/no_shebang
                        time:   [4.8656 ns 4.8680 ns 4.8711 ns]
                        thrpt:  [4.2062 GiB/s 4.2089 GiB/s 4.2110 GiB/s]
                 change:
                        time:   [−0.1156% −0.0139% +0.0821%] (p = 0.78 > 0.05)
                        thrpt:  [−0.0821% +0.0139% +0.1157%]
                        No change in performance detected.
Found 20 outliers among 100 measurements (20.00%)
  1 (1.00%) high mild
  19 (19.00%) high severe

Benchmarking tokenize/simple_function: Collecting 100 samples in estimated 5.001tokenize/simple_function
                        time:   [288.86 ns 293.20 ns 297.41 ns]
                        thrpt:  [173.16 MiB/s 175.64 MiB/s 178.28 MiB/s]
                 change:
                        time:   [−2.2198% −0.8716% +0.3321%] (p = 0.20 > 0.05)
                        thrpt:  [−0.3310% +0.8793% +2.2702%]
                        No change in performance detected.
Benchmarking tokenize/strings: Collecting 100 samples in estimated 5.0032 s (4.6tokenize/strings        time:   [1.1175 µs 1.1379 µs 1.1573 µs]
                        thrpt:  [44.497 MiB/s 45.258 MiB/s 46.083 MiB/s]
                 change:
                        time:   [−14.860% −13.620% −12.359%] (p = 0.00 < 0.05)
                        thrpt:  [+14.101% +15.767% +17.454%]
                        Performance has improved.
Benchmarking tokenize/single_line_comments: Collecting 100 samples in estimated tokenize/single_line_comments
                        time:   [159.67 ns 161.52 ns 163.29 ns]
                        thrpt:  [315.39 MiB/s 318.84 MiB/s 322.53 MiB/s]
                 change:
                        time:   [+0.4110% +1.4523% +2.4709%] (p = 0.01 < 0.05)
                        thrpt:  [−2.4113% −1.4315% −0.4093%]
                        Change within noise threshold.
Benchmarking tokenize/multi_line_comments: Collecting 100 samples in estimated 5tokenize/multi_line_comments
                        time:   [220.54 ns 223.33 ns 225.99 ns]
                        thrpt:  [227.88 MiB/s 230.60 MiB/s 233.51 MiB/s]
                 change:
                        time:   [−7.7271% −6.7443% −5.7976%] (p = 0.00 < 0.05)
                        thrpt:  [+6.1544% +7.2320% +8.3742%]
                        Performance has improved.
Benchmarking tokenize/literals: Collecting 100 samples in estimated 5.0008 s (13tokenize/literals       time:   [399.63 ns 405.42 ns 410.94 ns]
                        thrpt:  [125.32 MiB/s 127.02 MiB/s 128.86 MiB/s]
                 change:
                        time:   [−1.4649% −0.3653% +0.7608%] (p = 0.54 > 0.05)
                        thrpt:  [−0.7550% +0.3666% +1.4867%]
                        No change in performance detected.

Benchmarking frontmatter/frontmatter_allowed: Collecting 100 samples in estimatefrontmatter/frontmatter_allowed
                        time:   [188.37 ns 189.51 ns 190.85 ns]
                        thrpt:  [264.85 MiB/s 266.71 MiB/s 268.33 MiB/s]
                 change:
                        time:   [−26.032% −25.300% −24.590%] (p = 0.00 < 0.05)
                        thrpt:  [+32.609% +33.869% +35.194%]
                        Performance has improved.
Found 17 outliers among 100 measurements (17.00%)
  17 (17.00%) high severe

Benchmarking cursor_first/first: Collecting 100 samples in estimated 5.0000 s (5cursor_first/first      time:   [886.05 ps 886.23 ps 886.43 ps]
                        thrpt:  [42.026 GiB/s 42.035 GiB/s 42.044 GiB/s]
                 change:
                        time:   [−1.7088% −1.6398% −1.5732%] (p = 0.00 < 0.05)
                        thrpt:  [+1.5984% +1.6671% +1.7385%]
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  4 (4.00%) high mild
  4 (4.00%) high severe

Benchmarking cursor_iteration/bump_all: Collecting 100 samples in estimated 5.00cursor_iteration/bump_all
                        time:   [891.48 ns 892.06 ns 892.78 ns]
                        thrpt:  [4.1727 GiB/s 4.1760 GiB/s 4.1788 GiB/s]
                 change:
                        time:   [−50.335% −50.211% −50.037%] (p = 0.00 < 0.05)
                        thrpt:  [+100.15% +100.85% +101.35%]
                        Performance has improved.
Found 15 outliers among 100 measurements (15.00%)
  3 (3.00%) high mild
  12 (12.00%) high severe

Benchmarking cursor_eat_while/eat_while_alpha: Collecting 100 samples in estimatcursor_eat_while/eat_while_alpha
                        time:   [34.992 ns 34.999 ns 35.007 ns]
                        thrpt:  [1.7292 GiB/s 1.7297 GiB/s 1.7300 GiB/s]
                 change:
                        time:   [−1.0098% −0.8721% −0.7699%] (p = 0.00 < 0.05)
                        thrpt:  [+0.7759% +0.8798% +1.0201%]
                        Change within noise threshold.
Found 7 outliers among 100 measurements (7.00%)
  4 (4.00%) high mild
  3 (3.00%) high severe

Benchmarking cursor_eat_until/eat_until_newline: Collecting 100 samples in estimcursor_eat_until/eat_until_newline
                        time:   [3.1314 ns 3.1323 ns 3.1332 ns]
                        thrpt:  [15.754 GiB/s 15.759 GiB/s 15.763 GiB/s]
                 change:
                        time:   [−0.4774% −0.3069% −0.1459%] (p = 0.00 < 0.05)
                        thrpt:  [+0.1461% +0.3078% +0.4797%]
                        Change within noise threshold.
Found 21 outliers among 100 measurements (21.00%)
  14 (14.00%) low severe
  1 (1.00%) low mild
  3 (3.00%) high mild
  3 (3.00%) high severe
```