### PR TITLE
Prefer remapping the relative `library/` and `compiler/` directories

### DIFF
--- a/compiler/rustc_metadata/src/rmeta/decoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder.rs
@@ -1669,15 +1669,14 @@ impl<'a> CrateMetadataRef<'a> {
                 for virtual_dir in virtual_source_base_dir.iter().flatten() {
                     if let Some(real_dir) = &real_source_base_dir
                         && let rustc_span::FileName::Real(old_name) = name
-                        && let (_working_dir, embeddable_name) =
-                            old_name.embeddable_name(RemapPathScopeComponents::MACRO)
-                        && let Ok(rest) = embeddable_name.strip_prefix(virtual_dir)
+                        && let virtual_path = old_name.path(RemapPathScopeComponents::MACRO)
+                        && let Ok(rest) = virtual_path.strip_prefix(virtual_dir)
                     {
                         let new_path = real_dir.join(rest);
 
                         debug!(
                             "try_to_translate_virtual_to_real: `{}` -> `{}`",
-                            embeddable_name.display(),
+                            virtual_path.display(),
                             new_path.display(),
                         );
 

--- a/src/bootstrap/src/core/builder/cargo.rs
+++ b/src/bootstrap/src/core/builder/cargo.rs
@@ -1032,10 +1032,7 @@ impl Builder<'_> {
                     self.build.debuginfo_map_to(GitRepo::Rustc, RemapScheme::Compiler)
                 {
                     // When building compiler sources, we want to apply the compiler remap scheme.
-                    cargo.env(
-                        "RUSTC_DEBUGINFO_MAP",
-                        format!("{}={}", self.build.src.display(), map_to),
-                    );
+                    cargo.env("RUSTC_DEBUGINFO_MAP", format!("compiler/={map_to}/compiler"));
                     cargo.env("CFG_VIRTUAL_RUSTC_DEV_SOURCE_BASE_DIR", map_to);
                 }
             }
@@ -1047,10 +1044,7 @@ impl Builder<'_> {
                 if let Some(ref map_to) =
                     self.build.debuginfo_map_to(GitRepo::Rustc, RemapScheme::NonCompiler)
                 {
-                    cargo.env(
-                        "RUSTC_DEBUGINFO_MAP",
-                        format!("{}={}", self.build.src.display(), map_to),
-                    );
+                    cargo.env("RUSTC_DEBUGINFO_MAP", format!("library/={map_to}/library"));
                 }
             }
         }

--- a/tests/ui/extern/extern-types-field-offset.rs
+++ b/tests/ui/extern/extern-types-field-offset.rs
@@ -2,6 +2,7 @@
 //@ check-run-results
 //@ exec-env:RUST_BACKTRACE=0
 //@ normalize-stderr: "(core/src/panicking\.rs):[0-9]+:[0-9]+" -> "$1:$$LINE:$$COL"
+//@ normalize-stderr: "/rustc(?:-dev)?/[a-z0-9.]+/" -> ""
 //@ ignore-backends: gcc
 #![feature(extern_types)]
 

--- a/tests/ui/hygiene/panic-location.rs
+++ b/tests/ui/hygiene/panic-location.rs
@@ -2,6 +2,7 @@
 //@ check-run-results
 //@ exec-env:RUST_BACKTRACE=0
 //@ normalize-stderr: ".rs:\d+:\d+" -> ".rs:LL:CC"
+//@ normalize-stderr: "/rustc(?:-dev)?/[a-z0-9.]+/" -> ""
 //
 // Regression test for issue #70963
 // The reported panic location should not be `<::core::macros::panic macros>`.

--- a/tests/ui/mir/lint/storage-live.rs
+++ b/tests/ui/mir/lint/storage-live.rs
@@ -4,6 +4,7 @@
 //@ normalize-stderr: "thread 'rustc'.*panicked.*\n" -> ""
 //@ normalize-stderr: "storage_live\[....\]" -> "storage_live[HASH]"
 //@ normalize-stderr: "(delayed at [^:]+):\d+:\d+ - " -> "$1:LL:CC - "
+//@ normalize-stderr: "/rustc(?:-dev)?/[a-z0-9.]+/" -> ""
 //@ rustc-env:RUST_BACKTRACE=0
 
 #![feature(custom_mir, core_intrinsics)]

--- a/tests/ui/mir/lint/storage-live.stderr
+++ b/tests/ui/mir/lint/storage-live.stderr
@@ -1,12 +1,12 @@
 error: internal compiler error: broken MIR in Item(DefId(0:8 ~ storage_live[HASH]::multiple_storage)) (after pass CheckForceInline) at bb0[1]:
                                 StorageLive(_1) which already has storage here
