### PR TITLE
rustdoc: don't give deprecation notes special handling

### DIFF
--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -109,13 +109,15 @@ pub(crate) struct MarkdownWithToc<'a> {
     pub(crate) edition: Edition,
     pub(crate) playground: &'a Option<Playground>,
 }
-/// A tuple struct like `Markdown` that renders the markdown escaping HTML tags
+
+/// A struct like `Markdown` that renders the markdown escaping HTML tags
 /// and includes no paragraph tags.
 pub(crate) struct MarkdownItemInfo<'a> {
     pub(crate) content: &'a str,
     pub(crate) links: &'a [RenderedLink],
     pub(crate) ids: &'a mut IdMap,
 }
+
 /// A tuple struct like `Markdown` that renders only the first paragraph.
 pub(crate) struct MarkdownSummaryLine<'a>(pub &'a str, pub &'a [RenderedLink]);
 
@@ -1497,10 +1499,10 @@ impl<'a> MarkdownItemInfo<'a> {
             let p = SpannedLinkReplacer::new(p, links);
             let p = footnotes::Footnotes::new(p, existing_footnotes);
             let p = TableWrapper::new(p.map(|(ev, _)| ev));
-            let p = p.filter(|event| {
-                !matches!(event, Event::Start(Tag::Paragraph) | Event::End(TagEnd::Paragraph))
-            });
-            html::write_html_fmt(&mut f, p)
+            // in legacy wrap mode, strip <p> elements to avoid them inserting newlines
+            html::write_html_fmt(&mut f, p)?;
+
+            Ok(())
         })
     }
 }

--- a/src/librustdoc/html/markdown/tests.rs
+++ b/src/librustdoc/html/markdown/tests.rs
@@ -472,7 +472,7 @@ fn test_markdown_html_escape() {
         let mut idmap = IdMap::new();
         let mut output = String::new();
         MarkdownItemInfo::new(input, &[], &mut idmap).write_into(&mut output).unwrap();
-        assert_eq!(output, expect, "original: {}", input);
+        assert_eq!(output, format!("<p>{}</p>\n", expect), "original: {}", input);
     }
 
     t("`Struct<'a, T>`", "<code>Struct&lt;'a, T&gt;</code>");

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1585,7 +1585,6 @@ so that we can apply CSS-filters to change the arrow color in themes */
 	color: var(--main-color);
 	background-color: var(--stab-background-color);
 	width: fit-content;
-	white-space: pre-wrap;
 	border-radius: 3px;
 	display: inline;
 	vertical-align: baseline;

--- a/tests/rustdoc-html/deprecated.rs
+++ b/tests/rustdoc-html/deprecated.rs
@@ -30,3 +30,8 @@ pub struct W;
 //      'Deprecated: shorthand reason: code$'
 #[deprecated = "shorthand reason: `code`"]
 pub struct X;
+
+//@ matches deprecated/struct.Y.html '//*[@class="stab deprecated"]//p[1]' 'multiple'
+//@ matches deprecated/struct.Y.html '//*[@class="stab deprecated"]//p[2]' 'paragraphs'
+#[deprecated = "multiple\n\nparagraphs"]
+pub struct Y;


### PR DESCRIPTION
based on discussion in rust-lang/rust#149741

we're currently using pre-wrap here which forces us to do a bunch of other hacky weird stuff, but getting rid of all that would likely break some existing docs, so i'm proposing we do it across an edition.

r? @GuillaumeGomez

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
