### PR TITLE
Recursive delegation improvements

### DIFF
--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -220,9 +220,8 @@ pub struct ResolverAstLowering {
 
     /// Information about functions signatures for delegation items expansion
     pub delegation_fn_sigs: LocalDefIdMap<DelegationFnSig>,
-    // NodeIds (either delegation.id or item_id in case of a trait impl) for signature resolution,
-    // for details see https://github.com/rust-lang/rust/issues/118212#issuecomment-2160686914
-    pub delegation_sig_resolution_nodes: LocalDefIdMap<ast::NodeId>,
+    // Information about delegations which is used when handling recursive delegations
+    pub delegation_infos: LocalDefIdMap<DelegationInfo>,
 }
 
 bitflags::bitflags! {
@@ -236,13 +235,26 @@ bitflags::bitflags! {
 pub const DELEGATION_INHERIT_ATTRS_START: DelegationFnSigAttrs = DelegationFnSigAttrs::MUST_USE;
 
 #[derive(Debug)]
+pub struct DelegationInfo {
+    // NodeId (either delegation.id or item_id in case of a trait impl) for signature resolution,
+    // for details see https://github.com/rust-lang/rust/issues/118212#issuecomment-2160686914
+    pub resolution_node: ast::NodeId,
+    pub attrs: DelegationAttrs,
+}
+
+#[derive(Debug)]
+pub struct DelegationAttrs {
+    pub flags: DelegationFnSigAttrs,
+    pub to_inherit: AttrVec,
+}
+
+#[derive(Debug)]
 pub struct DelegationFnSig {
     pub header: ast::FnHeader,
     pub param_count: usize,
     pub has_self: bool,
     pub c_variadic: bool,
-    pub attrs_flags: DelegationFnSigAttrs,
-    pub to_inherit_attrs: AttrVec,
+    pub attrs: DelegationAttrs,
 }
 
 #[derive(Clone, Copy, Debug, HashStable)]

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -29,7 +29,8 @@ use rustc_hir::def_id::{CRATE_DEF_ID, DefId, LOCAL_CRATE, LocalDefId};
 use rustc_hir::{MissingLifetimeKind, PrimTy, TraitCandidate};
 use rustc_middle::middle::resolve_bound_vars::Set1;
 use rustc_middle::ty::{
-    AssocTag, DELEGATION_INHERIT_ATTRS_START, DelegationFnSig, DelegationFnSigAttrs, Visibility,
+    AssocTag, DELEGATION_INHERIT_ATTRS_START, DelegationAttrs, DelegationFnSig,
+    DelegationFnSigAttrs, DelegationInfo, Visibility,
 };
 use rustc_middle::{bug, span_bug};
 use rustc_session::config::{CrateType, ResolveDocLinks};
@@ -2928,7 +2929,7 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
                     item.id,
                     LifetimeBinderKind::Function,
                     span,
-                    |this| this.resolve_delegation(delegation, item.id, false),
+                    |this| this.resolve_delegation(delegation, item.id, false, &item.attrs),
                 );
             }
 
@@ -3257,7 +3258,7 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
                         item.id,
                         LifetimeBinderKind::Function,
                         delegation.path.segments.last().unwrap().ident.span,
-                        |this| this.resolve_delegation(delegation, item.id, false),
+                        |this| this.resolve_delegation(delegation, item.id, false, &item.attrs),
                     );
                 }
                 AssocItemKind::Type(box TyAlias { generics, .. }) => self
@@ -3386,7 +3387,7 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
                                                 debug!("resolve_implementation with_self_rib_ns(ValueNS, ...)");
                                                 let mut seen_trait_items = Default::default();
                                                 for item in impl_items {
-                                                    this.resolve_impl_item(&**item, &mut seen_trait_items, trait_id);
+                                                    this.resolve_impl_item(&**item, &mut seen_trait_items, trait_id, of_trait.is_some());
                                                 }
                                             });
                                         });
@@ -3405,6 +3406,7 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
         item: &'ast AssocItem,
         seen_trait_items: &mut FxHashMap<DefId, Span>,
         trait_id: Option<DefId>,
