### PR TITLE
Update bors configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ on:
       - try
       - try-perf
       - automation/bors/try
+      - automation/bors/auto
   pull_request:
     branches:
       - "**"
@@ -56,7 +57,7 @@ jobs:
       - name: Test citool
         # Only test citool on the auto branch, to reduce latency of the calculate matrix job
         # on PR/try builds.
-        if: ${{ github.ref == 'refs/heads/auto' }}
+        if: ${{ github.ref == 'refs/heads/auto' || github.ref == 'refs/heads/automation/bors/auto' }}
         run: |
           cd src/ci/citool
           CARGO_INCREMENTAL=0 cargo test
@@ -79,7 +80,7 @@ jobs:
     # access the environment.
     #
     # We only enable the environment for the rust-lang/rust repository, so that CI works on forks.
-    environment: ${{ ((github.repository == 'rust-lang/rust' && (github.ref == 'refs/heads/try' || github.ref == 'refs/heads/try-perf' || github.ref == 'refs/heads/automation/bors/try' || github.ref == 'refs/heads/auto')) && 'bors') || '' }}
+    environment: ${{ ((github.repository == 'rust-lang/rust' && (github.ref == 'refs/heads/try' || github.ref == 'refs/heads/try-perf' || github.ref == 'refs/heads/automation/bors/try' || github.ref == 'refs/heads/auto' || github.ref == 'refs/heads/automation/bors/auto')) && 'bors') || '' }}
     env:
       CI_JOB_NAME: ${{ matrix.name }}
       CI_JOB_DOC_URL: ${{ matrix.doc_url }}
@@ -313,7 +314,7 @@ jobs:
     needs: [ calculate_matrix, job ]
     # !cancelled() executes the job regardless of whether the previous jobs passed or failed
     if: ${{ !cancelled() && contains(fromJSON('["auto", "try"]'), needs.calculate_matrix.outputs.run_type) }}
-    environment: ${{ ((github.repository == 'rust-lang/rust' && (github.ref == 'refs/heads/try' || github.ref == 'refs/heads/try-perf' || github.ref == 'refs/heads/automation/bors/try' || github.ref == 'refs/heads/auto')) && 'bors') || '' }}
+    environment: ${{ ((github.repository == 'rust-lang/rust' && (github.ref == 'refs/heads/try' || github.ref == 'refs/heads/try-perf' || github.ref == 'refs/heads/automation/bors/try' || github.ref == 'refs/heads/auto' || github.ref == 'refs/heads/automation/bors/auto')) && 'bors') || '' }}
     steps:
       - name: checkout the source code
         uses: actions/checkout@v5

--- a/rust-bors.toml
+++ b/rust-bors.toml
@@ -25,3 +25,42 @@ labels_blocking_approval = [
     "S-waiting-on-t-rustdoc-frontend",
     "S-waiting-on-t-clippy"
 ]
+
+# If CI runs quicker than this duration, consider it to be a failure
+min_ci_time = 600
+
+[labels]
+approved = [
+    "+S-waiting-on-bors",
+    "-S-blocked",
+    "-S-waiting-on-author",
+    "-S-waiting-on-crater",
+    "-S-waiting-on-review",
+    "-S-waiting-on-team"
+]
+unapproved = [
+    "+S-waiting-on-author",
+    "-S-blocked",
+    "-S-waiting-on-bors",
+    "-S-waiting-on-crater",
+    "-S-waiting-on-review",
+    "-S-waiting-on-team"
+]
+try_failed = [
+    "+S-waiting-on-author",
+    "-S-waiting-on-review",
+    "-S-waiting-on-crater"
+]
+auto_build_succeeded = ["+merged-by-bors"]
+auto_build_failed = [
+    "+S-waiting-on-review",
+    "-S-blocked",
+    "-S-waiting-on-bors",
+    "-S-waiting-on-author",
+    "-S-waiting-on-crater",
+    "-S-waiting-on-team"
+]
+
+# Flip this two once new bors is used for actual merges on this repository
+merge_queue_enabled = false
+report_merge_conflicts = true

--- a/src/ci/citool/src/main.rs
+++ b/src/ci/citool/src/main.rs
@@ -46,7 +46,9 @@ impl GitHubContext {
                 let patterns = if !patterns.is_empty() { Some(patterns) } else { None };
                 Some(RunType::TryJob { job_patterns: patterns })
             }
-            ("push", "refs/heads/auto") => Some(RunType::AutoJob),
+            ("push", "refs/heads/auto" | "refs/heads/automation/bors/auto") => {
+                Some(RunType::AutoJob)
+            }
             ("push", "refs/heads/main") => Some(RunType::MainJob),
             _ => None,
         }


### PR DESCRIPTION
Updates the configuration of bors to bring it up to speed with homu, in preparation for https://github.com/rust-lang/infra-team/issues/168. Mirrors configuration from homu's [configuration file](https://github.com/rust-lang/homu/blob/master/cfg.production.toml#L46).

This PR also enables reporting of merge conflicts, so that we can test this part of bors on `rust-lang/rust`. The merge conflict reports will be duplicated (until/unless we disable it in homu), but that hopefully shouldn't be such a big deal.

r? @marcoieni