### PR TITLE
Implement clamp_to

### DIFF
--- a/library/core/src/cmp.rs
+++ b/library/core/src/cmp.rs
@@ -26,7 +26,10 @@
 #![stable(feature = "rust1", since = "1.0.0")]
 
 mod bytewise;
+mod clamp;
 pub(crate) use bytewise::BytewiseEq;
+#[unstable(feature = "clamp_bounds", issue = "147781")]
+pub use clamp::ClampBounds;
 
 use self::Ordering::*;
 use crate::marker::{Destruct, PointeeSized};
@@ -1120,6 +1123,35 @@ pub const trait Ord: [const] Eq + [const] PartialOrd<Self> + PointeeSized {
         } else {
             self
         }
+    }
+
+    /// Restrict a value to a certain range.
+    ///
+    /// This is equal to `max`, `min`, or `clamp`, depending on whether the range is `min..`,
+    /// `..=max`, or `min..=max`, respectively. Exclusive ranges are not permitted.
+    ///
+    /// # Panics
+    ///
+    /// Panics on `min..=max` if `min > max`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(clamp_to)]
+    /// assert_eq!((-3).clamp_to(-2..=1), -2);
+    /// assert_eq!(0.clamp_to(-2..=1), 0);
+    /// assert_eq!(2.clamp_to(..=1), 1);
+    /// assert_eq!(5.clamp_to(7..), 7);
+    /// ```
+    #[must_use]
+    #[inline]
+    #[unstable(feature = "clamp_to", issue = "147781")]
+    fn clamp_to<R>(self, range: R) -> Self
+    where
+        Self: Sized + [const] Destruct,
+        R: [const] ClampBounds<Self>,
+    {
+        range.clamp(self)
     }
 }
 

--- a/library/core/src/cmp.rs
+++ b/library/core/src/cmp.rs
@@ -26,7 +26,10 @@
 #![stable(feature = "rust1", since = "1.0.0")]
 
 mod bytewise;
+mod clamp;
 pub(crate) use bytewise::BytewiseEq;
+#[unstable(feature = "clamp_bounds", issue = "147781")]
+pub use clamp::ClampBounds;
 
 use self::Ordering::*;
 use crate::marker::{Destruct, PointeeSized};
@@ -1168,6 +1171,35 @@ pub const trait Ord: [const] Eq + [const] PartialOrd<Self> + PointeeSized {
         } else {
             self
         }
+    }
+
+    /// Restrict a value to a certain range.
+    ///
+    /// This is equal to `max`, `min`, or `clamp`, depending on whether the range is `min..`,
+    /// `..=max`, or `min..=max`, respectively. Exclusive ranges are not permitted.
+    ///
+    /// # Panics
+    ///
+    /// Panics on `min..=max` if `min > max`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(clamp_to)]
+    /// assert_eq!((-3).clamp_to(-2..=1), -2);
+    /// assert_eq!(0.clamp_to(-2..=1), 0);
+    /// assert_eq!(2.clamp_to(..=1), 1);
+    /// assert_eq!(5.clamp_to(7..), 7);
+    /// ```
+    #[must_use]
+    #[inline]
+    #[unstable(feature = "clamp_to", issue = "147781")]
+    fn clamp_to<R>(self, range: R) -> Self
+    where
+        Self: Sized + [const] Destruct,
+        R: [const] ClampBounds<Self>,
+    {
+        range.clamp(self)
     }
 }
 

