### PR TITLE
If there are too many suggestions for malformed attribute, do not suggest them

### DIFF
--- a/compiler/rustc_attr_parsing/src/session_diagnostics.rs
+++ b/compiler/rustc_attr_parsing/src/session_diagnostics.rs
@@ -769,16 +769,20 @@ impl<'a, G: EmissionGuarantee> Diagnostic<'a, G> for AttributeParseError<'_> {
             diag.note(format!("for more information, visit <{link}>"));
         }
 
-        diag.span_suggestions(
-            self.attr_span,
-            if self.suggestions.len() == 1 {
-                "must be of the form".to_string()
-            } else {
-                format!("try changing it to one of the following valid forms of the {description}")
-            },
-            self.suggestions,
-            Applicability::HasPlaceholders,
-        );
+        if self.suggestions.len() < 4 {
+            diag.span_suggestions(
+                self.attr_span,
+                if self.suggestions.len() == 1 {
+                    "must be of the form".to_string()
+                } else {
+                    format!(
+                        "try changing it to one of the following valid forms of the {description}"
+                    )
+                },
+                self.suggestions,
+                Applicability::HasPlaceholders,
+            );
+        }
 
         diag
     }

--- a/compiler/rustc_attr_parsing/src/validate_attr.rs
+++ b/compiler/rustc_attr_parsing/src/validate_attr.rs
@@ -198,6 +198,11 @@ fn emit_malformed_attribute(
             suggestions.push(format!("#{inner}[{name} = \"{descr}\"]"));
         }
     }
