### PR TITLE
Add AtomicPtr::null

### DIFF
--- a/library/core/src/sync/atomic.rs
+++ b/library/core/src/sync/atomic.rs
@@ -1550,6 +1550,23 @@ impl<T> AtomicPtr<T> {
         unsafe { &*ptr.cast() }
     }
 
+    /// Creates a new `AtomicPtr` initialized with a null pointer.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::sync::atomic::{AtomicPtr, Ordering};
+    ///
+    /// let atomic_ptr = AtomicPtr::<()>::null();
+    /// assert!(atomic_ptr.load(Ordering::Relaxed).is_null());
+    /// ```
+    #[inline]
+    #[must_use]
+    #[unstable(feature = "atomic_ptr_null", issue = "150733")]
+    pub const fn null() -> AtomicPtr<T> {
+        AtomicPtr::new(crate::ptr::null_mut())
+    }
+
     /// Returns a mutable reference to the underlying pointer.
     ///
     /// This is safe because the mutable reference guarantees that no other threads are

--- a/library/core/src/sync/atomic.rs
+++ b/library/core/src/sync/atomic.rs
@@ -1555,6 +1555,7 @@ impl<T> AtomicPtr<T> {
     /// # Examples
     ///
     /// ```
+    /// #![feature(atomic_ptr_null)]
     /// use std::sync::atomic::{AtomicPtr, Ordering};
     ///
     /// let atomic_ptr = AtomicPtr::<()>::null();


### PR DESCRIPTION
Implementation for https://github.com/rust-lang/rust/issues/150733.

I marked this function as `#[must_use]` even though the other `AtomicPtr` constructors aren't. It's unclear to me why they aren't already marked as such, I opened a zulip thread asking about it: [#t-libs > Is there a reason AtomicPtr constructors aren't #&#91;must_use&#93;?](https://rust-lang.zulipchat.com/#narrow/channel/219381-t-libs/topic/Is.20there.20a.20reason.20AtomicPtr.20constructors.20aren't.20.23.5Bmust_use.5D.3F/with/566624261).