### PR TITLE
Disable debuginfo when building GCC

### DIFF
--- a/src/bootstrap/src/core/build_steps/gcc.rs
+++ b/src/bootstrap/src/core/build_steps/gcc.rs
@@ -346,6 +346,9 @@ fn build_gcc(metadata: &Meta, builder: &Builder<'_>, target_pair: GccTargetPair)
             .map_or_else(|| cxx.clone(), |ccache| format!("{ccache} {cxx}"));
         configure_cmd.env("CXX", cxx);
     }
+    // Disable debuginfo to reduce size of libgccjit.so 10x
+    configure_cmd.env("CXXFLAGS", "-O2 -g0");
+    configure_cmd.env("CFLAGS", "-O2 -g0");
     configure_cmd.run(builder);
 
     command("make")


### PR DESCRIPTION
To reduce size of libgccjit.so from ~400 MiB to ~50 MiB.

r? @antoyo
