### PR TITLE
Add a sanity check in case of any duplicate nodes

### DIFF
--- a/compiler/rustc_query_system/src/dep_graph/graph.rs
+++ b/compiler/rustc_query_system/src/dep_graph/graph.rs
@@ -1363,7 +1363,10 @@ impl DepNodeColorMap {
             Ordering::Relaxed,
         ) {
             Ok(_) => Ok(()),
-            Err(v) => Err(DepNodeIndex::from_u32(v)),
+            Err(v) => Err({
+                assert_ne!(v, COMPRESSED_RED, "tried to mark a red node as green");
+                DepNodeIndex::from_u32(v)
+            }),
         }
     }
 

--- a/compiler/rustc_query_system/src/dep_graph/graph.rs
+++ b/compiler/rustc_query_system/src/dep_graph/graph.rs
@@ -1384,7 +1384,9 @@ impl DepNodeColorMap {
 
     #[inline]
     pub(super) fn insert_red(&self, index: SerializedDepNodeIndex) {
-        self.values[index].store(COMPRESSED_RED, Ordering::Release)
+        let value = self.values[index].swap(COMPRESSED_RED, Ordering::Release);
+        // Sanity check for duplicate nodes
+        assert_eq!(value, COMPRESSED_UNKNOWN, "trying to encode a dep node twice");
     }
 }
 


### PR DESCRIPTION
A simple check in case compiler tries to encode a dep node twice like in rust-lang/rust#141540.

Also if we'd try to mark a red node as green as it may then create a bad `DepNodeIndex` like in rust-lang/rust#148295.

If it prevents rust-lang/rust#141540 from emitting a faulty `dep-graph.bin` file via panic then it means you will be able to temporarily fix it by simply restarting cargo or rust-analyzer without cleaning up incremental cache.

UPDATE: Sadly it doesn't help for hypothesized temporary fix of rust-lang/rust#141540 with a simple rebuild. Although that issue and rust-lang/rust#148295 have progressed to rust-lang/rust#150018.