### PR TITLE
Port `#[rustc_legacy_const_generics]` to use attribute parser 

### DIFF
--- a/compiler/rustc_attr_parsing/src/attributes/rustc_internal.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/rustc_internal.rs
@@ -1,3 +1,5 @@
+use rustc_ast::{LitIntType, LitKind, MetaItemLit};
+
 use super::prelude::*;
 use super::util::parse_single_integer;
 use crate::session_diagnostics::RustcScalableVectorCountOutOfRange;
@@ -38,6 +40,50 @@ impl<S: Stage> SingleAttributeParser<S> for RustcLayoutScalarValidRangeEndParser
     fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
         parse_single_integer(cx, args)
             .map(|n| AttributeKind::RustcLayoutScalarValidRangeEnd(Box::new(n), cx.attr_span))
+    }
+}
+
+pub(crate) struct RustcLegacyConstGenericsParser;
+
+impl<S: Stage> SingleAttributeParser<S> for RustcLegacyConstGenericsParser {
+    const PATH: &[Symbol] = &[sym::rustc_legacy_const_generics];
+    const ATTRIBUTE_ORDER: AttributeOrder = AttributeOrder::KeepInnermost;
+    const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Error;
+    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Fn)]);
+    const TEMPLATE: AttributeTemplate = template!(List: &["N"]);
+
+    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
+        let ArgParser::List(meta_items) = args else {
+            cx.expected_list(cx.attr_span, args);
+            return None;
+        };
+
+        let mut parsed_indexes = ThinVec::new();
+        let mut errored = false;
+
+        for possible_index in meta_items.mixed() {
+            if let MetaItemOrLitParser::Lit(MetaItemLit {
+                kind: LitKind::Int(index, LitIntType::Unsuffixed),
+                ..
+            }) = possible_index
+            {
+                parsed_indexes.push((index.0 as usize, possible_index.span()));
+            } else {
+                cx.expected_integer_literal(possible_index.span());
+                errored = true;
+            }
+        }
+        if errored {
+            return None;
+        } else if parsed_indexes.is_empty() {
+            cx.expected_at_least_one_argument(args.span()?);
+            return None;
+        }
+
+        Some(AttributeKind::RustcLegacyConstGenerics {
+            fn_indexes: parsed_indexes,
+            attr_span: cx.attr_span,
+        })
     }
 }
 

