### PR TITLE
Retire `opt_str2` from compiletest cli parsing

### DIFF
--- a/src/tools/compiletest/src/lib.rs
+++ b/src/tools/compiletest/src/lib.rs
@@ -259,6 +259,13 @@ fn parse_config(args: Vec<String>) -> Config {
     let target = matches.opt_str("target").expect("`--target` must be unconditionally specified");
 
     let android_cross_path = matches.opt_str("android-cross-path").map(Utf8PathBuf::from);
+
+    // FIXME: `adb_path` should be an `Option<Utf8PathBuf>`...
+    let adb_path = matches.opt_str("adb-path").map(Utf8PathBuf::from).unwrap_or_default();
+    // FIXME: `adb_test_dir` should be an `Option<Utf8PathBuf>`...
+    let adb_test_dir = matches.opt_str("adb-test-dir").map(Utf8PathBuf::from).unwrap_or_default();
+    let adb_device_status = target.contains("android") && !adb_test_dir.as_str().is_empty();
+
     // FIXME: `cdb_version` is *derived* from cdb, but it's *not* technically a config!
     let cdb = debuggers::discover_cdb(matches.opt_str("cdb"), &target);
     let cdb_version = cdb.as_deref().and_then(debuggers::query_cdb_version);
@@ -445,11 +452,9 @@ fn parse_config(args: Vec<String>) -> Config {
         llvm_version,
         system_llvm: matches.opt_present("system-llvm"),
         android_cross_path,
-        adb_path: Utf8PathBuf::from(opt_str2(matches.opt_str("adb-path"))),
-        adb_test_dir: Utf8PathBuf::from(opt_str2(matches.opt_str("adb-test-dir"))),
-        adb_device_status: opt_str2(matches.opt_str("target")).contains("android")
-            && "(none)" != opt_str2(matches.opt_str("adb-test-dir"))
-            && !opt_str2(matches.opt_str("adb-test-dir")).is_empty(),
+        adb_path,
+        adb_test_dir,
+        adb_device_status,
         verbose: matches.opt_present("verbose"),
         only_modified: matches.opt_present("only-modified"),
         color,

--- a/src/tools/compiletest/src/lib.rs
+++ b/src/tools/compiletest/src/lib.rs
@@ -255,7 +255,9 @@ fn parse_config(args: Vec<String>) -> Config {
         }
     }
 
-    let target = opt_str2(matches.opt_str("target"));
+    let host = matches.opt_str("host").expect("`--host` must be unconditionally specified");
+    let target = matches.opt_str("target").expect("`--target` must be unconditionally specified");
+
     let android_cross_path = matches.opt_str("android-cross-path").map(Utf8PathBuf::from);
     // FIXME: `cdb_version` is *derived* from cdb, but it's *not* technically a config!
     let cdb = debuggers::discover_cdb(matches.opt_str("cdb"), &target);
@@ -433,7 +435,7 @@ fn parse_config(args: Vec<String>) -> Config {
         optimize_tests: matches.opt_present("optimize-tests"),
         rust_randomized_layout: matches.opt_present("rust-randomized-layout"),
         target,
-        host: opt_str2(matches.opt_str("host")),
+        host,
         cdb,
         cdb_version,
         gdb,

--- a/src/tools/compiletest/src/lib.rs
+++ b/src/tools/compiletest/src/lib.rs
@@ -500,13 +500,6 @@ fn parse_config(args: Vec<String>) -> Config {
     }
 }
 
-fn opt_str2(maybestr: Option<String>) -> String {
-    match maybestr {
-        None => "(none)".to_owned(),
-        Some(s) => s,
-    }
-}
-
 /// Called by `main` after the config has been parsed.
 fn run_tests(config: Arc<Config>) {
     debug!(?config, "run_tests");


### PR DESCRIPTION
We have `Option<..>`, we don't need to invent "(none)" as option-at-home.

- More specifically, when some test suite expect certain values to be present, they should `.expect(..)` the value, and not potentially receive some "(none)" in some cases.

r? Zalathar