### PR TITLE
test and document that `proc_macro::Ident` is NFC-normalized

### DIFF
--- a/library/proc_macro/src/lib.rs
+++ b/library/proc_macro/src/lib.rs
@@ -1038,6 +1038,8 @@ impl Ident {
     /// The `string` argument must be a valid identifier permitted by the
     /// language (including keywords, e.g. `self` or `fn`). Otherwise, the function will panic.
     ///
+    /// The constructed identifier will be NFC-normalized. See the [Reference] for more info.
+    ///
     /// Note that `span`, currently in rustc, configures the hygiene information
     /// for this identifier.
     ///
@@ -1052,6 +1054,8 @@ impl Ident {
     ///
     /// Due to the current importance of hygiene this constructor, unlike other
     /// tokens, requires a `Span` to be specified at construction.
+    ///
+    /// [Reference]: https://doc.rust-lang.org/nightly/reference/identifiers.html#r-ident.normalization
     #[stable(feature = "proc_macro_lib2", since = "1.29.0")]
     pub fn new(string: &str, span: Span) -> Ident {
         Ident(bridge::Ident {

--- a/tests/ui/proc-macro/auxiliary/api/ident.rs
+++ b/tests/ui/proc-macro/auxiliary/api/ident.rs
@@ -1,0 +1,37 @@
+use proc_macro::{Ident, Span};
+
+// FIXME: `Ident` does not yet implement `PartialEq<Ident>` directly (#146553)
+fn assert_eq(l: Ident, r: Ident) {
+    assert_eq!(l.to_string(), r.to_string());
+}
+
+fn assert_ne(l: Ident, r: Ident) {
+    assert_ne!(l.to_string(), r.to_string());
+}
+
+fn new(s: &str) -> Ident {
+    Ident::new(s, Span::call_site())
+}
+
+fn new_raw(s: &str) -> Ident {
+    Ident::new_raw(s, Span::call_site())
+}
+
+const LATIN_CAPITAL_LETTER_K: &str = "K";
+const KELVIN_SIGN: &str = "K";
+
+const NORMAL_MIDDLE_DOT: &str = "L·L";
+const GREEK_ANO_TELEIA: &str = "L·L";
+
+pub fn test() {
+    assert_eq(new("foo"), new("foo"));
+    assert_ne(new("foo"), new_raw("foo"));
+
+    assert_ne!(LATIN_CAPITAL_LETTER_K, KELVIN_SIGN);
+    assert_eq(new(LATIN_CAPITAL_LETTER_K), new(KELVIN_SIGN));
+    assert_eq(new_raw(LATIN_CAPITAL_LETTER_K), new_raw(KELVIN_SIGN));
+
+    assert_ne!(NORMAL_MIDDLE_DOT, GREEK_ANO_TELEIA);
+    assert_eq(new(NORMAL_MIDDLE_DOT), new(GREEK_ANO_TELEIA));
+    assert_eq(new_raw(NORMAL_MIDDLE_DOT), new_raw(GREEK_ANO_TELEIA));
+}

--- a/tests/ui/proc-macro/auxiliary/api/proc_macro_api_tests.rs
+++ b/tests/ui/proc-macro/auxiliary/api/proc_macro_api_tests.rs
@@ -6,6 +6,7 @@
 extern crate proc_macro;
 
 mod cmp;
+mod ident;
 mod literal;
 
 use proc_macro::TokenStream;
@@ -15,6 +16,7 @@ pub fn run(input: TokenStream) -> TokenStream {
     assert!(input.is_empty());
 
     cmp::test();
+    ident::test();
     literal::test();
 
     TokenStream::new()


### PR DESCRIPTION
Previously, this was not tested at all and the test suite would pass even when replacing the `normalize_and_validate_ident` implementation with a `panic!`.