### PR TITLE
Fix enum variant suggestion consuming trailing parenthesis

### DIFF
--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -1384,13 +1384,14 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 && let hir::Node::Stmt(&hir::Stmt { kind: hir::StmtKind::Semi(parent), .. })
                 | hir::Node::Expr(parent) = tcx.parent_hir_node(path_expr.hir_id)
             {
-                let replacement_span =
-                    if let hir::ExprKind::Call(..) | hir::ExprKind::Struct(..) = parent.kind {
-                        // We want to replace the parts that need to go, like `()` and `{}`.
+                // We want to replace the parts that need to go, like `()` and `{}`.
+                let replacement_span = match parent.kind {
+                    hir::ExprKind::Call(callee, _) if callee.hir_id == path_expr.hir_id => {
                         span.with_hi(parent.span.hi())
-                    } else {
-                        span
-                    };
+                    }
+                    hir::ExprKind::Struct(..) => span.with_hi(parent.span.hi()),
+                    _ => span,
+                };
                 match (variant.ctor, parent.kind) {
                     (None, hir::ExprKind::Struct(..)) => {
                         // We want a struct and we have a struct. We won't suggest changing

--- a/tests/ui/suggestions/suggest-variants.rs
+++ b/tests/ui/suggestions/suggest-variants.rs
@@ -16,3 +16,26 @@ fn main() {
     Shape::Circl; //~ ERROR no variant
     Shape::Rombus; //~ ERROR no variant
 }
+
+enum Color {
+  Red,
+  Green(()),
+  Blue,
+  Alpha{ a: u8 },
+}
+
+fn red() -> Result<Color, ()> {
+  Ok(Color::Redd) //~ ERROR no variant
+}
+
+fn green() -> Result<Color, ()> {
+  Ok(Color::Greenn(())) //~ ERROR no variant
+}
+
+fn blue() -> Result<Color, ()> {
+  Ok(Color::Blu) //~ ERROR no variant
+}
+
+fn alpha() -> Result<Color, ()> {
+  Ok(Color::Alph{ a: 255 }) //~ ERROR no variant
+}

--- a/tests/ui/suggestions/suggest-variants.stderr
+++ b/tests/ui/suggestions/suggest-variants.stderr
@@ -74,6 +74,64 @@ LL | enum Shape {
 LL |     Shape::Rombus;
    |            ^^^^^^ variant or associated item not found in `Shape`
 
-error: aborting due to 6 previous errors
+error[E0599]: no variant or associated item named `Redd` found for enum `Color` in the current scope
+  --> $DIR/suggest-variants.rs:28:13
+   |
+LL | enum Color {
+   | ---------- variant or associated item `Redd` not found for this enum
+...
+LL |   Ok(Color::Redd)
+   |             ^^^^ variant or associated item not found in `Color`
+   |
+help: there is a variant with a similar name
+   |
+LL -   Ok(Color::Redd)
+LL +   Ok(Color::Red)
+   |
+
+error[E0599]: no variant or associated item named `Greenn` found for enum `Color` in the current scope
+  --> $DIR/suggest-variants.rs:32:13
+   |
+LL | enum Color {
+   | ---------- variant or associated item `Greenn` not found for this enum
+...
+LL |   Ok(Color::Greenn(()))
+   |             ^^^^^^ variant or associated item not found in `Color`
+   |
+help: there is a variant with a similar name
+   |
+LL -   Ok(Color::Greenn(()))
+LL +   Ok(Color::Green(()))
+   |
+
+error[E0599]: no variant or associated item named `Blu` found for enum `Color` in the current scope
+  --> $DIR/suggest-variants.rs:36:13
+   |
+LL | enum Color {
+   | ---------- variant or associated item `Blu` not found for this enum
+...
+LL |   Ok(Color::Blu)
+   |             ^^^ variant or associated item not found in `Color`
+   |
+help: there is a variant with a similar name
+   |
+LL |   Ok(Color::Blue)
+   |                +
+
+error[E0599]: no variant named `Alph` found for enum `Color`
+  --> $DIR/suggest-variants.rs:40:13
+   |
+LL | enum Color {
+   | ---------- variant `Alph` not found here
+...
+LL |   Ok(Color::Alph{ a: 255 })
+   |             ^^^^
+   |
+help: there is a variant with a similar name
+   |
+LL |   Ok(Color::Alpha{ a: 255 })
+   |                 +
+
+error: aborting due to 10 previous errors
 
 For more information about this error, try `rustc --explain E0599`.


### PR DESCRIPTION
- Closes rust-lang/rust#150459 

Previously the logic incorrectly assumed the variant itself was the function being called when the parent node was a function all. This change adds a check to ensure the replacement span is only expanded if the path expression is actually the callee of the parent expression.