### PR TITLE
Allow vector types for amdgpu

### DIFF
--- a/compiler/rustc_monomorphize/src/mono_checks/abi_check.rs
+++ b/compiler/rustc_monomorphize/src/mono_checks/abi_check.rs
@@ -54,7 +54,7 @@ fn do_check_simd_vector_abi<'tcx>(
                     continue;
                 }
             };
-            if !have_feature(Symbol::intern(feature)) {
+            if !feature.is_empty() && !have_feature(Symbol::intern(feature)) {
                 // Emit error.
                 let (span, _hir_id) = loc();
                 tcx.dcx().emit_err(errors::AbiErrorDisabledVectorType {

--- a/compiler/rustc_target/src/target_features.rs
+++ b/compiler/rustc_target/src/target_features.rs
@@ -918,6 +918,7 @@ const AARCH64_FEATURES_FOR_CORRECT_VECTOR_ABI: &'static [(u64, &'static str)] = 
 // We might want to add "helium" too.
 const ARM_FEATURES_FOR_CORRECT_VECTOR_ABI: &'static [(u64, &'static str)] = &[(128, "neon")];
 
+const AMDGPU_FEATURES_FOR_CORRECT_VECTOR_ABI: &'static [(u64, &'static str)] = &[(1024, "")];
 const POWERPC_FEATURES_FOR_CORRECT_VECTOR_ABI: &'static [(u64, &'static str)] = &[(128, "altivec")];
 const WASM_FEATURES_FOR_CORRECT_VECTOR_ABI: &'static [(u64, &'static str)] = &[(128, "simd128")];
 const S390X_FEATURES_FOR_CORRECT_VECTOR_ABI: &'static [(u64, &'static str)] = &[(128, "vector")];
@@ -996,12 +997,12 @@ impl Target {
             Arch::Mips | Arch::Mips32r6 | Arch::Mips64 | Arch::Mips64r6 => {
                 MIPS_FEATURES_FOR_CORRECT_VECTOR_ABI
             }
+            Arch::AmdGpu => AMDGPU_FEATURES_FOR_CORRECT_VECTOR_ABI,
             Arch::Nvptx64 | Arch::Bpf | Arch::M68k => &[], // no vector ABI
             Arch::CSky => CSKY_FEATURES_FOR_CORRECT_VECTOR_ABI,
             // FIXME: for some tier3 targets, we are overly cautious and always give warnings
             // when passing args in vector registers.
-            Arch::AmdGpu
-            | Arch::Avr
+            Arch::Avr
             | Arch::Msp430
             | Arch::PowerPC64LE
             | Arch::SpirV


### PR DESCRIPTION
The amdgpu target uses vector types in various places. The vector types can be used on all architectures, there is no associated target feature that needs to be enabled.

The largest vector type found in LLVM intrinsics is `v32i32` (`[32 x i32]`) for mfma intrinsics. Note that while this intrinsic is only supported on some architectures, the vector type itself is supported on all architectures.

Tracking issue: rust-lang/rust#135024

(I used an empty string to say “does not need a target feature”. If you prefer an `Option` or something like that, I’ll change it.)

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
