### PR TITLE
Rollup of 2 pull requests

### DIFF
--- a/compiler/rustc_ast_lowering/src/expr.rs
+++ b/compiler/rustc_ast_lowering/src/expr.rs
@@ -114,7 +114,8 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 }
                 ExprKind::Tup(elts) => hir::ExprKind::Tup(self.lower_exprs(elts)),
                 ExprKind::Call(f, args) => {
-                    if let Some(legacy_args) = self.resolver.legacy_const_generic_args(f) {
+                    if let Some(legacy_args) = self.resolver.legacy_const_generic_args(f, self.tcx)
+                    {
                         self.lower_legacy_const_generics((**f).clone(), args.clone(), &legacy_args)
                     } else {
                         let f = self.lower_expr(f);

--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -47,13 +47,14 @@ use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
 use rustc_data_structures::sync::spawn;
 use rustc_data_structures::tagged_ptr::TaggedRef;
 use rustc_errors::{DiagArgFromDisplay, DiagCtxtHandle};
+use rustc_hir::attrs::AttributeKind;
 use rustc_hir::def::{DefKind, LifetimeRes, Namespace, PartialRes, PerNS, Res};
 use rustc_hir::def_id::{CRATE_DEF_ID, LOCAL_CRATE, LocalDefId};
 use rustc_hir::definitions::{DefPathData, DisambiguatorState};
 use rustc_hir::lints::DelayedLint;
 use rustc_hir::{
     self as hir, AngleBrackets, ConstArg, GenericArg, HirId, ItemLocalMap, LifetimeSource,
-    LifetimeSyntax, ParamName, Target, TraitCandidate,
+    LifetimeSyntax, ParamName, Target, TraitCandidate, find_attr,
 };
 use rustc_index::{Idx, IndexSlice, IndexVec};
 use rustc_macros::extension;
@@ -236,7 +237,7 @@ impl SpanLowerer {
 
 #[extension(trait ResolverAstLoweringExt)]
 impl ResolverAstLowering {
-    fn legacy_const_generic_args(&self, expr: &Expr) -> Option<Vec<usize>> {
+    fn legacy_const_generic_args(&self, expr: &Expr, tcx: TyCtxt<'_>) -> Option<Vec<usize>> {
         let ExprKind::Path(None, path) = &expr.kind else {
             return None;
         };
@@ -256,11 +257,12 @@ impl ResolverAstLowering {
             return None;
         }
 
-        if let Some(v) = self.legacy_const_generic_args.get(&def_id) {
-            return v.clone();
-        }
-
-        None
+        find_attr!(
+            // we can use parsed attrs here since for other crates they're already available
+            tcx.get_all_attrs(def_id),
+            AttributeKind::RustcLegacyConstGenerics{fn_indexes,..} => fn_indexes
+        )
+        .map(|fn_indexes| fn_indexes.iter().map(|(num, _)| *num).collect())
     }
 
     fn get_partial_res(&self, id: NodeId) -> Option<PartialRes> {

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -31,7 +31,7 @@ use rustc_ast::AttrVec;
 use rustc_ast::expand::typetree::{FncTree, Kind, Type, TypeTree};
 use rustc_ast::node_id::NodeMap;
 pub use rustc_ast_ir::{Movability, Mutability, try_visit};
-use rustc_data_structures::fx::{FxHashMap, FxHashSet, FxIndexMap, FxIndexSet};
+use rustc_data_structures::fx::{FxHashSet, FxIndexMap, FxIndexSet};
 use rustc_data_structures::intern::Interned;
 use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
 use rustc_data_structures::steal::Steal;
@@ -196,7 +196,6 @@ pub struct ResolverGlobalCtxt {
 /// This struct is meant to be consumed by lowering.
 #[derive(Debug)]
 pub struct ResolverAstLowering {
-    pub legacy_const_generic_args: FxHashMap<DefId, Option<Vec<usize>>>,
     /// Resolutions for nodes that have a single resolution.
     pub partial_res_map: NodeMap<hir::def::PartialRes>,
     /// Resolutions for import nodes, which have multiple resolutions in different namespaces.

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -2223,7 +2223,11 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             match binding.kind {
                 NameBindingKind::Import { import, .. } => {
                     for segment in import.module_path.iter().skip(1) {
-                        path.push(segment.ident);
+                        // Don't include `{{root}}` in suggestions - it's an internal symbol
+                        // that should never be shown to users.
+                        if segment.ident.name != kw::PathRoot {
+                            path.push(segment.ident);
+                        }
                     }
                     sugg_paths.push((
                         path.iter().cloned().chain(std::iter::once(ident)).collect::<Vec<_>>(),

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -1271,7 +1271,6 @@ pub struct Resolver<'ra, 'tcx> {
     /// and how the `impl Trait` fragments were introduced.
     invocation_parents: FxHashMap<LocalExpnId, InvocationParent>,
 
-    legacy_const_generic_args: FxHashMap<DefId, Option<Vec<usize>>>,
     /// Amount of lifetime parameters for each item in the crate.
     item_generics_num_lifetimes: FxHashMap<LocalDefId, usize>,
     delegation_fn_sigs: LocalDefIdMap<DelegationFnSig>,
@@ -1675,7 +1674,6 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             node_id_to_def_id,
             disambiguator: DisambiguatorState::new(),
             placeholder_field_indices: Default::default(),
-            legacy_const_generic_args: Default::default(),
             invocation_parents,
             item_generics_num_lifetimes: Default::default(),
             trait_impls: Default::default(),
@@ -1805,7 +1803,6 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             stripped_cfg_items,
         };
         let ast_lowering = ty::ResolverAstLowering {
-            legacy_const_generic_args: self.legacy_const_generic_args,
             partial_res_map: self.partial_res_map,
             import_res_map: self.import_res_map,
             label_res_map: self.label_res_map,
@@ -2413,15 +2410,12 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             return None;
         }
 
-        let indexes = find_attr!(
+        find_attr!(
             // we can use parsed attrs here since for other crates they're already available
             self.tcx.get_all_attrs(def_id),
             AttributeKind::RustcLegacyConstGenerics{fn_indexes,..} => fn_indexes
         )
-        .map(|fn_indexes| fn_indexes.iter().map(|(num, _)| *num).collect());
-
-        self.legacy_const_generic_args.insert(def_id, indexes.clone());
-        indexes
+        .map(|fn_indexes| fn_indexes.iter().map(|(num, _)| *num).collect())
     }
 
     fn resolve_main(&mut self) {

--- a/tests/ui/imports/nested-import-root-symbol-150103.rs
+++ b/tests/ui/imports/nested-import-root-symbol-150103.rs
@@ -1,0 +1,13 @@
+// Issue: https://github.com/rust-lang/rust/issues/150103
+// ICE when using `::` at start of nested imports
+// caused by `{{root}}` appearing in diagnostic suggestions
+
+mod A {
+    use Iuse::{ ::Fish }; //~ ERROR failed to resolve: use of unresolved module or unlinked crate
+}
+
+mod B {
+    use A::{::Fish}; //~ ERROR failed to resolve: crate root in paths can only be used in start position
+}
+
+fn main() {}

--- a/tests/ui/imports/nested-import-root-symbol-150103.stderr
+++ b/tests/ui/imports/nested-import-root-symbol-150103.stderr
@@ -1,0 +1,20 @@
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `Iuse`
+  --> $DIR/nested-import-root-symbol-150103.rs:6:9
+   |
+LL |     use Iuse::{ ::Fish };
+   |         ^^^^ use of unresolved module or unlinked crate `Iuse`
+   |
+help: you might be missing a crate named `Iuse`, add it to your project and import it in your code
+   |
+LL + extern crate Iuse;
+   |
+
+error[E0433]: failed to resolve: crate root in paths can only be used in start position
+  --> $DIR/nested-import-root-symbol-150103.rs:10:13
+   |
+LL |     use A::{::Fish};
+   |             ^ crate root in paths can only be used in start position
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0433`.


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#150098 (remove `legacy_const_generic_args` cache)
 - rust-lang/rust#150155 (fix ICE when {{root}} appears in import suggestions)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=150098,150155)
<!-- homu-ignore:end -->