### PR TITLE
Do not deduplicate captured args while expanding `format_args!`

### DIFF
--- a/compiler/rustc_ast_lowering/src/format.rs
+++ b/compiler/rustc_ast_lowering/src/format.rs
@@ -462,7 +462,7 @@ fn expand_format_args<'hir>(
                     let placeholder_span =
                         placeholder_span.unwrap_or(arg.expr.span).with_ctxt(macsp.ctxt());
                     let arg_span = match arg.kind {
-                        FormatArgumentKind::Captured(_) => placeholder_span,
+                        FormatArgumentKind::Captured => placeholder_span,
                         _ => arg.expr.span.with_ctxt(macsp.ctxt()),
                     };
                     let args_ident_expr = ctx.expr_ident(macsp, args_ident, args_hir_id);

--- a/compiler/rustc_builtin_macros/src/format.rs
+++ b/compiler/rustc_builtin_macros/src/format.rs
@@ -121,7 +121,7 @@ fn parse_args<'a>(ecx: &ExtCtxt<'a>, sp: Span, tts: TokenStream) -> PResult<'a, 
                 p.bump();
                 p.expect(exp!(Eq))?;
                 let expr = p.parse_expr()?;
-                if let Some((_, prev)) = args.by_name(ident.name) {
+                if let Some((_, prev)) = args.by_explicit_name(ident.name) {
                     ecx.dcx().emit_err(errors::FormatDuplicateArg {
                         span: ident.span,
                         prev: prev.kind.ident().unwrap().span,
@@ -374,12 +374,11 @@ fn make_format_args(
             }
             Name(name, span) => {
                 let name = Symbol::intern(name);
-                if let Some((index, _)) = args.by_name(name) {
+                if let Some((index, _)) = args.by_explicit_name(name) {
                     // Name found in `args`, so we resolve it to its index.
-                    if index < args.explicit_args().len() {
-                        // Mark it as used, if it was an explicit argument.
-                        used[index] = true;
-                    }
+                    assert!(index < args.explicit_args().len());
+                    // Mark it as used, as this is an explicit argument.
+                    used[index] = true;
                     Ok(index)
                 } else {
                     // Name not found in `args`, so we add it as an implicitly captured argument.
@@ -394,7 +393,7 @@ fn make_format_args(
                         unnamed_arg_after_named_arg = true;
                         DummyResult::raw_expr(span, Some(guar))
                     };
-                    Ok(args.add(FormatArgument { kind: FormatArgumentKind::Captured(ident), expr }))
+                    Ok(args.add(FormatArgument { kind: FormatArgumentKind::Captured, expr }))
                 }
             }
         };

--- a/src/tools/clippy/clippy_lints/src/format_args.rs
+++ b/src/tools/clippy/clippy_lints/src/format_args.rs
@@ -447,7 +447,7 @@ impl<'tcx> FormatArgsExpr<'_, 'tcx> {
         let index = pos.index.unwrap();
         let arg = &self.format_args.arguments.all_args()[index];
 
-        if !matches!(arg.kind, FormatArgumentKind::Captured(_))
+        if !matches!(arg.kind, FormatArgumentKind::Captured)
             && let rustc_ast::ExprKind::Path(None, path) = &arg.expr.kind
             && let [segment] = path.segments.as_slice()
             && segment.args.is_none()
@@ -467,7 +467,7 @@ impl<'tcx> FormatArgsExpr<'_, 'tcx> {
             // * if we can't inline a numbered argument, e.g. `print!("{0} ...", foo.bar, ...)`
             // * if allow_mixed_uninlined_format_args is false and this arg hasn't been inlined already
             pos.kind != FormatArgPositionKind::Number
-                && (!self.ignore_mixed || matches!(arg.kind, FormatArgumentKind::Captured(_)))
+                && (!self.ignore_mixed || matches!(arg.kind, FormatArgumentKind::Captured))
         }
     }
 

--- a/src/tools/clippy/clippy_lints/src/unit_types/let_unit_value.rs
+++ b/src/tools/clippy/clippy_lints/src/unit_types/let_unit_value.rs
@@ -202,7 +202,7 @@ impl<'tcx> Visitor<'tcx> for UnitVariableCollector<'_, 'tcx> {
         {
             if let Some(macro_call) = self.macro_call
                 && macro_call.arguments.all_args().iter().any(|arg| {
-                    matches!(arg.kind, FormatArgumentKind::Captured(_)) && find_format_arg_expr(ex, arg).is_some()
+                    matches!(arg.kind, FormatArgumentKind::Captured) && find_format_arg_expr(ex, arg).is_some()
                 })
             {
                 self.spans.push(VariableUsage::FormatCapture);

--- a/tests/pretty/hir-format-args-duplicated-captures.pp
+++ b/tests/pretty/hir-format-args-duplicated-captures.pp
@@ -1,0 +1,20 @@
+#[attr = MacroUse {arguments: UseAll}]
+extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
+//@ pretty-compare-only
+//@ pretty-mode:hir
+//@ pp-exact:hir-format-args-duplicated-captures.pp
+
+const X: i32 = 42;
+
+fn main() {
+    let _ =
+        {
+            super let args = (&X, &X);
+            super let args =
+                [format_argument::new_display(args.0),
+                        format_argument::new_display(args.1)];
+            unsafe { format_arguments::new(b"\xc0\x01 \xc0\x00", &args) }
+        };
+}

--- a/tests/pretty/hir-format-args-duplicated-captures.rs
+++ b/tests/pretty/hir-format-args-duplicated-captures.rs
@@ -1,0 +1,9 @@
+//@ pretty-compare-only
+//@ pretty-mode:hir
+//@ pp-exact:hir-format-args-duplicated-captures.pp
+
+const X: i32 = 42;
+
+fn main() {
+    let _ = format_args!("{X} {X}");
+}

--- a/tests/ui/drop/format-args-duplicated-captured-const-drops.rs
+++ b/tests/ui/drop/format-args-duplicated-captured-const-drops.rs
@@ -1,0 +1,53 @@
+//! A regression test for https://github.com/rust-lang/rust/issues/145739.
+//! `format_args!` should not deduplicate implicitly captured arguments.
+//! They must be evaluated once per occurrence, whereas explicitly
+//! provided arguments are evaluated only once, regardless of how many
+//! times they appear in the format string.
+//@ run-pass
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+static DROP_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+#[derive(Debug)]
+struct Foo;
+
+impl Drop for Foo {
+    fn drop(&mut self) {
+        DROP_COUNTER.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+fn main() {
+    assert_eq!(DROP_COUNTER.load(Ordering::Relaxed), 0);
+
+    {
+        let _x = format_args!("{Foo:?}");
+    }
+    assert_eq!(DROP_COUNTER.load(Ordering::Relaxed), 1);
+
+    {
+        let _x = format_args!("{Foo:?}{Foo:?}");
+    }
+    // Increased by 2, as `Foo` is constructed for each captured `Foo`.
+    assert_eq!(DROP_COUNTER.load(Ordering::Relaxed), 3);
+
+    {
+        let _x = format_args!("{:?}{0:?}", Foo);
+    }
+    // Increased by 1, as `foo` is constructed just once as an explicit argument.
+    assert_eq!(DROP_COUNTER.load(Ordering::Relaxed), 4);
+
+    {
+        let _x = format_args!("{foo:?}{foo:?}{bar:?}{Foo:?}{Foo:?}", foo = Foo, bar = Foo);
+    }
+    // Increased by 4, as `foo` is constructed twice for captured `Foo`, and once for each `foo` and
+    // `bar`.
+    assert_eq!(DROP_COUNTER.load(Ordering::Relaxed), 8);
+
+    {
+        let _x = format_args!("{Foo:?}{Foo:?}", Foo = Foo);
+    }
+    // Increased by 1, as `Foo` is shadowed by an explicit argument.
+    assert_eq!(DROP_COUNTER.load(Ordering::Relaxed), 9);
+}


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/149926)*
<!-- homu-ignore:end -->

Resolves https://github.com/rust-lang/rust/issues/145739

I ran crater with https://github.com/rust-lang/rust/pull/149291.
While there are still a few [seemingly flaky, spurious results](https://github.com/rust-lang/rust/pull/149291#issuecomment-3642672242), no crates appear to be affected by this breaking change.

The only hit from the lint was
https://github.com/multiversx/mx-sdk-rs/blob/813927c03a7b512a3c6ef9a15690eaf87872cc5c/framework/meta-lib/src/tools/rustc_version_warning.rs#L19-L30,
which performs formatting on consts of type `::semver::Version`. These constants contain a nested `::semver::Identifier` (`Version.pre.identifier`) that has a custom destructor. However, this case is not impacted by the change, so no breakage is expected.