### PR TITLE
cleanup: move c-variadic arguments handling into compute_inputs_and_output

### DIFF
--- a/tests/ui/c-variadic/variadic-ffi-4.stderr
+++ b/tests/ui/c-variadic/variadic-ffi-4.stderr
@@ -30,9 +30,9 @@ error: lifetime may not live long enough
   --> $DIR/variadic-ffi-4.rs:22:5
    |
 LL | pub unsafe extern "C" fn no_escape4(_: usize, mut ap0: &mut VaList, mut ap1: ...) {
-   |                                               -------               ------- has type `VaList<'2>`
+   |                                               -------               ------- has type `VaList<'1>`
    |                                               |
-   |                                               has type `&mut VaList<'1>`
+   |                                               has type `&mut VaList<'2>`
 LL |     ap0 = &mut ap1;
    |     ^^^^^^^^^^^^^^ assignment requires that `'1` must outlive `'2`
    |
@@ -44,9 +44,9 @@ error: lifetime may not live long enough
   --> $DIR/variadic-ffi-4.rs:22:5
    |
 LL | pub unsafe extern "C" fn no_escape4(_: usize, mut ap0: &mut VaList, mut ap1: ...) {
-   |                                               -------               ------- has type `VaList<'2>`
+   |                                               -------               ------- has type `VaList<'1>`
    |                                               |
-   |                                               has type `&mut VaList<'1>`
+   |                                               has type `&mut VaList<'2>`
 LL |     ap0 = &mut ap1;
    |     ^^^^^^^^^^^^^^ assignment requires that `'2` must outlive `'1`
    |


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Previously, ``unnormalized_input_tys`` needs to be mutable because the c_variadic arguments are added to ``unnormalized_input_tys`` outside of ``compute_inputs_and_output``. This could have been done together in ``compute_inputs_and_output``. 
