### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -150,10 +150,13 @@ impl From<Ident> for LifetimeSyntax {
 /// `LifetimeSource::OutlivesBound` or `LifetimeSource::PreciseCapturing`
 /// — there's no way to "elide" these lifetimes.
 #[derive(Debug, Copy, Clone, HashStable_Generic)]
-// Raise the aligement to at least 4 bytes - this is relied on in other parts of the compiler(for pointer tagging):
-// https://github.com/rust-lang/rust/blob/ce5fdd7d42aba9a2925692e11af2bd39cf37798a/compiler/rustc_data_structures/src/tagged_ptr.rs#L163
-// Removing this `repr(4)` will cause the compiler to not build on platforms like `m68k` Linux, where the aligement of u32 and usize is only 2.
-// Since `repr(align)` may only raise aligement, this has no effect on platforms where the aligement is already sufficient.
+// Raise the alignment to at least 4 bytes.
+// This is relied on in other parts of the compiler (for pointer tagging):
+// <https://github.com/rust-lang/rust/blob/ce5fdd7d42aba9a2925692e11af2bd39cf37798a/compiler/rustc_data_structures/src/tagged_ptr.rs#L163>
+// Removing this `repr(4)` will cause the compiler to not build on platforms
+// like `m68k` Linux, where the alignment of u32 and usize is only 2.
+// Since `repr(align)` may only raise alignment, this has no effect on
+// platforms where the alignment is already sufficient.
 #[repr(align(4))]
 pub struct Lifetime {
     #[stable_hasher(ignore)]

--- a/compiler/rustc_metadata/src/errors.rs
+++ b/compiler/rustc_metadata/src/errors.rs
@@ -466,6 +466,7 @@ pub struct CannotFindCrate {
     pub profiler_runtime: Symbol,
     pub locator_triple: TargetTuple,
     pub is_ui_testing: bool,
+    pub is_tier_3: bool,
 }
 
 impl<G: EmissionGuarantee> Diagnostic<'_, G> for CannotFindCrate {
@@ -485,11 +486,13 @@ impl<G: EmissionGuarantee> Diagnostic<'_, G> for CannotFindCrate {
                 diag.note(fluent::metadata_target_no_std_support);
             }
 
