### PR TITLE
Rollup of 11 pull requests

### DIFF
--- a/compiler/rustc_builtin_macros/src/source_util.rs
+++ b/compiler/rustc_builtin_macros/src/source_util.rs
@@ -147,9 +147,7 @@ pub(crate) fn expand_include<'cx>(
             let mut p = unwrap_or_emit_fatal(new_parser_from_file(
                 self.psess,
                 &self.path,
-                // Don't strip frontmatter for backward compatibility, `---` may be the start of a
-                // manifold negation. FIXME: Ideally, we wouldn't strip shebangs here either.
-                StripTokens::Shebang,
+                StripTokens::Nothing,
                 Some(self.span),
             ));
             let expr = parse_expr(&mut p).ok()?;

--- a/compiler/rustc_graphviz/src/lib.rs
+++ b/compiler/rustc_graphviz/src/lib.rs
@@ -416,7 +416,7 @@ impl<'a> Id<'a> {
 /// it in the generated .dot file. They can also provide more
 /// elaborate (and non-unique) label text that is used in the graphviz
 /// rendered output.
-
+///
 /// The graph instance is responsible for providing the DOT compatible
 /// identifiers for the nodes and (optionally) rendered labels for the nodes and
 /// edges, as well as an identifier for the graph itself.

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -2654,7 +2654,7 @@ struct InternedInSet<'tcx, T: ?Sized + PointeeSized>(&'tcx T);
 
 impl<'tcx, T: 'tcx + ?Sized + PointeeSized> Clone for InternedInSet<'tcx, T> {
     fn clone(&self) -> Self {
-        InternedInSet(self.0)
+        *self
     }
 }
 

