### PR TITLE
Wasm: stabilize `target_feature = "gc"`

### DIFF
--- a/compiler/rustc_target/src/target_features.rs
+++ b/compiler/rustc_target/src/target_features.rs
@@ -745,7 +745,7 @@ static WASM_FEATURES: &[(&str, Stability, ImpliedFeatures)] = &[
     ("bulk-memory", Stable, &[]),
     ("exception-handling", Unstable(sym::wasm_target_feature), &[]),
     ("extended-const", Stable, &[]),
-    ("gc", Unstable(sym::wasm_target_feature), &["reference-types"]),
+    ("gc", Stable, &["reference-types"]),
     ("multivalue", Stable, &[]),
     ("mutable-globals", Stable, &[]),
     ("nontrapping-fptoint", Stable, &[]),

--- a/tests/ui/wasm/wasm-stable-target-features.rs
+++ b/tests/ui/wasm/wasm-stable-target-features.rs
@@ -17,23 +17,26 @@ fn foo3() {}
 #[target_feature(enable = "extended-const")]
 fn foo4() {}
 
-#[target_feature(enable = "mutable-globals")]
+#[target_feature(enable = "gc")]
 fn foo5() {}
 
-#[target_feature(enable = "nontrapping-fptoint")]
+#[target_feature(enable = "mutable-globals")]
 fn foo6() {}
 
-#[target_feature(enable = "simd128")]
+#[target_feature(enable = "nontrapping-fptoint")]
 fn foo7() {}
 
-#[target_feature(enable = "relaxed-simd")]
+#[target_feature(enable = "simd128")]
 fn foo8() {}
 
-#[target_feature(enable = "sign-ext")]
+#[target_feature(enable = "relaxed-simd")]
 fn foo9() {}
 
-#[target_feature(enable = "tail-call")]
+#[target_feature(enable = "sign-ext")]
 fn foo10() {}
+
+#[target_feature(enable = "tail-call")]
+fn foo11() {}
 
 fn main() {
     foo1();
@@ -46,4 +49,5 @@ fn main() {
     foo8();
     foo9();
     foo10();
+    foo11();
 }


### PR DESCRIPTION
Follow-up to https://github.com/rust-lang/rust/pull/150111, stabilizing the new target features.

> [..] it has already [passed phase 5](https://github.com/WebAssembly/proposals/blob/88e7bd6ba9bc585135edcb4def2c4d284f5fd0fc/finished-proposals.md) in addition to being [implemented and stabilized by all major JS engines](https://webassembly.org/features).
>
> This doesn't enable the target feature by default!
>
> For context: while this proposal adds a lot of new features to Wasm, they are not accessible through Rust apart from unstable inline ASM. This is largely useful to signal tools to make use of the feature, e.g. `wasm-bindgen`, where this can be used to make some pretty optimizations.

While merging this has to wait until LLVM 22 releases, which is a long way off, I thought it might still be sensible to get FCP approval now. But let me know if this would be considered too premature.

Addresses rust-lang/rust#150260.
Companion PR: https://github.com/rust-lang/reference/pull/2114.

r? @alexcrichton 