### PR TITLE
MGCA: pretty printing for struct expressions and tuple calls 

### DIFF
--- a/compiler/rustc_hir_pretty/src/lib.rs
+++ b/compiler/rustc_hir_pretty/src/lib.rs
@@ -17,9 +17,9 @@ use rustc_ast_pretty::pprust::state::MacHeader;
 use rustc_ast_pretty::pprust::{Comments, PrintState};
 use rustc_hir::attrs::{AttributeKind, PrintAttribute};
 use rustc_hir::{
-    BindingMode, ByRef, ConstArgKind, GenericArg, GenericBound, GenericParam, GenericParamKind,
-    HirId, ImplicitSelfKind, LifetimeParamKind, Node, PatKind, PreciseCapturingArg, RangeEnd, Term,
-    TyPatKind,
+    BindingMode, ByRef, ConstArg, ConstArgExprField, ConstArgKind, GenericArg, GenericBound,
+    GenericParam, GenericParamKind, HirId, ImplicitSelfKind, LifetimeParamKind, Node, PatKind,
+    PreciseCapturingArg, RangeEnd, Term, TyPatKind,
 };
 use rustc_span::source_map::SourceMap;
 use rustc_span::{FileName, Ident, Span, Symbol, kw, sym};
@@ -1137,14 +1137,38 @@ impl<'a> State<'a> {
 
     fn print_const_arg(&mut self, const_arg: &hir::ConstArg<'_>) {
         match &const_arg.kind {
-            // FIXME(mgca): proper printing for struct exprs
-            ConstArgKind::Struct(..) => self.word("/* STRUCT EXPR */"),
-            ConstArgKind::TupleCall(..) => self.word("/* TUPLE CALL */"),
+            ConstArgKind::Struct(qpath, fields) => self.print_const_struct(qpath, fields),
+            ConstArgKind::TupleCall(qpath, args) => self.print_const_ctor(qpath, args),
             ConstArgKind::Path(qpath) => self.print_qpath(qpath, true),
             ConstArgKind::Anon(anon) => self.print_anon_const(anon),
             ConstArgKind::Error(_, _) => self.word("/*ERROR*/"),
             ConstArgKind::Infer(..) => self.word("_"),
         }
+    }
+
+    fn print_const_struct(&mut self, qpath: &hir::QPath<'_>, fields: &&[&ConstArgExprField<'_>]) {
+        self.print_qpath(qpath, true);
+        self.word(" ");
+        self.word("{");
+        if !fields.is_empty() {
+            self.nbsp();
+        }
+        self.commasep(Inconsistent, *fields, |s, field| {
+            s.word(field.field.as_str().to_string());
+            s.word(":");
+            s.nbsp();
+            s.print_const_arg(field.expr);
+        });
+        self.word("}");
+    }
+
+    fn print_const_ctor(&mut self, qpath: &hir::QPath<'_>, args: &&[&ConstArg<'_, ()>]) {
+        self.print_qpath(qpath, true);
+        self.word("(");
+        self.commasep(Inconsistent, *args, |s, arg| {
+            s.print_const_arg(arg);
+        });
+        self.word(")");
     }
 
     fn print_call_post(&mut self, args: &[hir::Expr<'_>]) {

--- a/tests/ui/unpretty/struct-exprs-tuple-call-pretty-printing.rs
+++ b/tests/ui/unpretty/struct-exprs-tuple-call-pretty-printing.rs
@@ -1,0 +1,33 @@
+//@ compile-flags: -Zunpretty=hir
+//@ check-pass
+
+#![feature(min_generic_const_args, adt_const_params)]
+#![expect(incomplete_features)]
+#![allow(dead_code)]
+
+use std::marker::ConstParamTy;
+
+struct Point(u32, u32);
+
+struct Point3();
+
+struct Point1 {
+    a: u32,
+    b: u32,
+}
+
+struct Point2 {}
+
+fn with_point<const P: Point>() {}
+fn with_point1<const P: Point1>() {}
+fn with_point2<const P: Point2>() {}
+fn with_point3<const P: Point3>() {}
+
+fn test<const N: u32>() {
+    with_point::<{ Point(N, N) }>();
+    with_point1::<{ Point1 { a: N, b: N } }>();
+    with_point2::<{ Point2 {} }>();
+    with_point3::<{ Point3() }>();
+}
+
+fn main() {}

--- a/tests/ui/unpretty/struct-exprs-tuple-call-pretty-printing.stdout
+++ b/tests/ui/unpretty/struct-exprs-tuple-call-pretty-printing.stdout
@@ -1,0 +1,39 @@
+//@ compile-flags: -Zunpretty=hir
+//@ check-pass
+
+#![feature(min_generic_const_args, adt_const_params)]
+#![expect(incomplete_features)]
+#![allow(dead_code)]
+#[attr = MacroUse {arguments: UseAll}]
+extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
+
+use std::marker::ConstParamTy;
+
+struct Point(u32, u32);
+
+struct Point3();
+
+struct Point1 {
+    a: u32,
+    b: u32,
+}
+
+struct Point2 {
+}
+
+fn with_point<const P: Point>() { }
+fn with_point1<const P: Point1>() { }
+fn with_point2<const P: Point2>() { }
+fn with_point3<const P: Point3>() { }
+
+fn test<const N:
+    u32>() {
+    with_point::<Point(N, N)>();
+    with_point1::<Point1 { a: N, b: N}>();
+    with_point2::<Point2 {}>();
+    with_point3::<Point3()>();
+}
+
+fn main() { }


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

not sure

1. if there any tests that i need to adjust
2. if i should add any test for it
3. if humanity has come up with anything better than checking if that's first iteration or not with flag when printing sequences with separator

in case there is no tests for it and i dont have to add any, there is a demonstration of this ✨ pretty ✨ printing (this is output from `-Z unpretty=hir`)

```
fn test_errors<const N:
    usize>() {
    // accepts_enum::<{ None::<u32> }>();
    accepts_point::<Point1 { a: N, b: N }>();
    accepts_point::<Point(N, N)>();
}
```

btw it does not print const block 

for this

```
accepts_point::<{ Point1 { a: const {N + 1}, b: N } }>();
```

it will print

```
accepts_point::<Point1 { a: { N + 1 }, b: N }>();
```

not sure if we want to print const blocks or not

r? BoxyUwU