### PR TITLE
mir_build: Remove unnecessary lifetime from THIR `PatCtxt`

### DIFF
--- a/compiler/rustc_mir_build/src/thir/pattern/const_to_pat.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/const_to_pat.rs
@@ -28,7 +28,7 @@ use crate::errors::{
     PointerPattern, TypeNotPartialEq, TypeNotStructural, UnionPattern, UnsizedPattern,
 };
 
-impl<'a, 'tcx> PatCtxt<'a, 'tcx> {
+impl<'tcx> PatCtxt<'tcx> {
     /// Converts a constant to a pattern (if possible).
     /// This means aggregate values (like structs and enums) are converted
     /// to a pattern that matches the value (as if you'd compared via structural equality).
@@ -64,7 +64,7 @@ struct ConstToPat<'tcx> {
 }
 
 impl<'tcx> ConstToPat<'tcx> {
-    fn new(pat_ctxt: &PatCtxt<'_, 'tcx>, id: hir::HirId, span: Span, c: ty::Const<'tcx>) -> Self {
+    fn new(pat_ctxt: &PatCtxt<'tcx>, id: hir::HirId, span: Span, c: ty::Const<'tcx>) -> Self {
         trace!(?pat_ctxt.typeck_results.hir_owner);
         ConstToPat { tcx: pat_ctxt.tcx, typing_env: pat_ctxt.typing_env, span, id, c }
     }

--- a/compiler/rustc_mir_build/src/thir/pattern/mod.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/mod.rs
@@ -30,19 +30,20 @@ pub(crate) use self::check_match::check_match;
 use self::migration::PatMigration;
 use crate::errors::*;
 
-struct PatCtxt<'a, 'tcx> {
+/// Context for lowering HIR patterns to THIR patterns.
+struct PatCtxt<'tcx> {
     tcx: TyCtxt<'tcx>,
     typing_env: ty::TypingEnv<'tcx>,
-    typeck_results: &'a ty::TypeckResults<'tcx>,
+    typeck_results: &'tcx ty::TypeckResults<'tcx>,
 
     /// Used by the Rust 2024 migration lint.
-    rust_2024_migration: Option<PatMigration<'a>>,
+    rust_2024_migration: Option<PatMigration<'tcx>>,
 }
 
-pub(super) fn pat_from_hir<'a, 'tcx>(
+pub(super) fn pat_from_hir<'tcx>(
     tcx: TyCtxt<'tcx>,
     typing_env: ty::TypingEnv<'tcx>,
-    typeck_results: &'a ty::TypeckResults<'tcx>,
+    typeck_results: &'tcx ty::TypeckResults<'tcx>,
     pat: &'tcx hir::Pat<'tcx>,
 ) -> Box<Pat<'tcx>> {
     let mut pcx = PatCtxt {
@@ -62,7 +63,7 @@ pub(super) fn pat_from_hir<'a, 'tcx>(
     result
 }
 
-impl<'a, 'tcx> PatCtxt<'a, 'tcx> {
+impl<'tcx> PatCtxt<'tcx> {
     fn lower_pattern(&mut self, pat: &'tcx hir::Pat<'tcx>) -> Box<Pat<'tcx>> {
         let adjustments: &[PatAdjustment<'tcx>] =
             self.typeck_results.pat_adjustments().get(pat.hir_id).map_or(&[], |v| &**v);


### PR DESCRIPTION
It turns out that lifetime `'a` is just `'tcx` in disguise.
