### PR TITLE
Add checks for gpu-kernel calling conv

### DIFF
--- a/compiler/rustc_abi/src/extern_abi.rs
+++ b/compiler/rustc_abi/src/extern_abi.rs
@@ -67,7 +67,6 @@ pub enum ExternAbi {
 
     /* gpu */
     /// An entry-point function called by the GPU's host
-    // FIXME: should not be callable from Rust on GPU targets, is for host's use only
     GpuKernel,
     /// An entry-point function called by the GPU's host
     // FIXME: why do we have two of these?

--- a/compiler/rustc_hir_typeck/messages.ftl
+++ b/compiler/rustc_hir_typeck/messages.ftl
@@ -133,6 +133,10 @@ hir_typeck_fru_suggestion =
 hir_typeck_functional_record_update_on_non_struct =
     functional record update syntax requires a struct
 
+hir_typeck_gpu_kernel_abi_cannot_be_called =
+    functions with the "gpu-kernel" ABI cannot be called
+    .note = an `extern "gpu-kernel"` function must be launched on the GPU by the runtime
+
 hir_typeck_help_set_edition_cargo = set `edition = "{$edition}"` in `Cargo.toml`
 hir_typeck_help_set_edition_standalone = pass `--edition {$edition}` to `rustc`
 

--- a/compiler/rustc_hir_typeck/src/callee.rs
+++ b/compiler/rustc_hir_typeck/src/callee.rs
@@ -169,27 +169,27 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             }
         };
 
-        let valid = match canon_abi {
+        match canon_abi {
             // Rust doesn't know how to call functions with this ABI.
-            CanonAbi::Custom => false,
-
-            // These is an entry point for the host, and cannot be called on the GPU.
-            CanonAbi::GpuKernel => false,
-
+            CanonAbi::Custom
             // The interrupt ABIs should only be called by the CPU. They have complex
             // pre- and postconditions, and can use non-standard instructions like `iret` on x86.
-            CanonAbi::Interrupt(_) => false,
+            | CanonAbi::Interrupt(_) => {
+                let err = crate::errors::AbiCannotBeCalled { span, abi };
+                self.tcx.dcx().emit_err(err);
+            }
+
+            // This is an entry point for the host, and cannot be called directly.
+            CanonAbi::GpuKernel => {
+                let err = crate::errors::GpuKernelAbiCannotBeCalled { span };
+                self.tcx.dcx().emit_err(err);
+            }
 
             CanonAbi::C
             | CanonAbi::Rust
             | CanonAbi::RustCold
             | CanonAbi::Arm(_)
-            | CanonAbi::X86(_) => true,
-        };
-
-        if !valid {
-            let err = crate::errors::AbiCannotBeCalled { span, abi };
-            self.tcx.dcx().emit_err(err);
+            | CanonAbi::X86(_) => {}
         }
     }
 

--- a/compiler/rustc_hir_typeck/src/errors.rs
+++ b/compiler/rustc_hir_typeck/src/errors.rs
@@ -1199,6 +1199,14 @@ pub(crate) struct AbiCannotBeCalled {
 }
 
 #[derive(Diagnostic)]
+#[diag(hir_typeck_gpu_kernel_abi_cannot_be_called)]
+pub(crate) struct GpuKernelAbiCannotBeCalled {
+    #[primary_span]
+    #[note]
+    pub span: Span,
+}
+
+#[derive(Diagnostic)]
 #[diag(hir_typeck_const_continue_bad_label)]
 pub(crate) struct ConstContinueBadLabel {
     #[primary_span]

--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -470,6 +470,9 @@ lint_improper_ctypes_union_non_exhaustive = this union is non-exhaustive
 
 lint_improper_ctypes_unsafe_binder = unsafe binders are incompatible with foreign function interfaces
 
+lint_improper_gpu_kernel_arg = passing type `{$ty}` to a function with "gpu-kernel" ABI may have unexpected behavior
+    .help = use primitive types and raw pointers to get reliable behavior
+
 lint_int_to_ptr_transmutes = transmuting an integer to a pointer creates a pointer without provenance
     .note = this is dangerous because dereferencing the resulting pointer is undefined behavior
     .note_exposed_provenance = exposed provenance semantics can be used to create a pointer based on some previously exposed provenance
@@ -596,6 +599,10 @@ lint_mismatched_lifetime_syntaxes_suggestion_mixed =
 
 lint_mismatched_lifetime_syntaxes_suggestion_mixed_only_paths =
     use `'_` for type paths
+
+lint_missing_gpu_kernel_export_name = function with the "gpu-kernel" ABI has a mangled name
+    .note = mangled names make it hard to find the kernel, this is usually not intended
+    .help = use `unsafe(no_mangle)` or `unsafe(export_name = "<name>")`
 
 lint_mixed_script_confusables =
     the usage of Script Group `{$set}` in this crate consists solely of mixed script confusables

--- a/compiler/rustc_lint/src/gpukernel_abi.rs
+++ b/compiler/rustc_lint/src/gpukernel_abi.rs
@@ -1,0 +1,194 @@
+use std::iter;
+
+use rustc_abi::ExternAbi;
+use rustc_hir::attrs::AttributeKind;
+use rustc_hir::{self as hir, find_attr};
+use rustc_middle::ty::{self, Ty, TyCtxt, TypeFoldable, TypeFolder, TypeSuperFoldable};
+use rustc_session::{declare_lint, declare_lint_pass};
+use rustc_span::Span;
+use rustc_span::def_id::LocalDefId;
+
+use crate::lints::{ImproperGpuKernelArg, MissingGpuKernelExportName};
+use crate::{LateContext, LateLintPass, LintContext};
+
+declare_lint! {
+    /// The `improper_gpu_kernel_arg` lint detects incorrect use of types in `gpu-kernel`
+    /// arguments.
+    ///
+    /// ### Example
+    ///
+    /// ```rust,ignore (fails on non-GPU targets)
+    /// #[unsafe(no_mangle)]
+    /// extern "gpu-kernel" fn kernel(_: [i32; 10]) {}
+    /// ```
+    ///
+    /// This will produce:
+    ///
+    /// ```text
+    /// warning: passing type `[i32; 10]` to a function with "gpu-kernel" ABI may have unexpected behavior
+    ///  --> t.rs:2:34
+    ///   |
+    /// 2 | extern "gpu-kernel" fn kernel(_: [i32; 10]) {}
+    ///   |                                  ^^^^^^^^^
+    ///   |
+    ///   = help: use primitive types and raw pointers to get reliable behavior
+    ///   = note: `#[warn(improper_gpu_kernel_arg)]` on by default
+    /// ```
+    ///
+    /// ### Explanation
+    ///
+    /// The compiler has several checks to verify that types used as arguments in `gpu-kernel`
+    /// functions follow certain rules to ensure proper compatibility with the foreign interfaces.
+    /// This lint is issued when it detects a probable mistake in a signature.
+    IMPROPER_GPU_KERNEL_ARG,
+    Warn,
+    "GPU kernel entry points have a limited ABI"
+}
+
+declare_lint! {
+    /// The `missing_gpu_kernel_export_name` lint detects `gpu-kernel` functions that have a mangled name.
+    ///
+    /// ### Example
+    ///
+    /// ```rust,ignore (fails on non-GPU targets)
+    /// extern "gpu-kernel" fn kernel() { }
+    /// ```
+    ///
+    /// This will produce:
+    ///
+    /// ```text
+    /// warning: function with the "gpu-kernel" ABI has a mangled name
+    ///  --> t.rs:1:1
+    ///   |
+    /// 1 | extern "gpu-kernel" fn kernel() {}
+    ///   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    ///   |
+    ///   = help: use `unsafe(no_mangle)` or `unsafe(export_name = "<name>")`
+    ///   = note: mangled names make it hard to find the kernel, this is usually not intended
+    ///   = note: `#[warn(missing_gpu_kernel_export_name)]` on by default
+    /// ```
+    ///
+    /// ### Explanation
+    ///
+    /// `gpu-kernel` functions are usually searched by name in the compiled file.
+    /// A mangled name is usually unintentional as it would need to be searched by the mangled name.
+    ///
+    /// To use an unmangled name for the kernel, either `no_mangle` or `export_name` can be used.
+    /// ```rust,ignore (fails on non-GPU targets)
+    /// // Can be found by the name "kernel"
+    /// #[unsafe(no_mangle)]
+    /// extern "gpu-kernel" fn kernel() { }
+    ///
+    /// // Can be found by the name "new_name"
+    /// #[unsafe(export_name = "new_name")]
+    /// extern "gpu-kernel" fn other_kernel() { }
+    /// ```
+    MISSING_GPU_KERNEL_EXPORT_NAME,
+    Warn,
+    "mangled gpu-kernel function"
+}
+
+declare_lint_pass!(ImproperGpuKernelLint => [
+    IMPROPER_GPU_KERNEL_ARG,
+    MISSING_GPU_KERNEL_EXPORT_NAME,
+]);
+
+/// Check for valid and invalid types.
+struct CheckGpuKernelTypes<'tcx> {
+    tcx: TyCtxt<'tcx>,
+    // If one or more invalid types were encountered while folding.
+    has_invalid: bool,
+}
+
+impl<'tcx> TypeFolder<TyCtxt<'tcx>> for CheckGpuKernelTypes<'tcx> {
+    fn cx(&self) -> TyCtxt<'tcx> {
+        self.tcx
+    }
+
+    fn fold_ty(&mut self, ty: Ty<'tcx>) -> Ty<'tcx> {
+        match ty.kind() {
+            ty::Bool | ty::Char | ty::Int(_) | ty::Uint(_) | ty::Float(_) => {}
+            // Thin pointers are allowed but fat pointers with metadata are not
+            ty::RawPtr(_, _) => {
+                if !ty.pointee_metadata_ty_or_projection(self.tcx).is_unit() {
+                    self.has_invalid = true;
+                }
+            }
+
+            ty::Adt(_, _)
+            | ty::Alias(_, _)
+            | ty::Array(_, _)
+            | ty::Bound(_, _)
+            | ty::Closure(_, _)
+            | ty::Coroutine(_, _)
+            | ty::CoroutineClosure(_, _)
+            | ty::CoroutineWitness(..)
+            | ty::Dynamic(_, _)
+            | ty::FnDef(_, _)
+            | ty::FnPtr(..)
+            | ty::Foreign(_)
+            | ty::Never
+            | ty::Pat(_, _)
+            | ty::Placeholder(_)
+            | ty::Ref(_, _, _)
+            | ty::Slice(_)
+            | ty::Str
+            | ty::Tuple(_) => self.has_invalid = true,
+
+            _ => return ty.super_fold_with(self),
+        }
+        ty
+    }
+}
+
+/// `ImproperGpuKernelLint` checks `gpu-kernel` function definitions:
+///
+/// - `extern "gpu-kernel" fn` arguments should be primitive types.
+/// - `extern "gpu-kernel" fn` should have an unmangled name.
+impl<'tcx> LateLintPass<'tcx> for ImproperGpuKernelLint {
+    fn check_fn(
+        &mut self,
+        cx: &LateContext<'tcx>,
+        kind: hir::intravisit::FnKind<'tcx>,
+        decl: &'tcx hir::FnDecl<'_>,
+        _: &'tcx hir::Body<'_>,
+        span: Span,
+        id: LocalDefId,
+    ) {
+        use hir::intravisit::FnKind;
+
+        let abi = match kind {
+            FnKind::ItemFn(_, _, header, ..) => header.abi,
+            FnKind::Method(_, sig, ..) => sig.header.abi,
+            _ => return,
+        };
+
+        if abi != ExternAbi::GpuKernel {
+            return;
+        }
+
+        let sig = cx.tcx.fn_sig(id).instantiate_identity();
+        let sig = cx.tcx.instantiate_bound_regions_with_erased(sig);
+
+        for (input_ty, input_hir) in iter::zip(sig.inputs(), decl.inputs) {
+            let mut checker = CheckGpuKernelTypes { tcx: cx.tcx, has_invalid: false };
+            input_ty.fold_with(&mut checker);
+            if checker.has_invalid {
+                cx.tcx.emit_node_span_lint(
+                    IMPROPER_GPU_KERNEL_ARG,
+                    input_hir.hir_id,
+                    input_hir.span,
+                    ImproperGpuKernelArg { ty: *input_ty },
+                );
+            }
+        }
+
+        // Check for no_mangle/export_name, so the kernel can be found when querying the compiled object for the kernel function by name
+        if !find_attr!(
+            cx.tcx.get_all_attrs(id),
+            AttributeKind::NoMangle(..) | AttributeKind::ExportName { .. }
+        ) {
+            cx.emit_span_lint(MISSING_GPU_KERNEL_EXPORT_NAME, span, MissingGpuKernelExportName);
+        }
+    }
+}

