### PR TITLE
Rollup of 2 pull requests

### DIFF
--- a/library/proc_macro/src/bridge/symbol.rs
+++ b/library/proc_macro/src/bridge/symbol.rs
@@ -77,10 +77,7 @@ impl Symbol {
 
     // Mimics the behavior of `Symbol::can_be_raw` from `rustc_span`
     fn can_be_raw(string: &str) -> bool {
-        match string {
-            "_" | "super" | "self" | "Self" | "crate" | "$crate" => false,
-            _ => true,
-        }
+        !matches!(string, "_" | "super" | "self" | "Self" | "crate" | "$crate")
     }
 }
 

--- a/library/proc_macro/src/escape.rs
+++ b/library/proc_macro/src/escape.rs
@@ -17,8 +17,7 @@ pub(crate) fn escape_bytes(bytes: &[u8], opt: EscapeOptions) -> String {
             escape_single_byte(byte, opt, &mut repr);
         }
     } else {
-        let mut chunks = bytes.utf8_chunks();
-        while let Some(chunk) = chunks.next() {
+        for chunk in bytes.utf8_chunks() {
             for ch in chunk.valid().chars() {
                 escape_single_char(ch, opt, &mut repr);
             }

--- a/library/proc_macro/src/lib.rs
+++ b/library/proc_macro/src/lib.rs
@@ -3,7 +3,7 @@
 //! This library, provided by the standard distribution, provides the types
 //! consumed in the interfaces of procedurally defined macro definitions such as
 //! function-like macros `#[proc_macro]`, macro attributes `#[proc_macro_attribute]` and
-//! custom derive attributes`#[proc_macro_derive]`.
+//! custom derive attributes `#[proc_macro_derive]`.
 //!
 //! See [the book] for more.
 //!
@@ -210,7 +210,6 @@ impl FromStr for TokenStream {
 /// `TokenTree::Punct`, or `TokenTree::Literal`.
 #[stable(feature = "proc_macro_lib", since = "1.15.0")]
 impl fmt::Display for TokenStream {
-    #[allow(clippy::recursive_format_impl)] // clippy doesn't see the specialization
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self.0 {
             Some(ts) => write!(f, "{}", ts.to_string()),
@@ -219,7 +218,7 @@ impl fmt::Display for TokenStream {
     }
 }
 
-/// Prints token in a form convenient for debugging.
+/// Prints tokens in a form convenient for debugging.
 #[stable(feature = "proc_macro_lib", since = "1.15.0")]
 impl fmt::Debug for TokenStream {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -571,7 +570,7 @@ impl Span {
     /// This path should not be embedded in the output of the macro; prefer `file()` instead.
     #[stable(feature = "proc_macro_span_file", since = "1.88.0")]
     pub fn local_file(&self) -> Option<PathBuf> {
-        self.0.local_file().map(|s| PathBuf::from(s))
+        self.0.local_file().map(PathBuf::from)
     }
 
     /// Creates a new span encompassing `self` and `other`.
@@ -750,7 +749,6 @@ impl From<Literal> for TokenTree {
 /// `TokenTree::Punct`, or `TokenTree::Literal`.
 #[stable(feature = "proc_macro_lib2", since = "1.29.0")]
 impl fmt::Display for TokenTree {
-    #[allow(clippy::recursive_format_impl)] // clippy doesn't see the specialization
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             TokenTree::Group(t) => write!(f, "{t}"),
@@ -888,7 +886,6 @@ impl Group {
 /// with `Delimiter::None` delimiters.
 #[stable(feature = "proc_macro_lib2", since = "1.29.0")]
 impl fmt::Display for Group {
-    #[allow(clippy::recursive_format_impl)] // clippy doesn't see the specialization
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", TokenStream::from(TokenTree::from(self.clone())))
     }

--- a/src/tools/rust-installer/README.md
+++ b/src/tools/rust-installer/README.md
@@ -49,7 +49,7 @@ To combine installers.
 
 # Future work
 
-* Make install.sh not have to be customized, pull it's data from a
+* Make install.sh not have to be customized, pull its data from a
   config file.
 * Be more resilient to installation failures, particularly if the disk
   is full.

--- a/src/tools/test-float-parse/README.md
+++ b/src/tools/test-float-parse/README.md
@@ -36,7 +36,7 @@ For each test case, the following is done:
   representation with infinite precision.
 - The rational value then gets checked that it is within the float's
   representable values (absolute value greater than the smallest number to round
-  to zero, but less less than the first value to round to infinity). If these
+  to zero, but less than the first value to round to infinity). If these
   limits are exceeded, check that the parsed float reflects that.
 - For real nonzero numbers, the parsed float is converted into a rational using
   `significand * 2^exponent`. It is then checked against the actual rational

--- a/tests/ui/README.md
+++ b/tests/ui/README.md
@@ -328,7 +328,7 @@ Tests for crate resolution and loading behavior, including `extern crate` declar
 
 ## `tests/ui/cross/`: Various tests related to the concept of "cross"
 
-**FIXME**: The unifying topic of these tests appears to be that their filenames begin with the word "cross". The similarities end there - one test is about "cross-borrowing" a `Box<T>` into `&T`, while another is about a global trait used "across" files. Some of these terminology are really outdated and does not match the current terminology. Additionally, "cross" is also way too generic, it's easy to confuse with cross-compile.
+**FIXME**: The unifying topic of these tests appears to be that their filenames begin with the word "cross". The similarities end there - one test is about "cross-borrowing" a `Box<T>` into `&T`, while another is about a global trait used "across" files. Some of this terminology is really outdated and does not match the current terminology. Additionally, "cross" is also way too generic, it's easy to confuse with cross-compile.
 
 ## `tests/ui/cross-crate/`: Cross-Crate Interaction
 
@@ -911,7 +911,7 @@ Something is missing which could be added to fix (e.g. suggestions).
 
 Tests for checking missing trait bounds, and their diagnostics.
 
-**FIMXE**: Maybe a subdirectory of `ui/trait-bounds` would be more appropriate.
+**FIXME**: Maybe a subdirectory of `ui/trait-bounds` would be more appropriate.
 
 ## `tests/ui/modules/`
 
@@ -957,7 +957,7 @@ Despite the size of the directory, this is a single test, spawning a sprawling `
 
 A very similar principle as `non_modrs_mods`, but with an added inline `mod` statement inside another `mod`'s code block.
 
-**FXIME**: Consider merge with `tests/ui/modules/`, keeping the directory structure.
+**FIXME**: Consider merge with `tests/ui/modules/`, keeping the directory structure.
 
 ## `tests/ui/no_std/`
 


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#150366 (Fix typos and grammar errors in README files)
 - rust-lang/rust#150371 (several `proc_macro` cleanups)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=150366,150371)
<!-- homu-ignore:end -->