+        is_in_trait_impl: bool,
     ) {
         use crate::ResolutionError::*;
         self.resolve_doc_links(&item.attrs, MaybeExported::ImplItem(trait_id.ok_or(&item.vis)));
@@ -3550,7 +3552,9 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
                             |i, s, c| MethodNotMemberOfTrait(i, s, c),
                         );
 
-                        this.resolve_delegation(delegation, item.id, trait_id.is_some());
+                        // Here we don't use `trait_id`, as we can process unresolved trait, however
+                        // in this case we are still in a trait impl, https://github.com/rust-lang/rust/issues/150152
+                        this.resolve_delegation(delegation, item.id, is_in_trait_impl, &item.attrs);
                     },
                 );
             }
@@ -3704,6 +3708,7 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
         delegation: &'ast Delegation,
         item_id: NodeId,
         is_in_trait_impl: bool,
+        attrs: &[Attribute],
     ) {
         self.smart_resolve_path(
             delegation.id,
@@ -3718,9 +3723,12 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
 
         self.visit_path(&delegation.path);
 
-        self.r.delegation_sig_resolution_nodes.insert(
+        self.r.delegation_infos.insert(
             self.r.local_def_id(item_id),
-            if is_in_trait_impl { item_id } else { delegation.id },
+            DelegationInfo {
+                attrs: create_delegation_attrs(attrs),
+                resolution_node: if is_in_trait_impl { item_id } else { delegation.id },
+            },
         );
 
         let Some(body) = &delegation.body else { return };
@@ -5334,39 +5342,43 @@ impl ItemInfoCollector<'_, '_, '_> {
         id: NodeId,
         attrs: &[Attribute],
     ) {
-        static NAMES_TO_FLAGS: &[(Symbol, DelegationFnSigAttrs)] = &[
-            (sym::target_feature, DelegationFnSigAttrs::TARGET_FEATURE),
-            (sym::must_use, DelegationFnSigAttrs::MUST_USE),
-        ];
+        self.r.delegation_fn_sigs.insert(
+            self.r.local_def_id(id),
+            DelegationFnSig {
+                header,
+                param_count: decl.inputs.len(),
+                has_self: decl.has_self(),
+                c_variadic: decl.c_variadic(),
+                attrs: create_delegation_attrs(attrs),
+            },
+        );
+    }
+}
 
-        let mut to_inherit_attrs = AttrVec::new();
-        let mut attrs_flags = DelegationFnSigAttrs::empty();
+fn create_delegation_attrs(attrs: &[Attribute]) -> DelegationAttrs {
+    static NAMES_TO_FLAGS: &[(Symbol, DelegationFnSigAttrs)] = &[
+        (sym::target_feature, DelegationFnSigAttrs::TARGET_FEATURE),
+        (sym::must_use, DelegationFnSigAttrs::MUST_USE),
+    ];
 
-        'attrs_loop: for attr in attrs {
-            for &(name, flag) in NAMES_TO_FLAGS {
-                if attr.has_name(name) {
-                    attrs_flags.set(flag, true);
+    let mut to_inherit_attrs = AttrVec::new();
+    let mut flags = DelegationFnSigAttrs::empty();
 
-                    if flag.bits() >= DELEGATION_INHERIT_ATTRS_START.bits() {
-                        to_inherit_attrs.push(attr.clone());
-                    }
+    'attrs_loop: for attr in attrs {
+        for &(name, flag) in NAMES_TO_FLAGS {
+            if attr.has_name(name) {
+                flags.set(flag, true);
 
-                    continue 'attrs_loop;
+                if flag.bits() >= DELEGATION_INHERIT_ATTRS_START.bits() {
+                    to_inherit_attrs.push(attr.clone());
                 }
+
+                continue 'attrs_loop;
             }
         }
-
-        let sig = DelegationFnSig {
-            header,
-            param_count: decl.inputs.len(),
-            has_self: decl.has_self(),
-            c_variadic: decl.c_variadic(),
-            attrs_flags,
-            to_inherit_attrs,
-        };
-
-        self.r.delegation_fn_sigs.insert(self.r.local_def_id(id), sig);
     }
+
+    DelegationAttrs { flags, to_inherit: to_inherit_attrs }
 }
 
 impl<'ast> Visitor<'ast> for ItemInfoCollector<'_, '_, '_> {

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -69,8 +69,8 @@ use rustc_middle::middle::privacy::EffectiveVisibilities;
 use rustc_middle::query::Providers;
 use rustc_middle::span_bug;
 use rustc_middle::ty::{
-    self, DelegationFnSig, Feed, MainDefinition, RegisteredTools, ResolverAstLowering,
-    ResolverGlobalCtxt, TyCtxt, TyCtxtFeed, Visibility,
+    self, DelegationFnSig, DelegationInfo, Feed, MainDefinition, RegisteredTools,
+    ResolverAstLowering, ResolverGlobalCtxt, TyCtxt, TyCtxtFeed, Visibility,
 };
 use rustc_query_system::ich::StableHashingContext;
 use rustc_session::config::CrateType;
@@ -1283,7 +1283,7 @@ pub struct Resolver<'ra, 'tcx> {
     /// Amount of lifetime parameters for each item in the crate.
     item_generics_num_lifetimes: FxHashMap<LocalDefId, usize>,
     delegation_fn_sigs: LocalDefIdMap<DelegationFnSig>,
-    delegation_sig_resolution_nodes: LocalDefIdMap<NodeId>,
+    delegation_infos: LocalDefIdMap<DelegationInfo>,
 
     main_def: Option<MainDefinition> = None,
     trait_impls: FxIndexMap<DefId, Vec<LocalDefId>>,
@@ -1701,7 +1701,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             current_crate_outer_attr_insert_span,
             mods_with_parse_errors: Default::default(),
             impl_trait_names: Default::default(),
-            delegation_sig_resolution_nodes: Default::default(),
+            delegation_infos: Default::default(),
             ..
         };
 
@@ -1829,7 +1829,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             lifetime_elision_allowed: self.lifetime_elision_allowed,
             lint_buffer: Steal::new(self.lint_buffer),
             delegation_fn_sigs: self.delegation_fn_sigs,
-            delegation_sig_resolution_nodes: self.delegation_sig_resolution_nodes,
+            delegation_infos: self.delegation_infos,
         };
         ResolverOutputs { global_ctxt, ast_lowering }
     }

