### PR TITLE
compiler: Make Externally Implementable Items (eii) in std build

### DIFF
--- a/compiler/rustc_builtin_macros/src/eii.rs
+++ b/compiler/rustc_builtin_macros/src/eii.rs
@@ -134,6 +134,7 @@ fn eii_(
         foreign_item_name,
         impl_unsafe,
         decl_span,
+        &attrs_from_decl,
     )));
 
     return_items.into_iter().map(wrap_item).collect()
@@ -353,8 +354,21 @@ fn generate_attribute_macro_to_implement(
     foreign_item_name: Ident,
     impl_unsafe: bool,
     decl_span: Span,
+    attrs_from_decl: &[Attribute],
 ) -> ast::Item {
     let mut macro_attrs = ThinVec::new();
+
+    // To avoid e.g. `error: attribute macro has missing stability attribute`
+    // errors for eii's in std.
+    macro_attrs.extend_from_slice(attrs_from_decl);
+
+    // Needed to avoid lots of unrelated "missing stability attribute" errors on
+    // unrelated items.
+    macro_attrs.push(ecx.attr_name_value_str(
+        sym::rustc_macro_transparency,
+        sym::transparent,
+        span,
+    ));
 
     // #[builtin_macro(eii_shared_macro)]
     macro_attrs.push(ecx.attr_nested_word(sym::rustc_builtin_macro, sym::eii_shared_macro, span));


### PR DESCRIPTION
Closes rust-lang/rust#150514

Merging this PR unblocks https://github.com/rust-lang/rust/pull/150591 and that PR will also act as a regression test since the code in that PR does not build without this fix. We could add a temporary dummy eii item to std before that PR lands, but it does not seem worth the effort.

To be honest I don't fully understand why `#[rustc_macro_transparency = "transparent"]` works, all I know is that it works. Without it, we get > 800 errors that looks like [this](https://github.com/rust-lang/rust/pull/150513#issuecomment-3699690258).

r? @jdonszelmann is maybe interested in reviewing? Of course feel free to re-roll if you don't have time right now though.

### Tracking issues
- https://github.com/rust-lang/rust/issues/125418
- https://github.com/rust-lang/rust/issues/150588