### PR TITLE
Alloc `String::retain` optimization

### DIFF
--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -126,6 +126,7 @@
 #![feature(iter_next_chunk)]
 #![feature(layout_for_ptr)]
 #![feature(legacy_receiver_trait)]
+#![feature(likely_unlikely)]
 #![feature(local_waker)]
 #![feature(maybe_uninit_uninit_array_transpose)]
 #![feature(panic_internals)]

--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -54,7 +54,7 @@ use core::ops::Add;
 use core::ops::AddAssign;
 use core::ops::{self, Range, RangeBounds};
 use core::str::pattern::{Pattern, Utf8Pattern};
-use core::{fmt, hash, ptr, slice};
+use core::{fmt, hash, hint, ptr, slice};
 
 #[cfg(not(no_global_oom_handling))]
 use crate::alloc::Allocator;
@@ -1645,53 +1645,57 @@ impl String {
     where
         F: FnMut(char) -> bool,
     {
-        struct SetLenOnDrop<'a> {
-            s: &'a mut String,
-            idx: usize,
-            del_bytes: usize,
-        }
-
-        impl<'a> Drop for SetLenOnDrop<'a> {
-            fn drop(&mut self) {
-                let new_len = self.idx - self.del_bytes;
-                debug_assert!(new_len <= self.s.len());
-                unsafe { self.s.vec.set_len(new_len) };
-            }
-        }
-
         let len = self.len();
-        let mut guard = SetLenOnDrop { s: self, idx: 0, del_bytes: 0 };
-
-        while guard.idx < len {
-            let ch =
-                // SAFETY: `guard.idx` is positive-or-zero and less that len so the `get_unchecked`
-                // is in bound. `self` is valid UTF-8 like string and the returned slice starts at
-                // a unicode code point so the `Chars` always return one character.
-                unsafe { guard.s.get_unchecked(guard.idx..len).chars().next().unwrap_unchecked() };
-            let ch_len = ch.len_utf8();
-
-            if !f(ch) {
-                guard.del_bytes += ch_len;
-            } else if guard.del_bytes > 0 {
-                // SAFETY: `guard.idx` is in bound and `guard.del_bytes` represent the number of
-                // bytes that are erased from the string so the resulting `guard.idx -
-                // guard.del_bytes` always represent a valid unicode code point.
-                //
-                // `guard.del_bytes` >= `ch.len_utf8()`, so taking a slice with `ch.len_utf8()` len
-                // is safe.
-                ch.encode_utf8(unsafe {
-                    crate::slice::from_raw_parts_mut(
-                        guard.s.as_mut_ptr().add(guard.idx - guard.del_bytes),
-                        ch.len_utf8(),
-                    )
-                });
-            }
-
-            // Point idx to the next char
-            guard.idx += ch_len;
+        if len == 0 {
+            // Explicit check results in better optimization
+            return;
         }
 
-        drop(guard);
+        struct PanicGuard<'a> {
+            s: &'a mut String,
+            write: usize,
+        }
+
+        impl Drop for PanicGuard<'_> {
+            fn drop(&mut self) {
+                debug_assert!(self.write <= self.s.len());
+                debug_assert!(str::from_utf8(&self.s.vec[..self.write]).is_ok());
+                // SAFETY: Restore the string length to the number of bytes written so far.
+                unsafe { self.s.vec.set_len(self.write) }
+            }
+        }
+
+        // Fast path: find the first character that should be removed or return early.
+        let mut chars = self.char_indices();
+        let (mut read, write) = loop {
+            let Some((idx, ch)) = chars.next() else { return };
+            if hint::unlikely(!f(ch)) {
+                break (idx + ch.len_utf8(), idx);
+            }
+        };
+        drop(chars);
+
+        // Slow path: at least one character is going to be removed.
+        let mut g = PanicGuard { s: self, write };
+        while read < len {
+            // SAFETY: `read` is within bound because `read` < `len`, so taking
+            // a slice with `len` is safe.
+            let ch = unsafe { g.s.get_unchecked(read..len).chars().next().unwrap_unchecked() };
+            let ch_len = ch.len_utf8();
+            if f(ch) {
+                // SAFETY: `read` is on a char boundary, as guaranteed above; `g.write` is
+                // within bounds because it is always behind `read`.
+                unsafe {
+                    let ptr = g.s.vec.as_mut_ptr();
+                    ptr::copy(ptr.add(read), ptr.add(g.write), ch_len);
+                }
+                g.write += ch_len;
+            }
+            read += ch_len;
+        }
+
+        // All bytes processed; commit the final length by dropping the guard.
+        drop(g);
     }
 
     /// Inserts a character into this `String` at byte position `idx`.

