### PR TITLE
compiletest: Add `LineNumber` newtype to avoid `+1` magic here and there

### DIFF
--- a/src/tools/compiletest/src/directives.rs
+++ b/src/tools/compiletest/src/directives.rs
@@ -29,6 +29,8 @@ mod directive_names;
 mod file;
 mod handlers;
 mod line;
+mod line_number;
+pub(crate) use line_number::LineNumber;
 mod needs;
 #[cfg(test)]
 mod tests;
@@ -591,7 +593,7 @@ fn iter_directives(
         ];
         // Process the extra implied directives, with a dummy line number of 0.
         for directive_str in extra_directives {
-            let directive_line = line_directive(testfile, 0, directive_str)
+            let directive_line = line_directive(testfile, LineNumber::ZERO, directive_str)
                 .unwrap_or_else(|| panic!("bad extra-directive line: {directive_str:?}"));
             it(&directive_line);
         }

--- a/src/tools/compiletest/src/directives/file.rs
+++ b/src/tools/compiletest/src/directives/file.rs
@@ -1,5 +1,6 @@
 use camino::Utf8Path;
 
+use crate::directives::LineNumber;
 use crate::directives::line::{DirectiveLine, line_directive};
 
 pub(crate) struct FileDirectives<'a> {
@@ -11,7 +12,7 @@ impl<'a> FileDirectives<'a> {
     pub(crate) fn from_file_contents(path: &'a Utf8Path, file_contents: &'a str) -> Self {
         let mut lines = vec![];
 
-        for (line_number, ln) in (1..).zip(file_contents.lines()) {
+        for (line_number, ln) in LineNumber::enumerate().zip(file_contents.lines()) {
             let ln = ln.trim();
 
             if let Some(directive_line) = line_directive(path, line_number, ln) {

--- a/src/tools/compiletest/src/directives/line.rs
+++ b/src/tools/compiletest/src/directives/line.rs
@@ -2,13 +2,15 @@ use std::fmt;
 
 use camino::Utf8Path;
 
+use crate::directives::LineNumber;
+
 const COMPILETEST_DIRECTIVE_PREFIX: &str = "//@";
 
 /// If the given line begins with the appropriate comment prefix for a directive,
 /// returns a struct containing various parts of the directive.
 pub(crate) fn line_directive<'a>(
     file_path: &'a Utf8Path,
-    line_number: usize,
+    line_number: LineNumber,
     original_line: &'a str,
 ) -> Option<DirectiveLine<'a>> {
     // Ignore lines that don't start with the comment prefix.
@@ -60,7 +62,7 @@ pub(crate) struct DirectiveLine<'a> {
     /// Mostly used for diagnostics, but some directives (e.g. `//@ pp-exact`)
     /// also use it to compute a value based on the filename.
     pub(crate) file_path: &'a Utf8Path,
-    pub(crate) line_number: usize,
+    pub(crate) line_number: LineNumber,
 
     /// Some test directives start with a revision name in square brackets
     /// (e.g. `[foo]`), and only apply to that revision of the test.

--- a/src/tools/compiletest/src/directives/line_number.rs
+++ b/src/tools/compiletest/src/directives/line_number.rs
@@ -1,0 +1,21 @@
+/// A line number in a file. Internally the first line has index 1.
+/// If it is 0 it means "no specific line" (used e.g. for implied directives).
+/// When `Display`:ed, the first line is `1`.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct LineNumber(usize);
+
+impl LineNumber {
+    /// This represents "no specific line" (used e.g. for implied directives).
+    pub(crate) const ZERO: Self = Self(0);
+
+    /// A never ending iterator over line numbers starting from the first line.
+    pub(crate) fn enumerate() -> impl Iterator<Item = LineNumber> {
+        (1..).map(LineNumber)
+    }
+}
+
+impl std::fmt::Display for LineNumber {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}

--- a/src/tools/compiletest/src/directives/tests.rs
+++ b/src/tools/compiletest/src/directives/tests.rs
@@ -6,8 +6,8 @@ use semver::Version;
 use crate::common::{Config, Debugger, TestMode};
 use crate::directives::{
     self, AuxProps, DIRECTIVE_HANDLERS_MAP, DirectivesCache, EarlyProps, Edition, EditionRange,
-    FileDirectives, KNOWN_DIRECTIVE_NAMES_SET, extract_llvm_version, extract_version_range,
-    line_directive, parse_edition, parse_normalize_rule,
+    FileDirectives, KNOWN_DIRECTIVE_NAMES_SET, LineNumber, extract_llvm_version,
+    extract_version_range, line_directive, parse_edition, parse_normalize_rule,
 };
 use crate::executor::{CollectedTestDesc, ShouldFail};
 
@@ -1000,7 +1000,8 @@ fn parse_edition_range(line: &str) -> Option<EditionRange> {
     let config = cfg().build();
 
     let line_with_comment = format!("//@ {line}");
-    let line = line_directive(Utf8Path::new("tmp.rs"), 0, &line_with_comment).unwrap();
+    let line =
+        line_directive(Utf8Path::new("tmp.rs"), LineNumber::ZERO, &line_with_comment).unwrap();
 
     super::parse_edition_range(&config, &line)
 }


### PR DESCRIPTION
Start small. If it works well we can increase usage bit by bit as time passes.

My main motivation for doing this is to get rid of the `+ 1` I otherwise have to add in https://github.com/rust-lang/rust/pull/150201 on this line:
```rs
                crate::directives::line::line_directive(file, zero_based_line_no + 1, &line)
```
But I think this is a nice general improvement by itself.

Note that we keep using "0" to represent "no specific line" because changing to `Option<LineNumber>` everywhere is a very noisy and significant change. That _can_ be changed later if wanted, but let's not do it now.