### PR TITLE
Do not suggest `derive` if there is already an impl

### DIFF
--- a/tests/ui/suggestions/derive-clone-already-present-issue-146515.rs
+++ b/tests/ui/suggestions/derive-clone-already-present-issue-146515.rs
@@ -1,0 +1,20 @@
+// issue: https://github.com/rust-lang/rust/issues/146515
+
+use std::rc::Rc;
+
+#[derive(Clone)]
+struct ContainsRc<T> {
+    value: Rc<T>,
+}
+
+fn clone_me<T>(x: &ContainsRc<T>) -> ContainsRc<T> {
+    //~^ NOTE expected `ContainsRc<T>` because of return type
+    x.clone()
+    //~^ ERROR mismatched types
+    //~| NOTE expected `ContainsRc<T>`, found `&ContainsRc<T>`
+    //~| NOTE expected struct `ContainsRc<_>`
+    //~| NOTE `ContainsRc<T>` does not implement `Clone`, so `&ContainsRc<T>` was cloned instead
+    //~| NOTE the trait `Clone` must be implemented
+}
+
+fn main() {}

--- a/tests/ui/suggestions/derive-clone-already-present-issue-146515.stderr
+++ b/tests/ui/suggestions/derive-clone-already-present-issue-146515.stderr
@@ -1,0 +1,23 @@
+error[E0308]: mismatched types
+  --> $DIR/derive-clone-already-present-issue-146515.rs:12:5
+   |
+LL | fn clone_me<T>(x: &ContainsRc<T>) -> ContainsRc<T> {
+   |                                      ------------- expected `ContainsRc<T>` because of return type
+LL |
+LL |     x.clone()
+   |     ^^^^^^^^^ expected `ContainsRc<T>`, found `&ContainsRc<T>`
+   |
+   = note: expected struct `ContainsRc<_>`
+           found reference `&ContainsRc<_>`
+note: `ContainsRc<T>` does not implement `Clone`, so `&ContainsRc<T>` was cloned instead
+  --> $DIR/derive-clone-already-present-issue-146515.rs:12:5
+   |
+LL |     x.clone()
+   |     ^
+   = help: `Clone` is not implemented because the trait bound `T: Clone` is not satisfied
+note: the trait `Clone` must be implemented
+  --> $SRC_DIR/core/src/clone.rs:LL:COL
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
This PR fixes an issue where the compiler would suggest adding `#[derive(Trait)]` even if the struct or enum already implements that trait manually.

Fixes [#146515](https://github.com/rust-lang/rust/issues/146515)