### PR TITLE
Remove unneeded `forbid_generic` field from `Res::SelfTyAlias`

### DIFF
--- a/compiler/rustc_hir/src/def.rs
+++ b/compiler/rustc_hir/src/def.rs
@@ -563,29 +563,6 @@ pub enum Res<Id = hir::HirId> {
         /// to get the underlying type.
         alias_to: DefId,
 
-        /// Whether the `Self` type is disallowed from mentioning generics (i.e. when used in an
-        /// anonymous constant).
-        ///
-        /// HACK(min_const_generics): self types also have an optional requirement to **not**
-        /// mention any generic parameters to allow the following with `min_const_generics`:
-        /// ```
-        /// # struct Foo;
-        /// impl Foo { fn test() -> [u8; size_of::<Self>()] { todo!() } }
-        ///
-        /// struct Bar([u8; baz::<Self>()]);
-        /// const fn baz<T>() -> usize { 10 }
-        /// ```
-        /// We do however allow `Self` in repeat expression even if it is generic to not break code
-        /// which already works on stable while causing the `const_evaluatable_unchecked` future
-        /// compat lint:
-        /// ```
-        /// fn foo<T>() {
-        ///     let _bar = [1_u8; size_of::<*mut T>()];
-        /// }
-        /// ```
-        // FIXME(generic_const_exprs): Remove this bodge once that feature is stable.
-        forbid_generic: bool,
-
         /// Is this within an `impl Foo for bar`?
         is_trait_impl: bool,
     },