-  --> $DIR/storage-live.rs:21:13
+  --> $DIR/storage-live.rs:22:13
    |
 LL |             StorageLive(a);
    |             ^^^^^^^^^^^^^^
    |
 note: delayed at compiler/rustc_mir_transform/src/lint.rs:LL:CC - disabled backtrace
-  --> $DIR/storage-live.rs:21:13
+  --> $DIR/storage-live.rs:22:13
    |
 LL |             StorageLive(a);
    |             ^^^^^^^^^^^^^^

--- a/tests/ui/panics/panic-in-cleanup.rs
+++ b/tests/ui/panics/panic-in-cleanup.rs
@@ -5,6 +5,7 @@
 //@ normalize-stderr: "\n +[0-9]+:[^\n]+" -> ""
 //@ normalize-stderr: "\n +at [^\n]+" -> ""
 //@ normalize-stderr: "(core/src/panicking\.rs):[0-9]+:[0-9]+" -> "$1:$$LINE:$$COL"
+//@ normalize-stderr: "/rustc(?:-dev)?/[a-z0-9.]+/" -> ""
 //@ needs-unwind
 //@ ignore-emscripten "RuntimeError" junk in output
 //@ ignore-msvc SEH doesn't do panic-during-cleanup the same way as everyone else

--- a/tests/ui/panics/panic-in-cleanup.run.stderr
+++ b/tests/ui/panics/panic-in-cleanup.run.stderr
@@ -1,9 +1,9 @@
 
-thread 'main' ($TID) panicked at $DIR/panic-in-cleanup.rs:22:5:
+thread 'main' ($TID) panicked at $DIR/panic-in-cleanup.rs:23:5:
 explicit panic
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 
-thread 'main' ($TID) panicked at $DIR/panic-in-cleanup.rs:16:9:
+thread 'main' ($TID) panicked at $DIR/panic-in-cleanup.rs:17:9:
 BOOM
 stack backtrace:
 

--- a/tests/ui/panics/panic-in-ffi.rs
+++ b/tests/ui/panics/panic-in-ffi.rs
@@ -6,6 +6,7 @@
 //@ normalize-stderr: "\n +[0-9]+:[^\n]+" -> ""
 //@ normalize-stderr: "\n +at [^\n]+" -> ""
 //@ normalize-stderr: "(core/src/panicking\.rs):[0-9]+:[0-9]+" -> "$1:$$LINE:$$COL"
+//@ normalize-stderr: "/rustc(?:-dev)?/[a-z0-9.]+/" -> ""
 //@ needs-unwind
 //@ ignore-emscripten "RuntimeError" junk in output
 

--- a/tests/ui/panics/panic-in-ffi.run.stderr
+++ b/tests/ui/panics/panic-in-ffi.run.stderr
@@ -1,5 +1,5 @@
 
-thread 'main' ($TID) panicked at $DIR/panic-in-ffi.rs:21:5:
+thread 'main' ($TID) panicked at $DIR/panic-in-ffi.rs:22:5:
 Test
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 Noisy Drop

--- a/tests/ui/process/println-with-broken-pipe.rs
+++ b/tests/ui/process/println-with-broken-pipe.rs
@@ -11,6 +11,7 @@
 //@ ignore-visionos no 'head'
 //@ ignore-backends: gcc
 //@ normalize-stderr: ".rs:\d+:\d+" -> ".rs:LL:CC"
+//@ normalize-stderr: "/rustc(?:-dev)?/[a-z0-9.]+/" -> ""
 //@ compile-flags: -Zon-broken-pipe=error
 
 // Test what the error message looks like when `println!()` panics because of

--- a/tests/ui/resolve/multiple_definitions_attribute_merging.rs
+++ b/tests/ui/resolve/multiple_definitions_attribute_merging.rs
@@ -7,6 +7,7 @@
 //@ normalize-stderr: "note: .*\n\n" -> ""
 //@ normalize-stderr: "thread 'rustc'.*panicked.*\n" -> ""
 //@ normalize-stderr: "(error: internal compiler error: [^:]+):\d+:\d+: " -> "$1:LL:CC: "
+//@ normalize-stderr: "/rustc(?:-dev)?/[a-z0-9.]+/" -> ""
 //@ rustc-env:RUST_BACKTRACE=0
 
 #[repr(packed)]

--- a/tests/ui/resolve/multiple_definitions_attribute_merging.stderr
+++ b/tests/ui/resolve/multiple_definitions_attribute_merging.stderr
@@ -1,5 +1,5 @@
 error[E0428]: the name `Dealigned` is defined multiple times
-  --> $DIR/multiple_definitions_attribute_merging.rs:17:1
+  --> $DIR/multiple_definitions_attribute_merging.rs:18:1
    |
 LL | struct Dealigned<T>(u8, T);
    | --------------------------- previous definition of the type `Dealigned` here
