### PR TITLE
Handle remapped paths correctly when generating "Source" links

### DIFF
--- a/src/librustdoc/html/render/context.rs
+++ b/src/librustdoc/html/render/context.rs
@@ -14,7 +14,7 @@ use rustc_hir::def_id::{DefIdMap, LOCAL_CRATE};
 use rustc_middle::ty::TyCtxt;
 use rustc_session::Session;
 use rustc_span::edition::Edition;
-use rustc_span::{BytePos, FileName, Symbol};
+use rustc_span::{BytePos, FileName, RemapPathScopeComponents, Symbol};
 use tracing::info;
 
 use super::print_item::{full_path, print_item, print_item_path};
@@ -365,7 +365,10 @@ impl<'tcx> Context<'tcx> {
 
         // We can safely ignore synthetic `SourceFile`s.
         let file = match span.filename(self.sess()) {
-            FileName::Real(ref path) => path.local_path()?.to_path_buf(),
+            FileName::Real(ref path) => path
+                .local_path()
+                .unwrap_or(path.path(RemapPathScopeComponents::MACRO))
+                .to_path_buf(),
             _ => return None,
         };
         let file = &file;
@@ -499,10 +502,12 @@ impl<'tcx> Context<'tcx> {
         } = options;
 
         let src_root = match krate.src(tcx) {
-            FileName::Real(ref p) => match p.local_path().map(|p| p.parent()).flatten() {
-                Some(p) => p.to_path_buf(),
-                None => PathBuf::new(),
-            },
+            FileName::Real(ref p) => {
+                match p.local_path().unwrap_or(p.path(RemapPathScopeComponents::MACRO)).parent() {
+                    Some(p) => p.to_path_buf(),
+                    None => PathBuf::new(),
+                }
+            }
             _ => PathBuf::new(),
         };
         // If user passed in `--playground-url` arg, we fill in crate name here

--- a/tests/rustdoc/auxiliary/remapped-paths.rs
+++ b/tests/rustdoc/auxiliary/remapped-paths.rs
@@ -1,0 +1,11 @@
+//@ compile-flags:-Zunstable-options --remap-path-prefix={{src-base}}=
+
+pub struct MyStruct {
+    field: u32,
+}
+
+impl MyStruct {
+    pub fn new() -> MyStruct {
+        MyStruct { field: 3 }
+    }
+}

--- a/tests/rustdoc/import-remapped-paths.rs
+++ b/tests/rustdoc/import-remapped-paths.rs
@@ -13,7 +13,6 @@
 extern crate remapped_paths;
 
 //@ has foo/struct.MyStruct.html
-// FIXME: Doesn't work!
 //@ has - '//a[@href="../src/remapped_paths/remapped-paths.rs.html#3"]' 'Source'
 //@ has - '//a[@href="../src/remapped_paths/remapped-paths.rs.html#8"]' 'Source'
 

--- a/tests/rustdoc/import-remapped-paths.rs
+++ b/tests/rustdoc/import-remapped-paths.rs
@@ -1,7 +1,7 @@
 // This is a regression for `--remap-path-prefix` in an auxiliary dependency.
 //
 // We want to make sure that we can still have the "Source" links to the dependency
-// even if it's paths are remapped.
+// even if its paths are remapped.
 //
 // See also rust-lang/rust#150100
 

--- a/tests/rustdoc/import-remapped-paths.rs
+++ b/tests/rustdoc/import-remapped-paths.rs
@@ -1,0 +1,20 @@
+// This is a regression for `--remap-path-prefix` in an auxiliary dependency.
+//
+// We want to make sure that we can still have the "Source" links to the dependency
+// even if it's paths are remapped.
+//
+// See also rust-lang/rust#150100
+
+//@ aux-build:remapped-paths.rs
+//@ build-aux-docs
+
+#![crate_name = "foo"]
+
+extern crate remapped_paths;
+
+//@ has foo/struct.MyStruct.html
+// FIXME: Doesn't work!
+//@ has - '//a[@href="../src/remapped_paths/remapped-paths.rs.html#3"]' 'Source'
+//@ has - '//a[@href="../src/remapped_paths/remapped-paths.rs.html#8"]' 'Source'
+
+pub use remapped_paths::MyStruct;


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/150100.

This PR fixes a regression introduced by [#149709](https://github.com/rust-lang/rust/issues/149709), I was overzealous in my changes (https://github.com/rust-lang/rust/pull/149709/changes#diff-e1cf7ef2fb411d24980cd4cbea1e867cc36029e9496e1ceca64cfb6a0e3510f6) and accidentally changed the behavior of `rustdoc` in the presence of remapped, to simply reject them instead of handling them.

With this PR remapped paths are handled correctly, in a similar way as it was before.

~~I added a run-make test to make sure we don't regress it again, a simple `rustdoc` test in not sufficient as `rustdoc` is not called on the auxiliary crate. It's not pretty but it works.~~ https://github.com/rust-lang/rust/pull/150172#issuecomment-3676762399

rustdoc doesn't have any handling for `--remap-path-scope`, so I used the `MACRO` scope (it was already used [elsewhere](https://github.com/rust-lang/rust/blob/b889870082dd0b0e3594bbfbebb4545d54710829/src/librustdoc/clean/types.rs#L154).

cf. https://rust-lang.zulipchat.com/#narrow/channel/266220-t-rustdoc/topic/source.20links.20missing.20for.20nightly.20std.20docs

<!-- homu-ignore:start -->
r? @GuillaumeGomez
<!-- homu-ignore:end -->
