### PR TITLE
Fixed ICE for EII with multiple defaults due to duplicate definition in nameres

### DIFF
--- a/compiler/rustc_passes/src/eii.rs
+++ b/compiler/rustc_passes/src/eii.rs
@@ -116,7 +116,8 @@ pub(crate) fn check_externally_implementable_items<'tcx>(tcx: TyCtxt<'tcx>, (): 
         }
 
         if default_impls.len() > 1 {
-            panic!("multiple not supported right now");
+            let decl_span = tcx.def_ident_span(decl_did).unwrap();
+            tcx.dcx().span_delayed_bug(decl_span, "multiple not supported right now");
         }
 
         let (local_impl, is_default) =

--- a/tests/ui/eii/default/multiple-default-impls-same-name.rs
+++ b/tests/ui/eii/default/multiple-default-impls-same-name.rs
@@ -1,0 +1,19 @@
+#![crate_type = "lib"]
+#![feature(extern_item_impls)]
+// `eii` expands to, among other things, `macro eii() {}`.
+// If we have two eiis named the same thing, we have a duplicate definition
+// for that macro. The compiler happily continues compiling on duplicate
+// definitions though, to emit as many diagnostics as possible.
+// However, in the case of eiis, this can break the assumption that every
+// eii has only one default implementation, since the default for both eiis will
+// name resolve to the same eii definiton (since the other definition was duplicate)
+// This test tests for the previously-ICE that occurred when this assumption
+// (of 1 default) was broken which was reported in #149982.
+
+#[eii(eii1)]
+fn a() {}
+
+#[eii(eii1)]
+//~^ ERROR the name `eii1` is defined multiple times
+fn a() {}
+//~^ ERROR the name `a` is defined multiple times

--- a/tests/ui/eii/default/multiple-default-impls-same-name.stderr
+++ b/tests/ui/eii/default/multiple-default-impls-same-name.stderr
@@ -1,0 +1,25 @@
+error[E0428]: the name `a` is defined multiple times
+  --> $DIR/multiple-default-impls-same-name.rs:18:1
+   |
+LL | fn a() {}
+   | ------ previous definition of the value `a` here
+...
+LL | fn a() {}
+   | ^^^^^^ `a` redefined here
+   |
+   = note: `a` must be defined only once in the value namespace of this module
+
+error[E0428]: the name `eii1` is defined multiple times
+  --> $DIR/multiple-default-impls-same-name.rs:16:1
+   |
+LL | #[eii(eii1)]
+   | ------------ previous definition of the macro `eii1` here
+...
+LL | #[eii(eii1)]
+   | ^^^^^^^^^^^^ `eii1` redefined here
+   |
+   = note: `eii1` must be defined only once in the macro namespace of this module
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0428`.

--- a/tests/ui/eii/default/multiple-default-impls.rs
+++ b/tests/ui/eii/default/multiple-default-impls.rs
@@ -1,0 +1,8 @@
+#![crate_type = "lib"]
+#![feature(extern_item_impls)]
+
+#[eii(eii1)]
+fn a() {}
+
+#[eii(eii1)]
+fn b() {}

--- a/tests/ui/eii/default/multiple-default-impls.rs
+++ b/tests/ui/eii/default/multiple-default-impls.rs
@@ -1,8 +1,18 @@
 #![crate_type = "lib"]
 #![feature(extern_item_impls)]
+// `eii` expands to, among other things, `macro eii() {}`.
+// If we have two eiis named the same thing, we have a duplicate definition
+// for that macro. The compiler happily continues compiling on duplicate
+// definitions though, to emit as many diagnostics as possible.
+// However, in the case of eiis, this can break the assumption that every
+// eii has only one default implementation, since the default for both eiis will
+// name resolve to the same eii definiton (since the other definition was duplicate)
+// This test tests for the previously-ICE that occurred when this assumption
+// (of 1 default) was broken which was reported in #149982.
 
 #[eii(eii1)]
 fn a() {}
 
 #[eii(eii1)]
+//~^ ERROR the name `eii1` is defined multiple times
 fn b() {}

--- a/tests/ui/eii/default/multiple-default-impls.stderr
+++ b/tests/ui/eii/default/multiple-default-impls.stderr
@@ -1,0 +1,14 @@
+error[E0428]: the name `eii1` is defined multiple times
+  --> $DIR/multiple-default-impls.rs:16:1
+   |
+LL | #[eii(eii1)]
+   | ------------ previous definition of the macro `eii1` here
+...
+LL | #[eii(eii1)]
+   | ^^^^^^^^^^^^ `eii1` redefined here
+   |
+   = note: `eii1` must be defined only once in the macro namespace of this module
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0428`.


### PR DESCRIPTION
r? @jieyouxu (since you looked at the other one)

Fixes https://github.com/rust-lang/rust/issues/149982

Previously a [fix was proposed](https://github.com/rust-lang/rust/pull/149985) by @SATVIKsynopsis which I marked as co-author on the first commit for the test they contributed. I'm closing this previous PR.

Duplicate definitions of EII defaults shouldn't be possible. I want to still panic on them, since I want to know when other bugs exist. However, in this case the duplicate was caused by something more subtle: both eiis have the same name, and as such a "duplicate definition" error is given. However, the compiler gracefully continues compiling despite that, assuming only one of the two EIIs is actually defined.

Both defaults then name resolve, and find the same single remaining EII, and both register themselves to be its default, breaking the single-default assumption.

The solution: I added a span-delayed-bug, to make sure we only panic if we hadn't previously had this duplicate definition name resolution error. 

Thanks to @SATVIKsynopsis for their attempt. Adding a diagnostic here could make some sense, but nonetheless I think this is the better solution here <3
Also thanks to @yaahc for debugging help, she made me understand the name resolution of the situation so much better and is just lovely in general :3

The last commit is something I tried during debugging, which felt like a relevant test to add (one where both eiis also have the same function name)