### PR TITLE
Use `PointeeSized` bound for `TrivialClone` impls

### DIFF
--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -860,7 +860,7 @@ impl<T: PointeeSized> Clone for PhantomData<T> {
 
 #[doc(hidden)]
 #[unstable(feature = "trivial_clone", issue = "none")]
-unsafe impl<T: ?Sized> TrivialClone for PhantomData<T> {}
+unsafe impl<T: PointeeSized> TrivialClone for PhantomData<T> {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_const_unstable(feature = "const_default", issue = "143894")]

--- a/library/core/src/ptr/metadata.rs
+++ b/library/core/src/ptr/metadata.rs
@@ -233,7 +233,7 @@ impl<Dyn: PointeeSized> Clone for DynMetadata<Dyn> {
 }
 
 #[doc(hidden)]
-unsafe impl<Dyn: ?Sized> TrivialClone for DynMetadata<Dyn> {}
+unsafe impl<Dyn: PointeeSized> TrivialClone for DynMetadata<Dyn> {}
 
 impl<Dyn: PointeeSized> Eq for DynMetadata<Dyn> {}
 

--- a/library/core/src/ptr/non_null.rs
+++ b/library/core/src/ptr/non_null.rs
@@ -1656,7 +1656,7 @@ impl<T: PointeeSized> Copy for NonNull<T> {}
 
 #[doc(hidden)]
 #[unstable(feature = "trivial_clone", issue = "none")]
-unsafe impl<T: ?Sized> TrivialClone for NonNull<T> {}
+unsafe impl<T: PointeeSized> TrivialClone for NonNull<T> {}
 
 #[unstable(feature = "coerce_unsized", issue = "18598")]
 impl<T: PointeeSized, U: PointeeSized> CoerceUnsized<NonNull<U>> for NonNull<T> where T: Unsize<U> {}

--- a/library/core/src/ptr/unique.rs
+++ b/library/core/src/ptr/unique.rs
@@ -168,7 +168,7 @@ impl<T: PointeeSized> Copy for Unique<T> {}
 
 #[doc(hidden)]
 #[unstable(feature = "trivial_clone", issue = "none")]
-unsafe impl<T: ?Sized> TrivialClone for Unique<T> {}
+unsafe impl<T: PointeeSized> TrivialClone for Unique<T> {}
 
 #[unstable(feature = "ptr_internals", issue = "none")]
 impl<T: PointeeSized, U: PointeeSized> CoerceUnsized<Unique<U>> for Unique<T> where T: Unsize<U> {}


### PR DESCRIPTION
These `TrivialClone` impls previously had `?Sized` bounds, which are different from the `PointeeSized` bounds on the corresponding `Clone` and `Copy` impls. So, I've changed the `?Sized` bounds into `PointeeSized` bounds.

This mistake was made presumably because the `TrivialClone` PR (https://github.com/rust-lang/rust/pull/135634) was opened in Jan 2025, but merged in Nov 2025. During that time, the sized hierachy PR (https://github.com/rust-lang/rust/pull/137944) was opened in Mar 2025, and merged in Jun 2025. The `TrivialClone` PR was not updated to account for the sized hierachy changes.

r? @joboet 