### PR TITLE
Removed confusing diagnostics note for trait required for `?` operator use

### DIFF
--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -1287,10 +1287,6 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     self.tcx.def_span(def.did()),
                     format!("`{self_ty}` needs to implement `From<{ty}>`"),
                 );
-                err.span_note(
-                    self.tcx.def_span(found.did()),
-                    format!("alternatively, `{ty}` needs to implement `Into<{self_ty}>`"),
-                );
             }
             (ty::Adt(def, _), None) if def.did().is_local() => {
                 let trait_path = self.tcx.short_string(

--- a/tests/ui/try-trait/bad-question-mark-on-trait-object.rs
+++ b/tests/ui/try-trait/bad-question-mark-on-trait-object.rs
@@ -1,6 +1,5 @@
 struct E;
 //~^ NOTE `E` needs to implement `std::error::Error`
-//~| NOTE alternatively, `E` needs to implement `Into<X>`
 struct X; //~ NOTE `X` needs to implement `From<E>`
 
 fn foo() -> Result<(), Box<dyn std::error::Error>> { //~ NOTE required `E: std::error::Error` because of this

--- a/tests/ui/try-trait/bad-question-mark-on-trait-object.stderr
+++ b/tests/ui/try-trait/bad-question-mark-on-trait-object.stderr
@@ -1,5 +1,5 @@
 error[E0277]: `?` couldn't convert the error: `E: std::error::Error` is not satisfied
-  --> $DIR/bad-question-mark-on-trait-object.rs:7:13
+  --> $DIR/bad-question-mark-on-trait-object.rs:6:13
    |
 LL | fn foo() -> Result<(), Box<dyn std::error::Error>> {
    |             -------------------------------------- required `E: std::error::Error` because of this
@@ -17,7 +17,7 @@ LL | struct E;
    = note: required for `Box<dyn std::error::Error>` to implement `From<E>`
 
 error[E0277]: `?` couldn't convert the error to `X`
-  --> $DIR/bad-question-mark-on-trait-object.rs:18:13
+  --> $DIR/bad-question-mark-on-trait-object.rs:17:13
    |
 LL | fn bat() -> Result<(), X> {
    |             ------------- expected `X` because of this
@@ -27,14 +27,9 @@ LL |     Ok(bar()?)
    |        this can't be annotated with `?` because it has type `Result<_, E>`
    |
 note: `X` needs to implement `From<E>`
-  --> $DIR/bad-question-mark-on-trait-object.rs:4:1
+  --> $DIR/bad-question-mark-on-trait-object.rs:3:1
    |
 LL | struct X;
-   | ^^^^^^^^
-note: alternatively, `E` needs to implement `Into<X>`
-  --> $DIR/bad-question-mark-on-trait-object.rs:1:1
-   |
-LL | struct E;
    | ^^^^^^^^
    = note: the question mark operation (`?`) implicitly performs a conversion on the error value using the `From` trait
 


### PR DESCRIPTION
- **test: modified `bad-question-mark-on-trait-objects` to match expected behavior**
- **removed confusing message from diagnostics**

fixes [#150527](https://github.com/rust-lang/rust/issues/150527)
