### PR TITLE
Remove Copy impl on Ancestors

### DIFF
--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -1093,7 +1093,7 @@ fn compare_components(mut left: Components<'_>, mut right: Components<'_>) -> cm
 /// ```
 ///
 /// [`ancestors`]: Path::ancestors
-#[derive(Copy, Clone, Debug)]
+#[derive(Clone, Debug)]
 #[must_use = "iterators are lazy and do nothing unless consumed"]
 #[stable(feature = "path_ancestors", since = "1.28.0")]
 pub struct Ancestors<'a> {


### PR DESCRIPTION
It's probably too late to claw this back given the stabilization was ages ago in 1.28, but I was confused reading some code using it so want to see how bad it would be.