### PR TITLE
Remove inactive nvptx maintainer

### DIFF
--- a/src/doc/rustc/src/platform-support/nvptx64-nvidia-cuda.md
+++ b/src/doc/rustc/src/platform-support/nvptx64-nvidia-cuda.md
@@ -7,7 +7,6 @@ platform.
 
 ## Target maintainers
 
-[@RDambrosio016](https://github.com/RDambrosio016)
 [@kjetilkjeka](https://github.com/kjetilkjeka)
 
 ## Requirements


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Since I just saw the discussion in [#t-compiler > Starting to enforce Tier 2-to-3 downgrade](https://rust-lang.zulipchat.com/#narrow/channel/131828-t-compiler/topic/Starting.20to.20enforce.20Tier.202-to-3.20downgrade/with/564788312), and I saw him pinged on PRs or issues. His last active open-source contributions were in early 2022: https://github.com/RDambrosio016 and IIRC he also mentioned that he had moved on.

ping @RDambrosio016 so you can confirm or correct me, if you want to chime in. I also pinged him on Zulip.

cc @kjetilkjeka who is the other maintainer and active on related issues/prs for his target.

I'd leave it open for a while, but 
r? @jieyouxu