### PR TITLE
contracts: fix lowering final declaration without trailing semicolon

### DIFF
--- a/tests/ui/contracts/requires-block-stmt.rs
+++ b/tests/ui/contracts/requires-block-stmt.rs
@@ -1,0 +1,22 @@
+//@ run-pass
+//@ compile-flags: -Zcontract-checks=yes
+
+#![expect(incomplete_features)]
+#![feature(contracts)]
+extern crate core;
+use core::contracts::requires;
+
+// Compound statements (those using [ExpressionWithBlock]
+// (https://doc.rust-lang.org/beta/reference/expressions.html#railroad-ExpressionWithBlock))
+// like blocks, if-expressions, and loops require no trailing semicolon. This
+// regression test captures the case where the last statement in the contract
+// declarations has no trailing semicolon.
+#[requires(
+    {}
+    true
+)]
+fn foo() {}
+
+fn main() {
+    foo()
+}


### PR DESCRIPTION
Lowering for contract delcarations introduced in rust-lang/rust#144444 incorrectly handled the final declaration statement when it didn't end in a semicolon. This change fixes the issue. 

See the included regression test for the minimal reproducible example.

Contracts tracking issue: https://github.com/rust-lang/rust/issues/128044
