### PR TITLE
clippy fix: non_canonical_clone_impl

### DIFF
--- a/library/core/src/clone.rs
+++ b/library/core/src/clone.rs
@@ -680,7 +680,7 @@ mod impls {
         #[inline(always)]
         #[rustc_diagnostic_item = "noop_method_clone"]
         fn clone(&self) -> Self {
-            self
+            *self
         }
     }
 

--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -849,7 +849,7 @@ impl<T: PointeeSized> Copy for PhantomData<T> {}
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: PointeeSized> Clone for PhantomData<T> {
     fn clone(&self) -> Self {
-        Self
+        *self
     }
 }
 


### PR DESCRIPTION
Fixes:

```text
warning: non-canonical implementation of `clone` on a `Copy` type
   --> library/core/src/clone.rs:682:33
    |
682 |           fn clone(&self) -> Self {
    |  _________________________________^
683 | |             self
684 | |         }
    | |_________^ help: change this to: `{ *self }`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#non_canonical_clone_impl
    = note: requested on the command line with `-W clippy::non-canonical-clone-impl`

warning: non-canonical implementation of `clone` on a `Copy` type
   --> library/core/src/convert/mod.rs:935:35
    |
935 |       fn clone(&self) -> Infallible {
    |  ___________________________________^
936 | |         match *self {}
937 | |     }
    | |_____^ help: change this to: `{ *self }`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#non_canonical_clone_impl

warning: non-canonical implementation of `clone` on a `Copy` type
   --> library/core/src/marker.rs:856:29
    |
856 |       fn clone(&self) -> Self {
    |  _____________________________^
857 | |         Self
858 | |     }
    | |_____^ help: change this to: `{ *self }`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#non_canonical_clone_impl

```