### PR TITLE
Fix broken edit links in Unstable and rustc books

### DIFF
--- a/src/doc/rustc/book.toml
+++ b/src/doc/rustc/book.toml
@@ -3,7 +3,7 @@ title = "The rustc book"
 
 [output.html]
 git-repository-url = "https://github.com/rust-lang/rust/tree/HEAD/src/doc/rustc"
-edit-url-template = "https://github.com/rust-lang/rust/edit/HEAD/src/doc/rustc/{path}"
+edit-url-template = "https://github.com/rust-lang/rust/edit/main/src/doc/rustc/{path}"
 
 [output.html.search]
 use-boolean-and = true

--- a/src/doc/unstable-book/book.toml
+++ b/src/doc/unstable-book/book.toml
@@ -3,4 +3,4 @@ title = "The Rust Unstable Book"
 
 [output.html]
 git-repository-url = "https://github.com/rust-lang/rust/tree/HEAD/src/doc/unstable-book"
-edit-url-template = "https://github.com/rust-lang/rust/edit/HEAD/src/doc/unstable-book/{path}"
+edit-url-template = "https://github.com/rust-lang/rust/edit/main/src/doc/unstable-book/{path}"


### PR DESCRIPTION
Updated the edit-url-template for the unstable book and the rustc book.

Fixes rust-lang/rust#150593

The "Suggest an edit" links were pointing to HEAD, which resulted in a 404. Changed these to point to main.

r? @Kobzol
