### PR TITLE
Corretly link URL in internal Windows docs

### DIFF
--- a/library/std/src/sys/pal/windows/mod.rs
+++ b/library/std/src/sys/pal/windows/mod.rs
@@ -334,7 +334,7 @@ pub fn dur2timeout(dur: Duration) -> u32 {
 /// this sequence of instructions will be treated as an access violation, which
 /// will still terminate the process but might run some exception handlers.
 ///
-/// https://docs.microsoft.com/en-us/cpp/intrinsics/fastfail
+/// <https://docs.microsoft.com/en-us/cpp/intrinsics/fastfail>
 #[cfg(not(miri))] // inline assembly does not work in Miri
 pub fn abort_internal() -> ! {
     unsafe {


### PR DESCRIPTION
```
warning: this URL is not a hyperlink
   --> library/std/src/sys/pal/windows/mod.rs:337:5
    |
337 | /// https://docs.microsoft.com/en-us/cpp/intrinsics/fastfail
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: bare URLs are not automatically turned into clickable links
    = note: `#[warn(rustdoc::bare_urls)]` on by default
help: use an automatic link instead
    |
337 | /// <https://docs.microsoft.com/en-us/cpp/intrinsics/fastfail>
    |     +                                                        +
```

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
