### PR TITLE
Simplify how inline asm handles `MaybeUninit`

### DIFF
--- a/compiler/rustc_codegen_cranelift/src/inline_asm.rs
+++ b/compiler/rustc_codegen_cranelift/src/inline_asm.rs
@@ -857,19 +857,9 @@ fn call_inline_asm<'tcx>(
 
 fn asm_clif_type<'tcx>(fx: &FunctionCx<'_, '_, 'tcx>, ty: Ty<'tcx>) -> Option<types::Type> {
     match ty.kind() {
-        // Adapted from https://github.com/rust-lang/rust/blob/f3c66088610c1b80110297c2d9a8b5f9265b013f/compiler/rustc_hir_analysis/src/check/intrinsicck.rs#L136-L151
+        // Adapted from https://github.com/rust-lang/rust/blob/df44a57fd29fca899ce473f85ed64efd0708dd7c/compiler/rustc_hir_typeck/src/inline_asm.rs#L180-L183
         ty::Adt(adt, args) if fx.tcx.is_lang_item(adt.did(), LangItem::MaybeUninit) => {
-            let fields = &adt.non_enum_variant().fields;
-            let ty = fields[FieldIdx::ONE].ty(fx.tcx, args);
-            let ty::Adt(ty, args) = ty.kind() else {
-                unreachable!("expected first field of `MaybeUninit` to be an ADT")
-            };
-            assert!(
-                ty.is_manually_drop(),
-                "expected first field of `MaybeUninit` to be `ManuallyDrop`"
-            );
-            let fields = &ty.non_enum_variant().fields;
-            let ty = fields[FieldIdx::ZERO].ty(fx.tcx, args);
+            let ty = args.type_at(0);
             fx.clif_type(ty)
         }
         _ => fx.clif_type(ty),

--- a/compiler/rustc_hir_typeck/src/inline_asm.rs
+++ b/compiler/rustc_hir_typeck/src/inline_asm.rs
@@ -178,19 +178,7 @@ impl<'a, 'tcx> InlineAsmCtxt<'a, 'tcx> {
             ty::Never if is_input => return None,
             _ if ty.references_error() => return None,
             ty::Adt(adt, args) if self.tcx().is_lang_item(adt.did(), LangItem::MaybeUninit) => {
-                let fields = &adt.non_enum_variant().fields;
-                let ty = fields[FieldIdx::ONE].ty(self.tcx(), args);
-                // FIXME: Are we just trying to map to the `T` in `MaybeUninit<T>`?
-                // If so, just get it from the args.
-                let ty::Adt(ty, args) = ty.kind() else {
-                    unreachable!("expected first field of `MaybeUninit` to be an ADT")
-                };
-                assert!(
-                    ty.is_manually_drop(),
-                    "expected first field of `MaybeUninit` to be `ManuallyDrop`"
-                );
-                let fields = &ty.non_enum_variant().fields;
-                let ty = fields[FieldIdx::ZERO].ty(self.tcx(), args);
+                let ty = args.type_at(0);
                 self.get_asm_ty(expr.span, ty)
             }
             _ => self.get_asm_ty(expr.span, ty),


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

This is just better, but this is also allows it to handle changes from https://github.com/rust-lang/rust/pull/149614 (i.e. `ManuallyDrop` containing `MaybeDangle`).
