### PR TITLE
Rollup of 2 pull requests

### DIFF
--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -2956,11 +2956,6 @@ impl Target {
             matches!(self.linker_flavor, LinkerFlavor::Bpf),
             "`linker_flavor` must be `bpf` if and only if `arch` is `bpf`"
         );
-        check_eq!(
-            self.arch == Arch::Nvptx64,
-            matches!(self.linker_flavor, LinkerFlavor::Ptx),
-            "`linker_flavor` must be `ptc` if and only if `arch` is `nvptx64`"
-        );
 
         for args in [
             &self.pre_link_args,

--- a/compiler/rustc_target/src/spec/targets/nvptx64_nvidia_cuda.rs
+++ b/compiler/rustc_target/src/spec/targets/nvptx64_nvidia_cuda.rs
@@ -19,9 +19,7 @@ pub(crate) fn target() -> Target {
         options: TargetOptions {
             os: Os::Cuda,
             vendor: "nvidia".into(),
-            linker_flavor: LinkerFlavor::Ptx,
-            // The linker can be installed from `crates.io`.
-            linker: Some("rust-ptx-linker".into()),
+            linker_flavor: LinkerFlavor::Llbc,
 
             // With `ptx-linker` approach, it can be later overridden via link flags.
             cpu: "sm_30".into(),

--- a/src/doc/rustc/src/platform-support/nvptx64-nvidia-cuda.md
+++ b/src/doc/rustc/src/platform-support/nvptx64-nvidia-cuda.md
@@ -12,7 +12,7 @@ platform.
 
 ## Requirements
 
-This target is `no_std` and will typically be built with crate-type `cdylib` and `-C linker-flavor=llbc`, which generates PTX.
+This target is `no_std`, and uses the `llvm-bitcode-linker` by default. For PTX output, build with crate-type `cdylib`.
 The necessary components for this workflow are:
 
 - `rustup toolchain add nightly`
@@ -38,7 +38,7 @@ While the compiler accepts `#[target_feature(enable = "ptx80", enable = "sm_89")
 A `no_std` crate containing one or more functions with `extern "ptx-kernel"` can be compiled to PTX using a command like the following.
 
 ```console
-$ RUSTFLAGS='-Ctarget-cpu=sm_89' cargo +nightly rustc --target=nvptx64-nvidia-cuda -Zbuild-std=core --crate-type=cdylib -- -Clinker-flavor=llbc -Zunstable-options
+$ RUSTFLAGS='-Ctarget-cpu=sm_89' cargo +nightly rustc --target=nvptx64-nvidia-cuda -Zbuild-std=core --crate-type=cdylib
 ```
 
 Intrinsics in `core::arch::nvptx` may use `#[cfg(target_feature = "...")]`, thus it's necessary to use `-Zbuild-std=core` with appropriate `RUSTFLAGS`. The following components are needed for this workflow:

--- a/src/librustdoc/html/render/context.rs
+++ b/src/librustdoc/html/render/context.rs
@@ -14,7 +14,7 @@ use rustc_hir::def_id::{DefIdMap, LOCAL_CRATE};
 use rustc_middle::ty::TyCtxt;
 use rustc_session::Session;
 use rustc_span::edition::Edition;
-use rustc_span::{BytePos, FileName, Symbol};
+use rustc_span::{BytePos, FileName, RemapPathScopeComponents, Symbol};
 use tracing::info;
 
 use super::print_item::{full_path, print_item, print_item_path};
@@ -365,7 +365,10 @@ impl<'tcx> Context<'tcx> {
 
         // We can safely ignore synthetic `SourceFile`s.
         let file = match span.filename(self.sess()) {
-            FileName::Real(ref path) => path.local_path()?.to_path_buf(),
+            FileName::Real(ref path) => path
+                .local_path()
+                .unwrap_or(path.path(RemapPathScopeComponents::MACRO))
+                .to_path_buf(),
             _ => return None,
         };
         let file = &file;
@@ -499,10 +502,12 @@ impl<'tcx> Context<'tcx> {
         } = options;
 
         let src_root = match krate.src(tcx) {
-            FileName::Real(ref p) => match p.local_path().map(|p| p.parent()).flatten() {
-                Some(p) => p.to_path_buf(),
-                None => PathBuf::new(),
-            },
+            FileName::Real(ref p) => {
+                match p.local_path().unwrap_or(p.path(RemapPathScopeComponents::MACRO)).parent() {
+                    Some(p) => p.to_path_buf(),
+                    None => PathBuf::new(),
+                }
+            }
             _ => PathBuf::new(),
         };
         // If user passed in `--playground-url` arg, we fill in crate name here

--- a/tests/assembly-llvm/nvptx-arch-default.rs
+++ b/tests/assembly-llvm/nvptx-arch-default.rs
@@ -1,5 +1,5 @@
 //@ assembly-output: ptx-linker
-//@ compile-flags: --crate-type cdylib -Z unstable-options -Clinker-flavor=llbc
+//@ compile-flags: --crate-type cdylib
 //@ only-nvptx64
 
 #![no_std]

--- a/tests/assembly-llvm/nvptx-arch-target-cpu.rs
+++ b/tests/assembly-llvm/nvptx-arch-target-cpu.rs
@@ -1,5 +1,5 @@
 //@ assembly-output: ptx-linker
-//@ compile-flags: --crate-type cdylib -C target-cpu=sm_50 -Z unstable-options -Clinker-flavor=llbc
+//@ compile-flags: --crate-type cdylib -C target-cpu=sm_50
 //@ only-nvptx64
 
 #![no_std]

--- a/tests/assembly-llvm/nvptx-c-abi-arg-v7.rs
+++ b/tests/assembly-llvm/nvptx-c-abi-arg-v7.rs
@@ -1,5 +1,5 @@
 //@ assembly-output: ptx-linker
-//@ compile-flags: --crate-type cdylib -C target-cpu=sm_86 -Z unstable-options -Clinker-flavor=llbc
+//@ compile-flags: --crate-type cdylib -C target-cpu=sm_86
 //@ only-nvptx64
 
 // The PTX ABI stability is tied to major versions of the PTX ISA

--- a/tests/assembly-llvm/nvptx-c-abi-ret-v7.rs
+++ b/tests/assembly-llvm/nvptx-c-abi-ret-v7.rs
@@ -1,5 +1,5 @@
 //@ assembly-output: ptx-linker
-//@ compile-flags: --crate-type cdylib -C target-cpu=sm_86 -Z unstable-options -Clinker-flavor=llbc
+//@ compile-flags: --crate-type cdylib -C target-cpu=sm_86
 //@ only-nvptx64
 
 // The PTX ABI stability is tied to major versions of the PTX ISA

--- a/tests/assembly-llvm/nvptx-kernel-abi/nvptx-kernel-args-abi-v7.rs
+++ b/tests/assembly-llvm/nvptx-kernel-abi/nvptx-kernel-args-abi-v7.rs
@@ -1,5 +1,5 @@
 //@ assembly-output: ptx-linker
-//@ compile-flags: --crate-type cdylib -C target-cpu=sm_86 -Z unstable-options -Clinker-flavor=llbc
+//@ compile-flags: --crate-type cdylib -C target-cpu=sm_86
 //@ only-nvptx64
 
 // The following ABI tests are made with nvcc 11.6 does.

--- a/tests/assembly-llvm/nvptx-safe-naming.rs
+++ b/tests/assembly-llvm/nvptx-safe-naming.rs
@@ -1,5 +1,5 @@
 //@ assembly-output: ptx-linker
-//@ compile-flags: --crate-type cdylib -Z unstable-options -Clinker-flavor=llbc
+//@ compile-flags: --crate-type cdylib
 //@ only-nvptx64
 //@ revisions: LLVM20 LLVM21
 //@ [LLVM21] min-llvm-version: 21

--- a/tests/rustdoc/auxiliary/remapped-paths.rs
+++ b/tests/rustdoc/auxiliary/remapped-paths.rs
@@ -1,0 +1,11 @@
+//@ compile-flags:-Zunstable-options --remap-path-prefix={{src-base}}=
+
+pub struct MyStruct {
+    field: u32,
+}
+
+impl MyStruct {
+    pub fn new() -> MyStruct {
+        MyStruct { field: 3 }
+    }
+}

--- a/tests/rustdoc/import-remapped-paths.rs
+++ b/tests/rustdoc/import-remapped-paths.rs
@@ -13,7 +13,6 @@
 extern crate remapped_paths;
 
 //@ has foo/struct.MyStruct.html
-// FIXME: Doesn't work!
 //@ has - '//a[@href="../src/remapped_paths/remapped-paths.rs.html#3"]' 'Source'
 //@ has - '//a[@href="../src/remapped_paths/remapped-paths.rs.html#8"]' 'Source'
 

--- a/tests/rustdoc/import-remapped-paths.rs
+++ b/tests/rustdoc/import-remapped-paths.rs
@@ -1,7 +1,7 @@
 // This is a regression for `--remap-path-prefix` in an auxiliary dependency.
 //
 // We want to make sure that we can still have the "Source" links to the dependency
-// even if it's paths are remapped.
+// even if its paths are remapped.
 //
 // See also rust-lang/rust#150100
 

--- a/tests/rustdoc/import-remapped-paths.rs
+++ b/tests/rustdoc/import-remapped-paths.rs
@@ -1,0 +1,20 @@
+// This is a regression for `--remap-path-prefix` in an auxiliary dependency.
+//
+// We want to make sure that we can still have the "Source" links to the dependency
+// even if it's paths are remapped.
+//
+// See also rust-lang/rust#150100
+
+//@ aux-build:remapped-paths.rs
+//@ build-aux-docs
+
+#![crate_name = "foo"]
+
+extern crate remapped_paths;
+
+//@ has foo/struct.MyStruct.html
+// FIXME: Doesn't work!
+//@ has - '//a[@href="../src/remapped_paths/remapped-paths.rs.html#3"]' 'Source'
+//@ has - '//a[@href="../src/remapped_paths/remapped-paths.rs.html#8"]' 'Source'
+
+pub use remapped_paths::MyStruct;


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#148499 (Nvptx: Use llbc as default linker)
 - rust-lang/rust#150172 (Handle remapped paths correctly when generating "Source" links)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=148499,150172)
<!-- homu-ignore:end -->