### PR TITLE
generalize Box::into_non_null over allocators

### DIFF
--- a/library/alloc/src/boxed.rs
+++ b/library/alloc/src/boxed.rs
@@ -1319,7 +1319,9 @@ impl<T: ?Sized> Box<T> {
     pub unsafe fn from_non_null(ptr: NonNull<T>) -> Self {
         unsafe { Self::from_raw(ptr.as_ptr()) }
     }
+}
 
+impl<T: ?Sized, A: Allocator> Box<T, A> {
     /// Consumes the `Box`, returning a wrapped raw pointer.
     ///
     /// The pointer will be properly aligned and non-null.


### PR DESCRIPTION
This is extracted from https://github.com/rust-lang/rust/pull/150344 to see if it is the cause of the Miri failure.