### PR TITLE
Make `BorrowedBuf` and `BorrowedCursor` generic over the data

### DIFF
--- a/library/core/src/io/borrowed_buf.rs
+++ b/library/core/src/io/borrowed_buf.rs
@@ -24,8 +24,8 @@ use crate::ptr;
 ///
 /// The lifetime `'data` is a bound on the lifetime of the underlying elements.
 ///
-/// The type defaults to managing bytes, but can manage any type of elements.
-pub struct BorrowedBuf<'data, T = u8> {
+/// The type is most commonly used to manage bytes, but can manage any type of elements.
+pub struct BorrowedBuf<'data, T> {
     /// The buffer's underlying elements.
     buf: &'data mut [MaybeUninit<T>],
     /// The number of elements of `self.buf` that are known to be filled.
@@ -193,7 +193,7 @@ impl<'data, T: Copy> BorrowedBuf<'data, T> {
 ///
 /// The lifetime `'a` is a bound on the lifetime of the underlying buffer (which means it is a bound
 /// on the elements in that buffer by transitivity).
-pub struct BorrowedCursor<'a, T = u8> {
+pub struct BorrowedCursor<'a, T> {
     /// The underlying buffer.
     // Safety invariant: we treat the type of buf as covariant in the lifetime of `BorrowedBuf` when
     // we create a `BorrowedCursor`. This is only safe if we never replace `buf` by assigning into

--- a/library/core/src/io/borrowed_buf.rs
+++ b/library/core/src/io/borrowed_buf.rs
@@ -4,10 +4,10 @@ use crate::fmt::{self, Debug, Formatter};
 use crate::mem::{self, MaybeUninit};
 use crate::ptr;
 
-/// A borrowed byte buffer which is incrementally filled.
+/// A borrowed buffer of initially uninitialized data, which is incrementally filled.
 ///
 /// This type makes it safer to work with `MaybeUninit` buffers, such as to read into a buffer
-/// without having to initialize it first. It tracks the region of bytes that have been filled and
+/// without having to initialize it first. It tracks the region of data that has been filled and
 /// whether the unfilled region was initialized.
 ///
 /// In summary, the contents of the buffer can be visualized as:
@@ -23,16 +23,18 @@ use crate::ptr;
 /// write-only iterator).
 ///
 /// The lifetime `'data` is a bound on the lifetime of the underlying data.
-pub struct BorrowedBuf<'data> {
+///
+/// The type defaults to managing bytes, but can manage any type of data.
+pub struct BorrowedBuf<'data, T = u8> {
     /// The buffer's underlying data.
-    buf: &'data mut [MaybeUninit<u8>],
-    /// The length of `self.buf` which is known to be filled.
+    buf: &'data mut [MaybeUninit<T>],
+    /// The number of elements of `self.buf` that are known to be filled.
     filled: usize,
     /// Whether the entire unfilled part of `self.buf` has explicitly been initialized.
     init: bool,
 }
 
-impl Debug for BorrowedBuf<'_> {
+impl<T: Copy> Debug for BorrowedBuf<'_, T> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.debug_struct("BorrowedBuf")
             .field("init", &self.init)
@@ -43,12 +45,12 @@ impl Debug for BorrowedBuf<'_> {
 }
 
 /// Creates a new `BorrowedBuf` from a fully initialized slice.
-impl<'data> From<&'data mut [u8]> for BorrowedBuf<'data> {
+impl<'data, T: Copy> From<&'data mut [T]> for BorrowedBuf<'data, T> {
     #[inline]
