### PR TITLE
Fix ICE when checking const qualifs for unevaluated constants

### DIFF
--- a/compiler/rustc_const_eval/src/check_consts/qualifs.rs
+++ b/compiler/rustc_const_eval/src/check_consts/qualifs.rs
@@ -349,11 +349,11 @@ where
         Const::Ty(_, ct) => match ct.kind() {
             ty::ConstKind::Param(_) | ty::ConstKind::Error(_) | ty::ConstKind::Value(_) => None,
             ty::ConstKind::Unevaluated(uv) => {
-                // Convert ty::UnevaluatedConst to mir::UnevaluatedConst
+                // FIXME(generic_const_exprs): remove this once the feature is replaced by gca
                 Some(mir::UnevaluatedConst {
                     def: uv.def,
                     args: uv.args,
-                    promoted: None, // <--- You need this field!
+                    promoted: None,
                 })
             }
             _ => bug!(

--- a/tests/ui/const-generics/ice-const-generic-unevaluated-145138.rs
+++ b/tests/ui/const-generics/ice-const-generic-unevaluated-145138.rs
@@ -1,0 +1,32 @@
+#![feature(generic_const_exprs)]
+#![allow(incomplete_features)]
+
+trait One: Sized {
+    const ONE: Self;
+}
+
+const fn noop<T: One>(a: &mut T, b: &mut T) {
+    _ = (a, b);
+}
+
+struct Test<T: One, const LEN: usize>([T; LEN * LEN])
+where
+    [u8; LEN * LEN]:;
+
+impl<T: One, const LEN: usize> Test<T, LEN>
+where
+    [u8; LEN * LEN]:,
+{
+    const fn test() -> Self {
+        let mut a = Self([T::ONE; LEN * LEN]);
+        let mut i = 0;
+        while i < LEN {
+            let mut one = T::ONE; //~ ERROR destructor of `T` cannot be evaluated at compile-time
+            noop(&mut one, &mut a.0[i * i + 1]);
+            i += 1;
+        }
+        a
+    }
+}
+
+fn main() {}

--- a/tests/ui/const-generics/ice-const-generic-unevaluated-145138.stderr
+++ b/tests/ui/const-generics/ice-const-generic-unevaluated-145138.stderr
@@ -1,0 +1,12 @@
+error[E0493]: destructor of `T` cannot be evaluated at compile-time
+  --> $DIR/ice-const-generic-unevaluated-145138.rs:24:17
+   |
+LL |             let mut one = T::ONE;
+   |                 ^^^^^^^ the destructor for this type cannot be evaluated in constant functions
+...
+LL |         }
+   |         - value is dropped here
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0493`.

--- a/tests/ui/const-generics/ice-const-generic-unevaluated-149844.rs
+++ b/tests/ui/const-generics/ice-const-generic-unevaluated-149844.rs
@@ -1,0 +1,27 @@
+//@ build-pass
+#![allow(incomplete_features)]
+#![feature(generic_const_exprs)]
+#![feature(const_trait_impl)]
+#![feature(const_convert)]
+
+#[derive(Clone, Copy, Debug)]
+pub struct A<T: const From<u8>, const N: usize>
+where
+    [(); N / 8]:,
+{
+    b: [u8; N / 8],
+}
+
+impl<T: const From<u8>, const N: usize> A<T, N>
+where
+    [(); N / 8]:,
+{
+    pub const fn f(&self) -> T
+    where
+        [(); N / 8]:,
+    {
+        self.b[0].into()
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
This PR fixes an internal compiler error (ICE) that occurred when checking constant qualifications (specifically NeedsDrop) for Const::Ty variants that contained an Unevaluated kind.

Previously, the code in rustc_const_eval/src/check_consts/qualifs.rs only handled Param, Error, and Value kinds, panicking on Unevaluated via bug!(). This PR adds a match arm for ty::ConstKind::Unevaluated that correctly converts it to mir::UnevaluatedConst and propagates it, similar to how the existing Const::Unevaluated branch behaves.

This fixes the crash observed when mixing generic const expressions with const trait-bounded generic type parameters.

Fixes rust-lang/rust#149844
Fixes rust-lang/rust#145138
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
