### PR TITLE
mir_build: Use the same length type for `TestableCase::Slice` and `TestKind::Len`

### DIFF
--- a/compiler/rustc_mir_build/src/builder/matches/buckets.rs
+++ b/compiler/rustc_mir_build/src/builder/matches/buckets.rs
@@ -218,7 +218,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 &TestKind::Len { len: test_len, op: BinOp::Eq },
                 &TestableCase::Slice { len, variable_length },
             ) => {
-                match (test_len.cmp(&(len as u64)), variable_length) {
+                match (test_len.cmp(&len), variable_length) {
                     (Ordering::Equal, false) => {
                         // on true, min_len = len = $actual_length,
                         // on false, len != $actual_length
@@ -251,7 +251,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 &TestableCase::Slice { len, variable_length },
             ) => {
                 // the test is `$actual_len >= test_len`
-                match (test_len.cmp(&(len as u64)), variable_length) {
+                match (test_len.cmp(&len), variable_length) {
                     (Ordering::Equal, true) => {
                         // $actual_len >= test_len = pat_len,
                         // so we can match.

--- a/compiler/rustc_mir_build/src/builder/matches/match_pair.rs
+++ b/compiler/rustc_mir_build/src/builder/matches/match_pair.rs
@@ -256,7 +256,7 @@ impl<'tcx> MatchPairTree<'tcx> {
                     None
                 } else {
                     Some(TestableCase::Slice {
-                        len: prefix.len() + suffix.len(),
+                        len: u64::try_from(prefix.len() + suffix.len()).unwrap(),
                         variable_length: slice.is_some(),
                     })
                 }

--- a/compiler/rustc_mir_build/src/builder/matches/mod.rs
+++ b/compiler/rustc_mir_build/src/builder/matches/mod.rs
@@ -1264,7 +1264,7 @@ enum TestableCase<'tcx> {
     Variant { adt_def: ty::AdtDef<'tcx>, variant_index: VariantIdx },
     Constant { value: ty::Value<'tcx> },
     Range(Arc<PatRange<'tcx>>),
-    Slice { len: usize, variable_length: bool },
+    Slice { len: u64, variable_length: bool },
     Deref { temp: Place<'tcx>, mutability: Mutability },
     Never,
     Or { pats: Box<[FlatPat<'tcx>]> },

--- a/compiler/rustc_mir_build/src/builder/matches/test.rs
+++ b/compiler/rustc_mir_build/src/builder/matches/test.rs
@@ -47,7 +47,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
 
             TestableCase::Slice { len, variable_length } => {
                 let op = if variable_length { BinOp::Ge } else { BinOp::Eq };
-                TestKind::Len { len: len as u64, op }
+                TestKind::Len { len, op }
             }
 
             TestableCase::Deref { temp, mutability } => TestKind::Deref { temp, mutability },


### PR DESCRIPTION
If we convert the minimum length to `u64` up-front when creating `TestableCase::Slice`, we can avoid more conversions to `u64` later.

There should be no change to compiler behaviour.