### PR TITLE
Add a context-consistency check before emitting redundant generic-argument suggestions

### DIFF
--- a/compiler/rustc_hir_analysis/src/errors/wrong_number_of_generic_args.rs
+++ b/compiler/rustc_hir_analysis/src/errors/wrong_number_of_generic_args.rs
@@ -988,6 +988,9 @@ impl<'a, 'tcx> WrongNumberOfGenericArgs<'a, 'tcx> {
                     gen_arg_spans[self.num_expected_type_or_const_args() - 1]
                 };
             let span_hi_redundant_type_or_const_args = gen_arg_spans[gen_arg_spans.len() - 1];
+            if !span_lo_redundant_type_or_const_args.eq_ctxt(span_hi_redundant_type_or_const_args) {
+                return;
+            }
             let span_redundant_type_or_const_args = span_lo_redundant_type_or_const_args
                 .shrink_to_hi()
                 .to(span_hi_redundant_type_or_const_args);

--- a/tests/ui/generics/wrong-number-of-args-in-macro.rs
+++ b/tests/ui/generics/wrong-number-of-args-in-macro.rs
@@ -1,0 +1,15 @@
+// Regression test for #149559
+
+struct Foo<T>; //~ ERROR type parameter `T` is never used
+
+macro_rules! foo_ty {
+    ($a:ty, $b:ty) => {
+        Foo<a, $b>
+        //~^ ERROR cannot find type `a` in this scope
+        //~| ERROR struct takes 1 generic argument but 2 generic arguments were supplied
+    };
+}
+
+fn foo<'a, 'b>() -> foo_ty!(&'b (), &'b ()) {}
+
+fn main() {}

--- a/tests/ui/generics/wrong-number-of-args-in-macro.stderr
+++ b/tests/ui/generics/wrong-number-of-args-in-macro.stderr
@@ -1,0 +1,44 @@
+error[E0425]: cannot find type `a` in this scope
+  --> $DIR/wrong-number-of-args-in-macro.rs:7:13
+   |
+LL |         Foo<a, $b>
+   |             ^ not found in this scope
+...
+LL | fn foo<'a, 'b>() -> foo_ty!(&'b (), &'b ()) {}
+   |                     ----------------------- in this macro invocation
+   |
+   = note: this error originates in the macro `foo_ty` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: you might be missing a type parameter
+   |
+LL | fn foo<'a, 'b, a>() -> foo_ty!(&'b (), &'b ()) {}
+   |              +++
+
+error[E0107]: struct takes 1 generic argument but 2 generic arguments were supplied
+  --> $DIR/wrong-number-of-args-in-macro.rs:7:9
+   |
+LL |         Foo<a, $b>
+   |         ^^^ expected 1 generic argument
+...
+LL | fn foo<'a, 'b>() -> foo_ty!(&'b (), &'b ()) {}
+   |                     ----------------------- in this macro invocation
+   |
+note: struct defined here, with 1 generic parameter: `T`
+  --> $DIR/wrong-number-of-args-in-macro.rs:3:8
+   |
+LL | struct Foo<T>;
+   |        ^^^ -
+   = note: this error originates in the macro `foo_ty` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0392]: type parameter `T` is never used
+  --> $DIR/wrong-number-of-args-in-macro.rs:3:12
+   |
+LL | struct Foo<T>;
+   |            ^ unused type parameter
+   |
+   = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
+   = help: if you intended `T` to be a const parameter, use `const T: /* Type */` instead
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0107, E0392, E0425.
+For more information about an error, try `rustc --explain E0107`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Fixes rust-lang/rust#149559

Add a context-consistency check before emitting redundant generic-argument suggestions. If the redundant argument spans come from mixed hygiene contexts (e.g., macro definition + macro callsite), we skip the suggestion to avoid malformed `shrink_to_hi().to(...)` spans and potential ICEs.