### PR TITLE
compiletest: Support revisions in debuginfo (read: debugger) tests

### DIFF
--- a/src/tools/compiletest/src/directives.rs
+++ b/src/tools/compiletest/src/directives.rs
@@ -15,7 +15,7 @@ use crate::directives::directive_names::{
 };
 pub(crate) use crate::directives::file::FileDirectives;
 use crate::directives::handlers::DIRECTIVE_HANDLERS_MAP;
-use crate::directives::line::{DirectiveLine, line_directive};
+use crate::directives::line::DirectiveLine;
 use crate::directives::needs::CachedNeedsConditions;
 use crate::edition::{Edition, parse_edition};
 use crate::errors::ErrorKind;
@@ -29,6 +29,7 @@ mod directive_names;
 mod file;
 mod handlers;
 mod line;
+pub(crate) use line::line_directive;
 mod line_number;
 pub(crate) use line_number::LineNumber;
 mod needs;

--- a/src/tools/compiletest/src/runtest/debuginfo.rs
+++ b/src/tools/compiletest/src/runtest/debuginfo.rs
@@ -46,7 +46,7 @@ impl TestCx<'_> {
         }
 
         // Parse debugger commands etc from test files
-        let dbg_cmds = DebuggerCommands::parse_from(&self.testpaths.file, "cdb")
+        let dbg_cmds = DebuggerCommands::parse_from(&self.testpaths.file, "cdb", self.revision)
             .unwrap_or_else(|e| self.fatal(&e));
 
         // https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/debugger-commands
@@ -105,7 +105,7 @@ impl TestCx<'_> {
     }
 
     fn run_debuginfo_gdb_test(&self) {
-        let dbg_cmds = DebuggerCommands::parse_from(&self.testpaths.file, "gdb")
+        let dbg_cmds = DebuggerCommands::parse_from(&self.testpaths.file, "gdb", self.revision)
             .unwrap_or_else(|e| self.fatal(&e));
         let mut cmds = dbg_cmds.commands.join("\n");
 
@@ -366,7 +366,7 @@ impl TestCx<'_> {
         }
 
         // Parse debugger commands etc from test files
-        let dbg_cmds = DebuggerCommands::parse_from(&self.testpaths.file, "lldb")
+        let dbg_cmds = DebuggerCommands::parse_from(&self.testpaths.file, "lldb", self.revision)
             .unwrap_or_else(|e| self.fatal(&e));
 
         // Write debugger script:

--- a/tests/debuginfo/macro-stepping.rs
+++ b/tests/debuginfo/macro-stepping.rs
@@ -14,8 +14,10 @@
 #[macro_use]
 extern crate macro_stepping; // exports new_scope!()
 
-//@ compile-flags:-g -Zmir-enable-passes=-SingleUseConsts
-// SingleUseConsts shouldn't need to be disabled, see #128945
+//@ compile-flags: -g
+// FIXME(#128945): SingleUseConsts shouldn't need to be disabled.
+//@ revisions: default-mir-passes no-SingleUseConsts-mir-pass
+//@ [no-SingleUseConsts-mir-pass] compile-flags: -Zmir-enable-passes=-SingleUseConsts
 
 // === GDB TESTS ===================================================================================
 
@@ -48,7 +50,7 @@ extern crate macro_stepping; // exports new_scope!()
 //@ gdb-check:[...]#inc-loc2[...]
 //@ gdb-command:next
 //@ gdb-command:frame
-//@ gdb-check:[...]#inc-loc3[...]
+//@ [no-SingleUseConsts-mir-pass] gdb-check:[...]#inc-loc3[...]
 
 // === LLDB TESTS ==================================================================================
 


### PR DESCRIPTION
And start using revisions in `tests/debuginfo/macro-stepping.rs` to prevent regressing both with and without `SingleUseConsts` MIR pass.

I recommend commit-by-commit review.

## ~TODO~

- [x] Verify this more carefully.
- [x] Possibly do some preparatory PRs before taking this PR out of draft. 
    - [x] Rebase on https://github.com/rust-lang/rust/pull/150205 once merged so we don't have to add another "`+ 1`".

## CC

CC @Zalathar since you might have opinions about that I expose a helper function to reduce duplication

CC @saethlin since this is what we will use for `tests/debuginfo/basic-stepping.rs` in https://github.com/rust-lang/rust/pull/147426 (in the same way I use it in `tests/debuginfo/macro-stepping.rs` here) 