### PR TITLE
Add inline attribute to generated delegation function if needed

### DIFF
--- a/tests/pretty/delegation_inline_attribute.pp
+++ b/tests/pretty/delegation_inline_attribute.pp
@@ -1,0 +1,94 @@
+//@ pretty-compare-only
+//@ pretty-mode:hir
+//@ pp-exact:delegation_inline_attribute.pp
+
+#![allow(incomplete_features)]
+#![feature(fn_delegation)]
+#[attr = MacroUse {arguments: UseAll}]
+extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
+
+mod to_reuse {
+    fn foo(x: usize) -> usize { x }
+}
+
+// Check that #[inline(hint)] is added to foo reuse
+#[attr = Inline(Hint)]
+fn bar(arg0: _) -> _ { to_reuse::foo(self + 1) }
+
+trait Trait {
+    fn foo(&self) { }
+    fn foo1(&self) { }
+    fn foo2(&self) { }
+    fn foo3(&self) { }
+    fn foo4(&self) { }
+}
+
+impl Trait for u8 { }
+
+struct S(u8);
+
+mod to_import {
+    fn check(arg: &'_ u8) -> &'_ u8 { arg }
+}
+
+impl Trait for S {
+    // Check that #[inline(hint)] is added to foo reuse
+    #[attr = Inline(Hint)]
+    fn foo(self: _)
+        ->
+            _ {
+        {
+                // Check that #[inline(hint)] is added to foo0 reuse inside another reuse
+                #[attr = Inline(Hint)]
+                fn foo0(arg0: _) -> _ { to_reuse::foo(self + 1) }
+
+                // Check that #[inline(hint)] is added when other attributes present in inner reuse
+                #[attr = Deprecation {deprecation: Deprecation {since: Unspecified}}]
+                #[attr = MustUse]
+                #[attr = Cold]
+                #[attr = Inline(Hint)]
+                fn foo1(arg0: _) -> _ { to_reuse::foo(self / 2) }
+
+                // Check that #[inline(never)] is preserved in inner reuse
+                #[attr = Inline(Never)]
+                fn foo2(arg0: _) -> _ { to_reuse::foo(self / 2) }
+
+                // Check that #[inline(always)] is preserved in inner reuse
+                #[attr = Inline(Always)]
+                fn foo3(arg0: _) -> _ { to_reuse::foo(self / 2) }
+
+                // Check that #[inline(never)] is preserved when there are other attributes in inner reuse
+                #[attr = Deprecation {deprecation: Deprecation {since: Unspecified}}]
+                #[attr = Inline(Never)]
+                #[attr = MustUse]
+                #[attr = Cold]
+                fn foo4(arg0: _) -> _ { to_reuse::foo(self / 2) }
+            }.foo()
+    }
+
+    // Check that #[inline(hint)] is added when there are other attributes present in trait reuse
+    #[attr = Deprecation {deprecation: Deprecation {since: Unspecified}}]
+    #[attr = MustUse]
+    #[attr = Cold]
+    #[attr = Inline(Hint)]
+    fn foo1(self: _) -> _ { self.0.foo1() }
+
+    // Check that #[inline(never)] is preserved in trait reuse
+    #[attr = Inline(Never)]
+    fn foo2(self: _) -> _ { self.0.foo2() }
+
+    // Check that #[inline(always)] is preserved in trait reuse
+    #[attr = Inline(Always)]
+    fn foo3(self: _) -> _ { self.0.foo3() }
+
+    // Check that #[inline(never)] is preserved when there are other attributes in trait reuse
+    #[attr = Deprecation {deprecation: Deprecation {since: Unspecified}}]
+    #[attr = Inline(Never)]
+    #[attr = MustUse]
+    #[attr = Cold]
+    fn foo4(self: _) -> _ { self.0.foo4() }
+}
+
+fn main() { }

--- a/tests/pretty/delegation_inline_attribute.rs
+++ b/tests/pretty/delegation_inline_attribute.rs
@@ -1,0 +1,104 @@
+//@ pretty-compare-only
+//@ pretty-mode:hir
+//@ pp-exact:delegation_inline_attribute.pp
+
+#![allow(incomplete_features)]
+#![feature(fn_delegation)]
+
+mod to_reuse {
+    pub fn foo(x: usize) -> usize {
+        x
+    }
+}
+
+// Check that #[inline(hint)] is added to foo reuse
+reuse to_reuse::foo as bar {
+    self + 1
+}
+
+trait Trait {
+    fn foo(&self) {}
+    fn foo1(&self) {}
+    fn foo2(&self) {}
+    fn foo3(&self) {}
+    fn foo4(&self) {}
+}
+
+impl Trait for u8 {}
+
+struct S(u8);
+
+mod to_import {
+    pub fn check(arg: &u8) -> &u8 { arg }
+}
+
+impl Trait for S {
+    // Check that #[inline(hint)] is added to foo reuse
+    reuse Trait::foo {
+        // Check that #[inline(hint)] is added to foo0 reuse inside another reuse
+        reuse to_reuse::foo as foo0 {
+            self + 1
+        }
+
+        // Check that #[inline(hint)] is added when other attributes present in inner reuse
+        #[cold]
+        #[must_use]
+        #[deprecated]
+        reuse to_reuse::foo as foo1 {
+            self / 2
+        }
+
+        // Check that #[inline(never)] is preserved in inner reuse
+        #[inline(never)]
+        reuse to_reuse::foo as foo2 {
+            self / 2
+        }
+
+        // Check that #[inline(always)] is preserved in inner reuse
+        #[inline(always)]
+        reuse to_reuse::foo as foo3 {
+            self / 2
+        }
+
+        // Check that #[inline(never)] is preserved when there are other attributes in inner reuse
+        #[cold]
+        #[must_use]
+        #[inline(never)]
+        #[deprecated]
+        reuse to_reuse::foo as foo4 {
+            self / 2
+        }
+    }
+
+    // Check that #[inline(hint)] is added when there are other attributes present in trait reuse
+    #[cold]
+    #[must_use]
+    #[deprecated]
+    reuse Trait::foo1 {
+        self.0
+    }
+
+    // Check that #[inline(never)] is preserved in trait reuse
+    #[inline(never)]
+    reuse Trait::foo2 {
+        self.0
+    }
+
+    // Check that #[inline(always)] is preserved in trait reuse
+    #[inline(always)]
+    reuse Trait::foo3 {
+        self.0
+    }
+
+    // Check that #[inline(never)] is preserved when there are other attributes in trait reuse
+    #[cold]
+    #[must_use]
+    #[inline(never)]
+    #[deprecated]
+    reuse Trait::foo4 {
+        self.0
+    }
+}
+
+fn main() {
+}

--- a/tests/pretty/hir-delegation.pp
+++ b/tests/pretty/hir-delegation.pp
@@ -12,6 +12,7 @@ use ::std::prelude::rust_2015::*;
 fn b<C>(e: C) { }
 
 trait G {
+    #[attr = Inline(Hint)]
     fn b(arg0: _) -> _ { b({ }) }
 }
 
@@ -19,6 +20,7 @@ mod m {
     fn add(a: u32, b: u32) -> u32 { a + b }
 }
 
+#[attr = Inline(Hint)]
 fn add(arg0: _, arg1: _) -> _ { m::add(arg0, arg1) }
 
 fn main() { { let _ = add(1, 2); }; }


### PR DESCRIPTION
This PR adds a functionality to add #[inline(always)] attribute to generated functions from delegation, if some #[inline(..)] attribute is already specified on the delegation then we do nothing. This PR is a part of the delegation feature rust-lang/rust#118212 and addresses `Add implicit #[inline] unless specified otherwise` item.

r? @petrochenkov