### PR TITLE
Merge `associated_const_equality` feature gate into MGCA

### DIFF
--- a/compiler/rustc_ast_passes/src/feature_gate.rs
+++ b/compiler/rustc_ast_passes/src/feature_gate.rs
@@ -505,7 +505,6 @@ pub fn check_crate(krate: &ast::Crate, sess: &Session, features: &Features) {
         half_open_range_patterns_in_slices,
         "half-open range patterns in slices are unstable"
     );
-    gate_all!(associated_const_equality, "associated const equality is incomplete");
     gate_all!(yeet_expr, "`do yeet` expression is experimental");
     gate_all!(const_closures, "const closures are experimental");
     gate_all!(builtin_syntax, "`builtin #` syntax is unstable");
@@ -518,6 +517,23 @@ pub fn check_crate(krate: &ast::Crate, sess: &Session, features: &Features) {
     gate_all!(postfix_match, "postfix match is experimental");
     gate_all!(mut_ref, "mutable by-reference bindings are experimental");
     gate_all!(min_generic_const_args, "unbraced const blocks as const args are experimental");
+    // associated_const_equality is stabilized as part of min_generic_const_args
+    if let Some(spans) = spans.get(&sym::associated_const_equality) {
+        for span in spans {
+            if !visitor.features.min_generic_const_args()
+                && !span.allows_unstable(sym::min_generic_const_args)
+            {
+                #[allow(rustc::untranslatable_diagnostic)]
+                feature_err(
+                    &visitor.sess,
+                    sym::min_generic_const_args,
+                    *span,
+                    "associated const equality is incomplete",
+                )
+                .emit();
+            }
+        }
+    }
     gate_all!(global_registration, "global registration is experimental");
     gate_all!(return_type_notation, "return type notation is experimental");
     gate_all!(pin_ergonomics, "pinned reference syntax is experimental");

--- a/compiler/rustc_codegen_ssa/src/debuginfo/type_names.rs
+++ b/compiler/rustc_codegen_ssa/src/debuginfo/type_names.rs
@@ -260,7 +260,7 @@ fn push_debuginfo_type_name<'tcx>(
                     .map(|bound| {
                         let ExistentialProjection { def_id: item_def_id, term, .. } =
                             tcx.instantiate_bound_regions_with_erased(bound);
-                        // FIXME(associated_const_equality): allow for consts here
+                        // FIXME(mgca): allow for consts here
                         (item_def_id, term.expect_type())
                     })
                     .collect();

--- a/compiler/rustc_feature/src/removed.rs
+++ b/compiler/rustc_feature/src/removed.rs
@@ -60,6 +60,9 @@ declare_features! (
     (removed, allocator, "1.0.0", None, None),
     /// Allows a test to fail without failing the whole suite.
     (removed, allow_fail, "1.60.0", Some(46488), Some("removed due to no clear use cases"), 93416),
+    /// Allows users to enforce equality of associated constants `TraitImpl<AssocConst=3>`.
+    (removed, associated_const_equality, "CURRENT_RUSTC_VERSION", Some(92827),
+     Some("merged into `min_generic_const_args`")),
     (removed, await_macro, "1.38.0", Some(50547),
      Some("subsumed by `.await` syntax"), 62293),
     /// Allows using the `box $expr` syntax.

--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -363,8 +363,6 @@ declare_features! (
     (unstable, asm_goto_with_outputs, "1.85.0", Some(119364)),
     /// Allows the `may_unwind` option in inline assembly.
     (unstable, asm_unwind, "1.58.0", Some(93334)),
-    /// Allows users to enforce equality of associated constants `TraitImpl<AssocConst=3>`.
-    (unstable, associated_const_equality, "1.58.0", Some(92827)),
     /// Allows associated type defaults.
     (unstable, associated_type_defaults, "1.2.0", Some(29661)),
     /// Allows implementing `AsyncDrop`.

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/bounds.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/bounds.rs
@@ -610,9 +610,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                                 AttributeKind::TypeConst(_)
                             )
                         {
-                            if tcx.features().min_generic_const_args()
-                                || tcx.features().associated_const_equality()
-                            {
+                            if tcx.features().min_generic_const_args() {
                                 let mut err = self.dcx().struct_span_err(
                                     constraint.span,
                                     "use of trait associated const without `#[type_const]`",

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/dyn_trait.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/dyn_trait.rs
@@ -239,7 +239,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                         // `trait_object_dummy_self`, so check for that.
                         let references_self = match pred.skip_binder().term.kind() {
                             ty::TermKind::Ty(ty) => ty.walk().any(|arg| arg == dummy_self.into()),
-                            // FIXME(associated_const_equality): We should walk the const instead of not doing anything
+                            // FIXME(mgca): We should walk the const instead of not doing anything
                             ty::TermKind::Const(_) => false,
                         };
 

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/errors.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/errors.rs
@@ -359,12 +359,12 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             None
         };
 
-        // FIXME(associated_const_equality): This has quite a few false positives and negatives.
+        // FIXME(mgca): This has quite a few false positives and negatives.
         let wrap_in_braces_sugg = if let Some(constraint) = constraint
             && let Some(hir_ty) = constraint.ty()
             && let ty = self.lower_ty(hir_ty)
             && (ty.is_enum() || ty.references_error())
-            && tcx.features().associated_const_equality()
+            && tcx.features().min_generic_const_args()
         {
             Some(errors::AssocKindMismatchWrapInBracesSugg {
                 lo: hir_ty.span.shrink_to_lo(),

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -907,10 +907,6 @@ impl<'tcx> rustc_type_ir::inherent::Features<TyCtxt<'tcx>> for &'tcx rustc_featu
         self.coroutine_clone()
     }
 
-    fn associated_const_equality(self) -> bool {
-        self.associated_const_equality()
-    }
-
     fn feature_bound_holds_in_crate(self, symbol: Symbol) -> bool {
         // We don't consider feature bounds to hold in the crate when `staged_api` feature is
         // enabled, even if it is enabled through `#[feature]`.

--- a/compiler/rustc_next_trait_solver/src/solve/assembly/structural_traits.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/assembly/structural_traits.rs
@@ -868,7 +868,7 @@ where
             .map(|(pred, _)| pred),
     ));
 
-    // FIXME(associated_const_equality): Also add associated consts to
+    // FIXME(mgca): Also add associated consts to
     // the requirements here.
     for associated_type_def_id in cx.associated_type_def_ids(trait_ref.def_id) {
         // associated types that require `Self: Sized` do not show up in the built-in

--- a/compiler/rustc_type_ir/src/inherent.rs
+++ b/compiler/rustc_type_ir/src/inherent.rs
@@ -646,8 +646,6 @@ pub trait Features<I: Interner>: Copy {
 
     fn coroutine_clone(self) -> bool;
 
-    fn associated_const_equality(self) -> bool;
-
     fn feature_bound_holds_in_crate(self, symbol: I::Symbol) -> bool;
 }
 

--- a/src/tools/clippy/tests/ui/trait_duplication_in_bounds_assoc_const_eq.fixed
+++ b/src/tools/clippy/tests/ui/trait_duplication_in_bounds_assoc_const_eq.fixed
@@ -1,6 +1,6 @@
 #![deny(clippy::trait_duplication_in_bounds)]
 #![expect(incomplete_features)]
-#![feature(associated_const_equality, min_generic_const_args)]
+#![feature(min_generic_const_args)]
 
 trait AssocConstTrait {
     #[type_const]

--- a/src/tools/clippy/tests/ui/trait_duplication_in_bounds_assoc_const_eq.rs
+++ b/src/tools/clippy/tests/ui/trait_duplication_in_bounds_assoc_const_eq.rs
@@ -1,6 +1,6 @@
 #![deny(clippy::trait_duplication_in_bounds)]
 #![expect(incomplete_features)]
-#![feature(associated_const_equality, min_generic_const_args)]
+#![feature(min_generic_const_args)]
 
 trait AssocConstTrait {
     #[type_const]

--- a/src/tools/rust-analyzer/crates/hir-ty/src/lower.rs
+++ b/src/tools/rust-analyzer/crates/hir-ty/src/lower.rs
@@ -862,7 +862,7 @@ impl<'db, 'a> TyLoweringContext<'db, 'a> {
                                 TermKind::Ty(ty) => {
                                     ty.walk().any(|arg| arg == dummy_self_ty.into())
                                 }
-                                // FIXME(associated_const_equality): We should walk the const instead of not doing anything
+                                // FIXME(mgca): We should walk the const instead of not doing anything
                                 TermKind::Const(_) => false,
                             };
 

--- a/tests/crashes/mgca/ace-with-const-ctor.rs
+++ b/tests/crashes/mgca/ace-with-const-ctor.rs
@@ -3,7 +3,7 @@
 // readded once fixed.
 // Previous issue (before mgca): https://github.com/rust-lang/rust/issues/105952
 #![crate_name = "foo"]
-#![feature(associated_const_equality, min_generic_const_args)]
+#![feature(min_generic_const_args)]
 pub enum ParseMode {
     Raw,
 }

--- a/tests/rustdoc-ui/associated-constant-not-allowed-102467.rs
+++ b/tests/rustdoc-ui/associated-constant-not-allowed-102467.rs
@@ -2,7 +2,7 @@
 // It ensures that the expected error is displayed.
 
 #![expect(incomplete_features)]
-#![feature(associated_const_equality, min_generic_const_args)]
+#![feature(min_generic_const_args)]
 
 trait T {
     type A: S<C<X = 0i32> = 34>;

--- a/tests/rustdoc/inline_cross/auxiliary/assoc-const-equality.rs
+++ b/tests/rustdoc/inline_cross/auxiliary/assoc-const-equality.rs
@@ -1,5 +1,5 @@
 #![expect(incomplete_features)]
-#![feature(associated_const_equality, min_generic_const_args)]
+#![feature(min_generic_const_args)]
 
 pub fn accept(_: impl Trait<K = 0>) {}
 

--- a/tests/ui/associated-consts/assoc-const-eq-ambiguity.rs
+++ b/tests/ui/associated-consts/assoc-const-eq-ambiguity.rs
@@ -1,7 +1,7 @@
 // We used to say "ambiguous associated type" on ambiguous associated consts.
 // Ensure that we now use the correct label.
 
-#![feature(associated_const_equality, min_generic_const_args, unsized_const_params)]
+#![feature(min_generic_const_args, unsized_const_params)]
 #![allow(incomplete_features)]
 
 trait Trait0: Parent0<i32> + Parent0<u32> {}

--- a/tests/ui/associated-consts/assoc-const-eq-bound-var-in-ty-not-wf.rs
+++ b/tests/ui/associated-consts/assoc-const-eq-bound-var-in-ty-not-wf.rs
@@ -1,7 +1,6 @@
 // Check that we eventually catch types of assoc const bounds
 // (containing late-bound vars) that are ill-formed.
 #![feature(
-    associated_const_equality,
     min_generic_const_args,
     adt_const_params,
     unsized_const_params,

--- a/tests/ui/associated-consts/assoc-const-eq-bound-var-in-ty-not-wf.stderr
+++ b/tests/ui/associated-consts/assoc-const-eq-bound-var-in-ty-not-wf.stderr
@@ -1,11 +1,11 @@
 error: higher-ranked subtype error
-  --> $DIR/assoc-const-eq-bound-var-in-ty-not-wf.rs:22:13
+  --> $DIR/assoc-const-eq-bound-var-in-ty-not-wf.rs:21:13
    |
 LL |         K = const { () }
    |             ^^^^^^^^^^^^
 
 error: higher-ranked subtype error
-  --> $DIR/assoc-const-eq-bound-var-in-ty-not-wf.rs:22:13
+  --> $DIR/assoc-const-eq-bound-var-in-ty-not-wf.rs:21:13
    |
 LL |         K = const { () }
    |             ^^^^^^^^^^^^

--- a/tests/ui/associated-consts/assoc-const-eq-bound-var-in-ty.rs
+++ b/tests/ui/associated-consts/assoc-const-eq-bound-var-in-ty.rs
@@ -4,7 +4,6 @@
 //@ check-pass
 
 #![feature(
-    associated_const_equality,
     min_generic_const_args,
     adt_const_params,
     unsized_const_params,

--- a/tests/ui/associated-consts/assoc-const-eq-const_evaluatable_unchecked.rs
+++ b/tests/ui/associated-consts/assoc-const-eq-const_evaluatable_unchecked.rs
@@ -4,7 +4,7 @@
 //
 // issue: <https://github.com/rust-lang/rust/issues/108220>
 //@ check-pass
-#![feature(associated_const_equality, min_generic_const_args)]
+#![feature(min_generic_const_args)]
 #![allow(incomplete_features)]
 
 pub trait TraitA<T> {

--- a/tests/ui/associated-consts/assoc-const-eq-esc-bound-var-in-ty.rs
+++ b/tests/ui/associated-consts/assoc-const-eq-esc-bound-var-in-ty.rs
@@ -1,7 +1,6 @@
 // Detect and reject escaping late-bound generic params in
 // the type of assoc consts used in an equality bound.
 #![feature(
-    associated_const_equality,
     min_generic_const_args,
     unsized_const_params,
     generic_const_parameter_types,

--- a/tests/ui/associated-consts/assoc-const-eq-esc-bound-var-in-ty.stderr
+++ b/tests/ui/associated-consts/assoc-const-eq-esc-bound-var-in-ty.stderr
@@ -1,5 +1,5 @@
 error: the type of the associated constant `K` cannot capture late-bound generic parameters
-  --> $DIR/assoc-const-eq-esc-bound-var-in-ty.rs:16:35
+  --> $DIR/assoc-const-eq-esc-bound-var-in-ty.rs:15:35
    |
 LL | fn take(_: impl for<'r> Trait<'r, K = const { &() }>) {}
    |                     --            ^ its type cannot capture the late-bound lifetime parameter `'r`

--- a/tests/ui/associated-consts/assoc-const-eq-missing.rs
+++ b/tests/ui/associated-consts/assoc-const-eq-missing.rs
@@ -1,5 +1,5 @@
-#![feature(associated_const_equality)]
-#![allow(unused)]
+#![feature(min_generic_const_args)]
+#![allow(incomplete_features, unused)]
 
 pub trait Foo {
   const N: usize;

--- a/tests/ui/associated-consts/assoc-const-eq-param-in-ty.rs
+++ b/tests/ui/associated-consts/assoc-const-eq-param-in-ty.rs
@@ -1,7 +1,6 @@
 // Regression test for issue #108271.
 // Detect and reject generic params in the type of assoc consts used in an equality bound.
 #![feature(
-    associated_const_equality,
     min_generic_const_args,
     adt_const_params,
     unsized_const_params,

--- a/tests/ui/associated-consts/assoc-const-eq-param-in-ty.stderr
+++ b/tests/ui/associated-consts/assoc-const-eq-param-in-ty.stderr
@@ -1,5 +1,5 @@
 error: the type of the associated constant `K` must not depend on generic parameters
-  --> $DIR/assoc-const-eq-param-in-ty.rs:23:29
+  --> $DIR/assoc-const-eq-param-in-ty.rs:22:29
    |
 LL | fn take0<'r, A: 'r + ConstParamTy_, const Q: usize>(
    |          -- the lifetime parameter `'r` is defined here
@@ -10,7 +10,7 @@ LL |     _: impl Trait<'r, A, Q, K = const { loop {} }>
    = note: `K` has type `&'r [A; Q]`
 
 error: the type of the associated constant `K` must not depend on generic parameters
-  --> $DIR/assoc-const-eq-param-in-ty.rs:23:29
+  --> $DIR/assoc-const-eq-param-in-ty.rs:22:29
    |
 LL | fn take0<'r, A: 'r + ConstParamTy_, const Q: usize>(
    |              - the type parameter `A` is defined here
@@ -21,7 +21,7 @@ LL |     _: impl Trait<'r, A, Q, K = const { loop {} }>
    = note: `K` has type `&'r [A; Q]`
 
 error: the type of the associated constant `K` must not depend on generic parameters
-  --> $DIR/assoc-const-eq-param-in-ty.rs:23:29
+  --> $DIR/assoc-const-eq-param-in-ty.rs:22:29
    |
 LL | fn take0<'r, A: 'r + ConstParamTy_, const Q: usize>(
    |                                           - the const parameter `Q` is defined here
@@ -32,7 +32,7 @@ LL |     _: impl Trait<'r, A, Q, K = const { loop {} }>
    = note: `K` has type `&'r [A; Q]`
 
 error: the type of the associated constant `SELF` must not depend on `impl Trait`
-  --> $DIR/assoc-const-eq-param-in-ty.rs:40:26
+  --> $DIR/assoc-const-eq-param-in-ty.rs:39:26
    |
 LL | fn take1(_: impl Project<SELF = const {}>) {}
    |             -------------^^^^------------
@@ -41,7 +41,7 @@ LL | fn take1(_: impl Project<SELF = const {}>) {}
    |             the `impl Trait` is specified here
 
 error: the type of the associated constant `SELF` must not depend on generic parameters
-  --> $DIR/assoc-const-eq-param-in-ty.rs:45:21
+  --> $DIR/assoc-const-eq-param-in-ty.rs:44:21
    |
 LL | fn take2<P: Project<SELF = const {}>>(_: P) {}
    |          -          ^^^^ its type must not depend on the type parameter `P`
@@ -51,7 +51,7 @@ LL | fn take2<P: Project<SELF = const {}>>(_: P) {}
    = note: `SELF` has type `P`
 
 error: the type of the associated constant `K` must not depend on generic parameters
-  --> $DIR/assoc-const-eq-param-in-ty.rs:54:52
+  --> $DIR/assoc-const-eq-param-in-ty.rs:53:52
    |
 LL | trait Iface<'r>: ConstParamTy_ {
    |             -- the lifetime parameter `'r` is defined here
@@ -62,7 +62,7 @@ LL |     type Assoc<const Q: usize>: Trait<'r, Self, Q, K = const { loop {} }>
    = note: `K` has type `&'r [Self; Q]`
 
 error: the type of the associated constant `K` must not depend on `Self`
-  --> $DIR/assoc-const-eq-param-in-ty.rs:54:52
+  --> $DIR/assoc-const-eq-param-in-ty.rs:53:52
    |
 LL |     type Assoc<const Q: usize>: Trait<'r, Self, Q, K = const { loop {} }>
    |                                                    ^ its type must not depend on `Self`
@@ -70,7 +70,7 @@ LL |     type Assoc<const Q: usize>: Trait<'r, Self, Q, K = const { loop {} }>
    = note: `K` has type `&'r [Self; Q]`
 
 error: the type of the associated constant `K` must not depend on generic parameters
-  --> $DIR/assoc-const-eq-param-in-ty.rs:54:52
+  --> $DIR/assoc-const-eq-param-in-ty.rs:53:52
    |
 LL |     type Assoc<const Q: usize>: Trait<'r, Self, Q, K = const { loop {} }>
    |                      -                             ^ its type must not depend on the const parameter `Q`
@@ -80,7 +80,7 @@ LL |     type Assoc<const Q: usize>: Trait<'r, Self, Q, K = const { loop {} }>
    = note: `K` has type `&'r [Self; Q]`
 
 error: the type of the associated constant `K` must not depend on generic parameters
-  --> $DIR/assoc-const-eq-param-in-ty.rs:54:52
+  --> $DIR/assoc-const-eq-param-in-ty.rs:53:52
    |
 LL | trait Iface<'r>: ConstParamTy_ {
    |             -- the lifetime parameter `'r` is defined here
@@ -92,7 +92,7 @@ LL |     type Assoc<const Q: usize>: Trait<'r, Self, Q, K = const { loop {} }>
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: the type of the associated constant `K` must not depend on `Self`
-  --> $DIR/assoc-const-eq-param-in-ty.rs:54:52
+  --> $DIR/assoc-const-eq-param-in-ty.rs:53:52
    |
 LL |     type Assoc<const Q: usize>: Trait<'r, Self, Q, K = const { loop {} }>
    |                                                    ^ its type must not depend on `Self`
@@ -101,7 +101,7 @@ LL |     type Assoc<const Q: usize>: Trait<'r, Self, Q, K = const { loop {} }>
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: the type of the associated constant `K` must not depend on generic parameters
-  --> $DIR/assoc-const-eq-param-in-ty.rs:54:52
+  --> $DIR/assoc-const-eq-param-in-ty.rs:53:52
    |
 LL |     type Assoc<const Q: usize>: Trait<'r, Self, Q, K = const { loop {} }>
    |                      -                             ^ its type must not depend on the const parameter `Q`

--- a/tests/ui/associated-consts/assoc-const-eq-supertraits.rs
+++ b/tests/ui/associated-consts/assoc-const-eq-supertraits.rs
@@ -4,7 +4,6 @@
 //@ check-pass
 
 #![feature(
-    associated_const_equality,
     min_generic_const_args,
     adt_const_params,
     unsized_const_params,

--- a/tests/ui/associated-consts/assoc-const-eq-ty-alias-noninteracting.rs
+++ b/tests/ui/associated-consts/assoc-const-eq-ty-alias-noninteracting.rs
@@ -5,7 +5,7 @@
 
 //@ check-pass
 
-#![feature(associated_const_equality, min_generic_const_args, unsized_const_params)]
+#![feature(min_generic_const_args, unsized_const_params)]
 #![allow(incomplete_features)]
 
 trait Trait: SuperTrait {

--- a/tests/ui/associated-consts/assoc-const-ty-mismatch.rs
+++ b/tests/ui/associated-consts/assoc-const-ty-mismatch.rs
@@ -1,5 +1,5 @@
-#![feature(associated_const_equality)]
-#![allow(unused)]
+#![feature(min_generic_const_args)]
+#![allow(incomplete_features, unused)]
 
 pub trait Foo {
     const N: usize;

--- a/tests/ui/associated-consts/assoc-const.rs
+++ b/tests/ui/associated-consts/assoc-const.rs
@@ -1,5 +1,5 @@
 //@ run-pass
-#![feature(associated_const_equality, min_generic_const_args)]
+#![feature(min_generic_const_args)]
 #![allow(unused, incomplete_features)]
 
 pub trait Foo {

--- a/tests/ui/associated-consts/equality-unused-issue-126729.rs
+++ b/tests/ui/associated-consts/equality-unused-issue-126729.rs
@@ -1,6 +1,6 @@
 //@ check-pass
 
-#![feature(associated_const_equality, min_generic_const_args)]
+#![feature(min_generic_const_args)]
 #![allow(incomplete_features)]
 #![deny(dead_code)]
 

--- a/tests/ui/associated-consts/issue-102335-const.rs
+++ b/tests/ui/associated-consts/issue-102335-const.rs
@@ -1,4 +1,4 @@
-#![feature(associated_const_equality, min_generic_const_args)]
+#![feature(min_generic_const_args)]
 #![allow(incomplete_features)]
 
 trait T {

--- a/tests/ui/associated-consts/issue-105330.stderr
+++ b/tests/ui/associated-consts/issue-105330.stderr
@@ -21,8 +21,8 @@ error[E0658]: associated const equality is incomplete
 LL | fn foo<A: TraitWAssocConst<A=32>>() {
    |                            ^^^^
    |
-   = note: see issue #92827 <https://github.com/rust-lang/rust/issues/92827> for more information
-   = help: add `#![feature(associated_const_equality)]` to the crate attributes to enable
+   = note: see issue #132980 <https://github.com/rust-lang/rust/issues/132980> for more information
+   = help: add `#![feature(min_generic_const_args)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: associated const equality is incomplete
@@ -31,8 +31,8 @@ error[E0658]: associated const equality is incomplete
 LL | fn main<A: TraitWAssocConst<A=32>>() {
    |                             ^^^^
    |
-   = note: see issue #92827 <https://github.com/rust-lang/rust/issues/92827> for more information
-   = help: add `#![feature(associated_const_equality)]` to the crate attributes to enable
+   = note: see issue #132980 <https://github.com/rust-lang/rust/issues/132980> for more information
+   = help: add `#![feature(min_generic_const_args)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0562]: `impl Trait` is not allowed in impl headers

--- a/tests/ui/associated-consts/issue-110933.rs
+++ b/tests/ui/associated-consts/issue-110933.rs
@@ -1,6 +1,6 @@
 //@ check-pass
 
-#![feature(associated_const_equality, min_generic_const_args)]
+#![feature(min_generic_const_args)]
 #![allow(incomplete_features)]
 
 pub trait Trait {

--- a/tests/ui/associated-consts/issue-93835.rs
+++ b/tests/ui/associated-consts/issue-93835.rs
@@ -4,9 +4,9 @@ fn e() {
     type_ascribe!(p, a<p:p<e=6>>);
     //~^ ERROR cannot find type `a` in this scope
     //~| ERROR cannot find value
-    //~| ERROR associated const equality
+    //~| ERROR associated const equality is incomplete
     //~| ERROR cannot find trait `p` in this scope
-    //~| ERROR associated const equality
+    //~| ERROR associated const equality is incomplete
 }
 
 fn main() {}

--- a/tests/ui/associated-consts/issue-93835.stderr
+++ b/tests/ui/associated-consts/issue-93835.stderr
@@ -22,8 +22,8 @@ error[E0658]: associated const equality is incomplete
 LL |     type_ascribe!(p, a<p:p<e=6>>);
    |                            ^^^
    |
-   = note: see issue #92827 <https://github.com/rust-lang/rust/issues/92827> for more information
-   = help: add `#![feature(associated_const_equality)]` to the crate attributes to enable
+   = note: see issue #132980 <https://github.com/rust-lang/rust/issues/132980> for more information
+   = help: add `#![feature(min_generic_const_args)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: associated const equality is incomplete
@@ -32,8 +32,8 @@ error[E0658]: associated const equality is incomplete
 LL |     type_ascribe!(p, a<p:p<e=6>>);
    |                            ^^^
    |
-   = note: see issue #92827 <https://github.com/rust-lang/rust/issues/92827> for more information
-   = help: add `#![feature(associated_const_equality)]` to the crate attributes to enable
+   = note: see issue #132980 <https://github.com/rust-lang/rust/issues/132980> for more information
+   = help: add `#![feature(min_generic_const_args)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 

--- a/tests/ui/associated-consts/projection-unspecified-but-bounded.rs
+++ b/tests/ui/associated-consts/projection-unspecified-but-bounded.rs
@@ -1,4 +1,4 @@
-#![feature(associated_const_equality, min_generic_const_args)]
+#![feature(min_generic_const_args)]
 #![allow(incomplete_features)]
 
 // Issue 110549

--- a/tests/ui/associated-type-bounds/const-projection-err.rs
+++ b/tests/ui/associated-type-bounds/const-projection-err.rs
@@ -1,4 +1,4 @@
-#![feature(associated_const_equality, min_generic_const_args)]
+#![feature(min_generic_const_args)]
 #![allow(incomplete_features)]
 
 trait TraitWAssocConst {

--- a/tests/ui/associated-type-bounds/duplicate-bound-err.rs
+++ b/tests/ui/associated-type-bounds/duplicate-bound-err.rs
@@ -1,7 +1,6 @@
 //@ edition: 2024
 
 #![feature(
-    associated_const_equality,
     min_generic_const_args,
     type_alias_impl_trait,
     return_type_notation

--- a/tests/ui/associated-type-bounds/duplicate-bound-err.stderr
+++ b/tests/ui/associated-type-bounds/duplicate-bound-err.stderr
@@ -1,5 +1,5 @@
 error[E0282]: type annotations needed
-  --> $DIR/duplicate-bound-err.rs:15:5
+  --> $DIR/duplicate-bound-err.rs:14:5
    |
 LL |     iter::empty()
    |     ^^^^^^^^^^^ cannot infer type of the type parameter `T` declared on the function `empty`
@@ -10,7 +10,7 @@ LL |     iter::empty::<T>()
    |                +++++
 
 error[E0282]: type annotations needed
-  --> $DIR/duplicate-bound-err.rs:19:5
+  --> $DIR/duplicate-bound-err.rs:18:5
    |
 LL |     iter::empty()
    |     ^^^^^^^^^^^ cannot infer type of the type parameter `T` declared on the function `empty`
@@ -21,7 +21,7 @@ LL |     iter::empty::<T>()
    |                +++++
 
 error[E0282]: type annotations needed
-  --> $DIR/duplicate-bound-err.rs:23:5
+  --> $DIR/duplicate-bound-err.rs:22:5
    |
 LL |     iter::empty()
    |     ^^^^^^^^^^^ cannot infer type of the type parameter `T` declared on the function `empty`
@@ -32,7 +32,7 @@ LL |     iter::empty::<T>()
    |                +++++
 
 error: unconstrained opaque type
-  --> $DIR/duplicate-bound-err.rs:27:51
+  --> $DIR/duplicate-bound-err.rs:26:51
    |
 LL | type Tait1<T: Iterator<Item: Copy, Item: Send>> = impl Copy;
    |                                                   ^^^^^^^^^
@@ -40,7 +40,7 @@ LL | type Tait1<T: Iterator<Item: Copy, Item: Send>> = impl Copy;
    = note: `Tait1` must be used in combination with a concrete type within the same crate
 
 error: unconstrained opaque type
-  --> $DIR/duplicate-bound-err.rs:29:51
+  --> $DIR/duplicate-bound-err.rs:28:51
    |
 LL | type Tait2<T: Iterator<Item: Copy, Item: Copy>> = impl Copy;
    |                                                   ^^^^^^^^^
@@ -48,7 +48,7 @@ LL | type Tait2<T: Iterator<Item: Copy, Item: Copy>> = impl Copy;
    = note: `Tait2` must be used in combination with a concrete type within the same crate
 
 error: unconstrained opaque type
-  --> $DIR/duplicate-bound-err.rs:31:57
+  --> $DIR/duplicate-bound-err.rs:30:57
    |
 LL | type Tait3<T: Iterator<Item: 'static, Item: 'static>> = impl Copy;
    |                                                         ^^^^^^^^^
@@ -56,7 +56,7 @@ LL | type Tait3<T: Iterator<Item: 'static, Item: 'static>> = impl Copy;
    = note: `Tait3` must be used in combination with a concrete type within the same crate
 
 error: unconstrained opaque type
-  --> $DIR/duplicate-bound-err.rs:34:14
+  --> $DIR/duplicate-bound-err.rs:33:14
    |
 LL | type Tait4 = impl Iterator<Item: Copy, Item: Send>;
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -64,7 +64,7 @@ LL | type Tait4 = impl Iterator<Item: Copy, Item: Send>;
    = note: `Tait4` must be used in combination with a concrete type within the same crate
 
 error: unconstrained opaque type
-  --> $DIR/duplicate-bound-err.rs:36:14
+  --> $DIR/duplicate-bound-err.rs:35:14
    |
 LL | type Tait5 = impl Iterator<Item: Copy, Item: Copy>;
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -72,7 +72,7 @@ LL | type Tait5 = impl Iterator<Item: Copy, Item: Copy>;
    = note: `Tait5` must be used in combination with a concrete type within the same crate
 
 error: unconstrained opaque type
-  --> $DIR/duplicate-bound-err.rs:38:14
+  --> $DIR/duplicate-bound-err.rs:37:14
    |
 LL | type Tait6 = impl Iterator<Item: 'static, Item: 'static>;
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -80,7 +80,7 @@ LL | type Tait6 = impl Iterator<Item: 'static, Item: 'static>;
    = note: `Tait6` must be used in combination with a concrete type within the same crate
 
 error[E0277]: `*const ()` cannot be sent between threads safely
-  --> $DIR/duplicate-bound-err.rs:41:18
+  --> $DIR/duplicate-bound-err.rs:40:18
    |
 LL | fn mismatch() -> impl Iterator<Item: Copy, Item: Send> {
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `*const ()` cannot be sent between threads safely
@@ -91,7 +91,7 @@ LL |     iter::empty::<*const ()>()
    = help: the trait `Send` is not implemented for `*const ()`
 
 error[E0277]: the trait bound `String: Copy` is not satisfied
-  --> $DIR/duplicate-bound-err.rs:46:20
+  --> $DIR/duplicate-bound-err.rs:45:20
    |
 LL | fn mismatch_2() -> impl Iterator<Item: Copy, Item: Send> {
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `String`
@@ -100,7 +100,7 @@ LL |     iter::empty::<String>()
    |     ----------------------- return type was inferred to be `std::iter::Empty<String>` here
 
 error[E0271]: expected `IntoIter<u32, 1>` to be an iterator that yields `i32`, but it yields `u32`
-  --> $DIR/duplicate-bound-err.rs:112:17
+  --> $DIR/duplicate-bound-err.rs:111:17
    |
 LL |     fn foo() -> impl Iterator<Item = i32, Item = u32> {
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `i32`, found `u32`
@@ -109,7 +109,7 @@ LL |         [2u32].into_iter()
    |         ------------------ return type was inferred to be `std::array::IntoIter<u32, 1>` here
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate-bound-err.rs:88:42
+  --> $DIR/duplicate-bound-err.rs:87:42
    |
 LL | type MustFail = dyn Iterator<Item = i32, Item = u32>;
    |                              ----------  ^^^^^^^^^^ re-bound here
@@ -117,7 +117,7 @@ LL | type MustFail = dyn Iterator<Item = i32, Item = u32>;
    |                              `Item` bound here first
 
 error: conflicting associated type bounds for `Item`
-  --> $DIR/duplicate-bound-err.rs:88:17
+  --> $DIR/duplicate-bound-err.rs:87:17
    |
 LL | type MustFail = dyn Iterator<Item = i32, Item = u32>;
    |                 ^^^^^^^^^^^^^----------^^----------^
@@ -126,7 +126,7 @@ LL | type MustFail = dyn Iterator<Item = i32, Item = u32>;
    |                              `Item` is specified to be `i32` here
 
 error[E0719]: the value of the associated type `ASSOC` in trait `Trait2` is already specified
-  --> $DIR/duplicate-bound-err.rs:97:43
+  --> $DIR/duplicate-bound-err.rs:96:43
    |
 LL | type MustFail2 = dyn Trait2<ASSOC = 3u32, ASSOC = 4u32>;
    |                             ------------  ^^^^^^^^^^^^ re-bound here
@@ -134,7 +134,7 @@ LL | type MustFail2 = dyn Trait2<ASSOC = 3u32, ASSOC = 4u32>;
    |                             `ASSOC` bound here first
 
 error: conflicting associated type bounds for `ASSOC`
-  --> $DIR/duplicate-bound-err.rs:97:18
+  --> $DIR/duplicate-bound-err.rs:96:18
    |
 LL | type MustFail2 = dyn Trait2<ASSOC = 3u32, ASSOC = 4u32>;
    |                  ^^^^^^^^^^^------------^^------------^
@@ -143,7 +143,7 @@ LL | type MustFail2 = dyn Trait2<ASSOC = 3u32, ASSOC = 4u32>;
    |                             `ASSOC` is specified to be `3` here
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate-bound-err.rs:101:43
+  --> $DIR/duplicate-bound-err.rs:100:43
    |
 LL | type MustFail3 = dyn Iterator<Item = i32, Item = i32>;
    |                               ----------  ^^^^^^^^^^ re-bound here
@@ -151,7 +151,7 @@ LL | type MustFail3 = dyn Iterator<Item = i32, Item = i32>;
    |                               `Item` bound here first
 
 error[E0719]: the value of the associated type `ASSOC` in trait `Trait2` is already specified
-  --> $DIR/duplicate-bound-err.rs:104:43
+  --> $DIR/duplicate-bound-err.rs:103:43
    |
 LL | type MustFail4 = dyn Trait2<ASSOC = 3u32, ASSOC = 3u32>;
    |                             ------------  ^^^^^^^^^^^^ re-bound here
@@ -159,19 +159,19 @@ LL | type MustFail4 = dyn Trait2<ASSOC = 3u32, ASSOC = 3u32>;
    |                             `ASSOC` bound here first
 
 error[E0271]: expected `impl Iterator<Item = u32>` to be an iterator that yields `i32`, but it yields `u32`
-  --> $DIR/duplicate-bound-err.rs:112:17
+  --> $DIR/duplicate-bound-err.rs:111:17
    |
 LL |     fn foo() -> impl Iterator<Item = i32, Item = u32> {
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `i32`, found `u32`
    |
 note: required by a bound in `Trait3::foo::{anon_assoc#0}`
-  --> $DIR/duplicate-bound-err.rs:108:31
+  --> $DIR/duplicate-bound-err.rs:107:31
    |
 LL |     fn foo() -> impl Iterator<Item = i32, Item = u32>;
    |                               ^^^^^^^^^^ required by this bound in `Trait3::foo::{anon_assoc#0}`
 
 error[E0271]: expected `Empty<u32>` to be an iterator that yields `i32`, but it yields `u32`
-  --> $DIR/duplicate-bound-err.rs:120:16
+  --> $DIR/duplicate-bound-err.rs:119:16
    |
 LL |     uncallable(iter::empty::<u32>());
    |     ---------- ^^^^^^^^^^^^^^^^^^^^ expected `i32`, found `u32`
@@ -179,13 +179,13 @@ LL |     uncallable(iter::empty::<u32>());
    |     required by a bound introduced by this call
    |
 note: required by a bound in `uncallable`
-  --> $DIR/duplicate-bound-err.rs:80:32
+  --> $DIR/duplicate-bound-err.rs:79:32
    |
 LL | fn uncallable(_: impl Iterator<Item = i32, Item = u32>) {}
    |                                ^^^^^^^^^^ required by this bound in `uncallable`
 
 error[E0271]: expected `Empty<i32>` to be an iterator that yields `u32`, but it yields `i32`
-  --> $DIR/duplicate-bound-err.rs:121:16
+  --> $DIR/duplicate-bound-err.rs:120:16
    |
 LL |     uncallable(iter::empty::<i32>());
    |     ---------- ^^^^^^^^^^^^^^^^^^^^ expected `u32`, found `i32`
@@ -193,13 +193,13 @@ LL |     uncallable(iter::empty::<i32>());
    |     required by a bound introduced by this call
    |
 note: required by a bound in `uncallable`
-  --> $DIR/duplicate-bound-err.rs:80:44
+  --> $DIR/duplicate-bound-err.rs:79:44
    |
 LL | fn uncallable(_: impl Iterator<Item = i32, Item = u32>) {}
    |                                            ^^^^^^^^^^ required by this bound in `uncallable`
 
 error[E0271]: type mismatch resolving `<() as Trait>::ASSOC == 4`
-  --> $DIR/duplicate-bound-err.rs:122:22
+  --> $DIR/duplicate-bound-err.rs:121:22
    |
 LL |     uncallable_const(());
    |     ---------------- ^^ expected `4`, found `3`
@@ -209,13 +209,13 @@ LL |     uncallable_const(());
    = note: expected constant `4`
               found constant `3`
 note: required by a bound in `uncallable_const`
-  --> $DIR/duplicate-bound-err.rs:82:46
+  --> $DIR/duplicate-bound-err.rs:81:46
    |
 LL | fn uncallable_const(_: impl Trait<ASSOC = 3, ASSOC = 4>) {}
    |                                              ^^^^^^^^^ required by this bound in `uncallable_const`
 
 error[E0271]: type mismatch resolving `<u32 as Trait>::ASSOC == 3`
-  --> $DIR/duplicate-bound-err.rs:123:22
+  --> $DIR/duplicate-bound-err.rs:122:22
    |
 LL |     uncallable_const(4u32);
    |     ---------------- ^^^^ expected `3`, found `4`
@@ -225,13 +225,13 @@ LL |     uncallable_const(4u32);
    = note: expected constant `3`
               found constant `4`
 note: required by a bound in `uncallable_const`
-  --> $DIR/duplicate-bound-err.rs:82:35
+  --> $DIR/duplicate-bound-err.rs:81:35
    |
 LL | fn uncallable_const(_: impl Trait<ASSOC = 3, ASSOC = 4>) {}
    |                                   ^^^^^^^^^ required by this bound in `uncallable_const`
 
 error[E0271]: type mismatch resolving `<() as Trait>::ASSOC == 4`
-  --> $DIR/duplicate-bound-err.rs:124:20
+  --> $DIR/duplicate-bound-err.rs:123:20
    |
 LL |     uncallable_rtn(());
    |     -------------- ^^ expected `4`, found `3`
@@ -241,7 +241,7 @@ LL |     uncallable_rtn(());
    = note: expected constant `4`
               found constant `3`
 note: required by a bound in `uncallable_rtn`
-  --> $DIR/duplicate-bound-err.rs:85:61
+  --> $DIR/duplicate-bound-err.rs:84:61
    |
 LL | fn uncallable_rtn(
    |    -------------- required by a bound in this function
@@ -249,7 +249,7 @@ LL |     _: impl Trait<foo(..): Trait<ASSOC = 3>, foo(..): Trait<ASSOC = 4>>
    |                                                             ^^^^^^^^^ required by this bound in `uncallable_rtn`
 
 error[E0271]: type mismatch resolving `<u32 as Trait>::ASSOC == 3`
-  --> $DIR/duplicate-bound-err.rs:125:20
+  --> $DIR/duplicate-bound-err.rs:124:20
    |
 LL |     uncallable_rtn(17u32);
    |     -------------- ^^^^^ expected `3`, found `4`
@@ -259,7 +259,7 @@ LL |     uncallable_rtn(17u32);
    = note: expected constant `3`
               found constant `4`
 note: required by a bound in `uncallable_rtn`
-  --> $DIR/duplicate-bound-err.rs:85:34
+  --> $DIR/duplicate-bound-err.rs:84:34
    |
 LL | fn uncallable_rtn(
    |    -------------- required by a bound in this function

--- a/tests/ui/associated-type-bounds/duplicate-bound.rs
+++ b/tests/ui/associated-type-bounds/duplicate-bound.rs
@@ -1,7 +1,7 @@
 //@ edition: 2024
 //@ run-pass
 
-#![feature(associated_const_equality, min_generic_const_args, return_type_notation)]
+#![feature(min_generic_const_args, return_type_notation)]
 #![expect(incomplete_features)]
 #![allow(dead_code, refining_impl_trait_internal, type_alias_bounds)]
 

--- a/tests/ui/associated-type-bounds/issue-99828.stderr
+++ b/tests/ui/associated-type-bounds/issue-99828.stderr
@@ -4,8 +4,8 @@ error[E0658]: associated const equality is incomplete
 LL | fn get_iter(vec: &[i32]) -> impl Iterator<Item = {}> + '_ {
    |                                           ^^^^^^^^^
    |
-   = note: see issue #92827 <https://github.com/rust-lang/rust/issues/92827> for more information
-   = help: add `#![feature(associated_const_equality)]` to the crate attributes to enable
+   = note: see issue #132980 <https://github.com/rust-lang/rust/issues/132980> for more information
+   = help: add `#![feature(min_generic_const_args)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: expected type, found constant

--- a/tests/ui/associated-types/associated-types-eq-2.stderr
+++ b/tests/ui/associated-types/associated-types-eq-2.stderr
@@ -7,8 +7,8 @@ LL |   impl Tr3<N
 LL | | = 42, T2 = Qux, T3 = usize> for Bar {
    | |____^
    |
-   = note: see issue #92827 <https://github.com/rust-lang/rust/issues/92827> for more information
-   = help: add `#![feature(associated_const_equality)]` to the crate attributes to enable
+   = note: see issue #132980 <https://github.com/rust-lang/rust/issues/132980> for more information
+   = help: add `#![feature(min_generic_const_args)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: associated const equality is incomplete
@@ -17,8 +17,8 @@ error[E0658]: associated const equality is incomplete
 LL | impl Tr3<n = 42, T2 = Qux, T3 = usize> for Qux {
    |          ^^^^^^
    |
-   = note: see issue #92827 <https://github.com/rust-lang/rust/issues/92827> for more information
-   = help: add `#![feature(associated_const_equality)]` to the crate attributes to enable
+   = note: see issue #132980 <https://github.com/rust-lang/rust/issues/132980> for more information
+   = help: add `#![feature(min_generic_const_args)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: associated const equality is incomplete
@@ -27,8 +27,8 @@ error[E0658]: associated const equality is incomplete
 LL | impl Tr3<42, T2 = 42, T3 = usize> for Bar {
    |              ^^^^^^^
    |
-   = note: see issue #92827 <https://github.com/rust-lang/rust/issues/92827> for more information
-   = help: add `#![feature(associated_const_equality)]` to the crate attributes to enable
+   = note: see issue #132980 <https://github.com/rust-lang/rust/issues/132980> for more information
+   = help: add `#![feature(min_generic_const_args)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: associated const equality is incomplete
@@ -37,8 +37,8 @@ error[E0658]: associated const equality is incomplete
 LL | impl Tr3<X = 42, Y = Qux, Z = usize> for Bar {
    |          ^^^^^^
    |
-   = note: see issue #92827 <https://github.com/rust-lang/rust/issues/92827> for more information
-   = help: add `#![feature(associated_const_equality)]` to the crate attributes to enable
+   = note: see issue #132980 <https://github.com/rust-lang/rust/issues/132980> for more information
+   = help: add `#![feature(min_generic_const_args)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0229]: associated item constraints are not allowed here

--- a/tests/ui/const-generics/assoc_const_eq_diagnostic.rs
+++ b/tests/ui/const-generics/assoc_const_eq_diagnostic.rs
@@ -1,5 +1,6 @@
 //@ edition:2015
-#![feature(associated_const_equality)]
+#![feature(min_generic_const_args)]
+#![allow(incomplete_features)]
 
 pub enum Mode {
     Cool,

--- a/tests/ui/const-generics/assoc_const_eq_diagnostic.stderr
+++ b/tests/ui/const-generics/assoc_const_eq_diagnostic.stderr
@@ -1,5 +1,5 @@
 error[E0573]: expected type, found variant `Mode::Cool`
-  --> $DIR/assoc_const_eq_diagnostic.rs:12:35
+  --> $DIR/assoc_const_eq_diagnostic.rs:13:35
    |
 LL | pub trait CoolStuff: Parse<MODE = Mode::Cool> {}
    |                                   ^^^^^^^^^^
@@ -8,7 +8,7 @@ LL | pub trait CoolStuff: Parse<MODE = Mode::Cool> {}
    |                                   help: try using the variant's enum: `Mode`
 
 error[E0573]: expected type, found variant `Mode::Cool`
-  --> $DIR/assoc_const_eq_diagnostic.rs:18:17
+  --> $DIR/assoc_const_eq_diagnostic.rs:19:17
    |
 LL | fn no_help() -> Mode::Cool {}
    |                 ^^^^^^^^^^
@@ -17,7 +17,7 @@ LL | fn no_help() -> Mode::Cool {}
    |                 help: try using the variant's enum: `Mode`
 
 error: expected constant, found type
-  --> $DIR/assoc_const_eq_diagnostic.rs:12:35
+  --> $DIR/assoc_const_eq_diagnostic.rs:13:35
    |
 LL | pub trait CoolStuff: Parse<MODE = Mode::Cool> {}
    |                            ----   ^^^^^^^^^^ unexpected type
@@ -25,7 +25,7 @@ LL | pub trait CoolStuff: Parse<MODE = Mode::Cool> {}
    |                            expected a constant because of this associated constant
    |
 note: the associated constant is defined here
-  --> $DIR/assoc_const_eq_diagnostic.rs:9:5
+  --> $DIR/assoc_const_eq_diagnostic.rs:10:5
    |
 LL |     const MODE: Mode;
    |     ^^^^^^^^^^^^^^^^
@@ -35,7 +35,7 @@ LL | pub trait CoolStuff: Parse<MODE = { Mode::Cool }> {}
    |                                   +            +
 
 error: expected constant, found type
-  --> $DIR/assoc_const_eq_diagnostic.rs:12:35
+  --> $DIR/assoc_const_eq_diagnostic.rs:13:35
    |
 LL | pub trait CoolStuff: Parse<MODE = Mode::Cool> {}
    |                            ----   ^^^^^^^^^^ unexpected type
@@ -43,7 +43,7 @@ LL | pub trait CoolStuff: Parse<MODE = Mode::Cool> {}
    |                            expected a constant because of this associated constant
    |
 note: the associated constant is defined here
-  --> $DIR/assoc_const_eq_diagnostic.rs:9:5
+  --> $DIR/assoc_const_eq_diagnostic.rs:10:5
    |
 LL |     const MODE: Mode;
    |     ^^^^^^^^^^^^^^^^
@@ -54,7 +54,7 @@ LL | pub trait CoolStuff: Parse<MODE = { Mode::Cool }> {}
    |                                   +            +
 
 error: expected constant, found type
-  --> $DIR/assoc_const_eq_diagnostic.rs:12:35
+  --> $DIR/assoc_const_eq_diagnostic.rs:13:35
    |
 LL | pub trait CoolStuff: Parse<MODE = Mode::Cool> {}
    |                            ----   ^^^^^^^^^^ unexpected type
@@ -62,7 +62,7 @@ LL | pub trait CoolStuff: Parse<MODE = Mode::Cool> {}
    |                            expected a constant because of this associated constant
    |
 note: the associated constant is defined here
-  --> $DIR/assoc_const_eq_diagnostic.rs:9:5
+  --> $DIR/assoc_const_eq_diagnostic.rs:10:5
    |
 LL |     const MODE: Mode;
    |     ^^^^^^^^^^^^^^^^

--- a/tests/ui/const-generics/associated_const_equality/coherence.rs
+++ b/tests/ui/const-generics/associated_const_equality/coherence.rs
@@ -1,4 +1,4 @@
-#![feature(associated_const_equality, min_generic_const_args)]
+#![feature(min_generic_const_args)]
 #![expect(incomplete_features)]
 
 pub trait IsVoid {

--- a/tests/ui/const-generics/associated_const_equality/equality_bound_with_infer.rs
+++ b/tests/ui/const-generics/associated_const_equality/equality_bound_with_infer.rs
@@ -1,6 +1,6 @@
 //@ check-pass
 
-#![feature(associated_const_equality, min_generic_const_args, generic_const_items)]
+#![feature(min_generic_const_args, generic_const_items)]
 #![expect(incomplete_features)]
 
 // Regression test for #133066 where we would try to evaluate `<() as Foo>::ASSOC<_>` even

--- a/tests/ui/const-generics/associated_const_equality/mismatched-types-with-generic-in-ace-no-feature-gate.stderr
+++ b/tests/ui/const-generics/associated_const_equality/mismatched-types-with-generic-in-ace-no-feature-gate.stderr
@@ -1,13 +1,3 @@
-error[E0658]: associated const equality is incomplete
-  --> $DIR/mismatched-types-with-generic-in-ace-no-feature-gate.rs:7:38
-   |
-LL | fn take0<const N: u64>(_: impl Owner<C<N> = { N }>) {}
-   |                                      ^^^^^^^^^^^^
-   |
-   = note: see issue #92827 <https://github.com/rust-lang/rust/issues/92827> for more information
-   = help: add `#![feature(associated_const_equality)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
 error[E0658]: generic const items are experimental
   --> $DIR/mismatched-types-with-generic-in-ace-no-feature-gate.rs:2:12
    |
@@ -16,6 +6,16 @@ LL |     const C<const N: u32>: u32 = N;
    |
    = note: see issue #113521 <https://github.com/rust-lang/rust/issues/113521> for more information
    = help: add `#![feature(generic_const_items)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: associated const equality is incomplete
+  --> $DIR/mismatched-types-with-generic-in-ace-no-feature-gate.rs:7:38
+   |
+LL | fn take0<const N: u64>(_: impl Owner<C<N> = { N }>) {}
+   |                                      ^^^^^^^^^^^^
+   |
+   = note: see issue #132980 <https://github.com/rust-lang/rust/issues/132980> for more information
+   = help: add `#![feature(min_generic_const_args)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 2 previous errors

--- a/tests/ui/const-generics/associated_const_equality/mismatched-types-with-generic-in-ace.rs
+++ b/tests/ui/const-generics/associated_const_equality/mismatched-types-with-generic-in-ace.rs
@@ -1,4 +1,4 @@
-#![feature(generic_const_items, associated_const_equality, min_generic_const_args)]
+#![feature(generic_const_items, min_generic_const_args)]
 #![expect(incomplete_features)]
 
 trait Foo {

--- a/tests/ui/const-generics/associated_const_equality/unconstrained_impl_param.stderr
+++ b/tests/ui/const-generics/associated_const_equality/unconstrained_impl_param.stderr
@@ -4,8 +4,8 @@ error[E0658]: associated const equality is incomplete
 LL | impl<U> Trait for () where (U,): AssocConst<A = 0> {}
    |                                             ^^^^^
    |
-   = note: see issue #92827 <https://github.com/rust-lang/rust/issues/92827> for more information
-   = help: add `#![feature(associated_const_equality)]` to the crate attributes to enable
+   = note: see issue #132980 <https://github.com/rust-lang/rust/issues/132980> for more information
+   = help: add `#![feature(min_generic_const_args)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0207]: the type parameter `U` is not constrained by the impl trait, self type, or predicates

--- a/tests/ui/const-generics/mgca/explicit_anon_consts.rs
+++ b/tests/ui/const-generics/mgca/explicit_anon_consts.rs
@@ -1,4 +1,4 @@
-#![feature(associated_const_equality, generic_const_items, min_generic_const_args)]
+#![feature(generic_const_items, min_generic_const_args)]
 #![expect(incomplete_features)]
 // library crates exercise weirder code paths around
 // DefIds which were created for const args.

--- a/tests/ui/const-generics/mgca/explicit_anon_consts_literals_hack.rs
+++ b/tests/ui/const-generics/mgca/explicit_anon_consts_literals_hack.rs
@@ -4,7 +4,7 @@
 // However, we don't allow so for const arguments in field init positions.
 // This is just harder to implement so we did not do so.
 
-#![feature(min_generic_const_args, adt_const_params, associated_const_equality)]
+#![feature(min_generic_const_args, adt_const_params)]
 #![expect(incomplete_features)]
 
 trait Trait {

--- a/tests/ui/const-generics/mgca/type_const-only-in-impl.rs
+++ b/tests/ui/const-generics/mgca/type_const-only-in-impl.rs
@@ -1,5 +1,5 @@
 #![expect(incomplete_features)]
-#![feature(associated_const_equality, min_generic_const_args)]
+#![feature(min_generic_const_args)]
 
 trait BadTr {
     const NUM: usize;

--- a/tests/ui/const-generics/mgca/type_const-only-in-trait.rs
+++ b/tests/ui/const-generics/mgca/type_const-only-in-trait.rs
@@ -1,5 +1,5 @@
 #![expect(incomplete_features)]
-#![feature(associated_const_equality, min_generic_const_args)]
+#![feature(min_generic_const_args)]
 
 trait GoodTr {
     #[type_const]

--- a/tests/ui/const-generics/mgca/using-fnptr-as-type_const.rs
+++ b/tests/ui/const-generics/mgca/using-fnptr-as-type_const.rs
@@ -1,7 +1,7 @@
 // Regression test for #119783
 
 #![expect(incomplete_features)]
-#![feature(associated_const_equality, min_generic_const_args)]
+#![feature(min_generic_const_args)]
 
 trait Trait {
     #[type_const]

--- a/tests/ui/const-generics/parser-error-recovery/issue-89013-no-kw.stderr
+++ b/tests/ui/const-generics/parser-error-recovery/issue-89013-no-kw.stderr
@@ -4,8 +4,8 @@ error[E0658]: associated const equality is incomplete
 LL | impl Foo<N = 3> for Bar {
    |          ^^^^^
    |
-   = note: see issue #92827 <https://github.com/rust-lang/rust/issues/92827> for more information
-   = help: add `#![feature(associated_const_equality)]` to the crate attributes to enable
+   = note: see issue #132980 <https://github.com/rust-lang/rust/issues/132980> for more information
+   = help: add `#![feature(min_generic_const_args)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0229]: associated item constraints are not allowed here

--- a/tests/ui/const-generics/parser-error-recovery/issue-89013.stderr
+++ b/tests/ui/const-generics/parser-error-recovery/issue-89013.stderr
@@ -16,8 +16,8 @@ error[E0658]: associated const equality is incomplete
 LL | impl Foo<N = const 3> for Bar {
    |          ^^^^^^^^^^^
    |
-   = note: see issue #92827 <https://github.com/rust-lang/rust/issues/92827> for more information
-   = help: add `#![feature(associated_const_equality)]` to the crate attributes to enable
+   = note: see issue #132980 <https://github.com/rust-lang/rust/issues/132980> for more information
+   = help: add `#![feature(min_generic_const_args)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0229]: associated item constraints are not allowed here

--- a/tests/ui/feature-gates/feature-gate-associated_const_equality.rs
+++ b/tests/ui/feature-gates/feature-gate-associated_const_equality.rs
@@ -8,7 +8,7 @@ impl TraitWAssocConst for Demo {
 }
 
 fn foo<A: TraitWAssocConst<A=32>>() {}
-//~^ ERROR associated const equality
+//~^ ERROR associated const equality is incomplete
 
 fn main() {
   foo::<Demo>();

--- a/tests/ui/feature-gates/feature-gate-associated_const_equality.stderr
+++ b/tests/ui/feature-gates/feature-gate-associated_const_equality.stderr
@@ -4,8 +4,8 @@ error[E0658]: associated const equality is incomplete
 LL | fn foo<A: TraitWAssocConst<A=32>>() {}
    |                            ^^^^
    |
-   = note: see issue #92827 <https://github.com/rust-lang/rust/issues/92827> for more information
-   = help: add `#![feature(associated_const_equality)]` to the crate attributes to enable
+   = note: see issue #132980 <https://github.com/rust-lang/rust/issues/132980> for more information
+   = help: add `#![feature(min_generic_const_args)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error

--- a/tests/ui/generic-const-items/assoc-const-no-infer-ice-115806.rs
+++ b/tests/ui/generic-const-items/assoc-const-no-infer-ice-115806.rs
@@ -1,6 +1,6 @@
 // ICE: assertion failed: !value.has_infer()
 // issue: rust-lang/rust#115806
-#![feature(associated_const_equality, min_generic_const_args, unsized_const_params)]
+#![feature(min_generic_const_args, unsized_const_params)]
 #![allow(incomplete_features)]
 
 pub struct NoPin;

--- a/tests/ui/generic-const-items/associated-const-equality.rs
+++ b/tests/ui/generic-const-items/associated-const-equality.rs
@@ -1,7 +1,7 @@
 //@ check-pass
 
 #![feature(generic_const_items, min_generic_const_args)]
-#![feature(associated_const_equality, adt_const_params)]
+#![feature(adt_const_params)]
 #![allow(incomplete_features)]
 
 trait Owner {

--- a/tests/ui/lowering/no-name-for-DefPath-issue-133426.stderr
+++ b/tests/ui/lowering/no-name-for-DefPath-issue-133426.stderr
@@ -4,8 +4,8 @@ error[E0658]: associated const equality is incomplete
 LL | fn b(_: impl Iterator<Item = { match 0 { ! } }>) {}
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: see issue #92827 <https://github.com/rust-lang/rust/issues/92827> for more information
-   = help: add `#![feature(associated_const_equality)]` to the crate attributes to enable
+   = note: see issue #132980 <https://github.com/rust-lang/rust/issues/132980> for more information
+   = help: add `#![feature(min_generic_const_args)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0614]: type `!` cannot be dereferenced

--- a/tests/ui/parser/recover/recover-assoc-const-constraint.stderr
+++ b/tests/ui/parser/recover/recover-assoc-const-constraint.stderr
@@ -4,8 +4,8 @@ error[E0658]: associated const equality is incomplete
 LL |     bar::<Item = 42>();
    |           ^^^^^^^^^
    |
-   = note: see issue #92827 <https://github.com/rust-lang/rust/issues/92827> for more information
-   = help: add `#![feature(associated_const_equality)]` to the crate attributes to enable
+   = note: see issue #132980 <https://github.com/rust-lang/rust/issues/132980> for more information
+   = help: add `#![feature(min_generic_const_args)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: associated const equality is incomplete
@@ -14,8 +14,8 @@ error[E0658]: associated const equality is incomplete
 LL |     bar::<Item = { 42 }>();
    |           ^^^^^^^^^^^^^
    |
-   = note: see issue #92827 <https://github.com/rust-lang/rust/issues/92827> for more information
-   = help: add `#![feature(associated_const_equality)]` to the crate attributes to enable
+   = note: see issue #132980 <https://github.com/rust-lang/rust/issues/132980> for more information
+   = help: add `#![feature(min_generic_const_args)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 2 previous errors

--- a/tests/ui/specialization/overlap-due-to-unsatisfied-const-bound.rs
+++ b/tests/ui/specialization/overlap-due-to-unsatisfied-const-bound.rs
@@ -1,6 +1,6 @@
 // Regression test for #140571. The compiler used to ICE
 
-#![feature(associated_const_equality, min_generic_const_args, specialization)]
+#![feature(min_generic_const_args, specialization)]
 //~^ WARN the feature `specialization` is incomplete
 //~| WARN the feature `min_generic_const_args` is incomplete
 

--- a/tests/ui/specialization/overlap-due-to-unsatisfied-const-bound.stderr
+++ b/tests/ui/specialization/overlap-due-to-unsatisfied-const-bound.stderr
@@ -1,17 +1,17 @@
 warning: the feature `min_generic_const_args` is incomplete and may not be safe to use and/or cause compiler crashes
-  --> $DIR/overlap-due-to-unsatisfied-const-bound.rs:3:39
+  --> $DIR/overlap-due-to-unsatisfied-const-bound.rs:3:12
    |
-LL | #![feature(associated_const_equality, min_generic_const_args, specialization)]
-   |                                       ^^^^^^^^^^^^^^^^^^^^^^
+LL | #![feature(min_generic_const_args, specialization)]
+   |            ^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #132980 <https://github.com/rust-lang/rust/issues/132980> for more information
    = note: `#[warn(incomplete_features)]` on by default
 
 warning: the feature `specialization` is incomplete and may not be safe to use and/or cause compiler crashes
-  --> $DIR/overlap-due-to-unsatisfied-const-bound.rs:3:63
+  --> $DIR/overlap-due-to-unsatisfied-const-bound.rs:3:36
    |
-LL | #![feature(associated_const_equality, min_generic_const_args, specialization)]
-   |                                                               ^^^^^^^^^^^^^^
+LL | #![feature(min_generic_const_args, specialization)]
+   |                                    ^^^^^^^^^^^^^^
    |
    = note: see issue #31844 <https://github.com/rust-lang/rust/issues/31844> for more information
    = help: consider using `min_specialization` instead, which is more stable and complete

--- a/tests/ui/traits/next-solver/dont-ice-on-assoc-projection.stderr
+++ b/tests/ui/traits/next-solver/dont-ice-on-assoc-projection.stderr
@@ -4,8 +4,8 @@ error[E0658]: associated const equality is incomplete
 LL | impl<T> Foo for T where T: Bar<ASSOC = 0> {}
    |                                ^^^^^^^^^
    |
-   = note: see issue #92827 <https://github.com/rust-lang/rust/issues/92827> for more information
-   = help: add `#![feature(associated_const_equality)]` to the crate attributes to enable
+   = note: see issue #132980 <https://github.com/rust-lang/rust/issues/132980> for more information
+   = help: add `#![feature(min_generic_const_args)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0119]: conflicting implementations of trait `Foo` for type `()`


### PR DESCRIPTION
Tracking Issues: rust-lang/rust#132980 rust-lang/rust#92827

Merge `associated_const_equality`(ACE) feature gate into `min_generic_const_args`(MGCA).

- Replaces `features().associated_const_equality()` checks with `features().min_generic_const_args()`
- Updates the parser to gate associated const equality under `min_generic_const_args`
- Moves `associated_const_equality` to the removed features list
- Removes the `associated_const_equality` method from the `Features` trait
- Updates all affected tests and tools (rust-analyzer, clippy)

Closes rust-lang/rust#150617

r? @BoxyUwU

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
