### PR TITLE
Enable llvm-libunwind by default for Hexagon targets

### DIFF
--- a/library/unwind/src/lib.rs
+++ b/library/unwind/src/lib.rs
@@ -73,8 +73,25 @@ cfg_select! {
     }
     _ => {
         #[link(name = "unwind", kind = "static", modifiers = "-bundle", cfg(target_feature = "crt-static"))]
-        #[link(name = "gcc_s", cfg(not(target_feature = "crt-static")))]
+        #[link(name = "gcc_s", cfg(all(not(target_feature = "crt-static"), not(target_arch = "hexagon"))))]
         unsafe extern "C" {}
+    }
+}
+
+// Hexagon with musl uses llvm-libunwind by default
+#[cfg(all(target_env = "musl", target_arch = "hexagon"))]
+cfg_select! {
+    feature = "llvm-libunwind" => {
+        #[link(name = "unwind", kind = "static", modifiers = "-bundle")]
+        unsafe extern "C" {}
+    }
+    feature = "system-llvm-libunwind" => {
+        #[link(name = "unwind", kind = "static", modifiers = "-bundle", cfg(target_feature = "crt-static"))]
+        #[link(name = "unwind", cfg(not(target_feature = "crt-static")))]
+        unsafe extern "C" {}
+    }
+    _ => {
+        // Fallback: should not happen since hexagon defaults to llvm-libunwind
     }
 }
 

--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -354,7 +354,10 @@ fn copy_third_party_objects(
 
     if target == "x86_64-fortanix-unknown-sgx"
         || builder.config.llvm_libunwind(target) == LlvmLibunwind::InTree
-            && (target.contains("linux") || target.contains("fuchsia") || target.contains("aix"))
+            && (target.contains("linux")
+                || target.contains("fuchsia")
+                || target.contains("aix")
+                || target.contains("hexagon"))
     {
         let libunwind_path =
             copy_llvm_libunwind(builder, target, &builder.sysroot_target_libdir(*compiler, target));

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -1851,7 +1851,7 @@ impl Config {
             .get(&target)
             .and_then(|t| t.llvm_libunwind)
             .or(self.llvm_libunwind_default)
-            .unwrap_or(if target.contains("fuchsia") {
+            .unwrap_or(if target.contains("fuchsia") || target.contains("hexagon") {
                 LlvmLibunwind::InTree
             } else {
                 LlvmLibunwind::No


### PR DESCRIPTION
Fixes library linking issues where libgcc_s was incorrectly being linked instead of the appropriate LLVM runtime libraries for Hexagon targets.

* Set llvm-libunwind as default for all hexagon targets in bootstrap
* Exclude hexagon from automatic libgcc_s linking in unwind
* Enable libunwind.a copying for hexagon targets
* Remove manual library linking from hexagon target specification

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
