### PR TITLE
Fix a typo in the docs of AsMut for #149609

### DIFF
--- a/library/core/src/convert/mod.rs
+++ b/library/core/src/convert/mod.rs
@@ -308,8 +308,8 @@ pub const trait AsRef<T: PointeeSized>: PointeeSized {
 /// both `AsMut<Vec<T>>` and `AsMut<[T]>`.
 ///
 /// In the following, the example functions `caesar` and `null_terminate` provide a generic
-/// interface which work with any type that can be converted by cheap mutable-to-mutable conversion
-/// into a byte slice (`[u8]`) or byte vector (`Vec<u8>`), respectively.
+/// interface which works with any type that can be converted by cheap mutable-to-mutable conversion
+/// into a byte slice (`[u8]`) or a byte vector (`Vec<u8>`), respectively.
 ///
 /// [dereference]: core::ops::DerefMut
 /// [target type]: core::ops::Deref::Target


### PR DESCRIPTION
This PR fixes the documentation of the trait `AsMut`, where in the sentence "[ ... ] interface which work with any type [ ... ]", "work" should be replaced by "works".

This also changes the later "[ ... ] into a byte slice ([u8]) or byte vector (Vec<u8>) [ ... ]" to be "[ ... ] into a byte slice ([u8]) or a byte vector (Vec<u8>) [ ... ]" to maintain consistency between "a byte slice" and "a byte vector".

Issue: rust-lang/rust#149609