### PR TITLE
resolve: Factor out and document the glob binding overwriting logic

### DIFF
--- a/compiler/rustc_resolve/src/build_reduced_graph.rs
+++ b/compiler/rustc_resolve/src/build_reduced_graph.rs
@@ -89,7 +89,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
     ) {
         let decl = self.arenas.alloc_decl(DeclData {
             kind: DeclKind::Def(res),
-            ambiguity,
+            ambiguity: CmCell::new(ambiguity),
             // External ambiguities always report the `AMBIGUOUS_GLOB_IMPORTS` lint at the moment.
             warn_ambiguity: CmCell::new(true),
             vis: CmCell::new(vis),

--- a/compiler/rustc_resolve/src/build_reduced_graph.rs
+++ b/compiler/rustc_resolve/src/build_reduced_graph.rs
@@ -92,7 +92,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             ambiguity,
             // External ambiguities always report the `AMBIGUOUS_GLOB_IMPORTS` lint at the moment.
             warn_ambiguity: CmCell::new(true),
-            vis,
+            vis: CmCell::new(vis),
             span,
             expansion,
         });
@@ -1158,18 +1158,18 @@ impl<'a, 'ra, 'tcx> BuildReducedGraphVisitor<'a, 'ra, 'tcx> {
             self.r.potentially_unused_imports.push(import);
             module.for_each_child_mut(self, |this, ident, ns, binding| {
                 if ns == MacroNS {
-                    let import = if this.r.is_accessible_from(binding.vis, this.parent_scope.module)
-                    {
-                        import
-                    } else {
-                        // FIXME: This branch is used for reporting the `private_macro_use` lint
-                        // and should eventually be removed.
-                        if this.r.macro_use_prelude.contains_key(&ident.name) {
-                            // Do not override already existing entries with compatibility entries.
-                            return;
-                        }
-                        macro_use_import(this, span, true)
-                    };
+                    let import =
+                        if this.r.is_accessible_from(binding.vis(), this.parent_scope.module) {
+                            import
+                        } else {
+                            // FIXME: This branch is used for reporting the `private_macro_use` lint
+                            // and should eventually be removed.
+                            if this.r.macro_use_prelude.contains_key(&ident.name) {
+                                // Do not override already existing entries with compatibility entries.
+                                return;
+                            }
+                            macro_use_import(this, span, true)
+                        };
                     let import_decl = this.r.new_import_decl(binding, import);
                     this.add_macro_use_decl(ident.name, import_decl, span, allow_shadowing);
                 }

--- a/compiler/rustc_resolve/src/build_reduced_graph.rs
+++ b/compiler/rustc_resolve/src/build_reduced_graph.rs
@@ -91,7 +91,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             kind: DeclKind::Def(res),
             ambiguity,
             // External ambiguities always report the `AMBIGUOUS_GLOB_IMPORTS` lint at the moment.
-            warn_ambiguity: true,
+            warn_ambiguity: CmCell::new(true),
             vis,
             span,
             expansion,

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -1338,7 +1338,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 }
 
                 let child_accessible =
-                    accessible && this.is_accessible_from(name_binding.vis, parent_scope.module);
+                    accessible && this.is_accessible_from(name_binding.vis(), parent_scope.module);
 
                 // do not venture inside inaccessible items of other crates
                 if in_module_is_extern && !child_accessible {
@@ -1358,8 +1358,8 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
 
                 // #90113: Do not count an inaccessible reexported item as a candidate.
                 if let DeclKind::Import { source_decl, .. } = name_binding.kind
-                    && this.is_accessible_from(source_decl.vis, parent_scope.module)
-                    && !this.is_accessible_from(name_binding.vis, parent_scope.module)
+                    && this.is_accessible_from(source_decl.vis(), parent_scope.module)
+                    && !this.is_accessible_from(name_binding.vis(), parent_scope.module)
                 {
                     return;
                 }
@@ -2243,7 +2243,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             let first = binding == first_binding;
             let def_span = self.tcx.sess.source_map().guess_head_span(binding.span);
             let mut note_span = MultiSpan::from_span(def_span);
-            if !first && binding.vis.is_public() {
+            if !first && binding.vis().is_public() {
                 let desc = match binding.kind {
                     DeclKind::Import { .. } => "re-export",
                     _ => "directly",

--- a/compiler/rustc_resolve/src/effective_visibilities.rs
+++ b/compiler/rustc_resolve/src/effective_visibilities.rs
@@ -145,7 +145,7 @@ impl<'a, 'ra, 'tcx> EffectiveVisibilitiesVisitor<'a, 'ra, 'tcx> {
             if !is_ambiguity(decl, warn_ambiguity)
                 && let Some(def_id) = decl.res().opt_def_id().and_then(|id| id.as_local())
             {
-                self.update_def(def_id, decl.vis.expect_local(), parent_id);
+                self.update_def(def_id, decl.vis().expect_local(), parent_id);
             }
         }
     }
@@ -188,7 +188,7 @@ impl<'a, 'ra, 'tcx> EffectiveVisibilitiesVisitor<'a, 'ra, 'tcx> {
     }
 
     fn update_import(&mut self, decl: Decl<'ra>, parent_id: ParentId<'ra>) {
-        let nominal_vis = decl.vis.expect_local();
+        let nominal_vis = decl.vis().expect_local();
         let Some(cheap_private_vis) = self.may_update(nominal_vis, parent_id) else { return };
         let inherited_eff_vis = self.effective_vis_or_private(parent_id);
         let tcx = self.r.tcx;

--- a/compiler/rustc_resolve/src/effective_visibilities.rs
+++ b/compiler/rustc_resolve/src/effective_visibilities.rs
@@ -100,7 +100,9 @@ impl<'a, 'ra, 'tcx> EffectiveVisibilitiesVisitor<'a, 'ra, 'tcx> {
                 if let Some(node_id) = import.id() {
                     r.effective_visibilities.update_eff_vis(r.local_def_id(node_id), eff_vis, r.tcx)
                 }
-            } else if decl.ambiguity.is_some() && eff_vis.is_public_at_level(Level::Reexported) {
+            } else if decl.ambiguity.get().is_some()
+                && eff_vis.is_public_at_level(Level::Reexported)
+            {
                 exported_ambiguities.insert(*decl);
             }
         }
@@ -125,7 +127,8 @@ impl<'a, 'ra, 'tcx> EffectiveVisibilitiesVisitor<'a, 'ra, 'tcx> {
             // If the binding is ambiguous, put the root ambiguity binding and all reexports
             // leading to it into the table. They are used by the `ambiguous_glob_reexports`
             // lint. For all bindings added to the table this way `is_ambiguity` returns true.
-            let is_ambiguity = |decl: Decl<'ra>, warn: bool| decl.ambiguity.is_some() && !warn;
+            let is_ambiguity =
+                |decl: Decl<'ra>, warn: bool| decl.ambiguity.get().is_some() && !warn;
             let mut parent_id = ParentId::Def(module_id);
             let mut warn_ambiguity = decl.warn_ambiguity.get();
             while let DeclKind::Import { source_decl, .. } = decl.kind {

--- a/compiler/rustc_resolve/src/effective_visibilities.rs
+++ b/compiler/rustc_resolve/src/effective_visibilities.rs
@@ -127,7 +127,7 @@ impl<'a, 'ra, 'tcx> EffectiveVisibilitiesVisitor<'a, 'ra, 'tcx> {
             // lint. For all bindings added to the table this way `is_ambiguity` returns true.
             let is_ambiguity = |decl: Decl<'ra>, warn: bool| decl.ambiguity.is_some() && !warn;
             let mut parent_id = ParentId::Def(module_id);
-            let mut warn_ambiguity = decl.warn_ambiguity;
+            let mut warn_ambiguity = decl.warn_ambiguity.get();
             while let DeclKind::Import { source_decl, .. } = decl.kind {
                 self.update_import(decl, parent_id);
 
@@ -140,7 +140,7 @@ impl<'a, 'ra, 'tcx> EffectiveVisibilitiesVisitor<'a, 'ra, 'tcx> {
 
                 parent_id = ParentId::Import(decl);
                 decl = source_decl;
-                warn_ambiguity |= source_decl.warn_ambiguity;
+                warn_ambiguity |= source_decl.warn_ambiguity.get();
             }
             if !is_ambiguity(decl, warn_ambiguity)
                 && let Some(def_id) = decl.res().opt_def_id().and_then(|id| id.as_local())

--- a/compiler/rustc_resolve/src/ident.rs
+++ b/compiler/rustc_resolve/src/ident.rs
@@ -1017,7 +1017,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
 
         // Items and single imports are not shadowable, if we have one, then it's determined.
         if let Some(binding) = binding {
-            let accessible = self.is_accessible_from(binding.vis, parent_scope.module);
+            let accessible = self.is_accessible_from(binding.vis(), parent_scope.module);
             return if accessible { Ok(binding) } else { Err(ControlFlow::Break(Determined)) };
         }
 
@@ -1103,7 +1103,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         // shadowing is enabled, see `macro_expanded_macro_export_errors`).
         if let Some(binding) = binding {
             return if binding.determined() || ns == MacroNS || shadowing == Shadowing::Restricted {
-                let accessible = self.is_accessible_from(binding.vis, parent_scope.module);
+                let accessible = self.is_accessible_from(binding.vis(), parent_scope.module);
                 if accessible { Ok(binding) } else { Err(ControlFlow::Break(Determined)) }
             } else {
                 Err(ControlFlow::Break(Undetermined))
@@ -1160,7 +1160,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             match result {
                 Err(Determined) => continue,
                 Ok(binding)
-                    if !self.is_accessible_from(binding.vis, glob_import.parent_scope.module) =>
+                    if !self.is_accessible_from(binding.vis(), glob_import.parent_scope.module) =>
                 {
                     continue;
                 }
@@ -1187,7 +1187,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             return Err(ControlFlow::Continue(Determined));
         };
 
-        if !self.is_accessible_from(binding.vis, parent_scope.module) {
+        if !self.is_accessible_from(binding.vis(), parent_scope.module) {
             if report_private {
                 self.privacy_errors.push(PrivacyError {
                     ident,
@@ -1304,7 +1304,8 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             ) {
                 Err(Determined) => continue,
                 Ok(binding)
-                    if !self.is_accessible_from(binding.vis, single_import.parent_scope.module) =>
+                    if !self
+                        .is_accessible_from(binding.vis(), single_import.parent_scope.module) =>
                 {
                     continue;
                 }

--- a/compiler/rustc_resolve/src/imports.rs
+++ b/compiler/rustc_resolve/src/imports.rs
@@ -384,10 +384,9 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             // We are glob-importing the same item but with greater visibility.
             old_glob_decl.vis.set_unchecked(glob_decl.vis());
             old_glob_decl
-        } else if glob_decl.is_ambiguity_recursive() {
-            // Overwriting with an ambiguous glob import.
-            glob_decl.warn_ambiguity.set_unchecked(true);
-            glob_decl
+        } else if glob_decl.is_ambiguity_recursive() && !old_glob_decl.is_ambiguity_recursive() {
+            // Overwriting a non-ambiguous glob import with an ambiguous glob import.
+            self.new_decl_with_ambiguity(old_glob_decl, glob_decl, true)
         } else {
             old_glob_decl
         }

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -2793,7 +2793,7 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
 
             in_module.for_each_child(self.r, |r, ident, _, name_binding| {
                 // abort if the module is already found or if name_binding is private external
-                if result.is_some() || !name_binding.vis.is_visible_locally() {
+                if result.is_some() || !name_binding.vis().is_visible_locally() {
                     return;
                 }
                 if let Some(module_def_id) = name_binding.res().module_like_def_id() {

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -811,7 +811,7 @@ struct DeclData<'ra> {
     warn_ambiguity: CmCell<bool>,
     expansion: LocalExpnId,
     span: Span,
-    vis: Visibility<DefId>,
+    vis: CmCell<Visibility<DefId>>,
 }
 
 /// All name declarations are unique and allocated on a same arena,
@@ -923,6 +923,10 @@ struct AmbiguityError<'ra> {
 }
 
 impl<'ra> DeclData<'ra> {
+    fn vis(&self) -> Visibility<DefId> {
+        self.vis.get()
+    }
+
     fn res(&self) -> Res {
         match self.kind {
             DeclKind::Def(res) => res,
@@ -1344,7 +1348,7 @@ impl<'ra> ResolverArenas<'ra> {
             kind: DeclKind::Def(res),
             ambiguity: None,
             warn_ambiguity: CmCell::new(false),
-            vis,
+            vis: CmCell::new(vis),
             span,
             expansion,
         })

--- a/tests/ui/imports/ambiguous-14.stderr
+++ b/tests/ui/imports/ambiguous-14.stderr
@@ -8,15 +8,15 @@ LL |     g::foo();
    = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `foo` could refer to the function imported here
-  --> $DIR/ambiguous-14.rs:13:13
+  --> $DIR/ambiguous-14.rs:18:13
    |
 LL |     pub use a::*;
    |             ^^^^
    = help: consider adding an explicit import of `foo` to disambiguate
 note: `foo` could also refer to the function imported here
-  --> $DIR/ambiguous-14.rs:14:13
+  --> $DIR/ambiguous-14.rs:19:13
    |
-LL |     pub use b::*;
+LL |     pub use f::*;
    |             ^^^^
    = help: consider adding an explicit import of `foo` to disambiguate
    = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
@@ -34,15 +34,15 @@ LL |     g::foo();
    = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `foo` could refer to the function imported here
-  --> $DIR/ambiguous-14.rs:13:13
+  --> $DIR/ambiguous-14.rs:18:13
    |
 LL |     pub use a::*;
    |             ^^^^
    = help: consider adding an explicit import of `foo` to disambiguate
 note: `foo` could also refer to the function imported here
-  --> $DIR/ambiguous-14.rs:14:13
+  --> $DIR/ambiguous-14.rs:19:13
    |
-LL |     pub use b::*;
+LL |     pub use f::*;
    |             ^^^^
    = help: consider adding an explicit import of `foo` to disambiguate
    = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default

--- a/tests/ui/imports/duplicate.stderr
+++ b/tests/ui/imports/duplicate.stderr
@@ -78,15 +78,15 @@ LL |     g::foo();
    = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `foo` could refer to the function imported here
-  --> $DIR/duplicate.rs:24:13
+  --> $DIR/duplicate.rs:29:13
    |
 LL |     pub use crate::a::*;
    |             ^^^^^^^^^^^
    = help: consider adding an explicit import of `foo` to disambiguate
 note: `foo` could also refer to the function imported here
-  --> $DIR/duplicate.rs:25:13
+  --> $DIR/duplicate.rs:30:13
    |
-LL |     pub use crate::b::*;
+LL |     pub use crate::f::*;
    |             ^^^^^^^^^^^
    = help: consider adding an explicit import of `foo` to disambiguate
    = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
@@ -106,15 +106,15 @@ LL |     g::foo();
    = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `foo` could refer to the function imported here
-  --> $DIR/duplicate.rs:24:13
+  --> $DIR/duplicate.rs:29:13
    |
 LL |     pub use crate::a::*;
    |             ^^^^^^^^^^^
    = help: consider adding an explicit import of `foo` to disambiguate
 note: `foo` could also refer to the function imported here
-  --> $DIR/duplicate.rs:25:13
+  --> $DIR/duplicate.rs:30:13
    |
-LL |     pub use crate::b::*;
+LL |     pub use crate::f::*;
    |             ^^^^^^^^^^^
    = help: consider adding an explicit import of `foo` to disambiguate
    = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default

--- a/tests/ui/imports/issue-55884-1.rs
+++ b/tests/ui/imports/issue-55884-1.rs
@@ -17,5 +17,5 @@ mod m {
 
 fn main() {
     use m::S; //~ ERROR `S` is ambiguous
-    let s = S {};
+    let s = S {}; //~ ERROR `S` is ambiguous
 }

--- a/tests/ui/imports/issue-55884-1.stderr
+++ b/tests/ui/imports/issue-55884-1.stderr
@@ -18,6 +18,26 @@ LL |     pub use self::m2::*;
    |             ^^^^^^^^^^^
    = help: consider adding an explicit import of `S` to disambiguate
 
-error: aborting due to 1 previous error
+error[E0659]: `S` is ambiguous
+  --> $DIR/issue-55884-1.rs:20:13
+   |
+LL |     let s = S {};
+   |             ^ ambiguous name
+   |
+   = note: ambiguous because of multiple glob imports of a name in the same module
+note: `S` could refer to the struct imported here
+  --> $DIR/issue-55884-1.rs:14:13
+   |
+LL |     pub use self::m1::*;
+   |             ^^^^^^^^^^^
+   = help: consider adding an explicit import of `S` to disambiguate
+note: `S` could also refer to the struct imported here
+  --> $DIR/issue-55884-1.rs:15:13
+   |
+LL |     pub use self::m2::*;
+   |             ^^^^^^^^^^^
+   = help: consider adding an explicit import of `S` to disambiguate
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0659`.


### PR DESCRIPTION
Also, avoid creating fresh name declarations and overwriting declarations in modules to update some fields in `DeclData`, when possible.
Instead, change the fields directly in `DeclData` using cells.

Unblocks https://github.com/rust-lang/rust/pull/149195.