### PR TITLE
Add a regression test for issue 145748

### DIFF
--- a/tests/ui/traits/next-solver/normalize/normalize-const-in-async-body.rs
+++ b/tests/ui/traits/next-solver/normalize/normalize-const-in-async-body.rs
@@ -2,6 +2,8 @@
 //@ check-pass
 //@ edition:2021
 
+// Regression test for https://github.com/rust-lang/rust/issues/129865.
+
 pub async fn cleanse_old_array_async(_: &[u8; BUCKET_LEN]) {}
 
 pub const BUCKET_LEN: usize = 0;

--- a/tests/ui/traits/next-solver/opaques/non-defining-use-borrowck-issue-145748.rs
+++ b/tests/ui/traits/next-solver/opaques/non-defining-use-borrowck-issue-145748.rs
@@ -1,0 +1,14 @@
+//@ ignore-compare-mode-next-solver
+//@ compile-flags: -Znext-solver
+//@ check-pass
+
+// Make sure that we support non-defining uses in borrowck.
+// Regression test for https://github.com/rust-lang/rust/issues/145748.
+
+pub fn f(_: &()) -> impl Fn() + '_ {
+    || {
+        let _ = f(&());
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
Seems to be fixed while allowing non-defining usages of opaques in next-solver.

Closes rust-lang/rust#145748
