### PR TITLE
Make `--print=backend-has-zstd` work by default on any backend

### DIFF
--- a/compiler/rustc_codegen_cranelift/src/lib.rs
+++ b/compiler/rustc_codegen_cranelift/src/lib.rs
@@ -47,7 +47,7 @@ use rustc_codegen_ssa::{CodegenResults, TargetConfig};
 use rustc_log::tracing::info;
 use rustc_middle::dep_graph::{WorkProduct, WorkProductId};
 use rustc_session::Session;
-use rustc_session::config::{OutputFilenames, PrintKind, PrintRequest};
+use rustc_session::config::OutputFilenames;
 use rustc_span::{Symbol, sym};
 use rustc_target::spec::{Abi, Arch, Env, Os};
 
@@ -157,16 +157,6 @@ impl CodegenBackend for CraneliftCodegenBackend {
 
         if config.jit_mode && !sess.opts.output_types.should_codegen() {
             sess.dcx().fatal("JIT mode doesn't work with `cargo check`");
-        }
-    }
-
-    fn print(&self, req: &PrintRequest, out: &mut String, _sess: &Session) {
-        match req.kind {
-            // FIXME have a default impl that returns false
-            PrintKind::BackendHasZstd => {
-                out.push_str("false\n");
-            }
-            _ => {}
         }
     }
 

--- a/compiler/rustc_codegen_llvm/src/lib.rs
+++ b/compiler/rustc_codegen_llvm/src/lib.rs
@@ -257,10 +257,6 @@ impl CodegenBackend for LlvmCodegenBackend {
                 }
                 writeln!(out).unwrap();
             }
-            PrintKind::BackendHasZstd => {
-                let has_zstd = llvm::LLVMRustLLVMHasZstdCompression();
-                writeln!(out, "{has_zstd}").unwrap();
-            }
             PrintKind::CodeModels => {
                 writeln!(out, "Available code models:").unwrap();
                 for name in &["tiny", "small", "kernel", "medium", "large"] {
@@ -312,6 +308,10 @@ impl CodegenBackend for LlvmCodegenBackend {
 
     fn print_version(&self) {
         llvm_util::print_version();
+    }
+
+    fn has_zstd(&self) -> bool {
+        llvm::LLVMRustLLVMHasZstdCompression()
     }
 
     fn target_config(&self, sess: &Session) -> TargetConfig {

--- a/compiler/rustc_codegen_ssa/src/traits/backend.rs
+++ b/compiler/rustc_codegen_ssa/src/traits/backend.rs
@@ -78,6 +78,14 @@ pub trait CodegenBackend {
 
     fn print_version(&self) {}
 
+    /// Value printed by `--print=backend-has-zstd`.
+    ///
+    /// Used by compiletest to determine whether tests involving zstd compression
+    /// (e.g. `-Zdebuginfo-compression=zstd`) should be executed or skipped.
+    fn has_zstd(&self) -> bool {
+        false
+    }
+
     /// The metadata loader used to load rlib and dylib metadata.
     ///
     /// Alternative codegen backends may want to use different rlib or dylib formats than the

--- a/compiler/rustc_driver_impl/src/lib.rs
+++ b/compiler/rustc_driver_impl/src/lib.rs
@@ -798,8 +798,11 @@ fn print_crate_info(
                 let calling_conventions = rustc_abi::all_names();
                 println_info!("{}", calling_conventions.join("\n"));
             }
+            BackendHasZstd => {
+                let has_zstd: bool = codegen_backend.has_zstd();
+                println_info!("{has_zstd}");
+            }
             RelocationModels
-            | BackendHasZstd
             | CodeModels
             | TlsModels
             | TargetCPUs

--- a/src/tools/compiletest/src/directives/needs.rs
+++ b/src/tools/compiletest/src/directives/needs.rs
@@ -432,6 +432,10 @@ fn has_symlinks() -> bool {
 }
 
 fn llvm_has_zstd(config: &Config) -> bool {
+    // FIXME(#149764): This actually queries the compiler's _default_ backend,
+    // which is usually LLVM, but can be another backend depending on the value
+    // of `rust.codegen-backends` in bootstrap.toml.
+
     // The compiler already knows whether LLVM was built with zstd or not,
     // so compiletest can just ask the compiler.
     let output = query_rustc_output(


### PR DESCRIPTION
Using a defaulted `CodegenBackend` method that querying for zstd support should automatically print a safe value of `false` on any backend that doesn't specifically indicate the presence or absence of zstd.

This should fix the compiletest failures reported in https://github.com/rust-lang/rust/pull/149666#discussion_r2597881482, which can occur when LLVM is not the default codegen backend.