### PR TITLE
adding Ordering enum to minicore.rs, importing minicore in "tests/assembly-llvm/rust-abi-arg-attr.rs" test file

### DIFF
--- a/tests/assembly-llvm/rust-abi-arg-attr.rs
+++ b/tests/assembly-llvm/rust-abi-arg-attr.rs
@@ -1,3 +1,4 @@
+//@ add-minicore
 //@ assembly-output: emit-asm
 //@ revisions: riscv64 riscv64-zbb loongarch64
 //@ compile-flags: -C opt-level=3
@@ -14,45 +15,8 @@
 #![no_std]
 #![no_core]
 // FIXME: Migrate these code after PR #130693 is landed.
-
-#[lang = "pointee_sized"]
-pub trait PointeeSized {}
-
-#[lang = "meta_sized"]
-pub trait MetaSized: PointeeSized {}
-
-#[lang = "sized"]
-pub trait Sized: MetaSized {}
-
-#[lang = "copy"]
-trait Copy {}
-
-impl Copy for i8 {}
-impl Copy for u32 {}
-impl Copy for i32 {}
-
-#[lang = "neg"]
-trait Neg {
-    type Output;
-
-    fn neg(self) -> Self::Output;
-}
-
-impl Neg for i8 {
-    type Output = i8;
-
-    fn neg(self) -> Self::Output {
-        -self
-    }
-}
-
-#[lang = "Ordering"]
-#[repr(i8)]
-enum Ordering {
-    Less = -1,
-    Equal = 0,
-    Greater = 1,
-}
+extern crate minicore;
+use minicore::*;
 
 #[rustc_intrinsic]
 fn three_way_compare<T: Copy>(lhs: T, rhs: T) -> Ordering;

--- a/tests/auxiliary/minicore.rs
+++ b/tests/auxiliary/minicore.rs
@@ -210,6 +210,14 @@ impl Neg for isize {
     }
 }
 
+impl Neg for i8 {
+    type Output = i8;
+
+    fn neg(self) -> i8 {
+        loop {}
+    }
+}
+
 #[lang = "sync"]
 trait Sync {}
 impl_marker_trait!(
@@ -279,6 +287,16 @@ pub enum c_void {
     __variant1,
     __variant2,
 }
+
+#[lang = "Ordering"]
+#[repr(i8)]
+pub enum Ordering {
+    Less = -1,
+    Equal = 0,
+    Greater = 1,
+}
+
+impl Copy for Ordering {}
 
 #[lang = "const_param_ty"]
 #[diagnostic::on_unimplemented(message = "`{Self}` can't be used as a const parameter type")]


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

this adds the `Ordering` enum to `minicore.rs`.

consequently, this updates `tests/assembly-llvm/rust-abi-arg-attr.rs` to import `minicore` directly. previously, this test file contained traits like `Copy` `Clone` `PointeeSized`, which were giving a duplicate lang item error, so replace those by importing `minicore` completely.