### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/library/std/src/sys/pal/hermit/time.rs
+++ b/library/std/src/sys/pal/hermit/time.rs
@@ -213,9 +213,9 @@ pub struct SystemTime(Timespec);
 pub const UNIX_EPOCH: SystemTime = SystemTime(Timespec::zero());
 
 impl SystemTime {
-    pub const MAX: SystemTime = SystemTime { t: Timespec::MAX };
+    pub const MAX: SystemTime = SystemTime(Timespec::MAX);
 
-    pub const MIN: SystemTime = SystemTime { t: Timespec::MIN };
+    pub const MIN: SystemTime = SystemTime(Timespec::MIN);
 
     pub fn new(tv_sec: i64, tv_nsec: i32) -> SystemTime {
         SystemTime(Timespec::new(tv_sec, tv_nsec))

--- a/library/std/src/sys/pal/vexos/mod.rs
+++ b/library/std/src/sys/pal/vexos/mod.rs
@@ -1,6 +1,4 @@
 pub mod os;
-#[path = "../unsupported/pipe.rs"]
-pub mod pipe;
 pub mod time;
 
 #[expect(dead_code)]

--- a/src/tools/compiletest/src/directives.rs
+++ b/src/tools/compiletest/src/directives.rs
@@ -29,6 +29,8 @@ mod directive_names;
 mod file;
 mod handlers;
 mod line;
+mod line_number;
+pub(crate) use line_number::LineNumber;
 mod needs;
 #[cfg(test)]
 mod tests;
@@ -591,7 +593,7 @@ fn iter_directives(
         ];
         // Process the extra implied directives, with a dummy line number of 0.
         for directive_str in extra_directives {
-            let directive_line = line_directive(testfile, 0, directive_str)
+            let directive_line = line_directive(testfile, LineNumber::ZERO, directive_str)
                 .unwrap_or_else(|| panic!("bad extra-directive line: {directive_str:?}"));
             it(&directive_line);
         }

--- a/src/tools/compiletest/src/directives/file.rs
+++ b/src/tools/compiletest/src/directives/file.rs
@@ -1,5 +1,6 @@
 use camino::Utf8Path;
 
+use crate::directives::LineNumber;
 use crate::directives::line::{DirectiveLine, line_directive};
 
 pub(crate) struct FileDirectives<'a> {
@@ -11,7 +12,7 @@ impl<'a> FileDirectives<'a> {
     pub(crate) fn from_file_contents(path: &'a Utf8Path, file_contents: &'a str) -> Self {
         let mut lines = vec![];
 
-        for (line_number, ln) in (1..).zip(file_contents.lines()) {
+        for (line_number, ln) in LineNumber::enumerate().zip(file_contents.lines()) {
             let ln = ln.trim();
 
             if let Some(directive_line) = line_directive(path, line_number, ln) {

--- a/src/tools/compiletest/src/directives/line.rs
+++ b/src/tools/compiletest/src/directives/line.rs
@@ -2,13 +2,15 @@ use std::fmt;
 
 use camino::Utf8Path;
 
+use crate::directives::LineNumber;
+
 const COMPILETEST_DIRECTIVE_PREFIX: &str = "//@";
 
 /// If the given line begins with the appropriate comment prefix for a directive,
 /// returns a struct containing various parts of the directive.
 pub(crate) fn line_directive<'a>(
     file_path: &'a Utf8Path,
-    line_number: usize,
+    line_number: LineNumber,
     original_line: &'a str,
 ) -> Option<DirectiveLine<'a>> {
     // Ignore lines that don't start with the comment prefix.
@@ -60,7 +62,7 @@ pub(crate) struct DirectiveLine<'a> {
     /// Mostly used for diagnostics, but some directives (e.g. `//@ pp-exact`)
     /// also use it to compute a value based on the filename.
     pub(crate) file_path: &'a Utf8Path,
-    pub(crate) line_number: usize,
+    pub(crate) line_number: LineNumber,
 
     /// Some test directives start with a revision name in square brackets
     /// (e.g. `[foo]`), and only apply to that revision of the test.

--- a/src/tools/compiletest/src/directives/line_number.rs
+++ b/src/tools/compiletest/src/directives/line_number.rs
@@ -1,0 +1,21 @@
+/// A line number in a file. Internally the first line has index 1.
+/// If it is 0 it means "no specific line" (used e.g. for implied directives).
+/// When `Display`:ed, the first line is `1`.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct LineNumber(usize);
+
+impl LineNumber {
+    /// This represents "no specific line" (used e.g. for implied directives).
+    pub(crate) const ZERO: Self = Self(0);
+
+    /// A never ending iterator over line numbers starting from the first line.
+    pub(crate) fn enumerate() -> impl Iterator<Item = LineNumber> {
+        (1..).map(LineNumber)
+    }
+}
+
+impl std::fmt::Display for LineNumber {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}

--- a/src/tools/compiletest/src/directives/tests.rs
+++ b/src/tools/compiletest/src/directives/tests.rs
@@ -6,8 +6,8 @@ use semver::Version;
 use crate::common::{Config, Debugger, TestMode};
 use crate::directives::{
     self, AuxProps, DIRECTIVE_HANDLERS_MAP, DirectivesCache, EarlyProps, Edition, EditionRange,
-    FileDirectives, KNOWN_DIRECTIVE_NAMES_SET, extract_llvm_version, extract_version_range,
-    line_directive, parse_edition, parse_normalize_rule,
+    FileDirectives, KNOWN_DIRECTIVE_NAMES_SET, LineNumber, extract_llvm_version,
+    extract_version_range, line_directive, parse_edition, parse_normalize_rule,
 };
 use crate::executor::{CollectedTestDesc, ShouldFail};
 
@@ -1000,7 +1000,8 @@ fn parse_edition_range(line: &str) -> Option<EditionRange> {
     let config = cfg().build();
 
     let line_with_comment = format!("//@ {line}");
-    let line = line_directive(Utf8Path::new("tmp.rs"), 0, &line_with_comment).unwrap();
+    let line =
+        line_directive(Utf8Path::new("tmp.rs"), LineNumber::ZERO, &line_with_comment).unwrap();
 
     super::parse_edition_range(&config, &line)
 }


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#150205 (compiletest: Add `LineNumber` newtype to avoid `+1` magic here and there)
 - rust-lang/rust#150295 (Fix compilation error in hermit-abi time.rs)
 - rust-lang/rust#150301 (std: remove unsupported pipe module from VEXos pal)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=150205,150295,150301)
<!-- homu-ignore:end -->