### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_hir/src/def.rs
+++ b/compiler/rustc_hir/src/def.rs
@@ -563,29 +563,6 @@ pub enum Res<Id = hir::HirId> {
         /// to get the underlying type.
         alias_to: DefId,
 
-        /// Whether the `Self` type is disallowed from mentioning generics (i.e. when used in an
-        /// anonymous constant).
-        ///
-        /// HACK(min_const_generics): self types also have an optional requirement to **not**
-        /// mention any generic parameters to allow the following with `min_const_generics`:
-        /// ```
-        /// # struct Foo;
-        /// impl Foo { fn test() -> [u8; size_of::<Self>()] { todo!() } }
-        ///
-        /// struct Bar([u8; baz::<Self>()]);
-        /// const fn baz<T>() -> usize { 10 }
-        /// ```
-        /// We do however allow `Self` in repeat expression even if it is generic to not break code
-        /// which already works on stable while causing the `const_evaluatable_unchecked` future
-        /// compat lint:
-        /// ```
-        /// fn foo<T>() {
-        ///     let _bar = [1_u8; size_of::<*mut T>()];
-        /// }
-        /// ```
-        // FIXME(generic_const_exprs): Remove this bodge once that feature is stable.
-        forbid_generic: bool,
-
         /// Is this within an `impl Foo for bar`?
         is_trait_impl: bool,
     },
@@ -910,8 +887,8 @@ impl<Id> Res<Id> {
             Res::PrimTy(id) => Res::PrimTy(id),
             Res::Local(id) => Res::Local(map(id)),
             Res::SelfTyParam { trait_ } => Res::SelfTyParam { trait_ },
-            Res::SelfTyAlias { alias_to, forbid_generic, is_trait_impl } => {
-                Res::SelfTyAlias { alias_to, forbid_generic, is_trait_impl }
+            Res::SelfTyAlias { alias_to, is_trait_impl } => {
+                Res::SelfTyAlias { alias_to, is_trait_impl }
             }
             Res::ToolMod => Res::ToolMod,
             Res::NonMacroAttr(attr_kind) => Res::NonMacroAttr(attr_kind),
@@ -926,8 +903,8 @@ impl<Id> Res<Id> {
             Res::PrimTy(id) => Res::PrimTy(id),
             Res::Local(id) => Res::Local(map(id)?),
             Res::SelfTyParam { trait_ } => Res::SelfTyParam { trait_ },
-            Res::SelfTyAlias { alias_to, forbid_generic, is_trait_impl } => {
-                Res::SelfTyAlias { alias_to, forbid_generic, is_trait_impl }
+            Res::SelfTyAlias { alias_to, is_trait_impl } => {
+                Res::SelfTyAlias { alias_to, is_trait_impl }
             }
             Res::ToolMod => Res::ToolMod,
             Res::NonMacroAttr(attr_kind) => Res::NonMacroAttr(attr_kind),

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
@@ -2149,7 +2149,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                 );
                 self.check_param_uses_if_mcg(tcx.types.self_param, span, false)
             }
-            Res::SelfTyAlias { alias_to: def_id, forbid_generic: _, .. } => {
+            Res::SelfTyAlias { alias_to: def_id, .. } => {
                 // `Self` in impl (we know the concrete type).
                 assert_eq!(opt_self_ty, None);
                 // Try to evaluate any array length constants.

--- a/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
@@ -559,6 +559,15 @@ pub(in crate::rmeta) fn provide(providers: &mut Providers) {
                     .filter_map(|(cnum, data)| data.used().then_some(cnum)),
             )
         },
+        duplicate_crate_names: |tcx, c: CrateNum| {
+            let name = tcx.crate_name(c);
+            tcx.arena.alloc_from_iter(
+                tcx.crates(())
+                    .into_iter()
+                    .filter(|k| tcx.crate_name(**k) == name && **k != c)
+                    .map(|c| *c),
+            )
+        },
         ..providers.queries
     };
     provide_extern(&mut providers.extern_queries);

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -2339,12 +2339,21 @@ rustc_queries! {
         eval_always
         desc { "fetching all foreign CrateNum instances" }
     }
+
     // Crates that are loaded non-speculatively (not for diagnostics or doc links).
     // FIXME: This is currently only used for collecting lang items, but should be used instead of
     // `crates` in most other cases too.
     query used_crates(_: ()) -> &'tcx [CrateNum] {
         eval_always
         desc { "fetching `CrateNum`s for all crates loaded non-speculatively" }
+    }
+
+    /// All crates that share the same name as crate `c`.
+    ///
+    /// This normally occurs when multiple versions of the same dependency are present in the
+    /// dependency tree.
+    query duplicate_crate_names(c: CrateNum) -> &'tcx [CrateNum] {
+        desc { "fetching `CrateNum`s with same name as `{c:?}`" }
     }
 
     /// A list of all traits in a crate, used by rustdoc and error reporting.

