### PR TITLE
Add FileCheck annotations to retag mir-opt test

### DIFF
--- a/tests/mir-opt/retag.rs
+++ b/tests/mir-opt/retag.rs
@@ -1,4 +1,3 @@
-// skip-filecheck
 //@ test-mir-pass: AddRetag
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 // ignore-tidy-linelength
@@ -12,9 +11,15 @@ struct Test(i32);
 // EMIT_MIR retag.{impl#0}-foo_shr.SimplifyCfg-pre-optimizations.after.mir
 impl Test {
     // Make sure we run the pass on a method, not just on bare functions.
+    // CHECK-LABEL: fn {{.*}}::foo(
+    // CHECK: Retag([fn entry] _2);
+    // CHECK: _0 = &mut (*_{{[0-9]+}});
     fn foo<'x>(&self, x: &'x mut i32) -> &'x mut i32 {
         x
     }
+    // CHECK-LABEL: fn {{.*}}::foo_shr(
+    // CHECK: Retag([fn entry] _2);
+    // CHECK: Retag(_0);
     fn foo_shr<'x>(&self, x: &'x i32) -> &'x i32 {
         x
     }
@@ -29,6 +34,8 @@ impl Drop for Test {
 // EMIT_MIR retag.main.SimplifyCfg-pre-optimizations.after.mir
 // EMIT_MIR retag.main-{closure#0}.SimplifyCfg-pre-optimizations.after.mir
 pub fn main() {
+    // CHECK-LABEL: fn main(
+    // CHECK: Retag(_{{[0-9]+}});
     let mut x = 0;
     {
         let v = Test(0).foo(&mut x); // just making sure we do not panic when there is a tuple struct ctor

--- a/tests/mir-opt/retag.rs
+++ b/tests/mir-opt/retag.rs
@@ -12,13 +12,16 @@ struct Test(i32);
 impl Test {
     // Make sure we run the pass on a method, not just on bare functions.
     // CHECK-LABEL: fn {{.*}}::foo(
-    // CHECK: Retag([fn entry] _2);
-    // CHECK: _0 = &mut (*_{{[0-9]+}});
+    // CHECK: bb0: {
+    // CHECK-NEXT: Retag([fn entry] _1);
+    // CHECK-NEXT: Retag([fn entry] _2);
     fn foo<'x>(&self, x: &'x mut i32) -> &'x mut i32 {
         x
     }
     // CHECK-LABEL: fn {{.*}}::foo_shr(
-    // CHECK: Retag([fn entry] _2);
+    // CHECK: bb0: {
+    // CHECK-NEXT: Retag([fn entry] _1);
+    // CHECK-NEXT: Retag([fn entry] _2);
     // CHECK: Retag(_0);
     fn foo_shr<'x>(&self, x: &'x i32) -> &'x i32 {
         x
@@ -36,6 +39,11 @@ impl Drop for Test {
 pub fn main() {
     // CHECK-LABEL: fn main(
     // CHECK: Retag(_{{[0-9]+}});
+    //
+    // CHECK-LABEL: fn main::{closure#0}(
+    // CHECK: bb0: {
+    // CHECK-NEXT: Retag([fn entry] _1);
+    // CHECK-NEXT: Retag([fn entry] _2);
     let mut x = 0;
     {
         let v = Test(0).foo(&mut x); // just making sure we do not panic when there is a tuple struct ctor

--- a/tests/mir-opt/retag.rs
+++ b/tests/mir-opt/retag.rs
@@ -71,6 +71,8 @@ pub fn main() {
 
 /// Casting directly to an array should also go through `&raw` and thus add appropriate retags.
 // EMIT_MIR retag.array_casts.SimplifyCfg-pre-optimizations.after.mir
+// CHECK-LABEL: fn array_casts(
+// CHECK: Retag(
 fn array_casts() {
     let mut x: [usize; 2] = [0, 0];
     let p = &mut x as *mut usize;

--- a/tests/mir-opt/retag.rs
+++ b/tests/mir-opt/retag.rs
@@ -86,6 +86,10 @@ fn array_casts() {
 }
 
 // EMIT_MIR retag.box_to_raw_mut.SimplifyCfg-pre-optimizations.after.mir
+// CHECK-LABEL: fn box_to_raw_mut(
+// CHECK: bb0: {
+// CHECK-NEXT: Retag([fn entry] _1);
+// CHECK: Retag([raw] _0);
 fn box_to_raw_mut(x: &mut Box<i32>) -> *mut i32 {
     std::ptr::addr_of_mut!(**x)
 }

--- a/tests/mir-opt/retag.{impl#0}-foo.SimplifyCfg-pre-optimizations.after.panic-abort.mir
+++ b/tests/mir-opt/retag.{impl#0}-foo.SimplifyCfg-pre-optimizations.after.panic-abort.mir
@@ -1,6 +1,6 @@
-// MIR for `<impl at $DIR/retag.rs:13:1: 13:10>::foo` after SimplifyCfg-pre-optimizations
+// MIR for `<impl at $DIR/retag.rs:12:1: 12:10>::foo` after SimplifyCfg-pre-optimizations
 
-fn <impl at $DIR/retag.rs:13:1: 13:10>::foo(_1: &Test, _2: &mut i32) -> &mut i32 {
+fn <impl at $DIR/retag.rs:12:1: 12:10>::foo(_1: &Test, _2: &mut i32) -> &mut i32 {
     debug self => _1;
     debug x => _2;
     let mut _0: &mut i32;

--- a/tests/mir-opt/retag.{impl#0}-foo.SimplifyCfg-pre-optimizations.after.panic-unwind.mir
+++ b/tests/mir-opt/retag.{impl#0}-foo.SimplifyCfg-pre-optimizations.after.panic-unwind.mir
@@ -1,6 +1,6 @@
-// MIR for `<impl at $DIR/retag.rs:13:1: 13:10>::foo` after SimplifyCfg-pre-optimizations
+// MIR for `<impl at $DIR/retag.rs:12:1: 12:10>::foo` after SimplifyCfg-pre-optimizations
 
-fn <impl at $DIR/retag.rs:13:1: 13:10>::foo(_1: &Test, _2: &mut i32) -> &mut i32 {
+fn <impl at $DIR/retag.rs:12:1: 12:10>::foo(_1: &Test, _2: &mut i32) -> &mut i32 {
     debug self => _1;
     debug x => _2;
     let mut _0: &mut i32;

--- a/tests/mir-opt/retag.{impl#0}-foo_shr.SimplifyCfg-pre-optimizations.after.panic-abort.mir
+++ b/tests/mir-opt/retag.{impl#0}-foo_shr.SimplifyCfg-pre-optimizations.after.panic-abort.mir
@@ -1,6 +1,6 @@
-// MIR for `<impl at $DIR/retag.rs:13:1: 13:10>::foo_shr` after SimplifyCfg-pre-optimizations
+// MIR for `<impl at $DIR/retag.rs:12:1: 12:10>::foo_shr` after SimplifyCfg-pre-optimizations
 
-fn <impl at $DIR/retag.rs:13:1: 13:10>::foo_shr(_1: &Test, _2: &i32) -> &i32 {
+fn <impl at $DIR/retag.rs:12:1: 12:10>::foo_shr(_1: &Test, _2: &i32) -> &i32 {
     debug self => _1;
     debug x => _2;
     let mut _0: &i32;

--- a/tests/mir-opt/retag.{impl#0}-foo_shr.SimplifyCfg-pre-optimizations.after.panic-unwind.mir
+++ b/tests/mir-opt/retag.{impl#0}-foo_shr.SimplifyCfg-pre-optimizations.after.panic-unwind.mir
@@ -1,6 +1,6 @@
-// MIR for `<impl at $DIR/retag.rs:13:1: 13:10>::foo_shr` after SimplifyCfg-pre-optimizations
+// MIR for `<impl at $DIR/retag.rs:12:1: 12:10>::foo_shr` after SimplifyCfg-pre-optimizations
 
-fn <impl at $DIR/retag.rs:13:1: 13:10>::foo_shr(_1: &Test, _2: &i32) -> &i32 {
+fn <impl at $DIR/retag.rs:12:1: 12:10>::foo_shr(_1: &Test, _2: &i32) -> &i32 {
     debug self => _1;
     debug x => _2;
     let mut _0: &i32;


### PR DESCRIPTION
Part of rust-lang/rust#116971.

Add FileCheck annotations to `tests/mir-opt/retag.rs`, removing the `// skip-filecheck` directive.

The added CHECK directives verify that the `AddRetag` pass correctly inserts `Retag` statements:
- At function entry for `self` and reference parameters (`Retag([fn entry] _1)`, `Retag([fn entry] _2)`)
- Uses `CHECK-NEXT` to verify Retag statements appear immediately after `bb0: {`
- After reborrows for shared reference return values (`Retag(_0)`)
- For closures (`main::{closure#0}`) with proper entry retags
- For `array_casts` function (testing retags through `&raw`)
- For `box_to_raw_mut` function with `[raw]` retag (`Retag([raw] _0)`)

r? @cjgillot

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
