### PR TITLE
Add methods to split off array chunks from slices

### DIFF
--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -5090,6 +5090,124 @@ impl<T> [T] {
         Some(last)
     }
 
+    /// Removes the first chunk of the slice and returns a reference
+    /// to it.
+    ///
+    /// Returns `None` if the slice has fewer than `N` elements.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(slice_split_off_chunk)]
+    /// let mut slice: &[_] = &['a', 'b', 'c', 'd'];
+    /// let head = slice.split_off_first_chunk::<2>().unwrap();
+    ///
+    /// assert_eq!(slice, &['c', 'd']);
+    /// assert_eq!(head, &['a', 'b']);
+    /// ```
+    #[unstable(feature = "slice_split_off_chunk", issue = "none")]
+    #[rustc_const_unstable(feature = "const_slice_split_off_chunk", issue = "none")]
+    pub const fn split_off_first_chunk<'a, const N: usize>(
+        self: &mut &'a Self,
+    ) -> Option<&'a [T; N]> {
+        // FIXME(const-hack): Use `?` when available in const instead of `let-else`.
+        let Some((head, rem)) = self.split_first_chunk::<N>() else { return None };
+        *self = rem;
+        Some(head)
+    }
+
+    /// Removes the first chunk of the slice and returns a mutable
+    /// reference to it.
+    ///
+    /// Returns `None` if the slice has fewer than `N` elements.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(slice_split_off_chunk)]
+    /// let mut slice: &mut [_] = &mut ['a', 'b', 'c', 'd'];
+    /// let head = slice.split_off_first_chunk_mut::<2>().unwrap();
+    ///
+    /// assert_eq!(slice, &mut ['c', 'd']);
+    /// assert_eq!(head, &mut ['a', 'b']);
+    /// ```
+    #[unstable(feature = "slice_split_off_chunk", issue = "none")]
+    #[rustc_const_unstable(feature = "const_slice_split_off_chunk", issue = "none")]
+    pub const fn split_off_first_chunk_mut<'a, const N: usize>(
+        self: &mut &'a mut Self,
+    ) -> Option<&'a mut [T; N]> {
+        if self.len() < N {
+            // Avoid failing in the next spot, which moves out of `self`.
+            return None;
+        }
+        // FIXME(const-hack): Use `mem::take` and `?` when available in const.
+        // Original: `mem::take(self).split_first_chunk_mut::<N>()?`
+        let Some((head, rem)) = mem::replace(self, &mut []).split_first_chunk_mut::<N>() else {
+            return None;
+        };
+        *self = rem;
+        Some(head)
+    }
+
+    /// Removes the last chunk of the slice and returns a reference
+    /// to it.
+    ///
+    /// Returns `None` if the slice has fewer than `N` elements.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(slice_split_off_chunk)]
+    /// let mut slice: &[_] = &['a', 'b', 'c', 'd'];
+    /// let tail = slice.split_off_last_chunk::<2>().unwrap();
+    ///
+    /// assert_eq!(slice, &['a', 'b']);
+    /// assert_eq!(tail, &['c', 'd']);
+    /// ```
+    #[unstable(feature = "slice_split_off_chunk", issue = "none")]
+    #[rustc_const_unstable(feature = "const_slice_split_off_chunk", issue = "none")]
+    pub const fn split_off_last_chunk<'a, const N: usize>(
+        self: &mut &'a Self,
+    ) -> Option<&'a [T; N]> {
+        // FIXME(const-hack): Use `?` when available in const instead of `let-else`.
+        let Some((rem, tail)) = self.split_last_chunk::<N>() else { return None };
+        *self = rem;
+        Some(tail)
+    }
+
+    /// Removes the last chunk of the slice and returns a mutable
+    /// reference to it.
+    ///
+    /// Returns `None` if the slice has fewer than `N` elements.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(slice_split_off_chunk)]
+    /// let mut slice: &mut [_] = &mut ['a', 'b', 'c', 'd'];
+    /// let tail = slice.split_off_last_chunk_mut::<2>().unwrap();
+    ///
+    /// assert_eq!(slice, &mut ['a', 'b']);
+    /// assert_eq!(tail, &mut ['c', 'd']);
+    /// ```
+    #[unstable(feature = "slice_split_off_chunk", issue = "none")]
+    #[rustc_const_unstable(feature = "const_slice_split_off_chunk", issue = "none")]
+    pub const fn split_off_last_chunk_mut<'a, const N: usize>(
+        self: &mut &'a mut Self,
+    ) -> Option<&'a mut [T; N]> {
+        if self.len() < N {
+            // Avoid failing in the next spot, which moves out of `self`.
+            return None;
+        }
+        // FIXME(const-hack): Use `mem::take` and `?` when available in const.
+        // Original: `mem::take(self).split_last_chunk_mut::<N>()?`
+        let Some((rem, tail)) = mem::replace(self, &mut []).split_last_chunk_mut::<N>() else {
+            return None;
+        };
+        *self = rem;
+        Some(tail)
+    }
+
     /// Returns mutable references to many indices at once, without doing any checks.
     ///
     /// An index can be either a `usize`, a [`Range`] or a [`RangeInclusive`]. Note

--- a/library/coretests/tests/lib.rs
+++ b/library/coretests/tests/lib.rs
@@ -103,6 +103,7 @@
 #![feature(slice_internals)]
 #![feature(slice_partition_dedup)]
 #![feature(slice_shift)]
+#![feature(slice_split_off_chunk)]
 #![feature(slice_split_once)]
 #![feature(sliceindex_wrappers)]
 #![feature(split_array)]


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

I implemented the slice methods described in my ACP https://github.com/rust-lang/libs-team/issues/543:
```rust
impl<T> [T] {
    pub const fn split_off_first_chunk<'a, const N: usize>(self: &mut &'a Self) -> Option<&'a [T; N]>;
    pub const fn split_off_first_chunk_mut<'a, const N: usize>(self: &mut &'a mut Self) -> Option<&'a mut [T; N]>;
    pub const fn split_off_last_chunk<'a, const N: usize>(self: &mut &'a Self) -> Option<&'a [T; N]>;
    pub const fn split_off_last_chunk_mut<'a, const N: usize>(self: &mut &'a mut Self) -> Option<&'a mut [T; N]>;
}
```

The only difference from my original ACP post was that I put the `first`/`last` before `chunk` in the name instead of after it (the ACP has also been updated to match these names). My default intuition when I wrote that ACP was to have the names all appear next to each other alphabetically, but as I was implementing it I checked for similar-looking functions, and I found that `split_first_chunk` and related methods (which are basically these methods but without the in-place modification of `self`) do the other order and I decided it would be better to match how the other functions are named.

This is my first PR into rust itself, so I did my best to figure out the norms (both for the process around making a PR and the code I put in the PR) and follow them, but I probably got some stuff wrong so I'm sorry in advance for whatever I got wrong.