### PR TITLE
Fix ICE when transmute Assume field is invalid

### DIFF
--- a/compiler/rustc_transmute/src/lib.rs
+++ b/compiler/rustc_transmute/src/lib.rs
@@ -155,14 +155,14 @@ mod rustc {
                     .enumerate()
                     .find(|(_, field_def)| name == field_def.name)
                     .unwrap_or_else(|| panic!("There were no fields named `{name}`."));
-                fields[field_idx].to_leaf() == ScalarInt::TRUE
+                fields[field_idx].try_to_leaf().map(|leaf| leaf == ScalarInt::TRUE)
             };
 
             Some(Self {
-                alignment: get_field(sym::alignment),
-                lifetimes: get_field(sym::lifetimes),
-                safety: get_field(sym::safety),
-                validity: get_field(sym::validity),
+                alignment: get_field(sym::alignment)?,
+                lifetimes: get_field(sym::lifetimes)?,
+                safety: get_field(sym::safety)?,
+                validity: get_field(sym::validity)?,
             })
         }
     }

--- a/tests/ui/transmutability/non_scalar_alignment_value.rs
+++ b/tests/ui/transmutability/non_scalar_alignment_value.rs
@@ -1,0 +1,30 @@
+#![feature(min_generic_const_args)]
+//~^ WARN the feature `min_generic_const_args` is incomplete
+
+#![feature(transmutability)]
+
+mod assert {
+    use std::mem::{Assume, TransmuteFrom};
+    struct Dst {}
+    fn is_maybe_transmutable()
+    where
+        Dst: TransmuteFrom<
+            (),
+            {
+                Assume {
+                    alignment: Assume {},
+                    //~^ ERROR struct expression with missing field initialiser for `alignment`
+                    //~| ERROR struct expression with missing field initialiser for `lifetimes`
+                    //~| ERROR struct expression with missing field initialiser for `safety`
+                    //~| ERROR struct expression with missing field initialiser for `validity`
+                    lifetimes: const { true },
+                    safety: const { true },
+                    validity: const { true },
+                }
+            },
+        >,
+    {
+    }
+}
+
+fn main() {}

--- a/tests/ui/transmutability/non_scalar_alignment_value.stderr
+++ b/tests/ui/transmutability/non_scalar_alignment_value.stderr
@@ -1,0 +1,35 @@
+warning: the feature `min_generic_const_args` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/non_scalar_alignment_value.rs:1:12
+   |
+LL | #![feature(min_generic_const_args)]
+   |            ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #132980 <https://github.com/rust-lang/rust/issues/132980> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+error: struct expression with missing field initialiser for `alignment`
+  --> $DIR/non_scalar_alignment_value.rs:15:32
+   |
+LL |                     alignment: Assume {},
+   |                                ^^^^^^
+
+error: struct expression with missing field initialiser for `lifetimes`
+  --> $DIR/non_scalar_alignment_value.rs:15:32
+   |
+LL |                     alignment: Assume {},
+   |                                ^^^^^^
+
+error: struct expression with missing field initialiser for `safety`
+  --> $DIR/non_scalar_alignment_value.rs:15:32
+   |
+LL |                     alignment: Assume {},
+   |                                ^^^^^^
+
+error: struct expression with missing field initialiser for `validity`
+  --> $DIR/non_scalar_alignment_value.rs:15:32
+   |
+LL |                     alignment: Assume {},
+   |                                ^^^^^^
+
+error: aborting due to 4 previous errors; 1 warning emitted
+


### PR DESCRIPTION
This PR fixes an internal compiler error in `rustc_transmute` where initializing an `Assume` field (like `alignment`) with a non-scalar constant (like a struct) caused a panic.

The fix updates `from_const` to use `try_to_scalar()` instead of assuming the value is always a leaf. It now gracefully returns `None` for invalid types, allowing the compiler to report standard "missing field initialiser" errors instead of crashing.

Fixes rust-lang/rust#150506


<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
