### PR TITLE
Update to LLVM 22

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -25,7 +25,7 @@
 [submodule "src/llvm-project"]
 	path = src/llvm-project
 	url = https://github.com/rust-lang/llvm-project.git
-	branch = rustc/21.1-2025-08-01
+	branch = rustc/22.1-2026-01-27
 	shallow = true
 [submodule "src/doc/embedded-book"]
 	path = src/doc/embedded-book

--- a/src/ci/docker/scripts/build-clang.sh
+++ b/src/ci/docker/scripts/build-clang.sh
@@ -5,7 +5,7 @@ set -ex
 source shared.sh
 
 # Try to keep the LLVM version here in sync with src/ci/scripts/install-clang.sh
-LLVM=llvmorg-21.1.0-rc2
+LLVM=llvmorg-22.1.0-rc2
 
 mkdir llvm-project
 cd llvm-project

--- a/tests/assembly-llvm/asm/loongarch-type.rs
+++ b/tests/assembly-llvm/asm/loongarch-type.rs
@@ -1,10 +1,14 @@
 //@ add-minicore
-//@ revisions: loongarch32 loongarch64
+//@ revisions: loongarch32s loongarch32r loongarch64
 
 //@ assembly-output: emit-asm
 
-//@[loongarch32] compile-flags: --target loongarch32-unknown-none
-//@[loongarch32] needs-llvm-components: loongarch
+//@[loongarch32s] compile-flags: --target loongarch32-unknown-none -Ctarget-feature=+32s
+//@[loongarch32s] needs-llvm-components: loongarch
+
+//@[loongarch32r] compile-flags: --target loongarch32-unknown-none
+//@[loongarch32r] needs-llvm-components: loongarch
+//@[loongarch32r] min-llvm-version: 22
 
 //@[loongarch64] compile-flags: --target loongarch64-unknown-none
 //@[loongarch64] needs-llvm-components: loongarch
@@ -28,8 +32,12 @@ extern "C" {
 
 // CHECK-LABEL: sym_fn:
 // CHECK: #APP
-// CHECK: pcalau12i $t0, %got_pc_hi20(extern_func)
-// CHECK: ld.{{[wd]}} $t0, $t0, %got_pc_lo12(extern_func)
+// loongarch64: pcalau12i $t0, %got_pc_hi20(extern_func)
+// loongarch64: ld.d $t0, $t0, %got_pc_lo12(extern_func)
+// loongarch32s: pcalau12i $t0, %got_pc_hi20(extern_func)
+// loongarch32s: ld.w $t0, $t0, %got_pc_lo12(extern_func)
+// loongarch32r: pcaddu12i $t0, %got_pcadd_hi20(extern_func)
+// loongarch32r: ld.w $t0, $t0, %got_pcadd_lo12(.Lpcadd_hi0)
 // CHECK: #NO_APP
 #[no_mangle]
 pub unsafe fn sym_fn() {
@@ -38,8 +46,13 @@ pub unsafe fn sym_fn() {
 
 // CHECK-LABEL: sym_static:
 // CHECK: #APP
-// CHECK: pcalau12i $t0, %got_pc_hi20(extern_static)
-// CHECK: ld.{{[wd]}} $t0, $t0, %got_pc_lo12(extern_static)
+// loongarch64: pcalau12i $t0, %got_pc_hi20(extern_static)
+// loongarch64: ld.d $t0, $t0, %got_pc_lo12(extern_static)
+// loongarch32s: pcalau12i $t0, %got_pc_hi20(extern_static)
+// loongarch32s: ld.w $t0, $t0, %got_pc_lo12(extern_static)
+// loongarch32r: pcaddu12i $t0, %got_pcadd_hi20(extern_static)
+// loongarch32r: ld.w $t0, $t0, %got_pcadd_lo12(.Lpcadd_hi1)
+
 // CHECK: #NO_APP
 #[no_mangle]
 pub unsafe fn sym_static() {


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/150722)*
<!-- homu-ignore:end -->

Scheduled release date: Feb 24
1.94 becomes stable: Mar 5

Changes:
 * Update to rc2, with one patch to work around our outdated illumos sysroot (https://github.com/rust-lang/llvm-project/commit/41256ab128f2af613b4a16771cda6baa36b55f45).
 * Update the host toolchain as well, otherwise we lose cross-language LTO, in particular for jemalloc.
 * Adjust one loongarch assembly test. The split into r and s variants is based on the suggestion in https://github.com/rust-lang/rust/pull/151134.

Depends on:

 * [x] https://github.com/rust-lang/rust/pull/151410
 * [ ] https://github.com/rust-lang/rust/issues/150756
 * [x] https://github.com/llvm/llvm-project/issues/175190
 * [x] https://github.com/llvm/llvm-project/pull/175912
 * [x] https://github.com/llvm/llvm-project/issues/175965
 * [x] https://github.com/llvm/llvm-project/pull/176195
 * [x] https://github.com/llvm/llvm-project/issues/157073
 * [x] https://github.com/llvm/llvm-project/issues/176421
 * [x] https://github.com/llvm/llvm-project/pull/176925
 * [x] https://github.com/llvm/llvm-project/pull/177187