### PR TITLE
lint: emit proper diagnostic for unsafe binders in improper_ctypes instead of ICE

### DIFF
--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -416,6 +416,8 @@ lint_improper_ctypes_union_layout_help = consider adding a `#[repr(C)]` or `#[re
 lint_improper_ctypes_union_layout_reason = this union has unspecified layout
 lint_improper_ctypes_union_non_exhaustive = this union is non-exhaustive
 
+lint_improper_ctypes_unsafe_binder = unsafe binders are incompatible with foreign function interfaces
+
 lint_int_to_ptr_transmutes = transmuting an integer to a pointer creates a pointer without provenance
     .note = this is dangerous because dereferencing the resulting pointer is undefined behavior
     .note_exposed_provenance = exposed provenance semantics can be used to create a pointer based on some previously exposed provenance

--- a/compiler/rustc_lint/src/types/improper_ctypes.rs
+++ b/compiler/rustc_lint/src/types/improper_ctypes.rs
@@ -669,7 +669,9 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
                 FfiSafe
             }
 
-            ty::UnsafeBinder(_) => todo!("FIXME(unsafe_binder)"),
+            ty::UnsafeBinder(_) => {
+                FfiUnsafe { ty, reason: fluent::lint_improper_ctypes_unsafe_binder, help: None }
+            }
 
             ty::Param(..)
             | ty::Alias(ty::Projection | ty::Inherent | ty::Free, ..)

--- a/tests/ui/lint/improper-ctypes/unsafe-binder-basic.rs
+++ b/tests/ui/lint/improper-ctypes/unsafe-binder-basic.rs
@@ -1,0 +1,10 @@
+#![feature(unsafe_binders)]
+#![expect(incomplete_features)]
+#![deny(improper_ctypes)]
+
+extern "C" {
+    fn exit_2(x: unsafe<'a> &'a ());
+    //~^ ERROR `extern` block uses type `unsafe<'a> &'a ()`, which is not FFI-safe
+}
+
+fn main() {}

--- a/tests/ui/lint/improper-ctypes/unsafe-binder-basic.stderr
+++ b/tests/ui/lint/improper-ctypes/unsafe-binder-basic.stderr
@@ -1,0 +1,15 @@
+error: `extern` block uses type `unsafe<'a> &'a ()`, which is not FFI-safe
+  --> $DIR/unsafe-binder-basic.rs:6:18
+   |
+LL |     fn exit_2(x: unsafe<'a> &'a ());
+   |                  ^^^^^^^^^^^^^^^^^ not FFI-safe
+   |
+   = note: unsafe binders are incompatible with foreign function interfaces
+note: the lint level is defined here
+  --> $DIR/unsafe-binder-basic.rs:3:9
+   |
+LL | #![deny(improper_ctypes)]
+   |         ^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Fixes rust-lang/rust#149719


This PR replaces the `todo!("FIXME(unsafe_binder)")` branch in the `improper_ctypes` lint with a proper diagnostic.

Previously, using an unsafe binder inside an extern `"C"` block caused an internal compiler error.
This fix now ensures that the compiler now emits a clear and stable error message explaining that types containing unsafe binders are not yet supported in FFI.

A new UI test `(unsafe-binder-basic.rs)` is included to ensure this behavior remains stable and prevent regressions.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
