### PR TITLE
Stable inline const using unstable intrinsics

### DIFF
--- a/compiler/rustc_ast_lowering/src/asm.rs
+++ b/compiler/rustc_ast_lowering/src/asm.rs
@@ -207,7 +207,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                         }
                     }
                     InlineAsmOperand::Const { anon_const } => hir::InlineAsmOperand::Const {
-                        anon_const: self.lower_const_block(anon_const),
+                        anon_const: self.lower_const_block(anon_const, &[]),
                     },
                     InlineAsmOperand::Sym { sym } => {
                         let static_def_id = self

--- a/compiler/rustc_ast_lowering/src/expr.rs
+++ b/compiler/rustc_ast_lowering/src/expr.rs
@@ -105,7 +105,9 @@ impl<'hir> LoweringContext<'_, 'hir> {
 
             let kind = match &e.kind {
                 ExprKind::Array(exprs) => hir::ExprKind::Array(self.lower_exprs(exprs)),
-                ExprKind::ConstBlock(c) => hir::ExprKind::ConstBlock(self.lower_const_block(c)),
+                ExprKind::ConstBlock(c) => {
+                    hir::ExprKind::ConstBlock(self.lower_const_block(c, attrs))
+                }
                 ExprKind::Repeat(expr, count) => {
                     let expr = self.lower_expr(expr);
                     let count = self.lower_array_length_to_const_arg(count);
@@ -394,12 +396,20 @@ impl<'hir> LoweringContext<'_, 'hir> {
         })
     }
 
-    pub(crate) fn lower_const_block(&mut self, c: &AnonConst) -> hir::ConstBlock {
+    pub(crate) fn lower_const_block(
+        &mut self,
+        c: &AnonConst,
+        attrs: &'hir [hir::Attribute],
+    ) -> hir::ConstBlock {
         self.with_new_scopes(c.value.span, |this| {
             let def_id = this.local_def_id(c.id);
+            let hir_id = this.lower_node_id(c.id);
+            if !attrs.is_empty() {
+                this.attrs.insert(hir_id.local_id, attrs);
+            }
             hir::ConstBlock {
                 def_id,
-                hir_id: this.lower_node_id(c.id),
+                hir_id,
                 body: this.lower_const_body(c.value.span, Some(&c.value)),
             }
         })

--- a/compiler/rustc_attr_parsing/src/attributes/allow_unstable.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/allow_unstable.rs
@@ -63,6 +63,7 @@ impl<S: Stage> CombineAttributeParser<S> for AllowConstFnUnstableParser {
         Allow(Target::Method(MethodKind::Inherent)),
         Allow(Target::Method(MethodKind::Trait { body: true })),
         Allow(Target::Method(MethodKind::TraitImpl)),
+        Allow(Target::Expression), // FIXME: should only allow inline consts
     ]);
     const TEMPLATE: AttributeTemplate = template!(Word, List: &["feat1, feat2, ..."]);
 

--- a/compiler/rustc_attr_parsing/src/attributes/stability.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/stability.rs
@@ -244,7 +244,21 @@ impl<S: Stage> AttributeParser<S> for ConstStabilityParser {
             this.promotable = true;
         }),
     ];
