### PR TITLE
rustdoc: Fix intra-doc link bugs involving type aliases and associated items

### DIFF
--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -614,7 +614,9 @@ impl<'tcx> LinkCollector<'_, 'tcx> {
                 // Resolve the link on the type the alias points to.
                 // FIXME: if the associated item is defined directly on the type alias,
                 // it will show up on its documentation page, we should link there instead.
-                let Some(res) = self.ty_to_res(tcx.type_of(did).instantiate_identity()) else { return Vec::new() };
+                let Some(res) = self.ty_to_res(tcx.type_of(did).instantiate_identity()) else {
+                    return Vec::new();
+                };
                 self.resolve_associated_item(res, item_name, ns, disambiguator, module_id)
             }
             Res::Def(
@@ -720,10 +722,7 @@ impl<'tcx> LinkCollector<'_, 'tcx> {
                 Ident::with_dummy_span(item_name),
                 ns,
             )
-            .map(|item| {
-                let res = Res::Def(item.as_def_kind(), item.def_id);
-                (res, item.def_id)
-            })
+            .map(|item| (root_res, item.def_id))
             .collect::<Vec<_>>(),
             _ => Vec::new(),
         }

--- a/tests/rustdoc-html/intra-doc/adt-through-alias.rs
+++ b/tests/rustdoc-html/intra-doc/adt-through-alias.rs
@@ -3,12 +3,35 @@
 //! [`TheStructAlias::the_field`]
 //! [`TheEnumAlias::TheVariant`]
 //! [`TheEnumAlias::TheVariant::the_field`]
+//! [`TheUnionAlias::f1`]
+//!
+//! [`TheStruct::trait_`]
+//! [`TheStructAlias::trait_`]
+//! [`TheEnum::trait_`]
+//! [`TheEnumAlias::trait_`]
+//!
+//! [`TheStruct::inherent`]
+//! [`TheStructAlias::inherent`]
+//! [`TheEnum::inherent`]
+//! [`TheEnumAlias::inherent`]
 
-// FIXME: this should resolve to the alias's version
-//@ has foo/index.html '//a[@href="struct.TheStruct.html#structfield.the_field"]' 'TheStructAlias::the_field'
-// FIXME: this should resolve to the alias's version
-//@ has foo/index.html '//a[@href="enum.TheEnum.html#variant.TheVariant"]' 'TheEnumAlias::TheVariant'
+//@ has foo/index.html '//a[@href="type.TheStructAlias.html#structfield.the_field"]' 'TheStructAlias::the_field'
+//@ has foo/index.html '//a[@href="type.TheEnumAlias.html#variant.TheVariant"]' 'TheEnumAlias::TheVariant'
 //@ has foo/index.html '//a[@href="type.TheEnumAlias.html#variant.TheVariant.field.the_field"]' 'TheEnumAlias::TheVariant::the_field'
