### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -320,46 +320,13 @@ declare_features! (
     // -------------------------------------------------------------------------
 
     // -------------------------------------------------------------------------
-    // feature-group-start: actual feature gates (target features)
-    // -------------------------------------------------------------------------
-
-    // FIXME: Document these and merge with the list below.
-
-    // Unstable `#[target_feature]` directives.
-    (unstable, aarch64_unstable_target_feature, "1.82.0", Some(44839)),
-    (unstable, aarch64_ver_target_feature, "1.27.0", Some(44839)),
-    (unstable, apx_target_feature, "1.88.0", Some(139284)),
-    (unstable, arm_target_feature, "1.27.0", Some(44839)),
-    (unstable, bpf_target_feature, "1.54.0", Some(44839)),
-    (unstable, csky_target_feature, "1.73.0", Some(44839)),
-    (unstable, ermsb_target_feature, "1.49.0", Some(44839)),
-    (unstable, hexagon_target_feature, "1.27.0", Some(44839)),
-    (unstable, lahfsahf_target_feature, "1.78.0", Some(44839)),
-    (unstable, loongarch_target_feature, "1.73.0", Some(44839)),
-    (unstable, m68k_target_feature, "1.85.0", Some(134328)),
-    (unstable, mips_target_feature, "1.27.0", Some(44839)),
-    (unstable, movrs_target_feature, "1.88.0", Some(137976)),
-    (unstable, nvptx_target_feature, "1.91.0", Some(44839)),
-    (unstable, powerpc_target_feature, "1.27.0", Some(44839)),
-    (unstable, prfchw_target_feature, "1.78.0", Some(44839)),
-    (unstable, riscv_target_feature, "1.45.0", Some(44839)),
-    (unstable, rtm_target_feature, "1.35.0", Some(44839)),
-    (unstable, s390x_target_feature, "1.82.0", Some(44839)),
-    (unstable, sparc_target_feature, "1.84.0", Some(132783)),
-    (unstable, wasm_target_feature, "1.30.0", Some(44839)),
-    (unstable, x87_target_feature, "1.85.0", Some(44839)),
-    // !!!!    !!!!    !!!!    !!!!   !!!!    !!!!    !!!!    !!!!    !!!!    !!!!    !!!!
-    // Features are listed in alphabetical order. Tidy will fail if you don't keep it this way.
-    // !!!!    !!!!    !!!!    !!!!   !!!!    !!!!    !!!!    !!!!    !!!!    !!!!    !!!!
-
-    // -------------------------------------------------------------------------
-    // feature-group-end: actual feature gates (target features)
-    // -------------------------------------------------------------------------
-
-    // -------------------------------------------------------------------------
     // feature-group-start: actual feature gates
     // -------------------------------------------------------------------------
 
+    /// The remaining unstable target features on aarch64.
+    (unstable, aarch64_unstable_target_feature, "1.82.0", Some(150244)),
+    /// Instruction set "version" target features on aarch64.
+    (unstable, aarch64_ver_target_feature, "1.27.0", Some(150245)),
     /// Allows `extern "avr-interrupt" fn()` and `extern "avr-non-blocking-interrupt" fn()`.
     (unstable, abi_avr_interrupt, "1.45.0", Some(69664)),
     /// Allows `extern "cmse-nonsecure-call" fn()`.
