### PR TITLE
Added codegen tests for different forms of `Option::or`

### DIFF
--- a/tests/codegen-llvm/issues/multiple-option-or-permutations.rs
+++ b/tests/codegen-llvm/issues/multiple-option-or-permutations.rs
@@ -19,6 +19,7 @@ pub fn or_match_u8(opta: Option<u8>, optb: Option<u8>) -> Option<u8> {
 }
 
 // CHECK-LABEL: @or_match_alt_u8
+// CHECK-SAME: (i1{{.+}}%opta.0, i8 %opta.1, i1{{.+}}%optb.0, i8 %optb.1)
 #[no_mangle]
 pub fn or_match_alt_u8(opta: Option<u8>, optb: Option<u8>) -> Option<u8> {
     // CHECK: start:
@@ -58,6 +59,7 @@ pub fn if_some_u8(opta: Option<u8>, optb: Option<u8>) -> Option<u8> {
 }
 
 // CHECK-LABEL: @or_match_slice_u8
+// CHECK-SAME: (i16 %0, i16 %1)
 #[no_mangle]
 pub fn or_match_slice_u8(opta: Option<[u8; 1]>, optb: Option<[u8; 1]>) -> Option<[u8; 1]> {
     // CHECK: start:

--- a/tests/codegen-llvm/issues/multiple-option-or-permutations.rs
+++ b/tests/codegen-llvm/issues/multiple-option-or-permutations.rs
@@ -1,0 +1,155 @@
+// Tests output of multiple permutations of `Option::or`
+//@ compile-flags: -Copt-level=3 -Zmerge-functions=disabled
+
+#![crate_type = "lib"]
+
+// CHECK-LABEL: @or_match_u8
+#[no_mangle]
+pub fn or_match_u8(opta: Option<u8>, optb: Option<u8>) -> Option<u8> {
+    // CHECK: start:
+    // CHECK-NEXT: or i1 %0
+    // CHECK-NEXT: select i1 %0
+    // CHECK-NEXT: insertvalue { i1, i8 }
+    // CHECK-NEXT: insertvalue { i1, i8 }
+    // ret { i1, i8 }
+    match opta {
+        Some(x) => Some(x),
+        None => optb,
+    }
+}
+
+// CHECK-LABEL: @or_match_alt_u8
+#[no_mangle]
+pub fn or_match_alt_u8(opta: Option<u8>, optb: Option<u8>) -> Option<u8> {
+    // CHECK: start:
+    // CHECK-NEXT: select i1
+    // CHECK-NEXT: or i1
+    // CHECK-NEXT: insertvalue { i1, i8 }
+    // CHECK-NEXT: insertvalue { i1, i8 }
+    // ret { i1, i8 }
+    match opta {
+        Some(_) => opta,
+        None => optb,
+    }
+}
+
+// CHECK-LABEL: @option_or_u8
+#[no_mangle]
+pub fn option_or_u8(opta: Option<u8>, optb: Option<u8>) -> Option<u8> {
+    // CHECK: start:
+    // CHECK-NEXT: select i1
+    // CHECK-NEXT: or i1
+    // CHECK-NEXT: insertvalue { i1, i8 }
+    // CHECK-NEXT: insertvalue { i1, i8 }
+    // ret { i1, i8 }
+    opta.or(optb)
+}
+
+// CHECK-LABEL: @if_some_u8
+#[no_mangle]
+pub fn if_some_u8(opta: Option<u8>, optb: Option<u8>) -> Option<u8> {
+    // CHECK: start:
+    // CHECK-NEXT: select i1
+    // CHECK-NEXT: or i1
+    // CHECK-NEXT: insertvalue { i1, i8 }
+    // CHECK-NEXT: insertvalue { i1, i8 }
+    // ret { i1, i8 }
+    if opta.is_some() { opta } else { optb }
+}
+
+// CHECK-LABEL: @or_match_slice_u8
+#[no_mangle]
+pub fn or_match_slice_u8(opta: Option<[u8; 1]>, optb: Option<[u8; 1]>) -> Option<[u8; 1]> {
+    // CHECK: start:
+    // CHECK-NEXT: trunc i16 %0 to i1
+    // CHECK-NEXT: select i1 %2, i16 %0, i16 %1
+    // ret i16
+    match opta {
+        Some(x) => Some(x),
+        None => optb,
+    }
+}
+
+// CHECK-LABEL: @or_match_slice_alt_u8
+#[no_mangle]
+pub fn or_match_slice_alt_u8(opta: Option<[u8; 1]>, optb: Option<[u8; 1]>) -> Option<[u8; 1]> {
+    // CHECK: start:
+    // CHECK-NEXT: trunc i16 %0 to i1
+    // CHECK-NEXT: select i1 %2, i16 %0, i16 %1
+    // ret i16
+    match opta {
+        Some(_) => opta,
+        None => optb,
+    }
+}
+
+// CHECK-LABEL: @option_or_slice_u8
+#[no_mangle]
+pub fn option_or_slice_u8(opta: Option<[u8; 1]>, optb: Option<[u8; 1]>) -> Option<[u8; 1]> {
+    // CHECK: start:
+    // CHECK-NEXT: trunc i16 %0 to i1
+    // CHECK-NEXT: select i1 %2, i16 %0, i16 %1
+    // ret i16
+    opta.or(optb)
+}
+
+// CHECK-LABEL: @if_some_slice_u8
+#[no_mangle]
+pub fn if_some_slice_u8(opta: Option<[u8; 1]>, optb: Option<[u8; 1]>) -> Option<[u8; 1]> {
+    // CHECK: start:
+    // CHECK-NEXT: trunc i16 %0 to i1
+    // CHECK-NEXT: select i1 %2, i16 %0, i16 %1
+    // ret i16
+    if opta.is_some() { opta } else { optb }
+}
+
+pub struct Test {
+    _a: u8,
+    _b: u8,
+}
+
+// CHECK-LABEL: @or_match_type
+#[no_mangle]
+pub fn or_match_type(opta: Option<Test>, optb: Option<Test>) -> Option<Test> {
+    // CHECK: start:
+    // CHECK-NEXT: trunc i24 %0 to i1
+    // CHECK-NEXT: select i1 %2, i24 %0, i24 %1
+    // ret i24
+    match opta {
+        Some(x) => Some(x),
+        None => optb,
+    }
+}
+
+// CHECK-LABEL: @or_match_alt_type
+#[no_mangle]
+pub fn or_match_alt_type(opta: Option<Test>, optb: Option<Test>) -> Option<Test> {
+    // CHECK: start:
+    // CHECK-NEXT: trunc i24 %0 to i1
+    // CHECK-NEXT: select i1 %2, i24 %0, i24 %1
+    // ret i24
+    match opta {
+        Some(_) => opta,
+        None => optb,
+    }
+}
+
+// CHECK-LABEL: @option_or_type
+#[no_mangle]
+pub fn option_or_type(opta: Option<Test>, optb: Option<Test>) -> Option<Test> {
+    // CHECK: start:
+    // CHECK-NEXT: trunc i24 %0 to i1
+    // CHECK-NEXT: select i1 %2, i24 %0, i24 %1
+    // ret i24
+    opta.or(optb)
+}
+
+// CHECK-LABEL: @if_some_type
+#[no_mangle]
+pub fn if_some_type(opta: Option<Test>, optb: Option<Test>) -> Option<Test> {
+    // CHECK: start:
+    // CHECK-NEXT: trunc i24 %0 to i1
+    // CHECK-NEXT: select i1 %2, i24 %0, i24 %1
+    // ret i24
+    if opta.is_some() { opta } else { optb }
+}

--- a/tests/codegen-llvm/issues/multiple-option-or-permutations.rs
+++ b/tests/codegen-llvm/issues/multiple-option-or-permutations.rs
@@ -10,11 +10,11 @@ use std::num::NonZero;
 #[no_mangle]
 pub fn or_match_u8(opta: Option<u8>, optb: Option<u8>) -> Option<u8> {
     // CHECK: start:
-    // CHECK-DAG: select i1 %0
-    // CHECK-DAG: or i1 %0
-    // CHECK-NEXT: insertvalue { i1, i8 }
-    // CHECK-NEXT: insertvalue { i1, i8 }
-    // ret { i1, i8 }
+    // CHECK-DAG: [[A_OR_B:%.+]] = select i1 %0, i8 %1, i8 %optb.1
+    // CHECK-DAG: [[IS_SOME:%.+]] = or i1 {{%0, %optb.0|%optb.0, %0}}
+    // CHECK-NEXT: [[FLAG:%.+]] = insertvalue { i1, i8 } poison, i1 [[IS_SOME]], 0
+    // CHECK-NEXT: [[R:%.+]] = insertvalue { i1, i8 } [[FLAG]], i8 [[A_OR_B]], 1
+    // CHECK: ret { i1, i8 } [[R]]
     match opta {
         Some(x) => Some(x),
         None => optb,
@@ -26,11 +26,11 @@ pub fn or_match_u8(opta: Option<u8>, optb: Option<u8>) -> Option<u8> {
 #[no_mangle]
 pub fn or_match_alt_u8(opta: Option<u8>, optb: Option<u8>) -> Option<u8> {
     // CHECK: start:
-    // CHECK-DAG: select i1 %opta.0, i8 %opta.1, i8 %optb.1
-    // CHECK-DAG: or i1 {{%opta.0, %optb.0|%optb.0, %opta.0}}
-    // CHECK-NEXT: insertvalue { i1, i8 }
-    // CHECK-NEXT: insertvalue { i1, i8 }
-    // ret { i1, i8 }
+    // CHECK-DAG: [[A_OR_B:%.+]] = select i1 %opta.0, i8 %opta.1, i8 %optb.1
+    // CHECK-DAG: [[IS_SOME:%.+]] = or i1 {{%opta.0, %optb.0|%optb.0, %opta.0}}
+    // CHECK-NEXT: [[FLAG:%.+]] = insertvalue { i1, i8 } poison, i1 [[IS_SOME]], 0
+    // CHECK-NEXT: [[R:%.+]] = insertvalue { i1, i8 } [[FLAG]], i8 [[A_OR_B]], 1
+    // CHECK: ret { i1, i8 } [[R]]
     match opta {
         Some(_) => opta,
         None => optb,
@@ -42,11 +42,11 @@ pub fn or_match_alt_u8(opta: Option<u8>, optb: Option<u8>) -> Option<u8> {
 #[no_mangle]
 pub fn option_or_u8(opta: Option<u8>, optb: Option<u8>) -> Option<u8> {
     // CHECK: start:
-    // CHECK-DAG: select i1
-    // CHECK-DAG: or i1
-    // CHECK-NEXT: insertvalue { i1, i8 }
-    // CHECK-NEXT: insertvalue { i1, i8 }
-    // ret { i1, i8 }
+    // CHECK-DAG: [[A_OR_B:%.+]] = select i1 %opta.0, i8 %opta.1, i8 %optb.1
+    // CHECK-DAG: [[IS_SOME:%.+]] = or i1 {{%opta.0, %optb.0|%optb.0, %opta.0}}
+    // CHECK-NEXT: [[FLAG:%.+]] = insertvalue { i1, i8 } poison, i1 [[IS_SOME]], 0
+    // CHECK-NEXT: [[R:%.+]] = insertvalue { i1, i8 } [[FLAG]], i8 [[A_OR_B]], 1
+    // CHECK: ret { i1, i8 } [[R]]
     opta.or(optb)
 }
 
@@ -55,11 +55,11 @@ pub fn option_or_u8(opta: Option<u8>, optb: Option<u8>) -> Option<u8> {
 #[no_mangle]
 pub fn if_some_u8(opta: Option<u8>, optb: Option<u8>) -> Option<u8> {
     // CHECK: start:
-    // CHECK-DAG: select i1
-    // CHECK-DAG: or i1
-    // CHECK-NEXT: insertvalue { i1, i8 }
-    // CHECK-NEXT: insertvalue { i1, i8 }
-    // ret { i1, i8 }
+    // CHECK-DAG: [[A_OR_B:%.+]] = select i1 %opta.0, i8 %opta.1, i8 %optb.1
+    // CHECK-DAG: [[IS_SOME:%.+]] = or i1 {{%opta.0, %optb.0|%optb.0, %opta.0}}
+    // CHECK-NEXT: [[FLAG:%.+]] = insertvalue { i1, i8 } poison, i1 [[IS_SOME]], 0
+    // CHECK-NEXT: [[R:%.+]] = insertvalue { i1, i8 } [[FLAG]], i8 [[A_OR_B]], 1
+    // CHECK: ret { i1, i8 } [[R]]
     if opta.is_some() { opta } else { optb }
 }
 
@@ -70,9 +70,9 @@ pub fn if_some_u8(opta: Option<u8>, optb: Option<u8>) -> Option<u8> {
 #[no_mangle]
 pub fn or_match_slice_u8(opta: Option<[u8; 1]>, optb: Option<[u8; 1]>) -> Option<[u8; 1]> {
     // CHECK: start:
-    // CHECK-NEXT: trunc i16 %0 to i1
-    // CHECK-NEXT: select i1 %2, i16 %0, i16 %1
-    // ret i16
+    // CHECK-NEXT: [[SOME_A:%.+]] = trunc i16 %0 to i1
+    // CHECK-NEXT: [[R:%.+]] = select i1 [[SOME_A]], i16 %0, i16 %1
+    // CHECK: ret i16 [[R]]
     match opta {
         Some(x) => Some(x),
         None => optb,
@@ -84,9 +84,9 @@ pub fn or_match_slice_u8(opta: Option<[u8; 1]>, optb: Option<[u8; 1]>) -> Option
 #[no_mangle]
 pub fn or_match_slice_alt_u8(opta: Option<[u8; 1]>, optb: Option<[u8; 1]>) -> Option<[u8; 1]> {
     // CHECK: start:
-    // CHECK-NEXT: trunc i16 %0 to i1
-    // CHECK-NEXT: select i1 %2, i16 %0, i16 %1
-    // ret i16
+    // CHECK-NEXT: [[SOME_A:%.+]] = trunc i16 %0 to i1
+    // CHECK-NEXT: [[R:%.+]] = select i1 [[SOME_A]], i16 %0, i16 %1
+    // CHECK: ret i16 [[R]]
     match opta {
         Some(_) => opta,
         None => optb,
@@ -98,9 +98,9 @@ pub fn or_match_slice_alt_u8(opta: Option<[u8; 1]>, optb: Option<[u8; 1]>) -> Op
 #[no_mangle]
 pub fn option_or_slice_u8(opta: Option<[u8; 1]>, optb: Option<[u8; 1]>) -> Option<[u8; 1]> {
     // CHECK: start:
-    // CHECK-NEXT: trunc i16 %0 to i1
-    // CHECK-NEXT: select i1 %2, i16 %0, i16 %1
-    // ret i16
+    // CHECK-NEXT: [[SOME_A:%.+]] = trunc i16 %0 to i1
+    // CHECK-NEXT: [[R:%.+]] = select i1 [[SOME_A]], i16 %0, i16 %1
+    // CHECK: ret i16 [[R]]
     opta.or(optb)
 }
 
@@ -109,9 +109,9 @@ pub fn option_or_slice_u8(opta: Option<[u8; 1]>, optb: Option<[u8; 1]>) -> Optio
 #[no_mangle]
 pub fn if_some_slice_u8(opta: Option<[u8; 1]>, optb: Option<[u8; 1]>) -> Option<[u8; 1]> {
     // CHECK: start:
-    // CHECK-NEXT: trunc i16 %0 to i1
-    // CHECK-NEXT: select i1 %2, i16 %0, i16 %1
-    // ret i16
+    // CHECK-NEXT: [[SOME_A:%.+]] = trunc i16 %0 to i1
+    // CHECK-NEXT: [[R:%.+]] = select i1 [[SOME_A]], i16 %0, i16 %1
+    // CHECK: ret i16 [[R]]
     if opta.is_some() { opta } else { optb }
 }
 
@@ -122,9 +122,9 @@ pub fn if_some_slice_u8(opta: Option<[u8; 1]>, optb: Option<[u8; 1]>) -> Option<
 #[no_mangle]
 pub fn or_match_nz_u8(opta: Option<NonZero<u8>>, optb: Option<NonZero<u8>>) -> Option<NonZero<u8>> {
     // CHECK: start:
-    // CHECK-NEXT: [[NOT_A:%.*]] = icmp eq i8 %0, 0
-    // CHECK-NEXT: select i1 [[NOT_A]], i8 %optb, i8 %0
-    // ret i8
+    // CHECK-NEXT: [[NOT_A:%.+]] = icmp eq i8 %0, 0
+    // CHECK-NEXT: [[R:%.+]] = select i1 [[NOT_A]], i8 %optb, i8 %0
+    // CHECK: ret i8 [[R]]
     match opta {
         Some(x) => Some(x),
         None => optb,
@@ -139,9 +139,9 @@ pub fn or_match_alt_nz_u8(
     optb: Option<NonZero<u8>>,
 ) -> Option<NonZero<u8>> {
     // CHECK: start:
-    // CHECK-NEXT: [[NOT_A:%.*]] = icmp eq i8 %opta, 0
-    // CHECK-NEXT: select i1 [[NOT_A]], i8 %optb, i8 %opta
-    // ret i8
+    // CHECK-NEXT: [[NOT_A:%.+]] = icmp eq i8 %opta, 0
+    // CHECK-NEXT: [[R:%.+]] = select i1 [[NOT_A]], i8 %optb, i8 %opta
+    // CHECK: ret i8 [[R]]
     match opta {
         Some(_) => opta,
         None => optb,
@@ -156,9 +156,9 @@ pub fn option_or_nz_u8(
     optb: Option<NonZero<u8>>,
 ) -> Option<NonZero<u8>> {
     // CHECK: start:
-    // CHECK-NEXT: [[NOT_A:%.*]] = icmp eq i8 %opta, 0
-    // CHECK-NEXT: select i1 [[NOT_A]], i8 %optb, i8 %opta
-    // ret i8
+    // CHECK-NEXT: [[NOT_A:%.+]] = icmp eq i8 %opta, 0
+    // CHECK-NEXT: [[R:%.+]] = select i1 [[NOT_A]], i8 %optb, i8 %opta
+    // CHECK: ret i8 [[R]]
     opta.or(optb)
 }
 
@@ -167,8 +167,8 @@ pub fn option_or_nz_u8(
 #[no_mangle]
 pub fn if_some_nz_u8(opta: Option<NonZero<u8>>, optb: Option<NonZero<u8>>) -> Option<NonZero<u8>> {
     // CHECK: start:
-    // CHECK-NEXT: [[NOT_A:%.*]] = icmp eq i8 %opta, 0
-    // CHECK-NEXT: select i1 [[NOT_A]], i8 %optb, i8 %opta
-    // ret i8
+    // CHECK-NEXT: [[NOT_A:%.+]] = icmp eq i8 %opta, 0
+    // CHECK-NEXT: [[R:%.+]] = select i1 [[NOT_A]], i8 %optb, i8 %opta
+    // CHECK: ret i8 [[R]]
     if opta.is_some() { opta } else { optb }
 }

--- a/tests/codegen-llvm/issues/multiple-option-or-permutations.rs
+++ b/tests/codegen-llvm/issues/multiple-option-or-permutations.rs
@@ -3,16 +3,15 @@
 
 #![crate_type = "lib"]
 
-extern crate core;
-use core::num::NonZero;
+use std::num::NonZero;
 
 // CHECK-LABEL: @or_match_u8
 // CHECK-SAME: (i1{{.+}}%0, i8 %1, i1{{.+}}%optb.0, i8 %optb.1)
 #[no_mangle]
 pub fn or_match_u8(opta: Option<u8>, optb: Option<u8>) -> Option<u8> {
     // CHECK: start:
-    // CHECK-DAG: or i1 %0
     // CHECK-DAG: select i1 %0
+    // CHECK-DAG: or i1 %0
     // CHECK-NEXT: insertvalue { i1, i8 }
     // CHECK-NEXT: insertvalue { i1, i8 }
     // ret { i1, i8 }
@@ -27,8 +26,8 @@ pub fn or_match_u8(opta: Option<u8>, optb: Option<u8>) -> Option<u8> {
 #[no_mangle]
 pub fn or_match_alt_u8(opta: Option<u8>, optb: Option<u8>) -> Option<u8> {
     // CHECK: start:
-    // CHECK-DAG: select i1
-    // CHECK-DAG: or i1
+    // CHECK-DAG: select i1 %opta.0, i8 %opta.1, i8 %optb.1
+    // CHECK-DAG: or i1 {{%opta.0, %optb.0|%optb.0, %opta.0}}
     // CHECK-NEXT: insertvalue { i1, i8 }
     // CHECK-NEXT: insertvalue { i1, i8 }
     // ret { i1, i8 }


### PR DESCRIPTION
Adds tests to check the output of the different ways of writing `Option::or`

Fixes rust-lang/rust#124533
