### PR TITLE
add #[cold] attribute to abort intrinsic for optimization hints

### DIFF
--- a/library/core/src/intrinsics/mod.rs
+++ b/library/core/src/intrinsics/mod.rs
@@ -365,6 +365,7 @@ pub fn rustc_peek<T>(_: T) -> T;
 /// `SIGBUS`.  The precise behavior is not guaranteed and not stable.
 #[rustc_nounwind]
 #[rustc_intrinsic]
+#[cold]
 pub fn abort() -> !;
 
 /// Informs the optimizer that this point in the code is not reachable,


### PR DESCRIPTION
Hey, 
as `std::process::abort` already has `#[cold]` attribute, and large part of rust core(no-std) is relying on `intrinsics::abort` instead, I believe marking it as cold will help the compiler generate more optimized code.