### PR TITLE
Generate macro expansion for rust compiler crates docs

### DIFF
--- a/src/bootstrap/src/core/build_steps/doc.rs
+++ b/src/bootstrap/src/core/build_steps/doc.rs
@@ -932,6 +932,7 @@ impl Step for Rustc {
         // see https://github.com/rust-lang/rust/pull/122066#issuecomment-1983049222
         // If there is any bug, please comment out the next line.
         cargo.rustdocflag("--generate-link-to-definition");
+        cargo.rustdocflag("--generate-macro-expansion");
 
         compile::rustc_cargo(builder, &mut cargo, target, &build_compiler, &self.crates);
         cargo.arg("-Zskip-rustdoc-fingerprint");


### PR DESCRIPTION
This enables the `--generate-macro-expansion` rustdoc flag, generating possibility to expand macros directly in source code pages (https://github.com/rust-lang/rust/pull/137229).

Needed this new feature when I was working on https://github.com/rust-lang/rust/pull/149919 and I thought "why not enable it by default?". So here we go.

Not too sure who to r? here so:

r? @kobzol