### PR TITLE
Remove uses of `cfg({any()/all()})`

### DIFF
--- a/compiler/rustc_codegen_cranelift/src/base.rs
+++ b/compiler/rustc_codegen_cranelift/src/base.rs
@@ -167,7 +167,7 @@ pub(crate) fn compile_fn(
     context.clear();
     context.func = codegened_func.func;
 
-    #[cfg(any())] // This is never true
+    #[cfg(false)]
     let _clif_guard = {
         use std::fmt::Write;
 

--- a/library/core/src/primitive_docs.rs
+++ b/library/core/src/primitive_docs.rs
@@ -591,7 +591,7 @@ impl () {}
 /// # pub unsafe fn malloc(_size: usize) -> *mut core::ffi::c_void { core::ptr::NonNull::dangling().as_ptr() }
 /// # pub unsafe fn free(_ptr: *mut core::ffi::c_void) {}
 /// # }
-/// # #[cfg(any())]
+/// # #[cfg(false)]
 /// #[allow(unused_extern_crates)]
 /// extern crate libc;
 ///

--- a/tests/ui/asm/naked-functions-inline.rs
+++ b/tests/ui/asm/naked-functions-inline.rs
@@ -30,7 +30,7 @@ pub extern "C" fn inline_never() {
 }
 
 #[unsafe(naked)]
-#[cfg_attr(all(), inline(never))]
+#[cfg_attr(true, inline(never))]
 //~^ ERROR [E0736]
 pub extern "C" fn conditional_inline_never() {
     naked_asm!("");

--- a/tests/ui/asm/naked-functions-inline.stderr
+++ b/tests/ui/asm/naked-functions-inline.stderr
@@ -23,12 +23,12 @@ LL | #[inline(never)]
    |   ^^^^^^ the `inline` attribute is incompatible with `#[unsafe(naked)]`
 
 error[E0736]: attribute incompatible with `#[unsafe(naked)]`
-  --> $DIR/naked-functions-inline.rs:33:19
+  --> $DIR/naked-functions-inline.rs:33:18
    |
 LL | #[unsafe(naked)]
    | ---------------- function marked with `#[unsafe(naked)]` here
-LL | #[cfg_attr(all(), inline(never))]
-   |                   ^^^^^^ the `inline` attribute is incompatible with `#[unsafe(naked)]`
+LL | #[cfg_attr(true, inline(never))]
+   |                  ^^^^^^ the `inline` attribute is incompatible with `#[unsafe(naked)]`
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/attributes/unsafe/cfg-unsafe-attributes.rs
+++ b/tests/ui/attributes/unsafe/cfg-unsafe-attributes.rs
@@ -1,6 +1,6 @@
 //@ build-pass
 
-#[cfg_attr(all(), unsafe(no_mangle))]
+#[cfg_attr(true, unsafe(no_mangle))]
 fn a() {}
 
 fn main() {}

--- a/tests/ui/attributes/unsafe/extraneous-unsafe-attributes.rs
+++ b/tests/ui/attributes/unsafe/extraneous-unsafe-attributes.rs
@@ -1,9 +1,9 @@
 //@ edition: 2024
 
-#[unsafe(cfg(any()))] //~ ERROR: is not an unsafe attribute
+#[unsafe(cfg(false))] //~ ERROR: is not an unsafe attribute
 fn a() {}
 
-#[unsafe(cfg_attr(any(), allow(dead_code)))] //~ ERROR: is not an unsafe attribute
+#[unsafe(cfg_attr(false, allow(dead_code)))] //~ ERROR: is not an unsafe attribute
 fn b() {}
 
 #[unsafe(test)] //~ ERROR: is not an unsafe attribute

--- a/tests/ui/attributes/unsafe/extraneous-unsafe-attributes.stderr
+++ b/tests/ui/attributes/unsafe/extraneous-unsafe-attributes.stderr
@@ -1,7 +1,7 @@
 error: `cfg` is not an unsafe attribute
   --> $DIR/extraneous-unsafe-attributes.rs:3:3
    |
-LL | #[unsafe(cfg(any()))]
+LL | #[unsafe(cfg(false))]
    |   ^^^^^^ this is not an unsafe attribute
    |
    = note: extraneous unsafe is not allowed in attributes
@@ -9,7 +9,7 @@ LL | #[unsafe(cfg(any()))]
 error: `cfg_attr` is not an unsafe attribute
   --> $DIR/extraneous-unsafe-attributes.rs:6:3
    |
-LL | #[unsafe(cfg_attr(any(), allow(dead_code)))]
+LL | #[unsafe(cfg_attr(false, allow(dead_code)))]
    |   ^^^^^^ this is not an unsafe attribute
    |
    = note: extraneous unsafe is not allowed in attributes

--- a/tests/ui/attributes/unsafe/unsafe-attributes.rs
+++ b/tests/ui/attributes/unsafe/unsafe-attributes.rs
@@ -6,7 +6,7 @@ fn a() {}
 #[unsafe(export_name = "foo")]
 fn b() {}
 
-#[cfg_attr(any(), unsafe(no_mangle))]
+#[cfg_attr(false, unsafe(no_mangle))]
 static VAR2: u32 = 1;
 
 fn main() {}

--- a/tests/ui/cfg/conditional-compilation-struct-11085.rs
+++ b/tests/ui/cfg/conditional-compilation-struct-11085.rs
@@ -11,7 +11,7 @@ struct Foo {
 }
 
 struct Foo2 {
-    #[cfg(all())]
+    #[cfg(true)]
     foo: isize,
 }
 

--- a/tests/ui/cfg/conditional-compile.rs
+++ b/tests/ui/cfg/conditional-compile.rs
@@ -151,5 +151,5 @@ mod test_methods {
     }
 }
 
-#[cfg(any())]
+#[cfg(false)]
 mod nonexistent_file; // Check that unconfigured non-inline modules are not loaded or parsed.

--- a/tests/ui/cfg/nested-cfg-attr-conditional-compilation.rs
+++ b/tests/ui/cfg/nested-cfg-attr-conditional-compilation.rs
@@ -3,14 +3,14 @@
 //! expansion works from outside to inside, eventually applying the innermost
 //! conditional compilation directive.
 //!
-//! In this test, `cfg_attr(all(), cfg_attr(all(), cfg(false)))` should expand to:
-//! 1. `cfg_attr(all(), cfg(false))` (outer cfg_attr applied)
+//! In this test, `cfg_attr(true, cfg_attr(true, cfg(false)))` should expand to:
+//! 1. `cfg_attr(true, cfg(false))` (outer cfg_attr applied)
 //! 2. `cfg(false)` (inner cfg_attr applied)
 //! 3. Function `f` is excluded from compilation
 //!
 //! Added in <https://github.com/rust-lang/rust/pull/34216>.
 
-#[cfg_attr(all(), cfg_attr(all(), cfg(false)))] //~ NOTE the item is gated here
+#[cfg_attr(true, cfg_attr(true, cfg(false)))] //~ NOTE the item is gated here
 fn f() {} //~ NOTE found an item that was configured out
 
 fn main() {

--- a/tests/ui/cfg/nested-cfg-attr-conditional-compilation.stderr
+++ b/tests/ui/cfg/nested-cfg-attr-conditional-compilation.stderr
@@ -7,8 +7,8 @@ LL |     f()
 note: found an item that was configured out
   --> $DIR/nested-cfg-attr-conditional-compilation.rs:14:4
    |
-LL | #[cfg_attr(all(), cfg_attr(all(), cfg(false)))]
-   |                                       ----- the item is gated here
+LL | #[cfg_attr(true, cfg_attr(true, cfg(false)))]
+   |                                     ----- the item is gated here
 LL | fn f() {}
    |    ^
 

--- a/tests/ui/coherence/coherence-cow.rs
+++ b/tests/ui/coherence/coherence-cow.rs
@@ -1,6 +1,6 @@
 //@ revisions: re_a re_b re_c
 
-#![cfg_attr(any(), re_a, re_b, re_c)]
+#![cfg_attr(false, re_a, re_b, re_c)]
 
 //@ aux-build:coherence_lib.rs
 

--- a/tests/ui/conditional-compilation/cfg-attr-multi-false.rs
+++ b/tests/ui/conditional-compilation/cfg-attr-multi-false.rs
@@ -5,7 +5,7 @@
 
 #![warn(unused_must_use)]
 
-#[cfg_attr(any(), deprecated, must_use)]
+#[cfg_attr(false, deprecated, must_use)]
 struct Struct {}
 
 impl Struct {

--- a/tests/ui/conditional-compilation/cfg-attr-multi-true.rs
+++ b/tests/ui/conditional-compilation/cfg-attr-multi-true.rs
@@ -6,7 +6,7 @@
 
 #![warn(unused_must_use)]
 
-#[cfg_attr(all(), deprecated, must_use)]
+#[cfg_attr(true, deprecated, must_use)]
 struct MustUseDeprecated {}
 
 impl MustUseDeprecated { //~ warning: use of deprecated

--- a/tests/ui/conditional-compilation/cfg-attr-parse.rs
+++ b/tests/ui/conditional-compilation/cfg-attr-parse.rs
@@ -5,50 +5,50 @@
 struct NoConfigurationPredicate;
 
 // Zero attributes, zero trailing comma (comma manatory here)
-#[cfg_attr(all())] //~ error: expected `,`, found end of `cfg_attr`
+#[cfg_attr(true)] //~ error: expected `,`, found end of `cfg_attr`
 struct A0C0;
 
 // Zero attributes, one trailing comma
-#[cfg_attr(all(),)]
+#[cfg_attr(true,)]
 //~^ WARN `#[cfg_attr]` does not expand to any attributes
 struct A0C1;
 
 // Zero attributes, two trailing commas
-#[cfg_attr(all(),,)] //~ ERROR expected identifier
+#[cfg_attr(true,,)] //~ ERROR expected identifier
 struct A0C2;
 
 // One attribute, no trailing comma
-#[cfg_attr(all(), must_use)] // Ok
+#[cfg_attr(true, must_use)] // Ok
 struct A1C0;
 
 // One attribute, one trailing comma
-#[cfg_attr(all(), must_use,)] // Ok
+#[cfg_attr(true, must_use,)] // Ok
 struct A1C1;
 
 // One attribute, two trailing commas
-#[cfg_attr(all(), must_use,,)] //~ ERROR expected identifier
+#[cfg_attr(true, must_use,,)] //~ ERROR expected identifier
 struct A1C2;
 
 // Two attributes, no trailing comma
-#[cfg_attr(all(), must_use, deprecated)] // Ok
+#[cfg_attr(true, must_use, deprecated)] // Ok
 struct A2C0;
 
 // Two attributes, one trailing comma
-#[cfg_attr(all(), must_use, deprecated,)] // Ok
+#[cfg_attr(true, must_use, deprecated,)] // Ok
 struct A2C1;
 
 // Two attributes, two trailing commas
-#[cfg_attr(all(), must_use, deprecated,,)] //~ ERROR expected identifier
+#[cfg_attr(true, must_use, deprecated,,)] //~ ERROR expected identifier
 struct A2C2;
 
 // Wrong delimiter `[`
-#[cfg_attr[all(),,]]
+#[cfg_attr[true,,]]
 //~^ ERROR wrong `cfg_attr` delimiters
 //~| ERROR expected identifier, found `,`
 struct BracketZero;
 
 // Wrong delimiter `{`
-#[cfg_attr{all(),,}]
+#[cfg_attr{true,,}]
 //~^ ERROR wrong `cfg_attr` delimiters
 //~| ERROR expected identifier, found `,`
 struct BraceZero;

--- a/tests/ui/conditional-compilation/cfg-attr-parse.stderr
+++ b/tests/ui/conditional-compilation/cfg-attr-parse.stderr
@@ -10,45 +10,45 @@ LL | #[cfg_attr()]
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute>
 
 error: expected `,`, found end of `cfg_attr` input
-  --> $DIR/cfg-attr-parse.rs:8:17
+  --> $DIR/cfg-attr-parse.rs:8:16
    |
-LL | #[cfg_attr(all())]
-   | ----------------^-
+LL | #[cfg_attr(true)]
+   | ---------------^-
+   | |              |
+   | |              expected `,`
+   | help: must be of the form: `#[cfg_attr(predicate, attr1, attr2, ...)]`
+   |
+   = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute>
+
+error: expected identifier, found `,`
+  --> $DIR/cfg-attr-parse.rs:17:17
+   |
+LL | #[cfg_attr(true,,)]
+   | ----------------^--
    | |               |
-   | |               expected `,`
+   | |               expected identifier
    | help: must be of the form: `#[cfg_attr(predicate, attr1, attr2, ...)]`
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute>
 
 error: expected identifier, found `,`
-  --> $DIR/cfg-attr-parse.rs:17:18
+  --> $DIR/cfg-attr-parse.rs:29:27
    |
-LL | #[cfg_attr(all(),,)]
-   | -----------------^--
-   | |                |
-   | |                expected identifier
+LL | #[cfg_attr(true, must_use,,)]
+   | --------------------------^--
+   | |                         |
+   | |                         expected identifier
    | help: must be of the form: `#[cfg_attr(predicate, attr1, attr2, ...)]`
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute>
 
 error: expected identifier, found `,`
-  --> $DIR/cfg-attr-parse.rs:29:28
+  --> $DIR/cfg-attr-parse.rs:41:39
    |
-LL | #[cfg_attr(all(), must_use,,)]
-   | ---------------------------^--
-   | |                          |
-   | |                          expected identifier
-   | help: must be of the form: `#[cfg_attr(predicate, attr1, attr2, ...)]`
-   |
-   = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute>
-
-error: expected identifier, found `,`
-  --> $DIR/cfg-attr-parse.rs:41:40
-   |
-LL | #[cfg_attr(all(), must_use, deprecated,,)]
-   | ---------------------------------------^--
-   | |                                      |
-   | |                                      expected identifier
+LL | #[cfg_attr(true, must_use, deprecated,,)]
+   | --------------------------------------^--
+   | |                                     |
+   | |                                     expected identifier
    | help: must be of the form: `#[cfg_attr(predicate, attr1, attr2, ...)]`
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute>
@@ -56,22 +56,22 @@ LL | #[cfg_attr(all(), must_use, deprecated,,)]
 error: wrong `cfg_attr` delimiters
   --> $DIR/cfg-attr-parse.rs:45:11
    |
-LL | #[cfg_attr[all(),,]]
-   |           ^^^^^^^^^
+LL | #[cfg_attr[true,,]]
+   |           ^^^^^^^^
    |
 help: the delimiters should be `(` and `)`
    |
-LL - #[cfg_attr[all(),,]]
-LL + #[cfg_attr(all(),,)]
+LL - #[cfg_attr[true,,]]
+LL + #[cfg_attr(true,,)]
    |
 
 error: expected identifier, found `,`
-  --> $DIR/cfg-attr-parse.rs:45:18
+  --> $DIR/cfg-attr-parse.rs:45:17
    |
-LL | #[cfg_attr[all(),,]]
-   | -----------------^--
-   | |                |
-   | |                expected identifier
+LL | #[cfg_attr[true,,]]
+   | ----------------^--
+   | |               |
+   | |               expected identifier
    | help: must be of the form: `#[cfg_attr(predicate, attr1, attr2, ...)]`
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute>
@@ -79,22 +79,22 @@ LL | #[cfg_attr[all(),,]]
 error: wrong `cfg_attr` delimiters
   --> $DIR/cfg-attr-parse.rs:51:11
    |
-LL | #[cfg_attr{all(),,}]
-   |           ^^^^^^^^^
+LL | #[cfg_attr{true,,}]
+   |           ^^^^^^^^
    |
 help: the delimiters should be `(` and `)`
    |
-LL - #[cfg_attr{all(),,}]
-LL + #[cfg_attr(all(),,)]
+LL - #[cfg_attr{true,,}]
+LL + #[cfg_attr(true,,)]
    |
 
 error: expected identifier, found `,`
-  --> $DIR/cfg-attr-parse.rs:51:18
+  --> $DIR/cfg-attr-parse.rs:51:17
    |
-LL | #[cfg_attr{all(),,}]
-   | -----------------^--
-   | |                |
-   | |                expected identifier
+LL | #[cfg_attr{true,,}]
+   | ----------------^--
+   | |               |
+   | |               expected identifier
    | help: must be of the form: `#[cfg_attr(predicate, attr1, attr2, ...)]`
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute>
@@ -102,8 +102,8 @@ LL | #[cfg_attr{all(),,}]
 warning: `#[cfg_attr]` does not expand to any attributes
   --> $DIR/cfg-attr-parse.rs:12:1
    |
-LL | #[cfg_attr(all(),)]
-   | ^^^^^^^^^^^^^^^^^^^
+LL | #[cfg_attr(true,)]
+   | ^^^^^^^^^^^^^^^^^^
    |
    = note: requested on the command line with `-W unused-attributes`
 

--- a/tests/ui/conditional-compilation/cfg-attr-unknown-attribute-macro-expansion.rs
+++ b/tests/ui/conditional-compilation/cfg-attr-unknown-attribute-macro-expansion.rs
@@ -1,6 +1,6 @@
 macro_rules! foo {
     () => {
-        #[cfg_attr(all(), unknown)]
+        #[cfg_attr(true, unknown)]
         //~^ ERROR cannot find attribute `unknown` in this scope
         fn foo() {}
     }

--- a/tests/ui/conditional-compilation/cfg-attr-unknown-attribute-macro-expansion.stderr
+++ b/tests/ui/conditional-compilation/cfg-attr-unknown-attribute-macro-expansion.stderr
@@ -1,8 +1,8 @@
 error: cannot find attribute `unknown` in this scope
-  --> $DIR/cfg-attr-unknown-attribute-macro-expansion.rs:3:27
+  --> $DIR/cfg-attr-unknown-attribute-macro-expansion.rs:3:26
    |
-LL |         #[cfg_attr(all(), unknown)]
-   |                           ^^^^^^^
+LL |         #[cfg_attr(true, unknown)]
+   |                          ^^^^^^^
 ...
 LL | foo!();
    | ------ in this macro invocation

--- a/tests/ui/conditional-compilation/cfg-empty-any-all.rs
+++ b/tests/ui/conditional-compilation/cfg-empty-any-all.rs
@@ -1,0 +1,12 @@
+//! Test the behaviour of `cfg(any())` and `cfg(all())`
+
+#[cfg(any())]  // Equivalent to cfg(false)
+struct Disabled;
+
+#[cfg(all())]  // Equivalent to cfg(true)
+struct Enabled;
+
+fn main() {
+    let _ = Disabled; //~ ERROR: cannot find value `Disabled`
+    let _ = Enabled;  //  ok
+}

--- a/tests/ui/conditional-compilation/cfg-empty-any-all.stderr
+++ b/tests/ui/conditional-compilation/cfg-empty-any-all.stderr
@@ -1,0 +1,21 @@
+error[E0425]: cannot find value `Disabled` in this scope
+  --> $DIR/cfg-empty-any-all.rs:10:13
+   |
+LL |     let _ = Disabled;
+   |             ^^^^^^^^ not found in this scope
+   |
+note: found an item that was configured out
+  --> $DIR/cfg-empty-any-all.rs:4:8
+   |
+LL | #[cfg(any())]  // Equivalent to cfg(false)
+   |          -- the item is gated here
+LL | struct Disabled;
+   |        ^^^^^^^^
+help: consider importing this unit variant
+   |
+LL + use std::backtrace::BacktraceStatus::Disabled;
+   |
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/conditional-compilation/cfg_attr_path.rs
+++ b/tests/ui/conditional-compilation/cfg_attr_path.rs
@@ -3,8 +3,8 @@
 #![deny(unused_attributes)] // c.f #35584
 
 mod auxiliary {
-    #[cfg_attr(any(), path = "nonexistent_file.rs")] pub mod namespaced_enums;
-    #[cfg_attr(all(), path = "namespaced_enums.rs")] pub mod nonexistent_file;
+    #[cfg_attr(false, path = "nonexistent_file.rs")] pub mod namespaced_enums;
+    #[cfg_attr(true, path = "namespaced_enums.rs")] pub mod nonexistent_file;
 }
 
 fn main() {

--- a/tests/ui/conditional-compilation/issue-34028.rs
+++ b/tests/ui/conditional-compilation/issue-34028.rs
@@ -1,7 +1,7 @@
 //@ check-pass
 
 macro_rules! m {
-    () => { #[cfg(any())] fn f() {} }
+    () => { #[cfg(false)] fn f() {} }
 }
 
 trait T {}

--- a/tests/ui/conditional-compilation/module_with_cfg.rs
+++ b/tests/ui/conditional-compilation/module_with_cfg.rs
@@ -1,3 +1,3 @@
 //@ ignore-auxiliary (used by `./inner-cfg-non-inline-mod.rs`)
 
-#![cfg_attr(all(), cfg(false))]
+#![cfg_attr(true, cfg(false))]

--- a/tests/ui/coroutine/static-closure-unexpanded.rs
+++ b/tests/ui/coroutine/static-closure-unexpanded.rs
@@ -1,7 +1,7 @@
 // Tests that static closures are not stable in the parser grammar unless the
 // coroutine feature is enabled.
 
-#[cfg(any())]
+#[cfg(false)]
 fn foo() {
     let _ = static || {};
     //~^ ERROR coroutine syntax is experimental

--- a/tests/ui/feature-gates/feature-gate-pin_ergonomics.rs
+++ b/tests/ui/feature-gates/feature-gate-pin_ergonomics.rs
@@ -58,7 +58,7 @@ fn patterns<'a>(
     ref pin const w: i32, //~ ERROR pinned reference syntax is experimental
 ) {}
 
-#[cfg(any())]
+#[cfg(false)]
 mod not_compiled {
     use std::pin::Pin;
 

--- a/tests/ui/feature-gates/feature-gate-super-let.rs
+++ b/tests/ui/feature-gates/feature-gate-super-let.rs
@@ -4,7 +4,7 @@ fn main() {
 }
 
 // Check that it also isn't accepted in cfg'd out code.
-#[cfg(any())]
+#[cfg(false)]
 fn a() {
     super let a = 1;
     //~^ ERROR `super let` is experimental

--- a/tests/ui/feature-gates/feature-gate-unsafe-binders.rs
+++ b/tests/ui/feature-gates/feature-gate-unsafe-binders.rs
@@ -1,4 +1,4 @@
-#[cfg(any())]
+#[cfg(false)]
 fn test() {
     let x: unsafe<> ();
     //~^ ERROR unsafe binder types are experimental

--- a/tests/ui/feature-gates/feature-gate-unsafe_fields.rs
+++ b/tests/ui/feature-gates/feature-gate-unsafe_fields.rs
@@ -4,7 +4,7 @@
 
 #![cfg_attr(with_gate, feature(unsafe_fields))] //[with_gate]~ WARNING
 
-#[cfg(any())]
+#[cfg(false)]
 struct Foo {
     unsafe field: (), //[without_gate]~ ERROR
 }
@@ -12,14 +12,14 @@ struct Foo {
 // This should not parse as an unsafe field definition.
 struct FooTuple(unsafe fn());
 
-#[cfg(any())]
+#[cfg(false)]
 enum Bar {
     Variant { unsafe field: () }, //[without_gate]~ ERROR
     // This should not parse as an unsafe field definition.
     VariantTuple(unsafe fn()),
 }
 
-#[cfg(any())]
+#[cfg(false)]
 union Baz {
     unsafe field: (), //[without_gate]~ ERROR
 }

--- a/tests/ui/feature-gates/feature-gate-where_clause_attrs.a.stderr
+++ b/tests/ui/feature-gates/feature-gate-where_clause_attrs.a.stderr
@@ -21,8 +21,8 @@ LL |     #[cfg(b)] T: TraitB,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:35:5
    |
-LL |     #[cfg(all())] T: TraitAll,
-   |     ^^^^^^^^^^^^^
+LL |     #[cfg(true)] T: TraitAll,
+   |     ^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
    = help: add `#![feature(where_clause_attrs)]` to the crate attributes to enable
@@ -31,7 +31,7 @@ LL |     #[cfg(all())] T: TraitAll,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:36:5
    |
-LL |     #[cfg(any())] T: TraitAny,
+LL |     #[cfg(false)] T: TraitAny,
    |     ^^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
@@ -61,8 +61,8 @@ LL |     #[cfg_attr(b, cfg(b))] T: TraitBB,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:39:5
    |
-LL |     #[cfg_attr(all(), cfg(all()))] T: TraitAllAll,
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     #[cfg_attr(true, cfg(true))] T: TraitAllAll,
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
    = help: add `#![feature(where_clause_attrs)]` to the crate attributes to enable
@@ -71,7 +71,7 @@ LL |     #[cfg_attr(all(), cfg(all()))] T: TraitAllAll,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:40:5
    |
-LL |     #[cfg_attr(any(), cfg(any()))] T: TraitAnyAny,
+LL |     #[cfg_attr(false, cfg(false))] T: TraitAnyAny,
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
@@ -101,8 +101,8 @@ LL |         #[cfg(b)] U: TraitB,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:46:9
    |
-LL |         #[cfg(all())] U: TraitAll,
-   |         ^^^^^^^^^^^^^
+LL |         #[cfg(true)] U: TraitAll,
+   |         ^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
    = help: add `#![feature(where_clause_attrs)]` to the crate attributes to enable
@@ -111,7 +111,7 @@ LL |         #[cfg(all())] U: TraitAll,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:47:9
    |
-LL |         #[cfg(any())] U: TraitAny,
+LL |         #[cfg(false)] U: TraitAny,
    |         ^^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
@@ -141,8 +141,8 @@ LL |         #[cfg_attr(b, cfg(b))] U: TraitBB,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:50:9
    |
-LL |         #[cfg_attr(all(), cfg(all()))] U: TraitAllAll,
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         #[cfg_attr(true, cfg(true))] U: TraitAllAll,
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
    = help: add `#![feature(where_clause_attrs)]` to the crate attributes to enable
@@ -151,7 +151,7 @@ LL |         #[cfg_attr(all(), cfg(all()))] U: TraitAllAll,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:51:9
    |
-LL |         #[cfg_attr(any(), cfg(any()))] U: TraitAnyAny;
+LL |         #[cfg_attr(false, cfg(false))] U: TraitAnyAny;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
@@ -181,8 +181,8 @@ LL |         #[cfg(b)] U: TraitB,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:57:9
    |
-LL |         #[cfg(all())] U: TraitAll,
-   |         ^^^^^^^^^^^^^
+LL |         #[cfg(true)] U: TraitAll,
+   |         ^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
    = help: add `#![feature(where_clause_attrs)]` to the crate attributes to enable
@@ -191,7 +191,7 @@ LL |         #[cfg(all())] U: TraitAll,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:58:9
    |
-LL |         #[cfg(any())] U: TraitAny,
+LL |         #[cfg(false)] U: TraitAny,
    |         ^^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
@@ -221,8 +221,8 @@ LL |         #[cfg_attr(b, cfg(b))] U: TraitBB,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:61:9
    |
-LL |         #[cfg_attr(all(), cfg(all()))] U: TraitAllAll,
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         #[cfg_attr(true, cfg(true))] U: TraitAllAll,
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
    = help: add `#![feature(where_clause_attrs)]` to the crate attributes to enable
@@ -231,7 +231,7 @@ LL |         #[cfg_attr(all(), cfg(all()))] U: TraitAllAll,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:62:9
    |
-LL |         #[cfg_attr(any(), cfg(any()))] U: TraitAnyAny;
+LL |         #[cfg_attr(false, cfg(false))] U: TraitAnyAny;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
@@ -261,8 +261,8 @@ LL |     #[cfg(b)] T: TraitB,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:69:5
    |
-LL |     #[cfg(all())] T: TraitAll,
-   |     ^^^^^^^^^^^^^
+LL |     #[cfg(true)] T: TraitAll,
+   |     ^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
    = help: add `#![feature(where_clause_attrs)]` to the crate attributes to enable
@@ -271,7 +271,7 @@ LL |     #[cfg(all())] T: TraitAll,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:70:5
    |
-LL |     #[cfg(any())] T: TraitAny,
+LL |     #[cfg(false)] T: TraitAny,
    |     ^^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
@@ -301,8 +301,8 @@ LL |     #[cfg_attr(b, cfg(b))] T: TraitBB,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:73:5
    |
-LL |     #[cfg_attr(all(), cfg(all()))] T: TraitAllAll,
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     #[cfg_attr(true, cfg(true))] T: TraitAllAll,
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
    = help: add `#![feature(where_clause_attrs)]` to the crate attributes to enable
@@ -311,7 +311,7 @@ LL |     #[cfg_attr(all(), cfg(all()))] T: TraitAllAll,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:74:5
    |
-LL |     #[cfg_attr(any(), cfg(any()))] T: TraitAnyAny,
+LL |     #[cfg_attr(false, cfg(false))] T: TraitAnyAny,
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
@@ -341,8 +341,8 @@ LL |         #[cfg(b)] U: TraitB,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:79:9
    |
-LL |         #[cfg(all())] U: TraitAll,
-   |         ^^^^^^^^^^^^^
+LL |         #[cfg(true)] U: TraitAll,
+   |         ^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
    = help: add `#![feature(where_clause_attrs)]` to the crate attributes to enable
@@ -351,7 +351,7 @@ LL |         #[cfg(all())] U: TraitAll,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:80:9
    |
-LL |         #[cfg(any())] U: TraitAny,
+LL |         #[cfg(false)] U: TraitAny,
    |         ^^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
@@ -381,8 +381,8 @@ LL |         #[cfg_attr(b, cfg(b))] U: TraitBB,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:83:9
    |
-LL |         #[cfg_attr(all(), cfg(all()))] U: TraitAllAll,
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         #[cfg_attr(true, cfg(true))] U: TraitAllAll,
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
    = help: add `#![feature(where_clause_attrs)]` to the crate attributes to enable
@@ -391,7 +391,7 @@ LL |         #[cfg_attr(all(), cfg(all()))] U: TraitAllAll,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:84:9
    |
-LL |         #[cfg_attr(any(), cfg(any()))] U: TraitAnyAny;
+LL |         #[cfg_attr(false, cfg(false))] U: TraitAnyAny;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
@@ -421,8 +421,8 @@ LL |         #[cfg(b)] U: TraitB,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:90:9
    |
-LL |         #[cfg(all())] T: TraitAll,
-   |         ^^^^^^^^^^^^^
+LL |         #[cfg(true)] T: TraitAll,
+   |         ^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
    = help: add `#![feature(where_clause_attrs)]` to the crate attributes to enable
@@ -431,7 +431,7 @@ LL |         #[cfg(all())] T: TraitAll,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:91:9
    |
-LL |         #[cfg(any())] T: TraitAny,
+LL |         #[cfg(false)] T: TraitAny,
    |         ^^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
@@ -461,8 +461,8 @@ LL |         #[cfg_attr(b, cfg(b))] U: TraitBB,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:94:9
    |
-LL |         #[cfg_attr(all(), cfg(all()))] T: TraitAllAll,
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         #[cfg_attr(true, cfg(true))] T: TraitAllAll,
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
    = help: add `#![feature(where_clause_attrs)]` to the crate attributes to enable
@@ -471,7 +471,7 @@ LL |         #[cfg_attr(all(), cfg(all()))] T: TraitAllAll,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:95:9
    |
-LL |         #[cfg_attr(any(), cfg(any()))] T: TraitAnyAny,
+LL |         #[cfg_attr(false, cfg(false))] T: TraitAnyAny,
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
@@ -501,8 +501,8 @@ LL |     #[cfg(b)] T: TraitB,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:103:5
    |
-LL |     #[cfg(all())] T: TraitAll,
-   |     ^^^^^^^^^^^^^
+LL |     #[cfg(true)] T: TraitAll,
+   |     ^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
    = help: add `#![feature(where_clause_attrs)]` to the crate attributes to enable
@@ -511,7 +511,7 @@ LL |     #[cfg(all())] T: TraitAll,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:104:5
    |
-LL |     #[cfg(any())] T: TraitAny,
+LL |     #[cfg(false)] T: TraitAny,
    |     ^^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
@@ -541,8 +541,8 @@ LL |     #[cfg_attr(b, cfg(b))] T: TraitBB,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:107:5
    |
-LL |     #[cfg_attr(all(), cfg(all()))] T: TraitAllAll,
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     #[cfg_attr(true, cfg(true))] T: TraitAllAll,
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
    = help: add `#![feature(where_clause_attrs)]` to the crate attributes to enable
@@ -551,7 +551,7 @@ LL |     #[cfg_attr(all(), cfg(all()))] T: TraitAllAll,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:108:5
    |
-LL |     #[cfg_attr(any(), cfg(any()))] T: TraitAnyAny,
+LL |     #[cfg_attr(false, cfg(false))] T: TraitAnyAny,
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
@@ -581,8 +581,8 @@ LL |     #[cfg(b)] T: TraitB,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:117:5
    |
-LL |     #[cfg(all())] T: TraitAll,
-   |     ^^^^^^^^^^^^^
+LL |     #[cfg(true)] T: TraitAll,
+   |     ^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
    = help: add `#![feature(where_clause_attrs)]` to the crate attributes to enable
@@ -591,7 +591,7 @@ LL |     #[cfg(all())] T: TraitAll,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:118:5
    |
-LL |     #[cfg(any())] T: TraitAny,
+LL |     #[cfg(false)] T: TraitAny,
    |     ^^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
@@ -621,8 +621,8 @@ LL |     #[cfg_attr(b, cfg(b))] T: TraitBB,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:121:5
    |
-LL |     #[cfg_attr(all(), cfg(all()))] T: TraitAllAll,
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     #[cfg_attr(true, cfg(true))] T: TraitAllAll,
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
    = help: add `#![feature(where_clause_attrs)]` to the crate attributes to enable
@@ -631,7 +631,7 @@ LL |     #[cfg_attr(all(), cfg(all()))] T: TraitAllAll,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:122:5
    |
-LL |     #[cfg_attr(any(), cfg(any()))] T: TraitAnyAny,
+LL |     #[cfg_attr(false, cfg(false))] T: TraitAnyAny,
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
@@ -661,8 +661,8 @@ LL |     #[cfg(b)] T: TraitB,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:132:5
    |
-LL |     #[cfg(all())] T: TraitAll,
-   |     ^^^^^^^^^^^^^
+LL |     #[cfg(true)] T: TraitAll,
+   |     ^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
    = help: add `#![feature(where_clause_attrs)]` to the crate attributes to enable
@@ -671,7 +671,7 @@ LL |     #[cfg(all())] T: TraitAll,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:133:5
    |
-LL |     #[cfg(any())] T: TraitAny,
+LL |     #[cfg(false)] T: TraitAny,
    |     ^^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
@@ -701,8 +701,8 @@ LL |     #[cfg_attr(b, cfg(b))] T: TraitBB,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:136:5
    |
-LL |     #[cfg_attr(all(), cfg(all()))] T: TraitAllAll,
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     #[cfg_attr(true, cfg(true))] T: TraitAllAll,
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
    = help: add `#![feature(where_clause_attrs)]` to the crate attributes to enable
@@ -711,7 +711,7 @@ LL |     #[cfg_attr(all(), cfg(all()))] T: TraitAllAll,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:137:5
    |
-LL |     #[cfg_attr(any(), cfg(any()))] T: TraitAnyAny,
+LL |     #[cfg_attr(false, cfg(false))] T: TraitAnyAny,
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
@@ -741,8 +741,8 @@ LL |     #[cfg(b)] T: TraitB,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:145:5
    |
-LL |     #[cfg(all())] T: TraitAll,
-   |     ^^^^^^^^^^^^^
+LL |     #[cfg(true)] T: TraitAll,
+   |     ^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
    = help: add `#![feature(where_clause_attrs)]` to the crate attributes to enable
@@ -751,7 +751,7 @@ LL |     #[cfg(all())] T: TraitAll,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:146:5
    |
-LL |     #[cfg(any())] T: TraitAny,
+LL |     #[cfg(false)] T: TraitAny,
    |     ^^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
@@ -781,8 +781,8 @@ LL |     #[cfg_attr(b, cfg(b))] T: TraitBB,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:149:5
    |
-LL |     #[cfg_attr(all(), cfg(all()))] T: TraitAllAll,
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     #[cfg_attr(true, cfg(true))] T: TraitAllAll,
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
    = help: add `#![feature(where_clause_attrs)]` to the crate attributes to enable
@@ -791,7 +791,7 @@ LL |     #[cfg_attr(all(), cfg(all()))] T: TraitAllAll,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:150:5
    |
-LL |     #[cfg_attr(any(), cfg(any()))] T: TraitAnyAny,
+LL |     #[cfg_attr(false, cfg(false))] T: TraitAnyAny,
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
@@ -821,8 +821,8 @@ LL |         #[cfg(b)] U: TraitB,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:155:9
    |
-LL |         #[cfg(all())] U: TraitAll,
-   |         ^^^^^^^^^^^^^
+LL |         #[cfg(true)] U: TraitAll,
+   |         ^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
    = help: add `#![feature(where_clause_attrs)]` to the crate attributes to enable
@@ -831,7 +831,7 @@ LL |         #[cfg(all())] U: TraitAll,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:156:9
    |
-LL |         #[cfg(any())] U: TraitAny,
+LL |         #[cfg(false)] U: TraitAny,
    |         ^^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
@@ -861,8 +861,8 @@ LL |         #[cfg_attr(b, cfg(b))] U: TraitBB,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:159:9
    |
-LL |         #[cfg_attr(all(), cfg(all()))] U: TraitAllAll,
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         #[cfg_attr(true, cfg(true))] U: TraitAllAll,
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
    = help: add `#![feature(where_clause_attrs)]` to the crate attributes to enable
@@ -871,7 +871,7 @@ LL |         #[cfg_attr(all(), cfg(all()))] U: TraitAllAll,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:160:9
    |
-LL |         #[cfg_attr(any(), cfg(any()))] U: TraitAnyAny,
+LL |         #[cfg_attr(false, cfg(false))] U: TraitAnyAny,
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information

--- a/tests/ui/feature-gates/feature-gate-where_clause_attrs.b.stderr
+++ b/tests/ui/feature-gates/feature-gate-where_clause_attrs.b.stderr
@@ -21,8 +21,8 @@ LL |     #[cfg(b)] T: TraitB,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:35:5
    |
-LL |     #[cfg(all())] T: TraitAll,
-   |     ^^^^^^^^^^^^^
+LL |     #[cfg(true)] T: TraitAll,
+   |     ^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
    = help: add `#![feature(where_clause_attrs)]` to the crate attributes to enable
@@ -31,7 +31,7 @@ LL |     #[cfg(all())] T: TraitAll,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:36:5
    |
-LL |     #[cfg(any())] T: TraitAny,
+LL |     #[cfg(false)] T: TraitAny,
    |     ^^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
@@ -61,8 +61,8 @@ LL |     #[cfg_attr(b, cfg(b))] T: TraitBB,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:39:5
    |
-LL |     #[cfg_attr(all(), cfg(all()))] T: TraitAllAll,
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     #[cfg_attr(true, cfg(true))] T: TraitAllAll,
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
    = help: add `#![feature(where_clause_attrs)]` to the crate attributes to enable
@@ -71,7 +71,7 @@ LL |     #[cfg_attr(all(), cfg(all()))] T: TraitAllAll,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:40:5
    |
-LL |     #[cfg_attr(any(), cfg(any()))] T: TraitAnyAny,
+LL |     #[cfg_attr(false, cfg(false))] T: TraitAnyAny,
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
@@ -101,8 +101,8 @@ LL |         #[cfg(b)] U: TraitB,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:46:9
    |
-LL |         #[cfg(all())] U: TraitAll,
-   |         ^^^^^^^^^^^^^
+LL |         #[cfg(true)] U: TraitAll,
+   |         ^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
    = help: add `#![feature(where_clause_attrs)]` to the crate attributes to enable
@@ -111,7 +111,7 @@ LL |         #[cfg(all())] U: TraitAll,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:47:9
    |
-LL |         #[cfg(any())] U: TraitAny,
+LL |         #[cfg(false)] U: TraitAny,
    |         ^^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
@@ -141,8 +141,8 @@ LL |         #[cfg_attr(b, cfg(b))] U: TraitBB,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:50:9
    |
-LL |         #[cfg_attr(all(), cfg(all()))] U: TraitAllAll,
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         #[cfg_attr(true, cfg(true))] U: TraitAllAll,
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
    = help: add `#![feature(where_clause_attrs)]` to the crate attributes to enable
@@ -151,7 +151,7 @@ LL |         #[cfg_attr(all(), cfg(all()))] U: TraitAllAll,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:51:9
    |
-LL |         #[cfg_attr(any(), cfg(any()))] U: TraitAnyAny;
+LL |         #[cfg_attr(false, cfg(false))] U: TraitAnyAny;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
@@ -181,8 +181,8 @@ LL |         #[cfg(b)] U: TraitB,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:57:9
    |
-LL |         #[cfg(all())] U: TraitAll,
-   |         ^^^^^^^^^^^^^
+LL |         #[cfg(true)] U: TraitAll,
+   |         ^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
    = help: add `#![feature(where_clause_attrs)]` to the crate attributes to enable
@@ -191,7 +191,7 @@ LL |         #[cfg(all())] U: TraitAll,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:58:9
    |
-LL |         #[cfg(any())] U: TraitAny,
+LL |         #[cfg(false)] U: TraitAny,
    |         ^^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
@@ -221,8 +221,8 @@ LL |         #[cfg_attr(b, cfg(b))] U: TraitBB,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:61:9
    |
-LL |         #[cfg_attr(all(), cfg(all()))] U: TraitAllAll,
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         #[cfg_attr(true, cfg(true))] U: TraitAllAll,
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
    = help: add `#![feature(where_clause_attrs)]` to the crate attributes to enable
@@ -231,7 +231,7 @@ LL |         #[cfg_attr(all(), cfg(all()))] U: TraitAllAll,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:62:9
    |
-LL |         #[cfg_attr(any(), cfg(any()))] U: TraitAnyAny;
+LL |         #[cfg_attr(false, cfg(false))] U: TraitAnyAny;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
@@ -261,8 +261,8 @@ LL |     #[cfg(b)] T: TraitB,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:69:5
    |
-LL |     #[cfg(all())] T: TraitAll,
-   |     ^^^^^^^^^^^^^
+LL |     #[cfg(true)] T: TraitAll,
+   |     ^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
    = help: add `#![feature(where_clause_attrs)]` to the crate attributes to enable
@@ -271,7 +271,7 @@ LL |     #[cfg(all())] T: TraitAll,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:70:5
    |
-LL |     #[cfg(any())] T: TraitAny,
+LL |     #[cfg(false)] T: TraitAny,
    |     ^^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
@@ -301,8 +301,8 @@ LL |     #[cfg_attr(b, cfg(b))] T: TraitBB,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:73:5
    |
-LL |     #[cfg_attr(all(), cfg(all()))] T: TraitAllAll,
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     #[cfg_attr(true, cfg(true))] T: TraitAllAll,
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
    = help: add `#![feature(where_clause_attrs)]` to the crate attributes to enable
@@ -311,7 +311,7 @@ LL |     #[cfg_attr(all(), cfg(all()))] T: TraitAllAll,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:74:5
    |
-LL |     #[cfg_attr(any(), cfg(any()))] T: TraitAnyAny,
+LL |     #[cfg_attr(false, cfg(false))] T: TraitAnyAny,
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
@@ -341,8 +341,8 @@ LL |         #[cfg(b)] U: TraitB,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:79:9
    |
-LL |         #[cfg(all())] U: TraitAll,
-   |         ^^^^^^^^^^^^^
+LL |         #[cfg(true)] U: TraitAll,
+   |         ^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
    = help: add `#![feature(where_clause_attrs)]` to the crate attributes to enable
@@ -351,7 +351,7 @@ LL |         #[cfg(all())] U: TraitAll,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:80:9
    |
-LL |         #[cfg(any())] U: TraitAny,
+LL |         #[cfg(false)] U: TraitAny,
    |         ^^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
@@ -381,8 +381,8 @@ LL |         #[cfg_attr(b, cfg(b))] U: TraitBB,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:83:9
    |
-LL |         #[cfg_attr(all(), cfg(all()))] U: TraitAllAll,
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         #[cfg_attr(true, cfg(true))] U: TraitAllAll,
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
    = help: add `#![feature(where_clause_attrs)]` to the crate attributes to enable
@@ -391,7 +391,7 @@ LL |         #[cfg_attr(all(), cfg(all()))] U: TraitAllAll,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:84:9
    |
-LL |         #[cfg_attr(any(), cfg(any()))] U: TraitAnyAny;
+LL |         #[cfg_attr(false, cfg(false))] U: TraitAnyAny;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
@@ -421,8 +421,8 @@ LL |         #[cfg(b)] U: TraitB,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:90:9
    |
-LL |         #[cfg(all())] T: TraitAll,
-   |         ^^^^^^^^^^^^^
+LL |         #[cfg(true)] T: TraitAll,
+   |         ^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
    = help: add `#![feature(where_clause_attrs)]` to the crate attributes to enable
@@ -431,7 +431,7 @@ LL |         #[cfg(all())] T: TraitAll,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:91:9
    |
-LL |         #[cfg(any())] T: TraitAny,
+LL |         #[cfg(false)] T: TraitAny,
    |         ^^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
@@ -461,8 +461,8 @@ LL |         #[cfg_attr(b, cfg(b))] U: TraitBB,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:94:9
    |
-LL |         #[cfg_attr(all(), cfg(all()))] T: TraitAllAll,
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         #[cfg_attr(true, cfg(true))] T: TraitAllAll,
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
    = help: add `#![feature(where_clause_attrs)]` to the crate attributes to enable
@@ -471,7 +471,7 @@ LL |         #[cfg_attr(all(), cfg(all()))] T: TraitAllAll,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:95:9
    |
-LL |         #[cfg_attr(any(), cfg(any()))] T: TraitAnyAny,
+LL |         #[cfg_attr(false, cfg(false))] T: TraitAnyAny,
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
@@ -501,8 +501,8 @@ LL |     #[cfg(b)] T: TraitB,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:103:5
    |
-LL |     #[cfg(all())] T: TraitAll,
-   |     ^^^^^^^^^^^^^
+LL |     #[cfg(true)] T: TraitAll,
+   |     ^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
    = help: add `#![feature(where_clause_attrs)]` to the crate attributes to enable
@@ -511,7 +511,7 @@ LL |     #[cfg(all())] T: TraitAll,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:104:5
    |
-LL |     #[cfg(any())] T: TraitAny,
+LL |     #[cfg(false)] T: TraitAny,
    |     ^^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
@@ -541,8 +541,8 @@ LL |     #[cfg_attr(b, cfg(b))] T: TraitBB,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:107:5
    |
-LL |     #[cfg_attr(all(), cfg(all()))] T: TraitAllAll,
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     #[cfg_attr(true, cfg(true))] T: TraitAllAll,
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
    = help: add `#![feature(where_clause_attrs)]` to the crate attributes to enable
@@ -551,7 +551,7 @@ LL |     #[cfg_attr(all(), cfg(all()))] T: TraitAllAll,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:108:5
    |
-LL |     #[cfg_attr(any(), cfg(any()))] T: TraitAnyAny,
+LL |     #[cfg_attr(false, cfg(false))] T: TraitAnyAny,
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
@@ -581,8 +581,8 @@ LL |     #[cfg(b)] T: TraitB,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:117:5
    |
-LL |     #[cfg(all())] T: TraitAll,
-   |     ^^^^^^^^^^^^^
+LL |     #[cfg(true)] T: TraitAll,
+   |     ^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
    = help: add `#![feature(where_clause_attrs)]` to the crate attributes to enable
@@ -591,7 +591,7 @@ LL |     #[cfg(all())] T: TraitAll,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:118:5
    |
-LL |     #[cfg(any())] T: TraitAny,
+LL |     #[cfg(false)] T: TraitAny,
    |     ^^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
@@ -621,8 +621,8 @@ LL |     #[cfg_attr(b, cfg(b))] T: TraitBB,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:121:5
    |
-LL |     #[cfg_attr(all(), cfg(all()))] T: TraitAllAll,
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     #[cfg_attr(true, cfg(true))] T: TraitAllAll,
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
    = help: add `#![feature(where_clause_attrs)]` to the crate attributes to enable
@@ -631,7 +631,7 @@ LL |     #[cfg_attr(all(), cfg(all()))] T: TraitAllAll,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:122:5
    |
-LL |     #[cfg_attr(any(), cfg(any()))] T: TraitAnyAny,
+LL |     #[cfg_attr(false, cfg(false))] T: TraitAnyAny,
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
@@ -661,8 +661,8 @@ LL |     #[cfg(b)] T: TraitB,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:132:5
    |
-LL |     #[cfg(all())] T: TraitAll,
-   |     ^^^^^^^^^^^^^
+LL |     #[cfg(true)] T: TraitAll,
+   |     ^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
    = help: add `#![feature(where_clause_attrs)]` to the crate attributes to enable
@@ -671,7 +671,7 @@ LL |     #[cfg(all())] T: TraitAll,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:133:5
    |
-LL |     #[cfg(any())] T: TraitAny,
+LL |     #[cfg(false)] T: TraitAny,
    |     ^^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
@@ -701,8 +701,8 @@ LL |     #[cfg_attr(b, cfg(b))] T: TraitBB,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:136:5
    |
-LL |     #[cfg_attr(all(), cfg(all()))] T: TraitAllAll,
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     #[cfg_attr(true, cfg(true))] T: TraitAllAll,
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
    = help: add `#![feature(where_clause_attrs)]` to the crate attributes to enable
@@ -711,7 +711,7 @@ LL |     #[cfg_attr(all(), cfg(all()))] T: TraitAllAll,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:137:5
    |
-LL |     #[cfg_attr(any(), cfg(any()))] T: TraitAnyAny,
+LL |     #[cfg_attr(false, cfg(false))] T: TraitAnyAny,
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
@@ -741,8 +741,8 @@ LL |     #[cfg(b)] T: TraitB,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:145:5
    |
-LL |     #[cfg(all())] T: TraitAll,
-   |     ^^^^^^^^^^^^^
+LL |     #[cfg(true)] T: TraitAll,
+   |     ^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
    = help: add `#![feature(where_clause_attrs)]` to the crate attributes to enable
@@ -751,7 +751,7 @@ LL |     #[cfg(all())] T: TraitAll,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:146:5
    |
-LL |     #[cfg(any())] T: TraitAny,
+LL |     #[cfg(false)] T: TraitAny,
    |     ^^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
@@ -781,8 +781,8 @@ LL |     #[cfg_attr(b, cfg(b))] T: TraitBB,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:149:5
    |
-LL |     #[cfg_attr(all(), cfg(all()))] T: TraitAllAll,
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     #[cfg_attr(true, cfg(true))] T: TraitAllAll,
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
    = help: add `#![feature(where_clause_attrs)]` to the crate attributes to enable
@@ -791,7 +791,7 @@ LL |     #[cfg_attr(all(), cfg(all()))] T: TraitAllAll,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:150:5
    |
-LL |     #[cfg_attr(any(), cfg(any()))] T: TraitAnyAny,
+LL |     #[cfg_attr(false, cfg(false))] T: TraitAnyAny,
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
@@ -821,8 +821,8 @@ LL |         #[cfg(b)] U: TraitB,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:155:9
    |
-LL |         #[cfg(all())] U: TraitAll,
-   |         ^^^^^^^^^^^^^
+LL |         #[cfg(true)] U: TraitAll,
+   |         ^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
    = help: add `#![feature(where_clause_attrs)]` to the crate attributes to enable
@@ -831,7 +831,7 @@ LL |         #[cfg(all())] U: TraitAll,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:156:9
    |
-LL |         #[cfg(any())] U: TraitAny,
+LL |         #[cfg(false)] U: TraitAny,
    |         ^^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
@@ -861,8 +861,8 @@ LL |         #[cfg_attr(b, cfg(b))] U: TraitBB,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:159:9
    |
-LL |         #[cfg_attr(all(), cfg(all()))] U: TraitAllAll,
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         #[cfg_attr(true, cfg(true))] U: TraitAllAll,
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information
    = help: add `#![feature(where_clause_attrs)]` to the crate attributes to enable
@@ -871,7 +871,7 @@ LL |         #[cfg_attr(all(), cfg(all()))] U: TraitAllAll,
 error[E0658]: attributes in `where` clause are unstable
   --> $DIR/feature-gate-where_clause_attrs.rs:160:9
    |
-LL |         #[cfg_attr(any(), cfg(any()))] U: TraitAnyAny,
+LL |         #[cfg_attr(false, cfg(false))] U: TraitAnyAny,
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #115590 <https://github.com/rust-lang/rust/issues/115590> for more information

--- a/tests/ui/feature-gates/feature-gate-where_clause_attrs.rs
+++ b/tests/ui/feature-gates/feature-gate-where_clause_attrs.rs
@@ -15,16 +15,16 @@ trait TraitAA {}
 #[cfg_attr(b, cfg(b))]
 trait TraitBB {}
 
-#[cfg(all())]
+#[cfg(true)]
 trait TraitAll {}
 
-#[cfg(any())]
+#[cfg(false)]
 trait TraitAny {}
 
-#[cfg_attr(all(), cfg(all()))]
+#[cfg_attr(true, cfg(true))]
 trait TraitAllAll {}
 
-#[cfg_attr(any(), cfg(any()))]
+#[cfg_attr(false, cfg(false))]
 trait TraitAnyAny {}
 
 
@@ -32,67 +32,67 @@ trait A<T>
 where
     #[cfg(a)] T: TraitA, //~ ERROR attributes in `where` clause are unstable
     #[cfg(b)] T: TraitB, //~ ERROR attributes in `where` clause are unstable
-    #[cfg(all())] T: TraitAll, //~ ERROR attributes in `where` clause are unstable
-    #[cfg(any())] T: TraitAny, //~ ERROR attributes in `where` clause are unstable
+    #[cfg(true)] T: TraitAll, //~ ERROR attributes in `where` clause are unstable
+    #[cfg(false)] T: TraitAny, //~ ERROR attributes in `where` clause are unstable
     #[cfg_attr(a, cfg(a))] T: TraitAA, //~ ERROR attributes in `where` clause are unstable
     #[cfg_attr(b, cfg(b))] T: TraitBB, //~ ERROR attributes in `where` clause are unstable
-    #[cfg_attr(all(), cfg(all()))] T: TraitAllAll, //~ ERROR attributes in `where` clause are unstable
-    #[cfg_attr(any(), cfg(any()))] T: TraitAnyAny, //~ ERROR attributes in `where` clause are unstable
+    #[cfg_attr(true, cfg(true))] T: TraitAllAll, //~ ERROR attributes in `where` clause are unstable
+    #[cfg_attr(false, cfg(false))] T: TraitAnyAny, //~ ERROR attributes in `where` clause are unstable
 {
     type B<U>
     where
         #[cfg(a)] U: TraitA, //~ ERROR attributes in `where` clause are unstable
         #[cfg(b)] U: TraitB, //~ ERROR attributes in `where` clause are unstable
-        #[cfg(all())] U: TraitAll, //~ ERROR attributes in `where` clause are unstable
-        #[cfg(any())] U: TraitAny, //~ ERROR attributes in `where` clause are unstable
+        #[cfg(true)] U: TraitAll, //~ ERROR attributes in `where` clause are unstable
+        #[cfg(false)] U: TraitAny, //~ ERROR attributes in `where` clause are unstable
         #[cfg_attr(a, cfg(a))] U: TraitAA, //~ ERROR attributes in `where` clause are unstable
         #[cfg_attr(b, cfg(b))] U: TraitBB, //~ ERROR attributes in `where` clause are unstable
-        #[cfg_attr(all(), cfg(all()))] U: TraitAllAll, //~ ERROR attributes in `where` clause are unstable
-        #[cfg_attr(any(), cfg(any()))] U: TraitAnyAny; //~ ERROR attributes in `where` clause are unstable
+        #[cfg_attr(true, cfg(true))] U: TraitAllAll, //~ ERROR attributes in `where` clause are unstable
+        #[cfg_attr(false, cfg(false))] U: TraitAnyAny; //~ ERROR attributes in `where` clause are unstable
 
     fn foo<U>(&self)
     where
         #[cfg(a)] U: TraitA, //~ ERROR attributes in `where` clause are unstable
         #[cfg(b)] U: TraitB, //~ ERROR attributes in `where` clause are unstable
-        #[cfg(all())] U: TraitAll, //~ ERROR attributes in `where` clause are unstable
-        #[cfg(any())] U: TraitAny, //~ ERROR attributes in `where` clause are unstable
+        #[cfg(true)] U: TraitAll, //~ ERROR attributes in `where` clause are unstable
+        #[cfg(false)] U: TraitAny, //~ ERROR attributes in `where` clause are unstable
         #[cfg_attr(a, cfg(a))] U: TraitAA, //~ ERROR attributes in `where` clause are unstable
         #[cfg_attr(b, cfg(b))] U: TraitBB, //~ ERROR attributes in `where` clause are unstable
-        #[cfg_attr(all(), cfg(all()))] U: TraitAllAll, //~ ERROR attributes in `where` clause are unstable
-        #[cfg_attr(any(), cfg(any()))] U: TraitAnyAny; //~ ERROR attributes in `where` clause are unstable
+        #[cfg_attr(true, cfg(true))] U: TraitAllAll, //~ ERROR attributes in `where` clause are unstable
+        #[cfg_attr(false, cfg(false))] U: TraitAnyAny; //~ ERROR attributes in `where` clause are unstable
 }
 
 impl<T> A<T> for T
 where
     #[cfg(a)] T: TraitA, //~ ERROR attributes in `where` clause are unstable
     #[cfg(b)] T: TraitB, //~ ERROR attributes in `where` clause are unstable
-    #[cfg(all())] T: TraitAll, //~ ERROR attributes in `where` clause are unstable
-    #[cfg(any())] T: TraitAny, //~ ERROR attributes in `where` clause are unstable
+    #[cfg(true)] T: TraitAll, //~ ERROR attributes in `where` clause are unstable
+    #[cfg(false)] T: TraitAny, //~ ERROR attributes in `where` clause are unstable
     #[cfg_attr(a, cfg(a))] T: TraitAA, //~ ERROR attributes in `where` clause are unstable
     #[cfg_attr(b, cfg(b))] T: TraitBB, //~ ERROR attributes in `where` clause are unstable
-    #[cfg_attr(all(), cfg(all()))] T: TraitAllAll, //~ ERROR attributes in `where` clause are unstable
-    #[cfg_attr(any(), cfg(any()))] T: TraitAnyAny, //~ ERROR attributes in `where` clause are unstable
+    #[cfg_attr(true, cfg(true))] T: TraitAllAll, //~ ERROR attributes in `where` clause are unstable
+    #[cfg_attr(false, cfg(false))] T: TraitAnyAny, //~ ERROR attributes in `where` clause are unstable
 {
     type B<U> = () where
         #[cfg(a)] U: TraitA, //~ ERROR attributes in `where` clause are unstable
         #[cfg(b)] U: TraitB, //~ ERROR attributes in `where` clause are unstable
-        #[cfg(all())] U: TraitAll, //~ ERROR attributes in `where` clause are unstable
-        #[cfg(any())] U: TraitAny, //~ ERROR attributes in `where` clause are unstable
+        #[cfg(true)] U: TraitAll, //~ ERROR attributes in `where` clause are unstable
+        #[cfg(false)] U: TraitAny, //~ ERROR attributes in `where` clause are unstable
         #[cfg_attr(a, cfg(a))] U: TraitAA, //~ ERROR attributes in `where` clause are unstable
         #[cfg_attr(b, cfg(b))] U: TraitBB, //~ ERROR attributes in `where` clause are unstable
-        #[cfg_attr(all(), cfg(all()))] U: TraitAllAll, //~ ERROR attributes in `where` clause are unstable
-        #[cfg_attr(any(), cfg(any()))] U: TraitAnyAny; //~ ERROR attributes in `where` clause are unstable
+        #[cfg_attr(true, cfg(true))] U: TraitAllAll, //~ ERROR attributes in `where` clause are unstable
+        #[cfg_attr(false, cfg(false))] U: TraitAnyAny; //~ ERROR attributes in `where` clause are unstable
 
     fn foo<U>(&self)
     where
         #[cfg(a)] U: TraitA, //~ ERROR attributes in `where` clause are unstable
         #[cfg(b)] U: TraitB, //~ ERROR attributes in `where` clause are unstable
-        #[cfg(all())] T: TraitAll, //~ ERROR attributes in `where` clause are unstable
-        #[cfg(any())] T: TraitAny, //~ ERROR attributes in `where` clause are unstable
+        #[cfg(true)] T: TraitAll, //~ ERROR attributes in `where` clause are unstable
+        #[cfg(false)] T: TraitAny, //~ ERROR attributes in `where` clause are unstable
         #[cfg_attr(a, cfg(a))] U: TraitAA, //~ ERROR attributes in `where` clause are unstable
         #[cfg_attr(b, cfg(b))] U: TraitBB, //~ ERROR attributes in `where` clause are unstable
-        #[cfg_attr(all(), cfg(all()))] T: TraitAllAll, //~ ERROR attributes in `where` clause are unstable
-        #[cfg_attr(any(), cfg(any()))] T: TraitAnyAny, //~ ERROR attributes in `where` clause are unstable
+        #[cfg_attr(true, cfg(true))] T: TraitAllAll, //~ ERROR attributes in `where` clause are unstable
+        #[cfg_attr(false, cfg(false))] T: TraitAnyAny, //~ ERROR attributes in `where` clause are unstable
     {}
 }
 
@@ -100,12 +100,12 @@ struct C<T>
 where
     #[cfg(a)] T: TraitA, //~ ERROR attributes in `where` clause are unstable
     #[cfg(b)] T: TraitB, //~ ERROR attributes in `where` clause are unstable
-    #[cfg(all())] T: TraitAll, //~ ERROR attributes in `where` clause are unstable
-    #[cfg(any())] T: TraitAny, //~ ERROR attributes in `where` clause are unstable
+    #[cfg(true)] T: TraitAll, //~ ERROR attributes in `where` clause are unstable
+    #[cfg(false)] T: TraitAny, //~ ERROR attributes in `where` clause are unstable
     #[cfg_attr(a, cfg(a))] T: TraitAA, //~ ERROR attributes in `where` clause are unstable
     #[cfg_attr(b, cfg(b))] T: TraitBB, //~ ERROR attributes in `where` clause are unstable
-    #[cfg_attr(all(), cfg(all()))] T: TraitAllAll, //~ ERROR attributes in `where` clause are unstable
-    #[cfg_attr(any(), cfg(any()))] T: TraitAnyAny, //~ ERROR attributes in `where` clause are unstable
+    #[cfg_attr(true, cfg(true))] T: TraitAllAll, //~ ERROR attributes in `where` clause are unstable
+    #[cfg_attr(false, cfg(false))] T: TraitAnyAny, //~ ERROR attributes in `where` clause are unstable
 {
     _t: PhantomData<T>,
 }
@@ -114,12 +114,12 @@ union D<T>
 where
     #[cfg(a)] T: TraitA, //~ ERROR attributes in `where` clause are unstable
     #[cfg(b)] T: TraitB, //~ ERROR attributes in `where` clause are unstable
-    #[cfg(all())] T: TraitAll, //~ ERROR attributes in `where` clause are unstable
-    #[cfg(any())] T: TraitAny, //~ ERROR attributes in `where` clause are unstable
+    #[cfg(true)] T: TraitAll, //~ ERROR attributes in `where` clause are unstable
+    #[cfg(false)] T: TraitAny, //~ ERROR attributes in `where` clause are unstable
     #[cfg_attr(a, cfg(a))] T: TraitAA, //~ ERROR attributes in `where` clause are unstable
     #[cfg_attr(b, cfg(b))] T: TraitBB, //~ ERROR attributes in `where` clause are unstable
-    #[cfg_attr(all(), cfg(all()))] T: TraitAllAll, //~ ERROR attributes in `where` clause are unstable
-    #[cfg_attr(any(), cfg(any()))] T: TraitAnyAny, //~ ERROR attributes in `where` clause are unstable
+    #[cfg_attr(true, cfg(true))] T: TraitAllAll, //~ ERROR attributes in `where` clause are unstable
+    #[cfg_attr(false, cfg(false))] T: TraitAnyAny, //~ ERROR attributes in `where` clause are unstable
 {
 
     _t: PhantomData<T>,
@@ -129,12 +129,12 @@ enum E<T>
 where
     #[cfg(a)] T: TraitA, //~ ERROR attributes in `where` clause are unstable
     #[cfg(b)] T: TraitB, //~ ERROR attributes in `where` clause are unstable
-    #[cfg(all())] T: TraitAll, //~ ERROR attributes in `where` clause are unstable
-    #[cfg(any())] T: TraitAny, //~ ERROR attributes in `where` clause are unstable
+    #[cfg(true)] T: TraitAll, //~ ERROR attributes in `where` clause are unstable
+    #[cfg(false)] T: TraitAny, //~ ERROR attributes in `where` clause are unstable
     #[cfg_attr(a, cfg(a))] T: TraitAA, //~ ERROR attributes in `where` clause are unstable
     #[cfg_attr(b, cfg(b))] T: TraitBB, //~ ERROR attributes in `where` clause are unstable
-    #[cfg_attr(all(), cfg(all()))] T: TraitAllAll, //~ ERROR attributes in `where` clause are unstable
-    #[cfg_attr(any(), cfg(any()))] T: TraitAnyAny, //~ ERROR attributes in `where` clause are unstable
+    #[cfg_attr(true, cfg(true))] T: TraitAllAll, //~ ERROR attributes in `where` clause are unstable
+    #[cfg_attr(false, cfg(false))] T: TraitAnyAny, //~ ERROR attributes in `where` clause are unstable
 {
     E(PhantomData<T>),
 }
@@ -142,21 +142,21 @@ where
 impl<T> C<T> where
     #[cfg(a)] T: TraitA, //~ ERROR attributes in `where` clause are unstable
     #[cfg(b)] T: TraitB, //~ ERROR attributes in `where` clause are unstable
-    #[cfg(all())] T: TraitAll, //~ ERROR attributes in `where` clause are unstable
-    #[cfg(any())] T: TraitAny, //~ ERROR attributes in `where` clause are unstable
+    #[cfg(true)] T: TraitAll, //~ ERROR attributes in `where` clause are unstable
+    #[cfg(false)] T: TraitAny, //~ ERROR attributes in `where` clause are unstable
     #[cfg_attr(a, cfg(a))] T: TraitAA, //~ ERROR attributes in `where` clause are unstable
     #[cfg_attr(b, cfg(b))] T: TraitBB, //~ ERROR attributes in `where` clause are unstable
-    #[cfg_attr(all(), cfg(all()))] T: TraitAllAll, //~ ERROR attributes in `where` clause are unstable
-    #[cfg_attr(any(), cfg(any()))] T: TraitAnyAny, //~ ERROR attributes in `where` clause are unstable
+    #[cfg_attr(true, cfg(true))] T: TraitAllAll, //~ ERROR attributes in `where` clause are unstable
+    #[cfg_attr(false, cfg(false))] T: TraitAnyAny, //~ ERROR attributes in `where` clause are unstable
 {
     fn new<U>() where
         #[cfg(a)] U: TraitA, //~ ERROR attributes in `where` clause are unstable
         #[cfg(b)] U: TraitB, //~ ERROR attributes in `where` clause are unstable
-        #[cfg(all())] U: TraitAll, //~ ERROR attributes in `where` clause are unstable
-        #[cfg(any())] U: TraitAny, //~ ERROR attributes in `where` clause are unstable
+        #[cfg(true)] U: TraitAll, //~ ERROR attributes in `where` clause are unstable
+        #[cfg(false)] U: TraitAny, //~ ERROR attributes in `where` clause are unstable
         #[cfg_attr(a, cfg(a))] U: TraitAA, //~ ERROR attributes in `where` clause are unstable
         #[cfg_attr(b, cfg(b))] U: TraitBB, //~ ERROR attributes in `where` clause are unstable
-        #[cfg_attr(all(), cfg(all()))] U: TraitAllAll, //~ ERROR attributes in `where` clause are unstable
-        #[cfg_attr(any(), cfg(any()))] U: TraitAnyAny, //~ ERROR attributes in `where` clause are unstable
+        #[cfg_attr(true, cfg(true))] U: TraitAllAll, //~ ERROR attributes in `where` clause are unstable
+        #[cfg_attr(false, cfg(false))] U: TraitAnyAny, //~ ERROR attributes in `where` clause are unstable
     {}
 }

--- a/tests/ui/issues/issue-24434.rs
+++ b/tests/ui/issues/issue-24434.rs
@@ -1,6 +1,6 @@
 //@ check-pass
 
-#![cfg_attr(all(), feature(rustc_attrs))]
+#![cfg_attr(true, feature(rustc_attrs))]
 #![rustc_dummy]
 
 fn main() {}

--- a/tests/ui/lint/issue-97094.rs
+++ b/tests/ui/lint/issue-97094.rs
@@ -2,19 +2,19 @@
 
 // Ensure that unknown lints inside cfg-attr's are linted for
 
-#![cfg_attr(all(), allow(nonex_lint_top_level))]
+#![cfg_attr(true, allow(nonex_lint_top_level))]
 //~^ ERROR unknown lint
-#![cfg_attr(all(), allow(bare_trait_object))]
+#![cfg_attr(true, allow(bare_trait_object))]
 //~^ ERROR has been renamed
 
-#[cfg_attr(all(), allow(nonex_lint_mod))]
+#[cfg_attr(true, allow(nonex_lint_mod))]
 //~^ ERROR unknown lint
 mod baz {
-    #![cfg_attr(all(), allow(nonex_lint_mod_inner))]
+    #![cfg_attr(true, allow(nonex_lint_mod_inner))]
     //~^ ERROR unknown lint
 }
 
-#[cfg_attr(all(), allow(nonex_lint_fn))]
+#[cfg_attr(true, allow(nonex_lint_fn))]
 //~^ ERROR unknown lint
 pub fn main() {}
 
@@ -25,24 +25,24 @@ macro_rules! bar {
 }
 
 bar!(
-    #[cfg_attr(all(), allow(nonex_lint_in_macro))]
+    #[cfg_attr(true, allow(nonex_lint_in_macro))]
     //~^ ERROR unknown lint
     pub fn _bar() {}
 );
 
 // No warning for non-applying cfg
-#[cfg_attr(any(), allow(nonex_lint_fn))]
+#[cfg_attr(false, allow(nonex_lint_fn))]
 pub fn _foo() {}
 
 // Allowing unknown lints works if inside cfg_attr
-#[cfg_attr(all(), allow(unknown_lints))]
+#[cfg_attr(true, allow(unknown_lints))]
 mod bar_allowed {
     #[allow(nonex_lint_fn)]
     fn _foo() {}
 }
 
 // ... but not if the cfg_attr doesn't evaluate
-#[cfg_attr(any(), allow(unknown_lints))]
+#[cfg_attr(false, allow(unknown_lints))]
 mod bar_not_allowed {
     #[allow(nonex_lint_fn)]
     //~^ ERROR unknown lint

--- a/tests/ui/lint/issue-97094.stderr
+++ b/tests/ui/lint/issue-97094.stderr
@@ -1,8 +1,8 @@
 error: unknown lint: `nonex_lint_top_level`
-  --> $DIR/issue-97094.rs:5:26
+  --> $DIR/issue-97094.rs:5:25
    |
-LL | #![cfg_attr(all(), allow(nonex_lint_top_level))]
-   |                          ^^^^^^^^^^^^^^^^^^^^
+LL | #![cfg_attr(true, allow(nonex_lint_top_level))]
+   |                         ^^^^^^^^^^^^^^^^^^^^
    |
 note: the lint level is defined here
   --> $DIR/issue-97094.rs:1:9
@@ -12,36 +12,36 @@ LL | #![deny(warnings)]
    = note: `#[deny(unknown_lints)]` implied by `#[deny(warnings)]`
 
 error: lint `bare_trait_object` has been renamed to `bare_trait_objects`
-  --> $DIR/issue-97094.rs:7:26
+  --> $DIR/issue-97094.rs:7:25
    |
-LL | #![cfg_attr(all(), allow(bare_trait_object))]
-   |                          ^^^^^^^^^^^^^^^^^ help: use the new name: `bare_trait_objects`
+LL | #![cfg_attr(true, allow(bare_trait_object))]
+   |                         ^^^^^^^^^^^^^^^^^ help: use the new name: `bare_trait_objects`
    |
    = note: `#[deny(renamed_and_removed_lints)]` implied by `#[deny(warnings)]`
 
 error: unknown lint: `nonex_lint_mod`
-  --> $DIR/issue-97094.rs:10:25
+  --> $DIR/issue-97094.rs:10:24
    |
-LL | #[cfg_attr(all(), allow(nonex_lint_mod))]
-   |                         ^^^^^^^^^^^^^^
+LL | #[cfg_attr(true, allow(nonex_lint_mod))]
+   |                        ^^^^^^^^^^^^^^
 
 error: unknown lint: `nonex_lint_mod_inner`
-  --> $DIR/issue-97094.rs:13:30
+  --> $DIR/issue-97094.rs:13:29
    |
-LL |     #![cfg_attr(all(), allow(nonex_lint_mod_inner))]
-   |                              ^^^^^^^^^^^^^^^^^^^^
+LL |     #![cfg_attr(true, allow(nonex_lint_mod_inner))]
+   |                             ^^^^^^^^^^^^^^^^^^^^
 
 error: unknown lint: `nonex_lint_fn`
-  --> $DIR/issue-97094.rs:17:25
+  --> $DIR/issue-97094.rs:17:24
    |
-LL | #[cfg_attr(all(), allow(nonex_lint_fn))]
-   |                         ^^^^^^^^^^^^^
+LL | #[cfg_attr(true, allow(nonex_lint_fn))]
+   |                        ^^^^^^^^^^^^^
 
 error: unknown lint: `nonex_lint_in_macro`
-  --> $DIR/issue-97094.rs:28:29
+  --> $DIR/issue-97094.rs:28:28
    |
-LL |     #[cfg_attr(all(), allow(nonex_lint_in_macro))]
-   |                             ^^^^^^^^^^^^^^^^^^^
+LL |     #[cfg_attr(true, allow(nonex_lint_in_macro))]
+   |                            ^^^^^^^^^^^^^^^^^^^
 
 error: unknown lint: `nonex_lint_fn`
   --> $DIR/issue-97094.rs:47:13

--- a/tests/ui/macros/issue-34171.rs
+++ b/tests/ui/macros/issue-34171.rs
@@ -6,5 +6,5 @@ macro_rules! apply_null {
 }
 
 fn main() {
-    apply_null!(#[cfg(all())] fn f() {});
+    apply_null!(#[cfg(true)] fn f() {});
 }

--- a/tests/ui/parser/attribute-on-empty.rs
+++ b/tests/ui/parser/attribute-on-empty.rs
@@ -4,7 +4,7 @@
 struct Baz<const N: usize>(i32);
 
 fn main() {
-    let _: Baz<#[cfg(any())]> = todo!();
+    let _: Baz<#[cfg(false)]> = todo!();
     //~^ ERROR attributes cannot be applied here
 }
 

--- a/tests/ui/parser/attribute-on-empty.stderr
+++ b/tests/ui/parser/attribute-on-empty.stderr
@@ -1,7 +1,7 @@
 error: attributes cannot be applied here
   --> $DIR/attribute-on-empty.rs:7:16
    |
-LL |     let _: Baz<#[cfg(any())]> = todo!();
+LL |     let _: Baz<#[cfg(false)]> = todo!();
    |          -     ^^^^^^^^^^^^^ attributes are not allowed here
    |          |
    |          while parsing the type for `_`

--- a/tests/ui/parser/attribute-on-type.rs
+++ b/tests/ui/parser/attribute-on-type.rs
@@ -16,16 +16,16 @@ fn main() {
     let _: #[attr] &'static str = "123";
     //~^ ERROR attributes cannot be applied to types
 
-    let _: Bar<#[cfg(any())] 'static> = Bar(&123);
+    let _: Bar<#[cfg(false)] 'static> = Bar(&123);
     //~^ ERROR attributes cannot be applied to generic arguments
 
-    let _: Baz<#[cfg(any())] 42> = Baz(42);
+    let _: Baz<#[cfg(false)] 42> = Baz(42);
     //~^ ERROR attributes cannot be applied to generic arguments
 
     let _: Foo<#[cfg(not(wrong))]String> = Foo(String::new());
     //~^ ERROR attributes cannot be applied to generic arguments
 
-    let _: Bar<#[cfg(any())]       'static> = Bar(&456);
+    let _: Bar<#[cfg(false)]       'static> = Bar(&456);
     //~^ ERROR attributes cannot be applied to generic arguments
 
     let _generic: Box<#[attr] i32> = Box::new(1);

--- a/tests/ui/parser/attribute-on-type.stderr
+++ b/tests/ui/parser/attribute-on-type.stderr
@@ -13,13 +13,13 @@ LL |     let _: #[attr] &'static str = "123";
 error: attributes cannot be applied to generic arguments
   --> $DIR/attribute-on-type.rs:19:16
    |
-LL |     let _: Bar<#[cfg(any())] 'static> = Bar(&123);
+LL |     let _: Bar<#[cfg(false)] 'static> = Bar(&123);
    |                ^^^^^^^^^^^^^ attributes are not allowed here
 
 error: attributes cannot be applied to generic arguments
   --> $DIR/attribute-on-type.rs:22:16
    |
-LL |     let _: Baz<#[cfg(any())] 42> = Baz(42);
+LL |     let _: Baz<#[cfg(false)] 42> = Baz(42);
    |                ^^^^^^^^^^^^^ attributes are not allowed here
 
 error: attributes cannot be applied to generic arguments
@@ -31,7 +31,7 @@ LL |     let _: Foo<#[cfg(not(wrong))]String> = Foo(String::new());
 error: attributes cannot be applied to generic arguments
   --> $DIR/attribute-on-type.rs:28:16
    |
-LL |     let _: Bar<#[cfg(any())]       'static> = Bar(&456);
+LL |     let _: Bar<#[cfg(false)]       'static> = Bar(&456);
    |                ^^^^^^^^^^^^^ attributes are not allowed here
 
 error: attributes cannot be applied to generic arguments

--- a/tests/ui/parser/attribute/attr-pat-struct-rest.rs
+++ b/tests/ui/parser/attribute/attr-pat-struct-rest.rs
@@ -3,6 +3,6 @@
 struct S {}
 
 fn main() {
-    let S { #[cfg(any())] .. } = S {};
+    let S { #[cfg(false)] .. } = S {};
     //~^ ERROR expected identifier, found `..`
 }

--- a/tests/ui/parser/attribute/attr-pat-struct-rest.stderr
+++ b/tests/ui/parser/attribute/attr-pat-struct-rest.stderr
@@ -1,7 +1,7 @@
 error: expected identifier, found `..`
   --> $DIR/attr-pat-struct-rest.rs:6:27
    |
-LL |     let S { #[cfg(any())] .. } = S {};
+LL |     let S { #[cfg(false)] .. } = S {};
    |         -                 ^^ expected identifier
    |         |
    |         while parsing the fields for this pattern

--- a/tests/ui/parser/cfg-keyword-lifetime.rs
+++ b/tests/ui/parser/cfg-keyword-lifetime.rs
@@ -1,6 +1,6 @@
 // Disallow `'keyword` even in cfg'd code.
 
-#[cfg(any())]
+#[cfg(false)]
 fn hello() -> &'ref () {}
 //~^ ERROR lifetimes cannot use keyword names
 

--- a/tests/ui/parser/issue-116781.rs
+++ b/tests/ui/parser/issue-116781.rs
@@ -1,6 +1,6 @@
 #[derive(Debug)]
 struct Foo {
-    #[cfg(all())]
+    #[cfg(true)]
     field: fn(($),), //~ ERROR expected pattern, found `$`
     //~^ ERROR expected pattern, found `$`
 }

--- a/tests/ui/parser/raw/raw-idents.rs
+++ b/tests/ui/parser/raw/raw-idents.rs
@@ -62,7 +62,7 @@ macro_rules! tests {
                 impl<$kw> B<$kw> {}
             }
             mod extern_crate {
-                #[cfg(any())]
+                #[cfg(false)]
                 extern crate $kw;
             }
             mod body {

--- a/tests/ui/parser/ty-path-followed-by-single-colon.rs
+++ b/tests/ui/parser/ty-path-followed-by-single-colon.rs
@@ -12,7 +12,7 @@ mod garden {
 
     fn g(_: impl Take<path:to::somewhere>) {} // OK!
 
-    #[cfg(any())] fn h() where a::path:to::nowhere {} // OK!
+    #[cfg(false)] fn h() where a::path:to::nowhere {} // OK!
 
     fn i(_: impl Take<path::<>:to::somewhere>) {} // OK!
 

--- a/tests/ui/proc-macro/ambiguous-builtin-attrs.rs
+++ b/tests/ui/proc-macro/ambiguous-builtin-attrs.rs
@@ -9,7 +9,7 @@ use builtin_attrs::{bench, test};
 
 #[repr(C)] //~ ERROR `repr` is ambiguous
 struct S;
-#[cfg_attr(all(), repr(C))] //~ ERROR `repr` is ambiguous
+#[cfg_attr(true, repr(C))] //~ ERROR `repr` is ambiguous
 struct SCond;
 
 #[test] // OK, shadowed

--- a/tests/ui/proc-macro/ambiguous-builtin-attrs.stderr
+++ b/tests/ui/proc-macro/ambiguous-builtin-attrs.stderr
@@ -20,10 +20,10 @@ LL | use builtin_attrs::*;
    = help: use `crate::repr` to refer to this attribute macro unambiguously
 
 error[E0659]: `repr` is ambiguous
-  --> $DIR/ambiguous-builtin-attrs.rs:12:19
+  --> $DIR/ambiguous-builtin-attrs.rs:12:18
    |
-LL | #[cfg_attr(all(), repr(C))]
-   |                   ^^^^ ambiguous name
+LL | #[cfg_attr(true, repr(C))]
+   |                  ^^^^ ambiguous name
    |
    = note: ambiguous because of a name conflict with a builtin attribute
    = note: `repr` could refer to a built-in attribute

--- a/tests/ui/proc-macro/auxiliary/derive-attr-cfg.rs
+++ b/tests/ui/proc-macro/auxiliary/derive-attr-cfg.rs
@@ -4,6 +4,6 @@ use proc_macro::TokenStream;
 
 #[proc_macro_derive(Foo, attributes(foo))]
 pub fn derive(input: TokenStream) -> TokenStream {
-    assert!(!input.to_string().contains("#[cfg(any())]"));
+    assert!(!input.to_string().contains("#[cfg(false)]"));
     "".parse().unwrap()
 }

--- a/tests/ui/proc-macro/cfg-eval.rs
+++ b/tests/ui/proc-macro/cfg-eval.rs
@@ -17,9 +17,9 @@ extern crate test_macros;
 struct S1 {
     #[cfg(false)]
     field_false: u8,
-    #[cfg(all(/*true*/))]
+    #[cfg(true)]
     #[cfg_attr(FALSE, unknown_attr)]
-    #[cfg_attr(all(/*true*/), allow())] //~ WARN unused attribute
+    #[cfg_attr(true, allow())] //~ WARN unused attribute
     field_true: u8,
 }
 
@@ -29,9 +29,9 @@ struct S2 {}
 
 fn main() {
     // Subtle - we need a trailing comma after the '1' - otherwise, `#[cfg_eval]` will
-    // turn this into `(#[cfg(all())] 1)`, which is a parenthesized expression, not a tuple
+    // turn this into `(#[cfg(true)] 1)`, which is a parenthesized expression, not a tuple
     // expression. `#[cfg]` is not supported inside parenthesized expressions, so this will
     // produce an error when attribute collection runs.
     let _ = #[cfg_eval] #[print_attr] #[cfg_attr(not(FALSE), rustc_dummy)]
-    (#[cfg(false)] 0, #[cfg(all(/*true*/))] 1,);
+    (#[cfg(false)] 0, #[cfg(true)] 1,);
 }

--- a/tests/ui/proc-macro/cfg-eval.stderr
+++ b/tests/ui/proc-macro/cfg-eval.stderr
@@ -1,8 +1,8 @@
 warning: unused attribute
   --> $DIR/cfg-eval.rs:22:5
    |
-LL |     #[cfg_attr(all(/*true*/), allow())]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove this attribute
+LL |     #[cfg_attr(true, allow())]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove this attribute
    |
    = note: attribute `allow` with an empty list has no effect
    = note: requested on the command line with `-W unused-attributes`

--- a/tests/ui/proc-macro/cfg-eval.stdout
+++ b/tests/ui/proc-macro/cfg-eval.stdout
@@ -1,5 +1,5 @@
-PRINT-ATTR INPUT (DISPLAY): struct S1 { #[cfg(all())] #[allow()] field_true: u8, }
-PRINT-ATTR DEEP-RE-COLLECTED (DISPLAY): struct S1 { #[cfg(all())] #[allow()] field_true : u8, }
+PRINT-ATTR INPUT (DISPLAY): struct S1 { #[cfg(true)] #[allow()] field_true: u8, }
+PRINT-ATTR DEEP-RE-COLLECTED (DISPLAY): struct S1 { #[cfg(true)] #[allow()] field_true : u8, }
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Ident {
         ident: "struct",
@@ -28,19 +28,14 @@ PRINT-ATTR INPUT (DEBUG): TokenStream [
                         delimiter: Parenthesis,
                         stream: TokenStream [
                             Ident {
-                                ident: "all",
-                                span: $DIR/cfg-eval.rs:20:11: 20:14 (#0),
-                            },
-                            Group {
-                                delimiter: Parenthesis,
-                                stream: TokenStream [],
-                                span: $DIR/cfg-eval.rs:20:14: 20:24 (#0),
+                                ident: "true",
+                                span: $DIR/cfg-eval.rs:20:11: 20:15 (#0),
                             },
                         ],
-                        span: $DIR/cfg-eval.rs:20:10: 20:25 (#0),
+                        span: $DIR/cfg-eval.rs:20:10: 20:16 (#0),
                     },
                 ],
-                span: $DIR/cfg-eval.rs:20:6: 20:26 (#0),
+                span: $DIR/cfg-eval.rs:20:6: 20:17 (#0),
             },
             Punct {
                 ch: '#',
@@ -52,15 +47,15 @@ PRINT-ATTR INPUT (DEBUG): TokenStream [
                 stream: TokenStream [
                     Ident {
                         ident: "allow",
-                        span: $DIR/cfg-eval.rs:22:31: 22:36 (#0),
+                        span: $DIR/cfg-eval.rs:22:22: 22:27 (#0),
                     },
                     Group {
                         delimiter: Parenthesis,
                         stream: TokenStream [],
-                        span: $DIR/cfg-eval.rs:22:36: 22:38 (#0),
+                        span: $DIR/cfg-eval.rs:22:27: 22:29 (#0),
                     },
                 ],
-                span: $DIR/cfg-eval.rs:22:6: 22:40 (#0),
+                span: $DIR/cfg-eval.rs:22:6: 22:31 (#0),
             },
             Ident {
                 ident: "field_true",
@@ -84,7 +79,7 @@ PRINT-ATTR INPUT (DEBUG): TokenStream [
         span: $DIR/cfg-eval.rs:17:11: 24:2 (#0),
     },
 ]
-PRINT-ATTR INPUT (DISPLAY): #[rustc_dummy] (#[cfg(all())] 1,)
+PRINT-ATTR INPUT (DISPLAY): #[rustc_dummy] (#[cfg(true)] 1,)
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Punct {
         ch: '#',
@@ -120,32 +115,27 @@ PRINT-ATTR INPUT (DEBUG): TokenStream [
                         delimiter: Parenthesis,
                         stream: TokenStream [
                             Ident {
-                                ident: "all",
-                                span: $DIR/cfg-eval.rs:36:29: 36:32 (#0),
-                            },
-                            Group {
-                                delimiter: Parenthesis,
-                                stream: TokenStream [],
-                                span: $DIR/cfg-eval.rs:36:32: 36:42 (#0),
+                                ident: "true",
+                                span: $DIR/cfg-eval.rs:36:29: 36:33 (#0),
                             },
                         ],
-                        span: $DIR/cfg-eval.rs:36:28: 36:43 (#0),
+                        span: $DIR/cfg-eval.rs:36:28: 36:34 (#0),
                     },
                 ],
-                span: $DIR/cfg-eval.rs:36:24: 36:44 (#0),
+                span: $DIR/cfg-eval.rs:36:24: 36:35 (#0),
             },
             Literal {
                 kind: Integer,
                 symbol: "1",
                 suffix: None,
-                span: $DIR/cfg-eval.rs:36:45: 36:46 (#0),
+                span: $DIR/cfg-eval.rs:36:36: 36:37 (#0),
             },
             Punct {
                 ch: ',',
                 spacing: Alone,
-                span: $DIR/cfg-eval.rs:36:46: 36:47 (#0),
+                span: $DIR/cfg-eval.rs:36:37: 36:38 (#0),
             },
         ],
-        span: $DIR/cfg-eval.rs:36:5: 36:48 (#0),
+        span: $DIR/cfg-eval.rs:36:5: 36:39 (#0),
     },
 ]

--- a/tests/ui/proc-macro/derive-attr-cfg.rs
+++ b/tests/ui/proc-macro/derive-attr-cfg.rs
@@ -9,7 +9,7 @@ use derive_attr_cfg::Foo;
 #[derive(Foo)]
 #[foo]
 struct S {
-    #[cfg(any())]
+    #[cfg(false)]
     x: i32
 }
 

--- a/tests/ui/proc-macro/derive-b.rs
+++ b/tests/ui/proc-macro/derive-b.rs
@@ -4,7 +4,7 @@
 extern crate derive_b_rpass as derive_b;
 
 #[derive(Debug, PartialEq, derive_b::B, Eq, Copy, Clone)]
-#[cfg_attr(all(), B[arbitrary tokens])]
+#[cfg_attr(true, B[arbitrary tokens])]
 struct B {
     #[C]
     a: u64

--- a/tests/ui/proc-macro/derive-helper-configured.rs
+++ b/tests/ui/proc-macro/derive-helper-configured.rs
@@ -7,9 +7,9 @@
 extern crate test_macros;
 
 #[derive(Empty)]
-#[cfg_attr(all(), empty_helper)]
+#[cfg_attr(true, empty_helper)]
 struct S {
-    #[cfg_attr(all(), empty_helper)]
+    #[cfg_attr(true, empty_helper)]
     field: u8,
 }
 

--- a/tests/ui/resolve/suggestions/suggest-import-without-clobbering-attrs.fixed
+++ b/tests/ui/resolve/suggestions/suggest-import-without-clobbering-attrs.fixed
@@ -3,7 +3,7 @@
 //@ compile-flags: -Aunused
 
 use y::z;
-#[cfg(all())]
+#[cfg(true)]
 use y::Whatever;
 
 mod y {

--- a/tests/ui/resolve/suggestions/suggest-import-without-clobbering-attrs.rs
+++ b/tests/ui/resolve/suggestions/suggest-import-without-clobbering-attrs.rs
@@ -2,7 +2,7 @@
 //@ run-rustfix
 //@ compile-flags: -Aunused
 
-#[cfg(all())]
+#[cfg(true)]
 use y::Whatever;
 
 mod y {

--- a/tests/ui/rust-2024/unsafe-attributes/unsafe-attributes-fix.fixed
+++ b/tests/ui/rust-2024/unsafe-attributes/unsafe-attributes-fix.fixed
@@ -43,7 +43,7 @@ macro_rules! meta2 {
 
 macro_rules! with_cfg_attr {
     () => {
-        #[cfg_attr(all(), unsafe(link_section = ".custom_section"))]
+        #[cfg_attr(true, unsafe(link_section = ".custom_section"))]
         //~^ ERROR: unsafe attribute used without unsafe
         //~| WARN this is accepted in the current edition
         pub extern "C" fn abc() {}

--- a/tests/ui/rust-2024/unsafe-attributes/unsafe-attributes-fix.rs
+++ b/tests/ui/rust-2024/unsafe-attributes/unsafe-attributes-fix.rs
@@ -43,7 +43,7 @@ macro_rules! meta2 {
 
 macro_rules! with_cfg_attr {
     () => {
-        #[cfg_attr(all(), link_section = ".custom_section")]
+        #[cfg_attr(true, link_section = ".custom_section")]
         //~^ ERROR: unsafe attribute used without unsafe
         //~| WARN this is accepted in the current edition
         pub extern "C" fn abc() {}

--- a/tests/ui/rust-2024/unsafe-attributes/unsafe-attributes-fix.stderr
+++ b/tests/ui/rust-2024/unsafe-attributes/unsafe-attributes-fix.stderr
@@ -77,10 +77,10 @@ LL |         #[unsafe($e = $l)]
    |           +++++++       +
 
 error: unsafe attribute used without unsafe
-  --> $DIR/unsafe-attributes-fix.rs:46:27
+  --> $DIR/unsafe-attributes-fix.rs:46:26
    |
-LL |         #[cfg_attr(all(), link_section = ".custom_section")]
-   |                           ^^^^^^^^^^^^ usage of unsafe attribute
+LL |         #[cfg_attr(true, link_section = ".custom_section")]
+   |                          ^^^^^^^^^^^^ usage of unsafe attribute
 ...
 LL | with_cfg_attr!();
    | ---------------- in this macro invocation
@@ -90,8 +90,8 @@ LL | with_cfg_attr!();
    = note: this error originates in the macro `with_cfg_attr` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: wrap the attribute in `unsafe(...)`
    |
-LL |         #[cfg_attr(all(), unsafe(link_section = ".custom_section"))]
-   |                           +++++++                                +
+LL |         #[cfg_attr(true, unsafe(link_section = ".custom_section"))]
+   |                          +++++++                                +
 
 error: unsafe attribute used without unsafe
   --> $DIR/unsafe-attributes-fix.rs:67:3

--- a/tests/ui/static/static-align.rs
+++ b/tests/ui/static/static-align.rs
@@ -53,7 +53,7 @@ thread_local! {
     #[allow(unused_mut, reason = "test attribute handling")]
     #[cfg_attr(TRUE,
       cfg_attr(FOURTY_TWO = "42",
-      cfg_attr(all(),
+      cfg_attr(true,
       cfg_attr(any(true),
       cfg_attr(true, rustc_align_static(4096))))))]
     #[allow(unused_mut, reason = "test attribute handling")]

--- a/tests/ui/structs/struct-field-cfg.rs
+++ b/tests/ui/structs/struct-field-cfg.rs
@@ -3,16 +3,16 @@ struct Foo {
 }
 
 fn main() {
-    let foo = Foo { #[cfg(all())] present: () };
-    let _ = Foo { #[cfg(any())] present: () };
+    let foo = Foo { #[cfg(true)] present: () };
+    let _ = Foo { #[cfg(false)] present: () };
     //~^ ERROR missing field `present` in initializer of `Foo`
-    let _ = Foo { present: (), #[cfg(any())] absent: () };
-    let _ = Foo { present: (), #[cfg(all())] absent: () };
+    let _ = Foo { present: (), #[cfg(false)] absent: () };
+    let _ = Foo { present: (), #[cfg(true)] absent: () };
     //~^ ERROR struct `Foo` has no field named `absent`
-    let Foo { #[cfg(all())] present: () } = foo;
-    let Foo { #[cfg(any())] present: () } = foo;
+    let Foo { #[cfg(true)] present: () } = foo;
+    let Foo { #[cfg(false)] present: () } = foo;
     //~^ ERROR pattern does not mention field `present`
-    let Foo { present: (), #[cfg(any())] absent: () } = foo;
-    let Foo { present: (), #[cfg(all())] absent: () } = foo;
+    let Foo { present: (), #[cfg(false)] absent: () } = foo;
+    let Foo { present: (), #[cfg(true)] absent: () } = foo;
     //~^ ERROR struct `Foo` does not have a field named `absent`
 }

--- a/tests/ui/structs/struct-field-cfg.stderr
+++ b/tests/ui/structs/struct-field-cfg.stderr
@@ -1,44 +1,44 @@
 error[E0063]: missing field `present` in initializer of `Foo`
   --> $DIR/struct-field-cfg.rs:7:13
    |
-LL |     let _ = Foo { #[cfg(any())] present: () };
+LL |     let _ = Foo { #[cfg(false)] present: () };
    |             ^^^ missing `present`
 
 error[E0560]: struct `Foo` has no field named `absent`
-  --> $DIR/struct-field-cfg.rs:10:46
+  --> $DIR/struct-field-cfg.rs:10:45
    |
-LL |     let _ = Foo { present: (), #[cfg(all())] absent: () };
-   |                                              ^^^^^^ `Foo` does not have this field
+LL |     let _ = Foo { present: (), #[cfg(true)] absent: () };
+   |                                             ^^^^^^ `Foo` does not have this field
    |
    = note: all struct fields are already assigned
 
 error[E0027]: pattern does not mention field `present`
   --> $DIR/struct-field-cfg.rs:13:9
    |
-LL |     let Foo { #[cfg(any())] present: () } = foo;
+LL |     let Foo { #[cfg(false)] present: () } = foo;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing field `present`
    |
 help: include the missing field in the pattern
    |
-LL -     let Foo { #[cfg(any())] present: () } = foo;
+LL -     let Foo { #[cfg(false)] present: () } = foo;
 LL +     let Foo { present } = foo;
    |
 help: if you don't care about this missing field, you can explicitly ignore it
    |
-LL -     let Foo { #[cfg(any())] present: () } = foo;
+LL -     let Foo { #[cfg(false)] present: () } = foo;
 LL +     let Foo { present: _ } = foo;
    |
 help: or always ignore missing fields here
    |
-LL -     let Foo { #[cfg(any())] present: () } = foo;
+LL -     let Foo { #[cfg(false)] present: () } = foo;
 LL +     let Foo { .. } = foo;
    |
 
 error[E0026]: struct `Foo` does not have a field named `absent`
-  --> $DIR/struct-field-cfg.rs:16:42
+  --> $DIR/struct-field-cfg.rs:16:41
    |
-LL |     let Foo { present: (), #[cfg(all())] absent: () } = foo;
-   |                                          ^^^^^^ struct `Foo` does not have this field
+LL |     let Foo { present: (), #[cfg(true)] absent: () } = foo;
+   |                                         ^^^^^^ struct `Foo` does not have this field
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/test-attrs/issue-34932.rs
+++ b/tests/ui/test-attrs/issue-34932.rs
@@ -1,6 +1,6 @@
 //@ run-pass
 //@ compile-flags:--test
-#![cfg(any())] // This test should be configured away
+#![cfg(false)] // This test should be configured away
 #![feature(rustc_attrs)] // Test that this is allowed on stable/beta
 #![feature(iter_arith_traits)] // Test that this is not unused
 #![deny(unused_features)]

--- a/tests/ui/typeck/issue-86721-return-expr-ice.rs
+++ b/tests/ui/typeck/issue-86721-return-expr-ice.rs
@@ -1,7 +1,7 @@
 // Regression test for the ICE described in #86721.
 
 //@ revisions: rev1 rev2
-#![cfg_attr(any(), rev1, rev2)]
+#![cfg_attr(false, rev1, rev2)]
 #![crate_type = "lib"]
 
 #[cfg(any(rev1))]


### PR DESCRIPTION
~~This implements the followup warning suggested in https://github.com/rust-lang/rfcs/pull/3695~~
~~Lint against an empty `cfg(any/all)`, suggest the boolean literal equivalents.~~
https://github.com/rust-lang/rust/pull/149791#issuecomment-3638624348

Tracking issue: https://github.com/rust-lang/rust/issues/131204