--- a/tests/pretty/delegation-inherit-attributes.pp
+++ b/tests/pretty/delegation-inherit-attributes.pp
@@ -57,5 +57,69 @@ const fn const_fn_extern() -> _ { to_reuse_functions::const_fn_extern() }
 #[attr = Inline(Hint)]
 async fn async_fn_extern() -> _ { to_reuse_functions::async_fn_extern() }
 
+mod recursive {
+    // Check that `baz` inherit attribute from `foo`
+    mod first {
+        fn bar() { }
+        #[attr = MustUse {reason: "some reason"}]
+        #[attr = Inline(Hint)]
+        fn foo() -> _ { bar() }
+        #[attr = MustUse {reason: "some reason"}]
+        #[attr = Inline(Hint)]
+        fn baz() -> _ { foo() }
+    }
+
+    // Check that `baz` inherit attribute from `bar`
+    mod second {
+        #[attr = MustUse {reason: "some reason"}]
+        fn bar() { }
+
+        #[attr = MustUse {reason: "some reason"}]
+        #[attr = Inline(Hint)]
+        fn foo() -> _ { bar() }
+        #[attr = MustUse {reason: "some reason"}]
+        #[attr = Inline(Hint)]
+        fn baz() -> _ { foo() }
+    }
+
+    // Check that `foo5` don't inherit attribute from `bar`
+    // and inherit attribute from foo4, check that foo1, foo2 and foo3
+    // inherit attribute from bar
+    mod third {
+        #[attr = MustUse {reason: "some reason"}]
+        fn bar() { }
+        #[attr = MustUse {reason: "some reason"}]
+        #[attr = Inline(Hint)]
+        fn foo1() -> _ { bar() }
+        #[attr = MustUse {reason: "some reason"}]
+        #[attr = Inline(Hint)]
+        fn foo2() -> _ { foo1() }
+        #[attr = MustUse {reason: "some reason"}]
+        #[attr = Inline(Hint)]
+        fn foo3() -> _ { foo2() }
+        #[attr = MustUse {reason: "foo4"}]
+        #[attr = Inline(Hint)]
+        fn foo4() -> _ { foo3() }
+        #[attr = MustUse {reason: "foo4"}]
+        #[attr = Inline(Hint)]
+        fn foo5() -> _ { foo4() }
+    }
+
+    mod fourth {
+        trait T {
+            fn foo(&self, x: usize) -> usize { x + 1 }
+        }
+
+        struct X;
+        impl T for X { }
+
+        #[attr = MustUse {reason: "some reason"}]
+        #[attr = Inline(Hint)]
+        fn foo(self: _, arg1: _) -> _ { <X as T>::foo(self + 1, arg1) }
+        #[attr = MustUse {reason: "some reason"}]
+        #[attr = Inline(Hint)]
+        fn bar(self: _, arg1: _) -> _ { foo(self + 1, arg1) }
+    }
+}
 
 fn main() { }

