### PR TITLE
std: remove unsupported pipe module from VEXos pal

### DIFF
--- a/library/std/src/sys/pal/vexos/mod.rs
+++ b/library/std/src/sys/pal/vexos/mod.rs
@@ -1,6 +1,4 @@
 pub mod os;
-#[path = "../unsupported/pipe.rs"]
-pub mod pipe;
 pub mod time;
 
 #[expect(dead_code)]


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
rust-lang/rust#146794 moved `pipe` implementations out of PAL and into a toplevel `sys` module. While most targets supporting libstd were updated, the PR did not remove the old module from the `vexos` PAL, causing builds to fail on the `armv7a-vex-v5` target.

<img width="2258" height="322" alt="image" src="https://github.com/user-attachments/assets/3bdb83f9-e577-4795-9d20-0ae4ab5d505c" />

This PR removes the old module path in the PAL and allows `vexos` targets to fall back to the `unsupported` implementation in sys/pipe.