### PR TITLE
Document default SOCK_CLOEXEC flag on new UnixStream

### DIFF
--- a/library/std/src/os/unix/net/stream.rs
+++ b/library/std/src/os/unix/net/stream.rs
@@ -63,7 +63,7 @@ use crate::time::Duration;
 /// On platforms that support it, we pass the close-on-exec flag to atomically create the socket and
 /// set it as CLOEXEC. On Linux, this was added in 2.6.27. See [`socket(2)`] for more information.
 ///
-/// [`socket(2)`](https://www.man7.org/linux/man-pages/man2/socket.2.html#:~:text=SOCK_CLOEXEC)
+/// [`socket(2)`]: https://www.man7.org/linux/man-pages/man2/socket.2.html#:~:text=SOCK_CLOEXEC
 ///
 /// # `SIGPIPE`
 ///

--- a/library/std/src/os/unix/net/stream.rs
+++ b/library/std/src/os/unix/net/stream.rs
@@ -58,6 +58,13 @@ use crate::time::Duration;
 /// }
 /// ```
 ///
+/// # `SOCK_CLOEXEC`
+///
+/// On platforms that support it, we pass the close-on-exec flag to atomically create the socket and
+/// set it as CLOEXEC. On Linux, this was added in 2.6.27. See [`socket(2)`] for more information.
+///
+/// [`socket(2)`](https://www.man7.org/linux/man-pages/man2/socket.2.html#:~:text=SOCK_CLOEXEC)
+///
 /// # `SIGPIPE`
 ///
 /// Writes to the underlying socket in `SOCK_STREAM` mode are made with `MSG_NOSIGNAL` flag.


### PR DESCRIPTION
Currently, the `std::os::unix::net::UnixStream` docs do not specify that the SOCK_CLOEXEC flag is set on new sockets. This commit adds a note clarifying that, in line with the note abuot the `MSG_NOSIGNAL` flag. 