--- a/compiler/rustc_resolve/src/ident.rs
+++ b/compiler/rustc_resolve/src/ident.rs
@@ -1332,7 +1332,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         &mut self,
         rib_index: usize,
         rib_ident: Ident,
-        mut res: Res,
+        res: Res,
         finalize: Option<Span>,
         original_rib_ident_def: Ident,
         all_ribs: &[Rib<'ra>],
@@ -1485,44 +1485,28 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                         }
 
                         RibKind::ConstantItem(trivial, _) => {
-                            if let ConstantHasGenerics::No(cause) = trivial {
-                                // HACK(min_const_generics): If we encounter `Self` in an anonymous
-                                // constant we can't easily tell if it's generic at this stage, so
-                                // we instead remember this and then enforce the self type to be
-                                // concrete later on.
-                                if let Res::SelfTyAlias {
-                                    alias_to: def,
-                                    forbid_generic: _,
-                                    is_trait_impl,
-                                } = res
-                                {
-                                    res = Res::SelfTyAlias {
-                                        alias_to: def,
-                                        forbid_generic: true,
-                                        is_trait_impl,
-                                    }
-                                } else {
-                                    if let Some(span) = finalize {
-                                        let error = match cause {
-                                            NoConstantGenericsReason::IsEnumDiscriminant => {
-                                                ResolutionError::ParamInEnumDiscriminant {
-                                                    name: rib_ident.name,
-                                                    param_kind: ParamKindInEnumDiscriminant::Type,
-                                                }
+                            if let ConstantHasGenerics::No(cause) = trivial
+                                && !matches!(res, Res::SelfTyAlias { .. })
+                            {
+                                if let Some(span) = finalize {
+                                    let error = match cause {
+                                        NoConstantGenericsReason::IsEnumDiscriminant => {
+                                            ResolutionError::ParamInEnumDiscriminant {
+                                                name: rib_ident.name,
+                                                param_kind: ParamKindInEnumDiscriminant::Type,
                                             }
-                                            NoConstantGenericsReason::NonTrivialConstArg => {
-                                                ResolutionError::ParamInNonTrivialAnonConst {
-                                                    name: rib_ident.name,
-                                                    param_kind:
-                                                        ParamKindInNonTrivialAnonConst::Type,
-                                                }
+                                        }
+                                        NoConstantGenericsReason::NonTrivialConstArg => {
+                                            ResolutionError::ParamInNonTrivialAnonConst {
+                                                name: rib_ident.name,
+                                                param_kind: ParamKindInNonTrivialAnonConst::Type,
                                             }
-                                        };
-                                        let _: ErrorGuaranteed = self.report_error(span, error);
-                                    }
-
-                                    return Res::Err;
+                                        }
+                                    };
+                                    let _: ErrorGuaranteed = self.report_error(span, error);
                                 }
+
+                                return Res::Err;
                             }
 
                             continue;

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -2655,11 +2655,7 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
                 |this| {
                     let item_def_id = this.r.local_def_id(item.id).to_def_id();
                     this.with_self_rib(
-                        Res::SelfTyAlias {
-                            alias_to: item_def_id,
-                            forbid_generic: false,
-                            is_trait_impl: false,
-                        },
+                        Res::SelfTyAlias { alias_to: item_def_id, is_trait_impl: false },
                         |this| {
                             visit::walk_item(this, item);
                         },
@@ -3368,8 +3364,7 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
                                     let item_def_id = item_def_id.to_def_id();
                                     let res = Res::SelfTyAlias {
                                         alias_to: item_def_id,
-                                        forbid_generic: false,
-                                        is_trait_impl: trait_id.is_some()
+                                        is_trait_impl: trait_id.is_some(),
                                     };
                                     this.with_self_rib(res, |this| {
                                         if let Some(of_trait) = of_trait {

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -33,6 +33,7 @@ use rustc_middle::ty::{
     TypeVisitableExt, Upcast,
 };
 use rustc_middle::{bug, span_bug};
+use rustc_span::def_id::CrateNum;
 use rustc_span::{BytePos, DUMMY_SP, STDLIB_STABLE_CRATES, Span, Symbol, sym};
 use tracing::{debug, instrument};
 
@@ -2172,6 +2173,13 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                         self.suggest_function_pointers_impl(None, &exp_found, err);
                     }
 
+                    if let ty::Adt(def, _) = trait_pred.self_ty().skip_binder().peel_refs().kind()
+                        && let crates = self.tcx.duplicate_crate_names(def.did().krate)
+                        && !crates.is_empty()
+                    {
+                        self.note_two_crate_versions(def.did().krate, MultiSpan::new(), err);
+                        err.help("you can use `cargo tree` to explore your dependency tree");
+                    }
                     true
                 })
             }) {
@@ -2281,6 +2289,14 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                         String::new()
                     }
                 ));
+            }
+
+            if let ty::Adt(def, _) = trait_pred.self_ty().skip_binder().peel_refs().kind()
+                && let crates = self.tcx.duplicate_crate_names(def.did().krate)
+                && !crates.is_empty()
+            {
+                self.note_two_crate_versions(def.did().krate, MultiSpan::new(), err);
+                err.help("you can use `cargo tree` to explore your dependency tree");
             }
             true
         };
@@ -2445,11 +2461,11 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
 
     pub fn note_two_crate_versions(
         &self,
-        did: DefId,
+        krate: CrateNum,
         sp: impl Into<MultiSpan>,
         err: &mut Diag<'_>,
     ) {
-        let crate_name = self.tcx.crate_name(did.krate);
+        let crate_name = self.tcx.crate_name(krate);
         let crate_msg = format!(
             "there are multiple different versions of crate `{crate_name}` in the dependency graph"
         );
@@ -2514,7 +2530,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
 
         for (similar_item, _) in similar_items {
             err.span_help(self.tcx.def_span(similar_item), "item with same name found");
-            self.note_two_crate_versions(similar_item, MultiSpan::new(), err);
+            self.note_two_crate_versions(similar_item.krate, MultiSpan::new(), err);
         }
     }
 

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -1287,10 +1287,6 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     self.tcx.def_span(def.did()),
                     format!("`{self_ty}` needs to implement `From<{ty}>`"),
                 );
