### PR TITLE
rustc book: fix `*-pc-windows-msvc` link label in sidebar

### DIFF
--- a/src/doc/rustc/src/SUMMARY.md
+++ b/src/doc/rustc/src/SUMMARY.md
@@ -130,7 +130,7 @@
     - [\*-unknown-openbsd](platform-support/openbsd.md)
     - [\*-unknown-redox](platform-support/redox.md)
     - [\*-unknown-uefi](platform-support/unknown-uefi.md)
-    - [\*-unknown-windows-msvc](platform-support/windows-msvc.md)
+    - [\*-pc-windows-msvc](platform-support/windows-msvc.md)
     - [\*-uwp-windows-msvc](platform-support/uwp-windows-msvc.md)
     - [\*-wrs-vxworks](platform-support/vxworks.md)
     - [wasm32-wasip1](platform-support/wasm32-wasip1.md)


### PR DESCRIPTION
As far as I know, `*-unknown-windows-msvc` is not a thing. At least if I search for "unknown-windows-msvc" in the entire [rust-lang](https://github.com/rust-lang) organization (https://github.com/search?q=org%3Arust-lang+%22unknown-windows-msvc%22++&type=code&state=open), it gives only this occurrence and 3 other occurrences in https://github.com/rust-lang/lld, which was archived in 2019.

I believe `*-pc-windows-msvc` is the correct replacement because that is the name of the page the link points to:

https://github.com/rust-lang/rust/blob/ba86c0460b0233319e01fd789a42a7276eade805/src/doc/rustc/src/platform-support/windows-msvc.md?plain=1#L1

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