+    // If there are too many suggestions, better remove all of them as it's just noise at this
+    // point.
+    if suggestions.len() > 3 {
+        suggestions.clear();
+    }
     if should_warn(name) {
         psess.buffer_lint(
             ILL_FORMED_ATTRIBUTE_INPUT,

--- a/tests/rustdoc-ui/bad-render-options.stderr
+++ b/tests/rustdoc-ui/bad-render-options.stderr
@@ -5,22 +5,6 @@ LL | #![doc(html_favicon_url)]
    | ^^^^^^^----------------^^
    |        |
    |        expected this to be of the form `html_favicon_url = "..."`
-   |
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL - #![doc(html_favicon_url)]
-LL + #![doc = "string"]
-   |
-LL - #![doc(html_favicon_url)]
-LL + #![doc(alias)]
-   |
-LL - #![doc(html_favicon_url)]
-LL + #![doc(attribute)]
-   |
-LL - #![doc(html_favicon_url)]
-LL + #![doc(auto_cfg)]
-   |
-   = and 21 other candidates
 
 error[E0539]: malformed `doc` attribute input
   --> $DIR/bad-render-options.rs:6:1
@@ -29,22 +13,6 @@ LL | #![doc(html_logo_url)]
    | ^^^^^^^-------------^^
    |        |
    |        expected this to be of the form `html_logo_url = "..."`
-   |
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL - #![doc(html_logo_url)]
-LL + #![doc = "string"]
-   |
-LL - #![doc(html_logo_url)]
-LL + #![doc(alias)]
-   |
-LL - #![doc(html_logo_url)]
-LL + #![doc(attribute)]
-   |
-LL - #![doc(html_logo_url)]
-LL + #![doc(auto_cfg)]
-   |
-   = and 21 other candidates
 
 error[E0539]: malformed `doc` attribute input
   --> $DIR/bad-render-options.rs:9:1
@@ -53,22 +21,6 @@ LL | #![doc(html_playground_url)]
    | ^^^^^^^-------------------^^
    |        |
    |        expected this to be of the form `html_playground_url = "..."`
-   |
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL - #![doc(html_playground_url)]
-LL + #![doc = "string"]
-   |
-LL - #![doc(html_playground_url)]
-LL + #![doc(alias)]
-   |
-LL - #![doc(html_playground_url)]
-LL + #![doc(attribute)]
-   |
-LL - #![doc(html_playground_url)]
-LL + #![doc(auto_cfg)]
-   |
-   = and 21 other candidates
 
 error[E0539]: malformed `doc` attribute input
   --> $DIR/bad-render-options.rs:12:1
@@ -77,22 +29,6 @@ LL | #![doc(issue_tracker_base_url)]
    | ^^^^^^^----------------------^^
    |        |
    |        expected this to be of the form `issue_tracker_base_url = "..."`
-   |
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL - #![doc(issue_tracker_base_url)]
-LL + #![doc = "string"]
-   |
-LL - #![doc(issue_tracker_base_url)]
-LL + #![doc(alias)]
-   |
-LL - #![doc(issue_tracker_base_url)]
-LL + #![doc(attribute)]
-   |
-LL - #![doc(issue_tracker_base_url)]
-LL + #![doc(auto_cfg)]
-   |
-   = and 21 other candidates
 
 error[E0539]: malformed `doc` attribute input
   --> $DIR/bad-render-options.rs:15:1
@@ -101,22 +37,6 @@ LL | #![doc(html_favicon_url = 1)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^-^^
    |                           |
    |                           expected a string literal here
-   |
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL - #![doc(html_favicon_url = 1)]
-LL + #![doc = "string"]
-   |
-LL - #![doc(html_favicon_url = 1)]
-LL + #![doc(alias)]
-   |
-LL - #![doc(html_favicon_url = 1)]
-LL + #![doc(attribute)]
-   |
-LL - #![doc(html_favicon_url = 1)]
-LL + #![doc(auto_cfg)]
-   |
-   = and 22 other candidates
 
 error[E0539]: malformed `doc` attribute input
   --> $DIR/bad-render-options.rs:18:1
@@ -125,22 +45,6 @@ LL | #![doc(html_logo_url = 2)]
    | ^^^^^^^^^^^^^^^^^^^^^^^-^^
    |                        |
    |                        expected a string literal here
-   |
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL - #![doc(html_logo_url = 2)]
-LL + #![doc = "string"]
-   |
-LL - #![doc(html_logo_url = 2)]
-LL + #![doc(alias)]
-   |
-LL - #![doc(html_logo_url = 2)]
-LL + #![doc(attribute)]
-   |
-LL - #![doc(html_logo_url = 2)]
-LL + #![doc(auto_cfg)]
-   |
-   = and 22 other candidates
 
 error[E0539]: malformed `doc` attribute input
   --> $DIR/bad-render-options.rs:21:1
@@ -149,22 +53,6 @@ LL | #![doc(html_playground_url = 3)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-^^
    |                              |
    |                              expected a string literal here
-   |
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL - #![doc(html_playground_url = 3)]
-LL + #![doc = "string"]
-   |
-LL - #![doc(html_playground_url = 3)]
-LL + #![doc(alias)]
-   |
-LL - #![doc(html_playground_url = 3)]
-LL + #![doc(attribute)]
-   |
-LL - #![doc(html_playground_url = 3)]
-LL + #![doc(auto_cfg)]
-   |
-   = and 22 other candidates
 
 error[E0539]: malformed `doc` attribute input
   --> $DIR/bad-render-options.rs:24:1
@@ -173,22 +61,6 @@ LL | #![doc(issue_tracker_base_url = 4)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-^^
    |                                 |
    |                                 expected a string literal here
-   |
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL - #![doc(issue_tracker_base_url = 4)]
-LL + #![doc = "string"]
-   |
-LL - #![doc(issue_tracker_base_url = 4)]
-LL + #![doc(alias)]
-   |
-LL - #![doc(issue_tracker_base_url = 4)]
-LL + #![doc(attribute)]
-   |
-LL - #![doc(issue_tracker_base_url = 4)]
-LL + #![doc(auto_cfg)]
-   |
-   = and 22 other candidates
 
 error[E0565]: malformed `doc` attribute input
   --> $DIR/bad-render-options.rs:27:1
@@ -197,22 +69,6 @@ LL | #![doc(html_no_source = "asdf")]
    | ^^^^^^^^^^^^^^^^^^^^^^--------^^
    |                       |
    |                       didn't expect any arguments here
-   |
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL - #![doc(html_no_source = "asdf")]
-LL + #![doc = "string"]
-   |
-LL - #![doc(html_no_source = "asdf")]
-LL + #![doc(alias)]
-   |
-LL - #![doc(html_no_source = "asdf")]
-LL + #![doc(attribute)]
-   |
-LL - #![doc(html_no_source = "asdf")]
-LL + #![doc(auto_cfg)]
-   |
-   = and 22 other candidates
 
 error: aborting due to 9 previous errors
 

--- a/tests/rustdoc-ui/check-doc-alias-attr.stderr
+++ b/tests/rustdoc-ui/check-doc-alias-attr.stderr
@@ -11,22 +11,6 @@ LL | #[doc(alias = 0)]
    | ^^^^^^^^^^^^^^-^^
    |               |
    |               expected a string literal here
-   |
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL - #[doc(alias = 0)]
-LL + #[doc = "string"]
-   |
-LL - #[doc(alias = 0)]
-LL + #[doc(alias)]
-   |
-LL - #[doc(alias = 0)]
-LL + #[doc(attribute)]
-   |
-LL - #[doc(alias = 0)]
-LL + #[doc(auto_cfg)]
-   |
-   = and 22 other candidates
 
 error: '"' character isn't allowed in `#[doc(alias = "...")]`
   --> $DIR/check-doc-alias-attr.rs:9:15
@@ -79,22 +63,6 @@ LL | #[doc(alias(0))]
    | ^^^^^^^^^^^^-^^^
    |             |
    |             expected a string literal here
-   |
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL - #[doc(alias(0))]
-LL + #[doc = "string"]
-   |
-LL - #[doc(alias(0))]
-LL + #[doc(alias)]
-   |
-LL - #[doc(alias(0))]
-LL + #[doc(attribute)]
-   |
-LL - #[doc(alias(0))]
-LL + #[doc(auto_cfg)]
-   |
-   = and 22 other candidates
 
 error: '"' character isn't allowed in `#[doc(alias = "...")]`
   --> $DIR/check-doc-alias-attr.rs:20:13

--- a/tests/rustdoc-ui/doc-cfg.stderr
+++ b/tests/rustdoc-ui/doc-cfg.stderr
@@ -5,22 +5,6 @@ LL | #[doc(cfg(), cfg(foo, bar))]
    | ^^^^^^^^^--^^^^^^^^^^^^^^^^^
    |          |
    |          expected a single argument here
-   |
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL - #[doc(cfg(), cfg(foo, bar))]
-LL + #[doc = "string"]
-   |
-LL - #[doc(cfg(), cfg(foo, bar))]
-LL + #[doc(alias)]
-   |
-LL - #[doc(cfg(), cfg(foo, bar))]
-LL + #[doc(attribute)]
-   |
-LL - #[doc(cfg(), cfg(foo, bar))]
-LL + #[doc(auto_cfg)]
-   |
-   = and 22 other candidates
 
 error[E0805]: malformed `doc` attribute input
   --> $DIR/doc-cfg.rs:3:1
@@ -29,22 +13,6 @@ LL | #[doc(cfg(), cfg(foo, bar))]
    | ^^^^^^^^^^^^^^^^----------^^
    |                 |
    |                 expected a single argument here
-   |
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL - #[doc(cfg(), cfg(foo, bar))]
-LL + #[doc = "string"]
-   |
-LL - #[doc(cfg(), cfg(foo, bar))]
-LL + #[doc(alias)]
-   |
-LL - #[doc(cfg(), cfg(foo, bar))]
-LL + #[doc(attribute)]
-   |
-LL - #[doc(cfg(), cfg(foo, bar))]
-LL + #[doc(auto_cfg)]
-   |
-   = and 22 other candidates
 
 error[E0805]: malformed `doc` attribute input
   --> $DIR/doc-cfg.rs:6:1
@@ -53,22 +21,6 @@ LL | #[doc(cfg())]
    | ^^^^^^^^^--^^
    |          |
    |          expected a single argument here
-   |
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL - #[doc(cfg())]
-LL + #[doc = "string"]
-   |
-LL - #[doc(cfg())]
-LL + #[doc(alias)]
-   |
-LL - #[doc(cfg())]
-LL + #[doc(attribute)]
-   |
-LL - #[doc(cfg())]
-LL + #[doc(auto_cfg)]
-   |
-   = and 22 other candidates
 
 error[E0805]: malformed `doc` attribute input
   --> $DIR/doc-cfg.rs:7:1
@@ -77,22 +29,6 @@ LL | #[doc(cfg(foo, bar))]
    | ^^^^^^^^^----------^^
    |          |
    |          expected a single argument here
-   |
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL - #[doc(cfg(foo, bar))]
-LL + #[doc = "string"]
-   |
-LL - #[doc(cfg(foo, bar))]
-LL + #[doc(alias)]
-   |
-LL - #[doc(cfg(foo, bar))]
-LL + #[doc(attribute)]
-   |
-LL - #[doc(cfg(foo, bar))]
-LL + #[doc(auto_cfg)]
-   |
-   = and 22 other candidates
 
 error[E0539]: malformed `doc` attribute input
   --> $DIR/doc-cfg.rs:8:1
@@ -101,22 +37,6 @@ LL | #[doc(auto_cfg(hide(foo::bar)))]
    | ^^^^^^^^^^^^^^^^^^^^--------^^^^
    |                     |
    |                     expected a valid identifier here
-   |
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL - #[doc(auto_cfg(hide(foo::bar)))]
-LL + #[doc = "string"]
-   |
-LL - #[doc(auto_cfg(hide(foo::bar)))]
-LL + #[doc(alias)]
-   |
-LL - #[doc(auto_cfg(hide(foo::bar)))]
-LL + #[doc(attribute)]
-   |
-LL - #[doc(auto_cfg(hide(foo::bar)))]
-LL + #[doc(auto_cfg)]
-   |
-   = and 22 other candidates
 
 error: aborting due to 5 previous errors
 

--- a/tests/rustdoc-ui/invalid-cfg.stderr
+++ b/tests/rustdoc-ui/invalid-cfg.stderr
@@ -3,22 +3,6 @@ error[E0539]: malformed `doc` attribute input
    |
 LL | #[doc(cfg = "x")]
    | ^^^^^^^^^^^^^^^^^ expected this to be a list
-   |
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL - #[doc(cfg = "x")]
-LL + #[doc = "string"]
-   |
-LL - #[doc(cfg = "x")]
-LL + #[doc(alias)]
-   |
-LL - #[doc(cfg = "x")]
-LL + #[doc(attribute)]
-   |
-LL - #[doc(cfg = "x")]
-LL + #[doc(auto_cfg)]
-   |
-   = and 22 other candidates
 
 error[E0805]: malformed `doc` attribute input
   --> $DIR/invalid-cfg.rs:3:1
@@ -27,44 +11,12 @@ LL | #[doc(cfg(x, y))]
    | ^^^^^^^^^------^^
    |          |
    |          expected a single argument here
-   |
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL - #[doc(cfg(x, y))]
-LL + #[doc = "string"]
-   |
-LL - #[doc(cfg(x, y))]
-LL + #[doc(alias)]
-   |
-LL - #[doc(cfg(x, y))]
-LL + #[doc(attribute)]
-   |
-LL - #[doc(cfg(x, y))]
-LL + #[doc(auto_cfg)]
-   |
-   = and 22 other candidates
 
 error[E0539]: malformed `doc` attribute input
   --> $DIR/invalid-cfg.rs:7:1
    |
 LL | #[doc(cfg = "x")]
    | ^^^^^^^^^^^^^^^^^ expected this to be a list
-   |
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL - #[doc(cfg = "x")]
-LL + #[doc = "string"]
-   |
-LL - #[doc(cfg = "x")]
-LL + #[doc(alias)]
-   |
-LL - #[doc(cfg = "x")]
-LL + #[doc(attribute)]
-   |
-LL - #[doc(cfg = "x")]
-LL + #[doc(auto_cfg)]
-   |
-   = and 22 other candidates
 
 error[E0805]: malformed `doc` attribute input
   --> $DIR/invalid-cfg.rs:8:1
@@ -73,44 +25,12 @@ LL | #[doc(cfg(x, y))]
    | ^^^^^^^^^------^^
    |          |
    |          expected a single argument here
-   |
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL - #[doc(cfg(x, y))]
-LL + #[doc = "string"]
-   |
-LL - #[doc(cfg(x, y))]
-LL + #[doc(alias)]
-   |
-LL - #[doc(cfg(x, y))]
-LL + #[doc(attribute)]
-   |
-LL - #[doc(cfg(x, y))]
-LL + #[doc(auto_cfg)]
-   |
-   = and 22 other candidates
 
 error[E0539]: malformed `doc` attribute input
   --> $DIR/invalid-cfg.rs:12:1
    |
 LL | #[doc(cfg = "x")]
    | ^^^^^^^^^^^^^^^^^ expected this to be a list
-   |
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL - #[doc(cfg = "x")]
-LL + #[doc = "string"]
-   |
-LL - #[doc(cfg = "x")]
-LL + #[doc(alias)]
-   |
-LL - #[doc(cfg = "x")]
-LL + #[doc(attribute)]
-   |
-LL - #[doc(cfg = "x")]
-LL + #[doc(auto_cfg)]
-   |
-   = and 22 other candidates
 
 error[E0805]: malformed `doc` attribute input
   --> $DIR/invalid-cfg.rs:13:1
@@ -119,44 +39,12 @@ LL | #[doc(cfg(x, y))]
    | ^^^^^^^^^------^^
    |          |
    |          expected a single argument here
-   |
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL - #[doc(cfg(x, y))]
-LL + #[doc = "string"]
-   |
-LL - #[doc(cfg(x, y))]
-LL + #[doc(alias)]
-   |
-LL - #[doc(cfg(x, y))]
-LL + #[doc(attribute)]
-   |
-LL - #[doc(cfg(x, y))]
-LL + #[doc(auto_cfg)]
-   |
-   = and 22 other candidates
 
 error[E0539]: malformed `doc` attribute input
   --> $DIR/invalid-cfg.rs:18:1
    |
 LL | #[doc(cfg = "x")]
    | ^^^^^^^^^^^^^^^^^ expected this to be a list
-   |
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL - #[doc(cfg = "x")]
-LL + #[doc = "string"]
-   |
-LL - #[doc(cfg = "x")]
-LL + #[doc(alias)]
-   |
-LL - #[doc(cfg = "x")]
-LL + #[doc(attribute)]
-   |
-LL - #[doc(cfg = "x")]
-LL + #[doc(auto_cfg)]
-   |
-   = and 22 other candidates
 
 error[E0805]: malformed `doc` attribute input
   --> $DIR/invalid-cfg.rs:19:1
@@ -165,22 +53,6 @@ LL | #[doc(cfg(x, y))]
    | ^^^^^^^^^------^^
    |          |
    |          expected a single argument here
-   |
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL - #[doc(cfg(x, y))]
-LL + #[doc = "string"]
-   |
-LL - #[doc(cfg(x, y))]
-LL + #[doc(alias)]
-   |
-LL - #[doc(cfg(x, y))]
-LL + #[doc(attribute)]
-   |
-LL - #[doc(cfg(x, y))]
-LL + #[doc(auto_cfg)]
-   |
-   = and 22 other candidates
 
 error: aborting due to 8 previous errors
 

--- a/tests/rustdoc-ui/lints/doc-attr.stderr
+++ b/tests/rustdoc-ui/lints/doc-attr.stderr
@@ -5,22 +5,6 @@ LL | #[doc(123)]
    | ^^^^^^---^^
    |       |
    |       expected this to be of the form `... = "..."`
-   |
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL - #[doc(123)]
-LL + #[doc = "string"]
-   |
-LL - #[doc(123)]
-LL + #[doc(alias)]
-   |
-LL - #[doc(123)]
-LL + #[doc(attribute)]
-   |
-LL - #[doc(123)]
-LL + #[doc(auto_cfg)]
-   |
-   = and 22 other candidates
 
 error[E0539]: malformed `doc` attribute input
   --> $DIR/doc-attr.rs:5:1
@@ -29,22 +13,6 @@ LL | #[doc("hello", "bar")]
    | ^^^^^^-------^^^^^^^^^
    |       |
    |       expected this to be of the form `... = "..."`
-   |
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL - #[doc("hello", "bar")]
-LL + #[doc = "string"]
-   |
-LL - #[doc("hello", "bar")]
-LL + #[doc(alias)]
-   |
-LL - #[doc("hello", "bar")]
-LL + #[doc(attribute)]
-   |
-LL - #[doc("hello", "bar")]
-LL + #[doc(auto_cfg)]
-   |
-   = and 22 other candidates
 
 error[E0539]: malformed `doc` attribute input
   --> $DIR/doc-attr.rs:5:1
@@ -53,22 +21,6 @@ LL | #[doc("hello", "bar")]
    | ^^^^^^^^^^^^^^^-----^^
    |                |
    |                expected this to be of the form `... = "..."`
-   |
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL - #[doc("hello", "bar")]
-LL + #[doc = "string"]
-   |
-LL - #[doc("hello", "bar")]
-LL + #[doc(alias)]
-   |
-LL - #[doc("hello", "bar")]
-LL + #[doc(attribute)]
-   |
-LL - #[doc("hello", "bar")]
-LL + #[doc(auto_cfg)]
-   |
-   = and 22 other candidates
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/attributes/crate-type-delimited.stderr
+++ b/tests/ui/attributes/crate-type-delimited.stderr
@@ -5,21 +5,7 @@ LL | #![crate_type(lib)]
    | ^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/linkage.html>
-help: the following are the possible correct uses
    |
-LL - #![crate_type(lib)]
-LL + #![crate_type = "bin"]
-   |
-LL - #![crate_type(lib)]
-LL + #![crate_type = "cdylib"]
-   |
-LL - #![crate_type(lib)]
-LL + #![crate_type = "dylib"]
-   |
-LL - #![crate_type(lib)]
-LL + #![crate_type = "lib"]
-   |
-   = and 4 other candidates
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/attributes/crate-type-empty.stderr
+++ b/tests/ui/attributes/crate-type-empty.stderr
@@ -5,17 +5,7 @@ LL | #![crate_type]
    | ^^^^^^^^^^^^^^
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/linkage.html>
-help: the following are the possible correct uses
    |
-LL | #![crate_type = "bin"]
-   |               +++++++
-LL | #![crate_type = "cdylib"]
-   |               ++++++++++
-LL | #![crate_type = "dylib"]
-   |               +++++++++
-LL | #![crate_type = "lib"]
-   |               +++++++
-   = and 4 other candidates
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/attributes/crate-type-macro-call.stderr
+++ b/tests/ui/attributes/crate-type-macro-call.stderr
@@ -5,21 +5,7 @@ LL | #![crate_type = foo!()]
    | ^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/linkage.html>
-help: the following are the possible correct uses
    |
-LL - #![crate_type = foo!()]
-LL + #![crate_type = "bin"]
-   |
-LL - #![crate_type = foo!()]
-LL + #![crate_type = "cdylib"]
-   |
-LL - #![crate_type = foo!()]
-LL + #![crate_type = "dylib"]
-   |
-LL - #![crate_type = foo!()]
-LL + #![crate_type = "lib"]
-   |
-   = and 4 other candidates
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/attributes/doc-attr.stderr
+++ b/tests/ui/attributes/doc-attr.stderr
@@ -5,22 +5,6 @@ LL | #[doc(123)]
    | ^^^^^^---^^
    |       |
    |       expected this to be of the form `... = "..."`
-   |
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL - #[doc(123)]
-LL + #[doc = "string"]
-   |
-LL - #[doc(123)]
-LL + #[doc(alias)]
-   |
-LL - #[doc(123)]
-LL + #[doc(attribute)]
-   |
-LL - #[doc(123)]
-LL + #[doc(auto_cfg)]
-   |
-   = and 22 other candidates
 
 error[E0539]: malformed `doc` attribute input
   --> $DIR/doc-attr.rs:11:1
@@ -29,22 +13,6 @@ LL | #[doc("hello", "bar")]
    | ^^^^^^-------^^^^^^^^^
    |       |
    |       expected this to be of the form `... = "..."`
-   |
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL - #[doc("hello", "bar")]
-LL + #[doc = "string"]
-   |
-LL - #[doc("hello", "bar")]
-LL + #[doc(alias)]
-   |
-LL - #[doc("hello", "bar")]
-LL + #[doc(attribute)]
-   |
-LL - #[doc("hello", "bar")]
-LL + #[doc(auto_cfg)]
-   |
-   = and 22 other candidates
 
 error[E0539]: malformed `doc` attribute input
   --> $DIR/doc-attr.rs:11:1
@@ -53,22 +21,6 @@ LL | #[doc("hello", "bar")]
    | ^^^^^^^^^^^^^^^-----^^
    |                |
    |                expected this to be of the form `... = "..."`
-   |
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL - #[doc("hello", "bar")]
-LL + #[doc = "string"]
-   |
-LL - #[doc("hello", "bar")]
-LL + #[doc(alias)]
-   |
-LL - #[doc("hello", "bar")]
-LL + #[doc(attribute)]
-   |
-LL - #[doc("hello", "bar")]
-LL + #[doc(auto_cfg)]
-   |
-   = and 22 other candidates
 
 error: unknown `doc` attribute `as_ptr`
   --> $DIR/doc-attr.rs:5:7

--- a/tests/ui/attributes/doc-test-literal.stderr
+++ b/tests/ui/attributes/doc-test-literal.stderr
@@ -5,22 +5,6 @@ LL | #![doc(test(""))]
    | ^^^^^^^^^^^^--^^^
    |             |
    |             didn't expect a literal here
-   |
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL - #![doc(test(""))]
-LL + #![doc = "string"]
-   |
-LL - #![doc(test(""))]
-LL + #![doc(alias)]
-   |
-LL - #![doc(test(""))]
-LL + #![doc(attribute)]
-   |
-LL - #![doc(test(""))]
-LL + #![doc(auto_cfg)]
-   |
-   = and 22 other candidates
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/attributes/malformed-attrs.stderr
+++ b/tests/ui/attributes/malformed-attrs.stderr
@@ -240,22 +240,6 @@ LL | #[deprecated = 5]
    | ^^^^^^^^^^^^^^^-^
    |                |
    |                expected a string literal here
-   |
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL - #[deprecated = 5]
-LL + #[deprecated = "reason"]
-   |
-LL - #[deprecated = 5]
-LL + #[deprecated(note = "reason")]
-   |
-LL - #[deprecated = 5]
-LL + #[deprecated(since = "version")]
-   |
-LL - #[deprecated = 5]
-LL + #[deprecated(since = "version", note = "reason")]
-   |
-   = and 1 other candidate
 
 error[E0539]: malformed `rustc_macro_transparency` attribute input
   --> $DIR/malformed-attrs.rs:44:1
@@ -287,17 +271,6 @@ LL | #[repr]
    | ^^^^^^^ expected this to be a list
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/type-layout.html#representations>
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL | #[repr(<integer type>)]
-   |       ++++++++++++++++
-LL | #[repr(C)]
-   |       +++
-LL | #[repr(Rust)]
-   |       ++++++
-LL | #[repr(align(...))]
-   |       ++++++++++++
-   = and 2 other candidates
 
 error[E0565]: malformed `rustc_as_ptr` attribute input
   --> $DIR/malformed-attrs.rs:50:1
@@ -437,17 +410,6 @@ LL | #[link]
    | ^^^^^^^ expected this to be a list
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute>
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL | #[link(name = "...")]
-   |       ++++++++++++++
-LL | #[link(name = "...", import_name_type = "decorated|noprefix|undecorated")]
-   |       +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-LL | #[link(name = "...", kind = "dylib|static|...")]
-   |       +++++++++++++++++++++++++++++++++++++++++
-LL | #[link(name = "...", kind = "dylib|static|...", wasm_import_module = "...", import_name_type = "decorated|noprefix|undecorated")]
-   |       ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-   = and 1 other candidate
 
 error[E0539]: malformed `link_name` attribute input
   --> $DIR/malformed-attrs.rs:88:1
@@ -483,18 +445,6 @@ error[E0539]: malformed `sanitize` attribute input
    |
 LL | #[sanitize]
    | ^^^^^^^^^^^ expected this to be a list
-   |
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL | #[sanitize(address = "on|off")]
-   |           ++++++++++++++++++++
-LL | #[sanitize(cfi = "on|off")]
-   |           ++++++++++++++++
-LL | #[sanitize(hwaddress = "on|off")]
-   |           ++++++++++++++++++++++
-LL | #[sanitize(kcfi = "on|off")]
-   |           +++++++++++++++++
-   = and 6 other candidates
 
 error[E0565]: malformed `no_implicit_prelude` attribute input
   --> $DIR/malformed-attrs.rs:101:1
@@ -634,18 +584,6 @@ error[E0539]: malformed `linkage` attribute input
    |
 LL |     #[linkage]
    |     ^^^^^^^^^^ expected this to be of the form `linkage = "..."`
-   |
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL |     #[linkage = "available_externally"]
-   |               ++++++++++++++++++++++++
-LL |     #[linkage = "common"]
-   |               ++++++++++
-LL |     #[linkage = "extern_weak"]
-   |               +++++++++++++++
-LL |     #[linkage = "external"]
-   |               ++++++++++++
-   = and 5 other candidates
 
 error[E0539]: malformed `debugger_visualizer` attribute input
   --> $DIR/malformed-attrs.rs:194:1

--- a/tests/ui/attributes/malformed-reprs.stderr
+++ b/tests/ui/attributes/malformed-reprs.stderr
@@ -5,17 +5,6 @@ LL | #![repr]
    | ^^^^^^^^ expected this to be a list
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/type-layout.html#representations>
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL | #![repr(<integer type>)]
-   |        ++++++++++++++++
-LL | #![repr(C)]
-   |        +++
-LL | #![repr(Rust)]
-   |        ++++++
-LL | #![repr(align(...))]
-   |        ++++++++++++
-   = and 2 other candidates
 
 error[E0589]: invalid `repr(align)` attribute: not a power of two
   --> $DIR/malformed-reprs.rs:9:14

--- a/tests/ui/deprecation/deprecation-sanity.stderr
+++ b/tests/ui/deprecation/deprecation-sanity.stderr
@@ -11,22 +11,6 @@ LL |     #[deprecated(since = "a", note)]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^----^^
    |                               |
    |                               expected this to be of the form `note = "..."`
-   |
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL -     #[deprecated(since = "a", note)]
-LL +     #[deprecated = "reason"]
-   |
-LL -     #[deprecated(since = "a", note)]
-LL +     #[deprecated(note = "reason")]
-   |
-LL -     #[deprecated(since = "a", note)]
-LL +     #[deprecated(since = "version")]
-   |
-LL -     #[deprecated(since = "a", note)]
-LL +     #[deprecated(since = "version", note = "reason")]
-   |
-   = and 1 other candidate
 
 error[E0539]: malformed `deprecated` attribute input
   --> $DIR/deprecation-sanity.rs:12:5
@@ -35,22 +19,6 @@ LL |     #[deprecated(since, note = "a")]
    |     ^^^^^^^^^^^^^-----^^^^^^^^^^^^^^
    |                  |
    |                  expected this to be of the form `since = "..."`
-   |
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL -     #[deprecated(since, note = "a")]
-LL +     #[deprecated = "reason"]
-   |
-LL -     #[deprecated(since, note = "a")]
-LL +     #[deprecated(note = "reason")]
-   |
-LL -     #[deprecated(since, note = "a")]
-LL +     #[deprecated(since = "version")]
-   |
-LL -     #[deprecated(since, note = "a")]
-LL +     #[deprecated(since = "version", note = "reason")]
-   |
-   = and 1 other candidate
 
 error[E0539]: malformed `deprecated` attribute input
   --> $DIR/deprecation-sanity.rs:15:5
@@ -59,22 +27,6 @@ LL |     #[deprecated(since = "a", note(b))]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^-------^^
    |                               |
    |                               expected this to be of the form `note = "..."`
-   |
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL -     #[deprecated(since = "a", note(b))]
-LL +     #[deprecated = "reason"]
-   |
-LL -     #[deprecated(since = "a", note(b))]
-LL +     #[deprecated(note = "reason")]
-   |
-LL -     #[deprecated(since = "a", note(b))]
-LL +     #[deprecated(since = "version")]
-   |
-LL -     #[deprecated(since = "a", note(b))]
-LL +     #[deprecated(since = "version", note = "reason")]
-   |
-   = and 1 other candidate
 
 error[E0539]: malformed `deprecated` attribute input
   --> $DIR/deprecation-sanity.rs:18:5
@@ -83,22 +35,6 @@ LL |     #[deprecated(since(b), note = "a")]
    |     ^^^^^^^^^^^^^--------^^^^^^^^^^^^^^
    |                  |
    |                  expected this to be of the form `since = "..."`
-   |
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL -     #[deprecated(since(b), note = "a")]
-LL +     #[deprecated = "reason"]
-   |
-LL -     #[deprecated(since(b), note = "a")]
-LL +     #[deprecated(note = "reason")]
-   |
-LL -     #[deprecated(since(b), note = "a")]
-LL +     #[deprecated(since = "version")]
-   |
-LL -     #[deprecated(since(b), note = "a")]
-LL +     #[deprecated(since = "version", note = "reason")]
-   |
-   = and 1 other candidate
 
 error[E0539]: malformed `deprecated` attribute input
   --> $DIR/deprecation-sanity.rs:21:5
@@ -117,22 +53,6 @@ LL |     #[deprecated("test")]
    |     ^^^^^^^^^^^^^------^^
    |                  |
    |                  didn't expect a literal here
-   |
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL -     #[deprecated("test")]
-LL +     #[deprecated = "reason"]
-   |
-LL -     #[deprecated("test")]
-LL +     #[deprecated(note = "reason")]
-   |
-LL -     #[deprecated("test")]
-LL +     #[deprecated(since = "version")]
-   |
-LL -     #[deprecated("test")]
-LL +     #[deprecated(since = "version", note = "reason")]
-   |
-   = and 1 other candidate
 
 error: multiple `deprecated` attributes
   --> $DIR/deprecation-sanity.rs:29:1
@@ -153,22 +73,6 @@ LL | #[deprecated(since = "a", since = "b", note = "c")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^-----------^^^^^^^^^^^^^^
    |                           |
    |                           found `since` used as a key more than once
-   |
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL - #[deprecated(since = "a", since = "b", note = "c")]
-LL + #[deprecated = "reason"]
-   |
-LL - #[deprecated(since = "a", since = "b", note = "c")]
-LL + #[deprecated(note = "reason")]
-   |
-LL - #[deprecated(since = "a", since = "b", note = "c")]
-LL + #[deprecated(since = "version")]
-   |
-LL - #[deprecated(since = "a", since = "b", note = "c")]
-LL + #[deprecated(since = "version", note = "reason")]
-   |
-   = and 1 other candidate
 
 error: `#[deprecated]` attribute cannot be used on trait impl blocks
   --> $DIR/deprecation-sanity.rs:37:1

--- a/tests/ui/error-codes/E0458.stderr
+++ b/tests/ui/error-codes/E0458.stderr
@@ -7,21 +7,6 @@ LL | #[link(kind = "wonderful_unicorn")] extern "C" {}
    |               valid arguments are "static", "dylib", "framework", "raw-dylib" or "link-arg"
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute>
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL - #[link(kind = "wonderful_unicorn")] extern "C" {}
-LL + #[link(name = "...")] extern "C" {}
-   |
-LL - #[link(kind = "wonderful_unicorn")] extern "C" {}
-LL + #[link(name = "...", import_name_type = "decorated|noprefix|undecorated")] extern "C" {}
-   |
-LL - #[link(kind = "wonderful_unicorn")] extern "C" {}
-LL + #[link(name = "...", kind = "dylib|static|...")] extern "C" {}
-   |
-LL - #[link(kind = "wonderful_unicorn")] extern "C" {}
-LL + #[link(name = "...", kind = "dylib|static|...", wasm_import_module = "...", import_name_type = "decorated|noprefix|undecorated")] extern "C" {}
-   |
-   = and 1 other candidate
 
 error[E0459]: `#[link]` attribute requires a `name = "string"` argument
   --> $DIR/E0458.rs:1:1

--- a/tests/ui/error-codes/E0565-1.stderr
+++ b/tests/ui/error-codes/E0565-1.stderr
@@ -5,22 +5,6 @@ LL | #[deprecated("since")]
    | ^^^^^^^^^^^^^-------^^
    |              |
    |              didn't expect a literal here
-   |
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL - #[deprecated("since")]
-LL + #[deprecated = "reason"]
-   |
-LL - #[deprecated("since")]
-LL + #[deprecated(note = "reason")]
-   |
-LL - #[deprecated("since")]
-LL + #[deprecated(since = "version")]
-   |
-LL - #[deprecated("since")]
-LL + #[deprecated(since = "version", note = "reason")]
-   |
-   = and 1 other candidate
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/issues/issue-43988.stderr
+++ b/tests/ui/issues/issue-43988.stderr
@@ -60,17 +60,6 @@ LL |     #[repr]
    |     ^^^^^^^ expected this to be a list
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/type-layout.html#representations>
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL |     #[repr(<integer type>)]
-   |           ++++++++++++++++
-LL |     #[repr(C)]
-   |           +++
-LL |     #[repr(Rust)]
-   |           ++++++
-LL |     #[repr(align(...))]
-   |           ++++++++++++
-   = and 2 other candidates
 
 error[E0539]: malformed `inline` attribute input
   --> $DIR/issue-43988.rs:31:5
@@ -108,17 +97,6 @@ LL |     let _z = #[repr] 1;
    |              ^^^^^^^ expected this to be a list
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/type-layout.html#representations>
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL |     let _z = #[repr(<integer type>)] 1;
-   |                    ++++++++++++++++
-LL |     let _z = #[repr(C)] 1;
-   |                    +++
-LL |     let _z = #[repr(Rust)] 1;
-   |                    ++++++
-LL |     let _z = #[repr(align(...))] 1;
-   |                    ++++++++++++
-   = and 2 other candidates
 
 error: aborting due to 9 previous errors
 

--- a/tests/ui/link-native-libs/issue-43925.stderr
+++ b/tests/ui/link-native-libs/issue-43925.stderr
@@ -16,21 +16,6 @@ LL | #[link(name = "foo", cfg("rlib"))]
    |                          expected a valid identifier here
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute>
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL - #[link(name = "foo", cfg("rlib"))]
-LL + #[link(name = "...")]
-   |
-LL - #[link(name = "foo", cfg("rlib"))]
-LL + #[link(name = "...", import_name_type = "decorated|noprefix|undecorated")]
-   |
-LL - #[link(name = "foo", cfg("rlib"))]
-LL + #[link(name = "...", kind = "dylib|static|...")]
-   |
-LL - #[link(name = "foo", cfg("rlib"))]
-LL + #[link(name = "...", kind = "dylib|static|...", wasm_import_module = "...", import_name_type = "decorated|noprefix|undecorated")]
-   |
-   = and 1 other candidate
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/link-native-libs/issue-43926.stderr
+++ b/tests/ui/link-native-libs/issue-43926.stderr
@@ -7,21 +7,6 @@ LL | #[link(name = "foo", cfg())]
    |                      expected a single argument here
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute>
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL - #[link(name = "foo", cfg())]
-LL + #[link(name = "...")]
-   |
-LL - #[link(name = "foo", cfg())]
-LL + #[link(name = "...", import_name_type = "decorated|noprefix|undecorated")]
-   |
-LL - #[link(name = "foo", cfg())]
-LL + #[link(name = "...", kind = "dylib|static|...")]
-   |
-LL - #[link(name = "foo", cfg())]
-LL + #[link(name = "...", kind = "dylib|static|...", wasm_import_module = "...", import_name_type = "decorated|noprefix|undecorated")]
-   |
-   = and 1 other candidate
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/link-native-libs/link-attr-validation-early.stderr
+++ b/tests/ui/link-native-libs/link-attr-validation-early.stderr
@@ -5,17 +5,6 @@ LL | #[link]
    | ^^^^^^^ expected this to be a list
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute>
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL | #[link(name = "...")]
-   |       ++++++++++++++
-LL | #[link(name = "...", import_name_type = "decorated|noprefix|undecorated")]
-   |       +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-LL | #[link(name = "...", kind = "dylib|static|...")]
-   |       +++++++++++++++++++++++++++++++++++++++++
-LL | #[link(name = "...", kind = "dylib|static|...", wasm_import_module = "...", import_name_type = "decorated|noprefix|undecorated")]
-   |       ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-   = and 1 other candidate
 
 error[E0539]: malformed `link` attribute input
   --> $DIR/link-attr-validation-early.rs:3:1
@@ -24,21 +13,6 @@ LL | #[link = "foo"]
    | ^^^^^^^^^^^^^^^ expected this to be a list
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute>
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL - #[link = "foo"]
-LL + #[link(name = "...")]
-   |
-LL - #[link = "foo"]
-LL + #[link(name = "...", import_name_type = "decorated|noprefix|undecorated")]
-   |
-LL - #[link = "foo"]
-LL + #[link(name = "...", kind = "dylib|static|...")]
-   |
-LL - #[link = "foo"]
-LL + #[link(name = "...", kind = "dylib|static|...", wasm_import_module = "...", import_name_type = "decorated|noprefix|undecorated")]
-   |
-   = and 1 other candidate
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/link-native-libs/link-attr-validation-late.stderr
+++ b/tests/ui/link-native-libs/link-attr-validation-late.stderr
@@ -7,21 +7,6 @@ LL | #[link(name = "...", "literal")]
    |                      didn't expect a literal here
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute>
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL - #[link(name = "...", "literal")]
-LL + #[link(name = "...")]
-   |
-LL - #[link(name = "...", "literal")]
-LL + #[link(name = "...", import_name_type = "decorated|noprefix|undecorated")]
-   |
-LL - #[link(name = "...", "literal")]
-LL + #[link(name = "...", kind = "dylib|static|...")]
-   |
-LL - #[link(name = "...", "literal")]
-LL + #[link(name = "...", kind = "dylib|static|...", wasm_import_module = "...", import_name_type = "decorated|noprefix|undecorated")]
-   |
-   = and 1 other candidate
 
 error[E0539]: malformed `link` attribute input
   --> $DIR/link-attr-validation-late.rs:5:1
@@ -32,21 +17,6 @@ LL | #[link(name = "...", unknown)]
    |                      valid arguments are "name", "kind", "modifiers", "cfg", "wasm_import_module" or "import_name_type"
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute>
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL - #[link(name = "...", unknown)]
-LL + #[link(name = "...")]
-   |
-LL - #[link(name = "...", unknown)]
-LL + #[link(name = "...", import_name_type = "decorated|noprefix|undecorated")]
-   |
-LL - #[link(name = "...", unknown)]
-LL + #[link(name = "...", kind = "dylib|static|...")]
-   |
-LL - #[link(name = "...", unknown)]
-LL + #[link(name = "...", kind = "dylib|static|...", wasm_import_module = "...", import_name_type = "decorated|noprefix|undecorated")]
-   |
-   = and 1 other candidate
 
 error[E0538]: malformed `link` attribute input
   --> $DIR/link-attr-validation-late.rs:9:1
@@ -57,21 +27,6 @@ LL | #[link(name = "foo", name = "bar")]
    |                      found `name` used as a key more than once
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute>
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL - #[link(name = "foo", name = "bar")]
-LL + #[link(name = "...")]
-   |
-LL - #[link(name = "foo", name = "bar")]
-LL + #[link(name = "...", import_name_type = "decorated|noprefix|undecorated")]
-   |
-LL - #[link(name = "foo", name = "bar")]
-LL + #[link(name = "...", kind = "dylib|static|...")]
-   |
-LL - #[link(name = "foo", name = "bar")]
-LL + #[link(name = "...", kind = "dylib|static|...", wasm_import_module = "...", import_name_type = "decorated|noprefix|undecorated")]
-   |
-   = and 1 other candidate
 
 error[E0538]: malformed `link` attribute input
   --> $DIR/link-attr-validation-late.rs:10:1
@@ -82,21 +37,6 @@ LL | #[link(name = "...", kind = "dylib", kind = "bar")]
    |                                      found `kind` used as a key more than once
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute>
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL - #[link(name = "...", kind = "dylib", kind = "bar")]
-LL + #[link(name = "...")]
-   |
-LL - #[link(name = "...", kind = "dylib", kind = "bar")]
-LL + #[link(name = "...", import_name_type = "decorated|noprefix|undecorated")]
-   |
-LL - #[link(name = "...", kind = "dylib", kind = "bar")]
-LL + #[link(name = "...", kind = "dylib|static|...")]
-   |
-LL - #[link(name = "...", kind = "dylib", kind = "bar")]
-LL + #[link(name = "...", kind = "dylib|static|...", wasm_import_module = "...", import_name_type = "decorated|noprefix|undecorated")]
-   |
-   = and 1 other candidate
 
 error[E0538]: malformed `link` attribute input
   --> $DIR/link-attr-validation-late.rs:11:1
@@ -107,21 +47,6 @@ LL | #[link(name = "...", modifiers = "+verbatim", modifiers = "bar")]
    |                                               found `modifiers` used as a key more than once
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute>
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL - #[link(name = "...", modifiers = "+verbatim", modifiers = "bar")]
-LL + #[link(name = "...")]
-   |
-LL - #[link(name = "...", modifiers = "+verbatim", modifiers = "bar")]
-LL + #[link(name = "...", import_name_type = "decorated|noprefix|undecorated")]
-   |
-LL - #[link(name = "...", modifiers = "+verbatim", modifiers = "bar")]
-LL + #[link(name = "...", kind = "dylib|static|...")]
-   |
-LL - #[link(name = "...", modifiers = "+verbatim", modifiers = "bar")]
-LL + #[link(name = "...", kind = "dylib|static|...", wasm_import_module = "...", import_name_type = "decorated|noprefix|undecorated")]
-   |
-   = and 1 other candidate
 
 error[E0538]: malformed `link` attribute input
   --> $DIR/link-attr-validation-late.rs:12:1
@@ -132,21 +57,6 @@ LL | #[link(name = "...", cfg(false), cfg(false))]
    |                                  found `cfg` used as a key more than once
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute>
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL - #[link(name = "...", cfg(false), cfg(false))]
-LL + #[link(name = "...")]
-   |
-LL - #[link(name = "...", cfg(false), cfg(false))]
-LL + #[link(name = "...", import_name_type = "decorated|noprefix|undecorated")]
-   |
-LL - #[link(name = "...", cfg(false), cfg(false))]
-LL + #[link(name = "...", kind = "dylib|static|...")]
-   |
-LL - #[link(name = "...", cfg(false), cfg(false))]
-LL + #[link(name = "...", kind = "dylib|static|...", wasm_import_module = "...", import_name_type = "decorated|noprefix|undecorated")]
-   |
-   = and 1 other candidate
 
 error[E0538]: malformed `link` attribute input
   --> $DIR/link-attr-validation-late.rs:13:1
@@ -157,21 +67,6 @@ LL | #[link(wasm_import_module = "foo", wasm_import_module = "bar")]
    |                                    found `wasm_import_module` used as a key more than once
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute>
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL - #[link(wasm_import_module = "foo", wasm_import_module = "bar")]
-LL + #[link(name = "...")]
-   |
-LL - #[link(wasm_import_module = "foo", wasm_import_module = "bar")]
-LL + #[link(name = "...", import_name_type = "decorated|noprefix|undecorated")]
-   |
-LL - #[link(wasm_import_module = "foo", wasm_import_module = "bar")]
-LL + #[link(name = "...", kind = "dylib|static|...")]
-   |
-LL - #[link(wasm_import_module = "foo", wasm_import_module = "bar")]
-LL + #[link(name = "...", kind = "dylib|static|...", wasm_import_module = "...", import_name_type = "decorated|noprefix|undecorated")]
-   |
-   = and 1 other candidate
 
 error[E0539]: malformed `link` attribute input
   --> $DIR/link-attr-validation-late.rs:17:1
@@ -182,17 +77,6 @@ LL | #[link(name)]
    |        expected this to be of the form `name = "..."`
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute>
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL | #[link(name = "...")]
-   |             +++++++
-LL | #[link(name = "...", import_name_type = "decorated|noprefix|undecorated")]
-   |             ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-LL | #[link(name = "...", kind = "dylib|static|...")]
-   |             ++++++++++++++++++++++++++++++++++
-LL | #[link(name = "...", kind = "dylib|static|...", wasm_import_module = "...", import_name_type = "decorated|noprefix|undecorated")]
-   |             +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-   = and 1 other candidate
 
 error[E0539]: malformed `link` attribute input
   --> $DIR/link-attr-validation-late.rs:18:1
@@ -203,21 +87,6 @@ LL | #[link(name())]
    |        expected this to be of the form `name = "..."`
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute>
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL - #[link(name())]
-LL + #[link(name = "...")]
-   |
-LL - #[link(name())]
-LL + #[link(name = "...", import_name_type = "decorated|noprefix|undecorated")]
-   |
-LL - #[link(name())]
-LL + #[link(name = "...", kind = "dylib|static|...")]
-   |
-LL - #[link(name())]
-LL + #[link(name = "...", kind = "dylib|static|...", wasm_import_module = "...", import_name_type = "decorated|noprefix|undecorated")]
-   |
-   = and 1 other candidate
 
 error[E0539]: malformed `link` attribute input
   --> $DIR/link-attr-validation-late.rs:19:1
@@ -228,19 +97,6 @@ LL | #[link(name = "...", kind)]
    |                      expected this to be of the form `kind = "..."`
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute>
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL - #[link(name = "...", kind)]
-LL + #[link(name = "...")]
-   |
-LL - #[link(name = "...", kind)]
-LL + #[link(name = "...", import_name_type = "decorated|noprefix|undecorated")]
-   |
-LL | #[link(name = "...", kind = "dylib|static|...")]
-   |                           ++++++++++++++++++++
-LL | #[link(name = "...", kind = "dylib|static|...", wasm_import_module = "...", import_name_type = "decorated|noprefix|undecorated")]
-   |                           +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-   = and 1 other candidate
 
 error[E0539]: malformed `link` attribute input
   --> $DIR/link-attr-validation-late.rs:20:1
@@ -251,21 +107,6 @@ LL | #[link(name = "...", kind())]
    |                      expected this to be of the form `kind = "..."`
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute>
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL - #[link(name = "...", kind())]
-LL + #[link(name = "...")]
-   |
-LL - #[link(name = "...", kind())]
-LL + #[link(name = "...", import_name_type = "decorated|noprefix|undecorated")]
-   |
-LL - #[link(name = "...", kind())]
-LL + #[link(name = "...", kind = "dylib|static|...")]
-   |
-LL - #[link(name = "...", kind())]
-LL + #[link(name = "...", kind = "dylib|static|...", wasm_import_module = "...", import_name_type = "decorated|noprefix|undecorated")]
-   |
-   = and 1 other candidate
 
 error[E0539]: malformed `link` attribute input
   --> $DIR/link-attr-validation-late.rs:21:1
@@ -276,21 +117,6 @@ LL | #[link(name = "...", modifiers)]
    |                      expected this to be of the form `modifiers = "..."`
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute>
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL - #[link(name = "...", modifiers)]
-LL + #[link(name = "...")]
-   |
-LL - #[link(name = "...", modifiers)]
-LL + #[link(name = "...", import_name_type = "decorated|noprefix|undecorated")]
-   |
-LL - #[link(name = "...", modifiers)]
-LL + #[link(name = "...", kind = "dylib|static|...")]
-   |
-LL - #[link(name = "...", modifiers)]
-LL + #[link(name = "...", kind = "dylib|static|...", wasm_import_module = "...", import_name_type = "decorated|noprefix|undecorated")]
-   |
-   = and 1 other candidate
 
 error[E0539]: malformed `link` attribute input
   --> $DIR/link-attr-validation-late.rs:22:1
@@ -301,21 +127,6 @@ LL | #[link(name = "...", modifiers())]
    |                      expected this to be of the form `modifiers = "..."`
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute>
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL - #[link(name = "...", modifiers())]
-LL + #[link(name = "...")]
-   |
-LL - #[link(name = "...", modifiers())]
-LL + #[link(name = "...", import_name_type = "decorated|noprefix|undecorated")]
-   |
-LL - #[link(name = "...", modifiers())]
-LL + #[link(name = "...", kind = "dylib|static|...")]
-   |
-LL - #[link(name = "...", modifiers())]
-LL + #[link(name = "...", kind = "dylib|static|...", wasm_import_module = "...", import_name_type = "decorated|noprefix|undecorated")]
-   |
-   = and 1 other candidate
 
 error[E0539]: malformed `link` attribute input
   --> $DIR/link-attr-validation-late.rs:23:1
@@ -326,21 +137,6 @@ LL | #[link(name = "...", cfg)]
    |                      expected this to be a list
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute>
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL - #[link(name = "...", cfg)]
-LL + #[link(name = "...")]
-   |
-LL - #[link(name = "...", cfg)]
-LL + #[link(name = "...", import_name_type = "decorated|noprefix|undecorated")]
-   |
-LL - #[link(name = "...", cfg)]
-LL + #[link(name = "...", kind = "dylib|static|...")]
-   |
-LL - #[link(name = "...", cfg)]
-LL + #[link(name = "...", kind = "dylib|static|...", wasm_import_module = "...", import_name_type = "decorated|noprefix|undecorated")]
-   |
-   = and 1 other candidate
 
 error[E0539]: malformed `link` attribute input
   --> $DIR/link-attr-validation-late.rs:24:1
@@ -351,21 +147,6 @@ LL | #[link(name = "...", cfg = "literal")]
    |                      expected this to be a list
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute>
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL - #[link(name = "...", cfg = "literal")]
-LL + #[link(name = "...")]
-   |
-LL - #[link(name = "...", cfg = "literal")]
-LL + #[link(name = "...", import_name_type = "decorated|noprefix|undecorated")]
-   |
-LL - #[link(name = "...", cfg = "literal")]
-LL + #[link(name = "...", kind = "dylib|static|...")]
-   |
-LL - #[link(name = "...", cfg = "literal")]
-LL + #[link(name = "...", kind = "dylib|static|...", wasm_import_module = "...", import_name_type = "decorated|noprefix|undecorated")]
-   |
-   = and 1 other candidate
 
 error[E0539]: malformed `link` attribute input
   --> $DIR/link-attr-validation-late.rs:25:1
@@ -376,21 +157,6 @@ LL | #[link(name = "...", cfg("literal"))]
    |                          expected a valid identifier here
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute>
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL - #[link(name = "...", cfg("literal"))]
-LL + #[link(name = "...")]
-   |
-LL - #[link(name = "...", cfg("literal"))]
-LL + #[link(name = "...", import_name_type = "decorated|noprefix|undecorated")]
-   |
-LL - #[link(name = "...", cfg("literal"))]
-LL + #[link(name = "...", kind = "dylib|static|...")]
-   |
-LL - #[link(name = "...", cfg("literal"))]
-LL + #[link(name = "...", kind = "dylib|static|...", wasm_import_module = "...", import_name_type = "decorated|noprefix|undecorated")]
-   |
-   = and 1 other candidate
 
 error[E0539]: malformed `link` attribute input
   --> $DIR/link-attr-validation-late.rs:26:1
@@ -401,21 +167,6 @@ LL | #[link(name = "...", wasm_import_module)]
    |                      expected this to be of the form `wasm_import_module = "..."`
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute>
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL - #[link(name = "...", wasm_import_module)]
-LL + #[link(name = "...")]
-   |
-LL - #[link(name = "...", wasm_import_module)]
-LL + #[link(name = "...", import_name_type = "decorated|noprefix|undecorated")]
-   |
-LL - #[link(name = "...", wasm_import_module)]
-LL + #[link(name = "...", kind = "dylib|static|...")]
-   |
-LL - #[link(name = "...", wasm_import_module)]
-LL + #[link(name = "...", kind = "dylib|static|...", wasm_import_module = "...", import_name_type = "decorated|noprefix|undecorated")]
-   |
-   = and 1 other candidate
 
 error[E0539]: malformed `link` attribute input
   --> $DIR/link-attr-validation-late.rs:27:1
@@ -426,21 +177,6 @@ LL | #[link(name = "...", wasm_import_module())]
    |                      expected this to be of the form `wasm_import_module = "..."`
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute>
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL - #[link(name = "...", wasm_import_module())]
-LL + #[link(name = "...")]
-   |
-LL - #[link(name = "...", wasm_import_module())]
-LL + #[link(name = "...", import_name_type = "decorated|noprefix|undecorated")]
-   |
-LL - #[link(name = "...", wasm_import_module())]
-LL + #[link(name = "...", kind = "dylib|static|...")]
-   |
-LL - #[link(name = "...", wasm_import_module())]
-LL + #[link(name = "...", kind = "dylib|static|...", wasm_import_module = "...", import_name_type = "decorated|noprefix|undecorated")]
-   |
-   = and 1 other candidate
 
 error: invalid linking modifier syntax, expected '+' or '-' prefix before one of: bundle, verbatim, whole-archive, as-needed
   --> $DIR/link-attr-validation-late.rs:31:34
@@ -463,21 +199,6 @@ LL | #[link(name = "...", modifiers = "+unknown")]
    |                                  valid arguments are "bundle", "verbatim", "whole-archive" or "as-needed"
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute>
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL - #[link(name = "...", modifiers = "+unknown")]
-LL + #[link(name = "...")]
-   |
-LL - #[link(name = "...", modifiers = "+unknown")]
-LL + #[link(name = "...", import_name_type = "decorated|noprefix|undecorated")]
-   |
-LL - #[link(name = "...", modifiers = "+unknown")]
-LL + #[link(name = "...", kind = "dylib|static|...")]
-   |
-LL - #[link(name = "...", modifiers = "+unknown")]
-LL + #[link(name = "...", kind = "dylib|static|...", wasm_import_module = "...", import_name_type = "decorated|noprefix|undecorated")]
-   |
-   = and 1 other candidate
 
 error: multiple `verbatim` modifiers in a single `modifiers` argument
   --> $DIR/link-attr-validation-late.rs:34:34

--- a/tests/ui/link-native-libs/modifiers-override-4.stderr
+++ b/tests/ui/link-native-libs/modifiers-override-4.stderr
@@ -12,49 +12,6 @@ LL | | )]
    | |__^
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute>
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL - #[link(
-LL -
-LL -     name = "bar",
-LL -     kind = "static",
-LL -     modifiers = "+whole-archive,-whole-archive",
-LL -
-LL -     modifiers = "+bundle"
-LL - )]
-LL + #[link(name = "...")]
-   |
-LL - #[link(
-LL -
-LL -     name = "bar",
-LL -     kind = "static",
-LL -     modifiers = "+whole-archive,-whole-archive",
-LL -
-LL -     modifiers = "+bundle"
-LL - )]
-LL + #[link(name = "...", import_name_type = "decorated|noprefix|undecorated")]
-   |
-LL - #[link(
-LL -
-LL -     name = "bar",
-LL -     kind = "static",
-LL -     modifiers = "+whole-archive,-whole-archive",
-LL -
-LL -     modifiers = "+bundle"
-LL - )]
-LL + #[link(name = "...", kind = "dylib|static|...")]
-   |
-LL - #[link(
-LL -
-LL -     name = "bar",
-LL -     kind = "static",
-LL -     modifiers = "+whole-archive,-whole-archive",
-LL -
-LL -     modifiers = "+bundle"
-LL - )]
-LL + #[link(name = "...", kind = "dylib|static|...", wasm_import_module = "...", import_name_type = "decorated|noprefix|undecorated")]
-   |
-   = and 1 other candidate
 
 error: multiple `whole-archive` modifiers in a single `modifiers` argument
   --> $DIR/modifiers-override-4.rs:6:17

