### PR TITLE
Enable merge queue in new bors

### DIFF
--- a/rust-bors.toml
+++ b/rust-bors.toml
@@ -29,8 +29,7 @@ labels_blocking_approval = [
 # If CI runs quicker than this duration, consider it to be a failure
 min_ci_time = 600
 
-# Flip this once new bors is used for actual merges on this repository
-merge_queue_enabled = false
+merge_queue_enabled = true
 report_merge_conflicts = true
 
 [labels]
@@ -55,7 +54,9 @@ try_failed = [
     "-S-waiting-on-review",
     "-S-waiting-on-crater"
 ]
-auto_build_succeeded = ["+merged-by-bors"]
+auto_build_succeeded = [
+    "+merged-by-bors"
+]
 auto_build_failed = [
     "+S-waiting-on-review",
     "-S-blocked",


### PR DESCRIPTION
We can proactively merge this now. Note that new bors will still default to being "paused" and not running the merge queue, after being restarted:
- https://github.com/rust-lang/bors/blob/e1fafaa3b89c225069fa2aa1193096e1d66075c3/src/bors/merge_queue.rs#L101
- https://github.com/rust-lang/bors/blob/bf491ee40d1fc877af273f2ec92a2968dee8cdb7/src/github/api/mod.rs#L159
- https://github.com/rust-lang/rust/pull/112049#issuecomment-3714114478

We can resume it quickly with a command, to test how the merging functionality behaves.