### PR TITLE
Improve missing core error for tier 3 targets

### DIFF
--- a/compiler/rustc_metadata/src/errors.rs
+++ b/compiler/rustc_metadata/src/errors.rs
@@ -466,6 +466,7 @@ pub struct CannotFindCrate {
     pub profiler_runtime: Symbol,
     pub locator_triple: TargetTuple,
     pub is_ui_testing: bool,
+    pub is_tier_3: bool,
 }
 
 impl<G: EmissionGuarantee> Diagnostic<'_, G> for CannotFindCrate {
@@ -485,11 +486,13 @@ impl<G: EmissionGuarantee> Diagnostic<'_, G> for CannotFindCrate {
                 diag.note(fluent::metadata_target_no_std_support);
             }
 
+            let has_precompiled_std = !self.is_tier_3;
+
             if self.missing_core {
                 if env!("CFG_RELEASE_CHANNEL") == "dev" && !self.is_ui_testing {
                     // Note: Emits the nicer suggestion only for the dev channel.
                     diag.help(fluent::metadata_consider_adding_std);
-                } else {
+                } else if has_precompiled_std {
                     // NOTE: this suggests using rustup, even though the user may not have it installed.
                     // That's because they could choose to install it; or this may give them a hint which
                     // target they need to install from their distro.
@@ -504,7 +507,9 @@ impl<G: EmissionGuarantee> Diagnostic<'_, G> for CannotFindCrate {
             if !self.missing_core && self.span.is_dummy() {
                 diag.note(fluent::metadata_std_required);
             }
-            if self.is_nightly_build {
+            // Recommend -Zbuild-std even on stable builds for Tier 3 targets because
+            // it's the recommended way to use the target, the user should switch to nightly.
+            if self.is_nightly_build || !has_precompiled_std {
                 diag.help(fluent::metadata_consider_building_std);
             }
         } else if self.crate_name == self.profiler_runtime {

--- a/compiler/rustc_metadata/src/locator.rs
+++ b/compiler/rustc_metadata/src/locator.rs
@@ -1224,6 +1224,7 @@ impl CrateError {
                         profiler_runtime: Symbol::intern(&sess.opts.unstable_opts.profiler_runtime),
                         locator_triple: locator.triple,
                         is_ui_testing: sess.opts.unstable_opts.ui_testing,
+                        is_tier_3: sess.target.metadata.tier == Some(3),
                     };
                     // The diagnostic for missing core is very good, but it is followed by a lot of
                     // other diagnostics that do not add information.
@@ -1249,6 +1250,7 @@ impl CrateError {
                     profiler_runtime: Symbol::intern(&sess.opts.unstable_opts.profiler_runtime),
                     locator_triple: sess.opts.target_triple.clone(),
                     is_ui_testing: sess.opts.unstable_opts.ui_testing,
+                    is_tier_3: sess.target.metadata.tier == Some(3),
                 };
                 // The diagnostic for missing core is very good, but it is followed by a lot of
                 // other diagnostics that do not add information.

--- a/tests/ui/crate-loading/missing-std-tier-3.rs
+++ b/tests/ui/crate-loading/missing-std-tier-3.rs
@@ -1,0 +1,14 @@
+// Ensure that we do not recommend rustup installing tier 3 targets.
+
+//@ compile-flags: --target m68k-unknown-linux-gnu
+//@ needs-llvm-components: m68k
+//@ rustc-env:CARGO_CRATE_NAME=foo
+//@ ignore-backends: gcc
+#![feature(no_core)]
+#![no_core]
+extern crate core;
+//~^ ERROR can't find crate for `core`
+//~| NOTE can't find crate
+//~| NOTE target may not be installed
+//~| HELP consider building the standard library from source with `cargo build -Zbuild-std`
+fn main() {}

--- a/tests/ui/crate-loading/missing-std-tier-3.stderr
+++ b/tests/ui/crate-loading/missing-std-tier-3.stderr
@@ -1,0 +1,12 @@
+error[E0463]: can't find crate for `core`
+  --> $DIR/missing-std-tier-3.rs:9:1
+   |
+LL | extern crate core;
+   | ^^^^^^^^^^^^^^^^^^ can't find crate
+   |
+   = note: the `m68k-unknown-linux-gnu` target may not be installed
+   = help: consider building the standard library from source with `cargo build -Zbuild-std`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0463`.


### PR DESCRIPTION
Tier 3 targets can't be installed via rustup, so don't recommend that. Additionally, do recommend build-std on stable because it's the recommended way to use these targets, people should switch to nightly.