@@ -910,8 +887,8 @@ impl<Id> Res<Id> {
             Res::PrimTy(id) => Res::PrimTy(id),
             Res::Local(id) => Res::Local(map(id)),
             Res::SelfTyParam { trait_ } => Res::SelfTyParam { trait_ },
-            Res::SelfTyAlias { alias_to, forbid_generic, is_trait_impl } => {
-                Res::SelfTyAlias { alias_to, forbid_generic, is_trait_impl }
+            Res::SelfTyAlias { alias_to, is_trait_impl } => {
+                Res::SelfTyAlias { alias_to, is_trait_impl }
             }
             Res::ToolMod => Res::ToolMod,
             Res::NonMacroAttr(attr_kind) => Res::NonMacroAttr(attr_kind),
@@ -926,8 +903,8 @@ impl<Id> Res<Id> {
             Res::PrimTy(id) => Res::PrimTy(id),
             Res::Local(id) => Res::Local(map(id)?),
             Res::SelfTyParam { trait_ } => Res::SelfTyParam { trait_ },
-            Res::SelfTyAlias { alias_to, forbid_generic, is_trait_impl } => {
-                Res::SelfTyAlias { alias_to, forbid_generic, is_trait_impl }
+            Res::SelfTyAlias { alias_to, is_trait_impl } => {
+                Res::SelfTyAlias { alias_to, is_trait_impl }
             }
             Res::ToolMod => Res::ToolMod,
             Res::NonMacroAttr(attr_kind) => Res::NonMacroAttr(attr_kind),

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
@@ -2149,7 +2149,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                 );
                 self.check_param_uses_if_mcg(tcx.types.self_param, span, false)
             }
-            Res::SelfTyAlias { alias_to: def_id, forbid_generic: _, .. } => {
+            Res::SelfTyAlias { alias_to: def_id, .. } => {
                 // `Self` in impl (we know the concrete type).
                 assert_eq!(opt_self_ty, None);
                 // Try to evaluate any array length constants.

--- a/compiler/rustc_resolve/src/ident.rs
+++ b/compiler/rustc_resolve/src/ident.rs
@@ -1332,7 +1332,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         &mut self,
         rib_index: usize,
         rib_ident: Ident,
-        mut res: Res,
+        res: Res,
         finalize: Option<Span>,
         original_rib_ident_def: Ident,
         all_ribs: &[Rib<'ra>],
@@ -1485,44 +1485,28 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                         }
 
                         RibKind::ConstantItem(trivial, _) => {
-                            if let ConstantHasGenerics::No(cause) = trivial {
-                                // HACK(min_const_generics): If we encounter `Self` in an anonymous
-                                // constant we can't easily tell if it's generic at this stage, so
-                                // we instead remember this and then enforce the self type to be
-                                // concrete later on.
-                                if let Res::SelfTyAlias {
-                                    alias_to: def,
-                                    forbid_generic: _,
-                                    is_trait_impl,
-                                } = res
-                                {
-                                    res = Res::SelfTyAlias {
-                                        alias_to: def,
-                                        forbid_generic: true,
-                                        is_trait_impl,
-                                    }
-                                } else {
-                                    if let Some(span) = finalize {
-                                        let error = match cause {
-                                            NoConstantGenericsReason::IsEnumDiscriminant => {
-                                                ResolutionError::ParamInEnumDiscriminant {
-                                                    name: rib_ident.name,
-                                                    param_kind: ParamKindInEnumDiscriminant::Type,
-                                                }
+                            if let ConstantHasGenerics::No(cause) = trivial
+                                && !matches!(res, Res::SelfTyAlias { .. })
+                            {
+                                if let Some(span) = finalize {
+                                    let error = match cause {
+                                        NoConstantGenericsReason::IsEnumDiscriminant => {
+                                            ResolutionError::ParamInEnumDiscriminant {
+                                                name: rib_ident.name,
+                                                param_kind: ParamKindInEnumDiscriminant::Type,
                                             }
-                                            NoConstantGenericsReason::NonTrivialConstArg => {
-                                                ResolutionError::ParamInNonTrivialAnonConst {
-                                                    name: rib_ident.name,
-                                                    param_kind:
-                                                        ParamKindInNonTrivialAnonConst::Type,
-                                                }
+                                        }
+                                        NoConstantGenericsReason::NonTrivialConstArg => {
+                                            ResolutionError::ParamInNonTrivialAnonConst {
+                                                name: rib_ident.name,
+                                                param_kind: ParamKindInNonTrivialAnonConst::Type,
                                             }
-                                        };
-                                        let _: ErrorGuaranteed = self.report_error(span, error);
-                                    }
-
-                                    return Res::Err;
+                                        }
+                                    };
+                                    let _: ErrorGuaranteed = self.report_error(span, error);
                                 }
+
+                                return Res::Err;
                             }
 
                             continue;

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -2655,11 +2655,7 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
                 |this| {
                     let item_def_id = this.r.local_def_id(item.id).to_def_id();
                     this.with_self_rib(
-                        Res::SelfTyAlias {
-                            alias_to: item_def_id,
-                            forbid_generic: false,
-                            is_trait_impl: false,
-                        },
+                        Res::SelfTyAlias { alias_to: item_def_id, is_trait_impl: false },
                         |this| {
                             visit::walk_item(this, item);
                         },
@@ -3368,8 +3364,7 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
                                     let item_def_id = item_def_id.to_def_id();
                                     let res = Res::SelfTyAlias {
                                         alias_to: item_def_id,
-                                        forbid_generic: false,
-                                        is_trait_impl: trait_id.is_some()
+                                        is_trait_impl: trait_id.is_some(),
                                     };
                                     this.with_self_rib(res, |this| {
                                         if let Some(of_trait) = of_trait {


### PR DESCRIPTION
Following rust-lang/rust#150519, the `forbid_generic` field in `Res::SelfTyAlias` is no longer needed and can be removed.

- Remove the `forbid_generic: bool` field from `Res::SelfTyAlias`
- Simplify the ConstantItem rib handling in `rustc_resolve` - no longer need to mutate res to set `forbid_generic: true`
- Update all pattern matches and constructors of `SelfTyAlias`

Closes rust-lang/rust#150579

r? @camelid
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
