### PR TITLE
Partially revert #147888 and print warning if LLVM CMake dir is missing when building Enzyme

### DIFF
--- a/src/bootstrap/src/core/config/toml/llvm.rs
+++ b/src/bootstrap/src/core/config/toml/llvm.rs
@@ -117,7 +117,7 @@ pub fn check_incompatible_options_for_ci_llvm(
         enable_warnings,
         download_ci_llvm: _,
         build_config,
-        enzyme: _,
+        enzyme,
     } = ci_llvm_config;
 
     err!(current_llvm_config.optimize, optimize);
@@ -139,6 +139,7 @@ pub fn check_incompatible_options_for_ci_llvm(
     err!(current_llvm_config.clang, clang);
     err!(current_llvm_config.build_config, build_config);
     err!(current_llvm_config.plugins, plugins);
+    err!(current_llvm_config.enzyme, enzyme);
 
     warn!(current_llvm_config.enable_warnings, enable_warnings);
 


### PR DESCRIPTION
Partially reverts https://github.com/rust-lang/rust/pull/147888, Enzyme cannot be build with `download-ci-llvm = true`.

r? @ZuseZ4
