### PR TITLE
Fix off-by-one staging output when testing the library

### DIFF
--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -2818,10 +2818,15 @@ fn run_cargo_test<'a>(
     builder: &Builder<'_>,
 ) -> bool {
     let compiler = cargo.compiler();
+    let stage = match cargo.mode() {
+        Mode::Std => compiler.stage,
+        _ => compiler.stage + 1,
+    };
+
     let mut cargo = prepare_cargo_test(cargo, libtest_args, crates, target, builder);
     let _time = helpers::timeit(builder);
-    let _group =
-        description.into().and_then(|what| builder.msg_test(what, target, compiler.stage + 1));
+
+    let _group = description.into().and_then(|what| builder.msg_test(what, target, stage));
 
     #[cfg(feature = "build-metrics")]
     builder.metrics.begin_test_suite(

--- a/src/bootstrap/src/core/builder/cargo.rs
+++ b/src/bootstrap/src/core/builder/cargo.rs
@@ -98,6 +98,7 @@ pub struct Cargo {
     command: BootstrapCommand,
     args: Vec<OsString>,
     compiler: Compiler,
+    mode: Mode,
     target: TargetSelection,
     rustflags: Rustflags,
     rustdocflags: Rustflags,
@@ -139,6 +140,10 @@ impl Cargo {
 
     pub fn compiler(&self) -> Compiler {
         self.compiler
+    }
+
+    pub fn mode(&self) -> Mode {
+        self.mode
     }
 
     pub fn into_cmd(self) -> BootstrapCommand {
@@ -1404,6 +1409,7 @@ impl Builder<'_> {
             command: cargo,
             args: vec![],
             compiler,
+            mode,
             target,
             rustflags,
             rustdocflags,


### PR DESCRIPTION
It seems generally useful to store the `Mode` in `Cargo`, I remember thinking a few times that it would be useful in other places.

Fixes: https://github.com/rust-lang/rust/issues/149558

r? @jieyouxu
