### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4574,7 +4574,6 @@ dependencies = [
 name = "rustc_resolve"
 version = "0.0.0"
 dependencies = [
- "bitflags",
  "indexmap",
  "itertools",
  "pulldown-cmark",

--- a/compiler/rustc_ast_lowering/src/asm.rs
+++ b/compiler/rustc_ast_lowering/src/asm.rs
@@ -52,7 +52,15 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                     | asm::InlineAsmArch::LoongArch64
                     | asm::InlineAsmArch::S390x
             );
-            if !is_stable && !self.tcx.features().asm_experimental_arch() {
+            if !is_stable
+                && !self.tcx.features().asm_experimental_arch()
+                && sp
+                    .ctxt()
+                    .outer_expn_data()
+                    .allow_internal_unstable
+                    .filter(|features| features.contains(&sym::asm_experimental_arch))
+                    .is_none()
+            {
                 feature_err(
                     &self.tcx.sess,
                     sym::asm_experimental_arch,

--- a/compiler/rustc_resolve/Cargo.toml
+++ b/compiler/rustc_resolve/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2024"
 
 [dependencies]
 # tidy-alphabetical-start
-bitflags = "2.4.1"
 indexmap = "2.4.0"
 itertools = "0.12"
 pulldown-cmark = { version = "0.11", features = ["html"], default-features = false }

--- a/compiler/rustc_resolve/src/ident.rs
+++ b/compiler/rustc_resolve/src/ident.rs
@@ -19,10 +19,10 @@ use crate::late::{
 };
 use crate::macros::{MacroRulesScope, sub_namespace_match};
 use crate::{
-    AmbiguityError, AmbiguityErrorMisc, AmbiguityKind, BindingKey, CmResolver, Determinacy,
-    Finalize, ImportKind, LexicalScopeBinding, Module, ModuleKind, ModuleOrUniformRoot,
-    NameBinding, NameBindingKind, ParentScope, PathResult, PrivacyError, Res, ResolutionError,
-    Resolver, Scope, ScopeSet, Segment, Stage, Used, errors,
+    AmbiguityError, AmbiguityKind, BindingKey, CmResolver, Determinacy, Finalize, ImportKind,
+    LexicalScopeBinding, Module, ModuleKind, ModuleOrUniformRoot, NameBinding, NameBindingKind,
+    ParentScope, PathResult, PrivacyError, Res, ResolutionError, Resolver, Scope, ScopeSet,
+    Segment, Stage, Used, errors,
 };
 
 #[derive(Copy, Clone)]
@@ -41,17 +41,6 @@ impl From<UsePrelude> for bool {
 enum Shadowing {
     Restricted,
     Unrestricted,
-}
-
-bitflags::bitflags! {
-    #[derive(Clone, Copy)]
-    struct Flags: u8 {
-        const MACRO_RULES          = 1 << 0;
-        const MODULE               = 1 << 1;
-        const MISC_SUGGEST_CRATE   = 1 << 2;
-        const MISC_SUGGEST_SELF    = 1 << 3;
-        const MISC_FROM_PRELUDE    = 1 << 4;
-    }
 }
 
 impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
@@ -430,10 +419,9 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         // }
         // So we have to save the innermost solution and continue searching in outer scopes
         // to detect potential ambiguities.
-        let mut innermost_result: Option<(NameBinding<'_>, Flags)> = None;
+        let mut innermost_result: Option<(NameBinding<'_>, Scope<'_>)> = None;
         let mut determinacy = Determinacy::Determined;
         let mut extern_prelude_item_binding = None;
-        let mut extern_prelude_flag_binding = None;
 
         // Go through all the scopes and try to resolve the name.
         let break_result = self.visit_scopes(
@@ -459,11 +447,8 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                     ignore_binding,
                     ignore_import,
                     &mut extern_prelude_item_binding,
-                    &mut extern_prelude_flag_binding,
                 )? {
-                    Ok((binding, flags))
-                        if sub_namespace_match(binding.macro_kinds(), macro_kind) =>
-                    {
+                    Ok(binding) if sub_namespace_match(binding.macro_kinds(), macro_kind) => {
                         // Below we report various ambiguity errors.
                         // We do not need to report them if we are either in speculative resolution,
                         // or in late resolution when everything is already imported and expanded
@@ -472,24 +457,23 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                             return ControlFlow::Break(Ok(binding));
                         }
 
-                        if let Some((innermost_binding, innermost_flags)) = innermost_result {
+                        if let Some((innermost_binding, innermost_scope)) = innermost_result {
                             // Found another solution, if the first one was "weak", report an error.
                             if this.get_mut().maybe_push_ambiguity(
                                 orig_ident,
                                 parent_scope,
                                 binding,
                                 innermost_binding,
-                                flags,
-                                innermost_flags,
+                                scope,
+                                innermost_scope,
                                 extern_prelude_item_binding,
-                                extern_prelude_flag_binding,
                             ) {
                                 // No need to search for more potential ambiguities, one is enough.
                                 return ControlFlow::Break(Ok(innermost_binding));
                             }
                         } else {
                             // Found the first solution.
-                            innermost_result = Some((binding, flags));
+                            innermost_result = Some((binding, scope));
                         }
                     }
                     Ok(_) | Err(Determinacy::Determined) => {}
@@ -507,7 +491,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
 
         // Scope visiting walked all the scopes and maybe found something in one of them.
         match innermost_result {
-            Some((binding, _)) => Ok(binding),
+            Some((binding, ..)) => Ok(binding),
             None => Err(Determinacy::determined(determinacy == Determinacy::Determined || force)),
         }
     }
@@ -526,18 +510,15 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         ignore_binding: Option<NameBinding<'ra>>,
         ignore_import: Option<Import<'ra>>,
         extern_prelude_item_binding: &mut Option<NameBinding<'ra>>,
-        extern_prelude_flag_binding: &mut Option<NameBinding<'ra>>,
-    ) -> ControlFlow<
-        Result<NameBinding<'ra>, Determinacy>,
-        Result<(NameBinding<'ra>, Flags), Determinacy>,
-    > {
+    ) -> ControlFlow<Result<NameBinding<'ra>, Determinacy>, Result<NameBinding<'ra>, Determinacy>>
+    {
         let ident = Ident::new(orig_ident.name, orig_ident.span.with_ctxt(ctxt));
         let ret = match scope {
             Scope::DeriveHelpers(expn_id) => {
                 if let Some(binding) = self.helper_attrs.get(&expn_id).and_then(|attrs| {
                     attrs.iter().rfind(|(i, _)| ident == *i).map(|(_, binding)| *binding)
                 }) {
-                    Ok((binding, Flags::empty()))
+                    Ok(binding)
                 } else {
                     Err(Determinacy::Determined)
                 }
@@ -559,7 +540,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                                     derive.span,
                                     LocalExpnId::ROOT,
                                 );
-                                result = Ok((binding, Flags::empty()));
+                                result = Ok(binding);
                                 break;
                             }
                         }
@@ -573,7 +554,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 MacroRulesScope::Binding(macro_rules_binding)
                     if ident == macro_rules_binding.ident =>
                 {
-                    Ok((macro_rules_binding.binding, Flags::MACRO_RULES))
+                    Ok(macro_rules_binding.binding)
                 }
                 MacroRulesScope::Invocation(_) => Err(Determinacy::Undetermined),
                 _ => Err(Determinacy::Determined),
@@ -612,14 +593,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                                 },
                             );
                         }
-                        let misc_flags = if module == self.graph_root {
-                            Flags::MISC_SUGGEST_CRATE
-                        } else if module.is_normal() {
-                            Flags::MISC_SUGGEST_SELF
-                        } else {
-                            Flags::empty()
-                        };
-                        Ok((binding, Flags::MODULE | misc_flags))
+                        Ok(binding)
                     }
                     Err(ControlFlow::Continue(determinacy)) => Err(determinacy),
                     Err(ControlFlow::Break(Determinacy::Undetermined)) => {
@@ -630,20 +604,20 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 }
             }
             Scope::MacroUsePrelude => match self.macro_use_prelude.get(&ident.name).cloned() {
-                Some(binding) => Ok((binding, Flags::MISC_FROM_PRELUDE)),
+                Some(binding) => Ok(binding),
                 None => Err(Determinacy::determined(
                     self.graph_root.unexpanded_invocations.borrow().is_empty(),
                 )),
             },
             Scope::BuiltinAttrs => match self.builtin_attrs_bindings.get(&ident.name) {
-                Some(binding) => Ok((*binding, Flags::empty())),
+                Some(binding) => Ok(*binding),
                 None => Err(Determinacy::Determined),
             },
             Scope::ExternPreludeItems => {
                 match self.reborrow().extern_prelude_get_item(ident, finalize.is_some()) {
                     Some(binding) => {
                         *extern_prelude_item_binding = Some(binding);
-                        Ok((binding, Flags::empty()))
+                        Ok(binding)
                     }
                     None => Err(Determinacy::determined(
                         self.graph_root.unexpanded_invocations.borrow().is_empty(),
@@ -652,15 +626,12 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             }
             Scope::ExternPreludeFlags => {
                 match self.extern_prelude_get_flag(ident, finalize.is_some()) {
-                    Some(binding) => {
-                        *extern_prelude_flag_binding = Some(binding);
-                        Ok((binding, Flags::empty()))
-                    }
+                    Some(binding) => Ok(binding),
                     None => Err(Determinacy::Determined),
                 }
             }
             Scope::ToolPrelude => match self.registered_tool_bindings.get(&ident) {
-                Some(binding) => Ok((*binding, Flags::empty())),
+                Some(binding) => Ok(*binding),
                 None => Err(Determinacy::Determined),
             },
             Scope::StdLibPrelude => {
@@ -679,7 +650,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                     && (matches!(use_prelude, UsePrelude::Yes)
                         || self.is_builtin_macro(binding.res()))
                 {
-                    result = Ok((binding, Flags::MISC_FROM_PRELUDE));
+                    result = Ok(binding)
                 }
 
                 result
@@ -712,7 +683,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                         )
                         .emit();
                     }
-                    Ok((*binding, Flags::empty()))
+                    Ok(*binding)
                 }
                 None => Err(Determinacy::Determined),
             },
@@ -727,16 +698,17 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         parent_scope: &ParentScope<'ra>,
         binding: NameBinding<'ra>,
         innermost_binding: NameBinding<'ra>,
-        flags: Flags,
-        innermost_flags: Flags,
+        scope: Scope<'ra>,
+        innermost_scope: Scope<'ra>,
         extern_prelude_item_binding: Option<NameBinding<'ra>>,
-        extern_prelude_flag_binding: Option<NameBinding<'ra>>,
     ) -> bool {
         let (res, innermost_res) = (binding.res(), innermost_binding.res());
         if res == innermost_res {
             return false;
         }
 
+        // FIXME: Use `scope` instead of `res` to detect built-in attrs and derive helpers,
+        // it will exclude imports, make slightly more code legal, and will require lang approval.
         let is_builtin = |res| matches!(res, Res::NonMacroAttr(NonMacroAttrKind::Builtin(..)));
         let derive_helper = Res::NonMacroAttr(NonMacroAttrKind::DeriveHelper);
         let derive_helper_compat = Res::NonMacroAttr(NonMacroAttrKind::DeriveHelperCompat);
@@ -747,12 +719,14 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             Some(AmbiguityKind::DeriveHelper)
         } else if res == derive_helper_compat && innermost_res != derive_helper {
             span_bug!(orig_ident.span, "impossible inner resolution kind")
-        } else if innermost_flags.contains(Flags::MACRO_RULES)
-            && flags.contains(Flags::MODULE)
+        } else if matches!(innermost_scope, Scope::MacroRules(_))
+            && matches!(scope, Scope::Module(..))
             && !self.disambiguate_macro_rules_vs_modularized(innermost_binding, binding)
         {
             Some(AmbiguityKind::MacroRulesVsModularized)
-        } else if flags.contains(Flags::MACRO_RULES) && innermost_flags.contains(Flags::MODULE) {
+        } else if matches!(scope, Scope::MacroRules(_))
+            && matches!(innermost_scope, Scope::Module(..))
+        {
             // should be impossible because of visitation order in
             // visit_scopes
             //
@@ -774,32 +748,21 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             // Skip ambiguity errors for extern flag bindings "overridden"
             // by extern item bindings.
             // FIXME: Remove with lang team approval.
-            let issue_145575_hack = Some(binding) == extern_prelude_flag_binding
+            let issue_145575_hack = matches!(scope, Scope::ExternPreludeFlags)
                 && extern_prelude_item_binding.is_some()
                 && extern_prelude_item_binding != Some(innermost_binding);
 
             if issue_145575_hack {
                 self.issue_145575_hack_applied = true;
             } else {
-                let misc = |f: Flags| {
-                    if f.contains(Flags::MISC_SUGGEST_CRATE) {
-                        AmbiguityErrorMisc::SuggestCrate
-                    } else if f.contains(Flags::MISC_SUGGEST_SELF) {
-                        AmbiguityErrorMisc::SuggestSelf
-                    } else if f.contains(Flags::MISC_FROM_PRELUDE) {
-                        AmbiguityErrorMisc::FromPrelude
-                    } else {
-                        AmbiguityErrorMisc::None
-                    }
-                };
                 self.ambiguity_errors.push(AmbiguityError {
                     kind,
                     ident: orig_ident,
                     b1: innermost_binding,
                     b2: binding,
+                    scope1: innermost_scope,
+                    scope2: scope,
                     warning: false,
-                    misc1: misc(innermost_flags),
-                    misc2: misc(flags),
                 });
                 return true;
             }
@@ -1216,9 +1179,9 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 ident,
                 b1: binding,
                 b2: shadowed_glob,
+                scope1: Scope::Module(self.empty_module, None),
+                scope2: Scope::Module(self.empty_module, None),
                 warning: false,
-                misc1: AmbiguityErrorMisc::None,
-                misc2: AmbiguityErrorMisc::None,
             });
         }
 

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -903,22 +903,14 @@ impl AmbiguityKind {
     }
 }
 
