### PR TITLE
`cstyle-export-rules`: export global symbols from upstream static libraries

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/linker.rs
+++ b/compiler/rustc_codegen_ssa/src/back/linker.rs
@@ -846,15 +846,31 @@ impl<'a> Linker for GccLinker<'a> {
             // Write an LD version script
             let res: io::Result<()> = try {
                 let mut f = File::create_buffered(&path)?;
-                writeln!(f, "{{")?;
-                if !symbols.is_empty() {
-                    writeln!(f, "  global:")?;
-                    for (sym, _) in symbols {
-                        debug!("    {sym};");
-                        writeln!(f, "    {sym};")?;
+                if self.sess.opts.unstable_opts.cstyle_export_rules {
+                    writeln!(f, "{{")?;
+                    writeln!(f, "  global:\n    *;\n")?;
+                    if !symbols.is_empty() {
+                        writeln!(f, "  local:")?;
+                        // writeln!(f, "    _ZN*;")?;
+                        // writeln!(f, "    _R*;")?;
+                        for (sym, _) in symbols {
+                            debug!("    {sym};");
+                            writeln!(f, "    {sym};")?;
+                        }
                     }
+                    writeln!(f, "\n}};")?;
+                } else {
+                    writeln!(f, "{{")?;
+                    if !symbols.is_empty() {
+                        writeln!(f, "  global:")?;
+                        for (sym, _) in symbols {
+                            debug!("    {sym};");
+                            writeln!(f, "    {sym};")?;
+                        }
+                    }
+                    writeln!(f, "\n  local:\n    *;\n}};")?;
                 }
-                writeln!(f, "\n  local:\n    *;\n}};")?;
+                
             };
             if let Err(error) = res {
                 self.sess.dcx().emit_fatal(errors::VersionScriptWriteFailure { error });
@@ -1810,6 +1826,38 @@ pub(crate) fn exported_symbols(
     } else {
         exported_symbols_for_non_proc_macro(tcx, crate_type)
     }
+}
+
+pub(crate) fn exported_symbols_cstyle(
+    tcx: TyCtxt<'_>,
+    crate_type: CrateType,
+) -> Vec<(String, SymbolExportKind)> {
+    if let Some(ref exports) = tcx.sess.target.override_export_symbols {
+        return exports
+            .iter()
+            .map(|name| {
+                (
+                    name.to_string(),
+                    // FIXME use the correct export kind for this symbol. override_export_symbols
+                    // can't directly specify the SymbolExportKind as it is defined in rustc_middle
+                    // which rustc_target can't depend on.
+                    SymbolExportKind::Text,
+                )
+            })
+            .collect();
+    }
+
+    let mut symbols = Vec::new();
+    let export_threshold = symbol_export::crates_export_threshold(&[crate_type]);
+    for_each_exported_symbols_include_dep(tcx, crate_type, |symbol, info, cnum| {
+        if !info.level.is_below_threshold(export_threshold) && !tcx.is_compiler_builtins(cnum) {
+            symbols.push((
+                symbol_export::exporting_symbol_name_for_instance_in_crate(tcx, symbol, cnum),
+                info.kind,
+            ));
+        }
+    });
+    symbols
 }
 
 fn exported_symbols_for_non_proc_macro(

--- a/compiler/rustc_codegen_ssa/src/base.rs
+++ b/compiler/rustc_codegen_ssa/src/base.rs
@@ -876,7 +876,11 @@ impl CrateInfo {
         let crate_types = tcx.crate_types().to_vec();
         let exported_symbols = crate_types
             .iter()
-            .map(|&c| (c, crate::back::linker::exported_symbols(tcx, c)))
+            .map(|&c| (c, if tcx.sess.opts.unstable_opts.cstyle_export_rules {
+                crate::back::linker::exported_symbols_cstyle(tcx, c)
+            } else {
+                crate::back::linker::exported_symbols(tcx, c)
+            }))
             .collect();
         let linked_symbols =
             crate_types.iter().map(|&c| (c, crate::back::linker::linked_symbols(tcx, c))).collect();

--- a/compiler/rustc_interface/src/tests.rs
+++ b/compiler/rustc_interface/src/tests.rs
@@ -784,6 +784,7 @@ fn test_unstable_options_tracking_hash() {
     );
     tracked!(crate_attr, vec!["abc".to_string()]);
     tracked!(cross_crate_inline_threshold, InliningThreshold::Always);
+    tracked!(cstyle_export_rules, true);
     tracked!(debug_info_for_profiling, true);
     tracked!(debug_info_type_line_numbers, true);
     tracked!(default_visibility, Some(rustc_target::spec::SymbolVisibility::Hidden));

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -2176,6 +2176,8 @@ options! {
         "inject the given attribute in the crate"),
     cross_crate_inline_threshold: InliningThreshold = (InliningThreshold::Sometimes(100), parse_inlining_threshold, [TRACKED],
         "threshold to allow cross crate inlining of functions"),
+    cstyle_export_rules: bool = (false, parse_bool, [TRACKED],
+        "global symbols from upstream static libraries will be exported by default"),
     debug_info_for_profiling: bool = (false, parse_bool, [TRACKED],
         "emit discriminators and other data necessary for AutoFDO"),
     debug_info_type_line_numbers: bool = (false, parse_bool, [TRACKED],

--- a/src/doc/unstable-book/src/compiler-flags/cstyle-export-rules.md
+++ b/src/doc/unstable-book/src/compiler-flags/cstyle-export-rules.md
@@ -1,0 +1,3 @@
+# `cstyle-export-rules`
+
+This option forces rustc to export the `global` symbol from the upstream C static library.


### PR DESCRIPTION
This is a demo I wrote based on an idea from [this Zulip thread](https://rust-lang.zulipchat.com/#narrow/channel/182449-t-compiler.2Fhelp/topic/Export.20global.20symbols.20from.20upstream.20static.20library), and it's currently in a very early stage (it doesn't yet limit unsupported platforms or consider LTO).

I wrote a test to check the effect of enabling this option. First, I wrote an upstream C static library and compiled it into an object file.

```C
int c_add(int a, int b) {
    return a + b;
}

int c_sub(int a, int b) {
    return a - b;
}
```

Then I created a `cdylib` project downstream.

`Cargo.toml`
```rust
[package]
name = "downstream-cdylib"
version = "0.1.0"
edition = "2021"

[lib]
crate-type = ["cdylib"]
```

`src/lib.rs`
```rust
extern "C" {
    fn c_add(a: i32, b: i32) -> i32;
}

#[no_mangle]
pub extern "C" fn downstream_add(a: i32, b: i32) -> i32 {
    unsafe { c_add(a, b) }
}
```

Then I tested by enabling and disabling `cstyle-export-rules` in the following two toolchains, and checked their symbol tables and the size of the generated .so files.
`default`:
```bash
rustc 1.85.0 (4d91de4e4 2025-02-17)
binary: rustc
commit-hash: 4d91de4e48198da2e33413efdcd9cd2cc0c46688
commit-date: 2025-02-17
host: x86_64-unknown-linux-gnu
release: 1.85.0
LLVM version: 19.1.7
```
`+c-e-r`
```bash
rustc 1.91.0-nightly (383b9c447 2025-08-03)
binary: rustc
commit-hash: 383b9c447b61641e1f1a3850253944a897a60827
commit-date: 2025-08-03
host: x86_64-unknown-linux-gnu
release: 1.91.0-nightly
LLVM version: 20.1.8
```
Here are the results:
1. `RUSTFLAGS="-Z cstyle-export-rules" cargo +c-e-r rustc --release -- -C link-arg=c_add.o`
`size`: 451KB
```bash
                 U abort@GLIBC_2.2.5
                 U bcmp@GLIBC_2.2.5
00000000000520ad T c_add
                 U calloc@GLIBC_2.2.5
                 U close@GLIBC_2.2.5
00000000000520c5 T c_sub
                 w __cxa_finalize@GLIBC_2.2.5
                 w __cxa_thread_atexit_impl@GLIBC_2.18
                 U dl_iterate_phdr@GLIBC_2.2.5
0000000000015160 T downstream_add
                 U __errno_location@GLIBC_2.2.5
                 U free@GLIBC_2.2.5
                 U fstat64@GLIBC_2.33
                 U getcwd@GLIBC_2.2.5
                 U getenv@GLIBC_2.2.5
                 w __gmon_start__
                 w _ITM_deregisterTMCloneTable
                 w _ITM_registerTMCloneTable
                 U lseek64@GLIBC_2.2.5
                 U malloc@GLIBC_2.2.5
                 U memcpy@GLIBC_2.14
                 U memmove@GLIBC_2.2.5
                 U memset@GLIBC_2.2.5
                 U mmap64@GLIBC_2.2.5
                 U munmap@GLIBC_2.2.5
                 U open64@GLIBC_2.2.5
                 U posix_memalign@GLIBC_2.2.5
                 U pthread_key_create@GLIBC_2.34
                 U pthread_key_delete@GLIBC_2.34
                 U pthread_setspecific@GLIBC_2.34
                 U read@GLIBC_2.2.5
                 U readlink@GLIBC_2.2.5
                 U realloc@GLIBC_2.2.5
                 U realpath@GLIBC_2.3
0000000000052074 T _RNvCs6OckbHhR1MK_7___rustc17___rust_probestack
                 U stat64@GLIBC_2.33
                 w statx@GLIBC_2.28
                 U strlen@GLIBC_2.2.5
                 U syscall@GLIBC_2.2.5
                 U __tls_get_addr@GLIBC_2.3
                 U _Unwind_Backtrace@GCC_3.3
                 U _Unwind_DeleteException@GCC_3.0
                 U _Unwind_GetDataRelBase@GCC_3.0
                 U _Unwind_GetIP@GCC_3.0
                 U _Unwind_GetIPInfo@GCC_4.2.0
                 U _Unwind_GetLanguageSpecificData@GCC_3.0
                 U _Unwind_GetRegionStart@GCC_3.0
                 U _Unwind_GetTextRelBase@GCC_3.0
                 U _Unwind_RaiseException@GCC_3.0
                 U _Unwind_Resume@GCC_3.0
                 U _Unwind_SetGR@GCC_3.0
                 U _Unwind_SetIP@GCC_3.0
                 U write@GLIBC_2.2.5
                 U writev@GLIBC_2.2.5
0000000000044bcc T _ZN119_$LT$core..iter..adapters..copied..Copied$LT$I$GT$$u20$as$u20$core..iter..traits..double_ended..DoubleEndedIterator$GT$9try_rfold17h00588b6766da7b19E
000000000001a800 T _ZN3std3sys9backtrace26__rust_end_short_backtrace17h9a45a5fa40018bf0E
00000000000414a0 T _ZN4core5slice4sort8unstable7ipnsort17hd24504d702ce9a58E
0000000000041590 T _ZN4core5slice4sort8unstable8heapsort8heapsort17h5983f0d9c6b77eb4E
```
2. `cargo +c-e-r rustc --release -- -C link-arg=c_add.o`
`size`: 450KB
```bash
                 U abort@GLIBC_2.2.5
                 U bcmp@GLIBC_2.2.5
                 U calloc@GLIBC_2.2.5
                 U close@GLIBC_2.2.5
                 w __cxa_finalize@GLIBC_2.2.5
                 w __cxa_thread_atexit_impl@GLIBC_2.18
                 U dl_iterate_phdr@GLIBC_2.2.5
0000000000014ea0 T downstream_add
                 U __errno_location@GLIBC_2.2.5
                 U free@GLIBC_2.2.5
                 U fstat64@GLIBC_2.33
                 U getcwd@GLIBC_2.2.5
                 U getenv@GLIBC_2.2.5
                 w __gmon_start__
                 w _ITM_deregisterTMCloneTable
                 w _ITM_registerTMCloneTable
                 U lseek64@GLIBC_2.2.5
                 U malloc@GLIBC_2.2.5
                 U memcpy@GLIBC_2.14
                 U memmove@GLIBC_2.2.5
                 U memset@GLIBC_2.2.5
                 U mmap64@GLIBC_2.2.5
                 U munmap@GLIBC_2.2.5
                 U open64@GLIBC_2.2.5
                 U posix_memalign@GLIBC_2.2.5
                 U pthread_key_create@GLIBC_2.34
                 U pthread_key_delete@GLIBC_2.34
                 U pthread_setspecific@GLIBC_2.34
                 U read@GLIBC_2.2.5
                 U readlink@GLIBC_2.2.5
                 U realloc@GLIBC_2.2.5
                 U realpath@GLIBC_2.3
                 U stat64@GLIBC_2.33
                 w statx@GLIBC_2.28
                 U strlen@GLIBC_2.2.5
                 U syscall@GLIBC_2.2.5
                 U __tls_get_addr@GLIBC_2.3
                 U _Unwind_Backtrace@GCC_3.3
                 U _Unwind_DeleteException@GCC_3.0
                 U _Unwind_GetDataRelBase@GCC_3.0
                 U _Unwind_GetIP@GCC_3.0
                 U _Unwind_GetIPInfo@GCC_4.2.0
                 U _Unwind_GetLanguageSpecificData@GCC_3.0
                 U _Unwind_GetRegionStart@GCC_3.0
                 U _Unwind_GetTextRelBase@GCC_3.0
                 U _Unwind_RaiseException@GCC_3.0
                 U _Unwind_Resume@GCC_3.0
                 U _Unwind_SetGR@GCC_3.0
                 U _Unwind_SetIP@GCC_3.0
                 U write@GLIBC_2.2.5
                 U writev@GLIBC_2.2.5
```
3. `cargo rustc --release -- -C link-arg=c_add.o`
`size`: 16KB
```bash
                 w __cxa_finalize@GLIBC_2.2.5
0000000000001100 T downstream_add
                 w __gmon_start__
                 w _ITM_deregisterTMCloneTable
                 w _ITM_registerTMCloneTable
```

It appears that the upstream `c_add` and `c_sub` were successfully exported, but many more symbols were exported, and the file size increased significantly. I'm not sure why this is happening.
    r? @bjorn3 

