### PR TITLE
Implement lint for black_boxing ZSTs

### DIFF
--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -58,12 +58,12 @@ lint_builtin_allow_internal_unsafe =
 lint_builtin_anonymous_params = anonymous parameters are deprecated and will be removed in the next edition
     .suggestion = try naming the parameter or explicitly ignoring it
 
-lint_builtin_black_box_zst_call = `black_box` on zero-sized callable `{$ty}` has no effect on call opacity
-    .label = zero-sized callable passed here
+lint_builtin_black_box_zst_call = use of `black_box` on the zero-sized type `{$ty}` has no effect
+    .label = zero-sized value passed here
 
-lint_builtin_black_box_zst_help = coerce to a function pointer and call `black_box` on that pointer instead
+lint_builtin_black_box_zst_help = if this is a function, coerce it to a function pointer first
 
-lint_builtin_black_box_zst_note = zero-sized callable values have no runtime representation, so the call still targets the original function directly
+lint_builtin_black_box_zst_note = zero-sized values have no runtime representation, so the compiler can ignore the call
 
 lint_builtin_clashing_extern_diff_name = `{$this}` redeclares `{$orig}` with a different signature
     .previous_decl_label = `{$orig}` previously declared here

--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -58,6 +58,13 @@ lint_builtin_allow_internal_unsafe =
 lint_builtin_anonymous_params = anonymous parameters are deprecated and will be removed in the next edition
     .suggestion = try naming the parameter or explicitly ignoring it
 
+lint_builtin_black_box_zst_call = `black_box` on zero-sized callable `{$ty}` has no effect on call opacity
+    .label = zero-sized callable passed here
+
+lint_builtin_black_box_zst_help = coerce to a function pointer and call `black_box` on that pointer instead
+
+lint_builtin_black_box_zst_note = zero-sized callable values have no runtime representation, so the call still targets the original function directly
+
 lint_builtin_clashing_extern_diff_name = `{$this}` redeclares `{$orig}` with a different signature
     .previous_decl_label = `{$orig}` previously declared here
     .mismatch_label = this signature doesn't match the previous declaration

