### PR TITLE
Improve move error diagnostic for `AsyncFn` closures

### DIFF
--- a/tests/ui/async-await/async-closures/move-from-async-fn-bound.rs
+++ b/tests/ui/async-await/async-closures/move-from-async-fn-bound.rs
@@ -1,0 +1,13 @@
+//@ edition:2021
+// Test that a by-ref `AsyncFn` closure gets an error when it tries to
+// consume a value, with a helpful diagnostic pointing to the bound.
+
+fn call<F>(_: F) where F: AsyncFn() {}
+
+fn main() {
+    let y = vec![format!("World")];
+    call(async || {
+        //~^ ERROR cannot move out of `y`, a captured variable in an `AsyncFn` closure
+        y.into_iter();
+    });
+}

--- a/tests/ui/async-await/async-closures/move-from-async-fn-bound.stderr
+++ b/tests/ui/async-await/async-closures/move-from-async-fn-bound.stderr
@@ -1,0 +1,30 @@
+error[E0507]: cannot move out of `y`, a captured variable in an `AsyncFn` closure
+  --> $DIR/move-from-async-fn-bound.rs:9:10
+   |
+LL |     let y = vec![format!("World")];
+   |         - captured outer variable
+LL |     call(async || {
+   |          ^^^^^^^^
+   |          |
+   |          captured by this `AsyncFn` closure
+   |          `y` is moved here
+LL |
+LL |         y.into_iter();
+   |         -
+   |         |
+   |         variable moved due to use in coroutine
+   |         move occurs because `y` has type `Vec<String>`, which does not implement the `Copy` trait
+   |
+help: `AsyncFn` and `AsyncFnMut` closures require captured values to be able to be consumed multiple times, but `AsyncFnOnce` closures may consume them only once
+  --> $DIR/move-from-async-fn-bound.rs:5:27
+   |
+LL | fn call<F>(_: F) where F: AsyncFn() {}
+   |                           ^^^^^^^^^
+help: consider cloning the value if the performance cost is acceptable
+   |
+LL |         y.clone().into_iter();
+   |          ++++++++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0507`.


### PR DESCRIPTION
When an async closure captures a variable by move but is constrained to `AsyncFn` or `AsyncFnMut`, the error message now explains that the closure kind is the issue and points to the trait bound, similar to the existing diagnostic for `Fn`/`FnMut` closures.

**Before:**
```
error[E0507]: cannot move out of `foos` which is behind a shared reference
  --> src/lib.rs:12:20
   |
11 | async fn foo(foos: &mut [&mut Foo]) -> Result<(), ()> {
   |              ---- move occurs because `foos` has type...
12 |     in_transaction(async || -> Result<(), ()> {
   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^ `foos` is moved here
13 |         for foo in foos {
   |                    ---- variable moved due to use in coroutine
```

**After:**
```
error[E0507]: cannot move out of `y`, a captured variable in an `AsyncFn` closure
  --> src/lib.rs:9:10
   |
LL |     let y = vec![format!("World")];
   |         - captured outer variable
LL |     call(async || {
   |          ^^^^^^^^ captured by this `AsyncFn` closure
...
help: `AsyncFn` and `AsyncFnMut` closures require captured values to be able
      to be consumed multiple times, but `AsyncFnOnce` closures may consume
      them only once
  --> src/lib.rs:5:27
   |
LL | fn call<F>(_: F) where F: AsyncFn() {}
   |                           ^^^^^^^^^
```

Fixes rust-lang/rust#150174