### PR TITLE
moving Ordering enum to minicore.rs for no_core codegen tests, mirroring core.

### DIFF
--- a/library/core/src/cmp.rs
+++ b/library/core/src/cmp.rs
@@ -1,4 +1,3 @@
-
 //! Utilities for comparing and ordering values.
 //!
 //! This module contains various tools for comparing and ordering values. In
@@ -23,7 +22,6 @@
 //!
 //! [`max`]: Ord::max
 //! [`min`]: Ord::min
-//! 
 
 #![stable(feature = "rust1", since = "1.0.0")]
 

--- a/library/core/src/cmp.rs
+++ b/library/core/src/cmp.rs
@@ -1,3 +1,4 @@
+
 //! Utilities for comparing and ordering values.
 //!
 //! This module contains various tools for comparing and ordering values. In
@@ -22,6 +23,7 @@
 //!
 //! [`max`]: Ord::max
 //! [`min`]: Ord::min
+//! 
 
 #![stable(feature = "rust1", since = "1.0.0")]
 

--- a/tests/assembly-llvm/rust-abi-arg-attr.rs
+++ b/tests/assembly-llvm/rust-abi-arg-attr.rs
@@ -14,6 +14,8 @@
 #![no_std]
 #![no_core]
 // FIXME: Migrate these code after PR #130693 is landed.
+extern crate minicore;
+use minicore::Ordering;
 
 #[lang = "pointee_sized"]
 pub trait PointeeSized {}
@@ -44,14 +46,6 @@ impl Neg for i8 {
     fn neg(self) -> Self::Output {
         -self
     }
-}
-
-#[lang = "Ordering"]
-#[repr(i8)]
-enum Ordering {
-    Less = -1,
-    Equal = 0,
-    Greater = 1,
 }
 
 #[rustc_intrinsic]

--- a/tests/assembly-llvm/rust-abi-arg-attr.rs
+++ b/tests/assembly-llvm/rust-abi-arg-attr.rs
@@ -1,3 +1,4 @@
+//@ aux-build:minicore.rs
 //@ assembly-output: emit-asm
 //@ revisions: riscv64 riscv64-zbb loongarch64
 //@ compile-flags: -C opt-level=3

--- a/tests/auxiliary/minicore.rs
+++ b/tests/auxiliary/minicore.rs
@@ -206,7 +206,15 @@ impl Neg for isize {
     type Output = isize;
 
     fn neg(self) -> isize {
-        loop {} // Dummy impl, not actually used
+        loop {} // Dummy impl, not actually used 
+    }
+}
+
+impl Neg for i8 {
+    type Output = i8;
+
+    fn neg(self) -> i8 {
+        loop {}
     }
 }
 
@@ -283,6 +291,16 @@ pub enum c_void {
 #[lang = "const_param_ty"]
 #[diagnostic::on_unimplemented(message = "`{Self}` can't be used as a const parameter type")]
 pub trait ConstParamTy_ {}
+
+#[lang = "Ordering"]
+#[repr(i8)]
+pub enum Ordering {
+    Less = -1,
+    Equal = 0,
+    Greater = 1,
+}
+
+impl Copy for Ordering {}
 
 pub enum SimdAlign {
     // These values must match the compiler's `SimdAlign` defined in

--- a/tests/auxiliary/minicore.rs
+++ b/tests/auxiliary/minicore.rs
@@ -206,7 +206,7 @@ impl Neg for isize {
     type Output = isize;
 
     fn neg(self) -> isize {
-        loop {} // Dummy impl, not actually used 
+        loop {} // Dummy impl, not actually used
     }
 }
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <workingjubilee>
-->
<!-- homu-ignore:end -->

some #![no_core] codegen and assembly tests rely on Ordering
being available without linking core. Defining it in minicore,
mirrors core::cmp::Ordering.

Tests:
- assembly-llvm/rust-abi-arg-attr.rs