@@ -8,7 +8,7 @@ LL | struct Dealigned<T>(u8, T);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Dealigned` redefined here
    |
    = error: internal compiler error: compiler/rustc_mir_transform/src/check_packed_ref.rs:LL:CC: builtin derive created an unaligned reference
-  --> $DIR/multiple_definitions_attribute_merging.rs:17:25
+  --> $DIR/multiple_definitions_attribute_merging.rs:18:25
    |
 LL | #[derive(PartialEq)]
    |          --------- in this derive macro expansion
@@ -19,8 +19,8 @@ LL | struct Dealigned<T>(u8, T);
 
 Box<dyn Any>
 query stack during panic:
-#0 [mir_built] building MIR for `<impl at $DIR/multiple_definitions_attribute_merging.rs:15:10: 15:19>::eq`
-#1 [check_unsafety] unsafety-checking `<impl at $DIR/multiple_definitions_attribute_merging.rs:15:10: 15:19>::eq`
+#0 [mir_built] building MIR for `<impl at $DIR/multiple_definitions_attribute_merging.rs:16:10: 16:19>::eq`
+#1 [check_unsafety] unsafety-checking `<impl at $DIR/multiple_definitions_attribute_merging.rs:16:10: 16:19>::eq`
 ... and 1 other queries... use `env RUST_BACKTRACE=1` to see the full query stack
 error: aborting due to 2 previous errors
 

--- a/tests/ui/resolve/proc_macro_generated_packed.rs
+++ b/tests/ui/resolve/proc_macro_generated_packed.rs
@@ -7,6 +7,7 @@
 //@ normalize-stderr: "note: .*\n\n" -> ""
 //@ normalize-stderr: "thread 'rustc'.*panicked.*\n" -> ""
 //@ normalize-stderr: "(error: internal compiler error: [^:]+):\d+:\d+: " -> "$1:LL:CC: "
+//@ normalize-stderr: "/rustc(?:-dev)?/[a-z0-9.]+/" -> ""
 //@ rustc-env:RUST_BACKTRACE=0
 
 extern crate proc_macro_generate_packed;

--- a/tests/ui/resolve/proc_macro_generated_packed.stderr
+++ b/tests/ui/resolve/proc_macro_generated_packed.stderr
@@ -1,5 +1,5 @@
 error: internal compiler error: compiler/rustc_mir_transform/src/check_packed_ref.rs:LL:CC: builtin derive created an unaligned reference
-  --> $DIR/proc_macro_generated_packed.rs:18:25
+  --> $DIR/proc_macro_generated_packed.rs:19:25
    |
 LL | #[derive(PartialEq)]
    |          --------- in this derive macro expansion
@@ -10,8 +10,8 @@ LL | struct Dealigned<T>(u8, T);
 
 Box<dyn Any>
 query stack during panic:
-#0 [mir_built] building MIR for `<impl at $DIR/proc_macro_generated_packed.rs:15:10: 15:19>::eq`
-#1 [check_unsafety] unsafety-checking `<impl at $DIR/proc_macro_generated_packed.rs:15:10: 15:19>::eq`
+#0 [mir_built] building MIR for `<impl at $DIR/proc_macro_generated_packed.rs:16:10: 16:19>::eq`
+#1 [check_unsafety] unsafety-checking `<impl at $DIR/proc_macro_generated_packed.rs:16:10: 16:19>::eq`
 ... and 1 other queries... use `env RUST_BACKTRACE=1` to see the full query stack
 error: aborting due to 1 previous error
 

--- a/tests/ui/track-diagnostics/track.rs
+++ b/tests/ui/track-diagnostics/track.rs
@@ -7,6 +7,7 @@
 // updating everytime someone adds or removes a line.
 //@ normalize-stderr: ".rs:\d+:\d+" -> ".rs:LL:CC"
 //@ normalize-stderr: "note: rustc .+ running on .+" -> "note: rustc $$VERSION running on $$TARGET"
+//@ normalize-stderr: "/rustc(?:-dev)?/[a-z0-9.]+/" -> ""
 
 // The test becomes too flaky if we care about exact args. If `-Z ui-testing`
 // from compiletest and `-Z track-diagnostics` from `// compile-flags` at the

--- a/tests/ui/track-diagnostics/track2.rs
+++ b/tests/ui/track-diagnostics/track2.rs
@@ -4,6 +4,7 @@
 // Normalize the emitted location so this doesn't need
 // updating everytime someone adds or removes a line.
 //@ normalize-stderr: ".rs:\d+:\d+" -> ".rs:LL:CC"