-                err.span_note(
-                    self.tcx.def_span(found.did()),
-                    format!("alternatively, `{ty}` needs to implement `Into<{self_ty}>`"),
-                );
             }
             (ty::Adt(def, _), None) if def.did().is_local() => {
                 let trait_path = self.tcx.short_string(

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/mod.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/mod.rs
@@ -442,7 +442,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     );
                 }
             }
-            self.note_two_crate_versions(expected_did, span, err);
+            self.note_two_crate_versions(expected_did.krate, span, err);
             err.help("you can use `cargo tree` to explore your dependency tree");
         }
         suggested

--- a/src/doc/rustc/book.toml
+++ b/src/doc/rustc/book.toml
@@ -3,7 +3,7 @@ title = "The rustc book"
 
 [output.html]
 git-repository-url = "https://github.com/rust-lang/rust/tree/HEAD/src/doc/rustc"
-edit-url-template = "https://github.com/rust-lang/rust/edit/HEAD/src/doc/rustc/{path}"
+edit-url-template = "https://github.com/rust-lang/rust/edit/main/src/doc/rustc/{path}"
 
 [output.html.search]
 use-boolean-and = true

--- a/src/doc/unstable-book/book.toml
+++ b/src/doc/unstable-book/book.toml
@@ -3,4 +3,4 @@ title = "The Rust Unstable Book"
 
 [output.html]
 git-repository-url = "https://github.com/rust-lang/rust/tree/HEAD/src/doc/unstable-book"
-edit-url-template = "https://github.com/rust-lang/rust/edit/HEAD/src/doc/unstable-book/{path}"
+edit-url-template = "https://github.com/rust-lang/rust/edit/main/src/doc/unstable-book/{path}"

--- a/tests/run-make/crate-loading/dep-2-reexport.rs
+++ b/tests/run-make/crate-loading/dep-2-reexport.rs
@@ -2,9 +2,23 @@
 #![crate_type = "rlib"]
 
 extern crate dependency;
-pub use dependency::{Trait2, Type, do_something_trait, do_something_type};
+pub use dependency::{Error, OtherError, Trait2, Type, do_something_trait, do_something_type};
 pub struct OtherType;
 impl dependency::Trait for OtherType {
     fn foo(&self) {}
     fn bar() {}
+}
+#[derive(Debug)]
+pub struct Error2;
+
+impl From<Error> for Error2 {
+    fn from(_: Error) -> Error2 {
+        Error2
+    }
+}
+
+impl From<OtherError> for Error2 {
+    fn from(_: OtherError) -> Error2 {
+        Error2
+    }
 }

