### PR TITLE
Use --print target-libdir in run-make tests

### DIFF
--- a/tests/run-make/apple-deployment-target/rmake.rs
+++ b/tests/run-make/apple-deployment-target/rmake.rs
@@ -169,9 +169,8 @@ fn main() {
 
     // Test that all binaries in rlibs produced by `rustc` have the same version.
     // Regression test for https://github.com/rust-lang/rust/issues/128419.
-    let sysroot = rustc().print("sysroot").run().stdout_utf8();
-    let target_sysroot = path(sysroot.trim()).join("lib/rustlib").join(target()).join("lib");
-    let rlibs = shallow_find_files(&target_sysroot, |path| has_extension(path, "rlib"));
+    let sysroot_libs_dir = rustc().print("target-libdir").target(target()).run().stdout_utf8();
+    let rlibs = shallow_find_files(sysroot_libs_dir.trim(), |path| has_extension(path, "rlib"));
 
     let output = cmd("otool").arg("-l").args(rlibs).run().stdout_utf8();
     let re = regex::Regex::new(r"(minos|version) ([0-9.]*)").unwrap();

--- a/tests/run-make/libstd-no-protected/rmake.rs
+++ b/tests/run-make/libstd-no-protected/rmake.rs
@@ -15,10 +15,8 @@ type SymbolTable<'data> = run_make_support::object::read::elf::SymbolTable<'data
 
 fn main() {
     // Find libstd-...rlib
-    let sysroot = rustc().print("sysroot").run().stdout_utf8();
-    let sysroot = sysroot.trim();
-    let target_sysroot = path(sysroot).join("lib/rustlib").join(target()).join("lib");
-    let mut libs = shallow_find_files(&target_sysroot, |path| {
+    let sysroot_libs_dir = rustc().print("target-libdir").target(target()).run().stdout_utf8();
+    let mut libs = shallow_find_files(sysroot_libs_dir.trim(), |path| {
         has_prefix(path, "libstd-") && has_suffix(path, ".rlib")
     });
     assert_eq!(libs.len(), 1);

--- a/tests/run-make/sysroot-crates-are-unstable/rmake.rs
+++ b/tests/run-make/sysroot-crates-are-unstable/rmake.rs
@@ -44,8 +44,8 @@ fn check_crate_is_unstable(cr: &Crate) {
 }
 
 fn get_unstable_sysroot_crates() -> Vec<Crate> {
-    let sysroot = PathBuf::from(rustc().print("sysroot").run().stdout_utf8().trim());
-    let sysroot_libs_dir = sysroot.join("lib").join("rustlib").join(target()).join("lib");
+    let sysroot_libs_dir =
+        PathBuf::from(rustc().print("target-libdir").target(target()).run().stdout_utf8().trim());
     println!("Sysroot libs dir: {sysroot_libs_dir:?}");
 
     // Generate a list of all library crates in the sysroot.


### PR DESCRIPTION
This makes the tests more robust against sysroot layout changes and slightly simplifies them.