### PR TITLE
Implement `try_new_uninit_slice` and similar for `Arc` and `Rc`

### DIFF
--- a/library/alloc/src/ffi/c_str.rs
+++ b/library/alloc/src/ffi/c_str.rs
@@ -636,7 +636,7 @@ impl CString {
         Self { inner: v.into_boxed_slice() }
     }
 
-    /// Attempts to converts a <code>[Vec]<[u8]></code> to a [`CString`].
+    /// Attempts to convert a <code>[Vec]<[u8]></code> to a [`CString`].
     ///
     /// Runtime checks are present to ensure there is only one nul byte in the
     /// [`Vec`], its last element.

--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -1166,8 +1166,8 @@ impl<T> Rc<[T]> {
     /// # Examples
     ///
     /// ```
-    ///
     /// #![feature(allocator_api)]
+    ///
     /// use std::rc::Rc;
     ///
     /// let mut values = Rc::<[u32]>::try_new_uninit_slice(3)?;
@@ -1191,7 +1191,7 @@ impl<T> Rc<[T]> {
         }
     }
     /// Constructs a new reference-counted slice with uninitialized contents, with the memory being
-    /// filled with `0` bytes.
+    /// filled with `0` bytes. Returns an error if the allocation fails.
     ///
     /// See [`MaybeUninit::zeroed`][zeroed] for examples of correct and
     /// incorrect usage of this method.
@@ -1200,6 +1200,7 @@ impl<T> Rc<[T]> {
     ///
     /// ```
     /// #![feature(allocator_api)]
+    ///
     /// use std::rc::Rc;
     ///
     /// let values = Rc::<[u32]>::try_new_zeroed_slice(3)?;
@@ -1319,6 +1320,7 @@ impl<T, A: Allocator> Rc<[T], A> {
     }
 
     /// Constructs a new reference-counted slice with uninitialized contents.
+    /// Returns an error if the allocation fails.
     ///
     /// # Examples
     ///
@@ -1351,7 +1353,7 @@ impl<T, A: Allocator> Rc<[T], A> {
         }
     }
     /// Constructs a new reference-counted slice with uninitialized contents, with the memory being
-    /// filled with `0` bytes.
+    /// filled with `0` bytes.  Returns an error if the allocation fails.
     ///
     /// See [`MaybeUninit::zeroed`][zeroed] for examples of correct and
     /// incorrect usage of this method.
@@ -2437,6 +2439,8 @@ impl<T> Rc<[T]> {
             Self::allocate_for_slice_in(len, &Global)
         }
     }
+    /// Allocates an `RcInner<[T]>` with the given length. Returns an error if
+    /// the allocation fails.
     #[inline]
     #[cfg(not(no_global_oom_handling))]
     unsafe fn try_allocate_for_slice(len: usize) -> Result<*mut RcInner<[T]>, AllocError> {
@@ -2517,10 +2521,12 @@ impl<T, A: Allocator> Rc<[T], A> {
             Rc::allocate_for_layout(
                 Layout::array::<T>(len).unwrap(),
                 |layout| alloc.allocate(layout),
-                |mem: *mut u8| ptr::slice_from_raw_parts_mut(mem.cast::<T>(), len) as *mut RcInner<[T]>,
+                |mem| ptr::slice_from_raw_parts_mut(mem.cast::<T>(), len) as *mut RcInner<[T]>,
             )
         }
     }
+    /// Allocates an `RcInner<[T]>` with the given length. Returns an error if
+    /// the allocation fails.
     #[inline]
     #[cfg(not(no_global_oom_handling))]
     unsafe fn try_allocate_for_slice_in(len: usize, alloc: &A) -> Result<*mut RcInner<[T]>, AllocError> {
@@ -2528,7 +2534,7 @@ impl<T, A: Allocator> Rc<[T], A> {
             Rc::try_allocate_for_layout(
                 Layout::array::<T>(len).unwrap(),
                 |layout| alloc.allocate(layout),
-                |mem: *mut u8| ptr::slice_from_raw_parts_mut(mem.cast::<T>(), len) as *mut RcInner<[T]>,
+                |mem| ptr::slice_from_raw_parts_mut(mem.cast::<T>(), len) as *mut RcInner<[T]>,
             )
         }
     }


### PR DESCRIPTION
This PR implements 4 new methods on both `Rc<T, A>` and `Arc<T, A>`:
* `try_new_uninit_slice`
* `try_new_zeroed_slice`
* `try_new_uninit_slice_in`
* `try_new_zeroed_slice_in`

# Motivation
This is to match `Box<T, A>`, which already implements all these methods, and in all constructors, `Rc` and `Arc` only miss these 4.

# Implementation
All 4 of these are implemented in the same way their version without `try_` is implemented, but using `try_allocate_for_layout` instead of `allocate_for_layout`, forwarding its error to the caller.