### PR TITLE
rustc_target: callconv: powerpc64: Use the ABI set in target options instead of guessing

### DIFF
--- a/compiler/rustc_target/src/callconv/powerpc64.rs
+++ b/compiler/rustc_target/src/callconv/powerpc64.rs
@@ -5,7 +5,7 @@
 use rustc_abi::{Endian, HasDataLayout, TyAbiInterface};
 
 use crate::callconv::{Align, ArgAbi, FnAbi, Reg, RegKind, Uniform};
-use crate::spec::{Env, HasTargetSpec, Os};
+use crate::spec::{Abi, HasTargetSpec, Os};
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 enum ABI {
@@ -106,8 +106,10 @@ where
     Ty: TyAbiInterface<'a, C> + Copy,
     C: HasDataLayout + HasTargetSpec,
 {
-    let abi = if cx.target_spec().env == Env::Musl || cx.target_spec().os == Os::FreeBsd {
+    let abi = if cx.target_spec().options.abi == Abi::ElfV2 {
         ELFv2
+    } else if cx.target_spec().options.abi == Abi::ElfV1 {
+        ELFv1
     } else if cx.target_spec().os == Os::Aix {
         AIX
     } else {

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -3182,6 +3182,27 @@ impl Target {
                     "ARM targets must set `llvm-floatabi` to `hard` or `soft`",
                 )
             }
+            // PowerPC64 targets that are not AIX must set their ABI to either ELFv1 or ELFv2
+            Arch::PowerPC64 => {
+                if self.os == Os::Aix {
+                    check!(
+                        self.llvm_abiname.is_empty(),
+                        "AIX targets always use the AIX ABI and `llvm_abiname` should be left empty",
+                    );
+                } else if self.endian == Endian::Big {
+                    check_matches!(
+                        &*self.llvm_abiname,
+                        "elfv1" | "elfv2",
+                        "invalid PowerPC64 ABI name: {}",
+                        self.llvm_abiname,
+                    );
+                } else {
+                    check!(
+                        self.llvm_abiname == "elfv2",
+                        "little-endian PowerPC64 targets only support the `elfv2` ABI",
+                    );
+                }
+            }
             _ => {}
         }
 


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/150468)*

All PowerPC64 targets except AIX explicitly set the ABI in the target options. We can therefore stop hardcoding the ABI to be used based on the target environment or OS, except for the AIX special case.

The fallback based on endianness is kept for the sake of compatibility with custom targets.

This makes it so that big endian targets not explicitly accounted for before (powerpc64-unknown-openbsd) and targets that don't use the expected default ABI (big-endian ELFv2 Glibc targets) use the correct ABI in the calling convention code.

The second commit is a tiny change to validate the `llvm_abiname` set on PowerPC64(LE) targets. See the commit messages for details.

CC @RalfJung who pointed out the missing `llvm_abiname` validation