### PR TITLE
diagnostics: add note when param-env shadows global impl

### DIFF
--- a/compiler/rustc_trait_selection/src/error_reporting/infer/mod.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/mod.rs
@@ -278,13 +278,6 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
 
             let is_shadowed = self.infcx.probe(|_| {
                 let impl_substs = self.infcx.fresh_args_for_item(DUMMY_SP, impl_def_id);
-                let impl_trait_ref = tcx.impl_trait_ref(impl_def_id).instantiate(tcx, impl_substs);
-
-                let expected_trait_ref = alias.trait_ref(tcx);
-
-                if !self.infcx.can_eq(param_env, expected_trait_ref, impl_trait_ref) {
-                    return false;
-                }
 
                 let leaf_def = match specialization_graph::assoc_def(tcx, impl_def_id, alias.def_id)
                 {

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/mod.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/mod.rs
@@ -294,7 +294,8 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             if is_shadowed {
                 diag.note(format!(
                     "the associated type `{}` is defined as `{}` in the implementation, \
-                    but the generic bound `{}` hides this definition",
+                    but the where-bound `{}` shadows this definition\n\
+                    see issue #152409 <https://github.com/rust-lang/rust/issues/152409> for more information",
                     self.ty_to_string(tcx.mk_ty_from_kind(ty::Alias(ty::Projection, *alias))),
                     self.ty_to_string(concrete),
                     self.ty_to_string(alias.self_ty())

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/mod.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/mod.rs
@@ -291,14 +291,14 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     return false;
                 }
 
-                let trait_def_id = alias.trait_def_id(tcx);
-                let rebased_args = alias.args.rebase_onto(tcx, trait_def_id, impl_substs);
-
                 let leaf_def = match specialization_graph::assoc_def(tcx, impl_def_id, alias.def_id)
                 {
                     Ok(leaf) => leaf,
                     Err(_) => return false,
                 };
+
+                let trait_def_id = alias.trait_def_id(tcx);
+                let rebased_args = alias.args.rebase_onto(tcx, trait_def_id, impl_substs);
 
                 let impl_item_def_id = leaf_def.item.def_id;
                 let impl_assoc_ty = tcx.type_of(impl_item_def_id).instantiate(tcx, rebased_args);

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/mod.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/mod.rs
@@ -279,8 +279,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
 
             let is_shadowed = self.infcx.probe(|_| {
                 let impl_substs = self.infcx.fresh_args_for_item(DUMMY_SP, impl_def_id);
-                let impl_trait_ref =
-                    tcx.impl_trait_ref(impl_def_id).instantiate(tcx, impl_substs);
+                let impl_trait_ref = tcx.impl_trait_ref(impl_def_id).instantiate(tcx, impl_substs);
 
                 let expected_trait_ref = alias.trait_ref(tcx);
 

--- a/compiler/rustc_trait_selection/src/traits/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/mod.rs
@@ -16,7 +16,7 @@ pub mod project;
 pub mod query;
 #[allow(hidden_glob_reexports)]
 mod select;
-mod specialize;
+pub mod specialize;
 mod structural_normalize;
 #[allow(hidden_glob_reexports)]
 mod util;

--- a/tests/ui/associated-type-bounds/suggest-contraining-assoc-type-because-of-assoc-const.stderr
+++ b/tests/ui/associated-type-bounds/suggest-contraining-assoc-type-because-of-assoc-const.stderr
@@ -6,6 +6,7 @@ LL |     const N: C::M = 4u8;
    |
    = note: expected associated type `<C as O>::M`
                          found type `u8`
+   = note: the associated type `<C as O>::M` is defined as `u8` in the implementation, but the generic bound `C` hides this definition
 help: consider constraining the associated type `<C as O>::M` to `u8`
    |
 LL | impl<C: O<M = u8>> U<C> for u16 {

--- a/tests/ui/associated-type-bounds/suggest-contraining-assoc-type-because-of-assoc-const.stderr
+++ b/tests/ui/associated-type-bounds/suggest-contraining-assoc-type-because-of-assoc-const.stderr
@@ -6,7 +6,8 @@ LL |     const N: C::M = 4u8;
    |
    = note: expected associated type `<C as O>::M`
                          found type `u8`
-   = note: the associated type `<C as O>::M` is defined as `u8` in the implementation, but the generic bound `C` hides this definition
+   = note: the associated type `<C as O>::M` is defined as `u8` in the implementation, but the where-bound `C` shadows this definition
+           see issue #152409 <https://github.com/rust-lang/rust/issues/152409> for more information
 help: consider constraining the associated type `<C as O>::M` to `u8`
    |
 LL | impl<C: O<M = u8>> U<C> for u16 {

--- a/tests/ui/associated-types/defaults-specialization.stderr
+++ b/tests/ui/associated-types/defaults-specialization.stderr
@@ -75,6 +75,7 @@ LL |     fn make() -> Self::Ty { 0u8 }
                          found type `u8`
    = help: consider constraining the associated type `<A2<T> as Tr>::Ty` to `u8` or calling a method that returns `<A2<T> as Tr>::Ty`
    = note: for more information, visit https://doc.rust-lang.org/book/ch19-03-advanced-traits.html
+   = note: the associated type `<A2<T> as Tr>::Ty` is defined as `u8` in the implementation, but the generic bound `A2<T>` hides this definition
 
 error[E0308]: mismatched types
   --> $DIR/defaults-specialization.rs:44:29
@@ -89,6 +90,7 @@ LL |     fn make() -> Self::Ty { true }
    |
    = note: expected associated type `<B2<T> as Tr>::Ty`
                          found type `bool`
+   = note: the associated type `<B2<T> as Tr>::Ty` is defined as `bool` in the implementation, but the generic bound `B2<T>` hides this definition
 
 error[E0308]: mismatched types
   --> $DIR/defaults-specialization.rs:87:32
@@ -121,6 +123,7 @@ help: a method is available that returns `<B<()> as Tr>::Ty`
    |
 LL |     fn make() -> Self::Ty {
    |     ^^^^^^^^^^^^^^^^^^^^^ consider calling `Tr::make`
+   = note: the associated type `<B<()> as Tr>::Ty` is defined as `bool` in the implementation, but the generic bound `B<()>` hides this definition
 
 error[E0308]: mismatched types
   --> $DIR/defaults-specialization.rs:89:33
@@ -153,6 +156,7 @@ help: a method is available that returns `<B2<()> as Tr>::Ty`
    |
 LL |     fn make() -> Self::Ty {
    |     ^^^^^^^^^^^^^^^^^^^^^ consider calling `Tr::make`
+   = note: the associated type `<B2<()> as Tr>::Ty` is defined as `bool` in the implementation, but the generic bound `B2<()>` hides this definition
 
 error: aborting due to 9 previous errors; 1 warning emitted
 

--- a/tests/ui/associated-types/defaults-specialization.stderr
+++ b/tests/ui/associated-types/defaults-specialization.stderr
@@ -75,7 +75,8 @@ LL |     fn make() -> Self::Ty { 0u8 }
                          found type `u8`
    = help: consider constraining the associated type `<A2<T> as Tr>::Ty` to `u8` or calling a method that returns `<A2<T> as Tr>::Ty`
    = note: for more information, visit https://doc.rust-lang.org/book/ch19-03-advanced-traits.html
-   = note: the associated type `<A2<T> as Tr>::Ty` is defined as `u8` in the implementation, but the generic bound `A2<T>` hides this definition
+   = note: the associated type `<A2<T> as Tr>::Ty` is defined as `u8` in the implementation, but the where-bound `A2<T>` shadows this definition
+           see issue #152409 <https://github.com/rust-lang/rust/issues/152409> for more information
 
 error[E0308]: mismatched types
   --> $DIR/defaults-specialization.rs:44:29
@@ -90,7 +91,8 @@ LL |     fn make() -> Self::Ty { true }
    |
    = note: expected associated type `<B2<T> as Tr>::Ty`
                          found type `bool`
-   = note: the associated type `<B2<T> as Tr>::Ty` is defined as `bool` in the implementation, but the generic bound `B2<T>` hides this definition
+   = note: the associated type `<B2<T> as Tr>::Ty` is defined as `bool` in the implementation, but the where-bound `B2<T>` shadows this definition
+           see issue #152409 <https://github.com/rust-lang/rust/issues/152409> for more information
 
 error[E0308]: mismatched types
   --> $DIR/defaults-specialization.rs:87:32
@@ -123,7 +125,8 @@ help: a method is available that returns `<B<()> as Tr>::Ty`
    |
 LL |     fn make() -> Self::Ty {
    |     ^^^^^^^^^^^^^^^^^^^^^ consider calling `Tr::make`
-   = note: the associated type `<B<()> as Tr>::Ty` is defined as `bool` in the implementation, but the generic bound `B<()>` hides this definition
+   = note: the associated type `<B<()> as Tr>::Ty` is defined as `bool` in the implementation, but the where-bound `B<()>` shadows this definition
+           see issue #152409 <https://github.com/rust-lang/rust/issues/152409> for more information
 
 error[E0308]: mismatched types
   --> $DIR/defaults-specialization.rs:89:33
@@ -156,7 +159,8 @@ help: a method is available that returns `<B2<()> as Tr>::Ty`
    |
 LL |     fn make() -> Self::Ty {
    |     ^^^^^^^^^^^^^^^^^^^^^ consider calling `Tr::make`
-   = note: the associated type `<B2<()> as Tr>::Ty` is defined as `bool` in the implementation, but the generic bound `B2<()>` hides this definition
+   = note: the associated type `<B2<()> as Tr>::Ty` is defined as `bool` in the implementation, but the where-bound `B2<()>` shadows this definition
+           see issue #152409 <https://github.com/rust-lang/rust/issues/152409> for more information
 
 error: aborting due to 9 previous errors; 1 warning emitted
 

--- a/tests/ui/associated-types/param-env-shadowing-false-positive.rs
+++ b/tests/ui/associated-types/param-env-shadowing-false-positive.rs
@@ -1,3 +1,7 @@
+// Regression test for issue #149910.
+// The compiler previously incorrectly claimed that the local param-env bound
+// shadowed the global impl, but they are actually the same.
+
 trait Trait {
     type Assoc;
 }

--- a/tests/ui/associated-types/param-env-shadowing-false-positive.rs
+++ b/tests/ui/associated-types/param-env-shadowing-false-positive.rs
@@ -1,0 +1,13 @@
+trait Trait {
+    type Assoc;
+}
+
+impl<T> Trait for T {
+    type Assoc = T;
+}
+
+fn foo<T: Trait>(x: T::Assoc) -> u32 {
+    x //~ ERROR mismatched types
+}
+
+fn main() {}

--- a/tests/ui/associated-types/param-env-shadowing-false-positive.stderr
+++ b/tests/ui/associated-types/param-env-shadowing-false-positive.stderr
@@ -1,0 +1,18 @@
+error[E0308]: mismatched types
+  --> $DIR/param-env-shadowing-false-positive.rs:10:5
+   |
+LL | fn foo<T: Trait>(x: T::Assoc) -> u32 {
+   |                                  --- expected `u32` because of return type
+LL |     x
+   |     ^ expected `u32`, found associated type
+   |
+   = note:         expected type `u32`
+           found associated type `<T as Trait>::Assoc`
+help: consider constraining the associated type `<T as Trait>::Assoc` to `u32`
+   |
+LL | fn foo<T: Trait<Assoc = u32>>(x: T::Assoc) -> u32 {
+   |                +++++++++++++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/associated-types/param-env-shadowing-false-positive.stderr
+++ b/tests/ui/associated-types/param-env-shadowing-false-positive.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/param-env-shadowing-false-positive.rs:10:5
+  --> $DIR/param-env-shadowing-false-positive.rs:14:5
    |
 LL | fn foo<T: Trait>(x: T::Assoc) -> u32 {
    |                                  --- expected `u32` because of return type

--- a/tests/ui/associated-types/param-env-shadowing-gat.rs
+++ b/tests/ui/associated-types/param-env-shadowing-gat.rs
@@ -1,3 +1,7 @@
+// Regression test for issue #149910.
+// This ensures that the diagnostics logic handles Generic Associated Types (GATs)
+// correctly without crashing (ICE).
+
 trait Trait {
     type Assoc<T>;
 }

--- a/tests/ui/associated-types/param-env-shadowing-gat.rs
+++ b/tests/ui/associated-types/param-env-shadowing-gat.rs
@@ -1,0 +1,13 @@
+trait Trait {
+    type Assoc<T>;
+}
+
+impl<T> Trait for T {
+    type Assoc<U> = U;
+}
+
+fn foo<T: Trait>(x: T::Assoc<T>) -> u32 {
+    x //~ ERROR mismatched types
+}
+
+fn main() {}

--- a/tests/ui/associated-types/param-env-shadowing-gat.stderr
+++ b/tests/ui/associated-types/param-env-shadowing-gat.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/param-env-shadowing-gat.rs:10:5
+  --> $DIR/param-env-shadowing-gat.rs:14:5
    |
 LL | fn foo<T: Trait>(x: T::Assoc<T>) -> u32 {
    |                                     --- expected `u32` because of return type

--- a/tests/ui/associated-types/param-env-shadowing-gat.stderr
+++ b/tests/ui/associated-types/param-env-shadowing-gat.stderr
@@ -1,0 +1,18 @@
+error[E0308]: mismatched types
+  --> $DIR/param-env-shadowing-gat.rs:10:5
+   |
+LL | fn foo<T: Trait>(x: T::Assoc<T>) -> u32 {
+   |                                     --- expected `u32` because of return type
+LL |     x
+   |     ^ expected `u32`, found associated type
+   |
+   = note:         expected type `u32`
+           found associated type `<T as Trait>::Assoc<T>`
+help: consider constraining the associated type `<T as Trait>::Assoc<T>` to `u32`
+   |
+LL | fn foo<T: Trait<Assoc<T> = u32>>(x: T::Assoc<T>) -> u32 {
+   |                ++++++++++++++++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/associated-types/param-env-shadowing-issue-149910.rs
+++ b/tests/ui/associated-types/param-env-shadowing-issue-149910.rs
@@ -1,0 +1,14 @@
+trait Trait {
+    type Assoc;
+}
+
+impl<T> Trait for T {
+    type Assoc = T;
+}
+
+fn foo<T: Trait>(x: T) -> T::Assoc {
+    x
+    //~^ ERROR mismatched types
+}
+
+fn main() {}

--- a/tests/ui/associated-types/param-env-shadowing-issue-149910.rs
+++ b/tests/ui/associated-types/param-env-shadowing-issue-149910.rs
@@ -1,3 +1,6 @@
+// Regression test for issue #149910.
+// We want to tell the user about param_env shadowing here.
+
 trait Trait {
     type Assoc;
 }

--- a/tests/ui/associated-types/param-env-shadowing-issue-149910.stderr
+++ b/tests/ui/associated-types/param-env-shadowing-issue-149910.stderr
@@ -1,11 +1,11 @@
 error[E0308]: mismatched types
-  --> $DIR/issue-149910.rs:10:5
+  --> $DIR/param-env-shadowing-issue-149910.rs:10:5
    |
 LL | fn foo<T: Trait>(x: T) -> T::Assoc {
    |        -                  -------- expected `<T as Trait>::Assoc` because of return type
    |        |
    |        found this type parameter
-LL |     x 
+LL |     x
    |     ^ expected associated type, found type parameter `T`
    |
    = note: expected associated type `<T as Trait>::Assoc`

--- a/tests/ui/associated-types/param-env-shadowing-issue-149910.stderr
+++ b/tests/ui/associated-types/param-env-shadowing-issue-149910.stderr
@@ -10,7 +10,8 @@ LL |     x
    |
    = note: expected associated type `<T as Trait>::Assoc`
                found type parameter `T`
-   = note: the associated type `<T as Trait>::Assoc` is defined as `T` in the implementation, but the generic bound `T` hides this definition
+   = note: the associated type `<T as Trait>::Assoc` is defined as `T` in the implementation, but the where-bound `T` shadows this definition
+           see issue #152409 <https://github.com/rust-lang/rust/issues/152409> for more information
 help: consider further restricting this bound
    |
 LL | fn foo<T: Trait<Assoc = T>>(x: T) -> T::Assoc {

--- a/tests/ui/associated-types/param-env-shadowing-issue-149910.stderr
+++ b/tests/ui/associated-types/param-env-shadowing-issue-149910.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/param-env-shadowing-issue-149910.rs:10:5
+  --> $DIR/param-env-shadowing-issue-149910.rs:13:5
    |
 LL | fn foo<T: Trait>(x: T) -> T::Assoc {
    |        -                  -------- expected `<T as Trait>::Assoc` because of return type

--- a/tests/ui/associated-types/param-env-shadowing-issue-149910.stderr
+++ b/tests/ui/associated-types/param-env-shadowing-issue-149910.stderr
@@ -1,0 +1,21 @@
+error[E0308]: mismatched types
+  --> $DIR/issue-149910.rs:10:5
+   |
+LL | fn foo<T: Trait>(x: T) -> T::Assoc {
+   |        -                  -------- expected `<T as Trait>::Assoc` because of return type
+   |        |
+   |        found this type parameter
+LL |     x 
+   |     ^ expected associated type, found type parameter `T`
+   |
+   = note: expected associated type `<T as Trait>::Assoc`
+               found type parameter `T`
+   = note: the associated type `<T as Trait>::Assoc` is defined as `T` in the implementation, but the generic bound `T` hides this definition
+help: consider further restricting this bound
+   |
+LL | fn foo<T: Trait<Assoc = T>>(x: T) -> T::Assoc {
+   |                +++++++++++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/specialization/specialization-default-projection.current.stderr
+++ b/tests/ui/specialization/specialization-default-projection.current.stderr
@@ -21,6 +21,7 @@ LL |     ()
                     found unit type `()`
    = help: consider constraining the associated type `<T as Foo>::Assoc` to `()` or calling a method that returns `<T as Foo>::Assoc`
    = note: for more information, visit https://doc.rust-lang.org/book/ch19-03-advanced-traits.html
+   = note: the associated type `<T as Foo>::Assoc` is defined as `()` in the implementation, but the generic bound `T` hides this definition
 
 error[E0308]: mismatched types
   --> $DIR/specialization-default-projection.rs:32:5
@@ -37,6 +38,7 @@ LL |     generic::<()>()
            found associated type `<() as Foo>::Assoc`
    = help: consider constraining the associated type `<() as Foo>::Assoc` to `()`
    = note: for more information, visit https://doc.rust-lang.org/book/ch19-03-advanced-traits.html
+   = note: the associated type `<() as Foo>::Assoc` is defined as `()` in the implementation, but the generic bound `()` hides this definition
 
 error: aborting due to 2 previous errors; 1 warning emitted
 

--- a/tests/ui/specialization/specialization-default-projection.current.stderr
+++ b/tests/ui/specialization/specialization-default-projection.current.stderr
@@ -21,7 +21,8 @@ LL |     ()
                     found unit type `()`
    = help: consider constraining the associated type `<T as Foo>::Assoc` to `()` or calling a method that returns `<T as Foo>::Assoc`
    = note: for more information, visit https://doc.rust-lang.org/book/ch19-03-advanced-traits.html
-   = note: the associated type `<T as Foo>::Assoc` is defined as `()` in the implementation, but the generic bound `T` hides this definition
+   = note: the associated type `<T as Foo>::Assoc` is defined as `()` in the implementation, but the where-bound `T` shadows this definition
+           see issue #152409 <https://github.com/rust-lang/rust/issues/152409> for more information
 
 error[E0308]: mismatched types
   --> $DIR/specialization-default-projection.rs:32:5
@@ -38,7 +39,8 @@ LL |     generic::<()>()
            found associated type `<() as Foo>::Assoc`
    = help: consider constraining the associated type `<() as Foo>::Assoc` to `()`
    = note: for more information, visit https://doc.rust-lang.org/book/ch19-03-advanced-traits.html
-   = note: the associated type `<() as Foo>::Assoc` is defined as `()` in the implementation, but the generic bound `()` hides this definition
+   = note: the associated type `<() as Foo>::Assoc` is defined as `()` in the implementation, but the where-bound `()` shadows this definition
+           see issue #152409 <https://github.com/rust-lang/rust/issues/152409> for more information
 
 error: aborting due to 2 previous errors; 1 warning emitted
 

--- a/tests/ui/specialization/specialization-default-projection.next.stderr
+++ b/tests/ui/specialization/specialization-default-projection.next.stderr
@@ -21,6 +21,7 @@ LL |     ()
                     found unit type `()`
    = help: consider constraining the associated type `<T as Foo>::Assoc` to `()` or calling a method that returns `<T as Foo>::Assoc`
    = note: for more information, visit https://doc.rust-lang.org/book/ch19-03-advanced-traits.html
+   = note: the associated type `<T as Foo>::Assoc` is defined as `()` in the implementation, but the generic bound `T` hides this definition
 
 error[E0308]: mismatched types
   --> $DIR/specialization-default-projection.rs:32:5
@@ -37,6 +38,7 @@ LL |     generic::<()>()
            found associated type `<() as Foo>::Assoc`
    = help: consider constraining the associated type `<() as Foo>::Assoc` to `()`
    = note: for more information, visit https://doc.rust-lang.org/book/ch19-03-advanced-traits.html
+   = note: the associated type `<() as Foo>::Assoc` is defined as `()` in the implementation, but the generic bound `()` hides this definition
 
 error: aborting due to 2 previous errors; 1 warning emitted
 

--- a/tests/ui/specialization/specialization-default-projection.next.stderr
+++ b/tests/ui/specialization/specialization-default-projection.next.stderr
@@ -21,7 +21,8 @@ LL |     ()
                     found unit type `()`
    = help: consider constraining the associated type `<T as Foo>::Assoc` to `()` or calling a method that returns `<T as Foo>::Assoc`
    = note: for more information, visit https://doc.rust-lang.org/book/ch19-03-advanced-traits.html
-   = note: the associated type `<T as Foo>::Assoc` is defined as `()` in the implementation, but the generic bound `T` hides this definition
+   = note: the associated type `<T as Foo>::Assoc` is defined as `()` in the implementation, but the where-bound `T` shadows this definition
+           see issue #152409 <https://github.com/rust-lang/rust/issues/152409> for more information
 
 error[E0308]: mismatched types
   --> $DIR/specialization-default-projection.rs:32:5
@@ -38,7 +39,8 @@ LL |     generic::<()>()
            found associated type `<() as Foo>::Assoc`
    = help: consider constraining the associated type `<() as Foo>::Assoc` to `()`
    = note: for more information, visit https://doc.rust-lang.org/book/ch19-03-advanced-traits.html
-   = note: the associated type `<() as Foo>::Assoc` is defined as `()` in the implementation, but the generic bound `()` hides this definition
+   = note: the associated type `<() as Foo>::Assoc` is defined as `()` in the implementation, but the where-bound `()` shadows this definition
+           see issue #152409 <https://github.com/rust-lang/rust/issues/152409> for more information
 
 error: aborting due to 2 previous errors; 1 warning emitted
 

--- a/tests/ui/specialization/specialization-default-types.current.stderr
+++ b/tests/ui/specialization/specialization-default-types.current.stderr
@@ -20,6 +20,7 @@ LL |         Box::new(self)
    |
    = note: expected associated type `<T as Example>::Output`
                        found struct `Box<T>`
+   = note: the associated type `<T as Example>::Output` is defined as `Box<T>` in the implementation, but the generic bound `T` hides this definition
 
 error[E0308]: mismatched types
   --> $DIR/specialization-default-types.rs:29:5
@@ -33,6 +34,7 @@ LL |     Example::generate(t)
            found associated type `<T as Example>::Output`
    = help: consider constraining the associated type `<T as Example>::Output` to `Box<T>`
    = note: for more information, visit https://doc.rust-lang.org/book/ch19-03-advanced-traits.html
+   = note: the associated type `<T as Example>::Output` is defined as `Box<T>` in the implementation, but the generic bound `T` hides this definition
 
 error: aborting due to 2 previous errors; 1 warning emitted
 

--- a/tests/ui/specialization/specialization-default-types.current.stderr
+++ b/tests/ui/specialization/specialization-default-types.current.stderr
@@ -20,7 +20,8 @@ LL |         Box::new(self)
    |
    = note: expected associated type `<T as Example>::Output`
                        found struct `Box<T>`
-   = note: the associated type `<T as Example>::Output` is defined as `Box<T>` in the implementation, but the generic bound `T` hides this definition
+   = note: the associated type `<T as Example>::Output` is defined as `Box<T>` in the implementation, but the where-bound `T` shadows this definition
+           see issue #152409 <https://github.com/rust-lang/rust/issues/152409> for more information
 
 error[E0308]: mismatched types
   --> $DIR/specialization-default-types.rs:29:5
@@ -34,7 +35,8 @@ LL |     Example::generate(t)
            found associated type `<T as Example>::Output`
    = help: consider constraining the associated type `<T as Example>::Output` to `Box<T>`
    = note: for more information, visit https://doc.rust-lang.org/book/ch19-03-advanced-traits.html
-   = note: the associated type `<T as Example>::Output` is defined as `Box<T>` in the implementation, but the generic bound `T` hides this definition
+   = note: the associated type `<T as Example>::Output` is defined as `Box<T>` in the implementation, but the where-bound `T` shadows this definition
+           see issue #152409 <https://github.com/rust-lang/rust/issues/152409> for more information
 
 error: aborting due to 2 previous errors; 1 warning emitted
 

--- a/tests/ui/specialization/specialization-default-types.next.stderr
+++ b/tests/ui/specialization/specialization-default-types.next.stderr
@@ -20,6 +20,7 @@ LL |         Box::new(self)
    |
    = note: expected associated type `<T as Example>::Output`
                        found struct `Box<T>`
+   = note: the associated type `<T as Example>::Output` is defined as `Box<T>` in the implementation, but the generic bound `T` hides this definition
 
 error[E0308]: mismatched types
   --> $DIR/specialization-default-types.rs:29:5
@@ -33,6 +34,7 @@ LL |     Example::generate(t)
            found associated type `<T as Example>::Output`
    = help: consider constraining the associated type `<T as Example>::Output` to `Box<T>`
    = note: for more information, visit https://doc.rust-lang.org/book/ch19-03-advanced-traits.html
+   = note: the associated type `<T as Example>::Output` is defined as `Box<T>` in the implementation, but the generic bound `T` hides this definition
 
 error: aborting due to 2 previous errors; 1 warning emitted
 

--- a/tests/ui/specialization/specialization-default-types.next.stderr
+++ b/tests/ui/specialization/specialization-default-types.next.stderr
@@ -20,7 +20,8 @@ LL |         Box::new(self)
    |
    = note: expected associated type `<T as Example>::Output`
                        found struct `Box<T>`
-   = note: the associated type `<T as Example>::Output` is defined as `Box<T>` in the implementation, but the generic bound `T` hides this definition
+   = note: the associated type `<T as Example>::Output` is defined as `Box<T>` in the implementation, but the where-bound `T` shadows this definition
+           see issue #152409 <https://github.com/rust-lang/rust/issues/152409> for more information
 
 error[E0308]: mismatched types
   --> $DIR/specialization-default-types.rs:29:5
@@ -34,7 +35,8 @@ LL |     Example::generate(t)
            found associated type `<T as Example>::Output`
    = help: consider constraining the associated type `<T as Example>::Output` to `Box<T>`
    = note: for more information, visit https://doc.rust-lang.org/book/ch19-03-advanced-traits.html
-   = note: the associated type `<T as Example>::Output` is defined as `Box<T>` in the implementation, but the generic bound `T` hides this definition
+   = note: the associated type `<T as Example>::Output` is defined as `Box<T>` in the implementation, but the where-bound `T` shadows this definition
+           see issue #152409 <https://github.com/rust-lang/rust/issues/152409> for more information
 
 error: aborting due to 2 previous errors; 1 warning emitted
 


### PR DESCRIPTION
 This PR adds a diagnostics note when param-env shadows global impl as discussed in https://github.com/rust-lang/rust/issues/149910

It adds a note explaining that the definition is hidden by the generic bound.

r?lcnr
