### PR TITLE
Cleanup in the attribute parsers

### DIFF
--- a/compiler/rustc_attr_parsing/src/attributes/allow_unstable.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/allow_unstable.rs
@@ -19,7 +19,7 @@ impl<S: Stage> CombineAttributeParser<S> for AllowInternalUnstableParser {
 
     fn extend<'c>(
         cx: &'c mut AcceptContext<'_, '_, S>,
-        args: &'c ArgParser<'_>,
+        args: &'c ArgParser,
     ) -> impl IntoIterator<Item = Self::Item> {
         parse_unstable(cx, args, <Self as CombineAttributeParser<S>>::PATH[0])
             .into_iter()
@@ -41,7 +41,7 @@ impl<S: Stage> CombineAttributeParser<S> for UnstableFeatureBoundParser {
 
     fn extend<'c>(
         cx: &'c mut AcceptContext<'_, '_, S>,
-        args: &'c ArgParser<'_>,
+        args: &'c ArgParser,
     ) -> impl IntoIterator<Item = Self::Item> {
         if !cx.features().staged_api() {
             cx.emit_err(session_diagnostics::StabilityOutsideStd { span: cx.attr_span });
@@ -69,7 +69,7 @@ impl<S: Stage> CombineAttributeParser<S> for AllowConstFnUnstableParser {
 
     fn extend<'c>(
         cx: &'c mut AcceptContext<'_, '_, S>,
-        args: &'c ArgParser<'_>,
+        args: &'c ArgParser,
     ) -> impl IntoIterator<Item = Self::Item> + 'c {
         parse_unstable(cx, args, <Self as CombineAttributeParser<S>>::PATH[0])
     }
@@ -77,7 +77,7 @@ impl<S: Stage> CombineAttributeParser<S> for AllowConstFnUnstableParser {
 
 fn parse_unstable<S: Stage>(
     cx: &AcceptContext<'_, '_, S>,
-    args: &ArgParser<'_>,
+    args: &ArgParser,
     symbol: Symbol,
 ) -> impl IntoIterator<Item = Symbol> {
     let mut res = Vec::new();

--- a/compiler/rustc_attr_parsing/src/attributes/allow_unstable.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/allow_unstable.rs
@@ -17,9 +17,9 @@ impl<S: Stage> CombineAttributeParser<S> for AllowInternalUnstableParser {
     ]);
     const TEMPLATE: AttributeTemplate = template!(Word, List: &["feat1, feat2, ..."]);
 
-    fn extend<'c>(
-        cx: &'c mut AcceptContext<'_, '_, S>,
-        args: &'c ArgParser,
+    fn extend(
+        cx: &mut AcceptContext<'_, '_, S>,
+        args: &ArgParser,
     ) -> impl IntoIterator<Item = Self::Item> {
         parse_unstable(cx, args, <Self as CombineAttributeParser<S>>::PATH[0])
             .into_iter()
@@ -39,9 +39,9 @@ impl<S: Stage> CombineAttributeParser<S> for UnstableFeatureBoundParser {
     ]);
     const TEMPLATE: AttributeTemplate = template!(Word, List: &["feat1, feat2, ..."]);
 
-    fn extend<'c>(
-        cx: &'c mut AcceptContext<'_, '_, S>,
-        args: &'c ArgParser,
+    fn extend(
+        cx: &mut AcceptContext<'_, '_, S>,
+        args: &ArgParser,
     ) -> impl IntoIterator<Item = Self::Item> {
         if !cx.features().staged_api() {
             cx.emit_err(session_diagnostics::StabilityOutsideStd { span: cx.attr_span });
@@ -67,10 +67,10 @@ impl<S: Stage> CombineAttributeParser<S> for AllowConstFnUnstableParser {
     ]);
     const TEMPLATE: AttributeTemplate = template!(Word, List: &["feat1, feat2, ..."]);
 
-    fn extend<'c>(
-        cx: &'c mut AcceptContext<'_, '_, S>,
-        args: &'c ArgParser,
-    ) -> impl IntoIterator<Item = Self::Item> + 'c {
+    fn extend(
+        cx: &mut AcceptContext<'_, '_, S>,
+        args: &ArgParser,
+    ) -> impl IntoIterator<Item = Self::Item> {
         parse_unstable(cx, args, <Self as CombineAttributeParser<S>>::PATH[0])
     }
 }

--- a/compiler/rustc_attr_parsing/src/attributes/cfg.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/cfg.rs
@@ -37,7 +37,7 @@ const CFG_ATTR_TEMPLATE: AttributeTemplate = template!(
 
 pub fn parse_cfg<'c, S: Stage>(
     cx: &'c mut AcceptContext<'_, '_, S>,
-    args: &'c ArgParser<'_>,
+    args: &'c ArgParser,
 ) -> Option<CfgEntry> {
     let ArgParser::List(list) = args else {
         cx.expected_list(cx.attr_span);
@@ -52,7 +52,7 @@ pub fn parse_cfg<'c, S: Stage>(
 
 pub fn parse_cfg_entry<S: Stage>(
     cx: &mut AcceptContext<'_, '_, S>,
-    item: &MetaItemOrLitParser<'_>,
+    item: &MetaItemOrLitParser,
 ) -> Result<CfgEntry, ErrorGuaranteed> {
     Ok(match item {
         MetaItemOrLitParser::MetaItemParser(meta) => match meta.args() {
@@ -98,7 +98,7 @@ pub fn parse_cfg_entry<S: Stage>(
 
 fn parse_cfg_entry_version<S: Stage>(
     cx: &mut AcceptContext<'_, '_, S>,
-    list: &MetaItemListParser<'_>,
+    list: &MetaItemListParser,
     meta_span: Span,
 ) -> Result<CfgEntry, ErrorGuaranteed> {
     try_gate_cfg(sym::version, meta_span, cx.sess(), cx.features_option());
@@ -130,7 +130,7 @@ fn parse_cfg_entry_version<S: Stage>(
 
 fn parse_cfg_entry_target<S: Stage>(
     cx: &mut AcceptContext<'_, '_, S>,
-    list: &MetaItemListParser<'_>,
+    list: &MetaItemListParser,
     meta_span: Span,
 ) -> Result<CfgEntry, ErrorGuaranteed> {
     if let Some(features) = cx.features_option()

--- a/compiler/rustc_attr_parsing/src/attributes/cfg.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/cfg.rs
@@ -35,9 +35,9 @@ const CFG_ATTR_TEMPLATE: AttributeTemplate = template!(
     "https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute"
 );
 
-pub fn parse_cfg<'c, S: Stage>(
-    cx: &'c mut AcceptContext<'_, '_, S>,
-    args: &'c ArgParser,
+pub fn parse_cfg<S: Stage>(
+    cx: &mut AcceptContext<'_, '_, S>,
+    args: &ArgParser,
 ) -> Option<CfgEntry> {
     let ArgParser::List(list) = args else {
         cx.expected_list(cx.attr_span);

--- a/compiler/rustc_attr_parsing/src/attributes/codegen_attrs.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/codegen_attrs.rs
@@ -23,7 +23,7 @@ impl<S: Stage> SingleAttributeParser<S> for OptimizeParser {
     ]);
     const TEMPLATE: AttributeTemplate = template!(List: &["size", "speed", "none"]);
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser<'_>) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
         let Some(list) = args.list() else {
             cx.expected_list(cx.attr_span);
             return None;
@@ -84,7 +84,7 @@ impl<S: Stage> SingleAttributeParser<S> for CoverageParser {
     ]);
     const TEMPLATE: AttributeTemplate = template!(OneOf: &[sym::off, sym::on]);
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser<'_>) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
         let Some(args) = args.list() else {
             cx.expected_specific_argument_and_list(cx.attr_span, &[sym::on, sym::off]);
             return None;
@@ -135,7 +135,7 @@ impl<S: Stage> SingleAttributeParser<S> for ExportNameParser {
     ]);
     const TEMPLATE: AttributeTemplate = template!(NameValueStr: "name");
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser<'_>) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
         let Some(nv) = args.name_value() else {
             cx.expected_name_value(cx.attr_span, None);
             return None;
@@ -164,7 +164,7 @@ impl<S: Stage> SingleAttributeParser<S> for ObjcClassParser {
         AllowedTargets::AllowList(&[Allow(Target::ForeignStatic)]);
     const TEMPLATE: AttributeTemplate = template!(NameValueStr: "ClassName");
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser<'_>) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
         let Some(nv) = args.name_value() else {
             cx.expected_name_value(cx.attr_span, None);
             return None;
@@ -196,7 +196,7 @@ impl<S: Stage> SingleAttributeParser<S> for ObjcSelectorParser {
         AllowedTargets::AllowList(&[Allow(Target::ForeignStatic)]);
     const TEMPLATE: AttributeTemplate = template!(NameValueStr: "methodName");
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser<'_>) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
         let Some(nv) = args.name_value() else {
             cx.expected_name_value(cx.attr_span, None);
             return None;
@@ -474,7 +474,7 @@ impl<S: Stage> AttributeParser<S> for UsedParser {
 
 fn parse_tf_attribute<'c, S: Stage>(
     cx: &'c mut AcceptContext<'_, '_, S>,
-    args: &'c ArgParser<'_>,
+    args: &'c ArgParser,
 ) -> impl IntoIterator<Item = (Symbol, Span)> + 'c {
     let mut features = Vec::new();
     let ArgParser::List(list) = args else {
@@ -531,7 +531,7 @@ impl<S: Stage> CombineAttributeParser<S> for TargetFeatureParser {
 
     fn extend<'c>(
         cx: &'c mut AcceptContext<'_, '_, S>,
-        args: &'c ArgParser<'_>,
+        args: &'c ArgParser,
     ) -> impl IntoIterator<Item = Self::Item> + 'c {
         parse_tf_attribute(cx, args)
     }
@@ -569,7 +569,7 @@ impl<S: Stage> CombineAttributeParser<S> for ForceTargetFeatureParser {
 
     fn extend<'c>(
         cx: &'c mut AcceptContext<'_, '_, S>,
-        args: &'c ArgParser<'_>,
+        args: &'c ArgParser,
     ) -> impl IntoIterator<Item = Self::Item> + 'c {
         parse_tf_attribute(cx, args)
     }
@@ -599,7 +599,7 @@ impl<S: Stage> SingleAttributeParser<S> for SanitizeParser {
     const ATTRIBUTE_ORDER: AttributeOrder = AttributeOrder::KeepOutermost;
     const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Error;
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser<'_>) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
         let Some(list) = args.list() else {
             cx.expected_list(cx.attr_span);
             return None;

--- a/compiler/rustc_attr_parsing/src/attributes/codegen_attrs.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/codegen_attrs.rs
@@ -472,10 +472,10 @@ impl<S: Stage> AttributeParser<S> for UsedParser {
     }
 }
 
-fn parse_tf_attribute<'c, S: Stage>(
-    cx: &'c mut AcceptContext<'_, '_, S>,
-    args: &'c ArgParser,
-) -> impl IntoIterator<Item = (Symbol, Span)> + 'c {
+fn parse_tf_attribute<S: Stage>(
+    cx: &mut AcceptContext<'_, '_, S>,
+    args: &ArgParser,
+) -> impl IntoIterator<Item = (Symbol, Span)> {
     let mut features = Vec::new();
     let ArgParser::List(list) = args else {
         cx.expected_list(cx.attr_span);
@@ -529,10 +529,10 @@ impl<S: Stage> CombineAttributeParser<S> for TargetFeatureParser {
     };
     const TEMPLATE: AttributeTemplate = template!(List: &["enable = \"feat1, feat2\""]);
 
-    fn extend<'c>(
-        cx: &'c mut AcceptContext<'_, '_, S>,
-        args: &'c ArgParser,
-    ) -> impl IntoIterator<Item = Self::Item> + 'c {
+    fn extend(
+        cx: &mut AcceptContext<'_, '_, S>,
+        args: &ArgParser,
+    ) -> impl IntoIterator<Item = Self::Item> {
         parse_tf_attribute(cx, args)
     }
 
@@ -567,10 +567,10 @@ impl<S: Stage> CombineAttributeParser<S> for ForceTargetFeatureParser {
         Allow(Target::Method(MethodKind::TraitImpl)),
     ]);
 
-    fn extend<'c>(
-        cx: &'c mut AcceptContext<'_, '_, S>,
-        args: &'c ArgParser,
-    ) -> impl IntoIterator<Item = Self::Item> + 'c {
+    fn extend(
+        cx: &mut AcceptContext<'_, '_, S>,
+        args: &ArgParser,
+    ) -> impl IntoIterator<Item = Self::Item> {
         parse_tf_attribute(cx, args)
     }
 }

--- a/compiler/rustc_attr_parsing/src/attributes/crate_level.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/crate_level.rs
@@ -11,7 +11,7 @@ impl<S: Stage> SingleAttributeParser<S> for CrateNameParser {
     const TEMPLATE: AttributeTemplate = template!(NameValueStr: "name");
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::CrateLevel;
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser<'_>) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
         let ArgParser::NameValue(n) = args else {
             cx.expected_name_value(cx.attr_span, None);
             return None;
@@ -35,7 +35,7 @@ impl<S: Stage> SingleAttributeParser<S> for RecursionLimitParser {
     const TEMPLATE: AttributeTemplate = template!(NameValueStr: "N", "https://doc.rust-lang.org/reference/attributes/limits.html#the-recursion_limit-attribute");
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::CrateLevel;
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser<'_>) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
         let ArgParser::NameValue(nv) = args else {
             cx.expected_name_value(cx.attr_span, None);
             return None;
@@ -58,7 +58,7 @@ impl<S: Stage> SingleAttributeParser<S> for MoveSizeLimitParser {
     const TEMPLATE: AttributeTemplate = template!(NameValueStr: "N");
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::CrateLevel;
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser<'_>) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
         let ArgParser::NameValue(nv) = args else {
             cx.expected_name_value(cx.attr_span, None);
             return None;
@@ -81,7 +81,7 @@ impl<S: Stage> SingleAttributeParser<S> for TypeLengthLimitParser {
     const TEMPLATE: AttributeTemplate = template!(NameValueStr: "N");
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::CrateLevel;
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser<'_>) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
         let ArgParser::NameValue(nv) = args else {
             cx.expected_name_value(cx.attr_span, None);
             return None;
@@ -104,7 +104,7 @@ impl<S: Stage> SingleAttributeParser<S> for PatternComplexityLimitParser {
     const TEMPLATE: AttributeTemplate = template!(NameValueStr: "N");
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::CrateLevel;
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser<'_>) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
         let ArgParser::NameValue(nv) = args else {
             cx.expected_name_value(cx.attr_span, None);
             return None;
@@ -154,7 +154,7 @@ impl<S: Stage> SingleAttributeParser<S> for WindowsSubsystemParser {
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::CrateLevel;
     const TEMPLATE: AttributeTemplate = template!(NameValueStr: ["windows", "console"], "https://doc.rust-lang.org/reference/runtime.html#the-windows_subsystem-attribute");
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser<'_>) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
         let Some(nv) = args.name_value() else {
             cx.expected_name_value(
                 args.span().unwrap_or(cx.inner_span),

--- a/compiler/rustc_attr_parsing/src/attributes/debugger.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/debugger.rs
@@ -16,10 +16,10 @@ impl<S: Stage> CombineAttributeParser<S> for DebuggerViualizerParser {
     type Item = DebugVisualizer;
     const CONVERT: ConvertFn<Self::Item> = |v, _| AttributeKind::DebuggerVisualizer(v);
 
-    fn extend<'c>(
-        cx: &'c mut AcceptContext<'_, '_, S>,
-        args: &'c ArgParser,
-    ) -> impl IntoIterator<Item = Self::Item> + 'c {
+    fn extend(
+        cx: &mut AcceptContext<'_, '_, S>,
+        args: &ArgParser,
+    ) -> impl IntoIterator<Item = Self::Item> {
         let Some(l) = args.list() else {
             cx.expected_list(args.span().unwrap_or(cx.attr_span));
             return None;

--- a/compiler/rustc_attr_parsing/src/attributes/debugger.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/debugger.rs
@@ -18,7 +18,7 @@ impl<S: Stage> CombineAttributeParser<S> for DebuggerViualizerParser {
 
     fn extend<'c>(
         cx: &'c mut AcceptContext<'_, '_, S>,
-        args: &'c ArgParser<'_>,
+        args: &'c ArgParser,
     ) -> impl IntoIterator<Item = Self::Item> + 'c {
         let Some(l) = args.list() else {
             cx.expected_list(args.span().unwrap_or(cx.attr_span));

--- a/compiler/rustc_attr_parsing/src/attributes/deprecation.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/deprecation.rs
@@ -12,7 +12,7 @@ fn get<S: Stage>(
     cx: &AcceptContext<'_, '_, S>,
     name: Symbol,
     param_span: Span,
-    arg: &ArgParser<'_>,
+    arg: &ArgParser,
     item: &Option<Symbol>,
 ) -> Option<Symbol> {
     if item.is_some() {
@@ -68,7 +68,7 @@ impl<S: Stage> SingleAttributeParser<S> for DeprecationParser {
         NameValueStr: "reason"
     );
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser<'_>) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
         let features = cx.features();
 
         let mut since = None;

--- a/compiler/rustc_attr_parsing/src/attributes/doc.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/doc.rs
@@ -10,7 +10,7 @@ use thin_vec::ThinVec;
 use super::prelude::{ALL_TARGETS, AllowedTargets};
 use super::{AcceptMapping, AttributeParser};
 use crate::context::{AcceptContext, FinalizeContext, Stage};
-use crate::parser::{ArgParser, MetaItemOrLitParser, MetaItemParser, PathParser};
+use crate::parser::{ArgParser, MetaItemOrLitParser, MetaItemParser, OwnedPathParser};
 use crate::session_diagnostics::{
     DocAliasBadChar, DocAliasEmpty, DocAliasMalformed, DocAliasStartEnd, DocAttributeNotAttribute,
     DocKeywordNotKeyword,
@@ -43,10 +43,10 @@ fn check_attribute<S: Stage>(
     false
 }
 
-fn parse_keyword_and_attribute<'c, S, F>(
-    cx: &'c mut AcceptContext<'_, '_, S>,
-    path: &PathParser<'_>,
-    args: &ArgParser<'_>,
+fn parse_keyword_and_attribute<S, F>(
+    cx: &mut AcceptContext<'_, '_, S>,
+    path: &OwnedPathParser,
+    args: &ArgParser,
     attr_value: &mut Option<(Symbol, Span)>,
     callback: F,
 ) where
@@ -82,10 +82,10 @@ pub(crate) struct DocParser {
 }
 
 impl DocParser {
-    fn parse_single_test_doc_attr_item<'c, S: Stage>(
+    fn parse_single_test_doc_attr_item<S: Stage>(
         &mut self,
-        cx: &'c mut AcceptContext<'_, '_, S>,
-        mip: &'c MetaItemParser<'_>,
+        cx: &mut AcceptContext<'_, '_, S>,
+        mip: &MetaItemParser,
     ) {
         let path = mip.path();
         let args = mip.args();
@@ -132,9 +132,9 @@ impl DocParser {
         }
     }
 
-    fn add_alias<'c, S: Stage>(
+    fn add_alias<S: Stage>(
         &mut self,
-        cx: &'c mut AcceptContext<'_, '_, S>,
+        cx: &mut AcceptContext<'_, '_, S>,
         alias: Symbol,
         span: Span,
     ) {
@@ -167,11 +167,11 @@ impl DocParser {
         self.attribute.aliases.insert(alias, span);
     }
 
-    fn parse_alias<'c, S: Stage>(
+    fn parse_alias<S: Stage>(
         &mut self,
-        cx: &'c mut AcceptContext<'_, '_, S>,
-        path: &PathParser<'_>,
-        args: &ArgParser<'_>,
+        cx: &mut AcceptContext<'_, '_, S>,
+        path: &OwnedPathParser,
+        args: &ArgParser,
     ) {
         match args {
             ArgParser::NoArgs => {
@@ -197,11 +197,11 @@ impl DocParser {
         }
     }
 
-    fn parse_inline<'c, S: Stage>(
+    fn parse_inline<S: Stage>(
         &mut self,
-        cx: &'c mut AcceptContext<'_, '_, S>,
-        path: &PathParser<'_>,
-        args: &ArgParser<'_>,
+        cx: &mut AcceptContext<'_, '_, S>,
+        path: &OwnedPathParser,
+        args: &ArgParser,
         inline: DocInline,
     ) {
         if let Err(span) = args.no_args() {
@@ -212,11 +212,7 @@ impl DocParser {
         self.attribute.inline.push((inline, path.span()));
     }
 
-    fn parse_cfg<'c, S: Stage>(
-        &mut self,
-        cx: &'c mut AcceptContext<'_, '_, S>,
-        args: &ArgParser<'_>,
-    ) {
+    fn parse_cfg<S: Stage>(&mut self, cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) {
         // This function replaces cases like `cfg(all())` with `true`.
         fn simplify_cfg(cfg_entry: &mut CfgEntry) {
             match cfg_entry {
@@ -236,11 +232,11 @@ impl DocParser {
         }
     }
 
-    fn parse_auto_cfg<'c, S: Stage>(
+    fn parse_auto_cfg<S: Stage>(
         &mut self,
-        cx: &'c mut AcceptContext<'_, '_, S>,
-        path: &PathParser<'_>,
-        args: &ArgParser<'_>,
+        cx: &mut AcceptContext<'_, '_, S>,
+        path: &OwnedPathParser,
+        args: &ArgParser,
     ) {
         match args {
             ArgParser::NoArgs => {
@@ -343,10 +339,10 @@ impl DocParser {
         }
     }
 
-    fn parse_single_doc_attr_item<'c, S: Stage>(
+    fn parse_single_doc_attr_item<S: Stage>(
         &mut self,
-        cx: &'c mut AcceptContext<'_, '_, S>,
-        mip: &MetaItemParser<'_>,
+        cx: &mut AcceptContext<'_, '_, S>,
+        mip: &MetaItemParser,
     ) {
         let path = mip.path();
         let args = mip.args();
@@ -506,10 +502,10 @@ impl DocParser {
         }
     }
 
-    fn accept_single_doc_attr<'c, S: Stage>(
+    fn accept_single_doc_attr<S: Stage>(
         &mut self,
-        cx: &'c mut AcceptContext<'_, '_, S>,
-        args: &'c ArgParser<'_>,
+        cx: &mut AcceptContext<'_, '_, S>,
+        args: &ArgParser,
     ) {
         match args {
             ArgParser::NoArgs => {

--- a/compiler/rustc_attr_parsing/src/attributes/dummy.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/dummy.rs
@@ -15,7 +15,7 @@ impl<S: Stage> SingleAttributeParser<S> for DummyParser {
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(ALL_TARGETS);
     const TEMPLATE: AttributeTemplate = template!(Word); // Anything, really
 
-    fn convert(_: &mut AcceptContext<'_, '_, S>, _: &ArgParser<'_>) -> Option<AttributeKind> {
+    fn convert(_: &mut AcceptContext<'_, '_, S>, _: &ArgParser) -> Option<AttributeKind> {
         Some(AttributeKind::Dummy)
     }
 }

--- a/compiler/rustc_attr_parsing/src/attributes/inline.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/inline.rs
@@ -34,7 +34,7 @@ impl<S: Stage> SingleAttributeParser<S> for InlineParser {
         "https://doc.rust-lang.org/reference/attributes/codegen.html#the-inline-attribute"
     );
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser<'_>) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
         match args {
             ArgParser::NoArgs => Some(AttributeKind::Inline(InlineAttr::Hint, cx.attr_span)),
             ArgParser::List(list) => {
@@ -77,7 +77,7 @@ impl<S: Stage> SingleAttributeParser<S> for RustcForceInlineParser {
 
     const TEMPLATE: AttributeTemplate = template!(Word, List: &["reason"], NameValueStr: "reason");
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser<'_>) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
         let reason = match args {
             ArgParser::NoArgs => None,
             ArgParser::List(list) => {

--- a/compiler/rustc_attr_parsing/src/attributes/link_attrs.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/link_attrs.rs
@@ -62,10 +62,10 @@ impl<S: Stage> CombineAttributeParser<S> for LinkParser {
         ], "https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute");
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(ALL_TARGETS); //FIXME Still checked fully in `check_attr.rs`
 
-    fn extend<'c>(
-        cx: &'c mut AcceptContext<'_, '_, S>,
-        args: &'c ArgParser,
-    ) -> impl IntoIterator<Item = Self::Item> + 'c {
+    fn extend(
+        cx: &mut AcceptContext<'_, '_, S>,
+        args: &ArgParser,
+    ) -> impl IntoIterator<Item = Self::Item> {
         let items = match args {
             ArgParser::List(list) => list,
             // This is an edgecase added because making this a hard error would break too many crates

--- a/compiler/rustc_attr_parsing/src/attributes/link_attrs.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/link_attrs.rs
@@ -33,7 +33,7 @@ impl<S: Stage> SingleAttributeParser<S> for LinkNameParser {
         "https://doc.rust-lang.org/reference/items/external-blocks.html#the-link_name-attribute"
     );
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser<'_>) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
         let Some(nv) = args.name_value() else {
             cx.expected_name_value(cx.attr_span, None);
             return None;
@@ -64,7 +64,7 @@ impl<S: Stage> CombineAttributeParser<S> for LinkParser {
 
     fn extend<'c>(
         cx: &'c mut AcceptContext<'_, '_, S>,
-        args: &'c ArgParser<'_>,
+        args: &'c ArgParser,
     ) -> impl IntoIterator<Item = Self::Item> + 'c {
         let items = match args {
             ArgParser::List(list) => list,
@@ -242,7 +242,7 @@ impl<S: Stage> CombineAttributeParser<S> for LinkParser {
 
 impl LinkParser {
     fn parse_link_name<S: Stage>(
-        item: &MetaItemParser<'_>,
+        item: &MetaItemParser,
         name: &mut Option<(Symbol, Span)>,
         cx: &mut AcceptContext<'_, '_, S>,
     ) -> bool {
@@ -267,7 +267,7 @@ impl LinkParser {
     }
 
     fn parse_link_kind<S: Stage>(
-        item: &MetaItemParser<'_>,
+        item: &MetaItemParser,
         kind: &mut Option<NativeLibKind>,
         cx: &mut AcceptContext<'_, '_, S>,
         sess: &Session,
@@ -347,7 +347,7 @@ impl LinkParser {
     }
 
     fn parse_link_modifiers<S: Stage>(
-        item: &MetaItemParser<'_>,
+        item: &MetaItemParser,
         modifiers: &mut Option<(Symbol, Span)>,
         cx: &mut AcceptContext<'_, '_, S>,
     ) -> bool {
@@ -368,7 +368,7 @@ impl LinkParser {
     }
 
     fn parse_link_cfg<S: Stage>(
-        item: &MetaItemParser<'_>,
+        item: &MetaItemParser,
         cfg: &mut Option<CfgEntry>,
         cx: &mut AcceptContext<'_, '_, S>,
         sess: &Session,
@@ -400,7 +400,7 @@ impl LinkParser {
     }
 
     fn parse_link_wasm_import_module<S: Stage>(
-        item: &MetaItemParser<'_>,
+        item: &MetaItemParser,
         wasm_import_module: &mut Option<(Symbol, Span)>,
         cx: &mut AcceptContext<'_, '_, S>,
     ) -> bool {
@@ -421,7 +421,7 @@ impl LinkParser {
     }
 
     fn parse_link_import_name_type<S: Stage>(
-        item: &MetaItemParser<'_>,
+        item: &MetaItemParser,
         import_name_type: &mut Option<(PeImportNameType, Span)>,
         cx: &mut AcceptContext<'_, '_, S>,
     ) -> bool {
@@ -478,7 +478,7 @@ impl<S: Stage> SingleAttributeParser<S> for LinkSectionParser {
         "https://doc.rust-lang.org/reference/abi.html#the-link_section-attribute"
     );
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser<'_>) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
         let Some(nv) = args.name_value() else {
             cx.expected_name_value(cx.attr_span, None);
             return None;
@@ -551,7 +551,7 @@ impl<S: Stage> SingleAttributeParser<S> for LinkOrdinalParser {
         "https://doc.rust-lang.org/reference/items/external-blocks.html#the-link_ordinal-attribute"
     );
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser<'_>) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
         let ordinal = parse_single_integer(cx, args)?;
 
         // According to the table at
@@ -607,7 +607,7 @@ impl<S: Stage> SingleAttributeParser<S> for LinkageParser {
         "weak_odr",
     ]);
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser<'_>) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
         let Some(name_value) = args.name_value() else {
             cx.expected_name_value(cx.attr_span, Some(sym::linkage));
             return None;

--- a/compiler/rustc_attr_parsing/src/attributes/macro_attrs.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/macro_attrs.rs
@@ -148,7 +148,7 @@ impl<S: Stage> SingleAttributeParser<S> for MacroExportParser {
         Error(Target::Crate),
     ]);
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser<'_>) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
         let local_inner_macros = match args {
             ArgParser::NoArgs => false,
             ArgParser::List(list) => {

--- a/compiler/rustc_attr_parsing/src/attributes/mod.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/mod.rs
@@ -62,7 +62,7 @@ pub(crate) mod traits;
 pub(crate) mod transparency;
 pub(crate) mod util;
 
-type AcceptFn<T, S> = for<'sess> fn(&mut T, &mut AcceptContext<'_, 'sess, S>, &ArgParser<'_>);
+type AcceptFn<T, S> = for<'sess> fn(&mut T, &mut AcceptContext<'_, 'sess, S>, &ArgParser);
 type AcceptMapping<T, S> = &'static [(&'static [Symbol], AttributeTemplate, AcceptFn<T, S>)];
 
 /// An [`AttributeParser`] is a type which searches for syntactic attributes.
@@ -133,7 +133,7 @@ pub(crate) trait SingleAttributeParser<S: Stage>: 'static {
     const TEMPLATE: AttributeTemplate;
 
     /// Converts a single syntactical attribute to a single semantic attribute, or [`AttributeKind`]
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser<'_>) -> Option<AttributeKind>;
+    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind>;
 }
 
 /// Use in combination with [`SingleAttributeParser`].
@@ -282,7 +282,7 @@ impl<T: NoArgsAttributeParser<S>, S: Stage> SingleAttributeParser<S> for Without
     const ALLOWED_TARGETS: AllowedTargets = T::ALLOWED_TARGETS;
     const TEMPLATE: AttributeTemplate = template!(Word);
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser<'_>) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
         if let Err(span) = args.no_args() {
             cx.expected_no_args(span);
         }
@@ -317,7 +317,7 @@ pub(crate) trait CombineAttributeParser<S: Stage>: 'static {
     /// Converts a single syntactical attribute to a number of elements of the semantic attribute, or [`AttributeKind`]
     fn extend<'c>(
         cx: &'c mut AcceptContext<'_, '_, S>,
-        args: &'c ArgParser<'_>,
+        args: &'c ArgParser,
     ) -> impl IntoIterator<Item = Self::Item> + 'c;
 }
 

--- a/compiler/rustc_attr_parsing/src/attributes/mod.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/mod.rs
@@ -315,10 +315,10 @@ pub(crate) trait CombineAttributeParser<S: Stage>: 'static {
     const TEMPLATE: AttributeTemplate;
 
     /// Converts a single syntactical attribute to a number of elements of the semantic attribute, or [`AttributeKind`]
-    fn extend<'c>(
-        cx: &'c mut AcceptContext<'_, '_, S>,
-        args: &'c ArgParser,
-    ) -> impl IntoIterator<Item = Self::Item> + 'c;
+    fn extend(
+        cx: &mut AcceptContext<'_, '_, S>,
+        args: &ArgParser,
+    ) -> impl IntoIterator<Item = Self::Item>;
 }
 
 /// Use in combination with [`CombineAttributeParser`].

--- a/compiler/rustc_attr_parsing/src/attributes/must_use.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/must_use.rs
@@ -29,7 +29,7 @@ impl<S: Stage> SingleAttributeParser<S> for MustUseParser {
         "https://doc.rust-lang.org/reference/attributes/diagnostics.html#the-must_use-attribute"
     );
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser<'_>) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
         Some(AttributeKind::MustUse {
             span: cx.attr_span,
             reason: match args {

--- a/compiler/rustc_attr_parsing/src/attributes/path.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/path.rs
@@ -13,7 +13,7 @@ impl<S: Stage> SingleAttributeParser<S> for PathParser {
         "https://doc.rust-lang.org/reference/items/modules.html#the-path-attribute"
     );
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser<'_>) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
         let Some(nv) = args.name_value() else {
             cx.expected_name_value(cx.attr_span, None);
             return None;

--- a/compiler/rustc_attr_parsing/src/attributes/proc_macro_attrs.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/proc_macro_attrs.rs
@@ -30,7 +30,7 @@ impl<S: Stage> SingleAttributeParser<S> for ProcMacroDeriveParser {
         "https://doc.rust-lang.org/reference/procedural-macros.html#derive-macros"
     );
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser<'_>) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
         let (trait_name, helper_attrs) = parse_derive_like(cx, args, true)?;
         Some(AttributeKind::ProcMacroDerive {
             trait_name: trait_name.expect("Trait name is mandatory, so it is present"),
@@ -49,7 +49,7 @@ impl<S: Stage> SingleAttributeParser<S> for RustcBuiltinMacroParser {
     const TEMPLATE: AttributeTemplate =
         template!(List: &["TraitName", "TraitName, attributes(name1, name2, ...)"]);
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser<'_>) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
         let (builtin_name, helper_attrs) = parse_derive_like(cx, args, false)?;
         Some(AttributeKind::RustcBuiltinMacro { builtin_name, helper_attrs, span: cx.attr_span })
     }
@@ -57,7 +57,7 @@ impl<S: Stage> SingleAttributeParser<S> for RustcBuiltinMacroParser {
 
 fn parse_derive_like<S: Stage>(
     cx: &mut AcceptContext<'_, '_, S>,
-    args: &ArgParser<'_>,
+    args: &ArgParser,
     trait_name_mandatory: bool,
 ) -> Option<(Option<Symbol>, ThinVec<Symbol>)> {
     let Some(list) = args.list() else {

--- a/compiler/rustc_attr_parsing/src/attributes/prototype.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/prototype.rs
@@ -25,7 +25,7 @@ impl<S: Stage> SingleAttributeParser<S> for CustomMirParser {
 
     const TEMPLATE: AttributeTemplate = template!(List: &[r#"dialect = "...", phase = "...""#]);
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser<'_>) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
         let Some(list) = args.list() else {
             cx.expected_list(cx.attr_span);
             return None;
@@ -70,7 +70,7 @@ impl<S: Stage> SingleAttributeParser<S> for CustomMirParser {
 fn extract_value<S: Stage>(
     cx: &mut AcceptContext<'_, '_, S>,
     key: Symbol,
-    arg: &ArgParser<'_>,
+    arg: &ArgParser,
     span: Span,
     out_val: &mut Option<(Symbol, Span)>,
     failed: &mut bool,

--- a/compiler/rustc_attr_parsing/src/attributes/repr.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/repr.rs
@@ -26,10 +26,10 @@ impl<S: Stage> CombineAttributeParser<S> for ReprParser {
         "https://doc.rust-lang.org/reference/type-layout.html#representations"
     );
 
-    fn extend<'c>(
-        cx: &'c mut AcceptContext<'_, '_, S>,
-        args: &'c ArgParser,
-    ) -> impl IntoIterator<Item = Self::Item> + 'c {
+    fn extend(
+        cx: &mut AcceptContext<'_, '_, S>,
+        args: &ArgParser,
+    ) -> impl IntoIterator<Item = Self::Item> {
         let mut reprs = Vec::new();
 
         let Some(list) = args.list() else {
@@ -275,7 +275,7 @@ impl AlignParser {
     const PATH: &'static [Symbol] = &[sym::rustc_align];
     const TEMPLATE: AttributeTemplate = template!(List: &["<alignment in bytes>"]);
 
-    fn parse<'c, S: Stage>(&mut self, cx: &'c mut AcceptContext<'_, '_, S>, args: &'c ArgParser) {
+    fn parse<S: Stage>(&mut self, cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) {
         match args {
             ArgParser::NoArgs | ArgParser::NameValue(_) => {
                 cx.expected_list(cx.attr_span);
@@ -332,7 +332,7 @@ impl AlignStaticParser {
     const PATH: &'static [Symbol] = &[sym::rustc_align_static];
     const TEMPLATE: AttributeTemplate = AlignParser::TEMPLATE;
 
-    fn parse<'c, S: Stage>(&mut self, cx: &'c mut AcceptContext<'_, '_, S>, args: &'c ArgParser) {
+    fn parse<S: Stage>(&mut self, cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) {
         self.0.parse(cx, args)
     }
 }

--- a/compiler/rustc_attr_parsing/src/attributes/repr.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/repr.rs
@@ -28,7 +28,7 @@ impl<S: Stage> CombineAttributeParser<S> for ReprParser {
 
     fn extend<'c>(
         cx: &'c mut AcceptContext<'_, '_, S>,
-        args: &'c ArgParser<'_>,
+        args: &'c ArgParser,
     ) -> impl IntoIterator<Item = Self::Item> + 'c {
         let mut reprs = Vec::new();
 
@@ -98,10 +98,7 @@ fn int_type_of_word(s: Symbol) -> Option<IntType> {
     }
 }
 
-fn parse_repr<S: Stage>(
-    cx: &AcceptContext<'_, '_, S>,
-    param: &MetaItemParser<'_>,
-) -> Option<ReprAttr> {
+fn parse_repr<S: Stage>(cx: &AcceptContext<'_, '_, S>, param: &MetaItemParser) -> Option<ReprAttr> {
     use ReprAttr::*;
 
     // FIXME(jdonszelmann): invert the parsing here to match on the word first and then the
@@ -192,7 +189,7 @@ enum AlignKind {
 
 fn parse_repr_align<S: Stage>(
     cx: &AcceptContext<'_, '_, S>,
-    list: &MetaItemListParser<'_>,
+    list: &MetaItemListParser,
     param_span: Span,
     align_kind: AlignKind,
 ) -> Option<ReprAttr> {
@@ -278,11 +275,7 @@ impl AlignParser {
     const PATH: &'static [Symbol] = &[sym::rustc_align];
     const TEMPLATE: AttributeTemplate = template!(List: &["<alignment in bytes>"]);
 
-    fn parse<'c, S: Stage>(
-        &mut self,
-        cx: &'c mut AcceptContext<'_, '_, S>,
-        args: &'c ArgParser<'_>,
-    ) {
+    fn parse<'c, S: Stage>(&mut self, cx: &'c mut AcceptContext<'_, '_, S>, args: &'c ArgParser) {
         match args {
             ArgParser::NoArgs | ArgParser::NameValue(_) => {
                 cx.expected_list(cx.attr_span);
@@ -339,11 +332,7 @@ impl AlignStaticParser {
     const PATH: &'static [Symbol] = &[sym::rustc_align_static];
     const TEMPLATE: AttributeTemplate = AlignParser::TEMPLATE;
 
-    fn parse<'c, S: Stage>(
-        &mut self,
-        cx: &'c mut AcceptContext<'_, '_, S>,
-        args: &'c ArgParser<'_>,
-    ) {
+    fn parse<'c, S: Stage>(&mut self, cx: &'c mut AcceptContext<'_, '_, S>, args: &'c ArgParser) {
         self.0.parse(cx, args)
     }
 }

--- a/compiler/rustc_attr_parsing/src/attributes/rustc_internal.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/rustc_internal.rs
@@ -19,7 +19,7 @@ impl<S: Stage> SingleAttributeParser<S> for RustcLayoutScalarValidRangeStartPars
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Struct)]);
     const TEMPLATE: AttributeTemplate = template!(List: &["start"]);
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser<'_>) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
         parse_single_integer(cx, args)
             .map(|n| AttributeKind::RustcLayoutScalarValidRangeStart(Box::new(n), cx.attr_span))
     }
@@ -34,7 +34,7 @@ impl<S: Stage> SingleAttributeParser<S> for RustcLayoutScalarValidRangeEndParser
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Struct)]);
     const TEMPLATE: AttributeTemplate = template!(List: &["end"]);
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser<'_>) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
         parse_single_integer(cx, args)
             .map(|n| AttributeKind::RustcLayoutScalarValidRangeEnd(Box::new(n), cx.attr_span))
     }
@@ -49,7 +49,7 @@ impl<S: Stage> SingleAttributeParser<S> for RustcObjectLifetimeDefaultParser {
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Struct)]);
     const TEMPLATE: AttributeTemplate = template!(Word);
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser<'_>) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
         if let Err(span) = args.no_args() {
             cx.expected_no_args(span);
             return None;
@@ -68,7 +68,7 @@ impl<S: Stage> SingleAttributeParser<S> for RustcSimdMonomorphizeLaneLimitParser
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Struct)]);
     const TEMPLATE: AttributeTemplate = template!(NameValueStr: "N");
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser<'_>) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
         let ArgParser::NameValue(nv) = args else {
             cx.expected_name_value(cx.attr_span, None);
             return None;

--- a/compiler/rustc_attr_parsing/src/attributes/stability.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/stability.rs
@@ -267,7 +267,7 @@ impl<S: Stage> AttributeParser<S> for ConstStabilityParser {
 /// `name = value`
 fn insert_value_into_option_or_error<S: Stage>(
     cx: &AcceptContext<'_, '_, S>,
-    param: &MetaItemParser<'_>,
+    param: &MetaItemParser,
     item: &mut Option<Symbol>,
     name: Ident,
 ) -> Option<()> {
@@ -289,7 +289,7 @@ fn insert_value_into_option_or_error<S: Stage>(
 /// its stability information.
 pub(crate) fn parse_stability<S: Stage>(
     cx: &AcceptContext<'_, '_, S>,
-    args: &ArgParser<'_>,
+    args: &ArgParser,
 ) -> Option<(Symbol, StabilityLevel)> {
     let mut feature = None;
     let mut since = None;
@@ -365,7 +365,7 @@ pub(crate) fn parse_stability<S: Stage>(
 /// attribute, and return the feature name and its stability information.
 pub(crate) fn parse_unstability<S: Stage>(
     cx: &AcceptContext<'_, '_, S>,
-    args: &ArgParser<'_>,
+    args: &ArgParser,
 ) -> Option<(Symbol, StabilityLevel)> {
     let mut feature = None;
     let mut reason = None;

--- a/compiler/rustc_attr_parsing/src/attributes/test_attrs.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/test_attrs.rs
@@ -15,7 +15,7 @@ impl<S: Stage> SingleAttributeParser<S> for IgnoreParser {
         "https://doc.rust-lang.org/reference/attributes/testing.html#the-ignore-attribute"
     );
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser<'_>) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
         Some(AttributeKind::Ignore {
             span: cx.attr_span,
             reason: match args {
@@ -49,7 +49,7 @@ impl<S: Stage> SingleAttributeParser<S> for ShouldPanicParser {
         "https://doc.rust-lang.org/reference/attributes/testing.html#the-should_panic-attribute"
     );
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser<'_>) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
         Some(AttributeKind::ShouldPanic {
             span: cx.attr_span,
             reason: match args {

--- a/compiler/rustc_attr_parsing/src/attributes/traits.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/traits.rs
@@ -18,7 +18,7 @@ impl<S: Stage> SingleAttributeParser<S> for SkipDuringMethodDispatchParser {
 
     const TEMPLATE: AttributeTemplate = template!(List: &["array, boxed_slice"]);
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser<'_>) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
         let mut array = false;
         let mut boxed_slice = false;
         let Some(args) = args.list() else {

--- a/compiler/rustc_attr_parsing/src/attributes/transparency.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/transparency.rs
@@ -17,7 +17,7 @@ impl<S: Stage> SingleAttributeParser<S> for TransparencyParser {
     const TEMPLATE: AttributeTemplate =
         template!(NameValueStr: ["transparent", "semitransparent", "opaque"]);
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser<'_>) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
         let Some(nv) = args.name_value() else {
             cx.expected_name_value(cx.attr_span, None);
             return None;

--- a/compiler/rustc_attr_parsing/src/attributes/util.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/util.rs
@@ -40,7 +40,7 @@ pub fn is_builtin_attr(attr: &impl AttributeExt) -> bool {
 /// `args` is the parser for the attribute arguments.
 pub(crate) fn parse_single_integer<S: Stage>(
     cx: &mut AcceptContext<'_, '_, S>,
-    args: &ArgParser<'_>,
+    args: &ArgParser,
 ) -> Option<u128> {
     let Some(list) = args.list() else {
         cx.expected_list(cx.attr_span);

--- a/compiler/rustc_attr_parsing/src/context.rs
+++ b/compiler/rustc_attr_parsing/src/context.rs
@@ -75,7 +75,7 @@ use crate::attributes::traits::{
 };
 use crate::attributes::transparency::TransparencyParser;
 use crate::attributes::{AttributeParser as _, Combine, Single, WithoutArgs};
-use crate::parser::{ArgParser, PathParser};
+use crate::parser::{ArgParser, RefPathParser};
 use crate::session_diagnostics::{
     AttributeParseError, AttributeParseErrorReason, ParsedDescription, UnknownMetaItem,
 };
@@ -95,7 +95,7 @@ pub(super) struct GroupTypeInnerAccept<S: Stage> {
 }
 
 type AcceptFn<S> =
-    Box<dyn for<'sess, 'a> Fn(&mut AcceptContext<'_, 'sess, S>, &ArgParser<'a>) + Send + Sync>;
+    Box<dyn for<'sess, 'a> Fn(&mut AcceptContext<'_, 'sess, S>, &ArgParser) + Send + Sync>;
 type FinalizeFn<S> =
     Box<dyn Send + Sync + Fn(&mut FinalizeContext<'_, '_, S>) -> Option<AttributeKind>>;
 
@@ -713,7 +713,7 @@ pub(crate) struct FinalizeContext<'p, 'sess, S: Stage> {
     ///
     /// Usually, you should use normal attribute parsing logic instead,
     /// especially when making a *denylist* of other attributes.
-    pub(crate) all_attrs: &'p [PathParser<'p>],
+    pub(crate) all_attrs: &'p [RefPathParser<'p>],
 }
 
 impl<'p, 'sess: 'p, S: Stage> Deref for FinalizeContext<'p, 'sess, S> {

--- a/compiler/rustc_attr_parsing/src/interface.rs
+++ b/compiler/rustc_attr_parsing/src/interface.rs
@@ -342,7 +342,7 @@ impl<'sess, S: Stage> AttributeParser<'sess, S> {
                         // blob
                         // a
                         if is_doc_attribute
-                            && let ArgParser::NameValue(nv) = args
+                            && let ArgParser::NameValue(nv) = &args
                             // If not a string key/value, it should emit an error, but to make
                             // things simpler, it's handled in `DocParser` because it's simpler to
                             // emit an error with `AcceptContext`.

--- a/compiler/rustc_attr_parsing/src/parser.rs
+++ b/compiler/rustc_attr_parsing/src/parser.rs
@@ -8,7 +8,7 @@ use std::fmt::{Debug, Display};
 
 use rustc_ast::token::{self, Delimiter, MetaVarKind};
 use rustc_ast::tokenstream::TokenStream;
-use rustc_ast::{AttrArgs, Expr, ExprKind, LitKind, MetaItemLit, NormalAttr, Path, StmtKind, UnOp};
+use rustc_ast::{AttrArgs, Expr, ExprKind, LitKind, MetaItemLit, Path, StmtKind, UnOp};
 use rustc_ast_pretty::pprust;
 use rustc_errors::{Diag, PResult};
 use rustc_hir::{self as hir, AttrPath};
@@ -249,22 +249,6 @@ impl<'a> Debug for MetaItemParser<'a> {
             .field("path", &self.path)
             .field("args", &self.args)
             .finish()
-    }
-}
-
-impl<'a> MetaItemParser<'a> {
-    /// Create a new parser from a [`NormalAttr`], which is stored inside of any
-    /// [`ast::Attribute`](rustc_ast::Attribute)
-    pub fn from_attr<'sess>(
-        attr: &'a NormalAttr,
-        parts: &[Symbol],
-        psess: &'sess ParseSess,
-        should_emit: ShouldEmit,
-    ) -> Option<Self> {
-        Some(Self {
-            path: PathParser(Cow::Borrowed(&attr.item.path)),
-            args: ArgParser::from_attr_args(&attr.item.args, parts, psess, should_emit)?,
-        })
     }
 }
 

--- a/compiler/rustc_attr_parsing/src/parser.rs
+++ b/compiler/rustc_attr_parsing/src/parser.rs
@@ -3,7 +3,7 @@
 //!
 //! FIXME(jdonszelmann): delete `rustc_ast/attr/mod.rs`
 
-use std::borrow::Cow;
+use std::borrow::Borrow;
 use std::fmt::{Debug, Display};
 
 use rustc_ast::token::{self, Delimiter, MetaVarKind};
@@ -26,9 +26,12 @@ use crate::session_diagnostics::{
 };
 
 #[derive(Clone, Debug)]
-pub struct PathParser<'a>(pub Cow<'a, Path>);
+pub struct PathParser<P: Borrow<Path>>(pub P);
 
-impl<'a> PathParser<'a> {
+pub type OwnedPathParser = PathParser<Path>;
+pub type RefPathParser<'p> = PathParser<&'p Path>;
+
+impl<P: Borrow<Path>> PathParser<P> {
     pub fn get_attribute_path(&self) -> hir::AttrPath {
         AttrPath {
             segments: self.segments().copied().collect::<Vec<_>>().into_boxed_slice(),
@@ -36,16 +39,16 @@ impl<'a> PathParser<'a> {
         }
     }
 
-    pub fn segments(&'a self) -> impl Iterator<Item = &'a Ident> {
-        self.0.segments.iter().map(|seg| &seg.ident)
+    pub fn segments(&self) -> impl Iterator<Item = &Ident> {
+        self.0.borrow().segments.iter().map(|seg| &seg.ident)
     }
 
     pub fn span(&self) -> Span {
-        self.0.span
+        self.0.borrow().span
     }
 
     pub fn len(&self) -> usize {
-        self.0.segments.len()
+        self.0.borrow().segments.len()
     }
 
     pub fn segments_is(&self, segments: &[Symbol]) -> bool {
@@ -76,21 +79,21 @@ impl<'a> PathParser<'a> {
     }
 }
 
-impl Display for PathParser<'_> {
+impl<P: Borrow<Path>> Display for PathParser<P> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", pprust::path_to_string(&self.0))
+        write!(f, "{}", pprust::path_to_string(self.0.borrow()))
     }
 }
 
 #[derive(Clone, Debug)]
 #[must_use]
-pub enum ArgParser<'a> {
+pub enum ArgParser {
     NoArgs,
-    List(MetaItemListParser<'a>),
+    List(MetaItemListParser),
     NameValue(NameValueParser),
 }
 
-impl<'a> ArgParser<'a> {
+impl ArgParser {
     pub fn span(&self) -> Option<Span> {
         match self {
             Self::NoArgs => None,
@@ -100,7 +103,7 @@ impl<'a> ArgParser<'a> {
     }
 
     pub fn from_attr_args<'sess>(
-        value: &'a AttrArgs,
+        value: &AttrArgs,
         parts: &[Symbol],
         psess: &'sess ParseSess,
         should_emit: ShouldEmit,
@@ -144,7 +147,7 @@ impl<'a> ArgParser<'a> {
     ///
     /// - `#[allow(clippy::complexity)]`: `(clippy::complexity)` is a list
     /// - `#[rustfmt::skip::macros(target_macro_name)]`: `(target_macro_name)` is a list
-    pub fn list(&self) -> Option<&MetaItemListParser<'a>> {
+    pub fn list(&self) -> Option<&MetaItemListParser> {
         match self {
             Self::List(l) => Some(l),
             Self::NameValue(_) | Self::NoArgs => None,
@@ -184,17 +187,17 @@ impl<'a> ArgParser<'a> {
 ///
 /// Choose which one you want using the provided methods.
 #[derive(Debug, Clone)]
-pub enum MetaItemOrLitParser<'a> {
-    MetaItemParser(MetaItemParser<'a>),
+pub enum MetaItemOrLitParser {
+    MetaItemParser(MetaItemParser),
     Lit(MetaItemLit),
     Err(Span, ErrorGuaranteed),
 }
 
-impl<'sess> MetaItemOrLitParser<'sess> {
-    pub fn parse_single(
+impl MetaItemOrLitParser {
+    pub fn parse_single<'sess>(
         parser: &mut Parser<'sess>,
         should_emit: ShouldEmit,
-    ) -> PResult<'sess, MetaItemOrLitParser<'static>> {
+    ) -> PResult<'sess, MetaItemOrLitParser> {
         let mut this = MetaItemListParserContext { parser, should_emit };
         this.parse_meta_item_inner()
     }
@@ -216,7 +219,7 @@ impl<'sess> MetaItemOrLitParser<'sess> {
         }
     }
 
-    pub fn meta_item(&self) -> Option<&MetaItemParser<'sess>> {
+    pub fn meta_item(&self) -> Option<&MetaItemParser> {
         match self {
             MetaItemOrLitParser::MetaItemParser(parser) => Some(parser),
             _ => None,
@@ -238,12 +241,12 @@ impl<'sess> MetaItemOrLitParser<'sess> {
 ///
 /// The syntax of MetaItems can be found at <https://doc.rust-lang.org/reference/attributes.html>
 #[derive(Clone)]
-pub struct MetaItemParser<'a> {
-    path: PathParser<'a>,
-    args: ArgParser<'a>,
+pub struct MetaItemParser {
+    path: OwnedPathParser,
+    args: ArgParser,
 }
 
-impl<'a> Debug for MetaItemParser<'a> {
+impl Debug for MetaItemParser {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("MetaItemParser")
             .field("path", &self.path)
@@ -252,12 +255,12 @@ impl<'a> Debug for MetaItemParser<'a> {
     }
 }
 
-impl<'a> MetaItemParser<'a> {
+impl MetaItemParser {
     pub fn span(&self) -> Span {
         if let Some(other) = self.args.span() {
-            self.path.span().with_hi(other.hi())
+            self.path.borrow().span().with_hi(other.hi())
         } else {
-            self.path.span()
+            self.path.borrow().span()
         }
     }
 
@@ -266,12 +269,12 @@ impl<'a> MetaItemParser<'a> {
     /// - `#[rustfmt::skip]`: `rustfmt::skip` is a path
     /// - `#[allow(clippy::complexity)]`: `clippy::complexity` is a path
     /// - `#[inline]`: `inline` is a single segment path
-    pub fn path(&self) -> &PathParser<'a> {
+    pub fn path(&self) -> &OwnedPathParser {
         &self.path
     }
 
     /// Gets just the args parser, without caring about the path.
-    pub fn args(&self) -> &ArgParser<'a> {
+    pub fn args(&self) -> &ArgParser {
         &self.args
     }
 
@@ -281,7 +284,7 @@ impl<'a> MetaItemParser<'a> {
     /// - `#[inline]`: `inline` is a word
     /// - `#[rustfmt::skip]`: `rustfmt::skip` is a path,
     ///   and not a word and should instead be parsed using [`path`](Self::path)
-    pub fn word_is(&self, sym: Symbol) -> Option<&ArgParser<'a>> {
+    pub fn word_is(&self, sym: Symbol) -> Option<&ArgParser> {
         self.path().word_is(sym).then(|| self.args())
     }
 }
@@ -405,7 +408,7 @@ impl<'a, 'sess> MetaItemListParserContext<'a, 'sess> {
         Ok(lit)
     }
 
-    fn parse_attr_item(&mut self) -> PResult<'sess, MetaItemParser<'static>> {
+    fn parse_attr_item(&mut self) -> PResult<'sess, MetaItemParser> {
         if let Some(MetaVarKind::Meta { has_meta_form }) = self.parser.token.is_metavar_seq() {
             return if has_meta_form {
                 let attr_item = self
@@ -441,10 +444,10 @@ impl<'a, 'sess> MetaItemListParserContext<'a, 'sess> {
             ArgParser::NoArgs
         };
 
-        Ok(MetaItemParser { path: PathParser(Cow::Owned(path)), args })
+        Ok(MetaItemParser { path: PathParser(path), args })
     }
 
-    fn parse_meta_item_inner(&mut self) -> PResult<'sess, MetaItemOrLitParser<'static>> {
+    fn parse_meta_item_inner(&mut self) -> PResult<'sess, MetaItemOrLitParser> {
         if let Some(token_lit) = self.parser.eat_token_lit() {
             // If a literal token is parsed, we commit to parsing a MetaItemLit for better errors
             Ok(MetaItemOrLitParser::Lit(self.unsuffixed_meta_item_from_lit(token_lit)?))
@@ -531,7 +534,7 @@ impl<'a, 'sess> MetaItemListParserContext<'a, 'sess> {
         psess: &'sess ParseSess,
         span: Span,
         should_emit: ShouldEmit,
-    ) -> PResult<'sess, MetaItemListParser<'static>> {
+    ) -> PResult<'sess, MetaItemListParser> {
         let mut parser = Parser::new(psess, tokens, None);
         let mut this = MetaItemListParserContext { parser: &mut parser, should_emit };
 
@@ -554,14 +557,14 @@ impl<'a, 'sess> MetaItemListParserContext<'a, 'sess> {
 }
 
 #[derive(Debug, Clone)]
-pub struct MetaItemListParser<'a> {
-    sub_parsers: ThinVec<MetaItemOrLitParser<'a>>,
+pub struct MetaItemListParser {
+    sub_parsers: ThinVec<MetaItemOrLitParser>,
     pub span: Span,
 }
 
-impl<'a> MetaItemListParser<'a> {
+impl MetaItemListParser {
     pub(crate) fn new<'sess>(
-        tokens: &'a TokenStream,
+        tokens: &TokenStream,
         span: Span,
         psess: &'sess ParseSess,
         should_emit: ShouldEmit,
@@ -570,7 +573,7 @@ impl<'a> MetaItemListParser<'a> {
     }
 
     /// Lets you pick and choose as what you want to parse each element in the list
-    pub fn mixed(&self) -> impl Iterator<Item = &MetaItemOrLitParser<'a>> {
+    pub fn mixed(&self) -> impl Iterator<Item = &MetaItemOrLitParser> {
         self.sub_parsers.iter()
     }
 
@@ -585,7 +588,7 @@ impl<'a> MetaItemListParser<'a> {
     /// Returns Some if the list contains only a single element.
     ///
     /// Inside the Some is the parser to parse this single element.
-    pub fn single(&self) -> Option<&MetaItemOrLitParser<'a>> {
+    pub fn single(&self) -> Option<&MetaItemOrLitParser> {
         let mut iter = self.mixed();
         iter.next().filter(|_| iter.next().is_none())
     }


### PR DESCRIPTION
* Removes a bunch of unused lifetimes in the attribute parsers
* Creates two variants of `PathParser`, because we statically know which variant we're in

r? @jdonszelmann 