### PR TITLE
miri: add -Zbinary-dep-depinfo to dependency builds

### DIFF
--- a/src/tools/clippy/tests/compile-test.rs
+++ b/src/tools/clippy/tests/compile-test.rs
@@ -173,6 +173,10 @@ impl TestContext {
                         p.envs.push(("RUSTC_SNAPSHOT".into(), Some(rustc.into())));
                         p.envs.push(("RUSTC_SNAPSHOT_LIBDIR".into(), Some(libdir.into())));
                         p.envs.push(("RUSTC_SYSROOT".into(), Some(sysroot.into())));
+                        // Ensure we rebuild the dependencies when the sysroot changes.
+                        // (Bootstrap usually sets this automatically, but since we invoke cargo
+                        // ourselves we have to do it.)
+                        p.args.push("-Zbinary-dep-depinfo".into());
                     }
                     p
                 },

--- a/src/tools/miri/tests/ui.rs
+++ b/src/tools/miri/tests/ui.rs
@@ -133,7 +133,11 @@ fn miri_config(
                     program: miri_path()
                         .with_file_name(format!("cargo-miri{}", env::consts::EXE_SUFFIX)),
                     // There is no `cargo miri build` so we just use `cargo miri run`.
-                    args: ["miri", "run"].into_iter().map(Into::into).collect(),
+                    // Add `-Zbinary-dep-depinfo` since it is needed for bootstrap builds (and doesn't harm otherwise).
+                    args: ["miri", "run", "--quiet", "-Zbinary-dep-depinfo"]
+                        .into_iter()
+                        .map(Into::into)
+                        .collect(),
                     // Reset `RUSTFLAGS` to work around <https://github.com/rust-lang/rust/pull/119574#issuecomment-1876878344>.
                     envs: vec![("RUSTFLAGS".into(), None)],
                     ..CommandBuilder::cargo()


### PR DESCRIPTION
Hopefully fixes https://github.com/rust-lang/rust/issues/149711

Cc @bjorn3 