### PR TITLE
miri: add `miri_spin_loop` to make `hint::spin_loop` work consistently

### DIFF
--- a/library/core/src/hint.rs
+++ b/library/core/src/hint.rs
@@ -269,6 +269,15 @@ pub const unsafe fn assert_unchecked(cond: bool) {
 #[stable(feature = "renamed_spin_loop", since = "1.49.0")]
 pub fn spin_loop() {
     crate::cfg_select! {
+        miri => {
+            unsafe extern "Rust" {
+                safe fn miri_spin_loop();
+            }
+
+            // Miri does support some of the intrinsics that are called below, but to guarantee
+            // consistent behavior across targets, this custom function is used.
+            miri_spin_loop();
+        }
         target_arch = "x86" => {
             // SAFETY: the `cfg` attr ensures that we only execute this on x86 targets.
             crate::arch::x86::_mm_pause()

--- a/src/tools/miri/src/shims/foreign_items.rs
+++ b/src/tools/miri/src/shims/foreign_items.rs
@@ -435,6 +435,13 @@ trait EvalContextExtPriv<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // Return value: 0 on success, otherwise the size it would have needed.
                 this.write_int(if success { 0 } else { needed_size }, dest)?;
             }
+            // Hint that a loop is spinning indefinitely.
+            "miri_spin_loop" => {
+                let [] = this.check_shim_sig_lenient(abi, CanonAbi::Rust, link_name, args)?;
+
+                // Try to run another thread to maximize the chance of finding actual bugs.
+                this.yield_active_thread();
+            }
             // Obtains the size of a Miri backtrace. See the README for details.
             "miri_backtrace_size" => {
                 this.handle_miri_backtrace_size(abi, link_name, args, dest)?;

--- a/src/tools/miri/tests/utils/miri_extern.rs
+++ b/src/tools/miri/tests/utils/miri_extern.rs
@@ -155,4 +155,7 @@ extern "Rust" {
 
     /// Blocks the current execution if the argument is false
     pub fn miri_genmc_assume(condition: bool);
+
+    /// Indicate to Miri that this thread is busy-waiting in a spin loop.
+    pub fn miri_spin_loop();
 }


### PR DESCRIPTION
fixes https://github.com/rust-lang/rust/issues/150050

Always use the same implementation when running miri (regardless of target, for consistency). This implementation yields the current thread to try find actual bugs.

r? RalfJung 