### PR TITLE
rustdoc: don't strip <p> from stability notes

### DIFF
--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -1479,9 +1479,6 @@ impl MarkdownItemInfo<'_> {
             let p = HeadingLinks::new(p, None, ids, HeadingOffset::H1);
             let p = footnotes::Footnotes::new(p, existing_footnotes);
             let p = TableWrapper::new(p.map(|(ev, _)| ev));
-            let p = p.filter(|event| {
-                !matches!(event, Event::Start(Tag::Paragraph) | Event::End(TagEnd::Paragraph))
-            });
             html::write_html_fmt(&mut f, p)
         })
     }

--- a/src/librustdoc/html/markdown/tests.rs
+++ b/src/librustdoc/html/markdown/tests.rs
@@ -472,7 +472,7 @@ fn test_markdown_html_escape() {
         let mut idmap = IdMap::new();
         let mut output = String::new();
         MarkdownItemInfo(input, &mut idmap).write_into(&mut output).unwrap();
-        assert_eq!(output, expect, "original: {}", input);
+        assert_eq!(output, format!("<p>{}</p>\n", expect), "original: {}", input);
     }
 
     t("`Struct<'a, T>`", "<code>Struct&lt;'a, T&gt;</code>");

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1577,12 +1577,13 @@ so that we can apply CSS-filters to change the arrow color in themes */
 	color: var(--main-color);
 	background-color: var(--stab-background-color);
 	width: fit-content;
-	white-space: pre-wrap;
 	border-radius: 3px;
 	display: inline;
 	vertical-align: baseline;
 }
-
+.stab p {
+	white-space: pre-wrap;
+}
 .stab.portability > code {
 	background: none;
 	color: var(--stab-code-color);

--- a/tests/rustdoc/deprecated.rs
+++ b/tests/rustdoc/deprecated.rs
@@ -30,3 +30,8 @@ pub struct W;
 //      'Deprecated: shorthand reason: code$'
 #[deprecated = "shorthand reason: `code`"]
 pub struct X;
+
+//@ matches deprecated/struct.Y.html '//*[@class="stab deprecated"]//p[1]' 'multiple'
+//@ matches deprecated/struct.Y.html '//*[@class="stab deprecated"]//p[2]' 'paragraphs'
+#[deprecated = "multiple\n\nparagraphs"]
+pub struct Y;


### PR DESCRIPTION
I believe the reason we were doing this before was that write_html_fmt adds a \n after each `<p>` element.

I have worked around this by making white-space:pre-wrap apply only to the contents of each paragraph, so the inserted whitespace between paragraphs is not included.

Perhaps a better solution would be getting rid of pre-wrap entirely, and instead inserting <br> events in place of newlines, but that would be a significantly larger change.

fixes rust-lang/rust#149732

r? @GuillaumeGomez 

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
