### PR TITLE
compiletest/codegen-llvm: automatically add `needs-target-std` if needed

### DIFF
--- a/src/tools/compiletest/src/directives.rs
+++ b/src/tools/compiletest/src/directives.rs
@@ -358,7 +358,8 @@ impl TestProps {
     fn load_from(&mut self, testfile: &Utf8Path, test_revision: Option<&str>, config: &Config) {
         if !testfile.is_dir() {
             let file_contents = fs::read_to_string(testfile).unwrap();
-            let file_directives = FileDirectives::from_file_contents(testfile, &file_contents);
+            let file_directives =
+                FileDirectives::from_file_contents(config.suite, testfile, &file_contents);
 
             iter_directives(
                 config.mode,

--- a/src/tools/compiletest/src/directives/file.rs
+++ b/src/tools/compiletest/src/directives/file.rs
@@ -9,15 +9,42 @@ pub(crate) struct FileDirectives<'a> {
 }
 
 impl<'a> FileDirectives<'a> {
-    pub(crate) fn from_file_contents(path: &'a Utf8Path, file_contents: &'a str) -> Self {
+    /// Create a new [`FileDirectives`] by iterating through the lines of `file_contents`.
+    ///
+    /// # Note
+    ///
+    /// When the `suite` argument matches [`crate::common::TestSuite::CodegenLlvm`] a synthetic
+    /// `needs-target-std` directive is inserted if needed - that is, if the file does not contain a
+    /// `#![no_std]` annotation.
+    ///
+    /// The objective of this addition is that of making it at least a bit easier to run
+    /// the codegen-llvm test suite for targets that do not have a stdlib, without forcing test
+    /// writers to remember yet another directive.
+    pub(crate) fn from_file_contents(
+        suite: crate::common::TestSuite,
+        path: &'a Utf8Path,
+        file_contents: &'a str,
+    ) -> Self {
         let mut lines = vec![];
+        let mut generate_needs_std_stub = true;
 
         for (line_number, ln) in LineNumber::enumerate().zip(file_contents.lines()) {
             let ln = ln.trim();
 
             if let Some(directive_line) = line_directive(path, line_number, ln) {
+                if directive_line.name == "needs-target-std" {
+                    generate_needs_std_stub = false;
+                }
                 lines.push(directive_line);
             }
+
+            if ln == "#![no_std]" {
+                generate_needs_std_stub = false;
+            }
+        }
+
+        if generate_needs_std_stub && matches!(suite, crate::common::TestSuite::CodegenLlvm) {
+            lines.push(crate::directives::line::generate_needs_std(path))
         }
 
         Self { path, lines }

--- a/src/tools/compiletest/src/directives/line.rs
+++ b/src/tools/compiletest/src/directives/line.rs
@@ -41,6 +41,19 @@ pub(crate) fn line_directive<'a>(
     Some(DirectiveLine { file_path, line_number, revision, raw_directive, name })
 }
 
+/// Generate a synthetic [`DirectiveLine`] to add the "needs-target-std" directive to a specific
+/// test. See [`crate::FileDirectives::from_file_contents`] for an explanation why this is needed.
+#[inline]
+pub(crate) fn generate_needs_std<'a>(file_path: &'a Utf8Path) -> DirectiveLine<'a> {
+    DirectiveLine {
+        file_path,
+        line_number: LineNumber::ZERO,
+        revision: None,
+        raw_directive: "needs-target-std",
+        name: "needs-target-std",
+    }
+}
+
 /// The (partly) broken-down contents of a line containing a test directive,
 /// which `iter_directives` passes to its callback function.
 ///

--- a/src/tools/compiletest/src/directives/tests.rs
+++ b/src/tools/compiletest/src/directives/tests.rs
@@ -49,7 +49,7 @@ fn make_test_description(
 ) -> CollectedTestDesc {
     let cache = DirectivesCache::load(config);
     let mut poisoned = false;
-    let file_directives = FileDirectives::from_file_contents(path, file_contents);
+    let file_directives = FileDirectives::from_file_contents(config.suite, path, file_contents);
 
     let mut aux_props = AuxProps::default();
     let test = crate::directives::make_test_description(
@@ -268,7 +268,8 @@ fn cfg() -> ConfigBuilder {
 }
 
 fn parse_early_props(config: &Config, contents: &str) -> EarlyProps {
-    let file_directives = FileDirectives::from_file_contents(Utf8Path::new("a.rs"), contents);
+    let file_directives =
+        FileDirectives::from_file_contents(config.suite, Utf8Path::new("a.rs"), contents);
     EarlyProps::from_file_directives(config, &file_directives)
 }
 
@@ -842,7 +843,12 @@ fn threads_support() {
 }
 
 fn run_path(poisoned: &mut bool, path: &Utf8Path, file_contents: &str) {
-    let file_directives = FileDirectives::from_file_contents(path, file_contents);
+    let file_directives = FileDirectives::from_file_contents(
+        // Arbitrary suite to prevent from_file_contents to add synthetic directives.
+        crate::common::TestSuite::Coverage,
+        path,
+        file_contents,
+    );
     let result = directives::do_early_directives_check(TestMode::Ui, &file_directives);
     if result.is_err() {
         *poisoned = true;

--- a/src/tools/compiletest/src/lib.rs
+++ b/src/tools/compiletest/src/lib.rs
@@ -855,7 +855,8 @@ fn make_test(cx: &TestCollectorCx, collector: &mut TestCollector, testpaths: &Te
     // Scan the test file to discover its revisions, if any.
     let file_contents =
         fs::read_to_string(&test_path).expect("reading test file for directives should succeed");
-    let file_directives = FileDirectives::from_file_contents(&test_path, &file_contents);
+    let file_directives =
+        FileDirectives::from_file_contents(cx.config.suite, &test_path, &file_contents);
 
     if let Err(message) = directives::do_early_directives_check(cx.config.mode, &file_directives) {
         // FIXME(Zalathar): Overhaul compiletest error handling so that we


### PR DESCRIPTION
When running the codegen-llvm test suite, the `needs-target-std` directive is automatically added if and only if the `#![no_std]` line is not seen and the `needs-target-std` directive was not already seen.

This is a best-effort help to make running the codegen-llvm test suite for targets that do not support std slightly easier. Ideally, with time, the tests that aren't marked as no_std but in fact only use types from core/alloc will be patched to reflect this, so that they can be reused for targets without std.

For an explanation of this patch instead of a patch that marks all the tests that aren't `#![no_std]` with `needs-target-std`, see [this Zulip thread](https://rust-lang.zulipchat.com/#narrow/channel/182449-t-compiler.2Fhelp/topic/.60compiletest.60.20cannot.20find.20.60core.60.20library.20for.20target.20!.3D.20host/near/564294191). Let me know if, instead, a patch adding the `needs-target-std` is preferred.

A simple test of the introduced behaviour is `./x test tests/codegen-llvm/align-fn.rs --target=riscv32e-unknown-none-elf --force-rerun -v`. The [test](https://github.com/rust-lang/rust/blob/main/tests/codegen-llvm/align-fn.rs) does not have the `needs-target-std` directive, but it is ignored with this message:
```
test [codegen] tests/codegen-llvm/align-fn.rs ... ignored, ignored if target does not support std
```
