### PR TITLE
./x check miri: enable check_only feature

### DIFF
--- a/src/bootstrap/src/core/build_steps/check.rs
+++ b/src/bootstrap/src/core/build_steps/check.rs
@@ -793,8 +793,7 @@ tool_check_step!(Clippy { path: "src/tools/clippy", mode: Mode::ToolRustcPrivate
 tool_check_step!(Miri {
     path: "src/tools/miri",
     mode: Mode::ToolRustcPrivate,
-    enable_features: ["stack-cache"],
-    default_features: false,
+    enable_features: ["check_only"],
 });
 tool_check_step!(CargoMiri { path: "src/tools/miri/cargo-miri", mode: Mode::ToolRustcPrivate });
 tool_check_step!(Rustfmt { path: "src/tools/rustfmt", mode: Mode::ToolRustcPrivate });


### PR DESCRIPTION
With this, we should no longer need to turn off the default features, so we can undo https://github.com/rust-lang/rust/pull/149550.

@bjorn3 you seem to have a test setup to check if this works properly in terms of skipping all the work that should not be required -- could you test if this PR works as intended?

FWIW we could now remove `default_features` from `run_tool_check_step`. Not sure if that's worth it.