### PR TITLE
assert impossible branch is impossible

### DIFF
--- a/compiler/rustc_resolve/src/ident.rs
+++ b/compiler/rustc_resolve/src/ident.rs
@@ -743,10 +743,10 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
 
         let ambiguity_error_kind = if is_builtin(innermost_res) || is_builtin(res) {
             Some(AmbiguityKind::BuiltinAttr)
-        } else if innermost_res == derive_helper_compat
-            || res == derive_helper_compat && innermost_res != derive_helper
-        {
+        } else if innermost_res == derive_helper_compat {
             Some(AmbiguityKind::DeriveHelper)
+        } else if res == derive_helper_compat && innermost_res != derive_helper {
+            span_bug!(orig_ident.span, "impossible inner resolution kind")
         } else if innermost_flags.contains(Flags::MACRO_RULES)
             && flags.contains(Flags::MODULE)
             && !self.disambiguate_macro_rules_vs_modularized(innermost_binding, binding)


### PR DESCRIPTION
The second half of this boolean or expression should not be possible with the current visitation implementation.

Reasoning:

- Innermost res will always be the first candidate visited.
- the first scopes visited are `derive_helper` candidates, followed by a single step at `derive_helper_compat`: https://github.com/rust-lang/rust/blob/ee447067/compiler/rustc_resolve/src/ident.rs#L180-L192
  - if there are candidates for both kinds the derive_helper candidate will always be innermost
  - there can only be one derive_helper_compat candidate
- The first branch handles cases where the first candidate is a `derive_helper_compat`
- if the first candidate is not a `derive_helper_compat` (as enforced by the first branch) and it is not a `derive_helper` (as enforced by the end of the second boolean expression) then then the first candidate and all subsequent candidates must be from later scope types, res cannot possibly be a `derive_helper_compat`

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
r? @petrochenkov 