### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -440,7 +440,7 @@ impl<'hir> ConstItemRhs<'hir> {
 /// versus const args that are literals or have arbitrary computations (e.g., `{ 1 + 3 }`).
 ///
 /// For an explanation of the `Unambig` generic parameter see the dev-guide:
-/// <https://rustc-dev-guide.rust-lang.org/hir/ambig-unambig-ty-and-consts.html>
+/// <https://rustc-dev-guide.rust-lang.org/ambig-unambig-ty-and-consts.html>
 #[derive(Clone, Copy, Debug, HashStable_Generic)]
 #[repr(C)]
 pub struct ConstArg<'hir, Unambig = ()> {
@@ -3374,7 +3374,7 @@ pub enum AmbigArg {}
 /// Represents a type in the `HIR`.
 ///
 /// For an explanation of the `Unambig` generic parameter see the dev-guide:
-/// <https://rustc-dev-guide.rust-lang.org/hir/ambig-unambig-ty-and-consts.html>
+/// <https://rustc-dev-guide.rust-lang.org/ambig-unambig-ty-and-consts.html>
 #[derive(Debug, Clone, Copy, HashStable_Generic)]
 #[repr(C)]
 pub struct Ty<'hir, Unambig = ()> {
@@ -3713,7 +3713,7 @@ pub enum InferDelegationKind {
 /// The various kinds of types recognized by the compiler.
 ///
 /// For an explanation of the `Unambig` generic parameter see the dev-guide:
-/// <https://rustc-dev-guide.rust-lang.org/hir/ambig-unambig-ty-and-consts.html>
+/// <https://rustc-dev-guide.rust-lang.org/ambig-unambig-ty-and-consts.html>
 // SAFETY: `repr(u8)` is required so that `TyKind<()>` and `TyKind<!>` are layout compatible
 #[repr(u8, C)]
 #[derive(Debug, Clone, Copy, HashStable_Generic)]

--- a/compiler/rustc_interface/src/interface.rs
+++ b/compiler/rustc_interface/src/interface.rs
@@ -55,7 +55,11 @@ pub(crate) fn parse_cfg(dcx: DiagCtxtHandle<'_>, cfgs: Vec<String>) -> Cfg {
     cfgs.into_iter()
         .map(|s| {
             let psess = ParseSess::emitter_with_note(
-                vec![crate::DEFAULT_LOCALE_RESOURCE, rustc_parse::DEFAULT_LOCALE_RESOURCE],
+                vec![
+                    crate::DEFAULT_LOCALE_RESOURCE,
+                    rustc_parse::DEFAULT_LOCALE_RESOURCE,
+                    rustc_session::DEFAULT_LOCALE_RESOURCE,
+                ],
                 format!("this occurred on the command line: `--cfg={s}`"),
             );
             let filename = FileName::cfg_spec_source_code(&s);
@@ -129,7 +133,11 @@ pub(crate) fn parse_check_cfg(dcx: DiagCtxtHandle<'_>, specs: Vec<String>) -> Ch
 
     for s in specs {
         let psess = ParseSess::emitter_with_note(
-            vec![crate::DEFAULT_LOCALE_RESOURCE, rustc_parse::DEFAULT_LOCALE_RESOURCE],
+            vec![
+                crate::DEFAULT_LOCALE_RESOURCE,
+                rustc_parse::DEFAULT_LOCALE_RESOURCE,
+                rustc_session::DEFAULT_LOCALE_RESOURCE,
+            ],
             format!("this occurred on the command line: `--check-cfg={s}`"),
         );
         let filename = FileName::cfg_spec_source_code(&s);

--- a/library/alloc/src/vec/in_place_drop.rs
+++ b/library/alloc/src/vec/in_place_drop.rs
@@ -1,6 +1,5 @@
 use core::marker::PhantomData;
 use core::ptr::{self, NonNull, drop_in_place};
-use core::slice::{self};
 
 use crate::alloc::Global;
 use crate::raw_vec::RawVec;
@@ -22,7 +21,7 @@ impl<T> Drop for InPlaceDrop<T> {
     #[inline]
     fn drop(&mut self) {
         unsafe {
-            ptr::drop_in_place(slice::from_raw_parts_mut(self.inner, self.len()));
+            ptr::drop_in_place(ptr::slice_from_raw_parts_mut(self.inner, self.len()));
         }
     }
 }

--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -238,8 +238,7 @@ pub trait Iterator {
     ///
     /// # Panics
     ///
-    /// This function might panic if the iterator has more than [`usize::MAX`]
-    /// elements.
+    /// This function might panic if the iterator is infinite.
     ///
     /// # Examples
     ///

--- a/library/std/src/sync/nonpoison/mutex.rs
+++ b/library/std/src/sync/nonpoison/mutex.rs
@@ -422,7 +422,7 @@ impl<T> From<T> for Mutex<T> {
 }
 
 #[unstable(feature = "nonpoison_mutex", issue = "134645")]
-impl<T: ?Sized + Default> Default for Mutex<T> {
+impl<T: Default> Default for Mutex<T> {
     /// Creates a `Mutex<T>`, with the `Default` value for T.
     fn default() -> Mutex<T> {
         Mutex::new(Default::default())

--- a/library/std/src/sync/poison/mutex.rs
+++ b/library/std/src/sync/poison/mutex.rs
@@ -688,7 +688,7 @@ impl<T> From<T> for Mutex<T> {
 }
 
 #[stable(feature = "mutex_default", since = "1.10.0")]
-impl<T: ?Sized + Default> Default for Mutex<T> {
+impl<T: Default> Default for Mutex<T> {
     /// Creates a `Mutex<T>`, with the `Default` value for T.
     fn default() -> Mutex<T> {
         Mutex::new(Default::default())

--- a/src/tools/compiletest/src/directives.rs
+++ b/src/tools/compiletest/src/directives.rs
@@ -15,7 +15,7 @@ use crate::directives::directive_names::{
 };
 pub(crate) use crate::directives::file::FileDirectives;
 use crate::directives::handlers::DIRECTIVE_HANDLERS_MAP;
-use crate::directives::line::{DirectiveLine, line_directive};
+use crate::directives::line::DirectiveLine;
 use crate::directives::needs::CachedNeedsConditions;
 use crate::edition::{Edition, parse_edition};
 use crate::errors::ErrorKind;
@@ -29,6 +29,7 @@ mod directive_names;
 mod file;
 mod handlers;
 mod line;
+pub(crate) use line::line_directive;
 mod line_number;
 pub(crate) use line_number::LineNumber;
 mod needs;

--- a/src/tools/compiletest/src/runtest/debuginfo.rs
+++ b/src/tools/compiletest/src/runtest/debuginfo.rs
@@ -46,7 +46,7 @@ impl TestCx<'_> {
         }
 
         // Parse debugger commands etc from test files
-        let dbg_cmds = DebuggerCommands::parse_from(&self.testpaths.file, "cdb")
+        let dbg_cmds = DebuggerCommands::parse_from(&self.testpaths.file, "cdb", self.revision)
             .unwrap_or_else(|e| self.fatal(&e));
 
         // https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/debugger-commands
@@ -105,7 +105,7 @@ impl TestCx<'_> {
     }
 
     fn run_debuginfo_gdb_test(&self) {
-        let dbg_cmds = DebuggerCommands::parse_from(&self.testpaths.file, "gdb")
+        let dbg_cmds = DebuggerCommands::parse_from(&self.testpaths.file, "gdb", self.revision)
             .unwrap_or_else(|e| self.fatal(&e));
         let mut cmds = dbg_cmds.commands.join("\n");
 
@@ -366,7 +366,7 @@ impl TestCx<'_> {
         }
 
         // Parse debugger commands etc from test files
-        let dbg_cmds = DebuggerCommands::parse_from(&self.testpaths.file, "lldb")
+        let dbg_cmds = DebuggerCommands::parse_from(&self.testpaths.file, "lldb", self.revision)
             .unwrap_or_else(|e| self.fatal(&e));
 
         // Write debugger script:

--- a/tests/debuginfo/macro-stepping.rs
+++ b/tests/debuginfo/macro-stepping.rs
@@ -14,8 +14,10 @@
 #[macro_use]
 extern crate macro_stepping; // exports new_scope!()
 
-//@ compile-flags:-g -Zmir-enable-passes=-SingleUseConsts
-// SingleUseConsts shouldn't need to be disabled, see #128945
+//@ compile-flags: -g
+// FIXME(#128945): SingleUseConsts shouldn't need to be disabled.
+//@ revisions: default-mir-passes no-SingleUseConsts-mir-pass
+//@ [no-SingleUseConsts-mir-pass] compile-flags: -Zmir-enable-passes=-SingleUseConsts
 
 // === GDB TESTS ===================================================================================
 
@@ -48,7 +50,7 @@ extern crate macro_stepping; // exports new_scope!()
 //@ gdb-check:[...]#inc-loc2[...]
 //@ gdb-command:next
 //@ gdb-command:frame
-//@ gdb-check:[...]#inc-loc3[...]
+//@ [no-SingleUseConsts-mir-pass] gdb-check:[...]#inc-loc3[...]
 
 // === LLDB TESTS ==================================================================================
 

--- a/tests/ui/associated-consts/assoc-const-eq-bound-var-in-ty-not-wf.rs
+++ b/tests/ui/associated-consts/assoc-const-eq-bound-var-in-ty-not-wf.rs
@@ -5,6 +5,7 @@
     min_generic_const_args,
     adt_const_params,
     unsized_const_params,
+    generic_const_parameter_types,
 )]
 #![allow(incomplete_features)]
 

--- a/tests/ui/associated-consts/assoc-const-eq-bound-var-in-ty-not-wf.stderr
+++ b/tests/ui/associated-consts/assoc-const-eq-bound-var-in-ty-not-wf.stderr
@@ -1,11 +1,11 @@
 error: higher-ranked subtype error
-  --> $DIR/assoc-const-eq-bound-var-in-ty-not-wf.rs:21:13
+  --> $DIR/assoc-const-eq-bound-var-in-ty-not-wf.rs:22:13
    |
 LL |         K = const { () }
    |             ^^^^^^^^^^^^
 
 error: higher-ranked subtype error
-  --> $DIR/assoc-const-eq-bound-var-in-ty-not-wf.rs:21:13
+  --> $DIR/assoc-const-eq-bound-var-in-ty-not-wf.rs:22:13
    |
 LL |         K = const { () }
    |             ^^^^^^^^^^^^

--- a/tests/ui/associated-consts/assoc-const-eq-bound-var-in-ty.rs
+++ b/tests/ui/associated-consts/assoc-const-eq-bound-var-in-ty.rs
@@ -8,6 +8,7 @@
     min_generic_const_args,
     adt_const_params,
     unsized_const_params,
+    generic_const_parameter_types,
 )]
 #![allow(incomplete_features)]
 

--- a/tests/ui/associated-consts/assoc-const-eq-esc-bound-var-in-ty.rs
+++ b/tests/ui/associated-consts/assoc-const-eq-esc-bound-var-in-ty.rs
@@ -1,6 +1,11 @@
 // Detect and reject escaping late-bound generic params in
 // the type of assoc consts used in an equality bound.
-#![feature(associated_const_equality, min_generic_const_args, unsized_const_params)]
+#![feature(
+    associated_const_equality,
+    min_generic_const_args,
+    unsized_const_params,
+    generic_const_parameter_types,
+)]
 #![allow(incomplete_features)]
 
 trait Trait<'a> {

--- a/tests/ui/associated-consts/assoc-const-eq-esc-bound-var-in-ty.stderr
+++ b/tests/ui/associated-consts/assoc-const-eq-esc-bound-var-in-ty.stderr
@@ -1,5 +1,5 @@
 error: the type of the associated constant `K` cannot capture late-bound generic parameters
-  --> $DIR/assoc-const-eq-esc-bound-var-in-ty.rs:11:35
+  --> $DIR/assoc-const-eq-esc-bound-var-in-ty.rs:16:35
    |
 LL | fn take(_: impl for<'r> Trait<'r, K = const { &() }>) {}
    |                     --            ^ its type cannot capture the late-bound lifetime parameter `'r`

--- a/tests/ui/associated-consts/assoc-const-eq-param-in-ty.rs
+++ b/tests/ui/associated-consts/assoc-const-eq-param-in-ty.rs
@@ -5,6 +5,7 @@
     min_generic_const_args,
     adt_const_params,
     unsized_const_params,
+    generic_const_parameter_types,
 )]
 #![allow(incomplete_features)]
 

--- a/tests/ui/associated-consts/assoc-const-eq-param-in-ty.stderr
+++ b/tests/ui/associated-consts/assoc-const-eq-param-in-ty.stderr
@@ -1,5 +1,5 @@
 error: the type of the associated constant `K` must not depend on generic parameters
-  --> $DIR/assoc-const-eq-param-in-ty.rs:22:29
+  --> $DIR/assoc-const-eq-param-in-ty.rs:23:29
    |
 LL | fn take0<'r, A: 'r + ConstParamTy_, const Q: usize>(
    |          -- the lifetime parameter `'r` is defined here
@@ -10,7 +10,7 @@ LL |     _: impl Trait<'r, A, Q, K = const { loop {} }>
    = note: `K` has type `&'r [A; Q]`
 
 error: the type of the associated constant `K` must not depend on generic parameters
-  --> $DIR/assoc-const-eq-param-in-ty.rs:22:29
+  --> $DIR/assoc-const-eq-param-in-ty.rs:23:29
    |
 LL | fn take0<'r, A: 'r + ConstParamTy_, const Q: usize>(
    |              - the type parameter `A` is defined here
@@ -21,7 +21,7 @@ LL |     _: impl Trait<'r, A, Q, K = const { loop {} }>
    = note: `K` has type `&'r [A; Q]`
 
 error: the type of the associated constant `K` must not depend on generic parameters
-  --> $DIR/assoc-const-eq-param-in-ty.rs:22:29
+  --> $DIR/assoc-const-eq-param-in-ty.rs:23:29
    |
 LL | fn take0<'r, A: 'r + ConstParamTy_, const Q: usize>(
    |                                           - the const parameter `Q` is defined here
@@ -32,7 +32,7 @@ LL |     _: impl Trait<'r, A, Q, K = const { loop {} }>
    = note: `K` has type `&'r [A; Q]`
 
 error: the type of the associated constant `SELF` must not depend on `impl Trait`
-  --> $DIR/assoc-const-eq-param-in-ty.rs:39:26
+  --> $DIR/assoc-const-eq-param-in-ty.rs:40:26
    |
 LL | fn take1(_: impl Project<SELF = const {}>) {}
    |             -------------^^^^------------
@@ -41,7 +41,7 @@ LL | fn take1(_: impl Project<SELF = const {}>) {}
    |             the `impl Trait` is specified here
 
 error: the type of the associated constant `SELF` must not depend on generic parameters
-  --> $DIR/assoc-const-eq-param-in-ty.rs:44:21
+  --> $DIR/assoc-const-eq-param-in-ty.rs:45:21
    |
 LL | fn take2<P: Project<SELF = const {}>>(_: P) {}
    |          -          ^^^^ its type must not depend on the type parameter `P`
@@ -51,7 +51,7 @@ LL | fn take2<P: Project<SELF = const {}>>(_: P) {}
    = note: `SELF` has type `P`
 
 error: the type of the associated constant `K` must not depend on generic parameters
-  --> $DIR/assoc-const-eq-param-in-ty.rs:53:52
+  --> $DIR/assoc-const-eq-param-in-ty.rs:54:52
    |
 LL | trait Iface<'r>: ConstParamTy_ {
    |             -- the lifetime parameter `'r` is defined here
@@ -62,7 +62,7 @@ LL |     type Assoc<const Q: usize>: Trait<'r, Self, Q, K = const { loop {} }>
    = note: `K` has type `&'r [Self; Q]`
 
 error: the type of the associated constant `K` must not depend on `Self`
-  --> $DIR/assoc-const-eq-param-in-ty.rs:53:52
+  --> $DIR/assoc-const-eq-param-in-ty.rs:54:52
    |
 LL |     type Assoc<const Q: usize>: Trait<'r, Self, Q, K = const { loop {} }>
    |                                                    ^ its type must not depend on `Self`
@@ -70,7 +70,7 @@ LL |     type Assoc<const Q: usize>: Trait<'r, Self, Q, K = const { loop {} }>
    = note: `K` has type `&'r [Self; Q]`
 
 error: the type of the associated constant `K` must not depend on generic parameters
-  --> $DIR/assoc-const-eq-param-in-ty.rs:53:52
+  --> $DIR/assoc-const-eq-param-in-ty.rs:54:52
    |
 LL |     type Assoc<const Q: usize>: Trait<'r, Self, Q, K = const { loop {} }>
    |                      -                             ^ its type must not depend on the const parameter `Q`
@@ -80,7 +80,7 @@ LL |     type Assoc<const Q: usize>: Trait<'r, Self, Q, K = const { loop {} }>
    = note: `K` has type `&'r [Self; Q]`
 
 error: the type of the associated constant `K` must not depend on generic parameters
-  --> $DIR/assoc-const-eq-param-in-ty.rs:53:52
+  --> $DIR/assoc-const-eq-param-in-ty.rs:54:52
    |
 LL | trait Iface<'r>: ConstParamTy_ {
    |             -- the lifetime parameter `'r` is defined here
@@ -92,7 +92,7 @@ LL |     type Assoc<const Q: usize>: Trait<'r, Self, Q, K = const { loop {} }>
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: the type of the associated constant `K` must not depend on `Self`
-  --> $DIR/assoc-const-eq-param-in-ty.rs:53:52
+  --> $DIR/assoc-const-eq-param-in-ty.rs:54:52
    |
 LL |     type Assoc<const Q: usize>: Trait<'r, Self, Q, K = const { loop {} }>
    |                                                    ^ its type must not depend on `Self`
@@ -101,7 +101,7 @@ LL |     type Assoc<const Q: usize>: Trait<'r, Self, Q, K = const { loop {} }>
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: the type of the associated constant `K` must not depend on generic parameters
-  --> $DIR/assoc-const-eq-param-in-ty.rs:53:52
+  --> $DIR/assoc-const-eq-param-in-ty.rs:54:52
    |
 LL |     type Assoc<const Q: usize>: Trait<'r, Self, Q, K = const { loop {} }>
    |                      -                             ^ its type must not depend on the const parameter `Q`

--- a/tests/ui/associated-consts/assoc-const-eq-supertraits.rs
+++ b/tests/ui/associated-consts/assoc-const-eq-supertraits.rs
@@ -8,6 +8,7 @@
     min_generic_const_args,
     adt_const_params,
     unsized_const_params,
+    generic_const_parameter_types,
 )]
 #![allow(incomplete_features)]
 

--- a/tests/ui/cfg/invalid-cli-cfg-pred.rs
+++ b/tests/ui/cfg/invalid-cli-cfg-pred.rs
@@ -1,0 +1,5 @@
+//@ compile-flags: --cfg foo=1x
+
+fn main() {}
+
+//~? ERROR invalid `--cfg` argument

--- a/tests/ui/cfg/invalid-cli-cfg-pred.stderr
+++ b/tests/ui/cfg/invalid-cli-cfg-pred.stderr
@@ -1,0 +1,7 @@
+error: invalid suffix `x` for number literal
+  |
+  = help: the suffix must be one of the numeric types (`u32`, `isize`, `f32`, etc.)
+  = note: this occurred on the command line: `--cfg=foo=1x`
+
+error: invalid `--cfg` argument: `foo=1x` (expected `key` or `key="value"`, ensure escaping is appropriate for your shell, try 'key="value"' or key=\"value\")
+

--- a/tests/ui/cfg/invalid-cli-check-cfg-pred.rs
+++ b/tests/ui/cfg/invalid-cli-check-cfg-pred.rs
@@ -1,0 +1,5 @@
+//@ compile-flags: --check-cfg 'foo=1x'
+
+fn main() {}
+
+//~? ERROR invalid `--check-cfg` argument

--- a/tests/ui/cfg/invalid-cli-check-cfg-pred.stderr
+++ b/tests/ui/cfg/invalid-cli-check-cfg-pred.stderr
@@ -1,0 +1,10 @@
+error: invalid suffix `x` for number literal
+  |
+  = help: the suffix must be one of the numeric types (`u32`, `isize`, `f32`, etc.)
+  = note: this occurred on the command line: `--check-cfg=foo=1x`
+
+error: invalid `--check-cfg` argument: `foo=1x`
+   |
+   = note: expected `cfg(name, values("value1", "value2", ... "valueN"))`
+   = note: visit <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more details
+

--- a/tests/ui/const-generics/mgca/type_const-generic-param-in-type.gate.stderr
+++ b/tests/ui/const-generics/mgca/type_const-generic-param-in-type.gate.stderr
@@ -1,0 +1,38 @@
+error: anonymous constants referencing generics are not yet supported
+  --> $DIR/type_const-generic-param-in-type.rs:9:53
+   |
+LL | const FOO<T: core::marker::ConstParamTy_>: [T; 0] = const { [] };
+   |                                                     ^^^^^^^^^^^^
+
+error: anonymous constants referencing generics are not yet supported
+  --> $DIR/type_const-generic-param-in-type.rs:14:38
+   |
+LL | const BAR<const N: usize>: [(); N] = const { [] };
+   |                                      ^^^^^^^^^^^^
+
+error: anonymous constants with lifetimes in their type are not yet supported
+  --> $DIR/type_const-generic-param-in-type.rs:19:30
+   |
+LL | const BAZ<'a>: [&'a (); 0] = const { [] };
+   |                              ^^^^^^^^^^^^
+
+error: anonymous constants referencing generics are not yet supported
+  --> $DIR/type_const-generic-param-in-type.rs:39:59
+   |
+LL |     const ASSOC<T: core::marker::ConstParamTy_>: [T; 0] = const { [] };
+   |                                                           ^^^^^^^^^^^^
+
+error: anonymous constants referencing generics are not yet supported
+  --> $DIR/type_const-generic-param-in-type.rs:44:50
+   |
+LL |     const ASSOC_CONST<const N: usize>: [(); N] = const { [] };
+   |                                                  ^^^^^^^^^^^^
+
+error: anonymous constants with lifetimes in their type are not yet supported
+  --> $DIR/type_const-generic-param-in-type.rs:49:39
+   |
+LL |     const ASSOC_LT<'a>: [&'a (); 0] = const { [] };
+   |                                       ^^^^^^^^^^^^
+
+error: aborting due to 6 previous errors
+

--- a/tests/ui/const-generics/mgca/type_const-generic-param-in-type.nogate.stderr
+++ b/tests/ui/const-generics/mgca/type_const-generic-param-in-type.nogate.stderr
@@ -1,0 +1,57 @@
+error[E0770]: the type of const parameters must not depend on other generic parameters
+  --> $DIR/type_const-generic-param-in-type.rs:9:45
+   |
+LL | const FOO<T: core::marker::ConstParamTy_>: [T; 0] = const { [] };
+   |                                             ^ the type must not depend on the parameter `T`
+
+error[E0770]: the type of const parameters must not depend on other generic parameters
+  --> $DIR/type_const-generic-param-in-type.rs:14:33
+   |
+LL | const BAR<const N: usize>: [(); N] = const { [] };
+   |                                 ^ the type must not depend on the parameter `N`
+
+error[E0770]: the type of const parameters must not depend on other generic parameters
+  --> $DIR/type_const-generic-param-in-type.rs:19:18
+   |
+LL | const BAZ<'a>: [&'a (); 0] = const { [] };
+   |                  ^^ the type must not depend on the parameter `'a`
+
+error[E0770]: the type of const parameters must not depend on other generic parameters
+  --> $DIR/type_const-generic-param-in-type.rs:25:51
+   |
+LL |     const ASSOC<T: core::marker::ConstParamTy_>: [T; 0];
+   |                                                   ^ the type must not depend on the parameter `T`
+
+error[E0770]: the type of const parameters must not depend on other generic parameters
+  --> $DIR/type_const-generic-param-in-type.rs:29:45
+   |
+LL |     const ASSOC_CONST<const N: usize>: [(); N];
+   |                                             ^ the type must not depend on the parameter `N`
+
+error[E0770]: the type of const parameters must not depend on other generic parameters
+  --> $DIR/type_const-generic-param-in-type.rs:33:27
+   |
+LL |     const ASSOC_LT<'a>: [&'a (); 0];
+   |                           ^^ the type must not depend on the parameter `'a`
+
+error[E0770]: the type of const parameters must not depend on other generic parameters
+  --> $DIR/type_const-generic-param-in-type.rs:39:51
+   |
+LL |     const ASSOC<T: core::marker::ConstParamTy_>: [T; 0] = const { [] };
+   |                                                   ^ the type must not depend on the parameter `T`
+
+error[E0770]: the type of const parameters must not depend on other generic parameters
+  --> $DIR/type_const-generic-param-in-type.rs:44:45
+   |
+LL |     const ASSOC_CONST<const N: usize>: [(); N] = const { [] };
+   |                                             ^ the type must not depend on the parameter `N`
+
+error[E0770]: the type of const parameters must not depend on other generic parameters
+  --> $DIR/type_const-generic-param-in-type.rs:49:27
+   |
+LL |     const ASSOC_LT<'a>: [&'a (); 0] = const { [] };
+   |                           ^^ the type must not depend on the parameter `'a`
+
+error: aborting due to 9 previous errors
+
+For more information about this error, try `rustc --explain E0770`.

