### PR TITLE
Make `asm_experimental_arch` work in `allow_internal_unstable` macros

### DIFF
--- a/compiler/rustc_ast_lowering/src/asm.rs
+++ b/compiler/rustc_ast_lowering/src/asm.rs
@@ -52,7 +52,15 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                     | asm::InlineAsmArch::LoongArch64
                     | asm::InlineAsmArch::S390x
             );
-            if !is_stable && !self.tcx.features().asm_experimental_arch() {
+            if !is_stable
+                && !self.tcx.features().asm_experimental_arch()
+                && sp
+                    .ctxt()
+                    .outer_expn_data()
+                    .allow_internal_unstable
+                    .filter(|features| features.contains(&sym::asm_experimental_arch))
+                    .is_none()
+            {
                 feature_err(
                     &self.tcx.sess,
                     sym::asm_experimental_arch,

--- a/tests/ui/internal/auxiliary/internal_unstable.rs
+++ b/tests/ui/internal/auxiliary/internal_unstable.rs
@@ -99,3 +99,10 @@ macro_rules! access_field_noallow {
 macro_rules! pass_through_noallow {
     ($e: expr) => { $e }
 }
+
+#[stable(feature = "stable", since = "1.0.0")]
+#[allow_internal_unstable(asm_experimental_arch)]
+#[macro_export]
+macro_rules! asm_redirect {
+    ($($t:tt)*) => { core::arch::global_asm!($($t)*); }
+}

--- a/tests/ui/internal/internal-unstable-asm-experimental-arch.rs
+++ b/tests/ui/internal/internal-unstable-asm-experimental-arch.rs
@@ -1,0 +1,18 @@
+//@ only-wasm32-wasip1
+//@ compile-flags: --crate-type=lib
+//@ build-pass
+//@ aux-build:internal_unstable.rs
+
+#[macro_use]
+extern crate internal_unstable;
+
+asm_redirect!(
+    "test:",
+    ".globl test",
+    ".functype test (i32) -> (i32)",
+    "local.get 0",
+    "i32.const 1",
+    "i32.add",
+    "end_function",
+    ".export_name test, test",
+);


### PR DESCRIPTION
This change makes it possible to use unstable `asm!`, usually requiring `feature(asm_experimental_arch)`, in proc-macros with the `allow_internal_unstable` attribute.

The test was added on a target where `asm!` is unstable: Wasm. However, this affects *any* target with an unstable `asm!` implementation.