### PR TITLE
rustc: Fix `-Zexport-executable-symbols` on wasm

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/linker.rs
+++ b/compiler/rustc_codegen_ssa/src/back/linker.rs
@@ -839,6 +839,11 @@ impl<'a> Linker for GccLinker<'a> {
                 self.sess.dcx().emit_fatal(errors::LibDefWriteFailure { error });
             }
             self.link_arg(path);
+        } else if self.sess.target.is_like_wasm {
+            self.link_arg("--no-export-dynamic");
+            for (sym, _) in symbols {
+                self.link_arg("--export").link_arg(sym);
+            }
         } else if crate_type == CrateType::Executable && !self.sess.target.is_like_solaris {
             let res: io::Result<()> = try {
                 let mut f = File::create_buffered(&path)?;
@@ -853,11 +858,6 @@ impl<'a> Linker for GccLinker<'a> {
                 self.sess.dcx().emit_fatal(errors::VersionScriptWriteFailure { error });
             }
             self.link_arg("--dynamic-list").link_arg(path);
-        } else if self.sess.target.is_like_wasm {
-            self.link_arg("--no-export-dynamic");
-            for (sym, _) in symbols {
-                self.link_arg("--export").link_arg(sym);
-            }
         } else {
             // Write an LD version script
             let res: io::Result<()> = try {


### PR DESCRIPTION
This commit reorders some cases in `export_symbols` in the linker implementation for wasm to ensure that the `is_like_wasm` case is handled before the catch-all `CrateType::Executable` case.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
