### PR TITLE
Make some MIR ref types closer to the source they are lowered from

### DIFF
--- a/compiler/rustc_mir_transform/src/promote_consts.rs
+++ b/compiler/rustc_mir_transform/src/promote_consts.rs
@@ -760,10 +760,12 @@ impl<'a, 'tcx> Promoter<'a, 'tcx> {
         }
 
         let num_stmts = self.source[loc.block].statements.len();
-        let new_temp = self.promoted.local_decls.push(LocalDecl::new(
-            self.source.local_decls[temp].ty,
-            self.source.local_decls[temp].source_info.span,
-        ));
+        let new_local_decl = {
+            let temp = &self.source.local_decls[temp];
+            let local_decl = LocalDecl::new(temp.ty, temp.source_info.span);
+            if temp.mutability == Mutability::Not { local_decl.immutable() } else { local_decl }
+        };
+        let new_temp = self.promoted.local_decls.push(new_local_decl);
 
         debug!("promote({:?} @ {:?}/{:?}, {:?})", temp, loc, num_stmts, self.keep_original);
 

--- a/tests/mir-opt/const_promotion_extern_static.BAR-promoted[0].SimplifyCfg-pre-optimizations.after.mir
+++ b/tests/mir-opt/const_promotion_extern_static.BAR-promoted[0].SimplifyCfg-pre-optimizations.after.mir
@@ -2,9 +2,9 @@
 
 const BAR::promoted[0]: &[&i32; 1] = {
     let mut _0: &[&i32; 1];
-    let mut _1: [&i32; 1];
+    let _1: [&i32; 1];
     let mut _2: &i32;
-    let mut _3: &i32;
+    let _3: &i32;
 
     bb0: {
         _3 = const {ALLOC0: &i32};

--- a/tests/mir-opt/const_promotion_extern_static.FOO-promoted[0].SimplifyCfg-pre-optimizations.after.mir
+++ b/tests/mir-opt/const_promotion_extern_static.FOO-promoted[0].SimplifyCfg-pre-optimizations.after.mir
@@ -2,9 +2,9 @@
 
 const FOO::promoted[0]: &[&i32; 1] = {
     let mut _0: &[&i32; 1];
-    let mut _1: [&i32; 1];
+    let _1: [&i32; 1];
     let mut _2: &i32;
-    let mut _3: *const i32;
+    let _3: *const i32;
 
     bb0: {
         _3 = const {ALLOC0: *const i32};


### PR DESCRIPTION
cc https://github.com/rust-lang/rust/pull/149973#issuecomment-3654158858

r? RalfJung 
Sorry for bothering you, but I think it might be better to get the required MIR changes approved first, and then move on to implementing the actual lints for recursive static refs 😅