### PR TITLE
`cfg_select!`: parse unused branches

### DIFF
--- a/compiler/rustc_builtin_macros/src/cfg_select.rs
+++ b/compiler/rustc_builtin_macros/src/cfg_select.rs
@@ -1,22 +1,65 @@
 use rustc_ast::tokenstream::TokenStream;
+use rustc_ast::{Expr, ast};
 use rustc_attr_parsing as attr;
 use rustc_attr_parsing::{
     CfgSelectBranches, CfgSelectPredicate, EvalConfigResult, parse_cfg_select,
 };
-use rustc_expand::base::{DummyResult, ExpandResult, ExtCtxt, MacroExpanderResult};
+use rustc_expand::base::{DummyResult, ExpandResult, ExtCtxt, MacResult, MacroExpanderResult};
 use rustc_span::{Ident, Span, sym};
+use smallvec::SmallVec;
 
 use crate::errors::{CfgSelectNoMatches, CfgSelectUnreachable};
 
-/// Selects the first arm whose predicate evaluates to true.
-fn select_arm(ecx: &ExtCtxt<'_>, branches: CfgSelectBranches) -> Option<(TokenStream, Span)> {
-    for (cfg, tt, arm_span) in branches.reachable {
-        if let EvalConfigResult::True = attr::eval_config_entry(&ecx.sess, &cfg) {
-            return Some((tt, arm_span));
-        }
-    }
+/// This intermediate structure is used to emit parse errors for the branches that are not chosen.
+/// The `MacResult` instance below parses all branches, emitting any errors it encounters, but only
+/// keeps the parse result for the selected branch.
+struct CfgSelectResult<'cx, 'sess> {
+    ecx: &'cx mut ExtCtxt<'sess>,
+    site_span: Span,
+    selected_tts: TokenStream,
+    selected_span: Span,
+    other_branches: CfgSelectBranches,
+}
 
-    branches.wildcard.map(|(_, tt, span)| (tt, span))
+fn tts_to_mac_result<'cx, 'sess>(
+    ecx: &'cx mut ExtCtxt<'sess>,
+    site_span: Span,
+    tts: TokenStream,
+    span: Span,
+) -> Box<dyn MacResult + 'cx> {
+    match ExpandResult::from_tts(ecx, tts, site_span, span, Ident::with_dummy_span(sym::cfg_select))
+    {
+        ExpandResult::Ready(x) => x,
+        _ => unreachable!("from_tts always returns Ready"),
+    }
+}
+
+macro_rules! forward_to_parser_any_macro {
+    ($method_name:ident, $ret_ty:ty) => {
+        fn $method_name(self: Box<Self>) -> Option<$ret_ty> {
+            let CfgSelectResult { ecx, site_span, selected_tts, selected_span, .. } = *self;
+
+            for (tts, span) in self.other_branches.into_iter_tts() {
+                let _ = tts_to_mac_result(ecx, site_span, tts, span).$method_name();
+            }
+
+            tts_to_mac_result(ecx, site_span, selected_tts, selected_span).$method_name()
+        }
+    };
+}
+
+impl<'cx, 'sess> MacResult for CfgSelectResult<'cx, 'sess> {
+    forward_to_parser_any_macro!(make_expr, Box<Expr>);
+    forward_to_parser_any_macro!(make_stmts, SmallVec<[ast::Stmt; 1]>);
+    forward_to_parser_any_macro!(make_items, SmallVec<[Box<ast::Item>; 1]>);
+
+    forward_to_parser_any_macro!(make_impl_items, SmallVec<[Box<ast::AssocItem>; 1]>);
+    forward_to_parser_any_macro!(make_trait_impl_items, SmallVec<[Box<ast::AssocItem>; 1]>);
+    forward_to_parser_any_macro!(make_trait_items, SmallVec<[Box<ast::AssocItem>; 1]>);
+    forward_to_parser_any_macro!(make_foreign_items, SmallVec<[Box<ast::ForeignItem>; 1]>);
+
+    forward_to_parser_any_macro!(make_ty, Box<ast::Ty>);
+    forward_to_parser_any_macro!(make_pat, Box<ast::Pat>);
 }
 
 pub(super) fn expand_cfg_select<'cx>(
