### PR TITLE
mapping an error from cmd.spawn() in npm::install

### DIFF
--- a/src/build_helper/src/npm.rs
+++ b/src/build_helper/src/npm.rs
@@ -22,7 +22,16 @@ pub fn install(src_root_path: &Path, out_dir: &Path, yarn: &Path) -> Result<Path
     cmd.arg("--frozen");
 
     cmd.current_dir(out_dir);
-    let exit_status = cmd.spawn()?.wait()?;
+    let exit_status = cmd
+        .spawn()
+        .map_err(|err| {
+            eprintln!("can not run yarn install");
+            io::Error::other(Box::<dyn Error + Send + Sync>::from(format!(
+                "unable to run yarn: {}",
+                err.kind()
+            )))
+        })?
+        .wait()?;
     if !exit_status.success() {
         eprintln!("yarn install did not exit successfully");
         return Err(io::Error::other(Box::<dyn Error + Send + Sync>::from(format!(


### PR DESCRIPTION
If the tool (yarn) has a problem, spawn in the install() raises an error, but the error message is hard to understand which/how application/file/directory has a problem. This commit enhances the error to explain why it fails.

For example, when I ran `./x test tidy --extra-checks=js`:
```bash
...
tidy check
tidy [extra_checks]: IO error: No such file or directory (os error 2)
tidy [extra_checks]: FAIL
tidy: The following check failed: extra_checks
```
.. It doesn't explain yarn has a problem (in that case, my env didn't have yarn).

After this PR, the same command prints:
```bash
tidy check
can not run yarn install
tidy [extra_checks]: IO error: unable to run yarn: entity not found
tidy [extra_checks]: FAIL
tidy: The following check failed: extra_checks
```