### PR TITLE
llvm-wrapper: adapt for LLVM API changes

### DIFF
--- a/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
@@ -23,7 +23,11 @@
 #include "llvm/MC/TargetRegistry.h"
 #include "llvm/Object/ObjectFile.h"
 #include "llvm/Passes/PassBuilder.h"
+#if LLVM_VERSION_GE(22, 0)
+#include "llvm/Plugins/PassPlugin.h"
+#else
 #include "llvm/Passes/PassPlugin.h"
+#endif
 #include "llvm/Passes/StandardInstrumentations.h"
 #include "llvm/Support/CBindingWrapping.h"
 #include "llvm/Support/FileSystem.h"


### PR DESCRIPTION
No functional changes intended.

Adapts the wrapper for https://github.com/llvm/llvm-project/commit/f54df0d09e19ec6b205cb0af45c7ecea2fd8aeff.

@rustbot label: +llvm-main
@r? @durin42
