### PR TITLE
Add PartialEq<Vec<U>> for [T; N]

### DIFF
--- a/library/core/src/array/equality.rs
+++ b/library/core/src/array/equality.rs
@@ -124,6 +124,23 @@ where
     }
 }
 
+#[stable(feature = "rust1", since = "1.0.0")]
+impl<T, U, const N: usize> PartialEq<Vec<U>> for [T; N]
+where
+    T: PartialEq<U>,
+{
+    #[inline]
+    fn eq(&self, other: &Vec<U>) -> bool {
+        self[..] == other[..]
+    }
+
+    #[inline]
+    fn ne(&self, other: &Vec<U>) -> bool {
+        self[..] != other[..]
+    }
+}
+
+
 // NOTE: some less important impls are omitted to reduce code bloat
 // __impl_slice_eq2! { [A; $N], &'b [B; $N] }
 // __impl_slice_eq2! { [A; $N], &'b mut [B; $N] }


### PR DESCRIPTION
### Summary

This PR fixes asymmetric equality between arrays and `Vec`s by adding a missing
`PartialEq<Vec<U>> for [T; N]` implementation.

Previously, comparisons like `Vec<T> == [T; N]` were supported, but the reverse
`[T; N] == Vec<T>` failed due to the absence of a corresponding `PartialEq` impl.
This PR completes the symmetry by forwarding the comparison to existing slice
equality.

### Details

- Adds `PartialEq<Vec<U>> for [T; N]` in the array equality implementation.
- The comparison is implemented by converting both sides to slices and reusing
  existing slice equality logic.
- No new behavior is introduced beyond completing the missing symmetric case.
- No allocations or unsafe code are involved.

Fixes rust-lang/rust#149017

