### PR TITLE
alloc: Move Cow impl to existing ones

### DIFF
--- a/library/alloc/src/borrow.rs
+++ b/library/alloc/src/borrow.rs
@@ -16,19 +16,6 @@ use crate::fmt;
 #[cfg(not(no_global_oom_handling))]
 use crate::string::String;
 
-// FIXME(inference): const bounds removed due to inference regressions found by crater;
-//   see https://github.com/rust-lang/rust/issues/147964
-// #[rustc_const_unstable(feature = "const_convert", issue = "143773")]
-#[stable(feature = "rust1", since = "1.0.0")]
-impl<'a, B: ?Sized + ToOwned> Borrow<B> for Cow<'a, B>
-// where
-//     B::Owned: [const] Borrow<B>,
-{
-    fn borrow(&self) -> &B {
-        &**self
-    }
-}
-
 /// A generalization of `Clone` to borrowed data.
 ///
 /// Some types make it possible to go from borrowed to owned, usually by
@@ -190,6 +177,19 @@ where
     /// Owned data.
     #[stable(feature = "rust1", since = "1.0.0")]
     Owned(#[stable(feature = "rust1", since = "1.0.0")] <B as ToOwned>::Owned),
+}
+
+// FIXME(inference): const bounds removed due to inference regressions found by crater;
+//   see https://github.com/rust-lang/rust/issues/147964
+// #[rustc_const_unstable(feature = "const_convert", issue = "143773")]
+#[stable(feature = "rust1", since = "1.0.0")]
+impl<'a, B: ?Sized + ToOwned> Borrow<B> for Cow<'a, B>
+// where
+//     B::Owned: [const] Borrow<B>,
+{
+    fn borrow(&self) -> &B {
+        &**self
+    }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]


### PR DESCRIPTION
Right now, the `borrow.rs` module starts with a `Cow` impl, although most of them can be found below.

This hurts code readability because there is `ToOwned` alongside its impl directly below it.

Moving it to the others down below makes sense here, given that the entire enum depends on `ToOwned` anyways.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
