### PR TITLE
Use ubuntu:24.04 for the `x86_64-gnu-miri` job

### DIFF
--- a/src/ci/docker/host-x86_64/x86_64-gnu-aux/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-aux/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ghcr.io/rust-lang/ubuntu:24.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/src/ci/docker/host-x86_64/x86_64-gnu-miri/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-miri/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/rust-lang/ubuntu:22.04
+FROM ghcr.io/rust-lang/ubuntu:24.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
Ralf asked for this in https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/Adding.20a.20C.2B.2B.20dependency.20to.20Miri.3F/with/560654845.