--- a/library/core/src/cmp/clamp.rs
+++ b/library/core/src/cmp/clamp.rs
@@ -1,0 +1,100 @@
+use crate::marker::Destruct;
+use crate::ops::{RangeFrom, RangeFull, RangeInclusive, RangeToInclusive};
+
+/// Trait for ranges supported by [`Ord::clamp_to`].
+#[unstable(feature = "clamp_bounds", issue = "147781")]
+#[rustc_const_unstable(feature = "clamp_bounds", issue = "147781")]
+pub const trait ClampBounds<T>: Sized {
+    /// The implementation of [`Ord::clamp_to`].
+    fn clamp(self, value: T) -> T
+    where
+        T: [const] Destruct;
+}
+
+#[unstable(feature = "clamp_bounds", issue = "147781")]
+#[rustc_const_unstable(feature = "clamp_bounds", issue = "147781")]
+const impl<T> ClampBounds<T> for RangeFrom<T>
+where
+    T: [const] Ord,
+{
+    fn clamp(self, value: T) -> T
+    where
+        T: [const] Destruct,
+    {
+        value.max(self.start)
+    }
+}
+
+#[unstable(feature = "clamp_bounds", issue = "147781")]
+#[rustc_const_unstable(feature = "clamp_bounds", issue = "147781")]
+const impl<T> ClampBounds<T> for RangeToInclusive<T>
+where
+    T: [const] Ord,
+{
+    fn clamp(self, value: T) -> T
+    where
+        T: [const] Destruct,
+    {
+        value.min(self.end)
+    }
+}
+
+#[unstable(feature = "clamp_bounds", issue = "147781")]
+#[rustc_const_unstable(feature = "clamp_bounds", issue = "147781")]
+const impl<T> ClampBounds<T> for RangeInclusive<T>
+where
+    T: [const] Ord,
+{
+    fn clamp(self, value: T) -> T
+    where
+        T: [const] Destruct,
+    {
+        let (start, end) = self.into_inner();
+        value.clamp(start, end)
+    }
+}
+
+#[unstable(feature = "clamp_bounds", issue = "147781")]
+#[rustc_const_unstable(feature = "clamp_bounds", issue = "147781")]
+const impl<T> ClampBounds<T> for RangeFull {
+    fn clamp(self, value: T) -> T {
+        value
+    }
+}
+
+macro impl_for_float($t:ty) {
+    #[unstable(feature = "clamp_bounds", issue = "147781")]
+    #[rustc_const_unstable(feature = "clamp_bounds", issue = "147781")]
+    const impl ClampBounds<$t> for RangeFrom<$t> {
+        fn clamp(self, value: $t) -> $t {
+            assert!(!self.start.is_nan(), "start was NaN");
+            value.max(self.start)
+        }
+    }
+
+    #[unstable(feature = "clamp_bounds", issue = "147781")]
+    #[rustc_const_unstable(feature = "clamp_bounds", issue = "147781")]
+    const impl ClampBounds<$t> for RangeToInclusive<$t> {
+        fn clamp(self, value: $t) -> $t {
+            assert!(!self.end.is_nan(), "end was NaN");
+            value.min(self.end)
+        }
+    }
+
+    #[unstable(feature = "clamp_bounds", issue = "147781")]
+    #[rustc_const_unstable(feature = "clamp_bounds", issue = "147781")]
+    const impl ClampBounds<$t> for RangeInclusive<$t> {
+        fn clamp(self, value: $t) -> $t {
+            let (start, end) = self.into_inner();
+            assert!(start <= end, "start > end, or either was NaN");
+            value.clamp(start, end)
+        }
+    }
+}
+
+// #[unstable(feature = "f16", issue = "116909")]
+impl_for_float!(f16);
+impl_for_float!(f32);
+impl_for_float!(f64);
+// #[unstable(feature = "f128", issue = "116909")]
+impl_for_float!(f128);

