### PR TITLE
Remove `[no-mentions]` handler in the triagebot config

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1680,12 +1680,6 @@ days-threshold = 28
 # Documentation at: https://forge.rust-lang.org/triagebot/issue-links.html
 [issue-links]
 
-# Prevents mentions in commits to avoid users being spammed
-# Documentation at: https://forge.rust-lang.org/triagebot/no-mentions.html
-[no-mentions]
-# Subtree update authors can't fix it, no point in warning.
-exclude-titles = ["subtree update"]
-
 # Allow members to formally register concerns (`@rustbot concern my concern`)
 # Documentation at: https://forge.rust-lang.org/triagebot/concern.html
 [concern]


### PR DESCRIPTION
This PR removes the `[no-mentions]` handler in the triagebot config as [GitHub is removing notifications for @-mentions in commit messages on December 8th 2025.](https://github.blog/changelog/2025-11-07-removing-notifications-for-mentions-in-commit-messages/)

cf. https://github.com/rust-lang/triagebot/issues/2225