### PR TITLE
THIR pattern building: Move all `thir::Pat` creation into `rustc_mir_build::thir::pattern`

### DIFF
--- a/compiler/rustc_mir_build/src/thir/cx/mod.rs
+++ b/compiler/rustc_mir_build/src/thir/cx/mod.rs
@@ -12,9 +12,6 @@ use rustc_hir::{self as hir, HirId, find_attr};
 use rustc_middle::bug;
 use rustc_middle::thir::*;
 use rustc_middle::ty::{self, TyCtxt};
-use tracing::instrument;
-
-use crate::thir::pattern::pat_from_hir;
 
 /// Query implementation for [`TyCtxt::thir_body`].
 pub(crate) fn thir_body(
@@ -111,9 +108,22 @@ impl<'tcx> ThirBuildCx<'tcx> {
         }
     }
 
-    #[instrument(level = "debug", skip(self))]
-    fn pattern_from_hir(&mut self, p: &'tcx hir::Pat<'tcx>) -> Box<Pat<'tcx>> {
-        pat_from_hir(self.tcx, self.typing_env, self.typeck_results, p)
+    fn pattern_from_hir(&mut self, pat: &'tcx hir::Pat<'tcx>) -> Box<Pat<'tcx>> {
+        self.pattern_from_hir_with_annotation(pat, None)
+    }
+
+    fn pattern_from_hir_with_annotation(
+        &mut self,
+        pat: &'tcx hir::Pat<'tcx>,
+        let_stmt_type: Option<&hir::Ty<'tcx>>,
+    ) -> Box<Pat<'tcx>> {
+        crate::thir::pattern::pat_from_hir(
+            self.tcx,
+            self.typing_env,
+            self.typeck_results,
+            pat,
+            let_stmt_type,
+        )
     }
 
     fn closure_env_param(&self, owner_def: LocalDefId, expr_id: HirId) -> Option<Param<'tcx>> {

--- a/compiler/rustc_mir_build/src/thir/pattern/mod.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/mod.rs
@@ -38,11 +38,14 @@ struct PatCtxt<'tcx> {
     rust_2024_migration: Option<PatMigration<'tcx>>,
 }
 
+#[instrument(level = "debug", skip(tcx, typing_env, typeck_results), ret)]
 pub(super) fn pat_from_hir<'tcx>(
     tcx: TyCtxt<'tcx>,
     typing_env: ty::TypingEnv<'tcx>,
     typeck_results: &'tcx ty::TypeckResults<'tcx>,
     pat: &'tcx hir::Pat<'tcx>,
+    // Present if `pat` came from a let statement with an explicit type annotation
+    let_stmt_type: Option<&hir::Ty<'tcx>>,
 ) -> Box<Pat<'tcx>> {
     let mut pcx = PatCtxt {
         tcx,
@@ -53,12 +56,35 @@ pub(super) fn pat_from_hir<'tcx>(
             .get(pat.hir_id)
             .map(PatMigration::new),
     };
-    let result = pcx.lower_pattern(pat);
-    debug!("pat_from_hir({:?}) = {:?}", pat, result);
+
+    let mut thir_pat = pcx.lower_pattern(pat);
+
+    // If this pattern came from a let statement with an explicit type annotation
+    // (e.g. `let x: Foo = ...`), retain that user type information in the THIR pattern.
+    if let Some(let_stmt_type) = let_stmt_type
+        && let Some(&user_ty) = typeck_results.user_provided_types().get(let_stmt_type.hir_id)
+    {
+        debug!(?user_ty);
+        let annotation = CanonicalUserTypeAnnotation {
+            user_ty: Box::new(user_ty),
+            span: let_stmt_type.span,
+            inferred_ty: typeck_results.node_type(let_stmt_type.hir_id),
+        };
+        thir_pat = Box::new(Pat {
+            ty: thir_pat.ty,
+            span: thir_pat.span,
+            kind: PatKind::AscribeUserType {
+                ascription: Ascription { annotation, variance: ty::Covariant },
+                subpattern: thir_pat,
+            },
+        });
+    }
+
     if let Some(m) = pcx.rust_2024_migration {
         m.emit(tcx, pat.hir_id);
     }
-    result
+
+    thir_pat
 }
 
 impl<'tcx> PatCtxt<'tcx> {


### PR DESCRIPTION
The code in `thir::cx::block` was the only code outside of `thir::pattern` that created `thir::Pat` nodes.

Moving it makes the signature of `pat_from_hir` a bit messier, but ensures that all `thir::Pat` creation occurs in one module. That will be useful when trying to change `thir::Pat`, e.g. by adding fields to remove the need for wrapper nodes.

There should be no change to compiler output.