### PR TITLE
mutex.rs: remove needless-maybe-unsized bounds

### DIFF
--- a/library/std/src/sync/nonpoison/mutex.rs
+++ b/library/std/src/sync/nonpoison/mutex.rs
@@ -422,7 +422,7 @@ impl<T> From<T> for Mutex<T> {
 }
 
 #[unstable(feature = "nonpoison_mutex", issue = "134645")]
-impl<T: ?Sized + Default> Default for Mutex<T> {
+impl<T: Default> Default for Mutex<T> {
     /// Creates a `Mutex<T>`, with the `Default` value for T.
     fn default() -> Mutex<T> {
         Mutex::new(Default::default())

--- a/library/std/src/sync/poison/mutex.rs
+++ b/library/std/src/sync/poison/mutex.rs
@@ -688,7 +688,7 @@ impl<T> From<T> for Mutex<T> {
 }
 
 #[stable(feature = "mutex_default", since = "1.10.0")]
-impl<T: ?Sized + Default> Default for Mutex<T> {
+impl<T: Default> Default for Mutex<T> {
     /// Creates a `Mutex<T>`, with the `Default` value for T.
     fn default() -> Mutex<T> {
         Mutex::new(Default::default())


### PR DESCRIPTION
Fixes for:

```text
warning: `?Sized` bound is ignored because of a `Sized` requirement
   --> library/std/src/sync/nonpoison/mutex.rs:425:9
    |
425 | impl<T: ?Sized + Default> Default for Mutex<T> {
    |         ^^^^^^
    |
note: `T` cannot be unsized because of the bound
   --> library/std/src/sync/nonpoison/mutex.rs:425:18
    |
425 | impl<T: ?Sized + Default> Default for Mutex<T> {
    |                  ^^^^^^^
    = note: ...because `Default` has the bound `Sized`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_maybe_sized
    = note: `-W clippy::needless-maybe-sized` implied by `-W clippy::suspicious`
    = help: to override `-W clippy::suspicious` add `#[allow(clippy::needless_maybe_sized)]`
help: change the bounds that require `Sized`, or remove the `?Sized` bound
    |
425 - impl<T: ?Sized + Default> Default for Mutex<T> {
425 + impl<T: Default> Default for Mutex<T> {
    |

warning: `?Sized` bound is ignored because of a `Sized` requirement
   --> library/std/src/sync/poison/mutex.rs:691:9
    |
691 | impl<T: ?Sized + Default> Default for Mutex<T> {
    |         ^^^^^^
    |
note: `T` cannot be unsized because of the bound
   --> library/std/src/sync/poison/mutex.rs:691:18
    |
691 | impl<T: ?Sized + Default> Default for Mutex<T> {
    |                  ^^^^^^^
    = note: ...because `Default` has the bound `Sized`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_maybe_sized
help: change the bounds that require `Sized`, or remove the `?Sized` bound
    |
691 - impl<T: ?Sized + Default> Default for Mutex<T> {
691 + impl<T: Default> Default for Mutex<T> {
```