### PR TITLE
fix docustring on fetch_or

### DIFF
--- a/library/core/src/sync/atomic.rs
+++ b/library/core/src/sync/atomic.rs
@@ -1151,8 +1151,8 @@ impl AtomicBool {
     /// assert_eq!(foo.fetch_or(false, Ordering::SeqCst), true);
     /// assert_eq!(foo.load(Ordering::SeqCst), true);
     ///
-    /// let foo = AtomicBool::new(true);
-    /// assert_eq!(foo.fetch_or(true, Ordering::SeqCst), true);
+    /// let foo = AtomicBool::new(false);
+    /// assert_eq!(foo.fetch_or(true, Ordering::SeqCst), false);
     /// assert_eq!(foo.load(Ordering::SeqCst), true);
     ///
     /// let foo = AtomicBool::new(false);


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->


The documentation had the same example twice in a row, but I think this was the intended second example.