### PR TITLE
Fix doc link used in suggestion for pinning self

### DIFF
--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -3589,8 +3589,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 "method `poll` found on `Pin<&mut {ty_str}>`, \
                 see documentation for `std::pin::Pin`"
             ));
-            err.help("self type must be pinned to call `Future::poll`, \
-                see https://rust-lang.github.io/async-book/04_pinning/01_chapter.html#pinning-in-practice"
+            err.help(
+                "self type must be pinned to call `Future::poll`, \
+                see https://rust-lang.github.io/async-book/part-reference/pinning.html",
             );
         }
 

--- a/tests/ui/async-await/issue-108572.stderr
+++ b/tests/ui/async-await/issue-108572.stderr
@@ -5,7 +5,7 @@ LL |     fut.poll(cx);
    |         ^^^^ method not found in `impl Future<Output = ()>`
    |
    = help: method `poll` found on `Pin<&mut impl Future<Output = ()>>`, see documentation for `std::pin::Pin`
-   = help: self type must be pinned to call `Future::poll`, see https://rust-lang.github.io/async-book/04_pinning/01_chapter.html#pinning-in-practice
+   = help: self type must be pinned to call `Future::poll`, see https://rust-lang.github.io/async-book/part-reference/pinning.html
 help: consider pinning the expression
    |
 LL ~     let mut pinned = std::pin::pin!(fut);


### PR DESCRIPTION
Fixes rust-lang/rust#147901

The old suggestion linked to a documentation page that [no longer exists](https://rust-lang.github.io/async-book/04_pinning/01_chapter.html#pinning-in-practice). Presumably, [this](https://rust-lang.github.io/async-book/part-reference/pinning.html) is the better place to link to now