### PR TITLE
Add convenient constructor for building `DropGuard<(), FnOnce(())>`

### DIFF
--- a/library/core/src/mem/drop_guard.rs
+++ b/library/core/src/mem/drop_guard.rs
@@ -19,7 +19,9 @@ use crate::ops::{Deref, DerefMut};
 /// {
 ///     // Create a new guard that will do something
 ///     // when dropped.
-///     defer! { println!("Goodbye, world!") };
+///     defer! {
+///         println!("Goodbye, world!");
+///     }
 ///
 ///     // The guard will be dropped here, printing:
 ///     // "Goodbye, world!"

--- a/library/core/src/mem/drop_guard.rs
+++ b/library/core/src/mem/drop_guard.rs
@@ -85,11 +85,8 @@ where
     /// ```
     #[unstable(feature = "drop_guard", issue = "144426")]
     #[must_use]
-    pub const fn new(value: T, f: F) -> DropGuard<T, F>
-    where
-        F: FnOnce(T),
-    {
-        DropGuard { inner: ManuallyDrop::new(value), f: ManuallyDrop::new(f) }
+    pub const fn new(inner: T, f: F) -> Self {
+        Self { inner: ManuallyDrop::new(inner), f: ManuallyDrop::new(f) }
     }
 
     /// Consumes the `DropGuard`, returning the wrapped value.

--- a/library/core/src/mem/drop_guard.rs
+++ b/library/core/src/mem/drop_guard.rs
@@ -73,7 +73,9 @@ where
 ///
 /// use std::mem::defer;
 ///
-/// defer! { println!("Goodbye, world!") };
+/// defer! {
+///     println!("Goodbye, world!");
+/// }
 /// ```
 #[unstable(feature = "drop_guard", issue = "144426")]
 pub macro defer($($t:tt)*) {

--- a/library/core/src/mem/drop_guard.rs
+++ b/library/core/src/mem/drop_guard.rs
@@ -19,7 +19,16 @@ use crate::ops::{Deref, DerefMut};
 /// {
 ///     // Create a new guard that will do something
 ///     // when dropped.
-///     let _guard = defer! { println!("Goodbye, world!") };
+///     defer! { println!("Goodbye, world!") };
+///
+///     // The guard will be dropped here, printing:
+///     // "Goodbye, world!"
+/// }
+///
+/// {
+///     // Create a new guard that will do something
+///     // when dropped.
+///     let _guard = DropGuard::new(|| println!("Goodbye, world!"));
 ///
 ///     // The guard will be dropped here, printing:
 ///     // "Goodbye, world!"
@@ -29,7 +38,7 @@ use crate::ops::{Deref, DerefMut};
 ///     // Create a new guard around a string that will
 ///     // print its value when dropped.
 ///     let s = String::from("Chashu likes tuna");
-///     let mut s = DropGuard::new(s, |s| println!("{s}"));
+///     let mut s = DropGuard::with_value(s, |s| println!("{s}"));
 ///
 ///     // Modify the string contained in the guard.
 ///     s.push_str("!!!");
@@ -41,7 +50,7 @@ use crate::ops::{Deref, DerefMut};
 #[unstable(feature = "drop_guard", issue = "144426")]
 #[doc(alias = "ScopeGuard")]
 #[doc(alias = "defer")]
-pub struct DropGuard<T, F>
+pub struct DropGuard<T = (), F = UnitFn<fn()>>
 where
     F: FnOnce(T),
 {
@@ -49,7 +58,10 @@ where
     f: ManuallyDrop<F>,
 }
 
-/// Create a new instance of `DropGuard` with a cleanup closure.
+/// Create an anonymous `DropGuard` with a cleanup closure.
+///
+/// The macro takes statements, which are the body of a closure
+/// that will run when the scope is exited.
 ///
 /// # Example
 ///
@@ -59,11 +71,34 @@ where
 ///
 /// use std::mem::defer;
 ///
-/// let _guard = defer! { println!("Goodbye, world!") };
+/// defer! { println!("Goodbye, world!") };
 /// ```
 #[unstable(feature = "drop_guard", issue = "144426")]
 pub macro defer($($t:tt)*) {
-    $crate::mem::DropGuard::new((), |()| { $($t)* })
+    let _guard = $crate::mem::DropGuard::new(|| { $($t)* });
+}
+
+impl<F> DropGuard<(), UnitFn<F>>
+where
+    F: FnOnce(),
+{
+    /// Create a new instance of `DropGuard` with a cleanup closure.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # #![allow(unused)]
+    /// #![feature(drop_guard)]
+    ///
+    /// use std::mem::DropGuard;
+    ///
+    /// let guard = DropGuard::new(|| println!("Goodbye, world!"));
+    /// ```
+    #[unstable(feature = "drop_guard", issue = "144426")]
+    #[must_use]
+    pub const fn new(f: F) -> Self {
+        Self { inner: ManuallyDrop::new(()), f: ManuallyDrop::new(UnitFn(f)) }
+    }
 }
 
 impl<T, F> DropGuard<T, F>
@@ -81,11 +116,11 @@ where
     /// use std::mem::DropGuard;
     ///
     /// let value = String::from("Chashu likes tuna");
-    /// let guard = DropGuard::new(value, |s| println!("{s}"));
+    /// let guard = DropGuard::with_value(value, |s| println!("{s}"));
     /// ```
     #[unstable(feature = "drop_guard", issue = "144426")]
     #[must_use]
-    pub const fn new(inner: T, f: F) -> Self {
+    pub const fn with_value(inner: T, f: F) -> Self {
         Self { inner: ManuallyDrop::new(inner), f: ManuallyDrop::new(f) }
     }
 
@@ -105,7 +140,7 @@ where
     /// use std::mem::DropGuard;
     ///
     /// let value = String::from("Nori likes chicken");
-    /// let guard = DropGuard::new(value, |s| println!("{s}"));
+    /// let guard = DropGuard::with_value(value, |s| println!("{s}"));
     /// assert_eq!(DropGuard::dismiss(guard), "Nori likes chicken");
     /// ```
     #[unstable(feature = "drop_guard", issue = "144426")]
@@ -183,5 +218,30 @@ where
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Debug::fmt(&**self, f)
+    }
+}
+
+#[unstable(feature = "drop_guard", issue = "144426")]
+pub struct UnitFn<F>(F);
+
+#[unstable(feature = "drop_guard", issue = "144426")]
+impl<F> FnOnce<((),)> for UnitFn<F>
+where
+    F: FnOnce(),
+{
+    type Output = ();
+
+    extern "rust-call" fn call_once(self, _args: ((),)) -> Self::Output {
+        (self.0)()
+    }
+}
+
+#[unstable(feature = "drop_guard", issue = "144426")]
+impl<F> Debug for UnitFn<F>
+where
+    F: FnOnce(),
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "UnitFn")
     }
 }

