### PR TITLE
Do not spill operand debuginfo to stack for AArch64 SVE predicates `<vscale x N x i1>` where `N != 16`

### DIFF
--- a/compiler/rustc_codegen_ssa/src/mir/debuginfo.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/debuginfo.rs
@@ -2,7 +2,7 @@ use std::collections::hash_map::Entry;
 use std::marker::PhantomData;
 use std::ops::Range;
 
-use rustc_abi::{BackendRepr, FieldIdx, FieldsShape, ScalableElt, Size, VariantIdx};
+use rustc_abi::{BackendRepr, FieldIdx, FieldsShape, Size, VariantIdx};
 use rustc_data_structures::fx::FxHashMap;
 use rustc_index::IndexVec;
 use rustc_middle::middle::codegen_fn_attrs::CodegenFnAttrFlags;
@@ -437,16 +437,11 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                 // debugging experience anyway.
                 if operand.layout.ty.is_scalable_vector()
                     && bx.sess().target.arch == rustc_target::spec::Arch::AArch64
-                    && let ty::Adt(adt, args) = &operand.layout.ty.kind()
-                    && let Some(marker_type_field) =
-                        adt.non_enum_variant().fields.get(FieldIdx::from_u32(0))
                 {
-                    let marker_type = marker_type_field.ty(bx.tcx(), args);
+                    let (count, element_ty) =
+                        operand.layout.ty.scalable_vector_element_count_and_type(bx.tcx());
                     // i.e. `<vscale x N x i1>` when `N != 16`
-                    if let ty::Slice(element_ty) = marker_type.kind()
-                        && element_ty.is_bool()
-                        && adt.repr().scalable != Some(ScalableElt::ElementCount(16))
-                    {
+                    if element_ty.is_bool() && count != 16 {
                         return;
                     }
                 }

--- a/compiler/rustc_codegen_ssa/src/mir/debuginfo.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/debuginfo.rs
@@ -431,10 +431,10 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                 // Internally, with an intrinsic operating on a `svint32_t`/`<vscale x 4 x i32>`
                 // (for example), the intrinsic takes the `svbool_t`/`<vscale x 16 x i1>` predicate
                 // and casts it to a `svbool4_t`/`<vscale x 4 x i1>`. Therefore, it's important that
-                // the `<vscale x 4 x i32>` never spills because that'll cause errors during
+                // the `<vscale x 4 x i1>` never spills because that'll cause errors during
                 // instruction selection. Spilling to the stack to create debuginfo for these
-                // intermediate values must be avoided and won't degrade the debugging experience
-                // anyway.
+                // intermediate values must be avoided and doing so won't affect the
+                // debugging experience anyway.
                 if operand.layout.ty.is_scalable_vector()
                     && bx.sess().target.arch == rustc_target::spec::Arch::AArch64
                     && let ty::Adt(adt, args) = &operand.layout.ty.kind()

--- a/tests/ui/scalable-vectors/debuginfo-does-not-spill.rs
+++ b/tests/ui/scalable-vectors/debuginfo-does-not-spill.rs
@@ -1,0 +1,39 @@
+// Compiletest for rust-lang/rust#150419: Do not spill operands to the stack when
+// creating debuginfo for AArch64 SVE predicates `<vscale x N x i1>` where `N != 16`
+//@ edition: 2021
+//@ only-aarch64
+//@ build-pass
+//@ compile-flags: -C debuginfo=2 -C target-feature=+sve
+
+#![crate_type = "lib"]
+#![allow(internal_features)]
+#![feature(rustc_attrs, link_llvm_intrinsics)]
+
+#[rustc_scalable_vector(16)]
+#[allow(non_camel_case_types)]
+#[repr(transparent)]
+pub struct svbool_t(bool);
+
+#[rustc_scalable_vector(4)]
+#[allow(non_camel_case_types)]
+#[repr(transparent)]
+pub struct svbool4_t(bool);
+
+impl std::convert::Into<svbool_t> for svbool4_t {
+    #[inline(always)]
+    fn into(self) -> svbool_t {
+        unsafe extern "C" {
+            #[link_name = "llvm.aarch64.sve.convert.to.svbool.nxv4i1"]
+            fn convert_to_svbool(b: svbool4_t) -> svbool_t;
+        }
+        unsafe { convert_to_svbool(self) }
+    }
+}
+
+pub fn svwhilelt_b32_u64(op1: u64, op2: u64) -> svbool_t {
+    unsafe extern "C" {
+        #[link_name = "llvm.aarch64.sve.whilelo.nxv4i1.u64"]
+        fn _svwhilelt_b32_u64(op1: u64, op2: u64) -> svbool4_t;
+    }
+    unsafe { _svwhilelt_b32_u64(op1, op2) }.into()
+}


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
This pull request tries to fix rust-lang/rust#150419.

The debuginfo for AArch64 SVE predicates `<vscale x N x i1>` where `N != 16` should be ignored by this [commit](https://github.com/rust-lang/rust/pull/143924/changes/89eea57594e3e1d8e618dd530ea1c8e7c9b4c7a4).

https://github.com/rust-lang/rust/blob/89eea57594e3e1d8e618dd530ea1c8e7c9b4c7a4/compiler/rustc_codegen_ssa/src/mir/debuginfo.rs#L438-L452

But in line 446, the `marker_type.kind()` is `ty::Bool` instead of `ty::Slice`, so the code doesn't work as intended.

This pull request uses the [`Ty::scalable_vector_element_count_and_type`](https://github.com/rust-lang/rust/blob/main/compiler/rustc_middle/src/ty/sty.rs#L1272) method to fix the condition checks for  `<vscale x N x i1>` where `N != 16` and add a compiletest for this case.