### PR TITLE
Rollup of 2 pull requests

### DIFF
--- a/compiler/rustc_infer/src/infer/freshen.rs
+++ b/compiler/rustc_infer/src/infer/freshen.rs
@@ -148,15 +148,12 @@ impl<'a, 'tcx> TypeFolder<TyCtxt<'tcx>> for TypeFreshener<'a, 'tcx> {
                     }
                 }
             }
-            ty::ConstKind::Infer(ty::InferConst::Fresh(i)) => {
-                if i >= self.const_freshen_count {
-                    bug!("freshened const id {} exceeds counter {}", i, self.const_freshen_count);
-                }
-                ct
+            ty::ConstKind::Infer(ty::InferConst::Fresh(_)) => {
+                bug!("trying to freshen already-freshened const {ct:?}");
             }
 
             ty::ConstKind::Bound(..) | ty::ConstKind::Placeholder(_) => {
-                bug!("unexpected const {:?}", ct)
+                bug!("unexpected const {ct:?}")
             }
 
             ty::ConstKind::Param(_)
@@ -171,8 +168,8 @@ impl<'a, 'tcx> TypeFolder<TyCtxt<'tcx>> for TypeFreshener<'a, 'tcx> {
 impl<'a, 'tcx> TypeFreshener<'a, 'tcx> {
     // This is separate from `fold_ty` to keep that method small and inlinable.
     #[inline(never)]
-    fn fold_infer_ty(&mut self, v: ty::InferTy) -> Option<Ty<'tcx>> {
-        match v {
+    fn fold_infer_ty(&mut self, ty: ty::InferTy) -> Option<Ty<'tcx>> {
+        match ty {
             ty::TyVar(v) => {
                 let mut inner = self.infcx.inner.borrow_mut();
                 match inner.type_variables().probe(v).known() {
@@ -212,11 +209,8 @@ impl<'a, 'tcx> TypeFreshener<'a, 'tcx> {
                 }
             }
 
-            ty::FreshTy(ct) | ty::FreshIntTy(ct) | ty::FreshFloatTy(ct) => {
-                if ct >= self.ty_freshen_count {
-                    bug!("freshened type id {} exceeds counter {}", ct, self.ty_freshen_count);
-                }
-                None
+            ty::FreshTy(_) | ty::FreshIntTy(_) | ty::FreshFloatTy(_) => {
+                bug!("trying to freshen already-freshened type {ty:?}");
             }
         }
     }

--- a/compiler/rustc_infer/src/infer/freshen.rs
+++ b/compiler/rustc_infer/src/infer/freshen.rs
@@ -60,45 +60,35 @@ impl<'a, 'tcx> TypeFreshener<'a, 'tcx> {
         }
     }
 
-    fn freshen_ty<F>(&mut self, input: Result<Ty<'tcx>, ty::InferTy>, mk_fresh: F) -> Ty<'tcx>
+    fn freshen_ty<F>(&mut self, input: ty::InferTy, mk_fresh: F) -> Ty<'tcx>
     where
         F: FnOnce(u32) -> Ty<'tcx>,
     {
-        match input {
-            Ok(ty) => ty.fold_with(self),
-            Err(key) => match self.ty_freshen_map.entry(key) {
-                Entry::Occupied(entry) => *entry.get(),
-                Entry::Vacant(entry) => {
-                    let index = self.ty_freshen_count;
-                    self.ty_freshen_count += 1;
-                    let t = mk_fresh(index);
-                    entry.insert(t);
-                    t
-                }
-            },
+        match self.ty_freshen_map.entry(input) {
+            Entry::Occupied(entry) => *entry.get(),
+            Entry::Vacant(entry) => {
+                let index = self.ty_freshen_count;
+                self.ty_freshen_count += 1;
+                let t = mk_fresh(index);
+                entry.insert(t);
+                t
+            }
         }
     }
 
-    fn freshen_const<F>(
-        &mut self,
-        input: Result<ty::Const<'tcx>, ty::InferConst>,
-        freshener: F,
-    ) -> ty::Const<'tcx>
+    fn freshen_const<F>(&mut self, input: ty::InferConst, freshener: F) -> ty::Const<'tcx>
     where
         F: FnOnce(u32) -> ty::InferConst,
     {
-        match input {
-            Ok(ct) => ct.fold_with(self),
-            Err(key) => match self.const_freshen_map.entry(key) {
-                Entry::Occupied(entry) => *entry.get(),
-                Entry::Vacant(entry) => {
-                    let index = self.const_freshen_count;
-                    self.const_freshen_count += 1;
-                    let ct = ty::Const::new_infer(self.infcx.tcx, freshener(index));
-                    entry.insert(ct);
-                    ct
-                }
-            },
+        match self.const_freshen_map.entry(input) {
+            Entry::Occupied(entry) => *entry.get(),
+            Entry::Vacant(entry) => {
+                let index = self.const_freshen_count;
+                self.const_freshen_count += 1;
+                let ct = ty::Const::new_infer(self.infcx.tcx, freshener(index));
+                entry.insert(ct);
+                ct
+            }
         }
     }
 }
@@ -146,21 +136,21 @@ impl<'a, 'tcx> TypeFolder<TyCtxt<'tcx>> for TypeFreshener<'a, 'tcx> {
         match ct.kind() {
             ty::ConstKind::Infer(ty::InferConst::Var(v)) => {
                 let mut inner = self.infcx.inner.borrow_mut();
-                let input =
-                    inner.const_unification_table().probe_value(v).known().ok_or_else(|| {
-                        ty::InferConst::Var(inner.const_unification_table().find(v).vid)
-                    });
-                drop(inner);
-                self.freshen_const(input, ty::InferConst::Fresh)
+                match inner.const_unification_table().probe_value(v).known() {
+                    Some(const_) => {
+                        drop(inner);
+                        const_.fold_with(self)
+                    }
+                    None => {
+                        let input =
+                            ty::InferConst::Var(inner.const_unification_table().find(v).vid);
+                        self.freshen_const(input, ty::InferConst::Fresh)
+                    }
+                }
             }
             ty::ConstKind::Infer(ty::InferConst::Fresh(i)) => {
                 if i >= self.const_freshen_count {
-                    bug!(
-                        "Encountered a freshend const with id {} \
-                            but our counter is only at {}",
-                        i,
-                        self.const_freshen_count,
-                    );
+                    bug!("freshened const id {} exceeds counter {}", i, self.const_freshen_count);
                 }
                 ct
             }
@@ -185,50 +175,46 @@ impl<'a, 'tcx> TypeFreshener<'a, 'tcx> {
         match v {
             ty::TyVar(v) => {
                 let mut inner = self.infcx.inner.borrow_mut();
-                let input = inner
-                    .type_variables()
-                    .probe(v)
-                    .known()
-                    .ok_or_else(|| ty::TyVar(inner.type_variables().root_var(v)));
-                drop(inner);
-                Some(self.freshen_ty(input, |n| Ty::new_fresh(self.infcx.tcx, n)))
+                match inner.type_variables().probe(v).known() {
+                    Some(ty) => {
+                        drop(inner);
+                        Some(ty.fold_with(self))
+                    }
+                    None => {
+                        let input = ty::TyVar(inner.type_variables().root_var(v));
+                        Some(self.freshen_ty(input, |n| Ty::new_fresh(self.infcx.tcx, n)))
+                    }
+                }
             }
 
             ty::IntVar(v) => {
                 let mut inner = self.infcx.inner.borrow_mut();
                 let value = inner.int_unification_table().probe_value(v);
-                let input = match value {
-                    ty::IntVarValue::IntType(ty) => Ok(Ty::new_int(self.infcx.tcx, ty)),
-                    ty::IntVarValue::UintType(ty) => Ok(Ty::new_uint(self.infcx.tcx, ty)),
+                match value {
+                    ty::IntVarValue::IntType(ty) => Some(Ty::new_int(self.infcx.tcx, ty)),
+                    ty::IntVarValue::UintType(ty) => Some(Ty::new_uint(self.infcx.tcx, ty)),
                     ty::IntVarValue::Unknown => {
-                        Err(ty::IntVar(inner.int_unification_table().find(v)))
+                        let input = ty::IntVar(inner.int_unification_table().find(v));
+                        Some(self.freshen_ty(input, |n| Ty::new_fresh_int(self.infcx.tcx, n)))
                     }
-                };
-                drop(inner);
-                Some(self.freshen_ty(input, |n| Ty::new_fresh_int(self.infcx.tcx, n)))
+                }
             }
 
             ty::FloatVar(v) => {
                 let mut inner = self.infcx.inner.borrow_mut();
                 let value = inner.float_unification_table().probe_value(v);
-                let input = match value {
-                    ty::FloatVarValue::Known(ty) => Ok(Ty::new_float(self.infcx.tcx, ty)),
+                match value {
+                    ty::FloatVarValue::Known(ty) => Some(Ty::new_float(self.infcx.tcx, ty)),
                     ty::FloatVarValue::Unknown => {
-                        Err(ty::FloatVar(inner.float_unification_table().find(v)))
+                        let input = ty::FloatVar(inner.float_unification_table().find(v));
+                        Some(self.freshen_ty(input, |n| Ty::new_fresh_float(self.infcx.tcx, n)))
                     }
-                };
-                drop(inner);
-                Some(self.freshen_ty(input, |n| Ty::new_fresh_float(self.infcx.tcx, n)))
+                }
             }
 
             ty::FreshTy(ct) | ty::FreshIntTy(ct) | ty::FreshFloatTy(ct) => {
                 if ct >= self.ty_freshen_count {
-                    bug!(
-                        "Encountered a freshend type with id {} \
-                          but our counter is only at {}",
-                        ct,
-                        self.ty_freshen_count
-                    );
+                    bug!("freshened type id {} exceeds counter {}", ct, self.ty_freshen_count);
                 }
                 None
             }

--- a/compiler/rustc_infer/src/infer/mod.rs
+++ b/compiler/rustc_infer/src/infer/mod.rs
@@ -637,10 +637,6 @@ impl<'tcx> InferCtxt<'tcx> {
         self.typing_mode
     }
 
-    pub fn freshen<T: TypeFoldable<TyCtxt<'tcx>>>(&self, t: T) -> T {
-        t.fold_with(&mut TypeFreshener::new(self))
-    }
-
     /// Returns the origin of the type variable identified by `vid`.
     ///
     /// No attempt is made to resolve `vid` to its root variable.

--- a/compiler/rustc_infer/src/infer/mod.rs
+++ b/compiler/rustc_infer/src/infer/mod.rs
@@ -638,7 +638,7 @@ impl<'tcx> InferCtxt<'tcx> {
     }
 
     pub fn freshen<T: TypeFoldable<TyCtxt<'tcx>>>(&self, t: T) -> T {
-        t.fold_with(&mut self.freshener())
+        t.fold_with(&mut TypeFreshener::new(self))
     }
 
     /// Returns the origin of the type variable identified by `vid`.
@@ -656,10 +656,6 @@ impl<'tcx> InferCtxt<'tcx> {
             ConstVariableValue::Known { .. } => None,
             ConstVariableValue::Unknown { origin, .. } => Some(origin),
         }
-    }
-
-    pub fn freshener<'b>(&'b self) -> TypeFreshener<'b, 'tcx> {
-        freshen::TypeFreshener::new(self)
     }
 
     pub fn unresolved_variables(&self) -> Vec<Ty<'tcx>> {

--- a/compiler/rustc_trait_selection/src/traits/auto_trait.rs
+++ b/compiler/rustc_trait_selection/src/traits/auto_trait.rs
@@ -13,6 +13,7 @@ use tracing::debug;
 
 use super::*;
 use crate::errors::UnableToConstructConstantValue;
+use crate::infer::TypeFreshener;
 use crate::infer::region_constraints::{ConstraintKind, RegionConstraintData};
 use crate::regions::OutlivesEnvironmentBuildExt;
 use crate::traits::project::ProjectAndUnifyResult;
@@ -817,6 +818,6 @@ impl<'tcx> AutoTraitFinder<'tcx> {
         infcx: &InferCtxt<'tcx>,
         p: ty::Predicate<'tcx>,
     ) -> ty::Predicate<'tcx> {
-        infcx.freshen(p)
+        p.fold_with(&mut TypeFreshener::new(infcx))
     }
 }

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -321,7 +321,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         self.check_recursion_limit(stack.obligation, stack.obligation)?;
 
         // Check the cache. Note that we freshen the trait-ref
-        // separately rather than using `stack.fresh_trait_ref` --
+        // separately rather than using `stack.fresh_trait_pred` --
         // this is because we want the unbound variables to be
         // replaced with fresh types starting from index 0.
         let cache_fresh_trait_pred =
@@ -1136,7 +1136,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
     /// `Option<Box<List<T>>>` is `Send` if `Box<List<T>>` is
     /// `Send`.
     ///
-    /// Note that we do this comparison using the `fresh_trait_ref`
+    /// Note that we do this comparison using the `fresh_trait_pred`
     /// fields. Because these have all been freshened using
     /// `self.freshener`, we can be sure that (a) this will not
     /// affect the inferencer state and (b) that if we see two
@@ -1220,7 +1220,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         if unbound_input_types
             && stack.iter().skip(1).any(|prev| {
                 stack.obligation.param_env == prev.obligation.param_env
-                    && self.match_fresh_trait_refs(stack.fresh_trait_pred, prev.fresh_trait_pred)
+                    && self.match_fresh_trait_preds(stack.fresh_trait_pred, prev.fresh_trait_pred)
             })
         {
             debug!("evaluate_stack --> unbound argument, recursive --> giving up",);
@@ -2743,7 +2743,7 @@ impl<'tcx> SelectionContext<'_, 'tcx> {
     ///////////////////////////////////////////////////////////////////////////
     // Miscellany
 
-    fn match_fresh_trait_refs(
+    fn match_fresh_trait_preds(
         &self,
         previous: ty::PolyTraitPredicate<'tcx>,
         current: ty::PolyTraitPredicate<'tcx>,
@@ -3032,7 +3032,7 @@ impl<'tcx> ProvisionalEvaluationCache<'tcx> {
     }
 
     /// Check the provisional cache for any result for
-    /// `fresh_trait_ref`. If there is a hit, then you must consider
+    /// `fresh_trait_pred`. If there is a hit, then you must consider
     /// it an access to the stack slots at depth
     /// `reached_depth` (from the returned value).
     fn get_provisional(

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -324,7 +324,8 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         // separately rather than using `stack.fresh_trait_ref` --
         // this is because we want the unbound variables to be
         // replaced with fresh types starting from index 0.
-        let cache_fresh_trait_pred = self.infcx.freshen(stack.obligation.predicate);
+        let cache_fresh_trait_pred =
+            stack.obligation.predicate.fold_with(&mut TypeFreshener::new(self.infcx));
         debug!(?cache_fresh_trait_pred);
         debug_assert!(!stack.obligation.predicate.has_escaping_bound_vars());
 

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -195,7 +195,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
     pub fn new(infcx: &'cx InferCtxt<'tcx>) -> SelectionContext<'cx, 'tcx> {
         SelectionContext {
             infcx,
-            freshener: infcx.freshener(),
+            freshener: TypeFreshener::new(infcx),
             intercrate_ambiguity_causes: None,
             query_mode: TraitQueryMode::Standard,
         }

--- a/compiler/rustc_type_ir/src/const_kind.rs
+++ b/compiler/rustc_type_ir/src/const_kind.rs
@@ -103,7 +103,7 @@ rustc_index::newtype_index! {
 pub enum InferConst {
     /// Infer the value of the const.
     Var(ConstVid),
-    /// A fresh const variable. See `infer::freshen` for more details.
+    /// A fresh const variable. See `TypeFreshener` for more details.
     Fresh(u32),
 }
 

--- a/compiler/rustc_type_ir/src/ty_kind.rs
+++ b/compiler/rustc_type_ir/src/ty_kind.rs
@@ -594,7 +594,7 @@ pub enum InferTy {
 
     /// A [`FreshTy`][Self::FreshTy] is one that is generated as a replacement
     /// for an unbound type variable. This is convenient for caching etc. See
-    /// `rustc_infer::infer::freshen` for more details.
+    /// `TypeFreshener` for more details.
     ///
     /// Compare with [`TyVar`][Self::TyVar].
     FreshTy(u32),

--- a/library/alloc/src/collections/linked_list.rs
+++ b/library/alloc/src/collections/linked_list.rs
@@ -597,7 +597,7 @@ impl<T, A: Allocator> LinkedList<T, A> {
     #[must_use]
     #[unstable(feature = "linked_list_cursors", issue = "58533")]
     pub fn cursor_back(&self) -> Cursor<'_, T, A> {
-        Cursor { index: self.len.checked_sub(1).unwrap_or(0), current: self.tail, list: self }
+        Cursor { index: self.len.saturating_sub(1), current: self.tail, list: self }
     }
 
     /// Provides a cursor with editing operations at the back element.
@@ -607,7 +607,7 @@ impl<T, A: Allocator> LinkedList<T, A> {
     #[must_use]
     #[unstable(feature = "linked_list_cursors", issue = "58533")]
     pub fn cursor_back_mut(&mut self) -> CursorMut<'_, T, A> {
-        CursorMut { index: self.len.checked_sub(1).unwrap_or(0), current: self.tail, list: self }
+        CursorMut { index: self.len.saturating_sub(1), current: self.tail, list: self }
     }
 
     /// Returns `true` if the `LinkedList` is empty.
@@ -1432,7 +1432,7 @@ impl<'a, T, A: Allocator> Cursor<'a, T, A> {
             // No current. We're at the start of the list. Yield None and jump to the end.
             None => {
                 self.current = self.list.tail;
-                self.index = self.list.len().checked_sub(1).unwrap_or(0);
+                self.index = self.list.len().saturating_sub(1);
             }
             // Have a prev. Yield it and go to the previous element.
             Some(current) => unsafe {
@@ -1559,7 +1559,7 @@ impl<'a, T, A: Allocator> CursorMut<'a, T, A> {
             // No current. We're at the start of the list. Yield None and jump to the end.
             None => {
                 self.current = self.list.tail;
-                self.index = self.list.len().checked_sub(1).unwrap_or(0);
+                self.index = self.list.len().saturating_sub(1);
             }
             // Have a prev. Yield it and go to the previous element.
             Some(current) => unsafe {

--- a/library/alloc/src/collections/linked_list.rs
+++ b/library/alloc/src/collections/linked_list.rs
@@ -167,7 +167,7 @@ impl<T, A: Allocator> LinkedList<T, A> {
     /// Adds the given node to the front of the list.
     ///
     /// # Safety
-    /// `node` must point to a valid node that was boxed and leaked using the list's allocator.
+    /// `node` must point to a valid node in the list's allocator.
     /// This method takes ownership of the node, so the pointer should not be used again.
     #[inline]
     unsafe fn push_front_node(&mut self, node: NonNull<Node<T>>) {
@@ -212,7 +212,7 @@ impl<T, A: Allocator> LinkedList<T, A> {
     /// Adds the given node to the back of the list.
     ///
     /// # Safety
-    /// `node` must point to a valid node that was boxed and leaked using the list's allocator.
+    /// `node` must point to a valid node in the list's allocator.
     /// This method takes ownership of the node, so the pointer should not be used again.
     #[inline]
     unsafe fn push_back_node(&mut self, node: NonNull<Node<T>>) {
@@ -866,12 +866,12 @@ impl<T, A: Allocator> LinkedList<T, A> {
     #[unstable(feature = "push_mut", issue = "135974")]
     #[must_use = "if you don't need a reference to the value, use `LinkedList::push_front` instead"]
     pub fn push_front_mut(&mut self, elt: T) -> &mut T {
-        let node = Box::new_in(Node::new(elt), &self.alloc);
-        let mut node_ptr = NonNull::from(Box::leak(node));
-        // SAFETY: node_ptr is a unique pointer to a node we boxed with self.alloc and leaked
+        let mut node =
+            Box::into_non_null_with_allocator(Box::new_in(Node::new(elt), &self.alloc)).0;
+        // SAFETY: node is a unique pointer to a node in self.alloc
         unsafe {
-            self.push_front_node(node_ptr);
-            &mut node_ptr.as_mut().element
+            self.push_front_node(node);
+            &mut node.as_mut().element
         }
     }
 
@@ -938,12 +938,12 @@ impl<T, A: Allocator> LinkedList<T, A> {
     #[unstable(feature = "push_mut", issue = "135974")]
     #[must_use = "if you don't need a reference to the value, use `LinkedList::push_back` instead"]
     pub fn push_back_mut(&mut self, elt: T) -> &mut T {
-        let node = Box::new_in(Node::new(elt), &self.alloc);
-        let mut node_ptr = NonNull::from(Box::leak(node));
-        // SAFETY: node_ptr is a unique pointer to a node we boxed with self.alloc and leaked
+        let mut node =
+            Box::into_non_null_with_allocator(Box::new_in(Node::new(elt), &self.alloc)).0;
+        // SAFETY: node is a unique pointer to a node in self.alloc
         unsafe {
-            self.push_back_node(node_ptr);
-            &mut node_ptr.as_mut().element
+            self.push_back_node(node);
+            &mut node.as_mut().element
         }
     }
 
@@ -1690,7 +1690,8 @@ impl<'a, T, A: Allocator> CursorMut<'a, T, A> {
     #[unstable(feature = "linked_list_cursors", issue = "58533")]
     pub fn insert_after(&mut self, item: T) {
         unsafe {
-            let spliced_node = Box::leak(Box::new_in(Node::new(item), &self.list.alloc)).into();
+            let spliced_node =
+                Box::into_non_null_with_allocator(Box::new_in(Node::new(item), &self.list.alloc)).0;
             let node_next = match self.current {
                 None => self.list.head,
                 Some(node) => node.as_ref().next,
@@ -1710,7 +1711,8 @@ impl<'a, T, A: Allocator> CursorMut<'a, T, A> {
     #[unstable(feature = "linked_list_cursors", issue = "58533")]
     pub fn insert_before(&mut self, item: T) {
         unsafe {
-            let spliced_node = Box::leak(Box::new_in(Node::new(item), &self.list.alloc)).into();
+            let spliced_node =
+                Box::into_non_null_with_allocator(Box::new_in(Node::new(item), &self.list.alloc)).0;
             let node_prev = match self.current {
                 None => self.list.tail,
                 Some(node) => node.as_ref().prev,

--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -93,6 +93,7 @@
 #![feature(assert_matches)]
 #![feature(async_fn_traits)]
 #![feature(async_iterator)]
+#![feature(box_vec_non_null)]
 #![feature(bstr)]
 #![feature(bstr_internals)]
 #![feature(cast_maybe_uninit)]

--- a/library/alloctests/lib.rs
+++ b/library/alloctests/lib.rs
@@ -18,6 +18,7 @@
 #![feature(allocator_api)]
 #![feature(array_into_iter_constructors)]
 #![feature(assert_matches)]
+#![feature(box_vec_non_null)]
 #![feature(char_internals)]
 #![feature(copied_into_inner)]
 #![feature(core_intrinsics)]


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#150239 (Simplify `TypeFreshener` methods.)
 - rust-lang/rust#150344 (Cleanup linked list)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=150239,150344)
<!-- homu-ignore:end -->