### PR TITLE
Use `let`...`else` instead of `match foo { ... _ => return };` and `if let ... else return` in std

### DIFF
--- a/library/alloc/src/collections/linked_list.rs
+++ b/library/alloc/src/collections/linked_list.rs
@@ -1646,9 +1646,8 @@ impl<'a, T> CursorMut<'a, T> {
     #[unstable(feature = "linked_list_cursors", issue = "58533")]
     pub fn splice_after(&mut self, list: LinkedList<T>) {
         unsafe {
-            let (splice_head, splice_tail, splice_len) = match list.detach_all_nodes() {
-                Some(parts) => parts,
-                _ => return,
+            let Some((splice_head, splice_tail, splice_len)) = list.detach_all_nodes() else {
+                return;
             };
             let node_next = match self.current {
                 None => self.list.head,

--- a/library/alloc/src/raw_vec/mod.rs
+++ b/library/alloc/src/raw_vec/mod.rs
@@ -788,9 +788,7 @@ impl<A: Allocator> RawVecInner<A> {
         elem_layout: Layout,
     ) -> Result<(), TryReserveError> {
         // SAFETY: Precondition passed to caller
-        let (ptr, layout) = if let Some(mem) = unsafe { self.current_memory(elem_layout) } {
-            mem
-        } else {
+        let Some((ptr, layout)) = (unsafe { self.current_memory(elem_layout) }) else {
             return Ok(());
         };
 

--- a/library/alloc/src/vec/splice.rs
+++ b/library/alloc/src/vec/splice.rs
@@ -112,12 +112,11 @@ impl<T, A: Allocator> Drain<'_, T, A> {
         };
 
         for place in range_slice {
-            if let Some(new_item) = replace_with.next() {
-                unsafe { ptr::write(place, new_item) };
-                vec.len += 1;
-            } else {
+            let Some(new_item) = replace_with.next() else {
                 return false;
-            }
+            };
+            unsafe { ptr::write(place, new_item) };
+            vec.len += 1;
         }
         true
     }

--- a/library/core/src/num/dec2flt/mod.rs
+++ b/library/core/src/num/dec2flt/mod.rs
@@ -255,11 +255,7 @@ fn biased_fp_to_float<F: RawFloat>(x: BiasedFp) -> F {
 #[inline(always)] // Will be inlined into a function with `#[inline(never)]`, see above
 pub fn dec2flt<F: RawFloat>(s: &str) -> Result<F, ParseFloatError> {
     let mut s = s.as_bytes();
-    let c = if let Some(&c) = s.first() {
-        c
-    } else {
-        return Err(pfe_empty());
-    };
+    let Some(&c) = s.first() else { return Err(pfe_empty()) };
     let negative = c == b'-';
     if c == b'-' || c == b'+' {
         s = &s[1..];

--- a/library/core/src/time.rs
+++ b/library/core/src/time.rs
@@ -672,11 +672,10 @@ impl Duration {
             let mut nanos = self.nanos.as_inner() + rhs.nanos.as_inner();
             if nanos >= NANOS_PER_SEC {
                 nanos -= NANOS_PER_SEC;
-                if let Some(new_secs) = secs.checked_add(1) {
-                    secs = new_secs;
-                } else {
+                let Some(new_secs) = secs.checked_add(1) else {
                     return None;
-                }
+                };
+                secs = new_secs;
             }
             debug_assert!(nanos < NANOS_PER_SEC);
             Some(Duration::new(secs, nanos))

--- a/library/std/src/sys/pal/windows/pipe.rs
+++ b/library/std/src/sys/pal/windows/pipe.rs
@@ -530,10 +530,7 @@ impl<'a> AsyncPipe<'a> {
 
 impl<'a> Drop for AsyncPipe<'a> {
     fn drop(&mut self) {
-        match self.state {
-            State::Reading => {}
-            _ => return,
-        }
+        let State::Reading = self.state else { return };
 
         // If we have a pending read operation, then we have to make sure that
         // it's *done* before we actually drop this type. The kernel requires


### PR DESCRIPTION
Split off rust-lang/rust#148837.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
