### PR TITLE
fix missing_panics_doc in `std::os::fd::owned`

### DIFF
--- a/library/std/src/os/fd/owned.rs
+++ b/library/std/src/os/fd/owned.rs
@@ -77,7 +77,11 @@ impl BorrowedFd<'_> {
     /// # Safety
     ///
     /// The resource pointed to by `fd` must remain open for the duration of
-    /// the returned `BorrowedFd`, and it must not have the value `-1`.
+    /// the returned `BorrowedFd`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the raw file descriptor has the value `-1`.
     #[inline]
     #[track_caller]
     #[rustc_const_stable(feature = "io_safety", since = "1.63.0")]
@@ -177,6 +181,10 @@ impl FromRawFd for OwnedFd {
     /// [ownership][io-safety]. The resource must not require any cleanup other than `close`.
     ///
     /// [io-safety]: io#io-safety
+    ///
+    /// # Panics
+    ///
+    /// Panics if the raw file descriptor has the value `-1`.
     #[inline]
     #[track_caller]
     unsafe fn from_raw_fd(fd: RawFd) -> Self {


### PR DESCRIPTION
https://rust-lang.github.io/rust-clippy/master/index.html#missing_panics_doc

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
