### PR TITLE
Cleanup of attribute parsing errors

### DIFF
--- a/compiler/rustc_attr_parsing/messages.ftl
+++ b/compiler/rustc_attr_parsing/messages.ftl
@@ -50,11 +50,6 @@ attr_parsing_expects_feature_list =
 attr_parsing_expects_features =
     `{$name}` expects feature names
 
-attr_parsing_ill_formed_attribute_input = {$num_suggestions ->
-        [1] attribute must be of the form {$suggestions}
-        *[other] valid forms for the attribute are {$suggestions}
-    }
-
 attr_parsing_import_name_type_raw =
     import name type can only be used with link kind `raw-dylib`
 

--- a/compiler/rustc_attr_parsing/messages.ftl
+++ b/compiler/rustc_attr_parsing/messages.ftl
@@ -213,10 +213,6 @@ attr_parsing_stability_outside_std = stability attributes may not be used outsid
 attr_parsing_suffixed_literal_in_attribute = suffixed literals are not allowed in attributes
     .help = instead of using a suffixed literal (`1u8`, `1.0f32`, etc.), use an unsuffixed version (`1`, `1.0`, etc.)
 
-attr_parsing_unknown_meta_item =
-    unknown meta item '{$item}'
-    .label = expected one of {$expected}
-
 attr_parsing_unknown_version_literal =
     unknown version literal format, assuming it refers to a future version
 

