### PR TITLE
[EXPERIMENT DO NOT MERGE] remove span tracking during lowering

### DIFF
--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -226,7 +226,7 @@ struct SpanLowerer {
 impl SpanLowerer {
     fn lower(&self, span: Span) -> Span {
         if self.is_incremental {
-            span.with_parent(Some(self.def_id))
+            span.with_parent_untracked(Some(self.def_id))
         } else {
             // Do not make spans relative when not using incremental compilation.
             span


### PR DESCRIPTION
r? @ghost

Just a little experiment to see how much it gains us. All incremental tests pass, I've not found a place yet where it matters that we track them. It makes some sense, spans are relative to their parent anyway so it makes some sense that they're regenerated anyway if their parent changes. But I can't yet prove this. I am wondering how much perf it gains us.