--- a/tests/ui/linkage-attr/linkage3.stderr
+++ b/tests/ui/linkage-attr/linkage3.stderr
@@ -5,22 +5,6 @@ LL |     #[linkage = "foo"]
    |     ^^^^^^^^^^^^-----^
    |                 |
    |                 valid arguments are `available_externally`, `common`, `extern_weak`, `external`, `internal`, `linkonce`, `linkonce_odr`, `weak` or `weak_odr`
-   |
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL -     #[linkage = "foo"]
-LL +     #[linkage = "available_externally"]
-   |
-LL -     #[linkage = "foo"]
-LL +     #[linkage = "common"]
-   |
-LL -     #[linkage = "foo"]
-LL +     #[linkage = "extern_weak"]
-   |
-LL -     #[linkage = "foo"]
-LL +     #[linkage = "external"]
-   |
-   = and 5 other candidates
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/linkage-attr/raw-dylib/windows/import-name-type-invalid-format.stderr
+++ b/tests/ui/linkage-attr/raw-dylib/windows/import-name-type-invalid-format.stderr
@@ -7,21 +7,6 @@ LL | #[link(name = "foo", kind = "raw-dylib", import_name_type = 6)]
    |                                          expected this to be of the form `import_name_type = "..."`
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute>
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL - #[link(name = "foo", kind = "raw-dylib", import_name_type = 6)]
-LL + #[link(name = "...")]
-   |
-LL - #[link(name = "foo", kind = "raw-dylib", import_name_type = 6)]
-LL + #[link(name = "...", import_name_type = "decorated|noprefix|undecorated")]
-   |
-LL - #[link(name = "foo", kind = "raw-dylib", import_name_type = 6)]
-LL + #[link(name = "...", kind = "dylib|static|...")]
-   |
-LL - #[link(name = "foo", kind = "raw-dylib", import_name_type = 6)]
-LL + #[link(name = "...", kind = "dylib|static|...", wasm_import_module = "...", import_name_type = "decorated|noprefix|undecorated")]
-   |
-   = and 1 other candidate
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/linkage-attr/raw-dylib/windows/import-name-type-multiple.stderr
+++ b/tests/ui/linkage-attr/raw-dylib/windows/import-name-type-multiple.stderr
@@ -7,21 +7,6 @@ LL | #[link(name = "foo", kind = "raw-dylib", import_name_type = "decorated", im
    |                                                                          found `import_name_type` used as a key more than once
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute>
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL - #[link(name = "foo", kind = "raw-dylib", import_name_type = "decorated", import_name_type = "decorated")]
-LL + #[link(name = "...")]
-   |
-LL - #[link(name = "foo", kind = "raw-dylib", import_name_type = "decorated", import_name_type = "decorated")]
-LL + #[link(name = "...", import_name_type = "decorated|noprefix|undecorated")]
-   |
-LL - #[link(name = "foo", kind = "raw-dylib", import_name_type = "decorated", import_name_type = "decorated")]
-LL + #[link(name = "...", kind = "dylib|static|...")]
-   |
-LL - #[link(name = "foo", kind = "raw-dylib", import_name_type = "decorated", import_name_type = "decorated")]
-LL + #[link(name = "...", kind = "dylib|static|...", wasm_import_module = "...", import_name_type = "decorated|noprefix|undecorated")]
-   |
-   = and 1 other candidate
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/linkage-attr/raw-dylib/windows/import-name-type-unknown-value.stderr
+++ b/tests/ui/linkage-attr/raw-dylib/windows/import-name-type-unknown-value.stderr
@@ -7,21 +7,6 @@ LL | #[link(name = "foo", kind = "raw-dylib", import_name_type = "unknown")]
    |                                          valid arguments are "decorated", "noprefix" or "undecorated"
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute>
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL - #[link(name = "foo", kind = "raw-dylib", import_name_type = "unknown")]
-LL + #[link(name = "...")]
-   |
-LL - #[link(name = "foo", kind = "raw-dylib", import_name_type = "unknown")]
-LL + #[link(name = "...", import_name_type = "decorated|noprefix|undecorated")]
-   |
-LL - #[link(name = "foo", kind = "raw-dylib", import_name_type = "unknown")]
-LL + #[link(name = "...", kind = "dylib|static|...")]
-   |
-LL - #[link(name = "foo", kind = "raw-dylib", import_name_type = "unknown")]
-LL + #[link(name = "...", kind = "dylib|static|...", wasm_import_module = "...", import_name_type = "decorated|noprefix|undecorated")]
-   |
-   = and 1 other candidate
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/malformed/malformed-regressions.stderr
+++ b/tests/ui/malformed/malformed-regressions.stderr
@@ -5,17 +5,6 @@ LL | #[link]
    | ^^^^^^^ expected this to be a list
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute>
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL | #[link(name = "...")]
-   |       ++++++++++++++
-LL | #[link(name = "...", import_name_type = "decorated|noprefix|undecorated")]
-   |       +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-LL | #[link(name = "...", kind = "dylib|static|...")]
-   |       +++++++++++++++++++++++++++++++++++++++++
-LL | #[link(name = "...", kind = "dylib|static|...", wasm_import_module = "...", import_name_type = "decorated|noprefix|undecorated")]
-   |       ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-   = and 1 other candidate
 
 error[E0539]: malformed `link` attribute input
   --> $DIR/malformed-regressions.rs:10:1
