### PR TITLE
enrich error info when tries to dlopen Enzyme

### DIFF
--- a/compiler/rustc_codegen_llvm/messages.ftl
+++ b/compiler/rustc_codegen_llvm/messages.ftl
@@ -1,5 +1,7 @@
-codegen_llvm_autodiff_component_unavailable = failed to load our autodiff backend.
-    .note = load error: {$err}
+codegen_llvm_autodiff_component_missing = autodiff backend not found in the sysroot: {$err}
+    .note = it will be distributed via rustup in the future
+
+codegen_llvm_autodiff_component_unavailable = failed to load our autodiff backend: {$err}
 
 codegen_llvm_autodiff_without_enable = using the autodiff feature requires -Z autodiff=Enable
 codegen_llvm_autodiff_without_lto = using the autodiff feature requires setting `lto="fat"` in your Cargo.toml

--- a/compiler/rustc_codegen_llvm/messages.ftl
+++ b/compiler/rustc_codegen_llvm/messages.ftl
@@ -1,4 +1,5 @@
-codegen_llvm_autodiff_component_unavailable = failed to load our autodiff backend. Did you install it via rustup?
+codegen_llvm_autodiff_component_unavailable = failed to load our autodiff backend.
+    .note = load error: {$err}
 
 codegen_llvm_autodiff_without_enable = using the autodiff feature requires -Z autodiff=Enable
 codegen_llvm_autodiff_without_lto = using the autodiff feature requires setting `lto="fat"` in your Cargo.toml

--- a/compiler/rustc_codegen_llvm/src/errors.rs
+++ b/compiler/rustc_codegen_llvm/src/errors.rs
@@ -34,8 +34,14 @@ impl<G: EmissionGuarantee> Diagnostic<'_, G> for ParseTargetMachineConfig<'_> {
 
 #[derive(Diagnostic)]
 #[diag(codegen_llvm_autodiff_component_unavailable)]
-#[note]
 pub(crate) struct AutoDiffComponentUnavailable {
+    pub err: String,
+}
+
+#[derive(Diagnostic)]
+#[diag(codegen_llvm_autodiff_component_missing)]
+#[note]
+pub(crate) struct AutoDiffComponentMissing {
     pub err: String,
 }
 

--- a/compiler/rustc_codegen_llvm/src/errors.rs
+++ b/compiler/rustc_codegen_llvm/src/errors.rs
@@ -34,7 +34,10 @@ impl<G: EmissionGuarantee> Diagnostic<'_, G> for ParseTargetMachineConfig<'_> {
 
 #[derive(Diagnostic)]
 #[diag(codegen_llvm_autodiff_component_unavailable)]
-pub(crate) struct AutoDiffComponentUnavailable;
+#[note]
+pub(crate) struct AutoDiffComponentUnavailable {
+    pub err: String,
+}
 
 #[derive(Diagnostic)]
 #[diag(codegen_llvm_autodiff_without_lto)]

--- a/compiler/rustc_codegen_llvm/src/lib.rs
+++ b/compiler/rustc_codegen_llvm/src/lib.rs
@@ -249,8 +249,10 @@ impl CodegenBackend for LlvmCodegenBackend {
 
             use crate::back::lto::enable_autodiff_settings;
             if sess.opts.unstable_opts.autodiff.contains(&AutoDiff::Enable) {
-                if let Err(_) = llvm::EnzymeWrapper::get_or_init(&sess.opts.sysroot) {
-                    sess.dcx().emit_fatal(crate::errors::AutoDiffComponentUnavailable);
+                if let Err(err) = llvm::EnzymeWrapper::get_or_init(&sess.opts.sysroot) {
+                    sess.dcx().emit_fatal(crate::errors::AutoDiffComponentUnavailable {
+                        err: format!("{err:?}"),
+                    });
                 }
                 enable_autodiff_settings(&sess.opts.unstable_opts.autodiff);
             }

--- a/compiler/rustc_codegen_llvm/src/lib.rs
+++ b/compiler/rustc_codegen_llvm/src/lib.rs
@@ -249,10 +249,14 @@ impl CodegenBackend for LlvmCodegenBackend {
 
             use crate::back::lto::enable_autodiff_settings;
             if sess.opts.unstable_opts.autodiff.contains(&AutoDiff::Enable) {
-                if let Err(err) = llvm::EnzymeWrapper::get_or_init(&sess.opts.sysroot) {
-                    sess.dcx().emit_fatal(crate::errors::AutoDiffComponentUnavailable {
-                        err: format!("{err:?}"),
-                    });
+                match llvm::EnzymeWrapper::get_or_init(&sess.opts.sysroot) {
+                    Ok(_) => {}
+                    Err(llvm::EnzymeLibraryError::NotFound { err }) => {
+                        sess.dcx().emit_fatal(crate::errors::AutoDiffComponentMissing { err });
+                    }
+                    Err(llvm::EnzymeLibraryError::LoadFailed { err }) => {
+                        sess.dcx().emit_fatal(crate::errors::AutoDiffComponentUnavailable { err });
+                    }
                 }
                 enable_autodiff_settings(&sess.opts.unstable_opts.autodiff);
             }


### PR DESCRIPTION
related: https://github.com/rust-lang/rust/issues/145899#issuecomment-3705550673

print error from EnzymeWrapper::get_or_init(sysroot) as a note

r? @ZuseZ4 

e.g.

1. when libEnzyme not found

```shell
$ rustc +stage1 -Z autodiff=Enable -C lto=fat src/main.rs
error: autodiff backend not found in the sysroot: failed to find a `libEnzyme-21` folder in the sysroot candidates:
       * /Volumes/WD_BLACK_SN850X_HS_1TB/rust-lang/rust/build/aarch64-apple-darwin/stage1/lib
  |
  = note: it will be distributed via rustup in the future
```

2. when could not load libEnzyme successfully

```shell
rustc +stage1 -Z autodiff=Enable -C lto=fat src/main.rs
error: failed to load our autodiff backend: DlOpen { source: "dlopen(/Volumes/WD_BLACK_SN850X_HS_1TB/rust-lang/rust/build/aarch64-apple-darwin/stage1/lib/rustlib/aarch64-apple-darwin/lib/libEnzyme-21.dylib, 0x0005): tried: \'/Volumes/WD_BLACK_SN850X_HS_1TB/rust-lang/rust/build/aarch64-apple-darwin/stage1/lib/rustlib/aarch64-apple-darwin/lib/libEnzyme-21.dylib\' (slice is not valid mach-o file), \'/System/Volumes/Preboot/Cryptexes/OS/Volumes/WD_BLACK_SN850X_HS_1TB/rust-lang/rust/build/aarch64-apple-darwin/stage1/lib/rustlib/aarch64-apple-darwin/lib/libEnzyme-21.dylib\' (no such file), \'/Volumes/WD_BLACK_SN850X_HS_1TB/rust-lang/rust/build/aarch64-apple-darwin/stage1/lib/rustlib/aarch64-apple-darwin/lib/libEnzyme-21.dylib\' (slice is not valid mach-o file)" }
```

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
