### PR TITLE
Add test for never type fallback in try blocks with `Into<!>`

### DIFF
--- a/tests/ui/never_type/try-block-never-type-fallback.e2021.stderr
+++ b/tests/ui/never_type/try-block-never-type-fallback.e2021.stderr
@@ -1,0 +1,20 @@
+error[E0277]: the trait bound `!: From<()>` is not satisfied
+  --> $DIR/try-block-never-type-fallback.rs:20:9
+   |
+LL |     bar(try { x? });
+   |     --- ^^^^^^^^^^ the trait `From<()>` is not implemented for `!`
+   |     |
+   |     required by a bound introduced by this call
+   |
+   = note: this error might have been caused by changes to Rust's type-inference algorithm (see issue #148922 <https://github.com/rust-lang/rust/issues/148922> for more information)
+   = help: you might have intended to use the type `()` here instead
+   = note: required for `()` to implement `Into<!>`
+note: required by a bound in `bar`
+  --> $DIR/try-block-never-type-fallback.rs:15:23
+   |
+LL | fn bar(_: Result<impl Into<!>, u32>) {
+   |                       ^^^^^^^ required by this bound in `bar`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/never_type/try-block-never-type-fallback.rs
+++ b/tests/ui/never_type/try-block-never-type-fallback.rs
@@ -1,0 +1,25 @@
+//@ revisions: e2021 e2024
+//@[e2021] edition: 2021
+//@[e2024] edition: 2024
+//@[e2024] check-pass
+
+// Issue #125364: Bad interaction between never_type, try_blocks, and From/Into
+//
+// In edition 2021, the never type in try blocks falls back to (),
+// causing a type error (since (): Into<!> does not hold).
+// In edition 2024, it falls back to !, allowing the code to compile correctly.
+
+#![feature(never_type)]
+#![feature(try_blocks)]
+
+fn bar(_: Result<impl Into<!>, u32>) {
+    unimplemented!()
+}
+
+fn foo(x: Result<!, u32>) {
+    bar(try { x? });
+    //[e2021]~^ ERROR the trait bound `!: From<()>` is not satisfied
+}
+
+fn main() {
+}


### PR DESCRIPTION
### Summary

Adds UI tests for issue rust-lang/rust#125364, which involves the interaction between 
never type fallback, try blocks, and `From`/`Into` trait bounds.

### Changes

- Added `tests/ui/never_type/try-block-never-type-fallback.rs`
- Tests both edition 2021 (where the issue manifests) and edition 2024 (where it's fixed)

### Issue

Closes rust-lang/rust#125364

### Testing

```bash
./x test tests/ui/never_type/try-block-never-type-fallback.rs
```

Both test variants pass:

e2021: Correctly fails with expected error
e2024: Compiles successfully (check-pass)

### Notes

This test documents the edition-dependent behavior of never type fallback in try blocks, as requested in the original issue.

cc @WaffleLapkin

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? WaffleLapkin
-->
<!-- homu-ignore:end -->
