### PR TITLE
experiment: Add simple externally implementable item to std

### DIFF
--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -283,6 +283,7 @@
 #![feature(doc_masked)]
 #![feature(doc_notable_trait)]
 #![feature(dropck_eyepatch)]
+#![feature(extern_item_impls)]
 #![feature(f16)]
 #![feature(f128)]
 #![feature(ffi_const)]
@@ -760,3 +761,9 @@ mod sealed {
 #[cfg(test)]
 #[allow(dead_code)] // Not used in all configurations.
 pub(crate) mod test_helpers;
+
+#[unstable(feature = "extern_item_impls", issue = "125418")]
+#[eii]
+pub fn changed_with_eii() -> bool {
+    false
+}


### PR DESCRIPTION
I am [looking into](https://github.com/rust-lang/rust/issues/150588) porting [`-Zon-broken-pipe=...`](https://doc.rust-lang.org/beta/unstable-book/compiler-flags/on-broken-pipe.html) (tracking issue https://github.com/rust-lang/rust/issues/97889) to use an [externally implementable item](https://github.com/rust-lang/rust/issues/125418) instead.

Trying to add an Externally Implementable Item to std results in lost of strange compilation errors. This PR contains this diff:
```diff
diff --git a/library/std/src/lib.rs b/library/std/src/lib.rs
index 0dab29712f4..777bf53d69f 100644
--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -283,6 +283,7 @@
 #![feature(doc_masked)]
 #![feature(doc_notable_trait)]
 #![feature(dropck_eyepatch)]
+#![feature(extern_item_impls)]
 #![feature(f16)]
 #![feature(f128)]
 #![feature(ffi_const)]
@@ -760,3 +761,9 @@ pub trait Sealed {}
 #[cfg(test)]
 #[allow(dead_code)] // Not used in all configurations.
 pub(crate) mod test_helpers;
+
+#[unstable(feature = "extern_item_impls", issue = "125418")]
+#[eii]
+pub fn changed_with_eii() -> bool {
+    false
+}
```

and gives > 800 compilation errors. The first three are below. See https://gist.github.com/Enselic/c643f454515db6f10caa7ab04045ab32 for the full list.

```
$ ./x build library/std
   Compiling std v0.0.0 (/home/martin/src/rust-eii-unix-sigpipe/library/std)
error: attribute macro has missing stability attribute
    --> library/std/src/lib.rs:766:1
     |
 766 | #[eii]
     | ^^^^^^ in this attribute macro expansion
     |
    ::: library/core/src/macros/mod.rs:1899:5
     |
1899 |     pub macro eii($item:item) {
     |     ------------- in this expansion of `#[eii]`

error: function has missing stability attribute
   --> library/std/src/io/stdio.rs:726:1
    |
726 | pub fn cleanup() {
    | ^^^^^^^^^^^^^^^^

error: module has missing stability attribute
  --> library/std/src/sys/mod.rs:16:1
   |
16 | pub mod args;
   | ^^^^^^^^^^^^
```

I am creating this PR just to demonstrate the problem to others so it's easier to discuss. See https://github.com/rust-lang/rust/issues/150514.

Tracking Issue: https://github.com/rust-lang/rust/issues/125418
