### PR TITLE
xous: fix build due to function and feature name changes

### DIFF
--- a/library/std/src/sys/pal/xous/mod.rs
+++ b/library/std/src/sys/pal/xous/mod.rs
@@ -1,14 +1,8 @@
 #![forbid(unsafe_op_in_unsafe_fn)]
 
-use crate::os::xous::ffi::exit;
-
 pub mod os;
 pub mod time;
 
 #[path = "../unsupported/common.rs"]
 mod common;
 pub use common::*;
-
-pub fn abort_internal() -> ! {
-    exit(101);
-}

--- a/library/std/src/sys/pal/xous/os.rs
+++ b/library/std/src/sys/pal/xous/os.rs
@@ -11,7 +11,7 @@ pub(crate) mod params;
 static PARAMS_ADDRESS: Atomic<*mut u8> = AtomicPtr::new(core::ptr::null_mut());
 
 #[cfg(not(test))]
-#[cfg(feature = "panic_unwind")]
+#[cfg(feature = "panic-unwind")]
 mod eh_unwinding {
     pub(crate) struct EhFrameFinder;
     pub(crate) static mut EH_FRAME_ADDRESS: usize = 0;
@@ -45,7 +45,7 @@ mod c_compat {
 
     #[unsafe(no_mangle)]
     pub extern "C" fn _start(eh_frame: usize, params_address: usize) {
-        #[cfg(feature = "panic_unwind")]
+        #[cfg(feature = "panic-unwind")]
         {
             unsafe { super::eh_unwinding::EH_FRAME_ADDRESS = eh_frame };
             unwind::set_custom_eh_frame_finder(&super::eh_unwinding::EH_FRAME_SETTINGS).ok();

--- a/library/std/src/sys/thread/xous.rs
+++ b/library/std/src/sys/thread/xous.rs
@@ -87,7 +87,7 @@ impl Thread {
             // dealloc calls from being reordered to after the TLS has been destroyed.
             // See https://github.com/rust-lang/rust/pull/144465#pullrequestreview-3289729950
             // for more context.
-            run_main_thread_not_inlined(init);
+            rust_main_thread_not_inlined(init);
 
             // Destroy TLS, which will free the TLS page and call the destructor for
             // any thread local storage (if any).


### PR DESCRIPTION
This tracks a rename of `panic_unwind` to `panic-unwind`, as well as the removal of `abort_internal` as a function.

This also fixes an incorrect function name from when `rust_main_thread_not_inlined` was added.