### PR TITLE
fix ice where unsafe fn was incorrectly handled 

### DIFF
--- a/tests/ui/coercion/unsafe-fn-to-fn-match-150128.rs
+++ b/tests/ui/coercion/unsafe-fn-to-fn-match-150128.rs
@@ -1,0 +1,15 @@
+fn main() {
+    // this is work
+    match () {
+        _ if true => || (),
+        _ => (|| ()) as unsafe fn(),
+        _ if true => (|| ()) as fn(),
+    };
+
+    // this is not
+    match () {
+        _ if true => || (), //~ ERROR cannot coerce between `fn()` and unsafe function pointers
+        _ if true => (|| ()) as fn(),
+        _ => (|| ()) as unsafe fn(),
+    };
+}

--- a/tests/ui/coercion/unsafe-fn-to-fn-match-150128.stderr
+++ b/tests/ui/coercion/unsafe-fn-to-fn-match-150128.stderr
@@ -1,0 +1,8 @@
+error: cannot coerce between `fn()` and unsafe function pointers
+  --> $DIR/unsafe-fn-to-fn-match-150128.rs:11:22
+   |
+LL |         _ if true => || (),
+   |                      ^^^^^
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

r? WaffleLapkin (it seems that the fixme in wildcard branch is yours, and i partially resolved it, at least as far as i understand, you might have different vision and/or feel free to reroll in case you are busy with irl things)

i don't quite fully understand this part of code, but it somewhat working, at least i don't fully understand the part why cases like 

```rust
    let x: fn() = if true {
        (|| ()) as fn()
    } else {
        (|| ()) as unsafe fn()
    };
```

```rust
    let x: unsafe fn() = || ();
    let y: fn() = x as fn();
```

is already correctly rejected by compiler, but this snippet from issue with match isn't

second unsureness is from i dont really understand if this is correct to emit error like this

so the problem is that this gets into wildcard where it get replace with `*entry.get_mut() = adj;` (also after this gets replaced it breaks mir) and just hoping for best, but then this closure gets into `fn_sig()` and ices (at least this is from my perspective, im not really familiar with this part of code)

according to what i said above, the best approach i came up with is add the special case for this and emit error

in case i do `span_delayed_bug` instead of hard error i still get this

```
error: internal compiler error: broken MIR in DefId(0:3 ~ main[de72]::fndef) (_1 = move _4 as fn() (PointerCoercion(ClosureFnPointer(Safe), Implicit))): bad assignment (Binder { value: unsafe fn(), bound_vars: [] } = Binder { value: fn(), bound_vars: [] }): NoSolution
```

also not sure about error message itself if everything else is fine, maybe just using "match arms have incompatible types"

fixes https://github.com/rust-lang/rust/issues/150128