### PR TITLE
Skip PhantomData in Unsize checks

### DIFF
--- a/compiler/rustc_traits/src/normalize_erasing_regions.rs
+++ b/compiler/rustc_traits/src/normalize_erasing_regions.rs
@@ -4,7 +4,7 @@ use rustc_middle::traits::query::NoSolution;
 use rustc_middle::ty::{self, PseudoCanonicalInput, TyCtxt, TypeFoldable, TypeVisitableExt};
 use rustc_trait_selection::traits::query::normalize::QueryNormalizeExt;
 use rustc_trait_selection::traits::{Normalized, ObligationCause};
-use tracing::debug;
+use tracing::{debug, instrument};
 
 pub(crate) fn provide(p: &mut Providers) {
     *p = Providers {
@@ -17,6 +17,7 @@ pub(crate) fn provide(p: &mut Providers) {
     };
 }
 
+#[instrument(level = "debug", skip(tcx))]
 fn try_normalize_after_erasing_regions<'tcx, T: TypeFoldable<TyCtxt<'tcx>> + PartialEq + Copy>(
     tcx: TyCtxt<'tcx>,
     goal: PseudoCanonicalInput<'tcx, T>,

--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -218,7 +218,7 @@ pub trait PointeeSized {
 /// - Structs `Foo<..., T1, ..., Tn, ...>` implement `Unsize<Foo<..., U1, ..., Un, ...>>`
 ///   where any number of (type and const) parameters may be changed if all of these conditions
 ///   are met:
-///   - Only the last field of `Foo` has a type involving the parameters `T1`, ..., `Tn`.
+///   - Other than `PhantomData<_>` fields, only the last field of `Foo` has a type involving the parameters `T1`, ..., `Tn`.
 ///   - All other parameters of the struct are equal.
 ///   - `Field<T1, ..., Tn>: Unsize<Field<U1, ..., Un>>`, where `Field<...>` stands for the actual
 ///     type of the struct's last field.

--- a/tests/ui/traits/dispatch-from-dyn-invalid-impls.rs
+++ b/tests/ui/traits/dispatch-from-dyn-invalid-impls.rs
@@ -68,4 +68,16 @@ where
 {
 }
 
+struct Ptr<T: ?Sized>(Box<T>);
+
+impl<'a, T: ?Sized, U: ?Sized> DispatchFromDyn<&'a Ptr<U>> for &'a Ptr<T> {}
+//~^ ERROR conflicting implementations of trait `DispatchFromDyn<&Ptr<_>>` for type `&Ptr<_>`
+
+struct Inner<T: ?Sized>(T);
+#[repr(transparent)]
+struct Outer<T: ?Sized>(PhantomData<T>, Inner<T>);
+
+impl<'a, T: Unsize<U> + ?Sized, U: ?Sized> DispatchFromDyn<&'a Outer<U>> for &'a Outer<T> {}
+//~^ ERROR  conflicting implementations of trait `DispatchFromDyn<&Outer<_>>` for type `&Outer<_>`
+
 fn main() {}

--- a/tests/ui/traits/dispatch-from-dyn-invalid-impls.stderr
+++ b/tests/ui/traits/dispatch-from-dyn-invalid-impls.stderr
@@ -1,3 +1,24 @@
+error[E0119]: conflicting implementations of trait `DispatchFromDyn<&Ptr<_>>` for type `&Ptr<_>`
+  --> $DIR/dispatch-from-dyn-invalid-impls.rs:73:1
+   |
+LL | impl<'a, T: ?Sized, U: ?Sized> DispatchFromDyn<&'a Ptr<U>> for &'a Ptr<T> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: conflicting implementation in crate `core`:
+           - impl<'a, T, U> DispatchFromDyn<&'a U> for &'a T
+             where T: Unsize<U>, T: ?Sized, U: ?Sized;
+   = note: downstream crates may implement trait `std::marker::Unsize<std::boxed::Box<_>>` for type `std::boxed::Box<_>`
+
+error[E0119]: conflicting implementations of trait `DispatchFromDyn<&Outer<_>>` for type `&Outer<_>`
+  --> $DIR/dispatch-from-dyn-invalid-impls.rs:80:1
+   |
+LL | impl<'a, T: Unsize<U> + ?Sized, U: ?Sized> DispatchFromDyn<&'a Outer<U>> for &'a Outer<T> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: conflicting implementation in crate `core`:
+           - impl<'a, T, U> DispatchFromDyn<&'a U> for &'a T
+             where T: Unsize<U>, T: ?Sized, U: ?Sized;
+
 error[E0378]: the trait `DispatchFromDyn` may only be implemented for structs containing the field being coerced, ZST fields with 1 byte alignment that don't mention type/const generics, and nothing else
   --> $DIR/dispatch-from-dyn-invalid-impls.rs:19:1
    |
@@ -54,7 +75,7 @@ LL | |     T: Unsize<U>
    |
    = note: extra field `1` of type `OverAlignedZst` is not allowed
 
-error: aborting due to 5 previous errors
+error: aborting due to 7 previous errors
 
-Some errors have detailed explanations: E0374, E0375, E0378.
-For more information about an error, try `rustc --explain E0374`.
+Some errors have detailed explanations: E0119, E0374, E0375, E0378.
+For more information about an error, try `rustc --explain E0119`.

--- a/tests/ui/unsized/unsize-with-phantom.rs
+++ b/tests/ui/unsized/unsize-with-phantom.rs
@@ -1,0 +1,41 @@
+//@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@[next] compile-flags: -Znext-solver
+//@ check-pass
+
+#![feature(unsize)]
+
+use std::marker::{PhantomData, Unsize};
+
+fn assert<A, B: ?Sized>()
+where
+    A: Unsize<B>,
+{
+}
+
+struct Ptr<A: ?Sized>(PhantomData<A>, A);
+
+trait ToPhantom {
+    type T;
+}
+impl<T: ?Sized> ToPhantom for T {
+    type T = PhantomData<fn() -> Self>;
+}
+
+struct Ptr2<A: ?Sized>(<A as ToPhantom>::T, A);
+
+trait Identity {
+    type T;
+}
+
+impl<T> Identity for T {
+    type T = T;
+}
+
+struct Ptr3<A: ?Sized>(<PhantomData<fn() -> A> as Identity>::T, A);
+
+fn main() {
+    assert::<Ptr<[u8; 4]>, Ptr<[u8]>>();
+    assert::<Ptr2<[u8; 4]>, Ptr2<[u8]>>();
+    assert::<Ptr3<[u8; 4]>, Ptr3<[u8]>>();
+}


### PR DESCRIPTION
This patch proposes relaxation on the type unsizing condition.
`PhantomData` has been in the current type system exempted from being treated as carrying any data, including dropck, virtual call dispatch by `DispatchFromDyn` and unsizing container by `CoerceUnsize`. `PhantomData` is a special 1-ZST that really carries no "data" of the types it captures.

I propose that we should also extend this interpretation to `Unsize`.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

<details>
<summary>Back story</summary>
This patch falls out of discussion on #148727 and I felt that we are "stricter" on how `Unsize` behaves than necessary.

For rust-lang/rust#148727, I am looking into [`anti-fundamenetal`](https://github.com/rust-lang/rust/pull/149068#issuecomment-3640529812) trait as suggested, which is a different problem. I don't intend to confuse this as a fix to rust-lang/rust#148727.
</details