### PR TITLE
resolve: Rename "name bindings" to "name declarations"

### DIFF
--- a/compiler/rustc_middle/src/metadata.rs
+++ b/compiler/rustc_middle/src/metadata.rs
@@ -26,7 +26,7 @@ impl Reexport {
     }
 }
 
-/// This structure is supposed to keep enough data to re-create `NameBinding`s for other crates
+/// This structure is supposed to keep enough data to re-create `Decl`s for other crates
 /// during name resolution. Right now the bindings are not recreated entirely precisely so we may
 /// need to add more data in the future to correctly support macros 2.0, for example.
 /// Module child can be either a proper item or a reexport (including private imports).

--- a/compiler/rustc_resolve/src/build_reduced_graph.rs
+++ b/compiler/rustc_resolve/src/build_reduced_graph.rs
@@ -36,9 +36,9 @@ use crate::imports::{ImportData, ImportKind};
 use crate::macros::{MacroRulesBinding, MacroRulesScope, MacroRulesScopeRef};
 use crate::ref_mut::CmCell;
 use crate::{
-    BindingKey, ExternPreludeEntry, Finalize, MacroData, Module, ModuleKind, ModuleOrUniformRoot,
-    NameBinding, NameBindingData, NameBindingKind, ParentScope, PathResult, ResolutionError,
-    Resolver, Segment, Used, VisResolutionError, errors,
+    BindingKey, Decl, DeclData, DeclKind, ExternPreludeEntry, Finalize, MacroData, Module,
+    ModuleKind, ModuleOrUniformRoot, ParentScope, PathResult, ResolutionError, Resolver, Segment,
+    Used, VisResolutionError, errors,
 };
 
 type Res = def::Res<NodeId>;
@@ -51,7 +51,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         parent: Module<'ra>,
         ident: Ident,
         ns: Namespace,
