### PR TITLE
Build auxiliary in pretty tests

### DIFF
--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -439,6 +439,9 @@ impl<'test> TestCx<'test> {
         };
 
         let mut rustc = Command::new(&self.config.rustc_path);
+
+        self.build_all_auxiliary(&self.aux_output_dir(), &mut rustc);
+
         rustc
             .arg(input)
             .args(&["-Z", &format!("unpretty={}", pretty_type)])


### PR DESCRIPTION
I've encountered a problem with building auxiliary in pretty tests with the following configuration:
```
//@ edition:2021
//@ aux-crate:to_reuse_functions=to-reuse-functions.rs
//@ pretty-mode:hir
//@ pretty-compare-only
//@ pp-exact:delegation-inherit-attributes.pp
```

In such kind of tests, I want to test the resulting HIR, without final typecheck (`pretty-compare-only`). I plan to use such tests during testing the attribute inheritance in delegation feature. However, related auxiliary is built only in [self.typecheck_source](https://github.com/rust-lang/rust/blob/2e667b0c6491678642a83e3aff86626397360af5/src/tools/compiletest/src/runtest/pretty.rs#L79) method (in `compose_and_run_compiler` routine), so it is impossible to execute test in my scenario. As a solution I've added the auxiliary build in [print_source](https://github.com/rust-lang/rust/blob/2e667b0c6491678642a83e3aff86626397360af5/src/tools/compiletest/src/runtest.rs#L434) method, so it is also built in a compare only scenarios.

I've tried to search other solutions to this problem, but I haven't found a way to force auxiliary build in such a configuration of a pretty test.

r? @petrochenkov 