### PR TITLE
Clarify panic conditions in `Iterator::last`

### DIFF
--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -238,8 +238,7 @@ pub trait Iterator {
     ///
     /// # Panics
     ///
-    /// This function might panic if the iterator has more than [`usize::MAX`]
-    /// elements.
+    /// This function might panic if the iterator is infinite.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
Follow-up PR to rust-lang/rust#150580.

Now `Iterator::last`'s docs specify that it might panic only if the iterator is infinite, rather than if it has more than `usize::MAX` elements.

# Motivation
This is because `Iterator::last`, unlike `count`, also works on iterators with more than `usize::MAX` elements, but could panic on infinite iterators (as in `Repeat`), as discussed in rust-lang/rust#150580.

r? @jhpratt 