### PR TITLE
Rollup of 15 pull requests

### DIFF
--- a/compiler/rustc_ast_pretty/src/pprust/mod.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/mod.rs
@@ -33,6 +33,9 @@ pub fn where_bound_predicate_to_string(where_bound_predicate: &ast::WhereBoundPr
     State::new().where_bound_predicate_to_string(where_bound_predicate)
 }
 
+/// # Panics
+///
+/// Panics if `pat.kind` is `PatKind::Missing`.
 pub fn pat_to_string(pat: &ast::Pat) -> String {
     State::new().pat_to_string(pat)
 }

--- a/compiler/rustc_builtin_macros/src/source_util.rs
+++ b/compiler/rustc_builtin_macros/src/source_util.rs
@@ -147,9 +147,7 @@ pub(crate) fn expand_include<'cx>(
             let mut p = unwrap_or_emit_fatal(new_parser_from_file(
                 self.psess,
                 &self.path,
-                // Don't strip frontmatter for backward compatibility, `---` may be the start of a
-                // manifold negation. FIXME: Ideally, we wouldn't strip shebangs here either.
-                StripTokens::Shebang,
+                StripTokens::Nothing,
                 Some(self.span),
             ));
             let expr = parse_expr(&mut p).ok()?;

--- a/compiler/rustc_graphviz/src/lib.rs
+++ b/compiler/rustc_graphviz/src/lib.rs
@@ -416,7 +416,7 @@ impl<'a> Id<'a> {
 /// it in the generated .dot file. They can also provide more
 /// elaborate (and non-unique) label text that is used in the graphviz
 /// rendered output.
-
+///
 /// The graph instance is responsible for providing the DOT compatible
 /// identifiers for the nodes and (optionally) rendered labels for the nodes and
 /// edges, as well as an identifier for the graph itself.

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -2654,7 +2654,7 @@ struct InternedInSet<'tcx, T: ?Sized + PointeeSized>(&'tcx T);
 
 impl<'tcx, T: 'tcx + ?Sized + PointeeSized> Clone for InternedInSet<'tcx, T> {
     fn clone(&self) -> Self {
-        InternedInSet(self.0)
+        *self
     }
 }
 