--- a/tests/pretty/delegation-inherit-attributes.rs
+++ b/tests/pretty/delegation-inherit-attributes.rs
@@ -52,5 +52,50 @@ reuse to_reuse_functions::const_fn_extern;
 #[must_use = "some reason"]
 reuse to_reuse_functions::async_fn_extern;
 
+mod recursive {
+    // Check that `baz` inherit attribute from `foo`
+    mod first {
+        fn bar() {}
+        #[must_use = "some reason"]
+        reuse bar as foo;
+        reuse foo as baz;
+    }
+
+    // Check that `baz` inherit attribute from `bar`
+    mod second {
+        #[must_use = "some reason"]
+        fn bar() {}
+
+        reuse bar as foo;
+        reuse foo as baz;
+    }
+
+    // Check that `foo5` don't inherit attribute from `bar`
+    // and inherit attribute from foo4, check that foo1, foo2 and foo3
+    // inherit attribute from bar
+    mod third {
+        #[must_use = "some reason"]
+        fn bar() {}
+        reuse bar as foo1;
+        reuse foo1 as foo2;
+        reuse foo2 as foo3;
+        #[must_use = "foo4"]
+        reuse foo3 as foo4;
+        reuse foo4 as foo5;
+    }
+
+    mod fourth {
+        trait T {
+            fn foo(&self, x: usize) -> usize { x + 1 }
+        }
+
+        struct X;
+        impl T for X {}
+
+        #[must_use = "some reason"]
+        reuse <X as T>::foo { self + 1 }
+        reuse foo as bar { self + 1 }
+    }
+}
 
 fn main() {}

--- a/tests/pretty/delegation-inline-attribute.pp
+++ b/tests/pretty/delegation-inline-attribute.pp
@@ -1,6 +1,6 @@
 //@ pretty-compare-only
 //@ pretty-mode:hir
-//@ pp-exact:delegation_inline_attribute.pp
+//@ pp-exact:delegation-inline-attribute.pp
 
 #![allow(incomplete_features)]
 #![feature(fn_delegation)]

--- a/tests/pretty/delegation-inline-attribute.rs
+++ b/tests/pretty/delegation-inline-attribute.rs
@@ -1,6 +1,6 @@
 //@ pretty-compare-only
 //@ pretty-mode:hir
-//@ pp-exact:delegation_inline_attribute.pp
+//@ pp-exact:delegation-inline-attribute.pp
 
 #![allow(incomplete_features)]
 #![feature(fn_delegation)]

--- a/tests/ui/delegation/recursive-delegation-ice-150152.rs
+++ b/tests/ui/delegation/recursive-delegation-ice-150152.rs
@@ -1,0 +1,31 @@
+#![feature(fn_delegation)]
+#![allow(incomplete_features)]
+
+mod first_example {
+    mod to_reuse { pub fn foo() {} }
+    struct S< S >;
+    //~^ ERROR type parameter `S` is never used
+
+    impl Item for S<S> {
+        //~^ ERROR cannot find trait `Item` in this scope
+        //~| ERROR missing generics for struct `S`
+        reuse to_reuse::foo;
+    }
+}
+
+mod second_example {
+    trait Trait {
+        reuse to_reuse::foo;
+        //~^ ERROR function `foo` is private
+    }
+    mod to_reuse {
+        fn foo() {}
+    }
+    impl Trait for S {
+        //~^ ERROR cannot find type `S` in this scope
+        reuse foo;
+        //~^ ERROR cannot find function `foo` in this scope
+    }
+}
+
+fn main() {}

