### PR TITLE
fix(bootstrap/dist)!: change dist path for `rustc-docs` to avoid clashing

### DIFF
--- a/src/bootstrap/src/core/build_steps/dist.rs
+++ b/src/bootstrap/src/core/build_steps/dist.rs
@@ -181,7 +181,7 @@ impl Step for RustcDocs {
 
         let mut tarball = Tarball::new(builder, "rustc-docs", &target.triple);
         tarball.set_product_name("Rustc Documentation");
-        tarball.add_bulk_dir(builder.compiler_doc_out(target), "share/doc/rust/html/rustc");
+        tarball.add_bulk_dir(builder.compiler_doc_out(target), "share/doc/rust/html/rustc-docs");
         tarball.generate()
     }
 }


### PR DESCRIPTION
Closes rust-lang/rust#75833, part of https://github.com/rust-lang/rustup/issues/3717:

> I'd like to know if we can assign another folder name to `rustc-docs`?
> [...]
> [@ThePuzzlemaker](https://github.com/ThePuzzlemaker)'s `share/doc/rust/html/nightly-rustc` does look a bit weird to me (`nightly-rustc` has nothing to do with the current `rustc`, i.e. the Rustc Book, but they somehow appear similar just looking at the names).
> 
> I personally would like to see something like `share/doc/rust/html/rustc-docs` or `share/doc/rust/html/rustc-api` for this component.
_https://github.com/rust-lang/rust/issues/75833#issuecomment-2002503223_

The TLDR is that currently the "rustc book"'s path clashes with "rustc APIs" (i.e. `rustc-docs`), so we change the path of the latter to make it distributable via rustup.

I'm new to `bootstrap` so please feel free to point out any inconsistencies or any extra work I'll need to do to fully land this somewhat breaking change.