### PR TITLE
fix lint to catch async fn with maybe sized return type

### DIFF
--- a/tests/ui/async-await/async-fn-unsized-return-type.rs
+++ b/tests/ui/async-await/async-fn-unsized-return-type.rs
@@ -1,0 +1,13 @@
+//@ edition: 2021
+#![deny(opaque_hidden_inferred_bound)]
+// Test that async functions cannot return unsized types via `impl Trait + ?Sized`
+// Issue #149438
+
+use std::fmt::Debug;
+
+async fn unsized_async() -> impl Debug + ?Sized {
+    //~^ ERROR opaque type `impl Future<Output = impl Debug + ?Sized>` does not satisfy its associated type bounds
+    123
+}
+
+fn main() {}

--- a/tests/ui/async-await/async-fn-unsized-return-type.stderr
+++ b/tests/ui/async-await/async-fn-unsized-return-type.stderr
@@ -1,0 +1,21 @@
+error: opaque type `impl Future<Output = impl Debug + ?Sized>` does not satisfy its associated type bounds
+  --> $DIR/async-fn-unsized-return-type.rs:8:29
+   |
+LL | async fn unsized_async() -> impl Debug + ?Sized {
+   |                             ^^^^^^^^^^^^^^^^^^^
+   |
+  --> $SRC_DIR/core/src/future/future.rs:LL:COL
+   |
+   = note: this associated type bound is unsatisfied for `impl Debug + ?Sized`
+note: the lint level is defined here
+  --> $DIR/async-fn-unsized-return-type.rs:2:9
+   |
+LL | #![deny(opaque_hidden_inferred_bound)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: add this bound
+   |
+LL | async fn unsized_async() -> impl Debug + ?Sized + Sized {
+   |                                                 +++++++
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Fixes rust-lang/rust#149438 

The compiler incorrectly accepted nested RPITs with `?Sized` bounds when used in associated type positions that have implicit Sized bounds. See this [playgound](https://play.rust-lang.org/?version=stable&mode=debug&edition=2024&gist=1afdfd8384c3a56c9f5c3bd2a1be2bba)

The fix is to only skip validation when the nested RPIT does NOT have an explicit ?Sized bound.