### PR TITLE
On name resolution error in parameter list, suggest possible `const` typo and avoid unnecessary second error

### DIFF
--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/generics.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/generics.rs
@@ -68,9 +68,9 @@ fn generic_arg_mismatch_err(
         ) => match path.res {
             Res::Err => {
                 add_braces_suggestion(arg, &mut err);
-                return err
-                    .with_primary_message("unresolved item provided when a constant was expected")
-                    .emit();
+                err.primary_message("unresolved item provided when a constant was expected");
+                // A resolve error will already have been emitted pointing at this.
+                return err.delay_as_bug();
             }
             Res::Def(DefKind::TyParam, src_def_id) => {
                 if let Some(param_local_id) = param.def_id.as_local() {

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -447,6 +447,8 @@ impl IntoDiagArg for ResolvingRestrictionKind {
 pub(crate) enum PathSource<'a, 'ast, 'ra> {
     /// Type paths `Path`.
     Type,
+    /// Type or constant in a `PathSegment` argument.
+    TypeParam,
     /// Trait paths in bounds or impls.
     Trait(AliasPossibility),
     /// Expression paths `path`, with optional parent context.
@@ -482,6 +484,7 @@ impl PathSource<'_, '_, '_> {
     fn namespace(self) -> Namespace {
         match self {
             PathSource::Type
+            | PathSource::TypeParam
             | PathSource::Trait(_)
             | PathSource::Struct(_)
             | PathSource::DefineOpaques
@@ -501,6 +504,7 @@ impl PathSource<'_, '_, '_> {
     fn defer_to_typeck(self) -> bool {
         match self {
             PathSource::Type
+            | PathSource::TypeParam
             | PathSource::Expr(..)
             | PathSource::Pat
             | PathSource::Struct(_)
@@ -521,6 +525,7 @@ impl PathSource<'_, '_, '_> {
         match &self {
             PathSource::DefineOpaques => "type alias or associated type with opaqaue types",
             PathSource::Type => "type",
+            PathSource::TypeParam => "type or constant",
             PathSource::Trait(_) => "trait",
             PathSource::Pat => "unit struct, unit variant or constant",
             PathSource::Struct(_) => "struct, variant or union type",
@@ -592,6 +597,29 @@ impl PathSource<'_, '_, '_> {
                         | DefKind::AssocTy
                         | DefKind::TyParam
                         | DefKind::OpaqueTy
+                        | DefKind::ForeignTy,
+                    _,
+                ) | Res::PrimTy(..)
+                    | Res::SelfTyParam { .. }
+                    | Res::SelfTyAlias { .. }
+            ),
+            PathSource::TypeParam => matches!(
+                res,
+                Res::Def(
+                    DefKind::Struct
+                        | DefKind::Union
+                        | DefKind::Enum
+                        | DefKind::Trait
+                        | DefKind::TraitAlias
+                        | DefKind::TyAlias
+                        | DefKind::AssocTy
+                        | DefKind::TyParam
+                        | DefKind::OpaqueTy
+                        | DefKind::AnonConst
+                        | DefKind::AssocConst
+                        | DefKind::Const
+                        | DefKind::ConstParam
+                        | DefKind::InlineConst
                         | DefKind::ForeignTy,
                     _,
                 ) | Res::PrimTy(..)
@@ -673,8 +701,8 @@ impl PathSource<'_, '_, '_> {
         match (self, has_unexpected_resolution) {
             (PathSource::Trait(_), true) => E0404,
             (PathSource::Trait(_), false) => E0405,
-            (PathSource::Type | PathSource::DefineOpaques, true) => E0573,
-            (PathSource::Type | PathSource::DefineOpaques, false) => E0425,
+            (PathSource::Type | PathSource::DefineOpaques | PathSource::TypeParam, true) => E0573,
+            (PathSource::Type | PathSource::DefineOpaques | PathSource::TypeParam, false) => E0425,
             (PathSource::Struct(_), true) => E0574,
             (PathSource::Struct(_), false) => E0422,
             (PathSource::Expr(..), true)
@@ -2233,6 +2261,7 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
                 PathSource::Trait(..)
                 | PathSource::TraitItem(..)
                 | PathSource::Type
+                | PathSource::TypeParam
                 | PathSource::PreciseCapturingArg(..)
                 | PathSource::ReturnTypeNotation
                 | PathSource::Macro

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -616,10 +616,9 @@ impl PathSource<'_, '_, '_> {
                         | DefKind::TyParam
                         | DefKind::OpaqueTy
                         | DefKind::AnonConst
-                        | DefKind::AssocConst
-                        | DefKind::Const
+                        | DefKind::AssocConst { is_type_const: _ }
+                        | DefKind::Const { is_type_const: _ }
                         | DefKind::ConstParam
-                        | DefKind::InlineConst
                         | DefKind::ForeignTy,
                     _,
                 ) | Res::PrimTy(..)

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -1043,9 +1043,11 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
                                 })
                                 .unwrap_or(false);
                             if field_is_format_named_arg {
-                                err.help(
-                                    format!("you might have meant to use the available field in a format string: `\"{{}}\", self.{}`", segment.ident.name),
-                                );
+                                err.help(format!(
+                                    "you might have meant to use the available field in a format \
+                                     string: `\"{{}}\", self.{}`",
+                                    segment.ident.name,
+                                ));
                             } else {
                                 err.span_suggestion_verbose(
                                     span.shrink_to_lo(),
@@ -1301,13 +1303,19 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
     fn suggest_typo(
         &mut self,
         err: &mut Diag<'_>,
-        source: PathSource<'_, 'ast, 'ra>,
+        mut source: PathSource<'_, 'ast, 'ra>,
         path: &[Segment],
         following_seg: Option<&Segment>,
         span: Span,
         base_error: &BaseError,
         suggested_candidates: FxHashSet<String>,
     ) -> bool {
+        if self.diag_metadata.currently_processing_generic_args
+            && matches!(source, PathSource::Type)
+        {
+            source = PathSource::TypeParam;
+        }
+
         let is_expected = &|res| source.is_expected(res);
         let ident_span = path.last().map_or(span, |ident| ident.ident.span);
 

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -669,11 +669,10 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
         path: &[Segment],
         following_seg: Option<&Segment>,
         span: Span,
-        source: PathSource<'_, 'ast, 'ra>,
+        mut source: PathSource<'_, 'ast, 'ra>,
         res: Option<Res>,
         qself: Option<&QSelf>,
     ) -> (Diag<'tcx>, Vec<ImportSuggestion>) {
-        debug!(?res, ?source);
         let cross_namespace_res = res.filter(|res| !res.matches_ns(source.namespace()));
         let could_be_expr = res.is_some_and(|res| self.could_be_expr(res, span));
         let base_error = self.make_base_error(
@@ -687,6 +686,14 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
         let code = source.error_code(res.is_some());
         let mut err = self.r.dcx().struct_span_err(base_error.span, base_error.msg.clone());
         err.code(code);
+
+        if self.diag_metadata.currently_processing_generic_args
+            && let PathSource::Type = source
+            && let [segment] = path
+            && !segment.has_generic_args
+        {
+            source = PathSource::TypeParam;
+        }
 
         if let Some(res) = cross_namespace_res {
             err.note(format!(
@@ -1303,19 +1310,13 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
     fn suggest_typo(
         &mut self,
         err: &mut Diag<'_>,
-        mut source: PathSource<'_, 'ast, 'ra>,
+        source: PathSource<'_, 'ast, 'ra>,
         path: &[Segment],
         following_seg: Option<&Segment>,
         span: Span,
         base_error: &BaseError,
         suggested_candidates: FxHashSet<String>,
     ) -> bool {
-        if self.diag_metadata.currently_processing_generic_args
-            && matches!(source, PathSource::Type)
-        {
-            source = PathSource::TypeParam;
-        }
-
         let is_expected = &|res| source.is_expected(res);
         let ident_span = path.last().map_or(span, |ident| ident.ident.span);
 

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/need_type_info.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/need_type_info.rs
@@ -567,6 +567,23 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             typeck_results,
             span,
         );
+        let delay_as_bug = match kind {
+            InferSourceKind::ClosureArg { kind, .. } if let PatKind::Err(_) = kind => {
+                // We will have already emitted an error about this pattern.
+                true
+            }
+            InferSourceKind::GenericArg { hir_id, argument_index, .. }
+                if let hir::Node::PathSegment(segment) = self.tcx.hir_node(hir_id)
+                    && let Some(args) = segment.args
+                    && let Some(hir::GenericArg::Type(ty)) = args.args.get(argument_index)
+                    && let hir::TyKind::Path(hir::QPath::Resolved(_, path)) = ty.kind
+                    && let Res::Err = path.res =>
+            {
+                // We have already emitted a name resolution error.
+                true
+            }
+            _ => false,
+        };
 
         let mut err = match error_code {
             TypeAnnotationNeeded::E0282 => self.dcx().create_err(AnnotationRequired {
@@ -595,8 +612,8 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             }),
         };
         *err.long_ty_path() = long_ty_path;
-        if let InferSourceKind::ClosureArg { kind: PatKind::Err(_), .. } = kind {
-            // We will have already emitted an error about this pattern.
+        if delay_as_bug {
+            // We have already emitted an earlier more relevant error.
             err.downgrade_to_delayed_bug();
         }
         err
@@ -886,6 +903,7 @@ struct InsertableGenericArgs<'tcx> {
     generics_def_id: DefId,
     def_id: DefId,
     have_turbofish: bool,
+    hir_id: HirId,
 }
 
 /// A visitor which searches for the "best" spot to use in the inference error.
@@ -1154,6 +1172,7 @@ impl<'a, 'tcx> FindInferSourceVisitor<'a, 'tcx> {
                             generics_def_id: def_id,
                             def_id,
                             have_turbofish,
+                            hir_id: expr.hir_id,
                         }
                     };
                     return Box::new(insertable.into_iter());
@@ -1193,6 +1212,7 @@ impl<'a, 'tcx> FindInferSourceVisitor<'a, 'tcx> {
                 generics_def_id,
                 def_id: path.res.def_id(),
                 have_turbofish,
+                hir_id: path.segments.last().unwrap().hir_id,
             }
         };
 
@@ -1213,6 +1233,7 @@ impl<'a, 'tcx> FindInferSourceVisitor<'a, 'tcx> {
                     generics_def_id,
                     def_id: res.def_id(),
                     have_turbofish,
+                    hir_id: segment.hir_id,
                 })
             })
             .chain(last_segment_using_path_data)
@@ -1246,6 +1267,7 @@ impl<'a, 'tcx> FindInferSourceVisitor<'a, 'tcx> {
                         generics_def_id: def_id,
                         def_id,
                         have_turbofish: false,
+                        hir_id: segment.hir_id,
                     })
                 };
 
@@ -1404,6 +1426,7 @@ impl<'a, 'tcx> Visitor<'tcx> for FindInferSourceVisitor<'a, 'tcx> {
                 generics_def_id,
                 def_id,
                 have_turbofish,
+                hir_id,
             } = args;
             let generics = tcx.generics_of(generics_def_id);
             if let Some(argument_index) = generics
@@ -1442,7 +1465,7 @@ impl<'a, 'tcx> Visitor<'tcx> for FindInferSourceVisitor<'a, 'tcx> {
                         def_id,
                         generic_args,
                         have_turbofish,
-                        hir_id: expr.hir_id,
+                        hir_id,
                     },
                 });
             }

--- a/tests/ui/const-generics/assoc_const_as_type_argument.rs
+++ b/tests/ui/const-generics/assoc_const_as_type_argument.rs
@@ -7,7 +7,6 @@ fn bar<const N: usize>() {}
 fn foo<T: Trait>() {
     bar::<<T as Trait>::ASSOC>();
     //~^ ERROR: cannot find associated type `ASSOC` in trait `Trait`
-    //~| ERROR: unresolved item provided when a constant was expected
 }
 
 fn main() {}

--- a/tests/ui/const-generics/assoc_const_as_type_argument.stderr
+++ b/tests/ui/const-generics/assoc_const_as_type_argument.stderr
@@ -6,18 +6,6 @@ LL |     bar::<<T as Trait>::ASSOC>();
    |
    = note: an associated constant named `Trait::ASSOC` exists in another namespace
 
-error[E0747]: unresolved item provided when a constant was expected
-  --> $DIR/assoc_const_as_type_argument.rs:8:11
-   |
-LL |     bar::<<T as Trait>::ASSOC>();
-   |           ^^^^^^^^^^^^^^^^^^^
-   |
-help: if this generic argument was intended as a const parameter, surround it with braces
-   |
-LL |     bar::<{ <T as Trait>::ASSOC }>();
-   |           +                     +
+error: aborting due to 1 previous error
 
-error: aborting due to 2 previous errors
-
-Some errors have detailed explanations: E0575, E0747.
-For more information about an error, try `rustc --explain E0575`.
+For more information about this error, try `rustc --explain E0575`.

--- a/tests/ui/const-generics/const-arg-in-const-arg.min.stderr
+++ b/tests/ui/const-generics/const-arg-in-const-arg.min.stderr
@@ -19,7 +19,7 @@ LL |     let _: [u8; bar::<N>()];
    = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
-  --> $DIR/const-arg-in-const-arg.rs:18:23
+  --> $DIR/const-arg-in-const-arg.rs:17:23
    |
 LL |     let _: [u8; faz::<'a>(&())];
    |                       ^^ cannot perform const operation using `'a`
@@ -29,7 +29,7 @@ LL |     let _: [u8; faz::<'a>(&())];
    = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
-  --> $DIR/const-arg-in-const-arg.rs:20:23
+  --> $DIR/const-arg-in-const-arg.rs:19:23
    |
 LL |     let _: [u8; baz::<'a>(&())];
    |                       ^^ cannot perform const operation using `'a`
@@ -39,7 +39,7 @@ LL |     let _: [u8; baz::<'a>(&())];
    = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
-  --> $DIR/const-arg-in-const-arg.rs:21:23
+  --> $DIR/const-arg-in-const-arg.rs:20:23
    |
 LL |     let _: [u8; faz::<'b>(&())];
    |                       ^^ cannot perform const operation using `'b`
@@ -49,7 +49,7 @@ LL |     let _: [u8; faz::<'b>(&())];
    = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
-  --> $DIR/const-arg-in-const-arg.rs:23:23
+  --> $DIR/const-arg-in-const-arg.rs:22:23
    |
 LL |     let _: [u8; baz::<'b>(&())];
    |                       ^^ cannot perform const operation using `'b`
@@ -59,7 +59,7 @@ LL |     let _: [u8; baz::<'b>(&())];
    = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
-  --> $DIR/const-arg-in-const-arg.rs:27:23
+  --> $DIR/const-arg-in-const-arg.rs:26:23
    |
 LL |     let _ = [0; bar::<N>()];
    |                       ^ cannot perform const operation using `N`
@@ -69,7 +69,7 @@ LL |     let _ = [0; bar::<N>()];
    = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
-  --> $DIR/const-arg-in-const-arg.rs:29:23
+  --> $DIR/const-arg-in-const-arg.rs:27:23
    |
 LL |     let _ = [0; faz::<'a>(&())];
    |                       ^^ cannot perform const operation using `'a`
@@ -79,7 +79,7 @@ LL |     let _ = [0; faz::<'a>(&())];
    = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
-  --> $DIR/const-arg-in-const-arg.rs:31:23
+  --> $DIR/const-arg-in-const-arg.rs:29:23
    |
 LL |     let _ = [0; baz::<'a>(&())];
    |                       ^^ cannot perform const operation using `'a`
@@ -89,7 +89,7 @@ LL |     let _ = [0; baz::<'a>(&())];
    = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
-  --> $DIR/const-arg-in-const-arg.rs:32:23
+  --> $DIR/const-arg-in-const-arg.rs:30:23
    |
 LL |     let _ = [0; faz::<'b>(&())];
    |                       ^^ cannot perform const operation using `'b`
@@ -99,7 +99,7 @@ LL |     let _ = [0; faz::<'b>(&())];
    = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
-  --> $DIR/const-arg-in-const-arg.rs:34:23
+  --> $DIR/const-arg-in-const-arg.rs:32:23
    |
 LL |     let _ = [0; baz::<'b>(&())];
    |                       ^^ cannot perform const operation using `'b`
@@ -109,7 +109,7 @@ LL |     let _ = [0; baz::<'b>(&())];
    = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
-  --> $DIR/const-arg-in-const-arg.rs:35:24
+  --> $DIR/const-arg-in-const-arg.rs:33:24
    |
 LL |     let _: Foo<{ foo::<T>() }>;
    |                        ^ cannot perform const operation using `T`
@@ -119,7 +119,7 @@ LL |     let _: Foo<{ foo::<T>() }>;
    = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
-  --> $DIR/const-arg-in-const-arg.rs:36:24
+  --> $DIR/const-arg-in-const-arg.rs:34:24
    |
 LL |     let _: Foo<{ bar::<N>() }>;
    |                        ^ cannot perform const operation using `N`
@@ -129,7 +129,7 @@ LL |     let _: Foo<{ bar::<N>() }>;
    = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
-  --> $DIR/const-arg-in-const-arg.rs:38:24
+  --> $DIR/const-arg-in-const-arg.rs:35:24
    |
 LL |     let _: Foo<{ faz::<'a>(&()) }>;
    |                        ^^ cannot perform const operation using `'a`
@@ -139,7 +139,7 @@ LL |     let _: Foo<{ faz::<'a>(&()) }>;
    = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
-  --> $DIR/const-arg-in-const-arg.rs:40:24
+  --> $DIR/const-arg-in-const-arg.rs:37:24
    |
 LL |     let _: Foo<{ baz::<'a>(&()) }>;
    |                        ^^ cannot perform const operation using `'a`
@@ -149,7 +149,7 @@ LL |     let _: Foo<{ baz::<'a>(&()) }>;
    = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
-  --> $DIR/const-arg-in-const-arg.rs:41:24
+  --> $DIR/const-arg-in-const-arg.rs:38:24
    |
 LL |     let _: Foo<{ faz::<'b>(&()) }>;
    |                        ^^ cannot perform const operation using `'b`
@@ -159,7 +159,7 @@ LL |     let _: Foo<{ faz::<'b>(&()) }>;
    = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
-  --> $DIR/const-arg-in-const-arg.rs:43:24
+  --> $DIR/const-arg-in-const-arg.rs:40:24
    |
 LL |     let _: Foo<{ baz::<'b>(&()) }>;
    |                        ^^ cannot perform const operation using `'b`
@@ -169,7 +169,7 @@ LL |     let _: Foo<{ baz::<'b>(&()) }>;
    = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
-  --> $DIR/const-arg-in-const-arg.rs:44:27
+  --> $DIR/const-arg-in-const-arg.rs:41:27
    |
 LL |     let _ = Foo::<{ foo::<T>() }>;
    |                           ^ cannot perform const operation using `T`
@@ -179,7 +179,7 @@ LL |     let _ = Foo::<{ foo::<T>() }>;
    = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
-  --> $DIR/const-arg-in-const-arg.rs:45:27
+  --> $DIR/const-arg-in-const-arg.rs:42:27
    |
 LL |     let _ = Foo::<{ bar::<N>() }>;
    |                           ^ cannot perform const operation using `N`
@@ -189,7 +189,7 @@ LL |     let _ = Foo::<{ bar::<N>() }>;
    = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
-  --> $DIR/const-arg-in-const-arg.rs:47:27
+  --> $DIR/const-arg-in-const-arg.rs:43:27
    |
 LL |     let _ = Foo::<{ faz::<'a>(&()) }>;
    |                           ^^ cannot perform const operation using `'a`
@@ -199,7 +199,7 @@ LL |     let _ = Foo::<{ faz::<'a>(&()) }>;
    = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
-  --> $DIR/const-arg-in-const-arg.rs:49:27
+  --> $DIR/const-arg-in-const-arg.rs:45:27
    |
 LL |     let _ = Foo::<{ baz::<'a>(&()) }>;
    |                           ^^ cannot perform const operation using `'a`
@@ -209,7 +209,7 @@ LL |     let _ = Foo::<{ baz::<'a>(&()) }>;
    = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
-  --> $DIR/const-arg-in-const-arg.rs:50:27
+  --> $DIR/const-arg-in-const-arg.rs:46:27
    |
 LL |     let _ = Foo::<{ faz::<'b>(&()) }>;
    |                           ^^ cannot perform const operation using `'b`
@@ -219,7 +219,7 @@ LL |     let _ = Foo::<{ faz::<'b>(&()) }>;
    = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
-  --> $DIR/const-arg-in-const-arg.rs:52:27
+  --> $DIR/const-arg-in-const-arg.rs:48:27
    |
 LL |     let _ = Foo::<{ baz::<'b>(&()) }>;
    |                           ^^ cannot perform const operation using `'b`
@@ -228,19 +228,8 @@ LL |     let _ = Foo::<{ baz::<'b>(&()) }>;
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
    = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
-error[E0747]: unresolved item provided when a constant was expected
-  --> $DIR/const-arg-in-const-arg.rs:16:23
-   |
-LL |     let _: [u8; bar::<N>()];
-   |                       ^
-   |
-help: if this generic argument was intended as a const parameter, surround it with braces
-   |
-LL |     let _: [u8; bar::<{ N }>()];
-   |                       +   +
-
 error[E0794]: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
-  --> $DIR/const-arg-in-const-arg.rs:18:23
+  --> $DIR/const-arg-in-const-arg.rs:17:23
    |
 LL |     let _: [u8; faz::<'a>(&())];
    |                       ^^
@@ -252,7 +241,7 @@ LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
    |              ^^
 
 error[E0794]: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
-  --> $DIR/const-arg-in-const-arg.rs:21:23
+  --> $DIR/const-arg-in-const-arg.rs:20:23
    |
 LL |     let _: [u8; faz::<'b>(&())];
    |                       ^^
@@ -264,7 +253,7 @@ LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
    |              ^^
 
 error: constant expression depends on a generic parameter
-  --> $DIR/const-arg-in-const-arg.rs:25:17
+  --> $DIR/const-arg-in-const-arg.rs:24:17
    |
 LL |     let _ = [0; foo::<T>()];
    |                 ^^^^^^^^^^
@@ -272,26 +261,15 @@ LL |     let _ = [0; foo::<T>()];
    = note: this may fail depending on what value the parameter takes
 
 error: constant expression depends on a generic parameter
-  --> $DIR/const-arg-in-const-arg.rs:25:13
+  --> $DIR/const-arg-in-const-arg.rs:24:13
    |
 LL |     let _ = [0; foo::<T>()];
    |             ^^^^^^^^^^^^^^^
    |
    = note: this may fail depending on what value the parameter takes
 
-error[E0747]: unresolved item provided when a constant was expected
-  --> $DIR/const-arg-in-const-arg.rs:27:23
-   |
-LL |     let _ = [0; bar::<N>()];
-   |                       ^
-   |
-help: if this generic argument was intended as a const parameter, surround it with braces
-   |
-LL |     let _ = [0; bar::<{ N }>()];
-   |                       +   +
-
 error[E0794]: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
-  --> $DIR/const-arg-in-const-arg.rs:29:23
+  --> $DIR/const-arg-in-const-arg.rs:27:23
    |
 LL |     let _ = [0; faz::<'a>(&())];
    |                       ^^
@@ -303,7 +281,7 @@ LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
    |              ^^
 
 error[E0794]: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
-  --> $DIR/const-arg-in-const-arg.rs:32:23
+  --> $DIR/const-arg-in-const-arg.rs:30:23
    |
 LL |     let _ = [0; faz::<'b>(&())];
    |                       ^^
@@ -314,19 +292,8 @@ note: the late bound lifetime parameter is introduced here
 LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
    |              ^^
 
-error[E0747]: unresolved item provided when a constant was expected
-  --> $DIR/const-arg-in-const-arg.rs:36:24
-   |
-LL |     let _: Foo<{ bar::<N>() }>;
-   |                        ^
-   |
-help: if this generic argument was intended as a const parameter, surround it with braces
-   |
-LL |     let _: Foo<{ bar::<{ N }>() }>;
-   |                        +   +
-
 error[E0794]: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
-  --> $DIR/const-arg-in-const-arg.rs:38:24
+  --> $DIR/const-arg-in-const-arg.rs:35:24
    |
 LL |     let _: Foo<{ faz::<'a>(&()) }>;
    |                        ^^
@@ -338,7 +305,7 @@ LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
    |              ^^
 
 error[E0794]: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
-  --> $DIR/const-arg-in-const-arg.rs:41:24
+  --> $DIR/const-arg-in-const-arg.rs:38:24
    |
 LL |     let _: Foo<{ faz::<'b>(&()) }>;
    |                        ^^
@@ -349,19 +316,8 @@ note: the late bound lifetime parameter is introduced here
 LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
    |              ^^
 
-error[E0747]: unresolved item provided when a constant was expected
-  --> $DIR/const-arg-in-const-arg.rs:45:27
-   |
-LL |     let _ = Foo::<{ bar::<N>() }>;
-   |                           ^
-   |
-help: if this generic argument was intended as a const parameter, surround it with braces
-   |
-LL |     let _ = Foo::<{ bar::<{ N }>() }>;
-   |                           +   +
-
 error[E0794]: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
-  --> $DIR/const-arg-in-const-arg.rs:47:27
+  --> $DIR/const-arg-in-const-arg.rs:43:27
    |
 LL |     let _ = Foo::<{ faz::<'a>(&()) }>;
    |                           ^^
@@ -373,7 +329,7 @@ LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
    |              ^^
 
 error[E0794]: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
-  --> $DIR/const-arg-in-const-arg.rs:50:27
+  --> $DIR/const-arg-in-const-arg.rs:46:27
    |
 LL |     let _ = Foo::<{ faz::<'b>(&()) }>;
    |                           ^^
@@ -384,7 +340,6 @@ note: the late bound lifetime parameter is introduced here
 LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
    |              ^^
 
-error: aborting due to 37 previous errors
+error: aborting due to 33 previous errors
 
-Some errors have detailed explanations: E0747, E0794.
-For more information about an error, try `rustc --explain E0747`.
+For more information about this error, try `rustc --explain E0794`.

--- a/tests/ui/const-generics/const-arg-in-const-arg.rs
+++ b/tests/ui/const-generics/const-arg-in-const-arg.rs
@@ -14,7 +14,6 @@ struct Foo<const N: usize>;
 fn test<'a, 'b, T, const N: usize>() where &'b (): Sized {
     let _: [u8; foo::<T>()]; //[min]~ ERROR generic parameters may not
     let _: [u8; bar::<N>()]; //[min]~ ERROR generic parameters may not
-                             //[min]~^ ERROR unresolved item provided when a constant was expected
     let _: [u8; faz::<'a>(&())]; //[min]~ ERROR generic parameters may not
                                  //[min]~^ ERROR cannot specify lifetime arguments
     let _: [u8; baz::<'a>(&())]; //[min]~ ERROR generic parameters may not
@@ -25,7 +24,6 @@ fn test<'a, 'b, T, const N: usize>() where &'b (): Sized {
     let _ = [0; foo::<T>()]; //[min]~ ERROR constant expression depends on a generic parameter
                              //[min]~^ ERROR constant expression depends on a generic parameter
     let _ = [0; bar::<N>()]; //[min]~ ERROR generic parameters may not
-                             //[min]~^ ERROR unresolved item provided when a constant was expected
     let _ = [0; faz::<'a>(&())]; //[min]~ ERROR generic parameters may not
                                  //[min]~^ ERROR cannot specify lifetime arguments
     let _ = [0; baz::<'a>(&())]; //[min]~ ERROR generic parameters may not
@@ -34,7 +32,6 @@ fn test<'a, 'b, T, const N: usize>() where &'b (): Sized {
     let _ = [0; baz::<'b>(&())]; //[min]~ ERROR generic parameters may not
     let _: Foo<{ foo::<T>() }>; //[min]~ ERROR generic parameters may not
     let _: Foo<{ bar::<N>() }>; //[min]~ ERROR generic parameters may not
-                                //[min]~^ ERROR unresolved item provided when a constant was expected
     let _: Foo<{ faz::<'a>(&()) }>; //[min]~ ERROR generic parameters may not
                                     //[min]~^ ERROR cannot specify lifetime arguments
     let _: Foo<{ baz::<'a>(&()) }>; //[min]~ ERROR generic parameters may not
@@ -43,7 +40,6 @@ fn test<'a, 'b, T, const N: usize>() where &'b (): Sized {
     let _: Foo<{ baz::<'b>(&()) }>; //[min]~ ERROR generic parameters may not
     let _ = Foo::<{ foo::<T>() }>; //[min]~ ERROR generic parameters may not
     let _ = Foo::<{ bar::<N>() }>; //[min]~ ERROR generic parameters may not
-                                   //[min]~^ ERROR unresolved item provided when a constant was expected
     let _ = Foo::<{ faz::<'a>(&()) }>; //[min]~ ERROR generic parameters may not
                                        //[min]~^ ERROR cannot specify lifetime arguments
     let _ = Foo::<{ baz::<'a>(&()) }>; //[min]~ ERROR generic parameters may not

--- a/tests/ui/const-generics/const-argument-typo.rs
+++ b/tests/ui/const-generics/const-argument-typo.rs
@@ -5,7 +5,6 @@ const CONST: usize = 0;
 fn foo<const C: usize>() {}
 
 fn main() {
-    foo::<CONS>(); 
+    foo::<CONS>();
     //~^ ERROR cannot find type `CONS` in this scope
-    //~| ERROR unresolved item provided when a constant was expected
 }

--- a/tests/ui/const-generics/const-argument-typo.rs
+++ b/tests/ui/const-generics/const-argument-typo.rs
@@ -1,0 +1,11 @@
+// Typo of `CONST` to `CONS`. #149660
+
+const CONST: usize = 0;
+
+fn foo<const C: usize>() {}
+
+fn main() {
+    foo::<CONS>(); 
+    //~^ ERROR cannot find type `CONS` in this scope
+    //~| ERROR unresolved item provided when a constant was expected
+}

--- a/tests/ui/const-generics/const-argument-typo.stderr
+++ b/tests/ui/const-generics/const-argument-typo.stderr
@@ -1,0 +1,24 @@
+error[E0425]: cannot find type `CONS` in this scope
+  --> $DIR/const-argument-typo.rs:8:11
+   |
+LL | const CONST: usize = 0;
+   | ----------------------- similarly named constant `CONST` defined here
+...
+LL |     foo::<CONS>(); 
+   |           ^^^^ help: a constant with a similar name exists: `CONST`
+
+error[E0747]: unresolved item provided when a constant was expected
+  --> $DIR/const-argument-typo.rs:8:11
+   |
+LL |     foo::<CONS>(); 
+   |           ^^^^
+   |
+help: if this generic argument was intended as a const parameter, surround it with braces
+   |
+LL |     foo::<{ CONS }>(); 
+   |           +      +
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0425, E0747.
+For more information about an error, try `rustc --explain E0425`.

--- a/tests/ui/const-generics/const-argument-typo.stderr
+++ b/tests/ui/const-generics/const-argument-typo.stderr
@@ -4,21 +4,14 @@ error[E0425]: cannot find type `CONS` in this scope
 LL | const CONST: usize = 0;
    | ----------------------- similarly named constant `CONST` defined here
 ...
-LL |     foo::<CONS>(); 
-   |           ^^^^ help: a constant with a similar name exists: `CONST`
-
-error[E0747]: unresolved item provided when a constant was expected
-  --> $DIR/const-argument-typo.rs:8:11
-   |
-LL |     foo::<CONS>(); 
+LL |     foo::<CONS>();
    |           ^^^^
    |
-help: if this generic argument was intended as a const parameter, surround it with braces
+help: a constant with a similar name exists
    |
-LL |     foo::<{ CONS }>(); 
-   |           +      +
+LL |     foo::<CONST>();
+   |               +
 
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 
-Some errors have detailed explanations: E0425, E0747.
-For more information about an error, try `rustc --explain E0425`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/const-generics/const-generic-function.rs
+++ b/tests/ui/const-generics/const-generic-function.rs
@@ -14,7 +14,6 @@ const FOO: i32 = 3;
 
 fn main() {
     foo::<baz()>(); //~ ERROR cannot find type `baz` in this scope
-    //~^ ERROR unresolved item provided when a constant was expected
     foo::<bar(bar(1, 1), bar(1, 1))>(); //~ ERROR expected type, found `1`
     foo::<bar(1, 1)>(); //~ ERROR expected type, found `1`
     foo::<bar(FOO, 2)>(); //~ ERROR expected type, found `2`

--- a/tests/ui/const-generics/const-generic-function.stderr
+++ b/tests/ui/const-generics/const-generic-function.stderr
@@ -1,5 +1,5 @@
 error: expected type, found `1`
-  --> $DIR/const-generic-function.rs:18:19
+  --> $DIR/const-generic-function.rs:17:19
    |
 LL |     foo::<bar(bar(1, 1), bar(1, 1))>();
    |                   ^ expected type
@@ -10,7 +10,7 @@ LL |     foo::<{ bar(bar(1, 1), bar(1, 1)) }>();
    |           +                           +
 
 error: expected type, found `1`
-  --> $DIR/const-generic-function.rs:19:15
+  --> $DIR/const-generic-function.rs:18:15
    |
 LL |     foo::<bar(1, 1)>();
    |               ^ expected type
@@ -21,7 +21,7 @@ LL |     foo::<{ bar(1, 1) }>();
    |           +           +
 
 error: expected type, found `2`
-  --> $DIR/const-generic-function.rs:20:20
+  --> $DIR/const-generic-function.rs:19:20
    |
 LL |     foo::<bar(FOO, 2)>();
    |                    ^ expected type
@@ -39,18 +39,6 @@ LL |     foo::<baz()>();
    |
    = note: a function named `baz` exists in another namespace
 
-error[E0747]: unresolved item provided when a constant was expected
-  --> $DIR/const-generic-function.rs:16:11
-   |
-LL |     foo::<baz()>();
-   |           ^^^^^
-   |
-help: if this generic argument was intended as a const parameter, surround it with braces
-   |
-LL |     foo::<{ baz() }>();
-   |           +       +
+error: aborting due to 4 previous errors
 
-error: aborting due to 5 previous errors
-
-Some errors have detailed explanations: E0573, E0747.
-For more information about an error, try `rustc --explain E0573`.
+For more information about this error, try `rustc --explain E0573`.

--- a/tests/ui/const-generics/early/invalid-const-arguments.rs
+++ b/tests/ui/const-generics/early/invalid-const-arguments.rs
@@ -3,8 +3,7 @@
 struct A<const N: u8>;
 trait Foo {}
 impl Foo for A<N> {}
-//~^ ERROR cannot find const `N` in this scope
-//~| ERROR unresolved item provided when a constant was expected
+//~^ ERROR cannot find const `N`
 
 struct B<const N: u8>;
 impl<N> Foo for B<N> {}
@@ -12,16 +11,13 @@ impl<N> Foo for B<N> {}
 
 struct C<const C: u8, const N: u8>;
 impl<const N: u8> Foo for C<N, T> {}
-//~^ ERROR cannot find const `T` in this scope
-//~| ERROR unresolved item provided when a constant was expected
+//~^ ERROR cannot find const `T`
 
 struct D<const E: u8, const X: u8, const P: u32>;
 impl Foo for D<E, X, P> {}
 //~^ ERROR cannot find const `E` in this scope
-//~| ERROR unresolved item provided when a constant was expected
 //~| ERROR cannot find const `X` in this scope
 //~| ERROR cannot find const `P` in this scope
 struct R<const O: u8, const G: u8, const F: u32>;
 impl<const F: u8, const H: u32> Foo for D<F, Q, D> {}
 //~^ ERROR cannot find const `Q` in this scope
-//~| ERROR unresolved item provided when a constant was expected

--- a/tests/ui/const-generics/early/invalid-const-arguments.stderr
+++ b/tests/ui/const-generics/early/invalid-const-arguments.stderr
@@ -13,7 +13,7 @@ LL | impl<const N: u8> Foo for A<N> {}
    |     +++++++++++++
 
 error[E0425]: cannot find const `T` in this scope
-  --> $DIR/invalid-const-arguments.rs:14:32
+  --> $DIR/invalid-const-arguments.rs:13:32
    |
 LL | struct C<const C: u8, const N: u8>;
    |                       ----------- corresponding const parameter on the type defined here
@@ -26,7 +26,7 @@ LL | impl<const N: u8, const T: u8> Foo for C<N, T> {}
    |                 +++++++++++++
 
 error[E0425]: cannot find const `E` in this scope
-  --> $DIR/invalid-const-arguments.rs:19:16
+  --> $DIR/invalid-const-arguments.rs:17:16
    |
 LL | struct D<const E: u8, const X: u8, const P: u32>;
    |          ----------- corresponding const parameter on the type defined here
@@ -39,7 +39,7 @@ LL | impl<const E: u8> Foo for D<E, X, P> {}
    |     +++++++++++++
 
 error[E0425]: cannot find const `X` in this scope
-  --> $DIR/invalid-const-arguments.rs:19:19
+  --> $DIR/invalid-const-arguments.rs:17:19
    |
 LL | struct D<const E: u8, const X: u8, const P: u32>;
    |                       ----------- corresponding const parameter on the type defined here
@@ -52,7 +52,7 @@ LL | impl<const X: u8> Foo for D<E, X, P> {}
    |     +++++++++++++
 
 error[E0425]: cannot find const `P` in this scope
-  --> $DIR/invalid-const-arguments.rs:19:22
+  --> $DIR/invalid-const-arguments.rs:17:22
    |
 LL | struct D<const E: u8, const X: u8, const P: u32>;
    |                                    ------------ corresponding const parameter on the type defined here
@@ -65,7 +65,7 @@ LL | impl<const P: u32> Foo for D<E, X, P> {}
    |     ++++++++++++++
 
 error[E0425]: cannot find const `Q` in this scope
-  --> $DIR/invalid-const-arguments.rs:25:46
+  --> $DIR/invalid-const-arguments.rs:22:46
    |
 LL | struct D<const E: u8, const X: u8, const P: u32>;
    |                       ----------- corresponding const parameter on the type defined here
@@ -78,19 +78,8 @@ help: you might have meant to introduce a const parameter `Q` on the impl
 LL | impl<const F: u8, const H: u32, const Q: u8> Foo for D<F, Q, D> {}
    |                               +++++++++++++
 
-error[E0747]: unresolved item provided when a constant was expected
-  --> $DIR/invalid-const-arguments.rs:5:16
-   |
-LL | impl Foo for A<N> {}
-   |                ^
-   |
-help: if this generic argument was intended as a const parameter, surround it with braces
-   |
-LL | impl Foo for A<{ N }> {}
-   |                +   +
-
 error[E0747]: type provided when a constant was expected
-  --> $DIR/invalid-const-arguments.rs:10:19
+  --> $DIR/invalid-const-arguments.rs:9:19
    |
 LL | impl<N> Foo for B<N> {}
    |                   ^
@@ -101,40 +90,7 @@ LL - impl<N> Foo for B<N> {}
 LL + impl<const N: u8> Foo for B<N> {}
    |
 
-error[E0747]: unresolved item provided when a constant was expected
-  --> $DIR/invalid-const-arguments.rs:14:32
-   |
-LL | impl<const N: u8> Foo for C<N, T> {}
-   |                                ^
-   |
-help: if this generic argument was intended as a const parameter, surround it with braces
-   |
-LL | impl<const N: u8> Foo for C<N, { T }> {}
-   |                                +   +
-
-error[E0747]: unresolved item provided when a constant was expected
-  --> $DIR/invalid-const-arguments.rs:19:16
-   |
-LL | impl Foo for D<E, X, P> {}
-   |                ^
-   |
-help: if this generic argument was intended as a const parameter, surround it with braces
-   |
-LL | impl Foo for D<{ E }, X, P> {}
-   |                +   +
-
-error[E0747]: unresolved item provided when a constant was expected
-  --> $DIR/invalid-const-arguments.rs:25:46
-   |
-LL | impl<const F: u8, const H: u32> Foo for D<F, Q, D> {}
-   |                                              ^
-   |
-help: if this generic argument was intended as a const parameter, surround it with braces
-   |
-LL | impl<const F: u8, const H: u32> Foo for D<F, { Q }, D> {}
-   |                                              +   +
-
-error: aborting due to 11 previous errors
+error: aborting due to 7 previous errors
 
 Some errors have detailed explanations: E0425, E0747.
 For more information about an error, try `rustc --explain E0425`.

--- a/tests/ui/const-generics/invalid-enum.rs
+++ b/tests/ui/const-generics/invalid-enum.rs
@@ -23,15 +23,12 @@ impl<const CF: CompileFlag, T> Example<CF, T> {
 pub fn main() {
     test_1::<CompileFlag::A>();
     //~^ ERROR: expected type, found variant
-    //~| ERROR: unresolved item provided when a constant was expected
 
     test_2::<_, CompileFlag::A>(0);
     //~^ ERROR: expected type, found variant
-    //~| ERROR: unresolved item provided when a constant was expected
 
     let _: Example<CompileFlag::A, _> = Example { x: 0 };
     //~^ ERROR: expected type, found variant
-    //~| ERROR: unresolved item provided when a constant was expected
 
     let _: Example<Example::ASSOC_FLAG, _> = Example { x: 0 };
     //~^ ERROR: type provided when a constant was expected

--- a/tests/ui/const-generics/invalid-enum.stderr
+++ b/tests/ui/const-generics/invalid-enum.stderr
@@ -11,7 +11,7 @@ LL +     test_1::<CompileFlag>();
    |
 
 error[E0573]: expected type, found variant `CompileFlag::A`
-  --> $DIR/invalid-enum.rs:28:17
+  --> $DIR/invalid-enum.rs:27:17
    |
 LL |     test_2::<_, CompileFlag::A>(0);
    |                 ^^^^^^^^^^^^^^ not a type
@@ -23,7 +23,7 @@ LL +     test_2::<_, CompileFlag>(0);
    |
 
 error[E0573]: expected type, found variant `CompileFlag::A`
-  --> $DIR/invalid-enum.rs:32:20
+  --> $DIR/invalid-enum.rs:30:20
    |
 LL |     let _: Example<CompileFlag::A, _> = Example { x: 0 };
    |                    ^^^^^^^^^^^^^^ not a type
@@ -34,41 +34,8 @@ LL -     let _: Example<CompileFlag::A, _> = Example { x: 0 };
 LL +     let _: Example<CompileFlag, _> = Example { x: 0 };
    |
 
-error[E0747]: unresolved item provided when a constant was expected
-  --> $DIR/invalid-enum.rs:24:14
-   |
-LL |     test_1::<CompileFlag::A>();
-   |              ^^^^^^^^^^^^^^
-   |
-help: if this generic argument was intended as a const parameter, surround it with braces
-   |
-LL |     test_1::<{ CompileFlag::A }>();
-   |              +                +
-
-error[E0747]: unresolved item provided when a constant was expected
-  --> $DIR/invalid-enum.rs:28:17
-   |
-LL |     test_2::<_, CompileFlag::A>(0);
-   |                 ^^^^^^^^^^^^^^
-   |
-help: if this generic argument was intended as a const parameter, surround it with braces
-   |
-LL |     test_2::<_, { CompileFlag::A }>(0);
-   |                 +                +
-
-error[E0747]: unresolved item provided when a constant was expected
-  --> $DIR/invalid-enum.rs:32:20
-   |
-LL |     let _: Example<CompileFlag::A, _> = Example { x: 0 };
-   |                    ^^^^^^^^^^^^^^
-   |
-help: if this generic argument was intended as a const parameter, surround it with braces
-   |
-LL |     let _: Example<{ CompileFlag::A }, _> = Example { x: 0 };
-   |                    +                +
-
 error[E0747]: type provided when a constant was expected
-  --> $DIR/invalid-enum.rs:36:20
+  --> $DIR/invalid-enum.rs:33:20
    |
 LL |     let _: Example<Example::ASSOC_FLAG, _> = Example { x: 0 };
    |                    ^^^^^^^^^^^^^^^^^^^
@@ -78,7 +45,7 @@ help: if this generic argument was intended as a const parameter, surround it wi
 LL |     let _: Example<{ Example::ASSOC_FLAG }, _> = Example { x: 0 };
    |                    +                     +
 
-error: aborting due to 7 previous errors
+error: aborting due to 4 previous errors
 
 Some errors have detailed explanations: E0573, E0747.
 For more information about an error, try `rustc --explain E0573`.

--- a/tests/ui/delegation/generics/generics-gen-args-errors.rs
+++ b/tests/ui/delegation/generics/generics-gen-args-errors.rs
@@ -28,13 +28,11 @@ mod test_1 {
         //~^ ERROR: cannot find type `asd` in this scope
         //~| ERROR: cannot find type `asd` in this scope
         //~| ERROR: cannot find type `asd` in this scope
-        //~| ERROR: unresolved item provided when a constant was expected
 
         reuse foo::<A, B, C> as xd;
         //~^ ERROR can't use generic parameters from outer item
         //~| ERROR can't use generic parameters from outer item
         //~| ERROR can't use generic parameters from outer item
-        //~| ERROR: unresolved item provided when a constant was expected
         //~| ERROR: function takes 2 lifetime arguments but 0 lifetime arguments were supplied
         //~| ERROR: inferred lifetimes are not allowed in delegations as we need to inherit signature
     }

--- a/tests/ui/delegation/generics/generics-gen-args-errors.stderr
+++ b/tests/ui/delegation/generics/generics-gen-args-errors.stderr
@@ -1,5 +1,5 @@
 error[E0401]: can't use generic parameters from outer item
-  --> $DIR/generics-gen-args-errors.rs:33:21
+  --> $DIR/generics-gen-args-errors.rs:32:21
    |
 LL |     fn check<A, B, C>() {
    |              - type parameter from outer item
@@ -12,7 +12,7 @@ LL |         reuse foo::<A, B, C> as xd;
    = note: nested items are independent from their parent item for everything except for privacy and name resolution
 
 error[E0401]: can't use generic parameters from outer item
-  --> $DIR/generics-gen-args-errors.rs:33:24
+  --> $DIR/generics-gen-args-errors.rs:32:24
    |
 LL |     fn check<A, B, C>() {
    |                 - type parameter from outer item
@@ -25,7 +25,7 @@ LL |         reuse foo::<A, B, C> as xd;
    = note: nested items are independent from their parent item for everything except for privacy and name resolution
 
 error[E0401]: can't use generic parameters from outer item
-  --> $DIR/generics-gen-args-errors.rs:33:27
+  --> $DIR/generics-gen-args-errors.rs:32:27
    |
 LL |     fn check<A, B, C>() {
    |                    - type parameter from outer item
@@ -38,7 +38,7 @@ LL |         reuse foo::<A, B, C> as xd;
    = note: nested items are independent from their parent item for everything except for privacy and name resolution
 
 error[E0261]: use of undeclared lifetime name `'asdasd`
-  --> $DIR/generics-gen-args-errors.rs:53:29
+  --> $DIR/generics-gen-args-errors.rs:51:29
    |
 LL |     reuse foo::<'static, _, 'asdasd, 'static, 'static, 'static, _> as bar3;
    |                             ^^^^^^^ undeclared lifetime
@@ -49,7 +49,7 @@ LL |     reuse foo'asdasd, ::<'static, _, 'asdasd, 'static, 'static, 'static, _>
    |              ++++++++
 
 error[E0261]: use of undeclared lifetime name `'a`
-  --> $DIR/generics-gen-args-errors.rs:75:50
+  --> $DIR/generics-gen-args-errors.rs:73:50
    |
 LL |     reuse foo::<"asdasd", asd, "askdn", 'static, 'a> as bar7;
    |                                                  ^^ undeclared lifetime
@@ -105,79 +105,79 @@ LL |     fn check<A, B, C, asd>() {
    |                     +++++
 
 error[E0425]: cannot find type `asdasd` in this scope
-  --> $DIR/generics-gen-args-errors.rs:59:39
+  --> $DIR/generics-gen-args-errors.rs:57:39
    |
 LL |     reuse foo::<String, 'static, 123, asdasd> as bar4;
    |                                       ^^^^^^ not found in this scope
 
 error[E0425]: cannot find type `asd` in this scope
-  --> $DIR/generics-gen-args-errors.rs:69:22
+  --> $DIR/generics-gen-args-errors.rs:67:22
    |
 LL |     reuse foo::<1, 2,asd,String, { let x = 0; }> as bar6;
    |                      ^^^ not found in this scope
 
 error[E0425]: cannot find type `asd` in this scope
-  --> $DIR/generics-gen-args-errors.rs:75:27
+  --> $DIR/generics-gen-args-errors.rs:73:27
    |
 LL |     reuse foo::<"asdasd", asd, "askdn", 'static, 'a> as bar7;
    |                           ^^^ not found in this scope
 
 error[E0425]: cannot find type `asd` in this scope
-  --> $DIR/generics-gen-args-errors.rs:92:19
+  --> $DIR/generics-gen-args-errors.rs:90:19
    |
 LL |     reuse Trait::<asd, asd, asd, asd, asd, asdasa>::foo as bar1;
    |                   ^^^ not found in this scope
 
 error[E0425]: cannot find type `asd` in this scope
-  --> $DIR/generics-gen-args-errors.rs:92:24
+  --> $DIR/generics-gen-args-errors.rs:90:24
    |
 LL |     reuse Trait::<asd, asd, asd, asd, asd, asdasa>::foo as bar1;
    |                        ^^^ not found in this scope
 
 error[E0425]: cannot find type `asd` in this scope
-  --> $DIR/generics-gen-args-errors.rs:92:29
+  --> $DIR/generics-gen-args-errors.rs:90:29
    |
 LL |     reuse Trait::<asd, asd, asd, asd, asd, asdasa>::foo as bar1;
    |                             ^^^ not found in this scope
 
 error[E0425]: cannot find type `asd` in this scope
-  --> $DIR/generics-gen-args-errors.rs:92:34
+  --> $DIR/generics-gen-args-errors.rs:90:34
    |
 LL |     reuse Trait::<asd, asd, asd, asd, asd, asdasa>::foo as bar1;
    |                                  ^^^ not found in this scope
 
 error[E0425]: cannot find type `asd` in this scope
-  --> $DIR/generics-gen-args-errors.rs:92:39
+  --> $DIR/generics-gen-args-errors.rs:90:39
    |
 LL |     reuse Trait::<asd, asd, asd, asd, asd, asdasa>::foo as bar1;
    |                                       ^^^ not found in this scope
 
 error[E0425]: cannot find type `asdasa` in this scope
-  --> $DIR/generics-gen-args-errors.rs:92:44
+  --> $DIR/generics-gen-args-errors.rs:90:44
    |
 LL |     reuse Trait::<asd, asd, asd, asd, asd, asdasa>::foo as bar1;
    |                                            ^^^^^^ not found in this scope
 
 error[E0425]: cannot find type `DDDD` in this scope
-  --> $DIR/generics-gen-args-errors.rs:122:34
+  --> $DIR/generics-gen-args-errors.rs:120:34
    |
 LL |     reuse Trait::<1, 2, 'static, DDDD>::foo::<1, 2, 3, 4, 5, 6> as bar6;
    |                                  ^^^^ not found in this scope
 
 error: wrong infer used: expected '_, found: _
-  --> $DIR/generics-gen-args-errors.rs:53:26
+  --> $DIR/generics-gen-args-errors.rs:51:26
    |
 LL |     reuse foo::<'static, _, 'asdasd, 'static, 'static, 'static, _> as bar3;
    |                          ^
 
 error: wrong infer used: expected '_, found: _
-  --> $DIR/generics-gen-args-errors.rs:131:33
+  --> $DIR/generics-gen-args-errors.rs:129:33
    |
 LL |     reuse Trait::<Trait, Clone, _, 'static, dyn Send, _>::foo::<1, 2, 3, _, 6> as bar7;
    |                                 ^
 
 error[E0107]: function takes 2 lifetime arguments but 0 lifetime arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:33:15
+  --> $DIR/generics-gen-args-errors.rs:32:15
    |
 LL |         reuse foo::<A, B, C> as xd;
    |               ^^^ expected 2 lifetime arguments
@@ -193,19 +193,19 @@ LL |         reuse foo::<'a, 'b, A, B, C> as xd;
    |                     +++++++
 
 error: inferred lifetimes are not allowed in delegations as we need to inherit signature
-  --> $DIR/generics-gen-args-errors.rs:33:15
+  --> $DIR/generics-gen-args-errors.rs:32:15
    |
 LL |         reuse foo::<A, B, C> as xd;
    |               ^^^
 
 error[E0107]: function takes 2 lifetime arguments but 0 lifetime arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:48:11
+  --> $DIR/generics-gen-args-errors.rs:46:11
    |
 LL |     reuse foo::<String, String> as bar2;
    |           ^^^ expected 2 lifetime arguments
    |
 note: function defined here, with 2 lifetime parameters: `'a`, `'b`
-  --> $DIR/generics-gen-args-errors.rs:44:8
+  --> $DIR/generics-gen-args-errors.rs:42:8
    |
 LL |     fn foo<'a: 'a, 'b: 'b, T: Clone, U: Clone, const N: usize>() {}
    |        ^^^ --      --
@@ -215,7 +215,7 @@ LL |     reuse foo::<'a, 'b, String, String> as bar2;
    |                 +++++++
 
 error[E0107]: function takes 3 generic arguments but 2 generic arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:48:11
+  --> $DIR/generics-gen-args-errors.rs:46:11
    |
 LL |     reuse foo::<String, String> as bar2;
    |           ^^^   ------  ------ supplied 2 generic arguments
@@ -223,7 +223,7 @@ LL |     reuse foo::<String, String> as bar2;
    |           expected 3 generic arguments
    |
 note: function defined here, with 3 generic parameters: `T`, `U`, `N`
-  --> $DIR/generics-gen-args-errors.rs:44:8
+  --> $DIR/generics-gen-args-errors.rs:42:8
    |
 LL |     fn foo<'a: 'a, 'b: 'b, T: Clone, U: Clone, const N: usize>() {}
    |        ^^^                 -         -         --------------
@@ -233,13 +233,13 @@ LL |     reuse foo::<String, String, N> as bar2;
    |                               +++
 
 error: inferred lifetimes are not allowed in delegations as we need to inherit signature
-  --> $DIR/generics-gen-args-errors.rs:48:11
+  --> $DIR/generics-gen-args-errors.rs:46:11
    |
 LL |     reuse foo::<String, String> as bar2;
    |           ^^^
 
 error[E0107]: function takes 2 lifetime arguments but 6 lifetime arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:53:11
+  --> $DIR/generics-gen-args-errors.rs:51:11
    |
 LL |     reuse foo::<'static, _, 'asdasd, 'static, 'static, 'static, _> as bar3;
    |           ^^^------------------------------------------------- help: remove the lifetime arguments
@@ -247,19 +247,19 @@ LL |     reuse foo::<'static, _, 'asdasd, 'static, 'static, 'static, _> as bar3;
    |           expected 2 lifetime arguments
    |
 note: function defined here, with 2 lifetime parameters: `'a`, `'b`
-  --> $DIR/generics-gen-args-errors.rs:44:8
+  --> $DIR/generics-gen-args-errors.rs:42:8
    |
 LL |     fn foo<'a: 'a, 'b: 'b, T: Clone, U: Clone, const N: usize>() {}
    |        ^^^ --      --
 
 error[E0107]: function takes 3 generic arguments but 1 generic argument was supplied
-  --> $DIR/generics-gen-args-errors.rs:53:11
+  --> $DIR/generics-gen-args-errors.rs:51:11
    |
 LL |     reuse foo::<'static, _, 'asdasd, 'static, 'static, 'static, _> as bar3;
    |           ^^^ expected 3 generic arguments                      - supplied 1 generic argument
    |
 note: function defined here, with 3 generic parameters: `T`, `U`, `N`
-  --> $DIR/generics-gen-args-errors.rs:44:8
+  --> $DIR/generics-gen-args-errors.rs:42:8
    |
 LL |     fn foo<'a: 'a, 'b: 'b, T: Clone, U: Clone, const N: usize>() {}
    |        ^^^                 -         -         --------------
@@ -269,7 +269,7 @@ LL |     reuse foo::<'static, _, 'asdasd, 'static, 'static, 'static, _, U, N> as
    |                                                                  ++++++
 
 error[E0107]: function takes 2 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/generics-gen-args-errors.rs:59:11
+  --> $DIR/generics-gen-args-errors.rs:57:11
    |
 LL |     reuse foo::<String, 'static, 123, asdasd> as bar4;
    |           ^^^   ------ supplied 1 lifetime argument
@@ -277,7 +277,7 @@ LL |     reuse foo::<String, 'static, 123, asdasd> as bar4;
    |           expected 2 lifetime arguments
    |
 note: function defined here, with 2 lifetime parameters: `'a`, `'b`
-  --> $DIR/generics-gen-args-errors.rs:44:8
+  --> $DIR/generics-gen-args-errors.rs:42:8
    |
 LL |     fn foo<'a: 'a, 'b: 'b, T: Clone, U: Clone, const N: usize>() {}
    |        ^^^ --      --
@@ -287,19 +287,19 @@ LL |     reuse foo::<String, 'static, 'static, 123, asdasd> as bar4;
    |                       +++++++++
 
 error: inferred lifetimes are not allowed in delegations as we need to inherit signature
-  --> $DIR/generics-gen-args-errors.rs:59:11
+  --> $DIR/generics-gen-args-errors.rs:57:11
    |
 LL |     reuse foo::<String, 'static, 123, asdasd> as bar4;
    |           ^^^
 
 error[E0107]: function takes 2 lifetime arguments but 0 lifetime arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:64:11
+  --> $DIR/generics-gen-args-errors.rs:62:11
    |
 LL |     reuse foo::<1, 2, _, 4, 5, _> as bar5;
    |           ^^^ expected 2 lifetime arguments
    |
 note: function defined here, with 2 lifetime parameters: `'a`, `'b`
-  --> $DIR/generics-gen-args-errors.rs:44:8
+  --> $DIR/generics-gen-args-errors.rs:42:8
    |
 LL |     fn foo<'a: 'a, 'b: 'b, T: Clone, U: Clone, const N: usize>() {}
    |        ^^^ --      --
@@ -309,7 +309,7 @@ LL |     reuse foo::<'a, 'b, 1, 2, _, 4, 5, _> as bar5;
    |                 +++++++
 
 error[E0107]: function takes 3 generic arguments but 6 generic arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:64:11
+  --> $DIR/generics-gen-args-errors.rs:62:11
    |
 LL |     reuse foo::<1, 2, _, 4, 5, _> as bar5;
    |           ^^^------------------- help: remove the unnecessary generic arguments
@@ -317,25 +317,25 @@ LL |     reuse foo::<1, 2, _, 4, 5, _> as bar5;
    |           expected 3 generic arguments
    |
 note: function defined here, with 3 generic parameters: `T`, `U`, `N`
-  --> $DIR/generics-gen-args-errors.rs:44:8
+  --> $DIR/generics-gen-args-errors.rs:42:8
    |
 LL |     fn foo<'a: 'a, 'b: 'b, T: Clone, U: Clone, const N: usize>() {}
    |        ^^^                 -         -         --------------
 
 error: inferred lifetimes are not allowed in delegations as we need to inherit signature
-  --> $DIR/generics-gen-args-errors.rs:64:11
+  --> $DIR/generics-gen-args-errors.rs:62:11
    |
 LL |     reuse foo::<1, 2, _, 4, 5, _> as bar5;
    |           ^^^
 
 error[E0107]: function takes 2 lifetime arguments but 0 lifetime arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:69:11
+  --> $DIR/generics-gen-args-errors.rs:67:11
    |
 LL |     reuse foo::<1, 2,asd,String, { let x = 0; }> as bar6;
    |           ^^^ expected 2 lifetime arguments
    |
 note: function defined here, with 2 lifetime parameters: `'a`, `'b`
-  --> $DIR/generics-gen-args-errors.rs:44:8
+  --> $DIR/generics-gen-args-errors.rs:42:8
    |
 LL |     fn foo<'a: 'a, 'b: 'b, T: Clone, U: Clone, const N: usize>() {}
    |        ^^^ --      --
@@ -345,7 +345,7 @@ LL |     reuse foo::<'a, 'b, 1, 2,asd,String, { let x = 0; }> as bar6;
    |                 +++++++
 
 error[E0107]: function takes 3 generic arguments but 5 generic arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:69:11
+  --> $DIR/generics-gen-args-errors.rs:67:11
    |
 LL |     reuse foo::<1, 2,asd,String, { let x = 0; }> as bar6;
    |           ^^^           ----------------------- help: remove the unnecessary generic arguments
@@ -353,37 +353,37 @@ LL |     reuse foo::<1, 2,asd,String, { let x = 0; }> as bar6;
    |           expected 3 generic arguments
    |
 note: function defined here, with 3 generic parameters: `T`, `U`, `N`
-  --> $DIR/generics-gen-args-errors.rs:44:8
+  --> $DIR/generics-gen-args-errors.rs:42:8
    |
 LL |     fn foo<'a: 'a, 'b: 'b, T: Clone, U: Clone, const N: usize>() {}
    |        ^^^                 -         -         --------------
 
 error: inferred lifetimes are not allowed in delegations as we need to inherit signature
-  --> $DIR/generics-gen-args-errors.rs:69:11
+  --> $DIR/generics-gen-args-errors.rs:67:11
    |
 LL |     reuse foo::<1, 2,asd,String, { let x = 0; }> as bar6;
    |           ^^^
 
 error: inferred lifetimes are not allowed in delegations as we need to inherit signature
-  --> $DIR/generics-gen-args-errors.rs:75:11
+  --> $DIR/generics-gen-args-errors.rs:73:11
    |
 LL |     reuse foo::<"asdasd", asd, "askdn", 'static, 'a> as bar7;
    |           ^^^
 
 error[E0747]: constant provided when a type was expected
-  --> $DIR/generics-gen-args-errors.rs:75:17
+  --> $DIR/generics-gen-args-errors.rs:73:17
    |
 LL |     reuse foo::<"asdasd", asd, "askdn", 'static, 'a> as bar7;
    |                 ^^^^^^^^
 
 error[E0107]: function takes 2 lifetime arguments but 0 lifetime arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:81:11
+  --> $DIR/generics-gen-args-errors.rs:79:11
    |
 LL |     reuse foo::<{}, {}, {}> as bar8;
    |           ^^^ expected 2 lifetime arguments
    |
 note: function defined here, with 2 lifetime parameters: `'a`, `'b`
-  --> $DIR/generics-gen-args-errors.rs:44:8
+  --> $DIR/generics-gen-args-errors.rs:42:8
    |
 LL |     fn foo<'a: 'a, 'b: 'b, T: Clone, U: Clone, const N: usize>() {}
    |        ^^^ --      --
@@ -393,19 +393,19 @@ LL |     reuse foo::<'a, 'b, {}, {}, {}> as bar8;
    |                 +++++++
 
 error: inferred lifetimes are not allowed in delegations as we need to inherit signature
-  --> $DIR/generics-gen-args-errors.rs:81:11
+  --> $DIR/generics-gen-args-errors.rs:79:11
    |
 LL |     reuse foo::<{}, {}, {}> as bar8;
    |           ^^^
 
 error[E0107]: trait takes 3 lifetime arguments but 0 lifetime arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:92:11
+  --> $DIR/generics-gen-args-errors.rs:90:11
    |
 LL |     reuse Trait::<asd, asd, asd, asd, asd, asdasa>::foo as bar1;
    |           ^^^^^ expected 3 lifetime arguments
    |
 note: trait defined here, with 3 lifetime parameters: `'b`, `'c`, `'a`
-  --> $DIR/generics-gen-args-errors.rs:88:11
+  --> $DIR/generics-gen-args-errors.rs:86:11
    |
 LL |     trait Trait<'b, 'c, 'a, T, const N: usize>: Sized {
    |           ^^^^^ --  --  --
@@ -415,7 +415,7 @@ LL |     reuse Trait::<'b, 'c, 'a, asd, asd, asd, asd, asd, asdasa>::foo as bar1
    |                   +++++++++++
 
 error[E0107]: trait takes 2 generic arguments but 6 generic arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:92:11
+  --> $DIR/generics-gen-args-errors.rs:90:11
    |
 LL |     reuse Trait::<asd, asd, asd, asd, asd, asdasa>::foo as bar1;
    |           ^^^^^           ----------------------- help: remove the unnecessary generic arguments
@@ -423,19 +423,19 @@ LL |     reuse Trait::<asd, asd, asd, asd, asd, asdasa>::foo as bar1;
    |           expected 2 generic arguments
    |
 note: trait defined here, with 2 generic parameters: `T`, `N`
-  --> $DIR/generics-gen-args-errors.rs:88:11
+  --> $DIR/generics-gen-args-errors.rs:86:11
    |
 LL |     trait Trait<'b, 'c, 'a, T, const N: usize>: Sized {
    |           ^^^^^             -  --------------
 
 error: inferred lifetimes are not allowed in delegations as we need to inherit signature
-  --> $DIR/generics-gen-args-errors.rs:92:11
+  --> $DIR/generics-gen-args-errors.rs:90:11
    |
 LL |     reuse Trait::<asd, asd, asd, asd, asd, asdasa>::foo as bar1;
    |           ^^^^^
 
 error[E0107]: trait takes 3 lifetime arguments but 2 lifetime arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:103:11
+  --> $DIR/generics-gen-args-errors.rs:101:11
    |
 LL |     reuse Trait::<'static, 'static>::foo as bar2;
    |           ^^^^^   -------  ------- supplied 2 lifetime arguments
@@ -443,7 +443,7 @@ LL |     reuse Trait::<'static, 'static>::foo as bar2;
    |           expected 3 lifetime arguments
    |
 note: trait defined here, with 3 lifetime parameters: `'b`, `'c`, `'a`
-  --> $DIR/generics-gen-args-errors.rs:88:11
+  --> $DIR/generics-gen-args-errors.rs:86:11
    |
 LL |     trait Trait<'b, 'c, 'a, T, const N: usize>: Sized {
    |           ^^^^^ --  --  --
@@ -453,25 +453,25 @@ LL |     reuse Trait::<'static, 'static, 'static>::foo as bar2;
    |                                   +++++++++
 
 error: inferred lifetimes are not allowed in delegations as we need to inherit signature
-  --> $DIR/generics-gen-args-errors.rs:103:11
+  --> $DIR/generics-gen-args-errors.rs:101:11
    |
 LL |     reuse Trait::<'static, 'static>::foo as bar2;
    |           ^^^^^
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/generics-gen-args-errors.rs:103:11
+  --> $DIR/generics-gen-args-errors.rs:101:11
    |
 LL |     reuse Trait::<'static, 'static>::foo as bar2;
    |           ^^^^^ not allowed in type signatures
 
 error[E0107]: trait takes 3 lifetime arguments but 0 lifetime arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:107:11
+  --> $DIR/generics-gen-args-errors.rs:105:11
    |
 LL |     reuse Trait::<1, 2, 3, 4, 5>::foo as bar3;
    |           ^^^^^ expected 3 lifetime arguments
    |
 note: trait defined here, with 3 lifetime parameters: `'b`, `'c`, `'a`
-  --> $DIR/generics-gen-args-errors.rs:88:11
+  --> $DIR/generics-gen-args-errors.rs:86:11
    |
 LL |     trait Trait<'b, 'c, 'a, T, const N: usize>: Sized {
    |           ^^^^^ --  --  --
@@ -481,7 +481,7 @@ LL |     reuse Trait::<'b, 'c, 'a, 1, 2, 3, 4, 5>::foo as bar3;
    |                   +++++++++++
 
 error[E0107]: trait takes 2 generic arguments but 5 generic arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:107:11
+  --> $DIR/generics-gen-args-errors.rs:105:11
    |
 LL |     reuse Trait::<1, 2, 3, 4, 5>::foo as bar3;
    |           ^^^^^       --------- help: remove the unnecessary generic arguments
@@ -489,25 +489,25 @@ LL |     reuse Trait::<1, 2, 3, 4, 5>::foo as bar3;
    |           expected 2 generic arguments
    |
 note: trait defined here, with 2 generic parameters: `T`, `N`
-  --> $DIR/generics-gen-args-errors.rs:88:11
+  --> $DIR/generics-gen-args-errors.rs:86:11
    |
 LL |     trait Trait<'b, 'c, 'a, T, const N: usize>: Sized {
    |           ^^^^^             -  --------------
 
 error: inferred lifetimes are not allowed in delegations as we need to inherit signature
-  --> $DIR/generics-gen-args-errors.rs:107:11
+  --> $DIR/generics-gen-args-errors.rs:105:11
    |
 LL |     reuse Trait::<1, 2, 3, 4, 5>::foo as bar3;
    |           ^^^^^
 
 error[E0107]: trait takes 3 lifetime arguments but 0 lifetime arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:112:11
+  --> $DIR/generics-gen-args-errors.rs:110:11
    |
 LL |     reuse Trait::<1, 2, true>::foo as bar4;
    |           ^^^^^ expected 3 lifetime arguments
    |
 note: trait defined here, with 3 lifetime parameters: `'b`, `'c`, `'a`
-  --> $DIR/generics-gen-args-errors.rs:88:11
+  --> $DIR/generics-gen-args-errors.rs:86:11
    |
 LL |     trait Trait<'b, 'c, 'a, T, const N: usize>: Sized {
    |           ^^^^^ --  --  --
@@ -517,7 +517,7 @@ LL |     reuse Trait::<'b, 'c, 'a, 1, 2, true>::foo as bar4;
    |                   +++++++++++
 
 error[E0107]: trait takes 2 generic arguments but 3 generic arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:112:11
+  --> $DIR/generics-gen-args-errors.rs:110:11
    |
 LL |     reuse Trait::<1, 2, true>::foo as bar4;
    |           ^^^^^       ------ help: remove the unnecessary generic argument
@@ -525,19 +525,19 @@ LL |     reuse Trait::<1, 2, true>::foo as bar4;
    |           expected 2 generic arguments
    |
 note: trait defined here, with 2 generic parameters: `T`, `N`
-  --> $DIR/generics-gen-args-errors.rs:88:11
+  --> $DIR/generics-gen-args-errors.rs:86:11
    |
 LL |     trait Trait<'b, 'c, 'a, T, const N: usize>: Sized {
    |           ^^^^^             -  --------------
 
 error: inferred lifetimes are not allowed in delegations as we need to inherit signature
-  --> $DIR/generics-gen-args-errors.rs:112:11
+  --> $DIR/generics-gen-args-errors.rs:110:11
    |
 LL |     reuse Trait::<1, 2, true>::foo as bar4;
    |           ^^^^^
 
 error[E0107]: trait takes 3 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/generics-gen-args-errors.rs:117:11
+  --> $DIR/generics-gen-args-errors.rs:115:11
    |
 LL |     reuse Trait::<'static>::foo as bar5;
    |           ^^^^^   ------- supplied 1 lifetime argument
@@ -545,7 +545,7 @@ LL |     reuse Trait::<'static>::foo as bar5;
    |           expected 3 lifetime arguments
    |
 note: trait defined here, with 3 lifetime parameters: `'b`, `'c`, `'a`
-  --> $DIR/generics-gen-args-errors.rs:88:11
+  --> $DIR/generics-gen-args-errors.rs:86:11
    |
 LL |     trait Trait<'b, 'c, 'a, T, const N: usize>: Sized {
    |           ^^^^^ --  --  --
@@ -555,19 +555,19 @@ LL |     reuse Trait::<'static, 'static, 'static>::foo as bar5;
    |                          ++++++++++++++++++
 
 error: inferred lifetimes are not allowed in delegations as we need to inherit signature
-  --> $DIR/generics-gen-args-errors.rs:117:11
+  --> $DIR/generics-gen-args-errors.rs:115:11
    |
 LL |     reuse Trait::<'static>::foo as bar5;
    |           ^^^^^
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/generics-gen-args-errors.rs:117:11
+  --> $DIR/generics-gen-args-errors.rs:115:11
    |
 LL |     reuse Trait::<'static>::foo as bar5;
    |           ^^^^^ not allowed in type signatures
 
 error[E0107]: trait takes 3 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/generics-gen-args-errors.rs:122:11
+  --> $DIR/generics-gen-args-errors.rs:120:11
    |
 LL |     reuse Trait::<1, 2, 'static, DDDD>::foo::<1, 2, 3, 4, 5, 6> as bar6;
    |           ^^^^^   - supplied 1 lifetime argument
@@ -575,7 +575,7 @@ LL |     reuse Trait::<1, 2, 'static, DDDD>::foo::<1, 2, 3, 4, 5, 6> as bar6;
    |           expected 3 lifetime arguments
    |
 note: trait defined here, with 3 lifetime parameters: `'b`, `'c`, `'a`
-  --> $DIR/generics-gen-args-errors.rs:88:11
+  --> $DIR/generics-gen-args-errors.rs:86:11
    |
 LL |     trait Trait<'b, 'c, 'a, T, const N: usize>: Sized {
    |           ^^^^^ --  --  --
@@ -585,7 +585,7 @@ LL |     reuse Trait::<1, 'static, 'static, 2, 'static, DDDD>::foo::<1, 2, 3, 4,
    |                    ++++++++++++++++++
 
 error[E0107]: trait takes 2 generic arguments but 3 generic arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:122:11
+  --> $DIR/generics-gen-args-errors.rs:120:11
    |
 LL |     reuse Trait::<1, 2, 'static, DDDD>::foo::<1, 2, 3, 4, 5, 6> as bar6;
    |           ^^^^^       --------------- help: remove the unnecessary generic argument
@@ -593,25 +593,25 @@ LL |     reuse Trait::<1, 2, 'static, DDDD>::foo::<1, 2, 3, 4, 5, 6> as bar6;
    |           expected 2 generic arguments
    |
 note: trait defined here, with 2 generic parameters: `T`, `N`
-  --> $DIR/generics-gen-args-errors.rs:88:11
+  --> $DIR/generics-gen-args-errors.rs:86:11
    |
 LL |     trait Trait<'b, 'c, 'a, T, const N: usize>: Sized {
    |           ^^^^^             -  --------------
 
 error: inferred lifetimes are not allowed in delegations as we need to inherit signature
-  --> $DIR/generics-gen-args-errors.rs:122:11
+  --> $DIR/generics-gen-args-errors.rs:120:11
    |
 LL |     reuse Trait::<1, 2, 'static, DDDD>::foo::<1, 2, 3, 4, 5, 6> as bar6;
    |           ^^^^^
 
 error[E0107]: method takes 1 lifetime argument but 0 lifetime arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:122:41
+  --> $DIR/generics-gen-args-errors.rs:120:41
    |
 LL |     reuse Trait::<1, 2, 'static, DDDD>::foo::<1, 2, 3, 4, 5, 6> as bar6;
    |                                         ^^^ expected 1 lifetime argument
    |
 note: method defined here, with 1 lifetime parameter: `'d`
-  --> $DIR/generics-gen-args-errors.rs:89:12
+  --> $DIR/generics-gen-args-errors.rs:87:12
    |
 LL |         fn foo<'d: 'd, U, const M: bool>(self) {}
    |            ^^^ --
@@ -621,7 +621,7 @@ LL |     reuse Trait::<1, 2, 'static, DDDD>::foo::<'d, 1, 2, 3, 4, 5, 6> as bar6
    |                                               +++
 
 error[E0107]: method takes 2 generic arguments but 6 generic arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:122:41
+  --> $DIR/generics-gen-args-errors.rs:120:41
    |
 LL |     reuse Trait::<1, 2, 'static, DDDD>::foo::<1, 2, 3, 4, 5, 6> as bar6;
    |                                         ^^^       ------------ help: remove the unnecessary generic arguments
@@ -629,19 +629,19 @@ LL |     reuse Trait::<1, 2, 'static, DDDD>::foo::<1, 2, 3, 4, 5, 6> as bar6;
    |                                         expected 2 generic arguments
    |
 note: method defined here, with 2 generic parameters: `U`, `M`
-  --> $DIR/generics-gen-args-errors.rs:89:12
+  --> $DIR/generics-gen-args-errors.rs:87:12
    |
 LL |         fn foo<'d: 'd, U, const M: bool>(self) {}
    |            ^^^         -  -------------
 
 error: inferred lifetimes are not allowed in delegations as we need to inherit signature
-  --> $DIR/generics-gen-args-errors.rs:122:41
+  --> $DIR/generics-gen-args-errors.rs:120:41
    |
 LL |     reuse Trait::<1, 2, 'static, DDDD>::foo::<1, 2, 3, 4, 5, 6> as bar6;
    |                                         ^^^
 
 error[E0107]: trait takes 3 lifetime arguments but 2 lifetime arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:131:11
+  --> $DIR/generics-gen-args-errors.rs:129:11
    |
 LL |     reuse Trait::<Trait, Clone, _, 'static, dyn Send, _>::foo::<1, 2, 3, _, 6> as bar7;
    |           ^^^^^   -----  ----- supplied 2 lifetime arguments
@@ -649,7 +649,7 @@ LL |     reuse Trait::<Trait, Clone, _, 'static, dyn Send, _>::foo::<1, 2, 3, _,
    |           expected 3 lifetime arguments
    |
 note: trait defined here, with 3 lifetime parameters: `'b`, `'c`, `'a`
-  --> $DIR/generics-gen-args-errors.rs:88:11
+  --> $DIR/generics-gen-args-errors.rs:86:11
    |
 LL |     trait Trait<'b, 'c, 'a, T, const N: usize>: Sized {
    |           ^^^^^ --  --  --
@@ -659,7 +659,7 @@ LL |     reuse Trait::<Trait, Clone, 'a, _, 'static, dyn Send, _>::foo::<1, 2, 3
    |                               ++++
 
 error[E0107]: trait takes 2 generic arguments but 4 generic arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:131:11
+  --> $DIR/generics-gen-args-errors.rs:129:11
    |
 LL |     reuse Trait::<Trait, Clone, _, 'static, dyn Send, _>::foo::<1, 2, 3, _, 6> as bar7;
    |           ^^^^^               ------------------------- help: remove the unnecessary generic arguments
@@ -667,25 +667,25 @@ LL |     reuse Trait::<Trait, Clone, _, 'static, dyn Send, _>::foo::<1, 2, 3, _,
    |           expected 2 generic arguments
    |
 note: trait defined here, with 2 generic parameters: `T`, `N`
-  --> $DIR/generics-gen-args-errors.rs:88:11
+  --> $DIR/generics-gen-args-errors.rs:86:11
    |
 LL |     trait Trait<'b, 'c, 'a, T, const N: usize>: Sized {
    |           ^^^^^             -  --------------
 
 error: inferred lifetimes are not allowed in delegations as we need to inherit signature
-  --> $DIR/generics-gen-args-errors.rs:131:11
+  --> $DIR/generics-gen-args-errors.rs:129:11
    |
 LL |     reuse Trait::<Trait, Clone, _, 'static, dyn Send, _>::foo::<1, 2, 3, _, 6> as bar7;
    |           ^^^^^
 
 error[E0107]: method takes 1 lifetime argument but 0 lifetime arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:131:59
+  --> $DIR/generics-gen-args-errors.rs:129:59
    |
 LL |     reuse Trait::<Trait, Clone, _, 'static, dyn Send, _>::foo::<1, 2, 3, _, 6> as bar7;
    |                                                           ^^^ expected 1 lifetime argument
    |
 note: method defined here, with 1 lifetime parameter: `'d`
-  --> $DIR/generics-gen-args-errors.rs:89:12
+  --> $DIR/generics-gen-args-errors.rs:87:12
    |
 LL |         fn foo<'d: 'd, U, const M: bool>(self) {}
    |            ^^^ --
@@ -695,7 +695,7 @@ LL |     reuse Trait::<Trait, Clone, _, 'static, dyn Send, _>::foo::<'a, 1, 2, 3
    |                                                                 +++
 
 error[E0107]: method takes 2 generic arguments but 5 generic arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:131:59
+  --> $DIR/generics-gen-args-errors.rs:129:59
    |
 LL |     reuse Trait::<Trait, Clone, _, 'static, dyn Send, _>::foo::<1, 2, 3, _, 6> as bar7;
    |                                                           ^^^       --------- help: remove the unnecessary generic arguments
@@ -703,13 +703,13 @@ LL |     reuse Trait::<Trait, Clone, _, 'static, dyn Send, _>::foo::<1, 2, 3, _,
    |                                                           expected 2 generic arguments
    |
 note: method defined here, with 2 generic parameters: `U`, `M`
-  --> $DIR/generics-gen-args-errors.rs:89:12
+  --> $DIR/generics-gen-args-errors.rs:87:12
    |
 LL |         fn foo<'d: 'd, U, const M: bool>(self) {}
    |            ^^^         -  -------------
 
 error: inferred lifetimes are not allowed in delegations as we need to inherit signature
-  --> $DIR/generics-gen-args-errors.rs:131:59
+  --> $DIR/generics-gen-args-errors.rs:129:59
    |
 LL |     reuse Trait::<Trait, Clone, _, 'static, dyn Send, _>::foo::<1, 2, 3, _, 6> as bar7;
    |                                                           ^^^
@@ -762,35 +762,13 @@ note: function defined here, with 3 generic parameters: `T`, `U`, `N`
 LL |     reuse foo as bar;
    |           ---    ^^^
 
-error[E0747]: unresolved item provided when a constant was expected
-  --> $DIR/generics-gen-args-errors.rs:27:25
-   |
-LL |         bar::<asd, asd, asd>();
-   |                         ^^^
-   |
-help: if this generic argument was intended as a const parameter, surround it with braces
-   |
-LL |         bar::<asd, asd, { asd }>();
-   |                         +     +
-
-error[E0747]: unresolved item provided when a constant was expected
-  --> $DIR/generics-gen-args-errors.rs:33:27
-   |
-LL |         reuse foo::<A, B, C> as xd;
-   |                           ^
-   |
-help: if this generic argument was intended as a const parameter, surround it with braces
-   |
-LL |         reuse foo::<A, B, { C }> as xd;
-   |                           +   +
-
 error[E0747]: constant provided when a type was expected
-  --> $DIR/generics-gen-args-errors.rs:81:17
+  --> $DIR/generics-gen-args-errors.rs:79:17
    |
 LL |     reuse foo::<{}, {}, {}> as bar8;
    |                 ^^
 
-error: aborting due to 74 previous errors
+error: aborting due to 72 previous errors
 
 Some errors have detailed explanations: E0107, E0121, E0261, E0401, E0423, E0425, E0747.
 For more information about an error, try `rustc --explain E0107`.

--- a/tests/ui/missing/missing-items/missing-type-parameter2.rs
+++ b/tests/ui/missing/missing-items/missing-type-parameter2.rs
@@ -2,11 +2,9 @@ struct X<const N: u8>();
 
 impl X<N> {}
 //~^ ERROR cannot find const `N` in this scope
-//~| ERROR unresolved item provided when a constant was expected
 impl<T, const A: u8 = 2> X<N> {}
 //~^ ERROR cannot find const `N` in this scope
 //~| ERROR defaults for generic parameters are not allowed here
-//~| ERROR unresolved item provided when a constant was expected
 
 fn foo(_: T) where T: Send {}
 //~^ ERROR cannot find type `T` in this scope

--- a/tests/ui/missing/missing-items/missing-type-parameter2.stderr
+++ b/tests/ui/missing/missing-items/missing-type-parameter2.stderr
@@ -13,7 +13,7 @@ LL | impl<const N: u8> X<N> {}
    |     +++++++++++++
 
 error[E0425]: cannot find const `N` in this scope
-  --> $DIR/missing-type-parameter2.rs:6:28
+  --> $DIR/missing-type-parameter2.rs:5:28
    |
 LL | struct X<const N: u8>();
    |          ----------- corresponding const parameter on the type defined here
@@ -27,7 +27,7 @@ LL | impl<T, const A: u8 = 2, const N: u8> X<N> {}
    |                        +++++++++++++
 
 error[E0425]: cannot find type `T` in this scope
-  --> $DIR/missing-type-parameter2.rs:11:20
+  --> $DIR/missing-type-parameter2.rs:9:20
    |
 LL | struct X<const N: u8>();
    | ------------------------ similarly named struct `X` defined here
@@ -46,7 +46,7 @@ LL | fn foo<T>(_: T) where T: Send {}
    |       +++
 
 error[E0425]: cannot find type `T` in this scope
-  --> $DIR/missing-type-parameter2.rs:11:11
+  --> $DIR/missing-type-parameter2.rs:9:11
    |
 LL | struct X<const N: u8>();
    | ------------------------ similarly named struct `X` defined here
@@ -65,7 +65,7 @@ LL | fn foo<T>(_: T) where T: Send {}
    |       +++
 
 error[E0425]: cannot find type `A` in this scope
-  --> $DIR/missing-type-parameter2.rs:15:24
+  --> $DIR/missing-type-parameter2.rs:13:24
    |
 LL | struct X<const N: u8>();
    | ------------------------ similarly named struct `X` defined here
@@ -83,35 +83,12 @@ help: you might be missing a type parameter
 LL | fn bar<const N: u8, A>(_: A) {}
    |                   +++
 
-error[E0747]: unresolved item provided when a constant was expected
-  --> $DIR/missing-type-parameter2.rs:3:8
-   |
-LL | impl X<N> {}
-   |        ^
-   |
-help: if this generic argument was intended as a const parameter, surround it with braces
-   |
-LL | impl X<{ N }> {}
-   |        +   +
-
 error: defaults for generic parameters are not allowed here
-  --> $DIR/missing-type-parameter2.rs:6:9
+  --> $DIR/missing-type-parameter2.rs:5:9
    |
 LL | impl<T, const A: u8 = 2> X<N> {}
    |         ^^^^^^^^^^^^^^^
 
-error[E0747]: unresolved item provided when a constant was expected
-  --> $DIR/missing-type-parameter2.rs:6:28
-   |
-LL | impl<T, const A: u8 = 2> X<N> {}
-   |                            ^
-   |
-help: if this generic argument was intended as a const parameter, surround it with braces
-   |
-LL | impl<T, const A: u8 = 2> X<{ N }> {}
-   |                            +   +
+error: aborting due to 6 previous errors
 
-error: aborting due to 8 previous errors
-
-Some errors have detailed explanations: E0425, E0747.
-For more information about an error, try `rustc --explain E0425`.
+For more information about this error, try `rustc --explain E0425`.


### PR DESCRIPTION
Fix rust-lang/rust#149660.