@@ -24,21 +13,6 @@ LL | #[link = ""]
    | ^^^^^^^^^^^^ expected this to be a list
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute>
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL - #[link = ""]
-LL + #[link(name = "...")]
-   |
-LL - #[link = ""]
-LL + #[link(name = "...", import_name_type = "decorated|noprefix|undecorated")]
-   |
-LL - #[link = ""]
-LL + #[link(name = "...", kind = "dylib|static|...")]
-   |
-LL - #[link = ""]
-LL + #[link(name = "...", kind = "dylib|static|...", wasm_import_module = "...", import_name_type = "decorated|noprefix|undecorated")]
-   |
-   = and 1 other candidate
 
 warning: attribute should be applied to an `extern` block with non-Rust ABI
   --> $DIR/malformed-regressions.rs:7:1

--- a/tests/ui/repr/repr.stderr
+++ b/tests/ui/repr/repr.stderr
@@ -5,17 +5,6 @@ LL | #[repr]
    | ^^^^^^^ expected this to be a list
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/type-layout.html#representations>
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL | #[repr(<integer type>)]
-   |       ++++++++++++++++
-LL | #[repr(C)]
-   |       +++
-LL | #[repr(Rust)]
-   |       ++++++
-LL | #[repr(align(...))]
-   |       ++++++++++++
-   = and 2 other candidates
 
 error[E0539]: malformed `repr` attribute input
   --> $DIR/repr.rs:4:1