--- a/tests/ui/delegation/recursive-delegation-ice-150152.stderr
+++ b/tests/ui/delegation/recursive-delegation-ice-150152.stderr
@@ -1,0 +1,74 @@
+error[E0405]: cannot find trait `Item` in this scope
+  --> $DIR/recursive-delegation-ice-150152.rs:9:10
+   |
+LL |     impl Item for S<S> {
+   |          ^^^^ not found in this scope
+
+error[E0425]: cannot find type `S` in this scope
+  --> $DIR/recursive-delegation-ice-150152.rs:24:20
+   |
+LL |     impl Trait for S {
+   |                    ^ not found in this scope
+   |
+note: struct `first_example::S` exists but is inaccessible
+  --> $DIR/recursive-delegation-ice-150152.rs:6:5
+   |
+LL |     struct S< S >;
+   |     ^^^^^^^^^^^^^^ not accessible
+
+error[E0425]: cannot find function `foo` in this scope
+  --> $DIR/recursive-delegation-ice-150152.rs:26:15
+   |
+LL |         reuse foo;
+   |               ^^^ not found in this scope
+   |
+note: these functions exist but are inaccessible
+  --> $DIR/recursive-delegation-ice-150152.rs:5:20
+   |
+LL |     mod to_reuse { pub fn foo() {} }
+   |                    ^^^^^^^^^^^^ `first_example::to_reuse::foo`: not accessible
+...
+LL |         fn foo() {}
+   |         ^^^^^^^^ `second_example::to_reuse::foo`: not accessible
+
+error[E0603]: function `foo` is private
+  --> $DIR/recursive-delegation-ice-150152.rs:18:25
+   |
+LL |         reuse to_reuse::foo;
+   |                         ^^^ private function
+   |
+note: the function `foo` is defined here
+  --> $DIR/recursive-delegation-ice-150152.rs:22:9
+   |
+LL |         fn foo() {}
+   |         ^^^^^^^^
+
+error[E0392]: type parameter `S` is never used
+  --> $DIR/recursive-delegation-ice-150152.rs:6:15
+   |
+LL |     struct S< S >;
+   |               ^ unused type parameter
+   |
+   = help: consider removing `S`, referring to it in a field, or using a marker such as `PhantomData`
+   = help: if you intended `S` to be a const parameter, use `const S: /* Type */` instead
+
+error[E0107]: missing generics for struct `S`
+  --> $DIR/recursive-delegation-ice-150152.rs:9:21
+   |
+LL |     impl Item for S<S> {
+   |                     ^ expected 1 generic argument
+   |
+note: struct defined here, with 1 generic parameter: `S`
+  --> $DIR/recursive-delegation-ice-150152.rs:6:12
+   |
+LL |     struct S< S >;
+   |            ^  -
+help: add missing generic argument
+   |
+LL |     impl Item for S<S<S>> {
+   |                      +++
+
+error: aborting due to 6 previous errors
+
+Some errors have detailed explanations: E0107, E0392, E0405, E0425, E0603.
+For more information about an error, try `rustc --explain E0107`.

--- a/tests/ui/delegation/recursive-delegation-pass.rs
+++ b/tests/ui/delegation/recursive-delegation-pass.rs
@@ -1,9 +1,10 @@
-//@ check-pass
+//@ run-pass
 //@ edition:2018
 //@ aux-crate:recursive_delegation_aux=recursive-delegation-aux.rs
 
 #![feature(fn_delegation)]
 #![allow(incomplete_features)]
+#![allow(warnings)]
 
 mod first_mod {
     pub mod to_reuse {
@@ -12,18 +13,35 @@ mod first_mod {
         }
     }
 
-    mod single_reuse {
-        reuse crate::first_mod::to_reuse::foo;
-        reuse foo as bar;
-        reuse foo as bar1;
-        reuse bar as goo;
-        reuse goo as koo;
-        reuse koo as too;
+    pub mod single_reuse {
+        reuse crate::first_mod::to_reuse::foo { self + 1 }
+        reuse foo as bar { self + 1 }
+        reuse foo as bar1 { self + 1 }
+        reuse bar as goo { self + 1 }
+        reuse goo as koo { self + 1 }
+        pub reuse koo as too { self + 1 }
+
+        pub fn check() {
+            assert_eq!(foo(1), 3);
+            assert_eq!(bar(1), 4);
+            assert_eq!(bar1(1), 4);
+            assert_eq!(goo(1), 5);
+            assert_eq!(koo(1), 6);
+            assert_eq!(too(1), 7);
+        }
     }
 
     mod glob_reuse {
         reuse super::to_reuse::{foo as bar, foo as bar1} { self }
         reuse super::glob_reuse::{bar as goo, goo as koo, koo as too} { self }
+
+        fn check() {
+            bar(1);
+            bar1(1);
+            goo(1);
+            koo(1);
+            too(1);
+        }
     }
 }
 
@@ -44,6 +62,29 @@ mod second_mod {
 
         reuse TGlob::{foo1 as bar1, foo3 as bar3, bar1 as bar11, bar11 as bar111} { self.xd() }
     }
+
+    fn check() {
+        struct X;
+        impl T for X {
+            fn foo(&self) {}
+            fn bar(&self) {}
+            fn goo(&self) {}
+            fn poo(&self) {}
+        }
+
+        impl TGlob for X {
+            fn xd(&self) -> &Self { &self }
+            fn foo1(&self) {}
+            fn foo2(&self) {}
+            fn foo3(&self) {}
+            fn foo4(&self) {}
+
+            fn bar1(&self) {}
+            fn bar3(&self) {}
+            fn bar11(&self) {}
+            fn bar111(&self) {}
+        }
+    }
 }
 
 mod third_mod {
@@ -63,6 +104,45 @@ mod third_mod {
 mod fourth_mod {
     reuse recursive_delegation_aux::goo as bar;
     reuse bar as foo;
+
+    fn check() {
+        bar();
+        foo();
+    }
 }
 
-fn main() {}
+mod fifth_mod {
+    mod m {
+        fn foo() { }
+        pub reuse foo as bar;
+    }
+
+    trait T {
+        reuse m::bar as foo;
+    }
+
+    struct X;
+    impl T for X {}
+
+    trait T1 {
+        reuse <X as T>::foo as baz;
+    }
+
+    impl T1 for X {}
+
+    struct Y;
+    impl T1 for Y {
+        reuse <X as T>::foo as baz;
+    }
+
+    fn check() {
+        m::bar();
+        <X as T>::foo();
+        <X as T1>::baz();
+        <Y as T1>::baz();
+    }
+}
+
+fn main() {
+    first_mod::single_reuse::check();
+}


### PR DESCRIPTION
This PR fixes interaction of recently added recursive delegations with other features, such as generics inheritance and attributes inheritance. It fixes rust-lang/rust#150152 ICE, it is a part of the delegation feature rust-lang/rust#118212. This issue contains two examples with different causes of ICE:
- The cause of the [first one](https://github.com/rust-lang/rust/issues/150152#issue-3747303525) is incorrect determination of whether we are in a trait impl [here](https://github.com/rust-lang/rust/blob/c4aa646f15e40bd3e64ddb5017b7b89b3646ac99/compiler/rustc_resolve/src/late.rs#L3553), we were using `trait_id.is_some()` which in case of an unresolved trait was `None`, we should have used `of_trait` from AST level for this purpose
- The cause of the [second example](https://github.com/rust-lang/rust/issues/150152#issuecomment-3674834654) is that with recursive delegations we started to provide DefIds of the root function of the delegation for recursive delegations instead of actual delegee id. This situation is described in comments in `DelegationIds` struct, now we provide different DefIds (either immediate delegee DefId or the root function DefId in `lower_delegation` method

Moreover, this PR fixes how attributes inheritance work with recursive delegations, earlier we would have copied attributes from the root function, however now we inherit attributes from the actual delegee, for this purpose we store attributes to inherit for delegations too, in the same way they were stored for functions.

r? @petrochenkov 