--- a/library/core/src/cmp/clamp.rs
+++ b/library/core/src/cmp/clamp.rs
@@ -1,0 +1,104 @@
+use crate::marker::Destruct;
+use crate::ops::{RangeFrom, RangeFull, RangeInclusive, RangeToInclusive};
+
+/// Trait for ranges supported by [`Ord::clamp_to`].
+#[unstable(feature = "clamp_bounds", issue = "147781")]
+#[rustc_const_unstable(feature = "clamp_bounds", issue = "147781")]
+pub const trait ClampBounds<T>: Sized {
+    /// The implementation of [`Ord::clamp_to`].
+    fn clamp(self, value: T) -> T
+    where
+        T: [const] Destruct;
+}
+
+#[unstable(feature = "clamp_bounds", issue = "147781")]
+#[rustc_const_unstable(feature = "clamp_bounds", issue = "147781")]
+const impl<T> ClampBounds<T> for RangeFrom<T>
+where
+    T: [const] Ord,
+{
+    fn clamp(self, value: T) -> T
+    where
+        T: [const] Destruct,
+    {
+        value.max(self.start)
+    }
+}
+
+#[unstable(feature = "clamp_bounds", issue = "147781")]
+#[rustc_const_unstable(feature = "clamp_bounds", issue = "147781")]
+const impl<T> ClampBounds<T> for RangeToInclusive<T>
+where
+    T: [const] Ord,
+{
+    fn clamp(self, value: T) -> T
+    where
+        T: [const] Destruct,
+    {
+        value.min(self.end)
+    }
+}
+
+#[unstable(feature = "clamp_bounds", issue = "147781")]
+#[rustc_const_unstable(feature = "clamp_bounds", issue = "147781")]
+const impl<T> ClampBounds<T> for RangeInclusive<T>
+where
+    T: [const] Ord,
+{
+    fn clamp(self, value: T) -> T
+    where
+        T: [const] Destruct,
+    {
+        let (start, end) = self.into_inner();
+        value.clamp(start, end)
+    }
+}
+
+#[unstable(feature = "clamp_bounds", issue = "147781")]
+#[rustc_const_unstable(feature = "clamp_bounds", issue = "147781")]
+const impl<T> ClampBounds<T> for RangeFull {
+    fn clamp(self, value: T) -> T {
+        value
+    }
+}
+
+macro impl_for_float($t:ty) {
+    #[unstable(feature = "clamp_bounds", issue = "147781")]
+    #[rustc_const_unstable(feature = "clamp_bounds", issue = "147781")]
+    const impl ClampBounds<$t> for RangeFrom<$t> {
+        fn clamp(self, value: $t) -> $t {
+            assert!(!self.start.is_nan(), "start was NaN");
+            value.max(self.start)
+        }
+    }
+
+    #[unstable(feature = "clamp_bounds", issue = "147781")]
+    #[rustc_const_unstable(feature = "clamp_bounds", issue = "147781")]
+    const impl ClampBounds<$t> for RangeToInclusive<$t> {
+        fn clamp(self, value: $t) -> $t {
+            assert!(!self.end.is_nan(), "end was NaN");
+            value.min(self.end)
+        }
+    }
+
+    #[unstable(feature = "clamp_bounds", issue = "147781")]
+    #[rustc_const_unstable(feature = "clamp_bounds", issue = "147781")]
+    const impl ClampBounds<$t> for RangeInclusive<$t> {
+        #[expect(
+            clippy::neg_cmp_op_on_partial_ord,
+            reason = "NaN check is intentionally included in comparison"
+        )]
+        fn clamp(self, value: $t) -> $t {
+            let (start, end) = self.into_inner();
+            assert!(start <= end, "start > end, or either was NaN");
+            value.clamp(start, end)
+        }
+    }
+}
+
+// #[unstable(feature = "f16", issue = "116909")]
+impl_for_float!(f16);
+impl_for_float!(f32);
+impl_for_float!(f64);
+// #[unstable(feature = "f128", issue = "116909")]
+impl_for_float!(f128);

