### PR TITLE
Detail expectation on non-`()` block tail in `if` then condition with no `else`

### DIFF
--- a/tests/ui/async-await/dont-ice-for-type-mismatch-in-closure-in-async.stderr
+++ b/tests/ui/async-await/dont-ice-for-type-mismatch-in-closure-in-async.stderr
@@ -6,7 +6,7 @@ LL | |             false
    | |             ^^^^^ expected `()`, found `bool`
 LL | |
 LL | |         }
-   | |_________- expected this to be `()`
+   | |_________- `if` expressions without `else` arms expect their inner expression to be `()`
 
 error[E0308]: mismatched types
   --> $DIR/dont-ice-for-type-mismatch-in-closure-in-async.rs:12:9

--- a/tests/ui/async-await/missing-return-in-async-block.stderr
+++ b/tests/ui/async-await/missing-return-in-async-block.stderr
@@ -5,7 +5,7 @@ LL | /         if true {
 LL | |             Ok(S)
    | |             ^^^^^ expected `()`, found `Result<S, _>`
 LL | |         }
-   | |_________- expected this to be `()`
+   | |_________- `if` expressions without `else` arms expect their inner expression to be `()`
    |
    = note: expected unit type `()`
                    found enum `Result<S, _>`
@@ -21,7 +21,7 @@ LL | /         if true {
 LL | |             Ok(S)
    | |             ^^^^^ expected `()`, found `Result<S, _>`
 LL | |         }
-   | |_________- expected this to be `()`
+   | |_________- `if` expressions without `else` arms expect their inner expression to be `()`
    |
    = note: expected unit type `()`
                    found enum `Result<S, _>`

--- a/tests/ui/lint/unused/unused-doc-comments-edge-cases.stderr
+++ b/tests/ui/lint/unused/unused-doc-comments-edge-cases.stderr
@@ -105,7 +105,7 @@ LL | /     if num == 3 {
 LL | |         true
    | |         ^^^^ expected `()`, found `bool`
 LL | |     }
-   | |_____- expected this to be `()`
+   | |_____- `if` expressions without `else` arms expect their inner expression to be `()`
    |
 help: you might have meant to return this value
    |

--- a/tests/ui/loops/dont-suggest-break-thru-item.stderr
+++ b/tests/ui/loops/dont-suggest-break-thru-item.stderr
@@ -6,7 +6,7 @@ LL | |                 Err(1)
    | |                 ^^^^^^ expected `()`, found `Result<_, {integer}>`
 ...  |
 LL | |             }
-   | |_____________- expected this to be `()`
+   | |_____________- `if` expressions without `else` arms expect their inner expression to be `()`
    |
    = note: expected unit type `()`
                    found enum `Result<_, {integer}>`
@@ -23,7 +23,7 @@ LL | |                 Err(1)
    | |                 ^^^^^^ expected `()`, found `Result<_, {integer}>`
 ...  |
 LL | |             }
-   | |_____________- expected this to be `()`
+   | |_____________- `if` expressions without `else` arms expect their inner expression to be `()`
    |
    = note: expected unit type `()`
                    found enum `Result<_, {integer}>`
@@ -40,7 +40,7 @@ LL | |                 Err(1)
    | |                 ^^^^^^ expected `()`, found `Result<_, {integer}>`
 LL | |
 LL | |             }
-   | |_____________- expected this to be `()`
+   | |_____________- `if` expressions without `else` arms expect their inner expression to be `()`
    |
    = note: expected unit type `()`
                    found enum `Result<_, {integer}>`
@@ -53,7 +53,7 @@ LL | |                 Err(1)
    | |                 ^^^^^^ expected `()`, found `Result<_, {integer}>`
 LL | |
 LL | |             }
-   | |_____________- expected this to be `()`
+   | |_____________- `if` expressions without `else` arms expect their inner expression to be `()`
    |
    = note: expected unit type `()`
                    found enum `Result<_, {integer}>`

