### PR TITLE
Add title field to `ice.md` issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/ice.md
+++ b/.github/ISSUE_TEMPLATE/ice.md
@@ -2,6 +2,7 @@
 name: Internal Compiler Error
 about: Create a report for an internal compiler error in rustc.
 labels: C-bug, I-ICE, T-compiler
+title: "[ICE]: "
 ---
 <!--
 Thank you for finding an Internal Compiler Error! 🧊  If possible, try to provide


### PR DESCRIPTION
The `ice.yml` template has [a title field](https://github.com/rust-lang/rust/blob/d0835adc4e114eac911150b3692b830b5583223a/.github/ISSUE_TEMPLATE/ice.yaml?plain=1#L4), but the `ice.md` template doesn't.