--- a/compiler/rustc_mir_build/src/builder/matches/buckets.rs
+++ b/compiler/rustc_mir_build/src/builder/matches/buckets.rs
@@ -218,7 +218,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 &TestKind::Len { len: test_len, op: BinOp::Eq },
                 &TestableCase::Slice { len, variable_length },
             ) => {
-                match (test_len.cmp(&(len as u64)), variable_length) {
+                match (test_len.cmp(&len), variable_length) {
                     (Ordering::Equal, false) => {
                         // on true, min_len = len = $actual_length,
                         // on false, len != $actual_length
@@ -251,7 +251,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 &TestableCase::Slice { len, variable_length },
             ) => {
                 // the test is `$actual_len >= test_len`
-                match (test_len.cmp(&(len as u64)), variable_length) {
+                match (test_len.cmp(&len), variable_length) {
                     (Ordering::Equal, true) => {
                         // $actual_len >= test_len = pat_len,
                         // so we can match.

--- a/compiler/rustc_mir_build/src/builder/matches/match_pair.rs
+++ b/compiler/rustc_mir_build/src/builder/matches/match_pair.rs
@@ -256,7 +256,7 @@ impl<'tcx> MatchPairTree<'tcx> {
                     None
                 } else {
                     Some(TestableCase::Slice {
-                        len: prefix.len() + suffix.len(),
+                        len: u64::try_from(prefix.len() + suffix.len()).unwrap(),
                         variable_length: slice.is_some(),
                     })
                 }

--- a/compiler/rustc_mir_build/src/builder/matches/mod.rs
+++ b/compiler/rustc_mir_build/src/builder/matches/mod.rs
@@ -1264,7 +1264,7 @@ enum TestableCase<'tcx> {
     Variant { adt_def: ty::AdtDef<'tcx>, variant_index: VariantIdx },
     Constant { value: ty::Value<'tcx> },
     Range(Arc<PatRange<'tcx>>),
-    Slice { len: usize, variable_length: bool },
+    Slice { len: u64, variable_length: bool },
     Deref { temp: Place<'tcx>, mutability: Mutability },
     Never,
     Or { pats: Box<[FlatPat<'tcx>]> },

--- a/compiler/rustc_mir_build/src/builder/matches/test.rs
+++ b/compiler/rustc_mir_build/src/builder/matches/test.rs
@@ -47,7 +47,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
 
             TestableCase::Slice { len, variable_length } => {
                 let op = if variable_length { BinOp::Ge } else { BinOp::Eq };
-                TestKind::Len { len: len as u64, op }
+                TestKind::Len { len, op }
             }
 
             TestableCase::Deref { temp, mutability } => TestKind::Deref { temp, mutability },

--- a/compiler/rustc_pattern_analysis/src/lib.rs
+++ b/compiler/rustc_pattern_analysis/src/lib.rs
@@ -141,7 +141,7 @@ pub struct MatchArm<'p, Cx: PatCx> {
 
 impl<'p, Cx: PatCx> Clone for MatchArm<'p, Cx> {
     fn clone(&self) -> Self {
-        Self { pat: self.pat, has_guard: self.has_guard, arm_data: self.arm_data }
+        *self
     }
 }
 

--- a/compiler/rustc_pattern_analysis/src/pat.rs
+++ b/compiler/rustc_pattern_analysis/src/pat.rs
@@ -174,10 +174,7 @@ pub(crate) enum PatOrWild<'p, Cx: PatCx> {
 
 impl<'p, Cx: PatCx> Clone for PatOrWild<'p, Cx> {
     fn clone(&self) -> Self {
-        match self {
-            PatOrWild::Wild => PatOrWild::Wild,
-            PatOrWild::Pat(pat) => PatOrWild::Pat(pat),
-        }
+        *self
     }
 }
 

--- a/compiler/rustc_pattern_analysis/src/usefulness.rs
+++ b/compiler/rustc_pattern_analysis/src/usefulness.rs
@@ -824,7 +824,7 @@ struct PlaceCtxt<'a, Cx: PatCx> {
 impl<'a, Cx: PatCx> Copy for PlaceCtxt<'a, Cx> {}
 impl<'a, Cx: PatCx> Clone for PlaceCtxt<'a, Cx> {
     fn clone(&self) -> Self {
-        Self { cx: self.cx, ty: self.ty }
+        *self
     }
 }
 

--- a/compiler/rustc_thread_pool/src/registry.rs
+++ b/compiler/rustc_thread_pool/src/registry.rs
@@ -153,8 +153,8 @@ pub struct Registry {
     terminate_count: AtomicUsize,
 }
 
-/// ////////////////////////////////////////////////////////////////////////
-/// Initialization
+///////////////////////////////////////////////////////////////////////////
+// Initialization
 
 static mut THE_REGISTRY: Option<Arc<Registry>> = None;
 static THE_REGISTRY_SET: Once = Once::new();
@@ -407,12 +407,12 @@ impl Registry {
         }
     }
 
-    /// ////////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////////
     /// MAIN LOOP
     ///
     /// So long as all of the worker threads are hanging out in their
     /// top-level loop, there is no work to be done.
-
+    ///
     /// Push a job into the given `registry`. If we are running on a
     /// worker thread for the registry, this will push onto the
     /// deque. Else, it will inject from the outside (which is slower).
@@ -668,8 +668,8 @@ impl ThreadInfo {
     }
 }
 
-/// ////////////////////////////////////////////////////////////////////////
-/// WorkerThread identifiers
+///////////////////////////////////////////////////////////////////////////
+// WorkerThread identifiers
 
 pub(super) struct WorkerThread {
     /// the "worker" half of our local deque
@@ -1018,8 +1018,6 @@ impl WorkerThread {
         }
     }
 }
-
-/// ////////////////////////////////////////////////////////////////////////
 
 unsafe fn main_loop(thread: ThreadBuilder) {
     let worker_thread = &WorkerThread::from(thread);

--- a/library/core/src/cell/once.rs
+++ b/library/core/src/cell/once.rs
@@ -353,7 +353,8 @@ impl<T> OnceCell<T> {
 }
 
 #[stable(feature = "once_cell", since = "1.70.0")]
-impl<T> Default for OnceCell<T> {
+#[rustc_const_unstable(feature = "const_default", issue = "143894")]
+impl<T> const Default for OnceCell<T> {
     #[inline]
     fn default() -> Self {
         Self::new()

--- a/library/core/src/prelude/v1.rs
+++ b/library/core/src/prelude/v1.rs
@@ -118,13 +118,6 @@ pub use crate::macros::builtin::deref;
 )]
 pub use crate::macros::builtin::define_opaque;
 
-#[unstable(
-    feature = "derive_from",
-    issue = "144889",
-    reason = "`derive(From)` is unstable"
-)]
-pub use crate::macros::builtin::From;
-
 #[unstable(feature = "extern_item_impls", issue = "125418")]
 pub use crate::macros::builtin::{eii, unsafe_eii};
 

--- a/library/core/src/sync/atomic.rs
+++ b/library/core/src/sync/atomic.rs
@@ -1151,8 +1151,8 @@ impl AtomicBool {
     /// assert_eq!(foo.fetch_or(false, Ordering::SeqCst), true);
     /// assert_eq!(foo.load(Ordering::SeqCst), true);
     ///
-    /// let foo = AtomicBool::new(true);
-    /// assert_eq!(foo.fetch_or(true, Ordering::SeqCst), true);
+    /// let foo = AtomicBool::new(false);
+    /// assert_eq!(foo.fetch_or(true, Ordering::SeqCst), false);
     /// assert_eq!(foo.load(Ordering::SeqCst), true);
     ///
     /// let foo = AtomicBool::new(false);

--- a/library/coretests/tests/fmt/mod.rs
+++ b/library/coretests/tests/fmt/mod.rs
@@ -30,6 +30,12 @@ fn test_format_flags() {
     assert_eq!(format!("{:p} {:x}", p, 16), format!("{p:p} 10"));
 
     assert_eq!(format!("{: >3}", 'a'), "  a");
+
+    /// Regression test for <https://github.com/rust-lang/rust/issues/50280#issuecomment-626035934>.
+    fn show(a: fn() -> f32, b: fn(&Vec<i8>) -> f32) {
+        println!("the two pointers: {:p} {:p}", a, b);
+    }
+    show(|| 1.0, |_| 2.0);
 }
 
 #[test]

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -274,6 +274,7 @@
 #![feature(cfg_sanitizer_cfi)]
 #![feature(cfg_target_thread_local)]
 #![feature(cfi_encoding)]
+#![feature(const_default)]
 #![feature(const_trait_impl)]
 #![feature(core_float_math)]
 #![feature(decl_macro)]

--- a/library/std/src/sync/once_lock.rs
+++ b/library/std/src/sync/once_lock.rs
@@ -582,7 +582,8 @@ impl<T: RefUnwindSafe + UnwindSafe> RefUnwindSafe for OnceLock<T> {}
 impl<T: UnwindSafe> UnwindSafe for OnceLock<T> {}
 
 #[stable(feature = "once_cell", since = "1.70.0")]
-impl<T> Default for OnceLock<T> {
+#[rustc_const_unstable(feature = "const_default", issue = "143894")]
+impl<T> const Default for OnceLock<T> {
     /// Creates a new uninitialized cell.
     ///
     /// # Example

--- a/library/unwind/src/lib.rs
+++ b/library/unwind/src/lib.rs
@@ -73,8 +73,25 @@ cfg_select! {
     }
     _ => {
         #[link(name = "unwind", kind = "static", modifiers = "-bundle", cfg(target_feature = "crt-static"))]
-        #[link(name = "gcc_s", cfg(not(target_feature = "crt-static")))]
+        #[link(name = "gcc_s", cfg(all(not(target_feature = "crt-static"), not(target_arch = "hexagon"))))]
         unsafe extern "C" {}
+    }
+}
+
+// Hexagon with musl uses llvm-libunwind by default
+#[cfg(all(target_env = "musl", target_arch = "hexagon"))]
+cfg_select! {
+    feature = "llvm-libunwind" => {
+        #[link(name = "unwind", kind = "static", modifiers = "-bundle")]
+        unsafe extern "C" {}
+    }
+    feature = "system-llvm-libunwind" => {
+        #[link(name = "unwind", kind = "static", modifiers = "-bundle", cfg(target_feature = "crt-static"))]
+        #[link(name = "unwind", cfg(not(target_feature = "crt-static")))]
+        unsafe extern "C" {}
+    }
+    _ => {
+        // Fallback: should not happen since hexagon defaults to llvm-libunwind
     }
 }
 

--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -354,7 +354,10 @@ fn copy_third_party_objects(
 
     if target == "x86_64-fortanix-unknown-sgx"
         || builder.config.llvm_libunwind(target) == LlvmLibunwind::InTree
-            && (target.contains("linux") || target.contains("fuchsia") || target.contains("aix"))
+            && (target.contains("linux")
+                || target.contains("fuchsia")
+                || target.contains("aix")
+                || target.contains("hexagon"))
     {
         let libunwind_path =
             copy_llvm_libunwind(builder, target, &builder.sysroot_target_libdir(*compiler, target));

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -1851,7 +1851,7 @@ impl Config {
             .get(&target)
             .and_then(|t| t.llvm_libunwind)
             .or(self.llvm_libunwind_default)
-            .unwrap_or(if target.contains("fuchsia") {
+            .unwrap_or(if target.contains("fuchsia") || target.contains("hexagon") {
                 LlvmLibunwind::InTree
             } else {
                 LlvmLibunwind::No

--- a/src/tools/clippy/tests/compile-test.rs
+++ b/src/tools/clippy/tests/compile-test.rs
@@ -173,6 +173,10 @@ impl TestContext {
                         p.envs.push(("RUSTC_SNAPSHOT".into(), Some(rustc.into())));
                         p.envs.push(("RUSTC_SNAPSHOT_LIBDIR".into(), Some(libdir.into())));
                         p.envs.push(("RUSTC_SYSROOT".into(), Some(sysroot.into())));
+                        // Ensure we rebuild the dependencies when the sysroot changes.
+                        // (Bootstrap usually sets this automatically, but since we invoke cargo
+                        // ourselves we have to do it.)
+                        p.args.push("-Zbinary-dep-depinfo".into());
                     }
                     p
                 },

--- a/src/tools/miri/tests/ui.rs
+++ b/src/tools/miri/tests/ui.rs
@@ -133,7 +133,11 @@ fn miri_config(
                     program: miri_path()
                         .with_file_name(format!("cargo-miri{}", env::consts::EXE_SUFFIX)),
                     // There is no `cargo miri build` so we just use `cargo miri run`.
-                    args: ["miri", "run"].into_iter().map(Into::into).collect(),
+                    // Add `-Zbinary-dep-depinfo` since it is needed for bootstrap builds (and doesn't harm otherwise).
+                    args: ["miri", "run", "--quiet", "-Zbinary-dep-depinfo"]
+                        .into_iter()
+                        .map(Into::into)
+                        .collect(),
                     // Reset `RUSTFLAGS` to work around <https://github.com/rust-lang/rust/pull/119574#issuecomment-1876878344>.
                     envs: vec![("RUSTFLAGS".into(), None)],
                     ..CommandBuilder::cargo()

--- a/tests/assembly-llvm/some-non-zero-from-atomic-optimization.rs
+++ b/tests/assembly-llvm/some-non-zero-from-atomic-optimization.rs
@@ -1,0 +1,45 @@
+//! Regression test for <https://github.com/rust-lang/rust/issues/60044>.
+
+//@ assembly-output: emit-asm
+//@ only-x86_64
+
+// We want to check that the None case is optimized away
+//@ compile-flags: -O
+
+// Simplify the generated assembly
+//@ compile-flags: -Cforce-unwind-tables=no
+
+#![crate_type = "lib"]
+
+use std::num::NonZeroUsize;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering::Relaxed;
+
+pub static X: AtomicUsize = AtomicUsize::new(1);
+
+/// This function function shall look like this:
+/// ```
+/// some_non_zero_from_atomic_get:
+///         movq    _RNvCs7C4TuIcXqwO_25some_non_zero_from_atomic1X@GOTPCREL(%rip), %rax
+///         movq    (%rax), %rax
+///         retq
+/// ```
+// CHECK-LABEL: some_non_zero_from_atomic_get:
+// CHECK-NEXT: movq    {{[_a-zA-Z0-9]+}}@GOTPCREL(%rip), %rax
+// CHECK-NEXT: movq    (%rax), %rax
+// CHECK-NEXT: retq
+#[no_mangle]
+pub unsafe fn some_non_zero_from_atomic_get() -> Option<NonZeroUsize> {
+    let x = X.load(Relaxed);
+    Some(NonZeroUsize::new_unchecked(x))
+}
+
+/// This function shall be identical to the above, which means:
+// CHECK-DAG: some_non_zero_from_atomic_get2 = some_non_zero_from_atomic_get
+#[no_mangle]
+pub unsafe fn some_non_zero_from_atomic_get2() -> usize {
+    match some_non_zero_from_atomic_get() {
+        Some(x) => x.get(),
+        None => unreachable!(), // shall be optimized out
+    }
+}

--- a/tests/ui/eii/error_statement_position.rs
+++ b/tests/ui/eii/error_statement_position.rs
@@ -1,6 +1,16 @@
 #![feature(extern_item_impls)]
+// EIIs can, despite not being super useful, be declared in statement position
+// nested inside items. Items in statement position, when expanded as part of a macro,
+// need to be wrapped slightly differently (in an `ast::Statement`).
+// We did this on the happy path (no errors), but when there was an error, we'd
+// replace it with *just* an `ast::Item` not wrapped in an `ast::Statement`.
+// This caused an ICE (https://github.com/rust-lang/rust/issues/149980).
+// this test fails to build, but demonstrates that no ICE is produced.
 
 fn main() {
+    struct Bar;
+
     #[eii]
+    //~^ ERROR `#[eii]` is only valid on functions
     impl Bar {}
 }

--- a/tests/ui/eii/error_statement_position.rs
+++ b/tests/ui/eii/error_statement_position.rs
@@ -1,0 +1,6 @@
+#![feature(extern_item_impls)]
+
+fn main() {
+    #[eii]
+    impl Bar {}
+}

--- a/tests/ui/eii/error_statement_position.stderr
+++ b/tests/ui/eii/error_statement_position.stderr
@@ -1,0 +1,8 @@
+error: `#[eii]` is only valid on functions
+  --> $DIR/error_statement_position.rs:13:5
+   |
+LL |     #[eii]
+   |     ^^^^^^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/include-macros/auxiliary/shebang-expr.rs
+++ b/tests/ui/include-macros/auxiliary/shebang-expr.rs
@@ -1,0 +1,3 @@
+#!/usr/bin/env my-rust-expr-evaluator
+
+2 * (1 + 3)

--- a/tests/ui/include-macros/auxiliary/shebang-items.rs
+++ b/tests/ui/include-macros/auxiliary/shebang-items.rs
@@ -1,0 +1,3 @@
+#!/usr/bin/env my-rust-script-runner
+
+fn main() {}

--- a/tests/ui/include-macros/shebang-in-expr-ctxt.rs
+++ b/tests/ui/include-macros/shebang-in-expr-ctxt.rs
@@ -1,0 +1,16 @@
+// Check that we *don't* strip shebang in files that were `include`d in an expression or
+// expression statement context.
+// We do that to be consistent with frontmatter (see test `frontmatter/include-in-expr-ctxt.rs`).
+// While there could be niche use cases for such shebang, it seems more confusing than beneficial.
+
+fn main() {
+    // expr ctxt
+    _ = include!("auxiliary/shebang-expr.rs");
+    //~^ ERROR non-expression macro in expression position
+    //~? ERROR expected `[`, found `/`
+
+    // stmt ctxt (reuses expr expander)
+    include!("auxiliary/shebang-expr.rs");
+    //~^ ERROR non-statement macro in statement position
+    //~? ERROR expected `[`, found `/`
+}

--- a/tests/ui/include-macros/shebang-in-expr-ctxt.stderr
+++ b/tests/ui/include-macros/shebang-in-expr-ctxt.stderr
@@ -1,0 +1,33 @@
+error: expected `[`, found `/`
+  --> $DIR/auxiliary/shebang-expr.rs:1:3
+   |
+LL | #!/usr/bin/env my-rust-expr-evaluator
+   |   ^ expected `[`
+   |
+   = note: the token sequence `#!` here looks like the start of a shebang interpreter directive but it is not
+   = help: if you meant this to be a shebang interpreter directive, move it to the very start of the file
+
+error: non-expression macro in expression position: include
+  --> $DIR/shebang-in-expr-ctxt.rs:8:9
+   |
+LL |     _ = include!("auxiliary/shebang-expr.rs");
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: expected `[`, found `/`
+  --> $DIR/auxiliary/shebang-expr.rs:1:3
+   |
+LL | #!/usr/bin/env my-rust-expr-evaluator
+   |   ^ expected `[`
+   |
+   = note: the token sequence `#!` here looks like the start of a shebang interpreter directive but it is not
+   = help: if you meant this to be a shebang interpreter directive, move it to the very start of the file
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: non-statement macro in statement position: include
+  --> $DIR/shebang-in-expr-ctxt.rs:13:5
+   |
+LL |     include!("auxiliary/shebang-expr.rs");
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 4 previous errors
+

--- a/tests/ui/include-macros/shebang-in-item-ctxt.rs
+++ b/tests/ui/include-macros/shebang-in-item-ctxt.rs
@@ -1,0 +1,4 @@
+// Ensure that we strip shebang in files `include`d in item contexts.
+//@ check-pass
+
+include!("auxiliary/shebang-items.rs");


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#146377 (Don't strip shebang in expr-ctxt `include!(…)`)
 - rust-lang/rust#149658 (tests/assembly-llvm/some-non-zero-from-atomic-optimization.rs: New test)
 - rust-lang/rust#149812 (Add const default for OnceCell and OnceLock)
 - rust-lang/rust#149882 (miri: add -Zbinary-dep-depinfo to dependency builds)
 - rust-lang/rust#150009 (Enable llvm-libunwind by default for Hexagon targets)
 - rust-lang/rust#150035 (fix docustring on fetch_or)
 - rust-lang/rust#150082 (tests/ui/traits/fmt-pointer-trait.rs: Add HRTB fn pointer case)
 - rust-lang/rust#150160 (Fix ICE (rust-lang/rust#149980) for invalid EII in statement position)
 - rust-lang/rust#150184 (mir_build: Use the same length type for `TestableCase::Slice` and `TestKind::Len`)
 - rust-lang/rust#150191 (change non-canonical clone impl to {*self}, fix some doc comments)
 - rust-lang/rust#150203 (Drop the From derive macro from the v1 prelude)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=146377,149658,149812,149882,150009,150035,150082,150160,150184,150191,150203)
<!-- homu-ignore:end -->