### PR TITLE
clearer error for pointer syntax in generic parameters

### DIFF
--- a/compiler/rustc_parse/messages.ftl
+++ b/compiler/rustc_parse/messages.ftl
@@ -358,6 +358,10 @@ parse_function_body_equals_expr = function body cannot be `= expression;`
 
 parse_generic_args_in_pat_require_turbofish_syntax = generic args in patterns require the turbofish syntax
 
+parse_generic_param_pointer_syntax = pointer types are not allowed in generic parameter lists
+    .label = unexpected pointer syntax `*`
+    .note = generic parameters must be types, constants, or lifetimes
+    .help = use a type parameter and specify the pointer in the argument, e.g. `fn size<T>(_v: *const T)`
 parse_generic_parameters_without_angle_brackets = generic parameters without surrounding angle brackets
     .suggestion = surround the type parameters with angle brackets
 

--- a/compiler/rustc_parse/src/errors.rs
+++ b/compiler/rustc_parse/src/errors.rs
@@ -3678,3 +3678,13 @@ pub(crate) struct ImplReuseInherentImpl {
     #[primary_span]
     pub span: Span,
 }
+
+#[derive(Diagnostic)]
+#[diag(parse_generic_param_pointer_syntax)]
+#[help]
+#[note]
+pub(crate) struct InvalidGenericPointerParam {
+    #[primary_span]
+    #[label]
+    pub span: Span,
+}

--- a/compiler/rustc_parse/src/parser/generics.rs
+++ b/compiler/rustc_parse/src/parser/generics.rs
@@ -193,6 +193,14 @@ impl<'a> Parser<'a> {
                     let _ = this.eat(exp!(Comma));
                 }
 
+                // Just emit and consume the star
+                if this.check_noexpect(&token::Star) {
+                    this.dcx().emit_err(errors::InvalidGenericPointerParam {
+                        span: this.prev_token.span,
+                    });
+                    this.bump();
+                }
+
                 let param = if this.check_lifetime() {
                     let lifetime = this.expect_lifetime();
                     // Parse lifetime parameter.

--- a/tests/ui/parser/pointer_generic.rs
+++ b/tests/ui/parser/pointer_generic.rs
@@ -1,0 +1,8 @@
+fn size<*T>(_v: *const T) {
+    //~^ ERROR pointer types are not allowed in generic parameter lists
+    println!("{:?}", std::mem::size_of::<T>());
+}
+
+fn main() {
+    size(0 as *const u8);
+}

--- a/tests/ui/parser/pointer_generic.stderr
+++ b/tests/ui/parser/pointer_generic.stderr
@@ -1,0 +1,11 @@
+error: pointer types are not allowed in generic parameter lists
+  --> $DIR/pointer_generic.rs:1:8
+   |
+LL | fn size<*T>(_v: *const T) {
+   |        ^ unexpected pointer syntax `*`
+   |
+   = help: use a type parameter and specify the pointer in the argument, e.g. `fn size<T>(_v: *const T)`
+   = note: generic parameters must be types, constants, or lifetimes
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
cc rust-lang/rust#76173

Wasn't entirely sure on how to handle this, so i just check if there is a `*`, emit an error and treat the param as if the `*` was never there.