### PR TITLE
Fix some divergences with the cg_clif subtree

### DIFF
--- a/compiler/rustc_codegen_cranelift/src/intrinsics/simd.rs
+++ b/compiler/rustc_codegen_cranelift/src/intrinsics/simd.rs
@@ -1005,14 +1005,6 @@ pub(super) fn codegen_simd_intrinsic_call<'tcx>(
             let lane_clif_ty = fx.clif_type(val_lane_ty).unwrap();
             let ret_lane_layout = fx.layout_of(ret_lane_ty);
 
-            let alignment =
-                generic_args[3].expect_const().to_branch()[0].to_leaf().to_simd_alignment();
-
-            let memflags = match alignment {
-                SimdAlign::Unaligned => MemFlags::new().with_notrap(),
-                _ => MemFlags::trusted(),
-            };
-
             for lane_idx in 0..ptr_lane_count {
                 let val_lane = val.value_lane(fx, lane_idx).load_scalar(fx);
                 let ptr_lane = ptr.value_lane(fx, lane_idx).load_scalar(fx);
@@ -1028,7 +1020,7 @@ pub(super) fn codegen_simd_intrinsic_call<'tcx>(
                 fx.bcx.seal_block(if_disabled);
 
                 fx.bcx.switch_to_block(if_enabled);
-                let res = fx.bcx.ins().load(lane_clif_ty, memflags, ptr_lane, 0);
+                let res = fx.bcx.ins().load(lane_clif_ty, MemFlags::trusted(), ptr_lane, 0);
                 fx.bcx.ins().jump(next, &[res.into()]);
 
                 fx.bcx.switch_to_block(if_disabled);


### PR DESCRIPTION
For some reason git-subtree incorrectly synced those changes.

r? @ghost

@rustbot label +A-codegen +A-cranelift +T-compiler