### PR TITLE
autodiff: emit an error if we fail to find libEnzyme

### DIFF
--- a/compiler/rustc_codegen_llvm/messages.ftl
+++ b/compiler/rustc_codegen_llvm/messages.ftl
@@ -1,8 +1,9 @@
+codegen_llvm_autodiff_component_unavailable = failed to load our autodiff backend. Did you install it via rustup?
+
 codegen_llvm_autodiff_without_enable = using the autodiff feature requires -Z autodiff=Enable
 codegen_llvm_autodiff_without_lto = using the autodiff feature requires setting `lto="fat"` in your Cargo.toml
 
 codegen_llvm_copy_bitcode = failed to copy bitcode to object file: {$err}
-
 
 codegen_llvm_fixed_x18_invalid_arch = the `-Zfixed-x18` flag is not supported on the `{$arch}` architecture
 

--- a/compiler/rustc_codegen_llvm/src/errors.rs
+++ b/compiler/rustc_codegen_llvm/src/errors.rs
@@ -32,6 +32,11 @@ impl<G: EmissionGuarantee> Diagnostic<'_, G> for ParseTargetMachineConfig<'_> {
     }
 }
 
+#[cfg(feature = "llvm_enzyme")]
+#[derive(Diagnostic)]
+#[diag(codegen_llvm_autodiff_component_unavailable)]
+pub(crate) struct AutoDiffComponentUnavailable;
+
 #[derive(Diagnostic)]
 #[diag(codegen_llvm_autodiff_without_lto)]
 pub(crate) struct AutoDiffWithoutLto;


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Tested manually by moving libEnzyme-21.so away. We should adjust the error msg. once we have the component up.

It's the first usage within rustc of this experimental feature, but afaik we're open to dogfooding those for test purpose, right?

r? @Kobzol 