### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/compiler/rustc_ast_pretty/src/pprust/mod.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/mod.rs
@@ -33,6 +33,9 @@ pub fn where_bound_predicate_to_string(where_bound_predicate: &ast::WhereBoundPr
     State::new().where_bound_predicate_to_string(where_bound_predicate)
 }
 
+/// # Panics
+///
+/// Panics if `pat.kind` is `PatKind::Missing`.
 pub fn pat_to_string(pat: &ast::Pat) -> String {
     State::new().pat_to_string(pat)
 }

--- a/compiler/rustc_target/src/spec/targets/arm_unknown_linux_gnueabihf.rs
+++ b/compiler/rustc_target/src/spec/targets/arm_unknown_linux_gnueabihf.rs
@@ -15,7 +15,7 @@ pub(crate) fn target() -> Target {
         options: TargetOptions {
             abi: Abi::EabiHf,
             llvm_floatabi: Some(FloatAbi::Hard),
-            features: "+strict-align,+v6,+vfp2,-d32".into(),
+            features: "+strict-align,+v6,+vfp2".into(),
             max_atomic_width: Some(64),
             mcount: "\u{1}__gnu_mcount_nc".into(),
             llvm_mcount_intrinsic: Some("llvm.arm.gnu.eabi.mcount".into()),

--- a/compiler/rustc_target/src/spec/targets/arm_unknown_linux_musleabihf.rs
+++ b/compiler/rustc_target/src/spec/targets/arm_unknown_linux_musleabihf.rs
@@ -17,7 +17,7 @@ pub(crate) fn target() -> Target {
             llvm_floatabi: Some(FloatAbi::Hard),
             // Most of these settings are copied from the arm_unknown_linux_gnueabihf
             // target.
-            features: "+strict-align,+v6,+vfp2,-d32".into(),
+            features: "+strict-align,+v6,+vfp2".into(),
             max_atomic_width: Some(64),
             mcount: "\u{1}mcount".into(),
             // FIXME(compiler-team#422): musl targets should be dynamically linked by default.

--- a/compiler/rustc_target/src/spec/targets/armv6_unknown_freebsd.rs
+++ b/compiler/rustc_target/src/spec/targets/armv6_unknown_freebsd.rs
@@ -15,7 +15,7 @@ pub(crate) fn target() -> Target {
         options: TargetOptions {
             abi: Abi::EabiHf,
             llvm_floatabi: Some(FloatAbi::Hard),
-            features: "+v6,+vfp2,-d32".into(),
+            features: "+v6,+vfp2".into(),
             max_atomic_width: Some(64),
             mcount: "\u{1}__gnu_mcount_nc".into(),
             llvm_mcount_intrinsic: Some("llvm.arm.gnu.eabi.mcount".into()),

--- a/compiler/rustc_target/src/spec/targets/armv6_unknown_netbsd_eabihf.rs
+++ b/compiler/rustc_target/src/spec/targets/armv6_unknown_netbsd_eabihf.rs
@@ -15,7 +15,7 @@ pub(crate) fn target() -> Target {
         options: TargetOptions {
             abi: Abi::EabiHf,
             llvm_floatabi: Some(FloatAbi::Hard),
-            features: "+v6,+vfp2,-d32".into(),
+            features: "+v6,+vfp2".into(),
             max_atomic_width: Some(64),
             mcount: "__mcount".into(),
             ..base::netbsd::opts()

--- a/compiler/rustc_target/src/spec/targets/armv7_linux_androideabi.rs
+++ b/compiler/rustc_target/src/spec/targets/armv7_linux_androideabi.rs
@@ -28,7 +28,7 @@ pub(crate) fn target() -> Target {
         options: TargetOptions {
             abi: Abi::Eabi,
             llvm_floatabi: Some(FloatAbi::Soft),
-            features: "+v7,+thumb-mode,+thumb2,+vfp3,-d32,-neon".into(),
+            features: "+v7,+thumb-mode,+thumb2,+vfp3d16,-neon".into(),
             supported_sanitizers: SanitizerSet::ADDRESS,
             max_atomic_width: Some(64),
             ..base

--- a/compiler/rustc_target/src/spec/targets/armv7_unknown_freebsd.rs
+++ b/compiler/rustc_target/src/spec/targets/armv7_unknown_freebsd.rs
@@ -15,7 +15,7 @@ pub(crate) fn target() -> Target {
         options: TargetOptions {
             abi: Abi::EabiHf,
             llvm_floatabi: Some(FloatAbi::Hard),
-            features: "+v7,+vfp3,-d32,+thumb2,-neon".into(),
+            features: "+v7,+vfp3d16,+thumb2,-neon".into(),
             max_atomic_width: Some(64),
             mcount: "\u{1}__gnu_mcount_nc".into(),
             ..base::freebsd::opts()

--- a/compiler/rustc_target/src/spec/targets/armv7_unknown_linux_gnueabihf.rs
+++ b/compiler/rustc_target/src/spec/targets/armv7_unknown_linux_gnueabihf.rs
@@ -19,7 +19,7 @@ pub(crate) fn target() -> Target {
             abi: Abi::EabiHf,
             llvm_floatabi: Some(FloatAbi::Hard),
             // Info about features at https://wiki.debian.org/ArmHardFloatPort
-            features: "+v7,+vfp3,-d32,+thumb2,-neon".into(),
+            features: "+v7,+vfp3d16,+thumb2,-neon".into(),
             max_atomic_width: Some(64),
             mcount: "\u{1}__gnu_mcount_nc".into(),
             llvm_mcount_intrinsic: Some("llvm.arm.gnu.eabi.mcount".into()),

--- a/compiler/rustc_target/src/spec/targets/armv7_unknown_linux_musleabihf.rs
+++ b/compiler/rustc_target/src/spec/targets/armv7_unknown_linux_musleabihf.rs
@@ -20,7 +20,7 @@ pub(crate) fn target() -> Target {
         options: TargetOptions {
             abi: Abi::EabiHf,
             llvm_floatabi: Some(FloatAbi::Hard),
-            features: "+v7,+vfp3,-d32,+thumb2,-neon".into(),
+            features: "+v7,+vfp3d16,+thumb2,-neon".into(),
             max_atomic_width: Some(64),
             mcount: "\u{1}mcount".into(),
             // FIXME(compiler-team#422): musl targets should be dynamically linked by default.

--- a/compiler/rustc_target/src/spec/targets/armv7_unknown_linux_uclibceabihf.rs
+++ b/compiler/rustc_target/src/spec/targets/armv7_unknown_linux_uclibceabihf.rs
@@ -19,7 +19,7 @@ pub(crate) fn target() -> Target {
 
         options: TargetOptions {
             // Info about features at https://wiki.debian.org/ArmHardFloatPort
-            features: "+v7,+vfp3,-d32,+thumb2,-neon".into(),
+            features: "+v7,+vfp3d16,+thumb2,-neon".into(),
             cpu: "generic".into(),
             max_atomic_width: Some(64),
             mcount: "_mcount".into(),

--- a/compiler/rustc_target/src/spec/targets/armv7_unknown_netbsd_eabihf.rs
+++ b/compiler/rustc_target/src/spec/targets/armv7_unknown_netbsd_eabihf.rs
@@ -15,7 +15,7 @@ pub(crate) fn target() -> Target {
         options: TargetOptions {
             abi: Abi::EabiHf,
             llvm_floatabi: Some(FloatAbi::Hard),
-            features: "+v7,+vfp3,-d32,+thumb2,-neon".into(),
+            features: "+v7,+vfp3d16,+thumb2,-neon".into(),
             max_atomic_width: Some(64),
             mcount: "__mcount".into(),
             ..base::netbsd::opts()

--- a/compiler/rustc_target/src/spec/targets/armv7_wrs_vxworks_eabihf.rs
+++ b/compiler/rustc_target/src/spec/targets/armv7_wrs_vxworks_eabihf.rs
@@ -16,7 +16,7 @@ pub(crate) fn target() -> Target {
             abi: Abi::EabiHf,
             llvm_floatabi: Some(FloatAbi::Hard),
             // Info about features at https://wiki.debian.org/ArmHardFloatPort
-            features: "+v7,+vfp3,-d32,+thumb2,-neon".into(),
+            features: "+v7,+vfp3d16,+thumb2,-neon".into(),
             max_atomic_width: Some(64),
             ..base::vxworks::opts()
         },

--- a/compiler/rustc_target/src/spec/targets/armv7a_kmc_solid_asp3_eabihf.rs
+++ b/compiler/rustc_target/src/spec/targets/armv7a_kmc_solid_asp3_eabihf.rs
@@ -17,7 +17,7 @@ pub(crate) fn target() -> Target {
             abi: Abi::EabiHf,
             llvm_floatabi: Some(FloatAbi::Hard),
             linker: Some("arm-kmc-eabi-gcc".into()),
-            features: "+v7,+vfp3,-d32,+thumb2,-neon".into(),
+            features: "+v7,+vfp3d16,+thumb2,-neon".into(),
             relocation_model: RelocModel::Static,
             disable_redzone: true,
             max_atomic_width: Some(64),

--- a/compiler/rustc_target/src/spec/targets/armv7a_none_eabihf.rs
+++ b/compiler/rustc_target/src/spec/targets/armv7a_none_eabihf.rs
@@ -16,7 +16,7 @@ pub(crate) fn target() -> Target {
         llvm_floatabi: Some(FloatAbi::Hard),
         linker_flavor: LinkerFlavor::Gnu(Cc::No, Lld::Yes),
         linker: Some("rust-lld".into()),
-        features: "+v7,+vfp3,-d32,+thumb2,-neon,+strict-align".into(),
+        features: "+v7,+vfp3d16,+thumb2,-neon,+strict-align".into(),
         relocation_model: RelocModel::Static,
         disable_redzone: true,
         max_atomic_width: Some(64),

--- a/src/librustdoc/html/macro_expansion.rs
+++ b/src/librustdoc/html/macro_expansion.rs
@@ -1,5 +1,5 @@
-use rustc_ast::visit::{Visitor, walk_crate, walk_expr, walk_item, walk_pat, walk_stmt};
-use rustc_ast::{Crate, Expr, Item, Pat, Stmt};
+use rustc_ast::visit::{Visitor, walk_crate, walk_expr, walk_item, walk_pat, walk_stmt, walk_ty};
+use rustc_ast::{Crate, Expr, Item, Pat, Stmt, Ty};
 use rustc_data_structures::fx::FxHashMap;
 use rustc_span::source_map::SourceMap;
 use rustc_span::{BytePos, Span};
@@ -151,6 +151,14 @@ impl<'ast> Visitor<'ast> for ExpandedCodeVisitor<'ast> {
             self.handle_new_span(pat.span, || rustc_ast_pretty::pprust::pat_to_string(pat));
         } else {
             walk_pat(self, pat);
+        }
+    }
+
+    fn visit_ty(&mut self, ty: &'ast Ty) {
+        if ty.span.from_expansion() {
+            self.handle_new_span(ty.span, || rustc_ast_pretty::pprust::ty_to_string(ty));
+        } else {
+            walk_ty(self, ty);
         }
     }
 }

--- a/tests/debuginfo/function-arg-initialization.rs
+++ b/tests/debuginfo/function-arg-initialization.rs
@@ -6,8 +6,7 @@
 // function name.
 
 //@ min-lldb-version: 1800
-//@ compile-flags:-g -Zmir-enable-passes=-SingleUseConsts
-// SingleUseConsts shouldn't need to be disabled, see #128945
+//@ compile-flags:-g
 //@ disable-gdb-pretty-printers
 //@ ignore-backends: gcc
 

--- a/tests/rustdoc/macro-expansion/type-macro-expansion.rs
+++ b/tests/rustdoc/macro-expansion/type-macro-expansion.rs
@@ -1,0 +1,27 @@
+// Ensure macro invocations at type position are expanded correctly
+
+//@ compile-flags: -Zunstable-options --generate-macro-expansion
+
+#![crate_name = "foo"]
+
+//@ has 'src/foo/type-macro-expansion.rs.html'
+
+macro_rules! foo {
+    () => {
+        fn(())
+    };
+    ($_arg:expr) => {
+        [(); 1]
+    };
+}
+
+fn bar() {
+    //@ has - '//*[@class="expansion"]/*[@class="original"]/*[@class="macro"]' 'foo!'
+    //@ has - '//*[@class="expansion"]/*[@class="original"]' 'foo!()'
+    //@ has - '//*[@class="expansion"]/*[@class="expanded"]' 'fn(())'
+    let _: foo!();
+    //@ has - '//*[@class="expansion"]/*[@class="original"]/*[@class="macro"]' 'foo!'
+    //@ has - '//*[@class="expansion"]/*[@class="original"]' 'foo!(42)'
+    //@ has - '//*[@class="expansion"]/*[@class="expanded"]' '[(); 1]'
+    let _: foo!(42);
+}


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#149512 (Fix d32 usage in Arm target specs )
 - rust-lang/rust#150210 (tests/debuginfo/function-arg-initialization.rs: Stop disabling SingleUseConsts MIR pass)
 - rust-lang/rust#150221 (rustdoc: handle macro expansions in types)
 - rust-lang/rust#150223 (GVN: Adds the `insert_unique` method)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=149512,150210,150221,150223)
<!-- homu-ignore:end -->