### PR TITLE
Fix clippy::ref_as_ptr for non-temporary references in let/const

### DIFF
--- a/src/tools/clippy/clippy_lints/src/casts/ref_as_ptr.rs
+++ b/src/tools/clippy/clippy_lints/src/casts/ref_as_ptr.rs
@@ -1,9 +1,9 @@
 use clippy_utils::diagnostics::span_lint_and_sugg;
 use clippy_utils::source::snippet_with_applicability;
 use clippy_utils::sugg::Sugg;
-use clippy_utils::{ExprUseNode, expr_use_ctxt, std_or_core};
+use clippy_utils::{ExprUseNode, expr_use_ctxt, is_expr_temporary_value, std_or_core};
 use rustc_errors::Applicability;
-use rustc_hir::{Expr, Mutability, Ty, TyKind};
+use rustc_hir::{Expr, ExprKind, Mutability, Ty, TyKind};
 use rustc_lint::LateContext;
 use rustc_middle::ty;
 
@@ -23,10 +23,18 @@ pub(super) fn check<'tcx>(
     if matches!(cast_from.kind(), ty::Ref(..))
         && let ty::RawPtr(_, to_mutbl) = cast_to.kind()
         && let use_cx = expr_use_ctxt(cx, expr)
-        // TODO: only block the lint if `cast_expr` is a temporary
-        && !matches!(use_cx.use_node(cx), ExprUseNode::LetStmt(_) | ExprUseNode::ConstStatic(_))
         && let Some(std_or_core) = std_or_core(cx)
     {
+        if matches!(
+            use_cx.use_node(cx),
+            ExprUseNode::LetStmt(_) | ExprUseNode::ConstStatic(_)
+        ) {
+            if let ExprKind::AddrOf(_, _, addr_inner) = cast_expr.kind
+                && is_expr_temporary_value(cx, addr_inner)
+            {
+                return;
+            }
+        }
         let fn_name = match to_mutbl {
             Mutability::Not => "from_ref",
             Mutability::Mut => "from_mut",

--- a/src/tools/clippy/tests/ui/ref_as_ptr.fixed
+++ b/src/tools/clippy/tests/ui/ref_as_ptr.fixed
@@ -3,6 +3,8 @@
 
 fn f<T>(_: T) {}
 
+static STATIC_I32: i32 = 42;
+
 fn main() {
     f(std::ptr::from_ref(&1u8));
     //~^ ref_as_ptr
@@ -63,6 +65,9 @@ fn main() {
     f(std::ptr::from_ref::<i32>(&val) as *const f64);
     //~^ ref_as_ptr
 
+    let _ptr_from_local: *const i32 = std::ptr::from_ref(&val);
+    //~^ ref_as_ptr
+
     let mut val: u8 = 2;
     f(std::ptr::from_mut::<u8>(&mut val));
     //~^ ref_as_ptr
@@ -84,6 +89,9 @@ fn main() {
     f(std::ptr::from_ref::<[usize; 8]>(&mut std::array::from_fn(|i| i * i)));
     //~^ ref_as_ptr
     f(std::ptr::from_mut::<[usize; 9]>(&mut std::array::from_fn(|i| i * i)));
+    //~^ ref_as_ptr
+
+    let _ptr_from_static: *const i32 = std::ptr::from_ref(&STATIC_I32);
     //~^ ref_as_ptr
 
     let _ = &String::new() as *const _;

--- a/src/tools/clippy/tests/ui/ref_as_ptr.rs
+++ b/src/tools/clippy/tests/ui/ref_as_ptr.rs
@@ -3,6 +3,8 @@
 
 fn f<T>(_: T) {}
 
+static STATIC_I32: i32 = 42;
+
 fn main() {
     f(&1u8 as *const _);
     //~^ ref_as_ptr
@@ -63,6 +65,9 @@ fn main() {
     f(&val as *const i32 as *const f64);
     //~^ ref_as_ptr
 
+    let _ptr_from_local: *const i32 = &val as *const _;
+    //~^ ref_as_ptr
+
     let mut val: u8 = 2;
     f(&mut val as *mut u8);
     //~^ ref_as_ptr
@@ -84,6 +89,9 @@ fn main() {
     f(&mut std::array::from_fn(|i| i * i) as *const [usize; 8]);
     //~^ ref_as_ptr
     f(&mut std::array::from_fn(|i| i * i) as *mut [usize; 9]);
+    //~^ ref_as_ptr
+
+    let _ptr_from_static: *const i32 = &STATIC_I32 as *const _;
     //~^ ref_as_ptr
 
     let _ = &String::new() as *const _;

--- a/src/tools/clippy/tests/ui/ref_as_ptr.stderr
+++ b/src/tools/clippy/tests/ui/ref_as_ptr.stderr
@@ -1,5 +1,5 @@
 error: reference as raw pointer
-  --> tests/ui/ref_as_ptr.rs:7:7
+  --> tests/ui/ref_as_ptr.rs:9:7
    |
 LL |     f(&1u8 as *const _);
    |       ^^^^^^^^^^^^^^^^ help: try: `std::ptr::from_ref(&1u8)`
@@ -8,262 +8,274 @@ LL |     f(&1u8 as *const _);
    = help: to override `-D warnings` add `#[allow(clippy::ref_as_ptr)]`
 
 error: reference as raw pointer
-  --> tests/ui/ref_as_ptr.rs:9:7
+  --> tests/ui/ref_as_ptr.rs:11:7
    |
 LL |     f(&2u32 as *const u32);
    |       ^^^^^^^^^^^^^^^^^^^ help: try: `std::ptr::from_ref::<u32>(&2u32)`
 
 error: reference as raw pointer
-  --> tests/ui/ref_as_ptr.rs:11:7
+  --> tests/ui/ref_as_ptr.rs:13:7
    |
 LL |     f(&3.0f64 as *const f64);
    |       ^^^^^^^^^^^^^^^^^^^^^ help: try: `std::ptr::from_ref::<f64>(&3.0f64)`
 
 error: reference as raw pointer
-  --> tests/ui/ref_as_ptr.rs:14:7
+  --> tests/ui/ref_as_ptr.rs:16:7
    |
 LL |     f(&4 as *const _ as *const f32);
    |       ^^^^^^^^^^^^^^ help: try: `std::ptr::from_ref(&4)`
 
 error: reference as raw pointer
-  --> tests/ui/ref_as_ptr.rs:16:7
+  --> tests/ui/ref_as_ptr.rs:18:7
    |
 LL |     f(&5.0f32 as *const f32 as *const u32);
    |       ^^^^^^^^^^^^^^^^^^^^^ help: try: `std::ptr::from_ref::<f32>(&5.0f32)`
 
 error: reference as raw pointer
-  --> tests/ui/ref_as_ptr.rs:19:7
+  --> tests/ui/ref_as_ptr.rs:21:7
    |
 LL |     f(&mut 6u8 as *const _);
    |       ^^^^^^^^^^^^^^^^^^^^ help: try: `std::ptr::from_ref(&mut 6u8)`
 
 error: reference as raw pointer
-  --> tests/ui/ref_as_ptr.rs:21:7
+  --> tests/ui/ref_as_ptr.rs:23:7
    |
 LL |     f(&mut 7u32 as *const u32);
    |       ^^^^^^^^^^^^^^^^^^^^^^^ help: try: `std::ptr::from_ref::<u32>(&mut 7u32)`
 
 error: reference as raw pointer
-  --> tests/ui/ref_as_ptr.rs:23:7
+  --> tests/ui/ref_as_ptr.rs:25:7
    |
 LL |     f(&mut 8.0f64 as *const f64);
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `std::ptr::from_ref::<f64>(&mut 8.0f64)`
 
 error: reference as raw pointer
-  --> tests/ui/ref_as_ptr.rs:26:7
+  --> tests/ui/ref_as_ptr.rs:28:7
    |
 LL |     f(&mut 9 as *const _ as *const f32);
    |       ^^^^^^^^^^^^^^^^^^ help: try: `std::ptr::from_ref(&mut 9)`
 
 error: reference as raw pointer
-  --> tests/ui/ref_as_ptr.rs:28:7
+  --> tests/ui/ref_as_ptr.rs:30:7
    |
 LL |     f(&mut 10.0f32 as *const f32 as *const u32);
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `std::ptr::from_ref::<f32>(&mut 10.0f32)`
 
 error: reference as raw pointer
-  --> tests/ui/ref_as_ptr.rs:31:7
+  --> tests/ui/ref_as_ptr.rs:33:7
    |
 LL |     f(&mut 11u8 as *mut _);
    |       ^^^^^^^^^^^^^^^^^^^ help: try: `std::ptr::from_mut(&mut 11u8)`
 
 error: reference as raw pointer
-  --> tests/ui/ref_as_ptr.rs:33:7
+  --> tests/ui/ref_as_ptr.rs:35:7
    |
 LL |     f(&mut 12u32 as *mut u32);
    |       ^^^^^^^^^^^^^^^^^^^^^^ help: try: `std::ptr::from_mut::<u32>(&mut 12u32)`
 
 error: reference as raw pointer
-  --> tests/ui/ref_as_ptr.rs:35:7
+  --> tests/ui/ref_as_ptr.rs:37:7
    |
 LL |     f(&mut 13.0f64 as *mut f64);
    |       ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `std::ptr::from_mut::<f64>(&mut 13.0f64)`
 
 error: reference as raw pointer
-  --> tests/ui/ref_as_ptr.rs:38:7
+  --> tests/ui/ref_as_ptr.rs:40:7
    |
 LL |     f(&mut 14 as *mut _ as *const f32);
    |       ^^^^^^^^^^^^^^^^^ help: try: `std::ptr::from_mut(&mut 14)`
 
 error: reference as raw pointer
-  --> tests/ui/ref_as_ptr.rs:40:7
+  --> tests/ui/ref_as_ptr.rs:42:7
    |
 LL |     f(&mut 15.0f32 as *mut f32 as *const u32);
    |       ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `std::ptr::from_mut::<f32>(&mut 15.0f32)`
 
 error: reference as raw pointer
-  --> tests/ui/ref_as_ptr.rs:43:7
+  --> tests/ui/ref_as_ptr.rs:45:7
    |
 LL |     f(&1u8 as *const _);
    |       ^^^^^^^^^^^^^^^^ help: try: `std::ptr::from_ref(&1u8)`
 
 error: reference as raw pointer
-  --> tests/ui/ref_as_ptr.rs:45:7
+  --> tests/ui/ref_as_ptr.rs:47:7
    |
 LL |     f(&2u32 as *const u32);
    |       ^^^^^^^^^^^^^^^^^^^ help: try: `std::ptr::from_ref::<u32>(&2u32)`
 
 error: reference as raw pointer
-  --> tests/ui/ref_as_ptr.rs:47:7
+  --> tests/ui/ref_as_ptr.rs:49:7
    |
 LL |     f(&3.0f64 as *const f64);
    |       ^^^^^^^^^^^^^^^^^^^^^ help: try: `std::ptr::from_ref::<f64>(&3.0f64)`
 
 error: reference as raw pointer
-  --> tests/ui/ref_as_ptr.rs:50:7
+  --> tests/ui/ref_as_ptr.rs:52:7
    |
 LL |     f(&4 as *const _ as *const f32);
    |       ^^^^^^^^^^^^^^ help: try: `std::ptr::from_ref(&4)`
 
 error: reference as raw pointer
-  --> tests/ui/ref_as_ptr.rs:52:7
+  --> tests/ui/ref_as_ptr.rs:54:7
    |
 LL |     f(&5.0f32 as *const f32 as *const u32);
    |       ^^^^^^^^^^^^^^^^^^^^^ help: try: `std::ptr::from_ref::<f32>(&5.0f32)`
 
 error: reference as raw pointer
-  --> tests/ui/ref_as_ptr.rs:56:7
+  --> tests/ui/ref_as_ptr.rs:58:7
    |
 LL |     f(&val as *const _);
    |       ^^^^^^^^^^^^^^^^ help: try: `std::ptr::from_ref(&val)`
 
 error: reference as raw pointer
-  --> tests/ui/ref_as_ptr.rs:58:7
+  --> tests/ui/ref_as_ptr.rs:60:7
    |
 LL |     f(&val as *const i32);
    |       ^^^^^^^^^^^^^^^^^^ help: try: `std::ptr::from_ref::<i32>(&val)`
 
 error: reference as raw pointer
-  --> tests/ui/ref_as_ptr.rs:61:7
+  --> tests/ui/ref_as_ptr.rs:63:7
    |
 LL |     f(&val as *const _ as *const f32);
    |       ^^^^^^^^^^^^^^^^ help: try: `std::ptr::from_ref(&val)`
 
 error: reference as raw pointer
-  --> tests/ui/ref_as_ptr.rs:63:7
+  --> tests/ui/ref_as_ptr.rs:65:7
    |
 LL |     f(&val as *const i32 as *const f64);
    |       ^^^^^^^^^^^^^^^^^^ help: try: `std::ptr::from_ref::<i32>(&val)`
 
 error: reference as raw pointer
-  --> tests/ui/ref_as_ptr.rs:67:7
+  --> tests/ui/ref_as_ptr.rs:68:39
+   |
+LL |     let _ptr_from_local: *const i32 = &val as *const _;
+   |                                       ^^^^^^^^^^^^^^^^ help: try: `std::ptr::from_ref(&val)`
+
+error: reference as raw pointer
+  --> tests/ui/ref_as_ptr.rs:72:7
    |
 LL |     f(&mut val as *mut u8);
    |       ^^^^^^^^^^^^^^^^^^^ help: try: `std::ptr::from_mut::<u8>(&mut val)`
 
 error: reference as raw pointer
-  --> tests/ui/ref_as_ptr.rs:69:7
+  --> tests/ui/ref_as_ptr.rs:74:7
    |
 LL |     f(&mut val as *mut _);
    |       ^^^^^^^^^^^^^^^^^^ help: try: `std::ptr::from_mut(&mut val)`
 
 error: reference as raw pointer
-  --> tests/ui/ref_as_ptr.rs:72:7
+  --> tests/ui/ref_as_ptr.rs:77:7
    |
 LL |     f(&mut val as *const u8);
    |       ^^^^^^^^^^^^^^^^^^^^^ help: try: `std::ptr::from_ref::<u8>(&mut val)`
 
 error: reference as raw pointer
-  --> tests/ui/ref_as_ptr.rs:74:7
+  --> tests/ui/ref_as_ptr.rs:79:7
    |
 LL |     f(&mut val as *const _);
    |       ^^^^^^^^^^^^^^^^^^^^ help: try: `std::ptr::from_ref(&mut val)`
 
 error: reference as raw pointer
-  --> tests/ui/ref_as_ptr.rs:77:7
+  --> tests/ui/ref_as_ptr.rs:82:7
    |
 LL |     f(&mut val as *const u8 as *const f64);
    |       ^^^^^^^^^^^^^^^^^^^^^ help: try: `std::ptr::from_ref::<u8>(&mut val)`
 
 error: reference as raw pointer
-  --> tests/ui/ref_as_ptr.rs:79:28
+  --> tests/ui/ref_as_ptr.rs:84:28
    |
 LL |     f::<*const Option<u8>>(&mut val as *const _ as *const _);
    |                            ^^^^^^^^^^^^^^^^^^^^ help: try: `std::ptr::from_ref(&mut val)`
 
 error: reference as raw pointer
-  --> tests/ui/ref_as_ptr.rs:82:7
+  --> tests/ui/ref_as_ptr.rs:87:7
    |
 LL |     f(&std::array::from_fn(|i| i * i) as *const [usize; 7]);
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `std::ptr::from_ref::<[usize; 7]>(&std::array::from_fn(|i| i * i))`
 
 error: reference as raw pointer
-  --> tests/ui/ref_as_ptr.rs:84:7
+  --> tests/ui/ref_as_ptr.rs:89:7
    |
 LL |     f(&mut std::array::from_fn(|i| i * i) as *const [usize; 8]);
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `std::ptr::from_ref::<[usize; 8]>(&mut std::array::from_fn(|i| i * i))`
 
 error: reference as raw pointer
-  --> tests/ui/ref_as_ptr.rs:86:7
+  --> tests/ui/ref_as_ptr.rs:91:7
    |
 LL |     f(&mut std::array::from_fn(|i| i * i) as *mut [usize; 9]);
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `std::ptr::from_mut::<[usize; 9]>(&mut std::array::from_fn(|i| i * i))`
 
 error: reference as raw pointer
-  --> tests/ui/ref_as_ptr.rs:109:7
+  --> tests/ui/ref_as_ptr.rs:94:40
+   |
+LL |     let _ptr_from_static: *const i32 = &STATIC_I32 as *const _;
+   |                                        ^^^^^^^^^^^^^^^^^^^^^^^ help: try: `std::ptr::from_ref(&STATIC_I32)`
+
+error: reference as raw pointer
+  --> tests/ui/ref_as_ptr.rs:117:7
    |
 LL |     f(val as *const i32);
    |       ^^^^^^^^^^^^^^^^^ help: try: `std::ptr::from_ref::<i32>(val)`
 
 error: reference as raw pointer
-  --> tests/ui/ref_as_ptr.rs:111:7
+  --> tests/ui/ref_as_ptr.rs:119:7
    |
 LL |     f(mut_val as *mut i32);
    |       ^^^^^^^^^^^^^^^^^^^ help: try: `std::ptr::from_mut::<i32>(mut_val)`
 
 error: reference as raw pointer
-  --> tests/ui/ref_as_ptr.rs:116:7
+  --> tests/ui/ref_as_ptr.rs:124:7
    |
 LL |     f(val as *const _);
    |       ^^^^^^^^^^^^^^^ help: try: `std::ptr::from_ref(val)`
 
 error: reference as raw pointer
-  --> tests/ui/ref_as_ptr.rs:118:7
+  --> tests/ui/ref_as_ptr.rs:126:7
    |
 LL |     f(val as *const [u8]);
    |       ^^^^^^^^^^^^^^^^^^ help: try: `std::ptr::from_ref::<[u8]>(val)`
 
 error: reference as raw pointer
-  --> tests/ui/ref_as_ptr.rs:123:7
+  --> tests/ui/ref_as_ptr.rs:131:7
    |
 LL |     f(val as *mut _);
    |       ^^^^^^^^^^^^^ help: try: `std::ptr::from_mut(val)`
 
 error: reference as raw pointer
-  --> tests/ui/ref_as_ptr.rs:125:7
+  --> tests/ui/ref_as_ptr.rs:133:7
    |
 LL |     f(val as *mut str);
    |       ^^^^^^^^^^^^^^^ help: try: `std::ptr::from_mut::<str>(val)`
 
 error: reference as raw pointer
-  --> tests/ui/ref_as_ptr.rs:133:9
+  --> tests/ui/ref_as_ptr.rs:141:9
    |
 LL |         self.0 as *const _ as *const _
    |         ^^^^^^^^^^^^^^^^^^ help: try: `std::ptr::from_ref(self.0)`
 
 error: reference as raw pointer
-  --> tests/ui/ref_as_ptr.rs:138:9
+  --> tests/ui/ref_as_ptr.rs:146:9
    |
 LL |         self.0 as *const _ as *const _
    |         ^^^^^^^^^^^^^^^^^^ help: try: `std::ptr::from_ref(self.0)`
 
 error: reference as raw pointer
-  --> tests/ui/ref_as_ptr.rs:147:9
+  --> tests/ui/ref_as_ptr.rs:155:9
    |
 LL |         self.0 as *const _ as *const _
    |         ^^^^^^^^^^^^^^^^^^ help: try: `std::ptr::from_ref(self.0)`
 
 error: reference as raw pointer
-  --> tests/ui/ref_as_ptr.rs:152:9
+  --> tests/ui/ref_as_ptr.rs:160:9
    |
 LL |         self.0 as *const _ as *const _
    |         ^^^^^^^^^^^^^^^^^^ help: try: `std::ptr::from_ref(self.0)`
 
 error: reference as raw pointer
-  --> tests/ui/ref_as_ptr.rs:157:9
+  --> tests/ui/ref_as_ptr.rs:165:9
    |
 LL |         self.0 as *mut _ as *mut _
    |         ^^^^^^^^^^^^^^^^ help: try: `std::ptr::from_mut(self.0)`
 
-error: aborting due to 44 previous errors
+error: aborting due to 46 previous errors
 


### PR DESCRIPTION
Fix `ref_as_ptr` lint: ignore casts used to initialize `const`/`static`/`let` bindings and avoid linting temporary values.

- Do not lint `&STATIC_I32 as *const _` and `&val as *const _` when used to initialize `const`/`static`/`let`.
- Still lint other `&T as *const U` / `&mut T as *mut U` casts and suggest `std::ptr::from_ref` / `from_mut`.