### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/compiler/rustc_hir_analysis/src/check/intrinsic.rs
+++ b/compiler/rustc_hir_analysis/src/check/intrinsic.rs
@@ -4,7 +4,7 @@ use rustc_abi::ExternAbi;
 use rustc_errors::DiagMessage;
 use rustc_hir::{self as hir, LangItem};
 use rustc_middle::traits::{ObligationCause, ObligationCauseCode};
-use rustc_middle::ty::{self, Ty, TyCtxt};
+use rustc_middle::ty::{self, Const, Ty, TyCtxt};
 use rustc_span::def_id::LocalDefId;
 use rustc_span::{Span, Symbol, sym};
 
@@ -315,7 +315,17 @@ pub(crate) fn check_intrinsic_type(
             let type_id = tcx.type_of(tcx.lang_items().type_id().unwrap()).instantiate_identity();
             (0, 0, vec![type_id, type_id], tcx.types.bool)
         }
-        sym::offload => (3, 0, vec![param(0), param(1)], param(2)),
+        sym::offload => (
+            3,
+            0,
+            vec![
+                param(0),
+                Ty::new_array_with_const_len(tcx, tcx.types.u32, Const::from_target_usize(tcx, 3)),
+                Ty::new_array_with_const_len(tcx, tcx.types.u32, Const::from_target_usize(tcx, 3)),
+                param(1),
+            ],
+            param(2),
+        ),
         sym::offset => (2, 0, vec![param(0), param(1)], param(0)),
         sym::arith_offset => (
             1,

--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -1218,6 +1218,12 @@ impl<'tcx> Ty<'tcx> {
         *self.kind() == Str
     }
 
+    /// Returns true if this type is `&str`. The reference's lifetime is ignored.
+    #[inline]
+    pub fn is_imm_ref_str(self) -> bool {
+        matches!(self.kind(), ty::Ref(_, inner, hir::Mutability::Not) if inner.is_str())
+    }
+
     #[inline]
     pub fn is_param(self, index: u32) -> bool {
         match self.kind() {

--- a/compiler/rustc_mir_build/src/builder/matches/buckets.rs
+++ b/compiler/rustc_mir_build/src/builder/matches/buckets.rs
@@ -314,7 +314,11 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             }
 
             (
-                TestKind::Eq { value: test_val, .. },
+                TestKind::StringEq { value: test_val, .. },
+                TestableCase::Constant { value: case_val, kind: PatConstKind::String },
+            )
+            | (
+                TestKind::ScalarEq { value: test_val, .. },
                 TestableCase::Constant {
                     value: case_val,
                     kind: PatConstKind::Float | PatConstKind::Other,
@@ -347,7 +351,8 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 | TestKind::If
                 | TestKind::SliceLen { .. }
                 | TestKind::Range { .. }
-                | TestKind::Eq { .. }
+                | TestKind::StringEq { .. }
+                | TestKind::ScalarEq { .. }
                 | TestKind::Deref { .. },
                 _,
             ) => {

--- a/compiler/rustc_mir_build/src/builder/matches/mod.rs
+++ b/compiler/rustc_mir_build/src/builder/matches/mod.rs
@@ -1290,9 +1290,10 @@ enum PatConstKind {
     /// These types don't support `SwitchInt` and require an equality test,
     /// but can also interact with range pattern tests.
     Float,
+    /// Constant string values, tested via string equality.
+    String,
     /// Any other constant-pattern is usually tested via some kind of equality
     /// check. Types that might be encountered here include:
-    /// - `&str`
     /// - raw pointers derived from integer values
     /// - pattern types, e.g. `pattern_type!(u32 is 1..)`
     Other,
@@ -1368,14 +1369,20 @@ enum TestKind<'tcx> {
     /// Test whether a `bool` is `true` or `false`.
     If,
 
-    /// Test for equality with value, possibly after an unsizing coercion to
-    /// `cast_ty`,
-    Eq {
+    /// Tests the place against a string constant using string equality.
+    StringEq {
+        /// Constant `&str` value to test against.
         value: ty::Value<'tcx>,
-        // Integer types are handled by `SwitchInt`, and constants with ADT
-        // types and `&[T]` types are converted back into patterns, so this can
-        // only be `&str` or floats.
-        cast_ty: Ty<'tcx>,
+        /// Type of the corresponding pattern node. Usually `&str`, but could
+        /// be `str` for patterns like `deref!("..."): String`.
+        pat_ty: Ty<'tcx>,
+    },
+
+    /// Tests the place against a constant using scalar equality.
+    ScalarEq {
+        value: ty::Value<'tcx>,
+        /// Type of the corresponding pattern node.
+        pat_ty: Ty<'tcx>,
     },
 
     /// Test whether the value falls within an inclusive or exclusive range.

--- a/compiler/rustc_mir_build/src/builder/matches/test.rs
+++ b/compiler/rustc_mir_build/src/builder/matches/test.rs
@@ -38,11 +38,11 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             TestableCase::Constant { value: _, kind: PatConstKind::IntOrChar } => {
                 TestKind::SwitchInt
             }
-            TestableCase::Constant { value, kind: PatConstKind::Float } => {
-                TestKind::Eq { value, cast_ty: match_pair.pattern_ty }
+            TestableCase::Constant { value, kind: PatConstKind::String } => {
+                TestKind::StringEq { value, pat_ty: match_pair.pattern_ty }
             }
-            TestableCase::Constant { value, kind: PatConstKind::Other } => {
-                TestKind::Eq { value, cast_ty: match_pair.pattern_ty }
+            TestableCase::Constant { value, kind: PatConstKind::Float | PatConstKind::Other } => {
+                TestKind::ScalarEq { value, pat_ty: match_pair.pattern_ty }
             }
 
             TestableCase::Range(ref range) => {
@@ -141,7 +141,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 self.cfg.terminate(block, self.source_info(match_start_span), terminator);
             }
 
-            TestKind::Eq { value, cast_ty: pat_ty } => {
+            TestKind::StringEq { value, pat_ty } | TestKind::ScalarEq { value, pat_ty } => {
                 let tcx = self.tcx;
                 let success_block = target_block(TestBranch::Success);
                 let fail_block = target_block(TestBranch::Failure);

--- a/compiler/rustc_mir_build/src/builder/matches/test.rs
+++ b/compiler/rustc_mir_build/src/builder/matches/test.rs
@@ -141,17 +141,19 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 self.cfg.terminate(block, self.source_info(match_start_span), terminator);
             }
 
-            TestKind::Eq { value, mut cast_ty } => {
+            TestKind::Eq { value, cast_ty: pat_ty } => {
                 let tcx = self.tcx;
                 let success_block = target_block(TestBranch::Success);
                 let fail_block = target_block(TestBranch::Failure);
 
-                let mut expect_ty = value.ty;
-                let mut expect = self.literal_operand(test.span, Const::from_ty_value(tcx, value));
+                let mut expected_value_ty = value.ty;
+                let mut expected_value_operand =
+                    self.literal_operand(test.span, Const::from_ty_value(tcx, value));
 
-                let mut place = place;
+                let mut actual_value_ty = pat_ty;
+                let mut actual_value_place = place;
 
-                match cast_ty.kind() {
+                match pat_ty.kind() {
                     ty::Str => {
                         // String literal patterns may have type `str` if `deref_patterns` is
                         // enabled, in order to allow `deref!("..."): String`. In this case, `value`
@@ -172,11 +174,11 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                             ref_place,
                             Rvalue::Ref(re_erased, BorrowKind::Shared, place),
                         );
-                        place = ref_place;
-                        cast_ty = ref_str_ty;
+                        actual_value_place = ref_place;
+                        actual_value_ty = ref_str_ty;
                     }
                     &ty::Pat(base, _) => {
-                        assert_eq!(cast_ty, value.ty);
+                        assert_eq!(pat_ty, value.ty);
                         assert!(base.is_trivially_pure_clone_copy());
 
                         let transmuted_place = self.temp(base, test.span);
@@ -184,7 +186,11 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                             block,
                             self.source_info(scrutinee_span),
                             transmuted_place,
-                            Rvalue::Cast(CastKind::Transmute, Operand::Copy(place), base),
+                            Rvalue::Cast(
+                                CastKind::Transmute,
+                                Operand::Copy(actual_value_place),
+                                base,
+                            ),
                         );
 
                         let transmuted_expect = self.temp(base, test.span);
@@ -192,19 +198,19 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                             block,
                             self.source_info(test.span),
                             transmuted_expect,
-                            Rvalue::Cast(CastKind::Transmute, expect, base),
+                            Rvalue::Cast(CastKind::Transmute, expected_value_operand, base),
                         );
 
-                        place = transmuted_place;
-                        expect = Operand::Copy(transmuted_expect);
-                        cast_ty = base;
-                        expect_ty = base;
+                        actual_value_place = transmuted_place;
+                        actual_value_ty = base;
+                        expected_value_operand = Operand::Copy(transmuted_expect);
+                        expected_value_ty = base;
                     }
                     _ => {}
                 }
 
-                assert_eq!(expect_ty, cast_ty);
-                if !cast_ty.is_scalar() {
+                assert_eq!(expected_value_ty, actual_value_ty);
+                if !actual_value_ty.is_scalar() {
                     // Use `PartialEq::eq` instead of `BinOp::Eq`
                     // (the binop can only handle primitives)
                     // Make sure that we do *not* call any user-defined code here.
@@ -212,12 +218,12 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     // comparison defined in `core`.
                     // (Interestingly this means that exhaustiveness analysis relies, for soundness,
                     // on the `PartialEq` impl for `str` to b correct!)
-                    match *cast_ty.kind() {
+                    match *actual_value_ty.kind() {
                         ty::Ref(_, deref_ty, _) if deref_ty == self.tcx.types.str_ => {}
                         _ => {
                             span_bug!(
                                 source_info.span,
-                                "invalid type for non-scalar compare: {cast_ty}"
+                                "invalid type for non-scalar compare: {actual_value_ty}"
                             )
                         }
                     };
@@ -226,8 +232,8 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                         success_block,
                         fail_block,
                         source_info,
-                        expect,
-                        Operand::Copy(place),
+                        expected_value_operand,
+                        Operand::Copy(actual_value_place),
                     );
                 } else {
                     self.compare(
@@ -236,8 +242,8 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                         fail_block,
                         source_info,
                         BinOp::Eq,
-                        expect,
-                        Operand::Copy(place),
+                        expected_value_operand,
+                        Operand::Copy(actual_value_place),
                     );
                 }
             }

--- a/library/alloc/src/ffi/c_str.rs
+++ b/library/alloc/src/ffi/c_str.rs
@@ -636,7 +636,7 @@ impl CString {
         Self { inner: v.into_boxed_slice() }
     }
 
-    /// Attempts to converts a <code>[Vec]<[u8]></code> to a [`CString`].
+    /// Attempts to convert a <code>[Vec]<[u8]></code> to a [`CString`].
     ///
     /// Runtime checks are present to ensure there is only one nul byte in the
     /// [`Vec`], its last element.

--- a/library/core/src/convert/mod.rs
+++ b/library/core/src/convert/mod.rs
@@ -308,8 +308,8 @@ pub const trait AsRef<T: PointeeSized>: PointeeSized {
 /// both `AsMut<Vec<T>>` and `AsMut<[T]>`.
 ///
 /// In the following, the example functions `caesar` and `null_terminate` provide a generic
-/// interface which work with any type that can be converted by cheap mutable-to-mutable conversion
-/// into a byte slice (`[u8]`) or byte vector (`Vec<u8>`), respectively.
+/// interface which works with any type that can be converted by cheap mutable-to-mutable conversion
+/// into a byte slice (`[u8]`) or a byte vector (`Vec<u8>`), respectively.
 ///
 /// [dereference]: core::ops::DerefMut
 /// [target type]: core::ops::Deref::Target

--- a/library/core/src/intrinsics/mod.rs
+++ b/library/core/src/intrinsics/mod.rs
@@ -3385,11 +3385,17 @@ pub const fn autodiff<F, G, T: crate::marker::Tuple, R>(f: F, df: G, args: T) ->
 /// - `T`: A tuple of arguments passed to `f`.
 /// - `R`: The return type of the kernel.
 ///
+/// Arguments:
+/// - `f`: The kernel function to offload.
+/// - `workgroup_dim`: A 3D size specifying the number of workgroups to launch.
+/// - `thread_dim`: A 3D size specifying the number of threads per workgroup.
+/// - `args`: A tuple of arguments forwarded to `f`.
+///
 /// Example usage (pseudocode):
 ///
 /// ```rust,ignore (pseudocode)
 /// fn kernel(x: *mut [f64; 128]) {
-///     core::intrinsics::offload(kernel_1, (x,))
+///     core::intrinsics::offload(kernel_1, [256, 1, 1], [32, 1, 1], (x,))
 /// }
 ///
 /// #[cfg(target_os = "linux")]
@@ -3408,7 +3414,12 @@ pub const fn autodiff<F, G, T: crate::marker::Tuple, R>(f: F, df: G, args: T) ->
 /// <https://clang.llvm.org/docs/OffloadingDesign.html>.
 #[rustc_nounwind]
 #[rustc_intrinsic]
-pub const fn offload<F, T: crate::marker::Tuple, R>(f: F, args: T) -> R;
+pub const fn offload<F, T: crate::marker::Tuple, R>(
+    f: F,
+    workgroup_dim: [u32; 3],
+    thread_dim: [u32; 3],
+    args: T,
+) -> R;
 
 /// Inform Miri that a given pointer definitely has a certain alignment.
 #[cfg(miri)]

--- a/library/unwind/src/libunwind.rs
+++ b/library/unwind/src/libunwind.rs
@@ -78,8 +78,8 @@ pub const unwinder_private_data_size: usize = 20;
 #[cfg(all(target_arch = "wasm32", target_os = "linux"))]
 pub const unwinder_private_data_size: usize = 2;
 
-#[cfg(all(target_arch = "hexagon", target_os = "linux"))]
-pub const unwinder_private_data_size: usize = 35;
+#[cfg(target_arch = "hexagon")]
+pub const unwinder_private_data_size: usize = 5;
 
 #[cfg(any(target_arch = "loongarch32", target_arch = "loongarch64"))]
 pub const unwinder_private_data_size: usize = 2;

--- a/src/build_helper/src/npm.rs
+++ b/src/build_helper/src/npm.rs
@@ -22,7 +22,16 @@ pub fn install(src_root_path: &Path, out_dir: &Path, yarn: &Path) -> Result<Path
     cmd.arg("--frozen");
 
     cmd.current_dir(out_dir);
-    let exit_status = cmd.spawn()?.wait()?;
+    let exit_status = cmd
+        .spawn()
+        .map_err(|err| {
+            eprintln!("can not run yarn install");
+            io::Error::other(Box::<dyn Error + Send + Sync>::from(format!(
+                "unable to run yarn: {}",
+                err.kind()
+            )))
+        })?
+        .wait()?;
     if !exit_status.success() {
         eprintln!("yarn install did not exit successfully");
         return Err(io::Error::other(Box::<dyn Error + Send + Sync>::from(format!(

--- a/src/doc/rustc-dev-guide/src/offload/usage.md
+++ b/src/doc/rustc-dev-guide/src/offload/usage.md
@@ -57,7 +57,7 @@ fn main() {
 
 #[inline(never)]
 unsafe fn kernel(x: *mut [f64; 256]) {
-    core::intrinsics::offload(kernel_1, (x,))
+    core::intrinsics::offload(_kernel_1, [256, 1, 1], [32, 1, 1], (x,))
 }
 
 #[cfg(target_os = "linux")]

--- a/tests/codegen-llvm/gpu_offload/control_flow.rs
+++ b/tests/codegen-llvm/gpu_offload/control_flow.rs
@@ -21,14 +21,19 @@
 // CHECK-NOT define
 // CHECK: bb3
 // CHECK: call void @__tgt_target_data_begin_mapper(ptr nonnull @anon.{{.*}}.1, i64 -1, i32 1, ptr nonnull %.offload_baseptrs, ptr nonnull %.offload_ptrs, ptr nonnull %.offload_sizes, ptr nonnull @.offload_maptypes.foo, ptr null, ptr null)
-// CHECK: %10 = call i32 @__tgt_target_kernel(ptr nonnull @anon.{{.*}}.1, i64 -1, i32 2097152, i32 256, ptr nonnull @.foo.region_id, ptr nonnull %kernel_args)
+// CHECK: %10 = call i32 @__tgt_target_kernel(ptr nonnull @anon.{{.*}}.1, i64 -1, i32 256, i32 32, ptr nonnull @.foo.region_id, ptr nonnull %kernel_args)
 // CHECK-NEXT: call void @__tgt_target_data_end_mapper(ptr nonnull @anon.{{.*}}.1, i64 -1, i32 1, ptr nonnull %.offload_baseptrs, ptr nonnull %.offload_ptrs, ptr nonnull %.offload_sizes, ptr nonnull @.offload_maptypes.foo, ptr null, ptr null)
 #[unsafe(no_mangle)]
 unsafe fn main() {
     let A = [1.0, 1.0, 1.0, 1.0, 1.0, 1.0];
 
     for i in 0..100 {
-        core::intrinsics::offload::<_, _, ()>(foo, (A.as_ptr() as *const [f32; 6],));
+        core::intrinsics::offload::<_, _, ()>(
+            foo,
+            [256, 1, 1],
+            [32, 1, 1],
+            (A.as_ptr() as *const [f32; 6],),
+        );
     }
 }
 

--- a/tests/codegen-llvm/gpu_offload/gpu_host.rs
+++ b/tests/codegen-llvm/gpu_offload/gpu_host.rs
@@ -82,14 +82,14 @@ fn main() {
 // CHECK-NEXT:   %5 = getelementptr inbounds nuw i8, ptr %kernel_args, i64 40
 // CHECK-NEXT:   %6 = getelementptr inbounds nuw i8, ptr %kernel_args, i64 72
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr noundef nonnull align 8 dereferenceable(32) %5, i8 0, i64 32, i1 false)
-// CHECK-NEXT:   store <4 x i32> <i32 2097152, i32 0, i32 0, i32 256>, ptr %6, align 8
-// CHECK-NEXT:   %.fca.1.gep3 = getelementptr inbounds nuw i8, ptr %kernel_args, i64 88
-// CHECK-NEXT:   store i32 0, ptr %.fca.1.gep3, align 8
-// CHECK-NEXT:   %.fca.2.gep4 = getelementptr inbounds nuw i8, ptr %kernel_args, i64 92
-// CHECK-NEXT:   store i32 0, ptr %.fca.2.gep4, align 4
+// CHECK-NEXT:   store <4 x i32> <i32 256, i32 1, i32 1, i32 32>, ptr %6, align 8
+// CHECK-NEXT:   %.fca.1.gep5 = getelementptr inbounds nuw i8, ptr %kernel_args, i64 88
+// CHECK-NEXT:   store i32 1, ptr %.fca.1.gep5, align 8
+// CHECK-NEXT:   %.fca.2.gep7 = getelementptr inbounds nuw i8, ptr %kernel_args, i64 92
+// CHECK-NEXT:   store i32 1, ptr %.fca.2.gep7, align 4
 // CHECK-NEXT:   %7 = getelementptr inbounds nuw i8, ptr %kernel_args, i64 96
 // CHECK-NEXT:   store i32 0, ptr %7, align 8
-// CHECK-NEXT:   %8 = call i32 @__tgt_target_kernel(ptr nonnull @anon.{{.*}}.1, i64 -1, i32 2097152, i32 256, ptr nonnull @._kernel_1.region_id, ptr nonnull %kernel_args)
+// CHECK-NEXT:   %8 = call i32 @__tgt_target_kernel(ptr nonnull @anon.{{.*}}.1, i64 -1, i32 256, i32 32, ptr nonnull @._kernel_1.region_id, ptr nonnull %kernel_args)
 // CHECK-NEXT:   call void @__tgt_target_data_end_mapper(ptr nonnull @anon.{{.*}}.1, i64 -1, i32 1, ptr nonnull %.offload_baseptrs, ptr nonnull %.offload_ptrs, ptr nonnull %.offload_sizes, ptr nonnull @.offload_maptypes._kernel_1, ptr null, ptr null)
 // CHECK-NEXT:   call void @__tgt_unregister_lib(ptr nonnull %EmptyDesc)
 // CHECK-NEXT:   ret void
@@ -98,7 +98,7 @@ fn main() {
 #[unsafe(no_mangle)]
 #[inline(never)]
 pub fn kernel_1(x: &mut [f32; 256]) {
-    core::intrinsics::offload(_kernel_1, (x,))
+    core::intrinsics::offload(_kernel_1, [256, 1, 1], [32, 1, 1], (x,))
 }
 
 #[unsafe(no_mangle)]


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#150425 (mapping an error from cmd.spawn() in npm::install)
 - rust-lang/rust#150444 (Expose kernel launch options as offload intrinsic args)
 - rust-lang/rust#150495 (Correct hexagon "unwinder_private_data_size")
 - rust-lang/rust#150578 (Fix a typo in the docs of AsMut for rust-lang/rust#149609)
 - rust-lang/rust#150581 (mir_build: Separate match lowering for string-equality and scalar-equality)
 - rust-lang/rust#150594 (Fix typo in the docs of `CString::from_vec_with_nul`)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=150425,150444,150495,150578,150581,150594)
<!-- homu-ignore:end -->