### PR TITLE
add several older crashtests

### DIFF
--- a/tests/crashes/114880.rs
+++ b/tests/crashes/114880.rs
@@ -1,0 +1,7 @@
+//@ known-bug: #114880
+//@ proc-macro: aux114880.rs
+//@ ignore-backends: gcc
+
+aux114880::expand!();
+
+fn main() {}

--- a/tests/crashes/119940.rs
+++ b/tests/crashes/119940.rs
@@ -1,0 +1,27 @@
+//@ known-bug: #119940
+//@ compile-flags: -Zvalidate-mir
+
+#![feature(custom_mir, core_intrinsics)]
+extern crate core;
+use core::intrinsics::mir::*;
+
+pub enum E {
+    V0 { fld0: &'static u64 },
+}
+
+#[custom_mir(dialect = "runtime", phase = "initial")]
+pub fn fn0() {
+    mir! {
+    let e: E;
+    let n: u64;
+    {
+        n = 0;
+        place!(Field::<&u64>(Variant(e, 0), 0)) = &n;
+        Return()
+    }
+
+    }
+}
+pub fn main() {
+    fn0();
+}

--- a/tests/crashes/138274.rs
+++ b/tests/crashes/138274.rs
@@ -1,0 +1,18 @@
+//@ known-bug: #138274
+//@ edition: 2021
+//@ compile-flags: --crate-type=lib
+trait Trait {}
+
+fn foo() -> Box<dyn Trait> {
+    todo!()
+}
+
+fn fetch() {
+    async {
+        let fut = async {
+            let _x = foo();
+            async {}.await;
+        };
+        let _: Box<dyn Send> = Box::new(fut);
+    };
+}

--- a/tests/crashes/138660.rs
+++ b/tests/crashes/138660.rs
@@ -1,0 +1,7 @@
+//@ known-bug: #138660
+enum A {
+    V1(isize) = 1..=10,
+    V0 = 1..=10,
+}
+const B: &'static [A] = &[A::V0, A::V1(111)];
+fn main() {}

--- a/tests/crashes/auxiliary/aux114880.rs
+++ b/tests/crashes/auxiliary/aux114880.rs
@@ -1,0 +1,13 @@
+#![feature(proc_macro_expand)]
+#![crate_type = "proc-macro"]
+
+extern crate proc_macro;
+use std::str::FromStr;
+
+use proc_macro::TokenStream;
+
+#[proc_macro]
+pub fn expand(_: TokenStream) -> TokenStream {
+    dbg!(TokenStream::from_str("include!(\"./doesnt_exist\")").unwrap().expand_expr())
+        .unwrap_or_default()
+}


### PR DESCRIPTION
Includes rust-lang/rust#114880, rust-lang/rust#119940, rust-lang/rust#138274, rust-lang/rust#138660.
Since their issue numbers are all smaller than 140000, this has no conflicts with rust-lang/rust#147857.
