### PR TITLE
Add specialization for `deque1.prepend(deque2.drain(range))` (VecDeque::prepend and extend_front)

### DIFF
--- a/library/alloc/src/collections/vec_deque/drain.rs
+++ b/library/alloc/src/collections/vec_deque/drain.rs
@@ -25,10 +25,10 @@ pub struct Drain<
     // drain_start is stored in deque.len
     pub(super) drain_len: usize,
     // index into the logical array, not the physical one (always lies in [0..deque.len))
-    idx: usize,
+    pub(super) idx: usize,
     // number of elements after the drained range
     pub(super) tail_len: usize,
-    remaining: usize,
+    pub(super) remaining: usize,
     // Needed to make Drain covariant over T
     _marker: PhantomData<&'a T>,
 }
@@ -53,7 +53,7 @@ impl<'a, T, A: Allocator> Drain<'a, T, A> {
 
     // Only returns pointers to the slices, as that's all we need
     // to drop them. May only be called if `self.remaining != 0`.
-    unsafe fn as_slices(&self) -> (*mut [T], *mut [T]) {
+    pub(super) unsafe fn as_slices(&self) -> (*mut [T], *mut [T]) {
         unsafe {
             let deque = self.deque.as_ref();
 


### PR DESCRIPTION
Tracking issue: rust-lang/rust#146975

This specialization makes sure `deque1.prepend(deque2.drain(..))` gets similar speed to `deque1.append(&mut deque2)`. `deque1.prepend(deque2.drain(..))` is the equivalent of `deque1.append(&mut deque2)` but appending to the front (see the [second example of prepend](https://doc.rust-lang.org/nightly/std/collections/struct.VecDeque.html#method.prepend), prepend is from the same tracking issue).

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