@@ -380,10 +347,14 @@ declare_features! (
     (unstable, adt_const_params, "1.56.0", Some(95174)),
     /// Allows defining an `#[alloc_error_handler]`.
     (unstable, alloc_error_handler, "1.29.0", Some(51540)),
+    /// The `apxf` target feature on x86
+    (unstable, apx_target_feature, "1.88.0", Some(139284)),
     /// Allows inherent and trait methods with arbitrary self types.
     (unstable, arbitrary_self_types, "1.23.0", Some(44874)),
     /// Allows inherent and trait methods with arbitrary self types that are raw pointers.
     (unstable, arbitrary_self_types_pointers, "1.83.0", Some(44874)),
+    /// Target features on arm.
+    (unstable, arm_target_feature, "1.27.0", Some(150246)),
     /// Enables experimental inline assembly support for additional architectures.
     (unstable, asm_experimental_arch, "1.58.0", Some(93335)),
     /// Enables experimental register support in inline assembly.
@@ -408,6 +379,8 @@ declare_features! (
     (unstable, async_trait_bounds, "1.85.0", Some(62290)),
     /// Allows using Intel AVX10 target features and intrinsics
     (unstable, avx10_target_feature, "1.88.0", Some(138843)),
+    /// Target features on bpf.
+    (unstable, bpf_target_feature, "1.54.0", Some(150247)),
     /// Allows using C-variadics.
     (unstable, c_variadic, "1.34.0", Some(44930)),
     /// Allows defining c-variadic naked functions with any extern ABI that is allowed
@@ -468,6 +441,8 @@ declare_features! (
     /// Allows function attribute `#[coverage(on/off)]`, to control coverage
     /// instrumentation of that function.
     (unstable, coverage_attribute, "1.74.0", Some(84605)),
+    /// Target features on csky.
+    (unstable, csky_target_feature, "1.73.0", Some(150248)),
     /// Allows non-builtin attributes in inner attribute position.
     (unstable, custom_inner_attributes, "1.30.0", Some(54726)),
     /// Allows custom test frameworks with `#![test_runner]` and `#[test_case]`.
@@ -495,6 +470,8 @@ declare_features! (
     (incomplete, effective_target_features, "1.91.0", Some(143352)),
     /// Allows the .use postfix syntax `x.use` and use closures `use |x| { ... }`
     (incomplete, ergonomic_clones, "1.87.0", Some(132290)),
+    /// ermsb target feature on x86.
+    (unstable, ermsb_target_feature, "1.49.0", Some(150249)),
     /// Allows exhaustive pattern matching on types that contain uninhabited types.
     (unstable, exhaustive_patterns, "1.13.0", Some(51085)),
     /// Disallows `extern` without an explicit ABI.
@@ -541,6 +518,8 @@ declare_features! (
     (incomplete, guard_patterns, "1.85.0", Some(129967)),
     /// Allows using `..=X` as a patterns in slices.
     (unstable, half_open_range_patterns_in_slices, "1.66.0", Some(67264)),
+    /// Target features on hexagon.
+    (unstable, hexagon_target_feature, "1.27.0", Some(150250)),
     /// Allows `if let` guard in match arms.
     (unstable, if_let_guard, "1.47.0", Some(51114)),
     /// Allows `impl Trait` to be used inside associated types (RFC 2515).
@@ -555,6 +534,8 @@ declare_features! (
     (incomplete, inherent_associated_types, "1.52.0", Some(8995)),
     /// Allows using `pointer` and `reference` in intra-doc links
     (unstable, intra_doc_pointers, "1.51.0", Some(80896)),
+    /// lahfsahf target feature on x86.
+    (unstable, lahfsahf_target_feature, "1.78.0", Some(150251)),
     /// Allows setting the threshold for the `large_assignments` lint.
     (unstable, large_assignments, "1.52.0", Some(83518)),
     /// Allow to have type alias types for inter-crate use.
@@ -562,8 +543,12 @@ declare_features! (
     /// Allows using `#[link(kind = "link-arg", name = "...")]`
     /// to pass custom arguments to the linker.
     (unstable, link_arg_attribute, "1.76.0", Some(99427)),
+    /// Target features on loongarch.
+    (unstable, loongarch_target_feature, "1.73.0", Some(150252)),
     /// Allows fused `loop`/`match` for direct intraprocedural jumps.
     (incomplete, loop_match, "1.90.0", Some(132306)),
+    /// Target features on m68k.
+    (unstable, m68k_target_feature, "1.85.0", Some(134328)),
     /// Allow `macro_rules!` attribute rules
     (unstable, macro_attr, "1.91.0", Some(143547)),
     /// Allow `macro_rules!` derive rules
@@ -580,8 +565,12 @@ declare_features! (
     /// standard library until the soundness issues with specialization
     /// are fixed.
     (unstable, min_specialization, "1.7.0", Some(31844)),
+    /// Target features on mips.
+    (unstable, mips_target_feature, "1.27.0", Some(150253)),
     /// Allows qualified paths in struct expressions, struct patterns and tuple struct patterns.
     (unstable, more_qualified_paths, "1.54.0", Some(86935)),
+    /// The `movrs` target feature on x86.
+    (unstable, movrs_target_feature, "1.88.0", Some(137976)),
     /// Allows the `#[must_not_suspend]` attribute.
     (unstable, must_not_suspend, "1.57.0", Some(83310)),
     /// Allows `mut ref` and `mut ref mut` identifier patterns.
@@ -606,6 +595,8 @@ declare_features! (
     (unstable, non_exhaustive_omitted_patterns_lint, "1.57.0", Some(89554)),
     /// Allows `for<T>` binders in where-clauses
     (incomplete, non_lifetime_binders, "1.69.0", Some(108185)),
+    /// Target feaures on nvptx.
+    (unstable, nvptx_target_feature, "1.91.0", Some(150254)),
     /// Allows using enums in offset_of!
     (unstable, offset_of_enum, "1.75.0", Some(120141)),
     /// Allows using fields with slice type in offset_of!
@@ -618,6 +609,10 @@ declare_features! (
     (incomplete, pin_ergonomics, "1.83.0", Some(130494)),
     /// Allows postfix match `expr.match { ... }`
     (unstable, postfix_match, "1.79.0", Some(121618)),
+    /// Target features on powerpc.
+    (unstable, powerpc_target_feature, "1.27.0", Some(150255)),
+    /// The prfchw target feature on x86.
+    (unstable, prfchw_target_feature, "1.78.0", Some(150256)),
     /// Allows macro attributes on expressions, statements and non-inline modules.
     (unstable, proc_macro_hygiene, "1.30.0", Some(54727)),
     /// Allows the use of raw-dylibs on ELF platforms
@@ -633,12 +628,20 @@ declare_features! (
     (unstable, repr_simd, "1.4.0", Some(27731)),
     /// Allows bounding the return type of AFIT/RPITIT.
     (unstable, return_type_notation, "1.70.0", Some(109417)),
+    /// Target features on riscv.
+    (unstable, riscv_target_feature, "1.45.0", Some(150257)),
+    /// The rtm target feature on x86.
+    (unstable, rtm_target_feature, "1.35.0", Some(150258)),
     /// Allows `extern "rust-cold"`.
     (unstable, rust_cold_cc, "1.63.0", Some(97544)),
+    /// Target features on s390x.
+    (unstable, s390x_target_feature, "1.82.0", Some(150259)),
     /// Allows the use of the `sanitize` attribute.
     (unstable, sanitize, "1.91.0", Some(39699)),
     /// Allows the use of SIMD types in functions declared in `extern` blocks.
     (unstable, simd_ffi, "1.0.0", Some(27731)),
+    /// Target features on sparc.
+    (unstable, sparc_target_feature, "1.84.0", Some(132783)),
     /// Allows specialization of implementations (RFC 1210).
     (incomplete, specialization, "1.7.0", Some(31844)),
     /// Allows using `#[rustc_align_static(...)]` on static items.
@@ -685,10 +688,14 @@ declare_features! (
     (internal, unsized_fn_params, "1.49.0", Some(48055)),
     /// Allows using the `#[used(linker)]` (or `#[used(compiler)]`) attribute.
     (unstable, used_with_arg, "1.60.0", Some(93798)),
+    /// Target features on wasm.
+    (unstable, wasm_target_feature, "1.30.0", Some(150260)),
     /// Allows use of attributes in `where` clauses.
     (unstable, where_clause_attrs, "1.87.0", Some(115590)),
     /// Allows use of x86 `AMX` target-feature attributes and intrinsics
     (unstable, x86_amx_intrinsics, "1.81.0", Some(126622)),
+    /// The x87 target feature on x86.
+    (unstable, x87_target_feature, "1.85.0", Some(150261)),
     /// Allows use of the `xop` target-feature
     (unstable, xop_target_feature, "1.81.0", Some(127208)),
     /// Allows `do yeet` expressions

--- a/compiler/rustc_target/src/spec/targets/armebv7r_none_eabi.rs
+++ b/compiler/rustc_target/src/spec/targets/armebv7r_none_eabi.rs
@@ -31,6 +31,7 @@ pub(crate) fn target() -> Target {
             emit_debug_gdb_scripts: false,
             // GCC defaults to 8 for arm-none here.
             c_enum_min_bits: Some(8),
+            has_thumb_interworking: true,
             ..Default::default()
         },
     }

--- a/compiler/rustc_target/src/spec/targets/armebv7r_none_eabihf.rs
+++ b/compiler/rustc_target/src/spec/targets/armebv7r_none_eabihf.rs
@@ -32,6 +32,7 @@ pub(crate) fn target() -> Target {
             emit_debug_gdb_scripts: false,
             // GCC defaults to 8 for arm-none here.
             c_enum_min_bits: Some(8),
+            has_thumb_interworking: true,
             ..Default::default()
         },
     }

--- a/compiler/rustc_target/src/spec/targets/armv7a_none_eabi.rs
+++ b/compiler/rustc_target/src/spec/targets/armv7a_none_eabi.rs
@@ -32,6 +32,7 @@ pub(crate) fn target() -> Target {
         panic_strategy: PanicStrategy::Abort,
         emit_debug_gdb_scripts: false,
         c_enum_min_bits: Some(8),
+        has_thumb_interworking: true,
         ..Default::default()
     };
     Target {

--- a/compiler/rustc_target/src/spec/targets/armv7a_none_eabihf.rs
+++ b/compiler/rustc_target/src/spec/targets/armv7a_none_eabihf.rs
@@ -24,6 +24,7 @@ pub(crate) fn target() -> Target {
         emit_debug_gdb_scripts: false,
         // GCC defaults to 8 for arm-none here.
         c_enum_min_bits: Some(8),
+        has_thumb_interworking: true,
         ..Default::default()
     };
     Target {

--- a/compiler/rustc_target/src/spec/targets/armv7r_none_eabi.rs
+++ b/compiler/rustc_target/src/spec/targets/armv7r_none_eabi.rs
@@ -29,6 +29,7 @@ pub(crate) fn target() -> Target {
             emit_debug_gdb_scripts: false,
             // GCC defaults to 8 for arm-none here.
             c_enum_min_bits: Some(8),
+            has_thumb_interworking: true,
             ..Default::default()
         },
     }

--- a/compiler/rustc_target/src/spec/targets/armv7r_none_eabihf.rs
+++ b/compiler/rustc_target/src/spec/targets/armv7r_none_eabihf.rs
@@ -30,6 +30,7 @@ pub(crate) fn target() -> Target {
             emit_debug_gdb_scripts: false,
             // GCC defaults to 8 for arm-none here.
             c_enum_min_bits: Some(8),
+            has_thumb_interworking: true,
             ..Default::default()
         },
     }

--- a/compiler/rustc_target/src/spec/targets/armv8r_none_eabihf.rs
+++ b/compiler/rustc_target/src/spec/targets/armv8r_none_eabihf.rs
@@ -39,6 +39,7 @@ pub(crate) fn target() -> Target {
             emit_debug_gdb_scripts: false,
             // GCC defaults to 8 for arm-none here.
             c_enum_min_bits: Some(8),
+            has_thumb_interworking: true,
             ..Default::default()
         },
     }

--- a/library/std/src/os/fd/owned.rs
+++ b/library/std/src/os/fd/owned.rs
@@ -91,7 +91,7 @@ impl OwnedFd {
     /// Creates a new `OwnedFd` instance that shares the same underlying file
     /// description as the existing `OwnedFd` instance.
     #[stable(feature = "io_safety", since = "1.63.0")]
-    pub fn try_clone(&self) -> crate::io::Result<Self> {
+    pub fn try_clone(&self) -> io::Result<Self> {
         self.as_fd().try_clone_to_owned()
     }
 }
@@ -106,7 +106,7 @@ impl BorrowedFd<'_> {
         target_os = "motor"
     )))]
     #[stable(feature = "io_safety", since = "1.63.0")]
-    pub fn try_clone_to_owned(&self) -> crate::io::Result<OwnedFd> {
+    pub fn try_clone_to_owned(&self) -> io::Result<OwnedFd> {
         // We want to atomically duplicate this file descriptor and set the
         // CLOEXEC flag, and currently that's done via F_DUPFD_CLOEXEC. This
         // is a POSIX flag that was added to Linux in 2.6.24.
@@ -129,15 +129,15 @@ impl BorrowedFd<'_> {
     /// description as the existing `BorrowedFd` instance.
     #[cfg(any(target_arch = "wasm32", target_os = "hermit", target_os = "trusty"))]
     #[stable(feature = "io_safety", since = "1.63.0")]
-    pub fn try_clone_to_owned(&self) -> crate::io::Result<OwnedFd> {
-        Err(crate::io::Error::UNSUPPORTED_PLATFORM)
+    pub fn try_clone_to_owned(&self) -> io::Result<OwnedFd> {
+        Err(io::Error::UNSUPPORTED_PLATFORM)
     }
 
     /// Creates a new `OwnedFd` instance that shares the same underlying file
     /// description as the existing `BorrowedFd` instance.
     #[cfg(target_os = "motor")]
     #[stable(feature = "io_safety", since = "1.63.0")]
-    pub fn try_clone_to_owned(&self) -> crate::io::Result<OwnedFd> {
+    pub fn try_clone_to_owned(&self) -> io::Result<OwnedFd> {
         let fd = moto_rt::fs::duplicate(self.as_raw_fd()).map_err(crate::sys::map_motor_error)?;
         Ok(unsafe { OwnedFd::from_raw_fd(fd) })
     }
@@ -233,7 +233,7 @@ macro_rules! impl_is_terminal {
         impl crate::sealed::Sealed for $t {}
 
         #[stable(feature = "is_terminal", since = "1.70.0")]
-        impl crate::io::IsTerminal for $t {
+        impl io::IsTerminal for $t {
             #[inline]
             fn is_terminal(&self) -> bool {
                 crate::sys::io::is_terminal(self)

--- a/library/std/src/os/solid/io.rs
+++ b/library/std/src/os/solid/io.rs
@@ -49,7 +49,7 @@
 use crate::marker::PhantomData;
 use crate::mem::ManuallyDrop;
 use crate::sys::{AsInner, FromInner, IntoInner};
-use crate::{fmt, net, sys};
+use crate::{fmt, io, net, sys};
 
 /// Raw file descriptors.
 pub type RawFd = i32;
@@ -110,7 +110,7 @@ impl BorrowedFd<'_> {
 impl OwnedFd {
     /// Creates a new `OwnedFd` instance that shares the same underlying file
     /// description as the existing `OwnedFd` instance.
-    pub fn try_clone(&self) -> crate::io::Result<Self> {
+    pub fn try_clone(&self) -> io::Result<Self> {
         self.as_fd().try_clone_to_owned()
     }
 }
@@ -118,7 +118,7 @@ impl OwnedFd {
 impl BorrowedFd<'_> {
     /// Creates a new `OwnedFd` instance that shares the same underlying file
     /// description as the existing `BorrowedFd` instance.
-    pub fn try_clone_to_owned(&self) -> crate::io::Result<OwnedFd> {
+    pub fn try_clone_to_owned(&self) -> io::Result<OwnedFd> {
         let fd = sys::net::cvt(unsafe { crate::sys::abi::sockets::dup(self.as_raw_fd()) })?;
         Ok(unsafe { OwnedFd::from_raw_fd(fd) })
     }
@@ -184,7 +184,7 @@ macro_rules! impl_is_terminal {
         impl crate::sealed::Sealed for $t {}
 
         #[stable(feature = "is_terminal", since = "1.70.0")]
-        impl crate::io::IsTerminal for $t {
+        impl io::IsTerminal for $t {
             #[inline]
             fn is_terminal(&self) -> bool {
                 crate::sys::io::is_terminal(self)

--- a/library/std/src/os/unix/net/addr.rs
+++ b/library/std/src/os/unix/net/addr.rs
@@ -264,7 +264,7 @@ impl linux_ext::addr::SocketAddrExt for SocketAddr {
         if let AddressKind::Abstract(name) = self.address() { Some(name.as_bytes()) } else { None }
     }
 
-    fn from_abstract_name<N>(name: N) -> crate::io::Result<Self>
+    fn from_abstract_name<N>(name: N) -> io::Result<Self>
     where
         N: AsRef<[u8]>,
     {

--- a/library/std/src/os/windows/io/handle.rs
+++ b/library/std/src/os/windows/io/handle.rs
@@ -184,7 +184,7 @@ impl OwnedHandle {
     /// Creates a new `OwnedHandle` instance that shares the same underlying
     /// object as the existing `OwnedHandle` instance.
     #[stable(feature = "io_safety", since = "1.63.0")]
-    pub fn try_clone(&self) -> crate::io::Result<Self> {
+    pub fn try_clone(&self) -> io::Result<Self> {
         self.as_handle().try_clone_to_owned()
     }
 }
@@ -193,7 +193,7 @@ impl BorrowedHandle<'_> {
     /// Creates a new `OwnedHandle` instance that shares the same underlying
     /// object as the existing `BorrowedHandle` instance.
     #[stable(feature = "io_safety", since = "1.63.0")]
-    pub fn try_clone_to_owned(&self) -> crate::io::Result<OwnedHandle> {
+    pub fn try_clone_to_owned(&self) -> io::Result<OwnedHandle> {
         self.duplicate(0, false, sys::c::DUPLICATE_SAME_ACCESS)
     }
 
@@ -409,7 +409,7 @@ macro_rules! impl_is_terminal {
         impl crate::sealed::Sealed for $t {}
 
         #[stable(feature = "is_terminal", since = "1.70.0")]
-        impl crate::io::IsTerminal for $t {
+        impl io::IsTerminal for $t {
             #[inline]
             fn is_terminal(&self) -> bool {
                 crate::sys::io::is_terminal(self)
@@ -546,7 +546,7 @@ impl From<OwnedHandle> for fs::File {
 }
 
 #[stable(feature = "io_safety", since = "1.63.0")]
-impl AsHandle for crate::io::Stdin {
+impl AsHandle for io::Stdin {
     #[inline]
     fn as_handle(&self) -> BorrowedHandle<'_> {
         unsafe { BorrowedHandle::borrow_raw(self.as_raw_handle()) }
@@ -554,7 +554,7 @@ impl AsHandle for crate::io::Stdin {
 }
 
 #[stable(feature = "io_safety", since = "1.63.0")]
-impl<'a> AsHandle for crate::io::StdinLock<'a> {
+impl<'a> AsHandle for io::StdinLock<'a> {
     #[inline]
     fn as_handle(&self) -> BorrowedHandle<'_> {
         unsafe { BorrowedHandle::borrow_raw(self.as_raw_handle()) }
@@ -562,7 +562,7 @@ impl<'a> AsHandle for crate::io::StdinLock<'a> {
 }
 
 #[stable(feature = "io_safety", since = "1.63.0")]
-impl AsHandle for crate::io::Stdout {
+impl AsHandle for io::Stdout {
     #[inline]
     fn as_handle(&self) -> BorrowedHandle<'_> {
         unsafe { BorrowedHandle::borrow_raw(self.as_raw_handle()) }
@@ -570,7 +570,7 @@ impl AsHandle for crate::io::Stdout {
 }
 
 #[stable(feature = "io_safety", since = "1.63.0")]
-impl<'a> AsHandle for crate::io::StdoutLock<'a> {
+impl<'a> AsHandle for io::StdoutLock<'a> {
     #[inline]
     fn as_handle(&self) -> BorrowedHandle<'_> {
         unsafe { BorrowedHandle::borrow_raw(self.as_raw_handle()) }
@@ -578,7 +578,7 @@ impl<'a> AsHandle for crate::io::StdoutLock<'a> {
 }
 
 #[stable(feature = "io_safety", since = "1.63.0")]
-impl AsHandle for crate::io::Stderr {
+impl AsHandle for io::Stderr {
     #[inline]
     fn as_handle(&self) -> BorrowedHandle<'_> {
         unsafe { BorrowedHandle::borrow_raw(self.as_raw_handle()) }
@@ -586,7 +586,7 @@ impl AsHandle for crate::io::Stderr {
 }
 
 #[stable(feature = "io_safety", since = "1.63.0")]
-impl<'a> AsHandle for crate::io::StderrLock<'a> {
+impl<'a> AsHandle for io::StderrLock<'a> {
     #[inline]
     fn as_handle(&self) -> BorrowedHandle<'_> {
         unsafe { BorrowedHandle::borrow_raw(self.as_raw_handle()) }

--- a/library/std/src/sys/pal/hermit/mod.rs
+++ b/library/std/src/sys/pal/hermit/mod.rs
@@ -16,7 +16,7 @@
 #![deny(unsafe_op_in_unsafe_fn)]
 #![allow(missing_docs, nonstandard_style)]
 
-use crate::io::ErrorKind;
+use crate::io;
 use crate::os::hermit::hermit_abi;
 use crate::os::raw::c_char;
 use crate::sys::env;
@@ -25,15 +25,12 @@ pub mod futex;
 pub mod os;
 pub mod time;
 
-pub fn unsupported<T>() -> crate::io::Result<T> {
+pub fn unsupported<T>() -> io::Result<T> {
     Err(unsupported_err())
 }
 
-pub fn unsupported_err() -> crate::io::Error {
-    crate::io::const_error!(
-        crate::io::ErrorKind::Unsupported,
-        "operation not supported on HermitCore yet",
-    )
+pub fn unsupported_err() -> io::Error {
+    io::const_error!(io::ErrorKind::Unsupported, "operation not supported on HermitCore yet")
 }
 
 pub fn abort_internal() -> ! {
@@ -83,24 +80,24 @@ pub(crate) fn is_interrupted(errno: i32) -> bool {
     errno == hermit_abi::errno::EINTR
 }
 
-pub fn decode_error_kind(errno: i32) -> ErrorKind {
+pub fn decode_error_kind(errno: i32) -> io::ErrorKind {
     match errno {
-        hermit_abi::errno::EACCES => ErrorKind::PermissionDenied,
-        hermit_abi::errno::EADDRINUSE => ErrorKind::AddrInUse,
-        hermit_abi::errno::EADDRNOTAVAIL => ErrorKind::AddrNotAvailable,
-        hermit_abi::errno::EAGAIN => ErrorKind::WouldBlock,
-        hermit_abi::errno::ECONNABORTED => ErrorKind::ConnectionAborted,
-        hermit_abi::errno::ECONNREFUSED => ErrorKind::ConnectionRefused,
-        hermit_abi::errno::ECONNRESET => ErrorKind::ConnectionReset,
-        hermit_abi::errno::EEXIST => ErrorKind::AlreadyExists,
-        hermit_abi::errno::EINTR => ErrorKind::Interrupted,
-        hermit_abi::errno::EINVAL => ErrorKind::InvalidInput,
-        hermit_abi::errno::ENOENT => ErrorKind::NotFound,
-        hermit_abi::errno::ENOTCONN => ErrorKind::NotConnected,
-        hermit_abi::errno::EPERM => ErrorKind::PermissionDenied,
-        hermit_abi::errno::EPIPE => ErrorKind::BrokenPipe,
-        hermit_abi::errno::ETIMEDOUT => ErrorKind::TimedOut,
-        _ => ErrorKind::Uncategorized,
+        hermit_abi::errno::EACCES => io::ErrorKind::PermissionDenied,
+        hermit_abi::errno::EADDRINUSE => io::ErrorKind::AddrInUse,
+        hermit_abi::errno::EADDRNOTAVAIL => io::ErrorKind::AddrNotAvailable,
+        hermit_abi::errno::EAGAIN => io::ErrorKind::WouldBlock,
+        hermit_abi::errno::ECONNABORTED => io::ErrorKind::ConnectionAborted,
+        hermit_abi::errno::ECONNREFUSED => io::ErrorKind::ConnectionRefused,
+        hermit_abi::errno::ECONNRESET => io::ErrorKind::ConnectionReset,
+        hermit_abi::errno::EEXIST => io::ErrorKind::AlreadyExists,
+        hermit_abi::errno::EINTR => io::ErrorKind::Interrupted,
+        hermit_abi::errno::EINVAL => io::ErrorKind::InvalidInput,
+        hermit_abi::errno::ENOENT => io::ErrorKind::NotFound,
+        hermit_abi::errno::ENOTCONN => io::ErrorKind::NotConnected,
+        hermit_abi::errno::EPERM => io::ErrorKind::PermissionDenied,
+        hermit_abi::errno::EPIPE => io::ErrorKind::BrokenPipe,
+        hermit_abi::errno::ETIMEDOUT => io::ErrorKind::TimedOut,
+        _ => io::ErrorKind::Uncategorized,
     }
 }
 
@@ -133,16 +130,16 @@ impl IsNegative for i32 {
 }
 impl_is_negative! { i8 i16 i64 isize }
 
-pub fn cvt<T: IsNegative>(t: T) -> crate::io::Result<T> {
+pub fn cvt<T: IsNegative>(t: T) -> io::Result<T> {
     if t.is_negative() {
         let e = decode_error_kind(t.negate());
-        Err(crate::io::Error::from(e))
+        Err(io::Error::from(e))
     } else {
         Ok(t)
     }
 }
 
-pub fn cvt_r<T, F>(mut f: F) -> crate::io::Result<T>
+pub fn cvt_r<T, F>(mut f: F) -> io::Result<T>
 where
     T: IsNegative,
     F: FnMut() -> T,

--- a/library/std/src/sys/pal/itron/error.rs
+++ b/library/std/src/sys/pal/itron/error.rs
@@ -1,6 +1,5 @@
 use super::abi;
-use crate::fmt;
-use crate::io::ErrorKind;
+use crate::{fmt, io};
 
 /// Wraps a μITRON error code.
 #[derive(Debug, Copy, Clone)]
@@ -84,39 +83,39 @@ pub fn is_interrupted(er: abi::ER) -> bool {
     er == abi::E_RLWAI
 }
 
-pub fn decode_error_kind(er: abi::ER) -> ErrorKind {
+pub fn decode_error_kind(er: abi::ER) -> io::ErrorKind {
     match er {
         // Success
-        er if er >= 0 => ErrorKind::Uncategorized,
+        er if er >= 0 => io::ErrorKind::Uncategorized,
 
         // μITRON 4.0
         // abi::E_SYS
-        abi::E_NOSPT => ErrorKind::Unsupported, // Some("unsupported function"),
-        abi::E_RSFN => ErrorKind::InvalidInput, // Some("reserved function code"),
-        abi::E_RSATR => ErrorKind::InvalidInput, // Some("reserved attribute"),
-        abi::E_PAR => ErrorKind::InvalidInput,  // Some("parameter error"),
-        abi::E_ID => ErrorKind::NotFound,       // Some("invalid ID number"),
+        abi::E_NOSPT => io::ErrorKind::Unsupported, // Some("unsupported function"),
+        abi::E_RSFN => io::ErrorKind::InvalidInput, // Some("reserved function code"),
+        abi::E_RSATR => io::ErrorKind::InvalidInput, // Some("reserved attribute"),
+        abi::E_PAR => io::ErrorKind::InvalidInput,  // Some("parameter error"),
+        abi::E_ID => io::ErrorKind::NotFound,       // Some("invalid ID number"),
         // abi::E_CTX
-        abi::E_MACV => ErrorKind::PermissionDenied, // Some("memory access violation"),
-        abi::E_OACV => ErrorKind::PermissionDenied, // Some("object access violation"),
+        abi::E_MACV => io::ErrorKind::PermissionDenied, // Some("memory access violation"),
+        abi::E_OACV => io::ErrorKind::PermissionDenied, // Some("object access violation"),
         // abi::E_ILUSE
-        abi::E_NOMEM => ErrorKind::OutOfMemory, // Some("insufficient memory"),
-        abi::E_NOID => ErrorKind::OutOfMemory,  // Some("no ID number available"),
+        abi::E_NOMEM => io::ErrorKind::OutOfMemory, // Some("insufficient memory"),
+        abi::E_NOID => io::ErrorKind::OutOfMemory,  // Some("no ID number available"),
         // abi::E_OBJ
-        abi::E_NOEXS => ErrorKind::NotFound, // Some("non-existent object"),
+        abi::E_NOEXS => io::ErrorKind::NotFound, // Some("non-existent object"),
         // abi::E_QOVR
-        abi::E_RLWAI => ErrorKind::Interrupted, // Some("forced release from waiting"),
-        abi::E_TMOUT => ErrorKind::TimedOut,    // Some("polling failure or timeout"),
+        abi::E_RLWAI => io::ErrorKind::Interrupted, // Some("forced release from waiting"),
+        abi::E_TMOUT => io::ErrorKind::TimedOut,    // Some("polling failure or timeout"),
         // abi::E_DLT
         // abi::E_CLS
         // abi::E_WBLK
         // abi::E_BOVR
 
         // The TOPPERS third generation kernels
-        abi::E_NORES => ErrorKind::OutOfMemory, // Some("insufficient system resources"),
+        abi::E_NORES => io::ErrorKind::OutOfMemory, // Some("insufficient system resources"),
         // abi::E_RASTER
         // abi::E_COMM
-        _ => ErrorKind::Uncategorized,
+        _ => io::ErrorKind::Uncategorized,
     }
 }
 

--- a/library/std/src/sys/pal/motor/mod.rs
+++ b/library/std/src/sys/pal/motor/mod.rs
@@ -5,12 +5,11 @@ pub mod time;
 
 pub use moto_rt::futex;
 
-use crate::io as std_io;
-use crate::sys::io::RawOsError;
+use crate::io;
 
-pub(crate) fn map_motor_error(err: moto_rt::Error) -> crate::io::Error {
+pub(crate) fn map_motor_error(err: moto_rt::Error) -> io::Error {
     let error_code: moto_rt::ErrorCode = err.into();
-    crate::io::Error::from_raw_os_error(error_code.into())
+    io::Error::from_raw_os_error(error_code.into())
 }
 
 #[cfg(not(test))]
@@ -37,50 +36,50 @@ pub unsafe fn init(_argc: isize, _argv: *const *const u8, _sigpipe: u8) {}
 // NOTE: this is not guaranteed to run, for example when the program aborts.
 pub unsafe fn cleanup() {}
 
-pub fn unsupported<T>() -> std_io::Result<T> {
+pub fn unsupported<T>() -> io::Result<T> {
     Err(unsupported_err())
 }
 
-pub fn unsupported_err() -> std_io::Error {
-    std_io::Error::UNSUPPORTED_PLATFORM
+pub fn unsupported_err() -> io::Error {
+    io::Error::UNSUPPORTED_PLATFORM
 }
 
-pub fn is_interrupted(_code: RawOsError) -> bool {
+pub fn is_interrupted(_code: io::RawOsError) -> bool {
     false // Motor OS doesn't have signals.
 }
 
-pub fn decode_error_kind(code: RawOsError) -> crate::io::ErrorKind {
-    use std_io::ErrorKind;
+pub fn decode_error_kind(code: io::RawOsError) -> io::ErrorKind {
+    use moto_rt::error::*;
 
     if code < 0 || code > u16::MAX.into() {
-        return std_io::ErrorKind::Uncategorized;
+        return io::ErrorKind::Uncategorized;
     }
 
     let error = moto_rt::Error::from(code as moto_rt::ErrorCode);
 
     match error {
-        moto_rt::Error::Unspecified => ErrorKind::Uncategorized,
-        moto_rt::Error::Unknown => ErrorKind::Uncategorized,
-        moto_rt::Error::NotReady => ErrorKind::WouldBlock,
-        moto_rt::Error::NotImplemented => ErrorKind::Unsupported,
-        moto_rt::Error::VersionTooHigh => ErrorKind::Unsupported,
-        moto_rt::Error::VersionTooLow => ErrorKind::Unsupported,
-        moto_rt::Error::InvalidArgument => ErrorKind::InvalidInput,
-        moto_rt::Error::OutOfMemory => ErrorKind::OutOfMemory,
-        moto_rt::Error::NotAllowed => ErrorKind::PermissionDenied,
-        moto_rt::Error::NotFound => ErrorKind::NotFound,
-        moto_rt::Error::InternalError => ErrorKind::Other,
-        moto_rt::Error::TimedOut => ErrorKind::TimedOut,
-        moto_rt::Error::AlreadyInUse => ErrorKind::AlreadyExists,
-        moto_rt::Error::UnexpectedEof => ErrorKind::UnexpectedEof,
-        moto_rt::Error::InvalidFilename => ErrorKind::InvalidFilename,
-        moto_rt::Error::NotADirectory => ErrorKind::NotADirectory,
-        moto_rt::Error::BadHandle => ErrorKind::InvalidInput,
-        moto_rt::Error::FileTooLarge => ErrorKind::FileTooLarge,
-        moto_rt::Error::NotConnected => ErrorKind::NotConnected,
-        moto_rt::Error::StorageFull => ErrorKind::StorageFull,
-        moto_rt::Error::InvalidData => ErrorKind::InvalidData,
-        _ => crate::io::ErrorKind::Uncategorized,
+        moto_rt::Error::Unspecified => io::ErrorKind::Uncategorized,
+        moto_rt::Error::Unknown => io::ErrorKind::Uncategorized,
+        moto_rt::Error::NotReady => io::ErrorKind::WouldBlock,
+        moto_rt::Error::NotImplemented => io::ErrorKind::Unsupported,
+        moto_rt::Error::VersionTooHigh => io::ErrorKind::Unsupported,
+        moto_rt::Error::VersionTooLow => io::ErrorKind::Unsupported,
+        moto_rt::Error::InvalidArgument => io::ErrorKind::InvalidInput,
+        moto_rt::Error::OutOfMemory => io::ErrorKind::OutOfMemory,
+        moto_rt::Error::NotAllowed => io::ErrorKind::PermissionDenied,
+        moto_rt::Error::NotFound => io::ErrorKind::NotFound,
+        moto_rt::Error::InternalError => io::ErrorKind::Other,
+        moto_rt::Error::TimedOut => io::ErrorKind::TimedOut,
+        moto_rt::Error::AlreadyInUse => io::ErrorKind::AlreadyExists,
+        moto_rt::Error::UnexpectedEof => io::ErrorKind::UnexpectedEof,
+        moto_rt::Error::InvalidFilename => io::ErrorKind::InvalidFilename,
+        moto_rt::Error::NotADirectory => io::ErrorKind::NotADirectory,
+        moto_rt::Error::BadHandle => io::ErrorKind::InvalidInput,
+        moto_rt::Error::FileTooLarge => io::ErrorKind::FileTooLarge,
+        moto_rt::Error::NotConnected => io::ErrorKind::NotConnected,
+        moto_rt::Error::StorageFull => io::ErrorKind::StorageFull,
+        moto_rt::Error::InvalidData => io::ErrorKind::InvalidData,
+        _ => io::ErrorKind::Uncategorized,
     }
 }
 

--- a/library/std/src/sys/pal/sgx/mod.rs
+++ b/library/std/src/sys/pal/sgx/mod.rs
@@ -5,7 +5,7 @@
 #![deny(unsafe_op_in_unsafe_fn)]
 #![allow(fuzzy_provenance_casts)] // FIXME: this entire module systematically confuses pointers and integers
 
-use crate::io::ErrorKind;
+use crate::io;
 use crate::sync::atomic::{Atomic, AtomicBool, Ordering};
 
 pub mod abi;
@@ -29,12 +29,12 @@ pub unsafe fn cleanup() {}
 
 /// This function is used to implement functionality that simply doesn't exist.
 /// Programs relying on this functionality will need to deal with the error.
-pub fn unsupported<T>() -> crate::io::Result<T> {
+pub fn unsupported<T>() -> io::Result<T> {
     Err(unsupported_err())
 }
 
-pub fn unsupported_err() -> crate::io::Error {
-    crate::io::const_error!(ErrorKind::Unsupported, "operation not supported on SGX yet")
+pub fn unsupported_err() -> io::Error {
+    io::const_error!(io::ErrorKind::Unsupported, "operation not supported on SGX yet")
 }
 
 /// This function is used to implement various functions that doesn't exist,
@@ -42,11 +42,11 @@ pub fn unsupported_err() -> crate::io::Error {
 /// returned, the program might very well be able to function normally. This is
 /// what happens when `SGX_INEFFECTIVE_ERROR` is set to `true`. If it is
 /// `false`, the behavior is the same as `unsupported`.
-pub fn sgx_ineffective<T>(v: T) -> crate::io::Result<T> {
+pub fn sgx_ineffective<T>(v: T) -> io::Result<T> {
     static SGX_INEFFECTIVE_ERROR: Atomic<bool> = AtomicBool::new(false);
     if SGX_INEFFECTIVE_ERROR.load(Ordering::Relaxed) {
-        Err(crate::io::const_error!(
-            ErrorKind::Uncategorized,
+        Err(io::const_error!(
+            io::ErrorKind::Uncategorized,
             "operation can't be trusted to have any effect on SGX",
         ))
     } else {
@@ -59,48 +59,48 @@ pub fn is_interrupted(code: i32) -> bool {
     code == fortanix_sgx_abi::Error::Interrupted as _
 }
 
-pub fn decode_error_kind(code: i32) -> ErrorKind {
+pub fn decode_error_kind(code: i32) -> io::ErrorKind {
     use fortanix_sgx_abi::Error;
 
     // FIXME: not sure how to make sure all variants of Error are covered
     if code == Error::NotFound as _ {
-        ErrorKind::NotFound
+        io::ErrorKind::NotFound
     } else if code == Error::PermissionDenied as _ {
-        ErrorKind::PermissionDenied
+        io::ErrorKind::PermissionDenied
     } else if code == Error::ConnectionRefused as _ {
-        ErrorKind::ConnectionRefused
+        io::ErrorKind::ConnectionRefused
     } else if code == Error::ConnectionReset as _ {
-        ErrorKind::ConnectionReset
+        io::ErrorKind::ConnectionReset
     } else if code == Error::ConnectionAborted as _ {
-        ErrorKind::ConnectionAborted
+        io::ErrorKind::ConnectionAborted
     } else if code == Error::NotConnected as _ {
-        ErrorKind::NotConnected
+        io::ErrorKind::NotConnected
     } else if code == Error::AddrInUse as _ {
-        ErrorKind::AddrInUse
+        io::ErrorKind::AddrInUse
     } else if code == Error::AddrNotAvailable as _ {
-        ErrorKind::AddrNotAvailable
+        io::ErrorKind::AddrNotAvailable
     } else if code == Error::BrokenPipe as _ {
-        ErrorKind::BrokenPipe
+        io::ErrorKind::BrokenPipe
     } else if code == Error::AlreadyExists as _ {
-        ErrorKind::AlreadyExists
+        io::ErrorKind::AlreadyExists
     } else if code == Error::WouldBlock as _ {
-        ErrorKind::WouldBlock
+        io::ErrorKind::WouldBlock
     } else if code == Error::InvalidInput as _ {
-        ErrorKind::InvalidInput
+        io::ErrorKind::InvalidInput
     } else if code == Error::InvalidData as _ {
-        ErrorKind::InvalidData
+        io::ErrorKind::InvalidData
     } else if code == Error::TimedOut as _ {
-        ErrorKind::TimedOut
+        io::ErrorKind::TimedOut
     } else if code == Error::WriteZero as _ {
-        ErrorKind::WriteZero
+        io::ErrorKind::WriteZero
     } else if code == Error::Interrupted as _ {
-        ErrorKind::Interrupted
+        io::ErrorKind::Interrupted
     } else if code == Error::Other as _ {
-        ErrorKind::Uncategorized
+        io::ErrorKind::Uncategorized
     } else if code == Error::UnexpectedEof as _ {
-        ErrorKind::UnexpectedEof
+        io::ErrorKind::UnexpectedEof
     } else {
-        ErrorKind::Uncategorized
+        io::ErrorKind::Uncategorized
     }
 }
 

--- a/library/std/src/sys/pal/sgx/thread_parking.rs
+++ b/library/std/src/sys/pal/sgx/thread_parking.rs
@@ -1,7 +1,7 @@
 use fortanix_sgx_abi::{EV_UNPARK, WAIT_INDEFINITE};
 
 use super::abi::usercalls;
-use crate::io::ErrorKind;
+use crate::io;
 use crate::time::Duration;
 
 pub type ThreadId = fortanix_sgx_abi::Tcs;
@@ -15,7 +15,7 @@ pub fn park(_hint: usize) {
 pub fn park_timeout(dur: Duration, _hint: usize) {
     let timeout = u128::min(dur.as_nanos(), WAIT_INDEFINITE as u128 - 1) as u64;
     if let Err(e) = usercalls::wait(EV_UNPARK, timeout) {
-        assert!(matches!(e.kind(), ErrorKind::TimedOut | ErrorKind::WouldBlock))
+        assert!(matches!(e.kind(), io::ErrorKind::TimedOut | io::ErrorKind::WouldBlock))
     }
 }
 

--- a/library/std/src/sys/pal/solid/error.rs
+++ b/library/std/src/sys/pal/solid/error.rs
@@ -1,6 +1,6 @@
 pub use self::itron::error::{ItronError as SolidError, expect_success};
 use super::{abi, itron};
-use crate::io::ErrorKind;
+use crate::io;
 use crate::sys::net;
 
 /// Describe the specified SOLID error code. Returns `None` if it's an
@@ -31,23 +31,23 @@ pub fn error_name(er: abi::ER) -> Option<&'static str> {
     }
 }
 
-pub fn decode_error_kind(er: abi::ER) -> ErrorKind {
+pub fn decode_error_kind(er: abi::ER) -> io::ErrorKind {
     match er {
         // Success
-        er if er >= 0 => ErrorKind::Uncategorized,
+        er if er >= 0 => io::ErrorKind::Uncategorized,
         er if er < abi::sockets::SOLID_NET_ERR_BASE => net::decode_error_kind(er),
 
-        abi::SOLID_ERR_NOTFOUND => ErrorKind::NotFound,
-        abi::SOLID_ERR_NOTSUPPORTED => ErrorKind::Unsupported,
-        abi::SOLID_ERR_EBADF => ErrorKind::InvalidInput,
-        abi::SOLID_ERR_INVALIDCONTENT => ErrorKind::InvalidData,
+        abi::SOLID_ERR_NOTFOUND => io::ErrorKind::NotFound,
+        abi::SOLID_ERR_NOTSUPPORTED => io::ErrorKind::Unsupported,
+        abi::SOLID_ERR_EBADF => io::ErrorKind::InvalidInput,
+        abi::SOLID_ERR_INVALIDCONTENT => io::ErrorKind::InvalidData,
         // abi::SOLID_ERR_NOTUSED
         // abi::SOLID_ERR_ALREADYUSED
-        abi::SOLID_ERR_OUTOFBOUND => ErrorKind::InvalidInput,
+        abi::SOLID_ERR_OUTOFBOUND => io::ErrorKind::InvalidInput,
         // abi::SOLID_ERR_BADSEQUENCE
-        abi::SOLID_ERR_UNKNOWNDEVICE => ErrorKind::NotFound,
+        abi::SOLID_ERR_UNKNOWNDEVICE => io::ErrorKind::NotFound,
         // abi::SOLID_ERR_BUSY
-        abi::SOLID_ERR_TIMEOUT => ErrorKind::TimedOut,
+        abi::SOLID_ERR_TIMEOUT => io::ErrorKind::TimedOut,
         // abi::SOLID_ERR_INVALIDACCESS
         // abi::SOLID_ERR_NOTREADY
         _ => itron::error::decode_error_kind(er),

--- a/library/std/src/sys/pal/solid/mod.rs
+++ b/library/std/src/sys/pal/solid/mod.rs
@@ -2,6 +2,8 @@
 #![allow(missing_docs, nonstandard_style)]
 #![forbid(unsafe_op_in_unsafe_fn)]
 
+use crate::io;
+
 pub mod abi;
 
 #[path = "../itron"]
@@ -28,12 +30,12 @@ pub unsafe fn init(_argc: isize, _argv: *const *const u8, _sigpipe: u8) {}
 // SAFETY: must be called only once during runtime cleanup.
 pub unsafe fn cleanup() {}
 
-pub fn unsupported<T>() -> crate::io::Result<T> {
+pub fn unsupported<T>() -> io::Result<T> {
     Err(unsupported_err())
 }
 
-pub fn unsupported_err() -> crate::io::Error {
-    crate::io::Error::UNSUPPORTED_PLATFORM
+pub fn unsupported_err() -> io::Error {
+    io::Error::UNSUPPORTED_PLATFORM
 }
 
 #[inline]
@@ -41,7 +43,7 @@ pub fn is_interrupted(code: i32) -> bool {
     crate::sys::net::is_interrupted(code)
 }
 
-pub fn decode_error_kind(code: i32) -> crate::io::ErrorKind {
+pub fn decode_error_kind(code: i32) -> io::ErrorKind {
     error::decode_error_kind(code)
 }
 

--- a/library/std/src/sys/pal/uefi/mod.rs
+++ b/library/std/src/sys/pal/uefi/mod.rs
@@ -13,8 +13,6 @@
 //! [`OsString`]: crate::ffi::OsString
 #![forbid(unsafe_op_in_unsafe_fn)]
 
-use crate::io::RawOsError;
-
 pub mod helpers;
 pub mod os;
 pub mod time;
@@ -22,7 +20,7 @@ pub mod time;
 #[cfg(test)]
 mod tests;
 
-use crate::io as std_io;
+use crate::io;
 use crate::os::uefi;
 use crate::ptr::NonNull;
 use crate::sync::atomic::{Atomic, AtomicPtr, Ordering};
@@ -76,19 +74,17 @@ pub unsafe fn cleanup() {
 }
 
 #[inline]
-pub const fn unsupported<T>() -> std_io::Result<T> {
+pub const fn unsupported<T>() -> io::Result<T> {
     Err(unsupported_err())
 }
 
 #[inline]
-pub const fn unsupported_err() -> std_io::Error {
-    std_io::const_error!(std_io::ErrorKind::Unsupported, "operation not supported on UEFI")
+pub const fn unsupported_err() -> io::Error {
+    io::const_error!(io::ErrorKind::Unsupported, "operation not supported on UEFI")
 }
 
-pub fn decode_error_kind(code: RawOsError) -> crate::io::ErrorKind {
+pub fn decode_error_kind(code: io::RawOsError) -> io::ErrorKind {
     use r_efi::efi::Status;
-
-    use crate::io::ErrorKind;
 
     match r_efi::efi::Status::from_usize(code) {
         Status::ALREADY_STARTED
@@ -108,28 +104,28 @@ pub fn decode_error_kind(code: RawOsError) -> crate::io::ErrorKind {
         | Status::PROTOCOL_ERROR
         | Status::PROTOCOL_UNREACHABLE
         | Status::TFTP_ERROR
-        | Status::VOLUME_CORRUPTED => ErrorKind::Other,
-        Status::BAD_BUFFER_SIZE | Status::INVALID_LANGUAGE => ErrorKind::InvalidData,
-        Status::ABORTED => ErrorKind::ConnectionAborted,
-        Status::ACCESS_DENIED => ErrorKind::PermissionDenied,
-        Status::BUFFER_TOO_SMALL => ErrorKind::FileTooLarge,
-        Status::CONNECTION_REFUSED => ErrorKind::ConnectionRefused,
-        Status::CONNECTION_RESET => ErrorKind::ConnectionReset,
-        Status::END_OF_FILE => ErrorKind::UnexpectedEof,
-        Status::HOST_UNREACHABLE => ErrorKind::HostUnreachable,
-        Status::INVALID_PARAMETER => ErrorKind::InvalidInput,
-        Status::IP_ADDRESS_CONFLICT => ErrorKind::AddrInUse,
-        Status::NETWORK_UNREACHABLE => ErrorKind::NetworkUnreachable,
-        Status::NO_RESPONSE => ErrorKind::HostUnreachable,
-        Status::NOT_FOUND => ErrorKind::NotFound,
-        Status::NOT_READY => ErrorKind::ResourceBusy,
-        Status::OUT_OF_RESOURCES => ErrorKind::OutOfMemory,
-        Status::SECURITY_VIOLATION => ErrorKind::PermissionDenied,
-        Status::TIMEOUT => ErrorKind::TimedOut,
-        Status::UNSUPPORTED => ErrorKind::Unsupported,
-        Status::VOLUME_FULL => ErrorKind::StorageFull,
-        Status::WRITE_PROTECTED => ErrorKind::ReadOnlyFilesystem,
-        _ => ErrorKind::Uncategorized,
+        | Status::VOLUME_CORRUPTED => io::ErrorKind::Other,
+        Status::BAD_BUFFER_SIZE | Status::INVALID_LANGUAGE => io::ErrorKind::InvalidData,
+        Status::ABORTED => io::ErrorKind::ConnectionAborted,
+        Status::ACCESS_DENIED => io::ErrorKind::PermissionDenied,
+        Status::BUFFER_TOO_SMALL => io::ErrorKind::FileTooLarge,
+        Status::CONNECTION_REFUSED => io::ErrorKind::ConnectionRefused,
+        Status::CONNECTION_RESET => io::ErrorKind::ConnectionReset,
+        Status::END_OF_FILE => io::ErrorKind::UnexpectedEof,
+        Status::HOST_UNREACHABLE => io::ErrorKind::HostUnreachable,
+        Status::INVALID_PARAMETER => io::ErrorKind::InvalidInput,
+        Status::IP_ADDRESS_CONFLICT => io::ErrorKind::AddrInUse,
+        Status::NETWORK_UNREACHABLE => io::ErrorKind::NetworkUnreachable,
+        Status::NO_RESPONSE => io::ErrorKind::HostUnreachable,
+        Status::NOT_FOUND => io::ErrorKind::NotFound,
+        Status::NOT_READY => io::ErrorKind::ResourceBusy,
+        Status::OUT_OF_RESOURCES => io::ErrorKind::OutOfMemory,
+        Status::SECURITY_VIOLATION => io::ErrorKind::PermissionDenied,
+        Status::TIMEOUT => io::ErrorKind::TimedOut,
+        Status::UNSUPPORTED => io::ErrorKind::Unsupported,
+        Status::VOLUME_FULL => io::ErrorKind::StorageFull,
+        Status::WRITE_PROTECTED => io::ErrorKind::ReadOnlyFilesystem,
+        _ => io::ErrorKind::Uncategorized,
     }
 }
 
@@ -163,6 +159,6 @@ extern "efiapi" fn exit_boot_service_handler(_e: r_efi::efi::Event, _ctx: *mut c
     uefi::env::disable_boot_services();
 }
 
-pub fn is_interrupted(_code: RawOsError) -> bool {
+pub fn is_interrupted(_code: io::RawOsError) -> bool {
     false
 }

--- a/library/std/src/sys/pal/uefi/os.rs
+++ b/library/std/src/sys/pal/uefi/os.rs
@@ -1,7 +1,7 @@
 use r_efi::efi::Status;
 use r_efi::efi::protocols::{device_path, loaded_image_device_path};
 
-use super::{RawOsError, helpers, unsupported_err};
+use super::{helpers, unsupported_err};
 use crate::ffi::{OsStr, OsString};
 use crate::marker::PhantomData;
 use crate::os::uefi;
@@ -9,11 +9,11 @@ use crate::path::{self, PathBuf};
 use crate::ptr::NonNull;
 use crate::{fmt, io};
 
-pub fn errno() -> RawOsError {
+pub fn errno() -> io::RawOsError {
     0
 }
 
-pub fn error_string(errno: RawOsError) -> String {
+pub fn error_string(errno: io::RawOsError) -> String {
     // Keep the List in Alphabetical Order
     // The Messages are taken from UEFI Specification Appendix D - Status Codes
     #[rustfmt::skip]

--- a/library/std/src/sys/pal/unix/mod.rs
+++ b/library/std/src/sys/pal/unix/mod.rs
@@ -1,6 +1,6 @@
 #![allow(missing_docs, nonstandard_style)]
 
-use crate::io::ErrorKind;
+use crate::io;
 
 #[cfg(target_os = "fuchsia")]
 pub mod fuchsia;
@@ -229,8 +229,8 @@ pub(crate) fn is_interrupted(errno: i32) -> bool {
     errno == libc::EINTR
 }
 
-pub fn decode_error_kind(errno: i32) -> ErrorKind {
-    use ErrorKind::*;
+pub fn decode_error_kind(errno: i32) -> io::ErrorKind {
+    use io::ErrorKind::*;
     match errno as libc::c_int {
         libc::E2BIG => ArgumentListTooLong,
         libc::EADDRINUSE => AddrInUse,
@@ -298,12 +298,12 @@ impl_is_minus_one! { i8 i16 i32 i64 isize }
 
 /// Converts native return values to Result using the *-1 means error is in `errno`*  convention.
 /// Non-error values are `Ok`-wrapped.
-pub fn cvt<T: IsMinusOne>(t: T) -> crate::io::Result<T> {
-    if t.is_minus_one() { Err(crate::io::Error::last_os_error()) } else { Ok(t) }
+pub fn cvt<T: IsMinusOne>(t: T) -> io::Result<T> {
+    if t.is_minus_one() { Err(io::Error::last_os_error()) } else { Ok(t) }
 }
 
 /// `-1` → look at `errno` → retry on `EINTR`. Otherwise `Ok()`-wrap the closure return value.
-pub fn cvt_r<T, F>(mut f: F) -> crate::io::Result<T>
+pub fn cvt_r<T, F>(mut f: F) -> io::Result<T>
 where
     T: IsMinusOne,
     F: FnMut() -> T,
@@ -318,8 +318,8 @@ where
 
 #[allow(dead_code)] // Not used on all platforms.
 /// Zero means `Ok()`, all other values are treated as raw OS errors. Does not look at `errno`.
-pub fn cvt_nz(error: libc::c_int) -> crate::io::Result<()> {
-    if error == 0 { Ok(()) } else { Err(crate::io::Error::from_raw_os_error(error)) }
+pub fn cvt_nz(error: libc::c_int) -> io::Result<()> {
+    if error == 0 { Ok(()) } else { Err(io::Error::from_raw_os_error(error)) }
 }
 
 // libc::abort() will run the SIGABRT handler.  That's fine because anyone who

--- a/library/std/src/sys/pal/unix/os.rs
+++ b/library/std/src/sys/pal/unix/os.rs
@@ -244,10 +244,10 @@ pub fn current_exe() -> io::Result<PathBuf> {
 
     #[cfg(not(test))]
     use crate::env;
-    use crate::io::ErrorKind;
+    use crate::io;
 
     let exe_path = env::args().next().ok_or(io::const_error!(
-        ErrorKind::NotFound,
+        io::ErrorKind::NotFound,
         "an executable path was not found because no arguments were provided through argv",
     ))?;
     let path = PathBuf::from(exe_path);
@@ -272,7 +272,7 @@ pub fn current_exe() -> io::Result<PathBuf> {
             }
         }
     }
-    Err(io::const_error!(ErrorKind::NotFound, "an executable path was not found"))
+    Err(io::const_error!(io::ErrorKind::NotFound, "an executable path was not found"))
 }
 
 #[cfg(any(target_os = "freebsd", target_os = "dragonfly"))]
@@ -463,8 +463,7 @@ pub fn current_exe() -> io::Result<PathBuf> {
             name.len(),
         );
         if result != libc::B_OK {
-            use crate::io::ErrorKind;
-            Err(io::const_error!(ErrorKind::Uncategorized, "error getting executable path"))
+            Err(io::const_error!(io::ErrorKind::Uncategorized, "error getting executable path"))
         } else {
             // find_path adds the null terminator.
             let name = CStr::from_ptr(name.as_ptr()).to_bytes();
@@ -485,8 +484,7 @@ pub fn current_exe() -> io::Result<PathBuf> {
 
 #[cfg(target_os = "l4re")]
 pub fn current_exe() -> io::Result<PathBuf> {
-    use crate::io::ErrorKind;
-    Err(io::const_error!(ErrorKind::Unsupported, "not yet implemented!"))
+    Err(io::const_error!(io::ErrorKind::Unsupported, "not yet implemented!"))
 }
 
 #[cfg(target_os = "vxworks")]
@@ -514,10 +512,9 @@ pub fn current_exe() -> io::Result<PathBuf> {
 
     #[cfg(not(test))]
     use crate::env;
-    use crate::io::ErrorKind;
 
     let exe_path = env::args().next().ok_or(io::const_error!(
-        ErrorKind::Uncategorized,
+        io::ErrorKind::Uncategorized,
         "an executable path was not found because no arguments were provided through argv",
     ))?;
     let path = PathBuf::from(exe_path);

--- a/library/std/src/sys/pal/wasi/os.rs
+++ b/library/std/src/sys/pal/wasi/os.rs
@@ -157,7 +157,7 @@ pub fn cvt<T: IsMinusOne>(t: T) -> io::Result<T> {
     if t.is_minus_one() { Err(io::Error::last_os_error()) } else { Ok(t) }
 }
 
-pub fn cvt_r<T, F>(mut f: F) -> crate::io::Result<T>
+pub fn cvt_r<T, F>(mut f: F) -> io::Result<T>
 where
     T: IsMinusOne,
     F: FnMut() -> T,

--- a/library/std/src/sys/pal/windows/handle.rs
+++ b/library/std/src/sys/pal/windows/handle.rs
@@ -3,7 +3,7 @@
 use core::ffi::c_void;
 use core::{cmp, mem, ptr};
 
-use crate::io::{self, BorrowedCursor, ErrorKind, IoSlice, IoSliceMut, Read};
+use crate::io::{self, BorrowedCursor, IoSlice, IoSliceMut, Read};
 use crate::os::windows::io::{
     AsHandle, AsRawHandle, BorrowedHandle, FromRawHandle, IntoRawHandle, OwnedHandle, RawHandle,
 };
@@ -83,7 +83,7 @@ impl Handle {
             // pipe semantics, which yields this error when *reading* from
             // a pipe after the other end has closed; we interpret that as
             // EOF on the pipe.
-            Err(ref e) if e.kind() == ErrorKind::BrokenPipe => Ok(0),
+            Err(ref e) if e.kind() == io::ErrorKind::BrokenPipe => Ok(0),
 
             Err(e) => Err(e),
         }
@@ -126,7 +126,7 @@ impl Handle {
             // pipe semantics, which yields this error when *reading* from
             // a pipe after the other end has closed; we interpret that as
             // EOF on the pipe.
-            Err(ref e) if e.kind() == ErrorKind::BrokenPipe => Ok(()),
+            Err(ref e) if e.kind() == io::ErrorKind::BrokenPipe => Ok(()),
 
             Err(e) => Err(e),
         }

--- a/library/std/src/thread/builder.rs
+++ b/library/std/src/thread/builder.rs
@@ -40,7 +40,6 @@ use crate::io;
 /// [`name`]: Builder::name
 /// [`spawn`]: Builder::spawn
 /// [`thread::spawn`]: super::spawn
-/// [`io::Result`]: crate::io::Result
 /// [`unwrap`]: crate::result::Result::unwrap
 /// [naming-threads]: ./index.html#naming-threads
 /// [stack-size]: ./index.html#stack-size
@@ -161,8 +160,6 @@ impl Builder {
     /// [`io::Result`] to capture any failure to create the thread at
     /// the OS level.
     ///
-    /// [`io::Result`]: crate::io::Result
-    ///
     /// # Panics
     ///
     /// Panics if a thread name was set and it contained null bytes.
@@ -250,7 +247,6 @@ impl Builder {
     /// handler.join().unwrap();
     /// ```
     ///
-    /// [`io::Result`]: crate::io::Result
     /// [`thread::spawn`]: super::spawn
     /// [`spawn`]: super::spawn
     #[stable(feature = "thread_spawn_unchecked", since = "1.82.0")]

--- a/library/std/src/thread/scoped.rs
+++ b/library/std/src/thread/scoped.rs
@@ -210,8 +210,6 @@ impl Builder {
     /// Unlike [`Scope::spawn`], this method yields an [`io::Result`] to
     /// capture any failure to create the thread at the OS level.
     ///
-    /// [`io::Result`]: crate::io::Result
-    ///
     /// # Panics
     ///
     /// Panics if a thread name was set and it contained null bytes.

--- a/library/std_detect/src/detect/arch/s390x.rs
+++ b/library/std_detect/src/detect/arch/s390x.rs
@@ -10,27 +10,27 @@ features! {
     /// When the feature is known to be enabled at compile time (e.g. via `-Ctarget-feature`)
     /// the macro expands to `true`.
     #[stable(feature = "stdarch_s390x_feature_detection", since = "1.93.0")]
-    @FEATURE: #[unstable(feature = "s390x_target_feature", issue = "44839")] concurrent_functions: "concurrent-functions";
+    @FEATURE: #[unstable(feature = "s390x_target_feature", issue = "150259")] concurrent_functions: "concurrent-functions";
     /// s390x concurrent-functions facility
-    @FEATURE: #[unstable(feature = "s390x_target_feature", issue = "44839")] deflate_conversion: "deflate-conversion";
+    @FEATURE: #[unstable(feature = "s390x_target_feature", issue = "150259")] deflate_conversion: "deflate-conversion";
     /// s390x deflate-conversion facility
-    @FEATURE: #[unstable(feature = "s390x_target_feature", issue = "44839")] enhanced_sort: "enhanced-sort";
+    @FEATURE: #[unstable(feature = "s390x_target_feature", issue = "150259")] enhanced_sort: "enhanced-sort";
     /// s390x enhanced-sort facility
-    @FEATURE: #[unstable(feature = "s390x_target_feature", issue = "44839")] guarded_storage: "guarded-storage";
+    @FEATURE: #[unstable(feature = "s390x_target_feature", issue = "150259")] guarded_storage: "guarded-storage";
     /// s390x guarded-storage facility
-    @FEATURE: #[unstable(feature = "s390x_target_feature", issue = "44839")] high_word: "high-word";
+    @FEATURE: #[unstable(feature = "s390x_target_feature", issue = "150259")] high_word: "high-word";
     /// s390x high-word facility
-    @FEATURE: #[unstable(feature = "s390x_target_feature", issue = "44839")] message_security_assist_extension3: "message-security-assist-extension3";
+    @FEATURE: #[unstable(feature = "s390x_target_feature", issue = "150259")] message_security_assist_extension3: "message-security-assist-extension3";
     /// s390x message-security-assist-extension3 facility
-    @FEATURE: #[unstable(feature = "s390x_target_feature", issue = "44839")] message_security_assist_extension4: "message-security-assist-extension4";
+    @FEATURE: #[unstable(feature = "s390x_target_feature", issue = "150259")] message_security_assist_extension4: "message-security-assist-extension4";
     /// s390x message-security-assist-extension4 facility
-    @FEATURE: #[unstable(feature = "s390x_target_feature", issue = "44839")] message_security_assist_extension5: "message-security-assist-extension5";
+    @FEATURE: #[unstable(feature = "s390x_target_feature", issue = "150259")] message_security_assist_extension5: "message-security-assist-extension5";
     /// s390x message-security-assist-extension5 facility
-    @FEATURE: #[unstable(feature = "s390x_target_feature", issue = "44839")] message_security_assist_extension8: "message-security-assist-extension8";
+    @FEATURE: #[unstable(feature = "s390x_target_feature", issue = "150259")] message_security_assist_extension8: "message-security-assist-extension8";
     /// s390x message-security-assist-extension8 facility
-    @FEATURE: #[unstable(feature = "s390x_target_feature", issue = "44839")] message_security_assist_extension9: "message-security-assist-extension9";
+    @FEATURE: #[unstable(feature = "s390x_target_feature", issue = "150259")] message_security_assist_extension9: "message-security-assist-extension9";
     /// s390x message-security-assist-extension9 facility
-    @FEATURE: #[unstable(feature = "s390x_target_feature", issue = "44839")] message_security_assist_extension12: "message-security-assist-extension12";
+    @FEATURE: #[unstable(feature = "s390x_target_feature", issue = "150259")] message_security_assist_extension12: "message-security-assist-extension12";
     /// s390x message-security-assist-extension12 facility
     @FEATURE: #[stable(feature = "s390x_target_feature_vector", since = "1.93.0")] miscellaneous_extensions_2: "miscellaneous-extensions-2";
     /// s390x miscellaneous-extensions-2 facility
@@ -40,7 +40,7 @@ features! {
     /// s390x miscellaneous-extensions-4 facility
     @FEATURE: #[stable(feature = "s390x_target_feature_vector", since = "1.93.0")] nnp_assist: "nnp-assist";
     /// s390x nnp-assist facility
-    @FEATURE: #[unstable(feature = "s390x_target_feature", issue = "44839")] transactional_execution: "transactional-execution";
+    @FEATURE: #[unstable(feature = "s390x_target_feature", issue = "150259")] transactional_execution: "transactional-execution";
     /// s390x transactional-execution facility
     @FEATURE: #[stable(feature = "s390x_target_feature_vector", since = "1.93.0")] vector: "vector";
     /// s390x vector facility

--- a/tests/ui/target-feature/gate.stderr
+++ b/tests/ui/target-feature/gate.stderr
@@ -4,7 +4,7 @@ error[E0658]: the target feature `x87` is currently unstable
 LL | #[target_feature(enable = "x87")]
    |                  ^^^^^^^^^^^^^^
    |
-   = note: see issue #44839 <https://github.com/rust-lang/rust/issues/44839> for more information
+   = note: see issue #150261 <https://github.com/rust-lang/rust/issues/150261> for more information
    = help: add `#![feature(x87_target_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#149778 (`crate::io::Result` → `io::Result` in most places)
 - rust-lang/rust#150264 (split up tracking issue for target feature feature gates)
 - rust-lang/rust#150548 (`region_scope_tree`: Rewrite a `loop` as tail recursion)
 - rust-lang/rust#150555 (Enable thumb interworking on ARMv7A/R and ARMv8R bare-metal targets)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=149778,150264,150548,150555)
<!-- homu-ignore:end -->