### PR TITLE
Adds a regression test for #137823

### DIFF
--- a/tests/ui/codegen/normalization-overflow/recursion-issue-137823.rs
+++ b/tests/ui/codegen/normalization-overflow/recursion-issue-137823.rs
@@ -1,0 +1,39 @@
+//@ build-fail
+
+// Regression test for issue #137823
+// Tests that recursive monomorphization with associated types produces
+// a proper "recursion limit" error instead of an ICE.
+
+fn convert<S: Converter>() -> S::Out {
+    convert2::<ConvertWrap<S>>()
+    //~^ ERROR: reached the recursion limit while instantiating
+}
+
+fn convert2<S: Converter>() -> S::Out {
+    convert::<S>()
+}
+
+fn main() {
+    convert::<Ser>();
+}
+
+trait Converter {
+    type Out;
+}
+
+struct Ser;
+
+impl Converter for Ser {
+    type Out = ();
+}
+
+struct ConvertWrap<S> {
+    _d: S,
+}
+
+impl<S> Converter for ConvertWrap<S>
+where
+    S: Converter,
+{
+    type Out = S::Out;
+}

--- a/tests/ui/codegen/normalization-overflow/recursion-issue-137823.stderr
+++ b/tests/ui/codegen/normalization-overflow/recursion-issue-137823.stderr
@@ -1,0 +1,14 @@
+error: reached the recursion limit while instantiating `convert2::<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<Ser>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>`
+  --> $DIR/recursion-issue-137823.rs:8:5
+   |
+LL |     convert2::<ConvertWrap<S>>()
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: `convert2` defined here
+  --> $DIR/recursion-issue-137823.rs:12:1
+   |
+LL | fn convert2<S: Converter>() -> S::Out {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Adds a regression test for rust-lang/rust#137823. The test ensures that recursive generic function instantiation properly triggers the recursion limit error instead of ICE-ing with `type variables should not be hashed`.

Closes rust-lang/rust#137823

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