--- a/tests/ui/const-generics/mgca/type_const-generic-param-in-type.rs
+++ b/tests/ui/const-generics/mgca/type_const-generic-param-in-type.rs
@@ -1,0 +1,54 @@
+//@ revisions: nogate gate
+//@ [gate] check-fail
+// FIXME(generic_const_parameter_types): this should pass
+#![expect(incomplete_features)]
+#![feature(adt_const_params, unsized_const_params, min_generic_const_args, generic_const_items)]
+#![cfg_attr(gate, feature(generic_const_parameter_types))]
+
+#[type_const]
+const FOO<T: core::marker::ConstParamTy_>: [T; 0] = const { [] };
+//[nogate]~^ ERROR the type of const parameters must not depend on other generic parameters
+//[gate]~^^ ERROR anonymous constants referencing generics are not yet supported
+
+#[type_const]
+const BAR<const N: usize>: [(); N] = const { [] };
+//[nogate]~^ ERROR the type of const parameters must not depend on other generic parameters
+//[gate]~^^ ERROR anonymous constants referencing generics are not yet supported
+
+#[type_const]
+const BAZ<'a>: [&'a (); 0] = const { [] };
+//[nogate]~^ ERROR the type of const parameters must not depend on other generic parameters
+//[gate]~^^ ERROR anonymous constants with lifetimes in their type are not yet supported
+
+trait Tr {
+    #[type_const]
+    const ASSOC<T: core::marker::ConstParamTy_>: [T; 0];
+    //[nogate]~^ ERROR the type of const parameters must not depend on other generic parameters
+
+    #[type_const]
+    const ASSOC_CONST<const N: usize>: [(); N];
+    //[nogate]~^ ERROR the type of const parameters must not depend on other generic parameters
+
+    #[type_const]
+    const ASSOC_LT<'a>: [&'a (); 0];
+    //[nogate]~^ ERROR the type of const parameters must not depend on other generic parameters
+}
+
+impl Tr for () {
+    #[type_const]
+    const ASSOC<T: core::marker::ConstParamTy_>: [T; 0] = const { [] };
+    //[nogate]~^ ERROR the type of const parameters must not depend on other generic parameters
+    //[gate]~^^ ERROR anonymous constants referencing generics are not yet supported
+
+    #[type_const]
+    const ASSOC_CONST<const N: usize>: [(); N] = const { [] };
+    //[nogate]~^ ERROR the type of const parameters must not depend on other generic parameters
+    //[gate]~^^ ERROR anonymous constants referencing generics are not yet supported
+
+    #[type_const]
+    const ASSOC_LT<'a>: [&'a (); 0] = const { [] };
+    //[nogate]~^ ERROR the type of const parameters must not depend on other generic parameters
+    //[gate]~^^ ERROR anonymous constants with lifetimes in their type are not yet supported
+}
+
+fn main() {}


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#150201 (compiletest: Support revisions in debuginfo (read: debugger) tests)
 - rust-lang/rust#150642 (mutex.rs: remove needless-maybe-unsized bounds)
 - rust-lang/rust#150643 (vec in-place-drop: avoid creating an intermediate slice)
 - rust-lang/rust#150650 (Forbid generic parameters in types of #[type_const] items)
 - rust-lang/rust#150658 (Clarify panic conditions in `Iterator::last`)
 - rust-lang/rust#150659 (Add missing translator resources for interface parse_cfg and parse_check_cfg)
 - rust-lang/rust#150666 (Fix ambig-unambig-ty-and-consts link)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=150201,150642,150643,150650,150658,150659,150666)
<!-- homu-ignore:end -->