### PR TITLE
Finish transition from `semitransparent` to `semiopaque` for `rustc_macro_transparency`

### DIFF
--- a/compiler/rustc_arena/src/lib.rs
+++ b/compiler/rustc_arena/src/lib.rs
@@ -618,7 +618,7 @@ impl DroplessArena {
 /// - Types that are `!Copy` and `Drop`: these must be specified in the
 ///   arguments. The `TypedArena` will be used for them.
 ///
-#[rustc_macro_transparency = "semitransparent"]
+#[rustc_macro_transparency = "semiopaque"]
 pub macro declare_arena([$($a:tt $name:ident: $ty:ty,)*]) {
     #[derive(Default)]
     pub struct Arena<'tcx> {

--- a/compiler/rustc_attr_parsing/src/attributes/transparency.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/transparency.rs
@@ -15,7 +15,7 @@ impl<S: Stage> SingleAttributeParser<S> for TransparencyParser {
     });
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::MacroDef)]);
     const TEMPLATE: AttributeTemplate =
-        template!(NameValueStr: ["transparent", "semitransparent", "opaque"]);
+        template!(NameValueStr: ["transparent", "semiopaque", "opaque"]);
 
     fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
         let Some(nv) = args.name_value() else {
@@ -24,12 +24,12 @@ impl<S: Stage> SingleAttributeParser<S> for TransparencyParser {
         };
         match nv.value_as_str() {
             Some(sym::transparent) => Some(Transparency::Transparent),
-            Some(sym::semiopaque | sym::semitransparent) => Some(Transparency::SemiOpaque),
+            Some(sym::semiopaque) => Some(Transparency::SemiOpaque),
             Some(sym::opaque) => Some(Transparency::Opaque),
             Some(_) => {
                 cx.expected_specific_argument_strings(
                     nv.value_span,
-                    &[sym::transparent, sym::semitransparent, sym::opaque],
+                    &[sym::transparent, sym::semiopaque, sym::opaque],
                 );
                 None
             }

--- a/compiler/rustc_codegen_cranelift/example/mini_core.rs
+++ b/compiler/rustc_codegen_cranelift/example/mini_core.rs
@@ -744,43 +744,43 @@ unsafe extern "C" {
 pub struct VaList<'a>(&'a mut VaListImpl);
 
 #[rustc_builtin_macro]
-#[rustc_macro_transparency = "semitransparent"]
+#[rustc_macro_transparency = "semiopaque"]
 pub macro stringify($($t:tt)*) {
     /* compiler built-in */
 }
 
 #[rustc_builtin_macro]
-#[rustc_macro_transparency = "semitransparent"]
+#[rustc_macro_transparency = "semiopaque"]
 pub macro file() {
     /* compiler built-in */
 }
 
 #[rustc_builtin_macro]
-#[rustc_macro_transparency = "semitransparent"]
+#[rustc_macro_transparency = "semiopaque"]
 pub macro line() {
     /* compiler built-in */
 }
 
 #[rustc_builtin_macro]
-#[rustc_macro_transparency = "semitransparent"]
+#[rustc_macro_transparency = "semiopaque"]
 pub macro cfg() {
     /* compiler built-in */
 }
 
 #[rustc_builtin_macro]
-#[rustc_macro_transparency = "semitransparent"]
+#[rustc_macro_transparency = "semiopaque"]
 pub macro asm() {
     /* compiler built-in */
 }
 
 #[rustc_builtin_macro]
-#[rustc_macro_transparency = "semitransparent"]
+#[rustc_macro_transparency = "semiopaque"]
 pub macro global_asm() {
     /* compiler built-in */
 }
 
 #[rustc_builtin_macro]
-#[rustc_macro_transparency = "semitransparent"]
+#[rustc_macro_transparency = "semiopaque"]
 pub macro naked_asm() {
     /* compiler built-in */
 }

--- a/compiler/rustc_codegen_cranelift/src/global_asm.rs
+++ b/compiler/rustc_codegen_cranelift/src/global_asm.rs
@@ -233,7 +233,7 @@ pub(crate) fn compile_global_asm(
                 #![allow(internal_features)]
                 #![no_core]
                 #[rustc_builtin_macro]
-                #[rustc_macro_transparency = "semitransparent"]
+                #[rustc_macro_transparency = "semiopaque"]
                 macro global_asm() { /* compiler built-in */ }
                 global_asm!(r###"
                 "####,

--- a/compiler/rustc_codegen_gcc/example/mini_core.rs
+++ b/compiler/rustc_codegen_gcc/example/mini_core.rs
@@ -748,25 +748,25 @@ extern "C" {
 pub struct VaList<'a>(&'a mut VaListImpl);
 
 #[rustc_builtin_macro]
-#[rustc_macro_transparency = "semitransparent"]
+#[rustc_macro_transparency = "semiopaque"]
 pub macro stringify($($t:tt)*) {
     /* compiler built-in */
 }
 
 #[rustc_builtin_macro]
-#[rustc_macro_transparency = "semitransparent"]
+#[rustc_macro_transparency = "semiopaque"]
 pub macro file() {
     /* compiler built-in */
 }
 
 #[rustc_builtin_macro]
-#[rustc_macro_transparency = "semitransparent"]
+#[rustc_macro_transparency = "semiopaque"]
 pub macro line() {
     /* compiler built-in */
 }
 
 #[rustc_builtin_macro]
-#[rustc_macro_transparency = "semitransparent"]
+#[rustc_macro_transparency = "semiopaque"]
 pub macro cfg() {
     /* compiler built-in */
 }

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -2041,7 +2041,6 @@ symbols! {
         self_in_typedefs,
         self_struct_ctor,
         semiopaque,
-        semitransparent,
         sha2,
         sha3,
         sha512_sm_x86,

--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -168,7 +168,7 @@ macro_rules! assert_ne {
 /// ```
 #[unstable(feature = "assert_matches", issue = "82775")]
 #[allow_internal_unstable(panic_internals)]
-#[rustc_macro_transparency = "semitransparent"]
+#[rustc_macro_transparency = "semiopaque"]
 pub macro assert_matches {
     ($left:expr, $(|)? $( $pattern:pat_param )|+ $( if $guard: expr )? $(,)?) => {
         match $left {
@@ -401,7 +401,7 @@ macro_rules! debug_assert_ne {
 /// ```
 #[unstable(feature = "assert_matches", issue = "82775")]
 #[allow_internal_unstable(assert_matches)]
-#[rustc_macro_transparency = "semitransparent"]
+#[rustc_macro_transparency = "semiopaque"]
 pub macro debug_assert_matches($($arg:tt)*) {
     if $crate::cfg!(debug_assertions) {
         $crate::assert_matches::assert_matches!($($arg)*);

--- a/library/core/src/panic.rs
+++ b/library/core/src/panic.rs
@@ -20,7 +20,7 @@ use crate::any::Any;
 #[unstable(feature = "edition_panic", issue = "none", reason = "use panic!() instead")]
 #[allow_internal_unstable(panic_internals, const_format_args)]
 #[rustc_diagnostic_item = "core_panic_2015_macro"]
-#[rustc_macro_transparency = "semitransparent"]
+#[rustc_macro_transparency = "semiopaque"]
 pub macro panic_2015 {
     () => (
         $crate::panicking::panic("explicit panic")
@@ -47,7 +47,7 @@ pub macro panic_2015 {
 #[unstable(feature = "edition_panic", issue = "none", reason = "use panic!() instead")]
 #[allow_internal_unstable(panic_internals, const_format_args)]
 #[rustc_diagnostic_item = "core_panic_2021_macro"]
-#[rustc_macro_transparency = "semitransparent"]
+#[rustc_macro_transparency = "semiopaque"]
 pub macro panic_2021 {
     () => (
         $crate::panicking::panic("explicit panic")
@@ -67,7 +67,7 @@ pub macro panic_2021 {
 #[unstable(feature = "edition_panic", issue = "none", reason = "use unreachable!() instead")]
 #[allow_internal_unstable(panic_internals)]
 #[rustc_diagnostic_item = "unreachable_2015_macro"]
-#[rustc_macro_transparency = "semitransparent"]
+#[rustc_macro_transparency = "semiopaque"]
 pub macro unreachable_2015 {
     () => (
         $crate::panicking::panic("internal error: entered unreachable code")
@@ -85,7 +85,7 @@ pub macro unreachable_2015 {
 #[doc(hidden)]
 #[unstable(feature = "edition_panic", issue = "none", reason = "use unreachable!() instead")]
 #[allow_internal_unstable(panic_internals)]
-#[rustc_macro_transparency = "semitransparent"]
+#[rustc_macro_transparency = "semiopaque"]
 pub macro unreachable_2021 {
     () => (
         $crate::panicking::panic("internal error: entered unreachable code")

--- a/library/core/src/pin.rs
+++ b/library/core/src/pin.rs
@@ -2027,7 +2027,7 @@ unsafe impl<T: ?Sized> PinCoerceUnsized for *mut T {}
 ///
 /// [`Box::pin`]: ../../std/boxed/struct.Box.html#method.pin
 #[stable(feature = "pin_macro", since = "1.68.0")]
-#[rustc_macro_transparency = "semitransparent"]
+#[rustc_macro_transparency = "semiopaque"]
 #[allow_internal_unstable(super_let)]
 #[rustc_diagnostic_item = "pin_macro"]
 // `super` gets removed by rustfmt

--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -2662,7 +2662,7 @@ impl<F: FnPtr> fmt::Debug for F {
 /// same requirements apply to field projections, even inside `addr_of!`. (In particular, it makes
 /// no difference whether the pointer is null or dangling.)
 #[stable(feature = "raw_ref_macros", since = "1.51.0")]
-#[rustc_macro_transparency = "semitransparent"]
+#[rustc_macro_transparency = "semiopaque"]
 pub macro addr_of($place:expr) {
     &raw const $place
 }
@@ -2752,7 +2752,7 @@ pub macro addr_of($place:expr) {
 /// same requirements apply to field projections, even inside `addr_of_mut!`. (In particular, it
 /// makes no difference whether the pointer is null or dangling.)
 #[stable(feature = "raw_ref_macros", since = "1.51.0")]
-#[rustc_macro_transparency = "semitransparent"]
+#[rustc_macro_transparency = "semiopaque"]
 pub macro addr_of_mut($place:expr) {
     &raw mut $place
 }

--- a/library/core/src/task/ready.rs
+++ b/library/core/src/task/ready.rs
@@ -46,7 +46,7 @@
 /// # }
 /// ```
 #[stable(feature = "ready_macro", since = "1.64.0")]
-#[rustc_macro_transparency = "semitransparent"]
+#[rustc_macro_transparency = "semiopaque"]
 pub macro ready($e:expr) {
     match $e {
         $crate::task::Poll::Ready(t) => t,

--- a/library/std/src/io/error.rs
+++ b/library/std/src/io/error.rs
@@ -187,7 +187,7 @@ pub struct SimpleMessage {
 ///     Err(FAIL)
 /// }
 /// ```
-#[rustc_macro_transparency = "semitransparent"]
+#[rustc_macro_transparency = "semiopaque"]
 #[unstable(feature = "io_const_error", issue = "133448")]
 #[allow_internal_unstable(hint_must_use, io_const_error_internals)]
 pub macro const_error($kind:expr, $message:expr $(,)?) {

--- a/library/std/src/panic.rs
+++ b/library/std/src/panic.rs
@@ -212,7 +212,7 @@ impl fmt::Display for PanicHookInfo<'_> {
 #[unstable(feature = "edition_panic", issue = "none", reason = "use panic!() instead")]
 #[allow_internal_unstable(libstd_sys_internals, const_format_args, panic_internals, rt)]
 #[cfg_attr(not(test), rustc_diagnostic_item = "std_panic_2015_macro")]
-#[rustc_macro_transparency = "semitransparent"]
+#[rustc_macro_transparency = "semiopaque"]
 pub macro panic_2015 {
     () => ({
         $crate::rt::begin_panic("explicit panic")

--- a/library/std/src/sys/thread_local/native/mod.rs
+++ b/library/std/src/sys/thread_local/native/mod.rs
@@ -47,7 +47,7 @@ pub use lazy::Storage as LazyStorage;
 )]
 #[allow_internal_unsafe]
 #[unstable(feature = "thread_local_internals", issue = "none")]
-#[rustc_macro_transparency = "semitransparent"]
+#[rustc_macro_transparency = "semiopaque"]
 pub macro thread_local_inner {
     // NOTE: we cannot import `LocalKey`, `LazyStorage` or `EagerStorage` with a `use` because that
     // can shadow user provided type or type alias with a matching name. Please update the shadowing
@@ -110,7 +110,7 @@ pub macro thread_local_inner {
     }},
 }
 
-#[rustc_macro_transparency = "semitransparent"]
+#[rustc_macro_transparency = "semiopaque"]
 pub(crate) macro local_pointer {
     () => {},
     ($vis:vis static $name:ident; $($rest:tt)*) => {

--- a/library/std/src/sys/thread_local/no_threads.rs
+++ b/library/std/src/sys/thread_local/no_threads.rs
@@ -9,7 +9,7 @@ use crate::ptr;
 #[allow_internal_unstable(thread_local_internals)]
 #[allow_internal_unsafe]
 #[unstable(feature = "thread_local_internals", issue = "none")]
-#[rustc_macro_transparency = "semitransparent"]
+#[rustc_macro_transparency = "semiopaque"]
 pub macro thread_local_inner {
     // used to generate the `LocalKey` value for const-initialized thread locals
     (@key $t:ty, $(#[$align_attr:meta])*, const $init:expr) => {{
@@ -119,7 +119,7 @@ impl<T> LazyStorage<T> {
 // SAFETY: the target doesn't have threads.
 unsafe impl<T> Sync for LazyStorage<T> {}
 
-#[rustc_macro_transparency = "semitransparent"]
+#[rustc_macro_transparency = "semiopaque"]
 pub(crate) macro local_pointer {
     () => {},
     ($vis:vis static $name:ident; $($rest:tt)*) => {

--- a/library/std/src/sys/thread_local/os.rs
+++ b/library/std/src/sys/thread_local/os.rs
@@ -12,7 +12,7 @@ use crate::ptr::{self, NonNull};
 #[allow_internal_unstable(thread_local_internals)]
 #[allow_internal_unsafe]
 #[unstable(feature = "thread_local_internals", issue = "none")]
-#[rustc_macro_transparency = "semitransparent"]
+#[rustc_macro_transparency = "semiopaque"]
 pub macro thread_local_inner {
     // NOTE: we cannot import `Storage` or `LocalKey` with a `use` because that can shadow user
     // provided type or type alias with a matching name. Please update the shadowing test in
@@ -261,7 +261,7 @@ unsafe extern "C" fn destroy_value<T: 'static, const ALIGN: usize>(ptr: *mut u8)
     });
 }
 
-#[rustc_macro_transparency = "semitransparent"]
+#[rustc_macro_transparency = "semiopaque"]
 pub(crate) macro local_pointer {
     () => {},
     ($vis:vis static $name:ident; $($rest:tt)*) => {

--- a/library/std/src/thread/local.rs
+++ b/library/std/src/thread/local.rs
@@ -140,7 +140,7 @@ impl<T: 'static> fmt::Debug for LocalKey<T> {
 #[doc(hidden)]
 #[allow_internal_unstable(thread_local_internals)]
 #[unstable(feature = "thread_local_internals", issue = "none")]
-#[rustc_macro_transparency = "semitransparent"]
+#[rustc_macro_transparency = "semiopaque"]
 pub macro thread_local_process_attrs {
 
     // Parse `cfg_attr` to figure out whether it's a `rustc_align_static`.

--- a/src/tools/rust-analyzer/crates/hir-def/src/expr_store/expander.rs
+++ b/src/tools/rust-analyzer/crates/hir-def/src/expr_store/expander.rs
@@ -61,7 +61,7 @@ impl Expander {
     pub(super) fn hygiene_for_range(&self, db: &dyn DefDatabase, range: TextRange) -> HygieneId {
         match self.span_map.as_ref() {
             hir_expand::span_map::SpanMapRef::ExpansionSpanMap(span_map) => {
-                HygieneId::new(span_map.span_at(range.start()).ctx.opaque_and_semitransparent(db))
+                HygieneId::new(span_map.span_at(range.start()).ctx.opaque_and_semiopaque(db))
             }
             hir_expand::span_map::SpanMapRef::RealSpanMap(_) => HygieneId::ROOT,
         }

--- a/src/tools/rust-analyzer/crates/hir-def/src/expr_store/lower.rs
+++ b/src/tools/rust-analyzer/crates/hir-def/src/expr_store/lower.rs
@@ -2546,7 +2546,7 @@ impl<'db> ExprCollector<'db> {
                         // Therefore, if we got to the rib of its declaration, give up its hygiene
                         // and use its parent expansion.
 
-                        hygiene_id = HygieneId::new(parent_ctx.opaque_and_semitransparent(self.db));
+                        hygiene_id = HygieneId::new(parent_ctx.opaque_and_semiopaque(self.db));
                         hygiene_info = parent_ctx.outer_expn(self.db).map(|expansion| {
                             let expansion = self.db.lookup_intern_macro_call(expansion.into());
                             (parent_ctx.parent(self.db), expansion.def)

--- a/src/tools/rust-analyzer/crates/hir-def/src/resolver.rs
+++ b/src/tools/rust-analyzer/crates/hir-def/src/resolver.rs
@@ -936,7 +936,7 @@ fn handle_macro_def_scope(
         // A macro is allowed to refer to variables from before its declaration.
         // Therefore, if we got to the rib of its declaration, give up its hygiene
         // and use its parent expansion.
-        *hygiene_id = HygieneId::new(parent_ctx.opaque_and_semitransparent(db));
+        *hygiene_id = HygieneId::new(parent_ctx.opaque_and_semiopaque(db));
         *hygiene_info = parent_ctx.outer_expn(db).map(|expansion| {
             let expansion = db.lookup_intern_macro_call(expansion.into());
             (parent_ctx.parent(db), expansion.def)

--- a/src/tools/rust-analyzer/crates/hir-expand/src/declarative.rs
+++ b/src/tools/rust-analyzer/crates/hir-expand/src/declarative.rs
@@ -100,7 +100,8 @@ impl DeclarativeMacroExpander {
                     {
                         match &*value {
                             "transparent" => ControlFlow::Break(Transparency::Transparent),
-                            "semitransparent" => ControlFlow::Break(Transparency::SemiTransparent),
+                            // "semitransparent" is for old rustc versions.
+                            "semiopaque" | "semitransparent" => ControlFlow::Break(Transparency::SemiOpaque),
                             "opaque" => ControlFlow::Break(Transparency::Opaque),
                             _ => ControlFlow::Continue(()),
                         }
@@ -140,7 +141,7 @@ impl DeclarativeMacroExpander {
                     )),
                 },
                 transparency(ast::AnyHasAttrs::from(macro_rules))
-                    .unwrap_or(Transparency::SemiTransparent),
+                    .unwrap_or(Transparency::SemiOpaque),
             ),
             ast::Macro::MacroDef(macro_def) => (
                 match macro_def.body() {

--- a/src/tools/rust-analyzer/crates/hir-expand/src/hygiene.rs
+++ b/src/tools/rust-analyzer/crates/hir-expand/src/hygiene.rs
@@ -54,7 +54,7 @@ pub fn span_with_mixed_site_ctxt(
     expn_id: MacroCallId,
     edition: Edition,
 ) -> Span {
-    span_with_ctxt_from_mark(db, span, expn_id, Transparency::SemiTransparent, edition)
+    span_with_ctxt_from_mark(db, span, expn_id, Transparency::SemiOpaque, edition)
 }
 
 fn span_with_ctxt_from_mark(
@@ -82,7 +82,7 @@ pub(super) fn apply_mark(
     }
 
     let call_site_ctxt = db.lookup_intern_macro_call(call_id.into()).ctxt;
-    let mut call_site_ctxt = if transparency == Transparency::SemiTransparent {
+    let mut call_site_ctxt = if transparency == Transparency::SemiOpaque {
         call_site_ctxt.normalize_to_macros_2_0(db)
     } else {
         call_site_ctxt.normalize_to_macro_rules(db)
@@ -117,16 +117,16 @@ fn apply_mark_internal(
     let call_id = Some(call_id);
 
     let mut opaque = ctxt.opaque(db);
-    let mut opaque_and_semitransparent = ctxt.opaque_and_semitransparent(db);
+    let mut opaque_and_semiopaque = ctxt.opaque_and_semiopaque(db);
 
     if transparency >= Transparency::Opaque {
         let parent = opaque;
         opaque = SyntaxContext::new(db, call_id, transparency, edition, parent, identity, identity);
     }
 
-    if transparency >= Transparency::SemiTransparent {
-        let parent = opaque_and_semitransparent;
-        opaque_and_semitransparent =
+    if transparency >= Transparency::SemiOpaque {
+        let parent = opaque_and_semiopaque;
+        opaque_and_semiopaque =
             SyntaxContext::new(db, call_id, transparency, edition, parent, |_| opaque, identity);
     }
 
@@ -138,6 +138,6 @@ fn apply_mark_internal(
         edition,
         parent,
         |_| opaque,
-        |_| opaque_and_semitransparent,
+        |_| opaque_and_semiopaque,
     )
 }

--- a/src/tools/rust-analyzer/crates/hir-expand/src/inert_attr_macro.rs
+++ b/src/tools/rust-analyzer/crates/hir-expand/src/inert_attr_macro.rs
@@ -429,7 +429,7 @@ pub const INERT_ATTRIBUTES: &[BuiltinAttribute] = &[
     rustc_attr!(rustc_proc_macro_decls, Normal, template!(Word), WarnFollowing, INTERNAL_UNSTABLE),
     rustc_attr!(
         rustc_macro_transparency, Normal,
-        template!(NameValueStr: "transparent|semitransparent|opaque"), ErrorFollowing,
+        template!(NameValueStr: "transparent|semiopaque|opaque"), ErrorFollowing,
         "used internally for testing macro hygiene",
     ),
 

--- a/src/tools/rust-analyzer/crates/hir-expand/src/mod_path.rs
+++ b/src/tools/rust-analyzer/crates/hir-expand/src/mod_path.rs
@@ -401,8 +401,8 @@ pub fn resolve_crate_root(db: &dyn ExpandDatabase, mut ctxt: SyntaxContext) -> O
         result_mark = Some(mark);
         iter.next();
     }
-    // Then find the last semi-transparent mark from the end if it exists.
-    while let Some((mark, Transparency::SemiTransparent)) = iter.next() {
+    // Then find the last semi-opaque mark from the end if it exists.
+    while let Some((mark, Transparency::SemiOpaque)) = iter.next() {
         result_mark = Some(mark);
     }
 

--- a/src/tools/rust-analyzer/crates/hir-ty/src/tests/simple.rs
+++ b/src/tools/rust-analyzer/crates/hir-ty/src/tests/simple.rs
@@ -3708,7 +3708,7 @@ fn main() {
 }
 
 #[test]
-fn macro_semitransparent_hygiene() {
+fn macro_semiopaque_hygiene() {
     check_types(
         r#"
 macro_rules! m {

--- a/src/tools/rust-analyzer/crates/hir/src/source_analyzer.rs
+++ b/src/tools/rust-analyzer/crates/hir/src/source_analyzer.rs
@@ -1808,5 +1808,5 @@ pub(crate) fn name_hygiene(db: &dyn HirDatabase, name: InFile<&SyntaxNode>) -> H
     };
     let span_map = db.expansion_span_map(macro_file);
     let ctx = span_map.span_at(name.value.text_range().start()).ctx;
-    HygieneId::new(ctx.opaque_and_semitransparent(db))
+    HygieneId::new(ctx.opaque_and_semiopaque(db))
 }

--- a/src/tools/rust-analyzer/crates/intern/src/symbol/symbols.rs
+++ b/src/tools/rust-analyzer/crates/intern/src/symbol/symbols.rs
@@ -442,7 +442,6 @@ define_symbols! {
     rustc_skip_array_during_method_dispatch,
     rustc_skip_during_method_dispatch,
     rustc_force_inline,
-    semitransparent,
     shl_assign,
     shl,
     shr_assign,

--- a/src/tools/rust-analyzer/crates/test-utils/src/minicore.rs
+++ b/src/tools/rust-analyzer/crates/test-utils/src/minicore.rs
@@ -546,11 +546,11 @@ pub mod ptr {
     // endregion:non_null
 
     // region:addr_of
-    #[rustc_macro_transparency = "semitransparent"]
+    #[rustc_macro_transparency = "semiopaque"]
     pub macro addr_of($place:expr) {
         &raw const $place
     }
-    #[rustc_macro_transparency = "semitransparent"]
+    #[rustc_macro_transparency = "semiopaque"]
     pub macro addr_of_mut($place:expr) {
         &raw mut $place
     }

--- a/tests/rustdoc-html/macro/macro_pub_in_module.rs
+++ b/tests/rustdoc-html/macro/macro_pub_in_module.rs
@@ -33,7 +33,7 @@ pub mod inner {
     // Make sure the logic is not affected by re-exports.
     mod unrenamed {
         //@ !has krate/macro.unrenamed.html
-        #[rustc_macro_transparency = "semitransparent"]
+        #[rustc_macro_transparency = "semiopaque"]
         pub macro unrenamed() {}
     }
     //@ has krate/inner/macro.unrenamed.html

--- a/tests/ui/attributes/malformed-attrs.stderr
+++ b/tests/ui/attributes/malformed-attrs.stderr
@@ -223,8 +223,8 @@ help: try changing it to one of the following valid forms of the attribute
    |
 LL | #[rustc_macro_transparency = "opaque"]
    |                            ++++++++++
-LL | #[rustc_macro_transparency = "semitransparent"]
-   |                            +++++++++++++++++++
+LL | #[rustc_macro_transparency = "semiopaque"]
+   |                            ++++++++++++++
 LL | #[rustc_macro_transparency = "transparent"]
    |                            +++++++++++++++
 

--- a/tests/ui/hygiene/duplicate_lifetimes.rs
+++ b/tests/ui/hygiene/duplicate_lifetimes.rs
@@ -3,7 +3,7 @@
 
 #![feature(decl_macro, rustc_attrs)]
 
-#[rustc_macro_transparency = "semitransparent"]
+#[rustc_macro_transparency = "semiopaque"]
 macro m($a:lifetime) {
     fn g<$a, 'a>() {} //~ ERROR the name `'a` is already used for a generic parameter
 }

--- a/tests/ui/hygiene/generic_params.rs
+++ b/tests/ui/hygiene/generic_params.rs
@@ -11,7 +11,7 @@ mod type_params {
         }
     }
 
-    #[rustc_macro_transparency = "semitransparent"]
+    #[rustc_macro_transparency = "semiopaque"]
     macro n($T:ident) {
         fn g<$T: Clone>(t1: $T, t2: T) -> (T, $T) {
             (t1.clone(), t2.clone())
@@ -43,7 +43,7 @@ mod lifetime_params {
         }
     }
 
-    #[rustc_macro_transparency = "semitransparent"]
+    #[rustc_macro_transparency = "semiopaque"]
     macro n($a:lifetime) {
         fn g<$a>(t1: &$a(), t2: &'a ()) -> (&'a (), &$a ()) {
             (t1, t2)
@@ -75,7 +75,7 @@ mod const_params {
         }
     }
 
-    #[rustc_macro_transparency = "semitransparent"]
+    #[rustc_macro_transparency = "semiopaque"]
     macro n($C:ident) {
         fn g<const $C: usize>(t1: [(); $C], t2: [(); C]) -> ([(); C], [(); $C]) {
             (t1, t2)

--- a/tests/ui/hygiene/rustc-macro-transparency.rs
+++ b/tests/ui/hygiene/rustc-macro-transparency.rs
@@ -5,7 +5,7 @@ macro transparent() {
     struct Transparent;
     let transparent = 0;
 }
-#[rustc_macro_transparency = "semitransparent"]
+#[rustc_macro_transparency = "semiopaque"]
 macro semiopaque() {
     struct SemiOpaque;
     let semiopaque = 0;

--- a/tests/ui/single-use-lifetime/issue-104440.rs
+++ b/tests/ui/single-use-lifetime/issue-104440.rs
@@ -8,7 +8,7 @@ mod type_params {
         }
     }
 
-    #[rustc_macro_transparency = "semitransparent"]
+    #[rustc_macro_transparency = "semiopaque"]
     macro n($T:ident) {
         fn g<$T: Clone>(t1: $T, t2: T) -> (T, $T) {
             (t1.clone(), t2.clone())
@@ -40,7 +40,7 @@ mod lifetime_params {
         }
     }
 
-    #[rustc_macro_transparency = "semitransparent"]
+    #[rustc_macro_transparency = "semiopaque"]
     macro n($a:lifetime) {
         fn g<$a>(t1: &$a(), t2: &'a ()) -> (&'a (), &$a ()) {
             (t1, t2)
@@ -72,7 +72,7 @@ mod const_params {
         }
     }
 
-    #[rustc_macro_transparency = "semitransparent"]
+    #[rustc_macro_transparency = "semiopaque"]
     macro n($C:ident) {
         fn g<const $C: usize>(t1: [(); $C], t2: [(); C]) -> ([(); C], [(); $C]) {
             (t1, t2)


### PR DESCRIPTION
Since it's a bit annoying to have different names for the same thing.

My understanding is that this is just internal stuff that is not part of any public API even tough rust-analyzer knows about it.

Continuation of
- https://github.com/rust-lang/rust/pull/139084.

Discovered while investigating
- https://github.com/rust-lang/rust/issues/150514