### PR TITLE
Add x86_64-asan-windows-msvc tier 3 target

### DIFF
--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -1800,6 +1800,8 @@ supported_targets! {
     ("x86_64-lynx-lynxos178", x86_64_lynx_lynxos178),
 
     ("x86_64-pc-cygwin", x86_64_pc_cygwin),
+
+    ("x86_64-asan-windows-msvc", x86_64_asan_windows_msvc),
 }
 
 /// Cow-Vec-Str: Cow<'static, [Cow<'static, str>]>

--- a/compiler/rustc_target/src/spec/targets/x86_64_asan_windows_msvc.rs
+++ b/compiler/rustc_target/src/spec/targets/x86_64_asan_windows_msvc.rs
@@ -1,0 +1,16 @@
+use crate::spec::{SanitizerSet, Target, TargetMetadata};
+
+pub(crate) fn target() -> Target {
+    let mut base = super::x86_64_pc_windows_msvc::target();
+    base.metadata = TargetMetadata {
+        description: Some("64-bit Windows with ASAN enabled by default".into()),
+        tier: Some(3),
+        host_tools: Some(false),
+        std: Some(true),
+    };
+    base.options.default_sanitizers = SanitizerSet::ADDRESS;
+
+    assert!(base.options.default_sanitizers.contains(SanitizerSet::ADDRESS));
+
+    base
+}

--- a/src/bootstrap/src/core/sanity.rs
+++ b/src/bootstrap/src/core/sanity.rs
@@ -42,6 +42,7 @@ const STAGE0_MISSING_TARGETS: &[&str] = &[
     // just a dummy comment so the list doesn't get onelined
     "riscv64gc-unknown-redox",
     "hexagon-unknown-qurt",
+    "x86_64-asan-windows-msvc",
 ];
 
 /// Minimum version threshold for libstdc++ required when using prebuilt LLVM

--- a/src/doc/rustc/src/SUMMARY.md
+++ b/src/doc/rustc/src/SUMMARY.md
@@ -146,6 +146,7 @@
     - [windows-gnullvm](platform-support/windows-gnullvm.md)
     - [\*-win7-windows-gnu](platform-support/win7-windows-gnu.md)
     - [\*-win7-windows-msvc](platform-support/win7-windows-msvc.md)
+    - [x86_64-asan-windows-msvc](platform-support/x86_64-asan-windows-msvc.md)
     - [x86_64-fortanix-unknown-sgx](platform-support/x86_64-fortanix-unknown-sgx.md)
     - [x86_64-pc-cygwin](platform-support/x86_64-pc-cygwin.md)
     - [x86_64-unknown-linux-none](platform-support/x86_64-unknown-linux-none.md)

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -425,6 +425,7 @@ target | std | host | notes
 [`wasm32-wasip3`](platform-support/wasm32-wasip3.md) | ✓ | WebAssembly with WASIp3
 [`x86_64-apple-tvos`](platform-support/apple-tvos.md) | ✓ |  | x86 64-bit tvOS
 [`x86_64-apple-watchos-sim`](platform-support/apple-watchos.md) | ✓ |  | x86 64-bit Apple WatchOS simulator
+[`x86_64-asan-windows-msvc`](platform-support/x86_64-asan-windows-msvc.md) | ✓ |  | x86 64-bit Windows with AddressSanitizer
 [`x86_64-lynx-lynxos178`](platform-support/lynxos178.md) |   |  | x86_64 LynxOS-178
 [`x86_64-pc-cygwin`](platform-support/x86_64-pc-cygwin.md) | ✓ |  | 64-bit x86 Cygwin |
 [`x86_64-pc-nto-qnx710`](platform-support/nto-qnx.md) | ✓ |  | x86 64-bit QNX Neutrino 7.1 RTOS with default network stack (io-pkt) |

--- a/src/doc/rustc/src/platform-support/x86_64-asan-windows-msvc.md
+++ b/src/doc/rustc/src/platform-support/x86_64-asan-windows-msvc.md
@@ -2,7 +2,7 @@
 
 **Tier: 3**
 
-Target mirror `x86_64-pc-windows-msvc` with AddressSanitizer enabled by default.
+Target mirrors `x86_64-pc-windows-msvc` with AddressSanitizer enabled by default.
 
 ## Target maintainers
 

--- a/src/doc/rustc/src/platform-support/x86_64-asan-windows-msvc.md
+++ b/src/doc/rustc/src/platform-support/x86_64-asan-windows-msvc.md
@@ -49,7 +49,8 @@ rustc --target x86_64-asan-windows-msvc my_program.rs
 Programs compiled for this target require `clang_rt.asan_dynamic-x86_64.dll` to
 be available. This can be installed by using the Visual Studio Installer to
 install the C++ AddressSanitizer component. Once installed, add the directory
-containing the DLL to your `PATH`.
+containing the DLL to your `PATH` or run your program from a Visual Studio
+Developer Command Prompt.
 
 ## Cross-compilation toolchains and C code
 

