### PR TITLE
Observe `close(2)` errors for `std::fs::{copy, write}`

### DIFF
--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -382,7 +382,10 @@ pub fn read_to_string<P: AsRef<Path>>(path: P) -> io::Result<String> {
 #[stable(feature = "fs_read_write_bytes", since = "1.26.0")]
 pub fn write<P: AsRef<Path>, C: AsRef<[u8]>>(path: P, contents: C) -> io::Result<()> {
     fn inner(path: &Path, contents: &[u8]) -> io::Result<()> {
-        File::create(path)?.write_all(contents)
+        let mut file = File::create(path)?;
+        file.write_all(contents)?;
+        file.close()?;
+        Ok(())
     }
     inner(path.as_ref(), contents.as_ref())
 }
@@ -707,6 +710,11 @@ impl File {
     #[cfg_attr(not(test), rustc_diagnostic_item = "file_options")]
     pub fn options() -> OpenOptions {
         OpenOptions::new()
+    }
+
+    /// Drops the file, returning any errors encountered.
+    pub(crate) fn close(self) -> io::Result<()> {
+        self.inner.close()
     }
 
     /// Attempts to sync all OS-internal file content and metadata to disk.

--- a/library/std/src/os/fd/owned.rs
+++ b/library/std/src/os/fd/owned.rs
@@ -11,13 +11,6 @@ use super::raw::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 use crate::fs;
 use crate::marker::PhantomData;
 use crate::mem::ManuallyDrop;
-#[cfg(not(any(
-    target_arch = "wasm32",
-    target_env = "sgx",
-    target_os = "hermit",
-    target_os = "trusty",
-    target_os = "motor"
-)))]
 use crate::sys::cvt;
 #[cfg(not(target_os = "trusty"))]
 use crate::sys_common::{AsInner, FromInner, IntoInner};
@@ -93,6 +86,23 @@ impl OwnedFd {
     #[stable(feature = "io_safety", since = "1.63.0")]
     pub fn try_clone(&self) -> crate::io::Result<Self> {
         self.as_fd().try_clone_to_owned()
+    }
+
+    /// Drops the file descriptor, returning any errors encountered.
+    pub(crate) fn close(self) -> io::Result<()> {
+        let this = ManuallyDrop::new(self);
+        let result = unsafe {
+            #[cfg(not(target_os = "hermit"))]
+            {
+                #[cfg(unix)]
+                crate::sys::fs::debug_assert_fd_is_open(this.fd.as_inner());
+
+                libc::close(this.fd.as_inner())
+            }
+            #[cfg(target_os = "hermit")]
+            hermit_abi::close(this.fd.as_inner())
+        };
+        cvt(result).map(|_| ())
     }
 }
 