--- a/library/core/src/num/f128.rs
+++ b/library/core/src/num/f128.rs
@@ -1483,7 +1483,7 @@ impl f128 {
     ///
     /// ```
     /// #![feature(f128)]
-    /// # #[cfg(target_has_reliable_f128)] {
+    /// # #[cfg(target_has_reliable_f128_math)] {
     ///
     /// assert!((-3.0f128).clamp(-2.0, 1.0) == -2.0);
     /// assert!((0.0f128).clamp(-2.0, 1.0) == 0.0);
@@ -1550,6 +1550,43 @@ impl f128 {
         assert!(limit >= 0.0, "limit must be non-negative and not NaN");
         let limit = limit.abs(); // Canonicalises -0.0 to 0.0
         self.clamp(-limit, limit)
+    }
+
+    /// Restrict a value to a certain range, unless it is NaN.
+    ///
+    /// This is largely equal to `max`, `min`, or `clamp`, depending on whether the range is
+    /// `min..`, `..=max`, or `min..=max`, respectively. However, unlike `max` and `min`, it will
+    /// panic if any bound is NaN.
+    ///
+    /// Note that this function returns NaN if the initial value was NaN as
+    /// well.
+    ///
+    /// Exclusive ranges are not permitted.
+    ///
+    /// # Panics
+    ///
+    /// Panics on `min..=max` if `min > max`, or if any bound is NaN.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(f128, clamp_to)]
+    /// # #[cfg(target_has_reliable_f128_math)] {
+    /// assert_eq!((-3.0f128).clamp_to(-2.0..=1.0), -2.0);
+    /// assert_eq!(0.0f128.clamp_to(-2.0..=1.0), 0.0);
+    /// assert_eq!(2.0f128.clamp_to(..=1.0), 1.0);
+    /// assert_eq!(5.0f128.clamp_to(7.0..), 7.0);
+    /// assert!(f128::NAN.clamp_to(1.0..=2.0).is_nan());
+    /// # }
+    /// ```
+    #[must_use]
+    #[inline]
+    #[unstable(feature = "clamp_to", issue = "147781")]
+    pub fn clamp_to<R>(self, range: R) -> Self
+    where
+        R: crate::cmp::ClampBounds<Self>,
+    {
+        range.clamp(self)
     }
 
     /// Computes the absolute value of `self`.

--- a/library/core/src/num/f128.rs
+++ b/library/core/src/num/f128.rs
@@ -1455,6 +1455,43 @@ impl f128 {
         self.clamp(-limit, limit)
     }
 
+    /// Restrict a value to a certain range, unless it is NaN.
+    ///
+    /// This is largely equal to `max`, `min`, or `clamp`, depending on whether the range is
+    /// `min..`, `..=max`, or `min..=max`, respectively. However, unlike `max` and `min`, it will
+    /// panic if any bound is NaN.
+    ///
+    /// Note that this function returns NaN if the initial value was NaN as
+    /// well.
+    ///
+    /// Exclusive ranges are not permitted.
+    ///
+    /// # Panics
+    ///
+    /// Panics on `min..=max` if `min > max`, or if any bound is NaN.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(f128, clamp_to)]
+    /// # #[cfg(target_has_reliable_f128)] {
+    /// assert_eq!((-3.0f128).clamp_to(-2.0..=1.0), -2.0);
+    /// assert_eq!(0.0f128.clamp_to(-2.0..=1.0), 0.0);
+    /// assert_eq!(2.0f128.clamp_to(..=1.0), 1.0);
+    /// assert_eq!(5.0f128.clamp_to(7.0..), 7.0);
+    /// assert!(f128::NAN.clamp_to(1.0..=2.0).is_nan());
+    /// # }
+    /// ```
+    #[must_use]
+    #[inline]
+    #[unstable(feature = "clamp_to", issue = "147781")]
+    pub fn clamp_to<R>(self, range: R) -> Self
+    where
+        R: crate::cmp::ClampBounds<Self>,
+    {
+        range.clamp(self)
+    }
+
     /// Computes the absolute value of `self`.
     ///
     /// This function always returns the precise result.

--- a/library/core/src/num/f16.rs
+++ b/library/core/src/num/f16.rs
@@ -1469,7 +1469,7 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # #[cfg(target_has_reliable_f16)] {
+    /// # #[cfg(target_has_reliable_f16_math)] {
     ///
     /// assert!((-3.0f16).clamp(-2.0, 1.0) == -2.0);
     /// assert!((0.0f16).clamp(-2.0, 1.0) == 0.0);
@@ -1536,6 +1536,43 @@ impl f16 {
         assert!(limit >= 0.0, "limit must be non-negative and not NaN");
         let limit = limit.abs(); // Canonicalises -0.0 to 0.0
         self.clamp(-limit, limit)
+    }
+
+    /// Restrict a value to a certain range, unless it is NaN.
+    ///
+    /// This is largely equal to `max`, `min`, or `clamp`, depending on whether the range is
+    /// `min..`, `..=max`, or `min..=max`, respectively. However, unlike `max` and `min`, it will
+    /// panic if any bound is NaN.
+    ///
+    /// Note that this function returns NaN if the initial value was NaN as
+    /// well.
+    ///
+    /// Exclusive ranges are not permitted.
+    ///
+    /// # Panics
+    ///
+    /// Panics on `min..=max` if `min > max`, or if any bound is NaN.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(f16, clamp_to)]
+    /// # #[cfg(target_has_reliable_f16_math)] {
+    /// assert_eq!((-3.0f16).clamp_to(-2.0..=1.0), -2.0);
+    /// assert_eq!(0.0f16.clamp_to(-2.0..=1.0), 0.0);
+    /// assert_eq!(2.0f16.clamp_to(..=1.0), 1.0);
+    /// assert_eq!(5.0f16.clamp_to(7.0..), 7.0);
+    /// assert!(f16::NAN.clamp_to(1.0..=2.0).is_nan());
+    /// # }
+    /// ```
+    #[must_use]
+    #[inline]
+    #[unstable(feature = "clamp_to", issue = "147781")]
+    pub fn clamp_to<R>(self, range: R) -> Self
+    where
+        R: crate::cmp::ClampBounds<Self>,
+    {
+        range.clamp(self)
     }
 
     /// Computes the absolute value of `self`.

--- a/library/core/src/num/f16.rs
+++ b/library/core/src/num/f16.rs
@@ -1441,6 +1441,43 @@ impl f16 {
         self.clamp(-limit, limit)
     }
 
+    /// Restrict a value to a certain range, unless it is NaN.
+    ///
+    /// This is largely equal to `max`, `min`, or `clamp`, depending on whether the range is
+    /// `min..`, `..=max`, or `min..=max`, respectively. However, unlike `max` and `min`, it will
+    /// panic if any bound is NaN.
+    ///
+    /// Note that this function returns NaN if the initial value was NaN as
+    /// well.
+    ///
+    /// Exclusive ranges are not permitted.
+    ///
+    /// # Panics
+    ///
+    /// Panics on `min..=max` if `min > max`, or if any bound is NaN.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(f16, clamp_to)]
+    /// # #[cfg(target_has_reliable_f16)] {
+    /// assert_eq!((-3.0f16).clamp_to(-2.0..=1.0), -2.0);
+    /// assert_eq!(0.0f16.clamp_to(-2.0..=1.0), 0.0);
+    /// assert_eq!(2.0f16.clamp_to(..=1.0), 1.0);
+    /// assert_eq!(5.0f16.clamp_to(7.0..), 7.0);
+    /// assert!(f16::NAN.clamp_to(1.0..=2.0).is_nan());
+    /// # }
+    /// ```
+    #[must_use]
+    #[inline]
+    #[unstable(feature = "clamp_to", issue = "147781")]
+    pub fn clamp_to<R>(self, range: R) -> Self
+    where
+        R: crate::cmp::ClampBounds<Self>,
+    {
+        range.clamp(self)
+    }
+
     /// Computes the absolute value of `self`.
     ///
     /// This function always returns the precise result.

--- a/library/core/src/num/f32.rs
+++ b/library/core/src/num/f32.rs
@@ -1609,6 +1609,41 @@ impl f32 {
         self.clamp(-limit, limit)
     }
 
+    /// Restrict a value to a certain range, unless it is NaN.
+    ///
+    /// This is largely equal to `max`, `min`, or `clamp`, depending on whether the range is
+    /// `min..`, `..=max`, or `min..=max`, respectively. However, unlike `max` and `min`, it will
+    /// panic if any bound is NaN.
+    ///
+    /// Note that this function returns NaN if the initial value was NaN as
+    /// well.
+    ///
+    /// Exclusive ranges are not permitted.
+    ///
+    /// # Panics
+    ///
+    /// Panics on `min..=max` if `min > max`, or if any bound is NaN.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(clamp_to)]
+    /// assert_eq!((-3.0f32).clamp_to(-2.0..=1.0), -2.0);
+    /// assert_eq!(0.0f32.clamp_to(-2.0..=1.0), 0.0);
+    /// assert_eq!(2.0f32.clamp_to(..=1.0), 1.0);
+    /// assert_eq!(5.0f32.clamp_to(7.0..), 7.0);
+    /// assert!(f32::NAN.clamp_to(1.0..=2.0).is_nan());
+    /// ```
+    #[must_use]
+    #[inline]
+    #[unstable(feature = "clamp_to", issue = "147781")]
+    pub fn clamp_to<R>(self, range: R) -> Self
+    where
+        R: crate::cmp::ClampBounds<Self>,
+    {
+        range.clamp(self)
+    }
+
     /// Computes the absolute value of `self`.
     ///
     /// This function always returns the precise result.

--- a/library/core/src/num/f32.rs
+++ b/library/core/src/num/f32.rs
@@ -1709,6 +1709,41 @@ impl f32 {
         self.clamp(-limit, limit)
     }
 
+    /// Restrict a value to a certain range, unless it is NaN.
+    ///
+    /// This is largely equal to `max`, `min`, or `clamp`, depending on whether the range is
+    /// `min..`, `..=max`, or `min..=max`, respectively. However, unlike `max` and `min`, it will
+    /// panic if any bound is NaN.
+    ///
+    /// Note that this function returns NaN if the initial value was NaN as
+    /// well.
+    ///
+    /// Exclusive ranges are not permitted.
+    ///
+    /// # Panics
+    ///
+    /// Panics on `min..=max` if `min > max`, or if any bound is NaN.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(clamp_to)]
+    /// assert_eq!((-3.0f32).clamp_to(-2.0..=1.0), -2.0);
+    /// assert_eq!(0.0f32.clamp_to(-2.0..=1.0), 0.0);
+    /// assert_eq!(2.0f32.clamp_to(..=1.0), 1.0);
+    /// assert_eq!(5.0f32.clamp_to(7.0..), 7.0);
+    /// assert!(f32::NAN.clamp_to(1.0..=2.0).is_nan());
+    /// ```
+    #[must_use]
+    #[inline]
+    #[unstable(feature = "clamp_to", issue = "147781")]
+    pub fn clamp_to<R>(self, range: R) -> Self
+    where
+        R: crate::cmp::ClampBounds<Self>,
+    {
+        range.clamp(self)
+    }
+
     /// Computes the absolute value of `self`.
     ///
     /// This function always returns the precise result.

--- a/library/core/src/num/f64.rs
+++ b/library/core/src/num/f64.rs
@@ -1589,6 +1589,41 @@ impl f64 {
         self.clamp(-limit, limit)
     }
 
+    /// Restrict a value to a certain range, unless it is NaN.
+    ///
+    /// This is largely equal to `max`, `min`, or `clamp`, depending on whether the range is
+    /// `min..`, `..=max`, or `min..=max`, respectively. However, unlike `max` and `min`, it will
+    /// panic if any bound is NaN.
+    ///
+    /// Note that this function returns NaN if the initial value was NaN as
+    /// well.
+    ///
+    /// Exclusive ranges are not permitted.
+    ///
+    /// # Panics
+    ///
+    /// Panics on `min..=max` if `min > max`, or if any bound is NaN.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(clamp_to)]
+    /// assert_eq!((-3.0f64).clamp_to(-2.0..=1.0), -2.0);
+    /// assert_eq!(0.0f64.clamp_to(-2.0..=1.0), 0.0);
+    /// assert_eq!(2.0f64.clamp_to(..=1.0), 1.0);
+    /// assert_eq!(5.0f64.clamp_to(7.0..), 7.0);
+    /// assert!(f64::NAN.clamp_to(1.0..=2.0).is_nan());
+    /// ```
+    #[must_use]
+    #[inline]
+    #[unstable(feature = "clamp_to", issue = "147781")]
+    pub fn clamp_to<R>(self, range: R) -> Self
+    where
+        R: crate::cmp::ClampBounds<Self>,
+    {
+        range.clamp(self)
+    }
+
     /// Computes the absolute value of `self`.
     ///
     /// This function always returns the precise result.

--- a/library/core/src/num/f64.rs
+++ b/library/core/src/num/f64.rs
@@ -1687,6 +1687,41 @@ impl f64 {
         self.clamp(-limit, limit)
     }
 
+    /// Restrict a value to a certain range, unless it is NaN.
+    ///
+    /// This is largely equal to `max`, `min`, or `clamp`, depending on whether the range is
+    /// `min..`, `..=max`, or `min..=max`, respectively. However, unlike `max` and `min`, it will
+    /// panic if any bound is NaN.
+    ///
+    /// Note that this function returns NaN if the initial value was NaN as
+    /// well.
+    ///
+    /// Exclusive ranges are not permitted.
+    ///
+    /// # Panics
+    ///
+    /// Panics on `min..=max` if `min > max`, or if any bound is NaN.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(clamp_to)]
+    /// assert_eq!((-3.0f64).clamp_to(-2.0..=1.0), -2.0);
+    /// assert_eq!(0.0f64.clamp_to(-2.0..=1.0), 0.0);
+    /// assert_eq!(2.0f64.clamp_to(..=1.0), 1.0);
+    /// assert_eq!(5.0f64.clamp_to(7.0..), 7.0);
+    /// assert!(f64::NAN.clamp_to(1.0..=2.0).is_nan());
+    /// ```
+    #[must_use]
+    #[inline]
+    #[unstable(feature = "clamp_to", issue = "147781")]
+    pub fn clamp_to<R>(self, range: R) -> Self
+    where
+        R: crate::cmp::ClampBounds<Self>,
+    {
+        range.clamp(self)
+    }
+
     /// Computes the absolute value of `self`.
     ///
     /// This function always returns the precise result.

--- a/library/coretests/tests/lib.rs
+++ b/library/coretests/tests/lib.rs
@@ -13,6 +13,7 @@
 #![feature(casefold)]
 #![feature(cfg_target_has_reliable_f16_f128)]
 #![feature(char_internals)]
+#![feature(clamp_to)]
 #![feature(clone_to_uninit)]
 #![feature(cmp_minmax)]
 #![feature(const_array)]

--- a/library/coretests/tests/lib.rs
+++ b/library/coretests/tests/lib.rs
@@ -14,6 +14,7 @@
 #![feature(cfg_overflow_checks)]
 #![feature(cfg_target_has_reliable_f16_f128)]
 #![feature(char_internals)]
+#![feature(clamp_to)]
 #![feature(clone_to_uninit)]
 #![feature(cmp_minmax)]
 #![feature(cmp_splat)]

--- a/library/coretests/tests/num/floats.rs
+++ b/library/coretests/tests/num/floats.rs
@@ -1360,6 +1360,48 @@ float_test! {
 }
 
 float_test! {
+    name: clamp_to_min_greater_than_max,
+    attrs: {
+        const: #[cfg(false)],
+        f16: #[should_panic, cfg(target_has_reliable_f16_math)],
+        f32: #[should_panic],
+        f64: #[should_panic],
+        f128: #[should_panic, cfg(target_has_reliable_f128_math)],
+    },
+    test {
+        let _ = Float::ONE.clamp_to(3.0..=1.0);
+    }
+}
+
+float_test! {
+    name: clamp_to_min_is_nan,
+    attrs: {
+        const: #[cfg(false)],
+        f16: #[should_panic, cfg(target_has_reliable_f16_math)],
+        f32: #[should_panic],
+        f64: #[should_panic],
+        f128: #[should_panic, cfg(target_has_reliable_f128_math)],
+    },
+    test {
+        let _ = Float::ONE.clamp_to(Float::NAN..=1.0);
+    }
+}
+
+float_test! {
+    name: clamp_to_max_is_nan,
+    attrs: {
+        const: #[cfg(false)],
+        f16: #[should_panic, cfg(target_has_reliable_f16_math)],
+        f32: #[should_panic],
+        f64: #[should_panic],
+        f128: #[should_panic, cfg(target_has_reliable_f128_math)],
+    },
+    test {
+        let _ = Float::ONE.clamp_to(3.0..=Float::NAN);
+    }
+}
+
+float_test! {
     name: total_cmp,
     attrs: {
         // Miri only uses softfloats here, so that always works

--- a/library/coretests/tests/num/floats.rs
+++ b/library/coretests/tests/num/floats.rs
@@ -1328,10 +1328,10 @@ float_test! {
     name: clamp_min_greater_than_max,
     attrs: {
         const: #[cfg(false)],
-        f16: #[should_panic, cfg(target_has_reliable_f16)],
+        f16: #[should_panic, cfg(target_has_reliable_f16_math)],
         f32: #[should_panic],
         f64: #[should_panic],
-        f128: #[should_panic, cfg(target_has_reliable_f128)],
+        f128: #[should_panic, cfg(target_has_reliable_f128_math)],
     },
     test {
         let _ = Float::ONE.clamp(3.0, 1.0);
@@ -1342,10 +1342,10 @@ float_test! {
     name: clamp_min_is_nan,
     attrs: {
         const: #[cfg(false)],
-        f16: #[should_panic, cfg(target_has_reliable_f16)],
+        f16: #[should_panic, cfg(target_has_reliable_f16_math)],
         f32: #[should_panic],
         f64: #[should_panic],
-        f128: #[should_panic, cfg(target_has_reliable_f128)],
+        f128: #[should_panic, cfg(target_has_reliable_f128_math)],
     },
     test {
         let _ = Float::ONE.clamp(Float::NAN, 1.0);
@@ -1356,13 +1356,55 @@ float_test! {
     name: clamp_max_is_nan,
     attrs: {
         const: #[cfg(false)],
-        f16: #[should_panic, cfg(target_has_reliable_f16)],
+        f16: #[should_panic, cfg(target_has_reliable_f16_math)],
         f32: #[should_panic],
         f64: #[should_panic],
-        f128: #[should_panic, cfg(target_has_reliable_f128)],
+        f128: #[should_panic, cfg(target_has_reliable_f128_math)],
     },
     test {
         let _ = Float::ONE.clamp(3.0, Float::NAN);
+    }
+}
+
+float_test! {
+    name: clamp_to_min_greater_than_max,
+    attrs: {
+        const: #[cfg(false)],
+        f16: #[should_panic, cfg(target_has_reliable_f16_math)],
+        f32: #[should_panic],
+        f64: #[should_panic],
+        f128: #[should_panic, cfg(target_has_reliable_f128_math)],
+    },
+    test {
+        let _ = Float::ONE.clamp_to(3.0..=1.0);
+    }
+}
+
+float_test! {
+    name: clamp_to_min_is_nan,
+    attrs: {
+        const: #[cfg(false)],
+        f16: #[should_panic, cfg(target_has_reliable_f16_math)],
+        f32: #[should_panic],
+        f64: #[should_panic],
+        f128: #[should_panic, cfg(target_has_reliable_f128_math)],
+    },
+    test {
+        let _ = Float::ONE.clamp_to(Float::NAN..=1.0);
+    }
+}
+
+float_test! {
+    name: clamp_to_max_is_nan,
+    attrs: {
+        const: #[cfg(false)],
+        f16: #[should_panic, cfg(target_has_reliable_f16_math)],
+        f32: #[should_panic],
+        f64: #[should_panic],
+        f128: #[should_panic, cfg(target_has_reliable_f128_math)],
+    },
+    test {
+        let _ = Float::ONE.clamp_to(3.0..=Float::NAN);
     }
 }
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/150075)*
<!-- homu-ignore:end -->

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Implements the revised version of https://github.com/rust-lang/rust/issues/147781. Supersedes rust-lang/rust#147786.

Currently I restrict the ClampBounds trait using a second, perma-unstable feature. I don't know if that's the usual way to deal with this kind of traits, I'd be happy to change it if not.

~~I currently define NaN as equal to no bound. This is consistent with `max` and `min`, but is inconsistent with `clamp`, which panics.~~

Changed so that the float versions panic if any bound is NaN, just like `clamp` does.
