### PR TITLE
Mark `into_iter` as `#[must_use]`

### DIFF
--- a/library/core/src/iter/traits/collect.rs
+++ b/library/core/src/iter/traits/collect.rs
@@ -306,6 +306,7 @@ pub trait IntoIterator {
     /// assert_eq!(None, iter.next());
     /// ```
     #[lang = "into_iter"]
+    #[must_use = "Iterators do nothing unless iterated over"]
     #[stable(feature = "rust1", since = "1.0.0")]
     fn into_iter(self) -> Self::IntoIter;
 }

--- a/library/coretests/tests/array.rs
+++ b/library/coretests/tests/array.rs
@@ -193,7 +193,7 @@ fn iterator_drops() {
     // Simple: drop new iterator.
     let i = Cell::new(0);
     {
-        IntoIterator::into_iter(five(&i));
+        drop(IntoIterator::into_iter(five(&i)));
     }
     assert_eq!(i.get(), 5);
 

--- a/tests/ui/borrowck/unboxed-closures-move-upvar-from-non-once-ref-closure.rs
+++ b/tests/ui/borrowck/unboxed-closures-move-upvar-from-non-once-ref-closure.rs
@@ -9,7 +9,7 @@ fn call<F>(f: F) where F : Fn() {
 fn main() {
     let y = vec![format!("World")];
     call(|| {
-        y.into_iter();
+        let _ = y.into_iter();
         //~^ ERROR cannot move out of `y`, a captured variable in an `Fn` closure
     });
 }


### PR DESCRIPTION
`into_iter` serves no function if not iterated over.

If it's being used just to consume `self`, that would be better served by `drop`.
