### PR TITLE
Return `ExitCode` from `rustc_driver::main` instead of calling `process::exit`

### DIFF
--- a/compiler/rustc/src/main.rs
+++ b/compiler/rustc/src/main.rs
@@ -3,6 +3,8 @@
 // Several crates are depended upon but unused so that they are present in the sysroot
 #![expect(unused_crate_dependencies)]
 
+use std::process::ExitCode;
+
 // A note about jemalloc: rustc uses jemalloc when built for CI and
 // distribution. The obvious way to do this is with the `#[global_allocator]`
 // mechanism. However, for complicated reasons (see
@@ -38,6 +40,6 @@
 #[cfg(feature = "jemalloc")]
 use tikv_jemalloc_sys as _;
 
-fn main() {
+fn main() -> ExitCode {
     rustc_driver::main()
 }

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -71,7 +71,7 @@ extern crate tikv_jemalloc_sys as _;
 use std::env::{self, VarError};
 use std::io::{self, IsTerminal};
 use std::path::Path;
-use std::process;
+use std::process::ExitCode;
 
 use rustc_errors::DiagCtxtHandle;
 use rustc_hir::def_id::LOCAL_CRATE;
@@ -126,7 +126,7 @@ mod visit;
 mod visit_ast;
 mod visit_lib;
 
-pub fn main() {
+pub fn main() -> ExitCode {
     let mut early_dcx = EarlyDiagCtxt::new(ErrorOutputType::default());
 
     rustc_driver::install_ice_hook(
@@ -164,11 +164,10 @@ pub fn main() {
         Err(error) => early_dcx.early_fatal(error.to_string()),
     }
 
-    let exit_code = rustc_driver::catch_with_exit_code(|| {
+    rustc_driver::catch_with_exit_code(|| {
         let at_args = rustc_driver::args::raw_args(&early_dcx);
         main_args(&mut early_dcx, &at_args);
-    });
-    process::exit(exit_code);
+    })
 }
 
 fn init_logging(early_dcx: &EarlyDiagCtxt) {

--- a/src/tools/rustdoc/main.rs
+++ b/src/tools/rustdoc/main.rs
@@ -1,6 +1,8 @@
 // We need this feature as it changes `dylib` linking behavior and allows us to link to `rustc_driver`.
 #![feature(rustc_private)]
 
-fn main() {
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
     rustdoc::main()
 }

--- a/tests/ui-fulldeps/obtain-borrowck.rs
+++ b/tests/ui-fulldeps/obtain-borrowck.rs
@@ -28,6 +28,7 @@ extern crate rustc_session;
 
 use std::cell::RefCell;
 use std::collections::HashMap;
+use std::process::ExitCode;
 use std::thread_local;
 
 use rustc_borrowck::consumers::{self, BodyWithBorrowckFacts, ConsumerOptions};
@@ -42,16 +43,15 @@ use rustc_middle::ty::TyCtxt;
 use rustc_middle::util::Providers;
 use rustc_session::Session;
 
-fn main() {
-    let exit_code = rustc_driver::catch_with_exit_code(move || {
+fn main() -> ExitCode {
+    rustc_driver::catch_with_exit_code(move || {
         let mut rustc_args: Vec<_> = std::env::args().collect();
         // We must pass -Zpolonius so that the borrowck information is computed.
         rustc_args.push("-Zpolonius".to_owned());
         let mut callbacks = CompilerCalls::default();
         // Call the Rust compiler with our callbacks.
         rustc_driver::run_compiler(&rustc_args, &mut callbacks);
-    });
-    std::process::exit(exit_code);
+    })
 }
 
 #[derive(Default)]


### PR DESCRIPTION
This makes rustc simply return an exit code from main rather than calling `std::process::exit` with an exit code. This means that drops run normally and the process exits cleanly. This is similar to what happens when an ICE occurs (due to being a panic that's caught by std's `lang_start`).

Also instead of hard coding success and failure codes this uses `ExitCode::SUCCESS` and `ExitCode::FAILURE`, which in turn effectively uses `libc::EXIT_SUCCESS` and `libc::EXIT_FAILURE` (via std). These are `0` and `1` respectively for all currently supported host platforms so it doesn't actually change the exit code.