--- a/tests/run-make/crate-loading/dependency-1.rs
+++ b/tests/run-make/crate-loading/dependency-1.rs
@@ -13,3 +13,27 @@ impl Trait for Type {
 pub fn do_something<X: Trait>(_: X) {}
 pub fn do_something_type(_: Type) {}
 pub fn do_something_trait(_: Box<dyn Trait2>) {}
+
+#[derive(Debug)]
+pub struct Error;
+
+impl From<()> for Error {
+    fn from(t: ()) -> Error {
+        Error
+    }
+}
+
+#[derive(Debug)]
+pub struct OtherError;
+
+impl From<()> for OtherError {
+    fn from(t: ()) -> OtherError {
+        OtherError
+    }
+}
+
+impl From<i32> for OtherError {
+    fn from(t: i32) -> OtherError {
+        OtherError
+    }
+}

--- a/tests/run-make/crate-loading/dependency-2.rs
+++ b/tests/run-make/crate-loading/dependency-2.rs
@@ -14,3 +14,27 @@ impl Trait for Type {
 pub fn do_something<X: Trait>(_: X) {}
 pub fn do_something_type(_: Type) {}
 pub fn do_something_trait(_: Box<dyn Trait2>) {}
+
+#[derive(Debug)]
+pub struct Error;
+
+impl From<()> for Error {
+    fn from(t: ()) -> Error {
+        Error
+    }
+}
+
+#[derive(Debug)]
+pub struct OtherError;
+
+impl From<()> for OtherError {
+    fn from(_: ()) -> OtherError {
+        OtherError
+    }
+}
+
+impl From<i32> for OtherError {
+    fn from(_: i32) -> OtherError {
+        OtherError
+    }
+}

--- a/tests/run-make/crate-loading/multiple-dep-versions.rs
+++ b/tests/run-make/crate-loading/multiple-dep-versions.rs
@@ -1,13 +1,20 @@
 extern crate dep_2_reexport;
 extern crate dependency;
-use dep_2_reexport::{OtherType, Trait2, Type};
-use dependency::{Trait, do_something, do_something_trait, do_something_type};
+use dep_2_reexport::{Error2, OtherType, Trait2, Type};
+use dependency::{Error, OtherError, Trait, do_something, do_something_trait, do_something_type};
 
-fn main() {
+fn main() -> Result<(), Error> {
     do_something(Type);
     Type.foo();
     Type::bar();
     do_something(OtherType);
     do_something_type(Type);
     do_something_trait(Box::new(Type) as Box<dyn Trait2>);
+    Err(Error2)?;
+    Ok(())
+}
+
+fn foo() -> Result<(), OtherError> {
+    Err(Error2)?;
+    Ok(())
 }

--- a/tests/run-make/crate-loading/multiple-dep-versions.stderr
+++ b/tests/run-make/crate-loading/multiple-dep-versions.stderr
@@ -144,7 +144,51 @@ note: function defined here
 LL | pub fn do_something_trait(_: Box<dyn Trait2>) {}
    |        ^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 6 previous errors
+error[E0277]: `?` couldn't convert the error to `dependency::Error`
+  --> replaced
+   |
+LL | fn main() -> Result<(), Error> {
+   |              ----------------- expected `dependency::Error` because of this
+...
+LL |     Err(Error2)?;
+   |     -----------^ the trait `From<Error2>` is not implemented for `dependency::Error`
+   |     |
+   |     this can't be annotated with `?` because it has type `Result<_, Error2>`
+   |
+   = note: the question mark operation (`?`) implicitly performs a conversion on the error value using the `From` trait
+help: the trait `From<Error2>` is not implemented for `dependency::Error`
+      but trait `From<()>` is implemented for it
+  --> replaced
+   |
+LL | impl From<()> for Error {
+   | ^^^^^^^^^^^^^^^^^^^^^^^
+   = help: for that trait implementation, expected `()`, found `Error2`
+   = note: there are multiple different versions of crate `dependency` in the dependency graph
+   = help: you can use `cargo tree` to explore your dependency tree
+
+error[E0277]: `?` couldn't convert the error to `dependency::OtherError`
+  --> replaced
+   |
+LL | fn foo() -> Result<(), OtherError> {
+   |             ---------------------- expected `dependency::OtherError` because of this
+LL |     Err(Error2)?;
+   |     -----------^ the trait `From<Error2>` is not implemented for `dependency::OtherError`
+   |     |
+   |     this can't be annotated with `?` because it has type `Result<_, Error2>`
+   |
+   = note: the question mark operation (`?`) implicitly performs a conversion on the error value using the `From` trait
+help: the following other types implement trait `From<T>`
+  --> replaced
+   |
+LL | impl From<()> for OtherError {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `dependency::OtherError` implements `From<()>`
+...
+LL | impl From<i32> for OtherError {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `dependency::OtherError` implements `From<i32>`
+   = note: there are multiple different versions of crate `dependency` in the dependency graph
+   = help: you can use `cargo tree` to explore your dependency tree
+
+error: aborting due to 8 previous errors
 
 Some errors have detailed explanations: E0277, E0308, E0599.
 For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/try-trait/bad-question-mark-on-trait-object.rs
+++ b/tests/ui/try-trait/bad-question-mark-on-trait-object.rs
@@ -1,6 +1,5 @@
 struct E;
 //~^ NOTE `E` needs to implement `std::error::Error`
-//~| NOTE alternatively, `E` needs to implement `Into<X>`
 struct X; //~ NOTE `X` needs to implement `From<E>`
 
 fn foo() -> Result<(), Box<dyn std::error::Error>> { //~ NOTE required `E: std::error::Error` because of this

--- a/tests/ui/try-trait/bad-question-mark-on-trait-object.stderr
+++ b/tests/ui/try-trait/bad-question-mark-on-trait-object.stderr
@@ -1,5 +1,5 @@
 error[E0277]: `?` couldn't convert the error: `E: std::error::Error` is not satisfied
-  --> $DIR/bad-question-mark-on-trait-object.rs:7:13
+  --> $DIR/bad-question-mark-on-trait-object.rs:6:13
    |
 LL | fn foo() -> Result<(), Box<dyn std::error::Error>> {
    |             -------------------------------------- required `E: std::error::Error` because of this
@@ -17,7 +17,7 @@ LL | struct E;
    = note: required for `Box<dyn std::error::Error>` to implement `From<E>`
 
 error[E0277]: `?` couldn't convert the error to `X`
-  --> $DIR/bad-question-mark-on-trait-object.rs:18:13
+  --> $DIR/bad-question-mark-on-trait-object.rs:17:13
    |
 LL | fn bat() -> Result<(), X> {
    |             ------------- expected `X` because of this
@@ -27,14 +27,9 @@ LL |     Ok(bar()?)
    |        this can't be annotated with `?` because it has type `Result<_, E>`
    |
 note: `X` needs to implement `From<E>`
-  --> $DIR/bad-question-mark-on-trait-object.rs:4:1
+  --> $DIR/bad-question-mark-on-trait-object.rs:3:1
    |
 LL | struct X;
-   | ^^^^^^^^
-note: alternatively, `E` needs to implement `Into<X>`
-  --> $DIR/bad-question-mark-on-trait-object.rs:1:1
-   |
-LL | struct E;
    | ^^^^^^^^
    = note: the question mark operation (`?`) implicitly performs a conversion on the error value using the `From` trait
 

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1059,6 +1059,18 @@ gets adapted for the changes, if necessary.
 """
 cc = ["@rust-lang/miri", "@RalfJung", "@oli-obk", "@lcnr"]
 
+[mentions."library/core/src/num/dec2flt"]
+message = "Some changes occurred in float parsing"
+cc = ["@tgross35"]
+
+[mentions."library/core/src/num/flt2dec"]
+message = "Some changes occurred in float printing"
+cc = ["@tgross35"]
+
+[mentions."library/core/src/fmt/num.rs"]
+message = "Some changes occurred in integer formatting"
+cc = ["@tgross35"]
+
 [mentions."library/portable-simd"]
 message = """
 Portable SIMD is developed in its own repository. If possible, consider \


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#150558 (Detect cases where `?` is applied on a type that could be coming from a different crate version than expected)
 - rust-lang/rust#150570 (Removed confusing diagnostics note for trait required for `?` operator use)
 - rust-lang/rust#150589 (Remove unneeded `forbid_generic` field from `Res::SelfTyAlias`)
 - rust-lang/rust#150635 (triagebot: Add a mention for `dec2flt`, `flt2dec`, and `fmt/num.rs`)
 - rust-lang/rust#150637 (Fix broken edit links in Unstable and rustc books)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=150558,150570,150589,150635,150637)
<!-- homu-ignore:end -->