### PR TITLE
std: Use `usleep` temporarily on WASI targets

### DIFF
--- a/library/std/src/sys/thread/unix.rs
+++ b/library/std/src/sys/thread/unix.rs
@@ -520,7 +520,7 @@ pub fn set_name(name: &CStr) {
     debug_assert_eq!(res, libc::OK);
 }
 
-#[cfg(not(target_os = "espidf"))]
+#[cfg(not(any(target_os = "espidf", target_os = "wasi")))]
 pub fn sleep(dur: Duration) {
     let mut secs = dur.as_secs();
     let mut nsecs = dur.subsec_nanos() as _;
@@ -546,7 +546,13 @@ pub fn sleep(dur: Duration) {
     }
 }
 
-#[cfg(target_os = "espidf")]
+#[cfg(any(
+    target_os = "espidf",
+    // wasi-libc prior to WebAssembly/wasi-libc#696 has a broken implementation
+    // of `nanosleep`, used above by most platforms, so use `usleep` until
+    // that fix propagates throughout the ecosystem.
+    target_os = "wasi",
+))]
 pub fn sleep(dur: Duration) {
     // ESP-IDF does not have `nanosleep`, so we use `usleep` instead.
     // As per the documentation of `usleep`, it is expected to support


### PR DESCRIPTION
This fixes some fallout from rust-lang/rust#147572 where the `thread::sleep` function is is broken on `wasm32-wasip2` after that PR. The cause for this is a broken implementation of `nanosleep` in wasi-libc itself which is being fixed in WebAssembly/wasi-libc#696. Similar to rust-lang/rust#149864 this avoids the problematic function for now while the wasi-libc changes take some time to propagate into a wasi-sdk release.

Closes rust-lang/rust#150290
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
