### PR TITLE
mir_build: Rename `TestCase` to `TestableCase`

### DIFF
--- a/compiler/rustc_mir_build/src/builder/matches/util.rs
+++ b/compiler/rustc_mir_build/src/builder/matches/util.rs
@@ -6,7 +6,7 @@ use tracing::debug;
 
 use crate::builder::Builder;
 use crate::builder::expr::as_place::PlaceBase;
-use crate::builder::matches::{Binding, Candidate, FlatPat, MatchPairTree, TestCase};
+use crate::builder::matches::{Binding, Candidate, FlatPat, MatchPairTree, TestableCase};
 
 impl<'a, 'tcx> Builder<'a, 'tcx> {
     /// Creates a false edge to `imaginary_target` and a real edge to
@@ -159,11 +159,11 @@ impl<'a, 'b, 'tcx> FakeBorrowCollector<'a, 'b, 'tcx> {
     }
 
     fn visit_match_pair(&mut self, match_pair: &MatchPairTree<'tcx>) {
-        if let TestCase::Or { pats, .. } = &match_pair.test_case {
+        if let TestableCase::Or { pats, .. } = &match_pair.testable_case {
             for flat_pat in pats.iter() {
                 self.visit_flat_pat(flat_pat)
             }
-        } else if matches!(match_pair.test_case, TestCase::Deref { .. }) {
+        } else if matches!(match_pair.testable_case, TestableCase::Deref { .. }) {
             // The subpairs of a deref pattern are all places relative to the deref temporary, so we
             // don't fake borrow them. Problem is, if we only shallowly fake-borrowed
             // `match_pair.place`, this would allow:


### PR DESCRIPTION
In the spirit of rust-lang/rust#149946, this is another renaming of something I've always found confusing.

When lowering match conditions, there is a subtle distinction between the kind of *test* being performed (on a scrutinee place), the possible outcomes of that test, and the different “cases” (corresponding to pattern nodes) that the test is distinguishing. Cases imply a particular preferred test, but once a test is chosen it can also interact with other cases as well.

I have often mixed up `TestKind` and `TestCase`, since the names are so similar, and they share several variant names. Therefore, this PR renames `TestCase` to `TestableCase`, to emphasise that these are the things selected by whatever test is being performed.

There should be no change to compiler behaviour.