### PR TITLE
Mirror `ubuntu:24.04` on ghcr

### DIFF
--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -55,6 +55,8 @@ jobs:
           images=(
             # Mirrored because used by the tidy job, which doesn't cache Docker images
             "ubuntu:22.04"
+            # Mirrored because used by x86-64-gnu-miri
+            "ubuntu:24.04"
             # Mirrored because used by all linux CI jobs, including tidy
             "moby/buildkit:buildx-stable-1"
             # Mirrored because used when CI is running inside a Docker container


### PR DESCRIPTION
The miri job wants to use it (https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/Adding.20a.20C.2B.2B.20dependency.20to.20Miri.3F/with/560654845), and sooner or later we will likely migrate our CI to it too.

r? @marcoieni