@@ -24,21 +13,6 @@ LL | #[repr = "B"]
    | ^^^^^^^^^^^^^ expected this to be a list
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/type-layout.html#representations>
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL - #[repr = "B"]
-LL + #[repr(<integer type>)]
-   |
-LL - #[repr = "B"]
-LL + #[repr(C)]
-   |
-LL - #[repr = "B"]
-LL + #[repr(Rust)]
-   |
-LL - #[repr = "B"]
-LL + #[repr(align(...))]
-   |
-   = and 2 other candidates
 
 error[E0539]: malformed `repr` attribute input
   --> $DIR/repr.rs:7:1
@@ -47,21 +21,6 @@ LL | #[repr = "C"]
    | ^^^^^^^^^^^^^ expected this to be a list
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/type-layout.html#representations>
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL - #[repr = "C"]
-LL + #[repr(<integer type>)]
-   |
-LL - #[repr = "C"]
-LL + #[repr(C)]
-   |
-LL - #[repr = "C"]
-LL + #[repr(Rust)]
-   |
-LL - #[repr = "C"]
-LL + #[repr(align(...))]
-   |
-   = and 2 other candidates
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/rustdoc/check-doc-alias-attr.stderr
+++ b/tests/ui/rustdoc/check-doc-alias-attr.stderr
@@ -11,22 +11,6 @@ LL | #[doc(alias = 0)]
    | ^^^^^^^^^^^^^^-^^
    |               |
    |               expected a string literal here
