### PR TITLE
Avoid unhelpful suggestion when crate name is invalid

### DIFF
--- a/compiler/rustc_session/messages.ftl
+++ b/compiler/rustc_session/messages.ftl
@@ -57,7 +57,6 @@ session_int_literal_too_large = integer literal is too large
     .note = value exceeds limit of `{$limit}`
 
 session_invalid_character_in_crate_name = invalid character {$character} in crate name: `{$crate_name}`
-    .help = you can either pass `--crate-name` on the command line or add `#![crate_name = "…"]` to set the crate name
 
 session_invalid_float_literal_suffix = invalid suffix `{$suffix}` for float literal
     .label = invalid suffix `{$suffix}`

--- a/compiler/rustc_session/src/errors.rs
+++ b/compiler/rustc_session/src/errors.rs
@@ -238,8 +238,6 @@ pub(crate) struct InvalidCharacterInCrateName {
     pub(crate) span: Option<Span>,
     pub(crate) character: char,
     pub(crate) crate_name: Symbol,
-    #[help]
-    pub(crate) help: Option<()>,
 }
 
 #[derive(Subdiagnostic)]

--- a/compiler/rustc_session/src/output.rs
+++ b/compiler/rustc_session/src/output.rs
@@ -69,7 +69,6 @@ pub fn validate_crate_name(sess: &Session, crate_name: Symbol, span: Option<Span
             span,
             character: c,
             crate_name,
-            help: span.is_none().then_some(()),
         }));
     }
 

--- a/tests/ui/compile-flags/invalid/need-crate-arg-ignore-tidy$x.stderr
+++ b/tests/ui/compile-flags/invalid/need-crate-arg-ignore-tidy$x.stderr
@@ -1,6 +1,4 @@
 error: invalid character '$' in crate name: `need_crate_arg_ignore_tidy$x`
-   |
-   = help: you can either pass `--crate-name` on the command line or add `#![crate_name = "…"]` to set the crate name
 
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
Pointing out they can set the crate's name is non-actionable: their problem is they found out how and set it incorrectly. Remove extraneous information that can only confuse the matter.

<!-- homu-ignore:start -->
Fixes rust-lang/rust#150023
<!-- homu-ignore:end -->