### PR TITLE
tests/debuginfo/function-arg-initialization.rs: Stop disabling SingleUseConsts MIR pass

### DIFF
--- a/tests/debuginfo/function-arg-initialization.rs
+++ b/tests/debuginfo/function-arg-initialization.rs
@@ -6,8 +6,7 @@
 // function name.
 
 //@ min-lldb-version: 1800
-//@ compile-flags:-g -Zmir-enable-passes=-SingleUseConsts
-// SingleUseConsts shouldn't need to be disabled, see #128945
+//@ compile-flags:-g
 //@ disable-gdb-pretty-printers
 //@ ignore-backends: gcc
 


### PR DESCRIPTION
This test passes locally for me. Let's see if it passes CI too.

Discovered while I worked on https://github.com/rust-lang/rust/pull/150201.

CC rust-lang/rust#128945