+            let has_precompiled_std = !self.is_tier_3;
+
             if self.missing_core {
                 if env!("CFG_RELEASE_CHANNEL") == "dev" && !self.is_ui_testing {
                     // Note: Emits the nicer suggestion only for the dev channel.
                     diag.help(fluent::metadata_consider_adding_std);
-                } else {
+                } else if has_precompiled_std {
                     // NOTE: this suggests using rustup, even though the user may not have it installed.
                     // That's because they could choose to install it; or this may give them a hint which
                     // target they need to install from their distro.
@@ -504,7 +507,9 @@ impl<G: EmissionGuarantee> Diagnostic<'_, G> for CannotFindCrate {
             if !self.missing_core && self.span.is_dummy() {
                 diag.note(fluent::metadata_std_required);
             }
-            if self.is_nightly_build {
+            // Recommend -Zbuild-std even on stable builds for Tier 3 targets because
+            // it's the recommended way to use the target, the user should switch to nightly.
+            if self.is_nightly_build || !has_precompiled_std {
                 diag.help(fluent::metadata_consider_building_std);
             }
         } else if self.crate_name == self.profiler_runtime {

--- a/compiler/rustc_metadata/src/locator.rs
+++ b/compiler/rustc_metadata/src/locator.rs
@@ -1224,6 +1224,7 @@ impl CrateError {
                         profiler_runtime: Symbol::intern(&sess.opts.unstable_opts.profiler_runtime),
                         locator_triple: locator.triple,
                         is_ui_testing: sess.opts.unstable_opts.ui_testing,
+                        is_tier_3: sess.target.metadata.tier == Some(3),
                     };
                     // The diagnostic for missing core is very good, but it is followed by a lot of
                     // other diagnostics that do not add information.
@@ -1249,6 +1250,7 @@ impl CrateError {
                     profiler_runtime: Symbol::intern(&sess.opts.unstable_opts.profiler_runtime),
                     locator_triple: sess.opts.target_triple.clone(),
                     is_ui_testing: sess.opts.unstable_opts.ui_testing,
+                    is_tier_3: sess.target.metadata.tier == Some(3),
                 };
                 // The diagnostic for missing core is very good, but it is followed by a lot of
                 // other diagnostics that do not add information.

--- a/library/std/src/os/unix/net/stream.rs
+++ b/library/std/src/os/unix/net/stream.rs
@@ -63,7 +63,7 @@ use crate::time::Duration;
 /// On platforms that support it, we pass the close-on-exec flag to atomically create the socket and
 /// set it as CLOEXEC. On Linux, this was added in 2.6.27. See [`socket(2)`] for more information.
 ///
-/// [`socket(2)`](https://www.man7.org/linux/man-pages/man2/socket.2.html#:~:text=SOCK_CLOEXEC)
+/// [`socket(2)`]: https://www.man7.org/linux/man-pages/man2/socket.2.html#:~:text=SOCK_CLOEXEC
 ///
 /// # `SIGPIPE`
 ///

--- a/library/std/src/os/unix/net/stream.rs
+++ b/library/std/src/os/unix/net/stream.rs
@@ -58,6 +58,13 @@ use crate::time::Duration;
 /// }
 /// ```
 ///
+/// # `SOCK_CLOEXEC`
+///
+/// On platforms that support it, we pass the close-on-exec flag to atomically create the socket and
+/// set it as CLOEXEC. On Linux, this was added in 2.6.27. See [`socket(2)`] for more information.
+///
+/// [`socket(2)`](https://www.man7.org/linux/man-pages/man2/socket.2.html#:~:text=SOCK_CLOEXEC)
+///
 /// # `SIGPIPE`
 ///
 /// Writes to the underlying socket in `SOCK_STREAM` mode are made with `MSG_NOSIGNAL` flag.

--- a/tests/rustdoc/extern/duplicate-reexports-section-150211.rs
+++ b/tests/rustdoc/extern/duplicate-reexports-section-150211.rs
@@ -1,0 +1,19 @@
+//@ aux-build:pub-extern-crate.rs
+
+// Regression test for issue <https://github.com/rust-lang/rust/issues/150211>.
+// When a module has both `pub extern crate` and `pub use` items,
+// they should both appear under a single "Re-exports" section,
+// not two separate sections.
+
+//@ has duplicate_reexports_section_150211/index.html
+// Verify there's exactly one Re-exports section header
+//@ count - '//h2[@id="reexports"]' 1
+//@ has - '//h2[@id="reexports"]' 'Re-exports'
+// Verify both the extern crate and the use item are present
+//@ has - '//code' 'pub extern crate inner;'
+//@ has - '//code' 'pub use inner::SomeStruct;'
+
+pub extern crate inner;
+
+#[doc(no_inline)]
+pub use inner::SomeStruct;

--- a/tests/ui/crate-loading/missing-std-tier-3.rs
+++ b/tests/ui/crate-loading/missing-std-tier-3.rs
@@ -1,0 +1,14 @@
+// Ensure that we do not recommend rustup installing tier 3 targets.
+
+//@ compile-flags: --target m68k-unknown-linux-gnu
+//@ needs-llvm-components: m68k
+//@ rustc-env:CARGO_CRATE_NAME=foo
+//@ ignore-backends: gcc
+#![feature(no_core)]
+#![no_core]
+extern crate core;
+//~^ ERROR can't find crate for `core`
+//~| NOTE can't find crate
+//~| NOTE target may not be installed
+//~| HELP consider building the standard library from source with `cargo build -Zbuild-std`
+fn main() {}

--- a/tests/ui/crate-loading/missing-std-tier-3.stderr
+++ b/tests/ui/crate-loading/missing-std-tier-3.stderr
@@ -1,0 +1,12 @@
+error[E0463]: can't find crate for `core`
+  --> $DIR/missing-std-tier-3.rs:9:1
+   |
+LL | extern crate core;
+   | ^^^^^^^^^^^^^^^^^^ can't find crate
+   |
+   = note: the `m68k-unknown-linux-gnu` target may not be installed
+   = help: consider building the standard library from source with `cargo build -Zbuild-std`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0463`.


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#150362 (rustdoc: fix duplicate Re-exports sections)
 - rust-lang/rust#150397 (Update hir.rs: fix typo ("aligement" -> "alignment"), conform to max_width)
 - rust-lang/rust#150410 (Document default SOCK_CLOEXEC flag on new UnixStream)
 - rust-lang/rust#150429 (Improve missing core error for tier 3 targets)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=150362,150397,150410,150429)
<!-- homu-ignore:end -->