### PR TITLE
Fix macro_metavar_expr_concat behavior with nested repetitions

### DIFF
--- a/tests/ui/macros/concat-nested-repetition.rs
+++ b/tests/ui/macros/concat-nested-repetition.rs
@@ -1,0 +1,35 @@
+//@ check-pass
+#![feature(macro_metavar_expr_concat)]
+
+struct A;
+struct B;
+const AA: A = A;
+const BB: B = B;
+
+macro_rules! define_ioctl_data {
+    (struct $s:ident {
+        $($field:ident: $ty:ident $([$opt:ident])?,)*
+    }) => {
+        pub struct $s {
+            $($field: $ty,)*
+        }
+
+        impl $s {
+            $($(
+                fn ${concat(get_, $field)}(&self) -> $ty {
+                    let _ = $opt;
+                    todo!()
+                }
+            )?)*
+        }
+    };
+}
+
+define_ioctl_data! {
+    struct Foo {
+        a: A [AA],
+        b: B [BB],
+    }
+}
+
+fn main() {}

--- a/tests/ui/macros/macro-metavar-expr-concat/in-repetition.rs
+++ b/tests/ui/macros/macro-metavar-expr-concat/in-repetition.rs
@@ -11,7 +11,7 @@ macro_rules! InRepetition {
      ) => {
         $(
             $(
-                ${concat(_, $arg)} //~ ERROR nested repetitions with `${concat(...)}` metavariable expressions are not yet supported
+                ${concat(_, $arg)} //~ ERROR macro expansion ends with an incomplete expression: expected one of `!` or `::`
             )*
         )*
     };

--- a/tests/ui/macros/macro-metavar-expr-concat/in-repetition.stderr
+++ b/tests/ui/macros/macro-metavar-expr-concat/in-repetition.stderr
@@ -1,8 +1,8 @@
-error: nested repetitions with `${concat(...)}` metavariable expressions are not yet supported
-  --> $DIR/in-repetition.rs:14:30
+error: macro expansion ends with an incomplete expression: expected one of `!` or `::`
+  --> $DIR/in-repetition.rs:14:35
    |
 LL |                 ${concat(_, $arg)}
-   |                              ^^^
+   |                                   ^ expected one of `!` or `::`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/macros/metavar-expressions/concat-repetitions.rs
+++ b/tests/ui/macros/metavar-expressions/concat-repetitions.rs
@@ -11,8 +11,7 @@ macro_rules! one_rep {
 macro_rules! issue_128346 {
     ( $($a:ident)* ) => {
         A(
-            const ${concat($a, Z)}: i32 = 3;
-            //~^ ERROR invalid syntax
+            const ${concat($a, Z)}: i32 = 3; //~ ERROR `${concat(...)}` variable is still repeating at this depth
         )*
     };
 }
@@ -20,8 +19,8 @@ macro_rules! issue_128346 {
 macro_rules! issue_131393 {
     ($t:ident $($en:ident)?) => {
         read::<${concat($t, $en)}>()
-        //~^ ERROR invalid syntax
-        //~| ERROR invalid syntax
+        //~^ ERROR `${concat(...)}` variable is still repeating at this depth
+        //~| ERROR `${concat(...)}` variable is still repeating at this depth
     }
 }
 

--- a/tests/ui/macros/metavar-expressions/concat-repetitions.stderr
+++ b/tests/ui/macros/metavar-expressions/concat-repetitions.stderr
@@ -1,20 +1,20 @@
-error: invalid syntax
-  --> $DIR/concat-repetitions.rs:14:20
+error: `${concat(...)}` variable is still repeating at this depth
+  --> $DIR/concat-repetitions.rs:14:29
    |
 LL |             const ${concat($a, Z)}: i32 = 3;
-   |                    ^^^^^^^^^^^^^^^
+   |                             ^
 
-error: invalid syntax
-  --> $DIR/concat-repetitions.rs:22:17
+error: `${concat(...)}` variable is still repeating at this depth
+  --> $DIR/concat-repetitions.rs:21:30
    |
 LL |         read::<${concat($t, $en)}>()
-   |                 ^^^^^^^^^^^^^^^^^
+   |                              ^^
 
-error: invalid syntax
-  --> $DIR/concat-repetitions.rs:22:17
+error: `${concat(...)}` variable is still repeating at this depth
+  --> $DIR/concat-repetitions.rs:21:30
    |
 LL |         read::<${concat($t, $en)}>()
-   |                 ^^^^^^^^^^^^^^^^^
+   |                              ^^
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 


### PR DESCRIPTION
**The Bug**: The `${concat(...)}` expression was using the wrong loop index when inside nested repetitions (like optional groups), causing it to get "stuck" on the first element and generate duplicate code.

**The Fix**: Updated `metavar_expr_concat` in `transcribe.rs` to correctly search the repetition stack (`tscx.repeats`) for the target variable instead of blindly using the last index.

**Tests**:
    Added `tests/ui/macros/concat-nested-repetition.rs.`

Fixes rust-lang/rust#150002
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
