### PR TITLE
fix ICE when {{root}} appears in import suggestions

### DIFF
--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -2223,7 +2223,11 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             match binding.kind {
                 NameBindingKind::Import { import, .. } => {
                     for segment in import.module_path.iter().skip(1) {
-                        path.push(segment.ident);
+                        // Don't include `{{root}}` in suggestions - it's an internal symbol
+                        // that should never be shown to users.
+                        if segment.ident.name != kw::PathRoot {
+                            path.push(segment.ident);
+                        }
                     }
                     sugg_paths.push((
                         path.iter().cloned().chain(std::iter::once(ident)).collect::<Vec<_>>(),

--- a/tests/ui/imports/nested-import-root-symbol-150103.rs
+++ b/tests/ui/imports/nested-import-root-symbol-150103.rs
@@ -1,0 +1,13 @@
+// Issue: https://github.com/rust-lang/rust/issues/150103
+// ICE when using `::` at start of nested imports
+// caused by `{{root}}` appearing in diagnostic suggestions
+
+mod A {
+    use Iuse::{ ::Fish }; //~ ERROR failed to resolve: use of unresolved module or unlinked crate
+}
+
+mod B {
+    use A::{::Fish}; //~ ERROR failed to resolve: crate root in paths can only be used in start position
+}
+
+fn main() {}

--- a/tests/ui/imports/nested-import-root-symbol-150103.stderr
+++ b/tests/ui/imports/nested-import-root-symbol-150103.stderr
@@ -1,0 +1,20 @@
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `Iuse`
+  --> $DIR/nested-import-root-symbol-150103.rs:6:9
+   |
+LL |     use Iuse::{ ::Fish };
+   |         ^^^^ use of unresolved module or unlinked crate `Iuse`
+   |
+help: you might be missing a crate named `Iuse`, add it to your project and import it in your code
+   |
+LL + extern crate Iuse;
+   |
+
+error[E0433]: failed to resolve: crate root in paths can only be used in start position
+  --> $DIR/nested-import-root-symbol-150103.rs:10:13
+   |
+LL |     use A::{::Fish};
+   |             ^ crate root in paths can only be used in start position
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0433`.


### PR DESCRIPTION
Fixes rust-lang/rust#150103 

When wrong nested imports like `use A::{::Fish}` were used, the internal {{root}} would appear in diagnostic suggestions, causing an ICE in `join_path_idents` which asserted that **{{root}} should only appear at the start of a path**.

r? @matthiaskrgr