-   |
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL - #[doc(alias = 0)]
-LL + #[doc = "string"]
-   |
-LL - #[doc(alias = 0)]
-LL + #[doc(alias)]
-   |
-LL - #[doc(alias = 0)]
-LL + #[doc(attribute)]
-   |
-LL - #[doc(alias = 0)]
-LL + #[doc(auto_cfg)]
-   |
-   = and 22 other candidates
 
 error: '"' character isn't allowed in `#[doc(alias = "...")]`
   --> $DIR/check-doc-alias-attr.rs:9:15
@@ -79,22 +63,6 @@ LL | #[doc(alias(0))]
    | ^^^^^^^^^^^^-^^^
    |             |
    |             expected a string literal here
-   |
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL - #[doc(alias(0))]
-LL + #[doc = "string"]
-   |
-LL - #[doc(alias(0))]
-LL + #[doc(alias)]
-   |
-LL - #[doc(alias(0))]
-LL + #[doc(attribute)]
-   |
-LL - #[doc(alias(0))]
-LL + #[doc(auto_cfg)]
-   |
-   = and 22 other candidates
 
 error: '"' character isn't allowed in `#[doc(alias = "...")]`
   --> $DIR/check-doc-alias-attr.rs:20:13

--- a/tests/ui/sanitize-attr/invalid-sanitize.stderr
+++ b/tests/ui/sanitize-attr/invalid-sanitize.stderr
@@ -5,22 +5,6 @@ LL | #[sanitize(brontosaurus = "off")]
    | ^^^^^^^^^^^------------^^^^^^^^^^
    |            |
    |            valid arguments are "address", "cfi", "kcfi", "memory", "memtag", "shadow_call_stack", "thread", "hwaddress" or "realtime"
