### PR TITLE
Avoid tearing dbg! prints

### DIFF
--- a/library/std/src/macros.rs
+++ b/library/std/src/macros.rs
@@ -386,7 +386,7 @@ macro_rules! dbg {
             let mut output = $crate::string::String::with_capacity(
                 // Make an educated guess about the final size to avoid
                 // multiple reallocations.
-                const { $(100 + $crate::file!().len() + $crate::stringify($val).len())++ },
+                const { 0 $(+ 100 + $crate::file!().len() + $crate::stringify!($val).len())+ },
             );
             let eager_eval = ($(
                 // Use of `match` here is intentional because it affects the lifetimes


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/136703.

I did attempt a solution which collects all expressions into a tuple `tmp` before iterating over that tuple using the unstable `macro_metavar_expr` `tmp.${index()}`, but that refused to compile even with `#[allow_internal_unstable(macro_metavar_expr)]` and/or `#![feature(macro_metavar_expr)]`:

```rust
error[E0658]: meta-variable expressions are unstable
   --> /Users/orlp/programming/rust/rust/library/std/src/macros.rs:394:34
    |
394 |                     &eager_eval.${index()} as &dyn $crate::fmt::Debug,
    |                                  ^^^^^^^^^
    |
    = note: see issue #83527 <https://github.com/rust-lang/rust/issues/83527> for more information
    = help: add `#![feature(macro_metavar_expr)]` to the crate attributes to enable
```

As mentioned in the code comment, the original proposed solution in the issue of simply holding the `stderr` lock is undesirable because it can lead to deadlocks.