### PR TITLE
[rustdoc] Add missing close tags in extern crate reexports

### DIFF
--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -439,6 +439,7 @@ fn item_module(cx: &Context<'_>, item: &clean::Item, items: &[clean::Item]) -> i
                                 )?;
                             }
                         }
+                        write!(w, "</code></dt>")?
                     }
                     clean::ImportItem(ref import) => {
                         let stab_tags =

--- a/tests/rustdoc/extern/pub-extern-crate-150176.rs
+++ b/tests/rustdoc/extern/pub-extern-crate-150176.rs
@@ -1,0 +1,5 @@
+//@ aux-build:pub-extern-crate.rs
+
+//@ has pub_extern_crate_150176/index.html
+//@ hasraw - 'pub extern crate inner;</code></dt>'
+pub extern crate inner;

--- a/tests/rustdoc/extern/pub-extern-crate-150176.rs
+++ b/tests/rustdoc/extern/pub-extern-crate-150176.rs
@@ -1,5 +1,9 @@
 //@ aux-build:pub-extern-crate.rs
 
+// A refactor had left us missing the closing tags,
+// ensure that they are present.
+// https://github.com/rust-lang/rust/issues/150176
+
 //@ has pub_extern_crate_150176/index.html
-//@ hasraw - 'pub extern crate inner;</code></dt>'
+//@ hasraw - '<dt><code>pub extern crate inner;</code></dt>'
 pub extern crate inner;


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Fixes rust-lang/rust#150176