### PR TITLE
Documented thread hooks on panics and errors of thread spawning functions.

### DIFF
--- a/library/std/src/thread/builder.rs
+++ b/library/std/src/thread/builder.rs
@@ -160,9 +160,17 @@ impl Builder {
     /// [`io::Result`] to capture any failure to create the thread at
     /// the OS level.
     ///
+    /// Like [`spawn`], this method will still call the main thread functions
+    /// added by [`add_spawn_hook`] (unless [`Builder::no_hooks`] was called),
+    /// but won't execute the returned functions if thread creation fails at the
+    /// OS level.
+    ///
     /// # Panics
     ///
     /// Panics if a thread name was set and it contained null bytes.
+    ///
+    /// Unlike the [`spawn`] free function, if it panics for this reason, the
+    /// parent thread functions added by [`add_spawn_hook`] will _not_ be called.
     ///
     /// # Examples
     ///
@@ -178,8 +186,10 @@ impl Builder {
     /// handler.join().unwrap();
     /// ```
     ///
+    /// [`io::Result`]: crate::io::Result
     /// [`thread::spawn`]: super::spawn
     /// [`spawn`]: super::spawn
+    /// [`add_spawn_hook`]: crate::thread::add_spawn_hook
     #[stable(feature = "rust1", since = "1.0.0")]
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
     pub fn spawn<F, T>(self, f: F) -> io::Result<JoinHandle<T>>
@@ -209,9 +219,17 @@ impl Builder {
     /// [`io::Result`] to capture any failure to create the thread at
     /// the OS level.
     ///
+    /// Like [`spawn`], this method will still call the main thread functions
+    /// added by [`add_spawn_hook`] (unless [`Builder::no_hooks`] was called),
+    /// but won't execute the returned functions if thread creation fails at the
+    /// OS level.
+    ///
     /// # Panics
     ///
     /// Panics if a thread name was set and it contained null bytes.
+    ///
+    /// Unlike the [`spawn`] free function, if it panics for this reason, the
+    /// parent thread functions added by [`add_spawn_hook`] will _not_ be called.
     ///
     /// # Safety
     ///
@@ -249,6 +267,7 @@ impl Builder {
     ///
     /// [`thread::spawn`]: super::spawn
     /// [`spawn`]: super::spawn
+    /// [`add_spawn_hook`]: crate::thread::add_spawn_hook
     #[stable(feature = "thread_spawn_unchecked", since = "1.82.0")]
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
     pub unsafe fn spawn_unchecked<F, T>(self, f: F) -> io::Result<JoinHandle<T>>

--- a/library/std/src/thread/functions.rs
+++ b/library/std/src/thread/functions.rs
@@ -45,8 +45,11 @@ use crate::{io, panicking};
 ///
 /// # Panics
 ///
-/// Panics if the OS fails to create a thread; use [`Builder::spawn`]
-/// to recover from such errors.
+/// Panics if the OS fails to create a thread; use [`Builder::spawn`] to recover
+/// from such errors.
+///
+/// Additionally, if hooks were added via [`add_spawn_hook`], they will still be
+/// called in the parent thread, but the returned functions will not be executed.
 ///
 /// # Examples
 ///
@@ -120,6 +123,7 @@ use crate::{io, panicking};
 /// [`channels`]: crate::sync::mpsc
 /// [`join`]: JoinHandle::join
 /// [`Err`]: crate::result::Result::Err
+/// [`add_spawn_hook`]: crate::thread::add_spawn_hook
 #[stable(feature = "rust1", since = "1.0.0")]
 #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
 pub fn spawn<F, T>(f: F) -> JoinHandle<T>

--- a/library/std/src/thread/scoped.rs
+++ b/library/std/src/thread/scoped.rs
@@ -196,7 +196,13 @@ impl<'scope, 'env> Scope<'scope, 'env> {
     /// Panics if the OS fails to create a thread; use [`Builder::spawn_scoped`]
     /// to recover from such errors.
     ///
+    /// like the free [`spawn`] function, if hooks were added via [`add_spawn_hook`],
+    /// they will still be called in the parent thread, but the returned functions will
+    /// not be executed.
+    ///
     /// [`join`]: ScopedJoinHandle::join
+    /// [`add_spawn_hook`]: crate::thread::add_spawn_hook
+    /// [`spawn`]: crate::thread::spawn
     #[stable(feature = "scoped_threads", since = "1.63.0")]
     pub fn spawn<F, T>(&'scope self, f: F) -> ScopedJoinHandle<'scope, T>
     where
@@ -213,9 +219,17 @@ impl Builder {
     /// Unlike [`Scope::spawn`], this method yields an [`io::Result`] to
     /// capture any failure to create the thread at the OS level.
     ///
+    /// Like [`Scope::spawn`], this method will still call the main thread functions
+    /// added by [`add_spawn_hook`] (unless [`Builder::no_hooks`] was called),
+    /// but won't execute the returned functions if thread creation fails at the
+    /// OS level.
+    ///
     /// # Panics
     ///
     /// Panics if a thread name was set and it contained null bytes.
+    ///
+    /// Unlike with [`Scope::spawn`], if it panics for this reason, the hooks
+    /// added by [`add_spawn_hook`] will _not_ be called.
     ///
     /// # Example
     ///
@@ -252,6 +266,9 @@ impl Builder {
     /// a.push(4);
     /// assert_eq!(x, a.len());
     /// ```
+    ///
+    /// [`io::Result`]: crate::io::Result
+    /// [`add_spawn_hook`]: crate::thread::add_spawn_hook
     #[stable(feature = "scoped_threads", since = "1.63.0")]
     pub fn spawn_scoped<'scope, 'env, F, T>(
         self,


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/149927)*
<!-- homu-ignore:end -->

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
This PR solves a concern regarding rust-lang/rust#132951

Considering that the feature has been on nightly for over a year, I would also like to see it stabilized, since no one has voiced any concerns about its current implementation.
<!-- homu-ignore:end -->