--- a/compiler/rustc_lint/src/lib.rs
+++ b/compiler/rustc_lint/src/lib.rs
@@ -47,6 +47,7 @@ mod expect;
 mod for_loops_over_fallibles;
 mod foreign_modules;
 mod function_cast_as_integer;
+mod gpukernel_abi;
 mod if_let_rescope;
 mod impl_trait_overcaptures;
 mod interior_mutable_consts;
@@ -93,6 +94,7 @@ use drop_forget_useless::*;
 use enum_intrinsics_non_enums::EnumIntrinsicsNonEnums;
 use for_loops_over_fallibles::*;
 use function_cast_as_integer::*;
+use gpukernel_abi::*;
 use if_let_rescope::IfLetRescope;
 use impl_trait_overcaptures::ImplTraitOvercaptures;
 use interior_mutable_consts::*;
@@ -197,6 +199,7 @@ late_lint_methods!(
             DerefIntoDynSupertrait: DerefIntoDynSupertrait,
             DropForgetUseless: DropForgetUseless,
             ImproperCTypesLint: ImproperCTypesLint,
+            ImproperGpuKernelLint: ImproperGpuKernelLint,
             InvalidFromUtf8: InvalidFromUtf8,
             VariantSizeDifferences: VariantSizeDifferences,
             PathStatements: PathStatements,

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -2009,6 +2009,19 @@ impl<'a> LintDiagnostic<'a, ()> for ImproperCTypes<'_> {
 }
 
 #[derive(LintDiagnostic)]
