### PR TITLE
Rollup of 2 pull requests

### DIFF
--- a/compiler/rustc_mir_build/src/builder/matches/buckets.rs
+++ b/compiler/rustc_mir_build/src/builder/matches/buckets.rs
@@ -1,12 +1,14 @@
 use std::cmp::Ordering;
 
 use rustc_data_structures::fx::FxIndexMap;
-use rustc_middle::mir::{BinOp, Place};
+use rustc_middle::mir::Place;
 use rustc_middle::span_bug;
 use tracing::debug;
 
 use crate::builder::Builder;
-use crate::builder::matches::{Candidate, PatConstKind, Test, TestBranch, TestKind, TestableCase};
+use crate::builder::matches::{
+    Candidate, PatConstKind, SliceLenOp, Test, TestBranch, TestKind, TestableCase,
+};
 
 /// Output of [`Builder::partition_candidates_into_buckets`].
 pub(crate) struct PartitionedCandidates<'tcx, 'b, 'c> {
@@ -213,11 +215,11 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             }
 
             (
-                &TestKind::SliceLen { len: test_len, op: BinOp::Eq },
-                &TestableCase::Slice { len, variable_length },
+                &TestKind::SliceLen { len: test_len, op: SliceLenOp::Equal },
+                &TestableCase::Slice { len: pat_len, op: pat_op },
             ) => {
-                match (test_len.cmp(&len), variable_length) {
-                    (Ordering::Equal, false) => {
+                match (test_len.cmp(&pat_len), pat_op) {
+                    (Ordering::Equal, SliceLenOp::Equal) => {
                         // on true, min_len = len = $actual_length,
                         // on false, len != $actual_length
                         fully_matched = true;
@@ -230,13 +232,13 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                         fully_matched = false;
                         Some(TestBranch::Failure)
                     }
-                    (Ordering::Equal | Ordering::Greater, true) => {
+                    (Ordering::Equal | Ordering::Greater, SliceLenOp::GreaterOrEqual) => {
                         // This can match both if $actual_len = test_len >= pat_len,
                         // and if $actual_len > test_len. We can't advance.
                         fully_matched = false;
                         None
                     }
-                    (Ordering::Greater, false) => {
+                    (Ordering::Greater, SliceLenOp::Equal) => {
                         // test_len != pat_len, so if $actual_len = test_len, then
                         // $actual_len != pat_len.
                         fully_matched = false;
@@ -245,31 +247,31 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 }
             }
             (
-                &TestKind::SliceLen { len: test_len, op: BinOp::Ge },
-                &TestableCase::Slice { len, variable_length },
+                &TestKind::SliceLen { len: test_len, op: SliceLenOp::GreaterOrEqual },
+                &TestableCase::Slice { len: pat_len, op: pat_op },
             ) => {
                 // the test is `$actual_len >= test_len`
-                match (test_len.cmp(&len), variable_length) {
-                    (Ordering::Equal, true) => {
+                match (test_len.cmp(&pat_len), pat_op) {
+                    (Ordering::Equal, SliceLenOp::GreaterOrEqual) => {
                         // $actual_len >= test_len = pat_len,
                         // so we can match.
                         fully_matched = true;
                         Some(TestBranch::Success)
                     }
-                    (Ordering::Less, _) | (Ordering::Equal, false) => {
+                    (Ordering::Less, _) | (Ordering::Equal, SliceLenOp::Equal) => {
                         // test_len <= pat_len. If $actual_len < test_len,
                         // then it is also < pat_len, so the test passing is
                         // necessary (but insufficient).
                         fully_matched = false;
                         Some(TestBranch::Success)
                     }
-                    (Ordering::Greater, false) => {
+                    (Ordering::Greater, SliceLenOp::Equal) => {
                         // test_len > pat_len. If $actual_len >= test_len > pat_len,
                         // then we know we won't have a match.
                         fully_matched = false;
                         Some(TestBranch::Failure)
                     }
-                    (Ordering::Greater, true) => {
+                    (Ordering::Greater, SliceLenOp::GreaterOrEqual) => {
                         // test_len < pat_len, and is therefore less
                         // strict. This can still go both ways.
                         fully_matched = false;

--- a/compiler/rustc_mir_build/src/builder/matches/buckets.rs
+++ b/compiler/rustc_mir_build/src/builder/matches/buckets.rs
@@ -213,7 +213,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             }
 
             (
-                &TestKind::Len { len: test_len, op: BinOp::Eq },
+                &TestKind::SliceLen { len: test_len, op: BinOp::Eq },
                 &TestableCase::Slice { len, variable_length },
             ) => {
                 match (test_len.cmp(&len), variable_length) {
@@ -245,7 +245,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 }
             }
             (
-                &TestKind::Len { len: test_len, op: BinOp::Ge },
+                &TestKind::SliceLen { len: test_len, op: BinOp::Ge },
                 &TestableCase::Slice { len, variable_length },
             ) => {
                 // the test is `$actual_len >= test_len`
@@ -338,7 +338,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 TestKind::Switch { .. }
                 | TestKind::SwitchInt { .. }
                 | TestKind::If
-                | TestKind::Len { .. }
+                | TestKind::SliceLen { .. }
                 | TestKind::Range { .. }
                 | TestKind::Eq { .. }
                 | TestKind::Deref { .. },

--- a/compiler/rustc_mir_build/src/builder/matches/match_pair.rs
+++ b/compiler/rustc_mir_build/src/builder/matches/match_pair.rs
@@ -8,7 +8,7 @@ use rustc_middle::ty::{self, Ty, TypeVisitableExt};
 use crate::builder::Builder;
 use crate::builder::expr::as_place::{PlaceBase, PlaceBuilder};
 use crate::builder::matches::{
-    FlatPat, MatchPairTree, PatConstKind, PatternExtraData, TestableCase,
+    FlatPat, MatchPairTree, PatConstKind, PatternExtraData, SliceLenOp, TestableCase,
 };
 
 impl<'a, 'tcx> Builder<'a, 'tcx> {
@@ -277,11 +277,20 @@ impl<'tcx> MatchPairTree<'tcx> {
                 );
 
                 if prefix.is_empty() && slice.is_some() && suffix.is_empty() {
+                    // This pattern is shaped like `[..]`. It can match a slice
+                    // of any length, so no length test is needed.
                     None
                 } else {
+                    // Any other shape of slice pattern requires a length test.
+                    // Slice patterns with a `..` subpattern require a minimum
+                    // length; those without `..` require an exact length.
                     Some(TestableCase::Slice {
                         len: u64::try_from(prefix.len() + suffix.len()).unwrap(),
-                        variable_length: slice.is_some(),
+                        op: if slice.is_some() {
+                            SliceLenOp::GreaterOrEqual
+                        } else {
+                            SliceLenOp::Equal
+                        },
                     })
                 }
             }

--- a/compiler/rustc_mir_build/src/builder/matches/mod.rs
+++ b/compiler/rustc_mir_build/src/builder/matches/mod.rs
@@ -1264,7 +1264,7 @@ enum TestableCase<'tcx> {
     Variant { adt_def: ty::AdtDef<'tcx>, variant_index: VariantIdx },
     Constant { value: ty::Value<'tcx>, kind: PatConstKind },
     Range(Arc<PatRange<'tcx>>),
-    Slice { len: u64, variable_length: bool },
+    Slice { len: u64, op: SliceLenOp },
     Deref { temp: Place<'tcx>, mutability: Mutability },
     Never,
     Or { pats: Box<[FlatPat<'tcx>]> },
@@ -1382,7 +1382,7 @@ enum TestKind<'tcx> {
     Range(Arc<PatRange<'tcx>>),
 
     /// Test that the length of the slice is `== len` or `>= len`.
-    SliceLen { len: u64, op: BinOp },
+    SliceLen { len: u64, op: SliceLenOp },
 
     /// Call `Deref::deref[_mut]` on the value.
     Deref {
@@ -1393,6 +1393,17 @@ enum TestKind<'tcx> {
 
     /// Assert unreachability of never patterns.
     Never,
+}
+
+/// Indicates the kind of slice-length constraint imposed by a slice pattern,
+/// or its corresponding test.
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum SliceLenOp {
+    /// The slice pattern can only match a slice with exactly `len` elements.
+    Equal,
+    /// The slice pattern can match a slice with `len` or more elements
+    /// (i.e. it contains a `..` subpattern in the middle).
+    GreaterOrEqual,
 }
 
 /// The branch to be taken after a test.

--- a/compiler/rustc_mir_build/src/builder/matches/mod.rs
+++ b/compiler/rustc_mir_build/src/builder/matches/mod.rs
@@ -1382,7 +1382,7 @@ enum TestKind<'tcx> {
     Range(Arc<PatRange<'tcx>>),
 
     /// Test that the length of the slice is `== len` or `>= len`.
-    Len { len: u64, op: BinOp },
+    SliceLen { len: u64, op: BinOp },
 
     /// Call `Deref::deref[_mut]` on the value.
     Deref {

--- a/compiler/rustc_mir_build/src/builder/matches/mod.rs
+++ b/compiler/rustc_mir_build/src/builder/matches/mod.rs
@@ -1332,7 +1332,21 @@ pub(crate) struct MatchPairTree<'tcx> {
     pattern_span: Span,
 }
 
-/// See [`Test`] for more.
+/// A runtime test to perform to determine which candidates match a scrutinee place.
+///
+/// The kind of test to perform is indicated by [`TestKind`].
+#[derive(Debug)]
+pub(crate) struct Test<'tcx> {
+    span: Span,
+    kind: TestKind<'tcx>,
+}
+
+/// The kind of runtime test to perform to determine which candidates match a
+/// scrutinee place. This is the main component of [`Test`].
+///
+/// Some of these variants don't contain the constant value(s) being tested
+/// against, because those values are stored in the corresponding bucketed
+/// candidates instead.
 #[derive(Clone, Debug, PartialEq)]
 enum TestKind<'tcx> {
     /// Test what enum variant a value is.
@@ -1379,16 +1393,6 @@ enum TestKind<'tcx> {
 
     /// Assert unreachability of never patterns.
     Never,
-}
-
-/// A test to perform to determine which [`Candidate`] matches a value.
-///
-/// [`Test`] is just the test to perform; it does not include the value
-/// to be tested.
-#[derive(Debug)]
-pub(crate) struct Test<'tcx> {
-    span: Span,
-    kind: TestKind<'tcx>,
 }
 
 /// The branch to be taken after a test.

--- a/compiler/rustc_mir_build/src/builder/matches/test.rs
+++ b/compiler/rustc_mir_build/src/builder/matches/test.rs
@@ -52,7 +52,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
 
             TestableCase::Slice { len, variable_length } => {
                 let op = if variable_length { BinOp::Ge } else { BinOp::Eq };
-                TestKind::Len { len, op }
+                TestKind::SliceLen { len, op }
             }
 
             TestableCase::Deref { temp, mutability } => TestKind::Deref { temp, mutability },
@@ -312,7 +312,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 }
             }
 
-            TestKind::Len { len, op } => {
+            TestKind::SliceLen { len, op } => {
                 let usize_ty = self.tcx.types.usize;
                 let actual = self.temp(usize_ty, test.span);
 

--- a/compiler/rustc_mir_build/src/builder/matches/test.rs
+++ b/compiler/rustc_mir_build/src/builder/matches/test.rs
@@ -20,7 +20,7 @@ use tracing::{debug, instrument};
 
 use crate::builder::Builder;
 use crate::builder::matches::{
-    MatchPairTree, PatConstKind, Test, TestBranch, TestKind, TestableCase,
+    MatchPairTree, PatConstKind, SliceLenOp, Test, TestBranch, TestKind, TestableCase,
 };
 
 impl<'a, 'tcx> Builder<'a, 'tcx> {
@@ -50,10 +50,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 TestKind::Range(Arc::clone(range))
             }
 
-            TestableCase::Slice { len, variable_length } => {
-                let op = if variable_length { BinOp::Ge } else { BinOp::Eq };
-                TestKind::SliceLen { len, op }
-            }
+            TestableCase::Slice { len, op } => TestKind::SliceLen { len, op },
 
             TestableCase::Deref { temp, mutability } => TestKind::Deref { temp, mutability },
 
@@ -332,7 +329,10 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     success_block,
                     fail_block,
                     source_info,
-                    op,
+                    match op {
+                        SliceLenOp::Equal => BinOp::Eq,
+                        SliceLenOp::GreaterOrEqual => BinOp::Ge,
+                    },
                     Operand::Move(actual),
                     Operand::Move(expected),
                 );

--- a/tests/ui/codegen/normalization-overflow/recursion-issue-137823.rs
+++ b/tests/ui/codegen/normalization-overflow/recursion-issue-137823.rs
@@ -1,0 +1,39 @@
+//@ build-fail
+
+// Regression test for issue #137823
+// Tests that recursive monomorphization with associated types produces
+// a proper "recursion limit" error instead of an ICE.
+
+fn convert<S: Converter>() -> S::Out {
+    convert2::<ConvertWrap<S>>()
+    //~^ ERROR: reached the recursion limit while instantiating
+}
+
+fn convert2<S: Converter>() -> S::Out {
+    convert::<S>()
+}
+
+fn main() {
+    convert::<Ser>();
+}
+
+trait Converter {
+    type Out;
+}
+
+struct Ser;
+
+impl Converter for Ser {
+    type Out = ();
+}
+
+struct ConvertWrap<S> {
+    _d: S,
+}
+
+impl<S> Converter for ConvertWrap<S>
+where
+    S: Converter,
+{
+    type Out = S::Out;
+}

--- a/tests/ui/codegen/normalization-overflow/recursion-issue-137823.stderr
+++ b/tests/ui/codegen/normalization-overflow/recursion-issue-137823.stderr
@@ -1,0 +1,14 @@
+error: reached the recursion limit while instantiating `convert2::<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<Ser>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>`
+  --> $DIR/recursion-issue-137823.rs:8:5
+   |
+LL |     convert2::<ConvertWrap<S>>()
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: `convert2` defined here
+  --> $DIR/recursion-issue-137823.rs:12:1
+   |
+LL | fn convert2<S: Converter>() -> S::Out {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#150422 (mir_build: Add a `SliceLenOp` enum for use by slice-length cases/tests)
 - rust-lang/rust#150509 (Adds a regression test for rust-lang/rust#137823)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=150422,150509)
<!-- homu-ignore:end -->