### PR TITLE
vec in-place-drop: avoid creating an intermediate slice

### DIFF
--- a/library/alloc/src/vec/in_place_drop.rs
+++ b/library/alloc/src/vec/in_place_drop.rs
@@ -1,6 +1,5 @@
 use core::marker::PhantomData;
 use core::ptr::{self, NonNull, drop_in_place};
-use core::slice::{self};
 
 use crate::alloc::Global;
 use crate::raw_vec::RawVec;
@@ -22,7 +21,7 @@ impl<T> Drop for InPlaceDrop<T> {
     #[inline]
     fn drop(&mut self) {
         unsafe {
-            ptr::drop_in_place(slice::from_raw_parts_mut(self.inner, self.len()));
+            ptr::drop_in_place(ptr::slice_from_raw_parts_mut(self.inner, self.len()));
         }
     }
 }


### PR DESCRIPTION
Avoids clippy warning:
```text
warning: implicitly casting the result of `from_raw_parts_mut` to `*mut [T]`
  --> library/alloc/src/vec/in_place_drop.rs:25:32
   |
25 |             ptr::drop_in_place(slice::from_raw_parts_mut(self.inner, self.len()));
   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace_with: `core::ptr::slice_from_raw_parts_mut(self.inner, self.len())`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_slice_from_raw_parts
   = note: `-W clippy::cast-slice-from-raw-parts` implied by `-W clippy::suspicious`
   = help: to override `-W clippy::suspicious` add `#[allow(clippy::cast_slice_from_raw_parts)]`
```