--- a/compiler/rustc_attr_parsing/src/context.rs
+++ b/compiler/rustc_attr_parsing/src/context.rs
@@ -59,9 +59,9 @@ use crate::attributes::proc_macro_attrs::{
 use crate::attributes::prototype::CustomMirParser;
 use crate::attributes::repr::{AlignParser, AlignStaticParser, ReprParser};
 use crate::attributes::rustc_internal::{
-    RustcLayoutScalarValidRangeEndParser, RustcLayoutScalarValidRangeStartParser, RustcMainParser,
-    RustcObjectLifetimeDefaultParser, RustcScalableVectorParser,
-    RustcSimdMonomorphizeLaneLimitParser,
+    RustcLayoutScalarValidRangeEndParser, RustcLayoutScalarValidRangeStartParser,
+    RustcLegacyConstGenericsParser, RustcMainParser, RustcObjectLifetimeDefaultParser,
+    RustcScalableVectorParser, RustcSimdMonomorphizeLaneLimitParser,
 };
 use crate::attributes::semantics::MayDangleParser;
 use crate::attributes::stability::{
@@ -209,6 +209,7 @@ attribute_parsers!(
         Single<RustcForceInlineParser>,
         Single<RustcLayoutScalarValidRangeEndParser>,
         Single<RustcLayoutScalarValidRangeStartParser>,
+        Single<RustcLegacyConstGenericsParser>,
         Single<RustcObjectLifetimeDefaultParser>,
         Single<RustcScalableVectorParser>,
         Single<RustcSimdMonomorphizeLaneLimitParser>,

--- a/compiler/rustc_hir/src/attrs/data_structures.rs
+++ b/compiler/rustc_hir/src/attrs/data_structures.rs
@@ -869,6 +869,9 @@ pub enum AttributeKind {
     /// Represents `#[rustc_layout_scalar_valid_range_start]`.
     RustcLayoutScalarValidRangeStart(Box<u128>, Span),
 
+    /// Represents `#[rustc_legacy_const_generics]`
+    RustcLegacyConstGenerics { fn_indexes: ThinVec<(usize, Span)>, attr_span: Span },
+
     /// Represents `#[rustc_main]`.
     RustcMain,
 

--- a/compiler/rustc_hir/src/attrs/encode_cross_crate.rs
+++ b/compiler/rustc_hir/src/attrs/encode_cross_crate.rs
@@ -92,6 +92,7 @@ impl AttributeKind {
             RustcCoherenceIsCore(..) => No,
             RustcLayoutScalarValidRangeEnd(..) => Yes,
             RustcLayoutScalarValidRangeStart(..) => Yes,
+            RustcLegacyConstGenerics { .. } => Yes,
             RustcMain => No,
             RustcObjectLifetimeDefault => No,
             RustcPassIndirectlyInNonRusticAbis(..) => No,

--- a/compiler/rustc_hir/src/attrs/pretty_printing.rs
+++ b/compiler/rustc_hir/src/attrs/pretty_printing.rs
@@ -169,7 +169,7 @@ macro_rules! print_tup {
 
 print_tup!(A B C D E F G H);
 print_skip!(Span, (), ErrorGuaranteed);
-print_disp!(u16, u128, bool, NonZero<u32>, Limit);
+print_disp!(u16, u128, usize, bool, NonZero<u32>, Limit);
 print_debug!(
     Symbol,
     Ident,

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -197,7 +197,6 @@ pub struct ResolverGlobalCtxt {
 #[derive(Debug)]
 pub struct ResolverAstLowering {
     pub legacy_const_generic_args: FxHashMap<DefId, Option<Vec<usize>>>,
-
     /// Resolutions for nodes that have a single resolution.
     pub partial_res_map: NodeMap<hir::def::PartialRes>,
     /// Resolutions for import nodes, which have multiple resolutions in different namespaces.

--- a/compiler/rustc_passes/messages.ftl
+++ b/compiler/rustc_passes/messages.ftl
@@ -478,9 +478,6 @@ passes_rustc_legacy_const_generics_index_exceed =
         *[other] arguments
     }
 
-passes_rustc_legacy_const_generics_index_negative =
-    arguments should be non-negative integers
-
 passes_rustc_legacy_const_generics_only =
     #[rustc_legacy_const_generics] functions must only have const generics
     .label = non-const generic parameter

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -10,9 +10,10 @@ use std::collections::hash_map::Entry;
 use std::slice;
 
 use rustc_abi::{Align, ExternAbi, Size};
-use rustc_ast::{AttrStyle, LitKind, MetaItemKind, ast};
+use rustc_ast::{AttrStyle, MetaItemKind, ast};
 use rustc_attr_parsing::{AttributeParser, Late};
 use rustc_data_structures::fx::FxHashMap;
+use rustc_data_structures::thin_vec::ThinVec;
 use rustc_errors::{DiagCtxtHandle, IntoDiagArg, MultiSpan, StashKey};
 use rustc_feature::{
     ACCEPTED_LANG_FEATURES, AttributeDuplicates, AttributeType, BUILTIN_ATTRIBUTE_MAP,
@@ -211,6 +212,9 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                 Attribute::Parsed(AttributeKind::MacroExport { span, .. }) => {
                     self.check_macro_export(hir_id, *span, target)
                 },
+                Attribute::Parsed(AttributeKind::RustcLegacyConstGenerics{attr_span, fn_indexes}) => {
+                    self.check_rustc_legacy_const_generics(item, *attr_span, fn_indexes)
+                },
                 Attribute::Parsed(AttributeKind::Doc(attr)) => self.check_doc_attrs(attr, hir_id, target),
                 Attribute::Parsed(AttributeKind::EiiImpls(impls)) => {
                      self.check_eii_impl(impls, target)
@@ -305,9 +309,6 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                         }
                         [sym::rustc_never_returns_null_ptr, ..] => {
                             self.check_applied_to_fn_or_method(hir_id, attr.span(), span, target)
-                        }
-                        [sym::rustc_legacy_const_generics, ..] => {
-                            self.check_rustc_legacy_const_generics(hir_id, attr, span, target, item)
                         }
                         [sym::rustc_lint_query_instability, ..] => {
                             self.check_applied_to_fn_or_method(hir_id, attr.span(), span, target)
@@ -1218,33 +1219,17 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
     /// Checks if `#[rustc_legacy_const_generics]` is applied to a function and has a valid argument.
     fn check_rustc_legacy_const_generics(
         &self,
-        hir_id: HirId,
-        attr: &Attribute,
-        span: Span,
-        target: Target,
         item: Option<ItemLike<'_>>,
+        attr_span: Span,
+        index_list: &ThinVec<(usize, Span)>,
     ) {
-        let is_function = matches!(target, Target::Fn);
-        if !is_function {
-            self.dcx().emit_err(errors::AttrShouldBeAppliedToFn {
-                attr_span: attr.span(),
-                defn_span: span,
-                on_crate: hir_id == CRATE_HIR_ID,
-            });
-            return;
-        }
-
-        let Some(list) = attr.meta_item_list() else {
-            // The attribute form is validated on AST.
-            return;
-        };
-
         let Some(ItemLike::Item(Item {
             kind: ItemKind::Fn { sig: FnSig { decl, .. }, generics, .. },
             ..
         })) = item
         else {
-            bug!("should be a function item");
+            // No error here, since it's already given by the parser
+            return;
         };
 
         for param in generics.params {
@@ -1252,7 +1237,7 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                 hir::GenericParamKind::Const { .. } => {}
                 _ => {
                     self.dcx().emit_err(errors::RustcLegacyConstGenericsOnly {
-                        attr_span: attr.span(),
+                        attr_span,
                         param_span: param.span,
                     });
                     return;
@@ -1260,33 +1245,22 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
             }
         }
 
-        if list.len() != generics.params.len() {
+        if index_list.len() != generics.params.len() {
             self.dcx().emit_err(errors::RustcLegacyConstGenericsIndex {
-                attr_span: attr.span(),
+                attr_span,
                 generics_span: generics.span,
             });
             return;
         }
 
-        let arg_count = decl.inputs.len() as u128 + generics.params.len() as u128;
-        let mut invalid_args = vec![];
-        for meta in list {
-            if let Some(LitKind::Int(val, _)) = meta.lit().map(|lit| &lit.kind) {
-                if *val >= arg_count {
-                    let span = meta.span();
-                    self.dcx().emit_err(errors::RustcLegacyConstGenericsIndexExceed {
-                        span,
-                        arg_count: arg_count as usize,
-                    });
-                    return;
-                }
-            } else {
-                invalid_args.push(meta.span());
+        let arg_count = decl.inputs.len() + generics.params.len();
+        for (index, span) in index_list {
+            if *index >= arg_count {
+                self.dcx().emit_err(errors::RustcLegacyConstGenericsIndexExceed {
+                    span: *span,
+                    arg_count,
+                });
             }
-        }
-
-        if !invalid_args.is_empty() {
-            self.dcx().emit_err(errors::RustcLegacyConstGenericsIndexNegative { invalid_args });
         }
     }
 

--- a/compiler/rustc_passes/src/errors.rs
+++ b/compiler/rustc_passes/src/errors.rs
@@ -291,13 +291,6 @@ pub(crate) struct RustcLegacyConstGenericsIndexExceed {
 }
 
 #[derive(Diagnostic)]
-#[diag(passes_rustc_legacy_const_generics_index_negative)]
-pub(crate) struct RustcLegacyConstGenericsIndexNegative {
-    #[primary_span]
-    pub invalid_args: Vec<Span>,
-}
-
-#[derive(Diagnostic)]
 #[diag(passes_rustc_dirty_clean)]
 pub(crate) struct RustcDirtyClean {
     #[primary_span]

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -44,7 +44,7 @@ use rustc_arena::{DroplessArena, TypedArena};
 use rustc_ast::node_id::NodeMap;
 use rustc_ast::{
     self as ast, AngleBracketedArg, CRATE_NODE_ID, Crate, Expr, ExprKind, GenericArg, GenericArgs,
-    LitKind, NodeId, Path, attr,
+    NodeId, Path, attr,
 };
 use rustc_data_structures::fx::{FxHashMap, FxHashSet, FxIndexMap, FxIndexSet};
 use rustc_data_structures::intern::Interned;
@@ -54,7 +54,7 @@ use rustc_data_structures::unord::{UnordMap, UnordSet};
 use rustc_errors::{Applicability, Diag, ErrCode, ErrorGuaranteed, LintBuffer};
 use rustc_expand::base::{DeriveResolution, SyntaxExtension, SyntaxExtensionKind};
 use rustc_feature::BUILTIN_ATTRIBUTES;
-use rustc_hir::attrs::StrippedCfgItem;
+use rustc_hir::attrs::{AttributeKind, StrippedCfgItem};
 use rustc_hir::def::Namespace::{self, *};
 use rustc_hir::def::{
     self, CtorOf, DefKind, DocLinkResMap, LifetimeRes, MacroKinds, NonMacroAttrKind, PartialRes,
@@ -62,7 +62,7 @@ use rustc_hir::def::{
 };
 use rustc_hir::def_id::{CRATE_DEF_ID, CrateNum, DefId, LOCAL_CRATE, LocalDefId, LocalDefIdMap};
 use rustc_hir::definitions::DisambiguatorState;
-use rustc_hir::{PrimTy, TraitCandidate};
+use rustc_hir::{PrimTy, TraitCandidate, find_attr};
 use rustc_index::bit_set::DenseBitSet;
 use rustc_metadata::creader::CStore;
 use rustc_middle::metadata::{AmbigModChild, ModChild, Reexport};
@@ -1676,8 +1676,8 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             node_id_to_def_id,
             disambiguator: DisambiguatorState::new(),
             placeholder_field_indices: Default::default(),
-            invocation_parents,
             legacy_const_generic_args: Default::default(),
+            invocation_parents,
             item_generics_num_lifetimes: Default::default(),
             trait_impls: Default::default(),
             confused_type_with_std_module: Default::default(),
@@ -2396,40 +2396,33 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
     /// `#[rustc_legacy_const_generics]` and returns the argument index list
     /// from the attribute.
     fn legacy_const_generic_args(&mut self, expr: &Expr) -> Option<Vec<usize>> {
-        if let ExprKind::Path(None, path) = &expr.kind {
-            // Don't perform legacy const generics rewriting if the path already
-            // has generic arguments.
-            if path.segments.last().unwrap().args.is_some() {
-                return None;
-            }
-
-            let res = self.partial_res_map.get(&expr.id)?.full_res()?;
-            if let Res::Def(def::DefKind::Fn, def_id) = res {
-                // We only support cross-crate argument rewriting. Uses
-                // within the same crate should be updated to use the new
-                // const generics style.
-                if def_id.is_local() {
-                    return None;
-                }
-
-                if let Some(v) = self.legacy_const_generic_args.get(&def_id) {
-                    return v.clone();
-                }
-
-                let attr = self.tcx.get_attr(def_id, sym::rustc_legacy_const_generics)?;
-                let mut ret = Vec::new();
-                for meta in attr.meta_item_list()? {
-                    match meta.lit()?.kind {
-                        LitKind::Int(a, _) => ret.push(a.get() as usize),
-                        _ => panic!("invalid arg index"),
-                    }
-                }
-                // Cache the lookup to avoid parsing attributes for an item multiple times.
-                self.legacy_const_generic_args.insert(def_id, Some(ret.clone()));
-                return Some(ret);
-            }
+        let ExprKind::Path(None, path) = &expr.kind else {
+            return None;
+        };
+        // Don't perform legacy const generics rewriting if the path already
+        // has generic arguments.
+        if path.segments.last().unwrap().args.is_some() {
+            return None;
         }
-        None
+
+        let def_id = self.partial_res_map.get(&expr.id)?.full_res()?.opt_def_id()?;
+
+        // We only support cross-crate argument rewriting. Uses
+        // within the same crate should be updated to use the new
+        // const generics style.
+        if def_id.is_local() {
+            return None;
+        }
+
+        let indexes = find_attr!(
+            // we can use parsed attrs here since for other crates they're already available
+            self.tcx.get_all_attrs(def_id),
+            AttributeKind::RustcLegacyConstGenerics{fn_indexes,..} => fn_indexes
+        )
+        .map(|fn_indexes| fn_indexes.iter().map(|(num, _)| *num).collect());
+
+        self.legacy_const_generic_args.insert(def_id, indexes.clone());
+        indexes
     }
 
     fn resolve_main(&mut self) {

--- a/tests/ui/invalid/invalid-rustc_legacy_const_generics-arguments.rs
+++ b/tests/ui/invalid/invalid-rustc_legacy_const_generics-arguments.rs
@@ -9,20 +9,24 @@ fn foo2<const X: usize>() {}
 #[rustc_legacy_const_generics(2)] //~ ERROR index exceeds number of arguments
 fn foo3<const X: usize>(_: u8) {}
 
-#[rustc_legacy_const_generics(a)] //~ ERROR arguments should be non-negative integers
+#[rustc_legacy_const_generics(a)] //~ ERROR  malformed `rustc_legacy_const_generics` attribute input
 fn foo4<const X: usize>() {}
 
-#[rustc_legacy_const_generics(1, a, 2, b)] //~ ERROR arguments should be non-negative integers
+#[rustc_legacy_const_generics(1, a, 2, b)]
+//~^ ERROR malformed `rustc_legacy_const_generics` attribute input
+//~^^ ERROR malformed `rustc_legacy_const_generics` attribute input
 fn foo5<const X: usize, const Y: usize, const Z: usize, const W: usize>() {}
 
-#[rustc_legacy_const_generics(0)] //~ ERROR attribute should be applied to a function
+#[rustc_legacy_const_generics(0)] //~ ERROR `#[rustc_legacy_const_generics]` attribute cannot be used on structs
 struct S;
 
-#[rustc_legacy_const_generics(0usize)] //~ ERROR suffixed literals are not allowed in attributes
+#[rustc_legacy_const_generics(0usize)]
+//~^ ERROR suffixed literals are not allowed in attributes
+//~^^ ERROR malformed `rustc_legacy_const_generics` attribute input
 fn foo6<const X: usize>() {}
 
 extern "C" {
-    #[rustc_legacy_const_generics(1)] //~ ERROR attribute should be applied to a function
+    #[rustc_legacy_const_generics(1)] //~ ERROR `#[rustc_legacy_const_generics]` attribute cannot be used on foreign functions
     fn foo7<const X: usize>(); //~ ERROR foreign items may not have const parameters
 }
 
@@ -30,14 +34,14 @@ extern "C" {
 fn foo8<X>() {}
 
 impl S {
-    #[rustc_legacy_const_generics(0)] //~ ERROR attribute should be applied to a function
+    #[rustc_legacy_const_generics(0)] //~ ERROR `#[rustc_legacy_const_generics]` attribute cannot be used on inherent methods
     fn foo9<const X: usize>() {}
 }
 
-#[rustc_legacy_const_generics] //~ ERROR malformed `rustc_legacy_const_generics` attribute
+#[rustc_legacy_const_generics] //~ ERROR malformed `rustc_legacy_const_generics` attribute input
 fn bar1() {}
 
-#[rustc_legacy_const_generics = 1] //~ ERROR malformed `rustc_legacy_const_generics` attribute
+#[rustc_legacy_const_generics = 1] //~ ERROR malformed `rustc_legacy_const_generics` attribute input
 fn bar2() {}
 
 fn main() {}

--- a/tests/ui/invalid/invalid-rustc_legacy_const_generics-arguments.stderr
+++ b/tests/ui/invalid/invalid-rustc_legacy_const_generics-arguments.stderr
@@ -1,22 +1,88 @@
+error[E0539]: malformed `rustc_legacy_const_generics` attribute input
+  --> $DIR/invalid-rustc_legacy_const_generics-arguments.rs:12:1
+   |
+LL | #[rustc_legacy_const_generics(a)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-^^
+   | |                             |
+   | |                             expected an integer literal here
+   | help: must be of the form: `#[rustc_legacy_const_generics(N)]`
+
+error[E0539]: malformed `rustc_legacy_const_generics` attribute input
+  --> $DIR/invalid-rustc_legacy_const_generics-arguments.rs:15:1
+   |
+LL | #[rustc_legacy_const_generics(1, a, 2, b)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-^^^^^^^^
+   | |                                |
+   | |                                expected an integer literal here
+   | help: must be of the form: `#[rustc_legacy_const_generics(N)]`
+
+error[E0539]: malformed `rustc_legacy_const_generics` attribute input
+  --> $DIR/invalid-rustc_legacy_const_generics-arguments.rs:15:1
+   |
+LL | #[rustc_legacy_const_generics(1, a, 2, b)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-^^
+   | |                                      |
+   | |                                      expected an integer literal here
+   | help: must be of the form: `#[rustc_legacy_const_generics(N)]`
+
+error: `#[rustc_legacy_const_generics]` attribute cannot be used on structs
+  --> $DIR/invalid-rustc_legacy_const_generics-arguments.rs:20:1
+   |
+LL | #[rustc_legacy_const_generics(0)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[rustc_legacy_const_generics]` can only be applied to functions
+
 error: suffixed literals are not allowed in attributes
-  --> $DIR/invalid-rustc_legacy_const_generics-arguments.rs:21:31
+  --> $DIR/invalid-rustc_legacy_const_generics-arguments.rs:23:31
    |
 LL | #[rustc_legacy_const_generics(0usize)]
    |                               ^^^^^^
    |
    = help: instead of using a suffixed literal (`1u8`, `1.0f32`, etc.), use an unsuffixed version (`1`, `1.0`, etc.)
 
-error: malformed `rustc_legacy_const_generics` attribute input
-  --> $DIR/invalid-rustc_legacy_const_generics-arguments.rs:37:1
+error[E0539]: malformed `rustc_legacy_const_generics` attribute input
+  --> $DIR/invalid-rustc_legacy_const_generics-arguments.rs:23:1
+   |
+LL | #[rustc_legacy_const_generics(0usize)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^------^^
+   | |                             |
+   | |                             expected an integer literal here
+   | help: must be of the form: `#[rustc_legacy_const_generics(N)]`
+
+error: `#[rustc_legacy_const_generics]` attribute cannot be used on foreign functions
+  --> $DIR/invalid-rustc_legacy_const_generics-arguments.rs:29:5
+   |
+LL |     #[rustc_legacy_const_generics(1)]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[rustc_legacy_const_generics]` can only be applied to functions
+
+error: `#[rustc_legacy_const_generics]` attribute cannot be used on inherent methods
+  --> $DIR/invalid-rustc_legacy_const_generics-arguments.rs:37:5
+   |
+LL |     #[rustc_legacy_const_generics(0)]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[rustc_legacy_const_generics]` can only be applied to functions
+
+error[E0539]: malformed `rustc_legacy_const_generics` attribute input
+  --> $DIR/invalid-rustc_legacy_const_generics-arguments.rs:41:1
    |
 LL | #[rustc_legacy_const_generics]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: must be of the form: `#[rustc_legacy_const_generics(N)]`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | |
+   | expected this to be a list
+   | help: must be of the form: `#[rustc_legacy_const_generics(N)]`
 
-error: malformed `rustc_legacy_const_generics` attribute input
-  --> $DIR/invalid-rustc_legacy_const_generics-arguments.rs:40:1
+error[E0539]: malformed `rustc_legacy_const_generics` attribute input
+  --> $DIR/invalid-rustc_legacy_const_generics-arguments.rs:44:1
    |
 LL | #[rustc_legacy_const_generics = 1]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: must be of the form: `#[rustc_legacy_const_generics(N)]`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---^
+   | |                             |
+   | |                             expected this to be a list
+   | help: must be of the form: `#[rustc_legacy_const_generics(N)]`
 
 error: #[rustc_legacy_const_generics] must have one index for each generic parameter
   --> $DIR/invalid-rustc_legacy_const_generics-arguments.rs:3:1
@@ -38,58 +104,23 @@ error: index exceeds number of arguments
 LL | #[rustc_legacy_const_generics(2)]
    |                               ^ there are only 2 arguments
 
-error: arguments should be non-negative integers
-  --> $DIR/invalid-rustc_legacy_const_generics-arguments.rs:12:31
-   |
-LL | #[rustc_legacy_const_generics(a)]
-   |                               ^
-
-error: arguments should be non-negative integers
-  --> $DIR/invalid-rustc_legacy_const_generics-arguments.rs:15:34
-   |
-LL | #[rustc_legacy_const_generics(1, a, 2, b)]
-   |                                  ^     ^
-
-error: attribute should be applied to a function definition
-  --> $DIR/invalid-rustc_legacy_const_generics-arguments.rs:18:1
-   |
-LL | #[rustc_legacy_const_generics(0)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-LL | struct S;
-   | --------- not a function definition
-
 error: #[rustc_legacy_const_generics] functions must only have const generics
-  --> $DIR/invalid-rustc_legacy_const_generics-arguments.rs:29:1
+  --> $DIR/invalid-rustc_legacy_const_generics-arguments.rs:33:1
    |
 LL | #[rustc_legacy_const_generics(0)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 LL | fn foo8<X>() {}
    |         - non-const generic parameter
 
-error: attribute should be applied to a function definition
-  --> $DIR/invalid-rustc_legacy_const_generics-arguments.rs:33:5
-   |
-LL |     #[rustc_legacy_const_generics(0)]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-LL |     fn foo9<const X: usize>() {}
-   |     ---------------------------- not a function definition
-
-error: attribute should be applied to a function definition
-  --> $DIR/invalid-rustc_legacy_const_generics-arguments.rs:25:5
-   |
-LL |     #[rustc_legacy_const_generics(1)]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-LL |     fn foo7<const X: usize>();
-   |     -------------------------- not a function definition
-
 error[E0044]: foreign items may not have const parameters
-  --> $DIR/invalid-rustc_legacy_const_generics-arguments.rs:26:5
+  --> $DIR/invalid-rustc_legacy_const_generics-arguments.rs:30:5
    |
 LL |     fn foo7<const X: usize>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ can't have const parameters
    |
    = help: replace the const parameters with concrete consts
 
-error: aborting due to 13 previous errors
+error: aborting due to 15 previous errors
 
-For more information about this error, try `rustc --explain E0044`.
+Some errors have detailed explanations: E0044, E0539.
+For more information about an error, try `rustc --explain E0044`.


### PR DESCRIPTION
Small PR that ports the `#[rustc_legacy_const_generics]` to use the new attribute parser!

r? JonathanBrouwer