### PR TITLE
mir_build: Remove several remnants of `#![feature(inline_const_pat)]`

### DIFF
--- a/compiler/rustc_middle/src/thir.rs
+++ b/compiler/rustc_middle/src/thir.rs
@@ -832,18 +832,18 @@ pub enum PatKind<'tcx> {
         value: ty::Value<'tcx>,
     },
 
-    /// Pattern obtained by converting a constant (inline or named) to its pattern
-    /// representation using `const_to_pat`. This is used for unsafety checking.
+    /// Wrapper node representing a named constant that was lowered to a pattern
+    /// using `const_to_pat`.
+    ///
+    /// This is used by some diagnostics for non-exhaustive matches, to map
+    /// the pattern node back to the `DefId` of its original constant.
+    ///
+    /// FIXME(#150498): Can we make this an `Option<DefId>` field on `Pat`
+    /// instead, so that non-diagnostic code can ignore it more easily?
     ExpandedConstant {
         /// [DefId] of the constant item.
         def_id: DefId,
         /// The pattern that the constant lowered to.
-        ///
-        /// HACK: we need to keep the `DefId` of inline constants around for unsafety checking;
-        /// therefore when a range pattern contains inline constants, we re-wrap the range pattern
-        /// with the `ExpandedConstant` nodes that correspond to the range endpoints. Hence
-        /// `subpattern` may actually be a range pattern, and `def_id` be the constant for one of
-        /// its endpoints.
         subpattern: Box<Pat<'tcx>>,
     },
 

--- a/compiler/rustc_mir_build/src/check_unsafety.rs
+++ b/compiler/rustc_mir_build/src/check_unsafety.rs
@@ -410,14 +410,6 @@ impl<'a, 'tcx> Visitor<'a, 'tcx> for UnsafetyVisitor<'a, 'tcx> {
                 visit::walk_pat(self, pat);
                 self.inside_adt = old_inside_adt;
             }
-            PatKind::ExpandedConstant { def_id, .. } => {
-                if let Some(def) = def_id.as_local()
-                    && matches!(self.tcx.def_kind(def_id), DefKind::InlineConst)
-                {
-                    self.visit_inner_body(def);
-                }
-                visit::walk_pat(self, pat);
-            }
             _ => {
                 visit::walk_pat(self, pat);
             }

--- a/compiler/rustc_mir_build/src/thir/pattern/const_to_pat.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/const_to_pat.rs
@@ -187,7 +187,7 @@ impl<'tcx> ConstToPat<'tcx> {
         }
 
         // Wrap the pattern in a marker node to indicate that it is the result of lowering a
-        // constant. This is used for diagnostics, and for unsafety checking of inline const blocks.
+        // constant. This is used for diagnostics.
         let kind = PatKind::ExpandedConstant { subpattern: inlined_const_as_pat, def_id: uv.def };
         Box::new(Pat { kind, ty, span: self.span })
     }

--- a/compiler/rustc_mir_build/src/thir/pattern/mod.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/mod.rs
@@ -21,7 +21,6 @@ use rustc_middle::ty::adjustment::{PatAdjust, PatAdjustment};
 use rustc_middle::ty::layout::IntegerExt;
 use rustc_middle::ty::{self, CanonicalUserTypeAnnotation, Ty, TyCtxt};
 use rustc_middle::{bug, span_bug};
-use rustc_span::def_id::DefId;
 use rustc_span::{ErrorGuaranteed, Span};
 use tracing::{debug, instrument};
 
@@ -131,9 +130,8 @@ impl<'tcx> PatCtxt<'tcx> {
     fn lower_pattern_range_endpoint(
         &mut self,
         expr: Option<&'tcx hir::PatExpr<'tcx>>,
-        // Out-parameters collecting extra data to be reapplied by the caller
+        // Out-parameter collecting extra data to be reapplied by the caller
         ascriptions: &mut Vec<Ascription<'tcx>>,
-        expanded_consts: &mut Vec<DefId>,
     ) -> Result<Option<PatRangeBoundary<'tcx>>, ErrorGuaranteed> {
         let Some(expr) = expr else { return Ok(None) };
 
@@ -148,8 +146,10 @@ impl<'tcx> PatCtxt<'tcx> {
                     ascriptions.push(ascription);
                     kind = subpattern.kind;
                 }
-                PatKind::ExpandedConstant { def_id, subpattern } => {
-                    expanded_consts.push(def_id);
+                PatKind::ExpandedConstant { def_id: _, subpattern } => {
+                    // Expanded-constant nodes are currently only needed by
+                    // diagnostics that don't apply to range patterns, so we
+                    // can just discard them here.
                     kind = subpattern.kind;
                 }
                 _ => break,
@@ -227,10 +227,7 @@ impl<'tcx> PatCtxt<'tcx> {
 
         // Collect extra data while lowering the endpoints, to be reapplied later.
         let mut ascriptions = vec![];
-        let mut expanded_consts = vec![];
-
-        let mut lower_endpoint =
-            |expr| self.lower_pattern_range_endpoint(expr, &mut ascriptions, &mut expanded_consts);
+        let mut lower_endpoint = |expr| self.lower_pattern_range_endpoint(expr, &mut ascriptions);
 
         let lo = lower_endpoint(lo_expr)?.unwrap_or(PatRangeBoundary::NegInfinity);
         let hi = lower_endpoint(hi_expr)?.unwrap_or(PatRangeBoundary::PosInfinity);
@@ -282,10 +279,11 @@ impl<'tcx> PatCtxt<'tcx> {
             let subpattern = Box::new(Pat { span, ty, kind });
             kind = PatKind::AscribeUserType { ascription, subpattern };
         }
-        for def_id in expanded_consts {
-            let subpattern = Box::new(Pat { span, ty, kind });
-            kind = PatKind::ExpandedConstant { def_id, subpattern };
-        }
+        // `PatKind::ExpandedConstant` wrappers from range endpoints used to
+        // also be preserved here, but that was only needed for unsafeck of
+        // inline `const { .. }` patterns, which were removed by
+        // <https://github.com/rust-lang/rust/pull/138492>.
+
         Ok(kind)
     }
 


### PR DESCRIPTION
This PR cleans up some THIR-related code that was only needed for inline `const { .. }` blocks in patterns. The `inline_const_pat` feature was removed in https://github.com/rust-lang/rust/pull/138492 due to implementation concerns.

I considered retaining the code for preserving `ExpandedConstant` for range endpoints, but ultimately decided to remove that too, because I found it very awkward to document an edge case that is currently not needed by any subsequent code.

With this PR, `is_const_pat_that_looks_like_binding` is the only function that meaningfully consumes `thir::PatKind::ExpandedConst`.