### PR TITLE
Add `target_feature = "gc"` for Wasm

### DIFF
--- a/compiler/rustc_codegen_llvm/src/llvm_util.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm_util.rs
@@ -266,6 +266,10 @@ pub(crate) fn to_llvm_features<'a>(sess: &Session, s: &'a str) -> Option<LLVMFea
             "leoncasa" => Some(LLVMFeature::new("hasleoncasa")),
             s => Some(LLVMFeature::new(s)),
         },
+        Arch::Wasm32 | Arch::Wasm64 => match s {
+            "gc" if major < 22 => None,
+            s => Some(LLVMFeature::new(s)),
+        },
         Arch::X86 | Arch::X86_64 => {
             match s {
                 "sse4.2" => Some(LLVMFeature::with_dependencies(

--- a/compiler/rustc_target/src/target_features.rs
+++ b/compiler/rustc_target/src/target_features.rs
@@ -745,6 +745,7 @@ static WASM_FEATURES: &[(&str, Stability, ImpliedFeatures)] = &[
     ("bulk-memory", Stable, &[]),
     ("exception-handling", Unstable(sym::wasm_target_feature), &[]),
     ("extended-const", Stable, &[]),
+    ("gc", Unstable(sym::wasm_target_feature), &["reference-types"]),
     ("multivalue", Stable, &[]),
     ("mutable-globals", Stable, &[]),
     ("nontrapping-fptoint", Stable, &[]),

--- a/tests/ui/check-cfg/target_feature.stderr
+++ b/tests/ui/check-cfg/target_feature.stderr
@@ -121,6 +121,7 @@ LL |     cfg!(target_feature = "_UNEXPECTED_VALUE");
 `frecipe`
 `frintts`
 `fxsr`
+`gc`
 `gfni`
 `guarded-storage`
 `hard-float`


### PR DESCRIPTION
This PR adds a new target feature for Wasm targets: [GC](https://github.com/WebAssembly/gc).

~~I went ahead and made this insta-stable because it has already [passed phase 5](https://github.com/WebAssembly/proposals/blob/88e7bd6ba9bc585135edcb4def2c4d284f5fd0fc/finished-proposals.md) in addition to being [implemented and stabilized by all major JS engines](https://webassembly.org/features).~~

~~This doesn't enable the target feature by default!~~

For context: while this proposal adds a lot of new features to Wasm, they are not accessible through Rust apart from unstable inline ASM. This is largely useful to signal tools to make use of the feature, e.g. `wasm-bindgen`, where this can be used to make some pretty optimizations.

Companion PR: https://github.com/rust-lang/reference/pull/2114.

r? @alexcrichton