+//@ normalize-stderr: "/rustc(?:-dev)?/[a-z0-9.]+/" -> ""
 
 fn main() {
     let _moved @ _from = String::from("foo");

--- a/tests/ui/track-diagnostics/track3.rs
+++ b/tests/ui/track-diagnostics/track3.rs
@@ -4,6 +4,7 @@
 // Normalize the emitted location so this doesn't need
 // updating everytime someone adds or removes a line.
 //@ normalize-stderr: ".rs:\d+:\d+" -> ".rs:LL:CC"
+//@ normalize-stderr: "/rustc(?:-dev)?/[a-z0-9.]+/" -> ""
 
 fn main() {
     let _unimported = Blah { field: u8 };

--- a/tests/ui/track-diagnostics/track4.rs
+++ b/tests/ui/track-diagnostics/track4.rs
@@ -4,6 +4,7 @@
 // Normalize the emitted location so this doesn't need
 // updating everytime someone adds or removes a line.
 //@ normalize-stderr: ".rs:\d+:\d+" -> ".rs:LL:CC"
+//@ normalize-stderr: "/rustc(?:-dev)?/[a-z0-9.]+/" -> ""
 
 pub onion {
     //~^ ERROR missing `enum` for enum definition

--- a/tests/ui/track-diagnostics/track5.rs
+++ b/tests/ui/track-diagnostics/track5.rs
@@ -4,6 +4,7 @@
 // Normalize the emitted location so this doesn't need
 // updating everytime someone adds or removes a line.
 //@ normalize-stderr: ".rs:\d+:\d+" -> ".rs:LL:CC"
+//@ normalize-stderr: "/rustc(?:-dev)?/[a-z0-9.]+/" -> ""
 
 }
 //~^ ERROR unexpected closing delimiter: `}`

--- a/tests/ui/track-diagnostics/track6.rs
+++ b/tests/ui/track-diagnostics/track6.rs
@@ -4,13 +4,13 @@
 // Normalize the emitted location so this doesn't need
 // updating everytime someone adds or removes a line.
 //@ normalize-stderr: ".rs:\d+:\d+" -> ".rs:LL:CC"
-
+//@ normalize-stderr: "/rustc(?:-dev)?/[a-z0-9.]+/" -> ""
 
 pub trait Foo {
     fn bar();
 }
 
-impl <T> Foo for T {
+impl<T> Foo for T {
     default fn bar() {}
     //~^ ERROR specialization is unstable
     //~| NOTE created at

--- a/tests/ui/type/pattern_types/bad_const_generics_args_on_const_param.rs
+++ b/tests/ui/type/pattern_types/bad_const_generics_args_on_const_param.rs
@@ -3,6 +3,7 @@
 //@ normalize-stderr: "note: .*\n\n" -> ""
 //@ normalize-stderr: "thread 'rustc'.*panicked.*\n" -> ""
 //@ normalize-stderr: "(error: internal compiler error: [^:]+):\d+:\d+: " -> "$1:LL:CC: "
+//@ normalize-stderr: "/rustc(?:-dev)?/[a-z0-9.]+/" -> ""
 //@ rustc-env:RUST_BACKTRACE=0
 
 #![feature(pattern_types, pattern_type_macro, generic_const_exprs)]

--- a/tests/ui/type/pattern_types/bad_const_generics_args_on_const_param.stderr
+++ b/tests/ui/type/pattern_types/bad_const_generics_args_on_const_param.stderr
@@ -1,12 +1,12 @@
 warning: the feature `generic_const_exprs` is incomplete and may not be safe to use and/or cause compiler crashes
-  --> $DIR/bad_const_generics_args_on_const_param.rs:8:47
+  --> $DIR/bad_const_generics_args_on_const_param.rs:9:47
    |
 LL | #![feature(pattern_types, pattern_type_macro, generic_const_exprs)]
    |                                               ^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #76560 <https://github.com/rust-lang/rust/issues/76560> for more information
    = error: internal compiler error: compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs:LL:CC: try_lower_anon_const_lit: received const param which shouldn't be possible
-  --> $DIR/bad_const_generics_args_on_const_param.rs:12:36
+  --> $DIR/bad_const_generics_args_on_const_param.rs:13:36
    |
 LL |     std::pat::pattern_type!(u32 is START::<(), i32, 2>..=END::<_, Assoc = ()>);
    |                                    ^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
This is done to avoid leaking the relative paths to the standard library after the overall of filenames in rust-lang/rust#149709.

Noted that the paths were already leaking before, but to a lesser extent since most (but not all) the paths embedded in the distributed `rlib` were absolute.

In general Cargo compiles workspace members with relative paths, so it's better anyway to remap the relative path.

In addition to our tests I have manually confirmed that it also works as expected for the printed diagnostics paths.

cf. https://rust-lang.zulipchat.com/#narrow/channel/131828-t-compiler/topic/remapping.20of.20the.20standard.20library/near/564093571

<!-- homu-ignore:start -->
r? @jieyouxu
<!-- homu-ignore:end -->
