### PR TITLE
Enable thumb interworking on ARMv7A/R and ARMv8R bare-metal targets

### DIFF
--- a/compiler/rustc_target/src/spec/targets/armebv7r_none_eabi.rs
+++ b/compiler/rustc_target/src/spec/targets/armebv7r_none_eabi.rs
@@ -31,6 +31,7 @@ pub(crate) fn target() -> Target {
             emit_debug_gdb_scripts: false,
             // GCC defaults to 8 for arm-none here.
             c_enum_min_bits: Some(8),
+            has_thumb_interworking: true,
             ..Default::default()
         },
     }

--- a/compiler/rustc_target/src/spec/targets/armebv7r_none_eabihf.rs
+++ b/compiler/rustc_target/src/spec/targets/armebv7r_none_eabihf.rs
@@ -32,6 +32,7 @@ pub(crate) fn target() -> Target {
             emit_debug_gdb_scripts: false,
             // GCC defaults to 8 for arm-none here.
             c_enum_min_bits: Some(8),
+            has_thumb_interworking: true,
             ..Default::default()
         },
     }

--- a/compiler/rustc_target/src/spec/targets/armv7a_none_eabi.rs
+++ b/compiler/rustc_target/src/spec/targets/armv7a_none_eabi.rs
@@ -32,6 +32,7 @@ pub(crate) fn target() -> Target {
         panic_strategy: PanicStrategy::Abort,
         emit_debug_gdb_scripts: false,
         c_enum_min_bits: Some(8),
+        has_thumb_interworking: true,
         ..Default::default()
     };
     Target {

--- a/compiler/rustc_target/src/spec/targets/armv7a_none_eabihf.rs
+++ b/compiler/rustc_target/src/spec/targets/armv7a_none_eabihf.rs
@@ -24,6 +24,7 @@ pub(crate) fn target() -> Target {
         emit_debug_gdb_scripts: false,
         // GCC defaults to 8 for arm-none here.
         c_enum_min_bits: Some(8),
+        has_thumb_interworking: true,
         ..Default::default()
     };
     Target {

--- a/compiler/rustc_target/src/spec/targets/armv7r_none_eabi.rs
+++ b/compiler/rustc_target/src/spec/targets/armv7r_none_eabi.rs
@@ -29,6 +29,7 @@ pub(crate) fn target() -> Target {
             emit_debug_gdb_scripts: false,
             // GCC defaults to 8 for arm-none here.
             c_enum_min_bits: Some(8),
+            has_thumb_interworking: true,
             ..Default::default()
         },
     }

--- a/compiler/rustc_target/src/spec/targets/armv7r_none_eabihf.rs
+++ b/compiler/rustc_target/src/spec/targets/armv7r_none_eabihf.rs
@@ -30,6 +30,7 @@ pub(crate) fn target() -> Target {
             emit_debug_gdb_scripts: false,
             // GCC defaults to 8 for arm-none here.
             c_enum_min_bits: Some(8),
+            has_thumb_interworking: true,
             ..Default::default()
         },
     }

--- a/compiler/rustc_target/src/spec/targets/armv8r_none_eabihf.rs
+++ b/compiler/rustc_target/src/spec/targets/armv8r_none_eabihf.rs
@@ -39,6 +39,7 @@ pub(crate) fn target() -> Target {
             emit_debug_gdb_scripts: false,
             // GCC defaults to 8 for arm-none here.
             c_enum_min_bits: Some(8),
+            has_thumb_interworking: true,
             ..Default::default()
         },
     }


### PR DESCRIPTION
This flag enables the `#[instruction_set(arm::t32)]` for the armv7a/armv7r/armv8r targets, which all support Thumb interwork but were missing this flag.

Target maintainers are @chrisnc, @rust-lang/arm-maintainers, @rust-embedded/arm (including me).