### PR TITLE
std: Don't use `linkat` on the `wasm32-wasi*` targets

### DIFF
--- a/library/std/src/sys/fs/unix.rs
+++ b/library/std/src/sys/fs/unix.rs
@@ -2077,12 +2077,25 @@ pub fn symlink(original: &CStr, link: &CStr) -> io::Result<()> {
 
 pub fn link(original: &CStr, link: &CStr) -> io::Result<()> {
     cfg_select! {
-        any(target_os = "vxworks", target_os = "redox", target_os = "android", target_os = "espidf", target_os = "horizon", target_os = "vita", target_env = "nto70") => {
-            // VxWorks, Redox and ESP-IDF lack `linkat`, so use `link` instead. POSIX leaves
-            // it implementation-defined whether `link` follows symlinks, so rely on the
-            // `symlink_hard_link` test in library/std/src/fs/tests.rs to check the behavior.
-            // Android has `linkat` on newer versions, but we happen to know `link`
-            // always has the correct behavior, so it's here as well.
+        any(
+            // VxWorks, Redox and ESP-IDF lack `linkat`, so use `link` instead.
+            // POSIX leaves it implementation-defined whether `link` follows
+            // symlinks, so rely on the `symlink_hard_link` test in
+            // library/std/src/fs/tests.rs to check the behavior.
+            target_os = "vxworks",
+            target_os = "redox",
+            target_os = "espidf",
+            // Android has `linkat` on newer versions, but we happen to know
+            // `link` always has the correct behavior, so it's here as well.
+            target_os = "android",
+            // wasi-sdk-29-and-prior have a buggy `linkat` so use `link` instead
+            // until wasi-sdk is updated (see WebAssembly/wasi-libc#690)
+            target_os = "wasi",
+            // Other misc platforms
+            target_os = "horizon",
+            target_os = "vita",
+            target_env = "nto70",
+        ) => {
             cvt(unsafe { libc::link(original.as_ptr(), link.as_ptr()) })?;
         }
         _ => {


### PR DESCRIPTION
This commit is a follow-up to rust-lang/rust#147572 and the issue reported at the end of that PR where the `std::fs::hard_link` function is broken after that PR landed. The true culprit and bug here is fixed in WebAssembly/wasi-libc#690 but until that's released in a wasi-sdk version it should be reasonable, on WASI, to skip the `linkat` function.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
