### PR TITLE
several `proc_macro` cleanups

### DIFF
--- a/library/proc_macro/src/bridge/symbol.rs
+++ b/library/proc_macro/src/bridge/symbol.rs
@@ -77,10 +77,7 @@ impl Symbol {
 
     // Mimics the behavior of `Symbol::can_be_raw` from `rustc_span`
     fn can_be_raw(string: &str) -> bool {
-        match string {
-            "_" | "super" | "self" | "Self" | "crate" | "$crate" => false,
-            _ => true,
-        }
+        !matches!(string, "_" | "super" | "self" | "Self" | "crate" | "$crate")
     }
 }
 

--- a/library/proc_macro/src/escape.rs
+++ b/library/proc_macro/src/escape.rs
@@ -17,8 +17,7 @@ pub(crate) fn escape_bytes(bytes: &[u8], opt: EscapeOptions) -> String {
             escape_single_byte(byte, opt, &mut repr);
         }
     } else {
-        let mut chunks = bytes.utf8_chunks();
-        while let Some(chunk) = chunks.next() {
+        for chunk in bytes.utf8_chunks() {
             for ch in chunk.valid().chars() {
                 escape_single_char(ch, opt, &mut repr);
             }

--- a/library/proc_macro/src/lib.rs
+++ b/library/proc_macro/src/lib.rs
@@ -3,7 +3,7 @@
 //! This library, provided by the standard distribution, provides the types
 //! consumed in the interfaces of procedurally defined macro definitions such as
 //! function-like macros `#[proc_macro]`, macro attributes `#[proc_macro_attribute]` and
-//! custom derive attributes`#[proc_macro_derive]`.
+//! custom derive attributes `#[proc_macro_derive]`.
 //!
 //! See [the book] for more.
 //!
@@ -210,7 +210,6 @@ impl FromStr for TokenStream {
 /// `TokenTree::Punct`, or `TokenTree::Literal`.
 #[stable(feature = "proc_macro_lib", since = "1.15.0")]
 impl fmt::Display for TokenStream {
-    #[allow(clippy::recursive_format_impl)] // clippy doesn't see the specialization
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self.0 {
             Some(ts) => write!(f, "{}", ts.to_string()),
@@ -219,7 +218,7 @@ impl fmt::Display for TokenStream {
     }
 }
 
-/// Prints token in a form convenient for debugging.
+/// Prints tokens in a form convenient for debugging.
 #[stable(feature = "proc_macro_lib", since = "1.15.0")]
 impl fmt::Debug for TokenStream {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -571,7 +570,7 @@ impl Span {
     /// This path should not be embedded in the output of the macro; prefer `file()` instead.
     #[stable(feature = "proc_macro_span_file", since = "1.88.0")]
     pub fn local_file(&self) -> Option<PathBuf> {
-        self.0.local_file().map(|s| PathBuf::from(s))
+        self.0.local_file().map(PathBuf::from)
     }
 
     /// Creates a new span encompassing `self` and `other`.
@@ -750,7 +749,6 @@ impl From<Literal> for TokenTree {
 /// `TokenTree::Punct`, or `TokenTree::Literal`.
 #[stable(feature = "proc_macro_lib2", since = "1.29.0")]
 impl fmt::Display for TokenTree {
-    #[allow(clippy::recursive_format_impl)] // clippy doesn't see the specialization
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             TokenTree::Group(t) => write!(f, "{t}"),
@@ -888,7 +886,6 @@ impl Group {
 /// with `Delimiter::None` delimiters.
 #[stable(feature = "proc_macro_lib2", since = "1.29.0")]
 impl fmt::Display for Group {
-    #[allow(clippy::recursive_format_impl)] // clippy doesn't see the specialization
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", TokenStream::from(TokenTree::from(self.clone())))
     }


### PR DESCRIPTION
Fixes typos and applies the suggestions from a few clippy lints that made sense here.