### PR TITLE
Move ambient cdb discovery from compiletest to bootstrap

### DIFF
--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -2181,6 +2181,10 @@ Please disable assertions with `rust.debug-assertions = false`.
         }
 
         if mode == CompiletestMode::Debuginfo {
+            if let Some(debuggers::Cdb { cdb }) = debuggers::discover_cdb(target) {
+                cmd.arg("--cdb").arg(cdb);
+            }
+
             if let Some(debuggers::Gdb { gdb }) = debuggers::discover_gdb(builder, android.as_ref())
             {
                 cmd.arg("--gdb").arg(gdb.as_ref());

--- a/src/bootstrap/src/core/debuggers/cdb.rs
+++ b/src/bootstrap/src/core/debuggers/cdb.rs
@@ -1,0 +1,41 @@
+use std::env;
+use std::path::PathBuf;
+
+use crate::core::config::TargetSelection;
+
+pub(crate) struct Cdb {
+    pub(crate) cdb: PathBuf,
+}
+
+/// FIXME: This CDB discovery code was very questionable when it was in
+/// compiletest, and it's just as questionable now that it's in bootstrap.
+pub(crate) fn discover_cdb(target: TargetSelection) -> Option<Cdb> {
+    if !cfg!(windows) || !target.ends_with("-pc-windows-msvc") {
+        return None;
+    }
+
+    let pf86 =
+        PathBuf::from(env::var_os("ProgramFiles(x86)").or_else(|| env::var_os("ProgramFiles"))?);
+    let cdb_arch = if cfg!(target_arch = "x86") {
+        "x86"
+    } else if cfg!(target_arch = "x86_64") {
+        "x64"
+    } else if cfg!(target_arch = "aarch64") {
+        "arm64"
+    } else if cfg!(target_arch = "arm") {
+        "arm"
+    } else {
+        return None; // No compatible CDB.exe in the Windows 10 SDK
+    };
+
+    let mut path = pf86;
+    path.push(r"Windows Kits\10\Debuggers"); // We could check 8.1 etc. too?
+    path.push(cdb_arch);
+    path.push(r"cdb.exe");
+
+    if !path.exists() {
+        return None;
+    }
+
+    Some(Cdb { cdb: path })
+}

--- a/src/bootstrap/src/core/debuggers/mod.rs
+++ b/src/bootstrap/src/core/debuggers/mod.rs
@@ -1,8 +1,10 @@
 //! Code for discovering debuggers and debugger-related configuration, so that
 //! it can be passed to compiletest when running debuginfo tests.
 
+pub(crate) use self::cdb::{Cdb, discover_cdb};
 pub(crate) use self::gdb::{Gdb, discover_gdb};
 pub(crate) use self::lldb::{Lldb, discover_lldb};
 
+mod cdb;
 mod gdb;
 mod lldb;

--- a/src/tools/compiletest/src/lib.rs
+++ b/src/tools/compiletest/src/lib.rs
@@ -263,7 +263,7 @@ fn parse_config(args: Vec<String>) -> Config {
     let adb_device_status = target.contains("android") && adb_test_dir.is_some();
 
     // FIXME: `cdb_version` is *derived* from cdb, but it's *not* technically a config!
-    let cdb = debuggers::discover_cdb(matches.opt_str("cdb"), &target);
+    let cdb = matches.opt_str("cdb").map(Utf8PathBuf::from);
     let cdb_version = cdb.as_deref().and_then(debuggers::query_cdb_version);
     // FIXME: `gdb_version` is *derived* from gdb, but it's *not* technically a config!
     let gdb = matches.opt_str("gdb").map(Utf8PathBuf::from);


### PR DESCRIPTION
- Follow-up to https://github.com/rust-lang/rust/pull/149710

---

As with the previous PR, this PR takes the compiletest code for discovering an “ambient” `cdb` in the user's path, and moves it to bootstrap.

The discovery code is indeed questionable, but improving it is out of scope for this PR.

r? jieyouxu