### PR TITLE
make specialization of `Vec::extend` and `VecDeque::extend_front` work for vec::IntoIter with any `Allocator`, not just `Global`

### DIFF
--- a/library/alloc/src/collections/vec_deque/spec_extend.rs
+++ b/library/alloc/src/collections/vec_deque/spec_extend.rs
@@ -77,8 +77,8 @@ where
 }
 
 #[cfg(not(test))]
-impl<T, A: Allocator> SpecExtend<T, vec::IntoIter<T>> for VecDeque<T, A> {
-    fn spec_extend(&mut self, mut iterator: vec::IntoIter<T>) {
+impl<T, A1: Allocator, A2: Allocator> SpecExtend<T, vec::IntoIter<T, A2>> for VecDeque<T, A1> {
+    fn spec_extend(&mut self, mut iterator: vec::IntoIter<T, A2>) {
         let slice = iterator.as_slice();
         self.reserve(slice.len());
 
@@ -153,9 +153,9 @@ where
 }
 
 #[cfg(not(test))]
-impl<T, A: Allocator> SpecExtendFront<T, vec::IntoIter<T>> for VecDeque<T, A> {
+impl<T, A1: Allocator, A2: Allocator> SpecExtendFront<T, vec::IntoIter<T, A2>> for VecDeque<T, A1> {
     #[track_caller]
-    fn spec_extend_front(&mut self, mut iterator: vec::IntoIter<T>) {
+    fn spec_extend_front(&mut self, mut iterator: vec::IntoIter<T, A2>) {
         let slice = iterator.as_slice();
         // SAFETY: elements in the slice are forgotten after this call
         unsafe { prepend_reversed(self, slice) };
@@ -164,9 +164,11 @@ impl<T, A: Allocator> SpecExtendFront<T, vec::IntoIter<T>> for VecDeque<T, A> {
 }
 
 #[cfg(not(test))]
-impl<T, A: Allocator> SpecExtendFront<T, Rev<vec::IntoIter<T>>> for VecDeque<T, A> {
+impl<T, A1: Allocator, A2: Allocator> SpecExtendFront<T, Rev<vec::IntoIter<T, A2>>>
+    for VecDeque<T, A1>
+{
     #[track_caller]
-    fn spec_extend_front(&mut self, iterator: Rev<vec::IntoIter<T>>) {
+    fn spec_extend_front(&mut self, iterator: Rev<vec::IntoIter<T, A2>>) {
         let mut iterator = iterator.into_inner();
         let slice = iterator.as_slice();
         // SAFETY: elements in the slice are forgotten after this call

--- a/library/alloc/src/vec/spec_extend.rs
+++ b/library/alloc/src/vec/spec_extend.rs
@@ -28,8 +28,8 @@ where
     }
 }
 
-impl<T, A: Allocator> SpecExtend<T, IntoIter<T>> for Vec<T, A> {
-    fn spec_extend(&mut self, mut iterator: IntoIter<T>) {
+impl<T, A1: Allocator, A2: Allocator> SpecExtend<T, IntoIter<T, A2>> for Vec<T, A1> {
+    fn spec_extend(&mut self, mut iterator: IntoIter<T, A2>) {
         unsafe {
             self.append_elements(iterator.as_slice() as _);
         }


### PR DESCRIPTION
These functions consume all the elements from the respective collection, but do not care about the `Allocator` they use. Without specifying one (like in `vec::IntoIter<T>`) the specialization is only chosen when `A=Global`.

(extra context: `VecDeque::extend_front` is unstable and tracked by rust-lang/rust#146975)

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
