### PR TITLE
Add missing translator resources for interface parse_cfg and parse_check_cfg

### DIFF
--- a/compiler/rustc_interface/src/interface.rs
+++ b/compiler/rustc_interface/src/interface.rs
@@ -55,7 +55,11 @@ pub(crate) fn parse_cfg(dcx: DiagCtxtHandle<'_>, cfgs: Vec<String>) -> Cfg {
     cfgs.into_iter()
         .map(|s| {
             let psess = ParseSess::emitter_with_note(
-                vec![crate::DEFAULT_LOCALE_RESOURCE, rustc_parse::DEFAULT_LOCALE_RESOURCE],
+                vec![
+                    crate::DEFAULT_LOCALE_RESOURCE,
+                    rustc_parse::DEFAULT_LOCALE_RESOURCE,
+                    rustc_session::DEFAULT_LOCALE_RESOURCE,
+                ],
                 format!("this occurred on the command line: `--cfg={s}`"),
             );
             let filename = FileName::cfg_spec_source_code(&s);
@@ -129,7 +133,11 @@ pub(crate) fn parse_check_cfg(dcx: DiagCtxtHandle<'_>, specs: Vec<String>) -> Ch
 
     for s in specs {
         let psess = ParseSess::emitter_with_note(
-            vec![crate::DEFAULT_LOCALE_RESOURCE, rustc_parse::DEFAULT_LOCALE_RESOURCE],
+            vec![
+                crate::DEFAULT_LOCALE_RESOURCE,
+                rustc_parse::DEFAULT_LOCALE_RESOURCE,
+                rustc_session::DEFAULT_LOCALE_RESOURCE,
+            ],
             format!("this occurred on the command line: `--check-cfg={s}`"),
         );
         let filename = FileName::cfg_spec_source_code(&s);

--- a/tests/ui/cfg/invalid-cli-cfg-pred.rs
+++ b/tests/ui/cfg/invalid-cli-cfg-pred.rs
@@ -1,0 +1,5 @@
+//@ compile-flags: --cfg foo=1x
+
+fn main() {}
+
+//~? ERROR invalid `--cfg` argument

--- a/tests/ui/cfg/invalid-cli-cfg-pred.stderr
+++ b/tests/ui/cfg/invalid-cli-cfg-pred.stderr
@@ -1,0 +1,7 @@
+error: invalid suffix `x` for number literal
+  |
+  = help: the suffix must be one of the numeric types (`u32`, `isize`, `f32`, etc.)
+  = note: this occurred on the command line: `--cfg=foo=1x`
+
+error: invalid `--cfg` argument: `foo=1x` (expected `key` or `key="value"`, ensure escaping is appropriate for your shell, try 'key="value"' or key=\"value\")
+

--- a/tests/ui/cfg/invalid-cli-check-cfg-pred.rs
+++ b/tests/ui/cfg/invalid-cli-check-cfg-pred.rs
@@ -1,0 +1,5 @@
+//@ compile-flags: --check-cfg 'foo=1x'
+
+fn main() {}
+
+//~? ERROR invalid `--check-cfg` argument

--- a/tests/ui/cfg/invalid-cli-check-cfg-pred.stderr
+++ b/tests/ui/cfg/invalid-cli-check-cfg-pred.stderr
@@ -1,0 +1,10 @@
+error: invalid suffix `x` for number literal
+  |
+  = help: the suffix must be one of the numeric types (`u32`, `isize`, `f32`, etc.)
+  = note: this occurred on the command line: `--check-cfg=foo=1x`
+
+error: invalid `--check-cfg` argument: `foo=1x`
+   |
+   = note: expected `cfg(name, values("value1", "value2", ... "valueN"))`
+   = note: visit <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more details
+


### PR DESCRIPTION
Missing resources leads to the failure of `translate_message`.

Fixes rust-lang/rust#150654