### PR TITLE
`target_features::Stability`: tweak docs of `requires_nightly()`

### DIFF
--- a/compiler/rustc_target/src/target_features.rs
+++ b/compiler/rustc_target/src/target_features.rs
@@ -62,8 +62,8 @@ impl Stability {
     /// the feature gate to actually be enabled when using a nightly compiler.)
     ///
     /// Before calling this, ensure the feature is even permitted for this use:
-    /// - for `#[target_feature]`/`-Ctarget-feature`, check `allow_toggle()`
-    /// - for `cfg(target_feature)`, check `in_cfg`
+    /// - for `#[target_feature]`/`-Ctarget-feature`, check `toggle_allowed()`
+    /// - for `cfg(target_feature)`, check `in_cfg()`
     pub fn requires_nightly(&self) -> Option<Symbol> {
         match *self {
             Stability::Unstable(nightly_feature) => Some(nightly_feature),


### PR DESCRIPTION
* No method named `allow_toggle()` exists on the type, but based on the documentation of both `requires_nightly()` and `toggle_allowed()` it seems that `toggle_allowed()` is the intended method to mention.

* Add `()` to the mention of `in_cfg()` to make it clear that a method is being referred to, and to match the presence of `()` in the mention of `toggle_allowed()`.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
