### PR TITLE
Document `panic!` in `Iterator::last` for #149707

### DIFF
--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -236,6 +236,11 @@ pub trait Iterator {
     /// doing so, it keeps track of the current element. After [`None`] is
     /// returned, `last()` will then return the last element it saw.
     ///
+    /// # Panics
+    ///
+    /// This function might panic if the iterator has more than [`usize::MAX`]
+    /// elements.
+    ///
     /// # Examples
     ///
     /// ```


### PR DESCRIPTION
This PR adds a section `# Panics` to the method `Iterator::last` equal to the section `# Panics` of the method `Iterator::count`, because now, after the changes made in Rust 1.92.0, both methods in `std::iter::Repeat` panics instead of doing an infinite loop.

`Iterator::count` already has documentation for this behavior ("This function might panic if the iterator has more than `usize::MAX` elements."), but `Iterator::last` does not. This PR adds documentation for this panic in the same way as `Iterator::count` does.

Issue: rust-lang/rust#149707