### PR TITLE
Fix copy code example with line numbers

### DIFF
--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -2163,7 +2163,15 @@ function preLoadCss(cssUrl) {
             // Should never happen, but the world is a dark and dangerous place.
             return;
         }
-        copyContentToClipboard(codeElem.textContent);
+        let content = "";
+        for (const node of codeElem.childNodes) {
+            // We exclude line numbers.
+            if (node instanceof HTMLElement && node.hasAttribute("data-nosnippet")) {
+                continue;
+            }
+            content += node.textContent;
+        }
+        copyContentToClipboard(content);
     }
 
     /**

--- a/tests/rustdoc-gui/copy-code.goml
+++ b/tests/rustdoc-gui/copy-code.goml
@@ -42,7 +42,31 @@ store-size: (".example-wrap:nth-of-type(1) .copy-button", {
 })
 assert: |copy_height| > 0 && |copy_width| > 0
 
-// Checking same things for the copy button when there is no run button.
+
+// We now check that copying code when line numbers are displayed don't include these line numbers.
+
+// First we ensure that the clipboard is empty.
+assert-clipboard: ""
+// We make the line numbers appear.
+click: "rustdoc-toolbar .settings-menu"
+wait-for-css: ("#settings", {"display": "block"})
+// We make the line numbers appear.
+click: "#line-numbers"
+wait-for-local-storage: {"rustdoc-line-numbers": "true" }
+// We close the settings menu.
+click: "rustdoc-toolbar .settings-menu"
+wait-for-css-false: ("#settings", {"display": "block"})
+// We ensure that there are actually line numbers generated in the DOM.
+assert-text: (".example-wrap pre.rust code span[data-nosnippet]", "1")
+// We make the copy button appear.
+move-cursor-to: ".example-wrap pre.rust code"
+wait-for-css: (".example-wrap .button-holder", {"visibility": "visible"})
+// We click on the copy button.
+click: ".example-wrap .button-holder .copy-button"
+assert-clipboard: 'println!("nothing fancy");
+println!("but with two lines!");'
+
+// Back to UI checks, checking same things for the copy button when there is no run button.
 go-to: "file://" + |DOC_PATH| + "/lib2/sub_mod/struct.Foo.html"
 call-function: ("check-copy-button", {})
 // Ensure there is no run button.


### PR DESCRIPTION
Fixes rust-lang/rust#150339.

Since the line numbers are now included in the actual highlighted code, we need to filter them out when we "copy" the code.

r? @yotamofek 