### PR TITLE
const-eval: always do full typed copies

### DIFF
--- a/compiler/rustc_const_eval/src/const_eval/machine.rs
+++ b/compiler/rustc_const_eval/src/const_eval/machine.rs
@@ -408,8 +408,8 @@ impl<'tcx> interpret::Machine<'tcx> for CompileTimeMachine<'tcx> {
     }
 
     #[inline(always)]
-    fn enforce_validity(ecx: &InterpCx<'tcx, Self>, layout: TyAndLayout<'tcx>) -> bool {
-        ecx.tcx.sess.opts.unstable_opts.extra_const_ub_checks || layout.is_uninhabited()
+    fn enforce_validity(_ecx: &InterpCx<'tcx, Self>, _layout: TyAndLayout<'tcx>) -> bool {
+        true
     }
 
     fn load_mir(


### PR DESCRIPTION
Perf experiment exploring alternatives to https://github.com/rust-lang/rust/pull/148967.

This is the maximally naive version that just always does full typed copies. It may be possible to skip some of the validation work if all we care about is resetting padding -- though it's not obvious to me how to do that in a way that actually helps with performance. Also, typed copies at integer type technically do not preserve provenance, which could become relevant in const-eval for the same reason as provenance in padding (see https://github.com/rust-lang/rust/issues/148470) -- so it's not like we can just skip all types without padding.