### PR TITLE
std: sys: fs: uefi: Ignore "." and ".." when reading directory

### DIFF
--- a/library/std/src/sys/fs/uefi.rs
+++ b/library/std/src/sys/fs/uefi.rs
@@ -160,7 +160,15 @@ impl Iterator for ReadDir {
     fn next(&mut self) -> Option<io::Result<DirEntry>> {
         match self.0.read_dir_entry() {
             Ok(None) => None,
-            Ok(Some(x)) => Some(Ok(DirEntry::from_uefi(x, self.0.path()))),
+            Ok(Some(x)) => {
+                let temp = DirEntry::from_uefi(x, self.0.path());
+                // Ignore "." and "..". This is how ReadDir behaves in Unix.
+                if temp.file_name == "." || temp.file_name == ".." {
+                    self.next()
+                } else {
+                    Some(Ok(temp))
+                }
+            }
             Err(e) => Some(Err(e)),
         }
     }


### PR DESCRIPTION
- At least in Unix, "." and ".." are not returned as a directory entry. So ignore these in UEFI as well.
- Will also allow using the `remove_dir_all` implementation from `sys/fs/common`.