--- a/src/doc/rustc/src/platform-support/x86_64-asan-windows-msvc.md
+++ b/src/doc/rustc/src/platform-support/x86_64-asan-windows-msvc.md
@@ -1,0 +1,58 @@
+# `x86_64-asan-windows-msvc`
+
+**Tier: 3**
+
+Target mirror `x86_64-pc-windows-msvc` with AddressSanitizer enabled by default.
+
+## Target maintainers
+
+[@ChrisDenton](https://github.com/ChrisDenton)
+[@dpaoliello](https://github.com/dpaoliello)
+[@eholk](https://github.com/eholk)
+[@Fulgen301](https://github.com/Fulgen301)
+[@lambdageek](https://github.com/lambdageek)
+[@sivadeilra](https://github.com/sivadeilra)
+[@wesleywiser](https://github.com/wesleywiser)
+
+## Requirements
+
+This target is for cross-compilation only. Host tools are not supported because
+this target's primary use cases do not require the host tools to be instrumented
+with AddressSanitizer. The standard library is fully supported.
+
+In all other aspects, this target is identical to `x86_64-pc-windows-msvc`.
+
+## Building the target
+
+This target can be built by adding it to the `target` list in `bootstrap.toml`.
+
+```toml
+[build]
+target = ["x86_64-asan-windows-msvc"]
+```
+
+## Building Rust programs
+
+Rust does not yet ship pre-compiled artifacts for this target. To compile for
+this target, you will either need to build Rust with the target enabled (see
+"Building the target" above), or build your own copy of `core` by using
+`build-std` or similar.
+
+Compilation can be done with:
+
+```sh
+rustc --target x86_64-asan-windows-msvc my_program.rs
+```
+
+## Testing
+
+Programs compiled for this target require `clang_rt.asan_dynamic-x86_64.dll` to
+be available. This can be installed by using the Visual Studio Installer to
+install the C++ AddressSanitizer component. Once installed, add the directory
+containing the DLL to your `PATH`.
+
+## Cross-compilation toolchains and C code
+
+Architectural cross-compilation from one Windows host to a different Windows
+platform is natively supported by the MSVC toolchain provided the appropriate
+components are selected when using the VS Installer.

--- a/tests/assembly-llvm/targets/targets-pe.rs
+++ b/tests/assembly-llvm/targets/targets-pe.rs
@@ -67,6 +67,9 @@
 //@ revisions: x86_64_pc_windows_msvc
 //@ [x86_64_pc_windows_msvc] compile-flags: --target x86_64-pc-windows-msvc
 //@ [x86_64_pc_windows_msvc] needs-llvm-components: x86
+//@ revisions: x86_64_asan_windows_msvc
+//@ [x86_64_asan_windows_msvc] compile-flags: --target x86_64-asan-windows-msvc
+//@ [x86_64_asan_windows_msvc] needs-llvm-components: x86
 //@ revisions: x86_64_unknown_uefi
 //@ [x86_64_unknown_uefi] compile-flags: --target x86_64-unknown-uefi
 //@ [x86_64_unknown_uefi] needs-llvm-components: x86


### PR DESCRIPTION
This is a companion to rust-lang/rust#149644 and adds a target that can be used to enable AddressSanitizer by default on Windows.

> - A tier 3 target must have a designated developer or developers (the "target
  maintainers") on record to be CCed when issues arise regarding the target.

I and the other maintainers of the Windows MSVC targets will be responsible for this target.

(cc @ChrisDenton @dpaoliello @Fulgen301  @lambdageek @sivadeilra @wesleywiser)

> - Targets must use naming consistent with any existing targets; for instance, a
  target for the same CPU or OS as an existing Rust target should use the same
  name for that CPU or OS. Targets should normally use the same names and
  naming conventions as used elsewhere in the broader ecosystem beyond Rust
  (such as in other toolchains), unless they have a very good reason to
  diverge. Changing the name of a target can be highly disruptive, especially
  once the target reaches a higher tier, so getting the name right is important
  even for a tier 3 target.

This target follows the naming conventions agreed on for the similar `x86_64-asan-linux-gnu` target.

> - Tier 3 targets may have unusual requirements to build or use, but must not
  create legal issues or impose onerous legal terms for the Rust project or for
  Rust developers or users.

This PR introduces no new legal terms or conditions.

> - Neither this policy nor any decisions made regarding targets shall create any
  binding agreement or estoppel by any party. If any member of an approving
  Rust team serves as one of the maintainers of a target, or has any legal or
  employment requirement (explicit or implicit) that might affect their
  decisions regarding a target, they must recuse themselves from any approval
  decisions regarding the target's tier status, though they may otherwise
  participate in discussions.

Understood.

> - Tier 3 targets should attempt to implement as much of the standard libraries
  as possible and appropriate (`core` for most targets, `alloc` for targets
  that can support dynamic memory allocation, `std` for targets with an
  operating system or equivalent layer of system-provided functionality), but
  may leave some code unimplemented (either unavailable or stubbed out as
  appropriate), whether because the target makes it impossible to implement or
  challenging to implement. The authors of pull requests are not obligated to
  avoid calling any portions of the standard library on the basis of a tier 3
  target not implementing those portions.

This is able to implement the same portions of the standard library that are supported by the other MSVC targets.

> - The target must provide documentation for the Rust community explaining how
  to build for the target, using cross-compilation if possible. If the target
  supports running binaries, or running tests (even if they do not pass), the
  documentation must explain how to run such binaries or tests for the target,
  using emulation if possible or dedicated hardware if necessary.

This PR includes such documentation.

> - Tier 3 targets must not impose burden on the authors of pull requests, or
  other developers in the community, to maintain the target. In particular,
  do not post comments (automated or manual) on a PR that derail or suggest a
  block on the PR based on a tier 3 target. Do not send automated messages or
  notifications (via any medium, including via `@`) to a PR author or others
  involved with a PR regarding a tier 3 target, unless they have opted into
  such messages.

Understood.

> - Patches adding or updating tier 3 targets must not break any existing tier 2
  or tier 1 target, and must not knowingly break another tier 3 target without
  approval of either the compiler team or the maintainers of the other tier 3
  target.

Understood.

> - Tier 3 targets must be able to produce assembly using at least one of
  rustc's supported backends from any host target. (Having support in a fork
  of the backend is not sufficient, it must be upstream.)

This target uses LLVM for code generation.