### PR TITLE
Stop emitting UbChecks on every Vec→Slice

### DIFF
--- a/library/core/src/slice/cmp.rs
+++ b/library/core/src/slice/cmp.rs
@@ -13,12 +13,13 @@ impl<T, U> const PartialEq<[U]> for [T]
 where
     T: [const] PartialEq<U>,
 {
+    // It's not worth trying to inline the loops underneath here *in MIR*,
+    // and preventing it encourages more useful inlining upstream,
+    // such as in `<str as PartialEq>::eq`.
+    // The codegen backend can still inline it later if needed.
+    #[rustc_no_mir_inline]
     fn eq(&self, other: &[U]) -> bool {
         SlicePartialEq::equal(self, other)
-    }
-
-    fn ne(&self, other: &[U]) -> bool {
-        SlicePartialEq::not_equal(self, other)
     }
 }
 
@@ -99,10 +100,6 @@ impl<T: PartialOrd> PartialOrd for [T] {
 #[rustc_const_unstable(feature = "const_cmp", issue = "143800")]
 const trait SlicePartialEq<B> {
     fn equal(&self, other: &[B]) -> bool;
-
-    fn not_equal(&self, other: &[B]) -> bool {
-        !self.equal(other)
-    }
 }
 
 // Generic slice equality

--- a/library/core/src/slice/cmp.rs
+++ b/library/core/src/slice/cmp.rs
@@ -13,11 +13,7 @@ impl<T, U> const PartialEq<[U]> for [T]
 where
     T: [const] PartialEq<U>,
 {
-    // It's not worth trying to inline the loops underneath here *in MIR*,
-    // and preventing it encourages more useful inlining upstream,
-    // such as in `<str as PartialEq>::eq`.
-    // The codegen backend can still inline it later if needed.
-    #[rustc_no_mir_inline]
+    #[inline]
     fn eq(&self, other: &[U]) -> bool {
         SlicePartialEq::equal(self, other)
     }
@@ -108,6 +104,11 @@ impl<A, B> const SlicePartialEq<B> for [A]
 where
     A: [const] PartialEq<B>,
 {
+    // It's not worth trying to inline the loops underneath here *in MIR*,
+    // and preventing it encourages more useful inlining upstream,
+    // such as in `<str as PartialEq>::eq`.
+    // The codegen backend can still inline it later if needed.
+    #[rustc_no_mir_inline]
     default fn equal(&self, other: &[B]) -> bool {
         if self.len() != other.len() {
             return false;
@@ -137,6 +138,16 @@ impl<A, B> const SlicePartialEq<B> for [A]
 where
     A: [const] BytewiseEq<B>,
 {
+    // This is usually a pretty good backend inlining candidate because the
+    // intrinsic tends to just be `memcmp`.  However, as of 2025-12 letting
+    // MIR inline this makes reuse worse because it means that, for example,
+    // `String::eq` doesn't inline, whereas by keeping this from inling all
+    // the wrappers until the call to this disappear.  If the heuristics have
+    // changed and this is no longer fruitful, though, please do remove it.
+    // In the mean time, it's fine to not inline it in MIR because the backend
+    // will still inline it if it things it's important to do so.
+    #[rustc_no_mir_inline]
+    #[inline]
     fn equal(&self, other: &[B]) -> bool {
         if self.len() != other.len() {
             return false;

--- a/tests/mir-opt/dont_reset_cast_kind_without_updating_operand.test.GVN.64bit.panic-abort.diff
+++ b/tests/mir-opt/dont_reset_cast_kind_without_updating_operand.test.GVN.64bit.panic-abort.diff
@@ -26,12 +26,12 @@
                   scope 4 {
                       debug _x => _8;
                   }
-                  scope 18 (inlined foo) {
+                  scope 19 (inlined foo) {
                       let mut _27: *const [()];
                   }
               }
-              scope 16 (inlined slice_from_raw_parts::<()>) {
-                  scope 17 (inlined std::ptr::from_raw_parts::<[()], ()>) {
+              scope 17 (inlined slice_from_raw_parts::<()>) {
+                  scope 18 (inlined std::ptr::from_raw_parts::<[()], ()>) {
                   }
               }
           }
@@ -49,19 +49,21 @@
               scope 7 {
                   let _21: std::ptr::NonNull<[u8]>;
                   scope 8 {
-                      scope 11 (inlined NonNull::<[u8]>::as_mut_ptr) {
-                          scope 12 (inlined NonNull::<[u8]>::as_non_null_ptr) {
-                              scope 13 (inlined NonNull::<[u8]>::cast::<u8>) {
+                      scope 12 (inlined NonNull::<[u8]>::as_mut_ptr) {
+                          scope 13 (inlined NonNull::<[u8]>::as_non_null_ptr) {
+                              scope 14 (inlined NonNull::<[u8]>::cast::<u8>) {
                                   let mut _25: *mut [u8];
-                                  scope 14 (inlined NonNull::<[u8]>::as_ptr) {
+                                  scope 15 (inlined NonNull::<[u8]>::as_ptr) {
                                   }
                               }
                           }
-                          scope 15 (inlined NonNull::<u8>::as_ptr) {
+                          scope 16 (inlined NonNull::<u8>::as_ptr) {
                           }
                       }
                   }
                   scope 10 (inlined <std::alloc::Global as Allocator>::allocate) {
+                      scope 11 (inlined std::alloc::Global::alloc_impl) {
+                      }
                   }
               }
               scope 9 (inlined #[track_caller] Layout::from_size_align_unchecked) {
@@ -192,8 +194,8 @@
 +         _18 = const Layout {{ size: 0_usize, align: std::ptr::Alignment(std::ptr::alignment::AlignmentEnum::_Align1Shl0) }};
           StorageDead(_24);
           StorageLive(_19);
--         _19 = std::alloc::Global::alloc_impl(const alloc::alloc::exchange_malloc::promoted[0], copy _18, const false) -> [return: bb7, unwind unreachable];
-+         _19 = std::alloc::Global::alloc_impl(const alloc::alloc::exchange_malloc::promoted[0], const Layout {{ size: 0_usize, align: std::ptr::Alignment(std::ptr::alignment::AlignmentEnum::_Align1Shl0) }}, const false) -> [return: bb7, unwind unreachable];
+-         _19 = std::alloc::Global::alloc_impl_runtime(copy _18, const false) -> [return: bb7, unwind unreachable];
++         _19 = std::alloc::Global::alloc_impl_runtime(const Layout {{ size: 0_usize, align: std::ptr::Alignment(std::ptr::alignment::AlignmentEnum::_Align1Shl0) }}, const false) -> [return: bb7, unwind unreachable];
       }
   
       bb7: {

--- a/tests/mir-opt/jump_threading.chained_conditions.JumpThreading.panic-abort.diff
+++ b/tests/mir-opt/jump_threading.chained_conditions.JumpThreading.panic-abort.diff
@@ -48,8 +48,8 @@
                   let _29: &str;
                   scope 7 (inlined String::as_str) {
                       let _30: &[u8];
-                      let mut _31: &std::vec::Vec<u8>;
                       scope 8 (inlined Vec::<u8>::as_slice) {
+                          let _31: *const [u8];
                           let mut _32: *const u8;
                           let mut _33: usize;
                           scope 9 (inlined Vec::<u8>::as_ptr) {
@@ -71,161 +71,83 @@
                                   }
                               }
                           }
-                          scope 18 (inlined #[track_caller] std::slice::from_raw_parts::<'_, u8>) {
-                              let _35: ();
-                              let mut _36: *mut ();
-                              let _37: *const [u8];
-                              scope 19 (inlined ub_checks::check_language_ub) {
-                                  scope 20 (inlined ub_checks::check_language_ub::runtime) {
-                                  }
-                              }
-                              scope 21 (inlined std::mem::size_of::<u8>) {
-                              }
-                              scope 22 (inlined std::mem::align_of::<u8>) {
-                              }
-                              scope 23 (inlined slice_from_raw_parts::<u8>) {
-                                  scope 24 (inlined std::ptr::from_raw_parts::<[u8], u8>) {
-                                  }
-                              }
-                          }
                       }
-                      scope 25 (inlined from_utf8_unchecked) {
+                      scope 18 (inlined from_utf8_unchecked) {
                       }
                   }
-                  scope 26 (inlined #[track_caller] core::str::traits::<impl SliceIndex<str> for RangeFull>::index) {
+                  scope 19 (inlined #[track_caller] core::str::traits::<impl SliceIndex<str> for RangeFull>::index) {
                   }
               }
-              scope 27 (inlined #[track_caller] core::str::traits::<impl Index<RangeFull> for str>::index) {
-                  scope 28 (inlined #[track_caller] core::str::traits::<impl SliceIndex<str> for RangeFull>::index) {
+              scope 20 (inlined #[track_caller] core::str::traits::<impl Index<RangeFull> for str>::index) {
+                  scope 21 (inlined #[track_caller] core::str::traits::<impl SliceIndex<str> for RangeFull>::index) {
                   }
               }
-              scope 29 (inlined core::str::traits::<impl PartialEq for str>::eq) {
-                  let mut _38: &&[u8];
-                  let _39: &[u8];
-                  let mut _40: &&[u8];
-                  let _41: &[u8];
-                  scope 30 (inlined core::str::<impl str>::as_bytes) {
+              scope 22 (inlined core::str::traits::<impl PartialEq for str>::eq) {
+                  let mut _35: &&[u8];
+                  let _36: &[u8];
+                  let mut _37: &&[u8];
+                  let _38: &[u8];
+                  scope 23 (inlined core::str::<impl str>::as_bytes) {
                   }
-                  scope 31 (inlined core::str::<impl str>::as_bytes) {
+                  scope 24 (inlined core::str::<impl str>::as_bytes) {
                   }
-                  scope 32 (inlined std::cmp::impls::<impl PartialEq for &[u8]>::eq) {
-                      scope 33 (inlined core::slice::cmp::<impl PartialEq for [u8]>::eq) {
-                          scope 34 (inlined <[u8] as core::slice::cmp::SlicePartialEq<u8>>::equal) {
-                              let mut _42: bool;
-                              let mut _43: usize;
-                              let mut _44: usize;
-                              let _45: usize;
-                              let mut _46: i32;
-                              let mut _47: *const u8;
-                              let mut _48: *const u8;
-                              scope 35 {
-                                  scope 37 (inlined core::slice::<impl [u8]>::as_ptr) {
-                                      let mut _50: *const [u8];
-                                  }
-                                  scope 38 (inlined core::slice::<impl [u8]>::as_ptr) {
-                                      let mut _51: *const [u8];
-                                  }
-                              }
-                              scope 36 (inlined std::mem::size_of_val::<[u8]>) {
-                                  let mut _49: *const [u8];
-                              }
-                          }
-                      }
+                  scope 25 (inlined std::cmp::impls::<impl PartialEq for &[u8]>::eq) {
                   }
               }
           }
       }
-      scope 39 (inlined std::cmp::impls::<impl PartialEq<&str> for &String>::eq) {
-          let mut _52: &std::string::String;
-          let mut _53: &str;
-          scope 40 (inlined <String as PartialEq<str>>::eq) {
-              scope 41 (inlined #[track_caller] <String as Index<RangeFull>>::index) {
-                  let _54: &str;
-                  scope 42 (inlined String::as_str) {
-                      let _55: &[u8];
-                      let mut _56: &std::vec::Vec<u8>;
-                      scope 43 (inlined Vec::<u8>::as_slice) {
-                          let mut _57: *const u8;
-                          let mut _58: usize;
-                          scope 44 (inlined Vec::<u8>::as_ptr) {
-                              scope 45 (inlined alloc::raw_vec::RawVec::<u8>::ptr) {
-                                  scope 46 (inlined alloc::raw_vec::RawVecInner::ptr::<u8>) {
-                                      scope 47 (inlined alloc::raw_vec::RawVecInner::non_null::<u8>) {
-                                          let mut _59: std::ptr::NonNull<u8>;
-                                          scope 48 (inlined Unique::<u8>::cast::<u8>) {
-                                              scope 49 (inlined NonNull::<u8>::cast::<u8>) {
-                                                  scope 50 (inlined NonNull::<u8>::as_ptr) {
+      scope 26 (inlined std::cmp::impls::<impl PartialEq<&str> for &String>::eq) {
+          let mut _39: &std::string::String;
+          let mut _40: &str;
+          scope 27 (inlined <String as PartialEq<str>>::eq) {
+              scope 28 (inlined #[track_caller] <String as Index<RangeFull>>::index) {
+                  let _41: &str;
+                  scope 29 (inlined String::as_str) {
+                      let _42: &[u8];
+                      scope 30 (inlined Vec::<u8>::as_slice) {
+                          let _43: *const [u8];
+                          let mut _44: *const u8;
+                          let mut _45: usize;
+                          scope 31 (inlined Vec::<u8>::as_ptr) {
+                              scope 32 (inlined alloc::raw_vec::RawVec::<u8>::ptr) {
+                                  scope 33 (inlined alloc::raw_vec::RawVecInner::ptr::<u8>) {
+                                      scope 34 (inlined alloc::raw_vec::RawVecInner::non_null::<u8>) {
+                                          let mut _46: std::ptr::NonNull<u8>;
+                                          scope 35 (inlined Unique::<u8>::cast::<u8>) {
+                                              scope 36 (inlined NonNull::<u8>::cast::<u8>) {
+                                                  scope 37 (inlined NonNull::<u8>::as_ptr) {
                                                   }
                                               }
                                           }
-                                          scope 51 (inlined Unique::<u8>::as_non_null_ptr) {
+                                          scope 38 (inlined Unique::<u8>::as_non_null_ptr) {
                                           }
                                       }
-                                      scope 52 (inlined NonNull::<u8>::as_ptr) {
+                                      scope 39 (inlined NonNull::<u8>::as_ptr) {
                                       }
                                   }
                               }
                           }
-                          scope 53 (inlined #[track_caller] std::slice::from_raw_parts::<'_, u8>) {
-                              let _60: ();
-                              let mut _61: *mut ();
-                              let _62: *const [u8];
-                              scope 54 (inlined ub_checks::check_language_ub) {
-                                  scope 55 (inlined ub_checks::check_language_ub::runtime) {
-                                  }
-                              }
-                              scope 56 (inlined std::mem::size_of::<u8>) {
-                              }
-                              scope 57 (inlined std::mem::align_of::<u8>) {
-                              }
-                              scope 58 (inlined slice_from_raw_parts::<u8>) {
-                                  scope 59 (inlined std::ptr::from_raw_parts::<[u8], u8>) {
-                                  }
-                              }
-                          }
                       }
-                      scope 60 (inlined from_utf8_unchecked) {
+                      scope 40 (inlined from_utf8_unchecked) {
                       }
                   }
-                  scope 61 (inlined #[track_caller] core::str::traits::<impl SliceIndex<str> for RangeFull>::index) {
+                  scope 41 (inlined #[track_caller] core::str::traits::<impl SliceIndex<str> for RangeFull>::index) {
                   }
               }
-              scope 62 (inlined #[track_caller] core::str::traits::<impl Index<RangeFull> for str>::index) {
-                  scope 63 (inlined #[track_caller] core::str::traits::<impl SliceIndex<str> for RangeFull>::index) {
+              scope 42 (inlined #[track_caller] core::str::traits::<impl Index<RangeFull> for str>::index) {
+                  scope 43 (inlined #[track_caller] core::str::traits::<impl SliceIndex<str> for RangeFull>::index) {
                   }
               }
-              scope 64 (inlined core::str::traits::<impl PartialEq for str>::eq) {
-                  let mut _63: &&[u8];
-                  let _64: &[u8];
-                  let mut _65: &&[u8];
-                  let _66: &[u8];
-                  scope 65 (inlined core::str::<impl str>::as_bytes) {
+              scope 44 (inlined core::str::traits::<impl PartialEq for str>::eq) {
+                  let mut _47: &&[u8];
+                  let _48: &[u8];
+                  let mut _49: &&[u8];
+                  let _50: &[u8];
+                  scope 45 (inlined core::str::<impl str>::as_bytes) {
                   }
-                  scope 66 (inlined core::str::<impl str>::as_bytes) {
+                  scope 46 (inlined core::str::<impl str>::as_bytes) {
                   }
-                  scope 67 (inlined std::cmp::impls::<impl PartialEq for &[u8]>::eq) {
-                      scope 68 (inlined core::slice::cmp::<impl PartialEq for [u8]>::eq) {
-                          scope 69 (inlined <[u8] as core::slice::cmp::SlicePartialEq<u8>>::equal) {
-                              let mut _67: bool;
-                              let mut _68: usize;
-                              let mut _69: usize;
-                              let _70: usize;
-                              let mut _71: i32;
-                              let mut _72: *const u8;
-                              let mut _73: *const u8;
-                              scope 70 {
-                                  scope 72 (inlined core::slice::<impl [u8]>::as_ptr) {
-                                      let mut _75: *const [u8];
-                                  }
-                                  scope 73 (inlined core::slice::<impl [u8]>::as_ptr) {
-                                      let mut _76: *const [u8];
-                                  }
-                              }
-                              scope 71 (inlined std::mem::size_of_val::<[u8]>) {
-                                  let mut _74: *const [u8];
-                              }
-                          }
-                      }
+                  scope 47 (inlined std::cmp::impls::<impl PartialEq for &[u8]>::eq) {
                   }
               }
           }
@@ -253,7 +175,7 @@
       bb3: {
           _1 = chained_conditions::BacktraceStyle::Off;
 -         goto -> bb18;
-+         goto -> bb37;
++         goto -> bb23;
       }
   
       bb4: {
@@ -272,15 +194,27 @@
           _27 = copy (*_8);
           _28 = copy (*_10);
           StorageLive(_29);
-          StorageLive(_35);
           StorageLive(_30);
-          StorageLive(_34);
+          StorageLive(_31);
           StorageLive(_32);
+          StorageLive(_34);
           _34 = copy ((((((*_27).0: std::vec::Vec<u8>).0: alloc::raw_vec::RawVec<u8>).0: alloc::raw_vec::RawVecInner).0: std::ptr::Unique<u8>).0: std::ptr::NonNull<u8>);
           _32 = copy _34 as *const u8 (Transmute);
+          StorageDead(_34);
           StorageLive(_33);
           _33 = copy (((*_27).0: std::vec::Vec<u8>).1: usize);
-          switchInt(UbChecks) -> [0: bb21, otherwise: bb19];
+          _31 = *const [u8] from (copy _32, move _33);
+          StorageDead(_33);
+          StorageDead(_32);
+          _30 = &(*_31);
+          StorageDead(_31);
+          _29 = copy _30 as &str (Transmute);
+          StorageDead(_30);
+          StorageLive(_36);
+          StorageLive(_38);
+          _36 = copy _29 as &[u8] (Transmute);
+          _38 = copy _28 as &[u8] (Transmute);
+          _7 = <[u8] as PartialEq>::eq(move _36, move _38) -> [return: bb19, unwind unreachable];
       }
   
       bb5: {
@@ -311,27 +245,39 @@
           StorageLive(_17);
           _20 = const chained_conditions::promoted[0];
           _17 = &(*_20);
-          StorageLive(_52);
-          StorageLive(_53);
-          _52 = copy (*_15);
-          _53 = copy (*_17);
-          StorageLive(_54);
-          StorageLive(_60);
-          StorageLive(_55);
-          StorageLive(_59);
-          StorageLive(_57);
-          _59 = copy ((((((*_52).0: std::vec::Vec<u8>).0: alloc::raw_vec::RawVec<u8>).0: alloc::raw_vec::RawVecInner).0: std::ptr::Unique<u8>).0: std::ptr::NonNull<u8>);
-          _57 = copy _59 as *const u8 (Transmute);
-          StorageLive(_58);
-          _58 = copy (((*_52).0: std::vec::Vec<u8>).1: usize);
-          switchInt(UbChecks) -> [0: bb29, otherwise: bb27];
+          StorageLive(_39);
+          StorageLive(_40);
+          _39 = copy (*_15);
+          _40 = copy (*_17);
+          StorageLive(_41);
+          StorageLive(_42);
+          StorageLive(_43);
+          StorageLive(_44);
+          StorageLive(_46);
+          _46 = copy ((((((*_39).0: std::vec::Vec<u8>).0: alloc::raw_vec::RawVec<u8>).0: alloc::raw_vec::RawVecInner).0: std::ptr::Unique<u8>).0: std::ptr::NonNull<u8>);
+          _44 = copy _46 as *const u8 (Transmute);
+          StorageDead(_46);
+          StorageLive(_45);
+          _45 = copy (((*_39).0: std::vec::Vec<u8>).1: usize);
+          _43 = *const [u8] from (copy _44, move _45);
+          StorageDead(_45);
+          StorageDead(_44);
+          _42 = &(*_43);
+          StorageDead(_43);
+          _41 = copy _42 as &str (Transmute);
+          StorageDead(_42);
+          StorageLive(_48);
+          StorageLive(_50);
+          _48 = copy _41 as &[u8] (Transmute);
+          _50 = copy _40 as &[u8] (Transmute);
+          _14 = <[u8] as PartialEq>::eq(move _48, move _50) -> [return: bb20, unwind unreachable];
       }
   
       bb7: {
           StorageDead(_5);
           StorageDead(_6);
 -         goto -> bb18;
-+         goto -> bb39;
++         goto -> bb21;
       }
   
       bb8: {
@@ -354,14 +300,14 @@
           StorageDead(_13);
           _1 = chained_conditions::BacktraceStyle::Short;
 -         goto -> bb18;
-+         goto -> bb37;
++         goto -> bb23;
       }
   
       bb10: {
           StorageDead(_12);
           StorageDead(_13);
 -         goto -> bb18;
-+         goto -> bb39;
++         goto -> bb21;
       }
   
       bb11: {
@@ -406,223 +352,39 @@
       }
   
       bb19: {
-          StorageLive(_36);
-          _36 = copy _34 as *mut () (Transmute);
-          _35 = std::slice::from_raw_parts::precondition_check(move _36, const <u8 as std::mem::SizedTypeProperties>::SIZE, const <u8 as std::mem::SizedTypeProperties>::ALIGN, copy _33) -> [return: bb20, unwind unreachable];
-      }
-  
-      bb20: {
+          StorageDead(_38);
           StorageDead(_36);
-          goto -> bb21;
-      }
-  
-      bb21: {
-          StorageLive(_37);
-          _37 = *const [u8] from (copy _32, copy _33);
-          _30 = &(*_37);
-          StorageDead(_37);
-          StorageDead(_33);
-          StorageDead(_32);
-          StorageDead(_34);
-          _29 = copy _30 as &str (Transmute);
-          StorageDead(_30);
-          StorageLive(_39);
-          StorageLive(_41);
-          _39 = copy _29 as &[u8] (Transmute);
-          _41 = copy _28 as &[u8] (Transmute);
-          StorageLive(_45);
-          StorageLive(_50);
-          StorageLive(_51);
-          StorageLive(_42);
-          StorageLive(_43);
-          _43 = PtrMetadata(copy _39);
-          StorageLive(_44);
-          _44 = PtrMetadata(copy _41);
-          _42 = Ne(move _43, move _44);
-          switchInt(move _42) -> [0: bb24, otherwise: bb23];
-      }
-  
-      bb22: {
-          StorageDead(_51);
-          StorageDead(_50);
-          StorageDead(_45);
-          StorageDead(_41);
-          StorageDead(_39);
-          StorageDead(_35);
           StorageDead(_29);
           StorageDead(_28);
           StorageDead(_27);
           switchInt(move _7) -> [0: bb6, otherwise: bb5];
       }
   
-      bb23: {
-          StorageDead(_44);
-          StorageDead(_43);
-          _7 = const false;
-          StorageDead(_42);
--         goto -> bb22;
-+         goto -> bb35;
-      }
-  
-      bb24: {
-          StorageDead(_44);
-          StorageDead(_43);
-          StorageDead(_42);
-          StorageLive(_49);
-          _49 = &raw const (*_39);
-          _45 = std::intrinsics::size_of_val::<[u8]>(move _49) -> [return: bb26, unwind unreachable];
-      }
-  
-      bb25: {
+      bb20: {
+          StorageDead(_50);
           StorageDead(_48);
-          StorageDead(_47);
-          _7 = Eq(move _46, const 0_i32);
-          StorageDead(_46);
-          goto -> bb22;
-      }
-  
-      bb26: {
-          StorageDead(_49);
-          StorageLive(_46);
-          StorageLive(_47);
-          _50 = &raw const (*_39);
-          _47 = copy _50 as *const u8 (PtrToPtr);
-          StorageLive(_48);
-          _51 = &raw const (*_41);
-          _48 = copy _51 as *const u8 (PtrToPtr);
-          _46 = compare_bytes(move _47, move _48, move _45) -> [return: bb25, unwind unreachable];
-      }
-  
-      bb27: {
-          StorageLive(_61);
-          _61 = copy _59 as *mut () (Transmute);
-          _60 = std::slice::from_raw_parts::precondition_check(move _61, const <u8 as std::mem::SizedTypeProperties>::SIZE, const <u8 as std::mem::SizedTypeProperties>::ALIGN, copy _58) -> [return: bb28, unwind unreachable];
-      }
-  
-      bb28: {
-          StorageDead(_61);
-          goto -> bb29;
-      }
-  
-      bb29: {
-          StorageLive(_62);
-          _62 = *const [u8] from (copy _57, copy _58);
-          _55 = &(*_62);
-          StorageDead(_62);
-          StorageDead(_58);
-          StorageDead(_57);
-          StorageDead(_59);
-          _54 = copy _55 as &str (Transmute);
-          StorageDead(_55);
-          StorageLive(_64);
-          StorageLive(_66);
-          _64 = copy _54 as &[u8] (Transmute);
-          _66 = copy _53 as &[u8] (Transmute);
-          StorageLive(_70);
-          StorageLive(_75);
-          StorageLive(_76);
-          StorageLive(_67);
-          StorageLive(_68);
-          _68 = PtrMetadata(copy _64);
-          StorageLive(_69);
-          _69 = PtrMetadata(copy _66);
-          _67 = Ne(move _68, move _69);
-          switchInt(move _67) -> [0: bb32, otherwise: bb31];
-      }
-  
-      bb30: {
-          StorageDead(_76);
-          StorageDead(_75);
-          StorageDead(_70);
-          StorageDead(_66);
-          StorageDead(_64);
-          StorageDead(_60);
-          StorageDead(_54);
-          StorageDead(_53);
-          StorageDead(_52);
+          StorageDead(_41);
+          StorageDead(_40);
+          StorageDead(_39);
           switchInt(move _14) -> [0: bb9, otherwise: bb8];
-      }
-  
-      bb31: {
-          StorageDead(_69);
-          StorageDead(_68);
-          _14 = const false;
-          StorageDead(_67);
--         goto -> bb30;
-+         goto -> bb36;
-      }
-  
-      bb32: {
-          StorageDead(_69);
-          StorageDead(_68);
-          StorageDead(_67);
-          StorageLive(_74);
-          _74 = &raw const (*_64);
-          _70 = std::intrinsics::size_of_val::<[u8]>(move _74) -> [return: bb34, unwind unreachable];
-      }
-  
-      bb33: {
-          StorageDead(_73);
-          StorageDead(_72);
-          _14 = Eq(move _71, const 0_i32);
-          StorageDead(_71);
-          goto -> bb30;
-      }
-  
-      bb34: {
-          StorageDead(_74);
-          StorageLive(_71);
-          StorageLive(_72);
-          _75 = &raw const (*_64);
-          _72 = copy _75 as *const u8 (PtrToPtr);
-          StorageLive(_73);
-          _76 = &raw const (*_66);
-          _73 = copy _76 as *const u8 (PtrToPtr);
-          _71 = compare_bytes(move _72, move _73, move _70) -> [return: bb33, unwind unreachable];
 +     }
 + 
-+     bb35: {
-+         StorageDead(_51);
-+         StorageDead(_50);
-+         StorageDead(_45);
-+         StorageDead(_41);
-+         StorageDead(_39);
-+         StorageDead(_35);
-+         StorageDead(_29);
-+         StorageDead(_28);
-+         StorageDead(_27);
-+         goto -> bb6;
-+     }
-+ 
-+     bb36: {
-+         StorageDead(_76);
-+         StorageDead(_75);
-+         StorageDead(_70);
-+         StorageDead(_66);
-+         StorageDead(_64);
-+         StorageDead(_60);
-+         StorageDead(_54);
-+         StorageDead(_53);
-+         StorageDead(_52);
-+         goto -> bb9;
-+     }
-+ 
-+     bb37: {
++     bb21: {
 +         _24 = discriminant(_2);
-+         switchInt(move _24) -> [1: bb38, otherwise: bb15];
++         switchInt(move _24) -> [1: bb22, otherwise: bb15];
 +     }
 + 
-+     bb38: {
-+         goto -> bb17;
-+     }
-+ 
-+     bb39: {
-+         _24 = discriminant(_2);
-+         switchInt(move _24) -> [1: bb40, otherwise: bb15];
-+     }
-+ 
-+     bb40: {
++     bb22: {
 +         goto -> bb15;
++     }
++ 
++     bb23: {
++         _24 = discriminant(_2);
++         switchInt(move _24) -> [1: bb24, otherwise: bb15];
++     }
++ 
++     bb24: {
++         goto -> bb17;
       }
   }
   

--- a/tests/mir-opt/jump_threading.chained_conditions.JumpThreading.panic-abort.diff
+++ b/tests/mir-opt/jump_threading.chained_conditions.JumpThreading.panic-abort.diff
@@ -92,62 +92,66 @@
                   scope 24 (inlined core::str::<impl str>::as_bytes) {
                   }
                   scope 25 (inlined std::cmp::impls::<impl PartialEq for &[u8]>::eq) {
+                      scope 26 (inlined core::slice::cmp::<impl PartialEq for [u8]>::eq) {
+                      }
                   }
               }
           }
       }
-      scope 26 (inlined std::cmp::impls::<impl PartialEq<&str> for &String>::eq) {
+      scope 27 (inlined std::cmp::impls::<impl PartialEq<&str> for &String>::eq) {
           let mut _39: &std::string::String;
           let mut _40: &str;
-          scope 27 (inlined <String as PartialEq<str>>::eq) {
-              scope 28 (inlined #[track_caller] <String as Index<RangeFull>>::index) {
+          scope 28 (inlined <String as PartialEq<str>>::eq) {
+              scope 29 (inlined #[track_caller] <String as Index<RangeFull>>::index) {
                   let _41: &str;
-                  scope 29 (inlined String::as_str) {
+                  scope 30 (inlined String::as_str) {
                       let _42: &[u8];
-                      scope 30 (inlined Vec::<u8>::as_slice) {
+                      scope 31 (inlined Vec::<u8>::as_slice) {
                           let _43: *const [u8];
                           let mut _44: *const u8;
                           let mut _45: usize;
-                          scope 31 (inlined Vec::<u8>::as_ptr) {
-                              scope 32 (inlined alloc::raw_vec::RawVec::<u8>::ptr) {
-                                  scope 33 (inlined alloc::raw_vec::RawVecInner::ptr::<u8>) {
-                                      scope 34 (inlined alloc::raw_vec::RawVecInner::non_null::<u8>) {
+                          scope 32 (inlined Vec::<u8>::as_ptr) {
+                              scope 33 (inlined alloc::raw_vec::RawVec::<u8>::ptr) {
+                                  scope 34 (inlined alloc::raw_vec::RawVecInner::ptr::<u8>) {
+                                      scope 35 (inlined alloc::raw_vec::RawVecInner::non_null::<u8>) {
                                           let mut _46: std::ptr::NonNull<u8>;
-                                          scope 35 (inlined Unique::<u8>::cast::<u8>) {
-                                              scope 36 (inlined NonNull::<u8>::cast::<u8>) {
-                                                  scope 37 (inlined NonNull::<u8>::as_ptr) {
+                                          scope 36 (inlined Unique::<u8>::cast::<u8>) {
+                                              scope 37 (inlined NonNull::<u8>::cast::<u8>) {
+                                                  scope 38 (inlined NonNull::<u8>::as_ptr) {
                                                   }
                                               }
                                           }
-                                          scope 38 (inlined Unique::<u8>::as_non_null_ptr) {
+                                          scope 39 (inlined Unique::<u8>::as_non_null_ptr) {
                                           }
                                       }
-                                      scope 39 (inlined NonNull::<u8>::as_ptr) {
+                                      scope 40 (inlined NonNull::<u8>::as_ptr) {
                                       }
                                   }
                               }
                           }
                       }
-                      scope 40 (inlined from_utf8_unchecked) {
+                      scope 41 (inlined from_utf8_unchecked) {
                       }
                   }
-                  scope 41 (inlined #[track_caller] core::str::traits::<impl SliceIndex<str> for RangeFull>::index) {
+                  scope 42 (inlined #[track_caller] core::str::traits::<impl SliceIndex<str> for RangeFull>::index) {
                   }
               }
-              scope 42 (inlined #[track_caller] core::str::traits::<impl Index<RangeFull> for str>::index) {
-                  scope 43 (inlined #[track_caller] core::str::traits::<impl SliceIndex<str> for RangeFull>::index) {
+              scope 43 (inlined #[track_caller] core::str::traits::<impl Index<RangeFull> for str>::index) {
+                  scope 44 (inlined #[track_caller] core::str::traits::<impl SliceIndex<str> for RangeFull>::index) {
                   }
               }
-              scope 44 (inlined core::str::traits::<impl PartialEq for str>::eq) {
+              scope 45 (inlined core::str::traits::<impl PartialEq for str>::eq) {
                   let mut _47: &&[u8];
                   let _48: &[u8];
                   let mut _49: &&[u8];
                   let _50: &[u8];
-                  scope 45 (inlined core::str::<impl str>::as_bytes) {
-                  }
                   scope 46 (inlined core::str::<impl str>::as_bytes) {
                   }
-                  scope 47 (inlined std::cmp::impls::<impl PartialEq for &[u8]>::eq) {
+                  scope 47 (inlined core::str::<impl str>::as_bytes) {
+                  }
+                  scope 48 (inlined std::cmp::impls::<impl PartialEq for &[u8]>::eq) {
+                      scope 49 (inlined core::slice::cmp::<impl PartialEq for [u8]>::eq) {
+                      }
                   }
               }
           }
@@ -214,7 +218,7 @@
           StorageLive(_38);
           _36 = copy _29 as &[u8] (Transmute);
           _38 = copy _28 as &[u8] (Transmute);
-          _7 = <[u8] as PartialEq>::eq(move _36, move _38) -> [return: bb19, unwind unreachable];
+          _7 = <[u8] as core::slice::cmp::SlicePartialEq<u8>>::equal(move _36, move _38) -> [return: bb19, unwind unreachable];
       }
   
       bb5: {
@@ -270,7 +274,7 @@
           StorageLive(_50);
           _48 = copy _41 as &[u8] (Transmute);
           _50 = copy _40 as &[u8] (Transmute);
-          _14 = <[u8] as PartialEq>::eq(move _48, move _50) -> [return: bb20, unwind unreachable];
+          _14 = <[u8] as core::slice::cmp::SlicePartialEq<u8>>::equal(move _48, move _50) -> [return: bb20, unwind unreachable];
       }
   
       bb7: {

--- a/tests/mir-opt/jump_threading.chained_conditions.JumpThreading.panic-unwind.diff
+++ b/tests/mir-opt/jump_threading.chained_conditions.JumpThreading.panic-unwind.diff
@@ -48,8 +48,8 @@
                   let _29: &str;
                   scope 7 (inlined String::as_str) {
                       let _30: &[u8];
-                      let mut _31: &std::vec::Vec<u8>;
                       scope 8 (inlined Vec::<u8>::as_slice) {
+                          let _31: *const [u8];
                           let mut _32: *const u8;
                           let mut _33: usize;
                           scope 9 (inlined Vec::<u8>::as_ptr) {
@@ -71,161 +71,83 @@
                                   }
                               }
                           }
-                          scope 18 (inlined #[track_caller] std::slice::from_raw_parts::<'_, u8>) {
-                              let _35: ();
-                              let mut _36: *mut ();
-                              let _37: *const [u8];
-                              scope 19 (inlined ub_checks::check_language_ub) {
-                                  scope 20 (inlined ub_checks::check_language_ub::runtime) {
-                                  }
-                              }
-                              scope 21 (inlined std::mem::size_of::<u8>) {
-                              }
-                              scope 22 (inlined std::mem::align_of::<u8>) {
-                              }
-                              scope 23 (inlined slice_from_raw_parts::<u8>) {
-                                  scope 24 (inlined std::ptr::from_raw_parts::<[u8], u8>) {
-                                  }
-                              }
-                          }
                       }
-                      scope 25 (inlined from_utf8_unchecked) {
+                      scope 18 (inlined from_utf8_unchecked) {
                       }
                   }
-                  scope 26 (inlined #[track_caller] core::str::traits::<impl SliceIndex<str> for RangeFull>::index) {
+                  scope 19 (inlined #[track_caller] core::str::traits::<impl SliceIndex<str> for RangeFull>::index) {
                   }
               }
-              scope 27 (inlined #[track_caller] core::str::traits::<impl Index<RangeFull> for str>::index) {
-                  scope 28 (inlined #[track_caller] core::str::traits::<impl SliceIndex<str> for RangeFull>::index) {
+              scope 20 (inlined #[track_caller] core::str::traits::<impl Index<RangeFull> for str>::index) {
+                  scope 21 (inlined #[track_caller] core::str::traits::<impl SliceIndex<str> for RangeFull>::index) {
                   }
               }
-              scope 29 (inlined core::str::traits::<impl PartialEq for str>::eq) {
-                  let mut _38: &&[u8];
-                  let _39: &[u8];
-                  let mut _40: &&[u8];
-                  let _41: &[u8];
-                  scope 30 (inlined core::str::<impl str>::as_bytes) {
+              scope 22 (inlined core::str::traits::<impl PartialEq for str>::eq) {
+                  let mut _35: &&[u8];
+                  let _36: &[u8];
+                  let mut _37: &&[u8];
+                  let _38: &[u8];
+                  scope 23 (inlined core::str::<impl str>::as_bytes) {
                   }
-                  scope 31 (inlined core::str::<impl str>::as_bytes) {
+                  scope 24 (inlined core::str::<impl str>::as_bytes) {
                   }
-                  scope 32 (inlined std::cmp::impls::<impl PartialEq for &[u8]>::eq) {
-                      scope 33 (inlined core::slice::cmp::<impl PartialEq for [u8]>::eq) {
-                          scope 34 (inlined <[u8] as core::slice::cmp::SlicePartialEq<u8>>::equal) {
-                              let mut _42: bool;
-                              let mut _43: usize;
-                              let mut _44: usize;
-                              let _45: usize;
-                              let mut _46: i32;
-                              let mut _47: *const u8;
-                              let mut _48: *const u8;
-                              scope 35 {
-                                  scope 37 (inlined core::slice::<impl [u8]>::as_ptr) {
-                                      let mut _50: *const [u8];
-                                  }
-                                  scope 38 (inlined core::slice::<impl [u8]>::as_ptr) {
-                                      let mut _51: *const [u8];
-                                  }
-                              }
-                              scope 36 (inlined std::mem::size_of_val::<[u8]>) {
-                                  let mut _49: *const [u8];
-                              }
-                          }
-                      }
+                  scope 25 (inlined std::cmp::impls::<impl PartialEq for &[u8]>::eq) {
                   }
               }
           }
       }
-      scope 39 (inlined std::cmp::impls::<impl PartialEq<&str> for &String>::eq) {
-          let mut _52: &std::string::String;
-          let mut _53: &str;
-          scope 40 (inlined <String as PartialEq<str>>::eq) {
-              scope 41 (inlined #[track_caller] <String as Index<RangeFull>>::index) {
-                  let _54: &str;
-                  scope 42 (inlined String::as_str) {
-                      let _55: &[u8];
-                      let mut _56: &std::vec::Vec<u8>;
-                      scope 43 (inlined Vec::<u8>::as_slice) {
-                          let mut _57: *const u8;
-                          let mut _58: usize;
-                          scope 44 (inlined Vec::<u8>::as_ptr) {
-                              scope 45 (inlined alloc::raw_vec::RawVec::<u8>::ptr) {
-                                  scope 46 (inlined alloc::raw_vec::RawVecInner::ptr::<u8>) {
-                                      scope 47 (inlined alloc::raw_vec::RawVecInner::non_null::<u8>) {
-                                          let mut _59: std::ptr::NonNull<u8>;
-                                          scope 48 (inlined Unique::<u8>::cast::<u8>) {
-                                              scope 49 (inlined NonNull::<u8>::cast::<u8>) {
-                                                  scope 50 (inlined NonNull::<u8>::as_ptr) {
+      scope 26 (inlined std::cmp::impls::<impl PartialEq<&str> for &String>::eq) {
+          let mut _39: &std::string::String;
+          let mut _40: &str;
+          scope 27 (inlined <String as PartialEq<str>>::eq) {
+              scope 28 (inlined #[track_caller] <String as Index<RangeFull>>::index) {
+                  let _41: &str;
+                  scope 29 (inlined String::as_str) {
+                      let _42: &[u8];
+                      scope 30 (inlined Vec::<u8>::as_slice) {
+                          let _43: *const [u8];
+                          let mut _44: *const u8;
+                          let mut _45: usize;
+                          scope 31 (inlined Vec::<u8>::as_ptr) {
+                              scope 32 (inlined alloc::raw_vec::RawVec::<u8>::ptr) {
+                                  scope 33 (inlined alloc::raw_vec::RawVecInner::ptr::<u8>) {
+                                      scope 34 (inlined alloc::raw_vec::RawVecInner::non_null::<u8>) {
+                                          let mut _46: std::ptr::NonNull<u8>;
+                                          scope 35 (inlined Unique::<u8>::cast::<u8>) {
+                                              scope 36 (inlined NonNull::<u8>::cast::<u8>) {
+                                                  scope 37 (inlined NonNull::<u8>::as_ptr) {
                                                   }
                                               }
                                           }
-                                          scope 51 (inlined Unique::<u8>::as_non_null_ptr) {
+                                          scope 38 (inlined Unique::<u8>::as_non_null_ptr) {
                                           }
                                       }
-                                      scope 52 (inlined NonNull::<u8>::as_ptr) {
+                                      scope 39 (inlined NonNull::<u8>::as_ptr) {
                                       }
                                   }
                               }
                           }
-                          scope 53 (inlined #[track_caller] std::slice::from_raw_parts::<'_, u8>) {
-                              let _60: ();
-                              let mut _61: *mut ();
-                              let _62: *const [u8];
-                              scope 54 (inlined ub_checks::check_language_ub) {
-                                  scope 55 (inlined ub_checks::check_language_ub::runtime) {
-                                  }
-                              }
-                              scope 56 (inlined std::mem::size_of::<u8>) {
-                              }
-                              scope 57 (inlined std::mem::align_of::<u8>) {
-                              }
-                              scope 58 (inlined slice_from_raw_parts::<u8>) {
-                                  scope 59 (inlined std::ptr::from_raw_parts::<[u8], u8>) {
-                                  }
-                              }
-                          }
                       }
-                      scope 60 (inlined from_utf8_unchecked) {
+                      scope 40 (inlined from_utf8_unchecked) {
                       }
                   }
-                  scope 61 (inlined #[track_caller] core::str::traits::<impl SliceIndex<str> for RangeFull>::index) {
+                  scope 41 (inlined #[track_caller] core::str::traits::<impl SliceIndex<str> for RangeFull>::index) {
                   }
               }
-              scope 62 (inlined #[track_caller] core::str::traits::<impl Index<RangeFull> for str>::index) {
-                  scope 63 (inlined #[track_caller] core::str::traits::<impl SliceIndex<str> for RangeFull>::index) {
+              scope 42 (inlined #[track_caller] core::str::traits::<impl Index<RangeFull> for str>::index) {
+                  scope 43 (inlined #[track_caller] core::str::traits::<impl SliceIndex<str> for RangeFull>::index) {
                   }
               }
-              scope 64 (inlined core::str::traits::<impl PartialEq for str>::eq) {
-                  let mut _63: &&[u8];
-                  let _64: &[u8];
-                  let mut _65: &&[u8];
-                  let _66: &[u8];
-                  scope 65 (inlined core::str::<impl str>::as_bytes) {
+              scope 44 (inlined core::str::traits::<impl PartialEq for str>::eq) {
+                  let mut _47: &&[u8];
+                  let _48: &[u8];
+                  let mut _49: &&[u8];
+                  let _50: &[u8];
+                  scope 45 (inlined core::str::<impl str>::as_bytes) {
                   }
-                  scope 66 (inlined core::str::<impl str>::as_bytes) {
+                  scope 46 (inlined core::str::<impl str>::as_bytes) {
                   }
-                  scope 67 (inlined std::cmp::impls::<impl PartialEq for &[u8]>::eq) {
-                      scope 68 (inlined core::slice::cmp::<impl PartialEq for [u8]>::eq) {
-                          scope 69 (inlined <[u8] as core::slice::cmp::SlicePartialEq<u8>>::equal) {
-                              let mut _67: bool;
-                              let mut _68: usize;
-                              let mut _69: usize;
-                              let _70: usize;
-                              let mut _71: i32;
-                              let mut _72: *const u8;
-                              let mut _73: *const u8;
-                              scope 70 {
-                                  scope 72 (inlined core::slice::<impl [u8]>::as_ptr) {
-                                      let mut _75: *const [u8];
-                                  }
-                                  scope 73 (inlined core::slice::<impl [u8]>::as_ptr) {
-                                      let mut _76: *const [u8];
-                                  }
-                              }
-                              scope 71 (inlined std::mem::size_of_val::<[u8]>) {
-                                  let mut _74: *const [u8];
-                              }
-                          }
-                      }
+                  scope 47 (inlined std::cmp::impls::<impl PartialEq for &[u8]>::eq) {
                   }
               }
           }
@@ -253,7 +175,7 @@
       bb3: {
           _1 = chained_conditions::BacktraceStyle::Off;
 -         goto -> bb19;
-+         goto -> bb41;
++         goto -> bb27;
       }
   
       bb4: {
@@ -272,15 +194,27 @@
           _27 = copy (*_8);
           _28 = copy (*_10);
           StorageLive(_29);
-          StorageLive(_35);
           StorageLive(_30);
-          StorageLive(_34);
+          StorageLive(_31);
           StorageLive(_32);
+          StorageLive(_34);
           _34 = copy ((((((*_27).0: std::vec::Vec<u8>).0: alloc::raw_vec::RawVec<u8>).0: alloc::raw_vec::RawVecInner).0: std::ptr::Unique<u8>).0: std::ptr::NonNull<u8>);
           _32 = copy _34 as *const u8 (Transmute);
+          StorageDead(_34);
           StorageLive(_33);
           _33 = copy (((*_27).0: std::vec::Vec<u8>).1: usize);
-          switchInt(UbChecks) -> [0: bb25, otherwise: bb23];
+          _31 = *const [u8] from (copy _32, move _33);
+          StorageDead(_33);
+          StorageDead(_32);
+          _30 = &(*_31);
+          StorageDead(_31);
+          _29 = copy _30 as &str (Transmute);
+          StorageDead(_30);
+          StorageLive(_36);
+          StorageLive(_38);
+          _36 = copy _29 as &[u8] (Transmute);
+          _38 = copy _28 as &[u8] (Transmute);
+          _7 = <[u8] as PartialEq>::eq(move _36, move _38) -> [return: bb23, unwind: bb22];
       }
   
       bb5: {
@@ -311,27 +245,39 @@
           StorageLive(_17);
           _20 = const chained_conditions::promoted[0];
           _17 = &(*_20);
-          StorageLive(_52);
-          StorageLive(_53);
-          _52 = copy (*_15);
-          _53 = copy (*_17);
-          StorageLive(_54);
-          StorageLive(_60);
-          StorageLive(_55);
-          StorageLive(_59);
-          StorageLive(_57);
-          _59 = copy ((((((*_52).0: std::vec::Vec<u8>).0: alloc::raw_vec::RawVec<u8>).0: alloc::raw_vec::RawVecInner).0: std::ptr::Unique<u8>).0: std::ptr::NonNull<u8>);
-          _57 = copy _59 as *const u8 (Transmute);
-          StorageLive(_58);
-          _58 = copy (((*_52).0: std::vec::Vec<u8>).1: usize);
-          switchInt(UbChecks) -> [0: bb33, otherwise: bb31];
+          StorageLive(_39);
+          StorageLive(_40);
+          _39 = copy (*_15);
+          _40 = copy (*_17);
+          StorageLive(_41);
+          StorageLive(_42);
+          StorageLive(_43);
+          StorageLive(_44);
+          StorageLive(_46);
+          _46 = copy ((((((*_39).0: std::vec::Vec<u8>).0: alloc::raw_vec::RawVec<u8>).0: alloc::raw_vec::RawVecInner).0: std::ptr::Unique<u8>).0: std::ptr::NonNull<u8>);
+          _44 = copy _46 as *const u8 (Transmute);
+          StorageDead(_46);
+          StorageLive(_45);
+          _45 = copy (((*_39).0: std::vec::Vec<u8>).1: usize);
+          _43 = *const [u8] from (copy _44, move _45);
+          StorageDead(_45);
+          StorageDead(_44);
+          _42 = &(*_43);
+          StorageDead(_43);
+          _41 = copy _42 as &str (Transmute);
+          StorageDead(_42);
+          StorageLive(_48);
+          StorageLive(_50);
+          _48 = copy _41 as &[u8] (Transmute);
+          _50 = copy _40 as &[u8] (Transmute);
+          _14 = <[u8] as PartialEq>::eq(move _48, move _50) -> [return: bb24, unwind: bb22];
       }
   
       bb7: {
           StorageDead(_5);
           StorageDead(_6);
 -         goto -> bb19;
-+         goto -> bb43;
++         goto -> bb25;
       }
   
       bb8: {
@@ -354,14 +300,14 @@
           StorageDead(_13);
           _1 = chained_conditions::BacktraceStyle::Short;
 -         goto -> bb19;
-+         goto -> bb41;
++         goto -> bb27;
       }
   
       bb10: {
           StorageDead(_12);
           StorageDead(_13);
 -         goto -> bb19;
-+         goto -> bb43;
++         goto -> bb25;
       }
   
       bb11: {
@@ -423,223 +369,39 @@
       }
   
       bb23: {
-          StorageLive(_36);
-          _36 = copy _34 as *mut () (Transmute);
-          _35 = std::slice::from_raw_parts::precondition_check(move _36, const <u8 as std::mem::SizedTypeProperties>::SIZE, const <u8 as std::mem::SizedTypeProperties>::ALIGN, copy _33) -> [return: bb24, unwind unreachable];
-      }
-  
-      bb24: {
+          StorageDead(_38);
           StorageDead(_36);
-          goto -> bb25;
-      }
-  
-      bb25: {
-          StorageLive(_37);
-          _37 = *const [u8] from (copy _32, copy _33);
-          _30 = &(*_37);
-          StorageDead(_37);
-          StorageDead(_33);
-          StorageDead(_32);
-          StorageDead(_34);
-          _29 = copy _30 as &str (Transmute);
-          StorageDead(_30);
-          StorageLive(_39);
-          StorageLive(_41);
-          _39 = copy _29 as &[u8] (Transmute);
-          _41 = copy _28 as &[u8] (Transmute);
-          StorageLive(_45);
-          StorageLive(_50);
-          StorageLive(_51);
-          StorageLive(_42);
-          StorageLive(_43);
-          _43 = PtrMetadata(copy _39);
-          StorageLive(_44);
-          _44 = PtrMetadata(copy _41);
-          _42 = Ne(move _43, move _44);
-          switchInt(move _42) -> [0: bb28, otherwise: bb27];
-      }
-  
-      bb26: {
-          StorageDead(_51);
-          StorageDead(_50);
-          StorageDead(_45);
-          StorageDead(_41);
-          StorageDead(_39);
-          StorageDead(_35);
           StorageDead(_29);
           StorageDead(_28);
           StorageDead(_27);
           switchInt(move _7) -> [0: bb6, otherwise: bb5];
       }
   
-      bb27: {
-          StorageDead(_44);
-          StorageDead(_43);
-          _7 = const false;
-          StorageDead(_42);
--         goto -> bb26;
-+         goto -> bb39;
-      }
-  
-      bb28: {
-          StorageDead(_44);
-          StorageDead(_43);
-          StorageDead(_42);
-          StorageLive(_49);
-          _49 = &raw const (*_39);
-          _45 = std::intrinsics::size_of_val::<[u8]>(move _49) -> [return: bb30, unwind unreachable];
-      }
-  
-      bb29: {
+      bb24: {
+          StorageDead(_50);
           StorageDead(_48);
-          StorageDead(_47);
-          _7 = Eq(move _46, const 0_i32);
-          StorageDead(_46);
-          goto -> bb26;
-      }
-  
-      bb30: {
-          StorageDead(_49);
-          StorageLive(_46);
-          StorageLive(_47);
-          _50 = &raw const (*_39);
-          _47 = copy _50 as *const u8 (PtrToPtr);
-          StorageLive(_48);
-          _51 = &raw const (*_41);
-          _48 = copy _51 as *const u8 (PtrToPtr);
-          _46 = compare_bytes(move _47, move _48, move _45) -> [return: bb29, unwind unreachable];
-      }
-  
-      bb31: {
-          StorageLive(_61);
-          _61 = copy _59 as *mut () (Transmute);
-          _60 = std::slice::from_raw_parts::precondition_check(move _61, const <u8 as std::mem::SizedTypeProperties>::SIZE, const <u8 as std::mem::SizedTypeProperties>::ALIGN, copy _58) -> [return: bb32, unwind unreachable];
-      }
-  
-      bb32: {
-          StorageDead(_61);
-          goto -> bb33;
-      }
-  
-      bb33: {
-          StorageLive(_62);
-          _62 = *const [u8] from (copy _57, copy _58);
-          _55 = &(*_62);
-          StorageDead(_62);
-          StorageDead(_58);
-          StorageDead(_57);
-          StorageDead(_59);
-          _54 = copy _55 as &str (Transmute);
-          StorageDead(_55);
-          StorageLive(_64);
-          StorageLive(_66);
-          _64 = copy _54 as &[u8] (Transmute);
-          _66 = copy _53 as &[u8] (Transmute);
-          StorageLive(_70);
-          StorageLive(_75);
-          StorageLive(_76);
-          StorageLive(_67);
-          StorageLive(_68);
-          _68 = PtrMetadata(copy _64);
-          StorageLive(_69);
-          _69 = PtrMetadata(copy _66);
-          _67 = Ne(move _68, move _69);
-          switchInt(move _67) -> [0: bb36, otherwise: bb35];
-      }
-  
-      bb34: {
-          StorageDead(_76);
-          StorageDead(_75);
-          StorageDead(_70);
-          StorageDead(_66);
-          StorageDead(_64);
-          StorageDead(_60);
-          StorageDead(_54);
-          StorageDead(_53);
-          StorageDead(_52);
+          StorageDead(_41);
+          StorageDead(_40);
+          StorageDead(_39);
           switchInt(move _14) -> [0: bb9, otherwise: bb8];
-      }
-  
-      bb35: {
-          StorageDead(_69);
-          StorageDead(_68);
-          _14 = const false;
-          StorageDead(_67);
--         goto -> bb34;
-+         goto -> bb40;
-      }
-  
-      bb36: {
-          StorageDead(_69);
-          StorageDead(_68);
-          StorageDead(_67);
-          StorageLive(_74);
-          _74 = &raw const (*_64);
-          _70 = std::intrinsics::size_of_val::<[u8]>(move _74) -> [return: bb38, unwind unreachable];
-      }
-  
-      bb37: {
-          StorageDead(_73);
-          StorageDead(_72);
-          _14 = Eq(move _71, const 0_i32);
-          StorageDead(_71);
-          goto -> bb34;
-      }
-  
-      bb38: {
-          StorageDead(_74);
-          StorageLive(_71);
-          StorageLive(_72);
-          _75 = &raw const (*_64);
-          _72 = copy _75 as *const u8 (PtrToPtr);
-          StorageLive(_73);
-          _76 = &raw const (*_66);
-          _73 = copy _76 as *const u8 (PtrToPtr);
-          _71 = compare_bytes(move _72, move _73, move _70) -> [return: bb37, unwind unreachable];
 +     }
 + 
-+     bb39: {
-+         StorageDead(_51);
-+         StorageDead(_50);
-+         StorageDead(_45);
-+         StorageDead(_41);
-+         StorageDead(_39);
-+         StorageDead(_35);
-+         StorageDead(_29);
-+         StorageDead(_28);
-+         StorageDead(_27);
-+         goto -> bb6;
-+     }
-+ 
-+     bb40: {
-+         StorageDead(_76);
-+         StorageDead(_75);
-+         StorageDead(_70);
-+         StorageDead(_66);
-+         StorageDead(_64);
-+         StorageDead(_60);
-+         StorageDead(_54);
-+         StorageDead(_53);
-+         StorageDead(_52);
-+         goto -> bb9;
-+     }
-+ 
-+     bb41: {
++     bb25: {
 +         _24 = discriminant(_2);
-+         switchInt(move _24) -> [1: bb42, otherwise: bb16];
++         switchInt(move _24) -> [1: bb26, otherwise: bb16];
 +     }
 + 
-+     bb42: {
-+         goto -> bb18;
-+     }
-+ 
-+     bb43: {
-+         _24 = discriminant(_2);
-+         switchInt(move _24) -> [1: bb44, otherwise: bb16];
-+     }
-+ 
-+     bb44: {
++     bb26: {
 +         goto -> bb16;
++     }
++ 
++     bb27: {
++         _24 = discriminant(_2);
++         switchInt(move _24) -> [1: bb28, otherwise: bb16];
++     }
++ 
++     bb28: {
++         goto -> bb18;
       }
   }
   

--- a/tests/mir-opt/jump_threading.chained_conditions.JumpThreading.panic-unwind.diff
+++ b/tests/mir-opt/jump_threading.chained_conditions.JumpThreading.panic-unwind.diff
@@ -92,62 +92,66 @@
                   scope 24 (inlined core::str::<impl str>::as_bytes) {
                   }
                   scope 25 (inlined std::cmp::impls::<impl PartialEq for &[u8]>::eq) {
+                      scope 26 (inlined core::slice::cmp::<impl PartialEq for [u8]>::eq) {
+                      }
                   }
               }
           }
       }
-      scope 26 (inlined std::cmp::impls::<impl PartialEq<&str> for &String>::eq) {
+      scope 27 (inlined std::cmp::impls::<impl PartialEq<&str> for &String>::eq) {
           let mut _39: &std::string::String;
           let mut _40: &str;
-          scope 27 (inlined <String as PartialEq<str>>::eq) {
-              scope 28 (inlined #[track_caller] <String as Index<RangeFull>>::index) {
+          scope 28 (inlined <String as PartialEq<str>>::eq) {
+              scope 29 (inlined #[track_caller] <String as Index<RangeFull>>::index) {
                   let _41: &str;
-                  scope 29 (inlined String::as_str) {
+                  scope 30 (inlined String::as_str) {
                       let _42: &[u8];
-                      scope 30 (inlined Vec::<u8>::as_slice) {
+                      scope 31 (inlined Vec::<u8>::as_slice) {
                           let _43: *const [u8];
                           let mut _44: *const u8;
                           let mut _45: usize;
-                          scope 31 (inlined Vec::<u8>::as_ptr) {
-                              scope 32 (inlined alloc::raw_vec::RawVec::<u8>::ptr) {
-                                  scope 33 (inlined alloc::raw_vec::RawVecInner::ptr::<u8>) {
-                                      scope 34 (inlined alloc::raw_vec::RawVecInner::non_null::<u8>) {
+                          scope 32 (inlined Vec::<u8>::as_ptr) {
+                              scope 33 (inlined alloc::raw_vec::RawVec::<u8>::ptr) {
+                                  scope 34 (inlined alloc::raw_vec::RawVecInner::ptr::<u8>) {
+                                      scope 35 (inlined alloc::raw_vec::RawVecInner::non_null::<u8>) {
                                           let mut _46: std::ptr::NonNull<u8>;
-                                          scope 35 (inlined Unique::<u8>::cast::<u8>) {
-                                              scope 36 (inlined NonNull::<u8>::cast::<u8>) {
-                                                  scope 37 (inlined NonNull::<u8>::as_ptr) {
+                                          scope 36 (inlined Unique::<u8>::cast::<u8>) {
+                                              scope 37 (inlined NonNull::<u8>::cast::<u8>) {
+                                                  scope 38 (inlined NonNull::<u8>::as_ptr) {
                                                   }
                                               }
                                           }
-                                          scope 38 (inlined Unique::<u8>::as_non_null_ptr) {
+                                          scope 39 (inlined Unique::<u8>::as_non_null_ptr) {
                                           }
                                       }
-                                      scope 39 (inlined NonNull::<u8>::as_ptr) {
+                                      scope 40 (inlined NonNull::<u8>::as_ptr) {
                                       }
                                   }
                               }
                           }
                       }
-                      scope 40 (inlined from_utf8_unchecked) {
+                      scope 41 (inlined from_utf8_unchecked) {
                       }
                   }
-                  scope 41 (inlined #[track_caller] core::str::traits::<impl SliceIndex<str> for RangeFull>::index) {
+                  scope 42 (inlined #[track_caller] core::str::traits::<impl SliceIndex<str> for RangeFull>::index) {
                   }
               }
-              scope 42 (inlined #[track_caller] core::str::traits::<impl Index<RangeFull> for str>::index) {
-                  scope 43 (inlined #[track_caller] core::str::traits::<impl SliceIndex<str> for RangeFull>::index) {
+              scope 43 (inlined #[track_caller] core::str::traits::<impl Index<RangeFull> for str>::index) {
+                  scope 44 (inlined #[track_caller] core::str::traits::<impl SliceIndex<str> for RangeFull>::index) {
                   }
               }
-              scope 44 (inlined core::str::traits::<impl PartialEq for str>::eq) {
+              scope 45 (inlined core::str::traits::<impl PartialEq for str>::eq) {
                   let mut _47: &&[u8];
                   let _48: &[u8];
                   let mut _49: &&[u8];
                   let _50: &[u8];
-                  scope 45 (inlined core::str::<impl str>::as_bytes) {
-                  }
                   scope 46 (inlined core::str::<impl str>::as_bytes) {
                   }
-                  scope 47 (inlined std::cmp::impls::<impl PartialEq for &[u8]>::eq) {
+                  scope 47 (inlined core::str::<impl str>::as_bytes) {
+                  }
+                  scope 48 (inlined std::cmp::impls::<impl PartialEq for &[u8]>::eq) {
+                      scope 49 (inlined core::slice::cmp::<impl PartialEq for [u8]>::eq) {
+                      }
                   }
               }
           }
@@ -214,7 +218,7 @@
           StorageLive(_38);
           _36 = copy _29 as &[u8] (Transmute);
           _38 = copy _28 as &[u8] (Transmute);
-          _7 = <[u8] as PartialEq>::eq(move _36, move _38) -> [return: bb23, unwind: bb22];
+          _7 = <[u8] as core::slice::cmp::SlicePartialEq<u8>>::equal(move _36, move _38) -> [return: bb23, unwind: bb22];
       }
   
       bb5: {
@@ -270,7 +274,7 @@
           StorageLive(_50);
           _48 = copy _41 as &[u8] (Transmute);
           _50 = copy _40 as &[u8] (Transmute);
-          _14 = <[u8] as PartialEq>::eq(move _48, move _50) -> [return: bb24, unwind: bb22];
+          _14 = <[u8] as core::slice::cmp::SlicePartialEq<u8>>::equal(move _48, move _50) -> [return: bb24, unwind: bb22];
       }
   
       bb7: {

--- a/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.64bit.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.64bit.panic-abort.mir
@@ -25,17 +25,21 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
                         }
                     }
                     scope 18 (inlined <std::alloc::Global as Allocator>::deallocate) {
-                        let mut _9: *mut u8;
-                        scope 19 (inlined Layout::size) {
-                        }
-                        scope 20 (inlined NonNull::<u8>::as_ptr) {
-                        }
-                        scope 21 (inlined std::alloc::dealloc) {
-                            let mut _10: usize;
-                            scope 22 (inlined Layout::size) {
-                            }
-                            scope 23 (inlined Layout::align) {
-                                scope 24 (inlined std::ptr::Alignment::as_usize) {
+                        scope 19 (inlined std::alloc::Global::deallocate_impl) {
+                            scope 20 (inlined std::alloc::Global::deallocate_impl_runtime) {
+                                let mut _9: *mut u8;
+                                scope 21 (inlined Layout::size) {
+                                }
+                                scope 22 (inlined NonNull::<u8>::as_ptr) {
+                                }
+                                scope 23 (inlined std::alloc::dealloc) {
+                                    let mut _10: usize;
+                                    scope 24 (inlined Layout::size) {
+                                    }
+                                    scope 25 (inlined Layout::align) {
+                                        scope 26 (inlined std::ptr::Alignment::as_usize) {
+                                        }
+                                    }
                                 }
                             }
                         }

--- a/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.64bit.panic-abort.diff
+++ b/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.64bit.panic-abort.diff
@@ -9,33 +9,33 @@
       let mut _4: *mut [u8];
       let mut _5: std::ptr::NonNull<[u8]>;
       let mut _6: std::result::Result<std::ptr::NonNull<[u8]>, std::alloc::AllocError>;
-      let mut _7: &std::alloc::Global;
-      let mut _8: std::alloc::Layout;
+      let mut _7: std::alloc::Layout;
       scope 1 {
           debug layout => _1;
-          let mut _9: &std::alloc::Global;
           scope 2 {
               debug ptr => _3;
           }
           scope 5 (inlined <std::alloc::Global as Allocator>::allocate) {
-          }
-          scope 6 (inlined #[track_caller] Result::<NonNull<[u8]>, std::alloc::AllocError>::unwrap) {
-              let mut _12: isize;
-              let _13: std::alloc::AllocError;
-              let mut _14: !;
-              let mut _15: &dyn std::fmt::Debug;
-              let _16: &std::alloc::AllocError;
-              scope 7 {
+              scope 6 (inlined std::alloc::Global::alloc_impl) {
               }
+          }
+          scope 7 (inlined #[track_caller] Result::<NonNull<[u8]>, std::alloc::AllocError>::unwrap) {
+              let mut _10: isize;
+              let _11: std::alloc::AllocError;
+              let mut _12: !;
+              let mut _13: &dyn std::fmt::Debug;
+              let _14: &std::alloc::AllocError;
               scope 8 {
               }
+              scope 9 {
+              }
           }
-          scope 9 (inlined NonNull::<[u8]>::as_ptr) {
+          scope 10 (inlined NonNull::<[u8]>::as_ptr) {
           }
       }
       scope 3 (inlined #[track_caller] Option::<Layout>::unwrap) {
-          let mut _10: isize;
-          let mut _11: !;
+          let mut _8: isize;
+          let mut _9: !;
           scope 4 {
           }
       }
@@ -46,10 +46,10 @@
           StorageLive(_2);
 -         _2 = Option::<Layout>::None;
 +         _2 = const Option::<Layout>::None;
-          StorageLive(_10);
--         _10 = discriminant(_2);
--         switchInt(move _10) -> [0: bb2, 1: bb3, otherwise: bb1];
-+         _10 = const 0_isize;
+          StorageLive(_8);
+-         _8 = discriminant(_2);
+-         switchInt(move _8) -> [0: bb2, 1: bb3, otherwise: bb1];
++         _8 = const 0_isize;
 +         switchInt(const 0_isize) -> [0: bb2, 1: bb3, otherwise: bb1];
       }
   
@@ -58,48 +58,44 @@
       }
   
       bb2: {
-          _11 = option::unwrap_failed() -> unwind unreachable;
+          _9 = option::unwrap_failed() -> unwind unreachable;
       }
   
       bb3: {
 -         _1 = move ((_2 as Some).0: std::alloc::Layout);
 +         _1 = const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(8 bytes) }: usize, align: std::ptr::Alignment(Scalar(0x0000000000000000): std::ptr::alignment::AlignmentEnum) }};
-          StorageDead(_10);
+          StorageDead(_8);
           StorageDead(_2);
           StorageLive(_3);
           StorageLive(_4);
           StorageLive(_5);
           StorageLive(_6);
           StorageLive(_7);
-          _9 = const main::promoted[0];
-          _7 = copy _9;
-          StorageLive(_8);
--         _8 = copy _1;
--         _6 = std::alloc::Global::alloc_impl(move _7, move _8, const false) -> [return: bb4, unwind unreachable];
-+         _8 = const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(8 bytes) }: usize, align: std::ptr::Alignment(Scalar(0x0000000000000000): std::ptr::alignment::AlignmentEnum) }};
-+         _6 = std::alloc::Global::alloc_impl(copy _9, const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(8 bytes) }: usize, align: std::ptr::Alignment(Scalar(0x0000000000000000): std::ptr::alignment::AlignmentEnum) }}, const false) -> [return: bb4, unwind unreachable];
+-         _7 = copy _1;
+-         _6 = std::alloc::Global::alloc_impl_runtime(move _7, const false) -> [return: bb4, unwind unreachable];
++         _7 = const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(8 bytes) }: usize, align: std::ptr::Alignment(Scalar(0x0000000000000000): std::ptr::alignment::AlignmentEnum) }};
++         _6 = std::alloc::Global::alloc_impl_runtime(const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(8 bytes) }: usize, align: std::ptr::Alignment(Scalar(0x0000000000000000): std::ptr::alignment::AlignmentEnum) }}, const false) -> [return: bb4, unwind unreachable];
       }
   
       bb4: {
-          StorageDead(_8);
           StorageDead(_7);
-          StorageLive(_12);
-          StorageLive(_16);
-          _12 = discriminant(_6);
-          switchInt(move _12) -> [0: bb6, 1: bb5, otherwise: bb1];
+          StorageLive(_10);
+          StorageLive(_14);
+          _10 = discriminant(_6);
+          switchInt(move _10) -> [0: bb6, 1: bb5, otherwise: bb1];
       }
   
       bb5: {
-          StorageLive(_15);
-          _16 = &_13;
-          _15 = copy _16 as &dyn std::fmt::Debug (PointerCoercion(Unsize, Implicit));
-          _14 = result::unwrap_failed(const "called `Result::unwrap()` on an `Err` value", move _15) -> unwind unreachable;
+          StorageLive(_13);
+          _14 = &_11;
+          _13 = copy _14 as &dyn std::fmt::Debug (PointerCoercion(Unsize, Implicit));
+          _12 = result::unwrap_failed(const "called `Result::unwrap()` on an `Err` value", move _13) -> unwind unreachable;
       }
   
       bb6: {
           _5 = move ((_6 as Ok).0: std::ptr::NonNull<[u8]>);
-          StorageDead(_16);
-          StorageDead(_12);
+          StorageDead(_14);
+          StorageDead(_10);
           StorageDead(_6);
           _4 = copy _5 as *mut [u8] (Transmute);
           StorageDead(_5);

--- a/tests/mir-opt/pre-codegen/vec_deref.vec_deref_to_slice.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/vec_deref.vec_deref_to_slice.PreCodegen.after.panic-abort.mir
@@ -9,6 +9,7 @@ fn vec_deref_to_slice(_1: &Vec<u8>) -> &[u8] {
             debug self => _1;
             let mut _3: *const u8;
             let mut _4: usize;
+            let _5: *const [u8];
             scope 3 (inlined Vec::<u8>::as_ptr) {
                 debug self => _1;
                 scope 4 (inlined alloc::raw_vec::RawVec::<u8>::ptr) {
@@ -29,43 +30,23 @@ fn vec_deref_to_slice(_1: &Vec<u8>) -> &[u8] {
                     }
                 }
             }
-            scope 12 (inlined #[track_caller] std::slice::from_raw_parts::<'_, u8>) {
-                debug data => _3;
-                debug len => _4;
-                let _5: *const [u8];
-                scope 13 (inlined core::ub_checks::check_language_ub) {
-                    scope 14 (inlined core::ub_checks::check_language_ub::runtime) {
-                    }
-                }
-                scope 15 (inlined std::mem::size_of::<u8>) {
-                }
-                scope 16 (inlined std::mem::align_of::<u8>) {
-                }
-                scope 17 (inlined slice_from_raw_parts::<u8>) {
-                    debug data => _3;
-                    debug len => _4;
-                    scope 18 (inlined std::ptr::from_raw_parts::<[u8], u8>) {
-                        debug data_pointer => _3;
-                    }
-                }
-            }
         }
     }
 
     bb0: {
-        StorageLive(_2);
+        StorageLive(_5);
         StorageLive(_3);
+        StorageLive(_2);
         _2 = copy (((((*_1).0: alloc::raw_vec::RawVec<u8>).0: alloc::raw_vec::RawVecInner).0: std::ptr::Unique<u8>).0: std::ptr::NonNull<u8>);
         _3 = copy _2 as *const u8 (Transmute);
+        StorageDead(_2);
         StorageLive(_4);
         _4 = copy ((*_1).1: usize);
-        StorageLive(_5);
-        _5 = *const [u8] from (copy _3, copy _4);
-        _0 = &(*_5);
-        StorageDead(_5);
+        _5 = *const [u8] from (copy _3, move _4);
         StorageDead(_4);
         StorageDead(_3);
-        StorageDead(_2);
+        _0 = &(*_5);
+        StorageDead(_5);
         return;
     }
 }

--- a/tests/mir-opt/pre-codegen/vec_deref.vec_deref_to_slice.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/vec_deref.vec_deref_to_slice.PreCodegen.after.panic-unwind.mir
@@ -9,6 +9,7 @@ fn vec_deref_to_slice(_1: &Vec<u8>) -> &[u8] {
             debug self => _1;
             let mut _3: *const u8;
             let mut _4: usize;
+            let _5: *const [u8];
             scope 3 (inlined Vec::<u8>::as_ptr) {
                 debug self => _1;
                 scope 4 (inlined alloc::raw_vec::RawVec::<u8>::ptr) {
@@ -29,43 +30,23 @@ fn vec_deref_to_slice(_1: &Vec<u8>) -> &[u8] {
                     }
                 }
             }
-            scope 12 (inlined #[track_caller] std::slice::from_raw_parts::<'_, u8>) {
-                debug data => _3;
-                debug len => _4;
-                let _5: *const [u8];
-                scope 13 (inlined core::ub_checks::check_language_ub) {
-                    scope 14 (inlined core::ub_checks::check_language_ub::runtime) {
-                    }
-                }
-                scope 15 (inlined std::mem::size_of::<u8>) {
-                }
-                scope 16 (inlined std::mem::align_of::<u8>) {
-                }
-                scope 17 (inlined slice_from_raw_parts::<u8>) {
-                    debug data => _3;
-                    debug len => _4;
-                    scope 18 (inlined std::ptr::from_raw_parts::<[u8], u8>) {
-                        debug data_pointer => _3;
-                    }
-                }
-            }
         }
     }
 
     bb0: {
-        StorageLive(_2);
+        StorageLive(_5);
         StorageLive(_3);
+        StorageLive(_2);
         _2 = copy (((((*_1).0: alloc::raw_vec::RawVec<u8>).0: alloc::raw_vec::RawVecInner).0: std::ptr::Unique<u8>).0: std::ptr::NonNull<u8>);
         _3 = copy _2 as *const u8 (Transmute);
+        StorageDead(_2);
         StorageLive(_4);
         _4 = copy ((*_1).1: usize);
-        StorageLive(_5);
-        _5 = *const [u8] from (copy _3, copy _4);
-        _0 = &(*_5);
-        StorageDead(_5);
+        _5 = *const [u8] from (copy _3, move _4);
         StorageDead(_4);
         StorageDead(_3);
-        StorageDead(_2);
+        _0 = &(*_5);
+        StorageDead(_5);
         return;
     }
 }


### PR DESCRIPTION
Spotted this in rust-lang/rust#148766's test changes.  It doesn't seem like this ubcheck would catch anything useful; let's see if skipping it helps perf.  (After all, this is inside *every* `[]` on a vec, among other things.)
