### PR TITLE
Clarify `MoveData::init_loc_map`.

### DIFF
--- a/compiler/rustc_mir_dataflow/src/move_paths/mod.rs
+++ b/compiler/rustc_mir_dataflow/src/move_paths/mod.rs
@@ -177,8 +177,9 @@ pub struct MoveData<'tcx> {
     pub rev_lookup: MovePathLookup<'tcx>,
     pub inits: IndexVec<InitIndex, Init>,
     /// Each Location `l` is mapped to the Inits that are effects
-    /// of executing the code at `l`.
-    pub init_loc_map: LocationMap<SmallVec<[InitIndex; 4]>>,
+    /// of executing the code at `l`. Only very rarely (e.g. inline asm)
+    /// is there more than one Init at any `l`.
+    pub init_loc_map: LocationMap<SmallVec<[InitIndex; 1]>>,
     pub init_path_map: IndexVec<MovePathIndex, SmallVec<[InitIndex; 4]>>,
 }
 


### PR DESCRIPTION
Change the `SmallVec` size from 4 to 1, because that's sufficient in the vast majority of cases. (This doesn't affect performance in practice, so it's more of a code clarity change than a performance change.)

r? @cjgillot 