-/// Miscellaneous bits of metadata for better ambiguity error reporting.
-#[derive(Clone, Copy, PartialEq)]
-enum AmbiguityErrorMisc {
-    SuggestCrate,
-    SuggestSelf,
-    FromPrelude,
-    None,
-}
-
 struct AmbiguityError<'ra> {
     kind: AmbiguityKind,
     ident: Ident,
     b1: NameBinding<'ra>,
     b2: NameBinding<'ra>,
-    misc1: AmbiguityErrorMisc,
-    misc2: AmbiguityErrorMisc,
+    // `empty_module` in module scope serves as an unknown module here.
+    scope1: Scope<'ra>,
+    scope2: Scope<'ra>,
     warning: bool,
 }
 
@@ -2045,8 +2037,6 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 && ambiguity_error.ident.span == ambi.ident.span
                 && ambiguity_error.b1.span == ambi.b1.span
                 && ambiguity_error.b2.span == ambi.b2.span
-                && ambiguity_error.misc1 == ambi.misc1
-                && ambiguity_error.misc2 == ambi.misc2
             {
                 return true;
             }
@@ -2071,8 +2061,8 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 ident,
                 b1: used_binding,
                 b2,
-                misc1: AmbiguityErrorMisc::None,
-                misc2: AmbiguityErrorMisc::None,
+                scope1: Scope::Module(self.empty_module, None),
+                scope2: Scope::Module(self.empty_module, None),
                 warning: warn_ambiguity,
             };
             if !self.matches_previous_ambiguity_error(&ambiguity_error) {

--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -236,6 +236,11 @@ pub trait Iterator {
     /// doing so, it keeps track of the current element. After [`None`] is
     /// returned, `last()` will then return the last element it saw.
     ///
+    /// # Panics
+    ///
+    /// This function might panic if the iterator has more than [`usize::MAX`]
+    /// elements.
+    ///
     /// # Examples
     ///
     /// ```

--- a/tests/ui/internal/auxiliary/internal_unstable.rs
+++ b/tests/ui/internal/auxiliary/internal_unstable.rs
@@ -99,3 +99,10 @@ macro_rules! access_field_noallow {
 macro_rules! pass_through_noallow {
     ($e: expr) => { $e }
 }
+
+#[stable(feature = "stable", since = "1.0.0")]
+#[allow_internal_unstable(asm_experimental_arch)]
+#[macro_export]
+macro_rules! asm_redirect {
+    ($($t:tt)*) => { core::arch::global_asm!($($t)*); }
+}

--- a/tests/ui/internal/internal-unstable-asm-experimental-arch.rs
+++ b/tests/ui/internal/internal-unstable-asm-experimental-arch.rs
@@ -1,0 +1,18 @@
+//@ only-wasm32-wasip1
+//@ compile-flags: --crate-type=lib
+//@ build-pass
+//@ aux-build:internal_unstable.rs
+
+#[macro_use]
+extern crate internal_unstable;
+
+asm_redirect!(
+    "test:",
+    ".globl test",
+    ".functype test (i32) -> (i32)",
+    "local.get 0",
+    "i32.const 1",
+    "i32.add",
+    "end_function",
+    ".export_name test, test",
+);


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#150073 (Make `asm_experimental_arch` work in `allow_internal_unstable` macros)
 - rust-lang/rust#150445 (resolve: Preserve binding scopes in ambiguity errors)
 - rust-lang/rust#150580 (Document `panic!` in `Iterator::last` for rust-lang/rust#149707)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=150073,150445,150580)
<!-- homu-ignore:end -->