+#[diag(lint_improper_gpu_kernel_arg)]
+#[help]
+pub(crate) struct ImproperGpuKernelArg<'a> {
+    pub ty: Ty<'a>,
+}
+
+#[derive(LintDiagnostic)]
+#[diag(lint_missing_gpu_kernel_export_name)]
+#[help]
+#[note]
+pub(crate) struct MissingGpuKernelExportName;
+
+#[derive(LintDiagnostic)]
 #[diag(lint_variant_size_differences)]
 pub(crate) struct VariantSizeDifferencesDiag {
     pub largest: u64,

--- a/tests/ui/abi/cannot-be-called.amdgpu.stderr
+++ b/tests/ui/abi/cannot-be-called.amdgpu.stderr
@@ -1,3 +1,9 @@
+error[E0570]: "msp430-interrupt" is not a supported ABI for the current target
+  --> $DIR/cannot-be-called.rs:43:8
+   |
+LL | extern "msp430-interrupt" fn msp430() {}
+   |        ^^^^^^^^^^^^^^^^^^
+
 error[E0570]: "avr-interrupt" is not a supported ABI for the current target
   --> $DIR/cannot-be-called.rs:45:8
    |
@@ -22,17 +28,17 @@ error[E0570]: "x86-interrupt" is not a supported ABI for the current target
 LL | extern "x86-interrupt" fn x86(_x: *const u8) {}
    |        ^^^^^^^^^^^^^^^
 
-error[E0570]: "gpu-kernel" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:53:8
-   |
-LL | extern "gpu-kernel" fn gpu_kernel() {}
-   |        ^^^^^^^^^^^^
-
 error[E0570]: "avr-interrupt" is not a supported ABI for the current target
   --> $DIR/cannot-be-called.rs:76:22
    |
 LL | fn avr_ptr(f: extern "avr-interrupt" fn()) {
    |                      ^^^^^^^^^^^^^^^
+
+error[E0570]: "msp430-interrupt" is not a supported ABI for the current target
+  --> $DIR/cannot-be-called.rs:82:25
+   |
+LL | fn msp430_ptr(f: extern "msp430-interrupt" fn()) {
+   |                         ^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "riscv-interrupt-m" is not a supported ABI for the current target
   --> $DIR/cannot-be-called.rs:88:26
@@ -52,32 +58,26 @@ error[E0570]: "x86-interrupt" is not a supported ABI for the current target
 LL | fn x86_ptr(f: extern "x86-interrupt" fn()) {
    |                      ^^^^^^^^^^^^^^^
 
-error[E0570]: "gpu-kernel" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:106:29
+error: functions with the "gpu-kernel" ABI cannot be called
+  --> $DIR/cannot-be-called.rs:70:5
    |
-LL | fn gpu_kernel_ptr(f: extern "gpu-kernel" fn()) {
-   |                             ^^^^^^^^^^^^
+LL |     gpu_kernel();
+   |     ^^^^^^^^^^^^
+   |
+note: an `extern "gpu-kernel"` function must be launched on the GPU by the runtime
+  --> $DIR/cannot-be-called.rs:70:5
+   |
+LL |     gpu_kernel();
+   |     ^^^^^^^^^^^^
 
-error: functions with the "msp430-interrupt" ABI cannot be called
-  --> $DIR/cannot-be-called.rs:62:5
-   |
-LL |     msp430();
-   |     ^^^^^^^^
-   |
-note: an `extern "msp430-interrupt"` function can only be called using inline assembly
-  --> $DIR/cannot-be-called.rs:62:5
-   |
-LL |     msp430();
-   |     ^^^^^^^^
-
-error: functions with the "msp430-interrupt" ABI cannot be called
-  --> $DIR/cannot-be-called.rs:84:5
+error: functions with the "gpu-kernel" ABI cannot be called
+  --> $DIR/cannot-be-called.rs:108:5
    |
 LL |     f()
    |     ^^^
    |
-note: an `extern "msp430-interrupt"` function can only be called using inline assembly
-  --> $DIR/cannot-be-called.rs:84:5
+note: an `extern "gpu-kernel"` function must be launched on the GPU by the runtime
+  --> $DIR/cannot-be-called.rs:108:5
    |
 LL |     f()
    |     ^^^

--- a/tests/ui/abi/cannot-be-called.avr.stderr
+++ b/tests/ui/abi/cannot-be-called.avr.stderr
@@ -1,75 +1,87 @@
 error[E0570]: "msp430-interrupt" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:38:8
+  --> $DIR/cannot-be-called.rs:43:8
    |
 LL | extern "msp430-interrupt" fn msp430() {}
    |        ^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "riscv-interrupt-m" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:42:8
+  --> $DIR/cannot-be-called.rs:47:8
    |
 LL | extern "riscv-interrupt-m" fn riscv_m() {}
    |        ^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "riscv-interrupt-s" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:44:8
+  --> $DIR/cannot-be-called.rs:49:8
    |
 LL | extern "riscv-interrupt-s" fn riscv_s() {}
    |        ^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "x86-interrupt" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:46:8
+  --> $DIR/cannot-be-called.rs:51:8
    |
 LL | extern "x86-interrupt" fn x86(_x: *const u8) {}
    |        ^^^^^^^^^^^^^^^
 
+error[E0570]: "gpu-kernel" is not a supported ABI for the current target
+  --> $DIR/cannot-be-called.rs:53:8
+   |
+LL | extern "gpu-kernel" fn gpu_kernel() {}
+   |        ^^^^^^^^^^^^
+
 error[E0570]: "msp430-interrupt" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:73:25
+  --> $DIR/cannot-be-called.rs:82:25
    |
 LL | fn msp430_ptr(f: extern "msp430-interrupt" fn()) {
    |                         ^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "riscv-interrupt-m" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:79:26
+  --> $DIR/cannot-be-called.rs:88:26
    |
 LL | fn riscv_m_ptr(f: extern "riscv-interrupt-m" fn()) {
    |                          ^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "riscv-interrupt-s" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:85:26
+  --> $DIR/cannot-be-called.rs:94:26
    |
 LL | fn riscv_s_ptr(f: extern "riscv-interrupt-s" fn()) {
    |                          ^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "x86-interrupt" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:91:22
+  --> $DIR/cannot-be-called.rs:100:22
    |
 LL | fn x86_ptr(f: extern "x86-interrupt" fn()) {
    |                      ^^^^^^^^^^^^^^^
 
+error[E0570]: "gpu-kernel" is not a supported ABI for the current target
+  --> $DIR/cannot-be-called.rs:106:29
+   |
+LL | fn gpu_kernel_ptr(f: extern "gpu-kernel" fn()) {
+   |                             ^^^^^^^^^^^^
+
 error: functions with the "avr-interrupt" ABI cannot be called
-  --> $DIR/cannot-be-called.rs:53:5
+  --> $DIR/cannot-be-called.rs:60:5
    |
 LL |     avr();
    |     ^^^^^
    |
 note: an `extern "avr-interrupt"` function can only be called using inline assembly
-  --> $DIR/cannot-be-called.rs:53:5
+  --> $DIR/cannot-be-called.rs:60:5
    |
 LL |     avr();
    |     ^^^^^
 
 error: functions with the "avr-interrupt" ABI cannot be called
-  --> $DIR/cannot-be-called.rs:69:5
+  --> $DIR/cannot-be-called.rs:78:5
    |
 LL |     f()
    |     ^^^
    |
 note: an `extern "avr-interrupt"` function can only be called using inline assembly
-  --> $DIR/cannot-be-called.rs:69:5
+  --> $DIR/cannot-be-called.rs:78:5
    |
 LL |     f()
    |     ^^^
 
-error: aborting due to 10 previous errors
+error: aborting due to 12 previous errors
 
 For more information about this error, try `rustc --explain E0570`.

--- a/tests/ui/abi/cannot-be-called.i686.stderr
+++ b/tests/ui/abi/cannot-be-called.i686.stderr
@@ -1,75 +1,87 @@
 error[E0570]: "msp430-interrupt" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:38:8
+  --> $DIR/cannot-be-called.rs:43:8
    |
 LL | extern "msp430-interrupt" fn msp430() {}
    |        ^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "avr-interrupt" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:40:8
+  --> $DIR/cannot-be-called.rs:45:8
    |
 LL | extern "avr-interrupt" fn avr() {}
    |        ^^^^^^^^^^^^^^^
 
 error[E0570]: "riscv-interrupt-m" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:42:8
+  --> $DIR/cannot-be-called.rs:47:8
    |
 LL | extern "riscv-interrupt-m" fn riscv_m() {}
    |        ^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "riscv-interrupt-s" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:44:8
+  --> $DIR/cannot-be-called.rs:49:8
    |
 LL | extern "riscv-interrupt-s" fn riscv_s() {}
    |        ^^^^^^^^^^^^^^^^^^^
 
+error[E0570]: "gpu-kernel" is not a supported ABI for the current target
+  --> $DIR/cannot-be-called.rs:53:8
+   |
+LL | extern "gpu-kernel" fn gpu_kernel() {}
+   |        ^^^^^^^^^^^^
+
 error[E0570]: "avr-interrupt" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:67:22
+  --> $DIR/cannot-be-called.rs:76:22
    |
 LL | fn avr_ptr(f: extern "avr-interrupt" fn()) {
    |                      ^^^^^^^^^^^^^^^
 
 error[E0570]: "msp430-interrupt" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:73:25
+  --> $DIR/cannot-be-called.rs:82:25
    |
 LL | fn msp430_ptr(f: extern "msp430-interrupt" fn()) {
    |                         ^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "riscv-interrupt-m" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:79:26
+  --> $DIR/cannot-be-called.rs:88:26
    |
 LL | fn riscv_m_ptr(f: extern "riscv-interrupt-m" fn()) {
    |                          ^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "riscv-interrupt-s" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:85:26
+  --> $DIR/cannot-be-called.rs:94:26
    |
 LL | fn riscv_s_ptr(f: extern "riscv-interrupt-s" fn()) {
    |                          ^^^^^^^^^^^^^^^^^^^
 
+error[E0570]: "gpu-kernel" is not a supported ABI for the current target
+  --> $DIR/cannot-be-called.rs:106:29
+   |
+LL | fn gpu_kernel_ptr(f: extern "gpu-kernel" fn()) {
+   |                             ^^^^^^^^^^^^
+
 error: functions with the "x86-interrupt" ABI cannot be called
-  --> $DIR/cannot-be-called.rs:61:5
+  --> $DIR/cannot-be-called.rs:68:5
    |
 LL |     x86(&raw const BYTE);
    |     ^^^^^^^^^^^^^^^^^^^^
    |
 note: an `extern "x86-interrupt"` function can only be called using inline assembly
-  --> $DIR/cannot-be-called.rs:61:5
+  --> $DIR/cannot-be-called.rs:68:5
    |
 LL |     x86(&raw const BYTE);
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: functions with the "x86-interrupt" ABI cannot be called
-  --> $DIR/cannot-be-called.rs:93:5
+  --> $DIR/cannot-be-called.rs:102:5
    |
 LL |     f()
    |     ^^^
    |
 note: an `extern "x86-interrupt"` function can only be called using inline assembly
-  --> $DIR/cannot-be-called.rs:93:5
+  --> $DIR/cannot-be-called.rs:102:5
    |
 LL |     f()
    |     ^^^
 
-error: aborting due to 10 previous errors
+error: aborting due to 12 previous errors
 
 For more information about this error, try `rustc --explain E0570`.

--- a/tests/ui/abi/cannot-be-called.nvptx.stderr
+++ b/tests/ui/abi/cannot-be-called.nvptx.stderr
@@ -1,3 +1,9 @@
+error[E0570]: "msp430-interrupt" is not a supported ABI for the current target
+  --> $DIR/cannot-be-called.rs:43:8
+   |
+LL | extern "msp430-interrupt" fn msp430() {}
+   |        ^^^^^^^^^^^^^^^^^^
+
 error[E0570]: "avr-interrupt" is not a supported ABI for the current target
   --> $DIR/cannot-be-called.rs:45:8
    |
@@ -22,17 +28,17 @@ error[E0570]: "x86-interrupt" is not a supported ABI for the current target
 LL | extern "x86-interrupt" fn x86(_x: *const u8) {}
    |        ^^^^^^^^^^^^^^^
 
-error[E0570]: "gpu-kernel" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:53:8
-   |
-LL | extern "gpu-kernel" fn gpu_kernel() {}
-   |        ^^^^^^^^^^^^
-
 error[E0570]: "avr-interrupt" is not a supported ABI for the current target
   --> $DIR/cannot-be-called.rs:76:22
    |
 LL | fn avr_ptr(f: extern "avr-interrupt" fn()) {
    |                      ^^^^^^^^^^^^^^^
+
+error[E0570]: "msp430-interrupt" is not a supported ABI for the current target
+  --> $DIR/cannot-be-called.rs:82:25
+   |
+LL | fn msp430_ptr(f: extern "msp430-interrupt" fn()) {
+   |                         ^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "riscv-interrupt-m" is not a supported ABI for the current target
   --> $DIR/cannot-be-called.rs:88:26
@@ -52,32 +58,26 @@ error[E0570]: "x86-interrupt" is not a supported ABI for the current target
 LL | fn x86_ptr(f: extern "x86-interrupt" fn()) {
    |                      ^^^^^^^^^^^^^^^
 
-error[E0570]: "gpu-kernel" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:106:29
+error: functions with the "gpu-kernel" ABI cannot be called
+  --> $DIR/cannot-be-called.rs:70:5
    |
-LL | fn gpu_kernel_ptr(f: extern "gpu-kernel" fn()) {
-   |                             ^^^^^^^^^^^^
+LL |     gpu_kernel();
+   |     ^^^^^^^^^^^^
+   |
+note: an `extern "gpu-kernel"` function must be launched on the GPU by the runtime
+  --> $DIR/cannot-be-called.rs:70:5
+   |
+LL |     gpu_kernel();
+   |     ^^^^^^^^^^^^
 
-error: functions with the "msp430-interrupt" ABI cannot be called
-  --> $DIR/cannot-be-called.rs:62:5
-   |
-LL |     msp430();
-   |     ^^^^^^^^
-   |
-note: an `extern "msp430-interrupt"` function can only be called using inline assembly
-  --> $DIR/cannot-be-called.rs:62:5
-   |
-LL |     msp430();
-   |     ^^^^^^^^
-
-error: functions with the "msp430-interrupt" ABI cannot be called
-  --> $DIR/cannot-be-called.rs:84:5
+error: functions with the "gpu-kernel" ABI cannot be called
+  --> $DIR/cannot-be-called.rs:108:5
    |
 LL |     f()
    |     ^^^
    |
-note: an `extern "msp430-interrupt"` function can only be called using inline assembly
-  --> $DIR/cannot-be-called.rs:84:5
+note: an `extern "gpu-kernel"` function must be launched on the GPU by the runtime
+  --> $DIR/cannot-be-called.rs:108:5
    |
 LL |     f()
    |     ^^^

--- a/tests/ui/abi/cannot-be-called.riscv32.stderr
+++ b/tests/ui/abi/cannot-be-called.riscv32.stderr
@@ -1,87 +1,99 @@
 error[E0570]: "msp430-interrupt" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:38:8
+  --> $DIR/cannot-be-called.rs:43:8
    |
 LL | extern "msp430-interrupt" fn msp430() {}
    |        ^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "avr-interrupt" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:40:8
+  --> $DIR/cannot-be-called.rs:45:8
    |
 LL | extern "avr-interrupt" fn avr() {}
    |        ^^^^^^^^^^^^^^^
 
 error[E0570]: "x86-interrupt" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:46:8
+  --> $DIR/cannot-be-called.rs:51:8
    |
 LL | extern "x86-interrupt" fn x86(_x: *const u8) {}
    |        ^^^^^^^^^^^^^^^
 
+error[E0570]: "gpu-kernel" is not a supported ABI for the current target
+  --> $DIR/cannot-be-called.rs:53:8
+   |
+LL | extern "gpu-kernel" fn gpu_kernel() {}
+   |        ^^^^^^^^^^^^
+
 error[E0570]: "avr-interrupt" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:67:22
+  --> $DIR/cannot-be-called.rs:76:22
    |
 LL | fn avr_ptr(f: extern "avr-interrupt" fn()) {
    |                      ^^^^^^^^^^^^^^^
 
 error[E0570]: "msp430-interrupt" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:73:25
+  --> $DIR/cannot-be-called.rs:82:25
    |
 LL | fn msp430_ptr(f: extern "msp430-interrupt" fn()) {
    |                         ^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "x86-interrupt" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:91:22
+  --> $DIR/cannot-be-called.rs:100:22
    |
 LL | fn x86_ptr(f: extern "x86-interrupt" fn()) {
    |                      ^^^^^^^^^^^^^^^
 
+error[E0570]: "gpu-kernel" is not a supported ABI for the current target
+  --> $DIR/cannot-be-called.rs:106:29
+   |
+LL | fn gpu_kernel_ptr(f: extern "gpu-kernel" fn()) {
+   |                             ^^^^^^^^^^^^
+
 error: functions with the "riscv-interrupt-m" ABI cannot be called
-  --> $DIR/cannot-be-called.rs:57:5
+  --> $DIR/cannot-be-called.rs:64:5
    |
 LL |     riscv_m();
    |     ^^^^^^^^^
    |
 note: an `extern "riscv-interrupt-m"` function can only be called using inline assembly
-  --> $DIR/cannot-be-called.rs:57:5
+  --> $DIR/cannot-be-called.rs:64:5
    |
 LL |     riscv_m();
    |     ^^^^^^^^^
 
 error: functions with the "riscv-interrupt-s" ABI cannot be called
-  --> $DIR/cannot-be-called.rs:59:5
+  --> $DIR/cannot-be-called.rs:66:5
    |
 LL |     riscv_s();
    |     ^^^^^^^^^
    |
 note: an `extern "riscv-interrupt-s"` function can only be called using inline assembly
-  --> $DIR/cannot-be-called.rs:59:5
+  --> $DIR/cannot-be-called.rs:66:5
    |
 LL |     riscv_s();
    |     ^^^^^^^^^
 
 error: functions with the "riscv-interrupt-m" ABI cannot be called
-  --> $DIR/cannot-be-called.rs:81:5
+  --> $DIR/cannot-be-called.rs:90:5
    |
 LL |     f()
    |     ^^^
    |
 note: an `extern "riscv-interrupt-m"` function can only be called using inline assembly
-  --> $DIR/cannot-be-called.rs:81:5
+  --> $DIR/cannot-be-called.rs:90:5
    |
 LL |     f()
    |     ^^^
 
 error: functions with the "riscv-interrupt-s" ABI cannot be called
-  --> $DIR/cannot-be-called.rs:87:5
+  --> $DIR/cannot-be-called.rs:96:5
    |
 LL |     f()
    |     ^^^
    |
 note: an `extern "riscv-interrupt-s"` function can only be called using inline assembly
-  --> $DIR/cannot-be-called.rs:87:5
+  --> $DIR/cannot-be-called.rs:96:5
    |
 LL |     f()
    |     ^^^
 
-error: aborting due to 10 previous errors
+error: aborting due to 12 previous errors
 
 For more information about this error, try `rustc --explain E0570`.

--- a/tests/ui/abi/cannot-be-called.riscv64.stderr
+++ b/tests/ui/abi/cannot-be-called.riscv64.stderr
@@ -1,87 +1,99 @@
 error[E0570]: "msp430-interrupt" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:38:8
+  --> $DIR/cannot-be-called.rs:43:8
    |
 LL | extern "msp430-interrupt" fn msp430() {}
    |        ^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "avr-interrupt" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:40:8
+  --> $DIR/cannot-be-called.rs:45:8
    |
 LL | extern "avr-interrupt" fn avr() {}
    |        ^^^^^^^^^^^^^^^
 
 error[E0570]: "x86-interrupt" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:46:8
+  --> $DIR/cannot-be-called.rs:51:8
    |
 LL | extern "x86-interrupt" fn x86(_x: *const u8) {}
    |        ^^^^^^^^^^^^^^^
 
+error[E0570]: "gpu-kernel" is not a supported ABI for the current target
+  --> $DIR/cannot-be-called.rs:53:8
+   |
+LL | extern "gpu-kernel" fn gpu_kernel() {}
+   |        ^^^^^^^^^^^^
+
 error[E0570]: "avr-interrupt" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:67:22
+  --> $DIR/cannot-be-called.rs:76:22
    |
 LL | fn avr_ptr(f: extern "avr-interrupt" fn()) {
    |                      ^^^^^^^^^^^^^^^
 
 error[E0570]: "msp430-interrupt" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:73:25
+  --> $DIR/cannot-be-called.rs:82:25
    |
 LL | fn msp430_ptr(f: extern "msp430-interrupt" fn()) {
    |                         ^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "x86-interrupt" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:91:22
+  --> $DIR/cannot-be-called.rs:100:22
    |
 LL | fn x86_ptr(f: extern "x86-interrupt" fn()) {
    |                      ^^^^^^^^^^^^^^^
 
+error[E0570]: "gpu-kernel" is not a supported ABI for the current target
+  --> $DIR/cannot-be-called.rs:106:29
+   |
+LL | fn gpu_kernel_ptr(f: extern "gpu-kernel" fn()) {
+   |                             ^^^^^^^^^^^^
+
 error: functions with the "riscv-interrupt-m" ABI cannot be called
-  --> $DIR/cannot-be-called.rs:57:5
+  --> $DIR/cannot-be-called.rs:64:5
    |
 LL |     riscv_m();
    |     ^^^^^^^^^
    |
 note: an `extern "riscv-interrupt-m"` function can only be called using inline assembly
-  --> $DIR/cannot-be-called.rs:57:5
+  --> $DIR/cannot-be-called.rs:64:5
    |
 LL |     riscv_m();
    |     ^^^^^^^^^
 
 error: functions with the "riscv-interrupt-s" ABI cannot be called
-  --> $DIR/cannot-be-called.rs:59:5
+  --> $DIR/cannot-be-called.rs:66:5
    |
 LL |     riscv_s();
    |     ^^^^^^^^^
    |
 note: an `extern "riscv-interrupt-s"` function can only be called using inline assembly
-  --> $DIR/cannot-be-called.rs:59:5
+  --> $DIR/cannot-be-called.rs:66:5
    |
 LL |     riscv_s();
    |     ^^^^^^^^^
 
 error: functions with the "riscv-interrupt-m" ABI cannot be called
-  --> $DIR/cannot-be-called.rs:81:5
+  --> $DIR/cannot-be-called.rs:90:5
    |
 LL |     f()
    |     ^^^
    |
 note: an `extern "riscv-interrupt-m"` function can only be called using inline assembly
-  --> $DIR/cannot-be-called.rs:81:5
+  --> $DIR/cannot-be-called.rs:90:5
    |
 LL |     f()
    |     ^^^
 
 error: functions with the "riscv-interrupt-s" ABI cannot be called
-  --> $DIR/cannot-be-called.rs:87:5
+  --> $DIR/cannot-be-called.rs:96:5
    |
 LL |     f()
    |     ^^^
    |
 note: an `extern "riscv-interrupt-s"` function can only be called using inline assembly
-  --> $DIR/cannot-be-called.rs:87:5
+  --> $DIR/cannot-be-called.rs:96:5
    |
 LL |     f()
    |     ^^^
 
-error: aborting due to 10 previous errors
+error: aborting due to 12 previous errors
 
 For more information about this error, try `rustc --explain E0570`.

--- a/tests/ui/abi/cannot-be-called.x64.stderr
+++ b/tests/ui/abi/cannot-be-called.x64.stderr
@@ -1,75 +1,87 @@
 error[E0570]: "msp430-interrupt" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:38:8
+  --> $DIR/cannot-be-called.rs:43:8
    |
 LL | extern "msp430-interrupt" fn msp430() {}
    |        ^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "avr-interrupt" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:40:8
+  --> $DIR/cannot-be-called.rs:45:8
    |
 LL | extern "avr-interrupt" fn avr() {}
    |        ^^^^^^^^^^^^^^^
 
 error[E0570]: "riscv-interrupt-m" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:42:8
+  --> $DIR/cannot-be-called.rs:47:8
    |
 LL | extern "riscv-interrupt-m" fn riscv_m() {}
    |        ^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "riscv-interrupt-s" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:44:8
+  --> $DIR/cannot-be-called.rs:49:8
    |
 LL | extern "riscv-interrupt-s" fn riscv_s() {}
    |        ^^^^^^^^^^^^^^^^^^^
 
+error[E0570]: "gpu-kernel" is not a supported ABI for the current target
+  --> $DIR/cannot-be-called.rs:53:8
+   |
+LL | extern "gpu-kernel" fn gpu_kernel() {}
+   |        ^^^^^^^^^^^^
+
 error[E0570]: "avr-interrupt" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:67:22
+  --> $DIR/cannot-be-called.rs:76:22
    |
 LL | fn avr_ptr(f: extern "avr-interrupt" fn()) {
    |                      ^^^^^^^^^^^^^^^
 
 error[E0570]: "msp430-interrupt" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:73:25
+  --> $DIR/cannot-be-called.rs:82:25
    |
 LL | fn msp430_ptr(f: extern "msp430-interrupt" fn()) {
    |                         ^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "riscv-interrupt-m" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:79:26
+  --> $DIR/cannot-be-called.rs:88:26
    |
 LL | fn riscv_m_ptr(f: extern "riscv-interrupt-m" fn()) {
    |                          ^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "riscv-interrupt-s" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:85:26
+  --> $DIR/cannot-be-called.rs:94:26
    |
 LL | fn riscv_s_ptr(f: extern "riscv-interrupt-s" fn()) {
    |                          ^^^^^^^^^^^^^^^^^^^
 
+error[E0570]: "gpu-kernel" is not a supported ABI for the current target
+  --> $DIR/cannot-be-called.rs:106:29
+   |
+LL | fn gpu_kernel_ptr(f: extern "gpu-kernel" fn()) {
+   |                             ^^^^^^^^^^^^
+
 error: functions with the "x86-interrupt" ABI cannot be called
-  --> $DIR/cannot-be-called.rs:61:5
+  --> $DIR/cannot-be-called.rs:68:5
    |
 LL |     x86(&raw const BYTE);
    |     ^^^^^^^^^^^^^^^^^^^^
    |
 note: an `extern "x86-interrupt"` function can only be called using inline assembly
-  --> $DIR/cannot-be-called.rs:61:5
+  --> $DIR/cannot-be-called.rs:68:5
    |
 LL |     x86(&raw const BYTE);
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: functions with the "x86-interrupt" ABI cannot be called
-  --> $DIR/cannot-be-called.rs:93:5
+  --> $DIR/cannot-be-called.rs:102:5
    |
 LL |     f()
    |     ^^^
    |
 note: an `extern "x86-interrupt"` function can only be called using inline assembly
-  --> $DIR/cannot-be-called.rs:93:5
+  --> $DIR/cannot-be-called.rs:102:5
    |
 LL |     f()
    |     ^^^
 
-error: aborting due to 10 previous errors
+error: aborting due to 12 previous errors
 
 For more information about this error, try `rustc --explain E0570`.

--- a/tests/ui/abi/cannot-be-called.x64_win.stderr
+++ b/tests/ui/abi/cannot-be-called.x64_win.stderr
@@ -1,75 +1,87 @@
 error[E0570]: "msp430-interrupt" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:38:8
+  --> $DIR/cannot-be-called.rs:43:8
    |
 LL | extern "msp430-interrupt" fn msp430() {}
    |        ^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "avr-interrupt" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:40:8
+  --> $DIR/cannot-be-called.rs:45:8
    |
 LL | extern "avr-interrupt" fn avr() {}
    |        ^^^^^^^^^^^^^^^
 
 error[E0570]: "riscv-interrupt-m" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:42:8
+  --> $DIR/cannot-be-called.rs:47:8
    |
 LL | extern "riscv-interrupt-m" fn riscv_m() {}
    |        ^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "riscv-interrupt-s" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:44:8
+  --> $DIR/cannot-be-called.rs:49:8
    |
 LL | extern "riscv-interrupt-s" fn riscv_s() {}
    |        ^^^^^^^^^^^^^^^^^^^
 
+error[E0570]: "gpu-kernel" is not a supported ABI for the current target
+  --> $DIR/cannot-be-called.rs:53:8
+   |
+LL | extern "gpu-kernel" fn gpu_kernel() {}
+   |        ^^^^^^^^^^^^
+
 error[E0570]: "avr-interrupt" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:67:22
+  --> $DIR/cannot-be-called.rs:76:22
    |
 LL | fn avr_ptr(f: extern "avr-interrupt" fn()) {
    |                      ^^^^^^^^^^^^^^^
 
 error[E0570]: "msp430-interrupt" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:73:25
+  --> $DIR/cannot-be-called.rs:82:25
    |
 LL | fn msp430_ptr(f: extern "msp430-interrupt" fn()) {
    |                         ^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "riscv-interrupt-m" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:79:26
+  --> $DIR/cannot-be-called.rs:88:26
    |
 LL | fn riscv_m_ptr(f: extern "riscv-interrupt-m" fn()) {
    |                          ^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "riscv-interrupt-s" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:85:26
+  --> $DIR/cannot-be-called.rs:94:26
    |
 LL | fn riscv_s_ptr(f: extern "riscv-interrupt-s" fn()) {
    |                          ^^^^^^^^^^^^^^^^^^^
 
+error[E0570]: "gpu-kernel" is not a supported ABI for the current target
+  --> $DIR/cannot-be-called.rs:106:29
+   |
+LL | fn gpu_kernel_ptr(f: extern "gpu-kernel" fn()) {
+   |                             ^^^^^^^^^^^^
+
 error: functions with the "x86-interrupt" ABI cannot be called
-  --> $DIR/cannot-be-called.rs:61:5
+  --> $DIR/cannot-be-called.rs:68:5
    |
 LL |     x86(&raw const BYTE);
    |     ^^^^^^^^^^^^^^^^^^^^
    |
 note: an `extern "x86-interrupt"` function can only be called using inline assembly
-  --> $DIR/cannot-be-called.rs:61:5
+  --> $DIR/cannot-be-called.rs:68:5
    |
 LL |     x86(&raw const BYTE);
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: functions with the "x86-interrupt" ABI cannot be called
-  --> $DIR/cannot-be-called.rs:93:5
+  --> $DIR/cannot-be-called.rs:102:5
    |
 LL |     f()
    |     ^^^
    |
 note: an `extern "x86-interrupt"` function can only be called using inline assembly
-  --> $DIR/cannot-be-called.rs:93:5
+  --> $DIR/cannot-be-called.rs:102:5
    |
 LL |     f()
    |     ^^^
 
-error: aborting due to 10 previous errors
+error: aborting due to 12 previous errors
 
 For more information about this error, try `rustc --explain E0570`.

--- a/tests/ui/abi/cannot-be-coroutine.amdgpu.stderr
+++ b/tests/ui/abi/cannot-be-coroutine.amdgpu.stderr
@@ -1,13 +1,13 @@
-error: functions with the "msp430-interrupt" ABI cannot be `async`
-  --> $DIR/cannot-be-coroutine.rs:46:1
+error: functions with the "gpu-kernel" ABI cannot be `async`
+  --> $DIR/cannot-be-coroutine.rs:62:1
    |
-LL | async extern "msp430-interrupt" fn msp430() {
+LL | async extern "gpu-kernel" fn async_kernel() {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `async` keyword from this definition
    |
-LL - async extern "msp430-interrupt" fn msp430() {
-LL + extern "msp430-interrupt" fn msp430() {
+LL - async extern "gpu-kernel" fn async_kernel() {
+LL + extern "gpu-kernel" fn async_kernel() {
    |
 
 error: requires `ResumeTy` lang_item

--- a/tests/ui/abi/cannot-be-coroutine.avr.stderr
+++ b/tests/ui/abi/cannot-be-coroutine.avr.stderr
@@ -1,5 +1,5 @@
 error: functions with the "avr-interrupt" ABI cannot be `async`
-  --> $DIR/cannot-be-coroutine.rs:37:1
+  --> $DIR/cannot-be-coroutine.rs:42:1
    |
 LL | async extern "avr-interrupt" fn avr() {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -11,7 +11,7 @@ LL + extern "avr-interrupt" fn avr() {
    |
 
 error: requires `ResumeTy` lang_item
-  --> $DIR/cannot-be-coroutine.rs:33:19
+  --> $DIR/cannot-be-coroutine.rs:38:19
    |
 LL |   async fn vanilla(){
    |  ___________________^

--- a/tests/ui/abi/cannot-be-coroutine.i686.stderr
+++ b/tests/ui/abi/cannot-be-coroutine.i686.stderr
@@ -1,5 +1,5 @@
 error: functions with the "x86-interrupt" ABI cannot be `async`
-  --> $DIR/cannot-be-coroutine.rs:53:1
+  --> $DIR/cannot-be-coroutine.rs:58:1
    |
 LL | async extern "x86-interrupt" fn x86(_p: *mut ()) {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -11,7 +11,7 @@ LL + extern "x86-interrupt" fn x86(_p: *mut ()) {
    |
 
 error: requires `ResumeTy` lang_item
-  --> $DIR/cannot-be-coroutine.rs:33:19
+  --> $DIR/cannot-be-coroutine.rs:38:19
    |
 LL |   async fn vanilla(){
    |  ___________________^

--- a/tests/ui/abi/cannot-be-coroutine.nvptx.stderr
+++ b/tests/ui/abi/cannot-be-coroutine.nvptx.stderr
@@ -1,13 +1,13 @@
-error: functions with the "msp430-interrupt" ABI cannot be `async`
-  --> $DIR/cannot-be-coroutine.rs:46:1
+error: functions with the "gpu-kernel" ABI cannot be `async`
+  --> $DIR/cannot-be-coroutine.rs:62:1
    |
-LL | async extern "msp430-interrupt" fn msp430() {
+LL | async extern "gpu-kernel" fn async_kernel() {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `async` keyword from this definition
    |
-LL - async extern "msp430-interrupt" fn msp430() {
-LL + extern "msp430-interrupt" fn msp430() {
+LL - async extern "gpu-kernel" fn async_kernel() {
+LL + extern "gpu-kernel" fn async_kernel() {
    |
 
 error: requires `ResumeTy` lang_item

--- a/tests/ui/abi/cannot-be-coroutine.riscv32.stderr
+++ b/tests/ui/abi/cannot-be-coroutine.riscv32.stderr
@@ -1,5 +1,5 @@
 error: functions with the "riscv-interrupt-m" ABI cannot be `async`
-  --> $DIR/cannot-be-coroutine.rs:45:1
+  --> $DIR/cannot-be-coroutine.rs:50:1
    |
 LL | async extern "riscv-interrupt-m" fn riscv_m() {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -11,7 +11,7 @@ LL + extern "riscv-interrupt-m" fn riscv_m() {
    |
 
 error: functions with the "riscv-interrupt-s" ABI cannot be `async`
-  --> $DIR/cannot-be-coroutine.rs:49:1
+  --> $DIR/cannot-be-coroutine.rs:54:1
    |
 LL | async extern "riscv-interrupt-s" fn riscv_s() {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -23,7 +23,7 @@ LL + extern "riscv-interrupt-s" fn riscv_s() {
    |
 
 error: requires `ResumeTy` lang_item
-  --> $DIR/cannot-be-coroutine.rs:33:19
+  --> $DIR/cannot-be-coroutine.rs:38:19
    |
 LL |   async fn vanilla(){
    |  ___________________^

--- a/tests/ui/abi/cannot-be-coroutine.riscv64.stderr
+++ b/tests/ui/abi/cannot-be-coroutine.riscv64.stderr
@@ -1,5 +1,5 @@
 error: functions with the "riscv-interrupt-m" ABI cannot be `async`
-  --> $DIR/cannot-be-coroutine.rs:45:1
+  --> $DIR/cannot-be-coroutine.rs:50:1
    |
 LL | async extern "riscv-interrupt-m" fn riscv_m() {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -11,7 +11,7 @@ LL + extern "riscv-interrupt-m" fn riscv_m() {
    |
 
 error: functions with the "riscv-interrupt-s" ABI cannot be `async`
-  --> $DIR/cannot-be-coroutine.rs:49:1
+  --> $DIR/cannot-be-coroutine.rs:54:1
    |
 LL | async extern "riscv-interrupt-s" fn riscv_s() {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -23,7 +23,7 @@ LL + extern "riscv-interrupt-s" fn riscv_s() {
    |
 
 error: requires `ResumeTy` lang_item
-  --> $DIR/cannot-be-coroutine.rs:33:19
+  --> $DIR/cannot-be-coroutine.rs:38:19
    |
 LL |   async fn vanilla(){
    |  ___________________^

--- a/tests/ui/abi/cannot-be-coroutine.rs
+++ b/tests/ui/abi/cannot-be-coroutine.rs
@@ -1,6 +1,6 @@
 //@ add-minicore
 //@ edition: 2021
-//@ revisions: x64 x64_win i686 riscv32 riscv64 avr msp430
+//@ revisions: x64 x64_win i686 riscv32 riscv64 avr msp430 amdgpu nvptx
 //
 //@ [x64] needs-llvm-components: x86
 //@ [x64] compile-flags: --target=x86_64-unknown-linux-gnu --crate-type=rlib
@@ -16,6 +16,10 @@
 //@ [avr] compile-flags: --target=avr-none -C target-cpu=atmega328p --crate-type=rlib
 //@ [msp430] needs-llvm-components: msp430
 //@ [msp430] compile-flags: --target=msp430-none-elf --crate-type=rlib
+//@ [amdgpu] needs-llvm-components: amdgpu
+//@ [amdgpu] compile-flags: --target amdgcn-amd-amdhsa -Ctarget-cpu=gfx900 --crate-type=rlib
+//@ [nvptx] needs-llvm-components: nvptx
+//@ [nvptx] compile-flags: --target nvptx64-nvidia-cuda --crate-type=rlib
 //@ ignore-backends: gcc
 #![no_core]
 #![feature(
@@ -23,7 +27,8 @@
     abi_msp430_interrupt,
     abi_avr_interrupt,
     abi_x86_interrupt,
-    abi_riscv_interrupt
+    abi_riscv_interrupt,
+    abi_gpu_kernel
 )]
 
 extern crate minicore;
@@ -52,4 +57,8 @@ async extern "riscv-interrupt-s" fn riscv_s() {
 
 async extern "x86-interrupt" fn x86(_p: *mut ()) {
     //[x64,x64_win,i686]~^ ERROR functions with the "x86-interrupt" ABI cannot be `async`
+}
+
+async extern "gpu-kernel" fn async_kernel() {
+    //[amdgpu,nvptx]~^ ERROR functions with the "gpu-kernel" ABI cannot be `async`
 }

--- a/tests/ui/abi/cannot-be-coroutine.x64.stderr
+++ b/tests/ui/abi/cannot-be-coroutine.x64.stderr
@@ -1,5 +1,5 @@
 error: functions with the "x86-interrupt" ABI cannot be `async`
-  --> $DIR/cannot-be-coroutine.rs:53:1
+  --> $DIR/cannot-be-coroutine.rs:58:1
    |
 LL | async extern "x86-interrupt" fn x86(_p: *mut ()) {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -11,7 +11,7 @@ LL + extern "x86-interrupt" fn x86(_p: *mut ()) {
    |
 
 error: requires `ResumeTy` lang_item
-  --> $DIR/cannot-be-coroutine.rs:33:19
+  --> $DIR/cannot-be-coroutine.rs:38:19
    |
 LL |   async fn vanilla(){
    |  ___________________^

--- a/tests/ui/abi/cannot-be-coroutine.x64_win.stderr
+++ b/tests/ui/abi/cannot-be-coroutine.x64_win.stderr
@@ -1,5 +1,5 @@
 error: functions with the "x86-interrupt" ABI cannot be `async`
-  --> $DIR/cannot-be-coroutine.rs:53:1
+  --> $DIR/cannot-be-coroutine.rs:58:1
    |
 LL | async extern "x86-interrupt" fn x86(_p: *mut ()) {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -11,7 +11,7 @@ LL + extern "x86-interrupt" fn x86(_p: *mut ()) {
    |
 
 error: requires `ResumeTy` lang_item
-  --> $DIR/cannot-be-coroutine.rs:33:19
+  --> $DIR/cannot-be-coroutine.rs:38:19
    |
 LL |   async fn vanilla(){
    |  ___________________^

--- a/tests/ui/abi/cannot-return.amdgpu.stderr
+++ b/tests/ui/abi/cannot-return.amdgpu.stderr
@@ -1,0 +1,15 @@
+error: invalid signature for `extern "gpu-kernel"` function
+  --> $DIR/cannot-return.rs:17:37
+   |
+LL | extern "gpu-kernel" fn ret_i32() -> i32 { 0 }
+   |                                     ^^^
+   |
+   = note: functions with the "gpu-kernel" ABI cannot have a return type
+help: remove the return type
+  --> $DIR/cannot-return.rs:17:37
+   |
+LL | extern "gpu-kernel" fn ret_i32() -> i32 { 0 }
+   |                                     ^^^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/abi/cannot-return.nvptx.stderr
+++ b/tests/ui/abi/cannot-return.nvptx.stderr
@@ -1,0 +1,15 @@
+error: invalid signature for `extern "gpu-kernel"` function
+  --> $DIR/cannot-return.rs:17:37
+   |
+LL | extern "gpu-kernel" fn ret_i32() -> i32 { 0 }
+   |                                     ^^^
+   |
+   = note: functions with the "gpu-kernel" ABI cannot have a return type
+help: remove the return type
+  --> $DIR/cannot-return.rs:17:37
+   |
+LL | extern "gpu-kernel" fn ret_i32() -> i32 { 0 }
+   |                                     ^^^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/abi/cannot-return.rs
+++ b/tests/ui/abi/cannot-return.rs
@@ -1,0 +1,18 @@
+//@ add-minicore
+//@ ignore-backends: gcc
+//@ edition: 2024
+//@ revisions: amdgpu nvptx
+//
+//@ [amdgpu] needs-llvm-components: amdgpu
+//@ [amdgpu] compile-flags: --target amdgcn-amd-amdhsa -Ctarget-cpu=gfx900 --crate-type=rlib
+//@ [nvptx] needs-llvm-components: nvptx
+//@ [nvptx] compile-flags: --target nvptx64-nvidia-cuda --crate-type=rlib
+#![no_core]
+#![feature(no_core, abi_gpu_kernel)]
+
+extern crate minicore;
+use minicore::*;
+
+#[unsafe(no_mangle)]
+extern "gpu-kernel" fn ret_i32() -> i32 { 0 }
+//~^ ERROR invalid signature for `extern "gpu-kernel"` function

--- a/tests/ui/lint/lint-gpu-kernel.amdgpu.stderr
+++ b/tests/ui/lint/lint-gpu-kernel.amdgpu.stderr
@@ -1,0 +1,86 @@
+warning: `extern` fn uses type `()`, which is not FFI-safe
+  --> $DIR/lint-gpu-kernel.rs:36:35
+   |
+LL | extern "gpu-kernel" fn arg_zst(_: ()) { }
+   |                                   ^^ not FFI-safe
+   |
+   = help: consider using a struct instead
+   = note: tuples have unspecified layout
+   = note: `#[warn(improper_ctypes_definitions)]` on by default
+
+warning: passing type `()` to a function with "gpu-kernel" ABI may have unexpected behavior
+  --> $DIR/lint-gpu-kernel.rs:36:35
+   |
+LL | extern "gpu-kernel" fn arg_zst(_: ()) { }
+   |                                   ^^
+   |
+   = help: use primitive types and raw pointers to get reliable behavior
+   = note: `#[warn(improper_gpu_kernel_arg)]` on by default
+
+warning: passing type `&i32` to a function with "gpu-kernel" ABI may have unexpected behavior
+  --> $DIR/lint-gpu-kernel.rs:41:35
+   |
+LL | extern "gpu-kernel" fn arg_ref(_: &i32) { }
+   |                                   ^^^^
+   |
+   = help: use primitive types and raw pointers to get reliable behavior
+
+warning: passing type `&mut i32` to a function with "gpu-kernel" ABI may have unexpected behavior
+  --> $DIR/lint-gpu-kernel.rs:44:39
+   |
+LL | extern "gpu-kernel" fn arg_ref_mut(_: &mut i32) { }
+   |                                       ^^^^^^^^
+   |
+   = help: use primitive types and raw pointers to get reliable behavior
+
+warning: `extern` fn uses type `S`, which is not FFI-safe
+  --> $DIR/lint-gpu-kernel.rs:49:38
+   |
+LL | extern "gpu-kernel" fn arg_struct(_: S) { }
+   |                                      ^ not FFI-safe
+   |
+   = help: consider adding a `#[repr(C)]` or `#[repr(transparent)]` attribute to this struct
+   = note: this struct has unspecified layout
+note: the type is defined here
+  --> $DIR/lint-gpu-kernel.rs:47:1
+   |
+LL | struct S { a: i32, b: i32 }
+   | ^^^^^^^^
+
+warning: passing type `S` to a function with "gpu-kernel" ABI may have unexpected behavior
+  --> $DIR/lint-gpu-kernel.rs:49:38
+   |
+LL | extern "gpu-kernel" fn arg_struct(_: S) { }
+   |                                      ^
+   |
+   = help: use primitive types and raw pointers to get reliable behavior
+
+warning: `extern` fn uses type `(i32, i32)`, which is not FFI-safe
+  --> $DIR/lint-gpu-kernel.rs:54:35
+   |
+LL | extern "gpu-kernel" fn arg_tup(_: (i32, i32)) { }
+   |                                   ^^^^^^^^^^ not FFI-safe
+   |
+   = help: consider using a struct instead
+   = note: tuples have unspecified layout
+
+warning: passing type `(i32, i32)` to a function with "gpu-kernel" ABI may have unexpected behavior
+  --> $DIR/lint-gpu-kernel.rs:54:35
+   |
+LL | extern "gpu-kernel" fn arg_tup(_: (i32, i32)) { }
+   |                                   ^^^^^^^^^^
+   |
+   = help: use primitive types and raw pointers to get reliable behavior
+
+warning: function with the "gpu-kernel" ABI has a mangled name
+  --> $DIR/lint-gpu-kernel.rs:61:1
+   |
+LL | pub extern "gpu-kernel" fn mangled_kernel() { }
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: use `unsafe(no_mangle)` or `unsafe(export_name = "<name>")`
+   = note: mangled names make it hard to find the kernel, this is usually not intended
+   = note: `#[warn(missing_gpu_kernel_export_name)]` on by default
+
+warning: 9 warnings emitted
+

--- a/tests/ui/lint/lint-gpu-kernel.nvptx.stderr
+++ b/tests/ui/lint/lint-gpu-kernel.nvptx.stderr
@@ -1,0 +1,86 @@
+warning: `extern` fn uses type `()`, which is not FFI-safe
+  --> $DIR/lint-gpu-kernel.rs:36:35
+   |
+LL | extern "gpu-kernel" fn arg_zst(_: ()) { }
+   |                                   ^^ not FFI-safe
+   |
+   = help: consider using a struct instead
+   = note: tuples have unspecified layout
+   = note: `#[warn(improper_ctypes_definitions)]` on by default
+
+warning: passing type `()` to a function with "gpu-kernel" ABI may have unexpected behavior
+  --> $DIR/lint-gpu-kernel.rs:36:35
+   |
+LL | extern "gpu-kernel" fn arg_zst(_: ()) { }
+   |                                   ^^
+   |
+   = help: use primitive types and raw pointers to get reliable behavior
+   = note: `#[warn(improper_gpu_kernel_arg)]` on by default
+
+warning: passing type `&i32` to a function with "gpu-kernel" ABI may have unexpected behavior
+  --> $DIR/lint-gpu-kernel.rs:41:35
+   |
+LL | extern "gpu-kernel" fn arg_ref(_: &i32) { }
+   |                                   ^^^^
+   |
+   = help: use primitive types and raw pointers to get reliable behavior
+
+warning: passing type `&mut i32` to a function with "gpu-kernel" ABI may have unexpected behavior
+  --> $DIR/lint-gpu-kernel.rs:44:39
+   |
+LL | extern "gpu-kernel" fn arg_ref_mut(_: &mut i32) { }
+   |                                       ^^^^^^^^
+   |
+   = help: use primitive types and raw pointers to get reliable behavior
+
+warning: `extern` fn uses type `S`, which is not FFI-safe
+  --> $DIR/lint-gpu-kernel.rs:49:38
+   |
+LL | extern "gpu-kernel" fn arg_struct(_: S) { }
+   |                                      ^ not FFI-safe
+   |
+   = help: consider adding a `#[repr(C)]` or `#[repr(transparent)]` attribute to this struct
+   = note: this struct has unspecified layout
+note: the type is defined here
+  --> $DIR/lint-gpu-kernel.rs:47:1
+   |
+LL | struct S { a: i32, b: i32 }
+   | ^^^^^^^^
+
+warning: passing type `S` to a function with "gpu-kernel" ABI may have unexpected behavior
+  --> $DIR/lint-gpu-kernel.rs:49:38
+   |
+LL | extern "gpu-kernel" fn arg_struct(_: S) { }
+   |                                      ^
+   |
+   = help: use primitive types and raw pointers to get reliable behavior
+
+warning: `extern` fn uses type `(i32, i32)`, which is not FFI-safe
+  --> $DIR/lint-gpu-kernel.rs:54:35
+   |
+LL | extern "gpu-kernel" fn arg_tup(_: (i32, i32)) { }
+   |                                   ^^^^^^^^^^ not FFI-safe
+   |
+   = help: consider using a struct instead
+   = note: tuples have unspecified layout
+
+warning: passing type `(i32, i32)` to a function with "gpu-kernel" ABI may have unexpected behavior
+  --> $DIR/lint-gpu-kernel.rs:54:35
+   |
+LL | extern "gpu-kernel" fn arg_tup(_: (i32, i32)) { }
+   |                                   ^^^^^^^^^^
+   |
+   = help: use primitive types and raw pointers to get reliable behavior
+
+warning: function with the "gpu-kernel" ABI has a mangled name
+  --> $DIR/lint-gpu-kernel.rs:61:1
+   |
+LL | pub extern "gpu-kernel" fn mangled_kernel() { }
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: use `unsafe(no_mangle)` or `unsafe(export_name = "<name>")`
+   = note: mangled names make it hard to find the kernel, this is usually not intended
+   = note: `#[warn(missing_gpu_kernel_export_name)]` on by default
+
+warning: 9 warnings emitted
+

--- a/tests/ui/lint/lint-gpu-kernel.rs
+++ b/tests/ui/lint/lint-gpu-kernel.rs
@@ -1,0 +1,62 @@
+// Test argument and return type restrictions of the gpu-kernel ABI and
+// check for warnings on mangled gpu-kernels.
+
+//@ check-pass
+//@ ignore-backends: gcc
+//@ revisions: amdgpu nvptx
+//@ add-minicore
+//@ edition: 2024
+//@[amdgpu] compile-flags: --target amdgcn-amd-amdhsa -Ctarget-cpu=gfx900
+//@[amdgpu] needs-llvm-components: amdgpu
+//@[nvptx]  compile-flags: --target nvptx64-nvidia-cuda
+//@[nvptx] needs-llvm-components: nvptx
+
+#![feature(no_core, abi_gpu_kernel)]
+#![no_core]
+#![crate_type = "lib"]
+
+extern crate minicore;
+use minicore::*;
+
+// Return types can be () or !
+#[unsafe(no_mangle)]
+extern "gpu-kernel" fn ret_empty() {}
+#[unsafe(no_mangle)]
+extern "gpu-kernel" fn ret_never() -> ! { loop {} }
+
+// Arguments can be scalars or pointers
+#[unsafe(no_mangle)]
+extern "gpu-kernel" fn arg_i32(_: i32) { }
+#[unsafe(no_mangle)]
+extern "gpu-kernel" fn arg_ptr(_: *const i32) { }
+#[unsafe(no_mangle)]
+extern "gpu-kernel" fn arg_ptr_mut(_: *mut i32) { }
+
+#[unsafe(no_mangle)]
+extern "gpu-kernel" fn arg_zst(_: ()) { }
+//~^ WARN passing type `()` to a function with "gpu-kernel" ABI may have unexpected behavior
+//~^^ WARN `extern` fn uses type `()`, which is not FFI-safe
+
+#[unsafe(no_mangle)]
+extern "gpu-kernel" fn arg_ref(_: &i32) { }
+//~^ WARN passing type `&i32` to a function with "gpu-kernel" ABI may have unexpected behavior
+#[unsafe(no_mangle)]
+extern "gpu-kernel" fn arg_ref_mut(_: &mut i32) { }
+//~^ WARN passing type `&mut i32` to a function with "gpu-kernel" ABI may have unexpected behavior
+
+struct S { a: i32, b: i32 }
+#[unsafe(no_mangle)]
+extern "gpu-kernel" fn arg_struct(_: S) { }
+//~^ WARN passing type `S` to a function with "gpu-kernel" ABI may have unexpected behavior
+//~^^ WARN `extern` fn uses type `S`, which is not FFI-safe
+
+#[unsafe(no_mangle)]
+extern "gpu-kernel" fn arg_tup(_: (i32, i32)) { }
+//~^ WARN passing type `(i32, i32)` to a function with "gpu-kernel" ABI may have unexpected behavior
+//~^^ WARN `extern` fn uses type `(i32, i32)`, which is not FFI-safe
+
+#[unsafe(export_name = "kernel")]
+pub extern "gpu-kernel" fn allowed_kernel_name() {}
+
+pub extern "gpu-kernel" fn mangled_kernel() { }
+//~^ WARN function with the "gpu-kernel" ABI has a mangled name


### PR DESCRIPTION
The `gpu-kernel` calling convention has several restrictions that were not enforced by the compiler until now.
Add the following restrictions:

1. Cannot be async
2. Cannot be called
3. Cannot return values, return type must be `()` or `!`
4. Arguments should be simple, i.e. passed by value. More complicated types can work when you know what you are doing, but it is rather unintuitive, one needs to know ABI/compiler internals.
5. Export name should be unmangled, either through `no_mangle` or `export_name`. Kernels are searched by name on the CPU side, having a mangled name makes it hard to find and probably almost always unintentional.

Tracking issue: rust-lang/rust#135467
amdgpu target tracking issue: rust-lang/rust#135024

@workingjubilee, these should be all the restrictions we talked about a year ago.

cc @RDambrosio016 @kjetilkjeka for nvptx
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