+//@ has foo/index.html '//a[@href="type.TheUnionAlias.html#structfield.f1"]' 'TheUnionAlias::f1'
+
+//@ has foo/index.html '//a[@href="struct.TheStruct.html#method.trait_"]' 'TheStruct::trait_'
+//@ has foo/index.html '//a[@href="struct.TheStruct.html#method.trait_"]' 'TheStructAlias::trait_'
+//@ has foo/index.html '//a[@href="enum.TheEnum.html#method.trait_"]' 'TheEnum::trait_'
+// FIXME: this one should resolve to alias since it's impl Trait for TheEnumAlias
+//@ has foo/index.html '//a[@href="enum.TheEnum.html#method.trait_"]' 'TheEnumAlias::trait_'
+
+//@ has foo/index.html '//a[@href="struct.TheStruct.html#method.inherent"]' 'TheStruct::inherent'
+// FIXME: this one should resolve to alias
+//@ has foo/index.html '//a[@href="struct.TheStruct.html#method.inherent"]' 'TheStructAlias::inherent'
+//@ has foo/index.html '//a[@href="enum.TheEnum.html#method.inherent"]' 'TheEnum::inherent'
+// FIXME: this one should resolve to alias
+//@ has foo/index.html '//a[@href="enum.TheEnum.html#method.inherent"]' 'TheEnumAlias::inherent'
 
 pub struct TheStruct {
     pub the_field: i32,
@@ -21,5 +44,28 @@ pub enum TheEnum {
 }
 
 pub type TheEnumAlias = TheEnum;
+
+pub trait Trait {
+    fn trait_() {}
+}
+
+impl Trait for TheStruct {}
+
+impl Trait for TheEnumAlias {}
+
+impl TheStruct {
+    pub fn inherent() {}
+}
+
+impl TheEnumAlias {
+    pub fn inherent() {}
+}
+
+pub union TheUnion {
+    pub f1: usize,
+    pub f2: isize,
+}
+
+pub type TheUnionAlias = TheUnion;
 
 fn main() {}

--- a/tests/rustdoc-html/intra-doc/adt-through-alias.rs
+++ b/tests/rustdoc-html/intra-doc/adt-through-alias.rs
@@ -1,0 +1,25 @@
+#![crate_name = "foo"]
+
+//! [`TheStructAlias::the_field`]
+//! [`TheEnumAlias::TheVariant`]
+//! [`TheEnumAlias::TheVariant::the_field`]
+
+// FIXME: this should resolve to the alias's version
+//@ has foo/index.html '//a[@href="struct.TheStruct.html#structfield.the_field"]' 'TheStructAlias::the_field'
+// FIXME: this should resolve to the alias's version
+//@ has foo/index.html '//a[@href="enum.TheEnum.html#variant.TheVariant"]' 'TheEnumAlias::TheVariant'
+//@ has foo/index.html '//a[@href="type.TheEnumAlias.html#variant.TheVariant.field.the_field"]' 'TheEnumAlias::TheVariant::the_field'
+
+pub struct TheStruct {
+    pub the_field: i32,
+}
+
+pub type TheStructAlias = TheStruct;
+
+pub enum TheEnum {
+    TheVariant { the_field: i32 },
+}
+
+pub type TheEnumAlias = TheEnum;
+
+fn main() {}

--- a/tests/rustdoc-html/intra-doc/associated-items.rs
+++ b/tests/rustdoc-html/intra-doc/associated-items.rs
@@ -13,7 +13,9 @@ pub fn foo() {}
 //@ has 'associated_items/struct.MyStruct.html' '//a[@href="struct.MyStruct.html#method.method"]' 'link from struct'
 //@ has 'associated_items/struct.MyStruct.html' '//a[@href="struct.MyStruct.html#method.clone"]' 'MyStruct::clone'
 //@ has 'associated_items/struct.MyStruct.html' '//a[@href="struct.MyStruct.html#associatedtype.Input"]' 'MyStruct::Input'
-pub struct MyStruct { foo: () }
+pub struct MyStruct {
+    foo: (),
+}
 
 impl Clone for MyStruct {
     fn clone(&self) -> Self {
@@ -31,8 +33,7 @@ impl T for MyStruct {
 
     /// [link from method][MyStruct::method] on method
     //@ has 'associated_items/struct.MyStruct.html' '//a[@href="struct.MyStruct.html#method.method"]' 'link from method'
-    fn method(i: usize) {
-    }
+    fn method(i: usize) {}
 }
 
 /// Ambiguity between which trait to use
@@ -57,7 +58,7 @@ impl T2 for S {
     fn ambiguous_method() {}
 }
 
-//@ has associated_items/enum.MyEnum.html '//a/@href' 'enum.MyEnum.html#variant.MyVariant'
+//@ has associated_items/enum.MyEnum.html '//a/@href' 'type.MyEnumAlias.html#variant.MyVariant'
 /// Link to [MyEnumAlias::MyVariant]
 pub enum MyEnum {
     MyVariant,


### PR DESCRIPTION
This PR:
- Add support for linking to fields of variants behind a type alias.
- Correctly resolve links to fields and variants behind a type alias to the alias's version of the docs.
- Refactor some intra-doc links code to make it simpler.
- Add tests for the status quo of linking to associated items behind aliases.

Future steps:
- Nail down the rules of when inherent and trait impls are inlined into an alias's docs, and when impls on the alias appear for the aliased type.
- Adjust the resolutions of intra-doc links, through aliases, to associated items based on these rules.

r? @GuillaumeGomez