--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -1651,50 +1651,50 @@ impl String {
             return;
         }
 
-        struct PanicGuard {
-            s: ptr::NonNull<String>,
-            read: usize,
+        struct PanicGuard<'a> {
+            s: &'a mut String,
             write: usize,
         }
 
-        impl Drop for PanicGuard {
+        impl Drop for PanicGuard<'_> {
             fn drop(&mut self) {
-                // SAFETY: This is guaranteed to be the only mutable reference to `s`.
-                let str = unsafe { &mut *self.s.as_ptr() };
-                debug_assert!(self.write <= str.len());
+                debug_assert!(self.write <= self.s.len());
+                debug_assert!(self.s.is_char_boundary(self.write));
                 // SAFETY: Restore the string length to the number of bytes written so far.
-                unsafe { str.vec.set_len(self.write) }
+                unsafe { self.s.vec.set_len(self.write) }
             }
         }
 
-        // Faster read-path
-        let string_ptr = ptr::NonNull::from(&mut *self);
-        let data_ptr = self.vec.as_mut_ptr();
+        // Fast path: find the first character that should be removed or return early.
         let mut chars = self.char_indices();
-        let (read, write) = loop {
-            let Some((write, ch)) = chars.next() else { return };
+        let (mut read, write) = loop {
+            let Some((idx, ch)) = chars.next() else { return };
             if hint::unlikely(!f(ch)) {
-                break (chars.offset(), write);
+                break (idx + ch.len_utf8(), idx);
             }
         };
+        drop(chars);
 
-        // Critical section starts here, at least one character is going to be removed.
-        let mut g = PanicGuard { s: string_ptr, read, write };
-        // Slower write-path
-        while let Some((read, ch)) = chars.next() {
-            let ch_len = chars.offset() - read;
+        // Slow path: at least one character is going to be removed.
+        let mut g = PanicGuard { s: self, write };
+        while read < len {
+            // SAFETY: `g.read` is in bound because `g.read` < `len`, so taking
+            // a slice with `len` is safe.
+            let ch = unsafe { g.s.get_unchecked(read..len).chars().next().unwrap_unchecked() };
+            let ch_len = ch.len_utf8();
             if f(ch) {
                 // SAFETY: `g.read` is in bound because `g.write` <= `g.read` - `ch_len`,
                 // so taking a slice with `ch_len` is safe.
                 unsafe {
-                    ptr::copy(data_ptr.add(g.read), data_ptr.add(g.write), ch_len);
+                    let ptr = g.s.vec.as_mut_ptr();
+                    ptr::copy(ptr.add(read), ptr.add(g.write), ch_len);
                 }
                 g.write += ch_len;
             }
-            g.read += ch_len;
+            read += ch_len;
         }
 
-        // All characters have been processed, set the final length by dropping the guard.
+        // All bytes processed; commit the final length by dropping the guard.
         drop(g);
     }
 

--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -1659,7 +1659,7 @@ impl String {
         impl Drop for PanicGuard<'_> {
             fn drop(&mut self) {
                 debug_assert!(self.write <= self.s.len());
-                debug_assert!(self.s.is_char_boundary(self.write));
+                debug_assert!(str::from_utf8(&self.s.vec[..self.write]).is_ok());
                 // SAFETY: Restore the string length to the number of bytes written so far.
                 unsafe { self.s.vec.set_len(self.write) }
             }
@@ -1677,6 +1677,7 @@ impl String {
 
         // Slow path: at least one character is going to be removed.
         let mut g = PanicGuard { s: self, write };
+        let ptr = g.s.vec.as_mut_ptr();
         while read < len {
             // SAFETY: `g.read` is in bound because `g.read` < `len`, so taking
             // a slice with `len` is safe.
@@ -1686,7 +1687,6 @@ impl String {
                 // SAFETY: `g.read` is in bound because `g.write` <= `g.read` - `ch_len`,
                 // so taking a slice with `ch_len` is safe.
                 unsafe {
-                    let ptr = g.s.vec.as_mut_ptr();
                     ptr::copy(ptr.add(read), ptr.add(g.write), ch_len);
                 }
                 g.write += ch_len;


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/150067)*
<!-- homu-ignore:end -->

Hi again!
This uses the exact same algorithm as my other PR: https://github.com/rust-lang/rust/pull/149784

Technically it should improve performance for `String::retain` too, But let's see what bors thinks.