### PR TITLE
Skip tidy target-specific check for `run-make-cargo` too

### DIFF
--- a/src/tools/tidy/src/target_specific_tests.rs
+++ b/src/tools/tidy/src/target_specific_tests.rs
@@ -52,8 +52,12 @@ pub fn check(tests_path: &Path, tidy_ctx: TidyCtx) {
             }
         });
 
-        // Skip run-make tests as revisions are not supported.
-        if entry.path().strip_prefix(tests_path).is_ok_and(|rest| rest.starts_with("run-make")) {
+        // Skip run-make/run-make-cargo tests as revisions are not supported.
+        if entry
+            .path()
+            .strip_prefix(tests_path)
+            .is_ok_and(|rest| rest.starts_with("run-make") || rest.starts_with("run-make-cargo"))
+        {
             return;
         }
 


### PR DESCRIPTION
I forgot to change this when implementing the run-make fission.

Noticed in https://github.com/rust-lang/rust/pull/149624#issuecomment-3609640422.