### PR TITLE
tests/run-make-cargo/same-crate-name-and-macro-name: New regression test

### DIFF
--- a/tests/run-make-cargo/same-crate-name-and-macro-name/consumer/Cargo.toml
+++ b/tests/run-make-cargo/same-crate-name-and-macro-name/consumer/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "consumer"
+version = "0.1.0"
+
+[dependencies]
+mylib_v1 = { path = "../mylib_v1", package = "mylib" }
+mylib_v2 = { path = "../mylib_v2", package = "mylib" }
+
+# Avoid interference with root workspace when casually testing
+[workspace]

--- a/tests/run-make-cargo/same-crate-name-and-macro-name/consumer/src/main.rs
+++ b/tests/run-make-cargo/same-crate-name-and-macro-name/consumer/src/main.rs
@@ -1,0 +1,7 @@
+fn main() {
+    let v1 = mylib_v1::my_macro!();
+    assert_eq!(v1, "version 1");
+
+    let v2 = mylib_v2::my_macro!();
+    assert_eq!(v2, "version 2");
+}

--- a/tests/run-make-cargo/same-crate-name-and-macro-name/mylib_v1/Cargo.toml
+++ b/tests/run-make-cargo/same-crate-name-and-macro-name/mylib_v1/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "mylib"
+version = "1.0.0"
+
+# Avoid interference with root workspace when casually testing
+[workspace]

--- a/tests/run-make-cargo/same-crate-name-and-macro-name/mylib_v1/src/lib.rs
+++ b/tests/run-make-cargo/same-crate-name-and-macro-name/mylib_v1/src/lib.rs
@@ -1,0 +1,6 @@
+#[macro_export]
+macro_rules! my_macro {
+    () => {
+        "version 1"
+    };
+}

--- a/tests/run-make-cargo/same-crate-name-and-macro-name/mylib_v2/Cargo.toml
+++ b/tests/run-make-cargo/same-crate-name-and-macro-name/mylib_v2/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "mylib"
+version = "2.0.0"
+
+# Avoid interference with root workspace when casually testing
+[workspace]

--- a/tests/run-make-cargo/same-crate-name-and-macro-name/mylib_v2/src/lib.rs
+++ b/tests/run-make-cargo/same-crate-name-and-macro-name/mylib_v2/src/lib.rs
@@ -1,0 +1,6 @@
+#[macro_export]
+macro_rules! my_macro {
+    () => {
+        "version 2"
+    };
+}

--- a/tests/run-make-cargo/same-crate-name-and-macro-name/rmake.rs
+++ b/tests/run-make-cargo/same-crate-name-and-macro-name/rmake.rs
@@ -1,0 +1,13 @@
+//! Regression test for
+//! <https://github.com/rust-lang/rust/issues/71259#issuecomment-615879925>
+//! (that particular comment describes the issue well).
+//!
+//! We test that two library crates with the same name can export macros with
+//! the same name without causing interference when both are used in another
+//! crate.
+
+use run_make_support::cargo;
+
+fn main() {
+    cargo().current_dir("consumer").arg("run").run();
+}


### PR DESCRIPTION
Closes https://github.com/rust-lang/rust/issues/71259 which just **E-needs-test**. See https://github.com/rust-lang/rust/issues/71259#issuecomment-615879925 for a good description of what we should test (which we do in this PR).

The project we add fails with an old nightly without the fix:

```console
$ cargo +nightly-2020-03-10 run
   Compiling consumer v0.1.0 (/home/martin/src/rust-same-crate-same-macro/tests/run-make-cargo/same-crate-name-and-macro-name/consumer)
    Finished dev [unoptimized + debuginfo] target(s) in 0.14s
     Running `target/debug/consumer`
thread 'main' panicked at 'assertion failed: `(left == right)`
  left: `"version 1"`,
 right: `"version 2"`', src/main.rs:6:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

and passes with a recent toolchain:

```console
$ cargo run
warning: /home/martin/src/rust-same-crate-same-macro/tests/run-make-cargo/same-crate-name-and-macro-name/consumer/Cargo.toml: no edition set: defaulting to the 2015 edition while the latest is 2024
warning: /home/martin/src/rust-same-crate-same-macro/tests/run-make-cargo/same-crate-name-and-macro-name/mylib_v1/Cargo.toml: no edition set: defaulting to the 2015 edition while the latest is 2024
warning: /home/martin/src/rust-same-crate-same-macro/tests/run-make-cargo/same-crate-name-and-macro-name/mylib_v2/Cargo.toml: no edition set: defaulting to the 2015 edition while the latest is 2024
   Compiling mylib v2.0.0 (/home/martin/src/rust-same-crate-same-macro/tests/run-make-cargo/same-crate-name-and-macro-name/mylib_v2)
   Compiling mylib v1.0.0 (/home/martin/src/rust-same-crate-same-macro/tests/run-make-cargo/same-crate-name-and-macro-name/mylib_v1)
   Compiling consumer v0.1.0 (/home/martin/src/rust-same-crate-same-macro/tests/run-make-cargo/same-crate-name-and-macro-name/consumer)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.14s
     Running `target/debug/consumer`
```

in other words, the test tests what it should and will catch regressions.
