### PR TITLE
Stabilize `-Zdebuginfo-compression` as `-Cdebuginfo-compression`

### DIFF
--- a/compiler/rustc_codegen_llvm/src/back/write.rs
+++ b/compiler/rustc_codegen_llvm/src/back/write.rs
@@ -250,7 +250,7 @@ pub(crate) fn target_machine_factory(
 
     let use_emulated_tls = matches!(sess.tls_model(), TlsModel::Emulated);
 
-    let debuginfo_compression = match sess.opts.unstable_opts.debuginfo_compression {
+    let debuginfo_compression = match sess.debuginfo_compression() {
         config::DebugInfoCompression::None => llvm::CompressionKind::None,
         config::DebugInfoCompression::Zlib => {
             if llvm::LLVMRustLLVMHasZlibCompression() {

--- a/compiler/rustc_codegen_ssa/src/back/linker.rs
+++ b/compiler/rustc_codegen_ssa/src/back/linker.rs
@@ -756,7 +756,7 @@ impl<'a> Linker for GccLinker<'a> {
                 self.link_arg("--strip-all");
             }
         }
-        match self.sess.opts.unstable_opts.debuginfo_compression {
+        match self.sess.debuginfo_compression() {
             config::DebugInfoCompression::None => {}
             config::DebugInfoCompression::Zlib => {
                 self.link_arg("--compress-debug-sections=zlib");

--- a/compiler/rustc_codegen_ssa/src/traits/backend.rs
+++ b/compiler/rustc_codegen_ssa/src/traits/backend.rs
@@ -81,7 +81,7 @@ pub trait CodegenBackend {
     /// Value printed by `--print=backend-has-zstd`.
     ///
     /// Used by compiletest to determine whether tests involving zstd compression
-    /// (e.g. `-Zdebuginfo-compression=zstd`) should be executed or skipped.
+    /// (e.g. `-Cdebuginfo-compression=zstd`) should be executed or skipped.
     fn has_zstd(&self) -> bool {
         false
     }

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -1357,15 +1357,15 @@ pub mod parse {
     }
 
     pub(crate) fn parse_debuginfo_compression(
-        slot: &mut DebugInfoCompression,
+        slot: &mut Option<DebugInfoCompression>,
         v: Option<&str>,
     ) -> bool {
-        match v {
-            Some("none") => *slot = DebugInfoCompression::None,
-            Some("zlib") => *slot = DebugInfoCompression::Zlib,
-            Some("zstd") => *slot = DebugInfoCompression::Zstd,
+        *slot = Some(match v {
+            Some("none") => DebugInfoCompression::None,
+            Some("zlib") => DebugInfoCompression::Zlib,
+            Some("zstd") => DebugInfoCompression::Zstd,
             _ => return false,
-        };
+        });
         true
     }
 
@@ -2101,6 +2101,9 @@ options! {
     debuginfo: DebugInfo = (DebugInfo::None, parse_debuginfo, [TRACKED],
         "debug info emission level (0-2, none, line-directives-only, \
         line-tables-only, limited, or full; default: 0)"),
+    #[rustc_lint_opt_deny_field_access("use `Session::debuginfo_compression` instead of this field")]
+    debuginfo_compression: Option<DebugInfoCompression> = (None, parse_debuginfo_compression, [TRACKED],
+        "compress debug info sections (none, zlib, zstd, default: none)"),
     default_linker_libraries: bool = (false, parse_bool, [UNTRACKED],
         "allow the linker to link its default libraries (default: no)"),
     dlltool: Option<PathBuf> = (None, parse_opt_pathbuf, [UNTRACKED],
@@ -2291,7 +2294,8 @@ options! {
         "emit discriminators and other data necessary for AutoFDO"),
     debug_info_type_line_numbers: bool = (false, parse_bool, [TRACKED],
         "emit type and line information for additional data types (default: no)"),
-    debuginfo_compression: DebugInfoCompression = (DebugInfoCompression::None, parse_debuginfo_compression, [TRACKED],
+    #[rustc_lint_opt_deny_field_access("use `Session::debuginfo_compression` instead of this field")]
+    debuginfo_compression: Option<DebugInfoCompression> = (None, parse_debuginfo_compression, [TRACKED],
         "compress debug info sections (none, zlib, zstd, default: none)"),
     deduplicate_diagnostics: bool = (true, parse_bool, [UNTRACKED],
         "deduplicate identical diagnostics (default: yes)"),

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -37,8 +37,9 @@ use rustc_target::spec::{
 use crate::code_stats::CodeStats;
 pub use crate::code_stats::{DataTypeKind, FieldInfo, FieldKind, SizeKind, VariantInfo};
 use crate::config::{
-    self, CoverageLevel, CoverageOptions, CrateType, DebugInfo, ErrorOutputType, FunctionReturn,
-    Input, InstrumentCoverage, OptLevel, OutFileName, OutputType, SwitchWithOptPath,
+    self, CoverageLevel, CoverageOptions, CrateType, DebugInfo, DebugInfoCompression,
+    ErrorOutputType, FunctionReturn, Input, InstrumentCoverage, OptLevel, OutFileName, OutputType,
+    SwitchWithOptPath,
 };
 use crate::filesearch::FileSearch;
 use crate::lint::LintId;
@@ -711,6 +712,14 @@ impl Session {
             .dwarf_version
             .or(self.opts.unstable_opts.dwarf_version)
             .unwrap_or(self.target.default_dwarf_version)
+    }
+
+    pub fn debuginfo_compression(&self) -> DebugInfoCompression {
+        self.opts
+            .cg
+            .debuginfo_compression
+            .or(self.opts.unstable_opts.debuginfo_compression)
+            .unwrap_or(DebugInfoCompression::None)
     }
 
     pub fn stack_protector(&self) -> StackProtector {

--- a/src/doc/rustc/src/codegen-options/index.md
+++ b/src/doc/rustc/src/codegen-options/index.md
@@ -91,6 +91,26 @@ following values:
 
 Note: The [`-g` flag][option-g-debug] is an alias for `-C debuginfo=2`.
 
+## debuginfo-compression
+
+This flag controls how debug information is compressed. It takes one of the
+following values:
+
+* `none`: debug info is not compressed (the default).
+* `zlib`: debug info is compressed using zlib.
+* `zstd`: debug info is compressed using zstd.
+
+Tools which read debug info such as debuggers and profilers must support the
+compression algorithm or they will be unable to process the debug info. `zlib`
+compression tends to be well supported by Linux tools but `zstd` may require
+very recent versions of such tools.
+
+Compressing debug info can improve binary size but will increase time and memory
+used during compilation.
+
+This flag is ignored by the compiler if the target does not support the specified
+compression algorithm.
+
 ## default-linker-libraries
 
 This flag controls whether or not the linker includes its default libraries.

--- a/tests/run-make/compressed-debuginfo-zstd/rmake.rs
+++ b/tests/run-make/compressed-debuginfo-zstd/rmake.rs
@@ -13,7 +13,7 @@ use run_make_support::{Rustc, llvm_readobj, run_in_tmpdir};
 fn check_compression(compression: &str, to_find: &str) {
     // check compressed debug sections via rustc flag
     prepare_and_check(to_find, |rustc| {
-        rustc.arg(&format!("-Zdebuginfo-compression={compression}"))
+        rustc.arg(&format!("-Cdebuginfo-compression={compression}"))
     });
 
     // check compressed debug sections via rust-lld flag

--- a/tests/run-make/compressed-debuginfo/rmake.rs
+++ b/tests/run-make/compressed-debuginfo/rmake.rs
@@ -14,7 +14,7 @@ fn check_compression(compression: &str, to_find: &str) {
             .crate_type("lib")
             .emit("obj")
             .arg("-Cdebuginfo=full")
-            .arg(&format!("-Zdebuginfo-compression={compression}"))
+            .arg(&format!("-Cdebuginfo-compression={compression}"))
             .input("foo.rs")
             .run();
         let stderr = out.stderr_utf8();


### PR DESCRIPTION
I propose stabilizing `-Zdebuginfo-compression` as `-Cdebuginfo-compression`. This PR adds a new `-Cdebuginfo-compression` flag, leaving the unstable `-Z` flag as-is to ease the transition period. The `-Z` flag will be removed in the future.

# `-Zdebuginfo-compression` stabilization report

## What is the RFC for this feature and what changes have occurred to the user-facing design since the RFC was finalized?

No RFC/MCP, this flag was added in https://github.com/rust-lang/rust/pull/115358 and was not deemed large enough to require additional process.

The tracking issue for this feature is rust-lang/rust#120953.

## What behavior are we committing to that has been controversial? Summarize the major arguments pro/con.

None that has been extensively debated but there is one obvious question:
  
1. What is the behavior when flag is used on targets that do not support compressed debuginfo?
  Currently, passing `-{C,Z} debuginfo-compression` on targets like `*-windows-msvc` does not do anything. I believe it generally makes sense to alert the user when codegen flags are being ignored and I've opened an MCP https://github.com/rust-lang/compiler-team/issues/957 that proposes handling this in a consistent way rather than on a ad-hoc, per-flag basis. 

## Are there extensions to this feature that remain unstable? How do we know that we are not accidentally committing to those.

No extensions per se, although not all debuginfo formats support compression (such as PDB/CodeView). If those formats incorporate compression support in the future, this feature can be extended when that support materializes. The implementation does not blindly forward the flag to the linker so we'll need to intentionally modify the compiler to enable that support.

## Summarize the major parts of the implementation and provide links into the code (or to PRs)

- We calculate the effective value of the flag taking into account both `-{C,Z} debuginfo-compression` (preferring the stabilized `-C` version) https://github.com/rust-lang/rust/blob/c4198169073cfaf1bafe09e850cd5e5132c96a11/compiler/rustc_session/src/session.rs#L717-L723
- The flag is validated in case the LLVM backend build does not support `zlib` or `zstd` compression (our LLVM builds include support for both) https://github.com/rust-lang/rust/blob/c4198169073cfaf1bafe09e850cd5e5132c96a11/compiler/rustc_codegen_llvm/src/back/write.rs#L253-L271
- When the linker is invoked, we pass along the requested debuginfo compression https://github.com/rust-lang/rust/blob/c4198169073cfaf1bafe09e850cd5e5132c96a11/compiler/rustc_codegen_ssa/src/back/linker.rs#L759-L767

The default for the flag is to not request debuginfo compression thus users have to opt-in to any level of compression. Zlib compression is widely supported across many versions of binutils and other tools that read debuginfo like `gdb`, `lldb`, `perf`, etc but zstd compression support is significantly newer and may require using the latest versions of these tools to support it. Users are responsible for ensuring whatever tools they use support the compression algorithm they've requested.

## Summarize existing test coverage of this feature

- End-to-end test that we can actually generate compressed debuginfo with both zlib and zstd algorithms
  - https://github.com/rust-lang/rust/tree/c4198169073cfaf1bafe09e850cd5e5132c96a11/tests/run-make/compressed-debuginfo
- End-to-end test that rust-lld can also generate compressed debuginfo with both zlib and zstd algorithms
  - https://github.com/rust-lang/rust/tree/c4198169073cfaf1bafe09e850cd5e5132c96a11/tests/run-make/compressed-debuginfo-zstd

## Has a call-for-testing period been conducted? If so, what feedback was received?

No call-for-testing has been conducted but Rust for Linux [has been using this flag](https://github.com/torvalds/linux/blob/bea82c80a5d64247045280b6d23e3ff95c355f56/scripts/Makefile.debug#L36-L46) without issue.

## What outstanding bugs in the issue tracker involve this feature? Are they stabilization-blocking?

All reported bugs have been resolved.

## Summarize contributors to the feature by name for recognition and assuredness that people involved in the feature agree with stabilization

- Initial implementation in https://github.com/rust-lang/rust/pull/115358 by @durin42 
- Zstd support was enabled in our LLVM build in https://github.com/rust-lang/rust/pull/125642 by @khuey 
- Minor cleanups in rust-lang/rust#150577 by @wesleywiser
- Initial support for zlib compressed debuginfo in the standard library backtrace implementation was added in https://github.com/rust-lang/backtrace-rs/pull/344 by @benesch
- Native support for zlib compressed debuginfo was a motivation for switching the backtrace implementation to gimli in https://github.com/rust-lang/backtrace-rs/pull/423 by @alexcrichton 
- Support for zstd compresssed debuginfo was added to the standard library backtrace implementation in https://github.com/rust-lang/backtrace-rs/pull/626 by @khuey 

## What FIXMEs are still in the code for that feature and why is it ok to leave them there?

No FIXMEs related to this feature.

## What static checks are done that are needed to prevent undefined behavior?

This feature cannot cause undefined behavior.

## In what way does this feature interact with the reference/specification, and are those edits prepared?

No changes to reference/spec, the stable book has documentation added as part of this stabilization PR.

## Does this feature introduce new expressions and can they produce temporaries? What are the lifetimes of those temporaries?

No.

## What other unstable features may be exposed by this feature?

None.

## What is tooling support like for this feature, w.r.t rustdoc, clippy, rust-analzyer, rustfmt, etc.?

No support needed for rustdoc, clippy, rust-analyzer, rustfmt or rustup.

Cargo could expose this as an option in build profiles but currently does not.

---

Closes rust-lang/rust#120953