### PR TITLE
std_detect: AArch64 Darwin: expose SME F16F16 and B16B16 features

### DIFF
--- a/library/std_detect/src/detect/os/darwin/aarch64.rs
+++ b/library/std_detect/src/detect/os/darwin/aarch64.rs
@@ -76,6 +76,8 @@ pub(crate) fn detect_features() -> cache::Initializer {
     let sme = _sysctlbyname(c"hw.optional.arm.FEAT_SME");
     let sme2 = _sysctlbyname(c"hw.optional.arm.FEAT_SME2");
     let sme2p1 = _sysctlbyname(c"hw.optional.arm.FEAT_SME2p1");
+    let sme_b16b16 = _sysctlbyname(c"hw.optional.arm.FEAT_SME_B16B16");
+    let sme_f16f16 = _sysctlbyname(c"hw.optional.arm.FEAT_SME_F16F16");
     let sme_f64f64 = _sysctlbyname(c"hw.optional.arm.FEAT_SME_F64F64");
     let sme_i16i64 = _sysctlbyname(c"hw.optional.arm.FEAT_SME_I16I64");
     let ssbs = _sysctlbyname(c"hw.optional.arm.FEAT_SSBS");
@@ -153,6 +155,8 @@ pub(crate) fn detect_features() -> cache::Initializer {
     enable_feature(Feature::sme, sme);
     enable_feature(Feature::sme2, sme2);
     enable_feature(Feature::sme2p1, sme2p1);
+    enable_feature(Feature::sme_b16b16, sme_b16b16);
+    enable_feature(Feature::sme_f16f16, sme_f16f16);
     enable_feature(Feature::sme_f64f64, sme_f64f64);
     enable_feature(Feature::sme_i16i64, sme_i16i64);
     enable_feature(Feature::ssbs, ssbs);


### PR DESCRIPTION
This synchronizes the list with the current state of `sysctl` on macOS “Tahoe” 26.2.

r? @Amanieu