### PR TITLE
Check `ConstArgHasType` goals even when not wfchecking

### DIFF
--- a/compiler/rustc_hir_analysis/src/check/check.rs
+++ b/compiler/rustc_hir_analysis/src/check/check.rs
@@ -36,7 +36,7 @@ use super::compare_impl_item::check_type_bounds;
 use super::*;
 use crate::check::wfcheck::{
     check_associated_item, check_trait_item, check_variances_for_type_defn, check_where_clauses,
-    enter_wf_checking_ctxt,
+    enter_wf_checking_ctxt, enter_wf_checking_ctxt_without_checking_global_bounds,
 };
 
 fn add_abi_diag_help<T: EmissionGuarantee>(abi: ExternAbi, diag: &mut Diag<'_, T>) {
@@ -937,10 +937,11 @@ pub(crate) fn check_item_type(tcx: TyCtxt<'_>, def_id: LocalDefId) -> Result<(),
             tcx.ensure_ok().type_of(def_id);
             tcx.ensure_ok().predicates_of(def_id);
             check_type_alias_type_params_are_used(tcx, def_id);
+
+            let ty = tcx.type_of(def_id).instantiate_identity();
+            let span = tcx.def_span(def_id);
             if tcx.type_alias_is_lazy(def_id) {
                 res = res.and(enter_wf_checking_ctxt(tcx, def_id, |wfcx| {
-                    let ty = tcx.type_of(def_id).instantiate_identity();
-                    let span = tcx.def_span(def_id);
                     let item_ty = wfcx.deeply_normalize(span, Some(WellFormedLoc::Ty(def_id)), ty);
                     wfcx.register_wf_obligation(
                         span,
@@ -951,6 +952,24 @@ pub(crate) fn check_item_type(tcx: TyCtxt<'_>, def_id: LocalDefId) -> Result<(),
                     Ok(())
                 }));
                 check_variances_for_type_defn(tcx, def_id);
+            } else {
+                res = res.and(enter_wf_checking_ctxt_without_checking_global_bounds(
+                    tcx,
+                    def_id,
+                    |wfcx| {
+                        // HACK: We sometimes incidentally check that const arguments
+                        // have the correct type as a side effect of the anon const
+                        // desugaring. To make this "consistent" for users we explicitly
+                        // check `ConstArgHasType` clauses so that const args that don't
+                        // go through an anon const still have their types checked.
+                        //
+                        // We use the unnormalized type as this mirrors the behaviour
+                        // that we previously would have had when all const arguments
+                        // were anon consts.
+                        wfcx.register_const_arg_has_type_obligations_from_wf(span, ty);
+                        Ok(())
+                    },
+                ));
             }
 
             // Only `Node::Item` and `Node::ForeignItem` still have HIR based

--- a/tests/ui/const-generics/check_const_arg_type_in_free_alias.eager.stderr
+++ b/tests/ui/const-generics/check_const_arg_type_in_free_alias.eager.stderr
@@ -1,0 +1,105 @@
+error: the constant `B` is not of type `usize`
+  --> $DIR/check_const_arg_type_in_free_alias.rs:15:1
+   |
+LL | type ArrLen<const B: bool> = [(); B];
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `usize`, found `bool`
+   |
+   = note: the length of array `[(); B]` must be type `usize`
+
+error: the constant `B` is not of type `usize`
+  --> $DIR/check_const_arg_type_in_free_alias.rs:19:1
+   |
+LL | type ConstArg<const B: bool> = Foo<B>;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `usize`, found `bool`
+   |
+note: required by a const generic parameter in `Foo`
+  --> $DIR/check_const_arg_type_in_free_alias.rs:13:12
+   |
+LL | struct Foo<const N: usize>;
+   |            ^^^^^^^^^^^^^^ required by this const generic parameter in `Foo`
+
+error: the constant `B` is not of type `usize`
+  --> $DIR/check_const_arg_type_in_free_alias.rs:32:1
+   |
+LL | type Alias<const B: bool> = <() as IdentityWithUnused<B>>::This;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^ expected `usize`, found `bool`
+   |
+note: required by a const generic parameter in `IdentityWithUnused`
+  --> $DIR/check_const_arg_type_in_free_alias.rs:24:26
+   |
+LL | trait IdentityWithUnused<const N: usize> {
+   |                          ^^^^^^^^^^^^^^ required by this const generic parameter in `IdentityWithUnused`
+
+error: the constant `B` is not of type `usize`
+  --> $DIR/check_const_arg_type_in_free_alias.rs:38:1
+   |
+LL | type UseFree<const B: bool> = Free<B>;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `usize`, found `bool`
+   |
+   = note: the length of array `[(); B]` must be type `usize`
+
+error: the constant `B` is not of type `usize`
+  --> $DIR/check_const_arg_type_in_free_alias.rs:58:1
+   |
+LL | type IndirectArr<const B: bool> = Wrap<Wrap<[(); B]>>;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `usize`, found `bool`
+   |
+   = note: the length of array `[(); B]` must be type `usize`
+
+error: the constant `B` is not of type `usize`
+  --> $DIR/check_const_arg_type_in_free_alias.rs:62:1
+   |
+LL | type IndirectConstArg<const B: bool> = Wrap<Wrap<Foo<B>>>;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `usize`, found `bool`
+   |
+note: required by a const generic parameter in `Foo`
+  --> $DIR/check_const_arg_type_in_free_alias.rs:13:12
+   |
+LL | struct Foo<const N: usize>;
+   |            ^^^^^^^^^^^^^^ required by this const generic parameter in `Foo`
+
+error[E0308]: mismatched types
+  --> $DIR/check_const_arg_type_in_free_alias.rs:17:24
+   |
+LL | type AnonArrLen = [(); true];
+   |                        ^^^^ expected `usize`, found `bool`
+
+error[E0308]: mismatched types
+  --> $DIR/check_const_arg_type_in_free_alias.rs:21:25
+   |
+LL | type AnonConstArg = Foo<true>;
+   |                         ^^^^ expected `usize`, found `bool`
+
+error[E0308]: mismatched types
+  --> $DIR/check_const_arg_type_in_free_alias.rs:34:44
+   |
+LL | type AnonAlias = <() as IdentityWithUnused<true>>::This;
+   |                                            ^^^^ expected `usize`, found `bool`
+
+error[E0308]: mismatched types
+  --> $DIR/check_const_arg_type_in_free_alias.rs:40:25
+   |
+LL | type AnonUseFree = Free<true>;
+   |                         ^^^^ expected `usize`, found `bool`
+
+error[E0308]: mismatched types
+  --> $DIR/check_const_arg_type_in_free_alias.rs:53:45
+   |
+LL | type AnonUseFreeIndirectlyCorrect = UseFree<1_usize>;
+   |                                             ^^^^^^^ expected `bool`, found `usize`
+
+error[E0308]: mismatched types
+  --> $DIR/check_const_arg_type_in_free_alias.rs:60:39
+   |
+LL | type AnonIndirectArr = Wrap<Wrap<[(); true]>>;
+   |                                       ^^^^ expected `usize`, found `bool`
+
+error[E0308]: mismatched types
+  --> $DIR/check_const_arg_type_in_free_alias.rs:64:43
+   |
+LL | type AnonIndirectConstArg = Wrap<Wrap<Foo<true>>>;
+   |                                           ^^^^ expected `usize`, found `bool`
+
+error: aborting due to 13 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/const-generics/check_const_arg_type_in_free_alias.lazy.stderr
+++ b/tests/ui/const-generics/check_const_arg_type_in_free_alias.lazy.stderr
@@ -1,0 +1,123 @@
+error: the constant `B` is not of type `usize`
+  --> $DIR/check_const_arg_type_in_free_alias.rs:15:1
+   |
+LL | type ArrLen<const B: bool> = [(); B];
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `usize`, found `bool`
+   |
+   = note: the length of array `[(); B]` must be type `usize`
+
+error: the constant `B` is not of type `usize`
+  --> $DIR/check_const_arg_type_in_free_alias.rs:19:1
+   |
+LL | type ConstArg<const B: bool> = Foo<B>;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `usize`, found `bool`
+   |
+note: required by a const generic parameter in `Foo`
+  --> $DIR/check_const_arg_type_in_free_alias.rs:13:12
+   |
+LL | struct Foo<const N: usize>;
+   |            ^^^^^^^^^^^^^^ required by this const generic parameter in `Foo`
+
+error: the constant `B` is not of type `usize`
+  --> $DIR/check_const_arg_type_in_free_alias.rs:32:1
+   |
+LL | type Alias<const B: bool> = <() as IdentityWithUnused<B>>::This;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^ expected `usize`, found `bool`
+   |
+note: required for `()` to implement `IdentityWithUnused<B>`
+  --> $DIR/check_const_arg_type_in_free_alias.rs:28:25
+   |
+LL | impl<T, const N: usize> IdentityWithUnused<N> for T {
+   |         --------------  ^^^^^^^^^^^^^^^^^^^^^     ^
+   |         |
+   |         unsatisfied trait bound introduced here
+
+error: the constant `B` is not of type `usize`
+  --> $DIR/check_const_arg_type_in_free_alias.rs:38:1
+   |
+LL | type UseFree<const B: bool> = Free<B>;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `usize`, found `bool`
+   |
+note: required by a bound on the type alias `Free`
+  --> $DIR/check_const_arg_type_in_free_alias.rs:37:11
+   |
+LL | type Free<const N: usize> = [(); N];
+   |           ^^^^^^^^^^^^^^ required by this bound
+
+error: the constant `N` is not of type `bool`
+  --> $DIR/check_const_arg_type_in_free_alias.rs:51:1
+   |
+LL | type UseFreeIndirectlyCorrect<const N: usize> = UseFree<N>;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `bool`, found `usize`
+   |
+note: required by a bound on the type alias `UseFree`
+  --> $DIR/check_const_arg_type_in_free_alias.rs:38:14
+   |
+LL | type UseFree<const B: bool> = Free<B>;
+   |              ^^^^^^^^^^^^^ required by this bound
+
+error: the constant `B` is not of type `usize`
+  --> $DIR/check_const_arg_type_in_free_alias.rs:58:1
+   |
+LL | type IndirectArr<const B: bool> = Wrap<Wrap<[(); B]>>;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `usize`, found `bool`
+   |
+   = note: the length of array `[(); B]` must be type `usize`
+
+error: the constant `B` is not of type `usize`
+  --> $DIR/check_const_arg_type_in_free_alias.rs:62:1
+   |
+LL | type IndirectConstArg<const B: bool> = Wrap<Wrap<Foo<B>>>;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `usize`, found `bool`
+   |
+note: required by a const generic parameter in `Foo`
+  --> $DIR/check_const_arg_type_in_free_alias.rs:13:12
+   |
+LL | struct Foo<const N: usize>;
+   |            ^^^^^^^^^^^^^^ required by this const generic parameter in `Foo`
+
+error[E0308]: mismatched types
+  --> $DIR/check_const_arg_type_in_free_alias.rs:17:24
+   |
+LL | type AnonArrLen = [(); true];
+   |                        ^^^^ expected `usize`, found `bool`
+
+error[E0308]: mismatched types
+  --> $DIR/check_const_arg_type_in_free_alias.rs:21:25
+   |
+LL | type AnonConstArg = Foo<true>;
+   |                         ^^^^ expected `usize`, found `bool`
+
+error[E0308]: mismatched types
+  --> $DIR/check_const_arg_type_in_free_alias.rs:34:44
+   |
+LL | type AnonAlias = <() as IdentityWithUnused<true>>::This;
+   |                                            ^^^^ expected `usize`, found `bool`
+
+error[E0308]: mismatched types
+  --> $DIR/check_const_arg_type_in_free_alias.rs:40:25
+   |
+LL | type AnonUseFree = Free<true>;
+   |                         ^^^^ expected `usize`, found `bool`
+
+error[E0308]: mismatched types
+  --> $DIR/check_const_arg_type_in_free_alias.rs:53:45
+   |
+LL | type AnonUseFreeIndirectlyCorrect = UseFree<1_usize>;
+   |                                             ^^^^^^^ expected `bool`, found `usize`
+
+error[E0308]: mismatched types
+  --> $DIR/check_const_arg_type_in_free_alias.rs:60:39
+   |
+LL | type AnonIndirectArr = Wrap<Wrap<[(); true]>>;
+   |                                       ^^^^ expected `usize`, found `bool`
+
+error[E0308]: mismatched types
+  --> $DIR/check_const_arg_type_in_free_alias.rs:64:43
+   |
+LL | type AnonIndirectConstArg = Wrap<Wrap<Foo<true>>>;
+   |                                           ^^^^ expected `usize`, found `bool`
+
+error: aborting due to 14 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/const-generics/check_const_arg_type_in_free_alias.rs
+++ b/tests/ui/const-generics/check_const_arg_type_in_free_alias.rs
@@ -1,0 +1,67 @@
+//@ revisions: eager lazy
+#![cfg_attr(lazy, feature(lazy_type_alias))]
+#![cfg_attr(lazy, expect(incomplete_features))]
+
+// We currently do not check free type aliases for well formedness.
+// However, previously we desugared all const arguments to anon
+// consts which resulted in us happening to check that they were
+// of the correct type. Nowadays we don't necessarily lower to a
+// const argument, but to continue erroring on such code we special
+// case `ConstArgHasType` clauses to be checked for free type aliases
+// even though we ignore the rest of the wf requirements.
+
+struct Foo<const N: usize>;
+
+type ArrLen<const B: bool> = [(); B];
+//~^ ERROR: the constant `B` is not of type
+type AnonArrLen = [(); true];
+//~^ ERROR: mismatched types
+type ConstArg<const B: bool> = Foo<B>;
+//~^ ERROR: the constant `B` is not of type
+type AnonConstArg = Foo<true>;
+//~^ ERROR: mismatched types
+
+trait IdentityWithUnused<const N: usize> {
+    type This;
+}
+
+impl<T, const N: usize> IdentityWithUnused<N> for T {
+    type This = T;
+}
+
+type Alias<const B: bool> = <() as IdentityWithUnused<B>>::This;
+//~^ ERROR: the constant `B` is not of type
+type AnonAlias = <() as IdentityWithUnused<true>>::This;
+//~^ ERROR: mismatched types
+
+type Free<const N: usize> = [(); N];
+type UseFree<const B: bool> = Free<B>;
+//~^ ERROR: the constant `B` is not of type
+type AnonUseFree = Free<true>;
+//~^ ERROR: mismatched types
+
+// This previously emitted an error before we stopped using
+// anon consts. Now, as free aliases don't exist after ty
+// lowering, we don't emit an error because we only see `N`
+// being used as an argument to an array length.
+//
+// Free type aliases are not allowed to have unused generic
+// parameters so this shouldn't be able to cause code to
+// pass that should error.
+type UseFreeIndirectlyCorrect<const N: usize> = UseFree<N>;
+//[lazy]~^ ERROR: the constant `N` is not of type
+type AnonUseFreeIndirectlyCorrect = UseFree<1_usize>;
+//~^ ERROR: mismatched types
+
+struct Wrap<T>(T);
+
+type IndirectArr<const B: bool> = Wrap<Wrap<[(); B]>>;
+//~^ ERROR: the constant `B` is not of type
+type AnonIndirectArr = Wrap<Wrap<[(); true]>>;
+//~^ ERROR: mismatched types
+type IndirectConstArg<const B: bool> = Wrap<Wrap<Foo<B>>>;
+//~^ ERROR: the constant `B` is not of type
+type AnonIndirectConstArg = Wrap<Wrap<Foo<true>>>;
+//~^ ERROR: mismatched types
+
+fn main() {}

--- a/tests/ui/const-generics/check_const_arg_type_in_trait_object.rs
+++ b/tests/ui/const-generics/check_const_arg_type_in_trait_object.rs
@@ -1,0 +1,34 @@
+// We currently do not check trait objects for well formedness.
+// However, previously we desugared all const arguments to anon
+// consts which resulted in us happening to check that they were
+// of the correct type. Nowadays we don't necessarily lower to a
+// const argument, but to continue erroring on such code we special
+// case `ConstArgHasType` clauses to be checked for trait objects
+// even though we ignore the rest of the wf requirements.
+
+trait Object<const N: usize> {}
+trait Object2<T> {}
+
+struct Wrap<T>(T);
+
+fn arg<
+    const B: bool,
+    const N: usize,
+>(
+    param: &dyn Object<B>,
+    //~^ ERROR: the constant `B` is not of type
+    anon: &dyn Object<true>,
+    //~^ ERROR: mismatched types
+) {}
+
+fn indirect<
+    const B: bool,
+    const N: usize,
+>(
+    param: &dyn Object2<Wrap<[(); B]>>,
+    //~^ ERROR: the constant `B` is not of type
+    anon: &dyn Object2<Wrap<[(); true]>>,
+    //~^ ERROR: mismatched types
+) {}
+
+fn main() {}

--- a/tests/ui/const-generics/check_const_arg_type_in_trait_object.stderr
+++ b/tests/ui/const-generics/check_const_arg_type_in_trait_object.stderr
@@ -1,0 +1,35 @@
+error: the constant `B` is not of type `usize`
+  --> $DIR/check_const_arg_type_in_trait_object.rs:18:12
+   |
+LL |     param: &dyn Object<B>,
+   |            ^^^^^^^^^^^^^^ expected `usize`, found `bool`
+   |
+note: required by a const generic parameter in `Object`
+  --> $DIR/check_const_arg_type_in_trait_object.rs:9:14
+   |
+LL | trait Object<const N: usize> {}
+   |              ^^^^^^^^^^^^^^ required by this const generic parameter in `Object`
+
+error: the constant `B` is not of type `usize`
+  --> $DIR/check_const_arg_type_in_trait_object.rs:28:12
+   |
+LL |     param: &dyn Object2<Wrap<[(); B]>>,
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `usize`, found `bool`
+   |
+   = note: the length of array `[(); B]` must be type `usize`
+
+error[E0308]: mismatched types
+  --> $DIR/check_const_arg_type_in_trait_object.rs:20:23
+   |
+LL |     anon: &dyn Object<true>,
+   |                       ^^^^ expected `usize`, found `bool`
+
+error[E0308]: mismatched types
+  --> $DIR/check_const_arg_type_in_trait_object.rs:30:34
+   |
+LL |     anon: &dyn Object2<Wrap<[(); true]>>,
+   |                                  ^^^^ expected `usize`, found `bool`
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/150322)*

Fixes rust-lang/rust#149774

r? types