### PR TITLE
add regression test for `proc_macro` error subdiagnostics

### DIFF
--- a/tests/ui/proc-macro/auxiliary/sub-error-diag.rs
+++ b/tests/ui/proc-macro/auxiliary/sub-error-diag.rs
@@ -1,0 +1,17 @@
+#![feature(proc_macro_diagnostic)]
+
+extern crate proc_macro;
+
+use proc_macro::{Diagnostic, Level, Span};
+
+#[proc_macro_attribute]
+pub fn proc_emit_err(
+    _: proc_macro::TokenStream,
+    input: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+    Diagnostic::new(Level::Error, "Parent message")
+        .span_error(Span::call_site(), "Child message")
+        .emit();
+
+    input
+}

--- a/tests/ui/proc-macro/sub-error-diag.rs
+++ b/tests/ui/proc-macro/sub-error-diag.rs
@@ -1,0 +1,13 @@
+//@ proc-macro: sub-error-diag.rs
+
+// Regression test for issue https://github.com/rust-lang/rust/issues/145305, which used to cause an ICE
+// due to an assertion in the compiler that errors could not be subdiagnostics.
+
+extern crate sub_error_diag;
+
+//~? ERROR: Parent message
+#[sub_error_diag::proc_emit_err]
+//~^ ERROR: Child message
+fn foo() {}
+
+fn main() {}

--- a/tests/ui/proc-macro/sub-error-diag.stderr
+++ b/tests/ui/proc-macro/sub-error-diag.stderr
@@ -1,0 +1,11 @@
+error: Parent message
+   |
+error: Child message
+  --> $DIR/sub-error-diag.rs:9:1
+   |
+LL | #[sub_error_diag::proc_emit_err]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: this error originates in the attribute macro `sub_error_diag::proc_emit_err` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
The previous ICE was already fixed by rust-lang/rust#148188, but no test was added at that time.
Closes rust-lang/rust#145305.