### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/src/bootstrap/src/core/build_steps/gcc.rs
+++ b/src/bootstrap/src/core/build_steps/gcc.rs
@@ -325,6 +325,7 @@ fn build_gcc(metadata: &Meta, builder: &Builder<'_>, target_pair: GccTargetPair)
         .arg("--enable-checking=release")
         .arg("--disable-bootstrap")
         .arg("--disable-multilib")
+        .arg("--with-bugurl=https://github.com/rust-lang/gcc/")
         .arg(format!("--prefix={}", install_dir.display()));
 
     let cc = builder.build.cc(host).display().to_string();

--- a/src/bootstrap/src/core/build_steps/gcc.rs
+++ b/src/bootstrap/src/core/build_steps/gcc.rs
@@ -346,6 +346,9 @@ fn build_gcc(metadata: &Meta, builder: &Builder<'_>, target_pair: GccTargetPair)
             .map_or_else(|| cxx.clone(), |ccache| format!("{ccache} {cxx}"));
         configure_cmd.env("CXX", cxx);
     }
+    // Disable debuginfo to reduce size of libgccjit.so 10x
+    configure_cmd.env("CXXFLAGS", "-O2 -g0");
+    configure_cmd.env("CFLAGS", "-O2 -g0");
     configure_cmd.run(builder);
 
     command("make")

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -997,7 +997,7 @@ rustdoc-topbar {
 .example-wrap [data-nosnippet] {
 	width: calc(var(--example-wrap-digits-count) + var(--line-number-padding) * 2);
 }
-.example-wrap pre > code {
+.example-wrap:not(.hide-lines) pre > code {
 	padding-left: calc(
 		var(--example-wrap-digits-count) + var(--line-number-padding) * 2
 		+ var(--line-number-right-margin));

--- a/tests/rustdoc-gui/docblock-code-block-line-number.goml
+++ b/tests/rustdoc-gui/docblock-code-block-line-number.goml
@@ -1,9 +1,14 @@
 // Checks that the setting "line numbers" is working as expected.
 include: "utils.goml"
+
 go-to: "file://" + |DOC_PATH| + "/test_docs/fn.foo.html"
 
+// Otherwise, we can't check text color
+show-text: true
+
+store-value: (line_numbers_selector, ".example-wrap pre.rust code [data-nosnippet]")
 // We check that without this setting, there is no line number displayed.
-assert-false: "pre.example-line-numbers"
+assert-count: (|line_numbers_selector|, 0)
 
 // All corners should be rounded.
 assert-css: (
@@ -17,14 +22,16 @@ assert-css: (
     ALL,
 )
 
-// We set the setting to show the line numbers on code examples.
-set-local-storage: {"rustdoc-line-numbers": "true"}
-reload:
-// We wait for the line numbers to be added into the DOM by the JS...
-wait-for: ".digits-1 pre"
+// Before we add line numbers, we get the X position of a span in a code example that we will
+// use later on to ensure that when we disable the line numbers, it goes back to its original
+// position.
+store-position: (".example-wrap code .macro", {"x": span_x_pos})
 
-// Otherwise, we can't check text color
-show-text: true
+// We enable the setting to show the line numbers on code examples.
+call-function: ("switch-line-numbers-setting", {"expected_status": "true"})
+// We ensure that there are actually line numbers generated in the DOM.
+assert-text: (".example-wrap pre.rust code span[data-nosnippet]", "1")
+assert-position-false: (".example-wrap code .macro", {"x": |span_x_pos|})
 
 // Let's now check some CSS properties...
 define-function: (
@@ -68,20 +75,18 @@ call-function: ("check-colors", {
 // Now, try changing the setting dynamically. We'll turn it off, using the settings menu,
 // and make sure it goes away.
 
-// First, open the settings menu.
-click: "rustdoc-toolbar .settings-menu"
-wait-for: "#settings"
-assert-css: ("#settings", {"display": "block"})
+call-function: ("switch-line-numbers-setting", {"expected_status": "false"})
+assert: ".digits-1.hide-lines"
 
-// Then, click the toggle button.
-click: "input#line-numbers"
-wait-for: ".digits-1.hide-lines"
-assert-local-storage: {"rustdoc-line-numbers": "false" }
+// The line numbers not being displayed, their "space" should have disappear as well.
+assert-position: (".example-wrap code .macro", {"x": |span_x_pos|})
 
 // Finally, turn it on again.
-click: "input#line-numbers"
+call-function: ("switch-line-numbers-setting", {"expected_status": "true"})
 wait-for: ".digits-1:not(.hide-lines)"
-assert-local-storage: {"rustdoc-line-numbers": "true" }
+
+// The line numbers are being displayed, their "space" should be back.
+assert-position-false: (".example-wrap code .macro", {"x": |span_x_pos|})
 
 // Same check with scraped examples line numbers.
 go-to: "file://" + |DOC_PATH| + "/scrape_examples/fn.test_many.html"
@@ -119,26 +124,14 @@ call-function: ("check-padding", {
 })
 
 define-function: ("check-line-numbers-existence", [], block {
-    assert-local-storage: {"rustdoc-line-numbers": "true" }
-    assert-false: ".example-line-numbers"
-    click: "rustdoc-toolbar .settings-menu"
-    wait-for: "#settings"
-
-    // Then, click the toggle button.
-    click: "input#line-numbers"
-    wait-for-local-storage-false: {"rustdoc-line-numbers": "true" }
-    assert-false: ".example-line-numbers"
+    assert-local-storage: {"rustdoc-line-numbers": "true"}
+    assert-count-false: (|line_numbers_selector|, 0)
+    call-function: ("switch-line-numbers-setting", {"expected_status": "false"})
     // Line numbers should still be there.
-    assert-css: ("[data-nosnippet]", { "display": "block"})
-    // Now disabling the setting.
-    click: "input#line-numbers"
-    wait-for-local-storage: {"rustdoc-line-numbers": "true" }
-    assert-false: ".example-line-numbers"
-    // Line numbers should still be there.
-    assert-css: ("[data-nosnippet]", { "display": "block"})
-    // Closing settings menu.
-    click: "rustdoc-toolbar .settings-menu"
-    wait-for-css: ("#settings", {"display": "none"})
+    assert-count-false: (|line_numbers_selector|, 0)
+    assert-css: (|line_numbers_selector|, {"display": "block"})
+    // Now re-enabling the setting.
+    call-function: ("switch-line-numbers-setting", {"expected_status": "true"})
 })
 
 // Checking that turning off the line numbers setting won't remove line numbers from scraped
@@ -168,16 +161,11 @@ assert: ".example-wrap > pre.rust"
 assert-count: (".example-wrap", 2)
 assert-count: (".example-wrap.digits-1", 2)
 
-click: "rustdoc-toolbar .settings-menu"
-wait-for: "#settings"
-
-// Then, click the toggle button.
-click: "input#line-numbers"
+// Disabling the line numbers setting.
+call-function: ("switch-line-numbers-setting", {"expected_status": "false"})
 wait-for-count: (".example-wrap.digits-1.hide-lines", 2)
-assert-local-storage-false: {"rustdoc-line-numbers": "true" }
 
-// Now turning off the setting.
-click: "input#line-numbers"
+// Now re-enabling the setting.
+call-function: ("switch-line-numbers-setting", {"expected_status": "true"})
 wait-for-count: (".example-wrap.digits-1", 2)
 wait-for-count: (".example-wrap.digits-1.hide-lines", 0)
-assert-local-storage: {"rustdoc-line-numbers": "true" }

--- a/tests/rustdoc-gui/sidebar-mobile.goml
+++ b/tests/rustdoc-gui/sidebar-mobile.goml
@@ -65,7 +65,7 @@ define-function: (
     "check-colors",
     [theme, color, background],
     block {
-        call-function: ("switch-theme-mobile", {"theme": |theme|})
+        call-function: ("switch-theme", {"theme": |theme|})
         reload:
 
         // Open the sidebar menu.

--- a/tests/rustdoc-gui/sidebar-mobile.goml
+++ b/tests/rustdoc-gui/sidebar-mobile.goml
@@ -65,7 +65,7 @@ define-function: (
     "check-colors",
     [theme, color, background],
     block {
-        call-function: ("switch-theme", {"theme": |theme|})
+        call-function: ("switch-theme-mobile", {"theme": |theme|})
         reload:
 
         // Open the sidebar menu.

--- a/tests/rustdoc-gui/utils.goml
+++ b/tests/rustdoc-gui/utils.goml
@@ -1,35 +1,34 @@
 // This file contains code to be re-used by other tests.
+
+define-function: (
+    "open-settings-menu",
+    [],
+    block {
+        // Open the settings menu.
+        click: "rustdoc-toolbar .settings-menu"
+        // Wait for the popover to appear...
+        wait-for-css: ("#settings", {"display": "block"})
+    }
+)
+
+define-function: (
+    "close-settings-menu",
+    [],
+    block {
+        click: "rustdoc-toolbar .settings-menu"
+        wait-for-css-false: ("#settings", {"display": "block"})
+    }
+)
+
 define-function: (
     "switch-theme",
     [theme],
     block {
         // Set the theme.
-        // Open the settings menu.
-        click: "rustdoc-toolbar .settings-menu"
-        // Wait for the popover to appear...
-        wait-for: "#settings"
+        call-function: ("open-settings-menu", {})
         // Change the setting.
         click: "#theme-"+ |theme|
-        // Close the popover.
-        click: "rustdoc-toolbar .settings-menu"
-        // Ensure that the local storage was correctly updated.
-        assert-local-storage: {"rustdoc-theme": |theme|}
-    },
-)
-
-define-function: (
-    "switch-theme-mobile",
-    [theme],
-    block {
-        // Set the theme.
-        // Open the settings menu.
-        click: "rustdoc-topbar .settings-menu"
-        // Wait for the popover to appear...
-        wait-for: "#settings"
-        // Change the setting.
-        click: "#theme-"+ |theme|
-        // Close the popover.
-        click: "rustdoc-topbar .settings-menu"
+        call-function: ("close-settings-menu", {})
         // Ensure that the local storage was correctly updated.
         assert-local-storage: {"rustdoc-theme": |theme|}
     },

--- a/tests/rustdoc-gui/utils.goml
+++ b/tests/rustdoc-gui/utils.goml
@@ -34,6 +34,24 @@ define-function: (
     },
 )
 
+// FIXME: To be removed once `browser-ui-test` has conditions.
+define-function: (
+    "switch-theme-mobile",
+    [theme],
+    block {
+        // Open the settings menu.
+        click: "rustdoc-topbar .settings-menu"
+        // Wait for the popover to appear...
+        wait-for-css: ("#settings", {"display": "block"})
+        // Change the setting.
+        click: "#theme-"+ |theme|
+        click: "rustdoc-topbar .settings-menu"
+        wait-for-css-false: ("#settings", {"display": "block"})
+        // Ensure that the local storage was correctly updated.
+        assert-local-storage: {"rustdoc-theme": |theme|}
+    },
+)
+
 define-function: (
     "perform-search",
     [query],
@@ -53,5 +71,17 @@ define-function: (
         wait-for: "#search-tabs"
         // then wait for it to finish
         wait-for-false: "#search-tabs .count.loading"
+    }
+)
+
+define-function: (
+    "switch-line-numbers-setting",
+    [expected_status],
+    block {
+        call-function: ("open-settings-menu", {})
+        // We change the line numbers setting.
+        click: "#line-numbers"
+        call-function: ("close-settings-menu", {})
+        assert-local-storage: {"rustdoc-line-numbers": |expected_status|}
     }
 )


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#150396 ([rustdoc] If line number setting is disabled, do not make line numbers take space)
 - rust-lang/rust#150489 (Disable debuginfo when building GCC)
 - rust-lang/rust#150490 (Specify bug URL when building GCC)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=150396,150489,150490)
<!-- homu-ignore:end -->