### PR TITLE
Check both where-clauses of ty aliases & assoc tys for late-bound vars in the post-expansion feature gater

### DIFF
--- a/compiler/rustc_ast_passes/src/feature_gate.rs
+++ b/compiler/rustc_ast_passes/src/feature_gate.rs
@@ -301,17 +301,12 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
         visit::walk_ty(self, ty)
     }
 
-    fn visit_generics(&mut self, g: &'a ast::Generics) {
-        for predicate in &g.where_clause.predicates {
-            match &predicate.kind {
-                ast::WherePredicateKind::BoundPredicate(bound_pred) => {
-                    // A type bound (e.g., `for<'c> Foo: Send + Clone + 'c`).
-                    self.check_late_bound_lifetime_defs(&bound_pred.bound_generic_params);
-                }
-                _ => {}
-            }
+    fn visit_where_predicate_kind(&mut self, kind: &'a ast::WherePredicateKind) {
+        if let ast::WherePredicateKind::BoundPredicate(bound) = kind {
+            // A type bound (e.g., `for<'c> Foo: Send + Clone + 'c`).
+            self.check_late_bound_lifetime_defs(&bound.bound_generic_params);
         }
-        visit::walk_generics(self, g);
+        visit::walk_where_predicate_kind(self, kind);
     }
 
     fn visit_fn_ret_ty(&mut self, ret_ty: &'a ast::FnRetTy) {

--- a/tests/ui/associated-types/associated-type-where-non-lifetime-const.rs
+++ b/tests/ui/associated-types/associated-type-where-non-lifetime-const.rs
@@ -1,0 +1,13 @@
+//! regression test for #148627
+
+#![feature(associated_type_defaults)]
+
+trait Trait {
+    type Assoc2
+        = ()
+    where
+        for<const C: usize> [(); C]: Copy;
+    //~^ ERROR: only lifetime parameters can be used in this context
+}
+
+fn main() {}

--- a/tests/ui/associated-types/associated-type-where-non-lifetime-const.stderr
+++ b/tests/ui/associated-types/associated-type-where-non-lifetime-const.stderr
@@ -1,0 +1,13 @@
+error[E0658]: only lifetime parameters can be used in this context
+  --> $DIR/associated-type-where-non-lifetime-const.rs:9:19
+   |
+LL |         for<const C: usize> [(); C]: Copy;
+   |                   ^
+   |
+   = note: see issue #108185 <https://github.com/rust-lang/rust/issues/108185> for more information
+   = help: add `#![feature(non_lifetime_binders)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/associated-types/associated-type-where-non-lifetime-type.rs
+++ b/tests/ui/associated-types/associated-type-where-non-lifetime-type.rs
@@ -1,0 +1,18 @@
+//! regression test for #149233
+
+trait Foo {
+    type Bar<'a>
+    where
+        Self: Sized;
+    fn test(&self);
+}
+impl Foo for () {
+    type Bar<'a>
+        = ()
+    where
+        for<T> T:;
+    //~^ ERROR: only lifetime parameters can be used in this context
+    fn test(&self) {}
+}
+
+fn main() {}

--- a/tests/ui/associated-types/associated-type-where-non-lifetime-type.stderr
+++ b/tests/ui/associated-types/associated-type-where-non-lifetime-type.stderr
@@ -1,0 +1,13 @@
+error[E0658]: only lifetime parameters can be used in this context
+  --> $DIR/associated-type-where-non-lifetime-type.rs:13:13
+   |
+LL |         for<T> T:;
+   |             ^
+   |
+   = note: see issue #108185 <https://github.com/rust-lang/rust/issues/108185> for more information
+   = help: add `#![feature(non_lifetime_binders)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0658`.


### PR DESCRIPTION
resolves: rust-lang/rust#148627
resolves: rust-lang/rust#149233

