### PR TITLE
do not encode constness for constructors

### DIFF
--- a/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
@@ -2,6 +2,7 @@ use std::any::Any;
 use std::mem;
 use std::sync::Arc;
 
+use rustc_hir::Constness;
 use rustc_hir::attrs::Deprecation;
 use rustc_hir::def::{CtorKind, DefKind};
 use rustc_hir::def_id::{CrateNum, DefId, DefIdMap, LOCAL_CRATE};
@@ -255,7 +256,13 @@ provide! { tcx, def_id, other, cdata,
     def_kind => { cdata.def_kind(tcx, def_id.index) }
     impl_parent => { table }
     defaultness => { table_direct }
-    constness => { table_direct }
+    constness => {
+        if let DefKind::Ctor(_, CtorKind::Fn) = cdata.def_kind(tcx, def_id.index) {
+            Constness::Const
+        } else {
+            cdata.root.tables.constness.get((cdata, tcx), def_id.index)
+        }
+    }
     const_conditions => { table }
     explicit_implied_const_bounds => { table_defaulted_array }
     coerce_unsized_info => {

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -1306,11 +1306,9 @@ fn should_encode_fn_sig(def_kind: DefKind) -> bool {
 
 fn should_encode_constness(def_kind: DefKind) -> bool {
     match def_kind {
-        DefKind::Fn
-        | DefKind::AssocFn
-        | DefKind::Closure
-        | DefKind::Ctor(_, CtorKind::Fn)
-        | DefKind::Impl { of_trait: false } => true,
+        DefKind::Fn | DefKind::AssocFn | DefKind::Closure | DefKind::Impl { of_trait: false } => {
+            true
+        }
 
         DefKind::Struct
         | DefKind::Union
@@ -1337,7 +1335,7 @@ fn should_encode_constness(def_kind: DefKind) -> bool {
         | DefKind::LifetimeParam
         | DefKind::GlobalAsm
         | DefKind::ExternCrate
-        | DefKind::Ctor(_, CtorKind::Const)
+        | DefKind::Ctor(..)
         | DefKind::Variant
         | DefKind::SyntheticCoroutineBody => false,
     }


### PR DESCRIPTION
since they are always const

r? oli-obk