### PR TITLE
Drop the From derive macro from the v1 prelude

### DIFF
--- a/library/core/src/prelude/v1.rs
+++ b/library/core/src/prelude/v1.rs
@@ -118,13 +118,6 @@ pub use crate::macros::builtin::deref;
 )]
 pub use crate::macros::builtin::define_opaque;
 
-#[unstable(
-    feature = "derive_from",
-    issue = "144889",
-    reason = "`derive(From)` is unstable"
-)]
-pub use crate::macros::builtin::From;
-
 #[unstable(feature = "extern_item_impls", issue = "125418")]
 pub use crate::macros::builtin::{eii, unsafe_eii};
 


### PR DESCRIPTION
This was accidentally added to the prelude in 3f4dc1e02d759aa3c3807d4efc1f7f6e293536a5.

Fixes: rust-lang/rust#150165

r? @jdonszelmann