-    fn from(slice: &'data mut [u8]) -> BorrowedBuf<'data> {
+    fn from(slice: &'data mut [T]) -> BorrowedBuf<'data, T> {
         BorrowedBuf {
             // SAFETY: initialized data never becoming uninitialized is an invariant of BorrowedBuf
-            buf: unsafe { &mut *(slice as *mut [u8] as *mut [MaybeUninit<u8>]) },
+            buf: unsafe { &mut *(slice as *mut [T] as *mut [MaybeUninit<T>]) },
             filled: 0,
             init: true,
         }
@@ -56,9 +58,9 @@ impl<'data> From<&'data mut [u8]> for BorrowedBuf<'data> {
 }
 
 /// Creates a new `BorrowedBuf` from an uninitialized buffer.
-impl<'data> From<&'data mut [MaybeUninit<u8>]> for BorrowedBuf<'data> {
+impl<'data, T: Copy> From<&'data mut [MaybeUninit<T>]> for BorrowedBuf<'data, T> {
     #[inline]
-    fn from(buf: &'data mut [MaybeUninit<u8>]) -> BorrowedBuf<'data> {
+    fn from(buf: &'data mut [MaybeUninit<T>]) -> BorrowedBuf<'data, T> {
         BorrowedBuf { buf, filled: 0, init: false }
     }
 }
@@ -66,9 +68,9 @@ impl<'data> From<&'data mut [MaybeUninit<u8>]> for BorrowedBuf<'data> {
 /// Creates a new `BorrowedBuf` from a cursor.
 ///
 /// Use `BorrowedCursor::with_unfilled_buf` instead for a safer alternative.
-impl<'data> From<BorrowedCursor<'data>> for BorrowedBuf<'data> {
+impl<'data, T: Copy> From<BorrowedCursor<'data, T>> for BorrowedBuf<'data, T> {
     #[inline]
-    fn from(buf: BorrowedCursor<'data>) -> BorrowedBuf<'data> {
+    fn from(buf: BorrowedCursor<'data, T>) -> BorrowedBuf<'data, T> {
         BorrowedBuf {
             // SAFETY: no initialized byte is ever uninitialized as per
             // `BorrowedBuf`'s invariant
@@ -79,7 +81,7 @@ impl<'data> From<BorrowedCursor<'data>> for BorrowedBuf<'data> {
     }
 }
 
-impl<'data> BorrowedBuf<'data> {
+impl<'data, T: Copy> BorrowedBuf<'data, T> {
     /// Returns the total capacity of the buffer.
     #[inline]
     pub fn capacity(&self) -> usize {
@@ -101,7 +103,7 @@ impl<'data> BorrowedBuf<'data> {
 
     /// Returns a shared reference to the filled portion of the buffer.
     #[inline]
-    pub fn filled(&self) -> &[u8] {
+    pub fn filled(&self) -> &[T] {
         // SAFETY: We only slice the filled part of the buffer, which is always valid
         unsafe {
             let buf = self.buf.get_unchecked(..self.filled);
@@ -111,7 +113,7 @@ impl<'data> BorrowedBuf<'data> {
 
     /// Returns a mutable reference to the filled portion of the buffer.
     #[inline]
-    pub fn filled_mut(&mut self) -> &mut [u8] {
+    pub fn filled_mut(&mut self) -> &mut [T] {
         // SAFETY: We only slice the filled part of the buffer, which is always valid
         unsafe {
             let buf = self.buf.get_unchecked_mut(..self.filled);
@@ -121,7 +123,7 @@ impl<'data> BorrowedBuf<'data> {
 
     /// Returns a shared reference to the filled portion of the buffer with its original lifetime.
     #[inline]
-    pub fn into_filled(self) -> &'data [u8] {
+    pub fn into_filled(self) -> &'data [T] {
         // SAFETY: We only slice the filled part of the buffer, which is always valid
         unsafe {
             let buf = self.buf.get_unchecked(..self.filled);
@@ -131,7 +133,7 @@ impl<'data> BorrowedBuf<'data> {
 
     /// Returns a mutable reference to the filled portion of the buffer with its original lifetime.
     #[inline]
-    pub fn into_filled_mut(self) -> &'data mut [u8] {
+    pub fn into_filled_mut(self) -> &'data mut [T] {
         // SAFETY: We only slice the filled part of the buffer, which is always valid
         unsafe {
             let buf = self.buf.get_unchecked_mut(..self.filled);
@@ -141,12 +143,14 @@ impl<'data> BorrowedBuf<'data> {
 
     /// Returns a cursor over the unfilled part of the buffer.
     #[inline]
-    pub fn unfilled<'this>(&'this mut self) -> BorrowedCursor<'this> {
+    pub fn unfilled<'this>(&'this mut self) -> BorrowedCursor<'this, T> {
         BorrowedCursor {
             // SAFETY: we never assign into `BorrowedCursor::buf`, so treating its
             // lifetime covariantly is safe.
             buf: unsafe {
-                mem::transmute::<&'this mut BorrowedBuf<'data>, &'this mut BorrowedBuf<'this>>(self)
+                mem::transmute::<&'this mut BorrowedBuf<'data, T>, &'this mut BorrowedBuf<'this, T>>(
+                    self,
+                )
             },
         }
     }
@@ -180,7 +184,7 @@ impl<'data> BorrowedBuf<'data> {
 /// Data can be written directly to the cursor by using [`append`](BorrowedCursor::append) or
 /// indirectly by getting a slice of part or all of the cursor and writing into the slice. In the
 /// indirect case, the caller must call [`advance`](BorrowedCursor::advance) after writing to inform
-/// the cursor how many bytes have been written.
+/// the cursor how many elements have been written.
 ///
 /// Once data is written to the cursor, it becomes part of the filled portion of the underlying
 /// `BorrowedBuf` and can no longer be accessed or re-written by the cursor. I.e., the cursor tracks
@@ -188,27 +192,32 @@ impl<'data> BorrowedBuf<'data> {
 ///
 /// The lifetime `'a` is a bound on the lifetime of the underlying buffer (which means it is a bound
 /// on the data in that buffer by transitivity).
-#[derive(Debug)]
-pub struct BorrowedCursor<'a> {
+pub struct BorrowedCursor<'a, T = u8> {
     /// The underlying buffer.
     // Safety invariant: we treat the type of buf as covariant in the lifetime of `BorrowedBuf` when
     // we create a `BorrowedCursor`. This is only safe if we never replace `buf` by assigning into
     // it, so don't do that!
-    buf: &'a mut BorrowedBuf<'a>,
+    buf: &'a mut BorrowedBuf<'a, T>,
 }
 
-impl<'a> BorrowedCursor<'a> {
+impl<T: Copy> Debug for BorrowedCursor<'_, T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("BorrowedCursor").field("buf", &self.buf).finish()
+    }
+}
+
+impl<'a, T: Copy> BorrowedCursor<'a, T> {
     /// Reborrows this cursor by cloning it with a smaller lifetime.
     ///
     /// Since a cursor maintains unique access to its underlying buffer, the borrowed cursor is
     /// not accessible while the new cursor exists.
     #[inline]
-    pub fn reborrow<'this>(&'this mut self) -> BorrowedCursor<'this> {
+    pub fn reborrow<'this>(&'this mut self) -> BorrowedCursor<'this, T> {
         BorrowedCursor {
             // SAFETY: we never assign into `BorrowedCursor::buf`, so treating its
             // lifetime covariantly is safe.
             buf: unsafe {
-                mem::transmute::<&'this mut BorrowedBuf<'a>, &'this mut BorrowedBuf<'this>>(
+                mem::transmute::<&'this mut BorrowedBuf<'a, T>, &'this mut BorrowedBuf<'this, T>>(
                     self.buf,
                 )
             },
@@ -251,16 +260,16 @@ impl<'a> BorrowedCursor<'a> {
     ///
     /// # Safety
     ///
-    /// The caller must not uninitialize any bytes of the cursor if it is initialized.
+    /// The caller must not uninitialize any data of the cursor if it is initialized.
     #[inline]
-    pub unsafe fn as_mut(&mut self) -> &mut [MaybeUninit<u8>] {
+    pub unsafe fn as_mut(&mut self) -> &mut [MaybeUninit<T>] {
         // SAFETY: always in bounds
         unsafe { self.buf.buf.get_unchecked_mut(self.buf.filled..) }
     }
 
-    /// Advances the cursor by asserting that `n` bytes have been filled.
+    /// Advances the cursor by asserting that `n` elements have been filled.
     ///
-    /// After advancing, the `n` bytes are no longer accessible via the cursor and can only be
+    /// After advancing, the `n` elements are no longer accessible via the cursor and can only be
     /// accessed via the underlying buffer. I.e., the buffer's filled portion grows by `n` elements
     /// and its unfilled portion (and the capacity of this cursor) shrinks by `n` elements.
     ///
@@ -289,32 +298,11 @@ impl<'a> BorrowedCursor<'a> {
     ///
     /// # Safety
     ///
-    /// The caller must ensure that the first `n` bytes of the cursor have been properly
-    /// initialised.
+    /// The caller must ensure that the first `n` elements of the cursor have been initialized.
     #[inline]
     pub unsafe fn advance(&mut self, n: usize) -> &mut Self {
         self.buf.filled += n;
         self
-    }
-
-    /// Initializes all bytes in the cursor and returns them.
-    #[unstable(feature = "borrowed_buf_init", issue = "78485")]
-    #[inline]
-    pub fn ensure_init(&mut self) -> &mut [u8] {
-        // SAFETY: always in bounds and we never uninitialize these bytes.
-        let unfilled = unsafe { self.buf.buf.get_unchecked_mut(self.buf.filled..) };
-
-        if !self.buf.init {
-            // SAFETY: 0 is a valid value for MaybeUninit<u8> and the length matches the allocation
-            // since it is comes from a slice reference.
-            unsafe {
-                ptr::write_bytes(unfilled.as_mut_ptr(), 0, unfilled.len());
-            }
-            self.buf.init = true;
-        }
-
-        // SAFETY: these bytes have just been initialized if they weren't before
-        unsafe { unfilled.assume_init_mut() }
     }
 
     /// Appends data to the cursor, advancing position within its buffer.
@@ -323,7 +311,10 @@ impl<'a> BorrowedCursor<'a> {
     ///
     /// Panics if `self.capacity()` is less than `buf.len()`.
     #[inline]
-    pub fn append(&mut self, buf: &[u8]) {
+    pub fn append(&mut self, buf: &[T])
+    where
+        T: Copy,
+    {
         assert!(self.capacity() >= buf.len());
 
         // SAFETY: we do not de-initialize any of the elements of the slice
@@ -343,7 +334,7 @@ impl<'a> BorrowedCursor<'a> {
     ///
     /// Panics if the `BorrowedBuf` given to the closure is replaced by another
     /// one.
-    pub fn with_unfilled_buf<T>(&mut self, f: impl FnOnce(&mut BorrowedBuf<'_>) -> T) -> T {
+    pub fn with_unfilled_buf<R>(&mut self, f: impl FnOnce(&mut BorrowedBuf<'_, T>) -> R) -> R {
         let mut buf = BorrowedBuf::from(self.reborrow());
         let prev_ptr = buf.buf as *const _;
         let res = f(&mut buf);
@@ -359,12 +350,33 @@ impl<'a> BorrowedCursor<'a> {
         // Update `init` and `filled` fields with what was written to the buffer.
         // `self.buf.filled` was the starting length of the `BorrowedBuf`.
         //
-        // SAFETY: These amounts of bytes were initialized/filled in the `BorrowedBuf`,
-        // and therefore they are initialized/filled in the cursor too, because the
-        // buffer wasn't replaced.
+        // SAFETY: This data was initialized/filled in the `BorrowedBuf`, and therefore it is
+        // initialized/filled in the cursor too, because the buffer wasn't replaced.
         self.buf.init = init;
         self.buf.filled += filled;
 
         res
+    }
+}
+
+impl<'a> BorrowedCursor<'a, u8> {
+    /// Initializes all bytes in the cursor and returns them.
+    #[unstable(feature = "borrowed_buf_init", issue = "78485")]
+    #[inline]
+    pub fn ensure_init(&mut self) -> &mut [u8] {
+        // SAFETY: always in bounds and we never uninitialize these bytes.
+        let unfilled = unsafe { self.buf.buf.get_unchecked_mut(self.buf.filled..) };
+
+        if !self.buf.init {
+            // SAFETY: 0 is a valid value for MaybeUninit<u8> and the length matches the allocation
+            // since it is comes from a slice reference.
+            unsafe {
+                ptr::write_bytes(unfilled.as_mut_ptr(), 0, unfilled.len());
+            }
+            self.buf.init = true;
+        }
+
+        // SAFETY: these bytes have just been initialized if they weren't before
+        unsafe { unfilled.assume_init_mut() }
     }
 }

--- a/library/core/src/io/borrowed_buf.rs
+++ b/library/core/src/io/borrowed_buf.rs
@@ -34,7 +34,7 @@ pub struct BorrowedBuf<'data, T = u8> {
     init: bool,
 }
 
-impl<T: Copy> Debug for BorrowedBuf<'_, T> {
+impl<T> Debug for BorrowedBuf<'_, T> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.debug_struct("BorrowedBuf")
             .field("init", &self.init)
@@ -81,7 +81,7 @@ impl<'data, T: Copy> From<BorrowedCursor<'data, T>> for BorrowedBuf<'data, T> {
     }
 }
 
-impl<'data, T: Copy> BorrowedBuf<'data, T> {
+impl<'data, T> BorrowedBuf<'data, T> {
     /// Returns the total capacity of the buffer.
     #[inline]
     pub fn capacity(&self) -> usize {
@@ -100,7 +100,9 @@ impl<'data, T: Copy> BorrowedBuf<'data, T> {
     pub fn is_init(&self) -> bool {
         self.init
     }
+}
 
+impl<'data, T: Copy> BorrowedBuf<'data, T> {
     /// Returns a shared reference to the filled portion of the buffer.
     #[inline]
     pub fn filled(&self) -> &[T] {
@@ -200,7 +202,7 @@ pub struct BorrowedCursor<'a, T = u8> {
     buf: &'a mut BorrowedBuf<'a, T>,
 }
 
-impl<T: Copy> Debug for BorrowedCursor<'_, T> {
+impl<T> Debug for BorrowedCursor<'_, T> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.debug_struct("BorrowedCursor").field("buf", &self.buf).finish()
     }

--- a/library/core/src/io/borrowed_buf.rs
+++ b/library/core/src/io/borrowed_buf.rs
@@ -312,10 +312,7 @@ impl<'a, T: Copy> BorrowedCursor<'a, T> {
     ///
     /// Panics if `self.capacity()` is less than `buf.len()`.
     #[inline]
-    pub fn append(&mut self, buf: &[T])
-    where
-        T: Copy,
-    {
+    pub fn append(&mut self, buf: &[T]) {
         assert!(self.capacity() >= buf.len());
 
         // SAFETY: we do not de-initialize any of the elements of the slice

--- a/library/core/src/io/borrowed_buf.rs
+++ b/library/core/src/io/borrowed_buf.rs
@@ -4,11 +4,11 @@ use crate::fmt::{self, Debug, Formatter};
 use crate::mem::{self, MaybeUninit};
 use crate::ptr;
 
-/// A borrowed buffer of initially uninitialized data, which is incrementally filled.
+/// A borrowed buffer of initially uninitialized elements, which is incrementally filled.
 ///
 /// This type makes it safer to work with `MaybeUninit` buffers, such as to read into a buffer
-/// without having to initialize it first. It tracks the region of data that has been filled and
-/// whether the unfilled region was initialized.
+/// without having to initialize it first. It tracks the region of elements that have been filled
+/// and whether the unfilled region was initialized.
 ///
 /// In summary, the contents of the buffer can be visualized as:
 /// ```not_rust
@@ -16,17 +16,17 @@ use crate::ptr;
 /// [ filled | unfilled (may be initialized) ]
 /// ```
 ///
-/// A `BorrowedBuf` is created around some existing data (or capacity for data) via a unique reference
-/// (`&mut`). The `BorrowedBuf` can be configured (e.g., using `clear` or `set_init`), but cannot be
-/// directly written. To write into the buffer, use `unfilled` to create a `BorrowedCursor`. The cursor
-/// has write-only access to the unfilled portion of the buffer (you can think of it as a
-/// write-only iterator).
+/// A `BorrowedBuf` is created around some existing elements (or capacity for elements) via a unique
+/// reference (`&mut`). The `BorrowedBuf` can be configured (e.g., using `clear` or `set_init`), but
+/// cannot be directly written. To write into the buffer, use `unfilled` to create a
+/// `BorrowedCursor`. The cursor has write-only access to the unfilled portion of the buffer (you
+/// can think of it as a write-only iterator).
 ///
-/// The lifetime `'data` is a bound on the lifetime of the underlying data.
+/// The lifetime `'data` is a bound on the lifetime of the underlying elements.
 ///
-/// The type defaults to managing bytes, but can manage any type of data.
+/// The type defaults to managing bytes, but can manage any type of elements.
 pub struct BorrowedBuf<'data, T = u8> {
-    /// The buffer's underlying data.
+    /// The buffer's underlying elements.
     buf: &'data mut [MaybeUninit<T>],
     /// The number of elements of `self.buf` that are known to be filled.
     filled: usize,
@@ -49,7 +49,7 @@ impl<'data, T: Copy> From<&'data mut [T]> for BorrowedBuf<'data, T> {
     #[inline]
     fn from(slice: &'data mut [T]) -> BorrowedBuf<'data, T> {
         BorrowedBuf {
-            // SAFETY: initialized data never becoming uninitialized is an invariant of BorrowedBuf
+            // SAFETY: no initialized element is ever uninitialized as per `BorrowedBuf`'s invariant
             buf: unsafe { &mut *(slice as *mut [T] as *mut [MaybeUninit<T>]) },
             filled: 0,
             init: true,
@@ -72,8 +72,7 @@ impl<'data, T: Copy> From<BorrowedCursor<'data, T>> for BorrowedBuf<'data, T> {
     #[inline]
     fn from(buf: BorrowedCursor<'data, T>) -> BorrowedBuf<'data, T> {
         BorrowedBuf {
-            // SAFETY: no initialized byte is ever uninitialized as per
-            // `BorrowedBuf`'s invariant
+            // SAFETY: no initialized element is ever uninitialized as per `BorrowedBuf`'s invariant
             buf: unsafe { buf.buf.buf.get_unchecked_mut(buf.buf.filled..) },
             filled: 0,
             init: buf.buf.init,
@@ -170,7 +169,7 @@ impl<'data, T: Copy> BorrowedBuf<'data, T> {
     ///
     /// # Safety
     ///
-    /// All the bytes of the buffer must be initialized.
+    /// All the elements of the buffer must be initialized.
     #[unstable(feature = "borrowed_buf_init", issue = "78485")]
     #[inline]
     pub unsafe fn set_init(&mut self) -> &mut Self {
@@ -188,12 +187,12 @@ impl<'data, T: Copy> BorrowedBuf<'data, T> {
 /// indirect case, the caller must call [`advance`](BorrowedCursor::advance) after writing to inform
 /// the cursor how many elements have been written.
 ///
-/// Once data is written to the cursor, it becomes part of the filled portion of the underlying
-/// `BorrowedBuf` and can no longer be accessed or re-written by the cursor. I.e., the cursor tracks
-/// the unfilled part of the underlying `BorrowedBuf`.
+/// Once elements are written to the cursor, they become part of the filled portion of the
+/// underlying `BorrowedBuf` and can no longer be accessed or re-written by the cursor. In other
+/// words, the cursor tracks the unfilled part of the underlying `BorrowedBuf`.
 ///
 /// The lifetime `'a` is a bound on the lifetime of the underlying buffer (which means it is a bound
-/// on the data in that buffer by transitivity).
+/// on the elements in that buffer by transitivity).
 pub struct BorrowedCursor<'a, T = u8> {
     /// The underlying buffer.
     // Safety invariant: we treat the type of buf as covariant in the lifetime of `BorrowedBuf` when
@@ -232,7 +231,7 @@ impl<'a, T: Copy> BorrowedCursor<'a, T> {
         self.buf.capacity() - self.buf.filled
     }
 
-    /// Returns the number of bytes written to the `BorrowedBuf` this cursor was created from.
+    /// Returns the number of elements written to the `BorrowedBuf` this cursor was created from.
     ///
     /// In particular, the count returned is shared by all reborrows of the cursor.
     #[inline]
@@ -251,7 +250,7 @@ impl<'a, T: Copy> BorrowedCursor<'a, T> {
     ///
     /// # Safety
     ///
-    /// All the bytes of the cursor must be initialized.
+    /// All the elements of the cursor must be initialized.
     #[unstable(feature = "borrowed_buf_init", issue = "78485")]
     #[inline]
     pub unsafe fn set_init(&mut self) {
@@ -262,7 +261,7 @@ impl<'a, T: Copy> BorrowedCursor<'a, T> {
     ///
     /// # Safety
     ///
-    /// The caller must not uninitialize any data of the cursor if it is initialized.
+    /// The caller must not uninitialize any elements of the cursor if it is initialized.
     #[inline]
     pub unsafe fn as_mut(&mut self) -> &mut [MaybeUninit<T>] {
         // SAFETY: always in bounds
@@ -275,12 +274,12 @@ impl<'a, T: Copy> BorrowedCursor<'a, T> {
     /// accessed via the underlying buffer. I.e., the buffer's filled portion grows by `n` elements
     /// and its unfilled portion (and the capacity of this cursor) shrinks by `n` elements.
     ///
-    /// If less than `n` bytes initialized (by the cursor's point of view), `set_init` should be
+    /// If less than `n` elements initialized (by the cursor's point of view), `set_init` should be
     /// called first.
     ///
     /// # Panics
     ///
-    /// Panics if there are less than `n` bytes initialized.
+    /// Panics if there are less than `n` elements initialized.
     #[unstable(feature = "borrowed_buf_init", issue = "78485")]
     #[inline]
     pub fn advance_checked(&mut self, n: usize) -> &mut Self {
@@ -292,9 +291,9 @@ impl<'a, T: Copy> BorrowedCursor<'a, T> {
         self
     }
 
-    /// Advances the cursor by asserting that `n` bytes have been filled.
+    /// Advances the cursor by asserting that `n` elements have been filled.
     ///
-    /// After advancing, the `n` bytes are no longer accessible via the cursor and can only be
+    /// After advancing, the `n` elements are no longer accessible via the cursor and can only be
     /// accessed via the underlying buffer. I.e., the buffer's filled portion grows by `n` elements
     /// and its unfilled portion (and the capacity of this cursor) shrinks by `n` elements.
     ///
@@ -307,7 +306,7 @@ impl<'a, T: Copy> BorrowedCursor<'a, T> {
         self
     }
 
-    /// Appends data to the cursor, advancing position within its buffer.
+    /// Append elements to the cursor, advancing position within its buffer.
     ///
     /// # Panics
     ///
@@ -343,7 +342,7 @@ impl<'a, T: Copy> BorrowedCursor<'a, T> {
 
         // Check that the caller didn't replace the `BorrowedBuf`.
         // This is necessary for the safety of the code below: if the check wasn't
-        // there, one could mark some bytes as initialized even though there aren't.
+        // there, one could mark some elements as initialized even though they aren't.
         assert!(core::ptr::eq(prev_ptr, buf.buf));
 
         let filled = buf.filled;
@@ -352,8 +351,8 @@ impl<'a, T: Copy> BorrowedCursor<'a, T> {
         // Update `init` and `filled` fields with what was written to the buffer.
         // `self.buf.filled` was the starting length of the `BorrowedBuf`.
         //
-        // SAFETY: This data was initialized/filled in the `BorrowedBuf`, and therefore it is
-        // initialized/filled in the cursor too, because the buffer wasn't replaced.
+        // SAFETY: These elements were initialized/filled in the `BorrowedBuf`, and therefore they
+        // are initialized/filled in the cursor too, because the buffer wasn't replaced.
         self.buf.init = init;
         self.buf.filled += filled;
 

--- a/library/coretests/tests/io/borrowed_buf.rs
+++ b/library/coretests/tests/io/borrowed_buf.rs
@@ -13,11 +13,33 @@ fn new() {
     assert_eq!(rbuf.unfilled().capacity(), 16);
 }
 
+#[test]
+fn new_u64() {
+    let buf: &mut [_] = &mut [0u64; 16];
+    let mut rbuf = BorrowedBuf::from(buf);
+
+    assert_eq!(rbuf.filled().len(), 0);
+    assert!(rbuf.is_init());
+    assert_eq!(rbuf.capacity(), 16);
+    assert_eq!(rbuf.unfilled().capacity(), 16);
+}
+
 /// Test that BorrowedBuf has the correct numbers when created with uninit
 #[test]
 fn uninit() {
     let buf: &mut [_] = &mut [MaybeUninit::uninit(); 16];
     let mut rbuf: BorrowedBuf<'_, u8> = buf.into();
+
+    assert_eq!(rbuf.filled().len(), 0);
+    assert!(!rbuf.is_init());
+    assert_eq!(rbuf.capacity(), 16);
+    assert_eq!(rbuf.unfilled().capacity(), 16);
+}
+
+#[test]
+fn uninit_u64() {
+    let buf: &mut [_] = &mut [MaybeUninit::<u64>::uninit(); 16];
+    let mut rbuf = BorrowedBuf::<u64>::from(buf);
 
     assert_eq!(rbuf.filled().len(), 0);
     assert!(!rbuf.is_init());
@@ -47,6 +69,17 @@ fn advance_filled() {
 }
 
 #[test]
+fn advance_filled_u64() {
+    let buf: &mut [_] = &mut [0u64; 16];
+    let mut rbuf = BorrowedBuf::from(buf);
+
+    rbuf.unfilled().advance_checked(1);
+
+    assert_eq!(rbuf.filled().len(), 1);
+    assert_eq!(rbuf.unfilled().capacity(), 15);
+}
+
+#[test]
 fn clear() {
     let buf: &mut [_] = &mut [255; 16];
     let mut rbuf: BorrowedBuf<'_, u8> = buf.into();
@@ -65,6 +98,28 @@ fn clear() {
 }
 
 #[test]
+fn clear_u64() {
+    let buf: &mut [_] = &mut [255u64; 16];
+    let mut rbuf = BorrowedBuf::from(buf);
+
+    rbuf.unfilled().advance_checked(16);
+
+    assert_eq!(rbuf.filled().len(), 16);
+    assert_eq!(rbuf.unfilled().capacity(), 0);
+
+    rbuf.clear();
+
+    assert_eq!(rbuf.filled().len(), 0);
+    assert_eq!(rbuf.unfilled().capacity(), 16);
+
+    unsafe {
+        rbuf.set_init();
+    }
+    rbuf.unfilled().advance_checked(16);
+    assert_eq!(rbuf.filled(), [255; 16]);
+}
+
+#[test]
 fn set_init() {
     let buf: &mut [_] = &mut [MaybeUninit::zeroed(); 16];
     let mut rbuf: BorrowedBuf<'_, u8> = buf.into();
@@ -74,12 +129,48 @@ fn set_init() {
     }
 
     assert!(rbuf.is_init());
+    rbuf.unfilled().advance_checked(16);
+    assert_eq!(rbuf.filled(), [0; 16]);
+}
+
+#[test]
+fn set_init_u64() {
+    let buf: &mut [_] = &mut [MaybeUninit::<u64>::zeroed(); 16];
+    let mut rbuf = BorrowedBuf::<u64>::from(buf);
+
+    unsafe {
+        rbuf.set_init();
+    }
+
+    assert!(rbuf.is_init());
+    rbuf.unfilled().advance_checked(16);
+    assert_eq!(rbuf.filled(), [0; 16]);
 }
 
 #[test]
 fn append() {
     let buf: &mut [_] = &mut [MaybeUninit::new(255); 16];
     let mut rbuf: BorrowedBuf<'_, u8> = buf.into();
+
+    rbuf.unfilled().append(&[0; 8]);
+
+    assert!(!rbuf.is_init());
+    assert_eq!(rbuf.filled().len(), 8);
+    assert_eq!(rbuf.filled(), [0; 8]);
+
+    rbuf.clear();
+
+    rbuf.unfilled().append(&[1; 16]);
+
+    assert!(!rbuf.is_init());
+    assert_eq!(rbuf.filled().len(), 16);
+    assert_eq!(rbuf.filled(), [1; 16]);
+}
+
+#[test]
+fn append_u64() {
+    let buf: &mut [_] = &mut [MaybeUninit::new(255u64); 16];
+    let mut rbuf = BorrowedBuf::<u64>::from(buf);
 
     rbuf.unfilled().append(&[0; 8]);
 
@@ -119,9 +210,51 @@ fn reborrow_written() {
 }
 
 #[test]
+fn reborrow_written_u64() {
+    let buf: &mut [_] = &mut [MaybeUninit::new(0u64); 32];
+    let mut buf = BorrowedBuf::<u64>::from(buf);
+
+    let mut cursor = buf.unfilled();
+    cursor.append(&[1; 16]);
+
+    let mut cursor2 = cursor.reborrow();
+    cursor2.append(&[2; 16]);
+
+    assert_eq!(cursor2.written(), 32);
+    assert_eq!(cursor.written(), 32);
+
+    assert_eq!(buf.unfilled().written(), 32);
+    assert!(!buf.is_init());
+    assert_eq!(buf.filled().len(), 32);
+    let filled = buf.filled();
+    assert_eq!(&filled[..16], [1; 16]);
+    assert_eq!(&filled[16..], [2; 16]);
+}
+
+#[test]
 fn cursor_set_init() {
     let buf: &mut [_] = &mut [MaybeUninit::zeroed(); 16];
     let mut rbuf: BorrowedBuf<'_, u8> = buf.into();
+    let mut cursor = rbuf.unfilled();
+
+    unsafe {
+        cursor.set_init();
+    }
+
+    assert!(cursor.is_init());
+    assert_eq!(unsafe { cursor.as_mut().len() }, 16);
+
+    cursor.advance_checked(4);
+
+    assert_eq!(unsafe { cursor.as_mut().len() }, 12);
+
+    assert!(rbuf.is_init());
+}
+
+#[test]
+fn cursor_set_init_u64() {
+    let buf: &mut [_] = &mut [MaybeUninit::<u64>::zeroed(); 16];
+    let mut rbuf = BorrowedBuf::<u64>::from(buf);
     let mut cursor = rbuf.unfilled();
 
     unsafe {

--- a/library/coretests/tests/io/borrowed_buf.rs
+++ b/library/coretests/tests/io/borrowed_buf.rs
@@ -5,7 +5,7 @@ use core::mem::MaybeUninit;
 #[test]
 fn new() {
     let buf: &mut [_] = &mut [0; 16];
-    let mut rbuf: BorrowedBuf<'_> = buf.into();
+    let mut rbuf: BorrowedBuf<'_, u8> = buf.into();
 
     assert_eq!(rbuf.filled().len(), 0);
     assert!(rbuf.is_init());
@@ -17,7 +17,7 @@ fn new() {
 #[test]
 fn uninit() {
     let buf: &mut [_] = &mut [MaybeUninit::uninit(); 16];
-    let mut rbuf: BorrowedBuf<'_> = buf.into();
+    let mut rbuf: BorrowedBuf<'_, u8> = buf.into();
 
     assert_eq!(rbuf.filled().len(), 0);
     assert!(!rbuf.is_init());
@@ -28,7 +28,7 @@ fn uninit() {
 #[test]
 fn initialize_unfilled() {
     let buf: &mut [_] = &mut [MaybeUninit::uninit(); 16];
-    let mut rbuf: BorrowedBuf<'_> = buf.into();
+    let mut rbuf: BorrowedBuf<'_, u8> = buf.into();
 
     rbuf.unfilled().ensure_init();
 
@@ -38,7 +38,7 @@ fn initialize_unfilled() {
 #[test]
 fn advance_filled() {
     let buf: &mut [_] = &mut [0; 16];
-    let mut rbuf: BorrowedBuf<'_> = buf.into();
+    let mut rbuf: BorrowedBuf<'_, u8> = buf.into();
 
     rbuf.unfilled().advance_checked(1);
 
@@ -49,7 +49,7 @@ fn advance_filled() {
 #[test]
 fn clear() {
     let buf: &mut [_] = &mut [255; 16];
-    let mut rbuf: BorrowedBuf<'_> = buf.into();
+    let mut rbuf: BorrowedBuf<'_, u8> = buf.into();
 
     rbuf.unfilled().advance_checked(16);
 
@@ -67,7 +67,7 @@ fn clear() {
 #[test]
 fn set_init() {
     let buf: &mut [_] = &mut [MaybeUninit::zeroed(); 16];
-    let mut rbuf: BorrowedBuf<'_> = buf.into();
+    let mut rbuf: BorrowedBuf<'_, u8> = buf.into();
 
     unsafe {
         rbuf.set_init();
@@ -79,7 +79,7 @@ fn set_init() {
 #[test]
 fn append() {
     let buf: &mut [_] = &mut [MaybeUninit::new(255); 16];
-    let mut rbuf: BorrowedBuf<'_> = buf.into();
+    let mut rbuf: BorrowedBuf<'_, u8> = buf.into();
 
     rbuf.unfilled().append(&[0; 8]);
 
@@ -99,7 +99,7 @@ fn append() {
 #[test]
 fn reborrow_written() {
     let buf: &mut [_] = &mut [MaybeUninit::new(0); 32];
-    let mut buf: BorrowedBuf<'_> = buf.into();
+    let mut buf: BorrowedBuf<'_, u8> = buf.into();
 
     let mut cursor = buf.unfilled();
     cursor.append(&[1; 16]);
@@ -121,7 +121,7 @@ fn reborrow_written() {
 #[test]
 fn cursor_set_init() {
     let buf: &mut [_] = &mut [MaybeUninit::zeroed(); 16];
-    let mut rbuf: BorrowedBuf<'_> = buf.into();
+    let mut rbuf: BorrowedBuf<'_, u8> = buf.into();
     let mut cursor = rbuf.unfilled();
 
     unsafe {

--- a/library/coretests/tests/io/borrowed_buf.rs
+++ b/library/coretests/tests/io/borrowed_buf.rs
@@ -24,6 +24,17 @@ fn new_u64() {
     assert_eq!(rbuf.unfilled().capacity(), 16);
 }
 
+#[test]
+fn new_unit() {
+    let buf: &mut [_] = &mut [(); 16];
+    let mut rbuf = BorrowedBuf::from(buf);
+
+    assert_eq!(rbuf.filled().len(), 0);
+    assert!(rbuf.is_init());
+    assert_eq!(rbuf.capacity(), 16);
+    assert_eq!(rbuf.unfilled().capacity(), 16);
+}
+
 /// Test that BorrowedBuf has the correct numbers when created with uninit
 #[test]
 fn uninit() {
@@ -40,6 +51,17 @@ fn uninit() {
 fn uninit_u64() {
     let buf: &mut [_] = &mut [MaybeUninit::<u64>::uninit(); 16];
     let mut rbuf = BorrowedBuf::<u64>::from(buf);
+
+    assert_eq!(rbuf.filled().len(), 0);
+    assert!(!rbuf.is_init());
+    assert_eq!(rbuf.capacity(), 16);
+    assert_eq!(rbuf.unfilled().capacity(), 16);
+}
+
+#[test]
+fn uninit_unit() {
+    let buf: &mut [_] = &mut [MaybeUninit::<()>::uninit(); 16];
+    let mut rbuf = BorrowedBuf::<()>::from(buf);
 
     assert_eq!(rbuf.filled().len(), 0);
     assert!(!rbuf.is_init());
@@ -71,6 +93,17 @@ fn advance_filled() {
 #[test]
 fn advance_filled_u64() {
     let buf: &mut [_] = &mut [0u64; 16];
+    let mut rbuf = BorrowedBuf::from(buf);
+
+    rbuf.unfilled().advance_checked(1);
+
+    assert_eq!(rbuf.filled().len(), 1);
+    assert_eq!(rbuf.unfilled().capacity(), 15);
+}
+
+#[test]
+fn advance_filled_unit() {
+    let buf: &mut [_] = &mut [(); 16];
     let mut rbuf = BorrowedBuf::from(buf);
 
     rbuf.unfilled().advance_checked(1);
@@ -120,6 +153,28 @@ fn clear_u64() {
 }
 
 #[test]
+fn clear_unit() {
+    let buf: &mut [_] = &mut [(); 16];
+    let mut rbuf = BorrowedBuf::from(buf);
+
+    rbuf.unfilled().advance_checked(16);
+
+    assert_eq!(rbuf.filled().len(), 16);
+    assert_eq!(rbuf.unfilled().capacity(), 0);
+
+    rbuf.clear();
+
+    assert_eq!(rbuf.filled().len(), 0);
+    assert_eq!(rbuf.unfilled().capacity(), 16);
+
+    unsafe {
+        rbuf.set_init();
+    }
+    rbuf.unfilled().advance_checked(16);
+    assert_eq!(rbuf.filled(), [(); 16]);
+}
+
+#[test]
 fn set_init() {
     let buf: &mut [_] = &mut [MaybeUninit::zeroed(); 16];
     let mut rbuf: BorrowedBuf<'_, u8> = buf.into();
@@ -145,6 +200,20 @@ fn set_init_u64() {
     assert!(rbuf.is_init());
     rbuf.unfilled().advance_checked(16);
     assert_eq!(rbuf.filled(), [0; 16]);
+}
+
+#[test]
+fn set_init_unit() {
+    let buf: &mut [_] = &mut [MaybeUninit::<()>::zeroed(); 16];
+    let mut rbuf = BorrowedBuf::<()>::from(buf);
+
+    unsafe {
+        rbuf.set_init();
+    }
+
+    assert!(rbuf.is_init());
+    rbuf.unfilled().advance_checked(16);
+    assert_eq!(rbuf.filled(), [(); 16]);
 }
 
 #[test]
@@ -185,6 +254,26 @@ fn append_u64() {
     assert!(!rbuf.is_init());
     assert_eq!(rbuf.filled().len(), 16);
     assert_eq!(rbuf.filled(), [1; 16]);
+}
+
+#[test]
+fn append_unit() {
+    let buf: &mut [_] = &mut [MaybeUninit::new(()); 16];
+    let mut rbuf = BorrowedBuf::<()>::from(buf);
+
+    rbuf.unfilled().append(&[(); 8]);
+
+    assert!(!rbuf.is_init());
+    assert_eq!(rbuf.filled().len(), 8);
+    assert_eq!(rbuf.filled(), [(); 8]);
+
+    rbuf.clear();
+
+    rbuf.unfilled().append(&[(); 16]);
+
+    assert!(!rbuf.is_init());
+    assert_eq!(rbuf.filled().len(), 16);
+    assert_eq!(rbuf.filled(), [(); 16]);
 }
 
 #[test]
@@ -232,6 +321,28 @@ fn reborrow_written_u64() {
 }
 
 #[test]
+fn reborrow_written_unit() {
+    let buf: &mut [_] = &mut [MaybeUninit::new(()); 32];
+    let mut buf = BorrowedBuf::<()>::from(buf);
+
+    let mut cursor = buf.unfilled();
+    cursor.append(&[(); 16]);
+
+    let mut cursor2 = cursor.reborrow();
+    cursor2.append(&[(); 16]);
+
+    assert_eq!(cursor2.written(), 32);
+    assert_eq!(cursor.written(), 32);
+
+    assert_eq!(buf.unfilled().written(), 32);
+    assert!(!buf.is_init());
+    assert_eq!(buf.filled().len(), 32);
+    let filled = buf.filled();
+    assert_eq!(&filled[..16], [(); 16]);
+    assert_eq!(&filled[16..], [(); 16]);
+}
+
+#[test]
 fn cursor_set_init() {
     let buf: &mut [_] = &mut [MaybeUninit::zeroed(); 16];
     let mut rbuf: BorrowedBuf<'_, u8> = buf.into();
@@ -255,6 +366,26 @@ fn cursor_set_init() {
 fn cursor_set_init_u64() {
     let buf: &mut [_] = &mut [MaybeUninit::<u64>::zeroed(); 16];
     let mut rbuf = BorrowedBuf::<u64>::from(buf);
+    let mut cursor = rbuf.unfilled();
+
+    unsafe {
+        cursor.set_init();
+    }
+
+    assert!(cursor.is_init());
+    assert_eq!(unsafe { cursor.as_mut().len() }, 16);
+
+    cursor.advance_checked(4);
+
+    assert_eq!(unsafe { cursor.as_mut().len() }, 12);
+
+    assert!(rbuf.is_init());
+}
+
+#[test]
+fn cursor_set_init_unit() {
+    let buf: &mut [_] = &mut [MaybeUninit::<()>::zeroed(); 16];
+    let mut rbuf = BorrowedBuf::<()>::from(buf);
     let mut cursor = rbuf.unfilled();
 
     unsafe {

--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -1354,7 +1354,7 @@ impl Read for &File {
     }
 
     #[inline]
-    fn read_buf(&mut self, cursor: BorrowedCursor<'_>) -> io::Result<()> {
+    fn read_buf(&mut self, cursor: BorrowedCursor<'_, u8>) -> io::Result<()> {
         self.inner.read_buf(cursor)
     }
 
@@ -1499,7 +1499,7 @@ impl Read for File {
     fn read_vectored(&mut self, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
         (&*self).read_vectored(bufs)
     }
-    fn read_buf(&mut self, cursor: BorrowedCursor<'_>) -> io::Result<()> {
+    fn read_buf(&mut self, cursor: BorrowedCursor<'_, u8>) -> io::Result<()> {
         (&*self).read_buf(cursor)
     }
     #[inline]

--- a/library/std/src/io/buffered/bufreader.rs
+++ b/library/std/src/io/buffered/bufreader.rs
@@ -350,7 +350,7 @@ impl<R: ?Sized + Read> Read for BufReader<R> {
         Ok(nread)
     }
 
-    fn read_buf(&mut self, mut cursor: BorrowedCursor<'_>) -> io::Result<()> {
+    fn read_buf(&mut self, mut cursor: BorrowedCursor<'_, u8>) -> io::Result<()> {
         // If we don't have any buffered data and we're doing a massive read
         // (larger than our internal buffer), bypass our internal buffer
         // entirely.
@@ -381,7 +381,7 @@ impl<R: ?Sized + Read> Read for BufReader<R> {
         crate::io::default_read_exact(self, buf)
     }
 
-    fn read_buf_exact(&mut self, mut cursor: BorrowedCursor<'_>) -> io::Result<()> {
+    fn read_buf_exact(&mut self, mut cursor: BorrowedCursor<'_, u8>) -> io::Result<()> {
         if self.buf.consume_with(cursor.capacity(), |claimed| cursor.append(claimed)) {
             return Ok(());
         }

--- a/library/std/src/io/buffered/tests.rs
+++ b/library/std/src/io/buffered/tests.rs
@@ -63,7 +63,7 @@ fn test_buffered_reader_read_buf() {
     let mut reader = BufReader::with_capacity(2, inner);
 
     let buf: &mut [_] = &mut [MaybeUninit::uninit(); 3];
-    let mut buf: BorrowedBuf<'_> = buf.into();
+    let mut buf: BorrowedBuf<'_, u8> = buf.into();
 
     reader.read_buf(buf.unfilled()).unwrap();
 
@@ -71,7 +71,7 @@ fn test_buffered_reader_read_buf() {
     assert_eq!(reader.buffer(), []);
 
     let buf: &mut [_] = &mut [MaybeUninit::uninit(); 2];
-    let mut buf: BorrowedBuf<'_> = buf.into();
+    let mut buf: BorrowedBuf<'_, u8> = buf.into();
 
     reader.read_buf(buf.unfilled()).unwrap();
 
@@ -79,7 +79,7 @@ fn test_buffered_reader_read_buf() {
     assert_eq!(reader.buffer(), []);
 
     let buf: &mut [_] = &mut [MaybeUninit::uninit(); 1];
-    let mut buf: BorrowedBuf<'_> = buf.into();
+    let mut buf: BorrowedBuf<'_, u8> = buf.into();
 
     reader.read_buf(buf.unfilled()).unwrap();
 
@@ -87,7 +87,7 @@ fn test_buffered_reader_read_buf() {
     assert_eq!(reader.buffer(), [3]);
 
     let buf: &mut [_] = &mut [MaybeUninit::uninit(); 3];
-    let mut buf: BorrowedBuf<'_> = buf.into();
+    let mut buf: BorrowedBuf<'_, u8> = buf.into();
 
     reader.read_buf(buf.unfilled()).unwrap();
 

--- a/library/std/src/io/copy.rs
+++ b/library/std/src/io/copy.rs
@@ -218,7 +218,7 @@ impl<I: Write + ?Sized> BufferedWriterSpec for BufWriter<I> {
 
         loop {
             let buf = self.buffer_mut();
-            let mut read_buf: BorrowedBuf<'_> = buf.spare_capacity_mut().into();
+            let mut read_buf: BorrowedBuf<'_, u8> = buf.spare_capacity_mut().into();
 
             if init {
                 // SAFETY: `init` is only true after `reader` initializes
@@ -272,7 +272,7 @@ fn stack_buffer_copy<R: Read + ?Sized, W: Write + ?Sized>(
     writer: &mut W,
 ) -> Result<u64> {
     let buf: &mut [_] = &mut [MaybeUninit::uninit(); DEFAULT_BUF_SIZE];
-    let mut buf: BorrowedBuf<'_> = buf.into();
+    let mut buf: BorrowedBuf<'_, u8> = buf.into();
 
     let mut len = 0;
 

--- a/library/std/src/io/cursor.rs
+++ b/library/std/src/io/cursor.rs
@@ -55,7 +55,7 @@ where
         Ok(n)
     }
 
-    fn read_buf(&mut self, mut cursor: BorrowedCursor<'_>) -> io::Result<()> {
+    fn read_buf(&mut self, mut cursor: BorrowedCursor<'_, u8>) -> io::Result<()> {
         let prev_written = cursor.written();
 
         Read::read_buf(&mut Cursor::split(self).1, cursor.reborrow())?;
@@ -93,7 +93,7 @@ where
         result
     }
 
-    fn read_buf_exact(&mut self, mut cursor: BorrowedCursor<'_>) -> io::Result<()> {
+    fn read_buf_exact(&mut self, mut cursor: BorrowedCursor<'_, u8>) -> io::Result<()> {
         let prev_written = cursor.written();
 
         let result = Read::read_buf_exact(&mut Cursor::split(self).1, cursor.reborrow());

--- a/library/std/src/io/impls.rs
+++ b/library/std/src/io/impls.rs
@@ -18,7 +18,7 @@ impl<R: Read + ?Sized> Read for &mut R {
     }
 
     #[inline]
-    fn read_buf(&mut self, cursor: BorrowedCursor<'_>) -> io::Result<()> {
+    fn read_buf(&mut self, cursor: BorrowedCursor<'_, u8>) -> io::Result<()> {
         (**self).read_buf(cursor)
     }
 
@@ -48,7 +48,7 @@ impl<R: Read + ?Sized> Read for &mut R {
     }
 
     #[inline]
-    fn read_buf_exact(&mut self, cursor: BorrowedCursor<'_>) -> io::Result<()> {
+    fn read_buf_exact(&mut self, cursor: BorrowedCursor<'_, u8>) -> io::Result<()> {
         (**self).read_buf_exact(cursor)
     }
 }
@@ -157,7 +157,7 @@ impl<R: Read + ?Sized> Read for Box<R> {
     }
 
     #[inline]
-    fn read_buf(&mut self, cursor: BorrowedCursor<'_>) -> io::Result<()> {
+    fn read_buf(&mut self, cursor: BorrowedCursor<'_, u8>) -> io::Result<()> {
         (**self).read_buf(cursor)
     }
 
@@ -187,7 +187,7 @@ impl<R: Read + ?Sized> Read for Box<R> {
     }
 
     #[inline]
-    fn read_buf_exact(&mut self, cursor: BorrowedCursor<'_>) -> io::Result<()> {
+    fn read_buf_exact(&mut self, cursor: BorrowedCursor<'_, u8>) -> io::Result<()> {
         (**self).read_buf_exact(cursor)
     }
 }
@@ -316,7 +316,7 @@ impl Read for &[u8] {
     }
 
     #[inline]
-    fn read_buf(&mut self, mut cursor: BorrowedCursor<'_>) -> io::Result<()> {
+    fn read_buf(&mut self, mut cursor: BorrowedCursor<'_, u8>) -> io::Result<()> {
         let amt = cmp::min(cursor.capacity(), self.len());
         let (a, b) = self.split_at(amt);
 
@@ -368,7 +368,7 @@ impl Read for &[u8] {
     }
 
     #[inline]
-    fn read_buf_exact(&mut self, mut cursor: BorrowedCursor<'_>) -> io::Result<()> {
+    fn read_buf_exact(&mut self, mut cursor: BorrowedCursor<'_, u8>) -> io::Result<()> {
         if cursor.capacity() > self.len() {
             // Append everything we can to the cursor.
             cursor.append(*self);
@@ -557,7 +557,7 @@ impl<A: Allocator> Read for VecDeque<u8, A> {
     }
 
     #[inline]
-    fn read_buf(&mut self, cursor: BorrowedCursor<'_>) -> io::Result<()> {
+    fn read_buf(&mut self, cursor: BorrowedCursor<'_, u8>) -> io::Result<()> {
         let (ref mut front, _) = self.as_slices();
         let n = cmp::min(cursor.capacity(), front.len());
         Read::read_buf(front, cursor)?;
@@ -566,7 +566,7 @@ impl<A: Allocator> Read for VecDeque<u8, A> {
     }
 
     #[inline]
-    fn read_buf_exact(&mut self, mut cursor: BorrowedCursor<'_>) -> io::Result<()> {
+    fn read_buf_exact(&mut self, mut cursor: BorrowedCursor<'_, u8>) -> io::Result<()> {
         let len = cursor.capacity();
         let (front, back) = self.as_slices();
 
@@ -670,7 +670,7 @@ impl<A: Allocator> Write for VecDeque<u8, A> {
 }
 
 #[unstable(feature = "read_buf", issue = "78485")]
-impl<'a> io::Write for core::io::BorrowedCursor<'a> {
+impl<'a> io::Write for core::io::BorrowedCursor<'a, u8> {
     #[inline]
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         let amt = cmp::min(buf.len(), self.capacity());
@@ -729,7 +729,7 @@ where
     }
 
     #[inline]
-    fn read_buf(&mut self, cursor: BorrowedCursor<'_>) -> io::Result<()> {
+    fn read_buf(&mut self, cursor: BorrowedCursor<'_, u8>) -> io::Result<()> {
         (&**self).read_buf(cursor)
     }
 
@@ -759,7 +759,7 @@ where
     }
 
     #[inline]
-    fn read_buf_exact(&mut self, cursor: BorrowedCursor<'_>) -> io::Result<()> {
+    fn read_buf_exact(&mut self, cursor: BorrowedCursor<'_, u8>) -> io::Result<()> {
         (&**self).read_buf_exact(cursor)
     }
 }

--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -469,7 +469,7 @@ pub(crate) fn default_read_to_end<R: Read + ?Sized>(
         let mut spare = buf.spare_capacity_mut();
         let buf_len = cmp::min(spare.len(), max_read_size);
         spare = &mut spare[..buf_len];
-        let mut read_buf: BorrowedBuf<'_> = spare.into();
+        let mut read_buf: BorrowedBuf<'_, u8> = spare.into();
 
         // Note that we don't track already initialized bytes here, but this is fine
         // because we explicitly limit the read size
@@ -566,7 +566,7 @@ pub(crate) fn default_read_exact<R: Read + ?Sized>(this: &mut R, mut buf: &mut [
     if !buf.is_empty() { Err(Error::READ_EXACT_EOF) } else { Ok(()) }
 }
 
-pub(crate) fn default_read_buf<F>(read: F, mut cursor: BorrowedCursor<'_>) -> Result<()>
+pub(crate) fn default_read_buf<F>(read: F, mut cursor: BorrowedCursor<'_, u8>) -> Result<()>
 where
     F: FnOnce(&mut [u8]) -> Result<usize>,
 {
@@ -577,7 +577,7 @@ where
 
 pub(crate) fn default_read_buf_exact<R: Read + ?Sized>(
     this: &mut R,
-    mut cursor: BorrowedCursor<'_>,
+    mut cursor: BorrowedCursor<'_, u8>,
 ) -> Result<()> {
     while cursor.capacity() > 0 {
         let prev_written = cursor.written();
@@ -1037,7 +1037,7 @@ pub trait Read {
     ///
     /// This method makes it possible to return both data and an error but it is advised against.
     #[unstable(feature = "read_buf", issue = "78485")]
-    fn read_buf(&mut self, buf: BorrowedCursor<'_>) -> Result<()> {
+    fn read_buf(&mut self, buf: BorrowedCursor<'_, u8>) -> Result<()> {
         default_read_buf(|b| self.read(b), buf)
     }
 
@@ -1060,7 +1060,7 @@ pub trait Read {
     ///
     /// If this function returns an error, all bytes read will be appended to `cursor`.
     #[unstable(feature = "read_buf", issue = "78485")]
-    fn read_buf_exact(&mut self, cursor: BorrowedCursor<'_>) -> Result<()> {
+    fn read_buf_exact(&mut self, cursor: BorrowedCursor<'_, u8>) -> Result<()> {
         default_read_buf_exact(self, cursor)
     }
 
@@ -2745,7 +2745,7 @@ impl<T: Read, U: Read> Read for Chain<T, U> {
     // We don't override `read_to_string` here because an UTF-8 sequence could
     // be split between the two parts of the chain
 
-    fn read_buf(&mut self, mut buf: BorrowedCursor<'_>) -> Result<()> {
+    fn read_buf(&mut self, mut buf: BorrowedCursor<'_, u8>) -> Result<()> {
         if buf.capacity() == 0 {
             return Ok(());
         }
@@ -2829,7 +2829,7 @@ impl<T: Read> Read for Take<T> {
         Ok(n)
     }
 
-    fn read_buf(&mut self, mut buf: BorrowedCursor<'_>) -> Result<()> {
+    fn read_buf(&mut self, mut buf: BorrowedCursor<'_, u8>) -> Result<()> {
         // Don't call into inner reader at all at EOF because it may still block
         if self.limit == 0 {
             return Ok(());

--- a/library/std/src/io/pipe.rs
+++ b/library/std/src/io/pipe.rs
@@ -227,7 +227,7 @@ impl io::Read for &PipeReader {
     fn read_to_end(&mut self, buf: &mut Vec<u8>) -> io::Result<usize> {
         self.0.read_to_end(buf)
     }
-    fn read_buf(&mut self, buf: io::BorrowedCursor<'_>) -> io::Result<()> {
+    fn read_buf(&mut self, buf: io::BorrowedCursor<'_, u8>) -> io::Result<()> {
         self.0.read_buf(buf)
     }
 }
@@ -247,7 +247,7 @@ impl io::Read for PipeReader {
     fn read_to_end(&mut self, buf: &mut Vec<u8>) -> io::Result<usize> {
         self.0.read_to_end(buf)
     }
-    fn read_buf(&mut self, buf: io::BorrowedCursor<'_>) -> io::Result<()> {
+    fn read_buf(&mut self, buf: io::BorrowedCursor<'_, u8>) -> io::Result<()> {
         self.0.read_buf(buf)
     }
 }

--- a/library/std/src/io/stdio.rs
+++ b/library/std/src/io/stdio.rs
@@ -100,7 +100,7 @@ impl Read for StdinRaw {
         handle_ebadf(self.0.read(buf), || Ok(0))
     }
 
-    fn read_buf(&mut self, buf: BorrowedCursor<'_>) -> io::Result<()> {
+    fn read_buf(&mut self, buf: BorrowedCursor<'_, u8>) -> io::Result<()> {
         handle_ebadf(self.0.read_buf(buf), || Ok(()))
     }
 
@@ -120,7 +120,7 @@ impl Read for StdinRaw {
         handle_ebadf(self.0.read_exact(buf), || Err(io::Error::READ_EXACT_EOF))
     }
 
-    fn read_buf_exact(&mut self, buf: BorrowedCursor<'_>) -> io::Result<()> {
+    fn read_buf_exact(&mut self, buf: BorrowedCursor<'_, u8>) -> io::Result<()> {
         if buf.capacity() == 0 {
             return Ok(());
         }
@@ -447,7 +447,7 @@ impl Read for Stdin {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         self.lock().read(buf)
     }
-    fn read_buf(&mut self, buf: BorrowedCursor<'_>) -> io::Result<()> {
+    fn read_buf(&mut self, buf: BorrowedCursor<'_, u8>) -> io::Result<()> {
         self.lock().read_buf(buf)
     }
     fn read_vectored(&mut self, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
@@ -466,7 +466,7 @@ impl Read for Stdin {
     fn read_exact(&mut self, buf: &mut [u8]) -> io::Result<()> {
         self.lock().read_exact(buf)
     }
-    fn read_buf_exact(&mut self, cursor: BorrowedCursor<'_>) -> io::Result<()> {
+    fn read_buf_exact(&mut self, cursor: BorrowedCursor<'_, u8>) -> io::Result<()> {
         self.lock().read_buf_exact(cursor)
     }
 }
@@ -476,7 +476,7 @@ impl Read for &Stdin {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         self.lock().read(buf)
     }
-    fn read_buf(&mut self, buf: BorrowedCursor<'_>) -> io::Result<()> {
+    fn read_buf(&mut self, buf: BorrowedCursor<'_, u8>) -> io::Result<()> {
         self.lock().read_buf(buf)
     }
     fn read_vectored(&mut self, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
@@ -495,7 +495,7 @@ impl Read for &Stdin {
     fn read_exact(&mut self, buf: &mut [u8]) -> io::Result<()> {
         self.lock().read_exact(buf)
     }
-    fn read_buf_exact(&mut self, cursor: BorrowedCursor<'_>) -> io::Result<()> {
+    fn read_buf_exact(&mut self, cursor: BorrowedCursor<'_, u8>) -> io::Result<()> {
         self.lock().read_buf_exact(cursor)
     }
 }
@@ -514,7 +514,7 @@ impl Read for StdinLock<'_> {
         self.inner.read(buf)
     }
 
-    fn read_buf(&mut self, buf: BorrowedCursor<'_>) -> io::Result<()> {
+    fn read_buf(&mut self, buf: BorrowedCursor<'_, u8>) -> io::Result<()> {
         self.inner.read_buf(buf)
     }
 
@@ -539,7 +539,7 @@ impl Read for StdinLock<'_> {
         self.inner.read_exact(buf)
     }
 
-    fn read_buf_exact(&mut self, cursor: BorrowedCursor<'_>) -> io::Result<()> {
+    fn read_buf_exact(&mut self, cursor: BorrowedCursor<'_, u8>) -> io::Result<()> {
         self.inner.read_buf_exact(cursor)
     }
 }

--- a/library/std/src/io/tests.rs
+++ b/library/std/src/io/tests.rs
@@ -190,7 +190,7 @@ fn read_exact_slice() {
 #[test]
 fn read_buf_exact() {
     let buf: &mut [_] = &mut [0; 4];
-    let mut buf: BorrowedBuf<'_> = buf.into();
+    let mut buf: BorrowedBuf<'_, u8> = buf.into();
 
     let mut c = Cursor::new(&b""[..]);
     assert_eq!(c.read_buf_exact(buf.unfilled()).unwrap_err().kind(), io::ErrorKind::UnexpectedEof);
@@ -832,7 +832,7 @@ fn bench_take_read_buf(b: &mut test::Bencher) {
     b.iter(|| {
         let buf: &mut [_] = &mut [MaybeUninit::uninit(); 64];
 
-        let mut buf: BorrowedBuf<'_> = buf.into();
+        let mut buf: BorrowedBuf<'_, u8> = buf.into();
 
         [255; 128].take(64).read_buf(buf.unfilled()).unwrap();
     });
@@ -874,7 +874,7 @@ impl Read for DataAndErrorReader {
         panic!("We want tests to use `read_buf`")
     }
 
-    fn read_buf(&mut self, buf: io::BorrowedCursor<'_>) -> io::Result<()> {
+    fn read_buf(&mut self, buf: io::BorrowedCursor<'_, u8>) -> io::Result<()> {
         self.0.read_buf(buf).unwrap();
         Err(io::Error::other("error"))
     }

--- a/library/std/src/io/util.rs
+++ b/library/std/src/io/util.rs
@@ -17,7 +17,7 @@ impl Read for Empty {
     }
 
     #[inline]
-    fn read_buf(&mut self, _cursor: BorrowedCursor<'_>) -> io::Result<()> {
+    fn read_buf(&mut self, _cursor: BorrowedCursor<'_, u8>) -> io::Result<()> {
         Ok(())
     }
 
@@ -39,7 +39,7 @@ impl Read for Empty {
     }
 
     #[inline]
-    fn read_buf_exact(&mut self, cursor: BorrowedCursor<'_>) -> io::Result<()> {
+    fn read_buf_exact(&mut self, cursor: BorrowedCursor<'_, u8>) -> io::Result<()> {
         if cursor.capacity() != 0 { Err(io::Error::READ_EXACT_EOF) } else { Ok(()) }
     }
 
@@ -202,7 +202,7 @@ impl Read for Repeat {
     }
 
     #[inline]
-    fn read_buf(&mut self, mut buf: BorrowedCursor<'_>) -> io::Result<()> {
+    fn read_buf(&mut self, mut buf: BorrowedCursor<'_, u8>) -> io::Result<()> {
         // SAFETY: No uninit bytes are being written.
         unsafe { buf.as_mut() }.write_filled(self.byte);
         // SAFETY: the entire unfilled portion of buf has been initialized.
@@ -211,7 +211,7 @@ impl Read for Repeat {
     }
 
     #[inline]
-    fn read_buf_exact(&mut self, buf: BorrowedCursor<'_>) -> io::Result<()> {
+    fn read_buf_exact(&mut self, buf: BorrowedCursor<'_, u8>) -> io::Result<()> {
         self.read_buf(buf)
     }
 

--- a/library/std/src/io/util/tests.rs
+++ b/library/std/src/io/util/tests.rs
@@ -72,49 +72,49 @@ fn empty_reads() {
     assert_eq!(e.read_vectored(bufs).unwrap(), 0);
 
     let buf: &mut [MaybeUninit<_>] = &mut [];
-    let mut buf: BorrowedBuf<'_> = buf.into();
+    let mut buf: BorrowedBuf<'_, u8> = buf.into();
     e.read_buf(buf.unfilled()).unwrap();
     assert_eq!(buf.len(), 0);
     assert!(!buf.is_init());
 
     let buf: &mut [_] = &mut [MaybeUninit::uninit()];
-    let mut buf: BorrowedBuf<'_> = buf.into();
+    let mut buf: BorrowedBuf<'_, u8> = buf.into();
     e.read_buf(buf.unfilled()).unwrap();
     assert_eq!(buf.len(), 0);
     assert!(!buf.is_init());
 
     let buf: &mut [_] = &mut [MaybeUninit::uninit(); 1024];
-    let mut buf: BorrowedBuf<'_> = buf.into();
+    let mut buf: BorrowedBuf<'_, u8> = buf.into();
     e.read_buf(buf.unfilled()).unwrap();
     assert_eq!(buf.len(), 0);
     assert!(!buf.is_init());
 
     let buf: &mut [_] = &mut [MaybeUninit::uninit(); 1024];
-    let mut buf: BorrowedBuf<'_> = buf.into();
+    let mut buf: BorrowedBuf<'_, u8> = buf.into();
     Read::by_ref(&mut e).read_buf(buf.unfilled()).unwrap();
     assert_eq!(buf.len(), 0);
     assert!(!buf.is_init());
 
     let buf: &mut [MaybeUninit<_>] = &mut [];
-    let mut buf: BorrowedBuf<'_> = buf.into();
+    let mut buf: BorrowedBuf<'_, u8> = buf.into();
     e.read_buf_exact(buf.unfilled()).unwrap();
     assert_eq!(buf.len(), 0);
     assert!(!buf.is_init());
 
     let buf: &mut [_] = &mut [MaybeUninit::uninit()];
-    let mut buf: BorrowedBuf<'_> = buf.into();
+    let mut buf: BorrowedBuf<'_, u8> = buf.into();
     assert_eq!(e.read_buf_exact(buf.unfilled()).unwrap_err().kind(), ErrorKind::UnexpectedEof);
     assert_eq!(buf.len(), 0);
     assert!(!buf.is_init());
 
     let buf: &mut [_] = &mut [MaybeUninit::uninit(); 1024];
-    let mut buf: BorrowedBuf<'_> = buf.into();
+    let mut buf: BorrowedBuf<'_, u8> = buf.into();
     assert_eq!(e.read_buf_exact(buf.unfilled()).unwrap_err().kind(), ErrorKind::UnexpectedEof);
     assert_eq!(buf.len(), 0);
     assert!(!buf.is_init());
 
     let buf: &mut [_] = &mut [MaybeUninit::uninit(); 1024];
-    let mut buf: BorrowedBuf<'_> = buf.into();
+    let mut buf: BorrowedBuf<'_, u8> = buf.into();
     assert_eq!(
         Read::by_ref(&mut e).read_buf_exact(buf.unfilled()).unwrap_err().kind(),
         ErrorKind::UnexpectedEof,

--- a/library/std/src/net/tcp.rs
+++ b/library/std/src/net/tcp.rs
@@ -682,7 +682,7 @@ impl Read for TcpStream {
         self.0.read(buf)
     }
 
-    fn read_buf(&mut self, buf: BorrowedCursor<'_>) -> io::Result<()> {
+    fn read_buf(&mut self, buf: BorrowedCursor<'_, u8>) -> io::Result<()> {
         self.0.read_buf(buf)
     }
 
@@ -721,7 +721,7 @@ impl Read for &TcpStream {
         self.0.read(buf)
     }
 
-    fn read_buf(&mut self, buf: BorrowedCursor<'_>) -> io::Result<()> {
+    fn read_buf(&mut self, buf: BorrowedCursor<'_, u8>) -> io::Result<()> {
         self.0.read_buf(buf)
     }
 

--- a/library/std/src/os/unix/fs.rs
+++ b/library/std/src/os/unix/fs.rs
@@ -163,7 +163,7 @@ pub trait FileExt {
     /// }
     /// ```
     #[unstable(feature = "read_buf_at", issue = "140771")]
-    fn read_buf_at(&self, buf: BorrowedCursor<'_>, offset: u64) -> io::Result<()> {
+    fn read_buf_at(&self, buf: BorrowedCursor<'_, u8>, offset: u64) -> io::Result<()> {
         io::default_read_buf(|b| self.read_at(b, offset), buf)
     }
 
@@ -199,7 +199,11 @@ pub trait FileExt {
     /// }
     /// ```
     #[unstable(feature = "read_buf_at", issue = "140771")]
-    fn read_buf_exact_at(&self, mut buf: BorrowedCursor<'_>, mut offset: u64) -> io::Result<()> {
+    fn read_buf_exact_at(
+        &self,
+        mut buf: BorrowedCursor<'_, u8>,
+        mut offset: u64,
+    ) -> io::Result<()> {
         while buf.capacity() > 0 {
             let prev_written = buf.written();
             match self.read_buf_at(buf.reborrow(), offset) {
@@ -350,7 +354,7 @@ impl FileExt for fs::File {
     fn read_at(&self, buf: &mut [u8], offset: u64) -> io::Result<usize> {
         self.as_inner().read_at(buf, offset)
     }
-    fn read_buf_at(&self, buf: BorrowedCursor<'_>, offset: u64) -> io::Result<()> {
+    fn read_buf_at(&self, buf: BorrowedCursor<'_, u8>, offset: u64) -> io::Result<()> {
         self.as_inner().read_buf_at(buf, offset)
     }
     fn read_vectored_at(&self, bufs: &mut [io::IoSliceMut<'_>], offset: u64) -> io::Result<usize> {

--- a/library/std/src/os/unix/net/stream.rs
+++ b/library/std/src/os/unix/net/stream.rs
@@ -617,7 +617,7 @@ impl io::Read for UnixStream {
         io::Read::read(&mut &*self, buf)
     }
 
-    fn read_buf(&mut self, buf: io::BorrowedCursor<'_>) -> io::Result<()> {
+    fn read_buf(&mut self, buf: io::BorrowedCursor<'_, u8>) -> io::Result<()> {
         io::Read::read_buf(&mut &*self, buf)
     }
 
@@ -637,7 +637,7 @@ impl<'a> io::Read for &'a UnixStream {
         self.0.read(buf)
     }
 
-    fn read_buf(&mut self, buf: io::BorrowedCursor<'_>) -> io::Result<()> {
+    fn read_buf(&mut self, buf: io::BorrowedCursor<'_, u8>) -> io::Result<()> {
         self.0.read_buf(buf)
     }
 

--- a/library/std/src/os/wasi/fs.rs
+++ b/library/std/src/os/wasi/fs.rs
@@ -52,7 +52,7 @@ pub trait FileExt {
     /// This equivalent to the [`read_at`](FileExt::read_at) method, except that it is passed a
     /// [`BorrowedCursor`] rather than `&mut [u8]` to allow use with uninitialized buffers. The new
     /// data will be appended to any existing contents of `buf`.
-    fn read_buf_at(&self, buf: BorrowedCursor<'_>, offset: u64) -> io::Result<()>;
+    fn read_buf_at(&self, buf: BorrowedCursor<'_, u8>, offset: u64) -> io::Result<()>;
 
     /// Reads the exact number of byte required to fill `buf` from the given offset.
     ///
@@ -228,7 +228,7 @@ impl FileExt for File {
         self.as_inner().read_at(buf, offset)
     }
 
-    fn read_buf_at(&self, buf: BorrowedCursor<'_>, offset: u64) -> io::Result<()> {
+    fn read_buf_at(&self, buf: BorrowedCursor<'_, u8>, offset: u64) -> io::Result<()> {
         self.as_inner().read_buf_at(buf, offset)
     }
 

--- a/library/std/src/os/windows/fs.rs
+++ b/library/std/src/os/windows/fs.rs
@@ -84,7 +84,7 @@ pub trait FileExt {
     /// }
     /// ```
     #[unstable(feature = "read_buf_at", issue = "140771")]
-    fn seek_read_buf(&self, buf: BorrowedCursor<'_>, offset: u64) -> io::Result<()> {
+    fn seek_read_buf(&self, buf: BorrowedCursor<'_, u8>, offset: u64) -> io::Result<()> {
         io::default_read_buf(|b| self.seek_read(b, offset), buf)
     }
 
@@ -128,7 +128,7 @@ impl FileExt for fs::File {
         self.as_inner().read_at(buf, offset)
     }
 
-    fn seek_read_buf(&self, buf: BorrowedCursor<'_>, offset: u64) -> io::Result<()> {
+    fn seek_read_buf(&self, buf: BorrowedCursor<'_, u8>, offset: u64) -> io::Result<()> {
         self.as_inner().read_buf_at(buf, offset)
     }
 

--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -417,7 +417,7 @@ impl Read for ChildStdout {
         self.inner.read(buf)
     }
 
-    fn read_buf(&mut self, buf: BorrowedCursor<'_>) -> io::Result<()> {
+    fn read_buf(&mut self, buf: BorrowedCursor<'_, u8>) -> io::Result<()> {
         self.inner.read_buf(buf)
     }
 
@@ -487,7 +487,7 @@ impl Read for ChildStderr {
         self.inner.read(buf)
     }
 
-    fn read_buf(&mut self, buf: BorrowedCursor<'_>) -> io::Result<()> {
+    fn read_buf(&mut self, buf: BorrowedCursor<'_, u8>) -> io::Result<()> {
         self.inner.read_buf(buf)
     }
 

--- a/library/std/src/sys/fd/hermit.rs
+++ b/library/std/src/sys/fd/hermit.rs
@@ -22,7 +22,7 @@ impl FileDesc {
         Ok(result as usize)
     }
 
-    pub fn read_buf(&self, mut buf: BorrowedCursor<'_>) -> io::Result<()> {
+    pub fn read_buf(&self, mut buf: BorrowedCursor<'_, u8>) -> io::Result<()> {
         // SAFETY: The `read` syscall does not read from the buffer, so it is
         // safe to use `&mut [MaybeUninit<u8>]`.
         let result = cvt(unsafe {

--- a/library/std/src/sys/fd/motor.rs
+++ b/library/std/src/sys/fd/motor.rs
@@ -12,7 +12,7 @@ impl FileDesc {
         moto_rt::fs::read(self.as_raw_fd(), buf).map_err(map_motor_error)
     }
 
-    pub fn read_buf(&self, cursor: BorrowedCursor<'_>) -> io::Result<()> {
+    pub fn read_buf(&self, cursor: BorrowedCursor<'_, u8>) -> io::Result<()> {
         crate::io::default_read_buf(|buf| self.read(buf), cursor)
     }
 
@@ -64,7 +64,7 @@ impl<'a> Read for &'a FileDesc {
         (**self).read(buf)
     }
 
-    fn read_buf(&mut self, cursor: BorrowedCursor<'_>) -> io::Result<()> {
+    fn read_buf(&mut self, cursor: BorrowedCursor<'_, u8>) -> io::Result<()> {
         (**self).read_buf(cursor)
     }
 

--- a/library/std/src/sys/fd/sgx.rs
+++ b/library/std/src/sys/fd/sgx.rs
@@ -28,7 +28,7 @@ impl FileDesc {
         usercalls::read(self.fd, &mut [IoSliceMut::new(buf)])
     }
 
-    pub fn read_buf(&self, buf: BorrowedCursor<'_>) -> io::Result<()> {
+    pub fn read_buf(&self, buf: BorrowedCursor<'_, u8>) -> io::Result<()> {
         usercalls::read_buf(self.fd, buf)
     }
 

--- a/library/std/src/sys/fd/unix.rs
+++ b/library/std/src/sys/fd/unix.rs
@@ -173,7 +173,7 @@ impl FileDesc {
         .map(|n| n as usize)
     }
 
-    pub fn read_buf(&self, mut cursor: BorrowedCursor<'_>) -> io::Result<()> {
+    pub fn read_buf(&self, mut cursor: BorrowedCursor<'_, u8>) -> io::Result<()> {
         // SAFETY: `cursor.as_mut()` starts with `cursor.capacity()` writable bytes
         let ret = cvt(unsafe {
             libc::read(
@@ -190,7 +190,7 @@ impl FileDesc {
         Ok(())
     }
 
-    pub fn read_buf_at(&self, mut cursor: BorrowedCursor<'_>, offset: u64) -> io::Result<()> {
+    pub fn read_buf_at(&self, mut cursor: BorrowedCursor<'_, u8>, offset: u64) -> io::Result<()> {
         // SAFETY: `cursor.as_mut()` starts with `cursor.capacity()` writable bytes
         let ret = cvt(unsafe {
             pread64(
@@ -640,7 +640,7 @@ impl<'a> Read for &'a FileDesc {
         (**self).read(buf)
     }
 
-    fn read_buf(&mut self, cursor: BorrowedCursor<'_>) -> io::Result<()> {
+    fn read_buf(&mut self, cursor: BorrowedCursor<'_, u8>) -> io::Result<()> {
         (**self).read_buf(cursor)
     }
 

--- a/library/std/src/sys/fs/hermit.rs
+++ b/library/std/src/sys/fs/hermit.rs
@@ -396,7 +396,7 @@ impl File {
         self.0.is_read_vectored()
     }
 
-    pub fn read_buf(&self, cursor: BorrowedCursor<'_>) -> io::Result<()> {
+    pub fn read_buf(&self, cursor: BorrowedCursor<'_, u8>) -> io::Result<()> {
         self.0.read_buf(cursor)
     }
 

--- a/library/std/src/sys/fs/motor.rs
+++ b/library/std/src/sys/fs/motor.rs
@@ -203,7 +203,7 @@ impl File {
         false
     }
 
-    pub fn read_buf(&self, cursor: BorrowedCursor<'_>) -> io::Result<()> {
+    pub fn read_buf(&self, cursor: BorrowedCursor<'_, u8>) -> io::Result<()> {
         crate::io::default_read_buf(|buf| self.read(buf), cursor)
     }
 

--- a/library/std/src/sys/fs/solid.rs
+++ b/library/std/src/sys/fs/solid.rs
@@ -383,7 +383,7 @@ impl File {
         }
     }
 
-    pub fn read_buf(&self, mut cursor: BorrowedCursor<'_>) -> io::Result<()> {
+    pub fn read_buf(&self, mut cursor: BorrowedCursor<'_, u8>) -> io::Result<()> {
         unsafe {
             let len = cursor.capacity();
             let mut out_num_bytes = MaybeUninit::uninit();

--- a/library/std/src/sys/fs/uefi.rs
+++ b/library/std/src/sys/fs/uefi.rs
@@ -332,7 +332,7 @@ impl File {
         false
     }
 
-    pub fn read_buf(&self, cursor: BorrowedCursor<'_>) -> io::Result<()> {
+    pub fn read_buf(&self, cursor: BorrowedCursor<'_, u8>) -> io::Result<()> {
         crate::io::default_read_buf(|buf| self.read(buf), cursor)
     }
 

--- a/library/std/src/sys/fs/unix.rs
+++ b/library/std/src/sys/fs/unix.rs
@@ -1717,11 +1717,11 @@ impl File {
         self.0.read_at(buf, offset)
     }
 
-    pub fn read_buf(&self, cursor: BorrowedCursor<'_>) -> io::Result<()> {
+    pub fn read_buf(&self, cursor: BorrowedCursor<'_, u8>) -> io::Result<()> {
         self.0.read_buf(cursor)
     }
 
-    pub fn read_buf_at(&self, cursor: BorrowedCursor<'_>, offset: u64) -> io::Result<()> {
+    pub fn read_buf_at(&self, cursor: BorrowedCursor<'_, u8>, offset: u64) -> io::Result<()> {
         self.0.read_buf_at(cursor, offset)
     }
 
@@ -2355,7 +2355,7 @@ mod cfm {
         fn read_vectored(&mut self, bufs: &mut [IoSliceMut<'_>]) -> Result<usize> {
             self.0.read_vectored(bufs)
         }
-        fn read_buf(&mut self, cursor: BorrowedCursor<'_>) -> Result<()> {
+        fn read_buf(&mut self, cursor: BorrowedCursor<'_, u8>) -> Result<()> {
             self.0.read_buf(cursor)
         }
         #[inline]

--- a/library/std/src/sys/fs/unsupported.rs
+++ b/library/std/src/sys/fs/unsupported.rs
@@ -236,7 +236,7 @@ impl File {
         self.0
     }
 
-    pub fn read_buf(&self, _cursor: BorrowedCursor<'_>) -> io::Result<()> {
+    pub fn read_buf(&self, _cursor: BorrowedCursor<'_, u8>) -> io::Result<()> {
         self.0
     }
 

--- a/library/std/src/sys/fs/vexos.rs
+++ b/library/std/src/sys/fs/vexos.rs
@@ -339,7 +339,7 @@ impl File {
         false
     }
 
-    pub fn read_buf(&self, cursor: BorrowedCursor<'_>) -> io::Result<()> {
+    pub fn read_buf(&self, cursor: BorrowedCursor<'_, u8>) -> io::Result<()> {
         crate::io::default_read_buf(|b| self.read(b), cursor)
     }
 

--- a/library/std/src/sys/fs/windows.rs
+++ b/library/std/src/sys/fs/windows.rs
@@ -632,11 +632,11 @@ impl File {
         self.handle.read_at(buf, offset)
     }
 
-    pub fn read_buf(&self, cursor: BorrowedCursor<'_>) -> io::Result<()> {
+    pub fn read_buf(&self, cursor: BorrowedCursor<'_, u8>) -> io::Result<()> {
         self.handle.read_buf(cursor)
     }
 
-    pub fn read_buf_at(&self, cursor: BorrowedCursor<'_>, offset: u64) -> io::Result<()> {
+    pub fn read_buf_at(&self, cursor: BorrowedCursor<'_, u8>, offset: u64) -> io::Result<()> {
         self.handle.read_buf_at(cursor, offset)
     }
 

--- a/library/std/src/sys/net/connection/motor.rs
+++ b/library/std/src/sys/net/connection/motor.rs
@@ -65,7 +65,7 @@ impl TcpStream {
         moto_rt::fs::read(self.inner.as_raw_fd(), buf).map_err(map_motor_error)
     }
 
-    pub fn read_buf(&self, cursor: BorrowedCursor<'_>) -> io::Result<()> {
+    pub fn read_buf(&self, cursor: BorrowedCursor<'_, u8>) -> io::Result<()> {
         crate::io::default_read_buf(|buf| self.read(buf), cursor)
     }
 

--- a/library/std/src/sys/net/connection/sgx.rs
+++ b/library/std/src/sys/net/connection/sgx.rs
@@ -169,7 +169,7 @@ impl TcpStream {
         self.inner.inner.read(buf)
     }
 
-    pub fn read_buf(&self, buf: BorrowedCursor<'_>) -> io::Result<()> {
+    pub fn read_buf(&self, buf: BorrowedCursor<'_, u8>) -> io::Result<()> {
         self.inner.inner.read_buf(buf)
     }
 

--- a/library/std/src/sys/net/connection/socket/hermit.rs
+++ b/library/std/src/sys/net/connection/socket/hermit.rs
@@ -132,7 +132,7 @@ impl Socket {
         Ok(Socket(unsafe { FileDesc::from_raw_fd(fd) }))
     }
 
-    fn recv_with_flags(&self, mut buf: BorrowedCursor<'_>, flags: i32) -> io::Result<()> {
+    fn recv_with_flags(&self, mut buf: BorrowedCursor<'_, u8>, flags: i32) -> io::Result<()> {
         let ret = cvt(unsafe {
             netc::recv(
                 self.0.as_raw_fd(),
@@ -159,7 +159,7 @@ impl Socket {
         Ok(buf.len())
     }
 
-    pub fn read_buf(&self, buf: BorrowedCursor<'_>) -> io::Result<()> {
+    pub fn read_buf(&self, buf: BorrowedCursor<'_, u8>) -> io::Result<()> {
         self.recv_with_flags(buf, 0)
     }
 

--- a/library/std/src/sys/net/connection/socket/mod.rs
+++ b/library/std/src/sys/net/connection/socket/mod.rs
@@ -414,7 +414,7 @@ impl TcpStream {
         self.inner.read(buf)
     }
 
-    pub fn read_buf(&self, buf: BorrowedCursor<'_>) -> io::Result<()> {
+    pub fn read_buf(&self, buf: BorrowedCursor<'_, u8>) -> io::Result<()> {
         self.inner.read_buf(buf)
     }
 

--- a/library/std/src/sys/net/connection/socket/solid.rs
+++ b/library/std/src/sys/net/connection/socket/solid.rs
@@ -186,7 +186,7 @@ impl Socket {
         Ok(Self(self.0.try_clone()?))
     }
 
-    fn recv_with_flags(&self, mut buf: BorrowedCursor<'_>, flags: c_int) -> io::Result<()> {
+    fn recv_with_flags(&self, mut buf: BorrowedCursor<'_, u8>, flags: c_int) -> io::Result<()> {
         let ret = cvt(unsafe {
             netc::recv(self.as_raw_fd(), buf.as_mut().as_mut_ptr().cast(), buf.capacity(), flags)
         })?;
@@ -208,7 +208,7 @@ impl Socket {
         Ok(buf.len())
     }
 
-    pub fn read_buf(&self, buf: BorrowedCursor<'_>) -> io::Result<()> {
+    pub fn read_buf(&self, buf: BorrowedCursor<'_, u8>) -> io::Result<()> {
         self.recv_with_flags(buf, 0)
     }
 

--- a/library/std/src/sys/net/connection/socket/unix.rs
+++ b/library/std/src/sys/net/connection/socket/unix.rs
@@ -284,7 +284,7 @@ impl Socket {
         Ok(ret as usize)
     }
 
-    fn recv_with_flags(&self, mut buf: BorrowedCursor<'_>, flags: c_int) -> io::Result<()> {
+    fn recv_with_flags(&self, mut buf: BorrowedCursor<'_, u8>, flags: c_int) -> io::Result<()> {
         let ret = cvt(unsafe {
             libc::recv(
                 self.as_raw_fd(),
@@ -311,7 +311,7 @@ impl Socket {
         Ok(buf.len())
     }
 
-    pub fn read_buf(&self, buf: BorrowedCursor<'_>) -> io::Result<()> {
+    pub fn read_buf(&self, buf: BorrowedCursor<'_, u8>) -> io::Result<()> {
         self.recv_with_flags(buf, 0)
     }
 

--- a/library/std/src/sys/net/connection/socket/windows.rs
+++ b/library/std/src/sys/net/connection/socket/windows.rs
@@ -225,7 +225,7 @@ impl Socket {
         Ok(Self(self.0.try_clone()?))
     }
 
-    fn recv_with_flags(&self, mut buf: BorrowedCursor<'_>, flags: c_int) -> io::Result<()> {
+    fn recv_with_flags(&self, mut buf: BorrowedCursor<'_, u8>, flags: c_int) -> io::Result<()> {
         // On unix when a socket is shut down all further reads return 0, so we
         // do the same on windows to map a shut down socket to returning EOF.
         let length = cmp::min(buf.capacity(), i32::MAX as usize) as i32;
@@ -255,7 +255,7 @@ impl Socket {
         Ok(buf.len())
     }
 
-    pub fn read_buf(&self, buf: BorrowedCursor<'_>) -> io::Result<()> {
+    pub fn read_buf(&self, buf: BorrowedCursor<'_, u8>) -> io::Result<()> {
         self.recv_with_flags(buf, 0)
     }
 

--- a/library/std/src/sys/net/connection/uefi/mod.rs
+++ b/library/std/src/sys/net/connection/uefi/mod.rs
@@ -64,7 +64,7 @@ impl TcpStream {
         self.inner.read(buf, self.read_timeout()?)
     }
 
-    pub fn read_buf(&self, cursor: BorrowedCursor<'_>) -> io::Result<()> {
+    pub fn read_buf(&self, cursor: BorrowedCursor<'_, u8>) -> io::Result<()> {
         crate::io::default_read_buf(|buf| self.read(buf), cursor)
     }
 

--- a/library/std/src/sys/net/connection/unsupported.rs
+++ b/library/std/src/sys/net/connection/unsupported.rs
@@ -39,7 +39,7 @@ impl TcpStream {
         self.0
     }
 
-    pub fn read_buf(&self, _buf: BorrowedCursor<'_>) -> io::Result<()> {
+    pub fn read_buf(&self, _buf: BorrowedCursor<'_, u8>) -> io::Result<()> {
         self.0
     }
 

--- a/library/std/src/sys/net/connection/wasip1.rs
+++ b/library/std/src/sys/net/connection/wasip1.rs
@@ -91,7 +91,7 @@ impl TcpStream {
         self.read_vectored(&mut [IoSliceMut::new(buf)])
     }
 
-    pub fn read_buf(&self, buf: BorrowedCursor<'_>) -> io::Result<()> {
+    pub fn read_buf(&self, buf: BorrowedCursor<'_, u8>) -> io::Result<()> {
         self.socket().as_inner().read_buf(buf)
     }
 

--- a/library/std/src/sys/net/connection/xous/tcpstream.rs
+++ b/library/std/src/sys/net/connection/xous/tcpstream.rs
@@ -238,7 +238,7 @@ impl TcpStream {
         crate::io::default_read_vectored(|b| self.read(b), bufs)
     }
 
-    pub fn read_buf(&self, cursor: BorrowedCursor<'_>) -> io::Result<()> {
+    pub fn read_buf(&self, cursor: BorrowedCursor<'_, u8>) -> io::Result<()> {
         crate::io::default_read_buf(|buf| self.read(buf), cursor)
     }
 

--- a/library/std/src/sys/pal/sgx/abi/usercalls/mod.rs
+++ b/library/std/src/sys/pal/sgx/abi/usercalls/mod.rs
@@ -39,7 +39,7 @@ pub fn read(fd: Fd, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
 /// Usercall `read` with an uninitialized buffer. See the ABI documentation for
 /// more information.
 #[unstable(feature = "sgx_platform", issue = "56975")]
-pub fn read_buf(fd: Fd, mut buf: BorrowedCursor<'_>) -> io::Result<()> {
+pub fn read_buf(fd: Fd, mut buf: BorrowedCursor<'_, u8>) -> io::Result<()> {
     unsafe {
         let mut userbuf = alloc::User::<[u8]>::uninitialized(buf.capacity());
         let len = raw::read(fd, userbuf.as_mut_ptr().cast(), userbuf.len()).from_sgx_result()?;

--- a/library/std/src/sys/pal/windows/handle.rs
+++ b/library/std/src/sys/pal/windows/handle.rs
@@ -109,7 +109,7 @@ impl Handle {
         }
     }
 
-    pub fn read_buf(&self, mut cursor: BorrowedCursor<'_>) -> io::Result<()> {
+    pub fn read_buf(&self, mut cursor: BorrowedCursor<'_, u8>) -> io::Result<()> {
         let res =
             unsafe { self.synchronous_read(cursor.as_mut().as_mut_ptr(), cursor.capacity(), None) };
 
@@ -132,7 +132,7 @@ impl Handle {
         }
     }
 
-    pub fn read_buf_at(&self, mut cursor: BorrowedCursor<'_>, offset: u64) -> io::Result<()> {
+    pub fn read_buf_at(&self, mut cursor: BorrowedCursor<'_, u8>, offset: u64) -> io::Result<()> {
         // SAFETY: `cursor.as_mut()` starts with `cursor.capacity()` writable bytes
         let read = unsafe {
             self.synchronous_read(cursor.as_mut().as_mut_ptr(), cursor.capacity(), Some(offset))
@@ -347,7 +347,7 @@ impl<'a> Read for &'a Handle {
         (**self).read(buf)
     }
 
-    fn read_buf(&mut self, buf: BorrowedCursor<'_>) -> io::Result<()> {
+    fn read_buf(&mut self, buf: BorrowedCursor<'_, u8>) -> io::Result<()> {
         (**self).read_buf(buf)
     }
 

--- a/library/std/src/sys/pipe/unsupported.rs
+++ b/library/std/src/sys/pipe/unsupported.rs
@@ -17,7 +17,7 @@ impl Pipe {
         self.0
     }
 
-    pub fn read_buf(&self, _buf: BorrowedCursor<'_>) -> io::Result<()> {
+    pub fn read_buf(&self, _buf: BorrowedCursor<'_, u8>) -> io::Result<()> {
         self.0
     }
 

--- a/library/std/src/sys/process/windows/child_pipe.rs
+++ b/library/std/src/sys/process/windows/child_pipe.rs
@@ -259,7 +259,7 @@ impl ChildPipe {
         }
     }
 
-    pub fn read_buf(&self, mut buf: BorrowedCursor<'_>) -> io::Result<()> {
+    pub fn read_buf(&self, mut buf: BorrowedCursor<'_, u8>) -> io::Result<()> {
         let result = unsafe {
             let len = crate::cmp::min(buf.capacity(), u32::MAX as usize) as u32;
             let ptr = buf.as_mut().as_mut_ptr().cast::<u8>();

--- a/library/std/src/sys/stdio/sgx.rs
+++ b/library/std/src/sys/stdio/sgx.rs
@@ -25,7 +25,7 @@ impl io::Read for Stdin {
         with_std_fd(abi::FD_STDIN, |fd| fd.read(buf))
     }
 
-    fn read_buf(&mut self, buf: BorrowedCursor<'_>) -> io::Result<()> {
+    fn read_buf(&mut self, buf: BorrowedCursor<'_, u8>) -> io::Result<()> {
         with_std_fd(abi::FD_STDIN, |fd| fd.read_buf(buf))
     }
 

--- a/library/std/src/sys/stdio/unix.rs
+++ b/library/std/src/sys/stdio/unix.rs
@@ -23,7 +23,7 @@ impl io::Read for Stdin {
         unsafe { ManuallyDrop::new(FileDesc::from_raw_fd(STDIN_FILENO)).read(buf) }
     }
 
-    fn read_buf(&mut self, buf: BorrowedCursor<'_>) -> io::Result<()> {
+    fn read_buf(&mut self, buf: BorrowedCursor<'_, u8>) -> io::Result<()> {
         unsafe { ManuallyDrop::new(FileDesc::from_raw_fd(STDIN_FILENO)).read_buf(buf) }
     }
 

--- a/library/std/src/sys/stdio/unsupported.rs
+++ b/library/std/src/sys/stdio/unsupported.rs
@@ -17,7 +17,7 @@ impl io::Read for Stdin {
     }
 
     #[inline]
-    fn read_buf(&mut self, _cursor: BorrowedCursor<'_>) -> io::Result<()> {
+    fn read_buf(&mut self, _cursor: BorrowedCursor<'_, u8>) -> io::Result<()> {
         Ok(())
     }
 
@@ -39,7 +39,7 @@ impl io::Read for Stdin {
     }
 
     #[inline]
-    fn read_buf_exact(&mut self, cursor: BorrowedCursor<'_>) -> io::Result<()> {
+    fn read_buf_exact(&mut self, cursor: BorrowedCursor<'_, u8>) -> io::Result<()> {
         if cursor.capacity() != 0 { Err(io::Error::READ_EXACT_EOF) } else { Ok(()) }
     }
 

--- a/library/std/src/sys/stdio/zkvm.rs
+++ b/library/std/src/sys/stdio/zkvm.rs
@@ -16,7 +16,7 @@ impl io::Read for Stdin {
         Ok(unsafe { abi::sys_read(fileno::STDIN, buf.as_mut_ptr(), buf.len()) })
     }
 
-    fn read_buf(&mut self, mut buf: BorrowedCursor<'_>) -> io::Result<()> {
+    fn read_buf(&mut self, mut buf: BorrowedCursor<'_, u8>) -> io::Result<()> {
         unsafe {
             let n = abi::sys_read(fileno::STDIN, buf.as_mut().as_mut_ptr().cast(), buf.capacity());
             buf.advance(n);


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/149749)*
<!-- homu-ignore:end -->

Replace uses of `u8` with a generic type. This will allow reusing
`BorrowedBuf` elsewhere in the standard library, for purposes other than
byte buffers.

This currently requires `T: Copy`, to prevent `T: Drop`, which would require additional careful handling. We can consider relaxing that restriction in the future if we make `T: Drop` work (without pessimizing `Copy` types like `u8`).
    
`ensure_init` currently continues to require `u8`. We could potentially generalize it to `T: Default`, but we'd need to ensure it produced the same or better assembly for `u8`.


-----

As discussed in libs-api; cc @Amanieu.