### PR TITLE
Use realstd current thread static variables in tests

### DIFF
--- a/library/std/src/io/stdio.rs
+++ b/library/std/src/io/stdio.rs
@@ -1287,4 +1287,4 @@ pub fn _eprint(args: fmt::Arguments<'_>) {
 }
 
 #[cfg(test)]
-pub use realstd::io::{_eprint, _print};
+pub use realstd::test_internals::{_eprint, _print};

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -255,7 +255,18 @@
 #![allow(unused_features)]
 //
 // Features:
-#![cfg_attr(test, feature(internal_output_capture, print_internals, update_panic_count, rt))]
+#![cfg_attr(
+    test,
+    feature(
+        internal_output_capture,
+        print_internals,
+        update_panic_count,
+        rt,
+        thread_current_internals,
+        thread_local_internals,
+        thread_local_internal_pointer
+    )
+)]
 #![cfg_attr(
     all(target_vendor = "fortanix", target_env = "sgx"),
     feature(slice_index_methods, coerce_unsized, sgx_platform)
@@ -361,6 +372,7 @@
 #![feature(str_internals)]
 #![feature(sync_unsafe_cell)]
 #![feature(temporary_niche_types)]
+#![feature(test_internals)]
 #![feature(ub_checks)]
 #![feature(used_with_arg)]
 // tidy-alphabetical-end
@@ -758,3 +770,8 @@ mod sealed {
 #[cfg(test)]
 #[allow(dead_code)] // Not used in all configurations.
 pub(crate) mod test_helpers;
+
+#[doc(hidden)]
+#[unstable(feature = "test_internals", issue = "none")]
+#[cfg(not(test))]
+pub mod test_internals;

--- a/library/std/src/panicking.rs
+++ b/library/std/src/panicking.rs
@@ -14,7 +14,7 @@ use core::panic::{Location, PanicPayload};
 // make sure to use the stderr output configured
 // by libtest in the real copy of std
 #[cfg(test)]
-use realstd::io::try_set_output_capture;
+use realstd::test_internals::try_set_output_capture;
 
 use crate::any::Any;
 #[cfg(not(test))]
@@ -487,7 +487,7 @@ pub mod panic_count {
 }
 
 #[cfg(test)]
-pub use realstd::rt::panic_count;
+pub use realstd::test_internals::panic_count;
 
 /// Invoke a closure, capturing the cause of an unwinding panic if one occurs.
 #[cfg(panic = "immediate-abort")]

--- a/library/std/src/sys/thread_local/native/mod.rs
+++ b/library/std/src/sys/thread_local/native/mod.rs
@@ -114,13 +114,17 @@ pub macro thread_local_inner {
 pub(crate) macro local_pointer {
     () => {},
     ($vis:vis static $name:ident; $($rest:tt)*) => {
+
+        #[doc(hidden)]
+        #[unstable(feature = "thread_local_internal_pointer", issue = "none")]
         #[thread_local]
         $vis static $name: $crate::sys::thread_local::LocalPointer = $crate::sys::thread_local::LocalPointer::__new();
         $crate::sys::thread_local::local_pointer! { $($rest)* }
     },
 }
 
-pub(crate) struct LocalPointer {
+#[allow(missing_debug_implementations)]
+pub struct LocalPointer {
     p: Cell<*mut ()>,
 }
 

--- a/library/std/src/sys/thread_local/no_threads.rs
+++ b/library/std/src/sys/thread_local/no_threads.rs
@@ -123,12 +123,15 @@ unsafe impl<T> Sync for LazyStorage<T> {}
 pub(crate) macro local_pointer {
     () => {},
     ($vis:vis static $name:ident; $($rest:tt)*) => {
+        #[doc(hidden)]
+        #[unstable(feature = "thread_local_internal_pointer", issue = "none")]
         $vis static $name: $crate::sys::thread_local::LocalPointer = $crate::sys::thread_local::LocalPointer::__new();
         $crate::sys::thread_local::local_pointer! { $($rest)* }
     },
 }
 
-pub(crate) struct LocalPointer {
+#[allow(missing_debug_implementations)]
+pub struct LocalPointer {
     p: Cell<*mut ()>,
 }
 

--- a/library/std/src/sys/thread_local/os.rs
+++ b/library/std/src/sys/thread_local/os.rs
@@ -265,12 +265,15 @@ unsafe extern "C" fn destroy_value<T: 'static, const ALIGN: usize>(ptr: *mut u8)
 pub(crate) macro local_pointer {
     () => {},
     ($vis:vis static $name:ident; $($rest:tt)*) => {
+        #[doc(hidden)]
+        #[unstable(feature = "thread_local_internal_pointer", issue = "none")]
         $vis static $name: $crate::sys::thread_local::LocalPointer = $crate::sys::thread_local::LocalPointer::__new();
         $crate::sys::thread_local::local_pointer! { $($rest)* }
     },
 }
 
-pub(crate) struct LocalPointer {
+#[allow(missing_debug_implementations)]
+pub struct LocalPointer {
     key: LazyKey,
 }
 

--- a/library/std/src/test_internals.rs
+++ b/library/std/src/test_internals.rs
@@ -1,0 +1,21 @@
+/// A collection of common re-exports to be used by the test version of this crate.
+pub use crate::thread::current::CURRENT as CURRENT_THREAD;
+
+cfg_select! {
+    target_thread_local => {
+        pub use crate::thread::current::id::ID as CURRENT_THREAD_ID;
+    }
+    target_pointer_width = "16" => {
+        pub use crate::thread::current::id::ID0 as CURRENT_THREAD_ID0;
+        pub use crate::thread::current::id::ID16 as CURRENT_THREAD_ID16;
+        pub use crate::thread::current::id::ID32 as CURRENT_THREAD_ID32;
+        pub use crate::thread::current::id::ID48 as CURRENT_THREAD_ID48;
+    }
+    target_pointer_width = "32" => {
+        pub use crate::thread::current::id::ID0 as CURRENT_THREAD_ID0;
+        pub use crate::thread::current::id::ID32 as CURRENT_THREAD_ID32;
+    }
+    _ => {
+        pub use crate::thread::current::id::ID as CURRENT_THREAD_ID;
+    }
+}

--- a/library/std/src/test_internals.rs
+++ b/library/std/src/test_internals.rs
@@ -1,4 +1,6 @@
 /// A collection of common re-exports to be used by the test version of this crate.
+pub use crate::io::{_eprint, _print, try_set_output_capture};
+pub use crate::rt::panic_count;
 pub use crate::thread::current::CURRENT as CURRENT_THREAD;
 
 cfg_select! {

--- a/library/std/src/thread/mod.rs
+++ b/library/std/src/thread/mod.rs
@@ -161,7 +161,9 @@ use crate::any::Any;
 #[macro_use]
 mod local;
 mod builder;
-mod current;
+#[doc(hidden)]
+#[unstable(feature = "thread_current_internals", issue = "none")]
+pub(crate) mod current;
 mod functions;
 mod id;
 mod join_handle;


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/150131)*
<!-- homu-ignore:end -->

Fixes rust-lang/rust#150053. This PR basically exports `thread::current::CURRENT` & `thread::current::ID*` static variables and be referred to them when testing. I also added a minor refactoring which collects symbols referred as `readlstd::...` in  `test_internals` module.

If approved, i would kindly ask this PR to be beta nominated.

Thank you.