### PR TITLE
Link POSIX instead of Linux manual for Instant

### DIFF
--- a/library/std/src/sys/pal/unix/time.rs
+++ b/library/std/src/sys/pal/unix/time.rs
@@ -275,7 +275,7 @@ impl Instant {
     #[cfg(not(target_vendor = "apple"))]
     pub(crate) const CLOCK_ID: libc::clockid_t = libc::CLOCK_MONOTONIC;
     pub fn now() -> Instant {
-        // https://www.manpagez.com/man/3/clock_gettime/
+        // https://pubs.opengroup.org/onlinepubs/9799919799/functions/clock_getres.html
         //
         // CLOCK_UPTIME_RAW   clock that increments monotonically, in the same man-
         //                    ner as CLOCK_MONOTONIC_RAW, but that does not incre-

--- a/library/std/src/time.rs
+++ b/library/std/src/time.rs
@@ -124,7 +124,7 @@ use crate::sys_common::{FromInner, IntoInner};
 /// [`insecure_time` usercall]: https://edp.fortanix.com/docs/api/fortanix_sgx_abi/struct.Usercalls.html#method.insecure_time
 /// [timekeeping in SGX]: https://edp.fortanix.com/docs/concepts/rust-std/#codestdtimecode
 /// [__wasi_clock_time_get]: https://github.com/WebAssembly/WASI/blob/main/legacy/preview1/docs.md#clock_time_get
-/// [clock_gettime]: https://linux.die.net/man/3/clock_gettime
+/// [clock_gettime]: https://pubs.opengroup.org/onlinepubs/9799919799/functions/clock_getres.html
 ///
 /// **Disclaimer:** These system calls might change over time.
 ///
@@ -234,7 +234,7 @@ pub struct Instant(time::Instant);
 /// [currently]: crate::io#platform-specific-behavior
 /// [`insecure_time` usercall]: https://edp.fortanix.com/docs/api/fortanix_sgx_abi/struct.Usercalls.html#method.insecure_time
 /// [timekeeping in SGX]: https://edp.fortanix.com/docs/concepts/rust-std/#codestdtimecode
-/// [clock_gettime (Realtime Clock)]: https://linux.die.net/man/3/clock_gettime
+/// [clock_gettime (Realtime Clock)]: https://pubs.opengroup.org/onlinepubs/9799919799/functions/clock_getres.html
 /// [__wasi_clock_time_get (Realtime Clock)]: https://github.com/WebAssembly/WASI/blob/main/legacy/preview1/docs.md#clock_time_get
 /// [GetSystemTimePreciseAsFileTime]: https://docs.microsoft.com/en-us/windows/win32/api/sysinfoapi/nf-sysinfoapi-getsystemtimepreciseasfiletime
 /// [GetSystemTimeAsFileTime]: https://docs.microsoft.com/en-us/windows/win32/api/sysinfoapi/nf-sysinfoapi-getsystemtimeasfiletime


### PR DESCRIPTION
This commit changes the links in the source code that link to a platform specific implementation of the POSIX interface of `clock_gettime`, despite the respective areas in the code being specifically UNIX system agnostic, thereby making it more reasonable to link the POSIX specific document.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
