### PR TITLE
triagebot: add A-rustdoc-js autolabel

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -332,6 +332,14 @@ trigger_labels = [
     "A-type-based-search",
 ]
 
+[autolabel."A-rustdoc-js"]
+trigger_files = [
+    "src/librustdoc/html/static/js/",
+    "src/librustdoc/html/static/css/",
+    "tests/rustdoc-js/",
+    "tests/rustdoc-js-std/",
+]
+
 [autolabel."T-compiler"]
 trigger_files = [
     # Source code


### PR DESCRIPTION
Adds an autolabel rule for rustdoc JavaScript/TypeScript files so PRs touching
rustdoc frontend assets and related tests are automatically labeled `A-rustdoc-js`.

Fixes rust-lang/rust#137983