### PR TITLE
Try mark `no_hash` queries as green after execution

### DIFF
--- a/compiler/rustc_data_structures/src/steal.rs
+++ b/compiler/rustc_data_structures/src/steal.rs
@@ -55,7 +55,7 @@ impl<T> Steal<T> {
 
     #[track_caller]
     pub fn steal(&self) -> T {
-        let value_ref = &mut *self.value.try_write().expect("stealing value which is locked");
+        let mut value_ref = self.value.write();
         let value = value_ref.take();
         value.expect("attempt to steal from stolen value")
     }

--- a/compiler/rustc_middle/src/dep_graph/mod.rs
+++ b/compiler/rustc_middle/src/dep_graph/mod.rs
@@ -12,8 +12,8 @@ pub use dep_node::{DepKind, DepNode, DepNodeExt, dep_kinds, label_strs};
 pub(crate) use dep_node::{make_compile_codegen_unit, make_compile_mono_item, make_metadata};
 pub use rustc_query_system::dep_graph::debug::{DepNodeFilter, EdgeFilter};
 pub use rustc_query_system::dep_graph::{
-    DepContext, DepGraphQuery, DepNodeIndex, Deps, SerializedDepGraph, SerializedDepNodeIndex,
-    TaskDepsRef, WorkProduct, WorkProductId, WorkProductMap, hash_result,
+    DepContext, DepGraphQuery, DepNodeIndex, Deps, MarkFrame, SerializedDepGraph,
+    SerializedDepNodeIndex, TaskDepsRef, WorkProduct, WorkProductId, WorkProductMap, hash_result,
 };
 
 pub type DepGraph = rustc_query_system::dep_graph::DepGraph<DepsType>;

--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -13,8 +13,8 @@ use rustc_hir::limit::Limit;
 use rustc_index::Idx;
 use rustc_middle::bug;
 use rustc_middle::dep_graph::{
-    self, DepContext, DepKind, DepKindStruct, DepNode, DepNodeIndex, SerializedDepNodeIndex,
-    dep_kinds,
+    self, DepContext, DepKind, DepKindStruct, DepNode, DepNodeIndex, MarkFrame,
+    SerializedDepNodeIndex, dep_kinds,
 };
 use rustc_middle::query::Key;
 use rustc_middle::query::on_disk_cache::{
@@ -489,7 +489,12 @@ where
     value
 }
 
-fn force_from_dep_node<'tcx, Q>(query: Q, tcx: TyCtxt<'tcx>, dep_node: DepNode) -> bool
+fn force_from_dep_node<'tcx, Q>(
+    query: Q,
+    tcx: TyCtxt<'tcx>,
+    dep_node: DepNode,
+    frame: &MarkFrame<'_>,
+) -> bool
 where
     Q: QueryConfig<QueryCtxt<'tcx>>,
 {
@@ -512,7 +517,7 @@ where
     );
 
     if let Some(key) = Q::Key::recover(tcx, &dep_node) {
-        force_query(query, QueryCtxt::new(tcx), key, dep_node);
+        force_query(query, QueryCtxt::new(tcx), key, dep_node, frame);
         true
     } else {
         false
@@ -540,8 +545,8 @@ where
         is_anon,
         is_eval_always,
         fingerprint_style,
-        force_from_dep_node: Some(|tcx, dep_node, _| {
-            force_from_dep_node(Q::config(tcx), tcx, dep_node)
+        force_from_dep_node: Some(|tcx, dep_node, _, frame| {
+            force_from_dep_node(Q::config(tcx), tcx, dep_node, frame)
         }),
         try_load_from_on_disk_cache: Some(|tcx, dep_node| {
             try_load_from_on_disk_cache(Q::config(tcx), tcx, dep_node)
@@ -853,7 +858,7 @@ macro_rules! define_queries {
                     is_anon: false,
                     is_eval_always: false,
                     fingerprint_style: FingerprintStyle::Unit,
-                    force_from_dep_node: Some(|_, dep_node, _| bug!("force_from_dep_node: encountered {:?}", dep_node)),
+                    force_from_dep_node: Some(|_, dep_node, _, _| bug!("force_from_dep_node: encountered {:?}", dep_node)),
                     try_load_from_on_disk_cache: None,
                     name: &"Null",
                 }
@@ -865,7 +870,7 @@ macro_rules! define_queries {
                     is_anon: false,
                     is_eval_always: false,
                     fingerprint_style: FingerprintStyle::Unit,
-                    force_from_dep_node: Some(|_, dep_node, _| bug!("force_from_dep_node: encountered {:?}", dep_node)),
+                    force_from_dep_node: Some(|_, dep_node, _, _| bug!("force_from_dep_node: encountered {:?}", dep_node)),
                     try_load_from_on_disk_cache: None,
                     name: &"Red",
                 }
@@ -876,7 +881,7 @@ macro_rules! define_queries {
                     is_anon: false,
                     is_eval_always: false,
                     fingerprint_style: FingerprintStyle::Unit,
-                    force_from_dep_node: Some(|tcx, _, prev_index| {
+                    force_from_dep_node: Some(|tcx, _, prev_index, _| {
                         tcx.dep_graph.force_diagnostic_node(QueryCtxt::new(tcx), prev_index);
                         true
                     }),
@@ -890,7 +895,7 @@ macro_rules! define_queries {
                     is_anon: true,
                     is_eval_always: false,
                     fingerprint_style: FingerprintStyle::Opaque,
-                    force_from_dep_node: Some(|_, _, _| bug!("cannot force an anon node")),
+                    force_from_dep_node: Some(|_, _, _, _| bug!("cannot force an anon node")),
                     try_load_from_on_disk_cache: None,
                     name: &"AnonZeroDeps",
                 }

--- a/compiler/rustc_query_system/src/dep_graph/dep_node.rs
+++ b/compiler/rustc_query_system/src/dep_graph/dep_node.rs
@@ -65,6 +65,7 @@ use rustc_hir::definitions::DefPathHash;
 use rustc_macros::{Decodable, Encodable};
 
 use super::{DepContext, FingerprintStyle, SerializedDepNodeIndex};
+use crate::dep_graph::graph::MarkFrame;
 use crate::ich::StableHashingContext;
 
 /// This serves as an index into arrays built by `make_dep_kind_array`.
@@ -276,8 +277,14 @@ pub struct DepKindStruct<Tcx: DepContext> {
     /// with kind `MirValidated`, we know that the GUID/fingerprint of the `DepNode`
     /// is actually a `DefPathHash`, and can therefore just look up the corresponding
     /// `DefId` in `tcx.def_path_hash_to_def_id`.
-    pub force_from_dep_node:
-        Option<fn(tcx: Tcx, dep_node: DepNode, prev_index: SerializedDepNodeIndex) -> bool>,
+    pub force_from_dep_node: Option<
+        fn(
+            tcx: Tcx,
+            dep_node: DepNode,
+            prev_index: SerializedDepNodeIndex,
+            frame: &MarkFrame<'_>,
+        ) -> bool,
+    >,
 
     /// Invoke a query to put the on-disk cached value in memory.
     pub try_load_from_on_disk_cache: Option<fn(Tcx, DepNode)>,

--- a/compiler/rustc_query_system/src/dep_graph/graph.rs
+++ b/compiler/rustc_query_system/src/dep_graph/graph.rs
@@ -749,6 +749,10 @@ impl<D: Deps> DepGraphData<D> {
                     false
                 }
             } else {
+                // This node existed in the previous compilation session. Its query was re-executed,
+                // but it doesn't compute a result hash (i.e. it represents a `no_hash` query).
+                // We can only check if node's dependencies are all green, which should be
+                // enough for us to color this node as green too.
                 if !feed && !cx.is_eval_always(key.kind) {
                     if let Some(green) = self.try_mark_previous_green(cx, prev_index, &key, frame) {
                         return green;

--- a/compiler/rustc_query_system/src/query/plumbing.rs
+++ b/compiler/rustc_query_system/src/query/plumbing.rs
@@ -20,7 +20,7 @@ use tracing::instrument;
 
 use super::{QueryConfig, QueryStackFrameExtra};
 use crate::HandleCycleError;
-use crate::dep_graph::{DepContext, DepGraphData, DepNode, DepNodeIndex, DepNodeParams};
+use crate::dep_graph::{DepContext, DepGraphData, DepNode, DepNodeIndex, DepNodeParams, MarkFrame};
 use crate::ich::StableHashingContext;
 use crate::query::caches::QueryCache;
 use crate::query::job::{QueryInfo, QueryJob, QueryJobId, QueryJobInfo, QueryLatch, report_cycle};
@@ -347,6 +347,7 @@ fn try_execute_query<Q, Qcx, const INCR: bool>(
     span: Span,
     key: Q::Key,
     dep_node: Option<DepNode>,
+    frame: Option<&MarkFrame<'_>>,
 ) -> (Q::Value, Option<DepNodeIndex>)
 where
     Q: QueryConfig<Qcx>,
@@ -382,7 +383,7 @@ where
             // Drop the lock before we start executing the query
             drop(state_lock);
 
-            execute_job::<_, _, INCR>(query, qcx, state, key, key_hash, id, dep_node)
+            execute_job::<_, _, INCR>(query, qcx, state, key, key_hash, id, dep_node, frame)
         }
         Entry::Occupied(mut entry) => {
             match &mut entry.get_mut().1 {
@@ -419,6 +420,7 @@ fn execute_job<Q, Qcx, const INCR: bool>(
     key_hash: u64,
     id: QueryJobId,
     dep_node: Option<DepNode>,
+    frame: Option<&MarkFrame<'_>>,
 ) -> (Q::Value, Option<DepNodeIndex>)
 where
     Q: QueryConfig<Qcx>,
@@ -437,6 +439,7 @@ where
             key,
             dep_node,
             id,
+            frame,
         )
     } else {
         execute_job_non_incr(query, qcx, key, id)
@@ -528,6 +531,7 @@ fn execute_job_incr<Q, Qcx>(
     key: Q::Key,
     mut dep_node_opt: Option<DepNode>,
     job_id: QueryJobId,
+    frame: Option<&MarkFrame<'_>>,
 ) -> (Q::Value, DepNodeIndex)
 where
     Q: QueryConfig<Qcx>,
@@ -568,6 +572,7 @@ where
             key,
             |(qcx, query), key| query.compute(qcx, key),
             query.hash_result(),
+            frame,
         )
     });
 
@@ -824,7 +829,9 @@ where
 {
     debug_assert!(!qcx.dep_context().dep_graph().is_fully_enabled());
 
-    ensure_sufficient_stack(|| try_execute_query::<Q, Qcx, false>(query, qcx, span, key, None).0)
+    ensure_sufficient_stack(|| {
+        try_execute_query::<Q, Qcx, false>(query, qcx, span, key, None, None).0
+    })
 }
 
 #[inline(always)]
@@ -852,7 +859,7 @@ where
     };
 
     let (result, dep_node_index) = ensure_sufficient_stack(|| {
-        try_execute_query::<_, _, true>(query, qcx, span, key, dep_node)
+        try_execute_query::<_, _, true>(query, qcx, span, key, dep_node, None)
     });
     if let Some(dep_node_index) = dep_node_index {
         qcx.dep_context().dep_graph().read_index(dep_node_index)
@@ -860,8 +867,13 @@ where
     Some(result)
 }
 
-pub fn force_query<Q, Qcx>(query: Q, qcx: Qcx, key: Q::Key, dep_node: DepNode)
-where
+pub fn force_query<Q, Qcx>(
+    query: Q,
+    qcx: Qcx,
+    key: Q::Key,
+    dep_node: DepNode,
+    frame: &MarkFrame<'_>,
+) where
     Q: QueryConfig<Qcx>,
     Qcx: QueryContext,
 {
@@ -875,6 +887,6 @@ where
     debug_assert!(!query.anon());
 
     ensure_sufficient_stack(|| {
-        try_execute_query::<_, _, true>(query, qcx, DUMMY_SP, key, Some(dep_node))
+        try_execute_query::<_, _, true>(query, qcx, DUMMY_SP, key, Some(dep_node), Some(frame))
     });
 }


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/150156)*
<!-- homu-ignore:end -->

~~This PR allows parallel front-end's green-red node coloring processes in the query dep graph to race.~~ Recall that whenever one thread tries to mark query node green and then fails to reconstruct a subquery's key to force it, parent query is tried to be forced or executed too. The subquery could be marked green by the thread during execution the parent query because key is now present. Other thread during this process is able to mark green parent query itself. And so after some time the first thread finishes the execution and finds in its place a green node. This is bad for `no_hash` queries since those are conservatively presumed to be red but actually queries must be deterministic anyway and so **`no_hash` nodes should be colored green if its deps are green too after its execution finishes.** ~~As such we can consider green color to be "stronger" that the red color and thus former would replace the latter.~~

**TODO: update rustc-dev-guide query docs and rustc comments on `no_hash` modifier**

~~I have left some refactor-ish changes I did during my dirty debugging. Let me know if you would want those to be redone or removed.~~

### Steps to reproduce

Quote from rust-lang/rust#150018, more details there:

> Do a clean build `x build library --stage 1` at 52fda2e54f805722807c90e91ac3329fe9e7ccb3, then `git checkout` to ba45f0b7d89e3b0722b20d2d25292983a5120fea and without cleaning try rebuilding it the same way again. And don't forget to set `RUSTFLAGS_BOOTSTRAP` to `-Zthreads=n` where n > 1.