### PR TITLE
Rename the gcc component to gcc-dev

### DIFF
--- a/src/bootstrap/src/core/build_steps/dist.rs
+++ b/src/bootstrap/src/core/build_steps/dist.rs
@@ -2871,24 +2871,26 @@ impl Step for ReproducibleArtifacts {
 /// Tarball containing a prebuilt version of the libgccjit library,
 /// needed as a dependency for the GCC codegen backend (similarly to the LLVM
 /// backend needing a prebuilt libLLVM).
+///
+/// This component is used for `download-ci-gcc`.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct Gcc {
+pub struct GccDev {
     target: TargetSelection,
 }
 
-impl Step for Gcc {
+impl Step for GccDev {
     type Output = GeneratedTarball;
 
     fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
-        run.alias("gcc")
+        run.alias("gcc-dev")
     }
 
     fn make_run(run: RunConfig<'_>) {
-        run.builder.ensure(Gcc { target: run.target });
+        run.builder.ensure(GccDev { target: run.target });
     }
 
     fn run(self, builder: &Builder<'_>) -> Self::Output {
-        let tarball = Tarball::new(builder, "gcc", &self.target.triple);
+        let tarball = Tarball::new(builder, "gcc-dev", &self.target.triple);
         let output = builder
             .ensure(super::gcc::Gcc { target_pair: GccTargetPair::for_native_build(self.target) });
         tarball.add_file(output.libgccjit(), "lib", FileType::NativeLibrary);
@@ -2896,6 +2898,6 @@ impl Step for Gcc {
     }
 
     fn metadata(&self) -> Option<StepMetadata> {
-        Some(StepMetadata::dist("gcc", self.target))
+        Some(StepMetadata::dist("gcc-dev", self.target))
     }
 }

--- a/src/bootstrap/src/core/builder/mod.rs
+++ b/src/bootstrap/src/core/builder/mod.rs
@@ -989,7 +989,7 @@ impl<'a> Builder<'a> {
                 dist::PlainSourceTarballGpl,
                 dist::BuildManifest,
                 dist::ReproducibleArtifacts,
-                dist::Gcc
+                dist::GccDev
             ),
             Kind::Install => describe!(
                 install::Docs,

--- a/src/bootstrap/src/core/download.rs
+++ b/src/bootstrap/src/core/download.rs
@@ -381,7 +381,7 @@ impl Config {
         }
         let base = &self.stage0_metadata.config.artifacts_server;
         let version = self.artifact_version_part(gcc_sha);
-        let filename = format!("gcc-{version}-{}.tar.xz", self.host_target.triple);
+        let filename = format!("gcc-dev-{version}-{}.tar.xz", self.host_target.triple);
         let tarball = gcc_cache.join(&filename);
         if !tarball.exists() {
             let help_on_error = "ERROR: failed to download gcc from ci

--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/dist.sh
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/dist.sh
@@ -9,8 +9,8 @@ python3 ../x.py build --set rust.debug=true opt-dist
     --include-default-paths \
     build-manifest bootstrap
 
-# Use GCC for building GCC, as it seems to behave badly when built with Clang
+# Use GCC for building GCC components, as it seems to behave badly when built with Clang
 # Only build GCC on full builds, not try builds
 if [ "${DIST_TRY_BUILD:-0}" == "0" ]; then
-    CC=/rustroot/bin/cc CXX=/rustroot/bin/c++ python3 ../x.py dist gcc
+    CC=/rustroot/bin/cc CXX=/rustroot/bin/c++ python3 ../x.py dist gcc-dev
 fi

--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -187,8 +187,9 @@ else
     RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --set llvm.static-libstdcpp"
   fi
 
-  # Download GCC from CI on test builders
-  RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --set gcc.download-ci-gcc=true"
+  # Download GCC from CI on test builders (temporarily disabled because the CI gcc component
+  # was renamed).
+  RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --set gcc.download-ci-gcc=false"
 
   # download-rustc seems to be broken on CI after the stage0 redesign
   # Disable it until these issues are debugged and resolved

--- a/src/tools/opt-dist/src/main.rs
+++ b/src/tools/opt-dist/src/main.rs
@@ -454,7 +454,6 @@ fn main() -> anyhow::Result<()> {
             "clippy",
             "miri",
             "rustfmt",
-            "gcc",
             "generate-copyright",
             "bootstrap",
         ] {


### PR DESCRIPTION
In preparation for https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/Safe.20rustup.20distribution.20of.20rustc_codegen_gcc/with/565801325.

try-job: dist-x86_64-linux