### PR TITLE
Run rustdoc tests in opt-dist tests

### DIFF
--- a/src/tools/opt-dist/src/tests.rs
+++ b/src/tools/opt-dist/src/tests.rs
@@ -123,6 +123,7 @@ llvm-config = "{llvm_config}"
             "tests/run-make/rust-lld-x86_64-unknown-linux-gnu-dist",
             "tests/ui",
             "tests/crashes",
+            "tests/rustdoc",
         ];
         for test_path in env.skipped_tests() {
             args.extend(["--skip", test_path]);


### PR DESCRIPTION
Context: https://github.com/rust-lang/rust/issues/150287

try-job: dist-x86_64-linux