### PR TITLE
Also hash spans inside the same file as relative (V2)

### DIFF
--- a/compiler/rustc_query_system/src/ich/hcx.rs
+++ b/compiler/rustc_query_system/src/ich/hcx.rs
@@ -5,9 +5,7 @@ use rustc_hir::definitions::DefPathHash;
 use rustc_session::Session;
 use rustc_session::cstore::Untracked;
 use rustc_span::source_map::SourceMap;
-use rustc_span::{
-    BytePos, CachingSourceMapView, DUMMY_SP, Span, SpanData, StableSourceFileId, Symbol,
-};
+use rustc_span::{BytePos, CachingSourceMapView, DUMMY_SP, SourceFile, Span, SpanData, Symbol};
 
 use crate::ich;
 
@@ -118,7 +116,7 @@ impl<'a> rustc_span::HashStableContext for StableHashingContext<'a> {
     fn span_data_to_lines_and_cols(
         &mut self,
         span: &SpanData,
-    ) -> Option<(StableSourceFileId, usize, BytePos, usize, BytePos)> {
+    ) -> Option<(&SourceFile, usize, BytePos, usize, BytePos)> {
         self.source_map().span_data_to_lines_and_cols(span)
     }
 

--- a/compiler/rustc_span/src/caching_source_map_view.rs
+++ b/compiler/rustc_span/src/caching_source_map_view.rs
@@ -2,7 +2,7 @@ use std::ops::Range;
 use std::sync::Arc;
 
 use crate::source_map::SourceMap;
-use crate::{BytePos, Pos, RelativeBytePos, SourceFile, SpanData, StableSourceFileId};
+use crate::{BytePos, Pos, RelativeBytePos, SourceFile, SpanData};
 
 #[derive(Clone)]
 struct CacheEntry {
@@ -114,7 +114,7 @@ impl<'sm> CachingSourceMapView<'sm> {
     pub fn span_data_to_lines_and_cols(
         &mut self,
         span_data: &SpanData,
-    ) -> Option<(StableSourceFileId, usize, BytePos, usize, BytePos)> {
+    ) -> Option<(&SourceFile, usize, BytePos, usize, BytePos)> {
         self.time_stamp += 1;
 
         // Check if lo and hi are in the cached lines.
@@ -136,7 +136,7 @@ impl<'sm> CachingSourceMapView<'sm> {
             let lo = &self.line_cache[lo_cache_idx as usize];
             let hi = &self.line_cache[hi_cache_idx as usize];
             return Some((
-                lo.file.stable_id,
+                &lo.file,
                 lo.line_number,
                 span_data.lo - lo.line.start,
                 hi.line_number,
@@ -224,7 +224,7 @@ impl<'sm> CachingSourceMapView<'sm> {
         assert_eq!(lo.file_index, hi.file_index);
 
         Some((
-            lo.file.stable_id,
+            &lo.file,
             lo.line_number,
             span_data.lo - lo.line.start,
             hi.line_number,


### PR DESCRIPTION
Hashes spans relatively to their parent, even if they are not contained inside their parent.

Fixes https://github.com/rust-lang/rust/issues/150400

Closes https://github.com/rust-lang/rust/pull/143882, as this is a successor PR
This PR is very closely based on that PR with a few minor changes, so to give proper credit I made @cjgillot coauthor of the commit.