--- a/compiler/rustc_mir_build/src/builder/matches/buckets.rs
+++ b/compiler/rustc_mir_build/src/builder/matches/buckets.rs
@@ -218,7 +218,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 &TestKind::Len { len: test_len, op: BinOp::Eq },
                 &TestableCase::Slice { len, variable_length },
             ) => {
-                match (test_len.cmp(&(len as u64)), variable_length) {
+                match (test_len.cmp(&len), variable_length) {
                     (Ordering::Equal, false) => {
                         // on true, min_len = len = $actual_length,
                         // on false, len != $actual_length
@@ -251,7 +251,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 &TestableCase::Slice { len, variable_length },
             ) => {
                 // the test is `$actual_len >= test_len`
-                match (test_len.cmp(&(len as u64)), variable_length) {
+                match (test_len.cmp(&len), variable_length) {
                     (Ordering::Equal, true) => {
                         // $actual_len >= test_len = pat_len,
                         // so we can match.

--- a/compiler/rustc_mir_build/src/builder/matches/match_pair.rs
+++ b/compiler/rustc_mir_build/src/builder/matches/match_pair.rs
@@ -256,7 +256,7 @@ impl<'tcx> MatchPairTree<'tcx> {
                     None
                 } else {
                     Some(TestableCase::Slice {
-                        len: prefix.len() + suffix.len(),
+                        len: u64::try_from(prefix.len() + suffix.len()).unwrap(),
                         variable_length: slice.is_some(),
                     })
                 }

--- a/compiler/rustc_mir_build/src/builder/matches/mod.rs
+++ b/compiler/rustc_mir_build/src/builder/matches/mod.rs
@@ -1264,7 +1264,7 @@ enum TestableCase<'tcx> {
     Variant { adt_def: ty::AdtDef<'tcx>, variant_index: VariantIdx },
     Constant { value: ty::Value<'tcx> },
     Range(Arc<PatRange<'tcx>>),
-    Slice { len: usize, variable_length: bool },
+    Slice { len: u64, variable_length: bool },
     Deref { temp: Place<'tcx>, mutability: Mutability },
     Never,
     Or { pats: Box<[FlatPat<'tcx>]> },

--- a/compiler/rustc_mir_build/src/builder/matches/test.rs
+++ b/compiler/rustc_mir_build/src/builder/matches/test.rs
@@ -47,7 +47,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
 
             TestableCase::Slice { len, variable_length } => {
                 let op = if variable_length { BinOp::Ge } else { BinOp::Eq };
-                TestKind::Len { len: len as u64, op }
+                TestKind::Len { len, op }
             }
 
             TestableCase::Deref { temp, mutability } => TestKind::Deref { temp, mutability },

--- a/compiler/rustc_pattern_analysis/src/lib.rs
+++ b/compiler/rustc_pattern_analysis/src/lib.rs
@@ -141,7 +141,7 @@ pub struct MatchArm<'p, Cx: PatCx> {
 
 impl<'p, Cx: PatCx> Clone for MatchArm<'p, Cx> {
     fn clone(&self) -> Self {
-        Self { pat: self.pat, has_guard: self.has_guard, arm_data: self.arm_data }
+        *self
     }
 }
 

--- a/compiler/rustc_pattern_analysis/src/pat.rs
+++ b/compiler/rustc_pattern_analysis/src/pat.rs
@@ -174,10 +174,7 @@ pub(crate) enum PatOrWild<'p, Cx: PatCx> {
 
 impl<'p, Cx: PatCx> Clone for PatOrWild<'p, Cx> {
     fn clone(&self) -> Self {
-        match self {
-            PatOrWild::Wild => PatOrWild::Wild,
-            PatOrWild::Pat(pat) => PatOrWild::Pat(pat),
-        }
+        *self
     }
 }
 

--- a/compiler/rustc_pattern_analysis/src/usefulness.rs
+++ b/compiler/rustc_pattern_analysis/src/usefulness.rs
@@ -824,7 +824,7 @@ struct PlaceCtxt<'a, Cx: PatCx> {
 impl<'a, Cx: PatCx> Copy for PlaceCtxt<'a, Cx> {}
 impl<'a, Cx: PatCx> Clone for PlaceCtxt<'a, Cx> {
     fn clone(&self) -> Self {
-        Self { cx: self.cx, ty: self.ty }
+        *self
     }
 }
 

--- a/compiler/rustc_target/src/spec/targets/arm_unknown_linux_gnueabihf.rs
+++ b/compiler/rustc_target/src/spec/targets/arm_unknown_linux_gnueabihf.rs
@@ -15,7 +15,7 @@ pub(crate) fn target() -> Target {
         options: TargetOptions {
             abi: Abi::EabiHf,
             llvm_floatabi: Some(FloatAbi::Hard),
-            features: "+strict-align,+v6,+vfp2,-d32".into(),
+            features: "+strict-align,+v6,+vfp2".into(),
             max_atomic_width: Some(64),
             mcount: "\u{1}__gnu_mcount_nc".into(),
             llvm_mcount_intrinsic: Some("llvm.arm.gnu.eabi.mcount".into()),

--- a/compiler/rustc_target/src/spec/targets/arm_unknown_linux_musleabihf.rs
+++ b/compiler/rustc_target/src/spec/targets/arm_unknown_linux_musleabihf.rs
@@ -17,7 +17,7 @@ pub(crate) fn target() -> Target {
             llvm_floatabi: Some(FloatAbi::Hard),
             // Most of these settings are copied from the arm_unknown_linux_gnueabihf
             // target.
-            features: "+strict-align,+v6,+vfp2,-d32".into(),
+            features: "+strict-align,+v6,+vfp2".into(),
             max_atomic_width: Some(64),
             mcount: "\u{1}mcount".into(),
             // FIXME(compiler-team#422): musl targets should be dynamically linked by default.

--- a/compiler/rustc_target/src/spec/targets/armv6_unknown_freebsd.rs
+++ b/compiler/rustc_target/src/spec/targets/armv6_unknown_freebsd.rs
@@ -15,7 +15,7 @@ pub(crate) fn target() -> Target {
         options: TargetOptions {
             abi: Abi::EabiHf,
             llvm_floatabi: Some(FloatAbi::Hard),
-            features: "+v6,+vfp2,-d32".into(),
+            features: "+v6,+vfp2".into(),
             max_atomic_width: Some(64),
             mcount: "\u{1}__gnu_mcount_nc".into(),
             llvm_mcount_intrinsic: Some("llvm.arm.gnu.eabi.mcount".into()),

--- a/compiler/rustc_target/src/spec/targets/armv6_unknown_netbsd_eabihf.rs
+++ b/compiler/rustc_target/src/spec/targets/armv6_unknown_netbsd_eabihf.rs
@@ -15,7 +15,7 @@ pub(crate) fn target() -> Target {
         options: TargetOptions {
             abi: Abi::EabiHf,
             llvm_floatabi: Some(FloatAbi::Hard),
-            features: "+v6,+vfp2,-d32".into(),
+            features: "+v6,+vfp2".into(),
             max_atomic_width: Some(64),
             mcount: "__mcount".into(),
             ..base::netbsd::opts()

--- a/compiler/rustc_target/src/spec/targets/armv7_linux_androideabi.rs
+++ b/compiler/rustc_target/src/spec/targets/armv7_linux_androideabi.rs
@@ -28,7 +28,7 @@ pub(crate) fn target() -> Target {
         options: TargetOptions {
             abi: Abi::Eabi,
             llvm_floatabi: Some(FloatAbi::Soft),
-            features: "+v7,+thumb-mode,+thumb2,+vfp3,-d32,-neon".into(),
+            features: "+v7,+thumb-mode,+thumb2,+vfp3d16,-neon".into(),
             supported_sanitizers: SanitizerSet::ADDRESS,
             max_atomic_width: Some(64),
             ..base

--- a/compiler/rustc_target/src/spec/targets/armv7_unknown_freebsd.rs
+++ b/compiler/rustc_target/src/spec/targets/armv7_unknown_freebsd.rs
@@ -15,7 +15,7 @@ pub(crate) fn target() -> Target {
         options: TargetOptions {
             abi: Abi::EabiHf,
             llvm_floatabi: Some(FloatAbi::Hard),
-            features: "+v7,+vfp3,-d32,+thumb2,-neon".into(),
+            features: "+v7,+vfp3d16,+thumb2,-neon".into(),
             max_atomic_width: Some(64),
             mcount: "\u{1}__gnu_mcount_nc".into(),
             ..base::freebsd::opts()

--- a/compiler/rustc_target/src/spec/targets/armv7_unknown_linux_gnueabihf.rs
+++ b/compiler/rustc_target/src/spec/targets/armv7_unknown_linux_gnueabihf.rs
@@ -19,7 +19,7 @@ pub(crate) fn target() -> Target {
             abi: Abi::EabiHf,
             llvm_floatabi: Some(FloatAbi::Hard),
             // Info about features at https://wiki.debian.org/ArmHardFloatPort
-            features: "+v7,+vfp3,-d32,+thumb2,-neon".into(),
+            features: "+v7,+vfp3d16,+thumb2,-neon".into(),
             max_atomic_width: Some(64),
             mcount: "\u{1}__gnu_mcount_nc".into(),
             llvm_mcount_intrinsic: Some("llvm.arm.gnu.eabi.mcount".into()),

--- a/compiler/rustc_target/src/spec/targets/armv7_unknown_linux_musleabihf.rs
+++ b/compiler/rustc_target/src/spec/targets/armv7_unknown_linux_musleabihf.rs
@@ -20,7 +20,7 @@ pub(crate) fn target() -> Target {
         options: TargetOptions {
             abi: Abi::EabiHf,
             llvm_floatabi: Some(FloatAbi::Hard),
-            features: "+v7,+vfp3,-d32,+thumb2,-neon".into(),
+            features: "+v7,+vfp3d16,+thumb2,-neon".into(),
             max_atomic_width: Some(64),
             mcount: "\u{1}mcount".into(),
             // FIXME(compiler-team#422): musl targets should be dynamically linked by default.

--- a/compiler/rustc_target/src/spec/targets/armv7_unknown_linux_uclibceabihf.rs
+++ b/compiler/rustc_target/src/spec/targets/armv7_unknown_linux_uclibceabihf.rs
@@ -19,7 +19,7 @@ pub(crate) fn target() -> Target {
 
         options: TargetOptions {
             // Info about features at https://wiki.debian.org/ArmHardFloatPort
-            features: "+v7,+vfp3,-d32,+thumb2,-neon".into(),
+            features: "+v7,+vfp3d16,+thumb2,-neon".into(),
             cpu: "generic".into(),
             max_atomic_width: Some(64),
             mcount: "_mcount".into(),

--- a/compiler/rustc_target/src/spec/targets/armv7_unknown_netbsd_eabihf.rs
+++ b/compiler/rustc_target/src/spec/targets/armv7_unknown_netbsd_eabihf.rs
@@ -15,7 +15,7 @@ pub(crate) fn target() -> Target {
         options: TargetOptions {
             abi: Abi::EabiHf,
             llvm_floatabi: Some(FloatAbi::Hard),
-            features: "+v7,+vfp3,-d32,+thumb2,-neon".into(),
+            features: "+v7,+vfp3d16,+thumb2,-neon".into(),
             max_atomic_width: Some(64),
             mcount: "__mcount".into(),
             ..base::netbsd::opts()

--- a/compiler/rustc_target/src/spec/targets/armv7_wrs_vxworks_eabihf.rs
+++ b/compiler/rustc_target/src/spec/targets/armv7_wrs_vxworks_eabihf.rs
@@ -16,7 +16,7 @@ pub(crate) fn target() -> Target {
             abi: Abi::EabiHf,
             llvm_floatabi: Some(FloatAbi::Hard),
             // Info about features at https://wiki.debian.org/ArmHardFloatPort
-            features: "+v7,+vfp3,-d32,+thumb2,-neon".into(),
+            features: "+v7,+vfp3d16,+thumb2,-neon".into(),
             max_atomic_width: Some(64),
             ..base::vxworks::opts()
         },

--- a/compiler/rustc_target/src/spec/targets/armv7a_kmc_solid_asp3_eabihf.rs
+++ b/compiler/rustc_target/src/spec/targets/armv7a_kmc_solid_asp3_eabihf.rs
@@ -17,7 +17,7 @@ pub(crate) fn target() -> Target {
             abi: Abi::EabiHf,
             llvm_floatabi: Some(FloatAbi::Hard),
             linker: Some("arm-kmc-eabi-gcc".into()),
-            features: "+v7,+vfp3,-d32,+thumb2,-neon".into(),
+            features: "+v7,+vfp3d16,+thumb2,-neon".into(),
             relocation_model: RelocModel::Static,
             disable_redzone: true,
             max_atomic_width: Some(64),

--- a/compiler/rustc_target/src/spec/targets/armv7a_none_eabihf.rs
+++ b/compiler/rustc_target/src/spec/targets/armv7a_none_eabihf.rs
@@ -16,7 +16,7 @@ pub(crate) fn target() -> Target {
         llvm_floatabi: Some(FloatAbi::Hard),
         linker_flavor: LinkerFlavor::Gnu(Cc::No, Lld::Yes),
         linker: Some("rust-lld".into()),
-        features: "+v7,+vfp3,-d32,+thumb2,-neon,+strict-align".into(),
+        features: "+v7,+vfp3d16,+thumb2,-neon,+strict-align".into(),
         relocation_model: RelocModel::Static,
         disable_redzone: true,
         max_atomic_width: Some(64),

--- a/compiler/rustc_thread_pool/src/registry.rs
+++ b/compiler/rustc_thread_pool/src/registry.rs
@@ -153,8 +153,8 @@ pub struct Registry {
     terminate_count: AtomicUsize,
 }
 
-/// ////////////////////////////////////////////////////////////////////////
-/// Initialization
+///////////////////////////////////////////////////////////////////////////
+// Initialization
 
 static mut THE_REGISTRY: Option<Arc<Registry>> = None;
 static THE_REGISTRY_SET: Once = Once::new();
@@ -407,12 +407,12 @@ impl Registry {
         }
     }
 
-    /// ////////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////////
     /// MAIN LOOP
     ///
     /// So long as all of the worker threads are hanging out in their
     /// top-level loop, there is no work to be done.
-
+    ///
     /// Push a job into the given `registry`. If we are running on a
     /// worker thread for the registry, this will push onto the
     /// deque. Else, it will inject from the outside (which is slower).
@@ -668,8 +668,8 @@ impl ThreadInfo {
     }
 }
 
-/// ////////////////////////////////////////////////////////////////////////
-/// WorkerThread identifiers
+///////////////////////////////////////////////////////////////////////////
+// WorkerThread identifiers
 
 pub(super) struct WorkerThread {
     /// the "worker" half of our local deque
@@ -1018,8 +1018,6 @@ impl WorkerThread {
         }
     }
 }
-
-/// ////////////////////////////////////////////////////////////////////////
 
 unsafe fn main_loop(thread: ThreadBuilder) {
     let worker_thread = &WorkerThread::from(thread);

--- a/library/core/src/cell/once.rs
+++ b/library/core/src/cell/once.rs
@@ -353,7 +353,8 @@ impl<T> OnceCell<T> {
 }
 
 #[stable(feature = "once_cell", since = "1.70.0")]
-impl<T> Default for OnceCell<T> {
+#[rustc_const_unstable(feature = "const_default", issue = "143894")]
+impl<T> const Default for OnceCell<T> {
     #[inline]
     fn default() -> Self {
         Self::new()

--- a/library/core/src/prelude/v1.rs
+++ b/library/core/src/prelude/v1.rs
@@ -118,13 +118,6 @@ pub use crate::macros::builtin::deref;
 )]
 pub use crate::macros::builtin::define_opaque;
 
-#[unstable(
-    feature = "derive_from",
-    issue = "144889",
-    reason = "`derive(From)` is unstable"
-)]
-pub use crate::macros::builtin::From;
-
 #[unstable(feature = "extern_item_impls", issue = "125418")]
 pub use crate::macros::builtin::{eii, unsafe_eii};
 

--- a/library/core/src/sync/atomic.rs
+++ b/library/core/src/sync/atomic.rs
@@ -1151,8 +1151,8 @@ impl AtomicBool {
     /// assert_eq!(foo.fetch_or(false, Ordering::SeqCst), true);
     /// assert_eq!(foo.load(Ordering::SeqCst), true);
     ///
-    /// let foo = AtomicBool::new(true);
-    /// assert_eq!(foo.fetch_or(true, Ordering::SeqCst), true);
+    /// let foo = AtomicBool::new(false);
+    /// assert_eq!(foo.fetch_or(true, Ordering::SeqCst), false);
     /// assert_eq!(foo.load(Ordering::SeqCst), true);
     ///
     /// let foo = AtomicBool::new(false);

--- a/library/coretests/tests/fmt/mod.rs
+++ b/library/coretests/tests/fmt/mod.rs
@@ -30,6 +30,12 @@ fn test_format_flags() {
     assert_eq!(format!("{:p} {:x}", p, 16), format!("{p:p} 10"));
 
     assert_eq!(format!("{: >3}", 'a'), "  a");
+
+    /// Regression test for <https://github.com/rust-lang/rust/issues/50280#issuecomment-626035934>.
+    fn show(a: fn() -> f32, b: fn(&Vec<i8>) -> f32) {
+        println!("the two pointers: {:p} {:p}", a, b);
+    }
+    show(|| 1.0, |_| 2.0);
 }
 
 #[test]

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -274,6 +274,7 @@
 #![feature(cfg_sanitizer_cfi)]
 #![feature(cfg_target_thread_local)]
 #![feature(cfi_encoding)]
+#![feature(const_default)]
 #![feature(const_trait_impl)]
 #![feature(core_float_math)]
 #![feature(decl_macro)]

--- a/library/std/src/sync/once_lock.rs
+++ b/library/std/src/sync/once_lock.rs
@@ -582,7 +582,8 @@ impl<T: RefUnwindSafe + UnwindSafe> RefUnwindSafe for OnceLock<T> {}
 impl<T: UnwindSafe> UnwindSafe for OnceLock<T> {}
 
 #[stable(feature = "once_cell", since = "1.70.0")]
-impl<T> Default for OnceLock<T> {
+#[rustc_const_unstable(feature = "const_default", issue = "143894")]
+impl<T> const Default for OnceLock<T> {
     /// Creates a new uninitialized cell.
     ///
     /// # Example

--- a/library/unwind/src/lib.rs
+++ b/library/unwind/src/lib.rs
@@ -73,8 +73,25 @@ cfg_select! {
     }
     _ => {
         #[link(name = "unwind", kind = "static", modifiers = "-bundle", cfg(target_feature = "crt-static"))]
-        #[link(name = "gcc_s", cfg(not(target_feature = "crt-static")))]
+        #[link(name = "gcc_s", cfg(all(not(target_feature = "crt-static"), not(target_arch = "hexagon"))))]
         unsafe extern "C" {}
+    }
+}
+
+// Hexagon with musl uses llvm-libunwind by default
+#[cfg(all(target_env = "musl", target_arch = "hexagon"))]
+cfg_select! {
+    feature = "llvm-libunwind" => {
+        #[link(name = "unwind", kind = "static", modifiers = "-bundle")]
+        unsafe extern "C" {}
+    }
+    feature = "system-llvm-libunwind" => {
+        #[link(name = "unwind", kind = "static", modifiers = "-bundle", cfg(target_feature = "crt-static"))]
+        #[link(name = "unwind", cfg(not(target_feature = "crt-static")))]
+        unsafe extern "C" {}
+    }
+    _ => {
+        // Fallback: should not happen since hexagon defaults to llvm-libunwind
     }
 }
 

--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -354,7 +354,10 @@ fn copy_third_party_objects(
 
     if target == "x86_64-fortanix-unknown-sgx"
         || builder.config.llvm_libunwind(target) == LlvmLibunwind::InTree
-            && (target.contains("linux") || target.contains("fuchsia") || target.contains("aix"))
+            && (target.contains("linux")
+                || target.contains("fuchsia")
+                || target.contains("aix")
+                || target.contains("hexagon"))
     {
         let libunwind_path =
             copy_llvm_libunwind(builder, target, &builder.sysroot_target_libdir(*compiler, target));

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -1851,7 +1851,7 @@ impl Config {
             .get(&target)
             .and_then(|t| t.llvm_libunwind)
             .or(self.llvm_libunwind_default)
-            .unwrap_or(if target.contains("fuchsia") {
+            .unwrap_or(if target.contains("fuchsia") || target.contains("hexagon") {
                 LlvmLibunwind::InTree
             } else {
                 LlvmLibunwind::No

--- a/src/librustdoc/html/macro_expansion.rs
+++ b/src/librustdoc/html/macro_expansion.rs
@@ -1,5 +1,5 @@
-use rustc_ast::visit::{Visitor, walk_crate, walk_expr, walk_item, walk_pat, walk_stmt};
-use rustc_ast::{Crate, Expr, Item, Pat, Stmt};
+use rustc_ast::visit::{Visitor, walk_crate, walk_expr, walk_item, walk_pat, walk_stmt, walk_ty};
+use rustc_ast::{Crate, Expr, Item, Pat, Stmt, Ty};
 use rustc_data_structures::fx::FxHashMap;
 use rustc_span::source_map::SourceMap;
 use rustc_span::{BytePos, Span};
@@ -151,6 +151,14 @@ impl<'ast> Visitor<'ast> for ExpandedCodeVisitor<'ast> {
             self.handle_new_span(pat.span, || rustc_ast_pretty::pprust::pat_to_string(pat));
         } else {
             walk_pat(self, pat);
+        }
+    }
+
+    fn visit_ty(&mut self, ty: &'ast Ty) {
+        if ty.span.from_expansion() {
+            self.handle_new_span(ty.span, || rustc_ast_pretty::pprust::ty_to_string(ty));
+        } else {
+            walk_ty(self, ty);
         }
     }
 }

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -439,6 +439,7 @@ fn item_module(cx: &Context<'_>, item: &clean::Item, items: &[clean::Item]) -> i
                                 )?;
                             }
                         }
+                        write!(w, "</code></dt>")?
                     }
                     clean::ImportItem(ref import) => {
                         let stab_tags =

--- a/src/tools/clippy/tests/compile-test.rs
+++ b/src/tools/clippy/tests/compile-test.rs
@@ -173,6 +173,10 @@ impl TestContext {
                         p.envs.push(("RUSTC_SNAPSHOT".into(), Some(rustc.into())));
                         p.envs.push(("RUSTC_SNAPSHOT_LIBDIR".into(), Some(libdir.into())));
                         p.envs.push(("RUSTC_SYSROOT".into(), Some(sysroot.into())));
+                        // Ensure we rebuild the dependencies when the sysroot changes.
+                        // (Bootstrap usually sets this automatically, but since we invoke cargo
+                        // ourselves we have to do it.)
+                        p.args.push("-Zbinary-dep-depinfo".into());
                     }
                     p
                 },

--- a/src/tools/miri/tests/ui.rs
+++ b/src/tools/miri/tests/ui.rs
@@ -133,7 +133,11 @@ fn miri_config(
                     program: miri_path()
                         .with_file_name(format!("cargo-miri{}", env::consts::EXE_SUFFIX)),
                     // There is no `cargo miri build` so we just use `cargo miri run`.
-                    args: ["miri", "run"].into_iter().map(Into::into).collect(),
+                    // Add `-Zbinary-dep-depinfo` since it is needed for bootstrap builds (and doesn't harm otherwise).
+                    args: ["miri", "run", "--quiet", "-Zbinary-dep-depinfo"]
+                        .into_iter()
+                        .map(Into::into)
+                        .collect(),
                     // Reset `RUSTFLAGS` to work around <https://github.com/rust-lang/rust/pull/119574#issuecomment-1876878344>.
                     envs: vec![("RUSTFLAGS".into(), None)],
                     ..CommandBuilder::cargo()

--- a/tests/debuginfo/function-arg-initialization.rs
+++ b/tests/debuginfo/function-arg-initialization.rs
@@ -6,8 +6,7 @@
 // function name.
 
 //@ min-lldb-version: 1800
-//@ compile-flags:-g -Zmir-enable-passes=-SingleUseConsts
-// SingleUseConsts shouldn't need to be disabled, see #128945
+//@ compile-flags:-g
 //@ disable-gdb-pretty-printers
 //@ ignore-backends: gcc
 

--- a/tests/rustdoc/extern/pub-extern-crate-150176.rs
+++ b/tests/rustdoc/extern/pub-extern-crate-150176.rs
@@ -1,0 +1,5 @@
+//@ aux-build:pub-extern-crate.rs
+
+//@ has pub_extern_crate_150176/index.html
+//@ hasraw - 'pub extern crate inner;</code></dt>'
+pub extern crate inner;

--- a/tests/rustdoc/extern/pub-extern-crate-150176.rs
+++ b/tests/rustdoc/extern/pub-extern-crate-150176.rs
@@ -1,5 +1,9 @@
 //@ aux-build:pub-extern-crate.rs
 
+// A refactor had left us missing the closing tags,
+// ensure that they are present.
+// https://github.com/rust-lang/rust/issues/150176
+
 //@ has pub_extern_crate_150176/index.html
-//@ hasraw - 'pub extern crate inner;</code></dt>'
+//@ hasraw - '<dt><code>pub extern crate inner;</code></dt>'
 pub extern crate inner;

--- a/tests/rustdoc/macro-expansion/type-macro-expansion.rs
+++ b/tests/rustdoc/macro-expansion/type-macro-expansion.rs
@@ -1,0 +1,27 @@
+// Ensure macro invocations at type position are expanded correctly
+
+//@ compile-flags: -Zunstable-options --generate-macro-expansion
+
+#![crate_name = "foo"]
+
+//@ has 'src/foo/type-macro-expansion.rs.html'
+
+macro_rules! foo {
+    () => {
+        fn(())
+    };
+    ($_arg:expr) => {
+        [(); 1]
+    };
+}
+
+fn bar() {
+    //@ has - '//*[@class="expansion"]/*[@class="original"]/*[@class="macro"]' 'foo!'
+    //@ has - '//*[@class="expansion"]/*[@class="original"]' 'foo!()'
+    //@ has - '//*[@class="expansion"]/*[@class="expanded"]' 'fn(())'
+    let _: foo!();
+    //@ has - '//*[@class="expansion"]/*[@class="original"]/*[@class="macro"]' 'foo!'
+    //@ has - '//*[@class="expansion"]/*[@class="original"]' 'foo!(42)'
+    //@ has - '//*[@class="expansion"]/*[@class="expanded"]' '[(); 1]'
+    let _: foo!(42);
+}

--- a/tests/ui/eii/error_statement_position.rs
+++ b/tests/ui/eii/error_statement_position.rs
@@ -1,6 +1,16 @@
 #![feature(extern_item_impls)]
+// EIIs can, despite not being super useful, be declared in statement position
+// nested inside items. Items in statement position, when expanded as part of a macro,
+// need to be wrapped slightly differently (in an `ast::Statement`).
+// We did this on the happy path (no errors), but when there was an error, we'd
+// replace it with *just* an `ast::Item` not wrapped in an `ast::Statement`.
+// This caused an ICE (https://github.com/rust-lang/rust/issues/149980).
+// this test fails to build, but demonstrates that no ICE is produced.
 
 fn main() {
+    struct Bar;
+
     #[eii]
+    //~^ ERROR `#[eii]` is only valid on functions
     impl Bar {}
 }

--- a/tests/ui/eii/error_statement_position.rs
+++ b/tests/ui/eii/error_statement_position.rs
@@ -1,0 +1,6 @@
+#![feature(extern_item_impls)]
+
+fn main() {
+    #[eii]
+    impl Bar {}
+}

--- a/tests/ui/eii/error_statement_position.stderr
+++ b/tests/ui/eii/error_statement_position.stderr
@@ -1,0 +1,8 @@
+error: `#[eii]` is only valid on functions
+  --> $DIR/error_statement_position.rs:13:5
+   |
+LL |     #[eii]
+   |     ^^^^^^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/include-macros/auxiliary/shebang-expr.rs
+++ b/tests/ui/include-macros/auxiliary/shebang-expr.rs
@@ -1,0 +1,3 @@
+#!/usr/bin/env my-rust-expr-evaluator
+
+2 * (1 + 3)

--- a/tests/ui/include-macros/auxiliary/shebang-items.rs
+++ b/tests/ui/include-macros/auxiliary/shebang-items.rs
@@ -1,0 +1,3 @@
+#!/usr/bin/env my-rust-script-runner
+
+fn main() {}

--- a/tests/ui/include-macros/shebang-in-expr-ctxt.rs
+++ b/tests/ui/include-macros/shebang-in-expr-ctxt.rs
@@ -1,0 +1,16 @@
+// Check that we *don't* strip shebang in files that were `include`d in an expression or
+// expression statement context.
+// We do that to be consistent with frontmatter (see test `frontmatter/include-in-expr-ctxt.rs`).
+// While there could be niche use cases for such shebang, it seems more confusing than beneficial.
+
+fn main() {
+    // expr ctxt
+    _ = include!("auxiliary/shebang-expr.rs");
+    //~^ ERROR non-expression macro in expression position
+    //~? ERROR expected `[`, found `/`
+
+    // stmt ctxt (reuses expr expander)
+    include!("auxiliary/shebang-expr.rs");
+    //~^ ERROR non-statement macro in statement position
+    //~? ERROR expected `[`, found `/`
+}

--- a/tests/ui/include-macros/shebang-in-expr-ctxt.stderr
+++ b/tests/ui/include-macros/shebang-in-expr-ctxt.stderr
@@ -1,0 +1,33 @@
+error: expected `[`, found `/`
+  --> $DIR/auxiliary/shebang-expr.rs:1:3
+   |
+LL | #!/usr/bin/env my-rust-expr-evaluator
+   |   ^ expected `[`
+   |
+   = note: the token sequence `#!` here looks like the start of a shebang interpreter directive but it is not
+   = help: if you meant this to be a shebang interpreter directive, move it to the very start of the file
+
+error: non-expression macro in expression position: include
+  --> $DIR/shebang-in-expr-ctxt.rs:8:9
+   |
+LL |     _ = include!("auxiliary/shebang-expr.rs");
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: expected `[`, found `/`
+  --> $DIR/auxiliary/shebang-expr.rs:1:3
+   |
+LL | #!/usr/bin/env my-rust-expr-evaluator
+   |   ^ expected `[`
+   |
+   = note: the token sequence `#!` here looks like the start of a shebang interpreter directive but it is not
+   = help: if you meant this to be a shebang interpreter directive, move it to the very start of the file
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: non-statement macro in statement position: include
+  --> $DIR/shebang-in-expr-ctxt.rs:13:5
+   |
+LL |     include!("auxiliary/shebang-expr.rs");
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 4 previous errors
+

--- a/tests/ui/include-macros/shebang-in-item-ctxt.rs
+++ b/tests/ui/include-macros/shebang-in-item-ctxt.rs
@@ -1,0 +1,4 @@
+// Ensure that we strip shebang in files `include`d in item contexts.
+//@ check-pass
+
+include!("auxiliary/shebang-items.rs");


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#146377 (Don't strip shebang in expr-ctxt `include!(…)`)
 - rust-lang/rust#149512 (Fix d32 usage in Arm target specs )
 - rust-lang/rust#149812 (Add const default for OnceCell and OnceLock)
 - rust-lang/rust#149882 (miri: add -Zbinary-dep-depinfo to dependency builds)
 - rust-lang/rust#150009 (Enable llvm-libunwind by default for Hexagon targets)
 - rust-lang/rust#150035 (fix docustring on fetch_or)
 - rust-lang/rust#150082 (tests/ui/traits/fmt-pointer-trait.rs: Add HRTB fn pointer case)
 - rust-lang/rust#150160 (Fix ICE (rust-lang/rust#149980) for invalid EII in statement position)
 - rust-lang/rust#150184 (mir_build: Use the same length type for `TestableCase::Slice` and `TestKind::Len`)
 - rust-lang/rust#150185 ([rustdoc] Add missing close tags in extern crate reexports)
 - rust-lang/rust#150191 (change non-canonical clone impl to {*self}, fix some doc comments)
 - rust-lang/rust#150203 (Drop the From derive macro from the v1 prelude)
 - rust-lang/rust#150210 (tests/debuginfo/function-arg-initialization.rs: Stop disabling SingleUseConsts MIR pass)
 - rust-lang/rust#150221 (rustdoc: handle macro expansions in types)
 - rust-lang/rust#150223 (GVN: Adds the `insert_unique` method)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=146377,149512,149812,149882,150009,150035,150082,150160,150184,150185,150191,150203,150210,150221,150223)
<!-- homu-ignore:end -->