### PR TITLE
docs(core): update `find()` and `rfind()` examples

### DIFF
--- a/library/core/src/iter/traits/double_ended.rs
+++ b/library/core/src/iter/traits/double_ended.rs
@@ -334,8 +334,18 @@ pub trait DoubleEndedIterator: Iterator {
     /// ```
     /// let a = [1, 2, 3];
     ///
-    /// assert_eq!(a.iter().rfind(|&&x| x == 2), Some(&2));
+    /// assert_eq!(a.into_iter().rfind(|&x| x == 2), Some(2));
+    /// assert_eq!(a.into_iter().rfind(|&x| x == 5), None);
+    /// ```
     ///
+    /// Iterating over references:
+    ///
+    /// ```
+    /// let a = [1, 2, 3];
+    ///
+    /// // `iter()` yields references i.e. `&i32` and `rfind()` takes a
+    /// // reference to each element.
+    /// assert_eq!(a.iter().rfind(|&&x| x == 2), Some(&2));
     /// assert_eq!(a.iter().rfind(|&&x| x == 5), None);
     /// ```
     ///

--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -2858,6 +2858,17 @@ pub trait Iterator {
     /// assert_eq!(a.into_iter().find(|&x| x == 5), None);
     /// ```
     ///
+    /// Iterating over references:
+    ///
+    /// ```
+    /// let a = [1, 2, 3];
+    ///
+    /// // `iter()` yields references i.e. `&i32` and `find()` takes a
+    /// // reference to each element.
+    /// assert_eq!(a.iter().find(|&&x| x == 2), Some(&2));
+    /// assert_eq!(a.iter().find(|&&x| x == 5), None);
+    /// ```
+    ///
     /// Stopping at the first `true`:
     ///
     /// ```


### PR DESCRIPTION
[find()](https://doc.rust-lang.org/std/iter/trait.Iterator.html) has a missing example. In the docs there is mention of an example with double reference but it doesn't exist.

<img width="1476" height="1229" alt="image" src="https://github.com/user-attachments/assets/b99062ed-3a47-4b87-8e0c-58afd7de1332" />


[rfind()](https://doc.rust-lang.org/core/iter/trait.DoubleEndedIterator.html#method.rfind) is also very similar to `find()`, however it has the double reference example and no owned value example like `find()` does.

<img width="1473" height="1163" alt="image" src="https://github.com/user-attachments/assets/7977ae5c-9888-4513-8dfc-a7c03c7ef072" />

This commit adds the missing examples and making them look consistent.