--- a/compiler/rustc_attr_parsing/src/attributes/cfg.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/cfg.rs
@@ -42,7 +42,7 @@ pub fn parse_cfg<S: Stage>(
     args: &ArgParser,
 ) -> Option<CfgEntry> {
     let ArgParser::List(list) = args else {
-        cx.expected_list(cx.attr_span);
+        cx.expected_list(cx.attr_span, args);
         return None;
     };
     let Some(single) = list.single() else {

--- a/compiler/rustc_attr_parsing/src/attributes/codegen_attrs.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/codegen_attrs.rs
@@ -25,7 +25,7 @@ impl<S: Stage> SingleAttributeParser<S> for OptimizeParser {
 
     fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
         let Some(list) = args.list() else {
-            cx.expected_list(cx.attr_span);
+            cx.expected_list(cx.attr_span, args);
             return None;
         };
 
@@ -478,7 +478,7 @@ fn parse_tf_attribute<S: Stage>(
 ) -> impl IntoIterator<Item = (Symbol, Span)> {
     let mut features = Vec::new();
     let ArgParser::List(list) = args else {
-        cx.expected_list(cx.attr_span);
+        cx.expected_list(cx.attr_span, args);
         return features;
     };
     if list.is_empty() {
@@ -601,7 +601,7 @@ impl<S: Stage> SingleAttributeParser<S> for SanitizeParser {
 
     fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
         let Some(list) = args.list() else {
-            cx.expected_list(cx.attr_span);
+            cx.expected_list(cx.attr_span, args);
             return None;
         };
 

--- a/compiler/rustc_attr_parsing/src/attributes/confusables.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/confusables.rs
@@ -13,7 +13,7 @@ impl<S: Stage> AttributeParser<S> for ConfusablesParser {
         template!(List: &[r#""name1", "name2", ..."#]),
         |this, cx, args| {
             let Some(list) = args.list() else {
-                cx.expected_list(cx.attr_span);
+                cx.expected_list(cx.attr_span, args);
                 return;
             };
 

--- a/compiler/rustc_attr_parsing/src/attributes/debugger.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/debugger.rs
@@ -21,7 +21,7 @@ impl<S: Stage> CombineAttributeParser<S> for DebuggerViualizerParser {
         args: &ArgParser,
     ) -> impl IntoIterator<Item = Self::Item> {
         let Some(l) = args.list() else {
-            cx.expected_list(args.span().unwrap_or(cx.attr_span));
+            cx.expected_list(cx.attr_span, args);
             return None;
         };
         let Some(single) = l.single() else {

--- a/compiler/rustc_attr_parsing/src/attributes/deprecation.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/deprecation.rs
@@ -110,13 +110,12 @@ impl<S: Stage> SingleAttributeParser<S> for DeprecationParser {
                                 Some(get(cx, name, param.span(), param.args(), &suggestion)?);
                         }
                         _ => {
-                            cx.unknown_key(
+                            cx.expected_specific_argument(
                                 param.span(),
-                                param.path().to_string(),
                                 if features.deprecated_suggestion() {
-                                    &["since", "note", "suggestion"]
+                                    &[sym::since, sym::note, sym::suggestion]
                                 } else {
-                                    &["since", "note"]
+                                    &[sym::since, sym::note]
                                 },
                             );
                             return None;

--- a/compiler/rustc_attr_parsing/src/attributes/doc.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/doc.rs
@@ -106,7 +106,7 @@ impl DocParser {
             }
             Some(sym::attr) => {
                 let Some(list) = args.list() else {
-                    cx.expected_list(cx.attr_span);
+                    cx.expected_list(cx.attr_span, args);
                     return;
                 };
 

--- a/compiler/rustc_attr_parsing/src/attributes/link_attrs.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/link_attrs.rs
@@ -76,7 +76,7 @@ impl<S: Stage> CombineAttributeParser<S> for LinkParser {
                 return None;
             }
             _ => {
-                cx.expected_list(cx.attr_span);
+                cx.expected_list(cx.attr_span, args);
                 return None;
             }
         };
@@ -379,7 +379,7 @@ impl LinkParser {
             return true;
         }
         let Some(link_cfg) = item.args().list() else {
-            cx.expected_list(item.span());
+            cx.expected_list(item.span(), item.args());
             return true;
         };
         let Some(link_cfg) = link_cfg.single() else {

--- a/compiler/rustc_attr_parsing/src/attributes/macro_attrs.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/macro_attrs.rs
@@ -99,8 +99,8 @@ impl<S: Stage> AttributeParser<S> for MacroUseParser {
                         }
                     }
                 }
-                ArgParser::NameValue(_) => {
-                    cx.expected_list_or_no_args(span);
+                ArgParser::NameValue(nv) => {
+                    cx.expected_list_or_no_args(nv.args_span());
                 }
             }
         },
@@ -155,8 +155,8 @@ impl<S: Stage> SingleAttributeParser<S> for MacroExportParser {
                     }
                 }
             }
-            ArgParser::NameValue(_) => {
-                cx.expected_list_or_no_args(cx.attr_span);
+            ArgParser::NameValue(nv) => {
+                cx.expected_list_or_no_args(nv.args_span());
                 return None;
             }
         };

--- a/compiler/rustc_attr_parsing/src/attributes/macro_attrs.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/macro_attrs.rs
@@ -1,9 +1,7 @@
-use rustc_errors::DiagArgValue;
 use rustc_hir::attrs::MacroUseArgs;
 use rustc_session::lint::builtin::INVALID_MACRO_EXPORT_ARGUMENTS;
 
 use super::prelude::*;
-use crate::session_diagnostics::{AttributeParseErrorReason, IllFormedAttributeInputLint};
 
 pub(crate) struct MacroEscapeParser;
 impl<S: Stage> NoArgsAttributeParser<S> for MacroEscapeParser {
@@ -158,15 +156,7 @@ impl<S: Stage> SingleAttributeParser<S> for MacroExportParser {
                 }
             }
             ArgParser::NameValue(_) => {
-                let span = cx.attr_span;
-                let suggestions = cx.suggestions();
-                cx.emit_err(IllFormedAttributeInputLint {
-                    num_suggestions: suggestions.len(),
-                    suggestions: DiagArgValue::StrListSepByAnd(
-                        suggestions.into_iter().map(|s| format!("`{s}`").into()).collect(),
-                    ),
-                    span,
-                });
+                cx.expected_list_or_no_args(cx.attr_span);
                 return None;
             }
         };

--- a/compiler/rustc_attr_parsing/src/attributes/macro_attrs.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/macro_attrs.rs
@@ -3,7 +3,7 @@ use rustc_hir::attrs::MacroUseArgs;
 use rustc_session::lint::builtin::INVALID_MACRO_EXPORT_ARGUMENTS;
 
 use super::prelude::*;
-use crate::session_diagnostics::IllFormedAttributeInputLint;
+use crate::session_diagnostics::{AttributeParseErrorReason, IllFormedAttributeInputLint};
 
 pub(crate) struct MacroEscapeParser;
 impl<S: Stage> NoArgsAttributeParser<S> for MacroEscapeParser {
@@ -102,14 +102,7 @@ impl<S: Stage> AttributeParser<S> for MacroUseParser {
                     }
                 }
                 ArgParser::NameValue(_) => {
-                    let suggestions = cx.suggestions();
-                    cx.emit_err(IllFormedAttributeInputLint {
-                        num_suggestions: suggestions.len(),
-                        suggestions: DiagArgValue::StrListSepByAnd(
-                            suggestions.into_iter().map(|s| format!("`{s}`").into()).collect(),
-                        ),
-                        span,
-                    });
+                    cx.expected_list_or_no_args(span);
                 }
             }
         },

--- a/compiler/rustc_attr_parsing/src/attributes/must_use.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/must_use.rs
@@ -41,8 +41,8 @@ impl<S: Stage> SingleAttributeParser<S> for MustUseParser {
                     };
                     Some(value_str)
                 }
-                ArgParser::List(_) => {
-                    cx.expected_name_value(cx.attr_span, None);
+                ArgParser::List(list) => {
+                    cx.expected_nv_or_no_args(list.span);
                     return None;
                 }
             },

--- a/compiler/rustc_attr_parsing/src/attributes/must_use.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/must_use.rs
@@ -1,7 +1,4 @@
-use rustc_errors::DiagArgValue;
-
 use super::prelude::*;
-use crate::session_diagnostics::IllFormedAttributeInputLint;
 
 pub(crate) struct MustUseParser;
 
@@ -45,14 +42,7 @@ impl<S: Stage> SingleAttributeParser<S> for MustUseParser {
                     Some(value_str)
                 }
                 ArgParser::List(_) => {
-                    let suggestions = cx.suggestions();
-                    cx.emit_err(IllFormedAttributeInputLint {
-                        num_suggestions: suggestions.len(),
-                        suggestions: DiagArgValue::StrListSepByAnd(
-                            suggestions.into_iter().map(|s| format!("`{s}`").into()).collect(),
-                        ),
-                        span: cx.attr_span,
-                    });
+                    cx.expected_name_value(cx.attr_span, None);
                     return None;
                 }
             },

--- a/compiler/rustc_attr_parsing/src/attributes/proc_macro_attrs.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/proc_macro_attrs.rs
@@ -65,7 +65,7 @@ fn parse_derive_like<S: Stage>(
         if args.no_args().is_ok() && !trait_name_mandatory {
             return Some((None, ThinVec::new()));
         }
-        cx.expected_list(cx.attr_span);
+        cx.expected_list(cx.attr_span, args);
         return None;
     };
     let mut items = list.mixed();
@@ -96,7 +96,7 @@ fn parse_derive_like<S: Stage>(
     let mut attributes = ThinVec::new();
     if let Some(attrs) = items.next() {
         let Some(attr_list) = attrs.meta_item() else {
-            cx.expected_list(attrs.span());
+            cx.unexpected_literal(attrs.span());
             return None;
         };
         if !attr_list.path().word_is(sym::attributes) {
@@ -104,7 +104,7 @@ fn parse_derive_like<S: Stage>(
             return None;
         }
         let Some(attr_list) = attr_list.args().list() else {
-            cx.expected_list(attrs.span());
+            cx.expected_list(attrs.span(), attr_list.args());
             return None;
         };
 

--- a/compiler/rustc_attr_parsing/src/attributes/prototype.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/prototype.rs
@@ -27,7 +27,7 @@ impl<S: Stage> SingleAttributeParser<S> for CustomMirParser {
 
     fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
         let Some(list) = args.list() else {
-            cx.expected_list(cx.attr_span);
+            cx.expected_list(cx.attr_span, args);
             return None;
         };
 

--- a/compiler/rustc_attr_parsing/src/attributes/prototype.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/prototype.rs
@@ -46,9 +46,8 @@ impl<S: Stage> SingleAttributeParser<S> for CustomMirParser {
                 extract_value(cx, sym::dialect, arg, meta_item.span(), &mut dialect, &mut failed);
             } else if let Some(arg) = meta_item.word_is(sym::phase) {
                 extract_value(cx, sym::phase, arg, meta_item.span(), &mut phase, &mut failed);
-            } else if let Some(word) = meta_item.path().word() {
-                let word = word.to_string();
-                cx.unknown_key(meta_item.span(), word, &["dialect", "phase"]);
+            } else if let Some(..) = meta_item.path().word() {
+                cx.expected_specific_argument(meta_item.span(), &[sym::dialect, sym::phase]);
                 failed = true;
             } else {
                 cx.expected_name_value(meta_item.span(), None);

--- a/compiler/rustc_attr_parsing/src/attributes/repr.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/repr.rs
@@ -33,7 +33,7 @@ impl<S: Stage> CombineAttributeParser<S> for ReprParser {
         let mut reprs = Vec::new();
 
         let Some(list) = args.list() else {
-            cx.expected_list(cx.attr_span);
+            cx.expected_list(cx.attr_span, args);
             return reprs;
         };
 
@@ -278,7 +278,7 @@ impl AlignParser {
     fn parse<S: Stage>(&mut self, cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) {
         match args {
             ArgParser::NoArgs | ArgParser::NameValue(_) => {
-                cx.expected_list(cx.attr_span);
+                cx.expected_list(cx.attr_span, args);
             }
             ArgParser::List(list) => {
                 let Some(align) = list.single() else {

--- a/compiler/rustc_attr_parsing/src/attributes/stability.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/stability.rs
@@ -315,11 +315,7 @@ pub(crate) fn parse_stability<S: Stage>(
                 insert_value_into_option_or_error(cx, &param, &mut since, word.unwrap())?
             }
             _ => {
-                cx.emit_err(session_diagnostics::UnknownMetaItem {
-                    span: param_span,
-                    item: param.path().to_string(),
-                    expected: &["feature", "since"],
-                });
+                cx.expected_specific_argument(param_span, &[sym::feature, sym::since]);
                 return None;
             }
         }
@@ -426,11 +422,17 @@ pub(crate) fn parse_unstability<S: Stage>(
                 insert_value_into_option_or_error(cx, &param, &mut old_name, word.unwrap())?
             }
             _ => {
-                cx.emit_err(session_diagnostics::UnknownMetaItem {
-                    span: param.span(),
-                    item: param.path().to_string(),
-                    expected: &["feature", "reason", "issue", "soft", "implied_by", "old_name"],
-                });
+                cx.expected_specific_argument(
+                    param.span(),
+                    &[
+                        sym::feature,
+                        sym::reason,
+                        sym::issue,
+                        sym::soft,
+                        sym::implied_by,
+                        sym::old_name,
+                    ],
+                );
                 return None;
             }
         }

--- a/compiler/rustc_attr_parsing/src/attributes/stability.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/stability.rs
@@ -295,7 +295,7 @@ pub(crate) fn parse_stability<S: Stage>(
     let mut since = None;
 
     let ArgParser::List(list) = args else {
-        cx.expected_list(cx.attr_span);
+        cx.expected_list(cx.attr_span, args);
         return None;
     };
 
@@ -367,7 +367,7 @@ pub(crate) fn parse_unstability<S: Stage>(
     let mut old_name = None;
 
     let ArgParser::List(list) = args else {
-        cx.expected_list(cx.attr_span);
+        cx.expected_list(cx.attr_span, args);
         return None;
     };
 

--- a/compiler/rustc_attr_parsing/src/attributes/traits.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/traits.rs
@@ -22,7 +22,7 @@ impl<S: Stage> SingleAttributeParser<S> for SkipDuringMethodDispatchParser {
         let mut array = false;
         let mut boxed_slice = false;
         let Some(args) = args.list() else {
-            cx.expected_list(cx.attr_span);
+            cx.expected_list(cx.attr_span, args);
             return None;
         };
         if args.is_empty() {

--- a/compiler/rustc_attr_parsing/src/attributes/util.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/util.rs
@@ -43,7 +43,7 @@ pub(crate) fn parse_single_integer<S: Stage>(
     args: &ArgParser,
 ) -> Option<u128> {
     let Some(list) = args.list() else {
-        cx.expected_list(cx.attr_span);
+        cx.expected_list(cx.attr_span, args);
         return None;
     };
     let Some(single) = list.single() else {

--- a/compiler/rustc_attr_parsing/src/context.rs
+++ b/compiler/rustc_attr_parsing/src/context.rs
@@ -77,7 +77,7 @@ use crate::attributes::transparency::TransparencyParser;
 use crate::attributes::{AttributeParser as _, Combine, Single, WithoutArgs};
 use crate::parser::{ArgParser, RefPathParser};
 use crate::session_diagnostics::{
-    AttributeParseError, AttributeParseErrorReason, ParsedDescription, UnknownMetaItem,
+    AttributeParseError, AttributeParseErrorReason, ParsedDescription,
 };
 use crate::target_checking::AllowedTargets;
 
@@ -425,15 +425,6 @@ impl<'f, 'sess: 'f, S: Stage> SharedContext<'f, 'sess, S> {
 }
 
 impl<'f, 'sess: 'f, S: Stage> AcceptContext<'f, 'sess, S> {
-    pub(crate) fn unknown_key(
-        &self,
-        span: Span,
-        found: String,
-        options: &[&'static str],
-    ) -> ErrorGuaranteed {
-        self.emit_err(UnknownMetaItem { span, item: found, expected: options })
-    }
-
     fn emit_parse_error(
         &self,
         span: Span,

--- a/compiler/rustc_attr_parsing/src/context.rs
+++ b/compiler/rustc_attr_parsing/src/context.rs
@@ -464,12 +464,21 @@ impl<'f, 'sess: 'f, S: Stage> AcceptContext<'f, 'sess, S> {
         self.emit_parse_error(span, AttributeParseErrorReason::ExpectedIntegerLiteral)
     }
 
-    pub(crate) fn expected_list(&self, span: Span) -> ErrorGuaranteed {
+    pub(crate) fn expected_list(&self, span: Span, args: &ArgParser) -> ErrorGuaranteed {
+        let span = match args {
+            ArgParser::NoArgs => span,
+            ArgParser::List(list) => list.span,
+            ArgParser::NameValue(nv) => nv.args_span(),
+        };
         self.emit_parse_error(span, AttributeParseErrorReason::ExpectedList)
     }
 
     pub(crate) fn expected_list_or_no_args(&self, span: Span) -> ErrorGuaranteed {
         self.emit_parse_error(span, AttributeParseErrorReason::ExpectedListOrNoArgs)
+    }
+
+    pub(crate) fn expected_nv_or_no_args(&self, span: Span) -> ErrorGuaranteed {
+        self.emit_parse_error(span, AttributeParseErrorReason::ExpectedNameValueOrNoArgs)
     }
 
     pub(crate) fn expected_no_args(&self, span: Span) -> ErrorGuaranteed {

--- a/compiler/rustc_attr_parsing/src/context.rs
+++ b/compiler/rustc_attr_parsing/src/context.rs
@@ -468,6 +468,10 @@ impl<'f, 'sess: 'f, S: Stage> AcceptContext<'f, 'sess, S> {
         self.emit_parse_error(span, AttributeParseErrorReason::ExpectedList)
     }
 
+    pub(crate) fn expected_list_or_no_args(&self, span: Span) -> ErrorGuaranteed {
+        self.emit_parse_error(span, AttributeParseErrorReason::ExpectedListOrNoArgs)
+    }
+
     pub(crate) fn expected_no_args(&self, span: Span) -> ErrorGuaranteed {
         self.emit_parse_error(span, AttributeParseErrorReason::ExpectedNoArgs)
     }

--- a/compiler/rustc_attr_parsing/src/parser.rs
+++ b/compiler/rustc_attr_parsing/src/parser.rs
@@ -177,7 +177,7 @@ impl ArgParser {
         match self {
             Self::NoArgs => Ok(()),
             Self::List(args) => Err(args.span),
-            Self::NameValue(args) => Err(args.eq_span.to(args.value_span)),
+            Self::NameValue(args) => Err(args.args_span()),
         }
     }
 }
@@ -313,6 +313,10 @@ impl NameValueParser {
 
     pub fn value_as_str(&self) -> Option<Symbol> {
         self.value_as_lit().kind.str()
+    }
+
+    pub fn args_span(&self) -> Span {
+        self.eq_span.to(self.value_span)
     }
 }
 

--- a/compiler/rustc_attr_parsing/src/session_diagnostics.rs
+++ b/compiler/rustc_attr_parsing/src/session_diagnostics.rs
@@ -511,6 +511,7 @@ pub(crate) enum AttributeParseErrorReason<'a> {
     ExpectedSingleArgument,
     ExpectedList,
     ExpectedListOrNoArgs,
+    ExpectedNameValueOrNoArgs,
     UnexpectedLiteral,
     ExpectedNameValue(Option<Symbol>),
     DuplicateKey(Symbol),
@@ -585,6 +586,9 @@ impl<'a, G: EmissionGuarantee> Diagnostic<'a, G> for AttributeParseError<'_> {
             }
             AttributeParseErrorReason::ExpectedListOrNoArgs => {
                 diag.span_label(self.span, "expected a list or no arguments here");
+            }
+            AttributeParseErrorReason::ExpectedNameValueOrNoArgs => {
+                diag.span_label(self.span, "didn't expect a list here");
             }
             AttributeParseErrorReason::DuplicateKey(key) => {
                 diag.span_label(self.span, format!("found `{key}` used as a key more than once"));

--- a/compiler/rustc_attr_parsing/src/session_diagnostics.rs
+++ b/compiler/rustc_attr_parsing/src/session_diagnostics.rs
@@ -519,6 +519,7 @@ pub(crate) enum AttributeParseErrorReason<'a> {
     ExpectedAtLeastOneArgument,
     ExpectedSingleArgument,
     ExpectedList,
+    ExpectedListOrNoArgs,
     UnexpectedLiteral,
     ExpectedNameValue(Option<Symbol>),
     DuplicateKey(Symbol),
@@ -590,6 +591,9 @@ impl<'a, G: EmissionGuarantee> Diagnostic<'a, G> for AttributeParseError<'_> {
             }
             AttributeParseErrorReason::ExpectedList => {
                 diag.span_label(self.span, "expected this to be a list");
+            }
+            AttributeParseErrorReason::ExpectedListOrNoArgs => {
+                diag.span_label(self.span, "expected a list or no arguments here");
             }
             AttributeParseErrorReason::DuplicateKey(key) => {
                 diag.span_label(self.span, format!("found `{key}` used as a key more than once"));

--- a/compiler/rustc_attr_parsing/src/session_diagnostics.rs
+++ b/compiler/rustc_attr_parsing/src/session_diagnostics.rs
@@ -64,26 +64,6 @@ pub(crate) struct DocAttributeNotAttribute {
     pub attribute: Symbol,
 }
 
-/// Error code: E0541
-pub(crate) struct UnknownMetaItem<'a> {
-    pub span: Span,
-    pub item: String,
-    pub expected: &'a [&'a str],
-}
-
-// Manual implementation to be able to format `expected` items correctly.
-impl<'a, G: EmissionGuarantee> Diagnostic<'a, G> for UnknownMetaItem<'_> {
-    fn into_diag(self, dcx: DiagCtxtHandle<'a>, level: Level) -> Diag<'a, G> {
-        let expected = self.expected.iter().map(|name| format!("`{name}`")).collect::<Vec<_>>();
-        Diag::new(dcx, level, fluent::attr_parsing_unknown_meta_item)
-            .with_span(self.span)
-            .with_code(E0541)
-            .with_arg("item", self.item)
-            .with_arg("expected", expected.join(", "))
-            .with_span_label(self.span, fluent::attr_parsing_label)
-    }
-}
-
 #[derive(Diagnostic)]
 #[diag(attr_parsing_missing_since, code = E0542)]
 pub(crate) struct MissingSince {

--- a/compiler/rustc_attr_parsing/src/session_diagnostics.rs
+++ b/compiler/rustc_attr_parsing/src/session_diagnostics.rs
@@ -381,15 +381,6 @@ pub(crate) struct UnusedMultiple {
 }
 
 #[derive(Diagnostic)]
-#[diag(attr_parsing_ill_formed_attribute_input)]
-pub(crate) struct IllFormedAttributeInputLint {
-    #[primary_span]
-    pub span: Span,
-    pub num_suggestions: usize,
-    pub suggestions: DiagArgValue,
-}
-
-#[derive(Diagnostic)]
 #[diag(attr_parsing_null_on_export, code = E0648)]
 pub(crate) struct NullOnExport {
     #[primary_span]

--- a/compiler/rustc_error_codes/src/error_codes/E0541.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0541.md
@@ -1,8 +1,10 @@
+#### Note: this error code is no longer emitted by the compiler.
+
 An unknown meta item was used.
 
 Erroneous code example:
 
-```compile_fail,E0541
+```compile_fail (no longer emitted)
 #[deprecated(
     since="1.0.0",
     // error: unknown meta item

--- a/tests/rustdoc-ui/invalid-cfg.stderr
+++ b/tests/rustdoc-ui/invalid-cfg.stderr
@@ -2,7 +2,9 @@ error[E0539]: malformed `doc` attribute input
   --> $DIR/invalid-cfg.rs:2:1
    |
 LL | #[doc(cfg = "x")]
-   | ^^^^^^^^^^^^^^^^^ expected this to be a list
+   | ^^^^^^^^^^-----^^
+   |           |
+   |           expected this to be a list
 
 error[E0805]: malformed `doc` attribute input
   --> $DIR/invalid-cfg.rs:3:1
@@ -16,7 +18,9 @@ error[E0539]: malformed `doc` attribute input
   --> $DIR/invalid-cfg.rs:7:1
    |
 LL | #[doc(cfg = "x")]
-   | ^^^^^^^^^^^^^^^^^ expected this to be a list
+   | ^^^^^^^^^^-----^^
+   |           |
+   |           expected this to be a list
 
 error[E0805]: malformed `doc` attribute input
   --> $DIR/invalid-cfg.rs:8:1
@@ -30,7 +34,9 @@ error[E0539]: malformed `doc` attribute input
   --> $DIR/invalid-cfg.rs:12:1
    |
 LL | #[doc(cfg = "x")]
-   | ^^^^^^^^^^^^^^^^^ expected this to be a list
+   | ^^^^^^^^^^-----^^
+   |           |
+   |           expected this to be a list
 
 error[E0805]: malformed `doc` attribute input
   --> $DIR/invalid-cfg.rs:13:1
@@ -44,7 +50,9 @@ error[E0539]: malformed `doc` attribute input
   --> $DIR/invalid-cfg.rs:18:1
    |
 LL | #[doc(cfg = "x")]
-   | ^^^^^^^^^^^^^^^^^ expected this to be a list
+   | ^^^^^^^^^^-----^^
+   |           |
+   |           expected this to be a list
 
 error[E0805]: malformed `doc` attribute input
   --> $DIR/invalid-cfg.rs:19:1

--- a/tests/ui/attributes/invalid-macro-use.rs
+++ b/tests/ui/attributes/invalid-macro-use.rs
@@ -2,7 +2,9 @@
 //~^ NOTE the lint level is defined here
 
 #[macro_use = 5]
-//~^ ERROR valid forms for the attribute are `#[macro_use(name1, name2, ...)]` and `#[macro_use]`
+//~^ ERROR malformed `macro_use` attribute input
+//~| NOTE expected a list or no arguments here
+//~| NOTE for more information, visit
 extern crate std as s1;
 
 #[macro_use(5)]

--- a/tests/ui/attributes/invalid-macro-use.stderr
+++ b/tests/ui/attributes/invalid-macro-use.stderr
@@ -14,7 +14,9 @@ error[E0539]: malformed `macro_use` attribute input
   --> $DIR/invalid-macro-use.rs:4:1
    |
 LL | #[macro_use = 5]
-   | ^^^^^^^^^^^^^^^^ expected a list or no arguments here
+   | ^^^^^^^^^^^^---^
+   |             |
+   |             expected a list or no arguments here
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/macros-by-example.html#the-macro_use-attribute>
 help: try changing it to one of the following valid forms of the attribute

--- a/tests/ui/attributes/invalid-macro-use.stderr
+++ b/tests/ui/attributes/invalid-macro-use.stderr
@@ -1,23 +1,33 @@
 error[E0469]: imported macro not found
-  --> $DIR/invalid-macro-use.rs:51:13
+  --> $DIR/invalid-macro-use.rs:53:13
    |
 LL | #[macro_use(a)]
    |             ^
 
 error[E0469]: imported macro not found
-  --> $DIR/invalid-macro-use.rs:53:13
+  --> $DIR/invalid-macro-use.rs:55:13
    |
 LL | #[macro_use(b)]
    |             ^
 
-error: valid forms for the attribute are `#[macro_use(name1, name2, ...)]` and `#[macro_use]`
+error[E0539]: malformed `macro_use` attribute input
   --> $DIR/invalid-macro-use.rs:4:1
    |
 LL | #[macro_use = 5]
-   | ^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^ expected a list or no arguments here
+   |
+   = note: for more information, visit <https://doc.rust-lang.org/reference/macros-by-example.html#the-macro_use-attribute>
+help: try changing it to one of the following valid forms of the attribute
+   |
+LL - #[macro_use = 5]
+LL + #[macro_use(name1, name2, ...)]
+   |
+LL - #[macro_use = 5]
+LL + #[macro_use]
+   |
 
 error[E0539]: malformed `macro_use` attribute input
-  --> $DIR/invalid-macro-use.rs:8:1
+  --> $DIR/invalid-macro-use.rs:10:1
    |
 LL | #[macro_use(5)]
    | ^^^^^^^^^^^^-^^
@@ -35,7 +45,7 @@ LL + #[macro_use]
    |
 
 error[E0565]: malformed `macro_use` attribute input
-  --> $DIR/invalid-macro-use.rs:14:1
+  --> $DIR/invalid-macro-use.rs:16:1
    |
 LL | #[macro_use(a = "b")]
    | ^^^^^^^^^^^^^^-----^^
@@ -53,7 +63,7 @@ LL + #[macro_use]
    |
 
 error[E0565]: malformed `macro_use` attribute input
-  --> $DIR/invalid-macro-use.rs:20:1
+  --> $DIR/invalid-macro-use.rs:22:1
    |
 LL | #[macro_use(a(b))]
    | ^^^^^^^^^^^^^---^^
@@ -71,7 +81,7 @@ LL + #[macro_use]
    |
 
 error[E0539]: malformed `macro_use` attribute input
-  --> $DIR/invalid-macro-use.rs:26:1
+  --> $DIR/invalid-macro-use.rs:28:1
    |
 LL | #[macro_use(a::b)]
    | ^^^^^^^^^^^^----^^
@@ -89,13 +99,13 @@ LL + #[macro_use]
    |
 
 error: unused attribute
-  --> $DIR/invalid-macro-use.rs:32:1
+  --> $DIR/invalid-macro-use.rs:34:1
    |
 LL | #[macro_use(a)]
    | ^^^^^^^^^^^^^^^ help: remove this attribute
    |
 note: attribute also specified here
-  --> $DIR/invalid-macro-use.rs:34:1
+  --> $DIR/invalid-macro-use.rs:36:1
    |
 LL | #[macro_use]
    | ^^^^^^^^^^^^
@@ -106,25 +116,25 @@ LL | #![deny(unused_attributes)]
    |         ^^^^^^^^^^^^^^^^^
 
 error: unused attribute
-  --> $DIR/invalid-macro-use.rs:40:1
+  --> $DIR/invalid-macro-use.rs:42:1
    |
 LL | #[macro_use(a)]
    | ^^^^^^^^^^^^^^^ help: remove this attribute
    |
 note: attribute also specified here
-  --> $DIR/invalid-macro-use.rs:38:1
+  --> $DIR/invalid-macro-use.rs:40:1
    |
 LL | #[macro_use]
    | ^^^^^^^^^^^^
 
 error: unused attribute
-  --> $DIR/invalid-macro-use.rs:46:1
+  --> $DIR/invalid-macro-use.rs:48:1
    |
 LL | #[macro_use]
    | ^^^^^^^^^^^^ help: remove this attribute
    |
 note: attribute also specified here
-  --> $DIR/invalid-macro-use.rs:44:1
+  --> $DIR/invalid-macro-use.rs:46:1
    |
 LL | #[macro_use]
    | ^^^^^^^^^^^^

--- a/tests/ui/attributes/malformed-attrs.rs
+++ b/tests/ui/attributes/malformed-attrs.rs
@@ -214,7 +214,7 @@ static mut TLS: u8 = 42;
 #[no_link()]
 //~^ ERROR malformed
 #[macro_use = 1]
-//~^ ERROR valid forms for the attribute are `#[macro_use(name1, name2, ...)]` and `#[macro_use]`
+//~^ ERROR malformed
 extern crate wloop;
 //~^ ERROR can't find crate for `wloop` [E0463]
 

--- a/tests/ui/attributes/malformed-attrs.rs
+++ b/tests/ui/attributes/malformed-attrs.rs
@@ -219,7 +219,7 @@ extern crate wloop;
 //~^ ERROR can't find crate for `wloop` [E0463]
 
 #[macro_export = 18]
-//~^ ERROR valid forms for the attribute are
+//~^ ERROR malformed
 #[allow_internal_unsafe = 1]
 //~^ ERROR malformed
 //~| ERROR allow_internal_unsafe side-steps the unsafe_code lint

--- a/tests/ui/attributes/malformed-attrs.rs
+++ b/tests/ui/attributes/malformed-attrs.rs
@@ -59,7 +59,7 @@
 #[cold = 1]
 //~^ ERROR malformed
 #[must_use()]
-//~^ ERROR valid forms for the attribute are
+//~^ ERROR malformed
 #[no_mangle = 1]
 //~^ ERROR malformed
 #[unsafe(naked())]

--- a/tests/ui/attributes/malformed-attrs.stderr
+++ b/tests/ui/attributes/malformed-attrs.stderr
@@ -318,7 +318,9 @@ error[E0539]: malformed `must_use` attribute input
   --> $DIR/malformed-attrs.rs:61:1
    |
 LL | #[must_use()]
-   | ^^^^^^^^^^^^^
+   | ^^^^^^^^^^--^
+   |           |
+   |           didn't expect a list here
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/attributes/diagnostics.html#the-must_use-attribute>
 help: try changing it to one of the following valid forms of the attribute
@@ -628,7 +630,9 @@ error[E0539]: malformed `macro_use` attribute input
   --> $DIR/malformed-attrs.rs:216:1
    |
 LL | #[macro_use = 1]
-   | ^^^^^^^^^^^^^^^^ expected a list or no arguments here
+   | ^^^^^^^^^^^^---^
+   |             |
+   |             expected a list or no arguments here
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/macros-by-example.html#the-macro_use-attribute>
 help: try changing it to one of the following valid forms of the attribute
@@ -644,7 +648,9 @@ error[E0539]: malformed `macro_export` attribute input
   --> $DIR/malformed-attrs.rs:221:1
    |
 LL | #[macro_export = 18]
-   | ^^^^^^^^^^^^^^^^^^^^ expected a list or no arguments here
+   | ^^^^^^^^^^^^^^^----^
+   |                |
+   |                expected a list or no arguments here
    |
 help: try changing it to one of the following valid forms of the attribute
    |

--- a/tests/ui/attributes/malformed-attrs.stderr
+++ b/tests/ui/attributes/malformed-attrs.stderr
@@ -314,11 +314,21 @@ LL | #[cold = 1]
    | |      didn't expect any arguments here
    | help: must be of the form: `#[cold]`
 
-error: valid forms for the attribute are `#[must_use = "reason"]` and `#[must_use]`
+error[E0539]: malformed `must_use` attribute input
   --> $DIR/malformed-attrs.rs:61:1
    |
 LL | #[must_use()]
    | ^^^^^^^^^^^^^
+   |
+   = note: for more information, visit <https://doc.rust-lang.org/reference/attributes/diagnostics.html#the-must_use-attribute>
+help: try changing it to one of the following valid forms of the attribute
+   |
+LL - #[must_use()]
+LL + #[must_use = "reason"]
+   |
+LL - #[must_use()]
+LL + #[must_use]
+   |
 
 error[E0565]: malformed `no_mangle` attribute input
   --> $DIR/malformed-attrs.rs:63:1

--- a/tests/ui/attributes/malformed-attrs.stderr
+++ b/tests/ui/attributes/malformed-attrs.stderr
@@ -614,11 +614,21 @@ LL | #[non_exhaustive = 1]
    | |                didn't expect any arguments here
    | help: must be of the form: `#[non_exhaustive]`
 
-error: valid forms for the attribute are `#[macro_use(name1, name2, ...)]` and `#[macro_use]`
+error[E0539]: malformed `macro_use` attribute input
   --> $DIR/malformed-attrs.rs:216:1
    |
 LL | #[macro_use = 1]
-   | ^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^ expected a list or no arguments here
+   |
+   = note: for more information, visit <https://doc.rust-lang.org/reference/macros-by-example.html#the-macro_use-attribute>
+help: try changing it to one of the following valid forms of the attribute
+   |
+LL - #[macro_use = 1]
+LL + #[macro_use(name1, name2, ...)]
+   |
+LL - #[macro_use = 1]
+LL + #[macro_use]
+   |
 
 error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
   --> $DIR/malformed-attrs.rs:221:1

--- a/tests/ui/attributes/malformed-attrs.stderr
+++ b/tests/ui/attributes/malformed-attrs.stderr
@@ -630,11 +630,20 @@ LL - #[macro_use = 1]
 LL + #[macro_use]
    |
 
-error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
+error[E0539]: malformed `macro_export` attribute input
   --> $DIR/malformed-attrs.rs:221:1
    |
 LL | #[macro_export = 18]
-   | ^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^ expected a list or no arguments here
+   |
+help: try changing it to one of the following valid forms of the attribute
+   |
+LL - #[macro_export = 18]
+LL + #[macro_export(local_inner_macros)]
+   |
+LL - #[macro_export = 18]
+LL + #[macro_export]
+   |
 
 error[E0565]: malformed `allow_internal_unsafe` attribute input
   --> $DIR/malformed-attrs.rs:223:1

--- a/tests/ui/attributes/malformed-fn-align.stderr
+++ b/tests/ui/attributes/malformed-fn-align.stderr
@@ -20,9 +20,9 @@ error[E0539]: malformed `rustc_align` attribute input
   --> $DIR/malformed-fn-align.rs:17:1
    |
 LL | #[rustc_align = 16]
-   | ^^^^^^^^^^^^^^^^^^^
-   | |
-   | expected this to be a list
+   | ^^^^^^^^^^^^^^----^
+   | |             |
+   | |             expected this to be a list
    | help: must be of the form: `#[rustc_align(<alignment in bytes>)]`
 
 error[E0589]: invalid alignment value: not an unsuffixed integer

--- a/tests/ui/attributes/malformed-must_use.rs
+++ b/tests/ui/attributes/malformed-must_use.rs
@@ -1,4 +1,4 @@
-#[must_use()] //~ ERROR valid forms for the attribute are `#[must_use = "reason"]` and `#[must_use]`
+#[must_use()] //~ ERROR malformed
 struct Test;
 
 fn main() {}

--- a/tests/ui/attributes/malformed-must_use.stderr
+++ b/tests/ui/attributes/malformed-must_use.stderr
@@ -1,8 +1,19 @@
-error: valid forms for the attribute are `#[must_use = "reason"]` and `#[must_use]`
+error[E0539]: malformed `must_use` attribute input
   --> $DIR/malformed-must_use.rs:1:1
    |
 LL | #[must_use()]
    | ^^^^^^^^^^^^^
+   |
+   = note: for more information, visit <https://doc.rust-lang.org/reference/attributes/diagnostics.html#the-must_use-attribute>
+help: try changing it to one of the following valid forms of the attribute
+   |
+LL - #[must_use()]
+LL + #[must_use = "reason"]
+   |
+LL - #[must_use()]
+LL + #[must_use]
+   |
 
 error: aborting due to 1 previous error
 
+For more information about this error, try `rustc --explain E0539`.

--- a/tests/ui/attributes/malformed-must_use.stderr
+++ b/tests/ui/attributes/malformed-must_use.stderr
@@ -2,7 +2,9 @@ error[E0539]: malformed `must_use` attribute input
   --> $DIR/malformed-must_use.rs:1:1
    |
 LL | #[must_use()]
-   | ^^^^^^^^^^^^^
+   | ^^^^^^^^^^--^
+   |           |
+   |           didn't expect a list here
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/attributes/diagnostics.html#the-must_use-attribute>
 help: try changing it to one of the following valid forms of the attribute

--- a/tests/ui/attributes/malformed-static-align.stderr
+++ b/tests/ui/attributes/malformed-static-align.stderr
@@ -2,9 +2,9 @@ error[E0539]: malformed `rustc_align_static` attribute input
   --> $DIR/malformed-static-align.rs:4:1
    |
 LL | #[rustc_align_static = 16]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
-   | |
-   | expected this to be a list
+   | ^^^^^^^^^^^^^^^^^^^^^----^
+   | |                    |
+   | |                    expected this to be a list
    | help: must be of the form: `#[rustc_align_static(<alignment in bytes>)]`
 
 error[E0589]: invalid alignment value: not an unsuffixed integer

--- a/tests/ui/attributes/rustc_skip_during_method_dispatch.stderr
+++ b/tests/ui/attributes/rustc_skip_during_method_dispatch.stderr
@@ -11,9 +11,9 @@ error[E0539]: malformed `rustc_skip_during_method_dispatch` attribute input
   --> $DIR/rustc_skip_during_method_dispatch.rs:7:1
    |
 LL | #[rustc_skip_during_method_dispatch = "array"]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   | |
-   | expected this to be a list
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---------^
+   | |                                   |
+   | |                                   expected this to be a list
    | help: must be of the form: `#[rustc_skip_during_method_dispatch(array, boxed_slice)]`
 
 error[E0539]: malformed `rustc_skip_during_method_dispatch` attribute input

--- a/tests/ui/conditional-compilation/cfg-attr-syntax-validation.stderr
+++ b/tests/ui/conditional-compilation/cfg-attr-syntax-validation.stderr
@@ -13,9 +13,9 @@ error[E0539]: malformed `cfg` attribute input
   --> $DIR/cfg-attr-syntax-validation.rs:7:1
    |
 LL | #[cfg = 10]
-   | ^^^^^^^^^^^
-   | |
-   | expected this to be a list
+   | ^^^^^^----^
+   | |     |
+   | |     expected this to be a list
    | help: must be of the form: `#[cfg(predicate)]`
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>

--- a/tests/ui/deprecation/deprecation-sanity.rs
+++ b/tests/ui/deprecation/deprecation-sanity.rs
@@ -3,7 +3,7 @@
 // Various checks that deprecation attributes are used correctly
 
 mod bogus_attribute_types_1 {
-    #[deprecated(since = "a", note = "a", reason)] //~ ERROR unknown meta item 'reason'
+    #[deprecated(since = "a", note = "a", reason)] //~ ERROR malformed `deprecated` attribute input [E0539]
     fn f1() { }
 
     #[deprecated(since = "a", note)] //~ ERROR malformed `deprecated` attribute input [E0539]

--- a/tests/ui/deprecation/deprecation-sanity.stderr
+++ b/tests/ui/deprecation/deprecation-sanity.stderr
@@ -1,8 +1,10 @@
-error[E0541]: unknown meta item 'reason'
-  --> $DIR/deprecation-sanity.rs:6:43
+error[E0539]: malformed `deprecated` attribute input
+  --> $DIR/deprecation-sanity.rs:6:5
    |
 LL |     #[deprecated(since = "a", note = "a", reason)]
-   |                                           ^^^^^^ expected one of `since`, `note`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^------^^
+   |                                           |
+   |                                           valid arguments are `since` or `note`
 
 error[E0539]: malformed `deprecated` attribute input
   --> $DIR/deprecation-sanity.rs:9:5
@@ -86,5 +88,5 @@ LL | #[deprecated = "hello"]
 
 error: aborting due to 10 previous errors
 
-Some errors have detailed explanations: E0538, E0539, E0541, E0565.
+Some errors have detailed explanations: E0538, E0539, E0565.
 For more information about an error, try `rustc --explain E0538`.

--- a/tests/ui/feature-gates/issue-43106-gating-of-macro_use.rs
+++ b/tests/ui/feature-gates/issue-43106-gating-of-macro_use.rs
@@ -13,7 +13,7 @@ mod macro_escape {
     //~^ ERROR arguments to `macro_use` are not allowed here
 
     #[macro_use = "2700"] struct S;
-    //~^ ERROR valid forms for the attribute are `#[macro_use(name1, name2, ...)]` and `#[macro_use]`
+    //~^ ERROR malformed
     //~| WARN cannot be used on
     //~| WARN previously accepted
 

--- a/tests/ui/feature-gates/issue-43106-gating-of-macro_use.stderr
+++ b/tests/ui/feature-gates/issue-43106-gating-of-macro_use.stderr
@@ -20,7 +20,9 @@ error[E0539]: malformed `macro_use` attribute input
   --> $DIR/issue-43106-gating-of-macro_use.rs:15:5
    |
 LL |     #[macro_use = "2700"] struct S;
-   |     ^^^^^^^^^^^^^^^^^^^^^ expected a list or no arguments here
+   |     ^^^^^^^^^^^^--------^
+   |                 |
+   |                 expected a list or no arguments here
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/macros-by-example.html#the-macro_use-attribute>
 help: try changing it to one of the following valid forms of the attribute

--- a/tests/ui/feature-gates/issue-43106-gating-of-macro_use.stderr
+++ b/tests/ui/feature-gates/issue-43106-gating-of-macro_use.stderr
@@ -16,11 +16,21 @@ error: arguments to `macro_use` are not allowed here
 LL | #![macro_use(my_macro)]
    | ^^^^^^^^^^^^^^^^^^^^^^^
 
-error: valid forms for the attribute are `#[macro_use(name1, name2, ...)]` and `#[macro_use]`
+error[E0539]: malformed `macro_use` attribute input
   --> $DIR/issue-43106-gating-of-macro_use.rs:15:5
    |
 LL |     #[macro_use = "2700"] struct S;
-   |     ^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^ expected a list or no arguments here
+   |
+   = note: for more information, visit <https://doc.rust-lang.org/reference/macros-by-example.html#the-macro_use-attribute>
+help: try changing it to one of the following valid forms of the attribute
+   |
+LL -     #[macro_use = "2700"] struct S;
+LL +     #[macro_use(name1, name2, ...)] struct S;
+   |
+LL -     #[macro_use = "2700"] struct S;
+LL +     #[macro_use] struct S;
+   |
 
 warning: `#[macro_use]` attribute cannot be used on structs
   --> $DIR/issue-43106-gating-of-macro_use.rs:15:5
@@ -61,3 +71,4 @@ LL |     #[macro_use] impl S { }
 
 error: aborting due to 4 previous errors; 4 warnings emitted
 
+For more information about this error, try `rustc --explain E0539`.

--- a/tests/ui/link-native-libs/link-attr-validation-early.stderr
+++ b/tests/ui/link-native-libs/link-attr-validation-early.stderr
@@ -10,7 +10,9 @@ error[E0539]: malformed `link` attribute input
   --> $DIR/link-attr-validation-early.rs:3:1
    |
 LL | #[link = "foo"]
-   | ^^^^^^^^^^^^^^^ expected this to be a list
+   | ^^^^^^^-------^
+   |        |
+   |        expected this to be a list
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute>
 

--- a/tests/ui/link-native-libs/link-attr-validation-late.stderr
+++ b/tests/ui/link-native-libs/link-attr-validation-late.stderr
@@ -142,9 +142,9 @@ error[E0539]: malformed `link` attribute input
   --> $DIR/link-attr-validation-late.rs:24:1
    |
 LL | #[link(name = "...", cfg = "literal")]
-   | ^^^^^^^^^^^^^^^^^^^^^---------------^^
-   |                      |
-   |                      expected this to be a list
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^-----------^^
+   |                          |
+   |                          expected this to be a list
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute>
 

--- a/tests/ui/malformed/malformed-regressions.stderr
+++ b/tests/ui/malformed/malformed-regressions.stderr
@@ -10,7 +10,9 @@ error[E0539]: malformed `link` attribute input
   --> $DIR/malformed-regressions.rs:10:1
    |
 LL | #[link = ""]
-   | ^^^^^^^^^^^^ expected this to be a list
+   | ^^^^^^^----^
+   |        |
+   |        expected this to be a list
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute>
 

--- a/tests/ui/proc-macro/attribute.stderr
+++ b/tests/ui/proc-macro/attribute.stderr
@@ -16,7 +16,9 @@ error[E0539]: malformed `proc_macro_derive` attribute input
   --> $DIR/attribute.rs:15:1
    |
 LL | #[proc_macro_derive = ""]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^ expected this to be a list
+   | ^^^^^^^^^^^^^^^^^^^^----^
+   |                     |
+   |                     expected this to be a list
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/procedural-macros.html#derive-macros>
 help: try changing it to one of the following valid forms of the attribute

--- a/tests/ui/repr/repr.stderr
+++ b/tests/ui/repr/repr.stderr
@@ -10,7 +10,9 @@ error[E0539]: malformed `repr` attribute input
   --> $DIR/repr.rs:4:1
    |
 LL | #[repr = "B"]
-   | ^^^^^^^^^^^^^ expected this to be a list
+   | ^^^^^^^-----^
+   |        |
+   |        expected this to be a list
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/type-layout.html#representations>
 
@@ -18,7 +20,9 @@ error[E0539]: malformed `repr` attribute input
   --> $DIR/repr.rs:7:1
    |
 LL | #[repr = "C"]
-   | ^^^^^^^^^^^^^ expected this to be a list
+   | ^^^^^^^-----^
+   |        |
+   |        expected this to be a list
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/type-layout.html#representations>
 

--- a/tests/ui/sanitize-attr/invalid-sanitize.stderr
+++ b/tests/ui/sanitize-attr/invalid-sanitize.stderr
@@ -42,7 +42,9 @@ error[E0539]: malformed `sanitize` attribute input
   --> $DIR/invalid-sanitize.rs:18:1
    |
 LL | #[sanitize = "off"]
-   | ^^^^^^^^^^^^^^^^^^^ expected this to be a list
+   | ^^^^^^^^^^^-------^
+   |            |
+   |            expected this to be a list
 
 error[E0539]: malformed `sanitize` attribute input
   --> $DIR/invalid-sanitize.rs:21:1

--- a/tests/ui/stability-attribute/stability-attribute-sanity-2.rs
+++ b/tests/ui/stability-attribute/stability-attribute-sanity-2.rs
@@ -7,7 +7,7 @@
 #[stable(feature = "a", feature = "b", since = "1.0.0")] //~ ERROR malformed `stable` attribute input [E0538]
 fn f1() { }
 
-#[stable(feature = "a", sinse = "1.0.0")] //~ ERROR unknown meta item 'sinse'
+#[stable(feature = "a", sinse = "1.0.0")] //~ ERROR malformed `stable` attribute input [E0539]
 fn f2() { }
 
 #[unstable(feature = "a", issue = "no")]

--- a/tests/ui/stability-attribute/stability-attribute-sanity-2.stderr
+++ b/tests/ui/stability-attribute/stability-attribute-sanity-2.stderr
@@ -7,11 +7,14 @@ LL | #[stable(feature = "a", feature = "b", since = "1.0.0")]
    | |                       found `feature` used as a key more than once
    | help: must be of the form: `#[stable(feature = "name", since = "version")]`
 
-error[E0541]: unknown meta item 'sinse'
-  --> $DIR/stability-attribute-sanity-2.rs:10:25
+error[E0539]: malformed `stable` attribute input
+  --> $DIR/stability-attribute-sanity-2.rs:10:1
    |
 LL | #[stable(feature = "a", sinse = "1.0.0")]
-   |                         ^^^^^^^^^^^^^^^ expected one of `feature`, `since`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^---------------^^
+   | |                       |
+   | |                       valid arguments are `feature` or `since`
+   | help: must be of the form: `#[stable(feature = "name", since = "version")]`
 
 error[E0545]: `issue` must be a non-zero numeric string or "none"
   --> $DIR/stability-attribute-sanity-2.rs:13:27
@@ -23,5 +26,5 @@ LL | #[unstable(feature = "a", issue = "no")]
 
 error: aborting due to 3 previous errors
 
-Some errors have detailed explanations: E0538, E0541, E0545.
+Some errors have detailed explanations: E0538, E0539, E0545.
 For more information about an error, try `rustc --explain E0538`.

--- a/tests/ui/stability-attribute/stability-attribute-sanity-4.stderr
+++ b/tests/ui/stability-attribute/stability-attribute-sanity-4.stderr
@@ -11,9 +11,9 @@ error[E0539]: malformed `unstable` attribute input
   --> $DIR/stability-attribute-sanity-4.rs:11:5
    |
 LL |     #[unstable = "b"]
-   |     ^^^^^^^^^^^^^^^^^
-   |     |
-   |     expected this to be a list
+   |     ^^^^^^^^^^^-----^
+   |     |          |
+   |     |          expected this to be a list
    |     help: must be of the form: `#[unstable(feature = "name", reason = "...", issue = "N")]`
 
 error[E0539]: malformed `stable` attribute input
@@ -29,9 +29,9 @@ error[E0539]: malformed `stable` attribute input
   --> $DIR/stability-attribute-sanity-4.rs:17:5
    |
 LL |     #[stable = "a"]
-   |     ^^^^^^^^^^^^^^^
-   |     |
-   |     expected this to be a list
+   |     ^^^^^^^^^-----^
+   |     |        |
+   |     |        expected this to be a list
    |     help: must be of the form: `#[stable(feature = "name", since = "version")]`
 
 error[E0542]: missing 'since'

--- a/tests/ui/stability-attribute/stability-attribute-sanity.rs
+++ b/tests/ui/stability-attribute/stability-attribute-sanity.rs
@@ -5,7 +5,7 @@
 #![stable(feature = "rust1", since = "1.0.0")]
 
 mod bogus_attribute_types_1 {
-    #[stable(feature = "a", since = "4.4.4", reason)] //~ ERROR unknown meta item 'reason' [E0541]
+    #[stable(feature = "a", since = "4.4.4", reason)] //~ ERROR malformed `stable` attribute input [E0539]
     fn f1() { }
 
     #[stable(feature = "a", since)] //~ ERROR malformed `stable` attribute input [E0539]

--- a/tests/ui/stability-attribute/stability-attribute-sanity.stderr
+++ b/tests/ui/stability-attribute/stability-attribute-sanity.stderr
@@ -1,8 +1,11 @@
-error[E0541]: unknown meta item 'reason'
-  --> $DIR/stability-attribute-sanity.rs:8:46
+error[E0539]: malformed `stable` attribute input
+  --> $DIR/stability-attribute-sanity.rs:8:5
    |
 LL |     #[stable(feature = "a", since = "4.4.4", reason)]
-   |                                              ^^^^^^ expected one of `feature`, `since`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^------^^
+   |     |                                        |
+   |     |                                        valid arguments are `feature` or `since`
+   |     help: must be of the form: `#[stable(feature = "name", since = "version")]`
 
 error[E0539]: malformed `stable` attribute input
   --> $DIR/stability-attribute-sanity.rs:11:5
@@ -138,5 +141,5 @@ LL | #[stable(feature = "a", since = "1.0.0")]
 
 error: aborting due to 20 previous errors
 
-Some errors have detailed explanations: E0539, E0541, E0542, E0543, E0544, E0546, E0547, E0549, E0711.
+Some errors have detailed explanations: E0539, E0542, E0543, E0544, E0546, E0547, E0549, E0711.
 For more information about an error, try `rustc --explain E0539`.

--- a/tests/ui/target-feature/invalid-attribute.stderr
+++ b/tests/ui/target-feature/invalid-attribute.stderr
@@ -26,9 +26,9 @@ error[E0539]: malformed `target_feature` attribute input
   --> $DIR/invalid-attribute.rs:17:1
    |
 LL | #[target_feature = "+sse2"]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   | |
-   | expected this to be a list
+   | ^^^^^^^^^^^^^^^^^---------^
+   | |                |
+   | |                expected this to be a list
    | help: must be of the form: `#[target_feature(enable = "feat1, feat2")]`
 
 error[E0539]: malformed `target_feature` attribute input


### PR DESCRIPTION
Removes the specific `UnknownMetaItem` and `IllFormedAttributeInputLint` errors.
Note that `IllFormedAttributeInputLint` is not a lint, contrary to its name

r? @jdonszelmann 