-        binding: NameBinding<'ra>,
+        binding: Decl<'ra>,
     ) {
         if let Err(old_binding) = self.try_define_local(parent, ident, ns, binding, false) {
             self.report_conflict(parent, ident, ns, old_binding, binding);
@@ -82,10 +82,10 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         vis: Visibility<DefId>,
         span: Span,
         expansion: LocalExpnId,
-        ambiguity: Option<NameBinding<'ra>>,
+        ambiguity: Option<Decl<'ra>>,
     ) {
-        let binding = self.arenas.alloc_name_binding(NameBindingData {
-            kind: NameBindingKind::Res(res),
+        let binding = self.arenas.alloc_name_binding(DeclData {
+            kind: DeclKind::Def(res),
             ambiguity,
             // External ambiguities always report the `AMBIGUOUS_GLOB_IMPORTS` lint at the moment.
             warn_ambiguity: true,
@@ -1092,7 +1092,7 @@ impl<'a, 'ra, 'tcx> BuildReducedGraphVisitor<'a, 'ra, 'tcx> {
     fn add_macro_use_binding(
         &mut self,
         name: Symbol,
-        binding: NameBinding<'ra>,
+        binding: Decl<'ra>,
         span: Span,
         allow_shadowing: bool,
     ) {

--- a/compiler/rustc_resolve/src/build_reduced_graph.rs
+++ b/compiler/rustc_resolve/src/build_reduced_graph.rs
@@ -44,20 +44,22 @@ use crate::{
 type Res = def::Res<NodeId>;
 
 impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
-    /// Defines `name` in namespace `ns` of module `parent` to be `def` if it is not yet defined;
-    /// otherwise, reports an error.
-    pub(crate) fn define_binding_local(
+    /// Attempt to put the declaration with the given name and namespace into the module,
+    /// and report an error in case of a collision.
+    pub(crate) fn plant_decl_into_local_module(
         &mut self,
         parent: Module<'ra>,
         ident: Ident,
         ns: Namespace,
         decl: Decl<'ra>,
     ) {
-        if let Err(old_binding) = self.try_define_local(parent, ident, ns, decl, false) {
-            self.report_conflict(parent, ident, ns, old_binding, decl);
+        if let Err(old_decl) = self.try_plant_decl_into_local_module(parent, ident, ns, decl, false)
+        {
+            self.report_conflict(parent, ident, ns, old_decl, decl);
         }
     }
 
+    /// Create a name definitinon from the given components, and put it into the local module.
     fn define_local(
         &mut self,
         parent: Module<'ra>,
@@ -68,10 +70,11 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         span: Span,
         expn_id: LocalExpnId,
     ) {
-        let binding = self.arenas.new_def_decl(res, vis.to_def_id(), span, expn_id);
-        self.define_binding_local(parent, ident, ns, binding);
+        let decl = self.arenas.new_def_decl(res, vis.to_def_id(), span, expn_id);
+        self.plant_decl_into_local_module(parent, ident, ns, decl);
     }
 
+    /// Create a name definitinon from the given components, and put it into the extern module.
     fn define_extern(
         &self,
         parent: Module<'ra>,
@@ -84,7 +87,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         expansion: LocalExpnId,
         ambiguity: Option<Decl<'ra>>,
     ) {
-        let binding = self.arenas.alloc_decl(DeclData {
+        let decl = self.arenas.alloc_decl(DeclData {
             kind: DeclKind::Def(res),
             ambiguity,
             // External ambiguities always report the `AMBIGUOUS_GLOB_IMPORTS` lint at the moment.
@@ -101,8 +104,8 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         if self
             .resolution_or_default(parent, key)
             .borrow_mut_unchecked()
-            .non_glob_binding
-            .replace(binding)
+            .non_glob_decl
+            .replace(decl)
             .is_some()
         {
             span_bug!(span, "an external binding was already defined");
@@ -691,7 +694,7 @@ impl<'a, 'ra, 'tcx> BuildReducedGraphVisitor<'a, 'ra, 'tcx> {
                 let kind = ImportKind::Single {
                     source: source.ident,
                     target: ident,
-                    bindings: Default::default(),
+                    decls: Default::default(),
                     type_ns_only,
                     nested,
                     id,
@@ -1019,7 +1022,7 @@ impl<'a, 'ra, 'tcx> BuildReducedGraphVisitor<'a, 'ra, 'tcx> {
             self.r.import_use_map.insert(import, Used::Other);
         }
         self.r.potentially_unused_imports.push(import);
-        let imported_binding = self.r.import(decl, import);
+        let import_decl = self.r.new_import_decl(decl, import);
         if ident.name != kw::Underscore && parent == self.r.graph_root {
             let norm_ident = Macros20NormalizedIdent::new(ident);
             // FIXME: this error is technically unnecessary now when extern prelude is split into
@@ -1042,17 +1045,17 @@ impl<'a, 'ra, 'tcx> BuildReducedGraphVisitor<'a, 'ra, 'tcx> {
                         let msg = format!("extern crate `{ident}` already in extern prelude");
                         self.r.tcx.dcx().span_delayed_bug(item.span, msg);
                     } else {
-                        entry.item_decl = Some((imported_binding, orig_name.is_some()));
+                        entry.item_decl = Some((import_decl, orig_name.is_some()));
                     }
                     entry
                 }
                 Entry::Vacant(vacant) => vacant.insert(ExternPreludeEntry {
-                    item_decl: Some((imported_binding, true)),
+                    item_decl: Some((import_decl, true)),
                     flag_decl: None,
                 }),
             };
         }
-        self.r.define_binding_local(parent, ident, TypeNS, imported_binding);
+        self.r.plant_decl_into_local_module(parent, ident, TypeNS, import_decl);
     }
 
     /// Constructs the reduced graph for one foreign item.
@@ -1167,8 +1170,8 @@ impl<'a, 'ra, 'tcx> BuildReducedGraphVisitor<'a, 'ra, 'tcx> {
                         }
                         macro_use_import(this, span, true)
                     };
-                    let import_binding = this.r.import(binding, import);
-                    this.add_macro_use_decl(ident.name, import_binding, span, allow_shadowing);
+                    let import_decl = this.r.new_import_decl(binding, import);
+                    this.add_macro_use_decl(ident.name, import_decl, span, allow_shadowing);
                 }
             });
         } else {
@@ -1183,13 +1186,8 @@ impl<'a, 'ra, 'tcx> BuildReducedGraphVisitor<'a, 'ra, 'tcx> {
                 if let Ok(binding) = result {
                     let import = macro_use_import(self, ident.span, false);
                     self.r.potentially_unused_imports.push(import);
-                    let imported_binding = self.r.import(binding, import);
-                    self.add_macro_use_decl(
-                        ident.name,
-                        imported_binding,
-                        ident.span,
-                        allow_shadowing,
-                    );
+                    let import_decl = self.r.new_import_decl(binding, import);
+                    self.add_macro_use_decl(ident.name, import_decl, ident.span, allow_shadowing);
                 } else {
                     self.r.dcx().emit_err(errors::ImportedMacroNotFound { span: ident.span });
                 }
@@ -1319,8 +1317,8 @@ impl<'a, 'ra, 'tcx> BuildReducedGraphVisitor<'a, 'ra, 'tcx> {
                     vis_span: item.vis.span,
                 });
                 self.r.import_use_map.insert(import, Used::Other);
-                let import_binding = self.r.import(decl, import);
-                self.r.define_binding_local(self.r.graph_root, ident, MacroNS, import_binding);
+                let import_decl = self.r.new_import_decl(decl, import);
+                self.r.plant_decl_into_local_module(self.r.graph_root, ident, MacroNS, import_decl);
             } else {
                 self.r.check_reserved_macro_name(ident, res);
                 self.insert_unused_macro(ident, def_id, item.id);

--- a/compiler/rustc_resolve/src/build_reduced_graph.rs
+++ b/compiler/rustc_resolve/src/build_reduced_graph.rs
@@ -33,7 +33,7 @@ use tracing::debug;
 use crate::Namespace::{MacroNS, TypeNS, ValueNS};
 use crate::def_collector::collect_definitions;
 use crate::imports::{ImportData, ImportKind};
-use crate::macros::{MacroRulesBinding, MacroRulesScope, MacroRulesScopeRef};
+use crate::macros::{MacroRulesDecl, MacroRulesScope, MacroRulesScopeRef};
 use crate::ref_mut::CmCell;
 use crate::{
     BindingKey, Decl, DeclData, DeclKind, ExternPreludeEntry, Finalize, MacroData, Module,
@@ -1326,8 +1326,8 @@ impl<'a, 'ra, 'tcx> BuildReducedGraphVisitor<'a, 'ra, 'tcx> {
                 self.insert_unused_macro(ident, def_id, item.id);
             }
             self.r.feed_visibility(feed, vis);
-            let scope = self.r.arenas.alloc_macro_rules_scope(MacroRulesScope::Binding(
-                self.r.arenas.alloc_macro_rules_binding(MacroRulesBinding {
+            let scope = self.r.arenas.alloc_macro_rules_scope(MacroRulesScope::Def(
+                self.r.arenas.alloc_macro_rules_binding(MacroRulesDecl {
                     parent_macro_rules_scope: parent_scope.macro_rules,
                     binding,
                     ident,

--- a/compiler/rustc_resolve/src/check_unused.rs
+++ b/compiler/rustc_resolve/src/check_unused.rs
@@ -36,7 +36,7 @@ use rustc_session::lint::builtin::{
 use rustc_span::{DUMMY_SP, Ident, Macros20NormalizedIdent, Span, kw};
 
 use crate::imports::{Import, ImportKind};
-use crate::{LexicalScopeBinding, NameBindingKind, Resolver, module_to_string};
+use crate::{DeclKind, LexicalScopeBinding, Resolver, module_to_string};
 
 struct UnusedImport {
     use_tree: ast::UseTree,
@@ -515,7 +515,7 @@ impl Resolver<'_, '_> {
         for module in &self.local_modules {
             for (_key, resolution) in self.resolutions(*module).borrow().iter() {
                 if let Some(binding) = resolution.borrow().best_binding()
-                    && let NameBindingKind::Import { import, .. } = binding.kind
+                    && let DeclKind::Import { import, .. } = binding.kind
                     && let ImportKind::Single { id, .. } = import.kind
                 {
                     if let Some(unused_import) = unused_imports.get(&import.root_id)
@@ -543,7 +543,7 @@ impl Resolver<'_, '_> {
         // in the item not being found.
         for unn_qua in &self.potentially_unnecessary_qualifications {
             if let LexicalScopeBinding::Item(name_binding) = unn_qua.binding
-                && let NameBindingKind::Import { import, .. } = name_binding.kind
+                && let DeclKind::Import { import, .. } = name_binding.kind
                 && (is_unused_import(import, &unused_imports)
                     || is_redundant_import(import, &redundant_imports))
             {

--- a/compiler/rustc_resolve/src/check_unused.rs
+++ b/compiler/rustc_resolve/src/check_unused.rs
@@ -36,7 +36,7 @@ use rustc_session::lint::builtin::{
 use rustc_span::{DUMMY_SP, Ident, Macros20NormalizedIdent, Span, kw};
 
 use crate::imports::{Import, ImportKind};
-use crate::{DeclKind, LexicalScopeBinding, Resolver, module_to_string};
+use crate::{DeclKind, LateDecl, Resolver, module_to_string};
 
 struct UnusedImport {
     use_tree: ast::UseTree,
@@ -542,7 +542,7 @@ impl Resolver<'_, '_> {
         // Deleting both unused imports and unnecessary segments of an item may result
         // in the item not being found.
         for unn_qua in &self.potentially_unnecessary_qualifications {
-            if let LexicalScopeBinding::Item(name_binding) = unn_qua.binding
+            if let LateDecl::Decl(name_binding) = unn_qua.binding
                 && let DeclKind::Import { import, .. } = name_binding.kind
                 && (is_unused_import(import, &unused_imports)
                     || is_redundant_import(import, &redundant_imports))

--- a/compiler/rustc_resolve/src/check_unused.rs
+++ b/compiler/rustc_resolve/src/check_unused.rs
@@ -514,8 +514,8 @@ impl Resolver<'_, '_> {
         let mut check_redundant_imports = FxIndexSet::default();
         for module in &self.local_modules {
             for (_key, resolution) in self.resolutions(*module).borrow().iter() {
-                if let Some(binding) = resolution.borrow().best_binding()
-                    && let DeclKind::Import { import, .. } = binding.kind
+                if let Some(decl) = resolution.borrow().best_decl()
+                    && let DeclKind::Import { import, .. } = decl.kind
                     && let ImportKind::Single { id, .. } = import.kind
                 {
                     if let Some(unused_import) = unused_imports.get(&import.root_id)
@@ -542,8 +542,8 @@ impl Resolver<'_, '_> {
         // Deleting both unused imports and unnecessary segments of an item may result
         // in the item not being found.
         for unn_qua in &self.potentially_unnecessary_qualifications {
-            if let LateDecl::Decl(name_binding) = unn_qua.binding
-                && let DeclKind::Import { import, .. } = name_binding.kind
+            if let LateDecl::Decl(decl) = unn_qua.decl
+                && let DeclKind::Import { import, .. } = decl.kind
                 && (is_unused_import(import, &unused_imports)
                     || is_redundant_import(import, &redundant_imports))
             {

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -1196,7 +1196,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 }
                 Scope::MacroRules(macro_rules_scope) => {
                     if let MacroRulesScope::Def(macro_rules_binding) = macro_rules_scope.get() {
-                        let res = macro_rules_binding.binding.res();
+                        let res = macro_rules_binding.decl.res();
                         if filter_fn(res) {
                             suggestions.push(TypoSuggestion::typo_from_ident(
                                 macro_rules_binding.ident,
@@ -1969,7 +1969,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         true
     }
 
-    fn binding_description(&self, b: Decl<'_>, ident: Ident, scope: Scope<'_>) -> String {
+    fn decl_description(&self, b: Decl<'_>, ident: Ident, scope: Scope<'_>) -> String {
         let res = b.res();
         if b.span.is_dummy() || !self.tcx.sess.source_map().is_span_accessible(b.span) {
             let (built_in, from) = match scope {
@@ -2005,7 +2005,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 && self
                     .extern_prelude
                     .get(&Macros20NormalizedIdent::new(ident))
-                    .is_some_and(|entry| entry.item_binding.map(|(b, _)| b) == Some(b1))
+                    .is_some_and(|entry| entry.item_decl.map(|(b, _)| b) == Some(b1))
         };
         let (b1, b2, scope1, scope2, swapped) = if b2.span.is_dummy() && !b1.span.is_dummy() {
             // We have to print the span-less alternative first, otherwise formatting looks bad.
@@ -2015,7 +2015,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         };
 
         let could_refer_to = |b: Decl<'_>, scope: Scope<'ra>, also: &str| {
-            let what = self.binding_description(b, ident, scope);
+            let what = self.decl_description(b, ident, scope);
             let note_msg = format!("`{ident}` could{also} refer to {what}");
 
             let thing = b.res().descr();
@@ -2073,9 +2073,9 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
 
     /// If the binding refers to a tuple struct constructor with fields,
     /// returns the span of its fields.
-    fn ctor_fields_span(&self, binding: Decl<'_>) -> Option<Span> {
+    fn ctor_fields_span(&self, decl: Decl<'_>) -> Option<Span> {
         let DeclKind::Def(Res::Def(DefKind::Ctor(CtorOf::Struct, CtorKind::Fn), ctor_def_id)) =
-            binding.kind
+            decl.kind
         else {
             return None;
         };

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -1357,8 +1357,8 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 }
 
                 // #90113: Do not count an inaccessible reexported item as a candidate.
-                if let DeclKind::Import { binding, .. } = name_binding.kind
-                    && this.is_accessible_from(binding.vis, parent_scope.module)
+                if let DeclKind::Import { source_decl, .. } = name_binding.kind
+                    && this.is_accessible_from(source_decl.vis, parent_scope.module)
                     && !this.is_accessible_from(name_binding.vis, parent_scope.module)
                 {
                     return;
@@ -2210,15 +2210,15 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             let name = next_ident;
             next_binding = match binding.kind {
                 _ if res == Res::Err => None,
-                DeclKind::Import { binding, import, .. } => match import.kind {
-                    _ if binding.span.is_dummy() => None,
+                DeclKind::Import { source_decl, import, .. } => match import.kind {
+                    _ if source_decl.span.is_dummy() => None,
                     ImportKind::Single { source, .. } => {
                         next_ident = source;
-                        Some(binding)
+                        Some(source_decl)
                     }
                     ImportKind::Glob { .. }
                     | ImportKind::MacroUse { .. }
-                    | ImportKind::MacroExport => Some(binding),
+                    | ImportKind::MacroExport => Some(source_decl),
                     ImportKind::ExternCrate { .. } => None,
                 },
                 _ => None,

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -45,10 +45,9 @@ use crate::imports::{Import, ImportKind};
 use crate::late::{DiagMetadata, PatternSource, Rib};
 use crate::{
     AmbiguityError, AmbiguityKind, BindingError, BindingKey, Decl, DeclKind, Finalize,
-    ForwardGenericParamBanReason, HasGenericParams, LexicalScopeBinding, MacroRulesScope, Module,
-    ModuleKind, ModuleOrUniformRoot, ParentScope, PathResult, PrivacyError, ResolutionError,
-    Resolver, Scope, ScopeSet, Segment, UseError, Used, VisResolutionError, errors as errs,
-    path_names_to_string,
+    ForwardGenericParamBanReason, HasGenericParams, LateDecl, MacroRulesScope, Module, ModuleKind,
+    ModuleOrUniformRoot, ParentScope, PathResult, PrivacyError, ResolutionError, Resolver, Scope,
+    ScopeSet, Segment, UseError, Used, VisResolutionError, errors as errs, path_names_to_string,
 };
 
 type Res = def::Res<ast::NodeId>;
@@ -2528,7 +2527,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                         diag_metadata,
                     ) {
                         // we found a locally-imported or available item/module
-                        Some(LexicalScopeBinding::Item(binding)) => Some(binding),
+                        Some(LateDecl::Decl(binding)) => Some(binding),
                         _ => None,
                     }
                 } else {
@@ -2590,7 +2589,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 //                               // variable `Foo`.
                 // }
                 // ```
-                Some(LexicalScopeBinding::Res(Res::Local(id))) => {
+                Some(LateDecl::RibDef(Res::Local(id))) => {
                     Some(*self.pat_span_map.get(&id).unwrap())
                 }
                 // Name matches item from a local name binding
@@ -2604,7 +2603,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 //                               // binding `Foo`.
                 // }
                 // ```
-                Some(LexicalScopeBinding::Item(name_binding)) => Some(name_binding.span),
+                Some(LateDecl::Decl(name_binding)) => Some(name_binding.span),
                 _ => None,
             };
             let suggestion = match_span.map(|span| {

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -1195,7 +1195,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                     // Never recommend deprecated helper attributes.
                 }
                 Scope::MacroRules(macro_rules_scope) => {
-                    if let MacroRulesScope::Binding(macro_rules_binding) = macro_rules_scope.get() {
+                    if let MacroRulesScope::Def(macro_rules_binding) = macro_rules_scope.get() {
                         let res = macro_rules_binding.binding.res();
                         if filter_fn(res) {
                             suggestions.push(TypoSuggestion::typo_from_ident(

--- a/compiler/rustc_resolve/src/effective_visibilities.rs
+++ b/compiler/rustc_resolve/src/effective_visibilities.rs
@@ -128,7 +128,7 @@ impl<'a, 'ra, 'tcx> EffectiveVisibilitiesVisitor<'a, 'ra, 'tcx> {
             let is_ambiguity = |decl: Decl<'ra>, warn: bool| decl.ambiguity.is_some() && !warn;
             let mut parent_id = ParentId::Def(module_id);
             let mut warn_ambiguity = decl.warn_ambiguity;
-            while let DeclKind::Import { binding: nested_binding, .. } = decl.kind {
+            while let DeclKind::Import { source_decl, .. } = decl.kind {
                 self.update_import(decl, parent_id);
 
                 if is_ambiguity(decl, warn_ambiguity) {
@@ -139,8 +139,8 @@ impl<'a, 'ra, 'tcx> EffectiveVisibilitiesVisitor<'a, 'ra, 'tcx> {
                 }
 
                 parent_id = ParentId::Import(decl);
-                decl = nested_binding;
-                warn_ambiguity |= nested_binding.warn_ambiguity;
+                decl = source_decl;
+                warn_ambiguity |= source_decl.warn_ambiguity;
             }
             if !is_ambiguity(decl, warn_ambiguity)
                 && let Some(def_id) = decl.res().opt_def_id().and_then(|id| id.as_local())

--- a/compiler/rustc_resolve/src/ident.rs
+++ b/compiler/rustc_resolve/src/ident.rs
@@ -182,7 +182,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 }
                 Scope::DeriveHelpersCompat => Scope::MacroRules(parent_scope.macro_rules),
                 Scope::MacroRules(macro_rules_scope) => match macro_rules_scope.get() {
-                    MacroRulesScope::Binding(binding) => {
+                    MacroRulesScope::Def(binding) => {
                         Scope::MacroRules(binding.parent_macro_rules_scope)
                     }
                     MacroRulesScope::Invocation(invoc_id) => {
@@ -559,9 +559,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 result
             }
             Scope::MacroRules(macro_rules_scope) => match macro_rules_scope.get() {
-                MacroRulesScope::Binding(macro_rules_binding)
-                    if ident == macro_rules_binding.ident =>
-                {
+                MacroRulesScope::Def(macro_rules_binding) if ident == macro_rules_binding.ident => {
                     Ok(macro_rules_binding.binding)
                 }
                 MacroRulesScope::Invocation(_) => Err(Determinacy::Undetermined),

--- a/compiler/rustc_resolve/src/imports.rs
+++ b/compiler/rustc_resolve/src/imports.rs
@@ -316,7 +316,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         }
 
         self.arenas.alloc_decl(DeclData {
-            kind: DeclKind::Import { binding: decl, import },
+            kind: DeclKind::Import { source_decl: decl, import },
             ambiguity: None,
             warn_ambiguity: false,
             span: import.span,
@@ -1199,10 +1199,10 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                                 let resolution = resolution.borrow();
                                 if let Some(name_binding) = resolution.best_decl() {
                                     match name_binding.kind {
-                                        DeclKind::Import { binding, .. } => {
-                                            match binding.kind {
-                                                // Never suggest the name that has binding error
-                                                // i.e., the name that cannot be previously resolved
+                                        DeclKind::Import { source_decl, .. } => {
+                                            match source_decl.kind {
+                                                // Never suggest names that previously could not
+                                                // be resolved.
                                                 DeclKind::Def(Res::Err) => None,
                                                 _ => Some(i.name),
                                             }

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -43,9 +43,9 @@ use thin_vec::ThinVec;
 use tracing::{debug, instrument, trace};
 
 use crate::{
-    BindingError, BindingKey, Finalize, LexicalScopeBinding, Module, ModuleOrUniformRoot,
-    NameBinding, ParentScope, PathResult, ResolutionError, Resolver, Segment, Stage, TyCtxt,
-    UseError, Used, errors, path_names_to_string, rustdoc,
+    BindingError, BindingKey, Decl, Finalize, LexicalScopeBinding, Module, ModuleOrUniformRoot,
+    ParentScope, PathResult, ResolutionError, Resolver, Segment, Stage, TyCtxt, UseError, Used,
+    errors, path_names_to_string, rustdoc,
 };
 
 mod diagnostics;
@@ -1489,7 +1489,7 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
         ident: Ident,
         ns: Namespace,
         finalize: Option<Finalize>,
-        ignore_binding: Option<NameBinding<'ra>>,
+        ignore_binding: Option<Decl<'ra>>,
     ) -> Option<LexicalScopeBinding<'ra>> {
         self.r.resolve_ident_in_lexical_scope(
             ident,

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -891,10 +891,8 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
     fn lookup_doc_alias_name(&mut self, path: &[Segment], ns: Namespace) -> Option<(DefId, Ident)> {
         let find_doc_alias_name = |r: &mut Resolver<'ra, '_>, m: Module<'ra>, item_name: Symbol| {
             for resolution in r.resolutions(m).borrow().values() {
-                let Some(did) = resolution
-                    .borrow()
-                    .best_binding()
-                    .and_then(|binding| binding.res().opt_def_id())
+                let Some(did) =
+                    resolution.borrow().best_decl().and_then(|binding| binding.res().opt_def_id())
                 else {
                     continue;
                 };
@@ -1589,19 +1587,17 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
             if let PathResult::Module(ModuleOrUniformRoot::Module(module)) =
                 self.resolve_path(mod_path, None, None, *source)
             {
-                let targets: Vec<_> = self
-                    .r
-                    .resolutions(module)
-                    .borrow()
-                    .iter()
-                    .filter_map(|(key, resolution)| {
-                        resolution
-                            .borrow()
-                            .best_binding()
-                            .map(|binding| binding.res())
-                            .and_then(|res| if filter_fn(res) { Some((*key, res)) } else { None })
-                    })
-                    .collect();
+                let targets: Vec<_> =
+                    self.r
+                        .resolutions(module)
+                        .borrow()
+                        .iter()
+                        .filter_map(|(key, resolution)| {
+                            resolution.borrow().best_decl().map(|binding| binding.res()).and_then(
+                                |res| if filter_fn(res) { Some((*key, res)) } else { None },
+                            )
+                        })
+                        .collect();
                 if let [target] = targets.as_slice() {
                     return Some(TypoSuggestion::single_item_from_ident(
                         target.0.ident.0,
@@ -2486,9 +2482,7 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
             .resolutions(*module)
             .borrow()
             .iter()
-            .filter_map(|(key, res)| {
-                res.borrow().best_binding().map(|binding| (key, binding.res()))
-            })
+            .filter_map(|(key, res)| res.borrow().best_decl().map(|binding| (key, binding.res())))
             .filter(|(_, res)| match (kind, res) {
                 (AssocItemKind::Const(..), Res::Def(DefKind::AssocConst, _)) => true,
                 (AssocItemKind::Fn(_), Res::Def(DefKind::AssocFn, _)) => true,

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -424,22 +424,21 @@ impl<'a> From<&'a ast::PathSegment> for Segment {
     }
 }
 
-/// An intermediate resolution result.
-///
-/// This refers to the thing referred by a name. The difference between `Res` and `Item` is that
-/// items are visible in their whole block, while `Res`es only from the place they are defined
-/// forward.
+/// Name declaration used during late resolution.
 #[derive(Debug, Copy, Clone)]
-enum LexicalScopeBinding<'ra> {
-    Item(Decl<'ra>),
-    Res(Res),
+enum LateDecl<'ra> {
+    /// A regular name declaration.
+    Decl(Decl<'ra>),
+    /// A name definition from a rib, e.g. a local variable.
+    /// Omits most of the data from regular `Decl` for performance reasons.
+    RibDef(Res),
 }
 
-impl<'ra> LexicalScopeBinding<'ra> {
+impl<'ra> LateDecl<'ra> {
     fn res(self) -> Res {
         match self {
-            LexicalScopeBinding::Item(binding) => binding.res(),
-            LexicalScopeBinding::Res(res) => res,
+            LateDecl::Decl(binding) => binding.res(),
+            LateDecl::RibDef(res) => res,
         }
     }
 }

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -38,7 +38,7 @@ use late::{
     ForwardGenericParamBanReason, HasGenericParams, PathSource, PatternSource,
     UnnecessaryQualification,
 };
-use macros::{MacroRulesBinding, MacroRulesScope, MacroRulesScopeRef};
+use macros::{MacroRulesDecl, MacroRulesScope, MacroRulesScopeRef};
 use rustc_arena::{DroplessArena, TypedArena};
 use rustc_ast::node_id::NodeMap;
 use rustc_ast::{
@@ -1391,8 +1391,8 @@ impl<'ra> ResolverArenas<'ra> {
     }
     fn alloc_macro_rules_binding(
         &'ra self,
-        binding: MacroRulesBinding<'ra>,
-    ) -> &'ra MacroRulesBinding<'ra> {
+        binding: MacroRulesDecl<'ra>,
+    ) -> &'ra MacroRulesDecl<'ra> {
         self.dropless.alloc(binding)
     }
     fn alloc_ast_paths(&'ra self, paths: &[ast::Path]) -> &'ra [ast::Path] {

--- a/compiler/rustc_resolve/src/macros.rs
+++ b/compiler/rustc_resolve/src/macros.rs
@@ -45,10 +45,10 @@ use crate::{
 
 type Res = def::Res<NodeId>;
 
-/// Binding produced by a `macro_rules` item.
+/// Name declaration produced by a `macro_rules` item definition.
 /// Not modularized, can shadow previous `macro_rules` bindings, etc.
 #[derive(Debug)]
-pub(crate) struct MacroRulesBinding<'ra> {
+pub(crate) struct MacroRulesDecl<'ra> {
     pub(crate) binding: Decl<'ra>,
     /// `macro_rules` scope into which the `macro_rules` item was planted.
     pub(crate) parent_macro_rules_scope: MacroRulesScopeRef<'ra>,
@@ -65,7 +65,7 @@ pub(crate) enum MacroRulesScope<'ra> {
     /// Empty "root" scope at the crate start containing no names.
     Empty,
     /// The scope introduced by a `macro_rules!` macro definition.
-    Binding(&'ra MacroRulesBinding<'ra>),
+    Def(&'ra MacroRulesDecl<'ra>),
     /// The scope introduced by a macro invocation that can potentially
     /// create a `macro_rules!` macro definition.
     Invocation(LocalExpnId),

--- a/compiler/rustc_resolve/src/macros.rs
+++ b/compiler/rustc_resolve/src/macros.rs
@@ -38,9 +38,9 @@ use crate::errors::{
 };
 use crate::imports::Import;
 use crate::{
-    BindingKey, CacheCell, CmResolver, DeriveData, Determinacy, Finalize, InvocationParent,
-    MacroData, ModuleKind, ModuleOrUniformRoot, NameBinding, NameBindingKind, ParentScope,
-    PathResult, ResolutionError, Resolver, ScopeSet, Segment, Used,
+    BindingKey, CacheCell, CmResolver, Decl, DeclKind, DeriveData, Determinacy, Finalize,
+    InvocationParent, MacroData, ModuleKind, ModuleOrUniformRoot, ParentScope, PathResult,
+    ResolutionError, Resolver, ScopeSet, Segment, Used,
 };
 
 type Res = def::Res<NodeId>;
@@ -49,7 +49,7 @@ type Res = def::Res<NodeId>;
 /// Not modularized, can shadow previous `macro_rules` bindings, etc.
 #[derive(Debug)]
 pub(crate) struct MacroRulesBinding<'ra> {
-    pub(crate) binding: NameBinding<'ra>,
+    pub(crate) binding: Decl<'ra>,
     /// `macro_rules` scope into which the `macro_rules` item was planted.
     pub(crate) parent_macro_rules_scope: MacroRulesScopeRef<'ra>,
     pub(crate) ident: Ident,
@@ -1062,7 +1062,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
 
     fn prohibit_imported_non_macro_attrs(
         &self,
-        binding: Option<NameBinding<'ra>>,
+        binding: Option<Decl<'ra>>,
         res: Option<Res>,
         span: Span,
     ) {
@@ -1084,12 +1084,12 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         path: &ast::Path,
         parent_scope: &ParentScope<'ra>,
         invoc_in_mod_inert_attr: Option<(LocalDefId, NodeId)>,
-        binding: Option<NameBinding<'ra>>,
+        binding: Option<Decl<'ra>>,
     ) {
         if let Some((mod_def_id, node_id)) = invoc_in_mod_inert_attr
             && let Some(binding) = binding
             // This is a `macro_rules` itself, not some import.
-            && let NameBindingKind::Res(res) = binding.kind
+            && let DeclKind::Def(res) = binding.kind
             && let Res::Def(DefKind::Macro(kinds), def_id) = res
             && kinds.contains(MacroKinds::BANG)
             // And the `macro_rules` is defined inside the attribute's module,

--- a/compiler/rustc_resolve/src/macros.rs
+++ b/compiler/rustc_resolve/src/macros.rs
@@ -46,7 +46,7 @@ use crate::{
 type Res = def::Res<NodeId>;
 
 /// Name declaration produced by a `macro_rules` item definition.
-/// Not modularized, can shadow previous `macro_rules` bindings, etc.
+/// Not modularized, can shadow previous `macro_rules` definitions, etc.
 #[derive(Debug)]
 pub(crate) struct MacroRulesDecl<'ra> {
     pub(crate) decl: Decl<'ra>,


### PR DESCRIPTION
This was discussed previously in some name resolution specification threads on zulip.
Link: [#t-compiler/help > understanding early name resolution of imports @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/182449-t-compiler.2Fhelp/topic/understanding.20early.20name.20resolution.20of.20imports/near/545306658)

The main change is that `NameBinding` is renamed to `Decl`.
The `Name` part is skipped because almost everything in `rustc_resolve` is about names.
So in general the naming looks more compact now (`binding: NameBinding` -> `decl: Decl`).

I didn't rename *everything* including all the local variables, but did rename most of significant interfaces.
Late resolution in particular uses "bindings" in slightly different meanings, I didn't touch that.

Also, some interface comments are added/improved.

Renaming list:
- fn `define_binding_local` -> `plant_decl_into_local_module`
- fn `add_macro_use_binding` -> `add_macro_use_decl`
- fn `binding_description` -> `decl_description`
- enum `PendingBinding` -> `PendingDecl`
- field `ImportKind::Single::bindings` -> `ImportKind::Single::decls`
- field `NameResolution::non_glob_binding` -> `NameResolution::non_glob_decl`
- field `NameResolution::glob_binding` -> `NameResolution::glob_decl`
- fn `best_binding` -> `best_decl`
- fn `import` -> `new_import_decl`
- fn `try_define_local` -> `try_plant_decl_into_local_module`
- fn `new_ambiguity_binding` -> `new_decl_with_ambiguity`
- fn `new_warn_ambiguity_binding` -> `new_decl_with_warn_ambiguity`
- field `UnnecessaryQualification::binding` -> `UnnecessaryQualification::decl`
- struct `MacroRulesBinding` -> `MacroRulesDef`
- field `MacroRulesBinding::binding` -> `MacroRulesDef::decl`
- variant `MacroRulesScope::Binding` -> `MacroRulesScope::Def`
- enum `LexicalScopeBinding` -> `LateDecl`
- variant `LexicalScopeBinding::Item` -> `LateDecl::Decl`
- variant `LexicalScopeBinding::Res` -> `LateDecl::RibDef`
- field `ModuleData::self_binding` -> `ModuleData::self_decl`
- struct `NameBindingData` -> `DeclData`
- type `NameBinding` -> `Decl`
- enum `NameBindingKind` -> `DeclKind`
- variant `NameBindingKind::Res` -> `DeclKind::Def`
- field `NameBindingKind::Import::binding` -> `DeclKind::Import::source_decl`
- field `PrivacyError::binding` -> `PrivacyError::decl`
- field `ExternPreludeEntry::item_binding` -> `ExternPreludeEntry::item_decl`
- field `ExternPreludeEntry::flag_binding` -> `ExternPreludeEntry::flag_decl`
- field `Resolver::binding_parent_modules` -> `Resolver::decl_parent_modules`
- field `Resolver::dummy_binding` -> `Resolver::dummy_decl`
- field `Resolver::builtin_types_bindings` -> `Resolver::builtin_type_decls`
- field `Resolver::builtin_attrs_bindings` -> `Resolver::builtin_attr_decls`
- field `Resolver::registered_tool_bindings` -> `Resolver::registered_tool_decls`
- fn `ResolverArenas::new_res_binding` -> `ResolverArenas::new_def_decl`
- fn `ResolverArenas::new_pub_res_binding` -> `ResolverArenas::new_pub_def_decl`
- fn `ResolverArenas::alloc_name_binding` -> `ResolverArenas::alloc_decl`
- fn `ResolverArenas::alloc_macro_rules_binding` -> `ResolverArenas::alloc_macro_rules_def`
- fn `set_binding_parent_module` -> `set_decl_parent_module`