### PR TITLE
Assume ubchecks

### DIFF
--- a/tests/mir-opt/ub_checks_assume_removals.rs
+++ b/tests/mir-opt/ub_checks_assume_removals.rs
@@ -7,9 +7,6 @@
 // This test ensures that `assume(RuntimeChecks)`
 // is not emitted in MIR after SimplifyCfg.
 
-// CHECK-NOT: assume(RuntimeChecks)
-// CHECK-NOT: RuntimeChecks
-
 // EMIT_MIR_FOR_EACH ub_checks_assume_removals.test SimplifyCfg-final
 pub unsafe fn test(ptr: *const u8) -> u8 {
     ptr.read()

--- a/tests/mir-opt/ub_checks_assume_removals.rs
+++ b/tests/mir-opt/ub_checks_assume_removals.rs
@@ -1,0 +1,21 @@
+//@ test-mir-pass: SimplifyCfg-final
+//@ compile-flags: -Zmir-opt-level=1
+
+#![crate_type = "lib"]
+#![feature(core_intrinsics)]
+
+// This test ensures that `assume(RuntimeChecks)`
+// is not emitted in MIR after SimplifyCfg.
+
+// CHECK-NOT: assume(RuntimeChecks)
+// CHECK-NOT: RuntimeChecks
+
+// EMIT_MIR_FOR_EACH ub_checks_assume_removals.test SimplifyCfg-final
+pub unsafe fn test(ptr: *const u8) -> u8 {
+    ptr.read()
+}
+
+// EMIT_MIR_FOR_EACH ub_checks_assume_removals.with_unchecked SimplifyCfg-final
+pub unsafe fn with_unchecked(x: i32, y: i32) -> i32 {
+    x.unchecked_add(y)
+}


### PR DESCRIPTION
<!-- homu-ignore:start -->
Fixes rust-lang/rust#150242

Hi 

While looking into this, I noticed that after SimplifyCfg runs we still end up with some assume(RuntimeChecks) statements in MIR.

At that point these checks are already effectively fixed, so keeping the assume doesn’t really help anything and just adds unwanted things. Since the control flow is already simplified and dead blocks are removed, the assume never provides additional information.

This PR removes those leftover assume(RuntimeChecks) statements after SimplifyCfg finishes.

I also added a small MIR opt test to make sure the assume doesn’t show up after SimplifyCfg final, so we don’t do on this later.

All existing tests pass, and the new test passes also pass.

Let me know if you would like this to be handled in a different pass or adjusted further.
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