-   |
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL - #[sanitize(brontosaurus = "off")]
-LL + #[sanitize(address = "on|off")]
-   |
-LL - #[sanitize(brontosaurus = "off")]
-LL + #[sanitize(cfi = "on|off")]
-   |
-LL - #[sanitize(brontosaurus = "off")]
-LL + #[sanitize(hwaddress = "on|off")]
-   |
-LL - #[sanitize(brontosaurus = "off")]
-LL + #[sanitize(kcfi = "on|off")]
-   |
-   = and 6 other candidates
 
 error: multiple `sanitize` attributes
   --> $DIR/invalid-sanitize.rs:7:1
@@ -53,62 +37,18 @@ LL | #[sanitize(address = "bogus")]
    | ^^^^^^^^^^^^^^^^^^^^^-------^^
    |                      |
    |                      valid arguments are "on" or "off"
-   |
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL - #[sanitize(address = "bogus")]
-LL + #[sanitize(address = "on|off")]
-   |
-LL - #[sanitize(address = "bogus")]
-LL + #[sanitize(cfi = "on|off")]
-   |
-LL - #[sanitize(address = "bogus")]
-LL + #[sanitize(hwaddress = "on|off")]
-   |
-LL - #[sanitize(address = "bogus")]
-LL + #[sanitize(kcfi = "on|off")]
-   |
-   = and 6 other candidates
 
 error[E0539]: malformed `sanitize` attribute input
   --> $DIR/invalid-sanitize.rs:18:1
    |
 LL | #[sanitize = "off"]
    | ^^^^^^^^^^^^^^^^^^^ expected this to be a list