-    const ALLOWED_TARGETS: AllowedTargets = ALLOWED_TARGETS;
+    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
+        Allow(Target::Fn),
+        Allow(Target::Method(MethodKind::Inherent)),
+        Allow(Target::Method(MethodKind::TraitImpl)),
+        Allow(Target::Method(MethodKind::Trait { body: true })),
+        Allow(Target::Impl { of_trait: false }),
+        Allow(Target::Impl { of_trait: true }),
+        Allow(Target::Use), // FIXME I don't think this does anything?
+        Allow(Target::Const),
+        Allow(Target::AssocConst),
+        Allow(Target::Trait),
+        Allow(Target::Static),
+        Allow(Target::Crate),
+        Allow(Target::MacroDef), // FIXME(oli-obk): remove this and eliminate the manual check for it
+    ]);
 
     fn finalize(mut self, cx: &FinalizeContext<'_, '_, S>) -> Option<AttributeKind> {
         if self.promotable {

--- a/compiler/rustc_attr_parsing/src/attributes/stability.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/stability.rs
@@ -256,6 +256,7 @@ impl<S: Stage> AttributeParser<S> for ConstStabilityParser {
         Allow(Target::AssocConst),
         Allow(Target::Trait),
         Allow(Target::Static),
+        Allow(Target::Expression), // FIXME: we really only want to allow inline consts
         Allow(Target::Crate),
         Allow(Target::MacroDef), // FIXME(oli-obk): remove this and eliminate the manual check for it
     ]);

--- a/compiler/rustc_const_eval/src/check_consts/mod.rs
+++ b/compiler/rustc_const_eval/src/check_consts/mod.rs
@@ -54,9 +54,11 @@ impl<'mir, 'tcx> ConstCx<'mir, 'tcx> {
     pub fn enforce_recursive_const_stability(&self) -> bool {
         // We can skip this if neither `staged_api` nor `-Zforce-unstable-if-unmarked` are enabled,
         // since in such crates `lookup_const_stability` will always be `None`.
-        self.const_kind == Some(hir::ConstContext::ConstFn)
-            && (self.tcx.features().staged_api()
-                || self.tcx.sess.opts.unstable_opts.force_unstable_if_unmarked)
+        matches!(
+            self.const_kind,
+            Some(hir::ConstContext::ConstFn | hir::ConstContext::Const { inline: true })
+        ) && (self.tcx.features().staged_api()
+            || self.tcx.sess.opts.unstable_opts.force_unstable_if_unmarked)
             && is_fn_or_trait_safe_to_expose_on_stable(self.tcx, self.def_id().to_def_id())
     }
 

--- a/compiler/rustc_passes/src/errors.rs
+++ b/compiler/rustc_passes/src/errors.rs
@@ -1059,6 +1059,18 @@ pub(crate) struct MissingConstErr {
 
 #[derive(Diagnostic)]
 #[diag(
+    "const stability of inline consts must match const stability of containing item"
+)]
+pub(crate) struct UnstableInlineConstInConst {
+    #[primary_span]
+    #[help("did you mean to use `rustc_allow_const_fn_unstable`?")]
+    pub span: Span,
+    #[note("stability marker of containing item defined here")]
+    pub parent_span: Option<Span>,
+}
+
+#[derive(Diagnostic)]
+#[diag(
     "attribute `#[rustc_const_stable]` can only be applied to functions that are declared `#[stable]`"
 )]
 pub(crate) struct ConstStableNotStable {

--- a/compiler/rustc_passes/src/stability.rs
+++ b/compiler/rustc_passes/src/stability.rs
@@ -334,9 +334,12 @@ impl<'tcx> MissingStabilityAnnotations<'tcx> {
 
         macro_rules! find_attr_span {
             ($name:ident) => {{
-                let attrs = self.tcx.hir_attrs(self.tcx.local_def_id_to_hir_id(def_id));
+                find_attr_span!($name, def_id)
+            }};
+            ($name:ident, $id: expr) => {{
+                let attrs = self.tcx.hir_attrs(self.tcx.local_def_id_to_hir_id($id));
                 find_attr!(attrs, AttributeKind::$name { span, .. } => *span)
-            }}
+            }};
         }
 
         if stab.is_none()