--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -3121,6 +3121,7 @@ declare_lint! {
     /// ### Example
     ///
     /// ```rust,compile_fail
+    /// #![deny(black_box_zst_calls)]
     /// use std::hint::black_box;
     ///
     /// fn add(a: u32, b: u32) -> u32 {

--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -3112,7 +3112,7 @@ impl<'tcx> LateLintPass<'tcx> for AsmLabels {
 }
 
 declare_lint! {
-    /// The `black_box_zst_call` lint detects calls to `core::hint::black_box`
+    /// The `black_box_zst_calls` lint detects calls to `core::hint::black_box`
     /// where the argument is a zero-sized callable (e.g. a function item or
     /// a capture-less closure). These values have no runtime representation,
     /// so the black boxing does not make subsequent calls opaque to the

--- a/compiler/rustc_lint/src/lib.rs
+++ b/compiler/rustc_lint/src/lib.rs
@@ -201,6 +201,7 @@ late_lint_methods!(
             InvalidFromUtf8: InvalidFromUtf8,
             VariantSizeDifferences: VariantSizeDifferences,
             PathStatements: PathStatements,
+            BlackBoxZstCalls: BlackBoxZstCalls,
             LetUnderscore: LetUnderscore,
             InvalidReferenceCasting: InvalidReferenceCasting,
             ImplicitAutorefs: ImplicitAutorefs,

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -119,6 +119,16 @@ pub(crate) struct BuiltinNonShorthandFieldPatterns {
 }
 
 #[derive(LintDiagnostic)]
+#[diag(lint_builtin_black_box_zst_call)]
+#[note(lint_builtin_black_box_zst_note)]
+#[help(lint_builtin_black_box_zst_help)]
+pub(crate) struct BuiltinBlackBoxZstCall {
+    #[label]
+    pub arg_span: Span,
+    pub ty: String,
+}
+
+#[derive(LintDiagnostic)]
 pub(crate) enum BuiltinUnsafe {
     #[diag(lint_builtin_allow_internal_unsafe)]
     AllowInternalUnsafe,

--- a/library/core/src/hint.rs
+++ b/library/core/src/hint.rs
@@ -478,6 +478,7 @@ pub fn spin_loop() {
 #[inline]
 #[stable(feature = "bench_black_box", since = "1.66.0")]
 #[rustc_const_stable(feature = "const_black_box", since = "1.86.0")]
+#[rustc_diagnostic_item = "black_box"]
 pub const fn black_box<T>(dummy: T) -> T {
     crate::intrinsics::black_box(dummy)
 }

--- a/library/std/src/sys/backtrace.rs
+++ b/library/std/src/sys/backtrace.rs
@@ -182,6 +182,7 @@ where
     let result = f();
 
     // prevent this frame from being tail-call optimised away
+    #[allow(black_box_zst_calls)]
     crate::hint::black_box(());
 
     result

--- a/tests/ui/lint/lint-black-box-zst-call.rs
+++ b/tests/ui/lint/lint-black-box-zst-call.rs
@@ -8,6 +8,6 @@ fn add(a: u32, b: u32) -> u32 {
 
 fn main() {
     let add_bb = black_box(add);
-    //~^ ERROR `black_box` on zero-sized callable
+    //~^ ERROR use of `black_box` on the zero-sized type
     let _ = add_bb(1, 2);
 }

--- a/tests/ui/lint/lint-black-box-zst-call.rs
+++ b/tests/ui/lint/lint-black-box-zst-call.rs
@@ -1,0 +1,13 @@
+#![deny(black_box_zst_calls)]
+
+use std::hint::black_box;
+
+fn add(a: u32, b: u32) -> u32 {
+    a + b
+}
+
+fn main() {
+    let add_bb = black_box(add);
+    //~^ ERROR `black_box` on zero-sized callable
+    let _ = add_bb(1, 2);
+}

--- a/tests/ui/lint/lint-black-box-zst-call.stderr
+++ b/tests/ui/lint/lint-black-box-zst-call.stderr
@@ -1,13 +1,13 @@
-error: `black_box` on zero-sized callable `fn(u32, u32) -> u32 {add}` has no effect on call opacity
+error: use of `black_box` on the zero-sized type `fn(u32, u32) -> u32 {add}` has no effect
   --> $DIR/lint-black-box-zst-call.rs:10:18
    |
 LL |     let add_bb = black_box(add);
    |                  ^^^^^^^^^^---^
    |                            |
-   |                            zero-sized callable passed here
+   |                            zero-sized value passed here
    |
-   = note: zero-sized callable values have no runtime representation, so the call still targets the original function directly
-   = help: coerce to a function pointer and call `black_box` on that pointer instead
+   = note: zero-sized values have no runtime representation, so the compiler can ignore the call
+   = help: if this is a function, coerce it to a function pointer first
 note: the lint level is defined here
   --> $DIR/lint-black-box-zst-call.rs:1:9
    |

--- a/tests/ui/lint/lint-black-box-zst-call.stderr
+++ b/tests/ui/lint/lint-black-box-zst-call.stderr
@@ -1,0 +1,18 @@
+error: `black_box` on zero-sized callable `fn(u32, u32) -> u32 {add}` has no effect on call opacity
+  --> $DIR/lint-black-box-zst-call.rs:10:18
+   |
+LL |     let add_bb = black_box(add);
+   |                  ^^^^^^^^^^---^
+   |                            |
+   |                            zero-sized callable passed here
+   |
+   = note: zero-sized callable values have no runtime representation, so the call still targets the original function directly
+   = help: coerce to a function pointer and call `black_box` on that pointer instead
+note: the lint level is defined here
+  --> $DIR/lint-black-box-zst-call.rs:1:9
+   |
+LL | #![deny(black_box_zst_calls)]
+   |         ^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/150037)*
<!-- homu-ignore:end -->

Implement a lint for black_boxing ZSTs as discussed in https://github.com/rust-lang/rust/issues/137658

This PR implements a new lint which warns when `std::hint::black_box` is called with a Zero-Sized Type (ZST).

Why the lint is needed?
The compiler is currently "silently failing" to do what the user asked. A warning closes the gap between what the user thinks is happening and what is actually happening. Users reach for `black_box` specifically to prevent optimizations. When passed a ZST `black_box` effectively does nothing, yet the user receives no feedback, which creates confusion.

Changes:
Added `#[rustc_diagnostic_item = "black_box"]` to `library/core/src/hint.rs`.
Implemented a `LateLintPass` to detect calls to `black_box` where the argument's layout is a ZST.

Closes: https://github.com/rust-lang/rust/issues/137658