### PR TITLE
test: add regression cases for valtree hashing ICE

### DIFF
--- a/tests/ui/const-generics/mgca/printing_valtrees_supports_non_values.rs
+++ b/tests/ui/const-generics/mgca/printing_valtrees_supports_non_values.rs
@@ -25,3 +25,14 @@ fn baz<T: Trait>() {
 }
 
 fn main() {}
+
+fn test_ice_missing_bound<T>() {
+    foo::<{Option::Some::<u32>{0: <T as Trait>::ASSOC}}>();
+    //~^ ERROR the trait bound `T: Trait` is not satisfied
+    //~| ERROR the constant `Option::<u32>::Some(_)` is not of type `Foo`
+}
+
+fn test_underscore_inference() {
+    foo::<{ Option::Some::<u32> { 0: _ } }>();
+    //~^ ERROR the constant `Option::<u32>::Some(_)` is not of type `Foo`
+}

--- a/tests/ui/const-generics/mgca/printing_valtrees_supports_non_values.stderr
+++ b/tests/ui/const-generics/mgca/printing_valtrees_supports_non_values.stderr
@@ -22,5 +22,41 @@ note: required by a const generic parameter in `foo`
 LL | fn foo<const N: Foo>() {}
    |        ^^^^^^^^^^^^ required by this const generic parameter in `foo`
 
-error: aborting due to 2 previous errors
+error[E0277]: the trait bound `T: Trait` is not satisfied
+  --> $DIR/printing_valtrees_supports_non_values.rs:30:5
+   |
+LL |     foo::<{Option::Some::<u32>{0: <T as Trait>::ASSOC}}>();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Trait` is not implemented for `T`
+   |
+help: consider restricting type parameter `T` with trait `Trait`
+   |
+LL | fn test_ice_missing_bound<T: Trait>() {
+   |                            +++++++
 
+error: the constant `Option::<u32>::Some(_)` is not of type `Foo`
+  --> $DIR/printing_valtrees_supports_non_values.rs:30:12
+   |
+LL |     foo::<{Option::Some::<u32>{0: <T as Trait>::ASSOC}}>();
+   |            ^^^^^^^^^^^^^^^^^^^ expected `Foo`, found `Option<u32>`
+   |
+note: required by a const generic parameter in `foo`
+  --> $DIR/printing_valtrees_supports_non_values.rs:15:8
+   |
+LL | fn foo<const N: Foo>() {}
+   |        ^^^^^^^^^^^^ required by this const generic parameter in `foo`
+
+error: the constant `Option::<u32>::Some(_)` is not of type `Foo`
+  --> $DIR/printing_valtrees_supports_non_values.rs:36:13
+   |
+LL |     foo::<{ Option::Some::<u32> { 0: _ } }>();
+   |             ^^^^^^^^^^^^^^^^^^^ expected `Foo`, found `Option<u32>`
+   |
+note: required by a const generic parameter in `foo`
+  --> $DIR/printing_valtrees_supports_non_values.rs:15:8
+   |
+LL | fn foo<const N: Foo>() {}
+   |        ^^^^^^^^^^^^ required by this const generic parameter in `foo`
+
+error: aborting due to 5 previous errors
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

This PR extends the existing regression test `printing_valtrees_supports_non_values.rs` to cover cases that previously caused an ICE in `const_kind.rs` due to hashing inference variables.

It specifically adds:

A case where an associated constant is used without the required trait bound.

The `0: _` case as suggested in [Here](https://github.com/rust-lang/rust/issues/150409#issuecomment-3700022690)

Fixes rust-lang/rust#150409
