### PR TITLE
Deprecated doc intra link

### DIFF
--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -1400,6 +1400,14 @@ impl AttributeExt for Attribute {
         }
     }
 
+    #[inline]
+    fn deprecation_note(&self) -> Option<Symbol> {
+        match &self {
+            Attribute::Parsed(AttributeKind::Deprecation { deprecation, .. }) => deprecation.note,
+            _ => None,
+        }
+    }
+
     fn is_automatically_derived_attr(&self) -> bool {
         matches!(self, Attribute::Parsed(AttributeKind::AutomaticallyDerived(..)))
     }

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -7,6 +7,7 @@ use std::{fmt, iter};
 use arrayvec::ArrayVec;
 use itertools::Either;
 use rustc_abi::{ExternAbi, VariantIdx};
+use rustc_ast::attr::AttributeExt;
 use rustc_data_structures::fx::{FxHashSet, FxIndexMap, FxIndexSet};
 use rustc_data_structures::thin_vec::ThinVec;
 use rustc_hir::attrs::{AttributeKind, DeprecatedSince, Deprecation, DocAttribute};
@@ -450,7 +451,16 @@ impl Item {
     }
 
     pub(crate) fn attr_span(&self, tcx: TyCtxt<'_>) -> rustc_span::Span {
+        let deprecation_notes = self
+            .attrs
+            .other_attrs
+            .iter()
+            .filter_map(|attr| attr.deprecation_note().map(|_| attr.span()));
+
         span_of_fragments(&self.attrs.doc_strings)
+            .into_iter()
+            .chain(deprecation_notes)
+            .reduce(|a, b| a.to(b))
             .unwrap_or_else(|| self.span(tcx).map_or(DUMMY_SP, |span| span.inner()))
     }
 

--- a/src/librustdoc/html/markdown/tests.rs
+++ b/src/librustdoc/html/markdown/tests.rs
@@ -471,7 +471,7 @@ fn test_markdown_html_escape() {
     fn t(input: &str, expect: &str) {
         let mut idmap = IdMap::new();
         let mut output = String::new();
-        MarkdownItemInfo::new(input, &mut idmap).write_into(&mut output).unwrap();
+        MarkdownItemInfo::new(input, &[], &mut idmap).write_into(&mut output).unwrap();
         assert_eq!(output, expect, "original: {}", input);
     }
 

--- a/src/librustdoc/html/markdown/tests.rs
+++ b/src/librustdoc/html/markdown/tests.rs
@@ -471,7 +471,7 @@ fn test_markdown_html_escape() {
     fn t(input: &str, expect: &str) {
         let mut idmap = IdMap::new();
         let mut output = String::new();
-        MarkdownItemInfo(input, &mut idmap).write_into(&mut output).unwrap();
+        MarkdownItemInfo::new(input, &mut idmap).write_into(&mut output).unwrap();
         assert_eq!(output, expect, "original: {}", input);
     }
 

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -877,7 +877,8 @@ fn short_item_info(
         if let Some(note) = note {
             let note = note.as_str();
             let mut id_map = cx.id_map.borrow_mut();
-            let html = MarkdownItemInfo::new(note, &mut id_map);
+            let links = item.links(cx);
+            let html = MarkdownItemInfo::new(note, &links, &mut id_map);
             message.push_str(": ");
             html.write_into(&mut message).unwrap();
         }

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -877,7 +877,7 @@ fn short_item_info(
         if let Some(note) = note {
             let note = note.as_str();
             let mut id_map = cx.id_map.borrow_mut();
-            let html = MarkdownItemInfo(note, &mut id_map);
+            let html = MarkdownItemInfo::new(note, &mut id_map);
             message.push_str(": ");
             html.write_into(&mut message).unwrap();
         }

--- a/tests/rustdoc-html/intra-doc/deprecated.rs
+++ b/tests/rustdoc-html/intra-doc/deprecated.rs
@@ -1,0 +1,12 @@
+//@ has deprecated/struct.A.html '//a[@href="{{channel}}/core/ops/range/struct.Range.html#structfield.start"]' 'start'
+//@ has deprecated/struct.B1.html '//a[@href="{{channel}}/std/io/error/enum.ErrorKind.html#variant.NotFound"]' 'not_found'
+//@ has deprecated/struct.B2.html '//a[@href="{{channel}}/std/io/error/enum.ErrorKind.html#variant.NotFound"]' 'not_found'
+
+#[deprecated = "[start][std::ops::Range::start]"]
+pub struct A;
+
+#[deprecated(since = "0.0.0", note = "[not_found][std::io::ErrorKind::NotFound]")]
+pub struct B1;
+
+#[deprecated(note = "[not_found][std::io::ErrorKind::NotFound]", since = "0.0.0")]
+pub struct B2;

--- a/tests/rustdoc-ui/intra-doc/deprecated.rs
+++ b/tests/rustdoc-ui/intra-doc/deprecated.rs
@@ -1,0 +1,10 @@
+#![deny(rustdoc::broken_intra_doc_links)]
+
+#[deprecated = "[broken cross-reference](TypeAlias::hoge)"] //~ ERROR
+pub struct A;
+
+#[deprecated(since = "0.0.0", note = "[broken cross-reference](TypeAlias::hoge)")] //~ ERROR
+pub struct B1;
+
+#[deprecated(note = "[broken cross-reference](TypeAlias::hoge)", since = "0.0.0")] //~ ERROR
+pub struct B2;

--- a/tests/rustdoc-ui/intra-doc/deprecated.stderr
+++ b/tests/rustdoc-ui/intra-doc/deprecated.stderr
@@ -1,0 +1,43 @@
+error: unresolved link to `TypeAlias::hoge`
+  --> $DIR/deprecated.rs:3:1
+   |
+LL | #[deprecated = "[broken cross-reference](TypeAlias::hoge)"]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: the link appears in this line:
+           
+           [broken cross-reference](TypeAlias::hoge)
+                                    ^^^^^^^^^^^^^^^
+   = note: no item named `TypeAlias` in scope
+note: the lint level is defined here
+  --> $DIR/deprecated.rs:1:9
+   |
+LL | #![deny(rustdoc::broken_intra_doc_links)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: unresolved link to `TypeAlias::hoge`
+  --> $DIR/deprecated.rs:6:1
+   |
+LL | #[deprecated(since = "0.0.0", note = "[broken cross-reference](TypeAlias::hoge)")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: the link appears in this line:
+           
+           [broken cross-reference](TypeAlias::hoge)
+                                    ^^^^^^^^^^^^^^^
+   = note: no item named `TypeAlias` in scope
+
+error: unresolved link to `TypeAlias::hoge`
+  --> $DIR/deprecated.rs:9:1
+   |
+LL | #[deprecated(note = "[broken cross-reference](TypeAlias::hoge)", since = "0.0.0")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: the link appears in this line:
+           
+           [broken cross-reference](TypeAlias::hoge)
+                                    ^^^^^^^^^^^^^^^
+   = note: no item named `TypeAlias` in scope
+
+error: aborting due to 3 previous errors
+


### PR DESCRIPTION
fixes https://github.com/rust-lang/rust/issues/98342
r? @GuillaumeGomez 

Renders intra-doc links in the note text of the `#[deprecated]` attribute. It is quite natural to suggest some other function to use there. So e.g. 

```rust
#[deprecated(since = "0.0.0", note = "use [`std::mem::size_of`] instead")]
```

renders as

<img width="431" height="74" alt="Screenshot from 2026-01-06 12-08-21" src="https://github.com/user-attachments/assets/8f608f08-13ee-4bbf-a631-6008058a51e2" />
