### PR TITLE
bootstrap: Don't pass an unused `--color` to compiletest

### DIFF
--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -2401,7 +2401,6 @@ Please disable assertions with `rust.debug-assertions = false`.
         let git_config = builder.config.git_config();
         cmd.arg("--nightly-branch").arg(git_config.nightly_branch);
         cmd.arg("--git-merge-commit-email").arg(git_config.git_merge_commit_email);
-        cmd.force_coloring_in_ci();
 
         #[cfg(feature = "build-metrics")]
         builder.metrics.begin_test_suite(

--- a/src/bootstrap/src/core/builder/cargo.rs
+++ b/src/bootstrap/src/core/builder/cargo.rs
@@ -2,6 +2,8 @@ use std::env;
 use std::ffi::{OsStr, OsString};
 use std::path::{Path, PathBuf};
 
+use build_helper::ci::CiEnv;
+
 use super::{Builder, Kind};
 use crate::core::build_steps::test;
 use crate::core::build_steps::tool::SourceType;
@@ -1334,7 +1336,13 @@ impl Builder<'_> {
         // Try to use a sysroot-relative bindir, in case it was configured absolutely.
         cargo.env("RUSTC_INSTALL_BINDIR", self.config.bindir_relative());
 
-        cargo.force_coloring_in_ci();
+        if CiEnv::is_ci() {
+            // Tell cargo to use colored output for nicer logs in CI, even
+            // though CI isn't printing to a terminal.
+            // Also set an explicit `TERM=xterm` so that cargo doesn't warn
+            // about TERM not being set.
+            cargo.env("TERM", "xterm").args(["--color=always"]);
+        };
 
         // When we build Rust dylibs they're all intended for intermediate
         // usage, so make sure we pass the -Cprefer-dynamic flag instead of

--- a/src/bootstrap/src/utils/exec.rs
+++ b/src/bootstrap/src/utils/exec.rs
@@ -21,7 +21,6 @@ use std::process::{
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
-use build_helper::ci::CiEnv;
 use build_helper::drop_bomb::DropBomb;
 use build_helper::exit;
 
@@ -388,18 +387,6 @@ impl<'a> BootstrapCommand {
     /// Returns the source code location where this command was created.
     pub fn get_created_location(&self) -> std::panic::Location<'static> {
         self.drop_bomb.get_created_location()
-    }
-
-    /// If in a CI environment, forces the command to run with colors.
-    pub fn force_coloring_in_ci(&mut self) {
-        if CiEnv::is_ci() {
-            // Due to use of stamp/docker, the output stream of bootstrap is not
-            // a TTY in CI, so coloring is by-default turned off.
-            // The explicit `TERM=xterm` environment is needed for
-            // `--color always` to actually work. This env var was lost when
-            // compiling through the Makefile. Very strange.
-            self.env("TERM", "xterm").args(["--color", "always"]);
-        }
     }
 
     pub fn fingerprint(&self) -> CommandFingerprint {

--- a/src/tools/compiletest/src/lib.rs
+++ b/src/tools/compiletest/src/lib.rs
@@ -136,8 +136,6 @@ fn parse_config(args: Vec<String>) -> Config {
         )
         .optflag("", "fail-fast", "stop as soon as possible after any test fails")
         .optopt("", "target", "the target to build for", "TARGET")
-        // FIXME: Should be removed once `bootstrap` will be updated to not use this option.
-        .optopt("", "color", "coloring: auto, always, never", "WHEN")
         .optopt("", "host", "the host to build for", "HOST")
         .optopt("", "cdb", "path to CDB to use for CDB debuginfo tests", "PATH")
         .optopt("", "gdb", "path to GDB to use for GDB debuginfo tests", "PATH")


### PR DESCRIPTION
- Follow-up to https://github.com/rust-lang/rust/pull/149850

---

This flag was an artifact of compiletest's old libtest-based test executor, and currently doesn't influence compiletest's output at all.

A follow-up commit also inlines `force_coloring_in_ci` into its only remaining caller, and updates its comment.