### PR TITLE
rustdoc: handle macro expansions in types

### DIFF
--- a/compiler/rustc_ast_pretty/src/pprust/mod.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/mod.rs
@@ -33,6 +33,9 @@ pub fn where_bound_predicate_to_string(where_bound_predicate: &ast::WhereBoundPr
     State::new().where_bound_predicate_to_string(where_bound_predicate)
 }
 
+/// # Panics
+///
+/// Panics if `pat.kind` is `PatKind::Missing`.
 pub fn pat_to_string(pat: &ast::Pat) -> String {
     State::new().pat_to_string(pat)
 }

--- a/src/librustdoc/html/macro_expansion.rs
+++ b/src/librustdoc/html/macro_expansion.rs
@@ -1,5 +1,5 @@
-use rustc_ast::visit::{Visitor, walk_crate, walk_expr, walk_item, walk_pat, walk_stmt};
-use rustc_ast::{Crate, Expr, Item, Pat, Stmt};
+use rustc_ast::visit::{Visitor, walk_crate, walk_expr, walk_item, walk_pat, walk_stmt, walk_ty};
+use rustc_ast::{Crate, Expr, Item, Pat, Stmt, Ty};
 use rustc_data_structures::fx::FxHashMap;
 use rustc_span::source_map::SourceMap;
 use rustc_span::{BytePos, Span};
@@ -151,6 +151,14 @@ impl<'ast> Visitor<'ast> for ExpandedCodeVisitor<'ast> {
             self.handle_new_span(pat.span, || rustc_ast_pretty::pprust::pat_to_string(pat));
         } else {
             walk_pat(self, pat);
+        }
+    }
+
+    fn visit_ty(&mut self, ty: &'ast Ty) {
+        if ty.span.from_expansion() {
+            self.handle_new_span(ty.span, || rustc_ast_pretty::pprust::ty_to_string(ty));
+        } else {
+            walk_ty(self, ty);
         }
     }
 }

--- a/tests/rustdoc/macro-expansion/type-macro-expansion.rs
+++ b/tests/rustdoc/macro-expansion/type-macro-expansion.rs
@@ -1,0 +1,27 @@
+// Ensure macro invocations at type position are expanded correctly
+
+//@ compile-flags: -Zunstable-options --generate-macro-expansion
+
+#![crate_name = "foo"]
+
+//@ has 'src/foo/type-macro-expansion.rs.html'
+
+macro_rules! foo {
+    () => {
+        fn(())
+    };
+    ($_arg:expr) => {
+        [(); 1]
+    };
+}
+
+fn bar() {
+    //@ has - '//*[@class="expansion"]/*[@class="original"]/*[@class="macro"]' 'foo!'
+    //@ has - '//*[@class="expansion"]/*[@class="original"]' 'foo!()'
+    //@ has - '//*[@class="expansion"]/*[@class="expanded"]' 'fn(())'
+    let _: foo!();
+    //@ has - '//*[@class="expansion"]/*[@class="original"]/*[@class="macro"]' 'foo!'
+    //@ has - '//*[@class="expansion"]/*[@class="original"]' 'foo!(42)'
+    //@ has - '//*[@class="expansion"]/*[@class="expanded"]' '[(); 1]'
+    let _: foo!(42);
+}


### PR DESCRIPTION
- Closes rust-lang/rust#150154.
- Closes rust-lang/rust#150197.

This PR implements `visit_ty` in `ExpandedCodeVisitor` to correctly handle macro expansions in type positions (e.g., `let _: foo!();`). This also fixes a crash in rustdoc caused by the same issue.

Before: 
<img width="419" height="182" alt="image" src="https://github.com/user-attachments/assets/89627230-032d-4ba1-af2e-8aa9a9cc6627" />
After:
<img width="288" height="107" alt="image" src="https://github.com/user-attachments/assets/c06caeda-28b7-45b8-845a-e7fe784a82e4" />

