### PR TITLE
Avoid index check in char::to_lowercase and char::to_uppercase

### DIFF
--- a/library/core/src/unicode/unicode_data.rs
+++ b/library/core/src/unicode/unicode_data.rs
@@ -767,7 +767,8 @@ pub mod conversions {
             LOWERCASE_TABLE
                 .binary_search_by(|&(key, _)| key.cmp(&c))
                 .map(|i| {
-                    let u = LOWERCASE_TABLE[i].1;
+                    // SAFETY: i is the result of the binary search
+                    let u = unsafe { LOWERCASE_TABLE.get_unchecked(i) }.1;
                     char::from_u32(u).map(|c| [c, '\0', '\0']).unwrap_or_else(|| {
                         // SAFETY: Index comes from statically generated table
                         unsafe { *LOWERCASE_TABLE_MULTI.get_unchecked((u & (INDEX_MASK - 1)) as usize) }
@@ -784,7 +785,8 @@ pub mod conversions {
             UPPERCASE_TABLE
                 .binary_search_by(|&(key, _)| key.cmp(&c))
                 .map(|i| {
-                    let u = UPPERCASE_TABLE[i].1;
+                    // SAFETY: i is the result of the binary search
+                    let u = unsafe { UPPERCASE_TABLE.get_unchecked(i) }.1;
                     char::from_u32(u).map(|c| [c, '\0', '\0']).unwrap_or_else(|| {
                         // SAFETY: Index comes from statically generated table
                         unsafe { *UPPERCASE_TABLE_MULTI.get_unchecked((u & (INDEX_MASK - 1)) as usize) }

--- a/src/tools/unicode-table-generator/src/case_mapping.rs
+++ b/src/tools/unicode-table-generator/src/case_mapping.rs
@@ -91,7 +91,8 @@ pub fn to_lower(c: char) -> [char; 3] {
         LOWERCASE_TABLE
             .binary_search_by(|&(key, _)| key.cmp(&c))
             .map(|i| {
-                let u = LOWERCASE_TABLE[i].1;
+                // SAFETY: i is the result of the binary search
+                let u = unsafe { LOWERCASE_TABLE.get_unchecked(i) }.1;
                 char::from_u32(u).map(|c| [c, '\0', '\0']).unwrap_or_else(|| {
                     // SAFETY: Index comes from statically generated table
                     unsafe { *LOWERCASE_TABLE_MULTI.get_unchecked((u & (INDEX_MASK - 1)) as usize) }
@@ -108,7 +109,8 @@ pub fn to_upper(c: char) -> [char; 3] {
         UPPERCASE_TABLE
             .binary_search_by(|&(key, _)| key.cmp(&c))
             .map(|i| {
-                let u = UPPERCASE_TABLE[i].1;
+                // SAFETY: i is the result of the binary search
+                let u = unsafe { UPPERCASE_TABLE.get_unchecked(i) }.1;
                 char::from_u32(u).map(|c| [c, '\0', '\0']).unwrap_or_else(|| {
                     // SAFETY: Index comes from statically generated table
                     unsafe { *UPPERCASE_TABLE_MULTI.get_unchecked((u & (INDEX_MASK - 1)) as usize) }


### PR DESCRIPTION
This generates a panic free code, with is helpful for smaller binary sizes.