### PR TITLE
fix rustfmt on `const impl Ty {}`

### DIFF
--- a/src/tools/rustfmt/src/items.rs
+++ b/src/tools/rustfmt/src/items.rs
@@ -971,7 +971,7 @@ fn format_impl_ref_and_type(
         result.push_str(format_defaultness(of_trait.defaultness));
         result.push_str(format_safety(of_trait.safety));
     } else {
-        result.push_str(format_constness_right(*constness));
+        result.push_str(format_constness(*constness));
     }
 
     let shape = if context.config.style_edition() >= StyleEdition::Edition2024 {

--- a/src/tools/rustfmt/tests/source/const_trait.rs
+++ b/src/tools/rustfmt/tests/source/const_trait.rs
@@ -7,7 +7,7 @@ const trait Foo = Bar;
 impl const Bar for () {}
 
 // const impl gets reformatted to impl const.. for now
-impl const Bar for u8 {}
+const impl Bar for u8 {}
 
 struct X;
 


### PR DESCRIPTION
r? @oli-obk on rust-lang/rust#148434, cc @ytmimi for https://github.com/rust-lang/rust/pull/148434/changes#r2637972310

format_constness_right outputs `" const"` whereas format_constness outputs `"const "`

Not making this change to rust-lang/rustfmt since I'm not sure if that repo has these changes yet.