### PR TITLE
resolve: Mark items under exported ambiguous imports as exported

### DIFF
--- a/tests/rustdoc-html/glob-shadowing.rs
+++ b/tests/rustdoc-html/glob-shadowing.rs
@@ -1,9 +1,9 @@
 //@ has 'glob_shadowing/index.html'
-//@ count - '//dt' 6
-//@ !has - '//dd' 'sub1::describe'
+//@ count - '//dt' 7
+//@ !has - '//dd' 'sub1::describe1'
 //@ has - '//dd' 'sub2::describe'
 
-//@ !has - '//dd' 'sub1::describe2'
+//@ has - '//dd' 'sub1::describe2'
 
 //@ !has - '//dd' 'sub1::prelude'
 //@ has - '//dd' 'mod::prelude'
@@ -18,7 +18,7 @@
 
 mod sub1 {
     // this should be shadowed by sub2::describe
-    /// sub1::describe
+    /// sub1::describe1
     pub fn describe() -> &'static str {
         "sub1::describe"
     }
@@ -33,7 +33,9 @@ mod sub1 {
     pub struct Foo;
 
     // this should be shadowed,
-    // because both sub1::describe2 and sub3::describe2 are from glob reexport
+    // because both sub1::describe2 and sub3::describe2 are from glob reexport,
+    // but it is still usable from other crates under the `ambiguous_glob_imports` lint,
+    // so it is reachable and documented
     /// sub1::describe2
     pub fn describe2() -> &'static str {
         "sub1::describe2"

--- a/tests/rustdoc-json/reexport/glob_collision.rs
+++ b/tests/rustdoc-json/reexport/glob_collision.rs
@@ -1,7 +1,9 @@
 // Regression test for https://github.com/rust-lang/rust/issues/100973
+// Update: the rules has changed after #147984, one of the colliding items is now available
+// from other crates under a deprecation lint.
 
 //@ set m1 = "$.index[?(@.name == 'm1' && @.inner.module)].id"
-//@ is "$.index[?(@.name == 'm1')].inner.module.items" []
+//@ is "$.index[?(@.name == 'm1')].inner.module.items" [0]
 //@ is "$.index[?(@.name == 'm1')].inner.module.is_stripped" true
 mod m1 {
     pub fn f() {}

--- a/tests/ui/imports/ambiguous-reachable.rs
+++ b/tests/ui/imports/ambiguous-reachable.rs
@@ -1,4 +1,4 @@
-//@ build-fail
+//@ build-pass
 //@ aux-crate: ambiguous_reachable_extern=ambiguous-reachable-extern.rs
 
 #![allow(ambiguous_glob_imports)]
@@ -6,5 +6,3 @@
 fn main() {
     ambiguous_reachable_extern::generic::<u8>();
 }
-
-//~? ERROR missing optimized MIR

--- a/tests/ui/imports/ambiguous-reachable.rs
+++ b/tests/ui/imports/ambiguous-reachable.rs
@@ -1,0 +1,10 @@
+//@ build-fail
+//@ aux-crate: ambiguous_reachable_extern=ambiguous-reachable-extern.rs
+
+#![allow(ambiguous_glob_imports)]
+
+fn main() {
+    ambiguous_reachable_extern::generic::<u8>();
+}
+
+//~? ERROR missing optimized MIR

--- a/tests/ui/imports/ambiguous-reachable.stderr
+++ b/tests/ui/imports/ambiguous-reachable.stderr
@@ -1,13 +1,3 @@
-error: missing optimized MIR for `ambiguous_reachable_extern::m1::generic::<u8>` in the crate `ambiguous_reachable_extern`
-   |
-note: missing optimized MIR for this item (was the crate `ambiguous_reachable_extern` compiled with `--emit=metadata`?)
-  --> $DIR/auxiliary/ambiguous-reachable-extern.rs:2:5
-   |
-LL |     pub fn generic<T>() {
-   |     ^^^^^^^^^^^^^^^^^^^
-
-error: aborting due to 1 previous error
-
 Future incompatibility report: Future breakage diagnostic:
 warning: `generic` is ambiguous
   --> $DIR/ambiguous-reachable.rs:7:33
@@ -23,6 +13,8 @@ note: `generic` could refer to the function defined here
    |
 LL | pub use m1::*;
    |         ^^
+   = help: consider updating this dependency to resolve this error
+   = help: if updating the dependency does not resolve the problem report the problem to the author of the relevant crate
 note: `generic` could also refer to the function defined here
   --> $DIR/auxiliary/ambiguous-reachable-extern.rs:14:9
    |

--- a/tests/ui/imports/ambiguous-reachable.stderr
+++ b/tests/ui/imports/ambiguous-reachable.stderr
@@ -1,0 +1,31 @@
+error: missing optimized MIR for `ambiguous_reachable_extern::m1::generic::<u8>` in the crate `ambiguous_reachable_extern`
+   |
+note: missing optimized MIR for this item (was the crate `ambiguous_reachable_extern` compiled with `--emit=metadata`?)
+  --> $DIR/auxiliary/ambiguous-reachable-extern.rs:2:5
+   |
+LL |     pub fn generic<T>() {
+   |     ^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+
+Future incompatibility report: Future breakage diagnostic:
+warning: `generic` is ambiguous
+  --> $DIR/ambiguous-reachable.rs:7:33
+   |
+LL |     ambiguous_reachable_extern::generic::<u8>();
+   |                                 ^^^^^^^ ambiguous name
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
+   = note: ambiguous because of multiple glob imports of a name in the same module
+note: `generic` could refer to the function defined here
+  --> $DIR/auxiliary/ambiguous-reachable-extern.rs:13:9
+   |
+LL | pub use m1::*;
+   |         ^^
+note: `generic` could also refer to the function defined here
+  --> $DIR/auxiliary/ambiguous-reachable-extern.rs:14:9
+   |
+LL | pub use m2::*;
+   |         ^^
+

--- a/tests/ui/imports/auxiliary/ambiguous-reachable-extern.rs
+++ b/tests/ui/imports/auxiliary/ambiguous-reachable-extern.rs
@@ -1,0 +1,14 @@
+mod m1 {
+    pub fn generic<T>() {
+        let x = 10;
+        let y = 11;
+        println!("hello {x} world {:?}", y);
+    }
+}
+
+mod m2 {
+    pub fn generic() {}
+}
+
+pub use m1::*;
+pub use m2::*;


### PR DESCRIPTION
After https://github.com/rust-lang/rust/pull/147984 one of the imports in an ambiguous import set becomes accessible under a deny-by-default deprecation lint.

So if it points to something, that something needs to be marked as exported, so its MIR is encoded into metadata, its symbol is not lost from object files, etc.
The added test shows an example.
This fixes around 10-20 crater regressions found in https://github.com/rust-lang/rust/pull/149195#issuecomment-3641704823.

Unblocks https://github.com/rust-lang/rust/pull/149195.