### PR TITLE
Add regression test for issue #99173

### DIFF
--- a/tests/ui/proc-macro/auxiliary/nested-empty-proc-macro.rs
+++ b/tests/ui/proc-macro/auxiliary/nested-empty-proc-macro.rs
@@ -1,0 +1,18 @@
+// Auxiliary proc-macro for issue #99173
+// Tests that nested proc-macro calls with empty output don't cause ICE
+
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+
+// This macro returns an empty TokenStream
+#[proc_macro]
+pub fn ignore(_input: TokenStream) -> TokenStream {
+    TokenStream::new()
+}
+
+// This macro generates code that calls the `ignore` macro
+#[proc_macro]
+pub fn outer_macro(_input: TokenStream) -> TokenStream {
+    "nested_empty_proc_macro::ignore!(42)".parse().unwrap()
+}

--- a/tests/ui/proc-macro/nested-empty-proc-macro.rs
+++ b/tests/ui/proc-macro/nested-empty-proc-macro.rs
@@ -1,0 +1,12 @@
+//@ check-pass
+//@ proc-macro: nested-empty-proc-macro.rs
+
+// Regression test for issue #99173
+// Tests that nested proc-macro calls where the inner macro returns
+// an empty TokenStream don't cause an ICE.
+
+extern crate nested_empty_proc_macro;
+
+fn main() {
+    nested_empty_proc_macro::outer_macro!(1 * 2 * 3 * 7);
+}


### PR DESCRIPTION
Close rust-lang/rust#99173.

Adds a regression test for rust-lang/rust#99173, which was an ICE that occurred when a proc-macro generated code that invoked another proc-macro returning an empty `TokenStream`.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