-   |
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL - #[sanitize = "off"]
-LL + #[sanitize(address = "on|off")]
-   |
-LL - #[sanitize = "off"]
-LL + #[sanitize(cfi = "on|off")]
-   |
-LL - #[sanitize = "off"]
-LL + #[sanitize(hwaddress = "on|off")]
-   |
-LL - #[sanitize = "off"]
-LL + #[sanitize(kcfi = "on|off")]
-   |
-   = and 6 other candidates
 
 error[E0539]: malformed `sanitize` attribute input
   --> $DIR/invalid-sanitize.rs:21:1
    |
 LL | #[sanitize]
    | ^^^^^^^^^^^ expected this to be a list
-   |
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL | #[sanitize(address = "on|off")]
-   |           ++++++++++++++++++++
-LL | #[sanitize(cfi = "on|off")]
-   |           ++++++++++++++++
-LL | #[sanitize(hwaddress = "on|off")]
-   |           ++++++++++++++++++++++
-LL | #[sanitize(kcfi = "on|off")]
-   |           +++++++++++++++++
-   = and 6 other candidates
 
 error[E0539]: malformed `sanitize` attribute input
   --> $DIR/invalid-sanitize.rs:24:1
@@ -117,22 +57,6 @@ LL | #[sanitize(realtime = "on")]
    | ^^^^^^^^^^^^^^^^^^^^^^----^^
    |                       |
    |                       valid arguments are "nonblocking", "blocking" or "caller"
-   |
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL - #[sanitize(realtime = "on")]
-LL + #[sanitize(address = "on|off")]
-   |
-LL - #[sanitize(realtime = "on")]
-LL + #[sanitize(cfi = "on|off")]
-   |
-LL - #[sanitize(realtime = "on")]
-LL + #[sanitize(hwaddress = "on|off")]
-   |
-LL - #[sanitize(realtime = "on")]
-LL + #[sanitize(kcfi = "on|off")]
-   |
-   = and 6 other candidates
 
 warning: the async executor can run blocking code, without realtime sanitizer catching it
   --> $DIR/invalid-sanitize.rs:27:1

--- a/tests/ui/wasm/wasm-import-module.stderr
+++ b/tests/ui/wasm/wasm-import-module.stderr
@@ -7,21 +7,6 @@ LL | #[link(name = "...", wasm_import_module)]
    |                      expected this to be of the form `wasm_import_module = "..."`
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute>
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL - #[link(name = "...", wasm_import_module)]
-LL + #[link(name = "...")]
-   |
-LL - #[link(name = "...", wasm_import_module)]
-LL + #[link(name = "...", import_name_type = "decorated|noprefix|undecorated")]
-   |
-LL - #[link(name = "...", wasm_import_module)]
-LL + #[link(name = "...", kind = "dylib|static|...")]
-   |
-LL - #[link(name = "...", wasm_import_module)]
-LL + #[link(name = "...", kind = "dylib|static|...", wasm_import_module = "...", import_name_type = "decorated|noprefix|undecorated")]
-   |
-   = and 1 other candidate
 
 error[E0539]: malformed `link` attribute input
   --> $DIR/wasm-import-module.rs:6:1
@@ -32,21 +17,6 @@ LL | #[link(name = "...", wasm_import_module(x))]
    |                      expected this to be of the form `wasm_import_module = "..."`
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute>
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL - #[link(name = "...", wasm_import_module(x))]
-LL + #[link(name = "...")]
-   |
-LL - #[link(name = "...", wasm_import_module(x))]
-LL + #[link(name = "...", import_name_type = "decorated|noprefix|undecorated")]
-   |
-LL - #[link(name = "...", wasm_import_module(x))]
-LL + #[link(name = "...", kind = "dylib|static|...")]
-   |
-LL - #[link(name = "...", wasm_import_module(x))]
-LL + #[link(name = "...", kind = "dylib|static|...", wasm_import_module = "...", import_name_type = "decorated|noprefix|undecorated")]
-   |
-   = and 1 other candidate
 
 error[E0539]: malformed `link` attribute input
   --> $DIR/wasm-import-module.rs:9:1
@@ -57,21 +27,6 @@ LL | #[link(name = "...", wasm_import_module())]
    |                      expected this to be of the form `wasm_import_module = "..."`
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute>
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL - #[link(name = "...", wasm_import_module())]
-LL + #[link(name = "...")]
-   |
-LL - #[link(name = "...", wasm_import_module())]
-LL + #[link(name = "...", import_name_type = "decorated|noprefix|undecorated")]
-   |
-LL - #[link(name = "...", wasm_import_module())]
-LL + #[link(name = "...", kind = "dylib|static|...")]
-   |
-LL - #[link(name = "...", wasm_import_module())]
-LL + #[link(name = "...", kind = "dylib|static|...", wasm_import_module = "...", import_name_type = "decorated|noprefix|undecorated")]
-   |
-   = and 1 other candidate
 
 error: `wasm_import_module` is incompatible with other arguments in `#[link]` attributes
   --> $DIR/wasm-import-module.rs:12:8


### PR DESCRIPTION
Part of https://github.com/rust-lang/rust/issues/149865.

This not only covers for doc attributes but for all attributes, so don't hesitate to tell me if you want it to be limited to only doc attributes (although I think it's actually a nice improvement overall).

Also, I picked 3 as the maximum number of suggestions before it becomes noise, but it's very much open to debate.

r? @JonathanBrouwer 