--- a/library/std/src/os/windows/io/handle.rs
+++ b/library/std/src/os/windows/io/handle.rs
@@ -182,6 +182,12 @@ impl Drop for HandleOrNull {
 }
 
 impl OwnedHandle {
+    /// Drops the handle, returning any errors encountered.
+    pub(crate) fn close(self) -> io::Result<()> {
+        let this = ManuallyDrop::new(self);
+        cvt(unsafe { sys::c::CloseHandle(this.handle) }).map(|_| ())
+    }
+
     /// Creates a new `OwnedHandle` instance that shares the same underlying
     /// object as the existing `OwnedHandle` instance.
     #[stable(feature = "io_safety", since = "1.63.0")]

--- a/library/std/src/sys/fd/unix.rs
+++ b/library/std/src/sys/fd/unix.rs
@@ -103,6 +103,10 @@ const fn max_iov() -> usize {
 }
 
 impl FileDesc {
+    pub fn close(self) -> io::Result<()> {
+        self.0.close()
+    }
+
     #[inline]
     pub fn try_clone(&self) -> io::Result<Self> {
         self.duplicate()

--- a/library/std/src/sys/fs/common.rs
+++ b/library/std/src/sys/fs/common.rs
@@ -23,6 +23,7 @@ pub fn copy(from: &Path, to: &Path) -> io::Result<u64> {
 
     let ret = io::copy(&mut reader, &mut writer)?;
     writer.set_permissions(perm)?;
+    writer.close()?;
     Ok(ret)
 }
 

--- a/library/std/src/sys/fs/hermit.rs
+++ b/library/std/src/sys/fs/hermit.rs
@@ -345,6 +345,10 @@ impl File {
         Ok(File(unsafe { FileDesc::from_raw_fd(fd as i32) }))
     }
 
+    pub fn close(self) -> io::Result<()> {
+        self.0.close()
+    }
+
     pub fn file_attr(&self) -> io::Result<FileAttr> {
         let mut stat_val: stat_struct = unsafe { mem::zeroed() };
         self.0.fstat(&mut stat_val)?;

--- a/library/std/src/sys/fs/motor.rs
+++ b/library/std/src/sys/fs/motor.rs
@@ -174,6 +174,10 @@ impl File {
             .map_err(map_motor_error)
     }
 
+    pub fn close(self) -> io::Result<()> {
+        self.0.close()
+    }
+
     pub fn file_attr(&self) -> io::Result<FileAttr> {
         moto_rt::fs::get_file_attr(self.as_raw_fd())
             .map(|inner| -> FileAttr { FileAttr { inner } })

--- a/library/std/src/sys/fs/uefi.rs
+++ b/library/std/src/sys/fs/uefi.rs
@@ -237,6 +237,10 @@ impl File {
         unsupported()
     }
 
+    pub fn close(self) -> io::Result<()> {
+        self.0
+    }
+
     pub fn file_attr(&self) -> io::Result<FileAttr> {
         self.0
     }

--- a/library/std/src/sys/fs/unix.rs
+++ b/library/std/src/sys/fs/unix.rs
@@ -1231,6 +1231,10 @@ impl File {
         Ok(File(unsafe { FileDesc::from_raw_fd(fd) }))
     }
 
+    pub fn close(self) -> io::Result<()> {
+        self.0.close()
+    }
+
     pub fn file_attr(&self) -> io::Result<FileAttr> {
         let fd = self.as_raw_fd();
 
@@ -2324,11 +2328,12 @@ pub(in crate::sys) use cfm::CachedFileMetadata;
 pub fn copy(from: &Path, to: &Path) -> io::Result<u64> {
     let (reader, reader_metadata) = open_from(from)?;
     let (writer, writer_metadata) = open_to_and_set_permissions(to, &reader_metadata)?;
+    let mut reader = cfm::CachedFileMetadata(reader, reader_metadata);
+    let mut writer = cfm::CachedFileMetadata(writer, writer_metadata);
 
-    io::copy(
-        &mut cfm::CachedFileMetadata(reader, reader_metadata),
-        &mut cfm::CachedFileMetadata(writer, writer_metadata),
-    )
+    let ret = io::copy(&mut reader, &mut writer)?;
+    writer.0.close()?;
+    Ok(ret)
 }
 
 #[cfg(target_vendor = "apple")]

--- a/library/std/src/sys/fs/unsupported.rs
+++ b/library/std/src/sys/fs/unsupported.rs
@@ -187,6 +187,10 @@ impl File {
         unsupported()
     }
 
+    pub fn close(self) -> io::Result<()> {
+        self.0
+    }
+
     pub fn file_attr(&self) -> io::Result<FileAttr> {
         self.0
     }

--- a/library/std/src/sys/fs/vexos.rs
+++ b/library/std/src/sys/fs/vexos.rs
@@ -271,6 +271,12 @@ impl File {
         })
     }
 
+    pub fn close(self) -> io::Result<()> {
+        // vexFileClose can't fail. Just implicitly drop `self`.
+        let _ = self;
+        Ok(())
+    }
+
     pub fn file_attr(&self) -> io::Result<FileAttr> {
         // `vexFileSize` returns -1 upon error, so u64::try_from will fail on error.
         if let Ok(size) = u64::try_from(unsafe {
@@ -537,7 +543,9 @@ pub fn copy(from: &Path, to: &Path) -> io::Result<u64> {
     let mut reader = File::open(from)?;
     let mut writer = File::create(to)?;
 
-    io::copy(&mut reader, &mut writer)
+    let ret = io::copy(&mut reader, &mut writer)?;
+    writer.close()?;
+    Ok(ret)
 }
 
 fn map_fresult(fresult: vex_sdk::FRESULT) -> io::Result<()> {

--- a/library/std/src/sys/fs/windows.rs
+++ b/library/std/src/sys/fs/windows.rs
@@ -366,6 +366,10 @@ impl File {
         }
     }
 
+    pub fn close(self) -> io::Result<()> {
+        self.handle.close()
+    }
+
     pub fn fsync(&self) -> io::Result<()> {
         cvt(unsafe { c::FlushFileBuffers(self.handle.as_raw_handle()) })?;
         Ok(())

--- a/library/std/src/sys/pal/windows/handle.rs
+++ b/library/std/src/sys/pal/windows/handle.rs
@@ -77,6 +77,10 @@ impl FromRawHandle for Handle {
 }
 
 impl Handle {
+    pub fn close(self) -> io::Result<()> {
+        self.0.close()
+    }
+
     pub fn read(&self, buf: &mut [u8]) -> io::Result<usize> {
         let res = unsafe { self.synchronous_read(buf.as_mut_ptr().cast(), buf.len(), None) };
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/149834)*
<!-- homu-ignore:end -->

Adds a (private to `std`) `File::close` method and uses it in `std::fs::write` and `std::fs::copy`.

This is a lighter version of https://github.com/rust-lang/libs-team/issues/705 that can be added even if that ACP isn't accepted, as this is purely a quality of implementation thing that could be reverted at any time. External libraries and applications can use external crates like https://crates.io/crates/close-err to achieve the same with the files they own.

CC https://github.com/rust-lang/libs-team/issues/705.