### PR TITLE
cg_llvm: Add noreturn attribute to inline assembly marked as noreturn

### DIFF
--- a/compiler/rustc_codegen_llvm/src/asm.rs
+++ b/compiler/rustc_codegen_llvm/src/asm.rs
@@ -341,6 +341,11 @@ impl<'ll, 'tcx> AsmBuilderMethods<'tcx> for Builder<'_, 'll, 'tcx> {
         } else if options.contains(InlineAsmOptions::READONLY) {
             attrs.push(llvm::MemoryEffects::ReadOnlyNotPure.create_attr(self.cx.llcx));
         }
+
+        if options.contains(InlineAsmOptions::NORETURN) {
+            attrs.push(llvm::AttributeKind::NoReturn.create_attr(self.cx.llcx));
+        }
+
         attributes::apply_to_callsite(result, llvm::AttributePlace::Function, &{ attrs });
 
         // Write results to outputs. We need to do this for all possible control flow.


### PR DESCRIPTION
Inline assembly marked with `options(noreturn)` isn't actually annotated with LLVM's `noreturn` attribute, which can cause extra instructions to be generated:

```rs
pub fn foo() -> ! {
    unsafe { core::arch::asm!("int 0x29", options(noreturn)); }
}
```

currently generates
```
int 0x29
ud2
```

Other options are mapped to their respective LLVM attributes, so this seems like an oversight.