### PR TITLE
Fix typo in the docs of `CString::from_vec_with_nul`

### DIFF
--- a/library/alloc/src/ffi/c_str.rs
+++ b/library/alloc/src/ffi/c_str.rs
@@ -636,7 +636,7 @@ impl CString {
         Self { inner: v.into_boxed_slice() }
     }
 
-    /// Attempts to converts a <code>[Vec]<[u8]></code> to a [`CString`].
+    /// Attempts to convert a <code>[Vec]<[u8]></code> to a [`CString`].
     ///
     /// Runtime checks are present to ensure there is only one nul byte in the
     /// [`Vec`], its last element.


### PR DESCRIPTION
This PR fixes the sentence "Attempts to converts a Vec<u8> to a CString." in the documentation of the method `CString::from_vec_with_nul` (line 639).

This is because "converts" in that sentence should form a to-infinitive form, and therefore should be in its base form.