### PR TITLE
Remove mentions of debootstrap and chroots from the m68k-unknown-none-elf platform support doc

### DIFF
--- a/src/doc/rustc/src/platform-support/m68k-unknown-none-elf.md
+++ b/src/doc/rustc/src/platform-support/m68k-unknown-none-elf.md
@@ -12,6 +12,7 @@ Bare metal Motorola 680x0
 
 This target requires an m68k build environment for cross-compilation which
 is available on Debian, Debian-based systems, openSUSE, and other distributions.
+The gnu linker is currently required, as `lld` has no support for the `m68k` architecture
 
 On Debian-based systems, it should be sufficient to install a g++ cross-compiler for the m68k
 architecture which will automatically pull in additional dependencies such as
@@ -31,7 +32,7 @@ binaries:
 
 ## Building
 
-At least llvm version `19.1.5` is required to build `core` and `alloc` for this target, and currently the gnu linker is required, as `lld` has no support for the `m68k` architecture
+At least llvm version `19.1.5` is required to build `core` and `alloc` for this target.
 
 ## Cross-compilation
 

--- a/src/doc/rustc/src/platform-support/m68k-unknown-none-elf.md
+++ b/src/doc/rustc/src/platform-support/m68k-unknown-none-elf.md
@@ -29,40 +29,6 @@ binaries:
 # apt install qemu-user-static
 ```
 
-To run more complex programs, it will be necessary to set up a Debian/m68k chroot with
-the help of the command `debootstrap`:
-
-```text
-# apt install debootstrap debian-ports-archive-keyring
-# debootstrap --keyring=/usr/share/keyrings/debian-ports-archive-keyring.gpg --arch=m68k unstable debian-68k http://ftp.ports.debian.org/debian-ports
-```
-
-This chroot can then seamlessly entered using the normal `chroot` command thanks to
-QEMU user emulation:
-
-```text
-# chroot /path/to/debian-68k
-```
-
-To get started with native builds, which are currently untested, a native Debian/m68k
-system can be installed either on real hardware such as 68k-based Commodore Amiga or
-Atari systems or emulated environments such as QEMU version 4.2 or newer or ARAnyM.
-
-ISO images for installation are provided by the Debian Ports team and can be obtained
-from the Debian CD image server available at:
-
-[https://cdimage.debian.org/cdimage/ports/current](https://cdimage.debian.org/cdimage/ports/current/)
-
-Documentation for Debian/m68k is available on the Debian Wiki at:
-
-[https://wiki.debian.org/M68k](https://wiki.debian.org/M68k)
-
-Support is available either through the `debian-68k` mailing list:
-
-[https://lists.debian.org/debian-68k/](https://lists.debian.org/debian-68k/)
-
-or the `#debian-68k` IRC channel on OFTC network.
-
 ## Building
 
 At least llvm version `19.1.5` is required to build `core` and `alloc` for this target, and currently the gnu linker is required, as `lld` has no support for the `m68k` architecture
@@ -105,4 +71,4 @@ Very simple programs can be run using the `qemu-m68k-static` program:
 qemu-m68k-static your-code
 ```
 
-For more complex applications, a chroot or native m68k system is required for testing.
+For more complex applications, a native (or emulated) m68k system is required for testing.


### PR DESCRIPTION
I left the mentions of qemu-user-static as it's one of the only easily accessible emulators for m68k, even though you would have to write your own `_start` and such. The C toolchain that is mentioned is also the easiest way I've found so far to get a linker, which is still needed unless I'm missing something. 

closes rust-lang/rust#150414

r? @Noratrieb 

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
