### PR TITLE
Enable to ping LoongArch group via triagebot

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -96,6 +96,17 @@ Thanks! <3
 """
 label = "O-ARM"
 
+[ping.loongarch]
+message = """\
+Hey LoongArch Group! This bug has been identified as a good "LoongArch candidate".
+In case it's useful, here are some [instructions] for tackling these sorts of
+bugs. Maybe take a look?
+Thanks! <3
+
+[instructions]: https://rustc-dev-guide.rust-lang.org/notification-groups/loongarch.html
+"""
+label = "O-loongarch"
+
 [ping.risc-v]
 message = """\
 Hey RISC-V Group! This bug has been identified as a good "RISC-V candidate".


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->