--- a/tests/ui/parser/struct-literals-in-invalid-places.stderr
+++ b/tests/ui/parser/struct-literals-in-invalid-places.stderr
@@ -200,7 +200,7 @@ LL |         if x == E::V { field } {}
    |         ---------------^^^^^--
    |         |              |
    |         |              expected `()`, found `bool`
-   |         expected this to be `()`
+   |         `if` expressions without `else` arms expect their inner expression to be `()`
    |
 help: you might have meant to return this value
    |

--- a/tests/ui/return/issue-82612-return-mutable-reference.stderr
+++ b/tests/ui/return/issue-82612-return-mutable-reference.stderr
@@ -6,7 +6,7 @@ LL | |             let value = unsafe { self.values.get_unchecked_mut(index) };
 LL | |             value.get_or_insert_with(func)
    | |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found `&mut V`
 LL | |         }
-   | |_________- expected this to be `()`
+   | |_________- `if` expressions without `else` arms expect their inner expression to be `()`
    |
    = note:      expected unit type `()`
            found mutable reference `&mut V`

--- a/tests/ui/return/tail-expr-as-potential-return.stderr
+++ b/tests/ui/return/tail-expr-as-potential-return.stderr
@@ -6,7 +6,7 @@ LL | |         Err(42)
    | |         ^^^^^^^ expected `()`, found `Result<_, {integer}>`
 ...  |
 LL | |     }
-   | |_____- expected this to be `()`
+   | |_____- `if` expressions without `else` arms expect their inner expression to be `()`
    |
    = note: expected unit type `()`
                    found enum `Result<_, {integer}>`
@@ -23,7 +23,7 @@ LL | |         1i32
    | |         ^^^^ expected `()`, found `i32`
 ...  |
 LL | |     }
-   | |_____- expected this to be `()`
+   | |_____- `if` expressions without `else` arms expect their inner expression to be `()`
    |
 help: you might have meant to return this value
    |
@@ -38,7 +38,7 @@ LL | |         Err(42)
    | |         ^^^^^^^ expected `()`, found `Result<_, {integer}>`
 ...  |
 LL | |     }
-   | |_____- expected this to be `()`
+   | |_____- `if` expressions without `else` arms expect their inner expression to be `()`
    |
    = note: expected unit type `()`
                    found enum `Result<_, {integer}>`

--- a/tests/ui/return/tail-expr-if-as-return.stderr
+++ b/tests/ui/return/tail-expr-if-as-return.stderr
@@ -5,7 +5,7 @@ LL | /     if true {
 LL | |         ""
    | |         ^^ expected `()`, found `&str`
 LL | |     }
-   | |_____- expected this to be `()`
+   | |_____- `if` expressions without `else` arms expect their inner expression to be `()`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/suggestions/try-operator-dont-suggest-semicolon.rs
+++ b/tests/ui/suggestions/try-operator-dont-suggest-semicolon.rs
@@ -12,7 +12,7 @@ fn main() -> Result<(), ()> {
     // Here, we do want to suggest a semicolon:
     let x = Ok(42);
     if true {
-    //~^ NOTE: expected this to be `()`
+    //~^ NOTE: `if` expressions without `else` arms expect their inner expression to be `()`
         x?
         //~^ ERROR: mismatched types [E0308]
         //~| NOTE: expected `()`, found integer

--- a/tests/ui/suggestions/try-operator-dont-suggest-semicolon.stderr
+++ b/tests/ui/suggestions/try-operator-dont-suggest-semicolon.stderr
@@ -15,7 +15,7 @@ LL | |         x?
    | |         ^^ expected `()`, found integer
 ...  |
 LL | |     }
-   | |_____- expected this to be `()`
+   | |_____- `if` expressions without `else` arms expect their inner expression to be `()`
    |
 help: consider using a semicolon here
    |


### PR DESCRIPTION
When encountering an `if` expression with no `else` where the then block has a tail expression, we emit an E0308 type error. We now explain why `()` was expected.

Partially address rust-lang/rust#144911.