### PR TITLE
fix ManuallyDrop::into_inner aliasing (Miri) issues

### DIFF
--- a/library/core/src/mem/manually_drop.rs
+++ b/library/core/src/mem/manually_drop.rs
@@ -200,7 +200,9 @@ impl<T> ManuallyDrop<T> {
     #[rustc_const_stable(feature = "const_manually_drop", since = "1.32.0")]
     #[inline(always)]
     pub const fn into_inner(slot: ManuallyDrop<T>) -> T {
-        slot.value.into_inner()
+        // Cannot use `MaybeDangling::into_inner` as that does not yet have the desired semantics.
+        // SAFETY: We know this is a valid `T`. `slot` will not be dropped.
+        unsafe { (&raw const slot).cast::<T>().read() }
     }
 
     /// Takes the value from the `ManuallyDrop<T>` container out.

--- a/src/tools/miri/tests/pass/issues/issue-miri-4793.rs
+++ b/src/tools/miri/tests/pass/issues/issue-miri-4793.rs
@@ -1,0 +1,3 @@
+fn main() {
+    let _ = std::panic::catch_unwind(|| Box::<str>::from("..."));
+}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/miri/issues/4793

r? @WaffleLapkin 