### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -150,10 +150,13 @@ impl From<Ident> for LifetimeSyntax {
 /// `LifetimeSource::OutlivesBound` or `LifetimeSource::PreciseCapturing`
 /// — there's no way to "elide" these lifetimes.
 #[derive(Debug, Copy, Clone, HashStable_Generic)]
-// Raise the aligement to at least 4 bytes - this is relied on in other parts of the compiler(for pointer tagging):
-// https://github.com/rust-lang/rust/blob/ce5fdd7d42aba9a2925692e11af2bd39cf37798a/compiler/rustc_data_structures/src/tagged_ptr.rs#L163
-// Removing this `repr(4)` will cause the compiler to not build on platforms like `m68k` Linux, where the aligement of u32 and usize is only 2.
-// Since `repr(align)` may only raise aligement, this has no effect on platforms where the aligement is already sufficient.
+// Raise the alignment to at least 4 bytes.
+// This is relied on in other parts of the compiler (for pointer tagging):
+// <https://github.com/rust-lang/rust/blob/ce5fdd7d42aba9a2925692e11af2bd39cf37798a/compiler/rustc_data_structures/src/tagged_ptr.rs#L163>
+// Removing this `repr(4)` will cause the compiler to not build on platforms
+// like `m68k` Linux, where the alignment of u32 and usize is only 2.
+// Since `repr(align)` may only raise alignment, this has no effect on
+// platforms where the alignment is already sufficient.
 #[repr(align(4))]
 pub struct Lifetime {
     #[stable_hasher(ignore)]

--- a/library/std/src/os/unix/net/stream.rs
+++ b/library/std/src/os/unix/net/stream.rs
@@ -63,7 +63,7 @@ use crate::time::Duration;
 /// On platforms that support it, we pass the close-on-exec flag to atomically create the socket and
 /// set it as CLOEXEC. On Linux, this was added in 2.6.27. See [`socket(2)`] for more information.
 ///
-/// [`socket(2)`](https://www.man7.org/linux/man-pages/man2/socket.2.html#:~:text=SOCK_CLOEXEC)
+/// [`socket(2)`]: https://www.man7.org/linux/man-pages/man2/socket.2.html#:~:text=SOCK_CLOEXEC
 ///
 /// # `SIGPIPE`
 ///

--- a/library/std/src/os/unix/net/stream.rs
+++ b/library/std/src/os/unix/net/stream.rs
@@ -58,6 +58,13 @@ use crate::time::Duration;
 /// }
 /// ```
 ///
+/// # `SOCK_CLOEXEC`
+///
+/// On platforms that support it, we pass the close-on-exec flag to atomically create the socket and
+/// set it as CLOEXEC. On Linux, this was added in 2.6.27. See [`socket(2)`] for more information.
+///
+/// [`socket(2)`](https://www.man7.org/linux/man-pages/man2/socket.2.html#:~:text=SOCK_CLOEXEC)
+///
 /// # `SIGPIPE`
 ///
 /// Writes to the underlying socket in `SOCK_STREAM` mode are made with `MSG_NOSIGNAL` flag.

--- a/tests/rustdoc/extern/duplicate-reexports-section-150211.rs
+++ b/tests/rustdoc/extern/duplicate-reexports-section-150211.rs
@@ -1,0 +1,19 @@
+//@ aux-build:pub-extern-crate.rs
+
+// Regression test for issue <https://github.com/rust-lang/rust/issues/150211>.
+// When a module has both `pub extern crate` and `pub use` items,
+// they should both appear under a single "Re-exports" section,
+// not two separate sections.
+
+//@ has duplicate_reexports_section_150211/index.html
+// Verify there's exactly one Re-exports section header
+//@ count - '//h2[@id="reexports"]' 1
+//@ has - '//h2[@id="reexports"]' 'Re-exports'
+// Verify both the extern crate and the use item are present
+//@ has - '//code' 'pub extern crate inner;'
+//@ has - '//code' 'pub use inner::SomeStruct;'
+
+pub extern crate inner;
+
+#[doc(no_inline)]
+pub use inner::SomeStruct;


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#150362 (rustdoc: fix duplicate Re-exports sections)
 - rust-lang/rust#150397 (Update hir.rs: fix typo ("aligement" -> "alignment"), conform to max_width)
 - rust-lang/rust#150410 (Document default SOCK_CLOEXEC flag on new UnixStream)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=150362,150397,150410)
<!-- homu-ignore:end -->