### PR TITLE
Fix : Handle inconsistent resolution gracefully

### DIFF
--- a/compiler/rustc_resolve/src/imports.rs
+++ b/compiler/rustc_resolve/src/imports.rs
@@ -1171,7 +1171,16 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                         }
                         if let Some(initial_res) = initial_res {
                             if res != initial_res {
-                                span_bug!(import.span, "inconsistent resolution for an import");
+                                // If we already have errors, ignore the inconsistency.
+                                if this.dcx().has_errors().is_some() {
+                                    return;
+                                }
+
+                                this.dcx().span_delayed_bug(
+                                    import.span,
+                                    "inconsistent resolution for an import",
+                                );
+                                return;
                             }
                         } else if this.privacy_errors.is_empty() {
                             this.dcx()

--- a/tests/ui/resolve/ice-inconsistent-resolution-149821.rs
+++ b/tests/ui/resolve/ice-inconsistent-resolution-149821.rs
@@ -1,0 +1,17 @@
+//@ edition: 2024
+
+mod m {
+    use crate::*;
+    use core;
+}
+
+macro_rules! define_other_core {
+    () => {
+        extern crate std as core;
+        //~^ ERROR macro-expanded `extern crate` items cannot shadow names passed with `--extern`
+    };
+}
+
+define_other_core! {}
+
+fn main() {}

--- a/tests/ui/resolve/ice-inconsistent-resolution-149821.stderr
+++ b/tests/ui/resolve/ice-inconsistent-resolution-149821.stderr
@@ -1,0 +1,13 @@
+error: macro-expanded `extern crate` items cannot shadow names passed with `--extern`
+  --> $DIR/ice-inconsistent-resolution-149821.rs:10:9
+   |
+LL |         extern crate std as core;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+...
+LL | define_other_core! {}
+   | --------------------- in this macro invocation
+   |
+   = note: this error originates in the macro `define_other_core` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
This PR fixes an Internal Compiler Error (ICE) that occurs when a macro-expanded `extern crate` shadows a name passed with `--extern`.

### The Issue
When `extern crate std as core;` is expanded from a macro while `core` is already imported (e.g. via `use core;` or `use crate::*;`), the resolver ends up in an inconsistent state where the `initial_res` differs from the final resolution `res`. Previously, this triggered a `span_bug!` panic in `finalize_import`.

### The Fix
The resolver already correctly identifies and reports the shadowing error (`macro-expanded extern crate items cannot shadow names passed with --extern`).

This PR modifies `finalize_import` to check if any errors have already been reported (`this.dcx().has_errors()`). If an error exists, we suppress the panic, assuming the inconsistency is a side-effect of the invalid code. As a fallback safety measure, `span_bug!` was replaced with `span_delayed_bug` to ensure we don't crash if the shadowing error were to be suppressed in the future.

### Test
Added regression test: `tests/ui/resolve/ice-inconsistent-resolution-149821.rs`
Fixes rust-lang/rust#149821

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