--- a/library/core/src/mem/drop_guard.rs
+++ b/library/core/src/mem/drop_guard.rs
@@ -19,7 +19,7 @@ use crate::ops::{Deref, DerefMut};
 /// {
 ///     // Create a new guard that will do something
 ///     // when dropped.
-///     let _guard = defer(|| println!("Goodbye, world!"));
+///     let _guard = defer! { println!("Goodbye, world!") };
 ///
 ///     // The guard will be dropped here, printing:
 ///     // "Goodbye, world!"
@@ -59,12 +59,11 @@ where
 ///
 /// use std::mem::defer;
 ///
-/// let guard = defer(|| println!("Goodbye, world!"));
+/// let _guard = defer! { println!("Goodbye, world!") };
 /// ```
 #[unstable(feature = "drop_guard", issue = "144426")]
-#[must_use]
-pub const fn defer(f: impl FnOnce()) -> DropGuard<(), impl FnOnce(())> {
-    guard((), move |_| f())
+pub macro defer($($t:tt)*) {
+    $crate::mem::DropGuard::new((), |()| { $($t)* })
 }
 
 impl<T, F> DropGuard<T, F>
@@ -86,7 +85,7 @@ where
     /// ```
     #[unstable(feature = "drop_guard", issue = "144426")]
     #[must_use]
-    pub const fn new<T, F>(value: T, f: F) -> DropGuard<T, F>
+    pub const fn new(value: T, f: F) -> DropGuard<T, F>
     where
         F: FnOnce(T),
     {

--- a/library/core/src/mem/drop_guard.rs
+++ b/library/core/src/mem/drop_guard.rs
@@ -16,10 +16,19 @@ use crate::ops::{Deref, DerefMut};
 /// use std::mem::DropGuard;
 ///
 /// {
+///     // Create a new guard that will do something
+///     // when dropped.
+///     let _guard = DropGuard::new(|()| println!("Goodbye, world!"));
+///
+///     // The guard will be dropped here, printing:
+///     // "Goodbye, world!"
+/// }
+///
+/// {
 ///     // Create a new guard around a string that will
 ///     // print its value when dropped.
 ///     let s = String::from("Chashu likes tuna");
-///     let mut s = DropGuard::new(s, |s| println!("{s}"));
+///     let mut s = DropGuard::new_with(s, |s| println!("{s}"));
 ///
 ///     // Modify the string contained in the guard.
 ///     s.push_str("!!!");
@@ -39,11 +48,34 @@ where
     f: ManuallyDrop<F>,
 }
 
+impl<F> DropGuard<(), F>
+where
+    F: FnOnce(()),
+{
+    /// Create a new instance of `DropGuard` with a cleanup closure.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # #![allow(unused)]
+    /// #![feature(drop_guard)]
+    ///
+    /// use std::mem::DropGuard;
+    ///
+    /// let guard = DropGuard::new(|()| println!("Goodbye, world!"));
+    /// ```
+    #[unstable(feature = "drop_guard", issue = "144426")]
+    #[must_use]
+    pub const fn new(f: F) -> Self {
+        Self { inner: ManuallyDrop::new(()), f: ManuallyDrop::new(f) }
+    }
+}
+
 impl<T, F> DropGuard<T, F>
 where
     F: FnOnce(T),
 {
-    /// Create a new instance of `DropGuard`.
+    /// Create a new instance of `DropGuard` with a value and a cleanup closure.
     ///
     /// # Example
     ///
@@ -54,11 +86,11 @@ where
     /// use std::mem::DropGuard;
     ///
     /// let value = String::from("Chashu likes tuna");
-    /// let guard = DropGuard::new(value, |s| println!("{s}"));
+    /// let guard = DropGuard::new_with(value, |s| println!("{s}"));
     /// ```
     #[unstable(feature = "drop_guard", issue = "144426")]
     #[must_use]
-    pub const fn new(inner: T, f: F) -> Self {
+    pub const fn new_with(inner: T, f: F) -> Self {
         Self { inner: ManuallyDrop::new(inner), f: ManuallyDrop::new(f) }
     }
 
@@ -78,7 +110,7 @@ where
     /// use std::mem::DropGuard;
     ///
     /// let value = String::from("Nori likes chicken");
-    /// let guard = DropGuard::new(value, |s| println!("{s}"));
+    /// let guard = DropGuard::new_with(value, |s| println!("{s}"));
     /// assert_eq!(DropGuard::dismiss(guard), "Nori likes chicken");
     /// ```
     #[unstable(feature = "drop_guard", issue = "144426")]

--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -25,7 +25,7 @@ pub use transmutability::{Assume, TransmuteFrom};
 
 mod drop_guard;
 #[unstable(feature = "drop_guard", issue = "144426")]
-pub use drop_guard::{DropGuard, defer, guard};
+pub use drop_guard::{DropGuard, defer};
 
 // This one has to be a re-export (rather than wrapping the underlying intrinsic) so that we can do
 // the special magic "types have equal size" check at the call site.

--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -25,7 +25,7 @@ pub use transmutability::{Assume, TransmuteFrom};
 
 mod drop_guard;
 #[unstable(feature = "drop_guard", issue = "144426")]
-pub use drop_guard::DropGuard;
+pub use drop_guard::{DropGuard, defer, guard};
 
 // This one has to be a re-export (rather than wrapping the underlying intrinsic) so that we can do
 // the special magic "types have equal size" check at the call site.

--- a/library/coretests/tests/mem.rs
+++ b/library/coretests/tests/mem.rs
@@ -800,9 +800,9 @@ fn const_maybe_uninit_zeroed() {
 #[test]
 fn drop_guards_only_dropped_by_closure_when_run() {
     let value_drops = Cell::new(0);
-    let value = defer! { value_drops.set(1 + value_drops.get()) };
+    let value = DropGuard::new(|| value_drops.set(1 + value_drops.get()));
     let closure_drops = Cell::new(0);
-    let guard = DropGuard::new(value, |_| closure_drops.set(1 + closure_drops.get()));
+    let guard = DropGuard::with_value(value, |_| closure_drops.set(1 + closure_drops.get()));
     assert_eq!(value_drops.get(), 0);
     assert_eq!(closure_drops.get(), 0);
     drop(guard);
@@ -813,8 +813,8 @@ fn drop_guards_only_dropped_by_closure_when_run() {
 #[test]
 fn drop_guard_into_inner() {
     let dropped = Cell::new(false);
-    let value = DropGuard::new(42, |_| dropped.set(true));
-    let guard = DropGuard::new(value, |_| dropped.set(true));
+    let value = DropGuard::with_value(42, |_| dropped.set(true));
+    let guard = DropGuard::with_value(value, |_| dropped.set(true));
     let inner = DropGuard::dismiss(guard);
     assert_eq!(dropped.get(), false);
     assert_eq!(*inner, 42);
@@ -825,10 +825,10 @@ fn drop_guard_into_inner() {
 fn drop_guard_always_drops_value_if_closure_drop_unwinds() {
     // Create a value with a destructor, which we will validate ran successfully.
     let mut value_was_dropped = false;
-    let value_with_tracked_destruction = defer! { value_was_dropped = true };
+    let value_with_tracked_destruction = DropGuard::new(|| value_was_dropped = true);
 
     // Create a closure that will begin unwinding when dropped.
-    let drop_bomb = defer! { panic!() };
+    let drop_bomb = DropGuard::new(|| panic!());
     let closure_that_panics_on_drop = move |_| {
         let _drop_bomb = drop_bomb;
     };
@@ -836,7 +836,8 @@ fn drop_guard_always_drops_value_if_closure_drop_unwinds() {
     // This will run the closure, which will panic when dropped. This should
     // run the destructor of the value we passed, which we validate.
     let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        let guard = DropGuard::new(value_with_tracked_destruction, closure_that_panics_on_drop);
+        let guard =
+            DropGuard::with_value(value_with_tracked_destruction, closure_that_panics_on_drop);
         DropGuard::dismiss(guard);
     }));
     assert!(value_was_dropped);
@@ -845,7 +846,7 @@ fn drop_guard_always_drops_value_if_closure_drop_unwinds() {
 #[test]
 fn defer_moved_value() {
     let data = "owned data".to_string();
-    let _guard = defer! {
+    defer! {
        std::thread::spawn(move || { assert_eq!(data.as_str(), "owned data") }).join().ok();
     };
 }

--- a/library/coretests/tests/mem.rs
+++ b/library/coretests/tests/mem.rs
@@ -800,9 +800,9 @@ fn const_maybe_uninit_zeroed() {
 #[test]
 fn drop_guards_only_dropped_by_closure_when_run() {
     let value_drops = Cell::new(0);
-    let value = DropGuard::new(|()| value_drops.set(1 + value_drops.get()));
+    let value = defer(|| value_drops.set(1 + value_drops.get()));
     let closure_drops = Cell::new(0);
-    let guard = DropGuard::new_with(value, |_| closure_drops.set(1 + closure_drops.get()));
+    let guard = guard(value, |_| closure_drops.set(1 + closure_drops.get()));
     assert_eq!(value_drops.get(), 0);
     assert_eq!(closure_drops.get(), 0);
     drop(guard);
@@ -813,8 +813,8 @@ fn drop_guards_only_dropped_by_closure_when_run() {
 #[test]
 fn drop_guard_into_inner() {
     let dropped = Cell::new(false);
-    let value = DropGuard::new_with(42, |_| dropped.set(true));
-    let guard = DropGuard::new_with(value, |_| dropped.set(true));
+    let value = guard(42, |_| dropped.set(true));
+    let guard = guard(value, |_| dropped.set(true));
     let inner = DropGuard::dismiss(guard);
     assert_eq!(dropped.get(), false);
     assert_eq!(*inner, 42);
@@ -825,10 +825,10 @@ fn drop_guard_into_inner() {
 fn drop_guard_always_drops_value_if_closure_drop_unwinds() {
     // Create a value with a destructor, which we will validate ran successfully.
     let mut value_was_dropped = false;
-    let value_with_tracked_destruction = DropGuard::new(|()| value_was_dropped = true);
+    let value_with_tracked_destruction = defer(|| value_was_dropped = true);
 
     // Create a closure that will begin unwinding when dropped.
-    let drop_bomb = DropGuard::new(|()| panic!());
+    let drop_bomb = defer(|| panic!());
     let closure_that_panics_on_drop = move |_| {
         let _drop_bomb = drop_bomb;
     };
@@ -836,8 +836,7 @@ fn drop_guard_always_drops_value_if_closure_drop_unwinds() {
     // This will run the closure, which will panic when dropped. This should
     // run the destructor of the value we passed, which we validate.
     let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        let guard =
-            DropGuard::new_with(value_with_tracked_destruction, closure_that_panics_on_drop);
+        let guard = guard(value_with_tracked_destruction, closure_that_panics_on_drop);
         DropGuard::dismiss(guard);
     }));
     assert!(value_was_dropped);

--- a/library/coretests/tests/mem.rs
+++ b/library/coretests/tests/mem.rs
@@ -800,9 +800,9 @@ fn const_maybe_uninit_zeroed() {
 #[test]
 fn drop_guards_only_dropped_by_closure_when_run() {
     let value_drops = Cell::new(0);
-    let value = DropGuard::new((), |()| value_drops.set(1 + value_drops.get()));
+    let value = DropGuard::new(|()| value_drops.set(1 + value_drops.get()));
     let closure_drops = Cell::new(0);
-    let guard = DropGuard::new(value, |_| closure_drops.set(1 + closure_drops.get()));
+    let guard = DropGuard::new_with(value, |_| closure_drops.set(1 + closure_drops.get()));
     assert_eq!(value_drops.get(), 0);
     assert_eq!(closure_drops.get(), 0);
     drop(guard);
@@ -813,8 +813,8 @@ fn drop_guards_only_dropped_by_closure_when_run() {
 #[test]
 fn drop_guard_into_inner() {
     let dropped = Cell::new(false);
-    let value = DropGuard::new(42, |_| dropped.set(true));
-    let guard = DropGuard::new(value, |_| dropped.set(true));
+    let value = DropGuard::new_with(42, |_| dropped.set(true));
+    let guard = DropGuard::new_with(value, |_| dropped.set(true));
     let inner = DropGuard::dismiss(guard);
     assert_eq!(dropped.get(), false);
     assert_eq!(*inner, 42);
@@ -825,10 +825,10 @@ fn drop_guard_into_inner() {
 fn drop_guard_always_drops_value_if_closure_drop_unwinds() {
     // Create a value with a destructor, which we will validate ran successfully.
     let mut value_was_dropped = false;
-    let value_with_tracked_destruction = DropGuard::new((), |_| value_was_dropped = true);
+    let value_with_tracked_destruction = DropGuard::new(|()| value_was_dropped = true);
 
     // Create a closure that will begin unwinding when dropped.
-    let drop_bomb = DropGuard::new((), |_| panic!());
+    let drop_bomb = DropGuard::new(|()| panic!());
     let closure_that_panics_on_drop = move |_| {
         let _drop_bomb = drop_bomb;
     };
@@ -836,7 +836,8 @@ fn drop_guard_always_drops_value_if_closure_drop_unwinds() {
     // This will run the closure, which will panic when dropped. This should
     // run the destructor of the value we passed, which we validate.
     let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        let guard = DropGuard::new(value_with_tracked_destruction, closure_that_panics_on_drop);
+        let guard =
+            DropGuard::new_with(value_with_tracked_destruction, closure_that_panics_on_drop);
         DropGuard::dismiss(guard);
     }));
     assert!(value_was_dropped);

--- a/library/std/src/sys/thread/unix.rs
+++ b/library/std/src/sys/thread/unix.rs
@@ -48,7 +48,7 @@ impl Thread {
         let data = init;
         let mut attr: mem::MaybeUninit<libc::pthread_attr_t> = mem::MaybeUninit::uninit();
         assert_eq!(libc::pthread_attr_init(attr.as_mut_ptr()), 0);
-        let mut attr = DropGuard::new(&mut attr, |attr| {
+        let mut attr = DropGuard::new_with(&mut attr, |attr| {
             assert_eq!(libc::pthread_attr_destroy(attr.as_mut_ptr()), 0)
         });
 

--- a/library/std/src/sys/thread/unix.rs
+++ b/library/std/src/sys/thread/unix.rs
@@ -48,7 +48,7 @@ impl Thread {
         let data = init;
         let mut attr: mem::MaybeUninit<libc::pthread_attr_t> = mem::MaybeUninit::uninit();
         assert_eq!(libc::pthread_attr_init(attr.as_mut_ptr()), 0);
-        let mut attr = DropGuard::new(&mut attr, |attr| {
+        let mut attr = DropGuard::with_value(&mut attr, |attr| {
             assert_eq!(libc::pthread_attr_destroy(attr.as_mut_ptr()), 0)
         });
 

--- a/library/std/src/sys/thread/unix.rs
+++ b/library/std/src/sys/thread/unix.rs
@@ -8,7 +8,7 @@
     target_os = "wasi",
 )))]
 use crate::ffi::CStr;
-use crate::mem::{self, DropGuard, ManuallyDrop};
+use crate::mem::{self, ManuallyDrop, guard};
 use crate::num::NonZero;
 #[cfg(all(target_os = "linux", target_env = "gnu"))]
 use crate::sys::weak::dlsym;
@@ -48,9 +48,8 @@ impl Thread {
         let data = init;
         let mut attr: mem::MaybeUninit<libc::pthread_attr_t> = mem::MaybeUninit::uninit();
         assert_eq!(libc::pthread_attr_init(attr.as_mut_ptr()), 0);
-        let mut attr = DropGuard::new_with(&mut attr, |attr| {
-            assert_eq!(libc::pthread_attr_destroy(attr.as_mut_ptr()), 0)
-        });
+        let mut attr =
+            guard(&mut attr, |attr| assert_eq!(libc::pthread_attr_destroy(attr.as_mut_ptr()), 0));
 
         #[cfg(any(target_os = "espidf", target_os = "nuttx"))]
         if stack > 0 {


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

This refers to https://github.com/rust-lang/rust/issues/144426.

cc @andylokandy @jplatte 

Updated with:

https://github.com/rust-lang/rust/pull/150027#issuecomment-3669955312

.. plus:

```rust
/// Create a new instance of `DropGuard` with a cleanup closure.
///
/// # Example
///
/// ```rust
/// # #![allow(unused)]
/// #![feature(drop_guard)]
///
/// use std::mem::defer;
///
/// let _guard = defer! { println!("Goodbye, world!") };
/// ```
#[unstable(feature = "drop_guard", issue = "144426")]
pub macro defer($($t:tt)*) {
    $crate::mem::DropGuard::new((), |()| { $($t)* })
}
```

---

Unfortunately, it's hard to convert `impl FnOnce()` to the input type param `F: FnOnce(T) where T = ()`.

I tried:

```rust
impl<F> DropGuard<(), F>
where
    F: FnOnce(()),
{
    pub const fn new<G: FnOnce()>(f: G) -> Self {
        let f = move |()| f();
        Self { inner: ManuallyDrop::new(()), f: ManuallyDrop::new(f) }
    }
}
```

But it failed because the new closure has a different type of `F`.