### PR TITLE
Fix compilation error in hermit-abi time.rs

### DIFF
--- a/library/std/src/sys/pal/hermit/time.rs
+++ b/library/std/src/sys/pal/hermit/time.rs
@@ -213,9 +213,9 @@ pub struct SystemTime(Timespec);
 pub const UNIX_EPOCH: SystemTime = SystemTime(Timespec::zero());
 
 impl SystemTime {
-    pub const MAX: SystemTime = SystemTime { t: Timespec::MAX };
+    pub const MAX: SystemTime = SystemTime(Timespec::MAX);
 
-    pub const MIN: SystemTime = SystemTime { t: Timespec::MIN };
+    pub const MIN: SystemTime = SystemTime(Timespec::MIN);
 
     pub fn new(tv_sec: i64, tv_nsec: i32) -> SystemTime {
         SystemTime(Timespec::new(tv_sec, tv_nsec))


### PR DESCRIPTION
Fixes time.rs by updating the MIN and MAX structs appropraitely.

Fixes rust-lang/rust#150294

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