@@ -396,6 +399,16 @@ impl<'tcx> MissingStabilityAnnotations<'tcx> {
             && find_attr_span!(RustcConstStability).is_some()
         {
             self.tcx.dcx().emit_err(errors::MissingConstErr { fn_sig_span: fn_sig.span });
+        }
+
+        if let DefKind::InlineConst = self.tcx.def_kind(def_id)
+            && const_stab.is_some()
+            && let parent = self.tcx.local_parent(def_id)
+            && self.tcx.lookup_const_stability(parent) != const_stab
+            && let Some(span) = find_attr_span!(RustcConstStability)
+        {
+            let parent_span = find_attr_span!(RustcConstStability, parent);
+            self.tcx.dcx().emit_err(errors::UnstableInlineConstInConst { span, parent_span });
         }
 
         // If this is marked const *stable*, it must also be regular-stable.
@@ -476,6 +489,11 @@ impl<'tcx> Visitor<'tcx> for MissingStabilityAnnotations<'tcx> {
         self.check_missing_const_stability(i.owner_id.def_id);
 
         intravisit::walk_item(self, i)
+    }
+
+    fn visit_inline_const(&mut self, c: &'tcx rustc_hir::ConstBlock) -> Self::Result {
+        self.check_compatible_stability(c.def_id);
+        intravisit::walk_inline_const(self, c)
     }
 
     fn visit_trait_item(&mut self, ti: &'tcx hir::TraitItem<'tcx>) {
@@ -601,7 +619,6 @@ impl<'tcx> Visitor<'tcx> for Checker<'tcx> {
                     let attrs = self.tcx.hir_attrs(item.hir_id());
                     let stab = find_attr!(attrs, AttributeKind::Stability{stability, span} => (*stability, *span));
 
-                    // FIXME(jdonszelmann): make it impossible to miss the or_else in the typesystem
                     let const_stab = find_attr!(attrs, AttributeKind::RustcConstStability{stability, ..} => *stability);
 
                     let unstable_feature_stab =

--- a/library/alloc/src/boxed/thin.rs
+++ b/library/alloc/src/boxed/thin.rs
@@ -321,7 +321,12 @@ impl<H> WithHeader<H> {
         // of the header, past the padding, so the assigned type makes sense.
         // It also ensures that the address at the end of the header is sufficiently
         // aligned for T.
-        let alloc: &<Dyn as Pointee>::Metadata = const {
+        // We generate the vtable in a const block instead of having the compiler
+        // generate it for us. The basics to allocate new memory during ctfe are
+        // unstable, but we can always change the intrinsic logic to support the
+        // needs of new_unsize_zst in the future.
+        let alloc: &<Dyn as Pointee>::Metadata = #[rustc_allow_const_fn_unstable(const_heap)]
+        const {
             // FIXME: just call `WithHeader::alloc_layout` with size reset to 0.
             // Currently that's blocked on `Layout::extend` not being `const fn`.
 

--- a/library/core/src/any.rs
+++ b/library/core/src/any.rs
@@ -864,7 +864,10 @@ impl fmt::Debug for TypeId {
 #[stable(feature = "type_name", since = "1.38.0")]
 #[rustc_const_unstable(feature = "const_type_name", issue = "63084")]
 pub const fn type_name<T: ?Sized>() -> &'static str {
-    const { intrinsics::type_name::<T>() }
+    #[rustc_const_unstable(feature = "const_type_name", issue = "63084")]
+    const {
+        intrinsics::type_name::<T>()
+    }
 }
 
 /// Returns the type name of the pointed-to value as a string slice.
@@ -942,13 +945,18 @@ pub const fn type_name_of_val<T: ?Sized>(_val: &T) -> &'static str {
 /// ```
 #[must_use]
 #[unstable(feature = "try_as_dyn", issue = "144361")]
+#[rustc_const_unstable(feature = "try_as_dyn", issue = "144361")]
 pub const fn try_as_dyn<
     T: Any + 'static,
     U: ptr::Pointee<Metadata = ptr::DynMetadata<U>> + ?Sized + 'static,
 >(
     t: &T,
 ) -> Option<&U> {
-    let vtable: Option<ptr::DynMetadata<U>> = const { intrinsics::vtable_for::<T, U>() };
+    let vtable: Option<ptr::DynMetadata<U>> =
+        #[rustc_const_unstable(feature = "try_as_dyn", issue = "144361")]
+        const {
+            intrinsics::vtable_for::<T, U>()
+        };
     match vtable {
         Some(dyn_metadata) => {
             let pointer = ptr::from_raw_parts(t, dyn_metadata);
@@ -995,13 +1003,18 @@ pub const fn try_as_dyn<
 /// ```
 #[must_use]
 #[unstable(feature = "try_as_dyn", issue = "144361")]
+#[rustc_const_unstable(feature = "try_as_dyn", issue = "144361")]
 pub const fn try_as_dyn_mut<
     T: Any + 'static,
     U: ptr::Pointee<Metadata = ptr::DynMetadata<U>> + ?Sized + 'static,
 >(
     t: &mut T,
 ) -> Option<&mut U> {
-    let vtable: Option<ptr::DynMetadata<U>> = const { intrinsics::vtable_for::<T, U>() };
+    let vtable: Option<ptr::DynMetadata<U>> =
+        #[rustc_const_unstable(feature = "try_as_dyn", issue = "144361")]
+        const {
+            intrinsics::vtable_for::<T, U>()
+        };
     match vtable {
         Some(dyn_metadata) => {
             let pointer = ptr::from_raw_parts_mut(t, dyn_metadata);

--- a/library/core/src/array/drain.rs
+++ b/library/core/src/array/drain.rs
@@ -31,7 +31,6 @@ impl<'l, 'f, T, U, const N: usize, F: FnMut(T) -> U> Drain<'l, 'f, T, N, F> {
 }
 
 /// See [`Drain::new`]; this is our fake iterator.
-#[rustc_const_unstable(feature = "array_try_map", issue = "79711")]
 #[unstable(feature = "array_try_map", issue = "79711")]
 pub(super) struct Drain<'l, 'f, T, const N: usize, F> {
     // FIXME(const-hack): This is essentially a slice::IterMut<'static>, replace when possible.

--- a/library/core/src/intrinsics/mod.rs
+++ b/library/core/src/intrinsics/mod.rs
@@ -2887,6 +2887,7 @@ pub const fn type_name<T: ?Sized>() -> &'static str;
 #[rustc_nounwind]
 #[unstable(feature = "core_intrinsics", issue = "none")]
 #[rustc_intrinsic]
+#[rustc_intrinsic_const_stable_indirect]
 pub const fn type_id<T: ?Sized + 'static>() -> crate::any::TypeId;
 
 /// Tests (at compile-time) if two [`crate::any::TypeId`] instances identify the

--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -1237,7 +1237,10 @@ pub const fn discriminant<T>(v: &T) -> Discriminant<T> {
 #[rustc_const_unstable(feature = "variant_count", issue = "73662")]
 #[rustc_diagnostic_item = "mem_variant_count"]
 pub const fn variant_count<T>() -> usize {
-    const { intrinsics::variant_count::<T>() }
+    #[rustc_const_unstable(feature = "variant_count", issue = "73662")]
+    const {
+        intrinsics::variant_count::<T>()
+    }
 }
 
 /// Provides associated constants for various useful properties of types,

--- a/library/core/src/mem/type_info.rs
+++ b/library/core/src/mem/type_info.rs
@@ -32,7 +32,10 @@ impl Type {
     #[rustc_const_unstable(feature = "type_info", issue = "146922")]
     // FIXME(reflection): don't require the 'static bound
     pub const fn of<T: ?Sized + 'static>() -> Self {
-        const { TypeId::of::<T>().info() }
+        #[rustc_const_unstable(feature = "type_info", issue = "146922")]
+        const {
+            TypeId::of::<T>().info()
+        }
     }
 }
 

--- a/tests/ui/consts/min_const_fn/const-fn-lang-feature-inline-const.rs
+++ b/tests/ui/consts/min_const_fn/const-fn-lang-feature-inline-const.rs
@@ -1,0 +1,47 @@
+//! Ensure we reject invalid combinations of feature gating inline consts
+
+#![feature(staged_api, abi_unadjusted)]
+#![stable(feature = "rust_test", since = "1.0.0")]
+
+#[unstable(feature = "abi_unadjusted", issue = "42")]
+#[rustc_const_unstable(feature = "abi_unadjusted", issue = "42")]
+const fn my_fun() {}
+
+#[stable(feature = "asdf", since = "99.0.0")]
+#[rustc_const_stable(feature = "asdf", since = "99.0.0")]
+const fn my_fun2() {
+    #[rustc_const_unstable(feature = "abi_unadjusted", issue = "42")]
+    //~^ ERROR: must match const stability of containing item
+    const {
+        my_fun()
+    }
+}
+
+// Check that const stable const blocks can only call const stable things
+#[stable(feature = "asdf", since = "99.0.0")]
+#[rustc_const_stable(feature = "asdf", since = "99.0.0")]
+const fn my_fun3() {
+    #[rustc_const_stable(feature = "asdf", since = "99.0.0")]
+    const {
+        my_fun()
+        //~^ ERROR: (indirectly) exposed to stable
+    }
+}
+
+// Check that const stable const blocks can only call const stable things
+#[stable(feature = "asdf", since = "99.0.0")]
+#[rustc_const_stable(feature = "asdf", since = "99.0.0")]
+const fn my_fun4() {
+    const {
+        my_fun()
+        //~^ ERROR: (indirectly) exposed to stable
+    }
+}
+
+fn main() {
+    #[rustc_const_unstable(feature = "abi_unadjusted", issue = "42")]
+    //~^ ERROR: must match const stability of containing item
+    const {
+        my_fun2()
+    };
+}

--- a/tests/ui/consts/min_const_fn/const-fn-lang-feature-inline-const.stderr
+++ b/tests/ui/consts/min_const_fn/const-fn-lang-feature-inline-const.stderr
@@ -1,0 +1,55 @@
+error: const stability of inline consts must match const stability of containing item.
+  --> $DIR/const-fn-lang-feature-inline-const.rs:13:5
+   |
+LL |     #[rustc_const_unstable(feature = "abi_unadjusted", issue = "42")]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: did you mean to use `rustc_allow_const_fn_unstable`?
+  --> $DIR/const-fn-lang-feature-inline-const.rs:13:5
+   |
+LL |     #[rustc_const_unstable(feature = "abi_unadjusted", issue = "42")]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: stability marker of containing item defined here
+  --> $DIR/const-fn-lang-feature-inline-const.rs:11:1
+   |
+LL | #[rustc_const_stable(feature = "asdf", since = "99.0.0")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: const stability of inline consts must match const stability of containing item.
+  --> $DIR/const-fn-lang-feature-inline-const.rs:42:5
+   |
+LL |     #[rustc_const_unstable(feature = "abi_unadjusted", issue = "42")]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: did you mean to use `rustc_allow_const_fn_unstable`?
+  --> $DIR/const-fn-lang-feature-inline-const.rs:42:5
+   |
+LL |     #[rustc_const_unstable(feature = "abi_unadjusted", issue = "42")]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: const function that might be (indirectly) exposed to stable cannot use `#[feature(abi_unadjusted)]`
+  --> $DIR/const-fn-lang-feature-inline-const.rs:26:9
+   |
+LL |         my_fun()
+   |         ^^^^^^^^
+   |
+   = help: mark the callee as `#[rustc_const_stable_indirect]` if it does not itself require any unstable features
+help: if the caller is not (yet) meant to be exposed to stable const contexts, add `#[rustc_const_unstable]`
+   |
+LL |     const #[rustc_const_unstable(feature = "...", issue = "...")]
+   |           +++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+error: const function that might be (indirectly) exposed to stable cannot use `#[feature(abi_unadjusted)]`
+  --> $DIR/const-fn-lang-feature-inline-const.rs:36:9
+   |
+LL |         my_fun()
+   |         ^^^^^^^^
+   |
+   = help: mark the callee as `#[rustc_const_stable_indirect]` if it does not itself require any unstable features
+help: if the caller is not (yet) meant to be exposed to stable const contexts, add `#[rustc_const_unstable]`
+   |
+LL |     const #[rustc_const_unstable(feature = "...", issue = "...")]
+   |           +++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+error: aborting due to 4 previous errors
+

--- a/tests/ui/consts/min_const_fn/const-fn-lang-feature.rs
+++ b/tests/ui/consts/min_const_fn/const-fn-lang-feature.rs
@@ -2,7 +2,7 @@
 //! enabling the feature gate actually lets us call the function.
 //@ check-pass
 
-#![feature(staged_api, abi_unadjusted)]
+#![feature(staged_api, abi_unadjusted, rustc_allow_const_fn_unstable)]
 #![stable(feature = "rust_test", since = "1.0.0")]
 
 #[unstable(feature = "abi_unadjusted", issue = "42")]
@@ -15,6 +15,39 @@ const fn my_fun2() {
     my_fun()
 }
 
+// Check that we can call unstable things in unstable const blocks
+// in unstable fns.
+#[unstable(feature = "abi_unadjusted", issue = "42")]
+#[rustc_const_unstable(feature = "abi_unadjusted", issue = "42")]
+const fn my_fun3() {
+    #[rustc_const_unstable(feature = "abi_unadjusted", issue = "42")]
+    const {
+        my_fun()
+    }
+}
+
+#[stable(feature = "asdf", since = "99.0.0")]
+#[rustc_const_stable(feature = "asdf", since = "99.0.0")]
+const fn stable_thing() {}
+
+#[stable(feature = "asdf", since = "99.0.0")]
+#[rustc_const_stable(feature = "asdf", since = "99.0.0")]
+const fn my_fun4() {
+    #[rustc_const_stable(feature = "asdf", since = "99.0.0")]
+    const {
+        stable_thing()
+    }
+}
+
+#[stable(feature = "asdf", since = "99.0.0")]
+#[rustc_const_stable(feature = "asdf", since = "99.0.0")]
+const fn my_fun5() {
+    const { stable_thing() }
+}
+
 fn main() {
-    const { my_fun2() };
+    #[rustc_allow_const_fn_unstable(abi_unadjusted)]
+    const {
+        my_fun2()
+    };
 }

--- a/tests/ui/thir-print/offset_of.stdout
+++ b/tests/ui/thir-print/offset_of.stdout
@@ -67,8 +67,8 @@ body:
                                                 }
                                             )
                                             else_block: None
-                                            hir_id: HirId(DefId(offset_of::concrete).10)
-                                            span: $DIR/offset_of.rs:37:5: 1445:57 (#0)
+                                            lint_level: Explicit(HirId(DefId(offset_of::concrete).10))
+                                            span: $DIR/offset_of.rs:37:5: 1433:57 (#0)
                                         }
                                     }
                                     Stmt {
@@ -116,8 +116,8 @@ body:
                                                 }
                                             )
                                             else_block: None
-                                            hir_id: HirId(DefId(offset_of::concrete).20)
-                                            span: $DIR/offset_of.rs:38:5: 1445:57 (#0)
+                                            lint_level: Explicit(HirId(DefId(offset_of::concrete).20))
+                                            span: $DIR/offset_of.rs:38:5: 1433:57 (#0)
                                         }
                                     }
                                     Stmt {
@@ -165,8 +165,8 @@ body:
                                                 }
                                             )
                                             else_block: None
-                                            hir_id: HirId(DefId(offset_of::concrete).30)
-                                            span: $DIR/offset_of.rs:39:5: 1445:57 (#0)
+                                            lint_level: Explicit(HirId(DefId(offset_of::concrete).30))
+                                            span: $DIR/offset_of.rs:39:5: 1433:57 (#0)
                                         }
                                     }
                                     Stmt {
@@ -214,8 +214,8 @@ body:
                                                 }
                                             )
                                             else_block: None
-                                            hir_id: HirId(DefId(offset_of::concrete).40)
-                                            span: $DIR/offset_of.rs:40:5: 1445:57 (#0)
+                                            lint_level: Explicit(HirId(DefId(offset_of::concrete).40))
+                                            span: $DIR/offset_of.rs:40:5: 1433:57 (#0)
                                         }
                                     }
                                     Stmt {
@@ -263,8 +263,8 @@ body:
                                                 }
                                             )
                                             else_block: None
-                                            hir_id: HirId(DefId(offset_of::concrete).50)
-                                            span: $DIR/offset_of.rs:41:5: 1445:57 (#0)
+                                            lint_level: Explicit(HirId(DefId(offset_of::concrete).50))
+                                            span: $DIR/offset_of.rs:41:5: 1433:57 (#0)
                                         }
                                     }
                                 ]
@@ -863,8 +863,8 @@ body:
                                                 }
                                             )
                                             else_block: None
-                                            hir_id: HirId(DefId(offset_of::generic).12)
-                                            span: $DIR/offset_of.rs:45:5: 1445:57 (#0)
+                                            lint_level: Explicit(HirId(DefId(offset_of::generic).12))
+                                            span: $DIR/offset_of.rs:45:5: 1433:57 (#0)
                                         }
                                     }
                                     Stmt {
@@ -912,8 +912,8 @@ body:
                                                 }
                                             )
                                             else_block: None
-                                            hir_id: HirId(DefId(offset_of::generic).24)
-                                            span: $DIR/offset_of.rs:46:5: 1445:57 (#0)
+                                            lint_level: Explicit(HirId(DefId(offset_of::generic).24))
+                                            span: $DIR/offset_of.rs:46:5: 1433:57 (#0)
                                         }
                                     }
                                     Stmt {
@@ -961,8 +961,8 @@ body:
                                                 }
                                             )
                                             else_block: None
-                                            hir_id: HirId(DefId(offset_of::generic).36)
-                                            span: $DIR/offset_of.rs:47:5: 1445:57 (#0)
+                                            lint_level: Explicit(HirId(DefId(offset_of::generic).36))
+                                            span: $DIR/offset_of.rs:47:5: 1433:57 (#0)
                                         }
                                     }
                                     Stmt {
@@ -1010,8 +1010,8 @@ body:
                                                 }
                                             )
                                             else_block: None
-                                            hir_id: HirId(DefId(offset_of::generic).48)
-                                            span: $DIR/offset_of.rs:48:5: 1445:57 (#0)
+                                            lint_level: Explicit(HirId(DefId(offset_of::generic).48))
+                                            span: $DIR/offset_of.rs:48:5: 1433:57 (#0)
                                         }
                                     }
                                 ]


### PR DESCRIPTION
cc @RalfJung 

Having moved several intrinsics from sth that gets invoked directly in a const fn to sth invoked in a const block kind of broke our "indirectly usable intrinsic" logic. So now we're actually checking it again. This required changing some intrinsics to now be indirectly callable

r? @jdonszelmann 

