### PR TITLE
tidy: add if-installed prefix condition to extra checks system

### DIFF
--- a/src/tools/tidy/src/extra_checks/mod.rs
+++ b/src/tools/tidy/src/extra_checks/mod.rs
@@ -121,12 +121,12 @@ fn check_impl(
             .collect(),
         None => vec![],
     };
+    lint_args.retain(|ck| ck.is_non_if_installed_or_matches(root_path, outdir));
     if lint_args.iter().any(|ck| ck.auto) {
         crate::files_modified_batch_filter(ci_info, &mut lint_args, |ck, path| {
             ck.is_non_auto_or_matches(path)
         });
     }
-    lint_args.retain(|ck| ck.is_non_if_installed_or_matches(root_path, outdir));
 
     macro_rules! extra_check {
         ($lang:ident, $kind:ident) => {
@@ -963,7 +963,6 @@ impl FromStr for ExtraCheckArg {
                     };
                     if_installed = true;
                     first = part;
-                    continue;
                 }
                 _ => break,
             }

--- a/src/tools/tidy/src/extra_checks/mod.rs
+++ b/src/tools/tidy/src/extra_checks/mod.rs
@@ -754,7 +754,7 @@ enum ExtraCheckParseError {
     /// `auto` specified without lang part.
     AutoRequiresLang,
     /// `if-installed` specified without lang part.
-    IfInsatlledRequiresLang,
+    IfInstalledRequiresLang,
 }
 
 struct ExtraCheckArg {
@@ -874,7 +874,7 @@ impl FromStr for ExtraCheckArg {
 
             if !if_installed && first == "if-installed" {
                 let Some(part) = parts.next() else {
-                    return Err(ExtraCheckParseError::IfInsatlledRequiresLang);
+                    return Err(ExtraCheckParseError::IfInstalledRequiresLang);
                 };
                 if_installed = true;
                 first = part;

--- a/src/tools/tidy/src/extra_checks/rustdoc_js.rs
+++ b/src/tools/tidy/src/extra_checks/rustdoc_js.rs
@@ -21,6 +21,11 @@ fn spawn_cmd(cmd: &mut Command) -> Result<Child, io::Error> {
     })
 }
 
+pub(super) fn has_tool(outdir: &Path, name: &str) -> bool {
+    let bin_path = node_module_bin(outdir, name);
+    Command::new(bin_path).arg("--version").status().is_ok()
+}
+
 /// install all js dependencies from package.json.
 pub(super) fn npm_install(root_path: &Path, outdir: &Path, npm: &Path) -> Result<(), super::Error> {
     npm::install(root_path, outdir, npm)?;

--- a/src/tools/tidy/src/extra_checks/tests.rs
+++ b/src/tools/tidy/src/extra_checks/tests.rs
@@ -1,0 +1,86 @@
+use std::str::FromStr;
+
+use crate::extra_checks::{ExtraCheckArg, ExtraCheckKind, ExtraCheckLang, ExtraCheckParseError};
+
+#[test]
+fn test_extra_check_arg_from_str_ok() {
+    let test_cases = [
+        (
+            "auto:if-installed:spellcheck",
+            Ok(ExtraCheckArg {
+                auto: true,
+                if_installed: true,
+                lang: ExtraCheckLang::Spellcheck,
+                kind: None,
+            }),
+        ),
+        (
+            "if-installed:auto:spellcheck",
+            Ok(ExtraCheckArg {
+                auto: true,
+                if_installed: true,
+                lang: ExtraCheckLang::Spellcheck,
+                kind: None,
+            }),
+        ),
+        (
+            "auto:spellcheck",
+            Ok(ExtraCheckArg {
+                auto: true,
+                if_installed: false,
+                lang: ExtraCheckLang::Spellcheck,
+                kind: None,
+            }),
+        ),
+        (
+            "if-installed:spellcheck",
+            Ok(ExtraCheckArg {
+                auto: false,
+                if_installed: true,
+                lang: ExtraCheckLang::Spellcheck,
+                kind: None,
+            }),
+        ),
+        (
+            "spellcheck",
+            Ok(ExtraCheckArg {
+                auto: false,
+                if_installed: false,
+                lang: ExtraCheckLang::Spellcheck,
+                kind: None,
+            }),
+        ),
+        (
+            "js:lint",
+            Ok(ExtraCheckArg {
+                auto: false,
+                if_installed: false,
+                lang: ExtraCheckLang::Js,
+                kind: Some(ExtraCheckKind::Lint),
+            }),
+        ),
+    ];
+
+    for (s, expected) in test_cases {
+        assert_eq!(ExtraCheckArg::from_str(s), expected);
+    }
+}
+
+#[test]
+fn test_extra_check_arg_from_str_err() {
+    let test_cases = [
+        ("some:spellcheck", Err(ExtraCheckParseError::UnknownLang("some".to_string()))),
+        ("spellcheck:some", Err(ExtraCheckParseError::UnknownKind("some".to_string()))),
+        ("spellcheck:lint", Err(ExtraCheckParseError::UnsupportedKindForLang)),
+        ("auto:spellcheck:some", Err(ExtraCheckParseError::UnknownKind("some".to_string()))),
+        ("auto:js:lint:some", Err(ExtraCheckParseError::TooManyParts)),
+        ("some", Err(ExtraCheckParseError::UnknownLang("some".to_string()))),
+        ("auto", Err(ExtraCheckParseError::AutoRequiresLang)),
+        ("if-installed", Err(ExtraCheckParseError::IfInstalledRequiresLang)),
+        ("", Err(ExtraCheckParseError::Empty)),
+    ];
+
+    for (s, expected) in test_cases {
+        assert_eq!(ExtraCheckArg::from_str(s), expected);
+    }
+}

--- a/src/tools/tidy/src/extra_checks/tests.rs
+++ b/src/tools/tidy/src/extra_checks/tests.rs
@@ -7,80 +7,80 @@ fn test_extra_check_arg_from_str_ok() {
     let test_cases = [
         (
             "auto:if-installed:spellcheck",
-            Ok(ExtraCheckArg {
+            ExtraCheckArg {
                 auto: true,
                 if_installed: true,
                 lang: ExtraCheckLang::Spellcheck,
                 kind: None,
-            }),
+            },
         ),
         (
             "if-installed:auto:spellcheck",
-            Ok(ExtraCheckArg {
+            ExtraCheckArg {
                 auto: true,
                 if_installed: true,
                 lang: ExtraCheckLang::Spellcheck,
                 kind: None,
-            }),
+            },
         ),
         (
             "auto:spellcheck",
-            Ok(ExtraCheckArg {
+            ExtraCheckArg {
                 auto: true,
                 if_installed: false,
                 lang: ExtraCheckLang::Spellcheck,
                 kind: None,
-            }),
+            },
         ),
         (
             "if-installed:spellcheck",
-            Ok(ExtraCheckArg {
+            ExtraCheckArg {
                 auto: false,
                 if_installed: true,
                 lang: ExtraCheckLang::Spellcheck,
                 kind: None,
-            }),
+            },
         ),
         (
             "spellcheck",
-            Ok(ExtraCheckArg {
+            ExtraCheckArg {
                 auto: false,
                 if_installed: false,
                 lang: ExtraCheckLang::Spellcheck,
                 kind: None,
-            }),
+            },
         ),
         (
             "js:lint",
-            Ok(ExtraCheckArg {
+            ExtraCheckArg {
                 auto: false,
                 if_installed: false,
                 lang: ExtraCheckLang::Js,
                 kind: Some(ExtraCheckKind::Lint),
-            }),
+            },
         ),
     ];
 
     for (s, expected) in test_cases {
-        assert_eq!(ExtraCheckArg::from_str(s), expected);
+        assert_eq!(ExtraCheckArg::from_str(s), Ok(expected));
     }
 }
 
 #[test]
 fn test_extra_check_arg_from_str_err() {
     let test_cases = [
-        ("some:spellcheck", Err(ExtraCheckParseError::UnknownLang("some".to_string()))),
-        ("spellcheck:some", Err(ExtraCheckParseError::UnknownKind("some".to_string()))),
-        ("spellcheck:lint", Err(ExtraCheckParseError::UnsupportedKindForLang)),
-        ("auto:spellcheck:some", Err(ExtraCheckParseError::UnknownKind("some".to_string()))),
-        ("auto:js:lint:some", Err(ExtraCheckParseError::TooManyParts)),
-        ("some", Err(ExtraCheckParseError::UnknownLang("some".to_string()))),
-        ("auto", Err(ExtraCheckParseError::AutoRequiresLang)),
-        ("if-installed", Err(ExtraCheckParseError::IfInstalledRequiresLang)),
-        ("", Err(ExtraCheckParseError::Empty)),
+        ("some:spellcheck", ExtraCheckParseError::UnknownLang("some".to_string())),
+        ("spellcheck:some", ExtraCheckParseError::UnknownKind("some".to_string())),
+        ("spellcheck:lint", ExtraCheckParseError::UnsupportedKindForLang),
+        ("auto:spellcheck:some", ExtraCheckParseError::UnknownKind("some".to_string())),
+        ("auto:js:lint:some", ExtraCheckParseError::TooManyParts),
+        ("some", ExtraCheckParseError::UnknownLang("some".to_string())),
+        ("auto", ExtraCheckParseError::AutoRequiresLang),
+        ("if-installed", ExtraCheckParseError::IfInstalledRequiresLang),
+        ("", ExtraCheckParseError::Empty),
     ];
 
     for (s, expected) in test_cases {
-        assert_eq!(ExtraCheckArg::from_str(s), expected);
+        assert_eq!(ExtraCheckArg::from_str(s), Err(expected));
     }
 }

--- a/src/tools/tidy/src/lib.rs
+++ b/src/tools/tidy/src/lib.rs
@@ -164,7 +164,8 @@ pub fn ensure_version(build_dir: &Path, bin_name: &str, version: &str) -> io::Re
 
     match Command::new(&bin_path).arg("--version").output() {
         Ok(output) => {
-            let Some(v) = str::from_utf8(&output.stdout).unwrap().trim().split_whitespace().last() else {
+            let Some(v) = str::from_utf8(&output.stdout).unwrap().trim().split_whitespace().last()
+            else {
                 return Err(io::Error::other("version check failed"));
             };
 


### PR DESCRIPTION
Ref: https://rust-lang.zulipchat.com/#narrow/channel/326414-t-infra.2Fbootstrap/topic/Should.20Spellcheck.20check.20all.20files.3F/with/543227610

tidy now runs spellcheck (typos-cli) without adding `--extra-checks=spellcheck` option if the tool is already installed under ./build/misc-tools and the version is expected.
It will improve code quality without bothering engineers who doesn't want to use typos or who cleans up ./build directory frequently.