### PR TITLE
Correct hexagon "unwinder_private_data_size"

### DIFF
--- a/library/unwind/src/libunwind.rs
+++ b/library/unwind/src/libunwind.rs
@@ -78,8 +78,8 @@ pub const unwinder_private_data_size: usize = 20;
 #[cfg(all(target_arch = "wasm32", target_os = "linux"))]
 pub const unwinder_private_data_size: usize = 2;
 
-#[cfg(all(target_arch = "hexagon", target_os = "linux"))]
-pub const unwinder_private_data_size: usize = 35;
+#[cfg(target_arch = "hexagon")]
+pub const unwinder_private_data_size: usize = 5;
 
 #[cfg(any(target_arch = "loongarch32", target_arch = "loongarch64"))]
 pub const unwinder_private_data_size: usize = 2;


### PR DESCRIPTION
Discovered while porting libstd to hexagon-unknown-qurt: the unwinder data size refers to the count of pointers in _Unwind_Exception but when I put the value "35" intiially for hexagon linux, I incorrectly considered the size of the exception context hexagon_thread_state_t data structure.

Correct the value for hexagon linux and expand it to cover all hexagon architecture instead.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
