### PR TITLE
document that mpmc channels deliver an item to (at most) one receiver

### DIFF
--- a/library/std/src/sync/mpmc/mod.rs
+++ b/library/std/src/sync/mpmc/mod.rs
@@ -6,9 +6,10 @@
 //! * [`Sender`]
 //! * [`Receiver`]
 //!
-//! [`Sender`]s are used to send data to a set of [`Receiver`]s. Both
-//! sender and receiver are cloneable (multi-producer) such that many threads can send
-//! simultaneously to receivers (multi-consumer).
+//! [`Sender`]s are used to send data to a set of [`Receiver`]s where each item
+//! sent is delivered to (at most) one receiver. Both sender and receiver are
+//! cloneable (multi-producer) such that many threads can send simultaneously
+//! to receivers (multi-consumer).
 //!
 //! These channels come in two flavors:
 //!


### PR DESCRIPTION
Tiny documentation change related to mpmc (tracking issue rust-lang/rust#126840).

This PR is meant to supersede rust-lang/rust#140158 due to it's inactivity. It is essentially the same addition structured a little differently.