### PR TITLE
Use annotate-snippet as default emitter on stable

### DIFF
--- a/compiler/rustc_errors/src/annotate_snippet_emitter_writer.rs
+++ b/compiler/rustc_errors/src/annotate_snippet_emitter_writer.rs
@@ -303,17 +303,6 @@ impl AnnotateSnippetEmitter {
             }
         }
 
-        let suggestions_expected = suggestions
-            .iter()
-            .filter(|s| {
-                matches!(
-                    s.style,
-                    SuggestionStyle::HideCodeInline
-                        | SuggestionStyle::ShowCode
-                        | SuggestionStyle::ShowAlways
-                )
-            })
-            .count();
         for suggestion in suggestions {
             match suggestion.style {
                 SuggestionStyle::CompletelyHidden => {
@@ -524,12 +513,6 @@ impl AnnotateSnippetEmitter {
                     }
                 }
             }
-        }
-
-        // FIXME: This hack should be removed once annotate_snippets is the
-        // default emitter.
-        if suggestions_expected > 0 && report.is_empty() {
-            group = group.element(Padding);
         }
 
         if !group.is_empty() {

--- a/compiler/rustc_errors/src/emitter.rs
+++ b/compiler/rustc_errors/src/emitter.rs
@@ -46,17 +46,14 @@ const DEFAULT_COLUMN_WIDTH: usize = 140;
 
 /// Describes the way the content of the `rendered` field of the json output is generated
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum HumanReadableErrorType {
-    Default { short: bool },
-    AnnotateSnippet { short: bool, unicode: bool },
+pub struct HumanReadableErrorType {
+    pub short: bool,
+    pub unicode: bool,
 }
 
 impl HumanReadableErrorType {
     pub fn short(&self) -> bool {
-        match self {
-            HumanReadableErrorType::Default { short }
-            | HumanReadableErrorType::AnnotateSnippet { short, .. } => *short,
-        }
+        self.short
     }
 }
 
@@ -607,7 +604,7 @@ pub enum OutputTheme {
     Unicode,
 }
 
-/// Handles the writing of `HumanReadableErrorType::Default` and `HumanReadableErrorType::Short`
+/// Handles the writing of `HumanReadableErrorType`
 #[derive(Setters)]
 pub struct HumanEmitter {
     #[setters(skip)]

--- a/compiler/rustc_errors/src/json.rs
+++ b/compiler/rustc_errors/src/json.rs
@@ -28,8 +28,8 @@ use serde::Serialize;
 use crate::annotate_snippet_emitter_writer::AnnotateSnippetEmitter;
 use crate::diagnostic::IsLint;
 use crate::emitter::{
-    ColorConfig, Destination, Emitter, HumanEmitter, HumanReadableErrorType, OutputTheme,
-    TimingEvent, should_show_source_code,
+    ColorConfig, Destination, Emitter, HumanReadableErrorType, OutputTheme, TimingEvent,
+    should_show_source_code,
 };
 use crate::registry::Registry;
 use crate::timings::{TimingRecord, TimingSection};
@@ -378,38 +378,17 @@ impl Diagnostic {
                 choice => choice,
             },
         );
-        match je.json_rendered {
-            HumanReadableErrorType::AnnotateSnippet { short, unicode } => {
-                AnnotateSnippetEmitter::new(dst, je.translator.clone())
-                    .short_message(short)
-                    .sm(je.sm.clone())
-                    .diagnostic_width(je.diagnostic_width)
-                    .macro_backtrace(je.macro_backtrace)
-                    .track_diagnostics(je.track_diagnostics)
-                    .terminal_url(je.terminal_url)
-                    .ui_testing(je.ui_testing)
-                    .ignored_directories_in_source_blocks(
-                        je.ignored_directories_in_source_blocks.clone(),
-                    )
-                    .theme(if unicode { OutputTheme::Unicode } else { OutputTheme::Ascii })
-                    .emit_diagnostic(diag, registry)
-            }
-            HumanReadableErrorType::Default { short } => {
-                HumanEmitter::new(dst, je.translator.clone())
-                    .short_message(short)
-                    .sm(je.sm.clone())
-                    .diagnostic_width(je.diagnostic_width)
-                    .macro_backtrace(je.macro_backtrace)
-                    .track_diagnostics(je.track_diagnostics)
-                    .terminal_url(je.terminal_url)
-                    .ui_testing(je.ui_testing)
-                    .ignored_directories_in_source_blocks(
-                        je.ignored_directories_in_source_blocks.clone(),
-                    )
-                    .theme(OutputTheme::Ascii)
-                    .emit_diagnostic(diag, registry)
-            }
-        }
+        AnnotateSnippetEmitter::new(dst, je.translator.clone())
+            .short_message(je.json_rendered.short)
+            .sm(je.sm.clone())
+            .diagnostic_width(je.diagnostic_width)
+            .macro_backtrace(je.macro_backtrace)
+            .track_diagnostics(je.track_diagnostics)
+            .terminal_url(je.terminal_url)
+            .ui_testing(je.ui_testing)
+            .ignored_directories_in_source_blocks(je.ignored_directories_in_source_blocks.clone())
+            .theme(if je.json_rendered.unicode { OutputTheme::Unicode } else { OutputTheme::Ascii })
+            .emit_diagnostic(diag, registry);
 
         let buf = Arc::try_unwrap(buf.0).unwrap().into_inner().unwrap();
         let buf = String::from_utf8(buf).unwrap();

--- a/compiler/rustc_errors/src/json/tests.rs
+++ b/compiler/rustc_errors/src/json/tests.rs
@@ -54,7 +54,7 @@ fn test_positions(code: &str, span: (u32, u32), expected_output: SpanTestData) {
             Some(sm),
             translator,
             true, // pretty
-            HumanReadableErrorType::Default { short: true },
+            HumanReadableErrorType { short: true, unicode: false },
             ColorConfig::Never,
         );
 

--- a/compiler/rustc_interface/src/tests.rs
+++ b/compiler/rustc_interface/src/tests.rs
@@ -321,7 +321,7 @@ fn test_search_paths_tracking_hash_different_order() {
     let early_dcx = EarlyDiagCtxt::new(JSON);
     const JSON: ErrorOutputType = ErrorOutputType::Json {
         pretty: false,
-        json_rendered: HumanReadableErrorType::Default { short: false },
+        json_rendered: HumanReadableErrorType { short: false, unicode: false },
         color_config: ColorConfig::Never,
     };
 

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -806,7 +806,7 @@ pub enum ErrorOutputType {
     /// Output meant for the consumption of humans.
     #[default]
     HumanReadable {
-        kind: HumanReadableErrorType = HumanReadableErrorType::Default { short: false },
+        kind: HumanReadableErrorType = HumanReadableErrorType { short: false, unicode: false },
         color_config: ColorConfig = ColorConfig::Auto,
     },
     /// Output that's consumed by other tools such as `rustfix` or the `RLS`.
@@ -1965,16 +1965,8 @@ impl JsonUnusedExterns {
 ///
 /// The first value returned is how to render JSON diagnostics, and the second
 /// is whether or not artifact notifications are enabled.
-pub fn parse_json(
-    early_dcx: &EarlyDiagCtxt,
-    matches: &getopts::Matches,
-    is_nightly_build: bool,
-) -> JsonConfig {
-    let mut json_rendered = if is_nightly_build {
-        HumanReadableErrorType::AnnotateSnippet { short: false, unicode: false }
-    } else {
-        HumanReadableErrorType::Default { short: false }
-    };
+pub fn parse_json(early_dcx: &EarlyDiagCtxt, matches: &getopts::Matches) -> JsonConfig {
+    let mut json_rendered = HumanReadableErrorType { short: false, unicode: false };
     let mut json_color = ColorConfig::Never;
     let mut json_artifact_notifications = false;
     let mut json_unused_externs = JsonUnusedExterns::No;
@@ -1991,15 +1983,10 @@ pub fn parse_json(
         for sub_option in option.split(',') {
             match sub_option {
                 "diagnostic-short" => {
-                    json_rendered = if is_nightly_build {
-                        HumanReadableErrorType::AnnotateSnippet { short: true, unicode: false }
-                    } else {
-                        HumanReadableErrorType::Default { short: true }
-                    };
+                    json_rendered = HumanReadableErrorType { short: true, unicode: false };
                 }
                 "diagnostic-unicode" => {
-                    json_rendered =
-                        HumanReadableErrorType::AnnotateSnippet { short: false, unicode: true };
+                    json_rendered = HumanReadableErrorType { short: false, unicode: true };
                 }
                 "diagnostic-rendered-ansi" => json_color = ColorConfig::Always,
                 "artifacts" => json_artifact_notifications = true,
@@ -2029,13 +2016,8 @@ pub fn parse_error_format(
     color_config: ColorConfig,
     json_color: ColorConfig,
     json_rendered: HumanReadableErrorType,
-    is_nightly_build: bool,
 ) -> ErrorOutputType {
-    let default_kind = if is_nightly_build {
-        HumanReadableErrorType::AnnotateSnippet { short: false, unicode: false }
-    } else {
-        HumanReadableErrorType::Default { short: false }
-    };
+    let default_kind = HumanReadableErrorType { short: false, unicode: false };
     // We need the `opts_present` check because the driver will send us Matches
     // with only stable options if no unstable options are used. Since error-format
     // is unstable, it will not be present. We have to use `opts_present` not
@@ -2046,7 +2028,7 @@ pub fn parse_error_format(
                 ErrorOutputType::HumanReadable { color_config, kind: default_kind }
             }
             Some("human-annotate-rs") => ErrorOutputType::HumanReadable {
-                kind: HumanReadableErrorType::AnnotateSnippet { short: false, unicode: false },
+                kind: HumanReadableErrorType { short: false, unicode: false },
                 color_config,
             },
             Some("json") => {
@@ -2056,15 +2038,11 @@ pub fn parse_error_format(
                 ErrorOutputType::Json { pretty: true, json_rendered, color_config: json_color }
             }
             Some("short") => ErrorOutputType::HumanReadable {
-                kind: if is_nightly_build {
-                    HumanReadableErrorType::AnnotateSnippet { short: true, unicode: false }
-                } else {
-                    HumanReadableErrorType::Default { short: true }
-                },
+                kind: HumanReadableErrorType { short: true, unicode: false },
                 color_config,
             },
             Some("human-unicode") => ErrorOutputType::HumanReadable {
-                kind: HumanReadableErrorType::AnnotateSnippet { short: false, unicode: true },
+                kind: HumanReadableErrorType { short: false, unicode: true },
                 color_config,
             },
             Some(arg) => {
@@ -2136,8 +2114,8 @@ fn check_error_format_stability(
     let format = match format {
         ErrorOutputType::Json { pretty: true, .. } => "pretty-json",
         ErrorOutputType::HumanReadable { kind, .. } => match kind {
-            HumanReadableErrorType::AnnotateSnippet { unicode: false, .. } => "human-annotate-rs",
-            HumanReadableErrorType::AnnotateSnippet { unicode: true, .. } => "human-unicode",
+            HumanReadableErrorType { unicode: false, .. } => "human-annotate-rs",
+            HumanReadableErrorType { unicode: true, .. } => "human-unicode",
             _ => return,
         },
         _ => return,
@@ -2465,16 +2443,9 @@ pub fn build_session_options(early_dcx: &mut EarlyDiagCtxt, matches: &getopts::M
         json_timings,
         json_unused_externs,
         json_future_incompat,
-    } = parse_json(early_dcx, matches, unstable_features.is_nightly_build());
+    } = parse_json(early_dcx, matches);
 
-    let error_format = parse_error_format(
-        early_dcx,
-        matches,
-        color,
-        json_color,
-        json_rendered,
-        unstable_features.is_nightly_build(),
-    );
+    let error_format = parse_error_format(early_dcx, matches, color, json_color, json_rendered);
 
     early_dcx.set_error_format(error_format);
 

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -2027,10 +2027,6 @@ pub fn parse_error_format(
             None | Some("human") => {
                 ErrorOutputType::HumanReadable { color_config, kind: default_kind }
             }
-            Some("human-annotate-rs") => ErrorOutputType::HumanReadable {
-                kind: HumanReadableErrorType { short: false, unicode: false },
-                color_config,
-            },
             Some("json") => {
                 ErrorOutputType::Json { pretty: false, json_rendered, color_config: json_color }
             }
@@ -2051,8 +2047,8 @@ pub fn parse_error_format(
                     kind: default_kind,
                 });
                 early_dcx.early_fatal(format!(
-                    "argument for `--error-format` must be `human`, `human-annotate-rs`, \
-                    `human-unicode`, `json`, `pretty-json` or `short` (instead was `{arg}`)"
+                    "argument for `--error-format` must be `human`, `human-unicode`, \
+                    `json`, `pretty-json` or `short` (instead was `{arg}`)"
                 ))
             }
         }
@@ -2114,7 +2110,6 @@ fn check_error_format_stability(
     let format = match format {
         ErrorOutputType::Json { pretty: true, .. } => "pretty-json",
         ErrorOutputType::HumanReadable { kind, .. } => match kind {
-            HumanReadableErrorType { unicode: false, .. } => "human-annotate-rs",
             HumanReadableErrorType { unicode: true, .. } => "human-unicode",
             _ => return,
         },

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -13,9 +13,7 @@ use rustc_data_structures::profiling::{SelfProfiler, SelfProfilerRef};
 use rustc_data_structures::sync::{DynSend, DynSync, Lock, MappedReadGuard, ReadGuard, RwLock};
 use rustc_errors::annotate_snippet_emitter_writer::AnnotateSnippetEmitter;
 use rustc_errors::codes::*;
-use rustc_errors::emitter::{
-    DynEmitter, HumanEmitter, HumanReadableErrorType, OutputTheme, stderr_destination,
-};
+use rustc_errors::emitter::{DynEmitter, HumanReadableErrorType, OutputTheme, stderr_destination};
 use rustc_errors::json::JsonEmitter;
 use rustc_errors::timings::TimingSectionHandler;
 use rustc_errors::translation::Translator;
@@ -920,7 +918,7 @@ fn default_emitter(
 
     match sopts.error_format {
         config::ErrorOutputType::HumanReadable { kind, color_config } => match kind {
-            HumanReadableErrorType::AnnotateSnippet { short, unicode } => {
+            HumanReadableErrorType { short, unicode } => {
                 let emitter =
                     AnnotateSnippetEmitter::new(stderr_destination(color_config), translator)
                         .sm(source_map)
@@ -936,20 +934,6 @@ fn default_emitter(
                                 .ignore_directory_in_diagnostics_source_blocks
                                 .clone(),
                         );
-                Box::new(emitter.ui_testing(sopts.unstable_opts.ui_testing))
-            }
-            HumanReadableErrorType::Default { short } => {
-                let emitter = HumanEmitter::new(stderr_destination(color_config), translator)
-                    .sm(source_map)
-                    .short_message(short)
-                    .diagnostic_width(sopts.diagnostic_width)
-                    .macro_backtrace(macro_backtrace)
-                    .track_diagnostics(track_diagnostics)
-                    .terminal_url(terminal_url)
-                    .theme(OutputTheme::Ascii)
-                    .ignored_directories_in_source_blocks(
-                        sopts.unstable_opts.ignore_directory_in_diagnostics_source_blocks.clone(),
-                    );
                 Box::new(emitter.ui_testing(sopts.unstable_opts.ui_testing))
             }
         },
@@ -1460,14 +1444,9 @@ fn mk_emitter(output: ErrorOutputType) -> Box<DynEmitter> {
         Translator::with_fallback_bundle(vec![rustc_errors::DEFAULT_LOCALE_RESOURCE], false);
     let emitter: Box<DynEmitter> = match output {
         config::ErrorOutputType::HumanReadable { kind, color_config } => match kind {
-            HumanReadableErrorType::AnnotateSnippet { short, unicode } => Box::new(
+            HumanReadableErrorType { short, unicode } => Box::new(
                 AnnotateSnippetEmitter::new(stderr_destination(color_config), translator)
                     .theme(if unicode { OutputTheme::Unicode } else { OutputTheme::Ascii })
-                    .short_message(short),
-            ),
-            HumanReadableErrorType::Default { short } => Box::new(
-                HumanEmitter::new(stderr_destination(color_config), translator)
-                    .theme(OutputTheme::Ascii)
                     .short_message(short),
             ),
         },

--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -404,15 +404,9 @@ impl Options {
         let unstable_features =
             rustc_feature::UnstableFeatures::from_environment(crate_name.as_deref());
         let config::JsonConfig { json_rendered, json_unused_externs, json_color, .. } =
-            config::parse_json(early_dcx, matches, unstable_features.is_nightly_build());
-        let error_format = config::parse_error_format(
-            early_dcx,
-            matches,
-            color,
-            json_color,
-            json_rendered,
-            unstable_features.is_nightly_build(),
-        );
+            config::parse_json(early_dcx, matches);
+        let error_format =
+            config::parse_error_format(early_dcx, matches, color, json_color, json_rendered);
         let diagnostic_width = matches.opt_get("diagnostic-width").unwrap_or_default();
 
         let mut target_modifiers = BTreeMap::<OptionsTargetModifiers, String>::new();

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -7,9 +7,7 @@ use rustc_driver::USING_INTERNAL_FEATURES;
 use rustc_errors::TerminalUrl;
 use rustc_errors::annotate_snippet_emitter_writer::AnnotateSnippetEmitter;
 use rustc_errors::codes::*;
-use rustc_errors::emitter::{
-    DynEmitter, HumanEmitter, HumanReadableErrorType, OutputTheme, stderr_destination,
-};
+use rustc_errors::emitter::{DynEmitter, HumanReadableErrorType, OutputTheme, stderr_destination};
 use rustc_errors::json::JsonEmitter;
 use rustc_feature::UnstableFeatures;
 use rustc_hir::def::Res;
@@ -162,22 +160,13 @@ pub(crate) fn new_dcx(
     let translator = rustc_driver::default_translator();
     let emitter: Box<DynEmitter> = match error_format {
         ErrorOutputType::HumanReadable { kind, color_config } => match kind {
-            HumanReadableErrorType::AnnotateSnippet { short, unicode } => Box::new(
+            HumanReadableErrorType { short, unicode } => Box::new(
                 AnnotateSnippetEmitter::new(stderr_destination(color_config), translator)
                     .sm(source_map.map(|sm| sm as _))
                     .short_message(short)
                     .diagnostic_width(diagnostic_width)
                     .track_diagnostics(unstable_opts.track_diagnostics)
                     .theme(if unicode { OutputTheme::Unicode } else { OutputTheme::Ascii })
-                    .ui_testing(unstable_opts.ui_testing),
-            ),
-            HumanReadableErrorType::Default { short } => Box::new(
-                HumanEmitter::new(stderr_destination(color_config), translator)
-                    .sm(source_map.map(|sm| sm as _))
-                    .short_message(short)
-                    .diagnostic_width(diagnostic_width)
-                    .track_diagnostics(unstable_opts.track_diagnostics)
-                    .theme(OutputTheme::Ascii)
                     .ui_testing(unstable_opts.ui_testing),
             ),
         },

--- a/src/librustdoc/doctest.rs
+++ b/src/librustdoc/doctest.rs
@@ -625,7 +625,7 @@ fn run_test(
     ]);
     if let ErrorOutputType::HumanReadable { kind, color_config } = rustdoc_options.error_format {
         let short = kind.short();
-        let unicode = kind == HumanReadableErrorType::AnnotateSnippet { unicode: true, short };
+        let unicode = kind == HumanReadableErrorType { unicode: true, short };
 
         if short {
             compiler_args.extend_from_slice(&["--error-format".to_owned(), "short".to_owned()]);

--- a/src/tools/clippy/tests/ui/unit_arg.stderr
+++ b/src/tools/clippy/tests/ui/unit_arg.stderr
@@ -204,21 +204,18 @@ error: passing a unit value to a function
    |
 LL |     fn_take_unit(mac!(def));
    |     ^^^^^^^^^^^^^^^^^^^^^^^
-   |
 
 error: passing a unit value to a function
   --> tests/ui/unit_arg.rs:173:5
    |
 LL |     fn_take_unit(mac!(func Default::default));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
 
 error: passing a unit value to a function
   --> tests/ui/unit_arg.rs:175:5
    |
 LL |     fn_take_unit(mac!(nonempty_block Default::default()));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
 
 error: aborting due to 13 previous errors
 

--- a/tests/ui/annotate-snippet/missing-type.rs
+++ b/tests/ui/annotate-snippet/missing-type.rs
@@ -1,5 +1,5 @@
 //@ edition: 2015
-//@ compile-flags: --error-format human-annotate-rs -Z unstable-options
+//@ compile-flags: --error-format human
 
 pub fn main() {
     let x: Iter;

--- a/tests/ui/annotate-snippet/multiple-files.rs
+++ b/tests/ui/annotate-snippet/multiple-files.rs
@@ -1,5 +1,5 @@
 //@ aux-build:other_file.rs
-//@ compile-flags: --error-format human-annotate-rs -Z unstable-options
+//@ compile-flags: --error-format human
 
 extern crate other_file;
 

--- a/tests/ui/annotate-snippet/multispan.rs
+++ b/tests/ui/annotate-snippet/multispan.rs
@@ -1,5 +1,5 @@
 //@ proc-macro: multispan.rs
-//@ compile-flags: --error-format human-annotate-rs -Z unstable-options
+//@ compile-flags: --error-format human
 
 #![feature(proc_macro_hygiene)]
 

--- a/tests/ui/attributes/crate-type-delimited.stderr
+++ b/tests/ui/attributes/crate-type-delimited.stderr
@@ -5,7 +5,6 @@ LL | #![crate_type(lib)]
    | ^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/linkage.html>
-   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/attributes/crate-type-empty.stderr
+++ b/tests/ui/attributes/crate-type-empty.stderr
@@ -5,7 +5,6 @@ LL | #![crate_type]
    | ^^^^^^^^^^^^^^
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/linkage.html>
-   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/attributes/crate-type-macro-call.stderr
+++ b/tests/ui/attributes/crate-type-macro-call.stderr
@@ -5,7 +5,6 @@ LL | #![crate_type = foo!()]
    | ^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/linkage.html>
-   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/generic_const_exprs/issue-105608.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/issue-105608.stderr
@@ -3,7 +3,6 @@ error[E0282]: type annotations needed
    |
 LL |     Combination::<0>.and::<_>().and::<_>();
    |                      ^^^ cannot infer type of the type parameter `M` declared on the method `and`
-   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/delegation/ice-line-bounds-issue-148732.stderr
+++ b/tests/ui/delegation/ice-line-bounds-issue-148732.stderr
@@ -5,7 +5,6 @@ LL |     dbg!(b);
    |     ^^^^^^^ expected named lifetime parameter
    |
    = note: this error originates in the macro `dbg` (in Nightly builds, run with -Z macro-backtrace for more info)
-   |
 
 error[E0425]: cannot find function `a` in this scope
   --> $DIR/ice-line-bounds-issue-148732.rs:1:7

--- a/tests/ui/macros/cfg_select.stderr
+++ b/tests/ui/macros/cfg_select.stderr
@@ -38,14 +38,12 @@ error[E0539]: malformed `cfg_select` macro input
    |
 LL |     "str" => {}
    |     ^^^^^ expected a valid identifier here
-   |
 
 error[E0539]: malformed `cfg_select` macro input
   --> $DIR/cfg_select.rs:80:5
    |
 LL |     a::b => {}
    |     ^^^^ expected a valid identifier here
-   |
 
 error[E0537]: invalid predicate `a`
   --> $DIR/cfg_select.rs:85:5

--- a/tests/ui/span/issue-42234-unknown-receiver-type.stderr
+++ b/tests/ui/span/issue-42234-unknown-receiver-type.stderr
@@ -16,7 +16,6 @@ error[E0282]: type annotations needed
    |
 LL |         .sum::<_>()
    |          ^^^ cannot infer type of the type parameter `S` declared on the method `sum`
-   |
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/structs/ice-line-bounds-issue-148684.stderr
+++ b/tests/ui/structs/ice-line-bounds-issue-148684.stderr
@@ -9,7 +9,6 @@ LL | | }
 ...
 LL |       A(2, vec![])
    |       ^^^^^^^^^^^^
-   |
 
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

This is implementation of https://github.com/rust-lang/rust/issues/149932

Now, after MCP was accepted, we can use annotate-snippet as default emitter for errors, that means that we not longer need of previous emitter, so this PR removed previous emitter and makes annotate-snippet new default one both on stable and nightly

(this PR does not remove a code of previous emitter it just removes a `Default` option of `HumanReadableErrorType` enum, and keeping only `HumanReadableErrorType::AnnotateSnippet` as it now uses by default)