@@ -31,7 +74,7 @@ pub(super) fn expand_cfg_select<'cx>(
             Some(ecx.ecfg.features),
             ecx.current_expansion.lint_node_id,
         ) {
-            Ok(branches) => {
+            Ok(mut branches) => {
                 if let Some((underscore, _, _)) = branches.wildcard {
                     // Warn for every unreachable predicate. We store the fully parsed branch for rustfmt.
                     for (predicate, _, _) in &branches.unreachable {
@@ -44,14 +87,17 @@ pub(super) fn expand_cfg_select<'cx>(
                     }
                 }
 
-                if let Some((tts, arm_span)) = select_arm(ecx, branches) {
-                    return ExpandResult::from_tts(
+                if let Some((selected_tts, selected_span)) = branches.pop_first_match(|cfg| {
+                    matches!(attr::eval_config_entry(&ecx.sess, cfg), EvalConfigResult::True)
+                }) {
+                    let mac = CfgSelectResult {
                         ecx,
-                        tts,
-                        sp,
-                        arm_span,
-                        Ident::with_dummy_span(sym::cfg_select),
-                    );
+                        selected_tts,
+                        selected_span,
+                        other_branches: branches,
+                        site_span: sp,
+                    };
+                    return ExpandResult::Ready(Box::new(mac));
                 } else {
                     // Emit a compiler error when none of the predicates matched.
                     let guar = ecx.dcx().emit_err(CfgSelectNoMatches { span: sp });

--- a/tests/ui/macros/cfg_select.rs
+++ b/tests/ui/macros/cfg_select.rs
@@ -47,6 +47,89 @@ fn arm_rhs_expr_3() -> i32 {
     }
 }
 
+fn expand_to_statements() -> i32 {
+    cfg_select! {
+        true => {
+            let a = 1;
+            a + 1
+        }
+        false => {
+            let b = 2;
+            b + 1
+        }
+    }
+}
+
+type ExpandToType = cfg_select! {
+    unix => u32,
+    _ => i32,
+};
+
+fn expand_to_pattern(x: Option<i32>) -> bool {
+    match x {
+        (cfg_select! {
+            unix => Some(n),
+            _ => None,
+        }) => true,
+        _ => false,
+    }
+}
+
+cfg_select! {
+    true => {
+        fn foo() {}
+    }
+    _ => {
+        fn bar() {}
+    }
+}
+
+struct S;
+
+impl S {
+    cfg_select! {
+        true => {
+            fn foo() {}
+        }
+        _ => {
+            fn bar() {}
+        }
+    }
+}
+
+trait T {
+    cfg_select! {
+        true => {
+            fn a();
+        }
+        _ => {
+            fn b();
+        }
+    }
+}
+
+impl T for S {
+    cfg_select! {
+        true => {
+            fn a() {}
+        }
+        _ => {
+            fn b() {}
+        }
+    }
+}
+
+extern "C" {
+    cfg_select! {
+        true => {
+            fn puts(s: *const i8) -> i32;
+        }
+        _ => {
+            fn printf(fmt: *const i8, ...) -> i32;
+        }
+    }
+}
+
 cfg_select! {
     _ => {}
     true => {}

--- a/tests/ui/macros/cfg_select.stderr
+++ b/tests/ui/macros/cfg_select.stderr
@@ -1,5 +1,5 @@
 warning: unreachable predicate
-  --> $DIR/cfg_select.rs:52:5
+  --> $DIR/cfg_select.rs:135:5
    |
 LL |     _ => {}
    |     - always matches
@@ -7,7 +7,7 @@ LL |     true => {}
    |     ^^^^ this predicate is never reached
 
 error: none of the predicates in this `cfg_select` evaluated to true
-  --> $DIR/cfg_select.rs:56:1
+  --> $DIR/cfg_select.rs:139:1
    |
 LL | / cfg_select! {
 LL | |
@@ -16,55 +16,55 @@ LL | | }
    | |_^
 
 error: none of the predicates in this `cfg_select` evaluated to true
-  --> $DIR/cfg_select.rs:61:1
+  --> $DIR/cfg_select.rs:144:1
    |
 LL | cfg_select! {}
    | ^^^^^^^^^^^^^^
 
 error: expected a literal (`1u8`, `1.0f32`, `"string"`, etc.) here, found `=>`
-  --> $DIR/cfg_select.rs:65:5
+  --> $DIR/cfg_select.rs:148:5
    |
 LL |     => {}
    |     ^^
 
 error: expected a literal (`1u8`, `1.0f32`, `"string"`, etc.) here, found expression
-  --> $DIR/cfg_select.rs:70:5
+  --> $DIR/cfg_select.rs:153:5
    |
 LL |     () => {}
    |     ^^ expressions are not allowed here
 
 error[E0539]: malformed `cfg_select` macro input
-  --> $DIR/cfg_select.rs:75:5
+  --> $DIR/cfg_select.rs:158:5
    |
 LL |     "str" => {}
    |     ^^^^^ expected a valid identifier here
 
 error[E0539]: malformed `cfg_select` macro input
-  --> $DIR/cfg_select.rs:80:5
+  --> $DIR/cfg_select.rs:163:5
    |
 LL |     a::b => {}
    |     ^^^^ expected a valid identifier here
 
 error[E0537]: invalid predicate `a`
-  --> $DIR/cfg_select.rs:85:5
+  --> $DIR/cfg_select.rs:168:5
    |
 LL |     a() => {}
    |     ^^^
 
 error: expected one of `(`, `::`, `=>`, or `=`, found `+`
-  --> $DIR/cfg_select.rs:90:7
+  --> $DIR/cfg_select.rs:173:7
    |
 LL |     a + 1 => {}
    |       ^ expected one of `(`, `::`, `=>`, or `=`
 
 error: expected one of `(`, `::`, `=>`, or `=`, found `!`
-  --> $DIR/cfg_select.rs:96:8
+  --> $DIR/cfg_select.rs:179:8
    |
 LL |     cfg!() => {}
    |        ^ expected one of `(`, `::`, `=>`, or `=`
 
 warning: unexpected `cfg` condition name: `a`
-  --> $DIR/cfg_select.rs:90:5
+  --> $DIR/cfg_select.rs:173:5
    |
 LL |     a + 1 => {}
    |     ^ help: found config with similar value: `target_feature = "a"`
@@ -75,7 +75,7 @@ LL |     a + 1 => {}
    = note: `#[warn(unexpected_cfgs)]` on by default
 
 warning: unexpected `cfg` condition name: `cfg`
-  --> $DIR/cfg_select.rs:96:5
+  --> $DIR/cfg_select.rs:179:5
    |
 LL |     cfg!() => {}
    |     ^^^

--- a/tests/ui/macros/cfg_select_parse_error.rs
+++ b/tests/ui/macros/cfg_select_parse_error.rs
@@ -1,0 +1,18 @@
+#![feature(cfg_select)]
+#![crate_type = "lib"]
+
+// Check that parse errors in arms that are not selected are still reported.
+
+fn print() {
+    println!(cfg_select! {
+        false => { 1 ++ 2 }
+        //~^ ERROR Rust has no postfix increment operator
+        _ => { "not unix" }
+    });
+}
+
+cfg_select! {
+    false => { fn foo() { 1 +++ 2 } }
+    //~^ ERROR Rust has no postfix increment operator
+    _ => {}
+}

--- a/tests/ui/macros/cfg_select_parse_error.stderr
+++ b/tests/ui/macros/cfg_select_parse_error.stderr
@@ -1,0 +1,26 @@
+error: Rust has no postfix increment operator
+  --> $DIR/cfg_select_parse_error.rs:8:22
+   |
+LL |         false => { 1 ++ 2 }
+   |                      ^^ not a valid postfix operator
+   |
+help: use `+= 1` instead
+   |
+LL -         false => { 1 ++ 2 }
+LL +         false => { { let tmp = 1 ; 1 += 1; tmp } 2 }
+   |
+
+error: Rust has no postfix increment operator
+  --> $DIR/cfg_select_parse_error.rs:15:29
+   |
+LL |     false => { fn foo() { 1 +++ 2 } }
+   |                             ^^ not a valid postfix operator
+   |
+help: use `+= 1` instead
+   |
+LL -     false => { fn foo() { 1 +++ 2 } }
+LL +     false => { fn foo() { { let tmp = 1 ; 1 += 1; tmp }+ 2 } }
+   |
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
tracking issue: https://github.com/rust-lang/rust/issues/115585

Emit parse errors that are found in the branches that are not selected, like e.g. how `#[cfg(false)] { 1 ++ 2 }` still emits a parse error even though the expression is never used by the program. Parsing the unused branches was requested by T-lang https://github.com/rust-lang/rust/pull/149783#issuecomment-3647541611.