### PR TITLE
add CSE optimization tests for iterating over slice

### DIFF
--- a/tests/codegen-llvm/slice_cse_optimization.rs
+++ b/tests/codegen-llvm/slice_cse_optimization.rs
@@ -1,0 +1,46 @@
+//! Various iterating method over slice correctly optimized using common subexpression elimination.
+//! Checks function has memory(argmem: read) attribute.
+//! Regression test for <https://github.com/rust-lang/rust/issues/119573>.
+//@ compile-flags: -O
+
+#![crate_type = "lib"]
+// CHECK-LABEL: @has_zero_iter
+// CHECK-SAME: #[[ATTR:[0-9]+]]
+#[inline(never)]
+#[unsafe(no_mangle)]
+pub fn has_zero_iter(xs: &[u8]) -> bool {
+    xs.iter().any(|&x| x == 0)
+}
+
+// CHECK-LABEL: @has_zero_ptr
+// CHECK-SAME: #[[ATTR]]
+#[inline(never)]
+#[unsafe(no_mangle)]
+fn has_zero_ptr(xs: &[u8]) -> bool {
+    let range = xs.as_ptr_range();
+    let mut start = range.start;
+    let end = range.end;
+    while start < end {
+        unsafe {
+            if *start == 0 {
+                return true;
+            }
+            start = start.add(1);
+        }
+    }
+    false
+}
+// CHECK-LABEL: @has_zero_for
+// CHECK-SAME: #[[ATTR]]
+#[inline(never)]
+#[unsafe(no_mangle)]
+fn has_zero_for(xs: &[u8]) -> bool {
+    for x in xs {
+        if *x == 0 {
+            return true;
+        }
+    }
+    false
+}
+
+// CHECK: attributes #[[ATTR]] = { {{.*}}memory(argmem: read){{.*}} }


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
This PR is regression test for issue rust-lang/rust#119573. 
This PR introduces a new regression test to verify a critical optimization known as Common Subexpression Elimination (CSE) is correctly applied during various slice iteration patterns.